### PR TITLE
fix(lease): #680 Problem A — git-less same-epoch split-brain convergence

### DIFF
--- a/src/core/LeaseCoordinator.ts
+++ b/src/core/LeaseCoordinator.ts
@@ -44,6 +44,14 @@ export interface LeaseStore {
    * confirms over the tunnel instead and may no-op this.
    */
   refresh(lease: LeaseRecord): boolean;
+  /**
+   * Force the local self-lease to read as expired (git-less relinquish, spec
+   * §Problem A). Used by LeaseCoordinator.relinquish() to break a same-epoch
+   * contested tie WITHOUT lowering the epoch floor. Optional: only the git-less
+   * LocalLeaseStore implements it; a git-substrate store resolves contention via
+   * CAS instead, so this is a no-op there.
+   */
+  forceLocalExpiry?(): void;
 }
 
 /** Optional low-latency tunnel transport for the lease. */
@@ -235,6 +243,62 @@ export class LeaseCoordinator {
    */
   currentLease(): LeaseRecord | null {
     return this.effectiveView().lease;
+  }
+
+  /**
+   * Relinquish this machine's claim to break a same-epoch contested tie (spec
+   * §Problem A — the deterministic loser, lower-`machineId` LOSES is FALSE: the
+   * lower machineId WINS, the higher relinquishes). Two effects, both required
+   * for convergence:
+   *  (a) clears `selfIssued` AND forces the local store's persisted self-lease to
+   *      read as expired — so we stop being a "live holder at epoch N": the
+   *      winner's `canAcquire()` no longer returns `held-by-live-peer` (it can
+   *      now advance to N+1) and our `holdsLease()` returns false (we reconcile
+   *      to standby);
+   *  (b) we then ADOPT the winner's N+1 lease via the strict-`>` tunnel fold in
+   *      effectiveView() (N+1 > N), so currentHolder() names the winner.
+   * Idempotent. The caller (MultiMachineCoordinator's contested branch) latches
+   * this ONE-SHOT per contested episode so we do not re-clear+re-acquire every
+   * tick (which would re-introduce the leapfrog). The epoch FLOOR is preserved
+   * (forceLocalExpiry keeps the committed epoch) so a replayed stale lease can't
+   * win after we relinquish.
+   */
+  relinquish(): void {
+    this.selfIssued = null;
+    this.d.store.forceLocalExpiry?.();
+    this.log('relinquished self-lease (contested tie-break loser) — winner may now advance to N+1');
+  }
+
+  /**
+   * Force a ONE-TIME epoch advance to resolve a same-epoch contested tie (spec
+   * §Problem A — the WINNER side, lower `machineId`). Unlike acquireIfEligible(),
+   * which RENEWS the same epoch when we already hold it, this builds the NEXT
+   * epoch (N+1) and CAS-writes it, establishing a strictly-higher signed lease
+   * that the contested peer (the loser, having relinquished) adopts via the
+   * strict-`>` tunnel fold. The caller latches this ONE-SHOT per contested
+   * episode (NOT per tick), so it is a tie-resolution, never a per-tick bump →
+   * no leapfrog. Routes through the SAME casWrite/broadcast/sign path as a normal
+   * acquisition. Returns true if the advance landed (or we already hold a
+   * strictly-higher epoch). Idempotent against a peer that advanced first.
+   */
+  async advanceEpochForContestedWin(): Promise<boolean> {
+    const view = this.effectiveView();
+    // buildAcquisition writes currentEpoch+1; currentEpoch is max(self@N, peer@N)=N.
+    const candidate = this.fl.buildAcquisition(view.lease, this.now(), this.nextNonce());
+    const res = this.d.store.casWrite(candidate);
+    if (res.ok) {
+      this.selfIssued = candidate;
+      await this.broadcast(candidate);
+      this.markRenewOk();
+      this.emitEpoch(candidate.epoch);
+      this.log(`advanced to epoch ${candidate.epoch} to resolve contested same-epoch tie (winner)`);
+      return true;
+    }
+    // CAS lost — a strictly-higher epoch already exists (a peer advanced first);
+    // adopt it. Either way the same-epoch tie is broken.
+    this.emitEpoch(res.observed.epoch);
+    this.log(`contested-win advance lost CAS to epoch ${res.observed.epoch} — adopting the higher lease`);
+    return res.observed.lease?.holder === this.selfMachineId;
   }
 
   /**

--- a/src/core/LocalLeaseStore.ts
+++ b/src/core/LocalLeaseStore.ts
@@ -112,4 +112,22 @@ export class LocalLeaseStore implements LeaseStore {
     this.persist(lease); // same epoch, fresh expiry + nonce
     return true;
   }
+
+  /**
+   * Relinquish THIS machine's local self-lease to break a same-epoch contested
+   * tie (spec §Problem A). The deterministic loser forces its persisted lease to
+   * read as EXPIRED — so it stops being a "live holder at epoch N" (the winner's
+   * canAcquire() unblocks; holdsLease() returns false) — while KEEPING the
+   * committed epoch as the CAS/replay floor. (Clearing to epoch 0 would drop the
+   * floor and let a replayed stale lease win; expiring-in-place preserves it.)
+   * The winner then advances to N+1, which the loser adopts via the strict-`>`
+   * tunnel fold in effectiveView(). No-op if there is no local lease.
+   */
+  forceLocalExpiry(): void {
+    this.load();
+    if (!this.cached) return;
+    const expired: LeaseRecord = { ...this.cached, expiresAt: new Date(0).toISOString() };
+    this.persist(expired); // keep epoch + holder as the floor; expiresAt deep-past
+    this.log(`local self-lease forced expired (epoch ${expired.epoch} retained as floor) → relinquished`);
+  }
 }

