### PR TITLE
fix(registry): pid-guarded unregister + self-resurrecting heartbeat (lost-update race)

### DIFF
--- a/.instar/instar-dev-decisions/2026-06-05T14-12-17-561Z-registry-guarded-unregister.json
+++ b/.instar/instar-dev-decisions/2026-06-05T14-12-17-561Z-registry-guarded-unregister.json
@@ -1,0 +1,11 @@
+{
+  "ts": "2026-06-05T14:12:17.561Z",
+  "slug": "registry-guarded-unregister",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 3,
+  "loc": 95
+}

--- a/src/commands/server.ts
+++ b/src/commands/server.ts
@@ -2430,7 +2430,13 @@ export async function startServer(options: StartOptions): Promise<void> {
     // detector still runs and falls back to the JSONL append.
     let stopHeartbeat: (() => void) | undefined;
     try {
-      stopHeartbeat = startHeartbeat(config.projectDir);
+      // The reRegister callback closes the registry lost-update race: if an
+      // old server generation's shutdown deleted our fresh registration
+      // (back-to-back update restarts), the next heartbeat notices the
+      // missing entry and resurrects it instead of silently no-oping forever.
+      stopHeartbeat = startHeartbeat(config.projectDir, undefined, () => {
+        registerAgent(config.projectDir, config.projectName, config.port);
+      });
     } catch (err) {
       // Registry heartbeat is non-critical — server should run without it.
       // ELOCKED errors from concurrent agent startups are transient.
@@ -10820,7 +10826,11 @@ export async function startServer(options: StartOptions): Promise<void> {
       wakeSocketServer?.stop();
       pipeSpawner?.killAll();
       try { stopHeartbeat?.(); } catch { /* non-critical during shutdown */ }
-      try { unregisterAgent(config.projectDir); } catch { /* ELOCKED is non-critical during shutdown */ }
+      // pid-guarded: only remove OUR OWN registration. An unguarded
+      // unregister-by-path here deletes the successor generation's fresh
+      // entry during back-to-back update restarts (registry lost-update
+      // race) — the agent then vanishes from the registry until restart.
+      try { unregisterAgent(config.projectDir, { onlyIfPid: process.pid }); } catch { /* ELOCKED is non-critical during shutdown */ }
       scheduler?.stop();
       if (telegram) await telegram.stop();
       sessionManager.stopMonitoring();

--- a/src/core/AgentRegistry.ts
+++ b/src/core/AgentRegistry.ts
@@ -402,11 +402,26 @@ export function registerAgent(
 
 /**
  * Unregister an agent by its canonical path.
+ *
+ * `opts.onlyIfPid` guards the removal: the entry is only removed when its
+ * recorded pid matches. Server shutdown MUST pass its own pid — otherwise an
+ * old server generation's late shutdown (auto-update restart) deletes the
+ * successor's fresh registration by path, and the agent silently vanishes
+ * from the registry (the registry lost-update race). An entry whose pid is
+ * missing or different is presumed to belong to the successor and is left
+ * intact. Operator/CLI removal (no opts) still removes unconditionally.
  */
-export function unregisterAgent(agentPath: string): void {
+export function unregisterAgent(agentPath: string, opts?: { onlyIfPid?: number }): void {
   const canonicalPath = path.resolve(agentPath);
   withLockSync(registry => {
-    registry.entries = registry.entries.filter(e => e.path !== canonicalPath);
+    registry.entries = registry.entries.filter(e => {
+      if (e.path !== canonicalPath) return true;
+      if (opts?.onlyIfPid !== undefined && e.pid !== opts.onlyIfPid) {
+        console.log(`[AgentRegistry] Skipped unregister of ${canonicalPath}: entry pid ${e.pid} != caller pid ${opts.onlyIfPid} (entry belongs to a newer generation)`);
+        return true;
+      }
+      return false;
+    });
   });
 }
 
@@ -427,15 +442,22 @@ export function updateStatus(agentPath: string, status: AgentStatus, pid?: numbe
 
 /**
  * Update the heartbeat for an agent by canonical path.
+ *
+ * Returns whether the entry was found. A `false` return means the entry has
+ * vanished (e.g. an old generation's shutdown raced the registration away) —
+ * callers that own a live server should re-register rather than silently
+ * no-op forever.
  */
-export function heartbeat(agentPath: string): void {
+export function heartbeat(agentPath: string): boolean {
   const canonicalPath = path.resolve(agentPath);
-  withLockSync(registry => {
+  return withLockSync(registry => {
     const entry = registry.entries.find(e => e.path === canonicalPath);
     if (entry) {
       entry.lastHeartbeat = new Date().toISOString();
       entry.pid = process.pid;
+      return true;
     }
+    return false;
   });
 }
 
@@ -462,15 +484,42 @@ export function forceRemoveRegistryLock(): boolean {
  * Start a periodic heartbeat. Returns a cleanup function.
  * Tracks consecutive failures and force-removes the registry lock after
  * repeated failures — recovers from crash-induced stale locks.
+ *
+ * `reRegister` (optional) is invoked when a heartbeat finds the entry MISSING
+ * — i.e. something deleted this agent's registration while its server is
+ * still alive (the classic case: an old generation's pid-unguarded shutdown
+ * unregister racing a back-to-back update restart). The callback should
+ * re-create the registration (e.g. `() => registerAgent(...)`); the next
+ * heartbeat then confirms it. Without the callback the missing entry is only
+ * logged — preserving the old behavior for callers that don't own a server.
  */
-export function startHeartbeat(agentPath: string, intervalMs: number = 60_000): () => void {
+export function startHeartbeat(
+  agentPath: string,
+  intervalMs: number = 60_000,
+  reRegister?: () => void,
+): () => void {
   const canonicalPath = path.resolve(agentPath);
   let consecutiveFailures = 0;
   const MAX_FAILURES_BEFORE_RECOVERY = 3;
 
+  const beatOnce = (): void => {
+    const found = heartbeat(canonicalPath);
+    if (!found) {
+      console.warn(`[AgentRegistry] Heartbeat found no entry for ${canonicalPath} — registration was removed while this server is alive`);
+      if (reRegister) {
+        try {
+          reRegister();
+          console.log(`[AgentRegistry] Re-registered ${canonicalPath} after missing-entry heartbeat`);
+        } catch (reErr) {
+          console.error(`[AgentRegistry] Re-registration failed for ${canonicalPath}: ${reErr}`);
+        }
+      }
+    }
+  };
+
   const interval = setInterval(() => {
     try {
-      heartbeat(canonicalPath);
+      beatOnce();
       consecutiveFailures = 0;
     } catch (err) {
       consecutiveFailures++;
@@ -490,8 +539,8 @@ export function startHeartbeat(agentPath: string, intervalMs: number = 60_000): 
     }
   }, intervalMs);
 
-  // Initial heartbeat
-  try { heartbeat(canonicalPath); } catch { /* ignore */ }
+  // Initial heartbeat (also resurrects immediately if the entry is missing)
+  try { beatOnce(); } catch { /* ignore */ }
 
   return () => clearInterval(interval);
 }

--- a/src/lifeline/TelegramLifeline.ts
+++ b/src/lifeline/TelegramLifeline.ts
@@ -416,7 +416,16 @@ export class TelegramLifeline {
       );
     } catch { /* non-critical */ }
     try {
-      this.stopHeartbeat = startHeartbeat(this.projectConfig.projectDir + '-lifeline');
+      // reRegister callback: if an old lifeline generation's shutdown deleted
+      // this generation's registration (coordinated version-skew restart,
+      // drift auto-promote), the next heartbeat resurrects the entry.
+      this.stopHeartbeat = startHeartbeat(this.projectConfig.projectDir + '-lifeline', undefined, () => {
+        registerAgent(
+          this.projectConfig.projectDir + '-lifeline',
+          `${this.projectConfig.projectName}-lifeline`,
+          this.projectConfig.port + 1000,
+        );
+      });
     } catch (err) {
       console.error(`[Lifeline] Registry heartbeat failed to start (non-critical): ${err instanceof Error ? err.message : err}`);
     }
@@ -583,7 +592,10 @@ export class TelegramLifeline {
     if (this.sessionRecoveryInterval) { clearInterval(this.sessionRecoveryInterval); this.sessionRecoveryInterval = null; }
     if (this.watchdog) this.watchdog.stop();
     try { if (this.stopHeartbeat) this.stopHeartbeat(); } catch { /* non-critical */ }
-    try { unregisterAgent(this.projectConfig.projectDir + '-lifeline'); } catch { /* non-critical */ }
+    // pid-guarded: only remove our OWN registration — an old lifeline
+    // generation's late shutdown must not delete the successor's fresh entry
+    // (registry lost-update race; same shape as the server-side fix).
+    try { unregisterAgent(this.projectConfig.projectDir + '-lifeline', { onlyIfPid: process.pid }); } catch { /* non-critical */ }
     try { releaseLockFile(this.lockPath); } catch { /* non-critical */ }
     try { await this.supervisor.stop(); } catch { /* best-effort */ }
   }

--- a/tests/unit/agent-registry.test.ts
+++ b/tests/unit/agent-registry.test.ts
@@ -502,4 +502,108 @@ describe('AgentRegistry', () => {
       expect(port).toBeGreaterThan(4045);
     });
   });
+
+  // ── Registry lost-update race (2026-06-05 incident) ─────────────────
+  // Back-to-back update restarts: the OLD server generation's shutdown ran
+  // `unregisterAgent(projectDir)` AFTER the successor had re-registered —
+  // removal-by-path deleted the successor's fresh entry, the agent vanished
+  // from the registry (live trace: "Registered agent \"echo\"" logged at
+  // 13:11 AND 13:18, entry absent at 13:21+), and heartbeat() silently
+  // no-oped on the missing entry forever. Fix: pid-guarded unregister +
+  // self-resurrecting heartbeat.
+  describe('registry lost-update race (pid-guarded unregister + resurrecting heartbeat)', () => {
+    it('pid-guarded unregister does NOT delete a successor generation\'s entry', async () => {
+      const { registerAgent, unregisterAgent, getAgent } = await getRegistry();
+      // Successor generation registers (pid 200)…
+      registerAgent('/tmp/race-project', 'race-agent', 4060, 'project-bound', 200);
+      // …then the OLD generation's late shutdown fires its pid-guarded
+      // unregister (its own pid was 100).
+      unregisterAgent('/tmp/race-project', { onlyIfPid: 100 });
+      const agent = getAgent('/tmp/race-project');
+      expect(agent).not.toBeNull();
+      expect(agent!.pid).toBe(200);
+    });
+
+    it('pid-guarded unregister removes the entry when the pid matches (normal shutdown)', async () => {
+      const { registerAgent, unregisterAgent, getAgent } = await getRegistry();
+      registerAgent('/tmp/race-project', 'race-agent', 4060, 'project-bound', 100);
+      unregisterAgent('/tmp/race-project', { onlyIfPid: 100 });
+      expect(getAgent('/tmp/race-project')).toBeNull();
+    });
+
+    it('unguarded unregister still removes regardless of pid (operator/CLI back-compat)', async () => {
+      const { registerAgent, unregisterAgent, getAgent } = await getRegistry();
+      registerAgent('/tmp/race-project', 'race-agent', 4060, 'project-bound', 12345);
+      unregisterAgent('/tmp/race-project');
+      expect(getAgent('/tmp/race-project')).toBeNull();
+    });
+
+    it('heartbeat returns true when the entry exists and false when it is missing', async () => {
+      const { registerAgent, heartbeat } = await getRegistry();
+      registerAgent('/tmp/hb-project', 'hb-agent', 4061, 'project-bound', process.pid);
+      expect(heartbeat('/tmp/hb-project')).toBe(true);
+      expect(heartbeat('/tmp/never-registered')).toBe(false);
+    });
+
+    it('startHeartbeat resurrects a deleted entry via the reRegister callback', async () => {
+      const { registerAgent, unregisterAgent, startHeartbeat, getAgent } = await getRegistry();
+      registerAgent('/tmp/resurrect-project', 'resurrect-agent', 4062, 'project-bound', process.pid);
+      // Simulate the race outcome: something deleted our registration while
+      // the server is still alive.
+      unregisterAgent('/tmp/resurrect-project');
+      expect(getAgent('/tmp/resurrect-project')).toBeNull();
+
+      // startHeartbeat's INITIAL beat finds the entry missing → reRegister.
+      const stop = startHeartbeat('/tmp/resurrect-project', 60_000, () => {
+        registerAgent('/tmp/resurrect-project', 'resurrect-agent', 4062, 'project-bound', process.pid);
+      });
+      try {
+        const agent = getAgent('/tmp/resurrect-project');
+        expect(agent).not.toBeNull();
+        expect(agent!.name).toBe('resurrect-agent');
+      } finally {
+        stop();
+      }
+    });
+
+    it('startHeartbeat without a reRegister callback leaves a missing entry missing (old behavior)', async () => {
+      const { startHeartbeat, getAgent } = await getRegistry();
+      const stop = startHeartbeat('/tmp/no-callback-project', 60_000);
+      try {
+        expect(getAgent('/tmp/no-callback-project')).toBeNull();
+      } finally {
+        stop();
+      }
+    });
+
+    it('a reRegister callback that throws is contained (heartbeat loop survives)', async () => {
+      const { startHeartbeat, getAgent } = await getRegistry();
+      const stop = startHeartbeat('/tmp/throwing-cb-project', 60_000, () => {
+        throw new Error('port conflict');
+      });
+      try {
+        // No crash, entry simply stays missing until a later beat succeeds.
+        expect(getAgent('/tmp/throwing-cb-project')).toBeNull();
+      } finally {
+        stop();
+      }
+    });
+
+    it('full race shape: register(old) → register(successor) → old pid-guarded shutdown → successor survives and heartbeats', async () => {
+      const { registerAgent, unregisterAgent, heartbeat, getAgent } = await getRegistry();
+      const OLD_PID = 1111;
+      const NEW_PID = 2222;
+      // Old generation running…
+      registerAgent('/tmp/full-race', 'full-race-agent', 4063, 'project-bound', OLD_PID);
+      // …update restart: successor registers (upsert by path — pid moves to successor)…
+      registerAgent('/tmp/full-race', 'full-race-agent', 4063, 'project-bound', NEW_PID);
+      // …old generation's late shutdown fires its guarded unregister.
+      unregisterAgent('/tmp/full-race', { onlyIfPid: OLD_PID });
+      // Successor's registration survives and its heartbeat finds it.
+      const agent = getAgent('/tmp/full-race');
+      expect(agent).not.toBeNull();
+      expect(agent!.pid).toBe(NEW_PID);
+      expect(heartbeat('/tmp/full-race')).toBe(true);
+    });
+  });
 });

--- a/upgrades/next/registry-guarded-unregister.md
+++ b/upgrades/next/registry-guarded-unregister.md
@@ -1,0 +1,20 @@
+---
+bump: patch
+---
+
+## What Changed
+
+Fixed the shared agent-registry lost-update race: during back-to-back update restarts, an old server generation's late shutdown removed the registry entry by path and deleted the successor's fresh registration, and the heartbeat silently no-oped on the missing entry forever. Server and lifeline shutdowns now pass their own pid and the registry only removes a matching-pid entry; the periodic heartbeat reports a missing entry and re-registers it via a callback. Operator/CLI removal stays unconditional.
+
+## What to Tell Your User
+
+Nothing user-visible day to day — this closes a race where an agent could silently vanish from the machine-wide agent registry after an update restart, which then made registry-dependent tooling (like worktree creation) refuse the agent until the next full restart. Agents now stay registered across rapid restarts, and if a registration is ever lost they re-add themselves within a minute.
+
+## Summary of New Capabilities
+
+- unregisterAgent accepts an onlyIfPid guard; server and lifeline shutdown only remove their own generation's entry.
+- heartbeat returns whether the entry was found; startHeartbeat accepts a reRegister callback that resurrects a missing registration (initial beat included).
+
+## Evidence
+
+Live trace (2026-06-05, echo): server log showed "Registered agent \"echo\" on port 4042" at 13:11 AND 13:18 (two restart generations), registry.json had no echo entry at 13:21+ while echo-lifeline remained — and `instar worktree create` refused the agent home with "agent echo is not present in the instar registry". Root: src/commands/server.ts shutdown called unregisterAgent(config.projectDir) unconditionally (removal by path), and AgentRegistry.heartbeat() was an if-found no-op. Pinned by 7 new race-shape unit tests in tests/unit/agent-registry.test.ts (guarded skip vs matching-pid removal vs unguarded back-compat, heartbeat found-flag both sides, resurrect via callback, throwing-callback containment, full register-old/register-new/old-shutdown sequence).

--- a/upgrades/registry-guarded-unregister.eli16.md
+++ b/upgrades/registry-guarded-unregister.eli16.md
@@ -1,0 +1,13 @@
+# An old server's shutdown can no longer erase its successor from the registry
+
+All agents on a machine share one phone book: `~/.instar/registry.json`. Every server writes itself in at startup and crosses itself out at shutdown. The bug: shutdown crossed out the entry **by address** (the agent's directory path), not by **who wrote it**. During back-to-back update restarts, the new server writes its fresh entry, and then the *old* server's late shutdown fires — and crosses out the new entry, because the address matches. The agent vanishes from the phone book even though its server is alive and healthy.
+
+The vanished entry then stays vanished, because the once-a-minute heartbeat used "find my entry and bump its timestamp" with a silent shrug when the entry was missing. Nothing ever put the entry back. Live trace: echo's log showed "Registered agent" twice in eight minutes (two restart generations), and minutes later the registry had no echo entry at all — which is why `instar worktree create` started refusing the agent home with "agent echo is not present in the instar registry".
+
+The fix is two halves of the same idea — only the owner may erase, and the owner can rewrite:
+
+1. **Pid-guarded unregister.** Server and lifeline shutdown now pass their own process id, and the registry only removes the entry if the recorded pid matches. An old generation's late shutdown sees the successor's pid in the entry, logs that it skipped, and leaves it alone. Operator/CLI removal (instar nuke) keeps the unconditional behavior — a human cleaning up should always win.
+
+2. **Self-resurrecting heartbeat.** The heartbeat now reports whether it found the entry. When the entry is missing and the caller owns a live server, a re-register callback recreates it on the spot (logged loudly, including on the immediate first beat). So even if some *other* writer erases the entry in the future, the agent reappears within one heartbeat interval instead of being durably gone.
+
+Both the server's own registration and the lifeline's `-lifeline` entry get the same treatment, because the lifeline restarts on version skew and drift-promote — the identical race shape.

--- a/upgrades/side-effects/registry-guarded-unregister.md
+++ b/upgrades/side-effects/registry-guarded-unregister.md
@@ -1,0 +1,46 @@
+# Side-Effects Review — Registry lost-update race fix (pid-guarded unregister + resurrecting heartbeat)
+
+**Version / slug:** `registry-guarded-unregister`
+**Date:** `2026-06-05`
+**Author:** `instar-echo`
+
+## Summary
+
+`unregisterAgent` gains an `onlyIfPid` guard; server and lifeline shutdowns pass their own pid so an old generation's late shutdown can no longer delete the successor's fresh registry entry. `heartbeat` now returns whether the entry was found, and `startHeartbeat` accepts a `reRegister` callback that recreates a missing registration (invoked on the initial beat and on every interval tick that finds the entry gone).
+
+## Decision-point inventory
+
+- `AgentRegistry.unregisterAgent` — modified — optional pid guard; removal only on matching `entry.pid` when `onlyIfPid` is given; skip is logged. No-opts call unchanged.
+- `AgentRegistry.heartbeat` — modified — return type `void` → `boolean` (found-flag). All existing callers ignore the return; no behavior change for them.
+- `AgentRegistry.startHeartbeat` — modified — new optional `reRegister` param; missing-entry beats log a warning and invoke the callback inside its own try/catch.
+- `server.ts` shutdown — modified — passes `{ onlyIfPid: process.pid }`.
+- `server.ts` heartbeat wiring — modified — passes a reRegister callback that re-runs `registerAgent(projectDir, projectName, port)`.
+- `TelegramLifeline` register/unregister — modified — same two changes for the `-lifeline` entry (lifeline restarts on version skew / drift-promote: identical race shape).
+- `nuke.ts` (operator removal) — untouched — unconditional removal preserved deliberately.
+
+## Direction of failure
+
+- Old failure: silent durable deregistration — agent vanishes from the registry while alive; registry-dependent tooling (worktree CLI agent-home resolution, discovery) refuses the agent until the next full restart.
+- New behavior: a guarded shutdown skips a non-matching entry (logged); a missing entry is resurrected within one heartbeat interval (60s default) or immediately at heartbeat start.
+- Conservative failure direction: when in doubt the entry is KEPT — a pid-guarded removal that cannot confirm ownership leaves the entry; `cleanStaleEntries` (dead-pid detection + 1h heartbeat expiry) remains the garbage collector for genuinely dead entries, so a kept-but-dead entry is bounded, not permanent.
+
+## Side-effects checklist
+
+1. **Over-block (entry kept when it should be removed):** a guarded shutdown whose own registration was somehow rewritten with a different pid (e.g. a concurrent re-register) leaves the entry behind. Bounded: the entry's pid is then dead, so `cleanStaleEntries` marks it stale on the next registry read and expires it. No permanent zombie.
+2. **Under-block (entry removed when it should be kept):** unguarded callers (CLI `nuke`, `unregisterPort` by name) still remove unconditionally — intentional operator semantics. The guarded path cannot remove a successor's entry by construction.
+3. **Level-of-abstraction fit:** the guard lives in `AgentRegistry` (the single registry mutation funnel), not in callers — every future shutdown path gets the same primitive. Callers only declare WHO they are (their pid); the registry decides.
+4. **Signal vs authority compliance:** no LLM involvement; pure structural fix. The resurrect log lines are signals for the operator; nothing blocks.
+5. **Interactions:** the reRegister callback calls `registerAgent`, which port-conflict-checks against RUNNING entries — if another live agent legitimately claimed the port meanwhile, re-registration throws and is contained (logged, retried next beat). Heartbeat lock-failure recovery (3-strikes force-unlock) is unchanged; missing-entry is handled separately from lock errors and does NOT count toward failure strikes.
+6. **External surfaces:** registry.json consumers (worktree CLI, `instar status`, discovery) see strictly more-accurate state. No API/route changes.
+7. **Rollback cost:** revert the commit; no data migration. Registry files written by the new code are schema-identical.
+
+## Scope not taken
+
+- No change to `cleanStaleEntries` semantics (dead-pid/1h-expiry pruning untouched).
+- No lock-protocol changes (proper-lockfile usage unchanged).
+- No registry watching/inotify — resurrect is heartbeat-cadence (60s), which matches the observed failure window.
+- No fix for the `startHeartbeatByName` path (no live consumers register through it with a server lifecycle; can adopt the callback later if one appears).
+
+## Rollback
+
+Revert the single commit. Behavior returns to unconditional unregister + silent heartbeat no-op.


### PR DESCRIPTION
## ELI16

All agents on a machine share one phone book: `~/.instar/registry.json`. Every server writes itself in at startup and crosses itself out at shutdown. The bug: shutdown crossed out the entry **by address** (the agent's directory path), not by **who wrote it**. During back-to-back update restarts, the new server writes its fresh entry — then the *old* server's late shutdown fires and crosses out the new entry, because the address matches. The agent vanishes from the phone book while alive. And it stays vanished: the heartbeat was "find my entry and bump its timestamp" with a silent shrug when missing.

**Live trace (2026-06-05, echo):** "Registered agent \"echo\" on port 4042" logged at 13:11 AND 13:18 (two restart generations); registry had no echo entry at 13:21+ while `echo-lifeline` remained. Downstream symptom: `instar worktree create` refused the agent home with *"agent echo is not present in the instar registry"* (task #84).

## The fix (both halves in the AgentRegistry funnel)

1. **Pid-guarded unregister** — `unregisterAgent(path, { onlyIfPid })`: removal only when the entry's recorded pid matches. Server + lifeline shutdowns pass their own pid; an old generation's late shutdown sees the successor's pid, logs the skip, leaves it alone. Operator/CLI removal (`nuke`) stays unconditional.
2. **Self-resurrecting heartbeat** — `heartbeat()` returns a found-flag; `startHeartbeat(path, ms, reRegister?)` invokes the callback when the entry is missing (initial beat included, throwing callback contained, handled separately from lock-failure strikes). Even a future unknown deleter is now bounded to one heartbeat interval, not permanent.

The lifeline's `-lifeline` entry gets the identical treatment (it restarts on version skew / drift-promote — same race shape).

## Conservative failure direction

When ownership can't be confirmed, the entry is KEPT — `cleanStaleEntries` (dead-pid + 1h expiry) remains the GC for genuinely dead entries, so a kept-but-dead entry is bounded, never a permanent zombie.

## Tests

7 new race-shape unit tests in `tests/unit/agent-registry.test.ts`: guarded skip vs matching-pid removal vs unguarded back-compat, heartbeat found-flag both sides, resurrect via callback, throwing-callback containment, and the full two-generation register/register/late-shutdown sequence. 42/42 green; tsc + lint clean; Tier-1 gate passed (eli16 + side-effects + fragment + per-entry decision audit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)