### PR TITLE
fix(presence): recognize the session-limit banner — stop saying "actively working" while paused

### DIFF
--- a/docs/specs/session-limit-presence-honesty.eli16.md
+++ b/docs/specs/session-limit-presence-honesty.eli16.md
@@ -1,0 +1,26 @@
+# "Actively working" while actually paused — fixed (the plain-English version)
+
+One night your conversation sat on a machine whose Claude session had hit its
+limit — the terminal literally said "Session limit reached ∙ resets 10:30pm" —
+and yet the standby watcher kept telling you "echo is actively working on
+something." You waited on a machine that was doing nothing.
+
+The watcher already knew how to be honest about this: when it sees a
+quota-limit banner in the session's terminal, it's supposed to say "the agent
+has hit its usage limit, the session is paused, no work is being done" — with
+the reset time. The bug was narrower and dumber: the newer banner WORDING
+wasn't in its list of recognizable phrases. It knew "You've hit your limit -
+resets 7pm (America/Los_Angeles)" but not "Session limit reached ∙ resets
+10:30pm" (no timezone in parentheses, different phrasing) — so it fell back to
+the generic "actively working" line.
+
+The fix adds the missing wordings: "session limit reached", "session limit …
+resets …", and any limit banner with a bare "resets 10:30pm" (no timezone).
+"Approaching session limit" deliberately does NOT trigger it — approaching
+isn't paused, and the session is still working then.
+
+What you'll see now: if a session is paused on its limit, every standby
+message says exactly that — paused, no work happening, resets at HH:MM —
+instead of pretending it's busy. That honest message already feeds all three
+check-in tiers (the 20-second, 2-minute, and 5-minute updates), so the very
+first thing you hear is the truth.

