### PR TITLE
fix(init): gemini/codex-only installs no longer scaffold Claude .claude/settings.json (fa93e951)

### DIFF
--- a/docs/eli16/GEMINI-SCAFFOLD-LEAK-ELI16.md
+++ b/docs/eli16/GEMINI-SCAFFOLD-LEAK-ELI16.md
@@ -1,0 +1,49 @@
+# The Gemini scaffold leak — explained simply
+
+## The problem
+
+When you install an Instar agent you pick which "brain" it runs on — Claude, Codex, or
+Gemini. If you picked **Gemini only**, the agent was still dropping a **Claude
+configuration file** (`.claude/settings.json`) into your project — a file full of
+Claude-specific hooks that a Gemini agent can never use. Harmless, but wrong and
+confusing: a Gemini agent shouldn't have Claude's settings sitting in it.
+
+Codey found this for real: he installed a fresh Gemini agent and noticed it had a
+7.5 KB Claude settings file even though it was set to Gemini-only.
+
+## Why it happened
+
+Deep in the install code there's a step that reads back "which brains are enabled" and
+then decides whether to write the Claude settings. That step had a hand-written list
+that only recognized two brains: `claude-code` and `codex-cli`. **Gemini wasn't on the
+list.**
+
+So when it read `["gemini-cli"]`, it filtered out the one entry it didn't recognize,
+ended up with an empty list, and fell back to a default of `["claude-code"]` — which
+made it think Claude was enabled. So it wrote the Claude file. The agent was told "you
+only run Gemini," but a stale hard-coded list quietly overruled that.
+
+## The fix
+
+Instead of a hand-written list that someone has to remember to update every time a new
+brain is added, there's now **one canonical list of known brains** (`KNOWN_FRAMEWORKS`)
+that includes Gemini — and a single helper (`isKnownFramework`) that both spots in the
+code use. So:
+
+- A **Gemini-only** install no longer gets a Claude settings file.
+- A **Codex-only** install no longer gets one either (it had the same blind spot).
+- A **Claude** install is completely unchanged — it still gets its settings.
+- And the next new brain we add won't silently hit this bug, because the list is in one
+  place tied to the official type.
+
+## How we know it's fixed
+
+A test drives the real install step four ways — Gemini-only, Codex-only, Claude-only,
+and Claude+Gemini — and checks the Claude settings file appears exactly when Claude is
+actually one of the enabled brains, and never otherwise. All four pass.
+
+## One honest note
+
+Agents installed *before* this fix still have the stray file sitting there (the fix
+stops creating it; it doesn't reach back and delete the old one). That leftover is inert
+— it just sits there unused — and cleaning it up safely is a small separate follow-up.

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -126,6 +126,26 @@ export function resolveEnabledFrameworks(
 }
 
 /**
+ * Canonical set of frameworks instar knows how to install. Keep in sync with
+ * `IntelligenceFramework`. Used to validate the `enabledFrameworks` array read
+ * back from config.json: a hardcoded `f === 'claude-code' || f === 'codex-cli'`
+ * filter silently DROPPED `gemini-cli`, so a gemini-only config produced an empty
+ * filtered list and fell through to the `['claude-code']` default — which made
+ * refreshHooksAndSettings scaffold a Claude `.claude/settings.json` into a
+ * gemini-only agent (framework-issue: gemini-cli scaffold leak). Using a complete
+ * known-framework guard makes this drift-proof as new frameworks are added.
+ */
+export const KNOWN_FRAMEWORKS: ReadonlyArray<'claude-code' | 'codex-cli' | 'gemini-cli'> = [
+  'claude-code',
+  'codex-cli',
+  'gemini-cli',
+];
+
+export function isKnownFramework(f: unknown): f is 'claude-code' | 'codex-cli' | 'gemini-cli' {
+  return typeof f === 'string' && (KNOWN_FRAMEWORKS as readonly string[]).includes(f);
+}
+
+/**
  * Main init entry point. Handles both fresh and existing project modes.
  */
 export async function initProject(options: InitOptions): Promise<void> {
@@ -3501,9 +3521,7 @@ export function refreshHooksAndSettings(projectDir: string, stateDir: string): v
       };
       serverPort = config.port;
       if (Array.isArray(config.enabledFrameworks) && config.enabledFrameworks.length > 0) {
-        const filtered = config.enabledFrameworks.filter(
-          (f): f is 'claude-code' | 'codex-cli' => f === 'claude-code' || f === 'codex-cli',
-        );
+        const filtered = config.enabledFrameworks.filter(isKnownFramework);
         if (filtered.length > 0) enabledFrameworks = filtered;
       }
     }
