### PR TITLE
fix(perf): cache StateManager.listSessions — kill the systemic session-dir re-read CPU hot-loop

### DIFF
--- a/src/core/StateManager.ts
+++ b/src/core/StateManager.ts
@@ -49,14 +49,33 @@ function describeReadError(err: unknown, filePath: string): {
   };
 }
 
+/** TTL for the listSessions read cache. Short enough that read-only staleness is
+ *  negligible for the reaper/scheduler/sentinels (which poll on far longer cycles),
+ *  long enough to collapse the many sub-second redundant calls into one disk read. */
+const SESSIONS_CACHE_TTL_MS = 1000;
+
 export class StateManager {
   private stateDir: string;
   private _readOnly: boolean = false;
   private _sessionPoolActive: boolean = false;
   private _machineId: string | null = null;
+  private readonly _now: () => number;
+  /** Memoized full session list — the fix for the systemic CPU hot-loop where
+   *  `listSessions` re-read + re-parsed EVERY session file from disk on EVERY call,
+   *  and is called each tick by the reaper + sentinels via `listRunningSessions`
+   *  (O(sessions × pollers × tick-rate) disk reads). Invalidated on any session
+   *  write so spawns/terminations remain instantly visible. */
+  private _sessionsCache: Session[] | null = null;
+  private _sessionsCacheAt = 0;
 
-  constructor(stateDir: string) {
+  constructor(stateDir: string, opts?: { now?: () => number }) {
     this.stateDir = stateDir;
+    this._now = opts?.now ?? (() => Date.now());
+  }
+
+  /** Drop the listSessions cache so the next read reflects a just-written change. */
+  private invalidateSessionsCache(): void {
+    this._sessionsCache = null;
   }
 
   /**
@@ -146,12 +165,35 @@ export class StateManager {
     this.validateKey(session.id, 'sessionId');
     const filePath = path.join(this.stateDir, 'state', 'sessions', `${session.id}.json`);
     this.atomicWrite(filePath, JSON.stringify(session, null, 2));
+    this.invalidateSessionsCache(); // a write must be visible to the next list
   }
 
   listSessions(filter?: { status?: Session['status'] }): Session[] {
-    const dir = path.join(this.stateDir, 'state', 'sessions');
-    if (!fs.existsSync(dir)) return [];
+    const all = this.readAllSessionsCached();
+    const filtered = filter?.status ? all.filter(s => s.status === filter.status) : all;
+    // Return shallow copies so a caller mutating a result can't corrupt the shared
+    // cache; listSessions output is treated as a read-only snapshot by all consumers.
+    return filtered.map(s => ({ ...s }));
+  }
 
+  /**
+   * Read every session file (readdir + readFileSync + JSON.parse), memoized for
+   * SESSIONS_CACHE_TTL_MS. THIS is the hot path: the reaper and every sentinel call
+   * `listRunningSessions` → `listSessions` on each tick, so without the cache the
+   * server re-read + re-parsed the FULL session directory many times per second
+   * (the systemic ~30%-CPU `readFileUtf8` hot-loop). Writes invalidate the cache, so
+   * a freshly spawned or removed session is visible on the very next call.
+   */
+  private readAllSessionsCached(): Session[] {
+    if (this._sessionsCache && (this._now() - this._sessionsCacheAt) < SESSIONS_CACHE_TTL_MS) {
+      return this._sessionsCache;
+    }
+    const dir = path.join(this.stateDir, 'state', 'sessions');
+    if (!fs.existsSync(dir)) {
+      this._sessionsCache = [];
+      this._sessionsCacheAt = this._now();
+      return this._sessionsCache;
+    }
     const files = fs.readdirSync(dir).filter(f => f.endsWith('.json'));
     const sessions: Session[] = [];
     for (const f of files) {
@@ -170,10 +212,8 @@ export class StateManager {
         });
       }
     }
-
-    if (filter?.status) {
-      return sessions.filter(s => s.status === filter.status);
-    }
+    this._sessionsCache = sessions;
+    this._sessionsCacheAt = this._now();
     return sessions;
   }
 
