### PR TITLE
fix(operations): fail-safe External Operation Gate classification on unknown input

### DIFF
--- a/docs/specs/extern-op-gate-failsafe.eli16.md
+++ b/docs/specs/extern-op-gate-failsafe.eli16.md
@@ -1,0 +1,50 @@
+# External Operation Gate fail-safe — explained simply
+
+## The everyday version
+
+Your agent has a safety gate that sits in front of risky actions on outside
+services — deleting emails, posting messages, changing files in another system.
+Before any such action runs, the gate looks at three things: what the action does
+(read, write, modify, delete), whether it can be undone, and how many items it
+touches. From those it computes a risk level (low / medium / high / critical) and
+decides whether to just let it through, log it, ask you first, or block it. This
+gate exists because of a real incident where an agent deleted 200+ emails on its
+own, ignoring "stop."
+
+## The bug
+
+The risk calculator had a blind spot. It carefully handled all the *expected*
+values — but if it was handed a value it didn't recognize (a typo, a brand-new
+kind of operation, or a deliberately weird input), it quietly fell through to
+"low risk" — which means "go ahead, proceed." So an operation the gate *couldn't
+classify* was waved straight through. For a safety gate, that's exactly backwards:
+the one case it doesn't understand is the one it should be most careful about.
+
+This matters because the gate is fed by untyped sources at runtime (an HTTP
+endpoint and a tool-intercepting hook), so unrecognized values genuinely reach it.
+
+## What we changed
+
+We made it fail *closed* instead of *open*. Now, if the operation's *type* is
+unrecognized, it's treated as the most dangerous level (critical), which means the
+gate asks you to approve it (or blocks it in the strictest mode) — it never just
+proceeds. And if the "can it be undone" or "how many items" fields are
+unrecognized, they're assumed to be the worst case (irreversible / bulk), so the
+risk is computed conservatively. Plain reads stay fast and frictionless, exactly
+as before.
+
+## Why it's safe
+
+Every one of the normal, recognized combinations behaves identically to before —
+we proved that with a test that spot-checks valid inputs are unchanged, on top of
+the existing 12 matrix tests. The only behavior that changes is for inputs the gate
+previously couldn't classify, which now get the careful treatment instead of a free
+pass. An independent reviewer checked the whole thing and agreed it's sound, and
+also pointed out a matching blind spot one layer up (in the hook that labels
+operations) that we're closing in issue-628. Nothing to configure — it just makes
+the safety gate harder to slip past.
+
+## Who found it
+
+The codex mentee agent (Codey) found this while being driven through real Instar
+development tasks — a nice proof that the mentorship loop surfaces genuine bugs.

