### PR TITLE
Fix session guard for sibling agent server restarts

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,10 @@ An agent that forgets what you discussed yesterday, doesn't recognize someone it
 
 > **Reference:** [CLI Commands](https://instar.sh/reference/cli/) · [API Endpoints](https://instar.sh/reference/api/) · [Configuration](https://instar.sh/reference/configuration/) · [File Structure](https://instar.sh/reference/file-structure/)
 
+Server lifecycle commands use `SessionServerGuard` so an active agent session
+cannot restart its own managing server, while sibling agent targets can still be
+started, stopped, or restarted for fleet maintenance.
+
 ## Agent Skills
 
 Instar ships fourteen skills total — twelve user-facing, plus two internal skills (`instar-dev` and `spec-converge`) used only by the agent that develops instar itself. The standard is the [Agent Skills open standard](https://agentskills.io) -- portable across Claude Code, Codex, Cursor, VS Code, and 35+ other platforms.

--- a/docs/specs/server-restart-sibling-target.eli16.md
+++ b/docs/specs/server-restart-sibling-target.eli16.md
@@ -50,4 +50,7 @@ This removes a real fleet-operations friction point without weakening the
 original safety invariant. A mentoring agent can maintain a sibling agent, while
 the current conversation remains protected from self-stranding restarts.
 
+The CLI reference and README now also name the guard so the exported core helper
+is covered by the docs-coverage gate.
+
 Framework-ledger ref: `57ecfb92`.

--- a/site/src/content/docs/reference/cli.md
+++ b/site/src/content/docs/reference/cli.md
@@ -23,6 +23,10 @@ instar server status [name]     # Show server status
 instar status                   # Show agent infrastructure status
 ```
 
+`SessionServerGuard` protects an active session from restarting its own
+managing server while still allowing server lifecycle commands that target a
+sibling agent by name or directory.
+
 ## Lifeline
 
 ```bash

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -33,8 +33,9 @@ import { addJob, listJobs } from './commands/job.js';
 import { listRelationships, importRelationships, exportRelationships } from './commands/relationship.js';
 import { listMachines, removeMachine, whoami, startPairing, joinMesh, leaveMesh, wakeup, doctor } from './commands/machine.js';
 import pc from 'picocolors';
-import { getInstarVersion } from './core/Config.js';
+import { getInstarVersion, resolveAgentDir } from './core/Config.js';
 import { listAgents } from './core/AgentRegistry.js';
+import { shouldRejectServerLifecycleFromSession } from './core/SessionServerGuard.js';
 
 /**
  * Add or update Telegram configuration in the project config.
@@ -1273,14 +1274,17 @@ telemetryCmd
 
 // ── Server ────────────────────────────────────────────────────────
 
-/** Guard: prevent sessions from inadvertently starting/stopping/restarting the server. */
-function rejectIfInsideSession(action: string): boolean {
-  if (process.env.INSTAR_SESSION_ID) {
-    console.error(pc.red(`Cannot '${action}' from inside a session (session ${process.env.INSTAR_SESSION_ID}).`));
-    console.error(pc.dim('The server is managed by the supervisor. Sessions should not start, stop, or restart it.'));
-    return true;
+/** Guard: prevent sessions from restarting their own managing server. */
+function rejectIfInsideSession(action: string, targetDir?: string): boolean {
+  const decision = shouldRejectServerLifecycleFromSession({ action, targetDir });
+  if (!decision.reject) return false;
+
+  console.error(pc.red(decision.message ?? `Cannot '${action}' from inside a session.`));
+  if (decision.detail) console.error(pc.dim(decision.detail));
+  if (decision.supervisorHint) {
+    console.error(pc.dim(`If you need to bounce this agent, use the supervisor: ${decision.supervisorHint}`));
   }
-  return false;
+  return true;
 }
 
 // ── Listener Daemon ──────────────────────────────────────────────────
@@ -1387,10 +1391,7 @@ serverCmd
   .option('--no-telegram', 'Skip Telegram polling (use when lifeline manages Telegram)')
   .option('-d, --dir <path>', 'Project directory')
   .action(async (name, opts) => {
-    if (rejectIfInsideSession('server start')) return;
     if (name && !opts.dir) {
-      // Resolve standalone agent name to directory
-      const { resolveAgentDir } = await import('./core/Config.js');
       try {
         opts.dir = resolveAgentDir(name);
       } catch (err) {
@@ -1398,6 +1399,7 @@ serverCmd
         process.exit(1);
       }
     }
+    if (rejectIfInsideSession('server start', opts.dir)) return;
     return startServer(opts);
   });
 
@@ -1406,9 +1408,7 @@ serverCmd
   .description('Stop the agent server (optional: standalone agent name)')
   .option('-d, --dir <path>', 'Project directory')
   .action(async (name, opts) => {
-    if (rejectIfInsideSession('server stop')) return;
     if (name && !opts.dir) {
-      const { resolveAgentDir } = await import('./core/Config.js');
       try {
         opts.dir = resolveAgentDir(name);
       } catch (err) {
@@ -1416,6 +1416,7 @@ serverCmd
         process.exit(1);
       }
     }
+    if (rejectIfInsideSession('server stop', opts.dir)) return;
     return stopServer(opts);
   });
 
@@ -1424,9 +1425,7 @@ serverCmd
   .description('Restart the agent server (handles launchd/systemd lifecycle)')
   .option('-d, --dir <path>', 'Project directory')
   .action(async (name, opts) => {
-    if (rejectIfInsideSession('server restart')) return;
     if (name && !opts.dir) {
-      const { resolveAgentDir } = await import('./core/Config.js');
       try {
         opts.dir = resolveAgentDir(name);
       } catch (err) {
@@ -1434,6 +1433,7 @@ serverCmd
         process.exit(1);
       }
     }
+    if (rejectIfInsideSession('server restart', opts.dir)) return;
     return restartServer(opts);
   });
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -33,7 +33,8 @@ import { addJob, listJobs } from './commands/job.js';
 import { listRelationships, importRelationships, exportRelationships } from './commands/relationship.js';
 import { listMachines, removeMachine, whoami, startPairing, joinMesh, leaveMesh, wakeup, doctor } from './commands/machine.js';
 import pc from 'picocolors';
-import { getInstarVersion, resolveAgentDir } from './core/Config.js';
+import { getInstarVersion } from './core/Config.js';
+import { resolveAgentDir } from './core/Config.js';
 import { listAgents } from './core/AgentRegistry.js';
 import { shouldRejectServerLifecycleFromSession } from './core/SessionServerGuard.js';
 

--- a/src/core/SessionServerGuard.ts
+++ b/src/core/SessionServerGuard.ts
@@ -1,0 +1,68 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { detectProjectDir } from './Config.js';
+
+export interface SessionServerGuardDecision {
+  reject: boolean;
+  message?: string;
+  detail?: string;
+  supervisorHint?: string;
+}
+
+export interface SessionServerGuardInput {
+  action: string;
+  targetDir?: string;
+  currentProjectDir?: string;
+  sessionId?: string;
+  uid?: number;
+  projectName?: string;
+}
+
+function normalizeDir(dir: string): string {
+  const resolved = path.resolve(dir);
+  try {
+    return fs.realpathSync(resolved);
+  } catch {
+    return resolved;
+  }
+}
+
+function defaultCurrentProjectDir(): string {
+  const envDir = process.env.INSTAR_PROJECT_DIR || process.env.CLAUDE_PROJECT_DIR;
+  return envDir ? normalizeDir(envDir) : normalizeDir(detectProjectDir());
+}
+
+function defaultSessionId(): string | undefined {
+  return process.env.INSTAR_SESSION_ID || undefined;
+}
+
+function defaultUid(): number {
+  return process.getuid?.() ?? 501;
+}
+
+function inferProjectName(dir: string, explicit?: string): string {
+  return explicit || path.basename(dir);
+}
+
+export function shouldRejectServerLifecycleFromSession(
+  input: SessionServerGuardInput
+): SessionServerGuardDecision {
+  const sessionId = input.sessionId ?? defaultSessionId();
+  if (!sessionId) return { reject: false };
+
+  const currentProjectDir = normalizeDir(input.currentProjectDir ?? defaultCurrentProjectDir());
+  const targetDir = normalizeDir(input.targetDir ?? currentProjectDir);
+
+  if (targetDir !== currentProjectDir) return { reject: false };
+
+  const projectName = inferProjectName(currentProjectDir, input.projectName);
+  const uid = input.uid ?? defaultUid();
+  const supervisorHint = `launchctl kickstart -k gui/${uid}/ai.instar.${projectName}`;
+
+  return {
+    reject: true,
+    message: `Cannot '${input.action}' for this agent from inside a session (session ${sessionId}).`,
+    detail: 'The managing server owns this session. Restarting it from here can strand the conversation.',
+    supervisorHint,
+  };
+}

--- a/tests/unit/server-commands.test.ts
+++ b/tests/unit/server-commands.test.ts
@@ -7,7 +7,11 @@
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
 import path from 'node:path';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+import { shouldRejectServerLifecycleFromSession } from '../../src/core/SessionServerGuard.js';
 
 describe('server command security', () => {
   it('execFileSync prevents shell injection in session names', () => {
@@ -63,5 +67,71 @@ describe('server session name derivation', () => {
     const projectName = 'agente-español';
     const serverSessionName = `${projectName}-server`;
     expect(serverSessionName).toBe('agente-español-server');
+  });
+});
+
+describe('session server lifecycle guard', () => {
+  it('allows server lifecycle commands outside a session', () => {
+    const decision = shouldRejectServerLifecycleFromSession({
+      action: 'server restart',
+      currentProjectDir: '/tmp/codey',
+      targetDir: '/tmp/codey',
+      sessionId: '',
+    });
+
+    expect(decision.reject).toBe(false);
+  });
+
+  it('rejects restarting the current managing server and includes a supervisor hint', () => {
+    const decision = shouldRejectServerLifecycleFromSession({
+      action: 'server restart',
+      currentProjectDir: '/tmp/codey',
+      targetDir: '/tmp/codey',
+      sessionId: 'session-123',
+      uid: 501,
+      projectName: 'codey',
+    });
+
+    expect(decision.reject).toBe(true);
+    expect(decision.message).toContain("Cannot 'server restart' for this agent");
+    expect(decision.supervisorHint).toBe('launchctl kickstart -k gui/501/ai.instar.codey');
+  });
+
+  it('allows restarting a sibling agent server from inside a session', () => {
+    const decision = shouldRejectServerLifecycleFromSession({
+      action: 'server restart',
+      currentProjectDir: '/tmp/codey',
+      targetDir: '/tmp/gemini',
+      sessionId: 'session-123',
+    });
+
+    expect(decision.reject).toBe(false);
+  });
+
+  it('rejects a symlink target that resolves to the current managing server', () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'instar-session-guard-'));
+    try {
+      const currentProjectDir = path.join(root, 'codey');
+      const linkedProjectDir = path.join(root, 'codey-link');
+      fs.mkdirSync(currentProjectDir);
+      fs.symlinkSync(currentProjectDir, linkedProjectDir);
+
+      const decision = shouldRejectServerLifecycleFromSession({
+        action: 'server restart',
+        currentProjectDir,
+        targetDir: linkedProjectDir,
+        sessionId: 'session-123',
+        uid: 501,
+        projectName: 'codey',
+      });
+
+      expect(decision.reject).toBe(true);
+    } finally {
+      SafeFsExecutor.safeRmSync(root, {
+        recursive: true,
+        force: true,
+        operation: 'tests/unit/server-commands.test.ts:session-server-lifecycle-guard',
+      });
+    }
   });
 });

--- a/upgrades/next/server-restart-sibling-target.md
+++ b/upgrades/next/server-restart-sibling-target.md
@@ -1,0 +1,32 @@
+<!-- bump: patch -->
+
+## What Changed
+
+Fixed the in-session server lifecycle guard so it only blocks the current
+session's own managing server. Restarting a sibling agent server by target
+directory or agent name is now allowed from inside a session.
+
+Self-targeted server lifecycle commands are still blocked, and the error now
+points operators to the supervisor path for bouncing that agent safely.
+
+## What to Tell Your User
+
+- **Sibling agent restarts**: "I can now bounce another agent's server during
+  mentoring or fleet maintenance without being blocked by my own session guard.
+  My own managing server is still protected, so the active conversation is not
+  stranded by accident."
+
+## Summary of New Capabilities
+
+| Capability | How to Use |
+|-----------|-----------|
+| Restart a sibling agent server from inside a session | Use the existing server lifecycle command with a sibling target |
+| Safer self-server failure message | Automatic when an agent targets its own managing server |
+
+## Evidence
+
+Reproduced the failing shape in a unit boundary test: a session with current
+project Codey and target Gemini now returns allow, while current project Codey
+targeting Codey still returns reject. The same targeted suite also verifies that
+a symlink pointing back to Codey is rejected after realpath normalization. The
+targeted server command test file passes with all ten tests green.

--- a/upgrades/next/server-restart-sibling-target.md
+++ b/upgrades/next/server-restart-sibling-target.md
@@ -9,6 +9,10 @@ directory or agent name is now allowed from inside a session.
 Self-targeted server lifecycle commands are still blocked, and the error now
 points operators to the supervisor path for bouncing that agent safely.
 
+The CLI import shape remains compatible with the version-detection regression
+test, and the exported guard is documented so docs coverage stays above the core
+floor.
+
 ## What to Tell Your User
 
 - **Sibling agent restarts**: "I can now bounce another agent's server during

--- a/upgrades/server-restart-sibling-target.eli16.md
+++ b/upgrades/server-restart-sibling-target.eli16.md
@@ -1,0 +1,53 @@
+# vNEXT — plain English overview
+
+## What this change is
+
+Agents can now restart a sibling agent's server from inside their own session.
+
+Before this change, the CLI blocked every `instar server start`, `stop`, or
+`restart` command whenever it saw `INSTAR_SESSION_ID`. That was safe for the
+agent's own server, because restarting the server that owns the current session
+can strand the conversation. But it was too broad for mentorship and fleet work:
+`instar server restart --dir gemini` was blocked even when Codey was trying to
+bounce Gemini, a different agent.
+
+This change makes that guard target-aware.
+
+## What already existed
+
+- A session guard in `src/cli.ts`.
+- `--dir` and optional agent-name support on `instar server start|stop|restart`.
+- Supervisor-managed server lifecycle via launchd/systemd.
+
+## What's new
+
+- A small guard helper compares the current session's project directory to the
+  requested server target.
+- If the target is a sibling agent, the command is allowed.
+- If the target is the current agent, the command is still blocked.
+- The self-target error now includes the concrete supervisor command:
+  `launchctl kickstart -k gui/$UID/ai.instar.<name>`.
+- The comparison resolves symlinks so an alias to the current project cannot
+  bypass the self-restart protection.
+
+## What you need to decide
+
+Nothing. The safer behavior remains the default: an agent still cannot restart
+the server that is managing its own active session.
+
+## How to verify it worked after deploy
+
+From inside Codey's session:
+
+- `instar server restart --dir gemini` should proceed to Gemini's normal server
+  restart path.
+- `instar server restart` with no `--dir` should still be blocked for Codey's own
+  server and should print the supervisor hint.
+
+## Why this matters
+
+This removes a real fleet-operations friction point without weakening the
+original safety invariant. A mentoring agent can maintain a sibling agent, while
+the current conversation remains protected from self-stranding restarts.
+
+Framework-ledger ref: `57ecfb92`.

--- a/upgrades/side-effects/server-restart-sibling-target.md
+++ b/upgrades/side-effects/server-restart-sibling-target.md
@@ -1,0 +1,94 @@
+# Side-effects review — session-safe sibling server restarts
+
+**Scope**: `instar server start|stop|restart` now checks whether the requested
+server target is the current session's own project before blocking lifecycle
+commands from inside a session. Sibling targets are allowed. Self-targets remain
+blocked and now print an actionable supervisor command.
+
+Framework-ledger ref: `57ecfb92`.
+
+## Decision audit
+
+**Candidate A: keep the blanket block and only improve the error.**
+
+This would have preserved the original safety invariant, but it would not remove
+the operational friction that caused this task. A mentoring agent still could
+not bounce a sibling agent's server from the correct workflow.
+
+**Candidate B: make the guard target-aware and keep a supervisor hint for
+self-targets.**
+
+Chosen. It preserves the invariant that a session cannot restart its own
+managing server, while allowing maintenance of sibling agents. The supervisor
+hint covers the remaining blocked case with an explicit human/operator path.
+
+## Over-block risk
+
+Low. The guard normalizes the current project and target project through
+`realpath` when possible. Sibling directories compare different and are allowed.
+The only expected block is the current managing server, including symlink aliases
+that point back to it.
+
+One residual over-block case remains intentional: if no target is provided from
+inside a session, the command targets the current project and is blocked.
+
+## Under-block risk
+
+Low. A symlink to the current project is rejected after realpath normalization.
+If a target path does not exist yet, normalization falls back to `path.resolve`;
+that could only affect non-existing paths before the server command validates
+them. Existing self-targets are protected.
+
+## Level-of-abstraction fit
+
+The comparison lives in a pure core helper. The CLI resolves the optional agent
+name before asking the helper for a decision, then formats any rejection for the
+terminal. This keeps policy separate from command output and makes the behavior
+directly unit-testable.
+
+## Signal vs authority
+
+The helper is authority for this CLI guard only. It does not change supervisor,
+launchd, systemd, or server internals. The server lifecycle implementation still
+owns the actual start/stop/restart mechanics.
+
+## Interactions
+
+- `server start [name]`, `server stop [name]`, and `server restart [name]` now
+  resolve the agent name before applying the guard.
+- `--dir` targets are compared directly.
+- `status [name]` is unchanged except that `resolveAgentDir` is now statically
+  imported by the CLI.
+- Supervisor-managed restarts remain the documented path for the current agent.
+
+## External surfaces
+
+User-facing behavior changes only for CLI output and command allowance:
+
+- Sibling server lifecycle commands from inside a session can proceed.
+- Self server lifecycle commands still fail, with a clearer message and
+  `launchctl kickstart -k gui/$UID/ai.instar.<name>` hint.
+
+No API keys, credentials, network calls, or config migrations are involved.
+
+## Rollback cost
+
+Small. Reverting the helper, CLI call-site changes, tests, and upgrade artifacts
+restores the prior blanket in-session block.
+
+## Tests
+
+Narrow regression coverage checks:
+
+- no session id allows lifecycle commands;
+- current managing server rejects;
+- sibling target allows;
+- symlink target resolving to the current managing server rejects.
+
+Local verification intentionally uses targeted tests and static gates under the
+current host load; CI remains the full matrix authority.
+
+## Conclusion
+
+This change removes the Gemini-onboarding friction without weakening the
+conversation-safety invariant that motivated the guard in the first place.

--- a/upgrades/side-effects/server-restart-sibling-target.md
+++ b/upgrades/side-effects/server-restart-sibling-target.md
@@ -84,6 +84,8 @@ Narrow regression coverage checks:
 - current managing server rejects;
 - sibling target allows;
 - symlink target resolving to the current managing server rejects.
+- docs coverage documents `SessionServerGuard` in two indexed docs so the core
+  category stays at its configured floor.
 
 Local verification intentionally uses targeted tests and static gates under the
 current host load; CI remains the full matrix authority.


### PR DESCRIPTION
## Summary
- Make the in-session server lifecycle guard target-aware so sibling agent server restarts are allowed.
- Keep blocking lifecycle commands for the current session's own managing server, with an actionable supervisor hint.
- Add direct guard coverage for no-session, self-target, sibling-target, and symlink self-target cases.

## Gate artifacts
- ELI16 overview included.
- Side-effects review included with framework-ledger ref `57ecfb92` and decision audit.
- Release-note fragment included with patch bump directive.

## Verification
- `npm test -- tests/unit/server-commands.test.ts`
- `npm run lint`
- `npm run check:upgrade-guide`
- `node scripts/instar-dev-precommit.js`
- `npm run check:pre-push-gate` passed with only the existing non-blocking version warning.

Full local Vitest was intentionally skipped under host-load guidance; CI remains the full matrix authority. The earlier branch created from the stale 0.28.x checkout was deleted and this PR was rebuilt from current `JKHeadley/instar` main at `1.3.244` (`693a66ee`).
