### PR TITLE
feat(gemini): escalate long capacity blocks (#708 defers but never escalated)

### DIFF
--- a/src/config/ConfigDefaults.ts
+++ b/src/config/ConfigDefaults.ts
@@ -191,6 +191,14 @@ const SHARED_DEFAULTS: Record<string, unknown> = {
       enabled: false,
       overdueAfterMinutes: 120,
     },
+    // GeminiCapacityEscalationMonitor — observe-only escalation when Gemini is
+    // capacity-blocked (deferred by #708) longer than escalateAfterMinutes.
+    // Ships OFF; raises one Attention item per deferral episode, never mutates
+    // the gate. Closes item-3's "escalate, not silently stall" half.
+    geminiCapacityEscalation: {
+      enabled: false,
+      escalateAfterMinutes: 60,
+    },
     // ReleaseReadinessSentinel (docs/specs/RELEASE-READINESS-VISIBILITY-SPEC.md
     // §4.2). Ships OFF — Echo dogfoods first. Repo-gated: inert unless the
     // install has an analyzable instar git repo. Thresholds default to

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -3310,6 +3310,18 @@ export interface MonitoringConfig {
     overdueAfterMinutes?: number;
   };
   /**
+   * GeminiCapacityEscalationMonitor — observe-only escalation when Gemini is
+   * capacity/quota-blocked (deferred by #708's policy) for longer than
+   * escalateAfterMinutes. Raises one Attention item per deferral episode so a
+   * multi-hour block isn't a silent outage. Never mutates the gate. Ships OFF.
+   */
+  geminiCapacityEscalation?: {
+    /** Master kill switch (default: false). */
+    enabled: boolean;
+    /** Escalate only when the remaining defer window >= this many minutes (default: 60). */
+    escalateAfterMinutes?: number;
+  };
+  /**
    * ReleaseReadinessSentinel (docs/specs/RELEASE-READINESS-VISIBILITY-SPEC.md §4.2)
    * — Layer B. A repo-gated dev-environment watchdog: evaluates the canonical
    * `main` of the instar checkout and surfaces a stalled/blocked release as a

--- a/src/data/builtin-manifest.json
+++ b/src/data/builtin-manifest.json
@@ -1,8 +1,8 @@
 {
   "$schema": "./builtin-manifest.schema.json",
   "schemaVersion": 1,
-  "generatedAt": "2026-06-03T10:28:54.696Z",
-  "instarVersion": "1.3.217",
+  "generatedAt": "2026-06-03T11:04:55.407Z",
+  "instarVersion": "1.3.219",
   "entryCount": 195,
   "entries": {
     "hook:session-start": {
@@ -418,7 +418,7 @@
       "type": "route-group",
       "domain": "monitoring",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "3ebec02e2055c35359e8c316f2516e427007a10f3858c987edae682833276aa6",
+      "contentHash": "af8b673a98bab2b47c8782a00013354e7ad340ad4c1558ce47b8811bdf521dab",
       "since": "2025-01-01"
     },
     "route-group:agents": {
@@ -426,7 +426,7 @@
       "type": "route-group",
       "domain": "sessions",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "3ebec02e2055c35359e8c316f2516e427007a10f3858c987edae682833276aa6",
+      "contentHash": "af8b673a98bab2b47c8782a00013354e7ad340ad4c1558ce47b8811bdf521dab",
       "since": "2025-01-01"
     },
     "route-group:backups": {
@@ -434,7 +434,7 @@
       "type": "route-group",
       "domain": "operations",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "3ebec02e2055c35359e8c316f2516e427007a10f3858c987edae682833276aa6",
+      "contentHash": "af8b673a98bab2b47c8782a00013354e7ad340ad4c1558ce47b8811bdf521dab",
       "since": "2025-01-01"
     },
     "route-group:git": {
@@ -442,7 +442,7 @@
       "type": "route-group",
       "domain": "coordination",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "3ebec02e2055c35359e8c316f2516e427007a10f3858c987edae682833276aa6",
+      "contentHash": "af8b673a98bab2b47c8782a00013354e7ad340ad4c1558ce47b8811bdf521dab",
       "since": "2025-01-01"
     },
     "route-group:memory": {
@@ -450,7 +450,7 @@
       "type": "route-group",
       "domain": "memory",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "3ebec02e2055c35359e8c316f2516e427007a10f3858c987edae682833276aa6",
+      "contentHash": "af8b673a98bab2b47c8782a00013354e7ad340ad4c1558ce47b8811bdf521dab",
       "since": "2025-01-01"
     },
     "route-group:semantic": {
@@ -458,7 +458,7 @@
       "type": "route-group",
       "domain": "memory",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "3ebec02e2055c35359e8c316f2516e427007a10f3858c987edae682833276aa6",
+      "contentHash": "af8b673a98bab2b47c8782a00013354e7ad340ad4c1558ce47b8811bdf521dab",
       "since": "2025-01-01"
     },
     "route-group:status": {
@@ -466,7 +466,7 @@
       "type": "route-group",
       "domain": "monitoring",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "3ebec02e2055c35359e8c316f2516e427007a10f3858c987edae682833276aa6",
+      "contentHash": "af8b673a98bab2b47c8782a00013354e7ad340ad4c1558ce47b8811bdf521dab",
       "since": "2025-01-01"
     },
     "route-group:capabilities": {
@@ -474,7 +474,7 @@
       "type": "route-group",
       "domain": "mapping",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "3ebec02e2055c35359e8c316f2516e427007a10f3858c987edae682833276aa6",
+      "contentHash": "af8b673a98bab2b47c8782a00013354e7ad340ad4c1558ce47b8811bdf521dab",
       "since": "2025-01-01"
     },
     "route-group:project-map": {
@@ -482,7 +482,7 @@
       "type": "route-group",
       "domain": "mapping",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "3ebec02e2055c35359e8c316f2516e427007a10f3858c987edae682833276aa6",
+      "contentHash": "af8b673a98bab2b47c8782a00013354e7ad340ad4c1558ce47b8811bdf521dab",
       "since": "2025-01-01"
     },
     "route-group:coherence": {
@@ -490,7 +490,7 @@
       "type": "route-group",
       "domain": "coherence",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "3ebec02e2055c35359e8c316f2516e427007a10f3858c987edae682833276aa6",
+      "contentHash": "af8b673a98bab2b47c8782a00013354e7ad340ad4c1558ce47b8811bdf521dab",
       "since": "2025-01-01"
     },
     "route-group:topic-bindings": {
@@ -498,7 +498,7 @@
       "type": "route-group",
       "domain": "sessions",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "3ebec02e2055c35359e8c316f2516e427007a10f3858c987edae682833276aa6",
+      "contentHash": "af8b673a98bab2b47c8782a00013354e7ad340ad4c1558ce47b8811bdf521dab",
       "since": "2025-01-01"
     },
     "route-group:context": {
@@ -506,7 +506,7 @@
       "type": "route-group",
       "domain": "context",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "3ebec02e2055c35359e8c316f2516e427007a10f3858c987edae682833276aa6",
+      "contentHash": "af8b673a98bab2b47c8782a00013354e7ad340ad4c1558ce47b8811bdf521dab",
       "since": "2025-01-01"
     },
     "route-group:scope-coherence": {
@@ -514,7 +514,7 @@
       "type": "route-group",
       "domain": "coherence",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "3ebec02e2055c35359e8c316f2516e427007a10f3858c987edae682833276aa6",
+      "contentHash": "af8b673a98bab2b47c8782a00013354e7ad340ad4c1558ce47b8811bdf521dab",
       "since": "2025-01-01"
     },
     "route-group:canonical-state": {
@@ -522,7 +522,7 @@
       "type": "route-group",
       "domain": "state",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "3ebec02e2055c35359e8c316f2516e427007a10f3858c987edae682833276aa6",
+      "contentHash": "af8b673a98bab2b47c8782a00013354e7ad340ad4c1558ce47b8811bdf521dab",
       "since": "2025-01-01"
     },
     "route-group:ci": {
@@ -530,7 +530,7 @@
       "type": "route-group",
       "domain": "monitoring",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "3ebec02e2055c35359e8c316f2516e427007a10f3858c987edae682833276aa6",
+      "contentHash": "af8b673a98bab2b47c8782a00013354e7ad340ad4c1558ce47b8811bdf521dab",
       "since": "2025-01-01"
     },
     "route-group:sessions": {
@@ -538,7 +538,7 @@
       "type": "route-group",
       "domain": "sessions",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "3ebec02e2055c35359e8c316f2516e427007a10f3858c987edae682833276aa6",
+      "contentHash": "af8b673a98bab2b47c8782a00013354e7ad340ad4c1558ce47b8811bdf521dab",
       "since": "2025-01-01"
     },
     "route-group:jobs": {
@@ -546,7 +546,7 @@
       "type": "route-group",
       "domain": "scheduling",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "3ebec02e2055c35359e8c316f2516e427007a10f3858c987edae682833276aa6",
+      "contentHash": "af8b673a98bab2b47c8782a00013354e7ad340ad4c1558ce47b8811bdf521dab",
       "since": "2025-01-01"
     },
     "route-group:skip-ledger": {
@@ -554,7 +554,7 @@
       "type": "route-group",
       "domain": "scheduling",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "3ebec02e2055c35359e8c316f2516e427007a10f3858c987edae682833276aa6",
+      "contentHash": "af8b673a98bab2b47c8782a00013354e7ad340ad4c1558ce47b8811bdf521dab",
       "since": "2025-01-01"
     },
     "route-group:telegram": {
@@ -562,7 +562,7 @@
       "type": "route-group",
       "domain": "communication",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "3ebec02e2055c35359e8c316f2516e427007a10f3858c987edae682833276aa6",
+      "contentHash": "af8b673a98bab2b47c8782a00013354e7ad340ad4c1558ce47b8811bdf521dab",
       "since": "2025-01-01"
     },
     "route-group:attention": {
@@ -570,7 +570,7 @@
       "type": "route-group",
       "domain": "communication",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "3ebec02e2055c35359e8c316f2516e427007a10f3858c987edae682833276aa6",
+      "contentHash": "af8b673a98bab2b47c8782a00013354e7ad340ad4c1558ce47b8811bdf521dab",
       "since": "2025-01-01"
     },
     "route-group:relationships": {
@@ -578,7 +578,7 @@
       "type": "route-group",
       "domain": "relationships",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "3ebec02e2055c35359e8c316f2516e427007a10f3858c987edae682833276aa6",
+      "contentHash": "af8b673a98bab2b47c8782a00013354e7ad340ad4c1558ce47b8811bdf521dab",
       "since": "2025-01-01"
     },
     "route-group:feedback": {
@@ -586,7 +586,7 @@
       "type": "route-group",
       "domain": "feedback",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "3ebec02e2055c35359e8c316f2516e427007a10f3858c987edae682833276aa6",
+      "contentHash": "af8b673a98bab2b47c8782a00013354e7ad340ad4c1558ce47b8811bdf521dab",
       "since": "2025-01-01"
     },
     "route-group:updates": {
@@ -594,7 +594,7 @@
       "type": "route-group",
       "domain": "updates",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "3ebec02e2055c35359e8c316f2516e427007a10f3858c987edae682833276aa6",
+      "contentHash": "af8b673a98bab2b47c8782a00013354e7ad340ad4c1558ce47b8811bdf521dab",
       "since": "2025-01-01"
     },
     "route-group:dispatches": {
@@ -602,7 +602,7 @@
       "type": "route-group",
       "domain": "dispatches",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "3ebec02e2055c35359e8c316f2516e427007a10f3858c987edae682833276aa6",
+      "contentHash": "af8b673a98bab2b47c8782a00013354e7ad340ad4c1558ce47b8811bdf521dab",
       "since": "2025-01-01"
     },
     "route-group:quota": {
@@ -610,7 +610,7 @@
       "type": "route-group",
       "domain": "monitoring",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "3ebec02e2055c35359e8c316f2516e427007a10f3858c987edae682833276aa6",
+      "contentHash": "af8b673a98bab2b47c8782a00013354e7ad340ad4c1558ce47b8811bdf521dab",
       "since": "2025-01-01"
     },
     "route-group:publishing": {
@@ -618,7 +618,7 @@
       "type": "route-group",
       "domain": "publishing",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "3ebec02e2055c35359e8c316f2516e427007a10f3858c987edae682833276aa6",
+      "contentHash": "af8b673a98bab2b47c8782a00013354e7ad340ad4c1558ce47b8811bdf521dab",
       "since": "2025-01-01"
     },
     "route-group:private-views": {
@@ -626,7 +626,7 @@
       "type": "route-group",
       "domain": "publishing",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "3ebec02e2055c35359e8c316f2516e427007a10f3858c987edae682833276aa6",
+      "contentHash": "af8b673a98bab2b47c8782a00013354e7ad340ad4c1558ce47b8811bdf521dab",
       "since": "2025-01-01"
     },
     "route-group:tunnel": {
@@ -634,7 +634,7 @@
       "type": "route-group",
       "domain": "networking",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "3ebec02e2055c35359e8c316f2516e427007a10f3858c987edae682833276aa6",
+      "contentHash": "af8b673a98bab2b47c8782a00013354e7ad340ad4c1558ce47b8811bdf521dab",
       "since": "2025-01-01"
     },
     "route-group:events": {
@@ -642,7 +642,7 @@
       "type": "route-group",
       "domain": "networking",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "3ebec02e2055c35359e8c316f2516e427007a10f3858c987edae682833276aa6",
+      "contentHash": "af8b673a98bab2b47c8782a00013354e7ad340ad4c1558ce47b8811bdf521dab",
       "since": "2025-01-01"
     },
     "route-group:evolution": {
@@ -650,7 +650,7 @@
       "type": "route-group",
       "domain": "evolution",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "3ebec02e2055c35359e8c316f2516e427007a10f3858c987edae682833276aa6",
+      "contentHash": "af8b673a98bab2b47c8782a00013354e7ad340ad4c1558ce47b8811bdf521dab",
       "since": "2025-01-01"
     },
     "route-group:watchdog": {
@@ -658,7 +658,7 @@
       "type": "route-group",
       "domain": "monitoring",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "3ebec02e2055c35359e8c316f2516e427007a10f3858c987edae682833276aa6",
+      "contentHash": "af8b673a98bab2b47c8782a00013354e7ad340ad4c1558ce47b8811bdf521dab",
       "since": "2025-01-01"
     },
     "route-group:topic-memory": {
@@ -666,7 +666,7 @@
       "type": "route-group",
       "domain": "memory",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "3ebec02e2055c35359e8c316f2516e427007a10f3858c987edae682833276aa6",
+      "contentHash": "af8b673a98bab2b47c8782a00013354e7ad340ad4c1558ce47b8811bdf521dab",
       "since": "2025-01-01"
     },
     "route-group:state-sync": {
@@ -674,7 +674,7 @@
       "type": "route-group",
       "domain": "coordination",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "3ebec02e2055c35359e8c316f2516e427007a10f3858c987edae682833276aa6",
+      "contentHash": "af8b673a98bab2b47c8782a00013354e7ad340ad4c1558ce47b8811bdf521dab",
       "since": "2025-01-01"
     },
     "route-group:intent": {
@@ -682,7 +682,7 @@
       "type": "route-group",
       "domain": "intent",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "3ebec02e2055c35359e8c316f2516e427007a10f3858c987edae682833276aa6",
+      "contentHash": "af8b673a98bab2b47c8782a00013354e7ad340ad4c1558ce47b8811bdf521dab",
       "since": "2025-01-01"
     },
     "route-group:triage": {
@@ -690,7 +690,7 @@
       "type": "route-group",
       "domain": "safety",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "3ebec02e2055c35359e8c316f2516e427007a10f3858c987edae682833276aa6",
+      "contentHash": "af8b673a98bab2b47c8782a00013354e7ad340ad4c1558ce47b8811bdf521dab",
       "since": "2025-01-01"
     },
     "route-group:operations": {
@@ -698,7 +698,7 @@
       "type": "route-group",
       "domain": "safety",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "3ebec02e2055c35359e8c316f2516e427007a10f3858c987edae682833276aa6",
+      "contentHash": "af8b673a98bab2b47c8782a00013354e7ad340ad4c1558ce47b8811bdf521dab",
       "since": "2025-01-01"
     },
     "route-group:sentinel": {
@@ -706,7 +706,7 @@
       "type": "route-group",
       "domain": "safety",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "3ebec02e2055c35359e8c316f2516e427007a10f3858c987edae682833276aa6",
+      "contentHash": "af8b673a98bab2b47c8782a00013354e7ad340ad4c1558ce47b8811bdf521dab",
       "since": "2025-01-01"
     },
     "route-group:trust": {
@@ -714,7 +714,7 @@
       "type": "route-group",
       "domain": "safety",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "3ebec02e2055c35359e8c316f2516e427007a10f3858c987edae682833276aa6",
+      "contentHash": "af8b673a98bab2b47c8782a00013354e7ad340ad4c1558ce47b8811bdf521dab",
       "since": "2025-01-01"
     },
     "route-group:monitoring": {
@@ -722,7 +722,7 @@
       "type": "route-group",
       "domain": "monitoring",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "3ebec02e2055c35359e8c316f2516e427007a10f3858c987edae682833276aa6",
+      "contentHash": "af8b673a98bab2b47c8782a00013354e7ad340ad4c1558ce47b8811bdf521dab",
       "since": "2025-01-01"
     },
     "route-group:commitments": {
@@ -730,7 +730,7 @@
       "type": "route-group",
       "domain": "commitments",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "3ebec02e2055c35359e8c316f2516e427007a10f3858c987edae682833276aa6",
+      "contentHash": "af8b673a98bab2b47c8782a00013354e7ad340ad4c1558ce47b8811bdf521dab",
       "since": "2025-01-01"
     },
     "route-group:episodes": {
@@ -738,7 +738,7 @@
       "type": "route-group",
       "domain": "memory",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "3ebec02e2055c35359e8c316f2516e427007a10f3858c987edae682833276aa6",
+      "contentHash": "af8b673a98bab2b47c8782a00013354e7ad340ad4c1558ce47b8811bdf521dab",
       "since": "2025-01-01"
     },
     "route-group:messages": {
@@ -746,7 +746,7 @@
       "type": "route-group",
       "domain": "coordination",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "3ebec02e2055c35359e8c316f2516e427007a10f3858c987edae682833276aa6",
+      "contentHash": "af8b673a98bab2b47c8782a00013354e7ad340ad4c1558ce47b8811bdf521dab",
       "since": "2025-01-01"
     },
     "route-group:system-reviews": {
@@ -754,7 +754,7 @@
       "type": "route-group",
       "domain": "monitoring",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "3ebec02e2055c35359e8c316f2516e427007a10f3858c987edae682833276aa6",
+      "contentHash": "af8b673a98bab2b47c8782a00013354e7ad340ad4c1558ce47b8811bdf521dab",
       "since": "2025-01-01"
     },
     "route-group:machine-mesh": {
@@ -770,7 +770,7 @@
       "type": "route-group",
       "domain": "security",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "3ebec02e2055c35359e8c316f2516e427007a10f3858c987edae682833276aa6",
+      "contentHash": "af8b673a98bab2b47c8782a00013354e7ad340ad4c1558ce47b8811bdf521dab",
       "since": "2025-01-01"
     },
     "cli:init": {
@@ -1474,7 +1474,7 @@
       "type": "subsystem",
       "domain": "server",
       "sourcePath": "src/server/AgentServer.ts",
-      "contentHash": "28ca6d76d81717a42a58dd6d72237158a511f72e6764a43eecfeb46e81da0d90",
+      "contentHash": "d1851d4bb663dd524af17cf4c45e143bc441314bbe2b005c5ee1626019b92184",
       "since": "2025-01-01"
     },
     "subsystem:session-manager": {

--- a/src/monitoring/GeminiCapacityEscalationMonitor.ts
+++ b/src/monitoring/GeminiCapacityEscalationMonitor.ts
@@ -1,0 +1,141 @@
+/**
+ * GeminiCapacityEscalationMonitor — observe-only escalation for LONG Gemini
+ * capacity blocks.
+ *
+ * #708's gemini capacity policy correctly DEFERS calls when Gemini reports a
+ * quota reset window (e.g. "retry after 46758s" → ~13h), refusing doomed
+ * subprocesses until the window passes. But it only schedules/defers — it never
+ * ESCALATES. A short defer (a few minutes) is fine to absorb silently; a
+ * multi-HOUR block means the agent/mentee is invisibly unavailable for half a
+ * day, which the operator should know about. Item-3's original intent was
+ * "detect quota → schedule/retry/ESCALATE, not silently stall" — this closes the
+ * missing escalate half.
+ *
+ * Design = observe-and-escalate (NOT a callback threaded into the two low-level
+ * provider call sites): the deferral state is already a queryable module-global
+ * via getGeminiCapacityGate(), so a monitor riding the existing cadence reads it
+ * and raises ONE attention item per deferral episode. Observe-only — it never
+ * mutates the gate, never blocks a call, never auto-recovers. Ships OFF.
+ *
+ * Mirrors ApprenticeshipCycleSlaMonitor: injectable clock + gate reader +
+ * raiseAttention for testability, per-episode dedup, enabled gate.
+ */
+
+import {
+  getGeminiCapacityGate,
+  type GeminiCapacityGate,
+} from '../providers/adapters/gemini-cli/observability/geminiCapacityPolicy.js';
+
+export interface GeminiCapacityEscalationConfig {
+  enabled?: boolean;
+  /** Only escalate when the remaining defer window is at/above this. Default 60. */
+  escalateAfterMinutes?: number;
+}
+
+export interface GeminiCapacityEscalationAttention {
+  id: string;
+  title: string;
+  summary: string;
+  category: string;
+  priority: 'LOW' | 'NORMAL' | 'HIGH' | 'URGENT';
+  sourceContext: string;
+}
+
+export interface GeminiCapacityEscalationMonitorOptions {
+  config?: GeminiCapacityEscalationConfig;
+  now?: () => number;
+  /** Reads the live capacity gate. Defaults to the module-global getGeminiCapacityGate. */
+  gateReader?: (now: number) => GeminiCapacityGate;
+  raiseAttention?: (item: GeminiCapacityEscalationAttention) => Promise<unknown> | unknown;
+}
+
+export interface GeminiCapacityEscalationTickResult {
+  enabled: boolean;
+  blocked: boolean;
+  remainingMs: number;
+  escalated: boolean;
+}
+
+const DEFAULT_ESCALATE_AFTER_MINUTES = 60;
+
+function normalizeMinutes(value: unknown): number {
+  const n = typeof value === 'number' ? value : Number.NaN;
+  if (!Number.isFinite(n) || n <= 0) return DEFAULT_ESCALATE_AFTER_MINUTES;
+  return Math.max(1, Math.floor(n));
+}
+
+export class GeminiCapacityEscalationMonitor {
+  private readonly config: Required<GeminiCapacityEscalationConfig>;
+  private readonly now: () => number;
+  private readonly gateReader: (now: number) => GeminiCapacityGate;
+  private readonly raiseAttention:
+    | ((item: GeminiCapacityEscalationAttention) => Promise<unknown> | unknown)
+    | null;
+  /** The `deferredUntil` value of the episode we've already escalated (dedup key). */
+  private escalatedEpisode: number | null = null;
+
+  constructor(opts: GeminiCapacityEscalationMonitorOptions = {}) {
+    this.config = {
+      enabled: opts.config?.enabled === true,
+      escalateAfterMinutes: normalizeMinutes(opts.config?.escalateAfterMinutes),
+    };
+    this.now = opts.now ?? (() => Date.now());
+    this.gateReader = opts.gateReader ?? getGeminiCapacityGate;
+    this.raiseAttention = opts.raiseAttention ?? null;
+  }
+
+  get enabled(): boolean {
+    return this.config.enabled;
+  }
+
+  /** Live view: is Gemini currently capacity-blocked, and for how much longer. */
+  status(): { blocked: boolean; remainingMs: number; deferredUntil: number | null; reason: string | null } {
+    const gate = this.gateReader(this.now());
+    return {
+      blocked: !gate.allow,
+      remainingMs: gate.allow ? 0 : Math.max(0, gate.retryAfterMs),
+      deferredUntil: gate.deferredUntil,
+      reason: gate.reason,
+    };
+  }
+
+  async tick(): Promise<GeminiCapacityEscalationTickResult> {
+    if (!this.config.enabled) {
+      return { enabled: false, blocked: false, remainingMs: 0, escalated: false };
+    }
+    const gate = this.gateReader(this.now());
+
+    // Not blocked → the episode (if any) is over; re-arm for the next one.
+    if (gate.allow) {
+      this.escalatedEpisode = null;
+      return { enabled: true, blocked: false, remainingMs: 0, escalated: false };
+    }
+
+    const remainingMs = Math.max(0, gate.retryAfterMs);
+    const thresholdMs = this.config.escalateAfterMinutes * 60_000;
+    const longEnough = remainingMs >= thresholdMs;
+    // Dedup per deferral episode, keyed on deferredUntil (a fresh defer → fresh key).
+    const episodeKey = gate.deferredUntil ?? -1;
+    const alreadyEscalated = this.escalatedEpisode === episodeKey;
+
+    if (!longEnough || alreadyEscalated || !this.raiseAttention) {
+      return { enabled: true, blocked: true, remainingMs, escalated: false };
+    }
+
+    this.escalatedEpisode = episodeKey;
+    const remainingMin = Math.round(remainingMs / 60_000);
+    const human = remainingMin >= 120 ? `${Math.round(remainingMin / 60)}h` : `${remainingMin}m`;
+    await this.raiseAttention({
+      id: `gemini-capacity-block-${episodeKey}`,
+      title: 'Gemini capacity-blocked for an extended window',
+      summary:
+        `Gemini is quota/capacity-blocked and deferring all calls for ~${human} ` +
+        `(threshold ${this.config.escalateAfterMinutes}m). The agent/mentee is effectively ` +
+        `unavailable until the window resets. Reason: ${gate.reason ?? 'capacity exhausted'}.`,
+      category: 'gemini-capacity',
+      priority: remainingMin >= 120 ? 'HIGH' : 'NORMAL',
+      sourceContext: 'gemini-capacity-escalation',
+    });
+    return { enabled: true, blocked: true, remainingMs, escalated: true };
+  }
+}

--- a/src/server/AgentServer.ts
+++ b/src/server/AgentServer.ts
@@ -52,6 +52,7 @@ import { CorrectionLedger } from '../monitoring/CorrectionLedger.js';
 import { ApprenticeshipProgram } from '../core/ApprenticeshipProgram.js';
 import { ApprenticeshipCycleStore } from '../monitoring/ApprenticeshipCycleStore.js';
 import { ApprenticeshipCycleSlaMonitor } from '../monitoring/ApprenticeshipCycleSlaMonitor.js';
+import { GeminiCapacityEscalationMonitor } from '../monitoring/GeminiCapacityEscalationMonitor.js';
 import { SafeGitExecutor } from '../core/SafeGitExecutor.js';
 import { createSpecReviewRoutes } from './specReviewRoutes.js';
 import { createUsherRoutes } from './usherRoutes.js';
@@ -171,6 +172,7 @@ export class AgentServer {
   private apprenticeshipProgram: ApprenticeshipProgram | null = null;
   private apprenticeshipCycleStore: ApprenticeshipCycleStore | null = null;
   private apprenticeshipCycleSlaMonitor: ApprenticeshipCycleSlaMonitor | null = null;
+  private geminiCapacityEscalationMonitor: GeminiCapacityEscalationMonitor | null = null;
   // Burn-detection-and-self-heal system (six-phase umbrella spec at
   // docs/specs/token-burn-detection-and-self-heal.md). Lazy-initialised
   // after the TokenLedger comes up — burn detection without a ledger is
@@ -881,6 +883,25 @@ export class AgentServer {
       this.apprenticeshipCycleSlaMonitor = null;
     }
 
+    // Gemini long-capacity-block escalation — observe-only, ships OFF. Reads the
+    // capacity gate module-global; rides the same afterTick cadence below; never
+    // mutates the gate or blocks a call.
+    try {
+      const cfg = options.config.monitoring?.geminiCapacityEscalation;
+      if (cfg?.enabled === true) {
+        const telegram = this.telegramAdapter;
+        this.geminiCapacityEscalationMonitor = new GeminiCapacityEscalationMonitor({
+          config: cfg,
+          raiseAttention: telegram
+            ? (item) => telegram.createAttentionItem(item)
+            : undefined,
+        });
+      }
+    } catch (err) {
+      console.warn('[instar] gemini capacity escalation monitor init failed (non-fatal):', err);
+      this.geminiCapacityEscalationMonitor = null;
+    }
+
     // Routes
     const routeCtx = {
       config: options.config,
@@ -983,6 +1004,7 @@ export class AgentServer {
       apprenticeshipProgram: this.apprenticeshipProgram,
       apprenticeshipCycleStore: this.apprenticeshipCycleStore,
       apprenticeshipCycleSlaMonitor: this.apprenticeshipCycleSlaMonitor,
+      geminiCapacityEscalationMonitor: this.geminiCapacityEscalationMonitor,
       sessionReaper: options.sessionReaper ?? null,
       agentWorktreeReaper: options.agentWorktreeReaper ?? null,
       sleepController: options.sleepController ?? null,
@@ -2120,6 +2142,7 @@ export class AgentServer {
               isIdle: () => this.sessionManager.listRunningSessions().length === 0,
               afterTick: async () => {
                 await this.apprenticeshipCycleSlaMonitor?.tick();
+                await this.geminiCapacityEscalationMonitor?.tick();
               },
             });
             this.tokenLedgerPoller.start();
@@ -2377,6 +2400,7 @@ export class AgentServer {
       this.apprenticeshipCycleStore = null;
     }
     this.apprenticeshipCycleSlaMonitor = null;
+    this.geminiCapacityEscalationMonitor = null;
 
     // Shutdown WebSocket manager first
     if (this.wsManager) {

--- a/src/server/CapabilityIndex.ts
+++ b/src/server/CapabilityIndex.ts
@@ -527,6 +527,17 @@ export const CAPABILITY_INDEX: readonly CapabilityEntry[] = [
     }),
   },
   {
+    key: 'geminiCapacity',
+    prefixes: ['/gemini'],
+    description: 'Gemini capacity — live view of whether Gemini calls are currently deferred by the capacity policy (quota/rate-limit) and for how long. The escalation monitor (observe-only, ships OFF behind monitoring.geminiCapacityEscalation) raises one attention item per long block. Read-only.',
+    build: () => ({
+      enabled: true,
+      endpoints: [
+        'GET /gemini/capacity — live capacity gate: { enabled, blocked, remainingMs, deferredUntil, reason }; 503 when the escalation monitor is disabled',
+      ],
+    }),
+  },
+  {
     key: 'featureMetrics',
     prefixes: ['/metrics'],
     description: 'FeatureMetricsLedger — read-only per-feature LLM observability: per gate/sentinel cost + hit-rate, so tuning the LLM checks is evidence-based. Phase 1a (the funnel tap that feeds it is Phase 1b). Never gates.',

--- a/src/server/routes.ts
+++ b/src/server/routes.ts
@@ -729,6 +729,9 @@ export interface RouteContext {
   apprenticeshipCycleStore?: import('../monitoring/ApprenticeshipCycleStore.js').ApprenticeshipCycleStore | null;
   /** Observe-only overdue-cycle SLA monitor. Null when disabled/unavailable. */
   apprenticeshipCycleSlaMonitor?: import('../monitoring/ApprenticeshipCycleSlaMonitor.js').ApprenticeshipCycleSlaMonitor | null;
+  /** Observe-only Gemini long-capacity-block escalation monitor. Null when disabled.
+   *  → GET /gemini/capacity 503s. */
+  geminiCapacityEscalationMonitor?: import('../monitoring/GeminiCapacityEscalationMonitor.js').GeminiCapacityEscalationMonitor | null;
   /** SessionReaper — pressure-aware idle-session reaper. Null when not wired
    *  (older boot paths). Powers GET /sessions/reaper observability. */
   sessionReaper?: import('../monitoring/SessionReaper.js').SessionReaper | null;
@@ -11608,6 +11611,14 @@ export function createRoutes(ctx: RouteContext): Router {
       ? req.query.instanceId
       : undefined;
     res.json({ overdue: ctx.apprenticeshipCycleSlaMonitor.listOverdue(instanceId) });
+  });
+
+  // GET /gemini/capacity — observe-only live view of the Gemini capacity gate
+  // (whether calls are deferred + remaining window). 503 when the escalation
+  // monitor is disabled/unavailable. Mirrors the sibling observe-only routes.
+  router.get('/gemini/capacity', (_req, res) => {
+    if (!ctx.geminiCapacityEscalationMonitor) { res.status(503).json({ error: 'gemini capacity escalation monitor disabled' }); return; }
+    res.json({ enabled: ctx.geminiCapacityEscalationMonitor.enabled, ...ctx.geminiCapacityEscalationMonitor.status() });
   });
 
   router.get('/apprenticeship/cycles/:id', (req, res) => {

--- a/tests/integration/gemini-capacity-escalation-route.test.ts
+++ b/tests/integration/gemini-capacity-escalation-route.test.ts
@@ -1,0 +1,85 @@
+// safe-fs-allow: test file — SafeFsExecutor used for tmpdir cleanup.
+
+/**
+ * Integration + E2E "feature is alive" coverage for the Gemini capacity
+ * escalation monitor's observability route, booting the REAL AgentServer (the
+ * same path server.ts uses). Verifies both sides of the enabled boundary:
+ *   - disabled (default) → GET /gemini/capacity 503;
+ *   - enabled → 200 with the live gate status shape;
+ *   - Bearer auth required.
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import express from 'express';
+import request from 'supertest';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { AgentServer } from '../../src/server/AgentServer.js';
+import { StateManager } from '../../src/core/StateManager.js';
+import type { InstarConfig } from '../../src/core/types.js';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+
+function mockSessions() {
+  return { listRunningSessions: () => [], getSession: () => null };
+}
+
+function baseConfig(stateDir: string, tmpDir: string, auth: string, enabled: boolean): InstarConfig {
+  return {
+    projectName: 'e2e', projectDir: tmpDir, stateDir, port: 0, authToken: auth,
+    requestTimeoutMs: 10000, version: '0.0.0',
+    sessions: { claudePath: '/usr/bin/echo', maxSessions: 3, defaultMaxDurationMinutes: 30, protectedSessions: [], monitorIntervalMs: 5000 },
+    scheduler: { enabled: false, jobsFile: '', maxParallelJobs: 1 },
+    messaging: [],
+    monitoring: { geminiCapacityEscalation: { enabled, escalateAfterMinutes: 60 } },
+    updates: {},
+  } as InstarConfig;
+}
+
+async function boot(enabled: boolean, auth: string): Promise<{ server: AgentServer; app: express.Express; tmpDir: string }> {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'gemini-cap-esc-'));
+  const stateDir = path.join(tmpDir, '.instar');
+  fs.mkdirSync(path.join(stateDir, 'state', 'sessions'), { recursive: true });
+  fs.mkdirSync(path.join(stateDir, 'logs'), { recursive: true });
+  fs.writeFileSync(path.join(stateDir, 'config.json'), JSON.stringify({ port: 0, projectName: 'e2e', agentName: 'E2E' }));
+  const server = new AgentServer({ config: baseConfig(stateDir, tmpDir, auth, enabled), sessionManager: mockSessions() as any, state: new StateManager(stateDir) });
+  await server.start();
+  return { server, app: server.getApp(), tmpDir };
+}
+
+describe('GET /gemini/capacity (Gemini capacity escalation route)', () => {
+  const AUTH = 'test-gemini-cap';
+  let enabled: Awaited<ReturnType<typeof boot>>;
+  let disabled: Awaited<ReturnType<typeof boot>>;
+
+  beforeAll(async () => {
+    enabled = await boot(true, AUTH);
+    disabled = await boot(false, AUTH);
+  });
+
+  afterAll(async () => {
+    await enabled.server.stop();
+    await disabled.server.stop();
+    SafeFsExecutor.safeRmSync(enabled.tmpDir, { recursive: true, force: true, operation: 'tests/integration/gemini-capacity-escalation-route.test.ts' });
+    SafeFsExecutor.safeRmSync(disabled.tmpDir, { recursive: true, force: true, operation: 'tests/integration/gemini-capacity-escalation-route.test.ts' });
+  });
+
+  const auth = () => ({ Authorization: `Bearer ${AUTH}` });
+
+  it('is alive (200, not 503) through AgentServer when enabled, with the gate status shape', async () => {
+    const res = await request(enabled.app).get('/gemini/capacity').set(auth());
+    expect(res.status).toBe(200);
+    expect(res.body.enabled).toBe(true);
+    expect(typeof res.body.blocked).toBe('boolean');
+    expect(typeof res.body.remainingMs).toBe('number');
+  });
+
+  it('503s when the monitor is disabled (default)', async () => {
+    const res = await request(disabled.app).get('/gemini/capacity').set(auth());
+    expect(res.status).toBe(503);
+  });
+
+  it('requires Bearer auth', async () => {
+    const res = await request(enabled.app).get('/gemini/capacity');
+    expect(res.status).toBe(401);
+  });
+});

--- a/tests/unit/gemini-capacity-escalation-monitor.test.ts
+++ b/tests/unit/gemini-capacity-escalation-monitor.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect, vi } from 'vitest';
+import { GeminiCapacityEscalationMonitor } from '../../src/monitoring/GeminiCapacityEscalationMonitor.js';
+import type { GeminiCapacityGate } from '../../src/providers/adapters/gemini-cli/observability/geminiCapacityPolicy.js';
+
+const NOW = 1_000_000;
+
+function gate(partial: Partial<GeminiCapacityGate>): GeminiCapacityGate {
+  return { allow: true, retryAfterMs: 0, deferredUntil: null, reason: null, ...partial };
+}
+
+function make(opts: {
+  enabled?: boolean;
+  escalateAfterMinutes?: number;
+  gate: GeminiCapacityGate;
+  raise?: ReturnType<typeof vi.fn>;
+}) {
+  return new GeminiCapacityEscalationMonitor({
+    config: { enabled: opts.enabled ?? true, escalateAfterMinutes: opts.escalateAfterMinutes ?? 60 },
+    now: () => NOW,
+    gateReader: () => opts.gate,
+    raiseAttention: opts.raise ?? vi.fn(),
+  });
+}
+
+describe('GeminiCapacityEscalationMonitor', () => {
+  it('disabled → no-op, never escalates', async () => {
+    const raise = vi.fn();
+    const m = new GeminiCapacityEscalationMonitor({
+      config: { enabled: false },
+      now: () => NOW,
+      gateReader: () => gate({ allow: false, retryAfterMs: 13 * 3600_000, deferredUntil: NOW + 13 * 3600_000 }),
+      raiseAttention: raise,
+    });
+    const r = await m.tick();
+    expect(r.enabled).toBe(false);
+    expect(raise).not.toHaveBeenCalled();
+  });
+
+  it('not blocked (gate allows) → no escalation', async () => {
+    const raise = vi.fn();
+    const m = make({ gate: gate({ allow: true }), raise });
+    const r = await m.tick();
+    expect(r.blocked).toBe(false);
+    expect(r.escalated).toBe(false);
+    expect(raise).not.toHaveBeenCalled();
+  });
+
+  it('blocked but SHORT (remaining < threshold) → no escalation', async () => {
+    const raise = vi.fn();
+    // 10 min remaining, threshold 60 min.
+    const m = make({ gate: gate({ allow: false, retryAfterMs: 10 * 60_000, deferredUntil: NOW + 10 * 60_000 }), raise });
+    const r = await m.tick();
+    expect(r.blocked).toBe(true);
+    expect(r.escalated).toBe(false);
+    expect(raise).not.toHaveBeenCalled();
+  });
+
+  it('blocked + LONG (remaining >= threshold) → escalates once with HIGH for multi-hour', async () => {
+    const raise = vi.fn();
+    const m = make({ gate: gate({ allow: false, retryAfterMs: 13 * 3600_000, deferredUntil: NOW + 13 * 3600_000, reason: 'gemini capacity exhausted' }), raise });
+    const r = await m.tick();
+    expect(r.escalated).toBe(true);
+    expect(raise).toHaveBeenCalledTimes(1);
+    const item = raise.mock.calls[0][0];
+    expect(item.sourceContext).toBe('gemini-capacity-escalation');
+    expect(item.priority).toBe('HIGH'); // ~13h >= 120min
+    expect(item.summary).toContain('13h');
+    expect(item.id).toContain(String(NOW + 13 * 3600_000));
+  });
+
+  it('escalation between 1h and 2h is NORMAL priority', async () => {
+    const raise = vi.fn();
+    const m = make({ gate: gate({ allow: false, retryAfterMs: 90 * 60_000, deferredUntil: NOW + 90 * 60_000 }), raise });
+    await m.tick();
+    expect(raise.mock.calls[0][0].priority).toBe('NORMAL'); // 90min < 120min
+  });
+
+  it('dedups across ticks within the same deferral episode (escalates ONCE)', async () => {
+    const raise = vi.fn();
+    const g = gate({ allow: false, retryAfterMs: 5 * 3600_000, deferredUntil: NOW + 5 * 3600_000 });
+    const m = make({ gate: g, raise });
+    await m.tick();
+    await m.tick();
+    await m.tick();
+    expect(raise).toHaveBeenCalledTimes(1);
+  });
+
+  it('re-arms after the block clears, escalates again on a NEW episode', async () => {
+    const raise = vi.fn();
+    let current = gate({ allow: false, retryAfterMs: 4 * 3600_000, deferredUntil: NOW + 4 * 3600_000 });
+    const m = new GeminiCapacityEscalationMonitor({
+      config: { enabled: true, escalateAfterMinutes: 60 },
+      now: () => NOW,
+      gateReader: () => current,
+      raiseAttention: raise,
+    });
+    await m.tick();                                   // episode A → escalate
+    current = gate({ allow: true });                  // cleared
+    await m.tick();                                   // re-arm
+    current = gate({ allow: false, retryAfterMs: 4 * 3600_000, deferredUntil: NOW + 99 * 3600_000 }); // NEW episode
+    await m.tick();                                   // episode B → escalate again
+    expect(raise).toHaveBeenCalledTimes(2);
+  });
+
+  it('status() reports the live block + remaining without escalating', () => {
+    const raise = vi.fn();
+    const m = make({ gate: gate({ allow: false, retryAfterMs: 7 * 3600_000, deferredUntil: NOW + 7 * 3600_000, reason: 'r' }), raise });
+    const s = m.status();
+    expect(s.blocked).toBe(true);
+    expect(s.remainingMs).toBe(7 * 3600_000);
+    expect(raise).not.toHaveBeenCalled();
+  });
+});

--- a/upgrades/gemini-capacity-escalation.eli16.md
+++ b/upgrades/gemini-capacity-escalation.eli16.md
@@ -1,0 +1,23 @@
+# Gemini "Long Block" Escalation — ELI16
+
+Viewable private artifact:
+https://echo.dawn-tunnel.dev/view/e5a1de0b-4e83-4d53-9565-ca23fc04857a?sig=18315449f889314be1565b8f89a7a13bbe9b0182b0cb8c55a6d0a55ff0d70d14
+
+When Gemini runs out of capacity, it tells Instar when to come back — sometimes "in 8 seconds,"
+sometimes "in 13 hours." Instar already knows not to keep hammering Gemini during that window (it waits
+politely instead). That's good.
+
+The gap: it waited **silently**. If Gemini said "come back in 13 hours," the agent (or a mentee agent
+it's supervising) would just be quietly unavailable for half a day, and nobody would know why.
+
+This change adds a quiet watcher: if Gemini is blocked for longer than a set time (default 1 hour),
+Instar raises **one** heads-up — "Gemini is capacity-blocked for about N hours" — so you actually know
+the agent is waiting on a quota reset, not broken or stuck. Short blips stay silent; only long blocks
+get flagged, and only once per block.
+
+It changes nothing about how Gemini calls work — it just turns a silent wait into a visible one. Ships
+off; you turn it on when you want it. There's also a `GET /gemini/capacity` you can check to see if
+Gemini is currently blocked and for how long.
+
+_Tier-1 fix · branch `echo/gemini-capacity-escalation` · 8 unit + 3 integration/e2e tests · completes
+item-3's "escalate, not silently stall" half._

--- a/upgrades/next/gemini-capacity-escalation.md
+++ b/upgrades/next/gemini-capacity-escalation.md
@@ -1,0 +1,44 @@
+<!-- bump: minor -->
+
+## What Changed
+
+Adds `GeminiCapacityEscalationMonitor`, an observe-only signal that surfaces a **long** Gemini
+capacity block instead of letting it be a silent outage.
+
+#708's capacity policy correctly *defers* Gemini calls when Gemini reports a quota reset window
+(e.g. live: "retry after 46758s" ≈ 13h), refusing doomed subprocesses until it clears — but it only
+schedules/defers, it never *escalates*. A short defer is fine to absorb silently; a multi-hour block
+means the agent/mentee is invisibly unavailable for half a day. This monitor reads the existing
+`getGeminiCapacityGate()` module-global on a tick and raises **one** attention item per deferral
+episode when the remaining window exceeds a threshold (default 60 min), re-arming when the block
+clears. It never mutates the gate, never blocks a call. This closes item-3's "escalate, not silently
+stall" half.
+
+Config ships **OFF** (`monitoring.geminiCapacityEscalation.enabled`). When enabled, it rides
+`TokenLedgerPoller`'s existing cadence via the same after-tick hook as the cycle-SLA monitor — no new
+timer. Adds read-only `GET /gemini/capacity` (live gate: `blocked`, `remainingMs`, `deferredUntil`,
+`reason`); 503 when disabled.
+
+## What to Tell Your User
+
+- **No more silent Gemini outages**: "If Gemini hits a long quota block (hours), I can now flag it
+  instead of just going quiet — so you know the agent/mentee is capacity-blocked and for roughly how
+  long. It starts turned off; ask me to enable it."
+
+## Summary of New Capabilities
+
+| Capability | How to Use |
+|-----------|-----------|
+| Long-capacity-block escalation | Enable `monitoring.geminiCapacityEscalation` to get one attention item per multi-hour Gemini block. |
+| Live capacity view | `GET /gemini/capacity` returns `{ enabled, blocked, remainingMs, deferredUntil, reason }` when the monitor is enabled. |
+
+## Evidence
+
+Verification:
+
+- Unit (8): disabled no-op; not-blocked → no escalation; short defer → no; long defer → escalates once
+  (HIGH ≥2h, NORMAL 1–2h); dedup across ticks within an episode; re-arm across a new episode; `status()`
+  reports without escalating.
+- Integration/E2E: `GET /gemini/capacity` through the real AgentServer — 200+shape when enabled, 503
+  when disabled, Bearer auth required.
+- `pnpm lint` (tsc + 4 lints) clean; `pnpm build` clean.

--- a/upgrades/side-effects/gemini-capacity-escalation.md
+++ b/upgrades/side-effects/gemini-capacity-escalation.md
@@ -1,0 +1,50 @@
+# Side-Effects Review — GeminiCapacityEscalationMonitor
+
+**Version / slug:** `gemini-capacity-escalation`
+**Date:** `2026-06-03`
+**Author:** `echo`
+**Second-pass reviewer:** `not required`
+
+## Summary of the change
+
+A new observe-only monitor reads the existing `getGeminiCapacityGate()` module-global on the
+TokenLedgerPoller after-tick cadence; when Gemini is deferred for ≥ `escalateAfterMinutes` (default 60)
+it raises ONE attention item per deferral episode (deduped on `deferredUntil`), re-arming when the
+block clears. Plus a config gate (ships OFF), AgentServer wiring, and a read-only `GET /gemini/capacity`
+route. Nothing else changes; #708's defer behavior is untouched.
+
+## Decision-point inventory
+
+One decision surface: *whether to raise an attention item*. It is bounded — observe-only, never mutates
+the gate, never blocks/retries a call, never auto-recovers. The worst case is an extra attention item;
+it cannot affect Gemini call behavior.
+
+## 1. Attention spam
+
+Mitigated three ways: (a) ships OFF by default; (b) per-episode dedup — at most one item per distinct
+`deferredUntil` value, so repeated ticks within the same block don't re-raise; (c) the `escalateAfterMinutes`
+threshold (default 60) means short, self-healing blips never escalate — only genuinely long blocks do.
+The episode key re-arms only when the gate clears (`allow`), so a fresh block warns once more.
+
+## 2. False escalation
+
+The monitor reads the SAME gate #708 uses to refuse calls, so "blocked" is ground truth, not a guess.
+`remainingMs` is the gate's own `retryAfterMs`. There is no independent classification that could
+disagree with the policy.
+
+## 3. Wiring / cadence
+
+Rides the existing `TokenLedgerPoller.afterTick` alongside the cycle-SLA monitor (awaited in sequence) —
+no new timer, no new process. When the poller is idle (no running sessions) the tick still fires on the
+poller's idle cadence; a missed tick only delays the escalation, never drops the block.
+
+## 4. Migration / reversibility
+
+Config default added to `ConfigDefaults.ts` → automatic `migrateConfig` parity via `applyDefaults` (no
+separate migration block). Default OFF, so existing agents are unaffected until they opt in. Revert =
+revert the commits; no persisted state, no schema change.
+
+## Verdict
+
+Observe-only, bounded, default-OFF, reads ground-truth gate state. The only behavioral change when
+enabled is one attention item per long Gemini block — strictly more visibility, never less availability.


### PR DESCRIPTION
## Gemini capacity policy: escalate LONG blocks instead of silently deferring (#70)

**Grounded in the live Gemini agent this session**: it hit `retry after 46758s` (~13h) — and `#708` correctly *deferred* all calls, but **silently**. The mentee was invisibly unavailable for half a day with no signal. Item-3's original intent was "detect quota → schedule/retry/**escalate**, not silently stall" — `#708` shipped the schedule/defer half; this closes the **escalate** half.

### What it does
`GeminiCapacityEscalationMonitor` (observe-only) reads the existing `getGeminiCapacityGate()` module-global on the `TokenLedgerPoller` after-tick cadence (no new timer — rides alongside the #710 cycle-SLA monitor). When Gemini is deferred for ≥ `escalateAfterMinutes` (default 60), it raises **one** attention item per deferral episode (deduped on `deferredUntil`, re-arming when the block clears). HIGH priority ≥2h, NORMAL 1–2h. **Never** mutates the gate, blocks, or retries — `#708`'s behavior is untouched.

- **Architecture choice**: observe-and-escalate (read the queryable gate global), *not* threading a callback into the two low-level provider call sites — cleaner, mirrors the sentinels.
- **Config** ships **OFF** (`monitoring.geminiCapacityEscalation`); added to `ConfigDefaults.ts` → automatic `migrateConfig` parity via `applyDefaults`.
- **Route** (read-only): `GET /gemini/capacity` → `{ enabled, blocked, remainingMs, deferredUntil, reason }`; 503 when disabled.

### Tests (3 tiers)
- **Unit (8)**: disabled no-op · not-blocked → no escalation · short defer → no · long defer → escalates once (HIGH/NORMAL by length) · dedup across ticks in an episode · re-arm on a new episode · `status()` non-escalating.
- **Integration/E2E**: `GET /gemini/capacity` through the real AgentServer — 200+shape enabled, 503 disabled, auth required.
- `pnpm lint` (tsc + 4 lints) clean · `pnpm build` clean · docs-coverage floor held.

### ELI16
https://echo.dawn-tunnel.dev/view/e5a1de0b-4e83-4d53-9565-ca23fc04857a?sig=18315449f889314be1565b8f89a7a13bbe9b0182b0cb8c55a6d0a55ff0d70d14

Tier-1 (additive observe-only monitor + read-only route + config, ships OFF). Composes with #711 (proportionate breaker on short resets) + #708 (per-call defer). Merge on green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
