### PR TITLE
feat(cli): instar dev:ci-failures <pr> — print a PR's exact failing tests (run-friction to infra #1)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -214,6 +214,8 @@ This returns your full capability matrix: scripts, hooks, Telegram status, jobs,
 
 Instar contributors can run `instar dev:preflight` before opening PRs to run lint, CapabilityIndex discoverability checks, and an advisory new-route-prefix scan against the diff.
 
+Run `instar dev:ci-failures <pr>` to print a red PR's exact failing tests (file:line + assertion) via the GitHub check-run annotations API — handy when `gh run view --log` returns nothing.
+
 
 **Private Viewing** — Render markdown as auth-gated HTML pages, accessible only through the agent's server (local or via tunnel).
 - Create: `curl -X POST http://localhost:4040/view -H 'Content-Type: application/json' -d '{"title":"Report","markdown":"# Private content"}'`

--- a/scripts/generate-builtin-manifest.cjs
+++ b/scripts/generate-builtin-manifest.cjs
@@ -307,6 +307,7 @@ function scanCliCommands() {
     { name: 'nuke', domain: 'operations' },
     { name: 'playbook', domain: 'context' },
     { name: 'dev-preflight', domain: 'development' },
+    { name: 'dev-ci-failures', domain: 'development' },
   ];
 
   for (const cmd of commands) {

--- a/site/src/content/docs/reference/cli.md
+++ b/site/src/content/docs/reference/cli.md
@@ -242,6 +242,7 @@ instar listener logs            # Tail listener logs
 ```bash
 instar route <task>             # One-shot framework + model routing for a task description
 instar dev:preflight            # Verify-only contributor guard: lint, CapabilityIndex tests, route-prefix warning
+instar dev:ci-failures <pr>     # Print a PR's exact failing tests (file:line + assertion) via the check-run annotations API
 instar jobMigrate               # Migrate jobs between schema versions
 instar ledgerCleanup            # Token ledger cleanup
 instar memoryBackfillEvidence   # Backfill evidence rows into the memory index

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2413,6 +2413,18 @@ program
     process.exit(exitCode);
   });
 
+// ── `instar dev:ci-failures <pr>` — print a PR's exact failing tests ─────
+
+program
+  .command('dev:ci-failures <pr>')
+  .description("Print a PR's exact failing tests (file:line + assertion) via the GitHub check-run annotations API")
+  .option('--repo <owner/repo>', 'Repository (default: JKHeadley/instar)')
+  .action(async (pr: string, opts: { repo?: string }) => {
+    const { runDevCiFailures } = await import('./commands/devCiFailures.js');
+    const exitCode = await runDevCiFailures({ pr, repo: opts.repo });
+    process.exit(exitCode);
+  });
+
 // ── `instar route` — Phase 5b suggest-and-confirm composition root (CLI) ─
 
 program

--- a/src/commands/devCiFailures.ts
+++ b/src/commands/devCiFailures.ts
@@ -1,0 +1,165 @@
+/**
+ * `instar dev:ci-failures <pr>` — print the exact failing tests (file:line +
+ * assertion) for a PR's CI run, via the GitHub **check-run annotations API**.
+ *
+ * Why this exists: in some environments `gh run view --log[-failed]` returns
+ * zero bytes (no readable job logs), which makes a red CI run undiagnosable from
+ * the terminal. The check-run *annotations* endpoint
+ * (`/repos/:owner/:repo/check-runs/:id/annotations`) still returns the failing
+ * `path:line` + the assertion message even when the log endpoint is empty. This
+ * command wraps that workaround so a contributor (or an autonomous agent) gets
+ * the precise failure instantly instead of re-discovering it mid-run.
+ *
+ * Read-only: it only calls `gh` GET endpoints; it never mutates anything.
+ */
+import { execFile } from 'node:child_process';
+import pc from 'picocolors';
+
+/** Shape of a GitHub check-run annotation (subset we use). */
+export interface CiAnnotation {
+  path?: string;
+  start_line?: number;
+  annotation_level?: string; // 'failure' | 'warning' | 'notice'
+  message?: string;
+}
+
+export interface CiFailuresOutput {
+  write(text: string): void;
+  error(text: string): void;
+}
+
+/** Injectable `gh` boundary so the command is unit-testable without the network. */
+export interface CiFailuresDeps {
+  /** Run a `gh` invocation and return its parsed JSON stdout (or throw). */
+  ghJson(args: string[]): Promise<unknown>;
+}
+
+export interface DevCiFailuresOptions {
+  pr: string;
+  repo?: string;
+  output?: CiFailuresOutput;
+  deps?: CiFailuresDeps;
+}
+
+const DEFAULT_REPO = 'JKHeadley/instar';
+const MAX_MESSAGE_LINES = 6;
+
+/**
+ * Pure: turn a check-run's annotations into actionable failure lines, dropping
+ * CI-infrastructure noise that isn't a test failure:
+ *  - non-`failure` levels (warnings/notices, e.g. the Node-20 deprecation notice),
+ *  - the workflow runner's own `.github/...` annotations,
+ *  - the generic `Process completed with exit code N.` step-failure line.
+ * Each kept entry is `path:line` + the (truncated) assertion message.
+ */
+export function extractFailureLines(annotations: CiAnnotation[]): string[] {
+  const lines: string[] = [];
+  for (const a of annotations) {
+    if ((a.annotation_level ?? '') !== 'failure') continue;
+    const path = a.path ?? '';
+    if (path === '.github' || path.startsWith('.github/')) continue;
+    const msg = (a.message ?? '').trim();
+    if (!msg) continue;
+    if (/^Process completed with exit code \d+\.?$/.test(msg)) continue;
+    const loc = a.start_line ? `${path}:${a.start_line}` : path || '(no path)';
+    const summary = msg.split('\n').slice(0, MAX_MESSAGE_LINES).join('\n');
+    lines.push(`${loc}\n${summary}`);
+  }
+  return lines;
+}
+
+function defaultDeps(): CiFailuresDeps {
+  return {
+    ghJson: (args) =>
+      new Promise((resolve, reject) => {
+        execFile('gh', args, { maxBuffer: 32 * 1024 * 1024 }, (err, stdout, stderr) => {
+          if (err) {
+            reject(new Error(`gh ${args.slice(0, 2).join(' ')} failed: ${(stderr || err.message).slice(0, 300)}`));
+            return;
+          }
+          try {
+            resolve(JSON.parse(stdout));
+          } catch (e) {
+            reject(new Error(`gh returned non-JSON: ${(e as Error).message}`));
+          }
+        });
+      }),
+  };
+}
+
+/**
+ * Resolve the PR's head SHA, list its FAILED check-runs, and print each one's
+ * test-level failure annotations. Returns 0 on success (even when failures are
+ * found — this is a diagnostic, not a gate), 1 on an operational error
+ * (PR unresolvable / API failure).
+ */
+export async function runDevCiFailures(opts: DevCiFailuresOptions): Promise<number> {
+  const repo = opts.repo ?? DEFAULT_REPO;
+  const out =
+    opts.output ?? { write: (t: string) => void process.stdout.write(t), error: (t: string) => void process.stderr.write(t) };
+  const deps = opts.deps ?? defaultDeps();
+
+  // 1. Resolve the PR head SHA.
+  let sha: string;
+  try {
+    const view = (await deps.ghJson(['pr', 'view', opts.pr, '--repo', repo, '--json', 'headRefOid'])) as {
+      headRefOid?: string;
+    };
+    sha = view.headRefOid ?? '';
+    if (!sha) throw new Error('no headRefOid on the PR');
+  } catch (e) {
+    out.error(`Could not resolve PR #${opts.pr} on ${repo}: ${(e as Error).message}\n`);
+    return 1;
+  }
+
+  // 2. Failed check-runs for that head SHA.
+  let failed: Array<{ id: number; name: string }>;
+  try {
+    const checks = (await deps.ghJson([
+      'api',
+      `repos/${repo}/commits/${sha}/check-runs?per_page=100`,
+      '--paginate',
+    ])) as { check_runs?: Array<{ id: number; name: string; conclusion: string }> };
+    failed = (checks.check_runs ?? [])
+      .filter((r) => r.conclusion === 'failure')
+      .map((r) => ({ id: r.id, name: r.name }));
+  } catch (e) {
+    out.error(`Could not list check-runs for ${sha.slice(0, 9)}: ${(e as Error).message}\n`);
+    return 1;
+  }
+
+  out.write(`${pc.bold(`PR #${opts.pr}`)} @ ${sha.slice(0, 9)} — ${failed.length} failed check(s)\n`);
+  if (failed.length === 0) {
+    out.write(pc.green('No failed checks.\n'));
+    return 0;
+  }
+
+  // 3. Annotations per failed check → actionable failure lines (deduped across
+  //    the node-20/node-22 shard pairs that report the identical failure).
+  const seen = new Set<string>();
+  let total = 0;
+  for (const check of failed) {
+    let annotations: CiAnnotation[] = [];
+    try {
+      annotations = ((await deps.ghJson(['api', `repos/${repo}/check-runs/${check.id}/annotations`])) as CiAnnotation[]) ?? [];
+    } catch {
+      continue; // annotations endpoint hiccup for one check — keep going
+    }
+    for (const line of extractFailureLines(annotations)) {
+      if (seen.has(line)) continue;
+      seen.add(line);
+      out.write(`\n${pc.red('✗')} ${line}\n`);
+      total++;
+    }
+  }
+
+  if (total === 0) {
+    out.write(
+      pc.yellow(
+        '\nThe failed checks have no test-level annotations — likely a build/lint/type step.\n' +
+          'Open the run in the browser, or check the step output directly.\n',
+      ),
+    );
+  }
+  return 0;
+}

