### PR TITLE
fix(monitoring): AUP-rejection wedge signature + fresh-respawn API lever

### DIFF
--- a/.instar/instar-dev-decisions/2026-06-06T04-02-18-752Z-url-pathname-path-encoding-fix.json
+++ b/.instar/instar-dev-decisions/2026-06-06T04-02-18-752Z-url-pathname-path-encoding-fix.json
@@ -1,0 +1,16 @@
+{
+  "ts": "2026-06-06T04:02:18.752Z",
+  "slug": "url-pathname-path-encoding-fix",
+  "suggestedTier": 2,
+  "declaredTier": null,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "irreversibility: src/core/PostUpdateMigrator.ts touches PostUpdateMigrator",
+    "migration / fleet-rollout surface: src/core/PostUpdateMigrator.ts touches PostUpdateMigrator (fleet migration machinery)"
+  ],
+  "belowFloor": false,
+  "files": 4,
+  "loc": 190,
+  "causalAutopsy": null,
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-06-06T04-04-07-179Z-aup-wedge-fresh-api.json
+++ b/.instar/instar-dev-decisions/2026-06-06T04-04-07-179Z-aup-wedge-fresh-api.json
@@ -1,0 +1,19 @@
+{
+  "ts": "2026-06-06T04:04:07.179Z",
+  "slug": "aup-wedge-fresh-api",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "irreversibility: src/core/PostUpdateMigrator.ts touches PostUpdateMigrator",
+    "migration / fleet-rollout surface: src/core/PostUpdateMigrator.ts touches PostUpdateMigrator (fleet migration machinery)"
+  ],
+  "belowFloor": true,
+  "files": 4,
+  "loc": 190,
+  "causalAutopsy": {
+    "origin": "latent",
+    "notes": "The sentinel shipped (by design) with only the thinking-block-400 signature; the AUP-rejection family existed as a latent blind spot from day one and was surfaced by a NEW usage pattern (red-team payload generation in the EXO 3.0 MTP harness work, 2026-06-05 topic 19437). Not caused by a prior PR regression. Separate operational finding from the same incident (sentinel config-disabled on Echo) is tracked under CMT-1115/guard-disable-tripwire, not this change."
+  },
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-06-06T04-04-50-046Z-aup-wedge-fresh-api.json
+++ b/.instar/instar-dev-decisions/2026-06-06T04-04-50-046Z-aup-wedge-fresh-api.json
@@ -1,0 +1,19 @@
+{
+  "ts": "2026-06-06T04:04:50.046Z",
+  "slug": "aup-wedge-fresh-api",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "irreversibility: src/core/PostUpdateMigrator.ts touches PostUpdateMigrator",
+    "migration / fleet-rollout surface: src/core/PostUpdateMigrator.ts touches PostUpdateMigrator (fleet migration machinery)"
+  ],
+  "belowFloor": true,
+  "files": 4,
+  "loc": 190,
+  "causalAutopsy": {
+    "origin": "latent",
+    "notes": "The sentinel shipped (by design) with only the thinking-block-400 signature; the AUP-rejection family existed as a latent blind spot from day one and was surfaced by a NEW usage pattern (red-team payload generation in the EXO 3.0 MTP harness work, 2026-06-05 topic 19437). Not caused by a prior PR regression. Separate operational finding from the same incident (sentinel config-disabled on Echo) is tracked under CMT-1115/guard-disable-tripwire, not this change."
+  },
+  "verdict": "pass"
+}

--- a/docs/specs/context-wedge-sentinel.md
+++ b/docs/specs/context-wedge-sentinel.md
@@ -76,6 +76,32 @@ two ways:
    re-captures. The wedge is confirmed only if the signature is STILL the tail
    (the session made no progress). A transient or a discussing-session clears.
 
+### Second signature family — AUP-rejection loop (added 2026-06-05)
+
+Triggering incident: the EXO 3.0 session's transcript accumulated literal
+red-team test payloads (prompt-injection probes, token-sharing asks) generated
+during MTP security-harness work. The API's Usage Policy classifier began
+rejecting the WHOLE conversation: `API Error: Claude Code is unable to respond
+to this request, which appears to violate our Usage Policy`. Every turn
+re-sends the full transcript, so every reply failed in ~8–10s — the same
+permanent-death shape as the thinking-block 400 (still emitting output, so the
+silence + socket sentinels miss it), and the same recovery (a resume re-sends
+the poisoned content and re-wedges; only a fresh respawn clears it).
+
+`detectAupRejection(text)` matches the rejection phrase;
+`classifyWedgeTail(text)` returns which family (if any) is the live tail.
+The AUP family carries one EXTRA discriminator beyond the tail gate + confirm
+window: the signature must appear on **more than one line** of the capture. A
+single policy rejection can be a benign one-off (one bad request; the next
+message works fine) and must NOT cost the session its conversation; the wedge
+loop always repeats because every turn re-fails. Events carry `kind`
+(`thinking-block-400` | `aup-rejection`) into the sentinel audit trail and the
+escalation wording.
+
+Prevention guidance (documented in the CLAUDE.md template): literal
+adversarial payloads belong in files on disk, referenced by path — never
+pasted into a conversation transcript.
+
 ### Recovery — fresh respawn (NOT a nudge)
 
 The corrupted turn is permanent in the transcript, so recovery is a **clean
@@ -87,6 +113,12 @@ resuming the corrupted one. Without this, a naive kill would re-wedge on the
 next message — the kill saves the UUID, the next inbound message `--resume`s it,
 and the same 400 fires (an infinite re-wedge loop). `SessionRefresh`'s existing
 rate-guard caps respawns.
+
+Fresh-mode is also reachable via the API (added 2026-06-05): `POST
+/sessions/refresh` accepts `fresh: true` and forwards it to
+`SessionRefresh.refreshSession`. Before this, only the sentinel's internal
+wiring could fresh-respawn — recovering the EXO AUP wedge manually required
+hand-editing `topic-resume-map.json`.
 
 ### Recovery policy + Graduated Feature Rollout
 

--- a/src/commands/server.ts
+++ b/src/commands/server.ts
@@ -6287,7 +6287,8 @@ export async function startServer(options: StartOptions): Promise<void> {
         ));
       }
 
-      // ── ContextWedgeSentinel — thinking-block-400 fast-fail wedge ──
+      // ── ContextWedgeSentinel — transcript fast-fail wedges (thinking-block
+      // 400 + AUP-rejection loop) ──
       // Detection + audit ship default-ON (harmless housekeeping). The
       // destructive fresh-respawn is gated by autoRecovery (default OFF +
       // dryRun) and rides the Graduated Feature Rollout track. freshRespawn is
@@ -6318,12 +6319,12 @@ export async function startServer(options: StartOptions): Promise<void> {
             confirmWindowMs: wedgeCfg.confirmWindowMs,
           },
         );
