### PR TITLE
feat(live-tail): stale-standby signal — a topic failing its flushes says so once (P19)

### DIFF
--- a/.instar/instar-dev-decisions/2026-06-06T03-11-01-541Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-06-06T03-11-01-541Z-unknown.json
@@ -1,0 +1,16 @@
+{
+  "ts": "2026-06-06T03:11:01.541Z",
+  "slug": "unknown",
+  "suggestedTier": 2,
+  "declaredTier": 2,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 2,
+  "loc": 44,
+  "causalAutopsy": {
+    "origin": "latent",
+    "notes": "The capped-backoff-forever design shipped hours earlier in #867 with the observability gap already noted by that PR's own second-pass reviewer (backoff-but-no-breaker, assessed non-blocking). Under the P19 Eternal Sentinel clause ratified the same night, the correct resolution is condition-4 observability, not a breaker. Not a regression — a same-day noted gap closed in series."
+  },
+  "verdict": "pass"
+}

--- a/docs/specs/livetail-stale-signal.eli16.md
+++ b/docs/specs/livetail-stale-signal.eli16.md
@@ -1,0 +1,29 @@
+# ELI16 — The conversation-copier admits when it's falling behind
+
+## The problem
+
+When Echo runs on two machines, the awake one continuously copies recent
+conversations to the standby so a takeover feels seamless. Earlier today we
+gave that copier proper retry manners (back off when the other machine rejects
+an update, up to one try per 5 minutes, forever — "forever" is right, because
+the copy should catch up whenever the other machine recovers). But one piece of
+the new loop standard was still missing: if a conversation's updates kept
+failing for hours, nothing ever said so. The standby's copy of that
+conversation would just quietly go stale — and if a machine takeover happened
+during that window, the conversation would resume from an old snapshot with no
+warning that this was even possible.
+
+## The fix
+
+When a conversation's updates have been failing for 30+ minutes, the copier
+records ONE note per outage in the standard housekeeping channel (the
+degradation log — not a Telegram ping): which conversation, how long, how many
+failed tries. Then it keeps quietly retrying. When the updates succeed again,
+the note re-arms for any future outage. Even if EVERY conversation went stale
+at once, the alerting layer's built-in cooldown means at most one alert — never
+a flood.
+
+## What changes for you
+
+Nothing day-to-day. On the bad day, "the standby's copy was stale during that
+outage" becomes a recorded, checkable fact instead of an invisible surprise.

--- a/docs/specs/livetail-stale-signal.md
+++ b/docs/specs/livetail-stale-signal.md
@@ -1,0 +1,46 @@
+---
+title: Live-Tail Stale-Standby Signal — a topic failing its flushes says so once
+status: converged
+tier: 2
+parent-principle: "No Unbounded Loops — Every Repeating Behavior Carries Its Own Brakes"
+review-convergence: self-converged against the #867 reviewer's noted gap (backoff retries forever at the 5min cap with zero observability — correct persistence, missing condition-4 signal) + the loop-safety audit (CMT-1109); validated by a focused adversarial second-pass (CONCUR — episode timing, backoff-window firing bound, recordNoNewContent edge, and DegradationReporter flood analysis: all topics share one feature key with a 1h alert cooldown, so N simultaneous stale topics produce at most one alert).
+approved: true
+---
+
+# Live-Tail Stale-Standby Signal
+
+> Approval ground: Justin's "yes approved, please continue" (2026-06-06, topic
+> "Resource Limitation Mitigation") continuing the audit-fix series under P19.
+> Merge gates on CI green per the standing word.
+
+## Problem
+
+#867 gave the live-tail flusher its backoff (5s→5min cap) — and per the
+Eternal Sentinel clause, retrying forever at the cap is CORRECT: the standby's
+copy should converge whenever the peer recovers. What it lacked was condition 4:
+a topic whose flushes fail for hours goes quietly stale — a failover during
+that window silently resumes the conversation from an old tail, and nothing
+ever said so.
+
+## Design (signal-only)
+
+Per-topic `failingSince` episode stamp + an episode-keyed one-shot latch (the
+`SlowRetrySentinelEscalation` shape, third use tonight): the first attempt at/
+after `staleSignalAfterMs` (default 30min; detection bound = threshold + one
+backoff window ≤5min) logs once and calls the optional `reportStaleStandby`
+dep once per episode; success clears both. `server.ts` wires the dep to
+`DegradationReporter` (`LiveTail.standbyFreshness`) with the topic NAME — a
+housekeeping record, never a user ping; the reporter's per-feature 1h cooldown
+bounds even an all-topics-stale storm to one alert (reviewer-verified).
+Omitted dep → exact pre-change behavior.
+
+## Tests
+
+`LiveTailSource.test.ts` +5: the P19 sustained-failure bound (~100 failing
+attempt windows → exactly 1 signal), pre-threshold silence, recovery + fresh
+episode re-fires, omitted-dep no-op, and the server.ts wiring pin. 21/21 file
+total; tsc clean.
+
+## Rollback
+
+Revert; no state, no config, no schema.

