### PR TITLE
fix(cli): reject unknown top-level commands

### DIFF
--- a/.instar/instar-dev-decisions/2026-06-06T02-26-49-300Z-cli-unknown-command-trap.json
+++ b/.instar/instar-dev-decisions/2026-06-06T02-26-49-300Z-cli-unknown-command-trap.json
@@ -1,0 +1,17 @@
+{
+  "ts": "2026-06-06T02:26:49.300Z",
+  "slug": "cli-unknown-command-trap",
+  "suggestedTier": 1,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 5,
+  "loc": 74,
+  "causalAutopsy": {
+    "origin": "latent",
+    "relatedPrs": [],
+    "notes": "Commander's program-level default action for bare `instar` was allowed to coexist with no explicit top-level unknown-command guard. The latent bug surfaced when a typo such as `instar dev:claim-checkk` entered setup instead of exiting, hanging agent Bash sessions."
+  },
+  "verdict": "pass"
+}

--- a/.instar/instar-dev-traces/2026-06-06T02-49-16-496Z-cli-unknown-command-trap-2b95a09b.json
+++ b/.instar/instar-dev-traces/2026-06-06T02-49-16-496Z-cli-unknown-command-trap-2b95a09b.json
@@ -1,0 +1,27 @@
+{
+  "version": 2,
+  "slug": "cli-unknown-command-trap",
+  "sessionId": "130f2955-ab78-424d-814e-b3a05fcc06c1",
+  "timestamp": "2026-06-06T02:49:16.496Z",
+  "artifactPath": "upgrades/side-effects/cli-unknown-command-trap.md",
+  "artifactSha256": "25737a7afd873d86aaed59bad9fef11b7d916cb2129bcbced4daba41261385fe",
+  "coveredFiles": [
+    ".instar/instar-dev-decisions/2026-06-06T02-26-49-300Z-cli-unknown-command-trap.json",
+    "docs/eli16/cli-unknown-command-trap.eli16.md",
+    "src/cli.ts",
+    "tests/e2e/cli-unknown-command.test.ts",
+    "upgrades/next/cli-unknown-command-trap.md",
+    "upgrades/side-effects/cli-unknown-command-trap.md"
+  ],
+  "phase": "complete",
+  "tier": 1,
+  "tierReasoning": "Small parser-boundary fix: rejects unknown top-level commands before the bare-installer default action can run while preserving bare setup and Commander implicit help behavior, with focused e2e coverage for typo and help paths.",
+  "eli16Path": "docs/eli16/cli-unknown-command-trap.eli16.md",
+  "sideEffectsPath": "upgrades/side-effects/cli-unknown-command-trap.md",
+  "causalAutopsy": {
+    "origin": "latent",
+    "notes": "Commander's program-level default action for bare `instar` was allowed to coexist with no explicit top-level unknown guard. The latent bug surfaced when typoed commands and the implicit help command entered setup instead of exiting or printing help."
+  },
+  "secondPass": "not-required",
+  "reviewerConcurred": null
+}

--- a/docs/eli16/cli-unknown-command-trap.eli16.md
+++ b/docs/eli16/cli-unknown-command-trap.eli16.md
@@ -1,0 +1,19 @@
+# CLI unknown-command trap - ELI16
+
+The one-line version: a typo in the first `instar` command word now fails fast instead of opening the setup wizard.
+
+## The problem
+
+`instar` with no arguments intentionally starts the interactive setup flow. That is useful for humans, but a typo like `instar dev:claim-checkk` could be interpreted as the bare command path and fall into setup instead of exiting. In an agent shell, that looks like a hung command.
+
+## What changed
+
+The CLI now checks the first positional argument immediately before parsing. If there is no argument, or the first argument is an option like `--version`, behavior is unchanged. If the first positional argument is not a registered top-level command or alias, the CLI prints a clear unknown-command error and exits with code 1. The implicit `help` command is treated as known even though Commander does not include it in the normal command list.
+
+## What did not change
+
+Bare `instar` still starts setup. Known commands such as `instar server`, `instar dev:claim-check`, `instar help`, and `instar --version` keep their existing behavior.
+
+## Why this is narrow
+
+The guard only handles the top-level command token. It does not rewrite nested command behavior or change any setup/init logic. Commander still owns parsing for known command families.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -270,6 +270,32 @@ async function addQuota(opts: { stateFile?: string }): Promise<void> {
 
 const program = new Command();
 
+function rejectUnknownTopLevelCommand(program: Command, argv: string[]): void {
+  const firstArg = argv[2];
+  if (!firstArg || firstArg.startsWith('-')) {
+    return;
+  }
+
+  if (firstArg === 'help') {
+    program.outputHelp();
+    process.exit(0);
+  }
+
+  const commandNames = new Set<string>();
+  for (const command of program.commands) {
+    commandNames.add(command.name());
+    for (const alias of command.aliases()) {
+      commandNames.add(alias);
+    }
+  }
+
+  if (!commandNames.has(firstArg)) {
+    console.error(`error: unknown command '${firstArg}'`);
+    console.error(`Run 'instar --help' for available commands.`);
+    process.exit(1);
+  }
+}
+
 program
   .name('instar')
   .description('Persistent autonomy infrastructure for AI agents')
@@ -2511,4 +2537,5 @@ program
     return route(taskPrompt, opts);
   });
 
