### PR TITLE
feat(gate): causalAutopsy — durable cause-of-issue record per fix (advisory slice)

### DIFF
--- a/.instar/instar-dev-decisions/2026-06-05T17-53-32-749Z-gate-causal-autopsy.json
+++ b/.instar/instar-dev-decisions/2026-06-05T17-53-32-749Z-gate-causal-autopsy.json
@@ -1,0 +1,13 @@
+{
+  "ts": "2026-06-05T17:53:32.749Z",
+  "slug": "gate-causal-autopsy",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 90,
+  "causalAutopsy": null,
+  "verdict": "pass"
+}

--- a/docs/eli16/gate-causal-autopsy.eli16.md
+++ b/docs/eli16/gate-causal-autopsy.eli16.md
@@ -1,0 +1,37 @@
+# Causal autopsy in the dev gate — ELI16
+
+We recently allowed small, low-risk fixes to ship through a fast lane: no
+design document, no second reviewer, just the author, some required artifacts,
+and green tests. That trade is fine — IF we compensate for the missing
+reviewer somewhere else. Justin named the compensation precisely: every time
+something breaks, we should write down what actually caused it. Was it a
+previous change? A shift in the environment that quietly invalidated an old
+assumption? Brand-new code? A bug that was always there? Or do we honestly not
+know? Without that record, we can't tell whether our fixes are making the
+system converge toward stability or whether we're playing whack-a-mole —
+or worse, each "fix" is quietly adding new chaos.
+
+Today that analysis is possible only by archaeology: digging through PR
+descriptions, chat logs, and one agent's session memory. The single day we
+tried it by hand produced a real insight — five of six bugs fixed that day
+were NOT new mistakes; they were old assumptions (retry budgets, cleanup
+timers) invalidated by one systemic shift, our release pace jumping to a
+restart every fifteen minutes. That's exactly the kind of pattern worth
+knowing, and exactly the kind that evaporates if nobody records causes.
+
+So the record now has a structural home. The dev gate already writes one
+small audit file per commit attempt (what tier was declared, what the risk
+classifier suggested, whether the gate passed or blocked). The fix-author can
+now add one field to their trace: the cause of the issue they're fixing — one
+of five honest categories, plus the linked PR numbers when the cause was a
+prior change. The gate validates it (a garbage cause is rejected loudly,
+because a corrupt record is worse than none) and copies it into the audit
+file. Meta-analysis stops being archaeology and becomes a one-line query over
+those files.
+
+Two deliberate softnesses in this first slice. Declaring a cause is optional:
+if a commit looks like a fix (the branch name or release note says so) and
+has no cause declared, the gate prints a loud nudge but never blocks — we
+want the field to earn trust before it gains teeth. And "unknown" is a fully
+legitimate answer: an honest "we don't know yet" is better data than a
+guessed cause, and far better than silence.

