### PR TITLE
fix(autonomous): repair stop-hook registration path so the loop re-engages

### DIFF
--- a/.claude/skills/autonomous/SKILL.md
+++ b/.claude/skills/autonomous/SKILL.md
@@ -57,11 +57,19 @@ import json
 with open('.claude/settings.json') as f:
     s = json.load(f)
 hooks = s.setdefault('hooks', {}).setdefault('Stop', [])
-if not any('autonomous-stop-hook' in str(h) for h in hooks):
-    hooks.append({'matcher': '', 'hooks': [{'type': 'command', 'command': 'bash .instar/hooks/instar/autonomous-stop-hook.sh', 'timeout': 10000}]})
+# The stop hook ships ONLY in the skill dir — register THAT path. (A legacy bug
+# registered '.instar/hooks/instar/autonomous-stop-hook.sh', where the file is
+# never deployed, so the hook silently failed every Stop and the loop never
+# re-engaged.) Self-heal: drop any prior autonomous-stop-hook entry (incl. the
+# legacy wrong path), then add exactly one correct-path entry.
+correct = 'bash \${CLAUDE_PROJECT_DIR}/.claude/skills/autonomous/hooks/autonomous-stop-hook.sh'
+before = json.dumps(hooks)
+hooks[:] = [e for e in hooks if not any('autonomous-stop-hook' in str(h.get('command','')) for h in e.get('hooks', []))]
+hooks.append({'matcher': '', 'hooks': [{'type': 'command', 'command': correct, 'timeout': 10000}]})
+if json.dumps(hooks) != before:
     with open('.claude/settings.json', 'w') as f:
         json.dump(s, f, indent=2)
