### PR TITLE
docs(coherence): P1 Coherence Journal spec (draft for review)

### DIFF
--- a/docs/specs/COHERENCE-JOURNAL-SPEC.eli16.md
+++ b/docs/specs/COHERENCE-JOURNAL-SPEC.eli16.md
@@ -1,0 +1,65 @@
+# Coherence Journal — the plain-English version
+
+## What we're building
+
+Each of my machines starts keeping a **diary**. Not feelings — logistics.
+Three kinds of entries to start:
+
+1. **"Topic moved"** — conversation 13481 is now on the Laptop, moved at
+   9:20pm because you asked. (This is the history you asked for by name:
+   which machine a topic was linked to, and when.)
+2. **"Session opened/closed"** — a work session for that topic started or
+   ended on this machine.
+3. **"Overnight job ran here"** — an autonomous run started on this machine
+   and wrote its results to *these files*. This line is the direct fix for
+   the night the Mini did a pile of analysis and the Laptop had no idea the
+   files existed.
+
+Every entry is one cheap line in a local file. A machine only ever writes
+its OWN diary — never anyone else's — which is the trick that makes the next
+part safe: machines simply **swap copies of each other's diaries** over the
+same secure machine-to-machine line they already use for everything else.
+No edit conflicts are possible, because nobody ever edits — diaries only
+grow, and only their owner adds lines.
+
+The swap is piggybacked on a check-in the machines already do on a schedule,
+so this adds essentially zero new chatter: "I have your diary up to line
+412" — "here are 413 through 420."
+
+## What you get out of it
+
+Ask any machine — not the "right" machine, ANY machine:
+- "Where did this conversation live this week, and why did it move?"
+- "Did the old machine actually close its session after the move?"
+- "Which machine has the overnight job's files, and what are they called?"
+
+One API call (or just reading the file — it works even when the server is
+choking, a lesson from this afternoon).
+
+## The seatbelts
+
+- Diary lines are **logistics only** — ids, paths, timestamps, reasons.
+  Never message contents, never anything secret-shaped (a scrubber runs over
+  every line as a double-check).
+- If the diary somehow can't be written, the real work (moving the topic,
+  running the session) proceeds anyway — the notebook must never break the
+  thing it's describing.
+- Crash mid-line? The half-line is cleanly repaired on restart. Same message
+  delivered twice? Dropped by line numbering. Both were live failure modes
+  this afternoon; both are now tests, not hopes.
+- Ships dark on the fleet, live on me (echo) first — the standard pattern.
+
+## Also riding along
+
+The census from P0 gets its **enforcement teeth** here: a build-time check
+that fails if any new feature writes durable state without declaring it in
+the registry. That's the "nothing becomes machine-local by accident ever
+again" guarantee.
+
+## Two questions for you (in §8)
+
+1. How long should diary history be kept? (Proposed: rotate at 16MB, keep
+   4 archives — call it weeks. Placement history could be kept forever if
+   you want; those lines are tiny.)
+2. OK to close P1 with the real two-machine proof on your live fleet —
+   move a topic, then read its history from both machines?

