### PR TITLE
feat(monitoring): wire Gemini multi-turn loop-driver (need-gem-002 increment 2, dark)

### DIFF
--- a/src/commands/server.ts
+++ b/src/commands/server.ts
@@ -16,7 +16,7 @@ import { fileURLToPath } from 'node:url';
 import pc from 'picocolors';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
-import { loadConfig, ensureStateDir, detectTmuxPath } from '../core/Config.js';
+import { loadConfig, ensureStateDir, detectTmuxPath, detectGeminiPath } from '../core/Config.js';
 import { isNonFatalUncaught, shouldLogStackForUncaught } from '../core/uncaughtExceptionPolicy.js';
 import { closeAllSqlite } from '../core/SqliteRegistry.js';
 import { SessionManager } from '../core/SessionManager.js';
@@ -9180,6 +9180,41 @@ export async function startServer(options: StartOptions): Promise<void> {
       ));
     }
 
+    // ── GeminiLoopRunner (need-gem-002) — multi-turn gemini loop-driver ──────────
+    // Lets the gemini mentee sustain a multi-turn task: turn 1 one-shot establishes
+    // a session, later turns re-spawn `gemini -r <handle>` so context restores
+    // natively (no transcript re-send → quota-efficient). Subscription-auth is
+    // structural (the transport strips billing env). Ships DARK
+    // (autonomousSessions.geminiLoopDriver.enabled); the developmentAgent gate turns
+    // it on for dev agents only. Powers POST + GET /gemini-loop/runs.
+    let geminiLoopRunner: import('../monitoring/GeminiLoopRunner.js').GeminiLoopRunner | null = null;
+    {
+      const gcfg = config.autonomousSessions?.geminiLoopDriver;
+      const enabled = gcfg?.enabled ?? !!config.developmentAgent; // dark fleet-wide; live on dev agents
+      if (enabled) {
+        const { GeminiLoopRunner } = await import('../monitoring/GeminiLoopRunner.js');
+        const { createGeminiLoopSpawn, createGeminiHandleCapture, createQuotaBudgetGate } =
+          await import('../monitoring/geminiLoopProduction.js');
+        const geminiPath = detectGeminiPath() ?? 'gemini';
+        const turnTimeoutMs = gcfg?.turnTimeoutMs ?? 180_000;
+        geminiLoopRunner = new GeminiLoopRunner({
+          config: {
+            enabled: true,
+            model: gcfg?.model ?? 'gemini-2.5-flash',
+            maxTurns: gcfg?.maxTurns ?? 12,
+            minTurnIntervalMs: gcfg?.minTurnIntervalMs ?? 2_000,
+            maxConcurrent: gcfg?.maxConcurrent ?? 1,
+            maxRetainedRuns: gcfg?.maxRetainedRuns ?? 50,
+          },
+          spawn: createGeminiLoopSpawn(geminiPath, turnTimeoutMs),
+          captureHandle: createGeminiHandleCapture(geminiPath),
+          budgetGate: createQuotaBudgetGate(quotaTracker ?? null),
+          log: (msg) => console.log(pc.dim(msg)),
+        });
+        console.log(pc.green('  GeminiLoopRunner enabled (multi-turn gemini mentee, subscription auth)'));
+      }
+    }
+
     // ── Agent hard-sleep — SleepController (RESPONSIBLE-RESOURCE-USAGE, Stage B) ──
     // Decides "is it safe for this idle agent to drop to near-zero footprint?" with
     // every safety guard. Ships OFF + dry-run: observes + audits to
@@ -9933,7 +9968,7 @@ export async function startServer(options: StartOptions): Promise<void> {
       console.log(pc.dim(`  [session-pool] rollout gate not wired: ${err instanceof Error ? err.message : String(err)}`));
     }
 
