### PR TITLE
fix(multi-machine): heartbeat-writer guard — a liveness write failure can no longer crash the awake holder (P19)

### DIFF
--- a/.instar/instar-dev-decisions/2026-06-06T03-33-35-773Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-06-06T03-33-35-773Z-unknown.json
@@ -1,0 +1,18 @@
+{
+  "ts": "2026-06-06T03:33:35.773Z",
+  "slug": "unknown",
+  "suggestedTier": 2,
+  "declaredTier": 2,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "new capability: new exported class / subsystem added"
+  ],
+  "belowFloor": false,
+  "files": 2,
+  "loc": 151,
+  "causalAutopsy": {
+    "origin": "latent",
+    "notes": "The unguarded writeHeartbeat() in the 2-min timer tick shipped with the original multi-machine heartbeat implementation — a designed-in crash vector (raw fs throw escaping a timer callback into the FATAL uncaughtException path), never observed live because heartbeat-path disk failures are rare. Surfaced by the CMT-1109 loop-safety audit; the audit lead itself misdiagnosed it as silent failure — grounding at source found the crash vector."
+  },
+  "verdict": "pass"
+}

--- a/docs/specs/heartbeat-writer-signal.eli16.md
+++ b/docs/specs/heartbeat-writer-signal.eli16.md
@@ -1,0 +1,41 @@
+# ELI16 — The "I'm alive" file can't take the machine down anymore
+
+## The problem
+
+When Echo runs on two machines, the one in charge writes a tiny "I'm alive"
+file every 2 minutes so the other machine knows not to take over. The audit
+flagged this writer as "fails silently." Reading the actual code showed
+something worse: a failed write didn't fail silently — it threw an error that
+**crashed the whole server**. A full disk or a permissions hiccup at the wrong
+moment would take down the machine that was actively serving you, every 2
+minutes, until the disk recovered. And during a takeover, a failed first write
+left the machine half-promoted: marked as "in charge" everywhere, but with the
+alive-file writer never actually started.
+
+## The fix
+
+Three situations, three right answers:
+
+1. **The every-2-minutes write** now catches failures: one log line when writes
+   start failing, one health-log note if it's still failing after 6 minutes
+   (deliberately before the ~15-minute point where the other machine would
+   assume death and take over), one line on recovery. It never stops trying —
+   this writer is the machine's voice, and persistence is the point.
+2. **Taking charge** is now all-or-nothing: if the very first "I'm alive" write
+   fails during a takeover, the takeover is cleanly cancelled and rolled back —
+   a machine that can't announce itself doesn't get to silently lead. (This one
+   came from the independent reviewer, who caught my first draft letting a
+   voiceless takeover complete.)
+3. The reusable one-note-per-outage logic got extracted into a small shared
+   piece — it's the same shape we've now shipped four times tonight, so future
+   loops stop re-inventing it.
+
+Bonus: the test suite caught a real bug before shipping — the "no outage"
+marker collided with an outage starting at exactly time zero. Same class of
+bug as an old hard-won lesson ("zero is a real value, not an empty one").
+
+## What changes for you
+
+A disk hiccup can no longer crash the machine that's serving you, takeovers
+can't half-complete, and a machine whose alive-signal is failing tells you
+within 6 minutes instead of letting the other machine discover it by surprise.