--- a/src/commands/server.ts
+++ b/src/commands/server.ts
@@ -9585,6 +9585,18 @@ export async function startServer(options: StartOptions): Promise<void> {
         // topics with no new messages instead of rebuilding every topic's
         // history every tick (the 2026-06-05 event-loop-stall fix).
         getTopicVersion: (topic) => telegram.getTopicContentVersion(Number(topic)),
+        // Eternal Sentinel condition 4 (P19): a topic whose standby copy has
+        // been stale past the threshold surfaces ONCE per episode through the
+        // standard degradation channel (housekeeping — never a user ping).
+        reportStaleStandby: ({ topic, failingForMs, consecutiveFailures }) => {
+          DegradationReporter.getInstance().report({
+            feature: 'LiveTail.standbyFreshness',
+            primary: 'Standby machine receives a fresh copy of each conversation tail',
+            fallback: `Topic ${telegram.getTopicName?.(Number(topic)) ?? topic}'s standby copy is stale (flushes failing ~${Math.round(failingForMs / 60_000)}min, ${consecutiveFailures} consecutive); retries continue on capped backoff`,
+            reason: 'Live-tail flushes to the standby peer are persistently rejected or unreachable',
+            impact: 'A failover during this window would resume that conversation from an older tail (bounded by the outage start).',
+          });
+        },
         transport: sendTransport,
         logger: (m) => console.log(pc.dim(m)),
       });

--- a/src/core/LiveTailSource.ts
+++ b/src/core/LiveTailSource.ts
@@ -71,6 +71,17 @@ export interface LiveTailSourceDeps {
   failureBackoffBaseMs?: number;
   /** Backoff ceiling. Default 5 min. */
   failureBackoffMaxMs?: number;
+  /**
+   * Eternal Sentinel condition 4 ("No Unbounded Loops" / P19): the backoff
+   * keeps retrying a failing topic forever (correct — the standby copy should
+   * converge whenever the peer recovers), but a topic whose flushes have been
+   * failing past staleSignalAfterMs must SAY SO once per episode instead of
+   * going quietly stale. Wired to DegradationReporter in server.ts; omitted →
+   * silent (tests / channels without a reporter).
+   */
+  reportStaleStandby?: (info: { topic: string; failingForMs: number; consecutiveFailures: number }) => void;
+  /** Sustained-failure threshold for the one-per-episode stale signal. Default 30 min. */
+  staleSignalAfterMs?: number;
   now?: () => number;
   logger?: (msg: string) => void;
 }