--- a/docs/specs/COHERENCE-JOURNAL-SPEC.md
+++ b/docs/specs/COHERENCE-JOURNAL-SPEC.md
@@ -1,0 +1,228 @@
+---
+title: "Coherence Journal — per-machine append-only event streams (P1 of multi-machine coherence)"
+slug: "coherence-journal"
+author: "echo"
+eli16-overview: "COHERENCE-JOURNAL-SPEC.eli16.md"
+status: "draft"
+layer: "core-instar-primitive"
+parent-principle: "Structure > Willpower — cross-machine awareness comes from a structural event stream, not from any session remembering to report what it did"
+parent-spec: "MULTI-MACHINE-COHERENCE-MASTER-SPEC.md"
+project: "multimachine-coherence"
+project-items: "P1.1 coherence-journal-core, P1.2 topic-placement-history-api, P1.3 journal-peer-replication"
+---
+
+# Coherence Journal (P1)
+
+> **One sentence:** every machine keeps a cheap append-only diary of the
+> events that matter for cross-machine coordination — topic placement,
+> session lifecycle, autonomous-run artifacts — and machines replicate each
+> other's diaries over the existing authenticated mesh, so any machine can
+> answer "what happened where, and where are the files?" from local disk.
+
+## 1. Motivation (inherited)
+
+Master spec §5-P1. The concrete consumer questions, each a real failure from
+the 2026-06-05 record:
+
+- "Which machine was topic 13481 on last night, and why did it move?" —
+  today answerable only by grepping one machine's server log (which rotates).
+- "The Mini ran an overnight workstream for topic 19437 — where are its
+  artifacts?" — today unanswerable from the Laptop (the EXO stranding).
+- "Did a session for this topic close on the old machine after the move?" —
+  today requires reading reap-log on THAT machine.
+
+## 2. Scope
+
+**In (P1.1–P1.3):** the journal writer library; THREE event kinds wired
+(topic-placement, session-lifecycle, autonomous-run); the `journal-sync`
+MeshRpc verb + replication loop; `GET /coherence/journal` merged read API;
+the machine-readable State-Coherence Registry JSON + new-store CI lint
+(master spec §5-P0 enforcement, landing with its first consumer as planned).
+
+**Out (explicitly):** gap-check digests + working-set pull (P2); threadline
+event semantics beyond the basic conversation-bound record (P3); replicating
+any EXISTING audit stream (reap-log etc. stay machine-local); commitments
+store convergence (P1.5 follow-up spec, per Justin's approved
+recommendation); any UI beyond the read API.
+
+## 3. Design
+
+### 3.1 The stream
+
+Path: `<stateDir>/state/coherence-journal/<sanitized-machineId>.jsonl`
+(sanitization mirrors `MachineHeartbeat`'s `[^A-Za-z0-9_-]` rule; the
+`coherence-journal/` dir joins `ensureStateDir()`). Replicated peer copies
+land read-only at `.../coherence-journal/peers/<machineId>.jsonl`.
+
+One JSON object per line:
+
+```jsonc
+{
+  "seq": 412,                        // strictly monotonic per stream, no gaps
+  "ts": "2026-06-05T21:40:00.000Z",
+  "machine": "m_cc2ec651…",          // author (redundant with filename; survives copies)
+  "kind": "topic-placement",         // the taxonomy, §3.2
+  "topic": 13481,                    // present when topic-scoped
+  "data": { ... }                    // kind-specific, metadata-only
+}
+```
+
+Writer rules (the journal writer is ONE class, `CoherenceJournal`):
+- **Append-only, fsync-on-write, own stream only.** A machine never writes
+  another machine's file (single-writer-per-stream ⇒ replication is
+  conflict-free by construction).
+- **Strictly monotonic `seq`** persisted via the file itself (last line on
+  open; a partial trailing line from a crash is truncated on open — the
+  recovery test in §6).
+- **Metadata only.** Ids, paths, statuses, machines, reasons, timestamps.
+  Never message content, never secret-bearing fields; the live-tail
+  redaction enum runs over `data` values as defense-in-depth.
+- **Never throws into its caller.** A journal-emit failure logs + increments
+  a degradation counter; it must never break placement/session/autonomous
+  code paths. (Observability must not endanger the observed.)
+- **Standby-safe:** journal writes are `sessionScoped`-class (own-stream
+  files), permitted on a read-only standby the same way pool session writes
+  are — the standby guard exception pattern, scoped to the journal dir.
+
+### 3.2 Event taxonomy (P1 ships exactly these)
+
+| kind | emitted when | data |
+|------|--------------|------|
+| `topic-placement` | ownership CAS commits (place/claim/transfer/release/failover) | `{ owner, prevOwner?, epoch, reason }` — reason ∈ `user-move` \| `placed` \| `failover` \| `released` \| `quota-block-move` |
+| `session-lifecycle` | session created / completed / killed / reaped | `{ sessionId, status, reapReason? }` |
+| `autonomous-run` | autonomous job start gate passes / job stops | `{ action: "started"\|"stopped", artifactPaths: [".instar/autonomous/13481.local.md", …] }` — **artifactPaths is the EXO fix's foundation** |
+
+Adding a kind later = append a writer call + a row to the registry; the
+format is forward-compatible (readers ignore unknown kinds).
+
+### 3.3 Emission points (grounded)
+
+- **topic-placement:** the ownership CAS chokepoint —
+  `SessionOwnershipRegistry` (the store behind `SessionRouter.deps.casClaimOwnership`,
+  `src/core/SessionRouter.ts:107,241`) plus the explicit-transfer path
+  (`POST /pool/transfer` planner). Emit AFTER the CAS commits, with the
+  winning epoch. Every path that mutates ownership goes through the CAS —
+  that is the invariant that makes one emit point sufficient; the
+  wiring-integrity test (§6) enforces it.
+- **session-lifecycle:** `SessionManager` at the three `saveSession`
+  lifecycle sites (create / complete / kill) + the reaper's reap event
+  (alongside the existing reap-log append — the journal entry references the
+  reap-log line, not duplicates it).
+- **autonomous-run:** start — at the `can-start` gate's grant (server-side,
+  the one structural point every autonomous start passes); stop —
+  `AutonomousSessions.stopAutonomousTopic` / `stopAllAutonomousJobs`. The
+  started event records the `.local.md` path it will own; a later
+  `artifact-declared` data field (same kind, action `artifacts-updated`) lets
+  a running session declare additional output paths.
+
+### 3.4 Replication — `journal-sync` verb
+
+New `MeshCommand`: `{ type: 'journal-sync'; watermarks: Record<MachineId, number>; entries?: JournalEntry[] }`
+(union at `src/core/MeshRpc.ts:29-36`; RBAC class: any registered peer,
+read/observe — same class as `capacity-report`; handler wired in the
+`commands/server.ts` mesh dispatcher `handlers` block alongside
+`secret-share`).
+
+Loop (piggybacks the existing capacity-heartbeat cadence — no new timer):
+1. With each heartbeat exchange, a machine includes its journal watermarks
+   `{machineId → highest seq held}` (own + replicated).
+2. A peer holding newer entries for any stream responds (or pushes) the
+   delta, batched and size-capped (`journalSyncMaxBatchBytes`, default 256KB).
+3. Receiver validates: entries for stream M must come in seq order,
+   appending only `lastHeldSeq + 1 …` (gaps → hold + re-request; duplicates →
+   drop silently). Idempotent under redelivery by construction.
+4. Transport authenticity = the existing machineAuth envelope. No journal
+   data ever rides Threadline.
+
+**Pull-first:** a machine asks for what it's missing; unsolicited bulk push
+is bounded to the heartbeat piggyback (the secret-sync anti-clobber lesson —
+and a stale machine can't corrupt anything anyway: it only ever appends to
+its OWN stream and serves immutable history).
+
+### 3.5 Read API
+
+`GET /coherence/journal?topic=N&kind=topic-placement&machine=M&limit=100&before=<seq|ts>`
+→ merged, ts-ordered view over own + peer streams:
+`{ entries: [...], streams: { <machineId>: { lastSeq, lastTs, source: "own"|"replica" } } }`.
+
+- Answers "where did topic N live and when" in one call from ANY machine.
+- Degradation rule (master spec §6.4): the journal is plain JSONL on disk —
+  the CLI/hooks may read the files directly when HTTP is starved; the route
+  is a convenience, not the only door.
+
+### 3.6 Registry JSON + CI lint (the P0 enforcement, shipping here)
+
+- `src/data/state-coherence-registry.json` — machine form of the approved
+  registry doc (category → axes → transport). The journal registers itself
+  as its first entry.
+- `scripts/lint-state-registry.js` — sweeps `src/` for durable-write
+  patterns (writeFileSync/appendFileSync/JSONL append/SQLite open targeting
+  state dirs); fails CI when a store has no registry entry. Modeled on
+  `lint-no-unfunneled-topic-creation.js`. Existing ~100 categories are
+  seeded from the census so the lint lands green, with `grandfathered: true`
+  markers where the census was uncertain (§4e of the registry doc).
+
+### 3.7 Config & rollout
+
+`.instar/config.json` → `multiMachine.coherenceJournal`:
+`{ enabled ?? !!developmentAgent, replication: { enabled ?? same, maxBatchBytes: 262144 }, retention: { maxFileBytes: 16777216, rotateKeep: 4 } }`.
+Dark on the fleet, live on echo (the `developmentAgent` gate standard).
+Single-machine agents: writer on (cheap, locally useful), replication no-op.
+Rotation: size-based rotate with the date-partitioned archive pattern;
+watermarks survive rotation (seq continues across files; sync serves from
+archive when a peer is far behind).
+
+## 4. Degradation requirements (inherited, master spec §6 — restated as behaviors)
+
+1. `journal-sync` acks only after the receiver's append fsyncs (ack-after-durable-commit).
+2. Crash mid-append → truncated partial line repaired on next open; seq
+   resumes correctly (kill -9 test).
+3. Every verb idempotent under redelivery (seq-gated appends).
+4. Journal files readable without the server (plain JSONL; no lock needed
+   for readers).
+5. Cheap: emits are single-line appends; replication is delta-only,
+   batch-capped, heartbeat-cadenced. No scans, ever.
+
+## 5. Security
+
+Master spec §8 verbatim applies: metadata-only entries, redaction enum over
+`data`, machineAuth-only transport, registered-peer RBAC. Peer streams are
+read-only on disk (mode 0444 after append? — no: receiver appends, so 0644
+with the single-writer rule enforced in code + a test).
+
+## 6. Testing (all three tiers + degradation)
+
+- **Unit:** writer (monotonic seq, append-only, crash-repair on open,
+  rotation continuity, redaction, never-throws-into-caller); watermark
+  merge; seq-gated apply (gap hold, duplicate drop).
+- **Integration:** two in-process journals round-trip `journal-sync` deltas
+  through the real MeshRpc envelope; `GET /coherence/journal` merged view +
+  filters; standby-write permitted via the scoped guard; registry lint green
+  on the seeded registry and red on an undeclared synthetic store.
+- **E2E:** production-init boots writer + route alive (200-not-503); a
+  simulated place→transfer→close sequence yields the correct placement
+  history from BOTH machines' read APIs; kill -9 mid-append → clean resume
+  (degradation tier).
+- **Wiring-integrity:** the CAS chokepoint, the three SessionManager
+  lifecycle sites, and both autonomous paths each emit — asserted by tests
+  that run those code paths and read the journal (the seamlessness Phase-0
+  lesson: unwired sync ships dead).
+
+## 7. Work breakdown (P1.1 → P1.3, one PR each unless trivially small)
+
+1. **P1.1** `CoherenceJournal` writer + emission wiring (placement /
+   session / autonomous) + registry JSON + CI lint + unit tests.
+2. **P1.2** `GET /coherence/journal` + reading merged streams + integration
+   tests. (Small; may ride with P1.1.)
+3. **P1.3** `journal-sync` verb + heartbeat piggyback + replication loop +
+   E2E across two in-process servers + live two-machine verification
+   (Laptop+Mini: move a topic, read its history from both sides).
+
+## 8. Open questions for Justin
+
+1. **Retention horizon** — proposed: size-rotate at 16MB keeping 4 archives
+   (~weeks of history). Enough, or do you want placement history effectively
+   forever (tiny events; could keep placement kind unrotated)?
+2. **Live verification scope for P1.3** — the real two-machine proof
+   (move topic, read history from both machines) — fine to run it on your
+   live fleet as the closing step, as we did for the pool features?


