### PR TITLE
feat(lifeline): slow-retry sentinel escalation — the never-give-up healer tells a human once (P19)

### DIFF
--- a/.instar/instar-dev-decisions/2026-06-06T02-31-57-936Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-06-06T02-31-57-936Z-unknown.json
@@ -1,0 +1,15 @@
+{
+  "ts": "2026-06-06T02:31:57.936Z",
+  "slug": "unknown",
+  "suggestedTier": 2,
+  "declaredTier": 2,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "new capability: new exported class / subsystem added"
+  ],
+  "belowFloor": false,
+  "files": 3,
+  "loc": 117,
+  "causalAutopsy": null,
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-06-06T02-32-04-412Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-06-06T02-32-04-412Z-unknown.json
@@ -1,0 +1,15 @@
+{
+  "ts": "2026-06-06T02:32:04.412Z",
+  "slug": "unknown",
+  "suggestedTier": 2,
+  "declaredTier": 2,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "new capability: new exported class / subsystem added"
+  ],
+  "belowFloor": false,
+  "files": 3,
+  "loc": 117,
+  "causalAutopsy": null,
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-06-06T02-32-46-462Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-06-06T02-32-46-462Z-unknown.json
@@ -1,0 +1,18 @@
+{
+  "ts": "2026-06-06T02:32:46.462Z",
+  "slug": "unknown",
+  "suggestedTier": 2,
+  "declaredTier": 2,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "new capability: new exported class / subsystem added"
+  ],
+  "belowFloor": false,
+  "files": 3,
+  "loc": 117,
+  "causalAutopsy": {
+    "origin": "latent",
+    "notes": "The slow-retry mode shipped (pre-instar-repo history) deliberately never-give-up with a code comment saying so; the missing operator escalation was a designed-in observability gap, not a regression from any PR. Surfaced by the 2026-06-05 multi-machine loop-safety audit (CMT-1109) and ratified as the namesake case of the No Unbounded Loops Eternal Sentinel clause (P19 condition 4)."
+  },
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-06-06T02-33-06-900Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-06-06T02-33-06-900Z-unknown.json
@@ -1,0 +1,18 @@
+{
+  "ts": "2026-06-06T02:33:06.900Z",
+  "slug": "unknown",
+  "suggestedTier": 2,
+  "declaredTier": 2,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "new capability: new exported class / subsystem added"
+  ],
+  "belowFloor": false,
+  "files": 3,
+  "loc": 117,
+  "causalAutopsy": {
+    "origin": "latent",
+    "notes": "The slow-retry mode shipped (pre-instar-repo history) deliberately never-give-up with a code comment saying so; the missing operator escalation was a designed-in observability gap, not a regression from any PR. Surfaced by the 2026-06-05 multi-machine loop-safety audit (CMT-1109) and ratified as the namesake case of the No Unbounded Loops Eternal Sentinel clause (P19 condition 4)."
+  },
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-06-06T02-34-15-005Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-06-06T02-34-15-005Z-unknown.json
@@ -1,0 +1,18 @@
+{
+  "ts": "2026-06-06T02:34:15.005Z",
+  "slug": "unknown",
+  "suggestedTier": 2,
+  "declaredTier": 2,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "new capability: new exported class / subsystem added"
+  ],
+  "belowFloor": false,
+  "files": 3,
+  "loc": 117,
+  "causalAutopsy": {
+    "origin": "latent",
+    "notes": "The slow-retry mode shipped (pre-instar-repo history) deliberately never-give-up with a code comment saying so; the missing operator escalation was a designed-in observability gap, not a regression from any PR. Surfaced by the 2026-06-05 multi-machine loop-safety audit (CMT-1109) and ratified as the namesake case of the No Unbounded Loops Eternal Sentinel clause (P19 condition 4)."
+  },
+  "verdict": "pass"
+}

