### PR TITLE
feat(mentor): autoloop prompt teaches the claim-check + ELI16-body rules

### DIFF
--- a/src/scheduler/MentorAutonomousGuardian.ts
+++ b/src/scheduler/MentorAutonomousGuardian.ts
@@ -143,5 +143,6 @@ export function buildAutoloopGoal(p: AutoloopGoalParams): string {
     ``,
     `Discipline (non-negotiable): verify before you claim — never write a result or a number before the producing tool has returned it. Never narrate a tool call you did not make. One cycle, then exit cleanly — do NOT spawn another copy of this loop or schedule a follow-up; the guardian starts the next cycle on its own heartbeat.`,
     `Gate compliance (ratchet gates): an intentional best-effort/fail-open catch must either report through DegradationReporter or carry an inline @silent-fallback-ok justification — never bump a ratchet baseline to pass CI. When you author a task brief or spec for another agent, spell these gate notes out explicitly: a spec that says "best-effort, never throws" without them invites the exact ratchet failure it is trying to avoid.`,
+    `Before you build (parallel-claim check): run \`instar dev:claim-check <paths you intend to touch> [--keywords ...]\` FIRST — if an open/recently-merged PR or a spec already owns a layer of the problem, claim a DIFFERENT layer explicitly (division-of-labor; earned 2026-06-05 when two parallel sessions built the same incident fix twice). And every PR DESCRIPTION must include an \`## ELI16\` section (a required CI gate) — write it in from the start, not after the gate goes red.`,
   ].join('\n');
 }

