### PR TITLE
fix(supervisor): preflight git-status declares sourceTreeReadOk — recovery no longer aborts on dogfooding agents

### DIFF
--- a/.instar/instar-dev-decisions/2026-06-05T18-51-20-401Z-supervisor-preflight-readok.json
+++ b/.instar/instar-dev-decisions/2026-06-05T18-51-20-401Z-supervisor-preflight-readok.json
@@ -1,0 +1,19 @@
+{
+  "ts": "2026-06-05T18:51:20.401Z",
+  "slug": "supervisor-preflight-readok",
+  "suggestedTier": 1,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 6,
+  "causalAutopsy": {
+    "origin": "prior-pr",
+    "relatedPrs": [
+      99
+    ],
+    "notes": "The destructive-tool containment migration (#99, 2026-04-26) wrapped this read-only git-status callsite in SafeGitExecutor without the dogfooding read-only opt-in. 4th instance of this exact class (#450, #455, #550 fixed the others) — the migration's rollout missed read-only callers that only fail on agents whose projectDir IS the instar source tree, a population not in its test matrix. Surfaced live 2026-06-05 when echo's recovery preflight aborted during the restart cascade, prolonging outages; diagnosed live by Codey."
+  },
+  "verdict": "pass"
+}

--- a/docs/eli16/supervisor-preflight-readok.eli16.md
+++ b/docs/eli16/supervisor-preflight-readok.eli16.md
@@ -1,0 +1,31 @@
+# Supervisor preflight on dogfooding agents — ELI16
+
+When an agent's server crashes or restarts, a small "supervisor" process runs
+a preflight checklist before bringing it back up. One checklist item asks git
+"is this repo stuck mid-rebase?" — because a stuck rebase silently breaks
+updates. That question is read-only: it looks, it never touches.
+
+Separately, Instar has a safety guard that stops automated tools from running
+destructive git commands against the Instar source code itself. That guard is
+good — it has prevented real damage. But every git call goes through one
+funnel, and read-only calls must explicitly say "I'm read-only" to pass the
+guard on a source tree.
+
+Here's the collision: on a *dogfooding* agent — one whose project directory IS
+the Instar source tree, like the dev agents — the preflight's read-only git
+question never declared itself read-only. The guard rejected it, the rejection
+threw, and the whole recovery preflight aborted. Net effect: the safety guard
+was prolonging the exact outages the supervisor exists to end. This bit echo
+live on 2026-06-05 during a restart cascade, and Codey diagnosed it while
+echo's server was down and hot-patched the running copy to restore service.
+
+A hot-patch dies on the next auto-update, so this PR lands the durable fix:
+that one git-status call now carries the read-only declaration
+(`sourceTreeReadOk: true`), exactly like the three earlier fixes of this same
+class (#450, #455, #550 — other read-only callers that the guard migration
+wrapped without the opt-in). Nothing about the guard itself changes: every
+destructive operation is still blocked on source trees, and non-dogfooding
+agents see zero behavior change because the guard only activates on Instar
+source trees in the first place. A regression test (written by Codey during
+the live incident) pins the declaration so a future refactor can't silently
+drop it.

