### PR TITLE
fix(server): guard duplicate response sends

### DIFF
--- a/.instar/instar-dev-traces/2026-06-04T05-46-05-000Z-double-send-route-guard.json
+++ b/.instar/instar-dev-traces/2026-06-04T05-46-05-000Z-double-send-route-guard.json
@@ -1,0 +1,23 @@
+{
+  "version": 2,
+  "sessionId": "telegram-1052-double-send-route-guard",
+  "timestamp": "2026-06-04T05:46:05.000Z",
+  "phase": "complete",
+  "tier": 1,
+  "declaredTier": 1,
+  "tierReasoning": "Server response-safety bug fix with no new route, config, migration, or capability surface. Runtime behavior changes only after a response is already committed; the first response remains authoritative.",
+  "eli16Path": "upgrades/double-send-route-guard.eli16.md",
+  "sideEffectsPath": "upgrades/side-effects/double-send-route-guard.md",
+  "artifactPath": "upgrades/side-effects/double-send-route-guard.md",
+  "artifactSha256": "73291697dff3accff609e863c80fecc9a0567cc7d148e0da178bf67ae0c4589e",
+  "coveredFiles": [
+    "src/server/AgentServer.ts",
+    "src/server/middleware.ts",
+    "tests/unit/duplicate-response-guard.test.ts",
+    "tests/unit/route-double-send-audit.test.ts",
+    "upgrades/double-send-route-guard.eli16.md",
+    "upgrades/next/double-send-route-guard.md",
+    "upgrades/side-effects/double-send-route-guard.md"
+  ],
+  "summary": "Adds a duplicate-response Express guard, hardens the shared error handler for late errors after committed responses, and adds runtime plus source-audit tests for the missing-return double-send class."
+}

