### PR TITLE
fix(shutdown): #680 Problem B — SQLite close-on-exit registry (15 stores)

### DIFF
--- a/src/commands/server.ts
+++ b/src/commands/server.ts
@@ -18,6 +18,7 @@ import pc from 'picocolors';
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 import { loadConfig, ensureStateDir, detectTmuxPath } from '../core/Config.js';
 import { isNonFatalUncaught } from '../core/uncaughtExceptionPolicy.js';
+import { closeAllSqlite } from '../core/SqliteRegistry.js';
 import { SessionManager } from '../core/SessionManager.js';
 import { StateManager } from '../core/StateManager.js';
 import { StuckInputSentinel } from '../core/StuckInputSentinel.js';
@@ -10014,7 +10015,13 @@ export async function startServer(options: StartOptions): Promise<void> {
     }
 
     // Graceful shutdown
+    let _shuttingDown = false;
     const shutdown = async () => {
+      // Re-entrancy guard: SIGINT+SIGTERM (or a restartDetected racing a signal)
+      // must not run the teardown twice. closeAllSqlite() is itself idempotent,
+      // but the resume-UUID save + sidecar flush should run once.
+      if (_shuttingDown) return;
+      _shuttingDown = true;
       console.log('\nShutting down...');
 
       // Save resume UUIDs for ALL active topic-linked sessions before exit.
@@ -10090,13 +10097,20 @@ export async function startServer(options: StartOptions): Promise<void> {
       if (telegram) await telegram.stop();
       sessionManager.stopMonitoring();
       stuckInputSentinel.stop();
-      // Close SQLite databases before exit — prevents "mutex lock failed" crash
-      // when better-sqlite3 destructors fire during process teardown.
-      topicMemory?.close();
-      semanticMemory?.close();
-      // Integrated-Being v1 — flush stats sidecar (coalesces pending writes).
+      // Integrated-Being v1 — flush stats sidecar (coalesces pending writes)
+      // BEFORE closing SQLite, so no unflushed write is lost.
       try { sharedStateLedger?.shutdown(); } catch { /* best effort */ }
       await server.stop();
+      // Close EVERY registered SQLite handle LAST — after all writers (server,
+      // scheduler, sentinels, telegram) have stopped — to prevent the
+      // "mutex lock failed" SIGABRT when better-sqlite3 static destructors fire
+      // during process teardown. The structural registry (SqliteRegistry.ts)
+      // replaces the old hand-maintained topicMemory/semanticMemory close-list,
+      // which covered only 2 of the 15 long-lived stores.
+      try {
+        const closed = closeAllSqlite();
+        console.log(`[shutdown] closed ${closed} sqlite handle(s)`);
+      } catch { /* best effort */ }
       process.exit(0);
     };
 
@@ -10118,8 +10132,10 @@ export async function startServer(options: StartOptions): Promise<void> {
       }
 
       console.error('[FATAL] Uncaught exception — closing databases before crash:', err.message);
-      try { topicMemory?.close(); } catch { /* best effort */ }
-      try { semanticMemory?.close(); } catch { /* best effort */ }
+      // Close ALL registered SQLite handles (not just topic/semantic memory) so
+      // the crash exit doesn't compound into a "mutex lock failed" SIGABRT on top
+      // of the original error. closeAllSqlite() is best-effort + idempotent.
+      try { closeAllSqlite(); } catch { /* best effort */ }
       process.exit(1);
     });
 

--- a/src/core/FeatureRegistry.ts
+++ b/src/core/FeatureRegistry.ts
@@ -16,6 +16,8 @@ import fs from 'node:fs';
 import path from 'node:path';
 import crypto from 'node:crypto';
 
+import { registerSqliteHandle } from './SqliteRegistry.js';
+
 // Dynamic import for better-sqlite3
 type Database = import('better-sqlite3').Database;
 
