### PR TITLE
Harden instar-dev build location grounding

### DIFF
--- a/docs/specs/AGENT-WORKTREE-CONVENTION-ELI16.md
+++ b/docs/specs/AGENT-WORKTREE-CONVENTION-ELI16.md
@@ -1,8 +1,9 @@
 ---
 title: Agent Worktree Convention — ELI16
 companion-spec: AGENT-WORKTREE-CONVENTION-SPEC.md
+parent-principle: Structure beats Willpower
 created: 2026-05-17
-updated: 2026-05-17 (round 2)
+updated: 2026-06-04 (constitutional traceability metadata)
 ---
 
 # Agent Worktree Convention — In Plain English

--- a/docs/specs/AGENT-WORKTREE-CONVENTION-SPEC.md
+++ b/docs/specs/AGENT-WORKTREE-CONVENTION-SPEC.md
@@ -10,6 +10,7 @@ review-completed-at: "2026-05-17T22:48:00Z"
 review-report: "docs/specs/reports/agent-worktree-convention-convergence.md"
 created: 2026-05-17
 owner: echo
+parent-principle: Structure beats Willpower
 companion-eli16: AGENT-WORKTREE-CONVENTION-ELI16.md
 eli16-overview: AGENT-WORKTREE-CONVENTION-ELI16.md
 ---

--- a/skills/instar-dev/SKILL.md
+++ b/skills/instar-dev/SKILL.md
@@ -72,7 +72,7 @@ The agent answers, in writing: "Does the change about to be made involve a decis
 
 The agent uses the standard planning patterns from `/build`: state the problem, the proposed fix, the acceptance criteria. Specifically required in the plan:
 
-- **Build location re-grounding:** confirm the change is being built in a FRESH worktree off current `JKHeadley/main`, created with `instar worktree create` (or an equivalent fresh clone when repairing the worktree helper itself), NOT the current working directory / agent-home checkout, which may be on a stale version line. Verify and record `git remote -v` and the `package.json` version before writing any code.
+- **Build location re-grounding:** confirm the change is being built in a FRESH worktree off current `JKHeadley/main`, created with `instar worktree create` (or an equivalent fresh clone when repairing the worktree helper itself), NOT the current working directory / agent-home checkout, which may be on a stale version line. Verify and record `git remote -v` and the `package.json` version before writing any code. If you use a fresh clone instead of `instar worktree create`, immediately set the agent identity in it: `git config user.email "<agent>@instar.local"` and `git config user.name "Instar Agent (<agent>)"`. Otherwise commits fall back to the operator's global git config and get misattributed to the human.
 - The decision points the change touches (if any).
 - What existing detectors or authorities the change interacts with.
 - The rollback path if the change turns out wrong.

--- a/skills/instar-dev/SKILL.md
+++ b/skills/instar-dev/SKILL.md
@@ -72,6 +72,7 @@ The agent answers, in writing: "Does the change about to be made involve a decis
 
 The agent uses the standard planning patterns from `/build`: state the problem, the proposed fix, the acceptance criteria. Specifically required in the plan:
 
+- **Build location re-grounding:** confirm the change is being built in a FRESH worktree off current `JKHeadley/main`, created with `instar worktree create` (or an equivalent fresh clone when repairing the worktree helper itself), NOT the current working directory / agent-home checkout, which may be on a stale version line. Verify and record `git remote -v` and the `package.json` version before writing any code.
 - The decision points the change touches (if any).
 - What existing detectors or authorities the change interacts with.
 - The rollback path if the change turns out wrong.

