### PR TITLE
fix(updates): UpdateGate keys session-health by tmux name, not display name

### DIFF
--- a/docs/specs/UPDATE-GATE-HEALTH-KEY-FIX-SPEC.eli16.md
+++ b/docs/specs/UPDATE-GATE-HEALTH-KEY-FIX-SPEC.eli16.md
@@ -1,0 +1,44 @@
+# ELI16 — Why my agent kept running an old version
+
+## The everyday version
+
+Your agent downloads its own updates in the background, then waits for a calm
+moment to actually switch over to the new code — it doesn't want to interrupt
+you mid-conversation. To decide whether the moment is calm, it looks at all its
+running chat sessions and asks each one: "are you busy right now, or just sitting
+idle?" If they're all idle, it switches to the new version immediately. If
+something is genuinely busy, it politely waits.
+
+That's the design. But there was a bug in how it asked the question.
+
+## The mix-up
+
+Every session has two names: a friendly one you'd recognize ("Codey
+Collaboration") and an internal computer one ("echo-codey-collaboration"). The
+part of the agent that tracks "is this session busy or idle?" filed its notes
+under the **computer** names. But the part that checks those notes looked them up
+by the **friendly** names. Different names → the lookup always came back empty.
+
+When the check comes back empty, the code plays it safe and assumes the session
+is busy ("better not interrupt something I can't see"). Because the lookup
+*always* came back empty, **every** session looked busy — even ones that had been
+sitting idle for days. So the "switch over when everything's calm" rule could
+never trigger. The agent stayed on its old version far longer than it should
+have, only catching up in the middle of the night when a separate timed window
+opened.
+
+## The fix
+
+Look up the busy/idle notes using the **computer** name (the one they were
+actually filed under), and only fall back to the friendly name if that's all
+that's available. Now the agent can really see which sessions are idle, so it can
+update promptly when nothing is busy — while still waiting whenever a session is
+genuinely doing work, so your active conversations are never interrupted.
+
+## Why it matters
+
+A stale agent is running yesterday's bug fixes and security patches. This was the
+root cause of an agent sitting on an old version for most of a day. It also made
+the agent *look* busier than it was ("7 active sessions!") when most of those
+sessions were idle — which muddied the picture when we were trying to tell real
+load apart from phantom load.

