### PR TITLE
feat(feedback-factory): Phase-3 parity monitor + cutover gate

### DIFF
--- a/src/feedback-factory/monitor/parityMonitor.ts
+++ b/src/feedback-factory/monitor/parityMonitor.ts
@@ -1,0 +1,141 @@
+/**
+ * parityMonitor.ts — the Phase-3 live dual-forward parity MONITOR + cutover gate (spec §2.5).
+ *
+ * The per-pass comparison already exists (processor/parity.ts → ParityResult over the
+ * order-independent invariants: per-report fingerprint, terminal-status, recurrence/cycling
+ * counts — NOT raw cluster membership, which is order-dependent and would flap on benign
+ * arrival-order noise). What Phase 3 needs ON TOP of one comparison is the WINDOW: run the
+ * comparison repeatedly over real dual-forward traffic and only clear the cutover when a
+ * genuine zero-divergence window has elapsed.
+ *
+ * This monitor records each pass, tracks the current zero-divergence streak (ANY divergent
+ * pass resets it), and exposes the single structural gate `gate()` → cleared/blocked. That
+ * `cleared` boolean is the objective `parity-zero-divergence` condition the Coordination
+ * Mandate's `execute-cutover` authority reads — the agent cannot fake it; the window decides.
+ *
+ * Structure > Willpower: cutover is blocked by the gate, not by an agent deciding "looks
+ * good". The pure core here is fully unit-testable; a thin durable wrapper (below) persists
+ * passes so the window survives a restart, since it spans real traffic time.
+ */
+
+import type { ParityResult } from '../processor/parity.js';
+
+/** One recorded comparison pass over a dual-forward traffic slice. */
+export interface MonitorPass {
+  /** ISO timestamp of this pass. */
+  at: string;
+  /** Clusters compared in this pass (the meaningful-sample input). */
+  clustersCompared: number;
+  /** Total divergences this pass (fingerprint + outcome). 0 == clean. */
+  divergences: number;
+  /** Convenience mirror of `divergences > 0`. */
+  divergent: boolean;
+}
+
+/** The window a clean streak must satisfy before the cutover gate clears. */
+export interface CutoverGatePolicy {
+  /** Consecutive zero-divergence passes required (default 3). */
+  requiredCleanPasses: number;
+  /** The clean streak must span at least this much REAL time (default 1h). */
+  minWindowMs: number;
+  /** Total clusters compared across the clean streak — a meaningful sample (default 1). */
+  minClustersObserved: number;
+}
+
+export const DEFAULT_GATE_POLICY: CutoverGatePolicy = {
+  requiredCleanPasses: 3,
+  minWindowMs: 60 * 60 * 1000,
+  minClustersObserved: 1,
+};
+
+export interface CutoverGateStatus {
+  /** The structural signal: true only when the zero-divergence window is genuinely satisfied. */
+  cleared: boolean;
+  reason: string;
+  cleanPasses: number;
+  windowMs: number;
+  clustersObserved: number;
+  /** ISO of the most recent divergent pass (the streak reset point), or null if never. */
+  lastDivergentAt: string | null;
+}
+
+function passDivergences(r: ParityResult): number {
+  return r.fingerprintDivergences.length + r.outcomeDivergences.length;
+}
+
+/**
+ * Records parity passes and computes the cutover gate over the current zero-divergence
+ * streak. Pure + clock-injected (gate(now) takes the current time) → fully testable.
+ */
+export class ParityMonitor {
+  private readonly policy: CutoverGatePolicy;
+  private readonly _passes: MonitorPass[] = [];
+
+  constructor(policy: Partial<CutoverGatePolicy> = {}) {
+    this.policy = { ...DEFAULT_GATE_POLICY, ...policy };
+  }
+
+  /** Feed a raw pass record. */
+  record(pass: MonitorPass): void {
+    this._passes.push(pass);
+  }
+
+  /** Convenience: record straight from a ParityResult + the pass timestamp. */
+  recordResult(result: ParityResult, at: string): void {
+    const divergences = passDivergences(result);
+    this._passes.push({ at, clustersCompared: result.clustersCompared, divergences, divergent: divergences > 0 });
+  }
+
+  get passes(): readonly MonitorPass[] {
+    return this._passes;
+  }
+
+  /**
+   * The structural cutover gate. `cleared` is true only when the trailing run of passes is:
+   *   - all clean (zero divergence), AND
+   *   - at least `requiredCleanPasses` long, AND
+   *   - spanning at least `minWindowMs` of real time (first-clean-pass → now), AND
+   *   - covering at least `minClustersObserved` clusters in total.
+   * Any divergent pass resets the streak. No passes → blocked.
+   */
+  gate(now: string): CutoverGateStatus {
+    // Find the index just after the most recent divergent pass — the start of the clean streak.
+    let streakStart = 0;
+    let lastDivergentAt: string | null = null;
+    for (let i = this._passes.length - 1; i >= 0; i--) {
+      if (this._passes[i].divergent) {
+        streakStart = i + 1;
+        lastDivergentAt = this._passes[i].at;
+        break;
+      }
+    }
+    const streak = this._passes.slice(streakStart);
+    const cleanPasses = streak.length;
+    const clustersObserved = streak.reduce((s, p) => s + p.clustersCompared, 0);
+    const nowMs = Date.parse(now);
+    const firstCleanMs = cleanPasses > 0 ? Date.parse(streak[0].at) : nowMs;
+    const windowMs = Number.isNaN(nowMs) || Number.isNaN(firstCleanMs) ? 0 : Math.max(0, nowMs - firstCleanMs);
+
+    const reasons: string[] = [];
+    if (cleanPasses < this.policy.requiredCleanPasses) {
+      reasons.push(`need ${this.policy.requiredCleanPasses} consecutive clean passes, have ${cleanPasses}`);
+    }
+    if (windowMs < this.policy.minWindowMs) {
+      reasons.push(`clean window ${Math.round(windowMs / 1000)}s < required ${Math.round(this.policy.minWindowMs / 1000)}s`);
+    }
+    if (clustersObserved < this.policy.minClustersObserved) {
+      reasons.push(`observed ${clustersObserved} clusters < required ${this.policy.minClustersObserved}`);
+    }
+    const cleared = reasons.length === 0;
+    return {
+      cleared,
+      reason: cleared
+        ? `zero-divergence window satisfied: ${cleanPasses} clean passes over ${Math.round(windowMs / 1000)}s, ${clustersObserved} clusters`
+        : reasons.join('; '),
+      cleanPasses,
+      windowMs,
+      clustersObserved,
+      lastDivergentAt,
+    };
+  }
+}