--- a/src/core/PostUpdateMigrator.ts
+++ b/src/core/PostUpdateMigrator.ts
@@ -224,6 +224,7 @@ export class PostUpdateMigrator {
     this.migrateSkillPortHardcoding(result);
     this.migrateBuildSkillMethodology(result);
     this.migrateTestAsSelfSkill(result);
+    this.migrateInstarDevBuildLocationRegrounding(result);
     this.migrateAutonomousStopHookTopicKeyed(result);
     this.migrateSelfKnowledgeTree(result);
     this.migrateSoulMd(result);
@@ -1468,7 +1469,7 @@ export class PostUpdateMigrator {
       if (!fs.existsSync(skillFile)) return; // installBuiltinSkills handles fresh installs
       const current = fs.readFileSync(skillFile, 'utf8');
       const MARKER = 'The one-button path (Part 2.1';
-      if (current.includes(MARKER)) return; // already updated — idempotent
+      if (current.includes(MARKER)) return; // already updated - idempotent
       // Stock-fingerprint guard: don't clobber a customized test-as-self skill.
       if (!current.includes('Throwaway-Deploy Harness') || !current.includes('verify.mjs')) {
         result.skipped.push('skills/test-as-self/SKILL.md: customized — left untouched (no Part 2.1 update)');
@@ -1483,6 +1484,39 @@ export class PostUpdateMigrator {
       }
     } catch (err) {
       result.errors.push(`skills/test-as-self/SKILL.md migration: ${err instanceof Error ? err.message : String(err)}`);
+    }
+  }
+
+  /**
+   * Update the deployed instar-dev skill so every fleet-development cycle
+   * re-grounds its build location before source edits. This backfills the
+   * mentor-onboarding hardening learned from Codey building a PR from a stale
+   * agent-home checkout instead of current JKHeadley/main.
+   *
+   * Idempotent + conservative: re-copy the bundled SKILL.md only when the
+   * installed copy (a) lacks the build-location marker AND (b) still matches
+   * the stock instar-dev fingerprint. A customized skill is left untouched.
+   */
+  private migrateInstarDevBuildLocationRegrounding(result: MigrationResult): void {
+    try {
+      const skillFile = path.join(this.config.projectDir, '.claude', 'skills', 'instar-dev', 'SKILL.md');
+      if (!fs.existsSync(skillFile)) return; // installBuiltinSkills handles fresh installs
+      const current = fs.readFileSync(skillFile, 'utf8');
+      const MARKER = 'Build location re-grounding';
+      if (current.includes(MARKER)) return; // already updated — idempotent
+      if (!current.includes('# /instar-dev') || !current.includes('### Phase 2 — Planning')) {
+        result.skipped.push('skills/instar-dev/SKILL.md: customized - left untouched (no build-location re-grounding update)');
+        return;
+      }
+      const bundled = path.join(__dirname, '..', '..', 'skills', 'instar-dev', 'SKILL.md');
+      if (!fs.existsSync(bundled)) return;
+      const next = fs.readFileSync(bundled, 'utf8');
+      if (next.includes(MARKER)) {
+        fs.writeFileSync(skillFile, next);
+        result.upgraded.push('skills/instar-dev/SKILL.md (Phase 2 build-location re-grounding)');
+      }
+    } catch (err) {
+      result.errors.push(`skills/instar-dev/SKILL.md migration: ${err instanceof Error ? err.message : String(err)}`);
     }
   }
 

--- a/src/data/builtin-manifest.json
+++ b/src/data/builtin-manifest.json
@@ -1,8 +1,8 @@
 {
   "$schema": "./builtin-manifest.schema.json",
   "schemaVersion": 1,
-  "generatedAt": "2026-06-04T15:59:08.973Z",
-  "instarVersion": "1.3.243",
+  "generatedAt": "2026-06-04T21:13:34.355Z",
+  "instarVersion": "1.3.247",
   "entryCount": 198,
   "entries": {
     "hook:session-start": {
@@ -11,7 +11,7 @@
       "domain": "identity",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/session-start.sh",
-      "contentHash": "556dd545f7048e4a4968786c7ff04746dca0f780651c97ebc0be57a920e4d56b",
+      "contentHash": "58605bd8699812a0274a4e2cf6b017ab280a0d32a3a771b28ab603fbaea28e1a",
       "since": "2025-01-01"
     },
     "hook:dangerous-command-guard": {
@@ -20,7 +20,7 @@
       "domain": "safety",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/dangerous-command-guard.sh",
-      "contentHash": "556dd545f7048e4a4968786c7ff04746dca0f780651c97ebc0be57a920e4d56b",
+      "contentHash": "58605bd8699812a0274a4e2cf6b017ab280a0d32a3a771b28ab603fbaea28e1a",
       "since": "2025-01-01"
     },
     "hook:grounding-before-messaging": {
@@ -29,7 +29,7 @@
       "domain": "safety",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/grounding-before-messaging.sh",
-      "contentHash": "556dd545f7048e4a4968786c7ff04746dca0f780651c97ebc0be57a920e4d56b",
+      "contentHash": "58605bd8699812a0274a4e2cf6b017ab280a0d32a3a771b28ab603fbaea28e1a",
       "since": "2025-01-01"
     },
     "hook:compaction-recovery": {
@@ -38,7 +38,7 @@
       "domain": "identity",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/compaction-recovery.sh",
-      "contentHash": "556dd545f7048e4a4968786c7ff04746dca0f780651c97ebc0be57a920e4d56b",
+      "contentHash": "58605bd8699812a0274a4e2cf6b017ab280a0d32a3a771b28ab603fbaea28e1a",
       "since": "2025-01-01"
     },
     "hook:external-operation-gate": {
@@ -47,7 +47,7 @@
       "domain": "safety",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/external-operation-gate.js",
-      "contentHash": "556dd545f7048e4a4968786c7ff04746dca0f780651c97ebc0be57a920e4d56b",
+      "contentHash": "58605bd8699812a0274a4e2cf6b017ab280a0d32a3a771b28ab603fbaea28e1a",
       "since": "2025-01-01"
     },
     "hook:deferral-detector": {
@@ -56,7 +56,7 @@
       "domain": "safety",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/deferral-detector.js",
-      "contentHash": "556dd545f7048e4a4968786c7ff04746dca0f780651c97ebc0be57a920e4d56b",
+      "contentHash": "58605bd8699812a0274a4e2cf6b017ab280a0d32a3a771b28ab603fbaea28e1a",
       "since": "2025-01-01"
     },
     "hook:self-stop-guard": {
@@ -65,7 +65,7 @@
       "domain": "coherence",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/self-stop-guard.js",
-      "contentHash": "556dd545f7048e4a4968786c7ff04746dca0f780651c97ebc0be57a920e4d56b",
+      "contentHash": "58605bd8699812a0274a4e2cf6b017ab280a0d32a3a771b28ab603fbaea28e1a",
       "since": "2025-01-01"
     },
     "hook:post-action-reflection": {
@@ -74,7 +74,7 @@
       "domain": "evolution",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/post-action-reflection.js",
-      "contentHash": "556dd545f7048e4a4968786c7ff04746dca0f780651c97ebc0be57a920e4d56b",
+      "contentHash": "58605bd8699812a0274a4e2cf6b017ab280a0d32a3a771b28ab603fbaea28e1a",
       "since": "2025-01-01"
     },
     "hook:external-communication-guard": {
@@ -83,7 +83,7 @@
       "domain": "safety",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/external-communication-guard.js",
-      "contentHash": "556dd545f7048e4a4968786c7ff04746dca0f780651c97ebc0be57a920e4d56b",
+      "contentHash": "58605bd8699812a0274a4e2cf6b017ab280a0d32a3a771b28ab603fbaea28e1a",
       "since": "2025-01-01"
     },
     "hook:scope-coherence-collector": {
@@ -92,7 +92,7 @@
       "domain": "coherence",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/scope-coherence-collector.js",
-      "contentHash": "556dd545f7048e4a4968786c7ff04746dca0f780651c97ebc0be57a920e4d56b",
+      "contentHash": "58605bd8699812a0274a4e2cf6b017ab280a0d32a3a771b28ab603fbaea28e1a",
       "since": "2025-01-01"
     },
     "hook:scope-coherence-checkpoint": {
@@ -101,7 +101,7 @@
       "domain": "coherence",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/scope-coherence-checkpoint.js",
-      "contentHash": "556dd545f7048e4a4968786c7ff04746dca0f780651c97ebc0be57a920e4d56b",
+      "contentHash": "58605bd8699812a0274a4e2cf6b017ab280a0d32a3a771b28ab603fbaea28e1a",
       "since": "2025-01-01"
     },
     "hook:free-text-guard": {
@@ -110,7 +110,7 @@
       "domain": "safety",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/free-text-guard.sh",
-      "contentHash": "556dd545f7048e4a4968786c7ff04746dca0f780651c97ebc0be57a920e4d56b",
+      "contentHash": "58605bd8699812a0274a4e2cf6b017ab280a0d32a3a771b28ab603fbaea28e1a",
       "since": "2025-01-01"
     },
     "hook:claim-intercept": {
@@ -119,7 +119,7 @@
       "domain": "coherence",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/claim-intercept.js",
-      "contentHash": "556dd545f7048e4a4968786c7ff04746dca0f780651c97ebc0be57a920e4d56b",
+      "contentHash": "58605bd8699812a0274a4e2cf6b017ab280a0d32a3a771b28ab603fbaea28e1a",
       "since": "2025-01-01"
     },
     "hook:claim-intercept-response": {
@@ -128,7 +128,7 @@
       "domain": "coherence",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/claim-intercept-response.js",
-      "contentHash": "556dd545f7048e4a4968786c7ff04746dca0f780651c97ebc0be57a920e4d56b",
+      "contentHash": "58605bd8699812a0274a4e2cf6b017ab280a0d32a3a771b28ab603fbaea28e1a",
       "since": "2025-01-01"
     },
     "hook:stop-gate-router": {
@@ -137,7 +137,7 @@
       "domain": "safety",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/stop-gate-router.js",
-      "contentHash": "556dd545f7048e4a4968786c7ff04746dca0f780651c97ebc0be57a920e4d56b",
+      "contentHash": "58605bd8699812a0274a4e2cf6b017ab280a0d32a3a771b28ab603fbaea28e1a",
       "since": "2025-01-01"
     },
     "hook:auto-approve-permissions": {
@@ -146,7 +146,7 @@
       "domain": "safety",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/auto-approve-permissions.js",
-      "contentHash": "556dd545f7048e4a4968786c7ff04746dca0f780651c97ebc0be57a920e4d56b",
+      "contentHash": "58605bd8699812a0274a4e2cf6b017ab280a0d32a3a771b28ab603fbaea28e1a",
       "since": "2025-01-01"
     },
     "job:health-check": {
@@ -418,7 +418,7 @@
       "type": "route-group",
       "domain": "monitoring",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "02c57df0ab1c47b6e03fa28dce38489ee18a19dba177f2f0bf35a14da342ae88",
+      "contentHash": "de1afbb5ae85ad64a3802c1953f0ab7672af2b05ce15609a3b6c3a177dc2bd72",
       "since": "2025-01-01"
     },
     "route-group:agents": {
@@ -426,7 +426,7 @@
       "type": "route-group",
       "domain": "sessions",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "02c57df0ab1c47b6e03fa28dce38489ee18a19dba177f2f0bf35a14da342ae88",
+      "contentHash": "de1afbb5ae85ad64a3802c1953f0ab7672af2b05ce15609a3b6c3a177dc2bd72",
       "since": "2025-01-01"
     },
     "route-group:backups": {
@@ -434,7 +434,7 @@
       "type": "route-group",
       "domain": "operations",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "02c57df0ab1c47b6e03fa28dce38489ee18a19dba177f2f0bf35a14da342ae88",
+      "contentHash": "de1afbb5ae85ad64a3802c1953f0ab7672af2b05ce15609a3b6c3a177dc2bd72",
       "since": "2025-01-01"
     },
     "route-group:git": {
@@ -442,7 +442,7 @@
       "type": "route-group",
       "domain": "coordination",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "02c57df0ab1c47b6e03fa28dce38489ee18a19dba177f2f0bf35a14da342ae88",
+      "contentHash": "de1afbb5ae85ad64a3802c1953f0ab7672af2b05ce15609a3b6c3a177dc2bd72",
       "since": "2025-01-01"
     },
     "route-group:memory": {
@@ -450,7 +450,7 @@
       "type": "route-group",
       "domain": "memory",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "02c57df0ab1c47b6e03fa28dce38489ee18a19dba177f2f0bf35a14da342ae88",
+      "contentHash": "de1afbb5ae85ad64a3802c1953f0ab7672af2b05ce15609a3b6c3a177dc2bd72",
       "since": "2025-01-01"
     },
     "route-group:semantic": {
@@ -458,7 +458,7 @@
       "type": "route-group",
       "domain": "memory",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "02c57df0ab1c47b6e03fa28dce38489ee18a19dba177f2f0bf35a14da342ae88",
+      "contentHash": "de1afbb5ae85ad64a3802c1953f0ab7672af2b05ce15609a3b6c3a177dc2bd72",
       "since": "2025-01-01"
     },
     "route-group:status": {
@@ -466,7 +466,7 @@
       "type": "route-group",
       "domain": "monitoring",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "02c57df0ab1c47b6e03fa28dce38489ee18a19dba177f2f0bf35a14da342ae88",
+      "contentHash": "de1afbb5ae85ad64a3802c1953f0ab7672af2b05ce15609a3b6c3a177dc2bd72",
       "since": "2025-01-01"
     },
     "route-group:capabilities": {
@@ -474,7 +474,7 @@
       "type": "route-group",
       "domain": "mapping",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "02c57df0ab1c47b6e03fa28dce38489ee18a19dba177f2f0bf35a14da342ae88",
+      "contentHash": "de1afbb5ae85ad64a3802c1953f0ab7672af2b05ce15609a3b6c3a177dc2bd72",
       "since": "2025-01-01"
     },
     "route-group:project-map": {
@@ -482,7 +482,7 @@
       "type": "route-group",
       "domain": "mapping",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "02c57df0ab1c47b6e03fa28dce38489ee18a19dba177f2f0bf35a14da342ae88",
+      "contentHash": "de1afbb5ae85ad64a3802c1953f0ab7672af2b05ce15609a3b6c3a177dc2bd72",
       "since": "2025-01-01"
     },
     "route-group:coherence": {
@@ -490,7 +490,7 @@
       "type": "route-group",
       "domain": "coherence",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "02c57df0ab1c47b6e03fa28dce38489ee18a19dba177f2f0bf35a14da342ae88",
+      "contentHash": "de1afbb5ae85ad64a3802c1953f0ab7672af2b05ce15609a3b6c3a177dc2bd72",
       "since": "2025-01-01"
     },
     "route-group:topic-bindings": {
@@ -498,7 +498,7 @@
       "type": "route-group",
       "domain": "sessions",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "02c57df0ab1c47b6e03fa28dce38489ee18a19dba177f2f0bf35a14da342ae88",
+      "contentHash": "de1afbb5ae85ad64a3802c1953f0ab7672af2b05ce15609a3b6c3a177dc2bd72",
       "since": "2025-01-01"
     },
     "route-group:context": {
@@ -506,7 +506,7 @@
       "type": "route-group",
       "domain": "context",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "02c57df0ab1c47b6e03fa28dce38489ee18a19dba177f2f0bf35a14da342ae88",
+      "contentHash": "de1afbb5ae85ad64a3802c1953f0ab7672af2b05ce15609a3b6c3a177dc2bd72",
       "since": "2025-01-01"
     },
     "route-group:scope-coherence": {
@@ -514,7 +514,7 @@
       "type": "route-group",
       "domain": "coherence",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "02c57df0ab1c47b6e03fa28dce38489ee18a19dba177f2f0bf35a14da342ae88",
+      "contentHash": "de1afbb5ae85ad64a3802c1953f0ab7672af2b05ce15609a3b6c3a177dc2bd72",
       "since": "2025-01-01"
     },
     "route-group:canonical-state": {
@@ -522,7 +522,7 @@
       "type": "route-group",
       "domain": "state",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "02c57df0ab1c47b6e03fa28dce38489ee18a19dba177f2f0bf35a14da342ae88",
+      "contentHash": "de1afbb5ae85ad64a3802c1953f0ab7672af2b05ce15609a3b6c3a177dc2bd72",
       "since": "2025-01-01"
     },
     "route-group:ci": {
@@ -530,7 +530,7 @@
       "type": "route-group",
       "domain": "monitoring",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "02c57df0ab1c47b6e03fa28dce38489ee18a19dba177f2f0bf35a14da342ae88",
+      "contentHash": "de1afbb5ae85ad64a3802c1953f0ab7672af2b05ce15609a3b6c3a177dc2bd72",
       "since": "2025-01-01"
     },
     "route-group:sessions": {
@@ -538,7 +538,7 @@
       "type": "route-group",
       "domain": "sessions",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "02c57df0ab1c47b6e03fa28dce38489ee18a19dba177f2f0bf35a14da342ae88",
+      "contentHash": "de1afbb5ae85ad64a3802c1953f0ab7672af2b05ce15609a3b6c3a177dc2bd72",
       "since": "2025-01-01"
     },
     "route-group:jobs": {
@@ -546,7 +546,7 @@
       "type": "route-group",
       "domain": "scheduling",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "02c57df0ab1c47b6e03fa28dce38489ee18a19dba177f2f0bf35a14da342ae88",
+      "contentHash": "de1afbb5ae85ad64a3802c1953f0ab7672af2b05ce15609a3b6c3a177dc2bd72",
       "since": "2025-01-01"
     },
     "route-group:skip-ledger": {
@@ -554,7 +554,7 @@
       "type": "route-group",
       "domain": "scheduling",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "02c57df0ab1c47b6e03fa28dce38489ee18a19dba177f2f0bf35a14da342ae88",
+      "contentHash": "de1afbb5ae85ad64a3802c1953f0ab7672af2b05ce15609a3b6c3a177dc2bd72",
       "since": "2025-01-01"
     },
     "route-group:telegram": {
@@ -562,7 +562,7 @@
       "type": "route-group",
       "domain": "communication",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "02c57df0ab1c47b6e03fa28dce38489ee18a19dba177f2f0bf35a14da342ae88",
+      "contentHash": "de1afbb5ae85ad64a3802c1953f0ab7672af2b05ce15609a3b6c3a177dc2bd72",
       "since": "2025-01-01"
     },
     "route-group:attention": {
@@ -570,7 +570,7 @@
       "type": "route-group",
       "domain": "communication",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "02c57df0ab1c47b6e03fa28dce38489ee18a19dba177f2f0bf35a14da342ae88",
+      "contentHash": "de1afbb5ae85ad64a3802c1953f0ab7672af2b05ce15609a3b6c3a177dc2bd72",
       "since": "2025-01-01"
     },
     "route-group:relationships": {
@@ -578,7 +578,7 @@
       "type": "route-group",
       "domain": "relationships",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "02c57df0ab1c47b6e03fa28dce38489ee18a19dba177f2f0bf35a14da342ae88",
+      "contentHash": "de1afbb5ae85ad64a3802c1953f0ab7672af2b05ce15609a3b6c3a177dc2bd72",
       "since": "2025-01-01"
     },
     "route-group:feedback": {
@@ -586,7 +586,7 @@
       "type": "route-group",
       "domain": "feedback",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "02c57df0ab1c47b6e03fa28dce38489ee18a19dba177f2f0bf35a14da342ae88",
+      "contentHash": "de1afbb5ae85ad64a3802c1953f0ab7672af2b05ce15609a3b6c3a177dc2bd72",
       "since": "2025-01-01"
     },
     "route-group:updates": {
@@ -594,7 +594,7 @@
       "type": "route-group",
       "domain": "updates",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "02c57df0ab1c47b6e03fa28dce38489ee18a19dba177f2f0bf35a14da342ae88",
+      "contentHash": "de1afbb5ae85ad64a3802c1953f0ab7672af2b05ce15609a3b6c3a177dc2bd72",
       "since": "2025-01-01"
     },
     "route-group:dispatches": {
@@ -602,7 +602,7 @@
       "type": "route-group",
       "domain": "dispatches",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "02c57df0ab1c47b6e03fa28dce38489ee18a19dba177f2f0bf35a14da342ae88",
+      "contentHash": "de1afbb5ae85ad64a3802c1953f0ab7672af2b05ce15609a3b6c3a177dc2bd72",
       "since": "2025-01-01"
     },
     "route-group:quota": {
@@ -610,7 +610,7 @@
       "type": "route-group",
       "domain": "monitoring",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "02c57df0ab1c47b6e03fa28dce38489ee18a19dba177f2f0bf35a14da342ae88",
+      "contentHash": "de1afbb5ae85ad64a3802c1953f0ab7672af2b05ce15609a3b6c3a177dc2bd72",
       "since": "2025-01-01"
     },
     "route-group:publishing": {
@@ -618,7 +618,7 @@
       "type": "route-group",
       "domain": "publishing",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "02c57df0ab1c47b6e03fa28dce38489ee18a19dba177f2f0bf35a14da342ae88",
+      "contentHash": "de1afbb5ae85ad64a3802c1953f0ab7672af2b05ce15609a3b6c3a177dc2bd72",
       "since": "2025-01-01"
     },
     "route-group:private-views": {
@@ -626,7 +626,7 @@
       "type": "route-group",
       "domain": "publishing",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "02c57df0ab1c47b6e03fa28dce38489ee18a19dba177f2f0bf35a14da342ae88",
+      "contentHash": "de1afbb5ae85ad64a3802c1953f0ab7672af2b05ce15609a3b6c3a177dc2bd72",
       "since": "2025-01-01"
     },
     "route-group:tunnel": {
@@ -634,7 +634,7 @@
       "type": "route-group",
       "domain": "networking",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "02c57df0ab1c47b6e03fa28dce38489ee18a19dba177f2f0bf35a14da342ae88",
+      "contentHash": "de1afbb5ae85ad64a3802c1953f0ab7672af2b05ce15609a3b6c3a177dc2bd72",
       "since": "2025-01-01"
     },
     "route-group:events": {
@@ -642,7 +642,7 @@
       "type": "route-group",
       "domain": "networking",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "02c57df0ab1c47b6e03fa28dce38489ee18a19dba177f2f0bf35a14da342ae88",
+      "contentHash": "de1afbb5ae85ad64a3802c1953f0ab7672af2b05ce15609a3b6c3a177dc2bd72",
       "since": "2025-01-01"
     },
     "route-group:evolution": {
@@ -650,7 +650,7 @@
       "type": "route-group",
       "domain": "evolution",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "02c57df0ab1c47b6e03fa28dce38489ee18a19dba177f2f0bf35a14da342ae88",
+      "contentHash": "de1afbb5ae85ad64a3802c1953f0ab7672af2b05ce15609a3b6c3a177dc2bd72",
       "since": "2025-01-01"
     },
     "route-group:watchdog": {
@@ -658,7 +658,7 @@
       "type": "route-group",
       "domain": "monitoring",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "02c57df0ab1c47b6e03fa28dce38489ee18a19dba177f2f0bf35a14da342ae88",
+      "contentHash": "de1afbb5ae85ad64a3802c1953f0ab7672af2b05ce15609a3b6c3a177dc2bd72",
       "since": "2025-01-01"
     },
     "route-group:topic-memory": {
@@ -666,7 +666,7 @@
       "type": "route-group",
       "domain": "memory",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "02c57df0ab1c47b6e03fa28dce38489ee18a19dba177f2f0bf35a14da342ae88",
+      "contentHash": "de1afbb5ae85ad64a3802c1953f0ab7672af2b05ce15609a3b6c3a177dc2bd72",
       "since": "2025-01-01"
     },
     "route-group:state-sync": {
@@ -674,7 +674,7 @@
       "type": "route-group",
       "domain": "coordination",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "02c57df0ab1c47b6e03fa28dce38489ee18a19dba177f2f0bf35a14da342ae88",
+      "contentHash": "de1afbb5ae85ad64a3802c1953f0ab7672af2b05ce15609a3b6c3a177dc2bd72",
       "since": "2025-01-01"
     },
     "route-group:intent": {
@@ -682,7 +682,7 @@
       "type": "route-group",
       "domain": "intent",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "02c57df0ab1c47b6e03fa28dce38489ee18a19dba177f2f0bf35a14da342ae88",
+      "contentHash": "de1afbb5ae85ad64a3802c1953f0ab7672af2b05ce15609a3b6c3a177dc2bd72",
       "since": "2025-01-01"
     },
     "route-group:triage": {
@@ -690,7 +690,7 @@
       "type": "route-group",
       "domain": "safety",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "02c57df0ab1c47b6e03fa28dce38489ee18a19dba177f2f0bf35a14da342ae88",
+      "contentHash": "de1afbb5ae85ad64a3802c1953f0ab7672af2b05ce15609a3b6c3a177dc2bd72",
       "since": "2025-01-01"
     },
     "route-group:operations": {
@@ -698,7 +698,7 @@
       "type": "route-group",
       "domain": "safety",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "02c57df0ab1c47b6e03fa28dce38489ee18a19dba177f2f0bf35a14da342ae88",
+      "contentHash": "de1afbb5ae85ad64a3802c1953f0ab7672af2b05ce15609a3b6c3a177dc2bd72",
       "since": "2025-01-01"
     },
     "route-group:sentinel": {
@@ -706,7 +706,7 @@
       "type": "route-group",
       "domain": "safety",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "02c57df0ab1c47b6e03fa28dce38489ee18a19dba177f2f0bf35a14da342ae88",
+      "contentHash": "de1afbb5ae85ad64a3802c1953f0ab7672af2b05ce15609a3b6c3a177dc2bd72",
       "since": "2025-01-01"
     },
     "route-group:trust": {
@@ -714,7 +714,7 @@
       "type": "route-group",
       "domain": "safety",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "02c57df0ab1c47b6e03fa28dce38489ee18a19dba177f2f0bf35a14da342ae88",
+      "contentHash": "de1afbb5ae85ad64a3802c1953f0ab7672af2b05ce15609a3b6c3a177dc2bd72",
       "since": "2025-01-01"
     },
     "route-group:monitoring": {
@@ -722,7 +722,7 @@
       "type": "route-group",
       "domain": "monitoring",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "02c57df0ab1c47b6e03fa28dce38489ee18a19dba177f2f0bf35a14da342ae88",
+      "contentHash": "de1afbb5ae85ad64a3802c1953f0ab7672af2b05ce15609a3b6c3a177dc2bd72",
       "since": "2025-01-01"
     },
     "route-group:commitments": {
@@ -730,7 +730,7 @@
       "type": "route-group",
       "domain": "commitments",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "02c57df0ab1c47b6e03fa28dce38489ee18a19dba177f2f0bf35a14da342ae88",
+      "contentHash": "de1afbb5ae85ad64a3802c1953f0ab7672af2b05ce15609a3b6c3a177dc2bd72",
       "since": "2025-01-01"
     },
     "route-group:episodes": {
@@ -738,7 +738,7 @@
       "type": "route-group",
       "domain": "memory",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "02c57df0ab1c47b6e03fa28dce38489ee18a19dba177f2f0bf35a14da342ae88",
+      "contentHash": "de1afbb5ae85ad64a3802c1953f0ab7672af2b05ce15609a3b6c3a177dc2bd72",
       "since": "2025-01-01"
     },
     "route-group:messages": {
@@ -746,7 +746,7 @@
       "type": "route-group",
       "domain": "coordination",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "02c57df0ab1c47b6e03fa28dce38489ee18a19dba177f2f0bf35a14da342ae88",
+      "contentHash": "de1afbb5ae85ad64a3802c1953f0ab7672af2b05ce15609a3b6c3a177dc2bd72",
       "since": "2025-01-01"
     },
     "route-group:system-reviews": {
@@ -754,7 +754,7 @@
       "type": "route-group",
       "domain": "monitoring",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "02c57df0ab1c47b6e03fa28dce38489ee18a19dba177f2f0bf35a14da342ae88",
+      "contentHash": "de1afbb5ae85ad64a3802c1953f0ab7672af2b05ce15609a3b6c3a177dc2bd72",
       "since": "2025-01-01"
     },
     "route-group:machine-mesh": {
@@ -770,7 +770,7 @@
       "type": "route-group",
       "domain": "security",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "02c57df0ab1c47b6e03fa28dce38489ee18a19dba177f2f0bf35a14da342ae88",
+      "contentHash": "de1afbb5ae85ad64a3802c1953f0ab7672af2b05ce15609a3b6c3a177dc2bd72",
       "since": "2025-01-01"
     },
     "cli:init": {
@@ -778,7 +778,7 @@
       "type": "cli-command",
       "domain": "setup",
       "sourcePath": "src/cli.ts",
-      "contentHash": "410c6f2c325138a52996c3e2339d9b21fe7a32d90a20cc83d8754ad2d44e700f",
+      "contentHash": "cedd7aaca10839a47af5a19f09b3ce8509a978166a6e2c4994fcbaa4de0a459a",
       "since": "2025-01-01"
     },
     "cli:setup": {
@@ -786,7 +786,7 @@
       "type": "cli-command",
       "domain": "setup",
       "sourcePath": "src/cli.ts",
-      "contentHash": "410c6f2c325138a52996c3e2339d9b21fe7a32d90a20cc83d8754ad2d44e700f",
+      "contentHash": "cedd7aaca10839a47af5a19f09b3ce8509a978166a6e2c4994fcbaa4de0a459a",
       "since": "2025-01-01"
     },
     "cli:add": {
@@ -794,7 +794,7 @@
       "type": "cli-command",
       "domain": "setup",
       "sourcePath": "src/cli.ts",
-      "contentHash": "410c6f2c325138a52996c3e2339d9b21fe7a32d90a20cc83d8754ad2d44e700f",
+      "contentHash": "cedd7aaca10839a47af5a19f09b3ce8509a978166a6e2c4994fcbaa4de0a459a",
       "since": "2025-01-01"
     },
     "cli:backup": {
@@ -802,7 +802,7 @@
       "type": "cli-command",
       "domain": "operations",
       "sourcePath": "src/cli.ts",
-      "contentHash": "410c6f2c325138a52996c3e2339d9b21fe7a32d90a20cc83d8754ad2d44e700f",
+      "contentHash": "cedd7aaca10839a47af5a19f09b3ce8509a978166a6e2c4994fcbaa4de0a459a",
       "since": "2025-01-01"
     },
     "cli:git": {
@@ -810,7 +810,7 @@
       "type": "cli-command",
       "domain": "coordination",
       "sourcePath": "src/cli.ts",
-      "contentHash": "410c6f2c325138a52996c3e2339d9b21fe7a32d90a20cc83d8754ad2d44e700f",
+      "contentHash": "cedd7aaca10839a47af5a19f09b3ce8509a978166a6e2c4994fcbaa4de0a459a",
       "since": "2025-01-01"
     },
     "cli:memory": {
@@ -818,7 +818,7 @@
       "type": "cli-command",
       "domain": "memory",
       "sourcePath": "src/cli.ts",
-      "contentHash": "410c6f2c325138a52996c3e2339d9b21fe7a32d90a20cc83d8754ad2d44e700f",
+      "contentHash": "cedd7aaca10839a47af5a19f09b3ce8509a978166a6e2c4994fcbaa4de0a459a",
       "since": "2025-01-01"
     },
     "cli:knowledge": {
@@ -826,7 +826,7 @@
       "type": "cli-command",
       "domain": "memory",
       "sourcePath": "src/cli.ts",
-      "contentHash": "410c6f2c325138a52996c3e2339d9b21fe7a32d90a20cc83d8754ad2d44e700f",
+      "contentHash": "cedd7aaca10839a47af5a19f09b3ce8509a978166a6e2c4994fcbaa4de0a459a",
       "since": "2025-01-01"
     },
     "cli:semantic": {
@@ -834,7 +834,7 @@
       "type": "cli-command",
       "domain": "memory",
       "sourcePath": "src/cli.ts",
-      "contentHash": "410c6f2c325138a52996c3e2339d9b21fe7a32d90a20cc83d8754ad2d44e700f",
+      "contentHash": "cedd7aaca10839a47af5a19f09b3ce8509a978166a6e2c4994fcbaa4de0a459a",
       "since": "2025-01-01"
     },
     "cli:intent": {
@@ -842,7 +842,7 @@
       "type": "cli-command",
       "domain": "intent",
       "sourcePath": "src/cli.ts",
-      "contentHash": "410c6f2c325138a52996c3e2339d9b21fe7a32d90a20cc83d8754ad2d44e700f",
+      "contentHash": "cedd7aaca10839a47af5a19f09b3ce8509a978166a6e2c4994fcbaa4de0a459a",
       "since": "2025-01-01"
     },
     "cli:feedback": {
@@ -850,7 +850,7 @@
       "type": "cli-command",
       "domain": "feedback",
       "sourcePath": "src/cli.ts",
-      "contentHash": "410c6f2c325138a52996c3e2339d9b21fe7a32d90a20cc83d8754ad2d44e700f",
+      "contentHash": "cedd7aaca10839a47af5a19f09b3ce8509a978166a6e2c4994fcbaa4de0a459a",
       "since": "2025-01-01"
     },
     "cli:server": {
@@ -858,7 +858,7 @@
       "type": "cli-command",
       "domain": "server",
       "sourcePath": "src/cli.ts",
-      "contentHash": "410c6f2c325138a52996c3e2339d9b21fe7a32d90a20cc83d8754ad2d44e700f",
+      "contentHash": "cedd7aaca10839a47af5a19f09b3ce8509a978166a6e2c4994fcbaa4de0a459a",
       "since": "2025-01-01"
     },
     "cli:status": {
@@ -866,7 +866,7 @@
       "type": "cli-command",
       "domain": "monitoring",
       "sourcePath": "src/cli.ts",
-      "contentHash": "410c6f2c325138a52996c3e2339d9b21fe7a32d90a20cc83d8754ad2d44e700f",
+      "contentHash": "cedd7aaca10839a47af5a19f09b3ce8509a978166a6e2c4994fcbaa4de0a459a",
       "since": "2025-01-01"
     },
     "cli:user": {
@@ -874,7 +874,7 @@
       "type": "cli-command",
       "domain": "users",
       "sourcePath": "src/cli.ts",
-      "contentHash": "410c6f2c325138a52996c3e2339d9b21fe7a32d90a20cc83d8754ad2d44e700f",
+      "contentHash": "cedd7aaca10839a47af5a19f09b3ce8509a978166a6e2c4994fcbaa4de0a459a",
       "since": "2025-01-01"
     },
     "cli:relationship": {
@@ -882,7 +882,7 @@
       "type": "cli-command",
       "domain": "relationships",
       "sourcePath": "src/cli.ts",
-      "contentHash": "410c6f2c325138a52996c3e2339d9b21fe7a32d90a20cc83d8754ad2d44e700f",
+      "contentHash": "cedd7aaca10839a47af5a19f09b3ce8509a978166a6e2c4994fcbaa4de0a459a",
       "since": "2025-01-01"
     },
     "cli:job": {
@@ -890,7 +890,7 @@
       "type": "cli-command",
       "domain": "scheduling",
       "sourcePath": "src/cli.ts",
-      "contentHash": "410c6f2c325138a52996c3e2339d9b21fe7a32d90a20cc83d8754ad2d44e700f",
+      "contentHash": "cedd7aaca10839a47af5a19f09b3ce8509a978166a6e2c4994fcbaa4de0a459a",
       "since": "2025-01-01"
     },
     "cli:lifeline": {
@@ -898,7 +898,7 @@
       "type": "cli-command",
       "domain": "communication",
       "sourcePath": "src/cli.ts",
-      "contentHash": "410c6f2c325138a52996c3e2339d9b21fe7a32d90a20cc83d8754ad2d44e700f",
+      "contentHash": "cedd7aaca10839a47af5a19f09b3ce8509a978166a6e2c4994fcbaa4de0a459a",
       "since": "2025-01-01"
     },
     "cli:list": {
@@ -906,7 +906,7 @@
       "type": "cli-command",
       "domain": "monitoring",
       "sourcePath": "src/cli.ts",
-      "contentHash": "410c6f2c325138a52996c3e2339d9b21fe7a32d90a20cc83d8754ad2d44e700f",
+      "contentHash": "cedd7aaca10839a47af5a19f09b3ce8509a978166a6e2c4994fcbaa4de0a459a",
       "since": "2025-01-01"
     },
     "cli:autostart": {
@@ -914,7 +914,7 @@
       "type": "cli-command",
       "domain": "operations",
       "sourcePath": "src/cli.ts",
-      "contentHash": "410c6f2c325138a52996c3e2339d9b21fe7a32d90a20cc83d8754ad2d44e700f",
+      "contentHash": "cedd7aaca10839a47af5a19f09b3ce8509a978166a6e2c4994fcbaa4de0a459a",
       "since": "2025-01-01"
     },
     "cli:migrate": {
@@ -922,7 +922,7 @@
       "type": "cli-command",
       "domain": "updates",
       "sourcePath": "src/cli.ts",
-      "contentHash": "410c6f2c325138a52996c3e2339d9b21fe7a32d90a20cc83d8754ad2d44e700f",
+      "contentHash": "cedd7aaca10839a47af5a19f09b3ce8509a978166a6e2c4994fcbaa4de0a459a",
       "since": "2025-01-01"
     },
     "cli:machines": {
@@ -930,7 +930,7 @@
       "type": "cli-command",
       "domain": "coordination",
       "sourcePath": "src/cli.ts",
-      "contentHash": "410c6f2c325138a52996c3e2339d9b21fe7a32d90a20cc83d8754ad2d44e700f",
+      "contentHash": "cedd7aaca10839a47af5a19f09b3ce8509a978166a6e2c4994fcbaa4de0a459a",
       "since": "2025-01-01"
     },
     "cli:whoami": {
@@ -938,7 +938,7 @@
       "type": "cli-command",
       "domain": "identity",
       "sourcePath": "src/cli.ts",
-      "contentHash": "410c6f2c325138a52996c3e2339d9b21fe7a32d90a20cc83d8754ad2d44e700f",
+      "contentHash": "cedd7aaca10839a47af5a19f09b3ce8509a978166a6e2c4994fcbaa4de0a459a",
       "since": "2025-01-01"
     },
     "cli:pair": {
@@ -946,7 +946,7 @@
       "type": "cli-command",
       "domain": "coordination",
       "sourcePath": "src/cli.ts",
-      "contentHash": "410c6f2c325138a52996c3e2339d9b21fe7a32d90a20cc83d8754ad2d44e700f",
+      "contentHash": "cedd7aaca10839a47af5a19f09b3ce8509a978166a6e2c4994fcbaa4de0a459a",
       "since": "2025-01-01"
     },
     "cli:join": {
@@ -954,7 +954,7 @@
       "type": "cli-command",
       "domain": "coordination",
       "sourcePath": "src/cli.ts",
-      "contentHash": "410c6f2c325138a52996c3e2339d9b21fe7a32d90a20cc83d8754ad2d44e700f",
+      "contentHash": "cedd7aaca10839a47af5a19f09b3ce8509a978166a6e2c4994fcbaa4de0a459a",
       "since": "2025-01-01"
     },
     "cli:wakeup": {
@@ -962,7 +962,7 @@
       "type": "cli-command",
       "domain": "coordination",
       "sourcePath": "src/cli.ts",
-      "contentHash": "410c6f2c325138a52996c3e2339d9b21fe7a32d90a20cc83d8754ad2d44e700f",
+      "contentHash": "cedd7aaca10839a47af5a19f09b3ce8509a978166a6e2c4994fcbaa4de0a459a",
       "since": "2025-01-01"
     },
     "cli:leave": {
@@ -970,7 +970,7 @@
       "type": "cli-command",
       "domain": "coordination",
       "sourcePath": "src/cli.ts",
-      "contentHash": "410c6f2c325138a52996c3e2339d9b21fe7a32d90a20cc83d8754ad2d44e700f",
+      "contentHash": "cedd7aaca10839a47af5a19f09b3ce8509a978166a6e2c4994fcbaa4de0a459a",
       "since": "2025-01-01"
     },
     "cli:doctor": {
@@ -978,7 +978,7 @@
       "type": "cli-command",
       "domain": "monitoring",
       "sourcePath": "src/cli.ts",
-      "contentHash": "410c6f2c325138a52996c3e2339d9b21fe7a32d90a20cc83d8754ad2d44e700f",
+      "contentHash": "cedd7aaca10839a47af5a19f09b3ce8509a978166a6e2c4994fcbaa4de0a459a",
       "since": "2025-01-01"
     },
     "cli:review": {
@@ -986,7 +986,7 @@
       "type": "cli-command",
       "domain": "monitoring",
       "sourcePath": "src/cli.ts",
-      "contentHash": "410c6f2c325138a52996c3e2339d9b21fe7a32d90a20cc83d8754ad2d44e700f",
+      "contentHash": "cedd7aaca10839a47af5a19f09b3ce8509a978166a6e2c4994fcbaa4de0a459a",
       "since": "2025-01-01"
     },
     "cli:nuke": {
@@ -994,7 +994,7 @@
       "type": "cli-command",
       "domain": "operations",
       "sourcePath": "src/cli.ts",
-      "contentHash": "410c6f2c325138a52996c3e2339d9b21fe7a32d90a20cc83d8754ad2d44e700f",
+      "contentHash": "cedd7aaca10839a47af5a19f09b3ce8509a978166a6e2c4994fcbaa4de0a459a",
       "since": "2025-01-01"
     },
     "cli:playbook": {
@@ -1002,7 +1002,7 @@
       "type": "cli-command",
       "domain": "context",
       "sourcePath": "src/cli.ts",
-      "contentHash": "410c6f2c325138a52996c3e2339d9b21fe7a32d90a20cc83d8754ad2d44e700f",
+      "contentHash": "cedd7aaca10839a47af5a19f09b3ce8509a978166a6e2c4994fcbaa4de0a459a",
       "since": "2025-01-01"
     },
     "cli:dev-preflight": {
@@ -1010,7 +1010,7 @@
       "type": "cli-command",
       "domain": "development",
       "sourcePath": "src/cli.ts",
-      "contentHash": "410c6f2c325138a52996c3e2339d9b21fe7a32d90a20cc83d8754ad2d44e700f",
+      "contentHash": "cedd7aaca10839a47af5a19f09b3ce8509a978166a6e2c4994fcbaa4de0a459a",
       "since": "2025-01-01"
     },
     "cli:dev-ci-failures": {
@@ -1018,7 +1018,7 @@
       "type": "cli-command",
       "domain": "development",
       "sourcePath": "src/cli.ts",
-      "contentHash": "410c6f2c325138a52996c3e2339d9b21fe7a32d90a20cc83d8754ad2d44e700f",
+      "contentHash": "cedd7aaca10839a47af5a19f09b3ce8509a978166a6e2c4994fcbaa4de0a459a",
       "since": "2025-01-01"
     },
     "cli:dev-profile-node": {
@@ -1026,7 +1026,7 @@
       "type": "cli-command",
       "domain": "development",
       "sourcePath": "src/cli.ts",
-      "contentHash": "410c6f2c325138a52996c3e2339d9b21fe7a32d90a20cc83d8754ad2d44e700f",
+      "contentHash": "cedd7aaca10839a47af5a19f09b3ce8509a978166a6e2c4994fcbaa4de0a459a",
       "since": "2025-01-01"
     },
     "template:build-stop-hook.sh": {
@@ -1498,7 +1498,7 @@
       "type": "subsystem",
       "domain": "server",
       "sourcePath": "src/server/AgentServer.ts",
-      "contentHash": "460b355d5c71dbedcb2118219eded0b68018dc47d51ff74d8b9cad2f715c6982",
+      "contentHash": "df80218338a05c47663780e16bff41f8ed77476f44f2b29d421a116ce8eb8352",
       "since": "2025-01-01"
     },
     "subsystem:session-manager": {
@@ -1530,7 +1530,7 @@
       "type": "subsystem",
       "domain": "updates",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
-      "contentHash": "556dd545f7048e4a4968786c7ff04746dca0f780651c97ebc0be57a920e4d56b",
+      "contentHash": "58605bd8699812a0274a4e2cf6b017ab280a0d32a3a771b28ab603fbaea28e1a",
       "since": "2025-01-01"
     },
     "subsystem:scheduler": {

--- a/src/data/builtin-manifest.json
+++ b/src/data/builtin-manifest.json
@@ -1,7 +1,7 @@
 {
   "$schema": "./builtin-manifest.schema.json",
   "schemaVersion": 1,
-  "generatedAt": "2026-06-04T21:29:29.885Z",
+  "generatedAt": "2026-06-04T21:35:43.868Z",
   "instarVersion": "1.3.249",
   "entryCount": 198,
   "entries": {

--- a/tests/unit/migrate-instar-dev-build-location.test.ts
+++ b/tests/unit/migrate-instar-dev-build-location.test.ts
@@ -1,0 +1,100 @@
+/**
+ * Unit tests for migrateInstarDevBuildLocationRegrounding - updates the
+ * deployed instar-dev SKILL.md so Phase 2 requires fresh-current-main build
+ * location verification before source edits.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { PostUpdateMigrator } from '../../src/core/PostUpdateMigrator.js';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+
+let projectDir: string;
+
+function makeMigrator(): PostUpdateMigrator {
+  return new PostUpdateMigrator({
+    projectDir,
+    stateDir: path.join(projectDir, '.instar'),
+    port: 4042,
+    hasTelegram: false,
+    projectName: 'test',
+  });
+}
+
+function emptyResult() {
+  return { upgraded: [] as string[], skipped: [] as string[], errors: [] as string[] };
+}
+
+function writeSkill(content: string): string {
+  const dir = path.join(projectDir, '.claude', 'skills', 'instar-dev');
+  fs.mkdirSync(dir, { recursive: true });
+  const file = path.join(dir, 'SKILL.md');
+  fs.writeFileSync(file, content);
+  return file;
+}
+
+const run = (result: ReturnType<typeof emptyResult>) =>
+  (makeMigrator() as unknown as { migrateInstarDevBuildLocationRegrounding: (r: typeof result) => void })
+    .migrateInstarDevBuildLocationRegrounding(result);
+
+const STOCK_BEFORE = `---
+name: instar-dev
+---
+
+# /instar-dev
+
+### Phase 2 — Planning
+
+The agent uses the standard planning patterns from /build.
+`;
+
+beforeEach(() => {
+  projectDir = fs.mkdtempSync(path.join(os.tmpdir(), 'instar-dev-skill-migration-'));
+});
+
+afterEach(() => {
+  SafeFsExecutor.safeRmSync(projectDir, {
+    recursive: true,
+    force: true,
+    operation: 'tests/unit/migrate-instar-dev-build-location.test.ts',
+  });
+});
+
+describe('migrateInstarDevBuildLocationRegrounding', () => {
+  it('updates a stock instar-dev skill that lacks the build-location marker', () => {
+    const file = writeSkill(STOCK_BEFORE);
+    const result = emptyResult();
+    run(result);
+    const updated = fs.readFileSync(file, 'utf8');
+    expect(updated).toContain('Build location re-grounding');
+    expect(updated).toContain('FRESH worktree off current `JKHeadley/main`');
+    expect(result.upgraded.some((u) => u.includes('skills/instar-dev/SKILL.md'))).toBe(true);
+  });
+
+  it('is idempotent when the marker is already present', () => {
+    const already = `${STOCK_BEFORE}\n- **Build location re-grounding:** already here.\n`;
+    const file = writeSkill(already);
+    const before = fs.readFileSync(file, 'utf8');
+    const result = emptyResult();
+    run(result);
+    expect(fs.readFileSync(file, 'utf8')).toBe(before);
+    expect(result.upgraded.length).toBe(0);
+  });
+
+  it('leaves a customized skill untouched when the stock fingerprint is missing', () => {
+    const customized = `---\nname: instar-dev\n---\n# My custom dev workflow\n`;
+    const file = writeSkill(customized);
+    const result = emptyResult();
+    run(result);
+    expect(fs.readFileSync(file, 'utf8')).toBe(customized);
+    expect(result.skipped.some((s) => s.includes('customized'))).toBe(true);
+  });
+
+  it('no-ops when the skill is not installed', () => {
+    const result = emptyResult();
+    run(result);
+    expect(result.upgraded.length).toBe(0);
+    expect(result.errors.length).toBe(0);
+  });
+});

--- a/tests/unit/migrate-instar-dev-build-location.test.ts
+++ b/tests/unit/migrate-instar-dev-build-location.test.ts
@@ -69,6 +69,9 @@ describe('migrateInstarDevBuildLocationRegrounding', () => {
     const updated = fs.readFileSync(file, 'utf8');
     expect(updated).toContain('Build location re-grounding');
     expect(updated).toContain('FRESH worktree off current `JKHeadley/main`');
+    expect(updated).toContain('git config user.email "<agent>@instar.local"');
+    expect(updated).toContain('git config user.name "Instar Agent (<agent>)"');
+    expect(updated).toContain("commits fall back to the operator's global git config");
     expect(result.upgraded.some((u) => u.includes('skills/instar-dev/SKILL.md'))).toBe(true);
   });
 

--- a/upgrades/next/instar-dev-build-location-regrounding.md
+++ b/upgrades/next/instar-dev-build-location-regrounding.md
@@ -1,0 +1,32 @@
+# instar-dev build-location re-grounding
+
+<!-- bump: patch -->
+
+## What Changed
+
+The instar-dev workflow now requires a build-location re-grounding step during
+Phase 2 planning. Before writing code, the agent must confirm it is building in
+a fresh worktree off current `JKHeadley/main`, verify the git remote, and verify
+the package version. PostUpdateMigrator backfills this updated skill text into
+existing dev agents when their installed instar-dev skill still matches the
+stock copy.
+
+## What to Tell Your User
+
+I added a structural checkpoint to the Instar development workflow so a restarted
+agent is less likely to build from an old checkout. It now has to prove it is
+working from current main before changing source.
+
+## Summary of New Capabilities
+
+| Capability | How to Use |
+|-----------|-----------|
+| instar-dev build-location re-grounding | Automatic in the instar-dev workflow; existing stock dev-agent skill files are updated on the next agent update. |
+
+## Evidence
+
+The failure was reproduced operationally during mentor onboarding: a respawned
+session built a fleet PR from an old agent-home checkout instead of current
+`JKHeadley/instar`. The fix was dogfooded from a fresh current-main checkout.
+Focused PostUpdateMigrator skill-migration tests verify stock update,
+idempotency, customized-skill preservation, and missing-skill no-op behavior.

--- a/upgrades/next/instar-dev-build-location-regrounding.md
+++ b/upgrades/next/instar-dev-build-location-regrounding.md
@@ -7,15 +7,18 @@
 The instar-dev workflow now requires a build-location re-grounding step during
 Phase 2 planning. Before writing code, the agent must confirm it is building in
 a fresh worktree off current `JKHeadley/main`, verify the git remote, and verify
-the package version. PostUpdateMigrator backfills this updated skill text into
-existing dev agents when their installed instar-dev skill still matches the
-stock copy.
+the package version. If it uses a fresh clone fallback, it must also set the
+local agent git identity immediately so commits do not fall back to the
+operator's global git config. PostUpdateMigrator backfills this updated skill
+text into existing dev agents when their installed instar-dev skill still
+matches the stock copy.
 
 ## What to Tell Your User
 
 I added a structural checkpoint to the Instar development workflow so a restarted
 agent is less likely to build from an old checkout. It now has to prove it is
-working from current main before changing source.
+working from current main before changing source, and fresh-clone fallbacks must
+set agent commit identity before writing code.
 
 ## Summary of New Capabilities
 
@@ -27,6 +30,9 @@ working from current main before changing source.
 
 The failure was reproduced operationally during mentor onboarding: a respawned
 session built a fleet PR from an old agent-home checkout instead of current
-`JKHeadley/instar`. The fix was dogfooded from a fresh current-main checkout.
-Focused PostUpdateMigrator skill-migration tests verify stock update,
-idempotency, customized-skill preservation, and missing-skill no-op behavior.
+`JKHeadley/instar`. During this PR, the fresh-clone fallback also exposed a git
+identity gap: without local agent identity, commits fell back to the operator's
+global git config. The fix was dogfooded from a fresh current-main checkout.
+Focused PostUpdateMigrator skill-migration tests verify stock update including
+the identity warning, idempotency, customized-skill preservation, and
+missing-skill no-op behavior.

--- a/upgrades/side-effects/instar-dev-build-location-regrounding.md
+++ b/upgrades/side-effects/instar-dev-build-location-regrounding.md
@@ -1,0 +1,85 @@
+# Side-Effects Review — instar-dev build-location re-grounding
+
+**Version / slug:** `instar-dev-build-location-regrounding`
+**Date:** `2026-06-04`
+**Author:** `instar-codey`
+**Second-pass reviewer:** `not required`
+
+## Summary of the change
+
+This change hardens the instar-dev workflow against a mentor-onboarding failure mode: a respawned agent built a fleet PR from a stale agent-home checkout instead of current `JKHeadley/instar` main. Phase 2 of the instar-dev skill now requires an explicit build-location re-grounding plan item before code edits: confirm a fresh current-main worktree, verify the remote, and verify the package version. PostUpdateMigrator backfills existing deployed instar-dev skills by content-sniffing for the new marker and replacing only stock skill copies; customized skill text is left untouched.
+
+## Decision-point inventory
+
+- `/instar-dev` Phase 2 planning checklist — modify — adds a required self-verification step before build execution.
+- `PostUpdateMigrator` built-in skill migration — modify — updates deployed stock instar-dev skill files during agent update.
+- Commit/push gates — pass-through — unchanged; they continue to enforce side-effects/release metadata after this workflow step has grounded the checkout.
+
+---
+
+## 1. Over-block
+
+The skill now requires a planning statement even for small instar-dev changes. That can feel redundant when the agent is already visibly in a correct worktree, but it is intentionally cheap and does not block via code; the enforcement is procedural text plus review artifacts. The migrator only overwrites installed instar-dev skill files that still match the stock fingerprint, so a customized local workflow is not clobbered.
+
+---
+
+## 2. Under-block
+
+This does not make a hard shell gate that rejects stale checkouts. An agent could still ignore the skill text or lie in the plan, but the expected workflow now requires the check at the right point, and the plan/review trail makes omissions visible. A future stronger gate could validate branch ancestry automatically, but this PR focuses on the requested structural skill and migration layer.
+
+---
+
+## 3. Level-of-abstraction fit
+
+The change belongs in Phase 2 because that is the last explicit planning checkpoint before `/build` starts edits. It also belongs in PostUpdateMigrator because the instar-dev skill is an agent-installed built-in file; updating only the package copy would leave existing agents on stale instructions.
+
+---
+
+## 4. Signal vs authority compliance
+
+- [x] No — this change produces a planning requirement and migration update, not a brittle block/allow authority.
+
+No new runtime authority is introduced. The skill text creates a required human/agent-visible checkpoint. PostUpdateMigrator makes the checkpoint available to existing agents but does not make build-location decisions.
+
+---
+
+## 5. Interactions
+
+- **Shadowing:** The new checklist item complements the existing worktree convention and pre-commit gates. It does not replace them.
+- **Double-fire:** Fresh installs receive the updated bundled skill; existing installs receive the same text once through the migrator. The marker makes repeated runs no-op.
+- **Races:** The migrator performs a single local file write during update. If the file is already customized or already current, it skips.
+- **Feedback loops:** The change reduces the chance of stale-repo fixes generating follow-up CI/PR cleanup loops.
+
+---
+
+## 6. External surfaces
+
+Existing dev agents will see updated instar-dev skill text after update if their installed copy is stock. This is intentionally fleet-visible because the bug came from a respawned development agent. End users do not invoke instar-dev; the surface is limited to infrastructure-development agents and their installed skill files.
+
+---
+
+## 7. Rollback cost
+
+Rollback is a normal code revert. Agents that already received the updated skill text would keep a harmless extra planning checklist item until a later migration rewrites it. No persistent database migration is involved.
+
+---
+
+## Conclusion
+
+The review confirms the right fix layer is the workflow body plus migration parity, not another ad hoc reminder in a transcript. The remaining gap is deliberate: this PR does not add an automatic stale-checkout blocker. It makes the grounding step required and fleet-distributed, with tests covering update, idempotency, customization preservation, and missing-skill no-op behavior.
+
+---
+
+## Second-pass review (if required)
+
+**Reviewer:** not required
+**Independent read of the artifact:** not required
+
+This changes a dev skill and migration path but does not alter session lifecycle, messaging gates, sentinels, or runtime block/allow logic.
+
+---
+
+## Evidence pointers
+
+- Focused PostUpdateMigrator built-in skill migration tests passed.
+- TypeScript typecheck passed.

--- a/upgrades/side-effects/instar-dev-build-location-regrounding.md
+++ b/upgrades/side-effects/instar-dev-build-location-regrounding.md
@@ -7,11 +7,11 @@
 
 ## Summary of the change
 
-This change hardens the instar-dev workflow against a mentor-onboarding failure mode: a respawned agent built a fleet PR from a stale agent-home checkout instead of current `JKHeadley/instar` main. Phase 2 of the instar-dev skill now requires an explicit build-location re-grounding plan item before code edits: confirm a fresh current-main worktree, verify the remote, and verify the package version. PostUpdateMigrator backfills existing deployed instar-dev skills by content-sniffing for the new marker and replacing only stock skill copies; customized skill text is left untouched.
+This change hardens the instar-dev workflow against a mentor-onboarding failure mode: a respawned agent built a fleet PR from a stale agent-home checkout instead of current `JKHeadley/instar` main. Phase 2 of the instar-dev skill now requires an explicit build-location re-grounding plan item before code edits: confirm a fresh current-main worktree, verify the remote, and verify the package version. If the agent uses a fresh clone fallback instead of `instar worktree create`, it must immediately set the local agent git identity so commits do not fall back to the operator's global git config. PostUpdateMigrator backfills existing deployed instar-dev skills by content-sniffing for the new marker and replacing only stock skill copies; customized skill text is left untouched.
 
 ## Decision-point inventory
 
-- `/instar-dev` Phase 2 planning checklist — modify — adds a required self-verification step before build execution.
+- `/instar-dev` Phase 2 planning checklist — modify — adds a required self-verification step before build execution, including agent git identity setup for fresh-clone fallbacks.
 - `PostUpdateMigrator` built-in skill migration — modify — updates deployed stock instar-dev skill files during agent update.
 - Commit/push gates — pass-through — unchanged; they continue to enforce side-effects/release metadata after this workflow step has grounded the checkout.
 
@@ -25,7 +25,7 @@ The skill now requires a planning statement even for small instar-dev changes. T
 
 ## 2. Under-block
 
-This does not make a hard shell gate that rejects stale checkouts. An agent could still ignore the skill text or lie in the plan, but the expected workflow now requires the check at the right point, and the plan/review trail makes omissions visible. A future stronger gate could validate branch ancestry automatically, but this PR focuses on the requested structural skill and migration layer.
+This does not make a hard shell gate that rejects stale checkouts or misattributed git identity. An agent could still ignore the skill text or lie in the plan, but the expected workflow now requires the check at the right point, and the plan/review trail makes omissions visible. A future stronger gate could validate branch ancestry and local git identity automatically, but this PR focuses on the requested structural skill and migration layer.
 
 ---
 
@@ -66,7 +66,7 @@ Rollback is a normal code revert. Agents that already received the updated skill
 
 ## Conclusion
 
-The review confirms the right fix layer is the workflow body plus migration parity, not another ad hoc reminder in a transcript. The remaining gap is deliberate: this PR does not add an automatic stale-checkout blocker. It makes the grounding step required and fleet-distributed, with tests covering update, idempotency, customization preservation, and missing-skill no-op behavior.
+The review confirms the right fix layer is the workflow body plus migration parity, not another ad hoc reminder in a transcript. The remaining gap is deliberate: this PR does not add an automatic stale-checkout or git-identity blocker. It makes the grounding step required and fleet-distributed, with tests covering update, idempotency, customization preservation, and missing-skill no-op behavior.
 
 ---
 


### PR DESCRIPTION
## Summary
- add Phase 2 build-location re-grounding to the instar-dev workflow so agents verify fresh current-main worktree, remote, and package version before source edits
- add an idempotent PostUpdateMigrator backfill for stock deployed instar-dev skill files
- add focused migration tests plus release and side-effects artifacts
- add missing constitutional parent-principle metadata to the approved worktree convention spec and companion ELI16 overview required by the gate

## Verification
- npm ci
- npx vitest run tests/unit/migrate-instar-dev-build-location.test.ts tests/unit/migrate-test-as-self-skill.test.ts tests/unit/PostUpdateMigrator-skillPortHardcoding.test.ts tests/unit/PostUpdateMigrator-autonomousStopHook.test.ts
- npx tsc --noEmit
- npm run lint
- npm run build
- npm run check:upgrade-guide (passes; existing historical guide warnings; non-blocking patch/minor advisory)
- npm run check:pre-push-gate (passes; non-blocking version advisory)

Dogfooded from a fresh current-main checkout of JKHeadley/instar at package version 1.3.247.