--- a/docs/specs/UPDATE-GATE-HEALTH-KEY-FIX-SPEC.md
+++ b/docs/specs/UPDATE-GATE-HEALTH-KEY-FIX-SPEC.md
@@ -1,0 +1,99 @@
+---
+title: "UpdateGate health lookup must key by tmux session name, not display name"
+slug: "update-gate-health-key-fix"
+author: "echo"
+status: "converged"
+review-convergence: "2026-05-31T16:40:00Z"
+review-iterations: 1
+review-completed-at: "2026-05-31T16:40:00Z"
+approved: true
+approved-by: "echo"
+approved-date: "2026-05-31"
+approval-note: "Root-cause bug fix surfaced by live dogfooding (restart-deferral / version-lag). Self-approved under the standing autonomous-dev mandate; flagged in the PR. Independently adversarially reviewed before merge."
+eli16-overview: "UPDATE-GATE-HEALTH-KEY-FIX-SPEC.eli16.md"
+---
+
+# UpdateGate health lookup must key by tmux session name, not display name
+
+## Problem
+
+`UpdateGate.classifyRunningSessions()` decides which running sessions block an
+auto-update restart. It excludes `idle` / `dead` / `unresponsive` sessions so
+that an otherwise-idle box can restart promptly (the restart-when-idle behavior,
+spec/issue #41). It does this by joining two data sources:
+
+- `sessionManager.listRunningSessions()` → `SessionInfo[]`, where `.name` is the
+  **human-facing display name** (e.g. `"Codey Collaboration"`) and `.tmuxSession`
+  is the **tmux slug** (e.g. `"echo-codey-collaboration"`).
+- `sessionMonitor.getStatus().sessionHealth` → entries keyed by `sessionName`,
+  which in production is the **tmux slug** (it is sourced from the
+  TelegramAdapter `topicToSession` registry, whose values are the tmux session
+  names — verified live in `topic-session-registry.json`).
+
+The join was written as `healthMap.get(session.name)` — display name against a
+map keyed by slug. **The lookup always misses.** Every interactive session
+therefore falls into the `!h` ("no health data — be conservative, treat as
+active") branch and is classified active, regardless of whether it is genuinely
+idle. The idle/dead exclusion is effectively **dead code**, so restart-when-idle
+(#41) never fires whenever any interactive session exists.
+
+### Observed impact (live, 2026-05-31)
+
+Echo ran stale `v1.3.165` in memory for ~hours while `v1.3.172` sat on disk. The
+AutoUpdater deferred the restart with reason `7 active session(s)`. The persisted
+`auto-updater.json.restartDeferral.currentBlockers` listed display names
+(`"Codey Collaboration"`, `"CPU Load Investigation"`, `"token management"`, …) —
+all days-old, genuinely-idle topic sessions — while `topic-session-registry.json`
+keyed those same sessions by slug (`"echo-codey-collaboration"`, …). The
+mismatch is the root cause of the day-long version-lag and a contributor to the
+"too many active sessions / load" signal.
+
+## Fix
+
+In `classifyRunningSessions`, look up session health by `session.tmuxSession`
+first (the key the health map actually uses), then fall back to `session.name`:
+
+```ts
+const h =
+  (session.tmuxSession ? healthMap.get(session.tmuxSession) : undefined) ??
+  healthMap.get(session.name);
+```
+
+This is a single-point change at the only place the health map is consulted, so
+it fixes both `canRestart()` (the real gate) and `getBlockingSessions()` (the
+pure idle probe used by the restart-window bypass), which both route through
+`classifyRunningSessions`.
+
+## Why this is safe
+
+- It makes the classification **correct**, not more aggressive. A genuinely
+  `healthy` session keyed by slug is now correctly seen as healthy and **still
+  blocks** the restart — active work remains protected. Only `idle` / `dead`
+  sessions become non-blocking, which is the documented intent.
+- The `name` fallback preserves backward compatibility with any caller/fixture
+  that keys health by display name (the pre-existing unit tests do this).
+- The conservative `!h` default is retained for genuinely-untracked sessions.
+- No change to the deferral state machine, warnings, or the max-deferral logic.
+
+## Non-goals
+
+- This does not change how sessions are named, nor the SessionMonitor health
+  classification thresholds.
+- It does not touch the restart-window configuration (that is a separate
+  operator setting).
+
+## Tests
+
+`tests/unit/UpdateGate.test.ts` adds a `health key shape — tmuxSession vs display
+name (#47)` block using the **real production key shape** (health keyed by slug,
+`session.name` a display name):
+
+1. an idle slug-keyed session is **not** blocking (was wrongly blocking pre-fix),
+2. `canRestart` **allows** the restart when the only session is idle,
+3. a healthy slug-keyed session **still blocks** (active work protected),
+4. a dead slug-keyed session is non-blocking,
+5. a name-keyed health entry is still found via the fallback (back-compat).
+
+Verified that tests 1, 2, 4 **fail** against the pre-fix lookup and pass with the
+fix (no vacuous assertions). All pre-existing UpdateGate + AutoUpdater unit tests
+stay green.

--- a/src/core/UpdateGate.ts
+++ b/src/core/UpdateGate.ts
@@ -219,7 +219,17 @@ export class UpdateGate {
         continue;
       }
 
-      const h = healthMap.get(session.name);
+      // Health is keyed by the tmux session name (the slug SessionMonitor
+      // tracks, e.g. "echo-codey-collaboration"), NOT the human-facing display
+      // name (e.g. "Codey Collaboration"). Look up by tmuxSession first, then
+      // fall back to name. Without the tmuxSession key, every interactive
+      // session misses the health map and hits the conservative "treat as
+      // active" default below — which silently turned the idle/dead exclusion
+      // into dead code and meant restart-when-idle (#41) never fired while ANY
+      // session existed (the day-long version-lag root cause).
+      const h =
+        (session.tmuxSession ? healthMap.get(session.tmuxSession) : undefined) ??
+        healthMap.get(session.name);
       if (!h) {
         // No health data — be conservative, treat as active
         activeSessions.push(session.name);

--- a/tests/unit/UpdateGate.test.ts
+++ b/tests/unit/UpdateGate.test.ts
@@ -114,4 +114,78 @@ describe('UpdateGate', () => {
       expect(status.finalWarningSent).toBe(false);
     });
   });
+
+  // #47 regression — in production SessionMonitor keys health by the tmux
+  // session name (slug, e.g. "echo-codey-collaboration"), while listRunningSessions
+  // returns the human-facing display name ("Codey Collaboration"). The gate must
+  // join them via session.tmuxSession. Before the fix it looked up by session.name,
+  // always missed, and fell into the conservative "treat as active" default — so
+  // EVERY interactive session blocked regardless of idle status, and the
+  // restart-when-idle bypass (#41) never fired. These fixtures use the REAL
+  // production key shape (health keyed by slug ≠ display name).
+  describe('health key shape — tmuxSession (slug) vs display name (#47)', () => {
+    const idleSlugKeyedMonitor = {
+      getStatus: () => ({
+        sessionHealth: [
+          { sessionName: 'echo-codey-collaboration', topicId: 13435, status: 'idle' as const, idleMinutes: 120 },
+        ],
+      }),
+    };
+    const displayNameManager = {
+      listRunningSessions: () => [{ name: 'Codey Collaboration', tmuxSession: 'echo-codey-collaboration' }],
+      hasActiveProcesses: () => false,
+    };
+
+    it('does NOT block an IDLE session when health is keyed by tmuxSession slug (was the dead-code bug)', () => {
+      const gate = new UpdateGate();
+      // Pre-fix: lookup by display name missed → conservative-active → ['Codey Collaboration'].
+      expect(gate.getBlockingSessions(displayNameManager, idleSlugKeyedMonitor)).toEqual([]);
+    });
+
+    it('canRestart ALLOWS the restart when the only session is idle (slug-keyed health)', () => {
+      const gate = new UpdateGate();
+      const result = gate.canRestart(displayNameManager, idleSlugKeyedMonitor);
+      expect(result.allowed).toBe(true);
+      expect(gate.getStatus().blockingSessions).toEqual([]);
+    });
+
+    it('still BLOCKS a HEALTHY session keyed by tmuxSession slug (active work stays protected)', () => {
+      const gate = new UpdateGate();
+      const healthyMonitor = {
+        getStatus: () => ({
+          sessionHealth: [
+            { sessionName: 'echo-codey-collaboration', topicId: 13435, status: 'healthy' as const, idleMinutes: 0 },
+          ],
+        }),
+      };
+      expect(gate.getBlockingSessions(displayNameManager, healthyMonitor)).toEqual(['Codey Collaboration']);
+    });
+
+    it('does NOT block a DEAD session keyed by tmuxSession slug', () => {
+      const gate = new UpdateGate();
+      const deadMonitor = {
+        getStatus: () => ({
+          sessionHealth: [
+            { sessionName: 'echo-codey-collaboration', topicId: 13435, status: 'dead' as const, idleMinutes: 999 },
+          ],
+        }),
+      };
+      expect(gate.getBlockingSessions(displayNameManager, deadMonitor)).toEqual([]);
+    });
+
+    it('falls back to display-name health key when tmuxSession has no slug-keyed entry (back-compat)', () => {
+      // Older/test fixtures key health by session.name; the fallback must still find it.
+      const gate = new UpdateGate();
+      const nameKeyedMonitor = {
+        getStatus: () => ({
+          sessionHealth: [{ sessionName: 'topic-458', topicId: 458, status: 'idle' as const, idleMinutes: 30 }],
+        }),
+      };
+      const mgr = {
+        listRunningSessions: () => [{ name: 'topic-458', tmuxSession: 'instar-topic-458' }],
+        hasActiveProcesses: () => false,
+      };
+      expect(gate.getBlockingSessions(mgr, nameKeyedMonitor)).toEqual([]); // idle via name-key fallback
+    });
+  });
 });