--- a/src/monitoring/PresenceProxy.ts
+++ b/src/monitoring/PresenceProxy.ts
@@ -278,6 +278,14 @@ const QUOTA_EXHAUSTION_PATTERNS = [
   /usage limit.*reached/i,
   /quota.*exceeded/i,
   /rate limit.*exceeded/i,
+  // 2026-06-05 incident (topic 2169): the session-limit banner reads
+  // "Session limit reached ∙ resets 10:30pm" — no parenthesized timezone, and
+  // none of the patterns above matched, so the standby kept saying "actively
+  // working" while the session was paused on its limit. "approaching session
+  // limit" deliberately does NOT match (approaching ≠ paused).
+  /session limit reached/i,
+  /session limit\b[^a-z]*resets/i,                       // "session limit, resets 10:30pm" / "Session limit ∙ resets…"
+  /\blimit\b.*\bresets?\s+\d{1,2}(?::\d{2})?\s*(?:am|pm)\b/i, // any limit banner with a bare "resets 10:30pm" (no tz paren)
 ];
 
 /**

--- a/tests/unit/presence-proxy-quota.test.ts
+++ b/tests/unit/presence-proxy-quota.test.ts
@@ -179,3 +179,31 @@ describe('PresenceProxy source — quota integration', () => {
     expect(quotaIdx).toBeLessThan(llmIdx);
   });
 });
+
+// ── 2026-06-05 incident (topic 2169) — the session-limit banner variant ──
+// The pane showed "Session limit reached ∙ resets 10:30pm" (no timezone
+// paren) while the standby kept reporting "actively working". None of the
+// original patterns matched that wording.
+describe('Quota exhaustion detection — session-limit banner (2026-06-05 incident)', () => {
+  it('detects "Session limit reached ∙ resets 10:30pm" (the verbatim incident banner)', () => {
+    const result = detectQuotaExhaustion(`Some output\nSession limit reached ∙ resets 10:30pm`);
+    expect(result).not.toBeNull();
+    expect(result).toContain('usage limit');
+  });
+
+  it('detects "session limit, resets 10:30pm" (comma variant)', () => {
+    expect(detectQuotaExhaustion(`session limit, resets 10:30pm`)).not.toBeNull();
+  });
+
+  it('detects a bare "You have reached your limit · resets 4pm" (no timezone paren)', () => {
+    expect(detectQuotaExhaustion(`You have reached your limit · resets 4pm`)).not.toBeNull();
+  });
+
+  it('does NOT fire on "approaching session limit" (approaching ≠ paused)', () => {
+    expect(detectQuotaExhaustion(`Approaching session limit — consider wrapping up\n> working on the next step`)).toBeNull();
+  });
+
+  it('does NOT fire on ordinary prose containing "resets" without a limit context', () => {
+    expect(detectQuotaExhaustion(`The cron job resets 3 counters at midnight\nmore output\nmore output`)).toBeNull();
+  });
+});

--- a/upgrades/next/session-limit-presence-honesty.md
+++ b/upgrades/next/session-limit-presence-honesty.md
@@ -1,0 +1,29 @@
+<!-- bump: patch -->
+
+## What Changed
+
+The standby presence watcher no longer reports "agent is actively working"
+while a session is actually paused on Claude's session limit. The honest
+"paused on its usage limit — resets at HH:MM" message already existed, but
+the newer limit-banner wording ("Session limit reached ∙ resets 10:30pm" —
+no parenthesized timezone) matched none of its detection patterns, so the
+watcher fell back to the generic busy message (the 2026-06-05 topic-2169
+incident). Three patterns added; "approaching session limit" deliberately
+does not trigger it.
+
+## What to Tell Your User
+
+If a session hits its Claude limit, my check-in messages now say exactly
+that — paused, nothing running, resets at HH:MM — instead of claiming I'm
+busy while you wait on a silent machine.
+
+## Summary of New Capabilities
+
+- Session-limit banners (all current wordings) produce the honest paused
+  message across all three presence tiers.
+
+## Evidence
+
+`tests/unit/presence-proxy-quota.test.ts` 21/21 — 5 new (verbatim incident
+banner, comma/middot variants, bare reset time, and two negative cases:
+"approaching" and prose "resets"). tsc + lint clean.

--- a/upgrades/side-effects/session-limit-presence-honesty.md
+++ b/upgrades/side-effects/session-limit-presence-honesty.md
@@ -1,0 +1,45 @@
+# Side-Effects Review — Session-limit presence honesty (pattern coverage)
+
+**Version / slug:** `session-limit-presence-honesty`
+**Date:** `2026-06-05`
+**Author:** `echo`
+**Second-pass reviewer:** `not required` (additive detection patterns in an existing, already-wired honest-message path; both sides test-pinned)
+
+## Summary of the change
+
+`detectQuotaExhaustion` (PresenceProxy) gains three patterns covering the
+session-limit banner wording from the 2026-06-05 topic-2169 incident
+("Session limit reached ∙ resets 10:30pm" — no timezone paren), so the
+standby reports "paused on its limit, resets at HH:MM" instead of "actively
+working". No new code paths — the honest message + its three tier call sites
+already exist.
+
+## Decision-point inventory
+
+1. New wordings match → honest paused message. Pinned (verbatim incident
+   banner + comma/middot variants + bare "resets 4pm").
+2. "Approaching session limit" → NOT matched (approaching ≠ paused). Pinned.
+3. Ordinary prose with "resets" (no limit context) → NOT matched. Pinned.
+4. Existing recovery logic (substantive output after the banner = stale)
+   unchanged and still covered by the 16 pre-existing tests.
+
+## Over-block / Under-block
+
+Over: a false match only swaps one templated standby message for another
+(more cautious) one — no action taken, nothing killed. Under: unknown future
+banner wordings still fall through to the generic message — same as today.
+
+## Level-of-abstraction fit / Signal vs authority
+
+Pattern list inside the single detection helper all three tiers share.
+Signal-only — message wording, never gates or kills.
+**Reference:** [docs/signal-vs-authority.md](../../docs/signal-vs-authority.md)
+
+## External surfaces / Rollback
+
+None / revert the pattern lines. No config, no state, no migration.
+
+## Evidence pointers
+
+`tests/unit/presence-proxy-quota.test.ts` 21/21 (5 new incl. the verbatim
+incident banner + both negative cases); tsc + lint clean.


### PR DESCRIPTION
## The incident (topic 2169; 12h autonomous mandate, topic 13481)

The session's pane showed **"Session limit reached ∙ resets 10:30pm"** while the presence watcher kept telling the user "echo is actively working on something." The user waited on a machine doing nothing.

## The fix (pattern coverage — the honest path already existed)

`detectQuotaExhaustion` already produces the honest message ("hit its usage limit — the session is paused, no work is being done — resets HH:MM") and already gates **all three presence tiers**. The newer banner wording just matched none of its patterns (no parenthesized timezone; "session limit" phrasing absent from the list).

Added: `/session limit reached/i`, `/session limit … resets/i`, and any limit banner with a bare `resets HH:MM(am|pm)` (no tz paren). **"approaching session limit" deliberately does NOT match** — approaching ≠ paused. Ordinary prose containing "resets" stays unmatched.

## Tests

`tests/unit/presence-proxy-quota.test.ts` 21/21 — 5 new: the verbatim incident banner, comma/middot variants, bare reset time, and both negative cases. tsc + lint clean.

Tier-1 lane (additive patterns in an existing helper, signal-only). Side-effects: `upgrades/side-effects/session-limit-presence-honesty.md`.

## ELI16

One night your conversation sat on a machine whose Claude session had hit its limit — the terminal literally said "Session limit reached ∙ resets 10:30pm" — and yet my standby watcher kept telling you "echo is actively working on something." The watcher already knew how to be honest about this: when it spots a limit banner in the terminal it's supposed to say "paused on its limit, nothing running, resets at HH:MM." The bug was narrower and dumber: the newer banner WORDING wasn't in its list of recognizable phrases — it knew "You've hit your limit - resets 7pm (America/Los_Angeles)" but not "Session limit reached ∙ resets 10:30pm". The fix adds the missing wordings. "Approaching session limit" deliberately doesn't trigger it, because approaching isn't paused — the session is still working then. From now on, if a session is paused on its limit, the very first check-in message you get says exactly that, with the reset time, instead of pretending it's busy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)