--- a/src/feedback-factory/monitor/parityMonitorStore.ts
+++ b/src/feedback-factory/monitor/parityMonitorStore.ts
@@ -1,0 +1,91 @@
+/**
+ * parityMonitorStore.ts — durable persistence for the Phase-3 parity monitor.
+ *
+ * The zero-divergence window that gates cutover spans HOURS of real dual-forward traffic.
+ * If the monitor's passes lived only in memory, a server restart mid-window would silently
+ * reset the streak — at best re-blocking cutover (conservative, survivable), at worst making
+ * the gate's `windowMs` meaningless across the very restart it must survive. So passes are
+ * appended to a JSONL and reloaded on construction: the window is durable across restarts.
+ *
+ * Append-only JSONL (one MonitorPass per line) matches Instar's file-based-state convention
+ * and is crash-safe (a torn final line is skipped on reload, never corrupting the rest).
+ * The pure ParityMonitor stays the gate brain; this is the I/O shell around it.
+ */
+
+import { appendFileSync, readFileSync, mkdirSync, existsSync } from 'node:fs';
+import { dirname } from 'node:path';
+import { ParityMonitor, type CutoverGatePolicy, type CutoverGateStatus, type MonitorPass } from './parityMonitor.js';
+import type { ParityResult } from '../processor/parity.js';
+
+/** Injectable I/O so unit tests can drive the durable layer without touching disk. */
+export interface PassPersistence {
+  /** Load all previously-recorded passes, oldest-first. */
+  load(): MonitorPass[];
+  /** Durably append one pass. */
+  append(pass: MonitorPass): void;
+}
+
+/** The default JSONL-on-disk persistence (append-only, torn-line tolerant). */
+export class JsonlPassPersistence implements PassPersistence {
+  constructor(private readonly path: string) {}
+
+  load(): MonitorPass[] {
+    if (!existsSync(this.path)) return [];
+    const out: MonitorPass[] = [];
+    const lines = readFileSync(this.path, 'utf8').split('\n');
+    for (const line of lines) {
+      const trimmed = line.trim();
+      if (!trimmed) continue;
+      try {
+        const p = JSON.parse(trimmed) as MonitorPass;
+        // Defensive: only accept well-formed pass records.
+        if (typeof p.at === 'string' && typeof p.clustersCompared === 'number' && typeof p.divergences === 'number') {
+          out.push({ at: p.at, clustersCompared: p.clustersCompared, divergences: p.divergences, divergent: !!p.divergent });
+        }
+      } catch {
+        // A torn final line (crash mid-append) is skipped, never corrupting the prior window.
+        // @silent-fallback-ok — durability is best-effort-forward; a bad line is dropped, loudly recoverable.
+      }
+    }
+    return out;
+  }
+
+  append(pass: MonitorPass): void {
+    mkdirSync(dirname(this.path), { recursive: true });
+    appendFileSync(this.path, JSON.stringify(pass) + '\n');
+  }
+}
+
+/**
+ * A ParityMonitor whose passes survive a restart. Reloads persisted passes on construction,
+ * then every record() both persists and feeds the in-memory monitor. gate() delegates to the
+ * monitor over the full (reloaded + new) history.
+ */
+export class DurableParityMonitor {
+  private readonly monitor: ParityMonitor;
+  private readonly persistence: PassPersistence;
+
+  constructor(persistence: PassPersistence, policy: Partial<CutoverGatePolicy> = {}) {
+    this.persistence = persistence;
+    this.monitor = new ParityMonitor(policy);
+    for (const p of persistence.load()) this.monitor.record(p);
+  }
+
+  record(pass: MonitorPass): void {
+    this.persistence.append(pass);
+    this.monitor.record(pass);
+  }
+
+  recordResult(result: ParityResult, at: string): void {
+    const divergences = result.fingerprintDivergences.length + result.outcomeDivergences.length;
+    this.record({ at, clustersCompared: result.clustersCompared, divergences, divergent: divergences > 0 });
+  }
+
+  gate(now: string): CutoverGateStatus {
+    return this.monitor.gate(now);
+  }
+
+  get passes(): readonly MonitorPass[] {
+    return this.monitor.passes;
+  }
+}

