### PR TITLE
fix(multi-machine): idempotent topic transfer + exactly-once ingress defaults ON for live pools

### DIFF
--- a/docs/specs/transfer-idempotency-exactly-once.eli16.md
+++ b/docs/specs/transfer-idempotency-exactly-once.eli16.md
@@ -1,0 +1,46 @@
+# Transfer idempotency + exactly-once — the plain-English version
+
+## What you saw
+
+You said "move this to the laptop" ONCE, and got back a mess: "Moving to
+Laptop" … "I can't move this right now (rate-limited)" … "Moving to Laptop"
+… "rate-limited" again. Contradictory, noisy, and it looked broken — even
+though the move actually worked on the first try.
+
+## Why it happened (two separate bugs)
+
+**Bug 1 — the wrong order of checks.** When a move request comes in, the
+planner checked "did someone just do a move recently?" (the anti-spam rate
+limit) BEFORE checking "wait, is this conversation already on that machine?"
+So when your one message got processed more than once, the repeats slammed
+into the rate limit and got narrated as "I can't move this" — when the
+truthful answer was "it's already there."
+
+**Bug 2 — why your message ran more than once at all.** There IS a guard
+that's supposed to make sure each incoming message executes exactly once
+(retries and replays get recognized and dropped). It's built and tested —
+but it ships switched OFF, and nothing turned it on when the multi-machine
+pool went live. So under load, my message-forwarder retried, and each retry
+re-RAN your command instead of being recognized as "already handled."
+
+## The fixes
+
+1. **"Already there" now wins.** A repeat "move to X" when the conversation
+   is already on X (or already heading to X) answers "already running on X —
+   nothing to move." The rate limit only applies to real back-and-forth
+   flip-flopping between different machines, which is its actual job.
+
+2. **Exactly-once turns itself on with the pool.** If the multi-machine pool
+   is live (actually routing your conversations between machines), the
+   exactly-once guard is now ON by default. You can still explicitly turn it
+   off in config, but you can no longer end up in the "pool is live, guard is
+   accidentally dark" state — which is exactly the state my own machine was
+   in when this bit you. (I've already flipped it on for myself; this change
+   makes it automatic for any future machine.)
+
+## What you'll notice
+
+Saying "move this to the laptop" twice — or having my internals hiccup and
+retry your message — produces at most one "Moving…" and, for any repeat, a
+calm "already running on Laptop." No more rate-limited contradictions, no
+more commands executing multiple times.

