### PR TITLE
fix(tunnel): quick provider captures cloudflared stderr so Cloudflare 429 is detected

### DIFF
--- a/src/tunnel/CloudflareQuickProvider.ts
+++ b/src/tunnel/CloudflareQuickProvider.ts
@@ -43,6 +43,30 @@ export interface CloudflareQuickProviderOptions {
   startTimeoutMs?: number;
 }
 
+/**
+ * Classify a cloudflared quick-tunnel failure into a fixed-substring reason the
+ * TunnelManager parses to a ProviderFailureReason. Pure + exported so the
+ * decision boundary (esp. the Cloudflare 429/1015 rate-limit detection) is
+ * unit-testable. Depends on the caller having captured cloudflared's real stderr
+ * (the 'stderr' event) into `stderr` — otherwise the rate-limit text never
+ * reaches the haystack and the classification falls through to generic.
+ */
+export function classifyQuickTunnelError(msg: string, stderr: string): Error {
+  const haystack = `${msg} ${stderr}`.toLowerCase();
+  // Cloudflare's quick-tunnel rate-limit surfaces as 429 / error 1015.
+  if (haystack.includes('429') || haystack.includes('1015') || haystack.includes('rate limit') || haystack.includes('too many requests')) {
+    return new Error(`rate-limited: cloudflared quick-tunnel rate-limited (${msg})`);
+  }
+  if (haystack.includes('enoent') || haystack.includes('not found') || haystack.includes('binary-missing')) {
+    return new Error(`binary-missing: ${msg}`);
+  }
+  if (haystack.includes('dns') || haystack.includes('eai_again') || haystack.includes('econnrefused') || haystack.includes('network')) {
+    return new Error(`network: ${msg}`);
+  }
+  // Preserve as-is so the manager's classifier sees the original prefix.
+  return new Error(msg);
+}
+
 export class CloudflareQuickProvider implements TunnelProvider {
   readonly name: ProviderName = 'cloudflare-quick';
   readonly tier: ProviderTier = 1;
@@ -125,6 +149,17 @@ export class CloudflareQuickProvider implements TunnelProvider {
       }
     }, this.startTimeoutMs);
 
