### PR TITLE
fix(multi-machine): tokenless standby skips its redundant local tone gate on a relayed reply

### DIFF
--- a/docs/specs/standby-skip-local-tone-gate-on-relay.eli16.md
+++ b/docs/specs/standby-skip-local-tone-gate-on-relay.eli16.md
@@ -1,0 +1,51 @@
+# ELI16: Why a moved conversation's reply got stuck behind a redundant safety check
+
+## The setup
+
+Before I send a message to you, a "tone gate" reads it and decides if it's
+okay to send — it's a quality check that uses a quick call to the AI model.
+
+Now, when a conversation is moved to my second machine (the Mac Mini), that
+machine doesn't send to you directly — it has no Telegram "password." So it hands
+the reply to the laptop (which has the password), and the laptop sends it. That
+hand-off is the "relay."
+
+## The problem
+
+Here's the waste: the reply got tone-gated **twice**. The Mac Mini ran the tone
+gate on the reply, *then* handed it to the laptop, and the laptop ran the tone
+gate on the very same reply again. Two AI calls for one message.
+
+That's not just inefficient — it's where things got stuck. The tone gate's AI
+call, under the rate-limit protection I added earlier, is allowed to **wait up to
+2 minutes** if the system is rate-limited (better to wait and stay correct than
+fail). So on a busy day, the Mac Mini's reply would sit in its own tone gate for
+up to two minutes *before it even started* handing the reply to the laptop. I
+watched a relayed reply hang for over 50 seconds for exactly this reason.
+
+## The fix
+
+Simple rule: **the machine that's only relaying shouldn't run the tone gate at
+all** — the machine that actually sends to you (the laptop) already runs it. One
+gate, on the machine that owns the connection, is the right place.
+
+So now: if a machine is about to relay a reply (because it has no Telegram
+password and a relay is set up), it skips its own tone gate and hands the reply
+straight over. The laptop still gates it properly before it reaches you. The
+message is just as safe, but the redundant check — and its up-to-2-minute stall —
+is gone.
+
+## Keeping it safe
+
+- A machine that sends **directly** (the one with the password) still runs its
+  tone gate exactly as before — nothing changes there.
+- Single-machine setups never relay, so they're completely unaffected.
+- The reply is never left ungated — it's gated by the machine that actually
+  delivers it, which is the correct single place.
+
+## Why it matters
+
+A multi-machine reply that freezes for a minute or two because of a doubled-up
+safety check is exactly the kind of fragility-under-load we're trying to kill.
+Removing the redundant gate makes the cross-machine reply both faster and simpler,
+without giving up any of the actual safety.

--- a/docs/specs/standby-skip-local-tone-gate-on-relay.md
+++ b/docs/specs/standby-skip-local-tone-gate-on-relay.md
@@ -1,0 +1,75 @@
+---
+title: A tokenless standby skips its local tone gate on a relayed reply (the holder gates it)
+slug: standby-skip-local-tone-gate-on-relay
+status: approved
+review-convergence: 2026-06-01T05:05:00+00:00
+approved: true
+author: echo
+approval-note: >
+  Self-approved by Echo under the delegated deploy mandate during the autonomous
+  multi-machine proof run (topic 13481, 2026-06-01). Found by code-grounded
+  diagnosis of why the standby's /telegram/reply hung >50s before relaying.
+  Serves Justin's "robust under degraded conditions" standard. Flagged per
+  cross-agent discipline.
+---
+
+# Standby skips its local tone gate on a relayed reply
+
+## Problem
+
+The `/telegram/reply` route runs the outbound tone gate
+(`checkOutboundMessage` → `MessagingToneGate.review`) on the reply text BEFORE
+sending. On a multi-machine pool standby serving a moved session, `sendToTopic`
+does not send directly — it RELAYS the reply to the Telegram-owning lease holder,
+whose own `/telegram/reply` runs the holder's tone gate again. So the standby
+tone-gating the reply is:
+
+1. **Redundant** — the holder (the single Telegram owner) gates the same reply on
+   receipt. The reply is already the agent's finalized output.
+2. **A pre-relay stall** — `MessagingToneGate.review` makes a serial LLM call
+   (`claude -p`), and under the rate-limit-resilience fix that call carries
+   `rateLimitWaitMs = 120_000`: when the LLM circuit breaker is open
+   (rate-limited), the tone gate WAITS up to 120s before returning — and the
+   relay only starts after that. Observed live (2026-06-01): a standby's
+   `/telegram/reply` hung >50s before relaying, with the relay's own
+   `AbortController` timeout unable to help because the stall is BEFORE the relay
+   call.
+
+Net: every cross-machine reply pays a double tone-gate, and under load the
+standby's gate can stall the whole reply for up to two minutes before the relay
+even begins — exactly the fragility the multi-machine feature must not have.
+
+## Solution
+
+When a server will RELAY the reply (a tokenless standby with `outboundRelay`
+wired), skip its LOCAL tone gate. The holder gates it.
+
+- `TelegramAdapter.willRelay(): boolean` — returns the exact `sendToTopic`
+  relay-vs-direct branch condition (`!hasUsableBotToken && outboundRelay !==
+  null`). A non-empty string token → false (direct send, still gates locally).
+- `/telegram/reply` skips `checkOutboundMessage` when `ctx.telegram.willRelay()`
+  (alongside the existing `isProxy` / `isSystemTemplate` skips). Direct sends are
+  unchanged — they still gate locally.
+
+## Scope
+
+- `src/messaging/TelegramAdapter.ts` — new `willRelay()` method.
+- `src/server/routes.ts` — `/telegram/reply` skips the local tone gate when
+  `willRelay()`.
+
+## Testing
+
+`tests/unit/telegram-tokenless-relay.test.ts` (+4): `willRelay()` is true for a
+`{secret:true}` placeholder + relay wired, true for null token + relay, false for
+a real string token, false for tokenless with no relay wired. Regression: 57/57
+across TelegramAdapter + MessagingToneGate + relay-timeout suites; `tsc` clean.
+
+## Non-goals / safety
+
+- Does NOT weaken outbound gating: the reply is still gated, by the holder (the
+  single Telegram owner). Only the redundant standby-side gate is skipped.
+- Direct (non-relay) sends are byte-unchanged — they gate locally exactly as
+  before. Single-machine agents never relay, so they are unaffected.
+- This pairs with the relay timeout/observability/truthful-success fix
+  (v1.3.182): together they bound BOTH the pre-relay path (this) and the relay
+  call itself.

