### PR TITLE
fix(stop-gate): block silent stall after stating you'll continue now

### DIFF
--- a/docs/specs/stop-gate-stated-continuation.eli16.md
+++ b/docs/specs/stop-gate-stated-continuation.eli16.md
@@ -1,0 +1,51 @@
+# Stated-continuation stop guard — explained simply
+
+## The annoying thing this fixes
+
+Imagine you ask a friend to fix your bike. They say "Okay, I'm fixing it right
+now!" — and then they just walk away and do nothing. You'd be confused and
+annoyed: they *said* they were starting, so why is nothing happening?
+
+The agent (Echo) did exactly that to its operator. It sent a message saying
+"I'm going to build that now, then finish the proof" — and then it ended its
+turn and went quiet for an hour and a half without building anything. The
+operator's reaction was, fairly: "this is incoherent."
+
+## Why it kept happening
+
+Every time the agent tries to end a turn, a little "stop gate" program runs and
+gets to say "wait, don't stop yet." But that program was set to **watch-only
+mode** — it took notes about questionable stops but never actually stopped them.
+So the gate saw the stall, wrote it in its notebook, and let the agent walk away
+anyway. The safety net was switched off at the exact moment it was needed.
+
+## The fix
+
+We add a tiny, always-on check right at the top of that stop gate. It reads the
+agent's last message to the user. If that message says something like "I'll do X
+**now**", "starting now", "next phase: ship the fix", or "on it" — a promise to
+act *this very turn* — and the agent is trying to end anyway, the gate stops it
+once and says:
+
+> You just told the user you're doing this now. So either actually do it, or
+> send the user one honest sentence saying you're stopping and why. Don't go
+> silent after promising to continue.
+
+Two things keep it safe and non-annoying:
+
+1. **It only nudges once.** There's already a guard that notices "this stop is
+   happening because the gate just blocked," and it lets the agent through the
+   second time. So the agent can never get trapped in a loop.
+2. **It always runs**, even in watch-only mode and even if the server is down —
+   because watch-only mode is exactly when these stalls slip through.
+
+If the check is ever a little too eager and fires when the agent really did mean
+to stop, no harm: the agent just has to say "I'm stopping here, because X" out
+loud to the user. That honest sign-off is the whole point — the operator should
+never again be left guessing whether work is still happening.
+
+## What it does NOT do
+
+It does not catch "I'll check back tomorrow" or "I'll report later" — those are
+real, scheduled follow-ups handled by a different system. It only catches "I'm
+doing it **now**" followed by silence.

