### PR TITLE
fix(threadline): A2A turn-based continuity — deterministic --session-id capture + --resume (Path 1)

### DIFF
--- a/src/commands/server.ts
+++ b/src/commands/server.ts
@@ -7706,6 +7706,13 @@ export async function startServer(options: StartOptions): Promise<void> {
           // do NOT set this and stay sandboxed. Bounded: Threadline only accepts
           // messages from trusted agents.
           codexAllowMcpTools: true,
+          // Threadline A2A continuity: forward the conversation-id intent so a
+          // claude-code A2A reply spawn sets (--session-id) a deterministic
+          // transcript on a fresh thread, or resumes (--resume) the prior
+          // transcript on a follow-up. Both undefined on every non-Threadline
+          // spawn, so existing behavior is unaffected.
+          sessionId: opts?.sessionId,
+          resumeSessionId: opts?.resumeSessionId,
         });
         // Return BOTH ids: spawnNewThread persists `tmuxSession` as the resume
         // entry's sessionName (the REAL `echo-msg-spawn-<ts>`), so live-inject /

--- a/src/core/SessionManager.ts
+++ b/src/core/SessionManager.ts
@@ -1133,6 +1133,24 @@ rm()  { "${shimRunner}" rm  "$@"; }
      *  init; with this flag a headless spawn boots in ~9s. No effect on Codex
      *  spawns (Codex MCP wiring is separate). */
     disableProjectMcp?: boolean;
+    /** Threadline A2A continuity (claude-code HEADLESS only): when set, the
+     *  headless `claude -p` spawn is launched with `--session-id <uuid>` so the
+     *  transcript is created at a deterministic, caller-chosen id. The caller
+     *  (ThreadlineRouter.spawnNewThread) stores this uuid as the thread's
+     *  resume-map entry, so the next inbound message on the same thread can
+     *  resume the exact conversation via `resumeSessionId`. Mutually exclusive
+     *  with `resumeSessionId` (sessionId wins). No effect on non-claude
+     *  frameworks or interactive spawns. */
+    sessionId?: string;
+    /** Threadline A2A continuity (claude-code HEADLESS only): when set, the
+     *  headless `claude -p` spawn is launched with `--resume <uuid>` so it
+     *  reloads the full prior transcript captured by an earlier `sessionId`
+     *  spawn. This is what makes A2A follow-ups land in a warm session with
+     *  full context instead of cold-spawning memoryless. Mutually exclusive
+     *  with `sessionId` (sessionId wins when both are present). A stale uuid is
+     *  covered by the existing resume-crash fallback. No effect on non-claude
+     *  frameworks or interactive spawns. */
+    resumeSessionId?: string;
   }): Promise<Session> {
     const runningSessions = this.listRunningSessions();
     if (runningSessions.length >= this.config.maxSessions) {
@@ -1245,6 +1263,27 @@ rm()  { "${shimRunner}" rm  "$@"; }
       const dashPIndex = headlessSpec.argv.indexOf('-p');
       if (dashPIndex > 0) {
         headlessSpec.argv.splice(dashPIndex, 0, ...extraClaudeFlags);
+      }
+    }
+
+    // Threadline A2A continuity (claude-code HEADLESS only): set/resume the
+    // conversation id so follow-up messages on the same thread land in a warm
+    // session with the full prior transcript instead of cold-spawning.
+    // Spliced before the `-p` positional, mirroring extraClaudeFlags exactly.
+    // Mutually exclusive: `sessionId` (--session-id) wins over `resumeSessionId`
+    // (--resume). Only emitted for claude-code and only when provided, so every
+    // existing spawn (jobs, topic sessions, codex) is byte-for-byte unaffected.
+    if (headlessFramework === 'claude-code') {
+      const continuityFlags: string[] = options.sessionId
+        ? ['--session-id', options.sessionId]
+        : options.resumeSessionId
+          ? ['--resume', options.resumeSessionId]
+          : [];
+      if (continuityFlags.length > 0) {
+        const dashPIndex = headlessSpec.argv.indexOf('-p');
+        if (dashPIndex > 0) {
+          headlessSpec.argv.splice(dashPIndex, 0, ...continuityFlags);
+        }
       }
     }
 

--- a/src/messaging/SpawnRequestManager.ts
+++ b/src/messaging/SpawnRequestManager.ts
@@ -81,6 +81,23 @@ export interface SpawnRequest {
    * (e.g., `spawn-request-retry`).
    */
   triggeredBy?: 'spawn-request' | 'spawn-request-drain';
+  /**
+   * Threadline A2A continuity (claude-code only): when set, the spawned
+   * session is launched with `--session-id <uuid>` so its transcript is
+   * created at a deterministic, caller-chosen id. ThreadlineRouter.spawnNewThread
+   * passes the uuid it stores as the thread's resume-map entry. Forwarded
+   * verbatim into the `spawnSession` callback options. Mutually exclusive with
+   * `resumeSessionId` (sessionId wins).
+   */
+  sessionId?: string;
+  /**
+   * Threadline A2A continuity (claude-code only): when set, the spawned
+   * session is launched with `--resume <uuid>` so it reloads the full prior
+   * transcript captured by an earlier `sessionId` spawn. ThreadlineRouter.resumeThread
+   * passes the resume-map entry's uuid here. Forwarded verbatim into the
+   * `spawnSession` callback options.
+   */
+  resumeSessionId?: string;
 }
 
 export interface SpawnResult {
@@ -168,6 +185,12 @@ export interface SpawnRequestManagerConfig {
     model?: string;
     maxDurationMinutes?: number;
     triggeredBy?: 'spawn-request' | 'spawn-request-drain';
+    /** Threadline A2A continuity: forwarded to `--session-id` (set a
+     *  deterministic conversation id). Mutually exclusive with resumeSessionId. */
+    sessionId?: string;
+    /** Threadline A2A continuity: forwarded to `--resume` (reload the prior
+     *  transcript captured by an earlier sessionId spawn). */
+    resumeSessionId?: string;
   }) => Promise<string | { sessionId: string; tmuxSession?: string }>;
   /** Function to check memory pressure. Returns true if pressure is too high. */
   isMemoryPressureHigh?: () => boolean;
@@ -565,6 +588,11 @@ export class SpawnRequestManager {
         maxDurationMinutes: request.suggestedMaxDuration,
         // §4.5: forward provenance tag (defaults to 'spawn-request' on inline path).
         triggeredBy: request.triggeredBy ?? 'spawn-request',
+        // Threadline A2A continuity: forward the conversation-id intent so the
+        // claude-code spawn sets (--session-id) or resumes (--resume) the
+        // transcript. Both undefined on every non-Threadline spawn path.
+        sessionId: request.sessionId,
+        resumeSessionId: request.resumeSessionId,
       });
       // Accept both the legacy bare-id return and the {sessionId, tmuxSession}
       // object form. The tmuxSession (when provided) is forwarded so callers

