### PR TITLE
fix(hooks): grounding-gate block reasons → STDERR (visible verdicts, not phantom errors)

### DIFF
--- a/src/core/PostUpdateMigrator.ts
+++ b/src/core/PostUpdateMigrator.ts
@@ -6486,9 +6486,13 @@ if echo "$INPUT" | grep -qE "(telegram-reply|send-email|send-message|POST.*/tele
     CHECK_EXIT=$?
 
     if [ "$CHECK_EXIT" -ne "0" ]; then
-      echo "$CHECK_RESULT"
-      echo ""
-      echo "=== MESSAGE BLOCKED — Review and revise before sending. ==="
+      # BLOCK output goes to STDERR: on a PreToolUse exit-2 block, Claude Code
+      # surfaces ONLY stderr to the agent. Writing the reason to stdout rendered
+      # every block as an unreadable "hook error ... No stderr output" — the agent
+      # saw a malfunction instead of the actual quality findings (2026-06-05).
+      echo "$CHECK_RESULT" >&2
+      echo "" >&2
+      echo "=== MESSAGE BLOCKED — Review and revise before sending. ===" >&2
       exit 2
     fi
   fi

--- a/src/templates/hooks/grounding-before-messaging.sh
+++ b/src/templates/hooks/grounding-before-messaging.sh
@@ -41,9 +41,14 @@ if echo "$INPUT" | grep -qE "(telegram-reply|send-email|send-message|POST.*/tele
     CHECK_EXIT=$?
 
     if [ "$CHECK_EXIT" -ne "0" ]; then
-      echo "$CHECK_RESULT"
-      echo ""
-      echo "=== MESSAGE BLOCKED — Review and revise before sending. ==="
+      # BLOCK output goes to STDERR: on a PreToolUse exit-2 block, Claude Code
+      # surfaces ONLY stderr to the agent. Writing the reason to stdout rendered
+      # every block as an unreadable "hook error ... No stderr output" — the agent
+      # saw a malfunction instead of the actual quality findings (2026-06-05 live
+      # incident: milestone reports bounced repeatedly with no visible reason).
+      echo "$CHECK_RESULT" >&2
+      echo "" >&2
+      echo "=== MESSAGE BLOCKED — Review and revise before sending. ===" >&2
       exit 2
     fi
   fi