--- a/docs/specs/heartbeat-writer-signal.md
+++ b/docs/specs/heartbeat-writer-signal.md
@@ -1,0 +1,71 @@
+---
+title: Heartbeat-Writer Guard — a liveness write failure can no longer crash the awake holder, and never fails silently
+status: converged
+tier: 2
+parent-principle: "No Unbounded Loops — Every Repeating Behavior Carries Its Own Brakes"
+review-convergence: self-converged against the loop-safety audit lead (CMT-1109) — grounding revealed the gap is WORSE than the audit's "silent failure" claim, since HeartbeatManager.writeHeartbeat() throws raw fs errors and the 2-min timer tick called it unguarded (uncaughtException → server FATAL path → a transient ENOSPC crashes the awake holder); validated by an adversarial second-pass whose narrow OBJECT on the promoteToAwake call site (silent completion of a voiceless promotion) was APPLIED pre-commit as rollback-and-rethrow.
+approved: true
+---
+
+# Heartbeat-Writer Guard
+
+> Approval ground: Justin's autonomous-session direction (topic "Resource
+> Limitation Mitigation", 2026-06-06): "enter an autonomous session to complete
+> the remaining tasks on the audit list," with standing merge-on-green approval.
+
+## Problem (grounded — worse than the audit lead)
+
+The audit flagged the heartbeat writer as "silent failure every 2min forever."
+Grounding showed the opposite and worse: `HeartbeatManager.writeHeartbeat()`
+throws raw fs errors (`mkdirSync`/`writeFileSync`/`renameSync` unguarded), and
+all three coordinator call paths invoked it raw. In the 2-min `setInterval`
+tick, a throw escapes as an `uncaughtException`; `server.ts` treats fs errors
+as FATAL — so **a transient disk error (ENOSPC, permissions) crashed the awake
+holder**, the worst possible per-attempt cost under P19. In `promoteToAwake`,
+a throw aborted promotion midway (role flipped + registry updated, writer
+never started).
+
+## Design
+
+Three call sites, three deliberate behaviors (the reviewer's framing):
+
+1. **Periodic tick** → `writeHeartbeatGuarded()`: try/catch +
+   `FailureEpisodeLatch` (new pure core class, the canonical extraction of the
+   episode-latch pattern used three times tonight): first-failure log, ONE
+   `DegradationReporter` signal per episode at 6min sustained (3 failed cycles
+   — deliberately BEFORE the peer's 15min heartbeat-expiry failover horizon,
+   verified against `DEFAULT_FAILOVER_TIMEOUT_MS`), recovery log + re-arm. The
+   writer keeps attempting every tick forever — it is the awake machine's
+   liveness voice (ETERNAL SENTINEL, declared per P19 condition 1).
+2. **Boot-immediate write in `startHeartbeatWriter`** → same guarded path.
+3. **`promoteToAwake`'s initial write** → rollback-and-rethrow (the reviewer's
+   OBJECT, applied): a promotion that cannot voice its liveness must ABORT
+   CLEANLY — `_role` and the registry are rolled back to the prior role before
+   rethrowing — never silently complete into a voiceless awake, and never
+   (pre-fix) die mid-transition with the role already flipped.
+
+`FailureEpisodeLatch` uses **null sentinels, not 0** — the P19
+sustained-failure test caught a zero-clock episode colliding with the
+"no episode" sentinel before it ever shipped (the Dawn "zero is falsy" lesson,
+again).
+
+CLI one-shot callers (`machine.ts` wakeup/handoff) keep raw calls — no timer
+vector, errors surface naturally to the CLI (reviewer probe 2). In lease-attached
+mode the fenced lease, not the heartbeat file, is the failover authority
+(`checkHeartbeatAndAct` returns early into `tickLease`), so the guarded path's
+dual-awake window is lease-resolved; heartbeat-only mode is bounded by
+`shouldDemote` on the next check cycle (reviewer probe 1 analysis).
+
+## Tests
+
+`tests/unit/FailureEpisodeLatch.test.ts` — 10 green: episode semantics, the
+P19 sustained-failure bound (a WEEK of 2-min-cadence failures → exactly 1
+signal and 1 first-failure line), threshold edge, recovery/re-arm, accuracy,
+plus source-shape wiring pins (exactly two sanctioned raw call sites — the
+guarded funnel + the promote-abort block with its rollback; latch constructed;
+degradation feature key; sentinel declaration). Neighbor suites green
+(multi-machine-coordinator 22, leasePull 3); tsc clean.
+
+## Rollback
+
+Revert; no persistent state, no config, no schema.

