### PR TITLE
feat(apprenticeship): persist differential cycles

### DIFF
--- a/.instar/instar-dev-decisions.jsonl
+++ b/.instar/instar-dev-decisions.jsonl
@@ -8,3 +8,5 @@
 {"ts":"2026-06-03T07:50:50.939Z","slug":"unknown","suggestedTier":1,"declaredTier":2,"riskFloor":1,"riskFloorReasons":[],"belowFloor":false,"files":3,"loc":22}
 {"ts":"2026-06-03T07:52:12.301Z","slug":"unknown","suggestedTier":1,"declaredTier":2,"riskFloor":1,"riskFloorReasons":[],"belowFloor":false,"files":3,"loc":22}
 {"ts":"2026-06-03T08:25:02.208Z","slug":"unknown","suggestedTier":2,"declaredTier":2,"riskFloor":1,"riskFloorReasons":[],"belowFloor":false,"files":3,"loc":61}
+{"ts":"2026-06-03T08:59:43.846Z","slug":"unknown","suggestedTier":2,"declaredTier":1,"riskFloor":2,"riskFloorReasons":["new capability: new route (router.<verb>() added","new capability: new exported class / subsystem added","new capability: new config key added"],"belowFloor":true,"files":4,"loc":422}
+{"ts":"2026-06-03T09:02:10.763Z","slug":"unknown","suggestedTier":2,"declaredTier":1,"riskFloor":2,"riskFloorReasons":["new capability: new route (router.<verb>() added","new capability: new exported class / subsystem added","new capability: new config key added"],"belowFloor":true,"files":4,"loc":422}

--- a/.instar/instar-dev-traces/2026-06-03T09-00-00Z-apprenticeship-cycle-store.json
+++ b/.instar/instar-dev-traces/2026-06-03T09-00-00Z-apprenticeship-cycle-store.json
@@ -1,0 +1,30 @@
+{
+  "version": 2,
+  "sessionId": "telegram-1052-apprenticeship-cycle-store",
+  "timestamp": "2026-06-03T09:00:00.000Z",
+  "phase": "complete",
+  "tier": 1,
+  "declaredTier": 1,
+  "tierReasoning": "The change adds a small additive SQLite store and authenticated routes for apprenticeship cycle capture without modifying existing lifecycle semantics.",
+  "artifactPath": "upgrades/side-effects/apprenticeship-cycle-store.md",
+  "artifactSha256": "4f75d2f2404328f4a8f1b1191e9d5320ad0546f72716d4e973941e97f2121625",
+  "eli16Path": "upgrades/apprenticeship-cycle-store.eli16.md",
+  "eli16Sha256": "7ef0218911d9e4c0523c30dac842028ba8eca08e75c5a6ba0ed47a3f88c2cc76",
+  "sideEffectsPath": "upgrades/side-effects/apprenticeship-cycle-store.md",
+  "upgradeGuidePath": "upgrades/next/apprenticeship-cycle-store.md",
+  "upgradeGuideSha256": "0b8666cb63297794944bab01a78cddbab460c0e9db93462926c1a9236cd29493",
+  "coveredFiles": [
+    "src/monitoring/ApprenticeshipCycleStore.ts",
+    "src/server/AgentServer.ts",
+    "src/server/routes.ts",
+    "tests/unit/apprenticeship-cycle-store.test.ts",
+    "tests/unit/SqliteRegistry-wiring.test.ts",
+    "tests/integration/apprenticeship-routes.test.ts",
+    "tests/e2e/apprenticeship-lifecycle.test.ts",
+    "site/src/content/docs/features/apprenticeship-program.md",
+    "upgrades/next/apprenticeship-cycle-store.md",
+    "upgrades/side-effects/apprenticeship-cycle-store.md",
+    "upgrades/apprenticeship-cycle-store.eli16.md"
+  ],
+  "summary": "Apprenticeship differential cycles now persist to a registered SQLite store and are available through bearer-authenticated record/list/get/close routes with unit, integration, and e2e liveness coverage."
+}

--- a/site/src/content/docs/features/apprenticeship-program.md
+++ b/site/src/content/docs/features/apprenticeship-program.md
@@ -43,6 +43,8 @@ verdict is appended to `logs/apprenticeship-decisions.jsonl`.
 
 All routes require a Bearer token.
 
