### PR TITLE
fix(cutover-readiness): single-flight guard over live source fetch + budget-derived route timeouts

### DIFF
--- a/.instar/instar-dev-decisions/2026-06-05T14-15-38-219Z-parity-pass-inflight-guard.json
+++ b/.instar/instar-dev-decisions/2026-06-05T14-15-38-219Z-parity-pass-inflight-guard.json
@@ -1,0 +1,11 @@
+{
+  "ts": "2026-06-05T14:15:38.219Z",
+  "slug": "parity-pass-inflight-guard",
+  "suggestedTier": 2,
+  "declaredTier": 2,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 3,
+  "loc": 56
+}

--- a/src/feedback-factory/cutoverReadiness.ts
+++ b/src/feedback-factory/cutoverReadiness.ts
@@ -126,6 +126,17 @@ interface PersistedDryRunEnvelope {
 export class CutoverReadiness {
   private readonly d: CutoverReadinessDeps;
   private readonly maxStaleMs: number;
+  /**
+   * Single-flight guard over the LIVE SOURCE FETCH — shared by the parity pass
+   * and the import dry-run because both page the full live source. Without it,
+   * repeated triggers pile CONCURRENT full fetches onto the source: the route's
+   * response window can elapse while the handler keeps running (the always-logged
+   * outcome contract), so a caller that retries on a 408 spawns a new fetch next
+   * to the live one (observed live 2026-06-05 12:16Z — four concurrent passes
+   * against an already-degraded Portal). One live fetch at a time; a concurrent
+   * trigger is refused immediately (409 at the route) and records nothing.
+   */
+  private liveFetchInFlight: { op: 'parity-pass' | 'import-dry-run'; startedAt: string } | null = null;
 
   constructor(deps: CutoverReadinessDeps) {
     if (deps.importDryRunReportPath && path.resolve(deps.importDryRunReportPath) === path.resolve(deps.integrityReportPath)) {
@@ -196,11 +207,17 @@ export class CutoverReadiness {
     if (!this.d.runParityCheck) {
       return { ok: false, reason: 'no parity source configured (feedbackMigration.paritySource) — cannot run a live check' };
     }
+    if (this.liveFetchInFlight) {
+      return { ok: false, reason: `live source fetch already in flight (${this.liveFetchInFlight.op} started ${this.liveFetchInFlight.startedAt}) — one at a time; retry after it completes` };
+    }
+    this.liveFetchInFlight = { op: 'parity-pass', startedAt: new Date(this.nowMs()).toISOString() };
     let result: ParityResult;
     try {
       result = await this.d.runParityCheck();
     } catch (err) {
       return { ok: false, reason: `parity check failed: ${err instanceof Error ? err.message : String(err)}` };
+    } finally {
+      this.liveFetchInFlight = null;
     }
     const at = new Date(this.nowMs()).toISOString();
     this.d.parityMonitor.recordResult(result, at);
@@ -222,11 +239,17 @@ export class CutoverReadiness {
     if (!this.d.runImportDryRun || !this.d.importDryRunReportPath) {
       return { ok: false, reason: 'no import source configured (feedbackMigration.paritySource) — cannot run an import dry-run' };
     }
+    if (this.liveFetchInFlight) {
+      return { ok: false, reason: `live source fetch already in flight (${this.liveFetchInFlight.op} started ${this.liveFetchInFlight.startedAt}) — one at a time; retry after it completes` };
+    }
+    this.liveFetchInFlight = { op: 'import-dry-run', startedAt: new Date(this.nowMs()).toISOString() };
     let result: ImportRunResult;
     try {
       result = await this.d.runImportDryRun();
     } catch (err) {
       return { ok: false, reason: `import dry-run failed: ${err instanceof Error ? err.message : String(err)}` };
+    } finally {
+      this.liveFetchInFlight = null;
     }
     const generatedAt = new Date(this.nowMs()).toISOString();
     const envelope: PersistedDryRunEnvelope = { generatedAt, mode: 'dry-run', result };

--- a/src/server/AgentServer.ts
+++ b/src/server/AgentServer.ts
@@ -625,7 +625,13 @@ export class AgentServer {
     // tests/e2e/standards-conformance-gate-lifecycle.test.ts; the budget itself
     // is verified at the unit level (AgentServer-outbound-timeout.test.ts via the
     // extracted production map/matcher). A 150s/180s budget is not E2E-observable.
-    this.app.use(requestTimeout(options.config.requestTimeoutMs, buildRequestTimeoutOverrides()));
+    // The parity-pass/import-dryrun route budgets derive from the configured
+    // live-source TOTAL fetch budget (feedbackMigration.paritySource.totalTimeoutMs)
+    // so widening the source budget for a degraded source widens the response
+    // window with it — see buildRequestTimeoutOverrides() for the live incident.
+    const paritySourceTotalTimeoutMs = (options.config as { feedbackMigration?: { paritySource?: { totalTimeoutMs?: number } } })
+      .feedbackMigration?.paritySource?.totalTimeoutMs;
+    this.app.use(requestTimeout(options.config.requestTimeoutMs, buildRequestTimeoutOverrides({ paritySourceTotalTimeoutMs })));
 
     // ── Token Ledger ──────────────────────────────────────────────────
     // Read-only token-usage observability. Reads Claude Code's per-session

--- a/src/server/middleware.ts
+++ b/src/server/middleware.ts
@@ -376,12 +376,31 @@ export const SPEC_REVIEW_TIMEOUT_MS = 180_000;
 export const PARITY_PASS_TIMEOUT_MS = 360_000;
 
 /**
+ * Slack added on top of a configured parity-source TOTAL fetch budget when
+ * deriving the parity-pass/import-dryrun route budgets: the route does the full
+ * live fetch PLUS server-side compare/import work after it.
+ */
+export const PARITY_ROUTE_SLACK_MS = 60_000;
+
+/**
  * The production per-path request-timeout overrides. Exported as the single
  * source of truth so wiring-integrity tests assert against the SAME map the
  * server actually wires — never a hand-rolled copy that could pass while the
  * server is misconfigured (the PR-#334 dead-code lesson).
+ *
+ * `paritySourceTotalTimeoutMs` (config `feedbackMigration.paritySource.totalTimeoutMs`):
+ * when an operator widens the live-source fetch budget for a degraded source, the
+ * parity-pass/import-dryrun ROUTE budgets must widen with it — otherwise every
+ * trigger 408s at the constant while the handler keeps running, and a caller that
+ * retries on the 408 piles a concurrent fetch onto the degraded source (observed
+ * live 2026-06-05: 600s/page configured, 360s route → four concurrent passes).
+ * The constant stays the floor; the derived budget never shrinks below it.
  */
-export function buildRequestTimeoutOverrides(): Record<string, number> {
+export function buildRequestTimeoutOverrides(opts?: { paritySourceTotalTimeoutMs?: number }): Record<string, number> {
+  const configuredTotal = opts?.paritySourceTotalTimeoutMs;
+  const parityBudgetMs = typeof configuredTotal === 'number' && Number.isFinite(configuredTotal) && configuredTotal > 0
+    ? Math.max(PARITY_PASS_TIMEOUT_MS, configuredTotal + PARITY_ROUTE_SLACK_MS)
+    : PARITY_PASS_TIMEOUT_MS;
   return {
     '/telegram/reply': OUTBOUND_MESSAGING_TIMEOUT_MS,
     '/telegram/post-update': OUTBOUND_MESSAGING_TIMEOUT_MS,
@@ -390,10 +409,10 @@ export function buildRequestTimeoutOverrides(): Record<string, number> {
     '/imessage/reply': OUTBOUND_MESSAGING_TIMEOUT_MS,
     '/imessage/validate-send': OUTBOUND_MESSAGING_TIMEOUT_MS,
     '/spec/conformance-check': SPEC_REVIEW_TIMEOUT_MS,
-    '/cutover-readiness/parity-pass': PARITY_PASS_TIMEOUT_MS,
+    '/cutover-readiness/parity-pass': parityBudgetMs,
     // The import dry-run does the same full live source fetch as a parity pass
     // (plus an in-memory import + gate, which is fast) — same budget.
-    '/cutover-readiness/import-dryrun': PARITY_PASS_TIMEOUT_MS,
+    '/cutover-readiness/import-dryrun': parityBudgetMs,
   };
 }
 

--- a/tests/integration/cutover-readiness-routes.test.ts
+++ b/tests/integration/cutover-readiness-routes.test.ts
@@ -106,6 +106,35 @@ describe('Cutover-readiness routes (spec §7 G2.4)', () => {
     expect(monitor.passes.length).toBe(0);
   });
 
+
+  it('a CONCURRENT trigger is 409 \'already in flight\' over the full pipeline (one live fetch at a time)', async () => {
+    // The live 2026-06-05 incident shape: a slow degraded-source pass holds the
+    // handler past the client's patience; a second trigger must refuse instantly
+    // instead of piling another full fetch onto the source.
+    let release!: (v: ParityResult) => void;
+    parityCheck = () => new Promise<ParityResult>((res) => { release = res; });
+
+    const first = fetch(`${server.url}/cutover-readiness/parity-pass`, { method: 'POST' });
+    // Give the first request time to reach the handler and take the guard.
+    await new Promise((r) => setTimeout(r, 150));
+
+    const second = await fetch(`${server.url}/cutover-readiness/parity-pass`, { method: 'POST' });
+    expect(second.status).toBe(409);
+    const refusal = await second.json();
+    expect(refusal.error).toContain('already in flight');
+
+    // The guard is shared with the import dry-run (same live source).
+    const dryRun = await fetch(`${server.url}/cutover-readiness/import-dryrun`, { method: 'POST' });
+    expect(dryRun.status).toBe(409);
+    expect((await dryRun.json()).error).toContain('parity-pass');
+
+    release(CLEAN);
+    const firstRes = await first;
+    expect(firstRes.status).toBe(200);
+    expect((await firstRes.json()).recorded).toBe(true);
+    expect(monitor.passes.length).toBe(1); // exactly one pass recorded
+  });
+
   it('there is NO fire-cutover route (decision 1A is structural)', async () => {
     for (const p of ['/cutover-readiness/execute', '/cutover-readiness/fire', '/cutover-readiness/cutover']) {
       const res = await fetch(`${server.url}${p}`, { method: 'POST' });

--- a/tests/unit/AgentServer-outbound-timeout.test.ts
+++ b/tests/unit/AgentServer-outbound-timeout.test.ts
@@ -23,6 +23,8 @@ import {
   resolveRequestTimeout,
   OUTBOUND_MESSAGING_TIMEOUT_MS,
   SPEC_REVIEW_TIMEOUT_MS,
+  PARITY_PASS_TIMEOUT_MS,
+  PARITY_ROUTE_SLACK_MS,
 } from '../../src/server/middleware.js';
 import { CONFORMANCE_REVIEW_TIMEOUT_MS } from '../../src/core/reviewers/standards-conformance.js';
 
@@ -79,8 +81,54 @@ describe('request-timeout override map (production wiring)', () => {
       'utf-8',
     );
     // Regression guard: the global default is still passed as the first arg, and
-    // the overrides come from the shared builder (so this test's map == prod's).
-    expect(agentServerSrc).toMatch(/requestTimeout\(options\.config\.requestTimeoutMs,\s*buildRequestTimeoutOverrides\(\)\)/);
+    // the overrides come from the shared builder (so this test's map == prod's) —
+    // fed the configured parity-source total budget so the parity routes' windows
+    // track the operator's degraded-source tuning.
+    expect(agentServerSrc).toMatch(/requestTimeout\(options\.config\.requestTimeoutMs,\s*buildRequestTimeoutOverrides\(\{ paritySourceTotalTimeoutMs \}\)\)/);
+    expect(agentServerSrc).toMatch(/feedbackMigration\?\.paritySource\?\.totalTimeoutMs/);
+  });
+
+  describe('parity-pass/import-dryrun route budgets track the configured source budget', () => {
+    const parityRoutes = ['/cutover-readiness/parity-pass', '/cutover-readiness/import-dryrun'];
+
+    it('without config, both resolve to the constant floor', () => {
+      for (const route of parityRoutes) {
+        expect(resolveRequestTimeout(route, DEFAULT_MS, buildRequestTimeoutOverrides())).toBe(PARITY_PASS_TIMEOUT_MS);
+      }
+    });
+
+    it('a configured total budget ABOVE the floor widens the route window (total + slack) — the live 2026-06-05 mismatch', () => {
+      // Live incident: source budgets widened to 600s/page + 4200s total for a
+      // degraded Portal, but the route still 408'd at the 360s constant — every
+      // feeder retry piled a CONCURRENT full fetch onto the degraded source.
+      const totalMs = 4_200_000;
+      const o = buildRequestTimeoutOverrides({ paritySourceTotalTimeoutMs: totalMs });
+      for (const route of parityRoutes) {
+        expect(resolveRequestTimeout(route, DEFAULT_MS, o)).toBe(totalMs + PARITY_ROUTE_SLACK_MS);
+      }
+    });
+
+    it('a configured total budget BELOW the floor never shrinks the window', () => {
+      const o = buildRequestTimeoutOverrides({ paritySourceTotalTimeoutMs: 60_000 });
+      for (const route of parityRoutes) {
+        expect(resolveRequestTimeout(route, DEFAULT_MS, o)).toBe(PARITY_PASS_TIMEOUT_MS);
+      }
+    });
+
+    it('zero / non-finite configured totals fall back to the floor (no NaN windows)', () => {
+      for (const bogus of [0, Number.NaN, Number.POSITIVE_INFINITY, -5_000]) {
+        const o = buildRequestTimeoutOverrides({ paritySourceTotalTimeoutMs: bogus });
+        for (const route of parityRoutes) {
+          expect(resolveRequestTimeout(route, DEFAULT_MS, o)).toBe(PARITY_PASS_TIMEOUT_MS);
+        }
+      }
+    });
+
+    it('the derived budget never disturbs unrelated routes', () => {
+      const o = buildRequestTimeoutOverrides({ paritySourceTotalTimeoutMs: 4_200_000 });
+      expect(resolveRequestTimeout('/telegram/reply', DEFAULT_MS, o)).toBe(OUTBOUND_MESSAGING_TIMEOUT_MS);
+      expect(resolveRequestTimeout('/health', DEFAULT_MS, o)).toBe(DEFAULT_MS);
+    });
   });
 });
 

--- a/tests/unit/cutover-readiness.test.ts
+++ b/tests/unit/cutover-readiness.test.ts
@@ -253,4 +253,90 @@ describe('CutoverReadiness (spec §7 G2.4)', () => {
     fs.writeFileSync(path.join(dir, 'import-dryrun.json'), '{"generatedAt": "2026-');
     expect(r.importDryRunStatus()).toMatchObject({ ran: false, passed: false });
   });
+  // ── single-flight guard over the live source fetch ──
+
+  function deferred<T>() {
+    let resolve!: (v: T) => void;
+    let reject!: (e: unknown) => void;
+    const promise = new Promise<T>((res, rej) => { resolve = res; reject = rej; });
+    return { promise, resolve, reject };
+  }
+
+  function buildBoth(runParityCheck: () => Promise<ParityResult>, runImportDryRun: () => Promise<typeof PASSED_RUN>) {
+    return new CutoverReadiness({
+      parityMonitor: monitor,
+      integrityReportPath: path.join(dir, 'integrity-report.json'),
+      runParityCheck,
+      importDryRunReportPath: path.join(dir, 'import-dryrun.json'),
+      runImportDryRun,
+      now: () => nowMs,
+    });
+  }
+
+  it('a concurrent parity pass is REFUSED while one is in flight, and records nothing', async () => {
+    // The live 2026-06-05 incident: the route 408s while the handler keeps
+    // running, so a retrying feeder piled four CONCURRENT full fetches onto a
+    // degraded source. The guard makes the second trigger an immediate refusal.
+    const gate = deferred<ParityResult>();
+    const r = build(() => gate.promise);
+
+    const first = r.runParityPass();
+    const second = await r.runParityPass();
+    expect(second.ok).toBe(false);
+    expect((second as { ok: false; reason: string }).reason).toContain('already in flight');
+    expect((second as { ok: false; reason: string }).reason).toContain('parity-pass');
+    expect(monitor.passes.length).toBe(0); // the refusal recorded nothing
+
+    gate.resolve(CLEAN);
+    const firstOutcome = await first;
+    expect(firstOutcome.ok).toBe(true);
+    expect(monitor.passes.length).toBe(1); // only the real pass recorded
+  });
+
+  it('the guard RELEASES after a pass completes — the next trigger runs', async () => {
+    const r = build(async () => CLEAN);
+    expect((await r.runParityPass()).ok).toBe(true);
+    expect((await r.runParityPass()).ok).toBe(true);
+    expect(monitor.passes.length).toBe(2);
+  });
+
+  it('the guard RELEASES after a FAILED check too (no wedged refusals)', async () => {
+    let calls = 0;
+    const r = build(async () => { calls++; if (calls === 1) throw new Error('page 3 timed out'); return CLEAN; });
+    const failed = await r.runParityPass();
+    expect(failed.ok).toBe(false);
+    expect((failed as { ok: false; reason: string }).reason).toContain('page 3 timed out');
+    const next = await r.runParityPass();
+    expect(next.ok).toBe(true); // not 'already in flight'
+  });
+
+  it('the guard is SHARED across ops: a dry-run is refused while a parity pass is in flight (and names the holder)', async () => {
+    const gate = deferred<ParityResult>();
+    const r = buildBoth(() => gate.promise, async () => PASSED_RUN);
+
+    const parity = r.runParityPass();
+    const dryRun = await r.runImportDryRunPass();
+    expect(dryRun.ok).toBe(false);
+    expect((dryRun as { ok: false; reason: string }).reason).toContain('parity-pass');
+    expect(fs.existsSync(path.join(dir, 'import-dryrun.json'))).toBe(false); // refusal persisted nothing
+
+    gate.resolve(CLEAN);
+    await parity;
+    expect((await r.runImportDryRunPass()).ok).toBe(true); // released → dry-run runs
+  });
+
+  it('and symmetrically: a parity pass is refused while a dry-run is in flight', async () => {
+    const gate = deferred<typeof PASSED_RUN>();
+    const r = buildBoth(async () => CLEAN, () => gate.promise);
+
+    const dryRun = r.runImportDryRunPass();
+    const parity = await r.runParityPass();
+    expect(parity.ok).toBe(false);
+    expect((parity as { ok: false; reason: string }).reason).toContain('import-dry-run');
+    expect(monitor.passes.length).toBe(0);
+
+    gate.resolve(PASSED_RUN);
+    await dryRun;
+    expect((await r.runParityPass()).ok).toBe(true);
+  });
 });

--- a/upgrades/next/parity-pass-inflight-guard.md
+++ b/upgrades/next/parity-pass-inflight-guard.md
@@ -1,0 +1,38 @@
+<!-- bump: patch -->
+
+## What Changed
+
+The migration readiness checker's two "go check the live source" triggers (the
+parity pass and the import rehearsal) now enforce ONE live fetch at a time. A
+second trigger while one is running gets an immediate, clearly-worded refusal
+instead of silently starting another full download next to the first. And when
+an operator widens the fetch budgets for a slow source, the HTTP response
+window now widens with them instead of cutting out at a fixed 6 minutes.
+
+## Evidence
+
+Found live (2026-06-05): while feeding the migration parity window against a
+degraded source, a sequential caller turned into FOUR concurrent full fetches —
+each trigger's response died at the fixed route budget while its work kept
+running, so the caller retried, and every retry stacked another fetch onto the
+struggling source. Both halves are now under test: 10 new unit tests (guard
+refuses concurrent triggers, releases after success AND failure, is shared
+across both trigger types; route budgets derive from config, never below the
+old floor, bogus values fall back), plus a full-pipeline integration test
+proving the second concurrent POST gets a 409 and exactly one pass records.
+
+## What to Tell Your User
+
+Nothing user-visible changes by default. If your agent drives a data-migration
+readiness check against a slow source, its checks are now polite under
+pressure: one live check at a time, and patient response windows that match the
+budgets you configured.
+
+## Summary of New Capabilities
+
+- `POST /cutover-readiness/parity-pass` and `POST /cutover-readiness/import-dryrun`
+  refuse a concurrent trigger with 409 `live source fetch already in flight
+  (<op> started <time>)` — one live source fetch at a time, shared across both.
+- The two routes' response budgets track `feedbackMigration.paritySource.totalTimeoutMs`
+  (+60s slack) when configured; the previous 360s constant remains the floor.
+- Maturity: stable (behavioral hardening of existing routes; no new surface).

--- a/upgrades/side-effects/parity-pass-inflight-guard.md
+++ b/upgrades/side-effects/parity-pass-inflight-guard.md
@@ -1,0 +1,54 @@
+# Side-effects review — parity-pass single-flight guard + budget-derived route timeout
+
+Live incident (2026-06-05 ~12:16Z, while feeding the migration parity window
+against a degraded source): a sequential feeder fired 4 parity passes; every
+POST died at the route's constant 360s budget while its handler KEPT RUNNING
+(the always-logged-outcome contract from #807) — so 4 CONCURRENT full live
+fetches piled onto an already ~16×-degraded Portal read path, each slowing the
+others. Two distinct gaps, both closed here.
+
+## 1. The change
+
+- `CutoverReadiness`: a **single-flight guard over the live source fetch**,
+  shared by `runParityPass()` and `runImportDryRunPass()` (both page the full
+  live source). A concurrent trigger is refused IMMEDIATELY with
+  `live source fetch already in flight (<op> started <ISO>)` — surfaced as the
+  routes' existing 409-records-nothing contract. The guard is released in
+  `finally` (a failed check can never wedge future passes).
+- `buildRequestTimeoutOverrides()`: the parity-pass/import-dryrun route budgets
+  now **derive from the configured source budget**
+  (`feedbackMigration.paritySource.totalTimeoutMs` + 60s slack), never below
+  the existing 360s floor. Widening the source budgets for a degraded source
+  (the #820 knobs) now widens the response window with them — previously the
+  route 408'd at the constant regardless, which is what turned a sequential
+  caller into a concurrent pile-up.
+- `AgentServer`: passes the configured `totalTimeoutMs` into the builder
+  (single-source-of-truth map unchanged otherwise).
+
+## 2. Blast radius
+
+Small and behavioral-only at the two cutover-readiness trigger routes:
+- A concurrent trigger that previously started a hidden second fetch now gets
+  an immediate 409. No caller could ever OBSERVE two concurrent passes succeed
+  (the second response was always a 408), so no working flow breaks.
+- Route timeouts for the two routes grow ONLY when an operator has explicitly
+  widened `totalTimeoutMs` in config; with no config the constant floor holds,
+  so default installs see zero change. Unrelated routes unaffected (asserted).
+- No new config keys, no migrations, no durable-state shape changes, no new
+  routes. The refusal reason string is new (additive).
+
+## 3. Test coverage
+
+- Unit (5 new, cutover-readiness.test.ts → 20): concurrent parity pass refused
+  + records nothing; guard releases after success; guard releases after a
+  FAILED check (no wedge); guard shared dry-run↔parity in both directions,
+  refusal names the holding op and persists nothing.
+- Unit (5 new, AgentServer-outbound-timeout.test.ts → 20): derived budget =
+  total+slack for both routes (the live 4200s case); below-floor configs stay
+  at the floor; zero/NaN/Infinity/negative fall back to the floor; unrelated
+  routes undisturbed; AgentServer wiring regex updated to the config-fed call.
+- Integration (1 new, cutover-readiness-routes.test.ts → 10): full-pipeline
+  concurrency — slow in-flight pass, second POST 409 'already in flight',
+  cross-op dry-run 409 names 'parity-pass', release → first completes 200 with
+  exactly one recorded pass.
+- E2E: existing cutover-readiness lifecycle suite re-run green (no new routes).


### PR DESCRIPTION
## ELI16 — one checker run at a time, and the phone line stays open as long as the download is allowed to take

My migration checker downloads a big snapshot from the old system to compare against the new one. Two bugs teamed up during a real incident: (1) if you triggered a check while one was already running, it silently started a SECOND full download next to the first — and a third, and a fourth — each making the others slower and hammering the already-struggling old system. Now it just answers "busy — one at a time, retry when it's done." (2) We have a knob that says "this download may take up to 70 minutes" (for when the old system is slow), but the HTTP route answering the trigger still hung up at a fixed 6 minutes no matter what — so callers thought the check died and retried, which is exactly what created the pile-up. Now the route's patience grows with the knob. Nothing changes for anyone who never touched the knob.

## Live incident (2026-06-05 ~12:16Z)

While feeding the migration parity window against a ~16×-degraded Portal read path, a strictly **sequential** feeder turned into **4 concurrent full live fetches**: every `POST /cutover-readiness/parity-pass` died at the route's constant 360s budget while its handler kept running (the #807 always-logged-outcome contract), so each retry stacked another full snapshot fetch onto the struggling source. Two distinct gaps, both closed here.

## The fix

1. **Single-flight guard over the live source fetch** (`CutoverReadiness`), shared by `runParityPass()` and `runImportDryRunPass()` (both page the full live source). A concurrent trigger is refused immediately with `live source fetch already in flight (<op> started <ISO>)` — surfaced via the routes' existing 409-records-nothing contract. Released in `finally`, so a failed check can never wedge future passes.
2. **Budget-derived route timeouts** (`buildRequestTimeoutOverrides`): the parity-pass/import-dryrun route budgets now track `feedbackMigration.paritySource.totalTimeoutMs` (+60s slack), never below the existing 360s floor. Widening the #820 source budgets for a degraded source now widens the response window with them — previously the route 408'd at the constant regardless, which is exactly what turned a sequential caller into a concurrent pile-up.
3. **AgentServer** feeds the configured total into the builder (single-source-of-truth map otherwise unchanged).

## Blast radius

Behavioral-only at the two trigger routes. No caller could ever observe two concurrent passes succeed (the second response was always a 408), so no working flow breaks. Route windows grow ONLY when an operator explicitly widened `totalTimeoutMs`; default installs see zero change. No new config keys, routes, or durable-state shapes.

## Tests (11 new)

- **Unit** `cutover-readiness.test.ts` →20: concurrent pass refused + records nothing; guard releases after success AND after a failed check; shared dry-run↔parity both directions (refusal names the holding op).
- **Unit** `AgentServer-outbound-timeout.test.ts` →20: derived budget = total+slack for both routes (the live 4200s case); below-floor stays at floor; 0/NaN/Infinity/negative → floor; unrelated routes undisturbed; AgentServer wiring regex updated to the config-fed call.
- **Integration** `cutover-readiness-routes.test.ts` →10: full pipeline — slow in-flight pass, second POST 409 'already in flight', cross-op dry-run 409 names 'parity-pass', release → first completes 200 with exactly one recorded pass.
- **E2E**: existing cutover-readiness lifecycle suite green (no new routes).

Gate artifacts: `upgrades/side-effects/parity-pass-inflight-guard.md`, `upgrades/next/parity-pass-inflight-guard.md` (bump: patch, maturity: stable).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
