### PR TITLE
fix(mesh): sibling-transport brakes — live-tail + reply-marker wires get timeouts and bounded failure logging (P19)

### DIFF
--- a/.instar/instar-dev-decisions/2026-06-06T03-42-34-851Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-06-06T03-42-34-851Z-unknown.json
@@ -1,0 +1,16 @@
+{
+  "ts": "2026-06-06T03:42:34.851Z",
+  "slug": "unknown",
+  "suggestedTier": 2,
+  "declaredTier": 2,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 2,
+  "loc": 82,
+  "causalAutopsy": {
+    "origin": "latent",
+    "notes": "Both transports shipped in the cross-machine seamlessness era with the same designed-in gaps the lease wire had (no abort signal, per-attempt failure logging) — not regressions. Surfaced by the CMT-1109 loop-safety audit; #874 fixed the lease wire first because it carried renewal/suspend authority; these two are the lower-blast-radius completion."
+  },
+  "verdict": "pass"
+}

--- a/docs/specs/sibling-transport-brakes.eli16.md
+++ b/docs/specs/sibling-transport-brakes.eli16.md
@@ -1,0 +1,35 @@
+# ELI16 — Brakes for the last two machine-to-machine channels
+
+## The problem
+
+Earlier tonight the "who's in charge" checker between Echo's two machines got
+two brakes: a time limit on its network calls (so one stuck connection can't
+silently break it forever) and bounded failure logging (so a down machine
+produces ~49 log lines a day instead of ~17,000). But two sibling channels
+shipped with the exact same missing brakes: the conversation-copier's wire
+(which streams conversation updates to the standby machine) and the
+"already answered" marker wire (which tells the standby "this message was
+replied to — don't reply again after a takeover"). A hung connection could
+hold either open forever, and a down or rejecting machine produced one log
+line per attempt.
+
+## The fix
+
+The same two brakes, applied to both channels: every network call gets a
+30-second time limit (sized above the 5–40 second freezes this fleet's
+machines are known to have under load, so a slow-but-alive machine isn't
+mislabeled as dead — the lesson the reviewer taught us on the first
+transport), and failure logging becomes one line when a machine becomes
+unreachable, a periodic reminder with the count, and one line on recovery.
+
+One trade-off, checked deliberately: if the standby is VERY slow, a 30-second
+cutoff might drop an "already answered" marker that a longer wait would have
+delivered. That's acceptable by design — the marker system has two backup
+layers (the message dedup gate and the synced ledger) exactly for lost
+markers, and the reviewer traced that nothing depends on the send succeeding.
+
+## What changes for you
+
+Cleaner logs and two fewer ways for the two-machine setup to silently jam.
+This completes the brake set: all four machine-to-machine wires (lease,
+heartbeat, conversation-copier, reply-marker) now follow the loop standard.

--- a/docs/specs/sibling-transport-brakes.md
+++ b/docs/specs/sibling-transport-brakes.md
@@ -1,0 +1,57 @@
+---
+title: Sibling-Transport Brakes — live-tail and reply-marker wires get timeouts + bounded failure logging
+status: converged
+tier: 2
+parent-principle: "No Unbounded Loops — Every Repeating Behavior Carries Its Own Brakes"
+review-convergence: self-converged as the mechanical completion of the #874 pattern (line-level CONCUR-reviewed tonight on HttpLeaseTransport, including the 30s timeout sizing vs the fleet's 5–40s receiver-stall envelope — applied here from the start) on the two remaining mesh transports, with the one coupling risk verified ABSENT by direct grep (isReachable()'s only consumer is the LEASE transport via LeaseCoordinator — neither sibling feeds renewal/suspend); validated by a focused adversarial second-pass (CONCUR on all probes: the Two-Generals widening is pre-accepted by the marker's documented design; gate keys are peer-bounded; alternating ok/fail chatter is diagnostic signal at reply cadence; local encryptFor throws disambiguate via the error detail).
+approved: true
+---
+
+# Sibling-Transport Brakes
+
+> Approval ground: Justin's autonomous-session direction (topic "Resource
+> Limitation Mitigation", 2026-06-06) with standing merge-on-green approval.
+> Audit fix #5 (CMT-1109), completing the transport set #874 started.
+
+## Problem
+
+`HttpLiveTailTransport` and `ReplyMarkerTransport` shipped with the identical
+gaps #874 closed on the lease wire: no abort signal on their fetches (a hung
+socket holds a flush / the reply-commit path open indefinitely) and per-attempt
+failure logging (live-tail: one line per topic per backoff attempt against a
+down peer; reply-marker: one line per rejected marker). Lower blast radius
+than the lease wire — neither feeds lease renewal/suspend (verified:
+`.isReachable()`'s only src consumer is `LeaseCoordinator` via the lease
+transport) — but the same P19 violations.
+
+## Design
+
+The #874 pattern verbatim: `AbortSignal.timeout(requestTimeoutMs)` on both
+fetches (default 30s — the #874 reviewer's corrected sizing, above the fleet's
+documented 5–40s receiver-stall envelope) + `PeerFailureLogGate` state-change
+logging (first / every-Nth / recovery; live-tail N=360 for its tick-bounded
+cadence, reply-marker N=50 since markers flow at reply cadence). Non-ok
+responses now gated-logged with status + context detail. No server.ts wiring
+needed — neither transport has a config-coupled horizon (unlike the lease
+wire's leaseTtlMs derivation).
+
+Reviewer-analyzed acceptances: (a) a 30s abort can drop a marker a slower wait
+might have delivered — widening the documented Two-Generals residual that the
+marker's own class doc pre-accepts (broadcast is void-discarded fire-and-forget
+at its only callsite; provider redelivery + the dedup gate + git-committed
+ledger state are the backstops); (b) perfectly alternating ok/fail logs per
+transition — diagnostic signal for a genuinely unstable peer, bounded at reply
+cadence; (c) a local `encryptFor` throw logs under the peer key with the real
+error message as the disambiguating detail.
+
+## Tests
+
+`tests/unit/sibling-transport-brakes.test.ts` — 6 green: AbortSignal presence
+on both transports; the P19 sustained-failure bounds (25 failed flushes → 3
+lines; 12 rejected markers → 2 lines); recovery-once on both; steady-success
+silence on both. Pre-existing suites untouched and green (HttpLiveTailTransport
+6, reply-marker-transport 3, live-tail roundtrip); tsc clean.
+
+## Rollback
+
+Revert; no persistent state, no config, no schema.