--- a/docs/specs/transfer-idempotency-exactly-once.md
+++ b/docs/specs/transfer-idempotency-exactly-once.md
@@ -1,0 +1,78 @@
+---
+parent-principle: "Cross-Machine Coherence — One Agent, Robust Under Degraded Conditions"
+review-convergence: "rev-1 — operator-approved incident response (2026-06-05 topic 13481 transfer noise). Both fixes grounded in production logs + source: (1) the transfer planner's rate-limit check ran BEFORE its already-on-target check, so duplicates of an already-satisfied move read as failures; (2) the exactly-once ingress gate ships default-OFF even on a pool actively routing real traffic, so lifeline retries / post-restart replays re-execute user commands. Minimal coherent fixes at the pure-planner and config-resolution layers; both sides of every boundary test-pinned."
+approved: true
+approved-by: "operator (Justin) via Telegram topic 13481 — 2026-06-05 ~04:48Z (\"Yes please fix it\", responding to the named fix list: idempotent move + replayed messages must not re-execute commands) under the standing multi-machine pre-approval"
+approved-at: "2026-06-05T04:48:27Z"
+---
+
+# Transfer Idempotency + Exactly-Once-When-Live
+
+**Status:** Approved 2026-06-05. Implemented.
+**Author:** Echo
+**Companion:** transfer-idempotency-exactly-once.eli16.md
+**Trigger:** 2026-06-05 incident (topic 13481): ONE "move this to the laptop"
+message produced "Moving this conversation to Laptop" → "I can't move this
+right now (rate-limited)" → "Moving…" → "rate-limited" again. The move had
+succeeded on the first attempt; everything after was duplicate processing
+narrated as failure.
+
+---
+
+## Failure 1 — duplicate move reads as "rate-limited"
+
+`planTransferByNickname` checked the rate limit BEFORE the already-on-target
+no-op. A duplicate of an already-satisfied move (lifeline retry under load,
+post-restart queue replay) within the 10s window returned
+`reject/rate-limited` — the user is told a move that already succeeded
+"can't" happen. Worse, in the window where the pin landed but ownership
+hadn't re-placed yet (`pin === target`, `owner !== target`), even an
+out-of-window duplicate planned a SECOND full transfer.
+
+**Fix:** idempotency before the rate limit, at the pure-planner layer:
+- `owner === target` → `noop/already-on-target` (was present, but ran after
+  the rate limit; now runs before it).
+- NEW `currentPinOf` state hook: `pin === target` →
+  `noop/already-pinned-to-target` — a duplicate during the
+  pin-landed-but-not-re-placed window is recognized as satisfied.
+- The rate limit now only gates ACTUAL placement changes (different target),
+  which is its real job (anti rapid-fire flip-flop).
+- Consumer (`server.ts`): wires `currentPinOf` from `TopicPlacementPinStore`
+  and renders `already-on-target` as "This conversation is already running on
+  X — nothing to move."
+
+`currentPinOf` is optional — existing callers keep the old semantics
+(backward compatible).
+
+## Failure 2 — exactly-once ingress dark on a live pool
+
+The exactly-once ingress gate (`decideIngress` + `MessageProcessingLedger`,
+spec §8 G3a) is fully built and tested but `exactlyOnceIngress` defaults to
+`false`. On the dev agent the session pool runs at `stage: 'live-transfer'`
+while the ingress ledger was never wired — so the documented guarantee
+("each inbound message is handled exactly once") was structurally absent
+exactly where it matters most. Production log evidence: zero `exactly-once`
+lines while one message executed 4×.
+
+**Fix:** the default now follows the pool stage:
+`exactlyOnceIngress: mm?.exactlyOnceIngress ?? (stage === 'live-transfer' || stage === 'rebalance')`.
+A live pool gets the dedupe ledger by default; `dark`/`shadow` stay dark; an
+explicit `false` still wins (operator opt-out preserved). No migration needed
+— resolution-time defaulting, config absence keeps meaning "follow the
+default."
+
+## Tests
+
+- `tests/unit/TransferByNickname.test.ts` (+5): the incident case (already-on
+  within the window → noop, not rate-limited); pin-landed window → noop;
+  different-target within window still rate-limited; `currentPinOf` absent →
+  pre-existing behavior; offline target with satisfied pin → noop.
+- `tests/unit/seamlessnessConfig.test.ts` (+4): no config → off; dark/shadow
+  → off; live-transfer/rebalance → on; explicit value beats stage both ways.
+
+## Out of scope
+
+- The restart-cadence noise ("Server is restarting…" per release) — separate
+  UX track.
+- Dashboard cross-machine session visibility — separate PR (operator request,
+  same session).

--- a/src/commands/server.ts
+++ b/src/commands/server.ts
@@ -10208,6 +10208,10 @@ export async function startServer(options: StartOptions): Promise<void> {
                 isOnline: (m) => machinePoolRegistry?.getCapacity(m)?.online ?? false,
                 currentOwnerOf: (sk) => ownReg.ownerOf(sk),
                 isMidReply: () => false, // best-effort; the pin takes effect on the next routed message
+                // Pin-aware idempotency: a duplicate "move to X" while already pinned
+                // to X (e.g. a lifeline retry / post-restart replay of the same
+                // message) no-ops as "already there" instead of burning the rate limit.
+                currentPinOf: (sk) => _topicPinStore?.get(sk)?.preferredMachine ?? null,
                 lastPlacementUpdateAt: (sk) => _topicPinStore?.lastUpdatedAtMs(sk) ?? null,
                 now: () => Date.now(),
               },
