### PR TITLE
fix(quota): warn once per missing-file episode, not every getState() call

### DIFF
--- a/src/data/builtin-manifest.json
+++ b/src/data/builtin-manifest.json
@@ -1,7 +1,7 @@
 {
   "$schema": "./builtin-manifest.schema.json",
   "schemaVersion": 1,
-  "generatedAt": "2026-06-03T10:04:51.168Z",
+  "generatedAt": "2026-06-03T10:28:54.696Z",
   "instarVersion": "1.3.217",
   "entryCount": 195,
   "entries": {

--- a/src/monitoring/QuotaTracker.ts
+++ b/src/monitoring/QuotaTracker.ts
@@ -32,6 +32,12 @@ export class QuotaTracker {
   private cachedState: QuotaState | null = null;
   private lastRead: number = 0;
   private readCooldownMs = 5000; // Don't re-read more than every 5s
+  // Warn ONCE per no-file episode, not on every getState() call. The
+  // `!this.cachedState` guard below was ineffective: when the file is absent,
+  // cachedState is never populated, so the warn fired on every call (observed
+  // 902×/day on the gemini-cli agent — pure log spam that drowns real signal).
+  // Re-armed when the file reappears so a later disappearance warns once more.
+  private warnedNoFile = false;
 
   constructor(config: QuotaTrackerConfig) {
     this.config = config;
@@ -51,11 +57,14 @@ export class QuotaTracker {
 
     try {
       if (!fs.existsSync(this.config.quotaFile)) {
-        if (!this.cachedState) {
+        if (!this.warnedNoFile) {
           console.warn('[quota] No quota state file found — all jobs will run (fail-open)');
+          this.warnedNoFile = true;
         }
         return null;
       }
+      // File present again → re-arm the one-shot warning for a future absence.
+      this.warnedNoFile = false;
 
       const raw = fs.readFileSync(this.config.quotaFile, 'utf-8');
       const state: QuotaState = JSON.parse(raw);

--- a/tests/unit/quota-tracker-warnings.test.ts
+++ b/tests/unit/quota-tracker-warnings.test.ts
@@ -83,7 +83,7 @@ describe('QuotaTracker — warnings and staleness', () => {
     expect(tracker.getState()).not.toBeNull();
 
     // 3) File removed again → warns once more (re-armed).
-    fs.rmSync(quotaFile);
+    SafeFsExecutor.safeRmSync(quotaFile, { force: true, operation: 'tests/unit/quota-tracker-warnings.test.ts:re-arm' });
     vi.advanceTimersByTime(6000);
     expect(tracker.getState()).toBeNull();
 

--- a/tests/unit/quota-tracker-warnings.test.ts
+++ b/tests/unit/quota-tracker-warnings.test.ts
@@ -42,6 +42,58 @@ describe('QuotaTracker — warnings and staleness', () => {
     );
   });
 
+  it('warns only ONCE across repeated getState() calls while the file stays missing', () => {
+    // Regression: the old `!this.cachedState` guard was ineffective (cachedState
+    // is never populated when the file is absent), so the warn fired on EVERY
+    // call — 902×/day observed on the gemini-cli agent.
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const tracker = new QuotaTracker({
+      quotaFile,
+      thresholds: { normal: 50, elevated: 70, critical: 85, shutdown: 95 },
+    });
+
+    for (let i = 0; i < 10; i++) {
+      expect(tracker.getState()).toBeNull();
+    }
+
+    const noFileWarns = warnSpy.mock.calls.filter(
+      (c) => typeof c[0] === 'string' && c[0].includes('No quota state file found'),
+    );
+    expect(noFileWarns).toHaveLength(1);
+  });
+
+  it('re-arms the missing-file warning after the file reappears then disappears', () => {
+    vi.useFakeTimers();
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const tracker = new QuotaTracker({
+      quotaFile,
+      thresholds: { normal: 50, elevated: 70, critical: 85, shutdown: 95 },
+    });
+
+    // 1) Absent → warns once.
+    expect(tracker.getState()).toBeNull();
+
+    // 2) File appears (fresh) → reading it re-arms the one-shot flag, no warn.
+    fs.writeFileSync(quotaFile, JSON.stringify({
+      usagePercent: 10,
+      lastUpdated: new Date().toISOString(),
+      recommendation: 'normal',
+    }));
+    vi.advanceTimersByTime(6000); // past the 5s read cooldown so it re-reads
+    expect(tracker.getState()).not.toBeNull();
+
+    // 3) File removed again → warns once more (re-armed).
+    fs.rmSync(quotaFile);
+    vi.advanceTimersByTime(6000);
+    expect(tracker.getState()).toBeNull();
+
+    const noFileWarns = warnSpy.mock.calls.filter(
+      (c) => typeof c[0] === 'string' && c[0].includes('No quota state file found'),
+    );
+    expect(noFileWarns).toHaveLength(2);
+    vi.useRealTimers();
+  });
+
   it('logs warning for stale data', () => {
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
 

--- a/upgrades/next/quota-no-file-warn-once.md
+++ b/upgrades/next/quota-no-file-warn-once.md
@@ -1,0 +1,34 @@
+<!-- bump: patch -->
+
+## What Changed
+
+`QuotaTracker.getState()` now logs the "No quota state file found — all jobs will run (fail-open)"
+warning **once per missing-file episode** instead of on every call.
+
+The previous `if (!this.cachedState)` guard was ineffective for the missing-file case: when the quota
+file is absent, `cachedState` is never populated and `lastRead` is never set, so the read-cooldown
+never engaged and the warning fired on **every** `getState()` — observed at **902 identical lines/day**
+on the gemini-cli agent, drowning real signal in the logs. A one-shot `warnedNoFile` flag now gates the
+warning and re-arms when the file reappears, so a later disappearance still surfaces exactly one warning.
+
+No behavior change: quota is still fail-open when the file is absent. Only the log spam is removed.
+
+## What to Tell Your User
+
+- **Quieter logs**: "An agent with no quota-state file was logging the same 'fail-open' warning hundreds
+  of times a day. It now says it once, so real log signals aren't buried."
+
+## Summary of New Capabilities
+
+| Capability | How to Use |
+|-----------|-----------|
+| One-shot missing-quota-file warning | Automatic — the warning logs once per absence episode instead of per call. |
+
+## Evidence
+
+Verification:
+
+- Unit: warns exactly once across 10 repeated `getState()` calls while the file stays missing;
+  re-arms after the file reappears then disappears (warns twice total across the episode boundary);
+  existing missing/stale/fresh-data warning tests unchanged.
+- 88 quota-tracker tests green; `tsc --noEmit` clean.

--- a/upgrades/quota-no-file-warn-once.eli16.md
+++ b/upgrades/quota-no-file-warn-once.eli16.md
@@ -1,0 +1,19 @@
+# Quota Warning Spam Fix — ELI16
+
+Viewable private artifact:
+https://echo.dawn-tunnel.dev/view/3549e97d-8bcc-4320-9fd0-c70b364dbe5a?sig=c4f780ce95e056f912a8aa959a982ad0baaeef692cfe993dbbf86a27efb168b7
+
+When an agent has no "quota state" file (a small file that tracks how much of its usage budget is
+left), Instar safely lets all scheduled jobs run anyway — and logs a one-line note: "No quota state
+file found — all jobs will run."
+
+The problem: that note was being written on **every single check** — hundreds of times a day (902× on
+one agent). A log full of the same harmless line over and over buries the messages that actually
+matter, like a smoke alarm that beeps every second so you stop hearing it.
+
+The fix makes Instar say it **once** when the file goes missing, then stay quiet until the situation
+changes. If the file later comes back and then disappears again, it'll say it once more. Nothing about
+how jobs run changes — the agent still safely runs everything when there's no budget file. Only the
+noise is gone.
+
+_Tier-1 fix · branch `echo/quota-no-file-warn-once` · 2 new unit tests + 88 quota-tracker tests green._

--- a/upgrades/side-effects/quota-no-file-warn-once.md
+++ b/upgrades/side-effects/quota-no-file-warn-once.md
@@ -1,0 +1,44 @@
+# Side-Effects Review — QuotaTracker one-shot missing-file warning
+
+**Version / slug:** `quota-no-file-warn-once`
+**Date:** `2026-06-03`
+**Author:** `echo`
+**Second-pass reviewer:** `not required`
+
+## Summary of the change
+
+A `warnedNoFile` boolean is added to `QuotaTracker`. The missing-file branch warns only when the flag
+is unset (then sets it); the file-present branch clears it. Net effect: one warning per absence episode
+instead of one per `getState()` call. No change to the value `getState()` returns.
+
+## Decision-point inventory
+
+None. `getState()` still returns `null` when the file is absent or stale (fail-open). The flag only
+gates a `console.warn` side-effect — it never affects the return value or any gating decision.
+
+## 1. Could a real warning be SUPPRESSED?
+
+Only repeats of the *same* condition are suppressed; the first occurrence of each absence episode still
+logs. The flag re-arms when the file reappears, so a file that later disappears warns again — the
+operator never loses the *signal*, only the *spam*. The stale-data and remote-API warnings are
+untouched.
+
+## 2. Could the flag get STUCK (never warn again when it should)?
+
+No. The clear happens on the file-present path (right after `existsSync` passes, before the read), so
+any successful observation of the file re-arms the one-shot. A persistently-missing file warns exactly
+once — which is the intent.
+
+## 3. Concurrency / state
+
+`QuotaTracker` is a per-process singleton with synchronous `getState()`; the flag is plain instance
+state mutated only inside that method. No async interleaving, no shared-file contention introduced.
+
+## 4. Reversibility
+
+Pure in-memory flag, no migration, no persisted state, no config. Revert = revert the two edits.
+
+## Verdict
+
+Bounded, additive, no decision-surface change. Removes a high-volume log-spam (902×/day observed)
+without altering quota behavior.


### PR DESCRIPTION
## QuotaTracker: warn once per missing-file episode (kill the 902×/day log spam)

**Found during the Phase-3 live-Gemini examination** (same sweep that surfaced #711).

### The bug
`QuotaTracker.getState()` logs `[quota] No quota state file found — all jobs will run (fail-open)` whenever the quota file is absent. The intended `if (!this.cachedState)` guard is **ineffective for the missing-file case**: when there's no file, `cachedState` is never populated and `lastRead` is never set, so the top read-cooldown never engages and the warning fires on **every** `getState()` call — **902 identical lines/day** on the gemini-cli agent, burying real log signal. (The stale-data branch correctly sets `lastRead`; the no-file branch forgot.)

### The fix
A one-shot `warnedNoFile` flag: warn once on entering the no-file state; clear it on the file-present path so a later disappearance warns exactly once more. **No behavior change** — quota is still fail-open when the file is absent; only the spam is removed. The value `getState()` returns is identical.

### Tests
- Warns exactly **once** across 10 repeated `getState()` calls while the file stays missing.
- **Re-arms** across a reappear→disappear episode (2 warns total, fake-timed past the read cooldown).
- Existing missing/stale/fresh-data warning tests unchanged. 88 quota-tracker tests green; `tsc` clean.

### ELI16
https://echo.dawn-tunnel.dev/view/3549e97d-8bcc-4320-9fd0-c70b364dbe5a?sig=c4f780ce95e056f912a8aa959a982ad0baaeef692cfe993dbbf86a27efb168b7

Tier-1 (internal logging fix, no route/capability/config). Fleet-wide — affects any agent with no quota state file. Merge on green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
