### PR TITLE
feat(spec-converge): cross-model review on the installed codex CLI (tiered-dev Step B)

### DIFF
--- a/docs/specs/codex-crossreview-stepB-spec.eli16.md
+++ b/docs/specs/codex-crossreview-stepB-spec.eli16.md
@@ -46,6 +46,21 @@ panel but NOT the outside second opinion, because no external reviewer was insta
 skipped — the lessons-aware reviewer — still runs no matter what, because it's our defense
 against approving something that quietly contradicts a hard-won lesson.
 
+There are a few other ways the outside opinion can come up short, and **every one of them
+gets the same loud warning banner** — none of them is allowed to quietly look like a clean
+pass. If codex was there but every single review attempt failed (it timed out or hit a usage
+limit on each round), the spec ends up flagged **`degraded-all-rounds`** — meaning it
+converged without ever actually getting a real outside opinion, which is just as serious as
+having no reviewer at all. And if the author deliberately took the fast path and skipped the
+outside review to save cost, that gets a loud banner too (**skipped**), not a quiet footnote
+— "I chose to skip the second opinion" should be just as visible to the person approving as
+"no second opinion was available." Only one banner has no warning mark on it: the one that
+says a real outside review genuinely ran. One more detail under the hood: when the outside
+reviewer is run, the spec and its supporting documents are pasted directly into the request
+(codex can't open files itself), and if there's too much to fit, the least-important
+documents are dropped in a fixed, predictable order — and the request says exactly which
+documents were trimmed, so the reviewer always knows what it couldn't see.
+
 ## Built to grow
 
 codex is the *first* supported outside reviewer, but it won't be the last. There's a little

--- a/docs/specs/codex-crossreview-stepB-spec.eli16.md
+++ b/docs/specs/codex-crossreview-stepB-spec.eli16.md
@@ -1,0 +1,63 @@
+# Plain-English overview — Cross-model review through codex (Step B)
+
+## What "cross-model review" is
+
+Before I'm allowed to change instar's own source code, every design spec has to survive a
+panel of reviewers — like getting a paper read by several people who each look for a
+different kind of mistake. Five of those reviewers are versions of me (Claude) wearing
+different hats: a security reviewer, a scalability reviewer, an adversarial "how could this
+be abused" reviewer, an integration reviewer, and a "does this break a lesson we already
+learned" reviewer. But there's a catch with using only me: if my whole model family shares
+a blind spot, all five of my hats miss it together. So the panel also includes a
+**cross-model** reviewer — a *different* AI (a GPT-family model), specifically because it
+thinks differently and catches the things I'd never think to question.
+
+## The problem this fixes
+
+That cross-model reviewer was never actually built. The skill that runs the panel just said
+the external reviewer would happen "via the /crossreview pattern" — but there was no
+`/crossreview`: no code, no script, nothing that actually sends the spec to a non-Claude
+model. It was a placeholder. So in practice the "outside opinion" either got skipped or
+faked. That's the gap Step B closes.
+
+## What we're moving it onto, and why
+
+Instead of relying on some third-party AI API (a new account, a new API key, a new thing to
+keep paid-up and secure), we route the outside review through the **codex CLI** — the GPT-
+powered command-line tool the agent **already has installed and logged in**. instar already
+uses codex for lots of small "make a judgment call" tasks, through a hardened, well-tested
+path. Step B reuses that exact same path for spec reviews: it hands codex the reviewer
+instructions plus the spec, codex (running as a GPT model) reads it and writes back a
+verdict and a list of concerns, and those get folded into the panel's findings. No new
+credential, no new network service — it rides the agent's own `codex login`. And it runs
+codex in a locked-down, read-only scratch space so a review can only *read and judge*, never
+write to the repo or accidentally boot the whole agent.
+
+## The "no codex" fallback (the important safety choice)
+
+What if codex isn't installed, or isn't logged in? We do **not** block. Blocking would mean
+"you can't review any spec until you install another tool" — which would grind development
+to a halt. Justin approved this rule directly. Instead, the review just runs with the
+internal Claude reviewers only, and it stamps a loud, impossible-to-miss flag on the spec
+and in the review report: **`cross-model-review: unavailable`**. That way, when Justin reads
+the report and decides whether to approve, he can clearly see "this spec got the internal
+panel but NOT the outside second opinion, because no external reviewer was installed." It's a
+*disclosed* reduction in confidence, not a silent one. The one reviewer that can *never* be
+skipped — the lessons-aware reviewer — still runs no matter what, because it's our defense
+against approving something that quietly contradicts a hard-won lesson.
+
+## Built to grow
+
+codex is the *first* supported outside reviewer, but it won't be the last. There's a little
+registry — a list — where future tools (like a Gemini CLI) can be plugged in later by adding
+one entry. The review skill doesn't need to change to add a new reviewer; the list is the one
+place that knows about them.
+
+## What changes for a person
+
+For an end user: nothing visible — this is all internal to how I safely develop instar
+itself. For Justin (who approves specs): the review reports now actually contain a real
+outside opinion when codex is available, and a clear "no outside opinion this time" banner
+when it isn't — so approval is always an informed decision. For me: the "outside reviewer"
+step stops being a placeholder and becomes a real, grounded check that genuinely catches my
+own blind spots before code gets written.

--- a/docs/specs/codex-crossreview-stepB-spec.md
+++ b/docs/specs/codex-crossreview-stepB-spec.md
@@ -2,8 +2,10 @@
 title: "Re-platform cross-model review onto the installed codex CLI (Step B of the tiered development process)"
 date: 2026-06-01
 author: echo
-review-convergence: pending
-approved: false
+review-convergence: abbreviated-internal-2026-06-01
+approved: true
+approved-by: Justin
+approved-via: "Telegram topic 13435 (2026-06-01) 'Approved'; abbreviated convergence (internal panel) returned MINOR ISSUES, 5 findings folded in (§2/§4/cost). External cross-model review is itself what this step builds, so its own convergence uses the internal path. Findings were refinements, not a redesign."
 eli16-overview: codex-crossreview-stepB-spec.eli16.md
 ---
 
@@ -12,8 +14,11 @@ eli16-overview: codex-crossreview-stepB-spec.eli16.md
 > **Status:** Step B of the **Tiered Development Process** project
 > (`docs/projects/tiered-dev-process/PROJECT.md`, §4 cross-model review re-platform; §6
 > decisions D3/D4). This is a **Tier-2** change: it needs spec-review-convergence and
-> Justin's approval before build. `review-convergence: pending` and `approved: false`
-> are intentional — they flip when convergence runs and Justin approves.
+> Justin's approval before build. Convergence ran the **abbreviated internal panel** (the
+> external cross-model reviewer is itself what this step *builds*, so its own convergence
+> uses the internal path) on 2026-06-01; it returned MINOR ISSUES and the 5 findings (F1–F5)
+> were folded into §2/§4/cost. Justin approved (Telegram topic 13435), so
+> `review-convergence` and `approved: true` are now set in the frontmatter.
 
 ## Goal
 
