### PR TITLE
fix(mentor): auto-seed framework playbook none→candidate on terminal resolution (§13.6)

### DIFF
--- a/docs/specs/PLAYBOOK-CANDIDATE-AUTOSEED-SPEC.eli16.md
+++ b/docs/specs/PLAYBOOK-CANDIDATE-AUTOSEED-SPEC.eli16.md
@@ -1,0 +1,52 @@
+# ELI16 — Why the "lessons for the next framework" list was always empty
+
+## The everyday version
+
+When we teach a new kind of AI agent (first Codex, later Cursor or Gemini) how to
+live inside Instar, we hit bumps — things that work for Claude but quietly break
+for the new one. We write every bump down in a notebook (the "ledger") so the NEXT
+new agent doesn't have to rediscover them. There's even a feature that hands the
+next agent a tidy study guide: "here are the lessons other frameworks already
+learned — check these first."
+
+The problem: that study guide was coming up **blank**. We'd written 18 Codex
+lessons in the notebook, but the study guide showed zero.
+
+## Why it was blank
+
+Every lesson in the notebook has a little flag: `none`, `candidate`, or
+`extracted`. The study guide only shows lessons flagged `candidate` or
+`extracted`. But every lesson got created flagged `none` and **nothing ever
+changed the flag**. The rulebook said "when Stage B notices a lesson is solid, bump
+it from `none` to `candidate`" — but that bumping step was never actually built.
+So all 18 lessons sat at `none` forever, invisible to the study guide. We were
+writing lessons down and then never letting anyone read them.
+
+## The fix
+
+Two small, careful changes:
+
+1. **The moment a generalizable lesson is truly resolved** (we fixed it, or
+   decided it's an unavoidable quirk we won't fix), automatically bump its flag
+   from `none` to `candidate`. Lessons that are still open or only half-specced
+   stay `none` — they're not proven yet. "Blame the agent" notes
+   (`generic-agent-mistake`) never count — they're not portable lessons.
+
+2. **Catch up the old notebook**: when the ledger starts, do a one-time sweep that
+   bumps every already-resolved generalizable lesson that's still stuck at `none`.
+   This is safe to run every startup — after the first sweep there's nothing left
+   to bump.
+
+## What we deliberately did NOT touch
+
+The strongest flag, `extracted` — meaning "this lesson is now part of the official
+checklist" — still requires a SECOND person (not the agent that wrote the lesson)
+to sign off. An agent can't canonize its own lessons. We only automated the gentle
+first step (`none → candidate`, i.e. "here's a proposed lesson"). A human still
+curates which proposals become canonical.
+
+## Why it matters
+
+It turns a notebook nobody could read into a real study guide. The next framework
+we onboard now actually inherits Codex's hard-won lessons instead of rediscovering
+every bump from scratch — which is the entire reason the ledger exists.

