### PR TITLE
fix(stale-detection): detect wedged-but-alive codex jobs (CPU-stall, not process existence)

### DIFF
--- a/src/commands/server.ts
+++ b/src/commands/server.ts
@@ -9122,6 +9122,8 @@ export async function startServer(options: StartOptions): Promise<void> {
               transcriptTailHash: tailHash,
               mainProcessActive: sessionManager.hasActiveProcesses(session.tmuxSession),
               idleStateToken: hash(frame),
+              descendantCpuSeconds: sessionManager.descendantCpuSeconds(session.tmuxSession),
+              isJobSession: !!session.jobSlug,
             };
           },
           raiseAttention: makeAttentionPoster({ port: config.port, authToken: config.authToken ?? '' }),

--- a/src/core/SessionManager.ts
+++ b/src/core/SessionManager.ts
@@ -136,6 +136,33 @@ export function shouldErrorNudge(armedThisEpisode: boolean, totalNudges: number,
 }
 
 /**
+ * Parse a `ps -o time` accumulated-CPU-time string to seconds. Handles the
+ * formats ps emits across platforms: `MM:SS`, `MM:SS.ss`, `HH:MM:SS`, and the
+ * day-prefixed `DD-HH:MM:SS` (Linux/BSD). Returns 0 on anything unparseable —
+ * used as a CPU-progress delta signal, so a bad sample just reads as no growth.
+ * Exported for unit tests.
+ */
+export function parseProcTimeToSeconds(raw: string): number {
+  if (!raw) return 0;
+  let rest = raw.trim();
+  let days = 0;
+  // Optional leading "DD-" day count (only when it looks like `<digits>-`).
+  const dashMatch = /^(\d+)-(.+)$/.exec(rest);
+  if (dashMatch) {
+    days = parseInt(dashMatch[1], 10) || 0;
+    rest = dashMatch[2];
+  }
+  const parts = rest.split(':');
+  let seconds = 0;
+  for (const part of parts) {
+    const n = parseFloat(part);
+    if (Number.isNaN(n)) return 0;
+    seconds = seconds * 60 + n; // sexagesimal accumulate: [HH,MM,SS] → HH*3600+MM*60+SS
+  }
+  return days * 86400 + seconds;
+}
+
+/**
  * Process names that are always running in a Claude Code session (MCP servers, etc.)
  * These do NOT indicate activity — they're background infrastructure.
  */
@@ -1516,6 +1543,64 @@ rm()  { "${shimRunner}" rm  "$@"; }
     } catch {
       // If we can't check processes, assume active (fail-safe: don't kill)
       return true;
+    }
+  }
+
+  /**
+   * Accumulated CPU-seconds of a session's non-baseline descendant processes.
+   *
+   * Unlike `hasActiveProcesses` (which checks process EXISTENCE only), this reads
+   * each descendant's accumulated CPU time. Comparing two samples across a window
+   * reveals whether the process actually USED CPU in the interval — the signal
+   * StaleSessionBackstop needs to tell a wedged-but-ALIVE session (0% CPU, e.g. a
+   * hung `codex exec --json` job) from one genuinely working. A wedged codex job
+   * keeps a live process (so `hasActiveProcesses` reads true and the stale-session
+   * escalation never fires), but its CPU-seconds stay flat — which this exposes.
+   *
+   * Returns 0 on any failure; callers compare DELTAS, so a flat/zero reading just
+   * reads as "no CPU progress" (the backstop's other signals + the operator-ask
+   * escalation make that safe — it never auto-kills).
+   */
+  descendantCpuSeconds(tmuxSession: string): number {
+    try {
+      const panePid = execFileSync(
+        this.config.tmuxPath,
+        ['list-panes', '-t', `=${tmuxSession}:`, '-F', '#{pane_pid}'],
+        { encoding: 'utf-8', timeout: 5000 },
+      ).trim();
+      if (!panePid || !/^\d+$/.test(panePid)) return 0;
+
+      const psOutput = execFileSync(
+        'ps', ['-eo', 'pid,ppid,time,command'],
+        { encoding: 'utf-8', timeout: 5000 },
+      );
+      const procs = new Map<string, { ppid: string; time: string; command: string }>();
+      for (const line of psOutput.split('\n').slice(1)) {
+        const m = line.trim().match(/^(\d+)\s+(\d+)\s+(\S+)\s+(.*)$/);
+        if (m) procs.set(m[1], { ppid: m[2], time: m[3], command: m[4] });
+      }
+
+      // Same descendant tree-walk as hasActiveProcesses.
+      const descendants: Array<{ time: string; command: string }> = [];
+      const queue = [panePid];
+      while (queue.length > 0) {
+        const parent = queue.shift()!;
+        for (const [pid, info] of procs) {
+          if (info.ppid === parent && pid !== panePid) {
+            descendants.push({ time: info.time, command: info.command });
+            queue.push(pid);
+          }
+        }
+      }
+
+      let total = 0;
+      for (const p of descendants) {
+        if (BASELINE_PROCESS_PATTERNS.some(pattern => pattern.test(p.command))) continue;
+        total += parseProcTimeToSeconds(p.time);
+      }
+      return total;
+    } catch {
+      return 0;
     }
   }
 

