### PR TITLE
test(e2e): make Telegraph publish e2e tolerant of transient API errors

### DIFF
--- a/docs/specs/telegraph-e2e-flake-tolerant.eli16.md
+++ b/docs/specs/telegraph-e2e-flake-tolerant.eli16.md
@@ -1,0 +1,36 @@
+# ELI16 — Telegraph e2e test tolerant of transient API hiccups
+
+## What this is, in plain English
+
+Instar can publish pages to Telegraph (a free public web-page service). To make
+sure that feature really works, there's an end-to-end test that actually talks
+to the live Telegraph website: it creates a page, edits it, reads it back.
+
+## The problem
+
+Talking to a real external website means sometimes the website has a momentary
+hiccup — it returns an error like `PAGE_SAVE_FAILED` for a second, then is fine
+again. That has nothing to do with our code. But our test ran on every pull
+request, so when Telegraph hiccupped, the WHOLE build went red — even on pull
+requests that never touched Telegraph at all. That actually happened: a teammate's
+unrelated change (fixing a Gemini quota bug) got a red build purely because the
+Telegraph website blinked at the wrong moment. Red builds block merges and waste
+everyone's time chasing a "failure" that isn't real.
+
+## What's new
+
+The test now retries those external calls a few times before giving up. If the
+website hiccups, the test quietly tries again (up to 4 times, with a short pause
+between) — and almost always the second try succeeds. So a momentary blink no
+longer fails the build.
+
+Crucially, it only retries the specific "the website had a temporary problem"
+errors. If the test finds a REAL bug — a wrong page title, a broken response, a
+genuine outage that doesn't clear — it still fails, loudly, the way it should.
+
+## Why it's safe
+
+It's a change to a test file only — no shipped behavior changes. It can only make
+the test more tolerant of the external website's flakiness, never less tolerant
+of real bugs (those still fail immediately). Verified: the test still passes all
+5 checks against the live Telegraph API, and a type-check is clean.

--- a/tests/e2e/telegraph-publish.test.ts
+++ b/tests/e2e/telegraph-publish.test.ts
@@ -19,6 +19,35 @@ import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
 
 const SKIP = process.env.SKIP_E2E === '1';
 