--- a/src/data/builtin-manifest.json
+++ b/src/data/builtin-manifest.json
@@ -1,9 +1,9 @@
 {
   "$schema": "./builtin-manifest.schema.json",
   "schemaVersion": 1,
-  "generatedAt": "2026-06-03T13:56:02.469Z",
-  "instarVersion": "1.3.222",
-  "entryCount": 196,
+  "generatedAt": "2026-06-03T17:11:28.166Z",
+  "instarVersion": "1.3.225",
+  "entryCount": 197,
   "entries": {
     "hook:session-start": {
       "id": "hook:session-start",
@@ -778,7 +778,7 @@
       "type": "cli-command",
       "domain": "setup",
       "sourcePath": "src/cli.ts",
-      "contentHash": "1b2634f7e1f2a14c409625a87774b5d9fe06cf11b529d38d8b4489a76c6b6f4d",
+      "contentHash": "0dbe9408c77a7f88ef9978644cb9be45885c7a095ff8424361a1e9f7953cd099",
       "since": "2025-01-01"
     },
     "cli:setup": {
@@ -786,7 +786,7 @@
       "type": "cli-command",
       "domain": "setup",
       "sourcePath": "src/cli.ts",
-      "contentHash": "1b2634f7e1f2a14c409625a87774b5d9fe06cf11b529d38d8b4489a76c6b6f4d",
+      "contentHash": "0dbe9408c77a7f88ef9978644cb9be45885c7a095ff8424361a1e9f7953cd099",
       "since": "2025-01-01"
     },
     "cli:add": {
@@ -794,7 +794,7 @@
       "type": "cli-command",
       "domain": "setup",
       "sourcePath": "src/cli.ts",
-      "contentHash": "1b2634f7e1f2a14c409625a87774b5d9fe06cf11b529d38d8b4489a76c6b6f4d",
+      "contentHash": "0dbe9408c77a7f88ef9978644cb9be45885c7a095ff8424361a1e9f7953cd099",
       "since": "2025-01-01"
     },
     "cli:backup": {
@@ -802,7 +802,7 @@
       "type": "cli-command",
       "domain": "operations",
       "sourcePath": "src/cli.ts",
-      "contentHash": "1b2634f7e1f2a14c409625a87774b5d9fe06cf11b529d38d8b4489a76c6b6f4d",
+      "contentHash": "0dbe9408c77a7f88ef9978644cb9be45885c7a095ff8424361a1e9f7953cd099",
       "since": "2025-01-01"
     },
     "cli:git": {
@@ -810,7 +810,7 @@
       "type": "cli-command",
       "domain": "coordination",
       "sourcePath": "src/cli.ts",
-      "contentHash": "1b2634f7e1f2a14c409625a87774b5d9fe06cf11b529d38d8b4489a76c6b6f4d",
+      "contentHash": "0dbe9408c77a7f88ef9978644cb9be45885c7a095ff8424361a1e9f7953cd099",
       "since": "2025-01-01"
     },
     "cli:memory": {
@@ -818,7 +818,7 @@
       "type": "cli-command",
       "domain": "memory",
       "sourcePath": "src/cli.ts",
-      "contentHash": "1b2634f7e1f2a14c409625a87774b5d9fe06cf11b529d38d8b4489a76c6b6f4d",
+      "contentHash": "0dbe9408c77a7f88ef9978644cb9be45885c7a095ff8424361a1e9f7953cd099",
       "since": "2025-01-01"
     },
     "cli:knowledge": {
@@ -826,7 +826,7 @@
       "type": "cli-command",
       "domain": "memory",
       "sourcePath": "src/cli.ts",
-      "contentHash": "1b2634f7e1f2a14c409625a87774b5d9fe06cf11b529d38d8b4489a76c6b6f4d",
+      "contentHash": "0dbe9408c77a7f88ef9978644cb9be45885c7a095ff8424361a1e9f7953cd099",
       "since": "2025-01-01"
     },
     "cli:semantic": {
@@ -834,7 +834,7 @@
       "type": "cli-command",
       "domain": "memory",
       "sourcePath": "src/cli.ts",
-      "contentHash": "1b2634f7e1f2a14c409625a87774b5d9fe06cf11b529d38d8b4489a76c6b6f4d",
+      "contentHash": "0dbe9408c77a7f88ef9978644cb9be45885c7a095ff8424361a1e9f7953cd099",
       "since": "2025-01-01"
     },
     "cli:intent": {
@@ -842,7 +842,7 @@
       "type": "cli-command",
       "domain": "intent",
       "sourcePath": "src/cli.ts",
-      "contentHash": "1b2634f7e1f2a14c409625a87774b5d9fe06cf11b529d38d8b4489a76c6b6f4d",
+      "contentHash": "0dbe9408c77a7f88ef9978644cb9be45885c7a095ff8424361a1e9f7953cd099",
       "since": "2025-01-01"
     },
     "cli:feedback": {
@@ -850,7 +850,7 @@
       "type": "cli-command",
       "domain": "feedback",
       "sourcePath": "src/cli.ts",
-      "contentHash": "1b2634f7e1f2a14c409625a87774b5d9fe06cf11b529d38d8b4489a76c6b6f4d",
+      "contentHash": "0dbe9408c77a7f88ef9978644cb9be45885c7a095ff8424361a1e9f7953cd099",
       "since": "2025-01-01"
     },
     "cli:server": {
@@ -858,7 +858,7 @@
       "type": "cli-command",
       "domain": "server",
       "sourcePath": "src/cli.ts",
-      "contentHash": "1b2634f7e1f2a14c409625a87774b5d9fe06cf11b529d38d8b4489a76c6b6f4d",
+      "contentHash": "0dbe9408c77a7f88ef9978644cb9be45885c7a095ff8424361a1e9f7953cd099",
       "since": "2025-01-01"
     },
     "cli:status": {
@@ -866,7 +866,7 @@
       "type": "cli-command",
       "domain": "monitoring",
       "sourcePath": "src/cli.ts",
-      "contentHash": "1b2634f7e1f2a14c409625a87774b5d9fe06cf11b529d38d8b4489a76c6b6f4d",
+      "contentHash": "0dbe9408c77a7f88ef9978644cb9be45885c7a095ff8424361a1e9f7953cd099",
       "since": "2025-01-01"
     },
     "cli:user": {
@@ -874,7 +874,7 @@
       "type": "cli-command",
       "domain": "users",
       "sourcePath": "src/cli.ts",
-      "contentHash": "1b2634f7e1f2a14c409625a87774b5d9fe06cf11b529d38d8b4489a76c6b6f4d",
+      "contentHash": "0dbe9408c77a7f88ef9978644cb9be45885c7a095ff8424361a1e9f7953cd099",
       "since": "2025-01-01"
     },
     "cli:relationship": {
@@ -882,7 +882,7 @@
       "type": "cli-command",
       "domain": "relationships",
       "sourcePath": "src/cli.ts",
-      "contentHash": "1b2634f7e1f2a14c409625a87774b5d9fe06cf11b529d38d8b4489a76c6b6f4d",
+      "contentHash": "0dbe9408c77a7f88ef9978644cb9be45885c7a095ff8424361a1e9f7953cd099",
       "since": "2025-01-01"
     },
     "cli:job": {
@@ -890,7 +890,7 @@
       "type": "cli-command",
       "domain": "scheduling",
       "sourcePath": "src/cli.ts",
-      "contentHash": "1b2634f7e1f2a14c409625a87774b5d9fe06cf11b529d38d8b4489a76c6b6f4d",
+      "contentHash": "0dbe9408c77a7f88ef9978644cb9be45885c7a095ff8424361a1e9f7953cd099",
       "since": "2025-01-01"
     },
     "cli:lifeline": {
@@ -898,7 +898,7 @@
       "type": "cli-command",
       "domain": "communication",
       "sourcePath": "src/cli.ts",
-      "contentHash": "1b2634f7e1f2a14c409625a87774b5d9fe06cf11b529d38d8b4489a76c6b6f4d",
+      "contentHash": "0dbe9408c77a7f88ef9978644cb9be45885c7a095ff8424361a1e9f7953cd099",
       "since": "2025-01-01"
     },
     "cli:list": {
@@ -906,7 +906,7 @@
       "type": "cli-command",
       "domain": "monitoring",
       "sourcePath": "src/cli.ts",
-      "contentHash": "1b2634f7e1f2a14c409625a87774b5d9fe06cf11b529d38d8b4489a76c6b6f4d",
+      "contentHash": "0dbe9408c77a7f88ef9978644cb9be45885c7a095ff8424361a1e9f7953cd099",
       "since": "2025-01-01"
     },
     "cli:autostart": {
@@ -914,7 +914,7 @@
       "type": "cli-command",
       "domain": "operations",
       "sourcePath": "src/cli.ts",
-      "contentHash": "1b2634f7e1f2a14c409625a87774b5d9fe06cf11b529d38d8b4489a76c6b6f4d",
+      "contentHash": "0dbe9408c77a7f88ef9978644cb9be45885c7a095ff8424361a1e9f7953cd099",
       "since": "2025-01-01"
     },
     "cli:migrate": {
@@ -922,7 +922,7 @@
       "type": "cli-command",
       "domain": "updates",
       "sourcePath": "src/cli.ts",
-      "contentHash": "1b2634f7e1f2a14c409625a87774b5d9fe06cf11b529d38d8b4489a76c6b6f4d",
+      "contentHash": "0dbe9408c77a7f88ef9978644cb9be45885c7a095ff8424361a1e9f7953cd099",
       "since": "2025-01-01"
     },
     "cli:machines": {
@@ -930,7 +930,7 @@
       "type": "cli-command",
       "domain": "coordination",
       "sourcePath": "src/cli.ts",
-      "contentHash": "1b2634f7e1f2a14c409625a87774b5d9fe06cf11b529d38d8b4489a76c6b6f4d",
+      "contentHash": "0dbe9408c77a7f88ef9978644cb9be45885c7a095ff8424361a1e9f7953cd099",
       "since": "2025-01-01"
     },
     "cli:whoami": {
@@ -938,7 +938,7 @@
       "type": "cli-command",
       "domain": "identity",
       "sourcePath": "src/cli.ts",
-      "contentHash": "1b2634f7e1f2a14c409625a87774b5d9fe06cf11b529d38d8b4489a76c6b6f4d",
+      "contentHash": "0dbe9408c77a7f88ef9978644cb9be45885c7a095ff8424361a1e9f7953cd099",
       "since": "2025-01-01"
     },
     "cli:pair": {
@@ -946,7 +946,7 @@
       "type": "cli-command",
       "domain": "coordination",
       "sourcePath": "src/cli.ts",
-      "contentHash": "1b2634f7e1f2a14c409625a87774b5d9fe06cf11b529d38d8b4489a76c6b6f4d",
+      "contentHash": "0dbe9408c77a7f88ef9978644cb9be45885c7a095ff8424361a1e9f7953cd099",
       "since": "2025-01-01"
     },
     "cli:join": {
@@ -954,7 +954,7 @@
       "type": "cli-command",
       "domain": "coordination",
       "sourcePath": "src/cli.ts",
-      "contentHash": "1b2634f7e1f2a14c409625a87774b5d9fe06cf11b529d38d8b4489a76c6b6f4d",
+      "contentHash": "0dbe9408c77a7f88ef9978644cb9be45885c7a095ff8424361a1e9f7953cd099",
       "since": "2025-01-01"
     },
     "cli:wakeup": {
@@ -962,7 +962,7 @@
       "type": "cli-command",
       "domain": "coordination",
       "sourcePath": "src/cli.ts",
-      "contentHash": "1b2634f7e1f2a14c409625a87774b5d9fe06cf11b529d38d8b4489a76c6b6f4d",
+      "contentHash": "0dbe9408c77a7f88ef9978644cb9be45885c7a095ff8424361a1e9f7953cd099",
       "since": "2025-01-01"
     },
     "cli:leave": {
@@ -970,7 +970,7 @@
       "type": "cli-command",
       "domain": "coordination",
       "sourcePath": "src/cli.ts",
-      "contentHash": "1b2634f7e1f2a14c409625a87774b5d9fe06cf11b529d38d8b4489a76c6b6f4d",
+      "contentHash": "0dbe9408c77a7f88ef9978644cb9be45885c7a095ff8424361a1e9f7953cd099",
       "since": "2025-01-01"
     },
     "cli:doctor": {
@@ -978,7 +978,7 @@
       "type": "cli-command",
       "domain": "monitoring",
       "sourcePath": "src/cli.ts",
-      "contentHash": "1b2634f7e1f2a14c409625a87774b5d9fe06cf11b529d38d8b4489a76c6b6f4d",
+      "contentHash": "0dbe9408c77a7f88ef9978644cb9be45885c7a095ff8424361a1e9f7953cd099",
       "since": "2025-01-01"
     },
     "cli:review": {
@@ -986,7 +986,7 @@
       "type": "cli-command",
       "domain": "monitoring",
       "sourcePath": "src/cli.ts",
-      "contentHash": "1b2634f7e1f2a14c409625a87774b5d9fe06cf11b529d38d8b4489a76c6b6f4d",
+      "contentHash": "0dbe9408c77a7f88ef9978644cb9be45885c7a095ff8424361a1e9f7953cd099",
       "since": "2025-01-01"
     },
     "cli:nuke": {
@@ -994,7 +994,7 @@
       "type": "cli-command",
       "domain": "operations",
       "sourcePath": "src/cli.ts",
-      "contentHash": "1b2634f7e1f2a14c409625a87774b5d9fe06cf11b529d38d8b4489a76c6b6f4d",
+      "contentHash": "0dbe9408c77a7f88ef9978644cb9be45885c7a095ff8424361a1e9f7953cd099",
       "since": "2025-01-01"
     },
     "cli:playbook": {
@@ -1002,7 +1002,7 @@
       "type": "cli-command",
       "domain": "context",
       "sourcePath": "src/cli.ts",
-      "contentHash": "1b2634f7e1f2a14c409625a87774b5d9fe06cf11b529d38d8b4489a76c6b6f4d",
+      "contentHash": "0dbe9408c77a7f88ef9978644cb9be45885c7a095ff8424361a1e9f7953cd099",
       "since": "2025-01-01"
     },
     "cli:dev-preflight": {
@@ -1010,7 +1010,15 @@
       "type": "cli-command",
       "domain": "development",
       "sourcePath": "src/cli.ts",
-      "contentHash": "1b2634f7e1f2a14c409625a87774b5d9fe06cf11b529d38d8b4489a76c6b6f4d",
+      "contentHash": "0dbe9408c77a7f88ef9978644cb9be45885c7a095ff8424361a1e9f7953cd099",
+      "since": "2025-01-01"
+    },
+    "cli:dev-ci-failures": {
+      "id": "cli:dev-ci-failures",
+      "type": "cli-command",
+      "domain": "development",
+      "sourcePath": "src/cli.ts",
+      "contentHash": "0dbe9408c77a7f88ef9978644cb9be45885c7a095ff8424361a1e9f7953cd099",
       "since": "2025-01-01"
     },
     "template:build-stop-hook.sh": {

--- a/src/scaffold/templates.ts
+++ b/src/scaffold/templates.ts
@@ -746,6 +746,8 @@ This returns your full capability matrix: scripts, hooks, Telegram status, jobs,
 
 Instar contributors can run \`instar dev:preflight\` before opening PRs to run lint, CapabilityIndex discoverability checks, and an advisory new-route-prefix scan against the diff.
 
+Run \`instar dev:ci-failures <pr>\` to print a red PR's exact failing tests (file:line + assertion) via the GitHub check-run annotations API — handy when \`gh run view --log\` returns nothing.
+
 **Critical rule**: If this CLAUDE.md says a feature is "for standalone agents" or "when configured" or uses any qualifier — do NOT conclude you lack the feature. Check \`/capabilities\` instead. Documentation describes features in general; the API tells you what's actually running for YOU right now. When they conflict, the API wins.
 
 ### Registry First, Explore Second

--- a/tests/unit/devCiFailures.test.ts
+++ b/tests/unit/devCiFailures.test.ts
@@ -1,0 +1,140 @@
+import { describe, it, expect } from 'vitest';
+import {
+  extractFailureLines,
+  runDevCiFailures,
+  type CiAnnotation,
+  type CiFailuresDeps,
+} from '../../src/commands/devCiFailures.js';
+
+describe('extractFailureLines', () => {
+  it('keeps a real test failure with its path:line + assertion', () => {
+    const ann: CiAnnotation[] = [
+      { path: 'tests/unit/foo.test.ts', start_line: 111, annotation_level: 'failure', message: 'AssertionError: expected X to be Y' },
+    ];
+    expect(extractFailureLines(ann)).toEqual(['tests/unit/foo.test.ts:111\nAssertionError: expected X to be Y']);
+  });
+
+  it('drops non-failure levels (warnings/notices)', () => {
+    const ann: CiAnnotation[] = [
+      { path: '.github', start_line: 2, annotation_level: 'warning', message: 'Node.js 20 actions are deprecated.' },
+      { path: 'tests/unit/x.test.ts', start_line: 9, annotation_level: 'notice', message: 'a notice' },
+    ];
+    expect(extractFailureLines(ann)).toEqual([]);
+  });
+
+  it('drops workflow-runner noise (.github path + "Process completed with exit code N")', () => {
+    const ann: CiAnnotation[] = [
+      { path: '.github', start_line: 13734, annotation_level: 'failure', message: 'Process completed with exit code 1.' },
+      { path: '.github/workflows/ci.yml', start_line: 1, annotation_level: 'failure', message: 'some workflow failure' },
+      { path: 'src/foo.ts', annotation_level: 'failure', message: 'Process completed with exit code 1' },
+    ];
+    expect(extractFailureLines(ann)).toEqual([]);
+  });
+
+  it('truncates a long multi-line assertion message', () => {
+    const msg = Array.from({ length: 12 }, (_, i) => `line${i}`).join('\n');
+    const out = extractFailureLines([{ path: 'a.test.ts', start_line: 1, annotation_level: 'failure', message: msg }]);
+    expect(out[0].split('\n').length).toBe(1 + 6); // loc line + first 6 message lines
+  });
+
+  it('handles a missing path/line and empty message', () => {
+    const ann: CiAnnotation[] = [
+      { annotation_level: 'failure', message: 'no path' },
+      { path: 'b.test.ts', start_line: 3, annotation_level: 'failure', message: '   ' },
+    ];
+    expect(extractFailureLines(ann)).toEqual(['(no path)\nno path']);
+  });
+});
+
+/** Build injectable gh deps from canned responses keyed by a substring of the args. */
+function mockDeps(responses: Array<{ match: string; value: unknown; throws?: string }>): CiFailuresDeps {
+  return {
+    ghJson: async (args: string[]) => {
+      const joined = args.join(' ');
+      const hit = responses.find((r) => joined.includes(r.match));
+      if (!hit) throw new Error(`unexpected gh call: ${joined}`);
+      if (hit.throws) throw new Error(hit.throws);
+      return hit.value;
+    },
+  };
+}
+
+function capture() {
+  const out: string[] = [];
+  const err: string[] = [];
+  return { output: { write: (t: string) => out.push(t), error: (t: string) => err.push(t) }, out, err };
+}
+
+describe('runDevCiFailures', () => {
+  it('prints the failing test for a red PR and exits 0 (diagnostic, not a gate)', async () => {
+    const deps = mockDeps([
+      { match: 'pr view 42', value: { headRefOid: 'abc123def456' } },
+      { match: 'commits/abc123def456/check-runs', value: { check_runs: [
+        { id: 1, name: 'Unit shard 2/4', conclusion: 'failure' },
+        { id: 2, name: 'Type Check', conclusion: 'success' },
+      ] } },
+      { match: 'check-runs/1/annotations', value: [
+        { path: 'tests/unit/foo.test.ts', start_line: 111, annotation_level: 'failure', message: 'AssertionError: nope' },
+      ] },
+    ]);
+    const cap = capture();
+    const code = await runDevCiFailures({ pr: '42', repo: 'o/r', deps, output: cap.output });
+    expect(code).toBe(0);
+    const text = cap.out.join('');
+    expect(text).toContain('1 failed check');
+    expect(text).toContain('tests/unit/foo.test.ts:111');
+    expect(text).toContain('AssertionError: nope');
+  });
+
+  it('dedupes the identical failure reported by node-20 and node-22 shard checks', async () => {
+    const sameAnnotation = [
+      { path: 'tests/unit/dup.test.ts', start_line: 5, annotation_level: 'failure', message: 'boom' },
+    ];
+    const deps = mockDeps([
+      { match: 'pr view 7', value: { headRefOid: 'deadbeef00' } },
+      { match: 'commits/deadbeef00/check-runs', value: { check_runs: [
+        { id: 10, name: 'Unit (node 20, shard 2/4)', conclusion: 'failure' },
+        { id: 11, name: 'Unit (node 22, shard 2/4)', conclusion: 'failure' },
+      ] } },
+      { match: 'check-runs/10/annotations', value: sameAnnotation },
+      { match: 'check-runs/11/annotations', value: sameAnnotation },
+    ]);
+    const cap = capture();
+    await runDevCiFailures({ pr: '7', repo: 'o/r', deps, output: cap.output });
+    const occurrences = cap.out.join('').split('tests/unit/dup.test.ts:5').length - 1;
+    expect(occurrences).toBe(1); // printed once despite two checks
+  });
+
+  it('reports "No failed checks" + exit 0 when CI is green', async () => {
+    const deps = mockDeps([
+      { match: 'pr view 5', value: { headRefOid: 'green00' } },
+      { match: 'commits/green00/check-runs', value: { check_runs: [{ id: 1, name: 'x', conclusion: 'success' }] } },
+    ]);
+    const cap = capture();
+    const code = await runDevCiFailures({ pr: '5', repo: 'o/r', deps, output: cap.output });
+    expect(code).toBe(0);
+    expect(cap.out.join('')).toContain('No failed checks');
+  });
+
+  it('exits 1 with an error message when the PR cannot be resolved', async () => {
+    const deps = mockDeps([{ match: 'pr view 999', throws: 'no such PR', value: null }]);
+    const cap = capture();
+    const code = await runDevCiFailures({ pr: '999', repo: 'o/r', deps, output: cap.output });
+    expect(code).toBe(1);
+    expect(cap.err.join('')).toContain('Could not resolve PR #999');
+  });
+
+  it('notes when failed checks have no test-level annotations (build/lint step)', async () => {
+    const deps = mockDeps([
+      { match: 'pr view 8', value: { headRefOid: 'buildfail0' } },
+      { match: 'commits/buildfail0/check-runs', value: { check_runs: [{ id: 3, name: 'Build', conclusion: 'failure' }] } },
+      { match: 'check-runs/3/annotations', value: [
+        { path: '.github', start_line: 1, annotation_level: 'failure', message: 'Process completed with exit code 1.' },
+      ] },
+    ]);
+    const cap = capture();
+    const code = await runDevCiFailures({ pr: '8', repo: 'o/r', deps, output: cap.output });
+    expect(code).toBe(0);
+    expect(cap.out.join('')).toContain('no test-level annotations');
+  });
+});

--- a/upgrades/dev-ci-failures-tool.eli16.md
+++ b/upgrades/dev-ci-failures-tool.eli16.md
@@ -1,0 +1,21 @@
+# `instar dev:ci-failures` — ELI16
+
+Viewable private artifact:
+https://echo.dawn-tunnel.dev/view/41bc3523-a95d-4038-bd43-af8a942e0008?sig=e785278aea6a2e82502cc55fe56b98e55ab4cef543b71ddf32c953db7985c191
+
+When a pull request's automated tests go red, you want to know *which* test broke and where.
+Normally you'd open the CI logs — but in some setups the command that fetches those logs comes
+back completely empty, so a red run tells you "something failed" and nothing else. I hit this
+repeatedly while shipping fixes this run, and had to re-discover a workaround each time.
+
+This turns that workaround into a permanent tool. `instar dev:ci-failures <pr>` reads a
+*different* GitHub endpoint (the per-check "annotations") that still reports the exact failing
+file, line number, and assertion message even when the logs are blank. It also tidies the
+output: it merges the duplicate failure that the Node-20 and Node-22 test shards both report,
+and it hides the generic CI-runner noise ("Process completed with exit code 1").
+
+It's read-only and informational — it never changes anything, it just shows you the failures.
+Pairs with `instar dev:preflight` as the contributor dev-loop toolkit.
+
+_Tier-2 · branch `echo/dev-ci-failures-tool` · the first of the "turn this run's friction into
+infrastructure" improvements._

--- a/upgrades/next/dev-ci-failures-tool.md
+++ b/upgrades/next/dev-ci-failures-tool.md
@@ -1,0 +1,50 @@
+# Upgrade Guide — vNEXT
+
+<!-- bump: minor -->
+
+## What Changed
+
+Adds `instar dev:ci-failures <pr>` — a contributor/agent dev command that prints a
+PR's **exact failing tests** (`file:line` + the assertion message) by reading the
+GitHub **check-run annotations API**.
+
+**Why this exists (a real friction → infrastructure).** In some environments
+`gh run view --log` / `--log-failed` return zero bytes, which makes a red CI run
+undiagnosable from the terminal — you can see *that* shards failed but not *which*
+test. The check-run *annotations* endpoint
+(`/repos/:owner/:repo/check-runs/:id/annotations`) still returns the failing
+`path:line` + assertion even when the log endpoint is empty. This command wraps
+that workaround so a contributor (or an autonomous agent shepherding its own PR)
+gets the precise failure instantly instead of re-discovering the trick mid-run.
+
+**What it does:** resolves the PR's head SHA → lists its FAILED check-runs →
+prints each one's test-level failure annotations, de-duplicating the identical
+failure that the node-20 / node-22 shard pair both report. It drops CI-runner
+noise (the `.github/...` annotations and the generic `Process completed with exit
+code N`). Read-only — it only calls `gh` GET endpoints; it never mutates anything.
+Exit 0 even when failures are found (it's a diagnostic, not a gate); exit 1 only on
+an operational error (PR unresolvable / API failure).
+
+Pairs with `instar dev:preflight` (#716) as the contributor dev-loop toolkit.
+
+## What to Tell Your User
+
+Nothing required — it's a developer/agent tool for working **on** Instar. When a PR's
+CI goes red, `instar dev:ci-failures <pr>` prints the exact failing tests instead of
+an unreadable log.
+
+## Summary of New Capabilities
+
+- `instar dev:ci-failures <pr> [--repo owner/repo]` — print a PR's exact failing tests
+  (file:line + assertion) via the GitHub check-run annotations API. Read-only.
+
+## Evidence
+
+- Built from a recurring mid-run friction: `gh run view --log[-failed]` returned 0 bytes
+  on this environment across multiple PRs (#716/#717/#718); the annotations API was the
+  reliable path to the failing test+line.
+- Tests: `tests/unit/devCiFailures.test.ts` — the pure `extractFailureLines` (keeps real
+  failures; drops warnings / `.github` / `Process completed` noise; truncates long
+  messages) + `runDevCiFailures` with injected `gh` deps (red PR → prints the test;
+  shard-pair dedup; green PR → "No failed checks"; unresolvable PR → exit 1; build/lint
+  failure with no test annotations → a helpful note).

--- a/upgrades/side-effects/dev-ci-failures-tool.md
+++ b/upgrades/side-effects/dev-ci-failures-tool.md
@@ -1,0 +1,54 @@
+# Side-Effects Review — `instar dev:ci-failures`
+
+**Version / slug:** `dev-ci-failures-tool`
+**Date:** `2026-06-03`
+**Author:** `echo`
+**Second-pass reviewer:** `not required (Tier-2 — new read-only dev CLI command; no runtime/server surface, no decision boundary)`
+
+## Summary of the change
+
+New `instar dev:ci-failures <pr>` CLI command (`src/commands/devCiFailures.ts`, wired in
+`src/cli.ts`) that prints a PR's failing tests via the GitHub check-run annotations API.
+Read-only: it shells out to `gh` GET endpoints only. Adds a manifest catalog entry
+(`cli:dev-ci-failures`, colon-free id per Codey's #716 convention fix) + awareness docs
+(CLAUDE.md, templates.ts, site cli reference). No server route, no config, no state.
+
+## Decision-point inventory
+
+1. **Annotations API vs log parsing.** Chose the check-run *annotations* endpoint because
+   `gh run view --log[-failed]` returns 0 bytes in some environments (the friction that
+   motivated this). Annotations carry `path:line` + the assertion even when logs are empty.
+2. **Diagnostic, not a gate (exit 0 even with failures).** It informs; it does not fail the
+   shell on a red PR. Exit 1 is reserved for operational errors (PR unresolvable / API
+   error) so a script can tell "couldn't run" from "ran, here are the failures."
+3. **Shard-pair dedup.** The node-20 / node-22 shard checks report the identical failure;
+   the command de-dupes by the formatted line so each distinct failure prints once.
+4. **Noise filter.** Drops `.github/...` annotations and `Process completed with exit code N`
+   (CI-runner artifacts, not test failures). When a failed check has no test-level
+   annotations (a build/lint/type step), it prints a note rather than silently showing nothing.
+
+## 1. Blast radius / reversibility
+
+Additive: one new command file + one cli.ts command block + a manifest entry + doc lines.
+Fully reversible. No existing behavior touched. Read-only external calls (gh GET).
+
+## 2. Failure modes
+
+- `gh` not installed / not authenticated → the command surfaces the gh error and exits 1.
+- An annotations-endpoint hiccup for one check → that check is skipped, others still print.
+- A PR with no failed checks → prints "No failed checks", exit 0.
+All handled; none crash.
+
+## 3. Manifest / docs
+
+`cli:dev-ci-failures` added to the generator's command list → colon-free manifest id
+(passes the type:name convention). CLAUDE.md and `templates.ts`'s `generateClaudeMd` were
+edited in sync so `verify-deployed-templates` stays green (locally confirmed). Manifest
+`generatedAt` timestamp aside, the generator output is deterministic.
+
+## 4. Tests
+
+`tests/unit/devCiFailures.test.ts` — pure `extractFailureLines` (both sides: keeps real
+failures, drops warnings/`.github`/`Process completed`, truncates long messages, handles
+missing path) + `runDevCiFailures` with injected `gh` deps (red PR prints the test; shard
+dedup; green PR; unresolvable PR → exit 1; build-step-with-no-test-annotations note). 10 tests.


### PR DESCRIPTION
## What
First of the **"turn this run's friction into infrastructure"** improvements.

`gh run view --log[-failed]` returns **0 bytes** in some environments, making a red CI run undiagnosable from the terminal — you see *that* shards failed, not *which* test. This cost real time across #716/#717/#718. The check-run **annotations API** (`/repos/:o/:r/check-runs/:id/annotations`) still returns the failing `path:line` + assertion even when the log endpoint is empty.

`instar dev:ci-failures <pr>` wraps that: resolve PR head SHA -> list FAILED check-runs -> print each one's test-level failure annotations. De-dupes the identical failure the node-20/node-22 shard pair both report; drops CI-runner noise (`.github/...`, the exit-code step line); notes when a failed check has no test annotations (build/lint step). **Read-only** (gh GET only). Exit 0 even with failures (diagnostic, not a gate); exit 1 only on an operational error.

## Tests
`tests/unit/devCiFailures.test.ts` (10): pure `extractFailureLines` (keeps real failures; drops warnings/`.github`/exit-code lines; trims long messages; missing path) + `runDevCiFailures` with injected `gh` deps (red PR prints the test; shard-pair dedup; green PR; unresolvable PR -> exit 1; build-step note).

Tier-2 · manifest entry (`cli:dev-ci-failures`, colon-free id per #716) + awareness docs (CLAUDE.md/templates.ts synced so verify-deployed-templates stays green; site cli ref) + ship-gate (`upgrades/next` bump:minor + side-effects + ELI16 verified-200). `pnpm lint` + `pnpm build` + discoverability(106) green. Pairs with Codey's `dev:preflight` (#716).

🤖 Generated with [Claude Code](https://claude.com/claude-code)