@@ -225,6 +227,8 @@ export class FeatureRegistry {
     this.db.pragma('busy_timeout = 5000');
 
     this.createSchema();
+    // Close-on-exit registry (SqliteRegistry.ts) — closed once at shutdown.
+    registerSqliteHandle(() => { try { this.db?.close(); } catch { /* already closed */ } });
   }
 
   /**

--- a/src/core/SqliteRegistry.ts
+++ b/src/core/SqliteRegistry.ts
@@ -1,0 +1,106 @@
+/**
+ * SqliteRegistry — a central close-on-exit registry for every long-lived
+ * better-sqlite3 database handle in the process.
+ *
+ * WHY THIS EXISTS (the bug it fixes):
+ *   When the process calls `process.exit()`, any better-sqlite3 database left
+ *   OPEN triggers a C++ static-destructor `std::mutex` lock during teardown
+ *   (`__cxa_finalize_ranges → exit`), which fails with
+ *   "mutex lock failed: Invalid argument" → std::terminate → SIGABRT. The
+ *   process ABORTS instead of exiting cleanly, and on a crash-loop it never
+ *   recovers. The codebase already knew this and closed TWO stores
+ *   (topicMemory, semanticMemory) before exit — but there are FIFTEEN
+ *   long-lived stores. Any of the other thirteen left open still aborts.
+ *
+ * THE STRUCTURAL FIX (Structure > Willpower):
+ *   Every store signs into ONE registry the moment its db opens. On exit, ONE
+ *   call (`closeAllSqlite`) closes them all. A new store added later is closed
+ *   automatically by registering — the close-list can never silently fall
+ *   behind again (the exact failure mode that produced this bug). This replaces
+ *   the hand-maintained two-store close-list in `server.ts`.
+ *
+ * CONTRACT:
+ *   - register AFTER the db is fully open (never in a half-constructed state);
+ *   - the store's own `.close()` calls the returned unregister fn BEFORE it
+ *     closes its handle, so the registry never double-closes it;
+ *   - `closeAllSqlite()` invokes each registered handle AT MOST ONCE (a closed
+ *     set guards re-entrancy — e.g. SIGTERM after an uncaughtException already
+ *     started teardown), best-effort per handle (a throwing close — such as an
+ *     already-closed handle — never blocks the others);
+ *   - run it LAST on every exit path, AFTER all writers stop + after any WAL
+ *     checkpoint / sidecar flush, so no later tick re-opens a statement on a
+ *     closed db and no unflushed write is lost.
+ *
+ * Spec: docs/specs/MULTI-MACHINE-LEASE-ROBUSTNESS-SPEC.md §Problem B.
+ */
+
+type SqliteCloseFn = () => void;
+
+interface RegisteredHandle {
+  readonly id: number;
+  readonly closeFn: SqliteCloseFn;
+}
+
+// Process-global mutable singleton. Module identity is the lifetime: a single
+// instar process imports this module once and shares one registry.
+const registry = new Map<number, RegisteredHandle>();
+// The "closed set": ids that have already been closed (via closeAllSqlite OR
+// an explicit unregister). Guarantees AT-MOST-ONCE invocation even if both the
+// registry close and an explicit store close target the same handle.
+const closedIds = new Set<number>();
+let nextId = 1;
+
+/**
+ * Register a SQLite handle's close function. Call this AFTER the db is open.
+ * Returns an unregister fn the store MUST call from its own `.close()` BEFORE
+ * closing its handle (so `closeAllSqlite` never double-closes it).
+ */
+export function registerSqliteHandle(closeFn: SqliteCloseFn): () => void {
+  const id = nextId++;
+  registry.set(id, { id, closeFn });
+  return function unregisterSqliteHandle(): void {
+    registry.delete(id);
+    // An explicit store close means this handle is (about to be) closed — record
+    // it so a racing closeAllSqlite never re-invokes a now-stale closeFn.
+    closedIds.add(id);
+  };
+}
+
+/**
+ * Close EVERY registered handle exactly once, best-effort. Returns the number
+ * of handles actually closed. Safe to call multiple times (idempotent via the
+ * closed set) and from any exit path. NEVER throws — a per-handle failure is
+ * swallowed so one bad close can't block the rest (the whole point).
+ */
+export function closeAllSqlite(): number {
+  let closed = 0;
+  // Snapshot: a closeFn could (in principle) touch the registry; iterate a copy.
+  for (const [id, handle] of Array.from(registry.entries())) {
+    registry.delete(id);
+    if (closedIds.has(id)) continue; // already closed — at-most-once
+    closedIds.add(id); // mark BEFORE invoking so a re-entrant call can't double-fire
+    try {
+      handle.closeFn();
+      closed++;
+    } catch {
+      // Best-effort: an already-closed handle throws "database connection is
+      // not open" — that's fine, the goal (no open handle at exit) still holds.
+    }
+  }
+  return closed;
+}
+
+/** Number of handles currently registered (not yet closed/unregistered). */
+export function sqliteRegistrySize(): number {
+  return registry.size;
+}
+
+/**
+ * Test-isolation reset. Clears BOTH the handle list AND the closed set — a
+ * half-reset would leak an "already closed" verdict from one test into the
+ * next (a handle registered in the next test would appear pre-closed).
+ */
+export function __resetSqliteRegistryForTests(): void {
+  registry.clear();
+  closedIds.clear();
+}

--- a/src/core/StopGateDb.ts
+++ b/src/core/StopGateDb.ts
@@ -25,6 +25,7 @@
 
 import Database from 'better-sqlite3';
 import type { Database as BetterSqliteDatabase } from 'better-sqlite3';
+import { registerSqliteHandle } from './SqliteRegistry.js';
 import fs from 'node:fs';
 import path from 'node:path';
 
@@ -168,7 +169,15 @@ export class StopGateDb {
 
     for (const ddl of SCHEMA) this.db.exec(ddl);
     this.prepareStatements();
+    // Close-on-exit registry — see SqliteRegistry.ts. Registered AFTER the db is
+    // fully open so closeAllSqlite() never targets a half-constructed handle.
+    this._unregisterSqlite = registerSqliteHandle(() => {
+      try { this.db?.close(); } catch { /* already closed — fine */ }
+    });
   }
+
+  private _unregisterSqlite?: () => void;
+  private _closed = false;
 
   private prepareStatements(): void {
     this.stmts = {
@@ -367,6 +376,13 @@ export class StopGateDb {
   }
 
   close(): void {
+    // Unregister BEFORE closing our own handle so closeAllSqlite() never
+    // double-closes it. Idempotent via the _closed guard (the spec flagged
+    // StopGateDb.close() as lacking one — better-sqlite3 .close() throws on a
+    // second call).
+    if (this._unregisterSqlite) { this._unregisterSqlite(); this._unregisterSqlite = undefined; }
+    if (this._closed) return;
+    this._closed = true;
     this.db.close();
   }
 }

--- a/src/memory/SemanticMemory.ts
+++ b/src/memory/SemanticMemory.ts
@@ -55,6 +55,7 @@ import {
   isEvidenceVisibleAtScope as rendererIsEvidenceVisibleAtScope,
 } from './EvidenceRenderer.js';
 import { NativeModuleHealer } from './NativeModuleHealer.js';
+import { registerSqliteHandle } from '../core/SqliteRegistry.js';
 
 // Dynamic import for better-sqlite3 (optional dependency)
 type Database = import('better-sqlite3').Database;
@@ -566,6 +567,10 @@ export class SemanticMemory {
     });
 
     this.db = constructor(this.config.dbPath) as Database;
+    // Close-on-exit registry (SqliteRegistry.ts) — the closeFn reads this.db live
+    // so a corruption-recovery reopen later in open() is still covered. Closed
+    // once at shutdown via closeAllSqlite().
+    registerSqliteHandle(() => { try { this.db?.close(); } catch { /* already closed */ } });
 
     // Integrity check — auto-recover from corruption (JSONL is source of truth).
     // Corrupt DBs are quarantined (renamed) not deleted, and a marker file is written

