### PR TITLE
fix(feedback-factory): normalize status in active-set + report partitioner (the consumers #651 left raw)

### DIFF
--- a/src/feedback-factory/processor/reportPartition.ts
+++ b/src/feedback-factory/processor/reportPartition.ts
@@ -20,6 +20,7 @@
  */
 
 import type { Cluster } from './types.js';
+import { normalizeStatus } from './transitions.js';
 
 export interface PreviousReportState {
   lastReportAt?: string;
@@ -60,8 +61,13 @@ export function partitionClustersForReport(
   const prevFixed = new Set(prev.reportedFixedIds ?? []);
   const lastReportTime = prev.lastReportAt ?? '';
 
-  const allOpen = clusters.filter((c) => c.status === 'open');
-  const allInvestigating = clusters.filter((c) => c.status === 'investigating');
+  // Partition on the NORMALIZED status so the report is robust to the mixed v1/v2
+  // vocabulary in live data: the "open" bucket is the canonical `new` (the v1 birth
+  // literal `open` projects to `new`), and "fixed" is the canonical `fix_applied`.
+  // Keying off the raw `open`/`fixed` literals silently emptied these partitions for
+  // any cluster already rewritten to its v2 spelling.
+  const allOpen = clusters.filter((c) => normalizeStatus(c.status ?? '') === 'new');
+  const allInvestigating = clusters.filter((c) => normalizeStatus(c.status ?? '') === 'investigating');
 
   const newIssues = allOpen.filter((c) => !prevOpen.has(c.clusterId)).sort(bySeverity);
   const continuingOpen = allOpen.filter((c) => prevOpen.has(c.clusterId));
@@ -77,7 +83,10 @@ export function partitionClustersForReport(
     cutoff = new Date(new Date(now).getTime() - 4 * 60 * 60 * 1000).toISOString();
   }
   const fixedNew = clusters.filter(
-    (c) => c.status === 'fixed' && String(c.updatedAt ?? '') > cutoff && !prevFixed.has(c.clusterId),
+    (c) =>
+      normalizeStatus(c.status ?? '') === 'fix_applied' &&
+      String(c.updatedAt ?? '') > cutoff &&
+      !prevFixed.has(c.clusterId),
   );
 
   const shouldSkip = newIssues.length === 0 && newInvestigating.length === 0 && fixedNew.length === 0;

--- a/src/feedback-factory/store/FeedbackStore.ts
+++ b/src/feedback-factory/store/FeedbackStore.ts
@@ -16,6 +16,7 @@
 import type { FeedbackItem, Cluster, ClusterResult } from '../processor/types.js';
 import type { ReopenDecision } from '../processor/reopen.js';
 import type { DispatchRecord } from '../dispatch/dispatch.js';
+import { isTerminalStatus } from '../processor/transitions.js';
 
 /** Read-only observability counters for the capture→cluster→reopen loop (spec §2.7). */
 export interface FeedbackMetrics {
@@ -28,7 +29,7 @@ export interface FeedbackMetrics {
 export interface FeedbackStore {
   /** Unprocessed feedback, oldest first (mirrors the reference's `status:'unprocessed'` query). */
   getUnprocessedFeedback(): FeedbackItem[];
-  /** Active clusters (status != 'resolved'), the merge candidates. */
+  /** Active clusters (normalized status NOT terminal), the merge candidates. */
   getActiveClusters(): Cluster[];
   getCluster(clusterId: string): Cluster | undefined;
   /** Create a new cluster from an item (or bump reportCount if it already exists). */
@@ -75,7 +76,13 @@ export class InMemoryFeedbackStore implements FeedbackStore {
   }
 
   getActiveClusters(): Cluster[] {
-    return [...this.clusters.values()].filter((c) => c.status !== 'resolved');
+    // Active = NOT terminal against the NORMALIZED status (mirrors the reference's
+    // active-cluster query, which excludes the full terminal set). The prior
+    // `!== 'resolved'` check only excluded the raw v1 literal, so it stranded every
+    // canonical terminal cluster — `closed`, `verified`, `wontfix`, `duplicate`,
+    // `chronic_escalated`, `legacy_closed` — as a perpetual merge candidate. It also
+    // missed a raw v1 `resolved` (terminal only once projected to `closed`).
+    return [...this.clusters.values()].filter((c) => !isTerminalStatus(c.status ?? ''));
   }
 
   getCluster(clusterId: string): Cluster | undefined {

--- a/tests/unit/feedback-factory/reportPartition.test.ts
+++ b/tests/unit/feedback-factory/reportPartition.test.ts
@@ -59,4 +59,30 @@ describe('partitionClustersForReport', () => {
     const hasNew = partitionClustersForReport([c('o2', 'open')], { lastReportAt: '2026-05-26T00:00:00Z' }, NOW);
     expect(hasNew.shouldSkip).toBe(false);
   });
+
+  // --- v2-vocabulary regression: the prior raw 'open'/'fixed' filters silently
+  //     emptied these partitions for any cluster already rewritten to its v2 spelling.
+  it('surfaces canonical v2 `new` clusters in the open partition (open ≡ new)', () => {
+    const clusters = [c('n1', 'new'), c('n2', 'new')];
+    const p = partitionClustersForReport(clusters, { lastReportAt: '2026-05-26T00:00:00Z', reportedOpenIds: ['n1'] }, NOW);
+    expect(p.newIssues.map(x => x.clusterId)).toEqual(['n2']);
+    expect(p.continuingOpen.map(x => x.clusterId)).toEqual(['n1']);
+  });
+
+  it('surfaces canonical v2 `fix_applied` clusters in the fixed partition (fixed → fix_applied)', () => {
+    const clusters = [c('fa', 'fix_applied', { updatedAt: '2026-05-26T12:00:00Z' })];
+    const p = partitionClustersForReport(clusters, { lastReportAt: '2026-05-26T00:00:00Z' }, NOW);
+    expect(p.fixedNew.map(x => x.clusterId)).toEqual(['fa']);
+  });
+
+  it('partitions a mixed v1/v2 batch identically (open+new together, fixed+fix_applied together)', () => {
+    const clusters = [
+      c('raw-open', 'open'), c('v2-new', 'new'),
+      c('raw-fixed', 'fixed', { updatedAt: '2026-05-26T12:00:00Z' }),
+      c('v2-fix', 'fix_applied', { updatedAt: '2026-05-26T12:00:00Z' }),
+    ];
+    const p = partitionClustersForReport(clusters, { lastReportAt: '2026-05-26T00:00:00Z' }, NOW);
+    expect(p.newIssues.map(x => x.clusterId).sort()).toEqual(['raw-open', 'v2-new']);
+    expect(p.fixedNew.map(x => x.clusterId).sort()).toEqual(['raw-fixed', 'v2-fix']);
+  });
 });

--- a/tests/unit/feedback-factory/store.test.ts
+++ b/tests/unit/feedback-factory/store.test.ts
@@ -21,12 +21,36 @@ describe('InMemoryFeedbackStore', () => {
     expect(s.getUnprocessedFeedback().map(f => f.feedbackId)).toEqual(['fb-1', 'fb-2']);
   });
 
-  it('getActiveClusters excludes resolved', () => {
+  it('getActiveClusters excludes resolved (legacy literal → normalizes to terminal closed)', () => {
     const s = new InMemoryFeedbackStore({ clusters: [
       { clusterId: 'c-open', title: 'o', description: 'd', status: 'investigating' },
       { clusterId: 'c-res', title: 'r', description: 'd', status: 'resolved' },
     ]});
     expect(s.getActiveClusters().map(c => c.clusterId)).toEqual(['c-open']);
+  });
+
+  it('getActiveClusters keeps every non-terminal lifecycle state as a merge candidate', () => {
+    // Non-terminal states (incl. legacy spellings open→new, fixed→fix_applied) stay active.
+    const active = ['new', 'open', 'investigating', 'research_complete', 'fix_applied',
+      'fixed', 'dispatched', 'verified_tentative', 'chronic', 'deferred', 'needs_human_verify'];
+    const s = new InMemoryFeedbackStore({
+      clusters: active.map((status, i) => ({ clusterId: `c-${i}`, title: 't', description: 'd', status })),
+    });
+    expect(s.getActiveClusters().map(c => c.clusterId)).toEqual(active.map((_, i) => `c-${i}`));
+  });
+
+  it('getActiveClusters excludes EVERY terminal state — the perpetual-merge-candidate bug', () => {
+    // The prior `!== "resolved"` filter wrongly kept closed/verified/wontfix/duplicate/
+    // chronic_escalated/legacy_closed as active forever. All must now be excluded;
+    // raw v1 `resolved` too (terminal only once normalized to `closed`).
+    const terminal = ['closed', 'verified', 'wontfix', 'duplicate', 'chronic_escalated', 'legacy_closed', 'resolved'];
+    const s = new InMemoryFeedbackStore({
+      clusters: [
+        { clusterId: 'c-active', title: 't', description: 'd', status: 'new' },
+        ...terminal.map((status, i) => ({ clusterId: `c-term-${i}`, title: 't', description: 'd', status })),
+      ],
+    });
+    expect(s.getActiveClusters().map(c => c.clusterId)).toEqual(['c-active']);
   });
 
   it('upsertClusterFromItem creates then bumps reportCount + created counter', () => {

--- a/upgrades/next/feedback-factory-report-active-consumers.md
+++ b/upgrades/next/feedback-factory-report-active-consumers.md
@@ -1,0 +1,61 @@
+## What Changed
+
+**The feedback-factory's merge-candidate query and operator-report partitioner no
+longer go blind when a cluster carries the canonical v2 status spelling.** #651 added
+the canonical status-normalization primitives and applied them to the parity
+comparator, but two *internal* call-sites still keyed off the legacy v1 status words.
+The active-cluster query (the merge-candidate set) treated only the literal
+`resolved` as terminal, and the operator-report partitioner matched only the literals
+`open` and `fixed`. Because live clusters are increasingly born and resolved in the
+canonical v2 vocabulary (`new`, `fix_applied`, `closed`, `verified`, …), those
+raw-literal checks silently misbehaved: every terminal v2 cluster (`closed`,
+`verified`, `wontfix`, `duplicate`, `chronic_escalated`, `legacy_closed`) was kept
+forever as an active merge candidate, and v2 `new` / `fix_applied` clusters never
+appeared in the "new issues" / "fixed" sections of the report.
+
+The fix routes both call-sites through the canonical primitives merged in #651
+(`normalizeStatus` / `isTerminalStatus` in `transitions.ts`) — no new module, one
+owner for the vocabulary. The active set is now "normalized status not terminal"; the
+report partitions on the normalized status (`open` ≡ `new`, `fixed` → `fix_applied`).
+Legacy and canonical spellings are treated identically.
+
+## What to Tell Your User
+
+Nothing to configure, and nothing changes for any current capability. This is
+internal plumbing for the in-progress feedback-factory migration. Two internal checks
+that decide which feedback clusters are still active and which appear in the operator
+digest were keyed to the old status words; they now understand the new status words
+too, so clusters are no longer wrongly held open forever and the digest no longer
+drops freshly opened or fixed items. No routes, jobs, or user-facing behavior change.
+
+## Summary of New Capabilities
+
+- `FeedbackStore.getActiveClusters` (`src/feedback-factory/store/FeedbackStore.ts`) now
+  excludes a cluster when its NORMALIZED status is terminal (`!isTerminalStatus(status)`),
+  instead of the raw `status !== 'resolved'` check that stranded every canonical
+  terminal cluster as a perpetual merge candidate.
+- `partitionClustersForReport` (`src/feedback-factory/processor/reportPartition.ts`) now
+  normalizes before bucketing: the open partition is canonical `new` (v1 `open` projects
+  to it), and the fixed partition is canonical `fix_applied`. A mixed v1/v2 batch
+  partitions identically.
+- Both reuse the `normalizeStatus` / `isTerminalStatus` primitives from `transitions.ts`
+  (the ones merged in #651) — no duplicate vocabulary module.
+
+## Evidence
+
+The two checks previously keyed off raw v1 literals. Behavior before vs after,
+confirmed by both-sides-of-boundary unit tests:
+
+```
+getActiveClusters, cluster.status = "closed" (canonical terminal):
+  BEFORE (status !== 'resolved'):    kept ACTIVE forever  ← perpetual merge-candidate bug
+  AFTER  (!isTerminalStatus):        excluded (terminal)
+
+reportPartition, cluster.status = "new" / "fix_applied" (canonical v2):
+  BEFORE (=== 'open' / === 'fixed'): never matched → dropped from the report
+  AFTER  (normalizeStatus ...):      surfaced in the open / fixed partitions
+```
+
+Verified across the full feedback-factory suite: 165 unit + integration tests green
+(incl. new `store.test.ts` terminal / non-terminal active-set tests and
+`reportPartition.test.ts` v1/v2 mixed-batch tests), `tsc` clean.

--- a/upgrades/side-effects/feedback-factory-report-active-consumers.md
+++ b/upgrades/side-effects/feedback-factory-report-active-consumers.md
@@ -1,0 +1,63 @@
+# Side-Effects Review — feedback-factory: normalize the active-set + report-partition consumers
+
+**Slug:** `feedback-factory-report-active-consumers`
+**Date:** `2026-05-31`
+**Author:** Echo
+**Spec:** `docs/specs/feedback-factory-migration.md` (converged v2, approved 2026-05-26, topic 12476)
+**Builds on:** #651 (canonical status normalization primitives in `transitions.ts` + parity comparator)
+**Second-pass reviewer:** not required (two call-site swaps onto an already-merged, already-reviewed primitive; both-sides-of-boundary unit coverage)
+**Scope:** Two internal consumers of cluster status that #651 did not touch — `FeedbackStore.getActiveClusters` (the merge-candidate set) and `partitionClustersForReport` (the operator-digest partitioner). Both now key off the canonical `normalizeStatus` / `isTerminalStatus` primitives instead of raw v1 literals.
+
+## Summary of the change
+
+During the Portal→Instar migration three status vocabularies coexist; #651 reconciled them in the parity comparator. Two internal call-sites were still raw:
+
+- `FeedbackStore.getActiveClusters` returned `clusters.filter(c => c.status !== 'resolved')`. `resolved` is a v1 literal; live v2/v3.1 clusters reach terminal as `closed` / `verified` / `wontfix` / `duplicate` / `chronic_escalated` / `legacy_closed`, none of which equal `'resolved'`. Result: every canonical terminal cluster was kept active forever as a merge candidate. (It also missed a raw v1 `resolved`, which is terminal only once projected to `closed`.)
+- `partitionClustersForReport` matched `c.status === 'open'` (new-issues bucket) and `c.status === 'fixed'` (fixed bucket). Live clusters born `new` and resolved `fix_applied` never matched, silently emptying those report partitions.
+
+The fix imports `isTerminalStatus` / `normalizeStatus` from `transitions.ts` (single owner, merged in #651) and: (a) active = `!isTerminalStatus(c.status ?? '')`; (b) open partition = `normalizeStatus(c.status ?? '') === 'new'`, fixed partition = `=== 'fix_applied'`. `c.status` is optional, so `?? ''` preserves the prior undefined→active / undefined→excluded behavior. No route, job, or schema change.
+
+## Decision-point inventory
+
+- `FeedbackStore.getActiveClusters` active/terminal filter — **modify** — raw `!== 'resolved'` → `!isTerminalStatus(normalized)`. Excludes the full terminal set; keeps every non-terminal state (incl. legacy `open`/`fixed` → `new`/`fix_applied`).
+- `partitionClustersForReport` open/investigating/fixed buckets — **modify** — raw `=== 'open'`/`'fixed'` → normalized `=== 'new'`/`'fix_applied'`; `investigating` unchanged (identity under normalization).
+- No new primitives — both reuse the #651 `transitions.ts` exports.
+
+---
+
+## 1. Over-block
+
+Neither call-site is an allow/block surface over user or agent traffic.
+
+- `getActiveClusters` over-inclusion (the real prior bug) was the inverse of a block: it kept terminal clusters as merge candidates, so new feedback could be merged into an already-closed cluster instead of opening a fresh one. The fix REMOVES that over-inclusion; it does not newly exclude any non-terminal cluster (every non-terminal v1/v2 state is asserted still-active in `store.test.ts`).
+- `partitionClustersForReport` decides report visibility, not gating. No new suppression: the open/fixed partitions now include MORE (the v2-spelled clusters that were silently dropped), never fewer.
+
+---
+
+## 2. Under-block
+
+**What real signal could normalization now mask?** Only a difference that vanishes under the fixed v1→v2 map (`open→new`, `fixed→fix_applied`, `resolved→closed`; identity otherwise) — the same small bijection reviewed in #651. For the active set: a cluster is dropped from merge candidates only when its normalized status is genuinely terminal; a non-terminal state can never normalize into the terminal set (asserted both-sides in `store.test.ts`). For the report: a `new`/`fix_applied`/`investigating` cluster is bucketed exactly as its v1 synonym would have been — no real "new issue" or "fix" is hidden; the change only stops hiding the v2-spelled ones. `legacy_closed` (terminal-only, not in `V2_STATES`) is correctly excluded from the active set via `isTerminalStatus`.
+
+---
+
+## 3. Level-of-abstraction fit
+
+Correct layer, and an explicit de-duplication: both consumers now call the shared `transitions.ts` primitives rather than re-encoding status semantics inline. This is the single-owner outcome — the vocabulary lives in one module (`transitions.ts`), and the store + report partitioner are pure consumers. No separate `statusVocab` module is introduced (an earlier scratch line that would have duplicated the primitives is deliberately abandoned). No higher-level gate is bypassed; no lower-level primitive is re-implemented.
+
+---
+
+## 4. Signal vs authority compliance
+
+**Required reference:** [docs/signal-vs-authority.md](../../docs/signal-vs-authority.md)
+
+- [x] No — neither change has any block/allow authority over user/agent messages or operations.
+
+`getActiveClusters` produces the merge-candidate SIGNAL consumed by the clustering step; the authoritative cluster history remains the curated store, untouched here. `partitionClustersForReport` produces a digest-visibility signal consumed by a human-read operator report. Both become MORE accurate (no stranded terminals, no dropped v2 clusters) without gaining new authority.
+
+---
+
+## Testing
+
+- `tests/unit/feedback-factory/store.test.ts` — getActiveClusters keeps every non-terminal lifecycle state (incl. legacy `open`/`fixed`) active; excludes EVERY terminal state (`closed`, `verified`, `wontfix`, `duplicate`, `chronic_escalated`, `legacy_closed`, raw `resolved`).
+- `tests/unit/feedback-factory/reportPartition.test.ts` — canonical `new` surfaces in the open partition; canonical `fix_applied` in the fixed partition; a mixed v1/v2 batch partitions identically.
+- Full feedback-factory suite: 165 unit + integration green; `tsc --noEmit` clean.


### PR DESCRIPTION
## What & why

#651 added the canonical status-normalization primitives (`normalizeStatus` / `isTerminalStatus` / `V1_TO_V2_STATUS` / `TERMINAL_STATUSES` in `transitions.ts`) and applied them to the **parity comparator**. This PR fixes the **two internal consumers #651 didn't touch**, which still keyed off raw v1 status literals:

- **`FeedbackStore.getActiveClusters`** used `c.status !== 'resolved'`. Live v2/v3.1 clusters reach terminal as `closed` / `verified` / `wontfix` / `duplicate` / `chronic_escalated` / `legacy_closed` — none equal `'resolved'` — so **every canonical terminal cluster was kept active forever as a merge candidate** (and a raw v1 `resolved` slipped through, terminal only once projected to `closed`).
- **`partitionClustersForReport`** matched `=== 'open'` / `=== 'fixed'`. Clusters born `new` and fixed `fix_applied` never matched, **silently emptying the new-issues and fixed partitions** of the operator digest.

## How

Both now route through the **already-merged** `transitions.ts` primitives — single owner, **no duplicate vocabulary module**:
- active = `!isTerminalStatus(c.status ?? '')`
- report partitions on the normalized status (`open` ≡ `new`, `fixed` → `fix_applied`)

`Cluster.status` is optional, so `?? ''` preserves the prior undefined-handling behavior (undefined → active / excluded exactly as before).

## Tests (both sides of every boundary)

- `store.test.ts` — keeps every non-terminal lifecycle state active (incl. legacy `open`/`fixed`); excludes EVERY terminal state (`closed`, `verified`, `wontfix`, `duplicate`, `chronic_escalated`, `legacy_closed`, raw `resolved`).
- `reportPartition.test.ts` — canonical `new` surfaces in the open partition; canonical `fix_applied` in the fixed partition; a mixed v1/v2 batch partitions identically.
- Full feedback-factory suite: **165 unit + integration green**, `tsc --noEmit` clean.

Ships with a release-note fragment + side-effects review artifact (`feedback-factory-report-active-consumers`).

Builds on #651. Contract grounded against Dawn's canonical Portal reference (thread-978f016b).

🤖 Generated with [Claude Code](https://claude.com/claude-code)