### PR TITLE
feat(mentor): teach ratchet-gate compliance in the autoloop prompt (+ unblock push path)

### DIFF
--- a/.instar/instar-dev-decisions.jsonl
+++ b/.instar/instar-dev-decisions.jsonl
@@ -31,3 +31,4 @@
 {"ts":"2026-06-05T00:39:11.267Z","slug":"unknown","suggestedTier":1,"declaredTier":1,"riskFloor":1,"riskFloorReasons":[],"belowFloor":false,"files":1,"loc":8}
 {"ts":"2026-06-05T00:40:23.586Z","slug":"unknown","suggestedTier":1,"declaredTier":1,"riskFloor":1,"riskFloorReasons":[],"belowFloor":false,"files":1,"loc":8}
 {"ts":"2026-06-05T04:31:21.695Z","slug":"unknown","suggestedTier":2,"declaredTier":1,"riskFloor":2,"riskFloorReasons":["safety-invariant proximity: src/messaging/TelegramAdapter.ts matches Telegram adapter","new capability: new config key added"],"belowFloor":true,"files":4,"loc":149}
+{"ts":"2026-06-05T06:26:07.035Z","slug":"autoloop-gate-compliance","suggestedTier":1,"declaredTier":1,"riskFloor":1,"riskFloorReasons":[],"belowFloor":false,"files":1,"loc":1}

--- a/src/scheduler/MentorAutonomousGuardian.ts
+++ b/src/scheduler/MentorAutonomousGuardian.ts
@@ -142,5 +142,6 @@ export function buildAutoloopGoal(p: AutoloopGoalParams): string {
     `5. ${reportLine}`,
     ``,
     `Discipline (non-negotiable): verify before you claim — never write a result or a number before the producing tool has returned it. Never narrate a tool call you did not make. One cycle, then exit cleanly — do NOT spawn another copy of this loop or schedule a follow-up; the guardian starts the next cycle on its own heartbeat.`,
+    `Gate compliance (ratchet gates): an intentional best-effort/fail-open catch must either report through DegradationReporter or carry an inline @silent-fallback-ok justification — never bump a ratchet baseline to pass CI. When you author a task brief or spec for another agent, spell these gate notes out explicitly: a spec that says "best-effort, never throws" without them invites the exact ratchet failure it is trying to avoid.`,
   ].join('\n');
 }

