### PR TITLE
feat(coordination): cutover-readiness checker — real condition resolvers, everything up to the door (G2.4)

### DIFF
--- a/site/src/content/docs/reference/api.md
+++ b/site/src/content/docs/reference/api.md
@@ -305,6 +305,17 @@ with respect to behavior; the ratio is a signal, never a gate.
 - `PATCH /config`
 - `POST /config/telemetry`
 
+## /cutover-readiness
+
+Cutover-READINESS (coordination-mandate spec §7 G2.4, decision 1A): everything UP
+TO the cutover door, never the door. The two objective conditions resolve from
+REAL durable state — the persisted import IntegrityReport and the durable
+zero-divergence parity window (with a readiness-layer freshness bound). The flip
+itself is the operator's manual click; there is no fire-cutover route by design.
+
+- `GET /cutover-readiness` — `{ ready, door: "manual-operator-click", integrity, parity }` (read-only)
+- `POST /cutover-readiness/parity-pass` — trigger a server-side live parity check; the request contributes nothing to the result; a failed check records nothing
+
 ## /context
 - `GET /context`
 - `GET /context/:segmentId`

--- a/src/feedback-factory/cutoverReadiness.ts
+++ b/src/feedback-factory/cutoverReadiness.ts
@@ -1,0 +1,184 @@
+/**
+ * cutoverReadiness.ts — the cutover-READINESS checker (coordination-mandate spec §7
+ * G2.4, scoped by decision 1A): everything UP TO the door, never the door.
+ *
+ * The Phase-4 cutover flip is Justin's one manual click — NOT an autonomously
+ * fireable action (decision 1A/3B). What CAN and SHOULD be autonomous is knowing,
+ * from REAL durable state, whether the flip is safe: this module composes the two
+ * objective conditions the spec names —
+ *
+ *   - `integrity-gate-pass`     ← the persisted Phase-4 import IntegrityReport
+ *                                 (`runIntegrityGate(...).passed`, written server-side
+ *                                 by the import tooling — never asserted by an agent)
+ *   - `parity-zero-divergence`  ← `DurableParityMonitor.gate(now).cleared` over the
+ *                                 durable zero-divergence window, PLUS a readiness-layer
+ *                                 freshness bound (a streak that stopped being fed is
+ *                                 visible staleness, not silent readiness)
+ *
+ * — and exposes them as one read-only status. The T7 discipline (conditions resolve
+ * from real state, never an agent's assertion) is structural here: the ONLY write
+ * paths are (a) `runParityPass()`, which the agent may TRIGGER but whose result is
+ * computed server-side from a live fetch+compare, and (b) `recordIntegrityReport()`,
+ * called by the server-side import tooling. There is no "set the condition" input.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import type { DurableParityMonitor } from './monitor/parityMonitorStore.js';
+import type { CutoverGateStatus } from './monitor/parityMonitor.js';
+import type { IntegrityReport } from './migration/importIntegrity.js';
+import type { ParityResult } from './processor/parity.js';
+
+export interface IntegrityStatus {
+  /** Has an import integrity report been recorded at all? */
+  ran: boolean;
+  /** The report's single gate boolean (false when never ran — deny-safe). */
+  passed: boolean;
+  generatedAt: string | null;
+  /** Compact counts for display; null when never ran. */
+  summary: {
+    fingerprintCollisions: number;
+    schemaDivergences: number;
+    checksumMismatches: number;
+    danglingRefs: number;
+  } | null;
+}
+
+export interface ParityReadiness extends CutoverGateStatus {
+  /** ISO of the most recent recorded pass (clean or divergent), or null. */
+  lastPassAt: string | null;
+  /** True when the last pass is older than `maxPassStalenessMs` — a cleared-but-stale
+   *  window is NOT readiness (the gate has no max-staleness by design; this layer adds it). */
+  stale: boolean;
+}
+
+export interface CutoverReadinessStatus {
+  /** True only when integrity passed AND the parity window is cleared AND fresh.
+   *  This is the everything-up-to-the-door signal — it never fires anything. */
+  ready: boolean;
+  /** Decision 1A, restated machine-readably so no consumer can misread the scope. */
+  door: 'manual-operator-click';
+  integrity: IntegrityStatus;
+  parity: ParityReadiness;
+}
+
+export type ParityPassOutcome =
+  | { ok: true; pass: { at: string; clustersCompared: number; divergences: number; divergent: boolean }; gate: CutoverGateStatus }
+  | { ok: false; reason: string };
+
+export interface CutoverReadinessDeps {
+  parityMonitor: DurableParityMonitor;
+  /** Where the import tooling's IntegrityReport persists (JSON envelope). */
+  integrityReportPath: string;
+  /** SERVER-SIDE parity check (live fetch + compare). Null when no parity source is
+   *  configured — runParityPass() then refuses, and the parity condition can only
+   *  clear via passes recorded by other server-side paths. */
+  runParityCheck: (() => Promise<ParityResult>) | null;
+  /** Freshness bound for the parity window (default 6h). */
+  maxPassStalenessMs?: number;
+  now?: () => number;
+}
+
+const DEFAULT_MAX_PASS_STALENESS_MS = 6 * 60 * 60 * 1000;
+
+interface PersistedIntegrityEnvelope {
+  generatedAt: string;
+  report: IntegrityReport;
+}
+
+export class CutoverReadiness {
+  private readonly d: CutoverReadinessDeps;
+  private readonly maxStaleMs: number;
+
+  constructor(deps: CutoverReadinessDeps) {
+    this.d = deps;
+    this.maxStaleMs = deps.maxPassStalenessMs ?? DEFAULT_MAX_PASS_STALENESS_MS;
+  }
+
+  private nowMs(): number {
+    return this.d.now ? this.d.now() : Date.now();
+  }
+
+  /** Persist an import IntegrityReport (server-side import tooling only). */
+  recordIntegrityReport(report: IntegrityReport, generatedAt?: string): void {
+    const envelope: PersistedIntegrityEnvelope = {
+      generatedAt: generatedAt ?? new Date(this.nowMs()).toISOString(),
+      report,
+    };
+    fs.mkdirSync(path.dirname(this.d.integrityReportPath), { recursive: true });
+    fs.writeFileSync(this.d.integrityReportPath, JSON.stringify(envelope, null, 2));
+  }
+
+  integrityStatus(): IntegrityStatus {
+    try {
+      const raw = JSON.parse(fs.readFileSync(this.d.integrityReportPath, 'utf8')) as PersistedIntegrityEnvelope;
+      const r = raw?.report;
+      if (!r || typeof r.passed !== 'boolean') {
+        return { ran: false, passed: false, generatedAt: null, summary: null };
+      }
+      return {
+        ran: true,
+        passed: r.passed,
+        generatedAt: typeof raw.generatedAt === 'string' ? raw.generatedAt : null,
+        summary: {
+          fingerprintCollisions: r.fingerprintCollisions?.length ?? 0,
+          schemaDivergences: r.schemaDivergences?.length ?? 0,
+          checksumMismatches: r.checksumMismatches?.length ?? 0,
+          danglingRefs: r.danglingRefs?.length ?? 0,
+        },
+      };
+    } catch { /* @silent-fallback-ok — no report on disk = the import never ran = NOT ready (deny-safe) */
+      return { ran: false, passed: false, generatedAt: null, summary: null };
+    }
+  }
+
+  parityStatus(): ParityReadiness {
+    const nowIso = new Date(this.nowMs()).toISOString();
+    const gate = this.d.parityMonitor.gate(nowIso);
+    const passes = this.d.parityMonitor.passes;
+    const lastPassAt = passes.length > 0 ? passes[passes.length - 1].at : null;
+    const stale = lastPassAt === null
+      ? true
+      : this.nowMs() - Date.parse(lastPassAt) > this.maxStaleMs;
+    return { ...gate, lastPassAt, stale };
+  }
+
+  /**
+   * TRIGGER a server-side parity pass: live fetch + compare via the injected check,
+   * record the result (clean OR divergent) into the durable window. The caller
+   * contributes nothing to the result — only the request to run it (T7). A FAILED
+   * check records nothing: a fetch error is absence of evidence, not evidence of
+   * divergence — and it cannot extend the clean window either.
+   */
+  async runParityPass(): Promise<ParityPassOutcome> {
+    if (!this.d.runParityCheck) {
+      return { ok: false, reason: 'no parity source configured (feedbackMigration.paritySource) — cannot run a live check' };
+    }
+    let result: ParityResult;
+    try {
+      result = await this.d.runParityCheck();
+    } catch (err) {
+      return { ok: false, reason: `parity check failed: ${err instanceof Error ? err.message : String(err)}` };
+    }
+    const at = new Date(this.nowMs()).toISOString();
+    this.d.parityMonitor.recordResult(result, at);
+    const divergences = result.fingerprintDivergences.length + result.outcomeDivergences.length;
+    return {
+      ok: true,
+      pass: { at, clustersCompared: result.clustersCompared, divergences, divergent: divergences > 0 },
+      gate: this.d.parityMonitor.gate(at),
+    };
+  }
+
+  /** The everything-up-to-the-door readiness signal. Read-only; never fires anything. */
+  status(): CutoverReadinessStatus {
+    const integrity = this.integrityStatus();
+    const parity = this.parityStatus();
+    return {
+      ready: integrity.passed && parity.cleared && !parity.stale,
+      door: 'manual-operator-click',
+      integrity,
+      parity,
+    };
+  }
+}

