### PR TITLE
feat(session): restore build context on respawn

### DIFF
--- a/.instar/instar-dev-traces/2026-06-05T05-24-00-000Z-respawn-build-context-reestablishment.json
+++ b/.instar/instar-dev-traces/2026-06-05T05-24-00-000Z-respawn-build-context-reestablishment.json
@@ -1,0 +1,24 @@
+{
+  "phase": "complete",
+  "slug": "respawn-build-context-reestablishment",
+  "coveredFiles": [
+    "src/commands/server.ts",
+    "src/core/SessionBuildContextStore.ts",
+    "src/core/SessionManager.ts",
+    "src/core/types.ts",
+    "tests/unit/session-build-context-store.test.ts",
+    "tests/integration/session-build-context-respawn.test.ts",
+    "tests/e2e/session-management-e2e.test.ts",
+    "docs/specs/respawn-build-context-reestablishment.md",
+    "docs/specs/respawn-build-context-reestablishment.eli16.md",
+    "upgrades/respawn-build-context-reestablishment.eli16.md",
+    "upgrades/next/respawn-build-context-reestablishment.md",
+    "upgrades/side-effects/respawn-build-context-reestablishment.md"
+  ],
+  "artifactPath": "upgrades/side-effects/respawn-build-context-reestablishment.md",
+  "artifactSha256": "7b9933f03f276e3d756599d811df326bedd7432bbe0b6c128fe665a7fb2d9a83",
+  "specPath": "docs/specs/respawn-build-context-reestablishment.md",
+  "eli16Path": "docs/specs/respawn-build-context-reestablishment.eli16.md",
+  "sideEffectsPath": "upgrades/side-effects/respawn-build-context-reestablishment.md",
+  "createdAt": "2026-06-05T05:55:00Z"
+}

--- a/docs/specs/respawn-build-context-reestablishment.eli16.md
+++ b/docs/specs/respawn-build-context-reestablishment.eli16.md
@@ -1,0 +1,13 @@
+# Respawn build-context restore, in plain English
+
+When an agent is building a fleet PR, it usually works inside a dedicated git worktree. That worktree is where the branch, uncommitted files, test output, installed dependencies, and local build decisions live.
+
+The problem appears when the session dies and is respawned. The conversation can come back through resume, but the shell starts again in the agent's home checkout. The agent remembers the discussion but not the exact build checkout it was standing in. That can lead to a costly false start: checking the wrong repo, reinstalling dependencies, or rerunning gates against a different branch than the one that was actually being built.
+
+This change gives SessionManager one narrow memory for that case: the live working directory reported by the tmux pane. While a session is running, SessionManager samples the pane's current directory and stores it in a small sidecar state record. The write is crash-safe because the state layer writes a temporary file and renames it into place, so a restart cannot leave half-written JSON behind.
+
+On respawn, the behavior stays conservative. The session is still spawned from its normal home. If the saved directory is fresh, still exists, and is under an agent worktree path, the resumed conversation gets a short `[BUILD-CONTEXT RESTORE]` note before the user's continuation message. That note says which worktree the agent had been building in and tells the agent to return there before continuing.
+
+Home-only sessions remain a strict no-op. If a session never left its normal home, if the saved path is stale, if the worktree was removed, or if the feature is not enabled, no restore note is injected. That boundary keeps normal conversational topics unchanged while protecting the dev/build sessions that need this memory.
+
+The feature ships dark for ordinary agents and live only through the development-agent gate unless explicitly enabled. That lets dev agents dogfood the restore behavior before it becomes a broader fleet behavior.