-    const server = new AgentServer({ config, sessionManager, state, scheduler, telegram, relationships, feedback, feedbackAnomalyDetector, dispatches, updateChecker, autoUpdater, autoDispatcher, quotaTracker, quotaManager, publisher, viewer, tunnel, evolution, watchdog, topicMemory, triageNurse, projectMapper, coherenceGate: scopeVerifier, contextHierarchy, canonicalState, operationGate, sentinel, adaptiveTrust, memoryMonitor, orphanReaper, coherenceMonitor, commitmentTracker, semanticMemory, activitySentinel, rateLimitSentinel, releaseReadinessSentinel: releaseReadinessSentinel ?? undefined, messageRouter, summarySentinel, spawnManager, systemReviewer, capabilityMapper, selfKnowledgeTree, coverageAuditor, topicResumeMap: _topicResumeMap ?? undefined, sessionRefresh: _sessionRefresh ?? undefined, autonomyManager, trustElevationTracker, autonomousEvolution, coordinator: coordinator.enabled ? coordinator : undefined, localSigningKeyPem, leaseTransport, onLeasePullRequest: () => leaseCoordinatorRef?.currentLease() ?? null, liveTailReceiver, handoffWireTransport, onHandoffBegin, onHandoffInitiate: handoffInitiate, handoffInProgress: handoffSentinelInProgress, messageLedger, currentInboundByTopic, replyMarkerTransport, onReplyMarker: messageLedger ? (marker: unknown) => { const m = marker as { dedupeKey: string; platform: string; replyIdempotencyKey: string; epoch: number; topic?: string | null }; messageLedger!.applyRemoteReplyMarker(m.dedupeKey, { platform: m.platform, replyIdempotencyKey: m.replyIdempotencyKey, epoch: m.epoch, topic: m.topic ?? null }); } : undefined, whatsapp: whatsappAdapter, slack: slackAdapter, imessage: imessageAdapter, whatsappBusinessBackend, messageBridge, hookEventReceiver, worktreeMonitor, subagentTracker, instructionsVerifier, handshakeManager: threadlineHandshake, threadlineRouter, conversationStore, warrantsReplyGate, collaborationSurfacer, threadResumeMap, topicLinkageHandler: topicLinkageHandler ?? undefined, threadlineRelayClient, threadlineReplyWaiters, listenerManager: listenerManager ?? undefined, responseReviewGate, messagingToneGate, outboundDedupGate, telemetryHeartbeat, pasteManager, featureRegistry, discoveryEvaluator, completionEvaluator, unifiedTrust, liveConfig, sharedStateLedger, ledgerSessionRegistry, worktreeManager, oidcEnrolledRepos: parallelDevConfig?.oidcEnrolledRepos, initiativeTracker, projectRoundRunner, projectDriftChecker, machineHeartbeat, machinePoolRegistry, meshRpcDispatcher, sessionOwnershipRegistry, sessionPoolE2EResultStore, proxyCoordinator, topicIntentStore, topicIntentArcCheck, usherSignalStore, intelligence: sharedIntelligence ?? undefined, telegramBridgeConfig, telegramBridge: telegramBridge ?? undefined, threadlineObservability, briefDeps, workingMemory, taskFlowRegistry, threadlineFlowBridge, sessionReaper, agentWorktreeReaper, mcpProcessReaper, sleepController, agentActivityState, reapLog, sleepWakeDetector, unjustifiedStopGate, stopGateDb, stopNotifier });
+    const server = new AgentServer({ config, sessionManager, state, scheduler, telegram, relationships, feedback, feedbackAnomalyDetector, dispatches, updateChecker, autoUpdater, autoDispatcher, quotaTracker, quotaManager, publisher, viewer, tunnel, evolution, watchdog, topicMemory, triageNurse, projectMapper, coherenceGate: scopeVerifier, contextHierarchy, canonicalState, operationGate, sentinel, adaptiveTrust, memoryMonitor, orphanReaper, coherenceMonitor, commitmentTracker, semanticMemory, activitySentinel, rateLimitSentinel, releaseReadinessSentinel: releaseReadinessSentinel ?? undefined, messageRouter, summarySentinel, spawnManager, systemReviewer, capabilityMapper, selfKnowledgeTree, coverageAuditor, topicResumeMap: _topicResumeMap ?? undefined, sessionRefresh: _sessionRefresh ?? undefined, autonomyManager, trustElevationTracker, autonomousEvolution, coordinator: coordinator.enabled ? coordinator : undefined, localSigningKeyPem, leaseTransport, onLeasePullRequest: () => leaseCoordinatorRef?.currentLease() ?? null, liveTailReceiver, handoffWireTransport, onHandoffBegin, onHandoffInitiate: handoffInitiate, handoffInProgress: handoffSentinelInProgress, messageLedger, currentInboundByTopic, replyMarkerTransport, onReplyMarker: messageLedger ? (marker: unknown) => { const m = marker as { dedupeKey: string; platform: string; replyIdempotencyKey: string; epoch: number; topic?: string | null }; messageLedger!.applyRemoteReplyMarker(m.dedupeKey, { platform: m.platform, replyIdempotencyKey: m.replyIdempotencyKey, epoch: m.epoch, topic: m.topic ?? null }); } : undefined, whatsapp: whatsappAdapter, slack: slackAdapter, imessage: imessageAdapter, whatsappBusinessBackend, messageBridge, hookEventReceiver, worktreeMonitor, subagentTracker, instructionsVerifier, handshakeManager: threadlineHandshake, threadlineRouter, conversationStore, warrantsReplyGate, collaborationSurfacer, threadResumeMap, topicLinkageHandler: topicLinkageHandler ?? undefined, threadlineRelayClient, threadlineReplyWaiters, listenerManager: listenerManager ?? undefined, responseReviewGate, messagingToneGate, outboundDedupGate, telemetryHeartbeat, pasteManager, featureRegistry, discoveryEvaluator, completionEvaluator, unifiedTrust, liveConfig, sharedStateLedger, ledgerSessionRegistry, worktreeManager, oidcEnrolledRepos: parallelDevConfig?.oidcEnrolledRepos, initiativeTracker, projectRoundRunner, projectDriftChecker, machineHeartbeat, machinePoolRegistry, meshRpcDispatcher, sessionOwnershipRegistry, sessionPoolE2EResultStore, proxyCoordinator, topicIntentStore, topicIntentArcCheck, usherSignalStore, intelligence: sharedIntelligence ?? undefined, telegramBridgeConfig, telegramBridge: telegramBridge ?? undefined, threadlineObservability, briefDeps, workingMemory, taskFlowRegistry, threadlineFlowBridge, sessionReaper, agentWorktreeReaper, mcpProcessReaper, geminiLoopRunner, sleepController, agentActivityState, reapLog, sleepWakeDetector, unjustifiedStopGate, stopGateDb, stopNotifier });
     // Boot-recovery (tunnel-failure-resilience spec Part 6): if the agent
     // died mid-relay-episode, the persisted tunnel.json carries
     // rotationPending=true. Rotate the dashboard PIN + authToken BEFORE

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -2275,6 +2275,32 @@ export interface InstarConfig {
     codexLoopDriver?: {
       enabled?: boolean;
     };
+    /**
+     * Gemini multi-turn loop-driver (need-gem-002; docs/specs/gemini-multi-turn-
+     * loop-driver.md). When enabled, the GeminiLoopRunner can drive a gemini
+     * mentee across turns via the native resume path (turn 1 one-shot establishes
+     * a session; later turns re-spawn `gemini -r <handle>` so context restores
+     * natively — no transcript re-send). Subscription auth is structural (reuses
+     * the billing-env-stripping transport). Ships DARK (`enabled: false`); the
+     * developmentAgent gate turns it on for dev agents only. Rollback = set
+     * `enabled: false` (instant). Budget is gated by the shared QuotaTracker
+     * spawn-admission signal; `maxConcurrent: 1` keeps handle capture unambiguous.
+     */
+    geminiLoopDriver?: {
+      enabled?: boolean;
+      /** Model for every turn (explicit -m bypasses the router classifier). */
+      model?: string;
+      /** Hard cap on turns per run (default 12). */
+      maxTurns?: number;
+      /** Min ms between turns, anti-spin (default 2000). */
+      minTurnIntervalMs?: number;
+      /** Max concurrent runs (default 1). */
+      maxConcurrent?: number;
+      /** Bounded in-memory run registry size (default 50). */
+      maxRetainedRuns?: number;
+      /** Per-turn gemini spawn timeout in ms (default 180000). */
+      turnTimeoutMs?: number;
+    };
   };
   /** Notification preferences for autonomy events */
   notifications?: NotificationPreferences;

