### PR TITLE
fix(multi-machine): never allocate a WHATWG fetch-blocked port (mesh uses node fetch)

### DIFF
--- a/docs/specs/fix-fetch-blocked-ports.eli16.md
+++ b/docs/specs/fix-fetch-blocked-ports.eli16.md
@@ -1,0 +1,54 @@
+# ELI16 — Don't put an agent on a "bad port"
+
+## The one-sentence version
+
+Some port numbers are secretly off-limits to the web-request function our agents
+use to talk between machines, and we were accidentally allowed to assign one of
+them — so an agent could end up on a port where it silently can't be reached by
+the rest of the fleet. This stops that.
+
+## What's actually going on
+
+When two of our agents on different machines talk to each other — to pair up, to
+agree on who's "in charge" (the lease), to send heartbeats — they use the
+built-in `fetch` function in Node.js (the same thing a browser uses to load a
+URL).
+
+It turns out `fetch` has a little-known safety rule baked into the web standard:
+it **refuses** to connect to a short list of "bad ports." These are ports
+historically tied to other system services (for example, port **4045** is the
+old NFS file-lock service). If you ask `fetch` to talk to `http://something:4045`,
+it doesn't even try — it immediately fails with the cryptic error
+`fetch failed: bad port`.
+
+Here's the trap: the normal way *we* picked a port for a new agent was "start at
+4040 and count up to 4099, grab the first free one." But **4045 is inside that
+range** and **4045 is on the bad-ports list.** So an agent could legitimately get
+assigned port 4045 — and then quietly be unable to join any mesh, because every
+other machine's `fetch` to it bounces off the bad-port rule. And it's *invisible*,
+because ordinary tools like `curl` don't follow that rule — `curl` to the agent
+works fine, so everything *looks* healthy. We hit this for real: a test agent on
+4045 simply could not be paired, no matter what, until we moved it.
+
+## What we changed
+
+Two small things:
+
+1. **The port picker now skips bad ports.** When allocating a port for a new
+   agent, we step over anything on the WHATWG bad-ports list (4045 and friends),
+   exactly like we already step over ports that are taken. New agents can never
+   land on a port the mesh can't reach.
+
+2. **A loud warning for any agent already on a bad port.** The port-picker fix
+   only helps *new* agents. If an existing agent is already sitting on 4045 (from
+   before this change, or set by hand), it would still be silently unreachable —
+   so on startup we now print a clear warning telling the operator to change the
+   port. We don't auto-change it, because silently moving a running agent's port
+   could surprise things; a loud nudge is safer.
+
+## Why it matters
+
+Multi-machine only works if machines can actually reach each other. A silent
+"can't be reached" failure on a handful of unlucky port numbers is exactly the
+kind of gremlin that wastes hours (it wasted ours). Now the failure mode is
+designed out for new agents and surfaced for old ones.

--- a/src/commands/server.ts
+++ b/src/commands/server.ts
@@ -40,7 +40,7 @@ import { AutoUpdater } from '../core/AutoUpdater.js';
 import { UpdateRestartHandshake, verifyRestartHandshake } from '../core/UpdateRestartHandshake.js';
 import { AutoDispatcher } from '../core/AutoDispatcher.js';
 import { DispatchExecutor } from '../core/DispatchExecutor.js';
-import { registerAgent, unregisterAgent, startHeartbeat } from '../core/AgentRegistry.js';
+import { registerAgent, unregisterAgent, startHeartbeat, isFetchBlockedPort } from '../core/AgentRegistry.js';
 import { TelegraphService } from '../publishing/TelegraphService.js';
 import { PrivateViewer } from '../publishing/PrivateViewer.js';
 import { TunnelManager } from '../tunnel/TunnelManager.js';