@@ -10223,7 +10227,9 @@ export async function startServer(options: StartOptions): Promise<void> {
                 }
               } catch { /* best-effort; route() re-places regardless once the owner is cleared */ }
               await telegram?.sendToTopic(topicId, plan.action === 'noop'
-                ? `This conversation is already pinned to ${cmd.nickname} — it'll keep running there.`
+                ? (plan.detail === 'already-on-target'
+                  ? `This conversation is already running on ${cmd.nickname} — nothing to move.`
+                  : `This conversation is already pinned to ${cmd.nickname} — it'll keep running there.`)
                 : `Moving this conversation to ${cmd.nickname} — it'll pick up there on your next message.`).catch(() => {});
               console.log(pc.green(`  [session-pool] topic ${topicId} pinned to ${target} (${plan.action}) via "${cmd.matchedVerb}"`));
               return { handled: true };

--- a/src/core/TransferByNickname.ts
+++ b/src/core/TransferByNickname.ts
@@ -21,6 +21,12 @@ export interface TransferByNicknameState {
   currentOwnerOf: (sessionKey: string) => string | null;
   /** Is the session mid-reply (a turn in flight)? Confirmation is required to interrupt it. */
   isMidReply: (sessionKey: string) => boolean;
+  /**
+   * The machine the topic is currently PINNED to (preferredMachine), or null if
+   * unpinned. Optional for backward compatibility — when absent, only the
+   * current-owner check can satisfy the already-there no-op.
+   */
+  currentPinOf?: (sessionKey: string) => string | null;
   /** When the topic last had a placement update (for the rate limit), or null. */
   lastPlacementUpdateAt: (sessionKey: string) => number | null;
   now: () => number;
@@ -60,18 +66,30 @@ export function planTransferByNickname(command: NicknameCommand, state: Transfer
     return { action: 'reject', sessionKey, rejectReason: 'unknown-machine-nickname', validNicknames: state.validNicknames(), detail: command.nickname };
   }
 
-  // Rate limit — at most one placement update per topic per interval (defeats rapid-fire transfers).
+  const owner = state.currentOwnerOf(sessionKey);
+
+  // Idempotency BEFORE the rate limit: a repeat "move to X" when the topic is
+  // already ON X — or already PINNED to X (the move landed but ownership hasn't
+  // re-placed yet) — is a duplicate of an already-satisfied request. It must
+  // read as "already there", never as a rate-limit rejection. (2026-06-05
+  // incident: a retried/replayed "move to laptop" hit the cooldown and the user
+  // was told "I can't move this right now (rate-limited)" seconds after
+  // "Moving this conversation to Laptop" — for ONE request that had already
+  // succeeded.)
+  if (owner === target) {
+    return { action: 'noop', sessionKey, targetMachine: target, setPin: true, detail: 'already-on-target' };
+  }
+  if ((state.currentPinOf?.(sessionKey) ?? null) === target) {
+    return { action: 'noop', sessionKey, targetMachine: target, setPin: true, detail: 'already-pinned-to-target' };
+  }
+
+  // Rate limit — at most one ACTUAL placement change per topic per interval
+  // (defeats rapid-fire transfers between DIFFERENT machines; duplicates of an
+  // already-satisfied move never reach this).
   const minInterval = state.minUpdateIntervalMs ?? DEFAULT_MIN_UPDATE_INTERVAL_MS;
   const last = state.lastPlacementUpdateAt(sessionKey);
   if (last != null && state.now() - last < minInterval) {
     return { action: 'reject', sessionKey, targetMachine: target, rejectReason: 'rate-limited' };
-  }
-
-  const owner = state.currentOwnerOf(sessionKey);
-
-  // Already on the target → no transfer needed (still applies the pin if requested).
-  if (owner === target) {
-    return { action: 'noop', sessionKey, targetMachine: target, setPin: true, detail: 'already-on-target' };
   }
 
   // Confirmation gate (§L4): offline target, OR a different owner while mid-reply.

--- a/src/core/seamlessnessConfig.ts
+++ b/src/core/seamlessnessConfig.ts
@@ -106,7 +106,19 @@ export function resolveSeamlessnessConfig(mm?: MultiMachineConfig): ResolvedSeam
     splitBrainEscalationCooldownMs: mm?.splitBrainEscalationCooldownMs ?? 5 * 60_000,
     handoffBar: mm?.handoffBar ?? 'near-instant',
     maxProcessingMs: mm?.maxProcessingMs ?? 5 * 60_000,
-    exactlyOnceIngress: mm?.exactlyOnceIngress ?? false,
+    // Exactly-once ingress defaults ON whenever the session pool is actively
+    // routing real traffic ('live-transfer' / 'rebalance'). Running a live
+    // multi-machine pool WITHOUT the ingress dedupe ledger is an incoherent
+    // configuration: a lifeline retry or a post-restart queue replay
+    // re-EXECUTES the user's message (2026-06-05 incident: one "move to
+    // laptop" ran 4×, producing contradictory "Moving"/"rate-limited"
+    // replies). An explicit `exactlyOnceIngress: false` still wins —
+    // operators can opt out; they just no longer get the dark-by-accident
+    // default while the pool is live. Pre-live stages ('dark'/'shadow')
+    // keep the old dark default.
+    exactlyOnceIngress:
+      mm?.exactlyOnceIngress ??
+      (mm?.sessionPool?.stage === 'live-transfer' || mm?.sessionPool?.stage === 'rebalance'),
     protocolVersion: mm?.protocolVersion ?? SEAMLESSNESS_PROTOCOL_VERSION,
   };
 }

