### PR TITLE
Fix Telegram reply robust content mode

### DIFF
--- a/.instar/instar-dev-traces/2026-06-05T01-44-09-146Z-telegram-reply-robust-content-57320946.json
+++ b/.instar/instar-dev-traces/2026-06-05T01-44-09-146Z-telegram-reply-robust-content-57320946.json
@@ -1,0 +1,24 @@
+{
+  "version": 2,
+  "sessionId": "45610377-b671-4264-a9fd-192d16f767c6",
+  "timestamp": "2026-06-05T01:44:09.146Z",
+  "artifactPath": "upgrades/side-effects/telegram-reply-robust-content.md",
+  "artifactSha256": "dd1f6cb2ebea8cc878622a6fd0e946d7cfbcfb619af4280f15abdcb53bb37e03",
+  "coveredFiles": [
+    "src/core/IdentityRenderer.ts",
+    "src/core/PostUpdateMigrator.ts",
+    "src/scaffold/templates.ts",
+    "src/templates/scripts/telegram-reply.sh",
+    "tests/unit/telegram-reply-port-resolution.test.ts",
+    "upgrades/next/telegram-reply-robust-content.md",
+    "upgrades/side-effects/telegram-reply-robust-content.md",
+    "upgrades/telegram-reply-robust-content.eli16.md"
+  ],
+  "phase": "complete",
+  "tier": 1,
+  "tierReasoning": "Additive relay-script input mode plus generated guidance and SHA migration; no new server route, config contract, or persistence schema.",
+  "eli16Path": "upgrades/telegram-reply-robust-content.eli16.md",
+  "sideEffectsPath": "upgrades/side-effects/telegram-reply-robust-content.md",
+  "secondPass": "not-required",
+  "reviewerConcurred": null
+}

