### PR TITLE
fix(feedback-migration): bound parity snapshot page fetches (hang fix)

### DIFF
--- a/src/feedback-factory/dryrun/HttpParitySource.ts
+++ b/src/feedback-factory/dryrun/HttpParitySource.ts
@@ -54,6 +54,20 @@ export interface HttpParitySourceConfig {
   fetchImpl?: FetchLike;
   /** Optional path override (defaults to `/api/instar/read`). */
   readPath?: string;
+  /**
+   * Per-page fetch timeout in ms. Default 90 000 (a healthy full snapshot ran
+   * ~15s/page, so 90s is ~6× headroom). Enforced via AbortSignal so one stalled
+   * Portal page request cannot hang `prepare()` forever — the 2026-06-05 live
+   * incident: a silent page stall left a triggered parity pass unresolved for
+   * 10+ minutes with no logged outcome and nothing recorded.
+   */
+  pageTimeoutMs?: number;
+  /**
+   * Total budget for the whole snapshot fetch in ms. Default 600 000 (10 min).
+   * Checked between pages AND bounds each page's abort signal, so `prepare()`
+   * has a hard upper duration even at the 200-page safety cap.
+   */
+  totalTimeoutMs?: number;
 }
 
 /** Shape returned by Portal at `/api/instar/read` (only the fields we read). */