--- a/src/data/builtin-manifest.json
+++ b/src/data/builtin-manifest.json
@@ -1,8 +1,8 @@
 {
   "$schema": "./builtin-manifest.schema.json",
   "schemaVersion": 1,
-  "generatedAt": "2026-06-04T04:02:11.346Z",
-  "instarVersion": "1.3.237",
+  "generatedAt": "2026-06-04T05:48:37.165Z",
+  "instarVersion": "1.3.239",
   "entryCount": 198,
   "entries": {
     "hook:session-start": {
@@ -1498,7 +1498,7 @@
       "type": "subsystem",
       "domain": "server",
       "sourcePath": "src/server/AgentServer.ts",
-      "contentHash": "aef725dff8db8e03973977c8d962c87bc678a4c21cfc39cd54c763331e830137",
+      "contentHash": "460b355d5c71dbedcb2118219eded0b68018dc47d51ff74d8b9cad2f715c6982",
       "since": "2025-01-01"
     },
     "subsystem:session-manager": {

--- a/src/server/AgentServer.ts
+++ b/src/server/AgentServer.ts
@@ -59,7 +59,7 @@ import { createUsherRoutes } from './usherRoutes.js';
 import { createHandoffInitiateRoutes } from './handoffInitiateRoutes.js';
 import type { TopicIntentStore } from '../core/TopicIntent.js';
 import type { WorktreeManager } from '../core/WorktreeManager.js';
-import { corsMiddleware, authMiddleware, requestTimeout, buildRequestTimeoutOverrides, errorHandler, dashboardSecurityHeaders } from './middleware.js';
+import { corsMiddleware, authMiddleware, requestTimeout, buildRequestTimeoutOverrides, errorHandler, dashboardSecurityHeaders, duplicateResponseGuard } from './middleware.js';
 import { WebSocketManager } from './WebSocketManager.js';
 import { assertSqliteAvailable, PendingRelayStore } from '../messaging/pending-relay-store.js';
 import { getOrCreateBootId } from './boot-id.js';
@@ -437,6 +437,7 @@ export class AgentServer {
 
     // Middleware
     this.app.use(express.json({ limit: '12mb' }));
+    this.app.use(duplicateResponseGuard);
     this.app.use(corsMiddleware);
 
     // Dashboard security headers — set before static serving so they apply to all dashboard responses

--- a/src/server/middleware.ts
+++ b/src/server/middleware.ts
@@ -5,6 +5,49 @@
 import type { Request, Response, NextFunction } from 'express';
 import { createHash, createHmac, timingSafeEqual } from 'node:crypto';
 
+const guardedResponses = new WeakSet<Response>();
+const GUARDED_RESPONSE_METHODS = ['json', 'send', 'sendStatus', 'redirect', 'download', 'sendFile'] as const;
+
+function responseAlreadyCommitted(res: Response): boolean {
+  return res.headersSent || res.writableEnded;
+}
+
+function logDuplicateResponse(req: Request, method: string): void {
+  const stack = new Error().stack?.split('\n').slice(2).join('\n');
+  console.warn(
+    `[server] Suppressed duplicate response send: ${req.method} ${req.originalUrl || req.url} via res.${method}()`
+    + (stack ? `\n${stack}` : ''),
+  );
+}
+
+/**
+ * Prevent a late duplicate Express response from throwing
+ * ERR_HTTP_HEADERS_SENT after a handler has already committed a response.
+ *
+ * This is a last-resort process guard; route handlers should still return
+ * immediately after early response branches.
+ */
+export function duplicateResponseGuard(req: Request, res: Response, next: NextFunction): void {
+  if (guardedResponses.has(res)) {
+    next();
+    return;
+  }
+  guardedResponses.add(res);
+
+  for (const method of GUARDED_RESPONSE_METHODS) {
+    const original = res[method].bind(res) as (...args: unknown[]) => Response;
+    (res[method] as unknown as (...args: unknown[]) => Response) = (...args: unknown[]) => {
+      if (responseAlreadyCommitted(res)) {
+        logDuplicateResponse(req, method);
+        return res;
+      }
+      return original(...args);
+    };
+  }
+
+  next();
+}
+
 export function corsMiddleware(req: Request, res: Response, next: NextFunction): void {
   // Restrict CORS to localhost origins only — this is a local management API
   const origin = req.headers.origin;
@@ -420,9 +463,17 @@ export function dashboardSecurityHeaders(req: Request, res: Response, next: Next
   next();
 }
 
-export function errorHandler(err: unknown, _req: Request, res: Response, _next: NextFunction): void {
+export function errorHandler(err: unknown, req: Request, res: Response, _next: NextFunction): void {
   const message = err instanceof Error ? err.message : String(err);
-  console.error(`[server] Error: ${message}`);
+  const stack = err instanceof Error ? err.stack : undefined;
+  if (responseAlreadyCommitted(res)) {
+    console.warn(
+      `[server] Error after response was already sent for ${req.method} ${req.originalUrl || req.url}: ${message}`
+      + (stack ? `\n${stack}` : ''),
+    );
+    return;
+  }
+  console.error(`[server] Error: ${message}` + (stack ? `\n${stack}` : ''));
   // Never leak internal error details to clients
   res.status(500).json({
     error: 'Internal server error',

--- a/tests/unit/duplicate-response-guard.test.ts
+++ b/tests/unit/duplicate-response-guard.test.ts
@@ -1,0 +1,44 @@
+import express from 'express';
+import request from 'supertest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { duplicateResponseGuard, errorHandler } from '../../src/server/middleware.js';
+
+describe('duplicateResponseGuard', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('suppresses a direct second JSON send after a response is committed', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const app = express();
+    app.use(duplicateResponseGuard);
+    app.get('/double-send', (_req, res) => {
+      res.json({ first: true });
+      expect(() => res.status(500).json({ second: true })).not.toThrow();
+    });
+    app.use(errorHandler);
+
+    const res = await request(app).get('/double-send');
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ first: true });
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('Suppressed duplicate response send'));
+  });
+
+  it('does not emit a second 500 when an error arrives after a response was sent', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const app = express();
+    app.use(duplicateResponseGuard);
+    app.get('/sent-then-error', (_req, res, next) => {
+      res.json({ ok: true });
+      next(new Error('late handler failure'));
+    });
+    app.use(errorHandler);
+
+    const res = await request(app).get('/sent-then-error');
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ ok: true });
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('Error after response was already sent'));
+  });
+});