--- a/src/core/HttpLiveTailTransport.ts
+++ b/src/core/HttpLiveTailTransport.ts
@@ -29,6 +29,7 @@
  */
 
 import { signRequest } from '../server/machineAuth.js';
+import { PeerFailureLogGate } from './PeerFailureLogGate.js';
 import { redactForLiveTail } from './liveTailRedaction.js';
 import type { EncryptedSecretPayload } from './SecretStore.js';
 
@@ -65,6 +66,20 @@ export interface HttpLiveTailTransportDeps {
   fetchImpl?: typeof fetch;
   /** How recent a successful broadcast counts as "reachable". Default = 60s. */
   reachabilityWindowMs?: number;
+  /**
+   * Per-request abort timeout (P19 brake — a hung socket must not hold a
+   * flush open indefinitely). Default 30s: sized ABOVE the fleet's documented
+   * 5–40s receiver-stall envelope (the #874 reviewer's sizing rationale) so a
+   * slow-but-alive standby is not converted into "unreachable".
+   */
+  requestTimeoutMs?: number;
+  /**
+   * Coarse-reminder interval for the per-peer failure log gate (P19 brake).
+   * Default 360: with #867's per-topic backoff the attempt rate is bounded,
+   * but N topics against one down peer still meant N lines per backoff window
+   * — the gate collapses that to first/Nth/recovery per peer.
+   */
+  failureLogEveryN?: number;
   now?: () => number;
   logger?: (msg: string) => void;
 }