--- a/docs/specs/supervisor-sentinel-escalation.eli16.md
+++ b/docs/specs/supervisor-sentinel-escalation.eli16.md
@@ -1,0 +1,34 @@
+# ELI16 — The server babysitter finally speaks up
+
+## The problem
+
+Every Instar agent has a babysitter process whose whole job is restarting the
+agent's server when it crashes. If the server keeps crashing, the babysitter
+backs off to one revival attempt every 2 hours — forever. The "forever" part is
+right (it's the thing that brings everything back; it should never quit). The
+broken part: it never told you. A server stuck in crash-revive-crash cycles for
+three days looked exactly like silence. You'd only find out your agent was down
+by noticing it stopped talking to you.
+
+This is the exact loop that inspired the "never give up, but never go silent"
+caveat in the new No Unbounded Loops standard — so it's the first one fixed
+under it.
+
+## The fix
+
+After 12 hours of failed revival attempts in one outage, the babysitter sends
+you ONE Telegram message: roughly "Still down after 12 hours. I'm retrying
+every 2 hours and won't stop, but a human may be needed — here's the command
+that diagnoses it, here's the one that retries right now. This is the only
+nudge I'll send for this outage." Then it goes back to quietly trying. When the
+server recovers, the one-shot re-arms for the next outage.
+
+Two details worth knowing: the message travels straight from the babysitter to
+Telegram (it doesn't depend on the dead server — that would be useless), and a
+test drives a simulated week-long outage through the logic to prove the
+message count stays at exactly one.
+
+## What changes for you
+
+Nothing, until the bad day. On the bad day, you find out within 12 hours
+instead of whenever you happen to notice the silence.

--- a/docs/specs/supervisor-sentinel-escalation.md
+++ b/docs/specs/supervisor-sentinel-escalation.md
@@ -1,0 +1,74 @@
+---
+title: Slow-Retry Sentinel Escalation — the supervisor's never-give-up loop tells a human once
+status: converged
+tier: 2
+parent-principle: "No Unbounded Loops — Every Repeating Behavior Carries Its Own Brakes"
+review-convergence: self-converged against the loop-safety audit finding (CMT-1109, verified at source — slowRetryIntervalMs comment literally says "never truly give up" with no escalation) + line-level trace of every slowRetryStartedAt write and the per-tick reachability of the slow-retry block; validated by an independent adversarial second-pass reviewer (CONCUR — all four probes safe, incl. the lifeline-restart re-fire window being correct-by-design and the Telegram path being server-independent).
+approved: true
+---
+
+# Slow-Retry Sentinel Escalation
+
+> Approval ground: Justin's ratification of the "No Unbounded Loops" standard
+> WITH his Eternal Sentinel caveat (2026-06-05, topic "Resource Limitation
+> Mitigation") — condition 4 of which ("still observable — escalates once after
+> a sustained-failure threshold") is precisely this change, applied to the exact
+> loop that inspired the caveat. He directed the audit fixes as individual PRs
+> ("Sounds great!"). Merge gates on his word as usual.
+
+## Problem (loop-safety audit, verified 2026-06-05)
+
+`ServerSupervisor`'s slow-retry mode is the healer of last resort: once the
+circuit breaker's fast retries are exhausted, it respawns the dead server every
+`slowRetryIntervalMs` (2h) forever — `src/lifeline/ServerSupervisor.ts`
+literally annotates it "never truly give up". Per the ratified Eternal Sentinel
+clause that persistence is CORRECT (it is what brings everything else back),
+and its rate floor + constant per-attempt cost already satisfy conditions 2–3.
+
+What it violated was **condition 4 — still observable**. Nothing ever told the
+operator. A server flailing in 2-hour respawn cycles for days was indistinguishable
+from silence; the operator learned of the outage by noticing the agent's absence.
+
+## Design (signal-only — no retry/kill/spawn decision changes)
+
+- `src/lifeline/SlowRetrySentinelEscalation.ts` — a pure one-shot latch
+  (injectable clock, two fields), the same suppressor shape as `AgeKillBackoff`:
+  `shouldEscalate(slowRetryStartedAt)` returns true exactly once per episode,
+  the first tick at/after `escalateAfterMs` (default 12h ≈ 6 failed 2h cycles).
+  The latch keys on the episode timestamp — a fresh episode re-arms even if a
+  reset were missed; `reset()` re-arms on recovery.
+- `ServerSupervisor`: the slow-retry block carries the explicit ETERNAL SENTINEL
+  declaration (condition 1) and, per tick in slow-retry mode, asks the latch;
+  on fire it emits `'sentinelStalled' { hoursStalled, retryIntervalHours }` and
+  keeps retrying. `resetCircuitBreaker()` (the single episode-ending funnel —
+  every recovery/operator path goes through it) re-arms the latch in lockstep
+  with zeroing `slowRetryStartedAt`, so key and latch can never desync.
+- `TelegramLifeline`: listens for `sentinelStalled` → ONE operator message
+  ("still down after Nh; retrying every 2h; `/lifeline doctor` / `/lifeline
+  reset`; this is the only nudge for this outage"). The send goes DIRECTLY to
+  the Telegram Bot API from the lifeline process — zero dependency on the agent
+  server, which is by definition down when this fires (reviewer-verified).
+- New optional `slowRetryEscalateAfterMs` constructor option (tests); shipped
+  default lives in code — no config surface, no migration.
+
+## Bounds (P19 sustained-failure proof)
+
+The unit suite drives a week-long never-recovering episode through the latch
+and asserts the escalation count is exactly 1 — the declared bound. A lifeline
+process restart zeroes the in-memory latch alongside ALL breaker state, so a
+re-fire requires rebuilding ~13.5h of fresh sustained failure: a correct
+"still broken after a bounce" re-notification, not a duplicate.
+
+## Tests
+
+`tests/unit/SlowRetrySentinelEscalation.test.ts` — 10 green: threshold
+semantics, the sustained-failure bound, reset/re-arm, episode-keyed defensive
+re-arm, plus source-shape wiring pins (supervisor constructs/checks/emits;
+reset re-arms inside `resetCircuitBreaker`; the sentinel declaration exists;
+the lifeline listens and delivers). Signal-only change with no HTTP route —
+wiring pins substitute for Tier-2/3 per the live-tail precedent (reviewer
+concurred).
+
+## Rollback
+
+Pure in-process; revert the commit. No persistent state, no config, no schema.

--- a/src/lifeline/ServerSupervisor.ts
+++ b/src/lifeline/ServerSupervisor.ts
@@ -24,6 +24,7 @@ import { fileURLToPath } from 'node:url';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 import { detectTmuxPath } from '../core/Config.js';
+import { SlowRetrySentinelEscalation } from './SlowRetrySentinelEscalation.js';
 import { SleepWakeDetector } from '../core/SleepWakeDetector.js';
 import { cpuLoadRatio, DEFAULT_MAX_LOAD_RATIO } from '../core/cpuStarvation.js';
 import { SafeFsExecutor } from '../core/SafeFsExecutor.js';
@@ -261,6 +262,12 @@ export class ServerSupervisor extends EventEmitter {
   private readonly maxCircuitBreakerRetries = 3; // Try 3 times at 30-min intervals before entering slow-retry
   private readonly slowRetryIntervalMs = 2 * 60 * 60_000; // 2 hours between slow retries (never truly give up)
   private slowRetryStartedAt = 0; // When slow retry mode started
+  /**
+   * Eternal Sentinel condition 4 ("No Unbounded Loops", P19): never-give-up
+   * must not mean never-tell-anyone. Fires the one-per-episode 'sentinelStalled'
+   * escalation after a sustained-failure threshold; the retrying continues.
+   */
+  private readonly sentinelEscalation: SlowRetrySentinelEscalation;
   private lastCrashOutput = ''; // Last captured crash output for diagnostics
   private doctorSessionSecret: string | null = null; // HMAC secret for doctor restart requests
   private sleepWakeDetector: SleepWakeDetector | null = null; // Detects short sleeps that gap-based detection misses
@@ -289,6 +296,8 @@ export class ServerSupervisor extends EventEmitter {
     startupGraceSeconds?: number;
     /** Injectable CPU-load-ratio source (loadavg[0]/cpuCount) for tests. Default: cpuLoadRatio. */
     loadRatioProvider?: () => number;
+    /** Sustained-failure threshold before the one-per-episode slow-retry escalation. Default: 12h. */
+    slowRetryEscalateAfterMs?: number;
   }) {
     super();
     this.projectDir = options.projectDir;
@@ -298,6 +307,9 @@ export class ServerSupervisor extends EventEmitter {
     this.tmuxPath = detectTmuxPath();
     this.serverSessionName = `${this.projectName}-server`;
     this.loadRatioProvider = options.loadRatioProvider ?? (() => cpuLoadRatio());
+    this.sentinelEscalation = new SlowRetrySentinelEscalation({
+      escalateAfterMs: options.slowRetryEscalateAfterMs,
+    });
 
     if (options.maintenanceWaitMinutes !== undefined) {
       this.maintenanceWaitMs = options.maintenanceWaitMinutes * 60_000;
@@ -478,6 +490,7 @@ export class ServerSupervisor extends EventEmitter {
     this.restartAttempts = 0;
     this.maxRetriesExhaustedAt = 0;
     this.slowRetryStartedAt = 0;
+    this.sentinelEscalation.reset(); // episode over — re-arm the one-shot escalation
     this.wakeTransitionUntil = 0;
     console.log('[Supervisor] Circuit breaker reset');
   }
@@ -1831,9 +1844,24 @@ export class ServerSupervisor extends EventEmitter {
 
       // Phase 2: Slow retry — never truly give up. Transient issues (Node version change,
       // disk full, port conflict) often resolve themselves. Try every 2 hours forever.
+      //
+      // ETERNAL SENTINEL (declared per "No Unbounded Loops" / P19): this loop is the
+      // healer of last resort for the server — the sanctioned never-give-up class.
+      // Its brakes: rate floor (one attempt per slowRetryIntervalMs, constant cost),
+      // and condition-4 observability below — after escalateAfterMs of sustained
+      // failure it tells the operator ONCE per episode, then keeps quietly trying.
       if (this.slowRetryStartedAt === 0) {
         this.slowRetryStartedAt = Date.now();
         console.log(`[Supervisor] Circuit breaker fast retries exhausted. Entering slow-retry mode (every ${this.slowRetryIntervalMs / 3600_000}h). Use /lifeline reset for immediate retry.`);
+      }
+
+      // Condition 4 — never-give-up must not mean never-tell-anyone. One
+      // escalation per episode after the sustained-failure threshold; the
+      // latch lives in SlowRetrySentinelEscalation, keyed on this episode.
+      if (this.sentinelEscalation.shouldEscalate(this.slowRetryStartedAt)) {
+        const hoursStalled = Math.round((Date.now() - this.slowRetryStartedAt) / 3600_000);
+        console.log(`[Supervisor] Slow-retry sentinel stalled ${hoursStalled}h without recovery — escalating once (retries continue)`);
+        this.emit('sentinelStalled', { hoursStalled, retryIntervalHours: this.slowRetryIntervalMs / 3600_000 });
       }
 
       const slowElapsed = Date.now() - (this.slowRetryStartedAt + this.slowRetryIntervalMs * Math.floor((Date.now() - this.slowRetryStartedAt) / this.slowRetryIntervalMs));

--- a/src/lifeline/SlowRetrySentinelEscalation.ts
+++ b/src/lifeline/SlowRetrySentinelEscalation.ts
@@ -1,0 +1,62 @@
+/**
+ * SlowRetrySentinelEscalation — the "still tells a human once" half of the
+ * supervisor's Eternal Sentinel contract (constitution: "No Unbounded Loops",
+ * Eternal Sentinel condition 4; P19).
+ *
+ * The ServerSupervisor's slow-retry mode is a SANCTIONED eternal sentinel: it
+ * respawns a dead server every `slowRetryIntervalMs` (2h) forever, because it
+ * is the healer of last resort — the thing that brings everything else back.
+ * Never giving up is correct. What was missing (loop-safety audit, 2026-06-05,
+ * topic "Resource Limitation Mitigation") is observability: an operator whose
+ * server has been flailing for a day learned it only by noticing the silence.
+ *
+ * This class owns exactly one decision: after a slow-retry episode has run for
+ * `escalateAfterMs` without recovery, fire ONCE — then stay quiet for the rest
+ * of that episode while the sentinel keeps retrying. A new episode (after a
+ * recovery reset) re-arms it. Pure logic, injectable clock, two fields of
+ * state — the same suppressor shape as AgeKillBackoff.
+ */
+
+export interface SlowRetrySentinelEscalationOpts {
+  /**
+   * How long an episode may run before the one-time escalation fires.
+   * Default 12h (≈6 failed 2-hour retry cycles — long enough that transient
+   * issues have clearly not self-resolved, short enough to matter same-day).
+   */
+  escalateAfterMs?: number;
+  now?: () => number;
+}
+
+const DEFAULT_ESCALATE_AFTER_MS = 12 * 60 * 60_000;
+
+export class SlowRetrySentinelEscalation {
+  private readonly escalateAfterMs: number;
+  private readonly now: () => number;
+  /** Latch: the episode-start timestamp we already escalated for (0 = armed). */
+  private escalatedForEpisode = 0;
+
+  constructor(opts: SlowRetrySentinelEscalationOpts = {}) {
+    this.escalateAfterMs = opts.escalateAfterMs ?? DEFAULT_ESCALATE_AFTER_MS;
+    this.now = opts.now ?? Date.now;
+  }
+
+  /**
+   * Call on every supervisor tick spent in slow-retry mode. Returns true
+   * EXACTLY ONCE per episode — the first tick at/after the sustained-failure
+   * threshold. `slowRetryStartedAt` is the episode key: the same episode never
+   * fires twice, and a fresh episode (different start) re-arms automatically
+   * even if reset() was missed.
+   */
+  shouldEscalate(slowRetryStartedAt: number): boolean {
+    if (slowRetryStartedAt <= 0) return false;
+    if (this.escalatedForEpisode === slowRetryStartedAt) return false; // already fired this episode
+    if (this.now() - slowRetryStartedAt < this.escalateAfterMs) return false;
+    this.escalatedForEpisode = slowRetryStartedAt;
+    return true;
+  }
+
+  /** Episode over (recovery / operator reset) — re-arm for the next one. */
+  reset(): void {
+    this.escalatedForEpisode = 0;
+  }
+}

--- a/src/lifeline/TelegramLifeline.ts
+++ b/src/lifeline/TelegramLifeline.ts
@@ -321,6 +321,15 @@ export class TelegramLifeline {
       this.notifyCircuitBroken(totalFailures, lastCrashOutput);
     });
 
+    // Eternal Sentinel condition 4 (P19): the slow-retry healer never gives up,
+    // but after a sustained-failure threshold it must tell the operator ONCE
+    // per episode instead of flailing silently for days. The one-shot latch
+    // lives supervisor-side; this is purely the delivery.
+    this.supervisor.on('sentinelStalled', (info: { hoursStalled: number; retryIntervalHours: number }) => {
+      console.error(`[Lifeline] Slow-retry sentinel stalled ${info.hoursStalled}h without recovery — notifying operator once`);
+      this.notifySentinelStalled(info);
+    });
+
     this.supervisor.on('updateApplied', (targetVersion: string) => {
       console.log(`[Lifeline] Update to v${targetVersion} applied — scheduling self-restart to pick up new code`);
       // Delay the self-exit to allow queue replay and notifications to flush.
@@ -2042,6 +2051,24 @@ export class TelegramLifeline {
       debugCommand +
       `\n\nTo retry: /lifeline reset (resets circuit breaker and restarts)\n` +
       `You'll be notified when the server recovers.`
+    ).catch(() => {});
+  }
+
+  /**
+   * One-per-episode escalation for the slow-retry Eternal Sentinel (P19
+   * condition 4). The supervisor keeps retrying after this — the message
+   * exists so "never give up" can never again mean "flail silently for days."
+   */
+  private async notifySentinelStalled(info: { hoursStalled: number; retryIntervalHours: number }): Promise<void> {
+    const topicId = this.lifelineTopicId ?? 1;
+    await this.sendToTopic(topicId,
+      `⏳ STILL DOWN AFTER ${info.hoursStalled} HOURS\n\n` +
+      `My server has been down for about ${info.hoursStalled} hours. I've kept retrying every ` +
+      `${info.retryIntervalHours} hours and will keep trying — but at this point a human may be needed.\n\n` +
+      `What you can do:\n` +
+      `  /lifeline doctor — spawns a diagnostic session that reads the crash logs\n` +
+      `  /lifeline reset — retry immediately instead of waiting for the next cycle\n\n` +
+      `This is the only nudge I'll send for this outage — I'll tell you when the server recovers.`
     ).catch(() => {});
   }
 

--- a/tests/unit/SlowRetrySentinelEscalation.test.ts
+++ b/tests/unit/SlowRetrySentinelEscalation.test.ts
@@ -1,0 +1,117 @@
+/**
+ * Tier-1 tests for SlowRetrySentinelEscalation — the "still tells a human once"
+ * half of the supervisor's Eternal Sentinel contract ("No Unbounded Loops" /
+ * P19, condition 4).
+ *
+ * The P19 sustained-failure pattern: drive the loop against a target that
+ * NEVER recovers and assert the escalation volume stays at the declared bound
+ * — exactly ONE escalation per episode, no matter how many ticks run.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { SlowRetrySentinelEscalation } from '../../src/lifeline/SlowRetrySentinelEscalation.js';
+
+const HOUR = 60 * 60_000;
+
+function make(escalateAfterMs: number) {
+  let nowMs = 0;
+  const esc = new SlowRetrySentinelEscalation({ escalateAfterMs, now: () => nowMs });
+  return { esc, setNow: (t: number) => { nowMs = t; } };
+}
+
+describe('SlowRetrySentinelEscalation', () => {
+  it('does not fire before the sustained-failure threshold', () => {
+    const { esc, setNow } = make(12 * HOUR);
+    const episodeStart = 1_000;
+    for (const t of [1_000, 2 * HOUR, 6 * HOUR, 11 * HOUR]) {
+      setNow(episodeStart + t);
+      expect(esc.shouldEscalate(episodeStart)).toBe(false);
+    }
+  });
+
+  it('SUSTAINED-FAILURE BOUND (P19): a never-recovering episode escalates exactly ONCE across unlimited ticks', () => {
+    const { esc, setNow } = make(12 * HOUR);
+    const episodeStart = 1_000;
+    let fired = 0;
+    // A week of supervisor ticks (every 10s would be 60k ticks; sample hourly —
+    // the latch is time-independent so the sampling density doesn't matter).
+    for (let h = 0; h <= 24 * 7; h++) {
+      setNow(episodeStart + h * HOUR);
+      if (esc.shouldEscalate(episodeStart)) fired++;
+    }
+    expect(fired).toBe(1);
+  });
+
+  it('fires at the first tick at/after the threshold', () => {
+    const { esc, setNow } = make(12 * HOUR);
+    const episodeStart = 5_000;
+    setNow(episodeStart + 12 * HOUR);
+    expect(esc.shouldEscalate(episodeStart)).toBe(true);
+  });
+
+  it('not in slow-retry mode (episode start 0) → never fires', () => {
+    const { esc, setNow } = make(1);
+    setNow(Number.MAX_SAFE_INTEGER);
+    expect(esc.shouldEscalate(0)).toBe(false);
+  });
+
+  it('reset() re-arms: a NEW episode after recovery escalates again', () => {
+    const { esc, setNow } = make(12 * HOUR);
+    const ep1 = 1_000;
+    setNow(ep1 + 13 * HOUR);
+    expect(esc.shouldEscalate(ep1)).toBe(true);
+    esc.reset(); // recovery / operator reset
+    const ep2 = ep1 + 20 * HOUR;
+    setNow(ep2 + 12 * HOUR);
+    expect(esc.shouldEscalate(ep2)).toBe(true);
+  });
+
+  it('a fresh episode re-arms automatically even WITHOUT reset() (episode-keyed latch)', () => {
+    // Defensive: if a reset path were ever missed, a different episodeStart
+    // must still escalate — the latch keys on the episode, not a boolean.
+    const { esc, setNow } = make(12 * HOUR);
+    const ep1 = 1_000;
+    setNow(ep1 + 13 * HOUR);
+    expect(esc.shouldEscalate(ep1)).toBe(true);
+    const ep2 = ep1 + 30 * HOUR; // new episode, no reset() call
+    setNow(ep2 + 12 * HOUR);
+    expect(esc.shouldEscalate(ep2)).toBe(true);
+    // ...and ep2 itself still only fires once.
+    setNow(ep2 + 40 * HOUR);
+    expect(esc.shouldEscalate(ep2)).toBe(false);
+  });
+});
+
+describe('wiring integrity: supervisor emits, lifeline delivers (source-shape pins)', () => {
+  // The full ServerSupervisor/TelegramLifeline are process-coupled (tmux,
+  // launchd, Telegram API), so the wiring is pinned at source level — the same
+  // pattern as the live-tail version-gate wiring pin. Without these, the pure
+  // unit above is "constructed but inert".
+  const fs = require('node:fs') as typeof import('node:fs');
+  const path = require('node:path') as typeof import('node:path');
+  const supervisorSrc = fs.readFileSync(path.join(process.cwd(), 'src/lifeline/ServerSupervisor.ts'), 'utf-8');
+  const lifelineSrc = fs.readFileSync(path.join(process.cwd(), 'src/lifeline/TelegramLifeline.ts'), 'utf-8');
+
+  it('the supervisor constructs the escalation, checks it in the slow-retry block, and emits sentinelStalled', () => {
+    expect(supervisorSrc).toContain('new SlowRetrySentinelEscalation(');
+    expect(supervisorSrc).toContain('this.sentinelEscalation.shouldEscalate(this.slowRetryStartedAt)');
+    expect(supervisorSrc).toContain("this.emit('sentinelStalled'");
+  });
+
+  it('the escalation latch re-arms on circuit-breaker reset (episode end)', () => {
+    const resetIdx = supervisorSrc.indexOf('resetCircuitBreaker(): void {');
+    expect(resetIdx).toBeGreaterThan(0);
+    const block = supervisorSrc.slice(resetIdx, resetIdx + 700);
+    expect(block).toContain('this.sentinelEscalation.reset()');
+  });
+
+  it('the slow-retry loop is DECLARED an eternal sentinel (P19 condition 1)', () => {
+    expect(supervisorSrc).toContain('ETERNAL SENTINEL (declared per "No Unbounded Loops" / P19)');
+  });
+
+  it('the lifeline listens for sentinelStalled and delivers the one-shot operator message', () => {
+    expect(lifelineSrc).toContain("this.supervisor.on('sentinelStalled'");
+    expect(lifelineSrc).toContain('notifySentinelStalled');
+    expect(lifelineSrc).toContain('/lifeline reset');
+  });
+});

--- a/upgrades/next/supervisor-sentinel-escalation.md
+++ b/upgrades/next/supervisor-sentinel-escalation.md
@@ -1,0 +1,43 @@
+---
+bump: patch
+---
+
+## What Changed
+
+The ServerSupervisor's slow-retry mode (respawn a dead server every 2h, forever)
+is a sanctioned Eternal Sentinel under the new "No Unbounded Loops" standard —
+but it violated condition 4: it never told anyone. A multi-day crash-revive loop
+was indistinguishable from silence. Now a pure one-shot latch
+(`SlowRetrySentinelEscalation`, the AgeKillBackoff suppressor shape) fires
+exactly once per outage episode after a sustained-failure threshold (default
+12h ≈ 6 failed cycles): the supervisor emits `sentinelStalled` and the lifeline
+sends ONE operator message with the two useful levers (`/lifeline doctor`,
+`/lifeline reset`), then the sentinel keeps quietly retrying. The message goes
+directly to the Telegram Bot API from the lifeline process — no dependency on
+the (down) agent server. Recovery re-arms the latch via the single
+`resetCircuitBreaker()` funnel; retry/kill/spawn decisions are unchanged.
+
+## What to Tell Your User
+
+If your agent's server ever gets stuck in a crash loop, you'll now get one
+clear heads-up after ~12 hours — "still down, here's how to diagnose or force a
+retry, I'll keep trying" — instead of discovering the outage by noticing your
+agent went quiet for days. One message per outage, never a stream.
+
+## Summary of New Capabilities
+
+- Slow-retry escalation: a sustained server outage (default 12h in slow-retry)
+  produces exactly one operator notification per episode; the never-give-up
+  revival behavior is unchanged. In-code default; no config required.
+
+## Evidence
+
+Loop-safety audit finding (CMT-1109), verified at source: the slow-retry block
+in `src/lifeline/ServerSupervisor.ts` was annotated "never truly give up" with
+no operator signal. Fix is the first PR under constitution P19 ("No Unbounded
+Loops", incl. Justin's Eternal Sentinel caveat — this loop is its namesake
+case). Tests: 10 green in `tests/unit/SlowRetrySentinelEscalation.test.ts`
+including the P19 sustained-failure bound (week-long never-recovering episode →
+exactly 1 escalation) and source-shape wiring pins. Independent adversarial
+second-pass: CONCUR (all probes safe — per-tick reachability, no double-fire,
+server-independent delivery, emit-before-spawn ordering). tsc clean.

--- a/upgrades/side-effects/supervisor-sentinel-escalation.md
+++ b/upgrades/side-effects/supervisor-sentinel-escalation.md
@@ -1,0 +1,61 @@
+# Side-Effects Review — Slow-Retry Sentinel Escalation
+
+**Version / slug:** `supervisor-sentinel-escalation`
+**Date:** `2026-06-05`
+**Author:** `Echo (instar-dev agent)`
+**Second-pass reviewer:** `independent adversarial reviewer subagent — CONCUR (all four probes safe; no blocking defects; non-blocking notes recorded below)`
+
+## Summary of the change
+
+The ServerSupervisor's slow-retry mode (2h respawn cadence, deliberately forever) gains the Eternal Sentinel's condition-4 observability: a pure one-shot latch (`src/lifeline/SlowRetrySentinelEscalation.ts`) fires once per outage episode after `escalateAfterMs` (default 12h), the supervisor emits `'sentinelStalled'`, and `TelegramLifeline.notifySentinelStalled` delivers ONE operator message (doctor/reset levers), after which the sentinel keeps retrying unchanged. `resetCircuitBreaker()` — the single episode-ending funnel — re-arms the latch in lockstep with zeroing `slowRetryStartedAt`. Files: `SlowRetrySentinelEscalation.ts` (new, pure), `ServerSupervisor.ts` (declaration comment + per-tick check + emit + reset hook + one constructor option), `TelegramLifeline.ts` (listener + notify method), one test file.
+
+## Decision-point inventory
+
+- `ServerSupervisor` slow-retry block — **modify (additive)** — gains a read-only latch check + event emit; the retry decision, cadence, kill, and spawn are untouched.
+- `SlowRetrySentinelEscalation` — **add** — a pure signal producer with no authority of any kind.
+- `TelegramLifeline` event wiring — **add** — delivery only; mirrors the existing `circuitBroken` handler shape (fire-and-forget, catch-swallowed).
+
+## 1. Over-block
+
+Nothing is blocked — this change cannot suppress, delay, or alter any retry or recovery action. The only "cost" added is one Telegram message per ≥12h outage episode.
+
+## 2. Under-block
+
+(a) A lifeline PROCESS restart zeroes the in-memory latch with all breaker state; after ~13.5h of freshly rebuilt sustained failure it would notify again. Reviewer-assessed as correct-by-design ("still broken after a bounce" is a legitimate re-notification), and persisting the latch was explicitly rejected — a stale on-disk latch could suppress a legitimate notification, the worse failure. (b) The threshold is time-based, not attempt-based: a machine asleep for 12h would escalate on wake even though few attempts ran — acceptable; the operator-facing claim ("down ~N hours") remains true. (c) Other eternal-sentinel-shaped loops (lease pull) are NOT covered here — next audit PR <!-- tracked: CMT-1109 -->.
+
+## 3. Level-of-abstraction fit
+
+Yes. The latch lives beside the loop it observes (lifeline package), as a pure helper in the established suppressor shape (`AgeKillBackoff`: injectable clock, bounded state, unit-testable). Delivery rides the existing supervisor→lifeline event channel (`circuitBroken` precedent) rather than inventing a new notification path — and deliberately does NOT use the agent server's attention queue, which is definitionally down when this fires.
+
+## 4. Signal vs authority compliance
+
+**Required reference:** `docs/signal-vs-authority.md`
+
+- [x] No — pure signal. The latch can only cause one message; it holds no authority over retries, kills, spawns, or the circuit breaker. The healer's behavior is byte-identical with the latch removed.
+
+## 5. Interactions
+
+- **Double-fire:** impossible within a process — the episode key (`slowRetryStartedAt`) is written only at episode start (when 0) and zeroed only inside `resetCircuitBreaker()`, which re-arms the latch in the same method; key and latch cannot desync (reviewer traced every write).
+- **Starvation:** the slow-retry block runs every 10s health-check tick while broken (the branch returns without resetting `consecutiveFailures`), so the latch check cannot be starved (reviewer traced `evaluateUnhealthyServer` → `handleUnhealthy` reachability).
+- **Ordering:** the emit's listener is fire-and-forget and catch-swallowed; it cannot block or throw into the same tick's kill/spawn (mirrors `circuitBroken`).
+- **Feedback loops:** none — a message cannot change health-check outcomes.
+
+## 6. External surfaces
+
+- **User-visible:** one new Telegram message class, bounded at one per episode (Bounded Notification Surface-compatible: no topic creation — it posts to the existing lifeline topic).
+- **Delivery independence:** `sendToTopic` → Telegram Bot API directly over HTTPS from the lifeline process; zero dependency on the down agent server (reviewer-verified at `apiCall`).
+- **Persistent state / config / schema:** none. In-code default; `slowRetryEscalateAfterMs` is a constructor option for tests only. No migration (Migration Parity: nothing installed changes).
+
+## 7. Rollback cost
+
+Revert the commit. No state to clean, no config to unwind. The only observable regression of rollback is the silence returning.
+
+## Conclusion
+
+Signal-only observability for the constitution's namesake Eternal Sentinel: persistence preserved, silence eliminated, volume bounded at one message per episode and proven by the P19 sustained-failure test (week-long never-recovering episode → exactly 1). Second-pass reviewer CONCUR with zero blocking findings; both non-blocking notes (restart re-fire window, no Tier-2/3 for a route-less signal change) are recorded in §2/§6 with their rationale.
+
+---
+
+## Phase 5 — Second-pass review (server-lifecycle-adjacent → performed)
+
+An independent adversarial reviewer audited the diff and final files at line level against four probes: (1) any >1-fire-per-outage path — traced every `slowRetryStartedAt`/`circuitBroken` write; none desync the episode key from the latch; lifeline-restart re-fire requires ~13.5h of rebuilt failure and is a correct re-notification; (2) any never-fire path — the slow-retry branch is reached every 10s tick while broken (per-tick reachability traced through `evaluateUnhealthyServer`/`handleUnhealthy`); (3) delivery dependence on the down server — none: the lifeline posts straight to the Telegram Bot API; (4) emit-vs-spawn ordering — fire-and-forget listener, cannot block or throw into the spawn. Ran the 10-test suite (green) and `tsc --noEmit` (clean). **Verdict: CONCUR.**


### PR DESCRIPTION
## ELI16

Every Instar agent has a babysitter process whose job is restarting the agent's server when it crashes. If the server keeps crashing, the babysitter backs off to one revival attempt every 2 hours — forever. The "forever" part is right: it's the healer of last resort, and the new constitution standard (P19, "No Unbounded Loops") explicitly sanctions it as an **Eternal Sentinel** under Justin's ratification caveat. The broken part: it never told anyone. A server stuck in crash-revive-crash cycles for three days looked exactly like silence — you'd only find out your agent was down by noticing it stopped talking.

This PR is the first fix under the new standard, applied to the exact loop that inspired the caveat. After 12 hours of failed revivals in one outage, the babysitter sends you ONE Telegram message: "still down after ~12h, I'm retrying every 2h and won't stop, but a human may be needed — `/lifeline doctor` to diagnose, `/lifeline reset` to retry now. This is the only nudge I'll send for this outage." Then it goes back to quietly trying. The message travels straight from the babysitter to Telegram — it cannot depend on the dead server. A test drives a simulated week-long outage through the logic and proves the message count stays at exactly one.

## What changed

- `src/lifeline/SlowRetrySentinelEscalation.ts` (new) — pure one-shot latch, episode-keyed, injectable clock (the `AgeKillBackoff` suppressor shape)
- `src/lifeline/ServerSupervisor.ts` — ETERNAL SENTINEL declaration on the slow-retry block (P19 condition 1), per-tick latch check, `sentinelStalled` emit, latch re-arm inside `resetCircuitBreaker()`
- `src/lifeline/TelegramLifeline.ts` — listener + `notifySentinelStalled` (mirrors the `circuitBroken` handler shape)

Signal-only: retry/kill/spawn decisions are byte-identical with the latch removed.

## Safety

Independent adversarial second-pass reviewer: **CONCUR**, zero blocking findings. Probes verified at line level: no double-fire path (episode key and latch can never desync — both live in the single `resetCircuitBreaker()` funnel), no starvation path (the slow-retry block runs every 10s tick while broken), delivery is server-independent (`sendToTopic` → Telegram Bot API directly), and the emit cannot block or throw into the same tick's respawn. Full review in `upgrades/side-effects/supervisor-sentinel-escalation.md`.

## Tests

10 green in `tests/unit/SlowRetrySentinelEscalation.test.ts`: threshold semantics, the P19 sustained-failure bound (week-long never-recovering episode → exactly 1 escalation), reset/re-arm, episode-keyed defensive re-arm, and source-shape wiring pins (supervisor constructs/checks/emits; reset re-arms; declaration present; lifeline listens and delivers). tsc clean.

Spec: `docs/specs/supervisor-sentinel-escalation.md` · Parent principle: P19 "No Unbounded Loops" · Audit: CMT-1109

🤖 Generated with [Claude Code](https://claude.com/claude-code)