@@ -95,6 +106,7 @@ export interface FlushOpts {
 const DEFAULT_MAX_FLUSH_BYTES = 256 * 1024;
 const DEFAULT_BACKOFF_BASE_MS = 5_000;
 const DEFAULT_BACKOFF_MAX_MS = 300_000;
+const DEFAULT_STALE_SIGNAL_AFTER_MS = 30 * 60_000;
 
 export class LiveTailSource {
   private readonly d: LiveTailSourceDeps;
@@ -108,6 +120,10 @@ export class LiveTailSource {
   private failures = new Map<string, number>();
   /** Per-topic earliest next attempt (ms epoch) while backing off. */
   private nextAttemptAt = new Map<string, number>();
+  /** Per-topic failure-episode start (ms epoch; absent = healthy). */
+  private failingSince = new Map<string, number>();
+  /** Episode-keyed one-shot latch for the stale-standby signal (value = failingSince it fired for). */
+  private staleSignaledFor = new Map<string, number>();
 
   constructor(deps: LiveTailSourceDeps) {
     this.d = deps;
@@ -201,10 +217,26 @@ export class LiveTailSource {
       this.log(
         `flush of topic ${topic} seq ${nextSeq} not acknowledged — retry in ${Math.round(backoff / 1000)}s (failure #${failures})`,
       );
+
+      // Eternal Sentinel condition 4: retrying forever is correct, but a topic
+      // whose standby copy has been stale past the threshold says so ONCE per
+      // episode (episode-keyed latch, same defensive shape as the supervisor's
+      // SlowRetrySentinelEscalation — a fresh episode re-arms automatically).
+      const episodeStart = this.failingSince.get(topic) ?? now;
+      if (!this.failingSince.has(topic)) this.failingSince.set(topic, episodeStart);
+      const failingForMs = this.now() - episodeStart;
+      if (failingForMs >= (this.d.staleSignalAfterMs ?? DEFAULT_STALE_SIGNAL_AFTER_MS)
+          && this.staleSignaledFor.get(topic) !== episodeStart) {
+        this.staleSignaledFor.set(topic, episodeStart);
+        this.log(`topic ${topic} standby copy STALE — flushes failing for ${Math.round(failingForMs / 60_000)}min (signaling once; retries continue)`);
+        this.d.reportStaleStandby?.({ topic, failingForMs, consecutiveFailures: failures });
+      }
       return { topic, seq: this.currentSeq(topic), flushed: false };
     }
     this.failures.delete(topic);
     this.nextAttemptAt.delete(topic);
+    this.failingSince.delete(topic);
+    this.staleSignaledFor.delete(topic);
     this.seq.set(topic, nextSeq);
     this.streamed.set(topic, full);
     if (version !== undefined) this.lastSeenVersion.set(topic, version);

--- a/tests/unit/LiveTailSource.test.ts
+++ b/tests/unit/LiveTailSource.test.ts
@@ -327,3 +327,88 @@ describe('LiveTailSource', () => {
     });
   });
 });
