### PR TITLE
fix(gemini): pass through explicit model ids

### DIFF
--- a/.instar/instar-dev-decisions/2026-06-05T16-18-10-810Z-model-flag-grounding.json
+++ b/.instar/instar-dev-decisions/2026-06-05T16-18-10-810Z-model-flag-grounding.json
@@ -1,0 +1,12 @@
+{
+  "ts": "2026-06-05T16:18:10.810Z",
+  "slug": "model-flag-grounding",
+  "suggestedTier": 1,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 6,
+  "verdict": "pass"
+}

--- a/docs/eli16/GEMINI-MODEL-PASSTHROUGH.md
+++ b/docs/eli16/GEMINI-MODEL-PASSTHROUGH.md
@@ -1,0 +1,9 @@
+# Gemini Explicit Model Names
+
+Instar lets a caller pick a framework and a model. Some names are simple tiers, like fast or capable. Those should be translated into the right model for the selected framework. But if an operator gives a concrete Gemini model name, Instar should not silently replace it with a safer default just because the name is not in our small known list.
+
+The previous Gemini session-launch resolver did that replacement. If the model name was not one of the two verified Gemini names, it quietly swapped the request to the default flash model. That hid mistakes, but it also ignored intentional overrides for newer or experimental Gemini models.
+
+This change keeps the safe mapping for generic tiers, but passes explicit Gemini model names through to the Gemini CLI. If the model is bad, the Gemini CLI fails loudly with a provider error. That is better than silently running the wrong model.
+
+Automatic capacity fallback remains constrained to known-good Gemini models. The boundary is: explicit caller intent passes through; automatic fallback choices stay on the verified list.

--- a/src/core/frameworkSessionLaunch.ts
+++ b/src/core/frameworkSessionLaunch.ts
@@ -15,10 +15,6 @@
 
 import type { IntelligenceFramework } from './intelligenceProviderFactory.js';
 import { codexSupportsHookTrustBypass } from './codexCapabilities.js';