--- a/docs/specs/extern-op-gate-failsafe.md
+++ b/docs/specs/extern-op-gate-failsafe.md
@@ -1,0 +1,123 @@
+---
+title: External Operation Gate — fail-safe classification on unknown input
+slug: extern-op-gate-failsafe
+date: 2026-05-31
+author: echo
+status: approved
+review-convergence: internal-self-review-2026-05-31 + independent adversarial security review (verdict SOUND, concurred)
+approved: true
+approved-by: Echo under the 12h autonomous deploy mandate (self-approved; flagged in PR). Surfaced by the codex mentee (Codey) during the live mentorship loop — exactly the "drive Codey → find real issues → fix as fleet PR" mandate.
+approval-note: >
+  computeRiskLevel fell through to 'low' (which maps to the 'proceed' action)
+  for any UNRECOGNIZED mutability / reversibility / scope, so an operation the
+  gate cannot classify BYPASSED the gate (fail-open). It is reachable from
+  untyped runtime boundaries (POST /operations/evaluate and the
+  external-operation-gate PreToolUse hook), where the three dimensions arrive as
+  arbitrary strings despite the TypeScript enum types. Now fails CLOSED:
+  unrecognized mutability → critical (→ show-plan/approve), unknown
+  reversibility → irreversible, unknown scope → bulk. Independently
+  adversarially reviewed: SOUND — no valid (known-enum) input is reclassified,
+  and 'critical' is the correct severity (no autonomy profile maps it to proceed).
+second-pass-required: true
+second-pass-status: concurred — independent adversarial security review returned verdict SOUND. It also surfaced the SYMMETRIC hook-layer fail-open (the hook's verb-classifier defaults unrecognized action verbs to 'read' → fast-exits with no gate call); that mirror gap is tracked as issue-628 (a coupled hook PR). <!-- tracked: issue-628 -->
+eli16-overview: extern-op-gate-failsafe.eli16.md
+---
+
+# External Operation Gate — fail-safe classification on unknown input
+
+## The bug, grounded (found by the codex mentee, Codey)
+
+During the live mentorship loop, Codey (the codex mentee agent) audited the
+External Operation Gate and surfaced two real issues. This PR fixes the
+higher-value one: a **fail-open** in the static risk classifier.
+
+`computeRiskLevel(mutability, reversibility, scope)` (`src/core/ExternalOperationGate.ts`)
+is the gate's static classification layer (born from the OpenClaw incident where
+an agent deleted 200+ emails autonomously). Its risk matrix handles the known
+combinations, then ends with a permissive `return 'low'` for "single reversible
+writes/modifies". The problem: that bottom `return 'low'` is also the fall-through
+for **unrecognized** input. An operation whose `mutability` (or
+`reversibility`/`scope`) is not one of the known enum values is not caught by any
+explicit case and falls through to `'low'` → which maps to the `proceed` action →
+the operation **bypasses the gate**.
+
+This is reachable in production: `computeRiskLevel` runs on input from **untyped
+runtime boundaries** — `POST /operations/evaluate` (raw JSON, cast with `as`) and
+the `external-operation-gate.js` PreToolUse hook. The TypeScript enum types are
+NOT enforced at runtime, so a malformed, novel, or adversarial `mutability` value
+(e.g. `"execute"`, `"force_delete"`, `""`, `undefined`) classified as `low` and
+auto-proceeds. For a *safety* gate, failing open on the exact case it cannot
+classify is the worst failure mode.
+
+## Fix
+
+Add a fail-safe guard at the top of `computeRiskLevel`, before any matrix logic:
+
+```ts
+const KNOWN_MUTABILITY = ['read', 'write', 'modify', 'delete'];
+const KNOWN_REVERSIBILITY = ['reversible', 'partially-reversible', 'irreversible'];
+const KNOWN_SCOPE = ['single', 'batch', 'bulk'];
+if (!KNOWN_MUTABILITY.includes(mutability)) return 'critical';
+if (!KNOWN_REVERSIBILITY.includes(reversibility)) reversibility = 'irreversible';
+if (!KNOWN_SCOPE.includes(scope)) scope = 'bulk';
+```
+
+- An operation whose **type** we cannot classify (`mutability`) is treated as
+  maximally dangerous → `critical`. Critical maps (across all three shipped
+  autonomy profiles) to `approve` (→ `show-plan`, surface to the human) or, in
+  the supervised profile, `block` — **never** `proceed`/`log`. So an
+  unclassifiable operation can never auto-proceed, and is not silently dropped
+  either (the user is asked).
+- Unknown **risk-modifiers** (`reversibility`, `scope`) are pinned to their most
+  dangerous valid value (`irreversible`, `bulk`), so the existing matrix computes
+  a conservative — never under-stated — risk.
+- The `read` fast-path (reads are always low) is preserved: `read` is a known
+  mutability, so it passes the guard and short-circuits to `low` as before.
+
+## Safety / why it's correct
+
+- **No valid input is reclassified.** For all 4×3×3 = 36 valid enum combinations,
+  every guard is a no-op and execution reaches the original matrix byte-for-byte
+  unchanged. Locked in by a "valid-input classifications unchanged" test.
+- **`critical` is the right level**, not over-conservative: `high` would have been
+  *weaker* (the autonomous profile maps `high → log → proceed`), which would have
+  left a residual auto-proceed for unknown ops. `critical` is the only level that
+  never auto-proceeds in any profile.
+- **Independently adversarially reviewed** (verdict: SOUND). The reviewer walked
+  the full matrix + the evaluate()/classify() pipeline + the autonomy profiles +
+  the HTTP route and confirmed: no surviving fail-open-to-low for unclassifiable
+  input, no valid input perturbed, correct severity, and `Array.includes` is safe
+  on `undefined`/`null`/non-string (returns false → fail-closed).
+
+## Known related gap (hook layer, tracked as issue-628) <!-- tracked: issue-628 -->
+
+The adversarial review surfaced the **symmetric** fail-open one layer up: the
+`external-operation-gate.js` hook classifies `mutability` by prefix-matching known
+destructive verbs and **defaults everything else to `read`** (then fast-exits with
+no gate call). So a destructive MCP verb that doesn't prefix-match (e.g.
+`force_delete_all`, `expunge`, `wipe`, `truncate`, `revoke`) is classified `read`
+and never reaches the gate. That is the same class, in the primary path, and is
+fixed in a coupled hook PR, tracked as issue-628 (read-verb allowlist + unknown
+verb → `modify`, with migration parity for the installed hook). <!-- tracked: issue-628 --> This server-side fix is
+defense-in-depth that also closes the HTTP-boundary path.
+
+## Migration parity
+
+N/A — code-only, compiled into `dist`; ships in the normal release. No
+agent-installed file / config / template change. (The hook PR, issue-628, DOES need
+migration parity — the hook is a built-in always-overwritten file.) <!-- tracked: issue-628 -->
+
+## Agent Awareness
+
+N/A — internal gate-classifier hardening; no new endpoint or capability.
+
+## Test plan
+
+Unit (`tests/unit/ExternalOperationGate.test.ts`, +5 cases):
+- unknown `mutability` (`'execute'`, `''`, `'purge-everything'`, `undefined`) → `critical` (each was `low` pre-fix).
+- unknown `reversibility` → pinned to irreversible (write→medium, delete→high; each was lower pre-fix).
+- unknown `scope` → pinned to bulk (→critical; was low pre-fix).
+- `read` stays `low` even with unknown reversibility/scope (read is inherently safe).
+- a spot-check that valid-input classifications are unchanged.
+
+The existing 12 known-input matrix tests stay green (the guards are no-ops for valid input). `tsc --noEmit` clean; `npm run lint` (all custom rules) clean.