--- a/docs/side-effects/gate-causal-autopsy.side-effects.md
+++ b/docs/side-effects/gate-causal-autopsy.side-effects.md
@@ -1,0 +1,43 @@
+# Side-effects review — causalAutopsy field in the instar-dev gate
+
+## What changes
+
+scripts/instar-dev-precommit.js: (1) Step 4.55 validates an OPTIONAL
+`causalAutopsy` field in the trace JSON (origin enum prior-pr |
+environment-shift | new-code | latent | unknown; relatedPrs required for
+prior-pr; validated-when-present); (2) the field is copied verbatim into the
+per-commit decision-audit entry (null when absent); (3) a fix-class commit
+(branch name or staged release fragment says fix) with NO autopsy gets an
+ADVISORY stderr warning — never a block.
+
+## Over-block surface (the risk direction for a gate change)
+
+The ONLY new block is a PRESENT-but-malformed autopsy — a deliberate choice:
+a corrupt record poisons the meta-analysis dataset, so it is rejected with the
+exact shape printed. Absence NEVER blocks (pinned by test). Commits with no
+trace, non-fix commits, Tier-2 flows: behavior unchanged. The blocked attempt
+is recorded with verdict 'blocked' via the existing exit handler — the
+riding-the-retry design is untouched.
+
+## Advisory noise
+
+The warning fires only on a fix-class signal: branch segment matching fix, or
+a staged upgrades/next fragment containing change_type: fix. A non-fix Tier-1
+commit with no autopsy prints NOTHING (pinned by test). Both detection probes
+are wrapped in try/catch — a detached HEAD or unreadable fragment silently
+skips the advisory rather than erroring the gate.
+
+## Audit-entry compatibility
+
+Entries gain one key (causalAutopsy: object|null). Existing consumers read
+named keys from these JSON files; an additional key is inert. Parallel-PR
+conflict immunity (per-entry files, #80) and verdict finalization (#844) are
+unchanged — the new field is written before the exit handler finalizes, so
+both the working-tree and staged copies carry it.
+
+## Blast radius
+
+One script, additive. No src/ change, no API, no config, no migration: the
+gate ships inside the repo and every fresh worktree gets it from main on
+branch. Slice 2 (hard-require for fix-class + a report command) is a separate
+decision after the field earns trust and Justin shapes the policy.

--- a/scripts/instar-dev-precommit.js
+++ b/scripts/instar-dev-precommit.js
@@ -278,6 +278,41 @@ try {
 const slug = (freshestTrace && (freshestTrace.slug || freshestTrace.name)) || 'unknown';
 const decision = decideRequirementSet(declaredTier);
 
+// ─── Step 4.55: causal autopsy (directive 2026-06-05) ───────────────────
+// Low-ceremony lanes (Tier-1) ship without an independent reviewer, so the
+// compensating control is a durable causal record per issue: every fix-class
+// commit SHOULD declare what caused the issue it fixes — a prior PR, an
+// environment shift that invalidated old assumptions, plain new code, a
+// latent bug, or honestly unknown. The field rides the decision audit so
+// meta-analysis ("are we converging or playing whack-a-mole?") is a query
+// over .instar/instar-dev-decisions/, not archaeology. ADVISORY in this
+// slice: absence warns on fix-class signals, never blocks. A PRESENT but
+// malformed autopsy blocks — a corrupt record is worse than none.
+const AUTOPSY_ORIGINS = ['prior-pr', 'environment-shift', 'new-code', 'latent', 'unknown'];
+let causalAutopsy = null;
+let autopsyError = null;
+if (freshestTrace && freshestTrace.causalAutopsy !== undefined) {
+  const ca = freshestTrace.causalAutopsy;
+  const validPrs = (a) => Array.isArray(a) && a.length > 0 && a.every((n) => Number.isInteger(n) && n > 0);
+  if (!ca || typeof ca !== 'object' || Array.isArray(ca)) {
+    autopsyError = 'causalAutopsy must be an object: { origin, relatedPrs?, notes? }';
+  } else if (!AUTOPSY_ORIGINS.includes(ca.origin)) {
+    autopsyError = `causalAutopsy.origin must be one of ${AUTOPSY_ORIGINS.join(' | ')} (got ${JSON.stringify(ca.origin)})`;
+  } else if (ca.origin === 'prior-pr' && !validPrs(ca.relatedPrs)) {
+    autopsyError = 'causalAutopsy.origin "prior-pr" requires relatedPrs: a non-empty array of positive PR numbers';
+  } else if (ca.relatedPrs !== undefined && !validPrs(ca.relatedPrs)) {
+    autopsyError = 'causalAutopsy.relatedPrs must be a non-empty array of positive integers when present';
+  } else if (ca.notes !== undefined && typeof ca.notes !== 'string') {
+    autopsyError = 'causalAutopsy.notes must be a string when present';
+  } else {
+    causalAutopsy = {
+      origin: ca.origin,
+      ...(ca.relatedPrs !== undefined ? { relatedPrs: ca.relatedPrs } : {}),
+      ...(ca.notes !== undefined ? { notes: ca.notes } : {}),
+    };
+  }
+}
+
 // AUDIT (all in-scope cases): one JSON line, written regardless of branch.
 // belowFloor = the agent declared UNDER the risk-signaled floor. We never
 // block on it (the mind holds authority) — the record is the backstop.
@@ -291,7 +326,54 @@ const decisionEntryPath = writeDecisionAudit({
   belowFloor,
   files: inScopeFiles.length,
   loc: totalChangedLoc,
+  causalAutopsy,
 });
+// Malformed autopsy blocks AFTER the audit write — the blocked attempt is
+// recorded (verdict 'blocked' via the exit handler), same as every gate
+// refusal. Validated-when-present: absence never reaches this.
+if (autopsyError) {
+  blockCommit(
+    inScopeFiles,
+    `Invalid causalAutopsy in trace: ${autopsyError}\n` +
+    `  Shape: { "origin": "prior-pr|environment-shift|new-code|latent|unknown", "relatedPrs": [123], "notes": "..." }\n` +
+    `  (origin "prior-pr" requires relatedPrs; the field is otherwise optional-but-validated.)`,
+  );
+}
+// Advisory (never blocks): a fix-class commit with NO autopsy gets a loud
+// nudge. Fix-class signal = branch name says fix, or a staged release-note
+// fragment declares change_type: fix.
+if (!causalAutopsy) {
+  let fixClassSignal = false;
+  try {
+    const branch = execSync('git rev-parse --abbrev-ref HEAD', { cwd: ROOT, encoding: 'utf8' }).trim();
+    if (/(^|[\/-])fix([\/-]|$)/i.test(branch)) fixClassSignal = true;
+  } catch { /* detached HEAD / no commits — stay quiet, advisory only */ }
+  if (!fixClassSignal) {
+    try {
+      const staged = execSync('git diff --cached --name-only', { cwd: ROOT, encoding: 'utf8' })
+        .split('\n').map((s) => s.trim()).filter(Boolean);
+      for (const f of staged) {
+        if (!/^upgrades\/next\/.+\.md$/.test(f)) continue;
+        const fp = path.join(ROOT, f);
+        if (fs.existsSync(fp) && /change_type:\s*fix/.test(fs.readFileSync(fp, 'utf8'))) {
+          fixClassSignal = true;
+          break;
+        }
+      }
+    } catch { /* advisory only */ }
+  }
+  if (fixClassSignal) {
+    console.error('');
+    console.error('┌──────────────────────────────────────────────────────────────────┐');
+    console.error('│  ⚠ ADVISORY — fix-class commit with no causalAutopsy in trace.    │');
+    console.error('│    What caused the issue this fixes? Add to your trace JSON:      │');
+    console.error('│    "causalAutopsy": { "origin": "prior-pr|environment-shift|      │');
+    console.error('│      new-code|latent|unknown", "relatedPrs": [N], "notes": "…" }  │');
+    console.error('│    NOT blocked — but the meta-analysis record stays blind here.   │');
+    console.error('└──────────────────────────────────────────────────────────────────┘');
+    console.error('');
+  }
+}
 if (belowFloor) {
   console.error('');
   console.error('┌──────────────────────────────────────────────────────────────────┐');
@@ -814,7 +896,7 @@ function blockCommit(files, reason) {
 // fire, the line just evaporated with the worktree). If the commit is later
 // blocked by the gate, the staged line simply rides the retry commit — both
 // lines describe real gate evaluations.
-function writeDecisionAudit({ slug, suggestedTier, declaredTier, riskFloor, riskFloorReasons, belowFloor, files, loc }) {
+function writeDecisionAudit({ slug, suggestedTier, declaredTier, riskFloor, riskFloorReasons, belowFloor, files, loc, causalAutopsy = null }) {
   try {
     fs.mkdirSync(DECISIONS_DIR, { recursive: true });
     const ts = new Date().toISOString();
@@ -840,6 +922,12 @@ function writeDecisionAudit({ slug, suggestedTier, declaredTier, riskFloor, risk
       belowFloor,
       files,
       loc,
+      // Causal autopsy (directive 2026-06-05): what caused the issue this
+      // commit fixes — prior-pr / environment-shift / new-code / latent /
+      // unknown, with linked PRs. null = not declared (advisory in slice 1).
+      // This is THE meta-analysis substrate: convergence vs whack-a-mole is
+      // a query over these entries, not archaeology.
+      causalAutopsy,
       // Finalized by the process exit handler below: 'pass' when the gate
       // allowed the commit, 'blocked' otherwise. The riding-the-retry design
       // (a blocked evaluation's entry rides the next successful commit, see

--- a/tests/unit/instar-dev-precommit-audit-staging.test.ts
+++ b/tests/unit/instar-dev-precommit-audit-staging.test.ts
@@ -240,3 +240,158 @@ describe('instar-dev pre-commit — decision-audit line rides the commit (self-s
     expect(entry.slug).toBe('pass-fixture');
   });
 });
+
+// ── Causal autopsy (directive 2026-06-05) ─────────────────────────────────
+// Low-ceremony lanes ship without an independent reviewer; the compensating
+// control is a durable causal record per fix: what caused the issue — a
+// prior PR, an environment shift, new code, a latent bug, or unknown. The
+// field rides the decision audit so meta-analysis (convergence vs
+// whack-a-mole) is a query over entries. Slice 1 contract pinned here:
+// present+valid → recorded verbatim; present+malformed → BLOCKED (a corrupt
+// record is worse than none) with the attempt recorded; absent → never
+// blocks, advisory warning only on fix-class signals.
+
+describe('instar-dev pre-commit — causalAutopsy (advisory slice)', () => {
+  let sandbox: string;
+
+  beforeEach(() => {
+    sandbox = fs.mkdtempSync(path.join(os.tmpdir(), 'audit-autopsy-hook-'));
+    execFileSync('git', ['init', '-q'], { cwd: sandbox });
+    execFileSync('git', ['config', 'user.email', 'test@example.com'], { cwd: sandbox });
+    execFileSync('git', ['config', 'user.name', 'test'], { cwd: sandbox });
+    fs.mkdirSync(path.join(sandbox, 'scripts', 'lib'), { recursive: true });
+    fs.mkdirSync(path.join(sandbox, 'docs', 'specs'), { recursive: true });
+    fs.mkdirSync(path.join(sandbox, 'upgrades', 'side-effects'), { recursive: true });
+    fs.mkdirSync(path.join(sandbox, 'upgrades', 'next'), { recursive: true });
+    fs.mkdirSync(path.join(sandbox, '.instar', 'instar-dev-traces'), { recursive: true });
+    fs.mkdirSync(path.join(sandbox, 'src'), { recursive: true });
+    fs.mkdirSync(path.join(sandbox, 'skills', 'instar-dev', 'scripts'), { recursive: true });
+    fs.writeFileSync(
+      path.join(sandbox, 'scripts', 'eli16-overview-check.mjs'),
+      `import path from 'node:path';\n` +
+      `export const MIN_ELI16_CHARS = 800;\n` +
+      `export function checkEli16Overview(specPath) {\n` +
+      `  const eli16Path = path.join(path.dirname(specPath), path.basename(specPath, '.md') + '.eli16.md');\n` +
+      `  return { ok: true, eli16Path, charCount: 9999, minChars: 1 };\n` +
+      `}\n`,
+    );
+    fs.writeFileSync(
+      path.join(sandbox, 'skills', 'instar-dev', 'scripts', 'verify-proposal-derived-runbook.mjs'),
+      'export function verifyProposalDerivedRunbooks() { return { ok: true, reason: "ok" }; }\n',
+    );
+    fs.copyFileSync(
+      path.join(path.dirname(HOOK_SCRIPT), 'lib', 'classify-tier.mjs'),
+      path.join(sandbox, 'scripts', 'lib', 'classify-tier.mjs'),
+    );
+    fs.copyFileSync(HOOK_SCRIPT, path.join(sandbox, 'scripts', 'instar-dev-precommit.js'));
+  });
+
+  afterEach(() => {
+    try { SafeFsExecutor.safeRmSync(sandbox, { recursive: true, force: true, operation: 'tests/unit/instar-dev-precommit-audit-staging.test.ts:cleanup' }); } catch { /* ignore */ }
+  });
+
+  function entryFiles(): string[] {
+    const dir = path.join(sandbox, '.instar', 'instar-dev-decisions');
+    if (!fs.existsSync(dir)) return [];
+    return fs.readdirSync(dir).filter(f => f.endsWith('.json')).sort();
+  }
+
+  function writePassingTier1Fixture(extraTrace: Record<string, unknown> = {}): void {
+    const srcRel = 'src/touched.ts';
+    const eli16Rel = 'upgrades/autopsy-fixture.eli16.md';
+    const seRel = 'upgrades/side-effects/autopsy-fixture.md';
+    fs.writeFileSync(path.join(sandbox, srcRel), '// touched\n');
+    fs.writeFileSync(path.join(sandbox, eli16Rel), 'E'.repeat(900));
+    fs.writeFileSync(path.join(sandbox, seRel), `# Side-Effects Review — autopsy fixture\n\n${'S'.repeat(250)}\n`);
+    fs.writeFileSync(
+      path.join(sandbox, '.instar', 'instar-dev-traces', `${Date.now()}-autopsy-fixture.json`),
+      JSON.stringify({
+        phase: 'complete',
+        slug: 'autopsy-fixture',
+        tier: 1,
+        coveredFiles: [srcRel, eli16Rel, seRel],
+        eli16Path: eli16Rel,
+        sideEffectsPath: seRel,
+        createdAt: new Date().toISOString(),
+        ...extraTrace,
+      }, null, 2),
+    );
+    execFileSync('git', ['add', srcRel, eli16Rel, seRel], { cwd: sandbox });
+  }
+
+  it('a valid causalAutopsy is recorded VERBATIM in the decision entry', async () => {
+    writePassingTier1Fixture({
+      causalAutopsy: {
+        origin: 'prior-pr',
+        relatedPrs: [839, 840],
+        notes: 'release-cadence shift invalidated retry budgets tuned for rare restarts',
+      },
+    });
+    const result = await runHook(process.env, sandbox);
+    expect(result.status).toBe(0);
+
+    const entries = entryFiles();
+    expect(entries.length).toBe(1);
+    const entry = JSON.parse(
+      fs.readFileSync(path.join(sandbox, '.instar', 'instar-dev-decisions', entries[0]), 'utf8'),
+    );
+    expect(entry.causalAutopsy).toEqual({
+      origin: 'prior-pr',
+      relatedPrs: [839, 840],
+      notes: 'release-cadence shift invalidated retry budgets tuned for rare restarts',
+    });
+    expect(entry.verdict).toBe('pass');
+  });
+
+  it('a MALFORMED causalAutopsy blocks the commit and the attempt is recorded as blocked', async () => {
+    writePassingTier1Fixture({
+      causalAutopsy: { origin: 'because-reasons' }, // invalid origin enum
+    });
+    const result = await runHook(process.env, sandbox);
+    expect(result.status).not.toBe(0);
+    expect(result.stderr + result.stdout).toMatch(/causalAutopsy\.origin must be one of/);
+
+    const entries = entryFiles();
+    expect(entries.length).toBe(1);
+    const entry = JSON.parse(
+      fs.readFileSync(path.join(sandbox, '.instar', 'instar-dev-decisions', entries[0]), 'utf8'),
+    );
+    expect(entry.verdict).toBe('blocked');
+    expect(entry.causalAutopsy).toBeNull(); // a corrupt declaration is never recorded as data
+  });
+
+  it('origin "prior-pr" without relatedPrs blocks with a specific message', async () => {
+    writePassingTier1Fixture({ causalAutopsy: { origin: 'prior-pr' } });
+    const result = await runHook(process.env, sandbox);
+    expect(result.status).not.toBe(0);
+    expect(result.stderr + result.stdout).toMatch(/"prior-pr" requires relatedPrs/);
+  });
+
+  it('ABSENT causalAutopsy never blocks; fix-class signal (fragment change_type: fix) warns advisory', async () => {
+    writePassingTier1Fixture(); // no causalAutopsy
+    const fragRel = 'upgrades/next/autopsy-fixture.md';
+    fs.writeFileSync(
+      path.join(sandbox, fragRel),
+      '---\nchange_type: fix\n---\n\n## What Changed\n\nfix fixture\n',
+    );
+    execFileSync('git', ['add', fragRel], { cwd: sandbox });
+
+    const result = await runHook(process.env, sandbox);
+    expect(result.status).toBe(0); // NEVER blocks on absence
+    expect(result.stderr).toMatch(/ADVISORY — fix-class commit with no causalAutopsy/);
+
+    const entries = entryFiles();
+    const entry = JSON.parse(
+      fs.readFileSync(path.join(sandbox, '.instar', 'instar-dev-decisions', entries[0]), 'utf8'),
+    );
+    expect(entry.causalAutopsy).toBeNull();
+    expect(entry.verdict).toBe('pass');
+  });
+
+  it('ABSENT causalAutopsy with no fix-class signal passes with NO advisory noise', async () => {
+    writePassingTier1Fixture();
+    const result = await runHook(process.env, sandbox);
+    expect(result.status).toBe(0);
+    expect(result.stderr).not.toMatch(/causalAutopsy/);
+  });
+});

--- a/upgrades/next/gate-causal-autopsy.md
+++ b/upgrades/next/gate-causal-autopsy.md
@@ -1,0 +1,20 @@
+---
+bump: patch
+---
+
+## What Changed
+
+The instar-dev pre-commit gate accepts an optional `causalAutopsy` field in the trace JSON — { origin: prior-pr | environment-shift | new-code | latent | unknown, relatedPrs, notes } — validates it when present (malformed blocks; absence never does), copies it verbatim into the per-commit decision-audit entry, and prints an advisory nudge on fix-class commits that omit it.
+
+## What to Tell Your User
+
+Every fix can now carry a durable record of what actually caused the issue it fixes. Over time that record shows whether the system is genuinely converging toward stability or just trading one bug for another — analysis that used to require digging through old conversations.
+
+## Summary of New Capabilities
+
+- Causal autopsy per fix, riding the existing decision-audit files — meta-analysis over causes becomes a one-line query.
+- Advisory-first rollout: fix-class commits without an autopsy get a loud nudge, never a block.
+
+## Evidence
+
+Directive from Justin (2026-06-05): with the Tier-1 lane shipping fixes without an independent reviewer, causal autopsies of every issue are the compensating control for convergence. Day-one retro-autopsy of 6 issues found 5 were prior-PR assumptions invalidated by the release-cadence shift — a pattern that currently lives only in session memory. 5 new gate tests pin the contract (valid recorded verbatim / malformed blocks with attempt recorded / prior-pr requires linked PRs / absent never blocks + advisory on fix signal / no noise on non-fix commits); 9/9 in the gate audit suite.


### PR DESCRIPTION
## Problem

Justin's directive (2026-06-05): the Tier-1 lane ships fixes without an independent reviewer, so the compensating control must be a durable causal record per issue — was it caused (even in part) by a previous PR? An environment shift? New code? A latent bug? Without that record, "are we converging or playing whack-a-mole?" is unanswerable except by archaeology through PR bodies and session memories.

Day-one motivating evidence (retro-autopsy of 2026-06-05's six issues): **5 of 6 were prior-PR timing/budget assumptions invalidated by one systemic shift** (release cadence → ~15-min restarts) — a pattern that currently lives only in one agent's session memory.

## Fix (advisory slice 1)

The instar-dev gate's trace JSON accepts an optional `causalAutopsy`:

```json
{ "origin": "prior-pr | environment-shift | new-code | latent | unknown",
  "relatedPrs": [839, 840], "notes": "..." }
```

- **Validated when present** — malformed BLOCKS (a corrupt record poisons the dataset; the attempt is recorded `verdict: blocked` via the existing exit handler). `prior-pr` requires linked PR numbers. `unknown` is fully legitimate — honest ignorance beats guessed causes.
- **Copied verbatim into the per-commit decision-audit entry** — meta-analysis becomes a one-line query over `.instar/instar-dev-decisions/`.
- **Absence NEVER blocks** — fix-class commits (branch or staged fragment signal) get a loud advisory nudge only. The field earns trust before it gains teeth; hard-require is a separate later decision for Justin to shape.

## Tests

5 new (valid→recorded verbatim · malformed→blocked+recorded · prior-pr-without-PRs→specific message · absent+fix-signal→advisory, no block · absent+no-signal→no noise); 9/9 in the gate audit suite.

## ELI16

We let small fixes ship through a fast lane with no second reviewer — fine, IF we compensate somewhere. The compensation is now structural: whoever fixes a bug writes down what actually caused it (a past change, an environment shift, new code, an old latent bug, or honestly "unknown"), and the gate validates that note and files it into the same per-commit audit record it already keeps. Over time those records answer the question that matters: are our fixes making the system more stable, or is each fix just trading one bug for another? The one day we did this analysis by hand, it found something real — five of six bugs weren't new mistakes at all, but old assumptions broken by our release pace speeding up. In this first slice the note is optional: forget it on a fix and the gate nags loudly but lets you through; write a garbage note and it refuses, because a corrupt record is worse than none.

🤖 Generated with [Claude Code](https://claude.com/claude-code)