### PR TITLE
feat(metrics): honest call counts (shed) + InputGuard/PresenceProxy attribution

### DIFF
--- a/docs/specs/llm-feature-metrics-spec.eli16.md
+++ b/docs/specs/llm-feature-metrics-spec.eli16.md
@@ -45,6 +45,15 @@ two changes colliding in the same file:
   data into the ledger — built on top of #638's final version, measuring its new
   wait-behavior too.
 
+- **Phase 1b refinement (2026-06-03):** two honesty fixes once real data flowed in.
+  (a) The breaker sometimes refuses a call entirely (the circuit is "open") — no LLM
+  runs, no cost. That was being recorded the same as a *completed* call, so the
+  numbers looked like "99% of calls did nothing" when really most calls never
+  happened. Now those are tagged **`shed`** and reported separately, and **`realCalls`**
+  (= calls − shed) is the honest count. (b) The two busiest callers weren't labeling
+  themselves, so their spend showed up as "unlabeled" — now tagged (InputGuard,
+  PresenceProxy). Still measurement-only.
+
 ## What the reader needs to decide
 
 Justin already approved the plan and said proceed. If reviewing: confirm this is

--- a/docs/specs/llm-feature-metrics-spec.md
+++ b/docs/specs/llm-feature-metrics-spec.md
@@ -2,6 +2,7 @@
 title: "Per-feature LLM metrics — measure every gate/sentinel so tuning is evidence-based"
 date: 2026-05-31
 author: echo
+parent-principle: "Observability — you can't tune what you can't see"
 review-convergence: internal-plus-conformance-2026-05-31
 approved: true
 approved-by: Justin

