### PR TITLE
feat(feedback-factory): Phase-4 migration integrity tooling + never-re-derive guard

### DIFF
--- a/src/feedback-factory/migration/immutableGuard.ts
+++ b/src/feedback-factory/migration/immutableGuard.ts
@@ -1,0 +1,196 @@
+/**
+ * immutableGuard.ts — the structural "never re-derive curated state" guard (spec §2.4).
+ *
+ * Curated cluster state — pre-cutover lifecycle status + the human/LLM governance
+ * judgment that lives in the notes fields — is IRREPLACEABLE. The migration imports it
+ * AS-IS and the processor must never overwrite it. "Structure > Willpower": rather than
+ * trust the processor to only ever run over new, post-cutover traffic, we wrap the store
+ * so a mutation of an immutable cluster is PHYSICALLY refused (and recorded), not merely
+ * discouraged by a comment. A wrong-date backfill therefore cannot overwrite curated
+ * lifecycle/governance state — the write simply does not happen.
+ *
+ * A cluster is immutable when EITHER:
+ *   - it carries non-null governance notes (a human/LLM triage decision lives on it), OR
+ *   - it predates the cutover (createdAt < cutoverTimestamp) — migrated curated history.
+ *
+ * The guard is a decorator over any FeedbackStore: reads and non-curated writes pass
+ * through untouched; the three methods that can mutate an existing cluster
+ * (mergeIntoCluster, applyReopen, upsertClusterFromItem-when-it-exists) are gated.
+ */
+
+import type { Cluster, FeedbackItem } from '../processor/types.js';
+import type { ReopenDecision } from '../processor/reopen.js';
+import type { DispatchRecord } from '../dispatch/dispatch.js';
+import type { FeedbackStore, FeedbackMetrics } from '../store/FeedbackStore.js';
+
+/** Fields that, when non-empty, mark a cluster as carrying curated governance judgment. */
+export const GOVERNANCE_FIELDS = [
+  'governanceNotes',
+  'processingNotes',
+  'actionTaken',
+  'researchNotes',
+] as const;
+
+/** True when the cluster carries any non-empty curated governance note. */
+export function hasGovernanceNotes(cluster: Cluster): boolean {
+  for (const f of GOVERNANCE_FIELDS) {
+    const v = (cluster as Record<string, unknown>)[f];
+    if (typeof v === 'string' && v.trim().length > 0) return true;
+  }
+  return false;
+}
+
+/**
+ * The structural invariant: is this cluster curated state the processor must not touch?
+ *
+ * - Governance notes present → immutable regardless of date (a triage decision lives here).
+ * - createdAt < cutoverTimestamp → migrated curated history, immutable.
+ * - createdAt present but unparseable → fail SAFE (immutable): a cluster that HAS a
+ *   timestamp we cannot read is suspicious; never risk overwriting curated state.
+ * - No createdAt and no governance notes → a fresh/post-cutover cluster → mutable
+ *   (curated rows always carry a timestamp or notes, so this is new processor state).
+ */
+export function isClusterImmutable(cluster: Cluster, cutoverTimestamp: string): boolean {
+  if (hasGovernanceNotes(cluster)) return true;
+
+  const createdAt = cluster.createdAt;
+  if (typeof createdAt === 'string' && createdAt.length > 0) {
+    const created = Date.parse(createdAt);
+    const cutover = Date.parse(cutoverTimestamp);
+    if (Number.isNaN(created) || Number.isNaN(cutover)) return true; // fail safe
+    return created < cutover;
+  }
+  return false;
+}
+
+/** One refused-mutation record, surfaced for the audit trail. */
+export interface GuardViolation {
+  clusterId: string;
+  operation: 'merge' | 'reopen' | 'upsert';
+  reason: 'pre-cutover' | 'governance-notes';
+  feedbackId?: string;
+  at: string;
+}
+
+export interface GuardedStoreOptions {
+  /** The one-way-door timestamp: clusters created before this are migrated curated history. */
+  cutoverTimestamp: string;
+  /** Called for every refused mutation, so the caller can audit it (never throws into the store). */
+  onViolation?: (v: GuardViolation) => void;
+  /** Injected clock for the violation timestamp (testable; defaults to a fixed-at-construction stamp). */
+  now?: () => string;
+}
+
+/** Why a cluster was deemed immutable, for the violation record. */
+function immutableReason(cluster: Cluster): GuardViolation['reason'] {
+  return hasGovernanceNotes(cluster) ? 'governance-notes' : 'pre-cutover';
+}
+
+/**
+ * A FeedbackStore decorator that enforces the never-re-derive invariant structurally.
+ * Mutations targeting an immutable cluster are refused (recorded as a GuardViolation),
+ * never delegated to the inner store — so curated state physically cannot be overwritten.
+ */
+export class GuardedFeedbackStore implements FeedbackStore {
+  private readonly inner: FeedbackStore;
+  private readonly cutoverTimestamp: string;
+  private readonly onViolation?: (v: GuardViolation) => void;
+  private readonly now: () => string;
+  private readonly _violations: GuardViolation[] = [];
+
+  constructor(inner: FeedbackStore, opts: GuardedStoreOptions) {
+    this.inner = inner;
+    this.cutoverTimestamp = opts.cutoverTimestamp;
+    this.onViolation = opts.onViolation;
+    // Default clock is fixed at construction so a guarded store has no hidden Date.now() call
+    // per mutation; callers that need per-event time pass opts.now.
+    const stamp = opts.now;
+    this.now = stamp ?? (() => this.cutoverTimestamp);
+  }
+
+  /** All refused mutations observed by this guard (in order). */
+  get violations(): readonly GuardViolation[] {
+    return this._violations;
+  }
+
+  private refuse(clusterId: string, operation: GuardViolation['operation'], cluster: Cluster, feedbackId?: string): void {
+    const v: GuardViolation = {
+      clusterId,
+      operation,
+      reason: immutableReason(cluster),
+      feedbackId,
+      at: this.now(),
+    };
+    this._violations.push(v);
+    if (this.onViolation) {
+      try {
+        this.onViolation(v);
+      } catch {
+        // An audit-sink failure must never break the store or surface as a mutation.
+        // @silent-fallback-ok — guard integrity is independent of the audit sink's health.
+      }
+    }
+  }
+
+  // ── Gated mutations (curated-cluster protection) ──────────────────────────
+
+  upsertClusterFromItem(clusterId: string, item: FeedbackItem): void {
+    const existing = this.inner.getCluster(clusterId);
+    if (existing && isClusterImmutable(existing, this.cutoverTimestamp)) {
+      this.refuse(clusterId, 'upsert', existing, item.feedbackId);
+      return;
+    }
+    this.inner.upsertClusterFromItem(clusterId, item);
+  }
+
+  mergeIntoCluster(clusterId: string, item: FeedbackItem): void {
+    const existing = this.inner.getCluster(clusterId);
+    if (existing && isClusterImmutable(existing, this.cutoverTimestamp)) {
+      this.refuse(clusterId, 'merge', existing, item.feedbackId);
+      return;
+    }
+    this.inner.mergeIntoCluster(clusterId, item);
+  }
+
+  applyReopen(clusterId: string, decision: ReopenDecision): void {
+    const existing = this.inner.getCluster(clusterId);
+    if (existing && isClusterImmutable(existing, this.cutoverTimestamp)) {
+      this.refuse(clusterId, 'reopen', existing);
+      return;
+    }
+    this.inner.applyReopen(clusterId, decision);
+  }
+
+  // ── Pass-through (reads + non-curated writes) ─────────────────────────────
+
+  getUnprocessedFeedback(): FeedbackItem[] {
+    return this.inner.getUnprocessedFeedback();
+  }
+  getActiveClusters(): Cluster[] {
+    return this.inner.getActiveClusters();
+  }
+  getCluster(clusterId: string): Cluster | undefined {
+    return this.inner.getCluster(clusterId);
+  }
+  markProcessed(feedbackId: string, clusterId: string): void {
+    this.inner.markProcessed(feedbackId, clusterId);
+  }
+  hasFeedback(feedbackId: string): boolean {
+    return this.inner.hasFeedback(feedbackId);
+  }
+  addFeedback(item: FeedbackItem): void {
+    this.inner.addFeedback(item);
+  }
+  listDispatches(filter?: { since?: string; type?: string }): DispatchRecord[] {
+    return this.inner.listDispatches(filter);
+  }
+  findDispatchByTitle(title: string): DispatchRecord | undefined {
+    return this.inner.findDispatchByTitle(title);
+  }
+  createDispatch(record: DispatchRecord): void {
+    this.inner.createDispatch(record);
+  }
+  metrics(): FeedbackMetrics {
+    return this.inner.metrics();
+  }
+}

