### PR TITLE
feat(ci): require an ELI16 overview in every PR description (Justin's standard)

### DIFF
--- a/.github/workflows/eli16-pr-gate.yml
+++ b/.github/workflows/eli16-pr-gate.yml
@@ -1,0 +1,37 @@
+# eli16-pr-gate — every PR's DESCRIPTION must carry a plain-English ELI16 overview.
+#
+# Justin's standard (2026-06-05): "when I click on the [PR] link, that's what I'm
+# going to see and read and approve." The ELI16 *file* (docs/specs/<slug>.eli16.md)
+# stays as the durable companion (enforced at commit time by the instar-dev gate);
+# this gate enforces that the OVERVIEW is also in the PR body so it is front and
+# centre at review time, and that PR formats are finally consistent across the fleet.
+#
+# Re-runs on `edited` so a reviewer/author can fix the description and the check
+# clears without a new push. Exemptions (bot authors, the automated release-cut PR)
+# live in scripts/eli16-pr-description-check.mjs.
+
+name: eli16-pr-gate
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened, ready_for_review]
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  eli16:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+      - name: PR description must include an ELI16 overview
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_AUTHOR_TYPE: ${{ github.event.pull_request.user.type }}
+        run: node scripts/eli16-pr-description-check.mjs

--- a/docs/specs/eli16-pr-description-gate.eli16.md
+++ b/docs/specs/eli16-pr-description-gate.eli16.md
@@ -1,0 +1,29 @@
+# ELI16 — Every pull request must explain itself in plain English, in the description
+
+## In plain English
+
+When someone opens a pull request (a proposed code change) and sends you the link, the first thing
+you see and read is the PR's DESCRIPTION. That's what you actually approve. But our PRs have been
+written in all different styles, and some don't include a plain-English summary at all — so the
+reviewer has to read raw code diffs to figure out what's going on.
+
+## What's new
+
+This adds an automatic check that runs on every pull request. It reads the PR's description and
+looks for a short "ELI16" section — an explain-it-like-I'm-16 overview of the change. If the
+description doesn't have one (or only has a throwaway one line), the check fails and tells the author
+exactly what to add. The author edits the description, and the check re-runs and clears on its own —
+no new code push needed.
+
+We already required an ELI16 *file* alongside specs; this closes the gap by also requiring the
+overview in the PR description itself, where the reviewer actually reads it. The result: every PR
+now leads with a human-readable summary, in a consistent format across everyone.
+
+## Why it's safe
+
+The check only ever looks at the PR description text — it can't touch the code, the build, or the
+release. The automated release PRs and bot PRs are exempt (no human reads an ELI16 there). The
+decision logic is a small pure function with thorough tests on both the "has a good overview → pass"
+and "missing/too-short → fail" sides, plus all the exemptions — so it won't accidentally block a PR
+that genuinely has its overview. And a failing check is loud and self-clears the moment the
+description is fixed, so it can never silently jam anything.