--- a/tests/unit/TransferByNickname.test.ts
+++ b/tests/unit/TransferByNickname.test.ts
@@ -68,3 +68,59 @@ describe('planTransferByNickname (§L4/§L5)', () => {
     expect(p.action).toBe('noop');
   });
 });
+
+// ── Idempotency before the rate limit (2026-06-05 incident) ─────────────
+// A retried/replayed "move to laptop" hit the transfer cooldown and told the
+// user "I can't move this right now (rate-limited)" SECONDS after "Moving this
+// conversation to Laptop" — for one request that had already succeeded. A
+// duplicate of an already-satisfied move must read as "already there", never
+// as a rate-limit rejection.
+describe('planTransferByNickname — duplicate-move idempotency', () => {
+  it('already ON the target within the rate window → noop, NOT rate-limited (the incident)', () => {
+    const p = planTransferByNickname(CMD, state({
+      currentOwnerOf: () => 'm_mini',
+      lastPlacementUpdateAt: () => 999_995, // 5ms ago — inside the 10s window
+      now: () => 1_000_000,
+    }), 's1');
+    expect(p).toMatchObject({ action: 'noop', detail: 'already-on-target' });
+  });
+
+  it('already PINNED to the target (ownership not yet re-placed) within the rate window → noop, NOT rate-limited', () => {
+    const p = planTransferByNickname(CMD, state({
+      currentOwnerOf: () => 'm_ws',          // still owned by the old machine
+      currentPinOf: () => 'm_mini',          // but the pin already points at the target
+      lastPlacementUpdateAt: () => 999_995,
+      now: () => 1_000_000,
+    }), 's1');
+    expect(p).toMatchObject({ action: 'noop', detail: 'already-pinned-to-target' });
+  });
+
+  it('a move to a DIFFERENT machine within the window is still rate-limited (the guard keeps its job)', () => {
+    const p = planTransferByNickname(CMD, state({
+      currentOwnerOf: () => 'm_ws',
+      currentPinOf: () => 'm_ws',            // pinned elsewhere — this is a real move
+      lastPlacementUpdateAt: () => 999_995,
+      now: () => 1_000_000,
+    }), 's1');
+    expect(p).toMatchObject({ action: 'reject', rejectReason: 'rate-limited' });
+  });
+
+  it('without currentPinOf (backward compat) a pin-only duplicate still rate-limits as before', () => {
+    const p = planTransferByNickname(CMD, state({
+      currentOwnerOf: () => 'm_ws',
+      // currentPinOf absent — pre-existing consumers
+      lastPlacementUpdateAt: () => 999_995,
+      now: () => 1_000_000,
+    }), 's1');
+    expect(p).toMatchObject({ action: 'reject', rejectReason: 'rate-limited' });
+  });
+
+  it('already-pinned noop still respects an offline target (no confirm prompt needed — nothing moves)', () => {
+    const p = planTransferByNickname(CMD, state({
+      currentOwnerOf: () => 'm_ws',
+      currentPinOf: () => 'm_mini',
+      isOnline: () => false,
+    }), 's1');
+    expect(p.action).toBe('noop');
+  });
+});