--- a/src/feedback-factory/migration/importIntegrity.ts
+++ b/src/feedback-factory/migration/importIntegrity.ts
@@ -1,0 +1,265 @@
+/**
+ * importIntegrity.ts — the integrity-safe import core (spec §2.4).
+ *
+ * "Row counts + spot-check" is too weak to catch silent corruption of the irreplaceable
+ * curated state. This module is the pure, deterministic core of the AS-IS import gate;
+ * the real Prisma adapter wraps these in one transaction (parent-before-child FK order)
+ * and runs the synthetic post-import insert. Keeping the logic pure makes the Phase-2
+ * gate fully unit-testable without a database.
+ *
+ * The gate (spec §2.4): per-row curated-field checksums match (in vs out) + pre-import
+ * fingerprint-uniqueness resolved + schema-equivalence holds + FK referential integrity
+ * + a sequence reset computed so the next post-cutover insert cannot collide (P2002).
+ */
+
+import { createHash } from 'node:crypto';
+import type { Cluster, FeedbackItem } from '../processor/types.js';
+
+/**
+ * Curated cluster fields whose exact preservation the checksum guards. The cluster table
+ * is curated human/LLM judgment, not a cache — every one of these must survive AS-IS.
+ */
+export const CURATED_CLUSTER_FIELDS = [
+  'clusterId',
+  'title',
+  'description',
+  'type',
+  'status',
+  'fingerprint',
+  'recurrenceCount',
+  'reportCount',
+  'createdAt',
+  'fixedInVersion',
+  'fixAppliedAt',
+  'dispatchedAt',
+  'governanceNotes',
+  'processingNotes',
+  'actionTaken',
+  'researchNotes',
+  'chronicCount',
+] as const;
+
+/** Curated feedback fields (the report rows linked to clusters). */
+export const CURATED_FEEDBACK_FIELDS = [
+  'feedbackId',
+  'title',
+  'description',
+  'type',
+  'status',
+  'receivedAt',
+  'instarVersion',
+] as const;
+
+/**
+ * Canonicalize a value for checksumming so that semantically-identical rows hash equal
+ * across the source→target hop. null and undefined and "" all collapse to "" (the
+ * null-vs-empty governance-note distinction is asserted separately by schema-equivalence;
+ * the checksum must not flap on it). Everything else is JSON-stringified.
+ */
+function canonicalValue(v: unknown): string {
+  if (v === null || v === undefined || v === '') return '';
+  if (typeof v === 'number' && Number.isNaN(v)) return 'NaN';
+  return JSON.stringify(v);
+}
+
+/** Deterministic checksum over the named fields of a row (field order fixed by `fields`). */
+export function curatedChecksum(row: Record<string, unknown>, fields: readonly string[]): string {
+  const h = createHash('sha256');
+  for (const f of fields) {
+    h.update(f);
+    h.update('\x1f'); // unit separator: field-name | value
+    h.update(canonicalValue(row[f]));
+    h.update('\x1e'); // record separator after each field (no cross-field run ambiguity)
+  }
+  return h.digest('hex');
+}
+
+export function clusterChecksum(cluster: Cluster): string {
+  return curatedChecksum(cluster as Record<string, unknown>, CURATED_CLUSTER_FIELDS);
+}
+export function feedbackChecksum(item: FeedbackItem): string {
+  return curatedChecksum(item as Record<string, unknown>, CURATED_FEEDBACK_FIELDS);
+}
+
+export interface ChecksumMismatch {
+  id: string;
+  kind: 'cluster' | 'feedback';
+  reason: 'missing-in-target' | 'extra-in-target' | 'checksum-differs';
+  sourceChecksum?: string;
+  targetChecksum?: string;
+}
+
+/**
+ * Compare source rows (Dawn's export) against imported rows (canonical instance) by id,
+ * field-by-field via checksum. Returns every divergence — empty array == clean import.
+ */
+export function verifyImportChecksums(
+  source: { clusters: Cluster[]; feedback: FeedbackItem[] },
+  target: { clusters: Cluster[]; feedback: FeedbackItem[] },
+): ChecksumMismatch[] {
+  const out: ChecksumMismatch[] = [];
+
+  const verify = <T extends Record<string, unknown>>(
+    kind: 'cluster' | 'feedback',
+    idField: string,
+    src: T[],
+    tgt: T[],
+    checksum: (row: T) => string,
+  ) => {
+    const tgtById = new Map(tgt.map((r) => [String(r[idField]), r]));
+    const seen = new Set<string>();
+    for (const s of src) {
+      const id = String(s[idField]);
+      seen.add(id);
+      const t = tgtById.get(id);
+      if (!t) {
+        out.push({ id, kind, reason: 'missing-in-target', sourceChecksum: checksum(s) });
+        continue;
+      }
+      const sc = checksum(s);
+      const tc = checksum(t);
+      if (sc !== tc) out.push({ id, kind, reason: 'checksum-differs', sourceChecksum: sc, targetChecksum: tc });
+    }
+    for (const t of tgt) {
+      const id = String(t[idField]);
+      if (!seen.has(id)) out.push({ id, kind, reason: 'extra-in-target', targetChecksum: checksum(t) });
+    }
+  };
+
+  verify('cluster', 'clusterId', source.clusters, target.clusters, (c) => clusterChecksum(c as Cluster));
+  verify('feedback', 'feedbackId', source.feedback, target.feedback, (f) => feedbackChecksum(f as FeedbackItem));
+  return out;
+}
+
+/** A set of clusters that collide on `fingerprint` (the @unique constraint would abort the import). */
+export interface FingerprintCollision {
+  fingerprint: string;
+  clusterIds: string[];
+}
+
+/**
+ * Pre-import uniqueness scan on the SOURCE: curated history may hold two clusters sharing a
+ * fingerprint (after manual merges/edits). An AS-IS import would abort on @unique mid-txn or
+ * silently collapse them — detect + surface BEFORE importing so a human resolves it.
+ */
+export function scanFingerprintUniqueness(clusters: Cluster[]): FingerprintCollision[] {
+  const byFp = new Map<string, string[]>();
+  for (const c of clusters) {
+    const fp = typeof c.fingerprint === 'string' ? c.fingerprint : '';
+    if (!fp) continue; // a missing fingerprint isn't a @unique collision
+    const arr = byFp.get(fp) ?? [];
+    arr.push(c.clusterId);
+    byFp.set(fp, arr);
+  }
+  const out: FingerprintCollision[] = [];
+  for (const [fingerprint, clusterIds] of byFp) {
+    if (clusterIds.length > 1) out.push({ fingerprint, clusterIds });
+  }
+  return out;
+}
+
+/** A field whose value-domain differs between Dawn's schema and the canonical instance. */
+export interface SchemaDivergence {
+  field: string;
+  kind: 'unknown-status-value' | 'type-mismatch' | 'missing-field';
+  detail: string;
+}
+
+export interface SchemaDescriptor {
+  /** Allowed lifecycle status values (enum or string union). */
+  statusValues: string[];
+  /** Field → declared type, for the fields the processor reads. */
+  fieldTypes: Record<string, string>;
+}
+
+/**
+ * Schema-equivalence assertion: every status value the SOURCE uses must be accepted by the
+ * TARGET, and the field types must line up. Mismatched enums or a status the target rejects
+ * would corrupt the import silently — surface it before the transaction.
+ */
+export function assertSchemaEquivalence(source: SchemaDescriptor, target: SchemaDescriptor): SchemaDivergence[] {
+  const out: SchemaDivergence[] = [];
+  const targetStatus = new Set(target.statusValues);
+  for (const s of source.statusValues) {
+    if (!targetStatus.has(s)) {
+      out.push({ field: 'status', kind: 'unknown-status-value', detail: `target does not accept status "${s}"` });
+    }
+  }
+  for (const [field, srcType] of Object.entries(source.fieldTypes)) {
+    const tgtType = target.fieldTypes[field];
+    if (tgtType === undefined) {
+      out.push({ field, kind: 'missing-field', detail: `target schema has no field "${field}"` });
+    } else if (tgtType !== srcType) {
+      out.push({ field, kind: 'type-mismatch', detail: `source ${srcType} vs target ${tgtType}` });
+    }
+  }
+  return out;
+}
+
+/** A feedback row pointing at a cluster that does not exist in the import set. */
+export interface DanglingRef {
+  feedbackId: string;
+  clusterId: string;
+}
+
+/**
+ * FK referential-integrity check (not just row counts): every feedback row that claims a
+ * clusterId must resolve to an imported cluster. Run AFTER the parent-before-child import
+ * to prove no dangling references survived.
+ */
+export function checkReferentialIntegrity(clusters: Cluster[], feedback: FeedbackItem[]): DanglingRef[] {
+  const clusterIds = new Set(clusters.map((c) => c.clusterId));
+  const out: DanglingRef[] = [];
+  for (const f of feedback) {
+    const cid = (f as Record<string, unknown>).clusterId;
+    if (typeof cid === 'string' && cid.length > 0 && !clusterIds.has(cid)) {
+      out.push({ feedbackId: f.feedbackId, clusterId: cid });
+    }
+  }
+  return out;
+}
+
+/**
+ * The next auto-increment value to set after importing explicit PKs, so the next NEW
+ * post-cutover insert cannot collide (P2002). Returns maxNumericId + 1, or 1 if no numeric
+ * ids were imported. Non-numeric ids are ignored (cuid/uuid PKs need no sequence reset).
+ */
+export function planSequenceReset(importedIds: Array<string | number>): number {
+  let max = 0;
+  for (const id of importedIds) {
+    const n = typeof id === 'number' ? id : Number(id);
+    if (Number.isFinite(n) && n > max) max = Math.floor(n);
+  }
+  return max + 1;
+}
+
+export interface IntegrityReport {
+  fingerprintCollisions: FingerprintCollision[];
+  schemaDivergences: SchemaDivergence[];
+  checksumMismatches: ChecksumMismatch[];
+  danglingRefs: DanglingRef[];
+  sequenceResetTo: number;
+  /** True only when EVERY check is clean — the Phase-2/4 import gate. */
+  passed: boolean;
+}
+
+/**
+ * Run the full integrity gate over a source export and its imported copy. `passed` is the
+ * single Phase-2/4 gate boolean; any non-empty divergence list fails it.
+ */
+export function runIntegrityGate(
+  source: { clusters: Cluster[]; feedback: FeedbackItem[]; schema: SchemaDescriptor },
+  target: { clusters: Cluster[]; feedback: FeedbackItem[]; schema: SchemaDescriptor },
+): IntegrityReport {
+  const fingerprintCollisions = scanFingerprintUniqueness(source.clusters);
+  const schemaDivergences = assertSchemaEquivalence(source.schema, target.schema);
+  const checksumMismatches = verifyImportChecksums(source, target);
+  const danglingRefs = checkReferentialIntegrity(target.clusters, target.feedback);
+  const sequenceResetTo = planSequenceReset(target.clusters.map((c) => c.clusterId));
+  const passed =
+    fingerprintCollisions.length === 0 &&
+    schemaDivergences.length === 0 &&
+    checksumMismatches.length === 0 &&
+    danglingRefs.length === 0;
+  return { fingerprintCollisions, schemaDivergences, checksumMismatches, danglingRefs, sequenceResetTo, passed };
+}