--- a/src/memory/TopicMemory.ts
+++ b/src/memory/TopicMemory.ts
@@ -23,6 +23,7 @@ import path from 'node:path';
 import readline from 'node:readline';
 import { SafeFsExecutor } from '../core/SafeFsExecutor.js';
 import { NativeModuleHealer } from './NativeModuleHealer.js';
+import { registerSqliteHandle } from '../core/SqliteRegistry.js';
 
 // Dynamic import for better-sqlite3
 type Database = import('better-sqlite3').Database;
@@ -190,6 +191,9 @@ export class TopicMemory {
     this.db!.pragma('busy_timeout = 5000');
 
     this.createSchema();
+    // Close-on-exit registry (SqliteRegistry.ts) — closed once at shutdown; the
+    // closeFn reads this.db live so a corruption-rebuild reopen is still covered.
+    registerSqliteHandle(() => { try { this.db?.close(); } catch { /* already closed */ } });
 
     // Auto-rebuild from JSONL after corruption recovery
     if (this._needsRebuild) {

--- a/src/messaging/MessageProcessingLedger.ts
+++ b/src/messaging/MessageProcessingLedger.ts
@@ -26,6 +26,7 @@
 
 import Database from 'better-sqlite3';
 import type { Database as BetterSqliteDatabase } from 'better-sqlite3';
+import { registerSqliteHandle } from '../core/SqliteRegistry.js';
 import crypto from 'node:crypto';
 import fs from 'node:fs';
 import path from 'node:path';
@@ -86,6 +87,9 @@ export class MessageProcessingLedger {
   private constructor(db: BetterSqliteDatabase, dbPath: string) {
     this.db = db;
     this.path = dbPath;
+    // Close-on-exit registry (SqliteRegistry.ts) — covers both open() and
+    // openMemory(); closed once at shutdown via closeAllSqlite().
+    registerSqliteHandle(() => { try { this.db?.close(); } catch { /* already closed */ } });
   }
 
   static open(agentId: string, stateDir: string): MessageProcessingLedger {

--- a/src/messaging/imessage/NativeBackend.ts
+++ b/src/messaging/imessage/NativeBackend.ts
@@ -19,6 +19,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import os from 'node:os';
 import type { IMessageIncoming, IMessageChat, ConnectionState } from './types.js';
+import { registerSqliteHandle } from '../../core/SqliteRegistry.js';
 
 // Apple Cocoa epoch: 2001-01-01T00:00:00Z in Unix epoch seconds
 const APPLE_EPOCH_OFFSET = 978307200;
@@ -97,6 +98,8 @@ export class NativeBackend extends EventEmitter {
       // while still allowing WAL reads.
       this.db = new Database(this.dbPath, { fileMustExist: true });
       this.db.pragma('query_only = ON');
+      // Close-on-exit registry (SqliteRegistry.ts) — closed once at shutdown.
+      registerSqliteHandle(() => { try { this.db?.close(); } catch { /* already closed */ } });
 
       // Scope poll query to authorized contacts for defense-in-depth.
       // Even if the adapter's auth check is bypassed, the SQL itself won't return

--- a/src/messaging/pending-relay-store.ts
+++ b/src/messaging/pending-relay-store.ts
@@ -29,6 +29,7 @@
 
 import Database from 'better-sqlite3';
 import type { Database as BetterSqliteDatabase } from 'better-sqlite3';
+import { registerSqliteHandle } from '../core/SqliteRegistry.js';
 import fs from 'node:fs';
 import path from 'node:path';
 import { execFileSync } from 'node:child_process';
@@ -143,6 +144,8 @@ export class PendingRelayStore {
   private constructor(db: BetterSqliteDatabase, dbPath: string) {
     this.db = db;
     this.path = dbPath;
+    // Close-on-exit registry (SqliteRegistry.ts) — closed once at shutdown.
+    registerSqliteHandle(() => { try { this.db?.close(); } catch { /* already closed */ } });
   }
 
   static open(agentId: string, stateDir: string): PendingRelayStore {

--- a/src/monitoring/CorrectionLedger.ts
+++ b/src/monitoring/CorrectionLedger.ts
@@ -26,6 +26,7 @@
  * gate keys on (spec §3.5). llm_confidence is LLM-set + advisory only.
  */
 import Database from 'better-sqlite3';
+import { registerSqliteHandle } from '../core/SqliteRegistry.js';
 import type { Database as BetterSqliteDatabase } from 'better-sqlite3';
 import crypto from 'node:crypto';
 import fs from 'node:fs';
@@ -226,6 +227,8 @@ export class CorrectionLedger {
     this.db.pragma('journal_mode = WAL');
     this.db.pragma('synchronous = NORMAL');
     for (const ddl of SCHEMA) this.db.exec(ddl);
+    // Close-on-exit registry (SqliteRegistry.ts) — closed once at shutdown.
+    registerSqliteHandle(() => { try { this.db?.close(); } catch { /* already closed */ } });
   }
 
   /**

--- a/src/monitoring/FailureLedger.ts
+++ b/src/monitoring/FailureLedger.ts
@@ -28,6 +28,7 @@
  *    back into the commit / reconciler / route that observed the failure.
  */
 import Database from 'better-sqlite3';
+import { registerSqliteHandle } from '../core/SqliteRegistry.js';
 import type { Database as BetterSqliteDatabase } from 'better-sqlite3';
 import fs from 'node:fs';
 import os from 'node:os';
@@ -345,6 +346,8 @@ export class FailureLedger {
     this.db.pragma('journal_mode = WAL');
     this.db.pragma('synchronous = NORMAL');
     for (const ddl of SCHEMA) this.db.exec(ddl);
+    // Close-on-exit registry (SqliteRegistry.ts) — closed once at shutdown.
+    registerSqliteHandle(() => { try { this.db?.close(); } catch { /* already closed */ } });
   }
 
   /** Deterministic dedupe key (spec §4.2 M5). */

--- a/src/monitoring/FeatureMetricsLedger.ts
+++ b/src/monitoring/FeatureMetricsLedger.ts
@@ -19,6 +19,7 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import Database from 'better-sqlite3';
+import { registerSqliteHandle } from '../core/SqliteRegistry.js';
 import type { Database as BetterSqliteDatabase } from 'better-sqlite3';
 import { NativeModuleHealer } from '../memory/NativeModuleHealer.js';
 
@@ -137,6 +138,8 @@ export class FeatureMetricsLedger {
     this.db.pragma('journal_mode = WAL');
     this.db.pragma('synchronous = NORMAL');
     for (const ddl of SCHEMA) this.db.exec(ddl);
+    // Close-on-exit registry (SqliteRegistry.ts) — closed once at shutdown.
+    registerSqliteHandle(() => { try { this.db?.close(); } catch { /* already closed */ } });
     this.insertStmt = this.db.prepare(
       `INSERT INTO feature_metrics
          (ts, feature, kind, outcome, tokens_in, tokens_out, latency_ms, model, waited, wait_ms, verdict_id)

--- a/src/monitoring/FrameworkIssueLedger.ts
+++ b/src/monitoring/FrameworkIssueLedger.ts
@@ -25,6 +25,7 @@
  * allowlists on write.
  */
 import Database from 'better-sqlite3';
+import { registerSqliteHandle } from '../core/SqliteRegistry.js';
 import type { Database as BetterSqliteDatabase } from 'better-sqlite3';
 import fs from 'node:fs';
 import path from 'node:path';
@@ -303,6 +304,8 @@ export class FrameworkIssueLedger {
     this.db.pragma('journal_mode = WAL');
     this.db.pragma('synchronous = NORMAL');
     this.db.pragma('busy_timeout = 5000');
+    // Close-on-exit registry (SqliteRegistry.ts) — closed once at shutdown.
+    registerSqliteHandle(() => { try { this.db?.close(); } catch { /* already closed */ } });
     for (const ddl of SCHEMA) {
       try {
         this.db.exec(ddl);

--- a/src/monitoring/TokenLedger.ts
+++ b/src/monitoring/TokenLedger.ts
@@ -13,6 +13,7 @@
  * observes. Routes expose summaries to the dashboard.
  */
 import Database from 'better-sqlite3';
+import { registerSqliteHandle } from '../core/SqliteRegistry.js';
 import type { Database as BetterSqliteDatabase } from 'better-sqlite3';
 import fs from 'node:fs';
 import path from 'node:path';
@@ -354,6 +355,10 @@ export class TokenLedger {
     );
     this.db.pragma('journal_mode = WAL');
     this.db.pragma('synchronous = NORMAL');
+    // Close-on-exit registry (SqliteRegistry.ts) — closed once at shutdown via
+    // closeAllSqlite(). The registry's at-most-once closed-set + this idempotent
+    // closeFn make an explicit unregister unnecessary for this lifetime singleton.
+    registerSqliteHandle(() => { try { this.db?.close(); } catch { /* already closed */ } });
     for (const ddl of SCHEMA) {
       try {
         this.db.exec(ddl);

--- a/src/providers/uxConfirm/PreferenceStore.ts
+++ b/src/providers/uxConfirm/PreferenceStore.ts
@@ -20,6 +20,7 @@
 
 import Database from 'better-sqlite3';
 import type { Database as BetterSqliteDatabase } from 'better-sqlite3';
+import { registerSqliteHandle } from '../../core/SqliteRegistry.js';
 import fs from 'node:fs';
 import path from 'node:path';
 
@@ -57,6 +58,7 @@ export interface PreferenceStoreOptions {
 
 export class PreferenceStore {
   private readonly db: BetterSqliteDatabase;
+  private _unregisterSqlite?: () => void;
 
   constructor(options: PreferenceStoreOptions) {
     if (options.dbPath !== ':memory:') {
@@ -71,6 +73,10 @@ export class PreferenceStore {
     this.db = new Database(options.dbPath);
     this.db.pragma('journal_mode = WAL');
     this.initSchema();
+    // Close-on-exit registry (SqliteRegistry.ts). Registered after the db is open.
+    this._unregisterSqlite = registerSqliteHandle(() => {
+      try { this.db?.close(); } catch { /* already closed — fine */ }
+    });
   }
 
   private initSchema(): void {
@@ -186,6 +192,7 @@ export class PreferenceStore {
 
   /** Close the underlying database connection. */
   close(): void {
+    if (this._unregisterSqlite) { this._unregisterSqlite(); this._unregisterSqlite = undefined; }
     this.db.close();
   }
 }

--- a/src/threadline/SpawnLedger.ts
+++ b/src/threadline/SpawnLedger.ts
@@ -21,6 +21,7 @@
  */
 
 import Database from 'better-sqlite3';
+import { registerSqliteHandle } from '../core/SqliteRegistry.js';
 import crypto from 'node:crypto';
 import path from 'node:path';
 import fs from 'node:fs';
@@ -73,6 +74,7 @@ const DEFAULTS = {
 export class SpawnLedger {
   private db: Database.Database;
   private opts: Required<SpawnLedgerOptions>;
+  private _unregisterSqlite?: () => void;
 
   constructor(dbPath: string, opts: SpawnLedgerOptions = {}) {
     fs.mkdirSync(path.dirname(dbPath), { recursive: true });
@@ -82,6 +84,10 @@ export class SpawnLedger {
     this.db.pragma('foreign_keys = ON');
     this.opts = { ...DEFAULTS, ...opts };
     this.applySchema();
+    // Close-on-exit registry (SqliteRegistry.ts). Registered after the db is open.
+    this._unregisterSqlite = registerSqliteHandle(() => {
+      try { this.db?.close(); } catch { /* already closed — fine */ }
+    });
   }
 
   private applySchema(): void {
@@ -256,6 +262,7 @@ export class SpawnLedger {
   }
 
   close(): void {
+    if (this._unregisterSqlite) { this._unregisterSqlite(); this._unregisterSqlite = undefined; }
     try {
       this.db.pragma('wal_checkpoint(TRUNCATE)');
     } catch {

--- a/src/threadline/relay/RegistryStore.ts
+++ b/src/threadline/relay/RegistryStore.ts
@@ -9,6 +9,7 @@
  */
 
 import Database from 'better-sqlite3';
+import { registerSqliteHandle } from '../../core/SqliteRegistry.js';
 import crypto from 'node:crypto';
 import path from 'node:path';
 import fs from 'node:fs';
@@ -183,6 +184,8 @@ export class RegistryStore {
 
     this.initSchema();
     this.resetOnlineStatus();
+    // Close-on-exit registry (SqliteRegistry.ts) — closed once at shutdown.
+    registerSqliteHandle(() => { try { this.db?.close(); } catch { /* already closed */ } });
 
     // Start stale cleanup cron (every 24 hours)
     this.staleCronTimer = setInterval(() => this.runStaleCron(), 24 * 60 * 60 * 1000);

--- a/tests/integration/sqlite-close-on-exit.test.ts
+++ b/tests/integration/sqlite-close-on-exit.test.ts
@@ -1,0 +1,109 @@
+/**
+ * Lifecycle / integration tests for the SQLite close-on-exit registry
+ * (docs/specs/MULTI-MACHINE-LEASE-ROBUSTNESS-SPEC.md §Problem B).
+ *
+ * Proves the registry closes REAL better-sqlite3 handles, and that server.ts
+ * wires closeAllSqlite() into every exit path in the correct ORDER (last, after
+ * the writers stop) — the ordering that prevents the "mutex lock failed" SIGABRT.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import Database from 'better-sqlite3';
+import {
+  registerSqliteHandle,
+  closeAllSqlite,
+  sqliteRegistrySize,
+  __resetSqliteRegistryForTests,
+} from '../../src/core/SqliteRegistry.js';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+import { StopGateDb } from '../../src/core/StopGateDb.js';
+
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..');
+
+describe('SQLite close-on-exit — real handles', () => {
+  let tmp: string;
+  beforeEach(() => {
+    __resetSqliteRegistryForTests();
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'sqlite-close-'));
+  });
+  afterEach(() => {
+    try { SafeFsExecutor.safeRmSync(tmp, { recursive: true, force: true, operation: 'tests/integration/sqlite-close-on-exit.test.ts' }); } catch { /* ignore */ }
+  });
+
+  it('closeAllSqlite actually closes real better-sqlite3 handles', () => {
+    const dbs = [0, 1, 2].map((i) => {
+      const db = new Database(path.join(tmp, `h${i}.db`));
+      registerSqliteHandle(() => db.close());
+      return db;
+    });
+    expect(dbs.every((d) => d.open)).toBe(true);
+
+    const closed = closeAllSqlite();
+
+    expect(closed).toBe(3);
+    expect(dbs.every((d) => !d.open)).toBe(true); // every real handle is now CLOSED
+    expect(sqliteRegistrySize()).toBe(0);
+  });
+
+  it('a real store (StopGateDb) is closed by closeAllSqlite without throwing', () => {
+    const store = new StopGateDb({ dbPath: path.join(tmp, 'sg.db') });
+    expect(sqliteRegistrySize()).toBe(1);
+
+    expect(() => closeAllSqlite()).not.toThrow();
+    expect(sqliteRegistrySize()).toBe(0);
+
+    // The store's own close() is now idempotent (the spec-flagged guard) — a
+    // later explicit close must not throw a double-close error.
+    expect(() => store.close()).not.toThrow();
+  });
+
+  it('a double closeAllSqlite (e.g. SIGTERM after uncaughtException) is safe', () => {
+    const db = new Database(path.join(tmp, 'x.db'));
+    registerSqliteHandle(() => db.close());
+    expect(closeAllSqlite()).toBe(1);
+    expect(() => closeAllSqlite()).not.toThrow();
+    expect(closeAllSqlite()).toBe(0);
+    expect(db.open).toBe(false);
+  });
+});
+
+describe('SQLite close-on-exit — server.ts wiring (ordering)', () => {
+  const serverSrc = fs.readFileSync(path.join(REPO_ROOT, 'src', 'commands', 'server.ts'), 'utf8');
+
+  it('imports closeAllSqlite from the registry', () => {
+    expect(serverSrc).toMatch(/import\s*\{\s*closeAllSqlite\s*\}\s*from\s*'\.\.\/core\/SqliteRegistry\.js'/);
+  });
+
+  it('the graceful shutdown calls closeAllSqlite() AFTER server.stop() (writers stopped first)', () => {
+    const shutdownStart = serverSrc.indexOf('const shutdown = async () => {');
+    expect(shutdownStart).toBeGreaterThan(0);
+    // bound the search to the shutdown function body
+    const body = serverSrc.slice(shutdownStart, shutdownStart + 6000);
+    const stopIdx = body.indexOf('await server.stop()');
+    expect(stopIdx).toBeGreaterThan(0);
+    // Find the actual CALL after server.stop() — there is an incidental mention
+    // of closeAllSqlite() in the re-entrancy-guard comment earlier in the body,
+    // so search from stopIdx forward for the real post-stop close.
+    const closeAfterStop = body.indexOf('closeAllSqlite()', stopIdx);
+    expect(closeAfterStop).toBeGreaterThan(stopIdx); // close LAST, after the server stops
+  });
+
+  it('the uncaughtException handler closes ALL sqlite (not just topic/semantic memory)', () => {
+    const uncaughtStart = serverSrc.indexOf("process.on('uncaughtException'");
+    expect(uncaughtStart).toBeGreaterThan(0);
+    const body = serverSrc.slice(uncaughtStart, uncaughtStart + 1200);
+    expect(body).toMatch(/closeAllSqlite\(\)/);
+  });
+
+  it('the old hand-maintained 2-store close-list is gone from the exit paths', () => {
+    // The explicit topicMemory?.close()/semanticMemory?.close() in the shutdown +
+    // uncaughtException paths are replaced by closeAllSqlite(). (They may still be
+    // referenced elsewhere, but not as the exit-path close-list.)
+    expect(serverSrc).not.toMatch(/try\s*\{\s*topicMemory\?\.close\(\);\s*\}\s*catch/);
+    expect(serverSrc).not.toMatch(/try\s*\{\s*semanticMemory\?\.close\(\);\s*\}\s*catch/);
+  });
+});

--- a/tests/unit/SqliteRegistry-wiring.test.ts
+++ b/tests/unit/SqliteRegistry-wiring.test.ts
@@ -1,0 +1,138 @@
+/**
+ * Wiring-integrity tests for the SQLite close-on-exit registry (P4 Wiring
+ * Integrity; docs/specs/MULTI-MACHINE-LEASE-ROBUSTNESS-SPEC.md §Problem B).
+ *
+ * Two guards:
+ *   1. ALLOWLIST COMPLETENESS (static) — every long-lived store registers, and
+ *      every better-sqlite3 open-callsite in src/ is accounted for (either a
+ *      long-lived store that registers, OR an explicitly-allowlisted transient).
+ *      This is the structural guarantee that a NEW store added later can't
+ *      silently fall out of the close-list — the exact bug this fixes.
+ *   2. REGISTRATION FIRES (functional) — instantiating a representative store
+ *      against a real temp db actually grows the registry by one.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+  sqliteRegistrySize,
+  __resetSqliteRegistryForTests,
+} from '../../src/core/SqliteRegistry.js';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+import { StopGateDb } from '../../src/core/StopGateDb.js';
+import { PreferenceStore } from '../../src/providers/uxConfirm/PreferenceStore.js';
+import { SpawnLedger } from '../../src/threadline/SpawnLedger.js';
+
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..');
+const SRC = path.join(REPO_ROOT, 'src');
+
+/** The 15 long-lived (process-lifetime) SQLite stores — the registry allowlist. */
+const LONG_LIVED_STORES = [
+  'src/core/StopGateDb.ts',
+  'src/core/FeatureRegistry.ts',
+  'src/providers/uxConfirm/PreferenceStore.ts',
+  'src/threadline/SpawnLedger.ts',
+  'src/threadline/relay/RegistryStore.ts',
+  'src/monitoring/TokenLedger.ts',
+  'src/monitoring/CorrectionLedger.ts',
+  'src/monitoring/FailureLedger.ts',
+  'src/monitoring/FeatureMetricsLedger.ts',
+  'src/monitoring/FrameworkIssueLedger.ts',
+  'src/memory/TopicMemory.ts',
+  'src/memory/SemanticMemory.ts',
+  'src/messaging/MessageProcessingLedger.ts',
+  'src/messaging/pending-relay-store.ts',
+  'src/messaging/imessage/NativeBackend.ts',
+];
+
+/**
+ * Files that open a better-sqlite3 handle but legitimately do NOT register —
+ * each documented as a transient (closes itself) or a non-owning helper.
+ */
+const TRANSIENT_SKIP: Record<string, string> = {
+  'src/commands/server.ts': ':memory: probe testDb — closes itself immediately',
+  'src/server/routes.ts': 'readonly per-request open — closed per request, not process-lifetime',
+  'src/memory/NativeModuleHealer.ts': 'generic ABI-heal helper — owns no handle (a comment mentions new Database)',
+};
+
+function walkTs(dir: string, acc: string[] = []): string[] {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (entry.name === 'node_modules') continue;
+      walkTs(full, acc);
+    } else if (entry.name.endsWith('.ts') && !entry.name.endsWith('.d.ts')) {
+      acc.push(full);
+    }
+  }
+  return acc;
+}
+
+describe('SqliteRegistry wiring — allowlist completeness (static)', () => {
+  it('every long-lived store calls registerSqliteHandle', () => {
+    const missing: string[] = [];
+    for (const rel of LONG_LIVED_STORES) {
+      const src = fs.readFileSync(path.join(REPO_ROOT, rel), 'utf8');
+      if (!/registerSqliteHandle\s*\(/.test(src)) missing.push(rel);
+    }
+    expect(missing).toEqual([]);
+  });
+
+  it('every better-sqlite3 open-callsite in src/ is accounted for (no silent un-registered store)', () => {
+    // Detect ANY way a store opens a handle: literal `new Database(` /
+    // `new BetterSqlite3(`, OR the NativeModuleHealer.openWithHealSync wrapper.
+    const OPEN_RE = /new\s+Database\s*\(|new\s+BetterSqlite3\s*\(|openWithHealSync\s*\(/;
+    const unaccounted: string[] = [];
+    for (const abs of walkTs(SRC)) {
+      const rel = path.relative(REPO_ROOT, abs).replace(/\\/g, '/');
+      // The registry module itself + test fixtures are not stores.
+      if (rel === 'src/core/SqliteRegistry.ts') continue;
+      const src = fs.readFileSync(abs, 'utf8');
+      if (!OPEN_RE.test(src)) continue;
+      const isLongLived = LONG_LIVED_STORES.includes(rel);
+      const isTransient = rel in TRANSIENT_SKIP;
+      if (!isLongLived && !isTransient) {
+        unaccounted.push(rel);
+      }
+      // A long-lived store that opens a handle MUST register.
+      if (isLongLived && !/registerSqliteHandle\s*\(/.test(src)) {
+        unaccounted.push(`${rel} (long-lived but does not register!)`);
+      }
+    }
+    // If this fails, a NEW sqlite store was added: either register it (and add
+    // to LONG_LIVED_STORES) or document it in TRANSIENT_SKIP with the reason.
+    expect(unaccounted).toEqual([]);
+  });
+});
+
+describe('SqliteRegistry wiring — registration fires (functional)', () => {
+  let tmp: string;
+  beforeEach(() => {
+    __resetSqliteRegistryForTests();
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'sqlite-reg-'));
+  });
+  afterEach(() => {
+    try { SafeFsExecutor.safeRmSync(tmp, { recursive: true, force: true, operation: 'tests/unit/SqliteRegistry-wiring.test.ts' }); } catch { /* ignore */ }
+  });
+
+  it('StopGateDb registers on construct', () => {
+    expect(sqliteRegistrySize()).toBe(0);
+    new StopGateDb({ dbPath: path.join(tmp, 'stopgate.db') });
+    expect(sqliteRegistrySize()).toBe(1);
+  });
+
+  it('PreferenceStore registers on construct', () => {
+    expect(sqliteRegistrySize()).toBe(0);
+    new PreferenceStore({ dbPath: path.join(tmp, 'prefs.db') });
+    expect(sqliteRegistrySize()).toBe(1);
+  });
+
+  it('SpawnLedger registers on construct', () => {
+    expect(sqliteRegistrySize()).toBe(0);
+    new SpawnLedger(path.join(tmp, 'spawn.db'));
+    expect(sqliteRegistrySize()).toBe(1);
+  });
+});

--- a/tests/unit/SqliteRegistry.test.ts
+++ b/tests/unit/SqliteRegistry.test.ts
@@ -1,0 +1,90 @@
+/**
+ * Unit tests for SqliteRegistry — the close-on-exit registry that fixes the
+ * "mutex lock failed" SIGABRT (docs/specs/MULTI-MACHINE-LEASE-ROBUSTNESS-SPEC.md
+ * §Problem B). Pure logic, no real databases.
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  registerSqliteHandle,
+  closeAllSqlite,
+  sqliteRegistrySize,
+  __resetSqliteRegistryForTests,
+} from '../../src/core/SqliteRegistry.js';
+
+describe('SqliteRegistry', () => {
+  beforeEach(() => __resetSqliteRegistryForTests());
+
+  it('closes every registered handle and reports the count', () => {
+    const closed: number[] = [];
+    for (let i = 0; i < 5; i++) registerSqliteHandle(() => closed.push(i));
+    expect(sqliteRegistrySize()).toBe(5);
+
+    const n = closeAllSqlite();
+
+    expect(n).toBe(5);
+    expect([...closed].sort((a, b) => a - b)).toEqual([0, 1, 2, 3, 4]);
+    expect(sqliteRegistrySize()).toBe(0);
+  });
+
+  it('a throwing close does NOT block the other handles (best-effort)', () => {
+    const closed: string[] = [];
+    registerSqliteHandle(() => { closed.push('a'); });
+    registerSqliteHandle(() => { throw new Error('database connection is not open'); });
+    registerSqliteHandle(() => { closed.push('c'); });
+
+    const n = closeAllSqlite();
+
+    // a + c closed; the thrower is swallowed (this is the whole point — one bad
+    // close can't abort the process teardown).
+    expect(n).toBe(2);
+    expect(closed).toContain('a');
+    expect(closed).toContain('c');
+  });
+
+  it('closeAllSqlite never throws even if EVERY handle throws', () => {
+    registerSqliteHandle(() => { throw new Error('boom1'); });
+    registerSqliteHandle(() => { throw new Error('boom2'); });
+    expect(() => closeAllSqlite()).not.toThrow();
+    expect(closeAllSqlite()).toBe(0); // all already drained
+  });
+
+  it('unregister removes a handle so closeAllSqlite skips it (unregister-before-close)', () => {
+    let aClosed = 0;
+    let bClosed = 0;
+    const unA = registerSqliteHandle(() => { aClosed++; });
+    registerSqliteHandle(() => { bClosed++; });
+
+    unA(); // the store's own .close() unregistered before closing its handle
+    expect(sqliteRegistrySize()).toBe(1);
+
+    closeAllSqlite();
+    expect(aClosed).toBe(0); // never invoked by the registry — the store closed it
+    expect(bClosed).toBe(1);
+  });
+
+  it('invokes each handle AT MOST ONCE — a second closeAllSqlite is a no-op', () => {
+    let count = 0;
+    registerSqliteHandle(() => { count++; });
+
+    expect(closeAllSqlite()).toBe(1);
+    expect(closeAllSqlite()).toBe(0); // re-entrancy guard (e.g. SIGTERM after uncaughtException)
+    expect(count).toBe(1);
+  });
+
+  it('__resetSqliteRegistryForTests clears BOTH the handle list AND the closed set', () => {
+    // Close a handle so its id lands in the closed set.
+    registerSqliteHandle(() => {});
+    closeAllSqlite();
+
+    __resetSqliteRegistryForTests();
+
+    // A freshly registered handle must NOT appear pre-closed (a half-reset that
+    // left the closed set would leak an "already closed" verdict into this test).
+    let closed = 0;
+    registerSqliteHandle(() => { closed++; });
+    expect(sqliteRegistrySize()).toBe(1);
+    expect(closeAllSqlite()).toBe(1);
+    expect(closed).toBe(1);
+  });
+});

--- a/upgrades/side-effects/sqlite-close-on-exit-registry.md
+++ b/upgrades/side-effects/sqlite-close-on-exit-registry.md
@@ -1,0 +1,27 @@
+# Side-effects review — SQLite close-on-exit registry (#680 Problem B)
+
+**Spec:** `docs/specs/MULTI-MACHINE-LEASE-ROBUSTNESS-SPEC.md` §Problem B (converged 3 rounds, approved).
+**Change:** a central `SqliteRegistry` (`registerSqliteHandle` / `closeAllSqlite` / `__resetSqliteRegistryForTests`); all 15 long-lived better-sqlite3 stores register their handle after open; `server.ts` closes every registered handle LAST on both exit paths (graceful shutdown + uncaughtException), replacing the hand-maintained 2-store close-list.
+
+## What it touches
+- **New module** `src/core/SqliteRegistry.ts` — pure, process-global singleton. No I/O, no deps.
+- **15 store constructors** gain one `registerSqliteHandle(() => this.db?.close())` call after the db is open (StopGateDb, FeatureRegistry, PreferenceStore, SpawnLedger, RegistryStore, TokenLedger, CorrectionLedger, FailureLedger, FeatureMetricsLedger, FrameworkIssueLedger, TopicMemory, SemanticMemory, MessageProcessingLedger, pending-relay-store, iMessage NativeBackend). StopGateDb + PreferenceStore + SpawnLedger also unregister + (StopGateDb) gained a `_closed` idempotency guard.
+- **`src/commands/server.ts`** — `shutdown()` gained a re-entrancy guard and now calls `closeAllSqlite()` after `server.stop()` (was: explicit `topicMemory?.close()` + `semanticMemory?.close()` before `server.stop()`); the `uncaughtException` handler calls `closeAllSqlite()`.
+
+## Side effects & blast radius
+- **Behavior change at exit only.** No runtime/request-path behavior changes — registration is a no-op at steady state; the only new work happens during process teardown.
+- **Ordering moved:** SQLite now closes AFTER `server.stop()` (writers stopped first) instead of before. This is intentional and safer — no route can touch a closed handle because the HTTP server is already stopped. The sidecar flush (`sharedStateLedger.shutdown()`) still runs before the close so no write is lost.
+- **Double-close safety:** better-sqlite3 `.close()` throws on an already-closed handle. The registry guards this three ways — unregister-before-explicit-close, an at-most-once closed-set, and a per-handle try/catch in `closeAllSqlite()` — so a store explicitly closed at runtime and then drained at exit cannot crash teardown.
+- **Reopen safety:** TopicMemory + SemanticMemory reopen their handle on corruption recovery. The registered closeFn reads `this.db` live (not a captured ref), so the current handle is always the one closed.
+- **Registration leak risk:** registration is fire-and-forget for most stores. These 15 are process-lifetime singletons (registered once), so the registry does not grow unboundedly. A store instantiated many times would accumulate entries — not the case for any of the 15.
+- **Test isolation:** `__resetSqliteRegistryForTests()` clears BOTH the handle list and the closed-set (a half-reset would leak an "already closed" verdict between tests).
+
+## What could go wrong (and why it won't break prod)
+- If a store's closeFn threw, the old code would abort teardown — now each is wrapped best-effort, so one bad close cannot block the others (the whole point).
+- The re-entrancy guard on `shutdown()` means a SIGINT+SIGTERM race (or restartDetected racing a signal) runs the resume-UUID save + flush once, not twice.
+- No migration needed — ships in code, reaches existing agents on normal update. No config/route/schema change.
+
+## Tests (3 tiers, all green)
+- Unit `tests/unit/SqliteRegistry.test.ts` (6) — close-all, throwing-close-isolation, unregister, at-most-once, reset-clears-both.
+- Wiring `tests/unit/SqliteRegistry-wiring.test.ts` (5) — static allowlist completeness (every long-lived store registers; every open-callsite accounted) + functional registration-fires.
+- Lifecycle `tests/integration/sqlite-close-on-exit.test.ts` (7) — real better-sqlite3 handles actually close (`.open === false`); StopGateDb closed without throw; double-close safe; server.ts ordering (closeAllSqlite after server.stop; uncaughtException closes all; old 2-store list gone).


### PR DESCRIPTION
## What & why

Fixes the **"mutex lock failed" SIGABRT crash-loop** observed live during the multi-machine run: any better-sqlite3 handle left **open** when the process calls `process.exit()` aborts during C++ static-destructor teardown. The codebase already knew this but closed only **2 of 15** long-lived stores before exit — so under any fatal exit with the other 13 open, the process aborts instead of exiting, and on a crash-loop never recovers.

This is **Problem B** of the converged spec `docs/specs/MULTI-MACHINE-LEASE-ROBUSTNESS-SPEC.md` (3 convergence rounds, approved). It ships first because a crash-looping holder makes the lease election (Problem A) un-observable.

## The fix (Structure > Willpower)

A central **`SqliteRegistry`** (`src/core/SqliteRegistry.ts`): every store signs in the moment its db opens; one `closeAllSqlite()` call closes them all on exit. A NEW store added later is closed automatically by registering — the close-list can never silently fall behind again (the exact failure mode that produced this bug).

- **15 long-lived stores** register after open. The closeFn reads `this.db` live, so TopicMemory/SemanticMemory **corruption-reopen** is covered. StopGateDb gained the `_closed` idempotency guard the spec flagged.
- **`server.ts`**: `shutdown()` gained a re-entrancy guard and calls `closeAllSqlite()` **LAST** — after `server.stop()` (writers stopped first) and after the sidecar flush — on both the graceful and `uncaughtException` exit paths, replacing the 2-store close-list.
- **At-most-once** closed-set + best-effort per-handle try/catch + unregister-before-explicit-close ⇒ a store closed at runtime and re-drained at exit cannot crash teardown.

## Tests (3 tiers, 18 new, all green)

- **Unit** `tests/unit/SqliteRegistry.test.ts` (6) — close-all, throwing-close isolation, unregister, at-most-once, reset-clears-both-sets.
- **Wiring-integrity** `tests/unit/SqliteRegistry-wiring.test.ts` (5) — static **allowlist completeness** (every long-lived store registers; every `new Database(`/`openWithHealSync(` callsite in `src/` is accounted for — long-lived-and-registers, or explicitly-allowlisted transient) + functional registration-fires.
- **Lifecycle** `tests/integration/sqlite-close-on-exit.test.ts` (7) — real better-sqlite3 handles actually close (`.open === false`); StopGateDb closed without throw; double-close safe; server.ts ordering (closeAllSqlite after server.stop; uncaughtException closes all; old 2-store list gone).

Plus 124 existing store-test regressions + `npm run lint` green. No migration needed (ships in code; no config/route/schema change).

## Note on the 15th store

`SemanticMemory` opens via an injected factory (`constructor(this.config.dbPath)`), invisible to a naive `new Database(` grep — the wiring test enumerates the allowlist explicitly so a factory-constructed store can't slip the close-list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)