### PR TITLE
fix(release): add missing ## Evidence to the decision-audit-self-commit fragment (unjam v1.3.283)

### DIFF
--- a/upgrades/next/decision-audit-self-commit.md
+++ b/upgrades/next/decision-audit-self-commit.md
@@ -14,3 +14,7 @@ Nothing user-visible. An internal audit-trail leak is closed: the per-commit bui
 ## What Changed
 
 One change in `writeDecisionAudit` (auto-stage after append) + a regression test (`tests/unit/instar-dev-precommit-audit-staging.test.ts`) pinning that the line is written AND staged even when the gate blocks. Root cause of the task-#62 "decision-audit didn't fire" mystery: it fired; the line sat uncommitted in the building worktree and was deleted with it.
+
+## Evidence
+
+Reproduced live twice on 2026-06-05 before the fix: two build worktrees (`keychain-per-agent`, then `dev-claim-check`) each held an orphaned, uncommitted `+{"ts":"2026-06-05T08:49:24Z","slug":"keychain-per-agent-master-key",...}` line in the tracked `.instar/instar-dev-decisions.jsonl` after their PR commit — `git status` showed ` M .instar/instar-dev-decisions.jsonl` post-commit, and removing the worktree would have deleted the only copy (one line was hand-rescued before reclaim). After the fix, observed on PR #814's own commit: `git status --short .instar/instar-dev-decisions.jsonl` is CLEAN immediately post-commit and the commit diff contains the gate's own audit line for that very commit — the dogfood proof quoted in the PR body.


### PR DESCRIPTION
## Why

The publish for #814's merge (`c9c6fc086`) FAILED at 'Check upgrade guide': the `decision-audit-self-commit` fragment's What Changed claims a fix but had no `## Evidence` section — so **every fleet release is jammed** until this lands (the exact task-#42 jam class).

## What

Adds the `## Evidence` section with the real before/after: two orphaned audit lines observed live in build worktrees pre-fix (one hand-rescued before worktree reclaim), and #814's own commit carrying its audit line with a clean post-commit status as the dogfood proof.

Validated locally: assembled fragments pass `validateGuideContent` with zero issues.

**Sequencing note:** #815 (green, awaiting merge) adds this exact validation to the required Repo Invariants CI check — its invariant run against current main reproduces this failure verbatim. Merge order: this PR first (unjams + makes main pass the new invariant), then #815 (arms the guard so the class can't reach main again).

## ELI16

Yesterday's merge included release notes that claim a bug fix without showing the evidence the release checker requires, and that checker runs at publish time — so every release for every agent is stuck until the notes are fixed. This adds the missing evidence section (what we actually observed before and after the fix), which un-sticks the release train. A companion change that's already green makes this kind of mistake turn the checks red on the pull request itself, before it can ever reach the main branch and block releases.

docs/release-notes only — no code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)