### PR TITLE
fix(scheduler): land Codey's gap-run fixes batch 2 (F005 + F009)

### DIFF
--- a/docs/specs/codey-gap-run-fixes-batch-2.eli16.md
+++ b/docs/specs/codey-gap-run-fixes-batch-2.eli16.md
@@ -1,0 +1,41 @@
+# Codey gap-run fixes, batch 2 — Plain-English Overview
+
+> The one-line version: two more bugs Codey found — "script" chores were being run by firing up a whole AI session (which sometimes hung for hours), and retired scheduled jobs could come back from the dead — now fixed.
+
+## The problem in one breath
+
+Some scheduled jobs are plain shell chores (like "refresh a dashboard link") that need
+no AI at all. Instar was launching a full AI session to run them anyway — and a couple
+got stuck for 9 and 16 hours, holding a slot and never finishing. Separately, when a
+built-in job was retired, it could fail to "cover" an old leftover copy of itself, so
+the retired job quietly ran again.
+
+## What already exists
+
+- **The job scheduler** — runs scheduled jobs on a cron timetable. Most jobs are AI
+  tasks that run in a session; a few are plain shell scripts.
+- **Per-job manifests** — each built-in job has a small file describing it, which is
+  supposed to take precedence over any older copy in the legacy job list.
+
+## What this adds
+
+1. **Script jobs now run directly as a quick subprocess**, not by launching an AI
+   session. They finish in a bounded time, record their result, and never tie up a
+   session slot — even when the system is at its session limit.
+2. **A retired job's manifest now still "covers" its old leftover copy** even after its
+   description file was deleted — so a retired job stays retired instead of coming back.
+
+## The safeguards
+
+**Nothing new is blocked.** The script job runs the exact same command as before, just
+without the AI wrapper. The retirement fix only stops a disabled job from being dropped
+(a disabled job never runs — it only shadows the old one).
+
+**No regression.** AI jobs are unaffected; only "script" jobs take the new direct path.
+Active jobs still require their description file. Both are covered by tests.
+
+## What ships when
+
+One small PR with both fixes. A third related fix (quieting repeated "no work to do"
+log noise from a couple of jobs) is held for a separate change because it needs an
+upgrade-migration to reach jobs already installed on existing agents.