--- a/tests/unit/MentorAutonomousGuardian.test.ts
+++ b/tests/unit/MentorAutonomousGuardian.test.ts
@@ -127,6 +127,11 @@ describe('buildAutoloopGoal — deterministic prompt assembly', () => {
     expect(goal).toMatch(/@silent-fallback-ok/);
     expect(goal).toMatch(/never bump a ratchet baseline/i);
     expect(goal).toMatch(/DegradationReporter/);
+    // Parallel-claim discipline (earned 2026-06-05: two sessions built the same
+    // incident fix twice — #802 vs the keychain spec, #810 vs #808) + the
+    // ELI16-in-PR-body required gate (also 2026-06-05, hit live on #813).
+    expect(goal).toMatch(/dev:claim-check/);
+    expect(goal).toMatch(/## ELI16/);
   });
 
   it('degrades gracefully when topics are unset (no "topic undefined" text)', () => {

--- a/upgrades/mentor-prompt-tonight-gates.eli16.md
+++ b/upgrades/mentor-prompt-tonight-gates.eli16.md
@@ -1,0 +1,3 @@
+# The autonomous-mentor loop now teaches two new ship rules
+
+The mentor system can run an autonomous develop-and-fix loop whose working instructions are encoded in code (so every cycle gets the same discipline, not whatever someone remembers to type). Two rules earned the hard way on 2026-06-05 are now part of those durable instructions: (1) before starting any build, run the new claim-check command so two parallel builders never construct the same fix twice — that exact collision happened twice in one night and wasted hours; (2) every PR description must include a plain-English ELI16 section from the start, because a required CI gate now rejects PRs without one — better to write it up front than to discover the red check after pushing.

--- a/upgrades/next/mentor-prompt-tonight-gates.md
+++ b/upgrades/next/mentor-prompt-tonight-gates.md
@@ -1,0 +1,15 @@
+<!-- bump: patch -->
+
+# Mentor autoloop prompt: pre-build claim check + ELI16-in-PR-body rules
+
+## What to Tell Your User
+
+Nothing user-visible. The autonomous mentor-development loop's built-in working instructions now include two recently-earned ship rules, so future cycles don't rediscover them the hard way.
+
+## Summary of New Capabilities
+
+- The mentor autoloop goal prompt instructs each cycle to run `instar dev:claim-check` before starting a build (parallel-claim collision prevention) and to include the `## ELI16` section in every PR description from the start (the required CI gate).
+
+## What Changed
+
+One discipline line appended in `buildAutoloopGoal` (`src/scheduler/MentorAutonomousGuardian.ts`), pinned by the existing deterministic prompt-assembly unit test (2 new assertions). Earned from the 2026-06-05 double parallel-collision and the live #813 eli16-gate hit.

--- a/upgrades/side-effects/mentor-prompt-tonight-gates.md
+++ b/upgrades/side-effects/mentor-prompt-tonight-gates.md
@@ -1,0 +1,34 @@
+# Side-Effects Review — mentor autoloop prompt: claim-check + ELI16-body rules
+
+**Version / slug:** `mentor-prompt-tonight-gates`
+**Date:** `2026-06-05`
+**Author:** `echo`
+**Second-pass reviewer:** `self-review under the Tier-1 lite lane (one prompt line in a pure, unit-tested string builder; no control-flow change)`
+
+## Summary of the change
+
+`buildAutoloopGoal` (the durable goal prompt for the mentor autonomous-fix loop, `MentorAutonomousGuardian.ts`) gains one discipline line encoding two 2026-06-05 lessons: run `instar dev:claim-check` before starting a build (the double parallel-collision night — #802 vs the keychain spec, #810 vs #808), and write the `## ELI16` section into the PR DESCRIPTION from the start (the new required CI gate, hit live on #813).
+
+## Decision-point inventory
+
+- `buildAutoloopGoal` — modified — one appended prompt line; pure function, no behavioral branch added.
+
+## 1. Over-block / 2. Over-permit
+
+None — prompt text only. The loop's gates (budget, single-instance, dark-by-default `mentor.autonomousFix.enabled`) are untouched. A host overriding via `mentor.autonomousFix.goalTemplate` is unaffected (the override path bypasses the built-in string entirely, unchanged).
+
+## 3. Drift note
+
+The prompt references the `dev:claim-check` CLI (shipped in #813) and the ELI16 PR-body gate (shipped 2026-06-05). If either is ever removed, this line goes stale — both are referenced by name so a grep finds them.
+
+## 4. Migration parity
+
+None — src-internal constant; ships with the package.
+
+## 5. Token/cost impact
+
+~90 extra prompt tokens per autoloop cycle spawn. Negligible.
+
+## 6. Rollback
+
+Revert the commit; the prompt loses the two reminders (structural gates still enforce both server-side — this line just saves the cycle from discovering them red).


### PR DESCRIPTION
## Why

Two ship rules were earned the hard way on 2026-06-05 and are now structurally enforced server-side (#813's `dev:claim-check` + the ELI16 PR-body required gate). The mentor autonomous-fix loop's durable goal prompt (`buildAutoloopGoal`) should make each cycle comply on the FIRST try instead of discovering a red check after pushing — Structure > Willpower applies to the prompt's own content: encode it once in code, not per-cycle by memory.

## What

One discipline line appended in `buildAutoloopGoal` (`src/scheduler/MentorAutonomousGuardian.ts`):
- Run `instar dev:claim-check <paths> [--keywords ...]` BEFORE starting a build; if a sibling owns a layer, claim a different layer explicitly (earned: two parallel sessions built the same incident fix twice in one night — #802 vs the keychain spec, #810 vs #808).
- Every PR DESCRIPTION must include an `## ELI16` section from the start (the required CI gate, hit live on #813).

Pure string builder; no control flow, gates (budget / single-instance / dark default) untouched; `goalTemplate` override path unaffected.

## Validation

12/12 guardian tests (2 new assertions pinning `dev:claim-check` and `## ELI16` in the assembled prompt), tsc clean. Tier-1 lane: eli16 + side-effects + fresh trace.

## ELI16

The mentor system can run an autonomous develop-and-fix loop whose working instructions are encoded in code, so every cycle gets the same discipline instead of whatever someone remembers to type. Two rules earned the hard way are now part of those durable instructions: (1) before starting any build, run the new claim-check command so two parallel builders never construct the same fix twice — that exact collision happened twice in one night and wasted hours of rework; (2) every PR description must include a plain-English ELI16 section from the start, because a required CI gate now rejects PRs without one — far better to write it up front than to discover the red check after pushing and have to edit the description and re-run the gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)