### PR TITLE
fix(git): skip agent-local state in sync

### DIFF
--- a/.instar/instar-dev-decisions/2026-06-05T19-26-38-202Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-06-05T19-26-38-202Z-unknown.json
@@ -1,0 +1,14 @@
+{
+  "ts": "2026-06-05T19:26:38.202Z",
+  "slug": "unknown",
+  "suggestedTier": 2,
+  "declaredTier": 2,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "new capability: new config key added"
+  ],
+  "belowFloor": false,
+  "files": 2,
+  "loc": 156,
+  "verdict": "pass"
+}

--- a/.instar/instar-dev-decisions/2026-06-05T19-44-48-255Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-06-05T19-44-48-255Z-unknown.json
@@ -1,0 +1,12 @@
+{
+  "ts": "2026-06-05T19:44:48.255Z",
+  "slug": "unknown",
+  "suggestedTier": 1,
+  "declaredTier": 2,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 2,
+  "loc": 4,
+  "verdict": "pass"
+}

--- a/docs/specs/git-hygiene-sentinel.eli16.md
+++ b/docs/specs/git-hygiene-sentinel.eli16.md
@@ -1,0 +1,26 @@
+# ELI16: Git Hygiene Sentinel
+
+Instar stores many things under `.instar/`. Some are real shared state, like
+jobs or registries. Some are local working files, like session logs, inbound
+Telegram message files, reports, shadow installs, and private config. Those
+local files should stay on the machine that made them.
+
+The bug is that GitSync used a broad staging command for `.instar/`. If a local
+runtime file was already tracked, `.gitignore` alone was not enough. Git would
+keep seeing the tracked file as changed, and the next sync could commit it
+again.
+
+This fix makes GitSync look at the actual dirty paths before staging. For each
+dirty path, it asks the file classifier whether the path is safe to sync. Normal
+state can still be committed. Runtime directories and secret-bearing config are
+skipped. Deletions are still allowed, because agents need to be able to remove
+bad tracked files from history going forward.
+
+There is one important parsing detail. Git's machine-readable status format uses
+leading spaces as meaningful status characters. The existing helper trims output,
+which would corrupt that format. The fix uses a raw helper for this one status
+call so the parser sees exactly what Git printed.
+
+The result is that cleaning one checkout is no longer a one-off repair. The
+product now has a guardrail that keeps future agent-local state from being
+staged by broad GitSync commits.

--- a/docs/specs/git-hygiene-sentinel.md
+++ b/docs/specs/git-hygiene-sentinel.md
@@ -1,0 +1,98 @@
+---
+title: Git hygiene sentinel for agent-local Instar state
+parent-principle: "Structure beats Willpower"
+approved: true
+eli16-overview: git-hygiene-sentinel.eli16.md
+review-convergence: "2026-06-05T19:25:13.297Z"
+review-iterations: 2
+review-completed-at: "2026-06-05T19:25:13.297Z"
+review-report: "docs/specs/reports/git-hygiene-sentinel-convergence.md"
+cross-model-review: "unavailable"
+cross-model-review-reason: "codex-auth-apikey-forbidden"
+---
+
+# Git Hygiene Sentinel for Agent-Local Instar State
+
+## Problem
+
+Instar agents can accumulate local runtime state under `.instar/` and adjacent
+agent config files. Some of that state is durable source-like state that should
+sync. Some of it is generated, private, machine-local, or secret-bearing. A broad
+`git add .instar` collapses that distinction and can repeatedly stage already
+tracked runtime files even after a `.gitignore` is corrected.
+
+The observed failure in the Codey checkout was a repository with many tracked
+local artifacts: Telegram inbound files, sessions, reports, local config,
+machine identity, and similar runtime state. The near-term repair can clean one
+checkout, but the product needs to stop future agents from recreating the same
+class of history.
+
+## Constitutional Fit
+
+Parent principle: **Structure beats Willpower**.
+
+The fix turns "remember not to stage local runtime state" into a structural
+GitSync boundary. Agents should still maintain clean checkouts, but the product
+must not rely on attention or local `.gitignore` hygiene when a broad sync path
+can enforce the rule mechanically.
+
+## Scope
+
+This change updates the git-sync staging path and file classifier only:
+
+- Classify known Instar agent-local runtime directories as generated/excluded.
+- Classify known Instar agent-local secret/config paths as never-sync.
+- Match classifier patterns against both basenames and repo-relative paths.
+- Before `GitSyncManager` stages files, ask `git status --porcelain -z` for the
+  requested path scope and classify each dirty path.
+- Skip non-delete dirty paths whose classification is `exclude` or `never-sync`.
+- Allow deletions of excluded/secret paths so a cleanup commit can untrack bad
+  historical files.
+- Keep old add/diff behavior when Git reports no dirty entries for the requested
+  path scope.
+
+## Non-Goals
+
+- Do not rewrite existing repository histories.
+- Do not push repaired branches automatically.
+- Do not make `.instar/config.json`, `.claude.json`, `.mcp.json`, agent tokens,
+  machine identities, Telegram inbound files, sessions, reports, or shadow
+  installs syncable.
+- Do not change conflict resolution behavior for files that are already staged
+  by another caller.
+- Do not replace external secret scanning tools.
+
+## Acceptance Criteria
+
+- `.instar/config.json`, `.instar/config.json.*`, `.instar/identity.json`,
+  `.instar/agent-tokens/`, `.instar/cloudflared-*.yml`, `.claude.json`, and
+  `.mcp.json` classify as `secret` / `never-sync`.
+- `.instar/messages/`, `.instar/reports/`, `.instar/sessions/`,
+  `.instar/shadow-install*`, `.instar/telegram-inbound/`, and `.instar/views/`
+  classify as generated / excluded.
+- A git-sync commit over `.instar/` stages legitimate state such as
+  `.instar/jobs.json` while skipping local secret/runtime paths.
+- Deletions remain stageable even when the deleted path would otherwise be
+  `exclude` or `never-sync`.
+- `git status --porcelain -z` output is parsed without trimming, because leading
+  spaces are meaningful status bytes.
+- Rename/copy entries in `git status --porcelain -z` stage the destination path,
+  not the source path.
+- Focused unit tests for `FileClassifier` and `GitSyncManager` pass.
+- TypeScript typecheck passes.
+
+## Direction of Failure
+
+If the classifier over-blocks a legitimate local state file, that file remains
+local and unsynced; GitSync emits a degradation report with the skipped path and
+reason. This is preferable to committing local secrets or high-churn runtime
+state.
+
+If the classifier under-blocks a new local runtime path, the previous risk
+remains for that path only. The remedy is additive: add the path pattern to
+`FileClassifier` and test it.
+
+## Rollback
+
+Rollback is a pure code revert of `FileClassifier`, `GitSync`, and the related
+unit tests. No schema or migration is introduced.

