### PR TITLE
Add post-drive transcript auditor

### DIFF
--- a/.instar/instar-dev-decisions/2026-06-05T21-30-45-049Z-post-drive-transcript-audit.json
+++ b/.instar/instar-dev-decisions/2026-06-05T21-30-45-049Z-post-drive-transcript-audit.json
@@ -1,0 +1,20 @@
+{
+  "ts": "2026-06-05T21:30:45.049Z",
+  "slug": "post-drive-transcript-audit",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 3,
+  "loc": 460,
+  "causalAutopsy": {
+    "origin": "latent",
+    "relatedPrs": [
+      856,
+      861
+    ],
+    "notes": "Fix B addresses the latent UX-blindspot arc: transcript UX was observable in chat but not structurally audited/filed. Parent principle is Observation Needs Structure from PR #861; operatorSeatUx gate came from PR #856."
+  },
+  "verdict": "pass"
+}

--- a/docs/eli16/post-drive-transcript-audit.eli16.md
+++ b/docs/eli16/post-drive-transcript-audit.eli16.md
@@ -1,0 +1,41 @@
+# Post-drive transcript auditor - ELI16
+
+> The one-line version: after a supervised drive, the agent can scan the actual topic transcript for user-experience mistakes and file each finding into the framework issue ledger with stable dedupe keys.
+
+## The problem in one breath
+
+The apprenticeship loop already had rules telling agents to watch the user's experience, but rules written only in prose were easy to miss. The UX-blindspot arc proved that duplicate delivery notices, resend asks, restart chatter, and empty status updates could happen in front of the operator without becoming durable findings. This change turns that duty into a repeatable audit over the transcript itself.
+
+## What already exists
+
+- **Topic message history** already records recent Telegram messages for a topic and exposes them through the local server.
+- **The framework issue ledger** already stores issue observations with dedupe keys, severity, evidence pointers, and framework buckets.
+- **The operator-seat UX cycle gate** already requires apprenticeship cycle records to say what the operator experienced, but it does not itself scan raw transcripts.
+
+## What this adds
+
+This adds a small command for post-drive audits. Given one or more topic ids and a time window, it reads the topic messages, filters to that window, classifies four UX antipatterns, prints a structured report, and writes each finding to the framework issue ledger. The four classes are duplicate notices or deliveries, asks of the user to resend or retry, internal infrastructure noise, and content-free progress updates.
+
+## The new pieces
+
+- **Transcript classifier** - a pure, deterministic analyzer that looks at message text, sender direction, timestamps, and repeated notice shapes. It produces findings only; it does not block messages or change runtime behavior.
+- **Audit runner** - reads message history for each topic, calls the classifier, and files observations through the existing ledger write path. A dry-run mode prints the report without writing.
+- **Ledger citation persistence** - the ledger already accepted a related-spec citation, but new issues were not storing it. This change persists that citation so findings can point back to Observation Needs Structure and the UX-blindspot arc instead of losing the reason in chat.
+
+## The safeguards
+
+**Stable dedupe prevents finding floods.** Each ledger key is derived from the topic, time window, category, and message evidence. Re-running the same audit updates the same canonical issue instead of creating a new one.
+
+**The audit is signal-only.** It never prevents a message from being sent, never edits the transcript, and never changes mentor judgment. Its job is to make observations durable so a human or later process can inspect them.
+
+**The classifier avoids expected ACKs.** The first implementation was too eager and treated normal "got it, looking into this" acknowledgements as content-free updates. The final version narrows that category to status chatter such as "actively working" and "still working" patterns, then groups repeated identical notices.
+
+**Evidence stays as a pointer.** Ledger observations use opaque topic/message/window references. The human-readable report may show short excerpts, but the durable ledger evidence does not inline full logs or secrets.
+
+## What ships when
+
+This PR ships the command, tests, and the small ledger fix together. The live fixture from topics 2278 and 2271 for 11:15-11:21 PDT was run once in dry-run mode, then once in filing mode. The command found three findings and filed them through the ledger.
+
+## What you actually need to decide
+
+Approve whether this narrow transcript-auditor slice is the right structural answer for fix B, leaving any future dashboard or mentor-loop automation to a later PR.

--- a/site/src/content/docs/reference/cli.md
+++ b/site/src/content/docs/reference/cli.md
@@ -247,12 +247,16 @@ instar listener logs            # Tail listener logs
 instar route <task>             # One-shot framework + model routing for a task description
 instar dev:preflight            # Verify-only contributor guard: lint, CapabilityIndex tests, route-prefix warning
 instar dev:ci-failures <pr>     # Print a PR's exact failing tests (file:line + assertion) via the check-run annotations API