+/**
+ * Telegraph's public API occasionally returns transient errors (PAGE_SAVE_FAILED,
+ * network blips, 5xx, rate-limit) that are no fault of ours. Those must NOT fail
+ * the build on unrelated PRs — a transient external hiccup once failed CI on a
+ * Gemini quota change that touches zero Telegraph code. Retry a few times with
+ * backoff, then fail only if the service is genuinely down. Non-transient errors
+ * (real bugs / assertion-worthy failures) throw immediately so they still surface.
+ */
+const TRANSIENT_API_ERROR =
+  /PAGE_SAVE_FAILED|FLOOD_WAIT|ENOTFOUND|ECONNRESET|ECONNREFUSED|ETIMEDOUT|EAI_AGAIN|socket hang up|network|fetch failed|\b5\d\d\b|\b429\b/i;
+
+async function withTransientRetry<T>(label: string, fn: () => Promise<T>, attempts = 4): Promise<T> {
+  let lastErr: unknown;
+  for (let attempt = 1; attempt <= attempts; attempt++) {
+    try {
+      return await fn();
+    } catch (err) {
+      lastErr = err;
+      const msg = err instanceof Error ? err.message : String(err);
+      if (!TRANSIENT_API_ERROR.test(msg)) throw err; // real failure — surface immediately
+      if (attempt < attempts) await new Promise((r) => setTimeout(r, 400 * attempt));
+    }
+  }
+  throw new Error(
+    `Telegraph ${label} failed after ${attempts} attempts (transient external API): ` +
+      `${lastErr instanceof Error ? lastErr.message : String(lastErr)}`,
+  );
+}
+
 describe('Telegraph E2E publish flow', () => {
   let stateDir: string;
   let service: TelegraphService;
@@ -39,12 +68,12 @@ describe('Telegraph E2E publish flow', () => {
   });
 
   it.skipIf(SKIP)('creates a Telegraph account', async () => {
-    const token = await service.ensureAccount();
+    const token = await withTransientRetry('ensureAccount', () => service.ensureAccount());
     expect(token).toBeTruthy();
     expect(typeof token).toBe('string');
 
     // Subsequent calls return the same token
-    const token2 = await service.ensureAccount();
+    const token2 = await withTransientRetry('ensureAccount', () => service.ensureAccount());
     expect(token2).toBe(token);
   });
 
@@ -79,7 +108,7 @@ describe('Telegraph E2E publish flow', () => {
       'Final paragraph with ~~strikethrough~~ text.',
     ].join('\n');
 
-    const page = await service.publishPage('Instar E2E Test', markdown);
+    const page = await withTransientRetry('publishPage', () => service.publishPage('Instar E2E Test', markdown));
 
     expect(page.url).toMatch(/^https:\/\/telegra\.ph\//);
     expect(page.path).toBeTruthy();
@@ -99,14 +128,14 @@ describe('Telegraph E2E publish flow', () => {
 
   it.skipIf(SKIP)('edits a published page', async () => {
     // Publish first
-    const original = await service.publishPage('Edit Test', '# Original\n\nOriginal content.');
+    const original = await withTransientRetry('publishPage', () => service.publishPage('Edit Test', '# Original\n\nOriginal content.'));
 
     // Edit it
-    const updated = await service.editPage(
+    const updated = await withTransientRetry('editPage', () => service.editPage(
       original.path,
       'Edit Test (Updated)',
       '# Updated\n\nThis content has been updated by the E2E test.',
-    );
+    ));
 
     expect(updated.url).toMatch(/^https:\/\/telegra\.ph\//);
     expect(updated.title).toBe('Edit Test (Updated)');
@@ -124,7 +153,7 @@ describe('Telegraph E2E publish flow', () => {
     const pages = service.listPages();
     expect(pages.length).toBeGreaterThan(0);
 
-    const views = await service.getPageViews(pages[0].path);
+    const views = await withTransientRetry('getPageViews', () => service.getPageViews(pages[0].path));
     expect(typeof views).toBe('number');
     expect(views).toBeGreaterThanOrEqual(0);
   });

--- a/upgrades/next/telegraph-e2e-flake-tolerant.md
+++ b/upgrades/next/telegraph-e2e-flake-tolerant.md
@@ -1,0 +1,43 @@
+<!-- bump: patch -->
+
+## What Changed
+
+The Telegraph publishing end-to-end test (`tests/e2e/telegraph-publish.test.ts`)
+makes real calls to the live Telegraph API, which occasionally returns transient
+errors (`PAGE_SAVE_FAILED`, network blips, 5xx, rate-limit) through no fault of
+ours. Because the suite runs in the standard CI lane (it only skips when
+`SKIP_E2E=1`), one such hiccup failed the entire build on an unrelated PR — a
+Gemini quota change (#756) that touches zero Telegraph code got a red build
+purely because the Telegraph service blinked at the wrong moment.
+
+This change adds a test-local `withTransientRetry` helper wrapping the six
+live-API call sites (`ensureAccount` / `publishPage` / `editPage` /
+`getPageViews`): a transient / network / 5xx / 429 error is retried up to 4× with
+short backoff; a real failure — an assertion-worthy bug, or a persistent outage
+after retries are exhausted — still fails immediately and loudly.
+
+## Evidence
+
+- **Reproduction:** Codey PR #756 (a Gemini quota-state change touching zero
+  Telegraph code) got a red CI build when the live Telegraph API returned a
+  transient `PAGE_SAVE_FAILED` during the Unit-Tests node-22 shard. Confirmed via
+  `instar dev:ci-failures 756`:
+  `✗ src/publishing/TelegraphService.ts:298 Telegraph API error: PAGE_SAVE_FAILED`
+  surfacing at `tests/e2e/telegraph-publish.test.ts:102`.
+- **Before:** any transient Telegraph hiccup failed the whole build on unrelated
+  PRs — a false failure that blocks merges and sends people chasing a non-bug.
+- **After:** the six live-API calls retry transient errors up to 4×; real
+  failures still fail immediately. Verified locally: `tsc --noEmit` clean and all
+  5 e2e tests pass against the live API
+  (`npx vitest run tests/e2e/telegraph-publish.test.ts --config vitest.e2e.config.ts`
+  → `Tests 5 passed (5)`).
+
+## What to Tell Your User
+
+Nothing user-facing — this is an internal CI-reliability fix. No shipped behavior
+changes; agent-only.
+
+## Summary of New Capabilities
+
+None — internal test-suite robustness improvement (flaky external-API e2e no
+longer fails CI on unrelated PRs).

--- a/upgrades/side-effects/telegraph-e2e-flake-tolerant.md
+++ b/upgrades/side-effects/telegraph-e2e-flake-tolerant.md
@@ -1,0 +1,58 @@
+# Side-Effects Review — Telegraph e2e tolerant of transient external-API errors
+
+**Version / slug:** `telegraph-e2e-flake-tolerant`
+**Date:** `2026-06-04`
+**Author:** `echo`
+**Second-pass reviewer:** `not required`
+
+## Summary of the change
+
+`tests/e2e/telegraph-publish.test.ts` makes REAL calls to the public Telegraph
+API. That API intermittently returns transient errors (`PAGE_SAVE_FAILED`,
+network blips, 5xx, rate-limit) under no fault of ours. Because the suite runs
+in the standard CI lane (it only skips when `SKIP_E2E=1`), a transient hiccup
+fails the whole build on UNRELATED PRs — it just failed the Unit-Tests shard on
+Codey PR #756 (a Gemini quota change touching zero Telegraph code).
+
+The fix adds a test-local `withTransientRetry(label, fn)` helper and wraps the
+six live-API call sites (`ensureAccount` ×2, `publishPage` ×2, `editPage`,
+`getPageViews`). On a transient/network error it retries up to 4× with linear
+backoff; a non-transient error (real bug / assertion-worthy failure) throws
+immediately; if all retries are exhausted it throws (genuinely-down → fail).
+
+## Decision-point inventory
+
+One decision point: `withTransientRetry` classifies a caught error as transient
+(via the `TRANSIENT_API_ERROR` regex) or not. Transient → retry/eventually-fail;
+non-transient → rethrow immediately.
+
+## 1. Over-block
+
+**What legitimate failures does this now hide?** None that matter. The regex
+matches only transient external-service signatures (`PAGE_SAVE_FAILED`,
+`ENOTFOUND`/`ECONNRESET`/`ETIMEDOUT`/`EAI_AGAIN`, `socket hang up`,
+`fetch failed`, 5xx, 429). Assertion failures (`expect(...)`) are NOT thrown by
+the wrapped service calls, so real test-logic regressions still fail. A genuine
+persistent API outage still fails the test after the retries are exhausted.
+
+## 2. Under-block
+
+**What does it still catch?** Any non-transient error from the service (bad
+auth, a real TelegraphService bug, a 4xx other than 429) rethrows on the first
+attempt — no masking. The retry is scoped to the e2e file only; no production
+code path retries (so the publish-idempotency concern — a retry creating a
+duplicate page — is irrelevant: duplicate test pages are harmless, Telegraph
+pages are free + don't expire, and the assertions check `>= 1`, not an exact
+count).
+
+## 3. Blast radius
+
+Test-only: one file, `tests/e2e/telegraph-publish.test.ts`. No `src/` change, no
+production behavior change, no API/schema/config change. The helper is local to
+the file (not exported / not shared).
+
+## 4. Reversibility
+
+Fully reversible: revert the one file. No state, no migration, no persisted
+format. Verified locally: `tsc --noEmit` clean and all 5 e2e tests pass against
+the live API.


### PR DESCRIPTION
## What

The Telegraph publish e2e (`tests/e2e/telegraph-publish.test.ts`) hits the **live** Telegraph API, which intermittently returns transient errors (`PAGE_SAVE_FAILED`, network, 5xx, 429). The suite runs in the standard CI lane (skips only on `SKIP_E2E=1`), so one hiccup fails the **whole build on unrelated PRs** — it just did so on **#756** (a Gemini quota change touching zero Telegraph code): `✗ TelegraphService.ts:298 PAGE_SAVE_FAILED` at `telegraph-publish.test.ts:102`.

## Fix

A test-local `withTransientRetry(label, fn)` helper wraps the 6 live-API call sites (`ensureAccount`×2, `publishPage`×2, `editPage`, `getPageViews`): transient/network/5xx/429 errors retry up to 4× with backoff; real failures (assertion-worthy, or persistent after retries) throw immediately. Duplicate test pages from a retry are harmless (Telegraph pages are free; assertions check `>= 1`, not exact count).

## Scope / risk

Test-only — one file, no `src`/production change, fully reversible.

## Verified

- `tsc --noEmit` clean
- `vitest run tests/e2e/telegraph-publish.test.ts` → **5 passed (5)** against the live API

Surfaced + fixed during the Echo→Codey apprenticeship loop (the flake blocked Codey's #756).