### PR TITLE
fix(multi-machine): active-pull must not demote a solo machine on a transient lease lapse

### DIFF
--- a/src/core/MultiMachineCoordinator.ts
+++ b/src/core/MultiMachineCoordinator.ts
@@ -614,8 +614,22 @@ export class MultiMachineCoordinator extends EventEmitter {
     this.leasePulling = true;
     try {
       await this.leaseCoordinator!.pullFromPeers();
-      this.reconcileRoleToLease('lease-pull');
-      this.surfacePullDiscoveredSplitBrain();
+      // Only reconcile role / surface split-brain when a peer lease was actually
+      // OBSERVED. A solo machine (no peers, or no peer lease seen this boot) must
+      // NEVER be demoted by the pull loop on a transient self-lease lapse — that
+      // is the heartbeat tickLease's job, which RE-ACQUIRES rather than just
+      // demoting. The pull's purpose is LEARNING from peers; with no peer signal
+      // there is nothing to learn and nothing to reconcile. Acting on the local
+      // lease state alone here turned the ~5s pull cadence into a demotion DoS:
+      // whenever a solo holder's lease momentarily lapsed between renewals it
+      // flipped to read-only standby, and a standby write crashed the server in a
+      // restart loop (incident 2026-06-02). Gating on an observed peer lease keeps
+      // the real feature intact (a standby pulling a higher-epoch holder still
+      // demotes) while removing the spurious solo demotion.
+      if (this.leaseCoordinator!.observedPeerLease()) {
+        this.reconcileRoleToLease('lease-pull');
+        this.surfacePullDiscoveredSplitBrain();
+      }
     } catch {
       // @silent-fallback-ok — a pull failure is retried next tick
     } finally {

--- a/tests/unit/MultiMachineCoordinator-leasePull.test.ts
+++ b/tests/unit/MultiMachineCoordinator-leasePull.test.ts
@@ -113,6 +113,57 @@ describe('MultiMachineCoordinator — active lease-pull split-brain surface', ()
     coord.stop();
   });
 
+  it('REGRESSION (incident 2026-06-02): a solo holder whose self-lease lapses is NOT demoted by the pull loop when no peer lease was observed', async () => {
+    // The crash-loop root cause: tickLeasePull reconciled role UNCONDITIONALLY every
+    // ~5s. A solo machine's 60s self-lease momentarily lapses between renewals →
+    // holdsLease() false → the pull loop flipped it to STANDBY → StateManager
+    // read-only → a standby write crashed the server in a restart loop. The fix:
+    // the pull loop only reconciles when a peer lease was actually OBSERVED.
+    const machineId = `m_${crypto.randomBytes(8).toString('hex')}`;
+    const identity = seedIdentity(dir, machineId);
+    new MachineIdentityManager(dir).registerMachine(identity as any, 'awake');
+
+    // Solo machine: pull-CAPABLE transport (loop arms) that NEVER observes a peer
+    // lease (no peers; nothing pushed or pulled) → observed() always null.
+    const soloTunnel: LeaseTransport = {
+      broadcast: async () => true,
+      observed: () => ({ lease: null, lastNonceByHolder: {} }),
+      isReachable: () => true,
+      pullAllPeers: async () => { /* solo: pulls nothing */ },
+    };
+    let now = 2_000;
+    const lc = new LeaseCoordinator({
+      lease: fl('A'),
+      store: new LocalLeaseStore({ filePath: path.join(dir, 'lease-local.json') }),
+      tunnel: soloTunnel,
+      presumedDeadHolders: () => new Set(),
+      now: () => now,
+      monotonicNow: () => now,
+    });
+
+    vi.useFakeTimers();
+    const state = new StateManager(dir);
+    const coord = new MultiMachineCoordinator(state, { stateDir: dir, multiMachine: { leasePullIntervalMs: 1_000 } as any });
+    coord.start();
+    coord.attachLeaseCoordinator(lc);
+    await coord.initializeLease(); // A acquires epoch 1 → awake
+    expect(coord.isAwake).toBe(true);
+    expect(lc.holdsLease()).toBe(true);
+    expect(state.readOnly).toBe(false);
+
+    // The self-lease LAPSES (TTL elapses before a renewal) — holdsLease() now false.
+    now = 2_000 + TTL + 1;
+    expect(lc.holdsLease()).toBe(false); // genuinely lapsed
+
+    // Fire a pull tick. With NO peer observed, the pull loop must NOT reconcile/demote.
+    await vi.advanceTimersByTimeAsync(1_300);
+
+    expect(coord.isAwake).toBe(true);                 // NOT demoted by the pull loop
+    expect(coord.getSyncStatus().role).toBe('awake');
+    expect(state.readOnly).toBe(false);               // never flipped to read-only (no crash path)
+    coord.stop();
+  });
+
   it('pull loop does not arm when the transport cannot pull (git-only mesh)', async () => {
     const machineId = `m_${crypto.randomBytes(8).toString('hex')}`;
     const identity = seedIdentity(dir, machineId);

--- a/upgrades/next/fix-activepull-solo-demotion.md
+++ b/upgrades/next/fix-activepull-solo-demotion.md
@@ -1,0 +1,26 @@
+# Upgrade Guide — vNEXT
+
+<!-- bump: patch -->
+
+## What Changed
+
+Fixes a crash-loop regression introduced with the multi-machine active-pull feature.
+
+On a machine running by itself (no other live machine in its mesh), the active-pull loop was re-checking the "who's awake" role every few seconds and, whenever the short-lived internal lease briefly lapsed between renewals, wrongly flipped the machine to a standby (read-only) state. A follow-up write then crashed the server, and it restarted into the same loop. Because the server is also the messaging relay, the operator saw silence during the loop.
+
+The fix: the active-pull loop now only re-evaluates the awake/standby role when it has actually heard a lease from a peer. A machine on its own is never demoted by the pull loop on a transient lease lapse — its normal heartbeat keeps renewing the lease as before. The genuine multi-machine behavior (a backup that pulls a newer lease from a live peer still steps down) is unchanged.
+
+This pairs with the earlier hardening that made a read-only/standby write non-fatal, so both the wrong state and the crash it could cause are now closed.
+
+## What to Tell Your User
+
+Nothing to do. If you run an agent on a single machine, this removes a rare crash-restart loop that could make it go quiet for a while; multi-machine setups behave the same as before, just without the spurious solo demotion.
+
+## Summary of New Capabilities
+
+- The active lease-pull loop only reconciles the awake/standby role when a peer lease was actually observed, so a solo machine is never demoted (and never driven read-only) by the pull loop on a transient self-lease lapse. Regression test added; the real peer-driven demotion path is retained and tested.
+
+## Evidence
+
+- `tsc --noEmit` clean; 45 multi-machine unit tests green, including a new regression (a solo holder whose self-lease lapses with no peer observed stays awake and never goes read-only) and the retained same-epoch contested-split-brain test (feature intact).
+- Root cause of the 2026-06-02 echo crash-loop incident. Spec: docs/specs/MULTI-MACHINE-ROBUST-LEASE-PROPAGATION-SPEC.md (approved). Side-effects review: upgrades/side-effects/fix-activepull-solo-demotion.md.

--- a/upgrades/side-effects/fix-activepull-solo-demotion.md
+++ b/upgrades/side-effects/fix-activepull-solo-demotion.md
@@ -1,0 +1,75 @@
+# Side-Effects Review — Fix: active-pull must not demote a solo machine on a transient lease lapse
+
+**Version / slug:** `fix-activepull-solo-demotion`
+**Date:** `2026-06-02`
+**Author:** `echo`
+**Spec:** `docs/specs/MULTI-MACHINE-ROBUST-LEASE-PROPAGATION-SPEC.md` (approved: true) — corrects a regression in the active-pull it introduced (#668).
+**Parent principle:** `Cross-Machine Coherence — One Agent, Robust Under Degraded Conditions`
+
+## Summary of the change
+
+A one-condition fix to `MultiMachineCoordinator.tickLeasePull`: it now only calls
+`reconcileRoleToLease('lease-pull')` + `surfacePullDiscoveredSplitBrain()` when a peer
+lease was **actually observed** (`leaseCoordinator.observedPeerLease()` non-null).
+
+### Why (live incident, 2026-06-02)
+
+The active-pull loop (shipped in #668) reconciled the machine's lease role
+**unconditionally** every `leasePullIntervalMs` (~5s). On a solo machine — one with no
+reachable peers (the only registry peer was dead 3 days, no `lastKnownUrl`, so `peers()`
+was empty) — every brief lapse of the 60s self-lease between renewals made
+`holdsLease()` return false, so the pull loop flipped the machine to **standby** →
+`StateManager` read-only → a standby write threw and (pre-#673) crashed the server in a
+launchd restart loop (lease epoch climbed into the thousands). The crashing server is the
+Telegram relay, so the operator saw silence. #673 already stopped the *crash* (read-only
+write is now an isolated/recoverable uncaught-exception class); this PR removes the *root
+cause* (the spurious demotion itself).
+
+## Decision-point inventory
+
+- `tickLeasePull` reconcile vs skip: reconcile only when `observedPeerLease()` is non-null.
+  Pull is for LEARNING from peers; with no peer signal there is nothing to reconcile.
+  Role/renewal for a solo holder stays with the heartbeat `tickLease` (which RE-ACQUIRES,
+  not merely demotes).
+
+## 1. Over-correction risk
+Does gating on an observed peer break the real feature (a standby pulling a higher-epoch
+holder must still demote)? No — that path records the holder's lease via `recordObserved`,
+so `observedPeerLease()` is non-null and the reconcile runs exactly as before. Covered by
+the retained "same-epoch contested" test.
+
+## 2. Under-correction risk
+A solo holder whose lease lapses is no longer demoted by the *pull* loop, but the 2-min
+heartbeat `tickLease` still renews/re-acquires it — so role management is preserved, just
+moved off the aggressive 5s pull cadence that caused the DoS.
+
+## 3. Level-of-abstraction fit
+The fix sits in the pull tick (the loop that caused the regression), gating on the
+coordinator's existing `observedPeerLease()` accessor — no new surface.
+
+## 4. Signal vs Authority
+The pull remains a SIGNAL (observe peer leases); the FencedLease epoch/validity checks
+remain the authority for who holds. The fix stops the signal loop from ACTING (demoting)
+in the absence of any signal.
+
+## 5. External surfaces
+None. No route/config/schema change. `leasePullIntervalMs` unchanged.
+
+## 6. Interactions with existing primitives
+Composes with #673 (read-only-write no longer fatal) as defense-in-depth: #673 prevents
+the crash; this prevents the wrong state that led to it. The heartbeat `tickLease` and the
+acquire path are untouched.
+
+## 7. Rollback cost
+Trivial + safe: a single `if (observedPeerLease())` guard. Reverting restores the prior
+(buggy) unconditional reconcile.
+
+## Migration parity
+None — pure code logic change, reaches existing agents on the normal dist update.
+
+## Tests
+`tsc --noEmit` clean. 45 multi-machine tests green, including a NEW regression
+(`MultiMachineCoordinator-leasePull` — a solo holder whose self-lease lapses with no peer
+observed stays awake + never goes read-only) and the retained same-epoch-contested test
+(feature intact). Operational note: echo was reverted to solo mode during the incident
+(machine identity moved aside); re-pairing its mesh is a separate, operator-gated step.


### PR DESCRIPTION
## Root cause of the 2026-06-02 echo crash-loop

The active-pull loop shipped in #668 reconciled the lease-role **unconditionally** every `leasePullIntervalMs` (~5s). On a **solo** machine (no reachable peers — the only registry peer was dead 3 days, no `lastKnownUrl`, so `peers()` was empty), every brief lapse of the 60s self-lease between renewals made `holdsLease()` return false, so the pull loop flipped the machine to **standby** → `StateManager` read-only → a standby write threw and crash-looped the server via launchd (lease epoch climbed to 1392). Since the server is the Telegram relay, the operator saw silence.

#673 already made the read-only write **non-fatal** (defense-in-depth). This PR removes the **root cause**: the spurious demotion itself.

## The fix

`MultiMachineCoordinator.tickLeasePull` now only calls `reconcileRoleToLease('lease-pull')` + `surfacePullDiscoveredSplitBrain()` when a peer lease was **actually observed** (`leaseCoordinator.observedPeerLease()` non-null). The pull is for *learning* from peers; with no peer signal there is nothing to reconcile. A solo machine's role/renewal stays with the heartbeat `tickLease` (which **re-acquires**, not merely demotes). The genuine feature — a standby pulling a higher-epoch live holder still demotes — is unchanged.

## Tests

- **New regression** (`MultiMachineCoordinator-leasePull`): a solo holder whose self-lease lapses with **no peer observed** stays awake and never flips read-only (the exact incident shape).
- **Retained**: the same-epoch contested-split-brain test (peer-driven path intact).
- 45 multi-machine unit tests green; pre-push smoke 142 green; `tsc --noEmit` clean.

## Safety / scope

One `if (observedPeerLease())` guard — trivially reversible. No route/config/schema change. Composes with #673 (crash now impossible even if a demotion were wrong). Spec: `docs/specs/MULTI-MACHINE-ROBUST-LEASE-PROPAGATION-SPEC.md` (approved). Operational note: echo was reverted to solo mode during the incident; re-pairing its mesh is a separate operator-gated step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)