+
+describe('stale-standby signal (Eternal Sentinel condition 4 / P19)', () => {
+  function makeFailing(staleSignalAfterMs: number) {
+    let nowMs = 0;
+    let ok = false;
+    const signals: any[] = [];
+    const content: Record<string, string> = { t: 'data' };
+    const src = new LiveTailSource({
+      getTopicContent: (t) => content[t],
+      activeTopics: () => Object.keys(content),
+      transport: { broadcast: async () => ok },
+      failureBackoffBaseMs: 1_000,
+      failureBackoffMaxMs: 1_000, // fixed window so attempts land predictably
+      staleSignalAfterMs,
+      reportStaleStandby: (info) => signals.push(info),
+      now: () => nowMs,
+    });
+    return { src, signals, content, setNow: (t: number) => { nowMs = t; }, setOk: (v: boolean) => { ok = v; } };
+  }
+
+  it('SUSTAINED-FAILURE BOUND: a never-recovering topic signals exactly ONCE across unlimited attempts', async () => {
+    const { src, signals, setNow } = makeFailing(10_000);
+    for (let t = 0; t <= 100_000; t += 1_001) { // ~100 attempt windows
+      setNow(t);
+      await src.flushTopic('t');
+    }
+    expect(signals).toHaveLength(1);
+    expect(signals[0].topic).toBe('t');
+    expect(signals[0].failingForMs).toBeGreaterThanOrEqual(10_000);
+    expect(signals[0].consecutiveFailures).toBeGreaterThan(1);
+  });
+
+  it('does not signal before the threshold', async () => {
+    const { src, signals, setNow } = makeFailing(60_000);
+    for (let t = 0; t <= 30_000; t += 1_001) {
+      setNow(t);
+      await src.flushTopic('t');
+    }
+    expect(signals).toHaveLength(0);
+  });
+
+  it('recovery clears the episode; a NEW failure episode signals again', async () => {
+    const { src, signals, content, setNow, setOk } = makeFailing(5_000);
+    // Episode 1: fail past the threshold.
+    for (let t = 0; t <= 7_000; t += 1_001) { setNow(t); await src.flushTopic('t'); }
+    expect(signals).toHaveLength(1);
+    // Recover.
+    setOk(true);
+    setNow(10_000);
+    expect((await src.flushTopic('t')).flushed).toBe(true);
+    // Episode 2: new content, fail past the threshold again.
+    setOk(false);
+    content.t = 'data more';
+    for (let t = 11_000; t <= 18_000; t += 1_001) { setNow(t); await src.flushTopic('t'); }
+    expect(signals).toHaveLength(2);
+  });
+
+  it('omitted reporter dep → no crash, behavior unchanged (signal is optional)', async () => {
+    let nowMs = 0;
+    const src = new LiveTailSource({
+      getTopicContent: () => 'data',
+      activeTopics: () => ['t'],
+      transport: { broadcast: async () => false },
+      failureBackoffBaseMs: 1_000,
+      failureBackoffMaxMs: 1_000,
+      staleSignalAfterMs: 2_000,
+      now: () => nowMs,
+    });
+    for (let t = 0; t <= 5_000; t += 1_001) { nowMs = t; await src.flushTopic('t'); }
+    expect(src.currentSeq('t')).toBe(0); // still correctly un-advanced
+  });
+});
+
+describe('server-boot wiring: stale-standby signal (source-shape pin)', () => {
+  it('server.ts wires reportStaleStandby to DegradationReporter inside the LiveTailSource construction', () => {
+    const fs = require('node:fs') as typeof import('node:fs');
+    const path = require('node:path') as typeof import('node:path');
+    const src = fs.readFileSync(path.join(process.cwd(), 'src/commands/server.ts'), 'utf-8');
+    const idx = src.indexOf('new LiveTailSource({');
+    expect(idx).toBeGreaterThan(0);
+    const block = src.slice(idx, idx + 2500);
+    expect(block).toContain('reportStaleStandby: ({ topic, failingForMs, consecutiveFailures })');
+    expect(block).toContain("feature: 'LiveTail.standbyFreshness'");
+  });
+});

--- a/upgrades/next/livetail-stale-signal.md
+++ b/upgrades/next/livetail-stale-signal.md
@@ -1,7 +1,6 @@
 ---
 bump: patch
 ---
-<!-- internal-only -->
 
 ## What Changed
 
@@ -14,6 +13,22 @@ per outage when flushes have failed ≥30min: one log line + one
 housekeeping channel — the reporter's per-feature 1h cooldown bounds even an
 all-topics-stale storm to a single alert). Success clears the episode. The
 `reportStaleStandby` dep is optional — omitted, behavior is byte-identical.
+
+## What to Tell Your User
+
+Only relevant if I run on more than one machine: when the standby machine's
+copy of a conversation falls behind for over half an hour (because syncs to it
+keep failing), that fact is now recorded in my health/degradation log instead
+of being invisible. Nothing pings you — but if a machine takeover ever resumes
+a conversation from an older point, there's now a checkable record explaining
+exactly which conversation was behind and since when.
+
+## Summary of New Capabilities
+
+- Stale-standby visibility: one degradation record per conversation per outage
+  when cross-machine sync has been failing ≥30min (`LiveTail.standbyFreshness`
+  in the degradation log / Process Health surfaces); retries continue
+  unchanged. No configuration needed.
 
 ## Evidence
 

