### PR TITLE
Fix Gemini quota-state attribution

### DIFF
--- a/src/commands/server.ts
+++ b/src/commands/server.ts
@@ -2961,10 +2961,20 @@ export async function startServer(options: StartOptions): Promise<void> {
       const built = buildIntelligenceProvider({
         framework,
         binaryPath: framework === 'claude-code' ? config.sessions.claudePath : undefined,
+        ...(framework === 'gemini-cli' && config.monitoring?.quotaTracking
+          ? {
+              quotaStateFile: (config.monitoring as { quotaStateFile?: string }).quotaStateFile
+                || path.join(config.stateDir, 'quota-state.json'),
+            }
+          : {}),
       });
       if (built) {
         sharedIntelligence = built;
-        intelligenceSource = framework === 'codex-cli' ? 'Codex CLI' : 'Claude CLI subscription';
+        intelligenceSource = framework === 'codex-cli'
+          ? 'Codex CLI'
+          : framework === 'gemini-cli'
+            ? 'Gemini CLI'
+            : 'Claude CLI subscription';
       } else {
         // Fall back to the legacy Claude path for backwards-compat. Wrap with
         // the circuit breaker (the factory path above is already wrapped).
@@ -3612,8 +3622,12 @@ export async function startServer(options: StartOptions): Promise<void> {
         try {
           const { QuotaCollector } = await import('../monitoring/QuotaCollector.js');
           const { createDefaultProvider } = await import('../monitoring/CredentialProvider.js');
-          const provider = createDefaultProvider();
-          collector = new QuotaCollector(provider, quotaTracker);
+          if (resolvedFramework === 'claude-code') {
+            const provider = createDefaultProvider();
+            collector = new QuotaCollector(provider, quotaTracker);
+          } else {
+            console.log(pc.yellow(`  QuotaCollector skipped for ${resolvedFramework} (no framework usage meter)`));
+          }
         } catch (err) {
           console.log(pc.yellow(`  QuotaCollector not available: ${err instanceof Error ? err.message : err}`));
         }

--- a/src/core/GeminiCliIntelligenceProvider.ts
+++ b/src/core/GeminiCliIntelligenceProvider.ts
@@ -120,6 +120,8 @@ export class GeminiCliIntelligenceProvider implements IntelligenceProvider {
         recordGeminiCapacityDeferral({
           retryAfterMs: capacity.retryAfterMs,
           reason: capacity.reason ?? message,
+          model: currentModel,
+          quotaStateFile: this.capacityPolicy?.quotaStateFile,
         });
         throw new Error(
           `${capacity.reason}; retry after ${Math.ceil(capacity.retryAfterMs / 1000)}s — ${message}`,

--- a/src/core/intelligenceProviderFactory.ts
+++ b/src/core/intelligenceProviderFactory.ts
@@ -58,6 +58,12 @@ export interface BuildIntelligenceProviderOptions {
    * actually holds (docs/specs/per-component-framework-routing.md, D3).
    */
   breaker?: LlmCircuitBreaker;
+  /**
+   * Optional quota-state path for providers whose live capacity signal is only
+   * available after invoking the CLI. Currently used by gemini-cli to persist
+   * CLI-reported usage-limit windows into the existing quota gate.
+   */
+  quotaStateFile?: string;
 }
 
 /**
@@ -105,6 +111,7 @@ export function buildIntelligenceProvider(
         new GeminiCliIntelligenceProvider({
           geminiPath: path,
           ...(options.workingDirectory ? { workingDirectory: options.workingDirectory } : {}),
+          ...(options.quotaStateFile ? { capacityPolicy: { quotaStateFile: options.quotaStateFile } } : {}),
         }),
         options.breaker,
       );

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -606,6 +606,14 @@ export interface QuotaState {
   usagePercent: number;
   /** 5-hour rolling rate limit utilization (0-100), if available */
   fiveHourPercent?: number;
+  /** Provider/framework that produced this quota snapshot, if known */
+  source?: 'anthropic-oauth' | 'claude-jsonl' | 'gemini-cli-capacity';
+  /** Provider model whose capacity window is currently blocked, if known */
+  model?: string;
+  /** When a provider-specific capacity block is expected to clear */
+  blockedUntil?: string;
+  /** Human-readable reason from the provider capacity signal */
+  blockReason?: string;
   /** When usage data was last updated */
   lastUpdated: string;
   /** Per-account breakdown if multi-account */

--- a/src/data/builtin-manifest.json
+++ b/src/data/builtin-manifest.json
@@ -1,8 +1,8 @@
 {
   "$schema": "./builtin-manifest.schema.json",
   "schemaVersion": 1,
-  "generatedAt": "2026-06-04T15:59:08.973Z",
-  "instarVersion": "1.3.243",
+  "generatedAt": "2026-06-04T20:28:42.949Z",
+  "instarVersion": "1.3.246",
   "entryCount": 198,
   "entries": {
     "hook:session-start": {
@@ -11,7 +11,7 @@
       "domain": "identity",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/session-start.sh",
-      "contentHash": "556dd545f7048e4a4968786c7ff04746dca0f780651c97ebc0be57a920e4d56b",
+      "contentHash": "4a7c91baa7cade8a07bfa1c7abf0669511fcf6fc07791403944aede1691567e2",
       "since": "2025-01-01"
     },
     "hook:dangerous-command-guard": {
@@ -20,7 +20,7 @@
       "domain": "safety",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/dangerous-command-guard.sh",
-      "contentHash": "556dd545f7048e4a4968786c7ff04746dca0f780651c97ebc0be57a920e4d56b",
+      "contentHash": "4a7c91baa7cade8a07bfa1c7abf0669511fcf6fc07791403944aede1691567e2",
       "since": "2025-01-01"
     },
     "hook:grounding-before-messaging": {
@@ -29,7 +29,7 @@
       "domain": "safety",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/grounding-before-messaging.sh",
-      "contentHash": "556dd545f7048e4a4968786c7ff04746dca0f780651c97ebc0be57a920e4d56b",
+      "contentHash": "4a7c91baa7cade8a07bfa1c7abf0669511fcf6fc07791403944aede1691567e2",
       "since": "2025-01-01"
     },
     "hook:compaction-recovery": {
@@ -38,7 +38,7 @@
       "domain": "identity",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/compaction-recovery.sh",
-      "contentHash": "556dd545f7048e4a4968786c7ff04746dca0f780651c97ebc0be57a920e4d56b",
+      "contentHash": "4a7c91baa7cade8a07bfa1c7abf0669511fcf6fc07791403944aede1691567e2",
       "since": "2025-01-01"
     },
     "hook:external-operation-gate": {
@@ -47,7 +47,7 @@
       "domain": "safety",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/external-operation-gate.js",
-      "contentHash": "556dd545f7048e4a4968786c7ff04746dca0f780651c97ebc0be57a920e4d56b",
+      "contentHash": "4a7c91baa7cade8a07bfa1c7abf0669511fcf6fc07791403944aede1691567e2",
       "since": "2025-01-01"
     },
     "hook:deferral-detector": {
@@ -56,7 +56,7 @@
       "domain": "safety",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/deferral-detector.js",
-      "contentHash": "556dd545f7048e4a4968786c7ff04746dca0f780651c97ebc0be57a920e4d56b",
+      "contentHash": "4a7c91baa7cade8a07bfa1c7abf0669511fcf6fc07791403944aede1691567e2",
       "since": "2025-01-01"
     },
     "hook:self-stop-guard": {
@@ -65,7 +65,7 @@
       "domain": "coherence",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/self-stop-guard.js",
-      "contentHash": "556dd545f7048e4a4968786c7ff04746dca0f780651c97ebc0be57a920e4d56b",
+      "contentHash": "4a7c91baa7cade8a07bfa1c7abf0669511fcf6fc07791403944aede1691567e2",
       "since": "2025-01-01"
     },
     "hook:post-action-reflection": {
@@ -74,7 +74,7 @@
       "domain": "evolution",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/post-action-reflection.js",
-      "contentHash": "556dd545f7048e4a4968786c7ff04746dca0f780651c97ebc0be57a920e4d56b",
+      "contentHash": "4a7c91baa7cade8a07bfa1c7abf0669511fcf6fc07791403944aede1691567e2",
       "since": "2025-01-01"
     },
     "hook:external-communication-guard": {
@@ -83,7 +83,7 @@
       "domain": "safety",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/external-communication-guard.js",
-      "contentHash": "556dd545f7048e4a4968786c7ff04746dca0f780651c97ebc0be57a920e4d56b",
+      "contentHash": "4a7c91baa7cade8a07bfa1c7abf0669511fcf6fc07791403944aede1691567e2",
       "since": "2025-01-01"
     },
     "hook:scope-coherence-collector": {
@@ -92,7 +92,7 @@
       "domain": "coherence",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/scope-coherence-collector.js",
-      "contentHash": "556dd545f7048e4a4968786c7ff04746dca0f780651c97ebc0be57a920e4d56b",
+      "contentHash": "4a7c91baa7cade8a07bfa1c7abf0669511fcf6fc07791403944aede1691567e2",
       "since": "2025-01-01"
     },
     "hook:scope-coherence-checkpoint": {
@@ -101,7 +101,7 @@
       "domain": "coherence",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/scope-coherence-checkpoint.js",
-      "contentHash": "556dd545f7048e4a4968786c7ff04746dca0f780651c97ebc0be57a920e4d56b",
+      "contentHash": "4a7c91baa7cade8a07bfa1c7abf0669511fcf6fc07791403944aede1691567e2",
       "since": "2025-01-01"
     },
     "hook:free-text-guard": {
@@ -110,7 +110,7 @@
       "domain": "safety",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/free-text-guard.sh",
-      "contentHash": "556dd545f7048e4a4968786c7ff04746dca0f780651c97ebc0be57a920e4d56b",
+      "contentHash": "4a7c91baa7cade8a07bfa1c7abf0669511fcf6fc07791403944aede1691567e2",
       "since": "2025-01-01"
     },
     "hook:claim-intercept": {
@@ -119,7 +119,7 @@
       "domain": "coherence",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/claim-intercept.js",
-      "contentHash": "556dd545f7048e4a4968786c7ff04746dca0f780651c97ebc0be57a920e4d56b",
+      "contentHash": "4a7c91baa7cade8a07bfa1c7abf0669511fcf6fc07791403944aede1691567e2",
       "since": "2025-01-01"
     },
     "hook:claim-intercept-response": {
@@ -128,7 +128,7 @@
       "domain": "coherence",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/claim-intercept-response.js",
-      "contentHash": "556dd545f7048e4a4968786c7ff04746dca0f780651c97ebc0be57a920e4d56b",
+      "contentHash": "4a7c91baa7cade8a07bfa1c7abf0669511fcf6fc07791403944aede1691567e2",
       "since": "2025-01-01"
     },
     "hook:stop-gate-router": {
@@ -137,7 +137,7 @@
       "domain": "safety",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/stop-gate-router.js",
-      "contentHash": "556dd545f7048e4a4968786c7ff04746dca0f780651c97ebc0be57a920e4d56b",
+      "contentHash": "4a7c91baa7cade8a07bfa1c7abf0669511fcf6fc07791403944aede1691567e2",
       "since": "2025-01-01"
     },
     "hook:auto-approve-permissions": {
@@ -146,7 +146,7 @@
       "domain": "safety",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/auto-approve-permissions.js",
-      "contentHash": "556dd545f7048e4a4968786c7ff04746dca0f780651c97ebc0be57a920e4d56b",
+      "contentHash": "4a7c91baa7cade8a07bfa1c7abf0669511fcf6fc07791403944aede1691567e2",
       "since": "2025-01-01"
     },
     "job:health-check": {
@@ -418,7 +418,7 @@
       "type": "route-group",
       "domain": "monitoring",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "02c57df0ab1c47b6e03fa28dce38489ee18a19dba177f2f0bf35a14da342ae88",
+      "contentHash": "de1afbb5ae85ad64a3802c1953f0ab7672af2b05ce15609a3b6c3a177dc2bd72",
       "since": "2025-01-01"
     },
     "route-group:agents": {
@@ -426,7 +426,7 @@
       "type": "route-group",
       "domain": "sessions",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "02c57df0ab1c47b6e03fa28dce38489ee18a19dba177f2f0bf35a14da342ae88",
+      "contentHash": "de1afbb5ae85ad64a3802c1953f0ab7672af2b05ce15609a3b6c3a177dc2bd72",
       "since": "2025-01-01"
     },
     "route-group:backups": {
@@ -434,7 +434,7 @@
       "type": "route-group",
       "domain": "operations",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "02c57df0ab1c47b6e03fa28dce38489ee18a19dba177f2f0bf35a14da342ae88",
+      "contentHash": "de1afbb5ae85ad64a3802c1953f0ab7672af2b05ce15609a3b6c3a177dc2bd72",
       "since": "2025-01-01"
     },
     "route-group:git": {
@@ -442,7 +442,7 @@
       "type": "route-group",
       "domain": "coordination",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "02c57df0ab1c47b6e03fa28dce38489ee18a19dba177f2f0bf35a14da342ae88",
+      "contentHash": "de1afbb5ae85ad64a3802c1953f0ab7672af2b05ce15609a3b6c3a177dc2bd72",
       "since": "2025-01-01"
     },
     "route-group:memory": {
@@ -450,7 +450,7 @@
       "type": "route-group",
       "domain": "memory",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "02c57df0ab1c47b6e03fa28dce38489ee18a19dba177f2f0bf35a14da342ae88",
+      "contentHash": "de1afbb5ae85ad64a3802c1953f0ab7672af2b05ce15609a3b6c3a177dc2bd72",
       "since": "2025-01-01"
     },
     "route-group:semantic": {
@@ -458,7 +458,7 @@
       "type": "route-group",
       "domain": "memory",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "02c57df0ab1c47b6e03fa28dce38489ee18a19dba177f2f0bf35a14da342ae88",
+      "contentHash": "de1afbb5ae85ad64a3802c1953f0ab7672af2b05ce15609a3b6c3a177dc2bd72",
       "since": "2025-01-01"
     },
     "route-group:status": {
@@ -466,7 +466,7 @@
       "type": "route-group",
       "domain": "monitoring",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "02c57df0ab1c47b6e03fa28dce38489ee18a19dba177f2f0bf35a14da342ae88",
+      "contentHash": "de1afbb5ae85ad64a3802c1953f0ab7672af2b05ce15609a3b6c3a177dc2bd72",
       "since": "2025-01-01"
     },
     "route-group:capabilities": {
@@ -474,7 +474,7 @@
       "type": "route-group",
       "domain": "mapping",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "02c57df0ab1c47b6e03fa28dce38489ee18a19dba177f2f0bf35a14da342ae88",
+      "contentHash": "de1afbb5ae85ad64a3802c1953f0ab7672af2b05ce15609a3b6c3a177dc2bd72",
       "since": "2025-01-01"
     },
     "route-group:project-map": {
@@ -482,7 +482,7 @@
       "type": "route-group",
       "domain": "mapping",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "02c57df0ab1c47b6e03fa28dce38489ee18a19dba177f2f0bf35a14da342ae88",
+      "contentHash": "de1afbb5ae85ad64a3802c1953f0ab7672af2b05ce15609a3b6c3a177dc2bd72",
       "since": "2025-01-01"
     },
     "route-group:coherence": {
@@ -490,7 +490,7 @@
       "type": "route-group",
       "domain": "coherence",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "02c57df0ab1c47b6e03fa28dce38489ee18a19dba177f2f0bf35a14da342ae88",
+      "contentHash": "de1afbb5ae85ad64a3802c1953f0ab7672af2b05ce15609a3b6c3a177dc2bd72",
       "since": "2025-01-01"
     },
     "route-group:topic-bindings": {
@@ -498,7 +498,7 @@
       "type": "route-group",
       "domain": "sessions",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "02c57df0ab1c47b6e03fa28dce38489ee18a19dba177f2f0bf35a14da342ae88",
+      "contentHash": "de1afbb5ae85ad64a3802c1953f0ab7672af2b05ce15609a3b6c3a177dc2bd72",
       "since": "2025-01-01"
     },
     "route-group:context": {
@@ -506,7 +506,7 @@
       "type": "route-group",
       "domain": "context",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "02c57df0ab1c47b6e03fa28dce38489ee18a19dba177f2f0bf35a14da342ae88",
+      "contentHash": "de1afbb5ae85ad64a3802c1953f0ab7672af2b05ce15609a3b6c3a177dc2bd72",
       "since": "2025-01-01"
     },
     "route-group:scope-coherence": {
@@ -514,7 +514,7 @@
       "type": "route-group",
       "domain": "coherence",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "02c57df0ab1c47b6e03fa28dce38489ee18a19dba177f2f0bf35a14da342ae88",
+      "contentHash": "de1afbb5ae85ad64a3802c1953f0ab7672af2b05ce15609a3b6c3a177dc2bd72",
       "since": "2025-01-01"
     },
     "route-group:canonical-state": {
@@ -522,7 +522,7 @@
       "type": "route-group",
       "domain": "state",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "02c57df0ab1c47b6e03fa28dce38489ee18a19dba177f2f0bf35a14da342ae88",
+      "contentHash": "de1afbb5ae85ad64a3802c1953f0ab7672af2b05ce15609a3b6c3a177dc2bd72",
       "since": "2025-01-01"
     },
     "route-group:ci": {
@@ -530,7 +530,7 @@
       "type": "route-group",
       "domain": "monitoring",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "02c57df0ab1c47b6e03fa28dce38489ee18a19dba177f2f0bf35a14da342ae88",
+      "contentHash": "de1afbb5ae85ad64a3802c1953f0ab7672af2b05ce15609a3b6c3a177dc2bd72",
       "since": "2025-01-01"
     },
     "route-group:sessions": {
@@ -538,7 +538,7 @@
       "type": "route-group",
       "domain": "sessions",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "02c57df0ab1c47b6e03fa28dce38489ee18a19dba177f2f0bf35a14da342ae88",
+      "contentHash": "de1afbb5ae85ad64a3802c1953f0ab7672af2b05ce15609a3b6c3a177dc2bd72",
       "since": "2025-01-01"
     },
     "route-group:jobs": {
@@ -546,7 +546,7 @@
       "type": "route-group",
       "domain": "scheduling",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "02c57df0ab1c47b6e03fa28dce38489ee18a19dba177f2f0bf35a14da342ae88",
+      "contentHash": "de1afbb5ae85ad64a3802c1953f0ab7672af2b05ce15609a3b6c3a177dc2bd72",
       "since": "2025-01-01"
     },
     "route-group:skip-ledger": {
@@ -554,7 +554,7 @@
       "type": "route-group",
       "domain": "scheduling",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "02c57df0ab1c47b6e03fa28dce38489ee18a19dba177f2f0bf35a14da342ae88",
+      "contentHash": "de1afbb5ae85ad64a3802c1953f0ab7672af2b05ce15609a3b6c3a177dc2bd72",
       "since": "2025-01-01"
     },
     "route-group:telegram": {
@@ -562,7 +562,7 @@
       "type": "route-group",
       "domain": "communication",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "02c57df0ab1c47b6e03fa28dce38489ee18a19dba177f2f0bf35a14da342ae88",
+      "contentHash": "de1afbb5ae85ad64a3802c1953f0ab7672af2b05ce15609a3b6c3a177dc2bd72",
       "since": "2025-01-01"
     },
     "route-group:attention": {
@@ -570,7 +570,7 @@
       "type": "route-group",
       "domain": "communication",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "02c57df0ab1c47b6e03fa28dce38489ee18a19dba177f2f0bf35a14da342ae88",
+      "contentHash": "de1afbb5ae85ad64a3802c1953f0ab7672af2b05ce15609a3b6c3a177dc2bd72",
       "since": "2025-01-01"
     },
     "route-group:relationships": {
@@ -578,7 +578,7 @@
       "type": "route-group",
       "domain": "relationships",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "02c57df0ab1c47b6e03fa28dce38489ee18a19dba177f2f0bf35a14da342ae88",
+      "contentHash": "de1afbb5ae85ad64a3802c1953f0ab7672af2b05ce15609a3b6c3a177dc2bd72",
       "since": "2025-01-01"
     },
     "route-group:feedback": {
@@ -586,7 +586,7 @@
       "type": "route-group",
       "domain": "feedback",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "02c57df0ab1c47b6e03fa28dce38489ee18a19dba177f2f0bf35a14da342ae88",
+      "contentHash": "de1afbb5ae85ad64a3802c1953f0ab7672af2b05ce15609a3b6c3a177dc2bd72",
       "since": "2025-01-01"
     },
     "route-group:updates": {
@@ -594,7 +594,7 @@
       "type": "route-group",
       "domain": "updates",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "02c57df0ab1c47b6e03fa28dce38489ee18a19dba177f2f0bf35a14da342ae88",
+      "contentHash": "de1afbb5ae85ad64a3802c1953f0ab7672af2b05ce15609a3b6c3a177dc2bd72",
       "since": "2025-01-01"
     },
     "route-group:dispatches": {
@@ -602,7 +602,7 @@
       "type": "route-group",
       "domain": "dispatches",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "02c57df0ab1c47b6e03fa28dce38489ee18a19dba177f2f0bf35a14da342ae88",
+      "contentHash": "de1afbb5ae85ad64a3802c1953f0ab7672af2b05ce15609a3b6c3a177dc2bd72",
       "since": "2025-01-01"
     },
     "route-group:quota": {
@@ -610,7 +610,7 @@
       "type": "route-group",
       "domain": "monitoring",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "02c57df0ab1c47b6e03fa28dce38489ee18a19dba177f2f0bf35a14da342ae88",
+      "contentHash": "de1afbb5ae85ad64a3802c1953f0ab7672af2b05ce15609a3b6c3a177dc2bd72",
       "since": "2025-01-01"
     },
     "route-group:publishing": {
@@ -618,7 +618,7 @@
       "type": "route-group",
       "domain": "publishing",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "02c57df0ab1c47b6e03fa28dce38489ee18a19dba177f2f0bf35a14da342ae88",
+      "contentHash": "de1afbb5ae85ad64a3802c1953f0ab7672af2b05ce15609a3b6c3a177dc2bd72",
       "since": "2025-01-01"
     },
     "route-group:private-views": {
@@ -626,7 +626,7 @@
       "type": "route-group",
       "domain": "publishing",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "02c57df0ab1c47b6e03fa28dce38489ee18a19dba177f2f0bf35a14da342ae88",
+      "contentHash": "de1afbb5ae85ad64a3802c1953f0ab7672af2b05ce15609a3b6c3a177dc2bd72",
       "since": "2025-01-01"
     },
     "route-group:tunnel": {
@@ -634,7 +634,7 @@
       "type": "route-group",
       "domain": "networking",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "02c57df0ab1c47b6e03fa28dce38489ee18a19dba177f2f0bf35a14da342ae88",
+      "contentHash": "de1afbb5ae85ad64a3802c1953f0ab7672af2b05ce15609a3b6c3a177dc2bd72",
       "since": "2025-01-01"
     },
     "route-group:events": {
@@ -642,7 +642,7 @@
       "type": "route-group",
       "domain": "networking",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "02c57df0ab1c47b6e03fa28dce38489ee18a19dba177f2f0bf35a14da342ae88",
+      "contentHash": "de1afbb5ae85ad64a3802c1953f0ab7672af2b05ce15609a3b6c3a177dc2bd72",
       "since": "2025-01-01"
     },
     "route-group:evolution": {
@@ -650,7 +650,7 @@
       "type": "route-group",
       "domain": "evolution",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "02c57df0ab1c47b6e03fa28dce38489ee18a19dba177f2f0bf35a14da342ae88",
+      "contentHash": "de1afbb5ae85ad64a3802c1953f0ab7672af2b05ce15609a3b6c3a177dc2bd72",
       "since": "2025-01-01"
     },
     "route-group:watchdog": {
@@ -658,7 +658,7 @@
       "type": "route-group",
       "domain": "monitoring",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "02c57df0ab1c47b6e03fa28dce38489ee18a19dba177f2f0bf35a14da342ae88",
+      "contentHash": "de1afbb5ae85ad64a3802c1953f0ab7672af2b05ce15609a3b6c3a177dc2bd72",
       "since": "2025-01-01"
     },
     "route-group:topic-memory": {
@@ -666,7 +666,7 @@
       "type": "route-group",
       "domain": "memory",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "02c57df0ab1c47b6e03fa28dce38489ee18a19dba177f2f0bf35a14da342ae88",
+      "contentHash": "de1afbb5ae85ad64a3802c1953f0ab7672af2b05ce15609a3b6c3a177dc2bd72",
       "since": "2025-01-01"
     },
     "route-group:state-sync": {
@@ -674,7 +674,7 @@
       "type": "route-group",
       "domain": "coordination",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "02c57df0ab1c47b6e03fa28dce38489ee18a19dba177f2f0bf35a14da342ae88",
+      "contentHash": "de1afbb5ae85ad64a3802c1953f0ab7672af2b05ce15609a3b6c3a177dc2bd72",
       "since": "2025-01-01"
     },
     "route-group:intent": {
@@ -682,7 +682,7 @@
       "type": "route-group",
       "domain": "intent",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "02c57df0ab1c47b6e03fa28dce38489ee18a19dba177f2f0bf35a14da342ae88",
+      "contentHash": "de1afbb5ae85ad64a3802c1953f0ab7672af2b05ce15609a3b6c3a177dc2bd72",
       "since": "2025-01-01"
     },
     "route-group:triage": {
@@ -690,7 +690,7 @@
       "type": "route-group",
       "domain": "safety",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "02c57df0ab1c47b6e03fa28dce38489ee18a19dba177f2f0bf35a14da342ae88",
+      "contentHash": "de1afbb5ae85ad64a3802c1953f0ab7672af2b05ce15609a3b6c3a177dc2bd72",
       "since": "2025-01-01"
     },
     "route-group:operations": {
@@ -698,7 +698,7 @@
       "type": "route-group",
       "domain": "safety",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "02c57df0ab1c47b6e03fa28dce38489ee18a19dba177f2f0bf35a14da342ae88",
+      "contentHash": "de1afbb5ae85ad64a3802c1953f0ab7672af2b05ce15609a3b6c3a177dc2bd72",
       "since": "2025-01-01"
     },
     "route-group:sentinel": {
@@ -706,7 +706,7 @@
       "type": "route-group",
       "domain": "safety",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "02c57df0ab1c47b6e03fa28dce38489ee18a19dba177f2f0bf35a14da342ae88",
+      "contentHash": "de1afbb5ae85ad64a3802c1953f0ab7672af2b05ce15609a3b6c3a177dc2bd72",
       "since": "2025-01-01"
     },
     "route-group:trust": {
@@ -714,7 +714,7 @@
       "type": "route-group",
       "domain": "safety",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "02c57df0ab1c47b6e03fa28dce38489ee18a19dba177f2f0bf35a14da342ae88",
+      "contentHash": "de1afbb5ae85ad64a3802c1953f0ab7672af2b05ce15609a3b6c3a177dc2bd72",
       "since": "2025-01-01"
     },
     "route-group:monitoring": {
@@ -722,7 +722,7 @@
       "type": "route-group",
       "domain": "monitoring",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "02c57df0ab1c47b6e03fa28dce38489ee18a19dba177f2f0bf35a14da342ae88",
+      "contentHash": "de1afbb5ae85ad64a3802c1953f0ab7672af2b05ce15609a3b6c3a177dc2bd72",
       "since": "2025-01-01"
     },
     "route-group:commitments": {
@@ -730,7 +730,7 @@
       "type": "route-group",
       "domain": "commitments",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "02c57df0ab1c47b6e03fa28dce38489ee18a19dba177f2f0bf35a14da342ae88",
+      "contentHash": "de1afbb5ae85ad64a3802c1953f0ab7672af2b05ce15609a3b6c3a177dc2bd72",
       "since": "2025-01-01"
     },
     "route-group:episodes": {
@@ -738,7 +738,7 @@
       "type": "route-group",
       "domain": "memory",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "02c57df0ab1c47b6e03fa28dce38489ee18a19dba177f2f0bf35a14da342ae88",
+      "contentHash": "de1afbb5ae85ad64a3802c1953f0ab7672af2b05ce15609a3b6c3a177dc2bd72",
       "since": "2025-01-01"
     },
     "route-group:messages": {
@@ -746,7 +746,7 @@
       "type": "route-group",
       "domain": "coordination",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "02c57df0ab1c47b6e03fa28dce38489ee18a19dba177f2f0bf35a14da342ae88",
+      "contentHash": "de1afbb5ae85ad64a3802c1953f0ab7672af2b05ce15609a3b6c3a177dc2bd72",
       "since": "2025-01-01"
     },
     "route-group:system-reviews": {
@@ -754,7 +754,7 @@
       "type": "route-group",
       "domain": "monitoring",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "02c57df0ab1c47b6e03fa28dce38489ee18a19dba177f2f0bf35a14da342ae88",
+      "contentHash": "de1afbb5ae85ad64a3802c1953f0ab7672af2b05ce15609a3b6c3a177dc2bd72",
       "since": "2025-01-01"
     },
     "route-group:machine-mesh": {
@@ -770,7 +770,7 @@
       "type": "route-group",
       "domain": "security",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "02c57df0ab1c47b6e03fa28dce38489ee18a19dba177f2f0bf35a14da342ae88",
+      "contentHash": "de1afbb5ae85ad64a3802c1953f0ab7672af2b05ce15609a3b6c3a177dc2bd72",
       "since": "2025-01-01"
     },
     "cli:init": {
@@ -778,7 +778,7 @@
       "type": "cli-command",
       "domain": "setup",
       "sourcePath": "src/cli.ts",
-      "contentHash": "410c6f2c325138a52996c3e2339d9b21fe7a32d90a20cc83d8754ad2d44e700f",
+      "contentHash": "cedd7aaca10839a47af5a19f09b3ce8509a978166a6e2c4994fcbaa4de0a459a",
       "since": "2025-01-01"
     },
     "cli:setup": {
@@ -786,7 +786,7 @@
       "type": "cli-command",
       "domain": "setup",
       "sourcePath": "src/cli.ts",
-      "contentHash": "410c6f2c325138a52996c3e2339d9b21fe7a32d90a20cc83d8754ad2d44e700f",
+      "contentHash": "cedd7aaca10839a47af5a19f09b3ce8509a978166a6e2c4994fcbaa4de0a459a",
       "since": "2025-01-01"
     },
     "cli:add": {
@@ -794,7 +794,7 @@
       "type": "cli-command",
       "domain": "setup",
       "sourcePath": "src/cli.ts",
-      "contentHash": "410c6f2c325138a52996c3e2339d9b21fe7a32d90a20cc83d8754ad2d44e700f",
+      "contentHash": "cedd7aaca10839a47af5a19f09b3ce8509a978166a6e2c4994fcbaa4de0a459a",
       "since": "2025-01-01"
     },
     "cli:backup": {
@@ -802,7 +802,7 @@
       "type": "cli-command",
       "domain": "operations",
       "sourcePath": "src/cli.ts",
-      "contentHash": "410c6f2c325138a52996c3e2339d9b21fe7a32d90a20cc83d8754ad2d44e700f",
+      "contentHash": "cedd7aaca10839a47af5a19f09b3ce8509a978166a6e2c4994fcbaa4de0a459a",
       "since": "2025-01-01"
     },
     "cli:git": {
@@ -810,7 +810,7 @@
       "type": "cli-command",
       "domain": "coordination",
       "sourcePath": "src/cli.ts",
-      "contentHash": "410c6f2c325138a52996c3e2339d9b21fe7a32d90a20cc83d8754ad2d44e700f",
+      "contentHash": "cedd7aaca10839a47af5a19f09b3ce8509a978166a6e2c4994fcbaa4de0a459a",
       "since": "2025-01-01"
     },
     "cli:memory": {
@@ -818,7 +818,7 @@
       "type": "cli-command",
       "domain": "memory",
       "sourcePath": "src/cli.ts",
-      "contentHash": "410c6f2c325138a52996c3e2339d9b21fe7a32d90a20cc83d8754ad2d44e700f",
+      "contentHash": "cedd7aaca10839a47af5a19f09b3ce8509a978166a6e2c4994fcbaa4de0a459a",
       "since": "2025-01-01"
     },
     "cli:knowledge": {
@@ -826,7 +826,7 @@
       "type": "cli-command",
       "domain": "memory",
       "sourcePath": "src/cli.ts",
-      "contentHash": "410c6f2c325138a52996c3e2339d9b21fe7a32d90a20cc83d8754ad2d44e700f",
+      "contentHash": "cedd7aaca10839a47af5a19f09b3ce8509a978166a6e2c4994fcbaa4de0a459a",
       "since": "2025-01-01"
     },
     "cli:semantic": {
@@ -834,7 +834,7 @@
       "type": "cli-command",
       "domain": "memory",
       "sourcePath": "src/cli.ts",
-      "contentHash": "410c6f2c325138a52996c3e2339d9b21fe7a32d90a20cc83d8754ad2d44e700f",
+      "contentHash": "cedd7aaca10839a47af5a19f09b3ce8509a978166a6e2c4994fcbaa4de0a459a",
       "since": "2025-01-01"
     },
     "cli:intent": {
@@ -842,7 +842,7 @@
       "type": "cli-command",
       "domain": "intent",
       "sourcePath": "src/cli.ts",
-      "contentHash": "410c6f2c325138a52996c3e2339d9b21fe7a32d90a20cc83d8754ad2d44e700f",
+      "contentHash": "cedd7aaca10839a47af5a19f09b3ce8509a978166a6e2c4994fcbaa4de0a459a",
       "since": "2025-01-01"
     },
     "cli:feedback": {
@@ -850,7 +850,7 @@
       "type": "cli-command",
       "domain": "feedback",
       "sourcePath": "src/cli.ts",
-      "contentHash": "410c6f2c325138a52996c3e2339d9b21fe7a32d90a20cc83d8754ad2d44e700f",
+      "contentHash": "cedd7aaca10839a47af5a19f09b3ce8509a978166a6e2c4994fcbaa4de0a459a",
       "since": "2025-01-01"
     },
     "cli:server": {
@@ -858,7 +858,7 @@
       "type": "cli-command",
       "domain": "server",
       "sourcePath": "src/cli.ts",
-      "contentHash": "410c6f2c325138a52996c3e2339d9b21fe7a32d90a20cc83d8754ad2d44e700f",
+      "contentHash": "cedd7aaca10839a47af5a19f09b3ce8509a978166a6e2c4994fcbaa4de0a459a",
       "since": "2025-01-01"
     },
     "cli:status": {
@@ -866,7 +866,7 @@
       "type": "cli-command",
       "domain": "monitoring",
       "sourcePath": "src/cli.ts",
-      "contentHash": "410c6f2c325138a52996c3e2339d9b21fe7a32d90a20cc83d8754ad2d44e700f",
+      "contentHash": "cedd7aaca10839a47af5a19f09b3ce8509a978166a6e2c4994fcbaa4de0a459a",
       "since": "2025-01-01"
     },
     "cli:user": {
@@ -874,7 +874,7 @@
       "type": "cli-command",
       "domain": "users",
       "sourcePath": "src/cli.ts",
-      "contentHash": "410c6f2c325138a52996c3e2339d9b21fe7a32d90a20cc83d8754ad2d44e700f",
+      "contentHash": "cedd7aaca10839a47af5a19f09b3ce8509a978166a6e2c4994fcbaa4de0a459a",
       "since": "2025-01-01"
     },
     "cli:relationship": {
@@ -882,7 +882,7 @@
       "type": "cli-command",
       "domain": "relationships",
       "sourcePath": "src/cli.ts",
-      "contentHash": "410c6f2c325138a52996c3e2339d9b21fe7a32d90a20cc83d8754ad2d44e700f",
+      "contentHash": "cedd7aaca10839a47af5a19f09b3ce8509a978166a6e2c4994fcbaa4de0a459a",
       "since": "2025-01-01"
     },
     "cli:job": {
@@ -890,7 +890,7 @@
       "type": "cli-command",
       "domain": "scheduling",
       "sourcePath": "src/cli.ts",
-      "contentHash": "410c6f2c325138a52996c3e2339d9b21fe7a32d90a20cc83d8754ad2d44e700f",
+      "contentHash": "cedd7aaca10839a47af5a19f09b3ce8509a978166a6e2c4994fcbaa4de0a459a",
       "since": "2025-01-01"
     },
     "cli:lifeline": {
@@ -898,7 +898,7 @@
       "type": "cli-command",
       "domain": "communication",
       "sourcePath": "src/cli.ts",
-      "contentHash": "410c6f2c325138a52996c3e2339d9b21fe7a32d90a20cc83d8754ad2d44e700f",
+      "contentHash": "cedd7aaca10839a47af5a19f09b3ce8509a978166a6e2c4994fcbaa4de0a459a",
       "since": "2025-01-01"
     },
     "cli:list": {
@@ -906,7 +906,7 @@
       "type": "cli-command",
       "domain": "monitoring",
       "sourcePath": "src/cli.ts",
-      "contentHash": "410c6f2c325138a52996c3e2339d9b21fe7a32d90a20cc83d8754ad2d44e700f",
+      "contentHash": "cedd7aaca10839a47af5a19f09b3ce8509a978166a6e2c4994fcbaa4de0a459a",
       "since": "2025-01-01"
     },
     "cli:autostart": {
@@ -914,7 +914,7 @@
       "type": "cli-command",
       "domain": "operations",
       "sourcePath": "src/cli.ts",
-      "contentHash": "410c6f2c325138a52996c3e2339d9b21fe7a32d90a20cc83d8754ad2d44e700f",
+      "contentHash": "cedd7aaca10839a47af5a19f09b3ce8509a978166a6e2c4994fcbaa4de0a459a",
       "since": "2025-01-01"
     },
     "cli:migrate": {
@@ -922,7 +922,7 @@
       "type": "cli-command",
       "domain": "updates",
       "sourcePath": "src/cli.ts",
-      "contentHash": "410c6f2c325138a52996c3e2339d9b21fe7a32d90a20cc83d8754ad2d44e700f",
+      "contentHash": "cedd7aaca10839a47af5a19f09b3ce8509a978166a6e2c4994fcbaa4de0a459a",
       "since": "2025-01-01"
     },
     "cli:machines": {
@@ -930,7 +930,7 @@
       "type": "cli-command",
       "domain": "coordination",
       "sourcePath": "src/cli.ts",
-      "contentHash": "410c6f2c325138a52996c3e2339d9b21fe7a32d90a20cc83d8754ad2d44e700f",
+      "contentHash": "cedd7aaca10839a47af5a19f09b3ce8509a978166a6e2c4994fcbaa4de0a459a",
       "since": "2025-01-01"
     },
     "cli:whoami": {
@@ -938,7 +938,7 @@
       "type": "cli-command",
       "domain": "identity",
       "sourcePath": "src/cli.ts",
-      "contentHash": "410c6f2c325138a52996c3e2339d9b21fe7a32d90a20cc83d8754ad2d44e700f",
+      "contentHash": "cedd7aaca10839a47af5a19f09b3ce8509a978166a6e2c4994fcbaa4de0a459a",
       "since": "2025-01-01"
     },
     "cli:pair": {
@@ -946,7 +946,7 @@
       "type": "cli-command",
       "domain": "coordination",
       "sourcePath": "src/cli.ts",
-      "contentHash": "410c6f2c325138a52996c3e2339d9b21fe7a32d90a20cc83d8754ad2d44e700f",
+      "contentHash": "cedd7aaca10839a47af5a19f09b3ce8509a978166a6e2c4994fcbaa4de0a459a",
       "since": "2025-01-01"
     },
     "cli:join": {
@@ -954,7 +954,7 @@
       "type": "cli-command",
       "domain": "coordination",
       "sourcePath": "src/cli.ts",
-      "contentHash": "410c6f2c325138a52996c3e2339d9b21fe7a32d90a20cc83d8754ad2d44e700f",
+      "contentHash": "cedd7aaca10839a47af5a19f09b3ce8509a978166a6e2c4994fcbaa4de0a459a",
       "since": "2025-01-01"
     },
     "cli:wakeup": {
@@ -962,7 +962,7 @@
       "type": "cli-command",
       "domain": "coordination",
       "sourcePath": "src/cli.ts",
-      "contentHash": "410c6f2c325138a52996c3e2339d9b21fe7a32d90a20cc83d8754ad2d44e700f",
+      "contentHash": "cedd7aaca10839a47af5a19f09b3ce8509a978166a6e2c4994fcbaa4de0a459a",
       "since": "2025-01-01"
     },
     "cli:leave": {
@@ -970,7 +970,7 @@
       "type": "cli-command",
       "domain": "coordination",
       "sourcePath": "src/cli.ts",
-      "contentHash": "410c6f2c325138a52996c3e2339d9b21fe7a32d90a20cc83d8754ad2d44e700f",
+      "contentHash": "cedd7aaca10839a47af5a19f09b3ce8509a978166a6e2c4994fcbaa4de0a459a",
       "since": "2025-01-01"
     },
     "cli:doctor": {
@@ -978,7 +978,7 @@
       "type": "cli-command",
       "domain": "monitoring",
       "sourcePath": "src/cli.ts",
-      "contentHash": "410c6f2c325138a52996c3e2339d9b21fe7a32d90a20cc83d8754ad2d44e700f",
+      "contentHash": "cedd7aaca10839a47af5a19f09b3ce8509a978166a6e2c4994fcbaa4de0a459a",
       "since": "2025-01-01"
     },
     "cli:review": {
@@ -986,7 +986,7 @@
       "type": "cli-command",
       "domain": "monitoring",
       "sourcePath": "src/cli.ts",
-      "contentHash": "410c6f2c325138a52996c3e2339d9b21fe7a32d90a20cc83d8754ad2d44e700f",
+      "contentHash": "cedd7aaca10839a47af5a19f09b3ce8509a978166a6e2c4994fcbaa4de0a459a",
       "since": "2025-01-01"
     },
     "cli:nuke": {
@@ -994,7 +994,7 @@
       "type": "cli-command",
       "domain": "operations",
       "sourcePath": "src/cli.ts",
-      "contentHash": "410c6f2c325138a52996c3e2339d9b21fe7a32d90a20cc83d8754ad2d44e700f",
+      "contentHash": "cedd7aaca10839a47af5a19f09b3ce8509a978166a6e2c4994fcbaa4de0a459a",
       "since": "2025-01-01"
     },
     "cli:playbook": {
@@ -1002,7 +1002,7 @@
       "type": "cli-command",
       "domain": "context",
       "sourcePath": "src/cli.ts",
-      "contentHash": "410c6f2c325138a52996c3e2339d9b21fe7a32d90a20cc83d8754ad2d44e700f",
+      "contentHash": "cedd7aaca10839a47af5a19f09b3ce8509a978166a6e2c4994fcbaa4de0a459a",
       "since": "2025-01-01"
     },
     "cli:dev-preflight": {
@@ -1010,7 +1010,7 @@
       "type": "cli-command",
       "domain": "development",
       "sourcePath": "src/cli.ts",
-      "contentHash": "410c6f2c325138a52996c3e2339d9b21fe7a32d90a20cc83d8754ad2d44e700f",
+      "contentHash": "cedd7aaca10839a47af5a19f09b3ce8509a978166a6e2c4994fcbaa4de0a459a",
       "since": "2025-01-01"
     },
     "cli:dev-ci-failures": {
@@ -1018,7 +1018,7 @@
       "type": "cli-command",
       "domain": "development",
       "sourcePath": "src/cli.ts",
-      "contentHash": "410c6f2c325138a52996c3e2339d9b21fe7a32d90a20cc83d8754ad2d44e700f",
+      "contentHash": "cedd7aaca10839a47af5a19f09b3ce8509a978166a6e2c4994fcbaa4de0a459a",
       "since": "2025-01-01"
     },
     "cli:dev-profile-node": {
@@ -1026,7 +1026,7 @@
       "type": "cli-command",
       "domain": "development",
       "sourcePath": "src/cli.ts",
-      "contentHash": "410c6f2c325138a52996c3e2339d9b21fe7a32d90a20cc83d8754ad2d44e700f",
+      "contentHash": "cedd7aaca10839a47af5a19f09b3ce8509a978166a6e2c4994fcbaa4de0a459a",
       "since": "2025-01-01"
     },
     "template:build-stop-hook.sh": {
@@ -1498,7 +1498,7 @@
       "type": "subsystem",
       "domain": "server",
       "sourcePath": "src/server/AgentServer.ts",
-      "contentHash": "460b355d5c71dbedcb2118219eded0b68018dc47d51ff74d8b9cad2f715c6982",
+      "contentHash": "df80218338a05c47663780e16bff41f8ed77476f44f2b29d421a116ce8eb8352",
       "since": "2025-01-01"
     },
     "subsystem:session-manager": {
@@ -1530,7 +1530,7 @@
       "type": "subsystem",
       "domain": "updates",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
-      "contentHash": "556dd545f7048e4a4968786c7ff04746dca0f780651c97ebc0be57a920e4d56b",
+      "contentHash": "4a7c91baa7cade8a07bfa1c7abf0669511fcf6fc07791403944aede1691567e2",
       "since": "2025-01-01"
     },
     "subsystem:scheduler": {

--- a/src/monitoring/QuotaCollector.ts
+++ b/src/monitoring/QuotaCollector.ts
@@ -15,6 +15,20 @@
  * - Request budget enforcement (max N requests per 5-minute window)
  *
  * Part of Phase 2 of the Instar Quota Migration spec.
+ *
+ * RULE 3.1 RATIONALE
+ *   Criticality: high — wrong quota state silently misroutes scheduler/spawn
+ *                decisions and can make a framework look available when it is
+ *                actually blocked.
+ *   Frequency:   per-poll (adaptive interval; normally minutes, not per-turn).
+ *   Stability:   semi-stable — the Anthropic OAuth usage response is external
+ *                provider state, while JSONL fallback parsing reads local
+ *                provider log shape.
+ *   Fallback:    OAuth failures degrade to JSONL estimates; stale/missing
+ *                quota state fails open in QuotaTracker.
+ *   Verdict:     deterministic collector with explicit source attribution and
+ *                registry coverage in specs/provider-portability/06-state-
+ *                detector-registry.md.
  */
 
 import fs from 'node:fs';
@@ -788,6 +802,7 @@ export class QuotaCollector extends EventEmitter {
     const state: QuotaState = {
       usagePercent: weeklyUtil,
       fiveHourPercent: fiveHourUtil,
+      source: 'anthropic-oauth',
       lastUpdated: new Date().toISOString(),
     };
 
@@ -894,6 +909,7 @@ export class QuotaCollector extends EventEmitter {
 
     return {
       usagePercent: estimatedPercent,
+      source: 'claude-jsonl',
       lastUpdated: new Date().toISOString(),
     };
   }

--- a/src/providers/adapters/gemini-cli/observability/geminiCapacityPolicy.ts
+++ b/src/providers/adapters/gemini-cli/observability/geminiCapacityPolicy.ts
@@ -13,6 +13,9 @@
  */
 
 import { GEMINI_DEFAULT_MODEL, isKnownGeminiModel } from '../models.js';
+import fs from 'node:fs';
+import path from 'node:path';
+import { SafeFsExecutor } from '../../../../core/SafeFsExecutor.js';
 
 export interface GeminiCapacityPolicyConfig {
   enabled?: boolean;
@@ -24,6 +27,12 @@ export interface GeminiCapacityPolicyConfig {
   backoffMs?: number;
   /** Optional operator-selected fallback. Ignored unless it is a known Gemini model. */
   fallbackModel?: string;
+  /**
+   * Optional quota-state output path. When set, long Gemini capacity deferrals
+   * are written as stop-state snapshots so the existing quota gate blocks
+   * doomed scheduler spawns until the CLI-reported reset window passes.
+   */
+  quotaStateFile?: string;
 }
 
 export type GeminiCapacityAction = 'none' | 'retry' | 'defer';
@@ -154,12 +163,65 @@ export function getGeminiCapacityGate(now = Date.now()): GeminiCapacityGate {
 export function recordGeminiCapacityDeferral(params: {
   retryAfterMs: number;
   reason: string;
+  model?: string;
+  quotaStateFile?: string;
   now?: number;
 }): GeminiCapacityGate {
   const now = params.now ?? Date.now();
   deferredUntil = now + Math.max(1, params.retryAfterMs) + RESET_GRACE_MS;
   deferredReason = params.reason;
+  if (params.quotaStateFile) {
+    try {
+      writeGeminiQuotaState({
+        quotaStateFile: params.quotaStateFile,
+        blockedUntil: deferredUntil,
+        reason: params.reason,
+        model: params.model ?? GEMINI_DEFAULT_MODEL,
+        now,
+      });
+    } catch (err) {
+      console.warn(
+        `[gemini-capacity-policy] failed to persist quota state: ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      );
+    }
+  }
   return getGeminiCapacityGate(now);
+}
+
+function writeGeminiQuotaState(params: {
+  quotaStateFile: string;
+  blockedUntil: number;
+  reason: string;
+  model: string;
+  now: number;
+}): void {
+  const state = {
+    usagePercent: 0,
+    fiveHourPercent: 100,
+    source: 'gemini-cli-capacity',
+    model: params.model,
+    blockedUntil: new Date(params.blockedUntil).toISOString(),
+    blockReason: params.reason,
+    lastUpdated: new Date(params.now).toISOString(),
+    recommendation: 'stop',
+  };
+
+  const dir = path.dirname(params.quotaStateFile);
+  fs.mkdirSync(dir, { recursive: true });
+  const tmp = `${params.quotaStateFile}.${process.pid}.${Math.random().toString(36).slice(2)}.tmp`;
+  try {
+    fs.writeFileSync(tmp, JSON.stringify(state, null, 2));
+    fs.renameSync(tmp, params.quotaStateFile);
+  } catch (err) {
+    try {
+      SafeFsExecutor.safeUnlinkSync(tmp, {
+        operation: 'geminiCapacityPolicy.writeGeminiQuotaState.cleanup',
+      });
+    } catch { /* best-effort cleanup */ }
+    throw err;
+  }
 }
 
 export function resetGeminiCapacityPolicyForTests(): void {

--- a/src/providers/adapters/gemini-cli/transport/oneShotCompletion.ts
+++ b/src/providers/adapters/gemini-cli/transport/oneShotCompletion.ts
@@ -110,6 +110,8 @@ class GeminiCliOneShotCompletion implements OneShotCompletion {
           recordGeminiCapacityDeferral({
             retryAfterMs: capacity.retryAfterMs,
             reason: capacity.reason ?? mapped.message,
+            model: currentModel,
+            quotaStateFile: this.config.capacityPolicy?.quotaStateFile,
           });
           throw new QuotaError(
             `${capacity.reason}: ${mapped.message}`,

--- a/tests/e2e/gemini-capacity-policy-lifecycle.test.ts
+++ b/tests/e2e/gemini-capacity-policy-lifecycle.test.ts
@@ -6,6 +6,7 @@ import os from 'node:os';
 import path from 'node:path';
 import { GeminiCliIntelligenceProvider } from '../../src/core/GeminiCliIntelligenceProvider.js';
 import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+import { QuotaTracker } from '../../src/monitoring/QuotaTracker.js';
 import { resetGeminiCapacityPolicyForTests } from '../../src/providers/adapters/gemini-cli/observability/geminiCapacityPolicy.js';
 
 describe('Gemini capacity policy lifecycle (E2E)', () => {
@@ -34,10 +35,36 @@ process.exit(1);
 `);
     fs.chmodSync(bin, 0o755);
 
-    const provider = new GeminiCliIntelligenceProvider({ geminiPath: bin });
+    const quotaFile = path.join(tmpDir, 'quota-state.json');
+    const provider = new GeminiCliIntelligenceProvider({
+      geminiPath: bin,
+      capacityPolicy: { quotaStateFile: quotaFile },
+    });
     await expect(provider.evaluate('p', { timeoutMs: 10_000 })).rejects.toThrow(/deferring|quota/i);
     await expect(provider.evaluate('p', { timeoutMs: 10_000 })).rejects.toThrow(/deferred|retry after/i);
     expect(fs.readFileSync(countFile, 'utf8')).toBe('1');
+
+    const written = JSON.parse(fs.readFileSync(quotaFile, 'utf8')) as {
+      source: string;
+      model: string;
+      fiveHourPercent: number;
+      blockedUntil: string;
+      recommendation: string;
+    };
+    expect(written.source).toBe('gemini-cli-capacity');
+    expect(written.model).toBe('gemini-2.5-flash');
+    expect(written.fiveHourPercent).toBe(100);
+    expect(written.recommendation).toBe('stop');
+    expect(new Date(written.blockedUntil).getTime()).toBeGreaterThan(Date.now());
+
+    const tracker = new QuotaTracker({
+      quotaFile,
+      thresholds: { normal: 50, elevated: 60, critical: 80, shutdown: 95 },
+    });
+    expect(tracker.shouldSpawnSession('low')).toMatchObject({
+      allowed: false,
+      reason: expect.stringContaining('5-hour rate limit'),
+    });
   });
 
   it('the live Gemini provider applies fallbackModel to the spawned retry argv', async () => {

--- a/tests/integration/gemini-capacity-policy-integration.test.ts
+++ b/tests/integration/gemini-capacity-policy-integration.test.ts
@@ -90,6 +90,7 @@ process.stdout.write('OK_WITH_FALLBACK');
 
   it('defers after a long quota reset and refuses the next call locally', async () => {
     const countFile = path.join(tmpDir, 'count');
+    const quotaFile = path.join(tmpDir, 'quota-state.json');
     const bin = fakeGemini(`
 const fs = require('fs');
 const countFile = ${JSON.stringify(countFile)};
@@ -98,10 +99,24 @@ fs.writeFileSync(countFile, String(n + 1));
 process.stderr.write('TerminalQuotaError: QUOTA_EXHAUSTED. Your quota will reset after 2h0m0s.');
 process.exit(1);
 `);
-    const adapter = createGeminiCliAdapter({ geminiPath: bin });
+    const adapter = createGeminiCliAdapter({
+      geminiPath: bin,
+      capacityPolicy: { quotaStateFile: quotaFile },
+    });
     const oneShot = adapter.primitive(CapabilityFlag.OneShotCompletion) as OneShotCompletion;
     await expect(oneShot.evaluate('p', { timeoutMs: 10_000 })).rejects.toBeInstanceOf(QuotaError);
     await expect(oneShot.evaluate('p', { timeoutMs: 10_000 })).rejects.toBeInstanceOf(QuotaError);
     expect(fs.readFileSync(countFile, 'utf8')).toBe('1');
+
+    const state = JSON.parse(fs.readFileSync(quotaFile, 'utf8')) as {
+      source: string;
+      fiveHourPercent: number;
+      model: string;
+      recommendation: string;
+    };
+    expect(state.source).toBe('gemini-cli-capacity');
+    expect(state.fiveHourPercent).toBe(100);
+    expect(state.model).toBe('gemini-2.5-flash');
+    expect(state.recommendation).toBe('stop');
   });
 });

--- a/tests/unit/intelligenceProviderFactory.test.ts
+++ b/tests/unit/intelligenceProviderFactory.test.ts
@@ -53,6 +53,18 @@ describe('buildIntelligenceProvider', () => {
     expectWraps(p, GeminiCliIntelligenceProvider);
   });
 
+  it('passes quotaStateFile only to the gemini provider capacity policy', () => {
+    const p = buildIntelligenceProvider({
+      framework: 'gemini-cli',
+      binaryPath: '/usr/bin/gemini',
+      quotaStateFile: '/tmp/gemini-quota-state.json',
+    });
+    expectWraps(p, GeminiCliIntelligenceProvider);
+    const inner = (p as unknown as { inner: GeminiCliIntelligenceProvider }).inner;
+    expect((inner as unknown as { capacityPolicy?: { quotaStateFile?: string } }).capacityPolicy?.quotaStateFile)
+      .toBe('/tmp/gemini-quota-state.json');
+  });
+
   it('defaults to claude-code when framework is omitted', () => {
     const p = buildIntelligenceProvider({ binaryPath: '/usr/bin/claude' });
     expectWraps(p, ClaudeCliIntelligenceProvider);

--- a/upgrades/next/gemini-quota-state-framework-aware.md
+++ b/upgrades/next/gemini-quota-state-framework-aware.md
@@ -1,0 +1,37 @@
+# Gemini Quota State Framework Awareness
+
+<!-- bump: patch -->
+
+## What Changed
+
+Gemini quota-state reporting is now framework-aware. Gemini agents no longer run
+the Claude/Anthropic quota collector, so they cannot accidentally display Claude
+usage as Gemini usage. When Gemini CLI itself reports a long model capacity reset,
+the Gemini adapter now writes a Gemini-authored stop-state into the existing quota
+file with source, model, reset-window, and reason metadata. That lets the
+scheduler see the same live capacity block the CLI enforced instead of repeatedly
+spawning doomed Gemini work.
+
+## What to Tell Your User
+
+When Gemini is throttled, I now treat the live Gemini CLI limit as the reliable
+signal and stop showing unrelated Claude quota as if it were Gemini's quota. That
+means fewer misleading "looks available" moments when Gemini itself is actually
+waiting for a reset.
+
+## Summary of New Capabilities
+
+| Capability | How to Use |
+|-----------|-----------|
+| Gemini quota-state attribution | Automatic. Gemini agents skip Claude quota collection and persist live Gemini CLI capacity blocks into the existing quota gate. |
+
+## Evidence
+
+The bug was reproduced during the Codey to Gemini mentorship loop: the quota
+state showed 15% usage, but a live Gemini CLI spawn reported a usage limit for
+the active Gemini model. Source tracing on current main showed the 15% value came
+from the Claude-specific quota collector, while Gemini capacity deferrals only
+lived in memory. After this change, focused unit, integration, and E2E tests
+verify that Gemini capacity deferrals persist a Gemini-authored quota stop-state
+and that the existing quota tracker blocks future low-priority spawns from that
+state.

--- a/upgrades/side-effects/gemini-quota-state-framework-aware.md
+++ b/upgrades/side-effects/gemini-quota-state-framework-aware.md
@@ -1,0 +1,87 @@
+# Side-Effects Review — Gemini quota state framework awareness
+
+**Version / slug:** `gemini-quota-state-framework-aware`
+**Date:** `2026-06-04`
+**Author:** `instar-codey`
+**Second-pass reviewer:** `not required`
+
+## Summary of the change
+
+This change fixes the Gemini quota-state mismatch found during the Codey to Gemini mentorship loop. The server no longer starts the Claude-specific quota collector for non-Claude frameworks, so Gemini agents cannot write Anthropic usage into their own quota state. The Gemini CLI capacity policy now persists long CLI-reported capacity blocks into the existing quota-state file, with source/model/reset metadata, so the existing spawn gate sees the same block the Gemini CLI reported. The change touches server wiring, the intelligence provider factory, Gemini live/registry capacity handling, the shared quota state type, the Claude quota collector's source attribution, and focused unit/integration/E2E tests.
+
+## Decision-point inventory
+
+- Server quota collector startup — modify — framework-aware: Claude collector starts only for `claude-code`; Gemini/Codex skip until a native usage meter exists.
+- Gemini capacity policy — modify — persists provider capacity deferrals into quota state as a stop recommendation.
+- Quota spawn gate — pass-through — continues to consume `QuotaState`; this change feeds it a Gemini-authored stop-state instead of changing its authority logic.
+- Intelligence source labeling — modify — reports Gemini CLI as Gemini CLI, not Claude CLI subscription.
+
+---
+
+## 1. Over-block
+
+Gemini can now write `fiveHourPercent: 100` when the CLI reports a long reset window, which causes the existing quota gate to block low-priority spawns until the reset window passes. A false-positive Gemini CLI error parse could therefore pause Gemini work that might otherwise have succeeded. The parser already distinguishes short retryable capacity failures from long deferrals, and the persisted state is written only after the Gemini capacity classifier chooses `defer`.
+
+---
+
+## 2. Under-block
+
+This does not implement a full native Gemini usage meter. If Gemini is near quota but has not yet produced a CLI capacity error, the quota file may still not forecast that future limit. It also does not parse every possible future Gemini/Antigravity wording; it persists the capacity signal only when the existing Gemini classifier recognizes the error as a long quota/capacity reset.
+
+---
+
+## 3. Level-of-abstraction fit
+
+The change stays at the framework boundary. Claude usage collection remains in the Claude collector. Gemini capacity persistence happens in the Gemini adapter's capacity policy, where the live CLI error and selected model are available. The existing quota tracker remains the authority for spawn decisions; the Gemini policy produces a framework-specific signal in the format that authority already consumes.
+
+---
+
+## 4. Signal vs authority compliance
+
+- [x] No — this change produces a signal consumed by an existing smart gate.
+
+The only blocking authority remains the existing quota tracker/spawn gate. The Gemini adapter writes a provider-authored state snapshot when the CLI reports a long capacity block. The deterministic part is limited to translating that provider signal into existing quota-state fields; it does not introduce a parallel block/allow gate.
+
+---
+
+## 5. Interactions
+
+- **Shadowing:** Skipping `QuotaCollector` for Gemini removes the previous Claude-specific writer. For Gemini, the new writer only fires after a live CLI capacity failure, so it does not shadow a native Gemini usage meter because none exists in this codebase.
+- **Double-fire:** Claude agents still use the Anthropic collector. Gemini agents write quota state from the capacity policy. A future native Gemini usage meter will need to coordinate with this writer, but today's framework guard prevents Claude and Gemini writers from competing on the same agent.
+- **Races:** The quota-state write is atomic via temp file plus rename. Write failures are logged and fail open so the original CLI quota error is preserved.
+- **Feedback loops:** A persisted Gemini stop-state makes future scheduler/spawn checks stop earlier instead of repeatedly invoking the already-blocked CLI. The state is reset by the existing quota-state lifecycle after the configured window/next successful collection path.
+
+---
+
+## 6. External surfaces
+
+Other agents see a quieter and more accurate quota state. Gemini-only agents no longer display Claude/Anthropic usage as their own quota. Persistent state gains optional metadata fields: source, model, blockedUntil, and blockReason. Existing readers tolerate optional fields because the required quota fields remain unchanged. The user-visible effect is that Gemini throttling should be reported as Gemini CLI capacity rather than as a misleading low usage percentage from another provider.
+
+---
+
+## 7. Rollback cost
+
+Rollback is a normal code revert. Persisted Gemini quota-state files may retain the optional metadata fields after rollback, but existing code ignores unknown optional fields and still reads the required percentage/timestamp/recommendation values. If a bad persisted stop-state blocks Gemini after rollback, deleting or refreshing that agent's quota-state file clears it; no database migration is involved.
+
+---
+
+## Conclusion
+
+The review kept authority in the existing quota gate and moved provider-specific observation to the provider boundary. The main residual gap is deliberate: this is not a complete Gemini usage meter, only correct attribution plus persistence of live CLI capacity blocks. Focused unit, integration, E2E, and typecheck coverage exercise the factory wiring, both Gemini capacity paths, persisted stop-state shape, and quota gate consumption.
+
+---
+
+## Second-pass review (if required)
+
+**Reviewer:** not required
+**Independent read of the artifact:** not required
+
+Tier-2 implementation against the approved Gemini runtime-adapter spec; no separate second-pass reviewer was required for this scoped fix.
+
+---
+
+## Evidence pointers
+
+- Focused Gemini capacity unit/integration/E2E tests passed.
+- TypeScript typecheck passed.
+- Additional quota-manager and quota-collection tests are run before push.


### PR DESCRIPTION
## Summary
- make quota collection framework-aware so Gemini/Codex agents do not run the Claude/Anthropic quota collector
- persist Gemini CLI long capacity deferrals into the existing quota-state gate with Gemini source/model/reset metadata
- add focused factory, integration, and E2E coverage plus side-effects and release-note artifacts

## Root cause
Gemi's quota state was not reading Gemini quota at all. The server wired the Claude-specific QuotaCollector for any quota-enabled agent, so a Gemini-only agent could write Anthropic usage into its quota-state file. Gemini CLI model-capacity blocks were handled separately in memory and were not persisted to quota state.

## Verification
- npx vitest run focused Gemini capacity/factory suites: 18 tests passed
- npx vitest run broader quota + Gemini capacity suites: 19 files / 257 tests passed
- npm run lint
- npm run build
- npm run check:upgrade-guide (validated current guide; historical warnings pre-existing)
- instar-dev precommit gate passed with approved Gemini runtime-adapter spec and side-effects artifact
- pre-push gate passed; local smoke affected set was too broad and deferred full matrix to CI
