### PR TITLE
Test Slack socket ack reconnect guard

### DIFF
--- a/docs/specs/slack-socket-ack-guard-regression.eli16.md
+++ b/docs/specs/slack-socket-ack-guard-regression.eli16.md
@@ -1,0 +1,15 @@
+# Slack Socket Ack-Guard Regression — ELI16
+
+The short version: the Slack reconnect crash fix already exists, and this change adds the missing behavioral test that proves the important guard actually works.
+
+Slack Socket Mode sends events through a live WebSocket. For each event, the agent is supposed to quickly send Slack an acknowledgement. The original crash happened during a reconnect race: the agent tried to send that acknowledgement while the socket was not fully connected, the socket threw "Sent before connected", and the exception escaped far enough to crash the whole agent.
+
+The production fix added two protections. First, before sending an acknowledgement, the socket client checks that the socket is really open. Second, even if the socket changes state after that check and the send still throws, the send is wrapped so the exception is logged instead of killing the process.
+
+Before this follow-up, coverage mostly checked that the source code contained those guard shapes. That is useful, but it is not the strongest proof. This change adds behavioral tests: it creates a socket client, gives it fake socket states, and feeds it a fake Slack event as if it arrived from the WebSocket.
+
+The first new test puts the socket in a not-open state and makes its send method dangerous. The expected behavior is that the send method is never called, nothing throws, and the Slack event still reaches the event handler.
+
+The second new test puts the socket in an open state but makes send throw anyway, matching the narrow race where state flips after the check. The expected behavior is that the throw is caught, a warning is logged, and the event still reaches the event handler.
+
+This is test-only. It does not change Slack runtime behavior, config, recovery policy, or user-visible behavior. Its value is that future edits to the Slack socket code cannot accidentally remove the ack guard without failing a real behavior test.

--- a/tests/unit/slack-socket-reconnect.test.ts
+++ b/tests/unit/slack-socket-reconnect.test.ts
@@ -10,9 +10,10 @@
  * and no further reconnects were attempted.
  */
 
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { readFileSync } from 'fs';
 import path from 'path';
+import { SocketModeClient, type SocketModeHandlers } from '../../src/messaging/slack/SocketModeClient.js';
 
 const socketClientPath = path.resolve(__dirname, '../../src/messaging/slack/SocketModeClient.ts');
 const socketClientSource = readFileSync(socketClientPath, 'utf-8');
@@ -22,6 +23,20 @@ const slackAdapterSource = readFileSync(slackAdapterPath, 'utf-8');
 
 const serverPath = path.resolve(__dirname, '../../src/commands/server.ts');
 const serverSource = readFileSync(serverPath, 'utf-8');
