### PR TITLE
feat(coherence): P1 closing step — journal-sync mesh transport (dark by gate)

### DIFF
--- a/.instar/instar-dev-decisions/2026-06-06T06-03-02-080Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-06-06T06-03-02-080Z-unknown.json
@@ -1,0 +1,15 @@
+{
+  "ts": "2026-06-06T06:03:02.080Z",
+  "slug": "unknown",
+  "suggestedTier": 2,
+  "declaredTier": 2,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "new capability: new config key added"
+  ],
+  "belowFloor": false,
+  "files": 4,
+  "loc": 286,
+  "causalAutopsy": null,
+  "verdict": "pass"
+}

--- a/src/commands/server.ts
+++ b/src/commands/server.ts
@@ -2567,6 +2567,15 @@ export async function startServer(options: StartOptions): Promise<void> {
     // the reaper/ownership wiring that emits into it. Writer runs even on a
     // single-machine agent (locally useful); replication is P1.3.
     let coherenceJournal: import('../core/CoherenceJournal.js').CoherenceJournal | undefined;
+    // The journal's OWN machine id (used by the journal-sync SERVE path to read
+    // this machine's own stream files, which are keyed on it). Hoisted so the
+    // mesh dispatcher (wired much later) can drive the shared applier's
+    // buildServeBatch against the right stream.
+    let cjOwnMachineId: string | undefined;
+    // ONE shared JournalSyncApplier (P1.3 engine) — drives both the journal-sync
+    // RECEIVE handler (always-registered; harmless when idle) and the
+    // REPLICATION-GATED puller delta drive. Constructed only when the journal is.
+    let journalSyncApplier: import('../core/JournalSyncApplier.js').JournalSyncApplier | undefined;
     {
       const cjCfg = config.multiMachine?.coherenceJournal;
       const cjEnabled = cjCfg?.enabled ?? !!config.developmentAgent;
@@ -2577,6 +2586,7 @@ export async function startServer(options: StartOptions): Promise<void> {
           // hostname-derived fallback for single-machine agents (sanitized by
           // the journal's own percent-encode rule either way).
           const cjMachineId = coordinator.identity?.machineId ?? `m_host_${os.hostname()}`;
+          cjOwnMachineId = cjMachineId;
           coherenceJournal = new cjMod.CoherenceJournal({
             stateDir: config.stateDir,
             machineId: cjMachineId,
@@ -2591,6 +2601,25 @@ export async function startServer(options: StartOptions): Promise<void> {
           // Lifecycle funnel (§3.3): every session status transition flows
           // through StateManager.saveSession; the diff-derived emit lives there.
           state.setCoherenceJournal(coherenceJournal);
+          // ONE shared JournalSyncApplier (P1.3 engine) — the RECEIVE/own-stream
+          // SERVE side of replication. Same guardWrite seam as the writer. The
+          // mesh dispatcher registers an always-on journal-sync handler over it
+          // (harmless when no peer sends), and the REPLICATION-GATED puller drive
+          // shares this same instance. Construction here does NOT enable
+          // replication SEND/drive — that gate is config.multiMachine
+          // .coherenceJournal.replication.enabled === true, checked at the puller
+          // wiring below.
+          try {
+            const applierMod = await import('../core/JournalSyncApplier.js');
+            journalSyncApplier = new applierMod.JournalSyncApplier({
+              stateDir: config.stateDir,
+              guardWrite: (p) => state.guardJournalWrite(p),
+              logger: (m) => console.log(pc.dim(`  [journal-sync] ${m}`)),
+            });
+          } catch (e) { /* @silent-fallback-ok: journal observability must never endanger the observed operation (COHERENCE-JOURNAL-SPEC §3.1) */
+            journalSyncApplier = undefined;
+            console.log(pc.dim(`  [journal-sync] applier not constructed: ${e instanceof Error ? e.message : String(e)}`));
+          }
           // §3.3 autonomous-run journal scanner — observation-based start/stop
           // (no single .local.md write funnel exists; polling is the structural
           // choice). P19 brakes, declared: constant per-tick cost (bounded by
@@ -10225,7 +10254,48 @@ export async function startServer(options: StartOptions): Promise<void> {
           },
           handlers: {
             'capacity-report': () => machinePoolRegistry?.getCapacities() ?? [],
-            'session-status': () => machinePoolRegistry?.getCapacity(meshSelfId) ?? { machineId: meshSelfId },
+            'session-status': () => {
+              const base = machinePoolRegistry?.getCapacity(meshSelfId) ?? { machineId: meshSelfId };
+              // COHERENCE-JOURNAL-SPEC §3.4 rule 5: advertise this machine's OWN
+              // durably-flushed stream heads so a peer can compute deltas. {}
+              // when the journal is disabled. Forward/backward compatible — old
+              // peers ignore the extra field, old callers don't read it.
+              const journalAdvert = coherenceJournal
+                ? { [cjOwnMachineId ?? meshSelfId]: coherenceJournal.getOwnAdvert() }
+                : {};
+              return { ...base, journalAdvert };
+            },
+            // COHERENCE-JOURNAL-SPEC §3.4 — always-registered journal-sync verb
+            // (harmless when no peer sends): serve our OWN stream on `request`
+            // (first-hop only), durably apply an inbound `batch`. The RBAC gate
+            // already proved a registered peer; the applier's first-hop sender
+            // binding fences forged entries (entry.machine must === env.sender).
+            'journal-sync': (cmd, _sender, env) => {
+              const c = cmd as import('../core/MeshRpc.js').MeshCommand & { type: 'journal-sync' };
+              if (!journalSyncApplier) return { ok: false, reason: 'journal disabled' };
+              if (c.request) {
+                // §3.4 rule 5 serve-batch byte cap (coherenceJournal.replication
+                // .maxBatchBytes; the applier defaults it when absent).
+                const maxBatchBytes = config.multiMachine?.coherenceJournal?.replication?.maxBatchBytes;
+                const served = journalSyncApplier.buildServeBatch(
+                  c.request.kind as import('../core/CoherenceJournal.js').JournalKind,
+                  c.request.fromSeq,
+                  cjOwnMachineId ?? meshSelfId,
+                  maxBatchBytes,
+                );
+                return { batch: [served] };
+              }
+              if (c.batch) {
+                // Apply binds every entry to the AUTHENTICATED envelope sender —
+                // never a payload field — so a forged sender is rejected + counted.
+                const r = journalSyncApplier.apply(
+                  env.sender,
+                  c.batch as import('../core/JournalSyncApplier.js').ApplyBatchStream[],
+                );
+                return { ok: true, result: r };
+              }
+              return { ok: true };
+            },
             place: ownAction,
             claim: ownAction,
             transfer: ownAction,
@@ -10486,6 +10556,68 @@ export async function startServer(options: StartOptions): Promise<void> {
           // so it authenticates off the mutual identity established at pairing —
           // no router role, no epoch fence required.
           const presenceMod = await import('../core/PeerPresencePuller.js');
+          // ── REPLICATION ACTIVATION GATE (CRITICAL SAFETY) ────────────────────
+          // The journal-sync SEND/drive path is gated on EXPLICIT-true only:
+          // config.multiMachine.coherenceJournal.replication.enabled === true.
+          // This is DELIBERATELY NOT the `?? !!developmentAgent` dark-feature
+          // gate — the engine + transport land dark even on the dev agent; a
+          // human flips replication on for a monitored live proof. When false
+          // (the default — ConfigDefaults leaves replication.enabled absent), the
+          // delta deps below are left undefined and the puller behaves EXACTLY as
+          // before: a presence-only poll, no journal delta ever requested/applied.
+          const _replicationEnabled =
+            (config.multiMachine?.coherenceJournal as { replication?: { enabled?: boolean } } | undefined)
+              ?.replication?.enabled === true;
+          const _journalDeltaDeps =
+            _replicationEnabled && journalSyncApplier
+              ? {
+                  requestJournalDelta: async (
+                    machineId: string,
+                    url: string,
+                    kind: string,
+                    fromSeq: number,
+                  ): Promise<import('../core/PeerPresencePuller.js').JournalDeltaStream | null> => {
+                    try {
+                      const res = await meshClient.send(
+                        { machineId, url },
+                        { type: 'journal-sync', request: { machineId, kind, fromSeq } },
+                        0,
+                      );
+                      if (res.ok && res.result && typeof res.result === 'object' && 'batch' in (res.result as object)) {
+                        const b = (res.result as { batch?: unknown }).batch;
+                        if (Array.isArray(b) && b.length > 0) {
+                          return b[0] as import('../core/PeerPresencePuller.js').JournalDeltaStream;
+                        }
+                      }
+                    } catch { /* @silent-fallback-ok: a journal-sync delta fetch to a peer is best-effort + self-healing — an unreachable/rejected peer simply yields no delta this pass and the next presence tick re-requests; never endanger the presence pass (COHERENCE-JOURNAL-SPEC §3.1) */ }
+                    return null;
+                  },
+                  applyDelta: (senderMachineId: string, batch: import('../core/PeerPresencePuller.js').JournalDeltaStream[]) => {
+                    journalSyncApplier?.apply(
+                      senderMachineId,
+                      batch as import('../core/JournalSyncApplier.js').ApplyBatchStream[],
+                    );
+                  },
+                  localAdvertFor: (machineId: string): Record<string, { incarnation: string; lastSeq: number }> =>
+                    journalSyncApplier?.getAdvertState()[machineId] ?? {},
+                }
+              : {};
+          if (_replicationEnabled) {
+            console.log(pc.yellow('  [journal-sync] REPLICATION SEND/drive ENABLED (replication.enabled===true) — live proof mode'));
+          }
+          // Unwrap the PEER's own-stream slice (keyed on its machine id) from the
+          // nested `{ [ownMachineId]: { kind → {…} } }` session-status advert to the
+          // flat `kind → {incarnation,lastSeq}` shape the puller drive compares
+          // against what we hold for that peer. First-hop: a peer serves only its
+          // OWN stream, so its advert has exactly its own key (fall back to the
+          // first/only entry if the key differs).
+          const _unwrapPeerJournalAdvert = (
+            machineId: string,
+            nested?: Record<string, Record<string, { incarnation: string; lastSeq: number }>>,
+          ): Record<string, { incarnation: string; lastSeq: number }> | undefined => {
+            if (!nested || typeof nested !== 'object') return undefined;
+            return nested[machineId] ?? Object.values(nested)[0];
+          };
           const peerPresencePuller = new presenceMod.PeerPresencePuller({
             selfMachineId: meshSelfId,
             listPeers: () =>
@@ -10493,15 +10625,23 @@ export async function startServer(options: StartOptions): Promise<void> {
                 .getActiveMachines()
                 .filter((m) => !m.entry.revokedAt)
                 .map((m) => ({ machineId: m.machineId, url: peerUrl(m.machineId) })),
+            recordHeartbeat: (obs) => { machinePoolRegistry?.recordHeartbeat(obs); },
+            log: (line) => console.log(pc.dim(`  [peer-presence] ${line}`)),
             fetchPeerCapacity: async (machineId, url) => {
               const res = await meshClient.send({ machineId, url }, { type: 'session-status' }, 0);
               if (res.ok && res.result && typeof res.result === 'object') {
-                return res.result as { selfReportedLastSeen?: string; loadAvg?: number };
+                const cap = res.result as {
+                  selfReportedLastSeen?: string;
+                  loadAvg?: number;
+                  journalAdvert?: Record<string, Record<string, { incarnation: string; lastSeq: number }>>;
+                };
+                const journalAdvert = _unwrapPeerJournalAdvert(machineId, cap.journalAdvert);
+                return { selfReportedLastSeen: cap.selfReportedLastSeen, loadAvg: cap.loadAvg, journalAdvert };
               }
               return null;
             },
-            recordHeartbeat: (obs) => { machinePoolRegistry?.recordHeartbeat(obs); },
-            log: (line) => console.log(pc.dim(`  [peer-presence] ${line}`)),
+            // REPLICATION-GATED: present only when replication.enabled === true.
+            ..._journalDeltaDeps,
           });
           void peerPresencePuller.pullOnce();
           const peerPresenceTimer = setInterval(() => { void peerPresencePuller.pullOnce(); }, 30_000);

--- a/src/core/CoherenceJournal.ts
+++ b/src/core/CoherenceJournal.ts
@@ -403,6 +403,23 @@ export class CoherenceJournal {
     }));
   }
 
+  /**
+   * The OWN-stream replication advert for the journal-sync transport (§3.4 rule
+   * 5): per kind, the incarnation + the highest DURABLY-FLUSHED seq this writer
+   * can serve. Unlike `streamStatuses().lastSeq`, this advertises `highWaterSeq`
+   * (advanced only after data fdatasync) — NEVER an enqueued-but-unflushed seq —
+   * so a peer never requests a delta we cannot serve from the file. Returns `{}`
+   * with a zeroed entry per kind when nothing has been flushed yet; callers may
+   * forward it verbatim (old peers ignore unknown fields).
+   */
+  getOwnAdvert(): Record<JournalKind, { incarnation: string; lastSeq: number }> {
+    const out = {} as Record<JournalKind, { incarnation: string; lastSeq: number }>;
+    for (const kind of JOURNAL_KINDS) {
+      out[kind] = { incarnation: this.incarnation, lastSeq: this.highWaterSeq[kind] };
+    }
+    return out;
+  }
+
   /** Number of entries enqueued but not yet flushed (tests / observability). */
   get pendingCount(): number {
     return this.queue.length;

--- a/src/core/MeshRpc.ts
+++ b/src/core/MeshRpc.ts
@@ -33,7 +33,19 @@ export type MeshCommand =
   | { type: 'deliverMessage'; session: string; messageId: string; payload: unknown; ownershipEpoch: number }
   | { type: 'capacity-report' }
   | { type: 'session-status'; session?: string }
-  | { type: 'secret-share'; encrypted: string };
+  | { type: 'secret-share'; encrypted: string }
+  | {
+      // Coherence-journal replication transport (COHERENCE-JOURNAL-SPEC §3.4).
+      // Read/observe class — any registered peer may issue it (same RBAC as
+      // capacity-report/session-status). All three optional shapes ride one verb:
+      //   • advert  — what the sender holds per stream (delta-request hint).
+      //   • request — "serve me your own <kind> from > fromSeq" (first-hop).
+      //   • batch   — durably-flushed own-stream entries the sender is pushing.
+      type: 'journal-sync';
+      advert?: Record<string, Record<string, { incarnation: string; lastSeq: number }>>;
+      request?: { machineId: string; kind: string; fromSeq: number };
+      batch?: { kind: string; incarnation: string; entries: unknown[]; oldestRetainedSeq?: number }[];
+    };
 
 export interface MeshEnvelope {
   sender: MachineId;
@@ -145,9 +157,13 @@ export function checkCommandRBAC(command: MeshCommand, sender: MachineId, deps: 
     }
     case 'capacity-report':
     case 'session-status':
+    case 'journal-sync':
     case 'secret-share':
       // Read/observe class (or e2e-encrypted) — any registered peer (already
-      // proven a registered peer by verifyEnvelope).
+      // proven a registered peer by verifyEnvelope). journal-sync joins this
+      // class: it serves/applies own-stream coherence-journal deltas, which are
+      // self-binding (first-hop sender binding fences forged entries in the
+      // applier) — no router/owner role is required.
       return { ok: true, reason: 'ok' };
     default:
       return { ok: false, reason: 'claim-unauthorized' };

--- a/src/core/PeerPresencePuller.ts
+++ b/src/core/PeerPresencePuller.ts
@@ -35,6 +35,22 @@ export interface PeerPresenceMachine {
 export interface PeerCapacity {
   selfReportedLastSeen?: string;
   loadAvg?: number;
+  /**
+   * The peer's OWN-stream coherence-journal advert (COHERENCE-JOURNAL-SPEC §3.4
+   * rule 5), keyed `kind → { incarnation, lastSeq }`. Present only when the peer
+   * runs the journal-sync transport; old peers omit it and the delta drive is a
+   * no-op. Replication-gated: the puller only acts on it when the delta deps are
+   * wired (server passes them ONLY when replication is explicitly enabled).
+   */
+  journalAdvert?: Record<string, { incarnation: string; lastSeq: number }>;
+}
+
+/** One stream slice of a journal-sync delta (mirrors MeshRpc's `journal-sync.batch`). */
+export interface JournalDeltaStream {
+  kind: string;
+  incarnation: string;
+  entries: unknown[];
+  oldestRetainedSeq?: number;
 }
 
 export interface PeerPresencePullerDeps {
@@ -54,6 +70,33 @@ export interface PeerPresencePullerDeps {
   now?: () => Date;
   /** Optional structured log line per pass (e.g. for the boot log). */
   log?: (line: string) => void;
+
+  // ── Coherence-journal delta drive (REPLICATION-GATED) ──────────────────────
+  // These three deps are passed by the server ONLY when journal replication is
+  // EXPLICITLY enabled (config.multiMachine.coherenceJournal.replication.enabled
+  // === true). When any is undefined the puller behaves exactly as before — no
+  // delta is ever requested or applied. This is the SEND/drive gate: the engine
+  // and transport land dark, and a human flips replication on for a monitored
+  // live proof.
+  /**
+   * Request a journal delta for `kind` from a peer (a signed `journal-sync`
+   * request → the peer's served own-stream batch), or null if unavailable.
+   * MUST NOT throw into the puller (the puller treats a throw as null).
+   */
+  requestJournalDelta?: (
+    machineId: string,
+    url: string,
+    kind: string,
+    fromSeq: number,
+  ) => Promise<JournalDeltaStream | null>;
+  /** Apply a served delta into the local replica (delegates to JournalSyncApplier.apply). */
+  applyDelta?: (senderMachineId: string, batch: JournalDeltaStream[]) => void;
+  /**
+   * What this machine ALREADY holds for `machineId` per kind (from the applier's
+   * advert state). Used to decide whether the peer's advert is ahead of us.
+   * Returns `{ kind → { incarnation, lastSeq } }` (possibly empty).
+   */
+  localAdvertFor?: (machineId: string) => Record<string, { incarnation: string; lastSeq: number }>;
 }
 
 export class PeerPresencePuller {
@@ -77,11 +120,69 @@ export class PeerPresencePuller {
         if (!cap) return null;
         const seen = cap.selfReportedLastSeen ?? (this.d.now?.() ?? new Date()).toISOString();
         this.d.recordHeartbeat({ machineId: m.machineId, selfReportedLastSeen: seen, loadAvg: cap.loadAvg });
+        // REPLICATION-GATED journal-delta drive — only when the server wired the
+        // delta deps (i.e. replication.enabled === true). Otherwise a complete
+        // no-op (engine/transport stay dark). Never throws into the puller.
+        await this.driveJournalDelta(m.machineId, m.url as string, cap.journalAdvert);
         return m.machineId;
       }),
     );
     const recorded = results.filter((r): r is string => r !== null);
     if (recorded.length && this.d.log) this.d.log(`recorded ${recorded.length} peer(s) online over HTTP: ${recorded.join(', ')}`);
     return { recorded };
+  }
+
+  /**
+   * REPLICATION-GATED: for a freshly-recorded peer, if the journal-delta deps are
+   * wired AND the peer's advert shows a kind ahead of what we hold (same
+   * incarnation, higher lastSeq — OR a kind we hold nothing for), request that
+   * kind's delta and apply it. The send/drive path is therefore active ONLY when
+   * the server passed these deps, which it does ONLY when replication is
+   * explicitly enabled. Never throws (a failing fetch/apply is swallowed — the
+   * presence pass must always complete).
+   */
+  private async driveJournalDelta(
+    machineId: string,
+    url: string,
+    peerAdvert?: Record<string, { incarnation: string; lastSeq: number }>,
+  ): Promise<void> {
+    // Gate: all three deps must be present (server wires them only when
+    // replication.enabled === true). Any absent → no-op (dark).
+    const { requestJournalDelta, applyDelta, localAdvertFor } = this.d;
+    if (!requestJournalDelta || !applyDelta || !localAdvertFor) return;
+    if (!peerAdvert || typeof peerAdvert !== 'object') return;
+
+    let local: Record<string, { incarnation: string; lastSeq: number }> = {};
+    try {
+      local = localAdvertFor(machineId) || {};
+    } catch { /* @silent-fallback-ok: the puller's contract is NEVER to throw (presence must always complete); an empty local view safely treats any peer seq as ahead and the applier de-dupes on apply */
+      local = {};
+    }
+
+    for (const [kind, peer] of Object.entries(peerAdvert)) {
+      try {
+        if (!peer || typeof peer.lastSeq !== 'number' || !Number.isFinite(peer.lastSeq)) continue;
+        const held = local[kind];
+        // We hold nothing for this kind → request from 0. We hold the SAME
+        // incarnation but the peer is ahead → request from our lastSeq. A
+        // DIFFERENT incarnation is still requested from our lastSeq; the applier
+        // performs the incarnation-fencing/quarantine on apply (its job, not
+        // ours) — so we still pull and let it reconcile.
+        const fromSeq = held && typeof held.lastSeq === 'number' ? held.lastSeq : 0;
+        const peerAhead = !held || peer.incarnation !== held.incarnation || peer.lastSeq > fromSeq;
+        if (!peerAhead) continue;
+
+        let delta: JournalDeltaStream | null = null;
+        try {
+          delta = await requestJournalDelta(machineId, url, kind, fromSeq);
+        } catch { /* @silent-fallback-ok: an unreachable/rejected delta fetch is a transient, self-healing condition — the next presence pass re-requests; surfacing it here would break the puller's never-throw contract */
+          delta = null;
+        }
+        if (!delta) continue;
+        try {
+          applyDelta(machineId, [delta]);
+        } catch { /* @silent-fallback-ok: apply() is itself fully tolerant + observable via its own counters; this guard only preserves the puller's never-throw contract */ }
+      } catch { /* @silent-fallback-ok: per-kind drive is best-effort; one bad kind must never poison the rest of the presence pass (the puller's never-throw contract) */ }
+    }
   }
 }

--- a/tests/integration/journal-sync-roundtrip.test.ts
+++ b/tests/integration/journal-sync-roundtrip.test.ts
@@ -1,0 +1,212 @@
+// safe-fs-allow: test fixture teardown uses SafeFsExecutor.safeRmSync on tmp dirs only.
+// safe-git-allow: test fixture teardown uses SafeFsExecutor.safeRmSync on tmp dirs only.
+/**
+ * Integration test (COHERENCE-JOURNAL-SPEC §3.4): coherence-journal replication
+ * over the REAL signed MeshRpc transport, end to end.
+ *
+ * Two in-process machines:
+ *  - Machine A runs a CoherenceJournal (the writer) + a JournalSyncApplier (its
+ *    own-stream SERVE side). It emits placement entries + flushes.
+ *  - Machine B runs a JournalSyncApplier (the RECEIVE side) behind a real
+ *    MeshRpcDispatcher exposed over a loopback `/mesh/rpc` route — exactly the
+ *    server's wiring.
+ *
+ * The flow proves the whole chain with NO fakes on the trust path:
+ *  1. A.applier.buildServeBatch reads A's OWN flushed stream → a serve batch.
+ *  2. The batch is sent as a signed, recipient-bound `journal-sync` envelope from
+ *     A to B through MeshRpcClient → the real Ed25519 canonicalize/verify path.
+ *  3. B's dispatcher accepts it (RBAC: read/observe class) and B.applier.apply
+ *     durably appends it under A's machine id (first-hop sender binding).
+ *  4. B's CoherenceJournalReader now answers from the REPLICA stream.
+ *  5. A FORGED batch (entry.machine ≠ envelope.sender) is rejected by the applier
+ *     (forgedEntries counted, nothing appended) even though the envelope itself
+ *     is a valid signature from a registered peer.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import express from 'express';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import type { AddressInfo } from 'node:net';
+
+import { createRoutes } from '../../src/server/routes.js';
+import { MeshRpcDispatcher, type MeshCommand, type MeshEnvelope } from '../../src/core/MeshRpc.js';
+import { MeshRpcClient } from '../../src/core/MeshRpcClient.js';
+import { generateSigningKeyPair, sign, verify } from '../../src/core/MachineIdentity.js';
+import { CoherenceJournal } from '../../src/core/CoherenceJournal.js';
+import { JournalSyncApplier, type ApplyBatchStream } from '../../src/core/JournalSyncApplier.js';
+import { CoherenceJournalReader } from '../../src/core/CoherenceJournalReader.js';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+
+const MACHINE_A = 'm_machine_a';
+const MACHINE_B = 'm_machine_b';
+
+interface Server {
+  url: string;
+  close: () => Promise<void>;
+}
+async function listen(app: express.Express): Promise<Server> {
+  return new Promise((resolve) => {
+    const srv = app.listen(0, () =>
+      resolve({
+        url: `http://127.0.0.1:${(srv.address() as AddressInfo).port}`,
+        close: () => new Promise<void>((r) => srv.close(() => r())),
+      }),
+    );
+  });
+}
+
+describe('journal-sync round-trip (A → B over real signed MeshRpc, §3.4)', () => {
+  let dirA: string;
+  let dirB: string;
+  let server: Server;
+  let journalA: CoherenceJournal;
+  let applierA: JournalSyncApplier;
+  let applierB: JournalSyncApplier;
+  let readerB: CoherenceJournalReader;
+  const keys: Record<string, { priv: string; pub: string }> = {};
+  let n = 0;
+
+  beforeEach(async () => {
+    dirA = fs.mkdtempSync(path.join(os.tmpdir(), 'jsync-a-'));
+    dirB = fs.mkdtempSync(path.join(os.tmpdir(), 'jsync-b-'));
+    for (const id of [MACHINE_A, MACHINE_B]) {
+      const kp = generateSigningKeyPair();
+      keys[id] = { priv: kp.privateKey, pub: kp.publicKey };
+    }
+
+    // ── Machine A: writer + own-stream serve applier ──
+    journalA = new CoherenceJournal({
+      stateDir: dirA,
+      machineId: MACHINE_A,
+      flushIntervalMs: 1_000_000, // manual flush
+    });
+    journalA.open();
+    applierA = new JournalSyncApplier({ stateDir: dirA });
+
+    // ── Machine B: receive applier + reader, behind a real dispatcher ──
+    applierB = new JournalSyncApplier({ stateDir: dirB });
+    readerB = new CoherenceJournalReader({ stateDir: dirB });
+
+    const seen = new Set<string>();
+    const dispatcherB = new MeshRpcDispatcher({
+      verify: {
+        selfMachineId: MACHINE_B,
+        verify: (c, s, sender) => !!keys[sender] && verify(c, s, keys[sender].pub),
+        isRegisteredPeer: (s) => !!keys[s],
+        seenNonce: (s, nn) => seen.has(`${s}:${nn}`),
+        now: () => Date.now(),
+      },
+      // Read/observe class — journal-sync needs no router/owner role.
+      rbac: { routerHolder: () => null, ownerOf: () => null, placementTargetOf: () => null },
+      recordNonce: (s, nn) => seen.add(`${s}:${nn}`),
+      handlers: {
+        'journal-sync': (cmd: MeshCommand, _sender: string, env: MeshEnvelope) => {
+          const c = cmd as MeshCommand & { type: 'journal-sync' };
+          if (c.batch) {
+            // first-hop sender binding: bind to the AUTHENTICATED envelope sender.
+            const r = applierB.apply(env.sender, c.batch as ApplyBatchStream[]);
+            return { ok: true, result: r };
+          }
+          return { ok: true };
+        },
+      },
+    });
+
+    const ctx: any = {
+      config: { authToken: 'test', stateDir: dirB, port: 0 },
+      stateDir: dirB,
+      meshRpcDispatcher: dispatcherB,
+    };
+    const app = express();
+    app.use(express.json());
+    app.use(createRoutes(ctx));
+    server = await listen(app);
+  });
+
+  afterEach(async () => {
+    try {
+      journalA.close();
+    } catch {
+      /* best-effort */
+    }
+    await server.close();
+    SafeFsExecutor.safeRmSync(dirA, { recursive: true, force: true, operation: 'tests/integration/journal-sync-roundtrip.test.ts' });
+    SafeFsExecutor.safeRmSync(dirB, { recursive: true, force: true, operation: 'tests/integration/journal-sync-roundtrip.test.ts' });
+  });
+
+  function clientA(): MeshRpcClient {
+    return new MeshRpcClient({
+      selfMachineId: MACHINE_A,
+      sign: (c) => sign(c, keys[MACHINE_A].priv),
+      nonce: () => `n${++n}`,
+      now: () => Date.now(),
+    });
+  }
+
+  it('A emits + flushes; A serves its own stream; B applies it through a signed envelope; B replica answers', async () => {
+    // 1. A writes placement history and flushes (durable).
+    journalA.emitPlacement(13481, { owner: 'm_owner_1', epoch: 1, reason: 'placed' });
+    journalA.emitPlacement(13481, { owner: 'm_owner_2', epoch: 2, reason: 'user-move', prevOwner: 'm_owner_1' });
+    journalA.flush();
+
+    // 2. A builds its OWN-stream serve batch (peer has nothing → fromSeq 0).
+    const served = applierA.buildServeBatch('topic-placement', 0, MACHINE_A);
+    expect(served.entries.length).toBe(2);
+    expect(served.entries.every((e) => e.machine === MACHINE_A)).toBe(true);
+
+    // 3. Send it A → B as a signed, recipient-bound journal-sync batch.
+    const res = await clientA().send(
+      { machineId: MACHINE_B, url: server.url },
+      { type: 'journal-sync', batch: [served] },
+      0,
+    );
+    expect(res).toMatchObject({ status: 200, ok: true });
+    const applyResult = (res.result as { result: { applied: number; forgedEntries: number } }).result;
+    expect(applyResult.applied).toBe(2);
+    expect(applyResult.forgedEntries).toBe(0);
+
+    // 4. B's reader now answers from the REPLICA stream for machine A.
+    const q = readerB.query({ machine: MACHINE_A, kind: 'topic-placement' });
+    const replicaEntries = q.entries.filter((e) => e.source === 'replica');
+    expect(replicaEntries.length).toBe(2);
+    expect(replicaEntries.map((e) => e.seq).sort((a, b) => a - b)).toEqual([1, 2]);
+    expect(replicaEntries.every((e) => e.machine === MACHINE_A)).toBe(true);
+    // The replica stream status surfaces under A's id.
+    const streamKey = Object.keys(q.streams).find((k) => k.includes('topic-placement'));
+    expect(streamKey).toBeTruthy();
+    expect(q.streams[streamKey as string].source).toBe('replica');
+    expect(q.streams[streamKey as string].lastSeq).toBe(2);
+  });
+
+  it('rejects a FORGED batch (entry.machine ≠ envelope.sender) even with a valid signature from a registered peer', async () => {
+    journalA.emitPlacement(99, { owner: 'm_owner_x', epoch: 1, reason: 'placed' });
+    journalA.flush();
+    const honest = applierA.buildServeBatch('topic-placement', 0, MACHINE_A);
+    expect(honest.entries.length).toBe(1);
+
+    // Forge the entry's `machine` to claim it came from B (a different machine),
+    // while the ENVELOPE is still a genuine, correctly-signed message from A.
+    const forged: ApplyBatchStream = {
+      kind: 'topic-placement',
+      incarnation: honest.incarnation,
+      entries: honest.entries.map((e) => ({ ...e, machine: MACHINE_B })),
+    };
+
+    const res = await clientA().send(
+      { machineId: MACHINE_B, url: server.url },
+      { type: 'journal-sync', batch: [forged] },
+      0,
+    );
+    // The envelope is accepted (signature valid, registered peer), but the
+    // applier's first-hop binding rejects the forged entries.
+    expect(res).toMatchObject({ status: 200, ok: true });
+    const applyResult = (res.result as { result: { applied: number; forgedEntries: number } }).result;
+    expect(applyResult.applied).toBe(0);
+    expect(applyResult.forgedEntries).toBe(1);
+
+    // Nothing landed in B's replica for A.
+    const q = readerB.query({ machine: MACHINE_A, kind: 'topic-placement' });
+    expect(q.entries.filter((e) => e.source === 'replica').length).toBe(0);
+  });
+});

--- a/tests/unit/CoherenceJournal.test.ts
+++ b/tests/unit/CoherenceJournal.test.ts
@@ -620,6 +620,48 @@ describe('CoherenceJournal — self-emission exclusion (§3.1)', () => {
   });
 });
 
