### PR TITLE
fix(sentinel): long-message pause classifications downgrade to normal (coaching messages were consumed)

### DIFF
--- a/.instar/instar-dev-decisions/2026-06-05T15-26-13-944Z-sentinel-pause-length-guard.json
+++ b/.instar/instar-dev-decisions/2026-06-05T15-26-13-944Z-sentinel-pause-length-guard.json
@@ -1,0 +1,11 @@
+{
+  "ts": "2026-06-05T15:26:13.944Z",
+  "slug": "sentinel-pause-length-guard",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 49
+}

--- a/src/core/MessageSentinel.ts
+++ b/src/core/MessageSentinel.ts
@@ -122,6 +122,25 @@ export interface SentinelStats {
  */
 const MAX_FAST_PATH_WORDS = 4;
 
+/**
+ * Pause-directive length ceiling for the LLM layer.
+ *
+ * A genuine natural-language pause directive is short ("pause please",
+ * "hold on, wait for me to finish reading before you continue") — well
+ * under this bound. A LONG message classified 'pause' is task content
+ * whose closing phrase ("…and stand by") seduced the classifier; CONSUMING
+ * it as a control command destroys the content for zero safety payoff
+ * (pause's value is politeness, not safety). Live 2026-06-05: two ~200-word
+ * mentor coaching messages ending "…and stand by" were eaten this way on
+ * topic 1052 ("Session paused" posted at 14:22:58Z and 14:41:24Z; the
+ * messages were never routed and existed in no queue or drop ledger).
+ *
+ * ASYMMETRY (deliberate): emergency-stop is NOT length-gated at this layer —
+ * stopping unnecessarily on a long panic message is a tolerable false
+ * positive (the prompt's own safety-first rule). Only 'pause' downgrades.
+ */
+const MAX_PAUSE_DIRECTIVE_WORDS = 25;
+
 // ── Fast-Path Patterns ───────────────────────────────────────────────
 
 /**
@@ -346,7 +365,7 @@ export class MessageSentinel {
 
     // Layer 2: LLM classification (if available and not fast-path-only)
     if (this.config.intelligence && !this.config.fastPathOnly) {
-      const llmResult = await this.llmClassify(message);
+      const llmResult = this.downgradeLongPause(await this.llmClassify(message), message);
       const latency = Date.now() - start;
       this.recordStats(llmResult.category, 'llm', latency);
       return {
@@ -368,6 +387,34 @@ export class MessageSentinel {
       action: { type: 'pass-through' },
       reason: 'No fast-path match, no LLM available',
       continuePingIntent,
+    };
+  }
+
+  /**
+   * Structural guard (Structure > Willpower): a 'pause' classification on a
+   * LONG message downgrades to 'normal' pass-through. The LLM prompt already
+   * ASKS for this judgment ("substantive content ⇒ NORMAL"), but a closing
+   * imperative ("…and stand by") intermittently wins anyway — and the
+   * forward route CONSUMES pause-classified messages, so the false positive
+   * silently destroys the message. Emergency-stop is deliberately untouched
+   * (see MAX_PAUSE_DIRECTIVE_WORDS). The fast path needs no equivalent: its
+   * 4-word gate already excludes long messages from pattern matches.
+   */
+  private downgradeLongPause(
+    result: Omit<SentinelClassification, 'method' | 'latencyMs'>,
+    message: string,
+  ): Omit<SentinelClassification, 'method' | 'latencyMs'> {
+    if (result.category !== 'pause') return result;
+    const wordCount = message.trim().split(/\s+/).length;
+    if (wordCount <= MAX_PAUSE_DIRECTIVE_WORDS) return result;
+    console.log(
+      `[sentinel] pause downgraded to normal: ${wordCount} words > ${MAX_PAUSE_DIRECTIVE_WORDS} (long messages are task content, not pause directives)`,
+    );
+    return {
+      category: 'normal',
+      confidence: result.confidence,
+      action: { type: 'pass-through' },
+      reason: `pause downgraded: ${wordCount}-word message exceeds the ${MAX_PAUSE_DIRECTIVE_WORDS}-word pause-directive ceiling (was: ${result.reason})`,
     };
   }
 

--- a/tests/unit/MessageSentinel.test.ts
+++ b/tests/unit/MessageSentinel.test.ts
@@ -519,4 +519,59 @@ describe('MessageSentinel', () => {
       expect(sentinel.isEnabled()).toBe(false);
     });
   });
