### PR TITLE
feat(spec-converge): structural ELI16-tunnel-link delivery for spec reviews

### DIFF
--- a/scripts/check-spec-review-link.mjs
+++ b/scripts/check-spec-review-link.mjs
@@ -1,0 +1,63 @@
+#!/usr/bin/env node
+/**
+ * check-spec-review-link.mjs — backstop for the spec-review ELI16-tunnel-link
+ * requirement.
+ *
+ * The sanctioned path (skills/spec-converge/scripts/publish-spec-review.mjs)
+ * guarantees a verified ELI16 tunnel link. This is the belt-and-suspenders:
+ * if a spec-review message is sent by hand WITHOUT going through that script,
+ * this detects "looks like a spec for review, but no rendered link" and warns,
+ * so the inconsistency can't slip through silently.
+ *
+ * Warn-only by design (signal, not a hard block) — it never eats the message;
+ * it reminds. Invoked from the outbound messaging gate (convergence-check.sh).
+ *
+ * Reads the candidate message on stdin. Exits 0 always; prints a one-line
+ * reminder to stderr when the message looks like an un-linked spec review.
+ */
+
+/**
+ * True when the text looks like a SPEC delivered for review but carries no
+ * rendered (tunnel /view) link the operator can actually open. Pure — testable.
+ *
+ * Deliberately NARROW (this blocks the send, so false-positives are costly):
+ * it fires only when a spec is unambiguously being handed over for review —
+ * a `docs/specs/*.md` reference, or a GitHub PR mentioned together with the
+ * word "spec" — in an explicit review/approval handoff, with no `/view/` link.
+ * An ordinary code-PR mention ("review PR #500", "merging #670, CI green")
+ * does NOT fire.
+ */
+export function messageLacksReviewLink(text) {
+  if (!text) return false;
+  const refsSpecFile = /docs\/specs\/[^\s)]+\.md/i.test(text);
+  const refsPr = /github\.com\/[^\s)]+\/pull\/\d+/i.test(text);
+  const mentionsSpec = /\bspec(s|ification)?\b/i.test(text);
+  // Is a SPEC being handed over? (a spec file, or a PR explicitly about a spec)
+  const isSpecHandoff = refsSpecFile || (refsPr && mentionsSpec);
+  if (!isSpecHandoff) return false;
+  // ...in an explicit review/approval handoff...
+  const reviewHandoff = /\b(review|approv\w*|sign[- ]?off|take a look|for your|ready for)\b/i.test(text);
+  if (!reviewHandoff) return false;
+  // ...but there is no rendered view link to read it.
+  const hasViewLink = /\/view\/[0-9a-f-]{8,}/i.test(text);
+  return !hasViewLink;
+}
+
+async function readStdin() {
+  const chunks = [];
+  for await (const c of process.stdin) chunks.push(c);
+  return Buffer.concat(chunks).toString('utf8');
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  readStdin().then(text => {
+    if (messageLacksReviewLink(text)) {
+      process.stderr.write(
+        '[spec-review-link] This looks like a spec handed over for review but has no rendered ELI16 tunnel link. ' +
+          'Deliver it via skills/spec-converge/scripts/publish-spec-review.mjs so the link is rendered + verified before it sends.\n',
+      );
+      process.exit(1);
+    }
+    process.exit(0);
+  });
+}

--- a/skills/spec-converge/SKILL.md
+++ b/skills/spec-converge/SKILL.md
@@ -203,7 +203,18 @@ The `approved: true` tag is NOT written by this skill. That's the user's step.
 
 ### Phase 6 — User handoff
 
-The skill emits the link to the convergence report via the messaging layer (Telegram or equivalent) so the user can read the ELI10 report and decide.
+When a spec is handed to the user for review, it MUST go out with a **rendered, verified ELI16 tunnel link** the user can tap and read — never a bare filename or a PR they have to dig through. This is the required delivery step, enforced structurally (not by memory):
+
+```bash
+node skills/spec-converge/scripts/publish-spec-review.mjs \
+  --spec docs/specs/<SPEC>.md \
+  --pr <github-pr-url> \
+  --topic <telegram-topic-id> --send
+```
+
+`publish-spec-review.mjs` is the sanctioned path. It (1) resolves the ELI16 companion via the same convention the commit-time gate enforces (`scripts/eli16-overview-check.mjs`) and refuses if it is missing or a stub; (2) renders it as an auth-gated Private View (`POST /view` on port 4042, `INSTAR_AUTH_TOKEN`); (3) **verifies the tunnel link returns HTTP 200 before it is ever sent** — no broken links; (4) composes and delivers the review message (rendered ELI16 link first, full-spec PR link second).
+
+Backstop (Structure > Willpower): the pre-messaging gate (`convergence-check.sh`, criterion 8) **blocks** any hand-sent spec-review message that lacks a rendered `/view/` link, so the requirement cannot be silently skipped even if the script is bypassed.
 
 The skill does NOT auto-apply `approved: true`. That requires explicit human action — editing the frontmatter or running `instar spec approve <path>` (follow-on CLI command).
 