--- a/upgrades/NEXT.md
+++ b/upgrades/NEXT.md
@@ -1,0 +1,46 @@
+# Upgrade Guide — vNEXT
+
+<!-- bump: patch -->
+
+## What Changed
+
+Fixed a bug in the auto-update restart gate that kept agents running a stale
+version far longer than intended. `UpdateGate` decides whether the box is "idle
+enough" to restart onto a freshly-downloaded update by checking each running
+session's health (`healthy` blocks; `idle`/`dead` don't). It looked that health
+up by the session's **display name** while the health map is keyed by the **tmux
+session name** (slug). The lookup always missed, so every interactive session was
+conservatively treated as active — which made the idle/dead exclusion dead code
+and meant the restart-when-idle path never fired while any session existed.
+
+The gate now looks up health by `session.tmuxSession` (the key the health map
+actually uses), falling back to the display name. Idle/dead sessions correctly
+stop blocking restarts; genuinely-active (`healthy`) sessions still block, so live
+work is never interrupted.
+
+## What to Tell Your User
+
+Nothing required — this is invisible robustness. If they noticed their agent
+"staying on an old version most of the day and only catching up overnight," or
+the agent reporting more active sessions than seemed real, this is the fix:
+updates now activate promptly when the box is genuinely idle.
+
+## Summary of New Capabilities
+
+- Auto-update restarts activate promptly on a genuinely-idle box instead of
+  waiting for the overnight restart window (completes the restart-when-idle
+  intent).
+- More accurate "active session" accounting in the restart gate (idle sessions
+  no longer inflate the blocker count).
+
+## Evidence
+
+- Root cause proven from live state: `auto-updater.json.restartDeferral.currentBlockers`
+  held display names (`"Codey Collaboration"`, …) while `topic-session-registry.json`
+  keyed the same sessions by slug (`"echo-codey-collaboration"`, …) — a guaranteed
+  lookup miss.
+- `tests/unit/UpdateGate.test.ts`: +5 tests using the production key shape; the
+  3 status-discriminating ones were confirmed RED pre-fix, GREEN post-fix.
+- `npx vitest run tests/unit/UpdateGate.test.ts tests/unit/AutoUpdater.test.ts` →
+  29 passed. `npm run lint` clean. `tsc --noEmit` clean.
+- Spec: `docs/specs/UPDATE-GATE-HEALTH-KEY-FIX-SPEC.md` (+ ELI16 companion).