+rejectUnknownTopLevelCommand(program, process.argv);
 program.parse();

--- a/tests/e2e/cli-unknown-command.test.ts
+++ b/tests/e2e/cli-unknown-command.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest';
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+
+describe('CLI unknown command handling', () => {
+  it('exits clearly for an unknown top-level command instead of entering setup', () => {
+    const cli = path.join(process.cwd(), 'dist', 'cli.js');
+    if (!fs.existsSync(cli)) {
+      return;
+    }
+
+    const result = spawnSync(process.execPath, [cli, 'dev:claim-checkk'], {
+      cwd: process.cwd(),
+      encoding: 'utf-8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+      timeout: 5000,
+    });
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain("error: unknown command 'dev:claim-checkk'");
+    expect(result.stderr).toContain("Run 'instar --help' for available commands.");
+    expect(result.stdout).not.toContain('Interactive setup wizard');
+    expect(result.error).toBeUndefined();
+  });
+
+  it('prints help for the implicit help command instead of entering setup', () => {
+    const cli = path.join(process.cwd(), 'dist', 'cli.js');
+    if (!fs.existsSync(cli)) {
+      return;
+    }
+
+    const result = spawnSync(process.execPath, [cli, 'help'], {
+      cwd: process.cwd(),
+      encoding: 'utf-8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+      timeout: 5000,
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain('Usage: instar');
+    expect(result.stdout).toContain('Commands:');
+    expect(result.stdout).not.toContain('Checking prerequisites');
+    expect(result.stdout).not.toContain('Welcome to Instar');
+    expect(result.stderr).toBe('');
+    expect(result.error).toBeUndefined();
+  });
+});

--- a/upgrades/next/cli-unknown-command-trap.md
+++ b/upgrades/next/cli-unknown-command-trap.md
@@ -1,0 +1,25 @@
+# Upgrade Guide - vNEXT
+
+<!-- bump: patch -->
+
+## What Changed
+
+The Instar CLI now rejects unknown top-level commands before the bare setup flow can run. A typo such as `instar dev:claim-checkk` prints a clear unknown-command error and exits with status 1 instead of falling into the interactive setup wizard.
+
+Bare `instar` remains unchanged: it still opens the setup flow for new or interrupted setup sessions. `instar help` now prints CLI help instead of entering setup.
+
+## What to Tell Your User
+
+- **Clearer command typos**: "When I mistype an Instar command, I now fail fast with a clear message instead of opening setup and looking stuck."
+
+## Summary of New Capabilities
+
+| Capability | How to Use |
+|-----------|-----------|
+| Unknown command rejection | Automatic for mistyped top-level Instar commands |
+| Bare setup preservation | Automatic when running Instar without a command |
+| Help command preservation | Automatic when asking Instar for help |
+
+## Evidence
+
+Reproduced the typo path locally with the built CLI. Before this change, a typoed command could enter the interactive setup path and hang an agent shell. After the change, `node dist/cli.js dev:claim-checkk` exits 1 with `error: unknown command 'dev:claim-checkk'` and the help hint. A separate `node dist/cli.js help` probe exits 0 and prints CLI help. A separate bare invocation probe, `timeout 3 node dist/cli.js`, still enters setup and times out at status 124, confirming the default setup behavior remains intact.

--- a/upgrades/side-effects/cli-unknown-command-trap.md
+++ b/upgrades/side-effects/cli-unknown-command-trap.md
@@ -1,0 +1,31 @@
+# Side-Effects Review - CLI unknown-command trap
+
+**Version / slug:** `cli-unknown-command-trap`
+**Date:** `2026-06-06`
+**Author:** `instar-codey`
+
+## Summary
+
+This change adds a top-level command guard before Commander parses the CLI. Unknown first-position command tokens now print a clear error and exit 1. The existing no-argument setup path is preserved, and Commander’s implicit `help` command remains allowed.
+
+## Decision Points
+
+- Add `rejectUnknownTopLevelCommand` in `src/cli.ts`.
+- Call it after all commands are registered and before `program.parse()`.
+- Add e2e regression tests for `dist/cli.js dev:claim-checkk` and `dist/cli.js help`.
+
+## Over-Block
+
+Risk: rejecting a legitimate command before Commander sees it. Mitigation: the guard builds its allowlist from `program.commands` and command aliases after registration, and explicitly handles Commander’s implicit `help` command because Commander does not list it in `program.commands` and otherwise sends it into the default setup action. Options and the no-argument path bypass the guard.
+
+## Under-Block
+
+Nested unknown subcommands remain Commander-owned. This fix targets the incident class: unknown top-level command tokens falling into the default setup action.
+
+## Interactions
+
+No server routes, persistent state, messaging, or external APIs change. The behavior changes are limited to process exit behavior for unknown top-level CLI commands and restoring the intended `instar help` help output.
+
+## Rollback
+
+Rollback is a normal revert of the helper, call site, test, and notes. No data migration is involved.


### PR DESCRIPTION
## Summary
- Reject unknown top-level CLI commands before the bare `instar` setup action can run.
- Preserve bare `instar` setup behavior and option handling such as `--help` / `--version`.
- Add a focused e2e regression test, ELI16 artifact, side-effects review, decision audit entry, trace, and release-note fragment.

## ELI16 — typoed instar commands now fail fast instead of opening setup
Before this change, Instar had a useful default behavior: running `instar` with no command opens setup. The bug was that a typoed command could accidentally look like that default path, so `instar dev:claim-checkk` could enter setup instead of saying the command was unknown. That is confusing for humans and worse for agents, because an interactive wizard can make a shell session look hung.

The fix adds a small parser-boundary guard after all commands are registered and before Commander parses argv. If the first positional token is not a registered command or alias, the CLI prints a clear unknown-command error and exits 1. If there is no first positional token, the existing setup path remains untouched.

## Claim Check
Ran `instar dev:claim-check src/cli.ts src/commands/init.ts package.json --keywords unknown-command commander default-action`.

Relevant overlap found: open PR #868 touches `src/cli.ts`; open PRs #661 and #489 also overlap historically. I treated this as a separate parser-layer fix from #868's transcript-audit gate and kept the diff scoped to the top-level CLI parser boundary.

## Causal Autopsy
Origin: latent.

Commander’s program-level default action for bare `instar` was allowed to coexist without an explicit top-level unknown-command guard. The latent bug surfaced when a typo such as `instar dev:claim-checkk` entered setup instead of exiting, hanging agent Bash sessions.

## Ledger
Filed framework issue `4e9b9e23-94ee-4931-9cf7-3350f079e968` with dedupKey `active-cli-path-stale-npx-cache-masks-deployed-version` for the separate stale active-CLI path discovery.

## Verification
- `npm ci`
- `npm run build`
- `npm run lint`
- `npx vitest run tests/e2e/cli-unknown-command.test.ts`
- `node scripts/docs-coverage.mjs --check`
- `BASE_SHA=$(git merge-base HEAD JKHeadley/main) HEAD_SHA=$(git rev-parse HEAD) node scripts/decision-audit-presence-check.mjs`
- Manual typo probe: `node dist/cli.js dev:claim-checkk` exits 1 with `error: unknown command 'dev:claim-checkk'` and a help hint.
- Manual bare probe: `timeout 3 node dist/cli.js` enters setup and times out at 124, confirming bare setup behavior is preserved.
- Pre-push smoke tier: focused CLI e2e passed.
- Pre-push scoped e2e: threadline scoped suite passed, 17 files / 332 tests.

Note: `npm run build` emitted the existing local warning that no release signing key is configured, so lock-file signing was skipped in this dev environment.