--- a/src/monitoring/GeminiLoopRunner.ts
+++ b/src/monitoring/GeminiLoopRunner.ts
@@ -1,0 +1,198 @@
+/**
+ * GeminiLoopRunner (need-gem-002, increment 2) — the budget-gated, dark-by-default
+ * service that makes the GeminiLoopDriver invocable.
+ *
+ * A multi-turn gemini loop can run for minutes (several turns × a turn each), so
+ * it CANNOT block an HTTP request. `startRun` admits a run (enabled? under
+ * concurrency cap? budget ok?), kicks off `driver.run()` in the background, and
+ * returns a `runId` immediately; the result lands in a bounded in-memory registry
+ * retrievable via `getRun`. Ships DARK (`enabled: false`); the `developmentAgent`
+ * gate turns it on for dev agents only.
+ *
+ * Subscription auth is structural: the runner's spawn dep is the production
+ * transport spawn (`buildGeminiChildEnv` strips every billing var), so no run can
+ * introduce an API key.
+ *
+ * Spec: docs/specs/gemini-multi-turn-loop-driver.md
+ */
+
+import { randomUUID } from 'node:crypto';
+import {
+  GeminiLoopDriver,
+  type GeminiLoopSpawn,
+  type GeminiLoopHandleCapture,
+  type GeminiLoopBudgetGate,
+  type GeminiLoopResult,
+} from './GeminiLoopDriver.js';
+
+export interface GeminiLoopDriverConfig {
+  enabled: boolean;
+  /** Model passed to every turn (explicit -m bypasses the router classifier). */
+  model: string;
+  /** Hard cap on turns per run. */
+  maxTurns: number;
+  /** Min ms between turns (anti-spin). */
+  minTurnIntervalMs: number;
+  /** Max concurrent runs. 1 keeps shared-cwd handle capture unambiguous. */
+  maxConcurrent: number;
+  /** Bounded registry size — oldest finished runs are evicted past this. */
+  maxRetainedRuns: number;
+  /** Sentinel the mentee emits when done. */
+  doneSentinel?: string;
+}
+
+export type GeminiLoopRunStatus = 'running' | 'done' | 'error';
+
+export interface GeminiLoopRunRecord {
+  runId: string;
+  status: GeminiLoopRunStatus;
+  goalPrompt: string;
+  model: string;
+  maxTurns: number;
+  startedAt: number;
+  finishedAt?: number;
+  result?: GeminiLoopResult;
+  error?: string;
+}
+
+export interface GeminiLoopStartRequest {
+  goalPrompt: string;
+  model?: string;
+  maxTurns?: number;
+}
+
+export type GeminiLoopStartOutcome =
+  | { ok: true; runId: string }
+  | { ok: false; reason: 'disabled' | 'at-capacity' | 'budget' | 'invalid'; detail?: string };
+
+export interface GeminiLoopRunnerDeps {
+  config: GeminiLoopDriverConfig;
+  spawn: GeminiLoopSpawn;
+  captureHandle: GeminiLoopHandleCapture;
+  budgetGate: GeminiLoopBudgetGate;
+  now?: () => number;
+  genId?: () => string;
+  log?: (msg: string) => void;
+}
+
+export class GeminiLoopRunner {
+  private readonly config: GeminiLoopDriverConfig;
+  private readonly spawn: GeminiLoopSpawn;
+  private readonly captureHandle: GeminiLoopHandleCapture;
+  private readonly budgetGate: GeminiLoopBudgetGate;
+  private readonly now: () => number;
+  private readonly genId: () => string;
+  private readonly log: (msg: string) => void;
+
+  private readonly runs = new Map<string, GeminiLoopRunRecord>();
+  private activeCount = 0;
+
+  constructor(deps: GeminiLoopRunnerDeps) {
+    this.config = deps.config;
+    this.spawn = deps.spawn;
+    this.captureHandle = deps.captureHandle;
+    this.budgetGate = deps.budgetGate;
+    this.now = deps.now ?? (() => Date.now());
+    this.genId = deps.genId ?? (() => randomUUID());
+    this.log = deps.log ?? (() => {});
+  }
+
+  isEnabled(): boolean {
+    return this.config.enabled === true;
+  }
+
+  activeRuns(): number {
+    return this.activeCount;
+  }
+
+  /**
+   * Admit + launch a run. Returns immediately with a runId; the loop runs in the
+   * background. Admission order: feature enabled → under concurrency cap → valid
+   * goal → budget gate open.
+   */
+  startRun(req: GeminiLoopStartRequest): GeminiLoopStartOutcome {
+    if (!this.isEnabled()) return { ok: false, reason: 'disabled' };
+    if (this.activeCount >= this.config.maxConcurrent) {
+      return { ok: false, reason: 'at-capacity', detail: `maxConcurrent=${this.config.maxConcurrent}` };
+    }
+    const goalPrompt = (req.goalPrompt ?? '').trim();
+    if (!goalPrompt) return { ok: false, reason: 'invalid', detail: 'goalPrompt is required' };
+
+    const gate = this.budgetGate();
+    if (!gate.ok) return { ok: false, reason: 'budget', detail: gate.reason };
+
+    const runId = this.genId();
+    const model = (req.model ?? this.config.model) || this.config.model;
+    const maxTurns = Number.isInteger(req.maxTurns) && (req.maxTurns as number) > 0
+      ? Math.min(req.maxTurns as number, this.config.maxTurns)
+      : this.config.maxTurns;
+
+    const record: GeminiLoopRunRecord = {
+      runId,
+      status: 'running',
+      goalPrompt,
+      model,
+      maxTurns,
+      startedAt: this.now(),
+    };
+    this.runs.set(runId, record);
+    this.evictOldFinished();
+    this.activeCount += 1;
+    this.log(`[gemini-loop] run ${runId} started (model=${model}, maxTurns=${maxTurns})`);
+
+    // Fire-and-forget — do NOT await; the HTTP caller already has the runId.
+    void this.execute(record);
+
+    return { ok: true, runId };
+  }
+
+  getRun(runId: string): GeminiLoopRunRecord | null {
+    return this.runs.get(runId) ?? null;
+  }
+
+  listRuns(): GeminiLoopRunRecord[] {
+    return [...this.runs.values()].sort((a, b) => b.startedAt - a.startedAt);
+  }
+
+  private async execute(record: GeminiLoopRunRecord): Promise<void> {
+    const driver = new GeminiLoopDriver({
+      spawn: this.spawn,
+      captureHandle: this.captureHandle,
+      budgetGate: this.budgetGate,
+    });
+    try {
+      const result = await driver.run({
+        model: record.model,
+        goalPrompt: record.goalPrompt,
+        maxTurns: record.maxTurns,
+        minTurnIntervalMs: this.config.minTurnIntervalMs,
+        doneSentinel: this.config.doneSentinel,
+      });
+      record.status = 'done';
+      record.result = result;
+      record.finishedAt = this.now();
+      this.log(`[gemini-loop] run ${record.runId} done (${result.stopReason}, ${result.turns.length} turns)`);
+    } catch (err) {
+      record.status = 'error';
+      record.error = err instanceof Error ? err.message : String(err);
+      record.finishedAt = this.now();
+      this.log(`[gemini-loop] run ${record.runId} error: ${record.error}`);
+    } finally {
+      this.activeCount = Math.max(0, this.activeCount - 1);
+    }
+  }
+
+  /** Keep the registry bounded — drop the oldest FINISHED runs past the cap. */
+  private evictOldFinished(): void {
+    if (this.runs.size <= this.config.maxRetainedRuns) return;
+    const finished = [...this.runs.values()]
+      .filter((r) => r.status !== 'running')
+      .sort((a, b) => (a.finishedAt ?? a.startedAt) - (b.finishedAt ?? b.startedAt));
+    let over = this.runs.size - this.config.maxRetainedRuns;
+    for (const r of finished) {
+      if (over <= 0) break;
+      this.runs.delete(r.runId);
+      over -= 1;
+    }
+  }
+}

--- a/src/monitoring/geminiLoopProduction.ts
+++ b/src/monitoring/geminiLoopProduction.ts
@@ -109,6 +109,10 @@ export function createGeminiHandleCapture(
       if (r.exitCode !== 0) return null;
       return parseLatestGeminiSessionHandle(r.stdout);
     } catch {
+      // @silent-fallback-ok — intentional fail-closed: if `--list-sessions` errors
+      // we return null, and the GeminiLoopDriver ABORTS the run (stopReason
+      // 'handle-capture-failure') rather than guessing a handle. Not a degraded
+      // silent continue — it is the safe stop, surfaced in the run's stopReason.
       return null;
     }
   };

