### PR TITLE
feat(instar-dev): tier classifier + Tier-1 PR path (tiered-dev Step A)

### DIFF
--- a/docs/specs/tier-classifier-and-tier1-path-spec.eli16.md
+++ b/docs/specs/tier-classifier-and-tier1-path-spec.eli16.md
@@ -1,0 +1,61 @@
+# Plain-English overview: the gate that suggests a tier and opens a lighter lane
+
+## What this is
+
+This is the first build step of the tiered-development project you approved. It changes
+the commit gate (the check that runs every time the agent tries to commit code) to do two
+new things:
+
+1. **Suggest a tier.** Before a commit, the gate looks at how big the change is *and* how
+   risky it is, and prints a suggested tier (1, 2, or 3) with the reasons. A tiny,
+   low-risk change → suggested Tier 1. Anything near the dangerous areas (secret-handling,
+   auth/tokens, the message-delivery path, the destructive-file/git guards) → bumped up,
+   no matter how small.
+
+2. **Open the Tier-1 lane.** If the change is Tier 1, the agent can commit it with just a
+   plain-English overview (ELI16) + a short side-effects note + passing tests — **no
+   full pre-approved spec.** Bigger changes (Tier 2 and up) still go through the full
+   spec process exactly as today.
+
+## The important part: the gate suggests, the agent decides
+
+This is the new constitution article ("The Body and the Mind") in action. The gate does
+**not** decide the tier — it *suggests* one and shows its reasoning. The **agent** picks
+the final tier and writes down *why*. Every one of those decisions is **recorded** to a
+log (what the gate suggested, what the agent chose, and why). If the agent ever picks a
+*lower* tier than the risk signals warrant, the gate doesn't block it — but it prints a
+loud notice and stamps the record as an "override," so it's visible and reviewable. That
+record is exactly what makes "let the agent decide" safe instead of a loophole — and it's
+the data we'll use later to make both the gate's suggestions and the agent's judgment
+better over time.
+
+## What already exists / what's new
+
+- The commit gate, the spec requirement, the ELI16 requirement, and the side-effects note
+  all already exist. Today they apply to *everything* the same way.
+- **New:** the tier suggestion (size + risk), the agent's recorded tier choice, the
+  audit log, and the lighter Tier-1 lane.
+
+## Why it's safe
+
+It's strictly additive. If the agent doesn't declare a tier at all, the gate behaves
+**exactly like today** (full spec required) — so nothing existing breaks. The only thing
+that gets *easier* is small, low-risk changes, and even those still need the overview, the
+side-effects note, and green tests. The risk floor is a loud, logged signal, never a
+silent downgrade.
+
+## What you need to decide
+
+This is a Tier-2 step, so per our own rules it gets a real spec (this), goes through
+cross-model review (convergence), and waits for your approval before I build it. If the
+design looks right, say so and I'll run convergence and bring it back to build. The
+specifics most worth your eye: the size threshold (≈40 lines / ≈3 files for Tier 1), the
+list of "high-risk" areas that force a bump, and where the audit log lives
+(`.instar/instar-dev-decisions.jsonl`).
+
+## How we'll know it worked, later
+
+A one-line observability fix will commit as a quick Tier-1 (overview + note + tests, no
+spec); a change touching the secret-handling code will refuse to be Tier-1 even if it's
+one line; and the decisions log will show, for every commit, what the gate suggested vs.
+what the agent chose — with any "override" clearly flagged.

--- a/docs/specs/tier-classifier-and-tier1-path-spec.eli16.md
+++ b/docs/specs/tier-classifier-and-tier1-path-spec.eli16.md
@@ -9,7 +9,8 @@ new things:
 1. **Suggest a tier.** Before a commit, the gate looks at how big the change is *and* how
    risky it is, and prints a suggested tier (1, 2, or 3) with the reasons. A tiny,
    low-risk change → suggested Tier 1. Anything near the dangerous areas (secret-handling,
-   auth/tokens, the message-delivery path, the destructive-file/git guards) → bumped up,
+   auth/tokens, the message-delivery path, the destructive-file/git guards, or the
+   migration/fleet-release machinery) → bumped up,
    no matter how small.
 
 2. **Open the Tier-1 lane.** If the change is Tier 1, the agent can commit it with just a
@@ -24,10 +25,14 @@ This is the new constitution article ("The Body and the Mind") in action. The ga
 the final tier and writes down *why*. Every one of those decisions is **recorded** to a
 log (what the gate suggested, what the agent chose, and why). If the agent ever picks a
 *lower* tier than the risk signals warrant, the gate doesn't block it — but it prints a
-loud notice and stamps the record as an "override," so it's visible and reviewable. That
-record is exactly what makes "let the agent decide" safe instead of a loophole — and it's
-the data we'll use later to make both the gate's suggestions and the agent's judgment
-better over time.
+loud notice and stamps the record as an "override," so it's visible and reviewable.
+
+That record is a **learning signal, not a security wall**: it only catches cases the gate
+*noticed* were risky, and the agent could still under-declare a risk the heuristics missed.
+The real human gates are the **pull-request review** (every Tier-1 change is a PR you see)
+and the **operator spot-check** on auto-merge. What the log gives us is the data to make
+both the gate's suggestions and the agent's judgment better over time — and to grow the
+risk list when a blind spot shows up.
 
 ## What already exists / what's new
 

