### PR TITLE
fix(upgrades): unblock publish — remove inline code from #724 release-note fragment

### DIFF
--- a/upgrades/next/reaper-busy-orphan-detect.md
+++ b/upgrades/next/reaper-busy-orphan-detect.md
@@ -42,9 +42,9 @@ gate (same as #722), so it's dogfooded on a real loaded box.
 
 ## What to Tell Your User
 
-Nothing — `busyOrphanDetection` is **dark by default** and observe-only (it never
-changes behavior, just writes audit rows). If surfaced at all, surface it as
-**⚗️ Experimental** observability that makes the busy-orphan case visible.
+Nothing — it is dark by default and observe-only (it never changes behavior, just
+writes audit rows). If surfaced at all, surface it as Experimental observability
+that makes the busy-orphan case visible.
 
 ## Summary of New Capabilities
 


### PR DESCRIPTION
#724's `reaper-busy-orphan-detect.md` fragment had inline code in **What to Tell Your User** (`busyOrphanDetection`), which the publish-time upgrade-guide check hard-rejects (user-facing copy must be plain). That **jammed the release** (the #724 publish run failed at *Check upgrade guide*), blocking the deploy of #722 (reaper cpu-aware keep), #724 (busy-orphan detect), and **#728 (the StateManager.listSessions cache — the root hot-loop fix)** to the fleet.

Same class + fix as #723. Plain-language reword, no content change. Unblocks the release so the resource fixes actually reach the agents.

🤖 Generated with [Claude Code](https://claude.com/claude-code)