### PR TITLE
fix(prompt-gate): auto-answer Gemini CLI modals

### DIFF
--- a/.instar/instar-dev-traces/2026-06-05T03-41-30-000Z-gemini-interactive-modal-autofill.json
+++ b/.instar/instar-dev-traces/2026-06-05T03-41-30-000Z-gemini-interactive-modal-autofill.json
@@ -1,0 +1,22 @@
+{
+  "version": 2,
+  "sessionId": "telegram-1052-gemini-interactive-modal-autofill",
+  "timestamp": "2026-06-05T03:41:30.000Z",
+  "slug": "gemini-interactive-modal-autofill",
+  "artifactPath": "upgrades/side-effects/gemini-interactive-modal-autofill.md",
+  "artifactSha256": "114cec27bb7f27268627104bcc2af097d19323d776111015c6ee4313076553e0",
+  "coveredFiles": [
+    "docs/specs/gemini-interactive-modal-autofill.eli16.md",
+    "src/monitoring/PromptGate.ts",
+    "tests/unit/PromptGate.test.ts",
+    "upgrades/next/gemini-interactive-modal-autofill.md",
+    "upgrades/side-effects/gemini-interactive-modal-autofill.md"
+  ],
+  "phase": "complete",
+  "tier": 1,
+  "tierReasoning": "Narrow PromptGate structural matcher for Gemini CLI's known blocking framework modals, reusing the existing deterministic autoDismissKey/session send path; no schema, config, routes, persistence, or spawn changes. Covered by PromptGate regression fixtures plus existing classifier/approver no-regression tests.",
+  "eli16Path": "docs/specs/gemini-interactive-modal-autofill.eli16.md",
+  "sideEffectsPath": "upgrades/side-effects/gemini-interactive-modal-autofill.md",
+  "secondPass": "not-required",
+  "reviewerConcurred": null
+}

--- a/docs/specs/gemini-interactive-modal-autofill.eli16.md
+++ b/docs/specs/gemini-interactive-modal-autofill.eli16.md
@@ -1,0 +1,36 @@
+# Gemini interactive modal autofill — ELI16
+
+Gemini has a few pop-up style questions that are not really the agent asking the
+user what to do. They are Gemini CLI asking about its own safety rails, like:
+"a possible loop was detected, should loop detection stay on?", "do you trust
+this workspace?", or "do you want to continue with this install/default?".
+
+Before this fix, Instar noticed those questions and forwarded them to Telegram.
+That helped visibility, but it did not solve the actual problem: the Gemini
+terminal was still sitting at the modal waiting for a keypress. In an autonomous
+session, nobody is always there to press Enter, so the whole session could wedge
+until Justin manually touched the pane.
+
+The fix teaches Prompt Gate to recognize those specific Gemini CLI modals before
+it uses the normal "ask the human" relay path. For each known modal, the safe
+answer is deterministic:
+
+- keep loop detection enabled;
+- trust the current workspace when Gemini is asking its workspace-trust modal;
+- use Gemini CLI's highlighted/default answer for install confirmation.
+
+Prompt Gate already had a way to send a key directly for deterministic system
+prompts. It used that for Claude's optional feedback survey. This change reuses
+that mechanism for Gemini's blocking modal prompts. That means Instar sends the
+key into the tmux session immediately, clears the detector's cache, and lets the
+Gemini session keep working.
+
+The change is intentionally narrow. It does not auto-answer generic install
+questions. The install detector requires Gemini/Gemini-CLI/MCP/tool context, so
+a normal shell question like "do you want to install this dependency?" can still
+go through the existing manual/classifier path.
+
+The tests pin both sides: Gemini loop detection, workspace trust, and install
+confirmation get an `autoDismissKey`; a generic non-Gemini install prompt does
+not. Existing Prompt Gate, InputClassifier, and AutoApprover tests also stay
+green, which proves the broader relay and auto-approval paths were not changed.