--- a/skills/spec-converge/scripts/publish-spec-review.mjs
+++ b/skills/spec-converge/scripts/publish-spec-review.mjs
@@ -1,0 +1,166 @@
+#!/usr/bin/env node
+/**
+ * publish-spec-review.mjs — the sanctioned way to deliver a spec for review.
+ *
+ * Structure > Willpower: sending a spec for review WITHOUT a rendered,
+ * verified ELI16 tunnel link should be impossible, not something the agent
+ * remembers to attach. This script makes the correct delivery atomic:
+ *
+ *   1. Resolve the spec's ELI16 companion using the SAME convention the
+ *      commit-time gate enforces (scripts/eli16-overview-check.mjs).
+ *   2. Refuse if the ELI16 is missing or a stub (reuses checkEli16Overview).
+ *   3. Render the ELI16 markdown as an auth-gated Private View (POST /view).
+ *   4. VERIFY the tunnel link returns HTTP 200 before it is ever sent —
+ *      never hand the operator a broken link.
+ *   5. Compose the review message (rendered ELI16 link + full-spec PR link)
+ *      and, with --send, deliver it via telegram-reply.sh.
+ *
+ * Usage:
+ *   node skills/spec-converge/scripts/publish-spec-review.mjs \
+ *     --spec docs/specs/FOO-SPEC.md \
+ *     --pr https://github.com/JKHeadley/instar/pull/670 \
+ *     --topic 12476 [--send]
+ *
+ * Auth: bearer API on port 4042 (NOT 4040 — that is dashboard/PIN auth),
+ * token from the INSTAR_AUTH_TOKEN env var (config.json authToken is
+ * externalized and will be rejected).
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { checkEli16Overview } from '../../../scripts/eli16-overview-check.mjs';
+
+export const API_PORT = Number(process.env.INSTAR_PORT) || 4042;
+
+/** Split a spec file into its frontmatter body and the rest. */
+export function extractFrontmatter(specText) {
+  const m = specText.match(/^---\n([\s\S]*?)\n---/);
+  return m ? m[1] : '';
+}
+
+/** Pull a human title from the spec frontmatter (`title:`) or first H1. */
+export function specTitle(specText, fallback) {
+  const fm = extractFrontmatter(specText);
+  const t = fm.match(/^\s*title\s*:\s*["']?([^"'\n]+)/m);
+  if (t) return t[1].trim();
+  const h1 = specText.match(/^#\s+(.+)$/m);
+  if (h1) return h1[1].trim();
+  return fallback;
+}
+
+/**
+ * Compose the operator-facing review message. Pure — no I/O.
+ * Leads with the rendered ELI16 link (what the operator reads first),
+ * then the full-spec PR for the deep read.
+ */
+export function composeReviewMessage({ title, eli16Url, prUrl }) {
+  const lines = [
+    `Spec ready for your review: ${title}`,
+    '',
+    `ELI16 overview (rendered — tap to read): ${eli16Url}`,
+  ];
+  if (prUrl) lines.push(`Full spec + the decisions I need: ${prUrl}`);
+  lines.push('', 'Nothing builds until you approve it.');
+  return lines.join('\n');
+}
+
+/** POST the ELI16 markdown to /view; returns { tunnelUrl, localUrl, id }. */
+async function createView({ title, markdown }) {
+  const token = process.env.INSTAR_AUTH_TOKEN;
+  if (!token) throw new Error('INSTAR_AUTH_TOKEN not set — cannot authenticate to the local API');
+  const res = await fetch(`http://localhost:${API_PORT}/view`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+    body: JSON.stringify({ title, markdown }),
+  });
+  if (!res.ok) throw new Error(`/view returned HTTP ${res.status} (${await res.text().catch(() => '')})`);
+  const d = await res.json();
+  if (!d.tunnelUrl) {
+    throw new Error('view created but no tunnelUrl — is the tunnel running? (GET /tunnel)');
+  }
+  return d;
+}
+
+/** Verify a URL renders (HTTP 200) before it is ever sent to the operator. */
+async function verifyUrl(url) {
+  const res = await fetch(url, { method: 'GET' });
+  return res.status;
+}
+
+function parseArgs(argv) {
+  const out = { send: false };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === '--spec') out.spec = argv[++i];
+    else if (a === '--pr') out.pr = argv[++i];
+    else if (a === '--topic') out.topic = argv[++i];
+    else if (a === '--send') out.send = true;
+  }
+  return out;
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  if (!args.spec) {
+    console.error('Usage: publish-spec-review.mjs --spec <path> --pr <url> --topic <id> [--send]');
+    process.exit(2);
+  }
+  const specPath = path.resolve(args.spec);
+  if (!fs.existsSync(specPath)) {
+    console.error(`Spec not found: ${specPath}`);
+    process.exit(2);
+  }
+  const specText = fs.readFileSync(specPath, 'utf8');
+  const fm = extractFrontmatter(specText);
+
+  // GATE: the ELI16 companion must exist and be non-stub (same convention as
+  // the commit-time precommit gate). Refuse to publish without it.
+  const eli16 = checkEli16Overview(specPath, fm);
+  if (!eli16.ok) {
+    console.error(`REFUSING to publish: ELI16 overview ${eli16.reason}.`);
+    console.error(`  Expected sibling: ${eli16.siblingPath} (or a frontmatter \`eli16-overview:\` pointer).`);
+    if (eli16.reason === 'too-short') {
+      console.error(`  Found ${eli16.charCount} chars; need >= ${eli16.minChars}.`);
+    }
+    process.exit(1);
+  }
+
+  const title = specTitle(specText, path.basename(specPath, '.md'));
+  const eli16Markdown = fs.readFileSync(eli16.eli16Path, 'utf8');
+
+  // Render + verify the tunnel link BEFORE composing/sending.
+  const view = await createView({ title: `${title} — ELI16`, markdown: eli16Markdown });
+  const status = await verifyUrl(view.tunnelUrl);
+  if (status !== 200) {
+    console.error(`REFUSING to send: rendered ELI16 link did not verify (HTTP ${status}). No broken links.`);
+    process.exit(1);
+  }
+
+  const message = composeReviewMessage({ title, eli16Url: view.tunnelUrl, prUrl: args.pr });
+
+  if (args.send) {
+    if (!args.topic) {
+      console.error('--send requires --topic <id>');
+      process.exit(2);
+    }
+    const reply = spawnSync('bash', ['.instar/scripts/telegram-reply.sh', String(args.topic)], {
+      input: message, encoding: 'utf8',
+    });
+    process.stderr.write(reply.stdout || '');
+    process.stderr.write(reply.stderr || '');
+    console.error(`\n[published] ELI16 link verified (HTTP 200) and delivered to topic ${args.topic}.`);
+  } else {
+    // Print the message + the verified link for the caller to send.
+    console.log(message);
+    console.error(`\n[ok] ELI16 link verified (HTTP 200): ${view.tunnelUrl}`);
+  }
+}
+
+// Run only when invoked directly (not when imported by tests).
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main().catch(err => {
+    console.error(`publish-spec-review failed: ${err.message}`);
+    process.exit(1);
+  });
+}

