### PR TITLE
fix(multi-machine): standby read-only write must not crash the server

### DIFF
--- a/src/core/uncaughtExceptionPolicy.ts
+++ b/src/core/uncaughtExceptionPolicy.ts
@@ -28,6 +28,17 @@ const NON_FATAL_UNCAUGHT_PATTERNS = [
   // that sleeps/wakes often, where reconnects are frequent). The root cause is
   // also guarded at the ack send site; this is the defense-in-depth backstop.
   'Sent before connected',
+  // Standby read-only write: when this machine is on standby (a peer holds the
+  // multi-machine lease), StateManager.guardWrite() throws on any stray
+  // write ("StateManager is read-only (this machine is on standby)"). That is a
+  // KNOWN, ISOLATED, recoverable condition — the active machine owns the
+  // canonical state; the standby machine simply should not have written. The
+  // throw has already unwound the offending write; the server stays useful in
+  // send-only mode. Crashing the whole agent here turns a benign dropped write
+  // into a crash-loop (boot → demote-to-standby → stray write → FATAL → respawn).
+  // This is a crash backstop ONLY — it does not change lease/standby behavior;
+  // it stops a standby write from taking the process down.
+  'StateManager is read-only',
 ];
 
 /**

--- a/tests/unit/uncaughtExceptionPolicy.test.ts
+++ b/tests/unit/uncaughtExceptionPolicy.test.ts
@@ -22,6 +22,19 @@ describe('isNonFatalUncaught', () => {
     expect(isNonFatalUncaught(new Error('ERR_STREAM_WRITE_AFTER_END'))).toBe(true);
   });
 
+  it('treats a standby read-only write as recoverable (must not crash-loop on a peer-held lease)', () => {
+    // The exact throw from StateManager.guardWrite() on a standby machine.
+    expect(
+      isNonFatalUncaught(
+        new Error('StateManager is read-only (this machine is on standby). Blocked: appendEvent'),
+      ),
+    ).toBe(true);
+    // Any blocked operation name, decorated message — substring match.
+    expect(
+      isNonFatalUncaught(new Error('FATAL: StateManager is read-only (this machine is on standby). Blocked: write')),
+    ).toBe(true);
+  });
+
   it('treats an UNKNOWN error as fatal (crash is the safe default)', () => {
     expect(isNonFatalUncaught(new Error('mutex lock failed'))).toBe(false);
     expect(isNonFatalUncaught(new Error('Cannot read properties of undefined'))).toBe(false);


### PR DESCRIPTION
**Crash backstop — does NOT change lease/standby behavior.**

A standby machine (a peer holds the multi-machine lease) crashes the whole server on any stray state write: `StateManager.guardWrite()` throws `StateManager is read-only (this machine is on standby)`, and the server's `uncaughtException` handler treated it as FATAL (close DBs + exit). That turns a benign dropped write into a **crash-loop**: boot → lease-pull demotes to standby → stray write → FATAL → lifeline respawn → repeat (~every 4 min).

**Fix:** add the standby read-only error to the non-fatal uncaught-exception allowlist (`uncaughtExceptionPolicy.ts`). It is isolated + recoverable by construction — the offending write has unwound, the active machine owns the canonical state, and the server stays useful in send-only mode. This is the exact documented purpose of that allowlist.

**Scope:** crash backstop ONLY. It does not touch lease/standby logic or the lease-war root cause (separate). Observed live on Echo: a lease war between `m_cc2ec651` and `m_4cbc0d4a` flapped this machine to standby every ~2.5 min, and each stray write took the server down.

**Tests:** `uncaughtExceptionPolicy.test.ts` adds the standby case (exact + decorated message → recoverable). tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)