### PR TITLE
fix(session-pool): a machine resolves its OWN nickname (completes §L4 relocation)

### DIFF
--- a/src/commands/server.ts
+++ b/src/commands/server.ts
@@ -9862,6 +9862,47 @@ export async function startServer(options: StartOptions): Promise<void> {
             const h = coordinator.getSyncStatus().leaseHolder;
             return h && h !== meshSelfId ? peerUrl(h) : null;
           };
+          // ── Self-nickname convergence (§L4, 2026-06-04 live-caught fix) ──
+          // `updateNickname` (PATCH /pool/machines) is local-only, so a rename applied on a
+          // PEER's registry never reaches the owning machine — leaving that machine unable to
+          // resolve its OWN nickname (the laptop's self-entry was nickname=None, so "move it
+          // back to the laptop" silently failed on the very machine that runs the relocation
+          // check). Periodically adopt our own nickname from a peer's authoritative /pool view
+          // and persist it, making getCapacities() SYMMETRIC so the recognizer, the transfer
+          // route, and /pool all resolve self. No-ops once the local nickname is known.
+          const selfNickMod = await import('../core/SelfNicknameResolver.js');
+          const convergeSelfNickname = async (): Promise<void> => {
+            try {
+              if (!machinePoolRegistry) return;
+              const localCaps = machinePoolRegistry.getCapacities();
+              if (localCaps.find((c) => c.machineId === meshSelfId)?.nickname?.trim()) return; // already known
+              // Collect peers' authoritative /pool views (they carry this machine's nickname).
+              const peerCapacities: { machineId: string; nickname?: string }[][] = [];
+              for (const m of meshIdMgr.getActiveMachines()) {
+                if (m.machineId === meshSelfId) continue;
+                const url = peerUrl(m.machineId);
+                if (!url) continue;
+                try {
+                  const r = await fetch(`${url}/pool`, { headers: { Authorization: `Bearer ${config.authToken}` } });
+                  if (!r.ok) continue;
+                  const j = (await r.json()) as { machines?: { machineId: string; nickname?: string }[] };
+                  if (j.machines) peerCapacities.push(j.machines);
+                } catch {
+                  /* @silent-fallback-ok — best-effort peer fetch; convergence retries on the timer */
+                }
+              }
+              const resolved = selfNickMod.resolveSelfNickname({ selfMachineId: meshSelfId, localCapacities: localCaps, peerCapacities });
+              if (resolved) {
+                meshIdMgr.updateNickname(meshSelfId, resolved);
+                console.log(pc.green(`  [self-nickname] adopted "${resolved}" for ${meshSelfId} from a peer's view (was unset locally)`));
+              }
+            } catch {
+              /* @silent-fallback-ok — convergence is best-effort; never blocks startup */
+            }
+          };
+          void convergeSelfNickname();
+          const selfNickTimer = setInterval(() => { void convergeSelfNickname(); }, 60_000);
+          if (typeof selfNickTimer.unref === 'function') selfNickTimer.unref();
           // This machine participates in the session pool, so a read-only standby may
           // persist the PER-SESSION state of sessions it's handed (the pool's owner-side
           // resume only fires for CAS-confirmed owned sessions, and only past 'dark').