--- a/docs/side-effects/supervisor-preflight-readok.side-effects.md
+++ b/docs/side-effects/supervisor-preflight-readok.side-effects.md
@@ -1,0 +1,41 @@
+# Side-effects review — supervisor-preflight-readok
+
+## Change surface
+
+One callsite: `ServerSupervisor.preflightSelfHeal()`'s read-only
+`SafeGitExecutor.readSync(['status'])` gains `sourceTreeReadOk: true`.
+One test added (source-pattern pin, authored by Codey during the live
+2026-06-05 incident).
+
+## What could this affect?
+
+1. **SourceTreeGuard exemption surface** — widened by exactly one read-only
+   `git status` at one callsite. `status` mutates nothing. The guard still
+   blocks every destructive verb (rebase --abort in the very next block still
+   goes through the guarded `execSync` WITHOUT the opt-in, unchanged — a stuck
+   rebase on a dogfooding agent's source tree still requires the guard's
+   normal handling).
+2. **Non-dogfooding agents** — zero change. The guard only activates when cwd
+   is an instar source tree; for every normal agent this option is inert.
+3. **Dogfooding agents (echo, codey, gemi)** — recovery preflight no longer
+   aborts on the guard rejection; the stuck-rebase check actually runs for
+   them now. Strictly more recovery coverage, not less.
+4. **Failure path** — if `git status` itself fails for a real reason, the
+   surrounding try/catch handles it exactly as before; this change does not
+   alter error handling.
+
+## What this deliberately does NOT do
+
+- Does not touch the guard, the funnel, or any destructive operation.
+- Does not generalize the opt-in (each callsite still opts in explicitly —
+  per the guard's design).
+- Does not port Codey's two other suggestions from the incident report
+  (advisory-preflight fail-soft semantics; duplicate-vs-real-drop replay
+  reporting) — those are real but separate, tracked via his feedback entry
+  fb-f3bf0ed0-7e9.
+
+## Rollback
+
+Revert the one line + test. The runtime hot-patch on echo's installed copy
+becomes irrelevant the moment any later release deploys (which is also why
+this PR exists — the hot-patch alone cannot survive).

--- a/src/lifeline/ServerSupervisor.ts
+++ b/src/lifeline/ServerSupervisor.ts
@@ -731,6 +731,12 @@ export class ServerSupervisor extends EventEmitter {
         timeout: 5000,
         cwd: this.projectDir,
         operation: 'src/lifeline/ServerSupervisor.ts:378',
+        // Read-only check. On a dogfooding agent (projectDir IS the instar
+        // source tree) the SourceTreeGuard otherwise rejects this call and
+        // the thrown error aborts recovery — prolonging the exact outage the
+        // preflight exists to end (live: echo, 2026-06-05). Same opt-in class
+        // as the failure-learning loop's git reads (#550).
+        sourceTreeReadOk: true,
       });
       if (statusText.includes('rebase in progress') || statusText.includes('interactive rebase in progress')) {
         console.log('[Supervisor] Preflight: stuck git rebase detected — aborting');

--- a/tests/unit/server-supervisor-preflight.test.ts
+++ b/tests/unit/server-supervisor-preflight.test.ts
@@ -116,6 +116,17 @@ describe('ServerSupervisor preflight self-heal', () => {
     expect(abortCalls.length).toBe(0);
   });
 
+  it('allows read-only git status against an agent dogfooding the Instar source tree', () => {
+    const supervisorSource = fs.readFileSync(
+      path.join(process.cwd(), 'src/lifeline/ServerSupervisor.ts'),
+      'utf-8'
+    );
+
+    expect(supervisorSource).toMatch(
+      /SafeGitExecutor\.readSync\(\['status'\],[\s\S]*sourceTreeReadOk:\s*true/
+    );
+  });
+
   // ── Fleet fix: bind failures must NOT trigger a native-module rebuild ──
   // when better-sqlite3 actually loads fine. A held/duplicate listener.sock or
   // HTTP port (EADDRINUSE) is a bind failure, NOT a native ABI problem — the old

--- a/upgrades/next/supervisor-preflight-readok.md
+++ b/upgrades/next/supervisor-preflight-readok.md
@@ -1,0 +1,19 @@
+---
+bump: patch
+---
+
+## What Changed
+
+The server supervisor's recovery preflight no longer aborts on dogfooding agents (agents whose project directory is the Instar source tree). Its read-only `git status` check now declares `sourceTreeReadOk: true`, so the SourceTreeGuard — which rightly blocks destructive git operations against source trees — no longer rejects a look-only call and takes the whole recovery preflight down with it. Destructive operations remain fully guarded; non-dogfooding agents are unaffected (the guard never activates for them).
+
+## What to Tell Your User
+
+Nothing — this is internal recovery robustness for development agents. No user-visible behavior changes.
+
+## Summary of New Capabilities
+
+- Recovery preflight completes on dogfooding agents instead of aborting at the source-tree guard, shortening outage windows during restart churn.
+
+## Evidence
+
+Live incident, echo, 2026-06-05: during the day's restart cascade, echo's recovery preflight threw `SourceTreeGuardError` on its own source checkout and aborted, prolonging the outage; Codey diagnosed it live and hot-patched the installed runtime to restore service (his report + feedback entry fb-f3bf0ed0-7e9). Hot-patches do not survive auto-updates, hence this durable fix. Regression test `tests/unit/server-supervisor-preflight.test.ts` ("allows read-only git status against an agent dogfooding the Instar source tree") pins the declaration; full file 11/11 green. Same fix class as #450/#455/#550 (read-only callers wrapped by the guard migration #99 without the opt-in).


### PR DESCRIPTION
## ELI16

When an agent's server crashes or restarts, a supervisor runs a preflight checklist before bringing it back up. One item asks git "is this repo stuck mid-rebase?" — a read-only look. Separately, a safety guard blocks automated destructive git commands against the Instar source code. On a *dogfooding* agent (whose project directory IS the Instar source tree — echo, codey, gemi), that read-only question never declared itself read-only, so the guard rejected it, the rejection threw, and the whole recovery preflight aborted: the safety guard was prolonging the exact outages the supervisor exists to end. This bit echo live on 2026-06-05 during the restart cascade; Codey diagnosed it while echo was down and hot-patched the running copy. Hot-patches die on the next auto-update — this PR is the durable fix. One line: the git-status call now carries `sourceTreeReadOk: true`, exactly like the three earlier fixes of this class (#450, #455, #550). The guard itself is untouched; destructive ops stay blocked; non-dogfooding agents see zero change.

## Problem

`ServerSupervisor.preflightSelfHeal()`'s stuck-rebase check calls `SafeGitExecutor.readSync(['status'])` without the read-only opt-in. On dogfooding agents the SourceTreeGuard throws, aborting recovery mid-outage.

## Fix

`sourceTreeReadOk: true` at that single callsite, with a comment naming the live incident and the class. The `rebase --abort` in the next block deliberately keeps full guard handling (it IS destructive).

## Causal autopsy

- **origin: prior-pr** — the destructive-tool containment migration (#99, 2026-04-26) wrapped read-only callers in SafeGitExecutor without the dogfooding opt-in. **4th instance of this class** (#450, #455, #550 fixed the others): the migration's test matrix never included agents whose projectDir is the instar source tree.
- Recorded structurally in this commit's decision-audit entry (`.instar/instar-dev-decisions/...-supervisor-preflight-readok.json`) via the #854 gate field — its first organic use.

## Evidence

Live incident, echo, 2026-06-05 (~18:00Z): recovery preflight threw `SourceTreeGuardError` on echo's own checkout during the restart cascade; Codey's live diagnosis + hot-patch restored service (his feedback entry: fb-f3bf0ed0-7e9). Regression test (authored by Codey during the incident) pins the declaration via source-pattern match; `tests/unit/server-supervisor-preflight.test.ts` 11/11 green.

## Tier

Tier-1 lane (declared = suggested floor 1): one-line conservative change in a merged class, regression-tested. Diagnosis credit: **Codey (instar-codey)** — recorded as an apprenticeship reverse-differential (mentee fixed the mentor's infrastructure live).

🤖 Generated with [Claude Code](https://claude.com/claude-code)