### PR TITLE
fix(tests): make local unit suite hermetic

### DIFF
--- a/.instar/instar-dev-decisions/2026-06-05T20-49-19-504Z-hermetic-unit-suite.json
+++ b/.instar/instar-dev-decisions/2026-06-05T20-49-19-504Z-hermetic-unit-suite.json
@@ -1,0 +1,16 @@
+{
+  "ts": "2026-06-05T20:49:19.504Z",
+  "slug": "hermetic-unit-suite",
+  "suggestedTier": 1,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 6,
+  "causalAutopsy": {
+    "origin": "latent",
+    "notes": "Local unit-suite assumptions were already non-hermetic; a live Codex agent plus Node 25 exposed real-config/framework leakage, a watchdog no-auth script bug, and a cold dynamic import timeout under full-suite load."
+  },
+  "verdict": "pass"
+}

--- a/.instar/instar-dev-traces/2026-06-05T20-46-51-443Z-hermetic-unit-suite-7206989f.json
+++ b/.instar/instar-dev-traces/2026-06-05T20-46-51-443Z-hermetic-unit-suite-7206989f.json
@@ -1,0 +1,24 @@
+{
+  "version": 2,
+  "slug": "hermetic-unit-suite",
+  "sessionId": "68b4f7cb-b071-47e3-b952-88a2601617bb",
+  "timestamp": "2026-06-05T20:46:51.443Z",
+  "artifactPath": "upgrades/side-effects/hermetic-unit-suite.md",
+  "artifactSha256": "b2912969a008a59d22fb0390ec612ffd7f5d90f6d2fe7546f506ac21943b84a6",
+  "coveredFiles": [
+    "src/templates/scripts/instar-watchdog.sh",
+    "tests/unit/Config.test.ts",
+    "tests/unit/coherence-gate-escalation.test.ts"
+  ],
+  "phase": "complete",
+  "tier": 1,
+  "tierReasoning": "Small local-unit hermeticity fix: one shipped watchdog no-auth bug plus test fixture/import isolation; no new capability, no schema or persistent-state change.",
+  "eli16Path": "docs/eli16/hermetic-unit-suite.eli16.md",
+  "sideEffectsPath": "upgrades/side-effects/hermetic-unit-suite.md",
+  "causalAutopsy": {
+    "origin": "latent",
+    "notes": "Local unit-suite assumptions were already non-hermetic; a live Codex agent plus Node 25 exposed real-config/framework leakage, a watchdog no-auth script bug, and a cold dynamic import timeout under full-suite load."
+  },
+  "secondPass": "not-required",
+  "reviewerConcurred": null
+}