--- a/src/messaging/TelegramAdapter.ts
+++ b/src/messaging/TelegramAdapter.ts
@@ -465,6 +465,25 @@ export class TelegramAdapter implements MessagingAdapter {
    */
   public outboundRelay: ((topicId: number, text: string, options?: { silent?: boolean }) => Promise<SendResult | null>) | null = null;
 
+  /**
+   * True when a `sendToTopic` will RELAY through the lease holder rather than
+   * send directly — i.e. this is a tokenless pool standby with `outboundRelay`
+   * wired. Mirrors the exact `sendToTopic` branch condition (no usable string
+   * bot token + a relay available). Callers use this to skip work the HOLDER
+   * will do anyway: e.g. the `/telegram/reply` route skips its LOCAL tone gate
+   * for a relayed reply, because (a) the reply is already the agent's finalized
+   * output, (b) the Telegram-owning holder runs ITS tone gate on receipt, and
+   * (c) running the standby's tone gate adds a serial LLM call to every
+   * cross-machine reply — which, under a rate-limited circuit, waits up to
+   * `MessagingToneGate` rateLimitWaitMs (120s) BEFORE the relay even starts.
+   * That double-gate + pre-relay stall is a real robustness defect on the
+   * standby reply path.
+   */
+  willRelay(): boolean {
+    const hasUsableBotToken = typeof this.config.token === 'string' && this.config.token.length > 0;
+    return !hasUsableBotToken && this.outboundRelay !== null;
+  }
+
   // Sentinel interceptor — fires BEFORE the message handler for real-time interrupt detection.
   // Returns the sentinel classification. If category is 'emergency-stop' or 'pause',
   // the adapter will handle the session action and skip the normal handler.

--- a/src/server/routes.ts
+++ b/src/server/routes.ts
@@ -5861,9 +5861,19 @@ export function createRoutes(ctx: RouteContext): Router {
     const isProxy = metadata?.isProxy === true;
     const allowDebugText = metadata?.allowDebugText === true;
     const allowDuplicate = metadata?.allowDuplicate === true;
+    // Skip the LOCAL tone gate when this server will RELAY the reply through the
+    // lease holder (a tokenless pool standby). The holder runs ITS OWN tone gate
+    // on receipt, so the standby gating too is redundant — and worse, it adds a
+    // serial LLM call to every cross-machine reply that, under a rate-limited
+    // circuit, can wait up to 120s (MessagingToneGate rateLimitWaitMs) BEFORE the
+    // relay even starts (observed: the standby's /telegram/reply hung >50s before
+    // relaying). The holder is the single Telegram owner and the correct place to
+    // gate. (Direct, non-relay sends still gate locally — unchanged.)
+    const willRelay = typeof ctx.telegram.willRelay === 'function' && ctx.telegram.willRelay();
     if (
       !isProxy &&
       !isSystemTemplate &&
+      !willRelay &&
       (await checkOutboundMessage(text, 'telegram', res, {
         topicId,
         allowDebugText,

--- a/tests/unit/telegram-tokenless-relay.test.ts
+++ b/tests/unit/telegram-tokenless-relay.test.ts
@@ -77,4 +77,34 @@ describe('TelegramAdapter — tokenless-standby relay decision (bug #7)', () => 
     expect(relay).not.toHaveBeenCalled();
     expect(mockFetch).toHaveBeenCalled(); // real token → direct Telegram API call
   });
+
+  // ── willRelay() — used by /telegram/reply to skip its local tone gate for a
+  // relayed reply (the holder gates it; the standby gating too is redundant and
+  // adds a 120s-under-rate-limit pre-relay stall). Must mirror sendToTopic's
+  // exact relay-vs-direct branch.
+  describe('willRelay()', () => {
+    it('is TRUE for a tokenless standby ({secret:true} placeholder) with a relay wired', () => {
+      adapter = makeAdapter({ secret: true });
+      adapter.outboundRelay = vi.fn().mockResolvedValue({ messageId: 1, topicId: 42 });
+      expect(adapter.willRelay()).toBe(true);
+    });
+
+    it('is TRUE for a null token with a relay wired', () => {
+      adapter = makeAdapter(null);
+      adapter.outboundRelay = vi.fn().mockResolvedValue({ messageId: 1, topicId: 42 });
+      expect(adapter.willRelay()).toBe(true);
+    });
+
+    it('is FALSE when a real string token is present (sends directly, gates locally)', () => {
+      adapter = makeAdapter('123456:realbottoken');
+      adapter.outboundRelay = vi.fn();
+      expect(adapter.willRelay()).toBe(false);
+    });
+
+    it('is FALSE for a tokenless adapter with NO relay wired (cannot relay)', () => {
+      adapter = makeAdapter({ secret: true });
+      adapter.outboundRelay = null;
+      expect(adapter.willRelay()).toBe(false);
+    });
+  });
 });

--- a/upgrades/next/standby-skip-local-tone-gate-on-relay.md
+++ b/upgrades/next/standby-skip-local-tone-gate-on-relay.md
@@ -1,0 +1,48 @@
+# Upgrade Guide — vNEXT
+
+<!-- bump: patch -->
+
+## What Changed
+
+**A moved conversation's reply no longer gets stuck behind a redundant safety
+check.** When a conversation is moved to another machine, that machine relays its
+replies through the machine that holds the Telegram connection. The reply was
+being tone-gated twice — once on the relaying machine and again on the machine
+that actually delivers it. The first gate was not just redundant: its quality
+check makes an AI call that, under rate-limit protection, is allowed to wait up
+to two minutes before proceeding — so on a busy system the relaying machine could
+stall a reply for that long before it even handed it off (a relayed reply was
+observed hanging over 50 seconds for exactly this reason).
+
+Now the relaying machine skips its own tone gate; the machine that actually
+delivers the reply still runs it. One gate, in the right place — the reply is
+just as safe, the redundant stall is gone. Machines that send directly (and
+single-machine setups) are unaffected.
+
+## What to Tell Your User
+
+Nothing to configure. If you run across more than one machine and move a
+conversation between them, replies relay faster and no longer stall behind a
+duplicated quality check — while still being checked once, on the machine that
+delivers them.
+
+## Summary of New Capabilities
+
+- `TelegramAdapter.willRelay()` — true when a send will relay through the lease
+  holder (tokenless standby). `/telegram/reply` uses it to skip its local tone
+  gate for a relayed reply (the holder gates it). Direct sends gate locally,
+  unchanged.
+
+## Evidence
+
+- Code-grounded diagnosis (2026-06-01): `/telegram/reply` runs
+  `checkOutboundMessage` → `MessagingToneGate.review` (a `claude -p` LLM call
+  carrying `rateLimitWaitMs: 120000`) BEFORE `sendToTopic`/relay. On a standby,
+  that gate runs, then the relay hands the same reply to the holder, which gates
+  it again. Under a rate-limited circuit the standby's gate can wait up to 120s
+  pre-relay — matching the observed >50s hang of a standby reply.
+- Tests: `tests/unit/telegram-tokenless-relay.test.ts` (+4) — `willRelay()` is
+  true for a tokenless standby ({secret:true} placeholder, or null token) with a
+  relay wired, false for a real string token, false for tokenless with no relay
+  wired. Regression: 57/57 across the TelegramAdapter, MessagingToneGate, and
+  relay-timeout suites. `tsc` clean.

--- a/upgrades/side-effects/standby-skip-local-tone-gate-on-relay.md
+++ b/upgrades/side-effects/standby-skip-local-tone-gate-on-relay.md
@@ -1,0 +1,41 @@
+# Side effects — standby skips its local tone gate on a relayed reply
+
+## What changes at runtime
+
+On a tokenless pool standby (a machine serving a moved session, relaying its
+replies through the lease holder), the `/telegram/reply` route now SKIPS its
+local tone gate. The holder's `/telegram/reply` still runs the holder's tone
+gate. Detection is a new `TelegramAdapter.willRelay()` (exact `sendToTopic`
+relay-vs-direct condition).
+
+## Who is affected
+
+- **Direct senders (the token-holding machine, single-machine agents):** ZERO
+  change. `willRelay()` is false (real string token), so they gate locally
+  exactly as before.
+- **Tokenless standbys (a moved session replying):** skip the local tone gate;
+  the reply is gated by the holder on receipt. This removes a redundant LLM call
+  per cross-machine reply and the up-to-120s pre-relay stall it caused under a
+  rate-limited circuit.
+
+## Blast radius
+
+- 2 files: `src/messaging/TelegramAdapter.ts` (new method) + `src/server/routes.ts`
+  (one skip condition in `/telegram/reply`). No config, no schema, no migration
+  (compiled source).
+- The skip is additive to the existing `isProxy` / `isSystemTemplate` skips.
+
+## Failure modes considered
+
+- **Ungated reply?** No — the reply is gated by the holder (the single Telegram
+  owner), which is the correct single place. The standby reply is the agent's
+  finalized output; gating it twice was redundant, not a second layer of real
+  protection.
+- **Misdetection?** `willRelay()` mirrors the exact `sendToTopic` branch
+  (`!hasUsableBotToken && outboundRelay`), so it's true iff the send would
+  actually relay. A defensive `typeof ctx.telegram.willRelay === 'function'`
+  guard in the route means an older adapter without the method just keeps gating
+  (safe default).
+- **Pairs with v1.3.182:** the relay call itself is already bounded + truthful;
+  this bounds the path BEFORE the relay. Together they remove both stall points
+  on the standby reply path.


### PR DESCRIPTION
## What

**A moved conversation's reply no longer stalls behind a redundant tone gate.** The reply endpoint runs the outbound tone gate (`checkOutboundMessage` → `MessagingToneGate.review`) before sending. On a pool standby serving a moved session, `sendToTopic` **relays** the reply to the Telegram-owning lease holder — whose own reply endpoint gates it again. So the standby's gate is:

1. **Redundant** — the holder (the single Telegram owner) gates the same finalized reply.
2. **A pre-relay stall** — `MessagingToneGate.review` is a serial `claude -p` LLM call carrying `rateLimitWaitMs=120000`; under an open (rate-limited) circuit it **waits up to 120s** before returning, and the relay only starts after. Observed live (2026-06-01): a standby reply endpoint hung **>50s before relaying** — and the relay's own `AbortController` timeout can't help, because the stall is *before* the relay call.

Found by code-grounded diagnosis while driving the multi-machine live proof under degraded conditions.

## Fix

`TelegramAdapter.willRelay()` returns the exact `sendToTopic` relay-vs-direct condition (`!hasUsableBotToken && outboundRelay !== null`). The reply endpoint **skips its local tone gate when `willRelay()`** (alongside the existing `isProxy`/`isSystemTemplate` skips). The holder still gates the relayed reply. Direct sends gate locally, unchanged; single-machine agents never relay → unaffected. A defensive `typeof`-guard means an older adapter without the method keeps gating (safe default).

Pairs with v1.3.182 (relay timeout + truthful success): together they bound the **pre-relay path** (this) and the **relay call** itself — no stall point left on the cross-machine reply path.

## Tests

`tests/unit/telegram-tokenless-relay.test.ts` (+4): `willRelay()` true for a `{secret:true}` placeholder + relay wired and for a null token + relay, false for a real string token, false for tokenless with no relay wired. Regression: **57/57** across the TelegramAdapter, MessagingToneGate, and relay-timeout suites. `tsc` clean.

## Safety

The reply is never left ungated — it's gated by the holder, the correct single place. Only the redundant standby-side gate is removed. (Branch name says "relay-durable-retry" — that was the original worktree; this PR is the tone-gate-skip fix found en route. Durable-retry remains a separate scoped follow-up.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