@@ -2222,6 +2222,20 @@ export async function startServer(options: StartOptions): Promise<void> {
   // which overwrites our intentional autoApply: false setting.
 
   const serverSessionName = `${config.projectName}-server`;
+
+  // Migration-parity warning: an EXISTING agent whose port predates the
+  // fetch-blocked-port allocator guard (or was set by hand) silently can't mesh —
+  // node fetch refuses WHATWG bad ports (e.g. 4045 = NFS lockd). New agents now
+  // skip these at allocation; surface it loudly for ones already on a bad port so
+  // the operator can re-port. (2026-06-02 incident.)
+  if (typeof config.port === 'number' && isFetchBlockedPort(config.port)) {
+    console.warn(pc.yellow(
+      `  ⚠ Port ${config.port} is on the WHATWG fetch "bad ports" list — multi-machine ` +
+      `mesh (pairing/lease/heartbeat use node fetch) CANNOT reach this agent on this port. ` +
+      `Change "port" in .instar/config.json to a non-blocked port (e.g. 4040–4044, 4046–4099) ` +
+      `and restart if you use multi-machine.`,
+    ));
+  }
 
   if (options.foreground) {
     // Run in foreground — useful for development

--- a/src/core/AgentRegistry.ts
+++ b/src/core/AgentRegistry.ts
@@ -31,6 +31,32 @@ function legacyRegistryPath(): string { return path.join(registryDir(), 'port-re
 const DEFAULT_PORT_RANGE_START = 4040;
 const DEFAULT_PORT_RANGE_END = 4099;
 
+/**
+ * WHATWG Fetch "bad ports" — node's global `fetch` (undici) throws
+ * `TypeError: fetch failed { cause: 'bad port' }` for any URL on one of these
+ * ports. Instar's multi-machine mesh does ALL of its cross-machine I/O over node
+ * fetch (pairing `POST /api/pair`, lease broadcast/pull, heartbeat), so an agent
+ * whose server lands on a blocked port is SILENTLY unreachable over the mesh —
+ * curl works (it ignores the blocklist), so the failure is invisible. Observed
+ * live 2026-06-02: a paired test agent on port 4045 (NFS `lockd`, on this list)
+ * could never be joined ("fetch failed: bad port") despite curl reaching it. The
+ * default allocation range (4040–4099) contains 4045, so the allocator MUST skip
+ * these. Source: the WHATWG Fetch spec "bad ports" table.
+ */
+export const FETCH_BLOCKED_PORTS: ReadonlySet<number> = new Set([
+  1, 7, 9, 11, 13, 15, 17, 19, 20, 21, 22, 23, 25, 37, 42, 43, 53, 69, 77, 79, 87,
+  95, 101, 102, 103, 104, 109, 110, 111, 113, 115, 117, 119, 123, 135, 137, 139,
+  143, 161, 179, 389, 427, 465, 512, 513, 514, 515, 526, 530, 531, 532, 540, 548,
+  554, 556, 563, 587, 601, 636, 989, 990, 993, 995, 1719, 1720, 1723, 2049, 3659,
+  4045, 4190, 5060, 5061, 6000, 6566, 6665, 6666, 6667, 6668, 6669, 6679, 6697,
+  10080,
+]);
+
+/** True if `port` is on the WHATWG fetch bad-ports list (node `fetch` refuses it). */
+export function isFetchBlockedPort(port: number): boolean {
+  return FETCH_BLOCKED_PORTS.has(port);
+}
+
 /** Agent name validation: alphanumeric, underscore, hyphen. Max 64 chars. */
 const AGENT_NAME_PATTERN = /^[a-zA-Z0-9][a-zA-Z0-9_-]{0,63}$/;
 
@@ -539,7 +565,7 @@ export function allocatePort(
     // agents that may still be running but have stale registry entries
     const usedPorts = new Set(registry.entries.map(e => e.port));
     for (let port = rangeStart; port <= rangeEnd; port++) {
-      if (!usedPorts.has(port) && isPortFreeSync(port)) {
+      if (!usedPorts.has(port) && !FETCH_BLOCKED_PORTS.has(port) && isPortFreeSync(port)) {
         return port;
       }
     }
@@ -644,7 +670,7 @@ export function allocatePortByName(
     // agents that may still be running but have stale registry entries
     const usedPorts = new Set(registry.entries.map(e => e.port));
     for (let port = rangeStart; port <= rangeEnd; port++) {
-      if (!usedPorts.has(port) && isPortFreeSync(port)) {
+      if (!usedPorts.has(port) && !FETCH_BLOCKED_PORTS.has(port) && isPortFreeSync(port)) {
         return port;
       }
     }

--- a/tests/unit/agent-registry.test.ts
+++ b/tests/unit/agent-registry.test.ts
@@ -463,4 +463,43 @@ describe('AgentRegistry', () => {
       expect(agentC).toBeDefined();
     });
   });
+
+  // ── Fetch-blocked port avoidance (2026-06-02 incident) ──────────────
+  // The mesh does all cross-machine I/O over node `fetch`, which throws
+  // "bad port" for WHATWG-blocked ports (e.g. 4045 = NFS lockd). The default
+  // allocation range 4040–4099 contains 4045, so the allocator must never hand
+  // it out, or the agent silently can't mesh.
+  describe('fetch-blocked port avoidance', () => {
+    it('isFetchBlockedPort flags WHATWG bad ports on both sides of the boundary', async () => {
+      const { isFetchBlockedPort } = await getRegistry();
+      // Blocked (on the WHATWG list):
+      expect(isFetchBlockedPort(4045)).toBe(true);  // NFS lockd — the live incident port
+      expect(isFetchBlockedPort(6000)).toBe(true);  // X11
+      expect(isFetchBlockedPort(6697)).toBe(true);  // IRC+TLS
+      expect(isFetchBlockedPort(2049)).toBe(true);  // NFS
+      // Not blocked (normal agent ports):
+      expect(isFetchBlockedPort(4040)).toBe(false);
+      expect(isFetchBlockedPort(4046)).toBe(false);
+      expect(isFetchBlockedPort(4050)).toBe(false);
+      expect(isFetchBlockedPort(4099)).toBe(false);
+    });
+
+    it('allocatePort never returns a fetch-blocked port (skips it even as the sole candidate)', async () => {
+      const { allocatePort } = await getRegistry();
+      // The only candidate in the range is the blocked port 4045 → the blocklist
+      // check precedes the lsof probe, so allocation must fail rather than return
+      // a port the mesh can never reach. (Deterministic regardless of whether
+      // 4045 is actually free on the host.)
+      expect(() => allocatePort('/tmp/blocked-port-agent', 4045, 4045)).toThrow(/No free ports/);
+    });
+
+    it('allocatePort skips a blocked port and returns the next usable one', async () => {
+      const { allocatePort } = await getRegistry();
+      // Range [4045, 4099]: 4045 is blocked and must be skipped; the allocator
+      // returns the first free, non-blocked port — never 4045.
+      const port = allocatePort('/tmp/skip-blocked-agent', 4045, 4099);
+      expect(port).not.toBe(4045);
+      expect(port).toBeGreaterThan(4045);
+    });
+  });
 });

--- a/upgrades/next/fix-fetch-blocked-ports.md
+++ b/upgrades/next/fix-fetch-blocked-ports.md
@@ -1,0 +1,23 @@
+# Upgrade Guide — vNEXT
+
+<!-- bump: patch -->
+
+## What Changed
+
+Agents are no longer assigned a network port that the multi-machine mesh secretly can't reach.
+
+The mesh talks between machines using Node's built-in web-request function, which refuses a short standard list of "bad ports" (for example 4045, the old file-lock service port). That list includes a port inside the default range agents were picked from — so an agent could be handed a port on which it would silently fail to pair or fail over, with no error in normal tools. The port picker now skips those bad ports, and any agent already running on one prints a clear startup warning telling you to change its port.
+
+## What to Tell Your User
+
+Nothing to do for new agents — they'll automatically avoid the handful of reserved ports that break multi-machine networking. If you run multiple machines and one happens to be on a bad port, the agent now warns you at startup with the exact fix (change its port and restart). This removes a silent, very-hard-to-spot failure where an agent looked healthy but could never join the mesh.
+
+## Summary of New Capabilities
+
+- The agent port allocator skips WHATWG fetch "bad ports" (4045, 6000, 6566, 6697, …), so a new agent never lands on a port the mesh's node-fetch comms can't reach.
+- A new exported helper, isFetchBlockedPort, plus an unconditional server-startup warning when an existing agent's configured port is on that list (the migration path for already-running agents).
+
+## Evidence
+
+- Root cause of a real 2026-06-02 failure: a paired test agent on port 4045 could never be joined ("fetch failed: bad port") even though curl reached its pairing endpoint; moving it off 4045 fixed the join immediately.
+- `tsc --noEmit` clean; 34 agent-registry unit tests green, including 3 new ones covering the blocklist helper (both sides of the boundary) and the allocator skipping a blocked port. Side-effects review: upgrades/side-effects/fix-fetch-blocked-ports.md.

--- a/upgrades/side-effects/fix-fetch-blocked-ports.md
+++ b/upgrades/side-effects/fix-fetch-blocked-ports.md
@@ -1,0 +1,74 @@
+# Side-Effects Review — Skip WHATWG fetch-blocked ports in agent port allocation
+
+**Version / slug:** `fix-fetch-blocked-ports`
+**Date:** `2026-06-02`
+**Author:** `echo`
+**Tier:** 1 (small, low-risk; ELI16 + side-effects, no converged spec)
+**Parent principle:** Cross-Machine Coherence — One Agent, Robust Under Degraded Conditions
+
+## Summary of the change
+
+Instar's multi-machine mesh does ALL cross-machine I/O over node's global `fetch`
+(pairing `POST /api/pair`, lease broadcast/pull, heartbeat). Node's `fetch` (undici)
+throws `TypeError: fetch failed { cause: 'bad port' }` for any URL whose port is on the
+WHATWG Fetch spec "bad ports" list. The default agent port-allocation range (4040–4099)
+**contains 4045** (NFS `lockd`, a blocked port), so the allocator could hand an agent a
+port on which it can **never** be reached over the mesh — silently, because `curl`
+ignores the blocklist so the endpoint looks healthy.
+
+**Observed live (2026-06-02):** a freshly-paired throwaway test agent landed on 4045 and
+could not be joined — `instar join` failed with "fetch failed" despite `curl` to the same
+`/api/pair` returning 400. Moving it off 4045 fixed the join instantly.
+
+### What changed
+- `src/core/AgentRegistry.ts`: added `FETCH_BLOCKED_PORTS` (the WHATWG bad-ports set) +
+  exported `isFetchBlockedPort(port)`. Both `allocatePort` and `allocatePortByName` now
+  skip blocked ports (in addition to used + lsof-busy ones).
+- `src/commands/server.ts`: an unconditional startup warning when `config.port` is a
+  blocked port — the migration-parity path for EXISTING agents already on one (the
+  allocator guard only protects newly-allocated agents).
+
+## Decision-point inventory
+- allocator: skip vs allocate a port → skip if on the blocklist (the check precedes the
+  lsof probe, so it's deterministic).
+- startup: warn vs silent → warn (loud, non-fatal) when an existing config sits on a
+  blocked port; we do NOT auto-re-port (that would change a running agent's port — left
+  to the operator).
+
+## 1. Over-correction risk
+The blocklist is the fixed WHATWG set; legitimate agent ports (4040–4044, 4046–4099, etc.)
+are unaffected. Only 4045 falls in the default range. Skipping reduces the usable range by
+one port — negligible (60→59).
+
+## 2. Under-correction risk
+Existing agents already on a blocked port aren't auto-fixed (that would change their port);
+the startup warning surfaces it so the operator re-ports. Acceptable — auto-re-porting a
+live agent is riskier than a loud warning.
+
+## 3. Level-of-abstraction fit
+The skip lives in the single port allocator both callers use; the warning at the single
+server-start path. No scattering.
+
+## 4. Signal vs Authority
+Pure deterministic check against a fixed spec list — no LLM, no heuristic. Appropriate.
+
+## 5. External surfaces
+None. No route/config-schema change. `isFetchBlockedPort` is a new pure export.
+
+## 6. Interactions with existing primitives
+The allocator's existing used-port + lsof checks are unchanged; the blocklist is an
+additional AND condition. The warning composes with the existing startup logs.
+
+## 7. Rollback cost
+Trivial: remove the `&& !FETCH_BLOCKED_PORTS.has(port)` clauses + the warning. No state.
+
+## Migration parity
+- New agents: allocator skips blocked ports (no action needed).
+- Existing agents on a blocked port: the startup warning surfaces it (operator re-ports).
+- Pure code; reaches existing agents on the normal dist update. No config/hook migration.
+
+## Tests
+`tsc --noEmit` clean. 34 `agent-registry` unit tests green, including 3 new: `isFetchBlockedPort`
+both sides of the boundary (4045/6000/6697/2049 blocked; 4040/4046/4050/4099 not),
+`allocatePort` throws rather than return a sole blocked candidate, and `allocatePort` skips
+a blocked port to return the next usable one.


### PR DESCRIPTION
## Problem

The multi-machine mesh does **all** cross-machine I/O over node's global `fetch` (pairing `POST /api/pair`, lease broadcast/pull, heartbeat). Node's `fetch` (undici) throws `TypeError: fetch failed { cause: 'bad port' }` for any URL whose port is on the [WHATWG Fetch spec "bad ports" list](https://fetch.spec.whatwg.org/#port-blocking). The default agent port range **4040–4099 contains 4045** (NFS `lockd`, a blocked port), so the allocator could hand an agent a port on which it can **never** be reached over the mesh — and it's invisible, because `curl` ignores the blocklist so the endpoint looks healthy.

**Observed live (2026-06-02):** a freshly-paired throwaway test agent landed on 4045 and could not be joined — `instar join` failed with "fetch failed" despite `curl` to the same `/api/pair` returning normally. Moving it off 4045 fixed the join instantly.

## Fix

- `src/core/AgentRegistry.ts`: add `FETCH_BLOCKED_PORTS` (the WHATWG bad-ports set) + exported `isFetchBlockedPort(port)`. Both `allocatePort` and `allocatePortByName` now skip blocked ports (alongside the existing used-port + lsof-busy checks).
- `src/commands/server.ts`: an unconditional startup warning when `config.port` is a blocked port — the **migration-parity** path for existing agents already on one (the allocator guard only protects newly-allocated agents; we don't auto-re-port a running agent).

## Tests

- `tsc --noEmit` clean.
- 34 `agent-registry` unit tests green, including 3 new: `isFetchBlockedPort` both sides of the boundary (4045/6000/6697/2049 blocked; 4040/4046/4050/4099 not), `allocatePort` throws rather than return a sole blocked candidate, and `allocatePort` skips a blocked port to return the next usable one.

Tier-1 change. Side-effects review: `upgrades/side-effects/fix-fetch-blocked-ports.md`. ELI16: `docs/specs/fix-fetch-blocked-ports.eli16.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)