--- a/docs/specs/PLAYBOOK-CANDIDATE-AUTOSEED-SPEC.md
+++ b/docs/specs/PLAYBOOK-CANDIDATE-AUTOSEED-SPEC.md
@@ -1,0 +1,118 @@
+---
+title: "Framework-issue playbook: auto-seed none→candidate on terminal resolution (§13.6)"
+slug: "playbook-candidate-autoseed"
+author: "echo"
+status: "converged"
+review-convergence: "2026-05-31T18:55:00Z"
+review-iterations: 1
+review-completed-at: "2026-05-31T18:55:00Z"
+approved: true
+approved-by: "echo"
+approved-date: "2026-05-31"
+approval-note: "Implements §13.6's specified-but-missing none→candidate auto-suggestion so the onboarding playbook actually populates for the NEXT framework. Self-approved under the standing autonomous-dev mandate (Justin's 2026-05-31 directive: log all codex issues so the lessons reach future-framework onboarding); flagged in the PR. Low-risk, additive, deterministic; the candidate→extracted non-Echo attestation guard is untouched."
+eli16-overview: "PLAYBOOK-CANDIDATE-AUTOSEED-SPEC.eli16.md"
+---
+
+# Framework-issue playbook: auto-seed none→candidate on terminal resolution (§13.6)
+
+## Problem
+
+The Framework-Onboarding Mentor System logs every observed framework issue into
+`FrameworkIssueLedger` (SQLite), tagged by bucket. The whole point of that ledger
+(spec §6, §13.6) is that **generalizable lessons from PRIOR frameworks feed the
+NEXT framework's onboarding** — when Cursor/Aider/Gemini is onboarded, its Stage A
+"draws its first checks from the existing playbook." That playbook is served at
+`GET /framework-issues/playbook?targetFramework=X` and is defined as:
+
+```
+framework != X  AND  bucket ∈ {framework-limitation, instar-integration-gap}  AND  playbook_status ∈ {candidate, extracted}
+```
+
+Every issue is created with `playbook_status = 'none'` (the SQL default). §13.6
+defines the lifecycle `none → candidate → extracted → superseded` and states:
+
+> **`none → candidate` may be auto-suggested by Stage B** (any actor). But
+> `candidate → extracted` — the step that puts a lesson into the reusable
+> onboarding checklist — REQUIRES a non-Echo attestation.
+
+**The `none → candidate` auto-suggestion was never implemented.** Nothing in the
+codebase moves an issue off `'none'` except the manual `POST
+/framework-issues/:id/promote` route. As a result, on a live ledger with 18
+generalizable codex lessons (11 of them terminal-resolved), **the playbook returns
+`[]`** — the lessons are logged but never surface. Logging worked; learning did
+not. The next framework would onboard with an empty playbook despite a full
+ledger of hard-won codex lessons.
+
+This was found by reading the live ledger (`GET .../playbook?targetFramework=cursor
+→ { playbook: [] }`) while verifying Justin's directive that codex issues feed
+future-framework onboarding.
+
+## Fix
+
+Two additive, deterministic changes in `FrameworkIssueLedger`, both confined to
+the `none → candidate` step (which §13.6 explicitly allows any actor to automate):
+
+### 1. Auto-suggest on terminal resolution (`updateIssue`)
+
+When an issue transitions to a **terminal-resolved** status (`fixed` or
+`wont-fix`) AND it is **generalizable** (bucket ∈ {framework-limitation,
+instar-integration-gap}) AND its current `playbook_status` is `'none'`, promote it
+to `'candidate'` in the same write transaction.
+
+- **Only on terminal resolution.** `open` / `spec'd` are in-flight — the lesson is
+  not yet proven, so they stay `'none'`.
+- **Only generalizable buckets.** `generic-agent-mistake` is never a portable
+  lesson and never enters the playbook.
+- **Never downgrades.** The bump acts only on `'none'`; `candidate` / `extracted`
+  / `superseded` are left as-is.
+- **Caller override respected.** If the caller passed an explicit
+  `playbookStatus`, the auto-bump is skipped (the explicit value wins).
+- This is the "Stage B auto-suggest" of §13.6, realized as a deterministic
+  write-path rule rather than an LLM call — always-on, testable, and independent
+  of whether the (dark) mentor loop is running.
+
+### 2. Idempotent backfill on construction (`backfillPlaybookCandidates`)
+
+A self-limiting `UPDATE` that promotes every already-terminal generalizable issue
+still stuck at `'none'` (i.e. resolved before this auto-suggestion existed) to
+`'candidate'`. Called once from the ledger constructor (after the DDL migrations),
+wrapped so a failure can never block construction. After the first run its WHERE
+clause matches nothing, so re-running on every boot is harmless. This is how every
+agent's existing ledger picks up the seeding on its next server start — no
+dedicated `PostUpdateMigrator` entry, because the change is runtime data, not an
+agent-installed file.
+
+## What is explicitly NOT changed
+
+- **The `candidate → extracted` attestation guard** in `promotePlaybook()` is
+  untouched: extraction — putting a lesson into the canonical reusable checklist —
+  still REQUIRES a non-Echo attester (`promoted_by !== 'echo'`). Auto-seeding only
+  populates the *candidate* tier (proposed lessons); a human/peer still curates
+  what becomes canonical. The integrity model is preserved end-to-end.
+- The playbook query, route, ranking (impactScore), and all read shapes are
+  unchanged — they already filter `playback_status ∈ {candidate, extracted}` and
+  `bucket ∈ generalizable`; they simply had nothing to return.
+
+## Testing (3-tier)
+
+- **Unit** (`tests/unit/FrameworkIssueLedger.test.ts`): fixed→candidate;
+  wont-fix→candidate; generic-agent-mistake stays none; non-terminal stays none;
+  explicit-playbookStatus override respected; never-downgrade-extracted; end-to-end
+  the auto-candidated lesson appears in another framework's `playbook()`;
+  `backfillPlaybookCandidates` promotes only eligible rows + is idempotent +
+  never downgrades; **the constructor self-seeds an existing on-disk ledger**.
+- **Integration** (`tests/integration/framework-issues-routes.test.ts`): the real
+  HTTP path — `POST /framework-issues/observe` with `status: 'fixed'` →
+  `issue.playbookStatus === 'candidate'`, and `GET
+  /framework-issues/playbook?targetFramework=cursor` now contains the lesson with
+  **no manual promote call**.
+- **E2E**: the playbook/observe routes' "feature is alive" lifecycle test
+  (`tests/e2e/framework-issue-ledger-lifecycle.test.ts`) remains green; this change
+  is behavior on those already-alive routes.
+
+## Risk
+
+Additive and deterministic. Worst case is an over-eager candidate (a generalizable
+fixed issue surfaces as a *proposed* lesson) — which is exactly the intended
+behavior and is gated by the unchanged extraction-attestation step before anything
+becomes canonical. No new routes, dependencies, network, or migrations.

