### PR TITLE
feat(cli): instar dev:profile-node — CPU-profile a running node process's JS (the technique that cracked the hot-loop)

### DIFF
--- a/.instar/instar-dev-decisions.jsonl
+++ b/.instar/instar-dev-decisions.jsonl
@@ -17,3 +17,5 @@
 {"ts":"2026-06-03T12:52:08.277Z","slug":"unknown","suggestedTier":2,"declaredTier":2,"riskFloor":2,"riskFloorReasons":["new capability: new route (router.<verb>() added"],"belowFloor":false,"files":4,"loc":181}
 {"ts":"2026-06-03T12:52:28.137Z","slug":"unknown","suggestedTier":2,"declaredTier":2,"riskFloor":2,"riskFloorReasons":["new capability: new route (router.<verb>() added"],"belowFloor":false,"files":4,"loc":181}
 {"ts":"2026-06-03T12:53:02.696Z","slug":"unknown","suggestedTier":2,"declaredTier":2,"riskFloor":2,"riskFloorReasons":["new capability: new route (router.<verb>() added"],"belowFloor":false,"files":4,"loc":181}
+{"ts":"2026-06-03T22:12:27.013Z","slug":"url-pathname-path-encoding-fix","suggestedTier":2,"declaredTier":null,"riskFloor":1,"riskFloorReasons":[],"belowFloor":false,"files":5,"loc":313}
+{"ts":"2026-06-03T22:14:24.891Z","slug":"unknown","suggestedTier":2,"declaredTier":1,"riskFloor":1,"riskFloorReasons":[],"belowFloor":false,"files":5,"loc":313}

--- a/.instar/instar-dev-decisions.jsonl
+++ b/.instar/instar-dev-decisions.jsonl
@@ -19,3 +19,7 @@
 {"ts":"2026-06-03T12:53:02.696Z","slug":"unknown","suggestedTier":2,"declaredTier":2,"riskFloor":2,"riskFloorReasons":["new capability: new route (router.<verb>() added"],"belowFloor":false,"files":4,"loc":181}
 {"ts":"2026-06-03T22:12:27.013Z","slug":"url-pathname-path-encoding-fix","suggestedTier":2,"declaredTier":null,"riskFloor":1,"riskFloorReasons":[],"belowFloor":false,"files":5,"loc":313}
 {"ts":"2026-06-03T22:14:24.891Z","slug":"unknown","suggestedTier":2,"declaredTier":1,"riskFloor":1,"riskFloorReasons":[],"belowFloor":false,"files":5,"loc":313}
+{"ts":"2026-06-03T22:26:05.024Z","slug":"unknown","suggestedTier":1,"declaredTier":1,"riskFloor":1,"riskFloorReasons":[],"belowFloor":false,"files":1,"loc":18}
+{"ts":"2026-06-03T22:26:50.605Z","slug":"unknown","suggestedTier":1,"declaredTier":1,"riskFloor":1,"riskFloorReasons":[],"belowFloor":false,"files":1,"loc":18}
+{"ts":"2026-06-03T22:27:56.444Z","slug":"unknown","suggestedTier":1,"declaredTier":1,"riskFloor":1,"riskFloorReasons":[],"belowFloor":false,"files":1,"loc":18}
+{"ts":"2026-06-03T22:28:57.934Z","slug":"unknown","suggestedTier":2,"declaredTier":1,"riskFloor":1,"riskFloorReasons":[],"belowFloor":false,"files":6,"loc":331}