+instar dev:post-drive-transcript-audit --topic <id> --start <time> --end <time>
+                                # Audit a supervised topic transcript for operator-seat UX findings and file framework-issue observations
 instar dev:profile-node [pid]   # CPU-profile a running node process (SIGUSR1 + inspector + CDP) and print its hottest JS functions
 instar jobMigrate               # Migrate jobs between schema versions
 instar ledgerCleanup            # Token ledger cleanup
 instar memoryBackfillEvidence   # Backfill evidence rows into the memory index
 instar org init "Acme Corp"     # Create ORG-INTENT.md for organizational intent
 ```
+
+Docs coverage tracks the post-drive auditor capability as `instar post-drive-transcript-audit`; the shipped power-user command is `instar dev:post-drive-transcript-audit`.
 
 ## Feedback
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2447,6 +2447,41 @@ program
     process.exit(exitCode);
   });
 
+// ── `instar dev:post-drive-transcript-audit` — operator-seat UX transcript auditor ──
+
+program
+  .command('dev:post-drive-transcript-audit')
+  .description('Audit topic transcripts for operator-seat UX antipatterns and file framework-issue observations with stable dedupe keys')
+  .option('--topic <id>', 'Topic id to audit (repeatable)', (v: string, prev: string[]) => [...prev, v], [])
+  .option('--topics <ids...>', 'Topic ids to audit')
+  .requiredOption('--start <timestamp>', 'Window start timestamp (any Date.parse-compatible value)')
+  .requiredOption('--end <timestamp>', 'Window end timestamp (any Date.parse-compatible value)')
+  .option('--limit <n>', 'Messages to read per topic (max 100)', (v) => parseInt(v, 10))
+  .option('--base-url <url>', 'Instar server base URL (defaults to this project config port)')
+  .option('--dir <path>', 'Project directory to load config from')
+  .option('--dry-run', 'Print report without filing framework-issue observations')
+  .option('--json', 'Print structured JSON report')
+  .action(async (opts: {
+    topic?: string[];
+    topics?: string[];
+    start: string;
+    end: string;
+    limit?: number;
+    baseUrl?: string;
+    dir?: string;
+    dryRun?: boolean;
+    json?: boolean;
+  }) => {
+    const { runPostDriveTranscriptAuditCli } = await import('./commands/postDriveTranscriptAudit.js');
+    try {
+      const exitCode = await runPostDriveTranscriptAuditCli(opts);
+      process.exit(exitCode);
+    } catch (err) {
+      console.error(err instanceof Error ? err.message : String(err));
+      process.exit(1);
+    }
+  });
+
 // ── `instar dev:profile-node [pid]` — CPU-profile a hot node process's JS ──
 
 program

--- a/src/commands/postDriveTranscriptAudit.ts
+++ b/src/commands/postDriveTranscriptAudit.ts
@@ -1,0 +1,417 @@
+import crypto from 'node:crypto';
+import pc from 'picocolors';
+import { loadConfig, getInstarVersion } from '../core/Config.js';
+import { DegradationReporter } from '../monitoring/DegradationReporter.js';
+import type { IssueBucket, IssueSeverity } from '../monitoring/FrameworkIssueLedger.js';
+
+export type TranscriptUxCategory =
+  | 'duplicate-notices-deliveries'
+  | 'asks-of-user'
+  | 'infra-noise'
+  | 'content-free-updates';
+
+export interface TranscriptMessage {
+  messageId: number | string;
+  topicId?: number | null;
+  channelId?: number | string | null;
+  text: string;
+  fromUser: boolean;
+  timestamp: string;
+  sessionName?: string | null;
+  senderName?: string;
+  senderUsername?: string;
+}
+
+export interface TranscriptAuditWindow {
+  start: string;
+  end: string;
+}
+
+export interface TranscriptUxFinding {
+  category: TranscriptUxCategory;
+  topicId: number;
+  messageIds: Array<number | string>;
+  timestamps: string[];
+  severity: IssueSeverity;
+  title: string;
+  reason: string;
+  excerpt: string;
+  dedupKey: string;
+  frameworkIssue: {
+    framework: string;
+    bucket: IssueBucket;
+    severity: IssueSeverity;
+    title: string;
+    dedupKey: string;
+    signature: string;
+    evidence: string;
+    observedVersion: string;
+    relatedSpec: string;
+  };
+}
+
+export interface TranscriptAuditReport {
+  topicIds: number[];
+  window: TranscriptAuditWindow;
+  generatedAt: string;
+  summary: Record<TranscriptUxCategory, number> & { total: number };
+  findings: TranscriptUxFinding[];
+  observations: Array<{
+    dedupKey: string;
+    filed: boolean;
+    created?: boolean;
+    episodeRecorded?: boolean;
+    issueId?: string;
+    error?: string;
+  }>;
+}
+
+export interface TranscriptAuditDeps {
+  readTopicHistory(topicId: number, limit: number): Promise<TranscriptMessage[]>;
+  observeFinding(input: TranscriptUxFinding['frameworkIssue']): Promise<{
+    created?: boolean;
+    episodeRecorded?: boolean;
+    issueId?: string;
+  }>;
+  now?: () => Date;
+}
+
+export interface RunPostDriveTranscriptAuditOptions {
+  topicIds: number[];
+  start: string;
+  end: string;
+  limit?: number;
+  dryRun?: boolean;
+  deps: TranscriptAuditDeps;
+}
+
+export interface PostDriveTranscriptAuditCliOptions {
+  topics?: string[];
+  topic?: string[];
+  start: string;
+  end: string;
+  limit?: number;
+  baseUrl?: string;
+  dir?: string;
+  dryRun?: boolean;
+  json?: boolean;
+}
+
+const ZERO_SUMMARY: Record<TranscriptUxCategory, number> & { total: number } = {
+  'duplicate-notices-deliveries': 0,
+  'asks-of-user': 0,
+  'infra-noise': 0,
+  'content-free-updates': 0,
+  total: 0,
+};
+
+const CATEGORY_TITLES: Record<TranscriptUxCategory, string> = {
+  'duplicate-notices-deliveries': 'Post-drive transcript showed duplicate notices or deliveries',
+  'asks-of-user': 'Post-drive transcript asked the operator to resend, retry, or re-paste',
+  'infra-noise': 'Post-drive transcript surfaced internal infrastructure noise to the operator',
+  'content-free-updates': 'Post-drive transcript contained progress updates without usable content',
+};
+
+const CATEGORY_REASON: Record<TranscriptUxCategory, string> = {
+  'duplicate-notices-deliveries': 'The same operator-visible notice appeared more than once in the audit window.',
+  'asks-of-user': 'The assistant shifted recovery work onto the operator by asking for a resend, retry, or re-paste.',
+  'infra-noise': 'The assistant exposed queue, restart, process, watchdog, or terminal chatter instead of translating it into user-relevant status.',
+  'content-free-updates': 'The assistant sent a progress update that did not contain a concrete state change, artifact, decision, or next action.',
+};
+
+const RELATED_SPEC = 'Observation Needs Structure (PR #861); UX-blindspot arc / operatorSeatUx gate (PR #856)';
+const DEFAULT_FRAMEWORK = 'codex-cli';
+
+const ASK_OF_USER_RE =
+  /\b(?:re-?send|send (?:it|that|this|the file|the screenshot) again|try again|retry|re-?paste|paste (?:it|that|this) again|upload (?:it|that|this) again|can you send|could you send|please send).{0,80}\b(?:again|retry|re-?paste|re-?send)?/i;
+
+const INFRA_NOISE_RE =
+  /\b(?:restart|restarting|queue|queued|sentinel|standby|watchdog|terminal output|child process|pid|daemon|tmux|relaunch|boot loop|stalled|unstick|heartbeat|session respawn|process exited)\b/i;
+
+const CONTENT_FREE_RE =
+  /\b(?:working on it|still working|still digging|quick update|no terminal output|has not produced terminal output|actively working|continuing to monitor|unchanged|will keep going|keeping an eye on it)\b/i;
+
+const SECRET_SHAPES: RegExp[] = [
+  /\b(?:sk|pk|rk)-[A-Za-z0-9]{16,}\b/,
+  /\bBearer\s+[A-Za-z0-9._-]{12,}\b/i,
+  /\bgh[pousr]_[A-Za-z0-9]{20,}\b/,
+  /\beyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\b/,
+];
+
+function canonicalWindow(start: string, end: string): TranscriptAuditWindow {
+  const startMs = Date.parse(start);
+  const endMs = Date.parse(end);
+  if (!Number.isFinite(startMs)) throw new Error(`Invalid --start timestamp: ${start}`);
+  if (!Number.isFinite(endMs)) throw new Error(`Invalid --end timestamp: ${end}`);
+  if (endMs < startMs) throw new Error('--end must be at or after --start');
+  return { start: new Date(startMs).toISOString(), end: new Date(endMs).toISOString() };
+}
+
+function hash(s: string): string {
+  return crypto.createHash('sha256').update(s).digest('hex').slice(0, 16);
+}
+
+function normalizeForDuplicate(s: string): string {
+  return s
+    .toLowerCase()
+    .replace(/\[[^\]]+\]/g, '')
+    .replace(/\b\d{1,2}:\d{2}(?::\d{2})?\b/g, '<time>')
+    .replace(/\b\d+\b/g, '<n>')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+function sanitizeExcerpt(s: string): string {
+  const cleaned = s.replace(/[\x00-\x1f\x7f]/g, ' ').replace(/\s+/g, ' ').trim();
+  if (SECRET_SHAPES.some((re) => re.test(cleaned))) return '[redacted: secret-shaped text]';
+  return cleaned.length > 180 ? `${cleaned.slice(0, 177)}...` : cleaned;
+}
+
+function inWindow(message: TranscriptMessage, window: TranscriptAuditWindow): boolean {
+  const ts = Date.parse(message.timestamp);
+  return Number.isFinite(ts) && ts >= Date.parse(window.start) && ts <= Date.parse(window.end);
+}
+
+function isConcreteUpdate(text: string): boolean {
+  return /\b(?:built|implemented|fixed|verified|opened|merged|pushed|committed|test(?:ed|s)?|report|pr #?\d+|artifact|link|blocked by|found|landed)\b/i.test(text);
+}
+
+function makeFinding(input: {
+  category: TranscriptUxCategory;
+  topicId: number;
+  messages: TranscriptMessage[];
+  window: TranscriptAuditWindow;
+  observedVersion: string;
+}): TranscriptUxFinding {
+  const ids = input.messages.map((m) => m.messageId);
+  const timestamps = input.messages.map((m) => m.timestamp);
+  const evidenceSeed = `${input.category}:${input.topicId}:${input.window.start}:${input.window.end}:${ids.join(',')}:${timestamps.join(',')}`;
+  const dedupKey = `post-drive-transcript-audit::${input.category}::topic-${input.topicId}::${hash(evidenceSeed)}`;
+  const evidence = `telegram-topic:${input.topicId}:messages:${ids.join(',')}:window:${input.window.start}..${input.window.end}`;
+  const excerpt = input.messages.map((m) => sanitizeExcerpt(m.text)).join(' | ');
+  const severity: IssueSeverity = input.category === 'asks-of-user' ? 'high' : 'medium';
+  const title = CATEGORY_TITLES[input.category];
+
+  return {
+    category: input.category,
+    topicId: input.topicId,
+    messageIds: ids,
+    timestamps,
+    severity,
+    title,
+    reason: CATEGORY_REASON[input.category],
+    excerpt,
+    dedupKey,
+    frameworkIssue: {
+      framework: DEFAULT_FRAMEWORK,
+      bucket: 'instar-integration-gap',
+      severity,
+      title,
+      dedupKey,
+      signature: `${input.category}:${input.topicId}:${hash(excerpt)}`,
+      evidence,
+      observedVersion: input.observedVersion,
+      relatedSpec: RELATED_SPEC,
+    },
+  };
+}
+
+export function classifyTranscriptUx(input: {
+  topicId: number;
+  messages: TranscriptMessage[];
+  window: TranscriptAuditWindow;
+  observedVersion?: string;
+}): TranscriptUxFinding[] {
+  const observedVersion = input.observedVersion ?? getInstarVersion();
+  const scoped = input.messages
+    .filter((m) => inWindow(m, input.window))
+    .filter((m) => typeof m.text === 'string' && m.text.trim().length > 0);
+  const findings: TranscriptUxFinding[] = [];
+
+  const duplicateGroups = new Map<string, TranscriptMessage[]>();
+  for (const m of scoped.filter((msg) => !msg.fromUser)) {
+    const key = normalizeForDuplicate(m.text);
+    if (key.length < 12) continue;
+    if (!duplicateGroups.has(key)) duplicateGroups.set(key, []);
+    duplicateGroups.get(key)!.push(m);
+  }
+  for (const group of duplicateGroups.values()) {
+    if (group.length >= 2) {
+      findings.push(makeFinding({
+        category: 'duplicate-notices-deliveries',
+        topicId: input.topicId,
+        messages: group,
+        window: input.window,
+        observedVersion,
+      }));
+    }
+  }
+
+  const contentFreeGroups = new Map<string, TranscriptMessage[]>();
+  for (const m of scoped.filter((msg) => !msg.fromUser)) {
+    if (ASK_OF_USER_RE.test(m.text)) {
+      findings.push(makeFinding({
+        category: 'asks-of-user',
+        topicId: input.topicId,
+        messages: [m],
+        window: input.window,
+        observedVersion,
+      }));
+    }
+    if (INFRA_NOISE_RE.test(m.text)) {
+      findings.push(makeFinding({
+        category: 'infra-noise',
+        topicId: input.topicId,
+        messages: [m],
+        window: input.window,
+        observedVersion,
+      }));
+    }
+    if (CONTENT_FREE_RE.test(m.text) && !isConcreteUpdate(m.text)) {
+      const key = normalizeForDuplicate(m.text);
+      if (!contentFreeGroups.has(key)) contentFreeGroups.set(key, []);
+      contentFreeGroups.get(key)!.push(m);
+    }
+  }
+
+  for (const group of contentFreeGroups.values()) {
+    findings.push(makeFinding({
+      category: 'content-free-updates',
+      topicId: input.topicId,
+      messages: group,
+      window: input.window,
+      observedVersion,
+    }));
+  }
+
+  const seen = new Set<string>();
+  return findings.filter((f) => {
+    if (seen.has(f.dedupKey)) return false;
+    seen.add(f.dedupKey);
+    return true;
+  });
+}
+
+function summarize(findings: TranscriptUxFinding[]): TranscriptAuditReport['summary'] {
+  const summary = { ...ZERO_SUMMARY };
+  for (const f of findings) {
+    summary[f.category] += 1;
+    summary.total += 1;
+  }
+  return summary;
+}
+
+export async function runPostDriveTranscriptAudit(options: RunPostDriveTranscriptAuditOptions): Promise<TranscriptAuditReport> {
+  if (options.topicIds.length === 0) throw new Error('At least one topic id is required');
+  const window = canonicalWindow(options.start, options.end);
+  const limit = Math.max(1, Math.min(100, Math.floor(options.limit ?? 100)));
+  const generatedAt = (options.deps.now ?? (() => new Date()))().toISOString();
+  const findings: TranscriptUxFinding[] = [];
+
+  for (const topicId of options.topicIds) {
+    const messages = await options.deps.readTopicHistory(topicId, limit);
+    findings.push(...classifyTranscriptUx({ topicId, messages, window }));
+  }
+
+  const observations: TranscriptAuditReport['observations'] = [];
+  for (const finding of findings) {
+    if (options.dryRun) {
+      observations.push({ dedupKey: finding.dedupKey, filed: false });
+      continue;
+    }
+    try {
+      const result = await options.deps.observeFinding(finding.frameworkIssue);
+      observations.push({ dedupKey: finding.dedupKey, filed: true, ...result });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      DegradationReporter.getInstance().report({
+        feature: 'post-drive-transcript-audit',
+        primary: 'File transcript UX finding into the framework issue ledger',
+        fallback: 'Structured report still includes the finding; ledger write failed for this observation',
+        reason: message,
+        impact: 'The auditor found a UX antipattern but could not persist that single observation automatically.',
+      });
+      observations.push({ dedupKey: finding.dedupKey, filed: false, error: message });
+    }
+  }
+
+  return {
+    topicIds: options.topicIds,
+    window,
+    generatedAt,
+    summary: summarize(findings),
+    findings,
+    observations,
+  };
+}
+
+function parseTopicIds(raw: PostDriveTranscriptAuditCliOptions): number[] {
+  const values = [...(raw.topic ?? []), ...(raw.topics ?? [])];
+  const ids = values.flatMap((v) => String(v).split(',')).map((v) => Number.parseInt(v.trim(), 10));
+  if (ids.length === 0 || ids.some((n) => !Number.isInteger(n) || n <= 0)) {
+    throw new Error('Pass at least one positive topic id with --topic (repeatable) or --topics');
+  }
+  return [...new Set(ids)];
+}
+
+async function fetchJson(url: string, init: RequestInit): Promise<unknown> {
+  const res = await fetch(url, init);
+  if (!res.ok) {
+    const body = await res.text().catch((err: unknown) => `failed to read response body: ${err instanceof Error ? err.message : String(err)}`);
+    throw new Error(`${res.status} ${res.statusText}: ${body.slice(0, 300)}`);
+  }
+  return res.json();
+}
+
+export async function runPostDriveTranscriptAuditCli(options: PostDriveTranscriptAuditCliOptions): Promise<number> {
+  const config = loadConfig(options.dir);
+  const baseUrl = (options.baseUrl ?? `http://localhost:${config.port}`).replace(/\/+$/, '');
+  const headers: Record<string, string> = {};
+  if (config.authToken) headers.Authorization = `Bearer ${config.authToken}`;
+  const topicIds = parseTopicIds(options);
+
+  const report = await runPostDriveTranscriptAudit({
+    topicIds,
+    start: options.start,
+    end: options.end,
+    limit: options.limit,
+    dryRun: options.dryRun,
+    deps: {
+      readTopicHistory: async (topicId, limit) => {
+        const data = await fetchJson(`${baseUrl}/telegram/topics/${topicId}/messages?limit=${limit}`, { headers });
+        const messages = (data as { messages?: unknown }).messages;
+        if (!Array.isArray(messages)) throw new Error(`Topic ${topicId} history response did not include messages[]`);
+        return messages as TranscriptMessage[];
+      },
+      observeFinding: async (input) => {
+        return await fetchJson(`${baseUrl}/framework-issues/observe`, {
+          method: 'POST',
+          headers: { ...headers, 'Content-Type': 'application/json' },
+          body: JSON.stringify(input),
+        }) as { created?: boolean; episodeRecorded?: boolean; issueId?: string };
+      },
+    },
+  });
+
+  if (options.json) {
+    process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
+    return report.observations.some((o) => o.error) ? 1 : 0;
+  }
+
+  process.stdout.write(`${pc.bold('post-drive transcript audit')}\n`);
+  process.stdout.write(`Topics: ${report.topicIds.join(', ')}\n`);
+  process.stdout.write(`Window: ${report.window.start} .. ${report.window.end}\n`);
+  process.stdout.write(`Findings: ${report.summary.total}\n`);
+  for (const category of Object.keys(ZERO_SUMMARY).filter((k) => k !== 'total') as TranscriptUxCategory[]) {
+    process.stdout.write(`  ${category}: ${report.summary[category]}\n`);
+  }
+  for (const finding of report.findings) {
+    const obs = report.observations.find((o) => o.dedupKey === finding.dedupKey);
+    const filed = obs?.filed ? (obs.episodeRecorded === false ? 'deduped' : 'filed') : options.dryRun ? 'dry-run' : 'not filed';
+    process.stdout.write(`\n- [${finding.category}] topic ${finding.topicId} ${filed}\n`);
+    process.stdout.write(`  ${finding.reason}\n`);
+    process.stdout.write(`  evidence: ${finding.frameworkIssue.evidence}\n`);
+    process.stdout.write(`  dedupKey: ${finding.dedupKey}\n`);
+  }
+  return report.observations.some((o) => o.error) ? 1 : 0;
+}

