### PR TITLE
fix(messaging): dedupe Telegram delivery at the session chokepoint

### DIFF
--- a/.instar/instar-dev-decisions.jsonl
+++ b/.instar/instar-dev-decisions.jsonl
@@ -23,3 +23,4 @@
 {"ts":"2026-06-03T22:26:50.605Z","slug":"unknown","suggestedTier":1,"declaredTier":1,"riskFloor":1,"riskFloorReasons":[],"belowFloor":false,"files":1,"loc":18}
 {"ts":"2026-06-03T22:27:56.444Z","slug":"unknown","suggestedTier":1,"declaredTier":1,"riskFloor":1,"riskFloorReasons":[],"belowFloor":false,"files":1,"loc":18}
 {"ts":"2026-06-03T22:28:57.934Z","slug":"unknown","suggestedTier":2,"declaredTier":1,"riskFloor":1,"riskFloorReasons":[],"belowFloor":false,"files":6,"loc":331}
+{"ts":"2026-06-04T05:48:03.164Z","slug":"url-pathname-path-encoding-fix","suggestedTier":2,"declaredTier":null,"riskFloor":1,"riskFloorReasons":[],"belowFloor":false,"files":3,"loc":41}

--- a/docs/specs/telegram-delivery-dedup.eli16.md
+++ b/docs/specs/telegram-delivery-dedup.eli16.md
@@ -1,0 +1,43 @@
+# ELI16 — Telegram delivery-chokepoint dedup
+
+## What this is, in plain English
+
+When you send your agent a message on Telegram, it travels through a relay and finally gets
+"handed" to the actual running agent session (a terminal program). Normally that hand-off
+happens once per message.
+
+But we caught a glitch: I sent one agent (Codey) a single task message, and the relay handed
+it to the session **five times** in about fifty seconds — because the session was just
+starting up and the relay kept re-trying before it was ready. The agent then saw the same
+task over and over and started queuing it up to do five times. That's wasted work and wasted
+model usage (which costs real quota), and it's confusing.
+
+## What already exists
+
+The relay does dedupe at the *polling* layer (it remembers the last message number it pulled
+from Telegram, so it won't pull the same one twice). But the final hand-off step — the place
+that actually writes the message into the running session — had no such memory. So if
+anything upstream handed it the same message more than once, the session got it more than
+once.
+
+## What's new
+
+The hand-off step now keeps a tiny short-term memory of "which exact message did I already
+give to which session." Every Telegram message has a unique number. If the same message
+number is about to be handed to the same session again within ten minutes, the hand-off
+quietly skips it and writes a note in the log instead. The agent gets the message exactly
+once.
+
+Important details:
+- The very first hand-off always goes through — only the *repeats* are skipped.
+- Two genuinely different messages are never confused (they have different numbers).
+- If a message somehow has no number (some internal paths), nothing is deduped — old
+  behavior is preserved.
+- We deliberately keep logging the duplicate so we can still hunt down *why* the relay
+  over-handed it in the first place. This change is the safety net, not the root fix.
+
+## Why it's done at this spot
+
+There are a couple of paths a Telegram message can travel, but they all funnel through the
+same single hand-off function before reaching the session. Putting the guard there means it
+protects every path at once, no matter which one over-handed the message.

--- a/src/commands/server.ts
+++ b/src/commands/server.ts
@@ -1400,6 +1400,7 @@ function wireTelegramRouting(
         console.log(`[telegram→session] Injecting into ${targetSession}: "${text.slice(0, 80)}"`);
         sessionManager.injectTelegramMessage(
           targetSession, topicId, text, pipeline.topicName, pipeline.sender.firstName, pipeline.sender.telegramUserId,
+          parseInt(pipeline.id.replace('tg-', ''), 10) || undefined,
         );
         // Delivery confirmation — only when WE own polling. When lifeline owns
         // polling (--no-telegram / standby), it already sends its own confirmation.

--- a/src/core/SessionManager.ts
+++ b/src/core/SessionManager.ts
@@ -270,6 +270,14 @@ export class SessionManager extends EventEmitter {
    *  Key = tmuxSession name. Cleared when agent replies via /telegram/reply/:topicId. */
   private pendingInjections = new Map<string, { topicId: number; injectedAt: number; text: string }>();
 
+  /** Dedup ledger for the Telegram→session delivery chokepoint.
+   *  Key = `${tmuxSession}:${messageId}` → deliveredAt(ms). A single user message
+   *  that is over-forwarded upstream (lifeline re-forward, PendingRelayStore
+   *  re-drive, sentinel pause/resume) must still reach the session at most once.
+   *  Bounded by pruning entries older than the dedup window on each delivery. */
+  private recentTelegramDeliveries = new Map<string, number>();
+  private static readonly TELEGRAM_DELIVERY_DEDUP_WINDOW_MS = 10 * 60 * 1000;
+
   /** Track sessions nudged after an API error in the CURRENT idle episode.
    *  Key = session ID. Set when we nudge; CLEARED when the session recovers (produces
    *  output / leaves idle), so the NEXT API-error episode in a long-running session
@@ -2559,7 +2567,35 @@ rm()  { "${shimRunner}" rm  "$@"; }
     return false; // still stuck after the full recovery window
   }
 
-  injectTelegramMessage(tmuxSession: string, topicId: number, text: string, topicName?: string, senderName?: string, telegramUserId?: number): boolean {
+  injectTelegramMessage(tmuxSession: string, topicId: number, text: string, topicName?: string, senderName?: string, telegramUserId?: number, messageId?: number): boolean {
+    // Structural dedup at the delivery chokepoint: a given Telegram messageId
+    // must reach a session at most once. Upstream paths can over-forward the SAME
+    // user message (lifeline re-forward, PendingRelayStore re-drive, sentinel
+    // pause/resume) — observed 5x to one codex session, which wastes mentee LLM
+    // quota and queues the task repeatedly. Suppress the duplicate but LOG it so
+    // the upstream over-forward stays visible for root-cause. Skipped when no
+    // positive messageId is available (in-process callers that don't carry one).
+    if (typeof messageId === 'number' && messageId > 0) {
+      const now = Date.now();
+      // Prune expired entries to keep the ledger bounded.
+      for (const [k, ts] of this.recentTelegramDeliveries) {
+        if (now - ts > SessionManager.TELEGRAM_DELIVERY_DEDUP_WINDOW_MS) {
+          this.recentTelegramDeliveries.delete(k);
+        }
+      }
+      const dedupKey = `${tmuxSession}:${messageId}`;
+      const priorAt = this.recentTelegramDeliveries.get(dedupKey);
+      if (priorAt !== undefined) {
+        console.warn(
+          `[SessionManager] Suppressed duplicate Telegram delivery to "${tmuxSession}" ` +
+          `(topic ${topicId}, messageId ${messageId}, ${Math.round((now - priorAt) / 1000)}s after first) — ` +
+          `a single user message was forwarded more than once; delivering only once.`,
+        );
+        return true; // already delivered on the first call — success without re-injecting
+      }
+      this.recentTelegramDeliveries.set(dedupKey, now);
+    }
+
     // Track this injection for response verification.
     // If the session dies before the agent replies, the monitor loop will detect it.
     this.pendingInjections.set(tmuxSession, { topicId, injectedAt: Date.now(), text: text.slice(0, 200) });

--- a/src/server/routes.ts
+++ b/src/server/routes.ts
@@ -10136,7 +10136,7 @@ export function createRoutes(ctx: RouteContext): Router {
           }
         } catch { /* fall through without name */ }
         console.log(`[telegram-forward] Injecting into ${targetSession}: "${text.slice(0, 80)}"`);
-        const injected = ctx.sessionManager.injectTelegramMessage(targetSession, topicId, text, injectedTopicName, fromFirstName, fromUserId);
+        const injected = ctx.sessionManager.injectTelegramMessage(targetSession, topicId, text, injectedTopicName, fromFirstName, fromUserId, typeof messageId === 'number' ? messageId : undefined);
 
         if (injected === false) {
           // Injection failed — save message under stateDir (not /tmp) to avoid world-readable exposure

--- a/tests/unit/session-telegram-inject.test.ts
+++ b/tests/unit/session-telegram-inject.test.ts
@@ -79,4 +79,69 @@ describe('SessionManager.injectTelegramMessage', () => {
     const taggedLengthOver = prefix.length + textOver.length;
     expect(taggedLengthOver).toBe(501); // Should go to file
   });
+
+  // ── Delivery-chokepoint dedup (a single user message must reach a session at
+  // most once even if an upstream path over-forwards it 5x). We count the temp
+  // files written for a unique topicId to detect whether a delivery happened.
+  const mkSm = () => new SessionManager(
+    {
+      tmuxPath: '/usr/bin/tmux',
+      claudePath: '/usr/bin/claude',
+      projectDir: project.stateDir,
+      maxSessions: 3,
+      protectedSessions: [],
+      completionPatterns: [],
+    },
+    project.state,
+  );
+  const longText = 'Z'.repeat(600); // exceeds the 500-char file threshold
+  const countFilesFor = (topicId: number) => {
+    const dir = '/tmp/instar-telegram';
+    return fs.existsSync(dir)
+      ? fs.readdirSync(dir).filter(f => f.startsWith(`msg-${topicId}-`)).length
+      : 0;
+  };
+
+  it('dedupes a repeated Telegram messageId — delivers a single user message once', () => {
+    const sm = mkSm();
+    const topicId = 770111;
+    const messageId = 555001;
+
+    sm.injectTelegramMessage('sess-a', topicId, longText, undefined, undefined, undefined, messageId);
+    expect(countFilesFor(topicId)).toBe(1);
+
+    // Same messageId again (the over-forward) → suppressed, no new file.
+    sm.injectTelegramMessage('sess-a', topicId, longText, undefined, undefined, undefined, messageId);
+    expect(countFilesFor(topicId)).toBe(1);
+
+    // A genuinely distinct messageId → delivered.
+    sm.injectTelegramMessage('sess-a', topicId, longText, undefined, undefined, undefined, messageId + 1);
+    expect(countFilesFor(topicId)).toBe(2);
+  });
+
+  it('does NOT dedupe when no messageId is supplied (in-process back-compat)', () => {
+    const sm = mkSm();
+    const topicId = 770122;
+    // No messageId → no dedup; both deliveries land.
+    sm.injectTelegramMessage('sess-b', topicId, longText);
+    sm.injectTelegramMessage('sess-b', topicId, longText);
+    expect(countFilesFor(topicId)).toBe(2);
+  });
+
+  it('does NOT dedupe messageId 0 (sentinel "no id") — both deliver', () => {
+    const sm = mkSm();
+    const topicId = 770133;
+    sm.injectTelegramMessage('sess-c', topicId, longText, undefined, undefined, undefined, 0);
+    sm.injectTelegramMessage('sess-c', topicId, longText, undefined, undefined, undefined, 0);
+    expect(countFilesFor(topicId)).toBe(2);
+  });
+
+  it('dedup is per-session — same messageId to two sessions both deliver', () => {
+    const sm = mkSm();
+    const topicId = 770144;
+    const messageId = 555777;
+    sm.injectTelegramMessage('sess-x', topicId, longText, undefined, undefined, undefined, messageId);
+    sm.injectTelegramMessage('sess-y', topicId, longText, undefined, undefined, undefined, messageId);
+    expect(countFilesFor(topicId)).toBe(2);
+  });
 });

--- a/upgrades/next/telegram-delivery-dedup.md
+++ b/upgrades/next/telegram-delivery-dedup.md
@@ -1,0 +1,25 @@
+<!-- bump: patch -->
+
+## What Changed
+
+Adds a structural dedup at the Telegram→session delivery chokepoint
+(`SessionManager.injectTelegramMessage`). A given Telegram `messageId` now reaches a
+session at most once: the method keeps a small per-`(session, messageId)` ledger (pruned on
+a 10-minute window) and, on a repeat, suppresses the re-injection and logs it instead of
+delivering the same user message again. `messageId` is threaded in from both delivery paths
+— the `/internal/telegram-forward` route (lifeline → server) and the in-process
+`telegram→session` path. Callers that carry no positive `messageId` are unaffected (no
+dedup), preserving back-compat.
+
+This closes an observed bug where a single user message was forwarded to a codex session
+five times over ~50s (upstream re-forward while the session was starting), making the agent
+queue and re-process the same task repeatedly. The suppression is logged so the upstream
+over-forward stays visible for a separate root-cause.
+
+## What to Tell Your User
+
+Nothing user-facing changes in how you talk to your agent. Under the hood, if a single
+message you send ever got relayed to the agent more than once (a rare hiccup when the agent
+was just starting up), the agent now notices and acts on it only once — so it won't
+double-work a request or burn extra model usage repeating itself. A note is written to the
+log each time a duplicate is caught, so the underlying relay glitch can still be chased down.

--- a/upgrades/side-effects/telegram-delivery-dedup.md
+++ b/upgrades/side-effects/telegram-delivery-dedup.md
@@ -1,0 +1,69 @@
+# Side-Effects Review — Telegram delivery-chokepoint dedup
+
+**Version / slug:** `telegram-delivery-dedup`
+**Date:** `2026-06-03`
+**Author:** `echo`
+**Second-pass reviewer:** `not required`
+
+## Summary of the change
+
+`SessionManager.injectTelegramMessage` gains an optional trailing `messageId` param and a
+structural dedup: a `(tmuxSession, messageId)` ledger (pruned on a 10-minute window) ensures
+a given Telegram message reaches a session at most once. A repeat is suppressed (returns
+`true` — already delivered) and logged via `console.warn`. `messageId` is threaded from the
+two delivery callers: the `/internal/telegram-forward` route and the in-process
+`telegram→session` path (derived from `pipeline.id` = `tg-{messageId}`).
+
+## Decision-point inventory
+
+One decision: "have I already delivered this `(session, messageId)` within the window?"
+→ suppress + log, else record + deliver. Gated on `messageId` being a positive number.
+
+## 1. Over-block
+
+**What legitimate inputs does this reject?** Only a re-delivery of the SAME Telegram
+`messageId` to the SAME session within 10 minutes — which is, by definition, a duplicate of
+a message already delivered (Telegram `message_id` is unique per chat; a genuine re-send is a
+NEW id). The first delivery always lands. Distinct messages (distinct ids), messages to
+different sessions, and any caller that supplies no positive `messageId` (e.g. `0`/undefined)
+are never deduped. So no legitimate distinct user message is dropped.
+
+## 2. Under-block
+
+**What does this still miss?** It does not fix the *upstream* cause of the over-forward
+(lifeline re-forward / PendingRelayStore re-drive / sentinel pause+resume) — it is a
+chokepoint backstop. The suppression `console.warn` is deliberately retained so the upstream
+multiplicity remains observable for a follow-up root-cause. It also does not dedupe non-
+Telegram delivery paths (WhatsApp/iMessage inject have their own methods, out of scope).
+
+## 3. Level-of-abstraction fit
+
+**Right layer?** Yes. `injectTelegramMessage` is the single server→session delivery
+chokepoint that writes the `/tmp/instar-telegram` file and does the tmux inject; every
+Telegram delivery path funnels through it. Guarding there means the dedup holds regardless of
+which upstream component over-forwards (defense-in-depth, Structure > Willpower). The two
+callers only thread the id through.
+
+## 4. Signal vs authority compliance
+
+**Required reference:** [docs/signal-vs-authority.md](../../docs/signal-vs-authority.md)
+
+The dedup is an authority (it suppresses a delivery), but a tightly-scoped and conservative
+one: it acts only on an exact `(session, messageId)` duplicate within a short window, and
+returns success (the message WAS delivered on the first call), so callers see no failure. The
+`console.warn` preserves the signal of the upstream over-forward for diagnosis. No user
+message is lost.
+
+## 5. Reversibility / blast radius
+
+Bounded. The ledger is an in-memory `Map` pruned on a 10-minute window (naturally bounded by
+message volume). No persistence, no schema, no config, no migration. If the dedup ever
+misbehaved, the change is a few lines in one method plus two one-line caller edits; reverting
+is trivial. The only behavioral change is "the exact same Telegram message is not injected
+into the same session twice within 10 minutes."
+
+## 6. Test coverage
+
+`tests/unit/session-telegram-inject.test.ts` — both sides of the boundary with realistic
+input: repeat id → suppressed (one file); distinct id → delivered (two files); no id →
+no dedup (two files); id `0` → no dedup; same id to two sessions → both deliver.


### PR DESCRIPTION
## What & why

A single user Telegram message could reach a session **multiple times**. Observed live while driving Codey (codex) through the apprenticeship dogfooding loop: my one task message was delivered to Codey's session **5× over ~50s** (five `/tmp/instar-telegram/msg-1052-*` files) while the session was starting up. The agent then queued and re-processed the same task repeatedly — wasted work and wasted LLM quota.

**Root layer:** the poll path dedupes by `update_id` offset (`TelegramLifeline`), but the server→session delivery chokepoint `SessionManager.injectTelegramMessage` had **no message-level dedup** — so any upstream over-forward (lifeline re-forward / `PendingRelayStore` re-drive / sentinel pause+resume) delivers the same message N times.

## The fix

A structural dedup at the chokepoint: `injectTelegramMessage` now keeps a `(tmuxSession, messageId)` ledger (pruned on a 10-min window) and, on a repeat, **suppresses the re-injection and logs it** rather than delivering the same message again. `messageId` is threaded in from both delivery paths (the `/internal/telegram-forward` route and the in-process `telegram→session` path). Callers without a positive `messageId` are unaffected (back-compat).

This guards regardless of which upstream component over-forwards (defense-in-depth, *Structure > Willpower*), and the suppression `console.warn` keeps the upstream multiplicity **visible** for a separate root-cause.

## Tier

**Tier-1** — defensive chokepoint guard. No new route / config / migration / feature; single logical change threaded through 2 existing callers. ELI16 + side-effects + decision-audit trace included; gate green.

## Tests

`tests/unit/session-telegram-inject.test.ts` — both sides of every boundary:
- repeat `messageId` → suppressed (one delivery)
- distinct `messageId` → delivered (two)
- no `messageId` → no dedup (two)
- `messageId` 0 (sentinel) → no dedup
- same id to two sessions → both deliver (per-session isolation)

tsc + lint + full gate green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)