@@ -184,6 +224,7 @@ export class StateManager {
     if (!fs.existsSync(filePath)) return false;
     try {
       SafeFsExecutor.safeUnlinkSync(filePath, { operation: 'src/core/StateManager.ts:166' });
+      this.invalidateSessionsCache(); // removal must be visible to the next list
       return true;
     } catch {
       return false;

--- a/tests/unit/state-manager-listsessions-cache.test.ts
+++ b/tests/unit/state-manager-listsessions-cache.test.ts
@@ -1,0 +1,92 @@
+/**
+ * StateManager.listSessions read-cache — the fix for the systemic CPU hot-loop
+ * where listSessions re-read + re-parsed EVERY session file on EVERY call (it's
+ * called each tick by the reaper + sentinels via listRunningSessions). The cache
+ * collapses sub-second redundant calls into one disk read, and is invalidated on
+ * any session write so spawns/terminations stay instantly visible.
+ *
+ * Both sides of every boundary: cache HIT within TTL, MISS after TTL, immediate
+ * invalidation on saveSession/removeSession, filter correctness, copy-safety.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { StateManager } from '../../src/core/StateManager.js';
+import type { Session } from '../../src/core/types.js';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+
+const mkSession = (over?: Partial<Session>): Session => ({
+  id: 'a', name: 'sess', status: 'running', tmuxSession: 'tmux-a',
+  startedAt: new Date(0).toISOString(), ...over,
+});
+
+describe('StateManager.listSessions cache', () => {
+  let tmpDir: string;
+  let clock: number;
+  let sm: StateManager;
+  const sessionsDir = () => path.join(tmpDir, 'state', 'sessions');
+  // Write a session file DIRECTLY (bypassing saveSession) to simulate a disk
+  // change the in-memory cache has NOT been told about.
+  const writeDirect = (s: Session) =>
+    fs.writeFileSync(path.join(sessionsDir(), `${s.id}.json`), JSON.stringify(s));
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'instar-smcache-'));
+    fs.mkdirSync(sessionsDir(), { recursive: true });
+    clock = 1_000_000;
+    sm = new StateManager(tmpDir, { now: () => clock });
+  });
+  afterEach(() => {
+    SafeFsExecutor.safeRmSync(tmpDir, { recursive: true, force: true, operation: 'tests/unit/state-manager-listsessions-cache.test.ts' });
+  });
+
+  it('serves a cache HIT within the TTL (a direct disk add is NOT seen until TTL elapses)', () => {
+    sm.saveSession(mkSession({ id: 'a' }));
+    expect(sm.listSessions().map(s => s.id).sort()).toEqual(['a']); // primes the cache
+    writeDirect(mkSession({ id: 'b' }));                            // disk changed, cache stale
+    expect(sm.listSessions().map(s => s.id).sort()).toEqual(['a']); // HIT — 'b' not seen
+    clock += 1100;                                                  // past the 1000ms TTL
+    expect(sm.listSessions().map(s => s.id).sort()).toEqual(['a', 'b']); // MISS — re-read
+  });
+
+  it('saveSession invalidates immediately (a spawn is visible on the very next call, no TTL wait)', () => {
+    sm.saveSession(mkSession({ id: 'a' }));
+    sm.listSessions(); // prime
+    sm.saveSession(mkSession({ id: 'c' })); // write through the funnel
+    expect(sm.listSessions().map(s => s.id).sort()).toEqual(['a', 'c']); // same clock instant
+  });
+
+  it('removeSession invalidates immediately (a termination is gone on the next call)', () => {
+    sm.saveSession(mkSession({ id: 'a' }));
+    sm.saveSession(mkSession({ id: 'b' }));
+    sm.listSessions(); // prime
+    sm.removeSession('a');
+    expect(sm.listSessions().map(s => s.id).sort()).toEqual(['b']); // same clock instant
+  });
+
+  it('applies the status filter to the cached list', () => {
+    sm.saveSession(mkSession({ id: 'a', status: 'running' }));
+    sm.saveSession(mkSession({ id: 'b', status: 'completed' }));
+    sm.saveSession(mkSession({ id: 'c', status: 'running' }));
+    expect(sm.listSessions({ status: 'running' }).map(s => s.id).sort()).toEqual(['a', 'c']);
+    // second call (cache hit) returns the same filtered result
+    expect(sm.listSessions({ status: 'completed' }).map(s => s.id)).toEqual(['b']);
+  });
+
+  it('returns copies — mutating a result cannot corrupt the shared cache', () => {
+    sm.saveSession(mkSession({ id: 'a', status: 'running' }));
+    const first = sm.listSessions();
+    first[0].status = 'completed'; // mutate the returned object
+    const second = sm.listSessions(); // cache hit
+    expect(second[0].status).toBe('running'); // cache untouched
+  });
+
+  it('still returns correct data + survives a corrupt session file (skips it)', () => {
+    sm.saveSession(mkSession({ id: 'a' }));
+    fs.writeFileSync(path.join(sessionsDir(), 'bad.json'), '{ not json');
+    clock += 1100; // force a fresh read so the corrupt file is encountered
+    expect(sm.listSessions().map(s => s.id)).toEqual(['a']); // corrupt skipped, valid kept
+  });
+});

--- a/upgrades/next/statemanager-listsessions-cache.md
+++ b/upgrades/next/statemanager-listsessions-cache.md
@@ -1,0 +1,52 @@
+# Upgrade Guide — vNEXT
+
+<!-- bump: patch -->
+
+## What Changed
+
+`StateManager.listSessions()` now serves from a short-TTL in-memory cache instead
+of re-reading and re-parsing every session file from disk on every call.
+
+**The bug (a systemic CPU hot-loop).** `listSessions()` did `readdirSync` +
+`readFileSync` + `JSON.parse` of **every** session JSON file on **every** call —
+and it's called each tick by the SessionReaper and the sentinels via
+`listRunningSessions()`. So the cost was O(sessions × pollers × tick-rate) disk
+reads, which kept agent servers spinning at 50–67% CPU (a CDP profile showed ~30%
+of server CPU was literally `readFileUtf8`, with `listSessions` on top). It was
+systemic (every agent with sessions + active pollers) and survived restarts —
+which is exactly why bouncing a hot server never helped.
+
+**The fix.** A 1-second TTL cache on the full session list. The many sub-second
+read-only callers within a tick now share one disk read; the cache is invalidated
+on every session write (`saveSession` / `removeSession`), so a freshly spawned or
+terminated session is visible on the very next call — no staleness for the cases
+that matter. `listSessions` returns shallow copies, so a caller can't corrupt the
+shared cache. StateManager is the sole in-process writer of session files, so the
+invalidation is complete (cross-machine writes carry at most the 1s TTL of
+staleness, which the reaper/scheduler already tolerate).
+
+Net effect: the per-tick session-directory churn collapses to near-zero, fixing
+the agent-server CPU hot-loop fleet-wide with no behavior change.
+
+## What to Tell Your User
+
+Nothing required — it's an internal performance fix. If your agent's server was
+running hot / the machine load was high with no obvious cause, this is a likely
+culprit and it's now fixed; servers idle much cooler.
+
+## Summary of New Capabilities
+
+- None (no new API, route, or config). `StateManager.listSessions()` is now cached
+  (1s TTL, write-invalidated); behavior is unchanged, cost drops from O(files) per
+  call to one read per second of read-only traffic.
+
+## Evidence
+
+- Pinned with node's inspector: SIGUSR1 → CDP CPU profile of a hot agent server
+  showed 30.8% `readFileUtf8` + 7% `listSessions` (StateManager.js:151), called via
+  the reaper/sentinel ticks — the symbolicated JS frame macOS `sample` couldn't show.
+- Tests: `tests/unit/state-manager-listsessions-cache.test.ts` — 6 tests (cache HIT
+  within TTL; MISS after TTL; immediate invalidation on saveSession + removeSession;
+  status-filter on cached data; copy-safety; corrupt-file skip). The 71 existing
+  StateManager tests + 255 consumer tests (reaper, scheduler, restart-all, recovery)
+  stay green.

--- a/upgrades/side-effects/statemanager-listsessions-cache.md
+++ b/upgrades/side-effects/statemanager-listsessions-cache.md
@@ -1,0 +1,72 @@
+# Side-Effects Review — StateManager.listSessions read-cache
+
+**Version / slug:** `statemanager-listsessions-cache`
+**Date:** `2026-06-03`
+**Author:** `echo`
+**Second-pass reviewer:** `recommended — touches a core, heavily-used read path`
+
+## Summary of the change
+
+`StateManager.listSessions()` is memoized with a 1s TTL, invalidated on
+`saveSession` / `removeSession`. Fixes the systemic CPU hot-loop where it re-read +
+re-parsed every session file on every reaper/sentinel tick.
+
+## Decision-point inventory
+
+1. **TTL = 1000ms.** Long enough to collapse the many sub-second redundant calls
+   (the churn), short enough that read-only staleness is negligible for the
+   consumers (reaper tick 120s; sentinels seconds-to-minutes; scheduler cron).
+2. **Invalidate on write, not TTL-only.** A spawn/termination must be visible
+   immediately (the scheduler/reaper must not act on a stale view of who exists),
+   so every write drops the cache rather than waiting out the TTL.
+3. **Return shallow copies.** Prevents a consumer that mutates a returned Session
+   from corrupting the shared cache. Consumers already treat the result as a
+   read-only snapshot; nested-object aliasing is a non-issue for the scalar fields
+   they read.
+
+## 1. Correctness — could a caller see a WRONG session list?
+
+- **A write this process made:** no — `saveSession`/`removeSession` invalidate, so
+  the next `listSessions` re-reads. Verified by tests (immediate visibility, same
+  clock instant).
+- **A write ANOTHER process/machine made:** visible after at most 1s (the TTL).
+  This is acceptable: the reaper is two-phase + idempotent-terminate (a vanished
+  session is a no-op), the scheduler polls on cron, and the multi-machine layer
+  already tolerates file-level races. No consumer requires sub-second cross-process
+  session visibility.
+- **Sole-writer invariant:** confirmed by grep — StateManager is the ONLY
+  in-process writer of `state/sessions/*.json` (all 13 SessionManager call sites
+  funnel through `saveSession`/`removeSession`). So in-process invalidation is
+  complete.
+
+## 2. Read-only / standby + session pool
+
+`listSessions` is a read; the cache is per-instance in-memory and does not touch
+`guardWrite`. On a read-only standby it behaves identically (just caches reads).
+Writes remain guarded; the cache is only dropped *after* a write succeeds.
+
+## 3. Memory
+
+One extra array reference per StateManager instance (the cached session list) —
+the same objects already parsed; negligible. Dropped/replaced on each refresh.
+
+## 4. Blast radius
+
+Pure internal optimization of one method; no API/route/config surface, no behavior
+change. Always-on (not flagged) because it's a correctness-preserving perf fix, not
+a risk-bearing feature — the same justification as any cache with write-invalidation.
+A second-pass review is still recommended because the read path is load-bearing
+(reaper, scheduler, restart, recovery all depend on it).
+
+## 5. Test seam
+
+Constructor gains an optional `{ now?: () => number }` (default `Date.now`) purely
+so the TTL is deterministically testable; production callers are unaffected
+(unchanged single-arg construction).
+
+## 6. What it does NOT change
+
+- `getSession(id)` (single-file read) is untouched — not a churn source.
+- No change to write semantics, atomicity, the read-only guard, or the on-disk
+  format.
+- No new config, route, migration, or agent-facing surface.

--- a/upgrades/statemanager-listsessions-cache.eli16.md
+++ b/upgrades/statemanager-listsessions-cache.eli16.md
@@ -1,0 +1,36 @@
+# Why the agent servers were running hot (and the one-line-idea fix)
+
+## The one-sentence version
+Every few moments, each agent's server asked "what sessions exist?" — and to answer, it opened and re-read **every** session file off the disk, **from scratch, every single time**. Many watchers asking that many times a second = the disk-reading never stopped, and the server's engine ran hot. The fix: remember the answer for one second.
+
+## The library analogy
+Imagine a librarian who, every time *anyone* asks "how many books are checked out?", walks the entire building, opens every drawer, and re-counts from zero. Now imagine five assistants each asking that question several times a second. The librarian never sits down — exhausted, sweating, accomplishing nothing new, because the answer barely changes second to second.
+
+The fix is obvious once you see it: **count once, write the number on a sticky note, and reuse it for the next second.** When a book is actually checked out or returned, tear up the note and re-count. That's it.
+
+## What was actually happening
+- `listSessions()` did: list the folder → open every `.json` file → parse each one. No memory of the last answer.
+- The session-reaper and several watchdogs each call it on every tick (many times a second between them).
+- So it was: (number of sessions) × (number of watchers) × (ticks per second) disk reads — constantly. A CPU profiler showed **~30% of the server's entire CPU was literally re-reading those files**.
+- This is why it was everywhere (every agent), and why **restarting a hot server never helped** — the re-reading just started over.
+
+## The fix
+- Remember the session list for **1 second** (a tiny cache).
+- All the watchers asking within that second share **one** read instead of dozens.
+- The instant a session is created or removed, **throw the note away** so the next answer is fresh — no stale views, spawns and shutdowns show up immediately.
+- Hand out **copies** so a reader can't accidentally scribble on the shared note.
+
+That collapses the constant disk-churn to about one read per second, and the agent servers idle cool again.
+
+## The safety rails
+1. **No behavior change** — same answers, just not re-derived from scratch every time.
+2. **Writes are instant** — a new or removed session is visible on the very next call (the note is torn up on every write).
+3. **Worst-case staleness is 1 second**, and only for changes made by a *different* machine — which the reaper and scheduler already tolerate.
+4. **Backed by tests** — cache-hit, cache-expiry, instant-invalidation-on-write, filtering, and copy-safety all covered; the existing 71 StateManager tests + 255 dependent tests stay green.
+
+## Why it matters
+This was the real, systemic reason the machine load kept climbing and bouncing servers didn't stick. One small cache fixes it for every agent at once.
+
+---
+
+**Rendered (verified HTTP 200):** https://echo.dawn-tunnel.dev/view/c4f223db-0376-4e74-9cec-362cbea16c9d?sig=296ffb5a0f90e907a4fe0637dd21265c6fe511c7eccb2507fb66566087d1105c


### PR DESCRIPTION
## The root cause (pinned, not guessed)

The fleet-wide agent-server CPU hot-loop — servers sustaining 50–67% CPU, surviving every bounce — is **`StateManager.listSessions()`**. It does `readdirSync` + `readFileSync` + `JSON.parse` of **every** session file on **every** call, and it's called each tick by the `SessionReaper` and the sentinels via `listRunningSessions()`. Cost: **O(sessions × pollers × tick-rate) disk reads**, constantly.

Pinned definitively with node's inspector (`SIGUSR1` → CDP CPU profile, which symbolicates the JS frame that macOS `sample` can't): **30.8% `readFileUtf8` + 7% `listSessions` (StateManager.ts:151)**. Systemic across gemini/sagemind/ai-guy, and restart-proof — which is exactly why bouncing hot servers never helped.

## The fix

A **1-second TTL in-memory cache** of the full session list, **invalidated on every session write** (`saveSession`/`removeSession`):
- The many sub-second read-only callers per tick share **one** disk read.
- A spawn/termination is visible on the **very next** call (write invalidates — no TTL wait), so the scheduler/reaper never act on a stale "who exists" view.
- `listSessions` returns **shallow copies** so a consumer can't corrupt the shared cache.
- StateManager is the **sole in-process** session-file writer (verified — all 13 SessionManager call sites funnel through it), so invalidation is complete. Cross-machine writes carry ≤1s staleness, which the reaper (two-phase + idempotent terminate) and the cron scheduler already tolerate.

No API/route/config/behavior change — pure perf. The constructor gains an optional `{ now }` clock purely for deterministic TTL tests.

## Tests

- `tests/unit/state-manager-listsessions-cache.test.ts` — 6 tests, both sides of every boundary: cache HIT within TTL (a direct disk add isn't seen until TTL elapses); MISS after TTL; immediate invalidation on `saveSession` + `removeSession`; status-filter on cached data; copy-safety; corrupt-file skip.
- **71 existing StateManager tests + 255 consumer tests** (reaper, scheduler, restart-all, recovery) stay green. `pnpm lint` ✓ `pnpm build` ✓.

## Ship-gate (instar-dev Tier-2)

- `upgrades/next/statemanager-listsessions-cache.md` (`<!-- bump: patch -->`)
- `upgrades/side-effects/statemanager-listsessions-cache.md` (correctness/staleness/sole-writer analysis; second-pass review recommended — load-bearing read path)
- ELI16 (rendered, verified HTTP 200): https://echo.dawn-tunnel.dev/view/c4f223db-0376-4e74-9cec-362cbea16c9d?sig=296ffb5a0f90e907a4fe0637dd21265c6fe511c7eccb2507fb66566087d1105c

This is the real durable fix for the resource-remediation autonomous run — it cools every agent server at once, where bouncing only ever bought an hour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)