### PR TITLE
fix(cutover-readiness): realistic parity-pass budget + always-traced outcome

### DIFF
--- a/src/server/middleware.ts
+++ b/src/server/middleware.ts
@@ -366,6 +366,16 @@ export const OUTBOUND_MESSAGING_TIMEOUT_MS = 120_000;
 export const SPEC_REVIEW_TIMEOUT_MS = 180_000;
 
 /**
+ * Extended budget for the cutover-readiness parity-pass trigger
+ * (`/cutover-readiness/parity-pass`). One pass fetches the FULL live Portal
+ * cluster set (paginated) and compares server-side — measured at ~3.5 minutes
+ * against the real endpoint under load (2026-06-05). Under the 30s default the
+ * client always got a 408 while the handler kept running, and a late failure's
+ * 409 then crashed into ERR_HTTP_HEADERS_SENT with no trace of the outcome.
+ */
+export const PARITY_PASS_TIMEOUT_MS = 360_000;
+
+/**
  * The production per-path request-timeout overrides. Exported as the single
  * source of truth so wiring-integrity tests assert against the SAME map the
  * server actually wires — never a hand-rolled copy that could pass while the
@@ -380,6 +390,7 @@ export function buildRequestTimeoutOverrides(): Record<string, number> {
     '/imessage/reply': OUTBOUND_MESSAGING_TIMEOUT_MS,
     '/imessage/validate-send': OUTBOUND_MESSAGING_TIMEOUT_MS,
     '/spec/conformance-check': SPEC_REVIEW_TIMEOUT_MS,
+    '/cutover-readiness/parity-pass': PARITY_PASS_TIMEOUT_MS,
   };
 }
 

--- a/src/server/routes.ts
+++ b/src/server/routes.ts
@@ -5237,13 +5237,24 @@ export function createRoutes(ctx: RouteContext): Router {
 
   // TRIGGER a server-side parity pass (T7: the agent may ask; the server computes).
   // The request body contributes NOTHING to the result. 409 when no source is
-  // configured or the live check fails (nothing recorded on failure).
+  // configured or the live check fails (nothing recorded on failure). A real pass
+  // takes minutes (full live cluster fetch) — the route has a per-path timeout
+  // override (PARITY_PASS_TIMEOUT_MS); if the response window is EVER outlived
+  // anyway, the outcome is logged server-side and the late response is skipped
+  // (never a double-respond crash, never a silent outcome).
   router.post('/cutover-readiness/parity-pass', async (_req, res) => {
     if (!ctx.cutoverReadiness) {
       res.status(503).json({ error: 'cutover-readiness unavailable (no stateDir or init failed)' });
       return;
     }
     const outcome = await ctx.cutoverReadiness.runParityPass();
+    // The outcome always leaves a trace, even when the client's response timed out.
+    if (outcome.ok) {
+      console.log(`[cutover-readiness] parity pass recorded: divergent=${outcome.pass.divergent} clusters=${outcome.pass.clustersCompared} gateCleared=${outcome.gate.cleared}`);
+    } else {
+      console.warn(`[cutover-readiness] parity pass FAILED (nothing recorded): ${outcome.reason}`);
+    }
+    if (res.headersSent) return; // 408 already went out — outcome logged above
     if (!outcome.ok) {
       res.status(409).json({ error: outcome.reason });
       return;

--- a/tests/unit/parity-pass-timeout.test.ts
+++ b/tests/unit/parity-pass-timeout.test.ts
@@ -1,0 +1,116 @@
+/**
+ * Tests for the parity-pass request-timeout fix (2026-06-05 live finding: a real
+ * pass takes ~3.5 min — full live cluster fetch — so the 30s default 408'd every
+ * trigger, and a late failure's 409 crashed into ERR_HTTP_HEADERS_SENT with no
+ * trace of the outcome).
+ *
+ * Three layers: (1) the override resolves for the route (and ONLY the route —
+ * the read-only sibling keeps the default); (2) over real HTTP with a tiny
+ * timeout, a slow SUCCESSFUL pass still RECORDS and the outcome is logged with
+ * no double-respond crash; (3) a slow FAILED pass records nothing and logs the
+ * reason.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import express from 'express';
+import type { AddressInfo } from 'node:net';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import {
+  buildRequestTimeoutOverrides,
+  resolveRequestTimeout,
+  requestTimeout,
+  PARITY_PASS_TIMEOUT_MS,
+} from '../../src/server/middleware.js';
+import { createRoutes } from '../../src/server/routes.js';
+import { CutoverReadiness } from '../../src/feedback-factory/cutoverReadiness.js';
+import { DurableParityMonitor, JsonlPassPersistence } from '../../src/feedback-factory/monitor/parityMonitorStore.js';
+import type { ParityResult } from '../../src/feedback-factory/processor/parity.js';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+
+const DEFAULT_MS = 30_000;
+
+const CLEAN: ParityResult = {
+  clustersCompared: 1346, clustersWithFingerprint: 746, outcomesCompared: 0,
+  fingerprintDivergences: [], outcomeDivergences: [], divergent: false,
+};
+
+describe('parity-pass timeout override (wiring)', () => {
+  const overrides = buildRequestTimeoutOverrides();
+
+  it('resolves /cutover-readiness/parity-pass to the extended budget', () => {
+    expect(resolveRequestTimeout('/cutover-readiness/parity-pass', DEFAULT_MS, overrides)).toBe(PARITY_PASS_TIMEOUT_MS);
+    expect(PARITY_PASS_TIMEOUT_MS).toBeGreaterThanOrEqual(300_000); // ≥ the measured ~3.5min real pass
+  });
+
+  it('the read-only readiness sibling keeps the default (only the trigger is extended)', () => {
+    expect(resolveRequestTimeout('/cutover-readiness', DEFAULT_MS, overrides)).toBe(DEFAULT_MS);
+  });
+});
+
+describe('parity-pass outcome survives a timed-out response', () => {
+  let dir: string;
+  let server: { url: string; close: () => Promise<void> };
+  let monitor: DurableParityMonitor;
+  let check: () => Promise<ParityResult>;
+  let logSpy: ReturnType<typeof vi.spyOn>;
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(async () => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'parity-timeout-'));
+    logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    monitor = new DurableParityMonitor(new JsonlPassPersistence(path.join(dir, 'passes.jsonl')));
+    const readiness = new CutoverReadiness({
+      parityMonitor: monitor,
+      integrityReportPath: path.join(dir, 'integrity.json'),
+      runParityCheck: () => check(),
+    });
+    const app = express();
+    app.use(express.json());
+    // A 50ms budget so the 408 fires long before the 150ms "slow" check finishes.
+    app.use(requestTimeout(50, {}));
+    const ctx: any = { cutoverReadiness: readiness, config: { authToken: 't', stateDir: '/tmp', port: 0 }, stateDir: '/tmp' };
+    app.use(createRoutes(ctx));
+    server = await new Promise((resolve) => {
+      const srv = app.listen(0, () => resolve({
+        url: `http://127.0.0.1:${(srv.address() as AddressInfo).port}`,
+        close: () => new Promise<void>((r) => srv.close(() => r())),
+      }));
+    });
+  });
+  afterEach(async () => {
+    await server.close();
+    logSpy.mockRestore();
+    warnSpy.mockRestore();
+    SafeFsExecutor.safeRmSync(dir, { recursive: true, force: true, operation: 'tests/unit/parity-pass-timeout.test.ts' });
+  });
+
+  it('a slow SUCCESSFUL pass: client gets 408, the pass still RECORDS, outcome logged, no crash', async () => {
+    check = () => new Promise((r) => setTimeout(() => r(CLEAN), 150));
+    const res = await fetch(`${server.url}/cutover-readiness/parity-pass`, { method: 'POST' });
+    expect(res.status).toBe(408); // the middleware's timeout response
+    await new Promise((r) => setTimeout(r, 250)); // let the handler finish
+    expect(monitor.passes.length).toBe(1); // RECORDED despite the timed-out response
+    expect(monitor.passes[0].divergent).toBe(false);
+    expect(logSpy.mock.calls.some((c) => String(c[0]).includes('parity pass recorded'))).toBe(true);
+  });
+
+  it('a slow FAILED pass: client gets 408, nothing recorded, reason logged, no crash', async () => {
+    check = () => new Promise((_, rej) => setTimeout(() => rej(new Error('Portal 503')), 150));
+    const res = await fetch(`${server.url}/cutover-readiness/parity-pass`, { method: 'POST' });
+    expect(res.status).toBe(408);
+    await new Promise((r) => setTimeout(r, 250));
+    expect(monitor.passes.length).toBe(0);
+    expect(warnSpy.mock.calls.some((c) => String(c[0]).includes('parity pass FAILED'))).toBe(true);
+  });
+
+  it('a FAST pass still gets the normal 200 with the gate snapshot', async () => {
+    check = async () => CLEAN;
+    const res = await fetch(`${server.url}/cutover-readiness/parity-pass`, { method: 'POST' });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.recorded).toBe(true);
+    expect(body.pass.clustersCompared).toBe(1346);
+  });
+});

--- a/upgrades/next/parity-pass-timeout.md
+++ b/upgrades/next/parity-pass-timeout.md
@@ -1,0 +1,24 @@
+<!-- bump: patch -->
+
+## What Changed
+
+Gave the cutover-readiness live-comparison trigger a realistic time budget. A real
+comparison downloads the full live dataset and takes a few minutes; the default
+30-second request limit cut off every response mid-run, and a late failure then
+crashed the response handling with no record of what happened. The trigger now has
+a six-minute budget, and whatever the outcome — recorded or failed — it is always
+written to the server log, even if the caller's connection already timed out.
+
+## What to Tell Your User
+
+Nothing changes day to day. If your agent runs live data comparisons for a
+migration, those checks now finish reliably instead of getting cut off, and their
+results always show up in the logs.
+
+## Summary of New Capabilities
+
+- The live parity-comparison trigger completes within a realistic six-minute
+  budget instead of being cut off at thirty seconds.
+- Comparison outcomes are always logged server-side, even when the requester's
+  connection timed out first.
+- Maturity: stable; no other route's timing changes.

--- a/upgrades/side-effects/parity-pass-timeout.md
+++ b/upgrades/side-effects/parity-pass-timeout.md
@@ -1,0 +1,30 @@
+# Side-effects review — parity-pass request-timeout fix
+
+Live finding (2026-06-05, first real trigger of the just-deployed G2.4 surface): a
+real parity pass fetches the FULL live Portal cluster set and takes ~3.5 minutes
+(measured 204s). The 30s default request timeout 408'd every trigger; the handler
+kept running, and a late failure's 409 crashed into ERR_HTTP_HEADERS_SENT with no
+trace of the outcome anywhere.
+
+## 1. The change
+
+- `middleware.ts`: `PARITY_PASS_TIMEOUT_MS = 360_000` + a `buildRequestTimeoutOverrides`
+  entry for `/cutover-readiness/parity-pass` — the exact `/spec/conformance-check`
+  precedent (single heavy call, per-path budget). Longest-prefix matching means the
+  read-only `GET /cutover-readiness` sibling keeps the 30s default (tested).
+- `routes.ts` (trigger route): the outcome is now ALWAYS logged server-side
+  (recorded/failed + reason), and the response is skipped when `res.headersSent`
+  (a 408 already went out) — never a double-respond crash, never a silent outcome.
+
+## 2. Blast radius
+
+Two files, additive. No other route's budget changes. T7 unchanged: the trigger
+still computes server-side; failures still record nothing.
+
+## 3. Test coverage
+
+5 new tests: override resolves for the trigger (≥ the measured real-pass duration)
+and ONLY the trigger; over real HTTP with a tiny budget — a slow SUCCESSFUL pass
+still records after the 408 with the outcome logged and no crash; a slow FAILED
+pass records nothing with the reason logged; the fast path still 200s. Existing
+override wiring suite green (20 total).


### PR DESCRIPTION
Live finding from the first real trigger of the just-deployed G2.4 surface: a real parity pass fetches the FULL live Portal cluster set and takes **~3.5 minutes** (measured 204s against `dawn.bot-me.ai` tonight; result was `divergent:false` over 1346 clusters). Under the 30s default request timeout, every trigger 408'd while the handler kept running — and a late failure's 409 then crashed into `ERR_HTTP_HEADERS_SENT` with **no trace of the outcome anywhere** (observed live in my server log).

## Fix

1. **`PARITY_PASS_TIMEOUT_MS = 360_000`** + a `buildRequestTimeoutOverrides` entry for `/cutover-readiness/parity-pass` — the exact `/spec/conformance-check` precedent (single heavy call → per-path budget). Longest-prefix matching keeps the read-only `GET /cutover-readiness` sibling on the 30s default (tested).
2. **The trigger route always logs the outcome server-side** (recorded / failed + reason) and skips its response when `res.headersSent` — never a double-respond crash, never a silent outcome, even for a fire-and-forget caller.

T7 unchanged: the trigger still computes server-side, failures still record nothing.

## Tests

5 new: override resolves for the trigger (and asserts the budget ≥ the measured real-pass duration) and ONLY the trigger; over real HTTP with a tiny budget — a slow SUCCESSFUL pass still RECORDS after the 408 with the outcome logged and no crash; a slow FAILED pass records nothing with the reason logged; the fast path still 200s. Existing override wiring suite green (20 total).

## ELI16

The new "run a fresh comparison" button kicks off a job that genuinely takes a few minutes — it downloads the whole live dataset and checks every row. But the server had a blanket rule: any web request that takes over 30 seconds gets a "took too long" reply. So every press of the button got "took too long" while the job quietly kept running backstage — and if the job then failed, the server tripped over itself trying to answer an already-answered request, and the result vanished. Now that one button has its own six-minute timer (the same trick an earlier slow endpoint uses), and win or lose, the job's result is always written in the server's diary — even if whoever pressed the button already hung up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
