### PR TITLE
fix(llm-circuit): parse provider "reset after Ns" hints (Gemini over-pause)

### DIFF
--- a/src/core/LlmCircuitBreaker.ts
+++ b/src/core/LlmCircuitBreaker.ts
@@ -140,15 +140,20 @@ function parseRetryAfterMs(m: string): number | undefined {
   let match = /retry[\s-]?after:?\s*(\d+(?:\.\d+)?)\s*(?:seconds?|s)?\b/.exec(m);
   if (match) seconds = Number(match[1]);
 
-  // resets in <N>s / reset in <N> seconds / try again in <N>s
+  // resets in/after <N>s / reset in <N> seconds / try again in <N>s.
+  // "(?:in|after)" also catches Gemini's "your quota will reset after 8s"
+  // phrasing — without it the hint failed to parse and the breaker fell back
+  // to the blunt DEFAULT_OPEN_MS (15 min), turning an 8-second provider reset
+  // into a 15-minute global LLM pause (~100x over-correction; observed live on
+  // the gemini-cli agent, 2026-06-03).
   if (seconds === undefined) {
-    match = /(?:resets?|try again)\s+in\s+(\d+(?:\.\d+)?)\s*(?:seconds?|s)\b/.exec(m);
+    match = /(?:resets?|try again)\s+(?:in|after)\s+(\d+(?:\.\d+)?)\s*(?:seconds?|s)\b/.exec(m);
     if (match) seconds = Number(match[1]);
   }
 
-  // resets in <N>m / reset in <N> minutes / try again in <N> minutes
+  // resets in/after <N>m / reset in <N> minutes / try again in <N> minutes
   if (seconds === undefined) {
-    match = /(?:resets?|try again)\s+in\s+(\d+(?:\.\d+)?)\s*(?:minutes?|m)\b/.exec(m);
+    match = /(?:resets?|try again)\s+(?:in|after)\s+(\d+(?:\.\d+)?)\s*(?:minutes?|m)\b/.exec(m);
     if (match) seconds = Number(match[1]) * 60;
   }
 

--- a/src/data/builtin-manifest.json
+++ b/src/data/builtin-manifest.json
@@ -1,8 +1,8 @@
 {
   "$schema": "./builtin-manifest.schema.json",
   "schemaVersion": 1,
-  "generatedAt": "2026-06-03T09:35:14.836Z",
-  "instarVersion": "1.3.216",
+  "generatedAt": "2026-06-03T10:04:51.168Z",
+  "instarVersion": "1.3.217",
   "entryCount": 195,
   "entries": {
     "hook:session-start": {

--- a/tests/unit/llm-circuit-breaker-wait.test.ts
+++ b/tests/unit/llm-circuit-breaker-wait.test.ts
@@ -84,6 +84,22 @@ describe('classifyRateLimit', () => {
     expect(c.retryAfterMs).toBe(180_000);
   });
 
+  // Gemini phrasing: "your quota will reset AFTER Ns" (not "in Ns"). Before the
+  // (?:in|after) fix this failed to parse → the breaker fell back to the blunt
+  // 15-min DEFAULT_OPEN_MS, turning an 8s provider reset into a 900s global
+  // pause (observed live on the gemini-cli agent, 2026-06-03).
+  it('parses Gemini "quota will reset after 8s" → 8000ms', () => {
+    const c = classifyRateLimit('You have exhausted your capacity on this model. Your quota will reset after 8s.');
+    expect(c.isLimit).toBe(true);
+    expect(c.retryAfterMs).toBe(8_000);
+  });
+
+  it('parses "reset after 5 minutes" → 300000ms', () => {
+    const c = classifyRateLimit('quota exhausted — reset after 5 minutes');
+    expect(c.isLimit).toBe(true);
+    expect(c.retryAfterMs).toBe(300_000);
+  });
+
   it('treats a plain 429 as a limit with no retryAfterMs', () => {
     const c = classifyRateLimit('HTTP 429 returned');
     expect(c.isLimit).toBe(true);
@@ -173,6 +189,24 @@ describe('LlmCircuitBreaker.onRateLimited with retryAfterMs', () => {
     expect(breaker.acquire().allow).toBe(false); // still inside 15min
     clock.advance(60 * 1000);
     expect(breaker.acquire().allow).toBe(true);
+  });
+
+  // End-to-end regression for the live Gemini over-pause: the real provider
+  // message must classify AND shorten the window. Before the (?:in|after) parse
+  // fix, retryAfterMs was undefined → 900s pause; now it floors to 30s and the
+  // agent recovers in ~30s instead of 15 minutes.
+  it('Gemini "quota will reset after 8s" recovers in ~30s, NOT the blunt 15min', () => {
+    const clock = makeClock(0);
+    const breaker = new LlmCircuitBreaker({ openMs: 15 * 60 * 1000, now: clock.now });
+    const msg = 'Gemini CLI exited 1 — Your quota will reset after 8s.';
+    const c = classifyRateLimit(msg);
+    expect(c.isLimit).toBe(true);
+    expect(c.retryAfterMs).toBe(8_000); // parsed (the fix); was undefined before
+    breaker.onRateLimited(msg, c.retryAfterMs); // 8s floored to the 30s minimum
+    clock.advance(29_000);
+    expect(breaker.acquire().allow).toBe(false); // still inside the floored 30s
+    clock.advance(2_000);
+    expect(breaker.acquire().allow).toBe(true); // recovered ~30s, not 900s
   });
 });
 

--- a/upgrades/circuit-breaker-reset-after.eli16.md
+++ b/upgrades/circuit-breaker-reset-after.eli16.md
@@ -1,0 +1,23 @@
+# Circuit Breaker "Reset After" Fix — ELI16
+
+Viewable private artifact:
+https://echo.dawn-tunnel.dev/view/bfae9763-aa22-4486-bc7d-9b7b2e470658?sig=72ade47ad66400b09f8ef262b0a5055fbf5f099684c0b45bb2da1b08b6977743
+
+When an AI provider like Gemini runs low on capacity, it usually tells you when to come back:
+"your quota will reset after 8 seconds." Instar has a safety switch — a **circuit breaker** — that
+briefly pauses AI calls after a rate limit so it doesn't keep hammering an overloaded provider.
+
+The breaker is smart enough to read the provider's "come back in N seconds" hint and only pause that
+long. But it was only listening for the phrase **"reset IN N seconds."** Gemini says **"reset AFTER
+N seconds."** That one-word difference meant Instar couldn't read Gemini's hint at all — so it used
+its blunt fallback: pause **everything for 15 minutes.**
+
+The result: Gemini would say "I'll be ready in 8 seconds," and Instar would freeze the whole agent
+for **15 minutes** — about **110× longer** than needed. On the live Gemini agent this happened over
+and over, making it look stuck.
+
+The fix teaches the breaker to also understand **"reset after N."** Now an 8-second reset means
+roughly a 30-second pause (a sensible floor), not 15 minutes — so the agent recovers quickly instead
+of sitting idle.
+
+_Tier-1 fix · branch `echo/circuit-breaker-reset-after` · 3 unit tests + full breaker suites green._

--- a/upgrades/next/circuit-breaker-reset-after.md
+++ b/upgrades/next/circuit-breaker-reset-after.md
@@ -1,0 +1,39 @@
+<!-- bump: patch -->
+
+## What Changed
+
+Fixes the LLM circuit breaker so it honors a provider's self-reported reset window when the
+provider phrases it as "reset **after** N seconds" — not just "reset **in** N seconds".
+
+`classifyRateLimit`'s `parseRetryAfterMs` previously matched only `resets in <N>s` / `try again in
+<N>s`. Gemini reports quota exhaustion as **"Your quota will reset after 8s"**, which did not parse
+→ `retryAfterMs` came back `undefined` → the breaker fell back to the blunt `DEFAULT_OPEN_MS`
+(15 minutes). The practical effect, observed live on the `gemini-cli` agent (2026-06-03): an
+8-second provider reset triggered a **900-second global LLM pause** — a ~110× over-correction that
+repeatedly froze the entire agent on a limit that had already cleared.
+
+The fix extends the two duration patterns from `\s+in\s+` to `\s+(?:in|after)\s+`, so "reset after
+Ns/Nm" now parses and the breaker opens for the floored provider window (min 30s) instead of the
+flat 15-minute default. No behavior change for the existing "reset in" phrasing.
+
+## What to Tell Your User
+
+- **Faster recovery from short rate limits**: "When a provider tells me its quota resets in a few
+  seconds, I now wait that short window instead of pausing all LLM work for a blunt 15 minutes. If
+  you saw a Gemini-backed agent freeze for long stretches after a brief rate limit, that's fixed."
+
+## Summary of New Capabilities
+
+| Capability | How to Use |
+|-----------|-----------|
+| Honors "reset after Ns" windows | Automatic — the circuit breaker now parses Gemini-style "reset after N" hints and opens for that window (floored to 30s) instead of the 15-minute default. |
+
+## Evidence
+
+Verification:
+
+- Unit: `classifyRateLimit('…quota will reset after 8s')` → `retryAfterMs === 8000`; `reset after 5
+  minutes` → `300000`; existing "reset in" cases unchanged.
+- Unit (end-to-end regression): the real Gemini message classified + fed to `onRateLimited` opens
+  the breaker for the floored ~30s window and recovers there, NOT at 900s.
+- Full `llm-circuit-breaker-wait` + `LlmCircuitBreaker` suites green (61 tests); `tsc --noEmit` clean.

--- a/upgrades/side-effects/circuit-breaker-reset-after.md
+++ b/upgrades/side-effects/circuit-breaker-reset-after.md
@@ -1,0 +1,51 @@
+# Side-Effects Review — Circuit-breaker "reset after Ns" parsing
+
+**Version / slug:** `circuit-breaker-reset-after`
+**Date:** `2026-06-03`
+**Author:** `echo`
+**Second-pass reviewer:** `not required`
+
+## Summary of the change
+
+Two regexes in `LlmCircuitBreaker.parseRetryAfterMs` change `\s+in\s+` → `\s+(?:in|after)\s+`,
+so a provider's "reset **after** N seconds/minutes" hint parses to `retryAfterMs` the same way
+"reset **in** N" already did. Adds three unit tests. No other code paths change.
+
+## Decision-point inventory
+
+None added. The change widens one existing best-effort parse; it introduces no new branch that
+decides anything. The parsed value flows into the same `onRateLimited` clamp that already existed.
+
+## 1. Over-block (false positive — a wrong/too-short window extracted)
+
+`parseRetryAfterMs` only runs inside `classifyRateLimit`, i.e. on a message ALREADY classified as a
+rate limit. The new alternation still requires the literal stem `reset`/`resets`/`try again`,
+immediately followed by `after`, a number, and a time unit — so it cannot fire on unrelated prose.
+Even if a genuine rate-limit message contained a misleading "reset after N" phrase, the extracted
+value is bounded twice: `classifyRateLimit` clamps to `[1s, 15min]`, and `onRateLimited` floors to
+`min(30s, openMs)`. The breaker therefore can never open for **less than 30s** or **more than 15min**
+regardless of what parses. The blast radius of a mis-parse is at most "recovers 30s vs the old 15min"
+— strictly safer than the bug being fixed.
+
+## 2. Under-block (false negative — a window still missed)
+
+Unchanged phrasings ("reset in Ns", "retry-after: N", "try again in N minutes") match exactly as
+before — the change is purely additive (an extra alternation), so no previously-parsed message
+stops parsing. Messages with no recognizable duration still return `undefined` and fall back to the
+flat default, identical to today.
+
+## 3. Interaction with #708 (gemini capacity policy)
+
+#708 handles the structured provider path (it retries within a single `evaluate` with the
+gemini-reported window). This fix is a layer up: it governs how long the GLOBAL breaker stays open
+when a gemini failure propagates as a classified rate-limit. The two compose — #708 keeps a single
+call resilient; this keeps a breaker trip proportionate. Neither overrides the other.
+
+## 4. Reversibility
+
+Pure code change, no migration, no persisted state, no config. Revert = revert the two regex edits.
+
+## Verdict
+
+Bounded, additive, no new decision surface. The only behavioral change is that gemini-style short
+resets now produce a proportionate (≥30s) breaker window instead of a flat 15-minute pause.


### PR DESCRIPTION
## Circuit breaker: parse "reset after Ns" hints (live Gemini over-pause fix)

**Found by re-running the apprenticeship loop (Phase 3) against the live, rate-limited Gemini agent.**

### The bug
`LlmCircuitBreaker.parseRetryAfterMs` matched only `reset IN Ns` / `try again in Ns`. Gemini reports quota exhaustion as **"Your quota will reset after 8s"** — `reset AFTER`. That phrasing didn't parse → `retryAfterMs` came back `undefined` → the breaker fell back to the blunt `DEFAULT_OPEN_MS` (15 minutes).

Observed live (`gemini-cli` agent, 2026-06-03, `logs/server.log`): repeated `[llm-circuit] OPEN … pausing ALL LLM-backed work for ~900s` trips, while the provider itself said the quota resets in **8 seconds**. An 8s reset → a **900s global LLM pause** (~110×), freezing the whole agent on a limit that had already cleared.

`classifyRateLimit` correctly flagged it as a limit (matches "quota"); the gap was purely the duration parse.

### The fix
Extend the two duration regexes from `\s+in\s+` → `\s+(?:in|after)\s+`. "reset after Ns/Nm" now parses; the breaker opens for the floored provider window (≥30s) instead of 15 min. Pure, additive, no new decision surface; the parsed value is clamped twice (`[1s,15min]` then floored to `min(30s,openMs)`), so a mis-parse can never open <30s or >15min.

Composes with **#708** (gemini capacity policy): #708 keeps a single provider *call* resilient (it already parsed "after 8s" at the provider level — `Retrying after 8807ms` in the same log); this keeps the **global breaker trip** proportionate. Different layers, no overlap.

### Tests
- `classifyRateLimit('…quota will reset after 8s')` → `8000`; `reset after 5 minutes` → `300000`; existing "reset in" cases unchanged.
- End-to-end regression: real Gemini message → `classifyRateLimit` → `onRateLimited` → breaker recovers at the floored ~30s, **not** 900s.
- 61 breaker tests green (`llm-circuit-breaker-wait` + `LlmCircuitBreaker`); `tsc --noEmit` clean; `pnpm build` clean.

### ELI16
https://echo.dawn-tunnel.dev/view/bfae9763-aa22-4486-bc7d-9b7b2e470658?sig=72ade47ad66400b09f8ef262b0a5055fbf5f099684c0b45bb2da1b08b6977743

Tier-1 (internal bug fix, no new route/capability/config). Merge on green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