--- a/scripts/eli16-pr-description-check.mjs
+++ b/scripts/eli16-pr-description-check.mjs
@@ -1,0 +1,77 @@
+#!/usr/bin/env node
+/**
+ * ELI16-on-every-PR gate (team standard, 2026-06-05).
+ *
+ * Every PR's DESCRIPTION must carry a plain-English ELI16 overview — because the
+ * PR description is what a reviewer reads and approves when they open the link.
+ * The ELI16 *file* (docs/specs/<slug>.eli16.md) remains the durable companion;
+ * this gate enforces that the OVERVIEW is also in the PR BODY so it is front and
+ * centre at review time. (Justin, 2026-06-05: "when I click on the link, that's
+ * what I'm going to see and read and approve.")
+ *
+ * Pure check — `checkPrDescriptionEli16({ body, title, authorType })` — plus a
+ * CLI wrapper that reads PR_BODY / PR_TITLE / PR_AUTHOR_TYPE from env (set by the
+ * workflow) and exits 0 when an ELI16 overview is present (or the PR is exempt),
+ * 1 with actionable guidance when it is missing.
+ */
+
+/** Minimum plain-English content under the ELI16 heading — a real overview, not a one-liner. */
+export const MIN_ELI16_DESCRIPTION_CHARS = 200;
+
+/** A markdown heading (any level) whose text contains "ELI16" / "ELI-16" / "ELI 16". */
+const ELI16_HEADING = /^[ \t]*#{1,6}[ \t]+.*ELI[ \t-]?16/im;
+
+/**
+ * @param {{ body?: string|null, title?: string|null, authorType?: string|null }} pr
+ * @returns {{ ok: boolean, exempt?: string, reason?: string, chars?: number, min?: number }}
+ */
+export function checkPrDescriptionEli16(pr) {
+  const title = String(pr?.title ?? '');
+  // Exempt the genuinely-automated PRs: bot authors + the release-cut commit.
+  if (String(pr?.authorType ?? '') === 'Bot') return { ok: true, exempt: 'bot-author' };
+  if (/^chore:\s*release\b/i.test(title)) return { ok: true, exempt: 'release-cut' };
+
+  const body = String(pr?.body ?? '');
+  const m = ELI16_HEADING.exec(body);
+  if (!m) return { ok: false, reason: 'no-eli16-heading' };
+
+  // Content under the ELI16 heading, up to the next heading.
+  const after = body.slice(m.index + m[0].length);
+  const section = after.split(/\n[ \t]*#{1,6}[ \t]/)[0];
+  const content = section.replace(/<!--[\s\S]*?-->/g, '').trim();
+  if (content.length < MIN_ELI16_DESCRIPTION_CHARS) {
+    return { ok: false, reason: 'eli16-too-short', chars: content.length, min: MIN_ELI16_DESCRIPTION_CHARS };
+  }
+  return { ok: true };
+}
+
+// ── CLI (used by .github/workflows/eli16-pr-gate.yml) ─────────────────
+const invokedDirectly =
+  process.argv[1] && import.meta.url === new URL(`file://${process.argv[1]}`).href;
+if (invokedDirectly) {
+  const res = checkPrDescriptionEli16({
+    body: process.env.PR_BODY,
+    title: process.env.PR_TITLE,
+    authorType: process.env.PR_AUTHOR_TYPE,
+  });
+  if (res.ok) {
+    console.log(
+      res.exempt
+        ? `ELI16 gate: exempt (${res.exempt}).`
+        : 'ELI16 gate: OK — the PR description includes an ELI16 overview.',
+    );
+    process.exit(0);
+  }
+  const detail =
+    res.reason === 'eli16-too-short'
+      ? ` (found an ELI16 heading but only ${res.chars} chars of content; need >= ${res.min}).`
+      : '.';
+  console.error(
+    `ELI16 gate FAILED: this PR's description has no plain-English ELI16 overview${detail}\n\n` +
+      `Team standard (2026-06-05): every PR description must include an "## ELI16 — <one line>" section ` +
+      `that explains the change for a non-expert — because the PR description is what the reviewer reads ` +
+      `and approves when they open the link. Add it to the PR body (copy from your ` +
+      `docs/specs/<slug>.eli16.md companion). Edit the PR description and this check will re-run.`,
+  );
+  process.exit(1);
+}

--- a/tests/unit/eli16-pr-description-check.test.ts
+++ b/tests/unit/eli16-pr-description-check.test.ts
@@ -1,0 +1,76 @@
+/**
+ * Unit tests — ELI16-on-every-PR gate (the pure check).
+ *
+ * The CI gate fails any PR whose DESCRIPTION lacks a plain-English ELI16 overview
+ * (Justin's standard: the description is the review surface). Because the gate
+ * blocks EVERY PR, the check must be exhaustively correct on both sides + honour
+ * its exemptions — a false-fail would block the whole fleet's PRs.
+ */
+
+import { describe, it, expect } from 'vitest';
+// @ts-expect-error — .mjs, no type declarations; runtime import is fine under vitest
+import { checkPrDescriptionEli16, MIN_ELI16_DESCRIPTION_CHARS } from '../../scripts/eli16-pr-description-check.mjs';
+
+const longOverview =
+  'In plain English: this change makes the widget read its config from the project ' +
+  'directory instead of a temp folder, so agents that run in a sandbox can actually ' +
+  'find it. Nothing about how you talk to your agent changes; it just stops a silent ' +
+  'failure that only showed up for sandboxed runtimes.';
+
+describe('checkPrDescriptionEli16', () => {
+  it('PASSES when the body has an ## ELI16 heading with enough content', () => {
+    const body = `## What\n\nSome change.\n\n## ELI16 — what this means\n\n${longOverview}\n\n## Tests\n\nAll pass.`;
+    expect(checkPrDescriptionEli16({ body, title: 'fix(x): something', authorType: 'User' })).toEqual({ ok: true });
+  });
+
+  it('accepts ELI16 / ELI-16 / ELI 16 spellings, any heading level', () => {
+    for (const h of ['## ELI16', '### ELI-16 overview', '# ELI 16 — plain english', '#### eli16']) {
+      const body = `${h}\n\n${longOverview}`;
+      expect(checkPrDescriptionEli16({ body, title: 't', authorType: 'User' }).ok).toBe(true);
+    }
+  });
+
+  it('FAILS when the body has no ELI16 heading at all', () => {
+    const body = `## What\n\nA change with a perfectly good description but no ELI16 section.\n\n## Tests\n\nPass.`;
+    const r = checkPrDescriptionEli16({ body, title: 'feat(x): y', authorType: 'User' });
+    expect(r.ok).toBe(false);
+    expect(r.reason).toBe('no-eli16-heading');
+  });
+
+  it('FAILS when the ELI16 section is present but too short (a one-liner)', () => {
+    const body = `## ELI16\n\nIt fixes a bug.\n\n## Tests\n\nPass.`;
+    const r = checkPrDescriptionEli16({ body, title: 'fix: z', authorType: 'User' });
+    expect(r.ok).toBe(false);
+    expect(r.reason).toBe('eli16-too-short');
+    expect(r.min).toBe(MIN_ELI16_DESCRIPTION_CHARS);
+  });
+
+  it('measures content only up to the NEXT heading (does not borrow other sections)', () => {
+    // ELI16 section itself is short; the long content belongs to the next section.
+    const body = `## ELI16\n\nShort.\n\n## What Changed\n\n${longOverview}`;
+    expect(checkPrDescriptionEli16({ body, title: 't', authorType: 'User' }).ok).toBe(false);
+  });
+
+  it('ignores HTML comments when measuring the ELI16 content', () => {
+    const body = `## ELI16\n\n<!-- ${'x'.repeat(500)} -->\n\nShort.`;
+    expect(checkPrDescriptionEli16({ body, title: 't', authorType: 'User' }).ok).toBe(false);
+  });
+
+  it('EXEMPTS bot-authored PRs', () => {
+    expect(checkPrDescriptionEli16({ body: '', title: 'Bump deps', authorType: 'Bot' })).toEqual({ ok: true, exempt: 'bot-author' });
+  });
+
+  it('EXEMPTS the automated release-cut PR', () => {
+    expect(checkPrDescriptionEli16({ body: '', title: 'chore: release v1.3.300 [skip ci]', authorType: 'User' })).toEqual({ ok: true, exempt: 'release-cut' });
+  });
+
+  it('does NOT exempt a normal fix/feat PR just because the title mentions release', () => {
+    const r = checkPrDescriptionEli16({ body: '## What\n\nx', title: 'feat: prep the release pipeline', authorType: 'User' });
+    expect(r.ok).toBe(false);
+  });
+
+  it('handles null/empty body and title without throwing', () => {
+    expect(checkPrDescriptionEli16({ body: null, title: null, authorType: null }).ok).toBe(false);
+    expect(checkPrDescriptionEli16({}).ok).toBe(false);
+  });
+});

--- a/upgrades/next/eli16-pr-description-gate.md
+++ b/upgrades/next/eli16-pr-description-gate.md
@@ -1,0 +1,22 @@
+<!-- bump: patch -->
+<!-- internal-only -->
+
+## What Changed
+
+Added a CI gate (`.github/workflows/eli16-pr-gate.yml` + the pure check
+`scripts/eli16-pr-description-check.mjs`) that requires every PR's DESCRIPTION to carry a
+plain-English ELI16 overview, and FAILS the PR when it is missing. Per Justin's standard
+(2026-06-05): the PR description is what a reviewer reads and approves on the link, and the PRs "had
+different formats." The ELI16 *file* (docs/specs/<slug>.eli16.md) is unchanged and still enforced at
+commit time; this closes the PR-body half. Re-runs on `edited` (self-clears on a description fix);
+exempts bot authors + the automated release-cut PR.
+
+## Evidence
+
+- The decision is a PURE function (`checkPrDescriptionEli16`) with 10 unit tests covering both
+  sides (has-overview → pass; missing / too-short / next-heading-boundary / comment-stripped → fail)
+  and every exemption (bot, release-cut, title-mentions-release non-exemption, null inputs).
+- `node --check scripts/eli16-pr-description-check.mjs` clean. New additive workflow — cannot affect
+  existing checks/builds/releases; a failing PR is visible + self-clears on a description edit.
+- This PR's own description carries an ELI16 overview (dogfoods the gate). scripts + workflow + test
+  only, no `src/` (internal-only lane).

--- a/upgrades/side-effects/eli16-pr-description-gate.md
+++ b/upgrades/side-effects/eli16-pr-description-gate.md
@@ -1,0 +1,48 @@
+# Side-Effects Review — ELI16-on-every-PR gate (PR description)
+
+**Version / slug:** `eli16-pr-description-gate`
+**Date:** `2026-06-05`
+**Author:** `echo`
+**Second-pass reviewer:** `required (a new gate that blocks EVERY PR)`
+
+## Summary
+
+Justin's standard (2026-06-05): every PR's DESCRIPTION must carry a plain-English ELI16 overview,
+because the description is what a reviewer reads and approves when they open the PR link — and the
+current PRs "have different formats." This adds a CI gate (`.github/workflows/eli16-pr-gate.yml`)
+that runs a pure check (`scripts/eli16-pr-description-check.mjs`) on every PR body and FAILS the PR
+when no ELI16 overview is present. The ELI16 *file* (`docs/specs/<slug>.eli16.md`) is unchanged and
+still enforced at commit time by the instar-dev gate; this is the missing PR-body half.
+
+## Decision-point inventory
+
+One decision: does the PR body contain an ELI16 overview? PASS when (a) the author is a Bot, or
+(b) the title is a `chore: release` cut, or (c) the body has a heading whose text contains
+`ELI16`/`ELI-16`/`ELI 16` followed by >= 200 chars of (comment-stripped) content. Otherwise FAIL.
+
+## 1. Over-block (what it blocks)
+
+A human/agent PR whose description lacks a real ELI16 overview is blocked — that's the point. The
+check re-runs on `edited`, so adding the overview to the description clears it WITHOUT a new push.
+The failure message is actionable (tells you exactly what to add + that the file is a good source).
+
+## 2. Under-block (what it lets through)
+
+Bot PRs and the automated `chore: release` PR (which has no human reviewer reading an ELI16). A PR
+that has a real ELI16 heading + >= 200 chars passes. The check measures content only up to the next
+heading, so a one-line ELI16 followed by a long "What Changed" does NOT slip through (tested).
+
+## 3. Blast radius — CRITICAL
+
+This gate blocks EVERY non-exempt PR, so a false-fail would block the whole fleet's PRs. Mitigations:
+the decision is a PURE function with 10 unit tests covering both sides AND every exemption (bot,
+release-cut, the "title mentions release" non-exemption, null/empty inputs, the next-heading
+boundary, comment-stripping). The gate is a NEW, additive workflow — it cannot affect existing
+checks, builds, or releases; a failing PR is VISIBLE and self-clears on a description edit (not a
+silent jam like the manifest/publish class). No `src/` runtime change.
+
+## 4. Reversibility
+
+Fully reversible: delete the workflow + script + test. No state, no migration. Verified: the check
+script parses (`node --check`); 10/10 unit tests pass. This PR's own description carries an ELI16
+overview (dogfoods the gate).


### PR DESCRIPTION
## ELI16 — every PR must explain itself in plain English, in the description

When someone opens a pull request and sends you the link, the first thing you see and read is the PR's DESCRIPTION — and that's what you approve. But our PRs have been written in all different styles, and some don't include a plain-English summary at all, so the reviewer has to read raw code diffs to figure out what's going on. This adds an automatic check that runs on every PR, reads the description, and looks for a short "ELI16" overview. If it's missing (or just a throwaway one-liner), the check fails and tells the author exactly what to add. The author edits the description and the check re-runs and clears on its own — no new push needed. It only ever looks at the description text (never the code/build/release), and the automated release + bot PRs are exempt.

## What

Justin's standard (2026-06-05): "when I click on the [PR] link, that's what I'm going to see and read and approve." Adds a CI gate — `.github/workflows/eli16-pr-gate.yml` + the pure check `scripts/eli16-pr-description-check.mjs` — that FAILS any PR whose description lacks an ELI16 overview. The ELI16 *file* (`docs/specs/<slug>.eli16.md`) is unchanged and still enforced at commit time; this closes the PR-body half.

## How it's safe

The decision is a pure function with **10 unit tests** covering both sides (has-overview → pass; missing / too-short / next-heading-boundary / comment-stripped → fail) and every exemption (bot author, `chore: release` cut, the "title merely mentions release" non-exemption, null inputs). A new gate that blocks every PR is risk #1, so a false-fail can't slip through. It's an additive workflow — it can't affect existing checks/builds/releases — and a failing PR is **visible and self-clears** on a description edit (`pull_request: edited`), never a silent jam.

## Dogfood

This PR's own description carries the ELI16 section above — so it must pass its own gate.

## Follow-up

A brief note in the instar-dev SKILL.md (so agents lead their PR descriptions with the ELI16) + its deploy migration — I'll scope that to Codey (mirrors the #766 migration pattern).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
