### PR TITLE
fix(presence): strip codex input-box ghost text — idle sessions no longer report confabulated activity

### DIFF
--- a/.instar/instar-dev-decisions/2026-06-06T03-16-13-933Z-presence-ghost-text-strip.json
+++ b/.instar/instar-dev-decisions/2026-06-06T03-16-13-933Z-presence-ghost-text-strip.json
@@ -1,0 +1,16 @@
+{
+  "ts": "2026-06-06T03:16:13.933Z",
+  "slug": "presence-ghost-text-strip",
+  "suggestedTier": 1,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 38,
+  "causalAutopsy": {
+    "origin": "latent",
+    "notes": "ANSI-stripping in sanitizeTmuxOutput has always erased the dim styling that distinguishes codex input-box ghost suggestions from typed text, so the assessment LLM could not tell them apart. Latent since the codex adapter landed; surfaced 2026-06-06 by the apprenticeship operator-seat discipline (presence said 'preparing to write tests' for an idle session; ledger d0fd5483). Found by the run-2 loop, originally assigned to the mentee, reassigned to mentor on his honest codex-budget flag."
+  },
+  "verdict": "pass"
+}

--- a/docs/eli16/presence-ghost-text-strip.eli16.md
+++ b/docs/eli16/presence-ghost-text-strip.eli16.md
@@ -1,0 +1,25 @@
+# Presence ghost-text strip - ELI16
+
+> The one-line version: the presence proxy no longer mistakes the suggestion text inside an empty codex input box for something the agent is actually doing.
+
+## The problem
+
+When you ask "what is my agent doing?", the presence proxy captures the agent's terminal pane and has a small LLM summarize it. Codex's input box shows rotating placeholder suggestions when it's empty — dim text like "Write tests for @filename" or "Implement {feature}" that nobody typed. The pane capture strips the colors, so by the time the summarizer sees it, the ghost text looks exactly like a real typed command.
+
+Last night that produced a confabulated status: the proxy reported a session was "preparing to write tests for the referenced file" while the session was completely IDLE at a fresh prompt — it was reading the input box's placeholder. The operator acted on a status that described nothing real (ledger finding d0fd5483, topic 2271 at 00:35:28Z).
+
+## What changed
+
+The pane sanitizer — the single chokepoint every presence snapshot passes through before reaching the summarizer — now strips input-box ghost lines. A line is treated as ghost text only when it is an input-box line (starts with the prompt chevron) AND its content is recognizably template text: it contains a `{placeholder}` or `@filename` token, or exactly matches the known codex suggestion set.
+
+## What is deliberately KEPT
+
+- A real typed-but-unsubmitted command in the input box stays visible — that is genuine pane state.
+- Prose in normal output that happens to mention `@filename` or `{tokens}` stays — only input-box lines are candidates.
+- Agent output lines that begin with a quote-style chevron mid-report stay (they don't match the template test).
+
+The rule: only text the user never wrote gets stripped.
+
+## Evidence
+
+The unit fixture is the REAL incident pane capture, asserted both ways: the ghost line disappears, the surrounding context survives. All nine existing presence-proxy suites stay green (96 tests).

--- a/src/monitoring/PresenceProxy.ts
+++ b/src/monitoring/PresenceProxy.ts
@@ -220,6 +220,39 @@ const INJECTION_PATTERNS = [
   /^\s*<\/?(?:system|instruction|prompt)/i,
 ];
 
+// Input-box GHOST TEXT (the 2026-06-06 presence-confabulation incident):
+// codex renders rotating placeholder suggestions inside its empty input box
+// ("› Write tests for @filename", "› Implement {feature}"). ANSI-stripping
+// erases the dim styling, so by the time the snapshot reaches the assessment
+// LLM the ghost text is indistinguishable from a typed command — and the LLM
+// reported "preparing to write tests for the referenced file" for a session
+// that was IDLE at a fresh prompt (topic 2271, 00:35:28Z). Status confabulated
+// from UI chrome.
+//
+// Match conservatively: only `›`-prefixed input-box lines whose content is
+// recognizably TEMPLATE text — it contains a `{placeholder}` or `@filename`
+// token, or exact-matches the known codex suggestion set. A real typed-but-
+// unsubmitted command stays visible (it is genuine pane state); only text the
+// USER NEVER WROTE is stripped.
+const KNOWN_INPUT_BOX_GHOSTS = new Set(
+  [
+    'implement {feature}',
+    'write tests for @filename',
+    'find and fix a bug in @filename',
+    'explain this codebase',
+    'summarize recent commits',
+  ],
+);
+const INPUT_BOX_LINE = /^\s*[›❯>]\s+(.*\S)\s*$/;
+const TEMPLATE_TOKEN = /\{[a-z_-]+\}|@filename\b/i;
+
+function isInputBoxGhostLine(line: string): boolean {
+  const m = INPUT_BOX_LINE.exec(line);
+  if (!m) return false;
+  const content = m[1].trim();
+  return TEMPLATE_TOKEN.test(content) || KNOWN_INPUT_BOX_GHOSTS.has(content.toLowerCase());
+}
+
 export function sanitizeTmuxOutput(raw: string, extraPatterns?: string[]): string {
   let output = raw;
 
@@ -240,10 +273,11 @@ export function sanitizeTmuxOutput(raw: string, extraPatterns?: string[]): strin
     output = output.replace(pattern, '[REDACTED]');
   }
 
-  // Remove lines matching injection patterns
+  // Remove lines matching injection patterns, and input-box ghost-text lines
+  // (placeholder suggestions the user never typed — see isInputBoxGhostLine).
   output = output
     .split('\n')
-    .filter(line => !INJECTION_PATTERNS.some(p => p.test(line)))
+    .filter(line => !INJECTION_PATTERNS.some(p => p.test(line)) && !isInputBoxGhostLine(line))
     .join('\n');
 
   return output.trim();

--- a/tests/unit/presence-proxy-ghost-text.test.ts
+++ b/tests/unit/presence-proxy-ghost-text.test.ts
@@ -1,0 +1,58 @@
+/**
+ * Input-box ghost-text stripping (the 2026-06-06 presence-confabulation
+ * incident): codex renders rotating placeholder suggestions inside its empty
+ * input box; ANSI-stripping erases the dim styling, and the assessment LLM
+ * reported "preparing to write tests for the referenced file" for a session
+ * that was IDLE at a fresh prompt (topic 2271, 00:35:28Z presence message vs
+ * the idle pane). Ledger finding d0fd5483 / dedupKey
+ * presence-proxy-codex-input-placeholder-as-activity.
+ *
+ * Tested through the public sanitizeTmuxOutput surface — the chokepoint every
+ * presence snapshot passes through before reaching the assessment LLM.
+ */
+import { describe, it, expect } from 'vitest';
+import { sanitizeTmuxOutput } from '../../src/monitoring/PresenceProxy.js';
+
+/** The REAL pane capture from the incident (ANSI already stripped by tmux -p). */
+const INCIDENT_PANE = [
+  '⚠ Heads up, you have less than 25% of your weekly limit left. Run /status for a breakdown.',
+  '',
+  '› Write tests for @filename',
+  '  gpt-5.5 default · ~/Documents/Projects/instar-codey',
+].join('\n');
+
+describe('input-box ghost-text stripping (presence confabulation fix)', () => {
+  it('strips the real incident ghost line — the pane reads as idle, not "writing tests"', () => {
+    const out = sanitizeTmuxOutput(INCIDENT_PANE);
+    expect(out).not.toContain('Write tests for @filename');
+    // Non-ghost context is preserved untouched.
+    expect(out).toContain('weekly limit');
+    expect(out).toContain('gpt-5.5 default');
+  });
+
+  it('strips template-token ghosts regardless of suggestion wording', () => {
+    expect(sanitizeTmuxOutput('› Implement {feature}')).toBe('');
+    expect(sanitizeTmuxOutput('› Refactor {module} for clarity')).toBe(''); // unseen wording, {token} marks it
+    expect(sanitizeTmuxOutput('❯ Write tests for @filename')).toBe(''); // claude-style prompt char
+  });
+
+  it('strips known codex suggestions case-insensitively even without a template token', () => {
+    expect(sanitizeTmuxOutput('› Explain this codebase')).toBe('');
+    expect(sanitizeTmuxOutput('›   summarize recent commits  ')).toBe('');
+  });
+
+  it('KEEPS a real typed-but-unsubmitted command — only text the user never wrote is stripped', () => {
+    const typed = '› fix the login bug in src/auth.ts and add a regression test';
+    expect(sanitizeTmuxOutput(typed)).toBe(typed.trim());
+  });
+
+  it('KEEPS prose mentioning @filename when it is not an input-box line', () => {
+    const prose = 'The auditor accepts @filename arguments in its config {feature} flags too.';
+    expect(sanitizeTmuxOutput(prose)).toBe(prose);
+  });
+
+  it('KEEPS real agent output lines that begin with a quote-style chevron', () => {
+    const output = '  › step 3 completed: wrote 14 tests, all green';
+    expect(sanitizeTmuxOutput(output)).toBe(output.trim());
+  });
+});

--- a/upgrades/next/presence-ghost-text-strip.md
+++ b/upgrades/next/presence-ghost-text-strip.md
@@ -1,0 +1,31 @@
+<!-- bump: patch -->
+<!-- change_type: fix -->
+
+## What Changed
+
+Presence reports no longer confabulate activity from codex's input-box ghost
+text. The pane sanitizer (`sanitizeTmuxOutput`) strips input-box lines whose
+content is recognizably template text — a `{placeholder}`/`@filename` token or
+the known codex suggestion set — before the assessment LLM summarizes the
+pane. Real typed-but-unsubmitted commands, prose mentioning the tokens, and
+chevron-prefixed output lines are preserved: only text the user never wrote is
+stripped.
+
+Why: ANSI-stripping erases the dim styling that distinguishes ghost
+suggestions from typed input, so an IDLE session was reported as "preparing to
+write tests for the referenced file" (2026-06-06 incident, ledger d0fd5483).
+
+## What to Tell Your User
+
+Nothing user-visible changes unless you were affected: "what is my agent
+doing?" answers no longer mistake an idle codex session's input-box example
+text for real work.
+
+## Summary of New Capabilities
+
+None — internal correctness fix to presence summarization.
+
+## Evidence
+
+New 6-test suite with the real incident pane as fixture (both sides of every
+boundary); all 9 existing presence-proxy suites green (96 tests); tsc clean.

--- a/upgrades/side-effects/presence-ghost-text-strip.md
+++ b/upgrades/side-effects/presence-ghost-text-strip.md
@@ -1,0 +1,35 @@
+# Side-Effects Review - presence ghost-text strip
+
+**Version / slug:** `presence-ghost-text-strip`
+**Date:** `2026-06-06`
+**Author:** `echo`
+**Second-pass reviewer:** `not required (Tier 1)`
+
+## Summary of the change
+
+Adds an input-box ghost-text filter to `sanitizeTmuxOutput` (PresenceProxy) so the assessment LLM never sees codex's placeholder suggestions as if they were typed commands. One pure function + one filter clause; no new routes, config, or persistent state.
+
+## Decision-point inventory
+
+- `isInputBoxGhostLine` - add - pure predicate; matches `›`/`❯`/`>`-prefixed lines whose content carries a `{token}`/`@filename` template marker or exact-matches the known codex suggestion set.
+- `sanitizeTmuxOutput` - modify - one additional line-filter clause alongside the existing injection-pattern filter.
+
+## 1. Over-strip (false positive)
+
+Risk: a REAL typed command containing `{braces}` or the literal `@filename` would be stripped from presence snapshots. Judged acceptable: such commands are rare, the loss is one line of presence context (never functional behavior), and the alternative (matching only the curated list) misses unseen suggestion rotations — the `{token}` test is what generalizes. Real typed commands without template markers are explicitly tested as KEPT.
+
+## 2. Under-strip (false negative)
+
+Codex may ship new suggestion wordings without template tokens (like "Explain this codebase"). The curated set covers the observed rotation; unseen token-less suggestions would still leak. Acceptable for this slice: each is one snapshot line, and the curated set is trivially extensible when a new wording is observed.
+
+## 3. Blast radius
+
+`sanitizeTmuxOutput` consumers are the PresenceProxy snapshot paths (5 call sites) — all observational. OutputActivityTracker (stall detection) does NOT use this function and keeps its own volatile-line handling; activity hashing is unaffected. No agent-installed files change → Migration Parity not applicable. No new capability surface → Agent Awareness template change not applicable (internal correctness fix).
+
+## 4. Failure modes
+
+The predicate is pure and total (no I/O, no throw paths). A regex non-match degrades to "keep the line" — the pre-fix behavior.
+
+## 5. Security
+
+The filter runs AFTER credential redaction and alongside injection-pattern removal; it only ever REMOVES lines, never adds or transforms content.


### PR DESCRIPTION
## Summary

The presence proxy reported a session as "preparing to write tests for the referenced file" while it was completely IDLE at a fresh codex prompt — the assessment LLM was reading the input box's rotating placeholder suggestion ("Write tests for @filename") as a typed command. ANSI-stripping in `sanitizeTmuxOutput` erases the dim styling that is the ONLY signal distinguishing ghost text from real input. Incident: topic 2271 presence message 2026-06-06T00:35:28Z vs the idle pane; ledger finding d0fd5483.

Fix: one pure predicate + one filter clause in the sanitizer (the chokepoint all 5 presence snapshot sites use). A line is stripped only when it is an input-box line (`›`/`❯`/`>` prefixed) AND recognizably template text — contains a `{placeholder}`/`@filename` token, or exact-matches the known codex suggestion set. Real typed-but-unsubmitted commands, prose mentioning the tokens, and chevron-prefixed output lines are explicitly tested as KEPT: only text the user never wrote is stripped.

## ELI16

Codex shows gray example text in its empty input box, like a search bar showing "Search here…". The robot that summarizes "what is my agent doing" can't see colors, so it read the example text as if the agent had typed it, and told the operator the agent was busy writing tests when it was actually sitting idle. Now the summarizer is shown the screen without that example text. Anything a person actually typed stays visible.

## Causal autopsy

`origin: latent` — present since the codex adapter landed; ANSI-stripping always erased the distinguishing signal. Surfaced by the run-2 apprenticeship operator-seat discipline. Originally assigned to the mentee; reassigned to the mentor on his honest codex-budget flag (83% weekly used) — the load-spread protocol working as designed.

## Evidence

- New suite `presence-proxy-ghost-text.test.ts` (6 tests): the REAL incident pane as fixture, both sides of every boundary
- All 9 existing presence-proxy suites green (96 tests); `tsc --noEmit` clean; pre-push smoke + scoped e2e green
- Release fragment included (the pre-push gate caught its absence — publish would have silently skipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)