--- a/docs/eli16/hermetic-unit-suite.eli16.md
+++ b/docs/eli16/hermetic-unit-suite.eli16.md
@@ -1,0 +1,35 @@
+# Hermetic local unit suite — ELI16
+
+> The one-line version: local unit tests should mean the same thing on a developer's live-agent machine as they do in CI.
+
+## The problem in one breath
+
+The unit suite was green in CI but red on a real developer box running a live Instar agent on Node 25. That makes local evidence unreliable: a developer can run the same nominal unit command and get failures caused by their installed agent's config, tunnel state, native-module state, or runtime load rather than by the code under test. This change keeps the suite honest by fixing the places where the local machine leaked into tests, while preserving the assertions that caught real behavior.
+
+## What already exists
+
+Instar already has a large Vitest unit suite, and CI runs it in a cleaner environment than a dogfooding developer machine. The repo also already has a watchdog bind probe, tunnel-manager tests, config loading tests, package export tests, and generated built-in manifest checks. Those tests are valuable because they catch real regressions, but they should not depend on the operator's active `.instar/config.json`, active tunnel lifecycle, current framework selection, or whether Node 25 has freshly rebuilt native modules.
+
+## What this adds
+
+This patch makes the local-red cases reproducible and isolated. The watchdog template now handles the no-auth health probe path explicitly, so an empty auth argument array cannot accidentally influence the curl invocation. The config tests pin the fixture's framework to `claude-code` when they are asserting `claudePath`, so a live Codex dev agent does not legitimately resolve the selected framework binary and fail a Claude-specific assertion. The coherence-gate export tests use static imports instead of repeated cold dynamic package imports, removing a full-suite timeout that appeared only under serial Node 25 load.
+
+## The new pieces
+
+- **Watchdog no-auth probe fix** — a tiny shell-path correction in the shipped watchdog template. It does not add a new decision; it makes the existing health probe call match the existing intent: send auth headers only when an auth token exists.
+- **Framework-explicit config fixtures** — test data now says which framework it is asserting. That keeps the test about config preservation, not about the developer machine's selected framework.
+- **Static export verification** — the export test still verifies the same public exports, but it avoids expensive dynamic imports during the full suite.
+
+## The safeguards
+
+No test was skipped, suppressed, or loosened. The tests still assert the same observable behavior: no auth header in the no-auth watchdog path, custom config paths are preserved, and the package exports are present and typed. The tunnel-manager and worktree-detector failures found earlier were absorbed by current main's newer provider/cwd seams, and the focused validation keeps those files in the evidence set so that rebase did not hide them.
+
+The generated built-in manifest failure from the first full run is recorded as a generated-artifact priming issue: the manifest test rewrote the ignored manifest, and the immediate targeted rerun passed. That does not become a committed source artifact and does not justify changing the assertion.
+
+## What ships when
+
+This ships as a small Tier-1 fix: one runtime template bug fix plus two unit-suite isolation changes. The next queued transcript-auditor build remains separate and should not be mixed into this PR.
+
+## What you actually need to decide
+
+Approve this if the local unit suite should be trusted as evidence on a live developer machine without skipping tests or weakening the assertions that found the leaks.