+    // Capture cloudflared's REAL stderr. The `cloudflared` wrapper emits a
+    // 'stderr' event per child stderr line (incl. the "429 Too Many Requests /
+    // error code 1015" rate-limit line). Without listening here, stderrTail
+    // stayed empty → 'exit' logged "no stderr captured" → classifyError's
+    // 429/1015 detection was DEAD for the exit path, so the manager could never
+    // recognize (or back off on) a Cloudflare rate-limit. (Found live 2026-05-31:
+    // a quick tunnel 429'd but surfaced only as opaque "process-exit code 1".)
+    tunnel.on('stderr', (data: string) => {
+      stderrTail = (stderrTail + ' ' + data).slice(-2000);
+    });
+
     tunnel.once('url', (url: string) => {
       if (resolved) return;
       resolved = true;
@@ -168,20 +203,7 @@ export class CloudflareQuickProvider implements TunnelProvider {
   }
 
   private classifyError(msg: string, stderr: string): Error {
-    const haystack = `${msg} ${stderr}`.toLowerCase();
-    // Cloudflare's quick-tunnel rate-limit surfaces as 429 / error 1015.
-    // Both substrings appear in cloudflared's stderr on rate-limit.
-    if (haystack.includes('429') || haystack.includes('1015') || haystack.includes('rate limit') || haystack.includes('too many requests')) {
-      return new Error(`rate-limited: cloudflared quick-tunnel rate-limited (${msg})`);
-    }
-    if (haystack.includes('enoent') || haystack.includes('not found') || haystack.includes('binary-missing')) {
-      return new Error(`binary-missing: ${msg}`);
-    }
-    if (haystack.includes('dns') || haystack.includes('eai_again') || haystack.includes('econnrefused') || haystack.includes('network')) {
-      return new Error(`network: ${msg}`);
-    }
-    // Preserve as-is so the manager's classifier sees the original prefix.
-    return new Error(msg);
+    return classifyQuickTunnelError(msg, stderr);
   }
 
   private async stopHandle(tunnel: Tunnel): Promise<void> {

--- a/tests/unit/CloudflareQuickProvider.test.ts
+++ b/tests/unit/CloudflareQuickProvider.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect, vi } from 'vitest';
+import { EventEmitter } from 'node:events';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+// Mock the cloudflared wrapper so Tunnel.quick returns a controllable EventEmitter.
+const fakeTunnels: EventEmitter[] = [];
+vi.mock('cloudflared', () => ({
+  bin: '/fake/path/to/cloudflared',
+  install: vi.fn(async () => {}),
+  Tunnel: {
+    quick: vi.fn(() => {
+      const t = new EventEmitter() as EventEmitter & { process?: unknown; stop?: () => void };
+      t.process = { pid: 999999, stderr: null };
+      t.stop = () => {};
+      fakeTunnels.push(t);
+      return t;
+    }),
+  },
+}));
+
+import { classifyQuickTunnelError, CloudflareQuickProvider } from '../../src/tunnel/CloudflareQuickProvider.js';
+
+describe('classifyQuickTunnelError — failure-reason decision boundary', () => {
+  it('Cloudflare 429 / 1015 in stderr → rate-limited (even with a generic exit msg)', () => {
+    // THE REGRESSION the stderr-capture fix targets: the exit msg is the opaque
+    // "process-exit code 1", and the 429 lives only in the captured stderr.
+    const e = classifyQuickTunnelError(
+      'process-exit code 1: ',
+      'ERR Error unmarshaling QuickTunnel response: error code: 1015 status_code="429 Too Many Requests"',
+    );
+    expect(e.message).toMatch(/^rate-limited:/);
+  });
+
+  it('"too many requests" / "rate limit" phrasing → rate-limited', () => {
+    expect(classifyQuickTunnelError('x', 'Too Many Requests').message).toMatch(/^rate-limited:/);
+    expect(classifyQuickTunnelError('x', 'rate limit exceeded').message).toMatch(/^rate-limited:/);
+  });
+
+  it('ENOENT / not found → binary-missing', () => {
+    expect(classifyQuickTunnelError('spawn ENOENT', '').message).toMatch(/^binary-missing:/);
+  });
+
+  it('DNS / ECONNREFUSED → network', () => {
+    expect(classifyQuickTunnelError('getaddrinfo EAI_AGAIN', '').message).toMatch(/^network:/);
+    expect(classifyQuickTunnelError('connect ECONNREFUSED', '').message).toMatch(/^network:/);
+  });
+
+  it('an unrecognized failure is preserved as-is (so the manager sees the original prefix)', () => {
+    expect(classifyQuickTunnelError('process-exit code 1: no stderr captured', '').message)
+      .toBe('process-exit code 1: no stderr captured');
+  });
+});
+
+describe('CloudflareQuickProvider — captures cloudflared stderr so 429 is detected (the fix)', () => {
+  it("the 'stderr' listener feeds the 429 into classifyError → start() rejects rate-limited (not opaque process-exit)", async () => {
+    fakeTunnels.length = 0;
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'cfq-'));
+    const provider = new CloudflareQuickProvider({ port: 4099, stateDir: tmp, startTimeoutMs: 8000 });
+    const started = provider.start(4099);
+    // start() awaits an async install; wait for Tunnel.quick to create the fake.
+    await vi.waitFor(() => expect(fakeTunnels.length).toBeGreaterThan(0), { timeout: 4000 });
+    const t = fakeTunnels[fakeTunnels.length - 1];
+    // cloudflared prints the rate-limit on stderr, THEN the child exits non-zero.
+    t.emit('stderr', 'ERR Error unmarshaling QuickTunnel response: error code: 1015 status_code="429 Too Many Requests"');
+    t.emit('exit', 1);
+    await expect(started).rejects.toThrow(/rate-limited/);
+  });
+});

