### PR TITLE
fix(secrets): vault key coherence — per-agent keychain slots, keyId header, dual-key reads (CMT-1038)

### DIFF
--- a/docs/specs/vault-key-coherence.eli16.md
+++ b/docs/specs/vault-key-coherence.eli16.md
@@ -1,0 +1,49 @@
+# One vault, one key, always explainable — the plain-English version
+
+## The disease this kills
+
+Your secrets vault is an encrypted file, and the key to it can live in two
+places: the Mac's keychain, or a small key file next to the vault. The old
+design had a landmine: the keychain slot was SHARED by every agent on the
+machine, and anything that created a fresh vault (a test, a new agent) would
+generate a new key and silently overwrite that shared slot. Result: half the
+readers suddenly had the wrong key — and instead of saying "wrong key," they
+reported the vault as EMPTY. That's the heart of "I've given you this secret
+MANY MANY times": the secrets were there the whole time, just invisible to
+whichever reader grabbed the wrong key.
+
+## The three fixes
+
+**1. Every agent gets its own keychain slot.** The slot name now includes the
+agent's home path, so two agents can never clobber each other. An agent still
+using the old shared slot adopts its key into its own slot automatically the
+first time it reads — nothing for you to do. And nothing ever writes the old
+shared slot again.
+
+**2. The vault file now says which key opens it.** New vault writes stamp a
+short fingerprint of the key into the file header. A reader with the wrong
+key now gets a precise error — "this vault needs key 3f9a…, you have 7c01…"
+— instead of pretending the vault is empty. Wrong-key and actual corruption
+are now different, diagnosable errors. (Old vault files still read fine.)
+
+**3. Readers try both keys before giving up.** If the keychain and file keys
+have drifted apart, a reader that fails with one key tries the other. If the
+backup key works, you get your data — plus a loud note in the degradation log
+that the keys have diverged. The next time anything writes to the vault, it
+re-encrypts with the primary key, which quietly heals the split.
+
+Bonus: the sync status page now distinguishes "the vault is empty" from "the
+vault has data but the key is missing" — the exact confusion that hid this
+bug for weeks.
+
+## What you'll notice
+
+Nothing — which is the point. Secrets you hand me stay readable by every part
+of me, on every machine, forever. If the keys ever do drift, I keep working,
+tell the log exactly what happened, and self-heal on the next write instead
+of asking you to send the secret again.
+
+## What did NOT change
+
+The encryption itself (AES-256-GCM), where the vault lives, the one-time drop
+links, and the rule that tests can never touch your real keychain.

