### PR TITLE
fix(threadline): stop PromiseBeacon flooding the user topic on agent-to-agent reply-waits

### DIFF
--- a/src/threadline/TopicLinkageHandler.ts
+++ b/src/threadline/TopicLinkageHandler.ts
@@ -281,10 +281,15 @@ export class TopicLinkageHandler {
       agentResponse: `Sent threadline message to ${input.remoteAgentDisplayName ?? input.remoteAgent}, awaiting reply.`,
       source: 'agent',
       expiresAt: new Date(this.nowFn() + ttlMs).toISOString(),
-      // Explicit beaconEnabled so the auto-opt path is deterministic regardless
-      // of whether the agentResponse text contains a time-promise marker.
-      beaconEnabled: true,
-      beaconCreatedBySource: 'api-loopback',
+      // Near-Silent Notifications: a threadline-reply commitment must NOT beacon
+      // the user's topic. Its purpose is reply ROUTING (relatedThreadId + topicId);
+      // the inbound reply is dispatched automatically when it arrives, so a cadenced
+      // "⏳ awaiting reply" heartbeat is pure housekeeping noise about an agent-to-
+      // agent conversation — beaconing it floods the user's chat (observed 2026-05-31,
+      // dozens of heartbeats on one topic). Explicit `false` also pins the
+      // CommitmentTracker auto-opt path, which would otherwise enable a beacon
+      // whenever a topicId is attached.
+      beaconEnabled: false,
     });
 
     return {

--- a/tests/unit/CommitmentTracker-threadline-reply.test.ts
+++ b/tests/unit/CommitmentTracker-threadline-reply.test.ts
@@ -167,7 +167,11 @@ describe('CommitmentTracker — threadline-reply verification method', () => {
       relatedAgent: 'agent',
       userRequest: 'q',
       agentResponse: 'a',
-      beaconEnabled: true, // explicit (matches TopicLinkageHandler call-site)
+      // Mechanism check only: the tracker honors an explicit beaconEnabled flag.
+      // NOTE: the real TopicLinkageHandler call-site now passes `false` (Near-Silent
+      // Notifications — agent-to-agent reply-waits must not beacon the user's topic);
+      // see TopicLinkageHandler.test.ts. This case exercises the explicit-true path.
+      beaconEnabled: true,
     });
     expect(c.beaconEnabled).toBe(true);
   });

--- a/tests/unit/TopicLinkageHandler.test.ts
+++ b/tests/unit/TopicLinkageHandler.test.ts
@@ -160,7 +160,10 @@ describe('TopicLinkageHandler.captureOriginOnSend', () => {
     expect(c.relatedAgent).toBe('ai-guy');
     expect(c.topicId).toBe(9210);
     expect(c.userRequest).toBe('ask for stripe data');
-    expect(c.beaconEnabled).toBe(true);
+    // Near-Silent Notifications: a threadline-reply commitment must NOT beacon the
+    // user's topic — the reply routes back automatically, so a cadenced "awaiting
+    // reply" heartbeat is housekeeping noise that floods the user's chat.
+    expect(c.beaconEnabled).toBe(false);
     expect(c.expiresAt).toBeDefined();
   });
 

--- a/upgrades/NEXT.md
+++ b/upgrades/NEXT.md
@@ -1,0 +1,45 @@
+# Upgrade Guide — vNEXT
+
+<!-- bump: patch -->
+
+## What Changed
+
+**Agent-to-agent reply-waits no longer flood the user's chat with "⏳ awaiting
+reply" heartbeats.** When an agent sent a Threadline message to another agent,
+`TopicLinkageHandler` created the reply-tracking commitment with
+`beaconEnabled: true` **and** the user's topic id attached. `PromiseBeacon` then
+fired cadenced `⏳ … awaiting reply` heartbeats straight into the user's Telegram
+topic for what is purely an agent-to-agent conversation — observed in the wild as
+dozens of heartbeats burying one topic, making real work invisible and reading as
+"stuck."
+
+The reply already routes back on its own: the threadline-reply commitment carries
+`relatedThreadId` + `topicId`, and the inbound dispatch matches on those when the
+reply lands — entirely independent of the beacon. So the heartbeat was pure
+housekeeping noise. The fix sets `beaconEnabled: false` on these reply-wait
+commitments. This is a direct application of the **Near-Silent Notifications**
+standard: routine agent-to-agent status belongs in logs, never the user's chat.
+
+## What to Tell Your User
+
+Nothing to configure. If your agent talks to other agents over Threadline, it will
+no longer spam your chat with "⏳ awaiting reply" heartbeats while it waits for a
+peer — the peer's reply still arrives and routes to the right place exactly as
+before. Beacons that were already running before this update auto-pause on their
+own; new ones won't be created.
+
+## Summary of New Capabilities
+
+- `TopicLinkageHandler` creates threadline-reply commitments with
+  `beaconEnabled: false` — the reply-routing (relatedThreadId + topicId) is
+  preserved; only the user-facing heartbeat is suppressed.
+- No change to user-facing PromiseBeacons for genuine commitments *to the user*;
+  this scopes the suppression to agent-to-agent reply-waits only.
+
+## Evidence
+
+- `tests/unit/TopicLinkageHandler.test.ts` — the threadline-reply commitment now
+  asserts `beaconEnabled === false` (regression pin).
+- `tests/unit/CommitmentTracker-threadline-reply.test.ts` — the tracker still
+  honors an explicit `beaconEnabled: true` (mechanism unchanged); stale "matches
+  call-site" comment corrected. 32/32 green across both files.


### PR DESCRIPTION
## Problem
When an agent sends a Threadline message to a peer, `TopicLinkageHandler` created the reply-tracking commitment with `beaconEnabled: true` and the user's topic id attached. PromiseBeacon then fired cadenced `⏳ awaiting reply` heartbeats straight into the user's Telegram topic for an agent-to-agent conversation — dozens on one topic (observed 2026-05-31), burying real work and reading as stuck. A Near-Silent-Notifications violation.

## Fix
Set `beaconEnabled: false` on threadline-reply commitments. The reply still routes back via `relatedThreadId` + `topicId` (inbound dispatch is independent of the beacon), so the heartbeat was pure housekeeping noise. Scoped strictly to agent-to-agent reply-waits — user-facing PromiseBeacons for genuine commitments to the user are unchanged.

## Tests
- `tests/unit/TopicLinkageHandler.test.ts` — asserts `beaconEnabled === false` (regression pin).
- `tests/unit/CommitmentTracker-threadline-reply.test.ts` — tracker still honors explicit `beaconEnabled: true` (mechanism unchanged); corrected a stale comment. 32/32 green.

## Release
`upgrades/NEXT.md` included (patch bump).

🤖 Generated with [Claude Code](https://claude.com/claude-code)