### PR TITLE
fix(release): pre-push gate blocks a src change with no release fragment (#23)

### DIFF
--- a/docs/specs/PRE-PUSH-RELEASE-FRAGMENT-GUARD-SPEC.eli16.md
+++ b/docs/specs/PRE-PUSH-RELEASE-FRAGMENT-GUARD-SPEC.eli16.md
@@ -1,0 +1,41 @@
+# ELI16 — Why a fix could merge but never actually ship
+
+## The everyday version
+
+When we change the code and want it to go out to all the agents, the release
+robot looks for a little "release note" file describing what changed. If it finds
+one, it publishes a new version. If it finds NO release note, it shrugs and does
+nothing — quietly. No error, no warning, just… nothing ships.
+
+That's mostly fine: if you didn't change any real code, there's nothing to
+release, so doing nothing is correct.
+
+The problem: what if you DID change real code but forgot to write the release
+note? The robot still shrugs and skips. Your fix gets merged into the main
+codebase, looks done, everyone moves on — but it never actually reaches the
+agents. It just sits there, unreleased, silently. We got bitten by exactly this:
+a real fix sat unpublished because its pull request had no release note, and
+nobody noticed until much later.
+
+## The check we already had (and the gap)
+
+Before you push code, a "gate" runs and checks a few things — like "you changed
+code but added no tests" (it warns you). But it had no check for "you changed
+code but wrote no release note." So the silent-skip walked right past it.
+
+## The fix
+
+Add one more check to that same gate, built exactly like the no-tests one: if you
+changed real code (`src/`) and there's no release-note file in your changes, the
+gate stops you with a clear message — "this would silently skip the release; add
+a release note." It only triggers on real code changes, so the routine
+"cut the release" housekeeping commit (which touches release files but not code)
+never sets it off. And if you're genuinely mid-work and not ready, the same
+existing escape hatch lets you push anyway.
+
+## Why it matters
+
+It turns an invisible failure — a fix that merges but never ships — into a loud,
+fix-it-now message at the moment you'd otherwise create the problem. Cheap guard,
+real failure class closed. (And this very change dogfoods it: it ships with its
+own release-note fragment.)

--- a/docs/specs/PRE-PUSH-RELEASE-FRAGMENT-GUARD-SPEC.md
+++ b/docs/specs/PRE-PUSH-RELEASE-FRAGMENT-GUARD-SPEC.md
@@ -1,0 +1,78 @@
+---
+title: "Pre-push gate: src change without a release fragment fails loudly (#23)"
+slug: "pre-push-release-fragment-guard"
+author: "echo"
+status: "converged"
+review-convergence: "2026-05-31T18:30:00Z"
+review-iterations: 1
+review-completed-at: "2026-05-31T18:30:00Z"
+approved: true
+approved-by: "echo"
+approved-date: "2026-05-31"
+approval-note: "Closes the long-standing #23 silent-release-skip class. Self-approved under the standing autonomous-dev mandate; flagged in the PR. Low-risk guard mirroring the existing src→tests check."
+eli16-overview: "PRE-PUSH-RELEASE-FRAGMENT-GUARD-SPEC.eli16.md"
+---
+
+# Pre-push gate: src change without a release fragment fails loudly (#23)
+
+## Problem
+
+`publish.yml` (the post-merge release workflow) decides whether to publish by
+checking for release notes: if there is no `upgrades/next/<slug>.md` fragment AND
+no `upgrades/NEXT.md`, it sets `skip=true` and **silently skips the release**
+(publish.yml: "No NEXT.md found — nothing to publish"). So a shippable `src/`
+change that merges WITHOUT a release-note fragment merges to `main` but **never
+ships** — with no signal anywhere. This is the #23 failure class, lived in
+practice (a fix sat unreleased because the PR had no NEXT.md).
+
+The pre-push gate (`scripts/pre-push-gate.js`) already guards related cases — it
+validates the assembled release notes for required sections and malformed
+fragments, and warns when `src/` changed but no test file changed — but it has
+**no check** for "`src/` changed but no release fragment exists at all". So the
+silent-skip slips through every local gate.
+
+## Fix
+
+Add a check in `scripts/pre-push-gate.js`, directly mirroring the existing
+src→tests check (same `changedFiles` branch diff, same shape): if `src/` `.ts`
+files changed in the branch AND no `upgrades/next/*.md` fragment (or
+`upgrades/NEXT.md`) is in the diff, push an **error** (gate exits non-zero):
+
+```js
+const fragmentChanges = changedFiles.filter(f =>
+  f.startsWith('upgrades/next/') || f === 'upgrades/NEXT.md'
+);
+if (srcChanges.length > 0 && fragmentChanges.length === 0) {
+  errors.push(`… source file(s) changed but no release-note fragment … SILENTLY SKIPS the release …`);
+}
+```
+
+## Why this is safe / correct
+
+- **No false positive on the release-cut commit.** The `chore: release [skip ci]`
+  commit renames `NEXT.md` → `<version>.md` and touches `upgrades/` but NOT
+  `src/`, so `srcChanges.length === 0` and the check never trips.
+- **No false positive on docs/test-only PRs** — `srcChanges` only counts
+  `src/**.ts`.
+- **Error, not warning** — a silent release-skip is a real failure (the fix never
+  ships), so it must block. Genuine WIP pushes bypass with the existing
+  `INSTAR_PRE_PUSH_SKIP=1` (same escape hatch as the rest of the gate).
+- It lives inside the same `try` that already brackets the git-diff checks, so a
+  git failure (CI / detached HEAD) skips it gracefully — same as the existing
+  checks.
+
+## Non-goals
+
+- Does not change publish.yml's skip logic itself (the skip is correct when there
+  genuinely is nothing to release; the gap was the missing *pre-merge* signal).
+- Does not add a CI-level mirror (the pre-push gate is the established place for
+  these git-diff checks; a CI mirror is a possible follow-up but out of scope).
+
+## Tests
+
+`tests/unit/pre-push-gate.test.ts` adds a content-assertion test verifying the
+guard's message + the fragment-detection logic are present — matching the file's
+established testing approach for the gate's git-dependent checks (the src→tests
+check is tested the same way; the git-diff section is skipped in the scratch-repo
+integration tests because they are not git repos). `npm run lint` + `tsc` clean;
+all 14 pre-push-gate tests pass.