--- a/tests/unit/seamlessnessConfig.test.ts
+++ b/tests/unit/seamlessnessConfig.test.ts
@@ -126,3 +126,28 @@ describe('assertSeamlessnessInvariants', () => {
     );
   });
 });
+
+// ── exactlyOnceIngress ↔ session-pool stage coupling (2026-06-05) ────────
+// Running a LIVE multi-machine pool without the ingress dedupe ledger is the
+// incoherent configuration that let one "move to laptop" execute 4×. The
+// default now follows the pool stage; an explicit value always wins.
+describe('exactlyOnceIngress default coupling', () => {
+  it('defaults OFF with no multiMachine config at all', () => {
+    expect(resolveSeamlessnessConfig(undefined).exactlyOnceIngress).toBe(false);
+  });
+
+  it('defaults OFF while the pool ships dark/shadow', () => {
+    expect(resolveSeamlessnessConfig({ sessionPool: { stage: 'dark' } } as never).exactlyOnceIngress).toBe(false);
+    expect(resolveSeamlessnessConfig({ sessionPool: { stage: 'shadow' } } as never).exactlyOnceIngress).toBe(false);
+  });
+
+  it('defaults ON once the pool routes real traffic (live-transfer / rebalance)', () => {
+    expect(resolveSeamlessnessConfig({ sessionPool: { stage: 'live-transfer' } } as never).exactlyOnceIngress).toBe(true);
+    expect(resolveSeamlessnessConfig({ sessionPool: { stage: 'rebalance' } } as never).exactlyOnceIngress).toBe(true);
+  });
+
+  it('an explicit value always wins over the stage-derived default', () => {
+    expect(resolveSeamlessnessConfig({ exactlyOnceIngress: false, sessionPool: { stage: 'live-transfer' } } as never).exactlyOnceIngress).toBe(false);
+    expect(resolveSeamlessnessConfig({ exactlyOnceIngress: true, sessionPool: { stage: 'dark' } } as never).exactlyOnceIngress).toBe(true);
+  });
+});

--- a/upgrades/next/transfer-idempotency-exactly-once.md
+++ b/upgrades/next/transfer-idempotency-exactly-once.md
@@ -1,0 +1,44 @@
+<!-- bump: patch -->
+
+## What Changed
+
+Two fixes for the 2026-06-05 "move this to the laptop" noise incident, where
+one user message produced contradictory "Moving to Laptop" / "I can't move
+this right now (rate-limited)" replies and executed multiple times.
+
+1. **Idempotent topic transfer.** The transfer planner now recognizes a move
+   request targeting the machine the topic is already on — or already pinned
+   to — BEFORE the rate limit. Duplicates of an already-satisfied move answer
+   "This conversation is already running on X — nothing to move" instead of a
+   rate-limit rejection. The rate limit keeps its real job: damping rapid
+   flip-flops between DIFFERENT machines.
+
+2. **Exactly-once ingress turns on with the pool.** The exactly-once inbound
+   message gate (the dedupe ledger that stops retried/replayed messages from
+   re-executing commands) shipped default-OFF — even on machines whose
+   multi-machine session pool was live. The default is now stage-aware: a pool
+   at `live-transfer` or `rebalance` gets `exactlyOnceIngress` ON
+   automatically. An explicit `multiMachine.exactlyOnceIngress: false` still
+   wins.
+
+## What to Tell Your User
+
+Asking me to move a conversation to a machine it's already on (or repeating
+the request) now gets a calm "already running there" instead of a confusing
+"rate-limited" error. And if my internals retry a message under load, the
+command runs once — not four times.
+
+## Summary of New Capabilities
+
+- Duplicate "move to X" requests no-op as "already there" — never "rate-limited."
+- The transfer planner accepts an optional `currentPinOf` hook (pin-aware idempotency).
+- `exactlyOnceIngress` defaults ON whenever the session pool routes real traffic.
+
+## Evidence
+
+`tests/unit/TransferByNickname.test.ts` (+5, including the verbatim incident
+case: already-on-target inside the rate window → noop) and
+`tests/unit/seamlessnessConfig.test.ts` (+4, stage coupling both ways +
+explicit-override both ways). tsc + lint clean. Production logs
+(2026-06-05T04:20Z double pin, zero `exactly-once` lines on a live-transfer
+pool) are the incident evidence.

