### PR TITLE
fix(server): log offending stack once per origin for suppressed uncaught exceptions (#72 step 1)

### DIFF
--- a/src/commands/server.ts
+++ b/src/commands/server.ts
@@ -17,7 +17,7 @@ import pc from 'picocolors';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 import { loadConfig, ensureStateDir, detectTmuxPath } from '../core/Config.js';
-import { isNonFatalUncaught } from '../core/uncaughtExceptionPolicy.js';
+import { isNonFatalUncaught, shouldLogStackForUncaught } from '../core/uncaughtExceptionPolicy.js';
 import { closeAllSqlite } from '../core/SqliteRegistry.js';
 import { SessionManager } from '../core/SessionManager.js';
 import { StateManager } from '../core/StateManager.js';
@@ -10204,7 +10204,15 @@ export async function startServer(options: StartOptions): Promise<void> {
       // work). See isNonFatalUncaught for the allowlist + rationale (HTTP
       // double-response races, Slack Socket Mode reconnect races).
       if (isNonFatalUncaught(err)) {
-        console.warn(`[WARN] Non-fatal uncaught exception (suppressed): ${err.message}`);
+        // Attach the stack the first time a given origin is seen so the offending
+        // call site (e.g. a route that double-responds → "Cannot set headers")
+        // is diagnosable; repeats log message-only to avoid flooding the log
+        // (these isolated races recur ~10-20x/hour).
+        const stackSuffix =
+          shouldLogStackForUncaught(err) && err.stack
+            ? `\n  first-seen stack (for diagnosis):\n${err.stack}`
+            : '';
+        console.warn(`[WARN] Non-fatal uncaught exception (suppressed): ${err.message}${stackSuffix}`);
         return; // Don't crash — the server is fine
       }
 

--- a/src/core/uncaughtExceptionPolicy.ts
+++ b/src/core/uncaughtExceptionPolicy.ts
@@ -52,3 +52,41 @@ export function isNonFatalUncaught(err: unknown): boolean {
   if (!msg) return false;
   return NON_FATAL_UNCAUGHT_PATTERNS.some((p) => msg.includes(p));
 }
+
+/**
+ * Decides whether to attach the FULL stack trace when logging a suppressed
+ * non-fatal uncaught exception. These isolated races recur (the HTTP
+ * double-response one — "Cannot set headers after they are sent" — fires
+ * ~10-20x/hour), so logging the stack on EVERY occurrence would flood the log.
+ * Yet without ANY stack the offending call site is undiagnosable: the throw
+ * originates in node's http internals, so the suppressed message alone carries
+ * no location — the route that double-responded is invisible.
+ *
+ * The fix: log the full stack the FIRST time a given stack is seen, then
+ * message-only for repeats. That surfaces each distinct originating call path
+ * exactly once (enough to find + fix the real double-send) without the flood.
+ *
+ * Dedup key is the full `err.stack` (not just the top frames): the distinguishing
+ * frame for an HTTP double-response is the application route DEEP in the stack —
+ * the top frames are always the same node internals — so only the whole stack
+ * separates one origin from another. Process-local + bounded (cleared past
+ * MAX_TRACKED_STACKS so a pathological variety of stacks can't grow it without
+ * limit). Returns false for non-Error / stackless input.
+ */
+const seenUncaughtStacks = new Set<string>();
+const MAX_TRACKED_STACKS = 200;
+
+export function shouldLogStackForUncaught(err: unknown): boolean {
+  if (!(err instanceof Error) || !err.stack) return false;
+  if (seenUncaughtStacks.has(err.stack)) return false;
+  // Bound memory: if a pathological variety of distinct stacks accumulates,
+  // reset rather than grow without limit (re-surfacing after the reset is fine).
+  if (seenUncaughtStacks.size >= MAX_TRACKED_STACKS) seenUncaughtStacks.clear();
+  seenUncaughtStacks.add(err.stack);
+  return true;
+}
+
+/** Test-only: reset the dedup memory so each test starts from a clean slate. */
+export function __resetUncaughtStackDedupeForTests(): void {
+  seenUncaughtStacks.clear();
+}

--- a/tests/integration/sqlite-close-on-exit.test.ts
+++ b/tests/integration/sqlite-close-on-exit.test.ts
@@ -95,7 +95,10 @@ describe('SQLite close-on-exit — server.ts wiring (ordering)', () => {
   it('the uncaughtException handler closes ALL sqlite (not just topic/semantic memory)', () => {
     const uncaughtStart = serverSrc.indexOf("process.on('uncaughtException'");
     expect(uncaughtStart).toBeGreaterThan(0);
-    const body = serverSrc.slice(uncaughtStart, uncaughtStart + 1200);
+    // Window generous enough to span the whole handler (the suppressed-error
+    // branch now logs a first-seen stack before the FATAL branch's
+    // closeAllSqlite() call — so a tight window would miss it).
+    const body = serverSrc.slice(uncaughtStart, uncaughtStart + 2000);
     expect(body).toMatch(/closeAllSqlite\(\)/);
   });
 

--- a/tests/unit/slack-socket-reconnect.test.ts
+++ b/tests/unit/slack-socket-reconnect.test.ts
@@ -108,7 +108,12 @@ describe('Ack send guard against a mid-reconnect socket (#43 — no whole-agent 
   it('server routes uncaught exceptions through the isNonFatalUncaught policy (defense-in-depth)', () => {
     // The recoverable-error allowlist (HTTP races + the Slack WS race) is now a
     // testable module, used by the process-level handler instead of an inline list.
-    expect(serverSource).toContain("import { isNonFatalUncaught } from '../core/uncaughtExceptionPolicy.js'");
+    // Tolerate additional named imports from the policy module (e.g.
+    // shouldLogStackForUncaught) — the intent is "server imports the
+    // isNonFatalUncaught policy", not a byte-exact import line.
+    expect(serverSource).toMatch(
+      /import \{[^}]*\bisNonFatalUncaught\b[^}]*\} from '\.\.\/core\/uncaughtExceptionPolicy\.js'/,
+    );
     expect(serverSource).toMatch(/if \(isNonFatalUncaught\(err\)\) \{[\s\S]*?return;/);
   });
 });

--- a/tests/unit/uncaughtExceptionPolicy.test.ts
+++ b/tests/unit/uncaughtExceptionPolicy.test.ts
@@ -5,8 +5,12 @@
  * instead of closing its databases and exiting. Both sides of the boundary are
  * tested with realistic messages.
  */
-import { describe, it, expect } from 'vitest';
-import { isNonFatalUncaught } from '../../src/core/uncaughtExceptionPolicy.js';
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  isNonFatalUncaught,
+  shouldLogStackForUncaught,
+  __resetUncaughtStackDedupeForTests,
+} from '../../src/core/uncaughtExceptionPolicy.js';
 
 describe('isNonFatalUncaught', () => {
   it('treats the Slack Socket Mode reconnect race as recoverable (#43 — must not crash the agent)', () => {
@@ -47,5 +51,66 @@ describe('isNonFatalUncaught', () => {
     expect(isNonFatalUncaught('Sent before connected')).toBe(true); // string with a known pattern
     expect(isNonFatalUncaught({})).toBe(false);
     expect(isNonFatalUncaught(new Error(''))).toBe(false); // empty message → not matched
+  });
+});
+
+/**
+ * #72 — the suppressed-uncaught handler logs the offending stack the FIRST time
+ * a given origin appears (so a double-responding route is diagnosable) then
+ * message-only for repeats (these races fire ~10-20x/hour; the stack would flood).
+ */
+describe('shouldLogStackForUncaught', () => {
+  beforeEach(() => __resetUncaughtStackDedupeForTests());
+
+  function errWithStack(message: string, stack: string): Error {
+    const e = new Error(message);
+    e.stack = stack;
+    return e;
+  }
+
+  it('logs the stack the FIRST time an origin is seen, then suppresses repeats', () => {
+    const e = errWithStack(
+      'Cannot set headers after they are sent to the client',
+      'Error: Cannot set headers...\n  at routeFoo (/app/src/routes/foo.ts:10:5)',
+    );
+    expect(shouldLogStackForUncaught(e)).toBe(true); // first → log stack
+    expect(shouldLogStackForUncaught(e)).toBe(false); // repeat → suppress
+    // Key is the stack string, so a fresh Error with the SAME stack is still deduped.
+    expect(shouldLogStackForUncaught(errWithStack('Cannot set headers...', e.stack!))).toBe(false);
+  });
+
+  it('surfaces a DIFFERENT origin (distinct stack) once, even for the same message', () => {
+    const a = errWithStack('Cannot set headers after they are sent', 'Error\n  at routeA (/app/a.ts:1:1)');
+    const b = errWithStack('Cannot set headers after they are sent', 'Error\n  at routeB (/app/b.ts:2:2)');
+    expect(shouldLogStackForUncaught(a)).toBe(true);
+    expect(shouldLogStackForUncaught(b)).toBe(true); // different stack → its own first-log
+    expect(shouldLogStackForUncaught(a)).toBe(false); // a already seen
+  });
+
+  it('returns false for non-Error / stackless input (nothing to attach)', () => {
+    expect(shouldLogStackForUncaught(undefined)).toBe(false);
+    expect(shouldLogStackForUncaught('Cannot set headers')).toBe(false);
+    const noStack = new Error('x');
+    noStack.stack = undefined;
+    expect(shouldLogStackForUncaught(noStack)).toBe(false);
+  });
+
+  it('re-surfaces a stack after the dedup memory is reset', () => {
+    const e = errWithStack('write after end', 'Error: write after end\n  at routeZ');
+    expect(shouldLogStackForUncaught(e)).toBe(true);
+    expect(shouldLogStackForUncaught(e)).toBe(false);
+    __resetUncaughtStackDedupeForTests();
+    expect(shouldLogStackForUncaught(e)).toBe(true); // logs again after reset
+  });
+
+  it('bounds memory: clears tracking past the cap so it cannot grow without limit', () => {
+    const first = errWithStack('write after end', 'Error\n  at origin0');
+    expect(shouldLogStackForUncaught(first)).toBe(true);
+    expect(shouldLogStackForUncaught(first)).toBe(false); // now tracked
+    // Exceed MAX_TRACKED_STACKS (200) with distinct stacks → triggers a clear.
+    for (let i = 1; i <= 200; i++) {
+      shouldLogStackForUncaught(errWithStack('write after end', `Error\n  at origin${i}`));
+    }
+    expect(shouldLogStackForUncaught(first)).toBe(true); // cleared past cap → surfaces again
   });
 });

--- a/upgrades/next/uncaught-suppressed-stack-capture.md
+++ b/upgrades/next/uncaught-suppressed-stack-capture.md
@@ -1,0 +1,45 @@
+# Upgrade Guide — vNEXT
+
+<!-- bump: patch -->
+
+## What Changed
+
+Makes suppressed non-fatal uncaught exceptions **diagnosable** by logging their stack
+trace once per origin.
+
+**The problem.** The server's `uncaughtException` handler logs a small allowlist of
+isolated/recoverable errors and continues (instead of crashing) — chiefly the HTTP
+double-response race `Cannot set headers after they are sent`. But it logged only
+`err.message`, no stack. Observed live: echo (~34×/2h) and codey (~26×/2h) emit
+`[WARN] Non-fatal uncaught exception (suppressed): Cannot set headers after they are sent`
+with **no location** — and since that error is thrown deep in node's http internals, the
+message alone can't tell you which route double-responded. The real double-send bug is
+therefore un-findable from the logs.
+
+**The fix.** A new `shouldLogStackForUncaught(err)` in `uncaughtExceptionPolicy.ts`: the
+handler now attaches the **full stack the first time a given stack is seen**, then logs
+message-only for repeats. That surfaces each distinct offending call path exactly once —
+enough to find and fix the real double-send — without flooding the log (these races recur
+~10–20×/hour). The dedup key is the whole `err.stack` (the distinguishing route frame is
+deep, not at the top); the tracking set is bounded (cleared past 200 distinct stacks).
+
+This is a **diagnostic** change — it does not alter which exceptions are suppressed vs.
+fatal (`isNonFatalUncaught` is unchanged), only how the suppressed ones are logged.
+
+## What to Tell Your User
+
+Nothing required — internal observability (agent-only). The next time the harmless-but-noisy
+"Cannot set headers" race fires, the log will include the originating stack once, so the
+underlying double-respond can be located and fixed.
+
+## Summary of New Capabilities
+
+None — observability/diagnostic only. No new routes, config, or surfaces.
+
+## Evidence
+
+- Live: echo/codey `logs/server.log` — `[WARN] Non-fatal uncaught exception (suppressed):
+  Cannot set headers after they are sent` recurring with no stack.
+- `src/commands/server.ts` uncaughtException handler now calls `shouldLogStackForUncaught`.
+- Tests: `tests/unit/uncaughtExceptionPolicy.test.ts` — first-logs-then-suppresses,
+  distinct-origin-surfaced-once, non-Error/stackless → false, reset re-surfaces, cap bound.

--- a/upgrades/side-effects/uncaught-suppressed-stack-capture.md
+++ b/upgrades/side-effects/uncaught-suppressed-stack-capture.md
@@ -1,0 +1,56 @@
+# Side-Effects Review — Suppressed-uncaught stack capture
+
+**Version / slug:** `uncaught-suppressed-stack-capture`
+**Date:** `2026-06-03`
+**Author:** `echo`
+**Second-pass reviewer:** `not required (Tier-1 — additive diagnostic helper + one log-line change; no control-flow/decision change)`
+
+## Summary of the change
+
+The server's `uncaughtException` handler suppresses an allowlist of isolated errors
+(HTTP double-response, Slack reconnect, standby read-only write) and logs `err.message`.
+For the recurring `Cannot set headers after they are sent` race the message has no location
+(thrown in node internals), so the offending route is un-findable. Added
+`shouldLogStackForUncaught(err)` to `uncaughtExceptionPolicy.ts` — logs the full stack the
+first time a given stack is seen, message-only thereafter. The handler appends that stack
+when the helper returns true. `isNonFatalUncaught` (the suppress-vs-crash decision) is
+unchanged.
+
+## Decision-point inventory
+
+1. **Dedup key = full `err.stack` (not top-N frames).** For an HTTP double-response the
+   top frames are always node's http internals; only the deep application frame separates
+   one route from another, so the whole stack is the right key. Errs toward surfacing more
+   distinct origins (good for diagnosis), not fewer.
+2. **First-occurrence-only logging (vs. always / rate-limited count).** These races fire
+   ~10–20×/hour; logging the stack every time would flood. Once-per-origin gives the route
+   exactly once (sufficient to fix the real bug). Chosen over a time-window rate-limit
+   because the goal is "reveal each origin once," not "sample volume."
+3. **Bounded tracking (clear past 200).** A pathological variety of distinct stacks can't
+   grow the Set without limit; clearing re-surfaces stacks after the cap, which is benign
+   (a little extra logging) and far better than unbounded memory.
+
+## 1. Behavior / safety
+
+No change to which exceptions crash vs. continue — `isNonFatalUncaught` and the FATAL
+branch are untouched. The only effect is additional (bounded) log output on the
+already-suppressed path. Cannot introduce a crash (the helper is pure + guarded for
+non-Error/stackless input → returns false).
+
+## 2. Log volume
+
+Net REDUCES noise risk vs. a naive "always log stack": one stack per origin, then
+message-only. The first-occurrence stacks are a small, finite set (the handful of
+double-respond origins + the other allowlisted errors).
+
+## 3. Blast radius / reversibility
+
+One new pure function + one log-line edit in the handler. Fully reversible (revert both).
+No schema/config/route/external surface. Memory: one process-local bounded `Set<string>`.
+
+## 4. Tests
+
+`tests/unit/uncaughtExceptionPolicy.test.ts` (existing isNonFatalUncaught suite unchanged) +
+a new `shouldLogStackForUncaught` block covering: first-logs-then-suppresses, same-stack
+fresh-Error still deduped, distinct-origin each surfaced once, non-Error/stackless → false,
+reset re-surfaces, and the cap-bound clear path. 10 tests pass.

--- a/upgrades/uncaught-suppressed-stack-capture.eli16.md
+++ b/upgrades/uncaught-suppressed-stack-capture.eli16.md
@@ -1,0 +1,22 @@
+# Suppressed-crash stack capture (#72) — ELI16
+
+Viewable private artifact:
+https://echo.dawn-tunnel.dev/view/311d1657-692e-48ca-a112-04c82fa74dec?sig=6e66a9515e16c2e28156a94169f7737cb86dd0c661440267eed93dc730ebd632
+
+The agent server has a short list of harmless-but-annoying errors it deliberately swallows
+instead of crashing — the main one is an HTTP race called "Cannot set headers after they are
+sent" (two replies sent for one web request). Swallowing it is correct: the request is already
+handled, and crashing the whole agent would be far worse.
+
+The snag: it only logged the error MESSAGE, not WHERE it came from. And that error is thrown
+deep inside Node's plumbing, so the message alone never says which piece of code double-replied.
+It fires 10–20 times an hour on each agent, completely un-findable.
+
+This change logs the full stack trace the FIRST time each distinct origin appears, then goes
+quiet (message-only) for the repeats. So the offending code reveals itself once — enough to
+actually fix the real double-reply — without flooding the log. Nothing about what gets swallowed
+vs. crashed changes; only how the swallowed ones are logged.
+
+_Patch · branch `echo/double-send-stack-capture` · found by scanning live fleet logs (the
+see-what-breaks loop). Step 1 (make it findable); the real double-send fix follows once the next
+occurrence reveals the route._


### PR DESCRIPTION
## What
The server's `uncaughtException` handler suppresses an allowlist of isolated errors (chiefly the HTTP double-response race `Cannot set headers after they are sent`) and logs only `err.message` — **no stack**. That error is thrown deep in node's http internals, so the message alone can't tell you which route double-responded. Observed live: echo (~34×/2h) + codey (~26×/2h), recurring with no location → the real double-send is un-findable from the logs.

## Fix
New `shouldLogStackForUncaught(err)` in `uncaughtExceptionPolicy.ts`: the handler attaches the **full stack the first time a given stack is seen**, then message-only for repeats — surfaces each distinct offending call path exactly once (enough to find + fix the real bug) without flooding (~10–20×/hr). Dedup key = full `err.stack` (the distinguishing route frame is deep, not at the top); tracking set bounded (cleared past 200).

**Diagnostic-only** — `isNonFatalUncaught` (the suppress-vs-crash decision) and the FATAL branch are unchanged; only how the already-suppressed errors are logged.

## Tests
`tests/unit/uncaughtExceptionPolicy.test.ts` (+5 cases): first-logs-then-suppresses, distinct-origin-surfaced-once, non-Error/stackless → false, reset re-surfaces, cap-bound clear. 10 pass.

Tier-1 · ship-gate: `upgrades/next/uncaught-suppressed-stack-capture.md` (bump: patch) + side-effects + ELI16 (verified tunnel link). This is **step 1 of #72** (make it findable); the real double-send fix follows once the next prod occurrence reveals the route.

🤖 Generated with [Claude Code](https://claude.com/claude-code)