### PR TITLE
feat(monitoring): McpProcessReaper — reap leaked MCP-server children (Option B)

### DIFF
--- a/docs/specs/MCP-PROCESS-REAPER-SPEC.eli16.md
+++ b/docs/specs/MCP-PROCESS-REAPER-SPEC.eli16.md
@@ -1,0 +1,47 @@
+# MCP-Process Reaper — the plain-English version
+
+## What's the problem?
+
+When an agent session runs, it starts little helper programs called **MCP servers**
+(for example, the Playwright browser helper or the Fathom bridge). When the
+session ends, those helpers are *supposed* to die with it — but they don't.
+Killing the session's main program doesn't automatically kill its helpers, so the
+helpers get "adopted" by the operating system and keep running. Over days, they
+pile up. The fleet had about **80 of these stray helpers**, some 5 days old, all
+quietly eating CPU. That's the "host load" problem.
+
+## What already exists?
+
+Instar already has reapers (cleanup robots): one for stale sessions, one for stale
+git worktrees. But none of them clean up these leaked **MCP helper** processes —
+they clean the session, not the session's leftover helpers.
+
+## What's new?
+
+A new cleanup robot, the **MCP-Process Reaper**. Once per pass it looks at every
+MCP helper process and asks: *who owns you?* It follows the family tree upward to
+find the tmux session the helper belongs to.
+
+- If the owner is **alive and tracked** → leave it alone (even if it's old — a
+  long-running session is allowed to own old helpers).
+- If the owner is **someone else's** (not an instar session) → never touch it.
+- If the owner is a **dead/stale instar session**, or the helper has **no owner at
+  all** (orphaned), and it's **old** → that's a leak; reap it.
+
+## How safe is it?
+
+Very deliberately safe:
+- It ships **off**, and even when on it starts in **dry-run** — it writes down what
+  it *would* kill but kills nothing — so you can review first at `GET /processes/mcp-reaper`.
+- It only ever matches **three exact helper types**, never a broad "any node program" match.
+- It **never** kills a live session's helpers, and **never** touches a non-instar
+  (your own) session's processes.
+- Every decision is written to an audit log.
+- On echo (the dev agent) it runs but stays in dry-run, so we can watch it judge the
+  real ~80 leaks before anyone turns the actual killing on.
+
+## What do you need to decide?
+
+Nothing to decide to ship it — it ships dark + dry-run, so merging changes no live
+behavior. The only later decision is *when* to flip `dryRun:false` on echo to let it
+actually reclaim the leaks, after you've looked at a dry-run pass.