--- a/src/templates/scripts/convergence-check.sh
+++ b/src/templates/scripts/convergence-check.sh
@@ -149,6 +149,26 @@ if echo "$CONTENT" | grep -qiE "(i used to (think|believe|feel|assume)|back when
   ISSUE_COUNT=$((ISSUE_COUNT + 1))
 fi
 
+# 8. SPEC-REVIEW LINK — a spec handed over for review must carry a rendered
+# ELI16 tunnel link the operator can open. Structure > Willpower: the link is
+# guaranteed by skills/spec-converge/scripts/publish-spec-review.mjs. Narrow by
+# design (this blocks the send): fires only on an unambiguous spec handoff —
+# a docs/specs/*.md reference, OR a GitHub PR mentioned with the word "spec" —
+# in an explicit review/approval handoff, with no /view/ link present. An
+# ordinary code-PR mention does not fire.
+SPEC_HANDOFF=""
+if echo "$CONTENT" | grep -qiE "docs/specs/[^ )]+\.md"; then
+  SPEC_HANDOFF="yes"
+elif echo "$CONTENT" | grep -qiE "github\.com/[^ )]+/pull/[0-9]+" && echo "$CONTENT" | grep -qiE "\bspec(s|ification)?\b"; then
+  SPEC_HANDOFF="yes"
+fi
+if [ -n "$SPEC_HANDOFF" ] \
+  && echo "$CONTENT" | grep -qiE "\b(review|approv|sign[- ]?off|take a look|for your|ready for)\b" \
+  && ! echo "$CONTENT" | grep -qiE "/view/[0-9a-f-]{8,}"; then
+  ISSUES+=("SPEC_REVIEW_LINK: You're handing a spec over for review with no rendered ELI16 tunnel link the operator can open. Deliver spec reviews via skills/spec-converge/scripts/publish-spec-review.mjs — it renders the ELI16, verifies the link (HTTP 200), and includes it. Don't send a spec for review without the rendered link.")
+  ISSUE_COUNT=$((ISSUE_COUNT + 1))
+fi
+
 # Output results
 if [ "$ISSUE_COUNT" -gt "0" ]; then
   echo "=== CONVERGENCE CHECK: ${ISSUE_COUNT} ISSUE(S) FOUND ==="