--- a/docs/specs/tier-classifier-and-tier1-path-spec.md
+++ b/docs/specs/tier-classifier-and-tier1-path-spec.md
@@ -1,0 +1,133 @@
+---
+title: "Tier classifier + Tier-1 PR path (Step A of the tiered development process)"
+date: 2026-06-01
+author: echo
+review-convergence: pending
+approved: false
+eli16-overview: tier-classifier-and-tier1-path-spec.eli16.md
+---
+
+# Tier classifier + Tier-1 PR path (Step A)
+
+> **Status:** Step A of the **Tiered Development Process** project
+> (`docs/projects/tiered-dev-process/PROJECT.md`, project shape approved by Justin
+> 2026-06-01). This is a Tier-2 change: it needs spec-review-convergence and Justin's
+> approval before build. `review-convergence` and `approved` are intentionally not yet
+> set — they flip when convergence runs and Justin approves.
+
+## Goal
+
+Teach the instar-dev commit gate (`scripts/instar-dev-precommit.js`) to (1) **compute a
+tier signal** from a staged change and **surface it**, (2) let the agent **declare the
+tier** (informed by the signal) and **record** signal + choice + reasoning to an audit
+trail, and (3) enforce the **chosen tier's** requirement set — adding a **Tier-1 path**
+where a small/low-risk change may commit with an ELI16 + side-effects + tests/lint and
+**no pre-approved converged spec**.
+
+This is the first executable instance of the constitution's **The Body and the Mind**
+(The Substrate): the gate (body) **informs**; the agent (mind) **decides**; the decision
+is **audited**. It deliberately does **not** make the gate decide the tier — an earlier
+draft of the parent project proposed exactly that and was caught as unconstitutional.
+
+## Current behavior (what Step A modifies)
+
+`instar-dev-precommit.js` today applies ONE requirement set to **every** in-scope staged
+change (`src/`, `scripts/`, `.husky/`, `skills/*`): a fresh trace (`phase: complete`,
+`coveredFiles ⊇` staged in-scope) → a side-effects artifact (staged, sha-matched) → a
+`specPath` whose spec carries `review-convergence` + `approved: true` → an ELI16 overview.
+There is no notion of size, risk, or tier; a one-line observability fix pays the same
+cost as a new subsystem (the friction this project removes).
+
+## Design
+
+### 1. The tier signal (computed by the gate, surfaced, never authoritative)
+
+A pure function `classifyTier(stagedInScopeFiles, diffStat, repoRoot)` returns
+`{ suggestedTier: 1|2|3, sizeTier, riskFloor, reasons: string[] }`:
+
+- **Size** → a base tier. `sizeTier = 1` when in-scope additions+deletions ≤ `SIZE_LOC`
+  (default 40) across ≤ `SIZE_FILES` (default 3); else `2`. (Tunable constants.)
+- **Risk floor** → may only *raise*, never lower, the tier. Risk signals (each emits a
+  reason string):
+  - **Safety-invariant proximity** — staged path or hunk matches a configured
+    invariant-bearing set: SecretDrop (`*secret*`, never-on-disk), the relay/delivery
+    path (`*Relay*`, `*Telegram*Adapter*`, delivery-robustness), auth/tokens
+    (`*auth*`, `*token*`), the destructive-op funnels (`SafeFsExecutor`,
+    `SafeGitExecutor`, `SourceTreeGuard`), the session lifecycle/reaper. → `riskFloor ≥ 2`.
+  - **Irreversibility** — touches a migration, a data-format/schema, or a
+    `PostUpdateMigrator` path. → `riskFloor ≥ 2`.
+  - **New capability** — adds a new route, a new exported subsystem/class, or a new
+    config surface (heuristic: net-new `router.<verb>(` / `export class ` / config key).
+    → `riskFloor ≥ 2`.
+- `suggestedTier = max(sizeTier, riskFloor)`. Tier **3** is never auto-suggested — it is
+  *declared* when a change is a step of an approved project (the project is what is
+  Tier-3; its step-specs are Tier-2 each).
+
+The gate **prints** `suggestedTier` + every reason. This is signal only.
+
+### 2. The agent's declaration (the mind decides) — via the trace
+
+The agent records its decision in the trace JSON (the gate already reads a fresh trace):
+- `tier: 1|2|3` — the agent's **chosen** tier.
+- `tierReasoning: string` — why (one or two sentences).
+- For **Tier 1**: `eli16Path` + `sideEffectsPath` (no `specPath`).
+- For **Tier 2+**: the existing `specPath` (+ `artifactPath`/`artifactSha256`) as today.
+
+**No trace, or no `tier` field → default to Tier 2** (today's full requirement set). This
+makes the change strictly additive and back-compatible: an unaware caller behaves exactly
+as before.
+
+### 3. Enforcement (the chosen tier's requirement set)
+
+- **Tier 1:** require a staged ELI16 (the "request" ELI16) + a staged side-effects
+  artifact (sha-matched, as today) + the project's tests/lint pass. **No converged
+  approved spec.** The PR is the review surface (and, per the Tier-1 merge policy,
+  auto-merges on green CI with operator spot-check — out of scope for *this* gate, which
+  governs the commit, not the merge).
+- **Tier 2 / 3-step:** the **current** requirement set unchanged (fresh trace +
+  coveredFiles superset + staged sha-matched artifact + `specPath` with
+  `review-convergence` + `approved: true` + ELI16). A Tier-3 *project step* is a Tier-2
+  spec; nothing new is enforced for "Tier 3" at the gate.
+
+### 4. The audit (closes the loop — what makes "the mind decides" safe)
+
+On every in-scope commit the gate appends one JSON line to
+`.instar/instar-dev-decisions.jsonl`: `{ ts, slug, suggestedTier, declaredTier,
+riskFloorReasons, belowFloor: boolean, files, loc }`. When `declaredTier < riskFloor`
+(the agent chose under the risk-signaled floor), the gate **prints a loud notice and
+records `belowFloor: true`** — it does **not** block (the mind holds authority), but the
+override is now a visible, reviewable record. This is the audit trail the constitution
+requires; a later step may surface `belowFloor` overrides for operator review.
+
+## Safety / blast radius
+
+Additive and back-compatible: with no `tier` declaration the gate enforces exactly
+today's Tier-2 requirement set, so every existing flow is unchanged. The **only**
+relaxation is the new Tier-1 path, and it still requires ELI16 + side-effects + green
+tests/lint — it drops only the *pre-approved converged spec*. The risk floor is a loud,
+audited signal, not a silent auto-downgrade. The classifier is pure and unit-testable;
+the gate's existing checks are untouched for Tier-2+.
+
+## Testing
+
+- **Unit (`classifyTier`):** size→tier boundaries (≤/> SIZE_LOC, SIZE_FILES);
+  each risk signal raises the floor (a 1-line change touching a `*secret*` path →
+  suggested Tier 2); `max(size, risk)`; Tier-3 never auto-suggested.
+- **Unit (gate enforcement):** Tier-1 trace (ELI16 + side-effects, no spec) → commit
+  allowed; Tier-1 trace missing ELI16 → blocked; no `tier` field → Tier-2 requirement
+  set enforced (back-compat); `declaredTier < riskFloor` → `belowFloor:true` recorded +
+  not blocked; Tier-2 path unchanged (existing tests stay green).
+- **Audit:** a commit appends exactly one well-formed `instar-dev-decisions.jsonl` line.
+
+## Migration parity
+
+`instar-dev-precommit.js` is the gate for agents *developing instar*; it ships in the
+instar repo, not installed into arbitrary agent homes by `init`. No `PostUpdateMigrator`
+change is required for end agents. The instar-dev skill (Step C) documents the new tier
+declaration so the developing agent knows to set it.
+
+## Out of scope (later steps)
+
+Tier-1 PR **auto-merge** policy (the merge, not the commit — config + CI wiring); the
+codex-CLI cross-model review (Step B); the skill/docs/CLAUDE.md-template awareness
+(Step C); migration of any deployed gate (Step D). Per the project breakdown.

--- a/docs/specs/tier-classifier-and-tier1-path-spec.md
+++ b/docs/specs/tier-classifier-and-tier1-path-spec.md
@@ -2,8 +2,10 @@
 title: "Tier classifier + Tier-1 PR path (Step A of the tiered development process)"
 date: 2026-06-01
 author: echo
-review-convergence: pending
-approved: false
+review-convergence: abbreviated-internal-2026-06-01
+approved: true
+approved-by: Justin
+approved-via: "Telegram topic 13435 (2026-06-01): 'Perfect approved please continue' on the design. Abbreviated convergence (internal adversarial/integration/lessons-aware panel) then ran and returned MINOR ISSUES; the three substantive findings + polish are folded in below (§1 risk list, §2 trace-writer, §4 audit honesty + Close-the-Loop). External cross-model review is itself built in Step B (it is the thing this project builds). Findings were refinements, not a redesign, so the approval stands."
 eli16-overview: tier-classifier-and-tier1-path-spec.eli16.md
 ---
 
@@ -53,9 +55,16 @@ A pure function `classifyTier(stagedInScopeFiles, diffStat, repoRoot)` returns
     invariant-bearing set: SecretDrop (`*secret*`, never-on-disk), the relay/delivery
     path (`*Relay*`, `*Telegram*Adapter*`, delivery-robustness), auth/tokens
     (`*auth*`, `*token*`), the destructive-op funnels (`SafeFsExecutor`,
-    `SafeGitExecutor`, `SourceTreeGuard`), the session lifecycle/reaper. → `riskFloor ≥ 2`.
-  - **Irreversibility** — touches a migration, a data-format/schema, or a
-    `PostUpdateMigrator` path. → `riskFloor ≥ 2`.
+    `SafeGitExecutor`, `SourceTreeGuard`), the session lifecycle/reaper
+    (`*Reaper*`, `*session*lifecycle*`). → `riskFloor ≥ 2`.
+  - **Migration / fleet-rollout surface** — touches the migration machinery by name
+    (`PostUpdateMigrator`, the `migrate*()` family, `src/data/http-hook-templates.ts`,
+    settings/config migration) or the **fleet-release / publish path** (`upgrades/NEXT.md`,
+    release/publish scripts). These are where the zombie-cleanup, lifeline-skew, and
+    "one malformed NEXT.md jams all releases" (#42) regressions lived — a one-line change
+    here is never Tier-1. → `riskFloor ≥ 2`.
+  - **Irreversibility** — touches a data-format/schema or anything not trivially
+    revertable. → `riskFloor ≥ 2`.
   - **New capability** — adds a new route, a new exported subsystem/class, or a new
     config surface (heuristic: net-new `router.<verb>(` / `export class ` / config key).
     → `riskFloor ≥ 2`.
@@ -77,6 +86,13 @@ The agent records its decision in the trace JSON (the gate already reads a fresh
 makes the change strictly additive and back-compatible: an unaware caller behaves exactly
 as before.
 
+**Trace writer (`skills/instar-dev/scripts/write-trace.mjs`) must emit the new fields**
+(convergence Finding 1 — without this the Tier-1 trace cannot be produced and the feature
+is unreachable). Add flags: `--tier <1|2|3>`, `--tier-reasoning <text>`, and (for Tier 1)
+`--eli16-path <path>` + `--side-effects-path <path>`; make `--spec` **optional when
+`--tier 1`** (a Tier-1 trace carries no `specPath`). A unit test must round-trip a Tier-1
+trace (tier:1 + eli16Path + sideEffectsPath, no specPath) and a Tier-2 trace (unchanged).
+
 ### 3. Enforcement (the chosen tier's requirement set)
 
 - **Tier 1:** require a staged ELI16 (the "request" ELI16) + a staged side-effects
@@ -93,11 +109,23 @@ as before.
 
 On every in-scope commit the gate appends one JSON line to
 `.instar/instar-dev-decisions.jsonl`: `{ ts, slug, suggestedTier, declaredTier,
-riskFloorReasons, belowFloor: boolean, files, loc }`. When `declaredTier < riskFloor`
-(the agent chose under the risk-signaled floor), the gate **prints a loud notice and
-records `belowFloor: true`** — it does **not** block (the mind holds authority), but the
-override is now a visible, reviewable record. This is the audit trail the constitution
-requires; a later step may surface `belowFloor` overrides for operator review.
+riskFloor, riskFloorReasons, belowFloor: boolean, files, loc }` (recording `riskFloor`
+the number — not just the derived boolean — keeps the line self-contained for later
+review without re-running the classifier). When `declaredTier < riskFloor` (the agent
+chose under the risk-signaled floor), the gate **prints a loud notice and records
+`belowFloor: true`** — it does **not** block (the mind holds authority), but the override
+is now a visible, reviewable record.
+
+**Honest scope of the audit (convergence Finding 2).** `belowFloor` only fires when the
+gate's heuristic *detected* the risk. A risky change that *evades* the path/keyword globs
+produces `riskFloor: 1`, so declaring Tier-1 on it is never flagged. The audit therefore
+backstops the **honest-but-overruling** case, not the **evasion** case. Undetected risk is
+caught downstream by the two surfaces the tier model already has: the **PR is the review
+surface** for every Tier-1 change, and the Tier-1 **auto-merge operator spot-check** (the
+merge policy, a sibling step) is the human gate. Per **Close the Loop**: `belowFloor`
+rates — and the broader question "are we mis-classifying?" — should be reviewed on a
+cadence, because that review is the only way the heuristic's blind spots surface and the
+risk-floor list grows. The audit is a *learning signal*, not a *security boundary*.
 
 ## Safety / blast radius
 
@@ -114,10 +142,15 @@ the gate's existing checks are untouched for Tier-2+.
   each risk signal raises the floor (a 1-line change touching a `*secret*` path →
   suggested Tier 2); `max(size, risk)`; Tier-3 never auto-suggested.
 - **Unit (gate enforcement):** Tier-1 trace (ELI16 + side-effects, no spec) → commit
-  allowed; Tier-1 trace missing ELI16 → blocked; no `tier` field → Tier-2 requirement
-  set enforced (back-compat); `declaredTier < riskFloor` → `belowFloor:true` recorded +
-  not blocked; Tier-2 path unchanged (existing tests stay green).
-- **Audit:** a commit appends exactly one well-formed `instar-dev-decisions.jsonl` line.
+  allowed; Tier-1 trace missing ELI16 → blocked; `declaredTier < riskFloor` →
+  `belowFloor:true` recorded + not blocked; Tier-2 path unchanged.
+- **Back-compat regression (required fixture):** an *existing-shape* trace with **no
+  `tier` field** + an approved converged spec must pass **byte-for-byte as today** — this
+  is the named guard that the additive change broke nothing.
+- **Trace writer (`write-trace.mjs`):** round-trip a Tier-1 trace (`tier:1` + `eli16Path`
+  + `sideEffectsPath`, **no** `specPath`) and a Tier-2 trace (unchanged).
+- **Audit:** a commit appends exactly one well-formed `instar-dev-decisions.jsonl` line,
+  including `riskFloor` (number) and `belowFloor` (boolean).
 
 ## Migration parity
 

--- a/scripts/instar-dev-precommit.js
+++ b/scripts/instar-dev-precommit.js
@@ -28,13 +28,15 @@ import path from 'node:path';
 import crypto from 'node:crypto';
 import { execSync } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
-import { checkEli16Overview } from './eli16-overview-check.mjs';
+import { checkEli16Overview, MIN_ELI16_CHARS } from './eli16-overview-check.mjs';
 import { verifyProposalDerivedRunbooks } from '../skills/instar-dev/scripts/verify-proposal-derived-runbook.mjs';
+import { classifyTier, decideRequirementSet } from './lib/classify-tier.mjs';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const ROOT = path.resolve(__dirname, '..');
 const TRACES_DIR = path.join(ROOT, '.instar', 'instar-dev-traces');
+const DECISIONS_LOG = path.join(ROOT, '.instar', 'instar-dev-decisions.jsonl');
 const WINDOW_MS = 60 * 60 * 1000; // 60 minutes
 const MIN_ARTIFACT_CHARS = 200;
 
@@ -135,6 +137,72 @@ if (bootstrapTrigger) {
   process.exit(0);
 }
 
+// ─── Step 3.5: compute + surface the tier signal ─────────────────────────
+// Pure classifier (scripts/lib/classify-tier.mjs). SIGNAL ONLY — the gate
+// SURFACES the suggestion; the agent DECLARES the real tier in its trace. The
+// classifier never decides for the agent and never blocks. (The Body and the
+// Mind: the body informs, the mind decides, the decision is audited.)
+
+let tierSignal = { suggestedTier: 2, sizeTier: 2, riskFloor: 1, reasons: [] };
+let totalChangedLoc = 0;
+{
+  let addedLines = 0;
+  let deletedLines = 0;
+  let addedDiffText = '';
+  try {
+    const numstat = execSync(
+      `git diff --cached --numstat -- ${inScopeFiles.map((f) => JSON.stringify(f)).join(' ')}`,
+      { cwd: ROOT, encoding: 'utf8' },
+    );
+    for (const line of numstat.split('\n')) {
+      const trimmed = line.trim();
+      if (!trimmed) continue;
+      const [a, d] = trimmed.split('\t');
+      // Binary files show "-\t-"; treat as 0 LOC.
+      addedLines += a === '-' ? 0 : parseInt(a, 10) || 0;
+      deletedLines += d === '-' ? 0 : parseInt(d, 10) || 0;
+    }
+  } catch {
+    // If numstat fails, leave LOC at 0 — sizeTier becomes 1, riskFloor still
+    // governs. We never crash the gate over a diff-stat hiccup.
+  }
+  try {
+    // Added-line-only diff text feeds the new-capability heuristic. We pull the
+    // full staged diff and keep only the added (`+`) lines, stripping the `+`.
+    const fullDiff = execSync(
+      `git diff --cached -- ${inScopeFiles.map((f) => JSON.stringify(f)).join(' ')}`,
+      { cwd: ROOT, encoding: 'utf8', maxBuffer: 32 * 1024 * 1024 },
+    );
+    addedDiffText = fullDiff
+      .split('\n')
+      .filter((l) => l.startsWith('+') && !l.startsWith('+++'))
+      .map((l) => l.slice(1))
+      .join('\n');
+  } catch {
+    // No added-diff text → classifier SKIPS the new-capability check (per spec).
+    addedDiffText = '';
+  }
+
+  totalChangedLoc = addedLines + deletedLines;
+
+  tierSignal = classifyTier({
+    inScopeFiles,
+    addedLines,
+    deletedLines,
+    addedDiffText: addedDiffText || undefined,
+  });
+
+  console.error(
+    `[instar-dev-precommit] tier signal: suggestedTier=${tierSignal.suggestedTier} ` +
+      `(size=${tierSignal.sizeTier}, riskFloor=${tierSignal.riskFloor}, ` +
+      `${addedLines + deletedLines} LOC across ${inScopeFiles.length} file(s))`,
+  );
+  if (tierSignal.reasons.length > 0) {
+    console.error('[instar-dev-precommit] risk-floor reasons:');
+    for (const r of tierSignal.reasons) console.error(`  • ${r}`);
+  }
+}
+
 // ─── Step 4: find a fresh trace ──────────────────────────────────────────
 
 if (!fs.existsSync(TRACES_DIR)) {
@@ -157,6 +225,75 @@ if (traceEntries.length === 0) {
     'No fresh trace found (< 60 min old) in .instar/instar-dev-traces/. Run the /instar-dev skill to produce one.',
   );
 }
+
+// ─── Step 4.5: read the agent's DECLARED tier + branch ───────────────────
+// The agent records its tier in the trace JSON. We peek the freshest fresh
+// trace to read `trace.tier` (1|2|3). decideRequirementSet() factors the pure
+// enforcement decision:
+//   - tier 1            → 'tier1-lite'  (ELI16 + side-effects staged; no spec)
+//   - tier 2 / 3        → 'tier2-full'  (the EXISTING full validation, unchanged)
+//   - missing / no tier → 'tier2-full'  (back-compat default — behaves as today)
+
+let declaredTier = null;
+let tierReasoning = '';
+let freshestTrace = null;
+try {
+  freshestTrace = JSON.parse(fs.readFileSync(traceEntries[0].file, 'utf8'));
+  if (freshestTrace && (freshestTrace.tier === 1 || freshestTrace.tier === 2 || freshestTrace.tier === 3)) {
+    declaredTier = freshestTrace.tier;
+  }
+  if (freshestTrace && typeof freshestTrace.tierReasoning === 'string') {
+    tierReasoning = freshestTrace.tierReasoning;
+  }
+} catch {
+  // Malformed freshest trace → declaredTier stays null → Tier-2 back-compat
+  // path (the existing Step 5 loop will surface the malformed-JSON attempt).
+}
+
+const slug = (freshestTrace && (freshestTrace.slug || freshestTrace.name)) || 'unknown';
+const decision = decideRequirementSet(declaredTier);
+
+// AUDIT (all in-scope cases): one JSON line, written regardless of branch.
+// belowFloor = the agent declared UNDER the risk-signaled floor. We never
+// block on it (the mind holds authority) — the record is the backstop.
+const belowFloor = declaredTier != null && declaredTier < tierSignal.riskFloor;
+writeDecisionAudit({
+  slug,
+  suggestedTier: tierSignal.suggestedTier,
+  declaredTier,
+  riskFloor: tierSignal.riskFloor,
+  riskFloorReasons: tierSignal.reasons,
+  belowFloor,
+  files: inScopeFiles.length,
+  loc: totalChangedLoc,
+});
+if (belowFloor) {
+  console.error('');
+  console.error('┌──────────────────────────────────────────────────────────────────┐');
+  console.error('│  ⚠ BELOW RISK FLOOR — declared tier is under the risk-signaled    │');
+  console.error('│    floor. NOT blocked (you hold authority), but recorded.         │');
+  console.error('└──────────────────────────────────────────────────────────────────┘');
+  console.error(`  declared Tier ${declaredTier} < risk floor ${tierSignal.riskFloor}. Risk signals:`);
+  for (const r of tierSignal.reasons) console.error(`    • ${r}`);
+  if (tierReasoning) console.error(`  Your tierReasoning: ${tierReasoning}`);
+  console.error(`  Recorded to ${path.relative(ROOT, DECISIONS_LOG)} (belowFloor:true).`);
+  console.error('');
+}
+
+// ─── Step 4.6: Tier-1 lite path ──────────────────────────────────────────
+// When the agent declared Tier 1, the requirement set is intentionally lighter:
+// a staged ELI16 (the "request" ELI16) + a staged side-effects artifact
+// (sha-matched if the trace records a sha) — and NO converged/approved spec.
+// (The tests/lint requirement from the spec lives in the pre-PUSH gate, not
+// here: this pre-COMMIT hook checks ARTIFACTS only.)
+if (decision.requirementSet === 'tier1-lite') {
+  enforceTier1(freshestTrace, traceEntries[0].file);
+  // enforceTier1 either passes through (process.exit(0)) or blockCommit()s.
+}
+
+// ── Otherwise: Tier-2 / Tier-3 / no-tier → the EXISTING full validation ──
+// Everything below (Steps 5–8) is unchanged. A Tier-3 project step is just a
+// Tier-2 spec; nothing new is enforced for "Tier 3" at the gate.
 
 // ─── Step 5: validate most recent trace against staged files ─────────────
 
@@ -538,4 +675,145 @@ function blockCommit(files, reason) {
   console.error('See docs/signal-vs-authority.md and skills/instar-dev/SKILL.md for details.');
   console.error('');
   process.exit(1);
+}
+
+// ─── Audit writer ─────────────────────────────────────────────────────────
+// Append exactly one JSON line to .instar/instar-dev-decisions.jsonl for every
+// in-scope commit (regardless of tier branch). Best-effort: a logging failure
+// must never crash the gate.
+function writeDecisionAudit({ slug, suggestedTier, declaredTier, riskFloor, riskFloorReasons, belowFloor, files, loc }) {
+  try {
+    fs.mkdirSync(path.dirname(DECISIONS_LOG), { recursive: true });
+    fs.appendFileSync(
+      DECISIONS_LOG,
+      JSON.stringify({
+        ts: new Date().toISOString(),
+        slug,
+        suggestedTier,
+        declaredTier,
+        // riskFloor (the number) keeps the line self-contained for later review
+        // without re-running the classifier — not just the derived belowFloor.
+        riskFloor,
+        riskFloorReasons,
+        belowFloor,
+        files,
+        loc,
+      }) + '\n',
+    );
+  } catch {
+    // best-effort — never block on audit I/O
+  }
+}
+
+// ─── Tier-1 lite enforcement ──────────────────────────────────────────────
+// Tier-1 requirement set: a staged ELI16 (trace.eli16Path) passing the length
+// check + a staged side-effects artifact (trace.sideEffectsPath, sha-matched if
+// trace.artifactSha256 is present). NO specPath / review-convergence / approved.
+// On success this PASSES the whole gate (process.exit(0)); on any failure it
+// blockCommit()s with a Tier-1-specific message.
+function enforceTier1(trace, traceFile) {
+  const traceName = path.basename(traceFile);
+
+  // ── ELI16 (request overview) ──
+  const eli16Rel = trace.eli16Path;
+  if (!eli16Rel) {
+    blockCommit(
+      inScopeFiles,
+      [
+        `Tier-1 trace ${traceName} does not declare an ELI16 overview (trace.eli16Path is missing).`,
+        '',
+        'A Tier-1 commit still requires a plain-English ELI16 overview of the',
+        'change. Write it, stage it, and set "eli16Path": "<relative-path>" in the trace.',
+      ].join('\n'),
+    );
+  }
+  const eli16Abs = path.resolve(ROOT, eli16Rel);
+  if (!fs.existsSync(eli16Abs)) {
+    blockCommit(
+      inScopeFiles,
+      `Tier-1 ELI16 overview ${eli16Rel} (trace.eli16Path) does not exist.`,
+    );
+  }
+  if (!staged.includes(eli16Rel)) {
+    blockCommit(
+      inScopeFiles,
+      [
+        `Tier-1 ELI16 overview ${eli16Rel} is not staged for commit.`,
+        'It must ship alongside the change.',
+      ].join('\n'),
+    );
+  }
+  const eli16Content = fs.readFileSync(eli16Abs, 'utf8');
+  if (eli16Content.trim().length < MIN_ELI16_CHARS) {
+    blockCommit(
+      inScopeFiles,
+      [
+        `Tier-1 ELI16 overview ${eli16Rel} is too short`,
+        `(${eli16Content.trim().length} chars, need ${MIN_ELI16_CHARS}).`,
+        '',
+        "A stub isn't an overview — write a real one.",
+        'See skills/instar-dev/templates/eli16-overview.md for the expected shape.',
+      ].join('\n'),
+    );
+  }
+
+  // ── Side-effects artifact ──
+  const sideEffectsRel = trace.sideEffectsPath;
+  if (!sideEffectsRel) {
+    blockCommit(
+      inScopeFiles,
+      [
+        `Tier-1 trace ${traceName} does not declare a side-effects artifact (trace.sideEffectsPath is missing).`,
+        '',
+        'A Tier-1 commit still requires a side-effects review artifact. Write it,',
+        'stage it, and set "sideEffectsPath": "<relative-path>" in the trace.',
+      ].join('\n'),
+    );
+  }
+  const sideEffectsAbs = path.resolve(ROOT, sideEffectsRel);
+  if (!fs.existsSync(sideEffectsAbs)) {
+    blockCommit(
+      inScopeFiles,
+      `Tier-1 side-effects artifact ${sideEffectsRel} (trace.sideEffectsPath) does not exist.`,
+    );
+  }
+  if (!staged.includes(sideEffectsRel)) {
+    blockCommit(
+      inScopeFiles,
+      [
+        `Tier-1 side-effects artifact ${sideEffectsRel} is not staged for commit.`,
+        'It must ship alongside the change.',
+      ].join('\n'),
+    );
+  }
+  const sideEffectsContent = fs.readFileSync(sideEffectsAbs, 'utf8');
+  if (sideEffectsContent.trim().length < MIN_ARTIFACT_CHARS) {
+    blockCommit(
+      inScopeFiles,
+      `Tier-1 side-effects artifact ${sideEffectsRel} is too short ` +
+        `(${sideEffectsContent.trim().length} chars, need ${MIN_ARTIFACT_CHARS}).`,
+    );
+  }
+  // sha-match exactly as the existing artifact logic, when a sha is recorded.
+  if (trace.artifactSha256) {
+    const sha = crypto.createHash('sha256').update(sideEffectsContent).digest('hex');
+    if (trace.artifactSha256 !== sha) {
+      blockCommit(
+        inScopeFiles,
+        [
+          `Tier-1 side-effects artifact ${sideEffectsRel} sha mismatch —`,
+          `trace records ${String(trace.artifactSha256).slice(0, 12)}… but the staged bytes hash to ${sha.slice(0, 12)}….`,
+          `If the current artifact is correct, set "artifactSha256": "${sha}" in the trace,`,
+          're-stage BOTH the artifact and the trace, and commit fresh (do NOT amend).',
+        ].join('\n'),
+      );
+    }
+  }
+
+  console.error(
+    `[instar-dev-precommit] OK (Tier 1) — trace ${traceName} covers ${inScopeFiles.length} in-scope file(s), ` +
+      `ELI16 ${eli16Rel} (${eli16Content.trim().length} chars) + side-effects ${sideEffectsRel} staged & verified. ` +
+      `No converged spec required for Tier 1.`,
+  );
+  process.exit(0);
 }

--- a/scripts/lib/classify-tier.mjs
+++ b/scripts/lib/classify-tier.mjs
@@ -1,0 +1,191 @@
+/**
+ * classify-tier.mjs — pure tier classifier for the instar-dev commit gate.
+ *
+ * Step A of the Tiered Development Process
+ * (docs/specs/tier-classifier-and-tier1-path-spec.md).
+ *
+ * Computes a TIER SIGNAL from a staged change. This is signal only — the gate
+ * SURFACES the suggestion, but the agent (the mind) DECLARES the actual tier in
+ * its trace. This module never decides the tier for the agent and never blocks.
+ *
+ * `classifyTier({ inScopeFiles, addedLines, deletedLines, addedDiffText })`
+ *   → { suggestedTier, sizeTier, riskFloor, reasons }
+ *
+ *   - sizeTier: 1 when (addedLines + deletedLines) <= SIZE_LOC AND
+ *     inScopeFiles.length <= SIZE_FILES, else 2.
+ *   - riskFloor: starts at 1, RAISED to >= 2 by any safety-invariant proximity,
+ *     irreversibility, migration/fleet-rollout, or new-capability signal (each
+ *     pushes a reason).
+ *   - suggestedTier = max(sizeTier, riskFloor). NEVER 3 — Tier 3 is declared
+ *     (an approved project step), not auto-suggested.
+ */
+
+// ─── Tunable size thresholds ─────────────────────────────────────────────
+export const SIZE_LOC = 40;
+export const SIZE_FILES = 3;
+
+// ─── Risk signal: safety-invariant proximity (path-based) ────────────────
+// An in-scope path matching any of these raises the risk floor to >= 2.
+const SAFETY_INVARIANT_PATTERNS = [
+  { regex: /secret/i, label: 'SecretDrop / never-on-disk invariant' },
+  { regex: /relay/i, label: 'relay / delivery path' },
+  { regex: /Telegram.*Adapter/, label: 'Telegram adapter' },
+  { regex: /\bauth\b/i, label: 'auth path' },
+  { regex: /token/i, label: 'token handling' },
+  { regex: /SafeFsExecutor/, label: 'SafeFsExecutor (destructive-fs funnel)' },
+  { regex: /SafeGitExecutor/, label: 'SafeGitExecutor (destructive-git funnel)' },
+  { regex: /SourceTreeGuard/, label: 'SourceTreeGuard (source-tree mutation guard)' },
+  { regex: /Reaper/, label: 'session reaper' },
+  { regex: /session.*lifecycle/i, label: 'session lifecycle' },
+];
+
+// ─── Risk signal: irreversibility (path-based) ───────────────────────────
+const IRREVERSIBILITY_PATTERNS = [
+  { regex: /migration/i, label: 'migration' },
+  { regex: /schema/i, label: 'data-format / schema' },
+  { regex: /PostUpdateMigrator/, label: 'PostUpdateMigrator' },
+];
+
+// ─── Risk signal: migration / fleet-rollout surface (path-based) ─────────
+// A change here touches the machinery that rolls out to EVERY deployed agent
+// (the migration family) or the fleet release/publish path. This is where the
+// zombie-cleanup, lifeline-skew, and "one malformed NEXT.md jams all releases"
+// (#42) regressions lived — a one-line change here is never Tier-1. Distinct
+// reason string from irreversibility even though `PostUpdateMigrator` /
+// `migrate*` overlap, because the fleet-rollout blast radius is the concern.
+const FLEET_ROLLOUT_PATTERNS = [
+  { regex: /PostUpdateMigrator/, label: 'PostUpdateMigrator (fleet migration machinery)' },
+  { regex: /migrate/i, label: 'migrate*() migration family' },
+  { regex: /http-hook-templates/, label: 'http-hook-templates (settings/hook migration source)' },
+  { regex: /NEXT\.md/, label: 'upgrades/NEXT.md (fleet release manifest)' },
+  // Release / publish scripts under scripts/ — the fleet publish path.
+  { regex: /^scripts\/.*release/i, label: 'release script (fleet publish path)' },
+  { regex: /^scripts\/.*publish/i, label: 'publish script (fleet publish path)' },
+];
+
+// ─── Risk signal: new capability (diff-text-based, only when provided) ───
+// Net-new added lines (the diff text passed in should be ADDED lines only;
+// the caller is responsible for that). Each heuristic emits a reason.
+const NEW_CAPABILITY_PATTERNS = [
+  {
+    // A new route registration: router.get( / router.post( / app.use( etc.
+    regex: /\brouter\.(get|post|put|patch|delete|use|all|options|head)\s*\(/,
+    label: 'new route (router.<verb>()',
+  },
+  {
+    regex: /\bexport\s+class\s+/,
+    label: 'new exported class / subsystem',
+  },
+  {
+    // A new config key — a quoted key followed by a colon, or an object-literal
+    // identifier key, that reads like a config surface addition. Conservative:
+    // require it to look like a JSON/TS config entry.
+    regex: /^[+]?\s*["']?[A-Za-z_][A-Za-z0-9_]*["']?\s*:\s*.+,?\s*$/m,
+    label: 'new config key',
+    // The generic key pattern is noisy on its own — gate it behind a hint that
+    // the diff is actually touching a config surface. See evaluation below.
+    requiresConfigHint: true,
+  },
+];
+
+// Heuristic hint that the added diff is touching a config SURFACE (not just any
+// object literal). Without this guard the bare `key: value` pattern fires on
+// almost every TS change. We only treat a `key: value` addition as a new config
+// key when the diff also mentions a recognizable config anchor.
+const CONFIG_SURFACE_HINT = /(ConfigDefaults|config\.json|defaultConfig|InstarConfig|\.config\b|configSchema)/;
+
+/**
+ * @param {object} input
+ * @param {string[]} input.inScopeFiles    Staged in-scope file paths.
+ * @param {number}   input.addedLines      Total added lines across inScopeFiles.
+ * @param {number}   input.deletedLines    Total deleted lines across inScopeFiles.
+ * @param {string} [input.addedDiffText]   Concatenated ADDED-line diff text. When
+ *                                          absent, the new-capability check is SKIPPED
+ *                                          (we never guess without the diff).
+ * @returns {{ suggestedTier: 1|2, sizeTier: 1|2, riskFloor: 1|2, reasons: string[] }}
+ */
+export function classifyTier({ inScopeFiles, addedLines, deletedLines, addedDiffText } = {}) {
+  const files = Array.isArray(inScopeFiles) ? inScopeFiles : [];
+  const added = Number.isFinite(addedLines) ? addedLines : 0;
+  const deleted = Number.isFinite(deletedLines) ? deletedLines : 0;
+
+  const reasons = [];
+
+  // ── Size tier ──
+  const totalLoc = added + deleted;
+  const sizeTier = totalLoc <= SIZE_LOC && files.length <= SIZE_FILES ? 1 : 2;
+
+  // ── Risk floor ──
+  let riskFloor = 1;
+  const raise = (reason) => {
+    riskFloor = Math.max(riskFloor, 2);
+    reasons.push(reason);
+  };
+
+  // (a) safety-invariant proximity — path-based
+  for (const file of files) {
+    for (const { regex, label } of SAFETY_INVARIANT_PATTERNS) {
+      if (regex.test(file)) {
+        raise(`safety-invariant proximity: ${file} matches ${label}`);
+      }
+    }
+  }
+
+  // (b) irreversibility — path-based
+  for (const file of files) {
+    for (const { regex, label } of IRREVERSIBILITY_PATTERNS) {
+      if (regex.test(file)) {
+        raise(`irreversibility: ${file} touches ${label}`);
+      }
+    }
+  }
+
+  // (b2) migration / fleet-rollout surface — path-based
+  for (const file of files) {
+    for (const { regex, label } of FLEET_ROLLOUT_PATTERNS) {
+      if (regex.test(file)) {
+        raise(`migration / fleet-rollout surface: ${file} touches ${label}`);
+      }
+    }
+  }
+
+  // (c) new capability — diff-text-based, only when addedDiffText is provided.
+  // If absent, SKIP entirely (don't guess).
+  if (typeof addedDiffText === 'string' && addedDiffText.length > 0) {
+    for (const { regex, label, requiresConfigHint } of NEW_CAPABILITY_PATTERNS) {
+      if (requiresConfigHint && !CONFIG_SURFACE_HINT.test(addedDiffText)) {
+        continue;
+      }
+      if (regex.test(addedDiffText)) {
+        raise(`new capability: ${label} added`);
+      }
+    }
+  }
+
+  // ── Suggested tier ── NEVER 3.
+  const suggestedTier = Math.max(sizeTier, riskFloor);
+
+  return { suggestedTier, sizeTier, riskFloor, reasons };
+}
+
+/**
+ * decideRequirementSet(declaredTier) — pure helper factoring the gate's
+ * tier-enforcement DECISION so it is unit-testable without git/fs mocking.
+ *
+ * Given the agent's DECLARED tier (from the trace; `null`/`undefined` when no
+ * trace or no `tier` field), return WHICH requirement set the gate enforces.
+ *
+ *   - null/undefined (or any non-1/2/3 value) → 'tier2-full' (back-compat default)
+ *   - 1 → 'tier1-lite'
+ *   - 2 or 3 → 'tier2-full' (a Tier-3 project step is just a Tier-2 spec)
+ *
+ * @param {number|null|undefined} declaredTier
+ * @returns {{ requirementSet: 'tier1-lite'|'tier2-full', resolvedTier: 1|2 }}
+ */
+export function decideRequirementSet(declaredTier) {
+  if (declaredTier === 1) {
+    return { requirementSet: 'tier1-lite', resolvedTier: 1 };
+  }
+  // 2, 3, missing, or anything else → the existing full Tier-2 requirement set.
+  return { requirementSet: 'tier2-full', resolvedTier: 2 };
+}

--- a/skills/instar-dev/scripts/write-trace.mjs
+++ b/skills/instar-dev/scripts/write-trace.mjs
@@ -11,6 +11,10 @@
  *     --artifact upgrades/side-effects/<slug>.md \
  *     --files "src/a.ts,src/b.ts,tests/x.test.ts" \
  *     [--spec docs/specs/<slug>.md] \
+ *     [--tier 1|2|3] \
+ *     [--tier-reasoning "<one or two sentences>"] \
+ *     [--eli16-path docs/specs/<slug>.eli16.md] \
+ *     [--side-effects-path upgrades/side-effects/<slug>.md] \
  *     [--second-pass true|false|not-required] \
  *     [--reviewer-concurred true|false]
  *
@@ -19,6 +23,17 @@
  * review-convergence and approved tags before allowing the commit.
  * Bootstrap commits (installing /instar-dev itself or /spec-converge itself)
  * may omit --spec; all other commits REQUIRE it.
+ *
+ * Tier declaration (Step A of the Tiered Development Process,
+ * docs/specs/tier-classifier-and-tier1-path-spec.md): the agent DECLARES the
+ * change's tier so the gate can enforce the chosen tier's requirement set.
+ *   - --tier 1 → a Tier-1 (small / low-risk) change. The trace carries
+ *     `tier: 1` + `eli16Path` + `sideEffectsPath` and NO `specPath` — a Tier-1
+ *     commit needs an ELI16 + side-effects artifact + green tests/lint, but no
+ *     pre-approved converged spec. `--spec` is therefore OPTIONAL when --tier 1.
+ *   - --tier 2|3 (or omitted) → the existing full requirement set; `--spec`
+ *     (a converged + approved spec) is required exactly as before.
+ * No tier declaration → the gate defaults to Tier 2 (back-compatible).
  *
  * The trace is written to .instar/instar-dev-traces/<timestamp>-<slug>.json.
  * Trace files are gitignored (runtime state, not source).
@@ -38,6 +53,10 @@ function parseArgs() {
   const args = process.argv.slice(2);
   const out = {
     artifact: null, files: [], spec: null, secondPass: 'not-required', reviewerConcurred: null,
+    // Tier declaration (Step A — Tiered Development Process). All OPTIONAL; when
+    // omitted the gate defaults to Tier 2 (back-compatible). For --tier 1 the
+    // trace carries tier + eli16Path + sideEffectsPath and no specPath.
+    tier: null, tierReasoning: null, eli16Path: null, sideEffectsPath: null,
     // v3 toolchain enrichment (Failure-Learning Loop §4.1) — all OPTIONAL, caller-passed
     // literals (O(1), no discovery/git/parse at commit time). Omitted fields → omitted
     // from the toolchain block; a gather failure → omit, never block the commit.
@@ -48,6 +67,10 @@ function parseArgs() {
     if (a === '--artifact') out.artifact = args[++i];
     else if (a === '--files') out.files = args[++i].split(',').map((s) => s.trim()).filter(Boolean);
     else if (a === '--spec') out.spec = args[++i];
+    else if (a === '--tier') out.tier = parseInt(args[++i], 10);
+    else if (a === '--tier-reasoning') out.tierReasoning = args[++i];
+    else if (a === '--eli16-path') out.eli16Path = args[++i];
+    else if (a === '--side-effects-path') out.sideEffectsPath = args[++i];
     else if (a === '--second-pass') out.secondPass = args[++i];
     else if (a === '--reviewer-concurred') out.reviewerConcurred = args[++i] === 'true';
     else if (a === '--build-skill') out.buildSkill = args[++i];
@@ -67,10 +90,27 @@ function parseArgs() {
     console.error('Missing --files');
     process.exit(1);
   }
+  if (out.tier != null && ![1, 2, 3].includes(out.tier)) {
+    console.error(`Invalid --tier ${out.tier}: must be 1, 2, or 3`);
+    process.exit(1);
+  }
+  // A Tier-1 trace must carry its own ELI16 + side-effects path (no converged
+  // spec). The side-effects path defaults to the --artifact (the sha is computed
+  // from that same file), but the ELI16 path is required and has no default.
+  if (out.tier === 1) {
+    if (!out.sideEffectsPath) out.sideEffectsPath = out.artifact;
+    if (!out.eli16Path) {
+      console.error('A Tier-1 trace requires --eli16-path (the request ELI16 overview).');
+      process.exit(1);
+    }
+  }
   return out;
 }
 
-const { artifact, files, spec, secondPass, reviewerConcurred, buildSkill, reviewSkills, convergenceReport, convergenceIterations } = parseArgs();
+const {
+  artifact, files, spec, tier, tierReasoning, eli16Path, sideEffectsPath,
+  secondPass, reviewerConcurred, buildSkill, reviewSkills, convergenceReport, convergenceIterations,
+} = parseArgs();
 
 /**
  * Build the v3 `toolchain` block (Failure-Learning Loop §4.1). Toolchain fields
@@ -136,15 +176,23 @@ fs.mkdirSync(traceDir, { recursive: true });
 
 const traceFile = path.join(traceDir, `${timestamp.replace(/[:.]/g, '-')}-${slug}-${traceId}.json`);
 const toolchain = buildToolchain();
+const isTier1 = tier === 1;
 const trace = {
   version: toolchain ? 3 : 2, // v3 only when enriched; readers ignore unknown fields either way
   sessionId: process.env.INSTAR_SESSION_ID || process.env.CLAUDE_CODE_SESSION_ID || 'unknown',
   timestamp,
   artifactPath: artifact,
   artifactSha256: crypto.createHash('sha256').update(artifactContent).digest('hex'),
-  specPath: spec,
+  // A Tier-1 trace carries NO specPath (it ships an ELI16 + side-effects instead
+  // of a converged + approved spec). Tier 2+/no-tier keep the existing specPath.
+  ...(isTier1 ? {} : { specPath: spec }),
   coveredFiles: files.sort(),
   phase: 'complete',
+  // Tier declaration (Step A). Emitted only when the agent declared a tier so an
+  // undeclared trace round-trips byte-identically to the pre-Step-A shape.
+  ...(tier != null ? { tier } : {}),
+  ...(tierReasoning != null ? { tierReasoning } : {}),
+  ...(isTier1 ? { eli16Path, sideEffectsPath } : {}),
   secondPass,
   reviewerConcurred,
   ...(toolchain ? { toolchain } : {}),

--- a/tests/unit/classify-tier.test.ts
+++ b/tests/unit/classify-tier.test.ts
@@ -1,0 +1,357 @@
+// Unit tests for the pure tier classifier used by /instar-dev's pre-commit
+// gate (scripts/lib/classify-tier.mjs). The classifier computes a TIER SIGNAL
+// from a staged change — size → base tier, risk floor → may only raise — and
+// surfaces a suggestion. It never decides for the agent and never returns 3.
+//
+// Also tests decideRequirementSet(): the pure helper that factors the gate's
+// tier-enforcement DECISION (which requirement set to apply) so it is testable
+// without git/fs mocking.
+
+import { describe, it, expect } from 'vitest';
+// @ts-expect-error: .mjs script, not typed
+import {
+  classifyTier,
+  decideRequirementSet,
+  SIZE_LOC,
+  SIZE_FILES,
+} from '../../scripts/lib/classify-tier.mjs';
+
+describe('classifyTier — exported constants', () => {
+  it('exports SIZE_LOC = 40 and SIZE_FILES = 3', () => {
+    expect(SIZE_LOC).toBe(40);
+    expect(SIZE_FILES).toBe(3);
+  });
+});
+
+describe('classifyTier — size tier boundaries', () => {
+  it('exactly 40 LOC across exactly 3 files → Tier 1', () => {
+    const r = classifyTier({
+      inScopeFiles: ['src/a.ts', 'src/b.ts', 'src/c.ts'],
+      addedLines: 30,
+      deletedLines: 10, // 40 total, == SIZE_LOC
+    });
+    expect(r.sizeTier).toBe(1);
+    expect(r.suggestedTier).toBe(1);
+    expect(r.riskFloor).toBe(1);
+  });
+
+  it('41 LOC → Tier 2 (over SIZE_LOC)', () => {
+    const r = classifyTier({
+      inScopeFiles: ['src/a.ts'],
+      addedLines: 41,
+      deletedLines: 0,
+    });
+    expect(r.sizeTier).toBe(2);
+    expect(r.suggestedTier).toBe(2);
+  });
+
+  it('40 LOC but 4 files → Tier 2 (over SIZE_FILES)', () => {
+    const r = classifyTier({
+      inScopeFiles: ['src/a.ts', 'src/b.ts', 'src/c.ts', 'src/d.ts'],
+      addedLines: 40,
+      deletedLines: 0,
+    });
+    expect(r.sizeTier).toBe(2);
+    expect(r.suggestedTier).toBe(2);
+  });
+
+  it('counts BOTH added and deleted lines toward the size budget', () => {
+    // 21 added + 20 deleted = 41 > 40 → Tier 2
+    const r = classifyTier({
+      inScopeFiles: ['src/a.ts'],
+      addedLines: 21,
+      deletedLines: 20,
+    });
+    expect(r.sizeTier).toBe(2);
+  });
+
+  it('zero-LOC, single-file change → Tier 1', () => {
+    const r = classifyTier({
+      inScopeFiles: ['src/a.ts'],
+      addedLines: 0,
+      deletedLines: 0,
+    });
+    expect(r.sizeTier).toBe(1);
+    expect(r.suggestedTier).toBe(1);
+  });
+});
+
+describe('classifyTier — risk floor: safety-invariant proximity', () => {
+  it('a 1-line change to a path containing "secret" → suggested Tier 2 with a reason', () => {
+    const r = classifyTier({
+      inScopeFiles: ['src/messaging/SecretDropManager.ts'],
+      addedLines: 1,
+      deletedLines: 0,
+    });
+    expect(r.sizeTier).toBe(1); // size alone would be Tier 1
+    expect(r.riskFloor).toBe(2); // risk floor raised it
+    expect(r.suggestedTier).toBe(2);
+    expect(r.reasons.length).toBeGreaterThan(0);
+    expect(r.reasons.join(' ')).toMatch(/secret/i);
+  });
+
+  it.each([
+    ['src/messaging/TelegramAdapter.ts', /telegram adapter/i],
+    ['src/monitoring/DeliveryRelay.ts', /relay/i],
+    ['src/auth/middleware.ts', /auth/i],
+    ['src/core/TokenLedger.ts', /token/i],
+    ['src/core/SafeFsExecutor.ts', /SafeFsExecutor/],
+    ['src/core/SafeGitExecutor.ts', /SafeGitExecutor/],
+    ['src/core/SourceTreeGuard.ts', /SourceTreeGuard/],
+    ['src/monitoring/SessionReaper.ts', /reaper/i],
+    ['src/core/session-lifecycle.ts', /lifecycle/i],
+  ])('path %s raises the risk floor', (file, reasonRe) => {
+    const r = classifyTier({ inScopeFiles: [file], addedLines: 1, deletedLines: 0 });
+    expect(r.riskFloor).toBe(2);
+    expect(r.suggestedTier).toBe(2);
+    expect(r.reasons.join(' ')).toMatch(reasonRe);
+  });
+});
+
+describe('classifyTier — risk floor: irreversibility', () => {
+  it.each([
+    ['src/core/migrations/0001-init.ts', /migration/i],
+    ['src/db/schema.ts', /schema/i],
+    ['src/core/PostUpdateMigrator.ts', /PostUpdateMigrator/],
+  ])('path %s raises the risk floor for irreversibility', (file, reasonRe) => {
+    const r = classifyTier({ inScopeFiles: [file], addedLines: 1, deletedLines: 0 });
+    expect(r.riskFloor).toBe(2);
+    expect(r.suggestedTier).toBe(2);
+    expect(r.reasons.join(' ')).toMatch(reasonRe);
+  });
+});
+
+describe('classifyTier — risk floor: migration / fleet-rollout surface', () => {
+  it.each([
+    // A 1-line change to http-hook-templates → suggested Tier 2 with a
+    // fleet-rollout reason (the convergence-required fixture).
+    ['src/data/http-hook-templates.ts', /fleet-rollout/i],
+    // A 1-line change to NEXT.md → suggested Tier 2 with a fleet-rollout reason.
+    ['upgrades/NEXT.md', /fleet-rollout/i],
+    ['src/core/PostUpdateMigrator.ts', /fleet-rollout/i],
+    ['src/core/migrateSettings.ts', /fleet-rollout/i],
+    ['scripts/release-publish.mjs', /fleet-rollout/i],
+    ['scripts/publish-fleet.js', /fleet-rollout/i],
+  ])('path %s raises the risk floor for fleet-rollout', (file, reasonRe) => {
+    const r = classifyTier({ inScopeFiles: [file], addedLines: 1, deletedLines: 0 });
+    expect(r.sizeTier).toBe(1); // size alone would be Tier 1
+    expect(r.riskFloor).toBe(2); // fleet-rollout raised it
+    expect(r.suggestedTier).toBe(2);
+    expect(r.reasons.join(' ')).toMatch(reasonRe);
+  });
+
+  it('a 1-line http-hook-templates change carries the DISTINCT fleet-rollout reason string', () => {
+    const r = classifyTier({
+      inScopeFiles: ['src/data/http-hook-templates.ts'],
+      addedLines: 1,
+      deletedLines: 0,
+    });
+    expect(r.suggestedTier).toBe(2);
+    expect(r.reasons.some((reason: string) => /migration \/ fleet-rollout surface/.test(reason))).toBe(true);
+  });
+
+  it('a 1-line upgrades/NEXT.md change → suggested Tier 2 (fleet release manifest)', () => {
+    const r = classifyTier({
+      inScopeFiles: ['upgrades/NEXT.md'],
+      addedLines: 1,
+      deletedLines: 0,
+    });
+    expect(r.suggestedTier).toBe(2);
+    expect(r.reasons.join(' ')).toMatch(/NEXT\.md/);
+  });
+
+  it('a release/publish script NOT under scripts/ does NOT trip the fleet-rollout signal alone', () => {
+    // The release/publish heuristic is anchored to scripts/ — a docs file that
+    // happens to contain "release" in its path must not raise the floor.
+    const r = classifyTier({
+      inScopeFiles: ['src/core/util.ts'],
+      addedLines: 1,
+      deletedLines: 0,
+      addedDiffText: '// mentions release and publish in a comment',
+    });
+    expect(r.riskFloor).toBe(1);
+    expect(r.suggestedTier).toBe(1);
+  });
+});
+
+describe('classifyTier — risk floor: new capability (diff-text based)', () => {
+  it('detects a net-new route (router.<verb>()) when addedDiffText is given', () => {
+    const r = classifyTier({
+      inScopeFiles: ['src/server/routes.ts'],
+      addedLines: 3,
+      deletedLines: 0,
+      addedDiffText: "router.post('/widgets', widgetHandler);",
+    });
+    expect(r.riskFloor).toBe(2);
+    expect(r.suggestedTier).toBe(2);
+    expect(r.reasons.join(' ')).toMatch(/route/i);
+  });
+
+  it('detects a net-new exported class', () => {
+    const r = classifyTier({
+      inScopeFiles: ['src/core/Thing.ts'],
+      addedLines: 5,
+      deletedLines: 0,
+      addedDiffText: 'export class WidgetEngine {\n  run() {}\n}',
+    });
+    expect(r.riskFloor).toBe(2);
+    expect(r.reasons.join(' ')).toMatch(/class/i);
+  });
+
+  it('detects a new config key when the diff touches a config surface', () => {
+    const r = classifyTier({
+      inScopeFiles: ['src/config/ConfigDefaults.ts'],
+      addedLines: 2,
+      deletedLines: 0,
+      addedDiffText: 'export const ConfigDefaults = {\n  newWidgetTimeout: 5000,\n};',
+    });
+    expect(r.riskFloor).toBe(2);
+    expect(r.reasons.join(' ')).toMatch(/config key/i);
+  });
+
+  it('does NOT fire new-capability on a plain key:value with no config-surface hint', () => {
+    const r = classifyTier({
+      inScopeFiles: ['src/core/util.ts'],
+      addedLines: 2,
+      deletedLines: 0,
+      addedDiffText: 'const opts = {\n  retries: 3,\n};',
+    });
+    // No router/class, and key:value gated behind config-surface hint → no raise
+    expect(r.riskFloor).toBe(1);
+    expect(r.suggestedTier).toBe(1);
+  });
+
+  it('SKIPS the new-capability check entirely when addedDiffText is absent', () => {
+    // The diff would have contained `export class` but we did not pass it →
+    // the classifier must NOT guess. Only size governs.
+    const r = classifyTier({
+      inScopeFiles: ['src/core/Thing.ts'],
+      addedLines: 5,
+      deletedLines: 0,
+      // addedDiffText omitted
+    });
+    expect(r.riskFloor).toBe(1);
+    expect(r.suggestedTier).toBe(1);
+    expect(r.reasons).toEqual([]);
+  });
+});
+
+describe('classifyTier — max(size, risk) and never-3', () => {
+  it('suggestedTier = max(sizeTier, riskFloor): big change on a benign path → Tier 2 from size', () => {
+    const r = classifyTier({
+      inScopeFiles: ['src/core/util.ts'],
+      addedLines: 100,
+      deletedLines: 0,
+    });
+    expect(r.sizeTier).toBe(2);
+    expect(r.riskFloor).toBe(1);
+    expect(r.suggestedTier).toBe(2);
+  });
+
+  it('suggestedTier = max: small change on a risky path → Tier 2 from risk', () => {
+    const r = classifyTier({
+      inScopeFiles: ['src/messaging/SecretDropManager.ts'],
+      addedLines: 2,
+      deletedLines: 0,
+    });
+    expect(r.sizeTier).toBe(1);
+    expect(r.riskFloor).toBe(2);
+    expect(r.suggestedTier).toBe(2);
+  });
+
+  it('NEVER returns 3 even with size + every risk signal stacked', () => {
+    const r = classifyTier({
+      inScopeFiles: [
+        'src/messaging/SecretDropManager.ts',
+        'src/core/PostUpdateMigrator.ts',
+        'src/db/schema.ts',
+        'src/auth/token.ts',
+      ],
+      addedLines: 500,
+      deletedLines: 500,
+      addedDiffText: "export class X {}\nrouter.get('/y', h);",
+    });
+    expect(r.suggestedTier).toBe(2);
+    expect(r.suggestedTier).not.toBe(3);
+    expect(r.reasons.length).toBeGreaterThan(1);
+  });
+});
+
+describe('classifyTier — defensive defaults', () => {
+  it('tolerates empty / missing input without throwing', () => {
+    const r = classifyTier({});
+    expect(r.sizeTier).toBe(1); // 0 LOC, 0 files
+    expect(r.riskFloor).toBe(1);
+    expect(r.suggestedTier).toBe(1);
+  });
+
+  it('tolerates no argument at all', () => {
+    const r = classifyTier();
+    expect(r.suggestedTier).toBe(1);
+  });
+});
+
+describe('decideRequirementSet — the gate enforcement decision', () => {
+  it('tier 1 → tier1-lite requirement set', () => {
+    expect(decideRequirementSet(1)).toEqual({ requirementSet: 'tier1-lite', resolvedTier: 1 });
+  });
+
+  it('tier 2 → tier2-full requirement set', () => {
+    expect(decideRequirementSet(2)).toEqual({ requirementSet: 'tier2-full', resolvedTier: 2 });
+  });
+
+  it('tier 3 (project step) → tier2-full (a Tier-3 step is just a Tier-2 spec)', () => {
+    expect(decideRequirementSet(3)).toEqual({ requirementSet: 'tier2-full', resolvedTier: 2 });
+  });
+
+  it('no tier (null) → tier2-full (back-compat default)', () => {
+    expect(decideRequirementSet(null)).toEqual({ requirementSet: 'tier2-full', resolvedTier: 2 });
+  });
+
+  it('no tier (undefined) → tier2-full (back-compat default)', () => {
+    expect(decideRequirementSet(undefined)).toEqual({ requirementSet: 'tier2-full', resolvedTier: 2 });
+  });
+
+  it('any unexpected value → tier2-full (conservative default)', () => {
+    expect(decideRequirementSet(99 as unknown as number)).toEqual({
+      requirementSet: 'tier2-full',
+      resolvedTier: 2,
+    });
+  });
+});
+
+describe('belowFloor detection (the audit decision, computed from classifier output)', () => {
+  // belowFloor = declaredTier != null && declaredTier < riskFloor. We test the
+  // pure comparison against classifier output so the gate's audit logic is
+  // covered without git/fs.
+  const belowFloor = (declaredTier: number | null, riskFloor: number) =>
+    declaredTier != null && declaredTier < riskFloor;
+
+  it('declared Tier 1 under a risk floor of 2 → belowFloor true', () => {
+    const r = classifyTier({
+      inScopeFiles: ['src/messaging/SecretDropManager.ts'],
+      addedLines: 1,
+      deletedLines: 0,
+    });
+    expect(r.riskFloor).toBe(2);
+    expect(belowFloor(1, r.riskFloor)).toBe(true);
+  });
+
+  it('declared Tier 2 at a risk floor of 2 → belowFloor false', () => {
+    const r = classifyTier({
+      inScopeFiles: ['src/messaging/SecretDropManager.ts'],
+      addedLines: 1,
+      deletedLines: 0,
+    });
+    expect(belowFloor(2, r.riskFloor)).toBe(false);
+  });
+
+  it('no declared tier → belowFloor false (never flagged when undeclared)', () => {
+    const r = classifyTier({
+      inScopeFiles: ['src/messaging/SecretDropManager.ts'],
+      addedLines: 1,
+      deletedLines: 0,
+    });
+    expect(belowFloor(null, r.riskFloor)).toBe(false);
+  });
+});

--- a/tests/unit/instar-dev-precommit-deferrals.test.ts
+++ b/tests/unit/instar-dev-precommit-deferrals.test.ts
@@ -66,6 +66,7 @@ describe('instar-dev pre-commit — orphan deferrals enforcement', () => {
     fs.writeFileSync(
       path.join(sandbox, 'scripts', 'eli16-overview-check.mjs'),
       `import path from 'node:path';\n` +
+      `export const MIN_ELI16_CHARS = 800;\n` +
       `export function checkEli16Overview(specPath) {\n` +
       `  const eli16Path = path.join(path.dirname(specPath), path.basename(specPath, '.md') + '.eli16.md');\n` +
       `  return { ok: true, eli16Path, charCount: 9999, minChars: 1 };\n` +
@@ -76,7 +77,13 @@ describe('instar-dev pre-commit — orphan deferrals enforcement', () => {
       'export function verifyProposalDerivedRunbooks() { return { ok: true, reason: "no-proposal-derived-runbooks-or-all-verified" }; }\n',
     );
 
-    // Copy the hook script under test into the sandbox.
+    // Copy the hook script under test + its new pure tier classifier dependency
+    // (scripts/lib/classify-tier.mjs) into the sandbox.
+    fs.mkdirSync(path.join(sandbox, 'scripts', 'lib'), { recursive: true });
+    fs.copyFileSync(
+      path.join(path.dirname(HOOK_SCRIPT), 'lib', 'classify-tier.mjs'),
+      path.join(sandbox, 'scripts', 'lib', 'classify-tier.mjs'),
+    );
     fs.copyFileSync(HOOK_SCRIPT, path.join(sandbox, 'scripts', 'instar-dev-precommit.js'));
   });
 
@@ -138,6 +145,57 @@ describe('instar-dev pre-commit — orphan deferrals enforcement', () => {
     });
     const result = await runHook(process.env, sandbox);
     expect(result.status).toBe(0);
+  });
+
+  // ─── BACK-COMPAT REGRESSION GUARD (Step A — tier classifier) ──────────────
+  // The named guard required by the spec's Testing section: an EXISTING-SHAPE
+  // trace with NO `tier` field + an approved converged spec must pass EXACTLY
+  // as before the tier classifier landed. The stageFixture() trace above writes
+  // no `tier` field, so this is the canonical legacy shape; the gate must take
+  // the full Tier-2 path (decideRequirementSet(null) → 'tier2-full') and the
+  // additive Step-A change must NOT alter the outcome.
+  it('BACK-COMPAT: a no-tier trace + approved converged spec passes the full Tier-2 path exactly as before', async () => {
+    const { tracePath } = stageFixture({
+      specFrontmatter: 'title: Legacy spec\napproved: true\nreview-convergence: tactical\neli16-overview: fixture.eli16.md',
+      specBody: 'A normal, fully-in-scope change. No deferrals, no tier field.',
+    });
+    // Sanity-check the fixture really is the legacy shape (no tier declaration).
+    const trace = JSON.parse(fs.readFileSync(path.join(sandbox, tracePath), 'utf-8'));
+    expect(trace).not.toHaveProperty('tier');
+
+    const result = await runHook(process.env, sandbox);
+    expect(result.status).toBe(0);
+    // The pass message is the unchanged full-Tier-2 OK line (NOT the Tier-1 line).
+    expect(result.stderr).toMatch(/OK — trace/);
+    expect(result.stderr).not.toMatch(/OK \(Tier 1\)/);
+    // And the converged + approved spec was actually checked (proves the full path ran).
+    expect(result.stderr).toMatch(/converged \+ approved/);
+  });
+
+  // The audit JSON line must record riskFloor (the NUMBER), not just belowFloor,
+  // so the decision record is self-contained for later review (convergence
+  // Finding — audit field). The no-tier legacy fixture above touches only a
+  // benign src/touched.ts, so riskFloor is 1.
+  it('AUDIT: a commit appends one well-formed decisions.jsonl line including riskFloor (number)', async () => {
+    stageFixture({
+      specFrontmatter: 'title: Audit spec\napproved: true\nreview-convergence: tactical\neli16-overview: fixture.eli16.md',
+      specBody: 'A normal change for audit-line shape verification.',
+    });
+    const result = await runHook(process.env, sandbox);
+    expect(result.status).toBe(0);
+
+    const auditPath = path.join(sandbox, '.instar', 'instar-dev-decisions.jsonl');
+    expect(fs.existsSync(auditPath)).toBe(true);
+    const lines = fs.readFileSync(auditPath, 'utf-8').trim().split('\n').filter(Boolean);
+    expect(lines.length).toBe(1);
+    const entry = JSON.parse(lines[0]);
+    expect(entry).toHaveProperty('riskFloor');
+    expect(typeof entry.riskFloor).toBe('number');
+    expect(entry.riskFloor).toBe(1); // benign src/touched.ts → no risk signals
+    expect(entry).toHaveProperty('belowFloor');
+    expect(entry.belowFloor).toBe(false); // no declared tier → never below floor
+    expect(entry).toHaveProperty('suggestedTier');
+    expect(Array.isArray(entry.riskFloorReasons)).toBe(true);
   });
 
   it('blocks when spec contains orphan "out of scope today"', async () => {

--- a/tests/unit/instar-dev-precommit-sha-error.test.ts
+++ b/tests/unit/instar-dev-precommit-sha-error.test.ts
@@ -59,6 +59,7 @@ describe('instar-dev pre-commit — artifact sha-mismatch error message', () => 
     fs.writeFileSync(
       path.join(sandbox, 'scripts', 'eli16-overview-check.mjs'),
       `import path from 'node:path';\n` +
+      `export const MIN_ELI16_CHARS = 800;\n` +
       `export function checkEli16Overview(specPath) {\n` +
       `  const eli16Path = path.join(path.dirname(specPath), path.basename(specPath, '.md') + '.eli16.md');\n` +
       `  return { ok: true, eli16Path, charCount: 9999, minChars: 1 };\n` +
@@ -67,6 +68,12 @@ describe('instar-dev pre-commit — artifact sha-mismatch error message', () => 
     fs.writeFileSync(
       path.join(sandbox, 'skills', 'instar-dev', 'scripts', 'verify-proposal-derived-runbook.mjs'),
       'export function verifyProposalDerivedRunbooks() { return { ok: true, reason: "ok" }; }\n',
+    );
+    // Copy the hook + its new pure tier classifier dependency into the sandbox.
+    fs.mkdirSync(path.join(sandbox, 'scripts', 'lib'), { recursive: true });
+    fs.copyFileSync(
+      path.join(path.dirname(HOOK_SCRIPT), 'lib', 'classify-tier.mjs'),
+      path.join(sandbox, 'scripts', 'lib', 'classify-tier.mjs'),
     );
     fs.copyFileSync(HOOK_SCRIPT, path.join(sandbox, 'scripts', 'instar-dev-precommit.js'));
   });

--- a/tests/unit/write-trace-tier.test.ts
+++ b/tests/unit/write-trace-tier.test.ts
@@ -1,0 +1,174 @@
+// safe-fs-allow: test file — SafeFsExecutor used for tmpdir cleanup.
+
+/**
+ * Tests for the tier declaration added to
+ * skills/instar-dev/scripts/write-trace.mjs (Step A of the Tiered Development
+ * Process, docs/specs/tier-classifier-and-tier1-path-spec.md).
+ *
+ * The trace writer must:
+ *   - Round-trip a TIER-1 trace: `tier: 1` + `eli16Path` + `sideEffectsPath`,
+ *     and NO `specPath` (a Tier-1 commit ships an ELI16 + side-effects instead
+ *     of a converged + approved spec). `--spec` is OPTIONAL when `--tier 1`.
+ *   - Round-trip a TIER-2 trace UNCHANGED: `specPath` is present, no tier
+ *     declaration leaks into the legacy shape unless explicitly passed.
+ *
+ * The script derives its ROOT from its own location (import.meta.url → up three
+ * dirs), not from cwd. So we copy it into a sandbox at the same relative depth
+ * (skills/instar-dev/scripts/) and run the sandbox copy, exactly as the gate
+ * tests copy the hook into their sandbox.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+
+const REPO_ROOT = path.resolve(__dirname, '..', '..');
+const WRITE_TRACE = path.join(REPO_ROOT, 'skills', 'instar-dev', 'scripts', 'write-trace.mjs');
+
+interface RunResult { status: number | null; stdout: string; stderr: string; }
+
+describe('write-trace.mjs — tier declaration (Step A)', () => {
+  let sandbox: string;
+  let sandboxScript: string;
+
+  beforeEach(() => {
+    sandbox = fs.mkdtempSync(path.join(os.tmpdir(), 'write-trace-tier-'));
+    // Mirror the script's expected layout: skills/instar-dev/scripts/<script>.
+    fs.mkdirSync(path.join(sandbox, 'skills', 'instar-dev', 'scripts'), { recursive: true });
+    fs.mkdirSync(path.join(sandbox, 'upgrades', 'side-effects'), { recursive: true });
+    fs.mkdirSync(path.join(sandbox, 'docs', 'specs'), { recursive: true });
+    sandboxScript = path.join(sandbox, 'skills', 'instar-dev', 'scripts', 'write-trace.mjs');
+    fs.copyFileSync(WRITE_TRACE, sandboxScript);
+  });
+
+  afterEach(() => {
+    try {
+      SafeFsExecutor.safeRmSync(sandbox, { recursive: true, force: true, operation: 'tests/unit/write-trace-tier.test.ts:cleanup' });
+    } catch { /* ignore */ }
+  });
+
+  function run(args: string[]): RunResult {
+    const r = spawnSync('node', [sandboxScript, ...args], { cwd: sandbox, encoding: 'utf8' });
+    return { status: r.status, stdout: r.stdout || '', stderr: r.stderr || '' };
+  }
+
+  function writeArtifact(rel: string): string {
+    const abs = path.join(sandbox, rel);
+    fs.writeFileSync(abs, `# Side-effects review\n\n## Summary\n\n${'x'.repeat(400)}\n`);
+    return rel;
+  }
+
+  function readTrace(stdoutRel: string): any {
+    const traceRel = stdoutRel.trim();
+    return JSON.parse(fs.readFileSync(path.join(sandbox, traceRel), 'utf8'));
+  }
+
+  it('round-trips a TIER-1 trace: tier:1 + eli16Path + sideEffectsPath, NO specPath', () => {
+    const artifact = writeArtifact('upgrades/side-effects/widget.md');
+    const eli16 = 'docs/specs/widget.eli16.md';
+    fs.writeFileSync(path.join(sandbox, eli16), `# ELI16\n\n${'y'.repeat(400)}\n`);
+
+    const res = run([
+      '--artifact', artifact,
+      '--files', 'src/a.ts,src/b.ts',
+      '--tier', '1',
+      '--tier-reasoning', 'Small observability tweak, no risk signals.',
+      '--eli16-path', eli16,
+      '--side-effects-path', artifact,
+    ]);
+
+    expect(res.status).toBe(0);
+    const trace = readTrace(res.stdout);
+
+    expect(trace.tier).toBe(1);
+    expect(trace.tierReasoning).toBe('Small observability tweak, no risk signals.');
+    expect(trace.eli16Path).toBe(eli16);
+    expect(trace.sideEffectsPath).toBe(artifact);
+    // A Tier-1 trace carries NO specPath.
+    expect(trace).not.toHaveProperty('specPath');
+    // Existing fields still present + correct.
+    expect(trace.phase).toBe('complete');
+    expect(trace.artifactPath).toBe(artifact);
+    expect(trace.coveredFiles).toEqual(['src/a.ts', 'src/b.ts']);
+    expect(typeof trace.artifactSha256).toBe('string');
+  });
+
+  it('--side-effects-path defaults to --artifact when omitted on a Tier-1 trace', () => {
+    const artifact = writeArtifact('upgrades/side-effects/widget.md');
+    const eli16 = 'docs/specs/widget.eli16.md';
+    fs.writeFileSync(path.join(sandbox, eli16), `# ELI16\n\n${'y'.repeat(400)}\n`);
+
+    const res = run([
+      '--artifact', artifact,
+      '--files', 'src/a.ts',
+      '--tier', '1',
+      '--eli16-path', eli16,
+    ]);
+
+    expect(res.status).toBe(0);
+    const trace = readTrace(res.stdout);
+    expect(trace.tier).toBe(1);
+    expect(trace.sideEffectsPath).toBe(artifact);
+    expect(trace).not.toHaveProperty('specPath');
+  });
+
+  it('a Tier-1 trace WITHOUT --eli16-path is rejected (usage error)', () => {
+    const artifact = writeArtifact('upgrades/side-effects/widget.md');
+    const res = run([
+      '--artifact', artifact,
+      '--files', 'src/a.ts',
+      '--tier', '1',
+    ]);
+    expect(res.status).not.toBe(0);
+    expect(res.stderr).toMatch(/eli16-path/i);
+  });
+
+  it('round-trips a TIER-2 trace UNCHANGED: specPath present, no tier1 fields', () => {
+    const artifact = writeArtifact('upgrades/side-effects/widget.md');
+    const spec = 'docs/specs/widget.md';
+    fs.writeFileSync(path.join(sandbox, spec), `---\ntitle: Widget\napproved: true\nreview-convergence: tactical\n---\n\nbody\n`);
+
+    const res = run([
+      '--artifact', artifact,
+      '--files', 'src/a.ts,src/b.ts',
+      '--spec', spec,
+      '--tier', '2',
+      '--tier-reasoning', 'New subsystem — converged spec required.',
+    ]);
+
+    expect(res.status).toBe(0);
+    const trace = readTrace(res.stdout);
+
+    expect(trace.tier).toBe(2);
+    expect(trace.specPath).toBe(spec);
+    // Tier-1-only fields must NOT appear on a Tier-2 trace.
+    expect(trace).not.toHaveProperty('eli16Path');
+    expect(trace).not.toHaveProperty('sideEffectsPath');
+    expect(trace.phase).toBe('complete');
+  });
+
+  it('a NO-TIER trace round-trips to the legacy shape (specPath present, no tier field)', () => {
+    // Back-compat: an undeclared trace must look exactly as before Step A.
+    const artifact = writeArtifact('upgrades/side-effects/widget.md');
+    const spec = 'docs/specs/widget.md';
+    fs.writeFileSync(path.join(sandbox, spec), `---\ntitle: Widget\napproved: true\nreview-convergence: tactical\n---\n\nbody\n`);
+
+    const res = run([
+      '--artifact', artifact,
+      '--files', 'src/a.ts',
+      '--spec', spec,
+    ]);
+
+    expect(res.status).toBe(0);
+    const trace = readTrace(res.stdout);
+
+    expect(trace.specPath).toBe(spec);
+    expect(trace).not.toHaveProperty('tier');
+    expect(trace).not.toHaveProperty('tierReasoning');
+    expect(trace).not.toHaveProperty('eli16Path');
+    expect(trace).not.toHaveProperty('sideEffectsPath');
+  });
+});

