### PR TITLE
fix(mentor): durable lastResult + per-tick logging (loop was undiagnosable)

### DIFF
--- a/.instar/instar-dev-decisions/2026-06-05T14-38-32-338Z-mentor-tick-observability.json
+++ b/.instar/instar-dev-decisions/2026-06-05T14-38-32-338Z-mentor-tick-observability.json
@@ -1,0 +1,13 @@
+{
+  "ts": "2026-06-05T14:38:32.338Z",
+  "slug": "mentor-tick-observability",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "new capability: new config key added"
+  ],
+  "belowFloor": true,
+  "files": 2,
+  "loc": 73
+}

--- a/src/scheduler/MentorOnboardingRunner.ts
+++ b/src/scheduler/MentorOnboardingRunner.ts
@@ -163,6 +163,14 @@ export interface MentorRunnerServices {
   /** Called once when a tick actually RAN (ran=true) — lets the host advance the
    *  min-interval clock and the per-day run counter. */
   onTickRan?: () => void;
+  /** Durable lastResult persistence (optional). `loadLastResult` hydrates the
+   *  runner once at construction; `saveLastResult` is invoked best-effort on
+   *  every lastResult write. Absent ⇒ in-memory only (the old behavior, where
+   *  every server restart wiped the only record of the loop's last outcome —
+   *  on a frequent-release day, restart cadence ≈ tick cadence, so the status
+   *  route read null essentially always). */
+  loadLastResult?: () => (MentorRunResult & { at: number }) | null;
+  saveLastResult?: (r: MentorRunResult & { at: number }) => void;
   now?: () => number;
   // --- Autonomous-fix loop ("just be Echo") services. Only consulted when
   //     mentor.autonomousFix.enabled is true; absent ⇒ the guardian path is
@@ -191,10 +199,25 @@ export class MentorOnboardingRunner {
   constructor(
     private readonly services: MentorRunnerServices,
     private readonly getConfig: () => MentorConfig,
-  ) {}
+  ) {
+    // Hydrate the last outcome from durable state so a server restart doesn't
+    // erase the loop's only observability record. Best-effort: a corrupt or
+    // missing file is just null (in-memory start, the old behavior).
+    try {
+      this.lastResult = services.loadLastResult?.() ?? null;
+    } catch { /* @silent-fallback-ok — hydration is best-effort; null = old behavior */ }
+  }
 
   private inFlight = false;
   private lastResult: (MentorRunResult & { at: number }) | null = null;
+
+  /** Single write funnel for lastResult: assigns + persists best-effort. */
+  private setLastResult(r: MentorRunResult & { at: number }): void {
+    this.lastResult = r;
+    try {
+      this.services.saveLastResult?.(r);
+    } catch { /* @silent-fallback-ok — persistence is best-effort; in-memory value is already set */ }
+  }
 
   status(): {
     enabled: boolean;
@@ -227,18 +250,25 @@ export class MentorOnboardingRunner {
     // the haiku observe-pipeline). So `mode:'off'` does NOT disable it.
     const autonomous = cfg.autonomousFix?.enabled === true;
     if (!cfg.enabled || (cfg.mode === 'off' && !autonomous)) {
-      this.lastResult = { ran: false, reason: 'disabled', at: (this.services.now ?? Date.now)() };
+      this.setLastResult({ ran: false, reason: 'disabled', at: (this.services.now ?? Date.now)() });
       return { accepted: false, reason: 'disabled' };
     }
     if (this.inFlight) return { accepted: false, reason: 'in-flight' };
     this.inFlight = true;
+    // One line per accepted tick — without it the loop is invisible in
+    // server.log (success was fully silent; only failures warned), which made
+    // "is the mentor running at all?" unanswerable from the logs.
+    // eslint-disable-next-line no-console
+    console.log(`[mentor] tick accepted (mode=${cfg.mode}, framework=${cfg.menteeFramework}${autonomous ? ', autonomous-fix' : ''})`);
     void this.tick()
       .then((r) => {
-        this.lastResult = { ...r, at: (this.services.now ?? Date.now)() };
+        this.setLastResult({ ...r, at: (this.services.now ?? Date.now)() });
+        // eslint-disable-next-line no-console
+        console.log(`[mentor] tick result: ran=${r.ran}, reason=${r.reason ?? 'ok'}`);
       })
       .catch((err) => {
         const message = err instanceof Error ? err.message : String(err);
-        this.lastResult = {
+        this.setLastResult({
           ran: false,
           reason: 'stage-a-failed',
           // Surface the real failure so GET /mentor/status.lastResult.error is
@@ -246,7 +276,7 @@ export class MentorOnboardingRunner {
           // only in a console.warn that may never reach the readable logs.
           error: message,
           at: (this.services.now ?? Date.now)(),
-        } as MentorRunResult & { at: number };
+        } as MentorRunResult & { at: number });
         // eslint-disable-next-line no-console
         console.warn('[mentor] tick failed:', message);
       })

--- a/src/server/AgentServer.ts
+++ b/src/server/AgentServer.ts
@@ -2113,9 +2113,42 @@ export class AgentServer {
     const getConfig = (): MentorConfig => readMentorConfigFromDisk(options.config.stateDir, startupMentorConfig);
     const intelligence = options.intelligence ?? null;
     const self = this;
+    // Durable lastResult: persist the loop's last outcome to the state dir so a
+    // server restart doesn't erase it. On a frequent-release day restart cadence
+    // matched the 15-min tick cadence, so GET /mentor/status.lastResult read
+    // null essentially always — the loop was undiagnosable from its own status
+    // route. Absent stateDir ⇒ in-memory only (old behavior).
+    const lastResultPath = options.config.stateDir
+      ? path.join(options.config.stateDir, 'mentor-last-result.json')
+      : null;
     return new MentorOnboardingRunner(
       {
         capture: (input) => ledger.captureRun(input),
+        loadLastResult: lastResultPath
+          ? () => {
+              try {
+                const raw = fs.readFileSync(lastResultPath, 'utf-8');
+                const parsed = JSON.parse(raw) as { ran?: unknown; at?: unknown };
+                // Minimal shape check — a corrupt/foreign file hydrates as null.
+                if (typeof parsed?.at === 'number' && typeof parsed?.ran === 'boolean') {
+                  return parsed as import('../scheduler/MentorOnboardingRunner.js').MentorRunResult & { at: number };
+                }
+              } catch { /* @silent-fallback-ok — missing/corrupt file ⇒ null (old in-memory start) */ }
+              return null;
+            }
+          : undefined,
+        saveLastResult: lastResultPath
+          ? (r) => {
+              try {
+                fs.mkdirSync(path.dirname(lastResultPath), { recursive: true });
+                const tmp = `${lastResultPath}.tmp`;
+                fs.writeFileSync(tmp, JSON.stringify(r, null, 2), 'utf-8');
+                fs.renameSync(tmp, lastResultPath);
+              } catch (err) {
+                console.warn('[mentor] lastResult persist failed (non-fatal):', err instanceof Error ? err.message : String(err));
+              }
+            }
+          : undefined,
         // Record a keystone `mentor-mentee-differential` CYCLE per tick — the
         // structural version of the manual differential-oversight loop. No-ops
         // unless `mentor.apprenticeshipInstanceId` is set AND the cycle store is

--- a/tests/unit/MentorOnboardingRunner.test.ts
+++ b/tests/unit/MentorOnboardingRunner.test.ts
@@ -133,6 +133,67 @@ describe('MentorOnboardingRunner', () => {
   });
 });
 
+describe('MentorOnboardingRunner — durable lastResult (restart-survivable observability)', () => {
+  // Restart cadence ≈ tick cadence on a frequent-release day wiped the
+  // in-memory lastResult essentially always — the loop was undiagnosable from
+  // GET /mentor/status. These pin the load/save service contract.
+
+  it('hydrates lastResult from loadLastResult at construction (restart keeps the record)', () => {
+    const persisted = { ran: false, reason: 'disabled' as const, at: 1717000000000 };
+    const svc = fakeServices({ loadLastResult: vi.fn(() => persisted) });
+    const runner = new MentorOnboardingRunner(svc, () => ({ ...DEFAULT_MENTOR_CONFIG }));
+    expect(runner.status().lastResult).toEqual(persisted);
+    expect(svc.loadLastResult).toHaveBeenCalledTimes(1);
+  });
+
+  it('absent persistence services keep the old in-memory behavior (lastResult starts null)', () => {
+    const runner = new MentorOnboardingRunner(fakeServices(), () => ({ ...DEFAULT_MENTOR_CONFIG }));
+    expect(runner.status().lastResult).toBeNull();
+  });
+
+  it('a throwing loadLastResult is contained (starts null, does not crash construction)', () => {
+    const svc = fakeServices({ loadLastResult: vi.fn(() => { throw new Error('corrupt state file'); }) });
+    const runner = new MentorOnboardingRunner(svc, () => ({ ...DEFAULT_MENTOR_CONFIG }));
+    expect(runner.status().lastResult).toBeNull();
+  });
+
+  it('saveLastResult is invoked on every lastResult write: disabled, success, and failure', async () => {
+    // Disabled short-circuit
+    const saved: unknown[] = [];
+    const save = vi.fn((r: unknown) => { saved.push(r); });
+    const svcOff = fakeServices({ saveLastResult: save });
+    new MentorOnboardingRunner(svcOff, () => ({ ...DEFAULT_MENTOR_CONFIG })).startTick();
+    expect(saved).toHaveLength(1);
+    expect((saved[0] as { reason: string }).reason).toBe('disabled');
+
+    // Success path
+    const svcOk = fakeServices({ saveLastResult: save });
+    const cfgOn: MentorConfig = { ...DEFAULT_MENTOR_CONFIG, enabled: true, mode: 'dry-run' };
+    new MentorOnboardingRunner(svcOk, () => cfgOn).startTick();
+    await new Promise((res) => setTimeout(res, 10));
+    expect((saved[saved.length - 1] as { ran: boolean }).ran).toBe(true);
+
+    // Failure path
+    const svcFail = fakeServices({
+      saveLastResult: save,
+      spawnStageA: vi.fn(async () => { throw new Error('boom'); }),
+    });
+    new MentorOnboardingRunner(svcFail, () => cfgOn).startTick();
+    await new Promise((res) => setTimeout(res, 10));
+    expect((saved[saved.length - 1] as { reason: string }).reason).toBe('stage-a-failed');
+  });
+
+  it('a throwing saveLastResult is contained (in-memory value still lands, tick completes)', async () => {
+    const svc = fakeServices({ saveLastResult: vi.fn(() => { throw new Error('disk full'); }) });
+    const cfg: MentorConfig = { ...DEFAULT_MENTOR_CONFIG, enabled: true, mode: 'dry-run' };
+    const runner = new MentorOnboardingRunner(svc, () => cfg);
+    expect(runner.startTick().accepted).toBe(true);
+    await new Promise((res) => setTimeout(res, 10));
+    expect(runner.status().lastResult?.ran).toBe(true);
+    expect(runner.status().inFlight).toBe(false);
+  });
+});
+
 describe('MentorOnboardingRunner — autonomous-fix guardian branch ("just be Echo")', () => {
   function autoCfg(over: Partial<MentorConfig> = {}): MentorConfig {
     return {

--- a/upgrades/mentor-tick-observability.eli16.md
+++ b/upgrades/mentor-tick-observability.eli16.md
@@ -1,0 +1,13 @@
+# The mentor loop's last outcome now survives restarts (and ticks show up in the log)
+
+The mentor system runs a heartbeat every 15 minutes: a small job session wakes up, pokes the server's "do one mentor tick" endpoint, and the outcome of that tick is supposed to be readable at the mentor status endpoint. Today, asking "is the mentor loop alive?" gave a permanently empty answer — `lastResult` was blank for days, even though the loop was configured on and live.
+
+Two compounding causes, both observability-only:
+
+1. **The last outcome lived only in memory.** Every server restart wiped it. On a day with frequent fleet releases, the server restarts about as often as the tick fires — so the one record of "what happened last tick" was erased before anyone could read it, essentially every time. The loop could have been working perfectly or completely broken; the status route couldn't tell you which.
+
+2. **Successful ticks logged nothing.** Only failures produced a log line. A server log with zero mentor lines was equally consistent with "every tick succeeded silently" and "no tick ever arrived" — we hit exactly this ambiguity while diagnosing it (three days of job sessions, two visible tick arrivals, zero outcome lines).
+
+The fix keeps the same shape as the runner's existing design: the host hands the runner two optional services — "load the last outcome" and "save the last outcome" — wired to a small JSON file in the agent's state directory (atomic write, corrupt-file-tolerant load). The runner hydrates from it once at construction and saves on every outcome write (disabled short-circuit, success, and failure all flow through one funnel). And every accepted tick now logs one line on start and one on completion, so the loop's pulse is visible in the server log.
+
+Nothing about WHAT the mentor does changed — no behavior, gating, or cadence change. If the file is missing or unwritable, the runner behaves exactly as before (in-memory only). Pure diagnosis plumbing for a loop that was flying blind.

--- a/upgrades/next/mentor-tick-observability.md
+++ b/upgrades/next/mentor-tick-observability.md
@@ -1,0 +1,20 @@
+---
+bump: patch
+---
+
+## What Changed
+
+The mentor runner's lastResult now persists to the agent state directory (mentor-last-result.json, atomic write, corrupt-tolerant load) and rehydrates at construction, so GET /mentor/status .lastResult survives server restarts. Accepted ticks log one start line and one outcome line in the server log; previously only failures logged anything.
+
+## What to Tell Your User
+
+Nothing user-visible — diagnosis plumbing. If you ever ask "is the mentor loop doing anything?", the status endpoint and server log can now actually answer, even right after an update restart.
+
+## Summary of New Capabilities
+
+- GET /mentor/status .lastResult is restart-survivable (persisted per outcome, hydrated at boot).
+- Server log shows one line per accepted mentor tick and one per outcome (mentor tick accepted / tick result).
+
+## Evidence
+
+Live trace (2026-06-05): mentor enabled+live with a */15 schedule, yet lastResult was empty at every read and server.log had ZERO mentor outcome lines across three days — while the reap-log showed every job-mentor-onboarding session ending boot-purge-dead and only two tick POSTs were visible (deduped auth warnings). Restart cadence matched tick cadence, so the in-memory record was wiped before any read. Pinned by 5 new unit tests in tests/unit/MentorOnboardingRunner.test.ts (hydration at construction, absent-services back-compat, throwing load contained, save invoked on all three write paths, throwing save contained).

--- a/upgrades/side-effects/mentor-tick-observability.md
+++ b/upgrades/side-effects/mentor-tick-observability.md
@@ -1,0 +1,44 @@
+# Side-Effects Review — Mentor tick observability (durable lastResult + tick logging)
+
+**Version / slug:** `mentor-tick-observability`
+**Date:** `2026-06-05`
+**Author:** `instar-echo`
+
+## Summary
+
+`MentorRunnerServices` gains optional `loadLastResult`/`saveLastResult`; the runner hydrates `lastResult` once at construction and routes all three write paths (disabled short-circuit, success, failure) through one `setLastResult` funnel that persists best-effort. The host (`AgentServer.buildMentorRunner`) wires both to `<stateDir>/mentor-last-result.json` (atomic tmp+rename write; shape-checked, corrupt-tolerant load). `startTick` logs one line on acceptance and one on outcome.
+
+## Decision-point inventory
+
+- `MentorRunnerServices.loadLastResult` / `saveLastResult` — added — optional; absent ⇒ byte-for-byte old behavior (in-memory only).
+- `MentorOnboardingRunner.setLastResult` — added — single write funnel; persist failures contained (in-memory value already set).
+- Constructor hydration — added — try/catch contained; corrupt/missing ⇒ null (old start state).
+- `startTick` logging — added — two `console.log` lines per accepted tick; no logging change on the disabled/in-flight short-circuits (they stay quiet — they fire every 15 min when dark and would be log spam).
+- `AgentServer.buildMentorRunner` — modified — wires the two services only when `stateDir` exists; the persist file lives beside the existing `mentor-sent.jsonl` precedent.
+
+## Direction of failure
+
+- Old failure: the loop's only outcome record was wiped by every restart; success was silent in logs — "is the mentor alive?" was unanswerable from its own surfaces.
+- New behavior: outcome survives restarts; the log carries the loop's pulse.
+- Conservative failure direction: ALL new I/O is best-effort and contained — a missing stateDir, unreadable file, corrupt JSON, or full disk degrades to exactly the old in-memory behavior, never a crash, never a blocked tick.
+
+## Side-effects checklist
+
+1. **Over-block:** none possible — the change never gates or refuses anything; it records and logs only.
+2. **Under-block:** none — no authority added. A stale persisted lastResult after config flip-off is possible (file shows an old outcome while disabled writes overwrite it on the next tick POST) — acceptable: the disabled short-circuit itself writes `reason: disabled`, refreshing the file on the very next heartbeat.
+3. **Level-of-abstraction fit:** the runner owns WHEN to persist (its write funnel); the host owns WHERE/HOW (state-dir path + atomic write) — mirrors the existing `capture`/`deliverToMentee` service split and the `mentor-sent.jsonl` persistence precedent.
+4. **Signal vs authority compliance:** observability-only; no LLM, no gate. Log lines are signals.
+5. **Interactions:** the persisted shape is exactly the in-memory `MentorRunResult & { at }` — the status route serializes it identically whether hydrated or fresh. The hydrated value can briefly present a PRIOR generation's outcome after a restart until the next tick overwrites it — that is the feature (it is timestamped via `at`, so staleness is readable).
+6. **External surfaces:** GET /mentor/status semantics unchanged (same field, now durable). One new state file in the agent state dir. Two new log line shapes (`[mentor] tick accepted…` / `[mentor] tick result…`).
+7. **Rollback cost:** revert the commit; the state file is ignored by old code (no reader), safe to leave or delete.
+
+## Scope not taken
+
+- No fix for the job-session 1-min age-limit race (`expectedDurationMinutes: 1` vs heavy boot) — that is task #14's lean loop-worker territory; this slice makes the symptom DIAGNOSABLE first.
+- No X-Instar-AgentId header fix in the job template (auth deprecation warning) — separate small follow-up.
+- No grounding-config addition for the mentor job (JobLoader audit warning) — separate.
+- No change to tick cadence, gating, budget, or Stage-A/B behavior.
+
+## Rollback
+
+Revert the single commit. The runner returns to in-memory-only lastResult and silent successful ticks.


### PR DESCRIPTION
## ELI16

The mentor system runs a heartbeat every 15 minutes, and the outcome of each tick is supposed to be readable at `GET /mentor/status`. Asking "is the mentor loop alive?" gave a permanently empty answer for days — while the loop was configured on and live.

Two compounding causes, both observability-only:

1. **The last outcome lived only in memory.** Every server restart wiped it. On a frequent-release day the server restarts about as often as the tick fires, so the one record of "what happened last tick" was erased before anyone could read it — essentially every time.
2. **Successful ticks logged nothing.** Only failures produced a log line. A server log with zero mentor lines was equally consistent with "every tick succeeded silently" and "no tick ever arrived" — exactly the ambiguity hit while diagnosing this (three days of job sessions, two visible tick POSTs, zero outcome lines).

## The fix (same shape as the runner's existing service design)

- `MentorRunnerServices` gains optional `loadLastResult`/`saveLastResult`. The runner hydrates once at construction and routes all three write paths (disabled short-circuit, success, failure) through one `setLastResult` funnel that persists best-effort. **Absent services ⇒ byte-for-byte old behavior.**
- The host wires them to `<stateDir>/mentor-last-result.json` — atomic tmp+rename write, shape-checked corrupt-tolerant load — beside the existing `mentor-sent.jsonl` persistence precedent.
- `startTick` logs one line on acceptance and one on outcome. Dark-mode short-circuits stay quiet (no 15-min log spam on agents where the mentor is off).

No behavior, gating, or cadence change. Every new I/O path is contained: missing stateDir, corrupt file, or full disk degrades to exactly the old in-memory behavior.

## Evidence

Live trace (2026-06-05, echo): mentor `enabled + live`, `*/15` heartbeat — `lastResult` empty at every read; reap-log shows every `job-mentor-onboarding` session for 3 days ending `boot-purge-dead`; only two tick POSTs visible (deduped auth warnings); zero `[mentor]` outcome lines in server.log.

## Tests

5 new unit tests (hydration at construction, absent-services back-compat, throwing load contained, save invoked on all three write paths, throwing save contained). 25/25 runner tests + 30 sibling mentor tests green; tsc + lint clean; Tier-1 gate passed.

Deliberately out of scope (tracked separately): the job-session 1-min age-limit race (task #14 lean loop-worker), the job template's missing X-Instar-AgentId header, the mentor job grounding config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)