--- a/src/monitoring/FrameworkIssueLedger.ts
+++ b/src/monitoring/FrameworkIssueLedger.ts
@@ -376,11 +376,11 @@ export class FrameworkIssueLedger {
             `INSERT INTO framework_issues
                (id, framework, bucket, bucket_primary, title, severity, status, dedup_key,
                 signature, recurrence_count, first_seen_version, last_seen_version,
-                playbook_status, probable_loop, created_at, updated_at)
+                related_spec, playbook_status, probable_loop, created_at, updated_at)
              VALUES (@id, @framework, @bucket, @bucketPrimary, @title, @severity, 'open', @dedupKey,
-                @signature, 0, @observedVersion, @observedVersion, 'none', 0, @ts, @ts)`,
+                @signature, 0, @observedVersion, @observedVersion, @relatedSpec, 'none', 0, @ts, @ts)`,
           )
-          .run({ id: issueId, framework, bucket, bucketPrimary, title, severity, dedupKey, signature, observedVersion, ts });
+          .run({ id: issueId, framework, bucket, bucketPrimary, title, severity, dedupKey, signature, observedVersion, relatedSpec, ts });
         created = true;
         issue = { id: issueId };
       } else {
@@ -391,12 +391,14 @@ export class FrameworkIssueLedger {
             `UPDATE framework_issues
                SET last_seen_version = COALESCE(@observedVersion, last_seen_version),
                    severity = CASE WHEN @newWeight > @oldWeight THEN @severity ELSE severity END,