--- a/src/monitoring/geminiLoopProduction.ts
+++ b/src/monitoring/geminiLoopProduction.ts
@@ -1,0 +1,136 @@
+/**
+ * Production wiring for the GeminiLoopDriver (need-gem-002, increment 2).
+ *
+ * Turns the injected-dependency engine (`GeminiLoopDriver`) into real
+ * subscription-auth gemini spawns:
+ *   - `createGeminiLoopSpawn`     — routes every turn through the gemini transport
+ *                                   (`spawnGeminiAndWait` + `buildGeminiChildEnv`,
+ *                                   which strips every billing env var → subscription
+ *                                   OAuth is the only possible auth path).
+ *   - `parseLatestGeminiSessionHandle` — pure parser of `gemini --list-sessions`
+ *                                   output → the FRESHEST session's UUID (the one
+ *                                   turn 1 just created). Min-age, not list order.
+ *   - `createGeminiHandleCapture` — runs `--list-sessions` via the transport and
+ *                                   parses it; returns null if no handle resolves
+ *                                   (the engine then ABORTS rather than guessing).
+ *   - `createQuotaBudgetGate`     — wraps the existing QuotaTracker so a loop refuses
+ *                                   to start / continue under load or spend pressure.
+ *
+ * Spec: docs/specs/gemini-multi-turn-loop-driver.md
+ */
+
+import {
+  buildGeminiChildEnv,
+  spawnGeminiAndWait,
+} from '../providers/adapters/gemini-cli/transport/geminiSpawn.js';
+import type {
+  GeminiLoopSpawn,
+  GeminiLoopHandleCapture,
+  GeminiLoopBudgetGate,
+} from './GeminiLoopDriver.js';
+
+/** Default per-turn spawn timeout (a single gemini turn). */
+export const DEFAULT_GEMINI_TURN_TIMEOUT_MS = 180_000;
+
+/**
+ * Parse `gemini --list-sessions` stdout and return the FRESHEST session's UUID.
+ *
+ * Each session row looks like:
+ *   `  3. Remember the codeword... (Just now) [ef951c6e-49b4-49df-a8f0-b8aa62b4403f]`
+ * The age is the parenthesised group immediately before the `[uuid]` bracket
+ * (anchored there so parentheses inside the title don't interfere). We pick the
+ * MINIMUM age rather than trusting list order, so the handle is the session turn 1
+ * just created. Returns null when no row parses.
+ */
+export function parseLatestGeminiSessionHandle(stdout: string): string | null {
+  const rowRe = /\(([^()]+)\)\s*\[([0-9a-fA-F-]{36})\]/g;
+  let best: { uuid: string; ageSec: number } | null = null;
+  let m: RegExpExecArray | null;
+  while ((m = rowRe.exec(stdout)) !== null) {
+    const ageSec = parseRelativeAgeSeconds(m[1]);
+    const uuid = m[2].toLowerCase();
+    if (!best || ageSec < best.ageSec) {
+      best = { uuid, ageSec };
+    }
+  }
+  return best ? best.uuid : null;
+}
+
+/** Parse a gemini relative-age string ("Just now", "16 minutes ago") to seconds. */
+function parseRelativeAgeSeconds(raw: string): number {
+  const s = raw.trim().toLowerCase();
+  if (/just now/.test(s)) return 0;
+  const num = s.match(/(\d+)/);
+  const n = num ? parseInt(num[1], 10) : NaN;
+  if (!Number.isFinite(n)) return Number.POSITIVE_INFINITY;
+  if (/second/.test(s)) return n;
+  if (/minute/.test(s)) return n * 60;
+  if (/hour/.test(s)) return n * 3_600;
+  if (/day/.test(s)) return n * 86_400;
+  if (/week/.test(s)) return n * 604_800;
+  if (/month/.test(s)) return n * 2_592_000;
+  return Number.POSITIVE_INFINITY;
+}
+
+/**
+ * Production gemini spawn — every turn routes through the subscription-auth
+ * transport. `buildGeminiChildEnv()` strips all billing env vars, so no argv this
+ * receives can introduce an API key.
+ */
+export function createGeminiLoopSpawn(
+  geminiPath: string,
+  turnTimeoutMs: number = DEFAULT_GEMINI_TURN_TIMEOUT_MS,
+): GeminiLoopSpawn {
+  return async (argv) => {
+    const r = await spawnGeminiAndWait(geminiPath, argv, {
+      timeoutMs: turnTimeoutMs,
+      env: buildGeminiChildEnv(),
+    });
+    return { exitCode: r.exitCode, stdout: r.stdout, stderr: r.stderr, truncated: r.truncated };
+  };
+}
+
+/**
+ * Production handle capture — after turn 1, list sessions and pick the freshest.
+ * Single-concurrency (`maxConcurrent: 1`) keeps this unambiguous: turn 1 just ran,
+ * so its session is the "Just now" / min-age row even if other gemini one-shots
+ * (e.g. cross-model review) created older sessions in the shared cwd.
+ */
+export function createGeminiHandleCapture(
+  geminiPath: string,
+  listTimeoutMs: number = 30_000,
+): GeminiLoopHandleCapture {
+  return async () => {
+    try {
+      const r = await spawnGeminiAndWait(geminiPath, ['--list-sessions'], {
+        timeoutMs: listTimeoutMs,
+        env: buildGeminiChildEnv(),
+      });
+      if (r.exitCode !== 0) return null;
+      return parseLatestGeminiSessionHandle(r.stdout);
+    } catch {
+      return null;
+    }
+  };
+}
+
+/** Minimal slice of QuotaTracker the budget gate needs. */
+export interface SpawnAdmissionSource {
+  shouldSpawnSession(): { allowed: boolean; reason: string };
+}
+
+/**
+ * Production budget gate — reuses the existing QuotaTracker spawn-admission
+ * decision (the same daily-spend / load-shedding signal every other instar spawn
+ * respects). Fails OPEN if no tracker is wired (the engine's own maxTurns +
+ * spawn-failure handling still bound the loop).
+ */
+export function createQuotaBudgetGate(
+  quota: SpawnAdmissionSource | null | undefined,
+): GeminiLoopBudgetGate {
+  return () => {
+    if (!quota) return { ok: true };
+    const v = quota.shouldSpawnSession();
+    return { ok: v.allowed, reason: v.allowed ? undefined : v.reason };
+  };
+}

