### PR TITLE
fix(multi-machine): stale/lower-epoch peer lease must not demote a live holder

### DIFF
--- a/docs/eli16/STALE-PEER-DEMOTION-FIX.md
+++ b/docs/eli16/STALE-PEER-DEMOTION-FIX.md
@@ -1,0 +1,35 @@
+# ELI16 — Stop a dead peer's old lease from knocking the live machine offline
+
+## The one-sentence version
+When two machines share one agent, the active machine kept briefly flipping itself to "read-only standby" ~half the time — because a **2-day-expired lease from the other (standby) machine** was being treated as if it still counted. This fix says: an **expired or older** lease from a peer carries no authority, so it can never demote the machine that's actually in charge.
+
+## How we got here (the live story)
+Today we turned on multi-machine for real on the laptop + Mac mini pair. The laptop (the one with the public tunnel) became the "awake" leader; the mini became "standby." Good.
+
+But then the laptop started **oscillating**: awake → standby → awake, roughly 50/50, every few seconds. While it was "standby" it went **read-only** and started **blocking real work** — saving job state, session bookkeeping — all failing with "StateManager is read-only." (It didn't crash, because an earlier safety net, #673, catches those. But the writes still failed.)
+
+## The root cause (one picture)
+Each machine's lease is like a **parking permit that expires every 60 seconds** and gets renewed on a timer. There are two independent loops:
+- **tick** — renews our own permit and says "I'm awake."
+- **pull** — looks at what peers are showing and, if a peer out-ranks us, steps us down to standby.
+
+The bug was in **pull**. It stepped us down whenever it saw *any* peer permit at all — without checking whether that permit was **still valid** or **newer than ours**.
+
+The mini was still showing a permit from **May 31, epoch 150** — expired two days ago, and far older than the laptop's live epoch ~1420. Every time the laptop's own permit lapsed for a split-second between renewals, the **pull** loop saw the mini's ancient permit and went "a peer has a permit, you must be out — step down." Then **tick** renewed and stepped it back up. Forever.
+
+## The fix (tiny + precise)
+A peer's lease may only demote us if it is **both**:
+1. **Live** — not expired, and
+2. **Strictly newer** — a higher epoch than our own.
+
+A stale/expired or older peer permit is now ignored for the purpose of stepping down. The machine that's genuinely in charge stays in charge; its own brief permit-lapses are simply re-renewed by the **tick** loop (which is its job). Genuine takeovers — a peer with a *live, newer* lease — still demote us exactly as before. Same-epoch ties are still handled by the existing split-brain resolver, untouched.
+
+Two small code changes:
+- `LeaseCoordinator.peerLeaseSupersedes()` — the new "does this peer actually out-rank me?" check (live AND higher-epoch).
+- `MultiMachineCoordinator.tickLeasePull()` — the pull loop now demotes only when `peerLeaseSupersedes()` is true.
+
+## How we know it's fixed
+A deterministic unit test (`LeaseCoordinator-stalePeerDemotion.test.ts`) reproduces the exact incident shape — a live holder observing an expired, lower-epoch peer, including the moment its own lease has just lapsed — and asserts it does **not** demote. It also checks the real takeover still works (a live, higher-epoch peer **does** demote). The existing convergence (#686) and split-brain-resolver tests still pass, so we didn't weaken the real failover.
+
+## Why a unit test and not "watch the live machines"
+We tried fixing it live first (clearing the stale lease, restarting) — it became whack-a-mole, because the stale lease keeps getting re-disclosed over the network and the observation is cached in memory. The unit test pins the behavior deterministically, the way #688 pinned convergence. The code change makes the live mesh robust regardless of caches or timing.

--- a/src/core/LeaseCoordinator.ts
+++ b/src/core/LeaseCoordinator.ts
@@ -330,6 +330,38 @@ export class LeaseCoordinator {
   }
 
   /**
+   * Whether the most-recently OBSERVED peer lease genuinely SUPERSEDES ours and
+   * may therefore drive a pull-loop demotion. True ONLY when that peer lease is
+   * LIVE (not expired) AND at a STRICTLY HIGHER epoch than our own self-issued
+   * lease.
+   *
+   * Why this stricter gate exists (live incident 2026-06-02, the real laptop+mini
+   * pair): the pull loop demoted on ANY non-null `observedPeerLease()`. A standby
+   * peer kept disclosing a 2-DAY-EXPIRED, epoch-150 lease (vs our live epoch-1400+),
+   * which satisfied that loose gate — so every time our own ~60s lease lapsed
+   * transiently between renewals, the legitimate holder flipped to read-only
+   * standby (~50% of the time), blocking real writes (#673 caught the crash but the
+   * writes still failed). A stale/expired or lower-or-equal-epoch peer carries no
+   * fencing authority and must NEVER demote a legitimate holder; that holder's
+   * transient self-lapse is re-acquired by `tickLease`. Same-epoch contention is a
+   * separate concern handled by the contested-split-brain resolver, not here.
+   *
+   * NOTE: compare against `selfIssued.epoch` (our OWN lease), NOT `currentEpoch()`
+   * — the latter is `effectiveView().epoch = max(self, observed-peer)`, so it would
+   * already fold the peer in and make `peer.epoch > currentEpoch()` impossible.
+   */
+  peerLeaseSupersedes(): boolean {
+    const peer = this.observedPeerLease();
+    if (!peer) return false;
+    // A stale/expired observed peer lease carries no fencing authority.
+    if (this.fl.isExpired(peer, this.now())) return false;
+    // Only a STRICTLY higher epoch out-fences our own self-issued lease. A peer at
+    // our epoch or below cannot demote us (same-epoch ties → contested resolver).
+    const ourEpoch = this.selfIssued?.epoch ?? -1;
+    return peer.epoch > ourEpoch;
+  }
+
+  /**
    * Attempt to acquire (or self-renew) the lease if eligible. Returns true if
    * THIS machine holds the lease afterward. Implements the bounded-retry CAS
    * with livelock backoff.

--- a/src/core/MultiMachineCoordinator.ts
+++ b/src/core/MultiMachineCoordinator.ts
@@ -639,7 +639,17 @@ export class MultiMachineCoordinator extends EventEmitter {
       // the real feature intact (a standby pulling a higher-epoch holder still
       // demotes) while removing the spurious solo demotion.
       if (this.leaseCoordinator!.observedPeerLease()) {
-        this.reconcileRoleToLease('lease-pull');
+        // DEMOTE via the pull loop ONLY when a peer genuinely supersedes us — a
+        // LIVE, strictly-higher-epoch lease (peerLeaseSupersedes()). A stale/expired
+        // or lower-or-equal-epoch observed peer must NOT flip a legitimate holder to
+        // read-only when its own lease merely lapsed transiently between renewals —
+        // that re-acquisition is tickLease's job. Without this guard, a 2-day-expired
+        // epoch-150 peer lease flapped the real laptop holder to read-only ~50% of
+        // the time (live incident 2026-06-02). Promotion stays tickLease's job; the
+        // same-epoch contested tie is handled by the resolver below regardless.
+        if (this.leaseCoordinator!.peerLeaseSupersedes()) {
+          this.reconcileRoleToLease('lease-pull');
+        }
         this.surfacePullDiscoveredSplitBrain();
         // §Problem A — ACT on a same-epoch contested tie (not just surface it):
         // deterministic tie-break → loser relinquishes / winner advances once.

--- a/tests/unit/LeaseCoordinator-stalePeerDemotion.test.ts
+++ b/tests/unit/LeaseCoordinator-stalePeerDemotion.test.ts
@@ -1,0 +1,133 @@
+/**
+ * Regression: a STALE/EXPIRED or lower-epoch observed peer lease must NEVER
+ * demote a legitimate holder via the active-pull loop.
+ *
+ * Live incident 2026-06-02 (the real laptop+mini pair): the pull-loop demotion
+ * gate was `if (observedPeerLease())` — ANY non-null observed peer. A standby
+ * peer kept disclosing a 2-DAY-EXPIRED, epoch-150 lease, so every time the live
+ * holder's own ~60s lease lapsed transiently between renewals it flipped to
+ * read-only standby (~50% of the time), blocking real writes (#673 caught the
+ * crash but the writes still failed). The fix gates the demotion on
+ * `peerLeaseSupersedes()` — LIVE (not expired) AND strictly-higher epoch than our
+ * own self-issued lease. This test is the deterministic ground truth: live
+ * observation on the real pair was too flaky to prove a timing-sensitive race.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import crypto from 'node:crypto';
+import { FencedLease, type LeaseCrypto } from '../../src/core/FencedLease.js';
+import { LeaseCoordinator } from '../../src/core/LeaseCoordinator.js';
+import { LocalLeaseStore } from '../../src/core/LocalLeaseStore.js';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+import type { LeaseRecord } from '../../src/core/types.js';
+
+function genKey() {
+  return crypto.generateKeyPairSync('ed25519', {
+    publicKeyEncoding: { type: 'spki', format: 'pem' },
+    privateKeyEncoding: { type: 'pkcs8', format: 'pem' },
+  });
+}
+const KEYS: Record<string, { publicKey: string; privateKey: string }> = { A: genKey(), B: genKey() };
+function crypt(self: string): LeaseCrypto {
+  return {
+    selfMachineId: self,
+    sign: (c) => crypto.sign(null, Buffer.from(c), KEYS[self].privateKey).toString('base64'),
+    verify: (c, sig, holder) => {
+      const pub = KEYS[holder]?.publicKey;
+      if (!pub) return false;
+      try { return crypto.verify(null, Buffer.from(c), pub, Buffer.from(sig, 'base64')); } catch { return false; }
+    },
+  };
+}
+const TTL = 60_000;
+const FAILOVER = 15 * 60_000;
+function fl(self: string) { return new FencedLease(crypt(self), { leaseTtlMs: TTL, failoverThresholdMs: FAILOVER }); }
+
+describe('LeaseCoordinator.peerLeaseSupersedes — stale/lower peer must not demote a holder (incident 2026-06-02)', () => {
+  let dir: string;
+  let now: number;
+  let observedPeer: LeaseRecord | null;
+  let lc: LeaseCoordinator;
+
+  function tunnel() {
+    return {
+      broadcast: async () => true,
+      observed: () => ({
+        lease: observedPeer,
+        lastNonceByHolder: observedPeer ? { [observedPeer.holder]: observedPeer.nonce } : {},
+      }),
+      isReachable: () => true,
+      pullAllPeers: async () => { /* observed() reads the injected buffer */ },
+    };
+  }
+
+  /** A peer (B) lease at a given epoch with an explicit expiry instant. */
+  function peerLease(epoch: number, expiresAtMs: number, acquiredAtMs = now): LeaseRecord {
+    return fl('B').signLease(epoch, new Date(acquiredAtMs).toISOString(), new Date(expiresAtMs).toISOString(), 1);
+  }
+
+  beforeEach(async () => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'lease-stale-'));
+    now = 2_000_000; // arbitrary fixed clock
+    observedPeer = null;
+    lc = new LeaseCoordinator({
+      lease: fl('A'),
+      store: new LocalLeaseStore({ filePath: path.join(dir, 'a.json') }),
+      tunnel: tunnel(),
+      presumedDeadHolders: () => new Set(),
+      now: () => now,
+      monotonicNow: () => now,
+    });
+    // A acquires a fresh lease at epoch 1 (no peer observed at acquire time).
+    expect(await lc.acquireIfEligible()).toBe(true);
+    expect(lc.holdsLease()).toBe(true);
+    expect(lc.currentEpoch()).toBe(1);
+  });
+
+  afterEach(() => {
+    try {
+      SafeFsExecutor.safeRmSync(dir, { recursive: true, force: true, operation: 'tests/unit/LeaseCoordinator-stalePeerDemotion.test.ts' });
+    } catch { /* ignore */ }
+  });
+
+  it('no observed peer → does not supersede', () => {
+    observedPeer = null;
+    expect(lc.peerLeaseSupersedes()).toBe(false);
+  });
+
+  it('THE INCIDENT: an EXPIRED, lower-epoch peer lease does NOT supersede the live holder', () => {
+    // Mirror the real shape: peer at a lower epoch, long expired (2 days).
+    const twoDays = 2 * 24 * 60 * 60 * 1000;
+    observedPeer = peerLease(0, now - twoDays, now - twoDays);
+    expect(lc.peerLeaseSupersedes()).toBe(false);
+  });
+
+  it('an EXPIRED peer lease does NOT supersede even at a HIGHER epoch (expiry strips authority)', () => {
+    observedPeer = peerLease(99, now - 1000); // epoch 99 (>1) but expired 1s ago
+    expect(lc.peerLeaseSupersedes()).toBe(false);
+  });
+
+  it('a LIVE peer lease at our epoch or below does NOT supersede', () => {
+    observedPeer = peerLease(1, now + TTL); // live, same epoch → contested resolver's job, not a demote
+    expect(lc.peerLeaseSupersedes()).toBe(false);
+  });
+
+  it('a LIVE, strictly-higher-epoch peer lease DOES supersede (genuine takeover preserved)', () => {
+    observedPeer = peerLease(2, now + TTL); // live, higher epoch
+    expect(lc.peerLeaseSupersedes()).toBe(true);
+  });
+
+  it('the incident self-lapse: our own lease lapsed AND only a stale peer is observed → still does NOT supersede', () => {
+    // Advance the clock past our own lease expiry — the transient between-renewals
+    // lapse that USED to trigger the spurious demotion in tickLeasePull.
+    now += TTL + 1;
+    expect(lc.holdsLease()).toBe(false); // our self-lease has lapsed (not yet renewed)
+    observedPeer = peerLease(0, now - 60_000); // stale, lower-epoch peer still being disclosed
+    // The bug demoted the holder right here. The fix: a stale peer carries no
+    // fencing authority, so peerLeaseSupersedes() stays false → tickLease re-acquires.
+    expect(lc.peerLeaseSupersedes()).toBe(false);
+  });
+});


