### PR TITLE
fix(commitments,health): land Codey's gap-run fixes batch 1 (F007 + F003)

### DIFF
--- a/docs/specs/codey-gap-run-fixes-batch-1.eli16.md
+++ b/docs/specs/codey-gap-run-fixes-batch-1.eli16.md
@@ -1,0 +1,50 @@
+# Codey gap-run fixes, batch 1 — Plain-English Overview
+
+> The one-line version: Codey (a codex agent) found and fixed two real bugs during an autonomous run but couldn't commit them himself, so Echo reviewed and is shipping the two clean ones — a "promise tracker" that was marking promises done before they happened, and a health check that cried "Telegram is broken" when it wasn't.
+
+## The problem in one breath
+
+When you experiment with a codex-based agent on a long autonomous task, it can find
+genuine bugs and even fix them — but it can't get its fixes through the safety gate
+that requires a converged spec and your approval. Echo (the agent that builds Instar)
+has that path. So Echo is landing the verified ones, the way a mentor lands a
+mentee's good work.
+
+## What already exists
+
+- **The promise tracker** — when an agent says "I'll report back in 20 minutes," it
+  opens a tracked commitment so the follow-through survives restarts. A background
+  "beacon" nudges it until it's actually done.
+- **Health checks** — the agent runs little probes that report whether things like
+  Telegram are working, so problems surface early.
+
+## What this adds
+
+Two fixes Codey found:
+
+1. **The promise tracker was marking beacon-backed promises "done" almost immediately**
+   — seconds after they were opened, before the beacon ever nudged once. That quietly
+   defeated the whole point of opening a promise. Now a beacon-backed promise stays
+   open until the agent explicitly says it delivered.
+
+2. **A health check was reporting "Telegram broken" when it was fine.** In one of
+   Instar's normal modes, a separate helper process does the Telegram listening and the
+   main server only sends. The health check didn't know about that mode and saw "not
+   listening = broken." Now it recognizes the helper-owns-listening mode and reports
+   healthy.
+
+## The safeguards
+
+**Neither fix forces anything.** The promise fix only keeps a promise open longer (it
+never force-marks it done). The health fix only turns a false alarm into a pass when
+the helper process is demonstrably doing the listening.
+
+**No regression.** Promises that aren't beacon-backed still resolve the way they did.
+The health check behaves exactly as before in every other mode. Both are covered by tests.
+
+## What ships when
+
+One small PR with both fixes. Three other fixes Codey staged (about how script jobs
+run and how some scheduler entries are loaded) need more careful adaptation to the
+current code plus an upgrade-migration, so they're being handled separately rather
+than rushed.