--- a/src/core/IdentityRenderer.ts
+++ b/src/core/IdentityRenderer.ts
@@ -182,6 +182,7 @@ function buildPersistentRelayAppendix(framework: string): string {
     '```',
     ``,
     `(Replace \`N\` with the topic id from the prefix. If \`.instar/scripts/telegram-reply.sh\` is missing on an older install, fall back to \`.claude/scripts/telegram-reply.sh\`.)`,
+    `If the response itself contains a literal \`EOF\` line or shell-sensitive content that could break the heredoc wrapper, base64-encode the response text and pipe that encoded text to \`telegram-reply.sh --stdin-base64 N\` instead.`,
     ``,
     `Rules:`,
     `- Strip the \`[telegram:N]\` prefix before interpreting the message.`,

--- a/src/core/PostUpdateMigrator.ts
+++ b/src/core/PostUpdateMigrator.ts
@@ -7788,6 +7788,10 @@ process.stdin.on('end', async () => {
     // verifier and lint both treat any deployed SHA matching this set as
     // a known-shipped instar version, not user-modified content.
     '371d7e8f4f72146bf8bd07115873bdbbaaf32e851ac6e1318ba5b8929cd06e68',
+    // Secret-externalization survivability version (env-first auth,
+    // recoverable queue, neutral relay mirror; no --stdin-base64 mode).
+    // Shipped through v1.3.266.
+    '0f6d27a522b123551871e6081774f8c89d1ad0ce248597af7dd60d8522871069',
   ]);
 
   /**
@@ -7843,7 +7847,7 @@ process.stdin.on('end', async () => {
         fs.writeFileSync(backupPath, existing, { mode: 0o644 });
         fs.writeFileSync(opts.scriptPath, opts.newContent, { mode: 0o755 });
         opts.result.upgraded.push(
-          `${opts.label} (upgraded to port-from-config + agent-id binding; ` +
+          `${opts.label} (upgraded to port-from-config + agent-id binding + robust base64 stdin; ` +
           `prior version backed up to ${path.relative(opts.stateDir, backupPath)})`
         );
       } catch (err) {

--- a/src/scaffold/templates.ts
+++ b/src/scaffold/templates.ts
@@ -1344,6 +1344,8 @@ Your response text here
 EOF
 \`\`\`
 
+If the response itself contains a literal \`EOF\` line or shell-sensitive content that could break the heredoc wrapper, base64-encode the response text and pipe that encoded text to \`.claude/scripts/telegram-reply.sh --stdin-base64 N\` instead.
+
 Strip the \`[telegram:N]\` prefix before interpreting the message. Only relay conversational text — not tool output.
 
 ### Session Continuity (CRITICAL)
@@ -1646,6 +1648,8 @@ cat <<'EOF' | .claude/scripts/telegram-reply.sh N
 Your response text here
 EOF
 \`\`\`
+
+If the response itself contains a literal \`EOF\` line or shell-sensitive content that could break the heredoc wrapper, base64-encode the response text and pipe that encoded text to \`.claude/scripts/telegram-reply.sh --stdin-base64 N\` instead.
 
 Strip the \`[telegram:N]\` prefix before interpreting the message. Only relay conversational text — not tool output.
 `;

--- a/src/templates/scripts/telegram-reply.sh
+++ b/src/templates/scripts/telegram-reply.sh
@@ -8,12 +8,16 @@
 #   cat <<'EOF' | ./telegram-reply.sh TOPIC_ID
 #   Multi-line message here
 #   EOF
+#   printf '%s' '<base64 text>' | ./telegram-reply.sh --stdin-base64 TOPIC_ID
 #
 # Flags:
 #   --format <mode>   Override server-side format mode for this send.
 #                     Valid: plain, code, markdown, legacy-passthrough
 #                     ('html' is reserved for trusted internal callers.)
 #                     When absent, the server's configured default applies.
+#   --stdin-base64    Decode stdin/argument text from base64 before sending.
+#                     Use this for content that may contain shell syntax or
+#                     heredoc delimiters such as a literal EOF line.
 #
 # Port resolution (in order):
 #   1. INSTAR_PORT environment variable (explicit operator override).
@@ -28,6 +32,7 @@
 #   comparison — a token sent to the wrong server is structurally inert.
 
 FORMAT=""
+STDIN_BASE64=0
 
 # Parse leading flags before positional args.
 while [ $# -gt 0 ]; do
@@ -38,6 +43,10 @@ while [ $# -gt 0 ]; do
       ;;
     --format=*)
       FORMAT="${1#--format=}"
+      shift
+      ;;
+    --stdin-base64|--base64-stdin)
+      STDIN_BASE64=1
       shift
       ;;
     --)
@@ -72,6 +81,19 @@ fi
 if [ -z "$MSG" ]; then
   echo "No message provided" >&2
   exit 1
+fi
+
+if [ "$STDIN_BASE64" = "1" ]; then
+  DECODED_MSG=$(printf '%s' "$MSG" | python3 -c '
+import base64, sys
+raw = "".join(sys.stdin.read().split())
+sys.stdout.write(base64.b64decode(raw, validate=True).decode("utf-8"))
+' 2>/dev/null)
+  if [ $? -ne 0 ]; then
+    echo "Invalid base64 message provided to --stdin-base64" >&2
+    exit 1
+  fi
+  MSG="$DECODED_MSG"
 fi
 
 # Resolve config-derived values from .instar/config.json (single python3

--- a/tests/unit/telegram-reply-port-resolution.test.ts
+++ b/tests/unit/telegram-reply-port-resolution.test.ts
@@ -77,6 +77,8 @@ interface RunOpts {
   configPort?: number;
   authToken?: string;
   agentId?: string;
+  args?: string[];
+  stdin?: string;
   /** When true, do NOT write a config.json. */
   noConfig?: boolean;
 }