--- a/upgrades/side-effects/update-gate-health-key-fix.md
+++ b/upgrades/side-effects/update-gate-health-key-fix.md
@@ -1,0 +1,69 @@
+# Side-Effects Review — UpdateGate health lookup keys by tmux session name
+
+**Version / slug:** `update-gate-health-key-fix`
+**Date:** 2026-05-31
+**Author:** echo
+
+## Summary of the change
+
+`UpdateGate.classifyRunningSessions()` looked up per-session health with
+`healthMap.get(session.name)` (display name) against a map keyed by the tmux
+session slug. The lookup always missed → every interactive session hit the
+conservative "treat as active" default → the idle/dead exclusion was dead code →
+restart-when-idle (#41) never fired. Fix: look up by `session.tmuxSession` first,
+fall back to `session.name`.
+
+**Files changed (source):**
+- `src/core/UpdateGate.ts` — one lookup expression in `classifyRunningSessions`
+  (+ an explanatory comment). No signature, interface, or control-flow change.
+
+**Files changed (tests):**
+- `tests/unit/UpdateGate.test.ts` — +1 describe block (5 tests) exercising the
+  production key shape (health keyed by slug, `session.name` a display name).
+
+## Blast radius
+
+`classifyRunningSessions` is the single private classifier behind both
+`canRestart()` (the restart gate) and `getBlockingSessions()` (the pure idle
+probe). Both are consumed only by `AutoUpdater` for restart gating. Nothing else
+calls them. So the change's reach is exactly: "which running sessions are deemed
+active for the purpose of deferring an auto-update restart."
+
+## Behavior delta
+
+| Scenario | Before | After |
+|---|---|---|
+| Interactive session, health=`idle` (keyed by slug) | counted **active** (lookup miss → conservative) → blocks restart | correctly **idle** → does not block |
+| Interactive session, health=`healthy` (keyed by slug) | counted active (right outcome, wrong reason) | counted active (correct reason) → still blocks |
+| Interactive session, health=`dead`/`unresponsive` (slug) | counted active (miss) | correctly excluded / unresponsive |
+| Session with genuinely no health entry | conservative active | conservative active (unchanged) |
+| Health keyed by display name (legacy/test) | found | still found (fallback) |
+
+Net: idle/dead sessions stop blocking restarts; **active (`healthy`) sessions
+still block, so live work is never interrupted.**
+
+## Risks considered
+
+- **False-idle interruption?** No. Only `idle`/`dead` health statuses become
+  non-blocking, and those are set by SessionMonitor's own thresholds (15-min
+  no-output for `idle`). A session actively producing output is `healthy` and
+  still blocks.
+- **Name collision (a session's display name equals another's slug)?** The
+  fallback only fires when the slug lookup misses; display vs slug formats differ
+  (spaces/caps vs hyphenated-prefixed), so a cross-match is implausible and would
+  at worst reuse an existing same-status entry.
+- **Restarts now happen more often** — that is the intended effect (#41). They
+  remain gated by genuinely-active sessions and the operator restart window.
+
+## Migration parity
+
+None required. `src/core/UpdateGate.ts` is shipped library code, not an
+agent-installed file (hook, config default, CLAUDE.md template, or skill). It
+takes effect for every agent on the normal server restart that activates the new
+version. No `PostUpdateMigrator` entry is needed.
+
+## Test evidence
+
+`npx vitest run tests/unit/UpdateGate.test.ts tests/unit/AutoUpdater.test.ts` →
+29 passed. The 3 status-discriminating new tests were confirmed RED against the
+pre-fix lookup and GREEN with the fix. `npm run lint` clean.


### PR DESCRIPTION
## What

Fixes a real, live-observed bug in the auto-update restart gate. `UpdateGate.classifyRunningSessions()` looked up per-session health with `healthMap.get(session.name)` — the **display name** (e.g. `"Codey Collaboration"`) — against a health map keyed by the **tmux session slug** (e.g. `"echo-codey-collaboration"`). The lookup **always missed**, so every interactive session fell into the conservative `!h` "no health data — treat as active" default. That turned the `idle`/`dead` exclusion into **dead code**: the restart-when-idle path (#41) never fired while any interactive session existed.

Now looks up by `session.tmuxSession` (the actual map key) with a `session.name` fallback for back-compat. Single-point change in the shared classifier, so both `canRestart()` and `getBlockingSessions()` are fixed.

## Why it matters (live evidence)

Found by dogfooding: Echo ran stale **v1.3.165** in memory for hours while **v1.3.172** sat on disk, with the AutoUpdater deferring on `7 active session(s)` — all of which were days-old, genuinely-idle topic sessions. Proven from live state:
- `auto-updater.json.restartDeferral.currentBlockers` → display names (`"Codey Collaboration"`, `"CPU Load Investigation"`, `"token management"`, …)
- `topic-session-registry.json` → the same sessions keyed by slug (`"echo-codey-collaboration"`, …)

A guaranteed lookup miss. This is the root cause of the day-long version-lag and a contributor to the "more active sessions than seem real / load" signal.

## Safety

Makes the classification **correct**, not more aggressive:
- A `healthy` session keyed by slug is now correctly seen as healthy and **still blocks** the restart — active work stays protected.
- Only `idle`/`dead` sessions become non-blocking (the documented intent).
- The `name` fallback keeps legacy/name-keyed callers working.
- No change to the deferral state machine, warnings, or max-deferral logic.

## Migration parity

None required — `src/core/UpdateGate.ts` is shipped library code, not an agent-installed file. Active for every agent on the normal restart that activates the new version.

## Tests

`tests/unit/UpdateGate.test.ts` +5 (production key shape: health keyed by slug, `session.name` a display name): idle → not blocking; `canRestart` allows when idle; healthy → still blocks; dead → not blocking; name-key fallback still found. The 3 status-discriminating tests were confirmed **RED against the pre-fix lookup** and GREEN with the fix (no vacuous assertions). `npx vitest run tests/unit/UpdateGate.test.ts tests/unit/AutoUpdater.test.ts` → 29 passed. `npm run lint` + `tsc --noEmit` clean.

## Ship-gate

Spec `docs/specs/UPDATE-GATE-HEALTH-KEY-FIX-SPEC.md` (converged + approved, self-approved under the standing autonomous-dev mandate) + ELI16 companion + side-effects review + `upgrades/NEXT.md` (`bump: patch`) + trace. Self-approval flagged here per the mandate; will be independently adversarially reviewed before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