--- a/docs/specs/reports/git-hygiene-sentinel-convergence.md
+++ b/docs/specs/reports/git-hygiene-sentinel-convergence.md
@@ -1,0 +1,93 @@
+# Spec Convergence Report — Git hygiene sentinel
+
+**Spec:** `docs/specs/git-hygiene-sentinel.md`
+**Date:** `2026-06-05`
+**Reviewer:** `instar-codey`
+**External cross-model posture:** unavailable (`codex-auth-apikey-forbidden`)
+
+## Result
+
+Converged for this implementation pass.
+
+No material findings remain after implementation and focused verification.
+
+## Review Pass
+
+### Security / privacy
+
+The change moves the automatic sync path away from broad `.instar/` staging and
+toward path-by-path classification. Known local secret paths classify
+`never-sync`; known local runtime paths classify `exclude`. Deletions remain
+stageable so cleanup commits can remove historically tracked bad files.
+
+Residual risk: new local runtime directories not represented in
+`FileClassifier` can still be staged. This is an additive maintenance risk, not
+a regression from the current behavior.
+
+### Integration
+
+The implementation stays within existing layers:
+
+- `FileClassifier` owns path strategy.
+- `GitSyncManager` owns staging.
+- `DegradationReporter` surfaces skipped-path decisions.
+
+No route, config, schema, or dashboard contract changes.
+
+### Failure direction
+
+Over-block leaves a file local and emits a degradation report. Under-block can
+still stage a newly introduced local path family. Given the incident that drove
+this change was accidental inclusion of local artifacts, this direction is the
+right default.
+
+### Verification
+
+- Focused unit tests:
+  `./node_modules/.bin/vitest run tests/unit/file-classifier.test.ts tests/unit/GitSync.test.ts`
+  passed, 137 tests.
+- CI failure reproductions:
+  `./node_modules/.bin/vitest run tests/e2e/sync-edge-cases.test.ts tests/unit/no-silent-fallbacks.test.ts tests/unit/file-classifier.test.ts tests/unit/GitSync.test.ts`
+  passed, 191 tests.
+- Typecheck:
+  `pnpm exec tsc --noEmit` passed.
+- Build:
+  `pnpm build` passed. It warned that uncommitted source changes can make the
+  generated manifest differ from committed source, and warned that no local
+  release signing key was available. Both are expected in this development
+  worktree.
+
+### Non-material observations
+
+An accidental broad test invocation ran unrelated suites and hit existing E2E
+session-management timeouts before being stopped. The focused tests and
+typecheck are the verification signal for this change.
+
+## Second-Pass Finding and Resolution
+
+Independent second-pass review initially raised one material concern:
+`git status --porcelain -z` rename/copy entries were parsed backwards. In NUL
+mode Git emits the destination path first and the source path second. The first
+implementation advanced to the second field, which would classify/stage the old
+source path instead of the destination.
+
+Resolution:
+
+- `GitSyncManager.syncEligibleDirtyPaths` now keeps the first path for rename
+  and copy records and skips the following source-path field.
+- `tests/unit/GitSync.test.ts` now covers rename destination staging, deletion
+  allowance for a `never-sync` path, and fallback behavior when the status
+  lookup fails.
+
+## CI Follow-Up
+
+The first PR CI run exposed two additional regressions:
+
+- The older sync edge-case test still expected `.instar/config.json` to be
+  structured data. The new product behavior deliberately treats that path as
+  secret / never-sync, so the test now uses `.instar/jobs.json` as the normal
+  structured state example.
+- The no-silent-fallback ratchet counted an existing binary-stage inspection
+  fallback in `FileClassifier` after nearby edits shifted its detection window.
+  That catch now carries the explicit exemption marker because it escalates to
+  conflict resolution rather than silently accepting a binary merge.

