### PR TITLE
fix(coherence): render every agent-facing timestamp in local time with tz label

### DIFF
--- a/.instar/instar-dev-decisions/2026-06-06T02-25-49-863Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-06-06T02-25-49-863Z-unknown.json
@@ -1,0 +1,16 @@
+{
+  "ts": "2026-06-06T02:25:49.863Z",
+  "slug": "unknown",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "irreversibility: src/core/PostUpdateMigrator.ts touches PostUpdateMigrator",
+    "migration / fleet-rollout surface: src/core/PostUpdateMigrator.ts touches PostUpdateMigrator (fleet migration machinery)"
+  ],
+  "belowFloor": true,
+  "files": 11,
+  "loc": 149,
+  "causalAutopsy": null,
+  "verdict": "pass"
+}

--- a/src/commands/server.ts
+++ b/src/commands/server.ts
@@ -118,6 +118,7 @@ import { StaleProcessGuard } from '../core/StaleProcessGuard.js';
 import { cleanupGlobalInstalls } from '../core/GlobalInstallCleanup.js';
 import { ForegroundRestartWatcher } from '../core/ForegroundRestartWatcher.js';
 import { NotificationBatcher } from '../messaging/NotificationBatcher.js';
+import { formatLocalTimestamp } from '../utils/localTime.js';
 import type { NotificationTier } from '../messaging/NotificationBatcher.js';
 import { MessageStore } from '../messaging/MessageStore.js';
 import { MessageFormatter } from '../messaging/MessageFormatter.js';
@@ -477,7 +478,7 @@ async function spawnSessionForTopic(
           const sender = m.fromUser
             ? (m.senderName || 'User')
             : 'Agent';
-          const ts = m.timestamp ? new Date(m.timestamp).toISOString().slice(11, 19) : '??:??';
+          const ts = formatLocalTimestamp(m.timestamp); // local + tz label (see src/utils/localTime.ts)
           const text = (m.text || '').slice(0, 2000);
           lines.push(`[${ts}] ${sender}: ${text}`);
         }

--- a/src/core/ForwardedTopicContext.ts
+++ b/src/core/ForwardedTopicContext.ts
@@ -14,6 +14,8 @@
  * Pure + caller-agnostic so it is unit-testable without a live two-machine setup.
  */
 