--- a/src/core/SelfNicknameResolver.ts
+++ b/src/core/SelfNicknameResolver.ts
@@ -1,0 +1,59 @@
+/**
+ * SelfNicknameResolver — resolve THIS machine's own user-facing nickname robustly
+ * (Multi-Machine Session Pool §L4).
+ *
+ * THE BUG THIS CLOSES (2026-06-04, live-caught on the real laptop+mini pair):
+ * a machine's local capacity view (`MachinePoolRegistry.getCapacities()`) can carry
+ * its PEERS' nicknames but NOT its own — because `updateNickname` (the rename behind
+ * the dashboard / PATCH /pool/machines) is local-only and was applied on a DIFFERENT
+ * machine's registry, so it never reached the owning machine. Net: the laptop's own
+ * entry is `nickname=None`, so "move it back to the laptop" can't resolve "Laptop"
+ * on the very machine (the holder) that runs the relocation check.
+ *
+ * The prior `RelocationNicknameSet` fix unions a self-nickname IF one is provided —
+ * but the bug is that the self-nickname could not be RESOLVED at all. This resolver
+ * fixes that: it falls back to what PEERS call this machine (their capacity view names
+ * it correctly), then to a deterministic derive. Pure over its inputs; the server
+ * supplies the local + peer capacity views.
+ */
+
+export interface NicknameCapacity {
+  machineId: string;
+  nickname?: string;
+}
+
+/**
+ * Resolve `selfMachineId`'s nickname. Priority:
+ *   1. The local capacity view (the common, already-symmetric case).
+ *   2. Any PEER's capacity view that names this machine (covers the drift bug — a
+ *      peer renamed us and the rename never propagated to our own registry).
+ *   3. A deterministic derive (last resort; reconstructs an auto-assigned name).
+ * Returns null when nothing resolves (caller then simply omits the self nickname,
+ * exactly the pre-existing behavior — never throws, never mis-resolves).
+ */
+export function resolveSelfNickname(opts: {
+  selfMachineId: string | null | undefined;
+  localCapacities: readonly NicknameCapacity[];
+  /** Capacity views obtained from peers (e.g. via mesh capacity-report). */
+  peerCapacities?: readonly (readonly NicknameCapacity[])[];
+  /** Deterministic derive fallback (e.g. deriveBaseNickname(identityName, platform)). */
+  derive?: () => string | null | undefined;
+}): string | null {
+  const self = opts.selfMachineId;
+  if (!self) return opts.derive?.() ?? null;
+  const pick = (caps: readonly NicknameCapacity[]): string | null => {
+    const n = caps.find((c) => c.machineId === self)?.nickname;
+    return n && n.trim() ? n : null;
+  };
+  // 1. Local view.
+  const local = pick(opts.localCapacities);
+  if (local) return local;
+  // 2. Peer views — the drift backstop.
+  for (const peerCaps of opts.peerCapacities ?? []) {
+    const fromPeer = pick(peerCaps);
+    if (fromPeer) return fromPeer;
+  }
+  // 3. Derive.
+  const derived = opts.derive?.();
+  return derived && derived.trim() ? derived : null;
+}

--- a/src/server/routes.ts
+++ b/src/server/routes.ts
@@ -17,6 +17,7 @@ import type { SessionRefresh } from '../core/SessionRefresh.js';
 import type { StateManager } from '../core/StateManager.js';
 import { describeTopicPlacement } from '../core/TopicPlacementDescription.js';
 import { buildRelocationNicknameSet } from '../core/RelocationNicknameSet.js';
+import { resolveSelfNickname } from '../core/SelfNicknameResolver.js';
 import { planTransferByNickname } from '../core/TransferByNickname.js';
 import type { JobScheduler } from '../scheduler/JobScheduler.js';
 import type { InstarConfig, JobPriority } from '../core/types.js';
@@ -7754,7 +7755,11 @@ export function createRoutes(ctx: RouteContext): Router {
     // We are the holder (or single-machine) — perform authoritatively.
     const self = ctx.meshSelfId ?? null;
     const caps = ctx.machinePoolRegistry?.getCapacities() ?? [];
-    const selfNickname = self ? (caps.find((c) => c.machineId === self)?.nickname ?? null) : null;
+    // Resolve THIS machine's own nickname robustly (not caps-only): a machine's capacity
+    // view can omit its own nickname (the live-caught self-nickname gap). The
+    // self-nickname convergence task persists it into caps; this resolver is the
+    // consistent path + boot-window backstop.
+    const selfNickname = resolveSelfNickname({ selfMachineId: self, localCapacities: caps });
     const { nickToMachine, knownNicknames } = buildRelocationNicknameSet({ capacities: caps, selfMachineId: self, selfNickname });
     const knownMachineIds = new Set(caps.map((c) => c.machineId));
     // Resolve `to` as a nickname OR a raw machineId, so callers can use either.

--- a/tests/e2e/pool-placement-transfer-alive.test.ts
+++ b/tests/e2e/pool-placement-transfer-alive.test.ts
@@ -112,6 +112,18 @@ describe('E2E: pool placement + transfer routes are ALIVE through the real Agent
     expect((await after.json()).reason).toBe('pinned');
   });
 