--- a/src/core/MultiMachineCoordinator.ts
+++ b/src/core/MultiMachineCoordinator.ts
@@ -104,6 +104,18 @@ export class MultiMachineCoordinator extends EventEmitter {
   private leasePulling: boolean = false;
   private leasePullContested: boolean = false;
   private leasePullStopped: boolean = false;
+  /**
+   * Cross-Machine Coherence §Problem A — the active CONTESTED-RESOLUTION state.
+   * When a same-epoch contested split-brain is detected (a git-less LocalLeaseStore
+   * leapfrog), a deterministic tie-break (lower machineId wins) drives a ONE-SHOT
+   * resolution per episode: the loser relinquishes, the winner advances once to
+   * N+1. `key` is the unordered {machineIdA, machineIdB} pair (epoch-independent,
+   * so it SURVIVES the leapfrog where the epoch changes each tick); `resolved`
+   * latches the one-shot (no per-tick re-relinquish/re-advance churn); `cycles`
+   * counts pull ticks the episode persisted; `escalated` dedupes the bounded
+   * K-cycle escalation. Cleared on the falling edge (contested resolved).
+   */
+  private contestedEpisode: { key: string; cycles: number; resolved: boolean; escalated: boolean } | null = null;
 
   constructor(state: StateManager, config: CoordinatorConfig) {
     super();
@@ -629,6 +641,9 @@ export class MultiMachineCoordinator extends EventEmitter {
       if (this.leaseCoordinator!.observedPeerLease()) {
         this.reconcileRoleToLease('lease-pull');
         this.surfacePullDiscoveredSplitBrain();
+        // §Problem A — ACT on a same-epoch contested tie (not just surface it):
+        // deterministic tie-break → loser relinquishes / winner advances once.
+        await this.resolveContestedSplitBrain();
       }
     } catch {
       // @silent-fallback-ok — a pull failure is retried next tick
@@ -664,6 +679,90 @@ export class MultiMachineCoordinator extends EventEmitter {
     } else if (!contested && this.leasePullContested) {
       this.leasePullContested = false;
       console.log('[MultiMachine] lease-pull: contested lease cleared');
+    }
+  }
+
+  /**
+   * §Problem A — RESOLVE a same-epoch contested split-brain (the git-less
+   * LocalLeaseStore leapfrog) to a single holder. surfacePullDiscoveredSplitBrain
+   * only DETECTS + latches the dashboard signal; this ACTS:
+   *
+   *   1. Deterministic tie-break — the lexicographically LOWER `machineId` WINS.
+   *      Both machines compute the SAME winner, so exactly one relinquishes and
+   *      exactly one advances (no coordination needed).
+   *   2. LOSER relinquishes ONCE (clears selfIssued + forces local expiry →
+   *      stops being a live holder@N, reconciles to standby).
+   *   3. WINNER advances ONCE to N+1 (a strictly-higher signed lease the loser
+   *      then adopts via effectiveView()'s strict-`>` tunnel fold → single holder).
+   *
+   * Both actions are LATCHED one-shot per contested episode (keyed on the
+   * epoch-independent {self,peer} pair), so they fire ONCE, not every ~5s tick —
+   * a per-tick relinquish/advance would re-introduce the very leapfrog this fixes.
+   * If the episode persists past K cycles (the resolution genuinely failed — a
+   * stuck/partitioned peer), emit ONE deduped escalation with a DETERMINISTIC
+   * recommendation (demote the tie-break loser). Distinct from the
+   * unresolvable-PARTITION path (checkForUnresolvableSplit); this is the
+   * same-epoch-CONTESTED path. Cleared on the falling edge.
+   */
+  private async resolveContestedSplitBrain(): Promise<void> {
+    if (!this.leaseCoordinator || !this._identity) return;
+    const ESCALATE_AFTER_CYCLES = 5;
+    const self = this._identity.machineId;
+    const peer = this.leaseCoordinator.observedPeerLease();
+    const weHold = this.leaseCoordinator.holdsLease();
+    const ourEpoch = this.leaseCoordinator.currentEpoch();
+    // A genuine same-epoch contested tie: we still hold AND a peer claims a
+    // different-holder lease at our epoch (or higher-but-equal after a leapfrog).
+    const contested = !!(weHold && peer && peer.holder && peer.holder !== self && peer.epoch >= ourEpoch);
+    if (!contested) {
+      // Falling edge — the tie resolved (we adopted the winner, or it cleared).
+      // Drop the episode so a future contested tie starts a fresh latch.
+      this.contestedEpisode = null;
+      return;
+    }
+    const peerHolder = peer!.holder;
+    const episodeKey = [self, peerHolder].sort().join('~'); // epoch-INDEPENDENT
+    if (!this.contestedEpisode || this.contestedEpisode.key !== episodeKey) {
+      this.contestedEpisode = { key: episodeKey, cycles: 0, resolved: false, escalated: false };
+    }
+    const ep = this.contestedEpisode;
+    ep.cycles++;
+    const winner = self < peerHolder ? self : peerHolder; // lower machineId WINS
+    const loser = self < peerHolder ? peerHolder : self;
+    const iAmWinner = winner === self;
+    if (!ep.resolved) {
+      if (iAmWinner) {
+        await this.leaseCoordinator.advanceEpochForContestedWin();
+        console.log(
+          `[MultiMachine] contested tie-break: WON vs ${peerHolder} at epoch ${ourEpoch} ` +
+          `— advanced once to N+1 to break the same-epoch split`,
+        );
+      } else {
+        this.leaseCoordinator.relinquish();
+        this.reconcileRoleToLease('contested-relinquish');
+        console.log(
+          `[MultiMachine] contested tie-break: YIELDED to ${winner} at epoch ${ourEpoch} ` +
+          `— relinquished self-lease (will adopt the winner's N+1)`,
+        );
+      }
+      ep.resolved = true; // one-shot latch — no per-tick churn (no re-leapfrog)
+    }
+    // Bounded escalation: the resolution did NOT converge after K cycles → a
+    // genuinely stuck/partitioned peer. Surface ONCE, deduped per episode, with a
+    // DETERMINISTIC recommendation (never a raw Y/N the operator could mis-answer).
+    if (ep.cycles >= ESCALATE_AFTER_CYCLES && !ep.escalated) {
+      ep.escalated = true;
+      this.emit('splitBrainEscalation', {
+        episodeKey,
+        winner,
+        loser,
+        recommendation: `demote ${loser}`,
+        reason: `same-epoch contested split-brain persisted ${ep.cycles} pull cycles without converging`,
+      });
+      console.warn(
+        `[MultiMachine] contested split-brain UNRESOLVED after ${ep.cycles} cycles — ` +
+        `recommend demoting ${loser} (episode ${episodeKey})`,
+      );
     }
   }
 

--- a/tests/integration/lease-contested-resolution.test.ts
+++ b/tests/integration/lease-contested-resolution.test.ts
@@ -1,0 +1,155 @@
+/**
+ * MultiMachineCoordinator contested-resolution orchestration (#680 Problem A v3,
+ * docs/specs/MULTI-MACHINE-LEASE-ROBUSTNESS-SPEC.md).
+ *
+ * surfacePullDiscoveredSplitBrain only DETECTS; resolveContestedSplitBrain ACTS.
+ * This exercises BOTH sides of the tie-break decision boundary on the real pull
+ * loop (single MMC + a controllable observed peer):
+ *   - WINNER (lower machineId): advances ONCE to N+1, and the one-shot latch
+ *     means the epoch does NOT climb on subsequent ticks (no re-leapfrog).
+ *   - LOSER (higher machineId): relinquishes (holdsLease→false, role→standby).
+ *   - Bounded escalation: a persistently-contested episode emits ONE deduped
+ *     splitBrainEscalation with a deterministic "demote <loser>" recommendation.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import crypto from 'node:crypto';
+import { MultiMachineCoordinator } from '../../src/core/MultiMachineCoordinator.js';
+import { MachineIdentityManager } from '../../src/core/MachineIdentity.js';
+import { StateManager } from '../../src/core/StateManager.js';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+import { FencedLease, type LeaseCrypto } from '../../src/core/FencedLease.js';
+import { LeaseCoordinator, type LeaseTransport } from '../../src/core/LeaseCoordinator.js';
+import { LocalLeaseStore } from '../../src/core/LocalLeaseStore.js';
+import type { LeaseRecord } from '../../src/core/types.js';
+
+function genKey() {
+  return crypto.generateKeyPairSync('ed25519', {
+    publicKeyEncoding: { type: 'spki', format: 'pem' },
+    privateKeyEncoding: { type: 'pkcs8', format: 'pem' },
+  });
+}
+const KEYS: Record<string, { publicKey: string; privateKey: string }> = { Aaa: genKey(), Bbb: genKey(), Zzz: genKey() };
+function crypt(self: string): LeaseCrypto {
+  return {
+    selfMachineId: self,
+    sign: (c) => crypto.sign(null, Buffer.from(c), KEYS[self].privateKey).toString('base64'),
+    verify: (c, sig, holder) => {
+      const pub = KEYS[holder]?.publicKey;
+      if (!pub) return false;
+      try { return crypto.verify(null, Buffer.from(c), pub, Buffer.from(sig, 'base64')); } catch { return false; }
+    },
+  };
+}
+const TTL = 60_000;
+function fl(self: string) { return new FencedLease(crypt(self), { leaseTtlMs: TTL, failoverThresholdMs: 15 * 60_000 }); }
+function seedIdentity(stateDir: string, machineId: string) {
+  const identity = { machineId, signingPublicKey: 'k1', encryptionPublicKey: 'k2', name: machineId, platform: 'test', createdAt: new Date(2_000).toISOString(), capabilities: ['sessions'] };
+  fs.mkdirSync(path.join(stateDir, 'machine'), { recursive: true });
+  fs.writeFileSync(path.join(stateDir, 'machine', 'identity.json'), JSON.stringify(identity));
+  return identity;
+}
+
+describe('MultiMachineCoordinator — contested-resolution (Problem A v3)', () => {
+  let dir: string;
+  beforeEach(() => { dir = fs.mkdtempSync(path.join(os.tmpdir(), 'mmc-resolve-')); });
+  afterEach(() => {
+    vi.useRealTimers();
+    SafeFsExecutor.safeRmSync(dir, { recursive: true, force: true, operation: 'tests/integration/lease-contested-resolution.test.ts' });
+  });
+
+  /** Build one MMC whose machineId === its FencedLease id (so the tie-break is
+   *  meaningful), with a controllable `observed` peer lease. */
+  async function setup(selfId: string, peerLeaseGetter: () => LeaseRecord | null) {
+    seedIdentity(dir, selfId);
+    new MachineIdentityManager(dir).registerMachine(
+      { machineId: selfId, signingPublicKey: 'k1', encryptionPublicKey: 'k2', name: selfId, platform: 'test', createdAt: new Date(2_000).toISOString(), capabilities: ['sessions'] } as any,
+      'awake',
+    );
+    const tunnel: LeaseTransport = {
+      broadcast: async () => true,
+      observed: () => { const p = peerLeaseGetter(); return { lease: p, lastNonceByHolder: p ? { [p.holder]: p.nonce } : {} }; },
+      isReachable: () => true,
+      pullAllPeers: async () => { /* observed() reads the controllable peer */ },
+    };
+    const lc = new LeaseCoordinator({
+      lease: fl(selfId), store: new LocalLeaseStore({ filePath: path.join(dir, 'lease-local.json') }),
+      tunnel, presumedDeadHolders: () => new Set(), now: () => 2_000, monotonicNow: () => 2_000,
+    });
+    vi.useFakeTimers();
+    const coord = new MultiMachineCoordinator(new StateManager(dir), { stateDir: dir, multiMachine: { leasePullIntervalMs: 1_000 } as any });
+    coord.start();
+    coord.attachLeaseCoordinator(lc);
+    await coord.initializeLease(); // selfId acquires epoch 1 (peer not yet visible)
+    return { lc, coord };
+  }
+
+  it('WINNER (lower machineId) advances ONCE to N+1; the latch stops the epoch climbing', async () => {
+    let peer: LeaseRecord | null = null;
+    const { lc, coord } = await setup('Aaa', () => peer);
+    expect(lc.currentEpoch()).toBe(1);
+    expect(lc.holdsLease()).toBe(true);
+
+    // A higher-machineId peer at the same epoch appears (Aaa < Bbb → we WIN).
+    peer = fl('Bbb').buildAcquisition(undefined, 1_000, 7); // Bbb @ epoch 1
+
+    await vi.advanceTimersByTimeAsync(1_300); // one pull tick → resolve → advance
+    expect(lc.currentEpoch()).toBe(2);          // advanced once
+    expect(lc.holdsLease()).toBe(true);
+    expect(lc.currentHolder()).toBe('Aaa');
+
+    // Several more ticks: the one-shot latch means NO further advance (no leapfrog).
+    await vi.advanceTimersByTimeAsync(5_000);
+    expect(lc.currentEpoch()).toBe(2);          // STILL 2 — epoch stopped climbing
+    coord.stop();
+  });
+
+  it('LOSER (higher machineId) relinquishes — stops holding, reconciles to standby', async () => {
+    let peer: LeaseRecord | null = null;
+    const { lc, coord } = await setup('Zzz', () => peer);
+    expect(lc.holdsLease()).toBe(true);
+    expect(coord.isAwake).toBe(true);
+
+    // A lower-machineId peer at the same epoch appears (Aaa < Zzz → we LOSE).
+    peer = fl('Aaa').buildAcquisition(undefined, 1_000, 7); // Aaa @ epoch 1
+
+    await vi.advanceTimersByTimeAsync(1_300); // one pull tick → resolve → relinquish
+    expect(lc.holdsLease()).toBe(false);        // relinquished
+    expect(coord.getSyncStatus().role).toBe('standby');
+    coord.stop();
+  });
+
+  it('bounded escalation: a persistently-contested episode emits ONE deduped splitBrainEscalation', async () => {
+    // A "stuck" peer that keeps pace at our epoch every tick (a leapfrogger that
+    // never converges) → the WINNER advances once, but the peer keeps reappearing
+    // at-or-above our epoch, so the episode persists past K cycles.
+    let peerActive = false; // invisible during the solo acquire, like the other tests
+    let peerEpoch = 1;
+    const peerGetter = (): LeaseRecord | null => {
+      if (!peerActive) return null;
+      // Bbb keeps claiming the SAME epoch we currently hold (a stuck leapfrogger
+      // that never converges). buildAcquisition writes currentEpoch+1, so pass
+      // {epoch: peerEpoch-1} to land the peer exactly at peerEpoch.
+      return fl('Bbb').buildAcquisition({ epoch: peerEpoch - 1 } as unknown as LeaseRecord, 1_000, 100 + peerEpoch);
+    };
+    const { lc, coord } = await setup('Aaa', peerGetter);
+    expect(lc.holdsLease()).toBe(true); // acquired epoch 1 solo
+    peerActive = true;                  // now the stuck leapfrogger appears
+    const escalations: any[] = [];
+    coord.on('splitBrainEscalation', (e: any) => escalations.push(e));
+
+    // Keep the peer pinned at our epoch each tick so `peer.epoch >= ourEpoch` holds.
+    for (let i = 0; i < 8; i++) {
+      peerEpoch = lc.currentEpoch();
+      await vi.advanceTimersByTimeAsync(1_300);
+    }
+
+    expect(escalations.length).toBe(1);                       // deduped — exactly once
+    expect(escalations[0].recommendation).toBe('demote Bbb'); // deterministic loser (Bbb > Aaa)
+    expect(escalations[0].winner).toBe('Aaa');
+    coord.stop();
+  });
+});

