### PR TITLE
fix(threadline): store resolved peer fingerprint as thread owner (fix composite-address cold-spawn)

### DIFF
--- a/src/server/routes.ts
+++ b/src/server/routes.ts
@@ -14806,14 +14806,28 @@ export function createRoutes(ctx: RouteContext): Router {
      * existing commitment when one already exists for this threadId, so 4
      * call-sites below are safe.
      */
-    const captureOrigin = async (effThreadId: string, remoteAgentDisplay: string): Promise<void> => {
+    // `canonicalRemoteAgent` MUST be the peer's resolved FULL fingerprint (the
+    // same identity used for routing) — NOT a display name or a "name:fpPrefix"
+    // address. The inbound anti-hijack guard (ThreadlineRouter) compares a reply's
+    // senderFingerprint against the stored thread owner (`remoteAgent`); if we
+    // stored a composite/display string instead of the full fingerprint, a known
+    // peer's reply fails the match and gets false-isolated to a fresh cold-spawn
+    // thread — breaking A2A continuity (the "one coherent individual" property).
+    // The human-facing display name is preserved separately. Mirrors
+    // telegramBridge.mirrorOutbound, which already stores the resolved fingerprint
+    // as `remoteAgent` and the raw target as `remoteAgentName`.
+    const captureOrigin = async (
+      effThreadId: string,
+      canonicalRemoteAgent: string,
+      displayName?: string,
+    ): Promise<void> => {
       if (!ctx.topicLinkageHandler) return;
       if (!resolvedOriginTopicId) return;
       try {
         ctx.topicLinkageHandler.captureOriginOnSend({
           threadId: effThreadId,
-          remoteAgent: remoteAgentDisplay,
-          remoteAgentDisplayName: remoteAgentDisplay,
+          remoteAgent: canonicalRemoteAgent,
+          remoteAgentDisplayName: displayName ?? canonicalRemoteAgent,
           originTopicId: resolvedOriginTopicId,
           purpose: resolvedPurpose,
           subject: 'Threadline conversation',
@@ -15124,7 +15138,14 @@ export function createRoutes(ctx: RouteContext): Router {
                       outcome,
                     }).catch(() => { /* swallow — bridge is relay-only */ });
                   }
-                  await captureOrigin(effectiveThreadId, localTarget.name);
+                  // Store the resolved full fingerprint as the canonical thread
+                  // owner (display = the local agent's name) so a reply matches
+                  // the anti-hijack guard instead of being false-isolated.
+                  await captureOrigin(
+                    effectiveThreadId,
+                    localTarget.fingerprint || localTarget.publicKey?.substring(0, 32) || localTarget.name,
+                    localTarget.name,
+                  );
                   if (waitForReply) {
                     const reply = await waitForThreadlineReply(ctx, localTarget.name, effectiveThreadId, timeoutSeconds);
                     res.json({
@@ -15239,7 +15260,12 @@ export function createRoutes(ctx: RouteContext): Router {
         }).catch(() => { /* swallow — bridge is relay-only */ });
       }
 
-      await captureOrigin(effectiveRelayThreadId, targetAgent);
+      // `resolvedId` is the peer's full routing fingerprint; store IT as the
+      // canonical thread owner (display = the raw target the caller typed) so a
+      // reply matches the anti-hijack guard instead of being false-isolated.
+      // This is the fix for the composite "name:fpPrefix" address being stored
+      // un-resolved and causing a known peer's replies to cold-spawn.
+      await captureOrigin(effectiveRelayThreadId, resolvedId, targetAgent);
       if (waitForReply) {
         const reply = await waitForThreadlineReply(ctx, resolvedId, effectiveRelayThreadId, timeoutSeconds);
         res.json({

--- a/tests/integration/threadline/relay-send-canonical-remoteagent.test.ts
+++ b/tests/integration/threadline/relay-send-canonical-remoteagent.test.ts
@@ -1,0 +1,134 @@
+/**
+ * Integration test — /threadline/relay-send stores the RESOLVED full fingerprint
+ * as the conversation's `remoteAgent`, not the raw "name:fpPrefix" address.
+ *
+ * REGRESSION (the Dawn cold-spawn incident, 2026-06-04): when a caller addressed
+ * a peer with the composite "name:fpPrefix" disambiguation syntax (e.g.
+ * "Dawn-Workstation:8c7928aa"), the route resolved the full fingerprint for
+ * ROUTING but `captureOrigin` stored the raw composite string as the thread
+ * owner. The peer's reply over the relay carries its BARE full fingerprint as
+ * senderFingerprint (often with an empty senderName), so the inbound anti-hijack
+ * guard (ThreadlineRouter) could not match composite-vs-fingerprint and
+ * false-isolated the reply to a fresh cold-spawn thread — breaking A2A
+ * continuity (the "one coherent individual" property).
+ *
+ * Fix: store the resolved full fingerprint (`resolvedId`) as `remoteAgent` and
+ * keep the raw target only as the display name. This test sends to a composite
+ * address and asserts captureOriginOnSend received the full fingerprint.
+ */
+
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
+import express from 'express';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import type { Server } from 'node:http';
+import { createRoutes } from '../../../src/server/routes.js';
+import { StateManager } from '../../../src/core/StateManager.js';
+import type { InstarConfig } from '../../../src/core/types.js';
+import { SafeFsExecutor } from '../../../src/core/SafeFsExecutor.js';
+
+const DAWN_FP = '8c7928aa9f04fbda947172a2f9b2d81a';
+
+let projectDir: string;
+let stateDir: string;
+let server: Server;
+let baseUrl: string;
+let captureOriginCalls: Array<{ threadId: string; remoteAgent: string; remoteAgentDisplayName?: string; originTopicId?: number }>;
+
+describe('/threadline/relay-send stores resolved fingerprint as remoteAgent (canonicalization)', () => {
+  beforeAll(async () => {
+    projectDir = fs.mkdtempSync(path.join(os.tmpdir(), 'instar-relay-canon-'));
+    stateDir = path.join(projectDir, '.instar');
+    fs.mkdirSync(path.join(stateDir, 'state', 'sessions'), { recursive: true });
+    fs.mkdirSync(path.join(stateDir, 'logs'), { recursive: true });
+    fs.mkdirSync(path.join(stateDir, 'threadline'), { recursive: true });
+    fs.writeFileSync(path.join(stateDir, 'config.json'), JSON.stringify({ projectName: 'echo-test' }));
+
+    const config = { projectDir, stateDir, projectName: 'echo-test', port: 4042 } as InstarConfig;
+    const state = new StateManager(stateDir);
+
+    // Relay resolver maps the composite address to Dawn's full fingerprint.
+    const stubRelayClient = {
+      connectionState: 'connected',
+      resolveAgent: async (_name: string) => DAWN_FP,
+      sendAuto: (_recipientId: string, _message: string, _threadId?: string) => `msg-stub-${Date.now()}`,
+    };
+
+    // Capture what captureOrigin → captureOriginOnSend receives.
+    captureOriginCalls = [];
+    const stubTopicLinkageHandler = {
+      captureOriginOnSend: vi.fn((input: { threadId: string; remoteAgent: string; remoteAgentDisplayName?: string; originTopicId?: number }) => {
+        captureOriginCalls.push({
+          threadId: input.threadId,
+          remoteAgent: input.remoteAgent,
+          remoteAgentDisplayName: input.remoteAgentDisplayName,
+          originTopicId: input.originTopicId,
+        });
+        return null;
+      }),
+    };
+
+    const app = express();
+    app.use(express.json());
+    const router = createRoutes({
+      config, state,
+      sessionManager: null as any, scheduler: null, telegram: null, relationships: null,
+      feedback: null, dispatches: null, updateChecker: null, autoUpdater: null, autoDispatcher: null,
+      quotaTracker: null, publisher: null, viewer: null, tunnel: null, evolution: null, watchdog: null,
+      triageNurse: null, topicMemory: null, feedbackAnomalyDetector: null, projectMapper: null,
+      coherenceGate: null, contextHierarchy: null, canonicalState: null, operationGate: null, sentinel: null,
+      adaptiveTrust: null, memoryMonitor: null, orphanReaper: null, coherenceMonitor: null,
+      commitmentTracker: null, semanticMemory: null, activitySentinel: null, messageRouter: null,
+      summarySentinel: null, spawnManager: null, workingMemory: null, quotaManager: null,
+      systemReviewer: null, capabilityMapper: null, selfKnowledgeTree: null, coverageAuditor: null,
+      topicResumeMap: null, autonomyManager: null, trustElevationTracker: null, autonomousEvolution: null,
+      whatsapp: null, messageBridge: null, hookEventReceiver: null, worktreeMonitor: null,
+      subagentTracker: null, instructionsVerifier: null, threadlineRouter: null, handshakeManager: null,
+      threadlineRelayClient: stubRelayClient as any, listenerManager: null, responseReviewGate: null,
+      telemetryHeartbeat: null, pasteManager: null, wsManager: null, soulManager: null,
+      discoveryEvaluator: null, topicLinkageHandler: stubTopicLinkageHandler as any,
+      startTime: new Date(),
+    } as any);
+    app.use(router);
+
+    await new Promise<void>((resolve) => {
+      server = app.listen(0, '127.0.0.1', () => {
+        baseUrl = `http://127.0.0.1:${(server.address() as { port: number }).port}`;
+        resolve();
+      });
+    });
+  });
+
+  afterAll(async () => {
+    if (server) await new Promise<void>((resolve) => server.close(() => resolve()));
+    SafeFsExecutor.safeRmSync(projectDir, {
+      recursive: true, force: true,
+      operation: 'tests/integration/threadline/relay-send-canonical-remoteagent.test.ts:cleanup',
+    });
+  });
+
+  it('stores the resolved full fingerprint as remoteAgent and the raw composite as the display name', async () => {
+    captureOriginCalls.length = 0;
+    const res = await fetch(`${baseUrl}/threadline/relay-send`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        targetAgent: 'Dawn-Workstation:8c7928aa', // composite "name:fpPrefix"
+        message: 'hello over the relay',
+        waitForReply: false,
+        originTopicId: 12476, // required so captureOrigin fires (origin capture)
+      }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(captureOriginCalls).toHaveLength(1);
+    // The canonical thread owner is the RESOLVED full fingerprint — so the
+    // peer's bare-fingerprint reply matches the anti-hijack guard.
+    expect(captureOriginCalls[0].remoteAgent).toBe(DAWN_FP);
+    expect(captureOriginCalls[0].remoteAgent).not.toBe('Dawn-Workstation:8c7928aa');
+    // The human-facing display name is preserved separately.
+    expect(captureOriginCalls[0].remoteAgentDisplayName).toBe('Dawn-Workstation:8c7928aa');
+    expect(captureOriginCalls[0].originTopicId).toBe(12476);
+  });
+});

--- a/tests/unit/ThreadlineRouter-anti-hijack.test.ts
+++ b/tests/unit/ThreadlineRouter-anti-hijack.test.ts
@@ -136,4 +136,48 @@ describe('ThreadlineRouter — anti-hijack guard', () => {
     const reason = spawnManager.evaluate.mock.calls[0][0].reason as string;
     expect(reason).toMatch(/^Resume thread/);
   });
+
+  // ── Regression: composite-address canonicalization (relay-send fix) ──
+  // The relay path on a plaintext-tofu inbound has trust.kind !== 'verified',
+  // so the guard falls through to the identity match. A known peer's reply over
+  // the relay carries its FULL fingerprint as senderFingerprint and frequently
+  // an EMPTY senderName. The thread owner must therefore be stored as that full
+  // fingerprint for the reply to resume — which is exactly what the /threadline/
+  // relay-send `captureOrigin` fix now does (store resolvedId, not the raw
+  // "name:fpPrefix" target the caller typed).
+
+  it('resumes when the stored owner is the peer full fingerprint and the reply presents that fingerprint with EMPTY senderName (the Dawn case, post-fix storage)', async () => {
+    const threadId = 'fp-owned-thread';
+    const peerFp = '8c7928aa9f04fbda947172a2f9b2d81a';
+    threadResumeMap._set(threadId, ownedEntry(peerFp));
+
+    const result = await router.handleInboundMessage(
+      envelopeFrom(peerFp, threadId),
+      relayCtx({ senderName: '', senderFingerprint: peerFp }),
+    );
+
+    expect(result.threadId).toBe(threadId);
+    const reason = spawnManager.evaluate.mock.calls[0][0].reason as string;
+    expect(reason).toMatch(/^Resume thread/);
+  });
+
+  it('isolates when the stored owner is a composite "name:fpPrefix" and the reply presents the bare full fingerprint (the bug the relay-send canonicalization prevents)', async () => {
+    const threadId = 'composite-owned-thread';
+    const peerFp = '8c7928aa9f04fbda947172a2f9b2d81a';
+    // OLD buggy storage: the composite address was stored un-resolved, so the
+    // guard cannot match it against the reply's bare full fingerprint.
+    threadResumeMap._set(threadId, ownedEntry('Dawn-Workstation:8c7928aa'));
+
+    const result = await router.handleInboundMessage(
+      envelopeFrom(peerFp, threadId),
+      relayCtx({ senderName: '', senderFingerprint: peerFp }),
+    );
+
+    // Isolation under the OLD storage proves WHY the send path must store the
+    // resolved full fingerprint — with the fix the owner is `peerFp` and the
+    // previous test resumes instead of cold-spawning.
+    expect(result.threadId).not.toBe(threadId);
+    const reason = spawnManager.evaluate.mock.calls[0][0].reason as string;
+    expect(reason).toMatch(/^New thread/);
+  });
 });

--- a/upgrades/next/threadline-canonicalize-peer-address.md
+++ b/upgrades/next/threadline-canonicalize-peer-address.md
@@ -1,0 +1,46 @@
+<!-- bump: patch -->
+
+## What Changed
+
+Fixed a Threadline continuity bug where a known peer's reply could be
+false-isolated to a fresh cold-spawn thread, breaking agent-to-agent
+conversation memory.
+
+When a caller addressed a peer with the `name:fpPrefix` disambiguation syntax
+(e.g. `Dawn-Workstation:8c7928aa`), `/threadline/relay-send` resolved the peer's
+full fingerprint for routing but `captureOrigin` stored the raw composite string
+as the conversation's `remoteAgent`. The inbound anti-hijack guard
+(`ThreadlineRouter`) compares a reply's bare `senderFingerprint` (often with an
+empty `senderName`) against the stored owner; a composite never equals a bare
+fingerprint, so the guard treated the legitimate reply as a possible hijack and
+shunted it into a new empty thread.
+
+The fix stores the **resolved full fingerprint** as `remoteAgent` (and keeps the
+typed label only as `remoteAgentDisplayName`), so the reply matches and resumes.
+This mirrors `telegramBridge.mirrorOutbound`, which already stored the resolved
+fingerprint as the owner. The anti-hijack guard is unchanged and not weakened: we
+only store the full fingerprint the server itself resolved for routing — never a
+guessed value and never a spoofable short prefix — so an impostor with a
+different fingerprint is still isolated.
+
+## What to Tell Your User
+
+Agent-to-agent conversations that were addressed using the name-plus-shortcode
+syntax now stay coherent across replies instead of occasionally restarting from
+scratch as if the other agent had become a stranger. Nothing to turn on, and no
+conversation history is lost.
+
+## Summary of New Capabilities
+
+| Capability | How to Use |
+|-----------|-----------|
+| Coherent replies for name:shortcode-addressed peers | Automatic. When you message a peer by the name-plus-fingerprint-prefix form, the conversation owner is now recorded as the peer's full resolved fingerprint, so their reply resumes the same thread instead of cold-spawning. |
+
+## Evidence
+
+Reproduced live as the 2026-06-04 Dawn cold-spawn incident (a reply isolated with
+`unverified sender 8c7928aa9f04… owned by Dawn-Workstation; isolating`). New unit
+test reproduces that exact log line for the composite-owner case and proves the
+full-fingerprint-owner case resumes; new integration test asserts
+`/threadline/relay-send` stores the resolved fingerprint. tsc clean; 56 related
+tests green.

--- a/upgrades/side-effects/threadline-canonicalize-peer-address.md
+++ b/upgrades/side-effects/threadline-canonicalize-peer-address.md
@@ -1,0 +1,93 @@
+# Side-Effects Review — Canonicalize peer address to full fingerprint on send
+
+**Version / slug:** `threadline-canonicalize-peer-address`
+**Date:** `2026-06-04`
+**Author:** `Echo (instar dev agent)`
+**Tier:** `1 (targeted bug fix to existing route + tests; no new surface, no schema change)`
+**Second-pass reviewer:** `recommended — SHARED Threadline security code (Dawn runs it too). PR is opened for Dawn's review before merge; NOT self-merged.`
+
+## Summary of the change
+
+`/threadline/relay-send` resolves a peer's **full fingerprint** for routing
+(`resolvedId` on the relay path; `localTarget.fingerprint` on the local path),
+but `captureOrigin` stored the raw caller-supplied target (which may be a
+`name:fpPrefix` composite like `Dawn-Workstation:8c7928aa`) as the conversation's
+`remoteAgent`. The inbound anti-hijack guard (`ThreadlineRouter`) compares a
+reply's `senderFingerprint` (the bare full fingerprint, often with empty
+`senderName`) against the stored `remoteAgent`; a composite/display string never
+equals a bare fingerprint, so a known peer's reply was false-isolated to a fresh
+cold-spawn thread — breaking A2A continuity (the "one coherent individual"
+property). Observed live as the 2026-06-04 Dawn cold-spawn incident.
+
+Fix: `captureOrigin(effThreadId, canonicalRemoteAgent, displayName?)` now stores
+the **resolved full fingerprint** as `remoteAgent` and keeps the raw target only
+as `remoteAgentDisplayName`. The two call-sites pass the already-resolved
+fingerprint (relay: `resolvedId`; local: `localTarget.fingerprint ||
+publicKey.slice(0,32) || name`). Mirrors `telegramBridge.mirrorOutbound`, which
+already stored `{ remoteAgent: resolvedId, remoteAgentName: targetAgent }`.
+
+Files: `src/server/routes.ts` (captureOrigin signature + 2 call-sites),
+`tests/unit/ThreadlineRouter-anti-hijack.test.ts` (+2 guard tests),
+`tests/integration/threadline/relay-send-canonical-remoteagent.test.ts` (new).
+
+## 1. Over-block / weakening
+
+Does it weaken the guard? No. We only ever store the **full** fingerprint the
+server itself resolved for routing — never a guessed value and never an
+8-char prefix (prefix-matching would be a ~32-bit, grind-able hijack vector and
+is explicitly NOT used). An impostor presenting a different fingerprint still
+fails `peer === inboundFp` and is still isolated (proved by the retained
+"isolates an unverified sender" test + the new composite-isolation test). The
+change strictly *adds* correct matches for a genuinely-resolved peer; it removes
+no isolation.
+
+## 2. Under-block
+
+Does it miss a case it should catch? No new bypass: the stored owner is now a
+stronger identity (full fingerprint) than before (a spoofable display string).
+Existing threads already persisted with a composite owner are NOT retroactively
+rewritten — this is a forward fix at the write path; the one historically-broken
+thread is a one-off. The deeper R2 question (relay inbound `trust.kind` is
+hardcoded `plaintext-tofu`, so a verified peer is never crypto-exempted) is
+intentionally OUT OF SCOPE here and left for security-design review.
+
+## 3. Level-of-abstraction fit
+
+The canonicalization lives at the send/record boundary (`captureOrigin`), the
+same place that already owns the resolved-fingerprint vs display-name split for
+the Telegram mirror. The guard is untouched (no change to ThreadlineRouter).
+
+## 4. Signal vs authority compliance
+
+No gate/authority change. `remoteAgentDisplayName` preserves the human-facing
+label for all display strings (`captureOriginOnSend` already falls back to
+`remoteAgentDisplayName ?? remoteAgent`).
+
+## 5. Interactions
+
+- The anti-hijack guard now matches a known peer's bare-fingerprint reply
+  (`peer === inboundFp`) and resumes instead of cold-spawning.
+- `appendCanonicalOutboxEntry` and `mirrorOutbound` already used `resolvedId`;
+  this aligns `captureOrigin` with them (consistency, not a new direction).
+- `captureOrigin` only fires when `originTopicId` is set (origin capture);
+  topic-less sends are unaffected (their owner is written by the inbound handler
+  as `message.from.agent = senderFingerprint`, already a full fingerprint).
+
+## 6. External surfaces
+
+No new HTTP route, no config, no template/CLAUDE.md change, no persisted-format
+change (the `remoteAgent` field already existed; only the VALUE stored is now the
+canonical fingerprint). Nothing to migrate.
+
+## 7. Rollback cost
+
+Low — revert one function signature + two call-sites + two test files. No
+data-format change; existing records are untouched.
+
+## Conclusion
+
+Low-risk, strictly non-weakening, additive correctness fix at the send/record
+boundary that closes the composite-address false-isolation (the Dawn cold-spawn
+incident). Guard unchanged; impostors still isolated; only genuinely-resolved
+peers now resume. Shipped behind a PR for Dawn's review (shared security code);
+the deeper R2 trust-propagation question is logged separately, not touched here.

--- a/upgrades/threadline-canonicalize-peer-address.eli16.md
+++ b/upgrades/threadline-canonicalize-peer-address.eli16.md
@@ -1,0 +1,58 @@
+# ELI16 — Store a peer's real fingerprint as the conversation owner
+
+## The problem, in plain English
+
+When one agent messages another over Threadline, you can address the other
+agent by a friendly "name plus a short code" label — for example
+`Dawn-Workstation:8c7928aa`. The `8c7928aa` part is just the first 8 characters
+of the other agent's long cryptographic fingerprint, used to tell apart two
+agents that happen to share a name.
+
+Here's the bug. When I sent the first message, my server looked up the *full*
+fingerprint (`8c7928aa9f04fbda947172a2f9b2d81a`) so it could actually route and
+encrypt the message to the right agent — but then, when it wrote down "who owns
+this conversation," it saved the raw label I typed (`Dawn-Workstation:8c7928aa`)
+instead of that resolved full fingerprint.
+
+That mattered because of a security guard. Threadline has an anti-hijack check:
+when a reply comes in claiming to belong to an existing conversation, the guard
+asks "is the sender actually the agent who owns this thread?" A genuine reply
+arrives carrying the sender's *full* fingerprint (and often no display name at
+all). The guard compared the stored owner (`Dawn-Workstation:8c7928aa`, a label)
+against the reply's bare full fingerprint (`8c7928aa9f04…`), saw they were not
+equal, and concluded the reply might be an impostor. So it shunted my friend's
+perfectly legitimate reply into a brand-new, empty conversation — and the thread
+lost all its memory. It felt like the other agent had become a stranger
+mid-conversation. This is the "fragmented identity" incoherence: a known peer's
+own replies being treated as someone else's.
+
+## The fix
+
+The server *already* resolves the peer's full fingerprint when it sends the
+message (it has to, in order to route and encrypt). The fix is simply: store
+*that* resolved full fingerprint as the conversation's owner, and keep the label
+I typed only as a separate, human-friendly display name. Now when the reply
+comes back carrying the full fingerprint, it matches the stored owner exactly,
+the guard says "yes, this is the same agent," and the conversation continues
+normally instead of cold-starting.
+
+This follows a pattern the code already uses elsewhere: the Telegram mirror for
+outbound messages already stored the resolved fingerprint as the owner and the
+typed name as the display name. Only the "capture origin" write had been using
+the raw label. We brought it in line.
+
+## Why it's safe
+
+The guard is not weakened at all. We never guess, and we never trust a short
+8-character prefix as proof of identity (that would be too easy to fake). We
+only store the *full* fingerprint that the server itself resolved for routing.
+An impostor presenting a *different* fingerprint still fails the match and still
+gets isolated — exactly as before. The only thing that changes is that a real,
+known peer's reply now correctly resumes its own conversation instead of being
+mistaken for a stranger.
+
+## What you'd notice
+
+Almost nothing — that's the point. Agent-to-agent conversations that were
+addressed with the `name:shortcode` syntax will simply stay coherent across
+replies instead of occasionally restarting as if from scratch.


### PR DESCRIPTION
## Summary

Fixes a Threadline A2A continuity bug: a known peer's reply could be **false-isolated to a fresh cold-spawn thread**, breaking conversation memory. This is the technical root of the 2026-06-04 Dawn cold-spawn incident (a verified peer's replies were treated as a possible impostor).

### Root cause
`/threadline/relay-send` resolves the peer's **full fingerprint** for routing (`resolvedId`), but `captureOrigin` stored the raw caller-supplied target — which may be the composite `name:fpPrefix` address (e.g. `Dawn-Workstation:8c7928aa`) — as the conversation's `remoteAgent`. The inbound anti-hijack guard (`ThreadlineRouter`) compares a reply's **bare** `senderFingerprint` (often with empty `senderName`) against the stored owner. A composite never string-equals a bare fingerprint → the guard isolates the legitimate reply.

### Fix
`captureOrigin(threadId, canonicalRemoteAgent, displayName?)` now stores the **resolved full fingerprint** as `remoteAgent` and keeps the typed label only as `remoteAgentDisplayName`. The two call-sites pass the already-resolved fingerprint (relay: `resolvedId`; local: `localTarget.fingerprint`). This mirrors `telegramBridge.mirrorOutbound`, which already stored the resolved fingerprint as the owner.

### Why it's strictly non-weakening
The anti-hijack guard is **unchanged**. We only store the full fingerprint the server itself resolved for routing — never a guessed value, and never an 8-char prefix (prefix-matching would be a ~32-bit grind-able hijack vector and is explicitly NOT used). An impostor presenting a different fingerprint still fails `peer === inboundFp` and is still isolated.

## Tests
- **Unit** (`ThreadlineRouter-anti-hijack.test.ts`, +2): full-fingerprint owner + bare-fingerprint reply with empty senderName → **resumes**; composite owner + bare-fingerprint reply → **isolates** (reproduces the exact production log line). Existing isolation tests retained.
- **Integration** (`relay-send-canonical-remoteagent.test.ts`, new): sending to a composite address stores the **resolved** fingerprint as `remoteAgent`, the raw composite as the display name.
- tsc clean; 56 related tests green.

## ⚠ Review note — shared security code
This touches the Threadline anti-hijack path, which Dawn also runs. **Requesting Dawn's review before merge** (not self-merging). 

**Out of scope (deeper R2 question for security review):** the relay inbound builds `relayContext.trust.kind` hardcoded to `plaintext-tofu` (server.ts), so a *verified* peer is never crypto-exempted from the guard. Propagating verified trust there would also fix this class — but only if the relay inbound is per-message authenticated. Left untouched here pending that design decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