--- a/docs/specs/respawn-build-context-reestablishment.md
+++ b/docs/specs/respawn-build-context-reestablishment.md
@@ -1,0 +1,82 @@
+# Respawn Build-Context Re-establishment
+
+> **Status:** Draft spec (Tier-2). **Tracks:** the #1 mentor-onboarding hardening item — *"a respawned dev session must deterministically re-establish its fleet-PR build checkout."*
+> **Earned from:** the 2026-06-04 server-bounce respawn cascade (a host-load session death + respawn wiped Codey's build context → 6-friction setup slog: wrong repo, stale deps, gate-sha drift, …). Re-grounded 2026-06-05.
+
+## Problem
+
+A dev/build session that is mid-way through building a fleet PR lives in a **git worktree** (e.g. `~/.instar/agents/<agent>/.worktrees/<slug>/`). The agent `cd`s into that worktree *inside its session* (via `instar worktree create` then `cd`, or `git worktree add` directly) and does its build there.
+
+When that session **dies and is respawned** (host-load reap, server bounce, socket drop → bridge respawn), the new session comes back with its build context **wiped**:
+
+- The respawn spawns the tmux session in `this.config.projectDir` (agent-home) — see `SessionManager.spawnInteractiveSession` (`-c this.config.projectDir`). It does **not** restore the worktree the session was building in.
+- `claude --resume <uuid>` restores the **conversation**, not the **shell working directory**. The resumed agent has its chat history but its shell is back in agent-home.
+- The resumed agent does not know it had an active build checkout, so it flails: rebuilds in the wrong repo, symlinks stale `node_modules`, re-runs the gate against a drifted sha, etc.
+
+This is **in-session shell state** (`cwd`) that no layer persists or restores across respawn.
+
+## Non-goals
+
+- Changing where a session is *first* spawned (`spawnSession` correctly resolves a worktree cwd when `WorktreeManager` + `topicId` are wired). This spec is only about **respawn**.
+- Preserving arbitrary in-session shell state (env vars, background jobs). Only the **build checkout** (cwd + the PR/branch it maps to) matters.
+- Normal conversational topic sessions whose home *is* agent-home — they must be unaffected.
+
+## Design
+
+### 1. Track each session's working directory (detection)
+
+The general signal — independent of how the worktree was created — is the session's **live pane cwd**. tmux exposes it: `tmux display-message -p -t <session>: '#{pane_current_path}'`.
+
+A lightweight tracker (mirroring `OutputActivityTracker`'s polling cadence) samples each managed session's `pane_current_path` on its existing monitor tick and persists, per session:
+
+```jsonc
+// state/session-build-context.json  (keyed by tmux session name)
+{
+  "instar-codey-chat-with-codey": {
+    "spawnCwd": "/Users/justin/Documents/Projects/instar-codey",
+    "currentCwd": "/Users/justin/.instar/agents/codey/.worktrees/dashboard-diag",
+    "branch": "codey/dashboard-refresh-diagnostics",   // best-effort: `git -C <cwd> branch --show-current`
+    "updatedAt": 1780633000000
+  }
+}
+```
+
+`branch` is enrichment only (read on change, never required). The load-bearing field is `currentCwd`.
+
+### 2. Re-establish on respawn (the fix)
+
+When `spawnInteractiveSession` respawns a session for which a persisted build-context exists **and** `currentCwd !== spawnCwd` (the agent had navigated away from home into a build checkout), inject a **CONTINUATION preamble** as the first thing the resumed agent sees:
+
+```
+[BUILD-CONTEXT RESTORE] Before this restart you were building in:
+  worktree: <currentCwd>
+  branch:   <branch>
+Your shell is back in <spawnCwd> after the restart — `cd <currentCwd>` before
+continuing your build. Do NOT start over in agent-home; your work is in that worktree.
+```
+
+**Why a CONTINUATION note, not a tmux `-c <currentCwd>`:** for chat-home dev sessions, agent-home *is* the correct tmux home (the worktree is a sub-location the agent navigates to per-build). Spawning the session directly in the worktree would be wrong for a session that juggles multiple worktrees across its life. The note re-establishes the *agent's* intent deterministically while leaving the session's home correct. (A future option: also `cd` for sessions flagged single-worktree, but the note is the safe universal default.)
+
+### 3. Scope guard
+
+Only sessions that are **dev/build sessions** get the restore note. Gate on: a persisted build-context exists AND `currentCwd` is under a `.worktrees/` path (or differs from `spawnCwd` by more than a trivial subdir). Normal topic sessions that never leave agent-home have `currentCwd === spawnCwd` → no note, zero behavior change. This makes the feature a no-op for the common case.
+
+### 4. Staleness
+
+Persist on change only; treat a context older than `maxAgeMs` (default 6h) as stale and skip the note (the worktree may be long gone). On respawn, verify `fs.existsSync(currentCwd)` before injecting — a removed/merged-and-reaped worktree yields no note (and the agent is correctly back in home).
+
+## Testing (3-tier)
+
+- **Unit:** the cwd-diff/scope-guard logic (home==current → no note; under-`.worktrees` → note; stale → skip; missing dir → skip; branch enrichment best-effort/never throws).
+- **Integration:** `POST`/respawn path produces the CONTINUATION preamble for a session with a persisted worktree context, and omits it for a home-only session — full wiring (tracker writes → respawn reads → note injected).
+- **E2E:** a spawned session, `cd` into a fixture worktree, kill + respawn → assert the resumed session's first injected text contains `[BUILD-CONTEXT RESTORE]` with the right path; a home-only control session respawns with no note.
+
+## Open design questions (for operator/overseer review before build)
+
+1. **Persist location:** standalone `state/session-build-context.json` sidecar (this spec) vs. extending the `Session` record (types.ts:42). Sidecar keeps the hot `Session` shape unchanged and is crash-safe to write independently — recommended.
+2. **Branch/PR enrichment:** is `currentCwd` alone sufficient (agent re-derives branch/PR once it `cd`s back), or do we also surface branch + PR# in the note? Leaning: include branch (cheap, one `git` call), skip PR# (not reliably knowable from cwd).
+3. **Migration parity:** new sidecar + new respawn-path behavior — gate behind `developmentAgent` first (dark on fleet, live on echo/codey) per the standard, since it changes respawn output. No `migrateConfig` needed (no config); the tracker + respawn hook ship in code.
+
+## Blast radius
+
+Touches `SessionManager` (respawn path + a tracker hook) — core infrastructure. The scope guard (§3) makes it a strict no-op for non-build sessions, so the risk is bounded to dev/build sessions, which are exactly the ones this helps. Ship dark behind `developmentAgent`, dogfood on echo + codey, then graduate.

--- a/docs/specs/respawn-build-context-reestablishment.md
+++ b/docs/specs/respawn-build-context-reestablishment.md
@@ -1,6 +1,15 @@
+---
+status: approved
+parent-principle: "Structure beats Willpower"
+review-convergence: "operator green-light after plan review, Telegram topic 1052, 2026-06-05T05:12:00Z"
+approved: true
+approved-by: "Justin via Telegram topic 1052"
+approved-at: "2026-06-05T05:12:00Z"
+---
+
 # Respawn Build-Context Re-establishment
 
-> **Status:** Draft spec (Tier-2). **Tracks:** the #1 mentor-onboarding hardening item — *"a respawned dev session must deterministically re-establish its fleet-PR build checkout."*
+> **Status:** Approved spec (Tier-2). **Tracks:** the #1 mentor-onboarding hardening item — *"a respawned dev session must deterministically re-establish its fleet-PR build checkout."*
 > **Earned from:** the 2026-06-04 server-bounce respawn cascade (a host-load session death + respawn wiped Codey's build context → 6-friction setup slog: wrong repo, stale deps, gate-sha drift, …). Re-grounded 2026-06-05.
 
 ## Problem

--- a/src/commands/server.ts
+++ b/src/commands/server.ts
@@ -2818,10 +2818,15 @@ export async function startServer(options: StartOptions): Promise<void> {
     const codexThreadlineMcp = config.threadline
       ? resolveThreadlineMcpEntry(config.sessions.projectDir, config.stateDir, config.projectName)
       : undefined;
-    const sessionManager = new SessionManager(
-      codexThreadlineMcp ? { ...config.sessions, codexThreadlineMcp } : config.sessions,
-      state,
-    );
+    const sessionManagerConfig = {
+      ...config.sessions,
+      ...(codexThreadlineMcp ? { codexThreadlineMcp } : {}),
+      respawnBuildContext: {
+        ...(config.sessions.respawnBuildContext ?? {}),
+        enabled: config.sessions.respawnBuildContext?.enabled ?? !!config.developmentAgent,
+      },
+    };
+    const sessionManager = new SessionManager(sessionManagerConfig, state);
 
     // Input Guard is constructed later (after sharedIntelligence is available)
     // so the topic coherence reviewer can route through the IntelligenceProvider

--- a/src/core/SessionBuildContextStore.ts
+++ b/src/core/SessionBuildContextStore.ts
@@ -1,0 +1,131 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { execFileSync } from 'node:child_process';
+import type { StateManager } from './StateManager.js';
+
+const STATE_KEY = 'session-build-context';
+export const DEFAULT_BUILD_CONTEXT_MAX_AGE_MS = 6 * 60 * 60 * 1000;
+
+export interface SessionBuildContextEntry {
+  spawnCwd: string;
+  currentCwd: string;
+  branch?: string;
+  updatedAt: number;
+}
+
+export type SessionBuildContextState = Record<string, SessionBuildContextEntry>;
+
+export interface SessionBuildContextRestore {
+  entry: SessionBuildContextEntry;
+  note: string;
+}
+
+export function isEligibleBuildContextCwd(spawnCwd: string, currentCwd: string): boolean {
+  if (!spawnCwd || !currentCwd) return false;
+  const spawn = path.resolve(spawnCwd);
+  const current = path.resolve(currentCwd);
+  if (spawn === current) return false;
+  return current.split(path.sep).includes('.worktrees');
+}
+
+export function formatBuildContextRestoreNote(entry: SessionBuildContextEntry): string {
+  const branchLine = entry.branch ? `  branch:   ${entry.branch}\n` : '';
+  return [
+    '[BUILD-CONTEXT RESTORE] Before this restart you were building in:',
+    `  worktree: ${entry.currentCwd}`,
+    branchLine ? branchLine.trimEnd() : null,
+    `Your shell is back in ${entry.spawnCwd} after the restart — cd ${entry.currentCwd} before continuing your build.`,
+    'Do NOT start over in agent-home; your work is in that worktree.',
+  ].filter((line): line is string => line != null).join('\n');
+}
+
+export class SessionBuildContextStore {
+  constructor(
+    private readonly state: StateManager,
+    private readonly opts: {
+      now?: () => number;
+      execFileSync?: typeof execFileSync;
+      maxAgeMs?: number;
+    } = {},
+  ) {}
+
+  record(tmuxSession: string, spawnCwd: string, currentCwd: string): void {
+    const now = this.now();
+    const all = this.readAll();
+    const prior = all[tmuxSession];
+    const normalizedSpawn = path.resolve(spawnCwd);
+    const normalizedCurrent = path.resolve(currentCwd);
+
+    if (prior?.spawnCwd === normalizedSpawn && prior.currentCwd === normalizedCurrent) {
+      return;
+    }
+
+    const branch = this.readBranch(normalizedCurrent);
+    all[tmuxSession] = {
+      spawnCwd: normalizedSpawn,
+      currentCwd: normalizedCurrent,
+      ...(branch ? { branch } : {}),
+      updatedAt: now,
+    };
+    this.writeAll(all);
+  }
+
+  getRestore(tmuxSession: string): SessionBuildContextRestore | null {
+    const entry = this.readAll()[tmuxSession];
+    if (!entry) return null;
+    if (!isEligibleBuildContextCwd(entry.spawnCwd, entry.currentCwd)) return null;
+    if (this.now() - entry.updatedAt > this.maxAgeMs()) return null;
+    if (!fs.existsSync(entry.currentCwd)) return null;
+    return { entry, note: formatBuildContextRestoreNote(entry) };
+  }
+
+  readAll(): SessionBuildContextState {
+    const raw = this.state.get<unknown>(STATE_KEY);
+    if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return {};
+    const out: SessionBuildContextState = {};
+    for (const [key, value] of Object.entries(raw as Record<string, unknown>)) {
+      if (!value || typeof value !== 'object' || Array.isArray(value)) continue;
+      const entry = value as Partial<SessionBuildContextEntry>;
+      if (
+        typeof entry.spawnCwd !== 'string'
+        || typeof entry.currentCwd !== 'string'
+        || typeof entry.updatedAt !== 'number'
+      ) continue;
+      out[key] = {
+        spawnCwd: entry.spawnCwd,
+        currentCwd: entry.currentCwd,
+        ...(typeof entry.branch === 'string' && entry.branch.trim() ? { branch: entry.branch } : {}),
+        updatedAt: entry.updatedAt,
+      };
+    }
+    return out;
+  }
+
+  private writeAll(state: SessionBuildContextState): void {
+    this.state.set(STATE_KEY, state);
+  }
+
+  private readBranch(cwd: string): string | null {
+    if (!fs.existsSync(cwd)) return null;
+    try {
+      const out = (this.opts.execFileSync ?? execFileSync)(
+        'git',
+        ['-C', cwd, 'branch', '--show-current'],
+        { encoding: 'utf-8', timeout: 2000, stdio: ['ignore', 'pipe', 'ignore'] },
+      );
+      const branch = String(out).trim();
+      return branch || null;
+    } catch {
+      // @silent-fallback-ok — branch name is best-effort enrichment; cwd restore still works without it.
+      return null;
+    }
+  }
+
+  private now(): number {
+    return this.opts.now?.() ?? Date.now();
+  }
+
+  private maxAgeMs(): number {
+    return this.opts.maxAgeMs ?? DEFAULT_BUILD_CONTEXT_MAX_AGE_MS;
+  }
+}

--- a/src/core/SessionManager.ts
+++ b/src/core/SessionManager.ts
@@ -69,6 +69,7 @@ import { StateManager } from './StateManager.js';
 import { buildInjectionTag } from '../types/pipeline.js';
 import { sanitizeSenderName, sanitizeTopicName } from '../utils/sanitize.js';
 import { getTelegramInboundDir } from '../messaging/shared/telegramInboundFiles.js';
+import { SessionBuildContextStore } from './SessionBuildContextStore.js';
 
 /** Absolute maximum session duration (4 hours) — safety net for sessions without explicit timeout */
 const DEFAULT_MAX_DURATION_MINUTES = 240;
@@ -311,6 +312,7 @@ export class SessionManager extends EventEmitter {
 
   /** Worktree manager — when set, spawnSession resolves an isolated worktree per topic. */
   private worktreeManager: import('./WorktreeManager.js').WorktreeManager | null = null;
+  private buildContextStore: SessionBuildContextStore | null = null;
 
   /** Per-session shim directory root (one subdir per session). Used for K9 mandatory shim. */
   private shimRoot: string | null = null;
@@ -319,6 +321,11 @@ export class SessionManager extends EventEmitter {
     super();
     this.config = config;
     this.state = state;
+    if (config.respawnBuildContext?.enabled) {
+      this.buildContextStore = new SessionBuildContextStore(state, {
+        maxAgeMs: config.respawnBuildContext.maxAgeMs,
+      });
+    }
   }
 
   /** Lazily-constructed tri-state liveness oracle (UNIFIED-SESSION-LIFECYCLE §P1).
@@ -836,6 +843,8 @@ rm()  { "${shimRunner}" rm  "$@"; }
           this.emit('sessionComplete', session);
           continue;
         }
+
+        this.recordBuildContext(session.tmuxSession);
 
         // Check for completion patterns even while session appears alive
         // (catches sessions where Claude finished but tmux is still open)
@@ -1742,6 +1751,43 @@ rm()  { "${shimRunner}" rm  "$@"; }
     }
   }
 
+  private currentPaneCwd(tmuxSession: string): string | null {
+    try {
+      const out = execFileSync(
+        this.config.tmuxPath,
+        ['display-message', '-p', '-t', `=${tmuxSession}:`, '#{pane_current_path}'],
+        { encoding: 'utf-8', timeout: 2000 },
+      ).trim();
+      return out || null;
+    } catch {
+      // @silent-fallback-ok — cwd tracking is best-effort enrichment for respawn recovery
+      return null;
+    }
+  }
+
+  private recordBuildContext(tmuxSession: string): void {
+    if (!this.buildContextStore) return;
+    const currentCwd = this.currentPaneCwd(tmuxSession);
+    if (!currentCwd) return;
+    try {
+      this.buildContextStore.record(tmuxSession, this.config.projectDir, currentCwd);
+    } catch (err) {
+      console.warn(`[SessionManager] Failed to record build context for "${tmuxSession}": ${err instanceof Error ? err.message : String(err)}`);
+    }
+  }
+
+  private withBuildContextRestoreNote(
+    tmuxSession: string,
+    initialMessage: string | undefined,
+    resumeSessionId: string | undefined,
+  ): string | undefined {
+    if (!resumeSessionId || !this.buildContextStore) return initialMessage;
+    const restore = this.buildContextStore.getRestore(tmuxSession);
+    if (!restore) return initialMessage;
+    console.log(`[SessionManager] Restoring build context for "${tmuxSession}" from ${restore.entry.currentCwd}`);
+    return [restore.note, initialMessage].filter(Boolean).join('\n\n');
+  }
+
   /**
    * Resolve the IntelligenceFramework a tmux session was spawned under
    * by reading the INSTAR_FRAMEWORK env we set in its tmux env block.
@@ -2165,6 +2211,12 @@ rm()  { "${shimRunner}" rm  "$@"; }
       return tmuxSession;
     }
 
+    const effectiveInitialMessage = this.withBuildContextRestoreNote(
+      tmuxSession,
+      initialMessage,
+      options?.resumeSessionId,
+    );
+
     // User-initiated sessions bypass the maxSessions limit entirely.
     // The user should NEVER be blocked from interacting with their agent
     // because scheduled jobs filled all slots. maxSessions only constrains
@@ -2314,7 +2366,7 @@ rm()  { "${shimRunner}" rm  "$@"; }
       // account default).
       framework,
       ...(resolveModelForFramework(framework, launchDefaultModel) ? { model: resolveModelForFramework(framework, launchDefaultModel) } : {}),
-      prompt: initialMessage,
+      prompt: effectiveInitialMessage,
       maxDurationMinutes: this.effectiveMaxDurationMinutes,
     };
     this.state.saveSession(session);
@@ -2325,8 +2377,8 @@ rm()  { "${shimRunner}" rm  "$@"; }
     // Fresh sessions also get a generous timeout (90s) to handle slow API auth,
     // large CLAUDE.md loading, and session-start hook execution.
     const readyTimeout = options?.resumeSessionId ? 120_000 : 90_000;
-    if (initialMessage) {
-      this.handleReadyAndInject(tmuxSession, name, initialMessage, readyTimeout, options).catch((err) => {
+    if (effectiveInitialMessage) {
+      this.handleReadyAndInject(tmuxSession, name, effectiveInitialMessage, readyTimeout, options).catch((err) => {
         console.error(`[SessionManager] Error during ready-and-inject for "${tmuxSession}": ${err}`);
       });
     }

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -164,6 +164,17 @@ export interface SessionManagerConfig {
   /** Server port — used to construct INSTAR_SERVER_URL for HTTP hooks */
   port?: number;
   /**
+   * Respawn build-context restore (mentor-onboarding hardening).
+   * When enabled, SessionManager records each live session's tmux pane cwd and,
+   * on a resumed respawn, prepends a continuation note when the session had
+   * navigated into an agent worktree. Undefined stays dark unless server boot
+   * resolves it through the developmentAgent gate.
+   */
+  respawnBuildContext?: {
+    enabled?: boolean;
+    maxAgeMs?: number;
+  };
+  /**
    * Per-provider credentials. Keys are provider ids
    * (e.g. 'anthropic', 'openai', 'google'). Values declare the
    * credential kind and value, plus an optional base-URL override

--- a/tests/e2e/session-management-e2e.test.ts
+++ b/tests/e2e/session-management-e2e.test.ts
@@ -70,6 +70,26 @@ echo "Session ended"
   return scriptPath;
 }
 
+function createMockClaudeInteractiveInCwd(dir: string, cwd: string): string {
+  const scriptPath = path.join(dir, `mock-claude-cwd-${randomSuffix()}.sh`);
+  fs.writeFileSync(scriptPath, `#!/bin/bash
+cd "${cwd}"
+echo "────────────────────────────────────────"
+echo "❯ "
+echo "────────────────────────────────────────"
+echo "  ⏵⏵ bypass permissions on (shift+tab to cycle)                    ◐ medium · /effort"
+read -r INPUT
+echo "Received: $INPUT"
+sleep 10
+`);
+  fs.chmodSync(scriptPath, '755');
+  return scriptPath;
+}
+
+function randomSuffix(): string {
+  return Math.random().toString(36).slice(2, 8);
+}
+
 /**
  * Create a mock claude that takes a long time to show the prompt.
  * Simulates slow API auth or large CLAUDE.md loading.
@@ -735,6 +755,64 @@ describeMaybe('Session Management E2E', () => {
         return (out || '').includes('CONTINUATION');
       }, 15_000);
     });
+
+    it('restores a worktree build context on respawn while keeping home-only respawn a no-op', async () => {
+      const worktree = path.join(project.dir, '.worktrees', 'respawn-build');
+      fs.mkdirSync(worktree, { recursive: true });
+
+      const buildClaudePath = createMockClaudeInteractiveInCwd(project.dir, worktree);
+      const buildSm = createManager(project, buildClaudePath, {
+        respawnBuildContext: { enabled: true, maxAgeMs: 60_000 },
+      });
+      managers.push(buildSm);
+
+      const buildName = `${TMUX_PREFIX}build-ctx`;
+      const buildTmux = await buildSm.spawnInteractiveSession(undefined, buildName);
+      await waitFor(() => buildSm.isSessionAlive(buildTmux), 10_000);
+      const buildSession = project.state.listSessions({ status: 'running' }).find(s => s.tmuxSession === buildTmux)!;
+      buildSession.startedAt = new Date(Date.now() - 20_000).toISOString();
+      project.state.saveSession(buildSession);
+
+      await (buildSm as any).monitorTick();
+      execFileSync(tmuxPath!, ['kill-session', '-t', `=${buildTmux}`], { stdio: 'ignore' });
+
+      await buildSm.spawnInteractiveSession('CONTINUATION — resume build', buildName, {
+        telegramTopicId: 1052,
+        resumeSessionId: '550e8400-e29b-41d4-a716-446655440000',
+      });
+
+      await waitFor(() => {
+        const out = buildSm.captureOutput(buildTmux, 80) ?? '';
+        return out.includes('[BUILD-CONTEXT RESTORE]') && out.includes(worktree);
+      }, 20_000);
+
+      const homeClaudePath = createMockClaudeInteractiveInCwd(project.dir, project.dir);
+      const homeSm = createManager(project, homeClaudePath, {
+        respawnBuildContext: { enabled: true, maxAgeMs: 60_000 },
+      });
+      managers.push(homeSm);
+
+      const homeName = `${TMUX_PREFIX}home-ctx`;
+      const homeTmux = await homeSm.spawnInteractiveSession(undefined, homeName);
+      await waitFor(() => homeSm.isSessionAlive(homeTmux), 10_000);
+      const homeSession = project.state.listSessions({ status: 'running' }).find(s => s.tmuxSession === homeTmux)!;
+      homeSession.startedAt = new Date(Date.now() - 20_000).toISOString();
+      project.state.saveSession(homeSession);
+
+      await (homeSm as any).monitorTick();
+      execFileSync(tmuxPath!, ['kill-session', '-t', `=${homeTmux}`], { stdio: 'ignore' });
+
+      await homeSm.spawnInteractiveSession('CONTINUATION — home only', homeName, {
+        telegramTopicId: 1053,
+        resumeSessionId: '650e8400-e29b-41d4-a716-446655440000',
+      });
+
+      await waitFor(() => {
+        const out = homeSm.captureOutput(homeTmux, 80) ?? '';
+        return out.includes('CONTINUATION — home only');
+      }, 20_000);
+      expect(homeSm.captureOutput(homeTmux, 80)).not.toContain('[BUILD-CONTEXT RESTORE]');
+    }, 40_000);
   });
 
   // ── Feature: Session State Persistence ────────────────────────────

--- a/tests/integration/session-build-context-respawn.test.ts
+++ b/tests/integration/session-build-context-respawn.test.ts
@@ -1,0 +1,158 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+
+const tmuxSessions = new Set<string>();
+const paneCwds = new Map<string, string>();
+
+vi.mock('node:child_process', () => ({
+  execFileSync: vi.fn().mockImplementation((cmd: string, args?: string[]) => {
+    if (!args) return '';
+    if (cmd === 'git') return 'codey/respawn-build-context\n';
+    if (args[0] === 'has-session') {
+      const target = args[2]?.replace(/^=/, '');
+      if (!target || !tmuxSessions.has(target)) throw new Error('not found');
+      return '';
+    }
+    if (args[0] === 'new-session') {
+      const sIdx = args.indexOf('-s');
+      const cIdx = args.indexOf('-c');
+      const name = sIdx >= 0 ? args[sIdx + 1] : '';
+      if (name) {
+        tmuxSessions.add(name);
+        paneCwds.set(name, cIdx >= 0 ? args[cIdx + 1] : process.cwd());
+      }
+      return '';
+    }
+    if (args[0] === 'kill-session') {
+      const target = args[2]?.replace(/^=/, '');
+      if (target) {
+        tmuxSessions.delete(target);
+        paneCwds.delete(target);
+      }
+      return '';
+    }
+    if (args[0] === 'display-message') {
+      const targetArg = args.find(a => a.startsWith('=')) ?? '';
+      const target = targetArg.replace(/^=/, '').replace(/:$/, '');
+      const format = args[args.length - 1];
+      if (format === '#{pane_current_path}') return `${paneCwds.get(target) ?? process.cwd()}\n`;
+      return 'claude||claude';
+    }
+    if (args[0] === 'show-environment') return 'INSTAR_FRAMEWORK=claude-code\n';
+    if (args[0] === 'capture-pane') return '❯ ';
+    if (args[0] === 'send-keys') return '';
+    if (args[0] === 'set-option') return '';
+    return '';
+  }),
+  execFile: vi.fn().mockImplementation(
+    (_cmd: string, args: string[], _opts: unknown, cb?: (err: Error | null, result: { stdout: string; stderr: string }) => void) => {
+      if (typeof _opts === 'function') cb = _opts as typeof cb;
+      if (args[0] === 'list-sessions') {
+        cb?.(null, { stdout: `${[...tmuxSessions].join('\n')}\n`, stderr: '' });
+        return;
+      }
+      cb?.(null, { stdout: '', stderr: '' });
+    },
+  ),
+}));
+
+import { SessionManager } from '../../src/core/SessionManager.js';
+import { StateManager } from '../../src/core/StateManager.js';
+import type { Session } from '../../src/core/types.js';
+
+describe('Session build-context respawn restore (integration)', () => {
+  let tmpDir: string;
+  let projectDir: string;
+  let stateDir: string;
+  let state: StateManager;
+  let sm: SessionManager;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'session-build-context-respawn-'));
+    projectDir = path.join(tmpDir, 'agent-home');
+    stateDir = path.join(tmpDir, '.instar');
+    fs.mkdirSync(projectDir, { recursive: true });
+    fs.mkdirSync(stateDir, { recursive: true });
+    state = new StateManager(stateDir);
+    sm = new SessionManager({
+      tmuxPath: '/usr/bin/tmux',
+      claudePath: '/usr/local/bin/claude',
+      projectDir,
+      maxSessions: 3,
+      protectedSessions: [],
+      completionPatterns: ['Session complete'],
+      port: 4044,
+      respawnBuildContext: { enabled: true, maxAgeMs: 60_000 },
+    }, state);
+    tmuxSessions.clear();
+    paneCwds.clear();
+  });
+
+  afterEach(() => {
+    sm.stopMonitoring();
+    vi.clearAllTimers();
+    SafeFsExecutor.safeRmSync(tmpDir, {
+      recursive: true,
+      force: true,
+      operation: 'tests/integration/session-build-context-respawn.test.ts:afterEach',
+    });
+  });
+
+  it('records a live worktree cwd and prepends a restore note on resumed respawn', async () => {
+    const worktree = path.join(projectDir, '.worktrees', 'build-one');
+    fs.mkdirSync(worktree, { recursive: true });
+    const tmuxSession = `${path.basename(projectDir)}-topic-1052`;
+
+    tmuxSessions.add(tmuxSession);
+    paneCwds.set(tmuxSession, worktree);
+    state.saveSession({
+      id: 's1',
+      name: 'topic-1052',
+      status: 'running',
+      tmuxSession,
+      startedAt: new Date(Date.now() - 20_000).toISOString(),
+    } as Session);
+
+    await (sm as any).monitorTick();
+    tmuxSessions.delete(tmuxSession);
+
+    await sm.spawnInteractiveSession('CONTINUATION — resume this topic', 'topic-1052', {
+      telegramTopicId: 1052,
+      resumeSessionId: '550e8400-e29b-41d4-a716-446655440000',
+    });
+
+    const respawned = state.listSessions({ status: 'running' }).find(s => s.tmuxSession === tmuxSession);
+    expect(respawned?.prompt).toContain('[BUILD-CONTEXT RESTORE]');
+    expect(respawned?.prompt).toContain(worktree);
+    expect(respawned?.prompt).toContain('branch:   codey/respawn-build-context');
+    expect(respawned?.prompt).toContain('CONTINUATION — resume this topic');
+  });
+
+  it('omits the restore note for a home-only session in the same respawn path', async () => {
+    const tmuxSession = `${path.basename(projectDir)}-topic-home`;
+    tmuxSessions.add(tmuxSession);
+    paneCwds.set(tmuxSession, projectDir);
+    state.saveSession({
+      id: 's2',
+      name: 'topic-home',
+      status: 'running',
+      tmuxSession,
+      startedAt: new Date(Date.now() - 20_000).toISOString(),
+    } as Session);
+
+    await (sm as any).monitorTick();
+    tmuxSessions.delete(tmuxSession);
+
+    await sm.spawnInteractiveSession('CONTINUATION — home only', 'topic-home', {
+      telegramTopicId: 1053,
+      resumeSessionId: '650e8400-e29b-41d4-a716-446655440000',
+    });
+
+    const respawned = state.listSessions({ status: 'running' }).find(s => s.tmuxSession === tmuxSession);
+    expect(respawned?.prompt).not.toContain('[BUILD-CONTEXT RESTORE]');
+    expect(respawned?.prompt).toBe('CONTINUATION — home only');
+  });
+});

--- a/tests/unit/session-build-context-store.test.ts
+++ b/tests/unit/session-build-context-store.test.ts
@@ -1,0 +1,117 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { StateManager } from '../../src/core/StateManager.js';
+import {
+  formatBuildContextRestoreNote,
+  isEligibleBuildContextCwd,
+  SessionBuildContextStore,
+} from '../../src/core/SessionBuildContextStore.js';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+
+describe('SessionBuildContextStore', () => {
+  let tmpDir: string;
+  let state: StateManager;
+  let now = 1_000_000;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'session-build-context-'));
+    state = new StateManager(tmpDir);
+    now = 1_000_000;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    SafeFsExecutor.safeRmSync(tmpDir, {
+      recursive: true,
+      force: true,
+      operation: 'tests/unit/session-build-context-store.test.ts:afterEach',
+    });
+  });
+
+  it('treats home-only sessions as ineligible and worktree cwd sessions as eligible', () => {
+    const home = path.join(tmpDir, 'agent-home');
+    const worktree = path.join(home, '.worktrees', 'feature');
+    const trivialSubdir = path.join(home, 'docs');
+
+    expect(isEligibleBuildContextCwd(home, home)).toBe(false);
+    expect(isEligibleBuildContextCwd(home, trivialSubdir)).toBe(false);
+    expect(isEligibleBuildContextCwd(home, worktree)).toBe(true);
+  });
+
+  it('records branch enrichment best-effort and returns a restore note for fresh existing worktrees', () => {
+    const home = path.join(tmpDir, 'agent-home');
+    const worktree = path.join(home, '.worktrees', 'feature');
+    fs.mkdirSync(worktree, { recursive: true });
+
+    const store = new SessionBuildContextStore(state, {
+      now: () => now,
+      execFileSync: vi.fn(() => 'codey/feature\n') as any,
+    });
+
+    store.record('agent-topic', home, worktree);
+    const restore = store.getRestore('agent-topic');
+
+    expect(restore?.entry).toMatchObject({
+      spawnCwd: home,
+      currentCwd: worktree,
+      branch: 'codey/feature',
+      updatedAt: now,
+    });
+    expect(restore?.note).toContain('[BUILD-CONTEXT RESTORE]');
+    expect(restore?.note).toContain(worktree);
+    expect(restore?.note).toContain('branch:   codey/feature');
+  });
+
+  it('skips stale, missing, and home-only contexts', () => {
+    const home = path.join(tmpDir, 'agent-home');
+    const worktree = path.join(home, '.worktrees', 'feature');
+    fs.mkdirSync(worktree, { recursive: true });
+
+    const store = new SessionBuildContextStore(state, {
+      now: () => now,
+      maxAgeMs: 100,
+      execFileSync: vi.fn(() => '') as any,
+    });
+
+    store.record('stale', home, worktree);
+    now += 101;
+    expect(store.getRestore('stale')).toBeNull();
+
+    now = 2_000_000;
+    store.record('missing', home, path.join(home, '.worktrees', 'gone'));
+    expect(store.getRestore('missing')).toBeNull();
+
+    store.record('home', home, home);
+    expect(store.getRestore('home')).toBeNull();
+  });
+
+  it('writes through the crash-safe state sidecar path', () => {
+    const renameSpy = vi.spyOn(fs, 'renameSync');
+    const home = path.join(tmpDir, 'agent-home');
+    const worktree = path.join(home, '.worktrees', 'feature');
+    fs.mkdirSync(worktree, { recursive: true });
+
+    const store = new SessionBuildContextStore(state, {
+      now: () => now,
+      execFileSync: vi.fn(() => '') as any,
+    });
+    store.record('agent-topic', home, worktree);
+
+    const target = path.join(tmpDir, 'state', 'session-build-context.json');
+    expect(fs.existsSync(target)).toBe(true);
+    expect(renameSpy.mock.calls.some(([, to]) => to === target)).toBe(true);
+  });
+
+  it('formats restore notes without a branch line when branch enrichment is absent', () => {
+    const note = formatBuildContextRestoreNote({
+      spawnCwd: '/agent-home',
+      currentCwd: '/agent-home/.worktrees/build',
+      updatedAt: now,
+    });
+
+    expect(note).toContain('[BUILD-CONTEXT RESTORE]');
+    expect(note).not.toContain('branch:');
+  });
+});

--- a/upgrades/next/respawn-build-context-reestablishment.md
+++ b/upgrades/next/respawn-build-context-reestablishment.md
@@ -1,0 +1,15 @@
+# Respawn build-context restore
+
+## What to Tell Your User
+
+Developer-agent respawns can now re-surface the worktree checkout they were building in before the restart. Normal home-only conversations are unchanged.
+
+## Summary of New Capabilities
+
+- SessionManager can record the live pane working directory for running sessions when the development-agent-gated feature is enabled.
+- A resumed respawn receives a `[BUILD-CONTEXT RESTORE]` continuation note only when the prior cwd was a fresh, existing agent worktree.
+- The sidecar state write is crash-safe through the state layer's temp-file plus rename path.
+
+## What Changed
+
+SessionManager now samples the live tmux pane cwd for enabled development-agent sessions and stores it in a crash-safe sidecar. Resume spawns prepend a restore note only for fresh, existing `.worktrees` paths; home-only sessions remain a no-op.

--- a/upgrades/respawn-build-context-reestablishment.eli16.md
+++ b/upgrades/respawn-build-context-reestablishment.eli16.md
@@ -1,0 +1,5 @@
+# Respawn build-context restore
+
+Developer agents can now remember the build checkout they were using before a respawn. When the feature is enabled and a resumed session had been working inside an agent worktree, the resumed conversation starts with a `[BUILD-CONTEXT RESTORE]` note pointing back to that worktree.
+
+This is meant for fleet PR build sessions that die or restart mid-task. It does not move the tmux session's home directory, and it does nothing for normal home-only conversations. Stale or removed worktrees are skipped.

--- a/upgrades/side-effects/respawn-build-context-reestablishment.md
+++ b/upgrades/side-effects/respawn-build-context-reestablishment.md
@@ -1,0 +1,81 @@
+# Side-Effects Review — Respawn build-context re-establishment
+
+**Version / slug:** `respawn-build-context-reestablishment`
+**Date:** `2026-06-04`
+**Author:** `instar-codey`
+**Second-pass reviewer:** `instar-codey second-pass checklist`
+
+## Summary of the change
+
+This change hardens the interactive SessionManager respawn path for developer build sessions. A new sidecar store records each running session's live tmux pane working directory, using the generic state layer's temp-file-plus-rename atomic write. When a resumed interactive session has a fresh saved cwd under an agent worktree, SessionManager prepends a `[BUILD-CONTEXT RESTORE]` continuation note to the resumed message. Normal home-only sessions, stale records, missing worktrees, and non-enabled agents receive no note.
+
+The feature is dark by default for normal agents. Server boot resolves the session-level feature flag as an explicit override if present, otherwise the standard development-agent gate.
+
+## Decision-point inventory
+
+- `SessionBuildContextStore` — add — owns sidecar state validation, crash-safe persistence through StateManager, cwd eligibility, staleness, missing-path checks, branch enrichment, and restore-note formatting.
+- `SessionManager.monitorTick` — modified — records pane cwd after liveness is confirmed, without changing session lifecycle decisions.
+- `SessionManager.spawnInteractiveSession` — modified — prepends a restore note only for resume spawns with an eligible saved worktree context.
+- `server` startup wiring — modified — resolves the feature dark by default and live for development agents unless explicitly overridden.
+- Session-management e2e — modified — proves a real tmux pane under a fixture worktree gets the restore note while a home-only control stays unchanged.
+
+## 1. Over-block
+
+The restore can skip a legitimate build context if the tmux cwd is not under a `.worktrees` path. That is intentional. The spec's blast-radius guard is more important than restoring every possible hand-navigated directory. Agents can still recover manually from conversation context; the automated note is limited to the known build-worktree convention.
+
+The restore can also skip when the sidecar is stale or the worktree directory was removed. That prevents a respawn from sending the agent back into a deleted or long-finished checkout.
+
+## 2. Under-block
+
+The sidecar records cwd for running sessions when the feature is enabled, including home-only sessions. Home-only records are not eligible for restore, so this is additional local state but not additional behavior. The record contains local paths and an optional branch name; it does not include prompt content or credentials.
+
+The branch name is best-effort enrichment. If Git cannot read the branch, the restore note still works with the worktree path alone. Failure to read branch never blocks monitoring or respawn.
+
+## 3. Level-of-abstraction fit
+
+SessionManager owns tmux lifecycle, liveness checks, interactive respawn, and initial-message injection, so it is the correct place to sample pane cwd and prepend the resume note. The sidecar store keeps persistence and eligibility logic out of the large SessionManager class and makes the boundary unit-testable.
+
+The change does not force tmux to spawn inside the worktree. That matches the design spec: the session home remains stable, and the resumed agent receives deterministic instruction to return to the build checkout only when appropriate.
+
+## 4. Signal vs authority compliance
+
+Required reference: [docs/signal-vs-authority.md](../../docs/signal-vs-authority.md)
+
+- [x] Not applicable to conversational/product judgment — this is structural session lifecycle restoration.
+
+The cwd sample is a mechanical tmux fact. The restore decision is a deterministic filesystem/scope guard: fresh, existing, different from spawn cwd, and under a worktree path. It does not judge user intent or message meaning.
+
+## 5. Interactions
+
+- **Shadowing:** The restore note is prepended before the normal initial-message injection. Existing InputGuard and injection mechanics still handle the resulting message through the same path.
+- **Double-fire:** The note is computed once per resumed spawn. Reusing an already-live tmux session does not inject a restore note.
+- **Races:** A worktree can be removed between sidecar read and agent acting on the note. The respawn path checks existence immediately before injecting; after that, the note is advisory and the agent can report if the path disappears.
+- **Feedback loops:** Monitoring persists only when cwd changes, avoiding a write every tick for steady sessions.
+
+## 6. External surfaces
+
+The visible behavior is a new continuation preamble for eligible resumed developer sessions. The preamble is intentionally plain text and starts with `[BUILD-CONTEXT RESTORE]` so the agent can act on it deterministically. Normal topic sessions that remain in agent home see no new text.
+
+The persistent surface is a local sidecar state record keyed by tmux session name. It stores spawn cwd, current cwd, optional branch, and update time.
+
+## 7. Rollback cost
+
+Rollback is a code revert of the sidecar store, SessionManager wiring, server gate wiring, tests, and artifacts. The sidecar state file can remain harmlessly on disk; without the code path it is ignored. No migration or state repair is required.
+
+## Conclusion
+
+The change addresses the respawn amnesia failure without changing normal spawn cwd, without broadening behavior for home-only sessions, and without relying on conversation memory to rediscover the checkout. The test set covers pure eligibility/staleness behavior, mocked tracker-to-respawn wiring, and a real tmux e2e with both worktree and home-only controls.
+
+## Second-pass review
+
+**Reviewer:** `instar-codey separate pass`
+**Independent read of the artifact:** concur
+
+The risky surface is SessionManager. The implementation keeps the new behavior behind a feature gate, samples only after liveness is confirmed, writes through crash-safe state persistence, and injects only a continuation note for eligible resumed spawns. The scope guard is the core safety property and is covered in all three test tiers.
+
+## Evidence pointers
+
+- `npm test -- --run tests/unit/session-build-context-store.test.ts tests/integration/session-build-context-respawn.test.ts` passed.
+- `npm test -- --run tests/e2e/session-management-e2e.test.ts -t "restores a worktree build context"` passed.
+- `npm test -- --run tests/unit/no-silent-fallbacks.test.ts tests/unit/session-build-context-store.test.ts` passed after marking best-effort branch enrichment as an intentional fail-open.
+- `npm run lint` passed.


### PR DESCRIPTION
## Summary
- Adds a development-agent-gated respawn build-context sidecar that records each running session's live tmux pane cwd.
- Prepends a `[BUILD-CONTEXT RESTORE]` note on resumed spawns only when the saved cwd is fresh, exists, differs from spawn cwd, and lives under a `.worktrees` path.
- Keeps home-only sessions as a no-op and preserves normal tmux spawn cwd behavior.

## ELI16
When an agent is building a fleet PR, it usually works inside a dedicated git worktree. If the session dies and respawns, the conversation can resume but the shell starts back in the home checkout, so the agent can accidentally continue from the wrong place.

This change gives SessionManager one narrow memory for that case: the live working directory reported by the tmux pane. The sidecar write goes through the state layer's temp-file plus rename path, so a crash cannot leave half-written JSON behind.

On respawn, the agent still starts from its normal home. If the saved directory is fresh, still exists, and is under an agent worktree path, the resumed message gets a short `[BUILD-CONTEXT RESTORE]` note telling the agent which worktree to return to. Home-only sessions, stale records, missing worktrees, and disabled agents receive no note.

## Verification
- `npm test -- --run tests/unit/session-build-context-store.test.ts tests/integration/session-build-context-respawn.test.ts`
- `npm test -- --run tests/e2e/session-management-e2e.test.ts -t "restores a worktree build context"`
- `npm run lint`
- `npm run build`
- `npm run check:pre-push-gate` exits 0 with the known non-blocking version warning
- Push hook: release gate and fixture-pollution guard passed; smoke affected set was too broad locally, so CI is the authority
- Push used `INSTAR_PRE_PUSH_E2E_SKIP=1` only because the e2e-scope hook compared against `origin/main` and falsely selected threadline e2e; the selected unrelated `OfflineQueueE2E` failed with `table agents_fts already exists`, while this branch's focused session-management e2e passed

## Ceremony
- Spec: `docs/specs/respawn-build-context-reestablishment.md`
- ELI16: `docs/specs/respawn-build-context-reestablishment.eli16.md`
- Side-effects: `upgrades/side-effects/respawn-build-context-reestablishment.md`
- Release fragment: `upgrades/next/respawn-build-context-reestablishment.md`