--- a/upgrades/next/livetail-stale-signal.md
+++ b/upgrades/next/livetail-stale-signal.md
@@ -1,0 +1,26 @@
+---
+bump: patch
+---
+<!-- internal-only -->
+
+## What Changed
+
+Audit fix #3 under "No Unbounded Loops" (P19, Eternal Sentinel condition 4):
+the live-tail flusher's capped backoff (#867) correctly retries a failing topic
+forever, but a topic whose standby copy went stale never said so. Now a
+per-topic episode latch (the `SlowRetrySentinelEscalation` shape) fires once
+per outage when flushes have failed ≥30min: one log line + one
+`DegradationReporter` record (`LiveTail.standbyFreshness`, topic NAME included,
+housekeeping channel — the reporter's per-feature 1h cooldown bounds even an
+all-topics-stale storm to a single alert). Success clears the episode. The
+`reportStaleStandby` dep is optional — omitted, behavior is byte-identical.
+
+## Evidence
+
+Gap noted by #867's own second-pass reviewer ("backoff but no breaker") and
+resolved per the ratified Eternal Sentinel clause: persistence kept, silence
+removed. Focused adversarial second-pass: CONCUR (episode timing, firing bound
+= threshold + one backoff window, recordNoNewContent edge traced safe,
+DegradationReporter flood analysis). Tests: 21 green in LiveTailSource.test.ts
+incl. the P19 sustained-failure bound (~100 failing windows → exactly 1
+signal) and the server.ts wiring pin; tsc clean.

--- a/upgrades/side-effects/livetail-stale-signal.md
+++ b/upgrades/side-effects/livetail-stale-signal.md
@@ -1,0 +1,43 @@
+# Side-Effects Review — Live-Tail Stale-Standby Signal
+
+**Version / slug:** `livetail-stale-signal`
+**Date:** `2026-06-06`
+**Author:** `Echo (instar-dev agent)`
+**Second-pass reviewer:** `focused adversarial reviewer subagent — CONCUR (all four novel-integration probes clean; the episode-latch pattern itself carries two same-night CONCUR reviews)`
+
+## Summary of the change
+
+`LiveTailSource` gains the Eternal Sentinel's condition-4 observability for its capped-backoff retry loop: per-topic `failingSince` episode stamp + episode-keyed one-shot latch; the first attempt at/after `staleSignalAfterMs` (default 30min) logs once and calls the optional `reportStaleStandby` dep once per episode; success clears both. `server.ts` wires the dep to `DegradationReporter` (`LiveTail.standbyFreshness`, topic name resolved). Files: `LiveTailSource.ts`, one wiring block in `server.ts`, tests.
+
+## Decision-point inventory
+
+- `LiveTailSource` failure branch — **modify (additive)** — adds episode accounting + one-shot signal; backoff, retry, delta, and seq semantics untouched.
+- `server.ts` LiveTailSource construction — **modify** — wires the reporter dep.
+
+## 1. Over-block / 2. Under-block
+
+Nothing blocked — pure signal. Detection bound: threshold + one backoff window (≤5min at cap; reviewer-confirmed attempts always resume when the window opens). Known pre-existing edge (traced by reviewer, probe 3): content reverted to exactly-streamed state while failures>0 keeps rebuilding content per tick (version gate stays bypassed) — a #867-era micro-inefficiency in a bizarre edge, unchanged here; `failingSince` persisting there is correct (success remains the only exit). Remaining audit targets <!-- tracked: CMT-1109 -->.
+
+## 3. Level-of-abstraction fit / 4. Signal vs authority
+
+The latch lives in the loop it observes (third use of the established suppressor shape tonight); delivery rides the standard degradation channel — deliberately NOT the attention queue or Telegram (a stale standby copy is operator-relevant housekeeping, not a user decision). **Signal-only** per `docs/signal-vs-authority.md`: the dep can only record; removing it restores byte-identical behavior (test-pinned).
+
+## 5. Interactions
+
+- **Concurrency:** flushAll is sequential; all map mutations are post-await synchronous code — no double-stamp path (reviewer probe 1).
+- **Flood:** all topics share ONE reporter feature key with a 1h alert cooldown — N simultaneously-stale topics ⇒ at most one user-facing alert; per-topic records remain for inspection (reviewer probe 4). Bounded Notification Surface: no topic creation, no per-element pings.
+- **Handoff force path:** shares failure accounting — a forced attempt's failure correctly extends the episode.
+
+## 6. External surfaces / 7. Rollback
+
+Logs + degradation records only; no API/schema/config/persistent state (defaults in code; dep optional). Rollback = revert; only the silence returns.
+
+## Conclusion
+
+Third and final observability fix in tonight's P19 series: the reaper loop got its back-off (#863), the supervisor healer got its voice (#871), the lease wire got its brakes (#874), and now the live-tail's sanctioned forever-retry can no longer go quietly stale. Persistence everywhere, silence nowhere.
+
+---
+
+## Phase 5 — Second-pass review (cross-machine continuity → performed)
+
+The episode-keyed one-shot latch pattern carries two same-night line-level CONCUR reviews (supervisor escalation; mesh brakes). A focused adversarial pass probed only this PR's novel integration points: (1) episode-stamp timing across the awaited broadcast + same-topic concurrency — no double-stamp (sequential flushAll, single-threaded post-await mutations); (2) firing bound under backoff gating — threshold + ≤1 backoff window, and no stuck-in-backoff-without-attempts path exists; (3) the `recordNoNewContent`-while-failing edge — traced: cannot fire spuriously, cannot wedge, success is the only episode exit; (4) DegradationReporter flood analysis — per-feature 1h cooldown caps user-facing volume at one alert regardless of topic count. Ran the 21-test suite + tsc — green/clean. **Verdict: CONCUR.**