--- a/tests/unit/feedback-factory/parity-monitor-store.test.ts
+++ b/tests/unit/feedback-factory/parity-monitor-store.test.ts
@@ -1,0 +1,109 @@
+/**
+ * Unit tests (Tier 1) — durable parity monitor (restart-survival of the cutover window).
+ *
+ * The Phase-3 zero-divergence window spans hours; a server restart mid-window must NOT
+ * silently reset the streak. These tests prove the window survives a simulated restart, and
+ * that the JSONL persistence round-trips + tolerates a torn final line.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { writeFileSync, mkdtempSync, readFileSync } from 'node:fs';
+import {
+  DurableParityMonitor,
+  JsonlPassPersistence,
+  type PassPersistence,
+} from '../../../src/feedback-factory/monitor/parityMonitorStore.js';
+import type { MonitorPass } from '../../../src/feedback-factory/monitor/parityMonitor.js';
+
+/** In-memory persistence so the monitor logic is testable without disk. */
+class MemPersistence implements PassPersistence {
+  constructor(public rows: MonitorPass[] = []) {}
+  load(): MonitorPass[] {
+    return [...this.rows];
+  }
+  append(pass: MonitorPass): void {
+    this.rows.push(pass);
+  }
+}
+
+const clean = (at: string): MonitorPass => ({ at, clustersCompared: 10, divergences: 0, divergent: false });
+const policy = { requiredCleanPasses: 3, minWindowMs: 60_000, minClustersObserved: 5 };
+
+describe('DurableParityMonitor — restart survival', () => {
+  it('reloads persisted passes on construction so the window survives a "restart"', () => {
+    const store = new MemPersistence();
+    // Instance A records a full clean window, then "the process dies".
+    const a = new DurableParityMonitor(store, policy);
+    a.record(clean('2026-06-05T00:00:00Z'));
+    a.record(clean('2026-06-05T00:30:00Z'));
+    a.record(clean('2026-06-05T01:00:00Z'));
+    expect(a.gate('2026-06-05T01:30:00Z').cleared).toBe(true);
+
+    // Instance B is a fresh construction over the SAME persistence (the restart).
+    const b = new DurableParityMonitor(store, policy);
+    expect(b.passes).toHaveLength(3);
+    expect(b.gate('2026-06-05T01:30:00Z').cleared).toBe(true); // window survived
+  });
+
+  it('record() both persists and feeds the live monitor', () => {
+    const store = new MemPersistence();
+    const m = new DurableParityMonitor(store, policy);
+    m.record(clean('2026-06-05T00:00:00Z'));
+    expect(store.rows).toHaveLength(1); // persisted
+    expect(m.passes).toHaveLength(1); // in-memory
+  });
+
+  it('a divergence persisted before a restart still resets the post-restart streak', () => {
+    const store = new MemPersistence();
+    const a = new DurableParityMonitor(store, policy);
+    a.record(clean('2026-06-05T00:00:00Z'));
+    a.record({ at: '2026-06-05T00:30:00Z', clustersCompared: 10, divergences: 1, divergent: true });
+    // restart
+    const b = new DurableParityMonitor(store, policy);
+    b.record(clean('2026-06-05T01:00:00Z'));
+    const g = b.gate('2026-06-05T02:00:00Z');
+    expect(g.cleared).toBe(false); // only 1 clean pass since the persisted divergence
+    expect(g.lastDivergentAt).toBe('2026-06-05T00:30:00Z');
+  });
+});
+
+describe('JsonlPassPersistence', () => {
+  const mkPath = () => join(mkdtempSync(join(tmpdir(), 'parity-')), 'passes.jsonl');
+
+  it('round-trips passes through the JSONL file', () => {
+    const p = mkPath();
+    const persistence = new JsonlPassPersistence(p);
+    persistence.append(clean('2026-06-05T00:00:00Z'));
+    persistence.append({ at: '2026-06-05T00:30:00Z', clustersCompared: 5, divergences: 2, divergent: true });
+    const loaded = new JsonlPassPersistence(p).load();
+    expect(loaded).toHaveLength(2);
+    expect(loaded[1].divergences).toBe(2);
+  });
+
+  it('returns [] for a missing file', () => {
+    expect(new JsonlPassPersistence(join(tmpdir(), 'does-not-exist-parity.jsonl')).load()).toEqual([]);
+  });
+
+  it('skips a torn final line (crash mid-append) without losing prior passes', () => {
+    const p = mkPath();
+    writeFileSync(p, JSON.stringify(clean('2026-06-05T00:00:00Z')) + '\n' + '{"at":"2026-06-05T00:30:00Z","clusters'); // truncated
+    const loaded = new JsonlPassPersistence(p).load();
+    expect(loaded).toHaveLength(1); // the good line survives; the torn one is dropped
+    expect(loaded[0].at).toBe('2026-06-05T00:00:00Z');
+  });
+
+  it('end-to-end: a DurableParityMonitor over a real JSONL survives restart', () => {
+    const p = mkPath();
+    const a = new DurableParityMonitor(new JsonlPassPersistence(p), policy);
+    a.record(clean('2026-06-05T00:00:00Z'));
+    a.record(clean('2026-06-05T00:30:00Z'));
+    a.record(clean('2026-06-05T01:00:00Z'));
+    // fresh monitor over the same on-disk file
+    const b = new DurableParityMonitor(new JsonlPassPersistence(p), policy);
+    expect(b.gate('2026-06-05T01:30:00Z').cleared).toBe(true);
+    // the file holds exactly three lines
+    expect(readFileSync(p, 'utf8').trim().split('\n')).toHaveLength(3);
+  });
+});