### PR DESCRIPTION
## ELI16 overview (plain English)

Each machine starts keeping a cheap append-only **diary** of coordination events — "topic 13481 moved to the Laptop at 9:20pm because the user asked," "an overnight job ran HERE and wrote its results to THESE files," "the session for that topic closed after the move." A machine only ever writes its own diary, and machines swap copies of each other's diaries over the secure line they already use — piggybacked on an existing scheduled check-in, so near-zero new chatter, and no merge conflicts are possible because diaries only grow. Result: ask ANY machine "where did this conversation live this week and where are its files?" and get a real answer. The diary lines are logistics-only (never message contents), the diary can never break the work it describes, and crash/duplicate handling comes from this afternoon's live failures — as tests, not hopes. Also riding along: the census from P0 gets its enforcement teeth — a build-time check that fails if new code writes durable state without declaring it in the registry.

## What this PR is

The P1 spec (draft) for the `multimachine-coherence` project — items P1.1–P1.3. Docs only. Per the per-round pipeline it goes through spec-converge before any build; Justin reviews via the rendered ELI16 + this PR.

- `docs/specs/COHERENCE-JOURNAL-SPEC.md` — design grounded against the real chokepoints: `SessionOwnershipRegistry` CAS (placement), `SessionManager` lifecycle sites, `AutonomousSessions` stop paths, the `MeshCommand` union + dispatcher wiring pattern (`secret-share` precedent), `MachineHeartbeat` cadence piggyback, per-machine file naming conventions.
- `docs/specs/COHERENCE-JOURNAL-SPEC.eli16.md` — the plain-English companion.

## Open questions (spec §8)

1. Retention horizon — size-rotate at 16MB×4 archives, or keep placement history forever?
2. OK to close P1.3 with the live two-machine proof (move a topic, read its history from both machines)?

Follows merged P0 #860 (census + master spec, approved). Dark on the fleet, live on echo via the `developmentAgent` gate when built.

🤖 Generated with [Claude Code](https://claude.com/claude-code)