### PR TITLE
docs(pi-harness-integration): Tier 1 — kickoff + hands-on eval + master spec

### DIFF
--- a/docs/specs/PI-HARNESS-INTEGRATION-SPEC.md
+++ b/docs/specs/PI-HARNESS-INTEGRATION-SPEC.md
@@ -1,0 +1,199 @@
+---
+title: Pi Harness Integration
+project: pi-harness-integration
+status: spec
+approved: true
+approval_basis: >
+  Pre-approved under Justin's blanket all-tiers authorization for the 24h
+  autonomous run (topic 20390, 2026-06-06T03:08Z: "Yes, go … please enter a 24
+  hour autonomous session to attempt to fully accomplish all Tiers robustly").
+  Scope changes beyond this spec still require his word.
+---
+
+# Pi Harness Integration Spec
+
+> Project `pi-harness-integration` (topic 20390). Grounding: kickoff
+> requirements (`_drafts/pi-harness-integration-kickoff.md`) and the hands-on
+> evaluation (`_drafts/pi-eval-report.md`, pi 0.78.1, both faces verified).
+> Tip-of-main integration target: the provider substrate from PR #873.
+
+## 0. Constraints (non-negotiable, from Justin)
+
+1. **Additive only.** No subscription path is displaced. Claude work stays on
+   Claude Code (plan limits). The pi route REFUSES Anthropic providers by
+   default (§4.3 structural guard) — extra-usage billing can never be selected
+   silently.
+2. **Dashboard parity.** pi sessions stream + accept direct input in the
+   dashboard exactly like Claude Code sessions (TUI-in-tmux, §3). The
+   event-stream renderer (§6.1) is an optional later UPGRADE, never a
+   replacement.
+3. **Ships dark.** Everything gates on `enabledFrameworks` containing
+   `'pi-cli'` (default absent). Existing agents see zero behavior change.
+
+## 1. Naming & identity
+
+Framework id: **`pi-cli`** (consistent with `codex-cli`/`gemini-cli`).
+Binary: `pi` (from `@earendil-works/pi-coding-agent`), path overridable via
+`frameworkBinaryPaths['pi-cli']`. Provider-substrate adapter id: `pi-cli`.
+
+## 2. Phase A — fourth framework (project items P1.1, P1.2)
+
+### 2.1 Type unions (compiler-enforced where possible)
+
+Add `'pi-cli'` to: `types.ts:65` (Session.framework), `types.ts:139-141`
+(componentFrameworks), `types.ts:154` (SessionManagerConfig.framework),
+`types.ts:2182` (topicFrameworks), `types.ts:2301` (enabledFrameworks),
+`types.ts:116/125` (frameworkBinaryPaths/frameworkDefaultModels), and
+`intelligenceProviderFactory.ts:46` (`IntelligenceFramework`) — the `never`
+exhaustiveness checks at `intelligenceProviderFactory.ts:170` and
+`frameworkSessionLaunch.ts:338` then force every dispatch site to handle it.
+
+### 2.2 Interactive launch builder (`piCliBuilder`)
+
+`frameworkSessionLaunch.ts` BUILDERS entry:
+
+- Command: `pi` + `--session-dir <agentStateDir>/pi-sessions` (durable,
+  reap-log-coherent location — eval caveat 4) + `--provider <p> --model <m>`
+  when `frameworkDefaultModels['pi-cli']` is set (format `provider/model`).
+- Resume: `--session-id <id>` (deterministic create-or-resume; verified
+  `--continue` also works but is ambient — we pin explicit ids like Claude's
+  `--resume`).
+- No permission-bypass flag exists or is needed (pi is YOLO by design; our
+  gate layer wraps it like every framework — kickoff Risks).
+- tmux: set `extended-keys on` for pi sessions (eval caveat 1); plain Enter
+  injection verified working regardless.
+- `frameworkInjectionProcesses.ts`: `'pi-cli' → ['pi']` (the
+  framework-agnosticism test enforces this pairing).
+- `SessionManager.isMarkerStuckAtPrompt`: pi's input box has no `❯`-class
+  prompt char; detection key: the bordered input region + stable status line
+  (`<cwd> … <model>` bottom line). P1.2 pins the exact pattern with the
+  hermetic fixture; until then pi falls back to the generic marker path.
+
+### 2.3 Headless builder
+
+`pi --mode rpc --no-session` one-shot: write `{"type":"prompt"...}` line,
+read events to `agent_end`, exit. (RPC is strictly LF-framed JSONL — parser
+MUST NOT use Node `readline`; eval-verified + upstream docs.) This builder is
+shared with §4's provider adapter — one implementation, two consumers.
+
+### 2.4 First-boot warm-up
+
+pi downloads `fd`/`ripgrep` on first run (eval caveat 2). The adapter
+tolerates the delay; `instar doctor` gains a non-blocking note when the pi
+binary is configured but has never booted.
+
+## 3. Phase A — dashboard parity (project item P1.3)
+
+NO dashboard code changes. Verification (tests, not assumption):
+- Integration: spawn pi session (hermetic fixture provider), assert
+  `GET /sessions` lists it with framework `pi-cli`; assert
+  `GET /sessions/:name/output` streams the pane (the eval showed tool
+  execution renders in-pane); assert `POST /sessions/:name/input` round-trips
+  (send prompt → mock-driven tool runs → pane shows `HERMETIC-TOOL-EXEC-OK`).
+- E2E: production-init path boots with `enabledFrameworks: ['claude-code','pi-cli']`
+  and the sessions surface is alive (200, not 503).
+
+## 4. Phase B/C — provider-substrate adapter + routing (P2.1, P2.2)
+
+### 4.1 RPC client (`src/providers/adapters/pi-cli/transport/rpcClient.ts`)
+
+Typed client over child-process stdio: strict-LF JSONL framing; request/
+response correlation by `id`; commands `prompt`, `steer`, `follow_up`,
+`get_state`; typed event union (verified event taxonomy: `agent_start/end`,
+`turn_start/end`, `message_start/update/end` with
+`toolcall_start/delta/end|text_start/delta/end`, `tool_execution_start/
+update/end`, `response`). Session persistence via `--session-dir` +
+`--session-id`.
+
+### 4.2 Provider adapter (`createPiCliAdapter`)
+
+Follows the #873 adapter pattern (mirror `adapters/openai-codex/` shape):
+capabilities `OneShotCompletion`, `AgenticSessionHeadless`,
+`AgenticSessionRpc`, `AgenticSessionInteractive`; registered at boot by
+`registerPiAdapters()` (mirrors `registerAnthropicAdapters()` — idempotent,
+gated on `enabledFrameworks` containing `'pi-cli'` AND pi binary resolvable;
+absent binary degrades to not-registered + doctor note, never a boot failure).
+
+### 4.3 Subscription guard (STRUCTURAL — the additive-only enforcement)
+
+`src/providers/adapters/pi-cli/policy.ts`: provider allowlist evaluated on
+EVERY session/prompt construction:
+
+- DEFAULT DENY for `provider === 'anthropic'` (and any provider whose auth
+  entry is an Anthropic subscription OAuth token): constructing a pi call
+  with an Anthropic provider throws `PiAnthropicRouteError` with the
+  explanation (extra-usage billing ≠ plan limits; use claude-code instead).
+- Override ONLY via explicit `piCli.allowAnthropicProviders: true` in
+  `.instar/config.json` — and even then the call is audit-logged with a
+  cost warning. No env-var or per-call bypass.
+- Unit tests cover both sides of the boundary (deny default, allow+audit on
+  explicit opt-in) per the Testing Integrity semantic-correctness rule.
+
+### 4.4 Component routing
+
+`intelligenceProviderFactory.ts`: `case 'pi-cli'` builds a
+`PiCliIntelligenceProvider` (one-shot headless RPC under the hood) with its
+OWN circuit breaker (per-framework isolation parity). `componentFrameworks`
+accepts `'pi-cli'` in categories/overrides — e.g.
+`{"categories": {"sentinel": "pi-cli"}}` routes sentinels through pi onto
+whatever non-Anthropic provider its config names (Codex/Copilot subscription
+or local). `GET /intelligence/routing` reports it like any framework.
+
+## 5. Phase D — metrics + quota (P2.3)
+
+- Per-feature metrics: `PiCliIntelligenceProvider` reports through the same
+  attribution path as Claude/Codex providers → rows appear in
+  `/metrics/features` (tokens from pi's usage events — verified present in
+  the wire capture).
+- ResourceLedger: pi sessions are tmux sessions → CPU/RSS sampling works
+  unchanged; pi-routed component calls attribute under their component name.
+- Quota: pi adapter exposes provider-reported usage when available;
+  rate-limit fallback mirrors other frameworks (breaker + heuristic
+  fallback, no herd).
+
+## 6. Phase E — optional (P3.1, P3.2; only after §2-5 land + test-as-self)
+
+1. **Event-stream dashboard renderer**: a `pi-rpc` session kind whose
+   transcript view renders from the typed event stream (messages, tool calls,
+   costs) — additive tab/view; tmux view remains default.
+2. **Apprenticeship mentee groundwork**: register `pi-cli` as a valid
+   framework for apprenticeship instances; the hermetic fixture doubles as
+   the mentee's training sandbox.
+
+## 7. Testing (Testing Integrity Standard — all three tiers)
+
+- **Fixture**: `tests/fixtures/pi-mock-provider/` — the eval's scripted-turn
+  mock OpenAI-completions server (tool-call turn, final-text turn,
+  configurable stream delay for steer tests) + models.json template +
+  isolated-HOME harness. Zero credentials, zero network beyond localhost.
+- **Unit**: builders (launch spec shapes incl. session-dir/session-id),
+  JSONL framing parser (incl. U+2028/U+2029-in-string case), policy guard
+  (deny/allow+audit), capability declaration.
+- **Integration**: real pi binary (devDependency, installed with
+  `--ignore-scripts`) against the fixture — RPC one-shot, steer, resume,
+  session listing/injection routes. Skip-with-reason when the binary is
+  unavailable offline (mirrors LLM-dependent test convention).
+- **E2E lifecycle**: production-init boot with pi enabled → routes alive
+  (sessions surface, `/intelligence/routing` shows pi-cli, adapter
+  registered); the Phase-1 "feature is alive" test.
+- **Wiring integrity**: registerPiAdapters deps non-null + real; framework-
+  agnosticism test extended for `pi-cli`.
+- **Migration parity**: config defaults via `migrateConfig()` (existence-
+  checked), CLAUDE.md template section via `migrateClaudeMd()` (content-
+  sniffed), template SHA lint satisfied.
+
+## 8. Ship plan within the 24h run
+
+PR 1: docs (kickoff + eval report + this spec). PR 2: Phase A (§2-3).
+PR 3: Phases B-D (§4-5). Each: fresh-worktree build, CI green, three tiers,
+merge per the established his-word pattern. Then test-as-self proof (deploy
+dist into a throwaway home with pi enabled; live pi session end-to-end via
+the fixture), THEN §6 optional items as time allows. Final honest scoreboard
+to topic 20390; every claim in it `verify-claim`-grade.
+
+## 9. Out of scope (durable record, not silent drops)
+
+- Replacing any Claude Code path (constraint 1).
+- pi-ai library adoption for non-pi internal calls (separate decision later).
+- OAuth flow automation (interactive by nature; documented unverified).
+- Mid-session cross-provider handoff via pi (powerful but no consumer yet).

--- a/docs/specs/_drafts/pi-eval-report.md
+++ b/docs/specs/_drafts/pi-eval-report.md
@@ -1,0 +1,89 @@
+# Pi Hands-On Evaluation Report (P0.1)
+
+> Project: `pi-harness-integration` · Item P0.1 · Evaluated: 2026-06-06 (24h
+> autonomous run, topic 20390) · pi version: **0.78.1** (`@earendil-works/pi-coding-agent`)
+> Method: sandboxed install (`/tmp/pi-eval`, isolated `HOME`), hermetic mock
+> OpenAI-completions provider (zero credentials, zero spend), tmux driving via
+> the same primitives our session layer uses.
+
+## Verdict
+
+**Both integration faces work as documented.** No blocker found for either the
+TUI-in-tmux adapter (P1) or the RPC client (P2). The hermetic-mock technique
+used here is directly reusable as the CI fixture for all adapter tests.
+
+## What was verified hands-on (all PASS)
+
+### RPC face (`pi --mode rpc`, JSONL over stdin/stdout)
+
+| Claim | Result |
+|-------|--------|
+| Starts + answers credential-free (`get_state`) | ✅ structured response incl. sessionId, steering/followUp modes, messageCount |
+| Custom provider via `~/.pi/agent/models.json` | ✅ `openai-completions` mock at localhost picked up by `--provider mock --model mock-model` |
+| Full agent loop | ✅ prompt → streamed tool-call → REAL `bash` execution in cwd → tool result returned to LLM → final text → `agent_end` (26 events) |
+| Event stream | ✅ typed JSONL: `agent_start/turn_start/message_start/message_update(toolcall_delta,text_delta)/tool_execution_start|update|end/turn_end/agent_end` + `response` correlation by `id` |
+| Mid-stream steering | ✅ `steer` accepted during streaming (`success:true`) and the steer message entered the conversation (verified in turn history) |
+| Session persistence | ✅ JSONL session file written under `--session-dir` |
+| Resume | ✅ `--continue` resumed the same sessionId with messageCount=5 carried over |
+
+### TUI face (interactive `pi` inside tmux — the v1 adapter path)
+
+| Claim | Result |
+|-------|--------|
+| Renders inside tmux | ✅ banner, input box, status line (cwd, ↑↓ tokens, context %, model name) |
+| Standard injection works | ✅ `tmux send-keys "<text>"` + separate `Enter` submits FIRST TRY — no Gemini-style auto-submit box quirk |
+| Tool execution visible in pane | ✅ `$ echo …` + output + `Took 0.0s` rendered — dashboard streaming will show real work |
+| Completion detectable | ✅ idle state = input box redrawn + status line stable; token counters (`↑250 ↓30`) give progress signal |
+
+### Wire format (captured from the mock — ground truth)
+
+- System prompt: **2,494 chars (~624 tokens)** — matches the "~1k token" minimalism claim.
+- Tools: exactly **4** (`read`, `bash`, `edit`, `write`), standard OpenAI function-calling schemas.
+- Requests are plain OpenAI-completions with `stream:true`; usage chunks carried.
+
+## Adapter-relevant caveats found
+
+1. **tmux extended-keys**: pi warns `tmux extended-keys is off. Modified Enter
+   keys may not work` — plain Enter works fine (verified), but the adapter
+   should set `extended-keys on` for the pi session or document the
+   degradation (Shift+Enter newline etc.).
+2. **First-boot binary downloads**: pi fetches `fd` + `ripgrep` from GitHub on
+   first run (403'd in the sandbox; degraded gracefully). Adapter should
+   pre-warm once per machine or tolerate the 30s first-boot delay.
+3. **zsh `=word` trap (ours, not pi's)**: unquoted `=session:` tmux targets
+   get eaten by zsh's `=cmd` expansion when commands run through `sh -c`
+   layers. Our adapter code paths quote these; eval scripts must too.
+4. **Session files are per-cwd-keyed** (project sessions); `--session-dir`
+   overrides location. The adapter should pin `--session-dir` into the agent
+   home state dir for durability + reap-log coherence.
+
+## NOT verified hands-on (documented honestly)
+
+- **Subscription OAuth flows** (Codex/ChatGPT, Claude Pro/Max, GitHub
+  Copilot): require interactive browser login; cannot be exercised headlessly
+  in a sandbox. Docs state Codex usage is officially endorsed by OpenAI and
+  Claude Pro/Max via third-party harness bills as **per-token extra usage,
+  not plan limits** (consistent with Anthropic policy). The P2.2 subscription
+  guard treats these as policy inputs, not assumptions: Claude-via-pi is
+  blocked by default regardless.
+- **Real-provider behavior differences** (Anthropic/OpenAI native APIs vs the
+  openai-completions mock). Mitigation: the adapter is provider-agnostic by
+  construction (pi owns provider quirks — that's the point of adopting it).
+
+## Reusable artifacts produced
+
+- `/tmp/pi-eval/mock-openai.mjs` — scripted-turn mock provider (tool-call turn
+  + final-text turn + configurable stream delay). **This is the CI fixture
+  design for every adapter test tier.**
+- `/tmp/pi-eval/home/.pi/agent/models.json` — custom-provider config template.
+- Captured request/event logs (`mock-requests.jsonl`, `rpc-events.jsonl`,
+  `rpc-steer.jsonl`) for schema reference.
+
+## Conclusion for P0.2 (master spec)
+
+Proceed as scoped. v1 TUI-in-tmux adapter is LOW risk (standard send-keys
+works; status line is scrapeable; extended-keys nit). RPC client is LOW risk
+(protocol behaves exactly as documented; strict-LF framing note from docs
+applies — do not use Node `readline`). The hermetic mock makes the whole
+adapter testable in CI without credentials — Testing Integrity Standard
+compliant by design.

--- a/docs/specs/_drafts/pi-harness-integration-kickoff.md
+++ b/docs/specs/_drafts/pi-harness-integration-kickoff.md
@@ -1,0 +1,100 @@
+# Pi Harness Integration — Kickoff / Requirements Capture
+
+> Status: kickoff draft (requirements capture for the `pi-harness-integration`
+> project). Research session: 2026-06-05/06, topic 20390. Approved direction by
+> Justin 2026-06-06 ("Lets make this an official initiative/project and start
+> scoping it out!"). Tracked follow-through: CMT-1108.
+
+## What pi is
+
+**pi** is a minimal coding-agent harness by Mario Zechner (badlogic, libGDX
+creator), acquired by Earendil Works in April 2026 (Mario joined; open-core:
+MIT core, Fair-Source coordination layers). ~60k GitHub stars, 2,100+
+community packages, powers OpenClaw, endorsed by Armin Ronacher.
+Repo: `badlogic/pi-mono` → `earendil-works/pi`; npm scope
+`@earendil-works/pi-*`; docs at `pi.dev/docs/latest`.
+
+Architecture (four packages):
+
+- **pi-ai** — unified multi-provider LLM API (Anthropic, OpenAI, Google, xAI,
+  Groq, Cerebras, OpenRouter, self-hosted/OpenAI-compatible; ~25 providers),
+  streaming, TypeBox tool schemas, cross-provider mid-session handoff, token +
+  cost tracking, auto-generated model registry.
+- **pi-agent-core** — minimal agent loop (tool exec, validation, event
+  streaming, message queuing).
+- **pi-coding-agent** — interactive CLI **plus** `--mode rpc` (JSONL over
+  stdin/stdout) **plus** a Node SDK (`createAgentSession`/`AgentSession`).
+- **pi-tui** — terminal UI lib (differential rendering).
+
+Philosophy: 4 tools (read/write/edit/bash), ~1k-token system prompt, no MCP,
+no subagents, NO permission system (containerize instead), full context
+observability.
+
+## Why Instar cares (the deltas)
+
+1. **RPC mode is the interface our tmux layer hand-reconstructs.** Structured
+   JSONL: `prompt`, `steer` (mid-stream), `follow_up`, session
+   persistence/resume, structured event stream — vs pane-scraping +
+   completion-detection heuristics + per-CLI quirks (Gemini auto-submit box,
+   codex wedges). A pi adapter would be the cleanest framework integration we
+   have and a reference shape for the interactive-pool work.
+2. **TypeScript SDK embeds in-process** — relevant to per-component framework
+   routing and internal LLM calls.
+3. **Subscription OAuth** — ChatGPT Plus/Pro (Codex; officially endorsed by
+   OpenAI) and GitHub Copilot (NEW leverage for us). ⚠ Claude Pro/Max via pi
+   bills as per-token **extra usage**, NOT plan limits — Claude Code remains
+   the only plan-limits path for Claude.
+4. **Complementary, not competitive** — pi deliberately excludes everything
+   Instar is (persistence, scheduling, messaging, multi-user, gates,
+   monitoring). Earendil monetizes coordination layers (adjacent — watch).
+
+## Hard constraints (Justin, 2026-06-06, topic 20390)
+
+- **Additive only — never forfeit subscription leverage.** Every framework we
+  support today (Claude Code, Codex, Gemini CLI) is driven through the user's
+  subscriptions; pi enters as one more adapter next to them, never instead.
+  Claude work stays on Claude Code (plan limits). A routing policy guard must
+  make Claude-via-pi structurally non-selectable by default.
+- **Dashboard parity.** Session streaming + direct access must not regress:
+  adapter v1 runs pi's interactive TUI in tmux (identical dashboard
+  behavior); the RPC face starts with internal background work; an
+  event-stream dashboard renderer is an optional later upgrade, never a
+  replacement.
+- **Sequencing.** Build rounds land AFTER the June-15 interactive-only /
+  subscription-only work ships (CMT-1105 / topic 9984). Scoping + hands-on
+  evaluation may proceed now.
+
+## Justin's stated goals
+
+- Efficiency ("really hoping this can help us be more efficient").
+- **Multiple frameworks for a single agent** — e.g. main work on Claude Code,
+  sentinels through Codex. NOTE: per-component framework routing
+  (`sessions.componentFrameworks`, `GET /intelligence/routing`) already ships
+  this for claude-code/codex-cli; this project extends the routing surface
+  with pi as a target and widens the provider set (Copilot subscription,
+  multi-provider fallback) rather than starting from zero.
+
+## Risks
+
+- Startup-owned (Earendil) with adjacent monetization; MIT core mitigates
+  (pin/fork). Use at the edge (one adapter among several), never as the
+  foundation.
+- Fast-moving project — pin versions; supply-chain posture upstream is good
+  (exact pins, shrinkwrap, audit CI).
+- No permission system in pi — Instar's gate layer (external-operation-gate,
+  dangerous-command-guard, SafeGit/SafeFs) must wrap pi sessions like any
+  other framework; containerization optional later.
+- Claims to verify hands-on before the master spec freezes: subscription OAuth
+  flows actually work as documented (Codex, Copilot), Claude extra-usage
+  billing reality, RPC session resume fidelity, TUI-in-tmux behavior under our
+  injector.
+
+## Sources
+
+- mariozechner.at/posts/2025-11-30-pi-coding-agent/ (design philosophy)
+- github.com/badlogic/pi-mono — docs: rpc.md, sdk.md, providers.md, sessions.md
+- mariozechner.at/posts/2026-04-08-ive-sold-out/ (Earendil acquisition)
+- syntax.fm/show/976 (Pi w/ Armin Ronacher & Mario Zechner)
+- lucumr.pocoo.org/2026/1/31/pi/ (Armin Ronacher)
+- Video that triggered the research: youtu.be/FJxgz5pN4wU ("Pi Agent explained
+  in 6min", Caleb Writes Code, 2026-06-03)


### PR DESCRIPTION
## Project pi-harness-integration — Tier 1 (P0.1 + P0.2)

Justin-approved initiative (topic 20390): integrate the pi agent harness as an ADDITIVE framework target. This PR ships the Tier 1 docs:

- **Kickoff requirements** — what pi is (earendil-works/pi, 60k★), the deltas for instar (RPC protocol, TS SDK, subscription OAuth for Codex/Copilot), Justin's hard constraints (additive-only / never forfeit subscription paths / dashboard parity), risks.
- **P0.1 hands-on eval report** — pi 0.78.1 verified in a sandbox with a hermetic mock provider (zero credentials): full RPC agent loop incl. REAL tool execution, mid-stream steering, session persist/resume; TUI-in-tmux renders + first-try send-keys injection + scrapeable status line. Caveats documented (extended-keys, first-boot downloads, OAuth not headlessly verifiable).
- **P0.2 master spec** — `pi-cli` as fourth framework shipped DARK behind `enabledFrameworks`; TUI-in-tmux launch builder; provider-substrate adapter (#873 pattern) with typed RPC client; **structural subscription guard: Anthropic-via-pi DENIED by default** (extra-usage billing can never be silently selected); routing/metrics integration; three-tier test plan around a hermetic fixture.

Docs-only — no behavior change. Build PRs (Phase A, B-D) follow in the same 24h autonomous run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## ELI16

We're adding support for a new AI coding tool called pi. This PR is JUST the homework before any code: a write-up of what pi is and why it matters to us, a lab report from actually installing and driving it in a sandbox (it passed everything we tested, with zero credentials used), and the blueprint for how we'll plug it in. The blueprint's most important rule comes straight from Justin: pi must only ever ADD options — it can never replace the subscription-based access we already have. The blueprint makes that rule actual code: trying to route Claude work through pi will throw an error by default, because that path would cost real money per token instead of using the plan we already pay for. Docs only — nothing changes for any running agent.