### PR TITLE
fix(messaging): type-tolerant Telegram authorizedUserIds comparison

### DIFF
--- a/docs/specs/telegram-auth-id-type-tolerant.eli16.md
+++ b/docs/specs/telegram-auth-id-type-tolerant.eli16.md
@@ -1,0 +1,46 @@
+# ELI16 — Telegram authorized-user check, type-tolerant
+
+## What this is, in plain English
+
+Instar agents talk to people over Telegram. To make sure only the right people
+can give the agent instructions, each agent keeps a short list of allowed Telegram
+user IDs (a Telegram ID is just a big number, like `7812716706`). When a message
+comes in, the agent checks: "is this sender's ID on my allowed list?" If yes, it
+answers. If no, it treats them as a stranger and shows a "you're not registered"
+gate instead.
+
+## The bug
+
+That allowed list lives in a config file, which is plain text (JSON). The code that
+reads it *expects* the IDs to be numbers, but nothing stops someone (a human editing
+the file, or an agent setting another agent up) from writing an ID as **text** —
+`"7812716706"` with quotes — instead of a number — `7812716706` without quotes.
+
+The check used JavaScript's `includes`, which compares *strictly*: the text
+`"7812716706"` is NOT considered equal to the number `7812716706`. So if your ID was
+written as text, the check said "not on the list" — and the real, authorized owner
+got treated as a stranger and locked out behind the registration gate. Silently.
+Nothing in the logs screamed "wrong type"; it just quietly failed.
+
+## How we found it
+
+While one agent (Codey) was setting up another agent (Gemini) on Telegram, it wrote
+the owner's ID as text. The newly-set-up agent then refused to recognize the owner —
+the exact symptom above. That made the underlying brittleness obvious.
+
+## What's new
+
+The check now compares IDs as text on both sides — it turns whatever is in the list
+into text and compares it to the sender's ID turned into text. So `7812716706` and
+`"7812716706"` are treated as the same person. Numbers, text, or a mix of both in
+the list all work now. Nobody who used to be recognized stops being recognized — the
+change only *widens* recognition to include the people it was always supposed to.
+
+A second spot (the auto-add step that remembers a newly-onboarded user) got the same
+treatment, so it won't add a duplicate when the list already holds the ID as text.
+
+## Why it's safe
+
+It can only make MORE of the intended IDs match — never fewer. The "empty list means
+accept everyone" behavior is untouched, and the other chat platforms (Slack, etc.)
+are separate code and unaffected.