--- a/tests/unit/LeaseCoordinator-convergence.test.ts
+++ b/tests/unit/LeaseCoordinator-convergence.test.ts
@@ -1,0 +1,156 @@
+/**
+ * Empirical convergence proof for the git-less same-epoch split-brain fix
+ * (docs/specs/MULTI-MACHINE-LEASE-ROBUSTNESS-SPEC.md §Problem A).
+ *
+ * The DESIGN failed verification twice in convergence (R1 zombie-holder, R2
+ * headless-loser); this test is the ground truth. Two coordinators both hold
+ * epoch N over a git-less LocalLeaseStore (the post-teardown split-brain). After
+ * the v3 resolution — loser relinquishes + winner advances ONCE to N+1 — assert
+ * the SINGLE-holder fixpoint, INCLUDING the headless-loser guard: the loser's
+ * currentHolder() must equal the WINNER (not itself, not null).
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import crypto from 'node:crypto';
+import { FencedLease, type LeaseCrypto } from '../../src/core/FencedLease.js';
+import { LeaseCoordinator } from '../../src/core/LeaseCoordinator.js';
+import { LocalLeaseStore } from '../../src/core/LocalLeaseStore.js';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+import type { LeaseRecord } from '../../src/core/types.js';
+
+function genKey() {
+  return crypto.generateKeyPairSync('ed25519', {
+    publicKeyEncoding: { type: 'spki', format: 'pem' },
+    privateKeyEncoding: { type: 'pkcs8', format: 'pem' },
+  });
+}
+const KEYS: Record<string, { publicKey: string; privateKey: string }> = { A: genKey(), B: genKey() };
+function crypt(self: string): LeaseCrypto {
+  return {
+    selfMachineId: self,
+    sign: (c) => crypto.sign(null, Buffer.from(c), KEYS[self].privateKey).toString('base64'),
+    verify: (c, sig, holder) => {
+      const pub = KEYS[holder]?.publicKey;
+      if (!pub) return false;
+      try { return crypto.verify(null, Buffer.from(c), pub, Buffer.from(sig, 'base64')); } catch { return false; }
+    },
+  };
+}
+const TTL = 60_000;
+const FAILOVER = 15 * 60_000;
+function fl(self: string) { return new FencedLease(crypt(self), { leaseTtlMs: TTL, failoverThresholdMs: FAILOVER }); }
+
+describe('LeaseCoordinator — git-less same-epoch convergence (#680 Problem A v3)', () => {
+  let dir: string;
+  let now: number;
+  let linked: boolean;
+  let mesh: Record<string, LeaseRecord | null>;
+  let lcA: LeaseCoordinator;
+  let lcB: LeaseCoordinator;
+
+  /** Push-based tunnel: broadcast writes mesh[self]; observed reads mesh[peer]
+   *  (only once linked). Reading a buffer — NOT the peer's live currentLease() —
+   *  avoids mutual effectiveView() recursion and models the real push transport. */
+  function tunnelFor(self: string, peer: string) {
+    return {
+      broadcast: async (lease: LeaseRecord) => { mesh[self] = lease; return true; },
+      observed: () => {
+        const p = linked ? mesh[peer] : null;
+        return { lease: p, lastNonceByHolder: p ? { [p.holder]: p.nonce } : {} };
+      },
+      isReachable: () => true,
+      pullAllPeers: async () => { /* push-based: observed() reads the buffer */ },
+    };
+  }
+
+  beforeEach(async () => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'lease-conv-'));
+    now = 2_000;
+    linked = false;
+    mesh = { A: null, B: null };
+    lcA = new LeaseCoordinator({
+      lease: fl('A'), store: new LocalLeaseStore({ filePath: path.join(dir, 'a.json') }),
+      tunnel: tunnelFor('A', 'B'), presumedDeadHolders: () => new Set(), now: () => now, monotonicNow: () => now,
+    });
+    lcB = new LeaseCoordinator({
+      lease: fl('B'), store: new LocalLeaseStore({ filePath: path.join(dir, 'b.json') }),
+      tunnel: tunnelFor('B', 'A'), presumedDeadHolders: () => new Set(), now: () => now, monotonicNow: () => now,
+    });
+    // Post-teardown split-brain: each acquired epoch 1 SOLO (unlinked → no peer
+    // observed), so both believe they hold epoch 1.
+    expect(await lcA.acquireIfEligible()).toBe(true);
+    expect(await lcB.acquireIfEligible()).toBe(true);
+    linked = true; // the tunnel now carries each peer's lease (a push finally arrives)
+  });
+
+  afterEach(() => {
+    try { SafeFsExecutor.safeRmSync(dir, { recursive: true, force: true, operation: 'tests/unit/LeaseCoordinator-convergence.test.ts' }); } catch { /* ignore */ }
+  });
+
+  it('sets up a genuine same-epoch split-brain (both hold epoch 1)', () => {
+    expect(lcA.holdsLease()).toBe(true);
+    expect(lcB.holdsLease()).toBe(true);
+    expect(lcA.currentHolder()).toBe('A');
+    expect(lcB.currentHolder()).toBe('B');
+    expect(lcA.currentEpoch()).toBe(1);
+    expect(lcB.currentEpoch()).toBe(1);
+  });
+
+  it('CONVERGES when the winner advances then the loser relinquishes', async () => {
+    // A = lower machineId = winner; B = loser.
+    await lcA.advanceEpochForContestedWin(); // A → epoch 2, broadcast
+    lcB.relinquish();                        // B clears selfIssued + forces local expiry
+
+    // Winner: holds epoch 2.
+    expect(lcA.holdsLease()).toBe(true);
+    expect(lcA.currentHolder()).toBe('A');
+    expect(lcA.currentEpoch()).toBe(2);
+
+    // Loser: the HEADLESS-LOSER GUARD — currentHolder() names the WINNER, not
+    // itself, not null. holdsLease() false. This is the assertion R2 caught.
+    expect(lcB.currentHolder()).toBe('A');
+    expect(lcB.holdsLease()).toBe(false);
+    expect(lcB.currentEpoch()).toBe(2);
+  });
+
+  it('CONVERGES regardless of order — loser relinquishes BEFORE the winner advances', async () => {
+    lcB.relinquish();                        // loser yields first
+    await lcA.advanceEpochForContestedWin(); // winner advances after
+
+    expect(lcA.currentHolder()).toBe('A');
+    expect(lcA.holdsLease()).toBe(true);
+    expect(lcA.currentEpoch()).toBe(2);
+    expect(lcB.currentHolder()).toBe('A'); // adopts winner@2 via strict-> fold
+    expect(lcB.holdsLease()).toBe(false);
+  });
+
+  it('the winner advancing ALONE already demotes the loser (strict-> fold adopts N+1)', async () => {
+    // Even without an explicit relinquish, once the winner is at N+1 the loser's
+    // effectiveView folds it in (N+1 > N) and holdsLease() flips false.
+    await lcA.advanceEpochForContestedWin();
+    expect(lcB.currentHolder()).toBe('A');
+    expect(lcB.holdsLease()).toBe(false);
+  });
+
+  it('relinquish() makes the loser stop holding and clears its self-claim', () => {
+    expect(lcB.holdsLease()).toBe(true);
+    lcB.relinquish();
+    expect(lcB.holdsLease()).toBe(false);
+  });
+
+  it('forceLocalExpiry keeps the epoch FLOOR (a cleared-to-0 floor would let a stale lease win)', () => {
+    const store = new LocalLeaseStore({ filePath: path.join(dir, 'c.json') });
+    const lease = fl('A').buildAcquisition(undefined, now, 1); // epoch 1
+    store.casWrite(lease);
+    expect(store.read().epoch).toBe(1);
+    store.forceLocalExpiry();
+    // Epoch floor retained at 1 (not reset to 0); the record now reads expired.
+    expect(store.read().epoch).toBe(1);
+    expect(store.read().lease?.expiresAt).toBe(new Date(0).toISOString());
+    // A same-or-lower epoch CAS still rejected (floor intact).
+    expect(store.casWrite(lease).ok).toBe(false);
+  });
+});