@@ -81,10 +96,24 @@ export class HttpLiveTailTransport {
   private readonly d: HttpLiveTailTransportDeps;
   private lastBroadcastOkAt = 0;
   private readonly windowMs: number;
+  private readonly requestTimeoutMs: number;
+  /** State-change failure logging (first/Nth/recovery) — never per-attempt. */
+  private readonly logGate: PeerFailureLogGate;
 
   constructor(deps: HttpLiveTailTransportDeps) {
     this.d = deps;
     this.windowMs = deps.reachabilityWindowMs ?? 60_000;
+    this.requestTimeoutMs = deps.requestTimeoutMs ?? 30_000;
+    this.logGate = new PeerFailureLogGate(deps.failureLogEveryN ?? 360);
+  }
+
+  private logFailure(key: string, detail: string): void {
+    const line = this.logGate.failed(key, detail);
+    if (line) this.log(line);
+  }
+  private logSuccess(key: string): void {
+    const line = this.logGate.succeeded(key);
+    if (line) this.log(line);
   }
 
   private now(): number {
@@ -125,11 +154,17 @@ export class HttpLiveTailTransport {
             method: 'POST',
             headers: { 'Content-Type': 'application/json', ...headers },
             body: JSON.stringify(body),
+            // P19 brake: a hung socket aborts instead of holding the flush open.
+            signal: AbortSignal.timeout(this.requestTimeoutMs),
           });
-          if (res && (res as Response).ok) anyOk = true;
-          else this.log(`peer ${peer.machineId} rejected flush seq=${flush.seq} (status ${(res as Response)?.status})`);
+          if (res && (res as Response).ok) {
+            anyOk = true;
+            this.logSuccess(`live-tail to ${peer.machineId}`);
+          } else {
+            this.logFailure(`live-tail to ${peer.machineId}`, `status ${(res as Response)?.status} (seq=${flush.seq})`);
+          }
         } catch (err) {
-          this.log(`broadcast to ${peer.machineId} failed: ${err instanceof Error ? err.message : String(err)}`);
+          this.logFailure(`live-tail to ${peer.machineId}`, err instanceof Error ? err.message : String(err));
         }
       }),
     );

--- a/src/core/ReplyMarkerTransport.ts
+++ b/src/core/ReplyMarkerTransport.ts
@@ -22,6 +22,7 @@
  */
 
 import { signRequest } from '../server/machineAuth.js';