@@ -102,7 +104,7 @@ async function runScript(opts: RunOpts): Promise<RunResult> {
   const env: NodeJS.ProcessEnv = { PATH: process.env.PATH };
   if (opts.envPort !== undefined) env.INSTAR_PORT = opts.envPort;
   return await new Promise<RunResult>((resolve, reject) => {
-    const proc = spawn('bash', [SCRIPT_PATH, '42'], {
+    const proc = spawn('bash', [SCRIPT_PATH, ...(opts.args ?? ['42'])], {
       cwd: tmpCwd,
       env,
     });
@@ -123,7 +125,7 @@ async function runScript(opts: RunOpts): Promise<RunResult> {
       clearTimeout(kill);
       resolve({ status, stdout, stderr, cwd: tmpCwd });
     });
-    proc.stdin.write('hello\n');
+    proc.stdin.write(opts.stdin ?? 'hello\n');
     proc.stdin.end();
   }).finally(() => {
     SafeFsExecutor.safeRmSync(tmpCwd, {
@@ -208,5 +210,24 @@ describe('telegram-reply.sh — port resolution', () => {
     expect(result.status).toBe(0);
     const req = mockA.lastRequest()!;
     expect(req.agentIdHeader).toBeUndefined();
+  });
+
+  it('decodes --stdin-base64 so shell-sensitive and heredoc-delimiter text is sent literally', async () => {
+    mockA.reset();
+    const message = [
+      'literal shell syntax: $(date) `whoami` "$TOKEN"',
+      'EOF',
+      'JSON-ish braces: {"ok": true}',
+    ].join('\n');
+    const result = await runScript({
+      configPort: mockA.port,
+      authToken: 'tok',
+      agentId: 'echo',
+      args: ['--stdin-base64', '42'],
+      stdin: Buffer.from(message, 'utf-8').toString('base64'),
+    });
+    expect(result.status).toBe(0);
+    const req = mockA.lastRequest()!;
+    expect(JSON.parse(req.body).text).toBe(message);
   });
 });

--- a/upgrades/next/telegram-reply-robust-content.md
+++ b/upgrades/next/telegram-reply-robust-content.md
@@ -1,0 +1,22 @@
+<!-- bump: patch -->
+
+## What Changed
+
+`telegram-reply.sh` now supports `--stdin-base64`, an additive mode for sending replies whose text may contain shell metacharacters or a literal heredoc delimiter line. The script decodes the base64 payload before using the existing JSON request path, so ordinary replies and server behavior are unchanged.
+
+Existing unmodified relay scripts are upgraded through the SHA-based migrator. Customized relay scripts are preserved and receive a `.new` candidate as before.
+
+## What to Tell Your User
+
+Telegram replies are more robust when an agent needs to send text that looks like shell syntax or contains a heredoc-closing line. Normal replies work the same way; the safer mode is only used when needed.
+
+## Summary of New Capabilities
+
+- `telegram-reply.sh --stdin-base64 TOPIC_ID` decodes base64 input and sends the original text.
+- Generated agent instructions mention the safer fallback for delimiter-sensitive content.
+- Post-update migration upgrades the v1.3.266 shipped relay script to the new version without overwriting local customizations.
+
+## Evidence
+
+- Focused unit run passed: `telegram-reply-port-resolution`, `PostUpdateMigrator-telegramReply`, `migration-relay-script-hash`, `IdentityRenderer`, and `telegramRelayPrompt`.
+- The new relay test sends shell-looking content plus a literal `EOF` line through `--stdin-base64` and asserts the server receives the exact original text.

--- a/upgrades/side-effects/telegram-reply-robust-content.md
+++ b/upgrades/side-effects/telegram-reply-robust-content.md
@@ -1,0 +1,31 @@
+# Side-effects review — telegram reply robust content mode
+
+## What changed
+
+`telegram-reply.sh` now accepts `--stdin-base64` / `--base64-stdin`. In that mode, the script decodes the provided base64 payload before building the existing JSON request body. This gives agents a transport-safe path when the reply text itself contains shell metacharacters, quotes, JSON-looking text, or a literal heredoc delimiter line.
+
+The normal heredoc path remains unchanged. The new mode is additive and only activates when the flag is present.
+
+## Why
+
+The standard relay instruction uses a single-quoted heredoc. That protects most shell-sensitive text, but it still fails when the response body contains a line that exactly matches the heredoc delimiter. During Gemini mentoring, Gemi hit this class directly: its heredoc relay attempt ended in a shell syntax error, then it recovered by squeezing the response into a quoted argument. That workaround is fragile for long or structured replies.
+
+Base64 stdin moves the fragile bytes out of shell syntax entirely. The shell only carries base64 characters; the canonical reply script restores the original text before sending.
+
+## Migration footprint
+
+Existing unmodified `telegram-reply.sh` copies are SHA-migrated by `PostUpdateMigrator`. This PR registers the v1.3.266 template SHA as a prior shipped version so deployed agents receive the new script on update. Locally modified scripts are still preserved: the migrator writes a `.new` candidate and reports the existing relay-script-modified-locally degradation instead of overwriting custom content.
+
+Generated identity/scaffold guidance now keeps the familiar heredoc example and adds the base64 fallback for delimiter-sensitive content.
+
+## Risk
+
+Low. The default send path, HTTP route, auth headers, port resolution, tone-gate handling, 408 ambiguous handling, recoverable relay queue, and JSON body shape are unchanged. The new branch only decodes input before the existing JSON builder.
+
+The main operational risk is invalid base64 input; the script exits before contacting the server and prints a clear error.
+
+## Tests
+
+- Unit: `tests/unit/telegram-reply-port-resolution.test.ts` now proves `--stdin-base64` sends shell-sensitive text and a literal `EOF` line as exact message text.
+- Unit: existing `PostUpdateMigrator-telegramReply`, `migration-relay-script-hash`, `IdentityRenderer`, and `telegramRelayPrompt` tests cover migration and generated guidance.
+- Focused run: 58 tests passed across those five files.

--- a/upgrades/telegram-reply-robust-content.eli16.md
+++ b/upgrades/telegram-reply-robust-content.eli16.md
@@ -1,0 +1,11 @@
+# ELI16 — Telegram Reply Robust Content Mode
+
+Agents usually send Telegram replies by pasting the reply into a shell heredoc. That is fine for normal text, but it can break if the reply itself contains the heredoc closing word on its own line.
+
+This change adds a safer backup path. The reply script can now accept base64 text, decode it, and send the original message. That means the shell only sees safe base64 characters, while Telegram receives the real reply text.
+
+Nothing changes for ordinary replies. The normal heredoc command still works, the server route is the same, and the script still builds the same JSON body after it has the final text. The new flag only changes how the text gets into the script.
+
+Existing agents with the standard reply script are upgraded automatically. The migrator recognizes the last shipped script by its hash, backs it up, and installs the new version. If an operator edited the script locally, Instar does not overwrite it. Instead it writes the new version next to it as a review candidate, preserving the local customization.
+
+This matters for agents because reply failures are easy to miss: the user sees silence, while the agent may only see a shell error in its pane. The safer path gives agents a reliable escape hatch for long reports, code examples, JSON snippets, or any text that accidentally contains the heredoc closing line.


### PR DESCRIPTION
## ELI16

Agents usually send Telegram replies by piping text through a shell heredoc. That protects most normal messages, but it can still break when the reply itself contains the heredoc closing word on its own line. In practice, that means a valid response can fail before it ever reaches Instar or Telegram; the user sees silence while the agent only sees a shell error in its pane.

This PR adds a safer backup path. `telegram-reply.sh` now accepts base64 input with `--stdin-base64`, decodes it inside the script, and then sends the exact original text through the existing JSON request path. Normal replies still work the same way. The new mode is only for content that might confuse shell parsing, such as code blocks, JSON snippets, shell-looking text, or a literal heredoc delimiter line.

Existing unmodified relay scripts are upgraded automatically through the SHA-based migrator. Customized relay scripts are preserved and receive a `.new` candidate, so local operator edits are not overwritten.

## What Changed

- Added `--stdin-base64` / `--base64-stdin` to `src/templates/scripts/telegram-reply.sh`.
- Updated generated Telegram relay guidance to mention the base64 fallback for delimiter-sensitive content.
- Registered the v1.3.261 relay script SHA as a prior shipped version so deployed agents migrate cleanly.
- Added focused unit coverage proving shell-sensitive text plus a literal `EOF` line arrives at the server unchanged.
- Added release-note, side-effects, ELI16, and instar-dev trace artifacts.

## Verification

- Focused unit run: `telegram-reply-port-resolution`, `PostUpdateMigrator-telegramReply`, `migration-relay-script-hash`, `IdentityRenderer`, `telegramRelayPrompt` — 58 tests passed.
- `npm run lint` passed.
- `npm run build` passed.
- `npm run check:pre-push-gate` passed with only the non-blocking version warning.
- Commit hook ran lint plus instar-dev precommit; passed. It recorded a Tier-2 risk-floor warning from `PostUpdateMigrator`, but accepted the declared Tier-1 path.
- Push pre-push path passed on retry, including 17 threadline e2e files / 332 tests. The first attempt hit a local RelayE2E sqlite setup flake; rerunning that file alone passed, then the full scoped e2e push gate passed.