--- a/tests/unit/route-double-send-audit.test.ts
+++ b/tests/unit/route-double-send-audit.test.ts
@@ -1,0 +1,150 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import ts from 'typescript';
+import { describe, expect, it } from 'vitest';
+
+const routeMethods = new Set(['get', 'post', 'put', 'patch', 'delete', 'use']);
+const responseMethods = new Set(['json', 'send', 'sendStatus', 'redirect', 'download', 'sendFile']);
+
+interface Finding {
+  file: string;
+  line: number;
+  snippet: string;
+}
+
+function isRouteRegistration(node: ts.CallExpression): boolean {
+  const expr = node.expression;
+  return ts.isPropertyAccessExpression(expr) && routeMethods.has(expr.name.text);
+}
+
+function isResponseSend(node: ts.Node): boolean {
+  if (!ts.isCallExpression(node)) return false;
+  const expr = node.expression;
+  if (!ts.isPropertyAccessExpression(expr) || !responseMethods.has(expr.name.text)) return false;
+
+  let base: ts.Expression = expr.expression;
+  while (ts.isCallExpression(base) || ts.isPropertyAccessExpression(base)) {
+    base = ts.isCallExpression(base) ? base.expression : base.expression;
+  }
+  return ts.isIdentifier(base) && base.text === 'res';
+}
+
+function nodeHasResponseSend(node: ts.Node): boolean {
+  let found = false;
+  const visit = (child: ts.Node): void => {
+    if (isResponseSend(child)) {
+      found = true;
+      return;
+    }
+    if (!found) ts.forEachChild(child, visit);
+  };
+  visit(node);
+  return found;
+}
+
+function statementHasDirectResponseSend(statement: ts.Statement): boolean {
+  if (ts.isExpressionStatement(statement)) return nodeHasResponseSend(statement.expression);
+  if (ts.isReturnStatement(statement) && statement.expression) return nodeHasResponseSend(statement.expression);
+  return false;
+}
+
+function statementIsTerminal(statement: ts.Statement): boolean {
+  return ts.isReturnStatement(statement) || ts.isThrowStatement(statement);
+}
+
+function branchSendsWithoutReturn(statement: ts.Statement): boolean {
+  const statements = ts.isBlock(statement) ? [...statement.statements] : [statement];
+  for (let index = 0; index < statements.length; index += 1) {
+    const current = statements[index];
+    if (statementIsTerminal(current)) continue;
+    if (!statementHasDirectResponseSend(current)) continue;
+    return !statements.slice(index + 1).some(statementIsTerminal);
+  }
+  return false;
+}
+
+function laterStatementsSend(statements: readonly ts.Statement[], index: number): boolean {
+  for (const later of statements.slice(index + 1)) {
+    if (statementIsTerminal(later)) return false;
+    if (statementHasDirectResponseSend(later)) return true;
+  }
+  return false;
+}
+
+function findMissingReturnDoubleSends(sourceText: string, file: string): Finding[] {
+  const source = ts.createSourceFile(file, sourceText, ts.ScriptTarget.Latest, true, ts.ScriptKind.TS);
+  const findings: Finding[] = [];
+
+  const inspectHandler = (handler: ts.Node): void => {
+    if (!ts.isArrowFunction(handler) && !ts.isFunctionExpression(handler)) return;
+    if (!ts.isBlock(handler.body)) return;
+
+    const statements = [...handler.body.statements];
+    for (let index = 0; index < statements.length; index += 1) {
+      const statement = statements[index];
+      if (!ts.isIfStatement(statement)) continue;
+      const unsafeBranch =
+        branchSendsWithoutReturn(statement.thenStatement)
+        || (statement.elseStatement ? branchSendsWithoutReturn(statement.elseStatement) : false);
+      if (!unsafeBranch || !laterStatementsSend(statements, index)) continue;
+
+      const pos = source.getLineAndCharacterOfPosition(statement.getStart(source));
+      findings.push({
+        file,
+        line: pos.line + 1,
+        snippet: statement.getText(source).split('\n').slice(0, 6).join('\n'),
+      });
+    }
+  };
+
+  const visit = (node: ts.Node): void => {
+    if (ts.isCallExpression(node) && isRouteRegistration(node)) {
+      for (const arg of node.arguments) inspectHandler(arg);
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(source);
+
+  return findings;
+}
+
+function sourceFiles(): string[] {
+  const roots = ['src/server', 'src/moltbridge', 'src/messaging/backends'];
+  const files: string[] = [];
+  const walk = (dir: string): void => {
+    if (!fs.existsSync(dir)) return;
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      const fullPath = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        walk(fullPath);
+      } else if (entry.isFile() && fullPath.endsWith('.ts')) {
+        files.push(fullPath);
+      }
+    }
+  };
+  for (const root of roots) walk(root);
+  return files.sort();
+}
+
+describe('route double-send source audit', () => {
+  it('detects the missing-return early-response shape', () => {
+    const fixture = `
+      router.get('/bad', (req, res) => {
+        if (!req.query.id) {
+          res.status(400).json({ error: 'id required' });
+        }
+        res.json({ ok: true });
+      });
+    `;
+
+    expect(findMissingReturnDoubleSends(fixture, 'fixture.ts')).toHaveLength(1);
+  });
+
+  it('keeps src/server route handlers free of missing-return double sends', () => {
+    const findings = sourceFiles().flatMap((file) =>
+      findMissingReturnDoubleSends(fs.readFileSync(path.resolve(file), 'utf8'), file)
+    );
+
+    expect(findings).toEqual([]);
+  });
+});

