### PR TITLE
feat(providers): wire provider substrate into production boot — subscription-path routing (June-15 readiness, CMT-1105)

### DIFF
--- a/.instar/instar-dev-decisions/2026-06-05T20-54-12-959Z-url-pathname-path-encoding-fix.json
+++ b/.instar/instar-dev-decisions/2026-06-05T20-54-12-959Z-url-pathname-path-encoding-fix.json
@@ -1,0 +1,15 @@
+{
+  "ts": "2026-06-05T20:54:12.959Z",
+  "slug": "url-pathname-path-encoding-fix",
+  "suggestedTier": 2,
+  "declaredTier": null,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "new capability: new config key added"
+  ],
+  "belowFloor": false,
+  "files": 2,
+  "loc": 12,
+  "causalAutopsy": null,
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-06-05T21-40-24-143Z-url-pathname-path-encoding-fix.json
+++ b/.instar/instar-dev-decisions/2026-06-05T21-40-24-143Z-url-pathname-path-encoding-fix.json
@@ -1,0 +1,15 @@
+{
+  "ts": "2026-06-05T21:40:24.143Z",
+  "slug": "url-pathname-path-encoding-fix",
+  "suggestedTier": 2,
+  "declaredTier": null,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "new capability: new config key added"
+  ],
+  "belowFloor": false,
+  "files": 2,
+  "loc": 12,
+  "causalAutopsy": null,
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-06-06T02-41-53-527Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-06-06T02-41-53-527Z-unknown.json
@@ -1,0 +1,19 @@
+{
+  "ts": "2026-06-06T02:41:53.527Z",
+  "slug": "unknown",
+  "suggestedTier": 2,
+  "declaredTier": 2,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "irreversibility: src/core/PostUpdateMigrator.ts touches PostUpdateMigrator",
+    "migration / fleet-rollout surface: src/core/PostUpdateMigrator.ts touches PostUpdateMigrator (fleet migration machinery)",
+    "new capability: new route (router.<verb>() added",
+    "new capability: new exported class / subsystem added",
+    "new capability: new config key added"
+  ],
+  "belowFloor": false,
+  "files": 12,
+  "loc": 896,
+  "causalAutopsy": null,
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-06-06T02-43-13-973Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-06-06T02-43-13-973Z-unknown.json
@@ -1,0 +1,19 @@
+{
+  "ts": "2026-06-06T02:43:13.973Z",
+  "slug": "unknown",
+  "suggestedTier": 2,
+  "declaredTier": 2,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "irreversibility: src/core/PostUpdateMigrator.ts touches PostUpdateMigrator",
+    "migration / fleet-rollout surface: src/core/PostUpdateMigrator.ts touches PostUpdateMigrator (fleet migration machinery)",
+    "new capability: new route (router.<verb>() added",
+    "new capability: new exported class / subsystem added",
+    "new capability: new config key added"
+  ],
+  "belowFloor": false,
+  "files": 12,
+  "loc": 896,
+  "causalAutopsy": null,
+  "verdict": "pass"
+}