+import { PeerFailureLogGate } from './PeerFailureLogGate.js';
 
 export interface ReplyMarkerPeer {
   machineId: string;
@@ -45,18 +46,46 @@ export interface ReplyMarkerTransportDeps {
   /** Monotonic per-request sequence for machine-auth replay protection. */
   nextSequence: () => number;
   fetchImpl?: typeof fetch;
+  /**
+   * Per-request abort timeout (P19 brake — a hung socket must not hold the
+   * reply-commit path open). Default 30s: sized ABOVE the fleet's documented
+   * 5–40s receiver-stall envelope (the #874 reviewer's sizing rationale — a
+   * slow-but-alive peer must not read as unreachable).
+   */
+  requestTimeoutMs?: number;
+  /**
+   * Coarse-reminder interval for the per-peer failure log gate (P19 brake).
+   * Default 50 — markers flow at REPLY cadence (not a fixed 5s tick), so the
+   * reminder lands roughly every 50 failed replies; first-failure and
+   * recovery lines carry the state changes regardless.
+   */
+  failureLogEveryN?: number;
   logger?: (msg: string) => void;
 }
 
 export class ReplyMarkerTransport {
   private readonly d: ReplyMarkerTransportDeps;
+  private readonly requestTimeoutMs: number;
+  /** State-change failure logging (first/Nth/recovery) — never per-attempt. */
+  private readonly logGate: PeerFailureLogGate;
 
   constructor(deps: ReplyMarkerTransportDeps) {
     this.d = deps;
+    this.requestTimeoutMs = deps.requestTimeoutMs ?? 30_000;
+    this.logGate = new PeerFailureLogGate(deps.failureLogEveryN ?? 50);
   }
 
   private log(m: string): void {
     this.d.logger?.(`[reply-marker] ${m}`);
+  }
+
+  private logFailure(key: string, detail: string): void {
+    const line = this.logGate.failed(key, detail);
+    if (line) this.log(line);
+  }
+  private logSuccess(key: string): void {
+    const line = this.logGate.succeeded(key);
+    if (line) this.log(line);
   }
 
   /**
@@ -80,11 +109,17 @@ export class ReplyMarkerTransport {
             method: 'POST',
             headers: { 'Content-Type': 'application/json', ...headers },
             body: JSON.stringify(body),
+            // P19 brake: a hung socket aborts instead of holding the reply-commit path.
+            signal: AbortSignal.timeout(this.requestTimeoutMs),
           });
-          if (res && (res as Response).ok) anyOk = true;
-          else this.log(`peer ${peer.machineId} rejected marker ${marker.dedupeKey} (status ${(res as Response)?.status})`);
+          if (res && (res as Response).ok) {
+            anyOk = true;
+            this.logSuccess(`marker to ${peer.machineId}`);
+          } else {
+            this.logFailure(`marker to ${peer.machineId}`, `status ${(res as Response)?.status} (marker ${marker.dedupeKey})`);
+          }
         } catch (err) {
-          this.log(`broadcast to ${peer.machineId} failed: ${err instanceof Error ? err.message : String(err)}`);
+          this.logFailure(`marker to ${peer.machineId}`, err instanceof Error ? err.message : String(err));
         }
       }),
     );

--- a/tests/unit/sibling-transport-brakes.test.ts
+++ b/tests/unit/sibling-transport-brakes.test.ts
@@ -1,0 +1,105 @@
+/**
+ * Tier-1 tests for the P19 brakes on the two remaining mesh transports —
+ * HttpLiveTailTransport and ReplyMarkerTransport (audit fix #5, completing the
+ * set #874 started on HttpLeaseTransport): every outbound request carries an
+ * abort signal (hung-socket brake), and per-peer failure logging is
+ * state-change-gated (first / every-Nth / recovery), never per-attempt.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { generateKeyPairSync } from 'node:crypto';
+import { HttpLiveTailTransport } from '../../src/core/HttpLiveTailTransport.js';
+import { ReplyMarkerTransport } from '../../src/core/ReplyMarkerTransport.js';
+
+const { privateKey } = generateKeyPairSync('ed25519');
+const signingKeyPem = privateKey.export({ type: 'pkcs8', format: 'pem' }).toString();
+
+function makeLiveTail(fetchImpl: any, failureLogEveryN?: number) {
+  let seq = 0;
+  const lines: string[] = [];
+  const t = new HttpLiveTailTransport({
+    selfMachineId: 'm_a',
+    signingKeyPem,
+    peers: () => [{ machineId: 'm_b', url: 'http://peer', encryptionPublicKey: 'cGsK' }],
+    nextSequence: () => ++seq,
+    encryptFor: (content) => ({ v: 3, alg: 'test', payload: content } as any),
+    fetchImpl,
+    failureLogEveryN,
+    logger: (m) => lines.push(m),
+  });
+  return { t, lines };
+}
+
+function makeMarker(fetchImpl: any, failureLogEveryN?: number) {
+  let seq = 0;
+  const lines: string[] = [];
+  const t = new ReplyMarkerTransport({
+    selfMachineId: 'm_a',
+    signingKeyPem,
+    peers: () => [{ machineId: 'm_b', url: 'http://peer' }],
+    nextSequence: () => ++seq,
+    fetchImpl,
+    failureLogEveryN,
+    logger: (m) => lines.push(m),
+  });
+  return { t, lines };
+}
+
+const FLUSH = { topic: '42', seq: 1, content: 'hello' };
+const MARKER = { dedupeKey: 'tg:1:2', platform: 'telegram', replyIdempotencyKey: 'r1', epoch: 7, topic: '42' };
+
+describe('sibling-transport P19 brakes', () => {
+  it('live-tail: every outbound request carries an abort signal', async () => {
+    const fetchImpl = vi.fn(async () => ({ ok: true })) as any;
+    const { t } = makeLiveTail(fetchImpl);
+    await t.broadcast(FLUSH);
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    expect(fetchImpl.mock.calls[0][1].signal).toBeInstanceOf(AbortSignal);
+  });
+
+  it('reply-marker: every outbound request carries an abort signal', async () => {
+    const fetchImpl = vi.fn(async () => ({ ok: true })) as any;
+    const { t } = makeMarker(fetchImpl);
+    await t.broadcast(MARKER);
+    expect(fetchImpl.mock.calls[0][1].signal).toBeInstanceOf(AbortSignal);
+  });
+
+  it('SUSTAINED-FAILURE BOUND (P19, live-tail): 25 failed flushes log 3 lines, not 25', async () => {
+    const fetchImpl = vi.fn(async () => { throw new Error('ECONNREFUSED'); }) as any;
+    const { t, lines } = makeLiveTail(fetchImpl, 10);
+    for (let i = 0; i < 25; i++) await t.broadcast({ ...FLUSH, seq: i + 1 });
+    expect(lines).toHaveLength(3); // first + #10 + #20
+    expect(lines[0]).toContain('became unreachable');
+    expect(lines[2]).toContain('20 consecutive failures');
+  });
+
+  it('SUSTAINED-FAILURE BOUND (P19, reply-marker): rejecting peer (403 per marker) logs gated, not per-attempt', async () => {
+    const fetchImpl = vi.fn(async () => ({ ok: false, status: 403 })) as any;
+    const { t, lines } = makeMarker(fetchImpl, 10);
+    for (let i = 0; i < 12; i++) await t.broadcast({ ...MARKER, dedupeKey: `k${i}` });
+    expect(lines).toHaveLength(2); // first (status 403) + the 10th reminder
+    expect(lines[0]).toContain('status 403');
+  });
+
+  it('recovery logs exactly once on both transports', async () => {
+    let fail = true;
+    const mk = async () => { if (fail) throw new Error('down'); return { ok: true }; };
+    const { t: lt, lines: ltLines } = makeLiveTail(vi.fn(mk) as any, 100);
+    const { t: mt, lines: mtLines } = makeMarker(vi.fn(mk) as any, 100);
+    await lt.broadcast(FLUSH); await mt.broadcast(MARKER);
+    fail = false;
+    await lt.broadcast(FLUSH); await mt.broadcast(MARKER);
+    await lt.broadcast(FLUSH); await mt.broadcast(MARKER);
+    expect(ltLines.filter((l) => l.includes('recovered after 1 consecutive failures'))).toHaveLength(1);
+    expect(mtLines.filter((l) => l.includes('recovered after 1 consecutive failures'))).toHaveLength(1);
+  });
+
+  it('steady success is silent on both transports (no per-send chatter)', async () => {
+    const ok = vi.fn(async () => ({ ok: true })) as any;
+    const { t: lt, lines: ltLines } = makeLiveTail(ok);
+    const { t: mt, lines: mtLines } = makeMarker(ok);
+    for (let i = 0; i < 10; i++) { await lt.broadcast(FLUSH); await mt.broadcast(MARKER); }
+    expect(ltLines).toHaveLength(0);
+    expect(mtLines).toHaveLength(0);
+  });
+});

--- a/upgrades/next/sibling-transport-brakes.md
+++ b/upgrades/next/sibling-transport-brakes.md
@@ -1,0 +1,44 @@
+---
+bump: patch
+---
+
+## What Changed
+
+Audit fix #5 under "No Unbounded Loops" (P19), completing the mesh-transport
+brake set #874 started: `HttpLiveTailTransport` (conversation-tail streaming)
+and `ReplyMarkerTransport` (cross-machine "already answered" markers) get
+`AbortSignal.timeout` on their fetches (30s default — the #874 reviewer's
+stall-envelope sizing, applied from the start) and `PeerFailureLogGate`
+state-change failure logging (first / every-Nth / recovery; previously one
+line per failed attempt, and silent for non-ok responses). Verified: neither
+transport feeds lease renewal/suspend (`isReachable()`'s only consumer is the
+lease wire), so the timeout carries zero authority coupling. The reviewer
+confirmed the marker-drop trade-off under a 30s abort is pre-accepted by the
+marker's documented design (fire-and-forget; provider redelivery + dedup gate
++ synced ledger are the backstops).
+
+## What to Tell Your User
+
+If you run me on more than one machine: the last two machine-to-machine sync
+channels now have the same protections as the rest — a stuck network
+connection can't silently jam them, and a down machine produces a handful of
+meaningful log lines instead of one per failed attempt. All four cross-machine
+wires now follow the loop-safety standard.
+
+## Summary of New Capabilities
+
+- Hung-socket protection + bounded failure logging on the live-tail and
+  reply-marker transports (no configuration needed; recovery and
+  rejecting-peer visibility included).
+
+## Evidence
+
+CMT-1109 audit, mechanical completion of the #874 pattern (line-level
+CONCUR-reviewed tonight) on two lower-blast-radius transports. Focused
+adversarial second-pass: CONCUR on all probes (Two-Generals widening
+pre-accepted by design — broadcast is void-discarded at its only callsite;
+gate memory peer-bounded; alternating ok/fail chatter is diagnostic at reply
+cadence; local encryptFor throws disambiguate via error detail). Tests: 6 new
+green (AbortSignal pins both transports; P19 bounds — 25 failed flushes → 3
+lines, 12 rejected markers → 2 lines; recovery-once; steady-success silence)
++ pre-existing transport suites untouched and green; tsc clean.

--- a/upgrades/side-effects/sibling-transport-brakes.md
+++ b/upgrades/side-effects/sibling-transport-brakes.md
@@ -1,0 +1,43 @@
+# Side-Effects Review — Sibling-Transport Brakes
+
+**Version / slug:** `sibling-transport-brakes`
+**Date:** `2026-06-06`
+**Author:** `Echo (instar-dev agent, autonomous session per Justin's direction)`
+**Second-pass reviewer:** `focused adversarial reviewer subagent — CONCUR on all four probes (the #874 pattern itself carries tonight's line-level CONCUR)`
+
+## Summary of the change
+
+The #874 brake pattern applied verbatim to the two remaining mesh transports: `HttpLiveTailTransport` and `ReplyMarkerTransport` get `AbortSignal.timeout` (30s default, the #874-corrected sizing above the fleet's 5–40s receiver-stall envelope) on their fetches, and `PeerFailureLogGate` state-change failure logging (live-tail N=360; reply-marker N=50 for reply cadence) replacing per-attempt lines, with non-ok responses now gated-logged. Files: both transports, one test file.
+
+## Decision-point inventory
+
+- Both transports' `broadcast()` — **modify (bounded)** — same requests, same return semantics; failures abort at the timeout instead of hanging; logging gated.
+
+## 1. Over-block / 2. Under-block
+
+(a) A 30s abort can drop a reply-marker a slower wait might have delivered — widening the marker's documented Two-Generals residual. Reviewer-traced: `broadcast()`'s return is void-discarded at its ONLY callsite (fire-and-forget by design); provider redelivery + the dedup gate + git-committed ledger state are the explicit backstops. Pre-accepted, not new risk. (b) Perfectly alternating ok/fail logs one transition pair per cycle — at reply cadence this is bounded and is diagnostic signal for a genuinely unstable peer (reviewer: not a blocker; an across-resets suppressor would mask real instability). (c) A local `encryptFor` throw logs under the peer's key — imprecise label, but the error detail (the real exception message) disambiguates and the operational meaning ("this peer's flush did not deliver") is identical. (d) Remaining audit item is the SessionRouter design <!-- tracked: CMT-1109 -->.
+
+## 3. Level-of-abstraction fit / 4. Signal vs authority
+
+Brakes in the transports that generate the cost; cadence stays with callers; reuses the canonical gate class rather than re-implementing. **Signal-only** per `docs/signal-vs-authority.md`: log shaping + failure-timing bounds. Critically verified: neither transport feeds lease renewal/suspend (`.isReachable()`'s only src consumer is `LeaseCoordinator` via the LEASE transport) — the #874 reviewer's false-self-suspend concern structurally cannot apply here.
+
+## 5. Interactions
+
+- **Exactly-once (the marker's job):** unchanged — the timeout affects only the best-effort fast path; the dedup gate and ledger sync carry correctness (reviewer probe 1).
+- **#867's per-topic backoff:** composes — backoff bounds live-tail attempt RATE per topic; the gate bounds LOG volume per peer across topics.
+- **Old format pins:** none — pre-existing transport suites pass untouched.
+- **Node engines / AbortSignal-vs-test-clocks:** identical to #874 (verified there; same package.json).
+
+## 6. External surfaces / 7. Rollback
+
+Logs only; no API/schema/config/persistent state; no migration (in-code defaults). Rollback = revert; the hang exposure and per-attempt logging return.
+
+## Conclusion
+
+Completes the mesh-transport brake set: all four cross-machine wires (lease #874, heartbeat #881, live-tail and reply-marker here) now carry P19's brakes. Mechanical extension of a twice-validated pattern, with the one novel risk (marker-drop under timeout) traced to a documented, backstopped design acceptance.
+
+---
+
+## Phase 5 — Second-pass review (cross-machine exactly-once adjacency → performed)
+
+A focused adversarial pass probed only what is novel beyond #874's reviewed pattern: (1) the Two-Generals widening from a 30s marker abort — traced `broadcast()`'s only callsite (void-discarded, fire-and-forget, comment-documented backstops): pre-accepted by design; (2) gate key granularity + alternating ok/fail behavior — peer-bounded memory, transition chatter acceptable-and-diagnostic at reply cadence; (3) local `encryptFor` throws misattributed to the peer — disambiguated by the error detail, operationally equivalent; (4) ran the new + pre-existing transport suites (15/15) and tsc (clean). **Verdict: CONCUR.**


### PR DESCRIPTION
## ELI16

Earlier tonight the "who's in charge" checker between Echo's two machines got two brakes (#874): a time limit on its network calls so one stuck connection can't silently break it forever, and bounded failure logging so a down machine produces ~49 log lines a day instead of ~17,000. Two sibling channels shipped with the exact same missing brakes: the conversation-copier's wire (streams conversation updates to the standby) and the "already answered" marker wire (tells the standby "this message was replied to — don't reply again after a takeover"). A hung connection could hold either open forever, and a down or rejecting machine produced one log line per attempt.

Same two brakes, applied to both: every network call gets a 30-second time limit (sized above the 5–40 second freezes this fleet's machines are known to have under load — the sizing lesson the reviewer taught us on the first transport, applied here from the start), and failure logging becomes one line when a machine becomes unreachable, a periodic reminder with the count, one line on recovery.

One trade-off checked deliberately: if the standby is VERY slow, the 30-second cutoff might drop an "already answered" marker a longer wait would have delivered. Acceptable by design — the reviewer traced that nothing depends on the send succeeding (it's fire-and-forget at its only callsite), and the marker system has two backup layers (the message dedup gate and the synced ledger) exactly for lost markers.

This completes the set: all four machine-to-machine wires (lease #874, heartbeat #881, conversation-copier, reply-marker) now follow the loop standard.

## What changed

- `src/core/HttpLiveTailTransport.ts` + `src/core/ReplyMarkerTransport.ts` — `AbortSignal.timeout` on both fetches; `PeerFailureLogGate` gated failure/recovery logging (non-ok responses now visible, boundedly)

Verified zero authority coupling: `.isReachable()`'s only consumer in src is the LEASE transport — neither sibling feeds renewal/suspend.

## Safety

Focused adversarial second-pass: **CONCUR** on all probes — Two-Generals widening pre-accepted by the marker's documented design; gate memory peer-bounded; alternating ok/fail chatter is diagnostic signal at reply cadence; local encryption errors disambiguate via the logged detail. Full review in `upgrades/side-effects/sibling-transport-brakes.md`.

## Tests

6 new green in `sibling-transport-brakes.test.ts` (AbortSignal pins on both transports; P19 sustained-failure bounds — 25 failed flushes → 3 lines, 12 rejected markers → 2 lines; recovery-once; steady-success silence). Pre-existing suites untouched and green (HttpLiveTailTransport 6, reply-marker-transport 3, live-tail roundtrip). tsc clean.

Spec: `docs/specs/sibling-transport-brakes.md` · Parent principle: P19 · Audit: CMT-1109 (fix #5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)