### PR TITLE
fix(tests): hermetic reply-script spawns — stop inheriting the live session's INSTAR_AUTH_TOKEN

### DIFF
--- a/tests/integration/telegram-reply-end-to-end.test.ts
+++ b/tests/integration/telegram-reply-end-to-end.test.ts
@@ -140,7 +140,11 @@ describe('telegram-reply.sh ↔ /events/delivery-failed end-to-end', () => {
         [path.join(projectDir, '.claude', 'scripts', 'telegram-reply.sh'), '50', 'a recoverable message'],
         {
           cwd: projectDir,
-          env: { ...process.env, INSTAR_PORT: '' },
+          // Hermetic: a live agent session exports INSTAR_AUTH_TOKEN; inheriting it
+          // makes the script send the REAL token, which this server's auth
+          // middleware rejects before the route can record the hit (found live
+          // 2026-06-05: the test failed only inside an agent session).
+          env: { ...process.env, INSTAR_PORT: '', INSTAR_AUTH_TOKEN: '' },
         },
       );
       child.stdout.on('data', () => {/* swallow */});

--- a/tests/unit/reply-scripts.test.ts
+++ b/tests/unit/reply-scripts.test.ts
@@ -92,7 +92,7 @@ async function runScript(script: string, args: string[], port: number, stdin?: s
     return await new Promise<RunResult>((resolve, reject) => {
       const proc = spawn('bash', [path.join(SCRIPT_DIR, script), ...args], {
         cwd: tmpCwd,
-        env: { ...process.env, INSTAR_PORT: String(port), PATH: process.env.PATH },
+        env: { ...process.env, INSTAR_PORT: String(port), INSTAR_AUTH_TOKEN: '', PATH: process.env.PATH }, // hermetic vs live-session env
       });
       let stdout = '';
       let stderr = '';

--- a/tests/unit/telegram-reply-recoverable-classification.test.ts
+++ b/tests/unit/telegram-reply-recoverable-classification.test.ts
@@ -128,7 +128,7 @@ function runScript(topicId: number, message: string): Promise<RunResult> {
   return new Promise((resolve) => {
     const child = spawn('bash', [scriptPath, String(topicId), message], {
       cwd: projectDir,
-      env: { ...process.env, INSTAR_PORT: '' },
+      env: { ...process.env, INSTAR_PORT: '', INSTAR_AUTH_TOKEN: '' }, // hermetic vs live-session env
     });
     let stdout = '';
     let stderr = '';

--- a/upgrades/next/test-env-hermetic-reply-scripts.md
+++ b/upgrades/next/test-env-hermetic-reply-scripts.md
@@ -1,0 +1,19 @@
+<!-- bump: patch -->
+<!-- internal-only -->
+
+## What Changed
+
+Made the three `telegram-reply.sh` test harnesses hermetic against a live
+agent session's environment: each script-spawn now blanks
+`INSTAR_AUTH_TOKEN` so the script exercises the config-file auth fallback
+the tests intend, instead of inheriting the runner's real session token
+(which the test servers' auth middleware correctly rejects, failing the
+tests only when run inside an agent session). Same hermeticity class as
+the #862 unit-suite fix, applied to the reply-script family.
+
+## Evidence
+
+- Bisected: `tests/integration/telegram-reply-end-to-end.test.ts` fails
+  with `INSTAR_AUTH_TOKEN` exported, passes without; single-var culprit.
+- Post-fix: all 4 reply-script test files (32 tests) green BOTH under a
+  live agent env and a stripped env.

--- a/upgrades/side-effects/test-env-hermetic-reply-scripts.md
+++ b/upgrades/side-effects/test-env-hermetic-reply-scripts.md
@@ -1,0 +1,67 @@
+# Side-Effects Review — Hermetic env for telegram-reply script tests
+
+**Version / slug:** `test-env-hermetic-reply-scripts`
+**Date:** `2026-06-05`
+**Author:** `echo`
+**Second-pass reviewer:** `not required (test-only change, no runtime surface)`
+
+## Summary of the change
+
+Three tests that spawn `telegram-reply.sh` (`tests/integration/telegram-reply-end-to-end.test.ts`, `tests/unit/telegram-reply-recoverable-classification.test.ts`, `tests/unit/reply-scripts.test.ts`) inherited the full process env via `{ ...process.env }`. Inside a live agent session, `INSTAR_AUTH_TOKEN` is exported (SessionManager injects it), the script's documented env-first auth resolution picks it up, and the test server's auth middleware rejects the mismatched Bearer before the route handler records the hit — failing the test only when run inside an agent session. Each spawn site now sets `INSTAR_AUTH_TOKEN: ''` so the script exercises the config-file fallback the tests intend. No runtime files changed.
+
+## Decision-point inventory
+
+No decision-point surface — test-only. The script's env-first auth precedence is intentionally UNCHANGED (it is documented, load-bearing behavior); only the tests' spawn environments changed.
+
+---
+
+## 1. Over-block
+
+No block/allow surface — not applicable.
+
+## 2. Under-block
+
+No block/allow surface — not applicable.
+
+## 3. Level-of-abstraction fit
+
+Right layer: the fix is at the test spawn sites, not the script. Weakening the script's env-first precedence to make tests pass would invert the actual contract. The sibling `telegram-reply-port-resolution.test.ts` already constructs a minimal env (`{ PATH }`) — the targeted blank keeps each test's existing env needs intact while removing the one leaking variable.
+
+## 4. Signal vs authority compliance
+
+**Required reference:** [docs/signal-vs-authority.md](../../docs/signal-vs-authority.md)
+
+- [x] No — this change has no block/allow surface.
+
+## 5. Interactions
+
+- Shadowing/double-fire/races/feedback loops: none — test-only env construction.
+- Verified the three tests + the already-hermetic sibling all pass together under a live agent env AND under a stripped env (both run locally).
+
+## 6. External surfaces
+
+None. No runtime change; CI behavior identical (CI never had the variable set — that's why CI was green while local was red).
+
+## 7. Rollback cost
+
+Trivial revert of three test lines. No persistent state.
+
+---
+
+## Conclusion
+
+Closes a hermeticity gap in the reply-script test family (the same class PR #862 closed for the unit suite's config leakage): tests must not change verdict based on the runner's live agent environment. Found via Zero-Failure triage of a local full-suite run. Clear to ship.
+
+---
+
+## Second-pass review (if required)
+
+**Reviewer:** not required
+**Independent read of the artifact:** not required — test-only.
+
+---
+
+## Evidence pointers
+
+- Repro: `npx vitest run tests/integration/telegram-reply-end-to-end.test.ts` fails with `INSTAR_AUTH_TOKEN` exported, passes with it unset (bisected: that single var).
+- Post-fix: all 4 reply-script test files green under the live agent env (32 tests).

--- a/upgrades/test-env-hermetic-reply-scripts.eli16.md
+++ b/upgrades/test-env-hermetic-reply-scripts.eli16.md
@@ -1,0 +1,9 @@
+# Tests stop failing just because a real agent is running them
+
+Three of our tests check the little script that delivers my chat replies. Each test builds a fake miniature server, points the script at it, and watches what the script does. The problem: when those tests run inside a LIVE agent work session (instead of a clean CI machine), the session environment carries the agent's REAL access token in an environment variable — and the script is designed to prefer that variable when it exists. So the script walks up to the fake test server holding the real token, the fake server's door check rejects it (wrong token), and the test fails with a confusing "the script never called the server" error — even though nothing is actually broken.
+
+This bit us tonight: the full test suite went red on my machine for exactly this reason, while the same tests pass everywhere else. The "fix" each time would have been to shrug and re-run on CI — which trains everyone to distrust local test runs, the opposite of what a test suite is for.
+
+The change is three one-line edits: each test now explicitly blanks that environment variable when launching the script, so the script falls back to reading the token from the test's own config file — the path the tests were always meant to exercise. A fourth sibling test already did this correctly (it builds a minimal clean environment from scratch), which is how we knew the pattern. Comments at each site explain why, so the next person who writes a test like this copies the safe pattern.
+
+Nothing about the real script changes. Production behavior is untouched — this only makes the tests honest about what environment they run in. Tests now pass identically on a clean CI box and inside a live agent session.


### PR DESCRIPTION
## ELI16 overview (plain English)

Three tests spawn my reply-delivery script against a fake mini-server. Run inside a LIVE agent session, the session's real auth token leaks into the script via an environment variable the script deliberately prefers — so the script shows up at the fake server with the wrong token, gets bounced at the door, and the test fails with a misleading 'script never called the server'. Same tests pass on clean CI boxes, which trains people to distrust local runs. Fix: each test now blanks that one variable when launching the script, exercising the config-file path the tests always meant to test. Three one-line edits + explanatory comments; the production script is untouched.

## What this fixes

Found via Zero-Failure triage tonight: the full local suite was red on exactly these tests inside my session, green elsewhere. Bisected to the single env var. Same hermeticity class as #862 (unit-suite config leakage), applied to the reply-script family. The already-hermetic sibling (`telegram-reply-port-resolution.test.ts`, minimal-env pattern) was the tell.

## Evidence

Post-fix: all 4 reply-script test files (32 tests) green BOTH under a live agent env and a stripped env.

🤖 Generated with Claude Code