--- a/tests/unit/route-double-send-audit.test.ts
+++ b/tests/unit/route-double-send-audit.test.ts
@@ -1,0 +1,140 @@
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+import ts from 'typescript';
+import { describe, expect, it } from 'vitest';
+
+const routeMethods = new Set(['get', 'post', 'put', 'patch', 'delete', 'use']);
+const responseMethods = new Set(['json', 'send', 'sendStatus', 'redirect', 'download', 'sendFile']);
+
+interface Finding {
+  file: string;
+  line: number;
+  snippet: string;
+}
+
+function isRouteRegistration(node: ts.CallExpression): boolean {
+  const expr = node.expression;
+  return ts.isPropertyAccessExpression(expr) && routeMethods.has(expr.name.text);
+}
+
+function isResponseSend(node: ts.Node): boolean {
+  if (!ts.isCallExpression(node)) return false;
+  const expr = node.expression;
+  if (!ts.isPropertyAccessExpression(expr) || !responseMethods.has(expr.name.text)) return false;
+
+  let base: ts.Expression = expr.expression;
+  while (ts.isCallExpression(base) || ts.isPropertyAccessExpression(base)) {
+    base = ts.isCallExpression(base) ? base.expression : base.expression;
+  }
+  return ts.isIdentifier(base) && base.text === 'res';
+}
+
+function nodeHasResponseSend(node: ts.Node): boolean {
+  let found = false;
+  const visit = (child: ts.Node): void => {
+    if (isResponseSend(child)) {
+      found = true;
+      return;
+    }
+    if (!found) ts.forEachChild(child, visit);
+  };
+  visit(node);
+  return found;
+}
+
+function statementHasDirectResponseSend(statement: ts.Statement): boolean {
+  if (ts.isExpressionStatement(statement)) return nodeHasResponseSend(statement.expression);
+  if (ts.isReturnStatement(statement) && statement.expression) return nodeHasResponseSend(statement.expression);
+  return false;
+}
+
+function statementIsTerminal(statement: ts.Statement): boolean {
+  return ts.isReturnStatement(statement) || ts.isThrowStatement(statement);
+}
+
+function branchSendsWithoutReturn(statement: ts.Statement): boolean {
+  const statements = ts.isBlock(statement) ? [...statement.statements] : [statement];
+  for (let index = 0; index < statements.length; index += 1) {
+    const current = statements[index];
+    if (statementIsTerminal(current)) continue;
+    if (!statementHasDirectResponseSend(current)) continue;
+    return !statements.slice(index + 1).some(statementIsTerminal);
+  }
+  return false;
+}
+
+function laterStatementsSend(statements: readonly ts.Statement[], index: number): boolean {
+  for (const later of statements.slice(index + 1)) {
+    if (statementIsTerminal(later)) return false;
+    if (statementHasDirectResponseSend(later)) return true;
+  }
+  return false;
+}
+
+function findMissingReturnDoubleSends(sourceText: string, file: string): Finding[] {
+  const source = ts.createSourceFile(file, sourceText, ts.ScriptTarget.Latest, true, ts.ScriptKind.TS);
+  const findings: Finding[] = [];
+
+  const inspectHandler = (handler: ts.Node): void => {
+    if (!ts.isArrowFunction(handler) && !ts.isFunctionExpression(handler)) return;
+    if (!ts.isBlock(handler.body)) return;
+
+    const statements = [...handler.body.statements];
+    for (let index = 0; index < statements.length; index += 1) {
+      const statement = statements[index];
+      if (!ts.isIfStatement(statement)) continue;
+      const unsafeBranch =
+        branchSendsWithoutReturn(statement.thenStatement)
+        || (statement.elseStatement ? branchSendsWithoutReturn(statement.elseStatement) : false);
+      if (!unsafeBranch || !laterStatementsSend(statements, index)) continue;
+
+      const pos = source.getLineAndCharacterOfPosition(statement.getStart(source));
+      findings.push({
+        file,
+        line: pos.line + 1,
+        snippet: statement.getText(source).split('\n').slice(0, 6).join('\n'),
+      });
+    }
+  };
+
+  const visit = (node: ts.Node): void => {
+    if (ts.isCallExpression(node) && isRouteRegistration(node)) {
+      for (const arg of node.arguments) inspectHandler(arg);
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(source);
+
+  return findings;
+}
+
+function sourceFiles(): string[] {
+  const output = execFileSync('rg', ['--files', 'src/server', 'src/moltbridge', 'src/messaging/backends', '-g', '*.ts'], {
+    encoding: 'utf8',
+  });
+  return output.trim().split('\n').filter(Boolean);
+}
+
+describe('route double-send source audit', () => {
+  it('detects the missing-return early-response shape', () => {
+    const fixture = `
+      router.get('/bad', (req, res) => {
+        if (!req.query.id) {
+          res.status(400).json({ error: 'id required' });
+        }
+        res.json({ ok: true });
+      });
+    `;
+
+    expect(findMissingReturnDoubleSends(fixture, 'fixture.ts')).toHaveLength(1);
+  });
+
+  it('keeps src/server route handlers free of missing-return double sends', () => {
+    const findings = sourceFiles().flatMap((file) =>
+      findMissingReturnDoubleSends(fs.readFileSync(path.resolve(file), 'utf8'), file)
+    );
+
+    expect(findings).toEqual([]);
+  });
+});

--- a/upgrades/double-send-route-guard.eli16.md
+++ b/upgrades/double-send-route-guard.eli16.md
@@ -1,0 +1,26 @@
+# ELI16 — Double-send route guard
+
+Some server routes can accidentally send an HTTP response and then keep running. If later code tries
+to send another response, Express throws the familiar "Cannot set headers after they are sent to the
+client" error. The original bug is usually a missing `return` after an early `res.json()` or
+`res.status(...).json()` branch.
+
+This change adds two protections.
+
+First, the server now installs a duplicate-response guard before routes run. If a handler has already
+committed a response and later tries to send another JSON/send-style response, the guard logs the
+duplicate with a stack and suppresses the second send instead of letting it throw through the request
+path.
+
+Second, the central Express error handler now checks whether the response was already sent. If an
+error arrives after a route has already replied, it logs the late error with stack context and returns
+without trying to send a second 500 response.
+
+There is also a source-level audit test for the classic missing-return shape: an early branch that
+sends a response without returning, followed by a later direct response in the same route handler. The
+test includes a bad fixture to prove the detector catches the pattern, then scans the current server
+route sources to keep that shape out.
+
+This does not change successful API responses. It only changes what happens after code tries to send
+again after a response is already committed: the server logs the mistake and preserves the first
+response.

--- a/upgrades/next/double-send-route-guard.md
+++ b/upgrades/next/double-send-route-guard.md
@@ -1,0 +1,23 @@
+<!-- bump: patch -->
+
+## What Changed
+
+Adds a duplicate-response guard around Express JSON/send-style response methods and hardens the shared
+error handler so late errors after an already-sent response are logged instead of attempting a second
+500 response. A source-level route audit test now guards the classic missing-return shape where an
+early response branch falls through to a later direct response.
+
+Evidence: `tests/unit/duplicate-response-guard.test.ts`, `tests/unit/route-double-send-audit.test.ts`.
+Side-effects review: `upgrades/side-effects/double-send-route-guard.md`.
+
+## What to Tell Your User
+
+Instar now has a server-side safety net for accidental duplicate HTTP replies. If a route sends a
+response and then a late error path tries to send another one, the server logs the duplicate attempt
+instead of crashing that request path.
+
+## Summary of New Capabilities
+
+| Capability | How to Use |
+|-----------|-----------|
+| Duplicate response suppression | Automatic for server routes |

--- a/upgrades/side-effects/double-send-route-guard.md
+++ b/upgrades/side-effects/double-send-route-guard.md
@@ -1,0 +1,66 @@
+# Side-Effects Review — Double-send route guard
+
+Slug: `double-send-route-guard`
+
+## Summary
+
+Adds a last-resort Express duplicate-response guard and hardens the shared error handler against
+late errors after a response has already been committed. Adds regression coverage for both runtime
+paths and a source-level audit test for the classic missing-return route pattern.
+
+## Decision inventory
+
+- New runtime decision: if `res.headersSent` or `res.writableEnded` is already true, suppress a later
+  `res.json`, `res.send`, `res.sendStatus`, `res.redirect`, `res.download`, or `res.sendFile` call
+  and log it.
+- New error-handler decision: if an error reaches `errorHandler` after the response is committed, log
+  the late error and do not attempt a second 500 response.
+- New test-time decision: a route source audit flags a direct early branch response without a return
+  when a later direct handler response exists.
+
+## Over-block
+
+The guard only activates after the response is already committed. It does not block the first
+response, does not reject requests, and does not change status codes on normal paths. It may suppress
+a second response attempt that a caller previously saw as a thrown server error, but that second
+response was never valid HTTP behavior.
+
+## Under-block
+
+The guard does not make route fallthrough logically correct; it prevents the process/request path from
+throwing on the second send and preserves stack evidence. The source audit focuses on the high-signal
+classic pattern and intentionally does not try to prove every possible nested control-flow path.
+Reviewers still need to inspect unusual async flows.
+
+## Level-of-abstraction fit
+
+The runtime protection belongs in Express middleware because duplicate sends are a response-layer
+failure that can happen in any route. The source audit belongs in tests because it is a structural
+authoring guard, not a production decision point.
+
+## Signal vs authority
+
+The source audit is authority in CI for the narrow syntactic pattern it detects. The runtime guard is
+authority only over a response that is already committed; at that point there is no valid second
+response to authorize. It logs enough stack context for follow-up instead of silently hiding the
+underlying route bug.
+
+## Adjacent interactions
+
+- `requestTimeout` already checks `!res.headersSent`; this change does not alter timeout budgets.
+- Dashboard, auth, machine, and API routes are covered because the middleware is installed before
+  route registration.
+- Express error middleware keeps returning normal 500 JSON for errors before a response is committed.
+- Direct low-level `res.end()` is not monkey-patched to avoid interfering with Express internals
+  during legitimate first sends.
+
+## Rollback
+
+Rollback is straightforward: remove `duplicateResponseGuard` wiring, remove the middleware export,
+restore the old `errorHandler` implementation, and remove the two unit tests. No data migration,
+config migration, or user action is involved.
+
+## Evidence
+
+- `npx vitest run tests/unit/duplicate-response-guard.test.ts tests/unit/route-double-send-audit.test.ts`
+- `npx tsc --noEmit`


### PR DESCRIPTION
## Summary
- installs a duplicate-response guard before server routes so late json/send-style response attempts after committed headers are logged and suppressed instead of throwing
- hardens the shared error handler to skip a second 500 when a route has already sent a response
- adds runtime regression coverage plus a source-level route audit for the classic missing-return double-send pattern

## Verification
- npx vitest run tests/unit/duplicate-response-guard.test.ts tests/unit/route-double-send-audit.test.ts
- npx tsc --noEmit
- pnpm lint
- pnpm build
- node scripts/docs-coverage.mjs --check
- node dist/cli.js dev:preflight
- npx vitest run tests/unit/duplicate-response-guard.test.ts tests/unit/route-double-send-audit.test.ts tests/unit/builtin-manifest.test.ts tests/unit/server.test.ts
- pre-push gate passed; local smoke affected set skipped as too broad; scoped e2e gate passed 331 threadline tests

## Instar-dev
- ELI16: upgrades/double-send-route-guard.eli16.md
- Side-effects: upgrades/side-effects/double-send-route-guard.md
- Trace: .instar/instar-dev-traces/2026-06-04T05-46-05-000Z-double-send-route-guard.json

Note: I started the full local push suite before switching to CI authority. It surfaced known local-only broad-suite flakes outside this diff, so I stopped chasing those and relied on the change-owned tests plus the actual pre-push gates.