### PR TITLE
feat(apprenticeship): enforce the dogfooded channel — shortcuts don't fire the keystone

### DIFF
--- a/src/monitoring/ApprenticeshipCycleStore.ts
+++ b/src/monitoring/ApprenticeshipCycleStore.ts
@@ -34,6 +34,9 @@ export interface ApprenticeshipCycleRecordInput {
   infraItems?: string[];
   kind?: string;
   status?: string;
+  /** The channel this cycle's mentor↔mentee interaction ACTUALLY ran through
+   *  (the dogfooded-channel standard, APPRENTICESHIP-PROGRAM-PROJECT-DESIGN §4a). */
+  channel?: string;
 }
 
 export const APPRENTICESHIP_CYCLE_AXES = [
@@ -44,6 +47,25 @@ export const APPRENTICESHIP_CYCLE_AXES = [
 
 export type ApprenticeshipCycleAxis = typeof APPRENTICESHIP_CYCLE_AXES[number];
 export type ApprenticeshipCycleKind = ApprenticeshipCycleAxis | 'unknown';
+
+/**
+ * How a cycle's mentor↔mentee interaction actually ran (§4a "dogfooded channel").
+ *  - `telegram-playwright` — THE channel: the mentor drove the mentee through the
+ *    real Telegram UX via the dedicated Playwright profile (experiences the UX).
+ *  - `threadline-backup`   — the backup transport (only when Playwright can't reach
+ *    Telegram); still counts toward the keystone.
+ *  - `direct-shortcut`     — a CLI/API shortcut that bypassed the UX-under-test;
+ *    recorded for honesty but does NOT count toward the keystone axis.
+ *  - `unknown`             — unset / grandfathered (pre-field cycles); counts, so the
+ *    enforcement never retroactively un-fires an already-earned keystone.
+ */
+export const APPRENTICESHIP_CYCLE_CHANNELS = [
+  'telegram-playwright',
+  'threadline-backup',
+  'direct-shortcut',
+  'unknown',
+] as const;
+export type ApprenticeshipCycleChannel = typeof APPRENTICESHIP_CYCLE_CHANNELS[number];
 
 export interface ApprenticeshipRoleAxisCoverage {
   fired: boolean;
@@ -57,6 +79,10 @@ export interface ApprenticeshipRoleCoverage {
   unknown: ApprenticeshipRoleAxisCoverage;
   dormantAxes: ApprenticeshipCycleAxis[];
   driftWarning: boolean;
+  /** mentor-mentee-differential cycles that ran via a `direct-shortcut` (so they
+   *  did NOT count toward the keystone axis). Surfaced for honesty — a shortcut is
+   *  recorded but can never make the keystone look healthy (§4a enforcement). */
+  shortcutDifferentialCount: number;
 }
 
 export interface ApprenticeshipCycleRecord {
@@ -72,6 +98,7 @@ export interface ApprenticeshipCycleRecord {
   infraItems: string[];
   kind: ApprenticeshipCycleKind;
   status: string;
+  channel: ApprenticeshipCycleChannel;
 }
 
 const SCHEMA = [
@@ -87,7 +114,8 @@ const SCHEMA = [
      coaching              TEXT NOT NULL,
      infra_items_json      TEXT NOT NULL,
      kind                  TEXT NOT NULL,
-     status                TEXT NOT NULL
+     status                TEXT NOT NULL,
+     channel               TEXT NOT NULL DEFAULT 'unknown'
    )`,
   `CREATE INDEX IF NOT EXISTS idx_apprenticeship_cycles_instance_created
      ON apprenticeship_cycles(instance_id, created_at DESC)`,
@@ -138,6 +166,16 @@ function normalizeKind(raw: unknown): ApprenticeshipCycleKind {
   throw new Error(`kind must be one of ${[...APPRENTICESHIP_CYCLE_AXES, 'unknown'].join(', ')}`);
 }
 
+function normalizeChannel(raw: unknown): ApprenticeshipCycleChannel {
+  if (
+    typeof raw === 'string' &&
+    (APPRENTICESHIP_CYCLE_CHANNELS as readonly string[]).includes(raw)
+  ) {
+    return raw as ApprenticeshipCycleChannel;
+  }
+  return 'unknown';
+}
+
 interface Row {
   id: string;
   instance_id: string;
@@ -151,6 +189,7 @@ interface Row {
   infra_items_json: string;
   kind: string;
   status: string;
+  channel: string;
 }
 
 export class ApprenticeshipCycleStore {
@@ -182,6 +221,14 @@ export class ApprenticeshipCycleStore {
       try { this.db.close(); } catch { /* already closed */ }
     });
     for (const ddl of SCHEMA) this.db.exec(ddl);
+    // Migration: add the `channel` column to DBs created before the dogfooded-
+    // channel enforcement (§4a). Idempotent — only ALTER if it's missing. Existing
+    // rows default to 'unknown' (grandfathered → still count, never un-firing an
+    // already-earned keystone).
+    const cols = this.db.prepare(`PRAGMA table_info(apprenticeship_cycles)`).all() as Array<{ name: string }>;
+    if (!cols.some((c) => c.name === 'channel')) {
+      this.db.exec(`ALTER TABLE apprenticeship_cycles ADD COLUMN channel TEXT NOT NULL DEFAULT 'unknown'`);
+    }
     // Legacy rows pre-date axis vocabulary. Keep them visible, but never
     // fabricate an axis from the old catch-all label.
     this.db.prepare(`UPDATE apprenticeship_cycles SET kind = 'unknown' WHERE kind = 'differential-cycle'`).run();
@@ -194,11 +241,11 @@ export class ApprenticeshipCycleStore {
         INSERT INTO apprenticeship_cycles
           (id, instance_id, cycle_number, created_at, task, mentee_output,
            mentor_flagged_json, overseer_diff_json, coaching, infra_items_json,
-           kind, status)
+           kind, status, channel)
         VALUES
           (@id, @instanceId, @cycleNumber, @createdAt, @task, @menteeOutput,
            @mentorFlaggedJson, @overseerDifferentialJson, @coaching,
-           @infraItemsJson, @kind, @status)
+           @infraItemsJson, @kind, @status, @channel)
       `),
       listAll: this.db.prepare(`
         SELECT * FROM apprenticeship_cycles
@@ -242,6 +289,7 @@ export class ApprenticeshipCycleStore {
       infraItems: stringArray(input.infraItems, 'infraItems'),
       kind: normalizeKind(input.kind),
       status: optionalString(input.status, 'open'),
+      channel: normalizeChannel(input.channel),
     };
 
     this.stmts.insert.run({
@@ -274,9 +322,20 @@ export class ApprenticeshipCycleStore {
       APPRENTICESHIP_CYCLE_AXES.map((axis) => [axis, blank()]),
     ) as Record<ApprenticeshipCycleAxis, ApprenticeshipRoleAxisCoverage>;
     const unknown = blank();
+    let shortcutDifferentialCount = 0;
 
     for (const row of rows) {
       const kind = normalizeKind(row.kind);
+      const channel = normalizeChannel(row.channel);
+      // §4a ENFORCEMENT: a mentor-mentee-differential cycle that ran through a
+      // `direct-shortcut` (bypassing the dogfooded Telegram-Playwright UX-under-test)
+      // is recorded for honesty but does NOT count toward the keystone axis — a
+      // shortcut can never make the program look healthy. Dogfooded, backup, and
+      // grandfathered ('unknown') channels all count as before.
+      if (kind === 'mentor-mentee-differential' && channel === 'direct-shortcut') {
+        shortcutDifferentialCount += 1;
+        continue;
+      }
       const target = kind === 'unknown' ? unknown : axes[kind];
       target.fired = true;
       target.cycleCount += 1;
@@ -288,7 +347,7 @@ export class ApprenticeshipCycleStore {
       !axes['mentor-mentee-differential'].fired &&
       axes['overseer-apprentice-devreview'].cycleCount >= 2;
 
-    return { instanceId: id, axes, unknown, dormantAxes, driftWarning };
+    return { instanceId: id, axes, unknown, dormantAxes, driftWarning, shortcutDifferentialCount };
   }
 
   closeCycle(id: string): ApprenticeshipCycleRecord | null {
@@ -320,6 +379,7 @@ export class ApprenticeshipCycleStore {
       infraItems: parseJsonArray(row.infra_items_json),
       kind: normalizeKind(row.kind),
       status: row.status,
+      channel: normalizeChannel(row.channel),
     };
   }
 }

--- a/tests/unit/apprenticeship-cycle-store.test.ts
+++ b/tests/unit/apprenticeship-cycle-store.test.ts
@@ -132,4 +132,61 @@ describe('ApprenticeshipCycleStore', () => {
     })).toThrow(/mentorFlagged/);
     store.close();
   });
+
+  describe('dogfooded-channel enforcement (§4a keystone gating)', () => {
+    const diff = (over: Record<string, unknown> = {}) => ({
+      instanceId: 'codey-to-gemini',
+      cycleNumber: 1,
+      task: 't',
+      menteeOutput: 'm',
+      kind: 'mentor-mentee-differential',
+      ...over,
+    });
+
+    it('a telegram-playwright differential FIRES the keystone axis', () => {
+      const store = makeStore();
+      store.record(diff({ channel: 'telegram-playwright' }));
+      const cov = store.roleCoverage('codey-to-gemini');
+      expect(cov.axes['mentor-mentee-differential'].fired).toBe(true);
+      expect(cov.shortcutDifferentialCount).toBe(0);
+      store.close();
+    });
+
+    it('a direct-shortcut differential is RECORDED but does NOT fire the keystone', () => {
+      const store = makeStore();
+      store.record(diff({ channel: 'direct-shortcut' }));
+      const cov = store.roleCoverage('codey-to-gemini');
+      expect(cov.axes['mentor-mentee-differential'].fired).toBe(false);
+      expect(cov.axes['mentor-mentee-differential'].cycleCount).toBe(0);
+      expect(cov.shortcutDifferentialCount).toBe(1);
+      // still stored (honesty) — visible via list()
+      expect(store.list({ instanceId: 'codey-to-gemini' })).toHaveLength(1);
+      store.close();
+    });
+
+    it('an unset (grandfathered) channel FIRES the keystone — never un-fires an earned one', () => {
+      const store = makeStore();
+      store.record(diff()); // no channel → normalizeChannel → 'unknown' → counts
+      const cov = store.roleCoverage('codey-to-gemini');
+      expect(cov.axes['mentor-mentee-differential'].fired).toBe(true);
+      const id = store.list({ instanceId: 'codey-to-gemini' })[0].id;
+      expect(store.get(id)!.channel).toBe('unknown');
+      store.close();
+    });
+
+    it('threadline-backup counts toward the keystone (legit backup channel)', () => {
+      const store = makeStore();
+      store.record(diff({ channel: 'threadline-backup' }));
+      expect(store.roleCoverage('codey-to-gemini').axes['mentor-mentee-differential'].fired).toBe(true);
+      store.close();
+    });
+
+    it('the channel round-trips through record/get and normalizes garbage to unknown', () => {
+      const store = makeStore();
+      const r = store.record(diff({ channel: 'not-a-real-channel' }));
+      expect(r.channel).toBe('unknown');
+      expect(store.get(r.id)!.channel).toBe('unknown');
+      store.close();
+    });
+  });
 });

--- a/upgrades/apprenticeship-channel-enforcement.eli16.md
+++ b/upgrades/apprenticeship-channel-enforcement.eli16.md
@@ -1,0 +1,16 @@
+# Enforcing the dogfooded channel — explained simply
+
+The apprenticeship rule (just documented) is: a mentor must drive its mentee through
+the REAL Telegram UX (via Playwright), because experiencing the user experience IS the
+test. A shortcut — calling the mentee's CLI directly — gets an answer but skips the
+thing we're actually testing.
+
+A doc alone is a wish. This makes it a guarantee: every recorded apprenticeship cycle
+now writes down WHICH channel it actually ran through. And the keystone check — the one
+that tells us the real mentor↔mentee work is happening — only counts a cycle if it ran
+through the real channel (Telegram-Playwright, or the backup). A shortcut cycle is still
+saved (so we're honest it happened), but it does NOT light up the keystone. So a shortcut
+can never make the program look healthier than it is.
+
+Older cycles (recorded before this field existed) are grandfathered in — they still
+count, so this never retroactively "un-fires" a keystone we already earned.

--- a/upgrades/next/apprenticeship-channel-enforcement.md
+++ b/upgrades/next/apprenticeship-channel-enforcement.md
@@ -1,0 +1,19 @@
+<!-- bump: patch -->
+
+## What Changed
+
+Enforces the dogfooded-channel standard (APPRENTICESHIP-PROGRAM-PROJECT-DESIGN §4a) in
+code. Every `ApprenticeshipCycleStore` record now carries a `channel`
+(`telegram-playwright` | `threadline-backup` | `direct-shortcut` | `unknown`), with an
+idempotent migration for existing DBs. `roleCoverage` now counts a
+`mentor-mentee-differential` cycle toward the keystone axis **only** when it did NOT run
+through a `direct-shortcut` — a shortcut cycle is still recorded (for honesty, surfaced via
+the new `shortcutDifferentialCount`) but can never make the keystone look healthy. Unset /
+pre-field channels are grandfathered as `unknown` and still count, so an already-earned
+keystone is never retroactively un-fired.
+
+## What to Tell Your User
+
+Nothing user-facing changes. Internally, the apprenticeship now records which channel each
+mentor↔mentee cycle ran through and structurally refuses to let a CLI/API shortcut count as
+real keystone progress — so "is the real mentorship happening?" can't be faked.

--- a/upgrades/side-effects/apprenticeship-channel-enforcement.md
+++ b/upgrades/side-effects/apprenticeship-channel-enforcement.md
@@ -1,0 +1,39 @@
+# Side-Effects Review — Apprenticeship dogfooded-channel enforcement
+
+**Slug:** `apprenticeship-channel-enforcement` · **Date:** `2026-06-04` · **Author:** `echo`
+**Second-pass reviewer:** `not required` (additive field + a counting gate; grandfathered)
+
+## Summary
+
+Adds a `channel` field to ApprenticeshipCycleStore records (`telegram-playwright` |
+`threadline-backup` | `direct-shortcut` | `unknown`), an idempotent ALTER-TABLE migration
+for existing DBs (default `unknown`), and a `roleCoverage` gate: a
+`mentor-mentee-differential` cycle on `direct-shortcut` is recorded but does NOT count
+toward the keystone axis (surfaced via a new `shortcutDifferentialCount`). Enforces the
+§4a dogfooded-channel standard in code.
+
+## Decision-point inventory
+
+One new branch in `roleCoverage`: a mentor-mentee-differential cycle is skipped from axis
+tallying iff `channel === 'direct-shortcut'`. Covered both-sides (dogfooded fires; shortcut
+doesn't + increments the counter; grandfathered/backup fire).
+
+## 1. Over-block
+
+Rejects nothing. Garbage/unset channels normalize to `unknown`, which COUNTS (grandfathered)
+— so it never retroactively un-fires an earned keystone (cycle #4, recorded pre-field, holds).
+Only an EXPLICIT `direct-shortcut` is gated, and even then the cycle is still stored + listed.
+
+## 2. Under-block
+
+The mentor tick (#743) records cycles without setting `channel` → they default to `unknown`
+→ count. That is intentionally grandfathered for now; aligning the automated tick to set
+`direct-shortcut` (or to drive via Playwright, the real fix) is the follow-on once Codey's
+Playwright driving capability exists. The gate is per-axis-tally; it does not retro-rewrite
+stored rows.
+
+## 3. Level-of-abstraction fit
+
+Right layer: the enforcement lives in the cycle store's `roleCoverage` (the single place the
+keystone is computed), reusing the existing axis-tally loop. No route/server change — the
+existing `GET /apprenticeship/instances/:id/role-coverage` surfaces the new field for free.


### PR DESCRIPTION
Enforce half of §4a (companion to docs #744): channel field + roleCoverage keystone-gating so a direct-shortcut differential never fires the keystone (grandfathered unset→counts). 5 tests; tsc clean; cycle-store(11)+routes(14) green. Tier-1.