--- a/upgrades/side-effects/transfer-idempotency-exactly-once.md
+++ b/upgrades/side-effects/transfer-idempotency-exactly-once.md
@@ -1,0 +1,105 @@
+# Side-Effects Review — Transfer idempotency + exactly-once-when-live
+
+**Version / slug:** `transfer-idempotency-exactly-once`
+**Date:** `2026-06-05`
+**Author:** `echo`
+**Second-pass reviewer:** `not required` (pure-planner reorder + config-resolution default; every boundary side test-pinned)
+
+## Summary of the change
+
+1. `planTransferByNickname`: the already-satisfied checks (`owner === target`,
+   NEW `pin === target` via optional `currentPinOf`) now run BEFORE the rate
+   limit, so a duplicate of an already-satisfied move plans `noop` ("already
+   there") instead of `reject/rate-limited`. The consumer wires `currentPinOf`
+   from `TopicPlacementPinStore` and words the `already-on-target` noop as
+   "already running on X — nothing to move."
+2. `resolveSeamlessnessConfig`: `exactlyOnceIngress` defaults ON when the
+   session pool stage is `live-transfer`/`rebalance` (a live pool without the
+   ingress dedupe ledger re-executes retried/replayed user commands — the
+   2026-06-05 4×-execution incident). Explicit values always win.
+
+## Decision-point inventory
+
+1. `owner === target` → noop vs continue. Both sides pinned (incident test +
+   transfer test).
+2. `pin === target` → noop vs continue; absent `currentPinOf` → old behavior.
+   All three pinned.
+3. Rate-limit window for a real move (different target) → still rejected.
+   Pinned.
+4. Stage-derived `exactlyOnceIngress` default: off (none/dark/shadow), on
+   (live-transfer/rebalance), explicit override both directions. All pinned.
+
+## 1. Over-block
+
+Nothing new is rejected. The planner now rejects strictly LESS (duplicates
+that previously rate-limited now noop). The exactly-once default only
+activates a gate that itself fails open (ledger errors fall through to normal
+routing, per the existing route code).
+
+## 2. Under-block
+
+- The rate limit no longer applies to same-target duplicates — deliberate:
+  re-pinning the same value is idempotent. Rapid same-target spam costs one
+  pin-store write + one "already there" reply per message; the per-topic
+  Telegram traffic itself is bounded upstream.
+- The exactly-once default does NOT retroactively enable the ledger on pools
+  still in dark/shadow — pre-live stages keep the old dark default by design.
+
+## 3. Level-of-abstraction fit
+
+The idempotency fix lives in the pure planner (the single decision function
+both the natural-language path and `POST /pool/transfer` flow through), not in
+the Telegram consumer. The exactly-once coupling lives in config RESOLUTION
+(`resolveSeamlessnessConfig`) — the one place defaults are derived — not in
+the wiring site.
+
+## 4. Signal vs authority compliance
+
+**Required reference:** [docs/signal-vs-authority.md](../../docs/signal-vs-authority.md)
+
+No new blocking authority. The planner reorder converts rejections into
+no-ops. The exactly-once gate it activates was already authority-bearing by
+design (spec §8 G3a) and fails open on any ledger error.
+
+## 5. Interactions
+
+- `noop` consumer behavior unchanged structurally (pin set + release-if-self
+  + message): re-setting an identical pin refreshes `updatedAt`, which can
+  extend the rate window for a SUBSEQUENT different-target move by up to 10s
+  — bounded, harmless.
+- Activating `exactlyOnceIngress` on live pools also activates the
+  reply-marker transport (same flag, existing wiring) — that is the intended
+  pairing per spec §8 G3a.
+- Sentinel intercepts (emergency stop / pause) run BEFORE the ingress gate in
+  the route — unchanged; an emergency stop is never deduped away.
+
+## 6. External surfaces
+
+No new routes, no new config keys (an existing key's DEFAULT becomes
+stage-aware). One user-visible message wording improvement. No migration:
+config absence means "follow the default," which is the point.
+
+## 7. Rollback cost
+
+Trivial. `exactlyOnceIngress: false` is an instant per-agent opt-out without
+deploy; reverting the PR restores both old behaviors. No state, no schema.
+
+## Conclusion
+
+Two small, surgical changes at the correct layers, each killing one half of a
+user-facing incident: duplicates narrated as failures, and duplicates
+executing at all. Strictly less rejection, strictly more dedupe, both
+test-pinned on every side.
+
+## Second-pass review (if required)
+
+Not required — see header.
+
+## Evidence pointers
+
+- `tests/unit/TransferByNickname.test.ts` — 5 new idempotency tests (incl. the
+  verbatim incident case).
+- `tests/unit/seamlessnessConfig.test.ts` — 4 new coupling tests.
+- Production evidence: `logs/server.log` 2026-06-05T04:20:43/04:20:55 double
+  pin + zero `exactly-once` lines; topic 13481 screenshot (Moving →
+  rate-limited → Moving → rate-limited).


### PR DESCRIPTION
## The incident (operator-approved fix — topic 13481, 2026-06-05)

ONE "move this to the laptop" message produced: "Moving this conversation to Laptop" → "I can't move this right now (rate-limited)" → "Moving…" → "rate-limited" again — and the underlying command executed **4 times**. The move had succeeded on the first attempt; everything after was duplicate processing narrated as failure.

## Fix 1 — duplicates of a satisfied move read as "already there", never "rate-limited"

`planTransferByNickname` ran its rate-limit check BEFORE its already-on-target check. Reordered, plus a new optional `currentPinOf` state hook so the pin-landed-but-ownership-not-yet-re-placed window is also recognized as satisfied:

- `owner === target` → `noop/already-on-target` ("This conversation is already running on X — nothing to move")
- `pin === target` → `noop/already-pinned-to-target` ("already pinned to X — it'll keep running there")
- The rate limit keeps its real job: damping rapid flip-flops between DIFFERENT machines

Backward compatible — `currentPinOf` is optional; existing callers keep prior semantics.

## Fix 2 — exactly-once ingress turns on with the pool

The exactly-once inbound gate (`decideIngress` + `MessageProcessingLedger`, spec §8 G3a) is fully built and tested — and shipped default-OFF, even on machines whose session pool runs at `live-transfer`. The CLAUDE.md-documented guarantee ("each inbound message is handled exactly once") was structurally absent exactly where it matters. Production evidence: zero `exactly-once` log lines while one message executed 4×.

`exactlyOnceIngress` now defaults ON when `sessionPool.stage` is `live-transfer`/`rebalance`. Explicit values always win (operator opt-out preserved); `dark`/`shadow` pools keep the old dark default. No migration — resolution-time defaulting.

## Tests

- `tests/unit/TransferByNickname.test.ts` +5 — including the verbatim incident case (already-on-target INSIDE the rate window → noop, not rate-limited), the pin-window case, different-target-still-rate-limited, backward compat, offline+satisfied
- `tests/unit/seamlessnessConfig.test.ts` +4 — stage coupling both ways, explicit override both directions

tsc + lint clean; 32/32 in the touched files.

## Ceremony

- Spec: `docs/specs/transfer-idempotency-exactly-once.md` (parent-principle: Cross-Machine Coherence)
- ELI16: `docs/specs/transfer-idempotency-exactly-once.eli16.md`
- Side-effects: `upgrades/side-effects/transfer-idempotency-exactly-once.md`
- Release fragment: `upgrades/next/transfer-idempotency-exactly-once.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## ELI16

You said "move this to the laptop" once and got back a mess: "Moving to Laptop" … "I can't move this right now (rate-limited)" … "Moving" … "rate-limited" again. Two bugs. First, the move planner checked the anti-spam rate limit BEFORE checking "wait, it's already on that machine" — so when your one message got processed more than once, the repeats were narrated as failures instead of "already there." Now "already there" wins, and the rate limit only applies to real flip-flopping between different machines. Second, the reason your message ran more than once at all: the exactly-once guard that recognizes retried/replayed messages exists and is fully tested — but it shipped switched OFF, and nothing turned it on when the multi-machine pool went live. Now it turns itself ON automatically whenever the pool is actually routing your conversations between machines. You can still opt out explicitly, but you can't end up in the "pool live, guard dark" state by accident anymore.
