### PR TITLE
fix(multi-machine): owner-side follow-up injects into moved session, not a duplicate spawn (bug #13)

### DIFF
--- a/docs/specs/owner-side-followup-inject.eli16.md
+++ b/docs/specs/owner-side-followup-inject.eli16.md
@@ -1,0 +1,49 @@
+# Don't let a moved conversation duplicate itself on every reply — explain it like I'm 16
+
+When you move a conversation from the laptop to the Mac mini, the mini takes over and
+starts the conversation. Good. But then you send a SECOND message — a normal follow-up
+like "ok, now do the other thing." That message still arrives at the laptop (the laptop
+is the one connected to Telegram), and the laptop forwards it to the mini, because the
+mini now owns this conversation.
+
+Here's the bug. Every time a forwarded message reached the mini, the mini ran its
+"start a session for this topic" code — even when a session for that topic was already
+running from the first message. It never checked "wait, am I already talking in this
+conversation?" So instead of handing the new message to the session that's already
+going, it tried to start a fresh one.
+
+And it got worse because of a naming detail. The mini remembers a session by its full
+internal name, something like `echo-topic-13481`. When the follow-up came in, it fed
+that full name back into the "start a session" function — which adds the `echo-` prefix
+AGAIN, producing `echo-echo-topic-13481`. The mini looked for a session by that
+double-prefixed name, didn't find one (because the real one is `echo-topic-13481`), and
+so spawned a brand-new duplicate session. Every single follow-up would spin up yet
+another duplicate, and none of them would be the original moved conversation. Your
+"now do the other thing" would land in some fresh, confused session — not the one that
+already knew what "the other thing" was.
+
+This matters a lot because the live test for the whole feature is exactly: move the
+conversation, then send a follow-up and expect a sensible reply. With this bug, the
+move would look fine but the follow-up would fall apart — which is the worst kind of
+bug, because it hides until the moment you actually rely on it.
+
+The fix makes the mini behave like the laptop already does for normal messages. When a
+forwarded message arrives:
+- First it checks: is there already a live session for this conversation on this
+  machine? If yes, it just hands the message to that running session (with the normal
+  `[telegram:…]` label the session expects), and stops. No new session, no duplicate.
+- Only if there's NO live session does it start one — and when it does, it uses a clean
+  name (`topic-13481`), never the already-prefixed one, so the double-prefix problem
+  can't happen again.
+
+One honest note: like the previous multi-machine fixes, I proved this at the code and
+unit-test level, but I have NOT yet proven it live, because the moved session can't
+actually run on the mini until the mini's Claude is logged in — a one-time step only
+the user can do. So this ships unit-verified, and the live confirmation (move, then a
+follow-up that the moved session answers correctly) comes the moment the mini is logged
+in and I re-run the test.
+
+Why it's safe to ship now: this code only runs when the multi-machine session pool is
+turned on (it's off by default), and if anything goes wrong it falls back to the old
+spawn behavior — it never blocks a message. A normal single-machine agent never touches
+this path at all.

--- a/docs/specs/owner-side-followup-inject.md
+++ b/docs/specs/owner-side-followup-inject.md
@@ -1,0 +1,92 @@
+---
+title: A forwarded follow-up to a moved session injects, not re-spawns (owner-side dispatch)
+slug: owner-side-followup-inject
+status: approved
+review-convergence: 2026-05-31T13:55:00+00:00
+approved: true
+author: echo
+approval-note: >
+  Self-approved by Echo under the standing 12h deploy mandate (topic 13481). Audit
+  item #13 of the multi-machine live-transfer cascade — found by code audit (the same
+  method that surfaced bug #2), not yet live. A latent defect in the owner-side
+  follow-up path: it would have broken the live "move + follow-up" test. Gated past
+  'dark' + fail-safe; unit-verified. Flagged in the PR per cross-agent discipline.
+---
+
+# A forwarded follow-up to a moved session injects, not re-spawns
+
+## Problem
+
+Audit finding #13, confirmed in code. After the session pool moves a topic to a
+standby (the new owner), every subsequent inbound message for that topic arrives at
+the owner ONLY via MeshRpc `deliverMessage` → the `onAccepted` callback (the owner
+is tokenless and never polls Telegram). `onAccepted` called `spawnSessionForTopic`
+**unconditionally** on every forwarded message, passing
+`tg.getSessionForTopic(topicId)` as the spawn name.
+
+Two defects compound there:
+
+1. **Double-prefix duplicate.** `registerTopicSession` stores the *returned* tmux
+   session name (already `<projectBase>-topic-N`). On the next follow-up,
+   `getSessionForTopic` returns that prefixed name, and `spawnInteractiveSession`
+   re-prefixes it (`<projectBase>-<projectBase>-topic-N`). `tmuxSessionExists` misses,
+   so a **brand-new duplicate session is spawned for every follow-up** instead of the
+   message reaching the running moved session.
+2. **No inject path.** Even without the prefix bug, the owner side never mirrored the
+   normal inbound dispatch, which injects a message into an already-running session
+   (`injectTelegramMessage`) rather than re-spawning. So the moved conversation never
+   advanced — each follow-up either started fresh or duplicated.
+
+Net effect: the live "move this to the mini" + a follow-up asking for a reply — the
+exact two-step the live test performs — would move correctly but then mishandle the
+follow-up (duplicate/blank session), so the reply would not come from the moved
+session. The transfer would look broken at exactly the step that matters.
+
+## Goal
+
+On the owner machine, a forwarded follow-up for a topic that already has a live
+session is **injected into that session** (with the `[telegram:N …]` prefix the
+session expects), exactly as the normal single-machine inbound path does. A session
+is spawned **only** when none is running, and the spawn always uses a clean
+topic-derived name — never the prefixed `getSessionForTopic` value.
+
+## Non-goals
+
+- Not a change to the normal single-machine dispatch (untouched) — this only fixes
+  the owner-side `onAccepted` forwarded-message path.
+- Not a change to ordering/dedup (the router already enforces per-session ordering
+  and messageId dedup upstream).
+- Gated past `'dark'` and fail-safe: a single-machine agent never reaches this code.
+
+## Design
+
+In `server.ts` `onAccepted` (the only owner-side entry for forwarded messages):
+
+1. **Inject-into-live first.** Resolve `existing = tg.getSessionForTopic(topicId)`.
+   If `existing` is set and `sessionManager.isSessionAlive(existing)`, call
+   `sessionManager.injectTelegramMessage(existing, topicId, text, topicName)` and
+   `tg.trackMessageInjection(topicId, existing, text)`, then return. This mirrors the
+   normal inbound dispatch's alive-session branch.
+2. **Spawn only when none.** Otherwise spawn the moved session (with the bug-#2
+   relayed context) under a clean `spawnName = `topic-${topicId}``. The returned tmux
+   name is registered via `registerTopicSession`, so the *next* follow-up takes the
+   inject branch above. The spawn name is never the prefixed `getSessionForTopic`
+   value (that was the double-prefix defect).
+
+## Testing
+
+- Wiring (`tests/unit/session-pool-activation-wiring.test.ts`): the owner-side bridge
+  injects into a live session before the spawn IIFE (`isSessionAlive(existing)`
+  precedes `spawnSessionForTopic`), uses `injectTelegramMessage` +
+  `trackMessageInjection`, and spawns under `topic-${topicId}` — never the prefixed
+  name. 52 session-pool + adapter tests green; `tsc --noEmit` clean.
+- **NOT yet live-verified** — the moved session running on the mini (and thus the
+  follow-up round-trip) can only be confirmed once the mini's Claude is logged in
+  (bug #12, pending Justin). The logic is unit-proven; the live follow-up is the
+  Tier-3 gate that follows his login.
+
+## Migration parity
+
+Pure code (one branch in `onAccepted` + a clean spawn name). No config/hook/route/
+CLAUDE.md change. Gated past `'dark'` + fail-safe → existing agents unaffected until
+the pool is on; they get it on the v-next update.

--- a/src/commands/server.ts
+++ b/src/commands/server.ts
@@ -9323,7 +9323,28 @@ export async function startServer(options: StartOptions): Promise<void> {
               : (cmd.payload && typeof cmd.payload === 'object' && 'text' in (cmd.payload as object))
                 ? String((cmd.payload as { text: unknown }).text)
                 : undefined;
-            const sessionName = tg.getSessionForTopic(topicId) ?? `topic-${topicId}`;
+            // bug #13: a moved session ALREADY running on this machine must receive
+            // follow-ups via INJECTION (mirroring the normal inbound dispatch), NOT a
+            // re-spawn. getSessionForTopic returns the already-prefixed tmux name; routing
+            // it back through spawnSessionForTopic re-prefixes it (projectBase-projectBase-
+            // topic-N) so tmuxSessionExists misses and a DUPLICATE session is spawned on
+            // every follow-up — the moved conversation never advances. So: if a live
+            // session exists, inject the text into it (with the [telegram:N …] prefix the
+            // session expects) and return; only spawn when there is none.
+            const existing = tg.getSessionForTopic(topicId);
+            if (existing && sessionManager.isSessionAlive(existing)) {
+              if (text) {
+                console.log(pc.green(`  [session-pool] owner-side inject for forwarded topic ${topicId} → ${existing}`));
+                sessionManager.injectTelegramMessage(existing, topicId, text, tg.getTopicName?.(topicId) ?? undefined);
+                tg.trackMessageInjection(topicId, existing, text);
+              }
+              return;
+            }
+            // No live session yet (the FIRST forwarded message for this topic, or the
+            // prior one died) — spawn the moved session with the relayed context, under a
+            // clean topic-derived name. NEVER reuse the prefixed getSessionForTopic value
+            // as the spawn name (that is the double-prefix defect above).
+            const spawnName = `topic-${topicId}`;
             // bug #2: fetch the prior conversation from the router (this machine's local
             // history for the topic is empty) so the moved session continues with context
             // instead of starting blank. Best-effort — on any failure we spawn without it.
@@ -9343,10 +9364,10 @@ export async function startServer(options: StartOptions): Promise<void> {
               } catch {
                 // @silent-fallback-ok — cross-machine context relay is best-effort
               }
-              return spawnSessionForTopic(sessionManager, tg, sessionName, topicId, text, undefined, undefined, movedContext);
+              return spawnSessionForTopic(sessionManager, tg, spawnName, topicId, text, undefined, undefined, movedContext);
             })()
               .then((name) => {
-                tg.registerTopicSession(topicId, name, sessionName);
+                tg.registerTopicSession(topicId, name, spawnName);
                 console.log(pc.green(`  [session-pool] owner-side resume for forwarded topic ${topicId} → ${name}`));
               })
               .catch((err) => console.warn(`  [session-pool] owner-side resume failed for topic ${topicId}: ${err instanceof Error ? err.message : String(err)}`));

--- a/tests/unit/session-pool-activation-wiring.test.ts
+++ b/tests/unit/session-pool-activation-wiring.test.ts
@@ -54,13 +54,33 @@ describe('Session Pool activation wiring (§L4)', () => {
   it('the owner-side bridge resumes the local session on a forwarded message, gated + fail-safe', () => {
     const idx = src.indexOf('onAccepted: (cmd) => {');
     expect(idx).toBeGreaterThan(0);
-    const block = src.slice(idx, idx + 2800);
+    const block = src.slice(idx, idx + 4200);
     // Gated on a non-dark stage + only with Telegram present.
     expect(block).toContain("_sessionPoolStage() === 'dark' || !telegram");
     // Bridges to the existing local spawn/resume path for the topic (now wrapped in an
     // async IIFE that first fetches the moved topic's history from the router — bug #2).
-    expect(block).toContain('spawnSessionForTopic(sessionManager, tg, sessionName, topicId, text');
+    // The spawn name is a clean topic-derived name, NOT the prefixed getSessionForTopic
+    // value (bug #13 — re-prefixing it spawned a duplicate per follow-up).
+    expect(block).toContain('spawnSessionForTopic(sessionManager, tg, spawnName, topicId, text');
     // Fire-and-forget + fail-safe (the receipt is already durably ACKed before this).
     expect(block).toContain('owner-side resume failed');
+  });
+
+  it('bug #13: a forwarded follow-up to an already-running moved session INJECTS, never re-spawns', () => {
+    const idx = src.indexOf('onAccepted: (cmd) => {');
+    expect(idx).toBeGreaterThan(0);
+    const block = src.slice(idx, idx + 4200);
+    // A live session for the topic short-circuits to injection BEFORE the spawn IIFE.
+    const injectIdx = block.indexOf('sessionManager.isSessionAlive(existing)');
+    const spawnIdx = block.indexOf('spawnSessionForTopic(sessionManager, tg, spawnName');
+    expect(injectIdx).toBeGreaterThan(0);
+    expect(spawnIdx).toBeGreaterThan(injectIdx); // inject decision precedes spawn
+    // Injection uses the Telegram-aware path (adds the [telegram:N …] prefix the moved
+    // session needs to reply) and tracks the injection for stall detection.
+    expect(block).toContain('sessionManager.injectTelegramMessage(existing, topicId, text');
+    expect(block).toContain('tg.trackMessageInjection(topicId, existing, text)');
+    // The spawn name must NOT be the prefixed session name (the double-prefix defect).
+    expect(block).toContain('const spawnName = `topic-${topicId}`');
+    expect(block).not.toContain('const sessionName = tg.getSessionForTopic(topicId)');
   });
 });

--- a/upgrades/NEXT.md
+++ b/upgrades/NEXT.md
@@ -1,0 +1,52 @@
+---
+review-convergence: complete
+approved: true
+approved-by: echo (standing 12h deploy mandate, topic 13481; multi-machine live-transfer cascade)
+---
+
+# Instar Upgrade Guide — vNEXT
+
+<!-- bump: patch -->
+
+## What Changed — a moved conversation now advances on follow-ups instead of duplicating
+
+A correctness fix for the multi-machine "move this conversation to my other machine"
+feature. After a conversation moved to the backup machine, the backup correctly started
+it. But the very next message you sent — a normal follow-up — was handled by code that
+always tried to start a session, even though one was already running. Because of how the
+session name was stored and then re-prefixed, it could not find the running session and
+spawned a duplicate instead. So follow-ups landed in fresh, confused sessions rather than
+the moved conversation.
+
+This release makes the receiving machine behave like the normal single-machine path: if a
+session for the conversation is already running, the follow-up is delivered straight into
+it; a new session is started only when there isn't one, and always under a clean name so
+the re-prefix problem cannot recur.
+
+## Summary of New Capabilities
+
+- The owner-side forwarded-message handler injects a follow-up into the already-running
+  moved session (with the standard message prefix the session expects) instead of
+  re-spawning.
+- A session is spawned only when none is running, always under a clean topic-derived
+  name, never the already-prefixed stored name.
+
+## What to Tell Your User
+
+If you run your agent across more than one machine and move a conversation to another one,
+follow-up messages now continue in the same moved conversation instead of starting a new,
+forgetful one each time. Only relevant when the multi-machine session pool is on;
+single-machine agents are unaffected. Nothing to configure.
+
+## Evidence
+
+- Confirmed in code: the stored session name was the already-prefixed tmux name, which
+  the spawn function prefixed again, so an existing session was never found and a
+  duplicate was spawned on every follow-up.
+- Wiring, tests/unit/session-pool-activation-wiring.test.ts: the owner-side handler
+  injects into a live session before any spawn, uses the Telegram-aware inject plus
+  injection tracking, and spawns under a clean topic-derived name.
+- 52 session-pool and adapter tests pass; tsc --noEmit clean.
+- Note: unit-verified; the live confirmation that a moved session answers a follow-up
+  correctly follows once the second machine's CLI is logged in.
+- Spec, docs/specs/owner-side-followup-inject.md plus the .eli16.md sibling.

--- a/upgrades/side-effects/owner-side-followup-inject.md
+++ b/upgrades/side-effects/owner-side-followup-inject.md
@@ -1,0 +1,96 @@
+# Side-Effects Review — owner-side follow-up injects, not re-spawns (bug #13)
+
+**Version / slug:** `owner-side-followup-inject`
+**Date:** `2026-05-31`
+**Author:** `echo`
+**Second-pass reviewer:** `not required`
+
+## Summary of the change
+
+On the owner machine, the forwarded-message handler (`server.ts` `onAccepted`) now
+injects a follow-up into the already-running moved session instead of unconditionally
+re-spawning. If a live session exists for the topic it calls `injectTelegramMessage` +
+`trackMessageInjection` and returns; otherwise it spawns under a clean
+`topic-${topicId}` name (never the prefixed `getSessionForTopic` value). Closes audit
+#13 (every follow-up spawned a double-prefixed duplicate session, so the moved
+conversation never advanced).
+
+## Decision-point inventory
+
+- **live session for topic?** `existing && sessionManager.isSessionAlive(existing)` →
+  inject + return; else → spawn. Both sides covered by the wiring test (the inject
+  decision must precede the spawn IIFE).
+- **spawn name** — always `topic-${topicId}` (clean). The prefixed `getSessionForTopic`
+  value is never reused as a spawn name (that was the double-prefix defect).
+
+## 1. Over-block
+
+**What legitimate inputs does this reject?** None. The single-machine inbound path is
+untouched (this is the `onAccepted` forwarded path, gated past `'dark'`). The first
+forwarded message for a topic still spawns exactly as before (no live session →
+spawn). The only behavior change is that the 2nd+ follow-up now reaches the running
+session instead of spawning a duplicate.
+
+## 2. Under-block
+
+**What does this still miss?** The injected follow-up carries the topic name but not
+the originating sender's first-name/user-id (the forwarded payload is text-only), so a
+multi-user topic's moved session sees a generic sender on follow-ups. Acceptable for
+continuity; a richer forwarded payload is a separate, smaller gap. Still NOT
+live-verified — the moved session can't run until the mini's Claude is logged in (bug
+#12, pending the user).
+
+## 3. Level-of-abstraction fit
+
+**Right layer?** Yes. It mirrors the normal inbound dispatch's alive-session branch
+(`injectTelegramMessage`) in the one owner-side place a forwarded message is handled.
+No new method; reuses `isSessionAlive` / `injectTelegramMessage` / `trackMessageInjection`.
+
+## 4. Signal vs authority compliance
+
+**Required reference:** [docs/signal-vs-authority.md](../../docs/signal-vs-authority.md)
+
+No blocking authority. It routes a message to a running session or spawns one; it
+gates nothing and blocks nothing. The spawn IIFE remains best-effort/fail-safe.
+
+## 5. Interactions
+
+Pairs with bug #2 (the spawn branch still fetches the router's relayed history) and
+bug #7/#8/#11 (forward + ownership). The inject branch short-circuits before the bug-#2
+fetch (a running session already has its context). Idempotent: each follow-up either
+injects into the live session or spawns when there is none.
+
+## 6. External surfaces
+
+None new. Same cross-machine GET (bug #2) only on the spawn branch. No new route,
+config, or notification. Visible effect: a moved conversation advances on follow-ups
+instead of spawning duplicates.
+
+## 7. Rollback cost
+
+Low. Revert the `onAccepted` branch to the prior unconditional `spawnSessionForTopic`
+call. No schema, state, or migration.
+
+## Conclusion
+
+Targeted owner-side dispatch fix; mirrors the proven single-machine alive-session
+inject; removes the double-prefix duplicate-spawn; gated past `'dark'` + fail-safe;
+single-machine path untouched; cheap revert. Honestly scoped: unit-verified, live
+follow-up confirmation pending the mini's Claude login.
+
+## Second-pass review (if required)
+
+Not required — additive owner-side branch mirroring an already-proven pattern,
+gated + fail-safe, single-machine path unchanged, reversible, no authority. The live
+move-then-follow-up check is the Tier-3 gate after the user's mini login.
+
+## Evidence pointers
+
+- `tests/unit/session-pool-activation-wiring.test.ts` — inject precedes spawn;
+  `injectTelegramMessage` + `trackMessageInjection`; spawn name `topic-${topicId}`;
+  no prefixed `getSessionForTopic` spawn name.
+- 52 session-pool + adapter tests green; `tsc --noEmit` clean.
+- Confirmed in code: `registerTopicSession` stores the prefixed tmux name →
+  `getSessionForTopic` returns it → `spawnInteractiveSession` re-prefixes →
+  `tmuxSessionExists` misses → duplicate spawn per follow-up.
+- Spec: `docs/specs/owner-side-followup-inject.md` (+ `.eli16.md`).


### PR DESCRIPTION
## What

Audit finding **#13** of the multi-machine live-transfer cascade, found by code audit (the same method that surfaced bug #2) — **not yet live-verified**.

After a topic is moved to a standby owner, every follow-up arrives only via MeshRpc `deliverMessage` → `onAccepted` (the owner is tokenless and never polls Telegram). `onAccepted` called `spawnSessionForTopic` **unconditionally**, passing the prefixed `getSessionForTopic` value as the spawn name — which `spawnInteractiveSession` **re-prefixed** (`projectBase-projectBase-topic-N`), so `tmuxSessionExists` missed and a **brand-new duplicate session was spawned on every follow-up**. The moved conversation never advanced.

This would have broken the live test at its key step: "move this to the mini" works, but the **follow-up** asking for a reply lands in a fresh/duplicate session, so the reply doesn't come from the moved conversation.

## Fix

Mirror the normal inbound dispatch in `onAccepted`:
- If a live session exists for the topic → inject the follow-up into it (`injectTelegramMessage` + `trackMessageInjection`) and return.
- Spawn only when none is running, always under a clean `topic-${topicId}` name — never the prefixed `getSessionForTopic` value (the double-prefix defect).

Gated past `'dark'` + fail-safe; the single-machine inbound path is untouched.

## Tests

- `tests/unit/session-pool-activation-wiring.test.ts` — the inject decision precedes the spawn IIFE; uses `injectTelegramMessage` + `trackMessageInjection`; spawns under `topic-${topicId}`; never a prefixed spawn name.
- 52 session-pool + adapter tests green; `tsc --noEmit` clean; lint clean.

## Honest status

Unit-verified. The live move-then-follow-up round-trip is the Tier-3 gate, pending the mini's Claude login (bug #12 — a user credential action, not code). Spec self-approved under the standing 12h deploy mandate (topic 13481), flagged here per cross-agent discipline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)