--- a/src/scaffold/templates.ts
+++ b/src/scaffold/templates.ts
@@ -694,6 +694,11 @@ This routes feedback to the Instar maintainers automatically. Valid types: \`bug
 - **When to use** (PROACTIVE — this is the trigger): the moment a mandate with \`sign-code-review\` exists and you need a peer agent's review of work in its scope, drive it through an exchange — NEVER improvise a sign-off in chat prose (an unrecorded "LGTM" over Threadline is not a sign-off; the gate-audited exchange is). A 403 on a sign step means the mandate denied it — STOP, do not work around it.
 - Inspect: \`GET /review-exchange\` · \`GET /review-exchange/:id\` (signatures + audit hashes).
 
+**Cutover Readiness** — When a migration (or any one-way cutover) is gated on objective conditions, this is the read surface for "is everything up to the door green?" — composed from REAL durable state (the persisted import integrity report + the durable zero-divergence parity window with a freshness bound), never from anyone's assertion.
+- Check: \`curl -H "Authorization: Bearer $AUTH" http://localhost:${port}/cutover-readiness\` → \`{ ready, door: "manual-operator-click", integrity, parity }\`.
+- Feed the parity window with a live check: \`curl -X POST -H "Authorization: Bearer $AUTH" http://localhost:${port}/cutover-readiness/parity-pass\` — the server fetches + compares server-side; you only trigger it. A failed check records nothing.
+- **The door is NOT yours**: \`ready: true\` means the conditions are green — it is NEVER an instruction to flip. The cutover click belongs to the operator. NEVER present \`ready\` to the user as "I can cut over now"; present it as "everything up to your click is green."
+
 **Session Clock** — How long have you been running, and how much time is left? For any active time-boxed (autonomous) session, this returns the computed elapsed + remaining so you never have to guess or compute it yourself. Read-only observability.
 - Check: \`curl -H "Authorization: Bearer $AUTH" "http://localhost:${port}/session/clock"\` (optional \`?topic=<N>\` to bind to one session)
 - Returns \`{ now, nowIso, sessions: [{ label, kind, startedAt, endsAt, elapsedSeconds, remainingSeconds, elapsedHuman, remainingHuman, percentElapsed, status }] }\`; \`{ sessions: [] }\` when nothing is time-boxed. Per-machine (the record is local).

--- a/src/server/AgentServer.ts
+++ b/src/server/AgentServer.ts
@@ -19,6 +19,11 @@ import { MandateGate } from '../coordination/MandateGate.js';
 import { MandateAudit } from '../coordination/MandateAudit.js';
 import { ConditionsRegistry } from '../coordination/conditions.js';
 import { ReviewExchangeEngine } from '../coordination/ReviewExchange.js';
+import { CutoverReadiness } from '../feedback-factory/cutoverReadiness.js';
+import { DurableParityMonitor, JsonlPassPersistence } from '../feedback-factory/monitor/parityMonitorStore.js';
+import { HttpParitySource } from '../feedback-factory/dryrun/HttpParitySource.js';
+import { runDryRunCompare } from '../feedback-factory/dryrun/dryRunCompare.js';
+import { SecretStore } from '../core/SecretStore.js';
 import { fileURLToPath } from 'node:url';
 import type { SessionManager } from '../core/SessionManager.js';
 import type { StateManager } from '../core/StateManager.js';
@@ -162,6 +167,7 @@ export class AgentServer {
   /** Coordination Mandate enforcement (spec §4): deny-by-default gate + signed
    *  store + hash-chained audit. Null when stateDir is unavailable. */
   private coordination: { store: MandateStore; gate: MandateGate; audit: MandateAudit; conditions: ConditionsRegistry; reviews: ReviewExchangeEngine } | null = null;
+  private cutoverReadiness: CutoverReadiness | null = null;
   private parallelActivityIndex: ParallelActivityIndex | null = null;
   private parallelWorkSentinel: ParallelWorkSentinel | null = null;
   private parallelWorkSentinelTimer: ReturnType<typeof setInterval> | null = null;
@@ -891,11 +897,45 @@ export class AgentServer {
           filePath: path.join(options.config.stateDir, 'state', 'mandate-audit.jsonl'),
         });
         const conditions = new ConditionsRegistry();
-        // Registered deny-safe: these return false until the real integrity/parity
-        // state is wired (the first mandate has no conditioned authority, so they
-        // are not exercised — built + tested for the future cutover authority).
-        conditions.register('integrity-gate-pass', () => false);
-        conditions.register('parity-zero-divergence', () => false);
+        // Cutover-READINESS (spec §7 G2.4, scoped by decision 1A: everything UP TO
+        // the door — the flip itself stays the operator's manual click). The two
+        // objective conditions resolve from REAL durable state (T7): the persisted
+        // import IntegrityReport and the durable zero-divergence parity window.
+        // An agent can TRIGGER a server-side parity pass; it can never assert one.
+        const parityMonitor = new DurableParityMonitor(
+          new JsonlPassPersistence(path.join(options.config.stateDir, 'state', 'feedback-parity-passes.jsonl')),
+        );
+        const migrationCfg = (this.config as { feedbackMigration?: { paritySource?: { baseUrl?: string; secretKey?: string; pageSize?: number; status?: string } } }).feedbackMigration;
+        const paritySourceCfg = migrationCfg?.paritySource;
+        const runParityCheck = paritySourceCfg?.baseUrl
+          ? async () => {
+            const token = String(new SecretStore({ stateDir: options.config.stateDir }).get(paritySourceCfg.secretKey ?? 'portal.instarReadToken') ?? '');
+            if (!token) throw new Error(`parity source token "${paritySourceCfg.secretKey ?? 'portal.instarReadToken'}" not found in the SecretStore`);
+            const source = new HttpParitySource({
+              baseUrl: paritySourceCfg.baseUrl!,
+              token,
+              ...(paritySourceCfg.pageSize ? { pageSize: paritySourceCfg.pageSize } : {}),
+              ...(paritySourceCfg.status ? { status: paritySourceCfg.status } : {}),
+            });
+            await source.prepare();
+            return runDryRunCompare(source);
+          }
+          : null;
+        const readiness = new CutoverReadiness({
+          parityMonitor,
+          integrityReportPath: path.join(options.config.stateDir, 'state', 'feedback-integrity-report.json'),
+          runParityCheck,
+        });
+        // The REAL resolvers (replacing the former deny-safe stubs): both read
+        // durable server-side state; both stay false until that state genuinely
+        // clears. The first mandate has no conditioned authority, so behavior is
+        // unchanged until an execute-cutover authority is ever issued.
+        conditions.register('integrity-gate-pass', () => readiness.integrityStatus().passed);
+        conditions.register('parity-zero-divergence', () => {
+          const p = readiness.parityStatus();
+          return p.cleared && !p.stale;
+        });
+        this.cutoverReadiness = readiness;
         const gate = new MandateGate({ store, conditions, audit });
         // ReviewExchange (spec §7 G2.3): mutual code-review sign-offs, every
         // signature evaluated through the SAME gate (same audit chain).
@@ -1246,6 +1286,7 @@ export class AgentServer {
       resourceLedger: this.resourceLedger,
       approvalLedger: this.approvalLedger,
       coordination: this.coordination,
+      cutoverReadiness: this.cutoverReadiness,
       parallelActivityIndex: this.parallelActivityIndex,
       frameworkIssueLedger: this.frameworkIssueLedger,
       mentorRunner: this.mentorRunner,

--- a/src/server/CapabilityIndex.ts
+++ b/src/server/CapabilityIndex.ts
@@ -609,6 +609,18 @@ export const CAPABILITY_INDEX: readonly CapabilityEntry[] = [
     }),
   },
   {
+    key: 'cutoverReadiness',
+    prefixes: ['/cutover-readiness'],
+    description: 'Cutover-READINESS checker (coordination-mandate spec §7 G2.4, decision 1A) — everything UP TO the cutover door, never the door. Composes the two objective conditions from REAL durable state: the persisted import IntegrityReport (integrity-gate-pass) and the durable zero-divergence parity window with a freshness bound (parity-zero-divergence). The flip itself is the operator\'s manual click; there is NO fire-cutover route by design.',
+    build: ({ ctx }) => ({
+      enabled: !!ctx.cutoverReadiness,
+      endpoints: [
+        'GET /cutover-readiness — { ready, door:"manual-operator-click", integrity, parity } from durable state (read-only)',
+        'POST /cutover-readiness/parity-pass — TRIGGER a server-side live parity check (fetch+compare server-side; the body contributes nothing); records the pass into the durable window',
+      ],
+    }),
+  },
+  {
     key: 'resourceLedger',
     prefixes: ['/resources'],
     description: 'Per-agent ResourceLedger — read-only CPU/memory + rate-limit-event observability (mirrors TokenLedger). Phase A persists rate-limit events (breaker trips + session-sentinel detections) across restarts; Phase B continuously samples CPU% + RSS of the agent server + its spawned sessions. Never gates.',

--- a/src/server/routes.ts
+++ b/src/server/routes.ts
@@ -729,6 +729,10 @@ export interface RouteContext {
     /** ReviewExchange engine (spec §7 G2.3) — mandate-gated mutual code-review sign-offs. */
     reviews: import('../coordination/ReviewExchange.js').ReviewExchangeEngine;
   } | null;
+  /** Cutover-READINESS checker (spec §7 G2.4, decision 1A: everything UP TO the
+   *  door). Read-only objective conditions from durable state; the flip itself is
+   *  never autonomous. Null when stateDir is unavailable. */
+  cutoverReadiness: import('../feedback-factory/cutoverReadiness.js').CutoverReadiness | null;
   /** Cross-topic activity index (Parallel-Work Awareness Phase A). Backs GET /parallel-work/activities. */
   parallelActivityIndex?: import('../core/ParallelActivityIndex.js').ParallelActivityIndex | null;
   /** The shared intelligence provider (an IntelligenceRouter when per-component routing is wired). Backs GET /intelligence/routing. */
@@ -5151,6 +5155,37 @@ export function createRoutes(ctx: RouteContext): Router {
       return;
     }
     res.json({ signed: true, exchange: result.record });
+  });
+
+  // ── Cutover-READINESS (coordination-mandate spec §7 G2.4, decision 1A) ──
+  // Everything UP TO the door: the two objective cutover conditions resolved from
+  // REAL durable state (persisted IntegrityReport + durable parity window). The
+  // flip itself is the operator's manual click — there is NO fire-cutover route
+  // here by design, and `door` says so machine-readably.
+
+  // The readiness signal. Read-only.
+  router.get('/cutover-readiness', (_req, res) => {
+    if (!ctx.cutoverReadiness) {
+      res.status(503).json({ error: 'cutover-readiness unavailable (no stateDir or init failed)' });
+      return;
+    }
+    res.json(ctx.cutoverReadiness.status());
+  });
+
+  // TRIGGER a server-side parity pass (T7: the agent may ask; the server computes).
+  // The request body contributes NOTHING to the result. 409 when no source is
+  // configured or the live check fails (nothing recorded on failure).
+  router.post('/cutover-readiness/parity-pass', async (_req, res) => {
+    if (!ctx.cutoverReadiness) {
+      res.status(503).json({ error: 'cutover-readiness unavailable (no stateDir or init failed)' });
+      return;
+    }
+    const outcome = await ctx.cutoverReadiness.runParityPass();
+    if (!outcome.ok) {
+      res.status(409).json({ error: outcome.reason });
+      return;
+    }
+    res.json({ recorded: true, pass: outcome.pass, gate: outcome.gate });
   });
 
   // ── Parallel-Work Awareness (docs/specs/parallel-activity-coherence.md, Phase A) ──

--- a/tests/e2e/cutover-readiness-lifecycle.test.ts
+++ b/tests/e2e/cutover-readiness-lifecycle.test.ts
@@ -1,0 +1,157 @@
+// safe-fs-allow: test file — SafeFsExecutor used for tmpdir cleanup.
+
+/**
+ * Tier-3 E2E "feature is alive" lifecycle test for the cutover-readiness checker
+ * (coordination-mandate spec §7 G2.4, decision 1A).
+ *
+ * Per TESTING-INTEGRITY-SPEC: boots the REAL AgentServer and proves, on the
+ * production init path:
+ *   1. /cutover-readiness is alive (200, not 503) and Bearer-gated, door manual.
+ *   2. WIRING-INTEGRITY (the load-bearing one): the mandate conditions
+ *      `integrity-gate-pass` + `parity-zero-divergence` resolve from REAL durable
+ *      state — a conditioned execute-cutover authority DENIES on a fresh boot,
+ *      and flips to ALLOW only after the durable state genuinely clears (parity
+ *      passes pre-seeded on disk + the integrity report written through the
+ *      production-path readiness instance). No agent assertion anywhere (T7).
+ *   3. POST /cutover-readiness/parity-pass without a configured source → 409.
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import express from 'express';
+import request from 'supertest';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { AgentServer } from '../../src/server/AgentServer.js';
+import { StateManager } from '../../src/core/StateManager.js';
+import type { InstarConfig } from '../../src/core/types.js';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+
+function createMockSessionManager() {
+  return { listRunningSessions: () => [], getSession: () => null, getRunningSessionPanePids: () => [] };
+}
+
+const AUTH = 'test-e2e-cutover-readiness';
+const PIN = '424242';
+const ECHO = 'fp-echo';
+const DAWN = 'fp-dawn';
+const FUTURE = '2999-01-01T00:00:00Z';
+const HOUR = 60 * 60 * 1000;
+
+describe('Cutover-readiness E2E lifecycle — alive + conditions resolve from REAL durable state', () => {
+  let tmpDir: string;
+  let stateDir: string;
+  let server: AgentServer;
+  let app: express.Express;
+
+  beforeAll(async () => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cutready-e2e-'));
+    stateDir = path.join(tmpDir, '.instar');
+    fs.mkdirSync(path.join(stateDir, 'state', 'sessions'), { recursive: true });
+    fs.mkdirSync(path.join(stateDir, 'logs'), { recursive: true });
+    fs.writeFileSync(path.join(stateDir, 'config.json'), JSON.stringify({ port: 0, projectName: 'e2e', agentName: 'E2E' }));
+
+    // Pre-seed the DURABLE parity window on disk BEFORE boot: 3 clean passes
+    // spanning >1h, the last one fresh (now). The production boot loads these —
+    // exactly how a real window survives a restart.
+    const now = Date.now();
+    const passes = [now - 2 * HOUR, now - HOUR, now].map((t) => JSON.stringify({
+      at: new Date(t).toISOString(), clustersCompared: 1346, divergences: 0, divergent: false,
+    })).join('\n') + '\n';
+    fs.writeFileSync(path.join(stateDir, 'state', 'feedback-parity-passes.jsonl'), passes);
+
+    const config = {
+      projectName: 'e2e', projectDir: tmpDir, stateDir, port: 0, authToken: AUTH,
+      dashboardPin: PIN,
+      requestTimeoutMs: 10000, version: '0.0.0',
+      sessions: { claudePath: '/usr/bin/echo', maxSessions: 3, defaultMaxDurationMinutes: 30, protectedSessions: [], monitorIntervalMs: 5000 },
+      scheduler: { enabled: false, jobsFile: '', maxParallelJobs: 1 },
+      messaging: [], monitoring: {}, updates: {},
+    } as InstarConfig;
+    server = new AgentServer({ config, sessionManager: createMockSessionManager() as any, state: new StateManager(stateDir) });
+    await server.start();
+    app = server.getApp();
+  });
+
+  afterAll(async () => {
+    await server.stop();
+    SafeFsExecutor.safeRmSync(tmpDir, { recursive: true, force: true, operation: 'tests/e2e/cutover-readiness-lifecycle.test.ts' });
+  });
+
+  const auth = () => ({ Authorization: `Bearer ${AUTH}` });
+
+  it('GET /cutover-readiness is alive (200, not 503), Bearer-gated, door manual; parity loaded from disk', async () => {
+    expect((await request(app).get('/cutover-readiness')).status).toBe(401);
+    const res = await request(app).get('/cutover-readiness').set(auth());
+    expect(res.status).toBe(200);
+    expect(res.body.door).toBe('manual-operator-click');
+    // The pre-seeded durable window was loaded on the production path.
+    expect(res.body.parity.cleared).toBe(true);
+    expect(res.body.parity.stale).toBe(false);
+    // Integrity never ran → not ready (deny-safe composition).
+    expect(res.body.integrity.ran).toBe(false);
+    expect(res.body.ready).toBe(false);
+  });
+
+  it('WIRING-INTEGRITY: a conditioned execute-cutover DENIES until the REAL durable state clears, then ALLOWS', async () => {
+    // Issue a mandate whose execute-cutover requires BOTH objective conditions.
+    const issued = await request(app).post('/mandate/issue').set(auth()).send({
+      pin: PIN, scope: 'feedback-migration', agents: [ECHO, DAWN],
+      authorities: [{
+        action: 'execute-cutover', bounds: {},
+        requiresCondition: 'integrity-gate-pass+parity-zero-divergence',
+      }],
+      expiresAt: FUTURE,
+    });
+    expect(issued.status).toBe(201);
+    const mandateId = issued.body.mandate.id;
+
+    // Parity is green (pre-seeded) but integrity NEVER ran → condition false → deny.
+    const denied = await request(app).post('/mandate/evaluate').set(auth()).send({
+      action: 'execute-cutover', params: {}, agentFp: ECHO, mandateId,
+    });
+    expect(denied.body.decision).toBe('deny');
+    expect(denied.body.conditionResult).toBe(false);
+
+    // Write a PASSED integrity report into the production state path — the
+    // server-side artifact the import tooling produces. NO server restart:
+    // integrityStatus() reads durable state per evaluation.
+    fs.writeFileSync(path.join(stateDir, 'state', 'feedback-integrity-report.json'), JSON.stringify({
+      generatedAt: new Date().toISOString(),
+      report: {
+        fingerprintCollisions: [], schemaDivergences: [], checksumMismatches: [],
+        danglingRefs: [], sequenceResetTo: 1347, passed: true,
+      },
+    }));
+
+    // Same evaluation now ALLOWS — the condition flipped from REAL durable state.
+    const allowed = await request(app).post('/mandate/evaluate').set(auth()).send({
+      action: 'execute-cutover', params: {}, agentFp: ECHO, mandateId,
+    });
+    expect(allowed.body.decision).toBe('allow');
+    expect(allowed.body.conditionResult).toBe(true);
+
+    // And the readiness surface agrees end-to-end.
+    const ready = await request(app).get('/cutover-readiness').set(auth());
+    expect(ready.body.ready).toBe(true);
+
+    // A FAILED report re-blocks (both sides of the boundary).
+    fs.writeFileSync(path.join(stateDir, 'state', 'feedback-integrity-report.json'), JSON.stringify({
+      generatedAt: new Date().toISOString(),
+      report: {
+        fingerprintCollisions: [], schemaDivergences: [],
+        checksumMismatches: [{ kind: 'cluster', id: 'c1', sourceChecksum: 'a', targetChecksum: 'b' }],
+        danglingRefs: [], sequenceResetTo: 1347, passed: false,
+      },
+    }));
+    const reblocked = await request(app).post('/mandate/evaluate').set(auth()).send({
+      action: 'execute-cutover', params: {}, agentFp: ECHO, mandateId,
+    });
+    expect(reblocked.body.decision).toBe('deny');
+  });
+
+  it('POST /cutover-readiness/parity-pass with no parity source configured → 409, nothing recorded', async () => {
+    const res = await request(app).post('/cutover-readiness/parity-pass').set(auth());
+    expect(res.status).toBe(409);
+    expect(res.body.error).toMatch(/no parity source configured/);
+  });
+});

--- a/tests/integration/cutover-readiness-routes.test.ts
+++ b/tests/integration/cutover-readiness-routes.test.ts
@@ -1,0 +1,120 @@
+/**
+ * Tier-2 integration tests for the /cutover-readiness routes (coordination-mandate
+ * spec §7 G2.4) — the full HTTP pipeline over a REAL CutoverReadiness.
+ *
+ * Load-bearing: the readiness endpoint is read-only truth from durable state, the
+ * parity-pass trigger computes server-side (the body contributes nothing), a failed
+ * check records nothing (409), and there is NO fire-cutover route.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import express from 'express';
+import type { AddressInfo } from 'node:net';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { createRoutes } from '../../src/server/routes.js';
+import { CutoverReadiness } from '../../src/feedback-factory/cutoverReadiness.js';
+import { DurableParityMonitor, JsonlPassPersistence } from '../../src/feedback-factory/monitor/parityMonitorStore.js';
+import type { ParityResult } from '../../src/feedback-factory/processor/parity.js';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+
+interface Server { url: string; close: () => Promise<void>; }
+
+async function listen(app: express.Express): Promise<Server> {
+  return new Promise((resolve) => {
+    const srv = app.listen(0, () => {
+      const port = (srv.address() as AddressInfo).port;
+      resolve({ url: `http://127.0.0.1:${port}`, close: () => new Promise<void>((r) => srv.close(() => r())) });
+    });
+  });
+}
+
+const CLEAN: ParityResult = {
+  clustersCompared: 1346, clustersWithFingerprint: 1346, outcomesCompared: 0,
+  fingerprintDivergences: [], outcomeDivergences: [], divergent: false,
+};
+
+function buildApp(cutoverReadiness: CutoverReadiness | null): express.Express {
+  const app = express();
+  app.use(express.json({ limit: '12mb' }));
+  const ctx: any = {
+    cutoverReadiness,
+    config: { authToken: 'test', stateDir: '/tmp', port: 0 },
+    stateDir: '/tmp',
+  };
+  app.use(createRoutes(ctx));
+  return app;
+}
+
+describe('Cutover-readiness routes (spec §7 G2.4)', () => {
+  let dir: string;
+  let server: Server;
+  let monitor: DurableParityMonitor;
+  let parityCheck: (() => Promise<ParityResult>) | null;
+
+  beforeEach(async () => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'cutready-routes-'));
+    monitor = new DurableParityMonitor(new JsonlPassPersistence(path.join(dir, 'passes.jsonl')));
+    parityCheck = null;
+    const readiness = new CutoverReadiness({
+      parityMonitor: monitor,
+      integrityReportPath: path.join(dir, 'integrity-report.json'),
+      // Late-bound so each test can choose the server-side check behavior.
+      runParityCheck: () => (parityCheck ? parityCheck() : Promise.reject(new Error('no check bound'))),
+    });
+    server = await listen(buildApp(readiness));
+  });
+  afterEach(async () => {
+    await server.close();
+    SafeFsExecutor.safeRmSync(dir, { recursive: true, force: true, operation: 'tests/integration/cutover-readiness-routes.test.ts' });
+  });
+
+  it('GET /cutover-readiness returns the composed read-only status with the manual door', async () => {
+    const res = await fetch(`${server.url}/cutover-readiness`);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ready).toBe(false);
+    expect(body.door).toBe('manual-operator-click');
+    expect(body.integrity.ran).toBe(false);
+    expect(body.parity.cleared).toBe(false);
+  });
+
+  it('POST /cutover-readiness/parity-pass triggers the SERVER-SIDE check and records the pass', async () => {
+    parityCheck = async () => CLEAN;
+    const res = await fetch(`${server.url}/cutover-readiness/parity-pass`, {
+      method: 'POST', headers: { 'Content-Type': 'application/json' },
+      // A hostile body asserting cleanliness — it must contribute NOTHING.
+      body: JSON.stringify({ divergent: false, divergences: 0, cleared: true }),
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.recorded).toBe(true);
+    expect(body.pass.clustersCompared).toBe(1346); // from the server-side check, not the body
+    expect(monitor.passes.length).toBe(1);
+  });
+
+  it('a FAILED server-side check is 409 and records NOTHING', async () => {
+    parityCheck = async () => { throw new Error('Portal unreachable'); };
+    const res = await fetch(`${server.url}/cutover-readiness/parity-pass`, { method: 'POST' });
+    expect(res.status).toBe(409);
+    expect((await res.json()).error).toMatch(/parity check failed/);
+    expect(monitor.passes.length).toBe(0);
+  });
+
+  it('there is NO fire-cutover route (decision 1A is structural)', async () => {
+    for (const p of ['/cutover-readiness/execute', '/cutover-readiness/fire', '/cutover-readiness/cutover']) {
+      const res = await fetch(`${server.url}${p}`, { method: 'POST' });
+      expect([404].includes(res.status)).toBe(true);
+    }
+  });
+
+  it('both routes 503 when the checker is unavailable', async () => {
+    const s2 = await listen(buildApp(null));
+    try {
+      expect((await fetch(`${s2.url}/cutover-readiness`)).status).toBe(503);
+      expect((await fetch(`${s2.url}/cutover-readiness/parity-pass`, { method: 'POST' })).status).toBe(503);
+    } finally {
+      await s2.close();
+    }
+  });
+});