--- a/src/monitoring/FrameworkIssueLedger.ts
+++ b/src/monitoring/FrameworkIssueLedger.ts
@@ -312,6 +312,15 @@ export class FrameworkIssueLedger {
         if (!/duplicate column name/i.test((err as Error).message || '')) throw err;
       }
     }
+    // §13.6: seed none→candidate for generalizable issues that were resolved
+    // before the auto-suggestion existed (idempotent + self-limiting — matches
+    // nothing after the first run). A backfill failure must never block ledger
+    // construction (read-mostly infra); the next boot simply retries.
+    try {
+      this.backfillPlaybookCandidates();
+    } catch {
+      /* non-fatal: ledger remains usable; backfill retries next construction */
+    }
   }
 
   /** Stable list of frameworks the ledger has seen — for the route allowlist (spec §5/§17). */
@@ -481,7 +490,7 @@ export class FrameworkIssueLedger {
 
       const status = patch.status ? assertEnum(patch.status, ISSUE_STATUSES, 'status') : (cur.status as IssueStatus);
       const bucket = patch.bucket ? assertEnum(patch.bucket, ISSUE_BUCKETS, 'bucket') : (cur.bucket as IssueBucket);
-      const playbookStatus = patch.playbookStatus
+      let playbookStatus = patch.playbookStatus
         ? assertEnum(patch.playbookStatus, PLAYBOOK_STATUSES, 'playbookStatus')
         : (cur.playbook_status as PlaybookStatus);
       const bucketPrimary =
@@ -495,6 +504,24 @@ export class FrameworkIssueLedger {
 
       if (status === 'wont-fix' && !wontFixReason) {
         throw new Error('FrameworkIssueLedger: wont-fix requires a wontFixReason (spec §13.7)');
+      }
+
+      // §13.6 auto-suggest: when a generalizable issue reaches a terminal-resolved
+      // state (fixed | wont-fix) its lesson is fully formed and should feed the
+      // NEXT framework's onboarding playbook — so promote none→candidate in the
+      // same write. Without this the playbook stays permanently empty: lessons are
+      // logged but never surface (every issue sits at 'none', and nothing else
+      // auto-suggests candidates). Only none→candidate is automated here; the
+      // candidate→extracted step still requires a non-Echo attestation via
+      // promotePlaybook(). Never downgrades (acts only on 'none'); skipped when the
+      // caller set playbookStatus explicitly.
+      if (
+        patch.playbookStatus === undefined &&
+        playbookStatus === 'none' &&
+        (status === 'fixed' || status === 'wont-fix') &&
+        GENERALIZABLE_BUCKETS.has(bucket)
+      ) {
+        playbookStatus = 'candidate';
       }
 
       this.db
@@ -555,6 +582,31 @@ export class FrameworkIssueLedger {
       return this.getIssue(issueId);
     });
     return txn();
+  }
+
+  /**
+   * Idempotent backfill of the §13.6 none→candidate auto-suggestion for issues
+   * that were already terminal-resolved (fixed | wont-fix) and generalizable
+   * BEFORE that auto-suggestion existed — their lessons were logged but stuck at
+   * 'none', so the onboarding playbook never surfaced them. Promotes every such
+   * row to 'candidate'; never touches candidate/extracted/superseded rows; never
+   * promotes non-generalizable or non-terminal issues. Self-limiting (the WHERE
+   * clause matches nothing after the first run) so it is safe to call on every
+   * boot — which is how existing ledgers across the fleet pick up the seeding
+   * without a dedicated PostUpdateMigrator entry. Returns the rows promoted.
+   * candidate→extracted still requires a non-Echo attestation (promotePlaybook);
+   * this only seeds candidates.
+   */
+  backfillPlaybookCandidates(): number {
+    const res = this.db
+      .prepare(
+        `UPDATE framework_issues SET playbook_status = 'candidate', updated_at = @ts
+           WHERE playbook_status = 'none'
+             AND status IN ('fixed', 'wont-fix')
+             AND bucket IN ('framework-limitation', 'instar-integration-gap')`,
+      )
+      .run({ ts: this.now() });
+    return res.changes;
   }
 
   /** Bucket-distribution telemetry (spec §15) — surfaces attribution skew (a

--- a/tests/integration/framework-issues-routes.test.ts
+++ b/tests/integration/framework-issues-routes.test.ts
@@ -131,6 +131,20 @@ describe('Framework-issues routes (integration)', () => {
       const res = await request(appWith(ledger)).get('/framework-issues/playbook?targetFramework=cursor');
       expect(res.body.playbook).toHaveLength(0);
     });
+
+    it('end-to-end (§13.6): observing a FIXED generalizable issue auto-seeds the next framework\'s playbook — no manual promote', async () => {
+      const app = appWith(ledger);
+      // The exact write path engineering uses: POST observe with a terminal status.
+      const obs = await request(app)
+        .post('/framework-issues/observe')
+        .send({ framework: 'codex-cli', bucket: 'instar-integration-gap', title: 'jsonlExists was claude-only', dedupKey: 'k1', severity: 'high', status: 'fixed', fixedInVersion: '1.3.x', evidence: 'PR #N' });
+      expect(obs.status).toBe(200);
+      expect(obs.body.issue.playbookStatus).toBe('candidate'); // auto-suggested on the fixed transition
+      // …and it now surfaces in cursor's onboarding playbook with no promote call.
+      const pb = await request(app).get('/framework-issues/playbook?targetFramework=cursor');
+      expect(pb.status).toBe(200);
+      expect(pb.body.playbook.map((i: { dedupKey: string }) => i.dedupKey)).toContain('k1');
+    });
   });
 
   describe('GET /framework-issues/observability (§15)', () => {

--- a/tests/unit/FrameworkIssueLedger.test.ts
+++ b/tests/unit/FrameworkIssueLedger.test.ts
@@ -8,11 +8,15 @@
  * redaction, retention pruning, and playbook cross-framework semantics.
  */
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
 import {
   FrameworkIssueLedger,
   clampLimit,
   scanForSecret,
 } from '../../src/monitoring/FrameworkIssueLedger.js';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
 
 let ledger: FrameworkIssueLedger;
 let clock: number;
