### PR TITLE
test(migrator): align coordination-awareness fixture with the import-dryrun splice (#823 follow-up)

### DIFF
--- a/tests/unit/PostUpdateMigrator-coordinationAwareness.test.ts
+++ b/tests/unit/PostUpdateMigrator-coordinationAwareness.test.ts
@@ -79,12 +79,43 @@ describe('PostUpdateMigrator — coordination-surface CLAUDE.md backfill (mandat
   });
 
   it('does not double-patch a freshly-initialized agent that already carries the sections', () => {
-    // Simulate a new agent whose template already includes the markers.
+    // Simulate a new agent whose template already includes the markers — including
+    // the import-dryrun rehearsal line a CURRENT template ships (an agent missing
+    // that line is the deployed-agent splice case, covered below).
     fs.writeFileSync(path.join(projectDir, 'CLAUDE.md'),
-      '# CLAUDE.md\n\n/mandate/evaluate … /review-exchange … /cutover-readiness …\n');
+      '# CLAUDE.md\n\n/mandate/evaluate … /review-exchange … /cutover-readiness … /cutover-readiness/import-dryrun …\n');
     const result = runClaudeMdMigration(migrator);
     expect(result.upgraded.some((u) => u.includes('Coordination Mandate'))).toBe(false);
     expect(result.upgraded.some((u) => u.includes('ReviewExchange'))).toBe(false);
     expect(result.upgraded.some((u) => u.includes('Cutover Readiness'))).toBe(false);
+  });
+
+  it('splices the import-dryrun line into an agent carrying the PRE-rehearsal Cutover Readiness section', () => {
+    // The deployed-agent case: the section shipped before the import rehearsal
+    // existed — has the route prefix and the door line, but no dry-run line.
+    fs.writeFileSync(path.join(projectDir, 'CLAUDE.md'), [
+      '# CLAUDE.md',
+      '',
+      '/mandate/evaluate … /review-exchange …',
+      '**Cutover Readiness** — read surface.',
+      '- Check: `curl http://localhost:4042/cutover-readiness`.',
+      '- **The door is NOT yours**: the cutover click belongs to the operator.',
+      '',
+    ].join('\n'));
+    const result = runClaudeMdMigration(migrator);
+    expect(result.upgraded.some((u) => u.includes('import dry-run'))).toBe(true);
+
+    const content = fs.readFileSync(path.join(projectDir, 'CLAUDE.md'), 'utf-8');
+    expect(content).toContain('/cutover-readiness/import-dryrun');
+    // Spliced AHEAD of the door-discipline line (workflow order preserved).
+    expect(content.indexOf('/cutover-readiness/import-dryrun'))
+      .toBeLessThan(content.indexOf('**The door is NOT yours**'));
+    // NEVER-greens honesty copy travels with the line.
+    expect(content).toContain('NEVER greens the canonical integrity condition');
+
+    // Idempotent: a second run leaves the file byte-identical.
+    const result2 = runClaudeMdMigration(migrator);
+    expect(result2.upgraded.some((u) => u.includes('import dry-run'))).toBe(false);
+    expect(fs.readFileSync(path.join(projectDir, 'CLAUDE.md'), 'utf-8')).toBe(content);
   });
 });


### PR DESCRIPTION
## ELI16

#823 taught the updater a new trick: if an agent's handbook has the old version of the migration-readiness section, splice in one new line about the rehearsal button. One existing test pretends to be a "brand-new agent" using a tiny stand-in handbook — but that stand-in was written before the new line existed, so to the updater it looks exactly like an OLD handbook, and the updater (correctly!) patches it. The test then failed saying "you shouldn't have patched a new agent." The updater is right; the stand-in was stale. This updates the stand-in to look like a genuinely current handbook, and adds a proper test for the old-handbook case so the splice behavior itself is now covered.

## What

- Fixture in `does not double-patch a freshly-initialized agent` now includes the `/cutover-readiness/import-dryrun` marker a current template ships.
- New test: an agent carrying the PRE-rehearsal section gets the line spliced ahead of the door-discipline line, with the never-greens honesty copy, idempotently (second run byte-identical).

## Evidence

Main went red on `Unit Tests shard 3/4` after #823 merged (run 27011785277): `AssertionError: expected true to be false` in this suite — the splice branch patching the stale fixture. Suite now 5/5 locally. Test-only change; no src diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)