### PR TITLE
feat(metrics): funnel tap — record per-feature LLM metrics (Phase 1b)

### DIFF
--- a/src/core/CircuitBreakingIntelligenceProvider.ts
+++ b/src/core/CircuitBreakingIntelligenceProvider.ts
@@ -33,13 +33,68 @@ import {
   classifyRateLimit,
 } from './LlmCircuitBreaker.js';
 
+/**
+ * Minimal structural recorder the funnel writes per-call metrics to. Kept as a
+ * local interface (not an import of FeatureMetricsLedger) so core/ never depends
+ * on monitoring/ — the concrete ledger is injected at runtime via
+ * setFeatureMetricsRecorder(). FeatureMetricsLedger.record() satisfies this.
+ */
+export interface FeatureMetricsRecorder {
+  record(entry: {
+    feature: string;
+    kind?: 'llm' | 'event';
+    outcome: 'fired' | 'noop' | 'error';
+    latencyMs?: number;
+    waited?: boolean;
+    waitMs?: number;
+  }): void;
+}
+
+// Module-level recorder — set once by AgentServer at startup. Every wrapped
+// provider reads it, so a single injection point instruments ALL LLM features
+// (the same single-funnel pattern the breaker itself uses). Null = no recording
+// (e.g. CLI commands without a server), which is a clean no-op.
+let _featureMetricsRecorder: FeatureMetricsRecorder | null = null;
+export function setFeatureMetricsRecorder(recorder: FeatureMetricsRecorder | null): void {
+  _featureMetricsRecorder = recorder;
+}
+export function getFeatureMetricsRecorder(): FeatureMetricsRecorder | null {
+  return _featureMetricsRecorder;
+}
+
 export class CircuitBreakingIntelligenceProvider implements IntelligenceProvider {
   constructor(
     private readonly inner: IntelligenceProvider,
     private readonly breaker: LlmCircuitBreaker = getLlmCircuitBreaker(),
   ) {}
 
+  /**
+   * Record one funnel call to the per-feature metrics ledger (Phase 1b). Pure
+   * side-channel: it MUST never throw into the LLM path (observability must not
+   * break what it observes — the Close the Loop principle applied to itself).
+   * outcome here is funnel-level: 'noop' = the call completed (the fired-vs-noop
+   * VERDICT is the caller's interpretation → Phase 2); 'error' = it failed.
+   */
+  private recordMetric(
+    feature: string,
+    outcome: 'noop' | 'error',
+    latencyMs: number,
+    waited: boolean,
+    waitMs: number | undefined,
+  ): void {
+    const rec = _featureMetricsRecorder;
+    if (!rec) return;
+    try {
+      rec.record({ feature, kind: 'llm', outcome, latencyMs, waited, waitMs: waited ? waitMs : undefined });
+    } catch {
+      /* never break the LLM path on a metrics write */
+    }
+  }
+
   async evaluate(prompt: string, options?: IntelligenceOptions): Promise<string> {
+    const feature = options?.attribution?.component ?? 'unlabeled';
+    const startedAt = Date.now();
+    let waited = false;
     let gate = this.breaker.acquire();
     if (!gate.allow) {
       // Coherence-critical callers set rateLimitWaitMs: wait (bounded) for the
@@ -47,9 +102,14 @@ export class CircuitBreakingIntelligenceProvider implements IntelligenceProvider
       // omit it — behavior is byte-identical to the instant throw below.
       const waitMs = options?.rateLimitWaitMs;
       if (typeof waitMs === 'number' && waitMs > 0) {
+        waited = true;
         gate = await this.breaker.acquireOrWait(waitMs);
       }
       if (!gate.allow) {
+        // Circuit open, no LLM call ran (no cost) — but the throttle itself is a
+        // signal worth measuring per feature (how often a gate hits the open
+        // window). Recorded as a no-op; `waited` marks whether a bounded wait was engaged.
+        this.recordMetric(feature, 'noop', Date.now() - startedAt, waited, options?.rateLimitWaitMs);
         throw new LlmCircuitOpenError(gate.retryAfterMs);
       }
     }
@@ -57,10 +117,12 @@ export class CircuitBreakingIntelligenceProvider implements IntelligenceProvider
     try {
       const result = await this.inner.evaluate(prompt, options);
       this.breaker.onResolved();
+      this.recordMetric(feature, 'noop', Date.now() - startedAt, waited, options?.rateLimitWaitMs);
       return result;
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
       const parsed = classifyRateLimit(message);
+      this.recordMetric(feature, 'error', Date.now() - startedAt, waited, options?.rateLimitWaitMs);
       if (err instanceof RateLimitError || parsed.isLimit) {
         // Pass the parsed retry-after hint through so the breaker can shorten
         // the open window when the provider told us when it resets.

--- a/src/server/AgentServer.ts
+++ b/src/server/AgentServer.ts
@@ -63,6 +63,7 @@ import { DeliveryFailureSentinel } from '../monitoring/delivery-failure-sentinel
 import os from 'node:os';
 import { TokenLedger } from '../monitoring/TokenLedger.js';
 import { FeatureMetricsLedger } from '../monitoring/FeatureMetricsLedger.js';
+import { setFeatureMetricsRecorder } from '../core/CircuitBreakingIntelligenceProvider.js';
 import { TokenLedgerPoller } from '../monitoring/TokenLedgerPoller.js';
 import { FrameworkIssueLedger } from '../monitoring/FrameworkIssueLedger.js';
 import { MentorOnboardingRunner, DEFAULT_MENTOR_CONFIG, resolveMentorDeliveryTopic, type MentorConfig } from '../scheduler/MentorOnboardingRunner.js';
@@ -629,8 +630,9 @@ export class AgentServer {
     // sentinel's cost + hit-rate (docs/specs/llm-feature-metrics-spec.md). Own
     // try/catch, independent of the other ledgers (same cascade-isolation as
     // FrameworkIssueLedger). Phase 1a: this store + the /metrics/features route.
-    // The single funnel tap that feeds it (CircuitBreakingIntelligenceProvider →
-    // record()) lands in Phase 1b, on top of #638's hardened funnel.
+    // Phase 1b: the funnel tap — setFeatureMetricsRecorder() registers this
+    // ledger as the module-level recorder every CircuitBreakingIntelligenceProvider
+    // reads, so the single funnel writes per-feature metrics for ALL LLM systems.
     if (options.config.stateDir) {
       try {
         const serverDataDir = path.join(options.config.stateDir, 'server-data');
@@ -638,6 +640,9 @@ export class AgentServer {
         this.featureMetricsLedger = new FeatureMetricsLedger({
           dbPath: path.join(serverDataDir, 'feature-metrics.db'),
         });
+        // Phase 1b: wire the funnel → ledger. One injection point covers every
+        // wrapped provider (current and future). Null-safe; no-op if it failed above.
+        setFeatureMetricsRecorder(this.featureMetricsLedger);
       } catch (err) {
         console.warn('[instar] feature-metrics-ledger init failed (non-fatal):', err);
         this.featureMetricsLedger = null;

--- a/tests/unit/CircuitBreaking-feature-metrics-tap.test.ts
+++ b/tests/unit/CircuitBreaking-feature-metrics-tap.test.ts
@@ -1,0 +1,127 @@
+/**
+ * Phase 1b: verifies the CircuitBreakingIntelligenceProvider funnel tap records
+ * per-feature metrics to the injected recorder — for success, error, the
+ * circuit-open skip, and the rate-limit wait path — and is a safe no-op with no
+ * recorder. Spec: docs/specs/llm-feature-metrics-spec.md.
+ */
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import {
+  CircuitBreakingIntelligenceProvider,
+  setFeatureMetricsRecorder,
+  type FeatureMetricsRecorder,
+} from '../../src/core/CircuitBreakingIntelligenceProvider.js';
+import { LlmCircuitOpenError } from '../../src/core/LlmCircuitBreaker.js';
+import { FeatureMetricsLedger } from '../../src/monitoring/FeatureMetricsLedger.js';
+import type { IntelligenceProvider } from '../../src/core/types.js';
+
+function fakeBreaker(opts: {
+  allow?: boolean;
+  waitAllow?: boolean;
+} = {}): any {
+  return {
+    acquire: () => ({ allow: opts.allow ?? true, retryAfterMs: 1000 }),
+    acquireOrWait: vi.fn(async () => ({ allow: opts.waitAllow ?? true, retryAfterMs: 1000 })),
+    onResolved: vi.fn(),
+    onRateLimited: vi.fn(),
+  };
+}
+
+const recorded: Array<Record<string, unknown>> = [];
+const recorder: FeatureMetricsRecorder = { record: (e) => { recorded.push(e as Record<string, unknown>); } };
+
+afterEach(() => {
+  setFeatureMetricsRecorder(null);
+  recorded.length = 0;
+  vi.restoreAllMocks();
+});
+
+describe('CircuitBreakingIntelligenceProvider — feature metrics tap (Phase 1b)', () => {
+  it('records a success as outcome=noop with the feature label + latency', async () => {
+    setFeatureMetricsRecorder(recorder);
+    const inner: IntelligenceProvider = { evaluate: async () => 'ok' };
+    const p = new CircuitBreakingIntelligenceProvider(inner, fakeBreaker());
+
+    const res = await p.evaluate('judge this', { attribution: { component: 'MessagingToneGate' } });
+
+    expect(res).toBe('ok');
+    expect(recorded.length).toBe(1);
+    expect(recorded[0]).toMatchObject({ feature: 'MessagingToneGate', kind: 'llm', outcome: 'noop', waited: false });
+    expect(typeof recorded[0].latencyMs).toBe('number');
+  });
+
+  it('buckets calls with no attribution under "unlabeled"', async () => {
+    setFeatureMetricsRecorder(recorder);
+    const inner: IntelligenceProvider = { evaluate: async () => 'ok' };
+    const p = new CircuitBreakingIntelligenceProvider(inner, fakeBreaker());
+    await p.evaluate('x');
+    expect(recorded[0].feature).toBe('unlabeled');
+  });
+
+  it('records a failure as outcome=error and still rethrows', async () => {
+    setFeatureMetricsRecorder(recorder);
+    const inner: IntelligenceProvider = { evaluate: async () => { throw new Error('boom'); } };
+    const p = new CircuitBreakingIntelligenceProvider(inner, fakeBreaker());
+
+    await expect(p.evaluate('x', { attribution: { component: 'CoherenceReviewer' } })).rejects.toThrow('boom');
+    expect(recorded.length).toBe(1);
+    expect(recorded[0]).toMatchObject({ feature: 'CoherenceReviewer', outcome: 'error' });
+  });
+
+  it('records the rate-limit wait path with waited=true + waitMs', async () => {
+    setFeatureMetricsRecorder(recorder);
+    const inner: IntelligenceProvider = { evaluate: async () => 'ok' };
+    // circuit initially closed, but the wait path clears it.
+    const p = new CircuitBreakingIntelligenceProvider(inner, fakeBreaker({ allow: false, waitAllow: true }));
+
+    const res = await p.evaluate('x', { attribution: { component: 'CoherenceGate' }, rateLimitWaitMs: 500 } as any);
+
+    expect(res).toBe('ok');
+    expect(recorded[0]).toMatchObject({ feature: 'CoherenceGate', outcome: 'noop', waited: true, waitMs: 500 });
+  });
+
+  it('records the circuit-open skip as a no-op (waited) and throws LlmCircuitOpenError', async () => {
+    setFeatureMetricsRecorder(recorder);
+    const inner: IntelligenceProvider = { evaluate: vi.fn(async () => 'should-not-run') };
+    const p = new CircuitBreakingIntelligenceProvider(inner, fakeBreaker({ allow: false, waitAllow: false }));
+
+    await expect(p.evaluate('x', { attribution: { component: 'X' }, rateLimitWaitMs: 200 } as any)).rejects.toBeInstanceOf(LlmCircuitOpenError);
+    expect(inner.evaluate).not.toHaveBeenCalled();
+    expect(recorded[0]).toMatchObject({ feature: 'X', outcome: 'noop', waited: true });
+  });
+
+  it('is a safe no-op when no recorder is set (and never breaks the call)', async () => {
+    setFeatureMetricsRecorder(null);
+    const inner: IntelligenceProvider = { evaluate: async () => 'ok' };
+    const p = new CircuitBreakingIntelligenceProvider(inner, fakeBreaker());
+    await expect(p.evaluate('x')).resolves.toBe('ok');
+    expect(recorded.length).toBe(0);
+  });
+
+  it('a throwing recorder never breaks the LLM path', async () => {
+    setFeatureMetricsRecorder({ record: () => { throw new Error('ledger down'); } });
+    const inner: IntelligenceProvider = { evaluate: async () => 'ok' };
+    const p = new CircuitBreakingIntelligenceProvider(inner, fakeBreaker());
+    await expect(p.evaluate('x')).resolves.toBe('ok');
+  });
+
+  it('feeds the REAL FeatureMetricsLedger end-to-end (funnel → ledger → queryable rollup)', async () => {
+    const ledger = new FeatureMetricsLedger({ dbPath: ':memory:' });
+    try {
+      setFeatureMetricsRecorder(ledger); // FeatureMetricsLedger structurally satisfies FeatureMetricsRecorder
+      const ok: IntelligenceProvider = { evaluate: async () => 'ok' };
+      const bad: IntelligenceProvider = { evaluate: async () => { throw new Error('boom'); } };
+
+      await new CircuitBreakingIntelligenceProvider(ok, fakeBreaker()).evaluate('a', { attribution: { component: 'ToneGate' } });
+      await new CircuitBreakingIntelligenceProvider(ok, fakeBreaker()).evaluate('b', { attribution: { component: 'ToneGate' } });
+      await expect(new CircuitBreakingIntelligenceProvider(bad, fakeBreaker()).evaluate('c', { attribution: { component: 'ToneGate' } })).rejects.toThrow();
+
+      const tone = ledger.byFeature().find(f => f.feature === 'ToneGate')!;
+      expect(tone.calls).toBe(3);
+      expect(tone.llmCalls).toBe(3);
+      expect(tone.errors).toBe(1);
+      expect(tone.noop).toBe(2);
+    } finally {
+      ledger.close();
+    }
+  });
+});

--- a/upgrades/next/llm-feature-metrics-phase1b.md
+++ b/upgrades/next/llm-feature-metrics-phase1b.md
@@ -1,0 +1,36 @@
+# Upgrade Guide — vNEXT
+
+<!-- bump: patch -->
+
+## What Changed
+
+The per-feature LLM metrics now actually collect data. Phase 1a added the ledger
++ `GET /metrics/features`; **Phase 1b adds the funnel tap** — the one shared LLM
+call (`CircuitBreakingIntelligenceProvider.evaluate`) now records, per gate/
+sentinel, its latency, whether it had to wait out a rate-limit window, and
+success/error. So `/metrics/features` goes from empty to live as your checks run.
+
+It's pure observability: a single side-channel `record()` per call, in a
+swallow-all try/catch, with the breaker/rate-limit control flow byte-identical.
+No gate changes behavior.
+
+## What to Tell Your User
+
+Nothing required. If asked: `GET /metrics/features` now shows real per-check cost
+(latency), how often each check runs, and how often it hits a rate-limit wait —
+the data that lets us tune the checks with evidence.
+
+## Summary of New Capabilities
+
+- `CircuitBreakingIntelligenceProvider` instruments every LLM call into the
+  `FeatureMetricsLedger` via a module-level recorder (`setFeatureMetricsRecorder`),
+  wired once in the server so it covers all current and future LLM features.
+- Per-feature data: call-count, latency (p50/p95), rate-limit wait-rate, error-rate.
+  (Fired-vs-noop verdict + token attribution are Phase 2.)
+
+## Evidence
+
+- Spec: `docs/specs/llm-feature-metrics-spec.md` (Phase 1b; approved Telegram 13435).
+- Tests: `tests/unit/CircuitBreaking-feature-metrics-tap.test.ts` (+8, incl. an
+  end-to-end feed into a real ledger); all 74 existing CircuitBreaking/breaker tests
+  pass unchanged; `npm run lint` clean.

--- a/upgrades/side-effects/llm-feature-metrics-phase1b.md
+++ b/upgrades/side-effects/llm-feature-metrics-phase1b.md
@@ -1,0 +1,83 @@
+# Side-Effects Review — Per-feature LLM metrics, Phase 1b (the funnel tap)
+
+**Slug:** `llm-feature-metrics-phase1b`
+**Date:** 2026-06-01
+**Author:** echo
+**Spec:** `docs/specs/llm-feature-metrics-spec.md` (Phase 1b; approved by Justin, Telegram 13435)
+
+## Summary of the change
+
+Phase 1a (#639) shipped the `FeatureMetricsLedger` + `/metrics/features` but nothing
+wrote to it in production. Phase 1b adds the **funnel tap**: the one shared
+`CircuitBreakingIntelligenceProvider.evaluate()` now records, per call, the calling
+feature + latency + whether a rate-limit bounded-wait was engaged + success/error —
+so every LLM-driven gate/sentinel is measured through a single instrumentation point
+(built on top of #638's now-merged `evaluate()`, measuring its wait-behavior).
+
+**Files changed (source):**
+- `src/core/CircuitBreakingIntelligenceProvider.ts`:
+  - new `FeatureMetricsRecorder` **interface** (kept local so core/ never imports
+    monitoring/ — no dependency cycle) + module-level recorder + `setFeatureMetricsRecorder()` /
+    `getFeatureMetricsRecorder()`.
+  - `evaluate()` records on all three exits — success (`noop`), inner failure (`error`),
+    and the circuit-open skip (`noop`, marking `waited`) — via a private `recordMetric()`
+    that **swallows all errors** (observability must never break the LLM path).
+- `src/server/AgentServer.ts`: after constructing the `FeatureMetricsLedger`, call
+  `setFeatureMetricsRecorder(this.featureMetricsLedger)` once — a single injection point
+  that instruments every wrapped provider (current and future).
+
+**Files changed (tests):**
+- `tests/unit/CircuitBreaking-feature-metrics-tap.test.ts` — +8: success→noop, unlabeled
+  bucketing, failure→error+rethrow, the rate-limit wait path (`waited`+`waitMs`), the
+  circuit-open skip (no inner call, throws `LlmCircuitOpenError`), safe no-op with no
+  recorder, a throwing recorder never breaks the call, and an **end-to-end** test feeding
+  a real `FeatureMetricsLedger` and asserting the queryable rollup.
+
+## Blast radius
+
+The hot LLM path gains one side-channel `record()` call per `evaluate()`. It is fully
+isolated: `recordMetric()` is in a try/catch that swallows everything, and a null
+recorder (CLI / no server) is a clean no-op. The breaker/rate-limit control flow is
+**byte-identical** to before — all 74 existing CircuitBreaking + breaker-wait tests pass
+unchanged. No route, config, or behavior of any gate changes.
+
+## Behavior delta
+
+| Scenario | Before (1a) | After (1b) |
+|---|---|---|
+| an LLM gate calls `evaluate()` | nothing recorded | one per-feature row (latency, waited, success/error) |
+| `/metrics/features` | alive but empty | populated as gates run |
+| rate-limit bounded wait (#638) | invisible | recorded (`waited`/`waitMs`) |
+| no recorder set (CLI) | n/a | no-op (no record) |
+| metrics write throws | n/a | swallowed; LLM call unaffected |
+| breaker / rate-limit control flow | as-is | **unchanged** (byte-identical) |
+
+## Outcome semantics (honest scoping)
+
+At the funnel, `outcome` is `noop` for a completed call and `error` for a failure — the
+**fired-vs-noop verdict** is the *caller's* interpretation of the result string, not
+visible here, and **tokens** live in TokenLedger (the provider returns a string). So
+Phase 1b delivers per-feature **call-count, latency (p50/p95), wait-rate, error-rate**;
+the verdict + token-join are **Phase 2** (caller-side `recordEvent` / TokenLedger
+attribution join). This is stated in the spec and the metric is labeled accordingly.
+
+## Risks considered
+
+- **Dependency cycle (core→monitoring)?** Avoided — the provider depends only on a local
+  `FeatureMetricsRecorder` interface; the concrete ledger is injected at runtime.
+- **Hot-path safety?** `recordMetric` swallows all errors; an end-to-end + a throwing-recorder
+  test prove the LLM path is never broken.
+- **Coverage of all providers?** The module-level recorder is read by every
+  `CircuitBreakingIntelligenceProvider` instance (all created via the same wrap), so one
+  `setFeatureMetricsRecorder()` covers all current and future LLM features — no per-call-site wiring.
+
+## Migration parity
+
+None needed — no agent-installed file changes (no hook/config/skill/CLAUDE.md template).
+The `/metrics/features` awareness shipped in Phase 1a (#639); Phase 1b only makes the
+existing endpoint produce data.
+
+## Tests / lint
+
+8 new + 74 existing CircuitBreaking/breaker tests pass; `npm run lint` (tsc +
+destructive/LLM/URL-log/codex-drift) clean.


### PR DESCRIPTION
## What

Phase 1b of the per-feature LLM metrics layer — **the funnel tap that makes data flow.** Phase 1a (#639) shipped the `FeatureMetricsLedger` + `GET /metrics/features` but nothing wrote to it. Now the one shared LLM call (`CircuitBreakingIntelligenceProvider.evaluate`) records, per gate/sentinel, its **latency**, whether a **#638 rate-limit bounded-wait** was engaged, and **success/error** — so `/metrics/features` goes from empty to live as the checks run.

Built on the now-merged **#638** funnel, and measures its wait-behavior directly.

## Design

- **One injection point covers all LLM features.** A module-level recorder (`setFeatureMetricsRecorder`) — same pattern as the shared `getLlmCircuitBreaker()` — is set once by `AgentServer` to the `FeatureMetricsLedger`. Every `CircuitBreakingIntelligenceProvider` reads it, so no per-call-site wiring (there are many).
- **No core→monitoring import cycle.** The provider depends only on a local `FeatureMetricsRecorder` interface; the concrete ledger is injected at runtime. (`FeatureMetricsLedger.record()` structurally satisfies it.)
- **Hot-path safe.** `recordMetric()` swallows all errors (observability must never break the LLM path), a null recorder (CLI / no server) is a clean no-op, and the breaker/rate-limit control flow is **byte-identical** — all 74 existing CircuitBreaking/breaker-wait tests pass unchanged.

## Honest scope

The funnel sees cost/latency/wait + success/error. The **fired-vs-noop verdict** is the *caller's* interpretation of the result, and **tokens** live in TokenLedger — both are **Phase 2** (caller-side `recordEvent` / TokenLedger attribution join). So Phase 1b delivers per-feature call-count, latency (p50/p95), wait-rate, error-rate.

## Tests

`tests/unit/CircuitBreaking-feature-metrics-tap.test.ts` (+8): success→noop, unlabeled bucketing, failure→error+rethrow, the rate-limit **wait path** (`waited`/`waitMs`), the **circuit-open skip** (no inner call, throws `LlmCircuitOpenError`), safe no-op without a recorder, **a throwing recorder never breaks the call**, and an **end-to-end** feed into a real `FeatureMetricsLedger` asserting the queryable rollup. All 74 existing CircuitBreaking/breaker tests pass; `npm run lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