+  // The live-caught self-nickname bug: a machine must resolve its OWN nickname.
+  // SELF here is "Mac Mini" — transferring to "Mac Mini" exercises self-resolution
+  // through the real stack (this 404'd as "unknown machine" before the fix).
+  it('POST /pool/transfer resolves THIS machine\'s OWN nickname (self-nickname fix)', async () => {
+    const res = await fetch(`${base}/pool/transfer`, { method: 'POST', headers: auth, body: JSON.stringify({ topic: 502, to: 'Mac Mini' }) });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+    expect(body.targetMachine).toBe(SELF);
+    expect(body.targetNickname).toBe('Mac Mini');
+  });
+
   it('routes sit behind auth (401/403 without a Bearer token) — proves the real middleware stack', async () => {
     const res = await fetch(`${base}/pool/placement?topic=500`);
     expect([401, 403]).toContain(res.status);

--- a/tests/unit/self-nickname-resolver.test.ts
+++ b/tests/unit/self-nickname-resolver.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from 'vitest';
+import { resolveSelfNickname } from '../../src/core/SelfNicknameResolver.js';
+
+describe('resolveSelfNickname', () => {
+  const SELF = 'm_laptop';
+  const PEER = 'm_mini';
+
+  it('uses the local capacity view when it carries the self nickname (symmetric case)', () => {
+    expect(
+      resolveSelfNickname({
+        selfMachineId: SELF,
+        localCapacities: [{ machineId: SELF, nickname: 'Laptop' }, { machineId: PEER, nickname: 'Mac Mini' }],
+      }),
+    ).toBe('Laptop');
+  });
+
+  // THE REGRESSION (live-caught 2026-06-04): self nickname ABSENT from the local view
+  // (laptop's own entry nickname=None) but PRESENT in a peer's view (the mini calls it
+  // "Laptop"). The old fix fed self-nickname in synthetically and never hit this.
+  it('falls back to a PEER view that names this machine when the local view omits it', () => {
+    expect(
+      resolveSelfNickname({
+        selfMachineId: SELF,
+        localCapacities: [{ machineId: SELF /* no nickname */ }, { machineId: PEER, nickname: 'Mac Mini' }],
+        peerCapacities: [[{ machineId: SELF, nickname: 'Laptop' }, { machineId: PEER, nickname: 'Mac Mini' }]],
+        derive: () => 'Justins Macbook Pro', // derive would give the WRONG name — peer view must win
+      }),
+    ).toBe('Laptop');
+  });
+
+  it('prefers the local view over a peer view when both have it', () => {
+    expect(
+      resolveSelfNickname({
+        selfMachineId: SELF,
+        localCapacities: [{ machineId: SELF, nickname: 'Local Name' }],
+        peerCapacities: [[{ machineId: SELF, nickname: 'Peer Name' }]],
+      }),
+    ).toBe('Local Name');
+  });
+
+  it('falls back to derive only when neither local nor any peer view names this machine', () => {
+    expect(
+      resolveSelfNickname({
+        selfMachineId: SELF,
+        localCapacities: [{ machineId: SELF }],
+        peerCapacities: [[{ machineId: PEER, nickname: 'Mac Mini' }]],
+        derive: () => 'Derived Name',
+      }),
+    ).toBe('Derived Name');
+  });
+
+  it('returns null when nothing resolves (caller omits self nickname — pre-existing behavior)', () => {
+    expect(
+      resolveSelfNickname({ selfMachineId: SELF, localCapacities: [{ machineId: SELF }] }),
+    ).toBeNull();
+  });
+
+  it('ignores blank/whitespace nicknames at every layer', () => {
+    expect(
+      resolveSelfNickname({
+        selfMachineId: SELF,
+        localCapacities: [{ machineId: SELF, nickname: '   ' }],
+        peerCapacities: [[{ machineId: SELF, nickname: '' }]],
+        derive: () => '  ',
+      }),
+    ).toBeNull();
+  });
+
+  it('derives (or null) when selfMachineId is unknown', () => {
+    expect(
+      resolveSelfNickname({ selfMachineId: null, localCapacities: [], derive: () => 'X' }),
+    ).toBe('X');
+  });
+});

--- a/upgrades/next/mm-self-nickname.md
+++ b/upgrades/next/mm-self-nickname.md
@@ -1,0 +1,36 @@
+# Upgrade Guide — vNEXT
+
+<!-- bump: patch -->
+
+## What Changed
+
+Completes the multi-machine relocation fix: a machine now resolves its OWN nickname.
+
+- **Root cause (live-caught on real hardware):** `updateNickname` is local-only, so a
+  machine rename applied on a peer's registry never reached the owning machine — its own
+  capacity entry was `nickname=None` while peers saw the name. The relocation check runs on
+  the holder, so it couldn't resolve its own nickname and "move it back to <this machine>"
+  silently failed.
+- **`SelfNicknameResolver`** (pure) — resolves self-nickname: local view → peer view → derive.
+- **Convergence task** — at boot and on a timer, if the local self-nickname is missing, it
+  adopts the name a peer authoritatively reports and persists it, making `getCapacities()`
+  symmetric so the recognizer, transfer route, and `/pool` all resolve self.
+- **Transfer route** resolves the self-nickname via the resolver (was capacity-only).
+
+## What to Tell Your User
+
+- **"Move it back here" works now.** When a conversation is on one of your machines and you
+  ask to move it back to the machine you're on, that used to silently do nothing in some
+  setups — your agent didn't know its own name. It learns its own name from its other
+  machines now, so moving things back and forth just works.
+
+## Summary of New Capabilities
+
+- A machine resolves its own user-facing nickname (from peers when its local copy is missing).
+- Reliable "move this to the machine it's already on" — the last gap in nickname transfers.
+
+## Evidence
+
+Live-caught on the real laptop+mini pair (laptop returned 404 "unknown machine: Laptop" for
+its own name). 7 unit tests incl. the asymmetry regression + an e2e proving self-nickname
+transfer resolves through the real AgentServer. Spec: MULTI-MACHINE-SESSION-POOL-SPEC §L4.

--- a/upgrades/side-effects/mm-self-nickname.md
+++ b/upgrades/side-effects/mm-self-nickname.md
@@ -1,0 +1,23 @@
+# Self-Nickname Convergence — Plain-English Overview
+
+> One line: a machine now learns its OWN user-facing nickname from its peers, so "move it back to <this machine>" finally works.
+
+## The problem in one breath
+
+We shipped placement/transfer robustness, but live-testing on the real laptop+mini pair exposed that the fix was incomplete: the laptop couldn't resolve its OWN name "Laptop". Root cause — `updateNickname` (the dashboard rename) is local-only, so a rename applied on a peer's registry never reached the owning machine. The laptop's own capacity entry was `nickname=None` while peers correctly saw "Laptop". The relocation check runs on the holder (laptop), so it couldn't match "Laptop" → "move it back to the laptop" silently failed.
+
+## What this adds
+
+- **`SelfNicknameResolver` (pure)** — resolves this machine's own nickname: local capacity view → any PEER's view that names it (the drift backstop) → deterministic derive. Unit-tested incl. the exact asymmetry (self absent locally, present in a peer view).
+- **Self-nickname convergence task (server)** — periodically (and at boot), if the local self-entry has no nickname, it fetches an online peer's `/pool`, finds what the peer calls this machine, and persists it via `updateNickname`. This makes `getCapacities()` SYMMETRIC, so the recognizer, the transfer route, and `/pool` all resolve self. No-ops once known.
+- **Transfer route** now resolves the self-nickname via the resolver (was caps-only).
+
+## The safeguards
+
+- **Best-effort, never blocks** — convergence catches all errors (annotated `@silent-fallback-ok`); a failed peer fetch just retries on the timer.
+- **No mis-routing** — adoption only happens when the local nickname is missing and a peer authoritatively names this machineId; `updateNickname` still enforces pool-uniqueness.
+- **Tests** — Tier 1 (7 unit on the resolver incl. the regression), Tier 3 (e2e: transfer to THIS machine's own nickname resolves through the real AgentServer — 404'd before). `tsc` clean.
+
+## Spec lineage
+
+§L4 of the approved `docs/specs/MULTI-MACHINE-SESSION-POOL-SPEC.md` (nickname-based placement/transfer). No new authority — a convergence read-model over existing nickname state.


### PR DESCRIPTION
Live-caught on the real laptop+mini pair: the prior recognizer fix was incomplete — `updateNickname` is local-only, so the laptop's own capacity entry was `nickname=None` (peers saw "Laptop") and it couldn't resolve its own name → "move it back to the laptop" still 404'd.

- **SelfNicknameResolver** (pure): local → peer view → derive (7 unit tests incl. the asymmetry regression).
- **Convergence task**: adopts self-nickname from a peer's /pool + persists it → `getCapacities()` symmetric.
- **Transfer route** resolves self-nickname via the resolver.
- **E2E**: transfer to THIS machine's own nickname resolves through the real AgentServer.

Spec §L4. Will live-verify on the real pair after deploy.