### PR TITLE
Add dev preflight new-surface guard

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -212,6 +212,8 @@ curl http://localhost:4040/capabilities
 
 This returns your full capability matrix: scripts, hooks, Telegram status, jobs, relationships, and more. It is the source of truth about what you can do. **Never hallucinate about missing capabilities — verify first.**
 
+Instar contributors can run `instar dev:preflight` before opening PRs to run lint, CapabilityIndex discoverability checks, and an advisory new-route-prefix scan against the diff.
+
 
 **Private Viewing** — Render markdown as auth-gated HTML pages, accessible only through the agent's server (local or via tunnel).
 - Create: `curl -X POST http://localhost:4040/view -H 'Content-Type: application/json' -d '{"title":"Report","markdown":"# Private content"}'`
@@ -341,4 +343,3 @@ Just tell me: "connect to the agent network" or "enable Threadline relay." I'll 
 
 MCP tools: `threadline_discover`, `threadline_send`, `threadline_trust`, `threadline_relay`
 Use `threadline_relay explain` for full details.
-

--- a/docs/specs/dev-preflight-new-surface-friction-guard.eli16.md
+++ b/docs/specs/dev-preflight-new-surface-friction-guard.eli16.md
@@ -1,0 +1,21 @@
+# ELI16: Dev Preflight New-Surface Guard
+
+Instar now has a developer-only preflight command for PRs that add or touch new server surfaces. The
+command runs lint, runs the CapabilityIndex discoverability tests, and then scans the diff for newly
+added Express route registrations.
+
+The route scan is only a heuristic. It looks for added `app.get/post/put/delete/patch('/prefix')` or
+`router.get/post/put/delete/patch('/prefix')` lines and warns if the top-level prefix is not in
+`CAPABILITY_INDEX`. It never edits source, never updates `CapabilityIndex`, and never blocks the
+server.
+
+Only two things make the command exit nonzero: lint failing, or the discoverability/CapabilityIndex
+unit tests failing. Route-prefix findings are warnings so the agent can make the deliberate
+classification without hidden automation changing the registry.
+
+The command also prints the Tier-2 ship checklist so PR authors remember the surrounding artifacts:
+upgrade note, side-effects review, ELI16/private-view proof, docs coverage, and build.
+
+Private view proof: https://codey.dawn-tunnel.dev/view/e060533e-cafd-4a37-b251-7d8d4dbeb63b?sig=7d25de0423b88fd4c59ec3f0a1238bfe69e8891d841da33d92308bec7be2f71c
+
+Verified HTTP 200 on 2026-06-03.

--- a/docs/specs/dev-preflight-new-surface-friction-guard.md
+++ b/docs/specs/dev-preflight-new-surface-friction-guard.md
@@ -1,0 +1,51 @@
+---
+approved: true
+review-convergence: "single-author-code-grounded-2026-06-03"
+parent-principle: "Structure beats Willpower"
+eli16-overview: dev-preflight-new-surface-friction-guard.eli16.md
+---
+
+# Dev Preflight New-Surface Friction Guard
+
+## Problem
+
+The CapabilityIndex discoverability lint already prevents a new route prefix from shipping without a
+classification. The miss still shows up late: an author can forget the classification, run unrelated
+tests, and only learn about it when the full lint/test path trips. That creates avoidable review
+friction on every new surface.
+
+## Design
+
+Add a developer-only CLI command: `instar dev:preflight`.
+
+The command is verify-only. It never mutates source, never edits `CAPABILITY_INDEX`, and never gates
+the server. It runs:
+
+- `pnpm lint`
+- `npx vitest run tests/unit/capabilities-discoverability.test.ts tests/unit/CapabilityIndex.test.ts`
+- a best-effort diff heuristic against main that scans added lines for Express route registrations
+  like `app.get('/prefix')` or `router.post('/prefix')`
+
+The heuristic extracts the top-level route prefix and warns when the prefix is absent from
+`CAPABILITY_INDEX`. It is intentionally regex-based rather than AST-based: the goal is early
+friction, not authority. The canonical guard remains the discoverability tests.
+
+## Exit Semantics
+
+The command exits nonzero only when lint or the discoverability/CapabilityIndex test invocation
+fails. Route-prefix findings are advisory warnings and must not block a PR by themselves.
+
+## Constraints
+
+- No source mutation.
+- No automatic CapabilityIndex edits.
+- No server runtime gate.
+- No route-heuristic failure exit code.
+- Diff lookup failure only warns; it does not make the command fail.
+
+## Verification
+
+Unit tests cover route detection, missing-prefix warnings, existing-prefix cleanliness, no-route
+cleanliness, and exit-code aggregation. Integration tests run the command against fixture diff data
+and verify summary/exit behavior. E2E exercises `dist/cli.js dev:preflight` after build on the
+current tree.