-        wedgeSentinel.on('detected', (e: { sessionName: string }) =>
-          notifier.record('detected', 'context-wedge', e.sessionName));
-        wedgeSentinel.on('recovered', (e: { sessionName: string }) =>
-          notifier.record('recovered', 'context-wedge', e.sessionName, 'fresh respawn'));
-        wedgeSentinel.on('dry-run', (e: { sessionName: string }) =>
-          notifier.record('dry-run', 'context-wedge', e.sessionName, 'would fresh-respawn'));
+        wedgeSentinel.on('detected', (e: { sessionName: string; kind?: string }) =>
+          notifier.record('detected', 'context-wedge', e.sessionName, e.kind));
+        wedgeSentinel.on('recovered', (e: { sessionName: string; kind?: string }) =>
+          notifier.record('recovered', 'context-wedge', e.sessionName, `fresh respawn (${e.kind ?? 'unknown'})`));
+        wedgeSentinel.on('dry-run', (e: { sessionName: string; kind?: string }) =>
+          notifier.record('dry-run', 'context-wedge', e.sessionName, `would fresh-respawn (${e.kind ?? 'unknown'})`));
         wedgeSentinel.on('false-alarm', (e: { sessionName: string }) =>
           notifier.record('false-alarm', 'context-wedge', e.sessionName, 'signature scrolled out of tail'));
         wedgeSentinel.on('recovery-error', (e: { sessionName: string; err: unknown }) =>
@@ -6331,7 +6332,7 @@ export async function startServer(options: StartOptions): Promise<void> {
         wedgeSentinel.start();
         wedgeRecoveryActive = (s: string) => wedgeSentinel.isRecoveryActive(s);
         const mode = autoRecovery.enabled ? (autoRecovery.dryRun ? 'auto-recover dry-run' : 'auto-recover LIVE') : 'detect-only';
-        console.log(pc.green(`  ContextWedgeSentinel enabled (thinking-block-400 wedge — ${mode})`));
+        console.log(pc.green(`  ContextWedgeSentinel enabled (thinking-block-400 + aup-rejection wedges — ${mode})`));
       }
     }
 

