### PR TITLE
feat(threadline): Ground Before You Assert — pre-send grounding gate on threadline_send

### DIFF
--- a/src/threadline/ThreadlineGroundingGate.ts
+++ b/src/threadline/ThreadlineGroundingGate.ts
@@ -1,0 +1,87 @@
+/**
+ * ThreadlineGroundingGate — "Ground Before You Assert" for OUTBOUND agent-to-agent
+ * messages (the constitution's proposed Interaction principle; companion to the
+ * pre-Telegram grounding gate).
+ *
+ * Pure, side-effect-free claim analysis: given the text an agent is about to send
+ * to a peer, surface the claims that need verification BEFORE they leave — so an
+ * unverified fact doesn't propagate to another agent as truth. The first concrete
+ * check is URL provenance: a scheme-qualified URL to an unfamiliar host that the
+ * agent has NOT confirmed this session is flagged, because that is exactly the
+ * class that caused the 2026-05-31 cross-agent incoherence (a peer handed over a
+ * `https://…` endpoint that 404'd, propagated as fact).
+ *
+ * This module is the DECISION; wiring it as a hard pre-send gate on threadline_send
+ * (block / require-confirm) is a separate step. Signal-vs-Authority: the gate
+ * returns structured issues; the caller chooses to block, warn, or require a
+ * verification step.
+ */
+
+export interface GroundingIssue {
+  kind: 'ungrounded-url' | 'malformed-url';
+  detail: string;
+}
+
+export interface GroundingContext {
+  /** Hosts that never need grounding (suffix-matched), in addition to the defaults. */
+  knownDomains?: string[];
+  /** Exact URLs the agent has confirmed resolve THIS session (e.g. curl-verified). */
+  verifiedUrls?: string[];
+}
+
+export interface GroundingResult {
+  /** True when no claim needs grounding. */
+  allow: boolean;
+  issues: GroundingIssue[];
+}
+
+/** Hosts that are part of the agent's own surface / well-known infra. */
+const DEFAULT_KNOWN_DOMAINS = [
+  'localhost',
+  'github.com',
+  'githubusercontent.com',
+  'npmjs.com',
+  'anthropic.com',
+  'claude.com',
+];
+
+function hostIsKnown(host: string, known: Set<string>): boolean {
+  for (const d of known) {
+    if (host === d || host.endsWith('.' + d)) return true;
+  }
+  return false;
+}
+
+/**
+ * Evaluate an outbound peer message for ungrounded claims. Only scheme-qualified
+ * (`http(s)://`) URLs are checked — bare host references (e.g. `dawn.bot-me.ai/x`)
+ * are intentionally NOT flagged, matching the convention that a bare host conveys
+ * the same curl-verified info without asserting a live, fetchable endpoint.
+ */
+export function evaluateOutboundGrounding(message: string, ctx: GroundingContext = {}): GroundingResult {
+  const known = new Set<string>([...DEFAULT_KNOWN_DOMAINS, ...(ctx.knownDomains ?? [])]);
+  const verified = new Set<string>(ctx.verifiedUrls ?? []);
+  const issues: GroundingIssue[] = [];
+
+  const urls = message.match(/https?:\/\/[^\s)"'>\]]+/g) ?? [];
+  for (const raw of urls) {
+    const url = raw.replace(/[.,;:]+$/, ''); // trim trailing punctuation
+    if (verified.has(url) || verified.has(raw)) continue;
+    let host: string;
+    try {
+      host = new URL(url).hostname;
+    } catch {
+      issues.push({ kind: 'malformed-url', detail: `${raw} is not a parseable URL.` });
+      continue;
+    }
+    if (!hostIsKnown(host, known)) {
+      issues.push({
+        kind: 'ungrounded-url',
+        detail: `${url} — unfamiliar host "${host}". Verify it resolves (curl) before asserting it to a peer, ` +
+          `or reference it bare (no scheme) if it carries already-verified info.`,
+      });
+    }
+  }
+
+  return { allow: issues.length === 0, issues };
+}

--- a/src/threadline/ThreadlineMCPServer.ts
+++ b/src/threadline/ThreadlineMCPServer.ts
@@ -31,6 +31,7 @@ import type { ThreadResumeMap, ThreadResumeEntry } from './ThreadResumeMap.js';
 import type { AgentTrustManager, AgentTrustLevel } from './AgentTrustManager.js';
 import type { MCPAuth, MCPTokenInfo, MCPTokenScope } from './MCPAuth.js';
 import { DEFAULT_RELAY_URL } from './constants.js';
+import { evaluateOutboundGrounding } from './ThreadlineGroundingGate.js';
 
 // ── Types ────────────────────────────────────────────────────────────
 
@@ -531,6 +532,15 @@ export class ThreadlineMCPServer {
           'commitment record for context when the reply lands; NEVER sent ' +
           'over the wire to the remote agent.'
         ),
+        groundingAck: z.boolean().default(false).describe(
+          'Ground Before You Assert: set true ONLY after you have verified the ' +
+          'claims in this message (endpoints resolve, tokens authenticate, ' +
+          'identities/state are current). Leave false (default) and the send is ' +
+          'refused if it contains a scheme-qualified URL to a host you have not ' +
+          'confirmed this session — so an unverified claim never propagates to a ' +
+          'peer as fact. Resend with groundingAck:true once verified, or write ' +
+          'the host bare (no scheme).'
+        ),
       },
       async (args) => {
         const authError = this.checkAuth('threadline:send');
@@ -544,6 +554,27 @@ export class ThreadlineMCPServer {
         // Validate message is non-empty
         if (!args.message.trim()) {
           return errorResult('Message cannot be empty');
+        }
+
+        // Ground Before You Assert (constitution Interaction principle): refuse to
+        // send a peer message that asserts an unverified scheme-qualified URL,
+        // unless the caller has consciously acked grounding. Block-with-override —
+        // a real structural gate (Structure > Willpower) that still respects
+        // Signal-vs-Authority: the agent can override after verifying, so a
+        // false-positive can never permanently block a legitimate send. The check
+        // is a pure function, so it runs correctly here in the MCP stdio process.
+        if (!args.groundingAck) {
+          const grounding = evaluateOutboundGrounding(args.message);
+          if (!grounding.allow) {
+            return errorResult(
+              'Ground Before You Assert — this message asserts something you have not ' +
+              'verified this session:\n' +
+              grounding.issues.map((i) => `• ${i.detail}`).join('\n') +
+              '\nVerify each (e.g. curl the endpoint), or reference the host bare (no ' +
+              'scheme) if it carries already-verified info. If you have already ' +
+              'verified it, resend with groundingAck: true.'
+            );
+          }
         }
 
         try {

--- a/tests/unit/threadline/ThreadResumeMap.test.ts
+++ b/tests/unit/threadline/ThreadResumeMap.test.ts
@@ -354,7 +354,12 @@ describe('ThreadResumeMap', () => {
     });
 
     it('archives stale active and idle threads before listing', () => {
-      const now = new Date('2026-05-30T09:00:00.000Z');
+      // Anchor timestamps to REAL wall-clock time, not a hardcoded fixture date.
+      // listActive() archives internally via retireInactive(new Date()) (real now),
+      // so a fixed historical `now` makes this a time bomb: once real time advances
+      // past 24h beyond the fixture, the "fresh" entry ages out of the window and
+      // listActive() returns []. Relative-to-now keeps it deterministic forever.
+      const now = new Date();
       const stale = new Date(now.getTime() - 25 * 60 * 60 * 1000).toISOString();
       const fresh = new Date(now.getTime() - 10 * 60 * 1000).toISOString();
 
@@ -362,7 +367,7 @@ describe('ThreadResumeMap', () => {
       map.save('stale-idle', makeEntry({ state: 'idle', lastAccessedAt: stale, savedAt: stale }));
       map.save('fresh-active', makeEntry({ state: 'active', lastAccessedAt: fresh, savedAt: fresh }));
 
-      expect(map.retireInactive(24 * 60 * 60 * 1000, now)).toBe(2);
+      expect(map.retireInactive(24 * 60 * 60 * 1000)).toBe(2);
       expect(map.listActive().map(t => t.threadId)).toEqual(['fresh-active']);
       expect(map.get('stale-active')?.state).toBe('archived');
       expect(map.get('stale-idle')?.state).toBe('archived');

--- a/tests/unit/threadline/ThreadlineGroundingGate.test.ts
+++ b/tests/unit/threadline/ThreadlineGroundingGate.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest';
+import { evaluateOutboundGrounding } from '../../../src/threadline/ThreadlineGroundingGate.js';
+
+describe('ThreadlineGroundingGate — Ground Before You Assert (outbound URL provenance)', () => {
+  it('allows a message with no URLs', () => {
+    const r = evaluateOutboundGrounding('Confirmed on my side — channel is up.');
+    expect(r.allow).toBe(true);
+    expect(r.issues).toHaveLength(0);
+  });
+
+  it('allows a known/infra domain', () => {
+    const r = evaluateOutboundGrounding('See https://github.com/JKHeadley/instar/pull/642');
+    expect(r.allow).toBe(true);
+  });
+
+  it('allows a subdomain of a known domain', () => {
+    const r = evaluateOutboundGrounding('raw at https://raw.githubusercontent.com/x/y/z.md');
+    expect(r.allow).toBe(true);
+  });
+
+  it('FLAGS a scheme-qualified URL to an unfamiliar host', () => {
+    const r = evaluateOutboundGrounding('The endpoint is https://the-portal.vercel.app/api/instar/read');
+    expect(r.allow).toBe(false);
+    expect(r.issues[0].kind).toBe('ungrounded-url');
+    expect(r.issues[0].detail).toContain('the-portal.vercel.app');
+  });
+
+  it('EXEMPTS a URL the agent has verified this session', () => {
+    const r = evaluateOutboundGrounding('Live: https://dawn.bot-me.ai/api/instar/read returns 401', {
+      verifiedUrls: ['https://dawn.bot-me.ai/api/instar/read'],
+    });
+    expect(r.allow).toBe(true);
+  });
+
+  it('does NOT flag a BARE host (no scheme) — same info without asserting a live endpoint', () => {
+    const r = evaluateOutboundGrounding('The live endpoint is dawn.bot-me.ai/api/instar/read (401 = real auth)');
+    expect(r.allow).toBe(true);
+    expect(r.issues).toHaveLength(0);
+  });
+
+  it('honors a caller-supplied knownDomains allowlist', () => {
+    const r = evaluateOutboundGrounding('Endpoint https://dawn.bot-me.ai/x', { knownDomains: ['bot-me.ai'] });
+    expect(r.allow).toBe(true);
+  });
+
+  it('flags only the unfamiliar URL among several', () => {
+    const r = evaluateOutboundGrounding(
+      'PR https://github.com/x/y/pull/1 and endpoint https://sketchy.example.io/v1',
+    );
+    expect(r.allow).toBe(false);
+    expect(r.issues).toHaveLength(1);
+    expect(r.issues[0].detail).toContain('sketchy.example.io');
+  });
+
+  it('trims trailing punctuation before host extraction', () => {
+    const r = evaluateOutboundGrounding('see https://sketchy.example.io/v1.', { verifiedUrls: ['https://sketchy.example.io/v1'] });
+    expect(r.allow).toBe(true); // trailing "." trimmed → matches the verified URL
+  });
+});

--- a/tests/unit/threadline/ThreadlineMCPServer.test.ts
+++ b/tests/unit/threadline/ThreadlineMCPServer.test.ts
@@ -619,6 +619,84 @@ describe('ThreadlineMCPServer', () => {
       }
     });
 
+    // ── Ground Before You Assert (grounding gate wired into the send path) ──
+    it('REFUSES a send asserting an unverified scheme-qualified URL (gate blocks, sendMessage not called)', async () => {
+      const { client, close } = await connectClientServer({}, deps);
+      try {
+        const result = await client.callTool({
+          name: 'threadline_send',
+          arguments: {
+            agentId: 'remote-agent',
+            message: 'The read endpoint is https://the-portal.vercel.app/api/instar/read',
+          },
+        });
+
+        const text = (result.content as any)[0].text;
+        expect(result.isError).toBe(true);
+        expect(text).toContain('Ground Before You Assert');
+        expect(text).toContain('the-portal.vercel.app');
+        // The block happens BEFORE delivery — the message never went out.
+        expect(deps.sendMessage).not.toHaveBeenCalled();
+      } finally {
+        await close();
+      }
+    });
+
+    it('ALLOWS the same ungrounded URL once the caller acks grounding (block-with-override)', async () => {
+      const { client, close } = await connectClientServer({}, deps);
+      try {
+        const result = await client.callTool({
+          name: 'threadline_send',
+          arguments: {
+            agentId: 'remote-agent',
+            message: 'The read endpoint is https://the-portal.vercel.app/api/instar/read',
+            groundingAck: true,
+          },
+        });
+
+        expect(result.isError).toBeFalsy();
+        expect(deps.sendMessage).toHaveBeenCalledTimes(1);
+      } finally {
+        await close();
+      }
+    });
+
+    it('ALLOWS a bare host (no scheme) without an ack — same info, no asserted live endpoint', async () => {
+      const { client, close } = await connectClientServer({}, deps);
+      try {
+        const result = await client.callTool({
+          name: 'threadline_send',
+          arguments: {
+            agentId: 'remote-agent',
+            message: 'The live endpoint is dawn.bot-me.ai/api/instar/read (401 = real auth)',
+          },
+        });
+
+        expect(result.isError).toBeFalsy();
+        expect(deps.sendMessage).toHaveBeenCalledTimes(1);
+      } finally {
+        await close();
+      }
+    });
+
+    it('ALLOWS a known/infra domain without an ack (gate does not over-fire)', async () => {
+      const { client, close } = await connectClientServer({}, deps);
+      try {
+        const result = await client.callTool({
+          name: 'threadline_send',
+          arguments: {
+            agentId: 'remote-agent',
+            message: 'See the PR: https://github.com/JKHeadley/instar/pull/642',
+          },
+        });
+
+        expect(result.isError).toBeFalsy();
+        expect(deps.sendMessage).toHaveBeenCalledTimes(1);
+      } finally {
+        await close();
+      }
+    });
+
     it('rejects invalid timeout', async () => {
       const { client, close } = await connectClientServer({}, deps);
       try {

--- a/upgrades/next/threadline-grounding-gate.md
+++ b/upgrades/next/threadline-grounding-gate.md
@@ -1,0 +1,55 @@
+<!-- bump: patch -->
+
+## What Changed
+
+Agent-to-agent messages now pass through a **"Ground Before You Assert"** gate
+before they leave. When you send a peer a message via `threadline_send` that
+asserts a full `https://…` URL to a host you have **not** confirmed this
+session, the send is refused with a clear explanation instead of going out —
+because an unverified claim handed to another agent propagates as fact (this is
+exactly the failure that caused recent Echo↔Dawn incoherence: a peer handed over
+an endpoint that 404'd and a token that 401'd, and both were treated as real).
+
+It is a **block-with-override** gate, not a wall: known infrastructure hosts
+(github, localhost, anthropic, npm, …) pass; a **bare** host reference (no
+scheme — e.g. `dawn.bot-me.ai/api/instar/read`) passes, since it conveys the same
+already-verified information without asserting a live, fetchable endpoint; and
+once you have actually verified the URL (e.g. you curled it), you resend with the
+new `groundingAck: true` argument and it goes through. So a false positive can
+never permanently block a legitimate send — it only forces a conscious moment of
+verification on the exact class of claim that has burned cross-agent trust.
+
+The check is a pure function and runs inside the Threadline MCP process, so it
+adds no network round-trip and never blocks on I/O.
+
+## What to Tell Your User
+
+Your agent is now harder to mislead when it talks to other agents. If it is
+about to tell a peer that some web endpoint is live without having checked, it
+stops itself, verifies, and only then asserts it — the same discipline it already
+applies before messaging you. Nothing for you to configure; agent-to-agent
+collaboration just becomes more trustworthy.
+
+## Summary of New Capabilities
+
+- `threadline_send` refuses a message asserting a scheme-qualified URL to an
+  unverified host, unless the caller sets the new `groundingAck: true` argument
+  (after verifying) — the structural realization of "grounding before every
+  Threadline communication."
+- Known/infra hosts and bare-host references (no scheme) are exempt, so the gate
+  targets only unverified live-endpoint assertions.
+- Pure, in-process check — no added latency, no I/O dependency.
+
+## Evidence
+
+- Logic: `src/threadline/ThreadlineGroundingGate.ts` (`evaluateOutboundGrounding`),
+  9 unit tests covering both sides of the boundary
+  (`tests/unit/threadline/ThreadlineGroundingGate.test.ts`).
+- Wiring: `src/threadline/ThreadlineMCPServer.ts` `registerSendTool` — 4 integration
+  tests over the real MCP Client/Server transport (refuses an ungrounded URL and
+  proves `sendMessage` is never called; allows with `groundingAck`; allows a bare
+  host; allows a known/infra domain) in
+  `tests/unit/threadline/ThreadlineMCPServer.test.ts` (49 tests green).
+- `tsc --noEmit` clean; companion constitution article
+  ("Ground Before You Assert", `docs/STANDARDS-REGISTRY.md`) proposed separately
+  and awaiting operator ratification.


### PR DESCRIPTION
## What

Wires a **"Ground Before You Assert"** gate into `threadline_send` so an agent can't hand a peer an unverified claim as fact. When a message asserts a scheme-qualified `https://…` URL to a host the agent has **not** confirmed this session, the send is refused with a clear explanation instead of going out.

This is the structural realization of Justin's directive: *"make it a standard practice that all INSTAR agents perform grounding before every Threadline communication."* It is the agent-to-agent analog of the existing pre-Telegram `grounding-before-messaging` gate.

**Motivating incoherence (2026-05-31):** a peer handed over `the-portal.vercel.app/api/instar/read` (404) and a token that 401'd on the real host; both propagated as fact because neither was verified before being asserted over the relay.

## Design — block-with-override (Structure > Willpower, Signal-vs-Authority preserved)

- **Refuses** a scheme-qualified URL to an unfamiliar, unverified host.
- **Exempts** known/infra hosts (github, localhost, anthropic, npm, …) and **bare** host references (no scheme — `dawn.bot-me.ai/api/instar/read`), which convey the same already-verified info without asserting a live endpoint.
- **Override:** once the agent has actually verified the URL, it resends with the new `groundingAck: true` arg. So a false positive can never *permanently* block a legitimate send — it only forces a conscious moment of verification on the exact class of claim that has burned cross-agent trust.
- Pure, in-process check (runs in the Threadline MCP stdio process) — no network round-trip, no I/O dependency.

## Blast radius

`threadline_send` is the **agent-initiated** MCP tool; automated server-side relay (the relay-send route) does not go through it. So only conscious agent sends are gated, and only those asserting an unverified live endpoint — the vast majority of agent chatter (no URLs, bare hosts, known domains) is untouched.

## Tests

- **Logic** (`tests/unit/threadline/ThreadlineGroundingGate.test.ts`) — 9 unit tests, both sides of the boundary (no-URL allow, known-domain allow, subdomain allow, ungrounded flag, verified-URL exempt, bare-host allow, allowlist, multi-URL, trailing-punct).
- **Wiring** (`tests/unit/threadline/ThreadlineMCPServer.test.ts`) — 4 integration tests over the real MCP Client/Server transport: refuses an ungrounded URL **and proves `sendMessage` is never called**; allows with `groundingAck`; allows a bare host; allows a known/infra domain.
- Also fixes a pre-existing **time-bomb test** in `ThreadResumeMap.test.ts` (hardcoded fixture date aged past the 24h archival window → deterministic failure after 2026-05-31). Zero-Failure Standard.
- `tsc --noEmit` clean; all 1448 threadline unit tests green.

## Release

- Upgrade-guide fragment: `upgrades/next/threadline-grounding-gate.md` (`bump: patch`).

## Related (separate, not in this PR)

- Companion **constitution article** "Ground Before You Assert" (`docs/STANDARDS-REGISTRY.md`, branch `echo/ground-before-assert`) — proposed, **awaiting operator ratification**. The gate is operationally separable and does not depend on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)