+### Instance lifecycle
+
 - `GET /apprenticeship/instances` — list every tracked instance.
 - `GET /apprenticeship/instances/:id` — fetch one instance.
 - `POST /apprenticeship/instances` — create an instance (the id and role names are charset-clamped;
@@ -53,6 +55,29 @@ All routes require a Bearer token.
 - `POST /apprenticeship/instances/:id/can-start` — a read-only preview of the retro-gate verdict.
 - `POST /apprenticeship/instances/:id/can-complete` — a read-only preview of the doc-gate verdict
   (returns the list of missing artifacts).
+
+### Differential cycles
+
+`ApprenticeshipCycleStore` persists the mentor/overseer learning loop in SQLite so each
+apprenticeship cycle has durable, queryable evidence instead of living only in chat transcripts.
+The server opens `server-data/apprenticeship-cycles.db`, registers the handle with the
+`SqliteRegistry`, and exposes the store through authenticated routes.
+
+Each cycle records `id`, `instanceId`, `cycleNumber`, `createdAt`, `task`, `menteeOutput`,
+`mentorFlagged`, `overseerDifferential`, `coaching`, `infraItems`, `kind`, and `status`.
+Array fields are stored as JSON and returned as arrays.
+
+- `POST /apprenticeship/cycles` — record one cycle. Required fields are `instanceId`,
+  `cycleNumber`, `task`, and `menteeOutput`; array fields are optional arrays of strings.
+- `GET /apprenticeship/cycles?instanceId=&limit=` — list recent cycles, optionally scoped to one
+  instance and bounded by `limit`.
+- `GET /apprenticeship/cycles/:id` — fetch one recorded cycle, returning 404 when the id is
+  unknown.
+- `POST /apprenticeship/cycles/:id/close` — mark an open cycle as closed and return the updated
+  record.
+
+If the SQLite store is unavailable, the cycle routes return 503 instead of pretending the feature
+is alive.
 
 ```bash
 # Preview whether an instance may start (the retro-gate)

--- a/src/data/builtin-manifest.json
+++ b/src/data/builtin-manifest.json
@@ -1,8 +1,8 @@
 {
   "$schema": "./builtin-manifest.schema.json",
   "schemaVersion": 1,
-  "generatedAt": "2026-06-03T08:24:07.282Z",
-  "instarVersion": "1.3.214",
+  "generatedAt": "2026-06-03T08:59:02.872Z",
+  "instarVersion": "1.3.215",
   "entryCount": 195,
   "entries": {
     "hook:session-start": {
@@ -418,7 +418,7 @@
       "type": "route-group",
       "domain": "monitoring",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "713c892607c4db840eb89f3bbba1ec287a169da23ca1688fa657362b77b77e78",
+      "contentHash": "bd2065782b05f1eb6317fd27b95974384974f9534052ec527ccded39153e4a88",
       "since": "2025-01-01"
     },
     "route-group:agents": {
@@ -426,7 +426,7 @@
       "type": "route-group",
       "domain": "sessions",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "713c892607c4db840eb89f3bbba1ec287a169da23ca1688fa657362b77b77e78",
+      "contentHash": "bd2065782b05f1eb6317fd27b95974384974f9534052ec527ccded39153e4a88",
       "since": "2025-01-01"
     },
     "route-group:backups": {
@@ -434,7 +434,7 @@
       "type": "route-group",
       "domain": "operations",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "713c892607c4db840eb89f3bbba1ec287a169da23ca1688fa657362b77b77e78",
+      "contentHash": "bd2065782b05f1eb6317fd27b95974384974f9534052ec527ccded39153e4a88",
       "since": "2025-01-01"
     },
     "route-group:git": {
@@ -442,7 +442,7 @@
       "type": "route-group",
       "domain": "coordination",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "713c892607c4db840eb89f3bbba1ec287a169da23ca1688fa657362b77b77e78",
+      "contentHash": "bd2065782b05f1eb6317fd27b95974384974f9534052ec527ccded39153e4a88",
       "since": "2025-01-01"
     },
     "route-group:memory": {
@@ -450,7 +450,7 @@
       "type": "route-group",
       "domain": "memory",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "713c892607c4db840eb89f3bbba1ec287a169da23ca1688fa657362b77b77e78",
+      "contentHash": "bd2065782b05f1eb6317fd27b95974384974f9534052ec527ccded39153e4a88",
       "since": "2025-01-01"
     },
     "route-group:semantic": {
@@ -458,7 +458,7 @@
       "type": "route-group",
       "domain": "memory",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "713c892607c4db840eb89f3bbba1ec287a169da23ca1688fa657362b77b77e78",
+      "contentHash": "bd2065782b05f1eb6317fd27b95974384974f9534052ec527ccded39153e4a88",
       "since": "2025-01-01"
     },
     "route-group:status": {
@@ -466,7 +466,7 @@
       "type": "route-group",
       "domain": "monitoring",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "713c892607c4db840eb89f3bbba1ec287a169da23ca1688fa657362b77b77e78",
+      "contentHash": "bd2065782b05f1eb6317fd27b95974384974f9534052ec527ccded39153e4a88",
       "since": "2025-01-01"
     },
     "route-group:capabilities": {
@@ -474,7 +474,7 @@
       "type": "route-group",
       "domain": "mapping",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "713c892607c4db840eb89f3bbba1ec287a169da23ca1688fa657362b77b77e78",
+      "contentHash": "bd2065782b05f1eb6317fd27b95974384974f9534052ec527ccded39153e4a88",
       "since": "2025-01-01"
     },
     "route-group:project-map": {
@@ -482,7 +482,7 @@
       "type": "route-group",
       "domain": "mapping",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "713c892607c4db840eb89f3bbba1ec287a169da23ca1688fa657362b77b77e78",
+      "contentHash": "bd2065782b05f1eb6317fd27b95974384974f9534052ec527ccded39153e4a88",
       "since": "2025-01-01"
     },
     "route-group:coherence": {
@@ -490,7 +490,7 @@
       "type": "route-group",
       "domain": "coherence",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "713c892607c4db840eb89f3bbba1ec287a169da23ca1688fa657362b77b77e78",
+      "contentHash": "bd2065782b05f1eb6317fd27b95974384974f9534052ec527ccded39153e4a88",
       "since": "2025-01-01"
     },
     "route-group:topic-bindings": {
@@ -498,7 +498,7 @@
       "type": "route-group",
       "domain": "sessions",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "713c892607c4db840eb89f3bbba1ec287a169da23ca1688fa657362b77b77e78",
+      "contentHash": "bd2065782b05f1eb6317fd27b95974384974f9534052ec527ccded39153e4a88",
       "since": "2025-01-01"
     },
     "route-group:context": {
@@ -506,7 +506,7 @@
       "type": "route-group",
       "domain": "context",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "713c892607c4db840eb89f3bbba1ec287a169da23ca1688fa657362b77b77e78",
+      "contentHash": "bd2065782b05f1eb6317fd27b95974384974f9534052ec527ccded39153e4a88",
       "since": "2025-01-01"
     },
     "route-group:scope-coherence": {
@@ -514,7 +514,7 @@
       "type": "route-group",
       "domain": "coherence",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "713c892607c4db840eb89f3bbba1ec287a169da23ca1688fa657362b77b77e78",
+      "contentHash": "bd2065782b05f1eb6317fd27b95974384974f9534052ec527ccded39153e4a88",
       "since": "2025-01-01"
     },
     "route-group:canonical-state": {
@@ -522,7 +522,7 @@
       "type": "route-group",
       "domain": "state",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "713c892607c4db840eb89f3bbba1ec287a169da23ca1688fa657362b77b77e78",
+      "contentHash": "bd2065782b05f1eb6317fd27b95974384974f9534052ec527ccded39153e4a88",
       "since": "2025-01-01"
     },
     "route-group:ci": {
@@ -530,7 +530,7 @@
       "type": "route-group",
       "domain": "monitoring",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "713c892607c4db840eb89f3bbba1ec287a169da23ca1688fa657362b77b77e78",
+      "contentHash": "bd2065782b05f1eb6317fd27b95974384974f9534052ec527ccded39153e4a88",
       "since": "2025-01-01"
     },
     "route-group:sessions": {
@@ -538,7 +538,7 @@
       "type": "route-group",
       "domain": "sessions",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "713c892607c4db840eb89f3bbba1ec287a169da23ca1688fa657362b77b77e78",
+      "contentHash": "bd2065782b05f1eb6317fd27b95974384974f9534052ec527ccded39153e4a88",
       "since": "2025-01-01"
     },
     "route-group:jobs": {
@@ -546,7 +546,7 @@
       "type": "route-group",
       "domain": "scheduling",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "713c892607c4db840eb89f3bbba1ec287a169da23ca1688fa657362b77b77e78",
+      "contentHash": "bd2065782b05f1eb6317fd27b95974384974f9534052ec527ccded39153e4a88",
       "since": "2025-01-01"
     },
     "route-group:skip-ledger": {
@@ -554,7 +554,7 @@
       "type": "route-group",
       "domain": "scheduling",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "713c892607c4db840eb89f3bbba1ec287a169da23ca1688fa657362b77b77e78",
+      "contentHash": "bd2065782b05f1eb6317fd27b95974384974f9534052ec527ccded39153e4a88",
       "since": "2025-01-01"
     },
     "route-group:telegram": {
@@ -562,7 +562,7 @@
       "type": "route-group",
       "domain": "communication",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "713c892607c4db840eb89f3bbba1ec287a169da23ca1688fa657362b77b77e78",
+      "contentHash": "bd2065782b05f1eb6317fd27b95974384974f9534052ec527ccded39153e4a88",
       "since": "2025-01-01"
     },
     "route-group:attention": {
@@ -570,7 +570,7 @@
       "type": "route-group",
       "domain": "communication",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "713c892607c4db840eb89f3bbba1ec287a169da23ca1688fa657362b77b77e78",
+      "contentHash": "bd2065782b05f1eb6317fd27b95974384974f9534052ec527ccded39153e4a88",
       "since": "2025-01-01"
     },
     "route-group:relationships": {
@@ -578,7 +578,7 @@
       "type": "route-group",
       "domain": "relationships",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "713c892607c4db840eb89f3bbba1ec287a169da23ca1688fa657362b77b77e78",
+      "contentHash": "bd2065782b05f1eb6317fd27b95974384974f9534052ec527ccded39153e4a88",
       "since": "2025-01-01"
     },
     "route-group:feedback": {
@@ -586,7 +586,7 @@
       "type": "route-group",
       "domain": "feedback",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "713c892607c4db840eb89f3bbba1ec287a169da23ca1688fa657362b77b77e78",
+      "contentHash": "bd2065782b05f1eb6317fd27b95974384974f9534052ec527ccded39153e4a88",
       "since": "2025-01-01"
     },
     "route-group:updates": {
@@ -594,7 +594,7 @@
       "type": "route-group",
       "domain": "updates",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "713c892607c4db840eb89f3bbba1ec287a169da23ca1688fa657362b77b77e78",
+      "contentHash": "bd2065782b05f1eb6317fd27b95974384974f9534052ec527ccded39153e4a88",
       "since": "2025-01-01"
     },
     "route-group:dispatches": {
@@ -602,7 +602,7 @@
       "type": "route-group",
       "domain": "dispatches",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "713c892607c4db840eb89f3bbba1ec287a169da23ca1688fa657362b77b77e78",
+      "contentHash": "bd2065782b05f1eb6317fd27b95974384974f9534052ec527ccded39153e4a88",
       "since": "2025-01-01"
     },
     "route-group:quota": {
@@ -610,7 +610,7 @@
       "type": "route-group",
       "domain": "monitoring",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "713c892607c4db840eb89f3bbba1ec287a169da23ca1688fa657362b77b77e78",
+      "contentHash": "bd2065782b05f1eb6317fd27b95974384974f9534052ec527ccded39153e4a88",
       "since": "2025-01-01"
     },
     "route-group:publishing": {
@@ -618,7 +618,7 @@
       "type": "route-group",
       "domain": "publishing",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "713c892607c4db840eb89f3bbba1ec287a169da23ca1688fa657362b77b77e78",
+      "contentHash": "bd2065782b05f1eb6317fd27b95974384974f9534052ec527ccded39153e4a88",
       "since": "2025-01-01"
     },
     "route-group:private-views": {
@@ -626,7 +626,7 @@
       "type": "route-group",
       "domain": "publishing",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "713c892607c4db840eb89f3bbba1ec287a169da23ca1688fa657362b77b77e78",
+      "contentHash": "bd2065782b05f1eb6317fd27b95974384974f9534052ec527ccded39153e4a88",
       "since": "2025-01-01"
     },
     "route-group:tunnel": {
@@ -634,7 +634,7 @@
       "type": "route-group",
       "domain": "networking",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "713c892607c4db840eb89f3bbba1ec287a169da23ca1688fa657362b77b77e78",
+      "contentHash": "bd2065782b05f1eb6317fd27b95974384974f9534052ec527ccded39153e4a88",
       "since": "2025-01-01"
     },
     "route-group:events": {
@@ -642,7 +642,7 @@
       "type": "route-group",
       "domain": "networking",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "713c892607c4db840eb89f3bbba1ec287a169da23ca1688fa657362b77b77e78",
+      "contentHash": "bd2065782b05f1eb6317fd27b95974384974f9534052ec527ccded39153e4a88",
       "since": "2025-01-01"
     },
     "route-group:evolution": {
@@ -650,7 +650,7 @@
       "type": "route-group",
       "domain": "evolution",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "713c892607c4db840eb89f3bbba1ec287a169da23ca1688fa657362b77b77e78",
+      "contentHash": "bd2065782b05f1eb6317fd27b95974384974f9534052ec527ccded39153e4a88",
       "since": "2025-01-01"
     },
     "route-group:watchdog": {
@@ -658,7 +658,7 @@
       "type": "route-group",
       "domain": "monitoring",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "713c892607c4db840eb89f3bbba1ec287a169da23ca1688fa657362b77b77e78",
+      "contentHash": "bd2065782b05f1eb6317fd27b95974384974f9534052ec527ccded39153e4a88",
       "since": "2025-01-01"
     },
     "route-group:topic-memory": {
@@ -666,7 +666,7 @@
       "type": "route-group",
       "domain": "memory",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "713c892607c4db840eb89f3bbba1ec287a169da23ca1688fa657362b77b77e78",
+      "contentHash": "bd2065782b05f1eb6317fd27b95974384974f9534052ec527ccded39153e4a88",
       "since": "2025-01-01"
     },
     "route-group:state-sync": {
@@ -674,7 +674,7 @@
       "type": "route-group",
       "domain": "coordination",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "713c892607c4db840eb89f3bbba1ec287a169da23ca1688fa657362b77b77e78",
+      "contentHash": "bd2065782b05f1eb6317fd27b95974384974f9534052ec527ccded39153e4a88",
       "since": "2025-01-01"
     },
     "route-group:intent": {
@@ -682,7 +682,7 @@
       "type": "route-group",
       "domain": "intent",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "713c892607c4db840eb89f3bbba1ec287a169da23ca1688fa657362b77b77e78",
+      "contentHash": "bd2065782b05f1eb6317fd27b95974384974f9534052ec527ccded39153e4a88",
       "since": "2025-01-01"
     },
     "route-group:triage": {
@@ -690,7 +690,7 @@
       "type": "route-group",
       "domain": "safety",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "713c892607c4db840eb89f3bbba1ec287a169da23ca1688fa657362b77b77e78",
+      "contentHash": "bd2065782b05f1eb6317fd27b95974384974f9534052ec527ccded39153e4a88",
       "since": "2025-01-01"
     },
     "route-group:operations": {
@@ -698,7 +698,7 @@
       "type": "route-group",
       "domain": "safety",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "713c892607c4db840eb89f3bbba1ec287a169da23ca1688fa657362b77b77e78",
+      "contentHash": "bd2065782b05f1eb6317fd27b95974384974f9534052ec527ccded39153e4a88",
       "since": "2025-01-01"
     },
     "route-group:sentinel": {
@@ -706,7 +706,7 @@
       "type": "route-group",
       "domain": "safety",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "713c892607c4db840eb89f3bbba1ec287a169da23ca1688fa657362b77b77e78",
+      "contentHash": "bd2065782b05f1eb6317fd27b95974384974f9534052ec527ccded39153e4a88",
       "since": "2025-01-01"
     },
     "route-group:trust": {
@@ -714,7 +714,7 @@
       "type": "route-group",
       "domain": "safety",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "713c892607c4db840eb89f3bbba1ec287a169da23ca1688fa657362b77b77e78",
+      "contentHash": "bd2065782b05f1eb6317fd27b95974384974f9534052ec527ccded39153e4a88",
       "since": "2025-01-01"
     },
     "route-group:monitoring": {
@@ -722,7 +722,7 @@
       "type": "route-group",
       "domain": "monitoring",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "713c892607c4db840eb89f3bbba1ec287a169da23ca1688fa657362b77b77e78",
+      "contentHash": "bd2065782b05f1eb6317fd27b95974384974f9534052ec527ccded39153e4a88",
       "since": "2025-01-01"
     },
     "route-group:commitments": {
@@ -730,7 +730,7 @@
       "type": "route-group",
       "domain": "commitments",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "713c892607c4db840eb89f3bbba1ec287a169da23ca1688fa657362b77b77e78",
+      "contentHash": "bd2065782b05f1eb6317fd27b95974384974f9534052ec527ccded39153e4a88",
       "since": "2025-01-01"
     },
     "route-group:episodes": {
@@ -738,7 +738,7 @@
       "type": "route-group",
       "domain": "memory",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "713c892607c4db840eb89f3bbba1ec287a169da23ca1688fa657362b77b77e78",
+      "contentHash": "bd2065782b05f1eb6317fd27b95974384974f9534052ec527ccded39153e4a88",
       "since": "2025-01-01"
     },
     "route-group:messages": {
@@ -746,7 +746,7 @@
       "type": "route-group",
       "domain": "coordination",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "713c892607c4db840eb89f3bbba1ec287a169da23ca1688fa657362b77b77e78",
+      "contentHash": "bd2065782b05f1eb6317fd27b95974384974f9534052ec527ccded39153e4a88",
       "since": "2025-01-01"
     },
     "route-group:system-reviews": {
@@ -754,7 +754,7 @@
       "type": "route-group",
       "domain": "monitoring",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "713c892607c4db840eb89f3bbba1ec287a169da23ca1688fa657362b77b77e78",
+      "contentHash": "bd2065782b05f1eb6317fd27b95974384974f9534052ec527ccded39153e4a88",
       "since": "2025-01-01"
     },
     "route-group:machine-mesh": {
@@ -770,7 +770,7 @@
       "type": "route-group",
       "domain": "security",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "713c892607c4db840eb89f3bbba1ec287a169da23ca1688fa657362b77b77e78",
+      "contentHash": "bd2065782b05f1eb6317fd27b95974384974f9534052ec527ccded39153e4a88",
       "since": "2025-01-01"
     },
     "cli:init": {
@@ -1474,7 +1474,7 @@
       "type": "subsystem",
       "domain": "server",
       "sourcePath": "src/server/AgentServer.ts",
-      "contentHash": "817c1981f1dcf55def31ed4d422a7b1e9f2c4c9e62b0855238765a2c69cf22c6",
+      "contentHash": "a251a9d664b4ba0fc86a474813a315da4a3fd2171b2f0d82e95bf1c12ec1af88",
       "since": "2025-01-01"
     },
     "subsystem:session-manager": {

--- a/src/monitoring/ApprenticeshipCycleStore.ts
+++ b/src/monitoring/ApprenticeshipCycleStore.ts
@@ -1,0 +1,259 @@
+/**
+ * ApprenticeshipCycleStore — durable differential-cycle capture.
+ *
+ * One row per apprenticeship/mentorship cycle. This is intentionally
+ * persistence-only: the store records what the mentee produced, what the mentor
+ * flagged, what the overseer differential found, coaching, and infra follow-up
+ * items. It does not judge quality or drive lifecycle transitions.
+ */
+import Database from 'better-sqlite3';
+import type { Database as BetterSqliteDatabase } from 'better-sqlite3';
+import fs from 'node:fs';
+import path from 'node:path';
+import { randomUUID } from 'node:crypto';
+import { registerSqliteHandle } from '../core/SqliteRegistry.js';
+import { NativeModuleHealer } from '../memory/NativeModuleHealer.js';
+
+export interface ApprenticeshipCycleStoreOptions {
+  /** SQLite DB path. Use `:memory:` for tests. */
+  dbPath: string;
+  /** Override clock for deterministic tests. */
+  now?: () => Date;
+}
+
+export interface ApprenticeshipCycleRecordInput {
+  id?: string;
+  instanceId: string;
+  cycleNumber: number;
+  createdAt?: string;
+  task: string;
+  menteeOutput: string;
+  mentorFlagged?: string[];
+  overseerDifferential?: string[];
+  coaching?: string;
+  infraItems?: string[];
+  kind?: string;
+  status?: string;
+}
+
+export interface ApprenticeshipCycleRecord {
+  id: string;
+  instanceId: string;
+  cycleNumber: number;
+  createdAt: string;
+  task: string;
+  menteeOutput: string;
+  mentorFlagged: string[];
+  overseerDifferential: string[];
+  coaching: string;
+  infraItems: string[];
+  kind: string;
+  status: string;
+}
+
+const SCHEMA = [
+  `CREATE TABLE IF NOT EXISTS apprenticeship_cycles (
+     id                    TEXT PRIMARY KEY,
+     instance_id           TEXT NOT NULL,
+     cycle_number          INTEGER NOT NULL,
+     created_at            TEXT NOT NULL,
+     task                  TEXT NOT NULL,
+     mentee_output         TEXT NOT NULL,
+     mentor_flagged_json   TEXT NOT NULL,
+     overseer_diff_json    TEXT NOT NULL,
+     coaching              TEXT NOT NULL,
+     infra_items_json      TEXT NOT NULL,
+     kind                  TEXT NOT NULL,
+     status                TEXT NOT NULL
+   )`,
+  `CREATE INDEX IF NOT EXISTS idx_apprenticeship_cycles_instance_created
+     ON apprenticeship_cycles(instance_id, created_at DESC)`,
+  `CREATE INDEX IF NOT EXISTS idx_apprenticeship_cycles_created
+     ON apprenticeship_cycles(created_at DESC)`,
+];
+
+function requireString(value: unknown, field: string): string {
+  if (typeof value !== 'string' || value.trim() === '') {
+    throw new Error(`${field} is required`);
+  }
+  return value;
+}
+
+function optionalString(value: unknown, fallback: string): string {
+  return typeof value === 'string' && value.trim() !== '' ? value : fallback;
+}
+
+function stringArray(value: unknown, field: string): string[] {
+  if (value === undefined) return [];
+  if (!Array.isArray(value) || value.some((item) => typeof item !== 'string')) {
+    throw new Error(`${field} must be an array of strings`);
+  }
+  return value;
+}
+
+function parseJsonArray(value: string): string[] {
+  try {
+    const parsed = JSON.parse(value);
+    return Array.isArray(parsed) ? parsed.filter((item): item is string => typeof item === 'string') : [];
+  } catch {
+    return [];
+  }
+}
+
+function clampLimit(raw: unknown): number {
+  const n = typeof raw === 'number' ? raw : typeof raw === 'string' ? parseInt(raw, 10) : NaN;
+  if (!Number.isFinite(n)) return 50;
+  return Math.max(1, Math.min(500, Math.floor(n)));
+}
+
+interface Row {
+  id: string;
+  instance_id: string;
+  cycle_number: number;
+  created_at: string;
+  task: string;
+  mentee_output: string;
+  mentor_flagged_json: string;
+  overseer_diff_json: string;
+  coaching: string;
+  infra_items_json: string;
+  kind: string;
+  status: string;
+}
+
+export class ApprenticeshipCycleStore {
+  private db: BetterSqliteDatabase;
+  private unregisterSqliteHandle: (() => void) | null = null;
+  private now: () => Date;
+  private stmts!: {
+    insert: Database.Statement;
+    listAll: Database.Statement;
+    listByInstance: Database.Statement;
+    get: Database.Statement;
+    close: Database.Statement;
+  };
+
+  constructor(opts: ApprenticeshipCycleStoreOptions) {
+    this.now = opts.now ?? (() => new Date());
+    if (opts.dbPath !== ':memory:') {
+      fs.mkdirSync(path.dirname(opts.dbPath), { recursive: true });
+    }
+    this.db = NativeModuleHealer.openWithHealSync(
+      'ApprenticeshipCycleStore',
+      () => new Database(opts.dbPath),
+    );
+    this.db.pragma('journal_mode = WAL');
+    this.db.pragma('synchronous = NORMAL');
+    this.db.pragma('busy_timeout = 5000');
+    this.unregisterSqliteHandle = registerSqliteHandle(() => {
+      try { this.db.close(); } catch { /* already closed */ }
+    });
+    for (const ddl of SCHEMA) this.db.exec(ddl);
+    this.prepareStatements();
+  }
+
+  private prepareStatements(): void {
+    this.stmts = {
+      insert: this.db.prepare(`
+        INSERT INTO apprenticeship_cycles
+          (id, instance_id, cycle_number, created_at, task, mentee_output,
+           mentor_flagged_json, overseer_diff_json, coaching, infra_items_json,
+           kind, status)
+        VALUES
+          (@id, @instanceId, @cycleNumber, @createdAt, @task, @menteeOutput,
+           @mentorFlaggedJson, @overseerDifferentialJson, @coaching,
+           @infraItemsJson, @kind, @status)
+      `),
+      listAll: this.db.prepare(`
+        SELECT * FROM apprenticeship_cycles
+        ORDER BY created_at DESC, cycle_number DESC
+        LIMIT ?
+      `),
+      listByInstance: this.db.prepare(`
+        SELECT * FROM apprenticeship_cycles
+        WHERE instance_id = ?
+        ORDER BY created_at DESC, cycle_number DESC
+        LIMIT ?
+      `),
+      get: this.db.prepare(`SELECT * FROM apprenticeship_cycles WHERE id = ?`),
+      close: this.db.prepare(`
+        UPDATE apprenticeship_cycles
+        SET status = 'closed'
+        WHERE id = ?
+        RETURNING *
+      `),
+    };
+  }
+
+  record(input: ApprenticeshipCycleRecordInput): ApprenticeshipCycleRecord {
+    const record: ApprenticeshipCycleRecord = {
+      id: optionalString(input.id, randomUUID()),
+      instanceId: requireString(input.instanceId, 'instanceId'),
+      cycleNumber: Number.isInteger(input.cycleNumber) && input.cycleNumber > 0
+        ? input.cycleNumber
+        : (() => { throw new Error('cycleNumber must be a positive integer'); })(),
+      createdAt: optionalString(input.createdAt, this.now().toISOString()),
+      task: requireString(input.task, 'task'),
+      menteeOutput: requireString(input.menteeOutput, 'menteeOutput'),
+      mentorFlagged: stringArray(input.mentorFlagged, 'mentorFlagged'),
+      overseerDifferential: stringArray(input.overseerDifferential, 'overseerDifferential'),
+      coaching: typeof input.coaching === 'string' ? input.coaching : '',
+      infraItems: stringArray(input.infraItems, 'infraItems'),
+      kind: optionalString(input.kind, 'differential-cycle'),
+      status: optionalString(input.status, 'open'),
+    };
+
+    this.stmts.insert.run({
+      ...record,
+      mentorFlaggedJson: JSON.stringify(record.mentorFlagged),
+      overseerDifferentialJson: JSON.stringify(record.overseerDifferential),
+      infraItemsJson: JSON.stringify(record.infraItems),
+    });
+    return record;
+  }
+
+  list(opts: { instanceId?: string; limit?: number | string } = {}): ApprenticeshipCycleRecord[] {
+    const limit = clampLimit(opts.limit);
+    const rows = opts.instanceId
+      ? this.stmts.listByInstance.all(opts.instanceId, limit)
+      : this.stmts.listAll.all(limit);
+    return (rows as Row[]).map((row) => this.rowToRecord(row));
+  }
+
+  get(id: string): ApprenticeshipCycleRecord | null {
+    const row = this.stmts.get.get(id) as Row | undefined;
+    return row ? this.rowToRecord(row) : null;
+  }
+
+  closeCycle(id: string): ApprenticeshipCycleRecord | null {
+    const row = this.stmts.close.get(id) as Row | undefined;
+    return row ? this.rowToRecord(row) : null;
+  }
+
+  close(): void {
+    try {
+      this.unregisterSqliteHandle?.();
+      this.unregisterSqliteHandle = null;
+      this.db.close();
+    } catch {
+      /* ignore */
+    }
+  }
+
+  private rowToRecord(row: Row): ApprenticeshipCycleRecord {
+    return {
+      id: row.id,
+      instanceId: row.instance_id,
+      cycleNumber: row.cycle_number,
+      createdAt: row.created_at,
+      task: row.task,
+      menteeOutput: row.mentee_output,
+      mentorFlagged: parseJsonArray(row.mentor_flagged_json),
+      overseerDifferential: parseJsonArray(row.overseer_diff_json),
+      coaching: row.coaching,
+      infraItems: parseJsonArray(row.infra_items_json),
+      kind: row.kind,
+      status: row.status,
+    };
+  }
+}

--- a/src/server/AgentServer.ts
+++ b/src/server/AgentServer.ts
@@ -50,6 +50,7 @@ import { CiFailurePoller } from '../monitoring/CiFailurePoller.js';
 import { RevertDetector } from '../monitoring/RevertDetector.js';
 import { CorrectionLedger } from '../monitoring/CorrectionLedger.js';
 import { ApprenticeshipProgram } from '../core/ApprenticeshipProgram.js';
+import { ApprenticeshipCycleStore } from '../monitoring/ApprenticeshipCycleStore.js';
 import { SafeGitExecutor } from '../core/SafeGitExecutor.js';
 import { createSpecReviewRoutes } from './specReviewRoutes.js';
 import { createUsherRoutes } from './usherRoutes.js';
@@ -167,6 +168,7 @@ export class AgentServer {
   private revertDetector: RevertDetector | null = null;
   private correctionLedger: CorrectionLedger | null = null;
   private apprenticeshipProgram: ApprenticeshipProgram | null = null;
+  private apprenticeshipCycleStore: ApprenticeshipCycleStore | null = null;
   // Burn-detection-and-self-heal system (six-phase umbrella spec at
   // docs/specs/token-burn-detection-and-self-heal.md). Lazy-initialised
   // after the TokenLedger comes up — burn detection without a ledger is
@@ -841,6 +843,22 @@ export class AgentServer {
       this.apprenticeshipProgram = null;
     }
 
+    // Apprenticeship differential-cycle capture — durable, queryable records for
+    // mentee output → mentor flags → overseer differential → coaching. Ships ON
+    // whenever stateDir exists; route layer returns 503 if this store fails.
+    try {
+      if (options.config.stateDir) {
+        const serverDataDir = path.join(options.config.stateDir, 'server-data');
+        fs.mkdirSync(serverDataDir, { recursive: true });
+        this.apprenticeshipCycleStore = new ApprenticeshipCycleStore({
+          dbPath: path.join(serverDataDir, 'apprenticeship-cycles.db'),
+        });
+      }
+    } catch (err) {
+      console.warn('[instar] apprenticeship cycle store init failed (non-fatal):', err);
+      this.apprenticeshipCycleStore = null;
+    }
+
     // Routes
     const routeCtx = {
       config: options.config,
@@ -941,6 +959,7 @@ export class AgentServer {
       failureAttributionEngine: this.failureAttributionEngine,
       correctionLedger: this.correctionLedger,
       apprenticeshipProgram: this.apprenticeshipProgram,
+      apprenticeshipCycleStore: this.apprenticeshipCycleStore,
       sessionReaper: options.sessionReaper ?? null,
       agentWorktreeReaper: options.agentWorktreeReaper ?? null,
       sleepController: options.sleepController ?? null,
@@ -2322,6 +2341,14 @@ export class AgentServer {
         // best-effort
       }
       this.tokenLedger = null;
+    }
+    if (this.apprenticeshipCycleStore) {
+      try {
+        this.apprenticeshipCycleStore.close();
+      } catch {
+        // best-effort
+      }
+      this.apprenticeshipCycleStore = null;
     }
 
     // Shutdown WebSocket manager first

--- a/src/server/routes.ts
+++ b/src/server/routes.ts
@@ -724,6 +724,9 @@ export interface RouteContext {
    *  instance-as-project registry, the retro-gate (pending→active) and the
    *  doc-as-required-artifact gate (active→complete). */
   apprenticeshipProgram?: import('../core/ApprenticeshipProgram.js').ApprenticeshipProgram | null;
+  /** Apprenticeship differential-cycle store. Null when SQLite/state init fails
+   *  → /apprenticeship/cycles* 503s. */
+  apprenticeshipCycleStore?: import('../monitoring/ApprenticeshipCycleStore.js').ApprenticeshipCycleStore | null;
   /** SessionReaper — pressure-aware idle-session reaper. Null when not wired
    *  (older boot paths). Powers GET /sessions/reaper observability. */
   sessionReaper?: import('../monitoring/SessionReaper.js').SessionReaper | null;
@@ -11571,6 +11574,45 @@ export function createRoutes(ctx: RouteContext): Router {
   //   POST /apprenticeship/instances/:id/transition {to} — gated status change
   //   POST /apprenticeship/instances/:id/can-start    — read-only start-gate preview
   //   POST /apprenticeship/instances/:id/can-complete — read-only completion-gate preview
+  //
+  // Differential-cycle capture (structural companion store):
+  //   POST /apprenticeship/cycles             — record one cycle row
+  //   GET  /apprenticeship/cycles             — list rows; optional instanceId, limit
+  //   GET  /apprenticeship/cycles/:id         — fetch one row (404 missing)
+  //   POST /apprenticeship/cycles/:id/close   — mark row closed (404 missing)
+  router.post('/apprenticeship/cycles', (req, res) => {
+    if (!ctx.apprenticeshipCycleStore) { res.status(503).json({ error: 'apprenticeship cycle store disabled' }); return; }
+    try {
+      const cycle = ctx.apprenticeshipCycleStore.record(req.body ?? {});
+      res.status(201).json(cycle);
+    } catch (err) {
+      res.status(400).json({ error: err instanceof Error ? err.message : String(err) });
+    }
+  });
+
+  router.get('/apprenticeship/cycles', (req, res) => {
+    if (!ctx.apprenticeshipCycleStore) { res.status(503).json({ error: 'apprenticeship cycle store disabled' }); return; }
+    const instanceId = typeof req.query.instanceId === 'string' && req.query.instanceId.trim() !== ''
+      ? req.query.instanceId
+      : undefined;
+    const limit = typeof req.query.limit === 'string' ? req.query.limit : undefined;
+    res.json({ cycles: ctx.apprenticeshipCycleStore.list({ instanceId, limit }) });
+  });
+
+  router.get('/apprenticeship/cycles/:id', (req, res) => {
+    if (!ctx.apprenticeshipCycleStore) { res.status(503).json({ error: 'apprenticeship cycle store disabled' }); return; }
+    const cycle = ctx.apprenticeshipCycleStore.get(req.params.id);
+    if (!cycle) { res.status(404).json({ error: 'not found' }); return; }
+    res.json(cycle);
+  });
+
+  router.post('/apprenticeship/cycles/:id/close', (req, res) => {
+    if (!ctx.apprenticeshipCycleStore) { res.status(503).json({ error: 'apprenticeship cycle store disabled' }); return; }
+    const cycle = ctx.apprenticeshipCycleStore.closeCycle(req.params.id);
+    if (!cycle) { res.status(404).json({ error: 'not found' }); return; }
+    res.json(cycle);
+  });
+
   router.get('/apprenticeship/instances', (_req, res) => {
     if (!ctx.apprenticeshipProgram) { res.status(503).json({ error: 'apprenticeship program disabled' }); return; }
     res.json({ instances: ctx.apprenticeshipProgram.list() });

--- a/tests/e2e/apprenticeship-lifecycle.test.ts
+++ b/tests/e2e/apprenticeship-lifecycle.test.ts
@@ -9,6 +9,7 @@
  * not 404/503)? This boots the REAL AgentServer (the same path server.ts uses)
  * and verifies:
  *   1. GET /apprenticeship/instances returns 200 through AgentServer (not 503).
+ *   2. POST /apprenticeship/cycles returns 201 through AgentServer (not 503).
  *   2. The route requires Bearer auth.
  *   3. The full lifecycle works end-to-end through the wired program: create →
  *      transition pending→active gated on a real on-disk harvest at the
@@ -102,6 +103,27 @@ describe('Apprenticeship Program E2E lifecycle (feature is alive)', () => {
     const res = await request(app).get('/apprenticeship/instances').set(auth());
     expect(res.status).toBe(200);
     expect(Array.isArray(res.body.instances)).toBe(true);
+  });
+
+  it('POST /apprenticeship/cycles is alive (201, not 503) through AgentServer', async () => {
+    const res = await request(app)
+      .post('/apprenticeship/cycles')
+      .set(auth())
+      .send({
+        id: 'e2e-cycle-1',
+        instanceId: 'echo-to-codey',
+        cycleNumber: 1,
+        task: 'Run an apprenticeship differential cycle',
+        menteeOutput: 'raw mentee output',
+        mentorFlagged: ['mentor finding'],
+        overseerDifferential: ['overseer finding'],
+        coaching: 'coaching note',
+        infraItems: ['infra follow-up'],
+      });
+
+    expect(res.status).toBe(201);
+    expect(res.body.status).toBe('open');
+    expect(res.body.overseerDifferential).toEqual(['overseer finding']);
   });
 
   it('requires Bearer auth', async () => {

--- a/tests/integration/apprenticeship-routes.test.ts
+++ b/tests/integration/apprenticeship-routes.test.ts
@@ -24,6 +24,7 @@ import { authMiddleware } from '../../src/server/middleware.js';
 import { ApprenticeshipProgram, type GateDeps } from '../../src/core/ApprenticeshipProgram.js';
 import { validateRetroHarvest } from '../../src/core/retroHarvestValidator.js';
 import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+import { ApprenticeshipCycleStore } from '../../src/monitoring/ApprenticeshipCycleStore.js';
 
 const AUTH = 'apprenticeship-routes-token';
 const auth = () => ({ Authorization: `Bearer ${AUTH}` });
@@ -57,7 +58,11 @@ function buildHarvest(): string {
   return `---\n${yamlLines}\n---\n\n${body}\n`;
 }
 
-function ctxFor(stateDir: string, program: ApprenticeshipProgram | null): RouteContext {
+function ctxFor(
+  stateDir: string,
+  program: ApprenticeshipProgram | null,
+  cycleStore: ApprenticeshipCycleStore | null = null,
+): RouteContext {
   return {
     config: {
       projectName: 'apprenticeship-routes', projectDir: path.dirname(stateDir), stateDir, port: 0,
@@ -70,6 +75,7 @@ function ctxFor(stateDir: string, program: ApprenticeshipProgram | null): RouteC
     quotaTracker: null, publisher: null, viewer: null, tunnel: null, evolution: null,
     watchdog: null, triageNurse: null, topicMemory: null, feedbackAnomalyDetector: null,
     discoveryEvaluator: null, correctionLedger: null, apprenticeshipProgram: program,
+    apprenticeshipCycleStore: cycleStore,
     startTime: new Date(),
   } as unknown as RouteContext;
 }
@@ -102,6 +108,13 @@ describe('/apprenticeship routes (integration)', () => {
     return new ApprenticeshipProgram({ stateDir, projectDir, deps });
   }
 
+  function makeCycleStore(): ApprenticeshipCycleStore {
+    return new ApprenticeshipCycleStore({
+      dbPath: path.join(stateDir, 'server-data', 'apprenticeship-cycles.db'),
+      now: () => new Date('2026-06-03T08:00:00.000Z'),
+    });
+  }
+
   // ── auth-negative ─────────────────────────────────────────────────────
   it('401 without a bearer token', async () => {
     const res = await request(appWith(ctxFor(stateDir, makeProgram()))).get('/apprenticeship/instances');
@@ -119,6 +132,78 @@ describe('/apprenticeship routes (integration)', () => {
     const res = await request(appWith(ctxFor(stateDir, null))).get('/apprenticeship/instances').set(auth());
     expect(res.status).toBe(503);
     expect(res.body.error).toContain('apprenticeship program disabled');
+  });
+
+  // ── cycle capture ───────────────────────────────────────────────────
+  it('cycle routes require bearer auth and 503 when the store is unavailable', async () => {
+    const app = appWith(ctxFor(stateDir, makeProgram(), null));
+    const unauth = await request(app).get('/apprenticeship/cycles');
+    expect(unauth.status).toBe(401);
+
+    const unavailable = await request(app).get('/apprenticeship/cycles').set(auth());
+    expect(unavailable.status).toBe(503);
+    expect(unavailable.body.error).toContain('cycle store disabled');
+  });
+
+  it('records, lists, gets, filters, and closes cycle rows over HTTP', async () => {
+    const store = makeCycleStore();
+    const app = appWith(ctxFor(stateDir, makeProgram(), store));
+
+    const bad = await request(app)
+      .post('/apprenticeship/cycles')
+      .set(auth())
+      .send({ instanceId: 'echo-to-codey' });
+    expect(bad.status).toBe(400);
+
+    const created = await request(app)
+      .post('/apprenticeship/cycles')
+      .set(auth())
+      .send({
+        id: 'cycle-http-1',
+        instanceId: 'echo-to-codey',
+        cycleNumber: 1,
+        task: 'Run Gemini identity review',
+        menteeOutput: 'raw output',
+        mentorFlagged: ['compressed principles'],
+        overseerDifferential: ['surface env issue'],
+        coaching: 'Keep reasoning and infra findings separate.',
+        infraItems: ['ripgrep missing'],
+        kind: 'mentorship',
+      });
+    expect(created.status).toBe(201);
+    expect(created.body.mentorFlagged).toEqual(['compressed principles']);
+    expect(created.body.infraItems).toEqual(['ripgrep missing']);
+
+    await request(app)
+      .post('/apprenticeship/cycles')
+      .set(auth())
+      .send({
+        id: 'cycle-other',
+        instanceId: 'other-instance',
+        cycleNumber: 1,
+        task: 'Other task',
+        menteeOutput: 'other output',
+      })
+      .expect(201);
+
+    const list = await request(app).get('/apprenticeship/cycles?instanceId=echo-to-codey&limit=10').set(auth());
+    expect(list.status).toBe(200);
+    expect(list.body.cycles.map((c: { id: string }) => c.id)).toEqual(['cycle-http-1']);
+
+    const fetched = await request(app).get('/apprenticeship/cycles/cycle-http-1').set(auth());
+    expect(fetched.status).toBe(200);
+    expect(fetched.body.overseerDifferential).toEqual(['surface env issue']);
+
+    const missing = await request(app).get('/apprenticeship/cycles/no-such').set(auth());
+    expect(missing.status).toBe(404);
+
+    const closed = await request(app).post('/apprenticeship/cycles/cycle-http-1/close').set(auth());
+    expect(closed.status).toBe(200);
+    expect(closed.body.status).toBe('closed');
+
+    const closeMissing = await request(app).post('/apprenticeship/cycles/no-such/close').set(auth());
+    expect(closeMissing.status).toBe(404);
+    store.close();
   });
 
   // ── create ────────────────────────────────────────────────────────────

--- a/tests/unit/SqliteRegistry-wiring.test.ts
+++ b/tests/unit/SqliteRegistry-wiring.test.ts
@@ -41,6 +41,7 @@ const LONG_LIVED_STORES = [
   'src/monitoring/FailureLedger.ts',
   'src/monitoring/FeatureMetricsLedger.ts',
   'src/monitoring/FrameworkIssueLedger.ts',
+  'src/monitoring/ApprenticeshipCycleStore.ts',
   'src/memory/TopicMemory.ts',
   'src/memory/SemanticMemory.ts',
   'src/messaging/MessageProcessingLedger.ts',

--- a/tests/unit/apprenticeship-cycle-store.test.ts
+++ b/tests/unit/apprenticeship-cycle-store.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { ApprenticeshipCycleStore } from '../../src/monitoring/ApprenticeshipCycleStore.js';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+
+describe('ApprenticeshipCycleStore', () => {
+  const tmpDirs: string[] = [];
+
+  afterEach(() => {
+    for (const dir of tmpDirs.splice(0)) {
+      SafeFsExecutor.safeRmSync(dir, {
+        recursive: true,
+        force: true,
+        operation: 'tests/unit/apprenticeship-cycle-store.test.ts:afterEach',
+      });
+    }
+  });
+
+  function makeStore(): ApprenticeshipCycleStore {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'apprenticeship-cycles-'));
+    tmpDirs.push(tmp);
+    return new ApprenticeshipCycleStore({
+      dbPath: path.join(tmp, 'cycles.db'),
+      now: () => new Date('2026-06-03T08:00:00.000Z'),
+    });
+  }
+
+  it('records, lists, gets, and closes a cycle with JSON fields intact', () => {
+    const store = makeStore();
+    const recorded = store.record({
+      id: 'cycle-1',
+      instanceId: 'echo-to-codey',
+      cycleNumber: 1,
+      task: 'Read Gemini identity and report five bullets',
+      menteeOutput: 'raw mentee answer',
+      mentorFlagged: ['compressed implementation principle'],
+      overseerDifferential: ['surface environment note separately'],
+      coaching: 'Separate reasoning findings from tooling anomalies.',
+      infraItems: ['ripgrep missing', 'TERM=dumb'],
+      kind: 'mentorship',
+    });
+
+    expect(recorded.createdAt).toBe('2026-06-03T08:00:00.000Z');
+    expect(recorded.status).toBe('open');
+    expect(recorded.mentorFlagged).toEqual(['compressed implementation principle']);
+    expect(recorded.overseerDifferential).toEqual(['surface environment note separately']);
+    expect(recorded.infraItems).toEqual(['ripgrep missing', 'TERM=dumb']);
+
+    expect(store.list()).toHaveLength(1);
+    expect(store.get('cycle-1')?.menteeOutput).toBe('raw mentee answer');
+
+    const closed = store.closeCycle('cycle-1');
+    expect(closed?.status).toBe('closed');
+    expect(store.get('cycle-1')?.status).toBe('closed');
+    store.close();
+  });
+
+  it('filters list results by instanceId and applies the limit', () => {
+    const store = makeStore();
+    store.record({ id: 'a1', instanceId: 'a', cycleNumber: 1, task: 'a1', menteeOutput: 'out' });
+    store.record({ id: 'b1', instanceId: 'b', cycleNumber: 1, task: 'b1', menteeOutput: 'out' });
+    store.record({ id: 'a2', instanceId: 'a', cycleNumber: 2, task: 'a2', menteeOutput: 'out' });
+
+    expect(store.list({ instanceId: 'a' }).map((c) => c.id)).toEqual(['a2', 'a1']);
+    expect(store.list({ limit: 2 })).toHaveLength(2);
+    expect(store.get('missing')).toBeNull();
+    expect(store.closeCycle('missing')).toBeNull();
+    store.close();
+  });
+
+  it('rejects malformed required fields and non-string array fields', () => {
+    const store = makeStore();
+    expect(() => store.record({ instanceId: '', cycleNumber: 1, task: 't', menteeOutput: 'm' })).toThrow(/instanceId/);
+    expect(() => store.record({ instanceId: 'i', cycleNumber: 0, task: 't', menteeOutput: 'm' })).toThrow(/cycleNumber/);
+    expect(() => store.record({
+      instanceId: 'i',
+      cycleNumber: 1,
+      task: 't',
+      menteeOutput: 'm',
+      mentorFlagged: ['ok', 1] as unknown as string[],
+    })).toThrow(/mentorFlagged/);
+    store.close();
+  });
+});

--- a/upgrades/apprenticeship-cycle-store.eli16.md
+++ b/upgrades/apprenticeship-cycle-store.eli16.md
@@ -1,0 +1,62 @@
+# Apprenticeship Cycle Store — plain English overview
+
+## What this change is
+
+The apprenticeship program already tracks big lifecycle state: which onboarding
+instance exists, who the overseer is, who the mentor is, who the mentee is, and
+whether the instance may start or complete.
+
+This change tracks the smaller repeated loop inside an apprenticeship.
+
+Each time a mentee does a task, the system can now save one "cycle":
+
+- what task the mentee tried
+- what the mentee produced
+- what the mentor noticed
+- what the overseer noticed differently
+- what coaching came out of that comparison
+- what infrastructure follow-ups should exist
+- whether the cycle is still open or closed
+
+## Why it matters
+
+Before this, the important learning loop could live mostly in chat. That is
+fragile. Chat is hard to query later, easy to lose in summaries, and too easy to
+skip when the next mentorship starts.
+
+Now the loop has a real SQLite table and an API. That makes the learning
+evidence durable.
+
+## What already existed
+
+- An apprenticeship instance registry.
+- Lifecycle routes for creating instances and moving them through status gates.
+- Tests that prove the lifecycle routes are alive.
+
+## What's new
+
+- `ApprenticeshipCycleStore`, a SQLite store with one row per differential
+  cycle.
+- Four authenticated routes:
+  - `POST /apprenticeship/cycles`
+  - `GET /apprenticeship/cycles`
+  - `GET /apprenticeship/cycles/:id`
+  - `POST /apprenticeship/cycles/:id/close`
+- Unit tests for persistence.
+- Integration tests for auth, validation, 404s, and the full route flow.
+- An e2e alive test that proves the real server returns success, not 503.
+
+## What you need to decide
+
+Nothing for this PR. It is additive. Existing apprenticeship instance behavior
+does not change.
+
+## How to verify it worked after deploy
+
+Record a cycle with `POST /apprenticeship/cycles`, list it with
+`GET /apprenticeship/cycles`, fetch it by id, and close it with
+`POST /apprenticeship/cycles/:id/close`.
+
+If the route returns 503, the server did not open the cycle store. If it returns
+201 on record, the feature is live.
+

--- a/upgrades/next/apprenticeship-cycle-store.md
+++ b/upgrades/next/apprenticeship-cycle-store.md
@@ -1,0 +1,44 @@
+# Upgrade Guide — Apprenticeship Cycle Store
+
+<!-- bump: patch -->
+
+## What Changed
+
+Apprenticeship differential cycles now have a structural SQLite-backed store.
+Each captured cycle records the instance id, cycle number, task, mentee output,
+mentor-flagged issues, overseer differentials, coaching, infrastructure items,
+kind, and status.
+
+The server opens `server-data/apprenticeship-cycles.db` beside the existing
+server state, registers the handle with the `SqliteRegistry`, and exposes the
+store through bearer-protected routes:
+
+- `POST /apprenticeship/cycles`
+- `GET /apprenticeship/cycles?instanceId=&limit=`
+- `GET /apprenticeship/cycles/:id`
+- `POST /apprenticeship/cycles/:id/close`
+
+When the store cannot be opened, those routes return 503 so monitoring and
+e2e tests can distinguish an unavailable feature from an empty dataset.
+
+## What to Tell Your User
+
+- **Apprenticeship learning loops are now durable:** "When a mentee completes
+  a cycle, I can persist what the mentee did, what the mentor noticed, what the
+  overseer saw differently, the coaching response, and any infrastructure
+  follow-ups in a queryable store."
+
+## Summary of New Capabilities
+
+| Capability | How to Use |
+|-----------|------------|
+| Record a differential cycle | `POST /apprenticeship/cycles` |
+| List recent cycles | `GET /apprenticeship/cycles?instanceId=&limit=` |
+| Fetch one cycle | `GET /apprenticeship/cycles/:id` |
+| Close a cycle | `POST /apprenticeship/cycles/:id/close` |
+
+## Evidence
+
+- `npx vitest run tests/unit/apprenticeship-cycle-store.test.ts tests/unit/SqliteRegistry-wiring.test.ts tests/integration/apprenticeship-routes.test.ts tests/e2e/apprenticeship-lifecycle.test.ts`
+- `npx tsc --noEmit`
+

--- a/upgrades/side-effects/apprenticeship-cycle-store.md
+++ b/upgrades/side-effects/apprenticeship-cycle-store.md
@@ -1,0 +1,109 @@
+# Side-Effects Review — Apprenticeship Cycle Store
+
+**Version / slug:** `apprenticeship-cycle-store`
+**Date:** `2026-06-03`
+**Author:** `instar-codey`
+**Second-pass reviewer:** `not required`
+
+## Summary of the change
+
+Adds `ApprenticeshipCycleStore`, a small better-sqlite3 store for one row per
+apprenticeship differential cycle, plus authenticated HTTP routes for recording,
+listing, fetching, and closing cycles. The server creates
+`server-data/apprenticeship-cycles.db` when a state directory is available and
+registers the SQLite handle with `SqliteRegistry`.
+
+## Decision-point inventory
+
+- `ApprenticeshipCycleStore.record` — add — validates required fields, stores
+  array fields as JSON, and defaults status to `open`.
+- `ApprenticeshipCycleStore.list` — add — lists recent cycles globally or by
+  `instanceId`, with a bounded positive limit.
+- `ApprenticeshipCycleStore.get` — add — returns one parsed cycle or null.
+- `ApprenticeshipCycleStore.closeCycle` — add — marks a cycle closed and returns
+  the updated parsed row.
+- `/apprenticeship/cycles*` routes — add — bearer-protected CRUD-style API with
+  503 when the store is unavailable, 400 for invalid input, and 404 for unknown
+  ids.
+
+## 1. Over-block
+
+The store rejects missing `instanceId`, non-positive `cycleNumber`, empty `task`,
+empty `menteeOutput`, and non-string entries in array fields. That is intentional:
+these are structural capture records, and accepting malformed rows would make the
+later retro-harvest less reliable.
+
+The route layer returns 503 when the store is not wired. This is stricter than
+returning an empty list, but it is the right failure mode because callers need to
+know the feature is unavailable rather than "no cycles exist."
+
+## 2. Under-block
+
+The store does not enforce that `instanceId` references an existing
+apprenticeship instance. That keeps this Tier-1 change additive and avoids
+coupling the cycle recorder to instance lifecycle transitions. A later workflow
+layer can add instance-aware capture if it needs that guarantee.
+
+The `coaching` and `kind` fields are plain strings, not constrained enums. The
+current default `kind` is `differential-cycle`; preserving strings keeps room for
+future cycle subtypes without a migration.
+
+## 3. Level-of-abstraction fit
+
+Persistence belongs in `src/monitoring` with the other small operational stores,
+not in the apprenticeship lifecycle JSON registry. The lifecycle registry owns
+instance state and gates; the cycle store owns repeatable evidence captured
+during an active mentorship.
+
+The HTTP routes stay thin: they validate availability, call the store, and map
+store validation errors to 400 responses.
+
+## 4. Signal vs authority compliance
+
+No conversational/product judgment is delegated to brittle logic. The change only
+persists explicit caller-provided fields and exposes them through authenticated
+routes. It does not decide whether a cycle was good, whether a mentor was right,
+or whether an instance may complete.
+
+## 5. Interactions
+
+- **SqliteRegistry:** the store registers and unregisters its handle so native
+  SQLite lifecycle checks include the new database.
+- **AgentServer shutdown:** the store closes during server stop, best-effort,
+  beside the other monitoring stores.
+- **ApprenticeshipProgram:** instance routes remain unchanged. Cycle capture is
+  adjacent to, not inside, the lifecycle transition gate.
+- **Monitoring/e2e:** the e2e alive path asserts `POST /apprenticeship/cycles`
+  returns 201 when the server has the store and not 503.
+
+## 6. External surfaces
+
+Adds four bearer-authenticated API routes:
+
+- `POST /apprenticeship/cycles`
+- `GET /apprenticeship/cycles?instanceId=&limit=`
+- `GET /apprenticeship/cycles/:id`
+- `POST /apprenticeship/cycles/:id/close`
+
+Adds one database file under server state when the server is running:
+`server-data/apprenticeship-cycles.db`.
+
+## 7. Rollback cost
+
+Rollback is a code and route revert. Existing `apprenticeship-cycles.db` files
+can remain inert on disk; the server simply stops opening them after rollback.
+No migration is required because no existing schema is modified.
+
+## Conclusion
+
+Ship. This is an additive Tier-1 persistence/API surface with focused store,
+integration, and e2e coverage. The only failure-mode hardening is returning 503
+when the store is unavailable, which is the correct liveness signal.
+
+## Evidence pointers
+
+- `tests/unit/apprenticeship-cycle-store.test.ts`
+- `tests/unit/SqliteRegistry-wiring.test.ts`
+- `tests/integration/apprenticeship-routes.test.ts`
+- `tests/e2e/apprenticeship-lifecycle.test.ts`
+


### PR DESCRIPTION
## Summary

- add `ApprenticeshipCycleStore`, a registered SQLite store for one row per apprenticeship differential cycle
- wire authenticated record/list/get/close routes under `/apprenticeship/cycles`
- add unit, integration, and e2e alive coverage plus site docs, upgrade artifacts, ELI16, dev trace, and regenerated builtin manifest

## Verification

- `npx vitest run tests/unit/apprenticeship-cycle-store.test.ts tests/unit/SqliteRegistry-wiring.test.ts tests/integration/apprenticeship-routes.test.ts tests/e2e/apprenticeship-lifecycle.test.ts`
- `node scripts/docs-coverage.mjs --check`
- `npx tsc --noEmit`
- `pnpm build`
- `node scripts/instar-dev-precommit.js`
- pre-push scoped e2e: 16 files / 331 tests passed

## Artifacts

- ELI16 private view verified HTTP 200: https://codey.dawn-tunnel.dev/view/7f68a57b-71a7-4fde-9d7d-0cc610f1628a?sig=2b14eeed5543498fc58c0ce4cc4b8131c463cb2111aa5021678182f5a1030aa9
- Upgrade guide: `upgrades/next/apprenticeship-cycle-store.md`
- Side-effects review: `upgrades/side-effects/apprenticeship-cycle-store.md`
