### PR TITLE
fix(updates): surface restartImmediately in GET /updates/status (#59 — close #641 obs gap)

### DIFF
--- a/docs/specs/updates-status-restart-immediately-spec.eli16.md
+++ b/docs/specs/updates-status-restart-immediately-spec.eli16.md
@@ -1,0 +1,44 @@
+# Plain-English overview: show the "always update now" switch in the status readout
+
+## What Changed
+
+The agent has a status readout you can fetch — `GET /updates/status` — that tells
+you things like what version it's on and whether a restart is being held. A
+recent change added a per-agent switch called "restart immediately" (always jump
+to the newest version instead of waiting). The release note for that switch said
+"you can see it in `/updates/status`" — but it actually wasn't there. This change
+adds the one missing line so the switch's on/off state really does show up in
+that readout.
+
+## What already exists
+
+- The status readout already exists and already lists a dozen fields.
+- The "restart immediately" switch already exists and already works — the agent
+  was correctly using it. The only thing missing was that you couldn't *see* its
+  value by reading the status endpoint.
+- The value was already being computed internally; the status route just didn't
+  copy it into the response it hands back.
+
+## What's new
+
+- One field added to the `/updates/status` response: `restartImmediately`
+  (true/false). For almost every agent it's `false`; for the developer's own
+  agent it's `true`.
+
+## What you need to decide
+
+Nothing. It's a read-only field. If you ever want to confirm whether an agent is
+in "always update now" mode, you fetch its status and look at that field.
+
+## How to verify it worked after deploy
+
+`GET /updates/status` now includes a `restartImmediately` field. There's a test
+that fetches the status with the switch on and off and checks the field is
+present and correct both ways, so it can't silently go missing again.
+
+## Why this matters
+
+It's a small honesty fix: a release note claimed something was visible that
+wasn't. Now the claim is true, and the switch's state is actually observable —
+useful when you're checking whether an agent is configured to stay on the latest
+build.

--- a/docs/specs/updates-status-restart-immediately-spec.md
+++ b/docs/specs/updates-status-restart-immediately-spec.md
@@ -1,0 +1,58 @@
+---
+title: "Surface restartImmediately in GET /updates/status (close the #641 observability gap)"
+date: 2026-06-01
+author: echo
+review-convergence: internal-plus-conformance-2026-06-01
+approved: true
+approved-by: Justin
+approved-via: "Telegram topic 13435 (2026-06-01): the restart-immediately directive + 'fix gaps as proper fleet PRs' — this closes Echo's own incomplete #641 claim ('surfaced in GET /updates/status'), found while verifying the work live."
+eli16-overview: updates-status-restart-immediately-spec.eli16.md
+---
+
+# Surface `restartImmediately` in GET /updates/status
+
+## Problem
+
+PR #641 (primary-developer mode) added `restartImmediately` to
+`AutoUpdaterStatus` and `AutoUpdater.getStatus()`, and its upgrade guide
+claimed the flag is "surfaced in GET /updates/status". But the
+`/updates/status` route builds a **hand-picked** response object and only
+`Object.assign`s a specific subset of `auto.getStatus()` fields — and
+`restartImmediately` was not in that list. So `GET /updates/status` returned no
+`restartImmediately` field, and the flag's live state was not observable via the
+endpoint. The claim was incomplete; the functional behavior worked, the
+observability did not. (Found live on 1.3.180 while verifying #641 deployed:
+`/updates/status` read no field even with the flag set true.)
+
+## Decision
+
+Add `restartImmediately: auto.restartImmediately` to the `/updates/status`
+route's `Object.assign`, so the route echoes the value that `getStatus()`
+already returns. Default false → fleet responses simply gain a
+`restartImmediately: false` field; the developer's agent shows `true`.
+
+## Design
+
+One line in `src/server/routes.ts` (`router.get('/updates/status')`): inside the
+`if (ctx.autoUpdater)` block, add `restartImmediately: auto.restartImmediately`
+to the assigned object (the value already exists on `AutoUpdaterStatus` from
+#641). No other change. When no `autoUpdater` is wired, the field is simply
+absent (unchanged behavior).
+
+## Safety / blast radius
+
+Pure additive observability — the route gains one boolean field sourced from an
+already-computed status. No behavior changes; no other field touched. tsc clean.
+
+## Testing
+
+`tests/integration/updates-status-restart-immediately-route.test.ts` (+2):
+builds the router with a stub `autoUpdater` and asserts `GET /updates/status`
+returns `restartImmediately` for both `true` (developer mode) and `false`
+(fleet default) — covering both sides of the boundary and pinning the
+regression so the field can't be dropped from the pick-list again.
+
+## Migration parity
+
+None — no agent-installed file changes (no hook/config/skill/CLAUDE.md template).
+A read-only API field; existing agents gain it automatically on update.

--- a/src/server/routes.ts
+++ b/src/server/routes.ts
@@ -8392,6 +8392,7 @@ export function createRoutes(ctx: RouteContext): Router {
         deferralElapsedMinutes: auto.deferralElapsedMinutes,
         maxDeferralHours: auto.maxDeferralHours,
         restartDeferral: auto.restartDeferral,
+        restartImmediately: auto.restartImmediately,
         lastCheck: auto.lastCheck,
         lastApply: auto.lastApply,
         lastAppliedVersion: auto.lastAppliedVersion,

--- a/tests/integration/updates-status-restart-immediately-route.test.ts
+++ b/tests/integration/updates-status-restart-immediately-route.test.ts
@@ -1,0 +1,62 @@
+/**
+ * Integration test for GET /updates/status — the restartImmediately field.
+ *
+ * Regression pin for the #641 observability gap (#59): #641 added
+ * `restartImmediately` to AutoUpdaterStatus + getStatus() and claimed it was
+ * "surfaced in GET /updates/status", but the route's hand-picked response
+ * object omitted it. This asserts the route now echoes auto.restartImmediately
+ * (both true and false), so the primary-developer-mode flag is observable.
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import express from 'express';
+import request from 'supertest';
+import { createRoutes } from '../../src/server/routes.js';
+import type { RouteContext } from '../../src/server/routes.js';
+
+function ctxWithRestartImmediately(restartImmediately: boolean): RouteContext {
+  return {
+    config: { projectName: 'test', projectDir: '/tmp', stateDir: '/tmp/.instar', port: 0, sessions: {} as any, scheduler: {} as any, updates: { autoApply: true } } as any,
+    sessionManager: { listRunningSessions: () => [] } as any,
+    state: { getJobState: () => null, getSession: () => null } as any,
+    scheduler: null, telegram: null, relationships: null, feedback: null, dispatches: null,
+    updateChecker: { getInstalledVersion: () => '1.3.181' } as any,
+    autoUpdater: {
+      getStatus: () => ({
+        running: true,
+        lastCheck: null, lastApply: null, lastAppliedVersion: null,
+        config: {} as any,
+        pendingUpdate: null, lastError: null, coalescingUntil: null, pendingUpdateDetectedAt: null,
+        deferralReason: null, deferralElapsedMinutes: 0, maxDeferralHours: 4,
+        restartDeferral: null,
+        restartImmediately,
+      }),
+    } as any,
+    autoDispatcher: null, quotaTracker: null, publisher: null, viewer: null, tunnel: null,
+    evolution: null, watchdog: null, triageNurse: null, topicMemory: null,
+    discoveryEvaluator: null, tokenLedger: null, startTime: new Date(),
+  } as unknown as RouteContext;
+}
+
+describe('GET /updates/status — restartImmediately (#59 regression)', () => {
+  function appWith(ri: boolean): express.Express {
+    const app = express();
+    app.use(express.json());
+    app.use('/', createRoutes(ctxWithRestartImmediately(ri)));
+    return app;
+  }
+
+  it('surfaces restartImmediately=true from the AutoUpdater status', async () => {
+    const res = await request(appWith(true)).get('/updates/status');
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveProperty('restartImmediately');
+    expect(res.body.restartImmediately).toBe(true);
+    expect(res.body.currentVersion).toBe('1.3.181');
+  });
+
+  it('surfaces restartImmediately=false (default, fleet) — present, not omitted', async () => {
+    const res = await request(appWith(false)).get('/updates/status');
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveProperty('restartImmediately');
+    expect(res.body.restartImmediately).toBe(false);
+  });
+});

--- a/upgrades/next/updates-status-restart-immediately.md
+++ b/upgrades/next/updates-status-restart-immediately.md
@@ -1,0 +1,33 @@
+# Upgrade Guide — vNEXT
+
+<!-- bump: patch -->
+
+## What Changed
+
+`GET /updates/status` now includes the `restartImmediately` field. PR #641 added
+the primary-developer-mode flag and claimed it was surfaced in this endpoint, but
+the route's hand-picked response object had omitted it — so the flag's live state
+wasn't actually readable there. This adds the one missing line so the route
+echoes the value `AutoUpdater.getStatus()` already computes.
+
+## What to Tell Your User
+
+Nothing to do. If anyone asks how to tell whether an agent is set to always jump
+to the newest version immediately, the status readout now shows that on/off state
+directly.
+
+## Summary of New Capabilities
+
+- `GET /updates/status` response gains a `restartImmediately` boolean (default
+  false for the fleet; true for an agent in primary-developer mode). Read-only;
+  agents gain it automatically on update.
+
+## Evidence
+
+- The gap was observed live on 1.3.180: with the flag set true in config, the
+  agent behaved correctly (restarts not deferred) but `/updates/status` returned
+  no `restartImmediately` field — the #641 "surfaced in /updates/status" claim
+  was incomplete.
+- Test: `tests/integration/updates-status-restart-immediately-route.test.ts`
+  (+2) — asserts the field is present and correct for both true and false. tsc +
+  linters clean.

--- a/upgrades/side-effects/updates-status-restart-immediately.md
+++ b/upgrades/side-effects/updates-status-restart-immediately.md
@@ -1,0 +1,55 @@
+# Side-Effects Review — Surface restartImmediately in GET /updates/status
+
+**Slug:** `updates-status-restart-immediately`
+**Date:** 2026-06-01
+**Author:** echo
+**Spec:** `docs/specs/updates-status-restart-immediately-spec.md` (approved by Justin, Telegram 13435)
+
+## Summary of the change
+
+Closes the #641 observability gap (#59): #641 added `restartImmediately` to
+`AutoUpdaterStatus` + `getStatus()` and claimed it was "surfaced in GET
+/updates/status", but the route's hand-picked response object omitted it. One
+line added so the route echoes `auto.restartImmediately`.
+
+**Files changed (source):**
+- `src/server/routes.ts`: inside `router.get('/updates/status')`, the
+  `if (ctx.autoUpdater)` `Object.assign(status, {...})` now includes
+  `restartImmediately: auto.restartImmediately`. The value already exists on the
+  status object (from #641); no other field touched.
+
+**Files changed (tests):**
+- `tests/integration/updates-status-restart-immediately-route.test.ts` — +2:
+  builds the router with a stub `autoUpdater` and asserts `GET /updates/status`
+  returns `restartImmediately` for both `true` and `false` (both sides of the
+  boundary; regression pin so it can't be dropped from the pick-list again).
+
+## Blast radius
+
+Pure additive observability. The route gains one boolean field sourced from an
+already-computed `getStatus()`. No behavior changes; no other field altered; the
+no-`autoUpdater` path is unchanged (field simply absent). tsc + linters clean.
+
+## Behavior delta
+
+| Scenario | Before | After |
+|---|---|---|
+| `GET /updates/status`, autoUpdater wired, flag on | no field | `restartImmediately: true` |
+| `GET /updates/status`, autoUpdater wired, flag off (fleet) | no field | `restartImmediately: false` |
+| `GET /updates/status`, no autoUpdater | field absent | field absent (unchanged) |
+
+## Risks considered
+
+- **Leaking sensitive data?** No — it's a boolean config flag, same exposure
+  class as the `autoApply` field already returned.
+- **Breaking existing consumers?** No — additive field; existing fields unchanged.
+
+## Migration parity
+
+None — no agent-installed file changes (no hook/config/skill/CLAUDE.md template).
+Read-only API field; existing agents gain it automatically on update.
+
+## Tests / lint
+
+2 new integration tests pass; `npm run lint` (tsc + destructive/LLM/URL-log/
+codex-drift) clean.


### PR DESCRIPTION
## What

Closes **#59** — the observability gap in my own **#641** (primary-developer mode). #641 added `restartImmediately` to `AutoUpdaterStatus` + `getStatus()` and its upgrade guide claimed it was *"surfaced in GET /updates/status"* — but the route builds a hand-picked response object and **omitted** the field. So `GET /updates/status` returned no `restartImmediately`, and the flag's live state wasn't observable.

Found live on 1.3.180 while verifying #641 deployed: the flag was set `true` in config and behaving correctly (restarts not deferred), but `/updates/status` read no field.

## Fix

One line in `src/server/routes.ts` (`router.get('/updates/status')`): add `restartImmediately: auto.restartImmediately` to the `Object.assign`. The value already exists on the status object (from #641); the route just wasn't copying it.

## Safety

Pure additive observability — one boolean field sourced from an already-computed status. Default `false` → fleet responses gain `restartImmediately: false`; the developer's agent shows `true`. No behavior changes, no other field touched.

## Tests

`tests/integration/updates-status-restart-immediately-route.test.ts` (+2) — asserts `GET /updates/status` returns `restartImmediately` for both `true` (developer mode) and `false` (fleet default), pinning the regression so the field can't be dropped from the pick-list again. tsc + linters clean.

Spec: `docs/specs/updates-status-restart-immediately-spec.md` (approved Telegram 13435).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