@@ -3686,9 +3704,7 @@ function refreshScripts(projectDir: string, stateDir: string): void {
   const enabled = ((): ReadonlyArray<string> => {
     const raw = (config as { enabledFrameworks?: unknown }).enabledFrameworks;
     if (Array.isArray(raw) && raw.length > 0) {
-      const filtered = raw.filter(
-        (f): f is 'claude-code' | 'codex-cli' => f === 'claude-code' || f === 'codex-cli',
-      );
+      const filtered = raw.filter(isKnownFramework);
       if (filtered.length > 0) return filtered;
     }
     return ['claude-code'];

--- a/src/data/builtin-manifest.json
+++ b/src/data/builtin-manifest.json
@@ -1,8 +1,8 @@
 {
   "$schema": "./builtin-manifest.schema.json",
   "schemaVersion": 1,
-  "generatedAt": "2026-06-02T19:09:35.138Z",
-  "instarVersion": "1.3.203",
+  "generatedAt": "2026-06-02T20:14:52.098Z",
+  "instarVersion": "1.3.205",
   "entryCount": 195,
   "entries": {
     "hook:session-start": {

--- a/tests/unit/gemini-scaffold-leak.test.ts
+++ b/tests/unit/gemini-scaffold-leak.test.ts
@@ -1,0 +1,79 @@
+/**
+ * Unit test — gemini-cli scaffold leak (framework-issue fa93e951).
+ *
+ * Bug: refreshHooksAndSettings() read `enabledFrameworks` from config.json
+ * through a hardcoded filter `f === 'claude-code' || f === 'codex-cli'` that
+ * silently DROPPED 'gemini-cli'. A gemini-only config produced an empty filtered
+ * list and fell through to the `['claude-code']` default, so `claudeEnabled`
+ * became true and installClaudeSettings() wrote a full Claude .claude/settings.json
+ * into a gemini-only agent. Fixed by filtering through the complete
+ * `isKnownFramework` guard.
+ *
+ * Found via live dogfooding: Codey installed a gemini agent and reported it still
+ * had a 7.5KB .claude/settings.json despite enabledFrameworks=['gemini-cli'].
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { refreshHooksAndSettings, isKnownFramework, KNOWN_FRAMEWORKS } from '../../src/commands/init.js';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+
+let tmp: string;
+let projectDir: string;
+let stateDir: string;
+
+beforeEach(() => {
+  tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'gemini-scaffold-leak-'));
+  projectDir = tmp;
+  stateDir = path.join(tmp, '.instar');
+  fs.mkdirSync(stateDir, { recursive: true });
+});
+
+afterEach(() => {
+  SafeFsExecutor.safeRmSync(tmp, { recursive: true, force: true, sourceTreeOverride: true });
+});
+
+function writeConfig(enabledFrameworks: string[]): void {
+  fs.writeFileSync(path.join(stateDir, 'config.json'), JSON.stringify({ port: 4042, enabledFrameworks }));
+}
+
+const claudeSettingsPath = () => path.join(projectDir, '.claude', 'settings.json');
+
+describe('isKnownFramework — the canonical guard that closed the drift', () => {
+  it('accepts every IntelligenceFramework and nothing else', () => {
+    expect(KNOWN_FRAMEWORKS).toEqual(['claude-code', 'codex-cli', 'gemini-cli']);
+    for (const f of KNOWN_FRAMEWORKS) expect(isKnownFramework(f)).toBe(true);
+    expect(isKnownFramework('gemini-cli')).toBe(true); // the one that was dropped
+    expect(isKnownFramework('not-a-framework')).toBe(false);
+    expect(isKnownFramework(undefined)).toBe(false);
+    expect(isKnownFramework(123)).toBe(false);
+  });
+});
+
+describe('refreshHooksAndSettings — no Claude scaffold leak into non-claude agents', () => {
+  it('does NOT write .claude/settings.json for a gemini-only install', () => {
+    writeConfig(['gemini-cli']);
+    refreshHooksAndSettings(projectDir, stateDir);
+    expect(fs.existsSync(claudeSettingsPath())).toBe(false);
+  });
+
+  it('does NOT write .claude/settings.json for a codex-only install', () => {
+    writeConfig(['codex-cli']);
+    refreshHooksAndSettings(projectDir, stateDir);
+    expect(fs.existsSync(claudeSettingsPath())).toBe(false);
+  });
+
+  it('STILL writes .claude/settings.json for a claude-code install (no regression)', () => {
+    writeConfig(['claude-code']);
+    refreshHooksAndSettings(projectDir, stateDir);
+    expect(fs.existsSync(claudeSettingsPath())).toBe(true);
+  });
+
+  it('writes .claude/settings.json when claude-code is among multiple frameworks', () => {
+    writeConfig(['claude-code', 'gemini-cli']);
+    refreshHooksAndSettings(projectDir, stateDir);
+    expect(fs.existsSync(claudeSettingsPath())).toBe(true);
+  });
+});

--- a/upgrades/next/gemini-scaffold-leak-fix.md
+++ b/upgrades/next/gemini-scaffold-leak-fix.md
@@ -1,0 +1,45 @@
+# Upgrade Guide — fix gemini/codex-only scaffold leak
+
+<!-- patch = bug fix, no breaking changes -->
+
+## What Changed
+
+`refreshHooksAndSettings()` (and the sibling resolver in init) read the persisted
+`enabledFrameworks` from config.json through a hardcoded filter
+`f === 'claude-code' || f === 'codex-cli'` that silently DROPPED `gemini-cli`. For a
+gemini-only agent (`enabledFrameworks: ['gemini-cli']`) the filtered list came back
+empty, so the code fell through to its `['claude-code']` default, `claudeEnabled`
+became true, and `installClaudeSettings()` wrote a full Claude `.claude/settings.json`
+into an agent that does not run Claude Code. Both filter sites now validate through a
+single canonical `isKnownFramework` guard (backed by a `KNOWN_FRAMEWORKS` list kept in
+sync with `IntelligenceFramework`), so no installed framework is dropped and a new one
+cannot silently regress this again. New gemini-only and codex-only installs no longer
+get a stray Claude settings file; claude-code installs are unchanged.
+
+## What to Tell Your User
+
+- **Cleaner non-Claude installs**: "If you set me up as a Gemini-only or Codex-only
+  agent, I was accidentally dropping a Claude configuration file into your project even
+  though I don't use Claude there. That's fixed — a Gemini agent now stays a Gemini
+  agent, with no stray Claude settings."
+
+## Summary of New Capabilities
+
+| Capability | How to Use |
+|-----------|-----------|
+| Framework-correct scaffolding | Automatic (gemini/codex-only installs skip Claude settings) |
+
+## Evidence
+
+- **Live before:** the gemini agent installed during dogfooding
+  (`~/.instar/agents/gemini`, `enabledFrameworks: ['gemini-cli']`) contained a
+  7559-byte `.claude/settings.json` plus `.claude/skills`/`.claude/scripts` — Claude
+  hook config it can never use. Confirmed by direct inspection of the agent home.
+- **After (code path):** a behavioral test drives `refreshHooksAndSettings()` against a
+  temp project with `enabledFrameworks: ['gemini-cli']` and asserts no
+  `.claude/settings.json` is written; `['codex-cli']` likewise; `['claude-code']` and
+  `['claude-code','gemini-cli']` still write it (no regression). A fresh gemini-only
+  install therefore no longer leaks the file.
+- **Residue note:** agents installed BEFORE this fix keep their already-written stray
+  `.claude/settings.json` (the fix stops re-writing it but does not delete the residue);
+  cleaning that inert leftover is a separate follow-up.

--- a/upgrades/side-effects/gemini-scaffold-leak-fix.md
+++ b/upgrades/side-effects/gemini-scaffold-leak-fix.md
@@ -1,0 +1,114 @@
+# Side-Effects Review — fix gemini/codex-only scaffold leak
+
+**Version / slug:** `gemini-scaffold-leak-fix`
+**Date:** `2026-06-02`
+**Author:** `echo`
+**Second-pass reviewer:** `not required (Tier-1 surgical bug fix; the change is strictly more permissive)`
+
+## Summary of the change
+
+`src/commands/init.ts`: replace two hardcoded `enabledFrameworks` filters
+(`f === 'claude-code' || f === 'codex-cli'`) — which dropped `gemini-cli` and caused
+gemini-only agents to fall through to the `['claude-code']` default and scaffold a
+Claude `.claude/settings.json` — with a single canonical `isKnownFramework` guard
+(+ exported `KNOWN_FRAMEWORKS`, kept in sync with `IntelligenceFramework`). Adds a
+unit test proving gemini/codex-only installs skip Claude settings while claude-code
+installs are unchanged.
+
+## Decision-point inventory
+
+- `refreshHooksAndSettings: claudeEnabled?` (init.ts:~3524) — **modify** — the input
+  (`enabledFrameworks` parsed from config) is now framework-complete; the gate logic is
+  unchanged.
+- `initStandalone framework resolution` (init.ts:~3707) — **modify** — same filter fix.
+
+---
+
+## 1. Over-block
+
+**What legitimate inputs does this change reject that it shouldn't?** None. The change
+is strictly MORE permissive than before: the old filter kept `{claude-code, codex-cli}`;
+the new guard keeps `{claude-code, codex-cli, gemini-cli}`. Nothing that previously
+passed is now dropped. Garbage values (non-framework strings) are still dropped, as
+before.
+
+---
+
+## 2. Under-block
+
+**What failure modes does this still miss?** A future framework added to
+`IntelligenceFramework` must also be added to `KNOWN_FRAMEWORKS` (they are co-located
+with a doc comment to make the coupling obvious). It does NOT retroactively clean the
+stray `.claude/settings.json` already written into agents installed before the fix —
+that inert residue is a separate follow-up (a destructive cleanup migration deserving
+its own careful gating).
+
+---
+
+## 3. Level-of-abstraction fit
+
+Correct layer — a data-validation guard at the config-read boundary, replacing an
+inline literal with a named, type-safe, single-source-of-truth predicate. It does not
+add a gate or authority; it fixes the INPUT to an existing gate (`claudeEnabled`).
+
+---
+
+## 4. Signal vs authority compliance
+
+**Required reference:** [docs/signal-vs-authority.md](../../docs/signal-vs-authority.md)
+
+- [x] No — this change has no block/allow surface. It corrects which frameworks survive
+  a config-parse filter; the downstream `claudeEnabled` gate already existed.
+
+---
+
+## 5. Interactions
+
+- **Shadowing:** none — single in-function filter, no ordering with other checks.
+- **Double-fire:** none.
+- **Races:** none — pure synchronous config parse.
+- **Feedback loops:** none.
+
+The only behavioral change: for a gemini-only or codex-only config, `claudeEnabled` is
+now correctly `false`, so `installClaudeSettings()` / `refreshClaudeMd()` are skipped.
+For claude-code (alone or among multiple frameworks) behavior is identical.
+
+---
+
+## 6. External surfaces
+
+- Persistent state: a NEW gemini/codex-only install no longer creates a stray
+  `projectDir/.claude/settings.json`. Existing agents: on their next update,
+  `refreshHooksAndSettings` stops re-writing the file for non-claude configs (the
+  pre-existing file is left in place — inert, see §2).
+- Other agents / external systems: none.
+- Timing: none.
+
+---
+
+## 7. Rollback cost
+
+Pure code change — revert the two filter lines + the guard, ship a patch. No persistent
+state created by this change to clean up (it REMOVES an unwanted write; it does not add
+state). No user-visible regression during rollback.
+
+---
+
+## Conclusion
+
+The review produced no design changes. The fix is a minimal, strictly-more-permissive
+correction of a framework-blind filter (the same drift class as the Step-2 resolver
+bugs), with a behavioral test that proves both sides of the boundary. Clear to ship as
+a Tier-1 bug fix. One honest residual logged: the inert leftover file on
+already-installed agents is a separate, carefully-gated cleanup follow-up.
+
+## Second-pass review (if required)
+
+Not required (Tier-1, strictly-more-permissive). Discovered via live dogfooding (Codey's
+gemini install) — the empirical "before" is itself an independent confirmation.
+
+## Evidence pointers
+
+- `tests/unit/gemini-scaffold-leak.test.ts` — 5 tests, both sides of the boundary.
+- Live before: `~/.instar/agents/gemini/.claude/settings.json` (7559 bytes) on a
+  `['gemini-cli']` config.


### PR DESCRIPTION
## What

A gemini-only (or codex-only) install was still writing a full Claude `.claude/settings.json` into the agent. Root cause: `refreshHooksAndSettings()` (and the standalone resolver) parsed `enabledFrameworks` from config through a hardcoded filter `f === 'claude-code' || f === 'codex-cli'` that **dropped `gemini-cli`** → a `['gemini-cli']` config filtered to empty → fell through to the `['claude-code']` default → `claudeEnabled` true → `installClaudeSettings()` wrote the stray file.

Both filter sites now validate through a single canonical **`isKnownFramework`** guard backed by **`KNOWN_FRAMEWORKS`** (kept in sync with `IntelligenceFramework`), so no installed framework is dropped and the next one can't silently regress this. Same drift class as the Step-2 framework-blind resolver fixes.

## Origin (differential-oversight)

Found through the live apprenticeship loop: Codey's dogfooding gemini install had a 7559-byte `.claude/settings.json` despite `enabledFrameworks: ['gemini-cli']`. Codey's PR #693 fixed the wizard *tool-contract*; this is the orthogonal scaffolding leak the overseer caught while reviewing #693.

## Tests

- `tests/unit/gemini-scaffold-leak.test.ts` — 5 tests: gemini-only/codex-only → no Claude settings; claude-code (alone + among multiple) → still writes it (no regression); `isKnownFramework` accepts all 3 frameworks + rejects garbage.
- `tsc --noEmit` clean. The change is strictly more permissive (near-zero blast radius).

## Artifacts

- `upgrades/next/gemini-scaffold-leak-fix.md` · `upgrades/side-effects/gemini-scaffold-leak-fix.md` · `docs/eli16/GEMINI-SCAFFOLD-LEAK-ELI16.md`

## Honest residual

Agents installed BEFORE this fix keep their already-written stray file (the fix stops re-writing it; it doesn't delete the inert residue). A safe cleanup migration is a separate follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)