### PR TITLE
feat(session-pool): owner-suspect breaker — wire the router's dead per-peer hook into a half-open circuit (P19)

### DIFF
--- a/.instar/instar-dev-decisions/2026-06-06T04-00-58-083Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-06-06T04-00-58-083Z-unknown.json
@@ -1,0 +1,18 @@
+{
+  "ts": "2026-06-06T04:00:58.083Z",
+  "slug": "unknown",
+  "suggestedTier": 2,
+  "declaredTier": 2,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "new capability: new exported class / subsystem added"
+  ],
+  "belowFloor": false,
+  "files": 3,
+  "loc": 184,
+  "causalAutopsy": {
+    "origin": "latent",
+    "notes": "The markOwnerSuspect hook shipped with the session-pool router design as a dep that no wiring ever implemented — constructed-but-inert at the wiring layer (the exact Testing-Integrity failure mode the wiring-integrity tests exist for, but the dep was optional so no wiring test required it). Surfaced by the CMT-1109 loop-safety audit chasing the per-peer load-shedding lead; the deeper grounding (heartbeat-only aliveness + no-op queueMessage) sharpened the audit claim into three concrete facts."
+  },
+  "verdict": "pass"
+}

--- a/docs/specs/owner-suspect-breaker.eli16.md
+++ b/docs/specs/owner-suspect-breaker.eli16.md
@@ -1,0 +1,45 @@
+# ELI16 — The message router stops re-learning the same bad news
+
+## The problem
+
+When Echo runs conversations across two machines, each message gets forwarded
+to whichever machine "owns" that conversation. If the owning machine is slow
+or down, the router retries a few times (about 4.5 seconds of trying), gives
+up, and re-homes the conversation on a healthy machine. Sensible — except the
+router learned NOTHING from it. The "this machine looks bad" signal existed in
+the code but was never plugged in. So if you had ten conversations on a
+struggling machine, all ten independently paid the same 4.5-second discovery
+tax, message after message, because the only health check the router consulted
+was "is it sending heartbeats?" — which a slow machine keeps passing.
+
+Also found while in there: the router kept a small bookkeeping entry for every
+conversation it ever routed, forever (a slow leak), and its "queue this
+message for later" option turned out to be wired to nothing — queued messages
+just relied on the messaging platform re-sending them.
+
+## The fix
+
+A small circuit breaker, plugged into the hook that was always there: when
+deliveries to a machine keep failing, that machine is marked "suspect" for 30
+seconds. During that window, every conversation it owns skips the retry tax
+and goes straight to the existing re-homing path. Any successful delivery
+clears the mark instantly. After 30 seconds the router tries the machine for
+real again — so a recovered machine gets picked back up quickly.
+
+The independent reviewer earned their keep AGAIN: my first version extended
+the 30-second window every time a new message arrived — meaning a busy machine
+that had already recovered could stay written off forever (the more traffic,
+the longer the wrongful exile — exactly backwards). The reviewer reproduced
+it, fixed it (the window now expires on schedule no matter the traffic), and
+added the regression test. The bookkeeping leak is also fixed.
+
+One thing deliberately NOT decided here: what to do with messages during the
+suspect window — re-home fast (today's behavior, kept) or hold-and-wait for
+stability. That's an operator-policy choice that needs a real message queue
+built first; it goes to Justin as options.
+
+## What changes for you
+
+A struggling machine costs one discovery instead of one per conversation per
+message, recovered machines come back into rotation within 30 seconds, and
+pinned conversations don't get moved by a brief blip.

--- a/docs/specs/owner-suspect-breaker.md
+++ b/docs/specs/owner-suspect-breaker.md
@@ -1,0 +1,82 @@
+---
+title: Owner-Suspect Breaker — wire the router's dead per-peer hook into a half-open circuit
+status: converged
+tier: 2
+parent-principle: "No Unbounded Loops — Every Repeating Behavior Carries Its Own Brakes"
+review-convergence: self-converged against deep grounding of the SessionRouter (the audit's "load-shedding" lead resolved to three concrete facts — markOwnerSuspect NEVER WIRED in production, isMachineAlive reads only capacity heartbeats so a slow-but-heartbeating peer never short-circuits, and queueMessage is a production NO-OP so re-placement is the only message-preserving path today); validated by an adversarial second-pass whose probe-1 OBJECT (forever-suspect under steady traffic — re-marks extended the TTL window so a recovered peer could never reach half-open) was CONFIRMED BY REPRODUCTION and fixed (absolute per-episode TTL) with a regression test, and whose remaining five probes (swap-count invariance, pin behavior, all-suspect fallback, stale-ack semantics, chains-cleanup race) all traced clean.
+approved: true
+---
+
+# Owner-Suspect Breaker (task 4a — the uncontroversial half)
+
+> Approval ground: Justin's autonomous-session direction with standing
+> merge-on-green approval (topic "Resource Limitation Mitigation",
+> 2026-06-06). The POLICY half (queue-vs-replace while suspect, which needs a
+> durable inbound queue built first) goes to Justin as lettered options — see
+> the companion message <!-- tracked: CMT-1109 -->.
+
+## Problem (grounded — three findings sharper than the audit lead)
+
+The audit said "SessionRouter lacks per-peer load-shedding." Grounding found:
+1. The router already HAS the breaker hook — `markOwnerSuspect` fires on
+   delivery-retry exhaustion — but it was **never wired in production**
+   ("constructed but inert" at the wiring layer).
+2. `isMachineAlive` reads only capacity-heartbeat `online` — a slow-but-
+   heartbeating peer keeps passing it, so EVERY session it owns re-pays the
+   full retry tax (~4.5s: initial + 3 backed-off retries) on EVERY message.
+3. `queueMessage` is a production no-op — "queued" means "dropped to platform
+   redelivery." Re-placement is the only message-preserving path today, which
+   is why this PR keeps the existing re-place semantics and the queue-based
+   stability policy is a separate operator decision.
+Plus: the per-session `chains` map grew one settled-promise entry per
+session-ever-routed, forever (the same leak shape as the tail-cache finding).
+
+## Design
+
+- **`OwnerSuspectBreaker`** (pure core class): per-peer suspect windows with
+  **absolute per-episode TTL** (default 30s — a re-mark inside an open window
+  does NOT extend it; the reviewer's reproduction showed extension semantics
+  made a recovered busy peer suspect FOREVER, since no delivery is attempted
+  while suspect so only the TTL can re-open probing). Half-open after expiry.
+  Composes `FailureEpisodeLatch` per peer: first-mark log once, ONE
+  degradation signal per 10min-sustained episode, recovery log + state
+  deleted on success (bounded memory).
+- **Router** (minimal): new optional `onOwnerResponsive` dep fired on ANY
+  deliverMessage ack (queued/duplicate/stale all prove the peer answered —
+  transport health, which is exactly what this breaker measures); `chains`
+  entry deleted when its tail settles while still current (bounded by
+  in-flight sessions; the identity-check guard preserves serialization —
+  reviewer probe 5 traced the interleaving clean).
+- **Wiring**: `markOwnerSuspect` → breaker; `isMachineAlive` composed with
+  `!isSuspect` (suspect peers' sessions take the EXISTING failover re-place
+  path without re-paying the retry tax); placement's `machineRegistry`
+  filtered to exclude suspect machines UNLESS that empties the set
+  (all-suspect → unfiltered, mirroring the all-machines-quota-blocked
+  precedent — reviewer probe 3 confirmed `spawnOnMachine` is not
+  `isMachineAlive`-gated, so the fallback cannot wedge).
+
+## Swap semantics (the "fewer swaps" check)
+
+Reviewer probe 1+2 traced: a session still moves at most once per peer-down
+episode (the breaker removes redundant retry tax for the peer's OTHER
+sessions; it does not add moves). HARD-pinned sessions do NOT migrate during
+a suspect window — placement returns `hard-pin-unavailable` and the message
+falls through; on TTL expiry the pin resolves in place. A 30s blip cannot
+permanently migrate a pinned session.
+
+## Tests
+
+`tests/unit/OwnerSuspectBreaker.test.ts` — 11 green: TTL/half-open, the
+ABSOLUTE per-episode TTL regression (the reviewer's bug — a steady <TTL
+re-mark stream must still reach half-open), recovery-once, the P19
+sustained-suspicion bound (20 marks → 1 first-log + 1 signal), peer
+independence + bounded memory, fresh-episode re-fire; router integration —
+onOwnerResponsive on success AND stale acks, the END-TO-END short-circuit
+(message 1 pays 4 attempts, message 2 pays ZERO), chains-map boundedness.
+SessionRouter suite (23), session-router-dispatch integration (3), and the
+session-pool deliverMessage e2e (4) all green; tsc clean.
+
+## Rollback
+
+Revert; no persistent state, no config, no schema. (The wiring is one block
+in server.ts; removing it restores the inert-hook status quo.)

--- a/site/src/content/docs/features/observability.md
+++ b/site/src/content/docs/features/observability.md
@@ -25,6 +25,12 @@ Where burn detection reacts to token *volume* over a rolling window, the circuit
 
 `CircuitBreakingIntelligenceProvider` wraps every intelligence provider at the single construction chokepoint, so every LLM-backed feature is covered without per-feature code. When a call returns a usage/rate/spend-limit error, the shared account-global `LlmCircuitBreaker` opens: subsequent calls short-circuit in-process — no subprocess is spawned, so they cost nothing — for a cool-down window (15 minutes by default). After the window it admits a single probe; a successful probe closes the breaker and work resumes, a still-limited probe re-opens it. The breaker enforces the provider's decision rather than making a policy decision of its own, and it is on by default (tune or disable via `intelligence.circuitBreaker` in `.instar/config.json`).
 
+## Loop-safety brakes (P19 "No Unbounded Loops")
+
+Components: `PeerFailureLogGate`, `FailureEpisodeLatch`, `OwnerSuspectBreaker`, `SlowRetrySentinelEscalation`, `AgeKillBackoff`.
+
+Every repeating behavior in the multi-machine mesh carries its own brakes, enforced by the constitution's "No Unbounded Loops" standard. `PeerFailureLogGate` converts per-attempt failure logging into state-change logging (one line when a peer becomes unreachable, a coarse reminder every Nth consecutive failure, one line on recovery) — a down peer produces ~49 log lines a day instead of ~17,000. `FailureEpisodeLatch` is the canonical episode accountant behind the Eternal Sentinel clause: a loop that retries forever raises exactly ONE degradation signal per sustained-failure episode, re-armed on recovery. `OwnerSuspectBreaker` is the session router's per-machine circuit: a machine whose message deliveries keep failing is marked suspect for an absolute 30-second half-open window, during which its sessions route straight to failover re-placement instead of each re-paying the delivery retry tax; any successful delivery closes the window instantly. `SlowRetrySentinelEscalation` gives the server supervisor's never-give-up revival loop its one-per-outage operator notification, and `AgeKillBackoff` keeps the session reaper from re-requesting a kill its keep-guard already vetoed.
+
 ## Quota tracking
 
 Components: `QuotaTracker`, `QuotaManager`, `QuotaCollector`, `QuotaNotifier`, `QuotaExhaustionDetector`.

--- a/src/commands/server.ts
+++ b/src/commands/server.ts
@@ -10255,17 +10255,52 @@ export async function startServer(options: StartOptions): Promise<void> {
           // Shared-cluster writes stay blocked on a standby. (bug #9: the moved session's
           // saveSession was blocked by the standby read-only guard.)
           state.setSessionPoolActive(true);
+          // Per-peer suspect breaker (P19) — the markOwnerSuspect hook's missing
+          // half. A peer whose deliveries exhaust retries is short-circuited for
+          // a half-open 30s window: every session it owns goes straight to the
+          // EXISTING failover re-place path instead of re-paying the ~4.5s retry
+          // tax per message. Any successful delivery closes the window; sustained
+          // suspicion (10min of consecutive windows) raises ONE degradation
+          // signal per episode.
+          const ownerSuspectBreaker = new (await import('../core/OwnerSuspectBreaker.js')).OwnerSuspectBreaker({
+            logger: (m) => console.log(pc.dim(m)),
+            reportSustained: ({ machineId, suspectForMs, marks }) => {
+              DegradationReporter.getInstance().report({
+                feature: 'SessionPool.ownerDelivery',
+                primary: 'Messages forward to the machine that owns their session',
+                fallback: `Owner ${machineId} unresponsive to deliveries for ~${Math.round(suspectForMs / 60_000)}min (${marks} suspect windows); its sessions re-place on dispatch; half-open re-probes continue`,
+                reason: 'deliverMessage retries to the owning machine keep exhausting',
+                impact: 'Sessions owned by that machine fail over to other machines on their next message instead of being delivered in place.',
+              });
+            },
+          });
           _sessionRouter = new routerMod.SessionRouter({
             selfMachineId: meshSelfId,
             placement: new placeMod.PlacementExecutor(),
-            machineRegistry: () => machinePoolRegistry?.getCapacities() ?? [],
+            // Placement must consult the breaker too: a message re-placed OFF a
+            // suspect owner must not be placed right back ONTO it. Suspect
+            // machines are filtered from the candidate set UNLESS that would
+            // empty it — with every machine suspect, placement proceeds on the
+            // full set (mirrors the all-machines-quota-blocked precedent:
+            // degraded placement beats no placement).
+            machineRegistry: () => {
+              const all = machinePoolRegistry?.getCapacities() ?? [];
+              const ok = all.filter((c) => !ownerSuspectBreaker.isSuspect(c.machineId));
+              return ok.length > 0 ? ok : all;
+            },
             resolveOwnership: (sk) => {
               const r = ownReg.read(sk);
               if (!r) return { owner: null, epoch: 0, status: null };
               const status = r.status === 'released' ? null : (r.status as 'active' | 'placing' | 'transferring');
               return { owner: ownReg.ownerOf(sk), epoch: r.ownershipEpoch, status, target: ownReg.placementTargetOf(sk) ?? undefined };
             },
-            isMachineAlive: (m) => m === meshSelfId || (machinePoolRegistry?.getCapacity(m)?.online ?? false),
+            // Capacity-online AND not currently suspect: a slow-but-heartbeating
+            // peer that keeps failing deliveries reads as not-alive for routing,
+            // sending its sessions down the existing failover re-place path
+            // without each message re-paying the retry tax.
+            isMachineAlive: (m) => m === meshSelfId || ((machinePoolRegistry?.getCapacity(m)?.online ?? false) && !ownerSuspectBreaker.isSuspect(m)),
+            markOwnerSuspect: (m) => ownerSuspectBreaker.markSuspect(m),
+            onOwnerResponsive: (m) => ownerSuspectBreaker.recordSuccess(m),
             casClaimOwnership: (sk, machineId) => {
               const r = ownReg.cas({ type: 'place', machineId }, { sessionKey: sk, sender: meshSelfId, nonce: `${meshSelfId}:c:${++routerNonce}` });
               return { ok: r.ok, epoch: ownReg.read(sk)?.ownershipEpoch ?? 0 };

--- a/src/core/OwnerSuspectBreaker.ts
+++ b/src/core/OwnerSuspectBreaker.ts
@@ -1,0 +1,123 @@
+/**
+ * OwnerSuspectBreaker — the per-peer circuit breaker behind the SessionRouter's
+ * `markOwnerSuspect` hook ("No Unbounded Loops" / P19).
+ *
+ * The router's forward path already had the SHAPE of a breaker: on delivery
+ * retry exhaustion it calls `markOwnerSuspect(owner)` before re-placing the
+ * message. But the hook was NEVER WIRED in production (the dep is optional and
+ * no implementation existed) — "constructed but inert". The consequence: every
+ * session owned by a slow-or-dead peer independently re-paid the full retry
+ * tax (3 attempts × backoff ≈ 4.5s+) per message, because `isMachineAlive`
+ * reads only capacity heartbeats, which a slow-but-alive peer keeps passing.
+ *
+ * This class is the wiring's missing half. Half-open TTL semantics:
+ *
+ *   markSuspect(peer)   — start/extend a suspect window (default 30s). The
+ *                         FIRST mark of an episode logs once; an episode
+ *                         sustained past signalAfterMs raises ONE degradation
+ *                         signal (per-peer FailureEpisodeLatch — P19 cond. 4).
+ *   isSuspect(peer)     — true inside the window. The composed isMachineAlive
+ *                         then short-circuits dispatches for ALL of that
+ *                         peer's sessions straight to the existing failover
+ *                         re-place path — no per-message retry tax repaid.
+ *   recordSuccess(peer) — a delivery reached the peer: window cleared,
+ *                         recovery logged once, latch re-armed.
+ *
+ *   After the TTL expires the breaker is HALF-OPEN: the next message tries the
+ *   peer for real (paying one retry cycle); success clears, failure re-marks.
+ *   The peer is never written off permanently — the TTL is the backoff, the
+ *   suspect state is the breaker, the per-message retry config is the cap.
+ *
+ * Deliberately POLICY-NEUTRAL: what happens to messages while a peer is
+ * suspect (today: the router's existing re-place path) is the wiring's choice
+ * — the queue-vs-replace stability policy is a separate operator decision
+ * <!-- tracked: CMT-1109 -->. Pure: injectable clock, per-peer bounded state.
+ */
+
+import { FailureEpisodeLatch } from './FailureEpisodeLatch.js';
+
+export interface OwnerSuspectBreakerOpts {
+  /** Suspect window per mark (the half-open backoff). Default 30s. */
+  suspectTtlMs?: number;
+  /** Sustained-suspicion threshold for the one-per-episode degradation signal. Default 10min. */
+  signalAfterMs?: number;
+  now?: () => number;
+  logger?: (msg: string) => void;
+  /** One-per-episode sustained-suspicion sink (wired to DegradationReporter). */
+  reportSustained?: (info: { machineId: string; suspectForMs: number; marks: number }) => void;
+}
+
+const DEFAULT_SUSPECT_TTL_MS = 30_000;
+const DEFAULT_SIGNAL_AFTER_MS = 10 * 60_000;
+
+export class OwnerSuspectBreaker {
+  private readonly ttlMs: number;
+  private readonly now: () => number;
+  private readonly opts: OwnerSuspectBreakerOpts;
+  /** Per-peer suspect-window end (ms epoch). Deleted on success. */
+  private suspectUntil = new Map<string, number>();
+  /** Per-peer episode accounting (created on first mark, deleted on success). */
+  private episodes = new Map<string, FailureEpisodeLatch>();
+
+  constructor(opts: OwnerSuspectBreakerOpts = {}) {
+    this.opts = opts;
+    this.ttlMs = opts.suspectTtlMs ?? DEFAULT_SUSPECT_TTL_MS;
+    this.now = opts.now ?? Date.now;
+  }
+
+  private log(m: string): void {
+    this.opts.logger?.(`[owner-suspect] ${m}`);
+  }
+
+  /** Delivery retries to this peer exhausted — open its suspect window.
+   *
+   * ABSOLUTE per-episode TTL: a mark that arrives while a window is ALREADY open
+   * does NOT push the window end forward. Otherwise a steady message stream
+   * arriving faster than the TTL would re-extend the window on every dispatch
+   * (each suspect dispatch re-enters dispatchOne's dead-owner branch, which
+   * re-calls markOwnerSuspect), so `isSuspect` would never go false at the
+   * moment a message arrives — the half-open re-probe (the ONLY path that ever
+   * re-attempts delivery and thus the ONLY path that can clear suspicion) would
+   * never be reached, leaving a fully-RECOVERED peer suspect forever and
+   * force-failing-over all its sessions on every message. The episode latch
+   * still records each mark (sustained-suspicion accounting), but the window
+   * end is fixed at the first mark of each TTL period. */
+  markSuspect(machineId: string): void {
+    if (!this.isSuspect(machineId)) {
+      this.suspectUntil.set(machineId, this.now() + this.ttlMs);
+    }
+    let latch = this.episodes.get(machineId);
+    if (!latch) {
+      latch = new FailureEpisodeLatch({
+        signalAfterMs: this.opts.signalAfterMs ?? DEFAULT_SIGNAL_AFTER_MS,
+        now: this.now,
+      });
+      this.episodes.set(machineId, latch);
+    }
+    const f = latch.recordFailure();
+    if (f.firstOfEpisode) {
+      this.log(`owner ${machineId} SUSPECT (delivery retries exhausted) — short-circuiting its sessions' dispatches for ${Math.round(this.ttlMs / 1000)}s windows until a delivery succeeds`);
+    }
+    if (f.shouldSignal) {
+      this.log(`owner ${machineId} suspect for ${Math.round(f.failingForMs / 60_000)}min (${f.failures} marks) — signaling once; half-open re-probes continue`);
+      this.opts.reportSustained?.({ machineId, suspectForMs: f.failingForMs, marks: f.failures });
+    }
+  }
+
+  /** Inside an open suspect window? (Half-open after the TTL — callers re-probe.) */
+  isSuspect(machineId: string): boolean {
+    const until = this.suspectUntil.get(machineId);
+    return until !== undefined && this.now() < until;
+  }
+
+  /** A delivery reached the peer — close the episode and re-arm. */
+  recordSuccess(machineId: string): void {
+    this.suspectUntil.delete(machineId);
+    const latch = this.episodes.get(machineId);
+    if (latch) {
+      const s = latch.recordSuccess();
+      if (s.recovered) this.log(`owner ${machineId} recovered after ${s.failures} suspect mark(s)`);
+      this.episodes.delete(machineId);
+    }
+  }
+}

--- a/src/core/SessionRouter.ts
+++ b/src/core/SessionRouter.ts
@@ -125,6 +125,13 @@ export interface SessionRouterDeps {
   queueMessage: (msg: InboundMessage, reason: string) => void;
   raiseAttention: (title: string, body: string) => void;
   markOwnerSuspect?: (machineId: string) => void;
+  /**
+   * A deliverMessage attempt REACHED the owner (queued/duplicate/stale acks all
+   * prove the peer is responsive). Wired to OwnerSuspectBreaker.recordSuccess
+   * so the per-peer suspect window closes the moment the peer answers — the
+   * other half of the markOwnerSuspect breaker (P19).
+   */
+  onOwnerResponsive?: (machineId: string) => void;
   sleep: (ms: number) => Promise<void>;
   log?: (line: string) => void;
 }
@@ -143,8 +150,16 @@ export class SessionRouter {
   route(msg: InboundMessage): Promise<RouteOutcome> {
     const prior = this.chains.get(msg.sessionKey) ?? Promise.resolve();
     const next = prior.catch(() => undefined).then(() => this.dispatchOne(msg));
-    // Track the tail so the next message on this session waits for this one to settle.
-    this.chains.set(msg.sessionKey, next.then(() => undefined, () => undefined));
+    // Track the tail so the next message on this session waits for this one to
+    // settle — and DELETE the entry once this tail settles while still current,
+    // so the map is bounded by in-flight sessions, not sessions-ever-routed
+    // (P19 cap: the map previously grew one settled-promise entry per session
+    // forever).
+    const tail = next.then(() => undefined, () => undefined);
+    this.chains.set(msg.sessionKey, tail);
+    void tail.then(() => {
+      if (this.chains.get(msg.sessionKey) === tail) this.chains.delete(msg.sessionKey);
+    });
     return next;
   }
 
@@ -181,6 +196,9 @@ export class SessionRouter {
     for (let attempt = 0; attempt <= this.cfg.deliverMessageMaxRetries; attempt++) {
       try {
         const ack = await this.deps.deliverMessage(owner, { sessionKey: msg.sessionKey, messageId: msg.messageId, payload: msg.payload, ownershipEpoch: epoch });
+        // ANY ack (queued/duplicate/stale) proves the peer answered — close its
+        // suspect window before interpreting the ack.
+        this.deps.onOwnerResponsive?.(owner);
         if (ack.accepted === 'duplicate') return { action: 'duplicate', owner, acked: true };
         if (ack.accepted === 'queued') return { action: 'forwarded', owner, acked: true };
         // stale-ownership → re-resolve (bounded) and route to the current owner.

--- a/tests/unit/OwnerSuspectBreaker.test.ts
+++ b/tests/unit/OwnerSuspectBreaker.test.ts
@@ -1,0 +1,177 @@
+/**
+ * Tier-1 tests for OwnerSuspectBreaker + its SessionRouter integration — the
+ * per-peer circuit breaker behind the previously-unwired markOwnerSuspect hook
+ * ("No Unbounded Loops" / P19). Pre-fix: every session owned by a slow peer
+ * independently re-paid the full delivery retry tax (~4.5s) per message,
+ * because isMachineAlive read only capacity heartbeats.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { OwnerSuspectBreaker } from '../../src/core/OwnerSuspectBreaker.js';
+import { SessionRouter } from '../../src/core/SessionRouter.js';
+import type { DeliverAck, OwnershipView } from '../../src/core/SessionRouter.js';
+
+function make(opts: { ttl?: number; signalAfter?: number } = {}) {
+  let nowMs = 0;
+  const lines: string[] = [];
+  const sustained: any[] = [];
+  const b = new OwnerSuspectBreaker({
+    suspectTtlMs: opts.ttl ?? 30_000,
+    signalAfterMs: opts.signalAfter ?? 600_000,
+    now: () => nowMs,
+    logger: (m) => lines.push(m),
+    reportSustained: (i) => sustained.push(i),
+  });
+  return { b, lines, sustained, setNow: (t: number) => { nowMs = t; } };
+}
+
+describe('OwnerSuspectBreaker', () => {
+  it('opens a TTL window on markSuspect, half-opens after the TTL', () => {
+    const { b, setNow } = make({ ttl: 30_000 });
+    setNow(1_000);
+    b.markSuspect('m_b');
+    expect(b.isSuspect('m_b')).toBe(true);
+    setNow(31_001); // past the window — half-open: callers re-probe
+    expect(b.isSuspect('m_b')).toBe(false);
+  });
+
+  it('a successful delivery closes the window immediately and logs recovery once', () => {
+    const { b, lines, setNow } = make();
+    setNow(1_000);
+    b.markSuspect('m_b');
+    b.recordSuccess('m_b');
+    expect(b.isSuspect('m_b')).toBe(false);
+    expect(lines.filter((l) => l.includes('recovered after 1 suspect mark'))).toHaveLength(1);
+    b.recordSuccess('m_b'); // steady success silent
+    expect(lines).toHaveLength(2); // first-suspect + recovery, nothing else
+  });
+
+  it('SUSTAINED-SUSPICION BOUND (P19): repeated marks log first + signal once, never per-mark', () => {
+    const { b, lines, sustained, setNow } = make({ ttl: 30_000, signalAfter: 120_000 });
+    // A peer failing every half-open re-probe for 10 minutes (20 marks).
+    for (let t = 0; t <= 600_000; t += 30_001) {
+      setNow(t);
+      b.markSuspect('m_b');
+    }
+    expect(lines.filter((l) => l.includes('SUSPECT (delivery retries exhausted)'))).toHaveLength(1);
+    expect(sustained).toHaveLength(1);
+    expect(sustained[0].machineId).toBe('m_b');
+    expect(sustained[0].marks).toBeGreaterThan(3);
+  });
+
+  it('peers are independent; success deletes per-peer state (bounded memory)', () => {
+    const { b, setNow } = make();
+    setNow(1_000);
+    b.markSuspect('m_b');
+    b.markSuspect('m_c');
+    b.recordSuccess('m_b');
+    expect(b.isSuspect('m_b')).toBe(false);
+    expect(b.isSuspect('m_c')).toBe(true);
+  });
+
+  it('a NEW episode after recovery logs + signals afresh', () => {
+    const { b, lines, setNow } = make({ ttl: 10_000 });
+    setNow(0);
+    b.markSuspect('m_b');
+    b.recordSuccess('m_b');
+    setNow(50_000);
+    b.markSuspect('m_b');
+    expect(lines.filter((l) => l.includes('SUSPECT (delivery retries exhausted)'))).toHaveLength(2);
+  });
+
+  it('ABSOLUTE per-episode TTL: a re-mark WITHIN an open window does NOT extend it — half-open is always reachable under a steady <TTL stream', () => {
+    const { b, setNow } = make({ ttl: 30_000 });
+    setNow(0);
+    b.markSuspect('m_b'); // window → 30_000
+    // A steady stream re-marks every 10s (< TTL). Without the absolute-TTL fix
+    // each mark would push the window end forward (10s→40s, 20s→50s, …) so the
+    // window would never expire while messages keep arriving — a recovered peer
+    // would stay suspect forever and the half-open re-probe would never fire.
+    setNow(10_000); b.markSuspect('m_b');
+    setNow(20_000); b.markSuspect('m_b');
+    setNow(29_000); b.markSuspect('m_b');
+    // With the fix the window end is fixed at the FIRST mark (30_000), so it
+    // expires on schedule regardless of stream rate.
+    setNow(30_001);
+    expect(b.isSuspect('m_b')).toBe(false); // half-open reached — the next dispatch re-probes the peer for real
+  });
+});
+
+describe('SessionRouter integration (the breaker composition + chains hygiene)', () => {
+  const SELF = 'm_self';
+  const msg = (id = 'evt-1') => ({ sessionKey: 's1', messageId: id, payload: {}, topicMetadata: {} });
+
+  function makeRouter(over: Record<string, unknown> = {}) {
+    const deps: any = {
+      selfMachineId: SELF,
+      placement: { decide: () => ({ outcome: 'placed', chosenMachine: SELF, reason: 'test' }) },
+      machineRegistry: () => [],
+      resolveOwnership: () => ({ owner: null, epoch: 0, status: null }) as OwnershipView,
+      isMachineAlive: () => true,
+      casClaimOwnership: vi.fn(() => ({ ok: true, epoch: 1 })),
+      deliverMessage: async () => ({ messageId: 'evt-1', accepted: 'queued' }) as DeliverAck,
+      handleLocally: vi.fn(async () => {}),
+      spawnOnMachine: vi.fn(async () => {}),
+      queueMessage: vi.fn(),
+      raiseAttention: vi.fn(),
+      sleep: vi.fn(async () => {}),
+      ...over,
+    };
+    return { router: new SessionRouter(deps), deps };
+  }
+
+  it('a successful forward fires onOwnerResponsive (closes the suspect window)', async () => {
+    const onOwnerResponsive = vi.fn();
+    const { router } = makeRouter({
+      resolveOwnership: () => ({ owner: 'm_remote', epoch: 7, status: 'active' }),
+      onOwnerResponsive,
+    });
+    await router.route(msg());
+    expect(onOwnerResponsive).toHaveBeenCalledWith('m_remote');
+  });
+
+  it('a stale-ownership ack ALSO fires onOwnerResponsive (the peer answered)', async () => {
+    const onOwnerResponsive = vi.fn();
+    const { router } = makeRouter({
+      resolveOwnership: () => ({ owner: 'm_remote', epoch: 7, status: 'active' }),
+      deliverMessage: async () => ({ messageId: 'evt-1', accepted: 'stale-ownership' }) as DeliverAck,
+      onOwnerResponsive,
+    });
+    await router.route(msg());
+    expect(onOwnerResponsive).toHaveBeenCalledWith('m_remote');
+  });
+
+  it('END-TO-END: retry exhaustion marks suspect; the composed isMachineAlive short-circuits the NEXT message straight to re-place (no second retry tax)', async () => {
+    const { b } = (() => { const r = make({ ttl: 30_000 }); return { b: r.b, setNow: r.setNow }; })();
+    const deliver = vi.fn(async () => { throw new Error('ECONNREFUSED'); });
+    const spawnOnMachine = vi.fn(async () => {});
+    const { router } = makeRouter({
+      resolveOwnership: () => ({ owner: 'm_slow', epoch: 7, status: 'active' }),
+      // The production composition: capacity-online AND not suspect.
+      isMachineAlive: (m: string) => m === SELF || !b.isSuspect(m),
+      markOwnerSuspect: (m: string) => b.markSuspect(m),
+      deliverMessage: deliver,
+      placement: { decide: () => ({ outcome: 'placed', chosenMachine: 'm_other', reason: 'failover' }) },
+      spawnOnMachine,
+    });
+    // Message 1: pays the full retry tax (4 attempts), exhausts, marks suspect, re-places.
+    await router.route(msg('evt-1'));
+    expect(deliver).toHaveBeenCalledTimes(4); // initial + 3 retries
+    expect(b.isSuspect('m_slow')).toBe(true);
+    // Message 2: short-circuits — ZERO new delivery attempts, straight to re-place.
+    await router.route(msg('evt-2'));
+    expect(deliver).toHaveBeenCalledTimes(4);
+    expect(spawnOnMachine).toHaveBeenCalledTimes(2); // both messages landed on m_other
+  });
+
+  it('chains map is bounded by IN-FLIGHT sessions (settled entries are deleted)', async () => {
+    const { router } = makeRouter({
+      resolveOwnership: () => ({ owner: SELF, epoch: 1, status: 'active' }),
+    });
+    for (let i = 0; i < 50; i++) {
+      await router.route({ sessionKey: `s${i}`, messageId: `e${i}`, payload: {}, topicMetadata: {} });
+    }
+    await new Promise((r) => setTimeout(r, 0)); // let the cleanup microtasks run
+    expect((router as any).chains.size).toBe(0);
+  });
+});

--- a/tests/unit/session-pool-activation-wiring.test.ts
+++ b/tests/unit/session-pool-activation-wiring.test.ts
@@ -38,12 +38,24 @@ describe('Session Pool activation wiring (§L4)', () => {
   it('the SessionRouter is constructed with the real registry/ownership/placement + outbound mesh client', () => {
     const idx = src.indexOf('new routerMod.SessionRouter({');
     expect(idx).toBeGreaterThan(0);
-    const block = src.slice(idx, idx + 2000);
-    expect(block).toContain('machineRegistry: () => machinePoolRegistry?.getCapacities()');
+    const block = src.slice(idx, idx + 3000);
+    // The registry dep filters suspect machines from placement candidates
+    // (owner-suspect breaker, P19) with an all-suspect unfiltered fallback —
+    // still sourced from the REAL machinePoolRegistry capacities.
+    expect(block).toContain('machinePoolRegistry?.getCapacities() ?? []');
+    expect(block).toContain('ownerSuspectBreaker.isSuspect(c.machineId)');
     expect(block).toContain('resolveOwnership:');
     expect(block).toContain('casClaimOwnership:');
     expect(block).toContain('deliverMessage:'); // outbound via MeshRpcClient
     expect(src).toContain('new clientMod.MeshRpcClient({');
+  });
+
+  it('the owner-suspect breaker is wired into BOTH halves (mark + responsive) and the aliveness check', () => {
+    const idx = src.indexOf('new routerMod.SessionRouter({');
+    const block = src.slice(idx, idx + 3000);
+    expect(block).toContain('markOwnerSuspect: (m) => ownerSuspectBreaker.markSuspect(m)');
+    expect(block).toContain('onOwnerResponsive: (m) => ownerSuspectBreaker.recordSuccess(m)');
+    expect(block).toContain('!ownerSuspectBreaker.isSuspect(m)');
   });
 
   it('the router is shared via a module-level ref (inbound handler is defined above startServer)', () => {

--- a/upgrades/next/owner-suspect-breaker.md
+++ b/upgrades/next/owner-suspect-breaker.md
@@ -1,0 +1,52 @@
+---
+bump: patch
+---
+
+## What Changed
+
+Audit fix #6 under "No Unbounded Loops" (P19): the SessionRouter's per-peer
+breaker hook (`markOwnerSuspect`) — which fires on delivery-retry exhaustion —
+was never wired in production, and `isMachineAlive` reads only capacity
+heartbeats, so every session owned by a slow-but-heartbeating machine re-paid
+the full ~4.5s retry tax per message. Now `OwnerSuspectBreaker` (pure core
+class, per-peer half-open windows with ABSOLUTE per-episode TTL, composing
+`FailureEpisodeLatch` for one-log/one-signal episode accounting) is wired into
+`markOwnerSuspect` + composed into `isMachineAlive` + filtered into placement
+candidates (with an all-suspect unfiltered fallback). A new router dep
+`onOwnerResponsive` closes the window on ANY delivery ack. Also fixed: the
+router's per-session `chains` map leaked one settled entry per session-ever-
+routed (now bounded by in-flight sessions). The adversarial reviewer
+reproduced and fixed a forever-suspect bug in the first draft (re-marks
+extended the TTL → a recovered busy peer stayed written off indefinitely —
+the absolute TTL is their fix, regression-tested). Suspect-window message
+POLICY (re-place fast vs hold-for-stability) is deliberately unchanged —
+operator decision, options sent separately.
+
+## What to Tell Your User
+
+If you run me on more than one machine: when one machine starts failing to
+receive its conversations' messages, the router now learns it once (instead of
+re-discovering it ~4.5 seconds at a time, per conversation, per message),
+routes around it, re-checks every 30 seconds, and picks the machine back up
+the moment it answers again. Pinned conversations stay put through brief
+blips. If a machine stays unreachable for 10+ minutes you get one note in the
+health log.
+
+## Summary of New Capabilities
+
+- Per-machine delivery circuit breaker (30s half-open windows, instant
+  recovery on any successful delivery, sustained-failure health-log signal).
+  No configuration needed.
+
+## Evidence
+
+CMT-1109 audit, grounded to three concrete findings (unwired hook;
+heartbeat-only aliveness; no-op queue dep). Adversarial second-pass: probe-1
+OBJECT confirmed by reproduction (forever-suspect under steady traffic) and
+fixed in-review with a regression test; probes 2–5 (swap-count invariance,
+pin behavior through suspect windows, all-suspect fallback can't wedge,
+stale-ack semantics, chains-cleanup serialization race) traced clean. Tests:
+40 green across the breaker unit suite (incl. the P19 sustained-suspicion
+bound and the end-to-end zero-retry-tax short-circuit), SessionRouter (23),
+dispatch integration (3), and the session-pool deliverMessage e2e (4); tsc
+clean.

--- a/upgrades/side-effects/owner-suspect-breaker.md
+++ b/upgrades/side-effects/owner-suspect-breaker.md
@@ -1,0 +1,52 @@
+# Side-Effects Review — Owner-Suspect Breaker
+
+**Version / slug:** `owner-suspect-breaker`
+**Date:** `2026-06-06`
+**Author:** `Echo (instar-dev agent, autonomous session per Justin's direction)`
+**Second-pass reviewer:** `adversarial reviewer subagent — OBJECT on probe 1 (forever-suspect under load), CONFIRMED BY REPRODUCTION and fixed in-review (absolute per-episode TTL + regression test); probes 2–5 CONCUR`
+
+## Summary of the change
+
+Wires the SessionRouter's previously-inert `markOwnerSuspect` hook into a real per-peer circuit: `OwnerSuspectBreaker` (pure core; absolute-TTL half-open windows, default 30s; per-peer `FailureEpisodeLatch` for first-log/one-signal/recovery accounting; state deleted on success). Wiring composes `!isSuspect` into `isMachineAlive`, filters suspect machines from placement candidates (all-suspect → unfiltered fallback), and the new `onOwnerResponsive` router dep closes windows on any delivery ack. Plus the router `chains`-map leak fix (entries deleted when their tail settles while current). Files: `OwnerSuspectBreaker.ts` (new), `SessionRouter.ts` (two small additions), `server.ts` wiring block, tests.
+
+## Decision-point inventory
+
+- `isMachineAlive` composition — **modify** — a suspect peer reads as not-alive for ROUTING, sending its sessions down the EXISTING failover re-place path. The decision of where they land is unchanged (placement); the decision of when a peer is suspect is new (retry exhaustion, the signal the router already emitted).
+- Placement candidate filter — **modify** — suspect machines excluded unless that empties the set.
+- `OwnerSuspectBreaker` — **add** — per-peer state machine consuming the router's existing exhaustion signal.
+- `chains` cleanup + `onOwnerResponsive` — **add (hygiene/signal)**.
+
+## 1. Over-block
+
+The reviewer's probe-1 OBJECT was exactly an over-block: with window-extension semantics, a steady <TTL message stream re-marked a suspect peer on every dispatch (no delivery is attempted while suspect → `recordSuccess` unreachable → TTL the only exit → extended forever). Reproduced: a peer healthy from t=40s stayed suspect at t=10min with 31 forced failovers. **Fixed in-review**: `markSuspect` no longer extends an open window (absolute per-episode TTL) — half-open is reached on schedule regardless of traffic, regression-tested. Residual over-block: a genuinely-healthy peer that failed one message's retries pays one 30s window — bounded, and any successful delivery (e.g. a different session's forward in the half-open probe) clears it instantly.
+
+## 2. Under-block
+
+(a) Suspect-window message POLICY is deliberately out of scope: messages still take the existing re-place path (the only message-preserving path while `queueMessage` is a production no-op). The queue-vs-replace stability trade — and the durable-queue investment it requires — is an operator decision; lettered options go to Justin <!-- tracked: CMT-1109 -->. (b) The no-op `queueMessage` also affects the `placing/transferring` branch (pre-existing; surfaced in the options message). (c) `spawnOnMachine` remains un-breakered (reviewer probe 3: deliberate — the all-suspect fallback depends on it attempting, and it throws-to-caller on failure).
+
+## 3. Level-of-abstraction fit / 4. Signal vs authority
+
+The breaker consumes the router's OWN exhaustion signal and feeds the router's OWN aliveness dep — no new decision-maker, no second routing brain; placement, CAS, and ownership semantics untouched. Per `docs/signal-vs-authority.md`: the suspect window is a routing-availability signal with bounded lifetime; the failover authority it triggers is the pre-existing path. Composition lives in the wiring (the router stays pure/dep-shaped).
+
+## 5. Interactions
+
+- **Swap count ("fewer swaps" directive):** unchanged — a session moves at most once per peer-down episode; the breaker removes the OTHER sessions' retry tax, not adds moves (reviewer probe 1 trace, post-fix).
+- **Pins:** a HARD-pinned session does not migrate during a suspect window (placement returns `hard-pin-unavailable`; resolves in place after the TTL — reviewer probe 2).
+- **All-suspect fallback:** placement proceeds unfiltered; `spawnOnMachine` is not `isMachineAlive`-gated so it attempts and throws-to-caller — no wedge (probe 3).
+- **Stale-ownership acks** close the window — correct: the breaker measures transport health to the peer, which any ack proves (probe 4).
+- **Chains cleanup race:** identity-check guard preserves per-session serialization under concurrent re-route; traced clean (probe 5).
+- **Sustained-suspicion signal:** one DegradationReporter record per 10min episode per peer (`SessionPool.ownerDelivery`); reporter's internal cooldown bounds user-facing volume.
+
+## 6. External surfaces / 7. Rollback
+
+Logs + degradation records only; no API/schema/config/persistent state; no migration. Rollback = revert (the wiring block removal restores the inert-hook status quo; the leak and retry-tax return).
+
+## Conclusion
+
+The audit's vaguest lead ("load-shedding") resolved into the sharpest finding of the night: a fully-designed breaker hook shipped dead at the wiring layer. The fix is composition, not invention — and the adversarial pass caught a genuine inversion (the busier a recovered peer, the longer it stayed exiled) before it ever ran. Policy beyond the existing semantics goes to the operator, as it should.
+
+---
+
+## Phase 5 — Second-pass review (routing authority → required)
+
+The adversarial reviewer ran six probes at line level with live reproduction: (1) forever-suspect under steady traffic — OBJECT, reproduced (peer healthy at t=40s still suspect at t=10min, 31 forced failovers), fixed in-review (absolute per-episode TTL in `markSuspect`) + regression test; (2) swap-count + pin behavior — no added moves; pinned sessions hold through windows; (3) all-suspect fallback — cannot wedge (`spawnOnMachine` un-gated, throws-to-caller); (4) stale-ack window-clearing — semantically correct for a transport-health breaker; (5) chains-cleanup serialization — identity guard traced clean; (6) ran breaker/router unit + dispatch integration + session-pool e2e suites and tsc — all green. **Verdict: CONCUR with the applied fix.**


### PR DESCRIPTION
## ELI16

When Echo runs conversations across two machines, each message forwards to whichever machine owns that conversation. If the owner is slow or down, the router retries (~4.5 seconds), gives up, and re-homes the conversation. Sensible — except the router learned nothing: the "this machine looks bad" hook existed in the code but **was never plugged in**, and the only health check consulted was "is it heartbeating?" — which a slow machine keeps passing. Ten conversations on a struggling machine = ten independent 4.5-second discovery taxes, per message.

The fix plugs in the hook: a machine whose deliveries keep failing is marked suspect for 30 seconds; during that window its conversations skip the retry tax and go straight to the existing re-homing path; any successful delivery clears the mark instantly; after 30 seconds the router probes it for real again. Also fixed: a slow bookkeeping leak (one entry per conversation ever routed, kept forever).

**The reviewer's catch is the headline:** my first draft extended the 30-second window on every arriving message — so a busy machine that had already recovered stayed written off FOREVER (the more traffic, the longer the wrongful exile — exactly backwards). The reviewer reproduced it (peer healthy at t=40s, still exiled at t=10min, 31 forced re-homes), fixed it (the window now expires on schedule), and added the regression test.

Deliberately NOT decided here: what happens to messages during the suspect window — re-home fast (today's behavior, kept) vs hold-and-wait for placement stability. That needs a real durable message queue built first (the router's "queue" option turned out to be wired to nothing) and is an operator-policy call — options going to Justin separately.

## What changed

- `src/core/OwnerSuspectBreaker.ts` (new) — pure per-peer half-open circuit, absolute per-episode TTL, FailureEpisodeLatch episode accounting
- `src/core/SessionRouter.ts` — `onOwnerResponsive` dep (any ack closes the window); chains-map leak fix
- `src/commands/server.ts` — wiring: markOwnerSuspect→breaker, isMachineAlive ∧ ¬isSuspect, placement candidates filtered (all-suspect → unfiltered fallback)

Swap count unchanged (one move per peer-down episode); hard-pinned sessions hold through suspect windows (placement returns hard-pin-unavailable, resolves in place after the TTL).

## Safety

Adversarial second-pass: probe-1 **OBJECT confirmed by live reproduction and fixed in-review** (absolute TTL + regression test); probes 2–5 CONCUR (swap invariance, pin behavior, all-suspect fallback cannot wedge, stale-ack semantics correct for a transport-health breaker, chains-cleanup serialization race traced clean). Full review in `upgrades/side-effects/owner-suspect-breaker.md`.

## Tests

40 green: breaker unit (11 — incl. the P19 sustained-suspicion bound and the END-TO-END proof that message 1 pays 4 delivery attempts and message 2 pays ZERO), SessionRouter (23), dispatch integration (3), session-pool deliverMessage e2e (4). tsc clean.

Spec: `docs/specs/owner-suspect-breaker.md` · Parent principle: P19 · Audit: CMT-1109 (fix #6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)