+
+function makeHandlers(): SocketModeHandlers {
+  return {
+    onEvent: vi.fn(async () => {}),
+    onInteraction: vi.fn(async () => {}),
+    onConnected: vi.fn(),
+    onDisconnected: vi.fn(),
+    onError: vi.fn(),
+  };
+}
+
+async function handleRaw(client: SocketModeClient, raw: string): Promise<void> {
+  await (client as unknown as { _handleRawMessage(raw: string): Promise<void> })._handleRawMessage(raw);
+}
 
 describe('SocketModeClient reconnection', () => {
   it('has a reconnect() method', () => {
@@ -90,6 +105,47 @@ describe('SleepWake Slack reconnection', () => {
 });
 
 describe('Ack send guard against a mid-reconnect socket (#43 — no whole-agent crash)', () => {
+  it('does not send or throw when an event arrives while the socket is not OPEN', async () => {
+    const handlers = makeHandlers();
+    const client = new SocketModeClient({} as any, handlers);
+    const send = vi.fn(() => {
+      throw new Error('Sent before connected.');
+    });
+    (client as any).ws = { readyState: WebSocket.CONNECTING, send };
+    const payload = {
+      envelope_id: 'E-mid-reconnect',
+      type: 'events_api',
+      payload: { event: { type: 'message' } },
+    };
+
+    await expect(handleRaw(client, JSON.stringify(payload))).resolves.toBeUndefined();
+
+    expect(send).not.toHaveBeenCalled();
+    expect(handlers.onEvent).toHaveBeenCalledWith('message', payload.payload);
+  });
+
+  it('catches an ack send race when the socket flips state after the OPEN check', async () => {
+    const handlers = makeHandlers();
+    const client = new SocketModeClient({} as any, handlers);
+    const send = vi.fn(() => {
+      throw new Error('Sent before connected.');
+    });
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    (client as any).ws = { readyState: WebSocket.OPEN, send };
+    const payload = {
+      envelope_id: 'E-send-race',
+      type: 'events_api',
+      payload: { event: { type: 'message' } },
+    };
+
+    await expect(handleRaw(client, JSON.stringify(payload))).resolves.toBeUndefined();
+
+    expect(send).toHaveBeenCalledWith(JSON.stringify({ envelope_id: 'E-send-race' }));
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('Ack send failed'));
+    expect(handlers.onEvent).toHaveBeenCalledWith('message', payload.payload);
+    warn.mockRestore();
+  });
+
   it('guards the event ack on socket readyState === OPEN', () => {
     // The "must ack within 3s" send previously called this.ws?.send() with only
     // a null check — during a reconnect race the socket can be CONNECTING/CLOSING,

--- a/upgrades/next/slack-socket-ack-guard-regression.md
+++ b/upgrades/next/slack-socket-ack-guard-regression.md
@@ -1,0 +1,12 @@
+<!-- bump: patch -->
+<!-- internal-only -->
+
+## What Changed
+
+Added behavioral regression coverage for the Slack Socket Mode reconnect ack guard. The existing fix already guards ack sends on socket readiness and catches the send-race path; this slice pins that behavior by instantiating the socket client and driving the raw-message handler directly.
+
+The test now proves that an event arriving while the socket is not open does not attempt the ack send or throw, and that an ack send throwing after an open-state check is caught while event processing continues.
+
+## Evidence
+
+Focused gate: `npx vitest run tests/unit/slack-socket-reconnect.test.ts` passed with 17 tests.

--- a/upgrades/side-effects/slack-socket-ack-guard-regression.md
+++ b/upgrades/side-effects/slack-socket-ack-guard-regression.md
@@ -1,0 +1,85 @@
+# Side-Effects Review — Slack Socket Mode ack-guard behavioral regression
+
+**Version / slug:** `slack-socket-ack-guard-regression`
+**Date:** `2026-06-05`
+**Author:** `instar-codey`
+**Second-pass reviewer:** `not required — test-only Tier 1`
+
+## Summary of the change
+
+This is a test-only follow-up for the Slack Socket Mode reconnect crash guard. The existing production fix in `src/messaging/slack/SocketModeClient.ts` already checks `readyState === WebSocket.OPEN` before sending event acknowledgements and catches the send-race path. This change adds behavioral coverage in `tests/unit/slack-socket-reconnect.test.ts` by instantiating `SocketModeClient`, injecting fake socket states, and driving the raw-message handler directly.
+
+## Decision-point inventory
+
+- Slack Socket Mode event ack behavior — **pass-through** — production behavior unchanged; tests now assert the already-shipped guard path.
+- Event processing after ack handling — **pass-through** — tests assert event processing continues after skipped or caught ack sends.
+
+---
+
+## 1. Over-block
+
+No runtime block/allow surface changed. The only possible over-block is a future code change being rejected by tests if it removes the ack readiness guard or stops event processing after a skipped/caught ack.
+
+---
+
+## 2. Under-block
+
+The test does not open a real Slack Socket Mode connection. It covers the unit-level failure mode directly: non-open socket state and send throwing after an open-state check. Real integration timing remains covered by existing reconnect/heartbeat tests and Slack's own redelivery behavior.
+
+---
+
+## 3. Level-of-abstraction fit
+
+The regression belongs at the `SocketModeClient` unit layer because the crash was caused by ack behavior in the raw message handler. A source assertion already existed, but this behavioral test is the right layer to prove the guard path actually prevents throws and preserves event handling.
+
+---
+
+## 4. Signal vs authority compliance
+
+**Required reference:** [docs/signal-vs-authority.md](../../docs/signal-vs-authority.md)
+
+- [ ] No — this change produces a signal consumed by an existing smart gate.
+- [x] No — this change has no block/allow surface.
+- [ ] Yes — but the logic is a smart gate with full conversational context.
+- [ ] Yes, with brittle logic — STOP. Reshape the design.
+
+This is test-only coverage. It does not add a detector, gate, relay policy, or runtime decision point.
+
+---
+
+## 5. Interactions
+
+- **Shadowing:** none at runtime.
+- **Double-fire:** none at runtime.
+- **Races:** the test explicitly simulates the reconnect race where the socket is not open, plus the narrower race where send throws after an open-state check.
+- **Feedback loops:** none.
+
+---
+
+## 6. External surfaces
+
+No external surface changes. Slack behavior, config, API routes, Telegram behavior, dashboard behavior, and persistent state are unchanged. The release fragment is marked internal-only because this ships only regression coverage.
+
+---
+
+## 7. Rollback cost
+
+Rollback is deleting the added test assertions and artifacts. No data migration, agent state repair, or user-visible rollback behavior exists.
+
+---
+
+## Conclusion
+
+Clear to ship as a test-only Tier-1 follow-up. The missing behavioral coverage now pins the crash guard that was previously covered only by source assertions.
+
+---
+
+## Second-pass review (if required)
+
+Not required — test-only Tier 1.
+
+---
+
+## Evidence pointers
+
+- `npx vitest run tests/unit/slack-socket-reconnect.test.ts` — 17 tests passed.


### PR DESCRIPTION
## Summary

- Adds behavioral regression coverage for the existing Slack Socket Mode ack-send guard.
- Pins both reconnect-race boundaries: a not-OPEN socket does not send/throw, and an OPEN-check send race is caught while event handling continues.
- Ships as Tier 1 with ELI16 + side-effects artifacts; no runtime Slack behavior changes.

## ELI16

The Slack crash fix already exists. This PR adds the missing behavior test that proves the fix keeps working. When Slack sends an event, the agent tries to acknowledge it over the WebSocket. During reconnect, that socket may not be open yet, or it may look open and then fail while sending. The new tests feed a fake Slack event through the real raw-message handler and prove both cases stay contained: no whole-agent throw, and the Slack event still reaches the handler.

## Validation

- `npx vitest run tests/unit/slack-socket-reconnect.test.ts` — 17 tests passed.
- `npm run lint` — passed.
- `npm run check:upgrade-guide` — passed; historical warnings only, exit 0.
- `node scripts/check-repo-invariants.mjs` — passed.
- `node scripts/docs-coverage.mjs --check` — passed.
- `git diff --check` / `git diff --cached --check` — passed.
- `npm run check:pre-push-gate` — exit 0 with existing package-version warning.
- Pre-push smoke on push — affected Slack reconnect test passed, 17 tests.

## Local pre-push anomaly

First push attempt let the path-scoped e2e gate run threadline e2e even though this branch only changes Slack tests/docs/upgrades. Slack smoke passed, then `tests/e2e/threadline/AbuseDetectionE2E.test.ts` failed during setup with `SqliteError: database is locked` at `src/threadline/relay/RegistryStore.ts:181` (`journal_mode = WAL`) and then cleanup failed on `adminServer.stop()` because setup did not finish. I retried the push with `INSTAR_PRE_PUSH_E2E_SKIP=1`; CI still runs the full e2e job.

## Claim Check / Scope

The handoff mentioned `src/messaging/SlackAdapter.ts`; current main has Slack under `src/messaging/slack/`. The production ack guard is already in `src/messaging/slack/SocketModeClient.ts`; this PR only adds the deferred behavioral regression coverage plus Tier-1 artifacts.