+
+  describe('long-message pause downgrade (consumed-coaching-message guard)', () => {
+    // Live failure (2026-06-05, topic 1052): two ~200-word mentor coaching
+    // messages ending "…and stand by" were LLM-classified 'pause'; the
+    // forward route CONSUMED them (paused the session, never routed the
+    // text — no queue, no drop ledger, just "Session paused" in the topic).
+    // The guard: a pause classification on a message longer than the
+    // pause-directive ceiling is task content → downgraded to normal.
+
+    const LONG_COACHING_MESSAGE =
+      'Status update on your lanes: the capsule spec still awaits the approved tag, and Gemini is still ' +
+      'quota-blocked until later tonight. Check the live quota state first before driving any cycle, and ' +
+      'if it has capacity run one small observation cycle, otherwise just report the numbers back here and stand by.';
+
+    it('downgrades a long LLM-pause to normal pass-through (message is task content)', async () => {
+      sentinel = new MessageSentinel({
+        intelligence: { evaluate: async () => 'pause' },
+      });
+      const result = await sentinel.classify(LONG_COACHING_MESSAGE);
+      expect(result.category).toBe('normal');
+      expect(result.action.type).toBe('pass-through');
+      expect(result.reason).toContain('pause downgraded');
+      expect(result.method).toBe('llm');
+    });
+
+    it('keeps a SHORT LLM-pause as pause (genuine directive still pauses)', async () => {
+      sentinel = new MessageSentinel({
+        intelligence: { evaluate: async () => 'pause' },
+      });
+      const result = await sentinel.classify('Hold on, wait for me to finish reading this before you continue.');
+      expect(result.category).toBe('pause');
+      expect(result.action.type).toBe('pause-session');
+    });
+
+    it('does NOT downgrade a long emergency-stop (safety asymmetry preserved)', async () => {
+      sentinel = new MessageSentinel({
+        intelligence: { evaluate: async () => 'emergency-stop' },
+      });
+      const result = await sentinel.classify(LONG_COACHING_MESSAGE);
+      expect(result.category).toBe('emergency-stop');
+      expect(result.action.type).toBe('kill-session');
+    });
+
+    it('boundary: exactly 25 words stays pause; 26 words downgrades', async () => {
+      sentinel = new MessageSentinel({
+        intelligence: { evaluate: async () => 'pause' },
+      });
+      const words25 = Array.from({ length: 25 }, (_, i) => `w${i}`).join(' ');
+      const words26 = Array.from({ length: 26 }, (_, i) => `w${i}`).join(' ');
+      expect((await sentinel.classify(words25)).category).toBe('pause');
+      const over = await sentinel.classify(words26);
+      expect(over.category).toBe('normal');
+      expect(over.action.type).toBe('pass-through');
+    });
+  });
 });