--- a/src/core/PostUpdateMigrator.ts
+++ b/src/core/PostUpdateMigrator.ts
@@ -63,6 +63,17 @@ import {
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
+/**
+ * CLAUDE.md note for the second wedge-signature family (2026-06-05 EXO
+ * incident) + the API fresh-respawn lever. Appended to NEW installs as part of
+ * the Stuck-Context Recovery section, and patched onto agents that already
+ * have the section. Marker for idempotency: 'AUP-rejection wedge'.
+ */
+const AUP_WEDGE_CLAUDE_MD_NOTE = `
+- **AUP-rejection wedge (second signature, 2026-06-05):** a transcript that accumulates content tripping the API's Usage Policy classifier (e.g. literal red-team / prompt-injection test payloads from security-harness work) gets EVERY reply rejected with \`API Error: … appears to violate our Usage Policy\` — same permanent death, same fresh-respawn recovery. The sentinel requires the signature on MORE THAN ONE line (the loop always repeats; a benign one-off rejection doesn't). Prevention: keep literal adversarial payloads in files on disk and reference them by path — never paste them into a conversation.
+- **Fresh respawn via API:** \`POST /sessions/refresh\` with \`{"sessionName":"<tmux-name>","fresh":true,"reason":"…"}\` kills + respawns WITHOUT \`--resume\` (clears the topic's resume UUID first). Use it when a transcript is poisoned — a normal refresh would re-wedge.
+`;
+
 export interface MigrationResult {
   /** What was upgraded */
   upgraded: string[];
@@ -3419,9 +3430,10 @@ A secret you give me on one machine — a Telegram token, an API key, a GitHub P
     }
 
     // ContextWedgeSentinel — the 4th silently-stopped sentinel. Tells the agent
-    // about the thinking-block-400 wedge + that auto-recovery is opt-in. Without
-    // it, an agent asked "why did my session keep failing instantly / what is
-    // the thinking-block error?" has no grounded answer. Idempotent via marker.
+    // about the transcript fast-fail wedges (thinking-block 400 + AUP-rejection
+    // loop) + that auto-recovery is opt-in. Without it, an agent asked "why did
+    // my session keep failing instantly / what is the thinking-block error?"
+    // has no grounded answer. Idempotent via marker.
     if (!content.includes('ContextWedgeSentinel') && !content.includes('Stuck-Context Recovery (thinking-block wedge)')) {
       const section = `
 ## Stuck-Context Recovery (thinking-block wedge)
@@ -3433,12 +3445,20 @@ A nudge can't fix this (re-engaging re-sends the corrupted turn). Recovery is a 
 - **Detection + audit are default-ON housekeeping** — every transition (detected / recovered / dry-run / false-alarm / escalated) lands in \`logs/sentinel-events.jsonl\`; the user sees nothing.
 - **Auto-recovery is OPT-IN** (it kills + respawns a session). It rides the Graduated Feature Rollout track and ships dark. Turn it on in \`.instar/config.json\`: \`{"monitoring": {"contextWedgeSentinel": {"autoRecovery": {"enabled": true, "dryRun": false}}}}\` (use \`dryRun: true\` first to log what it WOULD respawn). When OFF, a confirmed wedge escalates (gated by \`sentinelTelegramEscalation\`) so you can restart it yourself.
 - If a user asks "why did my session keep failing / get stuck on a thinking error?" — read \`logs/sentinel-events.jsonl\` (filter \`context-wedge\`) and explain the above. Spec: \`docs/specs/context-wedge-sentinel.md\`.
-`;
+${AUP_WEDGE_CLAUDE_MD_NOTE}`;
       content += '\n' + section;
       patched = true;
       result.upgraded.push('CLAUDE.md: added Stuck-Context Recovery section');
+    } else if (content.includes('ContextWedgeSentinel') && !content.includes('AUP-rejection wedge')) {
+      // Agents that already got the Stuck-Context section predate the second
+      // signature family (the 2026-06-05 EXO AUP-rejection incident). Append
+      // the note so they know about it + the API fresh-respawn lever.
+      // Idempotent via the 'AUP-rejection wedge' marker.
+      content += '\n' + AUP_WEDGE_CLAUDE_MD_NOTE;
+      patched = true;
+      result.upgraded.push('CLAUDE.md: added AUP-rejection wedge + fresh-respawn API note');
     } else {
-      result.skipped.push('CLAUDE.md: Stuck-Context Recovery section already present');
+      result.skipped.push('CLAUDE.md: Stuck-Context Recovery section already current');
     }
 
     // Reap-log (UNIFIED-SESSION-LIFECYCLE §P4) — tells the agent the durable

--- a/src/monitoring/ContextWedgeSentinel.ts
+++ b/src/monitoring/ContextWedgeSentinel.ts
@@ -1,17 +1,29 @@
 /**
- * ContextWedgeSentinel — detects Claude Code's "thinking/redacted_thinking
- * blocks in the latest assistant message cannot be modified" 400 wedge and
- * recovers via a FRESH respawn.
+ * ContextWedgeSentinel — detects transcript-level fast-fail wedges (the
+ * thinking-block 400 and the Usage-Policy rejection loop) and recovers via a
+ * FRESH respawn.
  *
- * The failure (diagnosed 2026-05-28): a tool call is cancelled inside a
- * parallel tool batch while extended thinking is on. Claude Code cancels every
- * sibling call, and that cancellation corrupts the thinking block on the latest
- * assistant turn. The Anthropic API then rejects EVERY resume of that session
- * with `400 ... thinking blocks in the latest assistant message cannot be
- * modified`. The session fast-fails instantly on every inbound message ("Cooked
- * for 0s"); it is permanently dead yet still emitting output, so neither the
- * silence sentinel (output never goes quiet) nor the socket sentinel (no
- * disconnect string) catches it.
+ * Signature family 1 — thinking-block 400 (diagnosed 2026-05-28): a tool call
+ * is cancelled inside a parallel tool batch while extended thinking is on.
+ * Claude Code cancels every sibling call, and that cancellation corrupts the
+ * thinking block on the latest assistant turn. The Anthropic API then rejects
+ * EVERY resume of that session with `400 ... thinking blocks in the latest
+ * assistant message cannot be modified`. The session fast-fails instantly on
+ * every inbound message ("Cooked for 0s"); it is permanently dead yet still
+ * emitting output, so neither the silence sentinel (output never goes quiet)
+ * nor the socket sentinel (no disconnect string) catches it.
+ *
+ * Signature family 2 — AUP-rejection loop (diagnosed 2026-06-05, EXO 3.0
+ * incident): the transcript accumulates content that trips the API's Usage
+ * Policy classifier (e.g. literal red-team / prompt-injection test payloads
+ * generated during security-harness work). Because every turn re-sends the
+ * full conversation, EVERY response attempt is rejected with `API Error:
+ * Claude Code is unable to respond to this request, which appears to violate
+ * our Usage Policy` — same permanent-death shape, same recovery. Unlike the
+ * thinking-block 400, a SINGLE policy rejection can be a benign one-off (one
+ * bad request, next message fine), so this family additionally requires the
+ * signature to appear MORE THAN ONCE in the capture (the loop always repeats;
+ * a one-off never does) before it counts as a wedge.
  *
  * Critical difference from the other silently-stopped sentinels: a send-keys
  * nudge CANNOT recover this — re-engaging just re-sends the corrupted turn and
@@ -56,6 +68,8 @@ export interface ContextWedgeState {
   sessionName: string;
   detectedAt: number;
   status: ContextWedgeStatus;
+  /** Which signature family triggered the detection. */
+  kind: WedgeKind;
 }
 
 export interface ContextWedgeSentinelDeps {
@@ -105,6 +119,18 @@ export const CONTEXT_WEDGE_PATTERNS: readonly RegExp[] = [
   /`?(?:thinking|redacted_thinking)`?\s+blocks.{0,80}cannot be modified/i,
 ];
 
+/**
+ * Patterns for the AUP-rejection loop. Anchored on the API-specific rejection
+ * phrase, which natural prose almost never contains verbatim.
+ */
+export const AUP_WEDGE_PATTERNS: readonly RegExp[] = [
+  /unable to respond to this request.{0,60}appears to violate our Usage Policy/is,
+  /appears to violate our Usage Policy/i,
+];
+
+/** Which signature family a wedge detection matched. */
+export type WedgeKind = 'thinking-block-400' | 'aup-rejection';
+
 /** Detector — true if `text` contains the thinking-block-400 signature. */
 export function detectContextWedge(text: string): boolean {
   if (!text) return false;
@@ -114,17 +140,51 @@ export function detectContextWedge(text: string): boolean {
   return false;
 }
 
-/**
- * Tail detector — is the signature present within the last `tailLines`
- * non-empty lines of the capture? A genuinely wedged session shows the error as
- * its live tail; a session that merely mentioned the error earlier and then
- * kept working has scrolled it out of the tail.
- */
-export function signatureIsTail(text: string, tailLines = 10): boolean {
+/** Detector — true if `text` contains the AUP-rejection signature. */
+export function detectAupRejection(text: string): boolean {
   if (!text) return false;
+  for (const pat of AUP_WEDGE_PATTERNS) {
+    if (pat.test(text)) return true;
+  }
+  return false;
+}
+
+/**
+ * Count how many distinct lines of `text` carry the AUP signature. The
+ * rejection loop re-prints the error on every failed turn, so a wedged session
+ * shows it repeatedly; a benign one-off rejection appears exactly once.
+ */
+function countAupSignatureLines(text: string): number {
+  if (!text) return 0;
+  let n = 0;
+  for (const line of text.split('\n')) {
+    if (line && detectAupRejection(line)) n++;
+  }
+  return n;
+}
+
+/**
+ * Tail classifier — which wedge family (if any) is the live tail of the
+ * capture? A genuinely wedged session shows the error as its tail; a session
+ * that merely mentioned the error earlier and then kept working has scrolled
+ * it out. The AUP family additionally requires the signature on >1 line of the
+ * full capture — the loop always repeats, a benign one-off rejection doesn't.
+ */
+export function classifyWedgeTail(text: string, tailLines = 10): WedgeKind | null {
+  if (!text) return null;
   const lines = text.split('\n').map(l => l.trim()).filter(Boolean);
   const tail = lines.slice(-tailLines).join('\n');
-  return detectContextWedge(tail);
+  if (detectContextWedge(tail)) return 'thinking-block-400';
+  if (detectAupRejection(tail) && countAupSignatureLines(text) > 1) return 'aup-rejection';
+  return null;
+}
+
+/**
+ * Tail detector — is any wedge signature the live tail? (Back-compat wrapper
+ * around classifyWedgeTail; existing callers and tests use the boolean form.)
+ */
+export function signatureIsTail(text: string, tailLines = 10): boolean {
+  return classifyWedgeTail(text, tailLines) !== null;
 }
 
 export class ContextWedgeSentinel extends EventEmitter {
@@ -168,12 +228,13 @@ export class ContextWedgeSentinel extends EventEmitter {
     const output = this.deps.getRecentOutput(sessionName);
     // Require the signature to be the live TAIL, not merely present somewhere in
     // the scrollback — the discriminator against a session discussing the bug.
-    if (!signatureIsTail(output)) return;
-    this.report(sessionName);
+    const kind = classifyWedgeTail(output);
+    if (!kind) return;
+    this.report(sessionName, kind);
   }
 
   /** Public entry: report a detected (not yet confirmed) wedge. Idempotent. */
-  report(sessionName: string): void {
+  report(sessionName: string, kind: WedgeKind = 'thinking-block-400'): void {
     if (!this.cfg.enabled) return;
     if (this.states.has(sessionName)) return;
     const now = (this.deps.now ?? Date.now)();
@@ -181,9 +242,10 @@ export class ContextWedgeSentinel extends EventEmitter {
       sessionName,
       detectedAt: now,
       status: 'detected',
+      kind,
     };
     this.states.set(sessionName, state);
-    this.emit('detected', { sessionName });
+    this.emit('detected', { sessionName, kind });
 
     // Enter the confirm window before any destructive action.
     state.status = 'confirming';
@@ -223,8 +285,8 @@ export class ContextWedgeSentinel extends EventEmitter {
     // Confirmation gate: the signature must STILL be the tail. If it scrolled
     // out (the session progressed past the error), this was not a wedge — a
     // false alarm (e.g. a session that quoted the error then kept working).
-    if (!signatureIsTail(output)) {
-      this.emit('false-alarm', { sessionName });
+    if (!classifyWedgeTail(output)) {
+      this.emit('false-alarm', { sessionName, kind: state.kind });
       this.clear(sessionName);
       return;
     }
@@ -241,14 +303,14 @@ export class ContextWedgeSentinel extends EventEmitter {
     switch (outcome) {
       case 'respawned':
         state.status = 'recovered';
-        this.emit('recovered', { sessionName });
+        this.emit('recovered', { sessionName, kind: state.kind });
         this.clear(sessionName);
         return;
       case 'dry-run':
         // Housekeeping only — would-have-respawned. Keep state so we don't
         // re-confirm the same wedge every tick; the dry-run log is the signal.
         state.status = 'escalated';
-        this.emit('dry-run', { sessionName });
+        this.emit('dry-run', { sessionName, kind: state.kind });
         return;
       case 'detect-only':
       case 'failed':
@@ -262,12 +324,16 @@ export class ContextWedgeSentinel extends EventEmitter {
     const state = this.states.get(sessionName);
     if (!state) return;
     state.status = 'escalated';
+    const cause =
+      state.kind === 'aup-rejection'
+        ? 'a policy-rejection loop (its conversation content is being refused by the API on every turn)'
+        : 'a stuck-context error';
     const detail =
       outcome === 'failed'
-        ? `${friendlyName(sessionName)} is wedged on a stuck-context error and my respawn attempt did not clear it. Want me to dig in?`
-        : `${friendlyName(sessionName)} is wedged on a stuck-context error (it can only be fixed by a fresh restart, which is currently off). Want me to restart it?`;
+        ? `${friendlyName(sessionName)} is wedged on ${cause} and my respawn attempt did not clear it. Want me to dig in?`
+        : `${friendlyName(sessionName)} is wedged on ${cause} (it can only be fixed by a fresh restart, which is currently off). Want me to restart it?`;
     void this.notify(sessionName, detail);
-    this.emit('escalated', { sessionName, outcome });
+    this.emit('escalated', { sessionName, outcome, kind: state.kind });
     // Keep state so a subsequent scan doesn't re-report the same wedge.
   }
 

--- a/src/server/routes.ts
+++ b/src/server/routes.ts
@@ -4508,6 +4508,13 @@ export function createRoutes(ctx: RouteContext): Router {
   // conversation. The response is 202 immediately because the kill itself
   // ends the requester's process — there is no synchronous result.
   //
+  // `fresh: true` skips the `--resume` — the topic's resume UUID is cleared so
+  // the respawn starts a brand-new conversation. This is the recovery path for
+  // a POISONED transcript (thinking-block-400 wedge, AUP-rejection loop) where
+  // resuming would just re-wedge. Before this param existed only the
+  // ContextWedgeSentinel's internal wiring could fresh-respawn; the 2026-06-05
+  // EXO incident required hand-editing topic-resume-map.json to recover.
+  //
   // Rate limit and lifecycle live in SessionRefresh (the orchestrator);
   // this route is a thin entry point.
   router.post('/sessions/refresh', spawnLimiter, (req, res) => {
@@ -4516,7 +4523,7 @@ export function createRoutes(ctx: RouteContext): Router {
       return;
     }
 
-    const { sessionName, followUpPrompt, reason } = req.body || {};
+    const { sessionName, followUpPrompt, reason, fresh } = req.body || {};
 
     if (!sessionName || typeof sessionName !== 'string' || !SESSION_NAME_RE.test(sessionName)) {
       res.status(400).json({ error: '"sessionName" is required and must contain only letters, numbers, hyphens, underscores (max 200)' });
@@ -4530,17 +4537,21 @@ export function createRoutes(ctx: RouteContext): Router {
       res.status(400).json({ error: '"reason" must be a string under 1000 chars' });
       return;
     }
+    if (fresh !== undefined && typeof fresh !== 'boolean') {
+      res.status(400).json({ error: '"fresh" must be a boolean' });
+      return;
+    }
 
     // Acknowledge BEFORE killing — the requester is the session being killed,
     // so it needs to receive the 202 before its process disappears.
-    res.status(202).json({ ok: true, message: 'Refresh scheduled', sessionName });
+    res.status(202).json({ ok: true, message: 'Refresh scheduled', sessionName, fresh: fresh === true });
 
     // Schedule the kill+spawn after the response has flushed and the agent
     // has a moment to log its last action. 500ms is enough for HTTP flush
     // on a local loopback without being a noticeable user-facing delay.
     const sessionRefresh = ctx.sessionRefresh;
     setTimeout(() => {
-      sessionRefresh.refreshSession({ sessionName, followUpPrompt, reason }).then(result => {
+      sessionRefresh.refreshSession({ sessionName, followUpPrompt, reason, fresh }).then(result => {
         if (!result.ok) {
           // Structured logging so over-blocks (rate guard) are detectable
           // in operations per signal-vs-authority logging rule. The agent's

--- a/tests/e2e/context-wedge-sentinel-lifecycle.test.ts
+++ b/tests/e2e/context-wedge-sentinel-lifecycle.test.ts
@@ -170,3 +170,78 @@ describe('ContextWedgeSentinel E2E — WIRED into server.ts (dead-code guard)', 
     expect(serverSrc).toMatch(/fresh:\s*true/);
   });
 });
+
+// ── AUP-rejection family (signature 2, 2026-06-05 EXO incident) ──────────────
+
+const AUP_ERROR_LINE =
+  '⏺ API Error: Claude Code is unable to respond to this request, which appears to violate our Usage Policy (https://www.anthropic.com/legal/aup). Please double press esc to edit your last message or start a new session for Claude Code to assist with a different task.';
+
+const AUP_WEDGE_TAIL = [
+  '❯ [telegram:19437 "🎯 EXO 3.0" from Justin] did you get my last 3 messages?',
+  AUP_ERROR_LINE,
+  '✻ Churned for 8s · 1 shell still running',
+  '❯ [telegram:19437 "🎯 EXO 3.0" from Unknown] did you get my last 3 messages?',
+  AUP_ERROR_LINE,
+  '✻ Cogitated for 8s · 1 shell still running',
+].join('\n');
+
+describe('ContextWedgeSentinel E2E — AUP-rejection wedge through the production wiring', () => {
+  it('live: a confirmed AUP loop respawns and the audit row carries the kind', async () => {
+    const surface: SentinelSessionSurface = {
+      captureOutput: () => AUP_WEDGE_TAIL,
+      isSessionAlive: () => true,
+      sendKey: () => true,
+      listRunningSessions: () => [{ tmuxSession: 'echo-exo-3-0' }],
+    };
+    const rig = wireProduction({ surface, autoRecovery: { enabled: true, dryRun: false } });
+    try {
+      rig.sentinel.tick();
+      await settle();
+      expect(rig.respawns()).toBe(1);
+      const audit = readAudit(rig.sentinelLogPath);
+      const recovered = audit.find(e => e.kind === 'recovered' && e.sentinel === 'context-wedge');
+      expect(recovered).toBeTruthy();
+    } finally {
+      rig.cleanup();
+    }
+  });
+
+  it('a benign ONE-OFF AUP rejection never enters the wedge lifecycle (no audit rows, no kill)', async () => {
+    const oneOff = [
+      '❯ [telegram:42] some message',
+      AUP_ERROR_LINE,
+      '✻ Worked for 22s',
+    ].join('\n');
+    const surface: SentinelSessionSurface = {
+      captureOutput: () => oneOff,
+      isSessionAlive: () => true,
+      sendKey: () => true,
+      listRunningSessions: () => [{ tmuxSession: 'echo-fine' }],
+    };
+    const rig = wireProduction({ surface, autoRecovery: { enabled: true, dryRun: false } });
+    try {
+      rig.sentinel.tick();
+      await settle();
+      expect(rig.respawns()).toBe(0);
+      const audit = readAudit(rig.sentinelLogPath);
+      expect(audit.filter(e => e.sentinel === 'context-wedge')).toHaveLength(0);
+    } finally {
+      rig.cleanup();
+    }
+  });
+});
+
+describe('Fresh-respawn API lever — WIRED into routes.ts (dead-code guard)', () => {
+  const routesSrc = fs.readFileSync(
+    path.join(process.cwd(), 'src/server/routes.ts'),
+    'utf-8',
+  );
+
+  it('routes.ts validates the fresh param', () => {
+    expect(routesSrc).toMatch(/"fresh" must be a boolean/);
+  });
+
+  it('routes.ts forwards fresh to refreshSession', () => {
+    expect(routesSrc).toMatch(/refreshSession\(\{ sessionName, followUpPrompt, reason, fresh \}\)/);
+  });
+});

--- a/tests/unit/PostUpdateMigrator-aupWedgeNote.test.ts
+++ b/tests/unit/PostUpdateMigrator-aupWedgeNote.test.ts
@@ -1,0 +1,105 @@
+/**
+ * Verifies PostUpdateMigrator patches existing agents' CLAUDE.md with the
+ * AUP-rejection wedge note (second wedge-signature family) + the API
+ * fresh-respawn lever.
+ *
+ * 2026-06-05 EXO 3.0 incident: a session whose transcript accumulated
+ * red-team test payloads got EVERY reply rejected by the API's Usage Policy
+ * classifier — permanently dead, invisible to the (then thinking-block-only)
+ * ContextWedgeSentinel, and recoverable only by hand-editing
+ * topic-resume-map.json because /sessions/refresh did not expose fresh:true.
+ *
+ * Migration Parity Standard: agents that already have the Stuck-Context
+ * Recovery section (installed by the original migration) only learn about
+ * the second signature + the API lever through this patch.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { PostUpdateMigrator } from '../../src/core/PostUpdateMigrator.js';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+
+type MigrationResult = { upgraded: string[]; skipped: string[]; errors: string[] };
+
+function newMigrator(projectDir: string): PostUpdateMigrator {
+  return new PostUpdateMigrator({
+    projectDir,
+    stateDir: path.join(projectDir, '.instar'),
+    port: 4042,
+    hasTelegram: false,
+    projectName: 'test',
+  });
+}
+
+function runClaudeMdMigration(migrator: PostUpdateMigrator): MigrationResult {
+  const result: MigrationResult = { upgraded: [], skipped: [], errors: [] };
+  (migrator as unknown as { migrateClaudeMd(r: MigrationResult): void }).migrateClaudeMd(result);
+  return result;
+}
+
+describe('PostUpdateMigrator — AUP-rejection wedge CLAUDE.md note', () => {
+  let projectDir: string;
+  let claudeMdPath: string;
+
+  beforeEach(() => {
+    projectDir = fs.mkdtempSync(path.join(os.tmpdir(), 'instar-aupwedge-'));
+    fs.mkdirSync(path.join(projectDir, '.instar'), { recursive: true });
+    claudeMdPath = path.join(projectDir, 'CLAUDE.md');
+  });
+
+  afterEach(() => {
+    SafeFsExecutor.safeRmSync(projectDir, {
+      recursive: true,
+      force: true,
+      operation: 'tests/unit/PostUpdateMigrator-aupWedgeNote.test.ts:cleanup',
+    });
+  });
+
+  it('fresh section install includes the AUP note (new agents get both families)', () => {
+    fs.writeFileSync(claudeMdPath, '# CLAUDE.md\n\nMy existing CLAUDE.md.\n');
+
+    const result = runClaudeMdMigration(newMigrator(projectDir));
+
+    expect(result.errors).toEqual([]);
+    const after = fs.readFileSync(claudeMdPath, 'utf-8');
+    expect(after).toContain('Stuck-Context Recovery');
+    expect(after).toContain('AUP-rejection wedge');
+    expect(after).toContain('"fresh":true');
+  });
+
+  it('patches agents that already have the Stuck-Context section but not the AUP note', () => {
+    fs.writeFileSync(
+      claudeMdPath,
+      '# CLAUDE.md\n\n## Stuck-Context Recovery (thinking-block wedge)\n\nThe ContextWedgeSentinel (4th member of the silently-stopped family) detects ...\n',
+    );
+
+    const result = runClaudeMdMigration(newMigrator(projectDir));
+
+    expect(result.errors).toEqual([]);
+    expect(result.upgraded.some(u => u.includes('AUP-rejection wedge'))).toBe(true);
+
+    const after = fs.readFileSync(claudeMdPath, 'utf-8');
+    expect(after).toContain('AUP-rejection wedge');
+    expect(after).toContain('POST /sessions/refresh');
+    // The original section is preserved, not duplicated.
+    expect(after.match(/Stuck-Context Recovery/g)!.length).toBe(1);
+  });
+
+  it('is idempotent — a second run skips, content unchanged', () => {
+    fs.writeFileSync(
+      claudeMdPath,
+      '# CLAUDE.md\n\n## Stuck-Context Recovery (thinking-block wedge)\n\nThe ContextWedgeSentinel detects ...\n',
+    );
+
+    runClaudeMdMigration(newMigrator(projectDir));
+    const afterFirst = fs.readFileSync(claudeMdPath, 'utf-8');
+
+    const second = runClaudeMdMigration(newMigrator(projectDir));
+    const afterSecond = fs.readFileSync(claudeMdPath, 'utf-8');
+
+    expect(afterSecond).toBe(afterFirst);
+    expect(second.upgraded.some(u => u.includes('AUP-rejection wedge'))).toBe(false);
+  });
+});

--- a/tests/unit/monitoring/ContextWedgeSentinel.test.ts
+++ b/tests/unit/monitoring/ContextWedgeSentinel.test.ts
@@ -11,8 +11,11 @@ import { describe, it, expect } from 'vitest';
 import {
   ContextWedgeSentinel,
   detectContextWedge,
+  detectAupRejection,
+  classifyWedgeTail,
   signatureIsTail,
   CONTEXT_WEDGE_PATTERNS,
+  AUP_WEDGE_PATTERNS,
   type WedgeRecoveryOutcome,
 } from '../../../src/monitoring/ContextWedgeSentinel.js';
 
@@ -220,5 +223,123 @@ describe('ContextWedgeSentinel — isRecoveryActive (SessionReaper veto)', () =>
     expect(s.isRecoveryActive('echo-wedged')).toBe(true);
     await deps.drainTimers();
     expect(s.isRecoveryActive('echo-wedged')).toBe(false);
+  });
+});
+
+// ── AUP-rejection family (signature 2, 2026-06-05 EXO incident) ──────────────
+
+// Verbatim shape of the wedged pane captured during the incident: every
+// injected message produces a fresh copy of the same rejection.
+const AUP_ERROR_LINE =
+  '⏺ API Error: Claude Code is unable to respond to this request, which appears to violate our Usage Policy (https://www.anthropic.com/legal/aup). Please double press esc to edit your last message or start a new session for Claude Code to assist with a different task.';
+
+const AUP_WEDGE_TAIL = [
+  '❯ [telegram:19437 "🎯 EXO 3.0" from Justin (uid:7812716706)] did you get my last 3 messages?',
+  AUP_ERROR_LINE,
+  '✻ Churned for 8s · 1 shell still running',
+  '❯ [telegram:19437 "🎯 EXO 3.0" from Unknown] did you get my last 3 messages?',
+  AUP_ERROR_LINE,
+  '✻ Cogitated for 8s · 1 shell still running',
+].join('\n');
+
+// A benign ONE-OFF rejection: single occurrence, session idle after it.
+const AUP_ONE_OFF_TAIL = [
+  '❯ [telegram:42] some message',
+  AUP_ERROR_LINE,
+  '✻ Worked for 22s',
+].join('\n');
+
+describe('detectAupRejection', () => {
+  it('matches the canonical AUP rejection', () => {
+    expect(detectAupRejection(AUP_ERROR_LINE)).toBe(true);
+  });
+
+  it('does not match unrelated text', () => {
+    expect(detectAupRejection('all systems normal; processing message')).toBe(false);
+  });
+
+  it('empty is false (no throw)', () => {
+    expect(detectAupRejection('')).toBe(false);
+  });
+
+  it('exports at least one pattern', () => {
+    expect(AUP_WEDGE_PATTERNS.length).toBeGreaterThan(0);
+  });
+});
+
+describe('classifyWedgeTail — family discrimination', () => {
+  it('classifies the repeated AUP loop as aup-rejection', () => {
+    expect(classifyWedgeTail(AUP_WEDGE_TAIL)).toBe('aup-rejection');
+  });
+
+  it('a benign ONE-OFF AUP rejection is NOT a wedge (single occurrence)', () => {
+    expect(classifyWedgeTail(AUP_ONE_OFF_TAIL)).toBeNull();
+    expect(signatureIsTail(AUP_ONE_OFF_TAIL)).toBe(false);
+  });
+
+  it('classifies the thinking-block 400 as thinking-block-400', () => {
+    expect(classifyWedgeTail(WEDGE_TAIL)).toBe('thinking-block-400');
+  });
+
+  it('AUP loop scrolled out of the tail is not a wedge (session progressed)', () => {
+    const progressed =
+      AUP_WEDGE_TAIL +
+      '\n' +
+      Array.from({ length: 20 }, (_, i) => `working line ${i}: doing real work now`).join('\n');
+    expect(classifyWedgeTail(progressed)).toBeNull();
+  });
+
+  it('signatureIsTail back-compat: true for the AUP loop tail', () => {
+    expect(signatureIsTail(AUP_WEDGE_TAIL)).toBe(true);
+  });
+});
+
+describe('ContextWedgeSentinel — AUP wedge lifecycle', () => {
+  it('scanSession detects the AUP loop and tags kind on the event', () => {
+    const deps = makeDeps({ output: AUP_WEDGE_TAIL });
+    const s = new ContextWedgeSentinel(deps);
+    let detected: { sessionName: string; kind?: string } | null = null;
+    s.on('detected', (e) => { detected = e; });
+    s.scanSession('echo-exo-3-0');
+    expect(detected).not.toBeNull();
+    expect(detected!.kind).toBe('aup-rejection');
+  });
+
+  it('scanSession ignores the benign one-off AUP rejection', () => {
+    const deps = makeDeps({ output: AUP_ONE_OFF_TAIL });
+    const s = new ContextWedgeSentinel(deps);
+    let detected = false;
+    s.on('detected', () => { detected = true; });
+    s.scanSession('echo-exo-3-0');
+    expect(detected).toBe(false);
+  });
+
+  it('recovered event carries the aup-rejection kind (audit detail)', async () => {
+    const deps = makeDeps({ output: AUP_WEDGE_TAIL, outcome: 'respawned' });
+    const s = new ContextWedgeSentinel(deps);
+    let recovered: { sessionName: string; kind?: string } | null = null;
+    s.on('recovered', (e) => { recovered = e; });
+    s.scanSession('echo-exo-3-0');
+    await deps.drainTimers();
+    expect(recovered).not.toBeNull();
+    expect(recovered!.kind).toBe('aup-rejection');
+  });
+
+  it('escalation message names the policy-rejection cause for AUP wedges', async () => {
+    const deps = makeDeps({ output: AUP_WEDGE_TAIL, outcome: 'detect-only' });
+    const s = new ContextWedgeSentinel(deps);
+    s.scanSession('echo-exo-3-0');
+    await deps.drainTimers();
+    expect(deps.captured).toHaveLength(1);
+    expect(deps.captured[0].text).toMatch(/policy-rejection/i);
+  });
+
+  it('escalation message keeps the stuck-context wording for thinking-block wedges', async () => {
+    const deps = makeDeps({ output: WEDGE_TAIL, outcome: 'detect-only' });
+    const s = new ContextWedgeSentinel(deps);
+    s.scanSession('echo-wedged');
+    await deps.drainTimers();
+    expect(deps.captured).toHaveLength(1);
+    expect(deps.captured[0].text).toMatch(/stuck-context/i);
   });
 });

--- a/tests/unit/sessions-refresh-route.test.ts
+++ b/tests/unit/sessions-refresh-route.test.ts
@@ -90,7 +90,24 @@ describe('POST /sessions/refresh', () => {
   it('returns 202 immediately on valid input', async () => {
     const r = await api('/sessions/refresh', { sessionName: 'echo-qalatra', followUpPrompt: 'continue' });
     expect(r.status).toBe(202);
-    expect(r.body).toEqual({ ok: true, message: 'Refresh scheduled', sessionName: 'echo-qalatra' });
+    expect(r.body).toEqual({ ok: true, message: 'Refresh scheduled', sessionName: 'echo-qalatra', fresh: false });
+  });
+
+  it('returns 400 when fresh is not a boolean', async () => {
+    const r = await api('/sessions/refresh', { sessionName: 'echo-qalatra', fresh: 'yes' });
+    expect(r.status).toBe(400);
+    expect(r.body.error).toMatch(/fresh/);
+  });
+
+  it('forwards fresh:true to refreshSession (poisoned-transcript recovery path)', async () => {
+    const r = await api('/sessions/refresh', { sessionName: 'echo-exo-3-0', fresh: true, reason: 'aup-rejection wedge' });
+    expect(r.status).toBe(202);
+    expect(r.body.fresh).toBe(true);
+
+    await new Promise(resolve => setTimeout(resolve, 600));
+    expect(sessionRefresh.refreshSession).toHaveBeenCalledWith(
+      expect.objectContaining({ sessionName: 'echo-exo-3-0', fresh: true, reason: 'aup-rejection wedge' }),
+    );
   });
 
   it('invokes sessionRefresh.refreshSession asynchronously after the response', async () => {

--- a/upgrades/aup-wedge-fresh-api.eli16.md
+++ b/upgrades/aup-wedge-fresh-api.eli16.md
@@ -1,0 +1,45 @@
+# ELI16 — AUP-Rejection Wedge Signature + Fresh-Respawn API
+
+## What happened
+
+Last night one of my sessions died in a new way. Justin and the session had
+been designing security test scenarios (deliberately-sneaky "try to trick the
+agent" prompts, for the EXO 3.0 test harness). Enough of that content piled up
+in the conversation that the AI provider's safety filter started refusing the
+ENTIRE conversation — every single reply came back "this request appears to
+violate our Usage Policy." Since each reply re-sends the whole conversation,
+every reply failed, forever. From Justin's side it looked like me ignoring him
+for an hour: "✓ Delivered" receipts, no answers.
+
+The watchdog that's supposed to catch dead-but-still-printing sessions (the
+ContextWedgeSentinel) only knew ONE death signature — the "thinking block"
+error from May. This new one sailed right past it. And the only repair lever —
+"restart fresh, do NOT reload the poisoned conversation" — existed solely
+inside the watchdog's own wiring, so fixing it by hand meant editing a state
+file directly.
+
+## What this change does
+
+1. **Teaches the watchdog the second signature.** It now recognizes the
+   policy-rejection loop too, and the audit log says WHICH kind of wedge it
+   caught. Safety detail: one single policy rejection is NOT treated as a
+   wedge — sometimes one message just gets refused and the next works fine,
+   and killing the conversation for that would destroy real state. The loop
+   version always repeats, so we require seeing it more than once.
+
+2. **Adds the repair lever to the API.** `POST /sessions/refresh` now accepts
+   `"fresh": true` — restart this session WITHOUT reloading its conversation.
+   That's the right move whenever a transcript itself is poisoned.
+
+3. **Tells every deployed agent about it.** The CLAUDE.md migration adds the
+   new signature, the API lever, and the prevention rule: keep literal attack
+   payloads in files on disk and reference them by path — never paste them
+   into the conversation itself.
+
+## Why it's safe
+
+Detection alone never kills anything (auto-recovery stays opt-in, unchanged).
+The one-off-vs-loop distinction is tested on both sides with the real pane
+text from the incident. The API param is validated, rate-guarded by the same
+limiter every refresh uses, and reuses the exact internal mode the sentinel
+already exercised in production twice this week.

--- a/upgrades/next/aup-wedge-fresh-api.md
+++ b/upgrades/next/aup-wedge-fresh-api.md
@@ -1,0 +1,55 @@
+---
+bump: patch
+---
+
+## What Changed
+
+Second wedge-signature family + the API fresh-respawn lever, from the
+2026-06-05 EXO 3.0 incident. A session whose transcript accumulated literal
+red-team test payloads (generated during MTP security-harness work) got EVERY
+reply rejected by the API's Usage Policy classifier — `API Error: … appears to
+violate our Usage Policy` on each turn, because every turn re-sends the full
+conversation. Same permanent-death shape as the thinking-block 400 (still
+emitting output, so the silence + socket sentinels miss it), but the
+ContextWedgeSentinel only knew the thinking-block signature, so it watched the
+session die for an hour and said nothing. Recovery required hand-editing
+`topic-resume-map.json` because `/sessions/refresh` did not forward `fresh`.
+
+Now: `classifyWedgeTail()` recognizes both families and tags every sentinel
+event with `kind` (`thinking-block-400` | `aup-rejection`) in the audit trail
+and escalation wording. The AUP family carries an extra discriminator — the
+signature must appear on MORE THAN ONE line (the loop always repeats; a benign
+one-off rejection must not cost the session its conversation). And
+`POST /sessions/refresh` accepts `fresh: true`, reaching the same
+SessionRefresh fresh-mode the sentinel uses internally.
+
+## What to Tell Your User
+
+If a conversation ever dies the way the EXO session did — every reply
+instantly refused by the AI provider because of what's accumulated in the
+transcript — I now notice it, can recover it automatically with a fresh
+restart (when auto-recovery is enabled), and explain what happened instead of
+leaving you staring at "delivered" receipts with no answers.
+
+## Summary of New Capabilities
+
+- ContextWedgeSentinel detects the AUP-rejection loop (second signature
+  family) with a repetition discriminator against benign one-off rejections;
+  audit events + escalations carry the wedge kind. No configuration change —
+  rides the existing `monitoring.contextWedgeSentinel` settings.
+- `POST /sessions/refresh` accepts `fresh: true` — kill + respawn WITHOUT
+  `--resume` (clears the topic's resume UUID), the recovery lever for any
+  poisoned transcript.
+- CLAUDE.md template + migration: existing agents learn about the second
+  family, the API lever, and the prevention rule (adversarial payloads live in
+  files on disk, never pasted into conversation transcripts).
+
+## Evidence
+
+Live incident recovery (2026-06-05, topic 19437): manual kill + resume-map
+clear + fresh spawn verified end-to-end — fresh session answered immediately
+where the wedged one had failed every turn for ~1h. Unit: 32 sentinel tests
+(incl. both sides of the one-off-vs-loop boundary, kind tagging, escalation
+wording per family) + 8 route tests (fresh validation, forwarding, 202 shape)
++ 3 migrator tests (fresh install carries the note; existing-section patch;
+idempotency). Integration + e2e wedge suites green; tsc clean; preflight PASS.

--- a/upgrades/side-effects/aup-wedge-fresh-api.md
+++ b/upgrades/side-effects/aup-wedge-fresh-api.md
@@ -1,0 +1,83 @@
+# Side-Effects Review — AUP-Rejection Wedge Signature + Fresh-Respawn API
+
+**Version / slug:** `aup-wedge-fresh-api`
+**Date:** `2026-06-06`
+**Author:** `Echo (instar-dev agent, session-robustness topic per Justin's "work on more robust ways to handle these scenarios")`
+**Second-pass reviewer:** `self-adversarial pass over the one-off-vs-loop boundary (the only place this change could destroy user state)`
+
+## Summary of the change
+
+ContextWedgeSentinel learns a second wedge-signature family — the AUP-rejection
+loop (2026-06-05 EXO incident) — via `classifyWedgeTail()`, which returns the
+matching family for the live tail and tags every event/escalation with `kind`.
+The AUP family requires the signature on >1 line of the capture (the loop
+repeats every turn; a benign one-off rejection appears once). `POST
+/sessions/refresh` forwards a validated `fresh` boolean to
+`SessionRefresh.refreshSession` — the previously-internal-only fresh-mode.
+CLAUDE.md migrator patch teaches deployed agents both additions. Files:
+`ContextWedgeSentinel.ts`, `server.ts` (wiring detail strings), `routes.ts`,
+`PostUpdateMigrator.ts`, spec doc, three test files.
+
+## Decision-point inventory
+
+- AUP tail classification — **add (detector)** — new signal only; same confirm
+  window + same opt-in recovery policy as the existing family.
+- One-line AUP occurrence — **deliberate non-detection** — a benign one-off
+  rejection must never cost a session its conversation; the wedge always
+  repeats, so the second occurrence arrives within one failed turn.
+- `fresh` route param — **add (lever, validated)** — exposes an existing
+  internal mode; same spawnLimiter + SessionRefresh rate-guard as every
+  refresh.
+
+## 1. Over-block
+
+None added. Detection alone never kills anything (autoRecovery ships dark,
+unchanged). The worst over-detection case — a session DISCUSSING the AUP error
+with two quoted copies in its tail — is covered by the same two defenses as the
+thinking-block family (tail gate + 45s no-progress confirm window): a working
+session scrolls the signature out before confirm.
+
+## 2. Under-block
+
+(a) A genuinely-wedged session whose FIRST rejection is the only one on screen
+is not detected until the next inbound message produces the second copy —
+bounded by one message turn; accepted to protect one-off conversations.
+(b) A wedge whose error text the provider rewords escapes both families —
+inherent to signature-based detection; the turn-receipt structural close is
+tracked separately (CMT-1115 follow-up design).
+
+## 3. Level-of-abstraction fit
+
+The family lives inside the existing sentinel (same lifecycle, confirm window,
+recovery, veto integration) rather than a 5th sentinel — the failure shape is
+identical; only the signature differs. `kind` is data on existing events, not
+a new event vocabulary. The route param reuses `RefreshOptions.fresh` which
+SessionRefresh already owned; the route stays a thin validated entry point.
+
+## 4. Signal vs authority compliance
+
+**Required reference:** `docs/signal-vs-authority.md`
+
+- [x] No new authority. The detector is a signal; recovery policy (detect-only
+  / dry-run / live) is unchanged and opt-in. The `fresh` param is operator/agent
+  initiative through an already-rate-guarded lever; the route grants no new
+  capability that the sentinel wiring didn't already exercise.
+
+## 5. Interactions
+
+- **SessionReaper veto:** `isRecoveryActive` covers AUP wedges identically
+  (state machine is shared) — the reaper can't kill a session mid-recovery.
+- **Sentinel audit:** `kind` lands in `logs/sentinel-events.jsonl` detail
+  strings; existing consumers parse free-text detail, no schema break.
+- **`fresh` + followUpPrompt:** unchanged interaction — fresh clears the resume
+  entry after the kill persists it; respawner then spawns clean (SessionRefresh
+  ordering, already tested).
+- **Back-compat:** `signatureIsTail()` boolean wrapper preserved — all existing
+  callers/tests pass unmodified (81 green pre-existing + new).
+
+## 6. External surfaces / 7. Rollback
+
+One new accepted body field on an existing authed route (400 on non-boolean);
+response gains `fresh` echo. No schema/config/persistent state; migrator patch
+is append-only + idempotent (marker: 'AUP-rejection wedge'). Rollback = revert;
+the second family goes blind again and fresh-respawn returns to internal-only.


### PR DESCRIPTION
## ELI16 Overview

Last night a session died in a brand-new way. Justin and that session had been designing security test scenarios (deliberately-sneaky "try to trick the agent" prompts for the EXO 3.0 test harness). Enough of that content piled up in the conversation that the AI provider's safety filter started refusing the ENTIRE conversation — every reply came back "this request appears to violate our Usage Policy." Each reply re-sends the whole conversation, so every reply failed, forever. From Justin's side it looked like being ignored for an hour: "✓ Delivered" receipts, no answers.

The watchdog for dead-but-still-printing sessions (ContextWedgeSentinel) only knew ONE death signature — the thinking-block error from May. This sailed right past it. And the only repair lever ("restart fresh, do NOT reload the poisoned conversation") existed solely inside the watchdog's internal wiring, so recovering the live incident meant hand-editing a state file.

This PR:
1. **Teaches the watchdog the second signature** — and the audit log now says which kind of wedge it caught. Safety detail: ONE policy rejection is NOT a wedge (sometimes a single message gets refused and the next works fine — killing the conversation for that would destroy real state). The loop version always repeats, so detection requires seeing it on more than one line.
2. **Adds the repair lever to the API** — `POST /sessions/refresh` accepts `"fresh": true` (restart without reloading the conversation), validated and behind the same rate guard as every refresh.
3. **Tells every deployed agent** — CLAUDE.md migration adds the new signature, the API lever, and the prevention rule: literal attack payloads live in files on disk, referenced by path, never pasted into conversation.

## Evidence

- Live incident recovery verified end-to-end (2026-06-05, topic 19437): manual kill + resume-map clear + fresh spawn — the fresh session answered immediately where the wedged one failed every turn for ~1h.
- Unit: both sides of the one-off-vs-loop boundary using the REAL pane text from the incident; kind tagging; per-family escalation wording; route validation + forwarding; migrator fresh-install/patch/idempotency.
- E2E: AUP loop through the production wiring → respawn + kind-tagged audit row; benign one-off → zero audit rows, zero kills; dead-code guards pin the route wiring.
- Full unit suite green locally; tsc clean; `dev:preflight` PASS.

## Causal autopsy

`latent` — the sentinel shipped single-signature by design; the blind spot existed from day one and was surfaced by a new usage pattern (red-team payload generation). Not a prior-PR regression. The same incident exposed a SEPARATE operational issue (the sentinel was config-disabled on Echo by the 06-05 meltdown load-shed — the same event as #882's scheduler flip); that gets its own guard-disable-tripwire fix, tracked on CMT-1115.

CMT-1115 · Spec: `docs/specs/context-wedge-sentinel.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)