### PR TITLE
test(threadline): defuse ConversationStore retire-test time bomb (main red)

### DIFF
--- a/tests/unit/ConversationStore.test.ts
+++ b/tests/unit/ConversationStore.test.ts
@@ -195,7 +195,13 @@ describe('ConversationStore', () => {
 
   it('retires stale non-pinned active and idle conversations without deleting them', async () => {
     const store = new ConversationStore(stateDir);
-    const now = new Date('2026-05-30T09:00:00.000Z');
+    // TIME-BOMB GUARD: `now` must be the REAL current time, not a pinned date.
+    // The store's commit() path prunes non-pinned conversations older than
+    // MAX_AGE_MS (7d) against the REAL clock — with a pinned now, the backdated
+    // records cross that horizon once the calendar moves far enough past the
+    // pinned date and get PRUNED before retireInactive ever sees them (this test
+    // detonated on 2026-06-05, exactly 7 days after its pinned 2026-05-29 data).
+    const now = new Date();
     const stale = new Date(now.getTime() - 25 * 60 * 60 * 1000).toISOString();
     const fresh = new Date(now.getTime() - 10 * 60 * 1000).toISOString();
 


### PR DESCRIPTION
**Main has been red since 2026-06-05T00:00** — `ConversationStore > retires stale non-pinned...` fails on plain main and on every open PR's unit shard (it red-flagged #805 twice tonight).

## Root cause: a scheduled time bomb

The test pinned `now = 2026-05-30` and backdated its records' `lastActivityAt` to **2026-05-29** — but `ConversationStore.commit()` runs `pruneMapInPlace`, which deletes non-pinned conversations older than `MAX_AGE_MS` (7 days) against the **real** clock. On 2026-06-05 — exactly 7 days after the pinned data — the backdated records started getting pruned at commit time, so `retireInactive` found nothing and returned 0 instead of 2. The test was guaranteed to detonate on this exact date the day it was written.

## Fix

Derive `now` from the real clock; keep the 25h/10min offsets. The retire boundary stays deterministic (25h > 24h threshold) while the records stay far inside the 7-day prune horizon — forever. Comment in the test explains the trap for the next author. No production code touched.

## ELI16

The test set its watch to a date in May and wrote "yesterday" on its papers — but the filing cabinet it uses shreds anything older than a week using the REAL calendar. The day the real world got a week past May 29, the cabinet started shredding the test's papers before the test could check them. Now the test always writes "25 hours ago" relative to today, so its papers are always old enough to matter and never old enough to shred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
