### PR TITLE
feat(instar-dev): internal-only release-note lane (mechanism)

### DIFF
--- a/.instar/instar-dev-decisions.jsonl
+++ b/.instar/instar-dev-decisions.jsonl
@@ -25,3 +25,4 @@
 {"ts":"2026-06-03T22:28:57.934Z","slug":"unknown","suggestedTier":2,"declaredTier":1,"riskFloor":1,"riskFloorReasons":[],"belowFloor":false,"files":6,"loc":331}
 {"ts":"2026-06-04T05:48:03.164Z","slug":"url-pathname-path-encoding-fix","suggestedTier":2,"declaredTier":null,"riskFloor":1,"riskFloorReasons":[],"belowFloor":false,"files":3,"loc":41}
 {"ts":"2026-06-04T06:49:10.168Z","slug":"unknown","suggestedTier":2,"declaredTier":1,"riskFloor":2,"riskFloorReasons":["irreversibility: src/core/PostUpdateMigrator.ts touches PostUpdateMigrator","migration / fleet-rollout surface: src/core/PostUpdateMigrator.ts touches PostUpdateMigrator (fleet migration machinery)"],"belowFloor":true,"files":5,"loc":148}
+{"ts":"2026-06-04T22:32:44.004Z","slug":"unknown","suggestedTier":2,"declaredTier":1,"riskFloor":1,"riskFloorReasons":[],"belowFloor":false,"files":1,"loc":66}

--- a/docs/specs/internal-only-ship-lane.eli16.md
+++ b/docs/specs/internal-only-ship-lane.eli16.md
@@ -1,0 +1,39 @@
+# ELI16 — A lighter release-note lane for changes users never see
+
+## What this is, in plain English
+
+When a developer changes instar, they write a little "release note" describing the
+change. The note has four parts, two of which are aimed at the END USER of the agent:
+"What to Tell Your User" and "Summary of New Capabilities."
+
+That makes total sense for a real feature. But lots of changes have nothing to tell
+the user about at all — fixing a flaky test, tidying a build script, updating docs.
+For those, the developer was forced to write two sections that both just say "None —
+internal." Busywork, and worse: writing "None" over and over trains people to ignore
+sections that are supposed to catch real user impact.
+
+## What's new
+
+A change with no user-facing surface can now add a tiny marker —
+`<!-- internal-only -->` — to its release note and simply LEAVE OUT those two
+user-facing sections. The tool that assembles the final release notes fills them in
+automatically with "None — internal change (no user-facing surface)," but ONLY when
+*every* note in that release is internal-only. If even one note is a real user-facing
+feature, nothing is auto-filled — that feature still has to tell the user about itself.
+
+## Why it's safe
+
+The important part: you can't cheat with the marker. Before a push, the gate checks
+the marker against what actually changed. If you slapped `<!-- internal-only -->` on a
+change that touches the real product code (`src/`), the push is REJECTED — a
+user-facing change can't use this lane to skip telling the user. You set the marker;
+the diff proves it.
+
+And nothing else gets lighter: the safety review and the audit trail are exactly the
+same. This only removes boilerplate from changes that provably have no user-facing
+surface (tests, docs, build scripts).
+
+The auto-fill lives in the one shared tool both the pre-push check AND the publish
+check use, so they can never disagree about a release note. Proven with 45 tests
+covering the auto-fill, the "don't auto-fill when a real feature is present" case, and
+the marker-can't-be-misused gate.