-import {
-  GEMINI_DEFAULT_MODEL,
-  isKnownGeminiModel,
-} from '../providers/adapters/gemini-cli/models.js';
 
 /**
  * Cross-framework generic model tiers. Higher-level code (UpgradeNotify,
@@ -82,7 +78,7 @@ export function resolveModelForFramework(
     if (key === 'fast' || key === 'haiku') return 'gemini-2.5-flash';
     if (key === 'balanced' || key === 'sonnet') return 'gemini-2.5-flash';
     if (key === 'capable' || key === 'opus') return 'gemini-2.5-pro';
-    return isKnownGeminiModel(modelOrTier) ? modelOrTier : GEMINI_DEFAULT_MODEL;
+    return modelOrTier;
   }
   return modelOrTier;
 }

--- a/tests/unit/frameworkSessionLaunch.test.ts
+++ b/tests/unit/frameworkSessionLaunch.test.ts
@@ -449,7 +449,29 @@ describe('frameworkSessionLaunch.resolveModelForFramework', () => {
     it('keeps raw Gemini model ids inside the verified known-model set', () => {
       expect(resolveModelForFramework('gemini-cli', 'gemini-2.5-flash')).toBe('gemini-2.5-flash');
       expect(resolveModelForFramework('gemini-cli', 'gemini-2.5-pro')).toBe('gemini-2.5-pro');
-      expect(resolveModelForFramework('gemini-cli', 'gemini-2.0-flash')).toBe('gemini-2.5-flash');
+    });
+    it('passes explicit raw Gemini model ids through so bad overrides fail loudly upstream', () => {
+      expect(resolveModelForFramework('gemini-cli', 'gemini-2.0-flash')).toBe('gemini-2.0-flash');
+      expect(resolveModelForFramework('gemini-cli', 'gemini-2.5-pro-exp')).toBe('gemini-2.5-pro-exp');
+    });
+    it('uses the raw Gemini model id in interactive and headless launch argv', () => {
+      const interactive = buildInteractiveLaunch('gemini-cli', {
+        binaryPath: '/x/gemini',
+        defaultModel: 'gemini-2.5-pro-exp',
+      });
+      expect(interactive.argv).toEqual(['/x/gemini', '-m', 'gemini-2.5-pro-exp', '--yolo']);
+
+      const headless = buildHeadlessLaunch('gemini-cli', {
+        binaryPath: '/x/gemini',
+        prompt: 'p',
+        model: 'gemini-2.5-pro-exp',
+      });
+      expect(headless.argv).toEqual([
+        '/x/gemini',
+        '-m', 'gemini-2.5-pro-exp',
+        '--approval-mode', 'default',
+        '-p', 'p',
+      ]);
     });
   });
 

--- a/upgrades/next/gemini-model-passthrough.md
+++ b/upgrades/next/gemini-model-passthrough.md
@@ -1,0 +1,21 @@
+# Gemini Explicit Model Passthrough
+
+<!-- bump: patch -->
+
+## What Changed
+
+Gemini session launch model resolution now honors explicit raw Gemini model ids. Generic tiers still map to verified Gemini defaults, but unrecognized explicit names pass through to the Gemini CLI instead of being silently replaced with the flash default.
+
+## What to Tell Your User
+
+If someone deliberately configures a newer or experimental Gemini model, I now try exactly that model. If the model name is wrong or unavailable, Gemini reports the real error instead of quietly running a different default model.
+
+## Summary of New Capabilities
+
+- Explicit Gemini model overrides are honored in interactive and headless session launches.
+- Automatic Gemini capacity fallback remains constrained to verified known models.
+- Regression tests now assert raw Gemini model ids reach the spawned CLI arguments.
+
+## Evidence
+
+Grounded against PR #708's review boundary and live CLI probes: Claude, Codex, and Gemini all fail loudly when given a bogus explicit model id. Focused validation: `npx vitest run tests/unit/frameworkSessionLaunch.test.ts tests/unit/gemini-cli-adapter.test.ts tests/unit/geminiCapacityPolicy.test.ts tests/unit/codex-model-tier-resolution.test.ts` passed, 91/91 tests.

--- a/upgrades/side-effects/gemini-model-passthrough.md
+++ b/upgrades/side-effects/gemini-model-passthrough.md
@@ -1,0 +1,43 @@
+# Side Effects — Gemini Explicit Model Passthrough
+
+## Change Summary
+
+`resolveModelForFramework('gemini-cli', model)` now passes unrecognized explicit Gemini model ids through instead of replacing them with the default flash model. Generic tiers and legacy Claude tier aliases still map to the verified Gemini tier choices. Gemini capacity fallback remains constrained by `resolveKnownGeminiFallback`.
+
+## Signal vs Authority
+
+This change does not add a detector or blocking authority. It changes deterministic model-string resolution before a framework CLI spawn. The relevant decision boundary is caller intent: explicit model ids are honored, while automatic fallback selection remains constrained by the existing capacity-policy helper.
+
+## Over-Block
+
+No legitimate explicit Gemini model id is blocked by this change. The previous behavior overrode unrecognized ids; this change removes that over-block.
+
+## Under-Block
+
+An invalid explicit Gemini model id can now reach the Gemini CLI and fail there. That is intentional: live CLI probes for Claude, Codex, and Gemini all showed explicit bogus model ids fail loudly at the provider/CLI boundary rather than defaulting silently.
+
+## Level Of Abstraction
+
+The change belongs in `frameworkSessionLaunch` because that helper owns framework-specific model translation for interactive and headless session spawns. The Gemini adapter resolver already had the correct pass-through contract; this brings the session-launch resolver back into alignment.
+
+## Interactions
+
+The capacity policy is not weakened. Its automatic fallback path still uses the known-model constraint, so guessed fallback choices remain bounded to verified Gemini models. The changed path only applies to explicit launch model input.
+
+## External Surfaces
+
+Gemini sessions launched with an explicit new or experimental model id will now actually pass that id to Gemini. If the id is unavailable, the session fails with the CLI/provider error instead of silently running the default model.
+
+## Rollback
+
+Rollback is a one-line revert in `resolveModelForFramework('gemini-cli', ...)`, plus reverting the added tests. No data migration or state repair is required.
+
+## Evidence
+
+Grounding:
+- PR #708 review established the principle: respect explicit caller intent; constrain only automatic or guessed fallback choices.
+- Current `resolveCliModelFlag` for Gemini already passes explicit raw model ids through.
+- Live bogus-model probes: Claude and Codex both surfaced explicit model errors; Gemini package-runner surfaced `ModelNotFoundError`.
+
+Validation:
+- `npx vitest run tests/unit/frameworkSessionLaunch.test.ts tests/unit/gemini-cli-adapter.test.ts tests/unit/geminiCapacityPolicy.test.ts tests/unit/codex-model-tier-resolution.test.ts` — 91/91 passed.


### PR DESCRIPTION
## Summary

- Changes `resolveModelForFramework('gemini-cli', rawModel)` to pass explicit raw Gemini model ids through instead of silently replacing unrecognized ids with the flash default.
- Keeps generic tier mapping unchanged: fast/balanced/haiku/sonnet → flash, capable/opus → pro.
- Leaves automatic Gemini capacity fallback constrained to the verified known-model set.

## Grounding

This came from PR #708's review boundary: respect explicit caller intent; constrain only automatic or guessed fallback choices.

Current main already has that behavior in `resolveCliModelFlag` for the Gemini adapter, but the cross-framework session launch resolver still defaulted unknown Gemini ids to flash. That meant an explicit interactive/headless Gemini model override could silently run the wrong model.

Live CLI probes with a deliberately bogus model id:

- Claude Code: reported the selected model may not exist or may be inaccessible.
- Codex CLI: returned a provider 400 for the unsupported explicit model.
- Gemini CLI via package runner: returned `ModelNotFoundError` / requested entity not found.

So the framework CLIs fail loudly on bad explicit model names. Silent defaulting in Instar is the surprising behavior.

## ELI16

If someone asks Instar to use a general tier like “fast,” Instar should translate that into the right model for the selected framework. But if someone gives a concrete Gemini model name, Instar should try that exact model. If the name is wrong, Gemini should say so. Running a different default model silently is worse because it hides the mistake and can make the operator think their override worked.

This PR keeps the safe tier defaults, but lets explicit Gemini model names reach the Gemini CLI.

## Validation

- `npx vitest run tests/unit/frameworkSessionLaunch.test.ts tests/unit/gemini-cli-adapter.test.ts tests/unit/geminiCapacityPolicy.test.ts tests/unit/codex-model-tier-resolution.test.ts` — 91/91 passed
- `npm run lint` — passed
- `npm run check:upgrade-guide` — passed for v1.3.306; existing historical warnings unchanged
- `node scripts/check-repo-invariants.mjs` — passed
- `node scripts/docs-coverage.mjs` — passed
- `npm run build` — passed; local signing-key warning is expected
- Pre-push smoke tier — 58 files / 747 tests passed
- Pre-push scoped e2e — 17 Threadline files / 332 tests passed

## Live #842 Re-Verification

Before this branch, I also re-verified the merged template auth fix live on Codey:

- Server initially ran stale v1.3.298 while disk had v1.3.304; after restart, v1.3.304 still emitted a bearer-only warning for `evolution/actions/overdue` because #842 had not landed in that release.
- Update check showed #842 in v1.3.306; I applied v1.3.306 and restarted through the supervisor.
- Health then reported v1.3.306 with no degradations.
- Managed jobs regenerated; `evolution-overdue-check` gate now includes the agent identity header.
- Fresh `evolution-overdue-check` trigger/gate activity skipped cleanly with no new bearer-only deprecation warning in the observed log interval.

One extra finding: the pre-push path-scoped e2e hook again selected Threadline suites for a non-Threadline diff. It passed, so this is not blocking, but the selector still looks over-broad.