@@ -123,12 +137,16 @@ export class HttpParitySource implements ParitySource {
   private readonly maxPages: number;
   private readonly fetch: FetchLike;
   private readonly readPath: string;
+  private readonly pageTimeoutMs: number;
+  private readonly totalTimeoutMs: number;
 
   constructor(private readonly config: HttpParitySourceConfig) {
     this.pageSize = config.pageSize ?? 1000;
     this.maxPages = config.maxPages ?? 200;
     this.fetch = config.fetchImpl ?? (globalThis.fetch as unknown as FetchLike);
     this.readPath = config.readPath ?? '/api/instar/read';
+    this.pageTimeoutMs = config.pageTimeoutMs ?? 90_000;
+    this.totalTimeoutMs = config.totalTimeoutMs ?? 600_000;
     if (!this.fetch) {
       throw new HttpParitySourceError(500, 'no fetch available — pass fetchImpl or run on a runtime with global fetch');
     }
@@ -139,6 +157,7 @@ export class HttpParitySource implements ParitySource {
     const byId = new Map<string, PortalCluster>();
     const base = this.config.baseUrl.replace(/\/+$/, '');
     const authHeader = `Bearer ${this.config.token}`;
+    const deadline = Date.now() + this.totalTimeoutMs;
 
     for (let page = 0; page < this.maxPages; page++) {
       const offset = page * this.pageSize;
@@ -146,7 +165,35 @@ export class HttpParitySource implements ParitySource {
       if (this.config.status) qs.set('status', this.config.status);
       const url = `${base}${this.readPath}?${qs.toString()}`;
 
-      const res = await this.fetch(url, { headers: { Authorization: authHeader, Accept: 'application/json' } });
+      // Hard duration bound (the 2026-06-05 hang fix): every page fetch carries
+      // an AbortSignal capped by BOTH the per-page timeout and the remaining
+      // total budget. A stalled request aborts instead of hanging the pass —
+      // the route layer then logs the classified failure (per #807's
+      // always-logged-outcome contract) and records nothing.
+      const remainingMs = deadline - Date.now();
+      if (remainingMs <= 0) {
+        throw new HttpParitySourceError(
+          504,
+          `parity snapshot fetch exceeded the total budget (${this.totalTimeoutMs}ms) before page ${page}`,
+        );
+      }
+      const budgetMs = Math.min(this.pageTimeoutMs, remainingMs);
+      let res: Awaited<ReturnType<FetchLike>>;
+      try {
+        res = await this.fetch(url, {
+          headers: { Authorization: authHeader, Accept: 'application/json' },
+          signal: AbortSignal.timeout(budgetMs),
+        });
+      } catch (err) {
+        const name = err instanceof Error ? err.name : '';
+        if (name === 'TimeoutError' || name === 'AbortError') {
+          throw new HttpParitySourceError(
+            504,
+            `Portal /api/instar/read page ${page} timed out after ${budgetMs}ms (pageTimeoutMs=${this.pageTimeoutMs}, totalTimeoutMs=${this.totalTimeoutMs})`,
+          );
+        }
+        throw err;
+      }
       if (!res.ok) {
         let detail = '';
         try { detail = (await res.text()).slice(0, 200); } catch { /* ignore */ }

--- a/src/server/AgentServer.ts
+++ b/src/server/AgentServer.ts
@@ -907,7 +907,7 @@ export class AgentServer {
         const parityMonitor = new DurableParityMonitor(
           new JsonlPassPersistence(path.join(options.config.stateDir, 'state', 'feedback-parity-passes.jsonl')),
         );
-        const migrationCfg = (this.config as { feedbackMigration?: { paritySource?: { baseUrl?: string; secretKey?: string; pageSize?: number; status?: string } } }).feedbackMigration;
+        const migrationCfg = (this.config as { feedbackMigration?: { paritySource?: { baseUrl?: string; secretKey?: string; pageSize?: number; status?: string; pageTimeoutMs?: number; totalTimeoutMs?: number } } }).feedbackMigration;
         const paritySourceCfg = migrationCfg?.paritySource;
         const runParityCheck = paritySourceCfg?.baseUrl
           ? async () => {
@@ -918,6 +918,8 @@ export class AgentServer {
               token,
               ...(paritySourceCfg.pageSize ? { pageSize: paritySourceCfg.pageSize } : {}),
               ...(paritySourceCfg.status ? { status: paritySourceCfg.status } : {}),
+              ...(paritySourceCfg.pageTimeoutMs ? { pageTimeoutMs: paritySourceCfg.pageTimeoutMs } : {}),
+              ...(paritySourceCfg.totalTimeoutMs ? { totalTimeoutMs: paritySourceCfg.totalTimeoutMs } : {}),
             });
             await source.prepare();
             return runDryRunCompare(source);

--- a/tests/unit/feedback-factory/http-parity-source.test.ts
+++ b/tests/unit/feedback-factory/http-parity-source.test.ts
@@ -184,6 +184,72 @@ describe('HttpParitySource — error mapping', () => {
   });
 });
 
+describe('HttpParitySource — fetch timeouts (the 2026-06-05 hang fix)', () => {
+  it('a stalled page fetch aborts at pageTimeoutMs and maps to HttpParitySourceError 504', async () => {
+    // Stub mirrors real fetch abort semantics: never resolves, rejects with the
+    // signal's reason (a DOMException named TimeoutError for AbortSignal.timeout).
+    const fetchStub: FetchLike = vi.fn(
+      (_url, init) =>
+        new Promise((_resolve, reject) => {
+          init?.signal?.addEventListener('abort', () => reject(init.signal!.reason));
+        }),
+    );
+    const source = new HttpParitySource({ baseUrl: 'https://p', token: 't', fetchImpl: fetchStub, pageTimeoutMs: 30 });
+    try {
+      await source.prepare();
+      throw new Error('expected throw');
+    } catch (e) {
+      expect(e).toBeInstanceOf(HttpParitySourceError);
+      expect((e as HttpParitySourceError).status).toBe(504);
+      expect((e as Error).message).toContain('timed out after');
+      expect((e as Error).message).toContain('page 0');
+    }
+  });
+
+  it('every page fetch carries an AbortSignal (no unbounded request can be issued)', async () => {
+    const signals: Array<AbortSignal | undefined> = [];
+    const fetchStub: FetchLike = vi.fn(async (_url, init) => {
+      signals.push(init?.signal);
+      return okResponse({ data: { clusters: [] }, meta: { returned_count: 0 } });
+    });
+    const source = new HttpParitySource({ baseUrl: 'https://p', token: 't', fetchImpl: fetchStub });
+    await source.prepare();
+    expect(signals).toHaveLength(1);
+    expect(signals[0]).toBeInstanceOf(AbortSignal);
+  });
+
+  it('enforces the total budget between pages (504 before issuing the next page)', async () => {
+    let calls = 0;
+    const fetchStub: FetchLike = vi.fn(async () => {
+      calls++;
+      await new Promise((r) => setTimeout(r, 15));
+      // always a full page → wants to keep paginating
+      return okResponse({
+        data: { clusters: [sampleCluster(calls)], feedback: new Array(10).fill({}), dispatches: [] },
+        meta: { returned_count: 10 },
+      });
+    });
+    const source = new HttpParitySource({ baseUrl: 'https://p', token: 't', pageSize: 10, fetchImpl: fetchStub, totalTimeoutMs: 1 });
+    try {
+      await source.prepare();
+      throw new Error('expected throw');
+    } catch (e) {
+      expect(e).toBeInstanceOf(HttpParitySourceError);
+      expect((e as HttpParitySourceError).status).toBe(504);
+      expect((e as Error).message).toContain('exceeded the total budget');
+    }
+    expect(calls).toBe(1); // page 0 ran; page 1 was refused before issue
+  });
+
+  it('non-abort fetch failures propagate unchanged (not masked as 504)', async () => {
+    const fetchStub: FetchLike = vi.fn(async () => {
+      throw new TypeError('network down');
+    });
+    const source = new HttpParitySource({ baseUrl: 'https://p', token: 't', fetchImpl: fetchStub });
+    await expect(source.prepare()).rejects.toThrow(TypeError);
+  });
+});
+
 describe('HttpParitySource — prepare-before-read invariant', () => {
   it('readPortalClusters() before prepare() throws (no silent empty)', () => {
     const fetchStub: FetchLike = vi.fn(async () => okResponse({ data: { clusters: [] }, meta: { returned_count: 0 } }));

--- a/upgrades/next/parity-fetch-timeout.md
+++ b/upgrades/next/parity-fetch-timeout.md
@@ -1,0 +1,37 @@
+<!-- bump: patch -->
+
+## What Changed
+
+Closed the remaining way a live data-comparison check could silently stall. The
+previous fix made sure every comparison's outcome gets logged — but only once
+the underlying download finishes. If the remote data source stalled mid-download
+and never answered, the comparison hung forever with no outcome at all. Each
+piece of the download now has its own time limit (90 seconds per page, 10
+minutes overall), so a stalled download fails cleanly with a clear log line
+instead of hanging.
+
+## What to Tell Your User
+
+Nothing changes day to day. If your agent runs live data comparisons for a
+migration, a stalled remote server now produces a clear "timed out" failure in
+the logs within minutes instead of a comparison that never finishes.
+
+## Evidence
+
+Reproduced live on echo's production server (2026-06-05): a parity comparison
+triggered at 09:11:57Z never produced an outcome — no log line, nothing
+recorded — for 19+ minutes, while the remote endpoint's auth wall answered in
+0.2s (the stall was inside the authenticated data download, which had no
+timeout). After: with the new per-page abort budgets, the same stall aborts as
+a classified 504 within the 90-second page limit and the failure is logged by
+the always-logged-outcome path shipped in the previous fix. Unit tests
+additionally prove the abort fires, the page number is named, the total budget
+refuses the next page, and non-timeout errors pass through unmasked.
+
+## Summary of New Capabilities
+
+- Live parity-comparison downloads abort cleanly when the remote source stalls
+  (90s per page, 10 minutes total), with the failure logged and classified.
+- Operators can tune both limits in config
+  (`feedbackMigration.paritySource.pageTimeoutMs` / `.totalTimeoutMs`).
+- Maturity: stable; defaults preserve existing behavior for healthy sources.

--- a/upgrades/side-effects/parity-fetch-timeout.md
+++ b/upgrades/side-effects/parity-fetch-timeout.md
@@ -1,0 +1,41 @@
+# Side-effects review — parity snapshot fetch hang fix
+
+Live finding (2026-06-05, the very next trigger after #807 deployed): a parity
+pass hung past 12 minutes with NO outcome line and nothing recorded. #807 fixed
+the response-side (realistic 360s budget + always-logged outcome), but the
+outcome log fires only when the server-side `prepare()` await RESOLVES — and
+`HttpParitySource.prepare()`'s page fetches carried no AbortSignal and no
+timeout. One silently-stalled Portal page request (the endpoint's auth wall
+answered in 0.2s; the authenticated data path just never returned) hangs the
+pass forever: nothing logs, nothing records, the parity window starves.
+
+## 1. The change
+
+- `HttpParitySource.ts`: every page fetch now carries
+  `AbortSignal.timeout(min(pageTimeoutMs, remaining-total-budget))` —
+  `pageTimeoutMs` default 90s (healthy pages measured ~15s → 6× headroom),
+  `totalTimeoutMs` default 600s hard-bounds the whole snapshot even at the
+  200-page safety cap. Aborts map to a classified `HttpParitySourceError(504)`
+  naming the page and both budgets; non-abort fetch failures propagate
+  unchanged (not masked).
+- `AgentServer.ts`: config passthrough only —
+  `feedbackMigration.paritySource.pageTimeoutMs` / `.totalTimeoutMs` (both
+  optional; absent = defaults). No migrateConfig entry by design: absence
+  preserves shipped defaults, same pattern as the sibling `pageSize`/`status`.
+
+## 2. Blast radius
+
+Two files, additive. The error path lands in the route layer's existing
+classified-failure handling from #807: outcome ALWAYS logged
+(`parity pass FAILED (nothing recorded): …504…timed out…`), nothing recorded —
+T7 unchanged. Healthy passes are untouched (a 204s real pass sits far inside
+both budgets). No route timing changes; #807's 360s response budget is
+orthogonal (response side vs upstream-fetch side).
+
+## 3. Test coverage
+
+4 new unit tests in the existing HttpParitySource suite (14 total green):
+stalled page fetch aborts at `pageTimeoutMs` → 504 naming the page; every page
+fetch carries an AbortSignal (no unbounded request can be issued); the total
+budget is enforced between pages (504 before issuing the next page, verified by
+call count); a non-abort fetch failure (TypeError) propagates unchanged.


### PR DESCRIPTION
## ELI16

The system regularly double-checks that Echo's copy of the feedback data matches Dawn's original — like comparing two spreadsheets to make sure nothing drifted. To do that it downloads Dawn's data page by page. There was no time limit on those downloads, so when Dawn's server stopped answering mid-download, the comparison just sat there forever — it never finished, never failed, and never wrote down what happened. This change gives every page download a timer (90 seconds each, 10 minutes for the whole thing). If the download stalls now, it stops cleanly and writes a clear 'timed out' note in the log instead of hanging silently.

## Live incident (follow-on to #807)

The very next parity pass after #807 deployed hung **19+ minutes with no outcome** — no log line, nothing recorded. #807's always-logged outcome only fires when the server-side `prepare()` await RESOLVES, and `HttpParitySource`'s page fetches carried **no AbortSignal and no timeout**. One silently-stalled Portal page request (auth wall answered in 0.2s; the authenticated data path never returned) hangs the pass forever and starves the parity window.

## Fix

- `HttpParitySource.prepare()`: every page fetch now carries `AbortSignal.timeout(min(pageTimeoutMs, remaining totalTimeoutMs))` — `pageTimeoutMs` default **90s** (healthy pages measured ~15s → 6× headroom), `totalTimeoutMs` default **600s** hard-bounds the whole snapshot even at the 200-page cap.
- Aborts map to classified `HttpParitySourceError(504)` naming the page + budgets → lands in #807's route layer: outcome ALWAYS logged, nothing recorded (T7 unchanged). Non-abort failures propagate unmasked.
- `AgentServer`: config passthrough only — `feedbackMigration.paritySource.pageTimeoutMs`/`.totalTimeoutMs` (optional; absent = defaults; no migrateConfig by design, same pattern as sibling `pageSize`/`status`).

## Tests

4 new unit tests (HttpParitySource suite 14/14 green): stalled page → 504 naming page 0; every fetch carries a signal; total budget refuses the next page (call-count proof); TypeError propagates unchanged. Targeted suites touching the diff: 23 files / 229 tests green. tsc + lint + gates green.

## Gate

Tier-1 incident-fix lane (the #807 shape): side-effects + ELI16 fragment with `## Evidence` (live repro), trace `parity-fetch-timeout.json`. Declared Tier 1 under the risk floor (the floor trigger is two OPTIONAL tuning knobs mirroring existing sibling keys) — recorded in `.instar/instar-dev-decisions.jsonl` with reasoning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)