### PR TITLE
fix(upgrades): unblock npm publish — clean technical leakage from 3 release-note fragments

### DIFF
--- a/upgrades/next/llm-feature-metrics-phase1b.md
+++ b/upgrades/next/llm-feature-metrics-phase1b.md
@@ -16,9 +16,9 @@ No gate changes behavior.
 
 ## What to Tell Your User
 
-Nothing required. If asked: `GET /metrics/features` now shows real per-check cost
-(latency), how often each check runs, and how often it hits a rate-limit wait —
-the data that lets us tune the checks with evidence.
+Nothing required. If asked: I can now show real per-check cost and timing, how
+often each check runs, and how often it hits a rate-limit wait — the data that
+lets us tune the checks with evidence.
 
 ## Summary of New Capabilities
 

--- a/upgrades/next/llm-feature-metrics.md
+++ b/upgrades/next/llm-feature-metrics.md
@@ -17,9 +17,9 @@ change (#638), so the two don't collide.
 
 ## What to Tell Your User
 
-Nothing required. If asked: the agent can now report, per safety check, how
-much it costs and how often it fires — `GET /metrics/features` — which is what
-lets us tune the checks with data instead of guesses.
+Nothing required. If asked: I can now report, per safety check, how much it costs
+and how often it fires — which is what lets us tune the checks with real data
+instead of guesses.
 
 ## Summary of New Capabilities
 

--- a/upgrades/next/restart-immediately.md
+++ b/upgrades/next/restart-immediately.md
@@ -16,12 +16,11 @@ fleet's existing session-aware + window-aware restart deferral is unchanged.
 ## What to Tell Your User
 
 Nothing for almost everyone — this is off by default and changes nothing unless
-you explicitly enable it. If you run the kind of agent that must always be on the
-latest build, set `{"updates": {"restartImmediately": true}}` in
-`.instar/config.json`. A server restart does **not** close your sessions (they
-resume via CONTINUATION); the only cost is a brief messaging blip while the
-server bounces. `GET /updates/status` now reports `restartImmediately` so you can
-confirm it's on.
+you explicitly turn it on. If you run the kind of agent that must always be on the
+latest build, I can switch it to restart right away whenever an update lands. A
+restart does not close your sessions — they resume right where they left off; the
+only cost is a brief pause in messaging while the server bounces. Just ask me and
+I can turn it on and confirm it's active.
 
 ## Summary of New Capabilities
 


### PR DESCRIPTION
## Problem
The npm publish workflow has been **failing on every release** (fleet stuck at 1.3.179). `assemble-next-md.mjs` folds `upgrades/next/*.md` fragments into the release guide; three fragments had inline code, a camelCase config key, and a 'set X in config.json' instruction in their **What to Tell Your User** sections. The upgrade-guide validator (correctly) rejects user-facing technical leakage, so the assembled guide for v1.3.180 was malformed and `check-upgrade-guide.js` exited 1 — blocking the beacon-flood fix (#642) and all queued releases.

## Fix
Rephrased the **What to Tell Your User** sections of the three fragments to plain, conversational language. The technical details (endpoints, config keys) already live in each fragment's **Summary of New Capabilities**, which is the correct home for them.

## Verification
Reproduced the full CI sequence locally — assemble fragments → bump to 1.3.180 → `check-upgrade-guide.js`:
- Before: exit 1, '1.3.180.md: What to Tell Your User contains inline code'
- After: exit 0, 'Upgrade guide validated for v1.3.180'

Markdown-only change; no code paths touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)