--- a/tests/unit/cutover-readiness.test.ts
+++ b/tests/unit/cutover-readiness.test.ts
@@ -1,0 +1,178 @@
+/**
+ * Tier-1 tests for the CutoverReadiness checker (coordination-mandate spec §7 G2.4,
+ * decision 1A: everything UP TO the door).
+ *
+ * Both sides of every boundary: integrity status (never-ran / failed / passed /
+ * torn file), parity readiness (no passes / cleared / cleared-but-STALE), the
+ * trigger-only parity pass (server-side check recorded clean AND divergent; a
+ * FAILED check records NOTHING; no source configured refuses), the composed
+ * `ready` signal, and the door being machine-readably manual.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { CutoverReadiness } from '../../src/feedback-factory/cutoverReadiness.js';
+import { DurableParityMonitor, JsonlPassPersistence } from '../../src/feedback-factory/monitor/parityMonitorStore.js';
+import type { IntegrityReport } from '../../src/feedback-factory/migration/importIntegrity.js';
+import type { ParityResult } from '../../src/feedback-factory/processor/parity.js';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+
+const T0 = Date.parse('2026-06-05T00:00:00Z');
+const HOUR = 60 * 60 * 1000;
+
+const PASSED_REPORT: IntegrityReport = {
+  fingerprintCollisions: [], schemaDivergences: [], checksumMismatches: [],
+  danglingRefs: [], sequenceResetTo: 1347, passed: true,
+};
+const FAILED_REPORT: IntegrityReport = {
+  ...PASSED_REPORT,
+  checksumMismatches: [{ kind: 'cluster', id: 'c1', sourceChecksum: 'a', targetChecksum: 'b' } as any],
+  passed: false,
+};
+
+const CLEAN: ParityResult = {
+  clustersCompared: 1346, clustersWithFingerprint: 1346, outcomesCompared: 0,
+  fingerprintDivergences: [], outcomeDivergences: [], divergent: false,
+};
+const DIVERGENT: ParityResult = {
+  ...CLEAN,
+  fingerprintDivergences: [{ clusterId: 'c9', stored: 'x', recomputed: 'y' } as any],
+  divergent: true,
+};
+
+describe('CutoverReadiness (spec §7 G2.4)', () => {
+  let dir: string;
+  let nowMs: number;
+  let monitor: DurableParityMonitor;
+
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'cutready-'));
+    nowMs = T0;
+    monitor = new DurableParityMonitor(new JsonlPassPersistence(path.join(dir, 'passes.jsonl')));
+  });
+  afterEach(() => SafeFsExecutor.safeRmSync(dir, { recursive: true, force: true, operation: 'tests/unit/cutover-readiness.test.ts' }));
+
+  function build(runParityCheck: (() => Promise<ParityResult>) | null = null) {
+    return new CutoverReadiness({
+      parityMonitor: monitor,
+      integrityReportPath: path.join(dir, 'integrity-report.json'),
+      runParityCheck,
+      now: () => nowMs,
+    });
+  }
+
+  /** Feed enough clean passes (spanning the policy window) to clear the parity gate. */
+  function feedCleanWindow() {
+    for (let i = 0; i < 3; i++) {
+      monitor.record({ at: new Date(T0 + i * HOUR).toISOString(), clustersCompared: 1346, divergences: 0, divergent: false });
+    }
+    nowMs = T0 + 2 * HOUR + 1; // after the 3rd pass; window > 1h
+  }
+
+  // ── integrity side ──
+
+  it('integrity: never-ran → ran:false passed:false (deny-safe); torn file likewise', () => {
+    const r = build();
+    expect(r.integrityStatus()).toEqual({ ran: false, passed: false, generatedAt: null, summary: null });
+    fs.writeFileSync(path.join(dir, 'integrity-report.json'), '{ torn');
+    expect(r.integrityStatus().passed).toBe(false);
+  });
+
+  it('integrity: recordIntegrityReport persists; passed and failed reports read back faithfully', () => {
+    const r = build();
+    r.recordIntegrityReport(FAILED_REPORT);
+    expect(r.integrityStatus()).toMatchObject({ ran: true, passed: false });
+    expect(r.integrityStatus().summary?.checksumMismatches).toBe(1);
+    r.recordIntegrityReport(PASSED_REPORT, '2026-06-05T01:00:00Z');
+    expect(r.integrityStatus()).toMatchObject({ ran: true, passed: true, generatedAt: '2026-06-05T01:00:00Z' });
+  });
+
+  // ── parity side ──
+
+  it('parity: no passes → blocked + stale; a fed clean window → cleared + fresh', () => {
+    const r = build();
+    expect(r.parityStatus()).toMatchObject({ cleared: false, stale: true, lastPassAt: null });
+    feedCleanWindow();
+    const p = r.parityStatus();
+    expect(p.cleared).toBe(true);
+    expect(p.stale).toBe(false);
+    expect(p.lastPassAt).toBe(new Date(T0 + 2 * HOUR).toISOString());
+  });
+
+  it('parity: a cleared window goes STALE when no pass lands within the freshness bound', () => {
+    const r = build();
+    feedCleanWindow();
+    expect(r.parityStatus().stale).toBe(false);
+    nowMs = T0 + 2 * HOUR + 7 * HOUR; // 7h after the last pass (> 6h default)
+    const p = r.parityStatus();
+    expect(p.cleared).toBe(true);   // the gate itself has no staleness…
+    expect(p.stale).toBe(true);     // …the readiness layer adds it
+    expect(r.status().ready).toBe(false);
+  });
+
+  // ── trigger-only parity pass (T7) ──
+
+  it('runParityPass: no source configured → refuses; nothing recorded', async () => {
+    const r = build(null);
+    const out = await r.runParityPass();
+    expect(out.ok).toBe(false);
+    if (!out.ok) expect(out.reason).toMatch(/no parity source configured/);
+    expect(monitor.passes.length).toBe(0);
+  });
+
+  it('runParityPass: a FAILED live check records NOTHING (absence of evidence)', async () => {
+    feedCleanWindow();
+    const before = monitor.passes.length;
+    const r = build(async () => { throw new Error('Portal 503'); });
+    const out = await r.runParityPass();
+    expect(out.ok).toBe(false);
+    if (!out.ok) expect(out.reason).toMatch(/parity check failed: Portal 503/);
+    expect(monitor.passes.length).toBe(before); // streak neither extended nor reset
+  });
+
+  it('runParityPass: records a clean pass AND a divergent pass faithfully (divergent resets the gate)', async () => {
+    feedCleanWindow();
+    const clean = build(async () => CLEAN);
+    const out1 = await clean.runParityPass();
+    expect(out1.ok).toBe(true);
+    if (out1.ok) {
+      expect(out1.pass.divergent).toBe(false);
+      expect(out1.gate.cleared).toBe(true);
+    }
+    const divergent = build(async () => DIVERGENT);
+    const out2 = await divergent.runParityPass();
+    expect(out2.ok).toBe(true);
+    if (out2.ok) {
+      expect(out2.pass.divergent).toBe(true);
+      expect(out2.gate.cleared).toBe(false); // a real divergence blocks the gate
+    }
+  });
+
+  // ── the composed signal + the door ──
+
+  it('ready ONLY when integrity passed AND parity cleared AND fresh; door is machine-readably manual', () => {
+    const r = build();
+    expect(r.status().ready).toBe(false);                    // nothing green
+    r.recordIntegrityReport(PASSED_REPORT);
+    expect(r.status().ready).toBe(false);                    // integrity alone insufficient
+    feedCleanWindow();
+    const s = r.status();
+    expect(s.ready).toBe(true);                              // both green + fresh
+    expect(s.door).toBe('manual-operator-click');            // decision 1A, structural
+    r.recordIntegrityReport(FAILED_REPORT);
+    expect(r.status().ready).toBe(false);                    // integrity regression re-blocks
+  });
+
+  it('parity window is DURABLE: a fresh monitor over the same file resumes the streak', () => {
+    feedCleanWindow();
+    const resumed = new DurableParityMonitor(new JsonlPassPersistence(path.join(dir, 'passes.jsonl')));
+    const r = new CutoverReadiness({
+      parityMonitor: resumed,
+      integrityReportPath: path.join(dir, 'integrity-report.json'),
+      runParityCheck: null,
+      now: () => nowMs,
+    });
+    expect(r.parityStatus().cleared).toBe(true);
+  });
+});