--- a/src/server/AgentServer.ts
+++ b/src/server/AgentServer.ts
@@ -395,6 +395,9 @@ export class AgentServer {
     /** McpProcessReaper — reclaims leaked MCP-server children of dead/stale
      *  sessions. Powers GET /processes/mcp-reaper. */
     mcpProcessReaper?: import('../monitoring/McpProcessReaper.js').McpProcessReaper;
+    /** GeminiLoopRunner — multi-turn gemini loop-driver (need-gem-002). Powers
+     *  POST + GET /gemini-loop/runs. */
+    geminiLoopRunner?: import('../monitoring/GeminiLoopRunner.js').GeminiLoopRunner | null;
     /** SleepController — agent hard-sleep decision (Stage B). Powers GET /sleep. */
     sleepController?: import('../monitoring/SleepController.js').SleepController;
     /** AgentActivityState — shared idle signal bumped at the inbound chokepoint. */
@@ -1087,6 +1090,7 @@ export class AgentServer {
       sessionReaper: options.sessionReaper ?? null,
       agentWorktreeReaper: options.agentWorktreeReaper ?? null,
       mcpProcessReaper: options.mcpProcessReaper ?? null,
+      geminiLoopRunner: options.geminiLoopRunner ?? null,
       sleepController: options.sleepController ?? null,
       agentActivityState: options.agentActivityState ?? null,
       reapLog: options.reapLog ?? null,

--- a/src/server/CapabilityIndex.ts
+++ b/src/server/CapabilityIndex.ts
@@ -922,6 +922,7 @@ export const INTERNAL_PREFIXES: ReadonlyArray<{ prefix: string; reason: string }
   { prefix: 'worktrees', reason: 'AgentWorktreeReaper read-only report (reclaimable stale worktrees) — operational observability the agent READS, like /sessions/reap-log; not a user-invokable capability' },
   { prefix: 'processes', reason: 'McpProcessReaper read-only report (reclaimable leaked MCP-server procs + per-proc keep/reap verdict) — operational observability the agent READS, like /worktrees/agent-reaper; not a user-invokable capability' },
   { prefix: 'sleep', reason: 'SleepController read-only verdict (agent hard-sleep decision + which guard holds it awake) — operational observability the agent READS; not a user-invokable capability' },
+  { prefix: 'gemini-loop', reason: 'GeminiLoopRunner (need-gem-002) multi-turn loop-driver — the dark, developmentAgent-gated mechanism the apprenticeship machinery uses to drive a Gemini mentee across turns. 503 on the fleet (dark); not a general user-invokable capability yet. Reclassify under apprenticeshipProgram if/when it graduates live.' },
   { prefix: 'ci', reason: 'operator-only CI status surface' },
   { prefix: 'session', reason: 'single-session context surfaced via topicMemory endpoints' },
   { prefix: 'identity', reason: 'identity files surfaced via the top-level `identity` field of the response' },

--- a/src/server/routes.ts
+++ b/src/server/routes.ts
@@ -747,6 +747,9 @@ export interface RouteContext {
   /** McpProcessReaper — reclaims leaked MCP-server children. Null when not wired.
    *  Powers GET /processes/mcp-reaper observability. */
   mcpProcessReaper?: import('../monitoring/McpProcessReaper.js').McpProcessReaper | null;
+  /** GeminiLoopRunner — multi-turn gemini loop-driver (need-gem-002). Null when not
+   *  wired / dark. Powers POST + GET /gemini-loop/runs. */
+  geminiLoopRunner?: import('../monitoring/GeminiLoopRunner.js').GeminiLoopRunner | null;
   /** SleepController — agent hard-sleep decision (Stage B). Powers GET /sleep. */
   sleepController?: import('../monitoring/SleepController.js').SleepController | null;
   /** AgentActivityState — shared idle signal; bumped at the inbound chokepoint. */
@@ -4078,6 +4081,54 @@ export function createRoutes(ctx: RouteContext): Router {
       return;
     }
     res.json(ctx.mcpProcessReaper.snapshot());
+  });
+
+  // GeminiLoopRunner (need-gem-002) — the multi-turn gemini loop-driver. Lets a
+  // caller hand the gemini mentee a goal it works across turns (turn 1 one-shot →
+  // resume by handle, no transcript re-send). A run can take minutes, so POST
+  // ADMITS + launches async and returns a runId immediately; GET polls the result.
+  // Subscription-auth only (the transport strips billing env). Ships DARK
+  // (autonomousSessions.geminiLoopDriver.enabled; developmentAgent gate turns it on
+  // for dev agents). 503 when not wired; 409 when disabled / at capacity / budget.
+  router.post('/gemini-loop/runs', (req, res) => {
+    if (!ctx.geminiLoopRunner) {
+      res.status(503).json({ error: 'gemini loop runner unavailable' });
+      return;
+    }
+    const { goalPrompt, model, maxTurns } = req.body ?? {};
+    if (!goalPrompt || typeof goalPrompt !== 'string') {
+      res.status(400).json({ error: 'goalPrompt (string) is required' });
+      return;
+    }
+    const outcome = ctx.geminiLoopRunner.startRun({ goalPrompt, model, maxTurns });
+    if (!outcome.ok) {
+      // disabled / at-capacity / budget / invalid → 409 (cannot admit right now)
+      const code = outcome.reason === 'invalid' ? 400 : 409;
+      res.status(code).json({ error: outcome.reason, detail: outcome.detail });
+      return;
+    }
+    res.status(202).json({ runId: outcome.runId, status: 'running' });
+  });
+
+  router.get('/gemini-loop/runs', (_req, res) => {
+    if (!ctx.geminiLoopRunner) {
+      res.status(503).json({ error: 'gemini loop runner unavailable' });
+      return;
+    }
+    res.json({ runs: ctx.geminiLoopRunner.listRuns(), active: ctx.geminiLoopRunner.activeRuns() });
+  });
+
+  router.get('/gemini-loop/runs/:id', (req, res) => {
+    if (!ctx.geminiLoopRunner) {
+      res.status(503).json({ error: 'gemini loop runner unavailable' });
+      return;
+    }
+    const run = ctx.geminiLoopRunner.getRun(req.params.id);
+    if (!run) {
+      res.status(404).json({ error: 'run not found' });
+      return;
+    }
+    res.json(run);
   });
 
   // SleepController (RESPONSIBLE-RESOURCE-USAGE — agent hard-sleep, Stage B). The

--- a/tests/e2e/gemini-loop-driver-lifecycle.test.ts
+++ b/tests/e2e/gemini-loop-driver-lifecycle.test.ts
@@ -1,0 +1,97 @@
+// safe-git-allow: test file — no git calls.
+// safe-fs-allow: test file — reads source only.
+
+/**
+ * E2E lifecycle test — GeminiLoopRunner production wiring (need-gem-002, increment 2).
+ *
+ * Two "feature is alive" gates (Testing Integrity Standard Tier 3):
+ *
+ *  1. ALIVE: assemble the components server.ts wires (the production deps via
+ *     geminiLoopProduction + the GeminiLoopRunner + createRoutes) and prove the
+ *     route ADMITS a run end-to-end (202) — i.e. the feature returns 202, not 503.
+ *     A stub spawn keeps it gemini-free; the real production factories
+ *     (createGeminiLoopSpawn / createGeminiHandleCapture / createQuotaBudgetGate)
+ *     are exercised for shape so the wiring is genuinely the production path.
+ *
+ *  2. WIRED source check: server.ts must ACTUALLY construct + thread the runner
+ *     (not ship it as an orphan class while release notes claim it's wired — the
+ *     PR #334 sin). Greps server.ts for `new GeminiLoopRunner(` + the ctx field,
+ *     and routes.ts for the route.
+ *
+ * Spec: docs/specs/gemini-multi-turn-loop-driver.md
+ */
+
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import express from 'express';
+import request from 'supertest';
+import { createRoutes, type RouteContext } from '../../src/server/routes.js';
+import { GeminiLoopRunner } from '../../src/monitoring/GeminiLoopRunner.js';
+import {
+  createGeminiLoopSpawn,
+  createGeminiHandleCapture,
+  createQuotaBudgetGate,
+} from '../../src/monitoring/geminiLoopProduction.js';
+import { DEFAULT_DONE_SENTINEL } from '../../src/monitoring/GeminiLoopDriver.js';
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const SRC = path.resolve(HERE, '../../src');
+
+describe('GeminiLoopRunner — E2E lifecycle (feature is alive)', () => {
+  it('Gate 1: the production-wired route ADMITS a run (202, not 503)', async () => {
+    // Exercise the real production factories for shape (no gemini call yet)...
+    expect(typeof createGeminiLoopSpawn('gemini', 1000)).toBe('function');
+    expect(typeof createGeminiHandleCapture('gemini')).toBe('function');
+    const budgetGate = createQuotaBudgetGate(null); // fail-open with no tracker
+    expect(budgetGate()).toEqual({ ok: true });
+
+    // ...then build the runner the way server.ts does, but with a gemini-free
+    // stub spawn so the async loop completes without touching the network.
+    const runner = new GeminiLoopRunner({
+      config: {
+        enabled: true,
+        model: 'gemini-2.5-flash',
+        maxTurns: 4,
+        minTurnIntervalMs: 0,
+        maxConcurrent: 1,
+        maxRetainedRuns: 50,
+      },
+      spawn: async () => ({ exitCode: 0, stdout: `ok\n${DEFAULT_DONE_SENTINEL}`, stderr: '', truncated: false }),
+      captureHandle: async () => 'handle-uuid',
+      budgetGate,
+    });
+
+    const ctx = {
+      config: { projectName: 't', projectDir: '/tmp', stateDir: '/tmp/.instar', port: 0, sessions: {} as any, scheduler: {} as any } as any,
+      sessionManager: { listRunningSessions: () => [] } as any,
+      state: { getJobState: () => null, getSession: () => null, listSessions: () => [] } as any,
+      geminiLoopRunner: runner,
+      startTime: new Date(),
+    } as unknown as RouteContext;
+
+    const app = express();
+    app.use(express.json());
+    app.use('/', createRoutes(ctx));
+
+    const res = await request(app).post('/gemini-loop/runs').send({ goalPrompt: 'prove the loop is alive' });
+    expect(res.status).toBe(202); // alive — not 503
+    expect(res.body.runId).toBeTruthy();
+  });
+
+  it('Gate 2: server.ts constructs + threads the runner (not an orphan class)', () => {
+    const serverSrc = fs.readFileSync(path.join(SRC, 'commands', 'server.ts'), 'utf8');
+    // actually instantiated in the boot path...
+    expect(serverSrc).toMatch(/new GeminiLoopRunner\(/);
+    // ...gated dark with the developmentAgent gate...
+    expect(serverSrc).toMatch(/geminiLoopDriver/);
+    expect(serverSrc).toMatch(/developmentAgent/);
+    // ...and threaded into the route context.
+    expect(serverSrc).toMatch(/geminiLoopRunner,/);
+
+    const routesSrc = fs.readFileSync(path.join(SRC, 'server', 'routes.ts'), 'utf8');
+    expect(routesSrc).toMatch(/\/gemini-loop\/runs/);
+    expect(routesSrc).toMatch(/ctx\.geminiLoopRunner/);
+  });
+});

--- a/tests/integration/gemini-loop-routes.test.ts
+++ b/tests/integration/gemini-loop-routes.test.ts
@@ -1,0 +1,97 @@
+/**
+ * POST + GET /gemini-loop/runs through the real createRoutes pipeline (need-gem-002).
+ *  - 503 when the runner is not wired.
+ *  - 409 'disabled' when the runner is wired but the feature flag is off.
+ *  - 400 when goalPrompt is missing.
+ *  - 202 {runId} on admission; GET /:id reflects the async result; GET lists runs.
+ */
+
+import { describe, it, expect } from 'vitest';
+import express from 'express';
+import request from 'supertest';
+import { createRoutes, type RouteContext } from '../../src/server/routes.js';
+import { GeminiLoopRunner } from '../../src/monitoring/GeminiLoopRunner.js';
+import { DEFAULT_DONE_SENTINEL } from '../../src/monitoring/GeminiLoopDriver.js';
+
+function ctxWith(runner: GeminiLoopRunner | null): RouteContext {
+  return {
+    config: { projectName: 'test', projectDir: '/tmp', stateDir: '/tmp/.instar', port: 0, sessions: {} as any, scheduler: {} as any } as any,
+    sessionManager: { listRunningSessions: () => [] } as any,
+    state: { getJobState: () => null, getSession: () => null, listSessions: () => [] } as any,
+    geminiLoopRunner: runner,
+    startTime: new Date(),
+  } as unknown as RouteContext;
+}
+
+function appWith(runner: GeminiLoopRunner | null): express.Express {
+  const app = express();
+  app.use(express.json());
+  app.use('/', createRoutes(ctxWith(runner)));
+  return app;
+}
+
+function makeRunner(enabled: boolean): GeminiLoopRunner {
+  let n = 0;
+  return new GeminiLoopRunner({
+    config: {
+      enabled,
+      model: 'gemini-2.5-flash',
+      maxTurns: 4,
+      minTurnIntervalMs: 0,
+      maxConcurrent: 1,
+      maxRetainedRuns: 50,
+    },
+    // finishes in one turn via the sentinel — no real gemini
+    spawn: async () => ({ exitCode: 0, stdout: `ok\n${DEFAULT_DONE_SENTINEL}`, stderr: '', truncated: false }),
+    captureHandle: async () => 'handle-uuid',
+    budgetGate: () => ({ ok: true }),
+    genId: () => `run-${++n}`,
+  });
+}
+
+describe('POST/GET /gemini-loop/runs (integration)', () => {
+  it('returns 503 when the runner is not wired', async () => {
+    const res = await request(appWith(null)).post('/gemini-loop/runs').send({ goalPrompt: 'x' });
+    expect(res.status).toBe(503);
+  });
+
+  it('returns 409 disabled when the feature flag is off', async () => {
+    const res = await request(appWith(makeRunner(false))).post('/gemini-loop/runs').send({ goalPrompt: 'x' });
+    expect(res.status).toBe(409);
+    expect(res.body.error).toBe('disabled');
+  });
+
+  it('returns 400 when goalPrompt is missing', async () => {
+    const res = await request(appWith(makeRunner(true))).post('/gemini-loop/runs').send({});
+    expect(res.status).toBe(400);
+  });
+
+  it('admits a run (202 + runId), then the result is retrievable, and listed', async () => {
+    const app = appWith(makeRunner(true));
+    const start = await request(app).post('/gemini-loop/runs').send({ goalPrompt: 'do the thing' });
+    expect(start.status).toBe(202);
+    expect(start.body.runId).toBeTruthy();
+    const runId = start.body.runId;
+
+    // poll the result route until the async loop settles
+    let rec: any;
+    for (let i = 0; i < 20; i++) {
+      const got = await request(app).get(`/gemini-loop/runs/${runId}`);
+      expect(got.status).toBe(200);
+      rec = got.body;
+      if (rec.status !== 'running') break;
+      await new Promise((r) => setTimeout(r, 10));
+    }
+    expect(rec.status).toBe('done');
+    expect(rec.result.stopReason).toBe('done-sentinel');
+
+    const list = await request(app).get('/gemini-loop/runs');
+    expect(list.status).toBe(200);
+    expect(list.body.runs.some((r: any) => r.runId === runId)).toBe(true);
+  });
+
+  it('returns 404 for an unknown runId', async () => {
+    const res = await request(appWith(makeRunner(true))).get('/gemini-loop/runs/nope');
+    expect(res.status).toBe(404);
+  });
+});

--- a/tests/unit/GeminiLoopRunner.test.ts
+++ b/tests/unit/GeminiLoopRunner.test.ts
@@ -1,0 +1,155 @@
+/**
+ * Unit tests for GeminiLoopRunner (need-gem-002, increment 2) — the budget-gated,
+ * dark-by-default async service that makes the GeminiLoopDriver invocable.
+ *
+ * Both sides of admission (disabled / at-capacity / budget / invalid / OK), the
+ * async run lifecycle (running → done, result captured), and registry eviction.
+ * All deps injected → zero real gemini calls.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import {
+  GeminiLoopRunner,
+  type GeminiLoopRunnerDeps,
+  type GeminiLoopDriverConfig,
+} from '../../src/monitoring/GeminiLoopRunner.js';
+import { DEFAULT_DONE_SENTINEL, type GeminiLoopSpawnResult } from '../../src/monitoring/GeminiLoopDriver.js';
+
+function cfg(over: Partial<GeminiLoopDriverConfig> = {}): GeminiLoopDriverConfig {
+  return {
+    enabled: true,
+    model: 'gemini-2.5-flash',
+    maxTurns: 12,
+    minTurnIntervalMs: 0,
+    maxConcurrent: 1,
+    maxRetainedRuns: 50,
+    ...over,
+  };
+}
+
+const ok = (stdout: string): GeminiLoopSpawnResult => ({ exitCode: 0, stdout, stderr: '', truncated: false });
+
+function mkRunner(over: Partial<GeminiLoopRunnerDeps> = {}): GeminiLoopRunner {
+  let id = 0;
+  const deps: GeminiLoopRunnerDeps = {
+    config: cfg(),
+    // turn 1 finishes immediately via the sentinel → one-turn run
+    spawn: async () => ok(`done\n${DEFAULT_DONE_SENTINEL}`),
+    captureHandle: async () => 'handle-uuid',
+    budgetGate: () => ({ ok: true }),
+    genId: () => `run-${++id}`,
+    ...over,
+  };
+  return new GeminiLoopRunner(deps);
+}
+
+async function settle() {
+  // let the fire-and-forget driver promise chain resolve
+  for (let i = 0; i < 5; i++) await Promise.resolve();
+}
+
+describe('GeminiLoopRunner — admission boundaries', () => {
+  it('refuses when disabled', () => {
+    const r = mkRunner({ config: cfg({ enabled: false }) });
+    const out = r.startRun({ goalPrompt: 'do X' });
+    expect(out).toEqual({ ok: false, reason: 'disabled' });
+    expect(r.isEnabled()).toBe(false);
+  });
+
+  it('refuses an empty/whitespace goal as invalid', () => {
+    const r = mkRunner();
+    expect(r.startRun({ goalPrompt: '   ' })).toMatchObject({ ok: false, reason: 'invalid' });
+  });
+
+  it('refuses when the budget gate is closed', () => {
+    const r = mkRunner({ budgetGate: () => ({ ok: false, reason: 'memory pressure' }) });
+    expect(r.startRun({ goalPrompt: 'do X' })).toMatchObject({ ok: false, reason: 'budget', detail: 'memory pressure' });
+  });
+
+  it('refuses a second run past maxConcurrent (and admits again after the first finishes)', async () => {
+    // a spawn that never resolves keeps run 1 active
+    let release!: () => void;
+    const blocker = new Promise<GeminiLoopSpawnResult>((res) => { release = () => res(ok(`x\n${DEFAULT_DONE_SENTINEL}`)); });
+    const r = mkRunner({ config: cfg({ maxConcurrent: 1 }), spawn: () => blocker });
+
+    const a = r.startRun({ goalPrompt: 'task A' });
+    expect(a.ok).toBe(true);
+    expect(r.activeRuns()).toBe(1);
+
+    const b = r.startRun({ goalPrompt: 'task B' });
+    expect(b).toMatchObject({ ok: false, reason: 'at-capacity' });
+
+    release();
+    await settle();
+    expect(r.activeRuns()).toBe(0);
+    // capacity freed → a new run admits
+    expect(r.startRun({ goalPrompt: 'task C' }).ok).toBe(true);
+  });
+});
+
+describe('GeminiLoopRunner — async run lifecycle', () => {
+  it('returns a runId immediately, then records the result when the loop finishes', async () => {
+    const r = mkRunner();
+    const out = r.startRun({ goalPrompt: 'do X' });
+    expect(out).toEqual({ ok: true, runId: 'run-1' });
+
+    // synchronously, the run is still "running"
+    expect(r.getRun('run-1')?.status).toBe('running');
+
+    await settle();
+    const rec = r.getRun('run-1')!;
+    expect(rec.status).toBe('done');
+    expect(rec.result?.stopReason).toBe('done-sentinel');
+    expect(rec.finishedAt).toBeGreaterThanOrEqual(rec.startedAt);
+    expect(r.activeRuns()).toBe(0);
+  });
+
+  it('clamps a requested maxTurns to the config cap', async () => {
+    const calls: string[][] = [];
+    const r = mkRunner({
+      config: cfg({ maxTurns: 3 }),
+      // never emit the sentinel → runs to the cap
+      spawn: async (argv) => { calls.push(argv); return ok('working'); },
+    });
+    r.startRun({ goalPrompt: 'do X', maxTurns: 99 });
+    await settle();
+    // capped at 3, not 99
+    expect(calls.length).toBe(3);
+  });
+
+  it('records an error status if the driver throws', async () => {
+    const r = mkRunner({ spawn: async () => { throw new Error('spawn blew up'); } });
+    r.startRun({ goalPrompt: 'do X' });
+    await settle();
+    const rec = r.getRun('run-1')!;
+    expect(rec.status).toBe('error');
+    expect(rec.error).toContain('spawn blew up');
+    expect(r.activeRuns()).toBe(0);
+  });
+});
+
+describe('GeminiLoopRunner — registry', () => {
+  it('evicts oldest FINISHED runs past maxRetainedRuns', async () => {
+    let n = 0;
+    const r = mkRunner({ config: cfg({ maxRetainedRuns: 2, maxConcurrent: 10 }), genId: () => `r${++n}` });
+    r.startRun({ goalPrompt: 'a' });
+    await settle();
+    r.startRun({ goalPrompt: 'b' });
+    await settle();
+    r.startRun({ goalPrompt: 'c' });
+    await settle();
+    const ids = r.listRuns().map((x) => x.runId);
+    expect(ids.length).toBeLessThanOrEqual(2);
+    expect(ids).toContain('r3'); // newest retained
+    expect(ids).not.toContain('r1'); // oldest evicted
+  });
+
+  it('listRuns returns newest-first', async () => {
+    let n = 0;
+    const r = mkRunner({ config: cfg({ maxConcurrent: 10 }), genId: () => `r${++n}`, now: () => n * 1000 });
+    r.startRun({ goalPrompt: 'a' });
+    r.startRun({ goalPrompt: 'b' });
+    await settle();
+    expect(r.listRuns()[0].goalPrompt).toBe('b');
+  });
+});

--- a/tests/unit/geminiLoopProduction.test.ts
+++ b/tests/unit/geminiLoopProduction.test.ts
@@ -1,0 +1,69 @@
+/**
+ * Unit tests for the GeminiLoopDriver production wiring (need-gem-002, increment 2):
+ *   - parseLatestGeminiSessionHandle: picks the FRESHEST session by min age (not
+ *     list order), tolerates title parentheses, returns null when nothing parses.
+ *   - createQuotaBudgetGate: maps the QuotaTracker spawn-admission signal, fails
+ *     OPEN when no tracker is wired.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  parseLatestGeminiSessionHandle,
+  createQuotaBudgetGate,
+} from '../../src/monitoring/geminiLoopProduction.js';
+
+const REAL_LIST = `Available sessions for this project (3):
+  1. Reply with exactly the word: PONG (1 day ago) [9b06d03d-f990-49c0-9cd5-1df66c06cf16]
+  2. You are a mentee in an AI-agent apprenticeship (16 minutes ago) [761d6464-8228-49a7-b385-f9e2bfa3511f]
+  3. Remember this codeword for later: PELICAN-7 (Just now) [ef951c6e-49b4-49df-a8f0-b8aa62b4403f]`;
+
+describe('parseLatestGeminiSessionHandle', () => {
+  it('returns the FRESHEST session (min age = "Just now"), not the last/first line', () => {
+    expect(parseLatestGeminiSessionHandle(REAL_LIST)).toBe('ef951c6e-49b4-49df-a8f0-b8aa62b4403f');
+  });
+
+  it('picks min age even when the freshest is NOT listed last', () => {
+    const out = `Available sessions (3):
+  1. fresh one (Just now) [aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa]
+  2. old one (2 hours ago) [bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb]
+  3. medium (5 minutes ago) [cccccccc-cccc-cccc-cccc-cccccccccccc]`;
+    expect(parseLatestGeminiSessionHandle(out)).toBe('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa');
+  });
+
+  it('is not confused by parentheses inside the title (age is the LAST parens)', () => {
+    const out = `  1. Fix the thing (part 1/4) (3 minutes ago) [dddddddd-dddd-dddd-dddd-dddddddddddd]`;
+    expect(parseLatestGeminiSessionHandle(out)).toBe('dddddddd-dddd-dddd-dddd-dddddddddddd');
+  });
+
+  it('handles seconds / hours / days units', () => {
+    const out = `  1. a (30 seconds ago) [11111111-1111-1111-1111-111111111111]
+  2. b (3 hours ago) [22222222-2222-2222-2222-222222222222]
+  3. c (2 days ago) [33333333-3333-3333-3333-333333333333]`;
+    // 30 seconds is the smallest
+    expect(parseLatestGeminiSessionHandle(out)).toBe('11111111-1111-1111-1111-111111111111');
+  });
+
+  it('returns null when no session row parses', () => {
+    expect(parseLatestGeminiSessionHandle('No sessions found for this project.')).toBeNull();
+    expect(parseLatestGeminiSessionHandle('')).toBeNull();
+  });
+});
+
+describe('createQuotaBudgetGate', () => {
+  it('passes through an allowing tracker', () => {
+    const gate = createQuotaBudgetGate({ shouldSpawnSession: () => ({ allowed: true, reason: 'ok' }) });
+    expect(gate()).toEqual({ ok: true, reason: undefined });
+  });
+
+  it('closes (with reason) when the tracker denies', () => {
+    const gate = createQuotaBudgetGate({
+      shouldSpawnSession: () => ({ allowed: false, reason: 'memory pressure' }),
+    });
+    expect(gate()).toEqual({ ok: false, reason: 'memory pressure' });
+  });
+
+  it('fails OPEN when no tracker is wired', () => {
+    expect(createQuotaBudgetGate(null)()).toEqual({ ok: true });
+    expect(createQuotaBudgetGate(undefined)()).toEqual({ ok: true });
+  });
+});

--- a/upgrades/next/gemini-loop-driver-wiring.md
+++ b/upgrades/next/gemini-loop-driver-wiring.md
@@ -1,0 +1,35 @@
+<!-- bump: patch -->
+
+## What Changed
+
+Wires the Gemini multi-turn loop-driver engine (`need-gem-002`, increment 1,
+already merged) into a real, budget-gated, **dark** capability — so the Gemini
+mentee can be handed a goal it works across turns instead of one reply.
+
+- `geminiLoopProduction.ts` — the production dependencies: a subscription-auth
+  spawn (routes through the billing-env-stripping gemini transport, so no run can
+  introduce an API key), a `gemini --list-sessions` handle parser that picks the
+  freshest session by age, and a budget gate that reuses the existing QuotaTracker
+  spawn-admission signal (fails open if no tracker).
+- `GeminiLoopRunner` — a multi-turn run can take minutes, so `POST` ADMITS a run
+  (enabled? under the concurrency cap? budget open?) and returns a `runId`
+  immediately; the loop runs in the background and the result lands in a bounded
+  in-memory registry.
+- Routes `POST /gemini-loop/runs` + `GET /gemini-loop/runs[/:id]`.
+- Config `autonomousSessions.geminiLoopDriver` (`enabled`, `model`, `maxTurns`
+  default 12, `minTurnIntervalMs`, `maxConcurrent` default 1, `turnTimeoutMs`).
+
+Ships **dark** behind `autonomousSessions.geminiLoopDriver.enabled` (default
+`false`); the `developmentAgent` gate turns it on for development agents only.
+Rollback = set the flag `false` (instant, no redeploy). Subscription auth is
+structural. 21 new tests across all three tiers (unit + integration route + e2e
+alive + wired-source check). Spec: `docs/specs/gemini-multi-turn-loop-driver.md`.
+
+## What to Tell Your User
+
+On development agents I can now be handed a multi-step task for the Gemini side
+and work it across several turns on my own — on subscription login, never an API
+key — with a hard turn cap and a spend gate so it can't run away. On every other
+agent it ships turned off, so nothing changes there. This is the capability the
+apprenticeship program needed so the Gemini mentee can do real multi-step work
+instead of stopping after one reply.

--- a/upgrades/side-effects/gemini-loop-driver-wiring.md
+++ b/upgrades/side-effects/gemini-loop-driver-wiring.md
@@ -1,0 +1,59 @@
+# Side-Effects Review — Gemini loop-driver wiring (need-gem-002, increment 2)
+
+**Version / slug:** `gemini-loop-driver-wiring`
+**Date:** `2026-06-04`
+**Author:** `echo`
+**Second-pass reviewer:** `not required` (ships DARK behind
+`autonomousSessions.geminiLoopDriver.enabled`; the developmentAgent gate turns it
+on for dev agents only; rollback = flag false, instant)
+
+## Summary of the change
+
+Wires the (already-merged, increment 1) `GeminiLoopDriver` engine into a real,
+budget-gated, dark capability:
+- `geminiLoopProduction.ts` — production deps: the subscription-auth spawn
+  (`createGeminiLoopSpawn` → the billing-env-stripping transport), the
+  `--list-sessions` handle parser (`parseLatestGeminiSessionHandle`, min-age), and
+  the QuotaTracker-backed budget gate (`createQuotaBudgetGate`).
+- `GeminiLoopRunner.ts` — admits + launches runs async (a loop can take minutes,
+  so a run returns a `runId` immediately) into a bounded in-memory registry.
+- Routes `POST /gemini-loop/runs` (admit) + `GET /gemini-loop/runs[/:id]` (poll).
+- `server.ts` constructs it under the developmentAgent gate; `types.ts` adds
+  `autonomousSessions.geminiLoopDriver`.
+
+## Decision-point inventory
+
+Admission has four refusal boundaries (disabled / at-capacity / budget / invalid)
+plus the OK path; the handle parser picks min-age or null; the budget gate maps
+the QuotaTracker signal (fail-open with no tracker). All covered both-sides
+across the unit/integration suites.
+
+## 1. Over-block
+
+**What legitimate inputs does this change reject?** Nothing on the fleet — it
+ships dark (disabled → POST returns 409 'disabled'). When enabled: a closed budget
+gate refuses to start (intended — the overspend guard), `maxConcurrent: 1` refuses
+a 2nd concurrent run (intended — keeps shared-cwd handle capture unambiguous), and
+an empty goal is 400. A requested `maxTurns` is clamped DOWN to the config cap, never
+up. These are all the guardrails, not false rejections.
+
+## 2. Under-block
+
+**What does this still miss?** Handle capture uses the shared process cwd, so it is
+only unambiguous at `maxConcurrent: 1` (a per-loop cwd needs a transport `cwd`
+option — deferred; documented in the spec risks). The runner does not persist runs
+across a restart (in-memory registry — acceptable for a dev dark feature; a SQLite
+store is a later increment if it graduates). A 429/capacity wall ends a turn via
+the engine's spawn-failure path rather than a graceful gemini-capacity-policy
+pause (noted as a refinement). A mentee that finishes silently (no sentinel) runs
+to the turn cap rather than an LLM-judge early-exit (judge = a later increment).
+
+## 3. Level-of-abstraction fit
+
+**Right layer?** Yes. Production deps live in `monitoring/` beside the engine and
+depend only on the gemini transport (subscription-auth guarantee stays in the
+transport, reused not re-implemented). The runner is constructed beside the other
+dark monitoring features in `server.ts` under the same `developmentAgent` gate
+pattern, and threads through the existing `AgentServer` options → `RouteContext`
+plumbing (mirrors `mcpProcessReaper`). The budget gate reuses the existing
+QuotaTracker spawn-admission decision rather than inventing new accounting.


### PR DESCRIPTION
## What

Increment 2 of **need-gem-002** — wires the `GeminiLoopDriver` engine (increment 1, merged in #738) into a real, **budget-gated, dark** capability so the Gemini mentee can be handed a multi-turn task.

- **`geminiLoopProduction.ts`** — production deps: subscription-auth spawn (routes through the billing-env-stripping transport → no API key possible), `gemini --list-sessions` handle parser (min-age, not list order), QuotaTracker-backed budget gate.
- **`GeminiLoopRunner`** — a loop runs minutes, so `POST` admits + launches async and returns a `runId` immediately; result lands in a bounded in-memory registry.
- **Routes** `POST /gemini-loop/runs` + `GET /gemini-loop/runs[/:id]`.
- **`server.ts`** constructs it under the **developmentAgent** gate; **`types.ts`** adds `autonomousSessions.geminiLoopDriver` (maxTurns 12, maxConcurrent 1 default — Justin-approved §6).

## Safety

Ships **DARK** behind `autonomousSessions.geminiLoopDriver.enabled` (default `false`); the developmentAgent gate turns it on for dev agents only. Rollback = flag `false` (instant). Subscription auth is structural (reuses the transport's billing-env strip). Single-concurrency keeps handle capture unambiguous; budget gate refuses-to-start under pressure.

## Tests

24 new across all three tiers — unit (parser min-age both-sides, budget gate fail-open, runner admission boundaries + async lifecycle + registry eviction), integration (route 503/409/400/202/404 + async poll), e2e (alive route ADMITS 202 + wired-source check that server.ts actually constructs it — the anti-PR#334-orphan-class gate). tsc clean.

Approved spec: `docs/specs/gemini-multi-turn-loop-driver.md`. Justin approved + "proceed" (2026-06-04, topic 13435).

🤖 Generated with [Claude Code](https://claude.com/claude-code)