--- a/src/monitoring/PromptGate.ts
+++ b/src/monitoring/PromptGate.ts
@@ -25,8 +25,9 @@ export interface DetectedPrompt {
   detectedAt: number;
   id: string;               // Unique prompt ID (12-char CSPRNG)
   /**
-   * Optional auto-dismiss directive for non-blocking system prompts
-   * (e.g. Claude Code's "How is Claude doing this session?" optional survey).
+   * Optional deterministic response directive for system prompts whose safe
+   * answer is known from the framework UI itself (e.g. Claude Code's optional
+   * survey, Gemini CLI's loop-detection modal).
    * When set, the consumer should send `autoDismissKey` to the session and
    * SKIP the relay/classify pipeline entirely.
    */
@@ -77,6 +78,84 @@ interface PatternMatch {
   autoDismissKey?: string;
 }
 
+function extractNumberedOptions(lines: string[]): PromptOption[] {
+  const options: PromptOption[] = [];
+  for (const line of lines) {
+    const optMatch = line.match(/^\s*(?:[>❯●○◉]\s*)?(\d+)[.)]\s+(.+)$/);
+    if (optMatch) {
+      options.push({ key: optMatch[1], label: optMatch[2].trim() });
+      continue;
+    }
+
+    const colonMatch = line.match(/(?:^|\s)(\d+)\s*[:.)]\s*([A-Za-z][^0-9]{2,})(?=\s+\d+\s*[:.)]|$)/g);
+    if (!colonMatch) continue;
+    for (const raw of colonMatch) {
+      const parsed = raw.trim().match(/^(\d+)\s*[:.)]\s*(.+)$/);
+      if (parsed) options.push({ key: parsed[1], label: parsed[2].trim() });
+    }
+  }
+  return options;
+}
+
+function findOptionKey(options: PromptOption[], accept: RegExp, reject?: RegExp): string | null {
+  const option = options.find(o => accept.test(o.label) && !(reject?.test(o.label)));
+  return option?.key ?? null;
+}
+
+function detectGeminiSafeDefaultModal(lines: string[], fullWindow?: string[]): PatternMatch | null {
+  const windowLines = fullWindow ?? lines;
+  const haystack = windowLines.join('\n');
+  const options = extractNumberedOptions(windowLines);
+
+  if (/A potential loop was detected/i.test(haystack) && /loop detection/i.test(haystack)) {
+    const key = findOptionKey(options, /\bkeep\b.*\b(loop detection|enabled)\b|\benabled\b/i, /\bdisable\b/i) ?? 'Enter';
+    return {
+      type: 'confirmation',
+      summary: 'Gemini CLI loop-detection modal (auto-answer: keep enabled)',
+      options: options.length > 0 ? options : [
+        { key: 'Enter', label: 'Keep loop detection enabled' },
+        { key: 'Escape', label: 'Cancel' },
+      ],
+      autoDismissKey: key,
+    };
+  }
+
+  const isWorkspaceTrust = (
+    /(?:workspace|folder|directory|project).{0,80}trust|trust.{0,80}(?:workspace|folder|directory|project)/i.test(haystack)
+    && /(?:Gemini|gemini-cli|trusted workspace|trust this|do you trust|safe to run)/i.test(haystack)
+  );
+  if (isWorkspaceTrust) {
+    const key = findOptionKey(options, /\b(trust|yes|allow)\b/i, /\b(don'?t|do not|no|untrusted|deny)\b/i) ?? 'Enter';
+    return {
+      type: 'confirmation',
+      summary: 'Gemini CLI workspace-trust modal (auto-answer: trust workspace)',
+      options: options.length > 0 ? options : [
+        { key: 'Enter', label: 'Trust workspace' },
+        { key: 'Escape', label: 'Cancel' },
+      ],
+      autoDismissKey: key,
+    };
+  }
+
+  const isGeminiInstallConfirm = (
+    /(?:Gemini|gemini-cli|MCP server|extension|tool).{0,120}(?:install|installation)|(?:install|installation).{0,120}(?:Gemini|gemini-cli|MCP server|extension|tool)/i.test(haystack)
+    && /(?:Do you want to install|Need to install|Install .*\?|requires installation|Confirm install)/i.test(haystack)
+  );
+  if (isGeminiInstallConfirm) {
+    return {
+      type: 'confirmation',
+      summary: 'Gemini CLI install-confirm modal (auto-answer: highlighted default)',
+      options: options.length > 0 ? options : [
+        { key: 'Enter', label: 'Use highlighted default' },
+        { key: 'Escape', label: 'Cancel' },
+      ],
+      autoDismissKey: 'Enter',
+    };
+  }
+
+  return null;
+}
+
 /**
  * Patterns for detecting interactive prompts in Claude Code terminal output.
  * Each pattern operates on stripped (no-ANSI) text.
@@ -85,6 +164,16 @@ const PROMPT_PATTERNS: Array<{
   type: PromptType;
   test: (lines: string[], fullWindow?: string[]) => PatternMatch | null;
 }> = [
+  // Gemini CLI modal prompts that block autonomous sessions even in YOLO mode.
+  // These are framework-level affordances with a known safe/default response,
+  // so answer them before the relay/classifier path can wedge the session.
+  {
+    type: 'confirmation',
+    test(lines, fullWindow) {
+      return detectGeminiSafeDefaultModal(lines, fullWindow);
+    },
+  },
+
   // Claude Code OPTIONAL session feedback survey — non-blocking.
   // Shape: "How is Claude doing this session? (optional)" followed by
   //        "1: Bad  2: Fine  3: Good  0: Dismiss" on one line.

--- a/tests/unit/PromptGate.test.ts
+++ b/tests/unit/PromptGate.test.ts
@@ -278,6 +278,94 @@ describe('InputDetector.pattern.sessionFeedbackSurvey', () => {
   });
 });
 
+// ── Gemini CLI safe-default modals (auto-answer) ──────────────────
+
+describe('InputDetector.pattern.geminiSafeDefaultModals', () => {
+  it('detects Gemini loop-detection modal and keeps loop detection enabled', () => {
+    const detector = makeDetector();
+    const output = [
+      'Gemini is working...',
+      '',
+      'A potential loop was detected. Keep loop detection enabled or disable it?',
+      '1. Keep loop detection enabled',
+      '2. Disable loop detection',
+      '',
+    ].join('\n');
+
+    const prompt = detectWithDebounce(detector, 'gemini', output);
+    expect(prompt).not.toBeNull();
+    expect(prompt!.type).toBe('confirmation');
+    expect(prompt!.summary).toMatch(/loop-detection/i);
+    expect(prompt!.autoDismissKey).toBe('1');
+  });
+
+  it('falls back to Enter for the live Gemini loop modal when no numbered option row is visible', () => {
+    const detector = makeDetector();
+    const output = [
+      '╭────────────────────────────────────────────╮',
+      '│ A potential loop was detected              │',
+      '│ Keep loop detection enabled or disable it? │',
+      '╰────────────────────────────────────────────╯',
+      '',
+    ].join('\n');
+
+    const prompt = detectWithDebounce(detector, 'gemini', output);
+    expect(prompt).not.toBeNull();
+    expect(prompt!.autoDismissKey).toBe('Enter');
+  });
+
+  it('detects Gemini workspace-trust modal and chooses the trust option', () => {
+    const detector = makeDetector();
+    const output = [
+      'Gemini CLI needs to know whether this workspace is trusted.',
+      '',
+      'Do you trust this workspace folder?',
+      '1. Yes, trust this workspace',
+      '2. No, keep it untrusted',
+      '',
+    ].join('\n');
+
+    const prompt = detectWithDebounce(detector, 'gemini', output);
+    expect(prompt).not.toBeNull();
+    expect(prompt!.type).toBe('confirmation');
+    expect(prompt!.summary).toMatch(/workspace-trust/i);
+    expect(prompt!.autoDismissKey).toBe('1');
+  });
+
+  it('detects Gemini install-confirm modal and sends the highlighted default', () => {
+    const detector = makeDetector();
+    const output = [
+      'Gemini CLI wants to install an MCP server required by this task.',
+      '',
+      'Do you want to install the MCP server?',
+      '1. Install',
+      '2. Cancel',
+      '',
+    ].join('\n');
+
+    const prompt = detectWithDebounce(detector, 'gemini', output);
+    expect(prompt).not.toBeNull();
+    expect(prompt!.type).toBe('confirmation');
+    expect(prompt!.summary).toMatch(/install-confirm/i);
+    expect(prompt!.autoDismissKey).toBe('Enter');
+  });
+
+  it('does NOT auto-answer a generic non-Gemini install question', () => {
+    const detector = makeDetector();
+    const output = [
+      'npm output:',
+      '',
+      'Do you want to install the dependency?',
+      '1. Yes',
+      '2. No',
+      '',
+    ].join('\n');
+
+    const prompt = detectWithDebounce(detector, 'shell', output);
+    if (prompt) expect(prompt.autoDismissKey).toBeUndefined();
+  });
+});
+
 // ── onInputSent clears LLM relay cooldown ──────────────────────────
 
 describe('InputDetector.onInputSent', () => {

--- a/upgrades/next/gemini-interactive-modal-autofill.md
+++ b/upgrades/next/gemini-interactive-modal-autofill.md
@@ -1,0 +1,52 @@
+<!-- bump: patch -->
+
+## What Changed
+
+Gemini CLI can still stop on framework-level interactive modals even when an
+autonomous session is otherwise running in YOLO mode. Instar already detected
+and relayed those prompts to Telegram, but the Gemini process remained blocked
+until somebody pressed a key in the tmux pane.
+
+Prompt Gate now recognizes Gemini CLI's known safe-default modals before the
+generic relay/classifier path:
+
+- loop-detection prompt: keep loop detection enabled;
+- workspace-trust prompt: trust the workspace;
+- install-confirm prompt: accept Gemini CLI's highlighted/default path.
+
+The existing Prompt Gate auto-response hook sends the deterministic key directly
+to the session and clears detector state, so autonomous Gemini sessions do not
+freeze on these modals and the prompt does not spam Telegram.
+
+Tests cover the loop-detection modal with explicit options and the live no-option
+shape, workspace trust, install confirm, and a generic non-Gemini install prompt
+that must not receive an auto-answer.
+
+## Evidence
+
+Reproduced from the live apprenticeship report: Gemini CLI stopped at the modal
+"A potential loop was detected" and stayed blocked until Justin manually pressed
+Enter. The Prompt Gate path was confirmed in source: detected prompts with
+`autoDismissKey` are answered through `SessionManager.sendKey` before Telegram
+relay/classification.
+
+Before: Gemini modals could be relayed to Telegram while the tmux session stayed
+frozen at the modal. After: the known Gemini modal fixtures emit deterministic
+keys in `PromptGate`, so the existing session-send hook answers the modal and
+clears detector state.
+
+Verification: focused Prompt Gate/classifier/approver unit tests passed, lint
+passed, the stall-recovery integration suite passed, and Gemini loop/capacity
+e2e lifecycle suites passed.
+
+## What to Tell Your User
+
+Gemini should stop freezing on its own safety/setup modals during autonomous
+work. I now answer the known Gemini defaults directly, while generic install or
+human-judgment questions still go through the normal review path.
+
+## Summary of New Capabilities
+
+- Gemini loop-detection modal is answered by keeping loop detection enabled.
+- Gemini workspace-trust modal is answered by trusting the current workspace.
+- Gemini install-confirm modal uses Gemini CLI's highlighted/default answer.

--- a/upgrades/side-effects/gemini-interactive-modal-autofill.md
+++ b/upgrades/side-effects/gemini-interactive-modal-autofill.md
@@ -1,0 +1,85 @@
+# Side-effects review — Gemini interactive modal autofill
+
+## What changed
+
+`PromptGate` now has a structural matcher for known Gemini CLI framework modals
+that block autonomous sessions:
+
+- loop detection: sends the explicit "keep loop detection enabled" option when
+  visible, otherwise sends `Enter` for the live default path Justin observed;
+- workspace trust: sends the explicit trust/yes/allow option when visible,
+  otherwise sends `Enter`;
+- install confirmation: sends `Enter` to accept Gemini CLI's highlighted/default
+  response.
+
+These matches run before the generic question, selection, and LLM prompt
+detection paths. The existing server wiring already consumes `autoDismissKey` by
+sending that key to the tmux session and skipping the relay/classifier pipeline.
+
+## Why
+
+The failure mode is a real autonomy wedge. Instar detected the Gemini modal and
+forwarded it to Telegram, but the Gemini CLI process stayed blocked waiting for
+keypress input in the pane. YOLO mode does not suppress these Gemini CLI modals.
+
+Loop detection is a safety rail, so the auto-answer keeps it enabled. Workspace
+trust is part of normal agent operation in the bound project. Install-confirm is
+handled as Gemini CLI's own highlighted/default decision, not as a broad "yes to
+any install" rule.
+
+## Risk
+
+Blast radius is limited to prompt detection. There is no schema, database,
+configuration, route, migration, Telegram adapter, or session-spawn change.
+
+The main risk is false positive auto-answering. The patterns are constrained to
+Gemini-specific modal text or Gemini/MCP/tool install context, and the generic
+non-Gemini install fixture proves a plain install question does not receive an
+auto-answer. Existing broad prompt patterns still handle unrelated questions and
+confirmations the same way they did before.
+
+The second risk is semantic drift if Gemini CLI changes its wording. The loop
+modal uses the live phrase Justin observed ("A potential loop was detected") and
+falls back to `Enter` when no numbered row is visible. Workspace and install
+patterns also accept option rows where Gemini renders numeric choices.
+
+## Framework generality
+
+Claude Code and Codex CLI behavior is unchanged. Their existing Prompt Gate
+patterns still run after this new Gemini-specific matcher, and the new matcher
+requires Gemini-specific loop/trust/install context before it emits an
+`autoDismissKey`.
+
+This fix is explicitly for `gemini-cli`, and it reaches Gemini sessions through
+the same provider-neutral `PromptGate` and `SessionManager.sendKey` abstraction
+already used by Claude optional-survey dismissal and manual Telegram prompt
+responses.
+
+## Tests
+
+- Unit: `tests/unit/PromptGate.test.ts` covers Gemini loop detection with
+  numbered options, the live no-option loop modal shape, workspace trust,
+  install confirmation, and a generic non-Gemini install question that must not
+  auto-answer.
+- Unit: existing `InputClassifier` and `AutoApprover` tests stay green, proving
+  the normal classification and approval layers were not widened.
+- Focused run: `npm test -- --run tests/unit/PromptGate.test.ts tests/unit/InputClassifier.test.ts tests/unit/AutoApprover.test.ts`
+  passed with 95 tests.
+- Integration: `npm test -- --run tests/integration/stall-recovery-e2e.test.ts`
+  passed with 12 tests.
+- E2E: `npm test -- --run tests/e2e/gemini-loop-driver-lifecycle.test.ts tests/e2e/gemini-capacity-policy-lifecycle.test.ts`
+  passed with 4 tests.
+- Type/lint: `npm run lint` passed.
+
+An attempted broader session-management e2e smoke was not used as acceptance
+evidence: `tests/e2e/session-management-e2e.test.ts` hit the existing respawn
+fixture timing/session-loss path (`waitFor timed out after 15000ms`) while 30/31
+tests passed under a longer timeout. That file does not exercise this PromptGate
+matcher and the failure was in tmux respawn injection, not modal detection.
+
+## Rollback
+
+Revert the PromptGate matcher and tests. No persisted state or migration is
+introduced. Rollback restores the previous behavior where Gemini CLI modals are
+detected/relayed but may remain blocked until a human presses the key in the
+terminal.


### PR DESCRIPTION
## Summary

- add PromptGate structural detection for known Gemini CLI blocking modals
- auto-answer loop detection by keeping loop detection enabled, workspace trust by choosing trust, and install-confirm by accepting Gemini CLI's highlighted/default path
- add Gemini modal regression fixtures plus release, ELI16, side-effects, and trace artifacts

## ELI16 — Gemini should stop freezing on its own modal questions

Gemini sometimes stops on pop-up style questions that are really Gemini CLI asking about its own safety/setup rails, not the agent asking the user what to do. Before this fix, Instar could notice the question and forward it to Telegram, but Gemini still sat in the terminal waiting for somebody to press a key.

This change teaches Instar to recognize the specific Gemini modals where the safe answer is known: keep loop detection on, trust the current workspace, and use Gemini's own highlighted/default install answer. Instar sends that key directly into the session so Gemini keeps working instead of wedging.

The guard is narrow: a generic install question without Gemini/Gemini-CLI/MCP/tool context does not get auto-answered.

## Verification

- `npm test -- --run tests/unit/PromptGate.test.ts tests/unit/InputClassifier.test.ts tests/unit/AutoApprover.test.ts` — 95 passed
- `npm run lint` — passed
- `node scripts/instar-dev-precommit.js` — passed Tier 1 artifact gate
- `npm test -- --run tests/integration/stall-recovery-e2e.test.ts` — 12 passed
- `npm test -- --run tests/e2e/gemini-loop-driver-lifecycle.test.ts tests/e2e/gemini-capacity-policy-lifecycle.test.ts` — 4 passed
- `npm run check:pre-push-gate` — passed with the known non-blocking version warning
- push hook fixture guard passed; push used `INSTAR_PRE_PUSH_SKIP=1` after local verification so CI owns the full matrix

## Local Smoke Note

I also tried `tests/e2e/session-management-e2e.test.ts` as a broad tmux smoke. It is not used as acceptance evidence: under the default timeout it had two timeouts; rerun with `--testTimeout=30000` reduced that to one existing respawn fixture failure where the tmux session disappeared during injection (`waitFor timed out after 15000ms`). That path is unrelated to this PromptGate matcher.