--- a/docs/specs/MCP-PROCESS-REAPER-SPEC.md
+++ b/docs/specs/MCP-PROCESS-REAPER-SPEC.md
@@ -1,0 +1,90 @@
+---
+title: MCP-Process Reaper (leaked-MCP descendant sweep — Option B)
+status: approved
+parent-principle: "Structure beats Willpower"
+review-convergence: "overseer-designed (Codey task brief, .instar/apprenticeship/codey-task-mcp-leak-reaper.md) + Echo build-review with both-sides safety tests; autonomous Tier-2 under standing preapproval"
+approved: true
+approved-by: "Justin (18h autonomous task list, 2026-06-04: 'build + ship the MCP-leak reaper (Option B)' + standing preapproval for autonomous dev)"
+eli16-overview: MCP-PROCESS-REAPER-SPEC.eli16.md
+lessons-engaged:
+  - "Structure beats Willpower — sessions should take their children with them, not rely on a human noticing stray procs"
+  - "Protected sessions are sacred (Dawn pattern) — never reap a live/tracked session's children"
+  - "Dark + dry-run default for any destructive reaper (SessionReaper / AgentWorktreeReaper precedent)"
+---
+
+# MCP-Process Reaper — Option B (descendant-aware sweep)
+
+## Problem
+
+A session spawns MCP-server children (Playwright, `mcp-remote`, instar's stdio MCP).
+Killing the session's main pid does **not** cascade to those children — they
+re-parent (to PID 1 / launchd) or are held by an `npm exec` wrapper and survive
+for **days**. The fleet accumulated **~80** such leaked procs, up to 5 days old,
+as a persistent load floor (profiling evidence: `autonomy_loop_fix_and_codex_recovery_wip`).
+`OrphanProcessReaper` reaps the session-level CLI proc but not its MCP descendants.
+
+This is **Justin's #1 host-load concern** and a real fleet bug. It is the
+descendant-leak counterpart to the per-agent CPU hog that #714/#728 addressed.
+
+## Design — Option B (sibling sweep), not a change to the shared reaper
+
+Codey's brief offered Option A (tree-kill on session teardown — fix at source)
+and Option B (a descendant-aware sweep — backstop that cleans the existing leak
+and catches future unclean deaths). **This spec ships Option B as a separate
+`McpProcessReaper`** — NOT a modification of `OrphanProcessReaper` / the shared
+`ReapGuard` / `ReapAuthority` path. Rationale: the shared reaper path governs
+*session* kills with a lease gate + KEEP-guard; an MCP-descendant sweep has a
+different safety model and a different blast radius, so isolating it as a sibling
+keeps the working session-reap authority untouched (zero blast radius — the same
+Option-B discipline used for #722). Option A (tree-kill at teardown) remains a
+worthwhile *source* fix and is noted as a follow-up; B both cleans the existing
+~80 and catches future unclean deaths regardless of how the session died.
+
+### Components
+
+- **`mcpProcessSignatures.ts`** — a precise allow-list of exactly three MCP-server
+  shapes (`playwright-mcp`, `mcp-remote`, `instar-mcp-stdio`), each a conjunction
+  match. Never a broad `node`/`npm` match — an unrelated node process can never be
+  a candidate.
+- **`McpProcessReaper.ts`** — pure `resolveOwningSession` (walks the ppid chain to
+  a tmux pane, cycle-safe + hop-bounded) + pure `classifyMcpProcess` + the reaper
+  class (mirrors `AgentWorktreeReaper`: dep-injected, EventEmitter, `start/stop`,
+  `reap()`, `snapshot()`).
+- **`mcpProcessReaperDeps.ts`** — production signal sources (ps / tmux / SessionManager
+  / `process.kill(SIGTERM)` / JSONL audit), kept out of the class so the classifier
+  is unit-testable without a real process table.
+
+### Safety model (the #1 review axis)
+
+For each allow-listed MCP proc, resolve its owning tmux session by walking the
+ppid chain to a tmux pane pid. Then:
+
+| Owning session | Verdict |
+|---|---|
+| live / tracked (in `listRunningSessions`) | **KEEP — `session-live`** (sacred, ANY age — a long-running autonomous session legitimately owns old MCP servers) |
+| external / non-instar tmux session | **KEEP — `external-session`** (never touch the user's processes) |
+| stale/dead *instar* session (in `listKnownTmuxSessions` but not live) + old | **reap — `stale-instar-session`** |
+| stale instar session + young | KEEP — `stale-instar-too-young` |
+| none (orphaned / re-parented, no tmux ancestor) + old | **reap — `orphaned-no-session`** (the dominant leak shape) |
+| orphaned + young | KEEP — `orphan-too-young` |
+
+Age alone is **never** sufficient. A failed evaluation always KEEPS (never reap on
+an error). `minAgeMs` defaults to **2h** (the leaked procs are hours-to-days old).
+
+### Rollout (dark + dry-run)
+
+- Config gate `monitoring.mcpProcessReaper = { enabled:false, dryRun:true, minAgeMs:7_200_000, reapIntervalMs:1_800_000, maxReapsPerPass:25, maxAncestorHops:30 }` (via `ConfigDefaults`, `applyDefaults` is add-missing-only ⇒ migration parity automatic).
+- **developmentAgent gate**: `enabled` defaults ON for dev agents (echo) — but `dryRun` stays `true`, so a dev agent **observes + audits would-reap without killing**. Fleet-wide it is fully OFF. Kills only ever happen when `dryRun:false` is set explicitly.
+- Every decision (`reaped` / `would-reap` / `kept`) is audited to `logs/mcp-reaper-audit.jsonl`.
+- Read-only observability at `GET /processes/mcp-reaper` (snapshot: per-proc verdict + owning session + `reapEligible` count + `enabled`/`dryRun`).
+
+## Tests (3 tiers, both sides of every boundary)
+
+- **Unit** (`tests/unit/mcp-process-reaper.test.ts`, 18): signature match/non-match; `resolveOwningSession` (direct pane / ancestor chain / no-ancestor / cycle-safe / hop-cap); `classifyMcpProcess` both sides of every boundary (live→keep at 10 days, external→keep, stale-instar→reap, too-young→keep, orphaned→reap, orphan-young→keep); `reap()` dry-run-classifies-not-kills, enabled-kills-orphan-never-live, `maxReapsPerPass` cap, disabled-kills-nothing, snapshot side-effect-free.
+- **Integration** (`tests/integration/mcp-process-reaper-routes.test.ts`): `GET /processes/mcp-reaper` → 503 unwired, 200 snapshot wired.
+- **E2E** (`tests/e2e/mcp-process-reaper-lifecycle.test.ts`): the route returns 200 (not 503) through the real `AgentServer` → `RouteContext` plumbing — the feature-is-alive guard.
+
+## Follow-up
+
+- **Option A (source fix):** make the session-teardown kill path tree-kill the
+  descendant MCP servers, so new leaks never form. B remains the backstop.

--- a/src/commands/server.ts
+++ b/src/commands/server.ts
@@ -9037,6 +9037,40 @@ export async function startServer(options: StartOptions): Promise<void> {
       ));
     }
 
+    // ── McpProcessReaper (RESPONSIBLE-RESOURCE-USAGE — MCP-leak fix, Option B) ──
+    // Reaps leaked MCP-server children (playwright-mcp / mcp-remote / instar
+    // stdio) whose owning session is dead/stale or fully orphaned. Killing a
+    // session's main pid doesn't cascade to MCP children, so they re-parent and
+    // accumulate for days. Ships OFF + dry-run fleet-wide; the developmentAgent
+    // gate ENABLES it (still dry-run) on dev agents (echo) so it observes +
+    // audits would-reap WITHOUT killing until dryRun is explicitly turned off.
+    // Observability at GET /processes/mcp-reaper.
+    const { McpProcessReaper } = await import('../monitoring/McpProcessReaper.js');
+    const { makeMcpProcessReaperDeps } = await import('../monitoring/mcpProcessReaperDeps.js');
+    const _mcpReaperCfg = (() => {
+      const mcfg = config.monitoring?.mcpProcessReaper;
+      // developmentAgent gate: `enabled` defaults ON for dev agents (dark fleet-
+      // wide); an explicit config value always wins. `dryRun` is untouched (stays
+      // true by default) so a dev agent only observes — never kills.
+      return { ...(mcfg ?? {}), enabled: mcfg?.enabled ?? !!config.developmentAgent };
+    })();
+    const mcpProcessReaper = new McpProcessReaper(
+      makeMcpProcessReaperDeps({
+        sessionManager,
+        tmuxPath: config.sessions.tmuxPath,
+        auditPath: path.join(config.stateDir, '..', 'logs', 'mcp-reaper-audit.jsonl'),
+      }),
+      _mcpReaperCfg,
+    );
+    mcpProcessReaper.start();
+    if (_mcpReaperCfg.enabled) {
+      console.log(pc.green(
+        _mcpReaperCfg.dryRun === false
+          ? '  McpProcessReaper enabled (leaked-MCP reclaim — LIVE)'
+          : '  McpProcessReaper enabled (leaked-MCP reclaim — dry-run, report only)',
+      ));
+    }
+
     // ── Agent hard-sleep — SleepController (RESPONSIBLE-RESOURCE-USAGE, Stage B) ──
     // Decides "is it safe for this idle agent to drop to near-zero footprint?" with
     // every safety guard. Ships OFF + dry-run: observes + audits to
@@ -9790,7 +9824,7 @@ export async function startServer(options: StartOptions): Promise<void> {
       console.log(pc.dim(`  [session-pool] rollout gate not wired: ${err instanceof Error ? err.message : String(err)}`));
     }
 
-    const server = new AgentServer({ config, sessionManager, state, scheduler, telegram, relationships, feedback, feedbackAnomalyDetector, dispatches, updateChecker, autoUpdater, autoDispatcher, quotaTracker, quotaManager, publisher, viewer, tunnel, evolution, watchdog, topicMemory, triageNurse, projectMapper, coherenceGate: scopeVerifier, contextHierarchy, canonicalState, operationGate, sentinel, adaptiveTrust, memoryMonitor, orphanReaper, coherenceMonitor, commitmentTracker, semanticMemory, activitySentinel, rateLimitSentinel, releaseReadinessSentinel: releaseReadinessSentinel ?? undefined, messageRouter, summarySentinel, spawnManager, systemReviewer, capabilityMapper, selfKnowledgeTree, coverageAuditor, topicResumeMap: _topicResumeMap ?? undefined, sessionRefresh: _sessionRefresh ?? undefined, autonomyManager, trustElevationTracker, autonomousEvolution, coordinator: coordinator.enabled ? coordinator : undefined, localSigningKeyPem, leaseTransport, onLeasePullRequest: () => leaseCoordinatorRef?.currentLease() ?? null, liveTailReceiver, handoffWireTransport, onHandoffBegin, onHandoffInitiate: handoffInitiate, handoffInProgress: handoffSentinelInProgress, messageLedger, currentInboundByTopic, replyMarkerTransport, onReplyMarker: messageLedger ? (marker: unknown) => { const m = marker as { dedupeKey: string; platform: string; replyIdempotencyKey: string; epoch: number; topic?: string | null }; messageLedger!.applyRemoteReplyMarker(m.dedupeKey, { platform: m.platform, replyIdempotencyKey: m.replyIdempotencyKey, epoch: m.epoch, topic: m.topic ?? null }); } : undefined, whatsapp: whatsappAdapter, slack: slackAdapter, imessage: imessageAdapter, whatsappBusinessBackend, messageBridge, hookEventReceiver, worktreeMonitor, subagentTracker, instructionsVerifier, handshakeManager: threadlineHandshake, threadlineRouter, conversationStore, warrantsReplyGate, collaborationSurfacer, threadResumeMap, topicLinkageHandler: topicLinkageHandler ?? undefined, threadlineRelayClient, threadlineReplyWaiters, listenerManager: listenerManager ?? undefined, responseReviewGate, messagingToneGate, outboundDedupGate, telemetryHeartbeat, pasteManager, featureRegistry, discoveryEvaluator, completionEvaluator, unifiedTrust, liveConfig, sharedStateLedger, ledgerSessionRegistry, worktreeManager, oidcEnrolledRepos: parallelDevConfig?.oidcEnrolledRepos, initiativeTracker, projectRoundRunner, projectDriftChecker, machineHeartbeat, machinePoolRegistry, meshRpcDispatcher, sessionOwnershipRegistry, sessionPoolE2EResultStore, proxyCoordinator, topicIntentStore, topicIntentArcCheck, usherSignalStore, intelligence: sharedIntelligence ?? undefined, telegramBridgeConfig, telegramBridge: telegramBridge ?? undefined, threadlineObservability, briefDeps, workingMemory, taskFlowRegistry, threadlineFlowBridge, sessionReaper, agentWorktreeReaper, sleepController, agentActivityState, reapLog, sleepWakeDetector, unjustifiedStopGate, stopGateDb, stopNotifier });
+    const server = new AgentServer({ config, sessionManager, state, scheduler, telegram, relationships, feedback, feedbackAnomalyDetector, dispatches, updateChecker, autoUpdater, autoDispatcher, quotaTracker, quotaManager, publisher, viewer, tunnel, evolution, watchdog, topicMemory, triageNurse, projectMapper, coherenceGate: scopeVerifier, contextHierarchy, canonicalState, operationGate, sentinel, adaptiveTrust, memoryMonitor, orphanReaper, coherenceMonitor, commitmentTracker, semanticMemory, activitySentinel, rateLimitSentinel, releaseReadinessSentinel: releaseReadinessSentinel ?? undefined, messageRouter, summarySentinel, spawnManager, systemReviewer, capabilityMapper, selfKnowledgeTree, coverageAuditor, topicResumeMap: _topicResumeMap ?? undefined, sessionRefresh: _sessionRefresh ?? undefined, autonomyManager, trustElevationTracker, autonomousEvolution, coordinator: coordinator.enabled ? coordinator : undefined, localSigningKeyPem, leaseTransport, onLeasePullRequest: () => leaseCoordinatorRef?.currentLease() ?? null, liveTailReceiver, handoffWireTransport, onHandoffBegin, onHandoffInitiate: handoffInitiate, handoffInProgress: handoffSentinelInProgress, messageLedger, currentInboundByTopic, replyMarkerTransport, onReplyMarker: messageLedger ? (marker: unknown) => { const m = marker as { dedupeKey: string; platform: string; replyIdempotencyKey: string; epoch: number; topic?: string | null }; messageLedger!.applyRemoteReplyMarker(m.dedupeKey, { platform: m.platform, replyIdempotencyKey: m.replyIdempotencyKey, epoch: m.epoch, topic: m.topic ?? null }); } : undefined, whatsapp: whatsappAdapter, slack: slackAdapter, imessage: imessageAdapter, whatsappBusinessBackend, messageBridge, hookEventReceiver, worktreeMonitor, subagentTracker, instructionsVerifier, handshakeManager: threadlineHandshake, threadlineRouter, conversationStore, warrantsReplyGate, collaborationSurfacer, threadResumeMap, topicLinkageHandler: topicLinkageHandler ?? undefined, threadlineRelayClient, threadlineReplyWaiters, listenerManager: listenerManager ?? undefined, responseReviewGate, messagingToneGate, outboundDedupGate, telemetryHeartbeat, pasteManager, featureRegistry, discoveryEvaluator, completionEvaluator, unifiedTrust, liveConfig, sharedStateLedger, ledgerSessionRegistry, worktreeManager, oidcEnrolledRepos: parallelDevConfig?.oidcEnrolledRepos, initiativeTracker, projectRoundRunner, projectDriftChecker, machineHeartbeat, machinePoolRegistry, meshRpcDispatcher, sessionOwnershipRegistry, sessionPoolE2EResultStore, proxyCoordinator, topicIntentStore, topicIntentArcCheck, usherSignalStore, intelligence: sharedIntelligence ?? undefined, telegramBridgeConfig, telegramBridge: telegramBridge ?? undefined, threadlineObservability, briefDeps, workingMemory, taskFlowRegistry, threadlineFlowBridge, sessionReaper, agentWorktreeReaper, mcpProcessReaper, sleepController, agentActivityState, reapLog, sleepWakeDetector, unjustifiedStopGate, stopGateDb, stopNotifier });
     // Boot-recovery (tunnel-failure-resilience spec Part 6): if the agent
     // died mid-relay-episode, the persisted tunnel.json carries
     // rotationPending=true. Rotate the dashboard PIN + authToken BEFORE

--- a/src/config/ConfigDefaults.ts
+++ b/src/config/ConfigDefaults.ts
@@ -121,6 +121,22 @@ const SHARED_DEFAULTS: Record<string, unknown> = {
       reapIntervalMs: 86_400_000,
       maxReapsPerPass: 20,
     },
+    // McpProcessReaper (Responsible Resource Usage — MCP-leak fix, Option B).
+    // Reaps leaked MCP-server children (playwright-mcp / mcp-remote / instar
+    // stdio) whose owning session is dead/stale or fully orphaned — killing a
+    // session's main pid does NOT cascade to these children, so they re-parent
+    // and accumulate for days (the fleet hit ~80, up to 5 days old). Ships OFF +
+    // dry-run (it kills processes); review a dry-run pass (GET /processes/mcp-
+    // reaper) before enabling. NEVER touches a proc under a live/tracked session
+    // or an external (non-instar) tmux session.
+    mcpProcessReaper: {
+      enabled: false,
+      dryRun: true,
+      minAgeMs: 7_200_000,
+      reapIntervalMs: 1_800_000,
+      maxReapsPerPass: 25,
+      maxAncestorHops: 30,
+    },
     // Agent hard-sleep — SleepController decision foundation (Stage B, slice 1;
     // docs/specs/agent-hard-sleep-controller.md). Decides "is it safe for this
     // idle agent to drop its server to near-zero footprint?" with every safety

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -3207,6 +3207,22 @@ export interface MonitoringConfig {
     maxReapsPerPass?: number;
   };
   /**
+   * McpProcessReaper (RESPONSIBLE-RESOURCE-USAGE — MCP-leak fix, Option B).
+   * Reaps leaked MCP-server children (playwright-mcp / mcp-remote / instar
+   * stdio) whose owning session is dead/stale or fully orphaned. Killing a
+   * session's main pid doesn't cascade to MCP children, so they accumulate for
+   * days. Ships OFF + dry-run; GET /processes/mcp-reaper exposes the dry-run
+   * verdict. NEVER reaps a proc under a live/tracked or external tmux session.
+   */
+  mcpProcessReaper?: {
+    enabled?: boolean;
+    dryRun?: boolean;
+    minAgeMs?: number;
+    reapIntervalMs?: number;
+    maxReapsPerPass?: number;
+    maxAncestorHops?: number;
+  };
+  /**
    * Agent hard-sleep — SleepController decision foundation (RESPONSIBLE-RESOURCE-
    * USAGE, Stage B; docs/specs/agent-hard-sleep-controller.md). Decides whether a
    * deeply-idle agent may drop its server to near-zero footprint, with safety

--- a/src/monitoring/McpProcessReaper.ts
+++ b/src/monitoring/McpProcessReaper.ts
@@ -1,0 +1,313 @@
+/**
+ * McpProcessReaper — Option B of the MCP-leak fix (Codey's design in
+ * `.instar/apprenticeship/codey-task-mcp-leak-reaper.md`).
+ *
+ * The problem: a session spawns MCP-server children (Playwright, mcp-remote,
+ * instar stdio). Killing the session's main pid does NOT cascade to those
+ * children — they re-parent (to PID 1 / launchd) or are held by an npm-exec
+ * wrapper and survive for days. The fleet accumulated ~80 such leaked procs,
+ * up to 5 days old, as a persistent load floor. `OrphanProcessReaper` reaps the
+ * session-level CLI proc but not these MCP *descendants*.
+ *
+ * This is a descendant-aware SWEEP (a sibling reaper, NOT a change to the
+ * shared OrphanProcessReaper / ReapGuard path — zero blast radius on the
+ * working reaper). For each allow-listed MCP proc it resolves the owning tmux
+ * session by walking the ppid chain, and reaps ONLY when the proc is old AND
+ * its owning session is a dead/stale *instar* session or fully orphaned. It
+ * NEVER touches a proc under a live/tracked session, nor under an external
+ * (non-instar) tmux session.
+ *
+ * Ships DARK + DRY-RUN by default (kills processes — same posture as
+ * SessionReaper / AgentWorktreeReaper). Every decision is audited.
+ */
+
+import { EventEmitter } from 'node:events';
+import { matchMcpSignature, type McpProcessSignature } from './mcpProcessSignatures.js';
+
+export interface McpProcessReaperConfig {
+  enabled: boolean;
+  dryRun: boolean;
+  /** A proc younger than this is always kept (a starting session's children). */
+  minAgeMs: number;
+  reapIntervalMs: number;
+  /** Bounded blast radius per pass. */
+  maxReapsPerPass: number;
+  /** Max ppid hops when resolving a proc's owning tmux session. */
+  maxAncestorHops: number;
+}
+
+export const DEFAULT_MCP_PROCESS_REAPER_CONFIG: McpProcessReaperConfig = {
+  enabled: false,
+  dryRun: true,
+  // Conservative: the leaked procs are hours-to-days old; 2h floor means a
+  // legitimately busy short-lived MCP child is never a candidate.
+  minAgeMs: 2 * 3600 * 1000,
+  reapIntervalMs: 30 * 60 * 1000,
+  maxReapsPerPass: 25,
+  maxAncestorHops: 30,
+};
+
+export interface McpProcessInfo {
+  pid: number;
+  ppid: number;
+  elapsedMs: number;
+  command: string;
+  signatureId: McpProcessSignature['id'];
+}
+
+export type McpVerdict = 'keep' | 'reap-eligible';
+
+export interface McpEvaluation {
+  pid: number;
+  signatureId: McpProcessSignature['id'];
+  ageMs: number;
+  owningSession: string | null;
+  verdict: McpVerdict;
+  /** The gate that forced KEEP, or the reap rationale. */
+  reason: string;
+}
+
+/**
+ * All signal sources injected so the classifier is unit-testable without a
+ * real process table, tmux, or kill(2). Production wiring supplies ps/tmux/
+ * SessionManager-backed implementations.
+ */
+export interface McpProcessReaperDeps {
+  /** Allow-listed MCP-server processes currently running (this uid). */
+  listMcpProcesses: () => McpProcessInfo[];
+  /** Full pid → ppid map of the process table (for ancestor resolution). */
+  getProcessTree: () => Map<number, number>;
+  /** tmux pane pid → session name. */
+  getTmuxPaneMap: () => Map<number, string>;
+  /** tmux session names that are genuinely live/tracked. SACRED — never reaped. */
+  getLiveSessions: () => Set<string>;
+  /** All instar-pattern tmux session names present (tracked or not). Used to
+   *  tell a dead/stale *instar* session (reapable) from an external one (kept). */
+  getInstarSessions: () => Set<string>;
+  /** SIGTERM the proc. Only called when killsEnabled. */
+  killProcess: (pid: number) => void;
+  /** Append one audit entry (JSONL). Never throws into the reap loop. */
+  audit?: (entry: McpReapAuditEntry) => void;
+  now?: () => number;
+}
+
+export interface McpReapAuditEntry {
+  ts: number;
+  type: 'reaped' | 'would-reap' | 'kept';
+  pid: number;
+  signatureId: string;
+  ageMs: number;
+  owningSession: string | null;
+  reason: string;
+  dryRun: boolean;
+}
+
+/**
+ * Walk the ppid chain from `startPid` until a pid is a tmux pane pid. Returns
+ * the owning tmux session name, or null when no tmux ancestor is found within
+ * `maxHops` (i.e. the proc is orphaned / re-parented — its session is dead).
+ * Pure — cycle-safe via a visited set.
+ */
+export function resolveOwningSession(
+  startPid: number,
+  tree: Map<number, number>,
+  tmuxPaneMap: Map<number, string>,
+  maxHops: number,
+): string | null {
+  let pid: number | undefined = startPid;
+  const seen = new Set<number>();
+  for (let hop = 0; hop <= maxHops && pid !== undefined && pid > 1; hop++) {
+    if (seen.has(pid)) break; // cycle guard
+    seen.add(pid);
+    const session = tmuxPaneMap.get(pid);
+    if (session) return session;
+    pid = tree.get(pid);
+  }
+  return null;
+}
+
+/**
+ * Pure per-proc classifier. KEEP unless the proc is old AND its owning session
+ * is a dead/stale instar session or fully orphaned. Order matters: the sacred
+ * gates (live session, external session) short-circuit before age is consulted.
+ */
+export function classifyMcpProcess(
+  proc: McpProcessInfo,
+  owningSession: string | null,
+  liveSessions: Set<string>,
+  instarSessions: Set<string>,
+  minAgeMs: number,
+): McpEvaluation {
+  const base = {
+    pid: proc.pid,
+    signatureId: proc.signatureId,
+    ageMs: proc.elapsedMs,
+    owningSession,
+  };
+  const keep = (reason: string): McpEvaluation => ({ ...base, verdict: 'keep', reason });
+  const reap = (reason: string): McpEvaluation => ({ ...base, verdict: 'reap-eligible', reason });
+
+  if (owningSession !== null) {
+    // SACRED: a live/tracked session owns it — keep regardless of age. A long-
+    // running autonomous session legitimately owns old MCP servers.
+    if (liveSessions.has(owningSession)) return keep('session-live');
+    // An external (non-instar) tmux session — never touch the user's processes.
+    if (!instarSessions.has(owningSession)) return keep('external-session');
+    // A stale/dead *instar* session still lingering in tmux: reapable when old.
+    if (proc.elapsedMs < minAgeMs) return keep('stale-instar-too-young');
+    return reap(`stale-instar-session:${owningSession}`);
+  }
+
+  // No tmux ancestor — the owning session is dead and this proc re-parented.
+  // This is the dominant leak shape. Reapable only when old.
+  if (proc.elapsedMs < minAgeMs) return keep('orphan-too-young');
+  return reap('orphaned-no-session');
+}
+
+export class McpProcessReaper extends EventEmitter {
+  private readonly cfg: McpProcessReaperConfig;
+  private readonly deps: McpProcessReaperDeps;
+  private readonly now: () => number;
+  private timer?: NodeJS.Timeout;
+  private running = false;
+  private lastPassAt = 0;
+  private reapedLastPass = 0;
+
+  constructor(deps: McpProcessReaperDeps, cfg?: Partial<McpProcessReaperConfig>) {
+    super();
+    this.deps = deps;
+    this.cfg = { ...DEFAULT_MCP_PROCESS_REAPER_CONFIG, ...(cfg ?? {}) };
+    this.now = deps.now ?? (() => Date.now());
+  }
+
+  start(): void {
+    if (this.timer || !this.cfg.enabled) return;
+    this.timer = setInterval(() => { void this.reap(); }, this.cfg.reapIntervalMs);
+    if (typeof this.timer.unref === 'function') this.timer.unref();
+  }
+
+  stop(): void {
+    if (this.timer) { clearInterval(this.timer); this.timer = undefined; }
+  }
+
+  private get killsEnabled(): boolean {
+    return this.cfg.enabled && !this.cfg.dryRun;
+  }
+
+  /** Resolve + classify one proc against the current process/tmux/session view. */
+  private evaluate(
+    proc: McpProcessInfo,
+    tree: Map<number, number>,
+    tmuxPaneMap: Map<number, string>,
+    liveSessions: Set<string>,
+    instarSessions: Set<string>,
+  ): McpEvaluation {
+    const owningSession = resolveOwningSession(proc.pid, tree, tmuxPaneMap, this.cfg.maxAncestorHops);
+    return classifyMcpProcess(proc, owningSession, liveSessions, instarSessions, this.cfg.minAgeMs);
+  }
+
+  /** One reap pass. Returns the per-proc evaluations + what was reaped. */
+  async reap(): Promise<{ ts: number; evaluations: McpEvaluation[]; reaped: number[]; dryRun: boolean }> {
+    if (this.running) return { ts: this.now(), evaluations: [], reaped: [], dryRun: !this.killsEnabled };
+    this.running = true;
+    const reaped: number[] = [];
+    const evaluations: McpEvaluation[] = [];
+    try {
+      let procs: McpProcessInfo[];
+      let tree: Map<number, number>;
+      let tmuxPaneMap: Map<number, string>;
+      let liveSessions: Set<string>;
+      let instarSessions: Set<string>;
+      try {
+        procs = this.deps.listMcpProcesses();
+        tree = this.deps.getProcessTree();
+        tmuxPaneMap = this.deps.getTmuxPaneMap();
+        liveSessions = this.deps.getLiveSessions();
+        instarSessions = this.deps.getInstarSessions();
+      } catch (err) {
+        this.emit('error', err);
+        return { ts: this.now(), evaluations: [], reaped: [], dryRun: !this.killsEnabled };
+      }
+
+      for (const proc of procs) {
+        let evaln: McpEvaluation;
+        try {
+          evaln = this.evaluate(proc, tree, tmuxPaneMap, liveSessions, instarSessions);
+        } catch {
+          // A signal threw — cannot reason about it, so KEEP. Never reap on a
+          // failed evaluation.
+          evaln = {
+            pid: proc.pid, signatureId: proc.signatureId, ageMs: proc.elapsedMs,
+            owningSession: null, verdict: 'keep', reason: 'eval-error',
+          };
+        }
+        evaluations.push(evaln);
+
+        if (evaln.verdict !== 'reap-eligible') {
+          this.writeAudit({ ts: this.now(), type: 'kept', pid: proc.pid, signatureId: proc.signatureId, ageMs: proc.elapsedMs, owningSession: evaln.owningSession, reason: evaln.reason, dryRun: !this.killsEnabled });
+          continue;
+        }
+        if (reaped.length >= this.cfg.maxReapsPerPass) continue; // blast-radius cap
+
+        if (!this.killsEnabled) {
+          // Dry-run: classify + audit what we WOULD kill, kill nothing.
+          this.writeAudit({ ts: this.now(), type: 'would-reap', pid: proc.pid, signatureId: proc.signatureId, ageMs: proc.elapsedMs, owningSession: evaln.owningSession, reason: evaln.reason, dryRun: true });
+          continue;
+        }
+        try {
+          this.deps.killProcess(proc.pid);
+          reaped.push(proc.pid);
+          this.writeAudit({ ts: this.now(), type: 'reaped', pid: proc.pid, signatureId: proc.signatureId, ageMs: proc.elapsedMs, owningSession: evaln.owningSession, reason: evaln.reason, dryRun: false });
+          this.emit('reaped', proc);
+        } catch (err) {
+          this.emit('error', err);
+        }
+      }
+      this.lastPassAt = this.now();
+      this.reapedLastPass = reaped.length;
+      this.emit('pass', { evaluations, reaped });
+    } finally {
+      this.running = false;
+    }
+    return { ts: this.now(), evaluations, reaped, dryRun: !this.killsEnabled };
+  }
+
+  private writeAudit(entry: McpReapAuditEntry): void {
+    try { this.deps.audit?.(entry); } catch { /* audit must never break the loop */ }
+  }
+
+  /** Observability snapshot for GET /processes/mcp-reaper (no side effects). */
+  snapshot(): {
+    enabled: boolean; dryRun: boolean; minAgeMs: number;
+    lastPassAt: number; reapedLastPass: number;
+    processes: McpEvaluation[];
+    reapEligible: number;
+  } {
+    let processes: McpEvaluation[] = [];
+    try {
+      const procs = this.deps.listMcpProcesses();
+      const tree = this.deps.getProcessTree();
+      const tmuxPaneMap = this.deps.getTmuxPaneMap();
+      const liveSessions = this.deps.getLiveSessions();
+      const instarSessions = this.deps.getInstarSessions();
+      processes = procs.map((proc) => {
+        try { return this.evaluate(proc, tree, tmuxPaneMap, liveSessions, instarSessions); }
+        catch {
+          return { pid: proc.pid, signatureId: proc.signatureId, ageMs: proc.elapsedMs, owningSession: null, verdict: 'keep' as McpVerdict, reason: 'eval-error' };
+        }
+      });
+    } catch { /* listing failed — report empty, never crash the route */ }
+    return {
+      enabled: this.cfg.enabled,
+      dryRun: this.cfg.dryRun,
+      minAgeMs: this.cfg.minAgeMs,
+      lastPassAt: this.lastPassAt,
+      reapedLastPass: this.reapedLastPass,
+      processes,
+      reapEligible: processes.filter((p) => p.verdict === 'reap-eligible').length,
+    };
+  }
+}
+
+/** Re-export for production wiring that builds McpProcessInfo from a ps line. */
+export { matchMcpSignature };

--- a/src/monitoring/mcpProcessReaperDeps.ts
+++ b/src/monitoring/mcpProcessReaperDeps.ts
@@ -1,0 +1,142 @@
+/**
+ * mcpProcessReaperDeps — production signal sources for {@link McpProcessReaper}.
+ *
+ * Kept out of the reaper class so the classifier stays unit-testable without a
+ * real process table, tmux, or kill(2). This factory supplies the ps/tmux/
+ * SessionManager/kill/audit implementations.
+ */
+
+import { execSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+import {
+  mcpGrepAlternation,
+  matchMcpSignature,
+} from './mcpProcessSignatures.js';
+import type {
+  McpProcessReaperDeps,
+  McpProcessInfo,
+  McpReapAuditEntry,
+} from './McpProcessReaper.js';
+
+function shellExec(cmd: string, timeout = 8000): string {
+  try {
+    return execSync(cmd, { encoding: 'utf8', timeout, stdio: ['ignore', 'pipe', 'ignore'] });
+  } catch {
+    return '';
+  }
+}
+
+/** Parse an `etime` field (`[[dd-]hh:]mm:ss`) into milliseconds. */
+function parseElapsedMs(etime: string): number {
+  const s = etime.trim();
+  let days = 0;
+  let rest = s;
+  if (rest.includes('-')) {
+    const [d, r] = rest.split('-');
+    days = parseInt(d, 10) || 0;
+    rest = r;
+  }
+  const parts = rest.split(':').map((p) => parseInt(p, 10) || 0);
+  let h = 0, m = 0, sec = 0;
+  if (parts.length === 3) [h, m, sec] = parts;
+  else if (parts.length === 2) [m, sec] = parts;
+  else if (parts.length === 1) [sec] = parts;
+  return (((days * 24 + h) * 60 + m) * 60 + sec) * 1000;
+}
+
+interface SessionLister {
+  listRunningSessions: () => Array<{ tmuxSession: string }>;
+  listKnownTmuxSessions: () => Set<string>;
+}
+
+export function makeMcpProcessReaperDeps(opts: {
+  sessionManager: SessionLister;
+  tmuxPath: string;
+  auditPath: string;
+  now?: () => number;
+}): McpProcessReaperDeps {
+  const { sessionManager, tmuxPath, auditPath } = opts;
+
+  return {
+    listMcpProcesses(): McpProcessInfo[] {
+      const uid = process.getuid?.() ?? 0;
+      const out = shellExec(
+        `ps -u ${uid} -o pid=,ppid=,etime=,command= 2>/dev/null | egrep -i '${mcpGrepAlternation()}' | grep -v egrep`,
+      ).trim();
+      if (!out) return [];
+      const procs: McpProcessInfo[] = [];
+      for (const line of out.split('\n')) {
+        const m = line.trim().match(/^(\d+)\s+(\d+)\s+([\d:.-]+)\s+(.+)$/);
+        if (!m) continue;
+        const command = m[4];
+        const sig = matchMcpSignature(command);
+        if (!sig) continue; // second-stage precise match — never a broad node/npm hit
+        procs.push({
+          pid: parseInt(m[1], 10),
+          ppid: parseInt(m[2], 10),
+          elapsedMs: parseElapsedMs(m[3]),
+          command: command.slice(0, 300),
+          signatureId: sig.id,
+        });
+      }
+      return procs;
+    },
+
+    getProcessTree(): Map<number, number> {
+      const tree = new Map<number, number>();
+      const out = shellExec(`ps -axo pid=,ppid= 2>/dev/null`).trim();
+      if (!out) return tree;
+      for (const line of out.split('\n')) {
+        const m = line.trim().match(/^(\d+)\s+(\d+)$/);
+        if (m) tree.set(parseInt(m[1], 10), parseInt(m[2], 10));
+      }
+      return tree;
+    },
+
+    getTmuxPaneMap(): Map<number, string> {
+      const map = new Map<number, string>();
+      const out = shellExec(`${tmuxPath} list-panes -a -F "#{session_name}||#{pane_pid}" 2>/dev/null`).trim();
+      if (!out) return map;
+      for (const line of out.split('\n')) {
+        const [session, pidStr] = line.split('||');
+        const pid = parseInt(pidStr, 10);
+        if (session && !isNaN(pid)) map.set(pid, session);
+      }
+      return map;
+    },
+
+    getLiveSessions(): Set<string> {
+      try {
+        return new Set(sessionManager.listRunningSessions().map((s) => s.tmuxSession).filter(Boolean));
+      } catch {
+        return new Set();
+      }
+    },
+
+    getInstarSessions(): Set<string> {
+      try {
+        return sessionManager.listKnownTmuxSessions();
+      } catch {
+        return new Set();
+      }
+    },
+
+    killProcess(pid: number): void {
+      // SIGTERM (graceful). The proc's session is already dead/stale, so there is
+      // nothing to coordinate with — a clean terminate is sufficient.
+      process.kill(pid, 'SIGTERM');
+    },
+
+    audit(entry: McpReapAuditEntry): void {
+      try {
+        fs.mkdirSync(path.dirname(auditPath), { recursive: true });
+        fs.appendFileSync(auditPath, JSON.stringify(entry) + '\n');
+      } catch {
+        // Audit must never break the reap loop.
+      }
+    },
+
+    now: opts.now,
+  };
+}

--- a/src/monitoring/mcpProcessSignatures.ts
+++ b/src/monitoring/mcpProcessSignatures.ts
@@ -1,0 +1,74 @@
+/**
+ * mcpProcessSignatures — the precise, allow-listed signatures for MCP-server
+ * processes that the {@link McpProcessReaper} is permitted to consider.
+ *
+ * These are NOT framework (claude/codex/gemini) processes — they are the
+ * long-lived MCP-server children a session spawns (Playwright, mcp-remote,
+ * instar's own stdio MCP) that survive their owning session's death and
+ * accumulate for days (see `.instar/apprenticeship/codey-task-mcp-leak-reaper.md`).
+ *
+ * The reaper matches ONLY these exact signatures — never a broad `node`/`npm`
+ * match — so an unrelated node process can never be a reap candidate. Each
+ * `psGrepNeedle` is bracket-escaped so the discovery `ps … | egrep` does not
+ * match its own argv.
+ */
+
+export interface McpProcessSignature {
+  /** Stable id for audit trails + tests. */
+  readonly id: 'playwright-mcp' | 'mcp-remote' | 'instar-mcp-stdio';
+  /** Human-readable label. */
+  readonly label: string;
+  /**
+   * Substrings that must ALL appear in the process command for a match. A
+   * conjunction keeps the match tight (e.g. requires both `mcp-remote` AND
+   * the npm/exec shape rather than any line mentioning "mcp").
+   */
+  readonly commandIncludesAll: ReadonlyArray<string>;
+  /** Bracket-escaped needle for the first-stage `ps … | egrep` discovery. */
+  readonly psGrepNeedle: string;
+}
+
+export const MCP_PROCESS_SIGNATURES: ReadonlyArray<McpProcessSignature> = [
+  {
+    id: 'playwright-mcp',
+    label: 'Playwright MCP server',
+    commandIncludesAll: ['playwright', 'mcp'],
+    psGrepNeedle: '[p]laywright.*mcp|[m]cp.*playwright',
+  },
+  {
+    id: 'mcp-remote',
+    label: 'mcp-remote bridge (e.g. Fathom)',
+    commandIncludesAll: ['mcp-remote'],
+    psGrepNeedle: '[m]cp-remote',
+  },
+  {
+    id: 'instar-mcp-stdio',
+    label: 'instar stdio MCP server',
+    commandIncludesAll: ['mcp-stdio-entry'],
+    psGrepNeedle: '[m]cp-stdio-entry',
+  },
+];
+
+/** The alternation passed to the discovery `egrep -i '<needle>'`. */
+export function mcpGrepAlternation(): string {
+  return MCP_PROCESS_SIGNATURES.map((s) => s.psGrepNeedle).join('|');
+}
+
+/**
+ * Match a process command against the allow-list. Returns the matched
+ * signature, or null when the command is not a recognized MCP-server process.
+ * Pure — exported for unit tests of both the match and the non-match side.
+ */
+export function matchMcpSignature(
+  command: string,
+  signatures: ReadonlyArray<McpProcessSignature> = MCP_PROCESS_SIGNATURES,
+): McpProcessSignature | null {
+  if (!command) return null;
+  const lower = command.toLowerCase();
+  for (const sig of signatures) {
+    if (sig.commandIncludesAll.every((needle) => lower.includes(needle.toLowerCase()))) {
+      return sig;
+    }
+  }
+  return null;
+}

--- a/src/server/AgentServer.ts
+++ b/src/server/AgentServer.ts
@@ -390,6 +390,9 @@ export class AgentServer {
     /** AgentWorktreeReaper — reclaims stale CLI worktrees. Powers
      *  GET /worktrees/agent-reaper. */
     agentWorktreeReaper?: import('../monitoring/AgentWorktreeReaper.js').AgentWorktreeReaper;
+    /** McpProcessReaper — reclaims leaked MCP-server children of dead/stale
+     *  sessions. Powers GET /processes/mcp-reaper. */
+    mcpProcessReaper?: import('../monitoring/McpProcessReaper.js').McpProcessReaper;
     /** SleepController — agent hard-sleep decision (Stage B). Powers GET /sleep. */
     sleepController?: import('../monitoring/SleepController.js').SleepController;
     /** AgentActivityState — shared idle signal bumped at the inbound chokepoint. */
@@ -1041,6 +1044,7 @@ export class AgentServer {
       geminiCapacityEscalationMonitor: this.geminiCapacityEscalationMonitor,
       sessionReaper: options.sessionReaper ?? null,
       agentWorktreeReaper: options.agentWorktreeReaper ?? null,
+      mcpProcessReaper: options.mcpProcessReaper ?? null,
       sleepController: options.sleepController ?? null,
       agentActivityState: options.agentActivityState ?? null,
       reapLog: options.reapLog ?? null,

--- a/src/server/CapabilityIndex.ts
+++ b/src/server/CapabilityIndex.ts
@@ -917,6 +917,7 @@ export const INTERNAL_PREFIXES: ReadonlyArray<{ prefix: string; reason: string }
   { prefix: 'build', reason: 'operator-only build endpoint' },
   { prefix: 'sessions', reason: 'operator/dashboard-only session listing (no agent-facing API)' },
   { prefix: 'worktrees', reason: 'AgentWorktreeReaper read-only report (reclaimable stale worktrees) — operational observability the agent READS, like /sessions/reap-log; not a user-invokable capability' },
+  { prefix: 'processes', reason: 'McpProcessReaper read-only report (reclaimable leaked MCP-server procs + per-proc keep/reap verdict) — operational observability the agent READS, like /worktrees/agent-reaper; not a user-invokable capability' },
   { prefix: 'sleep', reason: 'SleepController read-only verdict (agent hard-sleep decision + which guard holds it awake) — operational observability the agent READS; not a user-invokable capability' },
   { prefix: 'ci', reason: 'operator-only CI status surface' },
   { prefix: 'session', reason: 'single-session context surfaced via topicMemory endpoints' },

--- a/src/server/routes.ts
+++ b/src/server/routes.ts
@@ -740,6 +740,9 @@ export interface RouteContext {
   /** AgentWorktreeReaper — reclaims stale CLI worktrees. Null when not wired.
    *  Powers GET /worktrees/agent-reaper observability. */
   agentWorktreeReaper?: import('../monitoring/AgentWorktreeReaper.js').AgentWorktreeReaper | null;
+  /** McpProcessReaper — reclaims leaked MCP-server children. Null when not wired.
+   *  Powers GET /processes/mcp-reaper observability. */
+  mcpProcessReaper?: import('../monitoring/McpProcessReaper.js').McpProcessReaper | null;
   /** SleepController — agent hard-sleep decision (Stage B). Powers GET /sleep. */
   sleepController?: import('../monitoring/SleepController.js').SleepController | null;
   /** AgentActivityState — shared idle signal; bumped at the inbound chokepoint. */
@@ -4057,6 +4060,20 @@ export function createRoutes(ctx: RouteContext): Router {
       return;
     }
     res.json(ctx.agentWorktreeReaper.snapshot());
+  });
+
+  // McpProcessReaper (RESPONSIBLE-RESOURCE-USAGE — MCP-leak fix, Option B). The
+  // pull-surface answer to "which leaked MCP-server procs can be reclaimed, and
+  // why is each kept?": every matched MCP proc's verdict (session-live /
+  // external-session / *-too-young / stale-instar-session / orphaned-no-session)
+  // + its owning session + the reap-eligible count + whether reaping is armed
+  // (enabled, dryRun). Read-only, Bearer-auth. 503 when not wired/disabled.
+  router.get('/processes/mcp-reaper', (_req, res) => {
+    if (!ctx.mcpProcessReaper) {
+      res.status(503).json({ error: 'mcp process reaper unavailable' });
+      return;
+    }
+    res.json(ctx.mcpProcessReaper.snapshot());
   });
 
   // SleepController (RESPONSIBLE-RESOURCE-USAGE — agent hard-sleep, Stage B). The

--- a/tests/e2e/mcp-process-reaper-lifecycle.test.ts
+++ b/tests/e2e/mcp-process-reaper-lifecycle.test.ts
@@ -1,0 +1,77 @@
+/**
+ * E2E — McpProcessReaper on the PRODUCTION path.
+ *
+ * Phase 1 (the most important test): GET /processes/mcp-reaper returns 200
+ * (not 503) through the REAL AgentServer → RouteContext plumbing — the
+ * "dead on arrival" / "wired-but-dropped (?? null)" guard.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import request from 'supertest';
+import { AgentServer } from '../../src/server/AgentServer.js';
+import { McpProcessReaper, type McpProcessReaperDeps } from '../../src/monitoring/McpProcessReaper.js';
+import { createMockSessionManager } from '../helpers/setup.js';
+import { StateManager } from '../../src/core/StateManager.js';
+import type { InstarConfig } from '../../src/core/types.js';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+
+describe('McpProcessReaper E2E lifecycle', () => {
+  let tmpDir: string;
+  let stateDir: string;
+  let server: AgentServer;
+  let app: ReturnType<AgentServer['getApp']>;
+  const AUTH_TOKEN = 'test-e2e-mcp-process-reaper';
+
+  const deps: McpProcessReaperDeps = {
+    listMcpProcesses: () => [
+      { pid: 100, ppid: 1, elapsedMs: 5 * 3600 * 1000, command: 'node mcp-remote https://api.fathom.ai/mcp', signatureId: 'mcp-remote' },
+    ],
+    getProcessTree: () => new Map([[100, 1]]),
+    getTmuxPaneMap: () => new Map(),
+    getLiveSessions: () => new Set(),
+    getInstarSessions: () => new Set(),
+    killProcess: () => {},
+    now: () => 1_000_000_000_000,
+  };
+
+  beforeAll(async () => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mcp-reaper-e2e-'));
+    stateDir = path.join(tmpDir, '.instar');
+    fs.mkdirSync(path.join(stateDir, 'state', 'sessions'), { recursive: true });
+    fs.mkdirSync(path.join(stateDir, 'state', 'jobs'), { recursive: true });
+    fs.mkdirSync(path.join(stateDir, 'logs'), { recursive: true });
+    fs.writeFileSync(path.join(stateDir, 'config.json'), JSON.stringify({ port: 0, projectName: 'e2e-test', agentName: 'E2E Test' }));
+
+    const reaper = new McpProcessReaper(deps, { enabled: true, dryRun: true });
+    const config: InstarConfig = {
+      projectName: 'e2e-test', projectDir: tmpDir, stateDir, port: 0, authToken: AUTH_TOKEN,
+      requestTimeoutMs: 10000, version: '0.10.3',
+      sessions: { claudePath: '/usr/bin/echo', maxSessions: 3, defaultMaxDurationMinutes: 30, protectedSessions: [], monitorIntervalMs: 5000 },
+      scheduler: { enabled: false, jobsFile: '', maxParallelJobs: 1 },
+      messaging: [], monitoring: {}, updates: {},
+    };
+    const state = new StateManager(stateDir);
+    server = new AgentServer({ config, sessionManager: createMockSessionManager() as any, state, mcpProcessReaper: reaper });
+    await server.start();
+    app = server.getApp();
+  });
+
+  afterAll(async () => {
+    await server.stop();
+    SafeFsExecutor.safeRmSync(tmpDir, { recursive: true, force: true, operation: 'tests/e2e/mcp-process-reaper-lifecycle.test.ts' });
+  });
+
+  const auth = () => ({ Authorization: `Bearer ${AUTH_TOKEN}` });
+
+  it('GET /processes/mcp-reaper returns 200 with a snapshot through the real AgentServer plumbing', async () => {
+    const res = await request(app).get('/processes/mcp-reaper').set(auth());
+    expect(res.status).toBe(200);
+    expect(res.body.enabled).toBe(true);
+    expect(res.body.dryRun).toBe(true);
+    expect(Array.isArray(res.body.processes)).toBe(true);
+    expect(res.body.reapEligible).toBe(1); // old + orphaned mcp-remote
+  });
+});

--- a/tests/integration/mcp-process-reaper-routes.test.ts
+++ b/tests/integration/mcp-process-reaper-routes.test.ts
@@ -1,0 +1,85 @@
+/**
+ * GET /processes/mcp-reaper through the real createRoutes pipeline.
+ *  - 503 when the reaper is not wired.
+ *  - 200 with the snapshot (per-proc verdicts + reapEligible count) when present.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import express from 'express';
+import request from 'supertest';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { createRoutes, type RouteContext } from '../../src/server/routes.js';
+import {
+  McpProcessReaper,
+  type McpProcessReaperDeps,
+  type McpProcessInfo,
+} from '../../src/monitoring/McpProcessReaper.js';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+
+function ctxWith(stateDir: string, reaper: McpProcessReaper | null): RouteContext {
+  return {
+    config: { projectName: 'test', projectDir: path.dirname(stateDir), stateDir, port: 0, sessions: {} as any, scheduler: {} as any } as any,
+    sessionManager: { listRunningSessions: () => [] } as any,
+    state: { getJobState: () => null, getSession: () => null, listSessions: () => [] } as any,
+    tokenLedger: null,
+    mcpProcessReaper: reaper,
+    startTime: new Date(),
+  } as unknown as RouteContext;
+}
+
+function reaperDeps(procs: McpProcessInfo[]): McpProcessReaperDeps {
+  return {
+    listMcpProcesses: () => procs,
+    getProcessTree: () => new Map(procs.map((p) => [p.pid, p.ppid])),
+    getTmuxPaneMap: () => new Map(), // no tmux ancestor ⇒ orphaned
+    getLiveSessions: () => new Set(),
+    getInstarSessions: () => new Set(),
+    killProcess: () => {},
+    now: () => 1_000_000_000_000,
+  };
+}
+
+describe('GET /processes/mcp-reaper (integration)', () => {
+  let tmpDir: string;
+  let stateDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mcp-reaper-routes-'));
+    stateDir = path.join(tmpDir, '.instar');
+    fs.mkdirSync(stateDir, { recursive: true });
+  });
+  afterEach(() => {
+    SafeFsExecutor.safeRmSync(tmpDir, { recursive: true, force: true, operation: 'tests/integration/mcp-process-reaper-routes.test.ts' });
+  });
+
+  function appWith(reaper: McpProcessReaper | null): express.Express {
+    const app = express();
+    app.use(express.json());
+    app.use('/', createRoutes(ctxWith(stateDir, reaper)));
+    return app;
+  }
+
+  it('returns 503 when the reaper is not wired', async () => {
+    const res = await request(appWith(null)).get('/processes/mcp-reaper');
+    expect(res.status).toBe(503);
+    expect(res.body.error).toMatch(/unavailable/);
+  });
+
+  it('returns 200 with a snapshot when the reaper is present', async () => {
+    const reaper = new McpProcessReaper(
+      reaperDeps([
+        { pid: 100, ppid: 1, elapsedMs: 5 * 3600 * 1000, command: 'node playwright-mcp', signatureId: 'playwright-mcp' },
+      ]),
+      { enabled: true, dryRun: true },
+    );
+    const res = await request(appWith(reaper)).get('/processes/mcp-reaper');
+    expect(res.status).toBe(200);
+    expect(res.body.dryRun).toBe(true);
+    expect(Array.isArray(res.body.processes)).toBe(true);
+    expect(res.body.processes[0].pid).toBe(100);
+    expect(res.body.processes[0].verdict).toBe('reap-eligible'); // old + orphaned
+    expect(res.body.reapEligible).toBe(1);
+  });
+});

--- a/tests/unit/mcp-process-reaper.test.ts
+++ b/tests/unit/mcp-process-reaper.test.ts
@@ -1,0 +1,189 @@
+/**
+ * McpProcessReaper — Option B of the MCP-leak fix. THE safety requirement under
+ * test: NEVER reap an MCP proc whose owning session is live/tracked, and NEVER
+ * touch a proc under an external (non-instar) tmux session. A proc is reap-
+ * eligible ONLY when old AND (its owning instar session is dead/stale OR it is
+ * fully orphaned). Covers both sides of every boundary + dry-run + the cap.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import {
+  McpProcessReaper,
+  resolveOwningSession,
+  classifyMcpProcess,
+  type McpProcessReaperDeps,
+  type McpProcessInfo,
+} from '../../src/monitoring/McpProcessReaper.js';
+import { matchMcpSignature, MCP_PROCESS_SIGNATURES } from '../../src/monitoring/mcpProcessSignatures.js';
+
+const NOW = 1_000_000_000_000;
+const OLD = 3 * 3600 * 1000; // > default minAgeMs (2h)
+const YOUNG = 5 * 60 * 1000; // < minAgeMs
+
+function proc(over: Partial<McpProcessInfo> = {}): McpProcessInfo {
+  return { pid: 100, ppid: 50, elapsedMs: OLD, command: 'node playwright-mcp', signatureId: 'playwright-mcp', ...over };
+}
+
+function deps(over: Partial<McpProcessReaperDeps> = {}): McpProcessReaperDeps {
+  return {
+    listMcpProcesses: () => [],
+    getProcessTree: () => new Map(),
+    getTmuxPaneMap: () => new Map(),
+    getLiveSessions: () => new Set(),
+    getInstarSessions: () => new Set(),
+    killProcess: vi.fn(),
+    now: () => NOW,
+    ...over,
+  };
+}
+
+describe('matchMcpSignature', () => {
+  it('matches each allow-listed signature', () => {
+    expect(matchMcpSignature('npm exec @playwright/mcp@latest')?.id).toBe('playwright-mcp');
+    expect(matchMcpSignature('node mcp-remote https://api.fathom.ai/mcp')?.id).toBe('mcp-remote');
+    expect(matchMcpSignature('node /x/dist/mcp/mcp-stdio-entry.js')?.id).toBe('instar-mcp-stdio');
+  });
+  it('does NOT match an unrelated node/npm process (no broad match)', () => {
+    expect(matchMcpSignature('node /usr/local/bin/instar server start')).toBeNull();
+    expect(matchMcpSignature('npm run build')).toBeNull();
+    expect(matchMcpSignature('node some-app.js')).toBeNull();
+    expect(matchMcpSignature('')).toBeNull();
+  });
+  it('keeps the allow-list to exactly the three known MCP shapes', () => {
+    expect(MCP_PROCESS_SIGNATURES.map((s) => s.id).sort()).toEqual(['instar-mcp-stdio', 'mcp-remote', 'playwright-mcp']);
+  });
+});
+
+describe('resolveOwningSession', () => {
+  it('resolves via the proc pid directly being a pane pid', () => {
+    const tmux = new Map([[100, 'echo-topic-5']]);
+    expect(resolveOwningSession(100, new Map(), tmux, 30)).toBe('echo-topic-5');
+  });
+  it('walks the ppid chain to a tmux pane ancestor', () => {
+    // 100(mcp) -> 50(npm) -> 40(claude) -> 30(shell=pane)
+    const tree = new Map([[100, 50], [50, 40], [40, 30]]);
+    const tmux = new Map([[30, 'echo-topic-9']]);
+    expect(resolveOwningSession(100, tree, tmux, 30)).toBe('echo-topic-9');
+  });
+  it('returns null when no tmux ancestor exists (orphaned/re-parented)', () => {
+    const tree = new Map([[100, 50], [50, 1]]); // re-parented to launchd
+    expect(resolveOwningSession(100, tree, new Map(), 30)).toBeNull();
+  });
+  it('is cycle-safe and bounded by maxHops', () => {
+    const tree = new Map([[100, 50], [50, 100]]); // cycle
+    expect(resolveOwningSession(100, tree, new Map(), 30)).toBeNull();
+    const deep = new Map<number, number>();
+    for (let i = 0; i < 100; i++) deep.set(i, i + 1);
+    expect(resolveOwningSession(0, deep, new Map([[99, 's']]), 5)).toBeNull(); // hop-capped before reaching 99
+  });
+});
+
+describe('classifyMcpProcess (both sides of every boundary)', () => {
+  const live = new Set(['echo-live']);
+  const instar = new Set(['echo-live', 'echo-stale']);
+  const MIN = 2 * 3600 * 1000;
+
+  it('KEEPS a proc under a live/tracked session regardless of age', () => {
+    const e = classifyMcpProcess(proc({ elapsedMs: 10 * 24 * 3600 * 1000 }), 'echo-live', live, instar, MIN);
+    expect(e.verdict).toBe('keep');
+    expect(e.reason).toBe('session-live');
+  });
+  it('KEEPS a proc under an external (non-instar) session even when old', () => {
+    const e = classifyMcpProcess(proc({ elapsedMs: OLD }), 'user-tmux', live, instar, MIN);
+    expect(e.verdict).toBe('keep');
+    expect(e.reason).toBe('external-session');
+  });
+  it('REAPS a proc under a stale/dead instar session when old', () => {
+    const e = classifyMcpProcess(proc({ elapsedMs: OLD }), 'echo-stale', live, instar, MIN);
+    expect(e.verdict).toBe('reap-eligible');
+    expect(e.reason).toContain('stale-instar-session:echo-stale');
+  });
+  it('KEEPS a stale-instar proc that is too young', () => {
+    const e = classifyMcpProcess(proc({ elapsedMs: YOUNG }), 'echo-stale', live, instar, MIN);
+    expect(e.verdict).toBe('keep');
+    expect(e.reason).toBe('stale-instar-too-young');
+  });
+  it('REAPS a fully orphaned proc (no owning session) when old', () => {
+    const e = classifyMcpProcess(proc({ elapsedMs: OLD }), null, live, instar, MIN);
+    expect(e.verdict).toBe('reap-eligible');
+    expect(e.reason).toBe('orphaned-no-session');
+  });
+  it('KEEPS an orphaned proc that is too young', () => {
+    const e = classifyMcpProcess(proc({ elapsedMs: YOUNG }), null, live, instar, MIN);
+    expect(e.verdict).toBe('keep');
+    expect(e.reason).toBe('orphan-too-young');
+  });
+});
+
+describe('McpProcessReaper.reap()', () => {
+  // 100 = orphaned old playwright (reapable); 200 = under live session (sacred)
+  const procs: McpProcessInfo[] = [
+    proc({ pid: 100, ppid: 1, elapsedMs: OLD }),
+    proc({ pid: 200, ppid: 30, elapsedMs: OLD, signatureId: 'mcp-remote' }),
+  ];
+  const tree = new Map([[100, 1], [200, 30]]);
+  const tmux = new Map([[30, 'echo-live']]);
+  const base = () => deps({
+    listMcpProcesses: () => procs,
+    getProcessTree: () => tree,
+    getTmuxPaneMap: () => tmux,
+    getLiveSessions: () => new Set(['echo-live']),
+    getInstarSessions: () => new Set(['echo-live']),
+  });
+
+  it('DRY-RUN (default): classifies, audits would-reap, kills nothing', async () => {
+    const kill = vi.fn();
+    const audit = vi.fn();
+    const r = new McpProcessReaper(base(), { enabled: true, dryRun: true });
+    // override kill+audit
+    (r as any).deps.killProcess = kill;
+    (r as any).deps.audit = audit;
+    const res = await r.reap();
+    expect(kill).not.toHaveBeenCalled();
+    expect(res.reaped).toEqual([]);
+    expect(res.dryRun).toBe(true);
+    expect(audit.mock.calls.some(([e]) => e.type === 'would-reap' && e.pid === 100)).toBe(true);
+  });
+
+  it('ENABLED + not dry-run: reaps the orphaned proc, NEVER the live-session one', async () => {
+    const kill = vi.fn();
+    const d = base();
+    d.killProcess = kill;
+    const r = new McpProcessReaper(d, { enabled: true, dryRun: false });
+    const res = await r.reap();
+    expect(kill).toHaveBeenCalledTimes(1);
+    expect(kill).toHaveBeenCalledWith(100);
+    expect(kill).not.toHaveBeenCalledWith(200); // sacred live session
+    expect(res.reaped).toEqual([100]);
+  });
+
+  it('respects maxReapsPerPass', async () => {
+    const many = Array.from({ length: 5 }, (_, i) => proc({ pid: 1000 + i, ppid: 1, elapsedMs: OLD }));
+    const kill = vi.fn();
+    const d = deps({ listMcpProcesses: () => many, killProcess: kill });
+    const r = new McpProcessReaper(d, { enabled: true, dryRun: false, maxReapsPerPass: 2 });
+    const res = await r.reap();
+    expect(res.reaped.length).toBe(2);
+    expect(kill).toHaveBeenCalledTimes(2);
+  });
+
+  it('DISABLED reaper kills nothing even with reap-eligible procs', async () => {
+    const kill = vi.fn();
+    const d = base();
+    d.killProcess = kill;
+    const r = new McpProcessReaper(d, { enabled: false, dryRun: false });
+    const res = await r.reap();
+    expect(kill).not.toHaveBeenCalled();
+    expect(res.dryRun).toBe(true); // killsEnabled false ⇒ dryRun-reported
+  });
+
+  it('snapshot() reports reapEligible count without side effects', () => {
+    const kill = vi.fn();
+    const d = base();
+    d.killProcess = kill;
+    const r = new McpProcessReaper(d, { enabled: true, dryRun: true });
+    const snap = r.snapshot();
+    expect(snap.reapEligible).toBe(1); // only pid 100
+    expect(kill).not.toHaveBeenCalled();
+  });
+});

--- a/upgrades/next/mcp-process-reaper.md
+++ b/upgrades/next/mcp-process-reaper.md
@@ -1,0 +1,44 @@
+<!-- bump: minor -->
+
+## What Changed
+
+Added the **MCP-Process Reaper** (`McpProcessReaper`) — a new resource-hygiene
+reaper that reclaims leaked MCP-server child processes (Playwright MCP, mcp-remote
+bridges, instar's stdio MCP) whose owning session has died or gone stale. Killing a
+session's main process does not cascade to its MCP-server children, so they
+re-parent and accumulate for days (the fleet had ~80, up to 5 days old, as a
+persistent CPU-load floor). The existing OrphanProcessReaper reaps the session-level
+process but not its MCP descendants — this closes that gap.
+
+It is a separate sibling reaper (the shared session-reap authority path is
+untouched), with a strict safety model: it never reaps a process under a live or
+tracked session, never touches a non-instar (external) session's processes, only
+matches three exact MCP signatures, and requires the process to be old. Ships OFF +
+dry-run; a read-only report is available at GET /processes/mcp-reaper.
+
+## What to Tell Your User
+
+Your machine no longer slowly fills up with leftover helper programs from old agent
+sessions. When a session ends, the little background helpers it started (the browser
+helper, the data-bridge helper) used to keep running for days and quietly eat CPU.
+There is now a cleanup robot that spots those genuinely-abandoned helpers and clears
+them — while never touching anything a live session still needs, and never touching
+your own programs. It starts in a watch-only mode so it shows what it would clean
+before it cleans anything.
+
+## Summary of New Capabilities
+
+- New read-only endpoint GET /processes/mcp-reaper — shows every matched MCP helper,
+  whether it is keep or reap-eligible and why, its owning session, and whether
+  reaping is armed.
+- New config block monitoring.mcpProcessReaper (off + dry-run by default).
+- New audit trail at logs/mcp-reaper-audit.jsonl recording every keep/would-reap/reap
+  decision.
+
+## Evidence
+
+Three test tiers, all green: 18 unit tests covering both sides of every keep/reap
+boundary (including never reaping a live session's 10-day-old helper, dry-run kills
+nothing, and the per-pass blast-radius cap); 2 integration tests on the route
+(503 when unwired, 200 snapshot when wired); 1 e2e test confirming the route is alive
+through the real AgentServer plumbing (200, not 503). Full typecheck clean.

--- a/upgrades/side-effects/mcp-process-reaper.md
+++ b/upgrades/side-effects/mcp-process-reaper.md
@@ -1,0 +1,58 @@
+# Side-Effects Review — MCP-Process Reaper (Option B)
+
+**Version / slug:** `mcp-process-reaper`
+**Date:** `2026-06-04`
+**Author:** `echo`
+**Second-pass reviewer:** `recommended before dryRun:false is set on any agent (it kills processes)`
+
+## Summary of the change
+
+A new `McpProcessReaper` (separate sibling, NOT a change to `OrphanProcessReaper` /
+`ReapGuard` / `ReapAuthority`) reaps leaked MCP-server children (playwright-mcp /
+mcp-remote / instar-mcp-stdio) whose owning tmux session is dead/stale or fully
+orphaned. Ships OFF + dry-run fleet-wide; the `developmentAgent` gate enables it on
+echo but leaves `dryRun:true`, so it only observes + audits would-reap. Read-only
+report at `GET /processes/mcp-reaper`.
+
+## Decision-point inventory
+
+One decision point: the per-proc keep/reap classifier (`classifyMcpProcess`). It is
+pure and unit-tested on both sides of every boundary. The kill action is gated
+behind `killsEnabled = enabled && !dryRun`.
+
+## 1. Over-block (what legitimate things could it wrongly KILL?)
+
+The risk is killing an MCP server that a live session still needs. Mitigations,
+each unit-tested:
+- A proc under a **live/tracked** session is KEPT regardless of age (`session-live`)
+  — a long-running autonomous session keeps its old MCP servers.
+- A proc under an **external (non-instar)** tmux session is KEPT (`external-session`)
+  — the reaper never touches the user's own processes.
+- A proc **younger than `minAgeMs` (2h)** is KEPT — a starting session's children are
+  never candidates.
+- A **failed evaluation** KEEPS (never reap on error).
+- Only **three exact signatures** match — never a broad node/npm match.
+- Ships **dark + dry-run**; even on the dev agent it only observes. Kills require an
+  explicit `dryRun:false`.
+- `maxReapsPerPass` (25) bounds the blast radius per pass.
+
+## 2. Under-block (what leaks does it still MISS?)
+
+- It does not prevent NEW leaks — that is Option A (tree-kill on session teardown),
+  noted as a follow-up. B is the backstop that cleans existing + future unclean deaths.
+- A leaked MCP proc whose dead session's tmux pane somehow still lingers AND is not
+  recognized as an instar session would be treated as external (KEPT). This is the
+  safe failure direction (favor false-negatives).
+- Non-MCP leaked processes are out of scope by design (precise allow-list).
+
+## 3. Reversibility
+
+SIGTERM on an already-orphaned helper is low-risk (its session is gone). The reaper
+itself is fully reversible via config (`enabled:false`). No persistent state is
+mutated except the append-only audit log.
+
+## 4. Blast radius on the existing reaper
+
+**Zero.** This is a separate class; the shared `OrphanProcessReaper` / `ReapGuard` /
+`ReapAuthority` / session-reap authority path is untouched (the same Option-B
+isolation used for #722).


### PR DESCRIPTION
Builds the **MCP-leak reaper (Option B)** from Codey's design brief (`.instar/apprenticeship/codey-task-mcp-leak-reaper.md`) — Justin's #1 host-load concern. Part of the 18h autonomous loose-ends + apprenticeship session.

## Problem
Killing a session's main pid does NOT cascade to its MCP-server children (Playwright, mcp-remote, instar stdio). They re-parent and accumulate for days — the fleet hit ~80, up to 5 days old, as a persistent CPU-load floor. `OrphanProcessReaper` reaps the session-level proc but not its MCP descendants.

## Approach — Option B (sibling sweep)
A separate `McpProcessReaper`, NOT a change to `OrphanProcessReaper` / `ReapGuard` / the shared session-reap authority (zero blast radius — the Option-B discipline used for #722). Option A (tree-kill at teardown) is noted as a source-fix follow-up; B cleans the existing leak + catches future unclean deaths.

## Safety model (the #1 review axis, both-sides unit-tested)
Resolve each MCP proc's owning tmux session by walking the ppid chain to a pane:
- live/tracked session → **KEEP** (sacred, any age)
- external (non-instar) session → **KEEP** (never touch the user's procs)
- stale/dead instar session OR fully orphaned **and** old → **reap**
- too-young, or eval-error → **KEEP**

Only three exact MCP signatures match (never a broad node/npm match). Ships **dark + dry-run**; the `developmentAgent` gate enables it on echo but leaves `dryRun:true` (observe-only). Every decision audited to `logs/mcp-reaper-audit.jsonl`. Read-only `GET /processes/mcp-reaper`.

## Tests — 21 green, 3 tiers
- 18 unit (both sides of every keep/reap boundary, incl. never-reap-live-session-at-10-days, dry-run kills nothing, blast-radius cap)
- 2 integration (route 503 unwired / 200 snapshot)
- 1 e2e (feature alive on real AgentServer boot — 200 not 503)

tsc clean. Tier-2 ship-gate: spec `docs/specs/MCP-PROCESS-REAPER-SPEC.md` (+ ELI16), side-effects inventory, release fragment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)