### PR TITLE
fix(test-debt): re-arm security + delivery-completeness gates; fix what rotted under them

### DIFF
--- a/.instar/instar-dev-decisions/2026-06-05T14-27-54-797Z-test-debt-rearm.json
+++ b/.instar/instar-dev-decisions/2026-06-05T14-27-54-797Z-test-debt-rearm.json
@@ -1,0 +1,15 @@
+{
+  "ts": "2026-06-05T14:27:54.797Z",
+  "slug": "test-debt-rearm",
+  "suggestedTier": 2,
+  "declaredTier": 2,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "safety-invariant proximity: src/monitoring/mcpProcessReaperDeps.ts matches session reaper",
+    "irreversibility: src/core/PostUpdateMigrator.ts touches PostUpdateMigrator",
+    "migration / fleet-rollout surface: src/core/PostUpdateMigrator.ts touches PostUpdateMigrator (fleet migration machinery)"
+  ],
+  "belowFloor": false,
+  "files": 2,
+  "loc": 30
+}

--- a/src/core/PostUpdateMigrator.ts
+++ b/src/core/PostUpdateMigrator.ts
@@ -4382,6 +4382,14 @@ Create worktrees for collaborator repos with \`instar worktree create <branch>\`
       '**Multi-Session Autonomy**',
       '**Process Health (Dashboard Tab)**',
       "**Preferences I've learned about you**",
+      // Coordination-mandate family (coordination-mandate spec §7, G2.2–G2.4):
+      // framework-agnostic HTTP capabilities any mandate-named agent must know.
+      // A Codex/Gemini agent under a future mandate that never learns
+      // /mandate/evaluate will improvise around the gate (the Secret Drop
+      // lesson) — mirrored to the shadows like every agent-facing capability.
+      '**Coordination Mandate**',
+      '**ReviewExchange (autonomous code review)**',
+      '**Cutover Readiness**',
     ];
 
     for (const shadowName of ['AGENTS.md', 'GEMINI.md']) {

--- a/src/monitoring/mcpProcessReaperDeps.ts
+++ b/src/monitoring/mcpProcessReaperDeps.ts
@@ -6,7 +6,7 @@
  * SessionManager/kill/audit implementations.
  */
 
-import { execSync } from 'node:child_process';
+import { execFileSync } from 'node:child_process';
 import fs from 'node:fs';
 import path from 'node:path';
 import {
@@ -19,9 +19,14 @@ import type {
   McpReapAuditEntry,
 } from './McpProcessReaper.js';
 
-function shellExec(cmd: string, timeout = 8000): string {
+// execFileSync (argv array, no shell) instead of execSync: the previous
+// `ps | egrep | grep -v` shell pipeline tripped the no-execSync security gate
+// (tests/unit/security.test.ts) — the coarse egrep pre-filter now runs in JS
+// below, where matchMcpSignature was already doing the precise second-stage
+// match anyway. No shell, no interpolation surface.
+function fileExec(file: string, args: string[], timeout = 8000): string {
   try {
-    return execSync(cmd, { encoding: 'utf8', timeout, stdio: ['ignore', 'pipe', 'ignore'] });
+    return execFileSync(file, args, { encoding: 'utf8', timeout, stdio: ['ignore', 'pipe', 'ignore'] });
   } catch {
     return '';
   }
@@ -61,12 +66,13 @@ export function makeMcpProcessReaperDeps(opts: {
   return {
     listMcpProcesses(): McpProcessInfo[] {
       const uid = process.getuid?.() ?? 0;
-      const out = shellExec(
-        `ps -u ${uid} -o pid=,ppid=,etime=,command= 2>/dev/null | egrep -i '${mcpGrepAlternation()}' | grep -v egrep`,
-      ).trim();
+      const out = fileExec('ps', ['-u', String(uid), '-o', 'pid=,ppid=,etime=,command=']).trim();
       if (!out) return [];
+      // Coarse pre-filter (the old egrep stage), now in JS over the ps output.
+      const coarse = new RegExp(mcpGrepAlternation(), 'i');
       const procs: McpProcessInfo[] = [];
       for (const line of out.split('\n')) {
+        if (!coarse.test(line)) continue;
         const m = line.trim().match(/^(\d+)\s+(\d+)\s+([\d:.-]+)\s+(.+)$/);
         if (!m) continue;
         const command = m[4];
@@ -85,7 +91,7 @@ export function makeMcpProcessReaperDeps(opts: {
 
     getProcessTree(): Map<number, number> {
       const tree = new Map<number, number>();
-      const out = shellExec(`ps -axo pid=,ppid= 2>/dev/null`).trim();
+      const out = fileExec('ps', ['-axo', 'pid=,ppid=']).trim();
       if (!out) return tree;
       for (const line of out.split('\n')) {
         const m = line.trim().match(/^(\d+)\s+(\d+)$/);
@@ -96,7 +102,7 @@ export function makeMcpProcessReaperDeps(opts: {
 
     getTmuxPaneMap(): Map<number, string> {
       const map = new Map<number, string>();
-      const out = shellExec(`${tmuxPath} list-panes -a -F "#{session_name}||#{pane_pid}" 2>/dev/null`).trim();
+      const out = fileExec(tmuxPath, ['list-panes', '-a', '-F', '#{session_name}||#{pane_pid}']).trim();
       if (!out) return map;
       for (const line of out.split('\n')) {
         const [session, pidStr] = line.split('||');

--- a/tests/unit/feature-delivery-completeness.test.ts
+++ b/tests/unit/feature-delivery-completeness.test.ts
@@ -135,6 +135,13 @@ describe('Feature Delivery Completeness', () => {
       'Multi-Session Autonomy',    // per-topic concurrent autonomous jobs (templates.ts + migrator parity)
       'Process Health (Dashboard Tab)', // Failure-Learning Loop read surface (templates.ts + migrator + shadow-marker parity)
       "Preferences I've learned about you", // Correction & Preference Learning Sentinel Slice 1a read surface (templates.ts + migrator + shadow-marker parity)
+      // Coordination-mandate family (coordination-mandate spec §7, G2.2–G2.4): framework-agnostic
+      // agent-facing capabilities in BOTH templates.ts and the migrator. Were untracked — a latent
+      // red this guard never caught while it sat quarantined in vitest.push.config.ts; tracked here
+      // as part of re-arming the gate (2026-06-05 suite triage).
+      'Coordination Mandate',           // mandate gate awareness (/mandate/evaluate; deny-by-default; requester≠authorizer)
+      'ReviewExchange (autonomous code review)', // mandate-gated two-party review sign-off protocol
+      'Cutover Readiness',              // migration readiness read surface (/cutover-readiness; the door stays the operator's)
     ];
 
     for (const section of featureSections) {
@@ -248,6 +255,10 @@ describe('Feature Delivery Completeness', () => {
       '/session/clock',                                    // ROBUST-SESSION-TIME-AWARENESS read surface (templated "Session Clock" + migrator): observability the agent READS to answer "how long have I been running / how much is left?" — like /codex/usage and /metrics/features, not a framework-shadowed user-invokable capability
       'Token-Burn Alerts',                                 // BurnDetector noise/activity-gate awareness (monitoring.burnDetection): operational observability the agent READS to answer "why am I getting these token alerts / turn them off" — migrator-only behavioral/config guidance like 'Topic-Flood Guard' / Sentinel Notifications, no user-invokable route / template-shadow parity. (Was previously untracked — a pre-existing red in this guard, fixed here.)
       '/resources/summary',                                // per-agent ResourceLedger Phase B (CPU/memory) READ surface (templated "Resource Usage (CPU + memory + rate-limit events)" + migrator): observability the agent READS to answer "how much CPU/memory am I using right now?" — like /codex/usage, /metrics/features, /session/clock, and /resources/rate-limits, not a framework-shadowed user-invokable capability
+      '/mandate/evaluate',                                 // alternate (content-sniff) check for Coordination Mandate — tracked as a featureSection above
+      '/review-exchange',                                  // alternate (content-sniff) check for ReviewExchange — tracked as a featureSection above
+      '/cutover-readiness',                                // alternate (content-sniff) check for Cutover Readiness — tracked as a featureSection above
+      '/cutover-readiness/import-dryrun',                  // sub-line splice sniff key: the migrateClaudeMd else-if branch inserts the import-rehearsal line INTO the already-tracked Cutover Readiness section for agents that predate it (like '/corrections' for Preferences)
     ];
 
     it('all new migrator CLAUDE.md sections are tracked', () => {

--- a/tests/unit/serendipity-capture.test.ts
+++ b/tests/unit/serendipity-capture.test.ts
@@ -30,8 +30,15 @@ const AUTH_TOKEN = 'test-auth-token-for-serendipity';
 const SESSION_ID = 'test-session-123';
 
 function runCapture(args: string[], env: Record<string, string> = {}): { status: number; stdout: string; stderr: string } {
+  // Ambient-credential hygiene: agent shells export the REAL INSTAR_AUTH_TOKEN,
+  // and the script under test prefers that env var over the fixture config's
+  // authToken when deriving the HMAC key — so every HMAC assertion failed on any
+  // agent box while passing in CI (2026-06-05 suite triage). Strip it from the
+  // inherited env; a test that wants one sets it explicitly via `env`.
+  const inherited = { ...process.env };
+  delete inherited.INSTAR_AUTH_TOKEN;
   const fullEnv = {
-    ...process.env,
+    ...inherited,
     CLAUDE_SESSION_ID: SESSION_ID,
     CLAUDE_AGENT_TYPE: 'general-purpose',
     CLAUDE_TASK_DESCRIPTION: 'test task',

--- a/tests/unit/watchdog-bind-probe.test.ts
+++ b/tests/unit/watchdog-bind-probe.test.ts
@@ -234,13 +234,19 @@ describe('probe_server_identity — behaviour', () => {
   });
 
   function envSandbox(): NodeJS.ProcessEnv {
-    return {
+    const env: NodeJS.ProcessEnv = {
       ...process.env,
       HOME: tmp,
       INSTAR_WATCHDOG_LAUNCH_AGENTS_DIR: path.join(tmp, 'LaunchAgents'),
       INSTAR_WATCHDOG_STATE_DIR: sandboxStateDir,
       INSTAR_WATCHDOG_LOG_FILE: sandboxLogFile,
     };
+    // Ambient-credential hygiene: agent shells export the REAL INSTAR_AUTH_TOKEN,
+    // and the probe under test prefers that env var over the fixture config's
+    // authToken — so the Authorization-header assertions failed on any agent box
+    // while passing in CI (2026-06-05 suite triage). The sandbox must not inherit it.
+    delete env.INSTAR_AUTH_TOKEN;
+    return env;
   }
 
   function sourceTrick(rest: string): string {

--- a/upgrades/next/test-debt-rearm.md
+++ b/upgrades/next/test-debt-rearm.md
@@ -1,0 +1,41 @@
+<!-- bump: patch -->
+
+## What Changed
+
+Two of the project's own CI guards — the no-shell-exec security check and the
+"every capability reaches every agent" delivery-completeness check — had been
+parked in a skip-list and quietly stopped guarding. Both are fixed and turned
+back on. While parked, they missed two real issues, now also fixed: one
+internal monitor used a shell pipeline where a no-shell call belongs, and the
+coordination-mandate capability family (mandate gate, ReviewExchange, Cutover
+Readiness) was never mirrored to Codex/Gemini agents' awareness files.
+
+## What to Tell Your User
+
+Nothing user-visible on Claude-based agents. If you run Codex or Gemini
+framework agents: on their next update they gain awareness of the
+coordination-mandate capabilities (how to check a mandate before acting,
+the structured review-sign-off flow, and the migration-readiness read
+surface) — previously these were Claude-only knowledge.
+
+## Summary of New Capabilities
+
+- AGENTS.md / GEMINI.md shadows now receive the **Coordination Mandate**,
+  **ReviewExchange**, and **Cutover Readiness** sections on migration (the
+  existing idempotent mirroring mechanism; append-only).
+- The security gate (no bare `execSync` outside the audited funnels) and the
+  feature-delivery-completeness gate (template ↔ migrator ↔ shadow parity) run
+  in CI again.
+- Two unit suites no longer fail on machines whose shell exports a real
+  `INSTAR_AUTH_TOKEN` (test sandboxes strip ambient credentials).
+- Maturity: stable (guard re-arms + behavior-preserving refactor; the only
+  agent-visible delta is additive shadow-file content).
+
+## Evidence
+
+2026-06-05 full-suite triage: 37 local failures enumerated; classification
+separated quarantined-guard rot (these fixes), ambient-credential env leaks
+(these fixes), one incomplete local node_modules, and box-load flakes. The
+re-armed guards pass 84/84 deterministically; the migrator + shadow surface is
+green at 49 files / 324 tests; touched suites re-run green WITH the real token
+exported, proving the hygiene fix.

--- a/upgrades/side-effects/test-debt-rearm.md
+++ b/upgrades/side-effects/test-debt-rearm.md
@@ -1,0 +1,61 @@
+# Side-effects review — re-arm two quarantined CI gates + ambient-credential test hygiene
+
+Found during the 2026-06-05 full-suite triage (37 local failures enumerated and
+classified to root cause). Two of the repo's own source-content GUARDS had
+rotted while parked in the vitest.push.config.ts quarantine list — CI never ran
+them, so the exact bug classes they exist to catch reached main unnoticed.
+
+## 1. The change
+
+- **`src/monitoring/mcpProcessReaperDeps.ts`** — the `ps | egrep | grep -v`
+  shell pipeline (bare `execSync`) becomes `execFileSync` with argv arrays (no
+  shell, no interpolation surface); the coarse egrep pre-filter moves into JS
+  (`new RegExp(mcpGrepAlternation(), 'i')`) ahead of the existing precise
+  `matchMcpSignature` second stage. Behavior-preserving: same ps fields, same
+  two-stage filtering, same empty-string-on-failure contract.
+- **`src/core/PostUpdateMigrator.ts`** — `migrateFrameworkShadowCapabilities`
+  markers[] gains the coordination-mandate capability family
+  (`**Coordination Mandate**`, `**ReviewExchange (autonomous code review)**`,
+  `**Cutover Readiness**`). These are framework-agnostic HTTP capabilities in
+  BOTH templates.ts and the migrator, but were never mirrored to AGENTS.md /
+  GEMINI.md — a Codex/Gemini agent under a future mandate would never learn
+  `/mandate/evaluate` and would improvise around the gate (the Secret Drop
+  lesson). Mirroring is the existing idempotent slice-and-append mechanism;
+  no new mechanism.
+- **`tests/unit/feature-delivery-completeness.test.ts`** — tracks the mandate
+  family as featureSections (template ↔ migrator ↔ shadow-marker parity now
+  enforced) + the four content-sniff keys as alternate checks.
+- **`tests/unit/watchdog-bind-probe.test.ts` /
+  `tests/unit/serendipity-capture.test.ts`** — ambient-credential hygiene: both
+  spread `...process.env` into child envs, and on agent boxes the REAL
+  `INSTAR_AUTH_TOKEN` preempted the fixture tokens (Authorization-header and
+  HMAC-key assertions failed locally while green in CI). The sandboxes now
+  strip the ambient token; a test that wants one sets it explicitly.
+- **`vitest.push.config.ts`** — security.test.ts +
+  feature-delivery-completeness.test.ts REMOVED from the quarantine (re-armed;
+  both are deterministic source guards — the "environment-dependent" label was
+  wrong). TunnelManager.test.ts stays parked but its label now states the
+  truth: 22/29 tests fail because the suite predates the provider/tier rewrite
+  with the real reachability probe; rewrite tracked as a durable commitment.
+
+## 2. Blast radius
+
+- The reaper deps refactor is invisible to consumers (identical output
+  contract; the factory has no direct unit tests — covered by typecheck and
+  the McpProcessReaper suite, re-run green).
+- The markers addition only ever APPENDS missing sections to existing
+  AGENTS.md/GEMINI.md shadows on the next migration run — idempotent,
+  no-op for Claude-only installs, copies content verbatim from the
+  just-migrated CLAUDE.md so the files cannot drift.
+- Re-arming the two gates makes CI run 84 currently-green deterministic tests
+  it previously skipped. Risk is future-positive: regressions in these guards
+  now fail PRs instead of rotting.
+
+## 3. Test coverage
+
+- 5 directly-touched/affected files re-run green locally: 164 tests
+  (run WITH the real INSTAR_AUTH_TOKEN still exported — proving the hygiene
+  fix, since these exact assertions failed before it).
+- Full PostUpdateMigrator + shadow-capability surface: 49 files / 324 tests
+  green after the markers change.
+- `npx tsc --noEmit` clean.

--- a/vitest.push.config.ts
+++ b/vitest.push.config.ts
@@ -31,8 +31,15 @@ const FLAKY_TESTS = [
   // ── Environment-dependent / non-deterministic ─────────────────────
   'tests/unit/agent-registry.test.ts',
   'tests/unit/builtin-manifest.test.ts',
-  'tests/unit/feature-delivery-completeness.test.ts',
-  'tests/unit/security.test.ts',
+  // security.test.ts + feature-delivery-completeness.test.ts — RE-ARMED
+  // 2026-06-05. Both are DETERMINISTIC source-content guards (the old
+  // "environment-dependent" label was wrong) and both rotted while parked:
+  // a bare execSync reached src/monitoring/mcpProcessReaperDeps.ts, and the
+  // whole coordination-mandate capability family (mandate gate /
+  // ReviewExchange / cutover-readiness) shipped untracked by the
+  // template↔migrator↔shadow parity guard. Those are fixed and the gates now
+  // gate again. (Same lesson as the ESM-compliance re-arm above: a parked
+  // gate is no gate.)
 
   // ── Non-deterministic data / race conditions ──────────────────────
   'tests/integration/semantic-memory.test.ts',
@@ -72,7 +79,15 @@ const FLAKY_TESTS = [
   // ── Port assertion mismatch on some environments ──────────────────
   'tests/integration/fresh-install.test.ts',
 
-  // ── Error message format mismatch ─────────────────────────────────
+  // ── Stale test file: predates the TunnelManager provider/tier rewrite ──
+  // (#329 et seq.) — 22/29 tests fail because the suite mocks only the
+  // `cloudflared` module while production now drives a provider pool with a
+  // REAL reachability probe (driveTier1 → probeReachability fetches
+  // <url>/health and requires 2xx; the mock URL can never answer). The old
+  // "error message format mismatch" label badly understated this. Needs a
+  // rewrite against the provider/lifecycle architecture with the `fetch`
+  // injection seam (TunnelManager constructor `injections.fetch`) stubbed.
+  // Tracked: commitment "Rewrite TunnelManager unit suite" (2026-06-05).
   'tests/unit/TunnelManager.test.ts',
 
   // ── Supertest body size limit vs express limit mismatch ─────────


### PR DESCRIPTION
## ELI16 — two of our own smoke detectors were unplugged; they're back on, and we fixed what they missed

The repo keeps a "skip these flaky tests in CI" list. Two entries on it weren't flaky at all — they were working smoke detectors that got unplugged: one checks that no code shells out in the risky string-interpolation way, the other checks that every capability we teach Claude agents also reaches Codex/Gemini agents. While unplugged, both things actually happened: an internal process-monitor used the risky shell pattern, and the whole coordination-mandate feature family (the "check your permission slip before acting" API) was never taught to non-Claude agents — exactly the kind of gap that once made a Codex agent invent its own weaker workaround. Both are fixed, the detectors are plugged back in, and two other tests were hardened so they stop failing on machines that have a real credential in their shell environment.

## What this contains

1. **Security-gate fix** — `mcpProcessReaperDeps.ts`: `ps | egrep` shell pipeline (bare `execSync`) → `execFileSync` argv calls, coarse filter moved into JS ahead of the existing precise signature match. Behavior-preserving.
2. **Delivery-completeness fix** — Coordination Mandate / ReviewExchange / Cutover Readiness tracked as featureSections + added to `migrateFrameworkShadowCapabilities` markers[] so AGENTS.md/GEMINI.md shadows receive them (idempotent, append-only, existing mechanism).
3. **Gate re-arms** — both tests removed from the vitest.push.config.ts quarantine (the "environment-dependent" labels were wrong; they're deterministic source guards). TunnelManager's quarantine label now states the true rot (22/29 stale vs the provider/tier rewrite) with a durable rewrite tracker.
4. **Ambient-credential test hygiene** — watchdog-bind-probe + serendipity-capture sandboxes strip the inherited `INSTAR_AUTH_TOKEN` (real token on agent boxes preempted fixture tokens: local-red/CI-green split, 2026-06-05 triage).

## Verification

- Re-armed gates: 84/84 green (deterministic).
- Migrator + shadow surface after markers change: 49 files / 324 tests green.
- Touched suites re-run green WITH the real token exported — proving the hygiene fix.
- `tsc --noEmit` clean. Gate artifacts: `upgrades/side-effects/test-debt-rearm.md` (+ next.md, bump: patch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)