### PR TITLE
fix(release): repair the two malformed release-note fragments (unblocks publish)

### DIFF
--- a/upgrades/next/feedback-phase3-monitor.md
+++ b/upgrades/next/feedback-phase3-monitor.md
@@ -1,2 +1,23 @@
 <!-- bump: patch -->
-Phase-3 parity monitor + cutover gate (pure ParityMonitor; the objective parity-zero-divergence condition the cutover authority reads). Not yet wired.
+
+## What Changed
+
+Added the Phase-3 invariant-parity monitor for the feedback-factory migration: a
+windowing layer over parity results that computes the objective
+parity-zero-divergence condition (a sustained run of clean passes over a minimum
+real-traffic window) which the future cutover step reads as its go signal. Includes
+a durable, restart-surviving variant (append-only pass journal, torn-line tolerant).
+Internal migration tooling — not yet wired to any live behavior.
+
+## What to Tell Your User
+
+Nothing changes for you. This is internal plumbing for the feedback-system handover:
+a safety meter that has to read "clean for a sustained window" before the one-way
+switch can ever be considered. It ships dormant.
+
+## Summary of New Capabilities
+
+- Internal: order-independent parity windowing (per-report fingerprint,
+  terminal-status, recurrence/cycling counts) with a conservative
+  cleared-or-blocked gate verdict; survives restarts.
+- Maturity: internal migration tooling, dormant until the dual-forward phase.

--- a/upgrades/next/feedback-phase4-integrity.md
+++ b/upgrades/next/feedback-phase4-integrity.md
@@ -1,2 +1,23 @@
 <!-- bump: patch -->
-Phase-4 feedback-migration integrity tooling: never-re-derive guard + integrity-safe import core (library building blocks; not yet wired into the running server).
+
+## What Changed
+
+Added the Phase-4 data-migration integrity tooling for the feedback-factory
+migration: import-as-is preservation of every curated field, per-row checksums
+(in vs out), fingerprint-uniqueness scanning, auto-increment sequence reset,
+schema-equivalence assertion, and the structural never-re-derive guard (the
+processor refuses to mutate any cluster created before the cutover timestamp or
+carrying governance notes). Internal migration tooling — not yet wired to any
+live behavior.
+
+## What to Tell Your User
+
+Nothing changes for you. This is internal plumbing for the feedback-system
+handover: the checks that guarantee curated history is copied perfectly and can
+never be silently rewritten afterward. It ships dormant.
+
+## Summary of New Capabilities
+
+- Internal: integrity-safe import core + a guarded store wrapper that makes
+  pre-cutover and governance-noted clusters structurally immutable.
+- Maturity: internal migration tooling, dormant until the import phase.


### PR DESCRIPTION
## ELI16

The release robot refuses to write the changelog when a note has no section headings. Two notes (from the migration-tooling PRs) were heading-less, so every release since they merged has silently failed — which is why the four approved PRs haven't actually shipped to the fleet yet. This adds the required headings (with honest 'internal, dormant' descriptions). Docs-only; after this merges the publish workflow runs and the mandate engine finally reaches my running server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)