--- a/src/core/FailureEpisodeLatch.ts
+++ b/src/core/FailureEpisodeLatch.ts
@@ -1,0 +1,78 @@
+/**
+ * FailureEpisodeLatch — the generic failure-episode accountant behind the
+ * "No Unbounded Loops" (P19) Eternal Sentinel condition 4: a loop that retries
+ * forever must (a) log state CHANGES, not attempts, and (b) raise ONE
+ * sustained-failure signal per episode, then stay quiet while retrying.
+ *
+ * Third night-of-2026-06-05 incarnation of the episode-latch shape
+ * (SlowRetrySentinelEscalation in lifeline; the inline live-tail stale latch)
+ * — extracted to core as the canonical reusable form so future loops stop
+ * re-implementing it <!-- tracked: CMT-1109 -->. Pure: injectable clock, three
+ * fields of state, no I/O.
+ *
+ * Usage per attempt:
+ *   const f = latch.recordFailure();         // on a failed attempt
+ *   if (f.firstOfEpisode) log("X became failing: ...");
+ *   if (f.shouldSignal)  reportDegradationOnce(...);   // fires ONCE per episode
+ *   ...
+ *   const s = latch.recordSuccess();         // on a successful attempt
+ *   if (s.recovered) log(`X recovered after ${s.failures} failures`);
+ */
+
+export interface FailureEpisodeLatchOpts {
+  /** Sustained-failure threshold before the one-per-episode signal. */
+  signalAfterMs: number;
+  now?: () => number;
+}
+
+export interface FailureRecord {
+  /** True exactly once — the attempt that started this episode. */
+  firstOfEpisode: boolean;
+  /** True exactly once per episode — the first failed attempt at/after the threshold. */
+  shouldSignal: boolean;
+  /** Episode duration so far (ms). */
+  failingForMs: number;
+  /** Consecutive failures including this one. */
+  failures: number;
+}
+
+export class FailureEpisodeLatch {
+  private readonly signalAfterMs: number;
+  private readonly now: () => number;
+  // null sentinels, NOT 0 — an episode legitimately starting at clock value 0
+  // (tests with injected clocks; epoch-0 edge) must not collide with the
+  // "no episode" state. (The Dawn "zero is falsy" lesson, caught by the P19
+  // sustained-failure test before this ever shipped.)
+  private failingSince: number | null = null;
+  private failures = 0;
+  /** Episode key (failingSince value) the signal already fired for — null = armed. */
+  private signaledFor: number | null = null;
+
+  constructor(opts: FailureEpisodeLatchOpts) {
+    this.signalAfterMs = opts.signalAfterMs;
+    this.now = opts.now ?? Date.now;
+  }
+
+  recordFailure(): FailureRecord {
+    const now = this.now();
+    const firstOfEpisode = this.failingSince === null;
+    if (this.failingSince === null) this.failingSince = now;
+    this.failures++;
+    const failingForMs = now - this.failingSince;
+    let shouldSignal = false;
+    if (failingForMs >= this.signalAfterMs && this.signaledFor !== this.failingSince) {
+      this.signaledFor = this.failingSince;
+      shouldSignal = true;
+    }
+    return { firstOfEpisode, shouldSignal, failingForMs, failures: this.failures };
+  }
+
+  recordSuccess(): { recovered: boolean; failures: number } {
+    const failures = this.failures;
+    const recovered = failures > 0;
+    this.failingSince = null;
+    this.failures = 0;
+    this.signaledFor = null;
+    return { recovered, failures };
+  }
+}

--- a/src/core/MultiMachineCoordinator.ts
+++ b/src/core/MultiMachineCoordinator.ts
@@ -24,6 +24,8 @@ import { NonceStore } from './NonceStore.js';
 import type { StateManager } from './StateManager.js';
 import type { LeaseCoordinator } from './LeaseCoordinator.js';
 import { SEAMLESSNESS_PROTOCOL_VERSION } from './seamlessnessConfig.js';
+import { FailureEpisodeLatch } from './FailureEpisodeLatch.js';
+import { DegradationReporter } from '../monitoring/DegradationReporter.js';
 import type { MachineRole, MachineIdentity, MultiMachineConfig, CoordinationMode } from './types.js';
 
 /** Observability shape for /health.multiMachine.syncStatus (spec §11). */