--- a/tests/unit/grounding-hook-block-stderr.test.ts
+++ b/tests/unit/grounding-hook-block-stderr.test.ts
@@ -1,0 +1,83 @@
+/**
+ * The grounding-before-messaging hook must put BLOCK output on STDERR.
+ *
+ * On a PreToolUse exit-2 block, Claude Code surfaces ONLY stderr to the agent.
+ * The 2026-06-05 live incident: block reasons went to stdout, so every blocked
+ * message rendered as "hook error ... No stderr output" — the agent saw a
+ * malfunction instead of the quality findings and retried blind.
+ *
+ * Tests run the REAL template (both copies: src/templates/hooks/ and the
+ * PostUpdateMigrator inline source that migrateHooks deploys) against a stub
+ * convergence-check, asserting: block → exit 2 + findings on STDERR (stdout
+ * quiet of them); pass → exit 0 + GROUNDED on stdout.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { PostUpdateMigrator } from '../../src/core/PostUpdateMigrator.js';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const TEMPLATE = path.resolve(__dirname, '../../src/templates/hooks/grounding-before-messaging.sh');
+
+function runHook(hookPath: string, projectDir: string, input: string, checkExit: number) {
+  // Stub convergence-check: prints a finding and exits as instructed.
+  const scriptsDir = path.join(projectDir, '.instar', 'scripts');
+  fs.mkdirSync(scriptsDir, { recursive: true });
+  fs.writeFileSync(path.join(scriptsDir, 'convergence-check.sh'),
+    `#!/bin/bash\necho "FINDING: stub quality issue"\nexit ${checkExit}\n`, { mode: 0o755 });
+  try {
+    const stdout = execFileSync('bash', [hookPath, input], {
+      encoding: 'utf-8',
+      env: { ...process.env, CLAUDE_PROJECT_DIR: projectDir },
+    });
+    return { code: 0, stdout, stderr: '' };
+  } catch (err) {
+    const e = err as { status: number; stdout: string; stderr: string };
+    return { code: e.status, stdout: String(e.stdout ?? ''), stderr: String(e.stderr ?? '') };
+  }
+}
+
+const MSG = 'cat <<EOF | .instar/scripts/telegram-reply.sh 123\nhello\nEOF';
+
+describe.each([
+  ['src/templates copy', () => fs.readFileSync(TEMPLATE, 'utf-8')],
+  ['PostUpdateMigrator deployed copy', () => {
+    const migrator = new PostUpdateMigrator({ projectDir: '/tmp', stateDir: '/tmp/.instar', port: 4040 } as any);
+    return (migrator as unknown as { getGroundingBeforeMessaging(): string }).getGroundingBeforeMessaging();
+  }],
+])('grounding-before-messaging block-output routing — %s', (_label, getSource) => {
+  let dir: string;
+  let hookPath: string;
+
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'ground-hook-'));
+    hookPath = path.join(dir, 'hook.sh');
+    fs.writeFileSync(hookPath, getSource(), { mode: 0o755 });
+  });
+  afterEach(() => SafeFsExecutor.safeRmSync(dir, { recursive: true, force: true, operation: 'tests/unit/grounding-hook-block-stderr.test.ts' }));
+
+  it('BLOCK: exit 2 with the findings on STDERR (the channel Claude Code surfaces)', () => {
+    const r = runHook(hookPath, dir, MSG, 1);
+    expect(r.code).toBe(2);
+    expect(r.stderr).toContain('FINDING: stub quality issue');
+    expect(r.stderr).toContain('MESSAGE BLOCKED');
+    expect(r.stdout).not.toContain('MESSAGE BLOCKED');
+  });
+
+  it('PASS: exit 0 with GROUNDED on stdout', () => {
+    const r = runHook(hookPath, dir, MSG, 0);
+    expect(r.code).toBe(0);
+    expect(r.stdout).toContain('GROUNDED');
+    expect(r.stderr).toBe('');
+  });
+
+  it('NON-MESSAGING input passes through untouched', () => {
+    const r = runHook(hookPath, dir, 'ls -la /tmp', 1);
+    expect(r.code).toBe(0);
+    expect(r.stdout).not.toContain('GROUNDED');
+  });
+});

--- a/upgrades/next/hook-block-stderr.md
+++ b/upgrades/next/hook-block-stderr.md
@@ -1,0 +1,21 @@
+<!-- bump: patch -->
+
+## What Changed
+
+Fixed an invisible-verdict bug in the pre-send message-quality gate. When the gate
+blocked an outbound message, it wrote its reasons to the wrong output channel, so
+the agent saw a generic "hook error" instead of the actual findings — and would
+retry blind. The reasons now land on the channel the runtime actually shows, so a
+blocked message comes back with the specific quality findings to fix.
+
+## What to Tell Your User
+
+Your agent's pre-send quality check now explains itself. If it holds a message
+back, the agent sees exactly why and revises, instead of appearing to hit a
+mysterious error.
+
+## Summary of New Capabilities
+
+- Blocked outbound messages surface their quality findings to the agent instead
+  of an opaque hook error.
+- Maturity: stable; the gate's judgments are unchanged — only their visibility.

--- a/upgrades/side-effects/hook-block-stderr.md
+++ b/upgrades/side-effects/hook-block-stderr.md
@@ -1,0 +1,33 @@
+# Side-effects review — grounding hook block-output → STDERR
+
+Live incident (2026-06-05): the message-quality gate (convergence check inside the
+grounding-before-messaging PreToolUse hook) correctly BLOCKED several outbound
+messages — but wrote the findings + block banner to STDOUT. On a PreToolUse exit-2
+block, Claude Code surfaces ONLY STDERR, so every block rendered to the agent as
+"hook error ... No stderr output": a malfunction instead of a verdict. The agent
+(me) retried blind several times before diagnosing via direct hook invocation.
+
+## 1. The change
+
+Both copies of the hook source (the `src/templates/hooks/` init-time file AND the
+inline `PostUpdateMigrator.getGroundingBeforeMessaging()` that migrateHooks
+always-overwrites onto every agent) now route the block findings + banner to
+STDERR. The pass path (GROUNDED on stdout, exit 0) is unchanged.
+
+## 2. Migration parity
+
+Built-in hooks in `.instar/hooks/instar/` are ALWAYS overwritten on every
+migration run — the fix reaches every deployed agent automatically on the next
+update; no new migration code needed.
+
+## 3. Blast radius
+
+Two-line behavioral change inside an existing block branch. The gate's
+DECISIONS are untouched — only where the explanation lands. No config, routes,
+or schema.
+
+## 4. Test coverage
+
+6 tests (3 × both template copies via describe.each): block → exit 2 + findings
+on STDERR with stdout clean; pass → exit 0 + GROUNDED on stdout; non-messaging
+input untouched. Run against the REAL hook sources with a stubbed quality check.


### PR DESCRIPTION
Live incident tonight: the pre-send message-quality gate (convergence check in the `grounding-before-messaging` PreToolUse hook) was **correctly blocking** several of my outbound milestone reports (commitment-language findings) — but wrote the findings + block banner to **STDOUT**. On a PreToolUse exit-2 block, Claude Code surfaces ONLY **STDERR**, so every block rendered as `hook error ... No stderr output`. The agent (me) saw a malfunction, not a verdict, and retried blind several times before diagnosing it via direct hook invocation.

## Fix

Route the block findings + banner to stderr in BOTH copies of the hook source: `src/templates/hooks/grounding-before-messaging.sh` (init-time) and the inline `PostUpdateMigrator.getGroundingBeforeMessaging()` (what `migrateHooks` always-overwrites onto every agent — so the fix reaches the deployed fleet automatically on the next update; no new migration code needed). The gate's DECISIONS are untouched; only where the explanation lands.

## Tests

6 (3 × both copies via `describe.each`, run against the REAL hook sources with a stubbed quality check): block → exit 2 + findings on stderr with stdout clean; pass → exit 0 + GROUNDED on stdout; non-messaging input untouched.

## ELI16

The message bouncer was doing its job — stopping notes that broke the house rules — but it was writing the reason on the back of a card nobody flips over. All the sender ever saw was "bouncer malfunction," so they kept re-sending the same note. Now the reason is written on the front: "blocked — you promised something you can't guarantee; reword it." Same bouncer, same rules — you can finally read why.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
