### PR TITLE
feat(feedback-factory): report fingerprint coverage in ParityResult (Phase-1 dry-run transparency)

### DIFF
--- a/src/feedback-factory/dryrun/dryRunCompare.ts
+++ b/src/feedback-factory/dryrun/dryRunCompare.ts
@@ -69,6 +69,7 @@ export type DryRunRecord =
       kind: 'summary';
       at: string;
       clustersCompared: number;
+      clustersWithFingerprint: number;
       outcomesCompared: number;
       fingerprintDivergences: number;
       outcomeDivergences: number;
@@ -94,6 +95,7 @@ export function toRecords(result: ParityResult, now: string): DryRunRecord[] {
     kind: 'summary',
     at: now,
     clustersCompared: result.clustersCompared,
+    clustersWithFingerprint: result.clustersWithFingerprint,
     outcomesCompared: result.outcomesCompared,
     fingerprintDivergences: result.fingerprintDivergences.length,
     outcomeDivergences: result.outcomeDivergences.length,

--- a/src/feedback-factory/processor/parity.ts
+++ b/src/feedback-factory/processor/parity.ts
@@ -77,7 +77,23 @@ export interface OutcomeDivergence {
 
 /** The full parity verdict over a window. `divergent` gates Phase 4 cutover. */
 export interface ParityResult {
+  /**
+   * Total Portal clusters in the window — the coverage DENOMINATOR. This is every
+   * cluster read, NOT the number actually fingerprint-compared (see
+   * {@link clustersWithFingerprint}); invariant 1 can only compare a cluster that
+   * carries a stored fingerprint.
+   */
   clustersCompared: number;
+  /**
+   * Clusters that carried a stored fingerprint and were therefore actually subject
+   * to the invariant-1 comparison — the coverage NUMERATOR. When this is below
+   * {@link clustersCompared}, a `divergent: false` verdict means "no divergence
+   * among the covered clusters", NOT "100% equivalence across the window": the gap
+   * (`clustersCompared - clustersWithFingerprint`) was skipped for lack of a stored
+   * fingerprint to compare against. Pre-backfill windows expose exactly this gap, so
+   * a green run is never silently misread as full coverage.
+   */
+  clustersWithFingerprint: number;
   outcomesCompared: number;
   fingerprintDivergences: FingerprintDivergence[];
   outcomeDivergences: OutcomeDivergence[];
@@ -161,12 +177,18 @@ export function compareInvariants(args: {
   portalOutcomes?: ClusterOutcome[];
 }): ParityResult {
   const fingerprintDivergences = compareClusterFingerprints(args.portalClusters);
+  // Coverage numerator: clusters carrying a stored fingerprint are the only ones
+  // compareClusterFingerprints actually compares (it skips empties). This predicate
+  // MUST stay identical to the `if (!c.fingerprint) continue` skip there, or the
+  // reported coverage will lie about what was checked.
+  const clustersWithFingerprint = args.portalClusters.filter((c) => c.fingerprint).length;
   const outcomeDivergences =
     args.instarOutcomes && args.portalOutcomes
       ? compareClusterOutcomes(args.instarOutcomes, args.portalOutcomes)
       : [];
   return {
     clustersCompared: args.portalClusters.length,
+    clustersWithFingerprint,
     outcomesCompared: args.portalOutcomes?.length ?? 0,
     fingerprintDivergences,
     outcomeDivergences,

--- a/tests/unit/feedback-factory/dry-run-compare.test.ts
+++ b/tests/unit/feedback-factory/dry-run-compare.test.ts
@@ -43,9 +43,39 @@ describe('runDryRunCompare', () => {
 
     expect(result.divergent).toBe(false);
     expect(result.clustersCompared).toBe(2);
+    expect(result.clustersWithFingerprint).toBe(2);
     const records = readJsonl(out);
     expect(records).toHaveLength(1); // just the summary
-    expect(records[0]).toMatchObject({ kind: 'summary', divergent: false, clustersCompared: 2, fingerprintDivergences: 0 });
+    expect(records[0]).toMatchObject({
+      kind: 'summary',
+      divergent: false,
+      clustersCompared: 2,
+      clustersWithFingerprint: 2,
+      fingerprintDivergences: 0,
+    });
+  });
+
+  it('emits a partial-coverage summary: empty-fingerprint clusters keep divergent=false but lower clustersWithFingerprint', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'dryrun-'));
+    const out = join(dir, 'compare.jsonl');
+    const source = new InMemoryParitySource([
+      cluster('c1', 'bug', 'covered title'),
+      { clusterId: 'c2', type: 'bug', title: 'pre-backfill', fingerprint: '' },
+    ]);
+
+    const result = runDryRunCompare(source, { outPath: out, now: '2026-05-27T00:00:00Z' });
+
+    expect(result.divergent).toBe(false);
+    expect(result.clustersCompared).toBe(2);
+    expect(result.clustersWithFingerprint).toBe(1); // a green run that is NOT 100% coverage
+    const records = readJsonl(out);
+    expect(records).toHaveLength(1); // no divergences — just the summary
+    expect(records[0]).toMatchObject({
+      kind: 'summary',
+      divergent: false,
+      clustersCompared: 2,
+      clustersWithFingerprint: 1,
+    });
   });
 
   it('detects a fingerprint divergence, sets divergent=true, and logs the divergence + summary', () => {
@@ -99,6 +129,7 @@ describe('toRecords', () => {
     const records = toRecords(
       {
         clustersCompared: 1,
+        clustersWithFingerprint: 1,
         outcomesCompared: 0,
         fingerprintDivergences: [{ clusterId: 'c1', instar: 'a', portal: 'b' }],
         outcomeDivergences: [],
@@ -107,6 +138,11 @@ describe('toRecords', () => {
       '2026-05-27T12:00:00Z',
     );
     expect(records[0].kind).toBe('fingerprint-divergence');
-    expect(records[records.length - 1]).toMatchObject({ kind: 'summary', at: '2026-05-27T12:00:00Z', divergent: true });
+    expect(records[records.length - 1]).toMatchObject({
+      kind: 'summary',
+      at: '2026-05-27T12:00:00Z',
+      clustersWithFingerprint: 1,
+      divergent: true,
+    });
   });
 });

--- a/tests/unit/feedback-factory/parity.test.ts
+++ b/tests/unit/feedback-factory/parity.test.ts
@@ -93,7 +93,28 @@ describe('compareInvariants (full verdict)', () => {
     const r = compareInvariants({ portalClusters: clusters, instarOutcomes: outcomes, portalOutcomes: outcomes });
     expect(r.divergent).toBe(false);
     expect(r.clustersCompared).toBe(1);
+    expect(r.clustersWithFingerprint).toBe(1); // full coverage: every cluster carried a fingerprint
     expect(r.outcomesCompared).toBe(1);
+  });
+
+  it('reports a coverage gap — empty-fingerprint clusters count toward clustersCompared but NOT clustersWithFingerprint', () => {
+    // The exact misread-as-100% hazard: a window where some clusters have no stored
+    // fingerprint. Invariant 1 skips them, so the verdict is green — but it is green
+    // over a SUBSET, not the whole window. The coverage numerator makes that explicit.
+    const covered = cluster('c1', 'bug', 'has fingerprint');
+    const preBackfill: PortalCluster = { clusterId: 'c2', type: 'bug', title: 'pre-backfill', fingerprint: '' };
+    const r = compareInvariants({ portalClusters: [covered, preBackfill] });
+    expect(r.divergent).toBe(false); // no divergence among the COVERED clusters
+    expect(r.fingerprintDivergences).toEqual([]);
+    expect(r.clustersCompared).toBe(2); // denominator: every cluster read
+    expect(r.clustersWithFingerprint).toBe(1); // numerator: only the one with a fingerprint
+  });
+
+  it('clustersWithFingerprint counts every cluster when all carry a fingerprint', () => {
+    const clusters = [cluster('c1', 'bug', 'a'), cluster('c2', 'feature', 'b'), cluster('c3', 'bug', 'c')];
+    const r = compareInvariants({ portalClusters: clusters });
+    expect(r.clustersCompared).toBe(3);
+    expect(r.clustersWithFingerprint).toBe(3);
   });
 
   it('divergent=true on any fingerprint divergence (fingerprint-only pass, no outcomes)', () => {


### PR DESCRIPTION
## Why

Phase-1 migration dry-run finding (Echo↔Dawn parity work): the parity gate's **invariant 1** (per-cluster fingerprint) correctly *skips* any Portal cluster with no stored fingerprint — there's nothing to compare against. But `ParityResult.clustersCompared` reported the **total** cluster count regardless of how many were actually compared.

Consequence: in a window where a large fraction of clusters predate fingerprint backfill (Dawn observed ~44% / 581 empty fingerprints), a `divergent: false` verdict reads as *"100% equivalent across the window"* when in reality only the fingerprinted subset was ever checked. A green run silently overstates coverage — exactly the kind of false confidence that should never gate a production cutover decision.

## What

Add `clustersWithFingerprint` (coverage **numerator**) alongside the existing `clustersCompared` (**denominator**) on `ParityResult`, and surface it in the JSONL audit `summary` record. A reader now computes `coverage = clustersWithFingerprint / clustersCompared` and can distinguish a *partial*-coverage green run from a *full*-coverage one.

- The numerator predicate is the **identical** `c.fingerprint` truthiness check `compareClusterFingerprints` uses to skip, with a comment pinning the two together so reported coverage can't drift from what was actually compared.
- The field is **required** (not optional) — coverage can never be silently omitted, which is the precise failure mode this closes.

This is the **transparency** path (report scope, launch, backfill as Phase-2 hardening) rather than blocking cutover on a pre-backfill — per the agreed sequencing.

## Scope / non-goals

- Pure additive change to the comparator + audit record. No behavior change to `divergent` (the cutover gate) and no change to invariants 2 & 3.
- Status-vocabulary alignment (the other dry-run blocker) is tracked separately.

## Tests

Both-sides-of-boundary at the comparator (full coverage, partial coverage, green-but-partial) and through the dry-run runner + JSONL summary record.

- `tests/unit/feedback-factory/parity.test.ts` — coverage numerator under full vs partial fingerprint presence
- `tests/unit/feedback-factory/dry-run-compare.test.ts` — partial-coverage summary record + `toRecords` shape

`141/141` feedback-factory unit tests green, `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)