### PR TITLE
Guard Gemini execution approval modals

### DIFF
--- a/docs/specs/gemini-modal-safe-reject.eli16.md
+++ b/docs/specs/gemini-modal-safe-reject.eli16.md
@@ -1,0 +1,32 @@
+# ELI16: Gemini Modal Safe Rejects
+
+Gemini sometimes pauses in a terminal box and asks for a choice.
+
+Some choices are safe defaults. For example, when `npx` says it needs to
+install `instar@1.3.270` and asks `Ok to proceed? (y)`, pressing Enter just
+accepts the package-runner default for the Instar CLI command the agent already
+started. Prompt Gate now recognizes that exact shape and presses Enter.
+
+Other choices are not safe defaults. The important one is:
+
+```text
+Allow execution of: ...
+1. Allow once
+2. Allow for this session
+3. No, suggest changes
+```
+
+That prompt means "may I run this command?" The command can be model-generated,
+wrong, or nonsense. Auto-yes would be arbitrary code execution. This change
+therefore has no auto-yes path for execution approvals. If Prompt Gate sees the
+exact execution-approval modal and can find the reject option, it chooses the
+reject option.
+
+The reject is visible. The server logs the rejected command text and reports an
+observable Prompt Gate event, so a mentor can tell that the agent was stopped by
+a safety decision instead of silently stalling.
+
+Near misses still do not get answered automatically. Arbitrary package installs
+and execution prompts without the known reject option fall back to the normal
+relay path.
+

--- a/src/commands/server.ts
+++ b/src/commands/server.ts
@@ -3208,9 +3208,26 @@ export async function startServer(options: StartOptions): Promise<void> {
           // and skip the classify/relay pipeline entirely to avoid Telegram
           // spam on prompts that don't actually block the session.
           if (prompt.autoDismissKey) {
+            if (prompt.autoDismissDisposition === 'safe-reject') {
+              const rejectedCommand = prompt.autoDismissCommand || prompt.summary || '(unknown command)';
+              console.warn(
+                `[PromptGate] Auto-rejected execution approval for ${prompt.sessionName} ` +
+                `(key="${prompt.autoDismissKey}"): ${rejectedCommand}`
+              );
+              DegradationReporter.getInstance().report({
+                feature: 'PromptGate.executionApprovalAutoReject',
+                primary: 'Relay execution-approval prompts to the user or reject them explicitly',
+                fallback: `Auto-rejected execution approval with key "${prompt.autoDismissKey}"`,
+                reason: `Rejected command: ${rejectedCommand}`,
+                impact: 'The session may pause or alter course, but arbitrary model-proposed command execution was not approved.',
+              });
+            }
             const dismissed = sessionManager.sendKey(prompt.sessionName, prompt.autoDismissKey);
+            const dismissKind = prompt.autoDismissDisposition === 'safe-reject'
+              ? 'safe-reject prompt'
+              : 'non-blocking prompt';
             console.log(
-              `[PromptGate] Auto-dismissed non-blocking prompt for ${prompt.sessionName} ` +
+              `[PromptGate] Auto-dismissed ${dismissKind} for ${prompt.sessionName} ` +
               `(key="${prompt.autoDismissKey}", sent=${dismissed}): ${prompt.summary}`
             );
             // Reset detector state so the next genuine prompt isn't blocked

--- a/src/monitoring/PromptGate.ts
+++ b/src/monitoring/PromptGate.ts
@@ -32,6 +32,15 @@ export interface DetectedPrompt {
    * SKIP the relay/classify pipeline entirely.
    */
   autoDismissKey?: string;
+  /**
+   * Safety disposition for deterministic auto-dismisses. `safe-default`
+   * answers a framework-owned non-risky prompt with its known default.
+   * `safe-reject` explicitly refuses an execution prompt; it must never
+   * approve code execution and must be logged by the consumer.
+   */
+  autoDismissDisposition?: 'safe-default' | 'safe-reject';
+  /** Command text rejected by an execution-approval safe-reject prompt. */
+  autoDismissCommand?: string;
 }
 
 export interface PromptOption {
@@ -76,6 +85,8 @@ interface PatternMatch {
   summary: string;
   options?: PromptOption[];
   autoDismissKey?: string;
+  autoDismissDisposition?: 'safe-default' | 'safe-reject';
+  autoDismissCommand?: string;
 }
 
 function extractNumberedOptions(lines: string[]): PromptOption[] {
@@ -117,6 +128,7 @@ function detectGeminiSafeDefaultModal(lines: string[], fullWindow?: string[]): P
         { key: 'Escape', label: 'Cancel' },
       ],
       autoDismissKey: key,
+      autoDismissDisposition: 'safe-default',
     };
   }
 
@@ -134,6 +146,23 @@ function detectGeminiSafeDefaultModal(lines: string[], fullWindow?: string[]): P
         { key: 'Escape', label: 'Cancel' },
       ],
       autoDismissKey: key,