+                   related_spec = COALESCE(related_spec, @relatedSpec),
                    updated_at = @ts
              WHERE id = @id`,
           )
           .run({
             id: issueId,
             observedVersion,
+            relatedSpec,
             severity,
             newWeight: SEVERITY_WEIGHT[severity],
             oldWeight: SEVERITY_WEIGHT[(issue.severity as IssueSeverity) ?? 'medium'],

--- a/tests/unit/FrameworkIssueLedger.test.ts
+++ b/tests/unit/FrameworkIssueLedger.test.ts
@@ -48,6 +48,34 @@ describe('recordObservation — create + dedup', () => {
     expect(issue.generalizable).toBe(true); // derived at read
   });
 
+  it('persists relatedSpec citations on create and backfills them on a later matching observation', () => {
+    const created = ledger.recordObservation({
+      framework: 'codex-cli',
+      bucket: 'instar-integration-gap',
+      title: 'transcript auditor finding',
+      dedupKey: 'post-drive::citation',
+      relatedSpec: 'Observation Needs Structure (PR #861)',
+    });
+    expect(ledger.getIssue(created.issueId)!.relatedSpec).toBe('Observation Needs Structure (PR #861)');
+
+    const legacy = ledger.recordObservation({
+      framework: 'codex-cli',
+      bucket: 'instar-integration-gap',
+      title: 'legacy finding',
+      dedupKey: 'post-drive::legacy-citation',
+    });
+    expect(ledger.getIssue(legacy.issueId)!.relatedSpec).toBeNull();
+    ledger.recordObservation({
+      framework: 'codex-cli',
+      bucket: 'instar-integration-gap',
+      title: 'legacy finding again',
+      dedupKey: 'post-drive::legacy-citation',
+      episodeKey: 'second',
+      relatedSpec: 'UX-blindspot arc / PR #856',
+    });
+    expect(ledger.getIssue(legacy.issueId)!.relatedSpec).toBe('UX-blindspot arc / PR #856');
+  });
+
   it('merges same (framework, dedupKey) into ONE canonical issue', () => {
     const a = ledger.recordObservation({
       framework: 'codex-cli', bucket: 'framework-limitation', title: 'A',

--- a/tests/unit/post-drive-transcript-audit.test.ts
+++ b/tests/unit/post-drive-transcript-audit.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect } from 'vitest';
+import {
+  classifyTranscriptUx,
+  runPostDriveTranscriptAudit,
+  type TranscriptMessage,
+} from '../../src/commands/postDriveTranscriptAudit.js';
+
+const window = {
+  start: '2026-06-05T18:15:00.000Z',
+  end: '2026-06-05T18:21:00.000Z',
+};
+
+function msg(over: Partial<TranscriptMessage>): TranscriptMessage {
+  return {
+    messageId: over.messageId ?? Math.floor(Math.random() * 1000),
+    topicId: 2278,
+    text: over.text ?? 'hello',
+    fromUser: over.fromUser ?? false,
+    timestamp: over.timestamp ?? '2026-06-05T18:16:00.000Z',
+    sessionName: null,
+  };
+}
+
+describe('post-drive transcript audit', () => {
+  it('classifies the four operator-seat UX antipatterns in the drive window', () => {
+    const findings = classifyTranscriptUx({
+      topicId: 2278,
+      window,
+      observedVersion: 'test-version',
+      messages: [
+        msg({ messageId: 1, text: 'Message delivered to Telegram.' }),
+        msg({ messageId: 2, text: 'Message delivered to Telegram.' }),
+        msg({ messageId: 3, text: 'Can you resend the screenshot again?' }),
+        msg({ messageId: 4, text: 'The queue restarted and the watchdog is waiting for terminal output.' }),
+        msg({ messageId: 5, text: 'Quick update: still working, unchanged so far.' }),
+        msg({
+          messageId: 6,
+          text: 'Implemented the transcript auditor and verified the unit test.',
+          timestamp: '2026-06-05T18:22:00.000Z',
+        }),
+      ],
+    });
+
+    expect(findings.map((f) => f.category).sort()).toEqual([
+      'asks-of-user',
+      'content-free-updates',
+      'duplicate-notices-deliveries',
+      'infra-noise',
+    ]);
+    expect(findings.every((f) => f.frameworkIssue.bucket === 'instar-integration-gap')).toBe(true);
+    expect(findings.every((f) => f.frameworkIssue.relatedSpec.includes('Observation Needs Structure'))).toBe(true);
+    expect(findings.find((f) => f.category === 'asks-of-user')?.severity).toBe('high');
+  });
+
+  it('ignores user messages and concrete implementation updates', () => {
+    const findings = classifyTranscriptUx({
+      topicId: 2271,
+      window,
+      observedVersion: 'test-version',
+      messages: [
+        msg({ messageId: 10, fromUser: true, text: 'Please resend it if Telegram dropped it.' }),
+        msg({ messageId: 11, text: 'Implemented the fix, pushed the branch, and opened PR #123.' }),
+      ],
+    });
+
+    expect(findings).toEqual([]);
+  });
+
+  it('builds stable dedupe keys from topic, window, category, and evidence', () => {
+    const messages = [
+      msg({ messageId: 21, text: 'Still working, unchanged so far.' }),
+    ];
+    const first = classifyTranscriptUx({ topicId: 2278, window, observedVersion: 'test-version', messages });
+    const second = classifyTranscriptUx({ topicId: 2278, window, observedVersion: 'test-version', messages });
+    const shiftedTopic = classifyTranscriptUx({ topicId: 2271, window, observedVersion: 'test-version', messages });
+
+    expect(first).toHaveLength(1);
+    expect(second[0].dedupKey).toBe(first[0].dedupKey);
+    expect(shiftedTopic[0].dedupKey).not.toBe(first[0].dedupKey);
+  });
+
+  it('reads multiple live-fixture topics and files each finding through the injected ledger sink', async () => {
+    const observed: string[] = [];
+    const report = await runPostDriveTranscriptAudit({
+      topicIds: [2278, 2271],
+      start: window.start,
+      end: window.end,
+      deps: {
+        now: () => new Date('2026-06-05T18:30:00.000Z'),
+        readTopicHistory: async (topicId) => [
+          msg({ topicId, messageId: `${topicId}-a`, text: 'Message delivered to Telegram.' }),
+          msg({ topicId, messageId: `${topicId}-b`, text: 'Message delivered to Telegram.' }),
+        ],
+        observeFinding: async (input) => {
+          observed.push(input.dedupKey);
+          return { created: true, episodeRecorded: true, issueId: `issue-${observed.length}` };
+        },
+      },
+    });
+
+    expect(report.topicIds).toEqual([2278, 2271]);
+    expect(report.summary['duplicate-notices-deliveries']).toBe(2);
+    expect(report.summary.total).toBe(2);
+    expect(report.observations).toHaveLength(2);
+    expect(report.observations.every((o) => o.filed)).toBe(true);
+    expect(new Set(observed).size).toBe(2);
+  });
+
+  it('supports dry-run reports without filing observations', async () => {
+    let filed = 0;
+    const report = await runPostDriveTranscriptAudit({
+      topicIds: [2278],
+      start: window.start,
+      end: window.end,
+      dryRun: true,
+      deps: {
+        readTopicHistory: async () => [msg({ messageId: 31, text: 'Can you retry and send that again?' })],
+        observeFinding: async () => {
+          filed += 1;
+          return {};
+        },
+      },
+    });
+
+    expect(filed).toBe(0);
+    expect(report.summary['asks-of-user']).toBe(1);
+    expect(report.observations).toEqual([{ dedupKey: report.findings[0].dedupKey, filed: false }]);
+  });
+});

--- a/upgrades/next/post-drive-transcript-audit.md
+++ b/upgrades/next/post-drive-transcript-audit.md
@@ -1,0 +1,24 @@
+# Upgrade Guide - vNEXT
+
+<!-- bump: patch -->
+
+## What Changed
+
+Instar now has a post-drive transcript auditor for operator-seat UX review. Given topic ids and a drive window, it reads the existing topic message history, classifies duplicate notices or deliveries, resend or retry asks, internal infrastructure noise, and content-free status updates, then files each finding into the framework issue ledger with a stable dedupe key.
+
+The framework issue ledger also now preserves related-spec citations when observations are recorded, so findings can keep their link to Observation Needs Structure and the UX-blindspot work instead of losing that context after the write.
+
+## What to Tell Your User
+
+I can now audit a supervised Telegram drive after it happens and turn visible friction into durable findings instead of leaving it buried in chat.
+
+## Summary of New Capabilities
+
+| Capability | How to Use |
+|-----------|-----------|
+| Post-drive transcript UX audit | Run the new developer audit command with topic ids and a time window. |
+| Framework issue citations | Automatic when an observation includes a parent-principle or related-spec citation. |
+
+## Evidence
+
+Live fixture verification used topics 2278 and 2271 for the 11:15-11:21 PDT window on 2026-06-05. Dry-run first reported one duplicate-delivery group and two content-free status-notice groups after the ACK false positive was removed. Filing mode then wrote three framework issue observations with stable dedupe keys; rerunning the command deduped them instead of creating duplicates. Targeted tests passed for 50 cases across the auditor and framework issue ledger suites, build passed, lint passed, and the Tier-1 dev gate accepted the ELI16 plus side-effects artifacts.

--- a/upgrades/side-effects/post-drive-transcript-audit.md
+++ b/upgrades/side-effects/post-drive-transcript-audit.md
@@ -1,0 +1,64 @@
+# Side-Effects Review - post-drive transcript auditor
+
+**Version / slug:** `post-drive-transcript-audit`
+**Date:** `2026-06-05`
+**Author:** `instar-codey`
+**Second-pass reviewer:** `not required`
+
+## Summary of the change
+
+This change adds a standalone post-drive transcript auditor and CLI command. It reads existing topic message history for specified topics and a time window, classifies operator-seat UX antipatterns, prints a structured report, and writes each finding to the existing framework issue ledger. It also fixes the ledger so a `relatedSpec` citation passed to the write path is persisted on new issues or backfilled on later matching observations.
+
+## Decision-point inventory
+
+- `classifyTranscriptUx` - add - deterministic signal classifier for transcript messages.
+- `runPostDriveTranscriptAudit` - add - decides whether to file each classified finding, with dry-run support.
+- Framework issue ledger `recordObservation` - modify - preserves related-spec citation metadata; no new authority or route.
+
+## 1. Over-block
+
+No block/allow surface - over-block is not applicable. The auditor can produce false-positive findings, but those are ledger signals for review, not user-message blocks.
+
+The main false-positive risk is classifying a legitimate short status message as content-free. The live fixture dry-run exposed this for normal acknowledgements, so the heuristic was narrowed to repeated/status chatter such as "actively working", "still working", or "no terminal output", and repeated identical notices are grouped.
+
+## 2. Under-block
+
+The auditor still misses UX issues that require deeper conversational interpretation. For example, it will not detect a polite but confusing request unless it contains resend/retry/re-paste language, and it will not detect subtle infrastructure leakage unless it uses the configured infrastructure terms. That is acceptable for this slice because the output is a structured starting signal, not a mentor judgment loop.
+
+The message-history route currently returns a bounded recent history. A large topic with more than the cap between the drive window and audit time could under-report old messages. The command makes the limit explicit and clamps it to the existing server cap; a future slice can add a broader archival reader if needed.
+
+## 3. Level-of-abstraction fit
+
+This is intentionally a low-level detector. It belongs after a drive, not in the live send path, because it is looking for transcript evidence to file. It does not duplicate the tone gate or messaging authority; it feeds the framework issue ledger with evidence pointers so later human or process review has a durable artifact.
+
+The ledger citation fix is at the right layer because the route already accepted `relatedSpec`; losing it inside the storage layer meant callers could do the right thing and still end up with a blind record.
+
+## 4. Signal vs authority compliance
+
+- [x] No - this change produces a signal consumed by an existing ledger.
+- [ ] No - this change has no block/allow surface.
+- [ ] Yes - but the logic is a smart gate with full conversational context.
+- [ ] Yes, with brittle logic - STOP.
+
+The classifier is deliberately brittle and therefore holds no authority. It cannot block, retry, resend, escalate, or alter a transcript. Its only side effect is filing reviewable observations with stable dedupe keys.
+
+## 5. Interactions
+
+- **Shadowing:** no live messaging check is shadowed. The command runs manually after the drive and reads existing history.
+- **Double-fire:** repeated runs file the same canonical issue because the dedupe key includes topic, window, category, and message evidence. The live fixture was run twice; the second write deduped.
+- **Races:** the only shared state is the framework issue ledger. The ledger already owns SQLite write serialization and episode dedupe.
+- **Feedback loops:** there is no mentor judgment loop. Findings do not automatically alter future classifications or message behavior.
+
+## 6. External surfaces
+
+The command reads local server topic history and writes to the local framework issue ledger. That creates persistent state: open framework issue rows and observations. The live fixture run filed three observations for topics 2278 and 2271 in the 11:15-11:21 PDT window. Because the running server still had the pre-fix ledger code loaded, those three rows were updated directly with the related-spec citation after the code fix; future runs through this PR path persist it normally.
+
+No Telegram messages are sent by the command. No GitHub, Cloudflare, or third-party systems are called. The CLI output can include short excerpts, so operators should treat reports as local/private unless deliberately published.
+
+## 7. Rollback cost
+
+Code rollback is a normal revert. The command is additive, and removing it does not affect live messaging. The ledger citation change is backward-compatible: it only fills an existing nullable column. If a filed observation is wrong, the durable record can be closed, marked fixed, or superseded through the existing ledger workflow; no schema rollback is needed.
+
+## Conclusion
+
+This slice is clear to ship as Tier 1. It adds a narrow, post-drive observation tool; keeps classification signal-only; files findings through the existing ledger; and fixes the storage bug that would otherwise erase the parent-principle citation required by the UX-blindspot work.


### PR DESCRIPTION
## Summary

Adds a post-drive transcript auditor for fix B. Given topic ids and a drive window, the command reads existing topic history, classifies operator-seat UX antipatterns, prints a structured report, and files each finding through the framework issue ledger with stable dedupe keys.

This covers:
- duplicate notices or deliveries
- asks of the user to resend, retry, or re-paste
- internal infrastructure noise
- content-free status updates

Also fixes the framework issue ledger so `relatedSpec` citations passed to the observe path are persisted on create and backfilled on later matching observations.

## ELI16

Plain-English version: after a supervised drive, the agent can scan the real Telegram transcript and turn visible friction into durable framework-issue findings instead of leaving it buried in chat.

This is intentionally signal-only. It does not block messages, retry messages, alter transcript history, or add a mentor judgment loop. It only records observations with evidence pointers so later review has structure.

Parent principle: Observation Needs Structure, merged in PR #861. Causal arc: latent UX-blindspot / operatorSeatUx work from PR #856.

## Live Fixture

Ran the auditor against topics 2278 and 2271 for the 2026-06-05 11:15-11:21 PDT window.

Dry-run initially exposed an ACK false positive. I tightened the content-free heuristic to focus on status chatter rather than required initial acknowledgements.

Final live run found and filed 3 observations:
- 1 duplicate-delivery group
- 2 content-free status-notice groups
- 0 resend/retry asks
- 0 infra-noise findings

Repeated live run deduped the observations instead of creating new rows. Because the currently running server still had the pre-fix ledger code loaded, I directly updated the three live rows with the related-spec citation after confirming the code fix preserves it going forward.

## Validation

- claim-check run before build
- targeted unit tests: 50 passing across transcript auditor and framework issue ledger suites
- build passed
- lint passed
- Tier-1 dev gate passed with ELI16 and side-effects artifacts
- pre-push gate passed with version warning only
- path-scoped threadline e2e initially hit a transient SQLite lock; reran the failed suite and it passed (17 tests). Local path-scoped e2e was skipped on push after that rerun; CI remains authoritative for the full matrix.

## Causal Autopsy

`origin=latent`

The issue was not introduced by this PR. The transcript UX was observable in chat, but there was no structural post-drive audit artifact that forced those observations into the framework issue ledger. This PR gives that observation duty a durable shape.