@@ -190,10 +195,39 @@ cross-model reviewer driver**:
    sandbox, foreign cwd), so the context must be **inlined into the prompt**, not left as
    on-disk paths for codex to open. The driver reads each referenced doc from the repo
    (instar-side, before the spawn) and concatenates it under a clear `--- CONTEXT: <path>
-   ---` header. A per-call **context budget** (default 60 KB total, tunable) bounds the
-   prompt; if referenced docs exceed it, the driver includes the spec in full + as much
-   context as fits and notes the truncation in the prompt so the reviewer knows its view
-   was partial (a partial review is still signal; a silently-truncated one is a trap).
+   ---` header.
+
+   **The reviewer template matches the inlined reality (F3).** `reviewer-cross-model.md`
+   does **not** tell the model to "read the spec at `{SPEC_PATH}`" or to open any file —
+   codex has no repo access, so a file-reading instruction would be a dead end that wastes
+   a turn or invites a hallucinated read. Instead the template states that the spec and all
+   context are **inlined below** (under the `--- SPEC UNDER REVIEW: ... ---` and
+   `--- CONTEXT: <path> ---` markers), and that the model must review only what is inlined.
+   The template also drops the stale "GPT / Gemini / Grok" three-phantom-model framing: Step
+   B runs **one** cross-model pass through the first available supported framework (codex
+   today), so the prompt frames a single non-Claude GPT-tier reviewer, not three. The
+   `{SPEC_PATH}` token is retained purely as a label so the reviewer can cite the spec by
+   path; `assembleReviewerPrompt()` substitutes it and then inlines the spec body, so there
+   is no contradictory "open the file" instruction reaching codex.
+
+   **A per-call context budget** (default 60 KB total, tunable) bounds the prompt; if
+   referenced docs exceed it, the driver includes the spec in full + as much context as fits
+   and notes the truncation in the prompt so the reviewer knows its view was partial (a
+   partial review is still signal; a silently-truncated one is a trap).
+
+   **Truncation is deterministic and names what it dropped (F4).** When the budget can't
+   hold every referenced doc, the drop is **not** "whatever happened to come last in an
+   arbitrary order." `assembleReviewerPrompt()` first orders the referenced docs by a fixed
+   priority (`orderContextDeterministically`): the constitutional / lessons docs
+   (`signal-vs-authority`, `INSTAR-DESIGN-PRINCIPLES-AND-LESSONS`, `STANDARDS-REGISTRY`,
+   `integrated-being`) sort **first** — they are the highest-value context for a reviewer and
+   what the lessons-aware internal reviewer reads — and the remaining docs keep the
+   **spec-declared link order** (the order the caller passed them, which is the order they
+   appear in the spec). A stable sort means the same spec + same docs **always** drop the
+   same docs (a review is reproducible). And the truncation note **names the affected docs**
+   — which doc was cut mid-document (`PARTIAL`) and which were `FULLY OMITTED` — so the
+   reviewer knows exactly which context it could not see, not merely that "something" was
+   cut.
 2. **Invoke.** `provider.evaluate(prompt, { model: 'capable', timeoutMs: REVIEW_TIMEOUT_MS })`.
    `REVIEW_TIMEOUT_MS` default **120_000** (a reasoning review of a full spec is far heavier
    than the 30s judgment-call default; the value is a tunable constant). The provider's
@@ -281,10 +315,43 @@ installed/authed), convergence proceeds **internal-only**:
 - **Convergence still completes and is still taggable.** D4 is explicit: never block.
   `unavailable` is a disclosed reduction in assurance, not a gate.
 
+**Every non-ran state carries the loud banner (F1).** The `cross-model-review:` field has
+several non-`ran` states (`unavailable`, `degraded`, `degraded-all-rounds`,
+`skipped-abbreviated`), and **none of them may read as a clean pass.** The report banner
+(SKILL.md Phase 4) renders the loud `⚠` marker for **all** of them — including
+`skipped-abbreviated` (the author chose the fast path) — exactly as loudly as `unavailable`.
+The clean `## Cross-model review: codex-cli:<model>` form (no `⚠`) is reserved for the one
+state where a real external pass actually ran. A deliberately-skipped or all-degraded
+external review is a real reduction in assurance and must be as visible to the approving
+human as a missing reviewer — never a quiet footnote.
+
 A `degraded` external call (§2 — codex present but this round's call failed) is treated as
-a *partial* cross-model pass for that round: the flag reads
-`cross-model-review: codex-cli:gpt-5.5 (degraded: <reason>)`, and the report notes which
-round(s) degraded. It does not collapse to `unavailable` (the framework IS there).
+a *partial* cross-model pass for that round: the per-round flag reads
+`cross-model-review: codex-cli:gpt-5.5 (degraded: <reason>)`. It does not collapse to
+`unavailable` (the framework IS there).
+
+**Spec-level aggregation across rounds — `degraded-all-rounds` (F2).** Convergence runs
+**multiple rounds**, but the spec gets exactly **one** final `cross-model-review:` value.
+Each round produces a per-round `ReviewerResult` (`ok` / `degraded` / `unavailable`); the
+skill tracks the per-round outcomes and computes the final flag via
+`aggregateRoundOutcomes(rounds, { skippedAbbreviated })` (exported from
+`crossModelReviewer.ts`), per these rules:
+
+- **`codex-cli:<model>`** — **any** round got a successful external pass. One genuine outside
+  opinion is enough to say the spec received real cross-model review (the freshest successful
+  round's flag is used).
+- **`degraded-all-rounds`** — a framework was present in the rounds but **zero** rounds
+  succeeded (every attempt degraded). This is treated **as loud as `unavailable`**: the spec
+  converged having **never once received a real external opinion**, and that fact must surface
+  at the **spec level** (the banner + the frontmatter flag) — not hide inside per-round
+  degraded notes that, read individually, make it look like the review "tried."
+- **`unavailable`** — no supported framework was ever available across the rounds.
+- **`skipped-abbreviated`** — the author opted out of the external pass entirely.
+
+The motivation for `degraded-all-rounds` is precisely the trap it closes: a spec that
+degraded on every round looks, from per-round notes alone, like it attempted cross-model
+review — but it converged with the SAME assurance as one that had no reviewer at all. The
+spec-level aggregate makes "converged with no real external opinion" impossible to miss.
 
 ### 5. How it threads into spec-converge
 
@@ -302,12 +369,15 @@ reviewer step** (~line 74) and Phase 5 (tag) / Phase 4 (report):
 - **Internal reviewers + Standards-Conformance Gate: unchanged.** All five internal
   reviewers and the auto-invoked `POST /spec/conformance-check` still run on every round in
   every mode. The lessons-aware reviewer remains non-skippable.
-- **Phase 4 (report).** Add the cross-model status banner (§4) — `codex-cli:gpt-5.5`,
-  `degraded`, or `UNAVAILABLE` — so the human handoff always states the external-review
-  posture.
-- **Phase 5 (tag).** `write-convergence-tag.mjs` writes the `cross-model-review:` (+
-  `-reason`) frontmatter field. This is **additive** to the existing tag write (it already
-  rewrites frontmatter; we add one or two lines), and it does **not** change the
+- **Phase 4 (report).** Add the cross-model status banner (§4) — `codex-cli:<model>`,
+  `degraded`, `degraded-all-rounds`, `UNAVAILABLE`, or `SKIPPED` — so the human handoff
+  always states the external-review posture. **Every non-ran state carries the loud `⚠`
+  marker (F1)**; only the real-pass `codex-cli:<model>` form is unmarked.
+- **Phase 5 (tag).** `write-convergence-tag.mjs` writes the **aggregated, spec-level**
+  `cross-model-review:` (+ `-reason`) frontmatter field — the `aggregateRoundOutcomes`
+  result across all rounds (F2), not a single round's status. This is **additive** to the
+  existing tag write (it already rewrites frontmatter; we add one or two lines), and it does
+  **not** change the
   convergence/approval gate logic in `scripts/instar-dev-precommit.js` — that gate still
   keys only on `review-convergence` + `approved: true` (`instar-dev-precommit.js:417-435`).
   The cross-model flag is **disclosure, not a gate**: an `unavailable` spec can still be
@@ -342,6 +412,18 @@ be present but the author chose the fast path; the flag records that choice hone
 - **Driver parse**: a well-formed reviewer reply (`Verdict: SERIOUS ISSUES` + findings)
   parses into the structured record; an unparseable reply yields exactly one raw
   "unstructured external review" finding (never zero, never thrown).
+- **Spec-level aggregation across rounds (F2)** — `aggregateRoundOutcomes`: any successful
+  round → the clean `codex-cli:<model>` flag (last success wins); a framework present every
+  round but zero successes → `degraded-all-rounds` (carries the last degraded reason); all
+  rounds unavailable → `unavailable` (NOT `degraded-all-rounds`); `skippedAbbreviated` wins
+  over everything; empty rounds → `unavailable`. Plus `buildCrossModelFlag('degraded-all-rounds')`
+  emits the exact frontmatter string.
+- **Deterministic context truncation (F4)** — `assembleReviewerPrompt` /
+  `orderContextDeterministically`: constitutional/lessons docs (`signal-vs-authority`,
+  `INSTAR-DESIGN-PRINCIPLES-AND-LESSONS`, …) are kept FIRST regardless of caller order; the
+  truncation note **names** the partial doc and the fully-omitted docs (not just
+  "truncated"); identical inputs produce byte-identical prompts (reproducible); the ordering
+  function is pure (does not mutate its input).
 
 ### Integration (`tests/integration/`)
 
@@ -419,11 +501,16 @@ Two parity points to keep honest:
   + the internal lessons-aware reviewer are the cross-checks). It cannot exfiltrate or
   mutate anything (no write sandbox, allowlist env). This is the same trust posture as
   every other codex judgment call in instar.
-- **Cost.** One `capable`-tier (`gpt-5.5`, a heavy reasoning model) call per convergence
-  round, bounded by the 120s timeout and the account-global circuit breaker. The context
-  budget (60 KB) bounds prompt size. Convergence is a deliberate, infrequent, pre-build
-  action (not a hot path), so a heavyweight model per round is acceptable; the breaker is
-  the backstop if a burst of spec reviews hits the account limit.
+- **Cost (worst case stated explicitly).** One `capable`-tier (`gpt-5.5`, a heavy reasoning
+  model) call per convergence round. Convergence loops up to the **10-iteration hard cap**
+  (SKILL.md Phase 3), so the worst case for a single spec's convergence is **~10 rounds × 1
+  `gpt-5.5` call = ~10 capable-tier calls** before the cap forces a stop. Each call is
+  bounded by the 120s timeout and the account-global circuit breaker; the context budget
+  (60 KB) bounds prompt size. Convergence is a deliberate, infrequent, pre-build action (not
+  a hot path), so even the 10-call ceiling per spec is acceptable; the breaker is the
+  backstop if a burst of spec reviews hits the account limit (and once the breaker opens,
+  the remaining rounds degrade rather than spend — see the `degraded-all-rounds` aggregate
+  in §2/§4).
 
 ## Out of scope (later steps)
 

--- a/docs/specs/codex-crossreview-stepB-spec.md
+++ b/docs/specs/codex-crossreview-stepB-spec.md
@@ -1,0 +1,444 @@
+---
+title: "Re-platform cross-model review onto the installed codex CLI (Step B of the tiered development process)"
+date: 2026-06-01
+author: echo
+review-convergence: pending
+approved: false
+eli16-overview: codex-crossreview-stepB-spec.eli16.md
+---
+
+# Re-platform cross-model review onto the installed codex CLI (Step B)
+
+> **Status:** Step B of the **Tiered Development Process** project
+> (`docs/projects/tiered-dev-process/PROJECT.md`, §4 cross-model review re-platform; §6
+> decisions D3/D4). This is a **Tier-2** change: it needs spec-review-convergence and
+> Justin's approval before build. `review-convergence: pending` and `approved: false`
+> are intentional — they flip when convergence runs and Justin approves.
+
+## Goal
+
+The `/spec-converge` skill runs eight reviewers on every spec before `/instar-dev` may
+touch instar source. Five are internal Claude subagents; **three are external
+"cross-model" reviewers** (GPT-tier, Gemini-tier, Grok-tier) whose value is that they
+sit *outside* the Claude family and catch shared blind spots. The skill describes those
+externals as running **"via the /crossreview pattern"** (`skills/spec-converge/SKILL.md`
+~line 74) — a placeholder for an API-driven swap point that was never built as a
+concrete, reachable mechanism. There is no `/crossreview` skill, script, or route in the
+tree (verified: `skills/` has no `*crossreview*` dir; the only `crossreview` string is
+the SKILL.md prose itself).
+
+**Step B makes the external cross-model reviewer real by routing it through the agent's
+own installed `codex` CLI** — the same headless `codex exec` path instar already uses for
+every other judgment call — instead of a hypothetical third-party API. codex is the
+*first supported framework* in an extensible registry (gemini-cli and others land in a
+later step). When **no** supported reviewer framework is installed/authed, the system
+**degrades to internal-only convergence** and records a loud, machine-readable
+`cross-model-review: unavailable` flag on the spec and in the convergence report. It
+**never blocks** convergence, and the non-skippable lessons-aware internal reviewer always
+still runs.
+
+This is a faithful instance of the project's locked decisions **D3** (framework-native
+via the detected codex CLI — the agent's own auth, no new API key, no new network
+dependency) and **D4** (no-codex → internal-only + a loud unavailable flag, never a hard
+stop). Justin approved D3/D4 in the project shape.
+
+## Current behavior (what Step B modifies)
+
+`/spec-converge` Phase 1 spawns eight reviewers in parallel and collects their findings
+(`skills/spec-converge/SKILL.md` §"Phase 1"). The five internal reviewers are real Claude
+subagents driven by the prompts in `skills/spec-converge/templates/reviewer-*.md`. The
+three externals share **one** prompt, `reviewer-cross-model.md`, and are described as
+running "via the /crossreview pattern" — but that pattern has no implementation: nothing
+in the tree actually feeds the spec to a non-Claude model. In practice the external pass
+is either skipped or hand-waved. Step B replaces the hand-wave with a grounded mechanism.
+
+Two things are explicitly **out of scope and untouched**:
+
+- **The internal reviewers** (security, scalability, adversarial, integration,
+  lessons-aware) — they keep running exactly as today.
+- **The Standards-Conformance Gate** (`POST /spec/conformance-check`) — the code-backed
+  constitutional pass auto-invoked alongside the eight. Step B does not change it.
+
+`src/core/ConvergenceChecker.ts` / `src/templates/scripts/convergence-check.sh` are a
+**separate** heuristic content-quality gate (regex anti-pattern scan, no LLM, no
+reviewers). They are unrelated to the reviewer panel and are **not** modified by Step B.
+(They are listed in the grounding set only to confirm the boundary: the "convergence
+machinery" that Step B touches is the *reviewer orchestration in the skill*, not the
+content-quality regex gate.)
+
+## Grounded mechanism — headless codex invocation (the crux)
+
+instar **already runs codex headlessly** for every non-Claude judgment call, via
+`CodexCliIntelligenceProvider.evaluate()`
+(`src/core/CodexCliIntelligenceProvider.ts:96-176`). The exact command it builds is:
+
+```
+codex exec \
+  --model <resolved-model> \
+  --sandbox read-only \
+  --cd <empty-mkdtemp-scratch-dir> \
+  -c project_doc_max_bytes=0 \
+  --skip-git-repo-check \
+  "<prompt>"
+```
+
+with stdin closed (`child.stdin?.end()`) and the child env built by
+`buildCodexChildEnv()` (allowlist, never `{...process.env}` — so `OPENAI_API_KEY` can't
+leak in and silently bill the wrong account; `src/core/CodexCliIntelligenceProvider.ts:143`).
+This is `codex`'s genuine non-interactive one-shot mode (`codex exec` — the same mode the
+project's Step-A spec and `CodexCliIntelligenceProvider` doc-comment name). **codex has a
+clean headless one-shot mode; we do not need to synthesize one.**
+
+The flags matter and Step B reuses every one of them deliberately:
+
+- `--sandbox read-only` — a reviewer reads and judges; it never writes. (Default in the
+  provider.)
+- `--cd <empty scratch dir>` + `-c project_doc_max_bytes=0` — the scratch dir is created
+  with `mkdtempSync` (mode 0700, unguessable suffix; `resolveIntelligenceScratchDir`,
+  lines 58-62). This is the **clean-notepad** guarantee: running `codex exec` in the
+  agent's project dir would load the ~26 KB `AGENTS.md` identity AND fire the project's
+  `.codex/hooks.json` (session_start / user_prompt_submit / stop) on every call — turning
+  a review into a full agent boot (the 2026-05-26 ~1,550-spawns/day bug, lines 51-56).
+  A reviewer must judge the spec **as a neutral GPT-tier model**, not as a booted copy of
+  the agent — so the empty, hook-free, identity-free scratch dir is exactly right for
+  cross-model review.
+- `--skip-git-repo-check` — codex refuses to run when `--cd` points at a non-git dir; the
+  scratch dir isn't a repo, so this is required (lines 116-124).
+
+**Model selection (GPT-tier).** `resolveCliModelFlag(options.model)`
+(`src/providers/adapters/openai-codex/models.ts`) maps the canonical tier
+`'capable'` → **`gpt-5.5`** (newest frontier reasoning model, working on the ChatGPT
+subscription account; the `fast`/`balanced` tiers map to `gpt-5.2` / `gpt-5.4-mini`). A
+cross-model spec review is a heavyweight reasoning task, so Step B requests the
+**`capable`** tier → `gpt-5.5`. (The tier is the knob; the concrete model id stays owned
+by `models.ts`, so a future model bump needs no Step-B change.)
+
+**Auth = the agent's own codex auth, no new credential.** D3 is satisfied by reusing the
+provider: no API key is introduced, the call rides the agent's existing
+`codex login` (ChatGPT subscription OAuth in `~/.codex/auth.json`), and the
+allowlist-built env keeps `OPENAI_API_KEY` *out*.
+
+### Why route through the existing provider, not a new spawn
+
+The crux decision: Step B's invocation goes through
+**`buildIntelligenceProvider({ framework: 'codex-cli' })`**
+(`src/core/intelligenceProviderFactory.ts:59`) → a wrapped
+`CodexCliIntelligenceProvider`, NOT a bespoke `codex exec` spawn written in the skill.
+Reasons:
+
+1. **The hardening is already there and is non-obvious.** The scratch-dir clean-notepad,
+   the env allowlist, the stdin-close, the `--skip-git-repo-check`, the 30s timeout — each
+   encodes a real past failure. A hand-rolled spawn in the skill would re-litigate every
+   one of them and silently regress (e.g. re-introduce the AGENTS.md-boot spam).
+2. **The account-global circuit breaker is free.** Every provider the factory hands out is
+   wrapped with `CircuitBreakingIntelligenceProvider`
+   (`intelligenceProviderFactory.ts:64-67`), so a rate-limited codex review degrades the
+   same way every other instar LLM call does — no new fail-open path.
+3. **`IntelligenceOptions.timeoutMs`** is already honored per-call
+   (`CodexCliIntelligenceProvider.ts:151`), giving Step B a clean place to set the
+   reviewer timeout.
+
+The **only** new code is (a) a thin **codex cross-model reviewer driver** that builds the
+reviewer prompt + spec + referenced context into one string and calls
+`provider.evaluate(prompt, { model: 'capable', timeoutMs })`, parses the structured
+finding list out of the returned text, and (b) the **detection + registry + fallback-flag**
+plumbing below.
+
+## Design
+
+### 1. Detection — is a supported reviewer framework installed + authed?
+
+A pure function `detectCrossModelReviewer()` returns
+`{ available: boolean, framework?: 'codex-cli', model?: string, reason?: string }`:
+
+- **Binary present?** `detectCodexPath()` (`src/core/Config.ts:282`, which wraps
+  `detectFrameworkBinary('codex')` — PATH + asdf + nvm shim resolution, login-shell-safe).
+  `null` → not installed.
+- **Authed?** Reuse the canonical OAuth probe shape already used by the codex smoketest
+  (`src/providers/adapters/openai-codex/_smoketest.ts:22-36`): read
+  `${CODEX_HOME || ~/.codex}/auth.json`; **authed** iff `tokens.access_token` is present
+  (subscription OAuth — D3's required auth shape). A missing/unreadable/malformed file →
+  not authed.
+- **Spec-12 Rule 1 (API-key forbidden).** Run `validateRule1()`
+  (`src/providers/adapters/openai-codex/credentials.ts:132`). If it reports
+  `CODEX_AUTH_APIKEY_DETECTED` (env `OPENAI_API_KEY` set, or `auth.json` is API-key shape),
+  the reviewer is treated as **not available** with reason
+  `codex-auth-apikey-forbidden` — instar's policy is subscription-OAuth only, and we must
+  not run a cross-model review on a credential shape the rest of the codebase refuses. This
+  reuses existing policy rather than inventing a new one.
+
+`available: true` requires **all three**: binary found, OAuth `access_token` present,
+Rule-1 clean. Any miss → `available: false` with a specific `reason`
+(`codex-not-installed` | `codex-not-authed` | `codex-auth-apikey-forbidden`).
+
+**Where the check lives.** `detectCrossModelReviewer()` is a pure TS function exported
+from a new module `src/core/crossModelReviewer.ts` (unit-testable with injected
+`{ codexPathDetected, authJsonPath, env }`, no real spawns). The **converge skill calls it
+at Phase 1** to decide whether the external pass runs or the fallback flag is set. It is
+*signal-only* detection — it never throws and never blocks; a `false` simply routes to §4.
+
+### 2. Invocation — feed the reviewer prompt + spec + context to codex headlessly
+
+When `detectCrossModelReviewer()` returns `available: true`, the skill runs the **codex
+cross-model reviewer driver**:
+
+1. **Build the prompt.** Compose one string: the contents of
+   `skills/spec-converge/templates/reviewer-cross-model.md` (with `{SPEC_PATH}`
+   substituted) + the full spec markdown + the **referenced architectural context** the
+   spec names (the docs the spec links — same set the internal reviewers receive). codex
+   runs in an empty scratch dir with **no filesystem access to the repo** (read-only
+   sandbox, foreign cwd), so the context must be **inlined into the prompt**, not left as
+   on-disk paths for codex to open. The driver reads each referenced doc from the repo
+   (instar-side, before the spawn) and concatenates it under a clear `--- CONTEXT: <path>
+   ---` header. A per-call **context budget** (default 60 KB total, tunable) bounds the
+   prompt; if referenced docs exceed it, the driver includes the spec in full + as much
+   context as fits and notes the truncation in the prompt so the reviewer knows its view
+   was partial (a partial review is still signal; a silently-truncated one is a trap).
+2. **Invoke.** `provider.evaluate(prompt, { model: 'capable', timeoutMs: REVIEW_TIMEOUT_MS })`.
+   `REVIEW_TIMEOUT_MS` default **120_000** (a reasoning review of a full spec is far heavier
+   than the 30s judgment-call default; the value is a tunable constant). The provider's
+   own `codex exec` command (above) is reused verbatim; the driver passes only the prompt
+   and options.
+3. **Parse.** The reviewer prompt already mandates a bounded, structured shape:
+   `Verdict: CLEAN | MINOR ISSUES | SERIOUS ISSUES` + a findings list with section refs
+   (`reviewer-cross-model.md` lines 23-26). The driver extracts the verdict line and the
+   findings into the same `{ reviewer, verdict, findings[] }` record shape the internal
+   reviewers produce, tagged `reviewer: 'cross-model:codex-cli:gpt-5.5'`. If the verdict
+   line is unparseable, the finding set is captured as one raw "unstructured external
+   review — read manually" finding (never dropped).
+
+**Failure handling (every path fails toward internal-only, never toward a stall):**
+
+- **Timeout** (`execFile` timeout fires) → the provider rejects; the driver records a
+  `cross-model-review: degraded` note (reason `timeout`) and the round proceeds on the
+  internal reviewers + whatever externals succeeded. Not a block.
+- **Non-zero exit / CLI error** → the provider rejects with the stderr slice (it already
+  slices 600 chars for the rate-limit classifier); the driver records `degraded` with the
+  reason. Not a block.
+- **Circuit breaker open** (account rate-limited) → the wrapped provider surfaces it; the
+  driver records `degraded` (reason `rate-limited`) and proceeds. This is the **one
+  intentional fail-open**: a rate-limited cross-model review must not stall spec review,
+  consistent with how every other instar LLM gate behaves under load.
+- **Empty/blank stdout** → treated as an unparseable review → one raw finding, not silent
+  success.
+
+The distinction between `unavailable` (§4 — no supported framework at all) and `degraded`
+(framework present but this call failed) is recorded explicitly so the report can tell the
+user "you have no cross-model reviewer" apart from "your cross-model reviewer was rate-limited
+this round."
+
+### 3. Supported-reviewer registry — the extension point
+
+codex is the **first** supported framework; the registry is where gemini-cli and others
+plug in later. It is a small static table in `src/core/crossModelReviewer.ts`:
+
+```ts
+interface SupportedReviewerFramework {
+  id: 'codex-cli';                       // extend the union to add a framework
+  detect(): { available: boolean; model?: string; reason?: string };
+  // builds the prompt + calls the framework's IntelligenceProvider; returns findings
+  review(args: { promptText: string; timeoutMs: number }): Promise<ReviewerResult>;
+}
+
+const SUPPORTED_REVIEWER_FRAMEWORKS: SupportedReviewerFramework[] = [ codexReviewer ];
+```
+
+`detectCrossModelReviewer()` walks the registry in order and returns the **first**
+available framework (codex today; the order is the preference order). Adding a framework
+is: (a) extend the `id` union, (b) push a new entry that wires that framework's already-
+existing `IntelligenceProvider` (the factory already supports `framework: 'codex-cli'` and
+is built to extend — `intelligenceProviderFactory.ts:28` `IntelligenceFramework` union).
+**No skill change** is needed to add a framework — the registry is the single seam. This
+mirrors the established instar single-funnel pattern (one table, one detection walk).
+
+The registry lives in `src/` (not the skill) deliberately: detection + invocation are
+real code with security invariants (the auth probe, the env allowlist), and code is
+unit-testable and migration-trackable in a way a skill prompt is not (**Structure >
+Willpower**). The skill *calls* the registry; it does not *contain* it.
+
+### 4. No-codex fallback (Justin-approved D4) — internal-only + loud flag, never block
+
+When `detectCrossModelReviewer()` returns `available: false` (no supported framework
+installed/authed), convergence proceeds **internal-only**:
+
+- The five internal reviewers + the Standards-Conformance Gate run **exactly as today**.
+  The **lessons-aware reviewer is non-skippable** — it runs in every mode (it is the
+  structural defense against the spec-converge-pre-auth-circular failure; SKILL.md §"The
+  lessons-aware reviewer is not optional").
+- A **loud, machine-readable flag** is recorded in two places:
+  1. **On the spec frontmatter**, written alongside the convergence tag by
+     `write-convergence-tag.mjs`: `cross-model-review: unavailable` (+
+     `cross-model-review-reason: "<reason>"`). When a supported reviewer DID run, the same
+     field is written `cross-model-review: codex-cli:gpt-5.5` so the spec self-documents
+     which external pass it received (or didn't).
+  2. **In the convergence report** (`docs/specs/reports/<slug>-convergence.md`): a
+     dedicated, can't-miss banner section — `## ⚠ Cross-model review: UNAVAILABLE` — stating
+     no external (non-Claude) reviewer was installed/authed, that convergence ran on
+     internal Claude reviewers + the constitutional gate only, the specific reason, and the
+     one-line remediation (`codex login`, or install `@openai/codex`). The user reads this
+     before applying `approved: true`, so the reduced-assurance state is an **informed**
+     choice, not a silent one.
+- **Convergence still completes and is still taggable.** D4 is explicit: never block.
+  `unavailable` is a disclosed reduction in assurance, not a gate.
+
+A `degraded` external call (§2 — codex present but this round's call failed) is treated as
+a *partial* cross-model pass for that round: the flag reads
+`cross-model-review: codex-cli:gpt-5.5 (degraded: <reason>)`, and the report notes which
+round(s) degraded. It does not collapse to `unavailable` (the framework IS there).
+
+### 5. How it threads into spec-converge
+
+The change to `skills/spec-converge/SKILL.md` is surgical, at the **Phase 1 external
+reviewer step** (~line 74) and Phase 5 (tag) / Phase 4 (report):
+
+- **Phase 1.** Replace the prose "External reviewers (cross-model, via the /crossreview
+  pattern): GPT-tier / Gemini-tier / Grok-tier" with: *call
+  `detectCrossModelReviewer()`. If available, run the codex cross-model reviewer driver
+  (§2) as the external pass and fold its findings in alongside the internal reviewers'. If
+  unavailable, skip the external pass, set the fallback flag (§4), and continue.* The
+  GPT/Gemini/Grok "three externals" framing collapses to **one cross-model pass through the
+  first available supported framework** — which is the honest mechanism (one installed CLI,
+  not three phantom API models).
+- **Internal reviewers + Standards-Conformance Gate: unchanged.** All five internal
+  reviewers and the auto-invoked `POST /spec/conformance-check` still run on every round in
+  every mode. The lessons-aware reviewer remains non-skippable.
+- **Phase 4 (report).** Add the cross-model status banner (§4) — `codex-cli:gpt-5.5`,
+  `degraded`, or `UNAVAILABLE` — so the human handoff always states the external-review
+  posture.
+- **Phase 5 (tag).** `write-convergence-tag.mjs` writes the `cross-model-review:` (+
+  `-reason`) frontmatter field. This is **additive** to the existing tag write (it already
+  rewrites frontmatter; we add one or two lines), and it does **not** change the
+  convergence/approval gate logic in `scripts/instar-dev-precommit.js` — that gate still
+  keys only on `review-convergence` + `approved: true` (`instar-dev-precommit.js:417-435`).
+  The cross-model flag is **disclosure, not a gate**: an `unavailable` spec can still be
+  approved (D4). Whether `unavailable` should ever *raise* the tier or require an extra
+  approval acknowledgment is **out of scope here** (a policy question for a later step;
+  noted in Out of Scope).
+
+The "abbreviated convergence" mode (SKILL.md §"Anti-patterns": externals may be skipped to
+save cost, lessons-aware must still run) is preserved and made precise: abbreviated mode =
+`cross-model-review: skipped-abbreviated` (distinct from `unavailable`) — the framework may
+be present but the author chose the fast path; the flag records that choice honestly.
+
+## Testing (3-tier)
+
+### Unit (`tests/unit/`)
+
+- **Detection logic** (`detectCrossModelReviewer`, injected inputs — no real spawn):
+  - binary missing → `{ available: false, reason: 'codex-not-installed' }`.
+  - binary present + `auth.json` with `tokens.access_token` → `{ available: true,
+    framework: 'codex-cli', model: 'gpt-5.5' }`.
+  - binary present + `auth.json` missing/unreadable/malformed → `not-authed`.
+  - binary present + `OPENAI_API_KEY` in env → `codex-auth-apikey-forbidden`
+    (Rule-1 reuse).
+  - binary present + `auth.json` API-key shape (`sk-`) → `codex-auth-apikey-forbidden`.
+- **Registry**: walk returns the first available framework; with codex unavailable and no
+  other entry, returns `{ available: false }`; adding a second stub framework after codex
+  is selected only when codex is unavailable (order = preference).
+- **Fallback-flag emission**: `write-convergence-tag.mjs` writes
+  `cross-model-review: unavailable` + `-reason` when passed the unavailable state, and
+  `cross-model-review: codex-cli:gpt-5.5` when passed the available state; idempotent
+  (re-run strips/rewrites the field, like the existing review-* fields, lines 110-120).
+- **Driver parse**: a well-formed reviewer reply (`Verdict: SERIOUS ISSUES` + findings)
+  parses into the structured record; an unparseable reply yields exactly one raw
+  "unstructured external review" finding (never zero, never thrown).
+
+### Integration (`tests/integration/`)
+
+- **Convergence flow with codex present**: stub the `IntelligenceProvider.evaluate` to
+  return a canned structured review; assert the convergence round folds the external
+  findings in AND the report banner reads `codex-cli:gpt-5.5` AND the spec frontmatter
+  gets `cross-model-review: codex-cli:gpt-5.5`. (Provider is stubbed — no real codex spawn
+  in CI; the *real* `codex exec` command is already exercised by the existing
+  CodexCliIntelligenceProvider tests, so Step B's integration test verifies the
+  *wiring*, not codex itself.)
+- **Convergence flow with codex absent**: detection returns `unavailable`; assert the round
+  completes internal-only, the lessons-aware reviewer still ran, the report carries the
+  `## ⚠ Cross-model review: UNAVAILABLE` banner, the spec frontmatter carries
+  `cross-model-review: unavailable`, and convergence is **still taggable** (never blocked).
+- **Degraded path**: provider rejects (timeout/error/breaker-open); assert the round
+  proceeds, the flag reads `degraded: <reason>`, and it does **not** collapse to
+  `unavailable`.
+
+### E2E (`tests/e2e/`) — scope note
+
+There is no new HTTP route in Step B (the change is skill + a `src/` module the skill
+calls), so the "feature is alive / returns 200 not 503" Phase-1 E2E pattern does not
+directly apply — there is no endpoint to probe. The end-to-end assurance is provided by
+the integration tests above (full convergence flow, codex-present vs codex-absent) plus
+the existing `CodexCliIntelligenceProvider` provider tests that exercise the real
+`codex exec` command. **If** Step C later exposes a status route (e.g.
+`GET /spec/cross-model-reviewer` reporting detection state), that route gets the standard
+Phase-1 E2E test then. Calling this out explicitly rather than silently skipping the tier.
+
+## Migration parity
+
+`/spec-converge`, `write-convergence-tag.mjs`, and `instar-dev-precommit.js` are the
+**instar-developing agent's** tooling — they ship in the instar repo and are NOT installed
+into arbitrary agent homes by `init` (same posture as Step A's gate). So **no
+`PostUpdateMigrator` change is required for end agents.** The new `src/core/crossModelReviewer.ts`
+is a library module consumed by the dev tooling, not a fleet-installed file.
+
+Two parity points to keep honest:
+
+1. **The skill content itself.** If `/spec-converge` is ever in the built-in-skills set
+   installed into agent homes, an edit to its SKILL.md content needs the documented
+   "updating existing skill content" migration path (an idempotent `PostUpdateMigrator`
+   step, per the Migration Parity Standard). Step B must **check** whether spec-converge is
+   in the installed-skills allowlist; if it is, add the idempotent content migration; if it
+   is dev-only tooling, no migration. (Grounding finding: spec-converge is marked
+   `user_invocable: false`, audience "instar-developing agent only" — strongly suggesting
+   dev-only, but the build must confirm against the skills registry before concluding "no
+   migration," not assume.)
+2. **Agent Awareness.** Cross-model review is dev-process internal, not an end-user-facing
+   capability, so the CLAUDE.md *template* (`generateClaudeMd()`) does not need a new
+   Capabilities entry. The **instar-dev skill docs** (Step C) are where the developing
+   agent learns that the external reviewer now runs through codex and what the
+   `cross-model-review: unavailable` flag means — that awareness update is Step C's job,
+   noted in Out of Scope.
+
+## Safety / blast radius
+
+- **Additive and fail-safe.** When no supported reviewer is installed, the system behaves
+  like today's convergence (internal reviewers) **plus** a disclosure flag — strictly more
+  information, never less function. When codex IS present, the external pass becomes real
+  instead of hand-waved — strictly more review, not less.
+- **No new credential, no new network dependency.** D3: the call rides the agent's existing
+  `codex login` OAuth; the env allowlist (`buildCodexChildEnv`) keeps `OPENAI_API_KEY` out;
+  the read-only sandbox + empty scratch dir mean a reviewer call cannot write to the repo or
+  boot the agent's identity/hooks. The blast radius of a codex review is a bounded,
+  sandboxed, read-only one-shot.
+- **Never blocks.** Every failure mode (no framework, timeout, error, rate-limit, empty,
+  unparseable) routes toward internal-only or a captured-raw finding — convergence always
+  completes. The cross-model flag is **disclosure, not a gate**; it does not change the
+  `review-convergence` + `approved` enforcement in `instar-dev-precommit.js`.
+- **Prompt-injection surface.** The spec text under review is fed to codex as a prompt;
+  a malicious spec could try to steer the reviewer. Mitigation: the reviewer runs read-only
+  in an empty scratch dir with no tools and no repo access — the worst a poisoned spec can
+  do is produce a misleading *review*, which a human reads in the report (the report banner
+  + the internal lessons-aware reviewer are the cross-checks). It cannot exfiltrate or
+  mutate anything (no write sandbox, allowlist env). This is the same trust posture as
+  every other codex judgment call in instar.
+- **Cost.** One `capable`-tier (`gpt-5.5`, a heavy reasoning model) call per convergence
+  round, bounded by the 120s timeout and the account-global circuit breaker. The context
+  budget (60 KB) bounds prompt size. Convergence is a deliberate, infrequent, pre-build
+  action (not a hot path), so a heavyweight model per round is acceptable; the breaker is
+  the backstop if a burst of spec reviews hits the account limit.
+
+## Out of scope (later steps)
+
+- **A second supported framework** (gemini-cli, etc.) — the registry is built as the
+  extension point here, but only codex is wired. Adding gemini is a later step that pushes
+  one registry entry.
+- **instar-dev skill / CLAUDE.md-template awareness** of the new mechanism and the
+  `cross-model-review` flag — **Step C**.
+- **Migration of any deployed dev-tooling gate** — **Step D**.
+- **Policy on the `unavailable` flag** — whether an `unavailable` spec should require an
+  extra approval acknowledgment, raise the tier, or be surfaced on a review cadence. Step B
+  records the flag honestly; whether the flag should *gate* anything is a deliberate policy
+  question left for a later step (consistent with D4 "never block" — Step B's job is the
+  truthful signal, not a new gate).
+- **Replacing the internal Claude reviewers or the Standards-Conformance Gate** — untouched
+  by design; Step B only re-platforms the *external* reviewer.
+- **The content-quality regex gate** (`ConvergenceChecker` / `convergence-check.sh`) — a
+  separate subsystem, not modified.

--- a/skills/spec-converge/SKILL.md
+++ b/skills/spec-converge/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: spec-converge
-description: Iteratively review an instar-development spec with multi-angle internal reviewers (security, scalability, adversarial, integration) and cross-model external reviewers (GPT, Gemini, Grok) until convergence, then produce a comprehensive ELI10 convergence report. Output is a spec tagged review-convergence — one of the two tags /instar-dev requires before it will touch instar source. NOT user-invocable; run by the instar-developing agent before any spec-driven /instar-dev work.
+description: Iteratively review an instar-development spec with multi-angle internal reviewers (security, scalability, adversarial, integration, lessons-aware) and a real cross-model external reviewer routed through the agent's own installed codex CLI (GPT-tier) until convergence, then produce a comprehensive ELI10 convergence report. Output is a spec tagged review-convergence — one of the two tags /instar-dev requires before it will touch instar source. NOT user-invocable; run by the instar-developing agent before any spec-driven /instar-dev work.
 metadata:
   user_invocable: "false"
   audience: "instar-developing agent only — NOT end users"
@@ -71,17 +71,31 @@ The skill spawns reviewers in parallel:
 - **Integration/deployment.** Migration, backup/restore, multi-machine, config knobs, dashboard surface, rollback.
 - **Lessons-aware.** Loads the canonical Instar Design Principles + Lessons Learned index (`docs/INSTAR-DESIGN-PRINCIPLES-AND-LESSONS.md`) plus the running agent's local `.instar/memory/feedback_*.md` entries, then checks the spec for (a) direct contradictions of documented principles/lessons, (b) applicable lessons the spec fails to engage with, and (c) behavioral lessons violated by agent-facing surfaces the spec proposes. Catches the "Phase 2" anti-pattern and the spec-converge-pre-auth-circular failure mode (see `feedback_spec_converge_pre_auth_circular`).
 
-**External reviewers (cross-model, via the /crossreview pattern):**
+**External reviewer (cross-model, via the agent's own installed codex CLI):**
 
-- GPT-tier model — independent read on architecture and clarity.
-- Gemini-tier model — independent read.
-- Grok-tier model — independent read.
+The external "cross-model" pass is a single independent GPT-tier read that sits *outside* the Claude family to catch the blind spots Claude models share. It is **real**, routed through the agent's own `codex login` (no new API key, no new network dependency), and implemented in code — NOT a hand-wave. Run it like this:
 
-Each reviewer receives the spec, the architectural context docs referenced in the spec (`docs/signal-vs-authority.md`, `docs/integrated-being.md`, relevant subsystem docs), and a prompt specific to their perspective. Each produces a structured finding list.
+1. **Detect** whether a supported reviewer framework is installed + authed:
+   ```bash
+   node skills/spec-converge/scripts/cross-model-review.mjs --spec <spec-path> --detect-only
+   ```
+   Returns `{ available, framework?, model?, reason? }`. `available:false` → skip the external pass, set the fallback flag (see §"No-codex fallback" below / Phase 5), and continue internal-only. **Never block.**
 
-All **eight** reviewers run in parallel. Their findings are collected.
+2. **Run** the external review when available — pass the spec plus the same architectural context docs the internal reviewers receive (the docs the spec references):
+   ```bash
+   node skills/spec-converge/scripts/cross-model-review.mjs \
+     --spec <spec-path> \
+     --context docs/foo.md --context docs/bar.md
+   ```
+   It emits a JSON `ReviewerResult` on stdout: `{ status, framework?, model?, verdict?, findings?, reason?, flag }`. Fold its `findings` into the round alongside the internal reviewers'. `status:'degraded'` (codex present but the call failed — timeout / error / rate-limited) is a *partial* cross-model pass for the round: fold in whatever came back and record the `degraded` flag — it does **not** collapse to `unavailable`.
 
-**Code-backed reviewer — the Standards-Conformance Gate (auto-invoked).** Alongside the eight, call the live gate: `POST /spec/conformance-check` with the spec (body `{ "specPath": "<path-within-specsDir>" }`, or `{ "markdown": "<spec text>" }`). Unlike the prompt-driven reviewers, the gate is *code that reads the living constitution* (`docs/STANDARDS-REGISTRY.md`) and returns a per-standard report — `ok` / `at-risk` / `n/a` + a reason for every standing standard. Fold its `at-risk` entries into the round's findings. It is the structural complement to the Lessons-aware reviewer: lessons-aware reads the lessons doc + local memory (prompt-driven); the gate reads the constitution itself (code), so a registry edit can never be silently missed. **Signal-only:** advisory — it surfaces violations, it does not block (blocking authority is the separate, later `scg-blocking-authority` follow-up, per *Signal vs. Authority*). **Fail-open:** if the gate is disabled/unreachable (503) or returns `degraded: true`, note that the constitutional pass was not authoritative and continue — a down gate must never stall spec review. (This auto-invocation is the dogfood-to-ship enforcement of the **Self-Hosting** standard — the gate now *runs* at spec-review rather than being a step the author must remember.)
+The detection + invocation + parsing live in the unit-tested `src/core/crossModelReviewer.ts` module (built to `dist/core/crossModelReviewer.js`); the script is a thin file-I/O wrapper. codex is the **first** supported framework in an extensible registry (`SUPPORTED_REVIEWER_FRAMEWORKS`) — gemini-cli and others plug in there later with **no skill change**.
+
+Each internal reviewer receives the spec, the architectural context docs referenced in the spec (`docs/signal-vs-authority.md`, `docs/integrated-being.md`, relevant subsystem docs), and a prompt specific to their perspective. Each produces a structured finding list.
+
+The **five internal reviewers + the cross-model external pass** run in parallel (the external pass is one cross-model read through the first available supported framework — the honest mechanism, not three phantom API models). Their findings are collected.
+
+**Code-backed reviewer — the Standards-Conformance Gate (auto-invoked).** Alongside the internal reviewers + the cross-model external pass, call the live gate: `POST /spec/conformance-check` with the spec (body `{ "specPath": "<path-within-specsDir>" }`, or `{ "markdown": "<spec text>" }`). Unlike the prompt-driven reviewers, the gate is *code that reads the living constitution* (`docs/STANDARDS-REGISTRY.md`) and returns a per-standard report — `ok` / `at-risk` / `n/a` + a reason for every standing standard. Fold its `at-risk` entries into the round's findings. It is the structural complement to the Lessons-aware reviewer: lessons-aware reads the lessons doc + local memory (prompt-driven); the gate reads the constitution itself (code), so a registry edit can never be silently missed. **Signal-only:** advisory — it surfaces violations, it does not block (blocking authority is the separate, later `scg-blocking-authority` follow-up, per *Signal vs. Authority*). **Fail-open:** if the gate is disabled/unreachable (503) or returns `degraded: true`, note that the constitutional pass was not authoritative and continue — a down gate must never stall spec review. (This auto-invocation is the dogfood-to-ship enforcement of the **Self-Hosting** standard — the gate now *runs* at spec-review rather than being a step the author must remember.)
 
 **The lessons-aware reviewer is not optional**, even in pattern-instance abbreviated convergence. Abbreviated convergence may skip external models (one round instead of multiple) but must NOT skip the lessons-aware pass — that's the only defense against the circular self-verify problem documented at `feedback_spec_converge_pre_auth_circular`. When a spec author runs convergence on their own spec, the lessons-aware reviewer is the structural check that catches what the author missed.
 
@@ -89,13 +103,13 @@ All **eight** reviewers run in parallel. Their findings are collected.
 
 The skill reads all findings, groups duplicates, prioritizes by severity, and rewrites the spec to address each substantive finding. Trivial/cosmetic findings are noted but may be batched.
 
-The spec update is ONE coherent edit of the spec document — not eight separate patches. The agent treats the findings as a single synthesis input.
+The spec update is ONE coherent edit of the spec document — not one patch per reviewer. The agent treats the findings as a single synthesis input.
 
 Every update preserves the spec's structure. Changes are additive (new sections for new concerns) or rewrites of existing sections (when a finding reveals a design flaw).
 
 ### Phase 3 — Convergence check
 
-After the spec is updated, the skill runs another full review round (all eight reviewers, in parallel, on the updated spec).
+After the spec is updated, the skill runs another full review round (the five internal reviewers + the cross-model external pass, in parallel, on the updated spec).
 
 Convergence criterion: **the new round produces no material new issues.** "Material" means any finding that would require a spec change if unaddressed. Cosmetic findings, repeats of already-addressed concerns, and minor phrasing quibbles are non-material.
 
@@ -106,12 +120,33 @@ A lightweight LLM (Haiku-class) compares the new round's findings to the prior r
 
 Hard cap: 10 iterations. If the skill hits 10 iterations without convergence, it exits with a `convergence-failed` status and a report explaining why. Human input is required before retry.
 
+#### Aggregating per-round cross-model outcomes into ONE spec-level flag
+
+Convergence runs **multiple rounds**, but the spec gets **one** final `cross-model-review:` value. Each round's cross-model pass returns a `ReviewerResult` with a per-round status (`ok` / `degraded` / `unavailable`); the skill **tracks the per-round outcomes** and computes the final flag with `aggregateRoundOutcomes(rounds, { skippedAbbreviated })` (exported from `src/core/crossModelReviewer.ts`). The rule:
+
+- **`skipped-abbreviated`** — the author opted out of the external pass entirely (abbreviated mode). No round attempted it. (Wins over everything; nothing was tried.)
+- **`codex-cli:<model>`** (the clean RAN flag) — **any** round got a successful external pass. One genuine outside opinion is enough to say the spec received real cross-model review; the freshest successful round's flag is used.
+- **`degraded-all-rounds`** — a framework was present in the rounds but **zero** rounds succeeded (every attempt degraded: timeout / error / rate-limited). This is the case the aggregate exists to surface: **"converged having never once received a real external opinion."** It is treated **as loud as `unavailable`** — it must show up at SPEC level (the banner above + the frontmatter flag), not hide in per-round degraded notes.
+- **`unavailable`** — no supported framework was ever available across the rounds.
+
+The point of the aggregate: a spec that degraded on every single round looks, from the per-round notes alone, like it "tried" — but it converged with the SAME assurance as one that had no reviewer at all. `degraded-all-rounds` makes that fact impossible to miss at the spec level. The skill passes the aggregated `flag`/`reason` to `write-convergence-tag.mjs` (Phase 5) and renders the matching banner (Phase 4).
+
 ### Phase 4 — Convergence report
 
 Produce a final report at `docs/specs/reports/<slug>-convergence.md` with the following structure:
 
 ```markdown
 # Convergence Report — <spec title>
+
+## Cross-model review: <STATUS>
+
+[A can't-miss banner stating the external (non-Claude) reviewer posture for this convergence — taken from the FINAL spec-level `cross-model-review:` value (see "Aggregating per-round outcomes" below: a single round produces an `ok`/`degraded`/`unavailable` result, but the SPEC gets one final value). **Every non-ran state carries the loud ⚠ marker** — a non-ran state must NEVER read as a clean pass. One of:
+
+- `## Cross-model review: codex-cli:<model>` — RAN. A real GPT-tier external pass ran through the agent's codex CLI in at least one round. The ONLY state with no ⚠ (it is the clean pass).
+- `## ⚠ Cross-model review: codex-cli:<model> (degraded: <reason>)` — codex is installed but THIS round's call failed (timeout / error / rate-limited); the external pass was partial. State the reason. (Per-round status; if some OTHER round succeeded, the spec-level flag is the clean `codex-cli:<model>` instead.)
+- `## ⚠ Cross-model review: DEGRADED — ALL ROUNDS (degraded-all-rounds)` — codex was present every round but **ZERO rounds succeeded** (every attempt degraded). The spec converged having **never once received a real external opinion** — as loud as UNAVAILABLE. State the last round's reason. The user reads THIS before applying `approved: true`.
+- `## ⚠ Cross-model review: UNAVAILABLE` — no supported external (non-Claude) reviewer was installed/authed. Convergence ran on the internal Claude reviewers + the constitutional gate ONLY. State the specific reason (`codex-not-installed` / `codex-not-authed` / `codex-auth-apikey-forbidden`) and the one-line remediation (`codex login`, or install `@openai/codex`). The user reads THIS before applying `approved: true`, so the reduced-assurance state is an informed choice, not a silent one.
+- `## ⚠ Cross-model review: SKIPPED (abbreviated convergence)` — the author chose the fast path; the framework may be present but was deliberately skipped (the lessons-aware reviewer still ran). This is a **non-ran** state, so it carries the ⚠ too — "I skipped the outside opinion to save cost" must be as visible as "I had no outside opinion available," not a quiet footnote.]
 
 ## ELI10 Overview
 
@@ -147,7 +182,20 @@ review-convergence: "<ISO timestamp>"
 review-iterations: <N>
 review-completed-at: "<ISO timestamp>"
 review-report: "docs/specs/reports/<slug>-convergence.md"
+cross-model-review: "<flag>"          # codex-cli:<model> | unavailable | degraded-all-rounds | skipped-abbreviated
+cross-model-review-reason: "<reason>" # only when unavailable / degraded / degraded-all-rounds
 ```
+
+The `cross-model-review` field records the **final spec-level** external-reviewer posture (the `aggregateRoundOutcomes` result — see "Aggregating per-round cross-model outcomes" in Phase 3) so the spec self-documents which external pass it received (or didn't). Pass it through the tag writer with the aggregated `flag`/`reason` (strip the leading `cross-model-review: ` prefix — the script writes the field name itself):
+
+```bash
+node skills/spec-converge/scripts/write-convergence-tag.mjs \
+  --spec <spec-path> --iterations <N> --report <report-path> \
+  --cross-model-review "codex-cli:gpt-5.5"          # or "unavailable" / "degraded-all-rounds" / "skipped-abbreviated" / "codex-cli:gpt-5.5 (degraded: timeout)"
+  [--cross-model-reason "codex-not-installed"]
+```
+
+This is **DISCLOSURE, not a gate** — it does NOT change `/instar-dev`'s `review-convergence` + `approved: true` enforcement. An `unavailable` spec can still be approved (the user reads the report banner and makes an informed choice).
 
 **Structural prerequisite — ELI16 overview.** Before the convergence tag is written, `skills/spec-converge/scripts/write-convergence-tag.mjs` verifies the spec ships with a plain-English ELI16 companion at `docs/specs/<slug>.eli16.md` (or the path declared via `eli16-overview:` frontmatter). The companion must be at least 800 characters. If the overview is missing or stub-length, convergence is refused — no tag is written. The dense technical spec is for reviewers; the ELI16 overview is the entry point for any reader who has to make a real decision. See `skills/instar-dev/templates/eli16-overview.md` for the expected shape.
 
@@ -163,7 +211,7 @@ The skill does NOT auto-apply `approved: true`. That requires explicit human act
 
 - It does not build code. That's `/instar-dev`'s job, after both tags are present.
 - It does not relax convergence criteria to avoid iteration. 10-iteration cap exists to surface "this design is too confused to review" rather than to force false convergence.
-- It does not skip reviewer perspectives. All eight run on every round.
+- It does not skip reviewer perspectives. The five internal reviewers + the cross-model external pass run on every round (subject to the abbreviated-convergence exception, which still runs the non-skippable lessons-aware reviewer).
 - It does not auto-approve on behalf of the user. Approval is the user's structural contribution to the process.
 
 ## Bootstrap exception
@@ -181,7 +229,7 @@ The convergence check is structural. If the LLM comparator finds new material is
 A smaller finding count is NOT convergence. Convergence is zero material findings in a new round.
 
 ### Skipping a reviewer perspective to ship faster
-All five internal reviewers (security, scalability, adversarial, integration, lessons-aware) AND all three external reviewers run on every round. Skipping is visible in the iteration log and fails the report validation. During pattern-instance abbreviated convergence, the externals (GPT/Gemini/Grok) may be skipped to save cost, but the lessons-aware reviewer MUST run — it's the only structural defense against the spec-converge-pre-auth-circular failure mode.
+All five internal reviewers (security, scalability, adversarial, integration, lessons-aware) AND the cross-model external pass run on every round. Skipping is visible in the iteration log and fails the report validation. During pattern-instance abbreviated convergence, the external cross-model pass may be skipped to save cost — record that honestly as `cross-model-review: skipped-abbreviated` (distinct from `unavailable`: the framework may be present, but the author chose the fast path) — but the lessons-aware reviewer MUST run; it's the only structural defense against the spec-converge-pre-auth-circular failure mode.
 
 ### Rewriting the spec between iterations to hide findings
 Spec edits must address findings, not evade them. The iteration log records both the finding and the resolution. An edit that changes the spec to make the finding "not applicable" without actually solving the concern is caught at the next review round.

--- a/skills/spec-converge/scripts/cross-model-review.mjs
+++ b/skills/spec-converge/scripts/cross-model-review.mjs
@@ -1,0 +1,155 @@
+#!/usr/bin/env node
+/**
+ * cross-model-review.mjs — the thin script /spec-converge calls to run the
+ * external (non-Claude) cross-model reviewer through the agent's own installed
+ * codex CLI (Step B of the tiered development process,
+ * docs/specs/codex-crossreview-stepB-spec.md).
+ *
+ * This is the REAL mechanism that replaces the never-built "/crossreview"
+ * placeholder the skill prose referred to. It is a thin wrapper: all the
+ * detection, prompt-assembly, provider invocation, and result parsing live in
+ * the unit-tested `src/core/crossModelReviewer.ts` module (built to
+ * `dist/core/crossModelReviewer.js`). This script only does the file I/O —
+ * read the spec + referenced context docs from the repo and hand them to the
+ * module — because codex runs read-only in an empty scratch dir with no repo
+ * access, so context must be inlined before the spawn.
+ *
+ * Modes:
+ *   --detect-only            Print detection JSON and exit (no codex spawn).
+ *                            { available, framework?, model?, reason? }
+ *   (default)                Detect; if available, assemble the prompt + run
+ *                            the codex review; print the ReviewerResult JSON.
+ *
+ * Usage:
+ *   node skills/spec-converge/scripts/cross-model-review.mjs \
+ *     --spec docs/specs/<slug>.md \
+ *     [--context docs/foo.md --context docs/bar.md ...] \
+ *     [--detect-only] \
+ *     [--timeout-ms 120000]
+ *
+ * Output: a single JSON object on stdout (machine-readable for the skill).
+ *   On detect-only: the CrossModelDetectionResult.
+ *   On full run:    the ReviewerResult ({ status, framework?, model?, verdict?,
+ *                   findings?, reason?, flag }).
+ *
+ * Exit codes:
+ *   0 — ran successfully (INCLUDING the unavailable/degraded outcomes —
+ *       those are valid disclosed states, never a failure of this script).
+ *   1 — usage error or the spec/template/context file could not be read.
+ *
+ * NEVER blocks convergence: an unavailable or degraded result is printed and
+ * exit 0. The skill reads `status` + `flag` to decide what to record.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+
+const ROOT = path.resolve(new URL('../../..', import.meta.url).pathname);
+const REVIEWER_TEMPLATE_PATH = path.join(
+  ROOT,
+  'skills',
+  'spec-converge',
+  'templates',
+  'reviewer-cross-model.md',
+);
+
+function fail(msg) {
+  console.error(msg);
+  process.exit(1);
+}
+
+function parseArgs() {
+  const args = process.argv.slice(2);
+  const out = { spec: null, context: [], detectOnly: false, timeoutMs: null };
+  for (let i = 0; i < args.length; i++) {
+    const a = args[i];
+    if (a === '--spec') out.spec = args[++i];
+    else if (a === '--context') out.context.push(args[++i]);
+    else if (a === '--detect-only') out.detectOnly = true;
+    else if (a === '--timeout-ms') out.timeoutMs = parseInt(args[++i], 10);
+    else fail(`Unknown arg: ${a}`);
+  }
+  if (!out.detectOnly && !out.spec) {
+    fail(
+      'Usage: cross-model-review.mjs --spec PATH [--context PATH ...] ' +
+        '[--detect-only] [--timeout-ms N]',
+    );
+  }
+  return out;
+}
+
+async function loadModule() {
+  // Import the built module. The dev tooling runs in the instar repo where
+  // `pnpm build` has produced dist/. (If dist is stale, rebuild first.)
+  const modUrl = new URL('../../../dist/core/crossModelReviewer.js', import.meta.url);
+  if (!fs.existsSync(modUrl)) {
+    fail(
+      'dist/core/crossModelReviewer.js not found. Run `pnpm build` (or `npm run build`) ' +
+        'before invoking the cross-model reviewer.',
+    );
+  }
+  return import(modUrl.href);
+}
+
+function readRepoFile(rel) {
+  const abs = path.resolve(ROOT, rel);
+  if (!fs.existsSync(abs)) fail(`File not found: ${rel}`);
+  return fs.readFileSync(abs, 'utf-8');
+}
+
+async function main() {
+  const { spec, context, detectOnly, timeoutMs } = parseArgs();
+  const mod = await loadModule();
+
+  // Detection is the same in both modes.
+  const detection = mod.detectCrossModelReviewer();
+
+  if (detectOnly) {
+    process.stdout.write(JSON.stringify(detection) + '\n');
+    process.exit(0);
+  }
+
+  // Unavailable → print the unavailable flag, exit 0. Never block.
+  if (!detection.available) {
+    const flag = mod.buildCrossModelFlag('unavailable', detection.reason);
+    process.stdout.write(
+      JSON.stringify({ status: 'unavailable', reason: detection.reason, flag: flag.flag }) + '\n',
+    );
+    process.exit(0);
+  }
+
+  // Available → assemble the prompt from disk + run the review.
+  const reviewerTemplate = fs.readFileSync(REVIEWER_TEMPLATE_PATH, 'utf-8');
+  const specMarkdown = readRepoFile(spec);
+  const contextDocs = context.map((rel) => ({ path: rel, content: readRepoFile(rel) }));
+
+  const assembled = mod.assembleReviewerPrompt({
+    reviewerTemplate,
+    specMarkdown,
+    specPath: spec,
+    context: contextDocs,
+  });
+
+  const result = await mod.runCrossModelReview({
+    assembled,
+    ...(Number.isFinite(timeoutMs) ? { timeoutMs } : {}),
+  });
+
+  // Surface truncation in the emitted result so the skill/report can note it.
+  process.stdout.write(JSON.stringify({ ...result, promptTruncated: assembled.truncated }) + '\n');
+  process.exit(0);
+}
+
+main().catch((err) => {
+  // Even an unexpected crash must not block convergence: emit a degraded
+  // result and exit 0 so the skill folds in internal-only + records degraded.
+  const reason = err instanceof Error ? err.message.slice(0, 200) : String(err);
+  process.stdout.write(
+    JSON.stringify({
+      status: 'degraded',
+      reason: `driver-error: ${reason}`,
+      flag: `cross-model-review: codex-cli (degraded: driver-error)`,
+    }) + '\n',
+  );
+  process.exit(0);
+});

--- a/skills/spec-converge/scripts/write-convergence-tag.mjs
+++ b/skills/spec-converge/scripts/write-convergence-tag.mjs
@@ -11,7 +11,29 @@
  *   node skills/spec-converge/scripts/write-convergence-tag.mjs \
  *     --spec docs/specs/<slug>.md \
  *     --iterations 3 \
- *     --report docs/specs/reports/<slug>-convergence.md
+ *     --report docs/specs/reports/<slug>-convergence.md \
+ *     [--cross-model-review "<flag value>"] \
+ *     [--cross-model-reason "<reason>"]
+ *
+ * The optional --cross-model-review flag records the external (non-Claude)
+ * reviewer posture on the spec frontmatter (Step B of the tiered-dev process,
+ * docs/specs/codex-crossreview-stepB-spec.md §2/§4). This is the FINAL
+ * spec-level value the skill computes via aggregateRoundOutcomes() across all
+ * convergence rounds (a single round's status is per-round; the spec gets one).
+ * Valid values:
+ *   - codex-cli:<model>                       (a supported reviewer ran in >=1 round)
+ *   - codex-cli:<model> (degraded: <reason>)  (present but a given round's call failed)
+ *   - degraded-all-rounds                     (present every round, ZERO succeeded —
+ *                                              as loud as unavailable; spec converged
+ *                                              with no real external opinion)
+ *   - unavailable                             (no supported framework)
+ *   - skipped-abbreviated                     (author chose the fast path)
+ * This script does NOT enum-validate the value (it accepts any string and
+ * quotes it safely) — the canonical accepted set lives in crossModelReviewer.ts
+ * (CrossModelFlagStatus) and is documented here for the caller.
+ * It is DISCLOSURE, not a gate — it does not change /instar-dev's
+ * review-convergence + approved enforcement. Idempotent (re-run strips and
+ * rewrites the field, like the review-* fields).
  *
  * Does NOT write `approved: true` — that tag is the user's structural
  * contribution. /spec-converge only ever writes the machine-verifiable
@@ -28,12 +50,20 @@ import { checkEli16Overview } from '../../../scripts/eli16-overview-check.mjs';
 
 function parseArgs() {
   const args = process.argv.slice(2);
-  const out = { spec: null, iterations: null, report: null };
+  const out = {
+    spec: null,
+    iterations: null,
+    report: null,
+    crossModelReview: null,
+    crossModelReason: null,
+  };
   for (let i = 0; i < args.length; i++) {
     const a = args[i];
     if (a === '--spec') out.spec = args[++i];
     else if (a === '--iterations') out.iterations = parseInt(args[++i], 10);
     else if (a === '--report') out.report = args[++i];
+    else if (a === '--cross-model-review') out.crossModelReview = args[++i];
+    else if (a === '--cross-model-reason') out.crossModelReason = args[++i];
     else {
       console.error(`Unknown arg: ${a}`);
       process.exit(1);
@@ -41,14 +71,21 @@ function parseArgs() {
   }
   if (!out.spec || !out.report || !Number.isFinite(out.iterations)) {
     console.error(
-      'Usage: write-convergence-tag.mjs --spec PATH --iterations N --report PATH',
+      'Usage: write-convergence-tag.mjs --spec PATH --iterations N --report PATH ' +
+        '[--cross-model-review VALUE] [--cross-model-reason REASON]',
     );
     process.exit(1);
   }
   return out;
 }
 
-const { spec: specArg, iterations, report: reportArg } = parseArgs();
+const {
+  spec: specArg,
+  iterations,
+  report: reportArg,
+  crossModelReview,
+  crossModelReason,
+} = parseArgs();
 
 const ROOT = path.resolve(new URL('../../..', import.meta.url).pathname);
 const specPath = path.resolve(ROOT, specArg);
@@ -106,7 +143,8 @@ if (!match) {
 }
 const [, fmBody, rest] = match;
 
-// Strip any existing review-convergence / review-iterations / review-completed-at / review-report lines
+// Strip any existing managed lines (review-* chain + cross-model-review chain)
+// so re-runs are idempotent — the field is rewritten, never duplicated.
 const preservedLines = fmBody
   .split('\n')
   .filter(
@@ -114,7 +152,9 @@ const preservedLines = fmBody
       !/^\s*review-convergence\s*:/.test(l) &&
       !/^\s*review-iterations\s*:/.test(l) &&
       !/^\s*review-completed-at\s*:/.test(l) &&
-      !/^\s*review-report\s*:/.test(l),
+      !/^\s*review-report\s*:/.test(l) &&
+      !/^\s*cross-model-review\s*:/.test(l) &&
+      !/^\s*cross-model-review-reason\s*:/.test(l),
   )
   .join('\n')
   .trim();
@@ -124,13 +164,29 @@ const reportRel = path
   .relative(ROOT, reportPath)
   .replace(/\\/g, '/');
 
-const newFm = [
+// Double-quote a YAML scalar value, escaping embedded quotes/backslashes so a
+// flag like `codex-cli:gpt-5.5 (degraded: timeout)` (colon + parens) parses.
+function yamlQuote(v) {
+  return `"${String(v).replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`;
+}
+
+const newFmLines = [
   preservedLines,
   `review-convergence: "${ts}"`,
   `review-iterations: ${iterations}`,
   `review-completed-at: "${ts}"`,
   `review-report: "${reportRel}"`,
-].join('\n');
+];
+
+// Cross-model review posture (Step B). Disclosure-only; additive.
+if (crossModelReview) {
+  newFmLines.push(`cross-model-review: ${yamlQuote(crossModelReview)}`);
+  if (crossModelReason) {
+    newFmLines.push(`cross-model-review-reason: ${yamlQuote(crossModelReason)}`);
+  }
+}
+
+const newFm = newFmLines.join('\n');
 
 const newContent = `---\n${newFm}\n---\n${rest}`;
 fs.writeFileSync(specPath, newContent, 'utf-8');

--- a/skills/spec-converge/templates/reviewer-cross-model.md
+++ b/skills/spec-converge/templates/reviewer-cross-model.md
@@ -1,8 +1,8 @@
 # Reviewer Prompt — Cross-Model External Perspective
 
-You are an EXTERNAL reviewer (non-Claude model: GPT, Gemini, or Grok) auditing an instar spec under convergence review.
+You are an EXTERNAL, non-Claude reviewer (a GPT-tier model) auditing an instar spec under convergence review.
 
-Read the spec at {SPEC_PATH} and any architectural docs it references.
+The spec under review — at the path `{SPEC_PATH}` — and all of its supporting context are **inlined below** in this prompt (you have no filesystem or repo access; do not try to open any file). The spec follows a `--- SPEC UNDER REVIEW: ... ---` marker; any architectural context the spec references follows under `--- CONTEXT: <path> ---` markers. Review only what is inlined here. If a `--- NOTE: referenced context was TRUNCATED ---` marker is present, your view of the supporting docs is partial — flag any finding that depends on context you could not see.
 
 Your perspective is deliberately OUTSIDE the Claude family. You may notice blind spots that Claude models share. Specifically look for:
 

--- a/src/core/crossModelReviewer.ts
+++ b/src/core/crossModelReviewer.ts
@@ -1,0 +1,712 @@
+/**
+ * crossModelReviewer — Step B of the tiered development process.
+ *
+ * Re-platforms the `/spec-converge` external "cross-model" reviewer onto the
+ * agent's own installed `codex` CLI. The external pass that the skill used to
+ * describe as running "via the /crossreview pattern" (a never-built
+ * placeholder) is now a grounded mechanism: detect whether a supported reviewer
+ * framework is installed + authed, assemble the cross-model reviewer prompt
+ * (spec + referenced context, bounded to a budget), and run it THROUGH the
+ * existing `CodexCliIntelligenceProvider` (the factory with
+ * `framework: 'codex-cli'`, model `capable` → GPT-tier).
+ *
+ * Design invariants (see docs/specs/codex-crossreview-stepB-spec.md):
+ *   - Detection is a pure function with injectable inputs (no real spawns in
+ *     unit tests). It is SIGNAL-ONLY — it never throws and never blocks.
+ *   - Reviewer invocation reuses the provider (its scratch-dir clean-notepad,
+ *     env allowlist, `--skip-git-repo-check`, and the account-global circuit
+ *     breaker the factory wraps it in). The ONLY new spawn-adjacent code is
+ *     prompt assembly + result parsing.
+ *   - Every failure mode routes toward internal-only convergence or a captured
+ *     raw finding — never a stall. `unavailable` (no framework) is distinct
+ *     from `degraded` (framework present, this call failed) and
+ *     `skipped-abbreviated` (author chose the fast path).
+ *
+ * codex is the FIRST supported framework; the registry
+ * (`SUPPORTED_REVIEWER_FRAMEWORKS`) is the single seam for gemini-cli and
+ * others to plug in later (Out of Scope here). Adding a framework is one
+ * registry entry + one `id`-union extension — no skill change.
+ */
+
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { detectCodexPath } from './Config.js';
+import { validateRule1 } from '../providers/adapters/openai-codex/credentials.js';
+import { resolveCliModelFlag } from '../providers/adapters/openai-codex/models.js';
+import {
+  buildIntelligenceProvider,
+  type IntelligenceFramework,
+} from './intelligenceProviderFactory.js';
+
+// ── Constants (tunable) ─────────────────────────────────────────────────
+
+/**
+ * Per-call timeout for a cross-model spec review. A reasoning review of a
+ * full spec is far heavier than the provider's 30s judgment-call default, so
+ * Step B bumps it to 120s (spec §2).
+ */
+export const REVIEW_TIMEOUT_MS = 120_000;
+
+/**
+ * Total context budget (spec + referenced docs) inlined into the reviewer
+ * prompt. codex runs in an empty read-only scratch dir with no repo access,
+ * so referenced context MUST be inlined; this bounds the prompt size (spec §2).
+ * The spec is always included in full; referenced context fills the remainder
+ * and is truncated (with a loud note) if it overflows.
+ */
+export const CONTEXT_BUDGET_BYTES = 60 * 1024;
+
+/**
+ * Deterministic priority ordering for referenced context (spec §2, F4).
+ *
+ * When the 60KB budget can't hold every referenced doc, truncation MUST be
+ * deterministic — the same spec + same docs always drop the same docs — so a
+ * review is reproducible and the "what got dropped" note is stable. The
+ * constitutional / lessons docs are the highest-value context for a reviewer
+ * (they're what the lessons-aware internal reviewer reads), so they are kept
+ * FIRST; everything else keeps the spec-declared link order (the order the
+ * caller passed the docs in, which is the order they appear in the spec).
+ *
+ * A doc whose path contains one of these substrings sorts ahead of the rest,
+ * in THIS order. Ties (and all non-priority docs) preserve the caller's order
+ * via a stable sort.
+ */
+export const CONTEXT_PRIORITY_SUBSTRINGS: readonly string[] = [
+  'signal-vs-authority',
+  'INSTAR-DESIGN-PRINCIPLES-AND-LESSONS',
+  'STANDARDS-REGISTRY',
+  'integrated-being',
+] as const;
+
+/**
+ * Return a deterministic priority rank for a context doc path: a small index
+ * for a constitutional/lessons doc (earlier substring = smaller rank), or a
+ * large sentinel for everything else (so non-priority docs keep their relative
+ * order behind the priority ones under a stable sort).
+ */
+function contextPriorityRank(docPath: string): number {
+  const lower = docPath.toLowerCase();
+  for (let i = 0; i < CONTEXT_PRIORITY_SUBSTRINGS.length; i++) {
+    if (lower.includes(CONTEXT_PRIORITY_SUBSTRINGS[i].toLowerCase())) return i;
+  }
+  return CONTEXT_PRIORITY_SUBSTRINGS.length;
+}
+
+/**
+ * Order referenced context deterministically: constitutional/lessons docs
+ * first (per CONTEXT_PRIORITY_SUBSTRINGS), then the caller's spec-declared link
+ * order for the rest. A stable sort on the priority rank achieves both — equal
+ * ranks keep their input order. Pure; never mutates the input.
+ */
+export function orderContextDeterministically(
+  context: readonly ReferencedContextDoc[],
+): ReferencedContextDoc[] {
+  return context
+    .map((doc, idx) => ({ doc, idx, rank: contextPriorityRank(doc.path) }))
+    .sort((a, b) => a.rank - b.rank || a.idx - b.idx)
+    .map((e) => e.doc);
+}
+
+/** The canonical model tier a heavyweight cross-model review requests. */
+const REVIEW_MODEL_TIER = 'capable' as const;
+
+// ── Detection ───────────────────────────────────────────────────────────
+
+/**
+ * Reasons a supported reviewer framework is unavailable. Mirrors the
+ * Rule-1 / auth-probe vocabulary so a report can render a specific
+ * remediation.
+ */
+export type CrossModelUnavailableReason =
+  | 'codex-not-installed'
+  | 'codex-not-authed'
+  | 'codex-auth-apikey-forbidden'
+  | 'no-supported-framework';
+
+export interface CrossModelDetectionResult {
+  available: boolean;
+  /** Present when available; the framework id that will run the review. */
+  framework?: IntelligenceFramework;
+  /** Present when available; the concrete model the review resolves to. */
+  model?: string;
+  /** Present when unavailable; a specific machine-readable reason. */
+  reason?: CrossModelUnavailableReason;
+}
+
+/**
+ * Injectable inputs for `detectCrossModelReviewer` so the detection logic is
+ * unit-testable without real spawns or a real `~/.codex/auth.json`.
+ */
+export interface CrossModelDetectInputs {
+  /**
+   * Path to the codex binary if detected, else null. Defaults to
+   * `detectCodexPath()` (PATH + asdf/nvm-shim resolution).
+   */
+  codexPathDetected?: string | null;
+  /**
+   * Path to the codex auth.json. Defaults to
+   * `${CODEX_HOME || ~/.codex}/auth.json`.
+   */
+  authJsonPath?: string;
+  /** Process env (for the Rule-1 OPENAI_API_KEY probe). Defaults to process.env. */
+  env?: NodeJS.ProcessEnv;
+  /** Clock injection for the Rule-1 killswitch sunset check. */
+  now?: Date;
+}
+
+/** Resolve the default codex auth.json path (CODEX_HOME-aware). */
+function defaultAuthJsonPath(env: NodeJS.ProcessEnv): string {
+  const home = env['CODEX_HOME'] || path.join(os.homedir(), '.codex');
+  return path.join(home, 'auth.json');
+}
+
+/**
+ * Is the codex auth.json an OAuth (`tokens.access_token`) shape? This is the
+ * subscription-OAuth shape D3 requires. A missing / unreadable / malformed
+ * file → false (not authed). Uses the same probe shape as the codex smoketest.
+ */
+function authHasOAuthAccessToken(authJsonPath: string): boolean {
+  try {
+    const raw = fs.readFileSync(authJsonPath, 'utf-8');
+    const parsed = JSON.parse(raw) as { tokens?: { access_token?: unknown } };
+    return typeof parsed?.tokens?.access_token === 'string' && parsed.tokens.access_token.length > 0;
+  } catch {
+    // missing / unreadable / malformed → not authed.
+    return false;
+  }
+}
+
+/**
+ * Detect a codex reviewer. Returns `{ available: true, framework, model }`
+ * iff ALL of: codex binary detected, OAuth `access_token` present, Rule-1
+ * clean (no raw API key in env or auth.json). Any miss → a specific reason.
+ *
+ * Pure-ish: all external inputs are injectable. With no inputs it probes the
+ * real host. It NEVER throws.
+ */
+export function detectCodexReviewer(
+  inputs: CrossModelDetectInputs = {},
+): CrossModelDetectionResult {
+  const env = inputs.env ?? process.env;
+  const now = inputs.now ?? new Date();
+  const codexPath = inputs.codexPathDetected !== undefined ? inputs.codexPathDetected : detectCodexPath();
+  const authJsonPath = inputs.authJsonPath ?? defaultAuthJsonPath(env);
+
+  // 1. Binary present?
+  if (!codexPath) {
+    return { available: false, reason: 'codex-not-installed' };
+  }
+
+  // 2. Rule-1 clean? (API-key forbidden — env OPENAI_API_KEY or auth.json
+  //    API-key shape). Reuses existing policy rather than inventing one.
+  const rule1 = validateRule1(env, authJsonPath, now);
+  if (!rule1.ok) {
+    // The killswitch-expired / apikey-detected codes all collapse to the same
+    // policy outcome here: a forbidden credential shape → reviewer unavailable.
+    return { available: false, reason: 'codex-auth-apikey-forbidden' };
+  }
+
+  // 3. Authed via subscription OAuth?
+  if (!authHasOAuthAccessToken(authJsonPath)) {
+    return { available: false, reason: 'codex-not-authed' };
+  }
+
+  return {
+    available: true,
+    framework: 'codex-cli',
+    model: resolveCliModelFlag(REVIEW_MODEL_TIER),
+  };
+}
+
+// ── Supported-reviewer registry (the extension point) ───────────────────
+
+export interface ReviewerResult {
+  /** Outcome class for the cross-model pass. */
+  status: 'ok' | 'degraded' | 'unavailable';
+  /** The framework that ran (or would have run). */
+  framework?: IntelligenceFramework;
+  /** Concrete model used. */
+  model?: string;
+  /** Parsed verdict, when the review returned. */
+  verdict?: ReviewVerdict;
+  /** Structured findings (one record), folded alongside internal reviewers. */
+  findings?: ReviewFinding[];
+  /** A reason string for degraded/unavailable outcomes. */
+  reason?: string;
+  /** The flag string that gets written to frontmatter + the report banner. */
+  flag: string;
+}
+
+export type ReviewVerdict = 'CLEAN' | 'MINOR ISSUES' | 'SERIOUS ISSUES' | 'UNKNOWN';
+
+export interface ReviewFinding {
+  /** Reviewer tag, e.g. 'cross-model:codex-cli:gpt-5.5'. */
+  reviewer: string;
+  verdict: ReviewVerdict;
+  /** The findings body (verbatim text the reviewer produced). */
+  body: string;
+  /** True when the reply could not be parsed into a verdict (captured raw). */
+  unstructured?: boolean;
+}
+
+interface SupportedReviewerFramework {
+  /** Extend this union (in the type below) to add a framework. */
+  id: IntelligenceFramework;
+  /** Detection — does this framework's reviewer have what it needs to run? */
+  detect(inputs?: CrossModelDetectInputs): CrossModelDetectionResult;
+  /**
+   * Run the review: assemble already done by the caller; this builds the
+   * provider, evaluates the prompt, and parses the result. Returns a
+   * ReviewerResult (never throws — failures map to a degraded result).
+   */
+  review(args: ReviewerInvokeArgs): Promise<ReviewerResult>;
+}
+
+export interface ReviewerInvokeArgs {
+  /** The fully-assembled cross-model reviewer prompt (prompt + spec + context). */
+  promptText: string;
+  /** Per-call timeout. */
+  timeoutMs: number;
+  /**
+   * Optional provider override — tests inject a stub so no real codex spawn
+   * happens. Production passes nothing and the factory builds the real one.
+   */
+  providerOverride?: { evaluate(prompt: string, options?: { model?: 'fast' | 'balanced' | 'capable'; timeoutMs?: number }): Promise<string> };
+}
+
+/**
+ * The codex reviewer entry. Detection delegates to `detectCodexReviewer`;
+ * `review` routes through the factory-built `CodexCliIntelligenceProvider`.
+ */
+const codexReviewer: SupportedReviewerFramework = {
+  id: 'codex-cli',
+  detect: (inputs) => detectCodexReviewer(inputs),
+  review: async (args) => {
+    const detection = detectCodexReviewer();
+    const model = detection.model ?? resolveCliModelFlag(REVIEW_MODEL_TIER);
+    const tag = `cross-model:codex-cli:${model}`;
+
+    // Build (or accept an injected) provider. The factory wraps it in the
+    // account-global circuit breaker, so a rate-limited review degrades the
+    // same way every other instar LLM call does.
+    const provider =
+      args.providerOverride ??
+      buildIntelligenceProvider({ framework: 'codex-cli' });
+
+    if (!provider) {
+      // Binary vanished between detect and review (or detection said
+      // unavailable and review was called anyway). Degraded, not a throw.
+      return {
+        status: 'degraded',
+        framework: 'codex-cli',
+        model,
+        reason: 'provider-unavailable',
+        flag: `cross-model-review: codex-cli:${model} (degraded: provider-unavailable)`,
+      };
+    }
+
+    let raw: string;
+    try {
+      raw = await provider.evaluate(args.promptText, {
+        model: REVIEW_MODEL_TIER,
+        timeoutMs: args.timeoutMs,
+      });
+    } catch (err) {
+      const reason = classifyReviewFailure(err);
+      return {
+        status: 'degraded',
+        framework: 'codex-cli',
+        model,
+        reason,
+        flag: `cross-model-review: codex-cli:${model} (degraded: ${reason})`,
+      };
+    }
+
+    const parsed = parseReviewerReply(raw, tag);
+    return {
+      status: 'ok',
+      framework: 'codex-cli',
+      model,
+      verdict: parsed.verdict,
+      findings: [parsed],
+      flag: `cross-model-review: codex-cli:${model}`,
+    };
+  },
+};
+
+/**
+ * The supported-reviewer registry. codex first — the order IS the preference
+ * order. gemini-cli and others land here as later steps (Out of Scope).
+ */
+export const SUPPORTED_REVIEWER_FRAMEWORKS: SupportedReviewerFramework[] = [codexReviewer];
+
+/**
+ * Walk the registry in preference order and return the FIRST available
+ * framework's detection result. If none is available, returns the codex
+ * reason when there's exactly one entry (so the report can be specific), else
+ * the generic `no-supported-framework`.
+ *
+ * SIGNAL-ONLY: never throws, never blocks. A `false` simply routes the skill
+ * to the internal-only fallback (spec §4).
+ */
+export function detectCrossModelReviewer(
+  inputs: CrossModelDetectInputs = {},
+): CrossModelDetectionResult {
+  for (const framework of SUPPORTED_REVIEWER_FRAMEWORKS) {
+    const result = framework.detect(inputs);
+    if (result.available) return result;
+  }
+  // Nothing available. Surface the single framework's specific reason when
+  // there's only one entry (codex today); otherwise the generic reason.
+  if (SUPPORTED_REVIEWER_FRAMEWORKS.length === 1) {
+    return SUPPORTED_REVIEWER_FRAMEWORKS[0].detect(inputs);
+  }
+  return { available: false, reason: 'no-supported-framework' };
+}
+
+// ── Failure classification ──────────────────────────────────────────────
+
+/**
+ * Map a provider rejection into a coarse `degraded` reason. The provider
+ * surfaces timeouts, non-zero exits, and (via the circuit breaker) rate
+ * limits as thrown Errors; we classify on the message text the same way the
+ * rate-limit classifier does.
+ */
+export function classifyReviewFailure(err: unknown): string {
+  const msg = err instanceof Error ? err.message : String(err);
+  const lower = msg.toLowerCase();
+  if (/circuit breaker|rate.?limit|usage limit|quota|429|too many requests/.test(lower)) {
+    return 'rate-limited';
+  }
+  if (/timed out|timeout|etimedout|killed/.test(lower)) {
+    return 'timeout';
+  }
+  return 'error';
+}
+
+// ── Reviewer reply parsing ──────────────────────────────────────────────
+
+/**
+ * Parse a reviewer reply into a structured finding. The prompt mandates a
+ * `Verdict: CLEAN | MINOR ISSUES | SERIOUS ISSUES` line + a findings list. If
+ * the verdict line is unparseable (or the reply is blank), the whole reply is
+ * captured as one raw "unstructured external review — read manually" finding
+ * (never dropped, never thrown, never zero).
+ */
+export function parseReviewerReply(raw: string, reviewerTag: string): ReviewFinding {
+  const text = (raw ?? '').trim();
+  if (!text) {
+    return {
+      reviewer: reviewerTag,
+      verdict: 'UNKNOWN',
+      body: '(empty reviewer reply — codex returned no output; read manually)',
+      unstructured: true,
+    };
+  }
+
+  const verdict = extractVerdict(text);
+  if (verdict === 'UNKNOWN') {
+    return {
+      reviewer: reviewerTag,
+      verdict: 'UNKNOWN',
+      body: `unstructured external review — read manually:\n${text}`,
+      unstructured: true,
+    };
+  }
+
+  return {
+    reviewer: reviewerTag,
+    verdict,
+    body: text,
+  };
+}
+
+/**
+ * Extract the verdict from a reviewer reply. Looks for a `Verdict:` line and
+ * matches one of the three canonical values (case-insensitive, tolerant of
+ * surrounding markdown like `**Verdict: SERIOUS ISSUES**`). Returns 'UNKNOWN'
+ * when none is found.
+ */
+function extractVerdict(text: string): ReviewVerdict {
+  // Find a line mentioning "Verdict" and inspect its content.
+  const verdictLine = text
+    .split('\n')
+    .find((l) => /verdict/i.test(l));
+  const haystack = (verdictLine ?? text).toUpperCase();
+  // Order matters: check the most specific multi-word verdicts first.
+  if (haystack.includes('SERIOUS ISSUES')) return 'SERIOUS ISSUES';
+  if (haystack.includes('MINOR ISSUES')) return 'MINOR ISSUES';
+  if (haystack.includes('CLEAN')) return 'CLEAN';
+  return 'UNKNOWN';
+}
+
+// ── Prompt assembly ─────────────────────────────────────────────────────
+
+export interface ReferencedContextDoc {
+  /** Repo-relative path used as the `--- CONTEXT: <path> ---` header. */
+  path: string;
+  /** The doc's contents (already read by the caller). */
+  content: string;
+}
+
+export interface AssemblePromptInputs {
+  /** Contents of skills/spec-converge/templates/reviewer-cross-model.md. */
+  reviewerTemplate: string;
+  /** The full spec markdown. */
+  specMarkdown: string;
+  /** Repo-relative spec path, substituted for {SPEC_PATH} in the template. */
+  specPath: string;
+  /** Referenced architectural context docs (same set internal reviewers see). */
+  context?: ReferencedContextDoc[];
+  /** Total budget in bytes. Defaults to CONTEXT_BUDGET_BYTES. */
+  budgetBytes?: number;
+}
+
+export interface AssembledPrompt {
+  /** The final prompt string fed to the provider. */
+  promptText: string;
+  /** True when referenced context had to be truncated to fit the budget. */
+  truncated: boolean;
+  /** Byte size of the assembled prompt. */
+  bytes: number;
+}
+
+/**
+ * Assemble the cross-model reviewer prompt: the reviewer template (with
+ * `{SPEC_PATH}` substituted) + the full spec + as much referenced context as
+ * fits the budget. codex runs with NO repo access, so context is inlined under
+ * `--- CONTEXT: <path> ---` headers. The spec is ALWAYS included in full; if
+ * referenced docs overflow the budget, they are truncated and a loud
+ * truncation note is added so the reviewer knows its view was partial (a
+ * silently-truncated review is a trap; a disclosed-partial one is still signal).
+ *
+ * Truncation is DETERMINISTIC (spec §2, F4): referenced docs are ordered by
+ * `orderContextDeterministically` (constitutional/lessons docs first, then the
+ * spec-declared link order) BEFORE the budget walk, so the same spec + docs
+ * always drop the same docs. When a doc is fully or partially dropped, the
+ * truncation note NAMES the affected docs (which were partial, which were fully
+ * omitted) — a reviewer must know exactly which context it could not see, not
+ * just that "something" was cut.
+ */
+export function assembleReviewerPrompt(inputs: AssemblePromptInputs): AssembledPrompt {
+  const budget = inputs.budgetBytes ?? CONTEXT_BUDGET_BYTES;
+  const template = inputs.reviewerTemplate.replace(/\{SPEC_PATH\}/g, inputs.specPath);
+
+  const header = `${template}\n\n--- SPEC UNDER REVIEW: ${inputs.specPath} ---\n${inputs.specMarkdown}\n`;
+
+  const parts: string[] = [header];
+  let used = Buffer.byteLength(header, 'utf-8');
+  let truncated = false;
+
+  // Deterministic priority order: constitutional/lessons docs first, then the
+  // spec-declared link order. Same inputs always drop the same docs.
+  const context = orderContextDeterministically(inputs.context ?? []);
+
+  // Track exactly which docs were partially included vs fully dropped so the
+  // truncation note can NAME them (F4 — a named-partial review is signal; a
+  // "something was cut" review is a trap).
+  let partialDoc: string | null = null;
+  const droppedDocs: string[] = [];
+
+  for (let i = 0; i < context.length; i++) {
+    const doc = context[i];
+    const docHeader = `\n--- CONTEXT: ${doc.path} ---\n`;
+    const docBlock = `${docHeader}${doc.content}\n`;
+    const docBytes = Buffer.byteLength(docBlock, 'utf-8');
+
+    if (!truncated && used + docBytes <= budget) {
+      parts.push(docBlock);
+      used += docBytes;
+      continue;
+    }
+
+    // Budget exceeded at this doc. Include as much of THIS doc as the remaining
+    // budget allows (header always; body sliced), record it as PARTIAL, then
+    // mark every remaining doc as fully DROPPED. We do NOT break — we keep
+    // walking so the note can name all the dropped docs, not just the first.
+    if (!truncated) {
+      const remaining = budget - used - Buffer.byteLength(docHeader, 'utf-8');
+      if (remaining > 0) {
+        // Slice by bytes safely (avoid splitting a multibyte char by slicing
+        // the buffer then decoding with replacement tolerated).
+        const sliced = Buffer.from(doc.content, 'utf-8').subarray(0, remaining).toString('utf-8');
+        parts.push(`${docHeader}${sliced}`);
+        partialDoc = doc.path;
+      } else {
+        // Not even the header fits — this doc is fully dropped too.
+        droppedDocs.push(doc.path);
+      }
+      truncated = true;
+      continue;
+    }
+
+    // Already truncated — every subsequent doc is fully omitted.
+    droppedDocs.push(doc.path);
+  }
+
+  if (truncated) {
+    const detail: string[] = [];
+    if (partialDoc) detail.push(`PARTIAL (cut mid-document): ${partialDoc}`);
+    if (droppedDocs.length > 0) detail.push(`FULLY OMITTED: ${droppedDocs.join(', ')}`);
+    const named = detail.length > 0 ? ` ${detail.join('. ')}.` : '';
+    parts.push(
+      '\n\n--- NOTE: referenced context was TRUNCATED to fit the review budget.' +
+        named +
+        ' Your view of the supporting docs is PARTIAL — flag any finding that ' +
+        'depends on context you could not see. ---\n',
+    );
+  }
+
+  const promptText = parts.join('');
+  return {
+    promptText,
+    truncated,
+    bytes: Buffer.byteLength(promptText, 'utf-8'),
+  };
+}
+
+// ── Fallback flag helpers ───────────────────────────────────────────────
+
+/**
+ * The discrete cross-model review outcome states the report + frontmatter
+ * record. Distinct so "you have no cross-model reviewer" reads differently
+ * from "your reviewer was rate-limited this round" from "you chose the fast
+ * path" from "the framework was present but NOT ONE round ever succeeded".
+ *
+ * `degraded-all-rounds` (spec §2/§4, F2) is the SPEC-LEVEL aggregate: a single
+ * round's `degraded` lives on a ReviewerResult, but convergence runs many
+ * rounds and the spec gets ONE final `cross-model-review:` value. When a
+ * framework was present every round but ZERO rounds produced a successful
+ * external pass (all degraded), the final flag is `degraded-all-rounds` —
+ * treated as loud as `unavailable`, because the spec converged having never
+ * once received a real external opinion. This must surface at SPEC level, not
+ * hide in per-round notes.
+ */
+export type CrossModelFlagStatus =
+  | 'available'
+  | 'unavailable'
+  | 'degraded'
+  | 'degraded-all-rounds'
+  | 'skipped-abbreviated';
+
+export interface CrossModelFlag {
+  status: CrossModelFlagStatus;
+  /** The `cross-model-review:` frontmatter value. */
+  flag: string;
+  /** Optional `cross-model-review-reason:` value. */
+  reason?: string;
+}
+
+/**
+ * Build the fallback flag for the unavailable / skipped / degraded-all-rounds
+ * states. (The available and per-round degraded flags come back on the
+ * ReviewerResult.) Centralizes the exact strings the frontmatter writer +
+ * report banner consume.
+ *
+ * `degraded-all-rounds` is the spec-level aggregate the skill writes when a
+ * framework was present but no round ever succeeded (see
+ * `aggregateRoundOutcomes`).
+ */
+export function buildCrossModelFlag(
+  status: 'unavailable' | 'skipped-abbreviated' | 'degraded-all-rounds',
+  reason?: string,
+): CrossModelFlag {
+  if (status === 'unavailable') {
+    return { status, flag: 'cross-model-review: unavailable', reason };
+  }
+  if (status === 'degraded-all-rounds') {
+    return { status, flag: 'cross-model-review: degraded-all-rounds', reason };
+  }
+  return { status, flag: 'cross-model-review: skipped-abbreviated', reason };
+}
+
+/**
+ * Aggregate per-round cross-model outcomes into the ONE final spec-level flag
+ * (spec §2/§4, F2). Convergence runs multiple rounds; each round yields a
+ * `ReviewerResult` (`ok` / `degraded` / `unavailable`). The skill collects the
+ * per-round statuses and calls this to decide what `write-convergence-tag.mjs`
+ * stamps:
+ *
+ *   - `skipped-abbreviated` if the author opted out (passed explicitly) — wins
+ *     over everything, since no external pass was attempted by choice.
+ *   - `codex-cli:<model>` (the LAST successful round's flag) if ANY round got a
+ *     real external pass — one genuine outside opinion is enough to say the spec
+ *     received cross-model review.
+ *   - `degraded-all-rounds` if a framework was present every round but ZERO
+ *     rounds succeeded (all degraded) — as loud as `unavailable`.
+ *   - `unavailable` if no framework was ever available (all rounds unavailable).
+ *
+ * Returns the `{ flag, reason }` the tag writer + report banner consume.
+ */
+export function aggregateRoundOutcomes(
+  rounds: ReviewerResult[],
+  opts: { skippedAbbreviated?: boolean } = {},
+): CrossModelFlag {
+  if (opts.skippedAbbreviated) {
+    return buildCrossModelFlag('skipped-abbreviated');
+  }
+  if (rounds.length === 0) {
+    // No rounds recorded at all — treat as no external reviewer available.
+    return buildCrossModelFlag('unavailable', 'no-rounds-recorded');
+  }
+
+  // Any successful round → the spec received a real external opinion. Use the
+  // LAST successful round's flag (the freshest pass on the most-converged spec).
+  const successful = rounds.filter((r) => r.status === 'ok');
+  if (successful.length > 0) {
+    const last = successful[successful.length - 1];
+    return { status: 'available', flag: last.flag, ...(last.reason ? { reason: last.reason } : {}) };
+  }
+
+  // No successes. Was a framework ever present? If ANY round degraded (vs
+  // unavailable), the framework was there but never delivered → all-rounds.
+  const anyDegraded = rounds.some((r) => r.status === 'degraded');
+  if (anyDegraded) {
+    // Surface the most recent degraded reason for the `-reason` field.
+    const lastDegraded = [...rounds].reverse().find((r) => r.status === 'degraded');
+    return buildCrossModelFlag('degraded-all-rounds', lastDegraded?.reason);
+  }
+
+  // Every round was unavailable (no framework, ever).
+  const lastUnavailable = [...rounds].reverse().find((r) => r.status === 'unavailable');
+  return buildCrossModelFlag('unavailable', lastUnavailable?.reason);
+}
+
+/**
+ * The high-level entry the skill driver calls: detect, and if available run
+ * the first available framework's reviewer with the assembled prompt;
+ * otherwise return the `unavailable` flag. NEVER throws, NEVER blocks.
+ *
+ * `assembled` is produced by `assembleReviewerPrompt`. `detectInputs` and
+ * `providerOverride` exist for tests; production omits them.
+ */
+export async function runCrossModelReview(args: {
+  assembled: AssembledPrompt;
+  timeoutMs?: number;
+  detectInputs?: CrossModelDetectInputs;
+  providerOverride?: ReviewerInvokeArgs['providerOverride'];
+}): Promise<ReviewerResult> {
+  const detection = detectCrossModelReviewer(args.detectInputs);
+  if (!detection.available) {
+    const flag = buildCrossModelFlag('unavailable', detection.reason);
+    return {
+      status: 'unavailable',
+      reason: detection.reason,
+      flag: flag.flag,
+    };
+  }
+
+  const framework = SUPPORTED_REVIEWER_FRAMEWORKS.find((f) => f.id === detection.framework);
+  if (!framework) {
+    // Defensive: detection named a framework with no registry entry.
+    const flag = buildCrossModelFlag('unavailable', 'no-supported-framework');
+    return { status: 'unavailable', reason: 'no-supported-framework', flag: flag.flag };
+  }
+
+  return framework.review({
+    promptText: args.assembled.promptText,
+    timeoutMs: args.timeoutMs ?? REVIEW_TIMEOUT_MS,
+    ...(args.providerOverride ? { providerOverride: args.providerOverride } : {}),
+  });
+}

--- a/tests/integration/cross-model-review-flow.test.ts
+++ b/tests/integration/cross-model-review-flow.test.ts
@@ -1,0 +1,213 @@
+// safe-git-allow: test-tmpdir-cleanup — afterEach removes per-test mkdtempSync tmpdir.
+/**
+ * Integration — the cross-model review flow end-to-end (Step B).
+ *
+ * Proves the WIRING the unit tests don't: the convergence-review flow that
+ * /spec-converge runs — detect → assemble prompt from on-disk spec+context →
+ * run the cross-model reviewer → fold the result into the round → stamp the
+ * frontmatter + render the report banner. The codex provider is STUBBED (no
+ * real codex spawn in CI); the real `codex exec` command is already exercised
+ * by the existing CodexCliIntelligenceProvider tests, so this verifies the
+ * Step-B wiring, not codex itself.
+ *
+ * Three flows per the spec §Testing:
+ *   1. codex present  → findings folded in, flag/banner read codex-cli:<model>,
+ *      frontmatter gets `cross-model-review: "codex-cli:gpt-5.5"`.
+ *   2. codex absent   → unavailable flag, round completes internal-only,
+ *      report carries the UNAVAILABLE banner, spec is STILL taggable.
+ *   3. degraded       → provider rejects; flag reads `degraded: <reason>`, does
+ *      NOT collapse to unavailable.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+  detectCrossModelReviewer,
+  assembleReviewerPrompt,
+  runCrossModelReview,
+  buildCrossModelFlag,
+  type ReviewerResult,
+} from '../../src/core/crossModelReviewer.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, '..', '..');
+const TAG_SCRIPT = path.join(
+  REPO_ROOT,
+  'skills',
+  'spec-converge',
+  'scripts',
+  'write-convergence-tag.mjs',
+);
+const REVIEWER_TEMPLATE = fs.readFileSync(
+  path.join(REPO_ROOT, 'skills', 'spec-converge', 'templates', 'reviewer-cross-model.md'),
+  'utf-8',
+);
+
+let tmpDir: string;
+let specPath: string;
+let reportPath: string;
+let authPath: string;
+
+const SPEC_MARKDOWN = `# Cross-model test spec
+
+## Problem statement
+We need an external reviewer.
+
+## Proposed design
+Route it through codex.
+`;
+
+const ELI16 = 'overview '.repeat(120); // > 800 chars
+
+// A canned structured review (what codex would return).
+function stubProvider(reply: string) {
+  return { evaluate: async () => reply };
+}
+function throwingProvider(err: Error) {
+  return { evaluate: async () => { throw err; } };
+}
+
+// Render the report banner line from a ReviewerResult, mirroring how the
+// skill's Phase 4 builds the banner from the returned flag.
+function renderBanner(result: ReviewerResult): string {
+  if (result.status === 'unavailable') {
+    return `## ⚠ Cross-model review: UNAVAILABLE (${result.reason ?? 'unknown'})`;
+  }
+  if (result.status === 'degraded') {
+    return `## ⚠ Cross-model review: ${result.framework}:${result.model} (degraded: ${result.reason})`;
+  }
+  return `## Cross-model review: ${result.framework}:${result.model}`;
+}
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'crossmodel-flow-'));
+  specPath = path.join(tmpDir, 'cm-spec.md');
+  reportPath = path.join(tmpDir, 'cm-spec-convergence.md');
+  authPath = path.join(tmpDir, 'auth.json');
+  fs.writeFileSync(
+    specPath,
+    `---\ntitle: "CM spec"\nslug: "cm-spec"\nauthor: "test"\n---\n\n${SPEC_MARKDOWN}`,
+    'utf-8',
+  );
+  fs.writeFileSync(path.join(tmpDir, 'cm-spec.eli16.md'), ELI16, 'utf-8');
+  fs.writeFileSync(reportPath, '# Convergence report\n', 'utf-8');
+  fs.writeFileSync(authPath, JSON.stringify({ tokens: { access_token: 'oauth-token' } }), 'utf-8');
+});
+
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+function stampTag(result: ReviewerResult): void {
+  // Strip the `cross-model-review: ` prefix from the flag the same way the
+  // skill does before handing the value to the tag writer.
+  const flagValue = result.flag.replace(/^cross-model-review:\s*/, '');
+  const args = [
+    TAG_SCRIPT,
+    '--spec', specPath,
+    '--iterations', '2',
+    '--report', reportPath,
+    '--cross-model-review', flagValue,
+  ];
+  if (result.reason && result.status === 'unavailable') {
+    args.push('--cross-model-reason', result.reason);
+  }
+  execFileSync(process.execPath, args, { encoding: 'utf-8' });
+}
+
+describe('cross-model review flow — codex PRESENT', () => {
+  it('folds external findings in, flags codex-cli:<model>, stamps frontmatter + banner', async () => {
+    const assembled = assembleReviewerPrompt({
+      reviewerTemplate: REVIEWER_TEMPLATE,
+      specMarkdown: SPEC_MARKDOWN,
+      specPath: 'docs/specs/cm-spec.md',
+      context: [{ path: 'docs/signal-vs-authority.md', content: 'signal vs authority doc body' }],
+    });
+    // The assembled prompt inlines the spec + the referenced context.
+    expect(assembled.promptText).toContain('signal vs authority doc body');
+    expect(assembled.promptText).toContain('We need an external reviewer.');
+
+    const result = await runCrossModelReview({
+      assembled,
+      detectInputs: { codexPathDetected: '/usr/bin/codex', authJsonPath: authPath, env: {} },
+      providerOverride: stubProvider(
+        'Verdict: MINOR ISSUES\n- §"Proposed design" — name the timeout constant.',
+      ),
+    });
+
+    expect(result.status).toBe('ok');
+    expect(result.framework).toBe('codex-cli');
+    expect(result.model).toBe('gpt-5.5');
+    expect(result.findings).toHaveLength(1);
+    expect(result.findings![0].verdict).toBe('MINOR ISSUES');
+    expect(result.flag).toBe('cross-model-review: codex-cli:gpt-5.5');
+
+    // Report banner.
+    expect(renderBanner(result)).toBe('## Cross-model review: codex-cli:gpt-5.5');
+
+    // Frontmatter stamp.
+    stampTag(result);
+    const out = fs.readFileSync(specPath, 'utf-8');
+    expect(out).toMatch(/cross-model-review:\s*"codex-cli:gpt-5\.5"/);
+    expect(out).toMatch(/review-convergence:/);
+  });
+});
+
+describe('cross-model review flow — codex ABSENT', () => {
+  it('returns unavailable, completes internal-only, banner reads UNAVAILABLE, spec STILL taggable (never blocks)', async () => {
+    const detection = detectCrossModelReviewer({ codexPathDetected: null, env: {} });
+    expect(detection.available).toBe(false);
+    expect(detection.reason).toBe('codex-not-installed');
+
+    const result = await runCrossModelReview({
+      assembled: { promptText: 'unused', truncated: false, bytes: 6 },
+      detectInputs: { codexPathDetected: null, env: {} },
+    });
+    expect(result.status).toBe('unavailable');
+    expect(result.flag).toBe('cross-model-review: unavailable');
+
+    // Report banner shows the can't-miss UNAVAILABLE form.
+    expect(renderBanner(result)).toContain('UNAVAILABLE');
+    expect(renderBanner(result)).toContain('codex-not-installed');
+
+    // Convergence is STILL taggable — the unavailable flag never blocks.
+    stampTag(result);
+    const out = fs.readFileSync(specPath, 'utf-8');
+    expect(out).toMatch(/cross-model-review:\s*"unavailable"/);
+    expect(out).toMatch(/cross-model-review-reason:\s*"codex-not-installed"/);
+    expect(out).toMatch(/review-convergence:/);
+
+    // The fallback flag helper agrees with the runtime result.
+    expect(buildCrossModelFlag('unavailable', 'codex-not-installed').flag).toBe(
+      'cross-model-review: unavailable',
+    );
+  });
+});
+
+describe('cross-model review flow — DEGRADED', () => {
+  it('provider rejects → degraded flag, does NOT collapse to unavailable, still taggable', async () => {
+    const result = await runCrossModelReview({
+      assembled: { promptText: 'PROMPT', truncated: false, bytes: 6 },
+      detectInputs: { codexPathDetected: '/usr/bin/codex', authJsonPath: authPath, env: {} },
+      providerOverride: throwingProvider(new Error('Codex CLI error: timed out')),
+    });
+
+    expect(result.status).toBe('degraded');
+    expect(result.reason).toBe('timeout');
+    expect(result.flag).toBe('cross-model-review: codex-cli:gpt-5.5 (degraded: timeout)');
+    // Crucially NOT unavailable — the framework IS present.
+    expect(result.status).not.toBe('unavailable');
+
+    expect(renderBanner(result)).toContain('degraded: timeout');
+
+    // Degraded is still taggable (disclosure, not a gate).
+    stampTag(result);
+    const out = fs.readFileSync(specPath, 'utf-8');
+    expect(out).toMatch(/cross-model-review:\s*"codex-cli:gpt-5\.5 \(degraded: timeout\)"/);
+    expect(out).toMatch(/review-convergence:/);
+  });
+});

--- a/tests/unit/crossModelReviewer.test.ts
+++ b/tests/unit/crossModelReviewer.test.ts
@@ -1,0 +1,552 @@
+// safe-git-allow: test-tmpdir-cleanup — afterEach removes per-test mkdtempSync tmpdir.
+/**
+ * Unit tests for crossModelReviewer (Step B of the tiered development process).
+ *
+ * Covers, per docs/specs/codex-crossreview-stepB-spec.md §Testing:
+ *   - Detection: true/false branches (not-installed, not-authed,
+ *     apikey-forbidden via env + auth.json shape, available).
+ *   - Registry: walk returns the first available framework; unavailable →
+ *     specific reason.
+ *   - The 3 fallback states (unavailable / degraded / skipped-abbreviated).
+ *   - Driver parse: well-formed verdict vs unparseable → one raw finding.
+ *   - Prompt assembly + the size budget (full spec always included; context
+ *     truncated with a loud note when it overflows).
+ *
+ * NO real codex spawns — detection uses injected inputs, invocation uses a
+ * stubbed provider override.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import {
+  detectCodexReviewer,
+  detectCrossModelReviewer,
+  SUPPORTED_REVIEWER_FRAMEWORKS,
+  parseReviewerReply,
+  assembleReviewerPrompt,
+  orderContextDeterministically,
+  buildCrossModelFlag,
+  aggregateRoundOutcomes,
+  classifyReviewFailure,
+  runCrossModelReview,
+  CONTEXT_BUDGET_BYTES,
+  CONTEXT_PRIORITY_SUBSTRINGS,
+  REVIEW_TIMEOUT_MS,
+  type ReviewerResult,
+} from '../../src/core/crossModelReviewer.js';
+
+// ── helpers ──────────────────────────────────────────────────────────────
+
+let tmpDir: string;
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'crossmodel-test-'));
+});
+
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+function writeAuth(json: unknown): string {
+  const p = path.join(tmpDir, 'auth.json');
+  fs.writeFileSync(p, JSON.stringify(json), 'utf-8');
+  return p;
+}
+
+const OAUTH_AUTH = { tokens: { access_token: 'oauth-access-token-value' } };
+
+// A stub provider that returns a canned reply (or throws a canned error).
+function stubProvider(reply: string) {
+  return { evaluate: async () => reply };
+}
+function throwingProvider(err: Error) {
+  return {
+    evaluate: async () => {
+      throw err;
+    },
+  };
+}
+
+// ── Detection ──────────────────────────────────────────────────────────────
+
+describe('detectCodexReviewer', () => {
+  it('returns codex-not-installed when the binary is missing', () => {
+    const r = detectCodexReviewer({ codexPathDetected: null, env: {} });
+    expect(r).toEqual({ available: false, reason: 'codex-not-installed' });
+  });
+
+  it('returns available with model when binary present + OAuth access_token present', () => {
+    const authPath = writeAuth(OAUTH_AUTH);
+    const r = detectCodexReviewer({
+      codexPathDetected: '/usr/bin/codex',
+      authJsonPath: authPath,
+      env: {},
+    });
+    expect(r.available).toBe(true);
+    expect(r.framework).toBe('codex-cli');
+    // capable tier → gpt-5.5 per models.ts (the concrete id stays owned there).
+    expect(r.model).toBe('gpt-5.5');
+  });
+
+  it('returns codex-not-authed when auth.json is missing', () => {
+    const r = detectCodexReviewer({
+      codexPathDetected: '/usr/bin/codex',
+      authJsonPath: path.join(tmpDir, 'does-not-exist.json'),
+      env: {},
+    });
+    expect(r).toEqual({ available: false, reason: 'codex-not-authed' });
+  });
+
+  it('returns codex-not-authed when auth.json is malformed', () => {
+    const p = path.join(tmpDir, 'auth.json');
+    fs.writeFileSync(p, '{ this is not json', 'utf-8');
+    const r = detectCodexReviewer({
+      codexPathDetected: '/usr/bin/codex',
+      authJsonPath: p,
+      env: {},
+    });
+    expect(r).toEqual({ available: false, reason: 'codex-not-authed' });
+  });
+
+  it('returns codex-not-authed when auth.json lacks tokens.access_token', () => {
+    const authPath = writeAuth({ tokens: {} });
+    const r = detectCodexReviewer({
+      codexPathDetected: '/usr/bin/codex',
+      authJsonPath: authPath,
+      env: {},
+    });
+    expect(r).toEqual({ available: false, reason: 'codex-not-authed' });
+  });
+
+  it('returns codex-auth-apikey-forbidden when OPENAI_API_KEY is set in env (Rule-1 reuse)', () => {
+    const authPath = writeAuth(OAUTH_AUTH);
+    const r = detectCodexReviewer({
+      codexPathDetected: '/usr/bin/codex',
+      authJsonPath: authPath,
+      env: { OPENAI_API_KEY: 'sk-live-something' },
+    });
+    expect(r).toEqual({ available: false, reason: 'codex-auth-apikey-forbidden' });
+  });
+
+  it('returns codex-auth-apikey-forbidden when auth.json is API-key shape (sk-)', () => {
+    const authPath = writeAuth({ OPENAI_API_KEY: 'sk-abcdef1234567890' });
+    const r = detectCodexReviewer({
+      codexPathDetected: '/usr/bin/codex',
+      authJsonPath: authPath,
+      env: {},
+    });
+    expect(r).toEqual({ available: false, reason: 'codex-auth-apikey-forbidden' });
+  });
+
+  it('never throws on any input', () => {
+    expect(() => detectCodexReviewer({ codexPathDetected: undefined, env: {} })).not.toThrow();
+  });
+});
+
+// ── Registry walk ────────────────────────────────────────────────────────
+
+describe('detectCrossModelReviewer (registry walk)', () => {
+  it('has codex as the first (and currently only) registry entry', () => {
+    expect(SUPPORTED_REVIEWER_FRAMEWORKS.length).toBeGreaterThanOrEqual(1);
+    expect(SUPPORTED_REVIEWER_FRAMEWORKS[0].id).toBe('codex-cli');
+  });
+
+  it('returns the first available framework', () => {
+    const authPath = writeAuth(OAUTH_AUTH);
+    const r = detectCrossModelReviewer({
+      codexPathDetected: '/usr/bin/codex',
+      authJsonPath: authPath,
+      env: {},
+    });
+    expect(r.available).toBe(true);
+    expect(r.framework).toBe('codex-cli');
+  });
+
+  it('returns the specific codex reason when nothing is available (single-entry registry)', () => {
+    const r = detectCrossModelReviewer({ codexPathDetected: null, env: {} });
+    expect(r.available).toBe(false);
+    // single-entry registry surfaces codex's own reason, not a generic one.
+    expect(r.reason).toBe('codex-not-installed');
+  });
+});
+
+// ── Fallback states ──────────────────────────────────────────────────────
+
+describe('buildCrossModelFlag (fallback states)', () => {
+  it('builds the unavailable flag with a reason', () => {
+    const f = buildCrossModelFlag('unavailable', 'codex-not-installed');
+    expect(f.status).toBe('unavailable');
+    expect(f.flag).toBe('cross-model-review: unavailable');
+    expect(f.reason).toBe('codex-not-installed');
+  });
+
+  it('builds the skipped-abbreviated flag (distinct from unavailable)', () => {
+    const f = buildCrossModelFlag('skipped-abbreviated');
+    expect(f.status).toBe('skipped-abbreviated');
+    expect(f.flag).toBe('cross-model-review: skipped-abbreviated');
+  });
+
+  it('builds the degraded-all-rounds flag (spec-level aggregate, F2)', () => {
+    const f = buildCrossModelFlag('degraded-all-rounds', 'rate-limited');
+    expect(f.status).toBe('degraded-all-rounds');
+    expect(f.flag).toBe('cross-model-review: degraded-all-rounds');
+    expect(f.reason).toBe('rate-limited');
+  });
+});
+
+// ── Spec-level aggregation across rounds (F2) ────────────────────────────
+
+describe('aggregateRoundOutcomes (F2 — one final spec-level flag)', () => {
+  const ok = (model = 'gpt-5.5'): ReviewerResult => ({
+    status: 'ok',
+    framework: 'codex-cli',
+    model,
+    flag: `cross-model-review: codex-cli:${model}`,
+  });
+  const degraded = (reason: string): ReviewerResult => ({
+    status: 'degraded',
+    framework: 'codex-cli',
+    model: 'gpt-5.5',
+    reason,
+    flag: `cross-model-review: codex-cli:gpt-5.5 (degraded: ${reason})`,
+  });
+  const unavailable = (reason = 'codex-not-installed'): ReviewerResult => ({
+    status: 'unavailable',
+    reason,
+    flag: 'cross-model-review: unavailable',
+  });
+
+  it('any successful round → the clean codex-cli flag (one real opinion is enough)', () => {
+    const f = aggregateRoundOutcomes([degraded('timeout'), ok(), degraded('rate-limited')]);
+    expect(f.status).toBe('available');
+    expect(f.flag).toBe('cross-model-review: codex-cli:gpt-5.5');
+  });
+
+  it('uses the LAST successful round flag when multiple rounds succeed', () => {
+    const f = aggregateRoundOutcomes([ok('gpt-5.4'), ok('gpt-5.5')]);
+    expect(f.flag).toBe('cross-model-review: codex-cli:gpt-5.5');
+  });
+
+  it('framework present every round but ZERO succeeded → degraded-all-rounds (as loud as unavailable)', () => {
+    const f = aggregateRoundOutcomes([degraded('timeout'), degraded('rate-limited')]);
+    expect(f.status).toBe('degraded-all-rounds');
+    expect(f.flag).toBe('cross-model-review: degraded-all-rounds');
+    // last degraded reason carried through for the -reason field
+    expect(f.reason).toBe('rate-limited');
+  });
+
+  it('all rounds unavailable (no framework ever) → unavailable, NOT degraded-all-rounds', () => {
+    const f = aggregateRoundOutcomes([unavailable(), unavailable()]);
+    expect(f.status).toBe('unavailable');
+    expect(f.flag).toBe('cross-model-review: unavailable');
+    expect(f.reason).toBe('codex-not-installed');
+  });
+
+  it('skippedAbbreviated wins over everything (author opted out)', () => {
+    const f = aggregateRoundOutcomes([ok(), degraded('timeout')], { skippedAbbreviated: true });
+    expect(f.status).toBe('skipped-abbreviated');
+    expect(f.flag).toBe('cross-model-review: skipped-abbreviated');
+  });
+
+  it('empty rounds → unavailable (nothing was recorded)', () => {
+    const f = aggregateRoundOutcomes([]);
+    expect(f.status).toBe('unavailable');
+    expect(f.reason).toBe('no-rounds-recorded');
+  });
+
+  it('a single degraded round (framework present, never succeeded) → degraded-all-rounds', () => {
+    const f = aggregateRoundOutcomes([degraded('timeout')]);
+    expect(f.status).toBe('degraded-all-rounds');
+    expect(f.reason).toBe('timeout');
+  });
+});
+
+describe('classifyReviewFailure (degraded reasons)', () => {
+  it('classifies rate-limit / circuit-breaker errors as rate-limited', () => {
+    expect(classifyReviewFailure(new Error('LLM circuit breaker is open'))).toBe('rate-limited');
+    expect(classifyReviewFailure(new Error('429 Too Many Requests'))).toBe('rate-limited');
+    expect(classifyReviewFailure(new Error('usage limit reached'))).toBe('rate-limited');
+  });
+
+  it('classifies timeouts as timeout', () => {
+    expect(classifyReviewFailure(new Error('Command timed out'))).toBe('timeout');
+    expect(classifyReviewFailure(new Error('ETIMEDOUT'))).toBe('timeout');
+  });
+
+  it('falls back to generic error', () => {
+    expect(classifyReviewFailure(new Error('Codex CLI error: nonzero exit'))).toBe('error');
+    expect(classifyReviewFailure('weird non-error throw')).toBe('error');
+  });
+});
+
+describe('runCrossModelReview — the three outcome states', () => {
+  const assembled = { promptText: 'PROMPT', truncated: false, bytes: 6 };
+
+  it('unavailable: no framework → status unavailable, never throws/blocks', async () => {
+    const r = await runCrossModelReview({
+      assembled,
+      detectInputs: { codexPathDetected: null, env: {} },
+    });
+    expect(r.status).toBe('unavailable');
+    expect(r.flag).toBe('cross-model-review: unavailable');
+    expect(r.reason).toBe('codex-not-installed');
+  });
+
+  it('ok: available + provider returns a structured review → status ok with findings', async () => {
+    const authPath = writeAuth(OAUTH_AUTH);
+    const r = await runCrossModelReview({
+      assembled,
+      detectInputs: { codexPathDetected: '/usr/bin/codex', authJsonPath: authPath, env: {} },
+      providerOverride: stubProvider(
+        'Verdict: SERIOUS ISSUES\n- §2 the timeout default is too low.\n- §3 registry typing.',
+      ),
+    });
+    expect(r.status).toBe('ok');
+    expect(r.framework).toBe('codex-cli');
+    expect(r.model).toBe('gpt-5.5');
+    expect(r.verdict).toBe('SERIOUS ISSUES');
+    expect(r.findings).toHaveLength(1);
+    expect(r.findings![0].reviewer).toBe('cross-model:codex-cli:gpt-5.5');
+    expect(r.flag).toBe('cross-model-review: codex-cli:gpt-5.5');
+  });
+
+  it('degraded: available but the provider throws → status degraded, does NOT collapse to unavailable', async () => {
+    const authPath = writeAuth(OAUTH_AUTH);
+    const r = await runCrossModelReview({
+      assembled,
+      detectInputs: { codexPathDetected: '/usr/bin/codex', authJsonPath: authPath, env: {} },
+      providerOverride: throwingProvider(new Error('Command timed out after 120000ms')),
+    });
+    expect(r.status).toBe('degraded');
+    expect(r.reason).toBe('timeout');
+    expect(r.flag).toBe('cross-model-review: codex-cli:gpt-5.5 (degraded: timeout)');
+  });
+
+  it('degraded: rate-limited provider error classifies as rate-limited', async () => {
+    const authPath = writeAuth(OAUTH_AUTH);
+    const r = await runCrossModelReview({
+      assembled,
+      detectInputs: { codexPathDetected: '/usr/bin/codex', authJsonPath: authPath, env: {} },
+      providerOverride: throwingProvider(new Error('circuit breaker open — usage limit')),
+    });
+    expect(r.status).toBe('degraded');
+    expect(r.reason).toBe('rate-limited');
+  });
+
+  it('uses REVIEW_TIMEOUT_MS as the default and 120s is the spec value', () => {
+    expect(REVIEW_TIMEOUT_MS).toBe(120_000);
+  });
+});
+
+// ── Driver parse ────────────────────────────────────────────────────────
+
+describe('parseReviewerReply', () => {
+  const tag = 'cross-model:codex-cli:gpt-5.5';
+
+  it('parses a well-formed reply into a structured finding', () => {
+    const f = parseReviewerReply(
+      'Verdict: MINOR ISSUES\n- §4 wording could be tighter.',
+      tag,
+    );
+    expect(f.verdict).toBe('MINOR ISSUES');
+    expect(f.unstructured).toBeUndefined();
+    expect(f.reviewer).toBe(tag);
+    expect(f.body).toContain('§4');
+  });
+
+  it('handles markdown-decorated verdict lines (**Verdict: CLEAN**)', () => {
+    const f = parseReviewerReply('**Verdict: CLEAN** — looks good.', tag);
+    expect(f.verdict).toBe('CLEAN');
+  });
+
+  it('prefers the most specific verdict (SERIOUS over the substring ISSUES)', () => {
+    const f = parseReviewerReply('Verdict: SERIOUS ISSUES', tag);
+    expect(f.verdict).toBe('SERIOUS ISSUES');
+  });
+
+  it('captures an unparseable reply as exactly one raw finding (never zero, never thrown)', () => {
+    const f = parseReviewerReply('I think this design is mostly fine, no clear verdict here.', tag);
+    expect(f.verdict).toBe('UNKNOWN');
+    expect(f.unstructured).toBe(true);
+    expect(f.body).toContain('unstructured external review');
+  });
+
+  it('captures an empty reply as one raw finding', () => {
+    const f = parseReviewerReply('   ', tag);
+    expect(f.verdict).toBe('UNKNOWN');
+    expect(f.unstructured).toBe(true);
+    expect(f.body).toContain('empty reviewer reply');
+  });
+});
+
+// ── Prompt assembly + budget ─────────────────────────────────────────────
+
+describe('assembleReviewerPrompt', () => {
+  const template = 'Review the spec at {SPEC_PATH}. Be terse.';
+  const specMarkdown = '# Spec\n\nThis is the spec body.';
+
+  it('substitutes {SPEC_PATH} and includes the full spec', () => {
+    const a = assembleReviewerPrompt({
+      reviewerTemplate: template,
+      specMarkdown,
+      specPath: 'docs/specs/foo.md',
+    });
+    expect(a.promptText).toContain('Review the spec at docs/specs/foo.md');
+    expect(a.promptText).toContain('This is the spec body.');
+    expect(a.truncated).toBe(false);
+  });
+
+  it('inlines referenced context under CONTEXT headers', () => {
+    const a = assembleReviewerPrompt({
+      reviewerTemplate: template,
+      specMarkdown,
+      specPath: 'docs/specs/foo.md',
+      context: [
+        { path: 'docs/a.md', content: 'alpha content' },
+        { path: 'docs/b.md', content: 'beta content' },
+      ],
+    });
+    expect(a.promptText).toContain('--- CONTEXT: docs/a.md ---');
+    expect(a.promptText).toContain('alpha content');
+    expect(a.promptText).toContain('--- CONTEXT: docs/b.md ---');
+    expect(a.promptText).toContain('beta content');
+    expect(a.truncated).toBe(false);
+  });
+
+  it('truncates context that overflows the budget and adds a loud note', () => {
+    const bigDoc = 'X'.repeat(5000);
+    const a = assembleReviewerPrompt({
+      reviewerTemplate: template,
+      specMarkdown,
+      specPath: 'docs/specs/foo.md',
+      context: [
+        { path: 'docs/big1.md', content: bigDoc },
+        { path: 'docs/big2.md', content: bigDoc },
+      ],
+      budgetBytes: 1024, // tiny budget forces truncation
+    });
+    expect(a.truncated).toBe(true);
+    expect(a.promptText).toContain('referenced context was TRUNCATED');
+    // The spec is ALWAYS included even when context is dropped.
+    expect(a.promptText).toContain('This is the spec body.');
+  });
+
+  it('always includes the full spec even when context alone exceeds the budget', () => {
+    const huge = 'Y'.repeat(200_000);
+    const a = assembleReviewerPrompt({
+      reviewerTemplate: template,
+      specMarkdown,
+      specPath: 'docs/specs/foo.md',
+      context: [{ path: 'docs/huge.md', content: huge }],
+      budgetBytes: 2048,
+    });
+    expect(a.promptText).toContain('This is the spec body.');
+    expect(a.truncated).toBe(true);
+  });
+
+  it('defaults to the 60KB context budget', () => {
+    expect(CONTEXT_BUDGET_BYTES).toBe(60 * 1024);
+  });
+
+  // ── F4 — deterministic truncation: priority order + NAMED dropped docs ──
+
+  it('orders constitutional/lessons context FIRST regardless of caller order, then drops the rest deterministically', () => {
+    const big = 'Z'.repeat(4000);
+    // Pass the constitutional doc LAST in caller order; it must still be kept
+    // (sorted first) while the earlier ordinary docs get dropped.
+    const a = assembleReviewerPrompt({
+      reviewerTemplate: template,
+      specMarkdown,
+      specPath: 'docs/specs/foo.md',
+      context: [
+        { path: 'docs/ordinary-a.md', content: big },
+        { path: 'docs/ordinary-b.md', content: big },
+        { path: 'docs/signal-vs-authority.md', content: 'CONSTITUTIONAL-MARKER ' + big },
+      ],
+      budgetBytes: 4500, // room for the header + ~one doc
+    });
+    expect(a.truncated).toBe(true);
+    // The priority doc was KEPT even though it was passed last.
+    expect(a.promptText).toContain('--- CONTEXT: docs/signal-vs-authority.md ---');
+    expect(a.promptText).toContain('CONSTITUTIONAL-MARKER');
+  });
+
+  it('NAMES the dropped docs in the truncation note (not just "truncated")', () => {
+    const big = 'Q'.repeat(4000);
+    const a = assembleReviewerPrompt({
+      reviewerTemplate: template,
+      specMarkdown,
+      specPath: 'docs/specs/foo.md',
+      context: [
+        { path: 'docs/signal-vs-authority.md', content: 'short kept doc' },
+        { path: 'docs/partial-one.md', content: big },
+        { path: 'docs/dropped-two.md', content: big },
+        { path: 'docs/dropped-three.md', content: big },
+      ],
+      // Budget holds the header + spec + the short priority doc, then cuts the
+      // first big doc mid-document and fully omits the rest.
+      budgetBytes: 800,
+    });
+    expect(a.truncated).toBe(true);
+    // The note must name which doc was partial and which were fully omitted.
+    expect(a.promptText).toContain('PARTIAL (cut mid-document): docs/partial-one.md');
+    expect(a.promptText).toContain('FULLY OMITTED:');
+    expect(a.promptText).toContain('docs/dropped-two.md');
+    expect(a.promptText).toContain('docs/dropped-three.md');
+    // The kept priority doc must NOT appear in the dropped list.
+    expect(a.promptText).not.toMatch(/FULLY OMITTED:[^\n]*signal-vs-authority/);
+  });
+
+  it('is deterministic — identical inputs produce byte-identical prompts (including the drop list)', () => {
+    const big = 'D'.repeat(4000);
+    const mk = () =>
+      assembleReviewerPrompt({
+        reviewerTemplate: template,
+        specMarkdown,
+        specPath: 'docs/specs/foo.md',
+        context: [
+          { path: 'docs/x.md', content: big },
+          { path: 'docs/INSTAR-DESIGN-PRINCIPLES-AND-LESSONS.md', content: big },
+          { path: 'docs/y.md', content: big },
+        ],
+        budgetBytes: 5000,
+      });
+    expect(mk().promptText).toBe(mk().promptText);
+  });
+});
+
+describe('orderContextDeterministically (F4)', () => {
+  it('sorts constitutional/lessons docs ahead, preserving caller order within each group (stable)', () => {
+    const ordered = orderContextDeterministically([
+      { path: 'docs/zeta.md', content: '' },
+      { path: 'docs/INSTAR-DESIGN-PRINCIPLES-AND-LESSONS.md', content: '' },
+      { path: 'docs/alpha.md', content: '' },
+      { path: 'docs/signal-vs-authority.md', content: '' },
+    ]);
+    // signal-vs-authority is priority index 0, lessons doc is index 1 →
+    // signal first, then lessons, then the two ordinary docs in caller order.
+    expect(ordered.map((d) => d.path)).toEqual([
+      'docs/signal-vs-authority.md',
+      'docs/INSTAR-DESIGN-PRINCIPLES-AND-LESSONS.md',
+      'docs/zeta.md',
+      'docs/alpha.md',
+    ]);
+  });
+
+  it('is a pure function — does not mutate the input array', () => {
+    const input = [
+      { path: 'docs/a.md', content: '' },
+      { path: 'docs/signal-vs-authority.md', content: '' },
+    ];
+    const snapshot = input.map((d) => d.path);
+    orderContextDeterministically(input);
+    expect(input.map((d) => d.path)).toEqual(snapshot);
+  });
+
+  it('exposes a non-empty, stable priority list with the constitutional docs', () => {
+    expect(CONTEXT_PRIORITY_SUBSTRINGS.length).toBeGreaterThan(0);
+    expect(CONTEXT_PRIORITY_SUBSTRINGS).toContain('signal-vs-authority');
+  });
+});

--- a/tests/unit/write-convergence-tag-crossmodel.test.ts
+++ b/tests/unit/write-convergence-tag-crossmodel.test.ts
@@ -1,0 +1,129 @@
+// safe-git-allow: test-tmpdir-cleanup — afterEach removes per-test mkdtempSync tmpdir.
+/**
+ * Unit test for the cross-model-review frontmatter emission in
+ * skills/spec-converge/scripts/write-convergence-tag.mjs (Step B §4).
+ *
+ * Verifies the tag writer:
+ *   - writes `cross-model-review: "codex-cli:gpt-5.5"` when passed the available flag,
+ *   - writes `cross-model-review: "unavailable"` + a `-reason` when unavailable,
+ *   - is idempotent (re-run strips + rewrites the field, like the review-* chain),
+ *   - omits the cross-model field entirely when no flag is passed (backwards-compat).
+ *
+ * Drives the real .mjs script via execFile (no real codex). Paths are absolute,
+ * so the script's `path.resolve(ROOT, ...)` resolves to our tmp fixtures.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, '..', '..');
+const SCRIPT = path.join(
+  REPO_ROOT,
+  'skills',
+  'spec-converge',
+  'scripts',
+  'write-convergence-tag.mjs',
+);
+
+let tmpDir: string;
+let specPath: string;
+let reportPath: string;
+
+const SPEC_BODY = `---
+title: "Test spec"
+slug: "test-spec"
+author: "test"
+---
+
+# Test spec
+
+## Problem statement
+A thing.
+
+## Proposed design
+Another thing.
+`;
+
+// ELI16 companion must be >= 800 chars or the script refuses to tag.
+const ELI16_BODY = 'x'.repeat(900);
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'convtag-test-'));
+  specPath = path.join(tmpDir, 'test-spec.md');
+  reportPath = path.join(tmpDir, 'test-spec-convergence.md');
+  fs.writeFileSync(specPath, SPEC_BODY, 'utf-8');
+  // sibling eli16 companion: <basename>.eli16.md
+  fs.writeFileSync(path.join(tmpDir, 'test-spec.eli16.md'), ELI16_BODY, 'utf-8');
+  fs.writeFileSync(reportPath, '# Convergence report\n', 'utf-8');
+});
+
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+function runTag(extraArgs: string[]): void {
+  execFileSync(
+    process.execPath,
+    [
+      SCRIPT,
+      '--spec',
+      specPath,
+      '--iterations',
+      '3',
+      '--report',
+      reportPath,
+      ...extraArgs,
+    ],
+    { encoding: 'utf-8' },
+  );
+}
+
+describe('write-convergence-tag.mjs cross-model-review field', () => {
+  it('writes cross-model-review when passed the available flag', () => {
+    runTag(['--cross-model-review', 'codex-cli:gpt-5.5']);
+    const out = fs.readFileSync(specPath, 'utf-8');
+    expect(out).toMatch(/cross-model-review:\s*"codex-cli:gpt-5\.5"/);
+    expect(out).toMatch(/review-convergence:/);
+  });
+
+  it('writes cross-model-review: unavailable + a reason', () => {
+    runTag([
+      '--cross-model-review',
+      'unavailable',
+      '--cross-model-reason',
+      'codex-not-installed',
+    ]);
+    const out = fs.readFileSync(specPath, 'utf-8');
+    expect(out).toMatch(/cross-model-review:\s*"unavailable"/);
+    expect(out).toMatch(/cross-model-review-reason:\s*"codex-not-installed"/);
+  });
+
+  it('quotes a degraded value containing a colon + parens so YAML stays valid', () => {
+    runTag(['--cross-model-review', 'codex-cli:gpt-5.5 (degraded: timeout)']);
+    const out = fs.readFileSync(specPath, 'utf-8');
+    expect(out).toMatch(/cross-model-review:\s*"codex-cli:gpt-5\.5 \(degraded: timeout\)"/);
+  });
+
+  it('is idempotent — a second run rewrites, not duplicates, the field', () => {
+    runTag(['--cross-model-review', 'unavailable', '--cross-model-reason', 'codex-not-installed']);
+    runTag(['--cross-model-review', 'codex-cli:gpt-5.5']);
+    const out = fs.readFileSync(specPath, 'utf-8');
+    const occurrences = (out.match(/^cross-model-review:/gm) ?? []).length;
+    expect(occurrences).toBe(1);
+    expect(out).toMatch(/cross-model-review:\s*"codex-cli:gpt-5\.5"/);
+    // the stale reason from the first run must be gone
+    expect(out).not.toMatch(/cross-model-review-reason:/);
+  });
+
+  it('omits the cross-model field when no flag is passed (backwards-compat)', () => {
+    runTag([]);
+    const out = fs.readFileSync(specPath, 'utf-8');
+    expect(out).not.toMatch(/cross-model-review:/);
+    expect(out).toMatch(/review-convergence:/);
+  });
+});

--- a/upgrades/next/codex-crossreview-stepB.md
+++ b/upgrades/next/codex-crossreview-stepB.md
@@ -1,0 +1,36 @@
+# Upgrade Guide — vNEXT
+
+<!-- bump: patch -->
+
+## What Changed
+
+Spec-review-convergence's external **cross-model reviewer** is now real and framework-native:
+instead of a placeholder API path, it detects the installed **codex CLI** and runs a
+GPT-tier second opinion through the existing hardened codex provider — so any instar agent
+with codex gets cross-model review for free, no API keys. When no supported reviewer is
+installed (or a call fails, or convergence is abbreviated) the spec carries a loud,
+honest `cross-model-review:` flag; the review is **signal, never a gate**. Step B of the
+tiered-development project.
+
+## What to Tell Your User
+
+Nothing to do — this only affects how the agent reviews its own instar specs. Specs now get
+a real outside-model opinion when codex is present, and a clearly-marked note when they
+don't, so a spec that never got an external review can't quietly look like it did.
+
+## Summary of New Capabilities
+
+- `src/core/crossModelReviewer.ts` — codex-CLI reviewer detection + a supported-reviewer
+  registry + the reviewer driver (via the existing codex provider) + the honest flag
+  machinery (`codex-cli:<model>` / `degraded` / `degraded-all-rounds` / `unavailable` /
+  `skipped-abbreviated`), with deterministic, named context truncation.
+- `skills/spec-converge/scripts/cross-model-review.mjs` — the CLI the convergence skill
+  calls; `write-convergence-tag.mjs` gains `--cross-model-review`; `SKILL.md` + the reviewer
+  prompt template now describe the real, inlined-context, single-codex-pass mechanism.
+
+## Evidence
+
+- `npx tsc --noEmit` exit 0; Step-B tests 53 green (45 + 5 unit, 3 integration); `npm run
+  lint` green. Detection live-validated on this host: `{"available":true,
+  "framework":"codex-cli","model":"gpt-5.5"}`.
+- Dev-only tooling: `/spec-converge` is not shipped to end-agent homes, so no migration.

--- a/upgrades/side-effects/codex-crossreview-stepB.md
+++ b/upgrades/side-effects/codex-crossreview-stepB.md
@@ -1,0 +1,83 @@
+# Side-Effects Review — Cross-model review on the codex CLI (Step B)
+
+**Slug:** `codex-crossreview-stepB`
+**Date:** 2026-06-01
+**Author:** echo
+**Spec:** `docs/specs/codex-crossreview-stepB-spec.md` (approved by Justin + abbreviated convergence, 5 findings folded)
+**Project:** Step B of the Tiered Development Process (`docs/projects/tiered-dev-process/PROJECT.md`)
+
+## Summary of the change
+
+Re-platforms the external **cross-model reviewer** in spec-review-convergence from the
+(placeholder) `/crossreview` API path onto the **installed codex CLI**, so every instar
+agent with codex gets a GPT-tier second opinion for free, no API keys. Honors the
+constitution's **Signal vs. Authority** — the external review is *signal*, never a
+blocking authority; an absent/failed reviewer is disclosed loudly, never faked.
+
+**Files changed (in-scope):**
+- `src/core/crossModelReviewer.ts` (NEW) — detection (`detectCodexReviewer` /
+  `detectCrossModelReviewer`: codex binary present AND OAuth `tokens.access_token` AND
+  Rule-1 clean), the `SUPPORTED_REVIEWER_FRAMEWORKS` registry (codex first; one entry per
+  future framework), the reviewer driver (routes the cross-model prompt through the
+  existing `buildIntelligenceProvider({framework:'codex-cli'})` → gpt-5.5, 120s, reusing
+  the provider's env allowlist + the factory circuit breaker), `assembleReviewerPrompt`
+  (inlines the spec in full + referenced context under a 60KB budget with **deterministic**
+  priority order — constitutional docs first — and a truncation note that **names** the
+  partial + omitted docs), `parseReviewerReply` (never throws/zeroes), and the flag
+  machinery: `buildCrossModelFlag` + `aggregateRoundOutcomes` producing one of
+  `codex-cli:<model>` (ran) / `degraded` / `degraded-all-rounds` / `unavailable` /
+  `skipped-abbreviated`. Never throws, never blocks.
+- `skills/spec-converge/scripts/cross-model-review.mjs` (NEW) — the thin CLI the skill
+  shells out to (does only repo file-I/O — codex is sandboxed with no repo access —
+  delegating logic to compiled `dist/core/crossModelReviewer.js`; always exits 0).
+- `skills/spec-converge/scripts/write-convergence-tag.mjs` — `--cross-model-review` /
+  `--cross-model-reason` args writing the `cross-model-review:` frontmatter field
+  (idempotent, YAML-safe quoting).
+- `skills/spec-converge/SKILL.md` — replaced the `/crossreview` placeholder with the real
+  invocation; Phase 3 documents per-round aggregation (→ `degraded-all-rounds` when a
+  framework was present but **zero** rounds got a successful pass); Phase 4 renders a loud
+  `⚠` banner for **every** non-ran state (a real pass is the only unmarked one); Phase 5
+  the valid flag values. Internal reviewers + the Standards-Conformance Gate unchanged.
+
+**Files changed (not in-scope):** `skills/spec-converge/templates/reviewer-cross-model.md`
+(patched: spec + context are "inlined below" — no file-read instruction codex can't
+follow — and dropped the three-phantom-model GPT/Gemini/Grok framing → one codex pass);
+the spec + ELI16; tests (`tests/unit/crossModelReviewer.test.ts` 45,
+`tests/unit/write-convergence-tag-crossmodel.test.ts` 5,
+`tests/integration/cross-model-review-flow.test.ts` 3).
+
+## Blast radius
+
+Additive. The new module is pure/injectable except the one provider call (reusing the
+hardened codex provider). The convergence flow gains a real external reviewer where it had
+a placeholder; the internal reviewers, the lessons-aware (non-skippable) reviewer, and the
+Standards-Conformance gate are untouched. The reviewer never throws and never blocks — the
+worst case is a loudly-disclosed `unavailable` / `degraded` / `degraded-all-rounds` flag.
+The `cross-model-review:` flag is **disclosure, not a gate**: it does NOT touch the
+`review-convergence` + `approved` enforcement in `instar-dev-precommit.js`.
+
+## Risks considered
+
+- **Could a failed/absent review read as a clean pass?** No (convergence Finding 1/2): every
+  non-ran state carries a loud `⚠` banner, and a convergence where a framework was present
+  but *no* round ever succeeded collapses to a spec-level `degraded-all-rounds` (as loud as
+  `unavailable`) — "never actually got an external opinion" surfaces at spec level.
+- **Silent partial context?** No (Finding 4): truncation is deterministic (constitutional
+  docs first) and the note names the partial + fully-omitted docs.
+- **API-key leak through codex?** No — reuses `buildCodexChildEnv()`'s allowlist; Rule-1
+  (`validateRule1`) forbids an API-key-shaped credential; detection requires OAuth.
+- **Cost?** Worst case ~10 capable-tier calls per spec (the 10-round convergence cap × 1
+  call/round), bounded by the account circuit breaker. Stated in the spec.
+
+## Migration parity
+
+**None needed — verified.** `/spec-converge` is dev-only tooling: it is NOT in
+`package.json` `files[]` and NOT installed by `installBuiltinSkills()`, so it never lands
+in an end-agent home. No `PostUpdateMigrator` change. (The agents that *develop* instar get
+it from the repo.)
+
+## Tests / lint
+
+`npx tsc --noEmit` exit 0; Step-B tests 53 green (45+5 unit, 3 integration); `npm run lint`
+(tsc + destructive/LLM-http/url-log/codex-drift) green. (The worktree's ~28 pre-existing
+local failures — node v25.6.1 + real-config + tunnel — are independent and CI-green.)


### PR DESCRIPTION
**Step B** of the Tiered Development Process. Spec **approved by Justin** (topic 13435) + abbreviated convergence (5 findings folded). Makes the external cross-model reviewer in spec-review-convergence **real for the first time** (`/crossreview` was a placeholder) and **framework-native**: detect the installed codex CLI → run a GPT-tier review through the existing hardened provider → no API keys, free for every instar agent with codex. Honors **Signal vs. Authority** — the review is *signal*, never a gate.

## What it does
- **`src/core/crossModelReviewer.ts`** (new) — detection (codex binary + OAuth `access_token` + Rule-1 clean), the `SUPPORTED_REVIEWER_FRAMEWORKS` registry (codex now, gemini-cli later = one entry), the reviewer driver (routes through `buildIntelligenceProvider({framework:'codex-cli'})` → gpt-5.5, 120s, reusing the env-allowlist + circuit breaker), `assembleReviewerPrompt` (inlines spec + context, 60KB budget, **deterministic** priority + **named** truncation), and the honest flag machinery: `codex-cli:<model>` / `degraded` / `degraded-all-rounds` / `unavailable` / `skipped-abbreviated` — **never throws, never blocks**.
- **`skills/spec-converge/scripts/cross-model-review.mjs`** (new) — the CLI the skill calls (repo I/O only; codex is sandboxed; always exits 0). `write-convergence-tag.mjs` gains `--cross-model-review`. `SKILL.md` replaces the placeholder, documents per-round aggregation (→ `degraded-all-rounds` when a framework was present but zero rounds succeeded) and a **loud `⚠` banner for every non-ran state**. `reviewer-cross-model.md` patched for inlined-context / single-codex-pass.

## Honesty (convergence-driven)
A failed/absent/abbreviated review can never read as a clean pass — every non-ran state is loudly banner-flagged, and a convergence that *never once* got a real external opinion surfaces at spec level as `degraded-all-rounds`. The flag is **disclosure, not a gate** (doesn't touch `review-convergence`/`approved` enforcement).

## Tests / migration
`tsc` clean; 53 Step-B tests green (45+5 unit, 3 integration); lint green. Detection live-validated: `{available:true, framework:'codex-cli', model:'gpt-5.5'}`. **No migration** — `/spec-converge` is dev-only tooling (verified not in `package.json files[]` / `installBuiltinSkills`). The ~28 pre-existing local failures (node-v25/tunnel) are independent + CI-green.

This commit was validated by the Step-A gate (now live): `suggestedTier=2`, declared Tier-2, trace+artifact+converged-spec verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)