--- a/docs/specs/codey-gap-run-fixes-batch-1.md
+++ b/docs/specs/codey-gap-run-fixes-batch-1.md
@@ -1,0 +1,115 @@
+---
+title: Codey gap-run fixes, batch 1 — commitment auto-deliver (F007) + messaging-probe lifeline mode (F003)
+date: 2026-05-31
+author: echo
+status: in-flight
+review-convergence: codey-gap-run-2026-05-31
+approved: true
+approved-by: Justin
+approved-via: Telegram topic 17481 ("Yes, please continue", 2026-05-31, approving the second-wave landing of Codey's verified gap-run fixes)
+eli16-overview: codey-gap-run-fixes-batch-1.eli16.md
+companion-spec: codex-stranded-draft-recovery.md
+---
+
+# Spec — Codey gap-run fixes, batch 1
+
+**Date:** 2026-05-31 · **Author:** echo · **Status:** in-flight
+
+## Context
+
+During an 8-hour Codex-on-Instar autonomous gap run, Codey (a `codex-cli` agent)
+identified 11 findings and staged fixes for several in a worktree, but could not
+commit them (it lacks the provider-neutral dev-commit path — tracked separately as
+a framework issue). Echo, the instar-developing agent, is landing the verified
+subset through the dev-gate. This is the mentor loop working end-to-end: the
+mentee finds and fixes, the mentor with commit access reviews and lands.
+
+Codey's base was v1.3.78 (current main is v1.3.18x), so these were **ported and
+re-verified against current main**, not cherry-picked. Two findings that were
+already addressed differently on main (script-job quota bypass) or required deeper
+adaptation/migration (F005/F006/F009) are explicitly out of this batch and handled
+separately. <!-- tracked: codex-stranded-draft-marker-not-restart-durable -->
+
+## F007 — Beacon-enabled future commitments auto-delivered before the beacon ever beat
+
+### Symptom
+
+A beacon-enabled one-time-action commitment with no machine-checkable verifier was
+auto-marked `delivered` on the first verify sweep (resolution: "No automated
+verification method — trusting agent acknowledgment"), seconds after creation, with
+`heartbeatCount: 0`. The PromiseBeacon never fired, and a PATCH-reopen was rejected
+as terminal. This silently defeats the "open a commitment for follow-through"
+pattern that CLAUDE.md mandates — and that long autonomous runs depend on. (Codey
+found this independently; it matches Echo's own prior finding.)
+
+### Root cause
+
+`CommitmentTracker.isUnverifiableOneTime()` returned true for ANY one-time action
+whose `verificationMethod` is undefined/null/manual — including beacon-enabled ones.
+Both the constructor backfill and the periodic `verifyOne()` sweep then transitioned
+such commitments to `delivered`. But PromiseBeacon explicitly OWNS the follow-through
+for beacon-enabled promises: they are supposed to stay pending until the agent calls
+`deliver()`.
+
+### Fix
+
+- `isUnverifiableOneTime()` returns `false` when `beaconEnabled` — beacon commitments
+  are never "trust-the-ack auto-deliverable" (fixes the constructor backfill path).
+- The `verifyOne()` sweep returns `null` (a no-op, stays pending) for a beacon-enabled
+  one-time action with no verifier — placed before the unverifiable→delivered branch.
+
+A beacon commitment now stays pending across sweeps; only an explicit `deliver()`
+resolves it. Non-beacon unverifiable one-time actions are unchanged (still
+auto-delivered, preserving the 51k-violation-tick guard they were added for).
+
+## F003 — Messaging probe reports FAILURE in lifeline-owned polling mode
+
+### Symptom
+
+`/health` system review reported the Telegram adapter/polling probes as failed while
+the topic was actively sending and receiving messages — eroding trust by saying
+"Telegram broken" when the user-visible relay was fully working.
+
+### Root cause
+
+`MessagingProbe` treated `status.started === false` as a failure. But in
+lifeline-owned polling mode the in-server adapter is intentionally **send-only** — the
+lifeline process owns polling and forwards messages into the server, so `started` is
+false by design.
+
+### Fix
+
+- `MessagingProbeDeps` gains an optional `externalPollerActive?: () => boolean`.
+- When `!status.started` AND `externalPollerActive()` is true, the connected and
+  polling probes pass (description names the lifeline-owned poller). When the dep is
+  absent or returns false, the original failure behavior is byte-identical.
+- `server.ts` supplies `externalPollerActive` from the existing `lifelineOwnsPolling`
+  flag plus the presence of the `lifeline.lock` file. Only the two started-dependent
+  probes (connected, polling) change; the log/topics probes are untouched.
+
+## Safeguards
+
+**No new authority.** Both fixes only relax a too-aggressive failure/auto-resolve.
+F007 keeps a commitment pending (it never force-delivers); F003 only converts a
+false-negative health failure into a pass when the lifeline demonstrably owns polling.
+
+**No regression.** F007: non-beacon unverifiable one-time actions still auto-deliver
+(covered by a test). F003: with the dep absent/false, probe behavior is unchanged
+(covered by a test). The Claude/default paths are byte-identical.
+
+## Out of scope (handled separately)
+
+F005 (script jobs run directly), F006 (`retryOnGateSkip` gate-noise flag + its
+required migration), and F009 (disabled manifests shadow legacy) need real adaptation
+on current main (drifted internal APIs) and, for F006, a `PostUpdateMigrator`
+migration Codey's diff did not include. They are deliberately not rushed into this
+batch.
+
+## Testing
+
+- `tests/unit/CommitmentTracker.test.ts` — beacon one-time stays pending through
+  `verifyOne()`/`verify()`; non-beacon still auto-delivers (no regression).
+- `tests/unit/MessagingProbe-external-poller.test.ts` (new) — connected+polling pass
+  in lifeline mode, fail without a poller, unchanged when the dep is absent, pass when
+  started.
+- `tsc --noEmit` clean.

--- a/src/commands/server.ts
+++ b/src/commands/server.ts
@@ -7837,6 +7837,7 @@ export async function startServer(options: StartOptions): Promise<void> {
           getStatus: () => telegram!.getStatus(),
           messageLogPath: path.join(config.stateDir, 'telegram-messages.jsonl'),
           isConfigured: () => true,
+          externalPollerActive: () => Boolean(lifelineOwnsPolling && fs.existsSync(path.join(config.stateDir, 'lifeline.lock'))),
         }) : []),
         ...createLifelineProbes({
           // Supervisor status intentionally omitted: the supervisor only exists

--- a/src/monitoring/CommitmentTracker.ts
+++ b/src/monitoring/CommitmentTracker.ts
@@ -663,6 +663,12 @@ export class CommitmentTracker extends EventEmitter {
    */
   private static isUnverifiableOneTime(c: Commitment): boolean {
     if (c.type !== 'one-time-action') return false;
+    // Beacon-enabled future promises are NOT auto-deliverable: PromiseBeacon owns
+    // their follow-through and they stay pending until the agent explicitly calls
+    // deliver(). Treating them as "unverifiable → trust the ack" auto-marks them
+    // delivered ~seconds after creation (heartbeatCount 0), silently defeating the
+    // "open a commitment for follow-through" pattern. See the verify-sweep guard below.
+    if (c.beaconEnabled) return false;
     const m = c.verificationMethod;
     return m === undefined || m === null || m === 'manual';
   }
@@ -816,6 +822,22 @@ export class CommitmentTracker extends EventEmitter {
       commitment.verificationMethod === 'threadline-reply'
     ) {
       return { passed: false, detail: 'Awaiting threadline reply' };
+    }
+
+    // PromiseBeacon owns follow-through for beacon-enabled future promises. If
+    // such a one-time action has no machine-checkable verifier, keep it PENDING
+    // until the agent explicitly delivers the promised update via deliver() —
+    // do NOT auto-mark it delivered (which fires ~seconds after creation and
+    // makes the beacon never beat). The beacon's cadenced heartbeats are the
+    // intended follow-through; this sweep is a no-op for them.
+    if (
+      commitment.type === 'one-time-action' &&
+      commitment.beaconEnabled &&
+      (commitment.verificationMethod === undefined ||
+        commitment.verificationMethod === null ||
+        commitment.verificationMethod === 'manual')
+    ) {
+      return null;
     }
 
     // One-time-actions with no automated verification path cannot keep

--- a/src/monitoring/probes/MessagingProbe.ts
+++ b/src/monitoring/probes/MessagingProbe.ts
@@ -25,6 +25,11 @@ export interface MessagingProbeDeps {
   messageLogPath: string;
   /** Whether the Telegram adapter is configured */
   isConfigured: () => boolean;
+  /** True when another supervised component (the lifeline) owns Telegram polling
+   *  and the in-server adapter is intentionally send-only. In that mode
+   *  `status.started` is false by design, so the probe must treat the
+   *  lifeline-owned poller as the healthy signal instead of reporting a failure. */
+  externalPollerActive?: () => boolean;
 }
 
 export function createMessagingProbes(deps: MessagingProbeDeps): Probe[] {
@@ -48,6 +53,14 @@ export function createMessagingProbes(deps: MessagingProbeDeps): Probe[] {
           const status = deps.getStatus();
 
           if (!status.started) {
+            if (deps.externalPollerActive?.() ?? false) {
+              return {
+                ...base,
+                passed: true,
+                description: 'Telegram connected via lifeline-owned polling; adapter is send-only',
+                diagnostics: { status, externalPollerActive: true },
+              };
+            }
             const fatal = status.fatalReason ?? null;
             const lastErr = status.lastError ?? null;
             const stoppedAt = status.stoppedAt ?? null;
@@ -110,6 +123,19 @@ export function createMessagingProbes(deps: MessagingProbeDeps): Probe[] {
           const status = deps.getStatus();
 
           if (!status.started) {
+            if (deps.externalPollerActive?.() ?? false) {
+              return {
+                ...base,
+                passed: true,
+                description: 'Polling active via lifeline-owned Telegram poller',
+                diagnostics: {
+                  uptime: status.uptime,
+                  pendingStalls: status.pendingStalls,
+                  pendingPromises: status.pendingPromises,
+                  externalPollerActive: true,
+                },
+              };
+            }
             return {
               ...base,
               passed: false,

--- a/tests/unit/CommitmentTracker.test.ts
+++ b/tests/unit/CommitmentTracker.test.ts
@@ -1250,4 +1250,60 @@ describe('CommitmentTracker', () => {
       expect(tracker.verifyOne(c.id)).toBeNull();
     });
   });
+
+  // ── Beacon-enabled future promises are NOT auto-delivered ────────
+  //
+  // Regression (Codey gap-run F007, matches Echo's own finding): a beacon-enabled
+  // one-time-action with no machine-checkable verifier was auto-marked "delivered"
+  // on the very first verify sweep ("no automated verification method — trusting
+  // agent acknowledgment"), seconds after creation and before the PromiseBeacon
+  // ever beat — silently defeating the "open a commitment for follow-through"
+  // pattern. Such a commitment must stay PENDING until an explicit deliver().
+  describe('beacon-enabled follow-through is not auto-delivered', () => {
+    let stateDir: string;
+    let cleanup: () => void;
+    beforeEach(() => { ({ stateDir, cleanup } = createTmpState()); });
+    afterEach(() => cleanup());
+
+    it('verifyOne returns null (stays pending) for a beacon one-time action with no verifier', () => {
+      const tracker = makeTracker(stateDir);
+      const c = tracker.record({
+        type: 'one-time-action',
+        userRequest: 'check back in 20 minutes',
+        agentResponse: 'will report back',
+        beaconEnabled: true,
+      });
+      expect(c.beaconEnabled).toBe(true);
+      // The verify sweep must NOT resolve it.
+      expect(tracker.verifyOne(c.id)).toBeNull();
+      expect(tracker.get(c.id)?.status).not.toBe('delivered');
+      // It remains in the active set so the beacon keeps following through.
+      expect(tracker.getActive().some(x => x.id === c.id)).toBe(true);
+    });
+
+    it('a NON-beacon unverifiable one-time action is still auto-delivered (no regression)', () => {
+      const tracker = makeTracker(stateDir);
+      const c = tracker.record({
+        type: 'one-time-action',
+        userRequest: 'do a thing',
+        agentResponse: 'done',
+        beaconEnabled: false,
+      });
+      const result = tracker.verifyOne(c.id);
+      expect(result?.passed).toBe(true);
+      expect(tracker.get(c.id)?.status).toBe('delivered');
+    });
+
+    it('a full verify() sweep leaves the beacon commitment pending', () => {
+      const tracker = makeTracker(stateDir);
+      const c = tracker.record({
+        type: 'one-time-action',
+        userRequest: 'back in 20 minutes',
+        agentResponse: 'on it',
+        beaconEnabled: true,
+      });
+      tracker.verify();
+      expect(tracker.get(c.id)?.status).not.toBe('delivered');
+    });
+  });
 });

--- a/tests/unit/MessagingProbe-external-poller.test.ts
+++ b/tests/unit/MessagingProbe-external-poller.test.ts
@@ -1,0 +1,64 @@
+/**
+ * Regression (Codey gap-run F003): the Telegram messaging probes reported a
+ * health FAILURE whenever the in-server adapter wasn't "started" — but in
+ * lifeline-owned polling mode the adapter is intentionally send-only and the
+ * lifeline process owns polling. The probe was eroding trust by reporting
+ * "Telegram broken" while the user-visible relay was fully working.
+ *
+ * The fix adds an optional `externalPollerActive` dep: when it returns true and
+ * the adapter isn't started, the probe passes (lifeline owns polling). When it's
+ * absent or false, the original failure behavior is unchanged.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { createMessagingProbes, type MessagingProbeDeps } from '../../src/monitoring/probes/MessagingProbe.js';
+
+function deps(started: boolean, externalPollerActive?: () => boolean): MessagingProbeDeps {
+  return {
+    getStatus: () => ({
+      started,
+      uptime: started ? 60_000 : null,
+      pendingStalls: 0,
+      pendingPromises: 0,
+      topicMappings: 0,
+      lastError: null,
+      fatalReason: null,
+      stoppedAt: null,
+    }),
+    messageLogPath: '/tmp/does-not-matter.jsonl',
+    isConfigured: () => true,
+    externalPollerActive,
+  };
+}
+
+// Only the started-dependent probes are affected by the fix.
+const AFFECTED = ['instar.messaging.connected', 'instar.messaging.polling'];
+
+async function runAffected(d: MessagingProbeDeps) {
+  const probes = createMessagingProbes(d).filter(p => AFFECTED.includes(p.id));
+  expect(probes).toHaveLength(2);
+  return Promise.all(probes.map(p => p.run()));
+}
+
+describe('MessagingProbe — lifeline-owned polling (externalPollerActive)', () => {
+  it('connected + polling PASS when the adapter is send-only and the lifeline owns polling', async () => {
+    const results = await runAffected(deps(false, () => true));
+    expect(results.every(r => r.passed)).toBe(true);
+    expect(results.every(r => /lifeline-owned/i.test(r.description ?? ''))).toBe(true);
+  });
+
+  it('connected + polling FAIL when the adapter is not started and no external poller is active', async () => {
+    const results = await runAffected(deps(false, () => false));
+    expect(results.every(r => !r.passed)).toBe(true);
+  });
+
+  it('preserves the original failure when externalPollerActive is not provided', async () => {
+    const results = await runAffected(deps(false));
+    expect(results.every(r => !r.passed)).toBe(true);
+  });
+
+  it('pass normally when the adapter IS started (poller flag irrelevant)', async () => {
+    const results = await runAffected(deps(true, () => false));
+    expect(results.every(r => r.passed)).toBe(true);
+  });
+});

--- a/upgrades/next/codey-gap-run-fixes-batch-1.md
+++ b/upgrades/next/codey-gap-run-fixes-batch-1.md
@@ -1,0 +1,41 @@
+# Upgrade Guide — vNEXT
+
+<!-- bump: patch -->
+
+## What Changed
+
+Two fixes that a codex-based agent (Codey) found during an autonomous run, reviewed and
+landed by Echo:
+
+1. **Beacon-backed promises no longer auto-resolve before they're done.** A tracked
+   commitment with a follow-through beacon but no automatic verifier was being marked
+   "delivered" seconds after creation — before the beacon ever fired — silently defeating
+   the whole follow-through mechanism. Such a commitment now stays pending until the agent
+   explicitly delivers it.
+2. **The Telegram health check no longer reports a false failure** when the agent is
+   running in lifeline-owned polling mode (the in-server adapter is send-only and a
+   separate process owns polling). The probe now recognizes that mode as healthy.
+
+## What to Tell Your User
+
+If you use the "remind me / report back" style of tracked promises, they now stay open
+until they're actually finished instead of quietly closing themselves early. And your
+health view will stop occasionally claiming Telegram is broken when it is in fact working.
+Nothing for you to do.
+
+## Summary of New Capabilities
+
+- Beacon-enabled one-time commitments remain pending until an explicit deliver(),
+  letting the follow-through beacon actually do its job.
+- The messaging probe accepts an optional external-poller signal and reports healthy in
+  lifeline-owned send-only polling mode (the connected and polling probes only).
+
+## Evidence
+
+- Spec: `docs/specs/codey-gap-run-fixes-batch-1.md` (+ `.eli16.md`), review-convergence +
+  approved by Justin (Telegram topic 17481, 2026-05-31).
+- Tests: `tests/unit/CommitmentTracker.test.ts` (beacon-stays-pending + non-beacon
+  no-regression) and `tests/unit/MessagingProbe-external-poller.test.ts` (new); `tsc
+  --noEmit` clean.
+- Origin: findings F007 and F003 from Codey's Codex-on-Instar autonomous gap run,
+  ported from a v1.3.78 base and re-verified on current main.

--- a/upgrades/side-effects/codey-gap-run-fixes-batch-1.md
+++ b/upgrades/side-effects/codey-gap-run-fixes-batch-1.md
@@ -1,0 +1,73 @@
+# Side-Effects Review — Codey gap-run fixes, batch 1
+
+**Version / slug:** `codey-gap-run-fixes-batch-1`
+**Date:** `2026-05-31`
+**Author:** `echo`
+**Second-pass reviewer:** `not required`
+
+## Summary of the change
+
+Land two verified fixes Codey found during its autonomous gap run, ported to current
+main. F007: `CommitmentTracker` no longer auto-delivers beacon-enabled future
+commitments (they stay pending until explicit `deliver()`). F003: the Telegram
+messaging probe accepts an optional `externalPollerActive` signal so it reports healthy
+in lifeline-owned send-only polling mode instead of a false failure.
+
+## Decision-point inventory
+
+- **F007 — `isUnverifiableOneTime` beacon exclusion + verify-sweep beacon skip.** Both
+  sides tested: beacon one-time stays pending; non-beacon one-time still auto-delivers.
+- **F003 — probe pass-vs-fail on `!status.started`.** Both sides tested: poller-active →
+  pass; poller-absent/false → original failure; started → pass.
+
+## 1. Over-block
+
+**What legitimate inputs does this change reject?** None. Both changes only *relax* an
+over-aggressive terminal transition. F007 stops force-delivering a class of commitments;
+F003 stops a false health failure. No new rejection path is introduced.
+
+## 2. Under-block
+
+**What does this still miss?** F007: a beacon commitment with a real machine-checkable
+verifier is still verified/resolved normally (only the verifier-less case is held
+pending) — intended. F003: only the two started-dependent probes (connected, polling)
+are adjusted; the log/topics probes are unchanged. The other three gap-run findings
+(F005/F006/F009) are explicitly out of this batch.
+
+## 3. Level-of-abstraction fit
+
+**Right layer?** Yes. F007 lives in `CommitmentTracker.isUnverifiableOneTime` (the one
+predicate both the backfill and the sweep consult) plus the `verifyOne` sweep — the
+single decision points. F003 lives in `MessagingProbe` (the probe factory) with the
+signal injected once at the `server.ts` wiring site, sourced from the existing
+`lifelineOwnsPolling` flag.
+
+## 4. Signal vs authority compliance
+
+**Required reference:** [docs/signal-vs-authority.md](../../docs/signal-vs-authority.md)
+
+No blocking authority added. F007 makes a commitment *more* durable (keeps it pending,
+the safe direction). F003 is a read-only health signal that now reads the system more
+accurately; it gates nothing. The `externalPollerActive` dep is optional and defaults
+to the prior behavior.
+
+## 5. Interactions
+
+- **F007 ↔ PromiseBeacon:** beacon-enabled commitments now remain in the active set, so
+  the beacon continues its cadenced heartbeats as designed (previously they were
+  resolved out from under it). `deliver()` remains the explicit terminal path.
+- **F007 ↔ constructor backfill:** the same predicate gates the boot-time backfill, so a
+  beacon commitment loaded from disk is no longer backfilled-as-delivered either.
+- **F003 ↔ lifeline:** the `externalPollerActive` source mirrors the existing
+  `lifelineOwnsPolling` send-only decision and the `lifeline.lock` presence check
+  already used by the lifeline probes. No new files, no new state.
+- No interaction with the SessionReaper, sentinels, or any gate.
+
+## 6. External surfaces
+
+No new HTTP routes, no config keys, no Telegram, no new on-disk files. F007 changes the
+lifecycle of existing `/commitments` records (a beacon commitment reports `pending`
+longer); F003 changes a `/health` probe verdict (fewer false Telegram failures). No
+agent-installed file (`.claude/settings.json`, `.instar/config.json`, CLAUDE.md
+template, hook, skill, job template) is touched, so the Migration Parity Standard does
+not apply to this batch.


### PR DESCRIPTION
## Origin

Two fixes **Codey** (a `codex-cli` agent) found during an 8-hour Codex-on-Instar autonomous gap run. Codey staged them but couldn't commit (it lacks the provider-neutral dev-commit path — tracked separately). **Echo reviewed and ported them to current main** (Codey's base was v1.3.78) and re-verified. The mentor loop end-to-end.

## F007 — beacon-enabled future commitments were auto-delivered before the beacon ever beat

A beacon-enabled one-time-action commitment with no machine-checkable verifier was marked `delivered` on the first verify sweep ("No automated verification method — trusting agent acknowledgment"), seconds after creation, `heartbeatCount: 0` — silently defeating the "open a commitment for follow-through" pattern that long autonomous runs depend on. (Codey found this independently; it matches Echo's own prior finding.)

**Fix:** `isUnverifiableOneTime()` excludes `beaconEnabled` (fixes the constructor backfill path), and the `verifyOne()` sweep returns `null` (stays pending) for a beacon one-time with no verifier. Non-beacon unverifiable one-time actions still auto-deliver (the 51k-violation-tick guard they were added for is preserved).

## F003 — messaging probe reported a false failure in lifeline-owned polling mode

`MessagingProbe` treated `status.started === false` as a failure, but in lifeline-owned polling mode the in-server adapter is send-only by design (the lifeline owns polling). `/health` reported "Telegram broken" while the relay worked fine.

**Fix:** optional `externalPollerActive` dep; when set and the adapter isn't started, the connected + polling probes pass. Absent/false → byte-identical to before. Wired from the existing `lifelineOwnsPolling` flag + `lifeline.lock` presence.

## Tests

`tests/unit/CommitmentTracker.test.ts` (beacon-stays-pending + non-beacon no-regression) and `tests/unit/MessagingProbe-external-poller.test.ts` (new — both sides of the started/poller matrix). `tsc --noEmit` clean, smoke tier green.

## Spec

`docs/specs/codey-gap-run-fixes-batch-1.md` (+ `.eli16.md`) — approved by Justin (Telegram topic 17481, "Yes, please continue").

## Deliberately out of this batch

F005 (script jobs run directly), F006 (`retryOnGateSkip` + its required migration), F009 (disabled-manifest shadowing) from the same gap run need real adaptation on current main plus, for F006, a `PostUpdateMigrator` migration Codey's diff didn't include. Handled separately rather than rushed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