--- a/scripts/pre-push-gate.js
+++ b/scripts/pre-push-gate.js
@@ -165,6 +165,27 @@ try {
       (srcChanges.length > 5 ? `\n      • ...and ${srcChanges.length - 5} more` : '')
     );
   }
+
+  // ── 3b. Release-fragment gate (#23: src change without a release note) ─
+  // A shippable src/ change MUST carry a release-note fragment. publish.yml
+  // SILENTLY skips the release when there is no upgrades/next/<slug>.md fragment
+  // (and no upgrades/NEXT.md) — so the fix merges but never ships, with no
+  // signal. Mirror of the src→tests check above. The "chore: release" cut commit
+  // touches upgrades/ but not src/, so it never trips this. Bypass genuine WIP
+  // with INSTAR_PRE_PUSH_SKIP=1.
+  const fragmentChanges = changedFiles.filter(f =>
+    f.startsWith('upgrades/next/') || f === 'upgrades/NEXT.md'
+  );
+  if (srcChanges.length > 0 && fragmentChanges.length === 0) {
+    errors.push(
+      `${srcChanges.length} source file(s) changed but no release-note fragment was added. ` +
+      `Without upgrades/next/<slug>.md (or upgrades/NEXT.md), publish.yml SILENTLY SKIPS the ` +
+      `release — your change would merge but never ship. Add a fragment describing the change:\n` +
+      srcChanges.slice(0, 5).map(f => `      • ${f}`).join('\n') +
+      (srcChanges.length > 5 ? `\n      • ...and ${srcChanges.length - 5} more` : '')
+    );
+  }
+
   // ── 4. Adapter contract test gate ─────────────────────────────────────
   // If messaging adapter source files changed, require contract test evidence.
   // This prevents shipping integration code verified only by mocked unit tests.