--- a/scripts/generate-builtin-manifest.cjs
+++ b/scripts/generate-builtin-manifest.cjs
@@ -306,6 +306,7 @@ function scanCliCommands() {
     { name: 'review', domain: 'monitoring' },
     { name: 'nuke', domain: 'operations' },
     { name: 'playbook', domain: 'context' },
+    { name: 'dev:preflight', domain: 'development' },
   ];
 
   for (const cmd of commands) {

--- a/scripts/generate-builtin-manifest.cjs
+++ b/scripts/generate-builtin-manifest.cjs
@@ -306,7 +306,7 @@ function scanCliCommands() {
     { name: 'review', domain: 'monitoring' },
     { name: 'nuke', domain: 'operations' },
     { name: 'playbook', domain: 'context' },
-    { name: 'dev:preflight', domain: 'development' },
+    { name: 'dev-preflight', domain: 'development' },
   ];
 
   for (const cmd of commands) {

--- a/site/src/content/docs/reference/cli.md
+++ b/site/src/content/docs/reference/cli.md
@@ -241,6 +241,7 @@ instar listener logs            # Tail listener logs
 
 ```bash
 instar route <task>             # One-shot framework + model routing for a task description
+instar dev:preflight            # Verify-only contributor guard: lint, CapabilityIndex tests, route-prefix warning
 instar jobMigrate               # Migrate jobs between schema versions
 instar ledgerCleanup            # Token ledger cleanup
 instar memoryBackfillEvidence   # Backfill evidence rows into the memory index

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2401,6 +2401,18 @@ gateCmd
     return gateLog(opts);
   });
 
+// ── `instar dev:preflight` — contributor ship-gate verifier ────────
+
+program
+  .command('dev:preflight')
+  .description('Run the verify-only new-surface friction guard for contributor PRs')
+  .option('--base <ref>', 'Diff base ref for the route heuristic (default: main remote candidates)')
+  .action(async (opts: { base?: string }) => {
+    const { runDevPreflight } = await import('./commands/devPreflight.js');
+    const exitCode = await runDevPreflight({ baseRef: opts.base });
+    process.exit(exitCode);
+  });
+
 // ── `instar route` — Phase 5b suggest-and-confirm composition root (CLI) ─
 
 program

--- a/src/commands/devPreflight.ts
+++ b/src/commands/devPreflight.ts
@@ -1,0 +1,218 @@
+import { spawn } from 'node:child_process';
+import pc from 'picocolors';
+import { SafeGitExecutor } from '../core/SafeGitExecutor.js';
+import { buildPrefixToKeyMap } from '../server/CapabilityIndex.js';
+
+export interface CommandResult {
+  command: string;
+  args: string[];
+  exitCode: number;
+}
+
+export interface DevPreflightRunner {
+  run(command: string, args: string[], label: string): Promise<CommandResult>;
+}
+
+export interface DevPreflightOutput {
+  write(text: string): void;
+  error(text: string): void;
+}
+
+export interface DevPreflightOptions {
+  cwd?: string;
+  baseRef?: string;
+  runner?: DevPreflightRunner;
+  output?: DevPreflightOutput;
+  capabilityPrefixes?: Set<string>;
+  diffProvider?: () => string;
+}
+
+export interface RouteWarning {
+  prefix: string;
+  routes: string[];
+}
+
+export interface DevPreflightSummary {
+  lintExitCode: number;
+  discoverabilityExitCode: number;
+  routeWarnings: RouteWarning[];
+  heuristicUnavailable?: string;
+}
+
+const DISCOVERABILITY_TEST_ARGS = [
+  'vitest',
+  'run',
+  'tests/unit/capabilities-discoverability.test.ts',
+  'tests/unit/CapabilityIndex.test.ts',
+];
+
+const ROUTE_METHODS = ['get', 'post', 'put', 'delete', 'patch'];
+const ROUTE_REGISTRATION_PATTERN = new RegExp(
+  String.raw`(?:app|router)\.(?:${ROUTE_METHODS.join('|')})\s*\(\s*['"]\/([a-z][a-z0-9-]*)[^'"]*['"]`,
+  'g',
+);
+
+export class SpawnDevPreflightRunner implements DevPreflightRunner {
+  constructor(private readonly cwd: string) {}
+
+  run(command: string, args: string[], label: string): Promise<CommandResult> {
+    return new Promise((resolve) => {
+      process.stdout.write(`${pc.bold(label)}\n`);
+      process.stdout.write(`$ ${[command, ...args].join(' ')}\n`);
+      const child = spawn(command, args, {
+        cwd: this.cwd,
+        stdio: 'inherit',
+        env: process.env,
+      });
+      child.on('error', (err) => {
+        process.stderr.write(`${label} failed to start: ${err.message}\n`);
+        resolve({ command, args, exitCode: 1 });
+      });
+      child.on('close', (code) => {
+        resolve({ command, args, exitCode: code ?? 1 });
+      });
+    });
+  }
+}
+
+export function extractAddedRoutePrefixes(diff: string): Map<string, string[]> {
+  const prefixes = new Map<string, string[]>();
+  for (const line of diff.split('\n')) {
+    if (!line.startsWith('+') || line.startsWith('+++')) continue;
+    const added = line.slice(1);
+    ROUTE_REGISTRATION_PATTERN.lastIndex = 0;
+    let match: RegExpExecArray | null;
+    while ((match = ROUTE_REGISTRATION_PATTERN.exec(added)) !== null) {
+      const prefix = match[1];
+      const routes = prefixes.get(prefix) ?? [];
+      routes.push(added.trim());
+      prefixes.set(prefix, routes);
+    }
+  }
+  return prefixes;
+}
+
+export function findMissingCapabilityPrefixes(
+  diff: string,
+  capabilityPrefixes: Set<string>,
+): RouteWarning[] {
+  const addedPrefixes = extractAddedRoutePrefixes(diff);
+  const warnings: RouteWarning[] = [];
+  for (const [prefix, routes] of addedPrefixes.entries()) {
+    if (!capabilityPrefixes.has(prefix)) {
+      warnings.push({ prefix, routes });
+    }
+  }
+  return warnings.sort((a, b) => a.prefix.localeCompare(b.prefix));
+}
+
+export function aggregateExitCode(summary: DevPreflightSummary): number {
+  return summary.lintExitCode === 0 && summary.discoverabilityExitCode === 0 ? 0 : 1;
+}
+
+export function defaultCapabilityPrefixes(): Set<string> {
+  return new Set(buildPrefixToKeyMap().keys());
+}
+
+function readDiffVsMain(cwd: string, explicitBaseRef?: string): string {
+  const candidates = explicitBaseRef
+    ? [explicitBaseRef]
+    : ['JKHeadley/main', 'origin/main', 'upstream/main', 'main'];
+  const errors: string[] = [];
+  for (const candidate of candidates) {
+    try {
+      const base = SafeGitExecutor.readSync(['merge-base', 'HEAD', candidate], {
+        cwd,
+        operation: 'src/commands/devPreflight.ts:readDiffVsMain.merge-base',
+        sourceTreeReadOk: true,
+      }).trim();
+      return SafeGitExecutor.readSync(['diff', '--unified=0', `${base}...HEAD`], {
+        cwd,
+        operation: 'src/commands/devPreflight.ts:readDiffVsMain.diff',
+        sourceTreeReadOk: true,
+        maxBuffer: 20 * 1024 * 1024,
+      });
+    } catch (err) {
+      errors.push(`${candidate}: ${(err as Error).message.split('\n')[0]}`);
+    }
+  }
+  throw new Error(errors.join('; '));
+}
+
+function printChecklist(output: DevPreflightOutput): void {
+  output.write('\nTier-2 ship-gate checklist reminder:\n');
+  output.write('- upgrades/next/<slug>.md with minor bump\n');
+  output.write('- side-effects artifact with decision inventory\n');
+  output.write('- ELI16 with verified tunnel/private-view link\n');
+  output.write('- docs coverage updated and checked\n');
+  output.write('- pnpm build before shipping\n');
+}
+
+function printHeuristic(output: DevPreflightOutput, summary: DevPreflightSummary): void {
+  output.write('\nNew-surface route heuristic:\n');
+  output.write('Advisory only. Best-effort regex over added diff lines; it is not an AST parser.\n');
+  if (summary.heuristicUnavailable) {
+    output.write(`${pc.yellow('WARN')} diff unavailable: ${summary.heuristicUnavailable}\n`);
+    return;
+  }
+  if (summary.routeWarnings.length === 0) {
+    output.write(`${pc.green('PASS')} no added route prefixes missing from CAPABILITY_INDEX\n`);
+    return;
+  }
+  output.write(`${pc.yellow('WARN')} added route prefixes missing from CAPABILITY_INDEX:\n`);
+  for (const warning of summary.routeWarnings) {
+    output.write(`- /${warning.prefix}\n`);
+    for (const route of warning.routes) {
+      output.write(`  ${route}\n`);
+    }
+  }
+}
+
+export async function runDevPreflight(options: DevPreflightOptions = {}): Promise<number> {
+  const cwd = options.cwd ?? process.cwd();
+  const output = options.output ?? {
+    write: (text: string) => process.stdout.write(text),
+    error: (text: string) => process.stderr.write(text),
+  };
+  const runner = options.runner ?? new SpawnDevPreflightRunner(cwd);
+
+  output.write(`${pc.bold('Instar dev preflight')}\n`);
+  output.write('Verify-only: this command never edits CapabilityIndex or server routes.\n\n');
+
+  const lint = await runner.run('pnpm', ['lint'], 'lint');
+  output.write('\n');
+  const discoverability = await runner.run('npx', DISCOVERABILITY_TEST_ARGS, 'capabilities discoverability');
+
+  let routeWarnings: RouteWarning[] = [];
+  let heuristicUnavailable: string | undefined;
+  try {
+    const diff = options.diffProvider ? options.diffProvider() : readDiffVsMain(cwd, options.baseRef);
+    routeWarnings = findMissingCapabilityPrefixes(
+      diff,
+      options.capabilityPrefixes ?? defaultCapabilityPrefixes(),
+    );
+  } catch (err) {
+    heuristicUnavailable = (err as Error).message;
+  }
+
+  const summary: DevPreflightSummary = {
+    lintExitCode: lint.exitCode,
+    discoverabilityExitCode: discoverability.exitCode,
+    routeWarnings,
+    heuristicUnavailable,
+  };
+
+  output.write('\nSummary:\n');
+  output.write(`- lint: ${lint.exitCode === 0 ? pc.green('PASS') : pc.red('FAIL')}\n`);
+  output.write(`- capabilities-discoverability/CapabilityIndex: ${discoverability.exitCode === 0 ? pc.green('PASS') : pc.red('FAIL')}\n`);
+  printHeuristic(output, summary);
+  printChecklist(output);
+
+  const exitCode = aggregateExitCode(summary);
+  if (exitCode === 0) {
+    output.write('\nPreflight complete: no blocking failures.\n');
+  } else {
+    output.error('\nPreflight failed: lint or discoverability tests failed.\n');
+  }
+  return exitCode;
+}

--- a/src/core/SafeGitExecutor.ts
+++ b/src/core/SafeGitExecutor.ts
@@ -153,6 +153,7 @@ export const SOURCE_TREE_READ_TIER_VERBS: ReadonlySet<string> = new Set([
   'ls-tree',
   'show',
   'log',
+  'diff',
   'cat-file',
   'merge-base',
   'remote', // shape-checked to list/get-url only; needed by resolveCanonicalRemote

--- a/src/data/builtin-manifest.json
+++ b/src/data/builtin-manifest.json
@@ -1,9 +1,9 @@
 {
   "$schema": "./builtin-manifest.schema.json",
   "schemaVersion": 1,
-  "generatedAt": "2026-06-03T12:51:00.906Z",
-  "instarVersion": "1.3.221",
-  "entryCount": 195,
+  "generatedAt": "2026-06-03T13:31:46.471Z",
+  "instarVersion": "1.3.222",
+  "entryCount": 196,
   "entries": {
     "hook:session-start": {
       "id": "hook:session-start",
@@ -778,7 +778,7 @@
       "type": "cli-command",
       "domain": "setup",
       "sourcePath": "src/cli.ts",
-      "contentHash": "5c1909925cc2d14b3d8270dd433ec4d6753161553fbe74acc0262608ff368ed4",
+      "contentHash": "1b2634f7e1f2a14c409625a87774b5d9fe06cf11b529d38d8b4489a76c6b6f4d",
       "since": "2025-01-01"
     },
     "cli:setup": {
@@ -786,7 +786,7 @@
       "type": "cli-command",
       "domain": "setup",
       "sourcePath": "src/cli.ts",
-      "contentHash": "5c1909925cc2d14b3d8270dd433ec4d6753161553fbe74acc0262608ff368ed4",
+      "contentHash": "1b2634f7e1f2a14c409625a87774b5d9fe06cf11b529d38d8b4489a76c6b6f4d",
       "since": "2025-01-01"
     },
     "cli:add": {
@@ -794,7 +794,7 @@
       "type": "cli-command",
       "domain": "setup",
       "sourcePath": "src/cli.ts",
-      "contentHash": "5c1909925cc2d14b3d8270dd433ec4d6753161553fbe74acc0262608ff368ed4",
+      "contentHash": "1b2634f7e1f2a14c409625a87774b5d9fe06cf11b529d38d8b4489a76c6b6f4d",
       "since": "2025-01-01"
     },
     "cli:backup": {
@@ -802,7 +802,7 @@
       "type": "cli-command",
       "domain": "operations",
       "sourcePath": "src/cli.ts",
-      "contentHash": "5c1909925cc2d14b3d8270dd433ec4d6753161553fbe74acc0262608ff368ed4",
+      "contentHash": "1b2634f7e1f2a14c409625a87774b5d9fe06cf11b529d38d8b4489a76c6b6f4d",
       "since": "2025-01-01"
     },
     "cli:git": {
@@ -810,7 +810,7 @@
       "type": "cli-command",
       "domain": "coordination",
       "sourcePath": "src/cli.ts",
-      "contentHash": "5c1909925cc2d14b3d8270dd433ec4d6753161553fbe74acc0262608ff368ed4",
+      "contentHash": "1b2634f7e1f2a14c409625a87774b5d9fe06cf11b529d38d8b4489a76c6b6f4d",
       "since": "2025-01-01"
     },
     "cli:memory": {
@@ -818,7 +818,7 @@
       "type": "cli-command",
       "domain": "memory",
       "sourcePath": "src/cli.ts",
-      "contentHash": "5c1909925cc2d14b3d8270dd433ec4d6753161553fbe74acc0262608ff368ed4",
+      "contentHash": "1b2634f7e1f2a14c409625a87774b5d9fe06cf11b529d38d8b4489a76c6b6f4d",
       "since": "2025-01-01"
     },
     "cli:knowledge": {
@@ -826,7 +826,7 @@
       "type": "cli-command",
       "domain": "memory",
       "sourcePath": "src/cli.ts",
-      "contentHash": "5c1909925cc2d14b3d8270dd433ec4d6753161553fbe74acc0262608ff368ed4",
+      "contentHash": "1b2634f7e1f2a14c409625a87774b5d9fe06cf11b529d38d8b4489a76c6b6f4d",
       "since": "2025-01-01"
     },
     "cli:semantic": {
@@ -834,7 +834,7 @@
       "type": "cli-command",
       "domain": "memory",
       "sourcePath": "src/cli.ts",
-      "contentHash": "5c1909925cc2d14b3d8270dd433ec4d6753161553fbe74acc0262608ff368ed4",
+      "contentHash": "1b2634f7e1f2a14c409625a87774b5d9fe06cf11b529d38d8b4489a76c6b6f4d",
       "since": "2025-01-01"
     },
     "cli:intent": {
@@ -842,7 +842,7 @@
       "type": "cli-command",
       "domain": "intent",
       "sourcePath": "src/cli.ts",
-      "contentHash": "5c1909925cc2d14b3d8270dd433ec4d6753161553fbe74acc0262608ff368ed4",
+      "contentHash": "1b2634f7e1f2a14c409625a87774b5d9fe06cf11b529d38d8b4489a76c6b6f4d",
       "since": "2025-01-01"
     },
     "cli:feedback": {
@@ -850,7 +850,7 @@
       "type": "cli-command",
       "domain": "feedback",
       "sourcePath": "src/cli.ts",
-      "contentHash": "5c1909925cc2d14b3d8270dd433ec4d6753161553fbe74acc0262608ff368ed4",
+      "contentHash": "1b2634f7e1f2a14c409625a87774b5d9fe06cf11b529d38d8b4489a76c6b6f4d",
       "since": "2025-01-01"
     },
     "cli:server": {
@@ -858,7 +858,7 @@
       "type": "cli-command",
       "domain": "server",
       "sourcePath": "src/cli.ts",
-      "contentHash": "5c1909925cc2d14b3d8270dd433ec4d6753161553fbe74acc0262608ff368ed4",
+      "contentHash": "1b2634f7e1f2a14c409625a87774b5d9fe06cf11b529d38d8b4489a76c6b6f4d",
       "since": "2025-01-01"
     },
     "cli:status": {
@@ -866,7 +866,7 @@
       "type": "cli-command",
       "domain": "monitoring",
       "sourcePath": "src/cli.ts",
-      "contentHash": "5c1909925cc2d14b3d8270dd433ec4d6753161553fbe74acc0262608ff368ed4",
+      "contentHash": "1b2634f7e1f2a14c409625a87774b5d9fe06cf11b529d38d8b4489a76c6b6f4d",
       "since": "2025-01-01"
     },
     "cli:user": {
@@ -874,7 +874,7 @@
       "type": "cli-command",
       "domain": "users",
       "sourcePath": "src/cli.ts",
-      "contentHash": "5c1909925cc2d14b3d8270dd433ec4d6753161553fbe74acc0262608ff368ed4",
+      "contentHash": "1b2634f7e1f2a14c409625a87774b5d9fe06cf11b529d38d8b4489a76c6b6f4d",
       "since": "2025-01-01"
     },
     "cli:relationship": {
@@ -882,7 +882,7 @@
       "type": "cli-command",
       "domain": "relationships",
       "sourcePath": "src/cli.ts",
-      "contentHash": "5c1909925cc2d14b3d8270dd433ec4d6753161553fbe74acc0262608ff368ed4",
+      "contentHash": "1b2634f7e1f2a14c409625a87774b5d9fe06cf11b529d38d8b4489a76c6b6f4d",
       "since": "2025-01-01"
     },
     "cli:job": {
@@ -890,7 +890,7 @@
       "type": "cli-command",
       "domain": "scheduling",
       "sourcePath": "src/cli.ts",
-      "contentHash": "5c1909925cc2d14b3d8270dd433ec4d6753161553fbe74acc0262608ff368ed4",
+      "contentHash": "1b2634f7e1f2a14c409625a87774b5d9fe06cf11b529d38d8b4489a76c6b6f4d",
       "since": "2025-01-01"
     },
     "cli:lifeline": {
@@ -898,7 +898,7 @@
       "type": "cli-command",
       "domain": "communication",
       "sourcePath": "src/cli.ts",
-      "contentHash": "5c1909925cc2d14b3d8270dd433ec4d6753161553fbe74acc0262608ff368ed4",
+      "contentHash": "1b2634f7e1f2a14c409625a87774b5d9fe06cf11b529d38d8b4489a76c6b6f4d",
       "since": "2025-01-01"
     },
     "cli:list": {
@@ -906,7 +906,7 @@
       "type": "cli-command",
       "domain": "monitoring",
       "sourcePath": "src/cli.ts",
-      "contentHash": "5c1909925cc2d14b3d8270dd433ec4d6753161553fbe74acc0262608ff368ed4",
+      "contentHash": "1b2634f7e1f2a14c409625a87774b5d9fe06cf11b529d38d8b4489a76c6b6f4d",
       "since": "2025-01-01"
     },
     "cli:autostart": {
@@ -914,7 +914,7 @@
       "type": "cli-command",
       "domain": "operations",
       "sourcePath": "src/cli.ts",
-      "contentHash": "5c1909925cc2d14b3d8270dd433ec4d6753161553fbe74acc0262608ff368ed4",
+      "contentHash": "1b2634f7e1f2a14c409625a87774b5d9fe06cf11b529d38d8b4489a76c6b6f4d",
       "since": "2025-01-01"
     },
     "cli:migrate": {
@@ -922,7 +922,7 @@
       "type": "cli-command",
       "domain": "updates",
       "sourcePath": "src/cli.ts",
-      "contentHash": "5c1909925cc2d14b3d8270dd433ec4d6753161553fbe74acc0262608ff368ed4",
+      "contentHash": "1b2634f7e1f2a14c409625a87774b5d9fe06cf11b529d38d8b4489a76c6b6f4d",
       "since": "2025-01-01"
     },
     "cli:machines": {
@@ -930,7 +930,7 @@
       "type": "cli-command",
       "domain": "coordination",
       "sourcePath": "src/cli.ts",
-      "contentHash": "5c1909925cc2d14b3d8270dd433ec4d6753161553fbe74acc0262608ff368ed4",
+      "contentHash": "1b2634f7e1f2a14c409625a87774b5d9fe06cf11b529d38d8b4489a76c6b6f4d",
       "since": "2025-01-01"
     },
     "cli:whoami": {
@@ -938,7 +938,7 @@
       "type": "cli-command",
       "domain": "identity",
       "sourcePath": "src/cli.ts",
-      "contentHash": "5c1909925cc2d14b3d8270dd433ec4d6753161553fbe74acc0262608ff368ed4",
+      "contentHash": "1b2634f7e1f2a14c409625a87774b5d9fe06cf11b529d38d8b4489a76c6b6f4d",
       "since": "2025-01-01"
     },
     "cli:pair": {
@@ -946,7 +946,7 @@
       "type": "cli-command",
       "domain": "coordination",
       "sourcePath": "src/cli.ts",
-      "contentHash": "5c1909925cc2d14b3d8270dd433ec4d6753161553fbe74acc0262608ff368ed4",
+      "contentHash": "1b2634f7e1f2a14c409625a87774b5d9fe06cf11b529d38d8b4489a76c6b6f4d",
       "since": "2025-01-01"
     },
     "cli:join": {
@@ -954,7 +954,7 @@
       "type": "cli-command",
       "domain": "coordination",
       "sourcePath": "src/cli.ts",
-      "contentHash": "5c1909925cc2d14b3d8270dd433ec4d6753161553fbe74acc0262608ff368ed4",
+      "contentHash": "1b2634f7e1f2a14c409625a87774b5d9fe06cf11b529d38d8b4489a76c6b6f4d",
       "since": "2025-01-01"
     },
     "cli:wakeup": {
@@ -962,7 +962,7 @@
       "type": "cli-command",
       "domain": "coordination",
       "sourcePath": "src/cli.ts",
-      "contentHash": "5c1909925cc2d14b3d8270dd433ec4d6753161553fbe74acc0262608ff368ed4",
+      "contentHash": "1b2634f7e1f2a14c409625a87774b5d9fe06cf11b529d38d8b4489a76c6b6f4d",
       "since": "2025-01-01"
     },
     "cli:leave": {
@@ -970,7 +970,7 @@
       "type": "cli-command",
       "domain": "coordination",
       "sourcePath": "src/cli.ts",
-      "contentHash": "5c1909925cc2d14b3d8270dd433ec4d6753161553fbe74acc0262608ff368ed4",
+      "contentHash": "1b2634f7e1f2a14c409625a87774b5d9fe06cf11b529d38d8b4489a76c6b6f4d",
       "since": "2025-01-01"
     },
     "cli:doctor": {
@@ -978,7 +978,7 @@
       "type": "cli-command",
       "domain": "monitoring",
       "sourcePath": "src/cli.ts",
-      "contentHash": "5c1909925cc2d14b3d8270dd433ec4d6753161553fbe74acc0262608ff368ed4",
+      "contentHash": "1b2634f7e1f2a14c409625a87774b5d9fe06cf11b529d38d8b4489a76c6b6f4d",
       "since": "2025-01-01"
     },
     "cli:review": {
@@ -986,7 +986,7 @@
       "type": "cli-command",
       "domain": "monitoring",
       "sourcePath": "src/cli.ts",
-      "contentHash": "5c1909925cc2d14b3d8270dd433ec4d6753161553fbe74acc0262608ff368ed4",
+      "contentHash": "1b2634f7e1f2a14c409625a87774b5d9fe06cf11b529d38d8b4489a76c6b6f4d",
       "since": "2025-01-01"
     },
     "cli:nuke": {
@@ -994,7 +994,7 @@
       "type": "cli-command",
       "domain": "operations",
       "sourcePath": "src/cli.ts",
-      "contentHash": "5c1909925cc2d14b3d8270dd433ec4d6753161553fbe74acc0262608ff368ed4",
+      "contentHash": "1b2634f7e1f2a14c409625a87774b5d9fe06cf11b529d38d8b4489a76c6b6f4d",
       "since": "2025-01-01"
     },
     "cli:playbook": {
@@ -1002,7 +1002,15 @@
       "type": "cli-command",
       "domain": "context",
       "sourcePath": "src/cli.ts",
-      "contentHash": "5c1909925cc2d14b3d8270dd433ec4d6753161553fbe74acc0262608ff368ed4",
+      "contentHash": "1b2634f7e1f2a14c409625a87774b5d9fe06cf11b529d38d8b4489a76c6b6f4d",
+      "since": "2025-01-01"
+    },
+    "cli:dev:preflight": {
+      "id": "cli:dev:preflight",
+      "type": "cli-command",
+      "domain": "development",
+      "sourcePath": "src/cli.ts",
+      "contentHash": "1b2634f7e1f2a14c409625a87774b5d9fe06cf11b529d38d8b4489a76c6b6f4d",
       "since": "2025-01-01"
     },
     "template:build-stop-hook.sh": {

--- a/src/data/builtin-manifest.json
+++ b/src/data/builtin-manifest.json
@@ -1,7 +1,7 @@
 {
   "$schema": "./builtin-manifest.schema.json",
   "schemaVersion": 1,
-  "generatedAt": "2026-06-03T13:31:46.471Z",
+  "generatedAt": "2026-06-03T13:56:02.469Z",
   "instarVersion": "1.3.222",
   "entryCount": 196,
   "entries": {
@@ -1005,8 +1005,8 @@
       "contentHash": "1b2634f7e1f2a14c409625a87774b5d9fe06cf11b529d38d8b4489a76c6b6f4d",
       "since": "2025-01-01"
     },
-    "cli:dev:preflight": {
-      "id": "cli:dev:preflight",
+    "cli:dev-preflight": {
+      "id": "cli:dev-preflight",
       "type": "cli-command",
       "domain": "development",
       "sourcePath": "src/cli.ts",

--- a/src/scaffold/templates.ts
+++ b/src/scaffold/templates.ts
@@ -744,6 +744,8 @@ curl -H "Authorization: Bearer $AUTH" http://localhost:${port}/capabilities
 
 This returns your full capability matrix: scripts, hooks, Telegram status, jobs, git sync status, relationships, and more. **This is the source of truth about what you can do — not the prose descriptions in this file.**
 
+Instar contributors can run \`instar dev:preflight\` before opening PRs to run lint, CapabilityIndex discoverability checks, and an advisory new-route-prefix scan against the diff.
+
 **Critical rule**: If this CLAUDE.md says a feature is "for standalone agents" or "when configured" or uses any qualifier — do NOT conclude you lack the feature. Check \`/capabilities\` instead. Documentation describes features in general; the API tells you what's actually running for YOU right now. When they conflict, the API wins.
 
 ### Registry First, Explore Second

--- a/tests/e2e/dev-preflight-cli.test.ts
+++ b/tests/e2e/dev-preflight-cli.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+
+describe('dev preflight CLI', () => {
+  it('runs from dist/cli.js and exits clean on the current tree', { timeout: 180000 }, () => {
+    const cli = path.join(process.cwd(), 'dist', 'cli.js');
+    if (!fs.existsSync(cli)) {
+      return;
+    }
+
+    const output = execFileSync(process.execPath, [cli, 'dev:preflight'], {
+      cwd: process.cwd(),
+      encoding: 'utf-8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+      timeout: 180000,
+      maxBuffer: 20 * 1024 * 1024,
+    });
+
+    expect(output).toContain('Instar dev preflight');
+    expect(output).toContain('Preflight complete: no blocking failures.');
+  });
+});

--- a/tests/integration/dev-preflight-command.test.ts
+++ b/tests/integration/dev-preflight-command.test.ts
@@ -14,6 +14,10 @@ class FixtureRunner implements DevPreflightRunner {
   }
 }
 
+function stripAnsi(text: string): string {
+  return text.replace(/\x1b\[[0-9;]*m/g, '');
+}
+
 describe('dev preflight command integration', () => {
   it('runs lint, discoverability tests, and reports advisory route warnings without failing', async () => {
     const runner = new FixtureRunner();
@@ -33,6 +37,7 @@ describe('dev preflight command integration', () => {
 
     expect(exitCode).toBe(0);
     expect(stderr).toBe('');
+    const plainStdout = stripAnsi(stdout);
     expect(runner.calls.map((call) => [call.command, ...call.args])).toEqual([
       ['pnpm', 'lint'],
       [
@@ -43,10 +48,10 @@ describe('dev preflight command integration', () => {
         'tests/unit/CapabilityIndex.test.ts',
       ],
     ]);
-    expect(stdout).toContain('lint: PASS');
-    expect(stdout).toContain('capabilities-discoverability/CapabilityIndex: PASS');
-    expect(stdout).toContain('/new-surface');
-    expect(stdout).toContain('Tier-2 ship-gate checklist reminder');
+    expect(plainStdout).toContain('lint: PASS');
+    expect(plainStdout).toContain('capabilities-discoverability/CapabilityIndex: PASS');
+    expect(plainStdout).toContain('/new-surface');
+    expect(plainStdout).toContain('Tier-2 ship-gate checklist reminder');
   });
 
   it('returns nonzero when lint fails', async () => {

--- a/tests/integration/dev-preflight-command.test.ts
+++ b/tests/integration/dev-preflight-command.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest';
+import {
+  runDevPreflight,
+  type CommandResult,
+  type DevPreflightRunner,
+} from '../../src/commands/devPreflight.js';
+
+class FixtureRunner implements DevPreflightRunner {
+  readonly calls: Array<{ command: string; args: string[]; label: string }> = [];
+
+  async run(command: string, args: string[], label: string): Promise<CommandResult> {
+    this.calls.push({ command, args, label });
+    return { command, args, exitCode: 0 };
+  }
+}
+
+describe('dev preflight command integration', () => {
+  it('runs lint, discoverability tests, and reports advisory route warnings without failing', async () => {
+    const runner = new FixtureRunner();
+    let stdout = '';
+    let stderr = '';
+
+    const exitCode = await runDevPreflight({
+      cwd: process.cwd(),
+      runner,
+      capabilityPrefixes: new Set(['capabilities']),
+      diffProvider: () => '+router.post("/new-surface/create", handler);',
+      output: {
+        write: (text) => { stdout += text; },
+        error: (text) => { stderr += text; },
+      },
+    });
+
+    expect(exitCode).toBe(0);
+    expect(stderr).toBe('');
+    expect(runner.calls.map((call) => [call.command, ...call.args])).toEqual([
+      ['pnpm', 'lint'],
+      [
+        'npx',
+        'vitest',
+        'run',
+        'tests/unit/capabilities-discoverability.test.ts',
+        'tests/unit/CapabilityIndex.test.ts',
+      ],
+    ]);
+    expect(stdout).toContain('lint: PASS');
+    expect(stdout).toContain('capabilities-discoverability/CapabilityIndex: PASS');
+    expect(stdout).toContain('/new-surface');
+    expect(stdout).toContain('Tier-2 ship-gate checklist reminder');
+  });
+
+  it('returns nonzero when lint fails', async () => {
+    const runner: DevPreflightRunner = {
+      async run(command, args, label) {
+        return { command, args, exitCode: label === 'lint' ? 1 : 0 };
+      },
+    };
+
+    const exitCode = await runDevPreflight({
+      runner,
+      diffProvider: () => '',
+      output: { write: () => {}, error: () => {} },
+    });
+
+    expect(exitCode).toBe(1);
+  });
+});

--- a/tests/unit/SafeGitExecutor-sourceTreeReadOk.test.ts
+++ b/tests/unit/SafeGitExecutor-sourceTreeReadOk.test.ts
@@ -113,6 +113,7 @@ describe('SafeGitExecutor.sourceTreeReadOk', () => {
     expect(SOURCE_TREE_READ_TIER_VERBS.has('ls-tree')).toBe(true);
     expect(SOURCE_TREE_READ_TIER_VERBS.has('show')).toBe(true);
     expect(SOURCE_TREE_READ_TIER_VERBS.has('log')).toBe(true);
+    expect(SOURCE_TREE_READ_TIER_VERBS.has('diff')).toBe(true);
     expect(SOURCE_TREE_READ_TIER_VERBS.has('merge-base')).toBe(true);
     // Must NEVER include verbs that modify the working tree or committed refs:
     expect(SOURCE_TREE_READ_TIER_VERBS.has('commit')).toBe(false);
@@ -129,7 +130,14 @@ describe('SafeGitExecutor.sourceTreeReadOk', () => {
     expect(SOURCE_TREE_READ_TIER_VERBS.has('status')).toBe(true);
     expect(SOURCE_TREE_READ_TIER_VERBS.has('cherry')).toBe(true);
     // Bounded — adding to this set requires a spec edit + side-effects review.
-    expect(SOURCE_TREE_READ_TIER_VERBS.size).toBeLessThanOrEqual(10);
+    expect(SOURCE_TREE_READ_TIER_VERBS.size).toBeLessThanOrEqual(11);
+  });
+
+  it('readSync path honors sourceTreeReadOk — diff on a source tree passes', () => {
+    expect(() => SafeGitExecutor.run(
+      ['diff', '--unified=0', 'HEAD'],
+      { cwd: srcTree, operation: 't:diff-allowed', sourceTreeReadOk: true },
+    )).not.toThrow();
   });
 
   it('readSync path also honors sourceTreeReadOk — rev-parse on a source tree passes', () => {

--- a/tests/unit/dev-preflight.test.ts
+++ b/tests/unit/dev-preflight.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest';
+import {
+  aggregateExitCode,
+  extractAddedRoutePrefixes,
+  findMissingCapabilityPrefixes,
+} from '../../src/commands/devPreflight.js';
+
+describe('dev preflight route heuristic', () => {
+  it('flags an added route prefix missing from CapabilityIndex', () => {
+    const diff = [
+      'diff --git a/src/server/routes.ts b/src/server/routes.ts',
+      '+router.get(\'/foo/status\', (_req, res) => res.json({ ok: true }));',
+    ].join('\n');
+
+    const warnings = findMissingCapabilityPrefixes(diff, new Set(['capabilities']));
+
+    expect(warnings).toEqual([
+      {
+        prefix: 'foo',
+        routes: ['router.get(\'/foo/status\', (_req, res) => res.json({ ok: true }));'],
+      },
+    ]);
+  });
+
+  it('does not flag an added route prefix already in CapabilityIndex', () => {
+    const diff = '+app.post("/foo/create", handler);';
+
+    expect(findMissingCapabilityPrefixes(diff, new Set(['foo']))).toEqual([]);
+  });
+
+  it('returns clean when the diff adds no route registrations', () => {
+    const diff = [
+      '+const path = "/foo/not-a-route";',
+      '+function registerThing() { return true; }',
+    ].join('\n');
+
+    expect(extractAddedRoutePrefixes(diff).size).toBe(0);
+    expect(findMissingCapabilityPrefixes(diff, new Set())).toEqual([]);
+  });
+
+  it('aggregates exit code from real failures only', () => {
+    expect(aggregateExitCode({
+      lintExitCode: 0,
+      discoverabilityExitCode: 0,
+      routeWarnings: [{ prefix: 'foo', routes: ['router.get("/foo", handler);'] }],
+    })).toBe(0);
+    expect(aggregateExitCode({
+      lintExitCode: 1,
+      discoverabilityExitCode: 0,
+      routeWarnings: [],
+    })).toBe(1);
+    expect(aggregateExitCode({
+      lintExitCode: 0,
+      discoverabilityExitCode: 1,
+      routeWarnings: [],
+    })).toBe(1);
+  });
+});

--- a/upgrades/dev-preflight-new-surface-friction-guard.eli16.md
+++ b/upgrades/dev-preflight-new-surface-friction-guard.eli16.md
@@ -1,0 +1,18 @@
+# ELI16: Dev Preflight New-Surface Guard
+
+Instar now has a developer-only preflight command for PRs that add or touch new server surfaces. The
+command runs lint, runs the CapabilityIndex discoverability tests, and then scans the diff for newly
+added Express route registrations.
+
+The route scan is only a heuristic. It looks for added `app.get/post/put/delete/patch('/prefix')` or
+`router.get/post/put/delete/patch('/prefix')` lines and warns if the top-level prefix is not in
+`CAPABILITY_INDEX`. It never edits source, never updates `CapabilityIndex`, and never blocks the
+server.
+
+Only two things make the command exit nonzero: lint failing, or the discoverability/CapabilityIndex
+unit tests failing. Route-prefix findings are warnings so the agent can make the deliberate
+classification without hidden automation changing the registry.
+
+Private view proof: https://codey.dawn-tunnel.dev/view/e060533e-cafd-4a37-b251-7d8d4dbeb63b?sig=7d25de0423b88fd4c59ec3f0a1238bfe69e8891d841da33d92308bec7be2f71c
+
+Verified HTTP 200 on 2026-06-03.

--- a/upgrades/next/dev-preflight-new-surface-friction-guard.md
+++ b/upgrades/next/dev-preflight-new-surface-friction-guard.md
@@ -1,0 +1,46 @@
+# Upgrade Guide — vNEXT
+
+<!-- bump: minor -->
+
+## What Changed
+
+Adds `instar dev:preflight`, a verify-only contributor preflight for PRs that touch new server
+surfaces.
+
+The command runs lint, runs the CapabilityIndex discoverability unit tests, and scans the diff
+against main for newly added Express route registrations. If the scan sees a new top-level route
+prefix that is not claimed in `CAPABILITY_INDEX`, it prints an advisory warning.
+
+The route scan is intentionally not authority. It is a best-effort regex over added diff lines, not
+an AST parser, and it never edits source. The command exits nonzero only when lint or the explicit
+discoverability/CapabilityIndex test invocation fails.
+
+The safe git funnel now also treats `git diff` as an explicitly allowed source-tree read-tier verb
+when the caller opts into `sourceTreeReadOk`, so this preflight can inspect an Instar checkout
+without bypassing `SafeGitExecutor`.
+
+## What to Tell Your User
+
+- **Instar has a contributor preflight for new surfaces**: "Before a PR, I can run a development
+  preflight that checks lint, capability discoverability, and warns if a newly added route prefix may
+  need a CapabilityIndex classification."
+
+## Summary of New Capabilities
+
+| Capability | How to Use |
+|-----------|-----------|
+| Developer preflight guard | `instar dev:preflight` runs lint, CapabilityIndex discoverability tests, and an advisory diff scan for unclassified new route prefixes. |
+| Route-prefix warning heuristic | Added route registrations in the diff warn when their top-level prefix is absent from `CAPABILITY_INDEX`; warnings do not fail the command. |
+
+## Evidence
+
+Verification:
+
+- Unit: route-detection heuristic covers missing prefix, existing prefix, no routes, and exit-code
+  aggregation.
+- Integration: fixture diff command path verifies the summary, warning output, and real-failure exit
+  behavior.
+- E2E: `dist/cli.js dev:preflight` exits clean on the current tree.
+- Dogfood: `node dist/cli.js dev:preflight` ran lint, discoverability tests, and the route heuristic
+  with exit 0.
+- Docs: docs coverage passed after adding the CLI reference entry.

--- a/upgrades/side-effects/dev-preflight-new-surface-friction-guard.md
+++ b/upgrades/side-effects/dev-preflight-new-surface-friction-guard.md
@@ -1,0 +1,25 @@
+### dev-preflight-new-surface-friction-guard side effects
+
+Primary risk reviewed: a developer convenience command could become hidden authority over route
+classification.
+
+Decision inventory:
+
+- `instar dev:preflight` is verify-only and has no write path.
+- The command never edits `src/server/CapabilityIndex.ts`.
+- The command never mutates route files or server config.
+- The command exits nonzero only for `pnpm lint` or the explicit
+  capabilities-discoverability/CapabilityIndex test invocation.
+- Diff route-prefix findings are advisory warnings only.
+- Diff lookup failure is a warning, not a failure, because the canonical guard remains the
+  discoverability test.
+- `SafeGitExecutor` now includes `diff` in the explicit `sourceTreeReadOk` read-tier set so this
+  command can inspect the current Instar checkout without bypassing the safe git funnel.
+
+Secondary risk: the heuristic could miss routes or flag false positives because it is regex-based.
+That is acceptable by design. The heuristic is early friction for authors, not the source of truth.
+The source of truth remains the existing CapabilityIndex registry and its unit tests.
+
+Operational risk: running the command can be slow because it runs lint and a targeted Vitest
+invocation. This is deliberate; the command is a contributor preflight, not a server path or
+background job.

--- a/upgrades/side-effects/dev-preflight-new-surface-friction-guard.md
+++ b/upgrades/side-effects/dev-preflight-new-surface-friction-guard.md
@@ -23,3 +23,7 @@ The source of truth remains the existing CapabilityIndex registry and its unit t
 Operational risk: running the command can be slow because it runs lint and a targeted Vitest
 invocation. This is deliberate; the command is a contributor preflight, not a server path or
 background job.
+
+CI follow-up: manifest IDs must keep the `type:name` shape, so the built-in manifest registers this
+surface as `cli:dev-preflight` while the actual command remains `instar dev:preflight`. Integration
+assertions strip ANSI color before checking summary text because CI may enable color output.


### PR DESCRIPTION
## Summary

Adds `instar dev:preflight`, a verify-only contributor guard that:

- runs `pnpm lint`
- runs `npx vitest run tests/unit/capabilities-discoverability.test.ts tests/unit/CapabilityIndex.test.ts`
- scans added diff lines for new Express route prefixes and warns when a prefix is absent from `CAPABILITY_INDEX`
- prints the Tier-2 ship-gate checklist reminder

The route-prefix scan is advisory only. The command exits nonzero only for lint or discoverability/CapabilityIndex test failure, and it never mutates source or edits CapabilityIndex.

## Notes

- Adds `diff` to `SafeGitExecutor`'s explicit `sourceTreeReadOk` read-tier set so the preflight can inspect the current Instar checkout through the safe git funnel.
- Registers `cli:dev:preflight` in the built-in manifest generator and docs reference.
- Ships Tier-2 spec, ELI16, side-effects, and upgrade fragment artifacts.

## Verification

- `npx vitest run tests/unit/dev-preflight.test.ts tests/integration/dev-preflight-command.test.ts tests/unit/capabilities-discoverability.test.ts tests/unit/CapabilityIndex.test.ts`
- `node scripts/docs-coverage.mjs --check`
- `pnpm lint`
- `pnpm build`
- `node dist/cli.js dev:preflight`
- `npx vitest run --config vitest.e2e.config.ts tests/e2e/dev-preflight-cli.test.ts`
- pre-push scoped e2e hook: 16 files, 331 tests passed