--- a/upgrades/next/quick-tunnel-stderr-capture.md
+++ b/upgrades/next/quick-tunnel-stderr-capture.md
@@ -1,0 +1,41 @@
+# Upgrade Guide — vNEXT
+
+<!-- bump: patch -->
+
+## What Changed
+
+**Quick tunnels now correctly recognize when Cloudflare is rate-limiting them.**
+When the zero-config quick tunnel failed because Cloudflare's free tunnel service
+returned "429 Too Many Requests", instar only saw an opaque "process exited" with
+no detail — it couldn't tell a rate-limit apart from any other failure, so it
+couldn't react appropriately. The provider now captures cloudflared's real error
+output, so a rate-limit is identified as exactly that and handed to the tunnel
+manager's failure handling with the right reason.
+
+## What to Tell Your User
+
+Nothing to configure. If your quick tunnel ever gets rate-limited by Cloudflare,
+instar now recognizes it as a rate-limit (instead of a generic failure), which
+lets it respond more sensibly under that degraded condition. Named tunnels and
+the healthy path are unaffected.
+
+## Summary of New Capabilities
+
+- `classifyQuickTunnelError(msg, stderr)` — pure, exported, unit-tested
+  classifier mapping a cloudflared failure to a fixed reason
+  (rate-limited / binary-missing / network / passthrough).
+- `CloudflareQuickProvider` now listens to the cloudflared wrapper's `stderr`
+  event, so the rate-limit text actually reaches the classifier (it never did
+  before, which made the 429 detection dead on the process-exit path).
+
+## Evidence
+
+- Found live (2026-05-31): a quick tunnel hit Cloudflare 429, but instar
+  surfaced only "process-exit code 1: no stderr captured"; the 429 was visible
+  only by running cloudflared directly.
+- Tests: `tests/unit/CloudflareQuickProvider.test.ts` (6) — the classifier
+  across all reason branches, plus a mock-cloudflared test proving the new
+  stderr listener feeds a 429 line into the classifier so start() rejects with
+  rate-limited. `tsc --noEmit` clean.
+- Spec: tunnel-failure-resilience (the manager's single-owner failure handling
+  this classification feeds).

