### PR TITLE
fix(upgrades): unblock publish — strip inline code from two release-note fragments

### DIFF
--- a/upgrades/next/dev-ci-failures-tool.md
+++ b/upgrades/next/dev-ci-failures-tool.md
@@ -30,7 +30,7 @@ Pairs with `instar dev:preflight` (#716) as the contributor dev-loop toolkit.
 ## What to Tell Your User
 
 Nothing required — it's a developer/agent tool for working **on** Instar. When a PR's
-CI goes red, `instar dev:ci-failures <pr>` prints the exact failing tests instead of
+CI goes red, the new developer command prints the exact failing tests instead of
 an unreadable log.
 
 ## Summary of New Capabilities

--- a/upgrades/next/reaper-cpu-aware-keep.md
+++ b/upgrades/next/reaper-cpu-aware-keep.md
@@ -41,7 +41,7 @@ gate), so it's dogfooded on a real loaded box before any wider rollout.
 
 ## What to Tell Your User
 
-Nothing — `cpuAwareActiveProcessKeep` is **dark by default** (off everywhere
+Nothing — the new under-load reaper refinement is **dark by default** (off everywhere
 except development agents). It changes no user-visible behavior on a normal
 install. If surfaced at all, surface it as **⚗️ Experimental**: it refines the
 reaper's idle-detection under load and is still being validated on dev agents.


### PR DESCRIPTION
## Problem

The **Publish to npm** workflow has been failing at the **Check upgrade guide** step since v1.3.225 — so **no release has cut**, and three merged PRs (#720 dev:ci-failures, #721 burn-detector activity gate, #722 reaper cpu-aware-keep) are all stuck un-shipped. Agents never auto-updated; in particular the burn-detector noise fix (#721) that a user is actively waiting on never reached any agent.

## Root cause

The publish step assembles all queued `upgrades/next/*.md` fragments into one guide, then runs `check-upgrade-guide.js` (`validateGuideContent`). Two fragments had **inline code (backticks) in their "What to Tell Your User" section**, which the validator rejects (user-facing language must be plain, not config/CLI snippets):

- `dev-ci-failures-tool.md`: `` `instar dev:ci-failures <pr>` ``
- `reaper-cpu-aware-keep.md`: `` `cpuAwareActiveProcessKeep` ``

(Verified by assembling locally and running `validateGuideContent` → exactly this error. These slipped past per-PR pre-push because the assembled multi-fragment guide is what publish validates.)

## Fix

Rephrased both "What to Tell Your User" sections conversationally (no inline code). Assembled guide now validates clean (`validateGuideContent` → `[]`). Docs-only; no runtime surface; the fragments' "What Changed"/"Evidence" sections are untouched.

## Result

Once merged, publish succeeds and v1.3.226 ships #720 + #721 + #722 fleet-wide.

## Follow-up (not in this PR)

The per-PR pre-push gate validates each fragment in isolation but publish validates the **assembled** guide — that gap let these through. Worth hardening the pre-push gate to validate the assembled guide the same way publish does. <!-- tracked: will file as a gaps item after this lands -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)