@@ -80,6 +82,20 @@ export class MultiMachineCoordinator extends EventEmitter {
   private _identity: MachineIdentity | null = null;
   private _enabled: boolean = false;
   private heartbeatWriteTimer: ReturnType<typeof setInterval> | null = null;
+  /**
+   * Heartbeat-write failure episode accounting ("No Unbounded Loops" / P19,
+   * Eternal Sentinel condition 4). writeHeartbeat() throws raw fs errors
+   * (ENOSPC, EACCES) — pre-fix, a throw inside the 2-min timer tick escaped as
+   * an uncaughtException and CRASHED the awake holder (the worst possible cost
+   * for one failed attempt), while a hypothetical swallowed failure would have
+   * gone silent until a peer force-failed-over. Now: each tick's write is
+   * guarded, the first failure of an episode logs once, a sustained episode
+   * raises ONE degradation signal (before the peer failover horizon), recovery
+   * logs once and re-arms. The write keeps being attempted every tick forever
+   * — this writer is the awake machine's liveness voice; persistence is the
+   * point.
+   */
+  private readonly hbWriteEpisode = new FailureEpisodeLatch({ signalAfterMs: 6 * 60_000 });
   private heartbeatCheckTimer: ReturnType<typeof setInterval> | null = null;
   /** Integrated-Being v1 — tracks whether we've already emitted the
    *  per-machine-ledger warning this boot. Spec §Multi-machine. */
@@ -340,8 +356,20 @@ export class MultiMachineCoordinator extends EventEmitter {
     // Update registry
     this.identityManager.updateRole(this._identity.machineId, 'awake');
 
-    // Write initial heartbeat
-    this.heartbeatManager.writeHeartbeat();
+    // Write initial heartbeat. This is the ONE call site where a write failure
+    // is NOT retryable-in-place (second-pass reviewer): a promotion that cannot
+    // voice its liveness must ABORT CLEANLY — completing it silently would
+    // leave this machine serving as awake with no heartbeat, and (pre-fix) a
+    // raw throw left the role flipped + registry updated with no writer
+    // running. Roll both back, then rethrow for the caller.
+    try {
+      this.heartbeatManager.writeHeartbeat();
+    } catch (err) {
+      this._role = oldRole;
+      this.identityManager.updateRole(this._identity.machineId, oldRole);
+      console.error(`[MultiMachine] promotion aborted — initial heartbeat write failed (${err instanceof Error ? err.message : String(err)}); role rolled back to '${oldRole}'`);
+      throw err;
+    }
 
     // Start heartbeat writer
     this.startHeartbeatWriter();
@@ -787,12 +815,12 @@ export class MultiMachineCoordinator extends EventEmitter {
     }
 
     // Write immediately
-    this.heartbeatManager.writeHeartbeat();
+    this.writeHeartbeatGuarded();
 
     // Then every 2 minutes
     this.heartbeatWriteTimer = setInterval(() => {
       if (this._role === 'awake') {
-        this.heartbeatManager.writeHeartbeat();
+        this.writeHeartbeatGuarded();
         // Touch lastSeen in registry
         if (this._identity) {
           try {
@@ -806,6 +834,43 @@ export class MultiMachineCoordinator extends EventEmitter {
 
     if (this.heartbeatWriteTimer.unref) {
       this.heartbeatWriteTimer.unref();
+    }
+  }
+
+  /**
+   * ETERNAL SENTINEL (declared per "No Unbounded Loops" / P19): the heartbeat
+   * writer is the awake machine's liveness voice — it must keep attempting
+   * every tick forever (rate floor = HEARTBEAT_WRITE_INTERVAL_MS, constant
+   * cost). Its brakes live here: a write failure can no longer escape the
+   * timer tick as an uncaughtException (pre-fix: ENOSPC at the wrong moment
+   * CRASHED the awake holder), failure logging is state-change-bounded (first
+   * + recovery, one line each), and a sustained episode raises ONE degradation
+   * signal — sized at 6min (3 failed cycles) so the operator hears about it
+   * BEFORE the peer's ~15min heartbeat-expiry failover horizon.
+   */
+  private writeHeartbeatGuarded(): void {
+    try {
+      this.heartbeatManager.writeHeartbeat();
+      const s = this.hbWriteEpisode.recordSuccess();
+      if (s.recovered) {
+        console.log(`[MultiMachine] heartbeat write recovered after ${s.failures} consecutive failures`);
+      }
+    } catch (err) {
+      const f = this.hbWriteEpisode.recordFailure();
+      const msg = err instanceof Error ? err.message : String(err);
+      if (f.firstOfEpisode) {
+        console.error(`[MultiMachine] heartbeat write FAILED (${msg}) — retrying every ${HEARTBEAT_WRITE_INTERVAL_MS / 60_000}min; peers may failover if this persists`);
+      }
+      if (f.shouldSignal) {
+        console.error(`[MultiMachine] heartbeat write failing for ${Math.round(f.failingForMs / 60_000)}min (${f.failures} consecutive) — signaling once; retries continue`);
+        DegradationReporter.getInstance().report({
+          feature: 'MultiMachine.heartbeatWrite',
+          primary: "Awake machine persists its liveness heartbeat so peers don't failover",
+          fallback: `Heartbeat writes failing for ~${Math.round(f.failingForMs / 60_000)}min (${f.failures} consecutive: ${msg}); retries continue every ${HEARTBEAT_WRITE_INTERVAL_MS / 60_000}min`,
+          reason: 'Heartbeat file write throwing (disk full / permissions / path issue)',
+          impact: 'If this persists past the heartbeat expiry window, a standby peer will treat this machine as dead and fail over while it is still serving.',
+        });
+      }
     }
   }
 

--- a/tests/unit/FailureEpisodeLatch.test.ts
+++ b/tests/unit/FailureEpisodeLatch.test.ts
@@ -1,0 +1,125 @@
+/**
+ * Tier-1 tests for FailureEpisodeLatch — the canonical episode-latch behind
+ * P19 Eternal Sentinel condition 4 (state-change logging + one signal per
+ * sustained-failure episode) — plus wiring pins for its first consumer: the
+ * MultiMachineCoordinator heartbeat writer, whose unguarded writeHeartbeat()
+ * throw inside the 2-min timer tick previously CRASHED the awake holder
+ * (uncaughtException → FATAL path) on a transient fs error.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { FailureEpisodeLatch } from '../../src/core/FailureEpisodeLatch.js';
+
+const MIN = 60_000;
+
+function make(signalAfterMs: number) {
+  let nowMs = 0;
+  const latch = new FailureEpisodeLatch({ signalAfterMs, now: () => nowMs });
+  return { latch, setNow: (t: number) => { nowMs = t; } };
+}
+
+describe('FailureEpisodeLatch', () => {
+  it('first failure of an episode is marked firstOfEpisode exactly once', () => {
+    const { latch, setNow } = make(10 * MIN);
+    setNow(1_000);
+    expect(latch.recordFailure().firstOfEpisode).toBe(true);
+    setNow(2 * MIN);
+    expect(latch.recordFailure().firstOfEpisode).toBe(false);
+    expect(latch.recordFailure().firstOfEpisode).toBe(false);
+  });
+
+  it('SUSTAINED-FAILURE BOUND (P19): a week of 2-min-cadence failures signals exactly ONCE', () => {
+    const { latch, setNow } = make(6 * MIN);
+    let signals = 0;
+    let firsts = 0;
+    for (let t = 0; t <= 7 * 24 * 60 * MIN; t += 2 * MIN) {
+      setNow(t);
+      const f = latch.recordFailure();
+      if (f.shouldSignal) signals++;
+      if (f.firstOfEpisode) firsts++;
+    }
+    expect(signals).toBe(1);
+    expect(firsts).toBe(1); // bounded logging: one first-failure line, one signal — for a WEEK of failures
+  });
+
+  it('does not signal before the threshold', () => {
+    const { latch, setNow } = make(6 * MIN);
+    for (const t of [0, 2 * MIN, 4 * MIN]) {
+      setNow(t);
+      expect(latch.recordFailure().shouldSignal).toBe(false);
+    }
+    setNow(6 * MIN);
+    expect(latch.recordFailure().shouldSignal).toBe(true);
+  });
+
+  it('recovery reports the streak once, then steady success is silent', () => {
+    const { latch, setNow } = make(6 * MIN);
+    setNow(0); latch.recordFailure();
+    setNow(2 * MIN); latch.recordFailure();
+    const s = latch.recordSuccess();
+    expect(s.recovered).toBe(true);
+    expect(s.failures).toBe(2);
+    expect(latch.recordSuccess().recovered).toBe(false);
+    expect(latch.recordSuccess().recovered).toBe(false);
+  });
+
+  it('a new episode after recovery signals again (full re-arm)', () => {
+    const { latch, setNow } = make(4 * MIN);
+    setNow(0); latch.recordFailure();
+    setNow(4 * MIN);
+    expect(latch.recordFailure().shouldSignal).toBe(true);
+    latch.recordSuccess();
+    setNow(20 * MIN);
+    expect(latch.recordFailure().firstOfEpisode).toBe(true);
+    setNow(24 * MIN);
+    expect(latch.recordFailure().shouldSignal).toBe(true);
+  });
+
+  it('failingForMs and failures count are accurate', () => {
+    const { latch, setNow } = make(100 * MIN);
+    setNow(5_000); latch.recordFailure();
+    setNow(5_000 + 3 * MIN);
+    const f = latch.recordFailure();
+    expect(f.failingForMs).toBe(3 * MIN);
+    expect(f.failures).toBe(2);
+  });
+});
+
+describe('wiring integrity: heartbeat writer uses the guarded path (source-shape pins)', () => {
+  const fs = require('node:fs') as typeof import('node:fs');
+  const path = require('node:path') as typeof import('node:path');
+  const src = fs.readFileSync(path.join(process.cwd(), 'src/core/MultiMachineCoordinator.ts'), 'utf-8');
+
+  it('raw writeHeartbeat() calls exist ONLY in the two sanctioned sites (guarded funnel + promote-abort)', () => {
+    // The timer-tick crash vector requires every PERIODIC write to go through
+    // writeHeartbeatGuarded. Exactly two raw calls are sanctioned:
+    // 1. inside writeHeartbeatGuarded's try (the funnel itself);
+    // 2. inside promoteToAwake's abort-clean block (second-pass reviewer: a
+    //    promotion that cannot write its liveness must rollback-and-rethrow,
+    //    NOT silently complete) — which sits inside its own try with a
+    //    role-rollback catch.
+    const rawCalls = src.split('\n').filter((l) => l.includes('this.heartbeatManager.writeHeartbeat()'));
+    expect(rawCalls).toHaveLength(2);
+    const guardedIdx = src.indexOf('private writeHeartbeatGuarded()');
+    expect(guardedIdx).toBeGreaterThan(0);
+    // The promote-abort site must carry the rollback (not a bare raw call).
+    const promoteIdx = src.indexOf('promotion aborted — initial heartbeat write failed');
+    expect(promoteIdx).toBeGreaterThan(0);
+    const rollbackIdx = src.indexOf('this._role = oldRole;');
+    expect(rollbackIdx).toBeGreaterThan(0);
+  });
+
+  it('both writer call sites (boot-immediate + timer tick) use the guarded path', () => {
+    const matches = src.match(/this\.writeHeartbeatGuarded\(\)/g) ?? [];
+    expect(matches.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('the episode latch is constructed and drives a DegradationReporter signal', () => {
+    expect(src).toContain('new FailureEpisodeLatch({ signalAfterMs: 6 * 60_000 })');
+    expect(src).toContain("feature: 'MultiMachine.heartbeatWrite'");
+  });
+
+  it('the writer is DECLARED an eternal sentinel (P19 condition 1)', () => {
+    expect(src).toContain('ETERNAL SENTINEL (declared per "No Unbounded Loops" / P19)');
+  });
+});

--- a/upgrades/next/heartbeat-writer-signal.md
+++ b/upgrades/next/heartbeat-writer-signal.md
@@ -1,0 +1,52 @@
+---
+bump: patch
+---
+
+## What Changed
+
+Audit fix #4 under "No Unbounded Loops" (P19): the multi-machine heartbeat
+writer. Grounding revealed the audit lead ("silent failure") was backwards and
+worse — `HeartbeatManager.writeHeartbeat()` throws raw fs errors and the 2-min
+timer tick called it UNGUARDED, so a transient disk error (ENOSPC/EACCES)
+escaped as an uncaughtException and CRASHED the awake holder; in
+`promoteToAwake` a throw aborted promotion midway (role flipped, writer never
+started). Now: the periodic + boot writes go through a guarded funnel with the
+new `FailureEpisodeLatch` (pure core class — the canonical extraction of
+tonight's episode-latch pattern): first-failure log, one DegradationReporter
+signal per episode at 6min sustained (before the peer's 15min failover
+horizon), recovery log + re-arm, retries forever (declared Eternal Sentinel).
+`promoteToAwake`'s initial write is rollback-and-rethrow per the adversarial
+reviewer's finding: a promotion that cannot voice its liveness aborts cleanly
+(role + registry rolled back) instead of silently completing voiceless.
+
+## What to Tell Your User
+
+If you run me on more than one machine: a disk hiccup can no longer crash the
+machine that's actively serving you (previously a full disk at the wrong
+moment did exactly that, every 2 minutes), machine takeovers can't
+half-complete anymore, and if my "I'm alive" signal ever starts failing you
+get a health-log note within 6 minutes — before the other machine would
+assume I'm dead and take over.
+
+## Summary of New Capabilities
+
+- Heartbeat-write resilience: transient write failures are absorbed, bounded-
+  logged, and surfaced once per outage (`MultiMachine.heartbeatWrite` in the
+  degradation log); clean promotion abort on a failed initial write. No
+  configuration needed.
+- `FailureEpisodeLatch` (core): reusable episode-latch for P19 condition-4
+  signals — first/threshold-once/recovery accounting, null-sentinel-safe.
+
+## Evidence
+
+Loop-safety audit lead (CMT-1109) re-grounded at source: unguarded
+`writeHeartbeat()` in the `setInterval` tick + `server.ts`'s FATAL
+uncaughtException path for fs errors = crash vector (worse than the claimed
+silence). Adversarial second-pass: narrow OBJECT on the promote call site —
+APPLIED pre-commit (rollback-and-rethrow); probes 2–4 CONCUR (CLI one-shot raw
+calls safe; 6min < 15min failover horizon verified against
+DEFAULT_FAILOVER_TIMEOUT_MS; DegradationReporter cannot throw into the catch).
+Tests: 10 green in FailureEpisodeLatch.test.ts incl. the P19 bound (a week of
+2-min failures → exactly 1 signal) — which caught a real zero-sentinel bug
+pre-ship — + wiring pins (exactly two sanctioned raw call sites); neighbor
+suites green (coordinator 22, leasePull 3); tsc clean.

--- a/upgrades/side-effects/heartbeat-writer-signal.md
+++ b/upgrades/side-effects/heartbeat-writer-signal.md
@@ -1,0 +1,55 @@
+# Side-Effects Review — Heartbeat-Writer Guard
+
+**Version / slug:** `heartbeat-writer-signal`
+**Date:** `2026-06-06`
+**Author:** `Echo (instar-dev agent, autonomous session per Justin's direction)`
+**Second-pass reviewer:** `adversarial reviewer subagent — narrow OBJECT on the promoteToAwake call site, APPLIED pre-commit (rollback-and-rethrow); all other probes CONCUR`
+
+## Summary of the change
+
+The multi-machine heartbeat writer's three call paths get three deliberate behaviors: (1) the 2-min timer tick and (2) the boot-immediate write go through `writeHeartbeatGuarded()` — try/catch + the new pure `FailureEpisodeLatch` (first-failure log once, ONE DegradationReporter signal per episode at 6min sustained, recovery log + re-arm, retries forever; declared Eternal Sentinel per P19); (3) `promoteToAwake`'s initial write is rollback-and-rethrow — a failed write aborts the promotion cleanly (`_role` + registry rolled back) instead of (pre-fix) dying mid-transition or (first draft) silently completing voiceless. Files: `FailureEpisodeLatch.ts` (new), `MultiMachineCoordinator.ts`, tests.
+
+## Decision-point inventory
+
+- 2-min tick + boot-immediate write — **modify (guarded)** — a write failure can no longer escape as uncaughtException (pre-fix: server FATAL crash on transient fs error); write cadence unchanged.
+- `promoteToAwake` initial write — **modify (abort-clean)** — failure now rolls back role + registry and rethrows; pre-fix it threw AFTER flipping both (half-promotion).
+- `FailureEpisodeLatch` — **add** — pure signal accountant, no authority.
+
+## 1. Over-block
+
+`promoteToAwake` now refuses to complete when the initial heartbeat write fails — the only "block," and it is the reviewer-mandated correct behavior: the alternative (silent voiceless promotion) invites a peer failover into dual-awake; the pre-fix behavior (throw after flipping role+registry) was a half-promotion. Failover paths that call promote with a genuinely broken disk now fail loudly at the transition where the operator can see it, with state consistent.
+
+## 2. Under-block
+
+(a) In heartbeat-only coordination mode (no lease attached — not the production default), a machine whose writes start failing AFTER a successful promotion serves voiceless until the 15min expiry triggers a peer failover; the dual-awake window is bounded by `shouldDemote` on the next check cycle, and the 6min signal precedes the horizon (reviewer probe 1 analysis — lease-attached mode resolves this via epochs regardless). (b) Three raw `writeHeartbeat()` calls remain in `machine.ts` CLI one-shots — no timer vector, errors surface to the CLI naturally (reviewer probe 2: no fix needed). (c) Consolidating the two earlier inline episode latches (lifeline supervisor; live-tail) onto `FailureEpisodeLatch` is deliberate follow-up, not this PR — refactoring just-merged code mid-series adds risk for zero behavior <!-- tracked: CMT-1109 -->.
+
+## 3. Level-of-abstraction fit
+
+`FailureEpisodeLatch` lands in core (importable by both core and lifeline consumers — the layering that blocked reusing the lifeline-resident sibling), as the canonical extraction of a pattern now shipped four times in one night per Friction-Is-a-Spec. The guard lives in the coordinator that owns the timer; `HeartbeatManager.writeHeartbeat()` itself stays throwing (CLI callers WANT the throw; the policy decision belongs to each caller, which is exactly what the three-site design encodes).
+
+## 4. Signal vs authority compliance
+
+**Required reference:** `docs/signal-vs-authority.md`
+
+- [x] No — the latch is a pure signal accountant. The behavioral changes are failure-HANDLING policy at existing call sites: the tick guard removes an accidental authority (a disk error crashing the server), and the promote rollback makes an existing implicit abort CONSISTENT (state no longer half-flipped). No new decision-maker.
+
+## 5. Interactions
+
+- **Crash vector closed:** the tick's throw → `uncaughtException` → `server.ts` FATAL path (fs errors are not in the non-fatal allowlist) — traced pre-fix; the guard removes it.
+- **Signal-before-failover:** 6min threshold (3 failed 2-min cycles) < 15min `DEFAULT_FAILOVER_TIMEOUT_MS` expiry — operator hears before a peer acts (reviewer probe 3, verified at source).
+- **DegradationReporter in the catch:** cannot throw back (console + in-memory push + best-effort-wrapped disk persist + fire-and-forget dispatch; reviewer probe 4); 10+ core files already use the singleton.
+- **promoteToAwake consumers:** no test pinned the pre-fix throw-after-flip behavior (reviewer grep); coordinator suite (22) green.
+
+## 6. External surfaces / 7. Rollback
+
+Logs + one degradation record per episode; no API/schema/config/persistent state; no migration. Rollback = revert; the crash vector and the half-promotion return.
+
+## Conclusion
+
+The audit lead said "silent failure"; grounding found a crash vector — the verify-every-lead discipline paying again. The fix gives each of three call sites its correct failure policy, extracts the night's episode-latch pattern to its canonical reusable home, and was materially improved by the adversarial pass (the promote rollback) and by its own P19 test (the zero-sentinel bug, caught pre-ship).
+
+---
+
+## Phase 5 — Second-pass review (multi-machine role authority → required)
+
+An adversarial reviewer probed: (1) the promotion semantics change — OBJECT: the first draft's guarded swallow in `promoteToAwake` silently completed a voiceless promotion; prescribed rollback-and-rethrow, APPLIED (with the registry rollback included, which even the pre-fix crash lacked); analyzed heartbeat-only vs lease-attached failover authority end-to-end; (2) remaining raw callsites — CLI one-shots only, safe; (3) 6min signal vs 15min failover horizon — verified at source; (4) DegradationReporter throw-safety in the catch — safe, precedented. Ran the latch + coordinator + leasePull suites and tsc — green/clean. **Verdict: CONCUR with the applied fix.**


### PR DESCRIPTION
## ELI16

When Echo runs on two machines, the one in charge writes a tiny "I'm alive" file every 2 minutes so the other machine knows not to take over. The audit flagged this writer as "fails silently." Reading the actual code showed something worse: a failed write didn't fail silently — it threw an error that **crashed the whole server**. A full disk or permissions hiccup at the wrong moment would take down the machine actively serving you, every 2 minutes, until the disk recovered. And during a takeover, a failed first write left the machine half-promoted — marked "in charge" everywhere, with the alive-file writer never started.

The fix gives each of the three situations its right answer: (1) the every-2-minutes write now absorbs failures — one log line when they start, one health-log note if still failing after 6 minutes (deliberately before the ~15-minute point where the other machine would assume death), one line on recovery, and it never stops trying; (2) taking charge is now all-or-nothing — if the first "I'm alive" write fails, the takeover cleanly cancels and rolls back (this came from the independent reviewer, who caught my first draft letting a voiceless takeover complete); (3) the one-note-per-outage logic is extracted into a small reusable piece (`FailureEpisodeLatch`) — the same shape shipped four times tonight, now in its canonical home.

Bonus honesty: the required P19 test caught a real bug before shipping — the "no outage" marker collided with an outage starting at exactly time zero (the old "zero is a real value" lesson, again).

## What changed

- `src/core/FailureEpisodeLatch.ts` (new) — pure episode accountant: first-failure / one-signal-per-episode / recovery, null-sentinel-safe, injectable clock
- `src/core/MultiMachineCoordinator.ts` — `writeHeartbeatGuarded()` funnel for the tick + boot writes (ETERNAL SENTINEL declared per P19); `promoteToAwake` rollback-and-rethrow on a failed initial write

## Safety

Adversarial second-pass: narrow **OBJECT applied** (the promote rollback — analyzed heartbeat-only vs lease-attached failover authority end-to-end), probes 2–4 **CONCUR**: remaining raw calls are CLI one-shots (no timer vector); the 6min signal threshold verified against the 15min `DEFAULT_FAILOVER_TIMEOUT_MS` horizon at source; `DegradationReporter.report()` cannot throw into the catch. No test pinned the old throw-after-flip behavior. Full review in `upgrades/side-effects/heartbeat-writer-signal.md`.

## Tests

10 green in `FailureEpisodeLatch.test.ts` incl. the P19 sustained-failure bound (a WEEK of 2-min-cadence failures → exactly 1 signal + 1 first-failure line) and wiring pins (exactly two sanctioned raw call sites: the guarded funnel + the promote-abort block with its rollback). Neighbor suites green: multi-machine-coordinator (22), leasePull (3). tsc clean.

Spec: `docs/specs/heartbeat-writer-signal.md` · Parent principle: P19 · Audit: CMT-1109 (fix #4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)