--- a/upgrades/next/tier-classifier-and-tier1-path.md
+++ b/upgrades/next/tier-classifier-and-tier1-path.md
@@ -1,0 +1,36 @@
+# Upgrade Guide — vNEXT
+
+<!-- bump: patch -->
+
+## What Changed
+
+The instar-dev commit gate now computes a **tier signal** (size + risk) for each staged
+change and prints it, the developing agent **declares** the tier in its trace, and the
+gate enforces the **chosen** tier's requirement set — adding a lighter **Tier-1 path**
+(ELI16 + side-effects, no pre-approved converged spec) for small, low-risk changes. Every
+decision is recorded to `.instar/instar-dev-decisions.jsonl`. This is Step A of the
+tiered-development project and the first executable instance of the constitution's
+**The Body and the Mind**: the gate *informs*, the agent *decides*, the decision is
+*audited*.
+
+## What to Tell Your User
+
+Nothing to do — this only affects how the agent commits changes to instar itself. Small
+changes now move through a lighter lane (overview + side-effects note), bigger changes
+still get the full spec. The agent's tier choice and the gate's suggestion are logged.
+
+## Summary of New Capabilities
+
+- `scripts/lib/classify-tier.mjs` — pure tier classifier (size + risk → suggested tier).
+- `instar-dev-precommit.js` — prints the tier signal, routes by the declared tier, audits
+  the decision; Tier-1 path requires ELI16 + side-effects (no converged spec). No declared
+  tier → the existing Tier-2 requirement set, byte-for-byte (back-compat).
+- `write-trace.mjs` — `--tier`, `--tier-reasoning`, `--eli16-path`, `--side-effects-path`
+  flags; `--spec` optional when `--tier 1`.
+
+## Evidence
+
+- `npx tsc --noEmit` exit 0; Step-A unit tests green (classify-tier 47, write-trace-tier 5,
+  gate -deferrals/-sha-error 13/1), including a named no-tier back-compat regression and
+  the audit-line shape (with `riskFloor`).
+- This very commit dogfoods the change: it is declared **Tier 2** in its own trace.