--- a/src/templates/scripts/instar-watchdog.sh
+++ b/src/templates/scripts/instar-watchdog.sh
@@ -468,7 +468,11 @@ probe_server_identity() {
   if [ -n "$auth_token" ]; then
     auth_args=(-H "Authorization: Bearer $auth_token" -H "X-Instar-AgentId: $agent_id")
   fi
-  resp=$(curl -sS --max-time 5 -w '\n%{http_code}' "${auth_args[@]}" "http://localhost:${port}/health" 2>/dev/null || echo $'\n000')
+  if [ -n "$auth_token" ]; then
+    resp=$(curl -sS --max-time 5 -w '\n%{http_code}' "${auth_args[@]}" "http://localhost:${port}/health" 2>/dev/null || echo $'\n000')
+  else
+    resp=$(curl -sS --max-time 5 -w '\n%{http_code}' "http://localhost:${port}/health" 2>/dev/null || echo $'\n000')
+  fi
   http_code=$(echo "$resp" | tail -n1)
   body=$(echo "$resp" | sed '$d')
 

--- a/tests/unit/Config.test.ts
+++ b/tests/unit/Config.test.ts
@@ -37,7 +37,7 @@ describe('Config', () => {
       fs.writeFileSync(
         path.join(stateDir, 'config.json'),
         JSON.stringify({
-          sessions: { claudePath: customClaudePath, tmuxPath: '/usr/bin/tmux' },
+          sessions: { framework: 'claude-code', claudePath: customClaudePath, tmuxPath: '/usr/bin/tmux' },
         }),
       );
 
@@ -57,7 +57,7 @@ describe('Config', () => {
       fs.writeFileSync(
         path.join(stateDir, 'config.json'),
         JSON.stringify({
-          sessions: { tmuxPath: customTmuxPath, claudePath: '/usr/bin/claude-stub' },
+          sessions: { framework: 'claude-code', tmuxPath: customTmuxPath, claudePath: '/usr/bin/claude-stub' },
         }),
       );
 
@@ -81,7 +81,7 @@ describe('Config', () => {
 
       fs.writeFileSync(
         path.join(stateDir, 'config.json'),
-        JSON.stringify({}),
+        JSON.stringify({ sessions: { framework: 'claude-code' } }),
       );
 
       const config = loadConfig(tmpDir);

--- a/tests/unit/coherence-gate-escalation.test.ts
+++ b/tests/unit/coherence-gate-escalation.test.ts
@@ -17,6 +17,13 @@ import fs from 'node:fs';
 import path from 'node:path';
 import os from 'node:os';
 import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+import {
+  CapabilityRegistryGenerator,
+  CoherenceGate as ExportedCoherenceGate,
+  ResearchRateLimiter,
+  validateCommonBlockers,
+} from '../../src/index.js';
+import type { CapabilityRegistry, CommonBlocker } from '../../src/index.js';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -360,27 +367,30 @@ describe('CoherenceGate — escalation context wiring', () => {
   // ── Export verification ────────────────────────────────────────────────
 
   describe('exports', () => {
-    it('exports CapabilityRegistryGenerator from index', async () => {
-      const instar = await import('../../src/index.js');
-      expect(instar.CapabilityRegistryGenerator).toBeDefined();
+    it('exports CapabilityRegistryGenerator from index', () => {
+      expect(CapabilityRegistryGenerator).toBeDefined();
     });
 
-    it('exports validateCommonBlockers from index', async () => {
-      const instar = await import('../../src/index.js');
-      expect(instar.validateCommonBlockers).toBeDefined();
+    it('exports validateCommonBlockers from index', () => {
+      expect(validateCommonBlockers).toBeDefined();
     });
 
-    it('exports CommonBlocker type from index', async () => {
-      // Type-only test: verifying the type is importable
-      const instar = await import('../../src/index.js');
-      // CommonBlocker is a type-only export, verified at compile time
-      // Just verify the module loads successfully
-      expect(instar).toBeDefined();
+    it('exports CommonBlocker type from index', () => {
+      const blocker: CommonBlocker = {
+        description: 'Known operator step',
+        resolution: 'Use the existing internal tool',
+        status: 'confirmed',
+      };
+      expect(blocker.status).toBe('confirmed');
     });
 
-    it('exports CapabilityRegistry type from index', async () => {
-      const instar = await import('../../src/index.js');
-      expect(instar).toBeDefined();
+    it('exports CapabilityRegistry type from index', () => {
+      const registry: CapabilityRegistry = {
+        authentication: {},
+        tools: {},
+        surfaces: {},
+      };
+      expect(registry.tools).toEqual({});
     });
   });
 
@@ -560,11 +570,10 @@ describe('CoherenceGate — escalation context wiring', () => {
       expect(result._researchTriggered).toBeUndefined();
     });
 
-    it('exports ResearchTriggerContext from index', async () => {
-      const instar = await import('../../src/index.js');
+    it('exports ResearchTriggerContext from index', () => {
       // ResearchTriggerContext is a type-only export — just verify the module loads
-      expect(instar.CoherenceGate).toBeDefined();
-      expect(instar.ResearchRateLimiter).toBeDefined();
+      expect(ExportedCoherenceGate).toBeDefined();
+      expect(ResearchRateLimiter).toBeDefined();
     });
 
     it('CoherenceGate source includes ResearchRateLimiter integration', () => {

--- a/upgrades/side-effects/hermetic-unit-suite.md
+++ b/upgrades/side-effects/hermetic-unit-suite.md
@@ -1,0 +1,69 @@
+# Side-Effects Review — Hermetic local unit suite
+
+**Version / slug:** `hermetic-unit-suite`
+**Date:** `2026-06-05`
+**Author:** `instar-codey`
+**Second-pass reviewer:** `not required — Tier-1 patch; watchdog template path reviewed here`
+
+## Summary of the change
+
+This change makes local unit-suite evidence hermetic on a live-agent Node 25 developer box. It touches `src/templates/scripts/instar-watchdog.sh`, `tests/unit/Config.test.ts`, and `tests/unit/coherence-gate-escalation.test.ts`. The source change fixes the existing watchdog no-auth health probe so it calls curl without auth arguments when no auth token exists. The test changes pin framework-specific config fixtures and make package export checks static so full-suite load does not turn a valid export check into a timeout.
+
+## Decision-point inventory
+
+- `probe_server_identity` in `src/templates/scripts/instar-watchdog.sh` — modify — preserves the existing server identity decision, but corrects the no-auth request path so auth headers are only supplied when an auth token exists.
+- `Config.test.ts` fixture framework selection — modify — test-only fixture isolation; no production decision point.
+- `coherence-gate-escalation.test.ts` export verification — modify — test-only import strategy; no production decision point.
+
+## 1. Over-block
+
+No new block/allow surface is added. The watchdog already decided whether server identity was same-project, wrong-project, unreachable, or indeterminate; this patch only makes the unauthenticated curl invocation match the "no token" branch. There is no new legitimate input rejected by this change.
+
+## 2. Under-block
+
+This does not attempt to make every unit test hermetic in perpetuity. It fixes the local-red failures observed in this run: real-config/framework leakage, live tunnel leakage already addressed on current main, Node 25 native-module setup, the watchdog no-auth script bug, and the export-test timeout. Future tests can still leak live machine state if they read real config or network state without fixtures; that remains a suite hygiene class, not a new runtime gap introduced here.
+
+## 3. Level-of-abstraction fit
+
+The watchdog fix is at the right layer: the bug is in the shell template's curl argument construction, so the correction belongs in the shipped template rather than in the unit test. The config and export changes are correctly test-local: they do not ask production code to grow a seam just to satisfy this suite. Current main already provides the tunnel-provider and worktree cwd seams that absorbed the earlier tunnel/worktree local-reds, so this patch does not duplicate those abstractions.
+
+## 4. Signal vs authority compliance
+
+**Required reference:** [docs/signal-vs-authority.md](../../docs/signal-vs-authority.md)
+
+- [x] No — this change has no new block/allow surface.
+
+The watchdog path has existing operational authority to classify the server it probes, but this patch does not add a brittle new authority. It removes an accidental argument-shape dependency in the existing probe. The other two files are tests and have no runtime authority.
+
+## 5. Interactions
+
+- **Shadowing:** The watchdog no-auth branch now bypasses `auth_args` entirely when no token exists. It does not shadow the authenticated path; the authenticated path is unchanged.
+- **Double-fire:** No new timers, retries, or events are introduced.
+- **Races:** No persistent state or concurrent path changes are introduced. The generated `src/data/builtin-manifest.json` was primed locally by the manifest test and remains ignored.
+- **Feedback loops:** No release/update/job feedback loop changes.
+
+## 6. External surfaces
+
+Existing installed agents receive the corrected watchdog template when the template is shipped and applied. The visible behavior is narrower and intended: a no-auth probe should be genuinely no-auth. There is no database migration, ledger write, config-field change, public API change, or Telegram/Slack surface change. The local Node 25 dependency repair required `npm install --include=dev` on the dev box, but it did not modify `package.json` or `package-lock.json`.
+
+## 7. Rollback cost
+
+Rollback is a normal hot-fix revert. The source change is a shell-template branch, and the test changes are fixture/import isolation only. No persistent state is written, and no existing agent state needs repair. If the watchdog change were wrong, reverting it restores the prior curl invocation shape.
+
+## Conclusion
+
+The change is clear to ship as Tier 1. It fixes one real watchdog script bug and isolates two unit-suite failures without skipping tests, suppressing failures, or weakening assertions. The full unit-only run on the live-agent Node 25 box had one failure: a generated built-in manifest was stale because source was dirty; the manifest test regenerated that ignored file and its immediate rerun passed. Focused post-rebase validation passed on the edited/failure-class files.
+
+## Second-pass review (if required)
+
+**Reviewer:** not required for this Tier-1 patch.
+**Independent read of the artifact:** not run.
+
+The watchdog surface is documented above because it is the only runtime path touched. No new watchdog decision or recovery authority was added.
+
+## Evidence pointers
+
+- Full unit-only local run: 1,241/1,242 files passed; 23,548/23,549 tests passed. The only failure was `tests/unit/builtin-manifest.test.ts` because the generated ignored manifest was stale after source changes.
+- Targeted manifest rerun after local generation: `tests/unit/builtin-manifest.test.ts` passed, 9/9.
+- Focused post-rebase run: `AgentWorktreeDetector`, `Config`, `TunnelManager`, `watchdog-bind-probe`, `index-exports`, `coherence-gate-escalation`, and `builtin-manifest` passed, 124/124.
+- Claim-check: path advisory found merged PR #842 on the watchdog template and many keyword specs, with no open sibling claim requiring a different layer.


### PR DESCRIPTION
## Summary

Make the local unit suite trustworthy on a live-agent Node 25 developer box without skips or assertion weakening.

Changes:
- Fix the shipped watchdog no-auth health probe so curl is called without auth args when no auth token exists.
- Pin `Config.test.ts` fixtures to `claude-code` when asserting `sessions.claudePath`, avoiding live `INSTAR_FRAMEWORK=codex-cli` leakage.
- Convert coherence-gate export checks from repeated dynamic imports to static imports, preserving export/type assertions while avoiding full-suite cold-import timeout under load.

## ELI16

The local unit suite should mean the same thing on a developer's real machine as it does in CI. Before this patch, the suite could go red on a dogfooding box because tests accidentally depended on the live agent's framework config, live tunnel/runtime state, Node 25 native-module setup, or import timing under full-suite load. That makes local evidence weak: a developer cannot tell whether a red test is a product bug, a fixture leak, or their installed agent bleeding into the test environment.

This PR keeps the useful assertions and removes the accidental machine dependency. The watchdog test found a real shipped-script bug: the no-auth health probe was not cleanly separated from the auth-header path. The config tests now say explicitly that they are asserting Claude-path behavior, so a live Codex framework selection cannot legitimately change the expected binary. The export tests still prove the public exports exist and the types are importable, but they do it with static imports so the full unit suite does not time out on repeated dynamic package loads.

No test is skipped, suppressed, or weakened. The full local run still exercises the real unit list on the live-agent Node 25 box; the only remaining initial failure was the generated built-in manifest being stale while source was dirty, and the test-generated ignored manifest passed immediately on rerun. That is a generated-artifact priming issue, not a reason to loosen the manifest gate.

## Local-red classification

- Real script bug / env interaction: watchdog no-auth probe path fixed in `src/templates/scripts/instar-watchdog.sh`.
- Real-config leak: `Config.test.ts` fixtures now pin `sessions.framework: 'claude-code'` where they assert Claude-specific paths.
- Tunnel leak: current main's provider/tier `TunnelManager` suite already isolates reachability with injected providers/fetch; retained in focused validation.
- Worktree cwd leak: current main's `AgentWorktreeDetector` cwd seam already covers it; retained in focused validation.
- Node 25 setup: local `better-sqlite3` ABI was repaired by installing/rebuilding dev deps under Node 25; no package files changed.
- Other: coherence-gate export timeout under full-suite load fixed by static imports.

## Gate notes

- Tier: 1.
- Claim-check: ran on touched paths; no open sibling claim requiring a different layer. It surfaced merged #842 on the watchdog template as related prior work.
- Decision audit: committed slug-bearing pass record for `hermetic-unit-suite` with `causalAutopsy.origin: latent`.
- No ratchet baseline bump. No best-effort catch added. No skips/suppressions.

## Evidence

- Full local unit-only run on live-agent Node 25 box: 1,241/1,242 files passed; 23,548/23,549 tests passed. The sole failure was `builtin-manifest.test.ts` because the generated ignored manifest was stale after source changes.
- Targeted manifest rerun after local generation: `builtin-manifest.test.ts` passed, 9/9.
- Focused post-rebase validation: 7 files passed, 124/124 tests.
- Commit hook: lint/tsc/direct-call guards passed; instar-dev Tier-1 gate passed.
- Pre-push smoke: 2 files passed, 29/29 tests.
- Pre-push scoped e2e under Node 25: 17 files passed, 332/332 tests.