@@ -182,6 +186,110 @@ describe('playbook — cross-framework, ranked (§13.6)', () => {
   it('excludes the target framework\'s OWN issues (playbook is prior-frameworks only)', () => {
     const pb = ledger.playbook({ targetFramework: 'codex-cli' });
     expect(pb).toHaveLength(0); // codex's own lessons are not its own playbook
+  });
+});
+
+describe('none→candidate auto-suggest on terminal resolution (§13.6)', () => {
+  it('promotes a generalizable issue to candidate when it is fixed', () => {
+    const r = ledger.recordObservation({ framework: 'codex-cli', bucket: 'instar-integration-gap', title: 'A', dedupKey: 'k1' });
+    expect(ledger.getIssue(r.issueId)!.playbookStatus).toBe('none');
+    const updated = ledger.updateIssue(r.issueId, { status: 'fixed', fixedInVersion: '1.4.0' });
+    expect(updated!.status).toBe('fixed');
+    expect(updated!.playbookStatus).toBe('candidate');
+  });
+
+  it('promotes a generalizable issue to candidate when it is wont-fixed', () => {
+    const r = ledger.recordObservation({ framework: 'codex-cli', bucket: 'framework-limitation', title: 'A', dedupKey: 'k1' });
+    const updated = ledger.updateIssue(r.issueId, { status: 'wont-fix', wontFixReason: 'upstream capability gap, tracked' });
+    expect(updated!.playbookStatus).toBe('candidate');
+  });
+
+  it('does NOT promote a non-generalizable (generic-agent-mistake) issue', () => {
+    const r = ledger.recordObservation({ framework: 'codex-cli', bucket: 'generic-agent-mistake', title: 'A', dedupKey: 'k1' });
+    const updated = ledger.updateIssue(r.issueId, { status: 'fixed' });
+    expect(updated!.playbookStatus).toBe('none');
+  });
+
+  it('does NOT promote on a non-terminal transition (spec\'d / still open)', () => {
+    const r = ledger.recordObservation({ framework: 'codex-cli', bucket: 'framework-limitation', title: 'A', dedupKey: 'k1' });
+    expect(ledger.updateIssue(r.issueId, { status: "spec'd" })!.playbookStatus).toBe('none');
+    expect(ledger.getIssue(r.issueId)!.playbookStatus).toBe('none'); // still not terminal
+  });
+
+  it('respects an explicit caller playbookStatus (no auto-override)', () => {
+    const r = ledger.recordObservation({ framework: 'codex-cli', bucket: 'framework-limitation', title: 'A', dedupKey: 'k1' });
+    // Explicit 'none' alongside a terminal status simulates a pre-fix ledger row.
+    const updated = ledger.updateIssue(r.issueId, { status: 'fixed', playbookStatus: 'none' });
+    expect(updated!.playbookStatus).toBe('none');
+  });
+
+  it('never downgrades an already-extracted issue', () => {
+    const r = ledger.recordObservation({ framework: 'codex-cli', bucket: 'instar-integration-gap', title: 'A', dedupKey: 'k1' });
+    ledger.updateIssue(r.issueId, { playbookStatus: 'extracted' });
+    const updated = ledger.updateIssue(r.issueId, { status: 'fixed' });
+    expect(updated!.playbookStatus).toBe('extracted');
+  });
+
+  it('end-to-end: a fixed generalizable issue surfaces in the NEXT framework\'s playbook', () => {
+    const r = ledger.recordObservation({ framework: 'codex-cli', bucket: 'instar-integration-gap', title: 'lesson', dedupKey: 'k1', severity: 'high' });
+    ledger.updateIssue(r.issueId, { status: 'fixed', fixedInVersion: '1.4.0' });
+    const pb = ledger.playbook({ targetFramework: 'cursor' });
+    expect(pb.map((i) => i.dedupKey)).toContain('k1');
+  });
+});
+
+describe('backfillPlaybookCandidates — seed pre-existing terminal lessons (§13.6)', () => {
+  // Build a row stuck at 'none' despite being terminal+generalizable, exactly
+  // like a ledger resolved before the auto-suggestion existed.
+  function stuckRow(dedupKey: string, bucket: 'framework-limitation' | 'instar-integration-gap' | 'generic-agent-mistake', status: "fixed" | "wont-fix" | "spec'd" | 'open') {
+    const r = ledger.recordObservation({ framework: 'codex-cli', bucket, title: dedupKey, dedupKey });
+    if (status !== 'open') {
+      ledger.updateIssue(r.issueId, { status, playbookStatus: 'none', wontFixReason: status === 'wont-fix' ? 'tracked' : undefined });
+    }
+    return r.issueId;
+  }
+
+  it('promotes eligible (terminal + generalizable) rows and is idempotent', () => {
+    const fixedGen = stuckRow('a', 'instar-integration-gap', 'fixed');
+    const wontGen = stuckRow('b', 'framework-limitation', 'wont-fix');
+    const openGen = stuckRow('c', 'framework-limitation', 'open'); // not terminal
+    const specGen = stuckRow('d', 'framework-limitation', "spec'd"); // not terminal
+    const fixedNonGen = stuckRow('e', 'generic-agent-mistake', 'fixed'); // not generalizable
+
+    const n = ledger.backfillPlaybookCandidates();
+    expect(n).toBe(2);
+    expect(ledger.getIssue(fixedGen)!.playbookStatus).toBe('candidate');
+    expect(ledger.getIssue(wontGen)!.playbookStatus).toBe('candidate');
+    expect(ledger.getIssue(openGen)!.playbookStatus).toBe('none');
+    expect(ledger.getIssue(specGen)!.playbookStatus).toBe('none');
+    expect(ledger.getIssue(fixedNonGen)!.playbookStatus).toBe('none');
+
+    // Second call finds nothing (self-limiting).
+    expect(ledger.backfillPlaybookCandidates()).toBe(0);
+  });
+
+  it('never downgrades an extracted row', () => {
+    const r = ledger.recordObservation({ framework: 'codex-cli', bucket: 'instar-integration-gap', title: 'x', dedupKey: 'x' });
+    ledger.updateIssue(r.issueId, { status: 'fixed', playbookStatus: 'extracted' });
+    ledger.backfillPlaybookCandidates();
+    expect(ledger.getIssue(r.issueId)!.playbookStatus).toBe('extracted');
+  });
+
+  it('runs on construction so an existing ledger self-seeds on boot', () => {
+    // Seed a stuck row, then re-open the SAME on-disk db with a new ledger:
+    // the constructor backfill must promote it without any explicit call.
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'fwledger-'));
+    const dbPath = path.join(dir, 'ledger.db');
+    const first = new FrameworkIssueLedger({ dbPath, now: () => clock });
+    const id = first.recordObservation({ framework: 'codex-cli', bucket: 'instar-integration-gap', title: 'seed', dedupKey: 'seed' }).issueId;
+    first.updateIssue(id, { status: 'fixed', playbookStatus: 'none' }); // stuck at none
+    expect(first.getIssue(id)!.playbookStatus).toBe('none');
+    first.close();
+
+    const second = new FrameworkIssueLedger({ dbPath, now: () => clock });
+    expect(second.getIssue(id)!.playbookStatus).toBe('candidate'); // seeded on construction
+    second.close();
+    SafeFsExecutor.safeRmSync(dir, { recursive: true, force: true, operation: 'tests/unit/FrameworkIssueLedger.test.ts:backfill-on-construction' });
   });
 });
 