--- a/upgrades/next/cutover-readiness.md
+++ b/upgrades/next/cutover-readiness.md
@@ -1,0 +1,37 @@
+<!-- bump: minor -->
+
+## What Changed
+
+Added the cutover-readiness checker — the read-only surface that answers "is
+everything up to the cutover door green?" from durable server-side state, never from
+anyone's claim. It composes the two objective conditions the migration design names:
+the persisted import-integrity report and the durable zero-divergence parity window
+(now with a freshness bound, so a window that stopped being fed shows as stale instead
+of silently counting as ready). The two mandate conditions that previously always
+evaluated false now resolve from this real state — they still evaluate false until the
+state genuinely clears, so nothing changes behavior today. An agent can trigger a live
+parity check, but the server fetches and compares on its own; the request contributes
+nothing to the result, and a failed check records nothing. There is deliberately no
+route that fires the cutover itself: the flip stays a human action.
+
+## What to Tell Your User
+
+When a migration is gated on safety checks, you can now see at a glance whether
+everything up to the final switch is green — data integrity verified and live parity
+holding, both read from durable records the agents cannot fake. Your agent can ask the
+server to run a fresh comparison, but it cannot vouch for the result or write it in.
+And the final switch itself is still yours alone: there is intentionally no way for an
+agent to flip it.
+
+## Summary of New Capabilities
+
+- Read the composed cutover-readiness status: data-integrity verdict, live-parity
+  window with freshness, and an explicit marker that the final flip is a manual
+  operator action.
+- Trigger a server-side live parity comparison that records its result into the
+  durable window — failed checks record nothing.
+- Mandate conditions for gated authorities now resolve from this real durable state
+  instead of always refusing, enabling future conditioned delegations to actually
+  clear when the evidence does.
+- Maturity: stable; inert in behavior until integrity and parity records exist, and
+  the first issued mandate carries no conditioned authority.

