### PR TITLE
fix(codex): re-point fast tier off retired gpt-5.2 → gpt-5.4-mini

### DIFF
--- a/src/core/frameworkSessionLaunch.ts
+++ b/src/core/frameworkSessionLaunch.ts
@@ -62,10 +62,13 @@ export function resolveModelForFramework(
     // sensible Codex equivalent (haiku→fast, sonnet→balanced,
     // opus→capable) so an unported call site doesn't immediately
     // crash for a Codex agent.
-    // Confirmed light/medium/heavy mapping (Justin, 2026-05-23): the ChatGPT
-    // subscription meters by token-weighted credits, so non-reasoning gpt-5.2
-    // is genuinely the lightest. See models.ts for the full rationale.
-    if (key === 'fast' || key === 'haiku') return 'gpt-5.2';        // light — non-reasoning
+    // Light/medium/heavy mapping. NOTE (2026-06-03): OpenAI retired gpt-5.2 from
+    // the ChatGPT-account Codex surface (it now 400s "not supported … with a
+    // ChatGPT account"), so the `fast` tier moved off it onto the cheapest model
+    // still accepted — gpt-5.4-mini (== balanced). Keep this in lockstep with
+    // src/providers/adapters/openai-codex/models.ts (the single source of the
+    // full rationale + the drift-resilience follow-up).
+    if (key === 'fast' || key === 'haiku') return 'gpt-5.4-mini';   // light tier — gpt-5.2 retired 2026-06-03
     if (key === 'balanced' || key === 'sonnet') return 'gpt-5.4-mini'; // medium — cheapest reasoning
     if (key === 'capable' || key === 'opus') return 'gpt-5.5';      // heavy — frontier reasoning
     return modelOrTier;

--- a/src/providers/adapters/openai-codex/models.ts
+++ b/src/providers/adapters/openai-codex/models.ts
@@ -31,31 +31,47 @@ import type { ModelTier } from '../../types.js';
  *   Pattern holds: plain gpt-5.x models work; `-codex` suffix is API-only
  *   EXCEPT the grandfathered gpt-5.3-codex.
  *
+ * ⚠ RE-PROBED AGAIN 2026-06-03 (live, against Justin's ChatGPT subscription;
+ * triggered by codey's CommitmentSentinel failing fleet-wide). OpenAI has
+ * since RETIRED gpt-5.2 from the ChatGPT-account Codex surface — it now 400s:
+ *   "The 'gpt-5.2' model is not supported when using Codex with a ChatGPT account."
+ * This silently broke EVERY cheap (`fast`-tier) internal codex call — gates,
+ * tone-gate, classification, CommitmentSentinel — on every codex agent, since
+ * `fast` was hardcoded to gpt-5.2 below.
+ *   ✅ still working 2026-06-03: gpt-5.4, gpt-5.4-mini   (both replied to a trivial probe)
+ *   ❌ now rejected 2026-06-03:  gpt-5.2                 (the change since 2026-05-23)
+ * gpt-5.2 was the ONLY non-reasoning model. With it gone there is no longer a
+ * cheap non-reasoning option, so `fast` is moved to the cheapest model still
+ * accepted — gpt-5.4-mini (already the `balanced` choice). Consequence: `fast`
+ * now equals `balanced`, and cheap-call token burn rises (a reasoning model
+ * burns ~50–70x more than the old gpt-5.2 on a trivial prompt). This is an
+ * unavoidable cost regression — a working model beats a 400-ing one — but it
+ * is worth surfacing for the codex rate-limit picture (cf the self-inflicted
+ * cheap-call 429 volume). The structural fix (validate the resolved model
+ * against a known-good set + auto-fall-back on a "not supported" 400, so the
+ * NEXT retirement self-heals instead of breaking the fleet) is a follow-up —
+ * see the Drift-risk note below; this change just stops the active bleeding.
+ *
  * TOKEN-BURN observation (same trivial "reply OK" prompt, 2026-05-23):
  *   gpt-5.2 = 103 tokens · gpt-5.3-codex = 5,574 · gpt-5.5 = 7,399.
  *   The reasoning models (5.3-codex, 5.5) burn ~50-70x more than gpt-5.2
- *   even on a trivial prompt (reasoning overhead). This is why the `fast`
- *   tier — used by cheap internal calls (gates, tone-gate, classification)
- *   — MUST stay on gpt-5.2: routing those through a reasoning model would
- *   torch quota. The reasoning burn is only worth it for real session work.
+ *   even on a trivial prompt (reasoning overhead). gpt-5.2 was the cheap
+ *   non-reasoning workhorse for the `fast` tier — now retired (see the
+ *   2026-06-03 note above), so the cost advantage is gone fleet-wide.
  *
  * Default tier choices below favor the subscription path. The light/medium/
  * heavy mapping was confirmed by Justin on 2026-05-23 after deep research into
  * how the ChatGPT subscription meters usage (token-weighted credits in a 5h +
  * weekly window — so token-burn IS the right metric, not just an API proxy):
- *   - fast:     gpt-5.2 (LIGHT — non-reasoning, answers directly with ~0
- *                thinking tokens; cheapest working model; keep for all cheap
- *                internal LLM calls — gates, tone, classification. ~50-70x
- *                cheaper than the reasoning models even on a trivial prompt.
- *                Use the BASE gpt-5.2, NOT gpt-5.2-codex — the latter is a
- *                reasoning model and loses the non-reasoning cost advantage.)
+ *   - fast:     gpt-5.4-mini (was gpt-5.2 until its 2026-06-03 retirement; now
+ *                the cheapest model still accepted on the ChatGPT account. NOTE:
+ *                this is a *reasoning* model — the old non-reasoning cheap path
+ *                is gone, so fast == balanced until a cheaper working model
+ *                appears or the drift-resilient fallback lands.)
  *   - balanced: gpt-5.4-mini (MEDIUM — the cheapest *reasoning* model; a
  *                small worker gear for real-but-light work, e.g. searching a
- *                codebase or skimming a file. "mini" = small *within the
- *                reasoning tier*, not lighter than non-reasoning gpt-5.2 — it
- *                still emits reasoning tokens on trivial prompts, so it is the
- *                WRONG choice for the fast tier. Confirmed working on the
- *                ChatGPT subscription, live-tested 2026-05-23.)
+ *                codebase or skimming a file. Confirmed working on the
+ *                ChatGPT subscription, live-tested 2026-05-23 and 2026-06-03.)
  *   - capable:  gpt-5.5 (HEAVY — newest frontier reasoning model + Codex CLI's
  *                own default; the main interactive session resolves here.
  *                Reserve for hard problems + the user's main chat.)
@@ -67,22 +83,28 @@ import type { ModelTier } from '../../types.js';
  * overhead (see openai/codex#19996), not reasoning — the effort delta only
  * shows on complex tasks. codey's ~/.codex/config.toml sets medium (OpenAI's
  * recommended default); gpt-5.5 also uses fewer reasoning tokens than prior
- * models at the same effort. The real cheap-call quota win is the fast tier
- * (gpt-5.2), not turning reasoning down on a heavyweight model.
+ * models at the same effort.
  *
  * Callers on the API-key path can override these per-call to access the
  * full model surface (gpt-5-codex, etc.) by passing a raw model name
  * instead of a tier.
  *
- * Drift risk: model availability changes regularly. This map is a
- * Rule-3 surface and the codex event-normalizer canary catches the
- * resulting upstream errors (auth-classified error events), but the
- * authoritative-name check belongs in a dedicated canary — Phase 5
- * follow-up.
+ * Drift risk: model availability changes regularly (the gpt-5.2 retirement on
+ * 2026-06-03 is the second such break after the 2026-04-14 `-codex` retirement).
+ * This map is a Rule-3 surface and the codex event-normalizer canary catches the
+ * resulting upstream errors (auth-classified error events), but the authoritative
+ * fix — validate the resolved name against a known-good set and auto-fall-back on
+ * a "not supported" 400 so a retirement self-heals — belongs in a dedicated
+ * canary/fallback. Follow-up (the structural companion to this stop-the-bleeding
+ * re-point).
  */
 const TIER_TO_MODEL: Record<ModelTier, string> = {
-  // light — non-reasoning, ~0 thinking tokens; all cheap internal calls.
-  fast: 'gpt-5.2',
+  // fast — cheapest model accepted on the ChatGPT account. Was non-reasoning
+  // gpt-5.2 until OpenAI retired it (2026-06-03, see header); gpt-5.2 now 400s
+  // and broke every cheap codex call. No non-reasoning option remains, so this
+  // is gpt-5.4-mini (== balanced) — a reasoning model, raising cheap-call burn,
+  // but a working model beats a rejected one.
+  fast: 'gpt-5.4-mini',
   // medium — cheapest reasoning model; everyday light work / worker subagents.
   balanced: 'gpt-5.4-mini',
   // heavy — frontier reasoning model; hard problems + the user's main chat.

--- a/tests/unit/StallTriageNurse.test.ts
+++ b/tests/unit/StallTriageNurse.test.ts
@@ -164,7 +164,7 @@ describe('StallTriageNurse', () => {
         config: { ...TEST_CONFIG, framework: 'codex-cli', model: 'haiku' },
       });
       expect((nurse as unknown as { config: { model: string } }).config.model)
-        .toBe('gpt-5.2');
+        .toBe('gpt-5.4-mini'); // haiku → light tier; gpt-5.2 retired from ChatGPT-account Codex 2026-06-03
     });
     it('codex-cli: raw Codex model id passes through verbatim', () => {
       const nurse = new StallTriageNurse(deps, {

--- a/tests/unit/codex-model-tier-resolution.test.ts
+++ b/tests/unit/codex-model-tier-resolution.test.ts
@@ -1,0 +1,61 @@
+/**
+ * Codex model-tier resolution + retired-model regression guard.
+ *
+ * Context: OpenAI retired `gpt-5.2` from the ChatGPT-account Codex surface on
+ * 2026-06-03 (it now returns HTTP 400 "not supported when using Codex with a
+ * ChatGPT account"). Both codex tier maps — the adapter resolver
+ * (openai-codex/models.ts) and the session-launch resolver
+ * (frameworkSessionLaunch.ts) — hardcoded the `fast`/`haiku` tier to gpt-5.2,
+ * which silently broke EVERY cheap codex call (CommitmentSentinel, tone-gate,
+ * classification) on every codex agent. These tests pin the corrected mapping
+ * and guard the retired name so a future edit can't reintroduce it.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { resolveCliModelFlag } from '../../src/providers/adapters/openai-codex/models.js';
+import { resolveModelForFramework } from '../../src/core/frameworkSessionLaunch.js';
+
+const RETIRED_ON_CHATGPT_ACCOUNT = 'gpt-5.2';
+
+describe('codex model-tier resolution (post gpt-5.2 retirement 2026-06-03)', () => {
+  describe('adapter resolver — resolveCliModelFlag (intel / one-shot path)', () => {
+    it('fast tier resolves to the cheapest still-accepted model (gpt-5.4-mini)', () => {
+      expect(resolveCliModelFlag('fast')).toBe('gpt-5.4-mini');
+    });
+    it('balanced tier resolves to gpt-5.4-mini', () => {
+      expect(resolveCliModelFlag('balanced')).toBe('gpt-5.4-mini');
+    });
+    it('capable tier resolves to gpt-5.5', () => {
+      expect(resolveCliModelFlag('capable')).toBe('gpt-5.5');
+    });
+    it('undefined falls back to the balanced default', () => {
+      expect(resolveCliModelFlag(undefined)).toBe('gpt-5.4-mini');
+    });
+    it('a raw model id passes through verbatim', () => {
+      expect(resolveCliModelFlag('gpt-5.4')).toBe('gpt-5.4');
+    });
+  });
+
+  describe('session-launch resolver — resolveModelForFramework(codex-cli, ...)', () => {
+    it('fast tier resolves to gpt-5.4-mini', () => {
+      expect(resolveModelForFramework('codex-cli', 'fast')).toBe('gpt-5.4-mini');
+    });
+    it('legacy haiku alias resolves to gpt-5.4-mini (not the retired model)', () => {
+      expect(resolveModelForFramework('codex-cli', 'haiku')).toBe('gpt-5.4-mini');
+    });
+    it('balanced/capable tiers are unchanged', () => {
+      expect(resolveModelForFramework('codex-cli', 'balanced')).toBe('gpt-5.4-mini');
+      expect(resolveModelForFramework('codex-cli', 'capable')).toBe('gpt-5.5');
+    });
+  });
+
+  describe('retired-model regression guard', () => {
+    it('NO tier in EITHER resolver produces the retired gpt-5.2', () => {
+      for (const tier of ['fast', 'balanced', 'capable', 'haiku', 'sonnet', 'opus']) {
+        expect(resolveCliModelFlag(tier)).not.toBe(RETIRED_ON_CHATGPT_ACCOUNT);
+        expect(resolveModelForFramework('codex-cli', tier)).not.toBe(RETIRED_ON_CHATGPT_ACCOUNT);
+      }
+      expect(resolveCliModelFlag(undefined)).not.toBe(RETIRED_ON_CHATGPT_ACCOUNT);
+    });
+  });
+});

--- a/tests/unit/frameworkSessionLaunch.test.ts
+++ b/tests/unit/frameworkSessionLaunch.test.ts
@@ -404,15 +404,15 @@ describe('frameworkSessionLaunch.resolveModelForFramework', () => {
 
   describe('codex-cli', () => {
     it('maps generic tiers to subscription-safe Codex model ids', () => {
-      // Confirmed light/medium/heavy mapping (Justin, 2026-05-23):
-      // light=gpt-5.2 (non-reasoning), medium=gpt-5.4-mini (cheapest reasoning),
-      // heavy=gpt-5.5 (frontier). See models.ts for the subscription rationale.
-      expect(resolveModelForFramework('codex-cli', 'fast')).toBe('gpt-5.2');
+      // light/medium/heavy mapping. NOTE: gpt-5.2 was retired from ChatGPT-account
+      // Codex on 2026-06-03 (now 400s), so `fast`/`haiku` moved to gpt-5.4-mini —
+      // the cheapest still-accepted model (== balanced). See models.ts.
+      expect(resolveModelForFramework('codex-cli', 'fast')).toBe('gpt-5.4-mini');
       expect(resolveModelForFramework('codex-cli', 'balanced')).toBe('gpt-5.4-mini');
       expect(resolveModelForFramework('codex-cli', 'capable')).toBe('gpt-5.5');
     });
     it('maps legacy Claude tier names to Codex equivalents (cross-port back-compat)', () => {
-      expect(resolveModelForFramework('codex-cli', 'haiku')).toBe('gpt-5.2');
+      expect(resolveModelForFramework('codex-cli', 'haiku')).toBe('gpt-5.4-mini');
       expect(resolveModelForFramework('codex-cli', 'sonnet')).toBe('gpt-5.4-mini');
       expect(resolveModelForFramework('codex-cli', 'opus')).toBe('gpt-5.5');
     });

--- a/tests/unit/session-manager-behavioral.test.ts
+++ b/tests/unit/session-manager-behavioral.test.ts
@@ -181,12 +181,12 @@ describe('SessionManager behavioral tests', () => {
       });
 
       expect(session.framework).toBe('codex-cli');
-      expect(session.model).toBe('gpt-5.2'); // haiku → light → gpt-5.2 on Codex
+      expect(session.model).toBe('gpt-5.4-mini'); // haiku → light → gpt-5.4-mini on Codex (gpt-5.2 retired from ChatGPT-account Codex 2026-06-03)
       // And it must NOT leak the Claude tier alias onto a Codex session.
       expect(session.model).not.toBe('haiku');
 
       const saved = state.getSession(session.id);
-      expect(saved!.model).toBe('gpt-5.2');
+      expect(saved!.model).toBe('gpt-5.4-mini');
       expect(saved!.framework).toBe('codex-cli');
     });
 

--- a/upgrades/codex-fast-model-gpt52-retired.eli16.md
+++ b/upgrades/codex-fast-model-gpt52-retired.eli16.md
@@ -1,0 +1,26 @@
+# Codex fast-model fix (gpt-5.2 retired) — ELI16
+
+Viewable private artifact:
+https://echo.dawn-tunnel.dev/view/7bc3a2fc-512a-4d1a-b038-725e253145e9?sig=80a2a9cad2adf1d5871bf3611dd6a3b298c07997b7927a730faae64d09193745
+
+Every Codex-powered agent makes lots of small, cheap behind-the-scenes AI calls — spotting a
+promise it made, keeping its tone plain, sorting a message. To keep those cheap, they all ran
+on a lightweight model called **gpt-5.2**.
+
+On June 3, OpenAI quietly **stopped allowing gpt-5.2** on the ChatGPT-subscription kind of
+account these agents use. From that moment every one of those cheap calls started failing with
+a flat error — so, for example, Codey could no longer detect the commitments it makes, all day,
+silently.
+
+The model name was **hardcoded in two places**, so this fix updates both to point at the
+cheapest model that still works on the account: **gpt-5.4-mini**. The agents work again
+immediately.
+
+The one catch, called out honestly: gpt-5.2 was the only *non-thinking* (cheapest) model. The
+replacement is a small *thinking* model, which costs more per call. There was no cheaper option
+left, so this trades a bit more usage for actually working. A follow-up will make this self-heal
+— when a model gets retired, the agent will automatically fall back to a working one instead of
+breaking.
+
+_Patch fix · branch `echo/codex-fast-model-retire` · found by scanning live fleet logs (the
+see-what-breaks loop) and empirically re-probing which models the account still accepts._

--- a/upgrades/next/codex-fast-model-gpt52-retired.md
+++ b/upgrades/next/codex-fast-model-gpt52-retired.md
@@ -1,0 +1,55 @@
+# Upgrade Guide — vNEXT
+
+<!-- bump: patch -->
+
+## What Changed
+
+Re-points the Codex `fast` model tier off the now-retired `gpt-5.2`.
+
+**The bug (live, fleet-wide).** As of 2026-06-03 OpenAI retired `gpt-5.2` from the
+ChatGPT-account Codex surface — `codex exec --model gpt-5.2` now returns HTTP 400
+*"The 'gpt-5.2' model is not supported when using Codex with a ChatGPT account."*
+Both Codex model-tier maps hardcoded the `fast`/`haiku` tier to `gpt-5.2`:
+
+- `src/providers/adapters/openai-codex/models.ts` (`TIER_TO_MODEL.fast`) — the intel /
+  one-shot path (reviewers, sentinels, CommitmentSentinel, tone-gate, classification).
+- `src/core/frameworkSessionLaunch.ts` (`resolveModelForFramework`, codex-cli) — the
+  session-launch path.
+
+So **every cheap Codex call on every Codex agent was silently failing** — observed live as
+`[CommitmentSentinel] LLM detection failed: … --model gpt-5.2 …` on codey, repeating.
+
+**The fix.** Both maps now resolve `fast`/`haiku` to `gpt-5.4-mini` — the cheapest model
+still accepted on the ChatGPT account (empirically re-probed 2026-06-03: `gpt-5.2` rejected,
+`gpt-5.4`/`gpt-5.4-mini` accepted). `gpt-5.4-mini` is already the `balanced` choice, so the
+`fast` and `balanced` tiers now coincide.
+
+**Trade-off (intentional, documented).** `gpt-5.2` was the only *non-reasoning* model; with it
+retired there is no cheaper option, so cheap Codex calls now run on a reasoning model (higher
+token burn per call). A working model beats a 400-ing one, but this raises cheap-call quota
+pressure on Codex agents until the structural follow-up lands.
+
+**Follow-up (not in this patch).** Drift-resilience: validate the resolved model against a
+known-good set and auto-fall-back on a "not supported" 400, so the *next* model retirement
+self-heals instead of breaking the fleet (the second such break after the 2026-04-14 `-codex`
+retirement). Tracked as a follow-up in `models.ts`.
+
+## What to Tell Your User
+
+Nothing required — this is an internal Codex reliability fix (agent-only). Codex agents'
+cheap internal calls (commitment detection, tone gating, classification) were failing because
+a model name they used got retired; they now use a supported model again.
+
+## Summary of New Capabilities
+
+None — bug fix only. No new routes, config, or surfaces.
+
+## Evidence
+
+- Live failure: codey `logs/server.log` — `[CommitmentSentinel] LLM detection failed: Codex CLI
+  error: … codex exec --model gpt-5.2 …` + the codex 400 `invalid_request_error`.
+- Empirical re-probe (2026-06-03, Justin's ChatGPT subscription): `gpt-5.2` → 400 rejected;
+  `gpt-5.4` and `gpt-5.4-mini` → accepted.
+- Tests: `tests/unit/codex-model-tier-resolution.test.ts` (new — pins both resolvers + a
+  retired-`gpt-5.2` regression guard across all tiers); updated `session-manager-behavioral`
+  and `StallTriageNurse` assertions (haiku/fast → `gpt-5.4-mini`).

--- a/upgrades/side-effects/codex-fast-model-gpt52-retired.md
+++ b/upgrades/side-effects/codex-fast-model-gpt52-retired.md
@@ -1,0 +1,59 @@
+# Side-Effects Review — Codex `fast` tier off retired `gpt-5.2`
+
+**Version / slug:** `codex-fast-model-gpt52-retired`
+**Date:** `2026-06-03`
+**Author:** `echo`
+**Second-pass reviewer:** `not required (Tier-1 bug fix — model-string re-point + tests, no decision surface)`
+
+## Summary of the change
+
+Two Codex model-tier maps hardcoded `fast`/`haiku` → `gpt-5.2`. OpenAI retired `gpt-5.2`
+from the ChatGPT-account Codex surface (live 400 as of 2026-06-03), silently breaking every
+cheap Codex call fleet-wide. Both maps now resolve `fast`/`haiku` → `gpt-5.4-mini` (the
+cheapest model still accepted). A new unit test pins both resolvers and guards the retired
+name. No routes, config, schema, or external surface change.
+
+## Decision-point inventory
+
+1. **Which replacement model?** Candidates still accepted (empirically probed 2026-06-03):
+   `gpt-5.4`, `gpt-5.4-mini`, `gpt-5.5`. Chose `gpt-5.4-mini` — the cheapest (it is already
+   the validated `balanced` tier; "mini" < plain `gpt-5.4`). `gpt-5.2` was the only
+   *non-reasoning* model, so no zero-reasoning option remains; this is the least-cost working
+   choice, not a free one.
+2. **Re-point now vs. build the drift-resilient fallback first?** Chose to ship the re-point
+   immediately (it stops an active fleet-wide failure) and leave the structural fallback
+   (validate-against-known-good + auto-fall-back on a 400) as a follow-up. Rationale: the
+   urgent fix is small and regression-safe; the fallback is a larger, separately-testable
+   surface that shouldn't gate the stop-the-bleeding change.
+
+## 1. Cost / quota
+
+`fast` was the cheap non-reasoning tier (gpt-5.2 ≈ 103 tokens on a trivial prompt vs ~5–7k
+for reasoning models). Moving it to a reasoning model (`gpt-5.4-mini`) raises per-call token
+burn for all cheap Codex calls. This is **unavoidable** (gpt-5.2 is gone) but worth flagging
+against the known self-inflicted cheap-call 429 pressure on the shared ChatGPT account — it
+makes the structural drift-resilient fallback (and any cheap-call-volume reduction) more
+valuable, not less. No way to keep the old cost without the retired model.
+
+## 2. Tier collapse
+
+`fast` now equals `balanced` (`gpt-5.4-mini`). Callers that distinguished the two tiers by
+cost no longer get a cheaper `fast`. Acceptable: there is no cheaper accepted model. Reverts
+automatically if/when a cheaper non-reasoning model is re-added to the map.
+
+## 3. Blast radius / reversibility
+
+Two string literals + comment updates + one new test + two updated assertions. Fully
+reversible (revert the two map entries). Claude and Gemini resolvers are untouched
+(framework-scoped branches). No effect on API-key callers passing raw model names (those
+pass through verbatim — unchanged).
+
+## 4. Tests
+
+- New `tests/unit/codex-model-tier-resolution.test.ts`: both resolvers per tier + a
+  retired-`gpt-5.2` regression guard over `fast/balanced/capable/haiku/sonnet/opus` and the
+  undefined default.
+- Updated `session-manager-behavioral` (codex session spawn: haiku → `gpt-5.4-mini`) and
+  `StallTriageNurse` (legacy haiku alias → `gpt-5.4-mini`).
+- Transcript-fixture tests that contain `model: 'gpt-5.2'` (TokenLedger, CodexRolloutParser)
+  are unchanged — they parse historical rollouts and a past session legitimately used gpt-5.2.


### PR DESCRIPTION
## What
OpenAI **retired `gpt-5.2`** from the ChatGPT-account Codex surface (live as of 2026-06-03 — `codex exec --model gpt-5.2` now returns HTTP 400 *"not supported when using Codex with a ChatGPT account"*). Both Codex tier maps hardcoded `fast`/`haiku` → `gpt-5.2`, so **every cheap Codex call (CommitmentSentinel, tone-gate, classification) was silently failing fleet-wide** — observed live on codey (`[CommitmentSentinel] LLM detection failed: … --model gpt-5.2 …`, repeating).

## Fix
Re-point both resolvers to `gpt-5.4-mini` (the cheapest model still accepted; empirically re-probed 2026-06-03 — `gpt-5.2` rejected, `gpt-5.4`/`gpt-5.4-mini` accepted):
- `src/providers/adapters/openai-codex/models.ts` — `TIER_TO_MODEL.fast` (intel / one-shot path)
- `src/core/frameworkSessionLaunch.ts` — `resolveModelForFramework` codex-cli branch (session-launch path)

## Trade-off (documented)
`gpt-5.2` was the only *non-reasoning* model, so cheap calls now run on a reasoning model (`fast` == `balanced`), raising per-call token burn. Unavoidable (no cheaper accepted model remains) — a working model beats a 400-ing one. **Follow-up:** drift-resilient validate-against-known-good + auto-fall-back on a "not supported" 400 so the next retirement self-heals (noted in `models.ts`).

## Tests
- New `tests/unit/codex-model-tier-resolution.test.ts` — pins both resolvers per tier + a retired-`gpt-5.2` regression guard across all tiers + the undefined default.
- Updated `session-manager-behavioral` + `StallTriageNurse` assertions (haiku/fast → `gpt-5.4-mini`). Targeted suite green (98 tests).

Tier-1 fix · ship-gate artifacts: `upgrades/next/codex-fast-model-gpt52-retired.md` (bump: patch) + side-effects + ELI16 (verified tunnel link).

🤖 Generated with [Claude Code](https://claude.com/claude-code)