--- a/upgrades/next/sentinel-pause-length-guard.md
+++ b/upgrades/next/sentinel-pause-length-guard.md
@@ -1,0 +1,19 @@
+---
+bump: patch
+---
+
+## What Changed
+
+The MessageSentinel's LLM layer now downgrades a 'pause' classification to normal pass-through when the message exceeds 25 words (MAX_PAUSE_DIRECTIVE_WORDS). Emergency-stop is deliberately not length-gated (safety asymmetry). The downgrade is logged and carried in the classification reason.
+
+## What to Tell Your User
+
+Long working messages that happen to end with phrases like "stand by" or "hold off for now" can no longer be swallowed as pause commands. Previously such a message could pause your agent's session and vanish entirely — you'd see only "Session paused" where your instructions should have landed. Short, genuine pause directives still pause as before.
+
+## Summary of New Capabilities
+
+- Pause classifications on messages over 25 words pass through as normal conversation; the message is delivered instead of consumed.
+
+## Evidence
+
+Live failures (2026-06-05, topic 1052): two ~200-word mentor coaching messages ending "…and stand by" were LLM-classified 'pause' and CONSUMED by the telegram-forward sentinel intercept — "Session paused" posted at 14:22:58Z and 14:41:24Z, the messages never routed, present in no queue or drop ledger (the third mechanism of the day's delivery-loss trilogy, after #839 inbound replay and #840 outbound purge). The classifier prompt already instructs "substantive content ⇒ NORMAL" but the closing imperative intermittently won — prompt-as-willpower; this guard is the structure. Pinned by 4 tests: long-pause downgrade, short-pause preserved, long emergency-stop preserved, exact 25/26-word boundary.

--- a/upgrades/sentinel-pause-length-guard.eli16.md
+++ b/upgrades/sentinel-pause-length-guard.eli16.md
@@ -1,0 +1,12 @@
+# A long working message ending in "stand by" can no longer be eaten as a pause command
+
+The message sentinel reads every inbound message and classifies it: normal conversation, a redirect, a pause command, or an emergency stop. Pause and emergency-stop classifications are intercepted — the session is paused or killed, a confirmation is posted, and **the message itself is consumed**, never delivered. That's correct for "stop everything": the message IS the command.
+
+The failure: a ~200-word mentor coaching message — task status, instructions, and a closing "…report the numbers back here and stand by" — was classified as a **pause command**. The session paused, "Session paused. Send a message to resume." was posted, and the entire message vanished: not in any queue, not in any drop ledger, just gone. It happened twice in one afternoon on the same topic (14:22 and 14:41), both times on messages ending with "stand by". The classifier's prompt already asks for exactly the right judgment ("substantive content means NORMAL") — but a closing imperative intermittently wins anyway, and a prompt instruction is willpower, not structure.
+
+The structural guard: a **pause** classification on a message longer than 25 words downgrades to normal pass-through, with the downgrade logged and recorded in the classification's reason. The rationale is an asymmetry the prompt itself already encodes:
+
+- **Emergency-stop is untouched.** Stopping unnecessarily on a long panicked message is a tolerable false positive — safety first, always.
+- **Pause is politeness, not safety.** Consuming a long message to be polite destroys real content for zero protective payoff. A genuine natural-language pause directive ("hold on, wait for me to finish reading before you continue") is well under 25 words; nobody writes a 200-word pause command.
+
+The fast-path layer needed no change — its existing 4-word gate already keeps long messages away from pattern matches. Slash commands (/pause, /stop) are exact matches and unaffected. Four tests pin the boundary: long pause downgrades, short pause still pauses, long emergency-stop still stops, and the exact 25/26-word edge.

--- a/upgrades/side-effects/sentinel-pause-length-guard.md
+++ b/upgrades/side-effects/sentinel-pause-length-guard.md
@@ -1,0 +1,43 @@
+# Side-Effects Review — MessageSentinel: long-message pause downgrade
+
+**Version / slug:** `sentinel-pause-length-guard`
+**Date:** `2026-06-05`
+**Author:** `instar-echo`
+
+## Summary
+
+New `downgradeLongPause()` applied to the LLM layer's result in `classify()`: a 'pause' classification on a message longer than `MAX_PAUSE_DIRECTIVE_WORDS` (25) becomes `normal`/pass-through, logged, with the original reason preserved inside the downgrade reason. Emergency-stop, redirect, and all short-message behavior unchanged.
+
+## Decision-point inventory
+
+- `MAX_PAUSE_DIRECTIVE_WORDS` — added (25) — a genuine natural-language pause directive is well under this; the two live victims were ~200 words.
+- `downgradeLongPause()` — added — pure function of (classification, message); only transforms `pause`.
+- `classify()` LLM branch — modified — result passes through the guard. Fast path untouched (its 4-word gate already excludes long messages from patterns; slash commands are exact-match short).
+- The forward-route intercept, pause action semantics, stats recording — untouched (stats record the post-downgrade category, which is the truthful one).
+
+## Direction of failure
+
+- Old failure: a long task message classified 'pause' was CONSUMED — session paused, content destroyed, no trace in any queue/ledger (the delivery stack's only loss path with zero record).
+- New behavior: long messages always deliver; only short messages can pause.
+- Conservative failure direction: content is preserved. The worst new case is a user writing a >25-word pause request that now passes through as conversation — the session still RECEIVES it and can comply conversationally; nothing is destroyed. Compare old worst case: silent destruction of instructions.
+
+## Side-effects checklist
+
+1. **Over-deliver (missed pause):** a verbose pause directive (>25 words) no longer auto-pauses. Mitigations already in place: the message is delivered (the agent reads "please pause" and can stop itself), and /pause + short forms still work. Pause is politeness, not safety — the safety category (emergency-stop) is untouched.
+2. **Under-deliver:** none — no path consumes more than before.
+3. **Asymmetry justification:** emergency-stop on a long message remains possible by design (the prompt's own safety-first rule: better to stop unnecessarily than continue destructively). Length-gating it would trade safety for content; not taken.
+4. **Level-of-abstraction fit:** the guard lives in MessageSentinel (the classifier), not the forward route (the consumer) — every consumer of classify() (route intercept, TelegramAdapter.processUpdate, /sentinel/classify API) gets the same corrected verdict; no consumer-side divergence.
+5. **Signal vs authority:** the LLM keeps proposing; the structural gate bounds its authority over the destructive action. Exactly the signal-vs-authority pattern.
+6. **External surfaces:** `/sentinel/classify` responses for long pause-ish messages change category to `normal` with an explanatory reason — truthful, observable, and carried in `/metrics/features` stats as the post-guard category.
+7. **Rollback cost:** revert the commit; no state, config, or migration.
+
+## Scope not taken
+
+- No change to emergency-stop classification (deliberate, documented asymmetry).
+- No configurability of the 25-word ceiling (constant; make it config only if a real false-negative shows up).
+- No retroactive recovery of the two eaten messages (both manually resent during diagnosis).
+- No prompt changes (the prompt's guidance stays as a first line; the guard is the backstop).
+
+## Rollback
+
+Revert the commit. Long messages classified 'pause' are consumed again.


### PR DESCRIPTION
## ELI16

The message sentinel classifies every inbound message; **pause** and **emergency-stop** classifications are intercepted by the forward route — the session is paused/killed and the message itself is **consumed**: never routed, in no queue, in no drop ledger. Correct when the message IS the command. Catastrophic when it isn't.

**Live failures (2026-06-05, topic 1052):** two ~200-word mentor coaching messages — task status, instructions, and a closing "…report the numbers back here and **stand by**" — were LLM-classified `pause` and eaten. "Session paused. Send a message to resume." posted at 14:22:58Z and 14:41:24Z; the instructions destroyed without trace. The classifier's prompt already instructs exactly the right judgment ("substantive content ⇒ NORMAL") — the closing imperative intermittently won anyway. A prompt instruction is willpower; this PR is the structure.

This is the **third mechanism of today's delivery-loss trilogy** (after #839 inbound replay-budget burn and #840 outbound restore-purge) — all found by tracing a single lost mentor message.

## The guard (deliberately asymmetric)

`downgradeLongPause()` in `classify()`'s LLM branch: a `pause` classification on a message longer than **25 words** (`MAX_PAUSE_DIRECTIVE_WORDS`) downgrades to `normal` pass-through — logged, original reason preserved inside the downgrade reason.

- **Emergency-stop is untouched.** Stopping unnecessarily on a long panic message is the tolerable false positive (the prompt's own safety-first rule).
- **Pause is politeness, not safety.** Consuming a long message for politeness destroys content for zero protective payoff. A genuine natural-language pause directive ("hold on, wait for me to finish reading before you continue") is well under 25 words.
- Guard lives in the **classifier**, not the route — every consumer (forward intercept, processUpdate, /sentinel/classify API) gets the same corrected verdict.
- Fast path untouched: its existing 4-word gate already excludes long messages from patterns; slash commands are exact matches.

Worst new case: a >25-word verbose pause request passes through as conversation — the session still *receives* it and can comply; nothing is destroyed. Old worst case: silent destruction of instructions.

## Tests

4 new: long-pause downgrade, short-pause preserved, long emergency-stop preserved, exact 25/26-word boundary. 118/118 sentinel suite green; tsc + lint clean; Tier-1 gate passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)