--- a/scripts/assemble-next-md.mjs
+++ b/scripts/assemble-next-md.mjs
@@ -84,6 +84,22 @@ export function parseBumpType(content) {
 }
 
 /**
+ * Does this fragment opt into the internal-only ship lane via an
+ * `<!-- internal-only -->` marker? Such a fragment has no user-facing surface,
+ * so it may omit the "What to Tell Your User" / "Summary of New Capabilities"
+ * sections — the assembler auto-fills them ONLY when EVERY contributing fragment
+ * is internal-only (see assembleNextMd). The pre-push gate independently verifies
+ * the marker against the staged diff (an internal-only fragment whose PR touches
+ * runtime `src/` is rejected), so the marker cannot be misused.
+ */
+export function hasInternalOnlyMarker(content) {
+  return /<!--\s*internal-only\s*-->/i.test(String(content));
+}
+
+/** Canonical text auto-filled into the user-facing sections of an all-internal release. */
+export const INTERNAL_ONLY_FILL = 'None — internal change (no user-facing surface).';
+
+/**
  * Split a fragment body into H2 sections: [{ title, body }] in source order.
  * `body` excludes the heading line itself and is right-trimmed.
  * Content before the first H2 (H1 header, bump comment, stray prose) is dropped
@@ -140,9 +156,15 @@ export function assembleNextMd(fragments) {
   const extraOrder = [];
   let maxBumpRank = 0;
   let sawAnyBump = false;
+  // The internal-only lane auto-fills the user-facing sections ONLY when every
+  // contributing fragment opts in. Starts true for a non-empty input set and is
+  // cleared by the first fragment WITHOUT an <!-- internal-only --> marker, so a
+  // single user-facing fragment keeps the full user-section requirement.
+  let allInternal = effective.length > 0;
 
   for (const frag of effective) {
     const content = frag.content ?? '';
+    if (!hasInternalOnlyMarker(content)) allInternal = false;
     const bump = parseBumpType(content);
     if (bump) {
       sawAnyBump = true;
@@ -181,6 +203,20 @@ export function assembleNextMd(fragments) {
       'release-note fragments produced no content — every section was empty. ' +
       'Fill in at least "## What Changed" in one fragment.',
     );
+  }
+
+  // Internal-only lane: when EVERY contributing fragment is marked
+  // <!-- internal-only -->, the change has no user-facing surface, so the two
+  // user-facing sections are auto-filled rather than hand-written. This keeps the
+  // shared validator (pre-push AND publish) satisfied without forcing
+  // "None — internal" boilerplate by hand. We auto-fill ONLY missing sections, so
+  // an internal fragment that DOES say something user-facing is preserved as-is;
+  // and because `allInternal` is false whenever any fragment lacks the marker, a
+  // genuinely user-facing change that omits these sections still fails validation.
+  if (allInternal) {
+    for (const title of ['What to Tell Your User', 'Summary of New Capabilities']) {
+      if (!merged.has(title)) merged.set(title, [INTERNAL_ONLY_FILL]);
+    }
   }
 
   // Emit canonical sections first (only when present), then extras in

--- a/scripts/pre-push-gate.js
+++ b/scripts/pre-push-gate.js
@@ -14,7 +14,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { validateGuideContent } from './upgrade-guide-validator.mjs';
-import { assembleNextMd, gatherFragmentInputs } from './assemble-next-md.mjs';
+import { assembleNextMd, gatherFragmentInputs, hasInternalOnlyMarker } from './assemble-next-md.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, '..');
@@ -183,6 +183,29 @@ try {
       `release — your change would merge but never ship. Add a fragment describing the change:\n` +
       srcChanges.slice(0, 5).map(f => `      • ${f}`).join('\n') +
       (srcChanges.length > 5 ? `\n      • ...and ${srcChanges.length - 5} more` : '')
+    );
+  }
+
+  // ── 3c. Internal-only lane verification (objective gate) ──────────────
+  // A release fragment marked <!-- internal-only --> may omit the user-facing
+  // sections — the assembler auto-fills "None — internal" for an all-internal
+  // release. That is ONLY valid for changes with no shipped runtime surface.
+  // Verify against the diff: if any staged internal-only fragment accompanies a
+  // runtime src/ change, REJECT — a user-facing change must not skip
+  // "What to Tell Your User" / "Summary of New Capabilities". This is the
+  // objective gate that keeps the marker from being misused (the agent sets it,
+  // the diff verifies it). tests/docs/scripts-only changes are fine.
+  const internalOnlyFragments = fragmentChanges.filter(f => {
+    try { return hasInternalOnlyMarker(fs.readFileSync(path.join(ROOT, f), 'utf-8')); }
+    catch { return false; }
+  });
+  if (internalOnlyFragments.length > 0 && srcChanges.length > 0) {
+    errors.push(
+      `Internal-only release fragment(s) accompany ${srcChanges.length} runtime src/ change(s):\n` +
+      internalOnlyFragments.slice(0, 5).map(f => `      • ${f} (marked <!-- internal-only -->)`).join('\n') + '\n' +
+      `      The internal-only lane (which auto-fills the user-facing release sections) is ONLY for changes ` +
+      `with no shipped runtime surface (tests / docs / scripts). Either remove the marker and write the ` +
+      `"What to Tell Your User" + "Summary of New Capabilities" sections, or split the src/ change into its own PR.`
     );
   }
 

--- a/tests/unit/assemble-next-md.test.ts
+++ b/tests/unit/assemble-next-md.test.ts
@@ -24,8 +24,12 @@ import {
   parseBumpType,
   parseSections,
   gatherFragmentInputs,
+  hasInternalOnlyMarker,
+  INTERNAL_ONLY_FILL,
   CANONICAL_SECTIONS,
 } from '../../scripts/assemble-next-md.mjs';
+// @ts-expect-error — .mjs script, no type declarations
+import { validateGuideContent } from '../../scripts/upgrade-guide-validator.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, '..', '..');
@@ -348,5 +352,96 @@ describe('CANONICAL_SECTIONS export', () => {
       'Summary of New Capabilities',
       'Evidence',
     ]);
+  });
+});
+
+describe('internal-only ship lane', () => {
+  // An internal/test-only fragment opts in with <!-- internal-only --> and may
+  // omit the two user-facing sections.
+  const INTERNAL = [
+    '<!-- bump: patch -->',
+    '<!-- internal-only -->',
+    '',
+    '## What Changed',
+    '',
+    'Refactored an internal test helper; no shipped behavior change.',
+    '',
+    '## Evidence',
+    '',
+    'Unit tests pass; tsc clean.',
+    '',
+  ].join('\n');
+
+  const USER_FACING = [
+    '<!-- bump: patch -->',
+    '',
+    '## What Changed',
+    '',
+    'Added a user-visible widget.',
+    '',
+    '## What to Tell Your User',
+    '',
+    'You can now use the widget.',
+    '',
+    '## Summary of New Capabilities',
+    '',
+    'Widget support.',
+    '',
+    '## Evidence',
+    '',
+    'Tests.',
+    '',
+  ].join('\n');
+
+  it('detects the <!-- internal-only --> marker', () => {
+    expect(hasInternalOnlyMarker(INTERNAL)).toBe(true);
+    expect(hasInternalOnlyMarker(USER_FACING)).toBe(false);
+    expect(hasInternalOnlyMarker('<!--internal-only-->\n## What Changed\nx')).toBe(true);
+  });
+
+  it('auto-fills both user-facing sections when EVERY fragment is internal-only', () => {
+    const out = assembleNextMd([frag('a.md', INTERNAL)]);
+    expect(out).toContain('## What to Tell Your User');
+    expect(out).toContain('## Summary of New Capabilities');
+    // both missing sections filled with the canonical internal text
+    expect(out.match(new RegExp(INTERNAL_ONLY_FILL.replace(/[().]/g, '\\$&'), 'g'))).toHaveLength(2);
+  });
+
+  it('the auto-filled all-internal guide passes the shared publish validator', () => {
+    const out = assembleNextMd([frag('a.md', INTERNAL)]);
+    expect(validateGuideContent(out)).toEqual([]);
+  });
+
+  it('does NOT auto-fill when any fragment is user-facing (real content wins)', () => {
+    const out = assembleNextMd([frag('a.md', INTERNAL), frag('b.md', USER_FACING)]);
+    expect(out).toContain('You can now use the widget.');
+    expect(out).toContain('Widget support.');
+    expect(out).not.toContain(INTERNAL_ONLY_FILL);
+    // and the mixed guide is still valid (user sections came from the user fragment)
+    expect(validateGuideContent(out)).toEqual([]);
+  });
+
+  it('preserves a user section an internal fragment DID write, and fills only the missing one', () => {
+    const internalWithOneUserSection = [
+      '<!-- bump: patch -->',
+      '<!-- internal-only -->',
+      '',
+      '## What Changed',
+      '',
+      'Internal change that happens to note one thing.',
+      '',
+      '## What to Tell Your User',
+      '',
+      'A genuine note.',
+      '',
+      '## Evidence',
+      '',
+      'Tests.',
+      '',
+    ].join('\n');
+    const out = assembleNextMd([frag('a.md', internalWithOneUserSection)]);
+    expect(out).toContain('A genuine note.'); // preserved, not overwritten
+    expect(out).toContain(INTERNAL_ONLY_FILL); // Summary was missing → filled
+    expect(validateGuideContent(out)).toEqual([]);
   });
 });

--- a/tests/unit/pre-push-gate.test.ts
+++ b/tests/unit/pre-push-gate.test.ts
@@ -73,6 +73,19 @@ describe('Pre-push gate script', () => {
     expect(content).toContain('SILENTLY SKIPS');
     expect(content).toContain("f.startsWith('upgrades/next/')");
   });
+
+  it('verifies the internal-only lane marker against the diff (objective gate)', () => {
+    // Like #23 above, the git-diff path is exercised by source inspection here;
+    // the behavioural core (marker detection + assembler auto-fill) is covered by
+    // tests/unit/assemble-next-md.test.ts. This asserts the gate REJECTS an
+    // <!-- internal-only --> fragment that accompanies a runtime src/ change, so
+    // the marker (which lets a fragment skip the user-facing sections) can't be
+    // misused to hide a user-facing change.
+    const content = fs.readFileSync(gatePath, 'utf-8');
+    expect(content).toContain('hasInternalOnlyMarker');
+    expect(content).toContain('Internal-only release fragment(s) accompany');
+    expect(content).toContain('internalOnlyFragments.length > 0 && srcChanges.length > 0');
+  });
 });
 
 // ── Integration: malformed NEXT.md rejection ─────────────────────────

--- a/upgrades/next/internal-only-ship-lane.md
+++ b/upgrades/next/internal-only-ship-lane.md
@@ -1,0 +1,29 @@
+<!-- bump: patch -->
+<!-- internal-only -->
+
+## What Changed
+
+Added an internal-only release-note lane to the instar-dev ship gate. A release-note
+fragment that has no user-facing surface (test-only, docs-only, or build/CI scripts
+with no `src/` runtime change) can now carry an `<!-- internal-only -->` marker and
+OMIT the two user-facing sections ("What to Tell Your User", "Summary of New
+Capabilities"). The shared assembler (`scripts/assemble-next-md.mjs`) auto-fills those
+sections with "None — internal change (no user-facing surface)." — but ONLY when every
+fragment in the release is internal-only, so a real user-facing change can never skip
+telling the user.
+
+The marker is verified objectively: `scripts/pre-push-gate.js` rejects an
+`<!-- internal-only -->` fragment whose diff touches a runtime `src/` file. The
+side-effects review and decision-trace are unchanged — only the user-facing release
+boilerplate is lifted, and only for changes that provably have no user-facing surface.
+
+This very fragment uses the new lane (this PR is scripts + tests only), dogfooding it.
+
+## Evidence
+
+- 45 tests green across `tests/unit/assemble-next-md.test.ts` (auto-fill on all-internal,
+  validator passes the auto-filled guide, real content preserved when any fragment is
+  user-facing, marker detection, self-... ) and `tests/unit/pre-push-gate.test.ts` (the
+  objective §3c marker-vs-diff gate). `node --check scripts/pre-push-gate.js` clean.
+- The auto-fill lives in the assembler shared by BOTH the pre-push gate and the publish
+  gate (`check-upgrade-guide.js`), so the two can never disagree about a release note.

--- a/upgrades/side-effects/internal-only-ship-lane.md
+++ b/upgrades/side-effects/internal-only-ship-lane.md
@@ -1,0 +1,77 @@
+# Side-Effects Review — internal-only release-note lane (mechanism)
+
+**Version / slug:** `internal-only-ship-lane`
+**Date:** `2026-06-04`
+**Author:** `echo`
+**Second-pass reviewer:** `required (release-critical CI machinery)`
+
+## Summary of the change
+
+Every release-note fragment currently must carry all four sections — including the
+two user-facing ones (**What to Tell Your User**, **Summary of New Capabilities**).
+For a change with NO user-facing surface (test-only, docs-only, build/CI scripts with
+no `src/` runtime change) that copy is pure boilerplate ("None — internal"), which is
+disproportionate ceremony (the codex-#25 friction; the #758 telegraph test-flake fix
+had to hand-write two "None — internal" sections).
+
+This adds an **internal-only lane** (operator-approved). A fragment opts in with an
+`<!-- internal-only -->` marker and may OMIT the two user-facing sections. The
+assembler auto-fills them with a canonical "None — internal change…" ONLY when
+*every* contributing fragment is internal-only. The objective gate: the pre-push gate
+verifies the marker against the diff — an internal-only fragment whose change touches
+runtime `src/` is REJECTED. Side-effects review + decision-trace are unchanged — safety
+and auditability never get a lighter lane.
+
+This PR is the **mechanism** (assembler + pre-push verification + tests). The
+deployed-skill documentation (`skills/instar-dev/SKILL.md` + a PostUpdateMigrator
+migration to redeploy it) is a tracked follow-up.
+
+## Decision-point inventory
+
+1. **assembler auto-fill** (`assembleNextMd`): when `allInternal` (every fragment
+   marked) and a user-facing canonical section is missing from the merged map, inject
+   `INTERNAL_ONLY_FILL`. Never auto-fills when any fragment is non-internal.
+2. **pre-push verification** (`pre-push-gate.js` §3c): an internal-only fragment +
+   any `src/*.ts` change in the diff → error.
+
+## 1. Over-block (what still fails / is required)
+
+- A genuinely user-facing change that OMITS the user sections still fails: it is not
+  `allInternal` (it has no marker, or the gate rejects the marker on a `src/` diff), so
+  the assembler does NOT auto-fill, and `validateGuideContent` reports the missing
+  sections. (test: "does NOT auto-fill when any fragment is user-facing".)
+- `What Changed` + `Evidence` are still required; the Evidence-bar (fix-claim →
+  Evidence) is untouched.
+- All existing fragment validations (inline-code / camelCase / fenced-block leakage,
+  malformed fragment, bump tier) are unchanged — 25 pre-existing assembler tests +
+  the full pre-push suite stay green.
+
+## 2. Under-block (what it now allows)
+
+- An all-internal release may omit the two user-facing sections; the assembler fills
+  them. This is gated objectively: the marker is verified against the diff at pre-push,
+  so it cannot be set on a runtime `src/` change to hide user-facing impact. The agent
+  sets the marker; the diff verifies it. (test: source-presence of the §3c gate +
+  `hasInternalOnlyMarker`.)
+- Worst case of a wrong marker on a non-src change (e.g. a scripts change that DOES have
+  user impact): the publish notes say "None — internal" for that release. Bounded and
+  low-harm — scripts/docs/test changes have no agent-user runtime surface by
+  construction.
+
+## 3. Blast radius
+
+- `scripts/assemble-next-md.mjs` — pure function; new `hasInternalOnlyMarker` +
+  `INTERNAL_ONLY_FILL` exports + the auto-fill branch.
+- `scripts/pre-push-gate.js` — one new §3c check (reuses existing `srcChanges` /
+  `fragmentChanges`).
+- Tests only otherwise. NO `src/` change, no runtime/agent surface. The assembler is
+  shared by BOTH the pre-push gate and the publish gate (`check-upgrade-guide.js`), so
+  the auto-fill keeps both consistent — the change was deliberately placed in the shared
+  assembler so the two gates can never disagree.
+
+## 4. Reversibility
+
+Fully reversible: revert the two scripts + test edits. No state, no persisted format
+(the `<!-- internal-only -->` marker is just a fragment comment — a fragment without it
+behaves exactly as before). Verified: 45 tests green (assemble-next-md + pre-push-gate
+suites), `node --check` clean on the gate.


### PR DESCRIPTION
## What

Operator-approved (Justin, 2026-06-04). Adds a lighter **internal-only release-note lane** for changes with no user-facing surface — the codex-#25 / #758 friction (hand-writing two "None — internal" sections for a test-only fix).

A release-note fragment marks itself with `<!-- internal-only -->` and may OMIT the two user-facing sections (**What to Tell Your User**, **Summary of New Capabilities**). The shared assembler auto-fills them with `None — internal change (no user-facing surface).` — but **only when every fragment in the release is internal-only**, so a real user-facing change can never skip telling the user.

## Why it's safe (the objective gate)

The marker can't be misused: `scripts/pre-push-gate.js` (§3c) **rejects** an `<!-- internal-only -->` fragment whose diff touches a runtime `src/` file. The agent sets the marker; the diff verifies it. Side-effects review + decision-trace are **unchanged** — only user-facing release boilerplate is lifted, only for changes that provably have no user-facing surface.

The auto-fill lives in `scripts/assemble-next-md.mjs` — the assembler shared by BOTH the pre-push gate and the publish gate (`check-upgrade-guide.js`) — so the two can never disagree about a release note (this is the release-critical machinery, #42 class; placing the logic in the shared assembler is deliberate).

## Dogfood

This PR uses its own lane: it's scripts + tests only, so its release-note fragment carries `<!-- internal-only -->` and omits the user sections — and the pre-push gate (running this branch's new code) accepted it, proving the lane end-to-end through the real gate.

## Tests

45 tests across `tests/unit/assemble-next-md.test.ts` (auto-fill on all-internal; validator passes the auto-filled guide; **NO** auto-fill when any fragment is user-facing — real content wins; preserves a user section an internal fragment did write; marker detection) and `tests/unit/pre-push-gate.test.ts` (the objective §3c marker-vs-diff gate). `node --check` clean on the gate. Gate: Tier-1, at risk floor.

## Follow-up (assigned to Codey)

This is the **mechanism**. The instar-dev `SKILL.md` doc + a `PostUpdateMigrator` migration to deploy the doc to existing agents' `.claude/skills/instar-dev/SKILL.md` (which is untracked, so git doesn't deliver it) is a scoped follow-up — mirrors the #760 `migrateInstarDevBuildLocationRegrounding` pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