--- a/upgrades/side-effects/tier-classifier-and-tier1-path.md
+++ b/upgrades/side-effects/tier-classifier-and-tier1-path.md
@@ -1,0 +1,81 @@
+# Side-Effects Review — Tier classifier + Tier-1 PR path (Step A)
+
+**Slug:** `tier-classifier-and-tier1-path`
+**Date:** 2026-06-01
+**Author:** echo
+**Spec:** `docs/specs/tier-classifier-and-tier1-path-spec.md` (approved by Justin + abbreviated convergence)
+**Project:** Step A of the Tiered Development Process (`docs/projects/tiered-dev-process/PROJECT.md`)
+
+## Summary of the change
+
+Teaches the instar-dev commit gate to (1) compute + print a **tier signal** (size + risk),
+(2) let the agent **declare** the tier in its trace, (3) enforce the **chosen** tier's
+requirement set — adding a **Tier-1 path** (ELI16 + side-effects, no pre-approved
+converged spec) — and (4) **audit** every decision. First executable instance of the
+constitution's *The Body and the Mind*: the gate informs, the agent decides, the decision
+is recorded. Strictly additive: a commit with no declared tier behaves exactly as before.
+
+**Files changed (in-scope):**
+- `scripts/lib/classify-tier.mjs` (NEW) — pure `classifyTier({inScopeFiles, addedLines,
+  deletedLines, addedDiffText})` → `{suggestedTier, sizeTier, riskFloor, reasons}` +
+  `decideRequirementSet(declaredTier)`. Size tier (≤40 LOC / ≤3 files = 1). Risk floor
+  raised by safety-invariant proximity, irreversibility, migration/fleet-rollout, and
+  (diff-text-gated) new-capability. `suggestedTier = max(size, risk)`, never 3.
+- `scripts/instar-dev-precommit.js` — Step 3.5 computes + prints the signal (via
+  `git diff --cached --numstat`); Step 4.5 reads `trace.tier`/`trace.tierReasoning`,
+  routes via `decideRequirementSet`, writes one audit line to
+  `.instar/instar-dev-decisions.jsonl` (incl. `riskFloor` + `belowFloor`), and runs the
+  Tier-1 path (`enforceTier1`: staged ELI16 + side-effects, sha-matched) when `tier===1`.
+  **Tier-2/3/no-tier fall through to the existing Steps 5–8 unchanged.**
+- `skills/instar-dev/scripts/write-trace.mjs` — new flags `--tier`, `--tier-reasoning`,
+  `--eli16-path`, `--side-effects-path`; `--spec` optional when `--tier 1`. Undeclared
+  traces round-trip byte-identically to the legacy shape.
+
+**Files changed (tests, not in-scope):**
+- `tests/unit/classify-tier.test.ts` (NEW, 47) — size boundaries, every risk signal incl.
+  fleet-rollout, `max(size,risk)`, never-3, config-hint-gated new-capability.
+- `tests/unit/write-trace-tier.test.ts` (NEW, 5) — Tier-1/Tier-2/no-tier trace round-trips,
+  side-effects-path default, missing-ELI16 rejection.
+- `tests/unit/instar-dev-precommit-deferrals.test.ts` — named back-compat regression
+  (no-tier trace + approved spec passes the full Tier-2 path) + audit-line shape (incl.
+  `riskFloor`). `-sha-error.test.ts` — sandbox updated for the new static import.
+
+## Blast radius
+
+Additive and back-compatible. The classifier is pure (no I/O). The gate gains two new
+steps (3.5 signal print, 4.5 tier routing + audit) **before** the existing Steps 5–8,
+which are unchanged for Tier-2/no-tier. The default (no `tier` in trace) selects the exact
+current requirement set — verified by the named back-compat regression test. The only new
+relaxation is the Tier-1 path, still requiring ELI16 + side-effects. The risk floor is a
+loud, audited signal (`belowFloor`), never a silent downgrade; the audit is a learning
+signal, not a security boundary (PR review + the auto-merge spot-check are the human
+gates). New runtime cost: one `git diff --cached --numstat` + one classify call + one
+appended JSONL line per in-scope commit.
+
+## Risks considered
+
+- **Tier-1 as a loophole?** The agent declares its own tier; a risk change that evades the
+  heuristic globs isn't flagged `belowFloor`. Mitigation (documented in the spec §4): the
+  PR is the review surface for every Tier-1, the auto-merge operator spot-check is the
+  human gate, and `belowFloor` rates are reviewed on a cadence (Close the Loop) so blind
+  spots surface and the risk list grows.
+- **Breaking existing commits?** No — `no-tier → Tier-2` is byte-identical to today; named
+  regression test guards it.
+- **Leaking sensitive data?** No — the audit records tiers, reasons, file counts, LOC; no
+  content.
+
+## Migration parity
+
+`instar-dev-precommit.js` + `write-trace.mjs` ship in the instar repo for agents
+*developing* instar; they are not installed into arbitrary agent homes by `init`. No
+`PostUpdateMigrator` change for end agents. The instar-dev skill awareness update is a
+later project step (Step C).
+
+## Tests / lint
+
+`npx tsc --noEmit` exit 0; Step-A unit tests green (`classify-tier` 47, `write-trace-tier`
+5, gate `-deferrals`/`-sha-error` 13/1). Note: the worktree's full unit suite shows 28
+**pre-existing** failures (TunnelManager, watchdog-bind-probe, serendipity-capture,
+esm-compliance, no-silent-fallbacks) that fail **identically with and without** this change
+(verified by stash-test) — local-environment/harness/lint artifacts (real config + tunnel
+reachability + node v25.6.1), independent of Step A and green in clean CI.