--- a/upgrades/side-effects/cutover-readiness.md
+++ b/upgrades/side-effects/cutover-readiness.md
@@ -1,0 +1,63 @@
+# Side-effects review — Cutover-readiness checker (coordination-mandate spec §7, G2.4)
+
+Spec: `docs/specs/coordination-mandate.md` (approved by Justin, A/A/B, 2026-06-05) — §7
+names G2.4 and decision 1A scopes it: everything UP TO the door, never the door. Change:
+new `src/feedback-factory/cutoverReadiness.ts` + two `/cutover-readiness*` routes + the
+REAL condition resolvers replacing the deny-safe stubs in `AgentServer`'s coordination
+block.
+
+## 1. Blast radius
+
+Additive, with ONE deliberate behavior change inside the coordination block: the
+`integrity-gate-pass` and `parity-zero-divergence` conditions were `() => false` stubs;
+they now resolve from REAL durable state (the persisted import IntegrityReport and the
+durable parity window). Until that state genuinely clears, both still evaluate false —
+identical behavior to the stubs. The first mandate (per decision 3B) has no conditioned
+authority, so nothing live consumes them yet; the change makes the future
+execute-cutover authority REAL instead of permanently-denied. No other route, gate, or
+store is modified.
+
+## 2. State / data
+
+Two new files under the `.instar/state/` convention, created on first use:
+`feedback-parity-passes.jsonl` (append-only durable parity window, torn-line tolerant —
+the merged #781 persistence) and `feedback-integrity-report.json` (the import tooling's
+persisted IntegrityReport envelope). Absent files mean blocked/not-ready (deny-safe).
+
+## 3. Security model (T7 — the assertion-proof boundary)
+
+- **No "set the condition" input exists.** The ONLY writes: (a)
+  `POST /cutover-readiness/parity-pass` TRIGGERS a server-side live fetch+compare
+  (HttpParitySource → runDryRunCompare); the request body contributes NOTHING to the
+  result (integration-tested with a hostile body asserting cleanliness). (b)
+  `recordIntegrityReport()` is called by server-side import tooling — no HTTP route
+  writes it by design.
+- **A failed live check records NOTHING** — a fetch error is absence of evidence, not
+  evidence of divergence, and it cannot extend the clean window either (unit-tested
+  both ways).
+- **Freshness bound (readiness-layer addition):** the merged gate has no max-staleness —
+  a cleared streak stays cleared forever without new passes. The readiness layer marks
+  the window STALE when the last pass is older than 6h (default) and `ready` requires
+  fresh. Stated honestly: the gate's own policy is unchanged; staleness lives here.
+- **The door is structural:** there is NO fire-cutover route (integration-tested), the
+  status carries `door: 'manual-operator-click'` machine-readably, and the agent
+  template explicitly forbids presenting `ready` as permission to flip.
+- **Token handling:** the parity source token is read lazily from the encrypted
+  SecretStore (`portal.instarReadToken` by default) at check time — never persisted in
+  config, never logged, never in a response.
+
+## 4. Failure modes
+
+- No `feedbackMigration.paritySource` config → `runParityCheck` is null → the trigger
+  route 409s with a plain reason; the readiness read surface still works.
+- SecretStore miss → the check throws → 409, nothing recorded.
+- Engine init failure → coordination block's existing try/catch → routes 503, boot
+  unaffected.
+
+## 5. Test coverage
+
+9 unit + 5 integration + 3 e2e (17 total). The load-bearing e2e: a conditioned
+execute-cutover authority DENIES on a fresh boot and flips to ALLOW only after the
+durable state genuinely clears (pre-seeded parity window + integrity report written to
+the production state path, no restart) — then re-blocks on a failed report. Conditions
+provably resolve from REAL state on the production init path.