--- a/tests/unit/feedback-factory/immutable-guard.test.ts
+++ b/tests/unit/feedback-factory/immutable-guard.test.ts
@@ -1,0 +1,159 @@
+/**
+ * Unit tests (Tier 1) — the structural never-re-derive guard (spec §2.4).
+ *
+ * Covers both sides of every immutability boundary + the GuardedFeedbackStore decorator's
+ * refuse-vs-delegate behavior, including the processor running over a guarded store: a
+ * wrong-date backfill must be PHYSICALLY unable to overwrite curated state.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  hasGovernanceNotes,
+  isClusterImmutable,
+  GuardedFeedbackStore,
+  GOVERNANCE_FIELDS,
+} from '../../../src/feedback-factory/migration/immutableGuard.js';
+import { InMemoryFeedbackStore } from '../../../src/feedback-factory/store/FeedbackStore.js';
+import { processUnprocessed } from '../../../src/feedback-factory/processor/process.js';
+import type { Cluster, FeedbackItem } from '../../../src/feedback-factory/processor/types.js';
+
+const CUTOVER = '2026-06-05T00:00:00Z';
+const cluster = (over: Partial<Cluster>): Cluster => ({ clusterId: 'c1', title: 't', description: 'd', ...over });
+
+describe('hasGovernanceNotes', () => {
+  it('is true when any governance field is non-empty', () => {
+    for (const f of GOVERNANCE_FIELDS) {
+      expect(hasGovernanceNotes(cluster({ [f]: 'a human decision' }))).toBe(true);
+    }
+  });
+  it('is false when all governance fields are missing, null, or whitespace', () => {
+    expect(hasGovernanceNotes(cluster({}))).toBe(false);
+    expect(hasGovernanceNotes(cluster({ governanceNotes: '' }))).toBe(false);
+    expect(hasGovernanceNotes(cluster({ processingNotes: '   ' }))).toBe(false);
+    expect(hasGovernanceNotes(cluster({ actionTaken: null as unknown as string }))).toBe(false);
+  });
+});
+
+describe('isClusterImmutable', () => {
+  it('IMMUTABLE: governance notes present, regardless of a post-cutover date', () => {
+    expect(isClusterImmutable(cluster({ createdAt: '2026-07-01T00:00:00Z', actionTaken: 'patched' }), CUTOVER)).toBe(true);
+  });
+  it('IMMUTABLE: createdAt strictly before cutover', () => {
+    expect(isClusterImmutable(cluster({ createdAt: '2026-06-04T23:59:59Z' }), CUTOVER)).toBe(true);
+  });
+  it('MUTABLE: createdAt at/after cutover and no governance notes', () => {
+    expect(isClusterImmutable(cluster({ createdAt: CUTOVER }), CUTOVER)).toBe(false);
+    expect(isClusterImmutable(cluster({ createdAt: '2026-06-05T00:00:01Z' }), CUTOVER)).toBe(false);
+  });
+  it('IMMUTABLE (fail-safe): createdAt present but unparseable', () => {
+    expect(isClusterImmutable(cluster({ createdAt: 'not-a-date' }), CUTOVER)).toBe(true);
+  });
+  it('MUTABLE: no createdAt and no governance notes (a fresh post-cutover cluster)', () => {
+    expect(isClusterImmutable(cluster({}), CUTOVER)).toBe(false);
+  });
+});
+
+describe('GuardedFeedbackStore — refuse vs delegate', () => {
+  const preCutover = cluster({ clusterId: 'curated', createdAt: '2026-01-01T00:00:00Z', reportCount: 5 });
+  const postCutover = cluster({ clusterId: 'fresh', createdAt: '2026-06-05T12:00:00Z', reportCount: 1 });
+  const governed = cluster({ clusterId: 'governed', createdAt: '2026-07-01T00:00:00Z', actionTaken: 'shipped', reportCount: 3 });
+  const item: FeedbackItem = { feedbackId: 'f1', title: 't', description: 'd', type: 'bug' };
+
+  const mk = () => {
+    const inner = new InMemoryFeedbackStore({ clusters: [{ ...preCutover }, { ...postCutover }, { ...governed }] });
+    const guard = new GuardedFeedbackStore(inner, { cutoverTimestamp: CUTOVER, now: () => 'NOW' });
+    return { inner, guard };
+  };
+
+  it('REFUSES merge into a pre-cutover cluster (inner untouched, violation recorded)', () => {
+    const { inner, guard } = mk();
+    guard.mergeIntoCluster('curated', item);
+    expect(inner.getCluster('curated')!.reportCount).toBe(5); // not bumped
+    expect(guard.violations).toEqual([{ clusterId: 'curated', operation: 'merge', reason: 'pre-cutover', feedbackId: 'f1', at: 'NOW' }]);
+  });
+
+  it('REFUSES merge into a governance-noted cluster (reason: governance-notes)', () => {
+    const { inner, guard } = mk();
+    guard.mergeIntoCluster('governed', item);
+    expect(inner.getCluster('governed')!.reportCount).toBe(3);
+    expect(guard.violations[0].reason).toBe('governance-notes');
+  });
+
+  it('DELEGATES merge into a post-cutover cluster (inner mutated, no violation)', () => {
+    const { inner, guard } = mk();
+    guard.mergeIntoCluster('fresh', item);
+    expect(inner.getCluster('fresh')!.reportCount).toBe(2); // bumped
+    expect(guard.violations).toHaveLength(0);
+  });
+
+  it('REFUSES applyReopen on an immutable cluster but DELEGATES on a mutable one', () => {
+    const { inner, guard } = mk();
+    const decision = { newStatus: 'reopened', bumpRecurrence: true, annotateField: 'processingNotes' as const, note: 'x' };
+    guard.applyReopen('curated', decision);
+    expect(inner.getCluster('curated')!.status).toBeUndefined(); // refused
+    guard.applyReopen('fresh', decision);
+    expect(inner.getCluster('fresh')!.status).toBe('reopened'); // delegated
+  });
+
+  it('REFUSES upsert onto an existing immutable cluster, but DELEGATES creating a new cluster', () => {
+    const { inner, guard } = mk();
+    guard.upsertClusterFromItem('curated', item); // existing + immutable → refuse
+    expect(inner.getCluster('curated')!.reportCount).toBe(5);
+    guard.upsertClusterFromItem('brand-new', item); // does not exist → create
+    expect(inner.getCluster('brand-new')).toBeDefined();
+    expect(guard.violations).toHaveLength(1);
+  });
+
+  it('passes reads + non-curated writes straight through', () => {
+    const { inner, guard } = mk();
+    expect(guard.getActiveClusters().length).toBe(inner.getActiveClusters().length);
+    guard.addFeedback(item);
+    expect(inner.hasFeedback('f1')).toBe(true);
+  });
+
+  it('a throwing onViolation sink never breaks the store (still refuses, still records)', () => {
+    const inner = new InMemoryFeedbackStore({ clusters: [{ ...preCutover }] });
+    const guard = new GuardedFeedbackStore(inner, {
+      cutoverTimestamp: CUTOVER,
+      now: () => 'NOW',
+      onViolation: () => { throw new Error('audit sink down'); },
+    });
+    expect(() => guard.mergeIntoCluster('curated', item)).not.toThrow();
+    expect(inner.getCluster('curated')!.reportCount).toBe(5);
+    expect(guard.violations).toHaveLength(1);
+  });
+});
+
+describe('GuardedFeedbackStore — processor cannot re-derive curated state', () => {
+  it('processUnprocessed over a guarded store leaves a curated cluster untouched', () => {
+    // A curated, pre-cutover cluster whose title would otherwise attract a near-duplicate report.
+    const curated = cluster({
+      clusterId: 'login-bug',
+      title: 'Login button unresponsive on mobile',
+      description: 'Tapping login does nothing on iOS Safari',
+      fingerprint: 'fp-login',
+      createdAt: '2026-02-01T00:00:00Z',
+      status: 'triaged',
+      reportCount: 9,
+      actionTaken: 'Assigned to platform team',
+    });
+    const newReport: FeedbackItem = {
+      feedbackId: 'r-new',
+      title: 'Login button unresponsive on mobile',
+      description: 'Tapping login does nothing on iOS Safari',
+      type: 'bug',
+      status: 'unprocessed',
+      receivedAt: '2026-06-05T10:00:00Z',
+    };
+    const inner = new InMemoryFeedbackStore({ clusters: [curated], feedback: [newReport] });
+    const guard = new GuardedFeedbackStore(inner, { cutoverTimestamp: CUTOVER });
+
+    processUnprocessed(guard, '2026-06-05T10:05:00Z');
+
+    const after = inner.getCluster('login-bug')!;
+    expect(after.reportCount).toBe(9); // curated count preserved — NOT bumped
+    expect(after.status).toBe('triaged'); // lifecycle preserved
+    expect(after.actionTaken).toBe('Assigned to platform team'); // governance note preserved
+    expect(guard.violations.length).toBeGreaterThan(0); // the attempted mutation was caught
+  });
+});

--- a/tests/unit/feedback-factory/import-integrity.test.ts
+++ b/tests/unit/feedback-factory/import-integrity.test.ts
@@ -1,0 +1,139 @@
+/**
+ * Unit tests (Tier 1) — integrity-safe import core (spec §2.4).
+ *
+ * The Phase-2/4 gate: per-row curated-field checksums match (in vs out) + pre-import
+ * fingerprint-uniqueness resolved + schema-equivalence holds + FK referential integrity +
+ * a sequence reset that prevents a post-cutover P2002. Both sides of every check covered.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  clusterChecksum,
+  feedbackChecksum,
+  curatedChecksum,
+  verifyImportChecksums,
+  scanFingerprintUniqueness,
+  assertSchemaEquivalence,
+  checkReferentialIntegrity,
+  planSequenceReset,
+  runIntegrityGate,
+  type SchemaDescriptor,
+} from '../../../src/feedback-factory/migration/importIntegrity.js';
+import type { Cluster, FeedbackItem } from '../../../src/feedback-factory/processor/types.js';
+
+const cl = (over: Partial<Cluster>): Cluster => ({ clusterId: 'c1', title: 't', description: 'd', ...over });
+const fb = (over: Partial<FeedbackItem>): FeedbackItem => ({ feedbackId: 'f1', title: 't', description: 'd', type: 'bug', ...over });
+
+describe('curatedChecksum / clusterChecksum', () => {
+  it('is deterministic — same row hashes equal across calls', () => {
+    const c = cl({ status: 'triaged', fingerprint: 'fp', recurrenceCount: 2 });
+    expect(clusterChecksum(c)).toBe(clusterChecksum({ ...c }));
+  });
+  it('changes when ANY curated field changes', () => {
+    const base = cl({ status: 'open', recurrenceCount: 1, actionTaken: 'x' });
+    expect(clusterChecksum(base)).not.toBe(clusterChecksum(cl({ status: 'resolved', recurrenceCount: 1, actionTaken: 'x' })));
+    expect(clusterChecksum(base)).not.toBe(clusterChecksum(cl({ status: 'open', recurrenceCount: 2, actionTaken: 'x' })));
+    expect(clusterChecksum(base)).not.toBe(clusterChecksum(cl({ status: 'open', recurrenceCount: 1, actionTaken: 'y' })));
+  });
+  it('treats null, undefined, and "" as identical (no flap on null-vs-empty)', () => {
+    expect(clusterChecksum(cl({ governanceNotes: null as unknown as string }))).toBe(clusterChecksum(cl({ governanceNotes: '' })));
+    expect(clusterChecksum(cl({ governanceNotes: undefined }))).toBe(clusterChecksum(cl({})));
+  });
+  it('has no cross-field run ambiguity (separator-protected)', () => {
+    // Without separators, ("ab","c") and ("a","bc") could collide. They must not.
+    expect(curatedChecksum({ x: 'ab', y: 'c' }, ['x', 'y'])).not.toBe(curatedChecksum({ x: 'a', y: 'bc' }, ['x', 'y']));
+  });
+  it('feedbackChecksum distinguishes curated feedback fields', () => {
+    expect(feedbackChecksum(fb({ status: 'unprocessed' }))).not.toBe(feedbackChecksum(fb({ status: 'processing' })));
+  });
+});
+
+describe('verifyImportChecksums', () => {
+  const src = { clusters: [cl({ clusterId: 'a', status: 'open' })], feedback: [fb({ feedbackId: 'x' })] };
+  it('clean when target is identical', () => {
+    expect(verifyImportChecksums(src, { clusters: [cl({ clusterId: 'a', status: 'open' })], feedback: [fb({ feedbackId: 'x' })] })).toEqual([]);
+  });
+  it('flags missing-in-target', () => {
+    const m = verifyImportChecksums(src, { clusters: [], feedback: [fb({ feedbackId: 'x' })] });
+    expect(m).toEqual([expect.objectContaining({ id: 'a', kind: 'cluster', reason: 'missing-in-target' })]);
+  });
+  it('flags extra-in-target', () => {
+    const m = verifyImportChecksums(src, { clusters: [cl({ clusterId: 'a', status: 'open' }), cl({ clusterId: 'b' })], feedback: [fb({ feedbackId: 'x' })] });
+    expect(m).toEqual([expect.objectContaining({ id: 'b', reason: 'extra-in-target' })]);
+  });
+  it('flags checksum-differs (silent field corruption)', () => {
+    const m = verifyImportChecksums(src, { clusters: [cl({ clusterId: 'a', status: 'CORRUPTED' })], feedback: [fb({ feedbackId: 'x' })] });
+    expect(m).toEqual([expect.objectContaining({ id: 'a', reason: 'checksum-differs' })]);
+  });
+});
+
+describe('scanFingerprintUniqueness', () => {
+  it('detects two clusters sharing a fingerprint', () => {
+    const dup = scanFingerprintUniqueness([cl({ clusterId: 'a', fingerprint: 'fp' }), cl({ clusterId: 'b', fingerprint: 'fp' })]);
+    expect(dup).toEqual([{ fingerprint: 'fp', clusterIds: ['a', 'b'] }]);
+  });
+  it('clean when all fingerprints unique; ignores missing fingerprints', () => {
+    expect(scanFingerprintUniqueness([cl({ clusterId: 'a', fingerprint: 'fp1' }), cl({ clusterId: 'b', fingerprint: 'fp2' }), cl({ clusterId: 'c' })])).toEqual([]);
+  });
+});
+
+describe('assertSchemaEquivalence', () => {
+  const target: SchemaDescriptor = { statusValues: ['open', 'triaged', 'resolved'], fieldTypes: { status: 'string', recurrenceCount: 'number' } };
+  it('clean when source ⊆ target', () => {
+    expect(assertSchemaEquivalence({ statusValues: ['open', 'resolved'], fieldTypes: { status: 'string' } }, target)).toEqual([]);
+  });
+  it('flags a status value the target does not accept', () => {
+    const d = assertSchemaEquivalence({ statusValues: ['open', 'wontfix'], fieldTypes: {} }, target);
+    expect(d).toEqual([expect.objectContaining({ field: 'status', kind: 'unknown-status-value' })]);
+  });
+  it('flags a type mismatch and a missing field', () => {
+    const d = assertSchemaEquivalence({ statusValues: [], fieldTypes: { recurrenceCount: 'string', extra: 'string' } }, target);
+    expect(d).toEqual(expect.arrayContaining([
+      expect.objectContaining({ field: 'recurrenceCount', kind: 'type-mismatch' }),
+      expect.objectContaining({ field: 'extra', kind: 'missing-field' }),
+    ]));
+  });
+});
+
+describe('checkReferentialIntegrity', () => {
+  it('flags a feedback row pointing at a non-existent cluster', () => {
+    const d = checkReferentialIntegrity([cl({ clusterId: 'a' })], [fb({ feedbackId: 'x', clusterId: 'GHOST' } as Partial<FeedbackItem>)]);
+    expect(d).toEqual([{ feedbackId: 'x', clusterId: 'GHOST' }]);
+  });
+  it('clean when every link resolves (and ignores unlinked feedback)', () => {
+    expect(checkReferentialIntegrity([cl({ clusterId: 'a' })], [fb({ feedbackId: 'x', clusterId: 'a' } as Partial<FeedbackItem>), fb({ feedbackId: 'y' })])).toEqual([]);
+  });
+});
+
+describe('planSequenceReset', () => {
+  it('returns maxNumericId + 1', () => {
+    expect(planSequenceReset([1, 7, 3])).toBe(8);
+    expect(planSequenceReset(['10', '2'])).toBe(11);
+  });
+  it('returns 1 for no numeric ids (cuid/uuid PKs need no reset)', () => {
+    expect(planSequenceReset(['abc', 'def'])).toBe(1);
+    expect(planSequenceReset([])).toBe(1);
+  });
+});
+
+describe('runIntegrityGate', () => {
+  const schema: SchemaDescriptor = { statusValues: ['open', 'resolved'], fieldTypes: { status: 'string' } };
+  const cleanSrc = { clusters: [cl({ clusterId: 'a', fingerprint: 'fp1', status: 'open' })], feedback: [fb({ feedbackId: 'x', clusterId: 'a' } as Partial<FeedbackItem>)], schema };
+  const cleanTgt = { clusters: [cl({ clusterId: 'a', fingerprint: 'fp1', status: 'open' })], feedback: [fb({ feedbackId: 'x', clusterId: 'a' } as Partial<FeedbackItem>)], schema };
+
+  it('passes when every check is clean', () => {
+    const r = runIntegrityGate(cleanSrc, cleanTgt);
+    expect(r.passed).toBe(true);
+    expect(r.sequenceResetTo).toBe(1); // non-numeric ids
+  });
+  it('fails on a checksum mismatch', () => {
+    const r = runIntegrityGate(cleanSrc, { ...cleanTgt, clusters: [cl({ clusterId: 'a', fingerprint: 'fp1', status: 'TAMPERED' })] });
+    expect(r.passed).toBe(false);
+    expect(r.checksumMismatches.length).toBeGreaterThan(0);
+  });
+  it('fails on a source fingerprint collision', () => {
+    const r = runIntegrityGate({ ...cleanSrc, clusters: [cl({ clusterId: 'a', fingerprint: 'fp' }), cl({ clusterId: 'b', fingerprint: 'fp' })] }, cleanTgt);
+    expect(r.passed).toBe(false);
+    expect(r.fingerprintCollisions.length).toBe(1);
+  });
+});

--- a/upgrades/feedback-phase4-integrity.eli16.md
+++ b/upgrades/feedback-phase4-integrity.eli16.md
@@ -1,0 +1,54 @@
+# ELI16 — Phase-4 feedback-migration integrity tooling
+
+## What problem does this solve?
+
+We're moving the "feedback factory" (the thing that catches user bug reports, groups
+duplicates into clusters, and tracks each cluster's lifecycle) from Dawn's Portal over to
+Instar. The cluster records aren't just data — they hold human and AI *judgment*: which
+bug is which, what was already triaged, what was shipped. That curated judgment is
+irreplaceable. If the move corrupts it, or if the new processor later overwrites it, we
+lose work nobody can recreate.
+
+Two specific dangers:
+
+1. **A silent bad copy.** "The row counts match" is far too weak a check — a single
+   cluster could come across with its status flipped or its governance note dropped and a
+   count check would never notice. We need to prove *every curated field of every row*
+   survived the move byte-for-byte.
+
+2. **A wrong-date backfill overwriting curated history.** After cutover, the processor is
+   only supposed to touch *new* reports. But if someone ever re-runs it over old data, it
+   would happily "re-cluster" the curated history and discard every triage decision.
+
+## What this change adds
+
+Two small, pure, well-tested building blocks (no database, no network — just logic, so
+they're fully unit-testable):
+
+- **`importIntegrity.ts`** — the import gate. It computes a per-row checksum over every
+  curated field and compares source-vs-imported (catching silent corruption), scans the
+  source for two clusters sharing a fingerprint *before* importing (which would otherwise
+  abort the transaction or silently merge them), asserts the two schemas accept the same
+  status values and field types, checks that no feedback row points at a missing cluster
+  (referential integrity), and computes the auto-increment sequence reset so the next new
+  insert can't collide. `runIntegrityGate()` rolls all of that into one pass/fail.
+
+- **`immutableGuard.ts`** — the structural "never re-derive" guard. Instead of *trusting*
+  the processor to only run over new traffic, we wrap the store: a cluster that predates
+  cutover, or that carries any governance note, is **immutable**, and any attempt to merge
+  into it, reopen it, or upsert over it is physically refused and recorded. A wrong-date
+  backfill therefore *cannot* overwrite curated state — the write simply does not happen.
+
+## Why it's safe
+
+Both modules are pure functions plus one store decorator. The guard only ever *refuses*
+writes (it never invents or changes data), and reads pass straight through. Nothing is
+wired into the running server yet — these are the building blocks the Phase-4 cutover will
+use. 36 new unit tests cover both sides of every boundary, including the processor running
+over a guarded store and leaving a curated cluster's count, status, and note untouched.
+
+## Plain-language risk
+
+Near-zero. Worst case if the guard is mis-tuned: a *legitimate* post-cutover merge is
+refused and shows up in the violations list (loud, not silent) — far better than the
+alternative of silently overwriting curated judgment.

--- a/upgrades/next/feedback-phase4-integrity.md
+++ b/upgrades/next/feedback-phase4-integrity.md
@@ -1,0 +1,2 @@
+<!-- bump: patch -->
+Phase-4 feedback-migration integrity tooling: never-re-derive guard + integrity-safe import core (library building blocks; not yet wired into the running server).

--- a/upgrades/side-effects/feedback-phase4-integrity.md
+++ b/upgrades/side-effects/feedback-phase4-integrity.md
@@ -1,0 +1,35 @@
+# Side effects — Phase-4 feedback-migration integrity tooling
+
+## New files (additive only)
+- `src/feedback-factory/migration/immutableGuard.ts` — `GuardedFeedbackStore` decorator +
+  `isClusterImmutable` / `hasGovernanceNotes` invariants.
+- `src/feedback-factory/migration/importIntegrity.ts` — pure import-gate core (checksums,
+  fingerprint-uniqueness scan, schema-equivalence, referential integrity, sequence reset,
+  `runIntegrityGate`).
+- `tests/unit/feedback-factory/immutable-guard.test.ts` (15 tests).
+- `tests/unit/feedback-factory/import-integrity.test.ts` (21 tests).
+
+## Runtime impact
+- **None at boot / on the live server.** These modules are NOT imported by `server.ts`, any
+  route, job, or hook. They are library building blocks the Phase-4 cutover execution will
+  call. No new endpoint, no new config key, no migration to `PostUpdateMigrator`.
+- No new dependencies (uses `node:crypto` only).
+
+## Behavioral guarantees
+- `GuardedFeedbackStore` only ever REFUSES a mutation of an immutable cluster (pre-cutover
+  createdAt or non-null governance note) and records a `GuardViolation`; it never alters
+  data and passes all reads + non-curated writes straight through to the inner store.
+- A failing `onViolation` audit sink can never break the store or surface as a mutation
+  (try/caught, annotated `@silent-fallback-ok`).
+- Checksums collapse null/undefined/"" so the import gate does not flap on the
+  null-vs-empty governance-note distinction (that distinction is asserted separately by
+  schema-equivalence).
+
+## Reversibility
+- Fully reversible: delete the two `migration/` files + their tests. Nothing else
+  references them yet.
+
+## Follow-on wiring (not in this PR)
+- Phase-4 cutover executor (G2.4) constructs the `GuardedFeedbackStore` around the real
+  Prisma-backed store with the cutover timestamp from config, and runs `runIntegrityGate`
+  over the export/import pair as the Phase-2 gate.


### PR DESCRIPTION
## ELI16 — never lose curated bug-triage judgment during the migration

We're moving the feedback system from Dawn's Portal to Instar. The cluster records hold irreplaceable human/AI triage judgment — which bug is which, what was already decided, what shipped. This PR adds two safety building blocks so the move can't corrupt that judgment: (1) a **never-re-derive guard** that physically refuses to let the processor overwrite any pre-cutover or governance-noted cluster — a wrong-date backfill simply can't write; and (2) an **integrity-safe import gate** that checksums every curated field in-vs-out, scans for duplicate fingerprints before importing, asserts schema-equivalence, and checks referential integrity, so silent corruption a row-count would miss gets caught. Pure logic, 36 unit tests, not yet wired into the live server.

## What
Building blocks the Phase-4 feedback-migration cutover will use (spec §2.4) — Goal 1, G1.1.
- **immutableGuard.ts** — GuardedFeedbackStore decorator physically refuses any mutation (merge/reopen/upsert) of an immutable cluster (createdAt < cutoverTimestamp OR a non-null governance note), recording a GuardViolation. Reads + non-curated writes pass through.
- **importIntegrity.ts** — per-row curated-field checksum (in vs out), pre-import fingerprint-uniqueness scan, schema-equivalence assertion, FK referential-integrity check, sequence-reset planning, runIntegrityGate().

## Why it's safe
Pure logic (node:crypto only), not wired into the running server — no route/job/hook/config/migrator. Fully reversible.

## Tests
36 new unit tests both sides of every boundary (incl. the processor over a guarded store leaving a curated cluster untouched). Full feedback-factory suite green (192), tsc --noEmit clean, tier-1 instar-dev gate passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)