--- a/tests/unit/feedback-factory/parity-monitor.test.ts
+++ b/tests/unit/feedback-factory/parity-monitor.test.ts
@@ -1,0 +1,117 @@
+/**
+ * Unit tests (Tier 1) — Phase-3 parity monitor + cutover gate (spec §2.5).
+ *
+ * Both sides of every gate boundary: too-few passes, too-short window, too-few clusters,
+ * the satisfied window, and the streak-reset on any divergent pass. `gate().cleared` is the
+ * objective condition the Coordination Mandate's execute-cutover authority reads.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { ParityMonitor, DEFAULT_GATE_POLICY } from '../../../src/feedback-factory/monitor/parityMonitor.js';
+import type { ParityResult } from '../../../src/feedback-factory/processor/parity.js';
+
+const result = (over: Partial<ParityResult> = {}): ParityResult => ({
+  clustersCompared: 10,
+  clustersWithFingerprint: 10,
+  outcomesCompared: 10,
+  fingerprintDivergences: [],
+  outcomeDivergences: [],
+  divergent: false,
+  ...over,
+});
+
+// A tiny policy so tests don't need hour-long windows.
+const policy = { requiredCleanPasses: 3, minWindowMs: 60_000, minClustersObserved: 5 };
+
+describe('ParityMonitor.gate — blocked states', () => {
+  it('blocks with no passes', () => {
+    const m = new ParityMonitor(policy);
+    expect(m.gate('2026-06-05T01:00:00Z').cleared).toBe(false);
+  });
+
+  it('blocks when fewer than requiredCleanPasses', () => {
+    const m = new ParityMonitor(policy);
+    m.recordResult(result(), '2026-06-05T00:00:00Z');
+    m.recordResult(result(), '2026-06-05T00:30:00Z');
+    const g = m.gate('2026-06-05T02:00:00Z');
+    expect(g.cleared).toBe(false);
+    expect(g.reason).toMatch(/consecutive clean passes/);
+  });
+
+  it('blocks when the clean window is too short (enough passes, not enough time)', () => {
+    const m = new ParityMonitor(policy);
+    m.recordResult(result(), '2026-06-05T00:00:00Z');
+    m.recordResult(result(), '2026-06-05T00:00:10Z');
+    m.recordResult(result(), '2026-06-05T00:00:20Z');
+    const g = m.gate('2026-06-05T00:00:30Z'); // 30s < 60s required
+    expect(g.cleared).toBe(false);
+    expect(g.reason).toMatch(/clean window/);
+  });
+
+  it('blocks when too few clusters observed across the streak', () => {
+    const m = new ParityMonitor(policy);
+    m.recordResult(result({ clustersCompared: 1 }), '2026-06-05T00:00:00Z');
+    m.recordResult(result({ clustersCompared: 1 }), '2026-06-05T00:30:00Z');
+    m.recordResult(result({ clustersCompared: 1 }), '2026-06-05T01:00:00Z'); // 3 clusters < 5
+    const g = m.gate('2026-06-05T01:30:00Z');
+    expect(g.cleared).toBe(false);
+    expect(g.reason).toMatch(/clusters/);
+  });
+});
+
+describe('ParityMonitor.gate — cleared state', () => {
+  it('clears when passes, window, and clusters are all satisfied', () => {
+    const m = new ParityMonitor(policy);
+    m.recordResult(result(), '2026-06-05T00:00:00Z');
+    m.recordResult(result(), '2026-06-05T00:30:00Z');
+    m.recordResult(result(), '2026-06-05T01:00:00Z');
+    const g = m.gate('2026-06-05T01:30:00Z'); // 3 passes, 90min window, 30 clusters
+    expect(g.cleared).toBe(true);
+    expect(g.cleanPasses).toBe(3);
+    expect(g.clustersObserved).toBe(30);
+    expect(g.lastDivergentAt).toBeNull();
+  });
+});
+
+describe('ParityMonitor — streak reset on divergence', () => {
+  it('a divergent pass resets the clean streak (prior clean passes do not count)', () => {
+    const m = new ParityMonitor(policy);
+    // three clean...
+    m.recordResult(result(), '2026-06-05T00:00:00Z');
+    m.recordResult(result(), '2026-06-05T00:30:00Z');
+    m.recordResult(result(), '2026-06-05T01:00:00Z');
+    // ...then a divergence (resets)...
+    m.recordResult(result({ fingerprintDivergences: [{ clusterId: 'c', instar: 'a', portal: 'b' }], divergent: true }), '2026-06-05T01:30:00Z');
+    // ...then two clean (not yet enough).
+    m.recordResult(result(), '2026-06-05T02:00:00Z');
+    m.recordResult(result(), '2026-06-05T02:30:00Z');
+    const g = m.gate('2026-06-05T03:00:00Z');
+    expect(g.cleared).toBe(false);
+    expect(g.cleanPasses).toBe(2); // only the two after the divergence
+    expect(g.lastDivergentAt).toBe('2026-06-05T01:30:00Z');
+  });
+
+  it('re-clears once a fresh full clean window elapses after a divergence', () => {
+    const m = new ParityMonitor(policy);
+    m.recordResult(result({ divergent: true, outcomeDivergences: [{ fingerprint: 'f', kind: 'status', instar: 'x', portal: 'y' }] }), '2026-06-05T00:00:00Z');
+    m.recordResult(result(), '2026-06-05T00:30:00Z');
+    m.recordResult(result(), '2026-06-05T01:00:00Z');
+    m.recordResult(result(), '2026-06-05T01:30:00Z');
+    const g = m.gate('2026-06-05T02:00:00Z');
+    expect(g.cleared).toBe(true);
+    expect(g.lastDivergentAt).toBe('2026-06-05T00:00:00Z');
+  });
+});
+
+describe('ParityMonitor — recordResult derivation + defaults', () => {
+  it('derives divergence count from a ParityResult', () => {
+    const m = new ParityMonitor();
+    m.recordResult(result({ fingerprintDivergences: [{ clusterId: 'c', instar: 'a', portal: 'b' }], divergent: true }), '2026-06-05T00:00:00Z');
+    expect(m.passes[0].divergences).toBe(1);
+    expect(m.passes[0].divergent).toBe(true);
+  });
+  it('default policy requires a 1h window', () => {
+    expect(DEFAULT_GATE_POLICY.minWindowMs).toBe(60 * 60 * 1000);
+    expect(DEFAULT_GATE_POLICY.requiredCleanPasses).toBe(3);
+  });
+});

--- a/upgrades/feedback-phase3-monitor.eli16.md
+++ b/upgrades/feedback-phase3-monitor.eli16.md
@@ -41,3 +41,11 @@ reset on any divergence (including re-clearing only after a fresh full clean win
 
 Near-zero, and the failure mode is conservative: if the policy is too strict, the gate just
 stays *blocked* longer (cutover waits) — never the dangerous direction of clearing early.
+
+## Durability note
+
+The "they agreed" window can take hours to build up. If we kept it only in memory, restarting
+the server in the middle would silently wipe the streak and we'd have to start over (or worse,
+mis-measure the window across the restart). So each check result is appended to a small log file
+and reloaded when the monitor starts — the window survives restarts. A half-written final line
+from a crash is skipped cleanly, so one bad line never corrupts the rest of the history.

--- a/upgrades/feedback-phase3-monitor.eli16.md
+++ b/upgrades/feedback-phase3-monitor.eli16.md
@@ -1,0 +1,43 @@
+# ELI16 — Phase-3 parity monitor + cutover gate
+
+## What problem does this solve?
+
+Before we flip the feedback system from Dawn's Portal to Instar (the "cutover" — a one-way
+door), we run both processors side by side over real traffic for a while and check they
+agree. That side-by-side check ("the parity comparison") already exists. What was missing is
+the part that watches it *over time* and decides when it's genuinely safe to flip.
+
+You can't trust a single green check. Traffic is bursty; one quiet minute proves nothing. We
+need to see a real, sustained window where the two systems agreed on every report — and only
+*then* allow the cutover. And crucially, the decision to flip must not come from an agent
+"feeling confident" — it must come from an objective gate that an agent cannot fake.
+
+## What this change adds
+
+A small, pure `ParityMonitor`:
+
+- You feed it each comparison pass (how many clusters were compared, how many divergences).
+- It tracks the current **zero-divergence streak**. The moment any pass diverges, the streak
+  resets to zero — so a single disagreement, even after a long clean run, sends us back to
+  the start. No "mostly agreed" hand-waving.
+- It exposes one method, `gate(now)`, that returns **cleared** or **blocked** with a reason.
+  It clears only when the trailing run of passes is (a) all clean, (b) at least N passes
+  long, (c) spanning at least a real time window (default one hour), and (d) covering enough
+  clusters to be a meaningful sample. All four must hold.
+
+That `cleared` boolean is the objective `parity-zero-divergence` condition. It's exactly what
+the Coordination Mandate's "execute-cutover" authority reads: the agents can only flip the
+one-way door when this gate — not their judgment — says the window is satisfied.
+
+## Why it's safe
+
+Pure logic, no database, no network, no boot wiring. It only ever *reads* comparison results
+and *computes* a yes/no; it changes nothing and triggers nothing on its own. It's the
+building block the cutover executor will consult. 9 unit tests cover every gate boundary:
+too-few passes, too-short window, too-few clusters, the satisfied window, and the streak
+reset on any divergence (including re-clearing only after a fresh full clean window).
+
+## Plain-language risk
+
+Near-zero, and the failure mode is conservative: if the policy is too strict, the gate just
+stays *blocked* longer (cutover waits) — never the dangerous direction of clearing early.

--- a/upgrades/next/feedback-phase3-monitor.md
+++ b/upgrades/next/feedback-phase3-monitor.md
@@ -1,0 +1,2 @@
+<!-- bump: patch -->
+Phase-3 parity monitor + cutover gate (pure ParityMonitor; the objective parity-zero-divergence condition the cutover authority reads). Not yet wired.

--- a/upgrades/side-effects/feedback-phase3-monitor.md
+++ b/upgrades/side-effects/feedback-phase3-monitor.md
@@ -1,0 +1,29 @@
+# Side effects — Phase-3 parity monitor + cutover gate
+
+## New files (additive only)
+- `src/feedback-factory/monitor/parityMonitor.ts` — `ParityMonitor` (records passes, tracks
+  the zero-divergence streak, exposes the `gate()` cutover signal) + `DEFAULT_GATE_POLICY`.
+- `tests/unit/feedback-factory/parity-monitor.test.ts` (9 tests).
+
+## Runtime impact
+- **None at boot / on the live server.** Not imported by `server.ts`, any route, job, or
+  hook. No new endpoint, no config key, no `PostUpdateMigrator` entry. No new dependency
+  (pure logic over the existing `ParityResult` type).
+
+## Behavioral guarantees
+- `gate()` clears ONLY when all four conditions hold: ≥ requiredCleanPasses consecutive clean
+  passes, clean window ≥ minWindowMs of real time, ≥ minClustersObserved clusters across the
+  streak, and zero divergence in the streak. Any divergent pass resets the streak.
+- The monitor never mutates anything and never triggers cutover itself — it only computes a
+  cleared/blocked verdict that a downstream executor reads.
+- Conservative failure mode: an over-strict policy keeps the gate BLOCKED longer (cutover
+  waits); it can never clear early.
+
+## Reversibility
+- Fully reversible: delete `monitor/parityMonitor.ts` + its test. Nothing references it yet.
+
+## Follow-on wiring (not in this PR)
+- The Coordination Mandate condition registry (G2.2) maps `parity-zero-divergence` →
+  `monitor.gate(now).cleared`. The Phase-4 cutover executor (G2.4) consults it before the flip.
+- A durable wrapper (persist passes to JSONL so the window survives a restart) + a read-only
+  `/parity/status` route land with the cutover-executor wiring.

--- a/upgrades/side-effects/feedback-phase3-monitor.md
+++ b/upgrades/side-effects/feedback-phase3-monitor.md
@@ -27,3 +27,11 @@
   `monitor.gate(now).cleared`. The Phase-4 cutover executor (G2.4) consults it before the flip.
 - A durable wrapper (persist passes to JSONL so the window survives a restart) + a read-only
   `/parity/status` route land with the cutover-executor wiring.
+
+## Durability (added)
+- `parityMonitorStore.ts` — `DurableParityMonitor` + `JsonlPassPersistence`. The zero-divergence
+  window spans HOURS; without persistence a restart silently resets the streak. Passes are
+  appended to an append-only JSONL and reloaded on construction, so the window survives a
+  restart. Torn final line (crash mid-append) is skipped on reload, never corrupting the prior
+  window. Injectable `PassPersistence` keeps the logic unit-testable without disk. Still not
+  wired into the running server (the cutover executor constructs it with the live path).


### PR DESCRIPTION
## ELI16 — only allow the cutover after a real "they agreed" window

Before flipping the feedback system from Portal to Instar (a one-way door), we run both processors side-by-side and check they agree on every report. This PR adds the monitor that watches those checks over time: it tracks a zero-divergence streak, resets it the moment any check disagrees, and only reports "cleared for cutover" after enough consecutive clean checks spanning a real time window over enough traffic. That cleared/blocked verdict is an objective gate an agent can't fake — the window decides, not anyone's confidence. The conservative failure mode is the safe one: too-strict a policy just delays the cutover, it can never clear early. Pure logic, 9 unit tests.

## What
The windowing + structural cutover-gate layer on the existing per-pass parity comparison (spec §2.5) — Goal 1, G1.2.
ParityMonitor records each comparison pass over real dual-forward traffic, tracks the zero-divergence streak (any divergent pass resets it), and exposes gate(now) → cleared | blocked. Clears only when ALL hold: >= requiredCleanPasses consecutive clean passes (default 3), clean window >= minWindowMs (default 1h), >= minClustersObserved clusters. gate().cleared is the objective parity-zero-divergence condition the Coordination Mandate's execute-cutover authority reads.

## Why it's safe
Pure logic over the existing ParityResult type, not wired into the running server. Conservative failure mode (over-strict → blocked longer, never clears early). Fully reversible.

## Tests
9 unit tests, both sides of every gate boundary (too-few passes / too-short window / too-few clusters / satisfied / streak-reset / re-clear). tsc --noEmit clean, tier-1 gate passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)