--- a/tests/unit/convergence-check.test.ts
+++ b/tests/unit/convergence-check.test.ts
@@ -367,6 +367,40 @@ describe('Convergence Check', () => {
     });
   });
 
+  // ── Category 8: Spec-Review Link ───────────────────────────────────
+
+  describe('Category 8: Spec-Review Link', () => {
+    it('flags a spec PR handed over for review with no rendered view link', () => {
+      const result = runCheck(
+        'Spec is up for your review: PR https://github.com/JKHeadley/instar/pull/670. Nothing builds until you approve.',
+      );
+      expect(result.exitCode).toBe(1);
+      expect(result.output).toContain('SPEC_REVIEW_LINK');
+    });
+
+    it('flags a docs/specs file referenced for sign-off with no link', () => {
+      const result = runCheck('Please sign off on docs/specs/FOO-SPEC.md when you can.');
+      expect(result.exitCode).toBe(1);
+      expect(result.output).toContain('SPEC_REVIEW_LINK');
+    });
+
+    it('passes when a rendered /view/ link is present', () => {
+      // localhost is whitelisted by the URL-provenance check; the /view/ path
+      // is what criterion 8 looks for.
+      const result = runCheck(
+        'Spec ready for your review at http://localhost:4040/view/abc12345-c4e6-4636-b97f-2e6ea4e32af9 — full spec at https://github.com/JKHeadley/instar/pull/670',
+      );
+      expect(result.exitCode).toBe(0);
+    });
+
+    it('does NOT fire on an ordinary code-PR review (no spec)', () => {
+      const result = runCheck(
+        'Can you review https://github.com/JKHeadley/instar/pull/500 when you get a chance?',
+      );
+      expect(result.exitCode).toBe(0);
+    });
+  });
+
   // ── Multi-category detection ───────────────────────────────────────
 
   describe('Multi-category detection', () => {

--- a/tests/unit/spec-review-publish.test.ts
+++ b/tests/unit/spec-review-publish.test.ts
@@ -1,0 +1,102 @@
+/**
+ * Unit tests for the spec-review ELI16-tunnel-link delivery tooling.
+ *
+ * Covers the pure logic of:
+ *  - the backstop detector (scripts/check-spec-review-link.mjs)
+ *  - the publisher's message composition + frontmatter/title parsing
+ *    (skills/spec-converge/scripts/publish-spec-review.mjs)
+ *
+ * The I/O paths (POST /view, link verification, telegram send) need a running
+ * server and are exercised by dogfooding, not unit-mocked here.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { messageLacksReviewLink } from '../../scripts/check-spec-review-link.mjs';
+import {
+  composeReviewMessage,
+  extractFrontmatter,
+  specTitle,
+} from '../../skills/spec-converge/scripts/publish-spec-review.mjs';
+
+describe('messageLacksReviewLink — backstop detector', () => {
+  it('flags a PR handed over for review with no rendered view link', () => {
+    const text =
+      'Spec is up for your review — PR https://github.com/JKHeadley/instar/pull/670. ' +
+      'Nothing builds until you approve it.';
+    expect(messageLacksReviewLink(text)).toBe(true);
+  });
+
+  it('passes when a rendered tunnel /view link IS present', () => {
+    const text =
+      'Spec ready for review.\n' +
+      'ELI16: https://echo.dawn-tunnel.dev/view/b0df2aa3-c4e6-4636-b97f-2e6ea4e32af9?sig=abc\n' +
+      'Full spec: https://github.com/JKHeadley/instar/pull/670';
+    expect(messageLacksReviewLink(text)).toBe(false);
+  });
+
+  it('flags a docs/specs file referenced for sign-off without a view link', () => {
+    const text = 'Please sign off on docs/specs/FOO-SPEC.md when you get a chance.';
+    expect(messageLacksReviewLink(text)).toBe(true);
+  });
+
+  it('ignores ordinary messages that merely mention a PR (no review intent)', () => {
+    const text = 'CI is green on https://github.com/JKHeadley/instar/pull/670, merging now.';
+    // mentions a PR but no review/approve/spec/eli16 intent word
+    expect(messageLacksReviewLink(text)).toBe(false);
+  });
+
+  it('does NOT fire on an ordinary code-PR review (no spec involved)', () => {
+    const text = 'Can you please review https://github.com/JKHeadley/instar/pull/500 when you get a chance?';
+    // a PR for review, but not a spec — narrow scope must not over-block
+    expect(messageLacksReviewLink(text)).toBe(false);
+  });
+
+  it('ignores messages with neither a PR nor a spec-file reference', () => {
+    expect(messageLacksReviewLink('Please review my approach to the cache.')).toBe(false);
+  });
+
+  it('is safe on empty / undefined input', () => {
+    expect(messageLacksReviewLink('')).toBe(false);
+    // @ts-expect-error testing defensive guard
+    expect(messageLacksReviewLink(undefined)).toBe(false);
+  });
+});
+
+describe('composeReviewMessage — operator-facing review message', () => {
+  it('leads with the rendered ELI16 link and includes the PR', () => {
+    const msg = composeReviewMessage({
+      title: 'Threadline A2A Coherence',
+      eli16Url: 'https://echo.dawn-tunnel.dev/view/abc?sig=x',
+      prUrl: 'https://github.com/JKHeadley/instar/pull/670',
+    });
+    expect(msg).toContain('Threadline A2A Coherence');
+    expect(msg).toContain('https://echo.dawn-tunnel.dev/view/abc?sig=x');
+    expect(msg).toContain('https://github.com/JKHeadley/instar/pull/670');
+    // ELI16 link appears before the PR link
+    expect(msg.indexOf('view/abc')).toBeLessThan(msg.indexOf('/pull/670'));
+    expect(msg).toContain('Nothing builds until you approve');
+  });
+
+  it('omits the PR line gracefully when no PR is given', () => {
+    const msg = composeReviewMessage({
+      title: 'X',
+      eli16Url: 'https://echo.dawn-tunnel.dev/view/abc?sig=x',
+    });
+    expect(msg).toContain('view/abc');
+    expect(msg).not.toContain('Full spec');
+  });
+});
+
+describe('frontmatter + title parsing', () => {
+  it('extracts the frontmatter body between the --- fences', () => {
+    const spec = '---\ntitle: My Spec\napproved: false\n---\n\n# My Spec\nbody';
+    expect(extractFrontmatter(spec)).toContain('title: My Spec');
+    expect(extractFrontmatter(spec)).toContain('approved: false');
+  });
+
+  it('prefers the frontmatter title, falls back to the H1, then the fallback', () => {
+    expect(specTitle('---\ntitle: FM Title\n---\n# H1 Title', 'fb')).toBe('FM Title');
+    expect(specTitle('# H1 Title\nbody', 'fb')).toBe('H1 Title');
+    expect(specTitle('no title here', 'fb')).toBe('fb');
+  });
+});


### PR DESCRIPTION
**What & why.** A spec sent for review must ship with a rendered, verified ELI16 tunnel link the operator can tap — not a bare filename or a PR to dig through. This was inconsistent because it relied on the agent *remembering* to attach it. This makes it structural (Justin: "yes please" to baking it into the dev-flow).

**Two layers (Structure > Willpower):**
1. **The easy way is the guaranteed way** — `skills/spec-converge/scripts/publish-spec-review.mjs`: resolves the ELI16 via the existing convention (`eli16-overview-check.mjs`), refuses if missing/stub, renders it as a Private View (`POST /view`, port 4042 + `INSTAR_AUTH_TOKEN`), **verifies the tunnel link is HTTP 200 before sending** (no broken links), and composes the review message (ELI16 link first, full-spec PR second).
2. **Can't-skip backstop** — `convergence-check.sh` criterion 8 (the pre-messaging gate) **blocks** a hand-sent spec-review message lacking a rendered `/view/` link. Narrowly scoped (a `docs/specs/*.md` ref, or a PR + the word "spec", in a review handoff) so an ordinary code-PR mention never fires. Migration-parity is automatic — `convergence-check.sh` is always-overwritten from its template by `PostUpdateMigrator`.

**Tests:** 11 unit (publisher compose/parse + detector both sides of each boundary) + 4 new `convergence-check` Category 8 cases (block both un-linked forms; pass with a `/view/` link; don't fire on a code-PR). `tsc` + `npm run lint` clean.

**Scope note:** Tier-1 dev-flow tooling (a PR you review). No `docs/specs` change, so no ELI16 companion is required for this PR itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)