### PR TITLE
feat(time-awareness): Component 4 — signal-only premature-completion nudge (#682)

### DIFF
--- a/src/data/builtin-manifest.json
+++ b/src/data/builtin-manifest.json
@@ -1,9 +1,9 @@
 {
   "$schema": "./builtin-manifest.schema.json",
   "schemaVersion": 1,
-  "generatedAt": "2026-06-02T01:10:19.195Z",
-  "instarVersion": "1.3.192",
-  "entryCount": 193,
+  "generatedAt": "2026-06-02T13:10:20.434Z",
+  "instarVersion": "1.3.201",
+  "entryCount": 194,
   "entries": {
     "hook:session-start": {
       "id": "hook:session-start",
@@ -11,7 +11,7 @@
       "domain": "identity",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/session-start.sh",
-      "contentHash": "1cd3546e774a6045c3b8c1481a1aa2acfbbb330232f7d3f1353d0f92aca6b1bc",
+      "contentHash": "e8270e118c93a86da1982ba20f6432a566e59f6ae77c3e04c05d81fb3d79b386",
       "since": "2025-01-01"
     },
     "hook:dangerous-command-guard": {
@@ -20,7 +20,7 @@
       "domain": "safety",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/dangerous-command-guard.sh",
-      "contentHash": "1cd3546e774a6045c3b8c1481a1aa2acfbbb330232f7d3f1353d0f92aca6b1bc",
+      "contentHash": "e8270e118c93a86da1982ba20f6432a566e59f6ae77c3e04c05d81fb3d79b386",
       "since": "2025-01-01"
     },
     "hook:grounding-before-messaging": {
@@ -29,7 +29,7 @@
       "domain": "safety",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/grounding-before-messaging.sh",
-      "contentHash": "1cd3546e774a6045c3b8c1481a1aa2acfbbb330232f7d3f1353d0f92aca6b1bc",
+      "contentHash": "e8270e118c93a86da1982ba20f6432a566e59f6ae77c3e04c05d81fb3d79b386",
       "since": "2025-01-01"
     },
     "hook:compaction-recovery": {
@@ -38,7 +38,7 @@
       "domain": "identity",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/compaction-recovery.sh",
-      "contentHash": "1cd3546e774a6045c3b8c1481a1aa2acfbbb330232f7d3f1353d0f92aca6b1bc",
+      "contentHash": "e8270e118c93a86da1982ba20f6432a566e59f6ae77c3e04c05d81fb3d79b386",
       "since": "2025-01-01"
     },
     "hook:external-operation-gate": {
@@ -47,7 +47,7 @@
       "domain": "safety",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/external-operation-gate.js",
-      "contentHash": "1cd3546e774a6045c3b8c1481a1aa2acfbbb330232f7d3f1353d0f92aca6b1bc",
+      "contentHash": "e8270e118c93a86da1982ba20f6432a566e59f6ae77c3e04c05d81fb3d79b386",
       "since": "2025-01-01"
     },
     "hook:deferral-detector": {
@@ -56,7 +56,7 @@
       "domain": "safety",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/deferral-detector.js",
-      "contentHash": "1cd3546e774a6045c3b8c1481a1aa2acfbbb330232f7d3f1353d0f92aca6b1bc",
+      "contentHash": "e8270e118c93a86da1982ba20f6432a566e59f6ae77c3e04c05d81fb3d79b386",
       "since": "2025-01-01"
     },
     "hook:post-action-reflection": {
@@ -65,7 +65,7 @@
       "domain": "evolution",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/post-action-reflection.js",
-      "contentHash": "1cd3546e774a6045c3b8c1481a1aa2acfbbb330232f7d3f1353d0f92aca6b1bc",
+      "contentHash": "e8270e118c93a86da1982ba20f6432a566e59f6ae77c3e04c05d81fb3d79b386",
       "since": "2025-01-01"
     },
     "hook:external-communication-guard": {
@@ -74,7 +74,7 @@
       "domain": "safety",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/external-communication-guard.js",
-      "contentHash": "1cd3546e774a6045c3b8c1481a1aa2acfbbb330232f7d3f1353d0f92aca6b1bc",
+      "contentHash": "e8270e118c93a86da1982ba20f6432a566e59f6ae77c3e04c05d81fb3d79b386",
       "since": "2025-01-01"
     },
     "hook:scope-coherence-collector": {
@@ -83,7 +83,7 @@
       "domain": "coherence",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/scope-coherence-collector.js",
-      "contentHash": "1cd3546e774a6045c3b8c1481a1aa2acfbbb330232f7d3f1353d0f92aca6b1bc",
+      "contentHash": "e8270e118c93a86da1982ba20f6432a566e59f6ae77c3e04c05d81fb3d79b386",
       "since": "2025-01-01"
     },
     "hook:scope-coherence-checkpoint": {
@@ -92,7 +92,7 @@
       "domain": "coherence",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/scope-coherence-checkpoint.js",
-      "contentHash": "1cd3546e774a6045c3b8c1481a1aa2acfbbb330232f7d3f1353d0f92aca6b1bc",
+      "contentHash": "e8270e118c93a86da1982ba20f6432a566e59f6ae77c3e04c05d81fb3d79b386",
       "since": "2025-01-01"
     },
     "hook:free-text-guard": {
@@ -101,7 +101,7 @@
       "domain": "safety",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/free-text-guard.sh",
-      "contentHash": "1cd3546e774a6045c3b8c1481a1aa2acfbbb330232f7d3f1353d0f92aca6b1bc",
+      "contentHash": "e8270e118c93a86da1982ba20f6432a566e59f6ae77c3e04c05d81fb3d79b386",
       "since": "2025-01-01"
     },
     "hook:claim-intercept": {
@@ -110,7 +110,7 @@
       "domain": "coherence",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/claim-intercept.js",
-      "contentHash": "1cd3546e774a6045c3b8c1481a1aa2acfbbb330232f7d3f1353d0f92aca6b1bc",
+      "contentHash": "e8270e118c93a86da1982ba20f6432a566e59f6ae77c3e04c05d81fb3d79b386",
       "since": "2025-01-01"
     },
     "hook:claim-intercept-response": {
@@ -119,7 +119,7 @@
       "domain": "coherence",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/claim-intercept-response.js",
-      "contentHash": "1cd3546e774a6045c3b8c1481a1aa2acfbbb330232f7d3f1353d0f92aca6b1bc",
+      "contentHash": "e8270e118c93a86da1982ba20f6432a566e59f6ae77c3e04c05d81fb3d79b386",
       "since": "2025-01-01"
     },
     "hook:stop-gate-router": {
@@ -128,7 +128,7 @@
       "domain": "safety",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/stop-gate-router.js",
-      "contentHash": "1cd3546e774a6045c3b8c1481a1aa2acfbbb330232f7d3f1353d0f92aca6b1bc",
+      "contentHash": "e8270e118c93a86da1982ba20f6432a566e59f6ae77c3e04c05d81fb3d79b386",
       "since": "2025-01-01"
     },
     "hook:auto-approve-permissions": {
@@ -137,7 +137,7 @@
       "domain": "safety",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/auto-approve-permissions.js",
-      "contentHash": "1cd3546e774a6045c3b8c1481a1aa2acfbbb330232f7d3f1353d0f92aca6b1bc",
+      "contentHash": "e8270e118c93a86da1982ba20f6432a566e59f6ae77c3e04c05d81fb3d79b386",
       "since": "2025-01-01"
     },
     "job:health-check": {
@@ -409,7 +409,7 @@
       "type": "route-group",
       "domain": "monitoring",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "19cca04ff641efa44eca84b5eb9a524d3fd797807d0470445388d648982e16b9",
+      "contentHash": "ed378b5b589fe40b6d922aaf61a8b93d67751158598edd8a06499a8803c106d9",
       "since": "2025-01-01"
     },
     "route-group:agents": {
@@ -417,7 +417,7 @@
       "type": "route-group",
       "domain": "sessions",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "19cca04ff641efa44eca84b5eb9a524d3fd797807d0470445388d648982e16b9",
+      "contentHash": "ed378b5b589fe40b6d922aaf61a8b93d67751158598edd8a06499a8803c106d9",
       "since": "2025-01-01"
     },
     "route-group:backups": {
@@ -425,7 +425,7 @@
       "type": "route-group",
       "domain": "operations",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "19cca04ff641efa44eca84b5eb9a524d3fd797807d0470445388d648982e16b9",
+      "contentHash": "ed378b5b589fe40b6d922aaf61a8b93d67751158598edd8a06499a8803c106d9",
       "since": "2025-01-01"
     },
     "route-group:git": {
@@ -433,7 +433,7 @@
       "type": "route-group",
       "domain": "coordination",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "19cca04ff641efa44eca84b5eb9a524d3fd797807d0470445388d648982e16b9",
+      "contentHash": "ed378b5b589fe40b6d922aaf61a8b93d67751158598edd8a06499a8803c106d9",
       "since": "2025-01-01"
     },
     "route-group:memory": {
@@ -441,7 +441,7 @@
       "type": "route-group",
       "domain": "memory",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "19cca04ff641efa44eca84b5eb9a524d3fd797807d0470445388d648982e16b9",
+      "contentHash": "ed378b5b589fe40b6d922aaf61a8b93d67751158598edd8a06499a8803c106d9",
       "since": "2025-01-01"
     },
     "route-group:semantic": {
@@ -449,7 +449,7 @@
       "type": "route-group",
       "domain": "memory",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "19cca04ff641efa44eca84b5eb9a524d3fd797807d0470445388d648982e16b9",
+      "contentHash": "ed378b5b589fe40b6d922aaf61a8b93d67751158598edd8a06499a8803c106d9",
       "since": "2025-01-01"
     },
     "route-group:status": {
@@ -457,7 +457,7 @@
       "type": "route-group",
       "domain": "monitoring",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "19cca04ff641efa44eca84b5eb9a524d3fd797807d0470445388d648982e16b9",
+      "contentHash": "ed378b5b589fe40b6d922aaf61a8b93d67751158598edd8a06499a8803c106d9",
       "since": "2025-01-01"
     },
     "route-group:capabilities": {
@@ -465,7 +465,7 @@
       "type": "route-group",
       "domain": "mapping",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "19cca04ff641efa44eca84b5eb9a524d3fd797807d0470445388d648982e16b9",
+      "contentHash": "ed378b5b589fe40b6d922aaf61a8b93d67751158598edd8a06499a8803c106d9",
       "since": "2025-01-01"
     },
     "route-group:project-map": {
@@ -473,7 +473,7 @@
       "type": "route-group",
       "domain": "mapping",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "19cca04ff641efa44eca84b5eb9a524d3fd797807d0470445388d648982e16b9",
+      "contentHash": "ed378b5b589fe40b6d922aaf61a8b93d67751158598edd8a06499a8803c106d9",
       "since": "2025-01-01"
     },
     "route-group:coherence": {
@@ -481,7 +481,7 @@
       "type": "route-group",
       "domain": "coherence",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "19cca04ff641efa44eca84b5eb9a524d3fd797807d0470445388d648982e16b9",
+      "contentHash": "ed378b5b589fe40b6d922aaf61a8b93d67751158598edd8a06499a8803c106d9",
       "since": "2025-01-01"
     },
     "route-group:topic-bindings": {
@@ -489,7 +489,7 @@
       "type": "route-group",
       "domain": "sessions",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "19cca04ff641efa44eca84b5eb9a524d3fd797807d0470445388d648982e16b9",
+      "contentHash": "ed378b5b589fe40b6d922aaf61a8b93d67751158598edd8a06499a8803c106d9",
       "since": "2025-01-01"
     },
     "route-group:context": {
@@ -497,7 +497,7 @@
       "type": "route-group",
       "domain": "context",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "19cca04ff641efa44eca84b5eb9a524d3fd797807d0470445388d648982e16b9",
+      "contentHash": "ed378b5b589fe40b6d922aaf61a8b93d67751158598edd8a06499a8803c106d9",
       "since": "2025-01-01"
     },
     "route-group:scope-coherence": {
@@ -505,7 +505,7 @@
       "type": "route-group",
       "domain": "coherence",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "19cca04ff641efa44eca84b5eb9a524d3fd797807d0470445388d648982e16b9",
+      "contentHash": "ed378b5b589fe40b6d922aaf61a8b93d67751158598edd8a06499a8803c106d9",
       "since": "2025-01-01"
     },
     "route-group:canonical-state": {
@@ -513,7 +513,7 @@
       "type": "route-group",
       "domain": "state",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "19cca04ff641efa44eca84b5eb9a524d3fd797807d0470445388d648982e16b9",
+      "contentHash": "ed378b5b589fe40b6d922aaf61a8b93d67751158598edd8a06499a8803c106d9",
       "since": "2025-01-01"
     },
     "route-group:ci": {
@@ -521,7 +521,7 @@
       "type": "route-group",
       "domain": "monitoring",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "19cca04ff641efa44eca84b5eb9a524d3fd797807d0470445388d648982e16b9",
+      "contentHash": "ed378b5b589fe40b6d922aaf61a8b93d67751158598edd8a06499a8803c106d9",
       "since": "2025-01-01"
     },
     "route-group:sessions": {
@@ -529,7 +529,7 @@
       "type": "route-group",
       "domain": "sessions",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "19cca04ff641efa44eca84b5eb9a524d3fd797807d0470445388d648982e16b9",
+      "contentHash": "ed378b5b589fe40b6d922aaf61a8b93d67751158598edd8a06499a8803c106d9",
       "since": "2025-01-01"
     },
     "route-group:jobs": {
@@ -537,7 +537,7 @@
       "type": "route-group",
       "domain": "scheduling",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "19cca04ff641efa44eca84b5eb9a524d3fd797807d0470445388d648982e16b9",
+      "contentHash": "ed378b5b589fe40b6d922aaf61a8b93d67751158598edd8a06499a8803c106d9",
       "since": "2025-01-01"
     },
     "route-group:skip-ledger": {
@@ -545,7 +545,7 @@
       "type": "route-group",
       "domain": "scheduling",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "19cca04ff641efa44eca84b5eb9a524d3fd797807d0470445388d648982e16b9",
+      "contentHash": "ed378b5b589fe40b6d922aaf61a8b93d67751158598edd8a06499a8803c106d9",
       "since": "2025-01-01"
     },
     "route-group:telegram": {
@@ -553,7 +553,7 @@
       "type": "route-group",
       "domain": "communication",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "19cca04ff641efa44eca84b5eb9a524d3fd797807d0470445388d648982e16b9",
+      "contentHash": "ed378b5b589fe40b6d922aaf61a8b93d67751158598edd8a06499a8803c106d9",
       "since": "2025-01-01"
     },
     "route-group:attention": {
@@ -561,7 +561,7 @@
       "type": "route-group",
       "domain": "communication",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "19cca04ff641efa44eca84b5eb9a524d3fd797807d0470445388d648982e16b9",
+      "contentHash": "ed378b5b589fe40b6d922aaf61a8b93d67751158598edd8a06499a8803c106d9",
       "since": "2025-01-01"
     },
     "route-group:relationships": {
@@ -569,7 +569,7 @@
       "type": "route-group",
       "domain": "relationships",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "19cca04ff641efa44eca84b5eb9a524d3fd797807d0470445388d648982e16b9",
+      "contentHash": "ed378b5b589fe40b6d922aaf61a8b93d67751158598edd8a06499a8803c106d9",
       "since": "2025-01-01"
     },
     "route-group:feedback": {
@@ -577,7 +577,7 @@
       "type": "route-group",
       "domain": "feedback",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "19cca04ff641efa44eca84b5eb9a524d3fd797807d0470445388d648982e16b9",
+      "contentHash": "ed378b5b589fe40b6d922aaf61a8b93d67751158598edd8a06499a8803c106d9",
       "since": "2025-01-01"
     },
     "route-group:updates": {
@@ -585,7 +585,7 @@
       "type": "route-group",
       "domain": "updates",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "19cca04ff641efa44eca84b5eb9a524d3fd797807d0470445388d648982e16b9",
+      "contentHash": "ed378b5b589fe40b6d922aaf61a8b93d67751158598edd8a06499a8803c106d9",
       "since": "2025-01-01"
     },
     "route-group:dispatches": {
@@ -593,7 +593,7 @@
       "type": "route-group",
       "domain": "dispatches",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "19cca04ff641efa44eca84b5eb9a524d3fd797807d0470445388d648982e16b9",
+      "contentHash": "ed378b5b589fe40b6d922aaf61a8b93d67751158598edd8a06499a8803c106d9",
       "since": "2025-01-01"
     },
     "route-group:quota": {
@@ -601,7 +601,7 @@
       "type": "route-group",
       "domain": "monitoring",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "19cca04ff641efa44eca84b5eb9a524d3fd797807d0470445388d648982e16b9",
+      "contentHash": "ed378b5b589fe40b6d922aaf61a8b93d67751158598edd8a06499a8803c106d9",
       "since": "2025-01-01"
     },
     "route-group:publishing": {
@@ -609,7 +609,7 @@
       "type": "route-group",
       "domain": "publishing",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "19cca04ff641efa44eca84b5eb9a524d3fd797807d0470445388d648982e16b9",
+      "contentHash": "ed378b5b589fe40b6d922aaf61a8b93d67751158598edd8a06499a8803c106d9",
       "since": "2025-01-01"
     },
     "route-group:private-views": {
@@ -617,7 +617,7 @@
       "type": "route-group",
       "domain": "publishing",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "19cca04ff641efa44eca84b5eb9a524d3fd797807d0470445388d648982e16b9",
+      "contentHash": "ed378b5b589fe40b6d922aaf61a8b93d67751158598edd8a06499a8803c106d9",
       "since": "2025-01-01"
     },
     "route-group:tunnel": {
@@ -625,7 +625,7 @@
       "type": "route-group",
       "domain": "networking",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "19cca04ff641efa44eca84b5eb9a524d3fd797807d0470445388d648982e16b9",
+      "contentHash": "ed378b5b589fe40b6d922aaf61a8b93d67751158598edd8a06499a8803c106d9",
       "since": "2025-01-01"
     },
     "route-group:events": {
@@ -633,7 +633,7 @@
       "type": "route-group",
       "domain": "networking",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "19cca04ff641efa44eca84b5eb9a524d3fd797807d0470445388d648982e16b9",
+      "contentHash": "ed378b5b589fe40b6d922aaf61a8b93d67751158598edd8a06499a8803c106d9",
       "since": "2025-01-01"
     },
     "route-group:evolution": {
@@ -641,7 +641,7 @@
       "type": "route-group",
       "domain": "evolution",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "19cca04ff641efa44eca84b5eb9a524d3fd797807d0470445388d648982e16b9",
+      "contentHash": "ed378b5b589fe40b6d922aaf61a8b93d67751158598edd8a06499a8803c106d9",
       "since": "2025-01-01"
     },
     "route-group:watchdog": {
@@ -649,7 +649,7 @@
       "type": "route-group",
       "domain": "monitoring",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "19cca04ff641efa44eca84b5eb9a524d3fd797807d0470445388d648982e16b9",
+      "contentHash": "ed378b5b589fe40b6d922aaf61a8b93d67751158598edd8a06499a8803c106d9",
       "since": "2025-01-01"
     },
     "route-group:topic-memory": {
@@ -657,7 +657,7 @@
       "type": "route-group",
       "domain": "memory",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "19cca04ff641efa44eca84b5eb9a524d3fd797807d0470445388d648982e16b9",
+      "contentHash": "ed378b5b589fe40b6d922aaf61a8b93d67751158598edd8a06499a8803c106d9",
       "since": "2025-01-01"
     },
     "route-group:state-sync": {
@@ -665,7 +665,7 @@
       "type": "route-group",
       "domain": "coordination",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "19cca04ff641efa44eca84b5eb9a524d3fd797807d0470445388d648982e16b9",
+      "contentHash": "ed378b5b589fe40b6d922aaf61a8b93d67751158598edd8a06499a8803c106d9",
       "since": "2025-01-01"
     },
     "route-group:intent": {
@@ -673,7 +673,7 @@
       "type": "route-group",
       "domain": "intent",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "19cca04ff641efa44eca84b5eb9a524d3fd797807d0470445388d648982e16b9",
+      "contentHash": "ed378b5b589fe40b6d922aaf61a8b93d67751158598edd8a06499a8803c106d9",
       "since": "2025-01-01"
     },
     "route-group:triage": {
@@ -681,7 +681,7 @@
       "type": "route-group",
       "domain": "safety",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "19cca04ff641efa44eca84b5eb9a524d3fd797807d0470445388d648982e16b9",
+      "contentHash": "ed378b5b589fe40b6d922aaf61a8b93d67751158598edd8a06499a8803c106d9",
       "since": "2025-01-01"
     },
     "route-group:operations": {
@@ -689,7 +689,7 @@
       "type": "route-group",
       "domain": "safety",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "19cca04ff641efa44eca84b5eb9a524d3fd797807d0470445388d648982e16b9",
+      "contentHash": "ed378b5b589fe40b6d922aaf61a8b93d67751158598edd8a06499a8803c106d9",
       "since": "2025-01-01"
     },
     "route-group:sentinel": {
@@ -697,7 +697,7 @@
       "type": "route-group",
       "domain": "safety",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "19cca04ff641efa44eca84b5eb9a524d3fd797807d0470445388d648982e16b9",
+      "contentHash": "ed378b5b589fe40b6d922aaf61a8b93d67751158598edd8a06499a8803c106d9",
       "since": "2025-01-01"
     },
     "route-group:trust": {
@@ -705,7 +705,7 @@
       "type": "route-group",
       "domain": "safety",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "19cca04ff641efa44eca84b5eb9a524d3fd797807d0470445388d648982e16b9",
+      "contentHash": "ed378b5b589fe40b6d922aaf61a8b93d67751158598edd8a06499a8803c106d9",
       "since": "2025-01-01"
     },
     "route-group:monitoring": {
@@ -713,7 +713,7 @@
       "type": "route-group",
       "domain": "monitoring",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "19cca04ff641efa44eca84b5eb9a524d3fd797807d0470445388d648982e16b9",
+      "contentHash": "ed378b5b589fe40b6d922aaf61a8b93d67751158598edd8a06499a8803c106d9",
       "since": "2025-01-01"
     },
     "route-group:commitments": {
@@ -721,7 +721,7 @@
       "type": "route-group",
       "domain": "commitments",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "19cca04ff641efa44eca84b5eb9a524d3fd797807d0470445388d648982e16b9",
+      "contentHash": "ed378b5b589fe40b6d922aaf61a8b93d67751158598edd8a06499a8803c106d9",
       "since": "2025-01-01"
     },
     "route-group:episodes": {
@@ -729,7 +729,7 @@
       "type": "route-group",
       "domain": "memory",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "19cca04ff641efa44eca84b5eb9a524d3fd797807d0470445388d648982e16b9",
+      "contentHash": "ed378b5b589fe40b6d922aaf61a8b93d67751158598edd8a06499a8803c106d9",
       "since": "2025-01-01"
     },
     "route-group:messages": {
@@ -737,7 +737,7 @@
       "type": "route-group",
       "domain": "coordination",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "19cca04ff641efa44eca84b5eb9a524d3fd797807d0470445388d648982e16b9",
+      "contentHash": "ed378b5b589fe40b6d922aaf61a8b93d67751158598edd8a06499a8803c106d9",
       "since": "2025-01-01"
     },
     "route-group:system-reviews": {
@@ -745,7 +745,7 @@
       "type": "route-group",
       "domain": "monitoring",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "19cca04ff641efa44eca84b5eb9a524d3fd797807d0470445388d648982e16b9",
+      "contentHash": "ed378b5b589fe40b6d922aaf61a8b93d67751158598edd8a06499a8803c106d9",
       "since": "2025-01-01"
     },
     "route-group:machine-mesh": {
@@ -761,7 +761,7 @@
       "type": "route-group",
       "domain": "security",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "19cca04ff641efa44eca84b5eb9a524d3fd797807d0470445388d648982e16b9",
+      "contentHash": "ed378b5b589fe40b6d922aaf61a8b93d67751158598edd8a06499a8803c106d9",
       "since": "2025-01-01"
     },
     "cli:init": {
@@ -1089,7 +1089,15 @@
       "type": "template",
       "domain": "operations",
       "sourcePath": "src/templates/scripts/convergence-check.sh",
-      "contentHash": "41ef69307819140731f293b175093238f88988365c3973b8e44b9c18669e32bd",
+      "contentHash": "b0475554bde6729d2d9a1f8005dcada6a8e4c767203d8293c09a212f9bf0a196",
+      "since": "2025-01-01"
+    },
+    "template:emit-session-clock.sh": {
+      "id": "template:emit-session-clock.sh",
+      "type": "template",
+      "domain": "operations",
+      "sourcePath": "src/templates/scripts/emit-session-clock.sh",
+      "contentHash": "c83cff5728bef544c20ca4a8bce432981175161a4ac2272e112edc612949806d",
       "since": "2025-01-01"
     },
     "template:git-sync-gate.sh": {
@@ -1457,7 +1465,7 @@
       "type": "subsystem",
       "domain": "server",
       "sourcePath": "src/server/AgentServer.ts",
-      "contentHash": "fde1c526b156577e0ad447d179760c9a0b095b051b6af0fd56b879278f504c38",
+      "contentHash": "817c1981f1dcf55def31ed4d422a7b1e9f2c4c9e62b0855238765a2c69cf22c6",
       "since": "2025-01-01"
     },
     "subsystem:session-manager": {
@@ -1489,7 +1497,7 @@
       "type": "subsystem",
       "domain": "updates",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
-      "contentHash": "1cd3546e774a6045c3b8c1481a1aa2acfbbb330232f7d3f1353d0f92aca6b1bc",
+      "contentHash": "e8270e118c93a86da1982ba20f6432a566e59f6ae77c3e04c05d81fb3d79b386",
       "since": "2025-01-01"
     },
     "subsystem:scheduler": {
@@ -1537,7 +1545,7 @@
       "type": "subsystem",
       "domain": "memory",
       "sourcePath": "src/memory/SemanticMemory.ts",
-      "contentHash": "446518e120f33abe7903662340500e9aecd6d2f73793dc0d07c189e1f8f0557c",
+      "contentHash": "9c384e1db6fed559f6425a32d1f20490d98b40660b8f7be62d7cf515cb576df4",
       "since": "2025-01-01"
     },
     "subsystem:multi-machine-coordinator": {
@@ -1545,7 +1553,7 @@
       "type": "subsystem",
       "domain": "coordination",
       "sourcePath": "src/core/MultiMachineCoordinator.ts",
-      "contentHash": "f5c2bd171e32ec39384c2b16b73b3d2827f044d664b8923183f6006fce009ba8",
+      "contentHash": "9646bb62caff1d39524f0680bd6824bba5866ae283582cd9fd23cf011e083520",
       "since": "2025-01-01"
     },
     "subsystem:backup-manager": {

--- a/src/templates/scripts/convergence-check.sh
+++ b/src/templates/scripts/convergence-check.sh
@@ -169,6 +169,55 @@ if [ -n "$SPEC_HANDOFF" ] \
   ISSUE_COUNT=$((ISSUE_COUNT + 1))
 fi
 
+# 9. TIME-AWARENESS NUDGE (Robust Session Time Awareness spec — Component 4,
+# SIGNAL-ONLY). If this outbound message asserts the SESSION/RUN is done/over
+# while a LIVE autonomous record still has >10% of its time-box remaining, emit a
+# one-line SIGNAL to an operator log + stderr. It NEVER blocks or rewrites the
+# message (does NOT touch ISSUE_COUNT / the exit code) and NEVER quotes the
+# agent's phrase — it carries the computed fact (≈NN% remains) only, so the
+# signal can't be re-read as self-confirming evidence the run is finished
+# (P2 Signal vs Authority). Guards the exact wind-down-early incident class.
+if echo "$CONTENT" | grep -qiE "((the )?([a-z0-9 ._-]{0,25} )?(session|run|sprint) (is|was|.s) (now )?(done|over|complete|completed|finished|wrapped[ -]?up)|winding[ -]down( the| this| my)?( session| run)?|wrapping[ -]up the (session|run))"; then
+  TA_DIR="${CLAUDE_PROJECT_DIR:-.}/.instar/autonomous"
+  TA_SIG=""
+  TA_REC=""
+  if [ -d "$TA_DIR" ]; then
+    for ta_rec in "$TA_DIR"/*.local.md; do
+      [ -f "$ta_rec" ] || continue
+      ta_pct=$(python3 - "$ta_rec" <<'PY' 2>/dev/null
+import sys, re, datetime
+try:
+    body = open(sys.argv[1]).read()
+    def g(k):
+        m = re.search(r'^\s*' + k + r'\s*:\s*"?([^"\n]+)"?', body, re.M)
+        return m.group(1).strip() if m else ''
+    if g('active').lower() != 'true':
+        sys.exit(0)
+    end, dur = g('end_at'), g('duration_seconds')
+    if not end or not dur:
+        sys.exit(0)
+    end_dt = datetime.datetime.fromisoformat(end.replace('Z', '+00:00'))
+    now = datetime.datetime.now(datetime.timezone.utc)
+    remain = (end_dt - now).total_seconds()
+    durs = float(dur)
+    if durs > 0 and remain > 0 and (remain / durs) > 0.10:
+        print(int(round(remain / durs * 100)))
+except Exception:
+    sys.exit(0)
+PY
+)
+      if [ -n "$ta_pct" ]; then TA_SIG="$ta_pct"; TA_REC="$(basename "$ta_rec")"; break; fi
+    done
+  fi
+  if [ -n "$TA_SIG" ]; then
+    TA_TS=$(date -u +%Y-%m-%dT%H:%M:%SZ 2>/dev/null)
+    TA_LOG="${CLAUDE_PROJECT_DIR:-.}/logs"
+    mkdir -p "$TA_LOG" 2>/dev/null
+    printf '{"ts":"%s","signal":"premature-completion-assertion","remainingPct":%s,"record":"%s"}\n' "$TA_TS" "$TA_SIG" "$TA_REC" >> "$TA_LOG/time-awareness-signals.jsonl" 2>/dev/null || true
+    echo "[time-awareness] SIGNAL: this message asserts completion while ~${TA_SIG}% of the active autonomous time-box (${TA_REC}) remains — verify before concluding. (signal-only; message NOT blocked)" >&2
+  fi
+fi
+
 # Output results
 if [ "$ISSUE_COUNT" -gt "0" ]; then
   echo "=== CONVERGENCE CHECK: ${ISSUE_COUNT} ISSUE(S) FOUND ==="

--- a/tests/unit/convergence-check-time-awareness.test.ts
+++ b/tests/unit/convergence-check-time-awareness.test.ts
@@ -1,0 +1,115 @@
+/**
+ * Component 4 of the Robust Session Time Awareness spec (#681 / #682) — the
+ * SIGNAL-ONLY accurate-reporting nudge baked into the pre-messaging
+ * convergence-check.sh gate.
+ *
+ * Guards the exact wind-down-early incident class: an outbound message that
+ * asserts the SESSION/RUN is done/over while a live autonomous record still has
+ * >10% of its time-box remaining emits a one-line SIGNAL (operator log + stderr)
+ * — but NEVER blocks/rewrites the message (P2 Signal vs Authority) and NEVER
+ * quotes the agent's phrase (carries the computed %-remaining fact only).
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..');
+const SCRIPT = path.join(REPO_ROOT, 'src', 'templates', 'scripts', 'convergence-check.sh');
+
+/** Run convergence-check.sh with `content` on stdin + CLAUDE_PROJECT_DIR=projectDir.
+ *  Captures stderr to a file (execFileSync does not return stderr on exit 0, and
+ *  the Component-4 signal is emitted to stderr with exit 0). Never throws. */
+function runCheck(content: string, projectDir: string): { exitCode: number; stderr: string } {
+  const errFile = path.join(projectDir, '_stderr.txt');
+  let exitCode = 0;
+  try {
+    execFileSync('bash', ['-c', `bash "${SCRIPT}" 2> "${errFile}"`], {
+      input: content,
+      env: { ...process.env, CLAUDE_PROJECT_DIR: projectDir },
+      encoding: 'utf8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+  } catch (err: unknown) {
+    exitCode = (err as { status?: number }).status ?? -1;
+  }
+  const stderr = fs.existsSync(errFile) ? fs.readFileSync(errFile, 'utf8') : '';
+  return { exitCode, stderr };
+}
+
+function writeRecord(projectDir: string, name: string, opts: { active: boolean; remainingHours: number; durationSeconds?: number }): void {
+  const dir = path.join(projectDir, '.instar', 'autonomous');
+  fs.mkdirSync(dir, { recursive: true });
+  const end = new Date(Date.now() + opts.remainingHours * 3600 * 1000).toISOString().replace(/\.\d{3}Z$/, 'Z');
+  const fm = [
+    '---',
+    `active: ${opts.active}`,
+    `duration_seconds: ${opts.durationSeconds ?? 43200}`,
+    'started_at: "x"',
+    `end_at: "${end}"`,
+    '---',
+    '# rec',
+  ].join('\n');
+  fs.writeFileSync(path.join(dir, name), fm);
+}
+
+function signalLogLines(projectDir: string): string[] {
+  const p = path.join(projectDir, 'logs', 'time-awareness-signals.jsonl');
+  if (!fs.existsSync(p)) return [];
+  return fs.readFileSync(p, 'utf8').split('\n').filter(Boolean);
+}
+
+describe('convergence-check Component 4 — time-awareness signal (signal-only)', () => {
+  let dir: string;
+  beforeEach(() => { dir = fs.mkdtempSync(path.join(os.tmpdir(), 'cc-ta-')); });
+  afterEach(() => {
+    try { SafeFsExecutor.safeRmSync(dir, { recursive: true, force: true, operation: 'tests/unit/convergence-check-time-awareness.test.ts' }); } catch { /* ignore */ }
+  });
+
+  it('SIGNALS (log + stderr) on a session-done assertion while >10% of the time-box remains — but does NOT block', () => {
+    writeRecord(dir, 'run.local.md', { active: true, remainingHours: 10 }); // 10h of 12h ≈ 83% > 10%
+    const { exitCode, stderr } = runCheck('Great progress — the 12 hour session is done, wrapping up now.', dir);
+
+    expect(exitCode).toBe(0); // SIGNAL-ONLY — never blocks
+    expect(stderr).toMatch(/\[time-awareness\] SIGNAL/);
+    expect(stderr).toMatch(/~83% of the active autonomous time-box/);
+    expect(stderr).not.toMatch(/wrapping up/); // never quotes the agent's phrase
+    const log = signalLogLines(dir);
+    expect(log.length).toBe(1);
+    expect(JSON.parse(log[0])).toMatchObject({ signal: 'premature-completion-assertion', remainingPct: 83, record: 'run.local.md' });
+  });
+
+  it('does NOT signal when there is no completion assertion', () => {
+    writeRecord(dir, 'run.local.md', { active: true, remainingHours: 10 });
+    const { exitCode, stderr } = runCheck('Working the next task now — here is a status update.', dir);
+    expect(exitCode).toBe(0);
+    expect(stderr).not.toMatch(/time-awareness/);
+    expect(signalLogLines(dir).length).toBe(0);
+  });
+
+  it('does NOT signal when <10% of the time-box remains (a genuine near-end wrap-up)', () => {
+    writeRecord(dir, 'run.local.md', { active: true, remainingHours: 0.1 }); // ~0.8% of 12h
+    const { exitCode, stderr } = runCheck('The session is done now, all wrapped up.', dir);
+    expect(exitCode).toBe(0);
+    expect(stderr).not.toMatch(/time-awareness/);
+    expect(signalLogLines(dir).length).toBe(0);
+  });
+
+  it('does NOT signal when no autonomous record is active', () => {
+    writeRecord(dir, 'run.local.md', { active: false, remainingHours: 10 });
+    const { exitCode, stderr } = runCheck('The session is done, wrapping up.', dir);
+    expect(exitCode).toBe(0);
+    expect(stderr).not.toMatch(/time-awareness/);
+    expect(signalLogLines(dir).length).toBe(0);
+  });
+
+  it('does NOT signal when there is no autonomous record at all (normal non-autonomous messaging)', () => {
+    const { exitCode, stderr } = runCheck('The session is done, wrapping up.', dir);
+    expect(exitCode).toBe(0);
+    expect(stderr).not.toMatch(/time-awareness/);
+  });
+});

--- a/upgrades/side-effects/time-awareness-component4-reporting-nudge.md
+++ b/upgrades/side-effects/time-awareness-component4-reporting-nudge.md
@@ -1,0 +1,20 @@
+# Side-effects review — Time Awareness Component 4 (signal-only reporting nudge)
+
+**Spec:** `docs/specs/ROBUST-SESSION-TIME-AWARENESS-SPEC.md` §Component 4 (converged + approved, merged as #681; Component 4 was deferred to v1.1, tracked #682 — now built). **Tracks:** #682.
+
+**Change:** one new check (signal-only) appended to the pre-messaging `convergence-check.sh` gate (`src/templates/scripts/convergence-check.sh`). If an outbound message asserts the **session/run is done/over** (or "winding down" / "wrapping up the session/run") while a **live autonomous record** (`.instar/autonomous/*.local.md`, `active: true`) still has **>10% of its time-box remaining**, it emits a one-line SIGNAL to `logs/time-awareness-signals.jsonl` + stderr. This guards the exact wind-down-early incident class that started the time-tracking work.
+
+## What it touches
+- `src/templates/scripts/convergence-check.sh` ONLY (the pre-messaging quality gate, run by `grounding-before-messaging.sh`). One appended block + nothing else changed.
+- Reaches existing agents automatically: convergence-check.sh is **always-overwritten on migration** (`PostUpdateMigrator` line ~4122, "Convergence check — always overwrite") + installed by `init`. No new migration code needed. New agents get it via the same install path.
+
+## Side effects & blast radius (deliberately minimal — P2 Signal vs Authority)
+- **SIGNAL-ONLY: it NEVER blocks or rewrites the message.** The block does NOT touch `ISSUE_COUNT` or the exit code — the existing checks 1-8 and the gate's exit logic are untouched. A premature-completion assertion still SENDS; the operator just gets a side-channel signal. (Verified: exit 0 in all test scenarios, including when the signal fires.)
+- **Never quotes the agent's phrase.** The signal carries the computed fact (`≈NN% of the time-box remains`) only — never the "done/over" wording — so it can't be re-read as self-confirming evidence the run is finished (the adversarial-round-2 sink requirement).
+- **Signal sink = operator log + stderr, never the agent's injected context.** On exit 0 the grounding hook does not surface convergence-check output to the agent, so the signal does not pollute context. The JSONL log is the durable operator record.
+- **Targeted regex** (session/run/sprint-level completion + winding-down/wrapping-up-the-session) — chosen to avoid false-positives on subtask reports ("this PR's tasks are complete"). Even a false positive is low-cost (one log line; never blocks). Only fires when an `active: true` record with >10% remaining exists, so non-autonomous messaging is never touched.
+- **Portable date math** via the python3 already used by the script's URL-provenance check (no new dependency). Reads the record directly — no server call (the convergence-check host is pure-bash by design).
+- **Inline fallback NOT modified:** `getConvergenceCheckInline()` is a degraded "template-missing" safety net already divergent from the template (it lacks check 8 too); newer checks live in the template only by established pattern, and there is no template==inline drift test. The template is the canonical always-used source.
+
+## Tests (golden, 5; all green; 66 convergence-check tests total green — no regression)
+`tests/unit/convergence-check-time-awareness.test.ts` — runs the REAL template script: (1) done-assertion + >10% remaining → SIGNAL in log + stderr, computed %, no phrase-quote, exit 0 (not blocked); (2) no assertion → silent; (3) <10% remaining (genuine near-end wrap-up) → silent; (4) record not active → silent; (5) no record at all → silent. `bash -n` + `tsc` clean.


### PR DESCRIPTION
## What & why

Builds **Component 4** of the converged ROBUST-SESSION-TIME-AWARENESS spec (#681) — deferred to v1.1, tracked in **#682**. It guards the **exact wind-down-early incident** that started the time-tracking work: an agent asserting a long autonomous session is "done" when hours remain.

A **signal-only** check appended to the pre-messaging `convergence-check.sh` gate: if an outbound message asserts the **session/run is done/over** (or "winding down" / "wrapping up the session/run") while a **live autonomous record** (`.instar/autonomous/*.local.md`, `active: true`) still has **>10% of its time-box remaining**, it emits one SIGNAL to `logs/time-awareness-signals.jsonl` + stderr.

## P2 Signal vs Authority (the design constraints, all enforced + tested)

- **NEVER blocks or rewrites the message** — the block does not touch `ISSUE_COUNT` or the exit code; the existing checks 1-8 and the gate's exit logic are untouched. A premature-completion assertion still SENDS (verified exit 0 in every scenario, including when the signal fires).
- **NEVER quotes the agent's phrase** — carries the computed fact (`≈NN% of the time-box remains`) only, so it can't be re-read as self-confirming evidence the run is finished (the adversarial-round-2 sink requirement).
- **Signal sink = operator log + stderr, never the agent's injected context** (on exit 0 the grounding hook doesn't surface convergence-check output to the agent).
- **Targeted regex** (session/run/sprint-level) to avoid false-positives on subtask reports; only fires with an `active` record >10% remaining, so non-autonomous messaging is untouched.

## Migration / scope

Touches `src/templates/scripts/convergence-check.sh` only. It's **always-overwritten on migration** (`PostUpdateMigrator` ~line 4122) + installed by `init`, so existing agents get it automatically — no new migration code. The inline fallback (`getConvergenceCheckInline`) is a degraded "template-missing" safety net already divergent (lacks check 8 too) with no drift test — left as-is by established pattern. `builtin-manifest.json` regenerated by the pre-commit hook.

## Tests

`tests/unit/convergence-check-time-awareness.test.ts` (5 golden, real script): done-assertion + >10% → SIGNAL (computed %, no phrase-quote, exit 0 not blocked); no assertion / <10% remaining / record-inactive / no-record → silent. 66 convergence-check tests total green; `bash -n` + `tsc` clean.

Completes the full ROBUST-SESSION-TIME-AWARENESS spec (v1 Components 0-3 shipped earlier in #683/#684; this is the v1.1 Component 4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)