### PR TITLE
fix(pre-push-gate): diff against the main merge-target, not the branch upstream

### DIFF
--- a/docs/specs/prepush-gate-diff-base-main-ref.eli16.md
+++ b/docs/specs/prepush-gate-diff-base-main-ref.eli16.md
@@ -1,0 +1,28 @@
+# ELI16 — The pre-push check now measures your PR against main, not your last push
+
+## In plain English
+
+Before you push, instar runs a gate that asks "what files does this change touch?" and enforces
+rules (e.g. "if you changed product code, you must include a release note"). To answer "what
+files," it compared your branch to *your branch's last pushed version*.
+
+## The problem
+
+When you update a pull request by MERGING the latest main into it (the safe way to resolve
+conflicts without force-pushing), that comparison suddenly includes ALL of main's changes too —
+hundreds of files that other people already shipped. The gate then yells "you changed 173 files
+with no release note!" — none of which are actually yours. The only escape was to set a skip flag,
+which is exactly the kind of safety-bypass habit you don't want.
+
+## The fix
+
+The gate now measures your change against **main** (the branch you're merging into) instead of your
+last push. That gives your PR's TRUE set of changes whether you pushed normally or merged main in.
+
+## Why it's safe
+
+This comparison can never *hide* a change of yours — by definition it includes everything on your
+branch since it split from main. At worst it could show a few extra files (if your branch is built
+on another branch), which only makes the gate stricter, never looser. And if a clone has no "main"
+to compare against, it falls back to the old behaviour. Proven: the gate's 16 unit tests pass and
+the script still parses.

--- a/scripts/pre-push-gate.js
+++ b/scripts/pre-push-gate.js
@@ -147,8 +147,23 @@ if (latestPublished) {
 
 try {
   const { execSync } = await import('node:child_process');
-  // Get files changed since the remote tracking branch
-  const remoteBranch = execSync('git rev-parse --abbrev-ref @{u} 2>/dev/null || echo origin/main', { encoding: 'utf-8' }).trim();
+  // Compute "what this PR changes" against its MERGE TARGET (main), not the
+  // branch's own upstream (@{u}). Using @{u} breaks when a PR is updated by
+  // MERGING main in (the no-force-push path): `@{u}...HEAD` then includes all of
+  // main's already-shipped changes, producing false "src changed without a
+  // release-note fragment" errors (which forced INSTAR_PRE_PUSH_SKIP=1 on merge-
+  // updated PRs). A three-dot diff against main is the PR's TRUE diff in both the
+  // normal-incremental and merge-from-main cases, and never UNDER-reports the
+  // PR's own changes (merge-base of main and HEAD is the branch point).
+  const pickRef = (cands) => {
+    for (const r of cands) {
+      try { execSync(`git rev-parse --verify --quiet ${r}`, { stdio: 'pipe', encoding: 'utf-8' }); return r; }
+      catch { /* ref not present in this clone */ }
+    }
+    return null;
+  };
+  const remoteBranch = pickRef(['JKHeadley/main', 'origin/main', 'upstream/main', 'main'])
+    || execSync('git rev-parse --abbrev-ref @{u} 2>/dev/null || echo origin/main', { encoding: 'utf-8' }).trim();
   const changedFiles = execSync(`git diff --name-only ${remoteBranch}...HEAD 2>/dev/null || git diff --name-only HEAD~1 2>/dev/null`, { encoding: 'utf-8' })
     .trim()
     .split('\n')

--- a/tests/unit/pre-push-gate.test.ts
+++ b/tests/unit/pre-push-gate.test.ts
@@ -86,6 +86,21 @@ describe('Pre-push gate script', () => {
     expect(content).toContain('Internal-only release fragment(s) accompany');
     expect(content).toContain('internalOnlyFragments.length > 0 && srcChanges.length > 0');
   });
+
+  it('diffs against the main merge-target ref, not @{u}, so merge-from-main updates are not false-flagged', () => {
+    // A PR updated by MERGING main in (the no-force-push path) must NOT see all of
+    // main's already-shipped files as its own changes — that produced false
+    // "src changed without a fragment" errors (forcing INSTAR_PRE_PUSH_SKIP=1).
+    // The gate now prefers the main merge-target ref over the branch's upstream,
+    // so the three-dot diff is the PR's true diff. Source-presence (like #23):
+    // the git-diff path is not executed in unit tests.
+    const content = fs.readFileSync(gatePath, 'utf-8');
+    expect(content).toContain('pickRef');
+    expect(content).toContain("'JKHeadley/main'");
+    expect(content).toContain('never UNDER-reports');
+    // still falls back to @{u} when no main ref resolves in the clone
+    expect(content).toContain('@{u}');
+  });
 });
 
 // ── Integration: malformed NEXT.md rejection ─────────────────────────

--- a/upgrades/next/prepush-gate-diff-base-main-ref.md
+++ b/upgrades/next/prepush-gate-diff-base-main-ref.md
@@ -1,0 +1,22 @@
+<!-- bump: patch -->
+<!-- internal-only -->
+
+## What Changed
+
+`scripts/pre-push-gate.js` computed its "what files did this PR change" diff against `@{u}` (the
+branch's own upstream). When a PR is updated by MERGING main in (the no-force-push path to resolve
+conflicts), `@{u}...HEAD` then includes all of main's already-shipped files, so the gate's
+src→fragment / src→tests / internal-only checks false-flag 173+ unrelated files and force
+`INSTAR_PRE_PUSH_SKIP=1` (hit on #663, and complicated #766's re-trigger). The gate now diffs
+against the PR's merge target (`JKHeadley/main`||`origin/main`||`upstream/main`||`main`), falling
+back to `@{u}` only when no main ref resolves. A three-dot diff against main is the PR's true diff
+in both the normal-incremental and merge-from-main cases and never under-reports the PR's changes.
+
+## Evidence
+
+- Reproduced on #663 (merge-from-main → 173 false `src/` files → forced SKIP=1).
+- Safe-by-construction: `main...HEAD` (merge-base = branch point) always contains all the PR's
+  commits, so it can never under-report; the only error direction is over-reporting (safe).
+- 16 `tests/unit/pre-push-gate.test.ts` pass (incl. a new source-presence test for the main-ref
+  base); `node --check scripts/pre-push-gate.js` clean. Self-uses the internal-only lane (scripts +
+  test only, no `src/`).

--- a/upgrades/side-effects/prepush-gate-diff-base-main-ref.md
+++ b/upgrades/side-effects/prepush-gate-diff-base-main-ref.md
@@ -1,0 +1,45 @@
+# Side-Effects Review — pre-push gate diffs against the main ref, not @{u}
+
+**Version / slug:** `prepush-gate-diff-base-main-ref`
+**Date:** `2026-06-04`
+**Author:** `echo`
+**Second-pass reviewer:** `not required (build-gate diff base; safe-by-construction)`
+
+## Summary
+
+`scripts/pre-push-gate.js` computed `changedFiles` via `git diff --name-only ${remoteBranch}...HEAD`
+where `remoteBranch = @{u}` (the branch's OWN upstream). That breaks when a PR is updated by
+MERGING main in (the no-force-push path used to resolve conflicts): `@{u}...HEAD` then includes
+ALL of main's already-shipped changes, so the gate's section-3/3b checks see 173+ unrelated `src/`
+files → false "src changed without a release-note fragment" errors, forcing `INSTAR_PRE_PUSH_SKIP=1`
+(hit live on #663). The fix computes the diff against the PR's MERGE TARGET — the first resolvable
+of `JKHeadley/main`/`origin/main`/`upstream/main`/`main` — falling back to the old `@{u}` behaviour
+only when no main ref resolves.
+
+## 1. Over-block (what it still flags)
+
+Unchanged for the normal incremental-push case: `main...HEAD` (three-dot, from the merge-base =
+the branch point) == the PR's commits == what `@{u}...HEAD` gave for a never-merged-main branch.
+The src→tests, src→fragment (#23), and internal-only (§3c) checks all still fire on the PR's real
+`src/` changes. The "chore: release" commit (upgrades/ + version, no `src/`) still doesn't trip
+section-3b, same as before.
+
+## 2. Under-block (what it now lets through)
+
+Nothing it shouldn't. A three-dot diff against main can NEVER under-report the PR's own changes
+(the merge-base of main and HEAD is the branch point, so all the PR's commits are in the diff). The
+only direction it can err is OVER-reporting (if a branch is based off another branch, not main) —
+the safe direction (extra false-positives, never a missed src-change-without-fragment). The fix
+specifically REMOVES the merge-from-main false-positive without weakening any check.
+
+## 3. Blast radius
+
+One file: `scripts/pre-push-gate.js` (the `changedFiles` computation feeding sections 3/3b/3c) +
+its unit test. No `src/`, no runtime, no agent surface. `pickRef` is a local helper; on any error
+it falls through to the prior `@{u}` logic, so a clone without a `main` remote behaves exactly as
+before.
+
+## 4. Reversibility
+
+Fully reversible: revert the one hunk. No state. Verified: `node --check` clean; 16 pre-push-gate
+unit tests pass.


### PR DESCRIPTION
## What

`scripts/pre-push-gate.js` computed "what files did this PR change" via `git diff ${remoteBranch}...HEAD` where `remoteBranch = @{u}` (the branch's OWN upstream). That breaks when a PR is updated by **merging main in** — the no-force-push path used to resolve conflicts: `@{u}...HEAD` then includes all of main's already-shipped files, so the gate's src→fragment / src→tests / internal-only checks false-flag **173+ unrelated files** → forces `INSTAR_PRE_PUSH_SKIP=1`.

**Hit live on #663** (merge-from-main → 173 false `src/` files), and it complicated #766's flake re-trigger (had to use an empty commit to avoid it).

## The fix

Diff against the PR's **merge target** instead — the first resolvable of `JKHeadley/main` / `origin/main` / `upstream/main` / `main` — falling back to `@{u}` only when no main ref resolves. A three-dot diff against main is the PR's TRUE diff in both the normal-incremental and merge-from-main cases.

## Why it's safe

`main...HEAD` (merge-base = the branch point) **always contains all the PR's commits**, so it can never under-report the PR's changes. The only error direction is over-reporting (if a branch is based on another branch) — which only makes the gate *stricter*, never looser. No check is weakened; the merge-from-main false-positive is simply removed. `pickRef` falls through to the prior `@{u}` behaviour on any error.

## Tests

16 `tests/unit/pre-push-gate.test.ts` pass (incl. a new source-presence test for the main-ref base, consistent with how the existing git-dependent checks #23/§3c are tested). `node --check` clean. Gate: Tier-1, at floor.

This PR **dogfoods the internal-only lane** (scripts + test only, no `src/` runtime — its fragment carries `<!-- internal-only -->`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