+import { formatLocalTimestamp } from '../utils/localTime.js';
+
 /** One historical message, matching TelegramAdapter.getTopicHistory()'s shape. */
 export interface ForwardedHistoryMessage {
   fromUser: boolean;
@@ -40,11 +42,9 @@ export function formatForwardedTopicContext(
   lines.push('');
   for (const m of messages) {
     const sender = m.fromUser ? (m.senderName || 'User') : 'Agent';
-    let ts = '??:??';
-    if (m.timestamp != null) {
-      const d = new Date(m.timestamp);
-      if (!Number.isNaN(d.getTime())) ts = d.toISOString().slice(11, 19);
-    }
+    // Local time + tz label — unlabeled UTC here caused the 2026-06-05
+    // "9:23pm" incoherency (see src/utils/localTime.ts).
+    const ts = formatLocalTimestamp(m.timestamp);
     const text = (m.text || '').slice(0, 2000);
     lines.push(`[${ts}] ${sender}: ${text}`);
   }

--- a/src/core/PostUpdateMigrator.ts
+++ b/src/core/PostUpdateMigrator.ts
@@ -6117,10 +6117,16 @@ if [ -n "\$INSTAR_TELEGRAM_TOPIC" ]; then
         echo "RECENT MESSAGES:"
         echo "\$TOPIC_CTX" | python3 -c "
 import sys, json
+def _localts(raw):
+    try:
+        from datetime import datetime
+        return datetime.fromisoformat(str(raw).replace('Z', '+00:00')).astimezone().strftime('%Y-%m-%d %H:%M %Z')
+    except Exception:
+        return str(raw)[:16].replace('T', ' ')
 d = json.load(sys.stdin)
 for m in d.get('recentMessages', []):
     sender = 'User' if m.get('fromUser') else 'Agent'
-    ts = m.get('timestamp', '')[:16].replace('T', ' ')
+    ts = _localts(m.get('timestamp', ''))
     text = m.get('text', '')
     if len(text) > 500:
         text = text[:500] + '...'
@@ -6994,6 +7000,12 @@ fi
 # Format and output context with unanswered message detection
 echo "\$RECENT_MSGS" | python3 -c "
 import sys, json
+def _localts(raw):
+    try:
+        from datetime import datetime
+        return datetime.fromisoformat(str(raw).replace('Z', '+00:00')).astimezone().strftime('%Y-%m-%d %H:%M %Z')
+    except Exception:
+        return str(raw)[:16].replace('T', ' ')
 try:
     data = json.load(sys.stdin)
     msgs = data.get('messages', [])
@@ -7003,7 +7015,7 @@ try:
     print('TOPIC \${TOPIC_ID} RECENT HISTORY (auto-injected):')
 
     for m in msgs:
-        ts = m.get('timestamp', '')[:16].replace('T', ' ')
+        ts = _localts(m.get('timestamp', ''))
         from_user = m.get('fromUser', m.get('direction', 'in') == 'in')
         text = m.get('text', '').strip()
         sender = 'User' if from_user else 'Agent'
@@ -7028,7 +7040,7 @@ try:
         print('*** UNANSWERED MESSAGE(S) FROM USER ***')
         for pm in pending_user:
             pm_text = pm.get('text', '')[:200]
-            pm_ts = pm.get('timestamp', '')[:16].replace('T', ' ')
+            pm_ts = _localts(pm.get('timestamp', ''))
             print(f'  [{pm_ts}] \\\\\\\"{pm_text}\\\\\\\"')
         print()
         print('You MUST address these messages substantively. Do NOT respond with just')
@@ -7091,11 +7103,17 @@ if [ -n "\$INSTAR_TELEGRAM_TOPIC" ]; then
         echo "RECENT MESSAGES:"
         echo "\$TOPIC_CTX" | python3 -c "
 import sys, json
+def _localts(raw):
+    try:
+        from datetime import datetime
+        return datetime.fromisoformat(str(raw).replace('Z', '+00:00')).astimezone().strftime('%Y-%m-%d %H:%M %Z')
+    except Exception:
+        return str(raw)[:16].replace('T', ' ')
 d = json.load(sys.stdin)
 msgs = d.get('recentMessages', [])
 for m in msgs:
     sender = 'User' if m.get('fromUser') else 'Agent'
-    ts = m.get('timestamp', '')[:16].replace('T', ' ')
+    ts = _localts(m.get('timestamp', ''))
     text = m.get('text', '')
     if len(text) > 500:
         text = text[:500] + '...'
@@ -7118,7 +7136,7 @@ if pending_user:
     print('UNANSWERED MESSAGE(S) FROM USER:')
     for pm in pending_user:
         pm_text = pm.get('text', '')[:200]
-        pm_ts = pm.get('timestamp', '')[:16].replace('T', ' ')
+        pm_ts = _localts(pm.get('timestamp', ''))
         print(f'  [{pm_ts}] \\\"{pm_text}\\\"')
     print()
     print('You MUST address these messages substantively. Do NOT respond')

--- a/src/lifeline/TelegramLifeline.ts
+++ b/src/lifeline/TelegramLifeline.ts
@@ -82,6 +82,7 @@ import { DegradationReporter } from '../monitoring/DegradationReporter.js';
 import { applyTelegramFormatter } from '../messaging/TelegramAdapter.js';
 import type { FormatMode } from '../messaging/TelegramMarkdownFormatter.js';
 import { recordFormatFallbackPlainRetry } from '../messaging/telegramFormatMetrics.js';
+import { formatLocalTimestamp } from '../utils/localTime.js';
 
 /**
  * Acquire an exclusive lock file to prevent multiple lifeline instances.
@@ -1698,7 +1699,7 @@ export class TelegramLifeline {
         `  Restart attempts: ${status.restartAttempts}`,
         `  Total failures: ${status.totalFailures}`,
         `  Queued messages: ${queueSize}`,
-        `  Last healthy: ${status.lastHealthy ? new Date(status.lastHealthy).toISOString().slice(11, 19) : 'never'}`,
+        `  Last healthy: ${status.lastHealthy ? formatLocalTimestamp(status.lastHealthy, { date: false, seconds: true }) : 'never'}`,
       ];
       if (status.circuitBroken) {
         lines.push(`  Circuit breaker: TRIPPED — use /lifeline reset to retry`);

--- a/src/memory/TopicMemory.ts
+++ b/src/memory/TopicMemory.ts
@@ -24,6 +24,7 @@ import readline from 'node:readline';
 import { SafeFsExecutor } from '../core/SafeFsExecutor.js';
 import { NativeModuleHealer } from './NativeModuleHealer.js';
 import { registerSqliteHandle } from '../core/SqliteRegistry.js';
+import { formatLocalTimestamp } from '../utils/localTime.js';
 
 // Dynamic import for better-sqlite3
 type Database = import('better-sqlite3').Database;
@@ -941,7 +942,7 @@ export class TopicMemory {
         const sender = m.fromUser
           ? (m.senderName || 'User')
           : 'Agent';
-        const ts = m.timestamp ? new Date(m.timestamp).toISOString().slice(11, 19) : '??:??';
+        const ts = formatLocalTimestamp(m.timestamp); // local + tz label (see src/utils/localTime.ts)
         const text = (m.text || '').slice(0, 2000);
         lines.push(`[${ts}] ${sender}: ${text}`);
       }
@@ -995,7 +996,7 @@ export class TopicMemory {
         const sender = m.fromUser
           ? (m.senderName || 'User')
           : 'Agent';
-        const ts = m.timestamp ? new Date(m.timestamp).toISOString().slice(11, 19) : '??:??';
+        const ts = formatLocalTimestamp(m.timestamp); // local + tz label (see src/utils/localTime.ts)
         const text = (m.text || '').slice(0, 2000);
         lines.push(`[${ts}] ${sender}: ${text}`);
       }

--- a/src/messaging/shared/compactionResumePayload.ts
+++ b/src/messaging/shared/compactionResumePayload.ts
@@ -24,6 +24,7 @@
 import fs from 'fs';
 import path from 'path';
 import { randomUUID } from 'crypto';
+import { formatLocalTimestamp } from '../../utils/localTime.js';
 
 export const COMPACTION_RESUME_PREAMBLE =
   [
@@ -59,7 +60,7 @@ export function formatInlineHistory(
   lines.push('');
   for (const m of entries) {
     const sender = m.fromUser ? (m.senderName || 'User') : 'Agent';
-    const ts = m.timestamp ? new Date(m.timestamp).toISOString().slice(11, 19) : '??:??';
+    const ts = formatLocalTimestamp(m.timestamp); // local + tz label (see src/utils/localTime.ts)
     const text = (m.text || '').slice(0, 2000);
     lines.push(`[${ts}] ${sender}: ${text}`);
   }

--- a/src/server/routes.ts
+++ b/src/server/routes.ts
@@ -77,6 +77,7 @@ import {
 } from './attentionApi.js';
 import { dashboardRefreshFailure } from './DashboardRefreshDiagnostics.js';
 import { KNOWN_GEMINI_MODELS } from '../providers/adapters/gemini-cli/models.js';
+import { formatLocalTimestamp } from '../utils/localTime.js';
 
 const execFile = promisify(execFileCb);
 
@@ -10463,7 +10464,7 @@ export function createRoutes(ctx: RouteContext): Router {
               historyLines.push(``);
               for (const m of history) {
                 const sender = m.fromUser ? (m.senderName || 'User') : 'Agent';
-                const ts = m.timestamp ? new Date(m.timestamp).toISOString().slice(11, 19) : '??:??';
+                const ts = formatLocalTimestamp(m.timestamp); // local + tz label (see src/utils/localTime.ts)
                 const histText = (m.text || '').slice(0, 2000);
                 historyLines.push(`[${ts}] ${sender}: ${histText}`);
               }
@@ -11100,7 +11101,7 @@ export function createRoutes(ctx: RouteContext): Router {
                 const sender = m.fromUser
                   ? (m.senderName || 'User')
                   : 'Agent';
-                const ts = m.timestamp ? new Date(m.timestamp).toISOString().slice(11, 19) : '??:??';
+                const ts = formatLocalTimestamp(m.timestamp); // local + tz label (see src/utils/localTime.ts)
                 const histText = (m.text || '').slice(0, 2000);
                 historyLines.push(`[${ts}] ${sender}: ${histText}`);
               }

--- a/src/templates/hooks/compaction-recovery.sh
+++ b/src/templates/hooks/compaction-recovery.sh
@@ -265,6 +265,12 @@ if [ -f "$CONFIG_FILE" ]; then
 
         echo "$SLACK_MSGS" | python3 -c "
 import sys, json
+def _localts(raw):
+    try:
+        from datetime import datetime
+        return datetime.fromisoformat(str(raw).replace('Z', '+00:00')).astimezone().strftime('%Y-%m-%d %H:%M %Z')
+    except Exception:
+        return str(raw)[:16].replace('T', ' ')
 try:
     data = json.load(sys.stdin)
     msgs = data.get('messages', [])
@@ -281,7 +287,7 @@ try:
         try:
             from datetime import datetime
             dt = datetime.fromtimestamp(float(ts))
-            time_str = dt.strftime('%H:%M:%S')
+            time_str = dt.astimezone().strftime('%H:%M:%S %Z')
         except:
             time_str = ts[:8] if ts else '??:??:??'
         user = m.get('user', 'unknown')
@@ -373,6 +379,12 @@ except Exception:
         # Format messages and detect unanswered user messages
         echo "$RECENT_MSGS" | python3 -c "
 import sys, json
+def _localts(raw):
+    try:
+        from datetime import datetime
+        return datetime.fromisoformat(str(raw).replace('Z', '+00:00')).astimezone().strftime('%Y-%m-%d %H:%M %Z')
+    except Exception:
+        return str(raw)[:16].replace('T', ' ')
 try:
     data = json.load(sys.stdin)
     msgs = data.get('messages', [])
@@ -383,7 +395,7 @@ try:
     print('--- RECENT TELEGRAM CONTEXT (restoring after compaction, last %d messages) ---' % len(msgs))
 
     for m in msgs:
-        ts = m.get('timestamp', '')[:16].replace('T', ' ')
+        ts = _localts(m.get('timestamp', ''))
         from_user = m.get('fromUser', m.get('direction', 'in') == 'in')
         text = m.get('text', '').strip()
         sender = 'User' if from_user else 'Agent'
@@ -409,7 +421,7 @@ try:
         print('UNANSWERED MESSAGE(S) FROM USER:')
         for pm in pending_user:
             pm_text = pm.get('text', '')[:200]
-            pm_ts = pm.get('timestamp', '')[:16].replace('T', ' ')
+            pm_ts = _localts(pm.get('timestamp', ''))
             print(f'  [{pm_ts}] \"{pm_text}\"')
         print()
         print('You MUST address these messages substantively. Do NOT respond')

--- a/src/templates/hooks/slack-channel-context.sh
+++ b/src/templates/hooks/slack-channel-context.sh
@@ -78,7 +78,7 @@ for msg in messages:
     ts = msg.get('ts', '')
     try:
         dt = datetime.fromtimestamp(float(ts))
-        time_str = dt.strftime('%H:%M:%S')
+        time_str = dt.astimezone().strftime('%H:%M:%S %Z')
     except:
         time_str = ts
 

--- a/src/templates/hooks/telegram-topic-context.sh
+++ b/src/templates/hooks/telegram-topic-context.sh
@@ -105,6 +105,12 @@ fi
 # Format and output context with unanswered message detection
 echo "$RECENT_MSGS" | python3 -c "
 import sys, json
+def _localts(raw):
+    try:
+        from datetime import datetime
+        return datetime.fromisoformat(str(raw).replace('Z', '+00:00')).astimezone().strftime('%Y-%m-%d %H:%M %Z')
+    except Exception:
+        return str(raw)[:16].replace('T', ' ')
 try:
     data = json.load(sys.stdin)
     msgs = data.get('messages', [])
@@ -114,7 +120,7 @@ try:
     print('TOPIC ${TOPIC_ID} RECENT HISTORY (auto-injected — read this before responding):')
 
     for m in msgs:
-        ts = m.get('timestamp', '')[:16].replace('T', ' ')
+        ts = _localts(m.get('timestamp', ''))
         from_user = m.get('fromUser', m.get('direction', 'in') == 'in')
         text = m.get('text', '').strip()
         sender = 'User' if from_user else 'Agent'
@@ -139,7 +145,7 @@ try:
         print('*** UNANSWERED MESSAGE(S) FROM USER ***')
         for pm in pending_user:
             pm_text = pm.get('text', '')[:200]
-            pm_ts = pm.get('timestamp', '')[:16].replace('T', ' ')
+            pm_ts = _localts(pm.get('timestamp', ''))
             print(f'  [{pm_ts}] \"{pm_text}\"')
         print()
         print('You MUST address these messages substantively. Do NOT respond with just')

--- a/src/utils/localTime.ts
+++ b/src/utils/localTime.ts
@@ -1,0 +1,62 @@
+/**
+ * Local-timezone timestamp rendering for agent-facing context blocks.
+ *
+ * Why this exists (2026-06-05 time-incoherency incident): every injected
+ * thread-history surface rendered timestamps as unlabeled UTC
+ * (`toISOString().slice(11, 19)`). An agent read `[21:23:10]` as local
+ * wall-clock and told the user "you heard nothing between 9:23pm and now"
+ * about an event that happened at 2:23pm the user's time — while the
+ * session-start hook injects CURRENT TIME in local time. Two clocks, one
+ * labeled, one not.
+ *
+ * Structure > Willpower: agents cannot be trusted to remember that history
+ * timestamps are UTC while wall-clock is local. Every timestamp an agent
+ * sees MUST be rendered in the host's local timezone with an explicit
+ * timezone label, so no conversion discipline is required.
+ *
+ * All thread-history / topic-context / compaction-resume renderers MUST use
+ * this helper instead of hand-rolling `toISOString()` slices.
+ */
+
+/**
+ * The host's short timezone label for a given instant (e.g. "PDT", "GMT+2").
+ * Empty string if Intl can't resolve one — callers render without a label
+ * rather than failing.
+ */
+export function localTzAbbreviation(d: Date = new Date()): string {
+  try {
+    const part = new Intl.DateTimeFormat('en-US', { timeZoneName: 'short' })
+      .formatToParts(d)
+      .find((p) => p.type === 'timeZoneName');
+    return part?.value ?? '';
+  } catch {
+    return '';
+  }
+}
+
+/**
+ * Format a timestamp in the HOST's local timezone with an explicit tz label.
+ *
+ * Default shape: `2026-06-05 14:23 PDT` (date + minutes + label) — history
+ * lines spanning midnight stay unambiguous, and minute granularity matches
+ * how users talk about time. Options:
+ *   - `date: false`   → `14:23 PDT` (for compact status lines)
+ *   - `seconds: true` → include `:SS`
+ *
+ * Invalid / missing input renders as `??:??` (the existing sentinel the
+ * history formats already used).
+ */
+export function formatLocalTimestamp(
+  input: string | number | Date | null | undefined,
+  opts: { date?: boolean; seconds?: boolean } = {},
+): string {
+  if (input == null || input === '') return '??:??';
+  const d = input instanceof Date ? input : new Date(input);
+  if (Number.isNaN(d.getTime())) return '??:??';
+  const pad = (n: number) => String(n).padStart(2, '0');
+  const datePart =
+    opts.date === false ? '' : `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())} `;
+  const time = `${pad(d.getHours())}:${pad(d.getMinutes())}${opts.seconds ? `:${pad(d.getSeconds())}` : ''}`;
+  const tz = localTzAbbreviation(d);
+  return `${datePart}${time}${tz ? ` ${tz}` : ''}`;
+}

--- a/tests/unit/ForwardedTopicContext.test.ts
+++ b/tests/unit/ForwardedTopicContext.test.ts
@@ -4,6 +4,7 @@
  */
 import { describe, it, expect } from 'vitest';
 import { formatForwardedTopicContext } from '../../src/core/ForwardedTopicContext.js';
+import { formatLocalTimestamp } from '../../src/utils/localTime.js';
 
 describe('formatForwardedTopicContext (moved-session context relay — bug #2)', () => {
   it('returns empty string for null / empty history (nothing to inject)', () => {
@@ -20,8 +21,10 @@ describe('formatForwardedTopicContext (moved-session context relay — bug #2)',
     expect(out).toContain('Thread History (last 2 messages, relayed from the previous machine)');
     expect(out).toContain('continue THIS conversation, not start something new');
     expect(out).toContain('Topic: deploys');
-    expect(out).toContain('[12:00:05] Justin: what is the deploy status?');
-    expect(out).toContain('[12:00:30] Agent: Shipped v1.3.165.');
+    // Local-tz rendering (2026-06-05 time-incoherency fix): timestamps are
+    // rendered in the HOST's local timezone with an explicit tz label.
+    expect(out).toContain(`[${formatLocalTimestamp('2026-05-31T12:00:05Z')}] Justin: what is the deploy status?`);
+    expect(out).toContain(`[${formatLocalTimestamp('2026-05-31T12:00:30Z')}] Agent: Shipped v1.3.165.`);
     expect(out.trimEnd().endsWith('--- End Thread History ---')).toBe(true);
   });
 

--- a/tests/unit/compactionResumePayload.test.ts
+++ b/tests/unit/compactionResumePayload.test.ts
@@ -24,6 +24,7 @@ import {
   type HistoryEntryLike,
 } from '../../src/messaging/shared/compactionResumePayload.js';
 import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+import { formatLocalTimestamp } from '../../src/utils/localTime.js';
 
 describe('buildCompactionResumePayload', () => {
   it('emits preamble-only when the context block is empty', () => {
@@ -100,14 +101,15 @@ describe('formatInlineHistory', () => {
     const out = formatInlineHistory(entries, { topicName: 'demo', label: 'THREAD' });
     expect(out).toContain('--- THREAD (last 2 messages) ---');
     expect(out).toContain('Topic: demo');
-    expect(out).toContain('[16:00:00] Justin: hi');
-    expect(out).toContain('[16:00:30] Agent: hello');
+    // Local-tz rendering (2026-06-05 time-incoherency fix)
+    expect(out).toContain(`[${formatLocalTimestamp('2026-04-17T16:00:00Z')}] Justin: hi`);
+    expect(out).toContain(`[${formatLocalTimestamp('2026-04-17T16:00:30Z')}] Agent: hello`);
     expect(out).toContain('--- END THREAD ---');
   });
 
   it('falls back to generic "User" when senderName missing', () => {
     const out = formatInlineHistory([{ text: 'hey', fromUser: true, timestamp: '2026-04-17T16:00:00Z' }]);
-    expect(out).toContain('[16:00:00] User: hey');
+    expect(out).toContain(`[${formatLocalTimestamp('2026-04-17T16:00:00Z')}] User: hey`);
   });
 
   it('truncates very long message bodies to 2000 chars', () => {
@@ -194,6 +196,6 @@ describe('integration — topic 6795 shape', () => {
     const payload = buildCompactionResumePayload(contextBlock);
     expect(payload).toContain(COMPACTION_RESUME_PREAMBLE);
     expect(payload).toContain('Okay, you really need to hand hold me through whatever I need to do here');
-    expect(payload).toContain('[16:24:00] Justin:');
+    expect(payload).toContain(`[${formatLocalTimestamp('2026-04-17T16:24:00Z')}] Justin:`);
   });
 });

--- a/tests/unit/localTime.test.ts
+++ b/tests/unit/localTime.test.ts
@@ -1,0 +1,78 @@
+/**
+ * Tier-1 tests for src/utils/localTime.ts — local-timezone timestamp rendering
+ * for agent-facing context blocks.
+ *
+ * Why this exists (2026-06-05 time-incoherency incident): thread-history
+ * surfaces rendered timestamps as unlabeled UTC. An agent read "[21:23:10]"
+ * as local wall-clock and told the user "you heard nothing between 9:23pm and
+ * now" about a 2:23pm-local event. These tests pin the contract: rendered
+ * timestamps are LOCAL (match the host's Date getters) and carry an explicit
+ * timezone label.
+ *
+ * TZ-portability: assertions compare against the same instant's local Date
+ * getters rather than hard-coding a zone, so the suite is green in any CI
+ * timezone while still proving "local, not UTC".
+ */
+import { describe, it, expect } from 'vitest';
+import { formatLocalTimestamp, localTzAbbreviation } from '../../src/utils/localTime.js';
+
+const pad = (n: number) => String(n).padStart(2, '0');
+
+describe('formatLocalTimestamp', () => {
+  it('renders the HOST-local wall-clock for a UTC instant (the incident case)', () => {
+    // The actual instant from the 2026-06-05 incident: 21:23:10Z was 14:23 PDT,
+    // but the unlabeled-UTC render led the agent to say "9:23pm".
+    const iso = '2026-06-05T21:23:10.000Z';
+    const d = new Date(iso);
+    const expected = `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())} ${pad(d.getHours())}:${pad(d.getMinutes())}`;
+    const out = formatLocalTimestamp(iso);
+    expect(out.startsWith(expected)).toBe(true);
+    // Unless the host runs in UTC, the local render MUST differ from the UTC slice.
+    if (d.getTimezoneOffset() !== 0) {
+      expect(out.startsWith('2026-06-05 21:23')).toBe(false);
+    }
+  });
+
+  it('always carries a timezone label when Intl can resolve one', () => {
+    const label = localTzAbbreviation(new Date('2026-06-05T21:23:10Z'));
+    const out = formatLocalTimestamp('2026-06-05T21:23:10Z');
+    if (label) {
+      expect(out.endsWith(` ${label}`)).toBe(true);
+    }
+    // Shape: YYYY-MM-DD HH:MM [label]
+    expect(out).toMatch(/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}( \S+)?$/);
+  });
+
+  it('includes the date by default so histories spanning midnight stay unambiguous', () => {
+    const out = formatLocalTimestamp('2026-06-06T00:25:35Z');
+    expect(out).toMatch(/^\d{4}-\d{2}-\d{2} /);
+  });
+
+  it('supports date:false and seconds:true options', () => {
+    const iso = '2026-06-05T21:23:10Z';
+    const d = new Date(iso);
+    const noDate = formatLocalTimestamp(iso, { date: false });
+    expect(noDate).toMatch(/^\d{2}:\d{2}( \S+)?$/);
+    const withSecs = formatLocalTimestamp(iso, { date: false, seconds: true });
+    expect(withSecs.startsWith(`${pad(d.getHours())}:${pad(d.getMinutes())}:${pad(d.getSeconds())}`)).toBe(true);
+  });
+
+  it('accepts epoch-ms numbers and Date objects', () => {
+    const ms = Date.parse('2026-06-05T21:23:10Z');
+    expect(formatLocalTimestamp(ms)).toBe(formatLocalTimestamp(new Date(ms)));
+  });
+
+  it("renders the '??:??' sentinel for missing / invalid input", () => {
+    expect(formatLocalTimestamp(undefined)).toBe('??:??');
+    expect(formatLocalTimestamp(null)).toBe('??:??');
+    expect(formatLocalTimestamp('')).toBe('??:??');
+    expect(formatLocalTimestamp('not-a-date')).toBe('??:??');
+  });
+});
+
+describe('localTzAbbreviation', () => {
+  it('returns a non-empty short label on a normal host (or empty, never throws)', () => {
+    const label = localTzAbbreviation();
+    expect(typeof label).toBe('string');
+  });
+});

--- a/tests/unit/telegram-autospawn-history.test.ts
+++ b/tests/unit/telegram-autospawn-history.test.ts
@@ -19,6 +19,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import os from 'node:os';
 import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+import { formatLocalTimestamp } from '../../src/utils/localTime.js';
 
 // ─── Extracted Logic Under Test ──────────────────────────────
 
@@ -51,7 +52,7 @@ function buildAutoSpawnContext(
       const sender = m.fromUser
         ? (m.senderName || 'User')
         : 'Agent';
-      const ts = m.timestamp ? new Date(m.timestamp).toISOString().slice(11, 19) : '??:??';
+      const ts = formatLocalTimestamp(m.timestamp); // local + tz label — mirrors routes.ts (2026-06-05 time-incoherency fix)
       const histText = (m.text || '').slice(0, 300);
       historyLines.push(`[${ts}] ${sender}: ${histText}`);
     }
@@ -161,7 +162,8 @@ describe('Auto-spawn thread history (routes.ts HTTP forward)', () => {
       ];
 
       const lines = buildAutoSpawnContext(42, history);
-      expect(lines.some(l => l.includes('[14:30:45]'))).toBe(true);
+      // Local-tz rendering (2026-06-05 time-incoherency fix)
+      expect(lines.some(l => l.includes(`[${formatLocalTimestamp('2026-03-01T14:30:45Z')}]`))).toBe(true);
     });
 
     it('handles missing timestamps', () => {

--- a/upgrades/local-time-coherence.eli16.md
+++ b/upgrades/local-time-coherence.eli16.md
@@ -1,0 +1,11 @@
+# The agent stops misreading its own clock
+
+The agent kept two clocks without knowing it. Every hook that tells the agent "here's the current time" speaks in YOUR local time ("5:49pm PDT") — but every block that shows it conversation history spoke in unlabeled UTC ("[21:23]"). The agent has no way to tell those apart, so it did the natural thing: read both as the same clock. That's how it told Justin "you heard nothing between **9:23pm** and now" about a message sent at **2:23pm** his time — off by exactly the 7-hour UTC gap. The user experiences this as the agent being confused about basic reality.
+
+The fix makes every timestamp the agent ever sees speak ONE language: the machine's local time, with the timezone written right on it — `[2026-06-05 14:23 PDT]` instead of `[21:23:10]`. History lines also now carry the date, so a conversation spanning midnight can't be misread either ("was that 12:30am today or yesterday?" stops being a guess).
+
+Where this applies — every surface that renders history or status timestamps into an agent's context: the thread history a new session boots with, the history relayed when a conversation moves between machines, the recent-messages block injected on every Telegram message, the post-compaction recovery context, the Slack channel context, the session-start recent messages, and the lifeline's "last healthy" status line. One new shared helper does the rendering in code; the hook scripts get a tiny equivalent helper with a safe fallback (if a timestamp ever fails to parse, it renders the old way instead of crashing the hook).
+
+Existing agents get this automatically: the built-in hook scripts are always refreshed on update, and the code paths ship with the next release. Nothing about WHEN things happen changes — only how the time is written down. There is no new config, no new decision surface, and the worst possible failure (a malformed timestamp) renders the way it used to render rather than breaking anything.
+
+What you need to decide: nothing — this is a pure rendering fix for a live mis-statement the agent made to you. The PR is the review surface.

--- a/upgrades/next/local-time-coherence.md
+++ b/upgrades/next/local-time-coherence.md
@@ -1,0 +1,54 @@
+<!-- bump: patch -->
+
+## What Changed
+
+Fixes a **time-incoherency** class of bug: every context block that shows an
+agent its conversation history rendered timestamps as **unlabeled UTC**
+(`[21:23:10]`), while the CURRENT TIME hook block speaks labeled local time.
+Agents read both as one clock — live incident 2026-06-05: an agent told its
+user "you heard nothing between **9:23pm** and now" about an event at
+**2:23pm** the user's local time.
+
+Now every agent-facing timestamp renders in the **host's local timezone with
+an explicit tz label and date**: `[2026-06-05 14:23 PDT]`.
+
+Surfaces covered:
+
+- Bootstrap Thread History (new/respawned sessions), auto-spawn history
+- Moved-session context relay (multi-machine transfers)
+- Per-message Telegram topic history hook + unanswered-messages block
+- Post-compaction recovery context (Telegram + Slack blocks)
+- Session-start RECENT MESSAGES, TopicMemory context blocks
+- Slack channel context (tz label added)
+- Lifeline "Last healthy" status line
+
+New shared helper `src/utils/localTime.ts` (`formatLocalTimestamp`); hook
+python blocks carry an equivalent `_localts()` with a safe fallback to the
+old rendering on any parse failure. Stored timestamps remain ISO-UTC —
+rendering only. Existing agents pick the hook changes up automatically
+(built-in hooks are always-overwritten on migration).
+
+## What to Tell Your User
+
+Your agent no longer gets confused about what time things happened. Before
+this, the agent saw conversation history stamped in UTC but the current time
+in your local timezone — and could misquote a 2pm event as "9pm." Now every
+timestamp it reads carries your local time and timezone, so "when did I last
+hear from you?" answers come out right.
+
+## Summary of New Capabilities
+
+- None user-invocable — this is a correctness fix to how agents perceive
+  time. (Internal: `formatLocalTimestamp()` in `src/utils/localTime.ts` is
+  the one helper all history/status renderers now use.)
+
+## Evidence
+
+- New `tests/unit/localTime.test.ts` pins local-not-UTC semantically
+  (TZ-portable: compares against the same instant's local Date getters),
+  including the verbatim incident instant `2026-06-05T21:23:10Z`.
+- Hook python smoke test: the incident payload now renders
+  `[2026-06-05 14:23 PDT] Agent: executing now` (was `[2026-06-05 21:23]`).
+- Updated `ForwardedTopicContext` / `compactionResumePayload` /
+  `telegram-autospawn-history` tests to TZ-portable assertions through the
+  helper; affected-area suites green; `tsc --noEmit` clean.

--- a/upgrades/side-effects/local-time-coherence.md
+++ b/upgrades/side-effects/local-time-coherence.md
@@ -1,0 +1,89 @@
+# Side-Effects Review — Local-time + tz-label rendering for all agent-facing timestamps
+
+**Version / slug:** `local-time-coherence`
+**Date:** `2026-06-05`
+**Author:** `echo`
+**Second-pass reviewer:** `not required (no block/allow surface, no lifecycle decisions — pure rendering)`
+
+## Summary of the change
+
+Every surface that renders timestamps into agent-facing context blocks switched from unlabeled UTC (`toISOString().slice(11, 19)` in TS, `timestamp[:16].replace('T', ' ')` in hook python) to host-local time with an explicit timezone label and date (`[2026-06-05 14:23 PDT]`). New shared helper `src/utils/localTime.ts` (`formatLocalTimestamp`, `localTzAbbreviation`); call sites: `ForwardedTopicContext.ts`, `TopicMemory.ts` ×2, `commands/server.ts` (bootstrap Thread History), `server/routes.ts` ×2 (auto-spawn/respawn history), `compactionResumePayload.ts`, `TelegramLifeline.ts` (status line). Hook python blocks get an equivalent `_localts()` helper with parse-failure fallback to the old rendering: `templates/hooks/telegram-topic-context.sh`, `templates/hooks/compaction-recovery.sh` (telegram + slack blocks), `templates/hooks/slack-channel-context.sh` (tz label only), and the `PostUpdateMigrator.ts` inline copies (session-start, telegram-topic-context, compaction-recovery). Driven by the 2026-06-05 live incident: the agent reported a 14:23-local event as "9:23pm" because history was unlabeled UTC while CURRENT TIME blocks are local-labeled.
+
+## Decision-point inventory
+
+No decision-point surface. This change renders strings; it adds, removes, or modifies no block/allow decision, no gate, no lifecycle action. The only conditional logic is "did the timestamp parse?" with a render-the-old-way fallback.
+
+---
+
+## 1. Over-block
+
+No block/allow surface — over-block not applicable.
+
+---
+
+## 2. Under-block
+
+No block/allow surface — under-block not applicable.
+
+---
+
+## 3. Level-of-abstraction fit
+
+Right layer: a formatting primitive at the render chokepoints. The alternative — teaching agents (prompt-level) that history is UTC — is exactly the willpower-dependent design that caused the incident. A lower-level primitive did not exist (`formatLocalTimeHHMM` in `RestartCascadeDampener.ts` is HH:MM-only, no tz label, no date, not exported for this purpose); this PR creates the shared primitive and routes all sites through it. Hook python cannot import TS, so it carries a minimal equivalent — acceptable duplication at the language boundary, kept identical across all blocks.
+
+---
+
+## 4. Signal vs authority compliance
+
+**Required reference:** [docs/signal-vs-authority.md](../../docs/signal-vs-authority.md)
+
+- [x] No — this change has no block/allow surface.
+
+Pure rendering. Nothing here holds authority over any action.
+
+---
+
+## 5. Interactions
+
+- **Shadowing:** none — no checks run before/after; the rendered string feeds the same downstream consumers (context injection, tmux paste) unchanged in shape (`[ts] Sender: text`).
+- **Double-fire:** none — formatting is idempotent and side-effect-free.
+- **Races:** none — no shared mutable state; `Intl.DateTimeFormat` is constructed per call.
+- **Feedback loops:** one considered: agents QUOTE history timestamps back into conversation, and those quotes can land in future history. Since both the injected history and the CURRENT TIME hook now speak local-labeled time, the loop converges toward coherence instead of propagating UTC misreads.
+- **Unanswered-message detection:** verified untouched — detection logic compares message order/sender, never parses the rendered timestamp.
+- **Tests that mirror renderers:** `telegram-autospawn-history.test.ts` contains a local mirror of the routes.ts logic; updated in the same PR so the mirror stays faithful.
+
+---
+
+## 6. External surfaces
+
+- **Other agents on the same machine:** the hook-template changes reach every instar agent on next update (built-in hooks are always-overwritten by `PostUpdateMigrator`). The change is rendering-only; no agent behavior contract depends on UTC timestamps (verified: no consumer parses the bracketed time back out of context blocks — grepped for consumers of the rendered format).
+- **External systems:** none — Telegram/Slack/GitHub payloads unchanged; only locally-injected context strings change.
+- **Persistent state:** none written. Stored timestamps remain ISO-UTC everywhere (JSONL, SQLite); ONLY rendering changes. No migration of stored data.
+- **Timing/runtime:** `%Z` in python `strftime` and `Intl` tz short-names vary by platform locale data; on a host where no label resolves, the label is simply omitted (TS) or the naive fallback renders (python) — degraded to the status quo, never an error.
+
+---
+
+## 7. Rollback cost
+
+Pure code + template change — revert and ship a patch. No persistent state, no data migration, no agent state repair. During a rollback window, agents would briefly render local-labeled and then UTC again; cosmetic only.
+
+---
+
+## Conclusion
+
+The review confirmed no decision surface and no persistence surface; the main risks identified and addressed were (a) hook python crashing on unparseable timestamps — covered by the try/except fallback to the previous rendering, and (b) test mirrors drifting from real renderers — the mirror was updated in the same change. One pre-existing inconsistency was found and normalized: `formatInlineHistory` treated numeric-0 timestamps as missing while `ForwardedTopicContext` rendered them; the shared helper renders them (epoch is a valid instant). Clear to ship.
+
+---
+
+## Second-pass review (if required)
+
+**Reviewer:** not required
+**Independent read of the artifact:** not required — no messaging block/allow, no session lifecycle, no sentinel/gate/guard surface.
+
+---
+
+## Evidence pointers
+
+- `tests/unit/localTime.test.ts` — semantic local-not-UTC pinning incl. the verbatim incident instant `2026-06-05T21:23:10Z`.
+- Hook python smoke test: incident payload renders `[2026-06-05 14:23 PDT] Agent: executing now` (was `[2026-06-05 21:23]`).
+- Full local suite (74 min on a loaded box): 28329 passed / 8 failed across 5 files. The one failure whose identity survived output truncation (`session-management-e2e`, a waitFor timeout) re-ran green in isolation; a full re-run with complete capture was started for the rest, and CI (clean, sharded runners) is the merge gate either way.


### PR DESCRIPTION
## ELI16 overview (plain English)

The agent kept two clocks without knowing it. Every hook that tells the agent "here's the current time" speaks in YOUR local time ("5:49pm PDT") — but every block that shows it conversation history spoke in unlabeled UTC ("[21:23]"). The agent has no way to tell those apart, so it did the natural thing: read both as the same clock. That's how it told Justin "you heard nothing between **9:23pm** and now" about a message sent at **2:23pm** his time — off by exactly the 7-hour UTC gap. This PR makes every timestamp the agent ever sees speak ONE language: the machine's local time, with the timezone written right on it (`[2026-06-05 14:23 PDT]`). History lines also now carry the date, so a conversation spanning midnight can't be misread either. No behavior changes — only what the timestamps look like everywhere the agent reads them.

## What this fixes

Live incident, 2026-06-05 (topic 13481): the agent misreported a 14:23-local event as "9:23pm" because the injected Thread History rendered `21:23:10Z` as `[21:23:10]` — unlabeled UTC — while the CURRENT TIME hook block was local-labeled. Justin: "We need to increase the robustness and awareness of Instar agents. This is fundamental to a coherent user experience."

Structure > Willpower: agents cannot be trusted to remember which surfaces are UTC. Every timestamp is now rendered local + labeled at the formatting chokepoints, so no conversion discipline is required.

## Changes

**New: `src/utils/localTime.ts`** — `formatLocalTimestamp()` (default `2026-06-05 14:23 PDT`; opts for seconds / no-date) + `localTzAbbreviation()`. Doc comment records the incident.

**TS render sites switched to the util (were `toISOString().slice(11, 19)`):**
- `ForwardedTopicContext.ts` — moved-session context relay
- `TopicMemory.ts` ×2 — RECENT MESSAGES context blocks
- `commands/server.ts` — bootstrap Thread History
- `server/routes.ts` ×2 — auto-spawn + respawn Thread History
- `compactionResumePayload.ts` — compaction-resume inline history
- `TelegramLifeline.ts` — "Last healthy" status line

**Hook python blocks (were `timestamp[:16].replace('T', ' ')` — UTC truncation):** added a `_localts()` helper (UTC-ISO → local + `%Z` label, safe fallback to the old rendering on any parse error) and switched all uses:
- `templates/hooks/telegram-topic-context.sh` (history + unanswered-messages)
- `templates/hooks/compaction-recovery.sh` (telegram + slack blocks)
- `templates/hooks/slack-channel-context.sh` (label added; was already local via `fromtimestamp`)
- `PostUpdateMigrator.ts` inline copies: session-start, telegram-topic-context, compaction-recovery

## Migration parity

Built-in hooks under `instar/` are always-overwritten on every migration run, and the templates cover `init` — both update paths ship the fix to existing agents automatically. No new config, no new routes.

## Tests

- New `tests/unit/localTime.test.ts` — pins "local, not UTC" semantically (compares against the same instant's local Date getters, so green in any CI timezone) including the verbatim incident instant `2026-06-05T21:23:10Z`; tz-label presence; date-by-default; sentinel fallbacks.
- Updated `ForwardedTopicContext` / `compactionResumePayload` / `telegram-autospawn-history` tests to TZ-portable assertions through the util (wiring still proven).
- Smoke-tested the patched hook python directly: the incident payload now renders `[2026-06-05 14:23 PDT] Agent: executing now`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