--- a/src/data/builtin-manifest.json
+++ b/src/data/builtin-manifest.json
@@ -1,8 +1,8 @@
 {
   "$schema": "./builtin-manifest.schema.json",
   "schemaVersion": 1,
-  "generatedAt": "2026-06-03T05:48:40.799Z",
-  "instarVersion": "1.3.211",
+  "generatedAt": "2026-06-03T06:36:05.818Z",
+  "instarVersion": "1.3.212",
   "entryCount": 195,
   "entries": {
     "hook:session-start": {
@@ -1482,7 +1482,7 @@
       "type": "subsystem",
       "domain": "sessions",
       "sourcePath": "src/core/SessionManager.ts",
-      "contentHash": "3a9be3893df33d289184f4450f544da4e80178683fff537a20ed4c73a9d20a75",
+      "contentHash": "46706859e45b4bc503947a54338dbea94672e8bb1fd178afba517052d5ad4eb7",
       "since": "2025-01-01"
     },
     "subsystem:auto-updater": {

--- a/src/monitoring/StaleSessionBackstop.ts
+++ b/src/monitoring/StaleSessionBackstop.ts
@@ -46,6 +46,16 @@ export interface ProgressSnapshot {
   mainProcessActive: boolean | undefined;
   /** Opaque token for the positive-idle / prompt state — ANY change ⇒ progress. */
   idleStateToken: string;
+  /** Accumulated CPU-seconds of non-baseline descendant processes. Compared as a
+   *  DELTA across snapshots — real CPU used in the interval. For JOB sessions this
+   *  replaces the existence-based `mainProcessActive` progress test, so a
+   *  wedged-but-alive job (process up, 0% CPU) reads as no-progress. Default 0. */
+  descendantCpuSeconds: number;
+  /** True when this session was spawned by a job (`Session.jobSlug` set). A job
+   *  has no legitimate-idle state (it runs to completion), so it is held to the
+   *  stricter cpu-seconds-delta progress test; conversational sessions keep the
+   *  existence-based test (which correctly exempts idle-with-bg-process). */
+  isJobSession: boolean;
 }
 
 export interface LivenessBatch {
@@ -72,6 +82,11 @@ export interface StaleBackstopOptions {
   unverifiableEscalateMinutes: number;
   indeterminateEscalateCount: number;
   progressFloorBytes: number;
+  /** Minimum CPU-seconds a JOB session's descendants must accumulate between two
+   *  snapshots to count as forward progress. Below this, a job with a live but
+   *  idle (0% CPU) process is treated as making no progress. Small to catch a
+   *  genuinely-wedged job while ignoring sampling jitter. */
+  cpuFloorSeconds: number;
 }
 
 export const DEFAULT_STALE_BACKSTOP_OPTIONS: StaleBackstopOptions = {
@@ -80,6 +95,7 @@ export const DEFAULT_STALE_BACKSTOP_OPTIONS: StaleBackstopOptions = {
   unverifiableEscalateMinutes: 30,
   indeterminateEscalateCount: 15,
   progressFloorBytes: 512,
+  cpuFloorSeconds: 1,
 };
 
 interface Obs {
@@ -215,10 +231,20 @@ export class StaleSessionBackstop {
     ) {
       return true;
     }
-    // (ii) Main process doing CPU/IO work. `undefined` (uninspectable) is NOT progress
-    //      here — the escalation is a question to the operator, never a kill, so erring
-    //      toward "ask" on a truly-uninspectable session is safe.
-    if (cur.mainProcessActive === true) return true;
+    // (ii) Real work by the main process.
+    //      For JOB sessions (which have no legitimate-idle state — a job runs to
+    //      completion) require actual CPU USED in the interval: the cpu-seconds
+    //      delta past a small floor. A wedged-but-alive job (process up, 0% CPU)
+    //      reads as no-progress here, where the old existence-based check
+    //      false-positived it as "active" (the 12h-undetected codex-job wedge).
+    //      Conversational sessions keep the existence-based check, which correctly
+    //      exempts a legitimately-idle session that happens to have a background
+    //      process. `undefined` (uninspectable) is never progress.
+    if (cur.isJobSession) {
+      if (cur.descendantCpuSeconds - prev.descendantCpuSeconds > this.opts.cpuFloorSeconds) return true;
+    } else if (cur.mainProcessActive === true) {
+      return true;
+    }
     // (iii) Positive-idle / prompt state changed.
     if (cur.idleStateToken !== prev.idleStateToken) return true;
     return false;

--- a/tests/unit/parseProcTimeToSeconds.test.ts
+++ b/tests/unit/parseProcTimeToSeconds.test.ts
@@ -1,0 +1,46 @@
+/**
+ * Unit tests for parseProcTimeToSeconds — parses `ps -o time` accumulated-CPU
+ * strings to seconds. This is the pure core of the codex-wedged-job CPU-stall
+ * detector: comparing two CPU-seconds samples reveals whether a process actually
+ * used CPU in the interval (a wedged-but-alive codex job stays flat).
+ */
+
+import { describe, it, expect } from 'vitest';
+import { parseProcTimeToSeconds } from '../../src/core/SessionManager.js';
+
+describe('parseProcTimeToSeconds', () => {
+  it('parses MM:SS', () => {
+    expect(parseProcTimeToSeconds('12:34')).toBe(12 * 60 + 34); // 754
+    expect(parseProcTimeToSeconds('0:05')).toBe(5);
+  });
+
+  it('parses MM:SS.ss (fractional seconds)', () => {
+    expect(parseProcTimeToSeconds('0:05.23')).toBeCloseTo(5.23, 2);
+    expect(parseProcTimeToSeconds('1:30.50')).toBeCloseTo(90.5, 2);
+  });
+
+  it('parses HH:MM:SS', () => {
+    expect(parseProcTimeToSeconds('1:02:03')).toBe(1 * 3600 + 2 * 60 + 3); // 3723
+    expect(parseProcTimeToSeconds('10:00:00')).toBe(36000);
+  });
+
+  it('parses the day-prefixed DD-HH:MM:SS', () => {
+    expect(parseProcTimeToSeconds('2-03:00:00')).toBe(2 * 86400 + 3 * 3600); // 183600
+    expect(parseProcTimeToSeconds('1-00:00:01')).toBe(86400 + 1);
+  });
+
+  it('returns 0 for empty / unparseable input', () => {
+    expect(parseProcTimeToSeconds('')).toBe(0);
+    expect(parseProcTimeToSeconds('   ')).toBe(0);
+    expect(parseProcTimeToSeconds('-')).toBe(0);
+    expect(parseProcTimeToSeconds('not-a-time')).toBe(0);
+  });
+
+  it('is monotonic — more wall time → more seconds (the delta-progress invariant)', () => {
+    // A wedged process stays flat across samples; a working one grows. The
+    // detector keys on cur - prev > floor, so ordering must hold.
+    expect(parseProcTimeToSeconds('5:00')).toBeGreaterThan(parseProcTimeToSeconds('4:59'));
+    expect(parseProcTimeToSeconds('1:00:00')).toBeGreaterThan(parseProcTimeToSeconds('59:59'));
+    expect(parseProcTimeToSeconds('1-00:00:00')).toBeGreaterThan(parseProcTimeToSeconds('23:59:59'));
+  });
+});

--- a/tests/unit/stale-session-backstop.test.ts
+++ b/tests/unit/stale-session-backstop.test.ts
@@ -27,12 +27,13 @@ function harness(opts?: { snapshots?: Map<string, ProgressSnapshot> }) {
       snapshot: (s) => snaps.get(s.id) ?? {
         transcriptResolved: false, transcriptSize: 0, transcriptTailHash: null,
         mainProcessActive: false, idleStateToken: 'x',
+        descendantCpuSeconds: 0, isJobSession: false,
       },
       raiseAttention: async (item) => { raised.push({ id: item.id, title: item.title }); return true; },
       setLongIndeterminate: (id, isLong) => longFlags.set(id, isLong),
       now: () => clock,
     },
-    { enabled: true, tickIntervalSec: 120, unverifiableEscalateMinutes: M, indeterminateEscalateCount: N, progressFloorBytes: 512 },
+    { enabled: true, tickIntervalSec: 120, unverifiableEscalateMinutes: M, indeterminateEscalateCount: N, progressFloorBytes: 512, cpuFloorSeconds: 1 },
   );
 
   return {
@@ -48,6 +49,15 @@ function harness(opts?: { snapshots?: Map<string, ProgressSnapshot> }) {
 const idleSnap = (token = 'frame-static'): ProgressSnapshot => ({
   transcriptResolved: true, transcriptSize: 1000, transcriptTailHash: 'tail-A',
   mainProcessActive: false, idleStateToken: token,
+  descendantCpuSeconds: 0, isJobSession: false,
+});
+
+/** A JOB session's snapshot — transcript static, idle token static (no output),
+ *  with a configurable accumulated cpu-seconds. A wedged job keeps cpu flat. */
+const jobSnap = (cpuSeconds: number, mainProcessActive = true): ProgressSnapshot => ({
+  transcriptResolved: false, transcriptSize: 0, transcriptTailHash: null,
+  mainProcessActive, idleStateToken: 'job-frame-static',
+  descendantCpuSeconds: cpuSeconds, isJobSession: true,
 });
 
 describe('StaleSessionBackstop (§P5)', () => {
@@ -168,5 +178,48 @@ describe('StaleSessionBackstop (§P5)', () => {
     });
     expect(deps).not.toContain('terminate');
     expect(deps).not.toContain('kill');
+  });
+
+  // ── Job-session CPU-stall detection (codex wedged-job) ──────────────────────
+
+  it('JOB session: a live process with FLAT cpu-seconds is no-progress → escalates (the wedged-codex-job fix)', async () => {
+    const h = harness();
+    h.addSession('s1'); h.allAlive();
+    // Wedged job: process ALIVE (mainProcessActive true) but cpu-seconds never grow.
+    h.setSnap('s1', jobSnap(42, /* mainProcessActive */ true));
+    await h.backstop.tick();             // baseline
+    expect(h.raised).toHaveLength(0);
+    h.advanceMin(M + 1);
+    h.setSnap('s1', jobSnap(42, true));  // SAME cpu-seconds → no CPU used → stale
+    await h.backstop.tick();
+    expect(h.raised).toHaveLength(1);    // existence alone no longer counts for a job
+  });
+
+  it('JOB session: growing cpu-seconds is forward progress → no escalation', async () => {
+    const h = harness();
+    h.addSession('s1'); h.allAlive();
+    h.setSnap('s1', jobSnap(42, true));
+    await h.backstop.tick();
+    h.advanceMin(M + 1);
+    h.setSnap('s1', jobSnap(99, true));  // +57 cpu-seconds > floor → real work
+    await h.backstop.tick();
+    expect(h.raised).toHaveLength(0);
+  });
+
+  it('CONVERSATIONAL session: a live process (existence) still counts as progress — no regression', async () => {
+    const h = harness();
+    h.addSession('s1'); h.allAlive();
+    // Conversational (isJobSession=false) idle-with-bg: mainProcessActive true, cpu flat.
+    const convoBg = (): ProgressSnapshot => ({
+      transcriptResolved: false, transcriptSize: 0, transcriptTailHash: null,
+      mainProcessActive: true, idleStateToken: 'static',
+      descendantCpuSeconds: 7, isJobSession: false,
+    });
+    h.setSnap('s1', convoBg());
+    await h.backstop.tick();
+    h.advanceMin(M + 1);
+    h.setSnap('s1', convoBg());           // flat cpu, but existence-based check still applies
+    await h.backstop.tick();
+    expect(h.raised).toHaveLength(0);     // conversational unchanged — no false-positive
   });
 });

--- a/upgrades/next/codex-wedged-job-cpu-detection.md
+++ b/upgrades/next/codex-wedged-job-cpu-detection.md
@@ -1,0 +1,47 @@
+# Codex wedged-job detection (CPU-stall, not process existence)
+
+## What Changed
+
+A scheduled codex job (`codex exec --json`) can wedge: the process stays alive but
+makes no progress — 0% CPU, no output. One such job sat wedged ~12h undetected. The
+StaleSessionBackstop (which raises a "stale but unkillable" attention item, never
+kills) missed it because its forward-progress check used process **existence**:
+`hasActiveProcesses` walks descendant processes and returns true if any non-baseline
+child is alive — which a wedged-but-alive job is. So the backstop read it as
+"active" and never escalated. (Conversational claude sessions are saved by transcript
+growth, so only jobs — whose codex transcript doesn't resolve — were exposed.)
+
+The fix gives the backstop a real CPU signal: `SessionManager.descendantCpuSeconds`
+reads each non-baseline descendant's accumulated CPU time, and the backstop compares
+the delta across its two snapshots — real CPU *used* in the interval, not mere
+existence. This is scoped to **job sessions** (which have no legitimate-idle state):
+a job that uses no CPU between snapshots reads as no-progress and escalates.
+Conversational sessions keep the existing existence-based check, so a legitimately-idle
+session with a background process is *not* falsely flagged.
+
+## What to Tell Your User
+
+If one of my scheduled background jobs ever freezes — alive but doing nothing — I'll
+now actually notice it and flag it for attention, instead of mistaking "the process
+is still running" for "it's making progress." Before, a job could sit stuck for hours
+unseen; now a job that stops using any CPU gets surfaced. This only adds an
+attention notice — it never kills anything — and it doesn't change how I treat your
+normal interactive sessions.
+
+## Summary of New Capabilities
+
+- The stale-session backstop now detects a wedged-but-alive **job** (0% CPU, no
+  output) and raises its existing attention notice, where it previously read process
+  existence as "progress" and stayed silent.
+- New `SessionManager.descendantCpuSeconds` (accumulated CPU-seconds of a session's
+  real children) + `parseProcTimeToSeconds` — a CPU-delta progress signal.
+- Scoped to job sessions only; conversational sessions are unchanged (no new
+  false-positives on idle-with-a-background-process). Never kills — attention-only.
+
+## Evidence
+
+- 19 tests: `stale-session-backstop` (13 — incl. wedged-job→escalate, busy-job→no,
+  conversational-idle-with-bg→no-regression) + `parseProcTimeToSeconds` (6, covering
+  `MM:SS` / `MM:SS.ss` / `HH:MM:SS` / `DD-HH:MM:SS`). `tsc --noEmit` + `pnpm build` clean.
+- The escalation path is unchanged (still attention-only, never a kill); only the
+  forward-progress test gains a CPU-delta requirement for job sessions.

--- a/upgrades/side-effects/codex-wedged-job-cpu-detection.md
+++ b/upgrades/side-effects/codex-wedged-job-cpu-detection.md
@@ -1,0 +1,118 @@
+# Side-Effects Review — Codex wedged-job CPU-stall detection
+
+**Version / slug:** `codex-wedged-job-cpu-detection`
+**Date:** `2026-06-03`
+**Author:** `Echo`
+**Second-pass reviewer:** `Echo (self) — Tier-1; the regression analysis below is the load-bearing part`
+
+## Summary of the change
+
+StaleSessionBackstop's `hasForwardProgress` gains a CPU-delta progress signal for
+**job sessions**, replacing the existence-based `mainProcessActive` check for them.
+A wedged-but-alive codex job (0% CPU) now reads as no-progress and triggers the
+existing attention escalation (never a kill). Files: `SessionManager.ts`
+(`descendantCpuSeconds` + `parseProcTimeToSeconds`), `StaleSessionBackstop.ts`
+(ProgressSnapshot fields `descendantCpuSeconds`/`isJobSession`, the job-scoped
+`hasForwardProgress` branch, `cpuFloorSeconds` option), `server.ts` (snapshot
+populates the two fields). The only decision point: *is this session making forward
+progress* — and the change narrows what counts as progress for jobs.
+
+## Decision-point inventory
+
+- `StaleSessionBackstop.hasForwardProgress` (ii) — modify — for job sessions, require
+  cpu-seconds delta > floor instead of process existence.
+- No message block/allow surface. No kill/terminate surface (the backstop has none —
+  asserted by an existing structural test).
+
+## 1. Over-block
+
+No block/allow surface. The analogue ("does it raise a false attention notice?") is
+THE risk and is handled by scoping: the stricter cpu-delta test applies ONLY to job
+sessions (`!!session.jobSlug`). A conversational session that's legitimately idle
+with a background process keeps the existence-based check → not flagged. Verified by
+the `conversational-idle-with-bg → no` test.
+
+## 2. Under-block
+
+A job that uses *some* CPU between two 120s snapshots (above `cpuFloorSeconds=1`) is
+treated as progressing — so a job that's busy-looping (high CPU, no real output)
+would not be flagged by this signal. That's acceptable: this targets the 0%-CPU
+freeze; a CPU-burning runaway is a different detector's concern (and would show on
+load). I/O-bound jobs at 0% CPU with no output would be flagged — but a job has no
+legitimate long idle-wait state (it runs to completion), so flagging it for attention
+(not killing) is correct.
+
+## 3. Level-of-abstraction fit
+
+Correct layer. This is a cheap, deterministic process-metric read feeding an existing
+attention-raising backstop. It reuses `hasActiveProcesses`'s exact descendant
+tree-walk + baseline filter, adding only the CPU-time accumulation. No LLM needed —
+the signal is objective (CPU seconds), and the escalation it feeds is attention-only.
+
+## 4. Signal vs authority compliance
+
+**Required reference:** [docs/signal-vs-authority.md](../../docs/signal-vs-authority.md)
+
+- [x] No — this change has no message block/allow surface.
+
+It refines a SIGNAL (forward-progress) consumed by an existing smart-ish gate
+(the backstop's episode state machine), which only ever raises an attention item and
+never kills. No new authority.
+
+## 5. Interactions
+
+- **Shadowing:** The change is inside `hasForwardProgress`, one branch (ii). Branches
+  (i) transcript-growth and (iii) idle-token-change are unchanged and still short-
+  circuit to "progress" first, so a job that IS producing output/transcript is still
+  exempt before the CPU test is consulted.
+- **Double-fire:** None — same single escalation path, same per-episode dedup
+  (`episodeActive`), so a persistently-wedged job still raises exactly one item.
+- **Races:** `descendantCpuSeconds` is a synchronous `ps` read per snapshot, same
+  cadence/shape as the existing `hasActiveProcesses` call; no shared mutable state.
+- **Feedback loops:** None — the output is an attention notice, which does not feed
+  back into the session.
+
+## 6. External surfaces
+
+- **Persistent state:** none new. ProgressSnapshot lives in memory per tick.
+- **External systems:** none (the attention item uses the existing poster).
+- **Other agents/users:** none — per-agent backstop.
+- **`ps` cost:** one extra `ps -eo pid,ppid,time,command` per session per 120s tick —
+  negligible, same class as the existing `hasActiveProcesses` `ps`.
+- **Cross-platform:** `parseProcTimeToSeconds` handles the `ps -o time` formats
+  (`MM:SS`, `MM:SS.ss`, `HH:MM:SS`, `DD-HH:MM:SS`); a bad parse reads as 0 (no growth),
+  which is safe (the delta just shows no progress; attention, never kill).
+
+## 7. Rollback cost
+
+Pure code change; no persistent state, no migration. Back-out is `git revert` + ship
+the next patch — the backstop reverts to existence-based progress (the prior, looser
+behavior). No user-visible regression during rollback (it only changes whether a
+*job* gets a stale-attention notice). Worst case if the floor is mis-tuned: a busy
+job flagged spuriously (attention only) or a wedged job missed — both are
+attention-level, never destructive.
+
+## Conclusion
+
+The review's central risk — falsely flagging legitimately-idle sessions — is closed
+by scoping the cpu-delta requirement to job sessions (no legitimate-idle state) and
+leaving conversational sessions on the existing existence check. That scoping is the
+load-bearing design decision and is directly tested. The escalation remains
+attention-only (never a kill), and the change reuses the existing process-walk. Clear
+to ship.
+
+## Second-pass review (if required)
+
+**Reviewer:** Echo (self) — Tier-1.
+**Independent read of the artifact: concur**
+
+The job-scoping is the right way to avoid the idle-with-bg false-positive; the three
+behavior tests pin both the fix and the no-regression case; rollback is a revert.
+No concerns.
+
+## Evidence pointers
+
+- `tests/unit/stale-session-backstop.test.ts` (13: incl. the 3 new behavior cases),
+  `tests/unit/parseProcTimeToSeconds.test.ts` (6). `tsc` + `pnpm build` clean.
+- Root-cause + design trail: `.instar/autonomous/13435.local.md` item 2 (the iterative
+  diagnosis that caught the idle-with-bg / extended-think regression traps).


### PR DESCRIPTION
## The bug

A scheduled codex job (`codex exec --json`) can wedge: process alive, **0% CPU, no output**. One sat wedged ~12h undetected. `StaleSessionBackstop` (raises a "stale but unkillable" attention item — never kills) missed it because its forward-progress check `(ii)` used process **existence** (`hasActiveProcesses` walks descendants, returns true if any non-baseline child is alive). A wedged-but-alive job IS alive → read as "active" → never escalated. Conversational claude sessions are saved by transcript-growth `(i)`; only jobs (whose codex transcript doesn't resolve) fell through to the existence check.

## The fix — CPU used, not process existence (scoped to jobs)

- `SessionManager.descendantCpuSeconds` reads accumulated CPU-seconds of a session's non-baseline children; the backstop compares the **delta** across its two snapshots — real CPU *used* in the interval.
- `ProgressSnapshot` gains `descendantCpuSeconds` + `isJobSession` (`!!session.jobSlug`); `hasForwardProgress` requires cpu-delta > `cpuFloorSeconds` for **job** sessions instead of mere existence.
- **Scoped to job sessions** (which have no legitimate-idle state). Conversational sessions keep the existence-based check — so a legitimately-idle session with a background process is **not** falsely flagged. That scoping is the load-bearing design decision (it's why the naive "swap existence for CPU everywhere" would have regressed).

Attention-only — never kills (the backstop has no kill surface; asserted by an existing structural test).

## Tests — 19
- `stale-session-backstop` (13): incl. **wedged-job → escalate**, **busy-job → no**, **conversational-idle-with-bg → no-regression**.
- `parseProcTimeToSeconds` (6): `MM:SS` / `MM:SS.ss` / `HH:MM:SS` / `DD-HH:MM:SS`.
- `tsc --noEmit` + `pnpm build` clean.

Built in committed increments (1: cpu-seconds method + parser · 2: snapshot fields + wiring + job-scoped progress + tests). Spec, side-effects review, and upgrade fragment included.

The diagnosis caught two regression traps (extended-think claude; idle-with-bg conversational) before they shipped — the design trail is in the side-effects review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)