--- a/upgrades/next/playbook-candidate-autoseed.md
+++ b/upgrades/next/playbook-candidate-autoseed.md
@@ -1,0 +1,45 @@
+# Upgrade Guide — vNEXT
+
+<!-- bump: patch -->
+
+## What Changed
+
+The Framework-Onboarding Mentor System's "lessons for the next framework"
+playbook now actually populates. Generalizable framework issues (the portable
+lessons — `framework-limitation` and `instar-integration-gap`) are promoted from
+`none` to `candidate` the moment they're terminally resolved (fixed or won't-fix),
+which is the auto-suggestion step the spec (§13.6) defined but that had never been
+implemented. A one-time, idempotent backfill on ledger startup seeds lessons that
+were resolved before this existed. Without this, the onboarding playbook returned
+an empty list even with a full ledger of hard-won lessons — they were logged but
+never reached the next framework's onboarding.
+
+The `candidate → extracted` step (canonizing a lesson into the reusable onboarding
+checklist) is unchanged: it still requires a non-Echo attestation, so an agent
+cannot canonize its own lessons.
+
+## What to Tell Your User
+
+Nothing required — this is internal mentor-system robustness. If asked: the
+lessons learned onboarding one agent framework now actually carry forward to the
+next one, instead of sitting unused in the ledger.
+
+## Summary of New Capabilities
+
+- `GET /framework-issues/playbook?targetFramework=X` now returns the generalizable,
+  terminally-resolved lessons from prior frameworks (previously always empty because
+  nothing ever moved an issue off `playbook_status='none'`).
+- `FrameworkIssueLedger.backfillPlaybookCandidates()` seeds pre-existing eligible
+  lessons; runs automatically and idempotently on ledger construction.
+
+## Evidence
+
+- Root cause: §13.6's `none→candidate` auto-suggestion was specified but never
+  implemented — the only writer of `candidate` was the manual promote route, so a
+  live ledger with 18 generalizable codex lessons (11 terminal) served `playbook: []`.
+- Fix: deterministic auto-bump in `updateIssue` on terminal resolution + an
+  idempotent constructor backfill; the `candidate→extracted` non-Echo attestation
+  guard is untouched.
+- Tests: +10 unit, +1 integration end-to-end; 192 ledger/mentor/route/E2E tests pass.
+  `npm run lint` clean.
+- Spec: docs/specs/PLAYBOOK-CANDIDATE-AUTOSEED-SPEC.md (+ ELI16 companion).