--- a/upgrades/side-effects/git-less-lease-convergence.md
+++ b/upgrades/side-effects/git-less-lease-convergence.md
@@ -1,0 +1,31 @@
+# Side-effects review — git-less same-epoch lease convergence (#680 Problem A v3)
+
+**Spec:** `docs/specs/MULTI-MACHINE-LEASE-ROBUSTNESS-SPEC.md` §Problem A (converged 3 rounds, approved). The design failed verification twice (R1 zombie-holder, R2 headless-loser) before the v3 mechanism — this is why it shipped spec-first.
+
+**Change:** resolve a git-less `LocalLeaseStore` same-epoch leapfrog split-brain to a single holder. When the active pull (#668) observes a peer holding the SAME epoch as our self-issued lease, a deterministic tie-break (lower `machineId` wins) drives a one-shot resolution: the LOSER relinquishes, the WINNER advances once to N+1, the loser adopts N+1 via the existing strict-`>` tunnel fold.
+
+## What it touches (3 files, all on the lease path)
+- **`LocalLeaseStore.forceLocalExpiry()`** (NEW) — expires the persisted self-lease in place, KEEPING the committed epoch as the CAS/replay floor (clearing to 0 would let a replayed stale lease win). No-op if no local lease.
+- **`LeaseCoordinator`** — NEW `relinquish()` (clears `selfIssued` + calls `store.forceLocalExpiry?.()`), NEW `advanceEpochForContestedWin()` (one-time `buildAcquisition`→N+1 via the same casWrite/broadcast/sign path as a normal acquire; bypasses `canAcquire` deliberately — it IS the tie-resolution), + `forceLocalExpiry?()` added as an OPTIONAL method on the `LeaseStore` interface (GitLeaseStore does not implement it → no-op there).
+- **`MultiMachineCoordinator`** — NEW `contestedEpisode` state field + NEW `resolveContestedSplitBrain()` called from `tickLeasePull` after the existing detect-only `surfacePullDiscoveredSplitBrain()`. Tie-break → relinquish (loser) / advance (winner), latched one-shot per episode, K-cycle bounded escalation.
+
+## Side effects & blast radius
+- **Behavior change is confined to a genuine same-epoch contested tie** (two machines both holding epoch N over a git-less store — the post-teardown split-brain). The clean single-holder path, the partition path (checkForUnresolvableSplit), and the git-substrate path (GitLeaseStore) are UNTOUCHED. `forceLocalExpiry` is optional on the interface, so only the git-less store gains the behavior.
+- **The tie-break is deterministic + total-ordered** (lower machineId wins), so all machines compute the SAME winner with no coordination — exactly one relinquishes, exactly one advances. Transitive, so it generalizes to 3+ machines (tested-direction noted in the spec).
+- **One-shot latch per episode** (keyed on the epoch-independent {self,peer} pair) means the relinquish/advance fire ONCE, not every ~5s pull tick — a per-tick action would re-introduce the leapfrog this fixes. The episode clears on the falling edge (tie resolved).
+- **Winner-advance bypasses `canAcquire`** (direct `buildAcquisition`+casWrite). This is intentional: the winner must reach N+1 even while the loser's relinquished-but-floor-intact lease is observed. casWrite still enforces strict epoch advance (N+1 > committed N), so it cannot lower the epoch or forge.
+- **Relinquish → standby → read-only** is the path implicated in the #668 crash incident. #673 (on main) made the standby read-only write non-fatal; this change relies on that and on Problem B (closeAllSqlite) for a clean exit. Per the spec sequencing, B lands first.
+- **Adoption is via the EXISTING strict-`>` fold** — no new adoption write; the loser's `effectiveView()` folds the winner's N+1 (N+1 > N) and `currentHolder()` returns the winner. Verified empirically (the headless-loser guard).
+- **Escalation is observe-only**: a persistently-contested episode emits ONE deduped `splitBrainEscalation` event with a deterministic `demote <loser>` recommendation. It does not auto-act; a consumer routes it to Attention. Distinct from the partition escalation.
+- **No migration** — pure in-process lease logic; no config/route/schema change; reaches existing agents on normal update.
+
+## What could go wrong (and why it won't)
+- **Both advance (leapfrog)?** No — the tie-break gates advance to the winner only; the loser relinquishes. Both latched per-episode.
+- **Loser headless (R2's catch)?** No — the winner advancing to N+1 makes the loser's strict-`>` fold adopt it; `currentHolder()===winner`. Tested.
+- **Stale-lease replay after relinquish?** No — `forceLocalExpiry` keeps the epoch floor; a below-floor lease is rejected by CAS/acceptTunnelLease.
+- **Per-tick churn?** No — the one-shot latch.
+
+## Tests (all green; 9 new + 68 existing lease/MMC regressions)
+- Unit `tests/unit/LeaseCoordinator-convergence.test.ts` (6) — the EMPIRICAL convergence proof: two coordinators both at epoch N converge to a single holder at N+1, with the headless-loser guard (loser's `currentHolder()===winner`), order-independence, winner-advance-alone-adopts, relinquish/forceLocalExpiry primitives + epoch-floor retention.
+- Integration `tests/integration/lease-contested-resolution.test.ts` (3) — the orchestration on the real pull loop: WINNER advances once + latch (epoch stops climbing), LOSER relinquishes (standby), bounded K-cycle escalation (one deduped `demote <loser>`).
+- 68 existing lease/MMC tests unchanged-green; `npm run lint` + `tsc --noEmit` clean.


### PR DESCRIPTION
## What & why

Resolves the **git-less `LocalLeaseStore` same-epoch leapfrog split-brain** observed live: two source-tree-home machines that each booted solo both hold epoch N, and the active pull (#668) only **detected** the contention (a dashboard signal) — it never **resolved** it, so the epoch climbed forever with **two captains**.

This is **Problem A** of the converged spec `docs/specs/MULTI-MACHINE-LEASE-ROBUSTNESS-SPEC.md`. The design **failed verification twice** in convergence (R1 zombie-holder, R2 headless-loser) — which is exactly why it shipped spec-first. The v3 mechanism is now **empirically proven** by the convergence unit test.

## The v3 mechanism

On a same-epoch contested tie:
1. **Deterministic tie-break** — lower `machineId` WINS. A total order, so all machines compute the same winner with no coordination, and it generalizes to 3+ machines (transitive).
2. **LOSER relinquishes once** — `LeaseCoordinator.relinquish()` clears `selfIssued` + `LocalLeaseStore.forceLocalExpiry()` expires the local lease **in place, keeping the epoch as the CAS/replay floor** (clearing to 0 would let a replayed stale lease win). It stops being a live holder@N and reconciles to standby.
3. **WINNER advances once to N+1** — `advanceEpochForContestedWin()` (a `buildAcquisition` via the normal casWrite/broadcast/sign path). The loser then adopts N+1 via the **existing strict-`>` tunnel fold** (N+1 > N) — no new adoption write. Single holder; epoch stops climbing.

Both actions are **latched one-shot per contested episode** (keyed on the epoch-independent `{self,peer}` pair) so they fire once, not every ~5s pull tick — a per-tick action would re-introduce the leapfrog. A persistently-contested episode emits **one deduped** `splitBrainEscalation` with a deterministic `demote <loser>` recommendation.

Wired into `MultiMachineCoordinator.resolveContestedSplitBrain()`, called from `tickLeasePull` after the detect-only `surfacePullDiscoveredSplitBrain`.

## Tests (9 new, all green; 68 existing lease/MMC regressions unchanged-green)

- **Unit** `tests/unit/LeaseCoordinator-convergence.test.ts` (6) — the **empirical convergence proof**: two coordinators both at epoch N converge to a single holder at N+1, with the **headless-loser guard** (loser's `currentHolder()===winner`, not itself/null — the assertion R2 caught), order-independence, winner-advance-alone-adopts, and the relinquish/forceLocalExpiry primitives + epoch-floor retention.
- **Integration** `tests/integration/lease-contested-resolution.test.ts` (3) — the orchestration on the real pull loop: WINNER advances once + **latch** (epoch stops climbing), LOSER relinquishes (→ standby), bounded K-cycle escalation (one deduped `demote <loser>`).

`tsc --noEmit` + `npm run lint` clean.

## Scope / safety

Confined to a genuine same-epoch contested tie on the git-less path. The clean single-holder path, the partition path (`checkForUnresolvableSplit`), and the git-substrate path (`GitLeaseStore`) are untouched — `forceLocalExpiry` is optional on the `LeaseStore` interface. Relies on #673 (standby read-only write non-fatal, on main) and Problem B #685 (clean exit) per the spec sequencing. No migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)