--- a/src/threadline/ThreadlineRouter.ts
+++ b/src/threadline/ThreadlineRouter.ts
@@ -672,24 +672,25 @@ export class ThreadlineRouter {
   ): Promise<ThreadlineHandleResult> {
     const { message } = envelope;
 
-    // Build history context (trust-level-aware depth for relay)
-    const maxHistory = relayContext
-      ? RELAY_HISTORY_LIMITS[relayContext.trustLevel]
-      : this.config.maxHistoryMessages;
-    const historyContext = await this.buildHistoryContext(threadId, maxHistory);
-
-    // Build the resume prompt (with grounding preamble if relay)
+    // Threadline A2A continuity: this thread already has a claude-code
+    // transcript (created with `--session-id entry.uuid` by spawnNewThread).
+    // We resume it via `--resume entry.uuid`, which reloads the FULL prior
+    // conversation from disk. So the prompt must carry ONLY the new message +
+    // the relay grounding preamble — NOT buildHistoryContext, which would
+    // double the history (it's already in the resumed transcript). Pass an
+    // empty history so buildPrompt renders "No previous history available."
+    // and the spawn argument stays small.
     const prompt = this.buildPrompt(
       message,
       threadId,
       entry.subject,
       entry.messageCount,
       entry.remoteAgent,
-      historyContext,
+      '',
       relayContext,
     );
 
-    // Spawn with resume UUID
+    // Spawn with resume UUID — `--resume entry.uuid` reloads the transcript.
     const spawnResult = await this.spawnManager.evaluate({
       requester: message.from,
       target: { agent: this.config.localAgent, machine: this.config.localMachine },
@@ -697,6 +698,7 @@ export class ThreadlineRouter {
       context: prompt,
       priority: message.priority === 'critical' ? 'critical' : 'medium',
       pendingMessages: [message.id],
+      resumeSessionId: entry.uuid,
     });
 
     if (!spawnResult.approved) {
@@ -760,6 +762,17 @@ export class ThreadlineRouter {
       relayContext,
     );
 
+    // Threadline A2A continuity: mint the conversation id up front and launch
+    // the headless claude-code spawn with `--session-id <claudeUuid>` so its
+    // transcript is created at THIS exact id. We then persist claudeUuid as the
+    // thread's resume-map entry, so the next inbound message on this thread can
+    // `--resume` the precise conversation (resumeThread). Previously the entry
+    // uuid was a placeholder (the bare instar session id or a throwaway random
+    // uuid), which never matched any real transcript → every follow-up
+    // cold-spawned memoryless. (No effect for codex spawns — sessionId is
+    // claude-only in SessionManager.)
+    const claudeUuid = crypto.randomUUID();
+
     // Request spawn
     const spawnResult = await this.spawnManager.evaluate({
       requester: message.from,
@@ -768,6 +781,7 @@ export class ThreadlineRouter {
       context: prompt,
       priority: message.priority === 'critical' ? 'critical' : 'medium',
       pendingMessages: [message.id],
+      sessionId: claudeUuid,
     });
 
     if (!spawnResult.approved) {
@@ -788,10 +802,12 @@ export class ThreadlineRouter {
       };
     }
 
-    // Create the thread resume entry
+    // Create the thread resume entry. The uuid is the claudeUuid we passed as
+    // `--session-id`, NOT spawnResult.sessionId (the instar session id) — only
+    // claudeUuid matches the real claude-code transcript that `--resume` reloads.
     const now = new Date().toISOString();
     const newEntry: ThreadResumeEntry = {
-      uuid: spawnResult.sessionId || crypto.randomUUID(),
+      uuid: claudeUuid,
       sessionName: spawnResult.tmuxSession || `thread-${threadId.slice(0, 8)}`,
       createdAt: now,
       savedAt: now,

--- a/tests/unit/session-headless-continuity.test.ts
+++ b/tests/unit/session-headless-continuity.test.ts
@@ -1,0 +1,196 @@
+/**
+ * Unit tests for Threadline A2A continuity flags in
+ * SessionManager.spawnSession() (the HEADLESS `claude -p` path).
+ *
+ * Path-1 continuity: a fresh A2A reply spawn sets a deterministic conversation
+ * id via `--session-id <uuid>` so the transcript is created at that id; a
+ * follow-up resumes the exact conversation via `--resume <uuid>`. Both flags
+ * are spliced before the `-p` positional, mirroring the existing
+ * claudeHeadlessExtraFlags splice. They are claude-code-only, mutually
+ * exclusive (sessionId wins), and absent for every existing spawn.
+ *
+ * Uses the same child_process capture mock pattern as session-resume.test.ts.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+
+// Track mock tmux sessions and capture spawned args at module scope
+const mockTmuxSessions = new Set<string>();
+const capturedExecFileSyncCalls: Array<{ cmd: string; args: string[] }> = [];
+
+vi.mock('node:child_process', () => {
+  return {
+    execFileSync: vi.fn().mockImplementation((cmd: string, args?: string[]) => {
+      if (!args) return '';
+      capturedExecFileSyncCalls.push({ cmd, args: [...args] });
+
+      if (args[0] === 'has-session') {
+        const target = args[2]?.replace(/^=/, '');
+        if (!mockTmuxSessions.has(target)) {
+          throw new Error(`session not found: ${target}`);
+        }
+        return '';
+      }
+      if (args[0] === 'new-session') {
+        const sIdx = args.indexOf('-s');
+        if (sIdx >= 0 && args[sIdx + 1]) {
+          mockTmuxSessions.add(args[sIdx + 1]);
+        }
+        return '';
+      }
+      if (args[0] === 'kill-session') {
+        const target = args[2]?.replace(/^=/, '');
+        mockTmuxSessions.delete(target);
+        return '';
+      }
+      if (args[0] === 'display-message') return 'claude||claude';
+      return '';
+    }),
+    execFile: vi.fn().mockImplementation(
+      (_cmd: string, args: string[], _opts: unknown, cb?: (err: Error | null, result: { stdout: string }) => void) => {
+        if (typeof _opts === 'function') {
+          cb = _opts as (err: Error | null, result: { stdout: string }) => void;
+        }
+        if (args[0] === 'has-session') {
+          const target = args[2]?.replace(/^=/, '');
+          if (!mockTmuxSessions.has(target)) {
+            if (cb) cb(new Error(`session not found: ${target}`), { stdout: '' });
+          } else {
+            if (cb) cb(null, { stdout: '' });
+          }
+        } else {
+          if (cb) cb(null, { stdout: '' });
+        }
+      }
+    ),
+  };
+});
+
+// Import after mock
+import { SessionManager } from '../../src/core/SessionManager.js';
+import { StateManager } from '../../src/core/StateManager.js';
+import type { SessionManagerConfig } from '../../src/core/types.js';
+
+function findLastNewSessionCall(): string[] | undefined {
+  const calls = capturedExecFileSyncCalls.filter(c => c.args[0] === 'new-session');
+  return calls[calls.length - 1]?.args;
+}
+
+describe('SessionManager.spawnSession — Threadline A2A continuity flags (headless)', () => {
+  let tmpDir: string;
+  let stateDir: string;
+  let state: StateManager;
+  let config: SessionManagerConfig;
+  let manager: SessionManager;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'instar-continuity-test-'));
+    stateDir = path.join(tmpDir, 'state');
+    fs.mkdirSync(stateDir, { recursive: true });
+
+    state = new StateManager(stateDir);
+    config = {
+      tmuxPath: '/usr/bin/tmux',
+      claudePath: '/usr/local/bin/claude',
+      projectDir: tmpDir,
+      maxSessions: 3,
+      protectedSessions: [],
+      completionPatterns: ['Session complete'],
+    };
+    manager = new SessionManager(config, state);
+
+    mockTmuxSessions.clear();
+    capturedExecFileSyncCalls.length = 0;
+  });
+
+  afterEach(() => {
+    manager.stopMonitoring();
+    SafeFsExecutor.safeRmSync(tmpDir, { recursive: true, force: true, operation: 'tests/unit/session-headless-continuity.test.ts:cleanup' });
+  });
+
+  it('puts --session-id <uuid> before -p when sessionId is provided', async () => {
+    const uuid = '550e8400-e29b-41d4-a716-446655440000';
+    await manager.spawnSession({ name: 'a2a-new', prompt: 'reply prompt', sessionId: uuid });
+
+    const args = findLastNewSessionCall();
+    expect(args).toBeDefined();
+
+    const flagIdx = args!.indexOf('--session-id');
+    expect(flagIdx).toBeGreaterThan(-1);
+    expect(args![flagIdx + 1]).toBe(uuid);
+
+    // Spliced BEFORE the -p positional (so the prompt stays the last positional).
+    const dashPIdx = args!.indexOf('-p');
+    expect(dashPIdx).toBeGreaterThan(-1);
+    expect(flagIdx).toBeLessThan(dashPIdx);
+
+    // Mutually exclusive: --resume is NOT present when sessionId is set.
+    expect(args!.includes('--resume')).toBe(false);
+  });
+
+  it('puts --resume <uuid> before -p when resumeSessionId is provided', async () => {
+    const uuid = 'abcdef00-1111-2222-3333-444444444444';
+    await manager.spawnSession({ name: 'a2a-resume', prompt: 'follow-up prompt', resumeSessionId: uuid });
+
+    const args = findLastNewSessionCall();
+    expect(args).toBeDefined();
+
+    const flagIdx = args!.indexOf('--resume');
+    expect(flagIdx).toBeGreaterThan(-1);
+    expect(args![flagIdx + 1]).toBe(uuid);
+
+    const dashPIdx = args!.indexOf('-p');
+    expect(dashPIdx).toBeGreaterThan(-1);
+    expect(flagIdx).toBeLessThan(dashPIdx);
+
+    // --session-id is NOT present on the resume path.
+    expect(args!.includes('--session-id')).toBe(false);
+  });
+
+  it('sessionId wins when BOTH sessionId and resumeSessionId are provided (mutually exclusive)', async () => {
+    const sid = '11111111-2222-3333-4444-555555555555';
+    const rid = '99999999-8888-7777-6666-555555555555';
+    await manager.spawnSession({
+      name: 'a2a-both',
+      prompt: 'p',
+      sessionId: sid,
+      resumeSessionId: rid,
+    });
+
+    const args = findLastNewSessionCall();
+    expect(args).toBeDefined();
+
+    const sidIdx = args!.indexOf('--session-id');
+    expect(sidIdx).toBeGreaterThan(-1);
+    expect(args![sidIdx + 1]).toBe(sid);
+    // --resume must NOT appear — sessionId takes precedence.
+    expect(args!.includes('--resume')).toBe(false);
+  });
+
+  it('emits NEITHER flag when neither option is provided (existing spawns unaffected)', async () => {
+    await manager.spawnSession({ name: 'plain-job', prompt: 'job prompt' });
+
+    const args = findLastNewSessionCall();
+    expect(args).toBeDefined();
+    expect(args!.includes('--session-id')).toBe(false);
+    expect(args!.includes('--resume')).toBe(false);
+
+    // The -p positional is still present and the prompt is the final argument.
+    const dashPIdx = args!.indexOf('-p');
+    expect(dashPIdx).toBeGreaterThan(-1);
+    expect(args![args!.length - 1]).toBe('job prompt');
+  });
+
+  it('passes the uuid through verbatim (no normalization)', async () => {
+    const uuid = 'ABCDEF12-3456-7890-abcd-ef1234567890';
+    await manager.spawnSession({ name: 'verbatim', prompt: 'p', sessionId: uuid });
+
+    const args = findLastNewSessionCall();
+    const flagIdx = args!.indexOf('--session-id');
+    expect(args![flagIdx + 1]).toBe(uuid);
+  });
+});

--- a/tests/unit/threadline-fixes.test.ts
+++ b/tests/unit/threadline-fixes.test.ts
@@ -341,3 +341,46 @@ describe('SpawnRequestManager — tmuxSession propagation (A2A continuity)', () 
     expect(result.tmuxSession).toBeUndefined();
   });
 });
+
+// ── Path-1 continuity: sessionId / resumeSessionId forwarding ────────
+
+describe('SpawnRequestManager — continuity flag forwarding (A2A Path-1)', () => {
+  it('forwards request.sessionId into the spawnSession callback options', async () => {
+    const spawnFn = vi.fn().mockResolvedValue({ sessionId: 'inst-id', tmuxSession: 'echo-msg-spawn-1' });
+    const manager = createSpawnManager({ spawnSession: spawnFn });
+
+    const req: SpawnRequest = { ...makeRequest('peer-new'), sessionId: 'claude-uuid-aaa' };
+    const result = await manager.evaluate(req);
+
+    expect(result.approved).toBe(true);
+    // Second arg of the callback carries the forwarded options.
+    const opts = spawnFn.mock.calls[0][1];
+    expect(opts.sessionId).toBe('claude-uuid-aaa');
+    expect(opts.resumeSessionId).toBeUndefined();
+  });
+
+  it('forwards request.resumeSessionId into the spawnSession callback options', async () => {
+    const spawnFn = vi.fn().mockResolvedValue({ sessionId: 'inst-id', tmuxSession: 'echo-msg-spawn-2' });
+    const manager = createSpawnManager({ spawnSession: spawnFn });
+
+    const req: SpawnRequest = { ...makeRequest('peer-resume'), resumeSessionId: 'claude-uuid-bbb' };
+    const result = await manager.evaluate(req);
+
+    expect(result.approved).toBe(true);
+    const opts = spawnFn.mock.calls[0][1];
+    expect(opts.resumeSessionId).toBe('claude-uuid-bbb');
+    expect(opts.sessionId).toBeUndefined();
+  });
+
+  it('passes both as undefined on a plain (non-continuity) request', async () => {
+    const spawnFn = vi.fn().mockResolvedValue({ sessionId: 'inst-id', tmuxSession: 'echo-msg-spawn-3' });
+    const manager = createSpawnManager({ spawnSession: spawnFn });
+
+    const result = await manager.evaluate(makeRequest('peer-plain'));
+
+    expect(result.approved).toBe(true);
+    const opts = spawnFn.mock.calls[0][1];
+    expect(opts.sessionId).toBeUndefined();
+    expect(opts.resumeSessionId).toBeUndefined();
+  });
+});

--- a/tests/unit/threadline/ThreadlineRouter.test.ts
+++ b/tests/unit/threadline/ThreadlineRouter.test.ts
@@ -395,6 +395,35 @@ describe('ThreadlineRouter', () => {
       expect(data[threadId].messageCount).toBe(1);
     });
 
+    it('mints a claude session-id, forwards it to evaluate, and saves it as the entry uuid', async () => {
+      // Path-1 continuity: spawnNewThread mints a uuid up front and passes it as
+      // `sessionId` so the headless claude spawn launches with `--session-id <uuid>`.
+      // That EXACT uuid is then stored as the resume-map entry uuid (NOT the instar
+      // session id / a throwaway placeholder), so the next inbound can `--resume`
+      // the real transcript. Previously the entry uuid was a placeholder that never
+      // matched a transcript → every follow-up cold-spawned memoryless.
+      const threadId = crypto.randomUUID();
+      const envelope = makeEnvelope({ threadId, subject: 'Continuity Thread' });
+
+      await router.handleInboundMessage(envelope);
+
+      // The sessionId forwarded to evaluate is a real uuid (claude --session-id).
+      const call = mockSpawnManager.evaluate.mock.calls[0][0];
+      expect(call.sessionId).toMatch(
+        /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/,
+      );
+      // The new-thread path does NOT set resumeSessionId.
+      expect(call.resumeSessionId).toBeUndefined();
+
+      // The saved entry uuid is exactly that minted uuid — NOT spawnResult.sessionId
+      // ('spawned-session-uuid' from the mock) and NOT a throwaway placeholder.
+      // On disk the ThreadResumeEntry.uuid is serialized as `sessionUuid`.
+      const filePath = path.join(temp.stateDir, 'threadline', 'conversations.json');
+      const data = JSON.parse(fs.readFileSync(filePath, 'utf-8')).conversations;
+      expect(data[threadId].sessionUuid).toBe(call.sessionId);
+      expect(data[threadId].sessionUuid).not.toBe('spawned-session-uuid');
+    });
+
     it('includes the spawn prompt with subject and body', async () => {
       const threadId = crypto.randomUUID();
       const envelope = makeEnvelope({
@@ -501,11 +530,17 @@ describe('ThreadlineRouter', () => {
       expect(data[threadId].messageCount).toBe(6); // 5 + 1
     });
 
-    it('includes thread history in resume prompt when available', async () => {
+    it('does NOT re-inject thread history into the resume prompt (the --resume transcript already has it)', async () => {
+      // Path-1 continuity: resumeThread now spawns with `--resume entry.uuid`,
+      // which reloads the FULL prior conversation from the claude-code
+      // transcript on disk. Re-injecting buildHistoryContext would DOUBLE the
+      // history, so the resume prompt must carry only the NEW message (+ relay
+      // grounding when present) — never the old history. This test proves that
+      // even when getThread returns prior messages, they are NOT spliced into
+      // the resume prompt.
       const threadId = crypto.randomUUID();
       threadResumeMap.save(threadId, makeEntry({ uuid: existingUuid }));
 
-      // Set up mock to return thread history
       const historyEnvelope = makeEnvelope({
         threadId,
         body: 'Previous message in this thread',
@@ -524,12 +559,30 @@ describe('ThreadlineRouter', () => {
         messages: [historyEnvelope],
       });
 
-      const envelope = makeEnvelope({ threadId, body: 'New message' });
+      const envelope = makeEnvelope({ threadId, body: 'New resume message' });
       await router.handleInboundMessage(envelope);
 
       const call = mockSpawnManager.evaluate.mock.calls[0][0];
-      expect(call.context).toContain('Previous message in this thread');
-      expect(call.context).toContain('Recent thread history');
+      // The new message IS in the prompt.
+      expect(call.context).toContain('New resume message');
+      // The old history is NOT re-injected (it's already in the resumed transcript).
+      expect(call.context).not.toContain('Previous message in this thread');
+      expect(call.context).not.toContain('Recent thread history');
+      expect(call.context).toContain('No previous history available.');
+    });
+
+    it('forwards resumeSessionId = entry.uuid so the spawn reloads the transcript via --resume', async () => {
+      const threadId = crypto.randomUUID();
+      threadResumeMap.save(threadId, makeEntry({ uuid: existingUuid }));
+
+      const envelope = makeEnvelope({ threadId });
+      await router.handleInboundMessage(envelope);
+
+      const call = mockSpawnManager.evaluate.mock.calls[0][0];
+      // The resume path passes the existing transcript uuid as resumeSessionId.
+      expect(call.resumeSessionId).toBe(existingUuid);
+      // The new-thread continuity field is NOT set on the resume path.
+      expect(call.sessionId).toBeUndefined();
     });
   });
 

--- a/upgrades/next/threadline-a2a-resume-session-id.md
+++ b/upgrades/next/threadline-a2a-resume-session-id.md
@@ -1,0 +1,55 @@
+<!-- bump: patch -->
+
+## Summary of New Capabilities
+
+- **Turn-based agent-to-agent continuity:** a peer agent's follow-up message now resumes the SAME conversation (full prior context) instead of cold-spawning a memoryless reply session.
+
+## What Changed
+
+Path 1 of the Threadline A2A continuity fix. Headless one-shot `claude -p` reply
+sessions never report their session id, so the resume entry kept a placeholder
+uuid and every spaced follow-up cold-spawned (a live Echo↔Dawn round-trip proved
+Resumed=0 even after the prior foundation shipped).
+
+Fix: `ThreadlineRouter.spawnNewThread` now mints a uuid and launches the reply
+session with `claude --session-id <uuid>` (so its transcript is created at exactly
+`<uuid>.jsonl`), persisting that uuid as the thread's resume handle.
+`resumeThread` launches the follow-up with `claude --resume <uuid>` — reloading
+the full prior transcript — and sends only the new message + grounding (the
+transcript already holds the history, so re-injecting it is dropped). The
+`sessionId`/`resumeSessionId` options are threaded through
+`SessionManager.spawnSession` (spliced as `--session-id`/`--resume` into the
+claude-code headless argv before `-p`, mutually exclusive, gated on framework) and
+`SpawnRequestManager`. Additive + gated: every non-A2A spawn is unchanged when the
+options are absent; the stale-uuid resume-crash guard falls back to a fresh spawn.
+
+## Evidence
+
+Verified on this machine, before/after.
+
+**Mechanism (directly verified, 2026-06-04):** `claude --session-id
+a6b1c2d3-…-0002 -p "remember BANANA77"` created the transcript at exactly
+`<that-uuid>.jsonl` (29 lines). `claude --resume <that-uuid> -p "what was the
+secret word?"` grew the SAME transcript to 55 lines and the planted word
+`BANANA77` appears in the resumed transcript (6×) — i.e. `--resume` reloaded the
+full prior conversation. So set-then-resume by a known id gives real continuity.
+
+**Before (live A6 round-trip, `echo-dawn-A6-verify-…`, server on v1.3.239):**
+2× `[relay] Spawned session`, 0× `Resumed`; `onSessionComplete` fired + matched
+the thread ("demoted 1 thread(s)") but `claudeSessionId` POST events = 0, so the
+placeholder uuid was never upgraded → `jsonlExists` failed → cold-spawn.
+
+**After (unit):** spawning with `sessionId` emits `--session-id <uuid>` before
+`-p`; with `resumeSessionId` emits `--resume <uuid>`; neither when absent.
+`spawnNewThread` persists the minted uuid as the entry uuid (not a placeholder);
+`resumeThread` forwards `resumeSessionId = entry.uuid`. tsc clean; 1548
+threadline/fixes/continuity tests green. The live Dawn round-trip showing
+`Resumed` (not `Spawned`) runs post-deploy.
+
+## What to Tell Your User
+
+When another agent and I have a back-and-forth, I now stay in the same
+conversation across messages instead of forgetting between each one — so the
+realistic turn-based exchange (which the upcoming agent-to-agent feedback work
+relies on) holds its thread. It's an internal robustness fix; nothing to turn on.
+The rapid-fire 3-messages-in-10-seconds case is smoothed by a separate follow-up.

--- a/upgrades/side-effects/threadline-a2a-resume-session-id.md
+++ b/upgrades/side-effects/threadline-a2a-resume-session-id.md
@@ -1,0 +1,59 @@
+# Side-Effects Review — Threadline A2A resume via deterministic session-id
+
+**Version / slug:** `threadline-a2a-resume-session-id`
+**Date:** `2026-06-04`
+**Author:** `Echo (instar dev agent)`
+**Second-pass reviewer:** `not required (Tier 1)`
+
+## Summary of the change
+
+Path 1 of the A2A continuity fix. Headless `claude -p` reply sessions never reported their session id, so `onSessionComplete` left the resume entry's uuid as a placeholder and resume-after-exit cold-spawned. Fix: when `ThreadlineRouter.spawnNewThread` spawns the first reply session it mints a uuid and passes it as `claude --session-id <uuid>` (so the transcript is created at exactly `<uuid>.jsonl`), and persists that uuid as the resume entry. `resumeThread` spawns the follow-up with `claude --resume <uuid>` (reloading the full transcript) and a minimal prompt (new message + grounding only — the transcript already holds history). Threaded through: `SessionManager.spawnSession` (new `sessionId?`/`resumeSessionId?` options → `--session-id`/`--resume` spliced into the claude-code headless argv before `-p`, mutually exclusive, gated on framework), `SpawnRequestManager` (forwards both from `SpawnRequest` → callback), the relay `spawnSession` callback in `server.ts`. Files: `src/core/SessionManager.ts`, `src/messaging/SpawnRequestManager.ts`, `src/commands/server.ts`, `src/threadline/ThreadlineRouter.ts` + tests.
+
+## Decision-point inventory
+
+- `SessionManager.spawnSession` headless argv (`src/core/SessionManager.ts`) — **modify (additive)** — splice `--session-id`/`--resume` when the new options are set; no change when absent.
+- `ThreadlineRouter.spawnNewThread` resume-entry uuid (`src/threadline/ThreadlineRouter.ts`) — **modify** — save the real minted uuid instead of the placeholder.
+- `ThreadlineRouter.resumeThread` prompt + spawn (`src/threadline/ThreadlineRouter.ts`) — **modify** — pass `resumeSessionId` + minimal prompt (drop re-injected history).
+- `SpawnRequest`/`SpawnRequestManager.evaluate` forwarding — **modify (additive)** — carry `sessionId`/`resumeSessionId`.
+
+## 1. Over-block
+
+**What legitimate inputs does this change reject that it shouldn't?**
+
+None — no allow/block surface. The flags only set/resume the conversation id. No message is rejected. When the new options are absent (every non-A2A spawn), behavior is unchanged. "No block/allow surface — over-block not applicable."
+
+## 2. Under-block
+
+**What failure modes does this still miss?**
+
+Rapid-fire (multiple messages while the reply session is still running): `--resume` on a still-busy session, or a fresh spawn hitting the 30s cooldown, is unchanged by this slice — that is the warm-session follow-up. Also: a `--resume` against a transcript that was deleted/rotated falls back to a fresh spawn (handled by the existing stale-uuid guard), losing that thread's history — acceptable + lossless beyond history.
+
+## 3. Level-of-abstraction fit
+
+The uuid is minted + owned by `ThreadlineRouter` (which owns the resume entry) and threaded down to the spawn primitive — the right layering. `SessionManager` only learns "set/resume this id," mirroring its existing `--resume` (triage) and `extraClaudeFlags` patterns.
+
+## 4. Signal vs authority compliance
+
+Not a gate/authority change. No approval surface added or relaxed. Trust gates on the inbound path are untouched.
+
+## 5. Interactions
+
+- Builds on shipped slices 1+2 (router finds the live session + real tmux name). With this, `get()`'s `jsonlExists(uuid)` now passes legitimately (the transcript exists at the minted id) → resume path fires for spaced follow-ups.
+- The relay `spawnSession` callback keeps `codexAllowMcpTools: true` + all MCP/permission flags → the A2A worker still replies via `threadline_send`.
+- 1548 threadline/fixes/continuity unit tests pass; tsc clean. One obsolete test (`includes thread history in resume prompt`) replaced — it asserted the now-removed history-re-injection behavior.
+
+## 6. External surfaces
+
+No new HTTP routes, no config defaults, no template/CLAUDE.md change. Pure internal session-lifecycle behavior. Migration-parity: nothing to migrate (no config/hook/template surface).
+
+## 7. Rollback cost
+
+Low — revert the four source files. No persisted-format change (the resume entry already had a `uuid` field; it now holds a real id instead of a placeholder — old placeholder entries simply fail `jsonlExists` and cold-spawn as before). No external dependency.
+
+## Conclusion
+
+Low-risk, additive, deterministic fix that completes the realistic turn-based A2A continuity case on top of the shipped foundation. The mechanism (`--session-id` set + `--resume` reload) was empirically verified before coding. Rapid-fire smoothness is explicitly out of scope.
+
+## Second-pass review (if required)
+
+Not required — Tier 1 (additive, gated, ~single-concern).

--- a/upgrades/threadline-a2a-resume-session-id.eli16.md
+++ b/upgrades/threadline-a2a-resume-session-id.eli16.md
@@ -1,0 +1,28 @@
+# Why agent-to-agent conversations can now actually remember
+
+## The one-sentence version
+When another agent sends me several messages over a conversation, each of my replies used to run as a throwaway that finished and forgot everything — so the next message met a stranger. Now I give each reply session a **known name tag** when it starts, write that tag down, and on the next message I **re-open the exact same conversation by its tag** — so I pick up right where we left off, with the full history.
+
+## What was broken (proven live)
+A real round-trip with Dawn showed every follow-up still cold-spawned a memoryless session. The deep reason: each reply ran as a headless one-shot Claude that **never reports its own session id back to me**, so when it finished I had no handle to reconnect to. My earlier fix made the router *try* to reconnect, but there was nothing to reconnect to.
+
+## The fix (deterministic, no guessing)
+Claude lets you (a) **set** a session's id when you launch it (`--session-id <uuid>`) and (b) **re-open** a session by that id later (`--resume <uuid>`). I verified both directly: setting an id creates the transcript under that exact id, and resuming it reloads the whole prior conversation (I planted a secret word in turn 1 and the resumed session recalled it).
+
+So now:
+- When a peer's first message spawns a reply session, I **mint a fresh id and pass it as `--session-id`**, then store that id as the thread's resume handle.
+- When the next message arrives, I spawn with **`--resume <that id>`** so the session reloads the full prior transcript and continues — and I send it only the new message (the transcript already holds the history, so re-pasting it would just duplicate it).
+
+## The safety rails
+1. **Additive + off by default.** The new options do nothing unless set. Every other kind of session (jobs, your topic sessions, Codex) is byte-for-byte unchanged.
+2. **Claude-code only, and the two flags are mutually exclusive** — a launch either sets a new id or resumes one, never both.
+3. **A stale id can't wedge me.** If a transcript no longer exists, the existing resume-crash guard falls back to a fresh spawn instead of hanging.
+4. **The reply path is untouched.** Setting/resuming the conversation id doesn't change tools or permissions, so the agent still replies normally over the secure channel.
+5. **Built on the shipped foundation** (the router already finds the live session + carries the real session name); this adds the missing piece — the real, resumable id.
+
+## What it does NOT yet fix
+The *rapid-fire* case (three messages in ten seconds, while the reply is still being written) still isn't smooth — that needs the bigger persistent-session work. This fixes the realistic **turn-based** conversation (you reply, I reply, you reply a minute later), which is exactly what the agent-to-agent feedback migration needs.
+
+---
+
+**Rendered (verified) view:** _set below after creating the tunnel view._


### PR DESCRIPTION
## What
Path 1 of the A2A Threadline continuity fix. Builds on the shipped foundation (slices 1+2, v1.3.239): the router now *finds* the live session, but headless one-shot `claude -p` reply sessions never report their session id, so the resume entry kept a placeholder uuid and every spaced follow-up cold-spawned.

## Fix (deterministic — no output parsing, no hook dependency)
- `spawnNewThread` mints a uuid and launches the reply session with `claude --session-id <uuid>` → the transcript is created at exactly `<uuid>.jsonl`. That uuid is persisted as the thread's resume handle.
- `resumeThread` launches the follow-up with `claude --resume <uuid>` → reloads the full prior transcript → continues the conversation. The prompt is the new message + grounding only (the transcript already holds history; re-injecting it is dropped).
- Threaded through `SessionManager.spawnSession` (new `sessionId`/`resumeSessionId` options → `--session-id`/`--resume` spliced into the claude-code headless argv before `-p`, mutually exclusive, framework-gated) and `SpawnRequestManager`. **Additive + gated**: every non-A2A spawn is unchanged when the options are absent; the existing stale-uuid resume-crash guard falls back to a fresh spawn.

## Evidence
**Mechanism (directly verified before coding):** `claude --session-id X -p "remember BANANA77"` created the transcript at `X.jsonl` (29 lines); `claude --resume X -p "what was the word?"` grew the SAME transcript to 55 lines with `BANANA77` recalled — so set-then-resume by a known id gives real continuity.
**Before (live A6):** 2 Spawned / 0 Resumed; `claudeSessionId` POST events = 0.
**After (unit):** argv includes `--session-id`/`--resume` only when set; `spawnNewThread` persists the minted uuid; `resumeThread` forwards `resumeSessionId`. The live Dawn round-trip showing `Resumed` runs post-deploy.

## Tests
tsc clean; 1548 threadline/fixes/continuity unit tests + 331 e2e green. Tier-1 (ELI16 + side-effects + release fragment with Evidence).

## Scope
Fixes the realistic **turn-based** case (the feedback migration needs this). Rapid-fire (3-in-10s) smoothness is a separate warm-session follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)