--- a/src/core/CircuitBreakingIntelligenceProvider.ts
+++ b/src/core/CircuitBreakingIntelligenceProvider.ts
@@ -43,7 +43,7 @@ export interface FeatureMetricsRecorder {
   record(entry: {
     feature: string;
     kind?: 'llm' | 'event';
-    outcome: 'fired' | 'noop' | 'error';
+    outcome: 'fired' | 'noop' | 'error' | 'shed';
     latencyMs?: number;
     waited?: boolean;
     waitMs?: number;
@@ -81,11 +81,15 @@ export class CircuitBreakingIntelligenceProvider implements IntelligenceProvider
    * side-channel: it MUST never throw into the LLM path (observability must not
    * break what it observes — the Close the Loop principle applied to itself).
    * outcome here is funnel-level: 'noop' = the call completed (the fired-vs-noop
-   * VERDICT is the caller's interpretation → Phase 2); 'error' = it failed.
+   * VERDICT is the caller's interpretation → Phase 2); 'error' = it failed;
+   * 'shed' = the circuit was open so NO call ran (no token cost, no network
+   * round-trip). Keeping 'shed' distinct from 'noop' is what makes the metric
+   * honest: 'calls' minus 'shed' = real round-trips, so the breaker shedding
+   * load can't masquerade as completed work (the 0ms-latency confound).
    */
   private recordMetric(
     feature: string,
-    outcome: 'noop' | 'error',
+    outcome: 'noop' | 'error' | 'shed',
     latencyMs: number,
     waited: boolean,
     waitMs: number | undefined,
@@ -122,8 +126,10 @@ export class CircuitBreakingIntelligenceProvider implements IntelligenceProvider
       if (!gate.allow) {
         // Circuit open, no LLM call ran (no cost) — but the throttle itself is a
         // signal worth measuring per feature (how often a gate hits the open
-        // window). Recorded as a no-op; `waited` marks whether a bounded wait was engaged.
-        this.recordMetric(feature, 'noop', Date.now() - startedAt, waited, options?.rateLimitWaitMs);
+        // window). Recorded as 'shed' (NOT 'noop'): no round-trip happened, so it
+        // must not count toward real calls. `waited` marks whether a bounded wait
+        // was engaged.
+        this.recordMetric(feature, 'shed', Date.now() - startedAt, waited, options?.rateLimitWaitMs);
         throw new LlmCircuitOpenError(gate.retryAfterMs);
       }
     }

--- a/src/core/InputGuard.ts
+++ b/src/core/InputGuard.ts
@@ -322,6 +322,9 @@ Respond with ONLY valid JSON (no markdown, no explanation):
           model: 'fast',
           maxTokens: 150,
           temperature: 0,
+          // Attribution so /metrics/features can see this high-frequency caller
+          // (the "is this stuck?" review) instead of bucketing it under 'unlabeled'.
+          attribution: { component: 'InputGuard' },
         }),
         new Promise<never>((_, reject) =>
           setTimeout(() => reject(new Error(`Review timeout after ${timeout}ms`)), timeout),

--- a/src/monitoring/FeatureMetricsLedger.ts
+++ b/src/monitoring/FeatureMetricsLedger.ts
@@ -2,8 +2,10 @@
  * FeatureMetricsLedger — per-feature observability for LLM-driven systems.
  *
  * Records, per call, which system (sentinel/gate) invoked the LLM, what it
- * cost (tokens, latency), and what it decided (fired/noop/error), so that every
- * gate's cost and hit-rate becomes a tracked number instead of a guess. Read-
+ * cost (tokens, latency), and what it decided (fired/noop/error/shed), so that
+ * every gate's cost and hit-rate becomes a tracked number instead of a guess.
+ * 'shed' (circuit-open, no call) is counted separately so `realCalls` reflects
+ * only real round-trips. Read-
  * only observability — it NEVER gates, blocks, or mutates any flow (same
  * guarantee as TokenLedger). Spec: docs/specs/llm-feature-metrics-spec.md.
  *
@@ -24,14 +26,25 @@ import type { Database as BetterSqliteDatabase } from 'better-sqlite3';
 import { NativeModuleHealer } from '../memory/NativeModuleHealer.js';
 
 export type FeatureMetricKind = 'llm' | 'event';
-export type FeatureMetricOutcome = 'fired' | 'noop' | 'error';
+/**
+ * Outcome of a funnel call:
+ *  - 'fired' — the gate acted (blocked/flagged). The fired-vs-noop verdict is
+ *    Phase 2; today the funnel never sets this (the caller would).
+ *  - 'noop'  — a REAL call completed and the gate took no action.
+ *  - 'error' — a real call failed.
+ *  - 'shed'  — the circuit was OPEN so no call ran (no token cost, no network
+ *    round-trip). Distinct from 'noop' so `realCalls` (= calls − shed) reflects
+ *    only real round-trips; otherwise breaker-shed load (0ms latency) inflates
+ *    the call count and reads as completed work.
+ */
+export type FeatureMetricOutcome = 'fired' | 'noop' | 'error' | 'shed';
 
 export interface FeatureMetricRecord {
   /** Source-side component label (IntelligenceOptions.attribution.component). */
   feature: string;
   /** 'llm' for a provider call; 'event' for a programmatic guard invocation. */
   kind?: FeatureMetricKind;
-  /** What the system decided: fired (blocked/flagged/acted) vs noop (allow) vs error. */
+  /** What happened: fired (acted) vs noop (real call, no action) vs error vs shed (circuit-open, no call). */
   outcome: FeatureMetricOutcome;
   tokensIn?: number;
   tokensOut?: number;
@@ -48,7 +61,10 @@ export interface FeatureMetricRecord {
 
 export interface FeatureRollup {
   feature: string;
+  /** All recorded funnel rows (includes 'shed' no-calls). */
   calls: number;
+  /** Real round-trips only (calls − shed) — the honest call count. */
+  realCalls: number;
   llmCalls: number;
   events: number;
   tokensIn: number;
@@ -56,7 +72,9 @@ export interface FeatureRollup {
   fired: number;
   noop: number;
   errors: number;
-  /** fired / calls (0..1) — how often the system actually does something. */
+  /** Circuit-open no-calls: the breaker refused the call, nothing ran. */
+  shed: number;
+  /** fired / realCalls (0..1) — how often the system acts on a call that actually ran. */
   fireRate: number;
   avgLatencyMs: number;
   p50LatencyMs: number;
@@ -70,6 +88,7 @@ export interface FeatureMetricsSummary {
   sinceMs: number;
   totals: {
     calls: number;
+    realCalls: number;
     llmCalls: number;
     events: number;
     tokensIn: number;
@@ -77,6 +96,7 @@ export interface FeatureMetricsSummary {
     fired: number;
     noop: number;
     errors: number;
+    shed: number;
   };
   features: FeatureRollup[];
 }
@@ -190,6 +210,7 @@ export class FeatureMetricsLedger {
            SUM(CASE WHEN outcome='fired' THEN 1 ELSE 0 END)   AS fired,
            SUM(CASE WHEN outcome='noop'  THEN 1 ELSE 0 END)   AS noop,
            SUM(CASE WHEN outcome='error' THEN 1 ELSE 0 END)   AS errors,
+           SUM(CASE WHEN outcome='shed'  THEN 1 ELSE 0 END)   AS shed,
            SUM(waited)                                        AS waitedCalls,
            COALESCE(AVG(CASE WHEN waited=1 THEN wait_ms END), 0) AS avgWaitMs,
            COALESCE(AVG(latency_ms), 0)                       AS avgLatencyMs,
@@ -219,10 +240,13 @@ export class FeatureMetricsLedger {
     return agg.map((a) => {
       const calls = Number(a.calls) || 0;
       const fired = Number(a.fired) || 0;
+      const shed = Number(a.shed) || 0;
+      const realCalls = calls - shed;
       const lats = latByFeature.get(String(a.feature)) ?? [];
       return {
         feature: String(a.feature),
         calls,
+        realCalls,
         llmCalls: Number(a.llmCalls) || 0,
         events: Number(a.events) || 0,
         tokensIn: Number(a.tokensIn) || 0,
@@ -230,7 +254,8 @@ export class FeatureMetricsLedger {
         fired,
         noop: Number(a.noop) || 0,
         errors: Number(a.errors) || 0,
-        fireRate: calls > 0 ? fired / calls : 0,
+        shed,
+        fireRate: realCalls > 0 ? fired / realCalls : 0,
         avgLatencyMs: Math.round(Number(a.avgLatencyMs) || 0),
         p50LatencyMs: percentile(lats, 0.5),
         p95LatencyMs: percentile(lats, 0.95),
@@ -248,6 +273,7 @@ export class FeatureMetricsLedger {
     const totals = features.reduce(
       (acc, f) => {
         acc.calls += f.calls;
+        acc.realCalls += f.realCalls;
         acc.llmCalls += f.llmCalls;
         acc.events += f.events;
         acc.tokensIn += f.tokensIn;
@@ -255,9 +281,10 @@ export class FeatureMetricsLedger {
         acc.fired += f.fired;
         acc.noop += f.noop;
         acc.errors += f.errors;
+        acc.shed += f.shed;
         return acc;
       },
-      { calls: 0, llmCalls: 0, events: 0, tokensIn: 0, tokensOut: 0, fired: 0, noop: 0, errors: 0 },
+      { calls: 0, realCalls: 0, llmCalls: 0, events: 0, tokensIn: 0, tokensOut: 0, fired: 0, noop: 0, errors: 0, shed: 0 },
     );
     return { sinceMs, totals, features };
   }

--- a/src/monitoring/PresenceProxy.ts
+++ b/src/monitoring/PresenceProxy.ts
@@ -1706,6 +1706,13 @@ IMPORTANT BIAS: Default to "working" or "waiting" unless there is STRONG evidenc
     priority: 'low' | 'high',
     timeoutMs: number,
   ): Promise<string> {
+    // Default attribution so every PresenceProxy LLM call is labeled in
+    // /metrics/features (this is a high-frequency monitor); a caller that already
+    // set attribution wins.
+    const opts: IntelligenceOptions = {
+      ...options,
+      attribution: options.attribution ?? { component: 'PresenceProxy' },
+    };
     // Prefer the shared cross-monitor queue when wired (spec follow-up). Both
     // 'low' and 'high' priorities for PresenceProxy map to the `interactive`
     // lane — PresenceProxy is the user-facing monitor and always outranks
@@ -1717,7 +1724,7 @@ IMPORTANT BIAS: Default to "working" or "waiting" unless there is STRONG evidenc
           'interactive',
           async (signal) => {
             const result = await Promise.race([
-              this.config.intelligence.evaluate(prompt, options),
+              this.config.intelligence.evaluate(prompt, opts),
               new Promise<never>((_, reject) => {
                 const t = setTimeout(() => reject(new Error('LLM timeout')), timeoutMs);
                 signal.addEventListener('abort', () => {
@@ -1739,7 +1746,7 @@ IMPORTANT BIAS: Default to "working" or "waiting" unless there is STRONG evidenc
     }
     return this.llmQueue.enqueue(async () => {
       const result = await Promise.race([
-        this.config.intelligence.evaluate(prompt, options),
+        this.config.intelligence.evaluate(prompt, opts),
         new Promise<never>((_, reject) =>
           setTimeout(() => reject(new Error('LLM timeout')), timeoutMs)
         ),

--- a/tests/unit/CircuitBreaking-feature-metrics-tap.test.ts
+++ b/tests/unit/CircuitBreaking-feature-metrics-tap.test.ts
@@ -79,14 +79,16 @@ describe('CircuitBreakingIntelligenceProvider — feature metrics tap (Phase 1b)
     expect(recorded[0]).toMatchObject({ feature: 'CoherenceGate', outcome: 'noop', waited: true, waitMs: 500 });
   });
 
-  it('records the circuit-open skip as a no-op (waited) and throws LlmCircuitOpenError', async () => {
+  it('records the circuit-open skip as outcome=shed (no call ran) and throws LlmCircuitOpenError', async () => {
     setFeatureMetricsRecorder(recorder);
     const inner: IntelligenceProvider = { evaluate: vi.fn(async () => 'should-not-run') };
     const p = new CircuitBreakingIntelligenceProvider(inner, fakeBreaker({ allow: false, waitAllow: false }));
 
     await expect(p.evaluate('x', { attribution: { component: 'X' }, rateLimitWaitMs: 200 } as any)).rejects.toBeInstanceOf(LlmCircuitOpenError);
     expect(inner.evaluate).not.toHaveBeenCalled();
-    expect(recorded[0]).toMatchObject({ feature: 'X', outcome: 'noop', waited: true });
+    // 'shed' (NOT 'noop'): the breaker refused the call, nothing ran — so it must
+    // not count toward real round-trips. This is the 0ms-latency confound fix.
+    expect(recorded[0]).toMatchObject({ feature: 'X', outcome: 'shed', waited: true });
   });
 
   it('is a safe no-op when no recorder is set (and never breaks the call)', async () => {
@@ -114,10 +116,17 @@ describe('CircuitBreakingIntelligenceProvider — feature metrics tap (Phase 1b)
       await new CircuitBreakingIntelligenceProvider(ok, fakeBreaker()).evaluate('a', { attribution: { component: 'ToneGate' } });
       await new CircuitBreakingIntelligenceProvider(ok, fakeBreaker()).evaluate('b', { attribution: { component: 'ToneGate' } });
       await expect(new CircuitBreakingIntelligenceProvider(bad, fakeBreaker()).evaluate('c', { attribution: { component: 'ToneGate' } })).rejects.toThrow();
+      // Two circuit-OPEN skips: no call runs → recorded as 'shed', excluded from realCalls.
+      await expect(new CircuitBreakingIntelligenceProvider(ok, fakeBreaker({ allow: false, waitAllow: false }))
+        .evaluate('d', { attribution: { component: 'ToneGate' }, rateLimitWaitMs: 50 } as any)).rejects.toThrow();
+      await expect(new CircuitBreakingIntelligenceProvider(ok, fakeBreaker({ allow: false, waitAllow: false }))
+        .evaluate('e', { attribution: { component: 'ToneGate' }, rateLimitWaitMs: 50 } as any)).rejects.toThrow();
 
       const tone = ledger.byFeature().find(f => f.feature === 'ToneGate')!;
-      expect(tone.calls).toBe(3);
-      expect(tone.llmCalls).toBe(3);
+      expect(tone.calls).toBe(5);       // all funnel rows (incl. shed)
+      expect(tone.shed).toBe(2);        // breaker refused 2 — no round-trip
+      expect(tone.realCalls).toBe(3);   // calls − shed = honest call count
+      expect(tone.llmCalls).toBe(5);
       expect(tone.errors).toBe(1);
       expect(tone.noop).toBe(2);
     } finally {

--- a/upgrades/next/feature-metrics-shed-and-attribution.md
+++ b/upgrades/next/feature-metrics-shed-and-attribution.md
@@ -1,0 +1,40 @@
+# Upgrade Guide — vNEXT
+
+<!-- bump: patch -->
+
+## What Changed
+
+**`/metrics/features` now reports an honest LLM-call count.** The metrics funnel
+recorded circuit-open events — where the breaker refused the call and *no* LLM
+ran (≈0ms, no token cost) — with the same `noop` outcome as a genuinely completed
+call. On a saturated agent that made the numbers read as "≈99% of calls did
+nothing," when in reality most of those rows were calls that never happened (the
+0ms-latency confound).
+
+The circuit-open path now records a distinct **`shed`** outcome, and the
+per-feature rollup + totals expose **`shed`** and **`realCalls`** (= `calls −
+shed`). `calls` is unchanged (backward-compatible total); `realCalls` is the
+honest round-trip count, and `fireRate` now divides by `realCalls`.
+
+Separately, the two highest-frequency internal callers (**InputGuard** and
+**PresenceProxy**) now pass `attribution.component`, so their spend is attributed
+instead of bucketing under `unlabeled` — advancing the spec's "every caller gets
+tagged" goal. Remaining callers are a follow-up.
+
+This is observability-only — it never gates, blocks, or alters any decision (same
+safety property as the token ledger). Phase 1b of
+`docs/specs/llm-feature-metrics-spec.md`.
+
+## What to Tell Your User
+
+Nothing to configure. The per-system LLM metrics are now more trustworthy: calls
+the rate-limiter refused (where nothing actually ran) are counted separately from
+real calls, so the numbers no longer make it look like the systems are doing
+nothing when they're really just being throttled. Two of the busiest internal
+checks also now show up by name instead of as "unlabeled."
+
+## Summary of New Capabilities
+
+- `shed` outcome + `realCalls` field on `/metrics/features` (per-feature and totals).
+- `fireRate` now computed over `realCalls` (real round-trips), not all rows.
+- Attribution labels for the InputGuard and PresenceProxy LLM callers.

--- a/upgrades/side-effects/feature-metrics-shed-and-attribution.md
+++ b/upgrades/side-effects/feature-metrics-shed-and-attribution.md
@@ -1,0 +1,117 @@
+# Side-Effects Review — FeatureMetrics: honest call counts (`shed`) + caller attribution
+
+**Version / slug:** `feature-metrics-shed-and-attribution`
+**Date:** `2026-06-03`
+**Author:** `Echo (instar-dev agent)`
+**Second-pass reviewer:** `not required`
+
+## Summary of the change
+
+Two refinements to the per-feature LLM metrics funnel (Phase 1b of
+`docs/specs/llm-feature-metrics-spec.md`), both making `/metrics/features` an
+honest spend measure:
+
+1. **`shed` outcome** — `CircuitBreakingIntelligenceProvider.evaluate()` recorded
+   the circuit-OPEN path (no LLM call ran, ~0ms) as `'noop'`, identical to a
+   completed call. `FeatureMetricsLedger` therefore counted breaker-shed load as
+   completed work, so `calls` read ~99% "noop" when most rows were no-calls (the
+   0ms-latency confound). The circuit-open path now records a distinct `'shed'`
+   outcome; the rollup/summary expose `shed` + `realCalls` (= `calls − shed`);
+   `calls` is unchanged (backward-compatible total) and `fireRate` now divides by
+   `realCalls`.
+2. **Attribution** — the spec requires "every caller gets tagged," but the two
+   highest-frequency callers passed no `attribution.component`, so they bucketed
+   under `unlabeled`. Added `attribution: { component: 'InputGuard' }` at
+   `InputGuard`'s review call, and a default `{ component: 'PresenceProxy' }` in
+   `PresenceProxy.callLlm` (caller-supplied attribution still wins).
+
+Files: `src/core/CircuitBreakingIntelligenceProvider.ts`,
+`src/monitoring/FeatureMetricsLedger.ts`, `src/core/InputGuard.ts`,
+`src/monitoring/PresenceProxy.ts`,
+`tests/unit/CircuitBreaking-feature-metrics-tap.test.ts`.
+
+## Decision-point inventory
+
+- `CircuitBreakingIntelligenceProvider.evaluate → recordMetric (circuit-open path)` — modify — records `'shed'` instead of `'noop'` when no call ran.
+- `FeatureMetricsLedger.byFeature/summary rollup` — modify (additive) — new `shed` + `realCalls` fields; `fireRate` denominator changes to `realCalls`.
+- `InputGuard` LLM review attribution — add — passes `component: 'InputGuard'`.
+- `PresenceProxy.callLlm` attribution — add — default `component: 'PresenceProxy'`.
+
+This change has **no block/allow surface** — it is read-only observability plus
+metadata labels passed through an existing call. It never gates, blocks, throttles,
+or alters control flow.
+
+## 1. Over-block
+
+No block/allow surface — over-block not applicable. The metrics ledger never
+rejects anything; attribution is a label on an existing call.
+
+## 2. Under-block
+
+No block/allow surface — under-block not applicable.
+
+## 3. Level-of-abstraction fit
+
+Correct layer. This is observability (a detector/recorder), deliberately at the
+single funnel chokepoint the spec identifies (`CircuitBreakingIntelligenceProvider`).
+It does not own authority and does not duplicate a higher gate — it *feeds*
+`/metrics/features`, the existing read surface. The `shed` distinction lives where
+the circuit decision is already made, so no new decision logic is introduced —
+only an honest label on an outcome that already happened.
+
+## 4. Signal vs authority compliance
+
+**Required reference:** docs/signal-vs-authority.md
+
+- [x] No — this change has no block/allow surface.
+
+It produces signal (metrics rows) consumed by the read-only `/metrics/features`
+surface. No blocking authority, brittle or otherwise.
+
+## 5. Interactions
+
+- **Shadowing:** none. `recordMetric` is a side-channel after the breaker
+  decision; reordering is impossible (it records the decision already made).
+- **Double-fire:** none. Exactly one metric row per `evaluate()` as before; only
+  the recorded `outcome` string changed on the circuit-open path.
+- **Races:** none new. `FeatureMetricsLedger` writes are unchanged (WAL SQLite,
+  try/catch-swallowed). `PresenceProxy.callLlm` builds a local `opts` object — no
+  shared-state mutation (the caller's `options` is spread, not mutated).
+- **Feedback loops:** none. Metrics are observe-only; they never feed back into
+  the breaker or any gate.
+
+## 6. External surfaces
+
+- **Other agents / install base:** the `/metrics/features` JSON response gains
+  `shed` + `realCalls` fields (per-feature and in `totals`). Purely additive —
+  existing consumers reading `calls`/`noop`/`fired` are unaffected (`calls`
+  semantics preserved). The dashboard tab tolerates extra fields.
+- **External systems:** none (no Telegram/Slack/GitHub/Cloudflare surface).
+- **Persistent state:** `feature_metrics` SQLite rows now may carry
+  `outcome='shed'`. No schema change (`outcome` is free-text TEXT); old rows are
+  unaffected; no migration required.
+- **Timing:** none.
+
+## 7. Rollback cost
+
+Pure code change — revert and ship a patch. The only persistent residue is
+`outcome='shed'` rows in `feature_metrics`; after a revert those rows simply stop
+being written and any existing ones are harmless (queries that don't know `shed`
+ignore them; `calls` still counts them). No data migration, no agent-state repair,
+no user-visible regression during the rollback window.
+
+## Conclusion
+
+This review produced no design changes — the change is observability-only,
+additive, and squarely within the approved `llm-feature-metrics-spec` (Phase 1b).
+The `shed`/`realCalls` split is the fix for the misleading "99% noop" reading; the
+attribution labels advance the spec's stated "every caller gets tagged" goal for
+the two highest-volume callers (remaining callers are a follow-up). Build is clean
+and the metrics test suites (unit tap, ledger, integration, e2e) plus
+InputGuard/PresenceProxy suites are green (154 tests). Clear to ship.
+
+## Evidence pointers
+
+- `pnpm build` clean; `vitest run` green across the feature-metrics + InputGuard +
+  PresenceProxy suites (2026-06-03).
+- Durable patch: `.planning/resource-ledger-impl/slice-a-full.patch` (agent home).


### PR DESCRIPTION
## Summary

Phase 1b refinement of the per-feature LLM metrics funnel (`docs/specs/llm-feature-metrics-spec.md`), making `/metrics/features` an honest spend measure. Observability-only — never gates.

### 1. Honest call counts (`shed` outcome)
`CircuitBreakingIntelligenceProvider.evaluate` recorded circuit-open events (breaker refused the call, no LLM ran, ~0ms) as `noop` — identical to a completed call. So `calls` conflated "made a call" with "breaker refused a call," and a saturated agent read as ~99% `noop` (the 0ms-latency confound).

The circuit-open path now records a distinct **`shed`** outcome. `FeatureMetricsLedger` exposes **`shed`** + **`realCalls`** (= `calls − shed`) per-feature and in totals; `fireRate` divides by `realCalls`. `calls` is unchanged (backward-compatible).

### 2. Caller attribution
The spec requires "every caller gets tagged," but the two highest-frequency callers passed no `attribution.component` and bucketed under `unlabeled`. Added `component: 'InputGuard'` and a `PresenceProxy` default in `callLlm` (caller-supplied attribution still wins). Remaining callers are a follow-up.

## Testing
- `pnpm build` clean; 154 tests green (tap, ledger, integration, e2e, InputGuard, PresenceProxy suites).
- Tap test asserts `shed` on circuit-open; end-to-end ledger test asserts `shed`/`realCalls`.

## Process
- Side-effects review: `upgrades/side-effects/feature-metrics-shed-and-attribution.md`
- Release-note fragment: `upgrades/next/feature-metrics-shed-and-attribution.md`
- Added missing `parent-principle: "Observability"` to the spec (constitutional traceability).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
