### PR TITLE
fix(gemini): switch model on per-model exhaustion instead of a global block

### DIFF
--- a/docs/specs/gemini-model-fallback-on-exhaustion.eli16.md
+++ b/docs/specs/gemini-model-fallback-on-exhaustion.eli16.md
@@ -1,0 +1,50 @@
+# ELI16 — When one Gemini model runs out, switch instead of giving up
+
+## What this is, in plain English
+
+Some instar agents run on Google's Gemini. Gemini offers more than one model —
+think of them as two separate engines: a fast one (`gemini-2.5-flash`) and a
+heavier one (`gemini-2.5-pro`). Crucially, **each engine has its own separate fuel
+tank.** Running the fast engine dry does NOT empty the heavy engine's tank.
+
+## The problem
+
+When the model an agent was using ran out of fuel ("You have exhausted your
+capacity on this model, resets in 46 minutes"), instar treated it as "the whole
+Gemini account is out of fuel — stop everything." It wrote a little status file
+saying `recommendation: stop`, and anything that read that file — including the
+agent itself and the mentor watching it — concluded the agent was completely down
+for 46 minutes.
+
+But that was wrong: the OTHER engine still had fuel. We saw this live this
+session — a Gemini agent's fast model was exhausted, yet the account dashboard
+showed plenty of headroom. So we kept reporting "Gemi is blocked" when it wasn't.
+(The operator corrected this twice — rightly.)
+
+## What's new
+
+Now, when one model runs out, instar **switches to the other model and keeps
+going** — exactly like the equivalent feature we already have for the codex
+agents. Only if BOTH models are genuinely out of fuel does it actually stop and
+write the "account is blocked" status (now clearly marked as account-wide, so a
+reader can tell the difference between "one model resting" and "everything's
+out").
+
+The switch is quick (a fraction of a second — no point waiting, since it's a
+different fuel tank), and it's loop-proof: each exhausted model is remembered with
+its own reset time, so instar never bounces back and forth, and the memory clears
+itself once a model's window passes.
+
+## Why it's safe
+
+- It never makes a genuine outage invisible: when every model is exhausted, it
+  still defers and still writes the stop status — so doomed retries are still
+  prevented, exactly as before.
+- The only new cost is, at worst, one extra quick attempt on the second model
+  before giving up — and in the common case that second model has fuel, so the
+  agent simply keeps working instead of going dark for the better part of an hour.
+- It's confined to the Gemini path; Claude and codex agents are untouched.
+
+Proven with 21 tests across three levels (unit, integration, and a live-style
+end-to-end run) covering both the "switch and keep going" case and the "everything
+is genuinely exhausted, so stop" case.

--- a/src/providers/adapters/gemini-cli/observability/geminiCapacityPolicy.ts
+++ b/src/providers/adapters/gemini-cli/observability/geminiCapacityPolicy.ts
@@ -12,7 +12,7 @@
  * - fallback models must be in the verified Gemini model set.
  */
 
-import { GEMINI_DEFAULT_MODEL, isKnownGeminiModel } from '../models.js';
+import { GEMINI_DEFAULT_MODEL, isKnownGeminiModel, KNOWN_GEMINI_MODELS } from '../models.js';
 import fs from 'node:fs';
 import path from 'node:path';
 import { SafeFsExecutor } from '../../../../core/SafeFsExecutor.js';
@@ -54,11 +54,22 @@ export interface GeminiCapacityGate {
 const DEFAULT_IMMEDIATE_RETRIES = 1;
 const DEFAULT_IMMEDIATE_RETRY_MAX_MS = 30_000;
 const DEFAULT_BACKOFF_MS = 5_000;
+// Switching to a DIFFERENT model (separate quota) needs no real backoff — the
+// wait the exhausted model wanted does not apply to the fresh one. Use a tiny
+// delay only to avoid a tight loop in pathological cases.
+const DEFAULT_MODEL_SWITCH_BACKOFF_MS = 250;
 const DEFAULT_UNKNOWN_RESET_MS = 15 * 60_000;
 const RESET_GRACE_MS = 5_000;
 
 let deferredUntil = 0;
 let deferredReason: string | null = null;
+
+// Per-model exhaustion windows (model id → epoch ms its quota is expected to
+// reset). The known Gemini models draw on SEPARATE quotas, so a single model
+// exhausting is NOT an account-wide block: we record the exhausted model here
+// and switch to a model with headroom before globally deferring. Time-based, so
+// entries self-clear once a model's reported reset window has passed.
+const modelExhaustedUntil = new Map<string, number>();
 
 export function isGeminiCapacityError(message: string | null | undefined): boolean {
   if (!message) return false;
@@ -111,11 +122,37 @@ export function resolveKnownGeminiFallback(
   return fallback;
 }
 
+/**
+ * Pick a known Gemini model to switch to when `exhaustedModel` hit its capacity
+ * limit. A candidate qualifies when it is (a) a known Gemini model, (b) not the
+ * just-exhausted model, and (c) not itself inside a recorded exhaustion window
+ * at `now`. Prefers an operator-configured fallback when it qualifies, otherwise
+ * the first known model with headroom. Returns undefined when every known model
+ * is exhausted — the genuine account-wide block case.
+ */
+export function pickGeminiFallbackModel(
+  exhaustedModel: string,
+  config: GeminiCapacityPolicyConfig | undefined,
+  now: number,
+): string | undefined {
+  const hasHeadroom = (m: string | undefined): m is string =>
+    !!m &&
+    isKnownGeminiModel(m) &&
+    m !== exhaustedModel &&
+    (modelExhaustedUntil.get(m) ?? 0) <= now;
+  if (hasHeadroom(config?.fallbackModel)) return config?.fallbackModel;
+  for (const m of KNOWN_GEMINI_MODELS) {
+    if (hasHeadroom(m)) return m;
+  }
+  return undefined;
+}
+
 export function decideGeminiCapacityPolicy(params: {
   errorMessage: string;
   attempt: number;
   model: string;
   config?: GeminiCapacityPolicyConfig;
+  now?: number;
 }): GeminiCapacityDecision {
   const { errorMessage, attempt, model, config } = params;
   if (config?.enabled === false || !isGeminiCapacityError(errorMessage)) {
@@ -140,11 +177,29 @@ export function decideGeminiCapacityPolicy(params: {
   }
 
   const deferMs = retryAfterMs ?? DEFAULT_UNKNOWN_RESET_MS;
+  const now = params.now ?? Date.now();
+  // Per-model exhaustion is NOT an account-wide block — the known Gemini models
+  // (flash, pro) draw on SEPARATE quotas. Record this model's window, then switch
+  // to a model with headroom before globally deferring. The switch also means we
+  // do NOT write the global stop-state for a single-model exhaustion (the caller
+  // only records a deferral on action:'defer'), which is what made instar report
+  // a fully-available account as "blocked". Mirrors the codex auto-swap policy.
+  modelExhaustedUntil.set(model, now + deferMs);
+  const fallback = pickGeminiFallbackModel(model, config, now);
+  if (fallback) {
+    return {
+      action: 'retry',
+      retryAfterMs: DEFAULT_MODEL_SWITCH_BACKOFF_MS,
+      model: fallback,
+      reason: `gemini model ${model} exhausted; switching to ${fallback} (separate quota may have headroom)`,
+    };
+  }
+  // Every known model is exhausted — a genuine account-wide block.
   return {
     action: 'defer',
     retryAfterMs: deferMs,
     model,
-    reason: `gemini capacity exhausted; deferring calls for ${deferMs}ms`,
+    reason: `gemini capacity exhausted on all known models; deferring calls for ${deferMs}ms`,
   };
 }
 
@@ -201,6 +256,12 @@ function writeGeminiQuotaState(params: {
     usagePercent: 0,
     fiveHourPercent: 100,
     source: 'gemini-cli-capacity',
+    // 'account': this stop-state is only written once EVERY known model is
+    // exhausted (the genuine account-wide block). A single model exhausting no
+    // longer reaches here — the policy switches to a model with headroom first —
+    // so a reader can trust `recommendation:'stop'` here means the agent really
+    // is out of capacity, not just one model.
+    scope: 'account',
     model: params.model,
     blockedUntil: new Date(params.blockedUntil).toISOString(),
     blockReason: params.reason,
@@ -227,4 +288,5 @@ function writeGeminiQuotaState(params: {
 export function resetGeminiCapacityPolicyForTests(): void {
   deferredUntil = 0;
   deferredReason = null;
+  modelExhaustedUntil.clear();
 }

--- a/tests/e2e/gemini-capacity-policy-lifecycle.test.ts
+++ b/tests/e2e/gemini-capacity-policy-lifecycle.test.ts
@@ -40,9 +40,12 @@ process.exit(1);
       geminiPath: bin,
       capacityPolicy: { quotaStateFile: quotaFile },
     });
-    await expect(provider.evaluate('p', { timeoutMs: 10_000 })).rejects.toThrow(/deferring|quota/i);
+    await expect(provider.evaluate('p', { timeoutMs: 10_000 })).rejects.toThrow(/deferring|quota|exhausted/i);
     await expect(provider.evaluate('p', { timeoutMs: 10_000 })).rejects.toThrow(/deferred|retry after/i);
-    expect(fs.readFileSync(countFile, 'utf8')).toBe('1');
+    // First evaluate spawns Gemini twice (flash exhausts → switch to pro → pro
+    // exhausts → genuine account-wide defer). Second evaluate is refused locally
+    // by the gate, so the count stays at 2 — Gemini is NOT respawned again.
+    expect(fs.readFileSync(countFile, 'utf8')).toBe('2');
 
     const written = JSON.parse(fs.readFileSync(quotaFile, 'utf8')) as {
       source: string;
@@ -50,11 +53,14 @@ process.exit(1);
       fiveHourPercent: number;
       blockedUntil: string;
       recommendation: string;
+      scope: string;
     };
     expect(written.source).toBe('gemini-cli-capacity');
-    expect(written.model).toBe('gemini-2.5-flash');
+    // Last model confirmed exhausted; account-scoped (every known model is out).
+    expect(written.model).toBe('gemini-2.5-pro');
     expect(written.fiveHourPercent).toBe(100);
     expect(written.recommendation).toBe('stop');
+    expect(written.scope).toBe('account');
     expect(new Date(written.blockedUntil).getTime()).toBeGreaterThan(Date.now());
 
     const tracker = new QuotaTracker({

--- a/tests/integration/gemini-capacity-policy-integration.test.ts
+++ b/tests/integration/gemini-capacity-policy-integration.test.ts
@@ -106,17 +106,25 @@ process.exit(1);
     const oneShot = adapter.primitive(CapabilityFlag.OneShotCompletion) as OneShotCompletion;
     await expect(oneShot.evaluate('p', { timeoutMs: 10_000 })).rejects.toBeInstanceOf(QuotaError);
     await expect(oneShot.evaluate('p', { timeoutMs: 10_000 })).rejects.toBeInstanceOf(QuotaError);
-    expect(fs.readFileSync(countFile, 'utf8')).toBe('1');
+    // The FIRST evaluate now spawns Gemini twice — flash exhausts, the policy
+    // switches to pro (separate quota), pro ALSO exhausts → only then a genuine
+    // account-wide deferral. The SECOND evaluate is still refused locally by the
+    // gate (no further spawn), so the count stays at 2.
+    expect(fs.readFileSync(countFile, 'utf8')).toBe('2');
 
     const state = JSON.parse(fs.readFileSync(quotaFile, 'utf8')) as {
       source: string;
       fiveHourPercent: number;
       model: string;
       recommendation: string;
+      scope: string;
     };
     expect(state.source).toBe('gemini-cli-capacity');
     expect(state.fiveHourPercent).toBe(100);
-    expect(state.model).toBe('gemini-2.5-flash');
+    // The stop-state records the last model confirmed exhausted (pro) and is
+    // account-scoped — written only once EVERY known model is exhausted.
+    expect(state.model).toBe('gemini-2.5-pro');
     expect(state.recommendation).toBe('stop');
+    expect(state.scope).toBe('account');
   });
 });

--- a/tests/unit/geminiCapacityPolicy.test.ts
+++ b/tests/unit/geminiCapacityPolicy.test.ts
@@ -4,6 +4,7 @@ import {
   getGeminiCapacityGate,
   isGeminiCapacityError,
   parseGeminiRetryAfterMs,
+  pickGeminiFallbackModel,
   recordGeminiCapacityDeferral,
   resetGeminiCapacityPolicyForTests,
   resolveKnownGeminiFallback,
@@ -31,23 +32,74 @@ describe('geminiCapacityPolicy', () => {
     expect(parseGeminiRetryAfterMs('reset in 2 minutes')).toBe(120_000);
   });
 
-  it('retries once for short windows, then defers', () => {
+  it('retries once for a short window, then switches model, then defers once ALL models are exhausted', () => {
+    // attempt 0, short window → immediate retry on the same model.
     const first = decideGeminiCapacityPolicy({
       errorMessage: '429 resource exhausted, retry after 2s',
       attempt: 0,
       model: 'gemini-2.5-flash',
       config: { backoffMs: 1 },
+      now: 1_000,
     });
     expect(first.action).toBe('retry');
     expect(first.retryAfterMs).toBe(2_000);
 
+    // attempt 1, immediate retries spent + a long reset → flash is exhausted, but
+    // pro draws on a separate quota and has headroom, so switch to pro rather than
+    // globally deferring (the bug: a single-model exhaustion read as a full block).
     const second = decideGeminiCapacityPolicy({
-      errorMessage: '429 resource exhausted, retry after 2s',
+      errorMessage: 'exhausted your capacity on this model. quota will reset after 46m',
       attempt: 1,
       model: 'gemini-2.5-flash',
       config: { backoffMs: 1 },
+      now: 1_000,
     });
-    expect(second.action).toBe('defer');
+    expect(second.action).toBe('retry');
+    expect(second.model).toBe('gemini-2.5-pro');
+
+    // pro ALSO exhausts → every known model is now in an exhaustion window →
+    // genuine account-wide block → defer (and only NOW would a stop-state write).
+    const third = decideGeminiCapacityPolicy({
+      errorMessage: 'exhausted your capacity on this model. quota will reset after 46m',
+      attempt: 2,
+      model: 'gemini-2.5-pro',
+      config: { backoffMs: 1 },
+      now: 1_000,
+    });
+    expect(third.action).toBe('defer');
+  });
+
+  it('a single-model exhaustion switches to the model with headroom (no global stop)', () => {
+    const d = decideGeminiCapacityPolicy({
+      errorMessage:
+        'You have exhausted your capacity on this model. Your quota will reset after 46m11s.',
+      attempt: 5, // well past immediate retries
+      model: 'gemini-2.5-flash',
+      config: {},
+      now: 0,
+    });
+    // retry-with-switch, NOT defer → the caller never records a global deferral
+    // / writes recommendation:'stop' for a one-model exhaustion.
+    expect(d.action).toBe('retry');
+    expect(d.model).toBe('gemini-2.5-pro');
+  });
+
+  it('pickGeminiFallbackModel returns the other model, then undefined once both are exhausted', () => {
+    expect(pickGeminiFallbackModel('gemini-2.5-flash', undefined, 0)).toBe('gemini-2.5-pro');
+    // record both models as exhausted via the decision path
+    decideGeminiCapacityPolicy({ errorMessage: 'quota exhausted; reset after 46m', attempt: 9, model: 'gemini-2.5-flash', now: 0 });
+    decideGeminiCapacityPolicy({ errorMessage: 'quota exhausted; reset after 46m', attempt: 9, model: 'gemini-2.5-pro', now: 0 });
+    expect(pickGeminiFallbackModel('gemini-2.5-flash', undefined, 0)).toBeUndefined();
+  });
+
+  it('per-model exhaustion windows self-clear once the reset passes', () => {
+    const t0 = 1_000;
+    // pro exhausts with a ~1m reset
+    decideGeminiCapacityPolicy({ errorMessage: 'quota exhausted; reset after 1m', attempt: 9, model: 'gemini-2.5-pro', now: t0 });
+    // before the window passes, pro is not a usable fallback
+    expect(pickGeminiFallbackModel('gemini-2.5-flash', undefined, t0 + 1_000)).toBeUndefined();
+    // after the window, pro has headroom again
+    expect(pickGeminiFallbackModel('gemini-2.5-flash', undefined, t0 + 120_000)).toBe('gemini-2.5-pro');
   });
 
   it('records a local deferral gate past the reset window', () => {

--- a/upgrades/next/gemini-model-fallback-on-exhaustion.md
+++ b/upgrades/next/gemini-model-fallback-on-exhaustion.md
@@ -1,0 +1,53 @@
+<!-- bump: patch -->
+
+## What Changed
+
+When a Gemini call hit a per-model capacity limit (e.g. "You have exhausted your
+capacity on this model. Quota resets after 46m"), instar's Gemini capacity policy
+globally deferred on that model and wrote a `quota-state.json` snapshot with
+`recommendation: 'stop'` / `fiveHourPercent: 100`. But the known Gemini models
+(`gemini-2.5-flash`, `gemini-2.5-pro`) draw on SEPARATE quotas, so one model
+exhausting was mis-recorded as a full account-wide block — and every reader of that
+file (the agent, the mentor, the escalation monitor) concluded the whole Gemini
+agent was down, even when the account had headroom on the other model. This produced
+repeated false "agent is blocked" reports.
+
+The policy now switches to a known model with headroom and retries before deferring
+(mirroring the codex auto-swap-on-limit policy). Only when EVERY known model is
+exhausted does it globally defer and write the stop-state — now tagged
+`scope: 'account'`. The per-model exhaustion windows are tracked time-based and
+self-clear, so there is no switch loop and no stale state. The model switch uses a
+short 250ms backoff (a different model needs no wait).
+
+## What to Tell Your User
+
+If you run a Gemini-backed agent: when one Gemini model hits its limit, the agent now
+quietly switches to the other model and keeps working, instead of going dark for the
+length of that model's reset window. It only reports itself as out of capacity when
+every model is genuinely exhausted. Nothing to do — it just stops the false "blocked"
+reports and keeps the agent productive.
+
+## Summary of New Capabilities
+
+Gemini agents auto-fall-back across models on a per-model capacity limit (parity with
+the codex auto-swap), and the durable quota-state now distinguishes a single-model
+deferral from a genuine account-wide block (`scope: 'account'`).
+
+## Evidence
+
+- **Reproduction (live this session):** a Gemini agent's `gemini -p` probe returned
+  "You have exhausted your capacity on this model. Your quota will reset after 46m11s"
+  while the account `/stats` showed 20% remaining on the Auto model — i.e. one model
+  exhausted, account fine. The old policy wrote `recommendation: 'stop'` for this,
+  which read as a full block.
+- **Before:** single-model exhaustion → global defer + `recommendation:'stop'` /
+  `fiveHourPercent:100`; the agent appeared fully blocked for the whole reset window.
+- **After:** single-model exhaustion → switch to the model with headroom and keep
+  working; global stop-state (now `scope:'account'`) is written ONLY when every known
+  model is exhausted.
+- **Tests:** 21 across three tiers — `tests/unit/geminiCapacityPolicy.test.ts`
+  (switch-then-defer, single-model-no-global-stop, `pickGeminiFallbackModel`,
+  self-clearing windows), `tests/integration/gemini-capacity-policy-integration.test.ts`,
+  and `tests/e2e/gemini-capacity-policy-lifecycle.test.ts` (both updated to assert the
+  two-model attempt + account scope), plus the escalation-monitor suite. `tsc --noEmit`
+  clean.

--- a/upgrades/side-effects/gemini-model-fallback-on-exhaustion.md
+++ b/upgrades/side-effects/gemini-model-fallback-on-exhaustion.md
@@ -1,0 +1,81 @@
+# Side-Effects Review — Gemini per-model exhaustion switches model before deferring
+
+**Version / slug:** `gemini-model-fallback-on-exhaustion`
+**Date:** `2026-06-04`
+**Author:** `echo`
+**Second-pass reviewer:** `required (LLM-routing behavior change)`
+
+## Summary of the change
+
+When a Gemini call hit a capacity limit, `decideGeminiCapacityPolicy` (after its
+short-window immediate-retry path) went straight to a GLOBAL `defer` on the SAME
+model, and `recordGeminiCapacityDeferral` wrote a `quota-state.json` snapshot with
+`fiveHourPercent: 100` / `recommendation: 'stop'`. But the known Gemini models —
+`gemini-2.5-flash` and `gemini-2.5-pro` — draw on **separate** quotas. So one model
+exhausting (e.g. "You have exhausted your capacity on this model. Quota resets after
+46m") was recorded as a full account-wide block, and any reader of `quota-state.json`
+(including the agent itself, the mentor, the escalation monitor) saw `recommendation:
+'stop'` and concluded the whole Gemini agent was down — even when the account had
+headroom on the other model. This caused repeated false "Gemi is blocked" reports
+(confirmed live this session: a `gemini -p` probe returned that exact error while
+`/stats` showed the account at 20% remaining on Auto).
+
+The fix (mirrors the existing codex auto-swap-on-limit policy, #31): on per-model
+exhaustion, record the exhausted model's reset window, then switch to a known model
+with headroom and retry. Only when **every** known model is exhausted do we globally
+defer and write the stop-state — now tagged `scope: 'account'`. Because the caller
+records a deferral only on `action: 'defer'`, switching models also means a single-
+model exhaustion no longer writes a global stop at all.
+
+## Decision-point inventory
+
+1. **`decideGeminiCapacityPolicy` (long-reset branch):** record `model` as exhausted
+   (time-based, `now + deferMs`); pick a fallback via `pickGeminiFallbackModel`; if
+   one exists → `retry` with that model; else → `defer`.
+2. **`pickGeminiFallbackModel`:** a candidate qualifies when known, ≠ the exhausted
+   model, and not itself inside a recorded exhaustion window at `now`. Prefers an
+   operator-configured `fallbackModel`, else the first known model with headroom.
+
+## 1. Over-block (what still defers / blocks)
+
+- When ALL known models are in an exhaustion window → `defer` + the global stop-state
+  (now `scope: 'account'`). That is the genuine account-wide block and still gates
+  scheduler spawns exactly as before. (tests: "defers once ALL models exhausted",
+  integration "defers after a long quota reset", e2e lifecycle.)
+- The short-window immediate-retry path (attempt < maxImmediateRetries, small reset)
+  is unchanged.
+- Non-capacity errors are unchanged — `decide` returns `none` and the error surfaces.
+
+## 2. Under-block (what it now allows that it didn't)
+
+- A single model exhausting now triggers ONE extra Gemini spawn on the other model
+  (the switch) before any deferral. Worst-case cost when BOTH models are exhausted:
+  two spawns instead of one (flash then pro) before the global defer — bounded at 2
+  (one per known model; each is recorded exhausted so it is never retried within its
+  window). The model-switch retry uses a 250ms backoff (not the 5s same-model
+  backoff) since a different model needs no wait.
+- Loop-safety: `modelExhaustedUntil` is time-based and self-clears once a window
+  passes, so there is no permanent state and no A→B→A switch loop (each model is
+  recorded before fallback selection; once both are recorded, `pickGeminiFallbackModel`
+  returns undefined → defer). (tests: "returns undefined once both exhausted",
+  "windows self-clear once the reset passes".)
+
+## 3. Blast radius
+
+- One file of logic: `src/providers/adapters/gemini-cli/observability/geminiCapacityPolicy.ts`
+  (new module state `modelExhaustedUntil`, new export `pickGeminiFallbackModel`, a
+  `now?` param on `decide`, the switch-before-defer branch, `scope` on the stop-state,
+  reset clears the map).
+- NO consumer signature changes: both callers (`transport/oneShotCompletion.ts`,
+  `core/GeminiCliIntelligenceProvider.ts`) already switch to `decision.model` on
+  `action:'retry'` and record a deferral only on `action:'defer'`.
+- Affects only Gemini-CLI agents. Claude / codex paths untouched. The added
+  `scope` field is additive (readers that don't know it are unaffected).
+
+## 4. Reversibility
+
+Fully reversible: revert the one policy file + the test updates. Module state is
+in-process and time-based (no persistence); the `quota-state.json` shape only gains
+an additive `scope` field. Verified: `tsc --noEmit` clean; 21 tests green across
+unit + integration + e2e + escalation tiers (both the switch path and the genuine
+all-models-defer path).


### PR DESCRIPTION
## What

A Gemini per-model capacity limit was recorded as a global account-wide block. `decideGeminiCapacityPolicy` deferred on the exhausted model and `recordGeminiCapacityDeferral` wrote `quota-state.json` with `recommendation: 'stop'` / `fiveHourPercent: 100`. But `gemini-2.5-flash` and `gemini-2.5-pro` draw on **separate** quotas, so one model exhausting falsely read as the whole agent being down.

**Confirmed live this session** (the apprenticeship loop surfaced it): a `gemini -p` probe returned `"You have exhausted your capacity on this model. Your quota will reset after 46m11s"` while the account `/stats` showed **20% remaining on Auto** — one model exhausted, account fine. The old policy wrote `recommendation:'stop'` for this, producing repeated false "agent blocked" reports (the operator corrected this twice).

## The fix

On per-model exhaustion, switch to a known model with headroom and retry **before** deferring (parity with the codex auto-swap-on-limit policy, #31). Only when **every** known model is exhausted does it globally defer and write the stop-state — now tagged `scope: 'account'`. Since the caller records a deferral only on `action:'defer'`, switching models also means a single-model exhaustion no longer writes a global stop at all.

- Per-model exhaustion windows tracked time-based + self-clear → loop-safe (no A→B→A switching; once both recorded, `pickGeminiFallbackModel` returns undefined → defer).
- Model switch uses a 250ms backoff (a different model needs no wait — the e2e dropped 5.3s→0.5s).
- **No consumer signature changes**: both callers (`oneShotCompletion`, `GeminiCliIntelligenceProvider`) already switch to `decision.model` on `action:'retry'` and record a deferral only on `action:'defer'`.

## Blast radius

One policy file (`geminiCapacityPolicy.ts`) + test updates. Gemini-only; Claude/codex untouched. The `scope` field on `quota-state.json` is additive.

## Tests

21 across three tiers — unit (`switch-then-defer`, `single-model-no-global-stop`, `pickGeminiFallbackModel`, self-clearing windows), integration, and e2e lifecycle (both updated to assert the two-model attempt + `scope:'account'`), plus the escalation suite. `tsc --noEmit` clean. Gate: Tier-1, at risk floor (riskFloor 1).

This is the structural root of the recurring "Gemi is blocked" false-positive — the loop hit it, and this fixes it for every Gemini agent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
