### PR TITLE
docs(release): fix #750 fragment so v1.3.247 publishes

### DIFF
--- a/upgrades/next/mm-placement-transfer-robustness.md
+++ b/upgrades/next/mm-placement-transfer-robustness.md
@@ -28,10 +28,17 @@ move-back bug (shipped in #750; this fragment cuts the release that carries it).
 
 ## What to Tell Your User
 
-- **You can now ask where a conversation is running, and move it reliably**: "where is
-  this running / why?" reports the machine and whether it was deliberately moved there
-  or just load-balanced, and "move this to `<machine>`" now always works — including
-  moving it *back* to the machine you're already on (which used to silently do nothing).
+- **You can now ask where a conversation is running, and move it reliably.** Ask "where
+  is this running, and why?" and I'll tell you which machine has it and whether it was
+  deliberately moved there or just load-balanced. And "move this to the mini" (or any
+  machine) now always works — including moving it back to the machine you're already on,
+  which used to silently do nothing.
+
+## Summary of New Capabilities
+
+- Ask which machine a topic runs on and why (pinned vs load-placed), from any machine.
+- Reliable "move this to <machine>" — including the move-back that previously failed.
+- A deterministic transfer option that doesn't depend on phrasing.
 
 ## Evidence
 


### PR DESCRIPTION
The publish guide-check blocked v1.3.247 because the #750 release fragment was missing `## Summary of New Capabilities` and had inline code in `What to Tell Your User`. Fixed both (validated locally). Unblocks the release that deploys the placement/transfer fix.