### PR DESCRIPTION
## What
A peer's observed lease may demote the active holder (via the active-pull loop) **only** when it is **live (not expired) AND strictly-higher epoch** than our own self-issued lease. Previously the gate was `if (observedPeerLease())` — *any* non-null peer.

## Why (live incident 2026-06-02, real laptop+mini pair)
After enabling multi-machine on the real pair, the laptop (awake holder) **oscillated awake↔standby ~50% of the time**. Root cause, grounded in the live logs + lease files:
- The standby mini kept disclosing a **2-day-expired, epoch-150** lease (vs the laptop's live epoch ~1420).
- `tickLeasePull`'s gate demoted on any non-null observed peer. So whenever the laptop's own ~60s lease lapsed transiently *between renewals*, the pull loop saw the stale peer and flipped the holder to **read-only standby**.
- Impact: floods of `StateManager is read-only … Blocked: set/delete/saveJobState` + `SessionManager monitor tick error`. #673 caught the crash, but the **writes still failed** ~half the time.

The finding_668 fix guarded "no peer at all" but not "stale/expired/lower-epoch peer."

## The fix (2 small changes)
- `LeaseCoordinator.peerLeaseSupersedes()` — new: `observed peer is !expired AND peer.epoch > selfIssued.epoch`. (Compares against our **own** epoch, not `currentEpoch()` which folds the peer in.)
- `MultiMachineCoordinator.tickLeasePull()` — demote only when `peerLeaseSupersedes()`. Promotion stays `tickLease`'s job; same-epoch contention still goes through the contested-split-brain resolver (unchanged).

## Tests
- `tests/unit/LeaseCoordinator-stalePeerDemotion.test.ts` (6 cases) reproduces the incident deterministically: live holder + expired/lower peer + transient self-lapse → **does not demote**; and a live higher-epoch peer → **does demote** (real takeover preserved).
- `#686` convergence + `MultiMachineCoordinator-leasePull` resolver tests still pass; `tsc --noEmit` clean. (Local full unit suite OOM'd on resources mid-run — no test failures shown; CI runs it authoritatively.)

## Side effects / blast radius
- Touches only the pull-loop demotion gate. Genuine failover (live higher-epoch peer) is unchanged. Same-epoch split-brain resolution is unchanged.
- No config/migration/API changes.

## NEXT (post-merge)
- Deploy to the real laptop+mini pair (verify the oscillation + read-only flapping stops on the live mesh).
- Consider a follow-up: the in-memory `observed()` cache never expires a stale peer lease — this fix neutralizes its effect at the gate, but expiring the cache itself would be belt-and-suspenders.

ELI16: `docs/eli16/STALE-PEER-DEMOTION-FIX.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)