--- a/upgrades/side-effects/playbook-candidate-autoseed.md
+++ b/upgrades/side-effects/playbook-candidate-autoseed.md
@@ -1,0 +1,91 @@
+# Side-Effects Review — Playbook none→candidate auto-seed (§13.6)
+
+**Version / slug:** `playbook-candidate-autoseed`
+**Date:** 2026-05-31
+**Author:** echo
+
+## Summary of the change
+
+`FrameworkIssueLedger` gains the §13.6 `none→candidate` auto-suggestion that was
+specified but never implemented, so the onboarding playbook
+(`GET /framework-issues/playbook?targetFramework=X`) actually populates for the
+next framework instead of always returning `[]`.
+
+**Files changed (source):**
+- `src/monitoring/FrameworkIssueLedger.ts`:
+  - `updateIssue()` — when a generalizable issue (bucket ∈ {framework-limitation,
+    instar-integration-gap}) transitions to a terminal-resolved status
+    (`fixed` | `wont-fix`) while `playbook_status === 'none'`, bump it to
+    `'candidate'` in the same transaction. Skipped if the caller set
+    `playbookStatus` explicitly; never downgrades a non-`none` row.
+  - new `backfillPlaybookCandidates()` — idempotent, self-limiting `UPDATE` that
+    seeds already-terminal generalizable rows still stuck at `'none'`.
+  - constructor calls the backfill once (after DDL migrations), wrapped so a
+    failure can never block construction.
+
+**Files changed (tests):**
+- `tests/unit/FrameworkIssueLedger.test.ts` — +10 tests (auto-suggest matrix,
+  backfill eligibility/idempotency/no-downgrade, constructor self-seed on a
+  reopened on-disk db).
+- `tests/integration/framework-issues-routes.test.ts` — +1 end-to-end test
+  (`POST observe status:fixed` → `GET playbook` contains it, no manual promote).
+
+## Blast radius
+
+Confined to `FrameworkIssueLedger`. The ledger is read-mostly mentor-system infra;
+it never gates a job, blocks a message, or constrains a session. The playbook is
+served only via `GET /framework-issues/playbook` and consulted by Stage A when a
+NEW framework is onboarded — there is no live consumer for codex itself (the
+playbook for X excludes X's own issues). So the immediate live effect is: the
+playbook for cursor/aider/gemini changes from empty to 11 seeded codex candidates;
+nothing in the running codex/echo flow changes behavior.
+
+## Behavior delta
+
+| Scenario | Before | After |
+|---|---|---|
+| generalizable issue → `fixed` / `wont-fix` | stays `playbook_status='none'` | auto-bumps to `'candidate'` |
+| generalizable issue → `open` / `spec'd` | `'none'` | `'none'` (unchanged — not terminal) |
+| `generic-agent-mistake` → `fixed` | `'none'` | `'none'` (unchanged — not generalizable) |
+| caller passes explicit `playbookStatus` | honored | honored (auto-bump skipped) |
+| issue already `extracted` → `fixed` | `'extracted'` | `'extracted'` (never downgraded) |
+| existing terminal generalizable rows at `'none'` | invisible to playbook forever | seeded to `'candidate'` on next ledger construction |
+| `GET /playbook?targetFramework=cursor` (live: 11 eligible codex lessons) | `[]` | 11 candidates, impact-ranked |
+| `candidate → extracted` promotion | requires non-Echo attestation | requires non-Echo attestation (UNCHANGED) |
+
+## Risks considered
+
+- **Over-eager candidates?** Auto-seeding populates only the *candidate* tier
+  (proposed lessons). The `candidate→extracted` step — the one that makes a lesson
+  canonical — still requires a non-Echo attestation (`promotePlaybook` guard
+  untouched). So an over-eager candidate is a proposal a human still curates, not a
+  canonized lesson. This is the intended §13.6 behavior.
+- **Self-canonization bypass?** No. The auto-bump uses the internal write path
+  (the "Stage B auto-suggest" §13.6 explicitly permits any actor to automate), not
+  `promotePlaybook`, and stops at `candidate`. Echo still cannot reach `extracted`
+  on its own lessons.
+- **Construction-time mutation?** The constructor already runs DDL migrations; a
+  one-time idempotent data backfill is consistent with "bring the DB to current
+  shape." It is try/wrapped so it can never block ledger construction, and
+  self-limiting so it is a no-op after the first run.
+- **Existing tests / other consumers?** No other test or code path references
+  `playbookStatus` after a terminal transition (verified by grep). All 192
+  ledger/mentor/route/E2E tests pass.
+- **No new dependencies, routes, network, or persisted config.**
+
+## Migration parity
+
+No `PostUpdateMigrator` entry required. The change is runtime server code, not an
+agent-installed file (no hook / `.instar/config.json` default / CLAUDE.md template
+section / skill changed). Existing ledgers across the fleet pick up the data
+seeding via the constructor backfill on their next server boot after this code
+deploys — which is the migration path for ledger *data*. The CLAUDE.md template
+already documents the playbook route; its description ("generalizable lessons from
+PRIOR frameworks") is now simply accurate, so no Agent-Awareness template change is
+needed.
+
+## Test evidence
+
+`npx vitest run` on the ledger unit, routes integration, ledger E2E lifecycle, and
+all mentor suites → 192 passed. `npm run lint` (tsc --noEmit + the destructive/LLM/
+URL-log/codex-drift linters) clean.


### PR DESCRIPTION
## What

The framework-onboarding **playbook was always empty.** `GET /framework-issues/playbook?targetFramework=X` returns lessons where `playbook_status ∈ {candidate, extracted}`, and §13.6 specifies that `none→candidate` *"may be auto-suggested by Stage B (any actor)"* — but **that auto-suggestion was never implemented.** The only writer of `candidate` was the manual `POST /framework-issues/:id/promote` route, so every logged lesson sat at `playbook_status='none'` forever. On the live ledger — 18 generalizable codex lessons, 11 terminal-resolved — `GET .../playbook?targetFramework=cursor` returned `{ playbook: [] }`. Logging worked; **learning did not** — the next framework would onboard with an empty playbook despite a full ledger.

Found via the live dogfooding mandate while verifying Justin's directive that codex issues feed future-framework onboarding.

## The fix (`src/monitoring/FrameworkIssueLedger.ts`)

1. **`updateIssue`** — when a **generalizable** issue (`framework-limitation` | `instar-integration-gap`) reaches a **terminal-resolved** status (`fixed` | `wont-fix`) while `playbook_status === 'none'`, auto-bump to `'candidate'` in the same transaction. Skipped if the caller set `playbookStatus` explicitly; never downgrades a non-`none` row; never fires on `open`/`spec'd` or `generic-agent-mistake`. (§13.6's "Stage B auto-suggest", as a deterministic write-path rule — always-on, independent of the dark mentor loop.)
2. **`backfillPlaybookCandidates()`** — idempotent, self-limiting `UPDATE` that seeds already-terminal generalizable rows still stuck at `'none'`. Called once from the constructor (after DDL migrations, try-wrapped so it can never block construction) so existing fleet ledgers pick up the seeding on next boot.

**Explicitly unchanged:** the `candidate→extracted` non-Echo attestation guard in `promotePlaybook()`. Auto-seeding only populates the *candidate* (proposed-lesson) tier; a human/peer still curates what becomes canonical. An agent still cannot canonize its own lessons.

## Live effect

After deploy, Echo's ledger seeds its 11 terminal generalizable codex lessons, so the playbook for cursor/aider/gemini changes from `[]` to 11 impact-ranked candidates. Nothing in the running codex/echo flow changes behavior (the playbook for X excludes X's own issues).

## Tests (3-tier)

- **Unit** (+10): fixed→candidate, wont-fix→candidate, generic-agent-mistake stays none, non-terminal stays none, explicit-override respected, never-downgrade-extracted, end-to-end into another framework's `playbook()`, backfill eligibility/idempotency/no-downgrade, **constructor self-seeds a reopened on-disk ledger**.
- **Integration** (+1): the real HTTP path — `POST /framework-issues/observe status:'fixed'` → `issue.playbookStatus === 'candidate'`, and `GET /playbook?targetFramework=cursor` contains it **with no manual promote**.
- **E2E**: the playbook/observe "feature is alive" lifecycle test remains green.

192 ledger/mentor/route/E2E tests pass; `npm run lint` clean. Independent adversarial review: **SHIP, no must-fix** (no integrity bypass, no downgrade, constructor-safe, correct over-firing gates).

## Ship-gate

Spec `docs/specs/PLAYBOOK-CANDIDATE-AUTOSEED-SPEC.md` (converged + approved, self-approved under the standing autonomous-dev mandate) + ELI16 companion + side-effects review + release fragment + trace. No migration-parity entry: runtime code, not an agent-installed file; existing ledgers seed via the constructor backfill on boot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