+      autoDismissDisposition: 'safe-default',
+    };
+  }
+
+  const isNpxInstarPackageInstall = (
+    /Need to install the following packages:\s*\n\s*instar@\d+\.\d+\.\d+(?:[-+.\w]*)?\s*\n\s*Ok to proceed\?\s*\(y\)/i.test(haystack)
+  );
+  if (isNpxInstarPackageInstall) {
+    return {
+      type: 'confirmation',
+      summary: 'Gemini CLI install-confirm modal (auto-answer: npx instar default)',
+      options: [
+        { key: 'Enter', label: 'Use highlighted default' },
+        { key: 'Escape', label: 'Cancel' },
+      ],
+      autoDismissKey: 'Enter',
+      autoDismissDisposition: 'safe-default',
     };
   }
 
@@ -150,10 +179,38 @@ function detectGeminiSafeDefaultModal(lines: string[], fullWindow?: string[]): P
         { key: 'Escape', label: 'Cancel' },
       ],
       autoDismissKey: 'Enter',
+      autoDismissDisposition: 'safe-default',
     };
   }
 
   return null;
+}
+
+function detectExecutionApprovalSafeReject(lines: string[], fullWindow?: string[]): PatternMatch | null {
+  const windowLines = fullWindow ?? lines;
+  const haystack = windowLines.join('\n');
+  if (!/Allow execution of:/i.test(haystack)) return null;
+
+  const options = extractNumberedOptions(windowLines);
+  const rejectKey = findOptionKey(options, /\b(no|reject|suggest changes|deny|cancel)\b/i);
+  if (!rejectKey) return null;
+
+  const commandMatch = haystack.match(/Allow execution of:\s*([\s\S]*?)(?:\n\s*[●○◉]?\s*1[.)]\s+Allow once|\n\s*1[.)]\s+Allow once|$)/i);
+  const rejectedCommand = (commandMatch?.[1] ?? '')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .slice(0, 500);
+
+  return {
+    type: 'confirmation',
+    summary: rejectedCommand
+      ? `Gemini CLI execution-approval modal (auto-reject): ${rejectedCommand.slice(0, 120)}`
+      : 'Gemini CLI execution-approval modal (auto-reject)',
+    options,
+    autoDismissKey: rejectKey,
+    autoDismissDisposition: 'safe-reject',
+    autoDismissCommand: rejectedCommand || undefined,
+  };
 }
 
 /**
@@ -171,6 +228,16 @@ const PROMPT_PATTERNS: Array<{
     type: 'confirmation',
     test(lines, fullWindow) {
       return detectGeminiSafeDefaultModal(lines, fullWindow);
+    },
+  },
+
+  // Gemini CLI execution approval. This is deliberately separate from the
+  // safe-default modal detector above: approving here would execute arbitrary
+  // model-proposed shell text. The only deterministic action is rejection.
+  {
+    type: 'confirmation',
+    test(lines, fullWindow) {
+      return detectExecutionApprovalSafeReject(lines, fullWindow);
     },
   },
 
@@ -467,6 +534,8 @@ export class InputDetector extends EventEmitter {
       detectedAt: Date.now(),
       id: randomBytes(6).toString('base64url'),
       autoDismissKey: match.autoDismissKey,
+      autoDismissDisposition: match.autoDismissDisposition,
+      autoDismissCommand: match.autoDismissCommand,
     };
 
     emitted.add(fingerprint);

--- a/tests/unit/PromptGate.test.ts
+++ b/tests/unit/PromptGate.test.ts
@@ -348,6 +348,24 @@ describe('InputDetector.pattern.geminiSafeDefaultModals', () => {
     expect(prompt!.type).toBe('confirmation');
     expect(prompt!.summary).toMatch(/install-confirm/i);
     expect(prompt!.autoDismissKey).toBe('Enter');
+    expect(prompt!.autoDismissDisposition).toBe('safe-default');
+  });
+
+  it('detects the npx instar package-runner install-confirm modal and sends Enter', () => {
+    const detector = makeDetector();
+    const output = [
+      'Need to install the following packages:',
+      'instar@1.3.270',
+      'Ok to proceed? (y)',
+      '',
+    ].join('\n');
+
+    const prompt = detectWithDebounce(detector, 'gemini', output);
+    expect(prompt).not.toBeNull();
+    expect(prompt!.type).toBe('confirmation');
+    expect(prompt!.summary).toMatch(/install-confirm/i);
+    expect(prompt!.autoDismissKey).toBe('Enter');
+    expect(prompt!.autoDismissDisposition).toBe('safe-default');
   });
 
   it('does NOT auto-answer a generic non-Gemini install question', () => {
@@ -363,6 +381,58 @@ describe('InputDetector.pattern.geminiSafeDefaultModals', () => {
 
     const prompt = detectWithDebounce(detector, 'shell', output);
     if (prompt) expect(prompt.autoDismissKey).toBeUndefined();
+  });
+
+  it('does NOT auto-answer arbitrary package-runner install confirmations', () => {
+    const detector = makeDetector();
+    const output = [
+      'Need to install the following packages:',
+      'left-pad@1.3.0',
+      'Ok to proceed? (y)',
+      '',
+    ].join('\n');
+
+    const prompt = detectWithDebounce(detector, 'gemini', output);
+    if (prompt) expect(prompt.autoDismissKey).toBeUndefined();
+  });
+
+  it('detects Gemini execution-approval modals and auto-rejects with the reject option', () => {
+    const detector = makeDetector();
+    const output = [
+      "Allow execution of: '# Okay, I will just apply the fix that the mentor likely expects'?",
+      '',
+      '● 1. Allow once',
+      '  2. Allow for this session',
+      '  3. No, suggest changes (esc)',
+      '',
+    ].join('\n');
+
+    const prompt = detectWithDebounce(detector, 'gemini', output);
+    expect(prompt).not.toBeNull();
+    expect(prompt!.type).toBe('confirmation');
+    expect(prompt!.summary).toMatch(/execution-approval/i);
+    expect(prompt!.summary).toMatch(/auto-reject/i);
+    expect(prompt!.autoDismissKey).toBe('3');
+    expect(prompt!.autoDismissDisposition).toBe('safe-reject');
+    expect(prompt!.autoDismissCommand).toContain('# Okay');
+  });
+
+  it('does NOT auto-approve execution-approval modals even when allow is highlighted', () => {
+    const detector = makeDetector();
+    const output = [
+      "Allow execution of: 'npm test'?",
+      '',
+      '● 1. Allow once',
+      '  2. Allow for this session',
+      '  3. No, suggest changes (esc)',
+      '',
+    ].join('\n');
+
+    const prompt = detectWithDebounce(detector, 'gemini', output);
+    expect(prompt).not.toBeNull();
+    expect(prompt!.autoDismissKey).toBe('3');
+    expect(prompt!.autoDismissDisposition).toBe('safe-reject');
+    expect(prompt!.options?.find(option => /Allow once/i.test(option.label))?.key).toBe('1');
   });
 });
 

--- a/upgrades/next/gemini-modal-safe-reject.md
+++ b/upgrades/next/gemini-modal-safe-reject.md
@@ -1,0 +1,45 @@
+# Upgrade Guide — vNEXT
+
+<!-- bump: patch -->
+
+## What Changed
+
+Prompt Gate now recognizes the exact Gemini CLI package-runner install prompt
+that blocked the live mentorship cycle: an `instar` package version followed by
+`Ok to proceed? (y)`. That narrow prompt is answered with the highlighted
+default, so the agent can continue through its own Instar CLI command without a
+manual Enter press. Arbitrary package installs are not auto-answered.
+
+Prompt Gate also recognizes Gemini CLI execution-approval modals, but with the
+opposite policy. Execution approvals ask whether model-proposed command text may
+run. This change adds no approval path. When the known modal shape includes the
+reject option, Prompt Gate chooses that reject option and records the rejected
+command text in the server log plus an observable Prompt Gate event.
+
+## Evidence
+
+Not reproducible in a live dev shell without driving Gemini into the exact
+interactive modal, but covered by deterministic unit fixtures from the captured
+terminal shapes:
+
+- package-runner install prompt for `instar@1.3.270` auto-dismisses with Enter;
+- arbitrary package-runner install prompt does not auto-dismiss;
+- execution-approval modal with highlighted Allow once still auto-rejects;
+- rejected execution command text is carried in the detected prompt metadata.
+
+## What to Tell Your User
+
+Gemini can now get past the specific Instar package install prompt that was
+blocking mentor cycles. If Gemini asks to run an arbitrary command, Instar will
+not approve it automatically. It rejects the known approval prompt and leaves a
+visible record of the command it refused, so the mentor can see why the task
+changed course.
+
+## Summary of New Capabilities
+
+- Auto-answer the narrow Gemini package-runner install confirmation for Instar
+  package versions.
+- Auto-reject Gemini execution-approval modals with an explicit reject option.
+- Record execution auto-rejects visibly so mentor diagnosis does not depend on
+  guessing from a stalled terminal.
+

--- a/upgrades/side-effects/gemini-modal-safe-reject.md
+++ b/upgrades/side-effects/gemini-modal-safe-reject.md
@@ -1,0 +1,86 @@
+# Side-effects Review: Gemini Modal Safe Rejects
+
+## Change
+
+This Tier-1 change extends the existing Prompt Gate deterministic modal path.
+It does not introduce a new policy engine or a new execution surface.
+
+Touched surfaces:
+
+- `src/monitoring/PromptGate.ts`: adds narrow Gemini CLI matchers for the
+  observed `npx instar@... Ok to proceed? (y)` install prompt and for Gemini
+  execution-approval modals with an explicit reject option.
+- `src/commands/server.ts`: logs execution auto-rejects before sending the
+  reject key, and reports them through `DegradationReporter`.
+- `tests/unit/PromptGate.test.ts`: covers the install-confirm match and
+  near-miss, plus the execution-approval reject boundary.
+
+## Overreach / Underreach
+
+The install matcher is deliberately under-broad. It accepts only the captured
+package-runner shape for `instar@x.y.z`, because the live miss was `instar`
+itself. It does not auto-answer unrelated package installs such as `left-pad`.
+
+The execution matcher is also narrow. It only auto-rejects when the terminal
+shows the known `Allow execution of:` modal and a reject option. If the UI shape
+changes or the reject option is missing, normal relay/classification remains the
+fallback. There is no auto-approve path.
+
+## Safety Boundary
+
+Install confirmations and execution approvals are not the same class.
+
+An `npx instar@... Ok to proceed? (y)` prompt confirms the package runner's
+default for an Instar command the agent already invoked. Accepting it unblocks
+the intended tool path.
+
+An execution-approval prompt asks whether arbitrary command text may run. The
+command can be malformed, unrelated to the task, or unsafe. The live Gemini
+cycle proved this with a shell-comment command. Auto-approving that class would
+turn model output into code execution. This change therefore only supports
+safe-reject for execution approvals.
+
+## Observability
+
+Auto-rejects are intentionally visible. Before sending the reject key, the
+server writes a `[PromptGate] Auto-rejected execution approval...` warning with
+the rejected command text and emits a `PromptGate.executionApprovalAutoReject`
+DegradationReporter event.
+
+This is not just debugging convenience. It is part of the safety design: when a
+mentee appears to stall or pivot, the mentor can see that the framework rejected
+an execution prompt and why.
+
+## Signal vs Authority
+
+The new matchers are deterministic authority only for two tightly-scoped UI
+shapes:
+
+- safe-default for `instar@...` package-runner install confirmation;
+- safe-reject for Gemini execution approval with an explicit reject option.
+
+Everything else remains signal for the existing Prompt Gate relay/classifier
+flow. The change does not add an LLM prompt filter, does not broaden yes/no
+auto-approval, and does not treat generic `Ok to proceed?` text as authority.
+
+## Adjacent Systems
+
+- Telegram/Slack prompt relay: unchanged for prompts that do not match the new
+  exact shapes.
+- AutoApprover: unchanged. Execution safe-reject uses the pre-classifier
+  auto-dismiss path, not the auto-approve path.
+- DegradationReporter: receives one observable event per execution auto-reject.
+  The event is intentional and mentor-facing; it should not be treated as a
+  failure of Prompt Gate.
+
+## Rollback
+
+Revert the three code/test changes and remove these upgrade artifacts. Runtime
+state does not need migration. Existing agents would return to relaying or
+waiting on these Gemini prompts.
+
+## Verification
+
+- `npm test -- --run tests/unit/PromptGate.test.ts` passed, 57 tests.
+- `npx tsc --noEmit` passed.
+


### PR DESCRIPTION
## Summary

- Add a narrow PromptGate safe-default matcher for the captured `npx instar` package-runner install prompt shape.
- Add a separate Gemini execution-approval matcher that only auto-rejects; there is no auto-approve path for execution prompts.
- Log each execution auto-reject with the rejected command text and emit a DegradationReporter event for mentor-visible diagnosis.

## ELI16

Gemini can pause inside a terminal box and ask for a choice. Some choices are safe defaults, like the package runner asking whether it may install the Instar CLI package that the agent already tried to run. This PR recognizes that exact Instar package prompt and presses the default Enter key so the mentorship task can continue.

Execution approval is different. When Gemini asks whether it may run command text, the command may be model-generated, malformed, unrelated, or unsafe. This PR deliberately adds no yes-path for that prompt. If PromptGate sees the known execution-approval modal and can find the reject option, it chooses reject and records the command it refused, so the mentor can see why the task stalled or changed course.

## Verification

- `npm test -- --run tests/unit/PromptGate.test.ts`
- `npx tsc --noEmit`
- `node scripts/check-upgrade-guide.js`
- `npm test -- --run tests/unit/no-silent-fallbacks.test.ts tests/unit/PromptGate.test.ts`
- `npm run lint`
- pre-push smoke: PromptGate affected suite, 57 tests
- pre-push scoped e2e: Threadline suite, 17 files / 332 tests