--- a/scripts/docs-coverage.mjs
+++ b/scripts/docs-coverage.mjs
@@ -208,15 +208,24 @@ function findMentions(capability, docs) {
   // Returns list of doc paths that mention this capability.
   // Coverage strategy varies per capability type.
   let needles = [];
+  // Per-type content normalizer (identity by default).
+  let normalize = (s) => s;
   switch (capability.type) {
     case 'route':
       // Match exact path (with leading /). Substring match — close enough.
       needles = [capability.path];
       break;
-    case 'command':
-      // Match either `instar <name>` (CLI usage) or just the bare name.
-      needles = [`instar ${capability.name}`];
+    case 'command': {
+      // A command's id is its camelCase FILE name (`devProfileNode`), but the
+      // shipped command is colon/kebab (`dev:profile-node`). Match BOTH the raw
+      // name AND a kebab form, and treat `:`/`-` as interchangeable, so a
+      // colon-command documented as `instar dev:profile-node` still counts (it
+      // otherwise never matched — every `dev:*` command read as undocumented).
+      const kebab = capability.name.replace(/([a-z0-9])([A-Z])/g, '$1-$2').toLowerCase();
+      needles = [`instar ${capability.name}`, `instar ${kebab}`];
+      normalize = (s) => s.replace(/:/g, '-');
       break;
+    }
     case 'job':
       needles = [capability.name];
       break;
@@ -232,8 +241,9 @@ function findMentions(capability, docs) {
   }
   const matches = [];
   for (const [docPath, content] of Object.entries(docs)) {
+    const normalized = normalize(content);
     for (const needle of needles) {
-      if (content.includes(needle)) {
+      if (normalized.includes(normalize(needle))) {
         matches.push(docPath);
         break;
       }

--- a/scripts/generate-builtin-manifest.cjs
+++ b/scripts/generate-builtin-manifest.cjs
@@ -308,6 +308,7 @@ function scanCliCommands() {
     { name: 'playbook', domain: 'context' },
     { name: 'dev-preflight', domain: 'development' },
     { name: 'dev-ci-failures', domain: 'development' },
+    { name: 'dev-profile-node', domain: 'development' },
   ];
 
   for (const cmd of commands) {

--- a/site/src/content/docs/reference/cli.md
+++ b/site/src/content/docs/reference/cli.md
@@ -243,6 +243,7 @@ instar listener logs            # Tail listener logs
 instar route <task>             # One-shot framework + model routing for a task description
 instar dev:preflight            # Verify-only contributor guard: lint, CapabilityIndex tests, route-prefix warning
 instar dev:ci-failures <pr>     # Print a PR's exact failing tests (file:line + assertion) via the check-run annotations API
+instar dev:profile-node [pid]   # CPU-profile a running node process (SIGUSR1 + inspector + CDP) and print its hottest JS functions
 instar jobMigrate               # Migrate jobs between schema versions
 instar ledgerCleanup            # Token ledger cleanup
 instar memoryBackfillEvidence   # Backfill evidence rows into the memory index

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2425,6 +2425,19 @@ program
     process.exit(exitCode);
   });
 
+// ── `instar dev:profile-node [pid]` — CPU-profile a hot node process's JS ──
+
+program
+  .command('dev:profile-node [pid]')
+  .description("CPU-profile a running node process (via SIGUSR1 + the inspector) and print its hottest JS functions — sees the JS frames macOS `sample` can't")
+  .option('--duration <sec>', 'Sampling duration in seconds (default 5)', (v) => parseInt(v, 10))
+  .option('--top <n>', 'Number of hot frames to print (default 15)', (v) => parseInt(v, 10))
+  .action(async (pid: string | undefined, opts: { duration?: number; top?: number }) => {
+    const { runDevProfileNode } = await import('./commands/devProfileNode.js');
+    const exitCode = await runDevProfileNode({ pid, durationSec: opts.duration, top: opts.top });
+    process.exit(exitCode);
+  });
+
 // ── `instar route` — Phase 5b suggest-and-confirm composition root (CLI) ─
 
 program

--- a/src/commands/devProfileNode.ts
+++ b/src/commands/devProfileNode.ts
@@ -1,0 +1,185 @@
+/**
+ * `instar dev:profile-node [pid]` — CPU-profile a RUNNING node process and print
+ * the hottest JS functions (function + file:line + self-time %).
+ *
+ * Why this exists: macOS `sample` (and lsof snapshots, `gh run --log`, etc.) can't
+ * symbolicate a node process's JS frames — they show only native/V8 frames, so a
+ * busy node server's actual hot *function* stays invisible. This wraps the
+ * technique that DOES see it: SIGUSR1 opens node's inspector on the running
+ * process, then a CDP CPU profile over the inspector websocket reports the exact
+ * JS call frames. (This is how the StateManager.listSessions hot-loop was pinned —
+ * 30% of CPU in readFileUtf8 under listSessions, invisible to every other tool.)
+ *
+ * Side effect: SIGUSR1 opens the inspector on 127.0.0.1 (localhost-only) for the
+ * life of the process; it closes when the process restarts. The command says so.
+ * Read-only otherwise — it samples, it never mutates the target.
+ */
+import { execFile } from 'node:child_process';
+import pc from 'picocolors';
+
+export interface CdpCallFrame { functionName?: string; url?: string; lineNumber?: number; }
+export interface CdpProfileNode { callFrame?: CdpCallFrame; hitCount?: number; }
+export interface CdpProfile { nodes?: CdpProfileNode[]; }
+export interface InspectorTarget { webSocketDebuggerUrl?: string; title?: string; }
+export interface HotFrame { label: string; selfPct: number; samples: number; }
+
+export interface ProfileNodeOutput { write(text: string): void; error(text: string): void; }
+
+/** Injectable boundary so the command is unit-testable without a real process. */
+export interface ProfileNodeDeps {
+  /** Send SIGUSR1 to a pid (opens node's inspector). Throws if the pid is gone. */
+  signalUsr1(pid: number): void;
+  /** GET `http://127.0.0.1:<port>/json/list` → the first inspector target, or null. */
+  fetchInspectorTarget(port: number): Promise<InspectorTarget | null>;
+  /** Connect to the CDP websocket + capture a CPU profile over `durationMs`. */
+  captureCpuProfile(wsUrl: string, durationMs: number): Promise<CdpProfile>;
+  /** Resolve the hottest `node` pid for the no-arg form (or null). */
+  hottestNodePid(): Promise<number | null>;
+  /** Sleep (injected so tests don't actually wait). */
+  sleep(ms: number): Promise<void>;
+}
+
+export interface DevProfileNodeOptions {
+  pid?: string;
+  durationSec?: number;
+  top?: number;
+  output?: ProfileNodeOutput;
+  deps?: ProfileNodeDeps;
+}
+
+const INSPECTOR_PORTS = [9229, 9230, 9231, 9232, 9233, 9234, 9235];
+const DEFAULT_TOP = 15;
+const DEFAULT_DURATION_SEC = 5;
+
+/**
+ * Pure: aggregate a CDP CPU profile's self-time (per-node `hitCount`) by JS call
+ * frame, returning the top-N frames as `function  src/file.js:line` + self %.
+ * The biggest non-idle entry IS the hot loop. Idle/native frames (`(idle)`,
+ * `(program)`, GC) are kept — seeing "48% idle, 30% readFileUtf8" is the signal.
+ */
+export function aggregateHotFrames(profile: CdpProfile, topN: number = DEFAULT_TOP): HotFrame[] {
+  const self = new Map<string, number>();
+  for (const n of profile.nodes ?? []) {
+    const f = n.callFrame ?? {};
+    const fn = f.functionName && f.functionName.length > 0 ? f.functionName : '(anonymous)';
+    const loc = f.url ? `${f.url.replace(/^.*\/(dist|src)\//, '$1/')}:${(f.lineNumber ?? -1) + 1}` : '';
+    const key = loc ? `${fn}  ${loc}` : fn;
+    self.set(key, (self.get(key) ?? 0) + (n.hitCount ?? 0));
+  }
+  const total = [...self.values()].reduce((a, b) => a + b, 0) || 1;
+  return [...self.entries()]
+    .map(([label, samples]) => ({ label, samples, selfPct: Math.round((1000 * samples) / total) / 10 }))
+    .sort((a, b) => b.samples - a.samples)
+    .slice(0, topN);
+}
+
+/** Probe the inspector ports for the target opened by SIGUSR1. First hit wins. */
+export async function findInspectorTarget(deps: ProfileNodeDeps): Promise<InspectorTarget | null> {
+  for (const port of INSPECTOR_PORTS) {
+    try {
+      const t = await deps.fetchInspectorTarget(port);
+      if (t?.webSocketDebuggerUrl) return t;
+    } catch { /* try the next port */ }
+  }
+  return null;
+}
+
+/**
+ * Orchestrate: resolve pid → SIGUSR1 → find inspector → CDP CPU profile →
+ * aggregate → print. Returns an exit code (0 ok, 1 operational failure).
+ */
+export async function runDevProfileNode(opts: DevProfileNodeOptions): Promise<number> {
+  const out = opts.output ?? { write: (t) => process.stdout.write(t), error: (t) => process.stderr.write(t) };
+  const deps = opts.deps ?? productionDeps();
+  const durationMs = Math.max(1, opts.durationSec ?? DEFAULT_DURATION_SEC) * 1000;
+  const topN = opts.top ?? DEFAULT_TOP;
+
+  let pid: number | null = null;
+  if (opts.pid && /^\d+$/.test(opts.pid)) {
+    pid = parseInt(opts.pid, 10);
+  } else {
+    pid = await deps.hottestNodePid();
+    if (pid == null) { out.error(pc.red('No running node process found to profile.\n')); return 1; }
+    out.write(pc.dim(`No pid given — profiling the hottest node process: ${pid}\n`));
+  }
+
+  try { deps.signalUsr1(pid); }
+  catch { out.error(pc.red(`Could not signal pid ${pid} (is it alive? is it a node process?).\n`)); return 1; }
+
+  // The inspector takes a moment to bind after SIGUSR1.
+  await deps.sleep(800);
+  const target = await findInspectorTarget(deps);
+  if (!target?.webSocketDebuggerUrl) {
+    out.error(pc.red(`pid ${pid} did not expose a node inspector on 127.0.0.1:9229-9235.\n` +
+      `It may not be a node process, or the inspector is already bound elsewhere.\n`));
+    return 1;
+  }
+
+  out.write(pc.dim(`Profiling ${pid} for ${durationMs / 1000}s via the inspector…\n`));
+  let profile: CdpProfile;
+  try { profile = await deps.captureCpuProfile(target.webSocketDebuggerUrl, durationMs); }
+  catch (err) { out.error(pc.red(`CPU profile failed: ${err instanceof Error ? err.message : String(err)}\n`)); return 1; }
+
+  const frames = aggregateHotFrames(profile, topN);
+  if (frames.length === 0) { out.error(pc.yellow('Profile captured but no samples — try a longer --duration.\n')); return 0; }
+
+  out.write(pc.bold(`\nHottest JS frames (self-time) for pid ${pid}:\n`));
+  for (const f of frames) {
+    const pct = `${f.selfPct.toFixed(1)}%`.padStart(6);
+    out.write(`  ${pc.cyan(pct)}  ${f.label}\n`);
+  }
+  out.write(pc.dim(`\n(The biggest non-idle frame is the hot path. SIGUSR1 left the inspector ` +
+    `open on 127.0.0.1 for pid ${pid}; it closes on the process's next restart.)\n`));
+  return 0;
+}
+
+/** Production deps: real SIGUSR1, http inspector probe, ws CDP profile, ps. */
+export function productionDeps(): ProfileNodeDeps {
+  return {
+    signalUsr1(pid) { process.kill(pid, 'SIGUSR1'); },
+    async fetchInspectorTarget(port) {
+      const res = await fetch(`http://127.0.0.1:${port}/json/list`, { signal: AbortSignal.timeout(2000) });
+      if (!res.ok) return null;
+      const list = (await res.json()) as InspectorTarget[];
+      return Array.isArray(list) && list.length > 0 ? list[0] : null;
+    },
+    async captureCpuProfile(wsUrl, durationMs) {
+      const { WebSocket } = await import('ws');
+      return await new Promise<CdpProfile>((resolve, reject) => {
+        const ws = new WebSocket(wsUrl, { maxPayload: 512 * 1024 * 1024 });
+        let id = 0; const pending = new Map<number, (r: unknown) => void>();
+        const send = (method: string, params: Record<string, unknown> = {}) =>
+          new Promise<unknown>((r) => { const i = ++id; pending.set(i, r); ws.send(JSON.stringify({ id: i, method, params })); });
+        const fail = (e: Error) => { try { ws.close(); } catch { /* noop */ } reject(e); };
+        const timer = setTimeout(() => fail(new Error('inspector timed out')), durationMs + 15000);
+        ws.on('message', (m: Buffer | string) => {
+          const o = JSON.parse(m.toString()) as { id?: number; result?: unknown };
+          if (o.id != null && pending.has(o.id)) { pending.get(o.id)!(o.result); pending.delete(o.id); }
+        });
+        ws.on('error', (e: Error) => { clearTimeout(timer); fail(e); });
+        ws.on('open', () => { void (async () => {
+          await send('Profiler.enable');
+          await send('Profiler.setSamplingInterval', { interval: 100 });
+          await send('Profiler.start');
+          await new Promise((r) => setTimeout(r, durationMs));
+          const stop = (await send('Profiler.stop')) as { profile?: CdpProfile };
+          clearTimeout(timer);
+          try { ws.close(); } catch { /* noop */ }
+          resolve(stop.profile ?? {});
+        })().catch(fail); });
+      });
+    },
+    async hottestNodePid() {
+      return await new Promise<number | null>((resolve) => {
+        execFile('ps', ['-Aceo', 'pcpu,pid,comm'], { timeout: 5000 }, (err, stdout) => {
+          if (err) { resolve(null); return; }
+          const hot = stdout.split('\n').map((l) => l.trim().match(/^([\d.]+)\s+(\d+)\s+(.+)$/))
+            .filter((m): m is RegExpMatchArray => !!m && m[3] === 'node')
+            .sort((a, b) => parseFloat(b[1]) - parseFloat(a[1]))[0];
+          resolve(hot ? parseInt(hot[2], 10) : null);
+        });
+      });
+    },
+    sleep(ms) { return new Promise((r) => setTimeout(r, ms)); },
+  };
+}

--- a/src/data/builtin-manifest.json
+++ b/src/data/builtin-manifest.json
@@ -1,9 +1,9 @@
 {
   "$schema": "./builtin-manifest.schema.json",
   "schemaVersion": 1,
-  "generatedAt": "2026-06-03T17:48:41.732Z",
-  "instarVersion": "1.3.225",
-  "entryCount": 197,
+  "generatedAt": "2026-06-03T22:10:19.844Z",
+  "instarVersion": "1.3.227",
+  "entryCount": 198,
   "entries": {
     "hook:session-start": {
       "id": "hook:session-start",
@@ -11,7 +11,7 @@
       "domain": "identity",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/session-start.sh",
-      "contentHash": "e0f9e7499c6ae8288ddda30d255c9f6a8b0692fde57da6eb798a8b38976b49b5",
+      "contentHash": "ee2783d1b5cfa194f43e90b4a7fa0d9864e0d62b8c3f0634f79b45d0d2d4ff1c",
       "since": "2025-01-01"
     },
     "hook:dangerous-command-guard": {
@@ -20,7 +20,7 @@
       "domain": "safety",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/dangerous-command-guard.sh",
-      "contentHash": "e0f9e7499c6ae8288ddda30d255c9f6a8b0692fde57da6eb798a8b38976b49b5",
+      "contentHash": "ee2783d1b5cfa194f43e90b4a7fa0d9864e0d62b8c3f0634f79b45d0d2d4ff1c",
       "since": "2025-01-01"
     },
     "hook:grounding-before-messaging": {
@@ -29,7 +29,7 @@
       "domain": "safety",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/grounding-before-messaging.sh",
-      "contentHash": "e0f9e7499c6ae8288ddda30d255c9f6a8b0692fde57da6eb798a8b38976b49b5",
+      "contentHash": "ee2783d1b5cfa194f43e90b4a7fa0d9864e0d62b8c3f0634f79b45d0d2d4ff1c",
       "since": "2025-01-01"
     },
     "hook:compaction-recovery": {
@@ -38,7 +38,7 @@
       "domain": "identity",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/compaction-recovery.sh",
-      "contentHash": "e0f9e7499c6ae8288ddda30d255c9f6a8b0692fde57da6eb798a8b38976b49b5",
+      "contentHash": "ee2783d1b5cfa194f43e90b4a7fa0d9864e0d62b8c3f0634f79b45d0d2d4ff1c",
       "since": "2025-01-01"
     },
     "hook:external-operation-gate": {
@@ -47,7 +47,7 @@
       "domain": "safety",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/external-operation-gate.js",
-      "contentHash": "e0f9e7499c6ae8288ddda30d255c9f6a8b0692fde57da6eb798a8b38976b49b5",
+      "contentHash": "ee2783d1b5cfa194f43e90b4a7fa0d9864e0d62b8c3f0634f79b45d0d2d4ff1c",
       "since": "2025-01-01"
     },
     "hook:deferral-detector": {
@@ -56,7 +56,7 @@
       "domain": "safety",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/deferral-detector.js",
-      "contentHash": "e0f9e7499c6ae8288ddda30d255c9f6a8b0692fde57da6eb798a8b38976b49b5",
+      "contentHash": "ee2783d1b5cfa194f43e90b4a7fa0d9864e0d62b8c3f0634f79b45d0d2d4ff1c",
       "since": "2025-01-01"
     },
     "hook:self-stop-guard": {
@@ -65,7 +65,7 @@
       "domain": "coherence",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/self-stop-guard.js",
-      "contentHash": "e0f9e7499c6ae8288ddda30d255c9f6a8b0692fde57da6eb798a8b38976b49b5",
+      "contentHash": "ee2783d1b5cfa194f43e90b4a7fa0d9864e0d62b8c3f0634f79b45d0d2d4ff1c",
       "since": "2025-01-01"
     },
     "hook:post-action-reflection": {
@@ -74,7 +74,7 @@
       "domain": "evolution",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/post-action-reflection.js",
-      "contentHash": "e0f9e7499c6ae8288ddda30d255c9f6a8b0692fde57da6eb798a8b38976b49b5",
+      "contentHash": "ee2783d1b5cfa194f43e90b4a7fa0d9864e0d62b8c3f0634f79b45d0d2d4ff1c",
       "since": "2025-01-01"
     },
     "hook:external-communication-guard": {
@@ -83,7 +83,7 @@
       "domain": "safety",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/external-communication-guard.js",
-      "contentHash": "e0f9e7499c6ae8288ddda30d255c9f6a8b0692fde57da6eb798a8b38976b49b5",
+      "contentHash": "ee2783d1b5cfa194f43e90b4a7fa0d9864e0d62b8c3f0634f79b45d0d2d4ff1c",
       "since": "2025-01-01"
     },
     "hook:scope-coherence-collector": {
@@ -92,7 +92,7 @@
       "domain": "coherence",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/scope-coherence-collector.js",
-      "contentHash": "e0f9e7499c6ae8288ddda30d255c9f6a8b0692fde57da6eb798a8b38976b49b5",
+      "contentHash": "ee2783d1b5cfa194f43e90b4a7fa0d9864e0d62b8c3f0634f79b45d0d2d4ff1c",
       "since": "2025-01-01"
     },
     "hook:scope-coherence-checkpoint": {
@@ -101,7 +101,7 @@
       "domain": "coherence",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/scope-coherence-checkpoint.js",
-      "contentHash": "e0f9e7499c6ae8288ddda30d255c9f6a8b0692fde57da6eb798a8b38976b49b5",
+      "contentHash": "ee2783d1b5cfa194f43e90b4a7fa0d9864e0d62b8c3f0634f79b45d0d2d4ff1c",
       "since": "2025-01-01"
     },
     "hook:free-text-guard": {
@@ -110,7 +110,7 @@
       "domain": "safety",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/free-text-guard.sh",
-      "contentHash": "e0f9e7499c6ae8288ddda30d255c9f6a8b0692fde57da6eb798a8b38976b49b5",
+      "contentHash": "ee2783d1b5cfa194f43e90b4a7fa0d9864e0d62b8c3f0634f79b45d0d2d4ff1c",
       "since": "2025-01-01"
     },
     "hook:claim-intercept": {
@@ -119,7 +119,7 @@
       "domain": "coherence",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/claim-intercept.js",
-      "contentHash": "e0f9e7499c6ae8288ddda30d255c9f6a8b0692fde57da6eb798a8b38976b49b5",
+      "contentHash": "ee2783d1b5cfa194f43e90b4a7fa0d9864e0d62b8c3f0634f79b45d0d2d4ff1c",
       "since": "2025-01-01"
     },
     "hook:claim-intercept-response": {
@@ -128,7 +128,7 @@
       "domain": "coherence",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/claim-intercept-response.js",
-      "contentHash": "e0f9e7499c6ae8288ddda30d255c9f6a8b0692fde57da6eb798a8b38976b49b5",
+      "contentHash": "ee2783d1b5cfa194f43e90b4a7fa0d9864e0d62b8c3f0634f79b45d0d2d4ff1c",
       "since": "2025-01-01"
     },
     "hook:stop-gate-router": {
@@ -137,7 +137,7 @@
       "domain": "safety",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/stop-gate-router.js",
-      "contentHash": "e0f9e7499c6ae8288ddda30d255c9f6a8b0692fde57da6eb798a8b38976b49b5",
+      "contentHash": "ee2783d1b5cfa194f43e90b4a7fa0d9864e0d62b8c3f0634f79b45d0d2d4ff1c",
       "since": "2025-01-01"
     },
     "hook:auto-approve-permissions": {
@@ -146,7 +146,7 @@
       "domain": "safety",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/auto-approve-permissions.js",
-      "contentHash": "e0f9e7499c6ae8288ddda30d255c9f6a8b0692fde57da6eb798a8b38976b49b5",
+      "contentHash": "ee2783d1b5cfa194f43e90b4a7fa0d9864e0d62b8c3f0634f79b45d0d2d4ff1c",
       "since": "2025-01-01"
     },
     "job:health-check": {
@@ -778,7 +778,7 @@
       "type": "cli-command",
       "domain": "setup",
       "sourcePath": "src/cli.ts",
-      "contentHash": "0dbe9408c77a7f88ef9978644cb9be45885c7a095ff8424361a1e9f7953cd099",
+      "contentHash": "410c6f2c325138a52996c3e2339d9b21fe7a32d90a20cc83d8754ad2d44e700f",
       "since": "2025-01-01"
     },
     "cli:setup": {
@@ -786,7 +786,7 @@
       "type": "cli-command",
       "domain": "setup",
       "sourcePath": "src/cli.ts",
-      "contentHash": "0dbe9408c77a7f88ef9978644cb9be45885c7a095ff8424361a1e9f7953cd099",
+      "contentHash": "410c6f2c325138a52996c3e2339d9b21fe7a32d90a20cc83d8754ad2d44e700f",
       "since": "2025-01-01"
     },
     "cli:add": {
@@ -794,7 +794,7 @@
       "type": "cli-command",
       "domain": "setup",
       "sourcePath": "src/cli.ts",
-      "contentHash": "0dbe9408c77a7f88ef9978644cb9be45885c7a095ff8424361a1e9f7953cd099",
+      "contentHash": "410c6f2c325138a52996c3e2339d9b21fe7a32d90a20cc83d8754ad2d44e700f",
       "since": "2025-01-01"
     },
     "cli:backup": {
@@ -802,7 +802,7 @@
       "type": "cli-command",
       "domain": "operations",
       "sourcePath": "src/cli.ts",
-      "contentHash": "0dbe9408c77a7f88ef9978644cb9be45885c7a095ff8424361a1e9f7953cd099",
+      "contentHash": "410c6f2c325138a52996c3e2339d9b21fe7a32d90a20cc83d8754ad2d44e700f",
       "since": "2025-01-01"
     },
     "cli:git": {
@@ -810,7 +810,7 @@
       "type": "cli-command",
       "domain": "coordination",
       "sourcePath": "src/cli.ts",
-      "contentHash": "0dbe9408c77a7f88ef9978644cb9be45885c7a095ff8424361a1e9f7953cd099",
+      "contentHash": "410c6f2c325138a52996c3e2339d9b21fe7a32d90a20cc83d8754ad2d44e700f",
       "since": "2025-01-01"
     },
     "cli:memory": {
@@ -818,7 +818,7 @@
       "type": "cli-command",
       "domain": "memory",
       "sourcePath": "src/cli.ts",
-      "contentHash": "0dbe9408c77a7f88ef9978644cb9be45885c7a095ff8424361a1e9f7953cd099",
+      "contentHash": "410c6f2c325138a52996c3e2339d9b21fe7a32d90a20cc83d8754ad2d44e700f",
       "since": "2025-01-01"
     },
     "cli:knowledge": {
@@ -826,7 +826,7 @@
       "type": "cli-command",
       "domain": "memory",
       "sourcePath": "src/cli.ts",
-      "contentHash": "0dbe9408c77a7f88ef9978644cb9be45885c7a095ff8424361a1e9f7953cd099",
+      "contentHash": "410c6f2c325138a52996c3e2339d9b21fe7a32d90a20cc83d8754ad2d44e700f",
       "since": "2025-01-01"
     },
     "cli:semantic": {
@@ -834,7 +834,7 @@
       "type": "cli-command",
       "domain": "memory",
       "sourcePath": "src/cli.ts",
-      "contentHash": "0dbe9408c77a7f88ef9978644cb9be45885c7a095ff8424361a1e9f7953cd099",
+      "contentHash": "410c6f2c325138a52996c3e2339d9b21fe7a32d90a20cc83d8754ad2d44e700f",
       "since": "2025-01-01"
     },
     "cli:intent": {
@@ -842,7 +842,7 @@
       "type": "cli-command",
       "domain": "intent",
       "sourcePath": "src/cli.ts",
-      "contentHash": "0dbe9408c77a7f88ef9978644cb9be45885c7a095ff8424361a1e9f7953cd099",
+      "contentHash": "410c6f2c325138a52996c3e2339d9b21fe7a32d90a20cc83d8754ad2d44e700f",
       "since": "2025-01-01"
     },
     "cli:feedback": {
@@ -850,7 +850,7 @@
       "type": "cli-command",
       "domain": "feedback",
       "sourcePath": "src/cli.ts",
-      "contentHash": "0dbe9408c77a7f88ef9978644cb9be45885c7a095ff8424361a1e9f7953cd099",
+      "contentHash": "410c6f2c325138a52996c3e2339d9b21fe7a32d90a20cc83d8754ad2d44e700f",
       "since": "2025-01-01"
     },
     "cli:server": {
@@ -858,7 +858,7 @@
       "type": "cli-command",
       "domain": "server",
       "sourcePath": "src/cli.ts",
-      "contentHash": "0dbe9408c77a7f88ef9978644cb9be45885c7a095ff8424361a1e9f7953cd099",
+      "contentHash": "410c6f2c325138a52996c3e2339d9b21fe7a32d90a20cc83d8754ad2d44e700f",
       "since": "2025-01-01"
     },
     "cli:status": {
@@ -866,7 +866,7 @@
       "type": "cli-command",
       "domain": "monitoring",
       "sourcePath": "src/cli.ts",
-      "contentHash": "0dbe9408c77a7f88ef9978644cb9be45885c7a095ff8424361a1e9f7953cd099",
+      "contentHash": "410c6f2c325138a52996c3e2339d9b21fe7a32d90a20cc83d8754ad2d44e700f",
       "since": "2025-01-01"
     },
     "cli:user": {
@@ -874,7 +874,7 @@
       "type": "cli-command",
       "domain": "users",
       "sourcePath": "src/cli.ts",
-      "contentHash": "0dbe9408c77a7f88ef9978644cb9be45885c7a095ff8424361a1e9f7953cd099",
+      "contentHash": "410c6f2c325138a52996c3e2339d9b21fe7a32d90a20cc83d8754ad2d44e700f",
       "since": "2025-01-01"
     },
     "cli:relationship": {
@@ -882,7 +882,7 @@
       "type": "cli-command",
       "domain": "relationships",
       "sourcePath": "src/cli.ts",
-      "contentHash": "0dbe9408c77a7f88ef9978644cb9be45885c7a095ff8424361a1e9f7953cd099",
+      "contentHash": "410c6f2c325138a52996c3e2339d9b21fe7a32d90a20cc83d8754ad2d44e700f",
       "since": "2025-01-01"
     },
     "cli:job": {
@@ -890,7 +890,7 @@
       "type": "cli-command",
       "domain": "scheduling",
       "sourcePath": "src/cli.ts",
-      "contentHash": "0dbe9408c77a7f88ef9978644cb9be45885c7a095ff8424361a1e9f7953cd099",
+      "contentHash": "410c6f2c325138a52996c3e2339d9b21fe7a32d90a20cc83d8754ad2d44e700f",
       "since": "2025-01-01"
     },
     "cli:lifeline": {
@@ -898,7 +898,7 @@
       "type": "cli-command",
       "domain": "communication",
       "sourcePath": "src/cli.ts",
-      "contentHash": "0dbe9408c77a7f88ef9978644cb9be45885c7a095ff8424361a1e9f7953cd099",
+      "contentHash": "410c6f2c325138a52996c3e2339d9b21fe7a32d90a20cc83d8754ad2d44e700f",
       "since": "2025-01-01"
     },
     "cli:list": {
@@ -906,7 +906,7 @@
       "type": "cli-command",
       "domain": "monitoring",
       "sourcePath": "src/cli.ts",
-      "contentHash": "0dbe9408c77a7f88ef9978644cb9be45885c7a095ff8424361a1e9f7953cd099",
+      "contentHash": "410c6f2c325138a52996c3e2339d9b21fe7a32d90a20cc83d8754ad2d44e700f",
       "since": "2025-01-01"
     },
     "cli:autostart": {
@@ -914,7 +914,7 @@
       "type": "cli-command",
       "domain": "operations",
       "sourcePath": "src/cli.ts",
-      "contentHash": "0dbe9408c77a7f88ef9978644cb9be45885c7a095ff8424361a1e9f7953cd099",
+      "contentHash": "410c6f2c325138a52996c3e2339d9b21fe7a32d90a20cc83d8754ad2d44e700f",
       "since": "2025-01-01"
     },
     "cli:migrate": {
@@ -922,7 +922,7 @@
       "type": "cli-command",
       "domain": "updates",
       "sourcePath": "src/cli.ts",
-      "contentHash": "0dbe9408c77a7f88ef9978644cb9be45885c7a095ff8424361a1e9f7953cd099",
+      "contentHash": "410c6f2c325138a52996c3e2339d9b21fe7a32d90a20cc83d8754ad2d44e700f",
       "since": "2025-01-01"
     },
     "cli:machines": {
@@ -930,7 +930,7 @@
       "type": "cli-command",
       "domain": "coordination",
       "sourcePath": "src/cli.ts",
-      "contentHash": "0dbe9408c77a7f88ef9978644cb9be45885c7a095ff8424361a1e9f7953cd099",
+      "contentHash": "410c6f2c325138a52996c3e2339d9b21fe7a32d90a20cc83d8754ad2d44e700f",
       "since": "2025-01-01"
     },
     "cli:whoami": {
@@ -938,7 +938,7 @@
       "type": "cli-command",
       "domain": "identity",
       "sourcePath": "src/cli.ts",
-      "contentHash": "0dbe9408c77a7f88ef9978644cb9be45885c7a095ff8424361a1e9f7953cd099",
+      "contentHash": "410c6f2c325138a52996c3e2339d9b21fe7a32d90a20cc83d8754ad2d44e700f",
       "since": "2025-01-01"
     },
     "cli:pair": {
@@ -946,7 +946,7 @@
       "type": "cli-command",
       "domain": "coordination",
       "sourcePath": "src/cli.ts",
-      "contentHash": "0dbe9408c77a7f88ef9978644cb9be45885c7a095ff8424361a1e9f7953cd099",
+      "contentHash": "410c6f2c325138a52996c3e2339d9b21fe7a32d90a20cc83d8754ad2d44e700f",
       "since": "2025-01-01"
     },
     "cli:join": {
@@ -954,7 +954,7 @@
       "type": "cli-command",
       "domain": "coordination",
       "sourcePath": "src/cli.ts",
-      "contentHash": "0dbe9408c77a7f88ef9978644cb9be45885c7a095ff8424361a1e9f7953cd099",
+      "contentHash": "410c6f2c325138a52996c3e2339d9b21fe7a32d90a20cc83d8754ad2d44e700f",
       "since": "2025-01-01"
     },
     "cli:wakeup": {
@@ -962,7 +962,7 @@
       "type": "cli-command",
       "domain": "coordination",
       "sourcePath": "src/cli.ts",
-      "contentHash": "0dbe9408c77a7f88ef9978644cb9be45885c7a095ff8424361a1e9f7953cd099",
+      "contentHash": "410c6f2c325138a52996c3e2339d9b21fe7a32d90a20cc83d8754ad2d44e700f",
       "since": "2025-01-01"
     },
     "cli:leave": {
@@ -970,7 +970,7 @@
       "type": "cli-command",
       "domain": "coordination",
       "sourcePath": "src/cli.ts",
-      "contentHash": "0dbe9408c77a7f88ef9978644cb9be45885c7a095ff8424361a1e9f7953cd099",
+      "contentHash": "410c6f2c325138a52996c3e2339d9b21fe7a32d90a20cc83d8754ad2d44e700f",
       "since": "2025-01-01"
     },
     "cli:doctor": {
@@ -978,7 +978,7 @@
       "type": "cli-command",
       "domain": "monitoring",
       "sourcePath": "src/cli.ts",
-      "contentHash": "0dbe9408c77a7f88ef9978644cb9be45885c7a095ff8424361a1e9f7953cd099",
+      "contentHash": "410c6f2c325138a52996c3e2339d9b21fe7a32d90a20cc83d8754ad2d44e700f",
       "since": "2025-01-01"
     },
     "cli:review": {
@@ -986,7 +986,7 @@
       "type": "cli-command",
       "domain": "monitoring",
       "sourcePath": "src/cli.ts",
-      "contentHash": "0dbe9408c77a7f88ef9978644cb9be45885c7a095ff8424361a1e9f7953cd099",
+      "contentHash": "410c6f2c325138a52996c3e2339d9b21fe7a32d90a20cc83d8754ad2d44e700f",
       "since": "2025-01-01"
     },
     "cli:nuke": {
@@ -994,7 +994,7 @@
       "type": "cli-command",
       "domain": "operations",
       "sourcePath": "src/cli.ts",
-      "contentHash": "0dbe9408c77a7f88ef9978644cb9be45885c7a095ff8424361a1e9f7953cd099",
+      "contentHash": "410c6f2c325138a52996c3e2339d9b21fe7a32d90a20cc83d8754ad2d44e700f",
       "since": "2025-01-01"
     },
     "cli:playbook": {
@@ -1002,7 +1002,7 @@
       "type": "cli-command",
       "domain": "context",
       "sourcePath": "src/cli.ts",
-      "contentHash": "0dbe9408c77a7f88ef9978644cb9be45885c7a095ff8424361a1e9f7953cd099",
+      "contentHash": "410c6f2c325138a52996c3e2339d9b21fe7a32d90a20cc83d8754ad2d44e700f",
       "since": "2025-01-01"
     },
     "cli:dev-preflight": {
@@ -1010,7 +1010,7 @@
       "type": "cli-command",
       "domain": "development",
       "sourcePath": "src/cli.ts",
-      "contentHash": "0dbe9408c77a7f88ef9978644cb9be45885c7a095ff8424361a1e9f7953cd099",
+      "contentHash": "410c6f2c325138a52996c3e2339d9b21fe7a32d90a20cc83d8754ad2d44e700f",
       "since": "2025-01-01"
     },
     "cli:dev-ci-failures": {
@@ -1018,7 +1018,15 @@
       "type": "cli-command",
       "domain": "development",
       "sourcePath": "src/cli.ts",
-      "contentHash": "0dbe9408c77a7f88ef9978644cb9be45885c7a095ff8424361a1e9f7953cd099",
+      "contentHash": "410c6f2c325138a52996c3e2339d9b21fe7a32d90a20cc83d8754ad2d44e700f",
+      "since": "2025-01-01"
+    },
+    "cli:dev-profile-node": {
+      "id": "cli:dev-profile-node",
+      "type": "cli-command",
+      "domain": "development",
+      "sourcePath": "src/cli.ts",
+      "contentHash": "410c6f2c325138a52996c3e2339d9b21fe7a32d90a20cc83d8754ad2d44e700f",
       "since": "2025-01-01"
     },
     "template:build-stop-hook.sh": {
@@ -1490,7 +1498,7 @@
       "type": "subsystem",
       "domain": "server",
       "sourcePath": "src/server/AgentServer.ts",
-      "contentHash": "d1851d4bb663dd524af17cf4c45e143bc441314bbe2b005c5ee1626019b92184",
+      "contentHash": "e7cb9908ed4d4ff87da6b2398a2d1c472973085d8d55d71b5754ca13dd3f7835",
       "since": "2025-01-01"
     },
     "subsystem:session-manager": {
@@ -1522,7 +1530,7 @@
       "type": "subsystem",
       "domain": "updates",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
-      "contentHash": "e0f9e7499c6ae8288ddda30d255c9f6a8b0692fde57da6eb798a8b38976b49b5",
+      "contentHash": "ee2783d1b5cfa194f43e90b4a7fa0d9864e0d62b8c3f0634f79b45d0d2d4ff1c",
       "since": "2025-01-01"
     },
     "subsystem:scheduler": {

--- a/src/scaffold/templates.ts
+++ b/src/scaffold/templates.ts
@@ -755,6 +755,8 @@ Instar contributors can run \`instar dev:preflight\` before opening PRs to run l
 
 Run \`instar dev:ci-failures <pr>\` to print a red PR's exact failing tests (file:line + assertion) via the GitHub check-run annotations API — handy when \`gh run view --log\` returns nothing.
 
+Run \`instar dev:profile-node [pid]\` to CPU-profile a hot RUNNING node process and print its hottest JS functions (function + file:line + self-time %). It uses SIGUSR1 + node's inspector + a CDP CPU profile, so it sees the JS frames macOS \`sample\` can't symbolicate — the way to pin which function a busy agent server is burning CPU in. No pid → it profiles the hottest node process.
+
 **Critical rule**: If this CLAUDE.md says a feature is "for standalone agents" or "when configured" or uses any qualifier — do NOT conclude you lack the feature. Check \`/capabilities\` instead. Documentation describes features in general; the API tells you what's actually running for YOU right now. When they conflict, the API wins.
 
 ### Registry First, Explore Second

--- a/tests/unit/devProfileNode.test.ts
+++ b/tests/unit/devProfileNode.test.ts
@@ -1,0 +1,122 @@
+/**
+ * `instar dev:profile-node` — unit tests. The pure `aggregateHotFrames` (both
+ * sides of the boundary) + `runDevProfileNode` orchestration with injected deps
+ * (no real process/inspector/ws). Productizes the SIGUSR1+CDP technique used to
+ * pin the StateManager.listSessions hot-loop.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import {
+  aggregateHotFrames,
+  findInspectorTarget,
+  runDevProfileNode,
+  type CdpProfile,
+  type ProfileNodeDeps,
+  type ProfileNodeOutput,
+} from '../../src/commands/devProfileNode.js';
+
+function capture(): ProfileNodeOutput & { out: string; err: string } {
+  const o = { out: '', err: '', write(t: string) { o.out += t; }, error(t: string) { o.err += t; } };
+  return o;
+}
+
+// A profile dominated by one hot JS function (the listSessions-style case).
+const HOT_PROFILE: CdpProfile = {
+  nodes: [
+    { callFrame: { functionName: '(idle)', url: '', lineNumber: 0 }, hitCount: 480 },
+    { callFrame: { functionName: 'readFileUtf8', url: '', lineNumber: 0 }, hitCount: 300 },
+    { callFrame: { functionName: 'listSessions', url: '/x/dist/core/StateManager.js', lineNumber: 150 }, hitCount: 70 },
+    { callFrame: { functionName: 'readdir', url: '', lineNumber: 0 }, hitCount: 40 },
+    { callFrame: { functionName: '', url: '/x/dist/core/Foo.js', lineNumber: 9 }, hitCount: 10 },
+  ],
+};
+
+function mkDeps(over: Partial<ProfileNodeDeps> = {}): ProfileNodeDeps {
+  return {
+    signalUsr1: vi.fn(),
+    fetchInspectorTarget: vi.fn(async (port: number) =>
+      port === 9229 ? { webSocketDebuggerUrl: 'ws://127.0.0.1:9229/abc', title: 'inst' } : null),
+    captureCpuProfile: vi.fn(async () => HOT_PROFILE),
+    hottestNodePid: vi.fn(async () => 4242),
+    sleep: vi.fn(async () => {}),
+    ...over,
+  };
+}
+
+describe('aggregateHotFrames (pure, both sides)', () => {
+  it('ranks by self-time and normalizes the dist/src file:line', () => {
+    const frames = aggregateHotFrames(HOT_PROFILE);
+    expect(frames[0].label).toBe('(idle)');           // idle dominates the sample
+    expect(frames[1].label).toBe('readFileUtf8');     // the real hot work is #2
+    expect(frames[1].selfPct).toBeCloseTo(33.3, 0);   // 300 / (480+300+70+40+10=900)
+    const ls = frames.find(f => f.label.startsWith('listSessions'));
+    expect(ls?.label).toBe('listSessions  dist/core/StateManager.js:151'); // +1 line, path trimmed
+  });
+
+  it('falls back to (anonymous) for a nameless frame', () => {
+    const anon = aggregateHotFrames(HOT_PROFILE).find(f => f.label.startsWith('(anonymous)'));
+    expect(anon?.label).toBe('(anonymous)  dist/core/Foo.js:10');
+  });
+
+  it('empty profile → no frames (no divide-by-zero)', () => {
+    expect(aggregateHotFrames({})).toEqual([]);
+    expect(aggregateHotFrames({ nodes: [] })).toEqual([]);
+  });
+
+  it('respects the topN cap', () => {
+    expect(aggregateHotFrames(HOT_PROFILE, 2)).toHaveLength(2);
+  });
+});
+
+describe('findInspectorTarget', () => {
+  it('returns the first port that has a ws target', async () => {
+    const t = await findInspectorTarget(mkDeps());
+    expect(t?.webSocketDebuggerUrl).toBe('ws://127.0.0.1:9229/abc');
+  });
+  it('returns null when no port has a target', async () => {
+    const t = await findInspectorTarget(mkDeps({ fetchInspectorTarget: async () => null }));
+    expect(t).toBeNull();
+  });
+});
+
+describe('runDevProfileNode (orchestration, injected deps)', () => {
+  it('happy path: signals the pid, profiles, prints hot frames, exit 0', async () => {
+    const deps = mkDeps(); const out = capture();
+    const code = await runDevProfileNode({ pid: '4242', deps, output: out });
+    expect(code).toBe(0);
+    expect(deps.signalUsr1).toHaveBeenCalledWith(4242);
+    expect(out.out).toContain('readFileUtf8');
+    expect(out.out).toContain('listSessions  dist/core/StateManager.js:151');
+  });
+
+  it('no pid → profiles the hottest node process', async () => {
+    const deps = mkDeps(); const out = capture();
+    const code = await runDevProfileNode({ deps, output: out });
+    expect(code).toBe(0);
+    expect(deps.hottestNodePid).toHaveBeenCalled();
+    expect(deps.signalUsr1).toHaveBeenCalledWith(4242);
+  });
+
+  it('no node process found → exit 1', async () => {
+    const deps = mkDeps({ hottestNodePid: async () => null }); const out = capture();
+    expect(await runDevProfileNode({ deps, output: out })).toBe(1);
+    expect(out.err).toContain('No running node process');
+  });
+
+  it('SIGUSR1 fails (pid gone) → exit 1', async () => {
+    const deps = mkDeps({ signalUsr1: () => { throw new Error('ESRCH'); } }); const out = capture();
+    expect(await runDevProfileNode({ pid: '99', deps, output: out })).toBe(1);
+    expect(out.err).toContain('Could not signal');
+  });
+
+  it('no inspector target opened → exit 1', async () => {
+    const deps = mkDeps({ fetchInspectorTarget: async () => null }); const out = capture();
+    expect(await runDevProfileNode({ pid: '4242', deps, output: out })).toBe(1);
+    expect(out.err).toContain('did not expose a node inspector');
+  });
+
+  it('profile capture throws → exit 1', async () => {
+    const deps = mkDeps({ captureCpuProfile: async () => { throw new Error('ws closed'); } }); const out = capture();
+    expect(await runDevProfileNode({ pid: '4242', deps, output: out })).toBe(1);
+    expect(out.err).toContain('CPU profile failed');
+  });
+});

--- a/upgrades/dev-profile-node-tool.eli16.md
+++ b/upgrades/dev-profile-node-tool.eli16.md
@@ -1,0 +1,40 @@
+# A stethoscope for a node process that's running hot
+
+## The one-sentence version
+When one of our programs is burning the CPU for no obvious reason, the usual tools can tell you *that* it's busy but not *what line of code* is doing it. This new command — `instar dev:profile-node` — presses a stethoscope to the running program and prints the exact function that's hogging the CPU.
+
+## The problem it solves
+Picture a car idling in the driveway but somehow guzzling gas. You pop the hood with your usual gauge — it says "engine's working hard" but won't tell you *which part*. That's macOS's built-in profiler on a Node.js program: it sees the engine block (the low-level machinery) but can't read the actual code, so the real culprit stays hidden.
+
+This bit us for real: three of our agent servers were each burning ~50–60% CPU, bouncing them never helped, and four different tools all came back "busy, but I can't tell you why." 
+
+## The trick that worked (now a one-liner)
+Node programs have a hidden superpower: send them a specific nudge (the SIGUSR1 signal) and they open a little diagnostic port on themselves. Connect to that port, record a few seconds of "what function is running right now," and it tells you — in plain code terms — exactly where the time goes.
+
+That's how we finally caught it: **30% of the CPU was in `readFileUtf8`, inside `listSessions`** — a function re-reading every session file off the disk, over and over. Invisible to everything else; obvious once we looked through the right lens.
+
+`instar dev:profile-node` bakes that whole trick into one command:
+- Point it at a process (or let it auto-find the hottest one).
+- It nudges the process, records ~5 seconds, and prints the hottest functions with their percentages.
+- The biggest non-idle line is your culprit.
+
+## What it looks like
+```
+Hottest JS frames (self-time) for pid 12673:
+   87.6%  listOnTimeout  node:internal/timers:546
+    9.9%  (program)
+    2.5%  (garbage collector)
+```
+(That's from a test process running a busy loop inside a timer — and it correctly fingered the timer callback.)
+
+## The safety notes
+1. The only thing it changes is opening that diagnostic port — and only on **localhost** (your own machine), only until the process next restarts. The command tells you it did this.
+2. It **samples** the process — it never kills it, restarts it, or edits anything.
+3. It's a developer tool, run on demand — nothing in the running system uses it.
+
+## Why it matters
+The hard part of fixing a mystery slowdown isn't the fix — it's *finding* the cause. This turns a clever, hard-won debugging trick into a reusable one-liner, so the next time any node process runs hot, the answer is one command away instead of an afternoon of dead ends. (Same spirit as our `dev:ci-failures` tool: when a workaround saves the day, make it permanent.)
+
+---
+
+**Rendered (verified HTTP 200):** https://echo.dawn-tunnel.dev/view/e5433071-bf6f-4cf0-b97a-5e16d9f7b160?sig=2c015aaeedc96ebb20d57b326f44d88eaa93dd2bcba0b4e8347a33d23f4d2b4b

--- a/upgrades/dev-profile-node-tool.eli16.md
+++ b/upgrades/dev-profile-node-tool.eli16.md
@@ -38,3 +38,5 @@ The hard part of fixing a mystery slowdown isn't the fix — it's *finding* the 
 ---
 
 **Rendered (verified HTTP 200):** https://echo.dawn-tunnel.dev/view/e5433071-bf6f-4cf0-b97a-5e16d9f7b160?sig=2c015aaeedc96ebb20d57b326f44d88eaa93dd2bcba0b4e8347a33d23f4d2b4b
+
+*See also: the full success-story + meta-insights writeup for this run.*

--- a/upgrades/next/dev-profile-node-tool.md
+++ b/upgrades/next/dev-profile-node-tool.md
@@ -53,3 +53,13 @@ prints the exact JS function responsible, which native profilers cannot show.
   `findInspectorTarget` (first-hit / none) + `runDevProfileNode` orchestration with
   injected deps (happy path, no-pid→hottest, no-node→exit1, signal-fail→exit1,
   no-inspector→exit1, capture-throw→exit1).
+
+## Also in this change
+
+Fixes a real false-negative in `scripts/docs-coverage.mjs`: a command's coverage
+was keyed on its camelCase **file** name (`devProfileNode`), so the needle
+`instar devProfileNode` never matched the shipped colon-command
+`instar dev:profile-node` — every `dev:*` command (ci-failures, preflight,
+profile-node) read as undocumented. The matcher now also tries a kebab form and
+treats `:`/`-` as interchangeable, so colon-commands count. (The new command
+surfaced this — friction → structural fix.)

--- a/upgrades/next/dev-profile-node-tool.md
+++ b/upgrades/next/dev-profile-node-tool.md
@@ -1,0 +1,55 @@
+# Upgrade Guide — vNEXT
+
+<!-- bump: minor -->
+
+## What Changed
+
+Adds `instar dev:profile-node [pid]` — a contributor/agent dev command that
+CPU-profiles a **running** node process and prints its hottest JS functions
+(function + `file:line` + self-time %).
+
+**Why this exists (the technique that cracked a real bug).** macOS `sample` — and
+lsof snapshots, empty `gh run --log`, port-grep — cannot symbolicate a node
+process's **JS** frames; they show only native/V8 frames, so a busy agent server's
+actual hot *function* stays invisible. The way to see it is the node process's own
+introspection: `SIGUSR1` opens node's inspector on the running process, then a CDP
+CPU profile over the inspector websocket reports the exact JS call frames. This is
+literally how the systemic agent-server hot-loop was pinned — `StateManager.listSessions`
+burning ~30% of CPU in `readFileUtf8`, invisible to every other tool. This command
+turns that hard-won procedure into one reusable command.
+
+**What it does:** resolves the pid (or auto-finds the hottest `node` process) →
+`SIGUSR1` → probes `127.0.0.1:9229-9235` for the inspector target → captures a CPU
+profile (default 5s, `--duration`) → prints the top frames by self-time (`--top`).
+The biggest non-idle frame is the hot path. Read-only aside from the SIGUSR1, which
+opens the inspector on localhost for the process's lifetime (it closes on the next
+restart) — the command says so in its output.
+
+Pairs with `dev:ci-failures` and `dev:preflight` as the contributor dev-loop
+toolkit (friction → tooling).
+
+## What to Tell Your User
+
+Nothing required — it is a developer/agent tool for working on Instar. When an
+agent server is mysteriously burning CPU, the instar dev:profile-node command
+prints the exact JS function responsible, which native profilers cannot show.
+
+## Summary of New Capabilities
+
+- `instar dev:profile-node [pid] [--duration <sec>] [--top <n>]` — CPU-profile a
+  running node process (SIGUSR1 + inspector + CDP) and print its hottest JS frames.
+  No pid → profiles the hottest node process.
+
+## Evidence
+
+- Built directly from the technique that pinned the real hot-loop: after `sample`,
+  lsof, grep, and log-diffing all failed, SIGUSR1 + a CDP CPU profile showed 30.8%
+  `readFileUtf8` + 7% `listSessions` (StateManager) — the JS frame nothing else
+  could see — leading to the cache fix.
+- Live end-to-end smoke: profiling a spawned CPU-busy node correctly reported the
+  hot frame (`listOnTimeout`, where the busy loop ran).
+- Tests: `tests/unit/devProfileNode.test.ts` — pure `aggregateHotFrames` (ranking,
+  file:line normalization, anonymous-frame fallback, empty profile, topN) +
+  `findInspectorTarget` (first-hit / none) + `runDevProfileNode` orchestration with
+  injected deps (happy path, no-pid→hottest, no-node→exit1, signal-fail→exit1,
+  no-inspector→exit1, capture-throw→exit1).

--- a/upgrades/side-effects/dev-profile-node-tool.md
+++ b/upgrades/side-effects/dev-profile-node-tool.md
@@ -1,0 +1,75 @@
+# Side-Effects Review — `instar dev:profile-node`
+
+**Version / slug:** `dev-profile-node-tool`
+**Date:** `2026-06-03`
+**Author:** `echo`
+**Second-pass reviewer:** `not required (dev-only CLI; read-only sampling; no server/runtime surface)`
+
+## Summary of the change
+
+A new dev CLI command that CPU-profiles a running node process via SIGUSR1 + the
+node inspector + a CDP CPU profile, and prints the hottest JS frames. New file
+`src/commands/devProfileNode.ts` + a cli.ts registration + a manifest entry +
+awareness lines. No server, route, config, or runtime-behavior change.
+
+## Decision-point inventory
+
+1. **pid resolution** — explicit `[pid]` digits win; otherwise auto-pick the
+   hottest `node` process (`ps -Aceo pcpu,pid,comm`). No node found → exit 1.
+2. **Inspector discovery** — probe ports 9229–9235 (node's default + increments
+   when the default is taken); first target with a `webSocketDebuggerUrl` wins;
+   none → exit 1 with a clear message.
+3. **Profile aggregation** — `aggregateHotFrames` sums per-node `hitCount` by call
+   frame, normalizes the path to `dist/…`/`src/…`, +1 to the 0-based line, and
+   returns top-N by self-time. Idle/native frames are kept on purpose (seeing
+   "48% idle, 30% readFileUtf8" is the signal).
+4. **Exit codes** — 0 on a successful print (even "no samples"); 1 only on an
+   operational failure (no node, signal failed, no inspector, capture threw).
+
+## 1. The one real side effect — SIGUSR1 opens the inspector
+
+SIGUSR1 tells node to start its inspector on `127.0.0.1` (localhost-only) for the
+life of the process. Implications, all bounded:
+- **Localhost-only** — the inspector binds 127.0.0.1, not a public interface; it is
+  not remotely reachable.
+- **Transient** — it closes when the process restarts; it does not persist.
+- **Disclosed** — the command prints that it left the inspector open on the pid.
+- **No state mutation** — profiling samples the process; it does not change its
+  behavior, memory, or files.
+
+This is the same standard procedure node documents for live debugging; it is the
+*only* way to symbolicate JS frames on a running process. The benefit (pinning a
+hot loop that no other tool can see) outweighs a transient localhost debug port on
+a dev box. Operators who object can simply not run the command.
+
+## 2. Over/under-block
+
+Not applicable — it gates nothing and changes no behavior. A wrong pid or a
+non-node target fails cleanly with exit 1; it never acts on the target beyond
+SIGUSR1 + reading the profile.
+
+## 3. Blast radius
+
+Zero runtime surface. The command runs only when a contributor/agent invokes it.
+No server code path imports it; it is a leaf CLI command behind a dynamic import
+(like `dev:ci-failures`). The `ws` dependency is already present (`^8.19.0`).
+
+## 4. Migration parity
+
+CLAUDE.md template (`generateClaudeMd`) + `site/.../cli.md` + the builtin-manifest
+(`cli:dev-profile-node`) are updated in lockstep so the awareness + discoverability
+checks stay green. No config/hook/skill migration — it is a pure CLI addition
+(same shape as `dev:ci-failures`, which needed none).
+
+## 5. Testability
+
+`aggregateHotFrames` and `findInspectorTarget` are pure/dep-injected; the
+SIGUSR1 / inspector-http / ws-CDP boundary is behind `ProfileNodeDeps` so the
+orchestration is unit-tested without a real process. A live end-to-end smoke
+(profiling a spawned busy node) confirmed the real path.
+
+## 6. What it does NOT do
+
+- Does not kill, restart, or modify the target (only SIGUSR1 + sample).
+- Does not run as part of the server or any job — invoked on demand only.
+- Does not expose a remote/public debug port (inspector is localhost).

--- a/upgrades/side-effects/dev-profile-node-tool.md
+++ b/upgrades/side-effects/dev-profile-node-tool.md
@@ -73,3 +73,13 @@ orchestration is unit-tested without a real process. A live end-to-end smoke
 - Does not kill, restart, or modify the target (only SIGUSR1 + sample).
 - Does not run as part of the server or any job — invoked on demand only.
 - Does not expose a remote/public debug port (inspector is localhost).
+
+## 7. Collateral fix — docs-coverage matcher
+
+Adding the command surfaced a false-negative in `scripts/docs-coverage.mjs`: it
+matched a command by its camelCase file name, so colon-commands (`dev:*`) never
+matched their documented form and read as undocumented (the floor was sitting
+right at the limit, so the new command tipped it). The matcher now also tries a
+kebab form and normalizes `:`↔`-`. Audit-only script (the weekly docs-coverage
+report); no runtime/behavior effect. It re-classifies the three `dev:*` commands
+as documented, which is correct (they ARE in cli.md + the CLAUDE.md template).


### PR DESCRIPTION
Productizes the SIGUSR1 + node-inspector + CDP CPU-profile technique that pinned this run's systemic agent-server hot-loop (StateManager.listSessions, 30% in readFileUtf8) after macOS `sample`, lsof, grep, and empty gh-logs all came back blind — they can't symbolicate a node process's JS frames; the inspector can.

`instar dev:profile-node [pid] [--duration <sec>] [--top <n>]`: resolves the pid (or auto-finds the hottest node) → SIGUSR1 → probes 9229-9235 for the inspector → CPU profile → prints the hottest JS frames by self-time. Read-only aside from the SIGUSR1 (localhost inspector, closes on restart; disclosed in output).

Tests: 12 unit (pure aggregateHotFrames both-sides + findInspectorTarget + dep-injected orchestration: happy/no-pid/no-node/signal-fail/no-inspector/capture-throw) + a live end-to-end smoke (profiled a spawned busy node, correctly fingered the hot frame). lint+build+manifest+discoverability green. Tier-1 lane (dev-only tool).

ELI16 (verified 200): https://echo.dawn-tunnel.dev/view/e5433071-bf6f-4cf0-b97a-5e16d9f7b160?sig=2c015aaeedc96ebb20d57b326f44d88eaa93dd2bcba0b4e8347a33d23f4d2b4b

Friction → tooling, alongside dev:ci-failures + dev:preflight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)