--- a/upgrades/side-effects/quick-tunnel-stderr-capture.md
+++ b/upgrades/side-effects/quick-tunnel-stderr-capture.md
@@ -1,0 +1,63 @@
+# Side effects — quick-tunnel captures cloudflared stderr (429 detection)
+
+## What was broken
+
+`CloudflareQuickProvider` (the Tier-1 zero-config quick tunnel) classified
+failures via `classifyError(msg, stderr)`, whose rate-limit branch checks the
+text for `429` / `1015` / "rate limit" / "too many requests". But the provider
+listened only to the cloudflared wrapper's `url` / `error` / `exit` events — it
+**never listened to the wrapper's `stderr` event**, which is the only place
+cloudflared's real stderr (including the `429 Too Many Requests` / `error code
+1015` rate-limit line) is delivered. So `stderrTail` stayed empty, `exit` logged
+the opaque `process-exit code 1: no stderr captured`, and the 429 branch was
+**dead code on the exit path** — the manager could never recognize (or back off
+on / surface) a Cloudflare rate-limit.
+
+Found live (2026-05-31): a quick-tunnel start hit Cloudflare 429, but instar
+surfaced only "process-exit code 1: no stderr captured"; the 429 was visible
+only by running `cloudflared tunnel --url` directly.
+
+## The fix
+
+1. `CloudflareQuickProvider.startInner` now registers
+   `tunnel.on('stderr', (data) => { stderrTail = (stderrTail + ' ' + data).slice(-2000); })`,
+   capturing cloudflared's real stderr (bounded to the last 2000 chars). The
+   existing `error`/`exit` handlers already feed `stderrTail` into the
+   classifier, so the 429/1015 text now reaches it.
+2. The classification logic is extracted to a pure, exported
+   `classifyQuickTunnelError(msg, stderr)` (unchanged behavior), so the
+   decision boundary is unit-testable.
+
+## Who is affected
+
+- **Any agent with a quick tunnel that hits Cloudflare 429** (the free
+  trycloudflare service rate-limits under load): the failure is now classified
+  `rate-limited:` instead of opaque `process-exit`, so the TunnelManager's
+  failure handling (per the tunnel-failure-resilience spec) acts on the correct
+  reason. No behavior change on the success path or for non-rate-limited
+  failures (those classify exactly as before).
+
+## Blast radius
+
+- 1 source file: `src/tunnel/CloudflareQuickProvider.ts` (one added event
+  listener + a pure-function extraction). No config, no schema, no migration —
+  picked up by existing agents on the normal dist update. The TunnelManager,
+  other providers, and the success path are untouched.
+
+## Failure modes considered
+
+- **Listener fires after resolution?** Harmless — it only appends to a bounded
+  buffer; once `url` resolves, the buffer is unused.
+- **stderr never arrives (true silent exit)?** Behavior is exactly as before:
+  `stderrTail` empty → `exit` logs "no stderr captured" → classified generic.
+  The fix can only ADD signal, never remove it.
+- **Buffer growth?** Bounded to the last 2000 chars via `.slice(-2000)`.
+
+## Tests
+
+`tests/unit/CloudflareQuickProvider.test.ts` (6): `classifyQuickTunnelError`
+across 429/1015/"too many requests"/"rate limit", ENOENT→binary-missing,
+DNS/ECONNREFUSED→network, and unrecognized→preserved; plus a mock-`cloudflared`
+test proving the new `stderr` listener feeds a 429 stderr line into the
+classifier so `start()` rejects `rate-limited` (rather than the opaque
+`process-exit`). `tsc --noEmit` clean.


### PR DESCRIPTION
## What

**Quick tunnels never recognized Cloudflare rate-limiting.** `CloudflareQuickProvider` listened only to the `cloudflared` wrapper's `url`/`error`/`exit` events — **never its `stderr` event**, which is the one place cloudflared's real stderr (including the `429 Too Many Requests` / `error code 1015` rate-limit line) is delivered. So `stderrTail` stayed empty, `exit` logged the opaque `process-exit code 1: no stderr captured`, and `classifyError`'s 429/1015 branch was **dead code on the exit path** — the `TunnelManager` could never recognize, back off on, or surface a Cloudflare rate-limit.

**Found live (2026-05-31)** while attempting the multi-machine mmtest2 mesh: a quick tunnel hit Cloudflare 429, but instar surfaced only "process-exit code 1: no stderr captured" — the 429 was visible only by running `cloudflared tunnel --url` directly.

## Fix

1. `startInner` now registers `tunnel.on('stderr', (data) => stderrTail = (stderrTail + ' ' + data).slice(-2000))`, capturing cloudflared's real stderr (bounded). The existing `error`/`exit` handlers already feed `stderrTail` to the classifier, so the 429 text now reaches it.
2. Extracted the classification to a pure, exported, unit-tested `classifyQuickTunnelError(msg, stderr)` — behavior unchanged.

Success path and non-rate-limit failures classify exactly as before; the fix can only *add* signal.

## Tests

`tests/unit/CloudflareQuickProvider.test.ts` (6): the classifier across 429/1015/"too many requests"/"rate limit", ENOENT→binary-missing, DNS/ECONNREFUSED→network, unrecognized→preserved; **plus a mock-`cloudflared` test proving the new `stderr` listener feeds a 429 line into the classifier so `start()` rejects `rate-limited`** (not the opaque `process-exit`). `tsc` clean; full pre-commit + pre-push ship-gate green.

## Scope

Independent fix (touches only `CloudflareQuickProvider.ts`). Directly serves the "robust under degraded conditions" mandate — multi-machine reachability depends on tunnels, and Cloudflare-429 is a degraded condition the system must recognize. Spec: tunnel-failure-resilience (the manager's single-owner failure handling this classification feeds). Opened for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