--- a/docs/specs/codey-gap-run-fixes-batch-2.md
+++ b/docs/specs/codey-gap-run-fixes-batch-2.md
@@ -1,0 +1,99 @@
+---
+title: Codey gap-run fixes, batch 2 — script jobs run directly (F005) + disabled-manifest shadowing (F009)
+date: 2026-05-31
+author: echo
+status: in-flight
+review-convergence: codey-gap-run-2026-05-31
+approved: true
+approved-by: Justin
+approved-via: Telegram topic 17481 ("Yes, please continue", 2026-05-31, approving the second-wave landing of Codey's verified gap-run fixes)
+eli16-overview: codey-gap-run-fixes-batch-2.eli16.md
+companion-spec: codey-gap-run-fixes-batch-1.md
+---
+
+# Spec — Codey gap-run fixes, batch 2
+
+**Date:** 2026-05-31 · **Author:** echo · **Status:** in-flight
+
+## Context
+
+Two more fixes from Codey's Codex-on-Instar autonomous gap run, ported and re-verified
+against current main by Echo (Codey's base was v1.3.78). Batch 1 (#656, F007 + F003) is
+already merged. F006 (`retryOnGateSkip` gate-noise flag) is held for a separate batch
+because it requires a `PostUpdateMigrator` migration to reach existing agents'
+already-installed jobs — Codey's diff did not include one. <!-- tracked: codex-stranded-draft-marker-not-restart-durable -->
+
+## F005 — script jobs were dispatched by spawning a model session
+
+### Symptom
+
+Two `dashboard-link-refresh` script jobs (`expectedDurationMinutes: 1`) ran for ~9h and
+~16h holding live session slots, with run-history stuck at `pending`. The scheduler had
+spawned a model session with a prompt beginning `Run this script: ...` for what is
+zero-token shell work.
+
+### Root cause
+
+`JobScheduler.triggerJob` routed ALL execute types — including `script` — through
+`spawnJobSession`, which calls `buildPrompt` (whose `case 'script'` produces
+`"Run this script: ${value}"`) and spawns a model session. Script jobs also passed
+through the session-capacity gate, so at the cap they could queue and later dequeue
+into a model spawn as well.
+
+### Fix
+
+A new `runScriptJob()` executes `execute.type: 'script'` jobs directly in a bounded
+subprocess (`/bin/sh -c <script>`, timeout = 2× expected duration, `INSTAR_AUTH_TOKEN`
+injected, output captured), mirroring `spawnJobSession`'s run-history / job-state /
+claim bookkeeping. `triggerJob` branches to it **before the session-capacity check** —
+so a script job never spawns a model, never consumes a session slot, and never queues
+on capacity. (This is stronger than the staged fix, which branched after the capacity
+check and left the queue/dequeue path spawning a model.) The `buildPrompt` `case
+'script'` remains for switch-exhaustiveness but is no longer reached on the normal path.
+
+## F009 — disabled/retired manifests dropped when their body was deleted
+
+### Symptom
+
+`instar status` warned that `guardian-pulse` was missing its markdown body while still
+reporting a high-priority `guardian-pulse` job from legacy `jobs.json`. The disabled,
+retired per-slug manifest could not shadow the stale legacy entry.
+
+### Root cause
+
+`loadAgentMdJobs` tried to hydrate every surviving manifest's `agentmd` body before
+adding it to the in-memory job list. A disabled/retired manifest whose body file was
+deleted hit the missing-body path and was dropped — so it could not shadow the stale
+legacy job (the per-slug precedence rule), and the zombie legacy job ran.
+
+### Fix
+
+Disabled manifests load as disabled `JobDefinition`s without requiring a markdown body
+(the `if (!manifest.enabled)` short-circuit pushes `manifestToJobDefinition(manifest)`
+and continues). Enabled `agentmd` jobs keep the stricter hydrated-body path. A disabled
+manifest now shadows a stale legacy entry instead of being dropped as a missing-body
+problem.
+
+## Safeguards
+
+**No new authority.** F005 changes the dispatch mechanism for an existing job class (a
+subprocess instead of a model session); the script command is operator-defined and was
+already executed (just via a model prompt before). F009 only stops dropping a disabled
+job; a disabled job never runs, it only shadows.
+
+**No regression.** Non-script jobs are dispatched exactly as before (only `script` is
+re-routed). Enabled agentmd jobs still require their body. Both covered by tests.
+
+## Out of scope
+
+F006 (`retryOnGateSkip`) is held for a batch with its required `PostUpdateMigrator`
+migration so existing agents' installed jobs receive the flag, not just new agents.
+
+## Testing
+
+- `tests/unit/JobScheduler-script-job.test.ts` (new) — a script job triggers WITHOUT
+  spawning a session, runs the script directly, records success, and runs even at the
+  session cap.
+- `tests/unit/scheduler/JobLoader.agentmd.test.ts` — a disabled manifest with no body
+  loads as a disabled job and is not a missing-body problem.
+- `tsc --noEmit` clean; the full JobScheduler unit suite passes unchanged.

--- a/src/scheduler/AgentMdJobLoader.ts
+++ b/src/scheduler/AgentMdJobLoader.ts
@@ -297,6 +297,17 @@ export function loadAgentMdJobs(
   // Issues card.
   const jobs: JobDefinition[] = [];
   for (const { manifest } of survivors) {
+    // A disabled/retired per-slug manifest must load as a disabled JobDefinition
+    // WITHOUT requiring its markdown body — the body may have been deleted when
+    // the job was retired. Loading it disabled lets it still shadow a stale
+    // enabled entry in legacy jobs.json (the per-slug precedence rule), instead
+    // of being dropped for a missing body and letting the zombie legacy job run
+    // (Codey gap-run F009).
+    if (!manifest.enabled) {
+      jobs.push(manifestToJobDefinition(manifest));
+      continue;
+    }
+
     if (manifest.execute.type === 'agentmd') {
       const loaded = loadAgentMdBody(manifest, jobsRootDir);
       if (loaded.problem) {

--- a/src/scheduler/JobScheduler.ts
+++ b/src/scheduler/JobScheduler.ts
@@ -387,6 +387,17 @@ export class JobScheduler {
       }
     }
 
+    // Script jobs are zero-token shell work — they do NOT spawn a model session,
+    // so they bypass session-capacity gating and the spawn path entirely and run
+    // directly in a bounded subprocess. Without this they were spawned with a
+    // "Run this script: ..." prompt and could hang for hours holding a live
+    // session slot, leaving run-history stuck at `pending` (Codey gap-run F005).
+    if (job.execute.type === 'script') {
+      this.clearRetryState(slug);
+      this.runScriptJob(job, reason);
+      return 'triggered';
+    }
+
     // Check session capacity
     const runningSessions = this.sessionManager.listRunningSessions();
     const jobSessions = runningSessions.filter(s => s.jobSlug);
@@ -673,6 +684,94 @@ export class JobScheduler {
       const jobA = this.jobs.find(j => j.slug === a.slug);
       const jobB = this.jobs.find(j => j.slug === b.slug);
       return (PRIORITY_ORDER[jobA?.priority ?? 'low']) - (PRIORITY_ORDER[jobB?.priority ?? 'low']);
+    });
+  }
+
+  /**
+   * Execute a `script`-type job directly in a bounded subprocess instead of
+   * spawning a model session. Script jobs are zero-token infrastructure work
+   * (e.g. dashboard-link refresh); spawning a model for them wasted a session
+   * slot and could hang for hours (Codey gap-run F005). Mirrors spawnJobSession's
+   * run-history / job-state / claim bookkeeping so observability is identical.
+   */
+  private runScriptJob(job: JobDefinition, reason: string): void {
+    const script = `${job.execute.value}${job.execute.args ? ' ' + job.execute.args : ''}`;
+    const sessionName = `script-${job.slug}-${Date.now().toString(36)}`;
+    const observability = JobScheduler.computeRunObservability(job, JobScheduler.resolveAllowlist(job));
+    const runId = this.runHistory.recordStart({
+      slug: job.slug,
+      sessionId: sessionName,
+      trigger: reason,
+      model: job.model,
+      origin: observability.origin,
+      resolvedPath: observability.resolvedPath,
+      bodyHash: observability.bodyHash,
+      frontmatterHash: observability.frontmatterHash,
+      manifestVersion: observability.manifestVersion,
+      toolAllowlist: observability.toolAllowlist,
+      unrestrictedTools: observability.unrestrictedTools,
+      clampedAllowlist: observability.clampedAllowlist,
+    });
+
+    this.state.saveJobState({
+      slug: job.slug,
+      lastRun: new Date().toISOString(),
+      lastResult: 'pending',
+      lastError: undefined,
+      consecutiveFailures: 0,
+      nextScheduled: this.getNextRun(job.slug),
+    });
+
+    this.state.appendEvent({
+      type: 'job_triggered',
+      summary: `Job "${job.slug}" triggered (${reason})`,
+      sessionId: sessionName,
+      timestamp: new Date().toISOString(),
+      metadata: { slug: job.slug, reason, mode: 'script' },
+    });
+
+    const timeout = Math.max(1, job.expectedDurationMinutes ?? DEFAULT_EXPECTED_MINUTES) * 2 * 60_000;
+    const env = this.config.authToken
+      ? { ...process.env, INSTAR_AUTH_TOKEN: this.config.authToken }
+      : process.env;
+
+    execFileAsync('/bin/sh', ['-c', script], {
+      cwd: path.dirname(this.stateDir),
+      encoding: 'utf-8',
+      timeout,
+      env,
+      maxBuffer: 1024 * 1024,
+    }).then(({ stdout, stderr }) => {
+      const output = [stdout, stderr].filter(Boolean).join('\n').slice(-1000);
+      this.runHistory.recordCompletion({ runId, result: 'success', outputSummary: output || undefined });
+      this.state.saveJobState({
+        slug: job.slug,
+        lastRun: new Date().toISOString(),
+        lastResult: 'success',
+        lastError: undefined,
+        consecutiveFailures: 0,
+        nextScheduled: this.getNextRun(job.slug),
+      });
+      this.claimManager?.completeClaim(job.slug, 'success');
+    }).catch((err: unknown) => {
+      const errorMsg = err instanceof Error ? err.message : String(err);
+      const output = [
+        (err as { stdout?: string })?.stdout,
+        (err as { stderr?: string })?.stderr,
+      ].filter(Boolean).join('\n').slice(-1000);
+      const result = errorMsg.includes('timed out') || errorMsg.includes('ETIMEDOUT') ? 'timeout' : 'failure';
+      this.runHistory.recordCompletion({ runId, result, error: errorMsg, outputSummary: output || undefined });
+      const previous = this.state.getJobState(job.slug);
+      this.state.saveJobState({
+        slug: job.slug,
+        lastRun: new Date().toISOString(),
+        lastResult: result,
+        lastError: errorMsg,
+        consecutiveFailures: (previous?.consecutiveFailures ?? 0) + 1,
+        nextScheduled: this.getNextRun(job.slug),
+      });
+      this.claimManager?.completeClaim(job.slug, 'failure');
+      this.scheduleRetry(job.slug, 'error');
     });
   }
 

--- a/tests/unit/JobScheduler-script-job.test.ts
+++ b/tests/unit/JobScheduler-script-job.test.ts
@@ -1,0 +1,112 @@
+/**
+ * Regression (Codey gap-run F005): `script`-type jobs were dispatched by spawning
+ * a model session with a "Run this script: ..." prompt. Two such jobs hung for ~9h
+ * and ~16h holding live session slots with run-history stuck at `pending`. Script
+ * jobs are zero-token shell work and must run directly in a bounded subprocess,
+ * never a model session — and they must not consume session-capacity gating.
+ */
+
+import { describe, it, expect, afterEach } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { JobScheduler } from '../../src/scheduler/JobScheduler.js';
+import { createTempProject, createMockSessionManager } from '../helpers/setup.js';
+import type { TempProject } from '../helpers/setup.js';
+import type { JobDefinition, JobSchedulerConfig } from '../../src/core/types.js';
+
+function config(jobsFile: string): JobSchedulerConfig {
+  return {
+    jobsFile,
+    enabled: true,
+    maxParallelJobs: 2,
+    quotaThresholds: { normal: 50, elevated: 70, critical: 85, shutdown: 95 },
+  };
+}
+
+async function waitFor(predicate: () => boolean, timeoutMs = 4000): Promise<void> {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    if (predicate()) return;
+    await new Promise(r => setTimeout(r, 25));
+  }
+  throw new Error('waitFor: condition not met within timeout');
+}
+
+describe('JobScheduler — script jobs run directly (no model session)', () => {
+  let scheduler: JobScheduler | undefined;
+  let project: TempProject | undefined;
+
+  afterEach(() => {
+    scheduler?.stop();
+    project?.cleanup();
+  });
+
+  it('triggers a script job WITHOUT spawning a session, runs it, and records success', async () => {
+    project = createTempProject();
+    const mockSM = createMockSessionManager();
+    const markerPath = path.join(project.stateDir, 'script-ran.txt');
+    const jobs: JobDefinition[] = [{
+      slug: 'script-job',
+      name: 'Script Job',
+      description: 'runs a shell script directly',
+      schedule: '0 0 * * *',
+      priority: 'low',
+      expectedDurationMinutes: 1,
+      model: 'haiku',
+      enabled: true,
+      execute: { type: 'script', value: `echo ran > "${markerPath}"` },
+    }];
+    const jobsFile = path.join(project.stateDir, 'script-jobs.json');
+    fs.writeFileSync(jobsFile, JSON.stringify(jobs, null, 2));
+
+    scheduler = new JobScheduler(config(jobsFile), mockSM as any, project.state, project.stateDir);
+    scheduler.start();
+
+    const result = await scheduler.triggerJob('script-job', 'test');
+    expect(result).toBe('triggered');
+
+    // The core fix: a script job NEVER spawns a model session.
+    expect(mockSM._spawnCount).toBe(0);
+
+    // It actually executed directly in a subprocess.
+    await waitFor(() => fs.existsSync(markerPath));
+    expect(fs.readFileSync(markerPath, 'utf-8').trim()).toBe('ran');
+
+    // And run-history / job-state is recorded as success (not left pending).
+    await waitFor(() => project!.state.getJobState('script-job')?.lastResult === 'success');
+    expect(project.state.getJobState('script-job')?.lastResult).toBe('success');
+  });
+
+  it('a script job does not count against session capacity (runs even at the parallel cap)', async () => {
+    project = createTempProject();
+    const mockSM = createMockSessionManager();
+    // Saturate the session cap with non-script "running" sessions.
+    mockSM.listRunningSessions = () => ([
+      { tmuxSession: 'a', jobSlug: 'x' },
+      { tmuxSession: 'b', jobSlug: 'y' },
+    ]) as any;
+    const markerPath = path.join(project.stateDir, 'cap-script-ran.txt');
+    const jobs: JobDefinition[] = [{
+      slug: 'cap-script',
+      name: 'Cap Script',
+      description: 'runs even at capacity',
+      schedule: '0 0 * * *',
+      priority: 'low',
+      expectedDurationMinutes: 1,
+      model: 'haiku',
+      enabled: true,
+      execute: { type: 'script', value: `echo ok > "${markerPath}"` },
+    }];
+    const jobsFile = path.join(project.stateDir, 'cap-jobs.json');
+    fs.writeFileSync(jobsFile, JSON.stringify(jobs, null, 2));
+
+    scheduler = new JobScheduler({ ...config(jobsFile), maxParallelJobs: 2 }, mockSM as any, project.state, project.stateDir);
+    scheduler.start();
+
+    const result = await scheduler.triggerJob('cap-script', 'test');
+    // Not queued/skipped despite the cap — script jobs bypass session capacity.
+    expect(result).toBe('triggered');
+    expect(mockSM._spawnCount).toBe(0);
+    await waitFor(() => fs.existsSync(markerPath));
+  });
+});

--- a/tests/unit/job-scheduler-edge.test.ts
+++ b/tests/unit/job-scheduler-edge.test.ts
@@ -98,15 +98,19 @@ describe('JobScheduler edge cases', () => {
       expect(mockSM._lastSpawnArgs?.prompt).toContain('/scan --deep');
     });
 
-    it('builds prompt for "script" type job', async () => {
+    it('runs a "script" type job directly WITHOUT spawning a model session', async () => {
+      // F005: script jobs are zero-token shell work — they run directly in a
+      // bounded subprocess, never via a spawned "Run this script: ..." session.
       createScheduler([
         makeJob('test', { execute: { type: 'script', value: './check.sh' } }),
       ]);
       scheduler.start();
-      await scheduler.triggerJob('test', 'manual');
+      const result = await scheduler.triggerJob('test', 'manual');
       await new Promise(r => setTimeout(r, 50));
 
-      expect(mockSM._lastSpawnArgs?.prompt).toContain('Run this script: ./check.sh');
+      expect(result).toBe('triggered');
+      expect(mockSM._spawnCount).toBe(0);
+      expect(mockSM._lastSpawnArgs).toBeNull();
     });
 
     it('passes model tier to session', async () => {

--- a/tests/unit/scheduler/JobLoader.agentmd.test.ts
+++ b/tests/unit/scheduler/JobLoader.agentmd.test.ts
@@ -682,4 +682,22 @@ describe('JobLoader · agentmd (Phase 1a)', () => {
       expect(absent?.kind).toBe('agentmd-file-missing');
     });
   });
+
+  // Regression (Codey gap-run F009): a disabled/retired per-slug manifest was
+  // dropped when its markdown body had been deleted, so it could no longer shadow
+  // a stale enabled entry in legacy jobs.json — and the zombie legacy job ran.
+  describe('disabled manifest shadowing (F009)', () => {
+    it('loads a disabled/retired manifest as a disabled job without requiring its body', () => {
+      const a = setup({
+        manifests: { retired: mkManifest({ slug: 'retired', enabled: false }) },
+        // No body file for `retired` — it was deleted when the job was retired.
+      });
+      const result = loadAgentMdJobs(a.scheduleDir, a.jobsRoot);
+      const retired = result.jobs.find((j) => j.slug === 'retired');
+      expect(retired).toBeDefined();
+      expect(retired!.enabled).toBe(false);
+      // It must NOT be dropped as a missing-body problem.
+      expect(result.problems.find((p) => p.slug === 'retired')).toBeUndefined();
+    });
+  });
 });

--- a/upgrades/next/codey-gap-run-fixes-batch-2.md
+++ b/upgrades/next/codey-gap-run-fixes-batch-2.md
@@ -1,0 +1,41 @@
+# Upgrade Guide — vNEXT
+
+<!-- bump: patch -->
+
+## What Changed
+
+Two more fixes from Codey's autonomous gap run, reviewed and landed by Echo:
+
+1. **Script-type scheduled jobs now run directly instead of launching a model session.**
+   Plain shell chores (e.g. a dashboard-link refresh) were being dispatched by spawning
+   an AI session with a "Run this script:" prompt — and a couple hung for 9–16 hours
+   holding a session slot with their run-history stuck at "pending". They now run in a
+   bounded subprocess, record success/failure normally, and never consume a session slot
+   (even when the system is at its parallel-job cap).
+2. **Retired/disabled built-in jobs stay retired.** A disabled per-slug job manifest whose
+   markdown body had been deleted was being dropped, so it could no longer shadow a stale
+   copy of itself in the legacy job list — and the retired job quietly ran again. Disabled
+   manifests now load (disabled) without needing a body, so they correctly shadow the stale
+   entry.
+
+## What to Tell Your User
+
+Nothing for you to do. If you noticed a script-style scheduled job occasionally getting
+stuck for hours, or a job you thought was retired still showing up, both are fixed.
+
+## Summary of New Capabilities
+
+- Script jobs execute in a bounded subprocess via the scheduler's direct path (no model
+  session, no session-capacity consumption); run-history and claims are recorded the same way.
+- Disabled/retired per-slug manifests load as disabled job definitions without a body, so
+  they shadow stale legacy entries instead of being dropped.
+
+## Evidence
+
+- Spec: `docs/specs/codey-gap-run-fixes-batch-2.md` (+ `.eli16.md`), review-convergence +
+  approved by Justin (Telegram topic 17481, 2026-05-31).
+- Tests: `tests/unit/JobScheduler-script-job.test.ts` (new) and the disabled-manifest case
+  in `tests/unit/scheduler/JobLoader.agentmd.test.ts`; `tsc --noEmit` clean.
+- Origin: findings F005 and F009 from Codey's Codex-on-Instar gap run, ported from a
+  v1.3.78 base and re-verified on current main. F006 from the same run is held for a
+  separate change that includes its required upgrade-migration.

--- a/upgrades/side-effects/codey-gap-run-fixes-batch-2.md
+++ b/upgrades/side-effects/codey-gap-run-fixes-batch-2.md
@@ -1,0 +1,74 @@
+# Side-Effects Review — Codey gap-run fixes, batch 2
+
+**Version / slug:** `codey-gap-run-fixes-batch-2`
+**Date:** `2026-05-31`
+**Author:** `echo`
+**Second-pass reviewer:** `not required`
+
+## Summary of the change
+
+Two more verified Codey gap-run fixes, ported to current main. F005: `script`-type jobs
+execute directly in a bounded subprocess (`runScriptJob`) instead of spawning a model
+session, branched before the session-capacity check so they never hold a slot. F009:
+disabled/retired per-slug manifests load as disabled `JobDefinition`s without requiring
+a markdown body, so they can shadow stale legacy `jobs.json` entries.
+
+## Decision-point inventory
+
+- **F005 — `triggerJob` script-vs-non-script branch.** Both sides tested: a script job is
+  dispatched via `runScriptJob` (no session, runs even at the cap); non-script jobs are
+  unchanged (existing suite passes).
+- **F005 — `runScriptJob` success/failure paths.** Success records `success`; failure/
+  timeout records `failure`/`timeout`, bumps `consecutiveFailures`, schedules a retry.
+- **F009 — `loadAgentMdJobs` enabled-vs-disabled branch.** Both sides tested: disabled
+  manifest → disabled job (no body needed); enabled agentmd → still requires a body.
+
+## 1. Over-block
+
+**What legitimate inputs does this change reject?** None. F005 changes the dispatch
+mechanism for an existing job class, not its admissibility. F009 stops *dropping* a
+disabled manifest — it admits more (a disabled, non-running job), never fewer.
+
+## 2. Under-block
+
+**What does this still miss?** F005: a script job that exceeds 2× its expected duration
+is killed by the subprocess timeout and recorded as `timeout` (intended — that is the
+hang guard). F009: only the disabled-manifest path is short-circuited; enabled agentmd
+jobs still need a hydrated body. F006 (gate-noise flag) is out of this batch.
+
+## 3. Level-of-abstraction fit
+
+**Right layer?** Yes. F005 lives in `JobScheduler.triggerJob` (the single dispatch
+chokepoint) + a `runScriptJob` sibling of `spawnJobSession`, reusing the same
+`computeRunObservability` / `runHistory` / `state` / `claimManager` plumbing. F009 lives
+in `loadAgentMdJobs` (the single manifest→JobDefinition loop).
+
+## 4. Signal vs authority compliance
+
+**Required reference:** [docs/signal-vs-authority.md](../../docs/signal-vs-authority.md)
+
+No blocking authority added. `runScriptJob` is bounded (timeout, capped output buffer)
+and records outcomes through the same audit path as model jobs. F009 is a loader
+robustness change with no gating.
+
+## 5. Interactions
+
+- **F005 ↔ session capacity / queue:** branching before the capacity check means script
+  jobs never enqueue and never dequeue into a model spawn — the queue/dequeue path
+  (`spawnJobSession`) is now reached only by non-script jobs. The `buildPrompt` `case
+  'script'` remains for `switch` exhaustiveness but is no longer hit on the normal path.
+- **F005 ↔ claims:** `runScriptJob` calls `claimManager.completeClaim` on success/failure,
+  matching the model path's claim lifecycle.
+- **F009 ↔ legacy jobs.json:** a disabled manifest now reaches the in-memory job list and
+  shadows a same-slug legacy entry per the existing per-slug precedence rule.
+- No interaction with sentinels, the SessionReaper, or any gate.
+
+## 6. External surfaces
+
+No new HTTP routes, no config keys, no Telegram. F005 changes a `script` job's execution
+mechanism (subprocess vs session) — observable as a `script-<slug>-...` run-history entry
+instead of a `job-<slug>-...` session. F009 changes which jobs the loader returns
+(disabled retired manifests are now present + disabled). No agent-installed file
+(`.claude/settings.json`, `.instar/config.json`, CLAUDE.md template, hook, skill, or job
+template) is touched in this batch, so the Migration Parity Standard does not apply here
+(it is exactly why F006 — which DOES touch job templates — is held for its own migration).


### PR DESCRIPTION
## Origin

Two more fixes from **Codey**'s Codex-on-Instar autonomous gap run, reviewed and ported to current main by Echo (Codey's base was v1.3.78). Batch 1 (#656, F007 + F003) is merged + released as v1.3.187.

## F005 — script jobs were dispatched by spawning a model session

Two `dashboard-link-refresh` script jobs (`expectedDurationMinutes: 1`) ran for ~9h and ~16h holding live session slots with run-history stuck at `pending` — the scheduler spawned a model session with a `"Run this script: ..."` prompt for zero-token shell work.

**Fix:** a new `runScriptJob()` runs `execute.type: 'script'` jobs directly in a bounded subprocess (`/bin/sh -c`, timeout = 2× expected, auth env injected, output captured), branched in `triggerJob` **before the session-capacity check** — so script jobs never spawn a model, never hold a session slot, and never queue on capacity. (Stronger than Codey's staged version, which branched after the capacity check and left the dequeue path spawning a model.)

## F009 — disabled/retired manifests dropped when their body was deleted

A disabled per-slug manifest whose markdown body had been deleted hit the missing-body path and was dropped, so it could not shadow a stale enabled `jobs.json` entry — and the retired job ran again.

**Fix:** disabled manifests load as disabled `JobDefinition`s without requiring a body, so they shadow the stale legacy entry. Enabled agentmd jobs keep the stricter hydrated-body path.

## Tests

`tests/unit/JobScheduler-script-job.test.ts` (new — a script job triggers without spawning a session, runs directly, records success, and runs at the session cap) + the disabled-manifest case in `tests/unit/scheduler/JobLoader.agentmd.test.ts`. `tsc --noEmit` clean; full JobScheduler suite passes.

## Spec

`docs/specs/codey-gap-run-fixes-batch-2.md` (+ `.eli16.md`) — approved by Justin (Telegram topic 17481, "Yes, please continue").

## Held for a later batch

F006 (`retryOnGateSkip` gate-noise flag) is held because it touches job templates and therefore needs a `PostUpdateMigrator` migration to reach existing agents' installed jobs — which Codey's diff didn't include. That completes the gap-run trio once the migration is written.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