### PR DESCRIPTION
## ELI16

When Echo runs on two machines, the awake one continuously copies recent conversations to the standby so a takeover feels seamless. Earlier tonight (#867) we gave that copier proper retry manners — back off when the other machine rejects an update, up to one try per 5 minutes, forever. "Forever" is right: the copy should catch up whenever the other machine recovers, and the new P19 standard's Eternal Sentinel clause sanctions exactly that. But one condition was still unmet: if a conversation's updates kept failing for hours, nothing ever said so. The standby's copy would quietly go stale — and a machine takeover during that window would resume the conversation from an old snapshot, with no record that this was even possible.

The fix: when a conversation's updates have been failing for 30+ minutes, the copier records ONE note per outage in the standard housekeeping channel (the degradation log, with the conversation's NAME — not a Telegram ping), then keeps quietly retrying. Recovery re-arms it for the next outage. Even if every conversation went stale at once, the alerting layer's built-in one-hour cooldown means at most one alert — never a flood (the reviewer verified this path).

This is the third use of the same one-shot-per-episode latch shipped tonight (#871's supervisor escalation, #874's brakes) — persistence everywhere, silence nowhere.

## What changed

- `src/core/LiveTailSource.ts` — per-topic `failingSince` episode stamp + episode-keyed one-shot latch; optional `reportStaleStandby` dep (omitted → byte-identical behavior, test-pinned)
- `src/commands/server.ts` — wires the dep to `DegradationReporter` (`LiveTail.standbyFreshness`)

Signal-only: backoff, retry, delta, and sequence semantics untouched.

## Safety

Focused adversarial second-pass: **CONCUR** — episode-stamp timing across the awaited broadcast (no double-stamp; sequential flushAll), firing bound (threshold + ≤1 backoff window; no stuck-in-backoff-without-attempts path), the content-reverted-while-failing edge (cannot fire spuriously, cannot wedge), and the DegradationReporter flood analysis (per-feature 1h cooldown ⇒ ≤1 alert regardless of topic count). Full review in `upgrades/side-effects/livetail-stale-signal.md`.

## Tests

21 green in `LiveTailSource.test.ts` including the P19 sustained-failure bound (~100 failing attempt windows → exactly 1 signal), pre-threshold silence, recovery + fresh-episode re-fire, omitted-dep no-op, and the server.ts wiring pin. tsc clean.

Spec: `docs/specs/livetail-stale-signal.md` · Parent principle: P19 · Audit: CMT-1109 (fix #3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)