### PR TITLE
fix: relay completed Gemini pane replies

### DIFF
--- a/.instar/instar-dev-decisions/2026-06-05T13-32-57-076Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-06-05T13-32-57-076Z-unknown.json
@@ -1,0 +1,11 @@
+{
+  "ts": "2026-06-05T13:32:57.076Z",
+  "slug": "unknown",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 3,
+  "loc": 85
+}

--- a/src/commands/server.ts
+++ b/src/commands/server.ts
@@ -4771,6 +4771,14 @@ export async function startServer(options: StartOptions): Promise<void> {
       });
     }
 
+    sessionManager.on('injectionReplyDetected', (info: { topicId: number; sessionName: string; text: string; injectedAt: number }) => {
+      if (!telegram) return;
+      console.log(`[injectionReplyDetected] Surfacing Gemini final pane reply from "${info.sessionName}" to topic ${info.topicId}`);
+      telegram.sendToTopic(info.topicId, info.text).catch((err: Error) => {
+        console.error(`[injectionReplyDetected] Failed to send reply for topic ${info.topicId}:`, err.message);
+      });
+    });
+
     if (scheduler) {
       sessionManager.on('sessionComplete', (session) => {
         scheduler!.processQueue();

--- a/src/core/SessionManager.ts
+++ b/src/core/SessionManager.ts
@@ -17,7 +17,7 @@ import { fileURLToPath } from 'node:url';
 import { SessionLivenessOracle, type SessionLivenessOracleConfig } from './SessionLivenessOracle.js';
 import type { ReapGuard } from './ReapGuard.js';
 import { paneShowsClaudeWorking } from './claudeActivityIndicators.js';
-import { meaningfulTail } from './paneText.js';
+import { extractGeminiFinalAssistantBlock, meaningfulTail } from './paneText.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -850,6 +850,31 @@ rm()  { "${shimRunner}" rm  "$@"; }
         }
 
         this.recordBuildContext(session.tmuxSession);
+
+        // Gemini CLI can complete a Telegram turn by rendering the final
+        // assistant block in the TUI without executing the relay script. When a
+        // topic-bound injection is still pending, surface that completed block
+        // as the reply instead of leaving the user silent.
+        if (session.framework === 'gemini-cli') {
+          const pendingInjection = this.pendingInjections.get(session.tmuxSession);
+          if (pendingInjection) {
+            const pane = this.captureOutput(session.tmuxSession, 400) || '';
+            const marker = `[telegram:${pendingInjection.topicId}`;
+            const markerIdx = pane.lastIndexOf(marker);
+            if (markerIdx >= 0) {
+              const reply = extractGeminiFinalAssistantBlock(pane.slice(markerIdx));
+              if (reply && reply.trim()) {
+                this.pendingInjections.delete(session.tmuxSession);
+                this.emit('injectionReplyDetected', {
+                  topicId: pendingInjection.topicId,
+                  sessionName: session.tmuxSession,
+                  text: reply,
+                  injectedAt: pendingInjection.injectedAt,
+                });
+              }
+            }
+          }
+        }
 
         // Check for completion patterns even while session appears alive
         // (catches sessions where Claude finished but tmux is still open)

--- a/src/core/paneText.ts
+++ b/src/core/paneText.ts
@@ -31,3 +31,53 @@ export function meaningfulTail(text: string, n: number): string {
   const trimmed = trimTrailingBlankRows(text.split('\n'));
   return trimmed.slice(-n).join('\n');
 }
+
+/**
+ * Extract the last completed Gemini assistant block from a live TUI pane.
+ *
+ * Gemini renders final prose as a block beginning with `✦`, then returns to an
+ * input/footer area (`Type your message`, model footer, etc.). This helper only
+ * returns a block when that idle footer appears after the assistant block, so a
+ * streaming/in-progress answer does not get relayed early.
+ */
+export function extractGeminiFinalAssistantBlock(text: string): string | null {
+  if (!text) return null;
+  const lines = trimTrailingBlankRows(text.split('\n'));
+  let start = -1;
+  for (let i = lines.length - 1; i >= 0; i--) {
+    if (/^\s*✦\s*/.test(lines[i])) {
+      start = i;
+      break;
+    }
+  }
+  if (start < 0) return null;
+
+  const after = lines.slice(start + 1).join('\n');
+  if (!/(Type your message|YOLO mode|no sandbox|\/model)/i.test(after)) return null;
+
+  const out: string[] = [];
+  const first = lines[start].replace(/^\s*✦\s*/, '').trimEnd();
+  if (first.trim()) out.push(first);
+
+  for (let i = start + 1; i < lines.length; i++) {
+    const line = lines[i];
+    if (/^\s*[╭╰│]/.test(line)) break;
+    if (/(Type your message|YOLO mode|no sandbox|\/model)/i.test(line)) break;
+    if (/^\s*\d+\s+GEMINI\.md files\b/i.test(line)) break;
+    if (/^\s*>/.test(line)) break;
+    out.push(line);
+  }
+
+  const trimmed = trimTrailingBlankRows(out).join('\n').trim();
+  if (!trimmed) return null;
+
+  const bodyLines = trimmed.split('\n');
+  const nonEmpty = bodyLines.filter((l) => l.trim());
+  const indents = nonEmpty
+    .map((l) => (/^(\s*)/.exec(l)?.[1].length ?? 0))
+    .filter((n) => n > 0);
+  const commonIndent = indents.length ? Math.min(...indents) : 0;
+  return commonIndent > 0
+    ? bodyLines.map((l) => l.trim() ? l.slice(Math.min(commonIndent, /^(\s*)/.exec(l)?.[1].length ?? 0)) : '').join('\n').trim()
+    : trimmed;
+}

--- a/tests/integration/topic-framework-dispatch.test.ts
+++ b/tests/integration/topic-framework-dispatch.test.ts
@@ -74,6 +74,7 @@ function buildManager(): SessionManager {
     maxSessions: 5,
     protectedSessions: [],
     completionPatterns: [],
+    framework: 'claude-code',
     authToken: 'test-token',
     port: 9999,
   };

--- a/tests/unit/paneText.test.ts
+++ b/tests/unit/paneText.test.ts
@@ -9,7 +9,7 @@
  */
 
 import { describe, expect, it } from 'vitest';
-import { meaningfulTail, trimTrailingBlankRows } from '../../src/core/paneText.js';
+import { extractGeminiFinalAssistantBlock, meaningfulTail, trimTrailingBlankRows } from '../../src/core/paneText.js';
 
 describe('trimTrailingBlankRows', () => {
   it('trims trailing blanks only — interior blanks are modal structure and stay', () => {
@@ -51,6 +51,41 @@ describe('meaningfulTail', () => {
   it('interior blank lines within the tail are preserved', () => {
     const pane = ['header', 'a', '', 'b', '', ''].join('\n');
     expect(meaningfulTail(pane, 3)).toBe('a\n\nb');
+  });
+});
+
+describe('extractGeminiFinalAssistantBlock', () => {
+  it('extracts the completed Gemini assistant block before the idle footer', () => {
+    const pane = [
+      '[telegram:1 "topic-1" from Codey mentor] stop and report',
+      '',
+      '✦ GEMI_TASK_REPORT_1780640360',
+      '  what you checked',
+      '  result',
+      '  smallest proper fix',
+      '',
+      ' 2 GEMINI.md files                                      YOLO mode (ctrl + y to toggle)',
+      '╭────────────────────────────────────────────────────────╮',
+      '│ *   Type your message or @path/to/file                 │',
+      '╰────────────────────────────────────────────────────────╯',
+      ' ~/.instar/agents/gemini          no sandbox          gemini-2.5-flash-lite /model',
+    ].join('\n');
+
+    expect(extractGeminiFinalAssistantBlock(pane)).toBe([
+      'GEMI_TASK_REPORT_1780640360',
+      'what you checked',
+      'result',
+      'smallest proper fix',
+    ].join('\n'));
+  });
+
+  it('returns null while Gemini has not returned to the input footer', () => {
+    const pane = [
+      '[telegram:1] answer me',
+      '✦ Partial answer still streaming',
+      '  more content',
+    ].join('\n');
+    expect(extractGeminiFinalAssistantBlock(pane)).toBeNull();
   });
 });
 

--- a/tests/unit/session-headless-continuity.test.ts
+++ b/tests/unit/session-headless-continuity.test.ts
@@ -100,6 +100,7 @@ describe('SessionManager.spawnSession — Threadline A2A continuity flags (headl
       maxSessions: 3,
       protectedSessions: [],
       completionPatterns: ['Session complete'],
+      framework: 'claude-code',
     };
     manager = new SessionManager(config, state);
 

--- a/tests/unit/session-manager-behavioral.test.ts
+++ b/tests/unit/session-manager-behavioral.test.ts
@@ -113,6 +113,7 @@ describe('SessionManager behavioral tests', () => {
       maxSessions: 3,
       protectedSessions: ['my-project-server'],
       completionPatterns: ['Session complete', 'Goodbye'],
+      framework: 'claude-code',
     };
     manager = new SessionManager(config, state);
 

--- a/tests/unit/session-resume.test.ts
+++ b/tests/unit/session-resume.test.ts
@@ -137,6 +137,7 @@ describe('SessionManager.spawnInteractiveSession --resume support', () => {
       maxSessions: 3,
       protectedSessions: [],
       completionPatterns: ['Session complete'],
+      framework: 'claude-code',
     };
     manager = new SessionManager(config, state);
 

--- a/tests/unit/session-telegram-inject.test.ts
+++ b/tests/unit/session-telegram-inject.test.ts
@@ -136,4 +136,62 @@ describe('SessionManager.injectTelegramMessage', () => {
     sm.injectTelegramMessage('sess-y', topicId, longText, undefined, undefined, undefined, messageId);
     expect(countFilesFor(topicId)).toBe(2);
   });
+
+  it('Gemini pending Telegram injection emits a detected reply from a completed final pane block', async () => {
+    const sm = mkSm();
+    const session = {
+      id: 'gemini-session-1',
+      name: 'gemini-topic-1',
+      status: 'running' as const,
+      tmuxSession: 'gemini-topic-1',
+      startedAt: new Date(Date.now() - 60_000).toISOString(),
+      framework: 'gemini-cli' as const,
+    };
+    project.state.saveSession(session);
+
+    const smAny = sm as unknown as {
+      pendingInjections: Map<string, { topicId: number; injectedAt: number; text: string }>;
+      isSessionAliveAsync: (tmuxSession: string) => Promise<boolean>;
+      captureOutput: (tmuxSession: string, lines?: number) => string | null;
+      recordBuildContext: () => void;
+      monitorTick: () => Promise<void>;
+    };
+    smAny.pendingInjections.set('gemini-topic-1', {
+      topicId: 1,
+      injectedAt: Date.now() - 5_000,
+      text: 'mentor prompt',
+    });
+    smAny.isSessionAliveAsync = async () => true;
+    smAny.recordBuildContext = () => {};
+    smAny.captureOutput = () => [
+      '[telegram:1 "topic-1" from Codey mentor] stop and report',
+      '',
+      '✦ GEMI_TASK_REPORT_1780640360',
+      '  checked the dashboard-refresh job',
+      '  result: final pane output exists',
+      '',
+      ' 2 GEMINI.md files                                      YOLO mode (ctrl + y to toggle)',
+      '╭────────────────────────────────────────────────────────╮',
+      '│ *   Type your message or @path/to/file                 │',
+      '╰────────────────────────────────────────────────────────╯',
+      ' ~/.instar/agents/gemini          no sandbox          gemini-2.5-flash-lite /model',
+    ].join('\n');
+
+    const detected: Array<{ topicId: number; sessionName: string; text: string }> = [];
+    sm.on('injectionReplyDetected', (info) => detected.push(info as { topicId: number; sessionName: string; text: string }));
+
+    await smAny.monitorTick();
+
+    expect(detected).toHaveLength(1);
+    expect(detected[0]).toMatchObject({
+      topicId: 1,
+      sessionName: 'gemini-topic-1',
+      text: [
+        'GEMI_TASK_REPORT_1780640360',
+        'checked the dashboard-refresh job',
+        'result: final pane output exists',
+      ].join('\n'),
+    });
+    expect(smAny.pendingInjections.has('gemini-topic-1')).toBe(false);
+  });
 });

--- a/tests/unit/spawn-resume-fallback.test.ts
+++ b/tests/unit/spawn-resume-fallback.test.ts
@@ -120,6 +120,7 @@ describe('spawnInteractiveSession: resume-failure fallback', () => {
       maxSessions: 3,
       protectedSessions: [],
       completionPatterns: [],
+      framework: 'claude-code',
     };
     manager = new SessionManager(config, state);
     mockTmuxSessions.clear();

--- a/upgrades/gemini-final-pane-relay.eli16.md
+++ b/upgrades/gemini-final-pane-relay.eli16.md
@@ -1,0 +1,9 @@
+# Gemini final pane replies now reach Telegram
+
+Gemini can finish a Telegram task by printing the final answer in its terminal pane without running the Telegram reply script. That is exactly the bad user experience: the work is visible in the live pane, but Telegram stays silent.
+
+This change gives the session monitor a Gemini-specific fallback. When a Gemini topic has an unanswered Telegram message, the monitor looks for Gemini's completed assistant block: a line beginning with `✦`, followed later by Gemini's normal input footer. Only then does it treat the block as the reply and send it to the Telegram topic.
+
+The guard is intentionally narrow. It only runs for `gemini-cli` sessions with a pending Telegram injection, only considers text after the matching `[telegram:N]` prompt, and only fires after Gemini has returned to the input/footer state. Claude and Codex keep their existing reply-script and transcript paths.
+
+Respawn-context note: after the server restart, the durable pieces survived: the Telegram history preserved the cycle id and repro, and the `gemini-final-output-relay` worktree survived cleanly. What had to be re-derived was the in-memory claim-check trail: which exact source files owned final relay, completion detection, and Gemini pane parsing.

--- a/upgrades/next/gemini-final-pane-relay.md
+++ b/upgrades/next/gemini-final-pane-relay.md
@@ -1,0 +1,19 @@
+---
+bump: patch
+---
+
+## What Changed
+
+Added a Gemini-specific fallback for topic sessions that finish a Telegram turn in the live pane without running the Telegram reply script. When a Gemini CLI session still has a pending Telegram injection, SessionManager now recognizes the completed final assistant block after the matching Telegram prompt and emits a detected reply once Gemini has returned to its input footer. Server wiring sends that reply back to the original Telegram topic.
+
+## What to Tell Your User
+
+Gemini topic sessions can now relay a completed final pane answer back to Telegram instead of leaving you with silence after the work finishes.
+
+## Summary of New Capabilities
+
+- Gemini final pane answers are detected and relayed for topic sessions with an unanswered Telegram message.
+
+## Evidence
+
+Live repro before the fix: Gemini topic session gemini-topic-1 showed GEMI_TASK_REPORT_1780640360 in its completed pane output, while Telegram only received the acknowledgement/status/gate messages and no final report. After the fix, focused unit coverage verifies the Gemini pane extractor and the pending-injection monitor path that clears the tracker and emits the detected reply for Telegram delivery.

--- a/upgrades/side-effects/gemini-final-pane-relay.md
+++ b/upgrades/side-effects/gemini-final-pane-relay.md
@@ -1,0 +1,42 @@
+# Side-Effects Review — Gemini final pane Telegram relay
+
+**Version / slug:** `gemini-final-pane-relay`
+**Date:** `2026-06-05`
+**Author:** `instar-codey`
+
+## Summary
+
+When a `gemini-cli` topic session has a pending Telegram injection, `SessionManager` now checks the captured pane for a completed Gemini assistant block and emits `injectionReplyDetected`. Server wiring sends that detected reply to the same Telegram topic.
+
+## Decision-point inventory
+
+- Gemini pane parser — added — pure helper in `paneText`, requiring a `✦` assistant block followed by Gemini's idle/input footer.
+- Pending-injection monitor — modified — Gemini-only branch after liveness is confirmed and before generic completion/timeout checks.
+- Telegram send wiring — added — listens for `injectionReplyDetected` and posts to the original topic.
+
+## Direction of failure
+
+- Old failure: Gemini completed work in-pane, but no Telegram reply was sent because Gemini did not execute the relay script.
+- New behavior: a completed Gemini final block is relayed once and clears the pending injection tracker.
+- Conservative failure direction: if the pane shape is ambiguous, lacks the matching `[telegram:N]` marker, or Gemini has not returned to the idle footer, no automatic relay happens.
+
+## Side-effects checklist
+
+1. **Over-block:** The implementation relays only; it does not reject inputs or user actions. The concrete false-negative tradeoff is conservative non-relay when Gemini's footer shape changes, when the matching Telegram marker has scrolled out of the 400-line capture, or when the final block uses a shape other than the `✦` assistant marker.
+2. **Under-block:** It can still miss very long Gemini answers where the original `[telegram:N]` marker is outside the captured tail, panes with a future Gemini TUI footer vocabulary, or answers that are complete but remain in an intermediate TUI state without the idle footer.
+3. **Level-of-abstraction fit:** The helper lives in `paneText` because it is pane-shape parsing, not Telegram delivery policy. `SessionManager` owns the pending-injection tracker and can decide when a framework-specific pane observation is eligible for relay. `server` remains the Telegram transport boundary.
+4. **Signal vs authority compliance:** The parser is a detector and does not hold blocking authority. It only produces a completed-reply signal after a pending Gemini Telegram injection exists; the server listener surfaces that signal to the original topic. This complies with `docs/signal-vs-authority.md` because the brittle regex/TUI detection never blocks a judgment path.
+5. **Interactions:** The branch is scoped to `framework === 'gemini-cli'` and a live pending injection, so Claude and Codex transcript/reply-script behavior is unchanged. The pending injection is cleared before emitting the event to avoid duplicate sends on subsequent monitor ticks.
+6. **External surfaces:** Telegram users can now receive a Gemini final pane answer that previously stayed visible only in tmux. The behavior depends on runtime pane text, the pending-injection map, and Gemini's idle footer, so the implementation is intentionally narrow and fail-closed.
+7. **Rollback cost:** Reverting the parser, the Gemini monitor branch, and the server listener restores the prior behavior without data migration or state repair.
+
+## Scope not taken
+
+- No Claude/Codex behavior changes.
+- No broad "scrape any final-looking text" behavior.
+- No stale Gemini quota telemetry work; that remains parked per operator instruction.
+- No task-boundary blending fix; recorded as observation only.
+
+## Rollback
+
+Revert the parser, the Gemini pending-injection branch, and the `injectionReplyDetected` server listener. Gemini returns to the previous behavior: visible pane output may remain silent unless the agent runs the reply script.


### PR DESCRIPTION
## Summary

- Added a Gemini-specific fallback that detects a completed final assistant block in the live pane for pending Telegram injections and relays it back to the originating topic.
- Scoped detection to `gemini-cli`, the matching `[telegram:N]` marker, and Gemini's idle/input footer so in-progress output is not relayed early.
- Hardened affected SessionManager tests so Claude-default assertions do not inherit the agent process `INSTAR_FRAMEWORK=codex-cli` environment.

## ELI16

Gemini can finish a Telegram task by printing the final answer in its terminal pane without running the Telegram reply script. That is exactly the bad user experience: the work is visible in the live pane, but Telegram stays silent.

This change gives the session monitor a Gemini-specific fallback. When a Gemini topic has an unanswered Telegram message, the monitor looks for Gemini's completed assistant block: a line beginning with `✦`, followed later by Gemini's normal input footer. Only then does it treat the block as the reply and send it to the Telegram topic.

The guard is intentionally narrow. It only runs for `gemini-cli` sessions with a pending Telegram injection, only considers text after the matching `[telegram:N]` prompt, and only fires after Gemini has returned to the input/footer state. Claude and Codex keep their existing reply-script and transcript paths.

Respawn-context note: after the server restart, the durable pieces survived: the Telegram history preserved the cycle id and repro, and the `gemini-final-output-relay` worktree survived cleanly. What had to be re-derived was the in-memory claim-check trail: which exact source files owned final relay, completion detection, and Gemini pane parsing.

## Validation

- `npx vitest run tests/unit/paneText.test.ts tests/unit/session-telegram-inject.test.ts`
- `npx vitest run tests/integration/topic-framework-dispatch.test.ts tests/unit/session-headless-continuity.test.ts tests/unit/session-manager-behavioral.test.ts tests/unit/session-resume.test.ts tests/unit/spawn-resume-fallback.test.ts`
- `npm run lint`
- `npm run build`
- `npm run check:upgrade-guide`
- `npm run check:contract-evidence`
- `npm run check:pre-push-gate`
- Pre-push hook: affected smoke `46 passed / 468 tests`; scoped Threadline e2e `17 passed / 332 tests`.

## Notes

The local `test:smoke` command initially skipped because its standalone base calculation saw no changed files. The actual pre-push hook resolved 14 changed files and ran the affected smoke and path-scoped e2e gates successfully.