### PR TITLE
fix(llm): coherence-critical guards wait (bounded) for a rate-limit window instead of failing open

### DIFF
--- a/docs/specs/llm-ratelimit-bounded-wait.eli16.md
+++ b/docs/specs/llm-ratelimit-bounded-wait.eli16.md
@@ -1,0 +1,73 @@
+# ELI16: Why the safety checks stopped working under load — and the fix
+
+## The setup
+
+My server constantly makes little AI judgment calls to keep things safe and
+coherent: "is this outbound message about to leak a command?", "is this agent
+trying to quit without a good reason?", "does this reply contradict what we
+promised?" Each of those is a quick call to the AI model.
+
+All of those calls share ONE account with Anthropic. When too many calls happen
+too fast, Anthropic says "slow down" (a rate limit — like a busy signal). To
+avoid burning money hammering a busy signal, my server has a "circuit breaker":
+when it hears the busy signal, it flips a switch that pauses ALL AI calls for 15
+minutes.
+
+## The bug
+
+Here's the problem. When the breaker is flipped and a safety check can't get its
+AI answer, the check just... gives up and says "sure, allow it." That's called
+"failing open." It seemed safe-ish — don't block the user just because the AI is
+busy.
+
+But think about WHEN the breaker flips: exactly when the system is busiest and
+most stressed. So at the precise moment things are most likely to go wrong, every
+safety check quietly switches off and waves everything through. The logs literally
+showed "Stop allowed without authority ruling" and "message review failed — fail
+open." The guards were asleep on the job exactly when they mattered most.
+
+## The owner's instruction
+
+Justin's call: it's fine if things take a bit LONGER when we hit a busy signal —
+as long as the important checks stay correct. Better to wait 30 seconds and get a
+real answer than to instantly wave through something dangerous.
+
+## The fix
+
+We split the AI calls into two kinds:
+
+**Important checks** (the outbound-message gate, the "are you quitting for a real
+reason" gate, the high-stakes coherence reviewers): when the breaker is flipped,
+these now WAIT — up to a bounded amount of time — for the busy signal to clear,
+then get their real answer. Slower, but correct. The waits are capped so they can
+never hang forever (the quit-gate waits only 8 seconds, because it's on the
+agent's critical path; the message gate can wait up to 2 minutes).
+
+**Best-effort checks** (background observability stuff — commitment detection,
+tone nitpicks): these keep instantly giving up when the breaker is flipped. On
+purpose! They're the high-volume callers that TRIP the breaker in the first
+place, so having them step aside lets the breaker recover faster and frees up the
+scarce "is it clear yet?" probe for the important checks.
+
+We also taught the breaker to read a hint: if the busy-signal message says "try
+again in 30 seconds," the breaker only pauses 30 seconds instead of the full 15
+minutes. (It can only read hints that show up in the text — the real HTTP header
+is invisible to us because we call the AI through a command-line tool, not a
+direct web request — so when there's no hint it falls back to the old 15-minute
+wait.)
+
+## How we made sure it's safe
+
+A caller that doesn't ask to wait behaves EXACTLY like before — instant give-up —
+so nothing that wasn't explicitly upgraded changed at all. And the waiting logic
+is careful that when the busy signal clears, only ONE check actually pokes the AI
+to see if it's back; everybody else waits for that one answer, so we don't all
+rush the door at once and re-trip the breaker. 27 tests with a fake clock prove
+every path: waits-and-proceeds, gives-up-at-the-deadline, and the one-pokes-many-
+wait crowd behavior.
+
+## Why it matters
+
+Before: the safety net had a hole that opened exactly when you were falling.
+After: the important parts of the net hold — they pause and catch you a moment
+later instead of letting you through. Slower under stress, but actually safe.

--- a/docs/specs/llm-ratelimit-bounded-wait.md
+++ b/docs/specs/llm-ratelimit-bounded-wait.md
@@ -1,0 +1,128 @@
+---
+title: Coherence-critical LLM guards wait (bounded) for a rate-limit window instead of failing open
+slug: llm-ratelimit-bounded-wait
+status: approved
+review-convergence: 2026-05-31T23:30:00+00:00
+approved: true
+author: echo
+approval-note: >
+  Self-approved by Echo under the delegated deploy mandate. Justin explicitly
+  greenlit this on topic 13481 (2026-05-31): "Yes, please let's proceed in the
+  proper robust process to fix all of this correctly," after reviewing the
+  grounded design. Flagged here per cross-agent discipline.
+---
+
+# Coherence-critical LLM guards wait (bounded) for a rate-limit window
+
+## Problem
+
+Every server-side LLM call flows through one process-global circuit breaker
+(`getLlmCircuitBreaker()`). When Anthropic rate-limits the account, the breaker
+opens for a flat 15-minute window and refuses ALL calls. Each guard's catch
+block then **fails open** — it skips its check and lets the action through.
+
+Observed live (server.log, 2026-05-31): the breaker tripped 18× in one day;
+trips #15–#18 fired 20:34–21:59Z. During those windows the logs show
+`[InputGuard] DEGRADATION: LLM review failed ... fail-open`, `Stop event allowed
+without authority ruling (drift correction not applied). Using fail-open →
+allow`. So under exactly the load that should make the system most careful, the
+coherence guards stop guarding:
+
+- **MessagingToneGate** (outbound message gate) stops reviewing → leaked CLI
+  commands / file paths, context-death-stop framing, and false blockers reach
+  the user unreviewed.
+- **UnjustifiedStopGate authority** fails open → unjustified stops slip through.
+- **CoherenceGate** internal-channel reviewers abstain → checks skipped.
+
+The owner directive: *"It's acceptable for things to take longer if we have to
+wait on rate limits, as long as the operation is more robust and more
+coherent."* I.e. coherence-critical calls should prefer **wait-and-retry** over
+fail-open; best-effort/observability calls may keep failing open to shed load.
+
+## Why the breaker can't see Retry-After
+
+LLM calls shell out to `claude -p` as a subprocess, so the true
+`anthropic-ratelimit-*` / `Retry-After` HTTP headers never reach instar — only
+the CLI's combined stdout/stderr error text does. Header-accurate timing is
+structurally impossible on the subscription/CLI path (the direct-API path is
+forbidden). So "honor Retry-After" is best-effort-by-construction: we parse a
+duration from the error string when one is present, and fall back to the flat
+window otherwise.
+
+## Solution (additive — no behavior change for callers that don't opt in)
+
+1. **`classifyRateLimit(message)`** (`src/core/LlmCircuitBreaker.ts`) — a
+   superset of the existing `isRateLimitError` (which is reimplemented as
+   `classifyRateLimit(m).isLimit`, so detection is byte-identical). It also
+   best-effort parses a retry-after hint (`retry-after: N`, `resets in Ns`, `try
+   again in N minutes`, bare `N minutes`), clamped to [1s, 15min], else
+   undefined.
+
+2. **Per-trip window** — `onRateLimited(reason, retryAfterMs?)` shortens the
+   open window for THIS trip to the parsed hint, clamped to
+   `[min(30s, openMs), openMs]`. Without a hint, the flat default window is used
+   (unchanged). Reset to the full window on a clean close.
+
+3. **`acquireOrWait(maxWaitMs)`** — the coherence-critical primitive. Loops:
+   when open, sleeps just past the window edge; when half-open with another
+   caller's probe in flight, polls at `probePollMs`; returns `allow:true` as soon
+   as admitted, or `allow:false` at the bounded deadline. Waiters serialize
+   behind the single half-open probe — exactly one probe hits the provider, no
+   thundering herd. Clock + sleep are injectable for deterministic tests.
+
+4. **`IntelligenceOptions.rateLimitWaitMs`** — when a caller sets it and the
+   breaker is open, `CircuitBreakingIntelligenceProvider.evaluate()` awaits
+   `acquireOrWait(rateLimitWaitMs)` instead of throwing immediately. When unset,
+   behavior is byte-identical to today (instant `LlmCircuitOpenError`). The
+   catch path now passes the parsed retry-after through to `onRateLimited`.
+
+5. **Per-callsite policy** — coherence-critical callsites opt in:
+   - MessagingToneGate: `rateLimitWaitMs = 120_000` (outbound message can wait up
+     to 2 min for a correct, reviewed send).
+   - CoherenceGate high-stakes reviewers only (`value-alignment`,
+     `claim-provenance`, `capability-accuracy`, `information-leakage`):
+     `60_000`.
+   - UnjustifiedStopGate: `8_000` — SHORT, because it sits on the agent's Stop
+     critical path; a long wait would hang the agent, so it waits briefly then
+     falls back to its existing safe behavior.
+   - All best-effort/observability callsites omit it → instant fail-open,
+     unchanged, so they keep shedding load and let the breaker recover.
+
+## Scope
+
+- `src/core/LlmCircuitBreaker.ts` — classifyRateLimit, per-trip window,
+  acquireOrWait, injectable sleep/probePollMs.
+- `src/core/CircuitBreakingIntelligenceProvider.ts` — opt-in bounded wait.
+- `src/core/types.ts` — `IntelligenceOptions.rateLimitWaitMs`.
+- `src/core/MessagingToneGate.ts`, `src/core/UnjustifiedStopGate.ts`,
+  `src/core/CoherenceReviewer.ts`, `src/core/CoherenceGate.ts` — opt-in wiring.
+
+## Testing
+
+`tests/unit/llm-circuit-breaker-wait.test.ts` (27 tests, injected fake
+clock + clock-advancing sleep, fully deterministic):
+- `classifyRateLimit` parsing (retry-after / resets-in-Ns / N-minutes / bare
+  429 → isLimit-no-hint / non-limit / absurd-value clamp).
+- `onRateLimited(retryAfterMs)` shortens the window + admits a probe exactly at
+  the hint, floors to min(30s, openMs), falls back to flat default.
+- `acquireOrWait`: closed → immediate (no sleep); open-closes-in-time →
+  allow:true; window-longer-than-maxWait → allow:false at deadline; herd → one
+  probe admitted, loser polls then proceeds on close, or keeps waiting if the
+  probe reopens.
+- Provider-level: no `rateLimitWaitMs` → instant throw (byte-identical, zero
+  sleeps, inner provider never called); with it → waits and proceeds; shorter
+  than window → still throws; parsed retry-after threaded to `onRateLimited`.
+
+All affected suites green (191/191 across the 8 touched test files). tsc clean.
+
+## Non-goals / risks
+
+- Does not change the breaker's spend-protection purpose (the $452-incident
+  motivation) — it adds a bounded-wait TIER, it does not weaken the open state.
+- A bounded wait never hangs an urgent path: every wait has a hard `maxWaitMs`
+  then the caller's existing fallback runs. UnjustifiedStopGate's cap is small by
+  design.
+- Header-accurate Retry-After is impossible on the CLI path; the flat-window
+  fallback is honest about that rather than pretending to have header data.
+- Best-effort callers stay instant-fail-open so they don't consume the scarce
+  half-open probe slot.

--- a/src/core/CircuitBreakingIntelligenceProvider.ts
+++ b/src/core/CircuitBreakingIntelligenceProvider.ts
@@ -30,7 +30,7 @@ import {
   LlmCircuitOpenError,
   RateLimitError,
   getLlmCircuitBreaker,
-  isRateLimitError,
+  classifyRateLimit,
 } from './LlmCircuitBreaker.js';
 
 export class CircuitBreakingIntelligenceProvider implements IntelligenceProvider {
@@ -40,9 +40,18 @@ export class CircuitBreakingIntelligenceProvider implements IntelligenceProvider
   ) {}
 
   async evaluate(prompt: string, options?: IntelligenceOptions): Promise<string> {
-    const gate = this.breaker.acquire();
+    let gate = this.breaker.acquire();
     if (!gate.allow) {
-      throw new LlmCircuitOpenError(gate.retryAfterMs);
+      // Coherence-critical callers set rateLimitWaitMs: wait (bounded) for the
+      // window to clear instead of failing open immediately. Best-effort callers
+      // omit it — behavior is byte-identical to the instant throw below.
+      const waitMs = options?.rateLimitWaitMs;
+      if (typeof waitMs === 'number' && waitMs > 0) {
+        gate = await this.breaker.acquireOrWait(waitMs);
+      }
+      if (!gate.allow) {
+        throw new LlmCircuitOpenError(gate.retryAfterMs);
+      }
     }
 
     try {
@@ -51,8 +60,11 @@ export class CircuitBreakingIntelligenceProvider implements IntelligenceProvider
       return result;
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
-      if (err instanceof RateLimitError || isRateLimitError(message)) {
-        this.breaker.onRateLimited(message);
+      const parsed = classifyRateLimit(message);
+      if (err instanceof RateLimitError || parsed.isLimit) {
+        // Pass the parsed retry-after hint through so the breaker can shorten
+        // the open window when the provider told us when it resets.
+        this.breaker.onRateLimited(message, parsed.retryAfterMs);
         if (err instanceof RateLimitError) throw err;
         throw new RateLimitError(message, err);
       }

--- a/src/core/CoherenceGate.ts
+++ b/src/core/CoherenceGate.ts
@@ -131,6 +131,22 @@ const REVIEWER_CATEGORY_MAP: Record<string, string> = {
 /** Violation types for retry exhaustion handling */
 const HIGH_STAKES_CATEGORIES = new Set(['ACCURACY ISSUE', 'ALIGNMENT ISSUE']);
 
+/**
+ * Reviewers whose checks are coherence-critical (high criticality / high-stakes
+ * categories: value-alignment, claim-provenance, capability-accuracy,
+ * information-leakage). When the shared LLM circuit breaker is open, these wait
+ * up to HIGH_STAKES_RATE_LIMIT_WAIT_MS (bounded) for the window to clear rather
+ * than fail open and let a dangerous leak/false-claim through. All other
+ * reviewers omit the wait (instant fail-open, shedding load).
+ */
+const HIGH_STAKES_REVIEWERS = new Set([
+  'value-alignment',
+  'claim-provenance',
+  'capability-accuracy',
+  'information-leakage',
+]);
+const HIGH_STAKES_RATE_LIMIT_WAIT_MS = 60_000;
+
 // ── Value Document Cache ─────────────────────────────────────────────
 
 interface ValueDocCache {
@@ -631,8 +647,13 @@ export class CoherenceGate {
       const model = overrides[name] ?? defaultModel;
       const mode = reviewerConfig?.mode ?? 'block';
       const timeoutMs = config.timeoutMs ?? 8_000;
+      // High-stakes reviewers wait (bounded) for a rate-limit window rather than
+      // fail open; best-effort reviewers omit it.
+      const rateLimitWaitMs = HIGH_STAKES_REVIEWERS.has(name)
+        ? HIGH_STAKES_RATE_LIMIT_WAIT_MS
+        : undefined;
 
-      this.reviewers.set(name, new cls({ model, mode, timeoutMs, intelligence }));
+      this.reviewers.set(name, new cls({ model, mode, timeoutMs, intelligence, rateLimitWaitMs }));
     }
   }
 

--- a/src/core/CoherenceReviewer.ts
+++ b/src/core/CoherenceReviewer.ts
@@ -90,6 +90,12 @@ export interface ReviewerOptions {
    * intelligence provider will throw at first `review()` call.
    */
   intelligence?: IntelligenceProvider;
+  /**
+   * If set, this reviewer's LLM call waits up to this many ms (bounded) for an
+   * open circuit breaker window to clear before failing open. Set only for
+   * high-stakes reviewers; best-effort reviewers omit it (instant fail-open).
+   */
+  rateLimitWaitMs?: number;
 }
 
 export interface ReviewerHealthMetrics {
@@ -279,6 +285,9 @@ export abstract class CoherenceReviewer {
       model: this.mapModelToTier(this.options.model ?? 'haiku'),
       maxTokens: 200,
       temperature: 0,
+      // High-stakes reviewers wait (bounded) for a rate-limit window to clear
+      // rather than fail open; undefined for best-effort reviewers.
+      rateLimitWaitMs: this.options.rateLimitWaitMs,
     };
     // IntelligenceProvider implementations set their own timeouts; wrap here too.
     return await Promise.race([

--- a/src/core/LlmCircuitBreaker.ts
+++ b/src/core/LlmCircuitBreaker.ts
@@ -61,12 +61,35 @@ export class LlmCircuitOpenError extends Error {
  * "error"/"failed"/timeout text.
  */
 export function isRateLimitError(message: string | null | undefined): boolean {
-  if (!message) return false;
+  return classifyRateLimit(message).isLimit;
+}
+
+/** Sanity clamp for any parsed retry-after hint (ms). */
+const RETRY_AFTER_MIN_MS = 1_000; // 1s
+const RETRY_AFTER_MAX_MS = 15 * 60_000; // 15min
+
+/**
+ * Classify an error message as a rate-limit/quota condition AND, best-effort,
+ * extract a retry-after hint in milliseconds.
+ *
+ * SUPERSET of isRateLimitError: `isLimit` uses the exact same phrase/429/402
+ * detection. The CLI error text is unstructured (the underlying HTTP
+ * retry-after header is invisible to us — we only see the `claude -p` error
+ * string), so `retryAfterMs` is returned only when a duration phrase parses;
+ * callers fall back to the flat default window otherwise.
+ */
+export function classifyRateLimit(message: string | null | undefined): {
+  isLimit: boolean;
+  retryAfterMs?: number;
+} {
+  if (!message) return { isLimit: false };
   const m = message.toLowerCase();
 
+  let isLimit = false;
+
   // Explicit HTTP status codes for limit / billing rejections.
-  if (/\b429\b/.test(m)) return true; // Too Many Requests
-  if (/\b402\b/.test(m)) return true; // Payment Required
+  if (/\b429\b/.test(m)) isLimit = true; // Too Many Requests
+  if (/\b402\b/.test(m)) isLimit = true; // Payment Required
 
   const phrases = [
     'rate limit',
@@ -92,15 +115,54 @@ export function isRateLimitError(message: string | null | undefined): boolean {
     'spending limit',
     'billing',
   ];
-  if (phrases.some((p) => m.includes(p))) return true;
+  if (phrases.some((p) => m.includes(p))) isLimit = true;
 
   // "exceeded ... (limit|quota|usage)" with words in between.
-  if (/exceed(?:ed|s)?\b[^.\n]{0,40}(?:limit|quota|usage|credit)/.test(m)) return true;
+  if (/exceed(?:ed|s)?\b[^.\n]{0,40}(?:limit|quota|usage|credit)/.test(m)) isLimit = true;
 
   // Bare "quota" is a strong-enough signal on its own (Anthropic/OpenAI both use it).
-  if (/\bquota\b/.test(m)) return true;
+  if (/\bquota\b/.test(m)) isLimit = true;
 
-  return false;
+  const retryAfterMs = parseRetryAfterMs(m);
+  return retryAfterMs !== undefined ? { isLimit, retryAfterMs } : { isLimit };
+}
+
+/**
+ * Best-effort parse of a retry-after hint from an (already lower-cased) error
+ * message. Returns milliseconds clamped to a sane range, or undefined. Matches,
+ * in priority order: explicit retry-after, "resets/try again in Ns", then
+ * "resets/try again in Nm" and a bare "N minutes" fallback.
+ */
+function parseRetryAfterMs(m: string): number | undefined {
+  let seconds: number | undefined;
+
+  // retry-after: <N>  /  retry after <N> seconds|s
+  let match = /retry[\s-]?after:?\s*(\d+(?:\.\d+)?)\s*(?:seconds?|s)?\b/.exec(m);
+  if (match) seconds = Number(match[1]);
+
+  // resets in <N>s / reset in <N> seconds / try again in <N>s
+  if (seconds === undefined) {
+    match = /(?:resets?|try again)\s+in\s+(\d+(?:\.\d+)?)\s*(?:seconds?|s)\b/.exec(m);
+    if (match) seconds = Number(match[1]);
+  }
+
+  // resets in <N>m / reset in <N> minutes / try again in <N> minutes
+  if (seconds === undefined) {
+    match = /(?:resets?|try again)\s+in\s+(\d+(?:\.\d+)?)\s*(?:minutes?|m)\b/.exec(m);
+    if (match) seconds = Number(match[1]) * 60;
+  }
+
+  // bare "<N> minutes" fallback.
+  if (seconds === undefined) {
+    match = /(\d+(?:\.\d+)?)\s*minutes?\b/.exec(m);
+    if (match) seconds = Number(match[1]) * 60;
+  }
+
+  if (seconds === undefined || !Number.isFinite(seconds) || seconds <= 0) {
+    return undefined;
+  }
+  const ms = seconds * 1000;
+  return Math.min(Math.max(ms, RETRY_AFTER_MIN_MS), RETRY_AFTER_MAX_MS);
 }
 
 type CircuitState = 'closed' | 'open' | 'half-open';
@@ -114,6 +176,10 @@ export interface LlmCircuitBreakerOptions {
   now?: () => number;
   /** Injectable logger (defaults to console.warn → server log). */
   log?: (line: string) => void;
+  /** Injectable sleep for tests. Default real setTimeout-backed promise. */
+  sleep?: (ms: number) => Promise<void>;
+  /** Poll interval (ms) used by acquireOrWait while a probe is in flight. Default 250. */
+  probePollMs?: number;
 }
 
 export interface AcquireDecision {
@@ -136,6 +202,7 @@ export interface LlmCircuitBreakerStatus {
 }
 
 const DEFAULT_OPEN_MS = 15 * 60_000; // 15 minutes
+const DEFAULT_PROBE_POLL_MS = 250;
 
 export class LlmCircuitBreaker {
   private state: CircuitState = 'closed';
@@ -150,12 +217,25 @@ export class LlmCircuitBreaker {
   private enabled: boolean;
   private readonly now: () => number;
   private readonly log: (line: string) => void;
+  private readonly sleep: (ms: number) => Promise<void>;
+  private readonly probePollMs: number;
+  /**
+   * The window length for the CURRENT trip — may be shortened (toward
+   * min(30s, openMs)) by a parsed retry-after hint so waiters don't sit out the
+   * full flat cooldown when the provider told us when it resets. Reset to openMs
+   * on a clean close. The open window is [firstOpenedAt, openUntil); openUntil
+   * is firstOpenedAt + currentOpenMs.
+   */
+  private currentOpenMs: number;
 
   constructor(opts: LlmCircuitBreakerOptions = {}) {
     this.openMs = opts.openMs && opts.openMs > 0 ? opts.openMs : DEFAULT_OPEN_MS;
     this.enabled = opts.enabled ?? true;
     this.now = opts.now ?? (() => Date.now());
     this.log = opts.log ?? ((line) => console.warn(line));
+    this.sleep = opts.sleep ?? ((ms) => new Promise((r) => setTimeout(r, ms)));
+    this.probePollMs = opts.probePollMs && opts.probePollMs > 0 ? opts.probePollMs : DEFAULT_PROBE_POLL_MS;
+    this.currentOpenMs = this.openMs;
   }
 
   /** Runtime reconfiguration (called once at server startup from config). */
@@ -218,29 +298,83 @@ export class LlmCircuitBreaker {
     this.state = 'closed';
     this.probeInFlight = false;
     this.openUntil = 0;
+    // Clean slate — the next trip with no retry-after hint gets the full window.
+    this.currentOpenMs = this.openMs;
   }
 
   /**
    * Record that the underlying call was rejected for a usage/rate limit. Opens
-   * (or re-extends) the breaker for a full window.
+   * (or re-extends) the breaker for a window.
+   *
+   * When `retryAfterMs` is a finite, positive number (parsed best-effort from
+   * the provider error), the open window for THIS trip is shortened to that
+   * value, clamped to [min(30s, openMs), openMs] — so coherence-critical
+   * waiters don't sit out the full flat cooldown when the provider told us when
+   * it resets. Without a hint, the flat default window is used.
    */
-  onRateLimited(reason: string): void {
+  onRateLimited(reason: string, retryAfterMs?: number): void {
     if (!this.enabled) return;
     const now = this.now();
     if (this.state === 'closed') {
       this.firstOpenedAt = now;
     }
+    if (
+      typeof retryAfterMs === 'number' &&
+      Number.isFinite(retryAfterMs) &&
+      retryAfterMs > 0
+    ) {
+      const floor = Math.min(30_000, this.openMs);
+      this.currentOpenMs = Math.min(Math.max(retryAfterMs, floor), this.openMs);
+    } else {
+      this.currentOpenMs = this.openMs;
+    }
     this.tripCount += 1;
     this.lastReason = reason.slice(0, 200);
     this.lastTrippedAt = now;
     this.state = 'open';
-    this.openUntil = now + this.openMs;
+    this.openUntil = now + this.currentOpenMs;
     this.probeInFlight = false;
     this.log(
       `[llm-circuit] OPEN: provider rate-limited — pausing ALL LLM-backed work for ~${Math.round(
-        this.openMs / 1000,
+        this.currentOpenMs / 1000,
       )}s (trip #${this.tripCount}); reason: ${this.lastReason}`,
     );
+  }
+
+  /**
+   * Bounded wait-and-retry acquire — the coherence-critical primitive.
+   *
+   * Loops until either the breaker admits the caller (allow:true) or `maxWaitMs`
+   * elapses (allow:false — bounded fallback so the caller can fail open/closed
+   * on its own terms). When the breaker is open, sleeps until just past the
+   * window edge; when half-open with another caller's probe in flight, polls at
+   * probePollMs. This serializes waiters behind the single half-open probe:
+   * exactly one re-acquires the probe after the window, the rest poll until that
+   * probe's onResolved closes the breaker (then acquire returns closed→allow) or
+   * its onRateLimited reopens it (then they keep waiting until the deadline). No
+   * thundering herd — only one probe hits the provider.
+   *
+   * A passthrough (disabled) breaker allows immediately with no sleep.
+   */
+  async acquireOrWait(maxWaitMs: number): Promise<AcquireDecision> {
+    const deadline = this.now() + maxWaitMs;
+    let gate = this.acquire();
+    while (!gate.allow) {
+      const remaining = deadline - this.now();
+      if (remaining <= 0) break;
+      let waitMs: number;
+      if (this.state === 'open') {
+        // Sleep just past the window edge (gate.retryAfterMs is the remaining
+        // open window) so the next acquire() flips us to half-open.
+        waitMs = Math.min(gate.retryAfterMs + 1, remaining);
+      } else {
+        // half-open: someone else holds the probe — poll.
+        waitMs = Math.min(this.probePollMs, remaining);
+      }
+      await this.sleep(Math.max(0, waitMs));
+      gate = this.acquire();
+    }
+    return gate;
   }
 
   status(): LlmCircuitBreakerStatus {
@@ -262,6 +396,7 @@ export class LlmCircuitBreaker {
     this.openUntil = 0;
     this.firstOpenedAt = 0;
     this.probeInFlight = false;
+    this.currentOpenMs = this.openMs;
   }
 }
 

--- a/src/core/MessagingToneGate.ts
+++ b/src/core/MessagingToneGate.ts
@@ -21,6 +21,13 @@
 import crypto from 'node:crypto';
 import type { IntelligenceProvider } from './types.js';
 
+/**
+ * This is the outbound message gate — the highest-value coherence-critical
+ * check. If the LLM circuit breaker is open, wait up to 2min (bounded) for the
+ * window to clear rather than fail open and let an unreviewed message through.
+ */
+const RATE_LIMIT_WAIT_MS = 120_000;
+
 export interface ToneReviewResult {
   pass: boolean;
   /**
@@ -203,6 +210,7 @@ export class MessagingToneGate {
         model: 'fast',
         maxTokens: 200,
         temperature: 0,
+        rateLimitWaitMs: RATE_LIMIT_WAIT_MS,
       });
       const parsed = this.parseResponse(raw);
 

--- a/src/core/UnjustifiedStopGate.ts
+++ b/src/core/UnjustifiedStopGate.ts
@@ -249,6 +249,15 @@ const DEFAULT_BREAKER_THRESHOLD = 3;
 const DEFAULT_BREAKER_COOLDOWN_MS = 5 * 60_000;
 
 /**
+ * This runs on the agent Stop critical path, so the bounded rate-limit wait must
+ * stay SHORT — a long wait here delays every stop. If the shared LLM circuit
+ * breaker is open, wait at most 8s for the window to clear before failing open.
+ * (This is SEPARATE from this gate's own inner circuit breaker, which is
+ * untouched; it only flows to the shared-provider call's options.)
+ */
+const RATE_LIMIT_WAIT_MS = 8_000;
+
+/**
  * Evaluate a Stop event. Returns an authority result OR a structured
  * failure that the caller fail-opens on.
  *
@@ -408,6 +417,7 @@ export class UnjustifiedStopGate {
         model: 'fast',
         maxTokens: this.config.maxTokens,
         temperature: 0,
+        rateLimitWaitMs: RATE_LIMIT_WAIT_MS,
       });
       return await Promise.race([call, abortRace]);
     } finally {

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -669,6 +669,12 @@ export interface IntelligenceOptions {
   /** Per-call timeout in milliseconds; provider should honor or surface as throw. */
   timeoutMs?: number;
   /**
+   * If set and the LLM circuit breaker is open, wait up to this many ms
+   * (bounded) for the window to clear before failing. Coherence-critical
+   * callsites set this; best-effort callsites omit it (instant fail-open).
+   */
+  rateLimitWaitMs?: number;
+  /**
    * Attribution context for the burn-detection-and-self-heal system (Phase 1
    * of docs/specs/token-burn-detection-and-self-heal.md). Optional; missing
    * attribution lands under the `unknown::*` fallback keys so existing

--- a/tests/unit/llm-circuit-breaker-wait.test.ts
+++ b/tests/unit/llm-circuit-breaker-wait.test.ts
@@ -1,0 +1,352 @@
+import { describe, it, expect } from 'vitest';
+import {
+  LlmCircuitBreaker,
+  classifyRateLimit,
+  LlmCircuitOpenError,
+  RateLimitError,
+} from '../../src/core/LlmCircuitBreaker.js';
+import { CircuitBreakingIntelligenceProvider as CBProvider } from '../../src/core/CircuitBreakingIntelligenceProvider.js';
+import type {
+  IntelligenceProvider,
+  IntelligenceOptions,
+} from '../../src/core/types.js';
+
+/**
+ * Deterministic fake clock + sleep. `sleep` ADVANCES the clock by the requested
+ * ms then resolves, so acquireOrWait timing is fully deterministic — no real
+ * waiting. Records every sleep duration for assertions.
+ */
+function makeClock(start = 0) {
+  let t = start;
+  let slept: number[] = [];
+  return {
+    now: () => t,
+    sleep: (ms: number): Promise<void> => {
+      slept.push(ms);
+      t += ms;
+      return Promise.resolve();
+    },
+    advance: (ms: number) => {
+      t += ms;
+    },
+    get sleepCalls() {
+      return slept;
+    },
+    get totalSlept() {
+      return slept.reduce((a, b) => a + b, 0);
+    },
+    resetSleeps: () => {
+      slept = [];
+    },
+  };
+}
+
+class FakeProvider implements IntelligenceProvider {
+  public calls = 0;
+  public shouldThrow: Error | null = null;
+  async evaluate(_prompt: string, _options?: IntelligenceOptions): Promise<string> {
+    void _prompt;
+    void _options;
+    this.calls++;
+    if (this.shouldThrow) throw this.shouldThrow;
+    return 'ok';
+  }
+}
+
+describe('classifyRateLimit', () => {
+  it('parses "retry-after: 30" → 30000ms', () => {
+    const c = classifyRateLimit('Claude CLI error: 429 retry-after: 30');
+    expect(c.isLimit).toBe(true);
+    expect(c.retryAfterMs).toBe(30_000);
+  });
+
+  it('parses "retry after 30 seconds" → 30000ms', () => {
+    const c = classifyRateLimit('rate limit hit, retry after 30 seconds');
+    expect(c.isLimit).toBe(true);
+    expect(c.retryAfterMs).toBe(30_000);
+  });
+
+  it('parses "resets in 45s" → 45000ms', () => {
+    const c = classifyRateLimit('usage limit — resets in 45s');
+    expect(c.isLimit).toBe(true);
+    expect(c.retryAfterMs).toBe(45_000);
+  });
+
+  it('parses "try again in 2 minutes" → 120000ms', () => {
+    const c = classifyRateLimit('Too many requests. Try again in 2 minutes.');
+    expect(c.isLimit).toBe(true);
+    expect(c.retryAfterMs).toBe(120_000);
+  });
+
+  it('parses "resets in 3m" → 180000ms', () => {
+    const c = classifyRateLimit('quota exceeded, resets in 3m');
+    expect(c.isLimit).toBe(true);
+    expect(c.retryAfterMs).toBe(180_000);
+  });
+
+  it('treats a plain 429 as a limit with no retryAfterMs', () => {
+    const c = classifyRateLimit('HTTP 429 returned');
+    expect(c.isLimit).toBe(true);
+    expect(c.retryAfterMs).toBeUndefined();
+  });
+
+  it('returns isLimit false for non-limit text', () => {
+    const c = classifyRateLimit('Some unrelated parse error occurred');
+    expect(c.isLimit).toBe(false);
+    expect(c.retryAfterMs).toBeUndefined();
+  });
+
+  it('returns isLimit false for null/empty', () => {
+    expect(classifyRateLimit(null).isLimit).toBe(false);
+    expect(classifyRateLimit('').isLimit).toBe(false);
+    expect(classifyRateLimit(undefined).isLimit).toBe(false);
+  });
+
+  it('clamps an absurdly large retry-after to the 15min max', () => {
+    const c = classifyRateLimit('rate limit, retry-after: 99999 seconds');
+    expect(c.isLimit).toBe(true);
+    expect(c.retryAfterMs).toBe(15 * 60 * 1000);
+  });
+
+  it('clamps a sub-second retry-after up to the 1s min', () => {
+    const c = classifyRateLimit('rate limit, retry after 0.1 seconds');
+    expect(c.isLimit).toBe(true);
+    expect(c.retryAfterMs).toBe(1000);
+  });
+
+  it('is a superset of isRateLimitError (same phrases/402/quota)', () => {
+    expect(classifyRateLimit('out of credit').isLimit).toBe(true);
+    expect(classifyRateLimit('payment required 402').isLimit).toBe(true);
+    expect(classifyRateLimit('insufficient quota').isLimit).toBe(true);
+  });
+});
+
+describe('LlmCircuitBreaker.onRateLimited with retryAfterMs', () => {
+  it('uses a shortened window and admits a probe after retryAfterMs', () => {
+    const clock = makeClock(0);
+    const breaker = new LlmCircuitBreaker({ openMs: 15 * 60 * 1000, now: clock.now });
+    // 60s retry-after → window shortened to 60s (within [30s, 15min]).
+    breaker.onRateLimited('429', 60_000);
+    expect(breaker.status().state).toBe('open');
+
+    // Refuses during the window.
+    clock.advance(59_000);
+    expect(breaker.acquire().allow).toBe(false);
+
+    // Admits a probe exactly after retryAfterMs (60s), NOT the full 15min.
+    clock.advance(1_000);
+    const gate = breaker.acquire();
+    expect(gate.allow).toBe(true);
+    expect(gate.probe).toBe(true);
+  });
+
+  it('floors the window to min(30s, openMs) for a tiny retry-after', () => {
+    const clock = makeClock(0);
+    const breaker = new LlmCircuitBreaker({ openMs: 15 * 60 * 1000, now: clock.now });
+    breaker.onRateLimited('429', 5_000); // floored to 30s
+    clock.advance(29_000);
+    expect(breaker.acquire().allow).toBe(false);
+    clock.advance(1_000);
+    expect(breaker.acquire().allow).toBe(true);
+  });
+
+  it('falls back to the flat default window without retryAfterMs', () => {
+    const clock = makeClock(0);
+    const breaker = new LlmCircuitBreaker({ openMs: 1000, now: clock.now });
+    breaker.onRateLimited('429');
+    clock.advance(999);
+    expect(breaker.acquire().allow).toBe(false);
+    clock.advance(1);
+    expect(breaker.acquire().allow).toBe(true);
+  });
+
+  it('resets the per-trip window on a clean close (onResolved)', () => {
+    const clock = makeClock(0);
+    const breaker = new LlmCircuitBreaker({ openMs: 15 * 60 * 1000, now: clock.now });
+    breaker.onRateLimited('429', 60_000); // shorten to 60s
+    clock.advance(60_000);
+    breaker.acquire(); // half-open probe
+    breaker.onResolved(); // close + reset currentOpenMs to openMs
+    // Next trip with no hint must use the full default window again.
+    breaker.onRateLimited('429');
+    clock.advance(14 * 60 * 1000);
+    expect(breaker.acquire().allow).toBe(false); // still inside 15min
+    clock.advance(60 * 1000);
+    expect(breaker.acquire().allow).toBe(true);
+  });
+});
+
+describe('LlmCircuitBreaker.acquireOrWait', () => {
+  it('returns allow immediately when closed (no sleep)', async () => {
+    const clock = makeClock(0);
+    const breaker = new LlmCircuitBreaker({ now: clock.now, sleep: clock.sleep });
+    const gate = await breaker.acquireOrWait(10_000);
+    expect(gate.allow).toBe(true);
+    expect(clock.sleepCalls.length).toBe(0);
+  });
+
+  it('returns allow immediately when disabled (passthrough, no sleep)', async () => {
+    const clock = makeClock(0);
+    const breaker = new LlmCircuitBreaker({ enabled: false, now: clock.now, sleep: clock.sleep });
+    breaker.onRateLimited('429'); // no-op when disabled
+    const gate = await breaker.acquireOrWait(10_000);
+    expect(gate.allow).toBe(true);
+    expect(clock.sleepCalls.length).toBe(0);
+  });
+
+  it('waits ~window then returns allow:true when it becomes available in time', async () => {
+    const clock = makeClock(0);
+    const breaker = new LlmCircuitBreaker({ openMs: 5_000, now: clock.now, sleep: clock.sleep });
+    breaker.onRateLimited('429'); // open for 5s
+    const gate = await breaker.acquireOrWait(10_000);
+    expect(gate.allow).toBe(true);
+    expect(gate.probe).toBe(true); // it became the half-open probe
+    expect(clock.totalSlept).toBeGreaterThanOrEqual(5_000);
+    expect(clock.totalSlept).toBeLessThan(10_000);
+  });
+
+  it('returns allow:false at the deadline when window is longer than maxWait', async () => {
+    const clock = makeClock(0);
+    const breaker = new LlmCircuitBreaker({ openMs: 60_000, now: clock.now, sleep: clock.sleep });
+    breaker.onRateLimited('429'); // open for 60s
+    const start = clock.now();
+    const gate = await breaker.acquireOrWait(5_000); // willing to wait only 5s
+    expect(gate.allow).toBe(false);
+    // Bounded: total elapsed must not exceed maxWait.
+    expect(clock.now() - start).toBeLessThanOrEqual(5_000);
+  });
+
+  it('admits exactly one probe under a concurrent herd; the loser polls until close', async () => {
+    const clock = makeClock(0);
+    const breaker = new LlmCircuitBreaker({
+      openMs: 1_000,
+      probePollMs: 100,
+      now: clock.now,
+      sleep: clock.sleep,
+    });
+    breaker.onRateLimited('429'); // open for 1s
+
+    let probeCount = 0;
+    const p1 = breaker.acquireOrWait(10_000);
+    const p2 = breaker.acquireOrWait(10_000);
+
+    // Drive the breaker: once a half-open probe is admitted, resolve it so the
+    // loser can re-acquire on a closed breaker. Counts probes admitted.
+    let guard = 0;
+    while (breaker.status().state !== 'closed' && guard < 1000) {
+      await Promise.resolve();
+      if (breaker.status().state === 'half-open' && probeCount === 0) {
+        probeCount++;
+        breaker.onResolved();
+      }
+      guard++;
+    }
+
+    const [g1, g2] = await Promise.all([p1, p2]);
+
+    // Exactly one probe was admitted to the provider.
+    expect(probeCount).toBe(1);
+    // Both eventually proceed.
+    expect(g1.allow).toBe(true);
+    expect(g2.allow).toBe(true);
+    // One was the probe (probe:true), the other acquired on the now-closed
+    // breaker (probe:false).
+    const probeFlags = [g1.probe, g2.probe].sort();
+    expect(probeFlags).toEqual([false, true]);
+  });
+
+  it('loser keeps waiting until its bounded deadline if the probe reopens the breaker', async () => {
+    const clock = makeClock(0);
+    const breaker = new LlmCircuitBreaker({
+      openMs: 1_000,
+      probePollMs: 100,
+      now: clock.now,
+      sleep: clock.sleep,
+    });
+    breaker.onRateLimited('429');
+
+    // First caller becomes the probe.
+    const winner = await breaker.acquireOrWait(10_000);
+    expect(winner.allow).toBe(true);
+    expect(winner.probe).toBe(true);
+
+    // Probe fails as a rate-limit → reopens. A short-deadline waiter gives up.
+    breaker.onRateLimited('429'); // reopen for another 1s
+    const loser = await breaker.acquireOrWait(500);
+    expect(loser.allow).toBe(false);
+  });
+});
+
+describe('CircuitBreakingIntelligenceProvider rate-limit wait policy', () => {
+  function openBreaker() {
+    const clock = makeClock(0);
+    const breaker = new LlmCircuitBreaker({ openMs: 60_000, now: clock.now, sleep: clock.sleep });
+    breaker.onRateLimited('429'); // open for 60s
+    return { clock, breaker };
+  }
+
+  it('throws immediately when no rateLimitWaitMs is set (best-effort, no wait)', async () => {
+    const { breaker, clock } = openBreaker();
+    const provider = new FakeProvider();
+    const cb = new CBProvider(provider, breaker);
+    await expect(cb.evaluate('hi')).rejects.toThrow(LlmCircuitOpenError);
+    expect(provider.calls).toBe(0);
+    expect(clock.sleepCalls.length).toBe(0); // no wait
+  });
+
+  it('waits (bounded) and proceeds when rateLimitWaitMs >= window', async () => {
+    const { breaker } = openBreaker();
+    const provider = new FakeProvider();
+    const cb = new CBProvider(provider, breaker);
+    // Window 60s; willing to wait 120s → acquires the probe and calls.
+    const res = await cb.evaluate('hi', { rateLimitWaitMs: 120_000 });
+    expect(res).toBe('ok');
+    expect(provider.calls).toBe(1);
+  });
+
+  it('still throws when rateLimitWaitMs is shorter than the window', async () => {
+    const { breaker } = openBreaker();
+    const provider = new FakeProvider();
+    const cb = new CBProvider(provider, breaker);
+    await expect(cb.evaluate('hi', { rateLimitWaitMs: 5_000 })).rejects.toThrow(
+      LlmCircuitOpenError,
+    );
+    expect(provider.calls).toBe(0);
+  });
+
+  it('passes the parsed retryAfterMs through to onRateLimited on a fresh limit', async () => {
+    const clock = makeClock(0);
+    const breaker = new LlmCircuitBreaker({
+      openMs: 15 * 60 * 1000,
+      now: clock.now,
+      sleep: clock.sleep,
+    });
+    const provider = new FakeProvider();
+    provider.shouldThrow = new Error('Claude CLI error: rate limit retry-after: 45');
+    const cb = new CBProvider(provider, breaker);
+    await expect(cb.evaluate('hi')).rejects.toThrow(RateLimitError);
+    // Window should be shortened to 45s, not the full 15min.
+    clock.advance(44_000);
+    expect(breaker.acquire().allow).toBe(false);
+    clock.advance(1_000);
+    expect(breaker.acquire().allow).toBe(true);
+  });
+
+  it('is byte-identical for non-rate-limit errors (closes breaker, rethrows original)', async () => {
+    const clock = makeClock(0);
+    const breaker = new LlmCircuitBreaker({ openMs: 60_000, now: clock.now, sleep: clock.sleep });
+    const provider = new FakeProvider();
+    const original = new Error('some parse error');
+    provider.shouldThrow = original;
+    const cb = new CBProvider(provider, breaker);
+    await expect(cb.evaluate('hi')).rejects.toBe(original);
+    expect(breaker.status().state).toBe('closed');
+  });
+});
+
+describe('module exports', () => {
+  it('classifyRateLimit and CircuitBreakingIntelligenceProvider resolve', () => {
+    expect(typeof classifyRateLimit).toBe('function');
+    expect(typeof CBProvider).toBe('function');
+  });
+});

--- a/upgrades/NEXT.md
+++ b/upgrades/NEXT.md
@@ -1,0 +1,68 @@
+# Upgrade Guide — vNEXT
+
+<!-- assembled-by: assemble-next-md -->
+<!-- bump: patch -->
+
+## What Changed
+
+**Coherence-critical safety checks no longer switch off under rate-limit
+pressure.** Every server-side LLM call shares one circuit breaker; when the
+account is rate-limited it opens for ~15 min and refuses all calls. Until now,
+each guard's fallback was to *fail open* — skip its check and allow the action.
+So at exactly the moment the system is busiest, the outbound-message gate, the
+stop-authority gate, and the high-stakes coherence reviewers all stopped
+guarding (the logs literally showed `Stop event allowed without authority
+ruling … fail-open` and `message review failed … fail open`).
+
+Now a small set of coherence-critical guards WAIT (bounded) for the rate-limit
+window to clear and then get a real answer — "slower but coherent" — instead of
+waving things through. Best-effort/observability checks (the high-volume callers
+that trip the breaker) keep failing open so they shed load and let it recover.
+The breaker also reads a retry-after hint from the provider error when present
+and shortens its window accordingly (falling back to the flat window otherwise —
+true HTTP headers are invisible because LLM calls go through a CLI subprocess).
+
+## What to Tell Your User
+
+Nothing to configure. Under heavy rate-limit pressure, a few safety-critical
+checks (the outbound-message review, the "is this stop justified" ruling, the
+high-stakes coherence reviewers) may now take a little longer instead of being
+skipped — so the agent stays coherent and doesn't leak or wave through bad
+actions exactly when the system is most loaded. Everything else is unchanged.
+
+## Summary of New Capabilities
+
+- `LlmCircuitBreaker.acquireOrWait(maxWaitMs)` — bounded wait-and-retry that
+  serializes waiters behind the single half-open probe (no thundering herd).
+- `classifyRateLimit(message)` — superset of `isRateLimitError` that also
+  best-effort parses a retry-after hint; the breaker shortens its open window to
+  the hint (clamped), else uses the flat default.
+- `IntelligenceOptions.rateLimitWaitMs` — opt-in per-callsite policy; set on
+  MessagingToneGate (120s), CoherenceGate high-stakes reviewers (60s), and
+  UnjustifiedStopGate (8s). Unset = instant fail-open (unchanged).
+
+## Evidence
+
+**Reproduction (live, server.log, 2026-05-31):** LLM circuit breaker tripped 18×
+in one day; trips #15–#18 fired 20:34–21:59Z. During those open windows:
+`[InputGuard] DEGRADATION: LLM review failed: LLM circuit breaker open … fail-open`,
+and `Stop event allowed without authority ruling (drift correction not applied).
+Using fail-open → allow`. So coherence-critical guards were being skipped under
+exactly the load that should make them most careful.
+
+**Before/after behavior:**
+- Before: breaker open → guard's `provider.evaluate()` throws `LlmCircuitOpenError`
+  synchronously → guard fails open (skips its check), every time.
+- After: a guard that sets `rateLimitWaitMs` awaits `acquireOrWait(maxWaitMs)` —
+  it proceeds with a real ruling if the window clears within the bound, and only
+  falls back if the bound elapses. A guard that does NOT set it is byte-identical
+  to before (instant throw).
+
+**Tests:** `tests/unit/llm-circuit-breaker-wait.test.ts` — 27 tests, injected
+fake clock + clock-advancing sleep (deterministic, no real waiting). Covers
+classifyRateLimit parsing, per-trip window shortening + clamp, acquireOrWait
+(immediate/closes-in-time/deadline-fallback/herd-serialization), and the
+provider opt-in (no-policy instant throw with zero sleeps + inner provider never
+called; with-policy waits and proceeds; parsed retry-after threaded through).
+Affected-suite regression: 191/191 across the 8 touched test files. tsc clean
+(0 errors in changed files).

--- a/upgrades/side-effects/llm-ratelimit-bounded-wait.md
+++ b/upgrades/side-effects/llm-ratelimit-bounded-wait.md
@@ -1,0 +1,46 @@
+# Side effects — coherence-critical LLM rate-limit bounded wait
+
+## What changes at runtime
+
+When the shared LLM circuit breaker is open (account rate-limited), a small set
+of coherence-critical guards now WAIT (bounded) for the window to clear before
+falling back, instead of instantly failing open. Everything else is unchanged.
+
+## Who is affected
+
+- **Callers that do NOT set `rateLimitWaitMs`** (the vast majority — every
+  best-effort/observability LLM consumer): **zero behavior change.** When the
+  breaker is open they still throw `LlmCircuitOpenError` immediately and run
+  their existing fail-open fallback. Proven by a dedicated test (instant throw,
+  zero sleeps, inner provider never called).
+- **MessagingToneGate** (outbound gate): when rate-limited, waits up to 120s for
+  the window, then falls back to its current pass-through. Net effect: under rate
+  limit, an outbound message may be delayed up to 2 min to be properly reviewed,
+  rather than sent unreviewed.
+- **UnjustifiedStopGate**: waits up to 8s (short — it's on the Stop critical
+  path), then its existing fail-open behavior. A stop may be delayed up to 8s
+  under rate limit.
+- **CoherenceGate high-stakes reviewers** (value-alignment, claim-provenance,
+  capability-accuracy, information-leakage): wait up to 60s. Other reviewers
+  unchanged (instant fail-open).
+
+## Blast radius
+
+- 7 files, all in `src/core/`. No config keys, no new env, no migration (the
+  change is compiled source, not an agent-installed file/hook/skill).
+- The breaker remains a single process-global singleton; no new global state
+  beyond a per-trip window length field.
+- `isRateLimitError` detection is byte-identical (reimplemented as
+  `classifyRateLimit(m).isLimit`).
+
+## Failure modes considered
+
+- **Latency under rate limit:** bounded by `maxWaitMs` per callsite; the
+  Stop-path wait is deliberately small (8s). A wait can never hang indefinitely.
+- **Thundering herd on window-close:** `acquireOrWait` re-consults `acquire()`
+  so waiters serialize behind the single half-open probe; exactly one call
+  probes the provider on recovery.
+- **Retry-after parse error:** parsed values are clamped to [1s, 15min]; any
+  unparseable/absurd value falls back to the flat 15-min default window.
+- **Load shedding preserved:** best-effort high-volume callers keep failing open,
+  so they don't consume the scarce probe slot or re-trip the breaker.


### PR DESCRIPTION
## What

**Coherence-critical safety checks no longer switch off under rate-limit pressure.** Every server-side LLM call shares one circuit breaker; when the account is rate-limited it opens ~15 min and refuses all calls, and each guard's fallback was to **fail open** — skip its check and allow the action. So at exactly the moment the system is busiest, the outbound-message gate, the stop-authority gate, and the high-stakes coherence reviewers all stopped guarding.

Observed live (server.log, 2026-05-31): breaker tripped 18× in one day; trips #15–#18 fired 20:34–21:59Z, with `[InputGuard] DEGRADATION: LLM review failed … fail-open` and `Stop event allowed without authority ruling (drift correction not applied). Using fail-open → allow`.

Owner directive (Justin, topic 13481): coherence-critical calls should prefer **wait-and-retry** over fail-open — "slower but coherent" — while best-effort calls keep failing open to shed load.

## Fix (additive — byte-identical for callers that don't opt in)

- `classifyRateLimit(message)` — superset of `isRateLimitError` (now reimplemented as `classifyRateLimit(m).isLimit`) that also best-effort parses a retry-after hint. True HTTP headers are invisible (LLM calls go through a `claude -p` subprocess), so it parses the error string and clamps to [1s, 15min], else undefined.
- `onRateLimited(reason, retryAfterMs?)` — shortens **this trip's** open window to the hint, clamped `[min(30s, openMs), openMs]`; flat default without a hint.
- `acquireOrWait(maxWaitMs)` — bounded wait-and-retry that **serializes waiters behind the single half-open probe** (no thundering herd on recovery); injectable clock + sleep.
- `IntelligenceOptions.rateLimitWaitMs` — opt-in per-callsite policy. Provider awaits `acquireOrWait` when set; **instant throw (unchanged) when unset.**
- Wired: MessagingToneGate (120s), CoherenceGate high-stakes reviewers (60s: value-alignment, claim-provenance, capability-accuracy, information-leakage), UnjustifiedStopGate (8s — short, it's on the Stop critical path). All other callsites omit it → instant fail-open, unchanged, so they shed load and let the breaker recover.

## Tests / evidence

`tests/unit/llm-circuit-breaker-wait.test.ts` — 27 tests, injected fake clock + clock-advancing sleep (deterministic, no real waiting): classifyRateLimit parsing, per-trip window shortening + clamp, acquireOrWait (immediate / closes-in-time / deadline-fallback / herd-serialization), provider opt-in (no-policy → instant throw, zero sleeps, inner provider never called; with-policy → waits and proceeds; shorter-than-window → still throws; parsed retry-after threaded to onRateLimited). Affected-suite regression: **191/191** across the 8 touched test files. `tsc` clean (0 errors in changed files).

## Spec / approval

Spec `docs/specs/llm-ratelimit-bounded-wait.md` self-approved under the delegated deploy mandate; Justin explicitly greenlit on topic 13481 ("Yes, please let's proceed in the proper robust process to fix all of this correctly"). ELI16 sibling + side-effects artifact + ship-gate trace included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