--- a/src/core/FileClassifier.ts
+++ b/src/core/FileClassifier.ts
@@ -130,6 +130,25 @@ const DEFAULT_GENERATED_PATTERNS = [
   // resolution. See docs/specs/integrated-being-ledger-v1.md §Multi-machine.
   '.instar/shared-state.jsonl',
   '.instar/shared-state.jsonl.*',
+  // Agent-local runtime and generated state. These may be valuable locally, but
+  // they are not source-controlled sync artifacts.
+  '.instar/autonomous/',
+  '.instar/backups/',
+  '.instar/bin/',
+  '.instar/episodes/',
+  '.instar/hook-events/',
+  '.instar/ledger/',
+  '.instar/logs/',
+  '.instar/messages/',
+  '.instar/reports/',
+  '.instar/server-data/',
+  '.instar/sessions/',
+  '.instar/shadow-install*',
+  '.instar/telegram-images/',
+  '.instar/telegram-inbound/',
+  '.instar/threadline/',
+  '.instar/views/',
+  '.instar/worktree-monitor/',
 ];
 
 const DEFAULT_SECRET_PATTERNS = [
@@ -138,6 +157,16 @@ const DEFAULT_SECRET_PATTERNS = [
   '*credentials*', '*secret*',
   'id_rsa', 'id_ed25519', 'id_ecdsa',
   '.npmrc',  // may contain tokens
+  '.claude.json',
+  '.mcp.json',
+  '.instar/agent-tokens/',
+  '.instar/cloudflared-*.yml',
+  '.instar/config.json',
+  '.instar/config.json.*',
+  '.instar/identity.json',
+  '.instar/machine/identity.json',
+  '.instar/machine/*key*',
+  '.instar/secrets/',
 ];
 
 const SOURCE_CODE_EXTENSIONS = new Set([
@@ -375,6 +404,8 @@ export class FileClassifier {
         reason: 'Both sides modified the binary file — needs human decision',
       };
     } catch {
+      // @silent-fallback-ok — inability to inspect binary stages escalates to
+      // conflict resolution, not a silent accept.
       return { resolution: 'conflict', reason: 'Error reading git stages for binary file' };
     }
   }
@@ -382,23 +413,9 @@ export class FileClassifier {
   // ── Private Helpers ────────────────────────────────────────────────
 
   private isSecret(relPath: string, basename: string): boolean {
+    const normalized = relPath.replace(/\\/g, '/');
     for (const pattern of this.secretPatterns) {
-      if (pattern.startsWith('*') && pattern.endsWith('*')) {
-        // *pattern* → contains
-        const inner = pattern.slice(1, -1);
-        if (basename.toLowerCase().includes(inner)) return true;
-      } else if (pattern.startsWith('*.')) {
-        // *.ext → extension match
-        const ext = pattern.slice(1);
-        if (basename.endsWith(ext)) return true;
-      } else if (pattern.includes('.*')) {
-        // .env.* → prefix match
-        const prefix = pattern.split('.*')[0];
-        if (basename.startsWith(prefix)) return true;
-      } else {
-        // Exact match
-        if (basename === pattern) return true;
-      }
+      if (this.matchesPattern(normalized, basename, pattern)) return true;
     }
     return false;
   }
@@ -406,18 +423,36 @@ export class FileClassifier {
   private isGenerated(relPath: string): boolean {
     const normalized = relPath.replace(/\\/g, '/');
     for (const pattern of this.generatedPatterns) {
-      if (pattern.endsWith('/')) {
-        // Directory pattern
-        if (normalized.startsWith(pattern) || normalized.includes('/' + pattern)) return true;
-      } else if (pattern.startsWith('*.')) {
-        // Extension glob
-        const ext = pattern.slice(1);
-        if (normalized.endsWith(ext)) return true;
-      } else {
-        if (normalized === pattern || normalized.endsWith('/' + pattern)) return true;
-      }
+      if (this.matchesPattern(normalized, path.basename(normalized), pattern)) return true;
     }
     return false;
+  }
+
+  private matchesPattern(normalizedRelPath: string, basename: string, pattern: string): boolean {
+    const normalizedPattern = pattern.replace(/\\/g, '/');
+    const lowerBase = basename.toLowerCase();
+    const lowerRel = normalizedRelPath.toLowerCase();
+    const lowerPattern = normalizedPattern.toLowerCase();
+
+    if (lowerPattern.endsWith('/')) {
+      return lowerRel.startsWith(lowerPattern) || lowerRel.includes('/' + lowerPattern);
+    }
+
+    if (lowerPattern.startsWith('*.')) {
+      return lowerBase.endsWith(lowerPattern.slice(1));
+    }
+
+    if (lowerPattern.startsWith('*') && lowerPattern.endsWith('*')) {
+      return lowerBase.includes(lowerPattern.slice(1, -1));
+    }
+
+    if (lowerPattern.includes('*')) {
+      const escaped = lowerPattern.replace(/[.+?^${}()|[\]\\]/g, '\\$&').replace(/\*/g, '.*');
+      const re = new RegExp(`^${escaped}$`);
+      return re.test(lowerRel) || re.test(lowerBase);
+    }
+
+    return lowerBase === lowerPattern || lowerRel === lowerPattern || lowerRel.endsWith('/' + lowerPattern);
   }
 
   private isLockfile(basename: string): string | null {

--- a/src/core/GitSync.ts
+++ b/src/core/GitSync.ts
@@ -517,7 +517,8 @@ export class GitSyncManager {
    * Stage files and commit with machine signing.
    */
   commitAndPush(message: string, paths?: string[]): boolean {
-    const filesToAdd = paths || [this.stateDir];
+    const filesToAdd = this.syncEligibleDirtyPaths(paths || [this.stateDir]);
+    if (filesToAdd.length === 0) return false;
 
     try {
       for (const p of filesToAdd) {
@@ -539,6 +540,66 @@ export class GitSyncManager {
       // @silent-fallback-ok — push failure boolean return
       return false;
     }
+  }
+
+  /**
+   * Return dirty paths that are eligible for git-sync staging.
+   *
+   * The important distinction: `.instar/` contains both source-like state that
+   * should sync (jobs, identity docs, durable registries) and local runtime or
+   * secret material that must never be swept into Git. `git add .instar` erases
+   * that boundary, especially for repos that already tracked bad paths before a
+   * newer .gitignore existed. Enumerating porcelain status first lets the
+   * FileClassifier make the sync decision path-by-path.
+   */
+  private syncEligibleDirtyPaths(paths: string[]): string[] {
+    const args = ['status', '--porcelain', '-z', '--', ...paths];
+    let raw = '';
+    try {
+      raw = this.gitExecRaw(args);
+    } catch {
+      // @silent-fallback-ok — status preflight failure preserves the previous
+      // broad add/diff behavior rather than disabling GitSync entirely.
+      return paths;
+    }
+
+    const eligible: string[] = [];
+    const seen = new Set<string>();
+    const entries = raw.split('\0').filter(Boolean);
+    if (entries.length === 0) return paths;
+
+    for (let i = 0; i < entries.length; i++) {
+      const entry = entries[i];
+      if (entry.length < 4) continue;
+
+      const status = entry.slice(0, 2);
+      let relPath = entry.slice(3);
+      if ((status[0] === 'R' || status[0] === 'C') && entries[i + 1]) {
+        // In porcelain -z mode, rename/copy records emit the destination path
+        // first, followed by the source path as the next NUL-delimited field.
+        i++;
+      }
+
+      if (!relPath || seen.has(relPath)) continue;
+      seen.add(relPath);
+
+      const deleting = status.includes('D');
+      const classification = this.fileClassifier.classify(path.join(this.projectDir, relPath));
+      if (!deleting && (classification.strategy === 'never-sync' || classification.strategy === 'exclude')) {
+        DegradationReporter.getInstance().report({
+          feature: 'GitSync.gitHygiene',
+          primary: `Stage ${relPath}`,
+          fallback: 'Skip local-only or secret path',
+          reason: classification.reason,
+          impact: `${relPath} remains local and is not included in git-sync commits.`,
+        });
+        continue;
+      }
+
+      eligible.push(relPath);
+    }
+
+    return eligible;
   }
 
   /**
@@ -1129,6 +1190,16 @@ export class GitSyncManager {
       stdio: ['pipe', 'pipe', 'pipe'],
       operation: 'src/core/GitSync.ts:gitExec',
     }).trim();
+  }
+
+  private gitExecRaw(args: string[]): string {
+    return SafeGitExecutor.run(args, {
+      cwd: this.projectDir,
+      encoding: 'utf-8',
+      timeout: 30_000,
+      stdio: ['pipe', 'pipe', 'pipe'],
+      operation: 'src/core/GitSync.ts:gitExecRaw',
+    });
   }
 
   private gitConfig(key: string, value: string): void {

--- a/tests/e2e/sync-edge-cases.test.ts
+++ b/tests/e2e/sync-edge-cases.test.ts
@@ -507,7 +507,7 @@ describe('FileClassifier Edge Cases', () => {
 
   it('classifies structured data files under .instar/', () => {
     // Only .instar/ state files are classified as structured-data
-    const structured = ['.instar/config.json', '.instar/state/settings.yaml'];
+    const structured = ['.instar/jobs.json', '.instar/state/settings.yaml'];
 
     for (const file of structured) {
       const fullPath = path.join(tmpDir, file);

--- a/tests/unit/GitSync.test.ts
+++ b/tests/unit/GitSync.test.ts
@@ -4,6 +4,20 @@ import path from 'node:path';
 import os from 'node:os';
 import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
 
+const { classifyMock } = vi.hoisted(() => ({
+  classifyMock: vi.fn((filePath: string) => {
+    if (
+      filePath.includes('.instar/config.json') ||
+      filePath.includes('.instar/identity.json') ||
+      filePath.includes('.instar/messages/') ||
+      filePath.includes('.instar/sessions/')
+    ) {
+      return { strategy: filePath.includes('config') || filePath.includes('identity') ? 'never-sync' : 'exclude' };
+    }
+    return { strategy: 'programmatic' };
+  }),
+}));
+
 // Mock child_process before importing GitSyncManager
 vi.mock('node:child_process', () => ({
   execFileSync: vi.fn(() => ''),
@@ -21,7 +35,7 @@ vi.mock('../../src/monitoring/DegradationReporter.js', () => ({
 // Mock FileClassifier to avoid complex dependency chain
 vi.mock('../../src/core/FileClassifier.js', () => ({
   FileClassifier: vi.fn().mockImplementation(() => ({
-    classify: vi.fn(() => ({ strategy: 'programmatic' })),
+    classify: classifyMock,
     regenerateLockfile: vi.fn(() => ({ success: false })),
     resolveBinary: vi.fn(() => ({ resolution: 'conflict' })),
   })),
@@ -103,11 +117,12 @@ describe('GitSyncManager', () => {
     vi.useFakeTimers();
     vi.mocked(execFileSync).mockReset();
     vi.mocked(execFileSync).mockReturnValue('');
+    classifyMock.mockClear();
   });
 
   afterEach(() => {
     vi.useRealTimers();
-    vi.restoreAllMocks();
+    vi.clearAllMocks();
     try {
       SafeFsExecutor.safeRmSync(tmpDir, { recursive: true, force: true, operation: 'tests/unit/GitSync.test.ts:106' });
     } catch { /* cleanup best-effort */ }
@@ -121,6 +136,7 @@ describe('GitSyncManager', () => {
       const manager = new GitSyncManager(config);
       // Verify via commitAndPush behavior: when autoPush is true, it calls git push
       vi.mocked(execFileSync)
+        .mockReturnValueOnce('') // git status --porcelain -z (no scoped entries; preserve existing add/diff path)
         .mockReturnValueOnce('') // git add
         .mockReturnValueOnce('some-file.json\n') // git diff --cached --name-only (staged files exist)
         .mockReturnValueOnce('') // git commit
@@ -139,6 +155,7 @@ describe('GitSyncManager', () => {
       const manager = new GitSyncManager(config);
 
       vi.mocked(execFileSync)
+        .mockReturnValueOnce('') // git status --porcelain -z
         .mockReturnValueOnce('') // git add
         .mockReturnValueOnce('some-file.json\n') // git diff --cached
         .mockReturnValueOnce(''); // git commit
@@ -418,6 +435,7 @@ describe('GitSyncManager', () => {
     it('returns false when nothing is staged', () => {
       const manager = new GitSyncManager(createConfig());
       vi.mocked(execFileSync)
+        .mockReturnValueOnce('') // git status --porcelain -z
         .mockReturnValueOnce('') // git add
         .mockReturnValueOnce(''); // git diff --cached --name-only (empty)
 
@@ -428,6 +446,7 @@ describe('GitSyncManager', () => {
     it('returns true on successful commit', () => {
       const manager = new GitSyncManager(createConfig());
       vi.mocked(execFileSync)
+        .mockReturnValueOnce('') // git status --porcelain -z
         .mockReturnValueOnce('') // git add
         .mockReturnValueOnce('file.json\n') // git diff --cached
         .mockReturnValueOnce('') // git commit
@@ -512,6 +531,7 @@ describe('GitSyncManager', () => {
       const manager = new GitSyncManager(config);
       vi.mocked(execFileSync).mockImplementation((_cmd, args) => {
         const a = args as string[];
+        if (a[0] === 'status' && a.includes('--porcelain')) return ' M .instar/jobs.json\0';
         if (a[0] === 'diff' && a.includes('--cached')) return 'file.json\n';
         return '';
       });
@@ -525,6 +545,95 @@ describe('GitSyncManager', () => {
         (call) => call[0] === 'git' && (call[1] as string[])[0] === 'commit'
       );
       expect(commitCalls.length).toBe(1);
+    });
+
+    it('skips agent-local secret/runtime paths while staging legitimate state', () => {
+      const config = createConfig({ debounceMs: 60_000 });
+      const manager = new GitSyncManager(config);
+      vi.mocked(execFileSync).mockImplementation((_cmd, args) => {
+        const a = args as string[];
+        if (a[0] === 'status' && a.includes('--porcelain')) {
+          return [
+            ' M .instar/config.json',
+            '?? .instar/messages/store/topic.jsonl',
+            '?? .instar/sessions/session-1/summary.json',
+            ' M .instar/jobs.json',
+          ].join('\0') + '\0';
+        }
+        if (a[0] === 'diff' && a.includes('--cached')) return '.instar/jobs.json\n';
+        return '';
+      });
+
+      manager.queueAutoCommit(path.join(tmpDir, '.instar'));
+      manager.stop();
+
+      const addCalls = vi.mocked(execFileSync).mock.calls
+        .filter((call) => call[0] === 'git' && (call[1] as string[])[0] === 'add')
+        .map((call) => (call[1] as string[])[1]);
+
+      expect(addCalls).toEqual(['.instar/jobs.json']);
+    });
+
+    it('stages rename destinations from porcelain -z status', () => {
+      const config = createConfig({ debounceMs: 60_000 });
+      const manager = new GitSyncManager(config);
+      vi.mocked(execFileSync).mockImplementation((_cmd, args) => {
+        const a = args as string[];
+        if (a[0] === 'status' && a.includes('--porcelain')) {
+          return 'R  .instar/jobs-renamed.json\0.instar/config.json\0';
+        }
+        if (a[0] === 'diff' && a.includes('--cached')) return '.instar/jobs-renamed.json\n';
+        return '';
+      });
+
+      manager.queueAutoCommit(path.join(tmpDir, '.instar'));
+      manager.stop();
+
+      const addCalls = vi.mocked(execFileSync).mock.calls
+        .filter((call) => call[0] === 'git' && (call[1] as string[])[0] === 'add')
+        .map((call) => (call[1] as string[])[1]);
+
+      expect(addCalls).toEqual(['.instar/jobs-renamed.json']);
+    });
+
+    it('allows deletions of paths that otherwise classify never-sync', () => {
+      const config = createConfig({ debounceMs: 60_000 });
+      const manager = new GitSyncManager(config);
+      vi.mocked(execFileSync).mockImplementation((_cmd, args) => {
+        const a = args as string[];
+        if (a[0] === 'status' && a.includes('--porcelain')) return ' D .instar/config.json\0';
+        if (a[0] === 'diff' && a.includes('--cached')) return '.instar/config.json\n';
+        return '';
+      });
+
+      manager.queueAutoCommit(path.join(tmpDir, '.instar'));
+      manager.stop();
+
+      const addCalls = vi.mocked(execFileSync).mock.calls
+        .filter((call) => call[0] === 'git' && (call[1] as string[])[0] === 'add')
+        .map((call) => (call[1] as string[])[1]);
+
+      expect(addCalls).toEqual(['.instar/config.json']);
+    });
+
+    it('falls back to original paths when dirty status lookup fails', () => {
+      const config = createConfig({ debounceMs: 60_000 });
+      const manager = new GitSyncManager(config);
+      vi.mocked(execFileSync).mockImplementation((_cmd, args) => {
+        const a = args as string[];
+        if (a[0] === 'status' && a.includes('--porcelain')) throw new Error('status failed');
+        if (a[0] === 'diff' && a.includes('--cached')) return '.instar/jobs.json\n';
+        return '';
+      });
+
+      manager.queueAutoCommit(path.join(tmpDir, '.instar'));
+      manager.stop();
+
+      const addCalls = vi.mocked(execFileSync).mock.calls
+        .filter((call) => call[0] === 'git' && (call[1] as string[])[0] === 'add')
+        .map((call) => (call[1] as string[])[1]);
+
+      expect(addCalls).toEqual([path.join(tmpDir, '.instar')]);
     });
   });
 

--- a/tests/unit/file-classifier.test.ts
+++ b/tests/unit/file-classifier.test.ts
@@ -255,6 +255,22 @@ describe('FileClassifier', () => {
       expect(result.fileClass).toBe('secret');
       expect(result.strategy).toBe('never-sync');
     });
+
+    it.each([
+      '.instar/config.json',
+      '.instar/config.json.backup',
+      '.instar/identity.json',
+      '.instar/agent-tokens/instar-codey.token',
+      '.instar/cloudflared-quick.yml',
+      '.claude.json',
+      '.mcp.json',
+    ])('classifies agent-local secret path %s as never-sync', (relPath) => {
+      const classifier = makeClassifier(tmpDir);
+      const result = classifier.classify(path.join(tmpDir, relPath));
+
+      expect(result.fileClass).toBe('secret');
+      expect(result.strategy).toBe('never-sync');
+    });
   });
 
   // ── Structured Data Classification ───────────────────────────────
@@ -283,6 +299,21 @@ describe('FileClassifier', () => {
       // JSON outside .instar/ isn't guaranteed to have a programmatic strategy
       // It falls through to source code
       expect(result.strategy).toBe('llm');
+    });
+
+    it.each([
+      '.instar/messages/store/topic.jsonl',
+      '.instar/reports/check.md',
+      '.instar/sessions/session-1/summary.json',
+      '.instar/shadow-install/node_modules/instar/package.json',
+      '.instar/telegram-inbound/msg.txt',
+      '.instar/views/view.json',
+    ])('classifies agent-local runtime path %s as generated/excluded', (relPath) => {
+      const classifier = makeClassifier(tmpDir);
+      const result = classifier.classify(path.join(tmpDir, relPath));
+
+      expect(result.fileClass).toBe('generated');
+      expect(result.strategy).toBe('exclude');
     });
   });
 

--- a/upgrades/next/git-hygiene-sentinel.md
+++ b/upgrades/next/git-hygiene-sentinel.md
@@ -1,0 +1,55 @@
+# Upgrade Guide — vNEXT
+
+<!-- bump: patch -->
+
+## What Changed
+
+GitSync now filters broad Instar state commits path by path before staging. It
+uses the existing file classifier to skip local runtime directories and
+secret-bearing agent config, while still allowing legitimate shared state to
+sync.
+
+This closes a git hygiene failure mode where a tracked local runtime file could
+keep being staged by a broad Instar state sync even after ignore rules were
+corrected. The classifier now recognizes Instar-local runtime paths, local
+agent config, token directories, machine identity files, Telegram inbound files,
+session files, reports, views, and shadow installs.
+
+Cleanup remains possible: deletions of local-only paths are still stageable so
+agents can remove previously tracked bad files.
+
+## What to Tell Your User
+
+- **Cleaner automatic syncs**: "I’m less likely to accidentally carry local
+  runtime files or private agent configuration into source control when I sync
+  my own state."
+
+## Summary of New Capabilities
+
+| Capability | How to Use |
+|-----------|-----------|
+| GitSync local-state hygiene guard | Automatic during Instar state sync |
+| Instar-local runtime classification | Automatic in file classification and sync staging |
+| Cleanup-safe local-only deletions | Automatic when a cleanup commit removes previously tracked local-only files |
+
+## Evidence
+
+The local Codey checkout reproduced the failure class with hundreds of dirty or
+tracked local artifacts, including Telegram inbound files, sessions, reports,
+runtime ledgers, identity/config material, and generated cache state. A broad
+state add would not distinguish legitimate shared state from these local-only
+paths.
+
+The product change was verified in an isolated Instar worktree with focused
+tests covering agent-local secret/runtime classification, legitimate state
+staging, rename destination parsing, deletion allowance, and status-failure
+fallback behavior. The focused run passed 137 tests across FileClassifier and
+GitSync.
+
+After the first PR CI run, two additional regressions were reproduced locally:
+an older sync edge-case fixture still treated local config as normal structured
+data, and the no-silent-fallback ratchet counted an existing binary conflict
+fallback after nearby edits shifted its detection window. Both were fixed, and
+the expanded local verification passed 191 tests across the edge-case,
+no-silent-fallback, FileClassifier, and GitSync suites. TypeScript typecheck
+passed, and the full build completed successfully.

--- a/upgrades/side-effects/git-hygiene-sentinel.md
+++ b/upgrades/side-effects/git-hygiene-sentinel.md
@@ -1,0 +1,148 @@
+# Side-Effects Review — Git hygiene sentinel for agent-local Instar state
+
+**Version / slug:** `git-hygiene-sentinel`
+**Date:** `2026-06-05`
+**Author:** `instar-codey`
+**Second-pass reviewer:** `required before merge if policy requires an
+independent maintainer read; implementation is otherwise covered by focused
+tests and typecheck`
+
+## Summary of the change
+
+This change prevents `GitSyncManager` from sweeping local-only or secret-bearing
+agent state into commits when staging broad `.instar/` scopes.
+
+What lands:
+
+- `src/core/FileClassifier.ts`
+  - Adds Instar-specific runtime/generated patterns such as `.instar/messages/`,
+    `.instar/reports/`, `.instar/sessions/`, `.instar/shadow-install*`,
+    `.instar/telegram-inbound/`, and `.instar/views/`.
+  - Adds Instar-specific secret patterns such as `.instar/config.json`,
+    `.instar/config.json.*`, `.instar/identity.json`, `.instar/agent-tokens/`,
+    `.instar/cloudflared-*.yml`, `.claude.json`, and `.mcp.json`.
+  - Matches patterns against both basenames and normalized repo-relative paths.
+- `src/core/GitSync.ts`
+  - Replaces broad direct staging with `syncEligibleDirtyPaths`.
+  - Uses raw `git status --porcelain -z -- <paths...>` output to enumerate dirty
+    paths without corrupting leading-space status bytes.
+  - Skips non-delete dirty paths whose classifier strategy is `exclude` or
+    `never-sync`.
+  - Allows deletions so cleanup commits can untrack previously bad paths.
+  - Falls back to existing add/diff behavior when status reports no dirty entries
+    or the status call fails.
+- Tests:
+  - `tests/unit/file-classifier.test.ts` covers Instar local secret/runtime
+    classification.
+  - `tests/unit/GitSync.test.ts` covers skipped secret/runtime paths and
+    legitimate state staging.
+
+## Decision-point inventory
+
+1. **Pattern list expansion** — add — classifies known agent-local paths as
+   generated or secret.
+2. **Repo-relative pattern matching** — add — makes directory patterns like
+   `.instar/messages/` effective, not just basename patterns.
+3. **Status-first staging filter** — add — classifies dirty paths before `git add`.
+4. **Deletion allowance** — add — lets cleanup commits remove bad historical
+   tracked files even when their path classifies local-only.
+5. **Raw status helper** — add — avoids trimming machine-readable porcelain
+   status output.
+
+## 1. Over-block
+
+Possible over-block: a future file under one of the excluded directories might
+turn out to be useful shared state. The impact is that GitSync leaves it local
+and reports a degradation event. The fix is additive and low-risk: move that
+file to a syncable location or narrow the classifier pattern with a test.
+
+This is preferable to under-blocking because the failure class being addressed
+is accidental commit of local runtime artifacts and secret-bearing config.
+
+## 2. Under-block
+
+The classifier can only block paths it knows about. New local runtime paths not
+covered by these patterns can still be staged. The implementation makes this
+easy to extend by keeping the path list centralized in `FileClassifier` and
+testing the path families directly.
+
+The fallback to existing add/diff behavior on status failure is a deliberate
+availability tradeoff: a transient status failure should not permanently disable
+sync. The normal path is covered by focused tests.
+
+## 3. Level-of-Abstraction Fit
+
+Right layer. `FileClassifier` already owns merge/staging strategy categories,
+and `GitSyncManager` owns the staging operation. The server, dashboard, and
+caller code do not need to understand which local files are safe for Git.
+
+## 4. Signal vs Authority Compliance
+
+This is a structural git safety guard, not a conversational or product-judgment
+authority surface. It does not decide what an agent should do; it decides which
+local files may be staged by an automatic sync operation.
+
+## 5. Interactions
+
+- `.gitignore`: still useful for new untracked files, but this guard also
+  protects already-tracked bad paths by inspecting dirty tracked files before
+  staging.
+- Cleanup commits: deletions are allowed so agents can untrack local artifacts.
+- Existing commit messages and auto-push behavior: unchanged.
+- Degradation reporting: skipped paths are reported so the decision is visible
+  to operators without leaking file contents.
+
+## 6. External Surfaces
+
+No HTTP route, CLI flag, config field, dashboard panel, or schema migration is
+added. The visible behavior is that GitSync no longer includes local-only paths
+in auto-sync commits.
+
+## 7. Rollback Cost
+
+Trivial code revert. No state migration.
+
+## Verification
+
+- `./node_modules/.bin/vitest run tests/unit/file-classifier.test.ts tests/unit/GitSync.test.ts`
+  - 137 tests passed.
+- `./node_modules/.bin/vitest run tests/e2e/sync-edge-cases.test.ts tests/unit/no-silent-fallbacks.test.ts tests/unit/file-classifier.test.ts tests/unit/GitSync.test.ts`
+  - 191 tests passed after CI surfaced the edge-case and no-silent-fallback regressions.
+- `pnpm exec tsc --noEmit`
+  - clean.
+
+An accidental broad `pnpm test -- tests/unit/file-classifier.test.ts
+tests/unit/GitSync.test.ts` invocation ran unrelated suites and surfaced
+pre-existing E2E session-management timeouts before being stopped. Those
+failures are not attributed to this change.
+
+## Second-pass review
+
+**Reviewer:** `Ohm` subagent
+
+Initial result: concern raised. The reviewer found that the first implementation
+parsed `git status --porcelain -z` rename/copy records backwards: NUL mode emits
+the destination path first and the source path second, while the code advanced
+to the source path.
+
+Resolution:
+
+- `src/core/GitSync.ts` now keeps the destination path and skips the following
+  source-path field for rename/copy records.
+- `tests/unit/GitSync.test.ts` now includes regression coverage for rename
+  destination staging, deletion allowance for `never-sync` paths, and status
+  fallback behavior.
+
+Final result after amendments: `Concur with the review`.
+
+## CI follow-up
+
+The first PR CI run found two issues and both were addressed:
+
+- `tests/e2e/sync-edge-cases.test.ts` expected `.instar/config.json` to remain
+  normal structured data. That path is intentionally secret / never-sync under
+  this change, so the structured-data fixture now uses `.instar/jobs.json`.
+- `tests/unit/no-silent-fallbacks.test.ts` counted an existing
+  `FileClassifier` binary-stage inspection catch after nearby edits shifted its
+  detection window. The catch now has an explicit `@silent-fallback-ok` marker
+  because failure to inspect binary stages escalates to conflict resolution.


### PR DESCRIPTION
## Summary

Adds a GitSync hygiene guard so broad Instar state syncs classify dirty paths before staging. Local runtime/generated paths and secret-bearing agent config are skipped, while legitimate shared state can still sync and deletions remain stageable for cleanup.

## ELI16 — Git hygiene sentinel

Instar stores many things under `.instar/`. Some are real shared state, like jobs or registries. Some are local working files, like session logs, inbound Telegram message files, reports, shadow installs, and private config. Those local files should stay on the machine that made them.

The bug is that GitSync used a broad staging command for `.instar/`. If a local runtime file was already tracked, `.gitignore` alone was not enough. Git would keep seeing the tracked file as changed, and the next sync could commit it again.

This fix makes GitSync look at the actual dirty paths before staging. For each dirty path, it asks the file classifier whether the path is safe to sync. Normal state can still be committed. Runtime directories and secret-bearing config are skipped. Deletions are still allowed, because agents need to be able to remove bad tracked files from history going forward.

## Process

- Spec: `docs/specs/git-hygiene-sentinel.md`
- ELI16: `docs/specs/git-hygiene-sentinel.eli16.md`
- Side-effects review: `upgrades/side-effects/git-hygiene-sentinel.md`
- Release fragment: `upgrades/next/git-hygiene-sentinel.md`
- Second-pass review: initial concern raised on rename/copy parsing; fixed and final concurrence recorded.

## Verification

- `./node_modules/.bin/vitest run tests/unit/file-classifier.test.ts tests/unit/GitSync.test.ts` — 137 tests passed
- `pnpm exec tsc --noEmit` — passed
- `pnpm build` — passed; local release-signing key absent warning only
- Pre-push path-scoped Threadline e2e gate — 332 tests passed

## Notes

The Codey repository repair branch was not pushed because its old ancestry still contains polluted local/runtime history. The product guardrail branch is clean and based on `JKHeadley/main` v1.3.310.