### PR TITLE
feat(mentor): automated tick records keystone mentor-mentee-differential cycles (Task 7)

### DIFF
--- a/src/scheduler/MentorOnboardingRunner.ts
+++ b/src/scheduler/MentorOnboardingRunner.ts
@@ -12,7 +12,7 @@
  *
  * Ships dormant: `mentor.enabled=false` / `mentor.mode='off'` by default (§16).
  */
-import { runMentorTick, type MentorTickResult, type MentorMode } from './MentorOnboardingTick.js';
+import { runMentorTick, type MentorTickResult, type MentorMode, type MentorCycleCapture } from './MentorOnboardingTick.js';
 import { llmCircuitAvailable } from '../core/LlmCircuitBreaker.js';
 import {
   runAutonomousGuardian,
@@ -58,6 +58,11 @@ export interface MentorConfig {
    *  (codex-rollout parsing keys on framework). NOT necessarily the mentee's
    *  agent-registry name — see menteeAgentName. */
   menteeFramework: string;
+  /** Apprenticeship instance this mentor job serves (e.g. 'codey-to-gemini').
+   *  When set AND an ApprenticeshipCycleStore is wired, each tick records a
+   *  `mentor-mentee-differential` CYCLE (the keystone axis) — not just findings.
+   *  Unset (default) ⇒ no cycle recording (back-compat; the job just observes). */
+  apprenticeshipInstanceId?: string;
   /** The mentee's actual agent-registry name (e.g. 'instar-codey'). Used for
    *  same-machine peer lookup + the a2a marker `to=`/reply-allowlist. Defaults
    *  to `instar-${menteeFramework}` when unset (back-compat), but framework and
@@ -138,6 +143,10 @@ export const DEFAULT_MENTOR_CONFIG: MentorConfig = {
 export interface MentorRunnerServices {
   /** Write findings + log the run to the ledger funnel (§19.2). */
   capture: (input: CaptureRunInput) => CaptureRunResult;
+  /** Record a `mentor-mentee-differential` cycle (keystone axis). Optional —
+   *  the host wires it to the ApprenticeshipCycleStore only when
+   *  `apprenticeshipInstanceId` is configured; otherwise undefined ⇒ no-op. */
+  recordCycle?: (input: MentorCycleCapture) => void;
   /** Spawn Stage A with the empty tool grant; return its transcript. */
   spawnStageA: (prompt: string) => Promise<string>;
   /** Stage-B forensics for the framework; return findings. */
@@ -269,6 +278,7 @@ export class MentorOnboardingRunner {
       spawnStageA: this.services.spawnStageA,
       runStageBForensics: () => this.services.runStageBForensics(framework),
       capture: this.services.capture,
+      recordCycle: this.services.recordCycle,
       deliverToMentee: this.services.deliverToMentee,
       now: this.services.now,
     });

--- a/src/scheduler/MentorOnboardingTick.ts
+++ b/src/scheduler/MentorOnboardingTick.ts
@@ -32,6 +32,24 @@ import type { CaptureRunInput, CaptureRunResult, ForensicFinding } from '../moni
  *  everything except deliver a message to the mentee; `live` is the full loop. */
 export type MentorMode = 'dry-run' | 'live';
 
+/**
+ * One mentor↔mentee differential cycle captured from a tick — the raw materials
+ * for an ApprenticeshipCycleStore `mentor-mentee-differential` record. The tick
+ * produces these; the host's injected `recordCycle` decides whether/where to
+ * persist them (it no-ops unless an apprenticeship instance is configured). This
+ * is what makes the AUTOMATED mentor loop fire the keystone differential axis,
+ * the structural fix for the program's #1 drift failure.
+ */
+export interface MentorCycleCapture {
+  framework: string;
+  /** Short descriptor of the work the mentee was driven through this tick. */
+  task: string;
+  /** The mentee's Stage-A transcript (its output). */
+  menteeOutput: string;
+  /** The overseer/forensics differential — one string per finding. */
+  differential: string[];
+}
+
 export interface MentorTickDeps {
   framework: string;
   mode: MentorMode;
@@ -55,6 +73,14 @@ export interface MentorTickDeps {
   runStageBForensics: () => Promise<ForensicFinding[]>;
   /** Write findings + log the run to the ledger funnel (§19.2). */
   capture: (input: CaptureRunInput) => CaptureRunResult;
+  /**
+   * Record one mentor↔mentee differential CYCLE (in addition to the per-finding
+   * ledger capture above). Injected + optional: the host wires it to the
+   * ApprenticeshipCycleStore only when a `mentor.apprenticeshipInstanceId` is
+   * configured, so by default it no-ops. This is the keystone-axis hook — the
+   * automated loop records `mentor-mentee-differential` cycles, not just findings.
+   */
+  recordCycle?: (input: MentorCycleCapture) => void;
   /**
    * Deliver the Stage-A message to the mentee — called ONLY in `live` mode (§6).
    * The host's implementation MUST be persist-only (queue to a durable outbox the
@@ -177,6 +203,20 @@ export async function runMentorTick(deps: MentorTickDeps): Promise<MentorTickRes
   // 7. Capture — writes findings + logs the run to the funnel (§19.2),
   //    even if findings is empty (inert-writer guard).
   const captured = deps.capture({ framework: deps.framework, tickId, findings });
+
+  // 7b. Record the differential CYCLE (the keystone `mentor-mentee-differential`
+  //     axis) alongside the per-finding ledger capture. The mentee's transcript is
+  //     its output; the forensics findings ARE the differential. No-ops unless the
+  //     host wired `recordCycle` (i.e. a `mentor.apprenticeshipInstanceId` is set).
+  //     Guarded on a non-empty transcript — an empty/failed Stage A is not a cycle.
+  if (deps.recordCycle && transcript.trim()) {
+    deps.recordCycle({
+      framework: deps.framework,
+      task: `mentor-onboarding tick (${deps.framework})`,
+      menteeOutput: transcript,
+      differential: findings.map((f) => f.title),
+    });
+  }
 
   // 8. Deliver — ONLY in live mode, and ONLY via the host's persist-only path
   //    (§6). In dry-run we observe + capture but never contact the mentee.

--- a/src/server/AgentServer.ts
+++ b/src/server/AgentServer.ts
@@ -1894,6 +1894,35 @@ export class AgentServer {
     return new MentorOnboardingRunner(
       {
         capture: (input) => ledger.captureRun(input),
+        // Record a keystone `mentor-mentee-differential` CYCLE per tick — the
+        // structural version of the manual differential-oversight loop. No-ops
+        // unless `mentor.apprenticeshipInstanceId` is set AND the cycle store is
+        // wired. Reads `self.apprenticeshipCycleStore` LAZILY (at tick time, not
+        // construction time) because buildMentorRunner runs before the store is
+        // constructed during boot.
+        recordCycle: (input) => {
+          const instanceId = getConfig().apprenticeshipInstanceId;
+          const store = self.apprenticeshipCycleStore;
+          if (!instanceId || !store) return;
+          try {
+            const existing = store.list({ instanceId });
+            const cycleNumber = existing.length
+              ? Math.max(...existing.map((c) => c.cycleNumber)) + 1
+              : 1;
+            store.record({
+              instanceId,
+              cycleNumber,
+              task: input.task,
+              menteeOutput: input.menteeOutput,
+              overseerDifferential: input.differential,
+              kind: 'mentor-mentee-differential',
+            });
+          } catch (err) {
+            // @silent-fallback-ok — cycle capture is observability; a record
+            // failure must never crash a mentor tick. Logged, not swallowed.
+            console.warn('[mentor] recordCycle failed (non-fatal):', err instanceof Error ? err.message : String(err));
+          }
+        },
         // Stage A spawns with the EMPTY tool grant (structural two-hats boundary,
         // §4); we bounded-wait for it to finish, then capture its transcript.
         spawnStageA: async (prompt: string): Promise<string> => {

--- a/tests/unit/MentorOnboardingTick.test.ts
+++ b/tests/unit/MentorOnboardingTick.test.ts
@@ -157,3 +157,43 @@ describe('runMentorTick — gate order + structural guarantees', () => {
     expect(captures[0].findings[0].signature).toBe('stage-a-spawn-failed');
   });
 });
+
+describe('runMentorTick — keystone cycle capture (mentor-mentee-differential)', () => {
+  const finding = (title: string) => ({ title, severity: 'medium', bucket: 'generic-agent-mistake', dedupKey: title, evidence: 'e' } as unknown as import('../../src/monitoring/FrameworkIssueLedger.js').ForensicFinding);
+
+  it('records a differential cycle (transcript = menteeOutput, findings = differential) on a real tick', async () => {
+    const cycles: import('../../src/scheduler/MentorOnboardingTick.js').MentorCycleCapture[] = [];
+    const { deps } = makeDeps({
+      canaryCheck: () => true,
+      spawnStageA: vi.fn(async () => 'the mentee output here'),
+      runStageBForensics: vi.fn(async () => [finding('mentee missed the 0-is-falsy case'), finding('untyped param')]),
+      recordCycle: (c) => cycles.push(c),
+    });
+    const r = await runMentorTick(deps);
+    expect(r.ran).toBe(true);
+    expect(cycles).toHaveLength(1);
+    expect(cycles[0].framework).toBe('codex-cli');
+    expect(cycles[0].menteeOutput).toBe('the mentee output here');
+    expect(cycles[0].differential).toEqual(['mentee missed the 0-is-falsy case', 'untyped param']);
+    expect(cycles[0].task).toContain('codex-cli');
+  });
+
+  it('does NOT record a cycle when the transcript is empty (an empty Stage A is not a cycle)', async () => {
+    const cycles: unknown[] = [];
+    const { deps } = makeDeps({
+      canaryCheck: () => true,
+      spawnStageA: vi.fn(async () => '   '),
+      recordCycle: (c) => cycles.push(c),
+    });
+    const r = await runMentorTick(deps);
+    expect(r.ran).toBe(true);
+    expect(cycles).toHaveLength(0);
+  });
+
+  it('is a safe no-op when recordCycle is not wired (back-compat default)', async () => {
+    const { deps } = makeDeps({ canaryCheck: () => true, spawnStageA: vi.fn(async () => 'output') });
+    // recordCycle undefined → tick still runs cleanly
+    const r = await runMentorTick(deps);
+    expect(r.ran).toBe(true);
+  });
+});

--- a/upgrades/mentor-tick-cycle-capture.eli16.md
+++ b/upgrades/mentor-tick-cycle-capture.eli16.md
@@ -1,0 +1,18 @@
+# Mentor tick records keystone cycles — explained simply
+
+When the automated mentor job runs a "tick" (it watches the mentee, gathers
+findings), it used to log those findings to one place — but it never recorded a
+proper "cycle" of the mentorship the way the apprenticeship program tracks them.
+
+That mattered because the program's #1 failure mode is "role drift": the easy work
+gets logged, but the actual keystone — the mentor↔mentee differential — quietly
+never gets exercised. The manual loop I run by hand records those keystone cycles;
+the automated job didn't.
+
+This change wires the automated tick to ALSO record a real
+`mentor-mentee-differential` cycle each time: the mentee's output becomes the
+cycle's menteeOutput, the forensics findings become the differential. It only
+does this when an apprenticeship instance is configured (a new
+`mentor.apprenticeshipInstanceId` setting) — so by default nothing changes; it's
+opt-in. Now the automated loop fires the same keystone axis the manual loop does,
+which is the structural fix for that drift.

--- a/upgrades/next/mentor-tick-cycle-capture.md
+++ b/upgrades/next/mentor-tick-cycle-capture.md
@@ -1,0 +1,23 @@
+<!-- bump: patch -->
+
+## What Changed
+
+The automated mentor-onboarding tick now records a keystone
+`mentor-mentee-differential` apprenticeship **cycle** each run (in addition to the
+existing per-finding ledger capture) — the structural version of the manual
+differential-oversight loop. The mentee's Stage-A transcript becomes the cycle's
+`menteeOutput`; the forensics findings become the `overseerDifferential`.
+
+It is wired via a new optional `recordCycle` injected into `runMentorTick` and
+`MentorOnboardingRunner`, and a new `mentor.apprenticeshipInstanceId` config field.
+`AgentServer.buildMentorRunner` resolves it to the ApprenticeshipCycleStore only
+when that instance id is set — so it is **opt-in and a no-op by default**
+(back-compat). This makes the automated loop fire the keystone axis the program's
+role-coverage drift-warning watches, instead of only the easy finding-capture path.
+
+## What to Tell Your User
+
+Nothing changes by default. When I'm running an automated mentorship for a
+configured apprenticeship instance, the loop now records proper differential cycles
+on its own — the same keystone cycles I capture by hand — so the program can see
+the real mentor↔mentee work, not just logged findings.

--- a/upgrades/side-effects/mentor-tick-cycle-capture.md
+++ b/upgrades/side-effects/mentor-tick-cycle-capture.md
@@ -1,0 +1,39 @@
+# Side-Effects Review — Mentor tick keystone cycle capture
+
+**Slug:** `mentor-tick-cycle-capture` · **Date:** `2026-06-04` · **Author:** `echo`
+**Second-pass reviewer:** `not required` (additive, opt-in, no-op by default)
+
+## Summary
+
+`runMentorTick` now (after the existing per-finding ledger capture) records a
+`mentor-mentee-differential` apprenticeship CYCLE via an injected, optional
+`recordCycle`. The host (`AgentServer.buildMentorRunner`) wires it to the
+ApprenticeshipCycleStore ONLY when `mentor.apprenticeshipInstanceId` is set, so it
+is a no-op by default. The mentee's transcript is the cycle's menteeOutput; the
+forensics findings (mapped to titles) are the differential.
+
+## Decision-point inventory
+
+One new branch: record a cycle iff `recordCycle` is wired AND the transcript is
+non-empty. Both sides covered (records on a real tick; skips on empty transcript;
+no-op when unwired).
+
+## 1. Over-block
+
+Rejects nothing real. The transcript guard skips an empty/failed Stage A (not a
+cycle) — intended. Without `apprenticeshipInstanceId`, no cycle is recorded
+(back-compat); the existing finding-capture path is unchanged.
+
+## 2. Under-block
+
+It records ALL of a tick's findings as the differential without de-duping against
+prior cycles (acceptable — each tick is a distinct cycle). The cycle's `task` is a
+generic per-tick descriptor, not the full Stage-A prompt (kept terse on purpose).
+cycleNumber is computed as max-existing+1 (single-writer mentor tick, no race).
+
+## 3. Level-of-abstraction fit
+
+Right layer: the pure tick gets an injected callback (no store dependency in the
+pure core); the store wiring + instance resolution live in `buildMentorRunner`
+beside the existing `capture` wiring, reading the cycle store lazily to dodge the
+boot-order (buildMentorRunner runs before the store is constructed).


### PR DESCRIPTION
## What

Phase-2 Task 7 (optimize the automated mentor-onboarding job): the mentor tick now records a real **`mentor-mentee-differential`** apprenticeship CYCLE each run — the structural version of the manual differential-oversight loop — in addition to the existing per-finding ledger capture.

- Mentee Stage-A transcript → cycle `menteeOutput`; forensics findings → `overseerDifferential`.
- Wired via an optional `recordCycle` injected into `runMentorTick` + `MentorOnboardingRunner`, plus a new `mentor.apprenticeshipInstanceId` config field.
- `AgentServer.buildMentorRunner` resolves it to the `ApprenticeshipCycleStore` **only when that instance id is set** (lazy store read to dodge the boot-order) — **opt-in, no-op by default** (back-compat).

## Why

The program's #1 failure mode is role-coverage drift — the easy finding-capture path runs while the keystone mentor↔mentee differential axis stays dormant. This makes the *automated* loop fire the same keystone axis the manual loop does (and that the role-coverage `driftWarning` watches).

## Tests

3 new both-sides unit tests (records on a real tick with transcript+findings; skips on empty transcript; no-op when unwired). tsc clean; existing MentorOnboardingRunner (20) + no-silent-fallbacks green. Tier-1 (additive, opt-in, reuses existing store).

🤖 Generated with [Claude Code](https://claude.com/claude-code)