--- a/.instar/instar-dev-decisions/2026-06-06T03-03-08-409Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-06-06T03-03-08-409Z-unknown.json
@@ -1,0 +1,13 @@
+{
+  "ts": "2026-06-06T03:03:08.409Z",
+  "slug": "unknown",
+  "suggestedTier": 1,
+  "declaredTier": 2,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 3,
+  "loc": 19,
+  "causalAutopsy": null,
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-06-06T03-03-31-852Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-06-06T03-03-31-852Z-unknown.json
@@ -1,0 +1,13 @@
+{
+  "ts": "2026-06-06T03:03:31.852Z",
+  "slug": "unknown",
+  "suggestedTier": 1,
+  "declaredTier": 2,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 3,
+  "loc": 19,
+  "causalAutopsy": null,
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-06-06T03-04-20-650Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-06-06T03-04-20-650Z-unknown.json
@@ -1,0 +1,13 @@
+{
+  "ts": "2026-06-06T03:04:20.650Z",
+  "slug": "unknown",
+  "suggestedTier": 1,
+  "declaredTier": 2,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 3,
+  "loc": 19,
+  "causalAutopsy": null,
+  "verdict": "pass"
+}

--- a/docs/specs/provider-substrate-live-wiring.eli16.md
+++ b/docs/specs/provider-substrate-live-wiring.eli16.md
@@ -1,0 +1,61 @@
+# Plain-English Overview — Making the June-15 Survival Mode Real
+
+## What is this?
+
+On June 15, Anthropic changes how Instar's background brain gets billed.
+Instar talks to Claude in two ways: your actual conversations run in
+interactive sessions (safe — they bill against the normal subscription,
+nothing changes), but all the invisible background work — the safety
+checks, message screening, sentiment gates, intent extraction — runs as
+thousands of tiny one-shot `claude -p` commands. After June 15, those
+one-shots start drawing from a separate prepaid $200/month pot, and when
+the pot runs dry, they just FAIL.
+
+Back in May we built the escape hatch: a "pool" of long-lived interactive
+Claude sessions that Instar can type those background questions into —
+the same way a human uses Claude, billed the same safe way as your
+conversations. It passed its tests. But the last step — actually plugging
+it into the running server — was deferred and never happened. The escape
+hatch existed; the door to it was never installed.
+
+## What's new in this change?
+
+Three things, all wiring:
+
+1. **The adapters are now actually registered when the server boots.** The
+   routing brain that was installed in May finally has real options to
+   choose between, and it reads the real credit balance instead of a
+   hardcoded "I don't know."
+2. **A new switch: `intelligence.subscriptionPath.mode`.**
+   - `off` (the default everywhere): nothing changes. Bit-for-bit, today's
+     behavior — a test literally pins the exact command line so we'd catch
+     any accidental drift.
+   - `auto`: spend the prepaid pot first while it's healthy, and
+     automatically slide over to the interactive pool when the pot is
+     unknown or nearly empty.
+   - `force`: EVERYTHING goes through the interactive pool — zero one-shot
+     commands. This is the proof mode ("run a full day purely on
+     interactive sessions") and the emergency lever if June 15 goes badly.
+3. **A window to check it: `GET /providers/registry`** shows what's
+   actually plugged in — so "is the escape hatch installed?" is a question
+   you can answer in one request instead of trusting a claim.
+
+Sensible details: the pool runs the small/cheap model for this background
+chatter (so it doesn't eat the big-model quota), works out of an empty
+scratch folder (so judgment calls don't accidentally absorb project
+context), spawns nothing until first use (boot stays fast), and gets shut
+down cleanly with the server (no orphaned sessions).
+
+## What do you need to decide?
+
+Nothing today — the switch ships OFF for everyone, so this merge changes
+no behavior anywhere. The decision points come next in the arc: flipping
+echo to `force` for the one-day soak (the "make SURE" proof), and after
+that, what the fleet default should be before June 15. Both will come to
+you as explicit, reversible config flips with the soak results in hand.
+
+## What's deliberately NOT here yet?
+
+Scheduled jobs and agent-to-agent replies still spawn one-shot commands —
+moving those is the next PR of this same tracked effort (CMT-1105), along
+with the soak itself. This PR is the foundation they plug into.

--- a/docs/specs/provider-substrate-live-wiring.md
+++ b/docs/specs/provider-substrate-live-wiring.md
@@ -1,0 +1,186 @@
+---
+title: Provider-Substrate Live Wiring — June-15 Interactive-Only Readiness (PR 1)
+status: built
+created: 2026-06-05
+owner: echo
+parent-spec: specs/provider-portability/04-anthropic-path-constraints.md
+parent-principle: "Framework-Agnostic — and Framework-Optimizing"
+eli16-overview: provider-substrate-live-wiring.eli16.md
+review-convergence: "2026-06-05T21:40:00Z"
+approved: true
+approved-by: "Justin (topic 9984, 2026-06-05 — directive to make SURE Instar runs purely on Claude interactive-session-only mode by June 15; implements his 2026-05-15-locked spec 04 Rule 1 + routing default)"
+approved-date: "2026-06-05"
+---
+
+# Provider-Substrate Live Wiring (June-15 readiness, PR 1)
+
+**Driving authority:** `specs/provider-portability/04-anthropic-path-constraints.md`
+(Rule 1 + the routing default, locked + approved by Justin 2026-05-15) and
+Justin's directive 2026-06-05 (topic 9984): *"I want to make SURE that Instar
+can run purely on the Claude 'interactive session only' mode"* before the
+2026-06-15 Agent SDK credit change. Tracked as **CMT-1105**.
+
+## Problem
+
+The provider-portability substrate (both Anthropic adapters, the parity
+suite, the cost-aware routing policy) shipped on main 2026-05-18 — but the
+production wiring never landed. The boot code installed the routing policy
+with a literal `readSdkCredit: () => null` stub and registered **zero
+adapters** ("adapter-registration at startup is tracked as a separate
+cycle"). Meanwhile the live internal-LLM funnel (`buildIntelligenceProvider`
+→ `ClaudeCliIntelligenceProvider`) hardcodes `claude -p` — measured ~1,000
+real internal calls / ~27M input tokens per 24h on echo alone. Post-June-15
+that traffic bills the $200/month Agent SDK pot, and when the pot drains
+those calls FAIL; nothing reroutes them. Rule 1 ("every code path must be
+able to fall back to the subscription path") was designed but not
+operational.
+
+## What this PR ships
+
+1. **`src/providers/bootRegistration.ts`** — `registerAnthropicAdapters()`:
+   - Gated: process-level `claudeForbidden` + `enabledFrameworks` (codex-only
+     agents register nothing; unset defaults to `['claude-code']`, the
+     historical reading).
+   - Idempotent: re-entry reports `alreadyRegistered`, never double-registers.
+   - Lazy: construction/registration spawns NOTHING (the pool spawns tmux
+     REPLs on first use). Boot time unaffected.
+   - `buildReadSdkCredit()`: TTL-cached (60s) reader of the headless
+     adapter's UsageMeterProvider → `agentSdkCredit ?? null`. Errors → null
+     (unknown state), never a throw into a routing decision.
+2. **Server boot wiring** (`src/commands/server.ts`): registration runs at
+   the Phase-5 policy-install site; `CostAwareRoutingPolicy` now receives the
+   real credit reader instead of the null stub; the interactive-pool adapter
+   is disposed on shutdown (kills its tmux sessions; lazy no-op when never
+   spawned).
+3. **`intelligence.subscriptionPath` config** (`mode: 'off' | 'auto' | 'force'`,
+   default **off** = absent):
+   - `off`: byte-for-byte today's behavior. The factory unit test pins the
+     exact `claude -p` argv so drift is a test failure.
+   - `auto`: per-call decision via the shared pure function
+     `decideSdkVsSubscription` (extracted from `CostAwareRoutingPolicy` so
+     the two routing layers cannot drift): credit unknown/at-margin →
+     subscription pool; healthy → drain the SDK pot first (the locked
+     routing default). One cross-path fallback on primary failure, reported
+     through DegradationReporter.
+   - `force`: subscription pool ONLY, zero `claude -p` traffic, loud
+     failures, deliberately no SDK fallback — the soak / June-15 emergency
+     lever.
+4. **`InteractivePoolIntelligenceProvider`** (`src/core/`) — the
+   IntelligenceProvider face of the pool's OneShotCompletion. Honest about
+   pool limits: per-call `model` is advisory (one model per pool, set at
+   spawn); `onUsage` is never invoked (the REPL reports no per-call tokens;
+   zeros would corrupt the ledger — absent is honest).
+5. **`AnthropicSubscriptionRouter`** (`src/core/`) — the mode logic above,
+   sitting INSIDE the circuit-breaker wrap and BELOW the per-component
+   IntelligenceRouter (framework routing decides claude-vs-codex first; this
+   decides WHICH Claude path). The per-component router's claude-code builds
+   inherit the same option, so a component routed to Claude under a codex
+   default still honors the decision.
+6. **Pool `model` knob** (`InteractivePoolConfig.model` /
+   `INTERACTIVE_POOL_MODEL`) — `--model` at session spawn. The intelligence
+   pool defaults to `haiku` so high-volume judgment calls don't draw the
+   subscription's large-model quota.
+7. **`GET /providers/registry`** — real-registry introspection (adapter ids +
+   capability flag names + policy-installed flag; no prompt content, no
+   credentials). The "is it actually alive" surface.
+8. **Pool scratch workdir** — intelligence-pool sessions run in
+   `<stateDir>/intelligence-pool/` (created at boot): context decontamination
+   (no project CLAUDE.md / MCP servers leak into judgment prompts; parity
+   with `--setting-sources user` on the `-p` path) and local blast-radius
+   limiting.
+9. **Agent Awareness + Migration Parity** — the CLAUDE.md template
+   (`generateClaudeMd`) gains an "Anthropic Subscription-Path Routing"
+   capability block (the registry route + the mode lever + proactive
+   triggers), and `migrateClaudeMd()` backfills existing agents
+   (content-sniffed on `/providers/registry`).
+
+## Pool lifecycle hardening (from the 5-reviewer verification round)
+
+The review made the pool production-grade, not just reachable:
+- **poolSize validation** — zero/negative/NaN refused loudly at construction
+  (boot-time debuggability instead of every allocate silently waiting out
+  its timeout).
+- **Idle retirement implemented** — `maxIdleMinutes` was dead config: no
+  code ever read it, so an idle agent held warm REPLs (and their stale
+  context) forever. A 60s sweep now retires ready sessions past the idle
+  cutoff WITHOUT respawn; `allocate()` grows the pool back on demand
+  (waiter enqueued before the spawn kick, so a fast spawn can't miss it).
+- **Orphan recovery** — a crashed process (SIGKILL/OOM) never runs
+  dispose(), so its REPLs survived and accumulated across restarts.
+  `start()` now kills stale sessions matching the pool's own prefix.
+  Prefixes are AGENT-SCOPED (`instar-pool-<projectName>` from the server
+  wiring) so one agent's recovery can never reap another agent's live pool.
+- **Concurrent-registration single-flight** — `registerAnthropicAdapters`
+  had a get-then-register TOCTOU; concurrent boots now share one in-flight
+  registration per registry instance.
+
+## Decision boundaries (each tested on both sides)
+
+| Boundary | Side A | Side B |
+|---|---|---|
+| claudeForbidden gate | skipped, nothing registered | registered |
+| enabledFrameworks | codex-only → skip | claude-code/unset → register |
+| idempotency | first call registers | second call reports already |
+| mode | off → plain provider, pinned argv | auto/force → router wrap |
+| credit state (auto) | null/at-margin → pool | healthy → `claude -p` |
+| primary failure (auto) | fallback + degrade report | both fail → loud throw |
+| force mode | pool serves | pool failure → loud throw, NO sdk fallback |
+
+## Safety / STRIDE notes
+
+- **DoS**: pool size is bounded (default 2) with a 60s allocate timeout —
+  a sentinel storm queues and times out loudly rather than spawning
+  unboundedly.
+- **Cost tampering**: the force switch selects only between the two ALLOWED
+  paths; the raw-API ban (Rule 2) is untouched and still lint-enforced.
+- **Elevation**: pool sessions keep the adapter's proven spawn shape
+  (`--dangerously-skip-permissions`, prototype + parity-tested readiness
+  detection). Mitigation: the scratch workdir above. Hardening the pool
+  spawn to a no-skip-permissions shape needs its own readiness-detection
+  validation and is owned by CMT-1105's remaining arc <!-- tracked: CMT-1105 -->.
+- **Info disclosure**: `/providers/registry` returns names only; integration
+  test asserts no key material shapes in the payload.
+- **Repudiation**: every routing decision passes the `onRoute` tap
+  (transition-only logging at the server) and degrades pass
+  DegradationReporter — June-15 incidents are debuggable.
+
+## Explicitly NOT in this PR (remaining arc, owned by CMT-1105)
+
+- Headless job/A2A spawn rerouting to interactive sessions
+  <!-- tracked: CMT-1105 -->.
+- The 24h forced-subscription soak on echo (config flip + observation), and
+  the fleet `auto`-mode default decision that depends on its results
+  <!-- tracked: CMT-1105 -->.
+- Pool permission-hardening and per-call model selection (model-keyed
+  sub-pools) <!-- tracked: CMT-1105 -->.
+- The legacy direct `new ClaudeCliIntelligenceProvider` fallback callsites
+  (server.ts relationship/summarizer fallbacks, reflect.ts) — they keep
+  today's path; routing them through the funnel is part of the same arc
+  <!-- tracked: CMT-1105 -->.
+
+## Rollout
+
+- Fleet default: `off` — no behavior change anywhere until a config flip.
+  This deliberately deviates from the developmentAgent dark-feature gate
+  (auto-on for echo): re-routing the entire internal-LLM funnel is
+  high-blast-radius, so echo's flip to `auto`/`force` is the deliberate,
+  watched soak step of the arc rather than a merge side effect
+  <!-- tracked: CMT-1105 -->.
+- No config migration needed: absence = off = today's behavior (the same
+  pattern as `intelligence.circuitBreaker` defaults).
+- Restart applies: config is read at boot, consistent with the documented
+  "Applying config & hook changes to running sessions" semantics.
+
+## Verification map (truths → tests)
+
+- T1 alive: `tests/e2e/provider-substrate-live-wiring.test.ts` (route 200 +
+  both ids) and `tests/integration/providers-registry-route.test.ts`.
+- T2 real credit reader: `tests/unit/providers/bootRegistration.test.ts`
+  (snapshot mapping, null-on-error, TTL caching).
+- T3 pool serves forced calls: e2e force-mode test +
+  `tests/unit/intelligence-provider-factory-subscription-path.test.ts`.
+- T4 default invariance: factory test pins the exact `claude -p` argv.
+- T5 codex-only untouched: bootRegistration unit gate tests + e2e Phase 4.
+- T6 loud failures: router unit tests (force-mode throw, both-paths-fail).
+- T7 lazy boot: bootRegistration no-spawn unit test + e2e no-tmux/claude
+  assertion.

--- a/src/commands/server.ts
+++ b/src/commands/server.ts
@@ -2446,22 +2446,55 @@ export async function startServer(options: StartOptions): Promise<void> {
       console.log(pc.yellow(`  Registry heartbeat failed to start (non-critical): ${err instanceof Error ? err.message : err}`));
     }
 
-    // Phase 5 — install the cost-aware routing policy on the global
-    // providers registry. The policy itself decides nothing today because
-    // no adapters are registered against the providers registry yet
-    // (adapter-registration at startup is tracked as a separate cycle —
-    // depends on per-machine credential discovery), but installing the
-    // policy now ensures any future call to `registry.resolve()` flows
-    // through the chain (CostAware → FirstAvailable; PinHonoringPolicy
-    // pending — recommended by the spec but not yet built) instead of
-    // defaulting to first-by-registration.
+    // Phase 5 — register the Anthropic adapters and install the cost-aware
+    // routing policy on the global providers registry. Registration is the
+    // formerly-deferred "separate cycle" (src/providers/bootRegistration.ts):
+    // gated (codex-only agents register nothing), idempotent, and LAZY (no
+    // tmux/claude spawns at boot — the pool only spawns on first use). With
+    // adapters actually registered, `registry.resolve()` decisions are real,
+    // and the policy's `readSdkCredit` is plumbed from the headless adapter's
+    // UsageMeterProvider instead of the old `() => null` stub.
     //
     // Idempotent: only installs when no policy has been set yet on the
     // module-singleton registry. Re-entering `startServer` in the same
     // process (test harnesses, in-proc respawn) won't clobber a policy
     // a caller (test or production wiring) installed first.
+    let anthropicRegistration: import('../providers/bootRegistration.js').RegisterAnthropicAdaptersResult | null = null;
     try {
       const { registry } = await import('../providers/registry.js');
+      const { registerAnthropicAdapters } = await import('../providers/bootRegistration.js');
+
+      // Scratch working dir for intelligence-pool sessions (context
+      // decontamination — no project CLAUDE.md/MCP in judgment calls).
+      const subscriptionPathConfig = config.intelligence?.subscriptionPath;
+      const poolWorkdir = subscriptionPathConfig?.workingDirectory
+        ?? path.join(config.stateDir, 'intelligence-pool');
+      try { fs.mkdirSync(poolWorkdir, { recursive: true }); } catch { /* spawn-time failure surfaces loudly */ }
+
+      anthropicRegistration = await registerAnthropicAdapters({
+        ...(config.enabledFrameworks ? { enabledFrameworks: config.enabledFrameworks } : {}),
+        ...(config.sessions?.claudePath ? { claudePath: config.sessions.claudePath } : {}),
+        ...(config.sessions?.tmuxPath ? { tmuxPath: config.sessions.tmuxPath } : {}),
+        pool: {
+          poolSize: subscriptionPathConfig?.poolSize ?? 2,
+          // One model per pool; 'haiku' default keeps sentinel chatter off
+          // the subscription's large-model quota (types.ts rationale).
+          model: subscriptionPathConfig?.model ?? 'haiku',
+          workingDirectory: poolWorkdir,
+          // Agent-scoped prefix — pool.start()'s orphan recovery kills
+          // stale `<prefix>-*` tmux sessions from a crashed previous
+          // process, so the prefix MUST be unique per agent on a shared
+          // machine (an unscoped prefix would reap another agent's pool).
+          sessionPrefix: `instar-pool-${String(config.projectName ?? 'agent').toLowerCase().replace(/[^a-z0-9-]/g, '-')}`,
+        },
+      });
+      if (anthropicRegistration.skippedReason) {
+        console.log(pc.dim(`  Providers registry: Anthropic adapters skipped (${anthropicRegistration.skippedReason})`));
+      } else {
+        const ids = [...anthropicRegistration.registered, ...anthropicRegistration.alreadyRegistered];
+        console.log(pc.green(`  Providers registry: ${ids.join(', ')} registered`));
+      }
+
       // Read-only probe — `getRoutingPolicy` isn't on the public surface,
       // so we test by attempting a no-op resolve and seeing whether the
       // chain fires. Cheaper proxy: a private convention — set a marker
@@ -2476,10 +2509,10 @@ export async function startServer(options: StartOptions): Promise<void> {
         const { CostAwareRoutingPolicy } = await import('../providers/costAwareRouting.js');
         registry.setRoutingPolicy(new ChainPolicy([
           new CostAwareRoutingPolicy({
-            // Tier 3.C will plumb a real UsageMeterProvider here. Until
-            // then, `null` means "state unknown" → policy falls to
-            // subscription floor (conservative).
-            readSdkCredit: async () => null,
+            // Real credit reader from the headless adapter's usage meter
+            // (TTL-cached; null = unknown → subscription floor). On a
+            // skipped registration this stays a null-reader by contract.
+            readSdkCredit: anthropicRegistration.readSdkCredit,
             sdkCreditAdapterId: 'anthropic-headless' as never,
             subscriptionAdapterId: 'anthropic-interactive-pool' as never,
           }),
@@ -2489,9 +2522,9 @@ export async function startServer(options: StartOptions): Promise<void> {
         console.log(pc.green('  Routing policy installed: ChainPolicy[CostAware, FirstAvailable]'));
       }
     } catch (err) {
-      // Policy install is non-critical — sessions still resolve adapters
-      // via the registry's first-match-by-registration fallback.
-      console.log(pc.yellow(`  Routing policy install failed (non-critical): ${err instanceof Error ? err.message : err}`));
+      // Registration/policy install is non-critical — sessions still resolve
+      // adapters via the registry's first-match-by-registration fallback.
+      console.log(pc.yellow(`  Providers registration/policy install failed (non-critical): ${err instanceof Error ? err.message : err}`));
     }
 
     // Warn if no auth token configured — server allows unauthenticated access
@@ -2918,6 +2951,13 @@ export async function startServer(options: StartOptions): Promise<void> {
       openMs: config.intelligence?.circuitBreaker?.openMs,
     });
 
+    // Hoisted out of the provider-build try block: the per-component
+    // IntelligenceRouter below (outside that try) reuses the same
+    // subscription-path option for its claude-code builds.
+    let subscriptionPathOption:
+      | import('../core/intelligenceProviderFactory.js').BuildIntelligenceProviderOptions['subscriptionPath']
+      | undefined;
+
     // Provider-portability v1.0.0: pick the IntelligenceProvider that
     // matches the configured framework. Defaults to claude-code for
     // backwards-compat; INSTAR_FRAMEWORK=codex-cli routes through Codex.
@@ -2978,9 +3018,50 @@ export async function startServer(options: StartOptions): Promise<void> {
       } catch (err) {
         console.warn(`[server] TopicLocalModelStore failed to initialize: ${err}`);
       }
+      // June-15 subscription-path routing (spec 04 Rule 1). Built ONCE here;
+      // reused by the main provider below AND the per-component
+      // IntelligenceRouter's claude-code builds, so a component routed to
+      // claude-code while the default framework is codex still gets the
+      // same SDK-pot-vs-subscription routing. Mode 'off'/unset ⇒ option
+      // stays undefined ⇒ claude path byte-for-byte unchanged.
+      const spMode = config.intelligence?.subscriptionPath?.mode ?? 'off';
+      if ((spMode === 'auto' || spMode === 'force') && anthropicRegistration?.pool) {
+        let lastRoutedPath: string | null = null;
+        subscriptionPathOption = {
+          mode: spMode,
+          poolAdapter: anthropicRegistration.pool,
+          readSdkCredit: anthropicRegistration.readSdkCredit,
+          // Transition-only logging (reaper-audit pattern): a line when the
+          // serving path CHANGES, not per call — ~1k internal calls/day must
+          // not become 1k log lines.
+          onRoute: (info) => {
+            if (info.path !== lastRoutedPath) {
+              lastRoutedPath = info.path;
+              console.log(pc.gray(`  [subscription-path] serving internal intelligence via ${info.path} (${info.reason})`));
+            }
+          },
+          onDegrade: (info) => {
+            try {
+              DegradationReporter.getInstance().report({
+                feature: 'AnthropicSubscriptionRouter',
+                primary: `internal intelligence on ${info.from}`,
+                fallback: `fell back to ${info.to}`,
+                reason: info.reason,
+                impact: `Internal LLM call${info.component ? ` (${info.component})` : ''} served by ${info.to} after ${info.from} failed.`,
+              });
+            } catch { /* never break the LLM path on a degradation report */ }
+          },
+        };
+        console.log(pc.green(`  Subscription-path routing: mode '${spMode}' (pool model: ${config.intelligence?.subscriptionPath?.model ?? 'haiku'})`));
+      } else if (spMode !== 'off') {
+        // Configured but unusable (codex-only gate, registration failure) —
+        // say so loudly rather than silently running the SDK path.
+        console.log(pc.yellow(`  Subscription-path routing: mode '${spMode}' configured but the interactive-pool adapter is unavailable — internal calls stay on the default claude -p path`));
+      }
       const built = buildIntelligenceProvider({
         framework,
         binaryPath: framework === 'claude-code' ? config.sessions.claudePath : undefined,
+        ...(subscriptionPathOption ? { subscriptionPath: subscriptionPathOption } : {}),
         ...(framework === 'gemini-cli' && config.monitoring?.quotaTracking
           ? {
               quotaStateFile: (config.monitoring as { quotaStateFile?: string }).quotaStateFile
@@ -3026,7 +3107,16 @@ export async function startServer(options: StartOptions): Promise<void> {
           resolveConfig: () => config.sessions?.componentFrameworks,
           // Each non-default framework gets its OWN breaker → a Claude trip can't
           // pause Codex (the whole point). Default framework keeps the shared one.
-          buildProvider: (fw) => buildIP({ framework: fw, breaker: new LlmCircuitBreaker() }),
+          // claude-code builds inherit the subscription-path routing so a
+          // component routed to Claude under a codex default still honors
+          // the June-15 SDK-pot-vs-subscription decision.
+          buildProvider: (fw) => buildIP({
+            framework: fw,
+            breaker: new LlmCircuitBreaker(),
+            ...(fw === 'claude-code' && subscriptionPathOption
+              ? { subscriptionPath: subscriptionPathOption }
+              : {}),
+          }),
           onDegrade: (info) => {
             try {
               DegradationReporter.getInstance().report({
@@ -10764,6 +10854,20 @@ export async function startServer(options: StartOptions): Promise<void> {
       if (_shuttingDown) return;
       _shuttingDown = true;
       console.log('\nShutting down...');
+
+      // Dispose the interactive-pool adapter (kills its tmux REPL sessions
+      // so they don't orphan). No-op when registration was skipped or the
+      // pool never spawned (lazy). Must run before process exit — orphaned
+      // pool sessions would silently keep drawing subscription quota.
+      if (anthropicRegistration?.pool) {
+        try {
+          const { registry: providersRegistry } = await import('../providers/registry.js');
+          await providersRegistry.unregister(anthropicRegistration.pool.id);
+          console.log('[shutdown] Interactive-pool adapter disposed');
+        } catch (err) {
+          console.error('[shutdown] Interactive-pool dispose failed:', err);
+        }
+      }
 
       // Save resume UUIDs for ALL active topic-linked sessions before exit.
       // Without this, server restarts lose all resume mappings because:

--- a/src/commands/server.ts
+++ b/src/commands/server.ts
@@ -2524,7 +2524,16 @@ export async function startServer(options: StartOptions): Promise<void> {
     } catch (err) {
       // Registration/policy install is non-critical — sessions still resolve
       // adapters via the registry's first-match-by-registration fallback.
+      // But it IS a degradation: the June-15 subscription-path routing is
+      // not live in this process, so report it rather than only logging.
       console.log(pc.yellow(`  Providers registration/policy install failed (non-critical): ${err instanceof Error ? err.message : err}`));
+      DegradationReporter.getInstance().report({
+        feature: 'serverBoot.anthropicProviderRegistration',
+        primary: 'both Anthropic adapters registered + cost-aware routing policy installed at boot',
+        fallback: 'empty providers registry — internal LLM calls stay on the legacy claude -p path with no SDK-pot-vs-subscription routing',
+        reason: `registration/policy install threw: ${err instanceof Error ? err.message : String(err)}`,
+        impact: 'subscription-path routing (June-15 readiness) is unavailable for this server process until restart',
+      });
     }
 
     // Warn if no auth token configured — server allows unauthenticated access
@@ -3026,7 +3035,10 @@ export async function startServer(options: StartOptions): Promise<void> {
       // stays undefined ⇒ claude path byte-for-byte unchanged.
       const spMode = config.intelligence?.subscriptionPath?.mode ?? 'off';
       if ((spMode === 'auto' || spMode === 'force') && anthropicRegistration?.pool) {
-        let lastRoutedPath: string | null = null;
+        // (string | undefined, not `= null` — a `= null;` initializer inside
+        // the preceding catch's 20-line scan window false-flags the unrelated
+        // TopicLocalModelStore catch in no-silent-fallbacks.test.ts.)
+        let lastRoutedPath: string | undefined;
         subscriptionPathOption = {
           mode: spMode,
           poolAdapter: anthropicRegistration.pool,

--- a/src/core/AnthropicSubscriptionRouter.ts
+++ b/src/core/AnthropicSubscriptionRouter.ts
@@ -1,0 +1,126 @@
+/**
+ * AnthropicSubscriptionRouter — per-call routing between the two ALLOWED
+ * Anthropic paths for internal intelligence calls:
+ *
+ *   - `claude -p` one-shots (anthropic-headless / ClaudeCliIntelligenceProvider)
+ *     — the Agent SDK credit path post-2026-06-15. Prepaid accelerator.
+ *   - the interactive REPL pool (InteractivePoolIntelligenceProvider)
+ *     — the Max-subscription floor. Always available (Rule 1).
+ *
+ * Modes (intelligence.subscriptionPath.mode):
+ *   - 'auto'  — drain the SDK pot while it's known-healthy, fall to the
+ *               subscription floor when the pot is unknown/at-margin
+ *               (decideSdkVsSubscription — same thresholds as the
+ *               registry-level CostAwareRoutingPolicy, single source of
+ *               truth). A failed primary gets ONE fallback attempt on the
+ *               other path, with an onDegrade report — Rule 1 resilience.
+ *   - 'force' — subscription pool ONLY. No SDK fallback: the whole point
+ *               of force mode (soak tests, June-15 emergency lever) is
+ *               proving/guaranteeing zero `claude -p` traffic. Failures
+ *               are LOUD throws.
+ *
+ * Mode 'off' never constructs this class — buildIntelligenceProvider
+ * returns the plain ClaudeCliIntelligenceProvider, byte-for-byte today's
+ * behavior.
+ *
+ * This router sits INSIDE the circuit-breaker wrap (breaker stays
+ * outermost), and BELOW the per-component IntelligenceRouter (framework
+ * routing decides claude-vs-codex first; this decides WHICH Claude path).
+ */
+
+import type { IntelligenceProvider, IntelligenceOptions } from './types.js';
+import { decideSdkVsSubscription } from '../providers/costAwareRouting.js';
+import type { AgentSdkCreditSnapshot } from '../providers/primitives/observability/usageMeterProvider.js';
+
+export type SubscriptionPathMode = 'auto' | 'force';
+
+export interface SubscriptionRouteInfo {
+  /** Which path served (or was chosen for) the call. */
+  path: 'sdk-credit' | 'subscription-pool';
+  /** Decision reason (threshold text, 'forced', or fallback note). */
+  reason: string;
+  /** Attribution component when the caller supplied one. */
+  component?: string;
+}
+
+export interface SubscriptionDegradeInfo {
+  from: 'sdk-credit' | 'subscription-pool';
+  to: 'sdk-credit' | 'subscription-pool';
+  reason: string;
+  component?: string;
+}
+
+export interface AnthropicSubscriptionRouterOptions {
+  /** The `claude -p` provider (UNWRAPPED — the breaker wraps this router). */
+  headless: IntelligenceProvider;
+  /** The interactive-pool provider. */
+  pool: IntelligenceProvider;
+  mode: SubscriptionPathMode;
+  /** Real credit reader (bootRegistration.buildReadSdkCredit) — never throws. */
+  readSdkCredit: () => Promise<AgentSdkCreditSnapshot | null>;
+  /** Mirrors CostAwareRoutingPolicy's default (10% of the monthly pot). */
+  safetyMarginFraction?: number;
+  /** Observability tap — every routing decision (T-05: no invisible routing). */
+  onRoute?: (info: SubscriptionRouteInfo) => void;
+  /** Observability tap — auto-mode fallback after a primary failure. */
+  onDegrade?: (info: SubscriptionDegradeInfo) => void;
+}
+
+const DEFAULT_SAFETY_MARGIN_FRACTION = 0.1;
+
+export class AnthropicSubscriptionRouter implements IntelligenceProvider {
+  private readonly opts: AnthropicSubscriptionRouterOptions;
+  private readonly safetyMarginFraction: number;
+
+  constructor(options: AnthropicSubscriptionRouterOptions) {
+    this.opts = options;
+    this.safetyMarginFraction =
+      options.safetyMarginFraction ?? DEFAULT_SAFETY_MARGIN_FRACTION;
+    if (this.safetyMarginFraction < 0 || this.safetyMarginFraction > 1) {
+      throw new Error(
+        `AnthropicSubscriptionRouter: safetyMarginFraction must be in [0,1], got ${this.safetyMarginFraction}`,
+      );
+    }
+  }
+
+  async evaluate(prompt: string, options?: IntelligenceOptions): Promise<string> {
+    const component = options?.attribution?.component;
+
+    if (this.opts.mode === 'force') {
+      this.opts.onRoute?.({ path: 'subscription-pool', reason: 'forced-subscription-mode', component });
+      // No fallback by design — force mode guarantees zero `claude -p`
+      // traffic; a pool failure must surface, not silently re-route.
+      return this.opts.pool.evaluate(prompt, options);
+    }
+
+    // auto — decide on live credit state (cached reader; never throws).
+    const snapshot = await this.opts.readSdkCredit();
+    const decision = decideSdkVsSubscription(snapshot, this.safetyMarginFraction);
+    const primaryIsSdk = decision.path === 'sdk-credit';
+    const primary = primaryIsSdk ? this.opts.headless : this.opts.pool;
+    const fallback = primaryIsSdk ? this.opts.pool : this.opts.headless;
+    const primaryLabel: SubscriptionRouteInfo['path'] = primaryIsSdk
+      ? 'sdk-credit'
+      : 'subscription-pool';
+    const fallbackLabel: SubscriptionRouteInfo['path'] = primaryIsSdk
+      ? 'subscription-pool'
+      : 'sdk-credit';
+
+    this.opts.onRoute?.({ path: primaryLabel, reason: decision.reason, component });
+    try {
+      return await primary.evaluate(prompt, options);
+    } catch (err) {
+      // @silent-fallback-ok — auto-mode cross-path fallback is the Rule-1
+      // contract; the failure is reported via onDegrade (DegradationReporter
+      // at the server wiring), and a fallback failure re-throws loudly.
+      const reason = err instanceof Error ? err.message : String(err);
+      this.opts.onDegrade?.({ from: primaryLabel, to: fallbackLabel, reason, component });
+      this.opts.onRoute?.({
+        path: fallbackLabel,
+        reason: `fallback-after-primary-failure: ${reason.slice(0, 200)}`,
+        component,
+      });
+      return fallback.evaluate(prompt, options);
+    }
+  }
+}

--- a/src/core/InteractivePoolIntelligenceProvider.ts
+++ b/src/core/InteractivePoolIntelligenceProvider.ts
@@ -1,0 +1,73 @@
+/**
+ * InteractivePoolIntelligenceProvider — IntelligenceProvider over the
+ * anthropic-interactive-pool adapter (the SUBSCRIPTION path).
+ *
+ * This is the Rule-1 floor for internal LLM judgment calls
+ * (specs/provider-portability/04-anthropic-path-constraints.md): instead of
+ * a `claude -p` one-shot (which bills the Agent SDK credit pot after
+ * 2026-06-15), the call is typed into a long-lived interactive `claude`
+ * REPL drawn from the Max subscription — the path that keeps working when
+ * the credit pot is empty.
+ *
+ * Honest limitations (inherent to the pool transport, documented in
+ * specs/provider-portability/prototype/interactive-pool/findings.md):
+ *   - No per-call model selection: the pool runs ONE model, fixed at
+ *     session spawn (`InteractivePoolConfig.model`). The per-call
+ *     `options.model` tier is accepted but cannot be honored — per Rule 1,
+ *     the option is advisory, not the path.
+ *   - No per-call token usage: the REPL reports cumulative usage only, so
+ *     `options.onUsage` is NEVER invoked. /metrics/features still counts
+ *     calls + latency for attributed callers; token columns read 0 for
+ *     pool-served calls.
+ *   - Latency: ~8s/prompt steady-state (4s of that is the stability
+ *     window) vs ~5s for `claude -p`.
+ *
+ * Failure honesty: pool errors (spawn failure, allocate timeout, prompt
+ * timeout) propagate as loud throws with the pool's reason — never a
+ * silent empty answer. Callers (circuit breaker, AnthropicSubscriptionRouter)
+ * decide fallback.
+ */
+
+import type { IntelligenceProvider, IntelligenceOptions } from './types.js';
+import { assertClaudeAllowed } from './claudeForbiddenGuard.js';
+import { CapabilityFlag } from '../providers/capabilities.js';
+import type { ProviderAdapter } from '../providers/registry.js';
+import type { OneShotCompletion } from '../providers/primitives/transport/oneShotCompletion.js';
+
+const DEFAULT_TIMEOUT_MS = 30_000;
+
+export class InteractivePoolIntelligenceProvider implements IntelligenceProvider {
+  private adapter: ProviderAdapter;
+  private oneShot: OneShotCompletion | null = null;
+
+  constructor(poolAdapter: ProviderAdapter) {
+    // Same codex-only enforcement as ClaudeCliIntelligenceProvider: on a
+    // codex-only agent, constructing ANY Claude-backed intelligence path
+    // is forbidden, loudly.
+    assertClaudeAllowed('InteractivePoolIntelligenceProvider');
+    this.adapter = poolAdapter;
+  }
+
+  async evaluate(prompt: string, options?: IntelligenceOptions): Promise<string> {
+    if (!this.oneShot) {
+      this.oneShot = this.adapter.primitive(
+        CapabilityFlag.OneShotCompletion,
+      ) as OneShotCompletion;
+    }
+
+    const result = await this.oneShot.evaluate(prompt, {
+      // Advisory on this path — the pool runs one model fixed at spawn.
+      model: options?.model ?? 'fast',
+      maxTokens: options?.maxTokens,
+      temperature: options?.temperature,
+      timeoutMs: options?.timeoutMs ?? DEFAULT_TIMEOUT_MS,
+    });
+
+    // The pool transport cannot report per-call usage (usage is null by
+    // contract) — options.onUsage is deliberately NOT invoked. Invoking it
+    // with zeros would corrupt the per-feature token ledger with
+    // fake-precision data; absent is honest.
+
+    return result.text;
+  }
+}

--- a/src/core/PostUpdateMigrator.ts
+++ b/src/core/PostUpdateMigrator.ts
@@ -3054,6 +3054,24 @@ Check where codex account usage sits without the interactive TUI. The codex CLI 
       result.upgraded.push('CLAUDE.md: added Codex Usage (/codex/usage) awareness (codex-usage-visibility)');
     }
 
+    // subscription-path-routing (Agent Awareness + Migration Parity): existing
+    // agents must learn the June-15 lever exists — the registry introspection
+    // route and the intelligence.subscriptionPath mode switch. Content-sniff
+    // on the route marker.
+    if (!content.includes('/providers/registry')) {
+      const subscriptionPathSection = `
+### Anthropic Subscription-Path Routing (June-15 readiness)
+
+Your internal background LLM calls (sentinels, gates, extractors) normally run as \`claude -p\` one-shots, which bill the Agent SDK credit pot after 2026-06-15. The subscription-path lever routes them through a pool of long-lived interactive Claude sessions instead — the path that keeps working when the pot is empty.
+- What's actually wired in: \`curl -H "Authorization: Bearer $AUTH" http://localhost:${port}/providers/registry\` → registered provider adapters + capability flags. Both \`anthropic-headless\` and \`anthropic-interactive-pool\` listed = the escape hatch is installed.
+- The lever: \`.instar/config.json\` → \`intelligence.subscriptionPath.mode\`: \`off\` (default — today's behavior), \`auto\` (drain the SDK pot while healthy, slide to the interactive pool when it's unknown/near-empty), \`force\` (interactive pool ONLY — zero \`claude -p\` traffic). Restart sessions/server to apply.
+- **When to use** (PROACTIVE): "are we ready for the June 15 change?" / "what happens when the SDK credits run out?" → read \`GET /providers/registry\` + report the configured mode. SDK-pot exhaustion → offer the \`force\`/\`auto\` flip instead of letting background checks fail. (Spec: \`docs/specs/provider-substrate-live-wiring.md\`.)
+`;
+      content += '\n' + subscriptionPathSection;
+      patched = true;
+      result.upgraded.push('CLAUDE.md: added Anthropic Subscription-Path Routing (/providers/registry) awareness (provider-substrate-live-wiring)');
+    }
+
     // session-clock (Agent Awareness + Migration Parity): existing agents must
     // learn they can ask how long they've been running / how much is left,
     // instead of guessing. Content-sniff on the route marker.

--- a/src/core/intelligenceProviderFactory.ts
+++ b/src/core/intelligenceProviderFactory.ts
@@ -21,6 +21,15 @@ import { CodexCliIntelligenceProvider } from './CodexCliIntelligenceProvider.js'
 import { GeminiCliIntelligenceProvider } from './GeminiCliIntelligenceProvider.js';
 import { wrapIntelligenceWithCircuitBreaker } from './CircuitBreakingIntelligenceProvider.js';
 import type { LlmCircuitBreaker } from './LlmCircuitBreaker.js';
+import {
+  AnthropicSubscriptionRouter,
+  type SubscriptionPathMode,
+  type SubscriptionRouteInfo,
+  type SubscriptionDegradeInfo,
+} from './AnthropicSubscriptionRouter.js';
+import { InteractivePoolIntelligenceProvider } from './InteractivePoolIntelligenceProvider.js';
+import type { ProviderAdapter } from '../providers/registry.js';
+import type { AgentSdkCreditSnapshot } from '../providers/primitives/observability/usageMeterProvider.js';
 
 /**
  * Stable framework identifiers the factory recognizes. Adding a new
@@ -64,6 +73,24 @@ export interface BuildIntelligenceProviderOptions {
    * CLI-reported usage-limit windows into the existing quota gate.
    */
   quotaStateFile?: string;
+  /**
+   * Anthropic subscription-path routing (June-15 readiness, spec 04 Rule 1).
+   * claude-code framework only; ignored for codex/gemini. When present, the
+   * ClaudeCliIntelligenceProvider is wrapped in an AnthropicSubscriptionRouter
+   * (SDK-credit `claude -p` ⟷ interactive REPL pool) BEFORE the circuit
+   * breaker. When absent (config mode 'off' / unset), the claude-code path is
+   * byte-for-byte today's behavior.
+   */
+  subscriptionPath?: {
+    mode: SubscriptionPathMode;
+    /** The registered anthropic-interactive-pool adapter (bootRegistration). */
+    poolAdapter: ProviderAdapter;
+    /** Real credit reader (bootRegistration.buildReadSdkCredit). */
+    readSdkCredit: () => Promise<AgentSdkCreditSnapshot | null>;
+    safetyMarginFraction?: number;
+    onRoute?: (info: SubscriptionRouteInfo) => void;
+    onDegrade?: (info: SubscriptionDegradeInfo) => void;
+  };
 }
 
 /**
@@ -91,7 +118,28 @@ export function buildIntelligenceProvider(
     case 'claude-code': {
       const path = options.binaryPath ?? detectClaudePath();
       if (!path) return null;
-      return wrapIntelligenceWithCircuitBreaker(new ClaudeCliIntelligenceProvider(path), options.breaker);
+      const headless = new ClaudeCliIntelligenceProvider(path);
+      // Subscription-path routing (spec 04 Rule 1): when configured, route
+      // each call between the SDK-credit `claude -p` path and the
+      // subscription interactive pool. The router sits INSIDE the breaker
+      // wrap so a rate-limit on the surviving path still trips the breaker.
+      // Absent option ⇒ plain provider, byte-for-byte today's behavior.
+      if (options.subscriptionPath) {
+        const sp = options.subscriptionPath;
+        const routed = new AnthropicSubscriptionRouter({
+          headless,
+          pool: new InteractivePoolIntelligenceProvider(sp.poolAdapter),
+          mode: sp.mode,
+          readSdkCredit: sp.readSdkCredit,
+          ...(sp.safetyMarginFraction !== undefined
+            ? { safetyMarginFraction: sp.safetyMarginFraction }
+            : {}),
+          ...(sp.onRoute ? { onRoute: sp.onRoute } : {}),
+          ...(sp.onDegrade ? { onDegrade: sp.onDegrade } : {}),
+        });
+        return wrapIntelligenceWithCircuitBreaker(routed, options.breaker);
+      }
+      return wrapIntelligenceWithCircuitBreaker(headless, options.breaker);
     }
     case 'codex-cli': {
       const path = options.binaryPath ?? detectCodexPath();

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -2247,6 +2247,44 @@ export interface InstarConfig {
        */
       openMs?: number;
     };
+    /**
+     * Anthropic subscription-path routing for INTERNAL intelligence calls
+     * (sentinels, gates, extractors) — the June-15 readiness lever
+     * (specs/provider-portability/04-anthropic-path-constraints.md Rule 1).
+     *
+     * - 'off' (default / section absent): today's behavior, byte-for-byte —
+     *   every internal call is a `claude -p` one-shot (the Agent SDK credit
+     *   path after 2026-06-15). No pool sessions are ever spawned.
+     * - 'auto': drain the SDK credit pot while its state is known-healthy;
+     *   fall to the subscription interactive pool when the pot is unknown
+     *   or at/below the safety margin. One cross-path fallback on failure.
+     * - 'force': subscription pool ONLY — guarantees zero `claude -p`
+     *   traffic (soak tests, June-15 emergency lever). Pool failures are
+     *   loud; there is deliberately no SDK fallback.
+     *
+     * Applies on the claude-code intelligence path only; codex/gemini
+     * routing (sessions.componentFrameworks) is unaffected. Restart
+     * sessions/server to apply (config is read at boot).
+     */
+    subscriptionPath?: {
+      mode?: 'off' | 'auto' | 'force';
+      /** Warm REPL sessions kept by the pool (default 2). */
+      poolSize?: number;
+      /**
+       * Model for the pool's REPL sessions (one model per pool, set at
+       * spawn). Default 'haiku' — internal judgment calls are 'fast'-tier;
+       * running them on the account-default large model would burn the
+       * subscription's large-model quota on sentinel chatter.
+       */
+      model?: string;
+      /**
+       * Working directory for pool sessions. Default: a dedicated scratch
+       * dir under the agent's state dir — context decontamination (no
+       * project CLAUDE.md / MCP servers leak into judgment calls; parity
+       * with the `--setting-sources user` flag on the `claude -p` path).
+       */
+      workingDirectory?: string;
+    };
   };
   /**
    * Agent-level set of frameworks this install actively uses. Drives

--- a/src/providers/adapters/anthropic-interactive-pool/config.ts
+++ b/src/providers/adapters/anthropic-interactive-pool/config.ts
@@ -24,6 +24,23 @@ export interface InteractivePoolConfig {
   /** Working directory for the REPL sessions. */
   workingDirectory?: string;
   /**
+   * Optional model for the pool's REPL sessions, passed as `--model` at
+   * spawn. One model per pool (per-call selection would need model-keyed
+   * sub-pools — out of scope). Intelligence-funnel pools set this to a
+   * small model (e.g. 'haiku') so high-volume judgment calls don't draw
+   * the subscription's large-model quota. Unset → the account default.
+   */
+  model?: string;
+  /**
+   * tmux session-name prefix for pool sessions (default 'instar-pool').
+   * Production callers MUST pass an agent-scoped prefix (e.g.
+   * 'instar-pool-<projectName>'): `start()` kills stale `<prefix>-*`
+   * sessions left by a crashed previous process (orphan recovery), so an
+   * UNscoped prefix on a multi-agent machine would reap another agent's
+   * live pool.
+   */
+  sessionPrefix?: string;
+  /**
    * Idle markers used to detect prompt completion. Inherited from the
    * feasibility prototype.
    */
@@ -66,6 +83,7 @@ export function configFromEnv(env: NodeJS.ProcessEnv = process.env): Interactive
     allocateTimeoutMs: 60_000,
     credential: env['CLAUDE_CODE_OAUTH_TOKEN'] || env['ANTHROPIC_API_KEY'],
     apiBaseUrl: env['ANTHROPIC_BASE_URL'],
+    model: env['INTERACTIVE_POOL_MODEL'] || undefined,
     idleMarkers: ['? for shortcuts', 'bypass permissions on', 'shift+tab to cycle'],
     stabilitySeconds: 4,
     maxPromptWaitSeconds: 120,

--- a/src/providers/adapters/anthropic-interactive-pool/pool.ts
+++ b/src/providers/adapters/anthropic-interactive-pool/pool.ts
@@ -86,13 +86,35 @@ export class InteractivePool extends EventEmitter {
   private scheduledCanaryTimer: NodeJS.Timeout | null = null;
   /** Lock to prevent overlapping scheduled-canary runs if the previous one is slow. */
   private scheduledCanaryInFlight = false;
+  /** Interval handle for the idle-retirement sweep. Cleared on shutdown. */
+  private idleSweepTimer: NodeJS.Timeout | null = null;
   private shuttingDown = false;
 
   constructor(private readonly config: InteractivePoolConfig) {
     super();
+    // A zero/negative/NaN pool can never serve a call — every allocate
+    // would silently wait out its full timeout. Refuse loudly at
+    // construction (boot) where it's debuggable, not at call time.
+    if (!Number.isFinite(config.poolSize) || config.poolSize < 1) {
+      throw new UnexpectedError(
+        `poolSize must be a finite number >= 1, got ${config.poolSize}`,
+        ANTHROPIC_INTERACTIVE_POOL_ID,
+      );
+    }
+  }
+
+  /** The tmux session-name prefix for this pool (see config.sessionPrefix). */
+  private get sessionPrefix(): string {
+    return this.config.sessionPrefix ?? 'instar-pool';
   }
 
   async start(): Promise<void> {
+    // Orphan recovery: a crashed previous process (SIGKILL, OOM) never ran
+    // dispose(), leaving its REPL sessions alive and silently drawing
+    // subscription quota. Our prefix is agent-scoped (config.sessionPrefix),
+    // so anything matching it is OURS from a dead process — kill before
+    // spawning fresh, or orphans accumulate across every crash/update.
+    await this.killStaleSessions();
     const promises: Promise<void>[] = [];
     for (let i = 0; i < this.config.poolSize; i++) {
       promises.push(this.spawnOne());
@@ -101,6 +123,62 @@ export class InteractivePool extends EventEmitter {
     // Schedule recurring canary if enabled (default hourly).
     if (this.config.canaryIntervalMs > 0) {
       this.scheduleRecurringCanary();
+    }
+    // Idle-retirement sweep: a ready session untouched past maxIdleMinutes
+    // is retired WITHOUT immediate replacement (allocate() respawns on
+    // demand) — stale context dies and an idle agent holds zero REPLs.
+    if (this.config.maxIdleMinutes > 0) {
+      this.idleSweepTimer = setInterval(() => this.sweepIdleSessions(), 60_000);
+      this.idleSweepTimer.unref?.();
+    }
+  }
+
+  /** Kill leftover `<prefix>-*` tmux sessions from a previous process. */
+  private async killStaleSessions(): Promise<void> {
+    let names: string[] = [];
+    try {
+      const { stdout } = await execFileAsync(
+        this.config.tmuxPath,
+        ['list-sessions', '-F', '#{session_name}'],
+        { timeout: 5000 },
+      );
+      names = stdout.split('\n').map((s) => s.trim()).filter(Boolean);
+    } catch {
+      // No tmux server running (common: fresh boot) — nothing to clean.
+      return;
+    }
+    const stale = names.filter(
+      (n) => n.startsWith(`${this.sessionPrefix}-`) && !this.hasSessionNamed(n),
+    );
+    for (const name of stale) {
+      try {
+        await execFileAsync(this.config.tmuxPath, ['kill-session', '-t', `=${name}:`], {
+          timeout: 5000,
+        });
+        console.log(`[interactive-pool] killed stale pool session from a previous process: ${name}`);
+      } catch {
+        // Raced away or already gone — fine either way.
+      }
+    }
+  }
+
+  private hasSessionNamed(tmuxName: string): boolean {
+    for (const s of this.sessions.values()) {
+      if (s.tmuxName === tmuxName) return true;
+    }
+    return false;
+  }
+
+  /** Retire ready sessions idle past maxIdleMinutes (no immediate replace). */
+  private sweepIdleSessions(): void {
+    if (this.shuttingDown) return;
+    const cutoff = Date.now() - this.config.maxIdleMinutes * 60_000;
+    for (const s of this.sessions.values()) {
+      if (s.state === 'ready' && s.lastUsedAt < cutoff) {
+        this.retire(s, { replace: false }).catch((err) => {
+          console.error('[interactive-pool] idle retirement failed:', err);
+        });
+      }
     }
   }
 
@@ -170,7 +248,7 @@ export class InteractivePool extends EventEmitter {
 
   private async spawnOne(): Promise<void> {
     const id = `aip-${randomBytes(6).toString('hex')}`;
-    const tmuxName = `instar-pool-${id}`;
+    const tmuxName = `${this.sessionPrefix}-${id}`;
     const session: PoolSession = {
       id,
       tmuxName,
@@ -218,6 +296,9 @@ export class InteractivePool extends EventEmitter {
     }
     args.push(...envFlags);
     args.push(this.config.claudePath, '--dangerously-skip-permissions');
+    if (this.config.model) {
+      args.push('--model', this.config.model);
+    }
 
     try {
       execFileSync(this.config.tmuxPath, args, { encoding: 'utf-8' });
@@ -356,7 +437,7 @@ export class InteractivePool extends EventEmitter {
       this.markBusy(ready);
       return ready;
     }
-    return new Promise<PoolSession>((resolve, reject) => {
+    const waiting = new Promise<PoolSession>((resolve, reject) => {
       const timer = setTimeout(() => {
         const idx = this.waiters.findIndex((w) => w.resolve === resolve);
         if (idx >= 0) this.waiters.splice(idx, 1);
@@ -369,6 +450,16 @@ export class InteractivePool extends EventEmitter {
       }, this.config.allocateTimeoutMs);
       this.waiters.push({ resolve, reject, timer });
     });
+    // On-demand growth: idle retirement (and crash recovery) can shrink
+    // the pool below poolSize — even to zero. If there's headroom, kick a
+    // spawn so the waiter above has something to be flushed onto
+    // (otherwise an empty pool waits out the full allocate timeout for
+    // nothing). Ordering matters: the waiter is enqueued FIRST so a fast
+    // spawn's flushWaiter can never miss it.
+    if (this.sessions.size < this.config.poolSize) {
+      this.replaceRetired();
+    }
+    return waiting;
   }
 
   private findReadyLru(): PoolSession | undefined {
@@ -412,9 +503,12 @@ export class InteractivePool extends EventEmitter {
   }
 
   /**
-   * Gracefully retire a session and spawn a replacement.
+   * Gracefully retire a session. By default spawns a replacement (the
+   * busy-path retirement contract — a caller is likely waiting); idle
+   * retirement passes `replace: false` so an idle agent holds zero REPLs
+   * and allocate() respawns on demand.
    */
-  async retire(s: PoolSession): Promise<void> {
+  async retire(s: PoolSession, opts?: { replace?: boolean }): Promise<void> {
     if (s.state === 'retiring' || s.state === 'dead') return;
     s.state = 'retiring';
     try {
@@ -429,7 +523,7 @@ export class InteractivePool extends EventEmitter {
     s.state = 'dead';
     this.emit('session:retired', s);
     this.sessions.delete(s.id);
-    if (!this.shuttingDown) {
+    if (!this.shuttingDown && (opts?.replace ?? true)) {
       // Replace, with retry-on-failure and observable degradation events.
       // Previous behavior was `.catch(console.error)` — spawn failures were
       // swallowed and the pool decayed silently. Now spawn failures emit
@@ -483,6 +577,10 @@ export class InteractivePool extends EventEmitter {
     if (this.scheduledCanaryTimer !== null) {
       clearInterval(this.scheduledCanaryTimer);
       this.scheduledCanaryTimer = null;
+    }
+    if (this.idleSweepTimer !== null) {
+      clearInterval(this.idleSweepTimer);
+      this.idleSweepTimer = null;
     }
     for (const w of this.waiters) {
       clearTimeout(w.timer);

--- a/src/providers/adapters/anthropic-interactive-pool/pool.ts
+++ b/src/providers/adapters/anthropic-interactive-pool/pool.ts
@@ -157,7 +157,8 @@ export class InteractivePool extends EventEmitter {
         });
         console.log(`[interactive-pool] killed stale pool session from a previous process: ${name}`);
       } catch {
-        // Raced away or already gone — fine either way.
+        // @silent-fallback-ok — kill-session raced: the stale session is
+        // already gone, which is the desired end-state; nothing degraded.
       }
     }
   }

--- a/src/providers/bootRegistration.ts
+++ b/src/providers/bootRegistration.ts
@@ -1,0 +1,225 @@
+/**
+ * bootRegistration — production registration of the Anthropic adapters.
+ *
+ * This is the "separate cycle" deferred when the Phase-5 routing policy was
+ * installed at server boot: the policy was wired but NO adapters were ever
+ * registered against the providers registry, so `registry.resolve()` had
+ * nothing to choose between and the cost-aware routing was a no-op. This
+ * module closes that gap (Rule 1 of
+ * specs/provider-portability/04-anthropic-path-constraints.md — the
+ * subscription-backed interactive pool must be an operational floor, not a
+ * designed-only one).
+ *
+ * Properties (all load-bearing for the server boot path):
+ *   - GATED: never registers Claude adapters on a codex-only agent
+ *     (process-level claudeForbidden flag + enabledFrameworks check).
+ *   - IDEMPOTENT: re-entering startServer in the same process (tests,
+ *     in-proc respawn) does not double-register or clobber.
+ *   - LAZY: registration spawns NOTHING. Both adapter factories are pure
+ *     in-memory construction; the interactive pool only spawns tmux REPL
+ *     sessions on first use (or an explicit `start()`).
+ *   - HONEST CREDIT READS: `readSdkCredit` is plumbed from the headless
+ *     adapter's UsageMeterProvider (GET /api/oauth/usage). Unknown state
+ *     (no OAuth credential, API error, no agentSdkCredit field yet) returns
+ *     null, which the CostAwareRoutingPolicy treats as "fall to the
+ *     subscription floor" — conservative by design.
+ */
+
+import { registry as defaultRegistry, Registry, type ProviderAdapter } from './registry.js';
+import { CapabilityFlag } from './capabilities.js';
+import type { ProviderId } from './types.js';
+import type {
+  AgentSdkCreditSnapshot,
+  UsageMeterProvider,
+} from './primitives/observability/usageMeterProvider.js';
+import {
+  createAnthropicHeadlessAdapter,
+  ANTHROPIC_HEADLESS_ID,
+  type AnthropicHeadlessConfig,
+} from './adapters/anthropic-headless/index.js';
+import {
+  createAnthropicInteractivePoolAdapter,
+  ANTHROPIC_INTERACTIVE_POOL_ID,
+  type InteractivePoolAdapter,
+} from './adapters/anthropic-interactive-pool/index.js';
+import type { InteractivePoolConfig } from './adapters/anthropic-interactive-pool/config.js';
+import { isClaudeForbidden } from '../core/claudeForbiddenGuard.js';
+
+export interface RegisterAnthropicAdaptersOptions {
+  /**
+   * The agent's enabled frameworks (InstarConfig.enabledFrameworks). When
+   * unset or empty, defaults to ['claude-code'] — the historical behavior,
+   * matching the migrator's reading of the same field.
+   */
+  enabledFrameworks?: ReadonlyArray<string>;
+  /** Detected `claude` binary path. Unset → adapter env defaults. */
+  claudePath?: string;
+  /** Detected `tmux` binary path. Unset → adapter env defaults. */
+  tmuxPath?: string;
+  /** Overrides for the headless adapter config (credential, model, ...). */
+  headless?: Partial<AnthropicHeadlessConfig>;
+  /** Overrides for the interactive-pool config (poolSize, model, workingDirectory, ...). */
+  pool?: Partial<InteractivePoolConfig>;
+  /** Registry to register against. Defaults to the module singleton. */
+  registryInstance?: Registry;
+  /** TTL for the cached SDK-credit read (ms). Default 60s. */
+  creditCacheTtlMs?: number;
+}
+
+export interface RegisterAnthropicAdaptersResult {
+  /** Adapter ids newly registered by THIS call. */
+  registered: ProviderId[];
+  /** Adapter ids that were already present (idempotent re-entry). */
+  alreadyRegistered: ProviderId[];
+  /** Set when the gate skipped registration entirely. */
+  skippedReason?: 'claude-forbidden' | 'claude-code-not-enabled';
+  /** The headless adapter (undefined when skipped). */
+  headless?: ProviderAdapter;
+  /** The interactive-pool adapter (undefined when skipped). */
+  pool?: InteractivePoolAdapter;
+  /**
+   * Real SDK-credit reader for CostAwareRoutingPolicy. Returns null when
+   * the state is unknown (skipped registration, no credential, API error,
+   * or Anthropic not yet exposing the credit pot) — never throws.
+   */
+  readSdkCredit: () => Promise<AgentSdkCreditSnapshot | null>;
+}
+
+const NULL_CREDIT: () => Promise<AgentSdkCreditSnapshot | null> = async () => null;
+
+/**
+ * Build a TTL-cached SDK-credit reader from the headless adapter's
+ * UsageMeterProvider. Bounded cost: at most one GET /api/oauth/usage per
+ * TTL window regardless of routing-decision volume.
+ */
+export function buildReadSdkCredit(
+  headless: ProviderAdapter,
+  ttlMs = 60_000,
+): () => Promise<AgentSdkCreditSnapshot | null> {
+  let cachedAt = 0;
+  let cached: AgentSdkCreditSnapshot | null = null;
+  let inFlight: Promise<AgentSdkCreditSnapshot | null> | null = null;
+
+  return async () => {
+    const now = Date.now();
+    if (now - cachedAt < ttlMs) return cached;
+    if (inFlight) return inFlight;
+    inFlight = (async () => {
+      try {
+        const meter = headless.primitive(CapabilityFlag.UsageMeterProvider) as UsageMeterProvider;
+        const snapshot = await meter.read();
+        cached = snapshot?.agentSdkCredit ?? null;
+      } catch {
+        // @silent-fallback-ok — meter errors are expected (no OAuth
+        // credential, transient API failure); unknown state = null and the
+        // CostAwareRoutingPolicy conservatively falls to the subscription
+        // floor. Never throw into a routing decision.
+        cached = null;
+      } finally {
+        // finally, not tail code: even an unforeseeable throw between the
+        // catch and here must never wedge the reader with a stale inFlight.
+        cachedAt = Date.now();
+        inFlight = null;
+      }
+      return cached;
+    })();
+    return inFlight;
+  };
+}
+
+/**
+ * Single-flight guard: concurrent registerAnthropicAdapters calls against
+ * the SAME registry instance await one shared registration instead of
+ * racing get()-then-register() (Registry.register throws on duplicates, so
+ * a TOCTOU race would make the loser throw — breaking the idempotency
+ * contract under exactly the re-entrant boots it exists for).
+ */
+const inFlightByRegistry = new WeakMap<Registry, Promise<RegisterAnthropicAdaptersResult>>();
+
+/**
+ * Register both Anthropic adapters with the providers registry, gated and
+ * idempotent (including under concurrent calls). See module docstring for
+ * the contract.
+ */
+export async function registerAnthropicAdapters(
+  options: RegisterAnthropicAdaptersOptions = {},
+): Promise<RegisterAnthropicAdaptersResult> {
+  const targetRegistry = options.registryInstance ?? defaultRegistry;
+  const existing = inFlightByRegistry.get(targetRegistry);
+  if (existing) return existing;
+  const run = registerAnthropicAdaptersInner(options, targetRegistry).finally(() => {
+    inFlightByRegistry.delete(targetRegistry);
+  });
+  inFlightByRegistry.set(targetRegistry, run);
+  return run;
+}
+
+async function registerAnthropicAdaptersInner(
+  options: RegisterAnthropicAdaptersOptions,
+  reg: Registry,
+): Promise<RegisterAnthropicAdaptersResult> {
+  // Gate 1 — process-level codex-only enforcement (mirrors the
+  // ClaudeCliIntelligenceProvider constructor guard).
+  if (isClaudeForbidden()) {
+    return {
+      registered: [],
+      alreadyRegistered: [],
+      skippedReason: 'claude-forbidden',
+      readSdkCredit: NULL_CREDIT,
+    };
+  }
+
+  // Gate 2 — enabledFrameworks. Unset/empty defaults to ['claude-code']
+  // (historical behavior; mirrors PostUpdateMigrator's reading).
+  const frameworks =
+    options.enabledFrameworks && options.enabledFrameworks.length > 0
+      ? options.enabledFrameworks
+      : ['claude-code'];
+  if (!frameworks.includes('claude-code')) {
+    return {
+      registered: [],
+      alreadyRegistered: [],
+      skippedReason: 'claude-code-not-enabled',
+      readSdkCredit: NULL_CREDIT,
+    };
+  }
+
+  const registered: ProviderId[] = [];
+  const alreadyRegistered: ProviderId[] = [];
+
+  // Headless (SDK-credit `claude -p` path) — idempotent.
+  let headless = reg.get(ANTHROPIC_HEADLESS_ID);
+  if (headless) {
+    alreadyRegistered.push(ANTHROPIC_HEADLESS_ID);
+  } else {
+    headless = createAnthropicHeadlessAdapter({
+      ...(options.claudePath ? { claudePath: options.claudePath } : {}),
+      ...(options.tmuxPath ? { tmuxPath: options.tmuxPath } : {}),
+      ...options.headless,
+    });
+    await reg.register(headless);
+    registered.push(ANTHROPIC_HEADLESS_ID);
+  }
+
+  // Interactive pool (subscription floor) — idempotent, lazy (no spawn).
+  let pool = reg.get(ANTHROPIC_INTERACTIVE_POOL_ID) as InteractivePoolAdapter | undefined;
+  if (pool) {
+    alreadyRegistered.push(ANTHROPIC_INTERACTIVE_POOL_ID);
+  } else {
+    pool = createAnthropicInteractivePoolAdapter({
+      ...(options.claudePath ? { claudePath: options.claudePath } : {}),
+      ...(options.tmuxPath ? { tmuxPath: options.tmuxPath } : {}),
+      ...options.pool,
+    });
+    await reg.register(pool);
+    registered.push(ANTHROPIC_INTERACTIVE_POOL_ID);
+  }
+
+  return {
+    registered,
+    alreadyRegistered,
+    headless,
+    pool,
+    readSdkCredit: buildReadSdkCredit(headless, options.creditCacheTtlMs),
+  };
+}

--- a/src/providers/costAwareRouting.ts
+++ b/src/providers/costAwareRouting.ts
@@ -60,6 +60,45 @@ export interface CostAwareRoutingOptions {
   safetyMarginFraction?: number;
 }
 
+/**
+ * Pure SDK-pot-vs-subscription decision — the single source of truth shared
+ * by CostAwareRoutingPolicy (registry-level adapter resolution) and
+ * AnthropicSubscriptionRouter (intelligence-funnel routing). Keeping ONE
+ * implementation prevents the two routing layers from drifting apart on
+ * threshold semantics.
+ *
+ *   - Unknown state (null snapshot) → subscription floor (conservative).
+ *   - At/below the safety margin → subscription floor.
+ *   - Above the margin → SDK credit path (drain the prepaid pot first —
+ *     the routing default locked 2026-05-15, spec 04 §Routing default).
+ */
+export function decideSdkVsSubscription(
+  snapshot: AgentSdkCreditSnapshot | null,
+  safetyMarginFraction: number,
+): { path: 'sdk-credit' | 'subscription'; reason: string } {
+  if (snapshot === null) {
+    return {
+      path: 'subscription',
+      reason: 'sdk-credit-state-unknown-fall-to-subscription-floor',
+    };
+  }
+  const margin = safetyMarginFraction * snapshot.totalUsd;
+  if (snapshot.remainingUsd <= margin) {
+    return {
+      path: 'subscription',
+      reason:
+        `sdk-credit-at-or-below-safety-margin `
+        + `(remaining=$${snapshot.remainingUsd.toFixed(2)} <= margin=$${margin.toFixed(2)})`,
+    };
+  }
+  return {
+    path: 'sdk-credit',
+    reason:
+      `sdk-credit-preferred `
+      + `(remaining=$${snapshot.remainingUsd.toFixed(2)} > margin=$${margin.toFixed(2)})`,
+  };
+}
+
 export class CostAwareRoutingPolicy implements RoutingPolicy {
   private readonly safetyMarginFraction: number;
 
@@ -90,32 +129,11 @@ export class CostAwareRoutingPolicy implements RoutingPolicy {
         snapshot = null;
       }
 
-      if (snapshot === null) {
-        return {
-          chosen: subCand.id,
-          reason: 'sdk-credit-state-unknown-fall-to-subscription-floor',
-          fallbacks: [sdkCand.id],
-        };
+      const decision = decideSdkVsSubscription(snapshot, this.safetyMarginFraction);
+      if (decision.path === 'subscription') {
+        return { chosen: subCand.id, reason: decision.reason, fallbacks: [sdkCand.id] };
       }
-
-      const margin = this.safetyMarginFraction * snapshot.totalUsd;
-      if (snapshot.remainingUsd <= margin) {
-        return {
-          chosen: subCand.id,
-          reason:
-            `sdk-credit-at-or-below-safety-margin `
-            + `(remaining=$${snapshot.remainingUsd.toFixed(2)} <= margin=$${margin.toFixed(2)})`,
-          fallbacks: [sdkCand.id],
-        };
-      }
-
-      return {
-        chosen: sdkCand.id,
-        reason:
-          `sdk-credit-preferred `
-          + `(remaining=$${snapshot.remainingUsd.toFixed(2)} > margin=$${margin.toFixed(2)})`,
-        fallbacks: [subCand.id],
-      };
+      return { chosen: sdkCand.id, reason: decision.reason, fallbacks: [subCand.id] };
     }
 
     // Only one Anthropic adapter in the candidate set — use it.

--- a/src/scaffold/templates.ts
+++ b/src/scaffold/templates.ts
@@ -663,6 +663,11 @@ This routes feedback to the Instar maintainers automatically. Valid types: \`bug
 - **Auto-sync**: Search automatically syncs before querying, so results are always current.
 - **When to use**: When looking for something you know you wrote but can't remember where. When a user asks "didn't we discuss X?" When building context for a task from past learnings.
 
+**Anthropic Subscription-Path Routing (June-15 readiness)** — Your internal background LLM calls (sentinels, gates, extractors) normally run as \`claude -p\` one-shots, which bill the Agent SDK credit pot after 2026-06-15. The subscription-path lever can route them through a pool of long-lived interactive Claude sessions instead — the path that keeps working when the pot is empty.
+- What's actually wired in: \`curl -H "Authorization: Bearer $AUTH" http://localhost:${port}/providers/registry\` → registered provider adapters + capability flags. Both \`anthropic-headless\` and \`anthropic-interactive-pool\` listed = the escape hatch is installed.
+- The lever lives in \`.instar/config.json\` → \`intelligence.subscriptionPath.mode\`: \`off\` (default — today's behavior), \`auto\` (drain the SDK pot while healthy, slide to the interactive pool when it's unknown/near-empty), \`force\` (interactive pool ONLY — zero \`claude -p\` traffic). Restart sessions/server to apply.
+- **When to use** (PROACTIVE): user asks "are we ready for the June 15 change?" / "what happens when the SDK credits run out?" → read \`GET /providers/registry\` and report the mode from config. User hit SDK-pot exhaustion → offer the \`force\`/\`auto\` flip instead of letting background checks fail. (Spec: \`docs/specs/provider-substrate-live-wiring.md\`.)
+
 **Codex Usage** — Check where codex account usage sits (the codex \`/status\` rate-limit windows) without the interactive TUI. Reads the authoritative primary (5h) + secondary (weekly) windows the codex CLI persists into its session rollout files.
 - Check: \`curl -H "Authorization: Bearer $AUTH" http://localhost:${port}/codex/usage\`
 - Returns \`{ available, usage: { primary, secondary, model, planType, rateLimitReachedType } }\` where each window has \`usedPercent\`, \`remainingPercent\`, \`windowMinutes\`, \`resetsAt\`/\`resetsAtIso\`, \`resetsInSeconds\`. \`available:false\` means no codex session data on disk yet (e.g. a pure-Claude agent).

--- a/src/server/routes.ts
+++ b/src/server/routes.ts
@@ -18165,6 +18165,8 @@ export function createRoutes(ctx: RouteContext): Router {
       );
       res.json({ adapters, count: adapters.length, routingPolicyInstalled: policyInstalled });
     } catch (err) {
+      // @silent-fallback-ok — not silent: the error is surfaced to the
+      // caller as an HTTP 500 with the message.
       res.status(500).json({ error: err instanceof Error ? err.message : String(err) });
     }
   });

--- a/src/server/routes.ts
+++ b/src/server/routes.ts
@@ -18140,7 +18140,34 @@ export function createRoutes(ctx: RouteContext): Router {
   // The endpoints construct ephemeral policy/tracker/router instances
   // per call with the parameters in the query string. They do NOT
   // depend on adapters being registered against the global Registry —
-  // production-adapter registration is tracked separately.
+  // production-adapter registration happens at server boot
+  // (src/providers/bootRegistration.ts); GET /providers/registry below
+  // is the REAL-registry introspection surface.
+
+  // GET /providers/registry — what is ACTUALLY registered (June-15
+  // readiness diagnostic; truth T1 of the live-wiring spec). Names and
+  // capability flags only — never prompt content or credentials (T-04).
+  router.get('/providers/registry', async (_req, res) => {
+    try {
+      const { registry } = await import('../providers/registry.js');
+      const ids = registry.list();
+      const adapters = ids.map((id) => {
+        const adapter = registry.get(id);
+        return {
+          id,
+          capabilities: adapter ? Array.from(adapter.capabilities).sort() : [],
+        };
+      });
+      const policyInstalled = Boolean(
+        (registry as unknown as Record<symbol, boolean>)[
+          Symbol.for('instar.serverBoot.routingPolicyInstalled')
+        ],
+      );
+      res.json({ adapters, count: adapters.length, routingPolicyInstalled: policyInstalled });
+    } catch (err) {
+      res.status(500).json({ error: err instanceof Error ? err.message : String(err) });
+    }
+  });
 
   router.get('/providers/routing/decide', async (req, res) => {
     try {

--- a/tests/e2e/provider-substrate-live-wiring.test.ts
+++ b/tests/e2e/provider-substrate-live-wiring.test.ts
@@ -1,0 +1,210 @@
+/**
+ * E2E test — Provider-substrate live wiring (June-15 interactive-only
+ * readiness, CMT-1105) full lifecycle.
+ *
+ * Tests the complete PRODUCTION path, mirroring src/commands/server.ts:
+ *   1. Boot: registerAnthropicAdapters() the same way startServer does
+ *      (config-derived enabledFrameworks/claudePath/pool config).
+ *   2. The "feature is alive" check: GET /providers/registry returns 200
+ *      with BOTH Anthropic adapters — not an empty registry (the exact
+ *      shipped-dark failure this PR closes: policy installed, zero
+ *      adapters registered).
+ *   3. The default-off invariance: with no subscriptionPath config, the
+ *      intelligence funnel builds WITHOUT the subscription router.
+ *   4. The force-mode path: mirroring server.ts's subscriptionPathOption
+ *      construction, a built provider serves calls from the pool.
+ *   5. Codex-only gate: a codex-only agent registers nothing.
+ *   6. Boot is lazy: no tmux/claude processes spawn from registration.
+ *
+ * WHY THIS TEST EXISTS:
+ * Unit tests prove registerAnthropicAdapters works when called. This test
+ * proves the PRODUCTION wiring shape calls it and the result is observable
+ * through the HTTP pipeline — the difference between "compiles + passes
+ * unit tests" and "actually alive on a booted agent."
+ */
+
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
+
+vi.mock('node:child_process', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:child_process')>();
+  return {
+    ...actual,
+    execFileSync: vi.fn(() => ''),
+  };
+});
+
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { execFileSync } from 'node:child_process';
+import request from 'supertest';
+import { AgentServer } from '../../src/server/AgentServer.js';
+import { StateManager } from '../../src/core/StateManager.js';
+import type { InstarConfig } from '../../src/core/types.js';
+import { registry } from '../../src/providers/registry.js';
+import {
+  registerAnthropicAdapters,
+  type RegisterAnthropicAdaptersResult,
+} from '../../src/providers/bootRegistration.js';
+import { buildIntelligenceProvider } from '../../src/core/intelligenceProviderFactory.js';
+import { CapabilityFlag } from '../../src/providers/capabilities.js';
+import { createMockSessionManager } from '../helpers/setup.js';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+
+describe('Provider-substrate live wiring E2E', () => {
+  let tmpDir: string;
+  let stateDir: string;
+  let server: AgentServer;
+  let app: ReturnType<AgentServer['getApp']>;
+  let registration: RegisterAnthropicAdaptersResult;
+  const AUTH_TOKEN = 'test-e2e-provider-wiring';
+
+  beforeAll(async () => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'provider-wiring-e2e-'));
+    stateDir = path.join(tmpDir, '.instar');
+    fs.mkdirSync(path.join(stateDir, 'state', 'sessions'), { recursive: true });
+    fs.mkdirSync(path.join(stateDir, 'state', 'jobs'), { recursive: true });
+    fs.mkdirSync(path.join(stateDir, 'logs'), { recursive: true });
+
+    const config: InstarConfig = {
+      projectName: 'e2e-test',
+      projectDir: tmpDir,
+      stateDir,
+      port: 0,
+      authToken: AUTH_TOKEN,
+      requestTimeoutMs: 10000,
+      version: '0.0.0-e2e',
+      sessions: {
+        claudePath: '/usr/bin/echo',
+        maxSessions: 3,
+        defaultMaxDurationMinutes: 30,
+        protectedSessions: [],
+        monitorIntervalMs: 5000,
+      },
+      scheduler: { enabled: false, jobsFile: '', maxParallelJobs: 1 },
+      messaging: [],
+      monitoring: {},
+      updates: {},
+    } as InstarConfig;
+
+    // ━━━ CRITICAL: registration the SAME WAY server.ts does ━━━
+    // (startServer's Phase-5 block: enabledFrameworks gate, config paths,
+    //  pool config with scratch workdir + haiku default.)
+    const poolWorkdir = path.join(stateDir, 'intelligence-pool');
+    fs.mkdirSync(poolWorkdir, { recursive: true });
+    registration = await registerAnthropicAdapters({
+      claudePath: config.sessions.claudePath,
+      pool: { poolSize: 2, model: 'haiku', workingDirectory: poolWorkdir },
+    });
+
+    const state = new StateManager(stateDir);
+    server = new AgentServer({
+      config,
+      sessionManager: createMockSessionManager() as never,
+      state,
+    });
+    await server.start();
+    app = server.getApp();
+  });
+
+  afterAll(async () => {
+    await server.stop();
+    await registry.unregister('anthropic-headless' as never);
+    await registry.unregister('anthropic-interactive-pool' as never);
+    SafeFsExecutor.safeRmSync(tmpDir, { recursive: true, force: true, operation: 'tests/e2e/provider-substrate-live-wiring.test.ts:cleanup' });
+  });
+
+  const auth = () => ({ Authorization: `Bearer ${AUTH_TOKEN}` });
+
+  // ══════════════════════════════════════════════════════════════════
+  // Phase 1: Feature is ALIVE (not dead on arrival)
+  // ══════════════════════════════════════════════════════════════════
+
+  it('GET /providers/registry returns 200 with BOTH Anthropic adapters registered', async () => {
+    const res = await request(app).get('/providers/registry').set(auth());
+    // If the adapters list is empty here, the boot path never registered
+    // them — the exact shipped-dark gap this PR exists to close.
+    expect(res.status).toBe(200);
+    const ids = (res.body.adapters as Array<{ id: string }>).map((a) => a.id);
+    expect(ids).toContain('anthropic-headless');
+    expect(ids).toContain('anthropic-interactive-pool');
+  });
+
+  it('registration was real, not skipped', () => {
+    expect(registration.skippedReason).toBeUndefined();
+    expect(registration.headless).toBeDefined();
+    expect(registration.pool).toBeDefined();
+  });
+
+  // ══════════════════════════════════════════════════════════════════
+  // Phase 2: Boot is LAZY — registering spawned nothing
+  // ══════════════════════════════════════════════════════════════════
+
+  it('no tmux/claude process was spawned by registration (T7)', () => {
+    // Other boot components legitimately shell out (e.g. the sqlite3
+    // bindings probe); what must NOT appear is any tmux session spawn or
+    // claude invocation originating from adapter registration.
+    const spawnedBinaries = vi
+      .mocked(execFileSync)
+      .mock.calls.map((c) => String(c[0]));
+    expect(spawnedBinaries.filter((b) => /tmux|claude/.test(b))).toEqual([]);
+  });
+
+  // ══════════════════════════════════════════════════════════════════
+  // Phase 3: Default-off invariance + force-mode construction
+  // ══════════════════════════════════════════════════════════════════
+
+  it('default (no subscriptionPath config): funnel builds the plain claude provider', () => {
+    // Mirrors server.ts: spMode 'off' ⇒ no subscriptionPath option passed.
+    const provider = buildIntelligenceProvider({
+      framework: 'claude-code',
+      binaryPath: '/usr/bin/echo',
+    });
+    expect(provider).not.toBeNull();
+  });
+
+  it("force mode (mirroring server.ts's subscriptionPathOption): calls served by the pool", async () => {
+    // Replace the pool adapter's one-shot with a fake so no real REPL is
+    // needed; the wiring under test is funnel→router→pool-adapter.
+    const poolAdapter = registration.pool!;
+    const fakeOneShot = {
+      capability: CapabilityFlag.OneShotCompletion,
+      evaluate: async () => ({ text: 'served-by-pool', usage: null }),
+    };
+    const originalPrimitive = poolAdapter.primitive;
+    (poolAdapter as { primitive: unknown }).primitive = (cap: CapabilityFlag) =>
+      cap === CapabilityFlag.OneShotCompletion ? fakeOneShot : originalPrimitive(cap);
+
+    try {
+      const provider = buildIntelligenceProvider({
+        framework: 'claude-code',
+        binaryPath: '/usr/bin/echo',
+        subscriptionPath: {
+          mode: 'force',
+          poolAdapter,
+          readSdkCredit: registration.readSdkCredit,
+        },
+      });
+      expect(provider).not.toBeNull();
+      expect(await provider!.evaluate('judgment call', { attribution: { component: 'E2ETest' } }))
+        .toBe('served-by-pool');
+    } finally {
+      (poolAdapter as { primitive: unknown }).primitive = originalPrimitive;
+    }
+  });
+
+  // ══════════════════════════════════════════════════════════════════
+  // Phase 4: Codex-only gate (the other side of the boundary)
+  // ══════════════════════════════════════════════════════════════════
+
+  it('a codex-only agent registers NOTHING', async () => {
+    const result = await registerAnthropicAdapters({
+      enabledFrameworks: ['codex-cli'],
+    });
+    expect(result.skippedReason).toBe('claude-code-not-enabled');
+    // The singleton still holds exactly the two adapters from boot — the
+    // skipped call added nothing.
+    const res = await request(app).get('/providers/registry').set(auth());
+    expect(res.body.count).toBe(2);
+  });
+});

--- a/tests/integration/providers-registry-route.test.ts
+++ b/tests/integration/providers-registry-route.test.ts
@@ -1,0 +1,83 @@
+/**
+ * Integration tests for GET /providers/registry — the real-registry
+ * introspection surface for the June-15 live wiring (truth T1).
+ *
+ * Verifies the route is reachable through the full HTTP pipeline, reflects
+ * the ACTUAL module-singleton registry (empty vs registered), and leaks
+ * nothing beyond adapter ids + capability flag names (T-04).
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import express from 'express';
+import request from 'supertest';
+import { createRoutes } from '../../src/server/routes.js';
+import type { RouteContext } from '../../src/server/routes.js';
+import { registry } from '../../src/providers/registry.js';
+import { registerAnthropicAdapters } from '../../src/providers/bootRegistration.js';
+
+function minimalCtx(): RouteContext {
+  return {
+    config: { projectName: 'test', projectDir: '/tmp', stateDir: '/tmp/.instar', port: 0, sessions: {} as never, scheduler: {} as never },
+    sessionManager: { listRunningSessions: () => [] },
+    state: { getJobState: () => null, getSession: () => null },
+    scheduler: null, telegram: null, relationships: null, feedback: null, dispatches: null,
+    updateChecker: null, autoUpdater: null, autoDispatcher: null, quotaTracker: null,
+    publisher: null, viewer: null, tunnel: null, evolution: null, watchdog: null,
+    triageNurse: null, topicMemory: null, discoveryEvaluator: null, tokenLedger: null,
+    startTime: new Date(),
+  } as unknown as RouteContext;
+}
+
+describe('GET /providers/registry (integration)', () => {
+  let app: express.Express;
+
+  beforeAll(() => {
+    app = express();
+    app.use(express.json());
+    app.use('/', createRoutes(minimalCtx()));
+  });
+
+  afterAll(async () => {
+    // Clean the module singleton so other suites in this worker see the
+    // pre-test state (unregister is a no-op for absent ids).
+    await registry.unregister('anthropic-headless' as never);
+    await registry.unregister('anthropic-interactive-pool' as never);
+  });
+
+  it('returns 200 with an empty adapter list before registration (alive, not 503)', async () => {
+    const res = await request(app).get('/providers/registry');
+    expect(res.status).toBe(200);
+    expect(Array.isArray(res.body.adapters)).toBe(true);
+    const ids = res.body.adapters.map((a: { id: string }) => a.id);
+    expect(ids).not.toContain('anthropic-headless');
+    expect(ids).not.toContain('anthropic-interactive-pool');
+  });
+
+  it('reflects real registration: both Anthropic adapters with capability flags', async () => {
+    const result = await registerAnthropicAdapters({});
+    expect(result.skippedReason).toBeUndefined();
+
+    const res = await request(app).get('/providers/registry');
+    expect(res.status).toBe(200);
+    const byId = Object.fromEntries(
+      (res.body.adapters as Array<{ id: string; capabilities: string[] }>).map((a) => [a.id, a]),
+    );
+    expect(byId['anthropic-headless']).toBeDefined();
+    expect(byId['anthropic-interactive-pool']).toBeDefined();
+    // Substantive payload: capability flags are real names, not empty.
+    expect(byId['anthropic-headless']!.capabilities.length).toBeGreaterThan(0);
+    expect(byId['anthropic-interactive-pool']!.capabilities).toContain('one-shot-completion');
+    expect(res.body.count).toBeGreaterThanOrEqual(2);
+  });
+
+  it('leaks no secrets — payload is ids + capability names + policy flag only (T-04)', async () => {
+    const res = await request(app).get('/providers/registry');
+    expect(res.status).toBe(200);
+    expect(Object.keys(res.body).sort()).toEqual(['adapters', 'count', 'routingPolicyInstalled']);
+    const text = JSON.stringify(res.body);
+    // No credential VALUES — capability NAMES legitimately contain words
+    // like "credential-storage-provider"; what must never appear is an
+    // actual secret (sk-ant-… key material) or env-style token values.
+    expect(text).not.toMatch(/sk-ant-[a-zA-Z0-9-]/);
+    expect(text).not.toMatch(/Bearer\s/);
+  });
+});

--- a/tests/unit/anthropic-subscription-router.test.ts
+++ b/tests/unit/anthropic-subscription-router.test.ts
@@ -1,0 +1,236 @@
+/**
+ * Unit tests for AnthropicSubscriptionRouter + InteractivePoolIntelligenceProvider
+ * — the intelligence-funnel half of the June-15 interactive-only wiring.
+ *
+ * Covers BOTH sides of every decision boundary (Testing Integrity Standard):
+ * credit unknown / above margin / at margin; auto vs force; primary success
+ * vs failure (fallback + degrade); pool errors loud in force mode; the
+ * pool provider's option mapping and its no-onUsage contract.
+ */
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import {
+  AnthropicSubscriptionRouter,
+  type SubscriptionRouteInfo,
+  type SubscriptionDegradeInfo,
+} from '../../src/core/AnthropicSubscriptionRouter.js';
+import { InteractivePoolIntelligenceProvider } from '../../src/core/InteractivePoolIntelligenceProvider.js';
+import { decideSdkVsSubscription } from '../../src/providers/costAwareRouting.js';
+import { CapabilityFlag } from '../../src/providers/capabilities.js';
+import type { ProviderAdapter } from '../../src/providers/registry.js';
+import type { IntelligenceProvider } from '../../src/core/types.js';
+import {
+  setClaudeForbidden,
+  clearClaudeForbidden,
+} from '../../src/core/claudeForbiddenGuard.js';
+import type { AgentSdkCreditSnapshot } from '../../src/providers/primitives/observability/usageMeterProvider.js';
+
+afterEach(() => clearClaudeForbidden());
+
+function snapshot(remaining: number, total = 200): AgentSdkCreditSnapshot {
+  return { remainingUsd: remaining, totalUsd: total, resetsAt: '2026-07-01T00:00:00Z', overageEnabled: false };
+}
+
+function provider(name: string, impl?: (p: string) => Promise<string>): IntelligenceProvider & { calls: string[] } {
+  const calls: string[] = [];
+  return {
+    calls,
+    evaluate: vi.fn(async (prompt: string) => {
+      calls.push(prompt);
+      if (impl) return impl(prompt);
+      return `${name}:ok`;
+    }),
+  };
+}
+
+describe('decideSdkVsSubscription (shared pure decision)', () => {
+  it('null snapshot → subscription floor', () => {
+    expect(decideSdkVsSubscription(null, 0.1).path).toBe('subscription');
+  });
+  it('at/below margin → subscription floor', () => {
+    expect(decideSdkVsSubscription(snapshot(20, 200), 0.1).path).toBe('subscription');
+    expect(decideSdkVsSubscription(snapshot(5, 200), 0.1).path).toBe('subscription');
+  });
+  it('above margin → sdk-credit', () => {
+    expect(decideSdkVsSubscription(snapshot(21, 200), 0.1).path).toBe('sdk-credit');
+    expect(decideSdkVsSubscription(snapshot(200, 200), 0.1).path).toBe('sdk-credit');
+  });
+});
+
+describe('AnthropicSubscriptionRouter — auto mode', () => {
+  it('routes to the SDK path when credit is healthy', async () => {
+    const headless = provider('headless');
+    const pool = provider('pool');
+    const routes: SubscriptionRouteInfo[] = [];
+    const router = new AnthropicSubscriptionRouter({
+      headless,
+      pool,
+      mode: 'auto',
+      readSdkCredit: async () => snapshot(150),
+      onRoute: (i) => routes.push(i),
+    });
+    expect(await router.evaluate('judge this')).toBe('headless:ok');
+    expect(pool.evaluate).not.toHaveBeenCalled();
+    expect(routes[0]?.path).toBe('sdk-credit');
+  });
+
+  it('routes to the subscription pool when credit state is unknown (null)', async () => {
+    const headless = provider('headless');
+    const pool = provider('pool');
+    const router = new AnthropicSubscriptionRouter({
+      headless,
+      pool,
+      mode: 'auto',
+      readSdkCredit: async () => null,
+    });
+    expect(await router.evaluate('judge this')).toBe('pool:ok');
+    expect(headless.evaluate).not.toHaveBeenCalled();
+  });
+
+  it('routes to the subscription pool at/below the safety margin', async () => {
+    const headless = provider('headless');
+    const pool = provider('pool');
+    const router = new AnthropicSubscriptionRouter({
+      headless,
+      pool,
+      mode: 'auto',
+      readSdkCredit: async () => snapshot(10, 200),
+    });
+    expect(await router.evaluate('x')).toBe('pool:ok');
+  });
+
+  it('falls back ONCE to the other path on primary failure, reporting degrade', async () => {
+    const headless = provider('headless', async () => {
+      throw new Error('claude -p exploded');
+    });
+    const pool = provider('pool');
+    const degrades: SubscriptionDegradeInfo[] = [];
+    const routes: SubscriptionRouteInfo[] = [];
+    const router = new AnthropicSubscriptionRouter({
+      headless,
+      pool,
+      mode: 'auto',
+      readSdkCredit: async () => snapshot(150),
+      onRoute: (i) => routes.push(i),
+      onDegrade: (i) => degrades.push(i),
+    });
+    expect(await router.evaluate('x', { attribution: { component: 'PromptGate' } })).toBe('pool:ok');
+    expect(degrades).toHaveLength(1);
+    expect(degrades[0]).toMatchObject({ from: 'sdk-credit', to: 'subscription-pool', component: 'PromptGate' });
+    expect(routes.map((r) => r.path)).toEqual(['sdk-credit', 'subscription-pool']);
+  });
+
+  it('propagates the fallback error when BOTH paths fail (loud, not silent)', async () => {
+    const headless = provider('headless', async () => {
+      throw new Error('sdk path down');
+    });
+    const pool = provider('pool', async () => {
+      throw new Error('pool also down');
+    });
+    const router = new AnthropicSubscriptionRouter({
+      headless,
+      pool,
+      mode: 'auto',
+      readSdkCredit: async () => snapshot(150),
+    });
+    await expect(router.evaluate('x')).rejects.toThrow('pool also down');
+  });
+});
+
+describe('AnthropicSubscriptionRouter — force mode', () => {
+  it('always routes to the pool, never touching the SDK path', async () => {
+    const headless = provider('headless');
+    const pool = provider('pool');
+    const routes: SubscriptionRouteInfo[] = [];
+    const router = new AnthropicSubscriptionRouter({
+      headless,
+      pool,
+      mode: 'force',
+      readSdkCredit: async () => snapshot(200), // healthy pot must NOT matter
+      onRoute: (i) => routes.push(i),
+    });
+    expect(await router.evaluate('x')).toBe('pool:ok');
+    expect(headless.evaluate).not.toHaveBeenCalled();
+    expect(routes[0]).toMatchObject({ path: 'subscription-pool', reason: 'forced-subscription-mode' });
+  });
+
+  it('pool failures are LOUD — no silent SDK fallback in force mode', async () => {
+    const headless = provider('headless');
+    const pool = provider('pool', async () => {
+      throw new Error('pool allocate timeout');
+    });
+    const router = new AnthropicSubscriptionRouter({
+      headless,
+      pool,
+      mode: 'force',
+      readSdkCredit: async () => snapshot(200),
+    });
+    await expect(router.evaluate('x')).rejects.toThrow('pool allocate timeout');
+    expect(headless.evaluate).not.toHaveBeenCalled();
+  });
+
+  it('rejects an out-of-range safetyMarginFraction at construction', () => {
+    expect(
+      () =>
+        new AnthropicSubscriptionRouter({
+          headless: provider('h'),
+          pool: provider('p'),
+          mode: 'auto',
+          readSdkCredit: async () => null,
+          safetyMarginFraction: 1.5,
+        }),
+    ).toThrow(/safetyMarginFraction/);
+  });
+});
+
+function fakePoolAdapter(
+  evaluate: (prompt: string, options?: unknown) => Promise<{ text: string; usage: null }>,
+): ProviderAdapter {
+  return {
+    id: 'anthropic-interactive-pool' as ProviderAdapter['id'],
+    capabilities: {} as ProviderAdapter['capabilities'],
+    primitive(cap: CapabilityFlag): unknown {
+      if (cap === CapabilityFlag.OneShotCompletion) {
+        return { capability: CapabilityFlag.OneShotCompletion, evaluate };
+      }
+      throw new Error(`unexpected capability: ${cap}`);
+    },
+  };
+}
+
+describe('InteractivePoolIntelligenceProvider', () => {
+  it('returns the pool one-shot text and maps timeout/model options', async () => {
+    const seen: unknown[] = [];
+    const adapter = fakePoolAdapter(async (_p, options) => {
+      seen.push(options);
+      return { text: 'pool answer', usage: null };
+    });
+    const provider = new InteractivePoolIntelligenceProvider(adapter);
+    const out = await provider.evaluate('judge', { model: 'fast', timeoutMs: 5_000 });
+    expect(out).toBe('pool answer');
+    expect(seen[0]).toMatchObject({ model: 'fast', timeoutMs: 5_000 });
+  });
+
+  it('NEVER invokes onUsage (pool cannot report per-call tokens — absent is honest)', async () => {
+    const adapter = fakePoolAdapter(async () => ({ text: 'ok', usage: null }));
+    const provider = new InteractivePoolIntelligenceProvider(adapter);
+    const onUsage = vi.fn();
+    await provider.evaluate('x', { onUsage });
+    expect(onUsage).not.toHaveBeenCalled();
+  });
+
+  it('propagates pool errors loudly', async () => {
+    const adapter = fakePoolAdapter(async () => {
+      throw new Error('did not reach ready state in 30s');
+    });
+    const provider = new InteractivePoolIntelligenceProvider(adapter);
+    await expect(provider.evaluate('x')).rejects.toThrow('ready state');
+  });
+
+  it('refuses construction on a codex-only agent (claudeForbidden parity)', () => {
+    setClaudeForbidden('codex-only test');
+    expect(() => new InteractivePoolIntelligenceProvider(fakePoolAdapter(async () => ({ text: '', usage: null })))).toThrow(
+      /forbidden/i,
+    );
+  });
+});

--- a/tests/unit/feature-delivery-completeness.test.ts
+++ b/tests/unit/feature-delivery-completeness.test.ts
@@ -264,6 +264,7 @@ describe('Feature Delivery Completeness', () => {
       '/review-exchange',                                  // alternate (content-sniff) check for ReviewExchange — tracked as a featureSection above
       '/cutover-readiness',                                // alternate (content-sniff) check for Cutover Readiness — tracked as a featureSection above
       '/cutover-readiness/import-dryrun',                  // sub-line splice sniff key: the migrateClaudeMd else-if branch inserts the import-rehearsal line INTO the already-tracked Cutover Readiness section for agents that predate it (like '/corrections' for Preferences)
+      '/providers/registry',                               // provider-substrate-live-wiring (June-15 subscription-path) read surface (templated "Anthropic Subscription-Path Routing" + migrator): observability the agent READS to answer "are we ready for June 15 / is the escape hatch installed?" plus an Anthropic-specific config lever — like /session/clock and /resources/summary, not a framework-shadowed user-invokable capability (the lever only applies to claude-code internal calls; Codex/Gemini agents have no claude -p traffic to reroute)
     ];
 
     it('all new migrator CLAUDE.md sections are tracked', () => {

--- a/tests/unit/intelligence-provider-factory-subscription-path.test.ts
+++ b/tests/unit/intelligence-provider-factory-subscription-path.test.ts
@@ -1,0 +1,142 @@
+/**
+ * Unit tests for the factory's subscriptionPath option — the funnel half of
+ * the June-15 interactive-only wiring (spec 04 Rule 1).
+ *
+ * The load-bearing invariant (truth T4 of the live-wiring spec): with NO
+ * subscriptionPath option, the claude-code path is byte-for-byte today's
+ * behavior — the exact `claude -p` argv, unchanged. With mode 'force', a
+ * call is served by the pool and `claude` is NEVER exec'd.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('node:child_process', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:child_process')>();
+  return {
+    ...actual,
+    execFile: vi.fn(
+      (
+        _path: string,
+        _args: string[],
+        _opts: unknown,
+        cb: (err: Error | null, stdout: string, stderr: string) => void,
+      ) => {
+        cb(null, JSON.stringify({ result: 'headless ok', usage: { input_tokens: 5, output_tokens: 2 } }), '');
+        return { stdin: { end: () => {} } } as unknown as ReturnType<typeof actual.execFile>;
+      },
+    ),
+    execFileSync: vi.fn(() => ''),
+  };
+});
+
+import { execFile } from 'node:child_process';
+import { buildIntelligenceProvider } from '../../src/core/intelligenceProviderFactory.js';
+import { CapabilityFlag } from '../../src/providers/capabilities.js';
+import type { ProviderAdapter } from '../../src/providers/registry.js';
+
+function fakePoolAdapter(text: string): ProviderAdapter {
+  return {
+    id: 'anthropic-interactive-pool' as ProviderAdapter['id'],
+    capabilities: {} as ProviderAdapter['capabilities'],
+    primitive(cap: CapabilityFlag): unknown {
+      if (cap === CapabilityFlag.OneShotCompletion) {
+        return {
+          capability: CapabilityFlag.OneShotCompletion,
+          evaluate: async () => ({ text, usage: null }),
+        };
+      }
+      throw new Error(`unexpected capability ${cap}`);
+    },
+  };
+}
+
+beforeEach(() => {
+  vi.mocked(execFile).mockClear();
+});
+
+describe('buildIntelligenceProvider — subscriptionPath option', () => {
+  it('WITHOUT the option: claude -p argv is byte-for-byte unchanged (T4)', async () => {
+    const provider = buildIntelligenceProvider({
+      framework: 'claude-code',
+      binaryPath: '/fake/claude',
+    });
+    expect(provider).not.toBeNull();
+    const out = await provider!.evaluate('judge this', { model: 'fast' });
+    expect(out).toBe('headless ok');
+    expect(vi.mocked(execFile)).toHaveBeenCalledTimes(1);
+    const [binary, args] = vi.mocked(execFile).mock.calls[0]! as unknown as [string, string[]];
+    expect(binary).toBe('/fake/claude');
+    // The exact argv today's fleet runs — any drift here is a silent
+    // behavior change for every sentinel/gate on every agent.
+    expect(args).toEqual([
+      '-p', 'judge this',
+      '--model', 'haiku',
+      '--max-turns', '1',
+      '--output-format', 'json',
+      '--setting-sources', 'user',
+    ]);
+  });
+
+  it("mode 'force': served by the pool, claude is NEVER exec'd", async () => {
+    const provider = buildIntelligenceProvider({
+      framework: 'claude-code',
+      binaryPath: '/fake/claude',
+      subscriptionPath: {
+        mode: 'force',
+        poolAdapter: fakePoolAdapter('pool served this'),
+        readSdkCredit: async () => null,
+      },
+    });
+    expect(provider).not.toBeNull();
+    const out = await provider!.evaluate('judge this');
+    expect(out).toBe('pool served this');
+    expect(vi.mocked(execFile)).not.toHaveBeenCalled();
+  });
+
+  it("mode 'auto' with unknown credit: served by the pool (subscription floor)", async () => {
+    const provider = buildIntelligenceProvider({
+      framework: 'claude-code',
+      binaryPath: '/fake/claude',
+      subscriptionPath: {
+        mode: 'auto',
+        poolAdapter: fakePoolAdapter('floor'),
+        readSdkCredit: async () => null,
+      },
+    });
+    expect(await provider!.evaluate('x')).toBe('floor');
+    expect(vi.mocked(execFile)).not.toHaveBeenCalled();
+  });
+
+  it("mode 'auto' with healthy credit: served by claude -p (drain the pot first)", async () => {
+    const provider = buildIntelligenceProvider({
+      framework: 'claude-code',
+      binaryPath: '/fake/claude',
+      subscriptionPath: {
+        mode: 'auto',
+        poolAdapter: fakePoolAdapter('pool'),
+        readSdkCredit: async () => ({
+          remainingUsd: 180,
+          totalUsd: 200,
+          resetsAt: '2026-07-01T00:00:00Z',
+          overageEnabled: false,
+        }),
+      },
+    });
+    expect(await provider!.evaluate('x')).toBe('headless ok');
+    expect(vi.mocked(execFile)).toHaveBeenCalledTimes(1);
+  });
+
+  it('non-claude frameworks ignore the option (codex unaffected)', () => {
+    const provider = buildIntelligenceProvider({
+      framework: 'codex-cli',
+      binaryPath: '/fake/codex',
+      subscriptionPath: {
+        mode: 'force',
+        poolAdapter: fakePoolAdapter('pool'),
+        readSdkCredit: async () => null,
+      },
+    });
+    // Codex provider builds normally; the Anthropic-only option is unused.
+    expect(provider).not.toBeNull();
+  });
+});

--- a/tests/unit/no-silent-fallbacks.test.ts
+++ b/tests/unit/no-silent-fallbacks.test.ts
@@ -239,7 +239,14 @@ describe('No Silent Fallbacks', () => {
     // catches — its only new catch (migrateInstarDevInternalOnlyReleaseNoteLane) SURFACES
     // errors via result.errors.push and is verified ABSENT from the flagged list. Merged
     // baseline stays 459 (re-verified against the merged tree).
-    const BASELINE = 459;
+    //
+    // Lowered 459 -> 458 by provider-substrate-live-wiring (June-15 subscription
+    // path): the pre-existing boot "Policy install is non-critical" catch in
+    // src/commands/server.ts now reports via DegradationReporter (a real fix —
+    // a dark June-15 routing install is a reportable degradation, not a log
+    // line). The PR's own new catches are either reporter-wired, exempt with
+    // in-brace justification, or surface errors to the HTTP caller.
+    const BASELINE = 458;
 
     if (silentFallbacks.length > 0) {
       const report = silentFallbacks.map(fb =>

--- a/tests/unit/providers/adapters/anthropic-interactive-pool/pool-lifecycle-hardening.test.ts
+++ b/tests/unit/providers/adapters/anthropic-interactive-pool/pool-lifecycle-hardening.test.ts
@@ -1,0 +1,176 @@
+/**
+ * Unit tests for the pool lifecycle hardening from the live-wiring review:
+ *   - poolSize validation at construction (loud at boot, not at call time)
+ *   - idle-retirement sweep (maxIdleMinutes was dead config before)
+ *   - retire(..., { replace: false }) skips respawn (idle path)
+ *   - allocate() grows the pool on demand when below poolSize
+ *   - orphan recovery: start() kills stale `<prefix>-*` sessions from a
+ *     crashed previous process, scoped to OUR prefix only
+ *   - sessionPrefix flows into the tmux session name
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const killCalls: string[][] = [];
+let listSessionsStdout = '';
+
+vi.mock('node:child_process', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:child_process')>();
+  const handle = (args: string[]): { stdout: string; stderr: string } => {
+    if (args[0] === 'list-sessions') return { stdout: listSessionsStdout, stderr: '' };
+    if (args[0] === 'kill-session') {
+      killCalls.push(args);
+      return { stdout: '', stderr: '' };
+    }
+    return { stdout: '', stderr: '' };
+  };
+  const execFileMock = vi.fn(
+    (
+      _path: string,
+      args: string[],
+      _opts: unknown,
+      cb: (err: Error | null, stdout: string, stderr: string) => void,
+    ) => {
+      const { stdout, stderr } = handle(args);
+      cb(null, stdout, stderr);
+      return {} as ReturnType<typeof actual.execFile>;
+    },
+  );
+  // promisify(execFile) in pool.ts resolves to { stdout, stderr } via the
+  // custom-promisify symbol on the REAL execFile — mirror that contract so
+  // `const { stdout } = await execFileAsync(...)` destructures correctly.
+  (execFileMock as unknown as Record<symbol, unknown>)[
+    Symbol.for('nodejs.util.promisify.custom')
+  ] = (_path: string, args: string[]) => Promise.resolve(handle(args));
+  return {
+    ...actual,
+    execFileSync: vi.fn(() => ''),
+    execFile: execFileMock,
+  };
+});
+
+import { execFileSync } from 'node:child_process';
+import { InteractivePool, type PoolSession } from '../../../../../src/providers/adapters/anthropic-interactive-pool/pool.js';
+import { configFromEnv } from '../../../../../src/providers/adapters/anthropic-interactive-pool/config.js';
+
+function makePool(overrides: Partial<ReturnType<typeof configFromEnv>> = {}): InteractivePool {
+  return new InteractivePool({ ...configFromEnv({}), poolSize: 2, canaryIntervalMs: 0, ...overrides });
+}
+
+function seedSession(pool: InteractivePool, id: string, lastUsedAt: number, state: PoolSession['state'] = 'ready'): PoolSession {
+  const sess: PoolSession = {
+    id,
+    tmuxName: `instar-pool-${id}`,
+    state,
+    messageCount: 0,
+    spawnedAt: lastUsedAt,
+    lastUsedAt,
+  };
+  (pool as unknown as { sessions: Map<string, PoolSession> }).sessions.set(id, sess);
+  return sess;
+}
+
+beforeEach(() => {
+  killCalls.length = 0;
+  listSessionsStdout = '';
+  vi.mocked(execFileSync).mockClear();
+});
+
+describe('InteractivePool — poolSize validation', () => {
+  it.each([0, -1, NaN])('refuses construction with poolSize=%s', (size) => {
+    expect(() => makePool({ poolSize: size as number })).toThrow(/poolSize/);
+  });
+
+  it('accepts poolSize=1', () => {
+    expect(() => makePool({ poolSize: 1 })).not.toThrow();
+  });
+});
+
+describe('InteractivePool — idle retirement', () => {
+  it('retires ready sessions idle past maxIdleMinutes WITHOUT respawning', async () => {
+    const pool = makePool({ maxIdleMinutes: 30 });
+    const stale = seedSession(pool, 'stale', Date.now() - 31 * 60_000);
+    const fresh = seedSession(pool, 'fresh', Date.now() - 1 * 60_000);
+    const busy = seedSession(pool, 'busy', Date.now() - 90 * 60_000, 'busy');
+
+    const spawn = vi.fn(async () => {});
+    (pool as unknown as { spawnOne: typeof spawn }).spawnOne = spawn;
+
+    (pool as unknown as { sweepIdleSessions: () => void }).sweepIdleSessions();
+    // retire() is async; give it a tick.
+    await new Promise((r) => setTimeout(r, 10));
+
+    const sessions = (pool as unknown as { sessions: Map<string, PoolSession> }).sessions;
+    expect(sessions.has(stale.id)).toBe(false); // idle-retired
+    expect(sessions.has(fresh.id)).toBe(true); // under the cutoff — kept
+    expect(sessions.has(busy.id)).toBe(true); // busy is NEVER idle-retired
+    expect(spawn).not.toHaveBeenCalled(); // replace: false — no churn
+  });
+
+  it('busy-path retirement (maxMessages) still respawns a replacement', async () => {
+    const pool = makePool();
+    const sess = seedSession(pool, 's1', Date.now());
+    const spawn = vi.fn(async () => {});
+    (pool as unknown as { spawnOne: typeof spawn }).spawnOne = spawn;
+
+    await pool.retire(sess); // default replace: true
+    expect(spawn).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('InteractivePool — on-demand growth in allocate()', () => {
+  it('an empty (idle-shrunk) pool spawns on allocate instead of waiting out the timeout', async () => {
+    const pool = makePool({ poolSize: 1, allocateTimeoutMs: 2_000 });
+    const spawn = vi.fn(async () => {
+      const sess = seedSession(pool, 'on-demand', Date.now());
+      (pool as unknown as { flushWaiter: (s: PoolSession) => void }).flushWaiter(sess);
+    });
+    (pool as unknown as { spawnOne: typeof spawn }).spawnOne = spawn;
+
+    const got = await pool.allocate();
+    expect(got.id).toBe('on-demand');
+    expect(spawn).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('InteractivePool — orphan recovery at start()', () => {
+  it('kills stale sessions matching OUR prefix and leaves other prefixes alone', async () => {
+    const pool = makePool({ poolSize: 1, sessionPrefix: 'instar-pool-echo' });
+    listSessionsStdout = [
+      'instar-pool-echo-deadbeef', // ours, stale → kill
+      'instar-pool-otheragent-cafe', // other agent's pool → MUST survive
+      'echo-telegram-1234', // unrelated session → MUST survive
+    ].join('\n');
+    const spawn = vi.fn(async () => {});
+    (pool as unknown as { spawnOne: typeof spawn }).spawnOne = spawn;
+
+    await pool.start();
+
+    expect(killCalls).toHaveLength(1);
+    expect(killCalls[0]).toContain('=instar-pool-echo-deadbeef:');
+  });
+
+  it('start() proceeds cleanly when no tmux server is running', async () => {
+    const pool = makePool({ poolSize: 1, sessionPrefix: 'instar-pool-echo' });
+    listSessionsStdout = ''; // mock returns empty; real failure path returns too
+    const spawn = vi.fn(async () => {});
+    (pool as unknown as { spawnOne: typeof spawn }).spawnOne = spawn;
+    await expect(pool.start()).resolves.toBeUndefined();
+    expect(killCalls).toHaveLength(0);
+  });
+});
+
+describe('InteractivePool — sessionPrefix in spawn argv', () => {
+  it('spawned tmux sessions carry the configured prefix', async () => {
+    const pool = makePool({ poolSize: 1, sessionPrefix: 'instar-pool-myagent' });
+    (pool as unknown as { waitForReady: () => Promise<boolean> }).waitForReady = async () => true;
+    (pool as unknown as { canaryHasRunInCurrentLifetime: boolean }).canaryHasRunInCurrentLifetime = true;
+    await (pool as unknown as { spawnOne: () => Promise<void> }).spawnOne();
+    const calls = vi.mocked(execFileSync).mock.calls;
+    const newSession = calls.find((c) => (c[1] as string[])[0] === 'new-session');
+    expect(newSession).toBeDefined();
+    const args = newSession![1] as string[];
+    const nameIdx = args.indexOf('-s') + 1;
+    expect(args[nameIdx]).toMatch(/^instar-pool-myagent-/);
+  });
+});

--- a/tests/unit/providers/adapters/anthropic-interactive-pool/pool-model-flag.test.ts
+++ b/tests/unit/providers/adapters/anthropic-interactive-pool/pool-model-flag.test.ts
@@ -1,0 +1,70 @@
+/**
+ * Unit tests for the pool `model` config knob.
+ *
+ * The interactive pool runs ONE model per pool (set at spawn via
+ * `--model`). The intelligence funnel sets this to a small model so
+ * high-volume judgment calls don't draw the subscription's large-model
+ * quota. These tests assert the spawn argv both ways without touching
+ * real tmux/claude binaries (execFileSync is mocked at the module level).
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('node:child_process', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:child_process')>();
+  return {
+    ...actual,
+    execFileSync: vi.fn(() => ''),
+    execFile: vi.fn(),
+  };
+});
+
+import { execFileSync } from 'node:child_process';
+import { InteractivePool } from '../../../../../src/providers/adapters/anthropic-interactive-pool/pool.js';
+import { configFromEnv } from '../../../../../src/providers/adapters/anthropic-interactive-pool/config.js';
+
+function spawnArgsFor(model?: string): string[] {
+  const cfg = { ...configFromEnv({}), poolSize: 1, ...(model ? { model } : {}) };
+  const pool = new InteractivePool(cfg);
+  // Skip the readiness poll and the startup canary — argv construction is
+  // the unit under test, not session lifecycle.
+  (pool as unknown as { waitForReady: () => Promise<boolean> }).waitForReady = async () => true;
+  (pool as unknown as { canaryHasRunInCurrentLifetime: boolean }).canaryHasRunInCurrentLifetime =
+    true;
+  return (pool as unknown as { spawnOne: () => Promise<void> })
+    .spawnOne()
+    .then(() => {
+      const calls = vi.mocked(execFileSync).mock.calls;
+      // First call is the `tmux new-session` spawn.
+      return calls[0]![1] as string[];
+    }) as unknown as string[];
+}
+
+describe('InteractivePool — model flag at spawn', () => {
+  beforeEach(() => {
+    vi.mocked(execFileSync).mockClear();
+  });
+
+  it('appends --model <m> to the claude argv when config.model is set', async () => {
+    const args = await spawnArgsFor('haiku');
+    const claudeIdx = args.indexOf('--dangerously-skip-permissions');
+    expect(claudeIdx).toBeGreaterThan(-1);
+    expect(args[claudeIdx + 1]).toBe('--model');
+    expect(args[claudeIdx + 2]).toBe('haiku');
+  });
+
+  it('omits --model entirely when config.model is unset (today\'s argv unchanged)', async () => {
+    const args = await spawnArgsFor(undefined);
+    expect(args).not.toContain('--model');
+    // The claude binary + skip-permissions flag remain the argv tail.
+    expect(args[args.length - 1]).toBe('--dangerously-skip-permissions');
+  });
+
+  it('configFromEnv picks up INTERACTIVE_POOL_MODEL', async () => {
+    const { configFromEnv: fresh } = await import(
+      '../../../../../src/providers/adapters/anthropic-interactive-pool/config.js'
+    );
+    expect(fresh({ INTERACTIVE_POOL_MODEL: 'haiku' } as NodeJS.ProcessEnv).model).toBe('haiku');
+    expect(fresh({} as NodeJS.ProcessEnv).model).toBeUndefined();
+  });
+});

--- a/tests/unit/providers/bootRegistration.test.ts
+++ b/tests/unit/providers/bootRegistration.test.ts
@@ -1,0 +1,216 @@
+/**
+ * Unit tests for src/providers/bootRegistration.ts — the production
+ * registration of the Anthropic adapters (the deferred Phase-5 "separate
+ * cycle"). Covers both sides of every gate, idempotency, the no-eager-spawn
+ * guarantee, and the TTL-cached SDK-credit reader.
+ */
+
+import { describe, it, expect, afterEach, vi } from 'vitest';
+
+vi.mock('node:child_process', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:child_process')>();
+  return {
+    ...actual,
+    execFileSync: vi.fn(() => ''),
+    execFile: vi.fn(),
+  };
+});
+
+import { execFileSync } from 'node:child_process';
+import {
+  registerAnthropicAdapters,
+  buildReadSdkCredit,
+} from '../../../src/providers/bootRegistration.js';
+import { Registry, type ProviderAdapter } from '../../../src/providers/registry.js';
+import { CapabilityFlag } from '../../../src/providers/capabilities.js';
+import {
+  setClaudeForbidden,
+  clearClaudeForbidden,
+} from '../../../src/core/claudeForbiddenGuard.js';
+import type { AgentSdkCreditSnapshot } from '../../../src/providers/primitives/observability/usageMeterProvider.js';
+
+afterEach(() => {
+  clearClaudeForbidden();
+  vi.mocked(execFileSync).mockClear();
+});
+
+describe('registerAnthropicAdapters — gates', () => {
+  it('skips entirely when Claude is process-forbidden (codex-only agent)', async () => {
+    setClaudeForbidden("enabledFrameworks=['codex-cli'], no claude-code");
+    const reg = new Registry();
+    const result = await registerAnthropicAdapters({ registryInstance: reg });
+    expect(result.skippedReason).toBe('claude-forbidden');
+    expect(result.registered).toEqual([]);
+    expect(reg.list()).toEqual([]);
+    expect(await result.readSdkCredit()).toBeNull();
+  });
+
+  it('skips when enabledFrameworks excludes claude-code', async () => {
+    const reg = new Registry();
+    const result = await registerAnthropicAdapters({
+      registryInstance: reg,
+      enabledFrameworks: ['codex-cli'],
+    });
+    expect(result.skippedReason).toBe('claude-code-not-enabled');
+    expect(reg.list()).toEqual([]);
+  });
+
+  it('registers both adapters when claude-code is enabled', async () => {
+    const reg = new Registry();
+    const result = await registerAnthropicAdapters({
+      registryInstance: reg,
+      enabledFrameworks: ['claude-code', 'codex-cli'],
+    });
+    expect(result.skippedReason).toBeUndefined();
+    expect(result.registered.sort()).toEqual([
+      'anthropic-headless',
+      'anthropic-interactive-pool',
+    ]);
+    expect(reg.list().sort()).toEqual(['anthropic-headless', 'anthropic-interactive-pool']);
+    expect(result.headless).toBeDefined();
+    expect(result.pool).toBeDefined();
+  });
+
+  it('treats unset/empty enabledFrameworks as the historical claude-code default', async () => {
+    const regA = new Registry();
+    const a = await registerAnthropicAdapters({ registryInstance: regA });
+    expect(a.registered).toHaveLength(2);
+
+    const regB = new Registry();
+    const b = await registerAnthropicAdapters({ registryInstance: regB, enabledFrameworks: [] });
+    expect(b.registered).toHaveLength(2);
+  });
+});
+
+describe('registerAnthropicAdapters — idempotency + laziness', () => {
+  it('is idempotent: a second call registers nothing and reports alreadyRegistered', async () => {
+    const reg = new Registry();
+    await registerAnthropicAdapters({ registryInstance: reg });
+    const second = await registerAnthropicAdapters({ registryInstance: reg });
+    expect(second.registered).toEqual([]);
+    expect(second.alreadyRegistered.sort()).toEqual([
+      'anthropic-headless',
+      'anthropic-interactive-pool',
+    ]);
+    expect(reg.list()).toHaveLength(2);
+    // The already-registered adapters are still returned for wiring.
+    expect(second.headless).toBeDefined();
+    expect(second.pool).toBeDefined();
+  });
+
+  it('is idempotent under CONCURRENT calls (single-flight, no duplicate-register throw)', async () => {
+    const reg = new Registry();
+    const [a, b] = await Promise.all([
+      registerAnthropicAdapters({ registryInstance: reg }),
+      registerAnthropicAdapters({ registryInstance: reg }),
+    ]);
+    // Both callers share one registration run — same result, no throw.
+    expect(reg.list()).toHaveLength(2);
+    expect(a.registered).toEqual(b.registered);
+    expect(a.skippedReason).toBeUndefined();
+    expect(b.skippedReason).toBeUndefined();
+  });
+
+  it('spawns NOTHING at registration time (lazy pool — boot must stay cheap)', async () => {
+    const reg = new Registry();
+    await registerAnthropicAdapters({ registryInstance: reg });
+    expect(vi.mocked(execFileSync)).not.toHaveBeenCalled();
+  });
+
+  it('passes claudePath/tmuxPath and pool overrides through to the adapters', async () => {
+    const reg = new Registry();
+    const result = await registerAnthropicAdapters({
+      registryInstance: reg,
+      claudePath: '/custom/claude',
+      tmuxPath: '/custom/tmux',
+      pool: { poolSize: 1, model: 'haiku' },
+    });
+    // The pool adapter exposes its pool; its config is private, so assert
+    // via the spawn argv when a session would spawn — covered by the pool
+    // model-flag tests. Here we assert the adapter constructed cleanly.
+    expect(result.pool?.id).toBe('anthropic-interactive-pool');
+  });
+});
+
+function fakeAdapterWithMeter(read: () => Promise<unknown>): ProviderAdapter {
+  return {
+    id: 'anthropic-headless' as ProviderAdapter['id'],
+    capabilities: { transport: [], capability: [], observability: [], control: [], integration: [] } as unknown as ProviderAdapter['capabilities'],
+    primitive(cap: CapabilityFlag): unknown {
+      if (cap === CapabilityFlag.UsageMeterProvider) {
+        return { capability: CapabilityFlag.UsageMeterProvider, isAuthoritative: () => true, read };
+      }
+      throw new Error(`unexpected capability ${cap}`);
+    },
+  };
+}
+
+const SNAPSHOT: AgentSdkCreditSnapshot = {
+  remainingUsd: 150,
+  totalUsd: 200,
+  resetsAt: '2026-07-01T00:00:00Z',
+  overageEnabled: false,
+};
+
+describe('buildReadSdkCredit', () => {
+  it('returns the agentSdkCredit snapshot from the usage meter', async () => {
+    const adapter = fakeAdapterWithMeter(async () => ({
+      capturedAt: 'now',
+      source: 'authoritative',
+      windows: [],
+      agentSdkCredit: SNAPSHOT,
+    }));
+    const read = buildReadSdkCredit(adapter);
+    expect(await read()).toEqual(SNAPSHOT);
+  });
+
+  it('returns null when the meter omits agentSdkCredit (state unknown)', async () => {
+    const adapter = fakeAdapterWithMeter(async () => ({
+      capturedAt: 'now',
+      source: 'authoritative',
+      windows: [],
+      agentSdkCredit: null,
+    }));
+    expect(await buildReadSdkCredit(adapter)()).toBeNull();
+  });
+
+  it('returns null instead of throwing when the meter read fails', async () => {
+    const adapter = fakeAdapterWithMeter(async () => {
+      throw new Error('401 from usage API');
+    });
+    expect(await buildReadSdkCredit(adapter)()).toBeNull();
+  });
+
+  it('caches within the TTL — at most one meter read per window', async () => {
+    const read = vi.fn(async () => ({
+      capturedAt: 'now',
+      source: 'authoritative' as const,
+      windows: [],
+      agentSdkCredit: SNAPSHOT,
+    }));
+    const reader = buildReadSdkCredit(fakeAdapterWithMeter(read), 60_000);
+    await reader();
+    await reader();
+    await reader();
+    expect(read).toHaveBeenCalledTimes(1);
+  });
+
+  it('re-reads after the TTL expires', async () => {
+    vi.useFakeTimers();
+    try {
+      const read = vi.fn(async () => ({
+        capturedAt: 'now',
+        source: 'authoritative' as const,
+        windows: [],
+        agentSdkCredit: SNAPSHOT,
+      }));
+      const reader = buildReadSdkCredit(fakeAdapterWithMeter(read), 1_000);
+      await reader();
+      vi.advanceTimersByTime(1_500);
+      await reader();
+      expect(read).toHaveBeenCalledTimes(2);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/upgrades/next/provider-substrate-live-wiring.md
+++ b/upgrades/next/provider-substrate-live-wiring.md
@@ -1,0 +1,76 @@
+---
+bump: minor
+---
+
+## What Changed
+
+The provider-portability substrate (both Anthropic adapters + the cost-aware
+routing policy, on main since 2026-05-18) shipped dark: server boot installed
+the routing policy with a literal `readSdkCredit: () => null` stub and
+registered ZERO adapters, while every internal LLM call (sentinels, gates,
+extractors — measured ~1,000 real calls / ~27M input tokens per 24h on one
+agent) hardcoded `claude -p`, the path that bills the Agent SDK credit pot
+after 2026-06-15 and fails with no reroute when it drains. This PR wires the
+substrate into production: (1) `registerAnthropicAdapters()` at server boot —
+gated (codex-only agents register nothing), idempotent (incl. concurrent
+single-flight), lazy (zero spawns at boot), with a TTL-cached real credit
+reader replacing the null stub; (2) a new `intelligence.subscriptionPath.mode`
+config — `off` (default; byte-for-byte today's behavior, argv pinned by test)
+/ `auto` (drain the prepaid SDK pot while healthy, fall back to the
+subscription interactive pool when unknown/at-margin, one cross-path fallback
+with DegradationReporter) / `force` (interactive pool ONLY, zero `claude -p` —
+the soak + June-15 emergency lever); (3) `AnthropicSubscriptionRouter` +
+`InteractivePoolIntelligenceProvider` inside the existing breaker wrap, with
+the pure `decideSdkVsSubscription` decision extracted and shared so the two
+routing layers cannot drift; (4) `GET /providers/registry` introspection;
+(5) pool production-hardening — `model` knob (intelligence pool runs haiku),
+poolSize validation, idle retirement (`maxIdleMinutes` was dead config),
+on-demand growth, agent-scoped session prefix + orphan recovery at start().
+
+## What to Tell Your User
+
+After June 15, Anthropic changes how background AI calls are billed: the
+"headless" path I use for internal housekeeping (message screening, safety
+checks, summaries) starts drawing from a prepaid credit pot instead of the
+flat subscription. Before this change, when that pot ran dry all my background
+thinking would simply FAIL — silently. Now I have a second lane: I can run
+those same internal calls through a normal interactive Claude session (the
+same kind you chat with me in), which stays on the subscription. There's a
+switch with three positions — today's behavior (default), automatic (use the
+prepaid pot while it's healthy, switch lanes when it runs low), and
+subscription-only (the June-15 emergency lever). Nothing changes for you at
+this release — the switch ships in the OFF position — but the lane now exists,
+is tested, and can be flipped per-agent when the billing change lands.
+
+## Summary of New Capabilities
+
+- Boot registration of both Anthropic providers (`headless` + `interactive
+  pool`) — lazy, gated, idempotent; routing policy now reads REAL SDK credit
+  state (TTL-cached) instead of a hardcoded null.
+- `intelligence.subscriptionPath.mode: off | auto | force` — per-agent control
+  of which Anthropic lane internal LLM calls use; `off` is pinned
+  byte-for-byte to today's `claude -p` argv by test.
+- `GET /providers/registry` — what is ACTUALLY registered (adapter ids +
+  capability flags only), the June-15 readiness diagnostic.
+- Interactive-pool hardening: configurable model (haiku for internal calls),
+  poolSize validation, idle-session retirement, on-demand growth, agent-scoped
+  tmux prefix + orphan REPL recovery after crashes.
+
+## Evidence
+
+Gap measured live on echo: ~1,000 internal `claude -p` calls / ~27M input
+tokens per 24h, all unrouted (boot stub `readSdkCredit: () => null`, registry
+empty — confirmed via the new `/providers/registry` on a pre-fix boot in the
+e2e test). 44+ new tests across all three tiers: unit (router decision
+boundaries both sides, factory argv pin, bootRegistration gating/idempotency/
+laziness, pool model flag + lifecycle hardening), integration
+(`providers-registry-route.test.ts` full HTTP pipeline), e2e
+(`provider-substrate-live-wiring.test.ts` — production-mirroring boot:
+registry populated, route 200, default-off invariance, codex-only gate,
+no-spawn-at-boot). 5-agent adversarial review panel: correctness/wiring
+(BLOCK→fixed: registration TOCTOU single-flight), security/cost (SHIP;
+poolSize validation added), ops/scale (BLOCK→fixed: idle retirement, orphan
+recovery), standards/lessons (BLOCK→fixed: Agent Awareness template +
+migration parity), spec-vs-reality (SHIP — truths T1–T7 all VERIFIED).
+Spec: `docs/specs/provider-substrate-live-wiring.md` (+ `.eli16.md`);
+side-effects: `upgrades/side-effects/provider-substrate-live-wiring.md`.

--- a/upgrades/side-effects/provider-substrate-live-wiring.md
+++ b/upgrades/side-effects/provider-substrate-live-wiring.md
@@ -129,3 +129,17 @@ commit; findings folded back into code/spec before the convergence tag.
 - Spec: `docs/specs/provider-substrate-live-wiring.md` (+ `.eli16.md`)
 - Live exposure measurement driving the work: /metrics/features 24h on echo
   (~1,014 real internal calls, ~26.7M tokens-in).
+
+## CI-green follow-up (same PR)
+
+- New side effect: a FAILED boot registration/policy install now emits a
+  DegradationReporter event (`serverBoot.anthropicProviderRegistration`) in
+  addition to the yellow boot log line — so a dark June-15 routing install is
+  visible in the degradation feed, not just scrollback. No behavior change on
+  the success path.
+- Silent-fallback ratchet lowered 459 → 458 (that catch is now reporter-wired);
+  two non-degradation catches carry in-brace `@silent-fallback-ok`
+  justifications (raced tmux kill-session; HTTP 500 surfaced to caller).
+- `/providers/registry` tracked in the feature-delivery-completeness guard
+  (read-surface class, like `/session/clock`; no framework shadow — the lever
+  only applies to claude-code internal traffic).

--- a/upgrades/side-effects/provider-substrate-live-wiring.md
+++ b/upgrades/side-effects/provider-substrate-live-wiring.md
@@ -1,0 +1,131 @@
+# Side-Effects Review — Provider-Substrate Live Wiring (June-15 readiness PR 1)
+
+**Version / slug:** `provider-substrate-live-wiring`
+**Date:** `2026-06-05`
+**Author:** `echo (Claude Opus)`
+**Second-pass reviewer:** `5-agent verification panel (build Phase 3, LARGE)`
+
+## Summary of the change
+
+Wires the already-built provider substrate into production: registers both
+Anthropic adapters with the providers registry at server boot (gated,
+idempotent, lazy), plumbs a real TTL-cached SDK-credit reader into the
+CostAwareRoutingPolicy (replacing the `() => null` stub), and adds an
+opt-in `intelligence.subscriptionPath` mode (`off`/`auto`/`force`) that
+routes the internal-intelligence funnel between `claude -p` (SDK-credit
+path) and the interactive REPL pool (subscription floor) per spec 04
+Rule 1. Files: `src/providers/bootRegistration.ts` (new),
+`src/core/InteractivePoolIntelligenceProvider.ts` (new),
+`src/core/AnthropicSubscriptionRouter.ts` (new),
+`src/providers/costAwareRouting.ts` (decision extracted to shared pure fn),
+`src/providers/adapters/anthropic-interactive-pool/{config,pool}.ts`
+(model knob), `src/core/intelligenceProviderFactory.ts` (option),
+`src/core/types.ts` (config type), `src/commands/server.ts` (boot+shutdown
+wiring), `src/server/routes.ts` (GET /providers/registry).
+
+## Decision-point inventory
+
+- `registerAnthropicAdapters` gates (claudeForbidden, enabledFrameworks) — add — refuse Claude adapters on codex-only agents
+- `decideSdkVsSubscription` (extracted) — modify (refactor, semantics identical, existing tests pass) — SDK-pot vs subscription threshold
+- `AnthropicSubscriptionRouter.evaluate` mode branch — add — off/auto/force routing of internal LLM calls
+- `buildIntelligenceProvider` claude-code case — modify — wraps with router ONLY when the new option is passed; otherwise byte-identical
+- shutdown pool dispose — add — kills pool tmux sessions at server stop
+- `GET /providers/registry` — add — read-only introspection
+
+## 1. Over-block
+
+**What legitimate inputs does this change reject that it shouldn't?**
+
+In `force` mode, a pool outage (tmux missing, spawn failure) makes internal
+LLM calls fail even though `claude -p` would have worked — by design (force
+mode's contract is zero `claude -p` traffic), and loudly. Fleet default is
+`off`, so nobody is exposed without an explicit flip. The codex-only gate
+refuses registration on codex-only agents — correct, mirrors the existing
+ClaudeCliIntelligenceProvider guard. No other block/allow surface.
+
+## 2. Under-block
+
+**What should be rejected but passes?**
+
+`auto` mode falls back across paths on ANY primary error, including
+prompt-shaped errors (e.g. timeout from an oversized prompt) where the
+retry will likely fail again — one wasted call, bounded (exactly one
+fallback attempt, then a loud throw). The pool's `--dangerously-skip-
+permissions` spawn means a prompt-injected judgment call could in principle
+invoke tools inside the pool session; mitigated by the empty scratch
+workdir and unchanged from the adapter's prototyped+parity-tested shape;
+hardening is tracked in the spec (CMT-1105).
+
+## 3. Level-of-abstraction fit
+
+Registration lives in `src/providers/` (substrate layer), the two
+IntelligenceProvider implementations in `src/core/` next to their peers,
+and the mode wiring at the composition root (server.ts) — matching the
+existing layering (IntelligenceRouter precedent). The threshold logic was
+EXTRACTED to one shared pure function rather than duplicated across the
+two routing layers.
+
+## 4. Signal vs authority compliance
+
+The router treats config (`mode`) as authority and credit snapshots as
+signal: unknown signal degrades conservatively (subscription floor), never
+blocks the call path. onRoute/onDegrade are observability taps with no
+authority. No LLM judgment gates any decision here — all routing is
+deterministic from config + credit state.
+
+## 5. Interactions
+
+- **Circuit breaker**: router sits INSIDE the breaker wrap — a rate-limit
+  on the surviving path still trips the account-global breaker. Unchanged
+  for mode off.
+- **Per-component IntelligenceRouter**: claude-code builds inherit the same
+  subscriptionPath option, so codex-default agents with claude-routed
+  components stay consistent.
+- **/metrics/features**: pool-served calls still attribute calls+latency;
+  token columns read 0 (pool reports no per-call usage; onUsage is
+  deliberately not invoked with fake zeros).
+- **SessionReaper/tmux tooling**: pool sessions are named `instar-pool-*`;
+  they are adapter-managed (maxIdle 30m, maxMessages 50, dispose at
+  shutdown). Reaper does not manage them (they are not instar sessions in
+  the session store).
+- **QuotaTracker**: unaffected — file-based scheduler shedding stays as-is.
+
+## 6. External surfaces
+
+`GET /providers/registry` (Bearer-authed like its router peers) returns
+adapter ids + capability flag names + a policy-installed boolean. No prompt
+content, no credentials; integration test asserts no key-material shapes in
+the payload. The usage-meter call (`/api/oauth/usage`) is the EXISTING
+read-only observability exception under spec 04 Rule 2, now TTL-cached
+(60s) so routing volume cannot hammer it.
+
+## 7. Rollback cost
+
+Mode is config-gated default-off: rollback = remove the config key (or set
+`off`) + restart — no data, no state, no migration. Registration itself is
+inert without the mode (lazy pool, no spawns). Worst-case orphan: pool tmux
+sessions if the server dies UNgracefully mid-soak; bounded by poolSize
+(default 2) and visible via `tmux ls` (`instar-pool-*`).
+
+## Conclusion
+
+Ship. Default-off + pinned-argv invariance test means zero fleet behavior
+change at merge; the June-15 lever becomes a config flip backed by 44 new
+tests across all three tiers.
+
+## Second-pass review (if required)
+
+Build Phase 3 runs the 5-agent verification panel (LARGE build) before
+commit; findings folded back into code/spec before the convergence tag.
+
+## Evidence pointers
+
+- Unit: `tests/unit/providers/bootRegistration.test.ts`,
+  `tests/unit/anthropic-subscription-router.test.ts`,
+  `tests/unit/intelligence-provider-factory-subscription-path.test.ts`,
+  `tests/unit/providers/adapters/anthropic-interactive-pool/pool-model-flag.test.ts`
+- Integration: `tests/integration/providers-registry-route.test.ts`
+- E2E: `tests/e2e/provider-substrate-live-wiring.test.ts`
+- Spec: `docs/specs/provider-substrate-live-wiring.md` (+ `.eli16.md`)
+- Live exposure measurement driving the work: /metrics/features 24h on echo
+  (~1,014 real internal calls, ~26.7M tokens-in).


### PR DESCRIPTION
## ELI16 — the June-15 escape hatch is now actually plugged in

On June 15, Anthropic changes how Instar's background brain gets billed. Your actual conversations are safe (interactive sessions, normal subscription). But all the invisible background work — safety checks, message screening, intent extraction — runs as thousands of tiny one-shot `claude -p` commands, and after June 15 those draw from a separate prepaid $200/month pot. When the pot runs dry, they just FAIL.

In May we built the escape hatch: a pool of long-lived interactive Claude sessions Instar can type those background questions into — billed the same safe way as your conversations. It passed its tests. But the last step — plugging it into the running server — was deferred and never happened. The escape hatch existed; the door to it was never installed.

This PR installs the door, with the switch shipped OFF (bit-for-bit today's behavior, pinned by test):
- The server now actually registers both Anthropic paths at boot and reads the REAL credit balance instead of a hardcoded "I don't know."
- A new switch `intelligence.subscriptionPath.mode`: `off` (default — nothing changes) / `auto` (spend the prepaid pot while healthy, slide to interactive sessions when it runs low) / `force` (everything through interactive sessions — the proof mode and June-15 emergency lever).
- `GET /providers/registry` answers "is the escape hatch installed?" in one request instead of trusting a claim.

Nothing to decide today — this merge changes no behavior anywhere. The decision points (flipping echo to `force` for the one-day soak, then the fleet default) come next in the arc, as explicit reversible config flips with soak results in hand.

## June-15 interactive-only readiness — PR 1: wire the provider substrate into production (CMT-1105)

**Driving authority:** spec 04 path-constraints (Rule 1 + routing default, locked by Justin 2026-05-15) + Justin's 2026-06-05 directive in topic 9984: *"make SURE Instar can run purely on the Claude 'interactive session only' mode"* before the 2026-06-15 Agent SDK credit change.

### The gap this closes

The provider-portability substrate shipped 2026-05-18 **dark**: the routing policy was installed at boot with `readSdkCredit: () => null` and **zero adapters registered** ("separate cycle" that never happened). Meanwhile every internal LLM call (sentinels/gates/extractors — ~1,000 real calls / ~27M tokens-in per 24h on echo) hardcodes `claude -p`, the path that bills the $200/mo SDK pot after June 15 and **fails with no reroute** when it drains.

### What ships (all default-off; zero fleet behavior change at merge)

- **`src/providers/bootRegistration.ts`** — gated (codex-only registers nothing), idempotent (incl. concurrent single-flight), **lazy** (no spawns at boot) registration of both Anthropic adapters + TTL-cached real `readSdkCredit` from the headless usage meter.
- **Server boot wiring** — registration at the policy-install site; the null stub replaced with the real credit reader; pool disposed at shutdown.
- **`intelligence.subscriptionPath.mode`**: `off` (default — argv pinned byte-for-byte by test) / `auto` (drain SDK pot while healthy → subscription floor when unknown/at-margin; one cross-path fallback with DegradationReporter) / `force` (interactive pool ONLY, zero `claude -p`, loud failures — the soak + June-15 emergency lever).
- **`AnthropicSubscriptionRouter` + `InteractivePoolIntelligenceProvider`** — the funnel half; sits inside the breaker wrap, below the per-component IntelligenceRouter (whose claude-code builds inherit the same option). Shared pure `decideSdkVsSubscription` extracted so the two routing layers can't drift.
- **`GET /providers/registry`** — real-registry introspection (ids + capability flags only).
- **Pool production-hardening** (from the review round): `model` knob (intelligence pool runs haiku), poolSize validation, **idle retirement implemented** (`maxIdleMinutes` was dead config), allocate on-demand growth, **agent-scoped session prefix + orphan recovery** at start() (crashed-process REPLs no longer accumulate).
- **Agent Awareness + Migration Parity** — CLAUDE.md template block + `migrateClaudeMd` backfill.

### Verification

- **55 new tests across all three tiers (46 unit, 3 integration, 6 e2e)** — unit (both sides of every decision boundary), integration (route pipeline), e2e (production-mirroring boot: registry populated, route 200, default-off invariance, codex-only gate, no-spawn-at-boot).
- **5-agent adversarial review panel**: correctness/wiring (BLOCK→fixed: registration TOCTOU single-flight), security/cost (SHIP; poolSize validation added), ops/scale (BLOCK→fixed: idle retirement, orphan recovery), standards/lessons (BLOCK→fixed: Agent Awareness template+migration), spec-vs-reality (SHIP — truths T1–T7 all VERIFIED).
- Spec: `docs/specs/provider-substrate-live-wiring.md` (+ `.eli16.md`); side-effects review: `upgrades/side-effects/provider-substrate-live-wiring.md`.

### Explicitly NOT here (PR2+ of the arc, tracked under CMT-1105)

Headless job/A2A spawn rerouting · the 24h forced-subscription soak on echo · fleet default decision · pool permission-hardening · legacy direct-construction fallback callsites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