--- a/docs/specs/vault-key-coherence.md
+++ b/docs/specs/vault-key-coherence.md
@@ -1,0 +1,89 @@
+---
+parent-principle: "Distrust Temporary Success — A Recurrence Is a Root Cause"
+review-convergence: "rev-1 — the CMT-1038 root-cause fix for the recurring secret-invisibility disease (2026-06-05 incident: a machine-global keychain entry shared by every agent, silently overwritable by any fresh-stateDir SecretStore, bifurcated the vault into keychain-readers seeing 'empty' and file-readers seeing data). Three surgical layers: per-agent keychain accounts with legacy adoption; a key-id header (v2 format, v1 reads preserved) making wrong-key vs corruption diagnosable; dual-key read fallback with loud degradation and natural convergence on the next write. Crypto unchanged (AES-256-GCM); no defaults weakened; keychain ops made injectable so the logic is testable without touching a real keychain."
+approved: true
+approved-by: "operator (Justin) — standing mandate to fix the recurring secret loss (2026-06-04 topic 13481: 'this issue of dropping the secret has happened MANY MANY TIMES and we need to fix this') + the 2026-06-05 12h autonomous mandate; follow-up commitment CMT-1038 opened with his knowledge in the PR #789 report"
+approved-at: "2026-06-05T06:51:00Z"
+---
+
+# Vault Key Coherence — one agent, one key, diagnosable always
+
+**Status:** Approved 2026-06-05. Implementing.
+**Author:** Echo
+**Companion:** vault-key-coherence.eli16.md
+**Trigger:** CMT-1038. The 2026-06-05 incident: `instar-secret-store`/`master-key`
+is MACHINE-GLOBAL — one keychain slot shared by every agent and process on the
+box — while the file fallback key is per-agent. Any SecretStore constructed
+against a fresh stateDir generated a new key and silently OVERWROTE the global
+slot, instantly making every keychain-resolving reader see its vault as
+"empty" while file-key readers still saw the data. PR #789 made tests unable
+to trigger it; this PR removes the disease.
+
+## The three layers
+
+### 1. Per-agent keychain accounts (+ legacy adoption)
+
+`KEYCHAIN_ACCOUNT` becomes per-agent: `master-key:<stateDir>` (the absolute
+stateDir path — readable, unique, debuggable in Keychain Access). Resolution
+order on read:
+1. the per-agent entry;
+2. the LEGACY global entry (`master-key`) — if present, it is ADOPTED: copied
+   into the per-agent account (the global entry is left in place for other
+   not-yet-migrated agents; it is never written again by this code);
+3. the per-agent file key.
+
+Generation (no key anywhere) writes the per-agent account — never the global
+one. Combined with the #789 test guard, no code path writes the global slot
+again.
+
+### 2. Key-id header — v2 store format (v1 reads preserved)
+
+New writes: `'ISv2' (4) | keyId (8 = sha256(key)[0..8]) | iv (12) | tag (16) | ciphertext`.
+Reads:
+- v2 file → try the resolved candidate keys; only a key whose sha256 prefix
+  matches `keyId` is attempted; no candidate matches → a PRECISE error
+  ("encrypted with key id <hex>; available keys: <hexes>") — wrong-key is now
+  diagnosable and distinct from corruption (GCM auth failure with the
+  MATCHING key = corruption).
+- v1 file (no magic) → legacy path + layer 3 fallback.
+
+### 3. Dual-key read fallback + loud degradation + natural convergence
+
+`MasterKeyManager.getCandidateKeys()` returns `[primary, ...alternates]`
+(alternates = the other source, read-only — NEVER generates). `read()` tries
+the primary, then alternates; success via an alternate emits a
+DegradationReporter report ("vault decrypts with the <source> key but primary
+resolution is <source> — key sources diverged") and surfaces
+`lastReadKeySource` for observability. Convergence happens naturally: the next
+`write()`/`set()` re-encrypts v2 with the PRIMARY key — after which both
+sources agree (per-agent adoption makes the primary stable).
+
+`GET /secrets/sync-status` distinguishes decrypt-failure from empty: a read
+that throws yields `vaultStatus: 'decrypt-failed'` + the precise error instead
+of silently reporting `localKeyPaths: []` (the masking that hid the incident).
+
+## Testability seam
+
+Keychain ops (`read/write` per account) become injectable
+(`SecretStoreConfig.keychainOps`) so adoption/per-agent logic is unit-tested
+against a fake — the #789 VITEST file-key guard still forces file mode
+whenever keychainOps is NOT injected, so no test can ever touch the real
+keychain.
+
+## Backward compatibility
+
+- v1 files read forever; v2 written on the next write. Echo's live vault
+  (file-key, v1) reads unchanged; first write upgrades it to v2.
+- Agents still on the legacy global keychain entry adopt it on first read —
+  no operator action, no migration step (resolution-time adoption).
+- `forceFileKey` (config + tests) behavior unchanged.
+
+## Tests (unit — the crypto/resolution layer is pure given the seam)
+
+v2 roundtrip; v1 blob reads; v2 wrong-key error names the key ids; corruption
+with the matching key still throws GCM auth error; dual-key fallback both
+directions + degradation surfaced + lastReadKeySource; write-after-fallback
+converges to primary (v2, primary keyId); per-agent account preferred; legacy
+adoption copies to per-agent + never writes global; generation writes
+per-agent only; keychainOps-absent test runs stay file-key (the #789 guard).
+Integration: sync-status decrypt-failed vs empty. <!-- tracked: CMT-1038 -->

--- a/src/commands/server.ts
+++ b/src/commands/server.ts
@@ -10064,6 +10064,16 @@ export async function startServer(options: StartOptions): Promise<void> {
                   ? provisioner.provisionAll()
                   : Promise.resolve([]),
                 localKeyPaths: () => secretSyncMod.secretKeyPaths(readSecrets()),
+                // Vault readability probe — NEVER mask a decrypt failure as "empty"
+                // (the 2026-06-05 bifurcation hid behind localKeyPaths: []).
+                vaultStatus: () => {
+                  try {
+                    const secrets = provStore.read();
+                    return { status: Object.keys(secrets).length > 0 ? 'ok' as const : 'empty' as const };
+                  } catch (err) {
+                    return { status: 'decrypt-failed' as const, error: err instanceof Error ? err.message : String(err) };
+                  }
+                },
                 syncTargets: onlinePeers,
               };
               if (_secretSyncPushEnabled) {

--- a/src/core/SecretStore.ts
+++ b/src/core/SecretStore.ts
@@ -25,19 +25,51 @@ import { SafeFsExecutor } from './SafeFsExecutor.js';
 // ── Constants ────────────────────────────────────────────────────────
 
 const KEYCHAIN_SERVICE = 'instar-secret-store';
-const KEYCHAIN_ACCOUNT = 'master-key';
+/** LEGACY machine-global account — the root of the 2026-06-05 key-bifurcation
+ *  incident (one slot shared by every agent on the box, silently overwritable
+ *  by any fresh-stateDir SecretStore). Read for ADOPTION only; never written. */
+const KEYCHAIN_ACCOUNT_LEGACY = 'master-key';
 const MASTER_KEY_LENGTH = 32; // AES-256
 const IV_LENGTH = 12; // AES-256-GCM
 const AUTH_TAG_LENGTH = 16;
 const HKDF_INFO = 'instar-secret-sync-v1';
+/** v2 at-rest store format magic: 'ISv2' | keyId(8) | iv(12) | tag(16) | ct.
+ *  The keyId (sha256(key) prefix) makes wrong-key diagnosable vs corruption. */
+const STORE_MAGIC_V2 = Buffer.from('ISv2', 'ascii');
+const KEY_ID_LENGTH = 8;
+
+/** Per-agent keychain account: scoped by the absolute stateDir so two agents
+ *  on one machine can never clobber each other's master key. Readable in
+ *  Keychain Access (the path IS the identity — debuggable, collision-free). */
+export function perAgentKeychainAccount(stateDir: string): string {
+  return `master-key:${path.resolve(stateDir)}`;
+}
+
+/** The 8-byte key fingerprint stored in the v2 header. */
+export function keyIdOf(key: Buffer): Buffer {
+  return crypto.createHash('sha256').update(key).digest().subarray(0, KEY_ID_LENGTH);
+}
 
 // ── Types ────────────────────────────────────────────────────────────
+
+/** Injectable keychain operations (per service+account). Production uses the
+ *  real OS keychain (macOS `security` / Linux `secret-tool`); tests inject a
+ *  fake so the per-agent/adoption logic is unit-testable WITHOUT touching a
+ *  real keychain (the VITEST file-key guard stays in force when this is not
+ *  injected — an injected fake is, by definition, not the real keychain). */
+export interface KeychainOps {
+  read: (service: string, account: string) => Buffer | null;
+  /** Returns true on success. */
+  write: (service: string, account: string, key: Buffer) => boolean;
+}
 
 export interface SecretStoreConfig {
   /** State directory (.instar) */
   stateDir: string;
   /** Force file-based key storage (skip keychain) */
   forceFileKey?: boolean;
+  /** Test seam — see KeychainOps. Absent in production (real keychain used). */
+  keychainOps?: KeychainOps;
 }
 
 /** The decrypted secrets object (flat key-value or nested) */
@@ -65,149 +97,192 @@ export class MasterKeyManager {
   private stateDir: string;
   private forceFile: boolean;
   private keyFilePath: string;
+  private kc: KeychainOps;
 
-  constructor(stateDir: string, forceFile = false) {
+  constructor(stateDir: string, forceFile = false, keychainOps?: KeychainOps) {
     this.stateDir = stateDir;
-    // Test runs are ALWAYS file-key-only. The keychain entry is machine-global
-    // (one service/account shared by every agent and process on the box), so a
-    // test constructing a SecretStore against a fresh stateDir would generate a
-    // new master key and silently OVERWRITE that global entry — breaking every
-    // real store encrypted with the old key (2026-06-05 incident: an integration
-    // test run did exactly this to the dev agent's vault). Structural guard, not
-    // per-test convention: no test can pollute the keychain even if it forgets
-    // forceFileKey.
-    const inTestRun = !!process.env.VITEST || process.env.NODE_ENV === 'test';
+    // Test runs are ALWAYS file-key-only — UNLESS a fake keychain is injected
+    // (an injected KeychainOps is by definition not the real keychain, so the
+    // pollution risk the guard exists for cannot occur). The real-keychain
+    // guard (2026-06-05 incident: an integration test overwrote the then-
+    // machine-global entry and broke the dev agent's vault) stays structural:
+    // no test without an explicit fake can touch the OS keychain.
+    const inTestRun = (!!process.env.VITEST || process.env.NODE_ENV === 'test') && !keychainOps;
     this.forceFile = forceFile || inTestRun;
     this.keyFilePath = path.join(stateDir, 'machine', 'secrets-master.key');
+    this.kc = keychainOps ?? {
+      read: (service, account) => this.readOsKeychain(service, account),
+      write: (service, account, key) => this.writeOsKeychain(service, account, key),
+    };
   }
 
-  /** Retrieve or generate the master key. */
+  /**
+   * Retrieve or generate the master key. Resolution order (vault-key-coherence,
+   * CMT-1038 — the per-agent fix for the machine-global-slot bifurcation):
+   *   1. the PER-AGENT keychain entry (`master-key:<stateDir>`);
+   *   2. the LEGACY global entry (`master-key`) — ADOPTED on sight: copied into
+   *      the per-agent account (the global entry is left in place for other
+   *      not-yet-migrated agents; this code never writes it again);
+   *   3. the per-agent file key (generating one — and writing the PER-AGENT
+   *      keychain entry, never the global one — when none exists anywhere).
+   */
   getMasterKey(): Buffer {
     if (!this.forceFile) {
-      // Try keychain first
-      const keychainKey = this.readKeychain();
-      if (keychainKey) return keychainKey;
+      const account = perAgentKeychainAccount(this.stateDir);
+      const own = this.tryRead(account);
+      if (own) return own;
+      const legacy = this.tryRead(KEYCHAIN_ACCOUNT_LEGACY);
+      if (legacy) {
+        // Adoption: persist under the per-agent account so this agent's key
+        // resolution stops depending on the shared slot. Best-effort — a
+        // failed write just means adoption retries on the next read.
+        try { this.kc.write(KEYCHAIN_SERVICE, account, legacy); } catch { /* @silent-fallback-ok — retried next read */ }
+        return legacy;
+      }
     }
 
     // File fallback
     return this.getFileKey();
   }
 
+  /**
+   * Every key this agent could plausibly have encrypted its store with, primary
+   * first: [resolved primary, the OTHER source's key if it exists and differs].
+   * Read-only — alternates NEVER generate. Backs the dual-key read fallback
+   * (a v1 store written before the sources diverged stays readable, loudly).
+   */
+  getCandidateKeys(): Array<{ key: Buffer; source: 'keychain' | 'file' }> {
+    const out: Array<{ key: Buffer; source: 'keychain' | 'file' }> = [];
+    const push = (key: Buffer | null, source: 'keychain' | 'file'): void => {
+      if (key && !out.some((c) => c.key.equals(key))) out.push({ key, source });
+    };
+    if (this.forceFile) {
+      push(this.getFileKey(), 'file');
+      // Alternate: an existing keychain key (never generated) — covers a store
+      // written under keychain resolution before forceFileKey was flipped on.
+      push(this.tryRead(perAgentKeychainAccount(this.stateDir)), 'keychain');
+      push(this.tryRead(KEYCHAIN_ACCOUNT_LEGACY), 'keychain');
+      return out;
+    }
+    push(this.tryRead(perAgentKeychainAccount(this.stateDir)), 'keychain');
+    push(this.tryRead(KEYCHAIN_ACCOUNT_LEGACY), 'keychain');
+    // Existing file key as an alternate (do NOT generate one here — getFileKey
+    // generates; alternates must be read-only).
+    try {
+      if (fs.existsSync(this.keyFilePath)) {
+        push(Buffer.from(fs.readFileSync(this.keyFilePath, 'utf-8').trim(), 'hex'), 'file');
+      }
+    } catch { /* @silent-fallback-ok — unreadable alternate is simply absent */ }
+    if (out.length === 0) push(this.getMasterKey(), this.forceFile ? 'file' : 'keychain');
+    return out;
+  }
+
   /** Whether the master key is stored in the OS keychain (vs file fallback). */
   get isKeychainBacked(): boolean {
     if (this.forceFile) return false;
     try {
-      return this.readKeychain() !== null;
+      return (
+        this.tryRead(perAgentKeychainAccount(this.stateDir)) !== null ||
+        this.tryRead(KEYCHAIN_ACCOUNT_LEGACY) !== null
+      );
     } catch {
       // @silent-fallback-ok — keychain unavailable, file fallback
       return false;
     }
   }
 
-  // ── Keychain ────────────────────────────────────────────────────
+  private tryRead(account: string): Buffer | null {
+    try { return this.kc.read(KEYCHAIN_SERVICE, account); }
+    catch { return null; /* @silent-fallback-ok — keychain unavailable */ }
+  }
 
-  private readKeychain(): Buffer | null {
+  // ── OS keychain backends (account-parameterized) ────────────────
+
+  private readOsKeychain(service: string, account: string): Buffer | null {
     if (process.platform === 'darwin') {
-      return this.readMacKeychain();
+      try {
+        const result = execFileSync('security', [
+          'find-generic-password',
+          '-s', service,
+          '-a', account,
+          '-w', // Print password only
+        ], { encoding: 'utf-8', timeout: 5000, stdio: ['pipe', 'pipe', 'pipe'] }).trim();
+        return Buffer.from(result, 'base64');
+      } catch {
+        // @silent-fallback-ok — platform keychain read
+        return null;
+      }
     } else if (process.platform === 'linux') {
-      return this.readLinuxKeychain();
+      try {
+        const result = execFileSync('secret-tool', [
+          'lookup',
+          'service', service,
+          'account', account,
+        ], { encoding: 'utf-8', timeout: 5000, stdio: ['pipe', 'pipe', 'pipe'] }).trim();
+        return Buffer.from(result, 'base64');
+      } catch {
+        // @silent-fallback-ok — linux keychain read
+        return null;
+      }
     }
     return null; // Windows or unsupported — fall through to file
   }
 
-  private writeKeychain(key: Buffer): boolean {
+  private writeOsKeychain(service: string, account: string, key: Buffer): boolean {
     if (process.platform === 'darwin') {
-      return this.writeMacKeychain(key);
+      try {
+        // Delete existing entry first (ignore errors if it doesn't exist)
+        try {
+          execFileSync('security', [
+            'delete-generic-password',
+            '-s', service,
+            '-a', account,
+          ], { stdio: 'pipe', timeout: 5000 });
+        } catch {
+          // @silent-fallback-ok — entry may not exist
+        }
+        execFileSync('security', [
+          'add-generic-password',
+          '-s', service,
+          '-a', account,
+          '-w', key.toString('base64'),
+        ], { stdio: 'pipe', timeout: 5000 });
+        return true;
+      } catch (err) {
+        DegradationReporter.getInstance().report({
+          feature: 'SecretStore.writeMacOSKeychain',
+          primary: 'Persist master key to macOS keychain',
+          fallback: 'Key only in memory — lost on restart',
+          reason: `Why: ${err instanceof Error ? err.message : String(err)}`,
+          impact: 'Master key not persisted, may be lost',
+        });
+        return false;
+      }
     } else if (process.platform === 'linux') {
-      return this.writeLinuxKeychain(key);
+      try {
+        execFileSync('secret-tool', [
+          'store',
+          '--label', 'Instar Secret Store Master Key',
+          'service', service,
+          'account', account,
+        ], {
+          input: key.toString('base64'),
+          timeout: 5000,
+          stdio: ['pipe', 'pipe', 'pipe'],
+        });
+        return true;
+      } catch (err) {
+        DegradationReporter.getInstance().report({
+          feature: 'SecretStore.writeLinuxKeychain',
+          primary: 'Persist master key to Linux keychain',
+          fallback: 'Key only in memory — lost on restart',
+          reason: `Why: ${err instanceof Error ? err.message : String(err)}`,
+          impact: 'Master key not persisted, may be lost',
+        });
+        return false;
+      }
     }
     return false;
-  }
-
-  private readMacKeychain(): Buffer | null {
-    try {
-      const result = execFileSync('security', [
-        'find-generic-password',
-        '-s', KEYCHAIN_SERVICE,
-        '-a', KEYCHAIN_ACCOUNT,
-        '-w', // Print password only
-      ], { encoding: 'utf-8', timeout: 5000, stdio: ['pipe', 'pipe', 'pipe'] }).trim();
-      return Buffer.from(result, 'base64');
-    } catch {
-      // @silent-fallback-ok — platform keychain read
-      return null;
-    }
-  }
-
-  private writeMacKeychain(key: Buffer): boolean {
-    try {
-      // Delete existing entry first (ignore errors if it doesn't exist)
-      try {
-        execFileSync('security', [
-          'delete-generic-password',
-          '-s', KEYCHAIN_SERVICE,
-          '-a', KEYCHAIN_ACCOUNT,
-        ], { stdio: 'pipe', timeout: 5000 });
-      } catch {
-        // @silent-fallback-ok — entry may not exist
-      }
-
-      execFileSync('security', [
-        'add-generic-password',
-        '-s', KEYCHAIN_SERVICE,
-        '-a', KEYCHAIN_ACCOUNT,
-        '-w', key.toString('base64'),
-      ], { stdio: 'pipe', timeout: 5000 });
-      return true;
-    } catch (err) {
-      DegradationReporter.getInstance().report({
-        feature: 'SecretStore.writeMacOSKeychain',
-        primary: 'Persist master key to macOS keychain',
-        fallback: 'Key only in memory — lost on restart',
-        reason: `Why: ${err instanceof Error ? err.message : String(err)}`,
-        impact: 'Master key not persisted, may be lost',
-      });
-      return false;
-    }
-  }
-
-  private readLinuxKeychain(): Buffer | null {
-    try {
-      const result = execFileSync('secret-tool', [
-        'lookup',
-        'service', KEYCHAIN_SERVICE,
-        'account', KEYCHAIN_ACCOUNT,
-      ], { encoding: 'utf-8', timeout: 5000, stdio: ['pipe', 'pipe', 'pipe'] }).trim();
-      return Buffer.from(result, 'base64');
-    } catch {
-      // @silent-fallback-ok — linux keychain read
-      return null;
-    }
-  }
-
-  private writeLinuxKeychain(key: Buffer): boolean {
-    try {
-      execFileSync('secret-tool', [
-        'store',
-        '--label', 'Instar Secret Store Master Key',
-        'service', KEYCHAIN_SERVICE,
-        'account', KEYCHAIN_ACCOUNT,
-      ], {
-        input: key.toString('base64'),
-        timeout: 5000,
-        stdio: ['pipe', 'pipe', 'pipe'],
-      });
-      return true;
-    } catch (err) {
-      DegradationReporter.getInstance().report({
-        feature: 'SecretStore.writeLinuxKeychain',
-        primary: 'Persist master key to Linux keychain',
-        fallback: 'Key only in memory — lost on restart',
-        reason: `Why: ${err instanceof Error ? err.message : String(err)}`,
-        impact: 'Master key not persisted, may be lost',
-      });
-      return false;
-    }
   }
 
   // ── File fallback ───────────────────────────────────────────────
@@ -221,9 +296,13 @@ export class MasterKeyManager {
     // Generate new key
     const key = crypto.randomBytes(MASTER_KEY_LENGTH);
 
-    // Try to store in keychain first
-    if (!this.forceFile && this.writeKeychain(key)) {
-      return key;
+    // Try to store under the PER-AGENT keychain account first (never the
+    // legacy global slot — writing that slot is how the 2026-06-05 incident
+    // broke every other vault on the machine).
+    if (!this.forceFile) {
+      try {
+        if (this.kc.write(KEYCHAIN_SERVICE, perAgentKeychainAccount(this.stateDir), key)) return key;
+      } catch { /* @silent-fallback-ok — fall through to file */ }
     }
 
     // Write to file with restrictive permissions
@@ -242,28 +321,90 @@ export class SecretStore {
   private stateDir: string;
   private keyManager: MasterKeyManager;
   private encryptedPath: string;
+  /** Which key source decrypted the LAST successful read() — observability for
+   *  the dual-key fallback ('keychain' | 'file'; null before any read). */
+  lastReadKeySource: 'keychain' | 'file' | null = null;
 
   constructor(config: SecretStoreConfig) {
     this.stateDir = config.stateDir;
-    this.keyManager = new MasterKeyManager(config.stateDir, config.forceFileKey);
+    this.keyManager = new MasterKeyManager(config.stateDir, config.forceFileKey, config.keychainOps);
     this.encryptedPath = path.join(config.stateDir, 'secrets', 'config.secrets.enc');
   }
 
-  /** Read and decrypt secrets from the encrypted store. Returns empty object if no secrets exist. */
+  /**
+   * Read and decrypt secrets from the encrypted store. Returns empty object if
+   * no secrets exist.
+   *
+   * Vault-key-coherence (CMT-1038): tries every candidate key (primary first,
+   * then the OTHER source — keychain↔file) so a store written before the key
+   * sources diverged stays READABLE instead of looking "empty" to half the
+   * readers (the 2026-06-05 bifurcation incident). A v2 file's keyId header
+   * names the required key, so wrong-key is a precise error distinct from
+   * corruption. Success via a non-primary key emits a loud degradation report;
+   * the next write() converges the store back to the primary key.
+   */
   read(): Secrets {
     if (!fs.existsSync(this.encryptedPath)) {
       return {};
     }
 
     const raw = fs.readFileSync(this.encryptedPath);
-    const masterKey = this.keyManager.getMasterKey();
-    return this.decryptAES(raw, masterKey);
+    const candidates = this.keyManager.getCandidateKeys();
+
+    // ── v2 format: 'ISv2' | keyId(8) | iv | tag | ct — the keyId names the key ──
+    if (raw.length > STORE_MAGIC_V2.length + KEY_ID_LENGTH && raw.subarray(0, STORE_MAGIC_V2.length).equals(STORE_MAGIC_V2)) {
+      const wantId = raw.subarray(STORE_MAGIC_V2.length, STORE_MAGIC_V2.length + KEY_ID_LENGTH);
+      const body = raw.subarray(STORE_MAGIC_V2.length + KEY_ID_LENGTH);
+      const match = candidates.find((c) => keyIdOf(c.key).equals(wantId));
+      if (!match) {
+        throw new Error(
+          `SecretStore: store is encrypted with key id ${wantId.toString('hex')} — ` +
+          `no resolvable key matches (have: ${candidates.map((c) => `${c.source}:${keyIdOf(c.key).toString('hex')}`).join(', ') || 'none'}). ` +
+          `The vault is NOT empty; the matching master key is missing.`,
+        );
+      }
+      const secrets = this.decryptAES(body, match.key); // auth failure here = real corruption (key matched)
+      this.noteReadKeySource(match.source, candidates[0]?.source);
+      return secrets;
+    }
+
+    // ── v1 (legacy, headerless): try candidates in order ──
+    let lastErr: unknown = null;
+    for (const c of candidates) {
+      try {
+        const secrets = this.decryptAES(raw, c.key);
+        this.noteReadKeySource(c.source, candidates[0]?.source);
+        return secrets;
+      } catch (err) {
+        lastErr = err;
+      }
+    }
+    throw new Error(
+      `SecretStore: no resolvable key decrypts the store (tried ${candidates.length}: ` +
+      `${candidates.map((c) => `${c.source}:${keyIdOf(c.key).toString('hex')}`).join(', ') || 'none'}). ` +
+      `The vault is NOT empty; the matching master key is missing. Last error: ` +
+      `${lastErr instanceof Error ? lastErr.message : String(lastErr)}`,
+    );
   }
 
-  /** Encrypt and write secrets to the store. */
+  /** Record the source that decrypted; loudly report a non-primary success. */
+  private noteReadKeySource(used: 'keychain' | 'file', primary: 'keychain' | 'file' | undefined): void {
+    this.lastReadKeySource = used;
+    if (primary && used !== primary) {
+      DegradationReporter.getInstance().report({
+        feature: 'SecretStore.dualKeyRead',
+        primary: `Decrypt the vault with the primary (${primary}) master key`,
+        fallback: `Decrypted with the ${used} key instead`,
+        reason: 'Why: the keychain and file master keys have DIVERGED for this agent (the 2026-06-05 bifurcation class). The data is intact and readable.',
+        impact: 'The next write() re-encrypts with the primary key (v2 format), converging the sources. If divergence persists, inspect the per-agent keychain entry and .instar/machine/secrets-master.key.',
+      });
+    }
+  }
+
+  /** Encrypt and write secrets to the store (v2 format — keyId header). */
   write(secrets: Secrets): void {
     const masterKey = this.keyManager.getMasterKey();
-    const encrypted = this.encryptAES(secrets, masterKey);
+    const encrypted = Buffer.concat([STORE_MAGIC_V2, keyIdOf(masterKey), this.encryptAES(secrets, masterKey)]);
 
     const dir = path.dirname(this.encryptedPath);
     if (!fs.existsSync(dir)) {

--- a/src/core/SecretSync.ts
+++ b/src/core/SecretSync.ts
@@ -79,6 +79,10 @@ export interface SecretSyncHandle {
   provisionAll: () => Promise<{ machineId: string; ok: boolean; reason?: string }[]>;
   /** Leaf key-paths of secrets present in this machine's vault — NAMES only, never values. */
   localKeyPaths: () => string[];
+  /** Vault readability — distinguishes a genuinely empty vault from a
+   *  decrypt-failure (the 2026-06-05 masking: a key-bifurcated vault reported
+   *  localKeyPaths: [] as if empty). 'decrypt-failed' carries the precise error. */
+  vaultStatus?: () => { status: 'ok' | 'empty' | 'decrypt-failed'; error?: string };
   /** Online registered peers this machine would sync to (machineId + nickname). */
   syncTargets: () => { machineId: string; nickname?: string | null }[];
 }

--- a/src/server/routes.ts
+++ b/src/server/routes.ts
@@ -8325,6 +8325,9 @@ export function createRoutes(ctx: RouteContext): Router {
       pushEnabled: ss.pushEnabled,
       mode: ss.pushEnabled ? 'full' : 'receive-only',
       localKeyPaths: ss.localKeyPaths(),
+      // 'decrypt-failed' means the vault has DATA but no resolvable key opens it
+      // — categorically different from 'empty' (the 2026-06-05 masking bug).
+      vault: ss.vaultStatus ? ss.vaultStatus() : undefined,
       syncTargets: ss.syncTargets(),
     });
   });

--- a/tests/unit/secret-store-key-coherence.test.ts
+++ b/tests/unit/secret-store-key-coherence.test.ts
@@ -1,0 +1,208 @@
+/**
+ * Vault key coherence (CMT-1038, docs/specs/vault-key-coherence.md) — the
+ * root-cause fix for the 2026-06-05 bifurcation incident: a machine-global
+ * keychain slot shared by every agent, silently overwritable, split the vault
+ * into keychain-readers seeing "empty" and file-readers seeing data.
+ *
+ * Pins: per-agent keychain accounts + legacy adoption (never writes the global
+ * slot); the v2 keyId header (wrong-key is a precise, named error distinct
+ * from corruption); dual-key read fallback with loud convergence-on-write;
+ * v1 stores remain readable; the #789 real-keychain test guard still holds
+ * when no fake keychain is injected.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import crypto from 'node:crypto';
+import {
+  SecretStore,
+  MasterKeyManager,
+  perAgentKeychainAccount,
+  keyIdOf,
+  type KeychainOps,
+} from '../../src/core/SecretStore.js';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+
+const SERVICE = 'instar-secret-store';
+const LEGACY = 'master-key';
+
+/** In-memory fake keychain (service:account → key). */
+function fakeKeychain(seed: Record<string, Buffer> = {}) {
+  const store = new Map<string, Buffer>(Object.entries(seed));
+  const ops: KeychainOps = {
+    read: (service, account) => store.get(`${service}:${account}`) ?? null,
+    write: (service, account, key) => { store.set(`${service}:${account}`, key); return true; },
+  };
+  return { ops, store };
+}
+
+function writeFileKey(stateDir: string, key: Buffer): void {
+  fs.mkdirSync(path.join(stateDir, 'machine'), { recursive: true });
+  fs.writeFileSync(path.join(stateDir, 'machine', 'secrets-master.key'), key.toString('hex'), { mode: 0o600 });
+}
+
+/** Hand-craft a v1 (headerless legacy) store blob: iv | tag | ciphertext. */
+function v1Blob(secrets: Record<string, unknown>, key: Buffer): Buffer {
+  const iv = crypto.randomBytes(12);
+  const cipher = crypto.createCipheriv('aes-256-gcm', key, iv);
+  const ct = Buffer.concat([cipher.update(Buffer.from(JSON.stringify(secrets), 'utf-8')), cipher.final()]);
+  return Buffer.concat([iv, cipher.getAuthTag(), ct]);
+}
+
+describe('vault key coherence', () => {
+  let tmpDir: string;
+  let stateDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'instar-key-coherence-'));
+    stateDir = path.join(tmpDir, '.instar');
+    fs.mkdirSync(stateDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    SafeFsExecutor.safeRmSync(tmpDir, { recursive: true, force: true, operation: 'test-cleanup' });
+  });
+
+  // ── Per-agent accounts + adoption ─────────────────────────────────
+
+  it('prefers the per-agent keychain entry over the legacy global slot', () => {
+    const own = crypto.randomBytes(32);
+    const legacy = crypto.randomBytes(32);
+    const { ops } = fakeKeychain({
+      [`${SERVICE}:${perAgentKeychainAccount(stateDir)}`]: own,
+      [`${SERVICE}:${LEGACY}`]: legacy,
+    });
+    const mgr = new MasterKeyManager(stateDir, false, ops);
+    expect(mgr.getMasterKey().equals(own)).toBe(true);
+  });
+
+  it('ADOPTS the legacy global key into the per-agent account — and never rewrites the global slot', () => {
+    const legacy = crypto.randomBytes(32);
+    const { ops, store } = fakeKeychain({ [`${SERVICE}:${LEGACY}`]: legacy });
+    const mgr = new MasterKeyManager(stateDir, false, ops);
+
+    expect(mgr.getMasterKey().equals(legacy)).toBe(true);
+    // Adopted: per-agent slot now holds the key.
+    expect(store.get(`${SERVICE}:${perAgentKeychainAccount(stateDir)}`)?.equals(legacy)).toBe(true);
+    // The global slot is untouched (other agents may still depend on it).
+    expect(store.get(`${SERVICE}:${LEGACY}`)?.equals(legacy)).toBe(true);
+  });
+
+  it('a freshly GENERATED key is written to the per-agent account — NEVER the legacy global slot', () => {
+    const { ops, store } = fakeKeychain();
+    const mgr = new MasterKeyManager(stateDir, false, ops);
+    const key = mgr.getMasterKey();
+    expect(store.get(`${SERVICE}:${perAgentKeychainAccount(stateDir)}`)?.equals(key)).toBe(true);
+    expect(store.has(`${SERVICE}:${LEGACY}`)).toBe(false);
+  });
+
+  it('the #789 guard holds: WITHOUT an injected fake, a test-run manager is file-key-only', () => {
+    const mgr = new MasterKeyManager(stateDir, false); // no keychainOps, VITEST set
+    const key = mgr.getMasterKey();
+    expect(fs.existsSync(path.join(stateDir, 'machine', 'secrets-master.key'))).toBe(true);
+    expect(Buffer.from(fs.readFileSync(path.join(stateDir, 'machine', 'secrets-master.key'), 'utf-8').trim(), 'hex').equals(key)).toBe(true);
+  });
+
+  // ── v2 format: keyId header ───────────────────────────────────────
+
+  it('write() produces v2 (magic + keyId of the primary key) and read() round-trips it', () => {
+    const key = crypto.randomBytes(32);
+    const { ops } = fakeKeychain({ [`${SERVICE}:${perAgentKeychainAccount(stateDir)}`]: key });
+    const store = new SecretStore({ stateDir, keychainOps: ops });
+
+    store.write({ github_token: 'ghp_test' });
+    const raw = fs.readFileSync(path.join(stateDir, 'secrets', 'config.secrets.enc'));
+    expect(raw.subarray(0, 4).toString('ascii')).toBe('ISv2');
+    expect(raw.subarray(4, 12).equals(keyIdOf(key))).toBe(true);
+    expect(store.read()).toEqual({ github_token: 'ghp_test' });
+    expect(store.lastReadKeySource).toBe('keychain');
+  });
+
+  it('a v2 store encrypted with an UNKNOWN key fails with a precise, named error — not "empty"', () => {
+    const writerKey = crypto.randomBytes(32);
+    const { ops: writerOps } = fakeKeychain({ [`${SERVICE}:${perAgentKeychainAccount(stateDir)}`]: writerKey });
+    new SecretStore({ stateDir, keychainOps: writerOps }).write({ a: '1' });
+
+    // A different agent-process world: different keychain content, different file key.
+    const { ops: readerOps } = fakeKeychain({ [`${SERVICE}:${perAgentKeychainAccount(stateDir)}`]: crypto.randomBytes(32) });
+    const reader = new SecretStore({ stateDir, keychainOps: readerOps });
+    expect(() => reader.read()).toThrowError(new RegExp(`encrypted with key id ${keyIdOf(writerKey).toString('hex')}`));
+    expect(() => reader.read()).toThrowError(/NOT empty/);
+  });
+
+  it('corruption of a v2 store with the MATCHING key still surfaces as a GCM auth failure (distinct from wrong-key)', () => {
+    const key = crypto.randomBytes(32);
+    const { ops } = fakeKeychain({ [`${SERVICE}:${perAgentKeychainAccount(stateDir)}`]: key });
+    const store = new SecretStore({ stateDir, keychainOps: ops });
+    store.write({ a: '1' });
+    const p = path.join(stateDir, 'secrets', 'config.secrets.enc');
+    const raw = fs.readFileSync(p);
+    raw[raw.length - 1] ^= 0xff; // flip a ciphertext byte
+    fs.writeFileSync(p, raw);
+    expect(() => store.read()).toThrowError(/Unsupported state|unable to authenticate/i);
+  });
+
+  // ── v1 back-compat + dual-key fallback ────────────────────────────
+
+  it('a legacy v1 store still reads (primary key)', () => {
+    const key = crypto.randomBytes(32);
+    fs.mkdirSync(path.join(stateDir, 'secrets'), { recursive: true });
+    fs.writeFileSync(path.join(stateDir, 'secrets', 'config.secrets.enc'), v1Blob({ legacy: 'data' }, key));
+    const { ops } = fakeKeychain({ [`${SERVICE}:${perAgentKeychainAccount(stateDir)}`]: key });
+    const store = new SecretStore({ stateDir, keychainOps: ops });
+    expect(store.read()).toEqual({ legacy: 'data' });
+  });
+
+  it('THE INCIDENT: a v1 store written with the FILE key stays readable when the primary resolves to a different keychain key', () => {
+    const fileKey = crypto.randomBytes(32);
+    const keychainKey = crypto.randomBytes(32); // diverged (e.g. a test once clobbered the slot)
+    writeFileKey(stateDir, fileKey);
+    fs.mkdirSync(path.join(stateDir, 'secrets'), { recursive: true });
+    fs.writeFileSync(path.join(stateDir, 'secrets', 'config.secrets.enc'), v1Blob({ github_token: 'ghp_survives' }, fileKey));
+
+    const { ops } = fakeKeychain({ [`${SERVICE}:${perAgentKeychainAccount(stateDir)}`]: keychainKey });
+    const store = new SecretStore({ stateDir, keychainOps: ops });
+
+    // Pre-fix behavior: decrypt-fail → "empty vault" to keychain readers.
+    // Post-fix: the file-key alternate decrypts it, loudly.
+    expect(store.read()).toEqual({ github_token: 'ghp_survives' });
+    expect(store.lastReadKeySource).toBe('file');
+  });
+
+  it('the next write() after a fallback read CONVERGES the store to the primary key (v2)', () => {
+    const fileKey = crypto.randomBytes(32);
+    const keychainKey = crypto.randomBytes(32);
+    writeFileKey(stateDir, fileKey);
+    fs.mkdirSync(path.join(stateDir, 'secrets'), { recursive: true });
+    fs.writeFileSync(path.join(stateDir, 'secrets', 'config.secrets.enc'), v1Blob({ a: '1' }, fileKey));
+
+    const { ops } = fakeKeychain({ [`${SERVICE}:${perAgentKeychainAccount(stateDir)}`]: keychainKey });
+    const store = new SecretStore({ stateDir, keychainOps: ops });
+    store.set('b', '2'); // read (file-key fallback) + write (primary keychain key)
+
+    const raw = fs.readFileSync(path.join(stateDir, 'secrets', 'config.secrets.enc'));
+    expect(raw.subarray(0, 4).toString('ascii')).toBe('ISv2');
+    expect(raw.subarray(4, 12).equals(keyIdOf(keychainKey))).toBe(true);
+    expect(store.read()).toEqual({ a: '1', b: '2' });
+    expect(store.lastReadKeySource).toBe('keychain'); // converged
+  });
+
+  it('forceFileKey still wins as the primary, with an existing keychain key only as a read alternate', () => {
+    const fileKey = crypto.randomBytes(32);
+    const keychainKey = crypto.randomBytes(32);
+    writeFileKey(stateDir, fileKey);
+    fs.mkdirSync(path.join(stateDir, 'secrets'), { recursive: true });
+    fs.writeFileSync(path.join(stateDir, 'secrets', 'config.secrets.enc'), v1Blob({ k: 'v' }, keychainKey));
+
+    const { ops } = fakeKeychain({ [`${SERVICE}:${perAgentKeychainAccount(stateDir)}`]: keychainKey });
+    const store = new SecretStore({ stateDir, forceFileKey: true, keychainOps: ops });
+    expect(store.read()).toEqual({ k: 'v' });
+    expect(store.lastReadKeySource).toBe('keychain'); // alternate decrypted it
+    store.set('x', 'y');
+    // Converged to the FILE key (forceFileKey primary).
+    const raw = fs.readFileSync(path.join(stateDir, 'secrets', 'config.secrets.enc'));
+    expect(raw.subarray(4, 12).equals(keyIdOf(fileKey))).toBe(true);
+  });
+});

--- a/upgrades/next/vault-key-coherence.md
+++ b/upgrades/next/vault-key-coherence.md
@@ -1,0 +1,47 @@
+<!-- bump: patch -->
+
+## What Changed
+
+The secrets vault's master-key handling is rebuilt to kill the recurring
+"vault looks empty" disease (the 2026-06-05 bifurcation incident — CMT-1038):
+
+1. **Per-agent keychain slots.** The master key now lives under
+   `master-key:<stateDir>` instead of one machine-global slot shared by every
+   agent. Agents still on the legacy slot adopt their key automatically on
+   first read; nothing ever writes the global slot again.
+2. **Self-describing vault format (v2).** New vault writes stamp an 8-byte
+   key fingerprint into the header. A reader holding the wrong key gets a
+   precise, named error ("encrypted with key id …; the vault is NOT empty")
+   instead of silently treating the vault as empty. Old (v1) vaults read
+   forever; the first write upgrades them.
+3. **Dual-key reads + self-healing.** If the keychain and file keys diverge,
+   readers try both; a fallback success is loudly reported and the next write
+   converges the vault back to the primary key.
+4. `GET /secrets/sync-status` now reports `vault: ok | empty | decrypt-failed`
+   — decrypt failure is no longer masked as an empty key list.
+
+Encryption itself (AES-256-GCM), vault location, and the tests-can't-touch-
+the-real-keychain guard are unchanged.
+
+## What to Tell Your User
+
+Secrets you've handed me can no longer turn invisible because two parts of me
+ended up holding different vault keys. If the keys ever drift, I keep reading
+your secrets, log exactly what happened, and self-heal on the next write —
+instead of asking you to send the secret again.
+
+## Summary of New Capabilities
+
+- Per-agent keychain accounts with automatic legacy adoption.
+- v2 vault format with key fingerprint (wrong-key ≠ corruption ≠ empty).
+- Dual-key read fallback + convergence-on-write.
+- `vault` status on `GET /secrets/sync-status`.
+
+## Evidence
+
+`tests/unit/secret-store-key-coherence.test.ts` (11 new — including the
+verbatim incident: a vault written with the file key stays readable when the
+keychain key diverges, then converges on the next write) + 29 existing
+secret-store tests + 21 secret-adjacent regression tests (store-first
+integration, sealed-handoff at-rest, hardening, e2e) all green. tsc + lint
+clean.

--- a/upgrades/side-effects/vault-key-coherence.md
+++ b/upgrades/side-effects/vault-key-coherence.md
@@ -1,0 +1,113 @@
+# Side-Effects Review — Vault key coherence (CMT-1038)
+
+**Version / slug:** `vault-key-coherence`
+**Date:** `2026-06-05`
+**Author:** `echo`
+**Second-pass reviewer:** `not required` (crypto algorithm unchanged; resolution/format layers only; every boundary side test-pinned; v1 reads preserved; failure modes strictly improve on today's silent-empty)
+
+## Summary of the change
+
+Three layers killing the key-bifurcation disease: (1) per-agent keychain
+accounts (`master-key:<stateDir>`) with read-time adoption of the legacy
+global slot (which is never written again); (2) v2 store format with a keyId
+header (`'ISv2'|keyId(8)|iv|tag|ct`) so wrong-key is a precise, named error
+distinct from corruption — v1 files read forever; (3) dual-key read fallback
+(primary first, then the other source, read-only alternates) with a loud
+DegradationReporter on divergence and natural convergence on the next write.
+Plus: `GET /secrets/sync-status` now reports `vault: {status:'ok'|'empty'|
+'decrypt-failed', error?}` instead of masking decrypt-failure as empty.
+Keychain ops are injectable (`SecretStoreConfig.keychainOps`) so all of this
+is unit-tested against a fake; the #789 real-keychain test guard holds
+whenever no fake is injected.
+
+## Decision-point inventory (each side pinned)
+
+1. Per-agent slot present / legacy-only (adopt, global untouched) / neither
+   (generate → per-agent slot, NEVER global) — 3 tests.
+2. v2 keyId match / no-match (named error, "NOT empty") / matching-key
+   corruption (GCM auth error) — 3 tests.
+3. v1 primary-key read / v1 fallback-key read (THE incident case) /
+   write-after-fallback converges to primary / forceFileKey primary with
+   keychain alternate — 4 tests.
+4. Guard: no injected fake + VITEST ⇒ file-key only — 1 test.
+5. vaultStatus: ok / empty / decrypt-failed (route surface).
+
+## 1. Over-block
+
+Nothing readable today becomes unreadable: every key the old code could
+resolve is still a candidate, plus more. The new thrown errors fire ONLY
+where today's code also throws (v1, both keys wrong) or silently lied
+(reported empty); the route now reports those as `decrypt-failed` instead of
+`[]`.
+
+## 2. Under-block
+
+- The legacy global slot remains readable machine-wide until every agent
+  adopts — by design (deleting it would break un-migrated agents). It decays
+  naturally: nothing writes it, every reader adopts away from it.
+- Dual-key fallback widens which keys may open a vault to keys the SAME agent
+  resolves from ITS OWN two sources — no new principals, no cross-agent keys.
+- Convergence-on-write re-encrypts with the primary; if another process of
+  the same agent still resolves only the stale alternate, IT then uses its
+  own fallback (now in the other direction) and converges the same way — the
+  fixed point is both sources agreeing, reached after adoption.
+
+## 3. Level-of-abstraction fit
+
+Resolution lives in MasterKeyManager (the single key authority); format +
+fallback in SecretStore.read/write (the single at-rest codec); the route only
+gains a status field. Wire-sync crypto (X25519/HKDF) untouched.
+
+## 4. Signal vs authority compliance
+
+**Reference:** [docs/signal-vs-authority.md](../../docs/signal-vs-authority.md)
+No gating added. Errors got MORE precise; the degradation report is
+signal-only; adoption/convergence are self-healing writes within the agent's
+own key material.
+
+## 5. Interactions
+
+- Store-first drop persistence (#789), sealed-handoff at-rest, and the sync
+  provisioner all read through the same read() — regression suites green
+  (21/21).
+- Echo's live vault (v1, file-key, keychain slot deleted in the incident
+  remediation): reads via primary file key unchanged; first write upgrades to
+  v2 with the file keyId. No migration step needed anywhere — resolution-time
+  adoption + write-time format upgrade.
+- Mixed fleet versions: older readers can't read v2 — but a vault is only
+  read by ITS OWN agent on ITS OWN machine (wire sync re-encrypts per peer),
+  so the only mixed-version reader of a given file is the same agent
+  mid-update, which restarts onto the new code. Residual window ≈ one
+  restart; documented.
+
+## 6. External surfaces
+
+`vault` field on sync-status (additive); exported `perAgentKeychainAccount`/
+`keyIdOf` helpers; `SecretStoreConfig.keychainOps` (test seam). No config
+flags, no migration, no new routes.
+
+## 7. Rollback cost
+
+Revert restores old code — which reads v1 files only. Any vault already
+upgraded to v2 would need its 28-byte header stripped (`tail -c +13` of the
+post-magic body) — documented here as the rollback runbook; low likelihood
+(revert would only follow a fast-caught regression, before fleet-wide v2
+rewrites).
+
+## Conclusion
+
+The recurring "vault looks empty" disease removed at its three roots —
+shared slot, mute wrong-key failures, single-key reads — with strictly more
+diagnosable failure modes and zero operator action.
+
+## Second-pass review (if required)
+
+Not required — see header.
+
+## Evidence pointers
+
+- `tests/unit/secret-store-key-coherence.test.ts` (11, incl. THE incident
+  case verbatim and convergence-on-write).
+- `tests/unit/secret-store.test.ts` 29/29; secret-adjacent regression suites
+  21/21 (store-first integration + sealed-handoff + hardening + e2e).
+- `docs/specs/vault-key-coherence.md` + `.eli16.md`. <!-- tracked: CMT-1038 -->


### PR DESCRIPTION
## The disease (CMT-1038 — root fix; 12h autonomous mandate, topic 13481)

The machine-global keychain slot (`instar-secret-store`/`master-key`) is shared by EVERY agent on the box and silently overwritable by any fresh-stateDir SecretStore. When it diverged from the per-agent file key, the vault bifurcated: keychain-readers saw "empty" while file-readers saw data — the heart of the recurring "I've given you this secret MANY MANY times." PR #789 made tests unable to trigger it; this removes the disease.

## Three layers

1. **Per-agent keychain accounts** — `master-key:<stateDir>` (readable + collision-free). Legacy global slot is ADOPTED on first read (copied to the per-agent slot, left in place for un-migrated agents) and **never written again**. Generation writes the per-agent slot only.
2. **Self-describing v2 vault format** — `'ISv2' | keyId(8 = sha256(key) prefix) | iv | tag | ct`. Wrong-key is now a precise, NAMED error ("encrypted with key id 3f9a…; available: …; **the vault is NOT empty**") — categorically distinct from corruption (GCM auth failure with the MATCHING key). **v1 files read forever**; the first write upgrades.
3. **Dual-key read fallback** — primary key first, then the OTHER source (read-only alternates, never generated). Fallback success → loud DegradationReporter ("key sources diverged — data intact") + `lastReadKeySource` observability; the next `write()` re-encrypts with the primary, **converging the split automatically**.

Plus: `GET /secrets/sync-status` now reports `vault: ok | empty | decrypt-failed` — decrypt failure is no longer masked as an empty key list (the masking that hid the incident).

**Unchanged:** AES-256-GCM, vault location, wire-sync crypto, and the #789 tests-can't-touch-the-real-keychain guard (it holds whenever no fake `keychainOps` is injected — the new test seam is an in-memory fake, not the real keychain).

## Tests

- `tests/unit/secret-store-key-coherence.test.ts` (11) — including **THE incident verbatim** (a v1 vault written with the file key stays readable when the keychain key diverges — pre-fix this read as "empty") and convergence-on-write
- 29 existing secret-store tests + 21 secret-adjacent regression tests (store-first integration, sealed-handoff at-rest, hardening, e2e) all green; tsc + lint clean

## Ceremony

Spec: `docs/specs/vault-key-coherence.md` (parent-principle: Distrust Temporary Success — A Recurrence Is a Root Cause) · ELI16: `.eli16.md` · Side-effects (incl. rollback runbook for v2 files): `upgrades/side-effects/vault-key-coherence.md` · Fragment: `upgrades/next/vault-key-coherence.md`

## ELI16

Your secrets vault is an encrypted file whose key can live in two places: the Mac's keychain or a small key file. The old design had a landmine — the keychain slot was SHARED by every agent on the machine, and anything creating a fresh vault silently overwrote it. Half the readers then held the wrong key, and instead of saying "wrong key" they reported your vault as EMPTY. Your secrets were there the whole time, just invisible. Three fixes: every agent now gets its OWN keychain slot (old slots adopt over automatically); the vault file now names which key opens it, so wrong-key is a precise error instead of a lie; and readers try both keys before giving up — if the backup key works you get your data plus a loud log note, and the next write quietly heals the split. The encryption itself didn't change, and tests still can't touch your real keychain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)