--- a/tests/unit/pre-push-gate.test.ts
+++ b/tests/unit/pre-push-gate.test.ts
@@ -63,6 +63,16 @@ describe('Pre-push gate script', () => {
     const content = fs.readFileSync(gatePath, 'utf-8');
     expect(content).toContain('Did you forget to bump the version');
   });
+
+  it('errors when src/ changed but no release-note fragment was added (#23)', () => {
+    const content = fs.readFileSync(gatePath, 'utf-8');
+    // The guard mirrors the src→tests check: it inspects the branch diff for a
+    // src/ change with no upgrades/next/<slug>.md (or NEXT.md) fragment — which
+    // would make publish.yml silently skip the release.
+    expect(content).toContain('no release-note fragment was added');
+    expect(content).toContain('SILENTLY SKIPS');
+    expect(content).toContain("f.startsWith('upgrades/next/')");
+  });
 });
 
 // ── Integration: malformed NEXT.md rejection ─────────────────────────

--- a/upgrades/next/pre-push-release-fragment-guard.md
+++ b/upgrades/next/pre-push-release-fragment-guard.md
@@ -1,0 +1,35 @@
+# Upgrade Guide — vNEXT
+
+<!-- bump: patch -->
+
+## What Changed
+
+Closed a silent-release-skip gap in the dev/release tooling. The post-merge
+publish workflow skips publishing when a change carries no release-note fragment
+— which is correct when nothing needs releasing, but meant a real code change
+could merge with no release note and then never ship, with no signal anywhere.
+The pre-push gate now catches this: if source files changed but no release-note
+fragment is included, the push is rejected with a clear message instead of
+sailing through to a silent no-release. It mirrors the existing "you changed code
+but added no tests" check, never trips on the routine release-cut commit, and
+respects the same work-in-progress bypass.
+
+## What to Tell Your User
+
+Nothing required — this is invisible developer-tooling robustness. It prevents a
+fix from quietly merging without ever being released.
+
+## Summary of New Capabilities
+
+- The pre-push gate now blocks a source change that has no accompanying
+  release-note fragment, so fixes can no longer merge and then silently fail to
+  publish.
+
+## Evidence
+
+- Root cause: publish.yml sets skip when there is no fragment and no NEXT.md, so a
+  source change with neither merges but never releases (the lived #23 failure).
+- New guard in the pre-push gate mirrors the existing source-changed-without-tests
+  check; never trips on the release-cut commit (touches upgrades, not source).
+- tests/unit/pre-push-gate.test.ts: +1 test; all 14 pass. Lint + type-check clean.
+- Spec: docs/specs/PRE-PUSH-RELEASE-FRAGMENT-GUARD-SPEC.md (+ ELI16 companion).

--- a/upgrades/side-effects/pre-push-release-fragment-guard.md
+++ b/upgrades/side-effects/pre-push-release-fragment-guard.md
@@ -1,0 +1,61 @@
+# Side-Effects Review — Pre-push release-fragment guard (#23)
+
+**Version / slug:** `pre-push-release-fragment-guard`
+**Date:** 2026-05-31
+**Author:** echo
+
+## Summary of the change
+
+`scripts/pre-push-gate.js` gains a check, mirroring the existing src→tests check:
+if `src/**.ts` changed in the branch diff and no `upgrades/next/*.md` fragment
+(or `upgrades/NEXT.md`) is present, it pushes an error → the gate exits non-zero.
+Closes the #23 silent-release-skip class (a shippable src change merging without
+a release note → publish.yml silently skips → fix never ships).
+
+**Files changed (source/scripts):**
+- `scripts/pre-push-gate.js` — +1 check (~13 lines) inside the existing git-diff
+  `try` block, after the src→tests check.
+
+**Files changed (tests):**
+- `tests/unit/pre-push-gate.test.ts` — +1 content-assertion test (matches the
+  file's testing approach for the gate's git-dependent checks).
+
+## Blast radius
+
+`scripts/pre-push-gate.js` runs only on `git push` (husky pre-push). It gates
+LOCAL pushes; CI remains the authority for tests. The new check adds one more
+reason a push can be rejected: a src change with no release fragment.
+
+## Behavior delta
+
+| Scenario | Before | After |
+|---|---|---|
+| src/ changed + a fragment/NEXT.md present | push proceeds | push proceeds (unchanged) |
+| src/ changed + NO fragment | push proceeds → merges → **silent no-release** | push **rejected** with a clear message |
+| `chore: release` cut commit (touches upgrades/, not src/) | proceeds | proceeds (srcChanges=0, check inert) |
+| docs/test-only PR (no src/**.ts) | proceeds | proceeds (srcChanges=0, check inert) |
+| git unavailable (CI / detached HEAD) | git-diff checks skipped | skipped (same `try/catch`) |
+
+## Risks considered
+
+- **False-positive blocking a legitimate push?** Only when src/ changed with no
+  release note — which is exactly the bug. Genuine WIP bypasses via the existing
+  `INSTAR_PRE_PUSH_SKIP=1`. The release-cut commit and docs/test-only PRs don't
+  trip it (no src/**.ts).
+- **Severity (error vs warning):** error, because a silent release-skip is a real
+  failure (the fix never ships), matching the adapter-contract gate's error
+  severity rather than the softer src→tests warning.
+- **No new dependencies, no network, no state.**
+
+## Migration parity
+
+None required. `scripts/pre-push-gate.js` is a dev/release tooling script run from
+the repo's husky hook — not an agent-installed file (hook/config/CLAUDE.md
+template/skill). It ships in the repo; no `PostUpdateMigrator` entry needed.
+
+## Test evidence
+
+`npx vitest run tests/unit/pre-push-gate.test.ts` → 14 passed (incl. the new
+content-assertion). `npm run lint` + `tsc --noEmit` clean. Dogfood: this PR
+itself carries `upgrades/next/pre-push-release-fragment-guard.md`, so the new
+guard would pass on this very change.


### PR DESCRIPTION
## What

Closes the **#23 silent-release-skip** class. `publish.yml` sets `skip=true` and silently publishes nothing when a change carries no `upgrades/next/<slug>.md` fragment and no `upgrades/NEXT.md` ("No NEXT.md found — nothing to publish"). That's correct when there's genuinely nothing to release — but it means a **shippable `src/` change can merge to main yet never ship, with no signal anywhere**. Lived in practice (a fix sat unreleased because its PR had no release note).

The pre-push gate (`scripts/pre-push-gate.js`) already validated assembled release notes and warned on "src changed but no tests" — but had **no check** for "src changed but no release fragment at all." This adds one.

## The fix

A check mirroring the existing src→tests check (same `changedFiles` branch diff): if `src/**.ts` changed and no `upgrades/next/*.md` fragment (or `upgrades/NEXT.md`) is in the diff → push an **error** (gate exits non-zero) with a clear "this would silently skip the release" message.

- **Error, not warning** — a silent release-skip is a real failure (the fix never ships).
- **No false positives**: the `chore: release` cut commit touches `upgrades/` but not `src/` → inert; docs/test-only PRs have no `src/**.ts` → inert; git-unavailable (CI/detached HEAD) → skipped via the same surrounding `try/catch`.
- **WIP bypass**: the existing `INSTAR_PRE_PUSH_SKIP=1` (same escape hatch as the rest of the gate).

## Tests

`tests/unit/pre-push-gate.test.ts` +1 content-assertion test verifying the guard's message + fragment-detection logic — matching the file's established testing approach for the gate's git-dependent checks (the src→tests check is tested the same way; the scratch-repo integration tests aren't git repos, so the git-diff section is skipped there). All 14 pre-push-gate tests pass; `npm run lint` + `tsc --noEmit` clean.

**Dogfooded:** this PR ships its own `upgrades/next/pre-push-release-fragment-guard.md`, so the new guard passes on this very change.

## Ship-gate

Spec `docs/specs/PRE-PUSH-RELEASE-FRAGMENT-GUARD-SPEC.md` (converged + approved, self-approved under the standing autonomous-dev mandate) + ELI16 companion + side-effects review + release fragment + trace. Found via the live dogfooding mandate (the #23 task). No migration parity needed — it's repo dev/release tooling, not an agent-installed file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
