### PR TITLE
test(hybrid-search): skip cleanly on unreachable embedding model (CI hermeticity)

### DIFF
--- a/tests/e2e/hybrid-search-lifecycle.test.ts
+++ b/tests/e2e/hybrid-search-lifecycle.test.ts
@@ -18,7 +18,7 @@
  * to AgentServer — same as server.ts would do it.
  */
 
-import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
 import fs from 'node:fs';
 import path from 'node:path';
 import os from 'node:os';
@@ -39,6 +39,11 @@ describe('Hybrid Search E2E lifecycle', () => {
   let server: AgentServer;
   let app: ReturnType<AgentServer['getApp']>;
   const AUTH_TOKEN = 'test-e2e-hybrid';
+  // See the integration sibling (hybrid-search.test.ts): the embedding model is
+  // fetched from the HuggingFace hub. A transient/environmental hub outage must
+  // NOT hard-fail the whole E2E suite — the beforeEach guard skips these
+  // model-dependent tests cleanly when init fails. Normal runs are unchanged.
+  let providerReady = false;
 
   beforeAll(async () => {
     tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'hybrid-e2e-'));
@@ -49,9 +54,20 @@ describe('Hybrid Search E2E lifecycle', () => {
 
     // ── Initialize SemanticMemory with EmbeddingProvider (production mirror) ──
 
-    embeddingProvider = new EmbeddingProvider();
-    await embeddingProvider.initialize();
-    await embeddingProvider.loadVecModule();
+    try {
+      embeddingProvider = new EmbeddingProvider();
+      await embeddingProvider.initialize();
+      await embeddingProvider.loadVecModule();
+      providerReady = true;
+    } catch (err) {
+      providerReady = false;
+      console.error(
+        '[hybrid-search-e2e] SKIPPING SUITE — embedding provider failed to initialize ' +
+        '(environmental, e.g. HuggingFace hub unreachable/rate-limited). This is NOT a ' +
+        'code failure. Error: ' + ((err as Error)?.message ?? String(err)),
+      );
+      return; // skip the remaining provider-dependent setup
+    }
 
     semanticMemory = new SemanticMemory({
       dbPath: path.join(stateDir, 'semantic.db'),
@@ -85,6 +101,12 @@ describe('Hybrid Search E2E lifecycle', () => {
 
     app = server.getApp();
   }, 120_000); // Model download on first run
+
+  // Skip every model-dependent test cleanly when the embedding provider could
+  // not initialize (see beforeAll). ctx.skip() throws the vitest skip signal.
+  beforeEach((ctx) => {
+    if (!providerReady) ctx.skip();
+  });
 
   afterAll(() => {
     semanticMemory?.close();

--- a/tests/integration/hybrid-search.test.ts
+++ b/tests/integration/hybrid-search.test.ts
@@ -26,11 +26,32 @@ import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
 // ─── Shared State ─────────────────────────────────────────────────
 
 let sharedProvider: EmbeddingProvider;
+// True only once the embedding model has actually loaded. The model is fetched
+// from the HuggingFace hub on first init; when the hub is unreachable or
+// rate-limited (a transient, ENVIRONMENTAL failure — not a code regression),
+// we must NOT hard-fail the entire integration suite. The beforeEach guard in
+// the describe below skips these model-dependent tests cleanly when this stays
+// false. Normal runs (model reachable/cached) are completely unchanged.
+let providerReady = false;
 
 beforeAll(async () => {
-  sharedProvider = new EmbeddingProvider();
-  await sharedProvider.initialize();
-  await sharedProvider.loadVecModule();
+  try {
+    sharedProvider = new EmbeddingProvider();
+    await sharedProvider.initialize();
+    await sharedProvider.loadVecModule();
+    providerReady = true;
+  } catch (err) {
+    providerReady = false;
+    // Loud, unmistakable signal so a persistent skip is visible in CI logs and
+    // can't be mistaken for "all green". This is the only failure mode that
+    // skips — a reachable model always runs the full assertions.
+    console.error(
+      '[hybrid-search] SKIPPING SUITE — embedding provider failed to initialize ' +
+      '(environmental, e.g. HuggingFace hub unreachable/rate-limited). This is NOT ' +
+      'a code failure; hybrid-search coverage is suspended until the model is ' +
+      'reachable again. Error: ' + ((err as Error)?.message ?? String(err)),
+    );
+  }
 }, 120_000);
 
 // ─── Helpers ──────────────────────────────────────────────────────
@@ -94,6 +115,13 @@ const now = new Date().toISOString();
 
 describe('Hybrid Search Integration', () => {
   let setup: TestSetup;
+
+  // Runs outer-first, before any nested data-setup beforeEach, so a skip is
+  // raised before those hooks try (and fail) to build a provider-backed memory.
+  // ctx.skip() throws the vitest skip signal — never wrap it in try/catch.
+  beforeEach((ctx) => {
+    if (!providerReady) ctx.skip();
+  });
 
   afterEach(() => {
     setup?.cleanup();


### PR DESCRIPTION
## Problem (caught live this session)
The `hybrid-search` integration suite loads its embedding model from the HuggingFace hub in `beforeAll`. When the hub is transiently unreachable/rate-limited — an **environmental** failure, not a code regression — the throw in `beforeAll` failed the **entire integration suite**, which:
- turned **main red** (`e72c3fb97`, ~13:58Z — that commit was just #687/convergence-check.sh, unrelated to search), and
- **blocked an unrelated test-only PR (#688)** from merging.

Earlier runs the same day were all green and a plain job re-run cleared it — confirming a transient HF blip, not a real break.

## Fix (test-only, gate-free)
- `beforeAll` now **catches** an init failure, logs a **loud, unmistakable stderr warning** (so a persistent skip is visible in CI logs and can never read as "all green"), and leaves `providerReady=false`.
- A single outer `beforeEach((ctx) => { if (!providerReady) ctx.skip() })` skips every model-dependent test cleanly. It runs outer-first, before the nested data-setup hooks, so they never try (and fail) to build a provider-backed memory.
- **The normal path is completely unchanged** — when the model is reachable/cached, all 16 tests run with full assertions. Only a genuine init failure skips.

## Verified both paths locally against the real suite
| Scenario | Before | After |
|---|---|---|
| model reachable/cached | 16/16 pass | **16/16 pass** (unchanged) |
| model init throws (forced) | **Failed Suites 1** (whole integration run red) | **16 skipped, suite PASSES** + loud warning |

## Note for review — skip vs. vendor
This is the right-sized, test-only resilience fix against *transient* outages. A stronger (but larger, out-of-scope-for-a-test-file) option is to **cache/vendor the embedding model in CI** so the suite is fully hermetic and always runs. Flagging that as a possible follow-up; happy to do it if you'd prefer hermetic-always over skip-on-outage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)