--- a/src/commands/server.ts
+++ b/src/commands/server.ts
@@ -3721,7 +3721,12 @@ export async function startServer(options: StartOptions): Promise<void> {
         const telegramConfig = config.messaging?.find(m => m.type === 'telegram');
         if (telegramConfig?.config) {
           const authIds = (telegramConfig.config.authorizedUserIds as number[]) ?? [];
-          if (!authIds.includes(telegramUserId)) {
+          // Type-tolerant membership check: config JSON may already hold ids as
+          // strings, so a strict `includes(number)` would miss an existing string
+          // entry and push a duplicate (leaving mixed-type config). Compare as
+          // strings; isAuthorized() is likewise type-tolerant.
+          const already = authIds.some(id => String(id) === String(telegramUserId));
+          if (!already) {
             authIds.push(telegramUserId);
             telegramConfig.config.authorizedUserIds = authIds;
           }

--- a/src/messaging/TelegramAdapter.ts
+++ b/src/messaging/TelegramAdapter.ts
@@ -1820,7 +1820,15 @@ export class TelegramAdapter implements MessagingAdapter {
 
     const authorized = this.config.authorizedUserIds;
     if (!authorized || authorized.length === 0) return true;
-    return authorized.includes(userId);
+    // Type-tolerant comparison: the field is typed `number[]` but config JSON is
+    // untyped at runtime, so an operator (or an onboarding agent) can write an id
+    // as a string ("7812716706"). `Array.prototype.includes` uses SameValueZero
+    // (no coercion), so a string-configured id would NOT match the numeric userId
+    // and the authorized user would be silently treated as unknown (hitting the
+    // registration gate). Compare as strings so number- and string-configured ids
+    // both authorize. Mirrors the shared-AuthGate path above, which is string-based.
+    const target = String(userId);
+    return authorized.some(id => String(id) === target);
   }
 
   /**

--- a/tests/unit/telegram-auth-id-type-tolerant.test.ts
+++ b/tests/unit/telegram-auth-id-type-tolerant.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { TelegramAdapter } from '../../src/messaging/TelegramAdapter.js';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+
+/**
+ * Regression: the legacy (non-shared-AuthGate) auth path used
+ * `authorizedUserIds.includes(userId)`. The field is typed `number[]`, but
+ * config JSON is untyped at runtime, so an operator (or an onboarding agent)
+ * can write the id as a string. `includes` uses SameValueZero (no coercion),
+ * so a string-configured id silently failed to match the numeric userId and
+ * the authorized user was treated as unknown (hit the registration gate).
+ *
+ * Surfaced live while Codey onboarded the Gemini mentee onto Telegram: it
+ * wrote `authorizedUserIds` as a string and Gemini rejected the owner as an
+ * unknown user. The fix makes the comparison type-tolerant.
+ */
+describe('TelegramAdapter authorizedUserIds — type-tolerant auth', () => {
+  const dirs: string[] = [];
+
+  function makeAdapter(authorizedUserIds: unknown): TelegramAdapter {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'instar-tg-auth-'));
+    dirs.push(tmpDir);
+    return new TelegramAdapter(
+      {
+        token: 'test-token-123',
+        chatId: '-100123456',
+        pollIntervalMs: 100,
+        // Intentionally pass through whatever the test supplies (string,
+        // number, mixed) to mirror untyped config JSON.
+        authorizedUserIds: authorizedUserIds as number[],
+      },
+      tmpDir,
+    );
+  }
+
+  afterEach(() => {
+    for (const d of dirs.splice(0)) {
+      SafeFsExecutor.safeRmSync(d, {
+        recursive: true,
+        force: true,
+        operation: 'tests/unit/telegram-auth-id-type-tolerant.test.ts',
+      });
+    }
+  });
+
+  it('authorizes a numeric userId when config holds the id as a number', () => {
+    const adapter = makeAdapter([7812716706]);
+    expect((adapter as any).isAuthorized(7812716706)).toBe(true);
+  });
+
+  it('authorizes a numeric userId when config holds the id as a STRING (the bug)', () => {
+    const adapter = makeAdapter(['7812716706']);
+    // Before the fix this returned false (string !== number under includes),
+    // silently locking out the authorized user.
+    expect((adapter as any).isAuthorized(7812716706)).toBe(true);
+  });
+
+  it('authorizes from a MIXED string/number authorized list', () => {
+    const adapter = makeAdapter(['7812716706', 42]);
+    expect((adapter as any).isAuthorized(7812716706)).toBe(true);
+    expect((adapter as any).isAuthorized(42)).toBe(true);
+  });
+
+  it('rejects an unauthorized id regardless of config id type', () => {
+    expect((makeAdapter(['7812716706']) as any).isAuthorized(999)).toBe(false);
+    expect((makeAdapter([7812716706]) as any).isAuthorized(999)).toBe(false);
+  });
+
+  it('accepts all when authorizedUserIds is empty or absent (open, unchanged)', () => {
+    expect((makeAdapter([]) as any).isAuthorized(999)).toBe(true);
+    expect((makeAdapter(undefined) as any).isAuthorized(999)).toBe(true);
+  });
+});

--- a/upgrades/next/telegram-auth-id-type-tolerant.md
+++ b/upgrades/next/telegram-auth-id-type-tolerant.md
@@ -1,0 +1,22 @@
+# Upgrade Guide - vNEXT
+
+<!-- bump: patch -->
+
+## What Changed
+
+- The Telegram authorized-user check is now type-tolerant. The legacy auth path compared the incoming numeric Telegram id against the configured `authorizedUserIds` with a strict membership check, so an id written as a string in config silently failed to match and the authorized user was treated as unknown (hitting the registration gate).
+- The mini-onboarding auto-add now also compares ids loosely, so it no longer appends a duplicate when the configured list already holds the id as a string.
+
+## What to Tell Your User
+
+- **Telegram access fix**: "If your Telegram user id was ever written as text in my config, I would have wrongly treated you as a stranger and asked you to register. That comparison now ignores whether the id is stored as a number or text, so the right person is recognized either way."
+
+## Summary of New Capabilities
+
+| Capability | How to Use |
+|-----------|-----------|
+| Type-tolerant Telegram authorization | No action needed. Existing `authorizedUserIds` entries are honored whether they are stored as numbers or strings. |
+
+## Evidence
+
+Added a focused unit test (`telegram-auth-id-type-tolerant.test.ts`, 5 cases) covering number-configured ids, string-configured ids (the regression), mixed lists, unauthorized rejection, and the empty/open passthrough. `tsc --noEmit` is clean. CI is the authority across the full shard matrix.

--- a/upgrades/side-effects/telegram-auth-id-type-tolerant.md
+++ b/upgrades/side-effects/telegram-auth-id-type-tolerant.md
@@ -1,0 +1,56 @@
+# Side-Effects Review — Telegram authorizedUserIds type-tolerant comparison
+
+**Version / slug:** `telegram-auth-id-type-tolerant`
+**Date:** `2026-06-04`
+**Author:** `echo`
+**Second-pass reviewer:** `not required`
+
+## Summary of the change
+
+The legacy (non-shared-AuthGate) Telegram auth path used
+`authorizedUserIds.includes(userId)` where `userId` is a `number` but the config
+field, though typed `number[]`, is untyped JSON at runtime and may hold the id as
+a string. `Array.prototype.includes` uses SameValueZero (no coercion), so a
+string-configured id silently failed to match and the authorized user was treated
+as unknown. The fix compares as strings (`authorized.some(id => String(id) ===
+String(userId))`), mirroring the shared-AuthGate path which is already string-based.
+The mini-onboarding auto-add (`server.ts`) is given the same loose membership check
+so it does not append a duplicate when the list already holds the id as a string.
+
+## Decision-point inventory
+
+One decision point: `isAuthorized(userId)` returns true/false (authorized vs gated).
+The change only affects WHICH equal-by-value ids match; it does not change the
+empty-list semantics (still "accept all" on the legacy path) or any other branch.
+
+## 1. Over-block
+
+**What legitimate inputs does this change reject?** None. The change only makes the
+comparison match MORE inputs that were always intended to match (an id equal by
+value, regardless of number-vs-string representation). No id that previously
+authorized stops authorizing: `String(n) === String(n)` holds for every number that
+`includes` would have matched. The empty/absent-list "accept all" path is untouched.
+
+## 2. Under-block
+
+**What does this still miss?** It does not change the fail-open vs fail-closed
+posture of the legacy path (empty list still accepts all — unchanged, out of scope).
+It does not touch the shared-AuthGate path (already string-based) or the Slack/
+WhatsApp/iMessage adapters (separate code, their own typing). It compares by exact
+string equality after coercion, so it intentionally does NOT treat e.g. leading-zero
+or whitespace-padded ids as equal — Telegram ids are canonical integers, so this is
+correct.
+
+## 3. Blast radius
+
+Two callsites: `TelegramAdapter.isAuthorized` (the auth gate) and the `server.ts`
+mini-onboarding auto-add. Both are Telegram-only. No schema, config-shape, or API
+change — existing configs (number ids, string ids, or mixed) all keep working, and
+configs that already worked are unaffected. Behavior strictly widens recognition to
+match the documented intent.
+
+## 4. Reversibility
+
+Fully reversible: revert the two edits. No state migration, no persisted format
+change. Config files are not rewritten by this change (the mini-onboarding still
+pushes a numeric id as before; it just no longer duplicates an existing string id).


### PR DESCRIPTION
## What

The legacy (non-shared-`AuthGate`) Telegram auth path compared the incoming numeric Telegram id against `authorizedUserIds` with `includes()` — a strict (SameValueZero) check. The field is typed `number[]`, but config JSON is untyped at runtime, so an id written as a **string** (`"7812716706"`) silently failed to match the numeric `userId` and the authorized user was treated as **unknown** (hitting the registration gate).

Fix: compare as strings on both sides (`authorized.some(id => String(id) === String(userId))`), mirroring the shared-`AuthGate` path which is already string-based. The mini-onboarding auto-add (`server.ts`) gets the same loose membership check so it no longer appends a duplicate when the list already holds the id as a string.

## How it surfaced (differential-oversight)

Live, while **Codey onboarded the Gemini mentee onto Telegram**: Codey wrote `authorizedUserIds` as a string and Gemini rejected the owner as an unknown user. Codey applied the task-level workaround (numeric config); this PR fixes the root so no future agent/user hits it. Framework-issue ledger: `c3deb96d`.

## Scope / safety

- **Tier-1.** Strictly *widens* id matching to the documented intent — no id that previously authorized stops authorizing (`String(n) === String(n)`). Empty/absent-list "accept all" path untouched. No schema/config/API change; fully reversible.
- Two Telegram-only callsites: `TelegramAdapter.isAuthorized` + the `server.ts` mini-onboarding auto-add. Shared `AuthGate` path (already string-based) and Slack/WhatsApp/iMessage adapters unaffected.

## Tests

`tests/unit/telegram-auth-id-type-tolerant.test.ts` (5 cases): number-configured id, **string-configured id (the regression)**, mixed list, unauthorized rejection, empty/open passthrough. `tsc --noEmit` clean. CI is the authority across the shard matrix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)