-    print('Stop hook registered')
+    print('Stop hook registered (correct skill path)')
 "
 ```
 

--- a/src/core/PostUpdateMigrator.ts
+++ b/src/core/PostUpdateMigrator.ts
@@ -1555,6 +1555,21 @@ export class PostUpdateMigrator {
       'autonomous-state.local.md',
       'skills/autonomous/scripts/setup-autonomous.sh (codex native /goal auto-wire)',
     );
+    // SKILL.md Step 2a registration-path fix: the prior bundled SKILL.md registered the
+    // stop hook at `.instar/hooks/instar/autonomous-stop-hook.sh` (a path where the hook is
+    // never deployed → silent Stop-hook failure → the autonomous loop never re-engaged and
+    // the session went idle). The fixed SKILL.md registers the deployed skill path and
+    // self-heals any stale entry. Marker `Stop hook registered (correct skill path)` is
+    // present ONLY in the fixed version (the old printed plain `Stop hook registered`), so
+    // bumping to it re-deploys the corrected prompt to existing agents; customized SKILL.md
+    // files (missing the stock `ALL_TASKS_COMPLETE` fingerprint) are left untouched. Pairs
+    // with the settings.json wrong-path repair in ensureAutonomousStopHook().
+    upgrade(
+      '.claude/skills/autonomous/SKILL.md',
+      'Stop hook registered (correct skill path)',
+      'ALL_TASKS_COMPLETE',
+      'skills/autonomous/SKILL.md (autonomous stop-hook registration path fix — loop re-engages)',
+    );
   }
 
   /**
@@ -2466,6 +2481,30 @@ export class PostUpdateMigrator {
       hooks.Stop = [];
     }
     const stopEntries = hooks.Stop as Array<{ matcher?: string; hooks?: Array<{ command?: string }> }>;
+
+    // Repair the legacy wrong-path registration. A prior autonomous SKILL.md Step 2a
+    // registered the stop hook at `.instar/hooks/instar/autonomous-stop-hook.sh` — a
+    // path where the hook is NEVER deployed (it ships only in the skill dir). That
+    // dead reference fails silently on every Stop, so the autonomous loop never
+    // re-injects and the session goes idle (the "I stopped self-driving" bug). The
+    // `hasAutonomousHook` check below treats any autonomous-stop-hook entry as
+    // "present", so without this repair a wrong-path entry blocks the correct
+    // registration forever. Rewrite any such command to the deployed skill path.
+    const correctStopHookCmd = 'bash ${CLAUDE_PROJECT_DIR}/.claude/skills/autonomous/hooks/autonomous-stop-hook.sh';
+    for (const e of stopEntries) {
+      for (const h of e.hooks ?? []) {
+        if (
+          h.command?.includes('autonomous-stop-hook') &&
+          h.command.includes('.instar/hooks/instar/autonomous-stop-hook') &&
+          h.command !== correctStopHookCmd
+        ) {
+          h.command = correctStopHookCmd;
+          result.upgraded.push('.claude/settings.json: repaired autonomous stop-hook path (.instar/hooks/instar → skill dir; loop never re-engaged)');
+          patched = true;
+        }
+      }
+    }
+
     const hasAutonomousHook = stopEntries.some(e =>
       e.hooks?.some(h => h.command?.includes('autonomous-stop-hook')),
     );

--- a/src/data/builtin-manifest.json
+++ b/src/data/builtin-manifest.json
@@ -1,8 +1,8 @@
 {
   "$schema": "./builtin-manifest.schema.json",
   "schemaVersion": 1,
-  "generatedAt": "2026-06-02T21:30:53.437Z",
-  "instarVersion": "1.3.206",
+  "generatedAt": "2026-06-03T04:58:52.329Z",
+  "instarVersion": "1.3.210",
   "entryCount": 195,
   "entries": {
     "hook:session-start": {
@@ -11,7 +11,7 @@
       "domain": "identity",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/session-start.sh",
-      "contentHash": "797a5827842944d872077473dc0d87a1f99601f33d5f262e272748731d68250b",
+      "contentHash": "6cf82b68d5b625f674bfe7e5b43b85a3c51ee750038430f13f09d42d1a3fc14e",
       "since": "2025-01-01"
     },
     "hook:dangerous-command-guard": {
@@ -20,7 +20,7 @@
       "domain": "safety",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/dangerous-command-guard.sh",
-      "contentHash": "797a5827842944d872077473dc0d87a1f99601f33d5f262e272748731d68250b",
+      "contentHash": "6cf82b68d5b625f674bfe7e5b43b85a3c51ee750038430f13f09d42d1a3fc14e",
       "since": "2025-01-01"
     },
     "hook:grounding-before-messaging": {
@@ -29,7 +29,7 @@
       "domain": "safety",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/grounding-before-messaging.sh",
-      "contentHash": "797a5827842944d872077473dc0d87a1f99601f33d5f262e272748731d68250b",
+      "contentHash": "6cf82b68d5b625f674bfe7e5b43b85a3c51ee750038430f13f09d42d1a3fc14e",
       "since": "2025-01-01"
     },
     "hook:compaction-recovery": {
@@ -38,7 +38,7 @@
       "domain": "identity",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/compaction-recovery.sh",
-      "contentHash": "797a5827842944d872077473dc0d87a1f99601f33d5f262e272748731d68250b",
+      "contentHash": "6cf82b68d5b625f674bfe7e5b43b85a3c51ee750038430f13f09d42d1a3fc14e",
       "since": "2025-01-01"
     },
     "hook:external-operation-gate": {
@@ -47,7 +47,7 @@
       "domain": "safety",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/external-operation-gate.js",
-      "contentHash": "797a5827842944d872077473dc0d87a1f99601f33d5f262e272748731d68250b",
+      "contentHash": "6cf82b68d5b625f674bfe7e5b43b85a3c51ee750038430f13f09d42d1a3fc14e",
       "since": "2025-01-01"
     },
     "hook:deferral-detector": {
@@ -56,7 +56,7 @@
       "domain": "safety",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/deferral-detector.js",
-      "contentHash": "797a5827842944d872077473dc0d87a1f99601f33d5f262e272748731d68250b",
+      "contentHash": "6cf82b68d5b625f674bfe7e5b43b85a3c51ee750038430f13f09d42d1a3fc14e",
       "since": "2025-01-01"
     },
     "hook:self-stop-guard": {
@@ -65,7 +65,7 @@
       "domain": "coherence",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/self-stop-guard.js",
-      "contentHash": "797a5827842944d872077473dc0d87a1f99601f33d5f262e272748731d68250b",
+      "contentHash": "6cf82b68d5b625f674bfe7e5b43b85a3c51ee750038430f13f09d42d1a3fc14e",
       "since": "2025-01-01"
     },
     "hook:post-action-reflection": {
@@ -74,7 +74,7 @@
       "domain": "evolution",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/post-action-reflection.js",
-      "contentHash": "797a5827842944d872077473dc0d87a1f99601f33d5f262e272748731d68250b",
+      "contentHash": "6cf82b68d5b625f674bfe7e5b43b85a3c51ee750038430f13f09d42d1a3fc14e",
       "since": "2025-01-01"
     },
     "hook:external-communication-guard": {
@@ -83,7 +83,7 @@
       "domain": "safety",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/external-communication-guard.js",
-      "contentHash": "797a5827842944d872077473dc0d87a1f99601f33d5f262e272748731d68250b",
+      "contentHash": "6cf82b68d5b625f674bfe7e5b43b85a3c51ee750038430f13f09d42d1a3fc14e",
       "since": "2025-01-01"
     },
     "hook:scope-coherence-collector": {
@@ -92,7 +92,7 @@
       "domain": "coherence",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/scope-coherence-collector.js",
-      "contentHash": "797a5827842944d872077473dc0d87a1f99601f33d5f262e272748731d68250b",
+      "contentHash": "6cf82b68d5b625f674bfe7e5b43b85a3c51ee750038430f13f09d42d1a3fc14e",
       "since": "2025-01-01"
     },
     "hook:scope-coherence-checkpoint": {
@@ -101,7 +101,7 @@
       "domain": "coherence",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/scope-coherence-checkpoint.js",
-      "contentHash": "797a5827842944d872077473dc0d87a1f99601f33d5f262e272748731d68250b",
+      "contentHash": "6cf82b68d5b625f674bfe7e5b43b85a3c51ee750038430f13f09d42d1a3fc14e",
       "since": "2025-01-01"
     },
     "hook:free-text-guard": {
@@ -110,7 +110,7 @@
       "domain": "safety",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/free-text-guard.sh",
-      "contentHash": "797a5827842944d872077473dc0d87a1f99601f33d5f262e272748731d68250b",
+      "contentHash": "6cf82b68d5b625f674bfe7e5b43b85a3c51ee750038430f13f09d42d1a3fc14e",
       "since": "2025-01-01"
     },
     "hook:claim-intercept": {
@@ -119,7 +119,7 @@
       "domain": "coherence",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/claim-intercept.js",
-      "contentHash": "797a5827842944d872077473dc0d87a1f99601f33d5f262e272748731d68250b",
+      "contentHash": "6cf82b68d5b625f674bfe7e5b43b85a3c51ee750038430f13f09d42d1a3fc14e",
       "since": "2025-01-01"
     },
     "hook:claim-intercept-response": {
@@ -128,7 +128,7 @@
       "domain": "coherence",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/claim-intercept-response.js",
-      "contentHash": "797a5827842944d872077473dc0d87a1f99601f33d5f262e272748731d68250b",
+      "contentHash": "6cf82b68d5b625f674bfe7e5b43b85a3c51ee750038430f13f09d42d1a3fc14e",
       "since": "2025-01-01"
     },
     "hook:stop-gate-router": {
@@ -137,7 +137,7 @@
       "domain": "safety",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/stop-gate-router.js",
-      "contentHash": "797a5827842944d872077473dc0d87a1f99601f33d5f262e272748731d68250b",
+      "contentHash": "6cf82b68d5b625f674bfe7e5b43b85a3c51ee750038430f13f09d42d1a3fc14e",
       "since": "2025-01-01"
     },
     "hook:auto-approve-permissions": {
@@ -146,7 +146,7 @@
       "domain": "safety",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/auto-approve-permissions.js",
-      "contentHash": "797a5827842944d872077473dc0d87a1f99601f33d5f262e272748731d68250b",
+      "contentHash": "6cf82b68d5b625f674bfe7e5b43b85a3c51ee750038430f13f09d42d1a3fc14e",
       "since": "2025-01-01"
     },
     "job:health-check": {
@@ -370,7 +370,7 @@
       "type": "skill",
       "domain": "skills",
       "sourcePath": ".claude/skills/autonomous/skill.md",
-      "contentHash": "96280cf60c51b233259d5f38189e072fd863e145c5952d8add207a0d016b14fb",
+      "contentHash": "3075c343b636506da821b1c1483112fb38920f41b1547b4dacdc7ae1734c51be",
       "since": "2025-01-01"
     },
     "skill:build": {
@@ -418,7 +418,7 @@
       "type": "route-group",
       "domain": "monitoring",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "ed378b5b589fe40b6d922aaf61a8b93d67751158598edd8a06499a8803c106d9",
+      "contentHash": "21039f688686c29f43f57af4290f006f693176ea9d084a196925bbf59e290510",
       "since": "2025-01-01"
     },
     "route-group:agents": {
@@ -426,7 +426,7 @@
       "type": "route-group",
       "domain": "sessions",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "ed378b5b589fe40b6d922aaf61a8b93d67751158598edd8a06499a8803c106d9",
+      "contentHash": "21039f688686c29f43f57af4290f006f693176ea9d084a196925bbf59e290510",
       "since": "2025-01-01"
     },
     "route-group:backups": {
@@ -434,7 +434,7 @@
       "type": "route-group",
       "domain": "operations",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "ed378b5b589fe40b6d922aaf61a8b93d67751158598edd8a06499a8803c106d9",
+      "contentHash": "21039f688686c29f43f57af4290f006f693176ea9d084a196925bbf59e290510",
       "since": "2025-01-01"
     },
     "route-group:git": {
@@ -442,7 +442,7 @@
       "type": "route-group",
       "domain": "coordination",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "ed378b5b589fe40b6d922aaf61a8b93d67751158598edd8a06499a8803c106d9",
+      "contentHash": "21039f688686c29f43f57af4290f006f693176ea9d084a196925bbf59e290510",
       "since": "2025-01-01"
     },
     "route-group:memory": {
@@ -450,7 +450,7 @@
       "type": "route-group",
       "domain": "memory",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "ed378b5b589fe40b6d922aaf61a8b93d67751158598edd8a06499a8803c106d9",
+      "contentHash": "21039f688686c29f43f57af4290f006f693176ea9d084a196925bbf59e290510",
       "since": "2025-01-01"
     },
     "route-group:semantic": {
@@ -458,7 +458,7 @@
       "type": "route-group",
       "domain": "memory",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "ed378b5b589fe40b6d922aaf61a8b93d67751158598edd8a06499a8803c106d9",
+      "contentHash": "21039f688686c29f43f57af4290f006f693176ea9d084a196925bbf59e290510",
       "since": "2025-01-01"
     },
     "route-group:status": {
@@ -466,7 +466,7 @@
       "type": "route-group",
       "domain": "monitoring",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "ed378b5b589fe40b6d922aaf61a8b93d67751158598edd8a06499a8803c106d9",
+      "contentHash": "21039f688686c29f43f57af4290f006f693176ea9d084a196925bbf59e290510",
       "since": "2025-01-01"
     },
     "route-group:capabilities": {
@@ -474,7 +474,7 @@
       "type": "route-group",
       "domain": "mapping",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "ed378b5b589fe40b6d922aaf61a8b93d67751158598edd8a06499a8803c106d9",
+      "contentHash": "21039f688686c29f43f57af4290f006f693176ea9d084a196925bbf59e290510",
       "since": "2025-01-01"
     },
     "route-group:project-map": {
@@ -482,7 +482,7 @@
       "type": "route-group",
       "domain": "mapping",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "ed378b5b589fe40b6d922aaf61a8b93d67751158598edd8a06499a8803c106d9",
+      "contentHash": "21039f688686c29f43f57af4290f006f693176ea9d084a196925bbf59e290510",
       "since": "2025-01-01"
     },
     "route-group:coherence": {
@@ -490,7 +490,7 @@
       "type": "route-group",
       "domain": "coherence",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "ed378b5b589fe40b6d922aaf61a8b93d67751158598edd8a06499a8803c106d9",
+      "contentHash": "21039f688686c29f43f57af4290f006f693176ea9d084a196925bbf59e290510",
       "since": "2025-01-01"
     },
     "route-group:topic-bindings": {
@@ -498,7 +498,7 @@
       "type": "route-group",
       "domain": "sessions",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "ed378b5b589fe40b6d922aaf61a8b93d67751158598edd8a06499a8803c106d9",
+      "contentHash": "21039f688686c29f43f57af4290f006f693176ea9d084a196925bbf59e290510",
       "since": "2025-01-01"
     },
     "route-group:context": {
@@ -506,7 +506,7 @@
       "type": "route-group",
       "domain": "context",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "ed378b5b589fe40b6d922aaf61a8b93d67751158598edd8a06499a8803c106d9",
+      "contentHash": "21039f688686c29f43f57af4290f006f693176ea9d084a196925bbf59e290510",
       "since": "2025-01-01"
     },
     "route-group:scope-coherence": {
@@ -514,7 +514,7 @@
       "type": "route-group",
       "domain": "coherence",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "ed378b5b589fe40b6d922aaf61a8b93d67751158598edd8a06499a8803c106d9",
+      "contentHash": "21039f688686c29f43f57af4290f006f693176ea9d084a196925bbf59e290510",
       "since": "2025-01-01"
     },
     "route-group:canonical-state": {
@@ -522,7 +522,7 @@
       "type": "route-group",
       "domain": "state",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "ed378b5b589fe40b6d922aaf61a8b93d67751158598edd8a06499a8803c106d9",
+      "contentHash": "21039f688686c29f43f57af4290f006f693176ea9d084a196925bbf59e290510",
       "since": "2025-01-01"
     },
     "route-group:ci": {
@@ -530,7 +530,7 @@
       "type": "route-group",
       "domain": "monitoring",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "ed378b5b589fe40b6d922aaf61a8b93d67751158598edd8a06499a8803c106d9",
+      "contentHash": "21039f688686c29f43f57af4290f006f693176ea9d084a196925bbf59e290510",
       "since": "2025-01-01"
     },
     "route-group:sessions": {
@@ -538,7 +538,7 @@
       "type": "route-group",
       "domain": "sessions",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "ed378b5b589fe40b6d922aaf61a8b93d67751158598edd8a06499a8803c106d9",
+      "contentHash": "21039f688686c29f43f57af4290f006f693176ea9d084a196925bbf59e290510",
       "since": "2025-01-01"
     },
     "route-group:jobs": {
@@ -546,7 +546,7 @@
       "type": "route-group",
       "domain": "scheduling",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "ed378b5b589fe40b6d922aaf61a8b93d67751158598edd8a06499a8803c106d9",
+      "contentHash": "21039f688686c29f43f57af4290f006f693176ea9d084a196925bbf59e290510",
       "since": "2025-01-01"
     },
     "route-group:skip-ledger": {
@@ -554,7 +554,7 @@
       "type": "route-group",
       "domain": "scheduling",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "ed378b5b589fe40b6d922aaf61a8b93d67751158598edd8a06499a8803c106d9",
+      "contentHash": "21039f688686c29f43f57af4290f006f693176ea9d084a196925bbf59e290510",
       "since": "2025-01-01"
     },
     "route-group:telegram": {
@@ -562,7 +562,7 @@
       "type": "route-group",
       "domain": "communication",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "ed378b5b589fe40b6d922aaf61a8b93d67751158598edd8a06499a8803c106d9",
+      "contentHash": "21039f688686c29f43f57af4290f006f693176ea9d084a196925bbf59e290510",
       "since": "2025-01-01"
     },
     "route-group:attention": {
@@ -570,7 +570,7 @@
       "type": "route-group",
       "domain": "communication",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "ed378b5b589fe40b6d922aaf61a8b93d67751158598edd8a06499a8803c106d9",
+      "contentHash": "21039f688686c29f43f57af4290f006f693176ea9d084a196925bbf59e290510",
       "since": "2025-01-01"
     },
     "route-group:relationships": {
@@ -578,7 +578,7 @@
       "type": "route-group",
       "domain": "relationships",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "ed378b5b589fe40b6d922aaf61a8b93d67751158598edd8a06499a8803c106d9",
+      "contentHash": "21039f688686c29f43f57af4290f006f693176ea9d084a196925bbf59e290510",
       "since": "2025-01-01"
     },
     "route-group:feedback": {
@@ -586,7 +586,7 @@
       "type": "route-group",
       "domain": "feedback",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "ed378b5b589fe40b6d922aaf61a8b93d67751158598edd8a06499a8803c106d9",
+      "contentHash": "21039f688686c29f43f57af4290f006f693176ea9d084a196925bbf59e290510",
       "since": "2025-01-01"
     },
     "route-group:updates": {
@@ -594,7 +594,7 @@
       "type": "route-group",
       "domain": "updates",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "ed378b5b589fe40b6d922aaf61a8b93d67751158598edd8a06499a8803c106d9",
+      "contentHash": "21039f688686c29f43f57af4290f006f693176ea9d084a196925bbf59e290510",
       "since": "2025-01-01"
     },
     "route-group:dispatches": {
@@ -602,7 +602,7 @@
       "type": "route-group",
       "domain": "dispatches",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "ed378b5b589fe40b6d922aaf61a8b93d67751158598edd8a06499a8803c106d9",
+      "contentHash": "21039f688686c29f43f57af4290f006f693176ea9d084a196925bbf59e290510",
       "since": "2025-01-01"
     },
     "route-group:quota": {
@@ -610,7 +610,7 @@
       "type": "route-group",
       "domain": "monitoring",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "ed378b5b589fe40b6d922aaf61a8b93d67751158598edd8a06499a8803c106d9",
+      "contentHash": "21039f688686c29f43f57af4290f006f693176ea9d084a196925bbf59e290510",
       "since": "2025-01-01"
     },
     "route-group:publishing": {
@@ -618,7 +618,7 @@
       "type": "route-group",
       "domain": "publishing",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "ed378b5b589fe40b6d922aaf61a8b93d67751158598edd8a06499a8803c106d9",
+      "contentHash": "21039f688686c29f43f57af4290f006f693176ea9d084a196925bbf59e290510",
       "since": "2025-01-01"
     },
     "route-group:private-views": {
@@ -626,7 +626,7 @@
       "type": "route-group",
       "domain": "publishing",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "ed378b5b589fe40b6d922aaf61a8b93d67751158598edd8a06499a8803c106d9",
+      "contentHash": "21039f688686c29f43f57af4290f006f693176ea9d084a196925bbf59e290510",
       "since": "2025-01-01"
     },
     "route-group:tunnel": {
@@ -634,7 +634,7 @@
       "type": "route-group",
       "domain": "networking",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "ed378b5b589fe40b6d922aaf61a8b93d67751158598edd8a06499a8803c106d9",
+      "contentHash": "21039f688686c29f43f57af4290f006f693176ea9d084a196925bbf59e290510",
       "since": "2025-01-01"
     },
     "route-group:events": {
@@ -642,7 +642,7 @@
       "type": "route-group",
       "domain": "networking",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "ed378b5b589fe40b6d922aaf61a8b93d67751158598edd8a06499a8803c106d9",
+      "contentHash": "21039f688686c29f43f57af4290f006f693176ea9d084a196925bbf59e290510",
       "since": "2025-01-01"
     },
     "route-group:evolution": {
@@ -650,7 +650,7 @@
       "type": "route-group",
       "domain": "evolution",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "ed378b5b589fe40b6d922aaf61a8b93d67751158598edd8a06499a8803c106d9",
+      "contentHash": "21039f688686c29f43f57af4290f006f693176ea9d084a196925bbf59e290510",
       "since": "2025-01-01"
     },
     "route-group:watchdog": {
@@ -658,7 +658,7 @@
       "type": "route-group",
       "domain": "monitoring",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "ed378b5b589fe40b6d922aaf61a8b93d67751158598edd8a06499a8803c106d9",
+      "contentHash": "21039f688686c29f43f57af4290f006f693176ea9d084a196925bbf59e290510",
       "since": "2025-01-01"
     },
     "route-group:topic-memory": {
@@ -666,7 +666,7 @@
       "type": "route-group",
       "domain": "memory",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "ed378b5b589fe40b6d922aaf61a8b93d67751158598edd8a06499a8803c106d9",
+      "contentHash": "21039f688686c29f43f57af4290f006f693176ea9d084a196925bbf59e290510",
       "since": "2025-01-01"
     },
     "route-group:state-sync": {
@@ -674,7 +674,7 @@
       "type": "route-group",
       "domain": "coordination",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "ed378b5b589fe40b6d922aaf61a8b93d67751158598edd8a06499a8803c106d9",
+      "contentHash": "21039f688686c29f43f57af4290f006f693176ea9d084a196925bbf59e290510",
       "since": "2025-01-01"
     },
     "route-group:intent": {
@@ -682,7 +682,7 @@
       "type": "route-group",
       "domain": "intent",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "ed378b5b589fe40b6d922aaf61a8b93d67751158598edd8a06499a8803c106d9",
+      "contentHash": "21039f688686c29f43f57af4290f006f693176ea9d084a196925bbf59e290510",
       "since": "2025-01-01"
     },
     "route-group:triage": {
@@ -690,7 +690,7 @@
       "type": "route-group",
       "domain": "safety",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "ed378b5b589fe40b6d922aaf61a8b93d67751158598edd8a06499a8803c106d9",
+      "contentHash": "21039f688686c29f43f57af4290f006f693176ea9d084a196925bbf59e290510",
       "since": "2025-01-01"
     },
     "route-group:operations": {
@@ -698,7 +698,7 @@
       "type": "route-group",
       "domain": "safety",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "ed378b5b589fe40b6d922aaf61a8b93d67751158598edd8a06499a8803c106d9",
+      "contentHash": "21039f688686c29f43f57af4290f006f693176ea9d084a196925bbf59e290510",
       "since": "2025-01-01"
     },
     "route-group:sentinel": {
@@ -706,7 +706,7 @@
       "type": "route-group",
       "domain": "safety",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "ed378b5b589fe40b6d922aaf61a8b93d67751158598edd8a06499a8803c106d9",
+      "contentHash": "21039f688686c29f43f57af4290f006f693176ea9d084a196925bbf59e290510",
       "since": "2025-01-01"
     },
     "route-group:trust": {
@@ -714,7 +714,7 @@
       "type": "route-group",
       "domain": "safety",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "ed378b5b589fe40b6d922aaf61a8b93d67751158598edd8a06499a8803c106d9",
+      "contentHash": "21039f688686c29f43f57af4290f006f693176ea9d084a196925bbf59e290510",
       "since": "2025-01-01"
     },
     "route-group:monitoring": {
@@ -722,7 +722,7 @@
       "type": "route-group",
       "domain": "monitoring",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "ed378b5b589fe40b6d922aaf61a8b93d67751158598edd8a06499a8803c106d9",
+      "contentHash": "21039f688686c29f43f57af4290f006f693176ea9d084a196925bbf59e290510",
       "since": "2025-01-01"
     },
     "route-group:commitments": {
@@ -730,7 +730,7 @@
       "type": "route-group",
       "domain": "commitments",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "ed378b5b589fe40b6d922aaf61a8b93d67751158598edd8a06499a8803c106d9",
+      "contentHash": "21039f688686c29f43f57af4290f006f693176ea9d084a196925bbf59e290510",
       "since": "2025-01-01"
     },
     "route-group:episodes": {
@@ -738,7 +738,7 @@
       "type": "route-group",
       "domain": "memory",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "ed378b5b589fe40b6d922aaf61a8b93d67751158598edd8a06499a8803c106d9",
+      "contentHash": "21039f688686c29f43f57af4290f006f693176ea9d084a196925bbf59e290510",
       "since": "2025-01-01"
     },
     "route-group:messages": {
@@ -746,7 +746,7 @@
       "type": "route-group",
       "domain": "coordination",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "ed378b5b589fe40b6d922aaf61a8b93d67751158598edd8a06499a8803c106d9",
+      "contentHash": "21039f688686c29f43f57af4290f006f693176ea9d084a196925bbf59e290510",
       "since": "2025-01-01"
     },
     "route-group:system-reviews": {
@@ -754,7 +754,7 @@
       "type": "route-group",
       "domain": "monitoring",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "ed378b5b589fe40b6d922aaf61a8b93d67751158598edd8a06499a8803c106d9",
+      "contentHash": "21039f688686c29f43f57af4290f006f693176ea9d084a196925bbf59e290510",
       "since": "2025-01-01"
     },
     "route-group:machine-mesh": {
@@ -770,7 +770,7 @@
       "type": "route-group",
       "domain": "security",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "ed378b5b589fe40b6d922aaf61a8b93d67751158598edd8a06499a8803c106d9",
+      "contentHash": "21039f688686c29f43f57af4290f006f693176ea9d084a196925bbf59e290510",
       "since": "2025-01-01"
     },
     "cli:init": {
@@ -1482,7 +1482,7 @@
       "type": "subsystem",
       "domain": "sessions",
       "sourcePath": "src/core/SessionManager.ts",
-      "contentHash": "06802937e8bf579327e7a979440010c7841c717157186f4df68fb3a196e5e604",
+      "contentHash": "3a9be3893df33d289184f4450f544da4e80178683fff537a20ed4c73a9d20a75",
       "since": "2025-01-01"
     },
     "subsystem:auto-updater": {
@@ -1506,7 +1506,7 @@
       "type": "subsystem",
       "domain": "updates",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
-      "contentHash": "797a5827842944d872077473dc0d87a1f99601f33d5f262e272748731d68250b",
+      "contentHash": "6cf82b68d5b625f674bfe7e5b43b85a3c51ee750038430f13f09d42d1a3fc14e",
       "since": "2025-01-01"
     },
     "subsystem:scheduler": {

--- a/tests/unit/PostUpdateMigrator-autonomousHookPath.test.ts
+++ b/tests/unit/PostUpdateMigrator-autonomousHookPath.test.ts
@@ -1,0 +1,213 @@
+/**
+ * Verifies the autonomous stop-hook REGISTRATION PATH fix.
+ *
+ * Regression (2026-06-03): an autonomous session went idle between turns —
+ * the stop hook never re-engaged the loop. Root cause: the autonomous
+ * SKILL.md Step 2a registered the stop hook in settings.json at
+ * `bash .instar/hooks/instar/autonomous-stop-hook.sh`, but the hook ships
+ * ONLY in the skill dir (`.claude/skills/autonomous/hooks/`) — it is never
+ * deployed to `.instar/hooks/instar/`. So every Stop event hit a missing
+ * file, failed silently, and the autonomous loop never re-injected the task
+ * list. The session looked alive but never self-continued.
+ *
+ * Fix (two prongs, both tested here):
+ *  1. ensureAutonomousStopHook() repairs any wrong-path registration in
+ *     settings.json → rewrites the command to the deployed skill path. This
+ *     is the Migration-Parity path that heals existing agents on update.
+ *     (Without it, the `hasAutonomousHook` presence check treats the
+ *     wrong-path entry as "already registered" and never corrects it.)
+ *  2. migrateAutonomousStopHookTopicKeyed() re-deploys the fixed SKILL.md
+ *     (whose Step 2a now registers the correct path + self-heals) to existing
+ *     agents, gated on a marker unique to the fixed prompt.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { PostUpdateMigrator } from '../../src/core/PostUpdateMigrator.js';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+
+type MigrationResult = { upgraded: string[]; skipped: string[]; errors: string[] };
+
+const CORRECT_CMD = 'bash ${CLAUDE_PROJECT_DIR}/.claude/skills/autonomous/hooks/autonomous-stop-hook.sh';
+const WRONG_CMD = 'bash .instar/hooks/instar/autonomous-stop-hook.sh';
+
+function newMigrator(projectDir: string): PostUpdateMigrator {
+  return new PostUpdateMigrator({
+    projectDir,
+    stateDir: path.join(projectDir, '.instar'),
+    port: 4042,
+    hasTelegram: false,
+    projectName: 'test',
+  });
+}
+
+type Hooks = Record<string, Array<{ matcher?: string; hooks?: Array<{ type?: string; command?: string; timeout?: number }> }>>;
+
+function ensure(migrator: PostUpdateMigrator, hooks: Hooks): { patched: boolean; result: MigrationResult } {
+  const result: MigrationResult = { upgraded: [], skipped: [], errors: [] };
+  const patched = (migrator as unknown as {
+    ensureAutonomousStopHook(h: Hooks, r: MigrationResult): boolean;
+  }).ensureAutonomousStopHook(hooks, result);
+  return { patched, result };
+}
+
+function autonomousCommands(hooks: Hooks): string[] {
+  return (hooks.Stop ?? [])
+    .flatMap(e => e.hooks ?? [])
+    .map(h => h.command ?? '')
+    .filter(c => c.includes('autonomous-stop-hook'));
+}
+
+describe('PostUpdateMigrator — ensureAutonomousStopHook registration path repair', () => {
+  let projectDir: string;
+
+  beforeEach(() => {
+    projectDir = fs.mkdtempSync(path.join(os.tmpdir(), 'instar-autohook-path-'));
+    fs.mkdirSync(path.join(projectDir, '.instar'), { recursive: true });
+    fs.mkdirSync(path.join(projectDir, '.claude'), { recursive: true });
+  });
+
+  afterEach(() => {
+    SafeFsExecutor.safeRmSync(projectDir, { recursive: true, force: true, operation: 'tests/unit/PostUpdateMigrator-autonomousHookPath.test.ts' });
+  });
+
+  it('rewrites a legacy wrong-path registration to the deployed skill path', () => {
+    const hooks: Hooks = {
+      Stop: [
+        { matcher: '', hooks: [{ type: 'command', command: WRONG_CMD, timeout: 10000 }] },
+      ],
+    };
+    const { patched, result } = ensure(newMigrator(projectDir), hooks);
+
+    const cmds = autonomousCommands(hooks);
+    expect(cmds).toEqual([CORRECT_CMD]); // exactly one, at the correct path
+    expect(cmds).not.toContain(WRONG_CMD);
+    expect(patched).toBe(true);
+    expect(result.upgraded.some(u => u.includes('repaired autonomous stop-hook path'))).toBe(true);
+  });
+
+  it('does NOT add a duplicate when a wrong-path entry is repaired (no double-registration)', () => {
+    const hooks: Hooks = {
+      Stop: [
+        { matcher: '', hooks: [{ type: 'command', command: 'node ${CLAUDE_PROJECT_DIR}/.instar/hooks/instar/stop-gate-router.js' }] },
+        { matcher: '', hooks: [{ type: 'command', command: WRONG_CMD, timeout: 10000 }] },
+      ],
+    };
+    ensure(newMigrator(projectDir), hooks);
+    // Exactly one autonomous-stop-hook command survives, at the correct path.
+    expect(autonomousCommands(hooks)).toEqual([CORRECT_CMD]);
+  });
+
+  it('leaves sibling Stop hooks untouched while repairing only the autonomous entry', () => {
+    const hooks: Hooks = {
+      Stop: [
+        { matcher: '', hooks: [{ type: 'command', command: 'node ${CLAUDE_PROJECT_DIR}/.instar/hooks/instar/stop-gate-router.js' }] },
+        { matcher: '', hooks: [{ type: 'command', command: 'bash .instar/hooks/instar/build-stop-hook.sh' }] },
+        { matcher: '', hooks: [{ type: 'command', command: WRONG_CMD, timeout: 10000 }] },
+      ],
+    };
+    ensure(newMigrator(projectDir), hooks);
+    const allCmds = (hooks.Stop ?? []).flatMap(e => e.hooks ?? []).map(h => h.command);
+    expect(allCmds).toContain('node ${CLAUDE_PROJECT_DIR}/.instar/hooks/instar/stop-gate-router.js');
+    expect(allCmds).toContain('bash .instar/hooks/instar/build-stop-hook.sh');
+    expect(allCmds).toContain(CORRECT_CMD);
+    expect(allCmds).not.toContain(WRONG_CMD);
+  });
+
+  it('is a no-op (no repair) when the registration is already the correct skill path', () => {
+    const hooks: Hooks = {
+      Stop: [
+        { matcher: '', hooks: [{ type: 'command', command: CORRECT_CMD, timeout: 10000 }] },
+      ],
+    };
+    const { result } = ensure(newMigrator(projectDir), hooks);
+    expect(autonomousCommands(hooks)).toEqual([CORRECT_CMD]);
+    expect(result.upgraded.some(u => u.includes('repaired autonomous stop-hook path'))).toBe(false);
+  });
+
+  it('registers the correct skill path when no autonomous entry exists yet', () => {
+    const hooks: Hooks = {
+      Stop: [
+        { matcher: '', hooks: [{ type: 'command', command: 'node ${CLAUDE_PROJECT_DIR}/.instar/hooks/instar/stop-gate-router.js' }] },
+      ],
+    };
+    ensure(newMigrator(projectDir), hooks);
+    expect(autonomousCommands(hooks)).toEqual([CORRECT_CMD]);
+  });
+
+  it('is idempotent: a second pass over repaired settings makes no further change', () => {
+    const hooks: Hooks = {
+      Stop: [
+        { matcher: '', hooks: [{ type: 'command', command: WRONG_CMD, timeout: 10000 }] },
+      ],
+    };
+    const migrator = newMigrator(projectDir);
+    ensure(migrator, hooks);
+    const after1 = JSON.stringify(hooks);
+    const { result: result2 } = ensure(migrator, hooks);
+    expect(JSON.stringify(hooks)).toBe(after1);
+    expect(result2.upgraded.some(u => u.includes('repaired autonomous stop-hook path'))).toBe(false);
+  });
+});
+
+describe('autonomous SKILL.md — Step 2a registers the deployed skill path', () => {
+  it('the bundled SKILL.md registers the skill-dir path, not .instar/hooks/instar', () => {
+    const skillMd = path.resolve(__dirname, '../../.claude/skills/autonomous/SKILL.md');
+    const content = fs.readFileSync(skillMd, 'utf8');
+    // The fixed Step 2a registers the deployed skill path and prints a marker.
+    expect(content).toContain('.claude/skills/autonomous/hooks/autonomous-stop-hook.sh');
+    expect(content).toContain('Stop hook registered (correct skill path)');
+    // The legacy wrong path must not be the registered command anymore.
+    expect(content).not.toContain("'command': 'bash .instar/hooks/instar/autonomous-stop-hook.sh'");
+  });
+});
+
+describe('PostUpdateMigrator — migrateAutonomousStopHookTopicKeyed re-deploys fixed SKILL.md', () => {
+  let projectDir: string;
+  let skillMd: string;
+
+  beforeEach(() => {
+    projectDir = fs.mkdtempSync(path.join(os.tmpdir(), 'instar-autohook-skillmd-'));
+    const skillDir = path.join(projectDir, '.claude', 'skills', 'autonomous');
+    fs.mkdirSync(skillDir, { recursive: true });
+    skillMd = path.join(skillDir, 'SKILL.md');
+  });
+
+  afterEach(() => {
+    SafeFsExecutor.safeRmSync(projectDir, { recursive: true, force: true, operation: 'tests/unit/PostUpdateMigrator-autonomousHookPath.test.ts:skillmd' });
+  });
+
+  function runTopicKeyed(migrator: PostUpdateMigrator): MigrationResult {
+    const result: MigrationResult = { upgraded: [], skipped: [], errors: [] };
+    (migrator as unknown as { migrateAutonomousStopHookTopicKeyed(r: MigrationResult): void }).migrateAutonomousStopHookTopicKeyed(result);
+    return result;
+  }
+
+  it('re-deploys the SKILL.md when the installed copy lacks the fixed-path marker but is stock', () => {
+    // Old deployed SKILL.md: has the stock fingerprint, prints the old plain message.
+    fs.writeFileSync(skillMd, [
+      '# Autonomous Mode',
+      'Completion promise: "ALL_TASKS_COMPLETE"',
+      "    print('Stop hook registered')",
+      "command': 'bash .instar/hooks/instar/autonomous-stop-hook.sh'",
+    ].join('\n'));
+
+    const result = runTopicKeyed(newMigrator(projectDir));
+
+    const after = fs.readFileSync(skillMd, 'utf8');
+    expect(after).toContain('Stop hook registered (correct skill path)');
+    expect(result.upgraded.some(u => u.includes('SKILL.md'))).toBe(true);
+  });
+
+  it('leaves a customized SKILL.md (missing the stock fingerprint) untouched', () => {
+    const customized = '# My heavily customized autonomous prompt\nno standard markers here\n';
+    fs.writeFileSync(skillMd, customized);
+
+    const result = runTopicKeyed(newMigrator(projectDir));
+
+    expect(fs.readFileSync(skillMd, 'utf8')).toBe(customized);
+    expect(result.skipped.some(s => s.includes('SKILL.md') && s.includes('customized'))).toBe(true);
+  });
+});

--- a/upgrades/next/autonomous-stop-hook-path-fix.md
+++ b/upgrades/next/autonomous-stop-hook-path-fix.md
@@ -1,0 +1,60 @@
+# Autonomous loop re-engagement fix (stop-hook registration path)
+
+## What Changed
+
+The autonomous-mode stop hook was being registered in `settings.json` at
+`.instar/hooks/instar/autonomous-stop-hook.sh` — a path where the hook is **never
+deployed**. The hook ships only in the skill directory
+(`.claude/skills/autonomous/hooks/autonomous-stop-hook.sh`). So on every `Stop`
+event the hook command hit a missing file, failed silently, and the autonomous
+loop never re-injected the task list. The session stayed alive but stopped
+self-continuing between turns — it only advanced when the user sent a message.
+
+Three coordinated fixes:
+
+1. **`.claude/skills/autonomous/SKILL.md` (Step 2a)** now registers the deployed
+   skill path and self-heals: it strips any prior (including wrong-path)
+   autonomous stop-hook entry and writes exactly one correct-path entry.
+2. **`PostUpdateMigrator.ensureAutonomousStopHook()`** gained a repair pass that
+   rewrites any existing wrong-path registration in `settings.json` to the skill
+   path. Without it, the "already registered?" presence check treated the
+   wrong-path entry as present and never corrected it — so existing agents would
+   stay broken forever.
+3. **`PostUpdateMigrator.migrateAutonomousStopHookTopicKeyed()`** re-deploys the
+   fixed `SKILL.md` to existing agents, gated on a marker unique to the corrected
+   prompt (stock prompts upgrade; customized prompts are left untouched).
+
+## What to Tell Your User
+
+If you ran an autonomous session and noticed it went quiet between turns —
+continuing only when you messaged it, rather than driving itself forward — this
+fixes the cause. The loop's re-engagement step was pointed at a file that was
+never installed, so it silently did nothing each time the session tried to
+continue. After this update the autonomous loop re-engages on its own as
+intended, and any agent that already had the broken registration is repaired
+automatically on update. No action is needed on your side.
+
+## Summary of New Capabilities
+
+- Autonomous sessions reliably self-continue between turns (the stop hook now
+  resolves to a file that actually exists).
+- Existing agents with the broken registration are healed in place on update —
+  both the `settings.json` entry and the deployed skill prompt.
+- The skill registration is now self-healing: activating autonomous mode always
+  ends with exactly one correct-path stop-hook entry, regardless of prior state.
+
+## Evidence
+
+- New unit suite `tests/unit/PostUpdateMigrator-autonomousHookPath.test.ts`
+  (9 tests): wrong-path → repaired; no duplicate added; siblings untouched;
+  already-correct → no-op; missing → registered; idempotent; SKILL.md content
+  asserts the corrected path + marker; topic-keyed migration re-deploys a stock
+  SKILL.md and skips a customized one.
+- Empirical check of the SKILL.md Step 2a snippet against a settings file
+  carrying the wrong-path entry plus sibling hooks: the wrong entry is rewritten
+  to `bash ${CLAUDE_PROJECT_DIR}/.claude/skills/autonomous/hooks/autonomous-stop-hook.sh`,
+  siblings are preserved, and a second run is a no-op (idempotent).
+- Existing autonomous/migration suites stay green
+  (`autonomous-skill-deployment`, `PostUpdateMigrator-buildStopHook`,
+  `autonomous-stop-hook-notify`, `installCodexHooks`, `emit-session-clock` —
+  50 tests). `tsc --noEmit` clean.

--- a/upgrades/side-effects/autonomous-stop-hook-path-fix.md
+++ b/upgrades/side-effects/autonomous-stop-hook-path-fix.md
@@ -1,0 +1,156 @@
+# Side-Effects Review — Autonomous loop re-engagement fix (stop-hook registration path)
+
+**Version / slug:** `autonomous-stop-hook-path-fix`
+**Date:** `2026-06-03`
+**Author:** `Echo`
+**Second-pass reviewer:** `Echo (self, single-pass — Tier-1 fix)`
+
+## Summary of the change
+
+The autonomous-mode stop hook is what re-injects the task list on every `Stop`
+event so an autonomous session keeps working between turns. It was registered in
+`settings.json` at `.instar/hooks/instar/autonomous-stop-hook.sh`, but the hook
+is only ever deployed to the skill dir (`.claude/skills/autonomous/hooks/`). The
+registered path therefore pointed at a non-existent file: every `Stop` failed
+silently and the loop never re-engaged. Files touched:
+`.claude/skills/autonomous/SKILL.md` (Step 2a registration snippet),
+`src/core/PostUpdateMigrator.ts` (`ensureAutonomousStopHook` repair pass +
+`migrateAutonomousStopHookTopicKeyed` SKILL.md re-deploy), and a new unit suite.
+The decision surface is purely *which file path is written into the Stop-hook
+registration* — there is no message block/allow logic.
+
+## Decision-point inventory
+
+- `SKILL.md Step 2a registration` — modify — registers the deployed skill path
+  (was the never-deployed `.instar/hooks/instar/` path) and self-heals stale entries.
+- `PostUpdateMigrator.ensureAutonomousStopHook` — modify — adds a repair pass that
+  rewrites wrong-path entries before the existing presence check.
+- `PostUpdateMigrator.migrateAutonomousStopHookTopicKeyed` — modify — adds SKILL.md
+  to the marker-gated re-deploy list so existing agents receive the fixed prompt.
+- No message-gating / block-allow decision point is touched.
+
+---
+
+## 1. Over-block
+
+No block/allow surface — over-block not applicable. The change only corrects a
+filesystem path string in a hook registration; it never rejects any input.
+
+---
+
+## 2. Under-block
+
+No block/allow surface — under-block not applicable. One adjacent correctness
+note: the repair targets specifically the `.instar/hooks/instar/autonomous-stop-hook.sh`
+wrong path. If a future custom registration used some *third* wrong path, the
+repair would not catch it — but that path was never shipped by instar, so there
+is nothing in the install base to miss. The registration helper still adds a
+correct entry if none exists at all.
+
+---
+
+## 3. Level-of-abstraction fit
+
+Correct layer. This is a deterministic settings/file-path migration — exactly the
+class `PostUpdateMigrator` owns (Migration Parity Standard). The SKILL.md snippet
+is the install/activation-time registrar; the migrator is the in-place repair for
+already-deployed agents. No reasoning/LLM layer is involved or appropriate: the
+correct path is a fixed, known string, so a structural fix is the right tool (and
+matches the sibling `build-stop-hook.sh` path-repair precedent).
+
+---
+
+## 4. Signal vs authority compliance
+
+**Required reference:** [docs/signal-vs-authority.md](../../docs/signal-vs-authority.md)
+
+- [x] No — this change has no block/allow surface.
+
+It rewrites a hook-registration path in `settings.json`; it holds no message or
+operation authority. The autonomous stop hook itself (unchanged here) remains the
+authority for whether a session continues, and it is session-id-gated.
+
+---
+
+## 5. Interactions
+
+- **Shadowing:** The repair pass runs *before* the existing `hasAutonomousHook`
+  presence check inside `ensureAutonomousStopHook`. This is intentional and is the
+  core of the fix: previously the presence check matched the wrong-path entry and
+  short-circuited the correct registration, so the wrong path was permanent. After
+  repair, the entry already holds the correct path, so the presence check finds it
+  and adds no duplicate (verified by the "no duplicate" test).
+- **Double-fire:** Two registrars exist — the SKILL.md Step 2a (activation-time,
+  dynamic add/remove) and `ensureAutonomousStopHook` (update-time, permanent). Both
+  now converge on the *same* command string, so they can no longer disagree or
+  produce two divergent entries. The SKILL.md snippet strips-then-appends, and the
+  migrator's presence check prevents duplicates; combined they always yield exactly
+  one correct entry (verified).
+- **Races:** No shared concurrent state. `settings.json` is edited by the same
+  single-writer migration path as every other hook registration.
+- **Feedback loops:** None. A one-time path correction; the corrected entry is a
+  fixed string, so subsequent passes are no-ops (idempotency verified).
+
+---
+
+## 6. External surfaces
+
+- **Other agents on the machine:** none — per-project `settings.json` only.
+- **Install base:** existing agents are healed on next update (the intended
+  surface). The `migrateAutonomousStopHookTopicKeyed` re-deploy is marker-gated and
+  fingerprint-guarded, so a customized `SKILL.md` (missing the stock
+  `ALL_TASKS_COMPLETE` fingerprint) is left untouched — verified by test.
+- **External systems (Telegram/Slack/GitHub/Cloudflare):** none.
+- **Persistent state:** `.claude/settings.json` and the deployed `SKILL.md`. The
+  edit is convergent (always lands on the one correct entry), so re-running is safe.
+- **Timing/runtime:** none — the migration is synchronous on the existing update path.
+
+---
+
+## 7. Rollback cost
+
+Pure code + template change. Back-out is `git revert` + ship the next patch. There
+is one consideration: this migration *writes a corrected entry* into existing
+agents' `settings.json`. A revert would stop applying the correction but would NOT
+re-break already-corrected agents (the correct path resolves to a real file, so a
+reverted build leaves them working). No data migration, no agent reset, no
+user-visible regression during the rollback window. Worst case of the fix itself
+being wrong: an agent ends up with a Stop-hook entry pointing at the skill path —
+which is exactly where the file lives — so the failure mode of the fix is "it
+works".
+
+---
+
+## Conclusion
+
+The review produced no design changes. The fix is a narrow, deterministic path
+correction with a self-healing registrar and an in-place repair migration that
+satisfies the Migration Parity Standard for both the `settings.json` entry and the
+deployed skill prompt. The only decision surface is a fixed path string, the
+repair is idempotent and convergent, and the customized-prompt guard is preserved.
+Clear to ship.
+
+---
+
+## Second-pass review (if required)
+
+**Reviewer:** Echo (self) — Tier-1 fix, single-pass per the tiered process.
+**Independent read of the artifact: concur**
+
+The change has no message-gating surface, the repair-before-presence-check
+ordering is the load-bearing correctness point and is tested, and the Migration
+Parity obligations (settings repair + marker-gated SKILL.md re-deploy + customized
+guard) are all covered. No concerns.
+
+---
+
+## Evidence pointers
+
+- `tests/unit/PostUpdateMigrator-autonomousHookPath.test.ts` — 9 tests (repair,
+  no-duplicate, sibling-preservation, no-op-when-correct, register-when-missing,
+  idempotency, SKILL.md content marker, topic-keyed re-deploy + customized-skip).
+- Empirical SKILL.md snippet run against a wrong-path settings fixture: wrong entry
+  rewritten to the skill path, siblings preserved, second run idempotent.
+- Regression: `autonomous-skill-deployment`, `PostUpdateMigrator-buildStopHook`,
+  `autonomous-stop-hook-notify`, `installCodexHooks`, `emit-session-clock` — 50
+  tests green. `tsc --noEmit` clean.


### PR DESCRIPTION
## The bug

The autonomous-mode stop hook re-injects the task list on every `Stop` event so an autonomous session keeps working between turns. It was registered in `settings.json` at `.instar/hooks/instar/autonomous-stop-hook.sh` — **a path where the hook is never deployed.** The hook ships only in the skill dir (`.claude/skills/autonomous/hooks/autonomous-stop-hook.sh`). So every `Stop` hit a missing file, failed silently, and the loop never re-engaged: the session stayed alive but stopped self-continuing, advancing only when the user messaged it.

Found live: an autonomous session went idle between turns for ~40 min. The two registrars disagreed — `installCodexHooks.ts` and `PostUpdateMigrator.ensureAutonomousStopHook()` use the correct skill path, but the autonomous SKILL.md Step 2a registered the never-deployed `.instar/hooks/instar/` path, and the migrator's "already registered?" presence check treated that wrong entry as present, so it could never be corrected.

## The fix (three coordinated parts)

1. **`SKILL.md` Step 2a** registers the deployed skill path and self-heals: strips any prior (incl. wrong-path) entry, writes exactly one correct entry.
2. **`ensureAutonomousStopHook()`** gains a repair pass that rewrites wrong-path entries in `settings.json` *before* the presence check — this is what heals existing agents.
3. **`migrateAutonomousStopHookTopicKeyed()`** re-deploys the fixed `SKILL.md` to existing agents, marker-gated; customized prompts (missing the stock fingerprint) are left untouched.

Migration Parity: both the `settings.json` entry and the deployed skill prompt are healed in place on update.

## Tests
- New `tests/unit/PostUpdateMigrator-autonomousHookPath.test.ts` (9): wrong-path→repaired, no-duplicate, siblings-preserved, no-op-when-correct, register-when-missing, idempotent, SKILL.md content marker, topic-keyed re-deploy + customized-skip.
- Empirical SKILL.md snippet run against a wrong-path fixture (rewrite + idempotency confirmed).
- Regression suites green (50): autonomous-skill-deployment, PostUpdateMigrator-buildStopHook, autonomous-stop-hook-notify, installCodexHooks, emit-session-clock. `tsc --noEmit` clean.

Ship-gate artifacts: `upgrades/next/autonomous-stop-hook-path-fix.md`, `upgrades/side-effects/autonomous-stop-hook-path-fix.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)