--- a/docs/specs/stop-gate-stated-continuation.md
+++ b/docs/specs/stop-gate-stated-continuation.md
@@ -1,0 +1,88 @@
+---
+title: Stated-continuation stop guard (no silent stall after promising to continue)
+slug: stop-gate-stated-continuation
+status: approved
+review-convergence: 2026-05-31T18:55:00+00:00
+approved: true
+author: echo
+approval-note: >
+  Self-approved by Echo under the delegated deploy mandate. Justin requested this
+  fix DIRECTLY on topic 13481 (2026-05-31): "Looks like your session has stalled
+  again ... you gave me the impression you're ready to continue working ... we
+  need to improve INSTAR in the behavior." This spec is the structural response.
+  Flagged in the PR per cross-agent discipline.
+---
+
+# Stated-continuation stop guard
+
+## Problem
+
+A recurring, trust-eroding behavior: the agent's final user-facing message states
+it is about to act THIS turn — "I'll build that now", "starting now", "Next phase:
+ship the fix" — and then the turn simply **ends** without doing it. From the user's
+side this is a silent stall: they were told work was continuing, and instead got
+silence.
+
+Live incident (2026-05-31, topic 13481): Echo told Justin "I'm going to build that
+now ... then deploy and finish the round-trip proof," then reverted state, wrote
+internal notes, and ended the turn. The work never started. Justin: "this is
+incoherent and we need to improve INSTAR in the behavior." This is the same
+silent-stall / context-death self-stop class he has flagged repeatedly.
+
+Why nothing caught it: the existing `stop-gate-router.js` hook delegates the
+continue/stop decision to the server-side Unjustified Stop Gate, which **only
+blocks in `enforce` mode**. The gate ships in `shadow` mode (telemetry only) on
+subscription agents — so the exact moment a stall happens, nothing intervenes.
+
+## Solution
+
+Add a **local, mode-independent guard** to the `stop-gate-router.js` hook
+(`PostUpdateMigrator.getStopGateRouterHook()`), placed AFTER the `stop_hook_active`
+loop-guard and BEFORE the server round-trip. When the agent's final message
+(`last_assistant_message`) contains a first-person/sequenced commitment to act
+(`I'll`, `I'm going to`, `next phase/step`, `starting now`, `on it`, ...) together
+with an imminence marker (` now`, `right now`, `immediately`, `this turn/session`,
+`then I`), the hook emits `{decision:'block'}` + exit code 2 and re-feeds:
+
+> Either (a) actually do that work now, or (b) if you are genuinely blocked,
+> finished, or need the user, send ONE short honest message saying you are
+> stopping and exactly why — then you may stop.
+
+Key properties:
+
+- **Mode-independent.** Runs regardless of the server gate's shadow/enforce mode
+  and even if the server is unreachable — because shadow mode is precisely when
+  stalls slip through.
+- **Fires once.** The pre-existing `stop_hook_active` guard exits open on the
+  re-fire, so the agent gets exactly one nudge — never an infinite trap.
+- **Converts silent stalls into explicit stops.** Even on a borderline match, the
+  worst case is the agent must tell the user plainly that it is stopping and why —
+  which is exactly the desired behavior. "Report-back-later" intent (no imminence
+  marker) is NOT caught; that belongs to the commitment tracker.
+- **Pure substring matching.** No regex/`\b` escaping hazards inside the hook's
+  template literal.
+
+## Scope
+
+- `src/core/PostUpdateMigrator.ts` — `getStopGateRouterHook()` only. The built-in
+  `instar/` hook is always-overwritten on migration, so every existing agent
+  receives the guard on its next update (Migration Parity Standard — no separate
+  migration needed; the hook content method IS the migration path).
+
+## Testing
+
+`tests/unit/stop-gate-stated-continuation.test.ts` renders the real hook via
+`getHookContent('stop-gate-router')` and EXECUTES it as a subprocess against
+representative Stop-hook payloads:
+
+- Renders syntactically valid JS containing the guard (`node --check`).
+- BLOCKS on "I'll build that now" (exit 2 + `decision:block`).
+- BLOCKS on the exact real-world stall ("Next phase: build ...").
+- Does NOT block a benign completion ("Done — all tests passed ...").
+- Does NOT re-block when `stop_hook_active` is true (loop guard).
+
+## Non-goals
+
+- Not a replacement for the server-side Unjustified Stop Gate's nuanced judgment;
+  this is a narrow, high-precision local backstop for one unambiguous pattern.
+- Does not change the gate's mode or its telemetry.