--- a/src/core/ExternalOperationGate.ts
+++ b/src/core/ExternalOperationGate.ts
@@ -162,6 +162,24 @@ export function computeRiskLevel(
   reversibility: OperationReversibility,
   scope: OperationScope
 ): RiskLevel {
+  // ── Fail-safe on malformed/unknown input ──────────────────────────────
+  // computeRiskLevel is reachable from UNTYPED runtime boundaries (POST
+  // /operations/evaluate and the external-operation-gate hook), where these
+  // dimensions arrive as arbitrary strings — the TypeScript types are NOT
+  // enforced at runtime. An unrecognized value must NOT fall through to the
+  // permissive `return 'low'` at the bottom: that fails OPEN, letting an
+  // operation we cannot classify bypass the gate. A safety gate fails CLOSED —
+  // an unclassifiable operation is treated as maximally dangerous, and unknown
+  // risk-modifiers are pinned to their most dangerous valid value. (This gate
+  // exists precisely to stop the unclassified-destructive-op case — see the
+  // OpenClaw 200-email-deletion incident in the file header.)
+  const KNOWN_MUTABILITY: readonly OperationMutability[] = ['read', 'write', 'modify', 'delete'];
+  const KNOWN_REVERSIBILITY: readonly OperationReversibility[] = ['reversible', 'partially-reversible', 'irreversible'];
+  const KNOWN_SCOPE: readonly OperationScope[] = ['single', 'batch', 'bulk'];
+  if (!KNOWN_MUTABILITY.includes(mutability)) return 'critical';
+  if (!KNOWN_REVERSIBILITY.includes(reversibility)) reversibility = 'irreversible';
+  if (!KNOWN_SCOPE.includes(scope)) scope = 'bulk';
+
   // Reads are always low risk
   if (mutability === 'read') return 'low';
 

--- a/tests/unit/ExternalOperationGate.test.ts
+++ b/tests/unit/ExternalOperationGate.test.ts
@@ -72,6 +72,43 @@ describe('computeRiskLevel', () => {
   it('single reversible modifies are low risk', () => {
     expect(computeRiskLevel('modify', 'reversible', 'single')).toBe('low');
   });
+
+  // ── Fail-safe on unknown/malformed runtime input ──────────────────────
+  // computeRiskLevel is reachable from UNTYPED HTTP/hook boundaries, so an
+  // unrecognized dimension must fail CLOSED — never fall through to 'low'
+  // (which maps to `proceed` and would bypass the gate). The casts below
+  // model what arrives at runtime despite the TypeScript types.
+  it('unknown mutability is treated as critical (fails closed, not open to low)', () => {
+    // Pre-fix every one of these fell through to `return 'low'` → proceed.
+    expect(computeRiskLevel('execute' as OperationMutability, 'reversible', 'single')).toBe('critical');
+    expect(computeRiskLevel('' as OperationMutability, 'reversible', 'single')).toBe('critical');
+    expect(computeRiskLevel('purge-everything' as OperationMutability, 'reversible', 'single')).toBe('critical');
+    expect(computeRiskLevel(undefined as unknown as OperationMutability, 'reversible', 'single')).toBe('critical');
+  });
+
+  it('unknown reversibility is pinned to irreversible (fails closed)', () => {
+    // write + (unknown→irreversible) + single = medium (was 'low' pre-fix).
+    expect(computeRiskLevel('write', 'maybe' as OperationReversibility, 'single')).toBe('medium');
+    // delete + (unknown→irreversible) + single = high (was 'medium' pre-fix).
+    expect(computeRiskLevel('delete', 'unknown' as OperationReversibility, 'single')).toBe('high');
+  });
+
+  it('unknown scope is pinned to bulk (fails closed)', () => {
+    // write + reversible + (unknown→bulk) = critical (was 'low' pre-fix).
+    expect(computeRiskLevel('write', 'reversible', 'galaxy' as OperationScope)).toBe('critical');
+    expect(computeRiskLevel('modify', 'reversible', '' as OperationScope)).toBe('critical');
+  });
+
+  it('reads stay low even with unknown reversibility/scope (read is inherently safe)', () => {
+    expect(computeRiskLevel('read', 'bogus' as OperationReversibility, 'bogus' as OperationScope)).toBe('low');
+  });
+
+  it('all valid-input classifications are unchanged by the fail-safe guards', () => {
+    expect(computeRiskLevel('write', 'reversible', 'single')).toBe('low');
+    expect(computeRiskLevel('delete', 'irreversible', 'bulk')).toBe('critical');
+    expect(computeRiskLevel('read', 'irreversible', 'bulk')).toBe('low');
+    expect(computeRiskLevel('delete', 'reversible', 'single')).toBe('medium');
+  });
 });
 
 describe('scopeFromCount', () => {

--- a/upgrades/next/extern-op-gate-failsafe.md
+++ b/upgrades/next/extern-op-gate-failsafe.md
@@ -1,0 +1,52 @@
+<!-- bump: patch -->
+
+## What Changed — The external-operation safety gate no longer waves through operations it cannot classify
+
+Your agent has a safety gate in front of risky actions on outside services
+(deleting emails, posting messages, changing remote files). It scores each
+operation's risk and decides whether to proceed, log, ask you, or block. The risk
+scorer had a blind spot: if it was handed a value it did not recognize for what the
+operation does, whether it can be undone, or how many items it touches, it quietly
+fell back to "low risk" and let the operation proceed. For a safety gate, the one
+case it cannot classify is exactly the case it should be most careful about.
+
+Now it fails safe. An operation whose type the gate cannot recognize is treated as
+the most dangerous level, so it is surfaced for your approval (or blocked in the
+strictest mode) instead of proceeding. Unrecognized "can it be undone" or "how
+many" values are assumed to be the worst case so the risk is scored
+conservatively. Ordinary reads stay fast and frictionless, and every recognized
+operation behaves exactly as it did before.
+
+## Summary of New Capabilities
+
+- `computeRiskLevel` in the External Operation Gate now fails closed on
+  unrecognized input: an unknown operation mutability classifies as critical
+  (which maps to show-plan / approve, never proceed), and unknown reversibility or
+  scope are pinned to their most dangerous valid value (irreversible / bulk). All
+  valid enum combinations are unchanged. The function is reachable from untyped
+  runtime boundaries (the operations-evaluate route and the external-operation
+  PreToolUse hook), which is why the hardening matters.
+
+## What to Tell Your User
+
+Your agent's safety gate for risky outside actions is now harder to slip past. If
+an operation shows up that the gate cannot recognize, it asks you first instead of
+quietly letting it through. Normal actions are unaffected and there is nothing to
+configure.
+
+## Evidence
+
+- Found by the codex mentee agent during the live mentorship loop, then verified
+  against the actual code: the risk matrix ended in a permissive low-risk
+  fall-through that also caught unrecognized input, so an unclassifiable operation
+  mapped to proceed (fail-open).
+- The fix adds a fail-safe guard: unknown mutability returns critical; unknown
+  reversibility and scope are pinned to irreversible and bulk.
+- Unit tests, `tests/unit/ExternalOperationGate.test.ts` (+5): unknown mutability
+  classifies critical (was low); unknown reversibility and scope fail closed; reads
+  stay low; valid-input classifications are unchanged. The existing matrix tests
+  stay green.
+- Independent adversarial security review returned a verdict of sound, with no
+  valid input reclassified and the chosen severity confirmed correct.
+- A symmetric blind spot in the gate hook (unrecognized action verbs defaulting to
+  read) is being closed in the coupled hook PR, tracked as issue-628.

--- a/upgrades/side-effects/extern-op-gate-failsafe.md
+++ b/upgrades/side-effects/extern-op-gate-failsafe.md
@@ -1,0 +1,49 @@
+# Side-effects — External Operation Gate fail-safe classification
+
+## 1. What files/state does this touch at runtime?
+`src/core/ExternalOperationGate.ts` only — a 6-line fail-safe guard at the top of
+the pure `computeRiskLevel()` function. No new state, config, schema, endpoint, or
+dependency. `computeRiskLevel` is also re-exported via `src/index.ts` (public API);
+the signature is unchanged.
+
+## 2. Does it change any functional behavior?
+Only for UNRECOGNIZED input. An operation whose `mutability` is not
+read/write/modify/delete now classifies as `critical` (was `low`); unknown
+`reversibility`/`scope` are pinned to irreversible/bulk (conservative). For all 36
+valid enum combinations, behavior is byte-for-byte unchanged (proven by test).
+
+## 3. What happens on failure / weird config?
+This IS the weird-input path. `Array.includes` on `undefined`/`null`/`''`/any
+non-string returns false → the fail-closed branch → `critical`. No throw. The
+function remains pure and total.
+
+## 4. Migration parity — do existing agents get it?
+Yes, via the normal release — code-only, compiled into `dist`. No agent-installed
+file / config / template change → no `PostUpdateMigrator` pass. (NOTE: the
+coupled hook PR, tracked as issue-628, that fixes the verb-classifier WILL need
+migration parity — the hook is a built-in always-overwritten file.) <!-- tracked: issue-628 -->
+
+## 5. Could it spam / flood / burn resources?
+No — it's a pure synchronous classification with three array-membership checks. If
+anything it slightly REDUCES load on the unknown-input path (an unknown op that
+used to auto-proceed now routes to show-plan/approve, but that path is rare). It
+does not add timers, I/O, or LLM calls. (Unknown ops now classify `critical` →
+medium+ risk → eligible for the existing LLM proportionality step; but unknown ops
+are rare and the step is already rate-limited via the LlmCircuitBreaker.)
+
+## 6. Rollback / off-switch?
+Revert the 6-line guard. No data, no migration, no flag. Behavior returns to the
+prior (fail-open) state.
+
+## 7. Concurrency / ordering?
+None — pure synchronous function, no shared state. The guard runs first, then the
+unchanged matrix. `critical` for unknown mutability returns immediately (before the
+read short-circuit and the rest of the matrix).
+
+## Blast radius
+Minimal + contained. One pure function, unknown-input path only; all valid-input
+classifications unchanged (locked by test). Independently adversarially reviewed:
+SOUND. The only judgment call — severity `critical` vs `high` for unknown mutability
+— was reviewed and confirmed correct (`high` would leave a residual auto-proceed in
+the autonomous profile; `critical` never auto-proceeds). A symmetric hook-layer gap
+is acknowledged and fixed in the coupled hook PR, tracked as issue-628. <!-- tracked: issue-628 -->


### PR DESCRIPTION
## What

Fail-safe the External Operation Gate's static risk classifier. `computeRiskLevel(mutability, reversibility, scope)` ended in a permissive `return 'low'` that also caught **unrecognized** input — so an operation the gate could not classify mapped to `low` → the `proceed` action → it **bypassed the gate** (fail-open). This is reachable from untyped runtime boundaries (`POST /operations/evaluate` and the `external-operation-gate.js` PreToolUse hook), where the dimensions arrive as arbitrary strings despite the TypeScript enum types.

Now fails **closed**:
- unknown `mutability` → `critical` (maps to `show-plan`/approve across all shipped autonomy profiles, **never** `proceed`)
- unknown `reversibility` → pinned to `irreversible`
- unknown `scope` → pinned to `bulk`

All 36 valid enum combinations are unchanged (locked by a test). The `read` fast-path is preserved.

## Origin (mandate dogfooding)

Surfaced by the **codex mentee agent (Codey)** during the live mentorship loop — a real proof that driving Codey through Instar tasks finds genuine bugs. Verified against the actual code before fixing (the matrix fall-through was confirmed real, not over-claimed).

## Review

Independently **adversarially reviewed** — verdict **SOUND**: no valid input reclassified; `critical` is the correct severity (`high` would leave a residual auto-proceed in the autonomous profile); `Array.includes` is safe on `undefined`/`null`/non-string. The review also surfaced the **symmetric hook-layer fail-open** (the hook defaults unrecognized action verbs to `read`, fast-exiting with no gate call) — tracked as **#628** and fixed in a coupled hook PR.

## Tests

`tests/unit/ExternalOperationGate.test.ts` (+5): unknown mutability → critical; unknown reversibility/scope fail closed; reads stay low; valid-input classifications unchanged. Existing 12 matrix tests stay green. `tsc --noEmit` + `npm run lint` clean.

## Ship-gate

Spec `docs/specs/extern-op-gate-failsafe.md` (approved, second-pass concurred) + `.eli16.md` + side-effects + release fragment + trace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