### PR DESCRIPTION
G2.4 of the approved coordination-mandate spec (`docs/specs/coordination-mandate.md` §7, scoped by decision 1A): the cutover-readiness checker — **everything up to the door, never the door**.

## What

`CutoverReadiness` (`src/feedback-factory/cutoverReadiness.ts`) + two `/cutover-readiness*` routes + the REAL condition resolvers replacing the deny-safe stubs in `AgentServer`'s coordination block:

- **`integrity-gate-pass`** ← the persisted import `IntegrityReport` (#778's `runIntegrityGate`, written server-side by import tooling — no HTTP write route exists by design).
- **`parity-zero-divergence`** ← the durable zero-divergence parity window (#781's `DurableParityMonitor`), **plus a readiness-layer freshness bound**: the merged gate has no max-staleness, so a cleared streak nobody feeds would stay "cleared" forever — the readiness layer marks it STALE after 6h and `ready` requires fresh. (Stated honestly: the gate's own policy is untouched.)
- **`GET /cutover-readiness`** — `{ ready, door: "manual-operator-click", integrity, parity }`, read-only. Decision 1A is structural: there is **no fire-cutover route** (integration-tested), and the agent template forbids presenting `ready` as permission to flip.
- **`POST /cutover-readiness/parity-pass`** — TRIGGERS a server-side live fetch+compare (`HttpParitySource` → `runDryRunCompare`; token read lazily from the encrypted SecretStore at check time). T7 discipline: the request body contributes NOTHING to the result (integration-tested with a hostile body asserting cleanliness), and a FAILED check records nothing — it can neither extend nor reset the window.

Behavior today is unchanged: both conditions still evaluate false until the durable state genuinely clears, and the first mandate (decision 3B) carries no conditioned authority.

## Tests

17 new (9 unit / 5 integration / 3 e2e). The load-bearing e2e: a conditioned `execute-cutover` authority DENIES on a fresh production boot and flips to ALLOW only after the durable state genuinely clears (pre-seeded parity window + integrity report written into the production state path, no restart) — then re-blocks on a failed report. Full coordination surface sweep: 70/70 green.

## ELI16

The migration ends with one big one-way switch, and the rule (Justin's decision) is that ONLY Justin flips it. But "is it safe to flip?" shouldn't be anyone's opinion — it should be a dashboard light wired to real sensors. This PR wires the light. Sensor one: did the data move over perfectly (checksums, no orphans)? That verdict comes from a report the import machinery writes — there's deliberately no web endpoint to fake it. Sensor two: have the old and new systems been agreeing for hours of live traffic? That comes from a tamper-resistant running log, and if nobody's fed it fresh comparisons recently, the light goes amber ("stale") instead of pretending green. An agent can press "run a fresh comparison," but the server does the comparing — asking nicely with a body that says "trust me, it's clean" does nothing, and a comparison that errors out writes nothing. And the switch itself? There's literally no route that flips it. The light can only ever say "everything up to your hand on the switch is green."

🤖 Generated with [Claude Code](https://claude.com/claude-code)