--- a/src/core/PostUpdateMigrator.ts
+++ b/src/core/PostUpdateMigrator.ts
@@ -8208,6 +8208,37 @@ if (!reviewEnabled) {
   if (input.stop_hook_active) { exitOpen(); return; }
   const sessionId = String(input.session_id || input.sessionId || process.env.INSTAR_SESSION_ID || 'unknown');
 
+  // ── Stated-continuation guard (mode-INDEPENDENT). ───────────────────────────
+  // Catches the specific silent-stall pattern that shadow mode lets through: the
+  // agent's FINAL message tells the user it is about to act this turn ("I'll
+  // build X now", "starting now", "next phase: ship ...") and then the turn ENDS
+  // without doing it. Blocks ONCE (the stop_hook_active guard above prevents a
+  // loop) regardless of the gate's shadow/enforce mode — shadow is exactly when
+  // these stalls slip through (telemetry only). The re-feed allows a clean exit:
+  // do the work, OR send the user one honest message that you are stopping and
+  // why. Pure substring matching (no regex-escape hazards in this template).
+  (function statedContinuationGuard() {
+    const lc = String(input.last_assistant_message || '').toLowerCase();
+    if (lc.length < 8) return;
+    function hasAny(arr) { for (let i = 0; i < arr.length; i++) { if (lc.indexOf(arr[i]) !== -1) return arr[i]; } return null; }
+    const commit = hasAny([
+      "i'm going to", 'i am going to', "i'll ", 'i will ', 'about to ', 'gonna ',
+      'next phase', 'next step', 'next up', 'next round', 'kicking off',
+      'getting started', 'starting now', 'on it', "i'll build", "i'll ship",
+      "i'll continue", "i'll finish", "i'll fix", "i'll start", "i'll do",
+    ]);
+    const imminent = hasAny([
+      ' now', 'right now', 'immediately', 'starting now', 'next phase',
+      'next step', 'next up', 'this turn', 'this session', 'then i',
+    ]);
+    if (!commit || !imminent) return;
+    process.stdout.write(JSON.stringify({
+      decision: 'block',
+      reason: 'STOP-GATE (stated-continuation): your final message tells the user you are about to act ("' + commit + '" / "' + imminent + '") but you are ending the turn without doing it. Do NOT give the impression you are continuing and then stall silently. Either (a) actually do that work now, or (b) if you are genuinely blocked, finished, or need the user, send ONE short honest message saying you are stopping and exactly why — then you may stop. This guard fires once.',
+    }));
+    process.exit(2);
+  })();
+
   try {
     const hot = await getJson('/internal/stop-gate/hot-path?session=' + encodeURIComponent(sessionId), 1500);
     if (!hot || hot.killSwitch || hot.mode === 'off' || hot.compactionInFlight) { exitOpen(); return; }

--- a/tests/unit/stop-gate-stated-continuation.test.ts
+++ b/tests/unit/stop-gate-stated-continuation.test.ts
@@ -1,0 +1,122 @@
+/**
+ * Unit tests for the stated-continuation guard in the stop-gate-router hook.
+ *
+ * The guard is the structural fix for the recurring "silent stall after stating
+ * you'll continue" behavior: the agent's final message tells the user it is
+ * about to act this turn ("I'll build X now", "Next phase: ship ...") and then
+ * the turn ENDS without doing it. The guard blocks ONCE (mode-independent, so it
+ * fires even when the server-side gate is in shadow mode — which is exactly when
+ * these stalls slipped through) and re-feeds: do the work, or tell the user
+ * plainly you're stopping.
+ *
+ * These tests render the real hook via PostUpdateMigrator.getHookContent and
+ * EXECUTE it as a subprocess against representative Stop-hook payloads — so a
+ * template-string syntax error or a broken detection path fails the suite.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { execFileSync } from 'node:child_process';
+import { PostUpdateMigrator } from '../../src/core/PostUpdateMigrator.js';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+
+function renderHook(): string {
+  const m = new PostUpdateMigrator({
+    projectDir: '/tmp/stop-gate-render',
+    stateDir: '/tmp/stop-gate-render/.instar',
+    hasTelegram: false,
+    port: 59999,
+  });
+  return m.getHookContent('stop-gate-router');
+}
+
+function runHook(hookPath: string, projectDir: string, input: object): { code: number; stdout: string } {
+  try {
+    const stdout = execFileSync('node', [hookPath], {
+      input: JSON.stringify(input),
+      encoding: 'utf-8',
+      env: { ...process.env, CLAUDE_PROJECT_DIR: projectDir, INSTAR_AUTH_TOKEN: 'test' },
+      timeout: 8000,
+    });
+    return { code: 0, stdout };
+  } catch (e: unknown) {
+    const err = e as { status?: number; stdout?: Buffer | string };
+    return { code: err.status ?? -1, stdout: (err.stdout || '').toString() };
+  }
+}
+
+describe('stop-gate-router — stated-continuation guard', () => {
+  let tmp: string;
+  let projectDir: string;
+  let hookPath: string;
+
+  beforeEach(() => {
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'stated-cont-'));
+    projectDir = path.join(tmp, 'agent');
+    fs.mkdirSync(path.join(projectDir, '.instar'), { recursive: true });
+    // Dead server port → the server round-trip fails fast (ECONNREFUSED) so the
+    // benign path reaches exitOpen without depending on a running Instar server.
+    fs.writeFileSync(
+      path.join(projectDir, '.instar', 'config.json'),
+      JSON.stringify({ port: 59999, authToken: 'test' }),
+    );
+    hookPath = path.join(tmp, 'stop-gate-router.js');
+    fs.writeFileSync(hookPath, renderHook(), { mode: 0o755 });
+  });
+
+  afterEach(() => {
+    SafeFsExecutor.safeRmSync(tmp, {
+      recursive: true,
+      force: true,
+      operation: 'tests/unit/stop-gate-stated-continuation.test.ts',
+    });
+  });
+
+  it('renders syntactically valid JS containing the guard', () => {
+    // node --check throws on any syntax error in the rendered template string.
+    execFileSync('node', ['--check', hookPath], { encoding: 'utf-8' });
+    expect(fs.readFileSync(hookPath, 'utf-8')).toContain('statedContinuationGuard');
+  });
+
+  it('BLOCKS when the final message states imminent action ("I\'ll build X now")', () => {
+    const r = runHook(hookPath, projectDir, {
+      session_id: 's1',
+      last_assistant_message: "Great — I'll build that now and report back.",
+    });
+    expect(r.code).toBe(2);
+    expect(r.stdout).toContain('"decision":"block"');
+    expect(r.stdout).toContain('stated-continuation');
+  });
+
+  it('BLOCKS on the exact real-world stall pattern ("Next phase: build ...")', () => {
+    const r = runHook(hookPath, projectDir, {
+      session_id: 's2',
+      last_assistant_message:
+        'Milestone reached. Next phase: build the reverse reply-relay, then ship the durable fix.',
+    });
+    expect(r.code).toBe(2);
+    expect(r.stdout).toContain('block');
+  });
+
+  it('does NOT block a benign completion message (no imminent commitment)', () => {
+    const r = runHook(hookPath, projectDir, {
+      session_id: 's3',
+      last_assistant_message:
+        'Done — all tests passed and the PR is merged. Let me know if you need anything else.',
+    });
+    expect(r.code).toBe(0);
+    expect(r.stdout).not.toContain('"decision":"block"');
+  });
+
+  it('does NOT re-block when stop_hook_active is true (loop guard prevents traps)', () => {
+    const r = runHook(hookPath, projectDir, {
+      session_id: 's4',
+      stop_hook_active: true,
+      last_assistant_message: "I'll build that now.",
+    });
+    expect(r.code).toBe(0);
+    expect(r.stdout).not.toContain('"decision":"block"');
+  });
+});

--- a/upgrades/NEXT.md
+++ b/upgrades/NEXT.md
@@ -1,0 +1,62 @@
+# Upgrade Guide — vNEXT
+
+<!-- bump: patch -->
+
+## What Changed
+
+**The stop gate now catches the "I'll do it now" silent stall — even in shadow
+mode.** A recurring failure: an agent's final message tells the user it is about
+to act this turn ("I'll build that now", "starting now", "Next phase: ship the
+fix") and then the turn simply ends, leaving the user staring at silence after
+being told work was continuing.
+
+The existing `stop-gate-router.js` hook delegated the continue/stop decision to
+the server-side Unjustified Stop Gate, which only blocks in `enforce` mode — but
+the gate ships in `shadow` (telemetry-only) mode on most agents, so the exact
+moment a stall happened, nothing intervened.
+
+This adds a small, always-on guard at the top of the hook. When the final message
+states an imminent this-turn action together with an imminence marker (now / right
+now / this turn / next phase / on it), the hook blocks once and re-feeds the
+agent: either actually do the work, or send the user one honest sentence that it
+is stopping and why. The guard is mode-independent (works even when the gate is in
+shadow mode or the server is unreachable) and fires at most once — the existing
+loop guard prevents any continuation trap. "Report-back-later" intent (no
+imminence marker) is not caught; that stays with the commitment tracker.
+
+## Evidence
+
+Reproduction (live, topic 13481, 2026-05-31): the agent posted "I'm going to
+build that now ... then deploy and finish the round-trip proof" at 16:56 UTC,
+then ended the turn and went silent for ~90 minutes without starting the work.
+Operator response: "your session has stalled again ... this is incoherent."
+
+Root cause observed: a direct probe of the running gate returned
+GET /internal/stop-gate/hot-path -> {"mode":"shadow",...}. In shadow mode the
+stop-gate-router records telemetry but never blocks, so the stall passed through
+unchallenged — the safety net was off at the exact moment it was needed.
+
+Before: rendering the prior hook and feeding it the exact stall message
+("Next phase: build the reverse reply-relay, then ship the fix") exits 0 — the
+agent is allowed to stop silently.
+
+After: the same rendered hook fed the same message exits 2 and writes
+{"decision":"block", reason:"STOP-GATE (stated-continuation): ..."}, regardless
+of the server's shadow/enforce mode and even with no server reachable. A benign
+completion ("Done — all tests passed ...") still exits 0, and stop_hook_active=true
+exits 0 (loop guard intact). Confirmed by executing the rendered hook as a
+subprocess against each payload (tests/unit/stop-gate-stated-continuation.test.ts,
+5/5 green).
+
+## What to Tell Your User
+
+Nothing to configure. Your agent can no longer tell you "I'll do that now" and
+then quietly stop without doing it — if it tries, it gets nudged once to either
+actually do the work or tell you plainly that it is stopping and why. The result
+is fewer confusing silences after an agent says it is continuing.
+
+## Summary of New Capabilities
+
+- Local, mode-independent stated-continuation guard in the stop-gate-router hook
+  (`PostUpdateMigrator.getStopGateRouterHook()`); deploys to every agent on update
+  via the always-overwrite built-in hook path.

--- a/upgrades/side-effects/stop-gate-stated-continuation.md
+++ b/upgrades/side-effects/stop-gate-stated-continuation.md
@@ -1,0 +1,41 @@
+# Side effects — stated-continuation stop guard
+
+## What changes at runtime
+
+The built-in `stop-gate-router.js` Stop hook gains a local, mode-independent
+guard. On every Stop, if the agent's final message states an imminent this-turn
+action ("I'll build X now", "starting now", "next phase: ...", "on it ... now")
+the hook returns `{decision:'block'}` (exit 2) ONCE, re-feeding the agent to
+either do the work or tell the user plainly it is stopping and why.
+
+## Who is affected
+
+- **Every Instar agent on update.** Built-in `instar/` hooks are always
+  overwritten on migration, so the guard deploys automatically — no opt-in,
+  no per-agent migration. New agents get it via `init`.
+
+## Behavioral side effects (intended)
+
+- An agent that ends a turn right after saying "I'll do X now" will be blocked
+  once and pushed to either act or send an explicit stop message. This is the
+  intended fix; it converts silent stalls into either real work or an honest
+  "I'm stopping because…" message.
+- Borderline matches (e.g. a summary heading "Next phase: …") cost exactly one
+  extra nudge and force an explicit sign-off — acceptable and desirable.
+
+## What is NOT affected
+
+- The server-side Unjustified Stop Gate, its mode (shadow/enforce), its telemetry,
+  and its circuit breaker are all untouched.
+- The autonomous-stop-hook and hook-event-reporter Stop hooks are untouched.
+- The loop-prevention contract is preserved: the existing `stop_hook_active` guard
+  still short-circuits on the re-fire, so the guard fires at most once per stop —
+  no infinite continuation loop is possible.
+- "Report-back-later" / scheduled commitments (no imminence marker) are NOT
+  caught — those remain the commitment tracker's domain.
+
+## Rollback
+
+Revert the `getStopGateRouterHook()` change; the next migration overwrites the
+installed hook back to the prior content. No state, config, or schema changes are
+involved.


### PR DESCRIPTION
## Problem
Recurring trust-eroding stall: the agent's final message states it's about to act this turn ("I'll build that now", "starting now", "Next phase: ship the fix") and then the turn just ends — the user is told work is continuing and gets silence. Live incident on topic 13481 (2026-05-31); operator: "this is incoherent and we need to improve INSTAR in the behavior."

Root cause: `stop-gate-router.js` delegated the continue/stop call to the server-side Unjustified Stop Gate, which only blocks in `enforce` mode. The gate ships in `shadow` (telemetry-only) on most agents — so the exact moment a stall happens, nothing intervenes. Confirmed via `GET /internal/stop-gate/hot-path` → `{"mode":"shadow",...}`.

## Fix
A local, mode-independent guard in `PostUpdateMigrator.getStopGateRouterHook()`, placed after the `stop_hook_active` loop-guard and before the server round-trip. When the final message has an imminent this-turn action commitment + an imminence marker, the hook emits `{decision:'block'}` (exit 2) ONCE and re-feeds: do the work, or send the user one honest sentence that you're stopping and why.

- **Mode-independent** — fires even in shadow mode / with the server unreachable (shadow is exactly when stalls slip through).
- **Fires once** — the existing `stop_hook_active` guard exits open on the re-fire → no trap.
- **Converts silent stalls into explicit stops** — worst case on a borderline match is the agent must say it's stopping and why.
- "Report-back-later" intent (no imminence marker) is NOT caught — that stays with the commitment tracker.

## Migration parity
Built-in `instar/` hook → always-overwritten on migration, so every existing agent gets the guard on its next update. New agents via `init`.

## Tests
`tests/unit/stop-gate-stated-continuation.test.ts` renders the real hook and EXECUTES it as a subprocess: valid JS (`node --check`); blocks "I'll build that now" + the exact real-world "Next phase: build…" stall; does NOT block a benign completion; loop-guard verified. 5/5 green. tsc + `pnpm run lint` clean.

## Approval
Self-approved under the delegated deploy mandate. Justin requested this fix DIRECTLY on topic 13481 ("we need to improve INSTAR in the behavior"). Self-reviewed (small, high-precision, tested); flagged here per cross-agent discipline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