--- a/tests/unit/MentorAutonomousGuardian.test.ts
+++ b/tests/unit/MentorAutonomousGuardian.test.ts
@@ -122,6 +122,11 @@ describe('buildAutoloopGoal — deterministic prompt assembly', () => {
     expect(goal).toMatch(/JKHeadley\/main/);
     expect(goal).toMatch(/verify before you claim/i);
     expect(goal).toMatch(/one cycle, then exit/i);
+    // Gate compliance (earned: #792's no-silent-fallbacks ratchet failure — the
+    // spec's "best-effort, never throws" guidance invited a swallowed catch).
+    expect(goal).toMatch(/@silent-fallback-ok/);
+    expect(goal).toMatch(/never bump a ratchet baseline/i);
+    expect(goal).toMatch(/DegradationReporter/);
   });
 
   it('degrades gracefully when topics are unset (no "topic undefined" text)', () => {

--- a/upgrades/autoloop-gate-compliance.eli16.md
+++ b/upgrades/autoloop-gate-compliance.eli16.md
@@ -1,0 +1,11 @@
+# Mentor autoloop prompt: gate-compliance line
+
+Instar has an automated "mentor loop" — a prompt that tells a developer agent how to run one cycle of dogfooding a mentee agent: check its health, assign it a real task, observe, and fix what breaks as a proper PR.
+
+That prompt already teaches the ship discipline (three test tiers, the dev gate, verify-before-claim). But it said nothing about the repo's *ratchet gates* — CI checks like no-silent-fallbacks that count known-bad patterns and fail if the count ever goes UP.
+
+We learned why that matters the hard way: a spec told the builder a helper should be "best-effort, never throws." The builder did exactly that — wrapped it in a catch that swallowed the error — and CI went red, because a swallowed catch is exactly what the no-silent-fallbacks ratchet counts. The spec's own wording invited the failure.
+
+This change adds one paragraph to the mentor-loop prompt: an intentional fail-open catch must either report the failure (through DegradationReporter) or carry an inline `@silent-fallback-ok` justification — and you never bump a ratchet baseline just to get CI green. It also tells the mentor to spell these notes out whenever it authors a task brief or spec for another agent, so the next builder doesn't get trapped by well-meaning "never throws" guidance.
+
+One prompt paragraph, three new test assertions locking it in. No behavior change anywhere else.

--- a/upgrades/next/autoloop-gate-compliance.md
+++ b/upgrades/next/autoloop-gate-compliance.md
@@ -1,0 +1,14 @@
+# Mentor autoloop prompt teaches ratchet-gate compliance
+
+## What to Tell Your User
+
+Nothing user-visible. The autonomous mentor loop's instructions now include how to satisfy the repo's ratchet CI gates, so mentor-driven fixes stop tripping no-silent-fallbacks.
+
+## Summary of New Capabilities
+
+- `buildAutoloopGoal` includes a gate-compliance paragraph: intentional fail-open catches must report via DegradationReporter or carry an inline `@silent-fallback-ok` justification — never a ratchet baseline bump.
+- The mentor is instructed to spell out these gate notes in any task brief or spec it authors for another agent.
+
+## What Changed
+
+One additive line in the mentor autoloop prompt (`src/scheduler/MentorAutonomousGuardian.ts`), locked by three new unit-test assertions. Earned from PR #792's no-silent-fallbacks CI failure, where a spec's "best-effort, never throws" wording invited the swallowed catch the ratchet counts.

--- a/upgrades/side-effects/autoloop-gate-compliance.md
+++ b/upgrades/side-effects/autoloop-gate-compliance.md
@@ -1,0 +1,43 @@
+# Side-Effects Review — Mentor autoloop gate-compliance line
+
+**Version / slug:** `autoloop-gate-compliance`
+**Date:** `2026-06-05`
+**Author:** `echo`
+**Second-pass reviewer:** `echo second-pass checklist`
+
+## Summary of the change
+
+Adds one static paragraph to `buildAutoloopGoal()` in `src/scheduler/MentorAutonomousGuardian.ts` — the deterministic prompt assembled for the autonomous mentor dogfooding loop. The paragraph teaches ratchet-gate compliance: intentional fail-open catches must report via DegradationReporter or carry an inline `@silent-fallback-ok` justification (never a baseline bump), and task briefs/specs authored for other agents must spell these notes out explicitly. Earned from PR #792's no-silent-fallbacks CI failure, where the spec's "best-effort, never throws" guidance invited the exact swallowed catch the ratchet counts.
+
+## Decision-point inventory
+
+- `buildAutoloopGoal` — modified — one additional template line appended to the returned prompt string. Pure string assembly; no new branches, no I/O, no config.
+- `tests/unit/MentorAutonomousGuardian.test.ts` — modified — three new content assertions on the assembled prompt.
+
+## 1. Over-block
+
+None possible. The function returns a string; nothing is gated, blocked, or filtered. The added text instructs the *consuming agent*; it cannot prevent any operation by itself.
+
+## 2. Over-permit
+
+None. No permission surface is touched.
+
+## 3. Token/cost impact
+
+The prompt grows by ~430 characters, sent once per autonomous-fix guardian cycle (budget- and min-interval-gated, single-instance). Negligible.
+
+## 4. Behavior change for existing consumers
+
+The only consumer is `MentorAutonomousGuardian` → spawned loop session goal text. Existing assertions on the prompt (cycle steps, discipline line, topics) are unchanged and still pass — the new line is purely additive. The `degrades gracefully when topics are unset` test still passes (the added text contains no topic interpolation).
+
+## 5. Failure modes
+
+A string literal cannot throw at runtime. The TypeScript build verifies the template syntax. If the guidance itself were wrong, the blast radius is advisory-only (an agent following it would still produce gate-passing code — DegradationReporter and `@silent-fallback-ok` are both legitimate, documented paths in `tests/unit/no-silent-fallbacks.test.ts`).
+
+## 6. Migration parity
+
+None required: the prompt is assembled at runtime from shipped code; every agent gets it on its next update through the normal release path. No installed files, hooks, config defaults, or templates change.
+
+## 7. Rollback
+
+Revert the commit. No persisted state references the new text.


### PR DESCRIPTION
## ELI16 — what this PR does

Instar has an automated "mentor loop" — a prompt that tells a developer agent how to run one dogfooding cycle with a mentee agent: check health, assign a real task, observe both sides, fix what breaks as a proper PR. That prompt already taught the ship discipline (three test tiers, the dev gate, verify-before-claim) but said NOTHING about the repo's ratchet gates — CI checks like no-silent-fallbacks that count known-bad patterns and fail when the count goes up.

We learned the cost live in PR #792: the spec told the builder a helper should be "best-effort, never throws," the builder did exactly that with a swallowed catch, and CI went red — the spec's own wording invited the failure. This PR adds one paragraph to the mentor-loop prompt: an intentional fail-open catch must either report through DegradationReporter or carry an inline @silent-fallback-ok justification (never a baseline bump), AND any task brief or spec the mentor authors for another agent must spell these notes out explicitly. Three new unit-test assertions lock the paragraph in.

Bundled (push-unblock): two release-note fragments merged earlier tonight (#781 + the Phase-4 sibling) had no "## " section heading, which the pre-push gate's fragment validator rejects — blocking EVERY push repo-wide. Added the required "## What Changed" headings (content unchanged). Root fix (author-side validation in the precommit gate) is tracked separately.

## Summary

- `src/scheduler/MentorAutonomousGuardian.ts`: one additive gate-compliance paragraph in `buildAutoloopGoal` (pure string; no branches, no I/O, no config)
- `tests/unit/MentorAutonomousGuardian.test.ts`: 3 new prompt-content assertions
- `upgrades/autoloop-gate-compliance.eli16.md` + `upgrades/side-effects/autoloop-gate-compliance.md` + `upgrades/next/autoloop-gate-compliance.md`: Tier-1 ceremony
- `upgrades/next/feedback-phase3-monitor.md` + `upgrades/next/feedback-phase4-integrity.md`: add missing `## What Changed` headings (push-path unblock)
- `.instar/instar-dev-decisions.jsonl`: gate decision-audit line (bundled in the same commit set)

## Notes

Tier-1 lane (declared in trace; gate verified ELI16 + side-effects, no spec required). Earned from cycle 5 of the apprenticeship program — recorded in the ApprenticeshipCycleStore.
