### PR TITLE
fix(messaging): consumer-side guards — no crash-loop / 404-zombie on an unresolved secret placeholder

### DIFF
--- a/src/commands/server.ts
+++ b/src/commands/server.ts
@@ -3403,7 +3403,11 @@ export async function startServer(options: StartOptions): Promise<void> {
     // token, and dual-polling would 409. Fail-OPEN: any read miss/stale/
     // mismatch ⇒ false ⇒ server polls as today, so setups without a lifeline
     // are unaffected. Reads only — never writes the lease here.
-    const telegramBotToken = telegramConfig ? (telegramConfig.config as { token?: string }).token : undefined;
+    // HARDENED (v1.3.270 boot-crash incident): an unresolved `{ secret: true }`
+    // placeholder is a truthy OBJECT — only a real string token may reach
+    // tokenHash(), or the whole boot dies with ERR_INVALID_ARG_TYPE.
+    const rawTelegramToken = telegramConfig ? (telegramConfig.config as { token?: unknown }).token : undefined;
+    const telegramBotToken = typeof rawTelegramToken === 'string' && rawTelegramToken ? rawTelegramToken : undefined;
     const lifelineOwnsPolling = telegramConfig && telegramBotToken
       ? lifelineOwnsTelegramPoll(config.stateDir, telegramBotToken)
       : false;

--- a/src/messaging/TelegramAdapter.ts
+++ b/src/messaging/TelegramAdapter.ts
@@ -398,7 +398,7 @@ export class TelegramAdapter implements MessagingAdapter {
   private consecutivePollErrors = 0;
   // Diagnostics surfaced via getStatus() so health probes can explain WHY polling stopped.
   private lastPollError: string | null = null;
-  private fatalPollReason: '401' | 'network' | null = null;
+  private fatalPollReason: '401' | 'network' | 'no-usable-bot-token' | null = null;
   private pollStoppedAt: Date | null = null;
   private pending401Retry = false;
 
@@ -688,6 +688,18 @@ export class TelegramAdapter implements MessagingAdapter {
         `Update messaging.config.chatId in your instar.config.json with a valid numeric ID.`,
       );
     }
+    // HARDENED (v1.3.270 boot-crash incident): when the secrets merge fails, the
+    // externalized token arrives as the truthy `{ secret: true }` placeholder OBJECT.
+    // Polling with it stringified into the bot URL 404-zombies forever. Normalize a
+    // non-string token to '' — the well-defined TOKENLESS state every guard in this
+    // adapter already handles (standby/relay) — and say so loudly.
+    if (config.token != null && typeof config.token !== 'string') {
+      console.warn(
+        '[telegram] Bot token is not a string (unresolved secret placeholder — secret store unavailable at boot?). ' +
+        'Running TOKENLESS this boot: no polling, sends only via relay if available. A restart after the secret store recovers restores full service.',
+      );
+      config = { ...config, token: '' };
+    }
     this.config = config;
     this.stateDir = stateDir;
     this.suppressLifelineAutoCreate = opts?.suppressLifelineAutoCreate ?? false;
@@ -951,6 +963,19 @@ export class TelegramAdapter implements MessagingAdapter {
 
   async start(): Promise<void> {
     if (this.polling) return;
+    // HARDENED (v1.3.270 incident): without a usable bot token (empty/normalized
+    // placeholder), getUpdates 404s forever — a zombie poll loop that looks alive
+    // but never serves a message. Refuse to start polling and say why; send-only
+    // paths (relay) keep working, and the supervisor's next restart recovers full
+    // service once the secret store is readable again.
+    if (typeof this.config.token !== 'string' || this.config.token.length === 0) {
+      this.fatalPollReason = 'no-usable-bot-token';
+      console.error(
+        '[telegram] NOT starting long-polling: no usable bot token (unresolved secret placeholder or empty token). ' +
+        'The secret store was likely unavailable at boot — restart after it recovers to restore polling.',
+      );
+      return;
+    }
     this.polling = true;
     this.startedAt = new Date();
     this.consecutivePollErrors = 0;
@@ -2749,7 +2774,7 @@ export class TelegramAdapter implements MessagingAdapter {
     topicMappings: number;
     lastError: string | null;
     consecutivePollErrors: number;
-    fatalReason: '401' | 'network' | null;
+    fatalReason: '401' | 'network' | 'no-usable-bot-token' | null;
     stoppedAt: string | null;
   } {
     const stallStatus = this.sharedStallDetector

--- a/src/monitoring/probes/MessagingProbe.ts
+++ b/src/monitoring/probes/MessagingProbe.ts
@@ -18,7 +18,7 @@ export interface MessagingProbeDeps {
     topicMappings: number;
     lastError?: string | null;
     consecutivePollErrors?: number;
-    fatalReason?: '401' | 'network' | null;
+    fatalReason?: '401' | 'network' | 'no-usable-bot-token' | null;
     stoppedAt?: string | null;
   };
   /** Path to the Telegram message log JSONL file */

--- a/tests/unit/secrets-boot-hardening.test.ts
+++ b/tests/unit/secrets-boot-hardening.test.ts
@@ -1,0 +1,83 @@
+/**
+ * Tier-1 tests for the v1.3.270 boot-crash hardening — CONSUMER-SIDE guards.
+ *
+ * Scope note: the config-layer fix (per-agent keychain master key, verify-decrypt
+ * precedence, loud merge failure + critical-placeholder fail-fast) is a SEPARATE
+ * converged spec (docs/specs/keychain-per-agent-master-key.md) built in a parallel
+ * session. THIS file covers the consumer-side guards that hold regardless of WHY
+ * an unresolved `{ secret: true }` placeholder reaches the messaging layer:
+ *   1. TelegramAdapter constructor — a placeholder token NORMALIZES to the
+ *      well-defined tokenless state (never a truthy object downstream).
+ *   2. TelegramAdapter.start() — refuses to long-poll without a usable token
+ *      (fatalReason surfaced via getStatus) instead of 404-zombie-looping;
+ *      a real token still starts polling.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { TelegramAdapter } from '../../src/messaging/TelegramAdapter.js';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+
+describe('TelegramAdapter — placeholder-token normalization + poll refusal', () => {
+  let tmpDir: string;
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+  let errorSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'instar-boot-hard-'));
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+  afterEach(() => {
+    warnSpy.mockRestore();
+    errorSpy.mockRestore();
+    SafeFsExecutor.safeRmSync(tmpDir, { recursive: true, force: true, operation: 'tests/unit/secrets-boot-hardening.test.ts' });
+  });
+
+  it('constructor NORMALIZES a `{ secret: true }` placeholder token to tokenless — loudly, no throw', () => {
+    const adapter = new TelegramAdapter({
+      token: { secret: true } as unknown as string,
+      chatId: '-100123456',
+    }, tmpDir);
+    // The truthy-object can never flow downstream: status shows a clean stopped state.
+    expect(adapter.getStatus().started).toBe(false);
+    expect(warnSpy.mock.calls.some((c) => String(c[0]).includes('TOKENLESS'))).toBe(true);
+  });
+
+  it('start() REFUSES to long-poll without a usable token (no 404 zombie) and surfaces the reason', async () => {
+    const adapter = new TelegramAdapter({
+      token: { secret: true } as unknown as string,
+      chatId: '-100123456',
+    }, tmpDir);
+    await adapter.start();
+    const status = adapter.getStatus();
+    expect(status.started).toBe(false); // polling never began
+    expect(status.fatalReason).toBe('no-usable-bot-token');
+    expect(errorSpy.mock.calls.some((c) => String(c[0]).includes('NOT starting long-polling'))).toBe(true);
+    await adapter.stop();
+  });
+
+  it('start() with an EMPTY string token also refuses (both sides of the normalize path)', async () => {
+    const adapter = new TelegramAdapter({ token: '', chatId: '-100123456' }, tmpDir);
+    await adapter.start();
+    expect(adapter.getStatus().started).toBe(false);
+    expect(adapter.getStatus().fatalReason).toBe('no-usable-bot-token');
+    await adapter.stop();
+  });
+
+  it('a REAL string token still starts polling (the healthy path is untouched)', async () => {
+    const adapter = new TelegramAdapter({
+      token: 'test-token-123',
+      chatId: '-100123456',
+      pollIntervalMs: 50,
+    }, tmpDir);
+    // Stub the network so the poll loop runs without real HTTP.
+    (adapter as unknown as { getUpdates: () => Promise<unknown[]> }).getUpdates = async () => [];
+    (adapter as unknown as { ensureLifelineTopic: () => Promise<void> }).ensureLifelineTopic = async () => {};
+    await adapter.start();
+    expect(adapter.getStatus().started).toBe(true);
+    expect(adapter.getStatus().fatalReason).toBeNull();
+    await adapter.stop();
+  });
+});

--- a/upgrades/next/secrets-boot-hardening.md
+++ b/upgrades/next/secrets-boot-hardening.md
@@ -1,0 +1,28 @@
+<!-- bump: patch -->
+
+## What Changed
+
+Hardened the messaging layer against a failure seen in the field: when the
+encrypted-secrets read fails at startup, the unresolved secret marker used to flow
+into the messaging adapter as-is — crash-looping the server on a type error and
+leaving the message poller spinning uselessly against a dead address. Now the
+adapter recognizes an unusable credential, announces it loudly, and runs in a
+well-defined reduced mode instead: no polling, relay sends still work, and the
+reason is visible in its status. The deeper at-the-source fix (per-agent keychain
+keys and a loud, fail-fast secrets merge) ships separately; this change makes the
+messaging layer structurally unable to crash or go silently deaf regardless.
+
+## What to Tell Your User
+
+If your agent ever starts up while its encrypted secrets are unreadable, it now
+boots in a clearly-announced reduced messaging mode instead of crashing or going
+silently deaf — and a normal restart brings everything back. Nothing changes during
+ordinary startups.
+
+## Summary of New Capabilities
+
+- The messaging adapter refuses to poll with an unusable credential and reports the
+  reason in its status, rather than spinning forever against a dead address.
+- The server boots through an unresolved messaging credential instead of
+  crash-looping on it.
+- Maturity: stable; behavior on healthy startups is unchanged.

--- a/upgrades/side-effects/secrets-boot-hardening.md
+++ b/upgrades/side-effects/secrets-boot-hardening.md
@@ -1,0 +1,52 @@
+# Side-effects review — messaging consumer-side hardening (v1.3.270 incident)
+
+Incident (2026-06-05): Echo's server crash-looped at boot (~13 min Telegram mute) and
+the lifeline 404-zombied. The `{ secret: true }` placeholder OBJECT for the Telegram
+token survived a failed secrets merge and flowed into consumers — `tokenHash(Object)`
+threw ERR_INVALID_ARG_TYPE at startServer, and the poller stringified the object into
+the bot-token URL.
+
+**Scope note (parallel-work split):** the CONFIG-LAYER root-cause fix — per-agent
+keychain master key, verify-decrypt precedence, loud merge failure + critical-
+placeholder fail-fast — is a separate converged Tier-2 spec
+(`docs/specs/keychain-per-agent-master-key.md`, codex-adversarial-reviewed) built in a
+parallel session; its forensics identified the true root cause (a machine-global
+keychain slot poisoned by another agent's freshly-generated key — NOT transient
+contention). THIS change is deliberately narrowed to the CONSUMER-SIDE guards that
+hold regardless of why an unresolved placeholder ever reaches the messaging layer.
+The two compose: that spec makes the failure rare and loud at the source; this makes
+the messaging layer structurally unable to crash or zombie on it.
+
+## 1. The change (two consumer-side guards + one type widening)
+
+1. **Crash-path guard** (`commands/server.ts`): only a real non-empty STRING token
+   reaches `lifelineOwnsTelegramPoll`/`tokenHash` — a placeholder object is treated
+   as missing (no poll-ownership check; boot continues).
+2. **Zombie-path guard** (`TelegramAdapter`): a non-string token NORMALIZES to `''`
+   in the constructor (the well-defined TOKENLESS state every existing guard —
+   pool-standby/relay/send-only — already handles) with a loud warn, and `start()`
+   REFUSES to long-poll without a usable token, surfacing
+   `fatalReason: 'no-usable-bot-token'` via `getStatus()` instead of 404-looping.
+3. `fatalPollReason`/`fatalReason` union widened with `'no-usable-bot-token'`
+   (display-only; no consumer branches on the old literals — verified by grep).
+
+## 2. Blast radius
+
+Healthy boots byte-for-byte unchanged (string token → identical paths; no new
+warns). The tokenless pool-standby case is PRESERVED — normalization maps the
+failure into exactly that existing state. `start()`'s refusal fires only where
+polling would have 404-zombied anyway. No config, schema, or route changes.
+
+## 3. Failure modes after the fix
+
+An unresolved placeholder reaching the adapter → loud warn + tokenless boot (sends
+via relay still work) + visible `no-usable-bot-token` status; never a crash-loop,
+never a zombie poller. Recovery = next restart after the secret store is readable
+(or the keychain-per-agent fix lands and the failure stops occurring at all).
+
+## 4. Test coverage
+
+4 unit tests: constructor normalization (loud, no-throw, placeholder object);
+start() refusal for the placeholder AND the empty-string token with `fatalReason`
+surfaced; the healthy string-token path still polls. Adjacent suites re-run green
+(TelegramAdapter, Config, SecretMigrator — 32 passing).


### PR DESCRIPTION
**RE-SCOPED after a parallel-work check** (one agent, two sessions — caught via the Parallel-Work discipline before racing): a parallel Echo session has a converged, codex-adversarially-reviewed Tier-2 spec (`keychain-per-agent-master-key`) that owns the CONFIG-LAYER root cause — its forensics show the real failure was a **machine-global keychain slot poisoned by another agent's freshly-generated key** (deterministic decrypt failure), not transient contention as this PR originally framed. A retry-the-merge approach would NOT have fixed that; their per-agent-key + verify-decrypt-precedence + critical-placeholder-fail-fast design does.

This PR is therefore narrowed to the **consumer-side guards** that hold regardless of WHY an unresolved `{ secret: true }` placeholder ever reaches the messaging layer — zero file overlap with that spec's diff (it owns `Config.ts`/`SecretStore`/`SecretMigrator`; this touches `commands/server.ts`, `TelegramAdapter.ts`, `MessagingProbe.ts`):

1. **Crash-path guard** (`commands/server.ts`): only a non-empty STRING token reaches `tokenHash` — a placeholder object is treated as missing. No more `ERR_INVALID_ARG_TYPE` boot crash-loop.
2. **Zombie-path guard** (`TelegramAdapter`): a non-string token normalizes to `''` — the EXISTING well-defined tokenless pool-standby state — with a loud warn; `start()` refuses to long-poll without a usable token, surfacing `fatalReason: 'no-usable-bot-token'` via `getStatus()` instead of 404-looping forever.
3. `fatalReason` union widened (display-only).

Healthy boots are byte-for-byte unchanged; tokenless pool-standby behavior preserved.

## Tests

4 unit tests (constructor normalization loud + no-throw; poll refusal for placeholder AND empty-string tokens with `fatalReason` surfaced; healthy-token path still polls). Adjacent suites green (TelegramAdapter, Config, SecretMigrator — 32 passing).

## ELI16

Sometimes an agent boots while its lockbox of secrets won't open, and what it gets instead of the real messaging key is a sticky note reading "secret goes here." Before: one part of the boot did math on the sticky note and crashed the whole server, over and over; another part spent hours knocking on a door addressed by the note's text — looking alive, hearing nothing. The deeper fix for WHY the lockbox jammed (each agent getting its own key slot) ships separately. THIS change makes the messaging layer shrug-proof: if it's ever handed a sticky note again, it says so out loud, runs in an honest no-polling mode where relay sending still works, and reports exactly why in its status — no crash, no fake knocking, full service on the next clean restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)