### PR DESCRIPTION
**Step A** of the Tiered Development Process (`docs/projects/tiered-dev-process/PROJECT.md`). Spec **approved by Justin** (topic 13435) + abbreviated convergence (3 findings folded). The first executable instance of the constitution's **The Body and the Mind**: the gate *informs*, the agent *decides*, the decision is *audited*.

## What it does
- **`scripts/lib/classify-tier.mjs`** (new) — pure `classifyTier()` (size + risk → suggested tier; never 3) + `decideRequirementSet()`. Risk floor raised by safety-invariant proximity, irreversibility, migration/fleet-rollout, and diff-gated new-capability.
- **`scripts/instar-dev-precommit.js`** — Step 3.5 computes + **prints** the tier signal; Step 4.5 reads the agent's declared `trace.tier`, routes to the chosen requirement set, **audits** every decision to `.instar/instar-dev-decisions.jsonl` (incl. `riskFloor` + `belowFloor`), and runs the **Tier-1 path** (ELI16 + side-effects, *no pre-approved spec*) when `tier===1`. **Tier-2/3/no-tier fall through to the existing checks unchanged.**
- **`skills/instar-dev/scripts/write-trace.mjs`** — `--tier`/`--tier-reasoning`/`--eli16-path`/`--side-effects-path`; `--spec` optional when `--tier 1`.

## Strictly additive
No declared tier → the existing Tier-2 requirement set, **byte-for-byte** (named back-compat regression test guards it). The only relaxation is the new Tier-1 lane, still requiring ELI16 + side-effects. The `belowFloor` audit is a **learning signal, not a security boundary** (PR review + the auto-merge spot-check are the human gates).

## Dogfood
This very commit was validated by the **new** gate: it printed `suggestedTier=2 (size=2, riskFloor=2, 523 LOC / 3 files)`, I declared Tier-2 in its trace, and the audit recorded `{declaredTier:2, belowFloor:false}`. End-to-end proof the classifier + audit + Tier-2 path all work.

## Tests
`tsc` clean; classify-tier (47), write-trace-tier (5), gate -deferrals/-sha-error (13/1) green. ⚠️ The worktree's full unit suite shows 28 **pre-existing** failures (TunnelManager/watchdog-bind-probe/serendipity-capture/esm-compliance/no-silent-fallbacks) that fail **identically with and without** this change (stash-tested) — local-env/harness/lint artifacts (real config + tunnel + node v25.6.1), independent of Step A and green in clean CI (the path-scoped pre-push gate passed).

⚠️ **This changes the commit gate that protects all instar development** — flagging for your eyes before merge rather than auto-merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)