+describe('CoherenceJournal — getOwnAdvert (§3.4 rule 5)', () => {
+  it('advertises per-kind incarnation + the DURABLY-FLUSHED lastSeq (highWaterSeq), zeros when empty', () => {
+    const j = makeJournal();
+    // Nothing written yet → every kind advertises lastSeq 0.
+    const empty = j.getOwnAdvert();
+    expect(Object.keys(empty).sort()).toEqual(['autonomous-run', 'session-lifecycle', 'topic-placement']);
+    for (const kind of ['topic-placement', 'session-lifecycle', 'autonomous-run'] as JournalKind[]) {
+      expect(empty[kind].lastSeq).toBe(0);
+    }
+    const incarnation = empty['topic-placement'].incarnation;
+    expect(typeof incarnation).toBe('string');
+    expect(incarnation.length).toBeGreaterThan(0);
+    // All kinds share the writer's single stream-set incarnation token.
+    expect(empty['session-lifecycle'].incarnation).toBe(incarnation);
+
+    // Two placement emits, flushed → advert advances to the flushed head.
+    j.emitPlacement(1, { owner: 'm_a', epoch: 1, reason: 'placed' });
+    j.emitPlacement(2, { owner: 'm_b', epoch: 2, reason: 'user-move' });
+    j.flush();
+    const adv = j.getOwnAdvert();
+    expect(adv['topic-placement'].lastSeq).toBe(2);
+    expect(adv['topic-placement'].incarnation).toBe(incarnation);
+    // Other kinds untouched.
+    expect(adv['session-lifecycle'].lastSeq).toBe(0);
+    j.close();
+  });
+
+  it('does NOT advertise an enqueued-but-unflushed seq (only durable heads are servable)', () => {
+    const j = makeJournal();
+    j.emitPlacement(1, { owner: 'm_a', epoch: 1, reason: 'placed' });
+    // Intentionally NOT flushed — the entry is queued, not durable.
+    expect(j.pendingCount).toBeGreaterThan(0);
+    const adv = j.getOwnAdvert();
+    // §3.4: advertise highWaterSeq (advanced only after fdatasync), so a peer
+    // never requests a delta we cannot serve from the file.
+    expect(adv['topic-placement'].lastSeq).toBe(0);
+    j.flush();
+    expect(j.getOwnAdvert()['topic-placement'].lastSeq).toBe(1);
+    j.close();
+  });
+});
+
 /** A clone of the real fs seam (the wedged test overrides one method). */
 function realFsClone(): JournalFs {
   return {

--- a/tests/unit/PeerPresencePuller-journal.test.ts
+++ b/tests/unit/PeerPresencePuller-journal.test.ts
@@ -1,0 +1,175 @@
+/**
+ * PeerPresencePuller — REPLICATION-GATED journal-delta drive (COHERENCE-JOURNAL-
+ * SPEC §3.4 rule 5). The puller's presence pass, AFTER recording a peer online,
+ * may request + apply a coherence-journal delta when (and only when) the server
+ * wired the delta deps — which it does ONLY when replication.enabled === true.
+ * These tests pin that gate + the drive semantics with injected fakes:
+ *
+ *  - GATE OFF (no delta deps): never requests, never applies — even when the
+ *    peer's advert is ahead. This is the dark-on-merge guarantee.
+ *  - GATE ON + peer ahead: requests the delta for the ahead kind from our held
+ *    lastSeq, then applies the served batch (sender = the peer machine id).
+ *  - GATE ON + peer NOT ahead: nothing requested (same incarnation, same seq).
+ *  - GATE ON + we hold nothing for the kind: requests from seq 0.
+ *  - A failing delta fetch never throws and never applies (presence pass still
+ *    completes, peer still recorded).
+ */
+import { describe, it, expect, vi } from 'vitest';
+import {
+  PeerPresencePuller,
+  type PeerPresenceMachine,
+  type PeerCapacity,
+  type JournalDeltaStream,
+} from '../../src/core/PeerPresencePuller.js';
+
+const URL_MINI = 'https://mini.example.dev';
+
+interface DeltaDeps {
+  requestJournalDelta: (m: string, u: string, k: string, f: number) => Promise<JournalDeltaStream | null>;
+  applyDelta: (sender: string, batch: JournalDeltaStream[]) => void;
+  localAdvertFor: (m: string) => Record<string, { incarnation: string; lastSeq: number }>;
+}
+
+function basePuller(opts: {
+  peerCapacity: PeerCapacity | null;
+  delta?: Partial<DeltaDeps>;
+  peers?: PeerPresenceMachine[];
+}) {
+  const recorded: string[] = [];
+  const puller = new PeerPresencePuller({
+    selfMachineId: 'm_self',
+    listPeers: () => opts.peers ?? [{ machineId: 'm_mini', url: URL_MINI }],
+    fetchPeerCapacity: async () => opts.peerCapacity,
+    recordHeartbeat: (obs) => recorded.push(obs.machineId),
+    ...(opts.delta ?? {}),
+  });
+  return { puller, recorded };
+}
+
+describe('PeerPresencePuller — journal-delta drive (REPLICATION-GATED)', () => {
+  it('GATE OFF: does NOTHING with the journal advert when delta deps are absent (dark on merge)', async () => {
+    // The peer advertises a stream far ahead of anything we hold, but with no
+    // delta deps wired the puller must not request or apply anything.
+    const { puller, recorded } = basePuller({
+      peerCapacity: {
+        loadAvg: 0.3,
+        journalAdvert: { 'topic-placement': { incarnation: 'inc-A', lastSeq: 42 } },
+      },
+      // delta: undefined → no requestJournalDelta / applyDelta / localAdvertFor
+    });
+
+    const res = await puller.pullOnce();
+
+    // Presence still works (peer recorded), but no journal side effects.
+    expect(res.recorded).toEqual(['m_mini']);
+    expect(recorded).toEqual(['m_mini']);
+  });
+
+  it('GATE ON + peer ahead: requests the delta from our held lastSeq and applies it', async () => {
+    const served: JournalDeltaStream = {
+      kind: 'topic-placement',
+      incarnation: 'inc-A',
+      entries: [{ seq: 6, ts: '2026-06-05T00:00:00.000Z', machine: 'm_mini', kind: 'topic-placement', data: {} }],
+    };
+    const requestJournalDelta = vi.fn(async () => served);
+    const applyDelta = vi.fn();
+    const localAdvertFor = vi.fn(() => ({ 'topic-placement': { incarnation: 'inc-A', lastSeq: 5 } }));
+
+    const { puller } = basePuller({
+      peerCapacity: {
+        loadAvg: 0.3,
+        journalAdvert: { 'topic-placement': { incarnation: 'inc-A', lastSeq: 9 } },
+      },
+      delta: { requestJournalDelta, applyDelta, localAdvertFor },
+    });
+
+    await puller.pullOnce();
+
+    // Requested for the ahead kind, from OUR lastSeq (5), against the peer.
+    expect(requestJournalDelta).toHaveBeenCalledTimes(1);
+    expect(requestJournalDelta).toHaveBeenCalledWith('m_mini', URL_MINI, 'topic-placement', 5);
+    // Applied under the PEER's machine id (first-hop sender binding).
+    expect(applyDelta).toHaveBeenCalledTimes(1);
+    expect(applyDelta).toHaveBeenCalledWith('m_mini', [served]);
+  });
+
+  it('GATE ON + peer NOT ahead (same incarnation, same seq): requests nothing', async () => {
+    const requestJournalDelta = vi.fn(async () => null);
+    const applyDelta = vi.fn();
+    const localAdvertFor = vi.fn(() => ({ 'topic-placement': { incarnation: 'inc-A', lastSeq: 9 } }));
+
+    const { puller } = basePuller({
+      peerCapacity: {
+        journalAdvert: { 'topic-placement': { incarnation: 'inc-A', lastSeq: 9 } },
+      },
+      delta: { requestJournalDelta, applyDelta, localAdvertFor },
+    });
+
+    await puller.pullOnce();
+
+    expect(requestJournalDelta).not.toHaveBeenCalled();
+    expect(applyDelta).not.toHaveBeenCalled();
+  });
+
+  it('GATE ON + we hold nothing for the kind: requests from seq 0', async () => {
+    const served: JournalDeltaStream = { kind: 'session-lifecycle', incarnation: 'inc-Z', entries: [] };
+    const requestJournalDelta = vi.fn(async () => served);
+    const applyDelta = vi.fn();
+    const localAdvertFor = vi.fn(() => ({})); // we hold nothing for this peer
+
+    const { puller } = basePuller({
+      peerCapacity: {
+        journalAdvert: { 'session-lifecycle': { incarnation: 'inc-Z', lastSeq: 3 } },
+      },
+      delta: { requestJournalDelta, applyDelta, localAdvertFor },
+    });
+
+    await puller.pullOnce();
+
+    expect(requestJournalDelta).toHaveBeenCalledWith('m_mini', URL_MINI, 'session-lifecycle', 0);
+    expect(applyDelta).toHaveBeenCalledWith('m_mini', [served]);
+  });
+
+  it('a failing delta fetch never throws and never applies (presence pass still completes)', async () => {
+    const requestJournalDelta = vi.fn(async () => {
+      throw new Error('ETIMEDOUT');
+    });
+    const applyDelta = vi.fn();
+    const localAdvertFor = vi.fn(() => ({}));
+
+    const { puller, recorded } = basePuller({
+      peerCapacity: {
+        journalAdvert: { 'topic-placement': { incarnation: 'inc-A', lastSeq: 9 } },
+      },
+      delta: { requestJournalDelta, applyDelta, localAdvertFor },
+    });
+
+    const res = await puller.pullOnce(); // must resolve, not reject
+
+    expect(res.recorded).toEqual(['m_mini']); // peer still recorded
+    expect(recorded).toEqual(['m_mini']);
+    expect(requestJournalDelta).toHaveBeenCalledTimes(1);
+    expect(applyDelta).not.toHaveBeenCalled(); // fetch failed → nothing applied
+  });
+
+  it('a different incarnation is still pulled (the applier fences it on apply, not the puller)', async () => {
+    const served: JournalDeltaStream = { kind: 'topic-placement', incarnation: 'inc-B', entries: [] };
+    const requestJournalDelta = vi.fn(async () => served);
+    const applyDelta = vi.fn();
+    const localAdvertFor = vi.fn(() => ({ 'topic-placement': { incarnation: 'inc-A', lastSeq: 9 } }));
+
+    const { puller } = basePuller({
+      peerCapacity: {
+        journalAdvert: { 'topic-placement': { incarnation: 'inc-B', lastSeq: 9 } }, // same seq, NEW incarnation
+      },
+      delta: { requestJournalDelta, applyDelta, localAdvertFor },
+    });
+
+    await puller.pullOnce();
+
+    // Even though lastSeq is equal, the incarnation differs → still requested
+    // (from our lastSeq); incarnation fencing/quarantine is the applier's job.
+    expect(requestJournalDelta).toHaveBeenCalledWith('m_mini', URL_MINI, 'topic-placement', 9);
+    expect(applyDelta).toHaveBeenCalledWith('m_mini', [served]);
+  });
+});

--- a/upgrades/coherence-journal-meshwire.eli16.md
+++ b/upgrades/coherence-journal-meshwire.eli16.md
@@ -1,0 +1,9 @@
+# The diaries actually sync now (P1 closing step — mesh transport)
+
+P1.1 made each machine keep its diaries, P1.2 made them readable, P1.3 built the engine that safely receives a peer's diary. This is the wire that connects them: machines now actually hand each other their diaries over the secure line they already use.
+
+It's deliberately tiny and cheap. The existing once-every-30-seconds "are you alive?" check between machines now carries one extra scrap of information: a peer's "I'm at line N in each of my diaries." When a machine notices a peer is further along than the copy it holds, it asks for just the missing lines — over a separate, size-capped request, so the fast heartbeat itself never gets heavy. The receiving side runs every defense from P1.3 (a machine can only hand over its OWN diary; every line validated; restores caught; nothing trusted until durably saved).
+
+**The safety choice that matters:** this ships DARK even on me. Merging it does NOT turn on cross-machine syncing. The transport and the drive are gated behind an explicit "replication on" switch that defaults off everywhere — so landing this code changes nothing about live mesh traffic. Turning it on between the Laptop and the Mini is a separate, deliberate, watched step (the live proof you pre-approved). This is on purpose: the mesh is load-bearing for everything, and "merge a PR" should never silently rewire it.
+
+What the live proof will show, once both machines are on this version and I flip the switch: move conversation 13481 from the Laptop to the Mini, then ask the LAPTOP "where did 13481 live and why did it move?" — and it answers correctly from the Mini's synced diary. That's the whole initiative's promise, demonstrated end to end. After the proof, the switch can become the spec's default (live-on-dev); until then it stays off so nothing surprises us.

--- a/upgrades/next/coherence-journal-meshwire.md
+++ b/upgrades/next/coherence-journal-meshwire.md
@@ -1,0 +1,32 @@
+<!-- bump: minor -->
+
+## What Changed
+
+**Coherence Journal mesh transport (P1 closing step)** — the `journal-sync`
+MeshCommand + receive handler + own-stream advert on the `session-status`
+response + `PeerPresencePuller` delta-drive that runs the merged
+`JournalSyncApplier` over the existing 30s machine check-in
+(COHERENCE-JOURNAL-SPEC §3.4 rule 5). Adverts are O(kinds) integers on the
+heartbeat; entry deltas ride separate size-capped requests. Ships DARK
+everywhere (gated on explicit `multiMachine.coherenceJournal.replication.enabled
+=== true`) — merge does not change live mesh traffic; cross-machine sync is
+a deliberate flip (the live two-machine proof).
+
+## What to Tell Your User
+
+This is the wire that lets your agent's machines actually exchange their
+diaries — but it ships switched OFF. Turning it on (so the Laptop can answer
+"where did this conversation live on the Mini?") is a deliberate, watched
+step, not something a code update flips silently.
+
+## Summary of New Capabilities
+
+- None user-invocable yet — the transport is dark until the replication
+  switch is turned on. Internal: `journal-sync` mesh verb + advert-driven
+  delta replication.
+
+## Evidence
+
+- Integration round-trip (two in-process journal+applier pairs through a
+  real signed MeshRpc envelope; forged-sender rejection) + gated-drive unit
+  test (no-op when off, never throws). tsc + full lint chain clean.

--- a/upgrades/side-effects/coherence-journal-meshwire.md
+++ b/upgrades/side-effects/coherence-journal-meshwire.md
@@ -1,0 +1,49 @@
+# Side-Effects Review — Coherence Journal mesh transport (P1 closing step)
+
+**Version / slug:** `coherence-journal-meshwire`
+**Date:** `2026-06-05`
+**Author:** `echo`
+**Second-pass reviewer:** `not required as a PR-time pass — design converged (§3.4 rule 5); this is the transport that drives the already-merged, already-reviewed JournalSyncApplier`
+
+## Summary of the change
+
+Wires the `journal-sync` mesh transport (COHERENCE-JOURNAL-SPEC §3.4 rule 5) that drives the merged `JournalSyncApplier`: a `journal-sync` MeshCommand (read/observe RBAC class), an always-registered receive handler (serve own-stream batch / apply inbound), the own-stream advert piggybacked on the `session-status` response, and the `PeerPresencePuller` delta-drive (request + apply when a peer is ahead). The SEND/drive path is gated on `multiMachine.coherenceJournal.replication.enabled === true` (explicit true only) — ships DARK on every agent including echo; merge does not alter live mesh traffic.
+
+## Decision-point inventory
+- `journal-sync` RBAC classification — ADD — read/observe class (any registered peer), same as capacity-report/session-status. No new authority: it serves/accepts replica DATA, never an actuation.
+- Replication activation — gated on explicit `replication.enabled===true`; absent in ConfigDefaults → false everywhere. The proof flips it deliberately.
+
+## 1. Over-block
+Receive handler rejects forged/invalid entries via the applier's §3.4 gates (already reviewed) — counted, never silent. No new over-block surface on the live path (drive is dark).
+
+## 2. Under-block
+First-hop-only: a third machine's history relayed by a peer is rejected (accepted P1 limitation; transitive relay is post-P1). The receive handler being always-on is safe because the applier validates every entry and no peer SENDS unless its own replication flag is on.
+
+## 3. Level-of-abstraction fit
+Transport is a thin driver over the pure applier/writer; the puller carries the advert because the puller IS the existing 30s cadence (no new timer — §3.4 rule 5's grounded correction). Right seam.
+
+## 4. Signal vs authority compliance
+**Required reference:** [docs/signal-vs-authority.md](../../docs/signal-vs-authority.md)
+- [x] No — the transport moves signal data (replica streams). The §3.9 actuation-ban lint (merged) keeps consumers signal-only.
+
+## 5. Interactions
+- Heartbeat bloat: the advert is O(kinds) integers on the session-status RESPONSE; entry payloads ride SEPARATE size-capped journal-sync requests, never the heartbeat envelope (the master spec's JSON.stringify-on-hot-path root cause is avoided).
+- Mixed-version: an old peer RBAC-default-denies journal-sync (403) or has no handler (501); the sender treats both as "peer lacks the verb" and backs off — no retry storm (gated drive only runs when replication is on anyway).
+- Backward-compat: the journalAdvert field on session-status is optional; old callers parse permissively and ignore it (verified).
+- guardWrite seam: replica appends go through state.guardJournalWrite (standby-safe, prefix-allowlisted) — same as the writer.
+
+## 6. External surfaces
+- New mesh verb on the wire ONLY when replication.enabled===true on the sender. On merge: dark everywhere → zero new mesh traffic. The receive handler accepts journal-sync if a peer ever sends, but no peer sends while dark.
+- New replica files under state/coherence-journal/peers/ ONLY once the proof flips it on.
+
+## 7. Rollback cost
+Pure code revert + patch; replica files inert plain JSONL. The dark default means rollback before the proof is a no-op in practice.
+
+## Conclusion
+The transport lands dark by explicit gate so merge ≠ live mesh change; the live two-machine proof is a deliberate, monitored flip (pre-approved). The §3.4-rule-5 grounded transport (advert on the real 30s pull, deltas separate + capped) is implemented as specified. After a successful proof, the gate can move to the spec's live-on-dev default in a follow-up. Clear to ship dark.
+
+## Second-pass review (if required)
+**Reviewer:** convergence panel (§3.4 design-time) + the live two-machine proof as the closing functional verification.
+
+## Evidence pointers
+- tests/integration/journal-sync-roundtrip.test.ts (two in-process pairs through a real signed envelope; forged-sender rejection), tests/unit/PeerPresencePuller-journal.test.ts (gated drive; no-op when off; never throws).


### PR DESCRIPTION
## ELI16 overview (plain English)

The wire that connects the diaries. P1.1 made each machine keep its diaries, P1.2 made them readable, P1.3 built the engine that safely receives a peer's diary — this hands them across the secure line machines already use. The existing 30-second "are you alive?" check now also carries "I'm at line N in each diary"; when a machine sees a peer is further along, it asks for just the missing lines (over a separate, size-capped request, so the heartbeat stays light).

**Ships DARK even on echo.** Merging this does NOT turn on cross-machine sync. The send/drive path is gated behind an explicit `replication.enabled === true` that defaults off everywhere — so landing it changes nothing about live mesh traffic. Turning it on between the Laptop and the Mini is a separate, deliberate, watched step (the live proof, pre-approved). The mesh is load-bearing; merging a PR should never silently rewire it.

Once both machines carry this version and replication is flipped on, the proof: move conversation 13481 to the Mini, then ask the LAPTOP "where did 13481 live and why?" — it answers from the Mini's synced diary. The whole initiative's promise, end to end.

## Gate chain

Spec: converged + `approved: true` (Justin, topic 13481). Tier-2 trace (ELI16 + side-effects + fragment). Drives the already-merged, already-reviewed `JournalSyncApplier` (§3.4).

## Evidence

- Real signed MeshRpc round-trip (two in-process journal+applier pairs; forged-sender rejection), gated-drive unit test (no-op when off, never throws), getOwnAdvert test
- Full push suite green (24715 passing); no-silent-fallbacks at baseline; tsc + full lint chain clean (incl. journal-actuation-ban over 8 actuator modules)
- Replication SEND/drive confirmed gated on explicit `replication.enabled===true` (dark on merge)

🤖 Generated with Claude Code
