### PR TITLE
feat(security): PrincipalGuard — cross-principal attribution detector (Know Your Principal #898, Phase 1)

### DIFF
--- a/.instar/instar-dev-decisions/2026-06-06T06-29-39-850Z-principal-guard-phase1.json
+++ b/.instar/instar-dev-decisions/2026-06-06T06-29-39-850Z-principal-guard-phase1.json
@@ -1,0 +1,16 @@
+{
+  "ts": "2026-06-06T06:29:39.850Z",
+  "slug": "principal-guard-phase1",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 165,
+  "causalAutopsy": {
+    "origin": "new-code",
+    "notes": "Implements the cross-principal guard from the Caroline identity-bleed incident (CMT-1125) + the ratified Know Your Principal standard (#898)."
+  },
+  "verdict": "pass"
+}

--- a/docs/eli16/principal-guard-phase1.eli16.md
+++ b/docs/eli16/principal-guard-phase1.eli16.md
@@ -1,0 +1,26 @@
+# Principal Guard (Phase 1 brain) — ELI16
+
+> The one-line version: a detector that reads the agent's own writing and flags it whenever the agent credits a decision to a person who isn't the verified operator and isn't a known user — the structural catch for the Caroline failure.
+
+## The problem in one breath
+
+On a shared machine, my overnight session credited my real operator's decisions to a different real person ("Caroline") across three documents — "Mandate (Caroline)," "Locked with Caroline," "have Caroline drop a token" — and nothing noticed, because the mix-up was in the agent's own writing, not in any message someone sent. The existing gate only watches who is allowed to message the agent; nothing watched whom the agent decided to credit and act for.
+
+## What already exists
+
+Instar has a user registry (the authoritative list of real principals) and an onboarding gate for inbound messages. What it lacked is a check on the agent's own output for misattributed authority. The "Know Your Principal" constitution standard (just ratified) requires exactly that check.
+
+## What this adds
+
+A pure-logic module, `PrincipalGuard`, that is the testable brain of that check:
+- It establishes a topic's operator only from the platform-verified sender id — never from a name read in text (so a name in a document can never become the operator).
+- It scans agent-authored text for operator-role decision shapes ("X approved," "Mandate (X)," "locked with X," "X dropped a token," "on behalf of X") and pulls out the credited name.
+- It flags any credited name that isn't the bound operator and doesn't resolve to a known user — blocking when the decision carries authority or credentials (a mandate, a token drop), warning for ordinary prose.
+
+## The safeguards
+
+It's deterministic and self-contained — no network, no files, not wired into the live request path yet (that's a later increment), so it can't affect the running server. It ships with the incident-replay regression test the spec requires: the three real Caroline document lines, with the topic bound to my operator, must all be caught (block for the mandate and credential lines, warn for the rest); and the same lines crediting the bound operator must all pass, so it doesn't cry wolf. Capitalized non-names like "Production approved" are deliberately not flagged.
+
+## What ships when
+
+This is the first, foundational, fully-tested piece. The later increments wire it into the topic-operator binding, the session-start "who is my operator" injection, and the outbound/at-rest review path.

--- a/docs/specs/PRINCIPAL-GUARD.md
+++ b/docs/specs/PRINCIPAL-GUARD.md
@@ -1,0 +1,39 @@
+# PrincipalGuard — module reference
+
+`src/core/PrincipalGuard.ts` is the pure-logic detector behind the **Know Your
+Principal** constitution standard (`docs/STANDARDS-REGISTRY.md`) and the
+operator-identity binding spec (`docs/specs/OPERATOR-IDENTITY-BINDING-SPEC.md`).
+It is the Phase-1 brain of the cross-principal coherence guard born from the
+"Caroline" identity-bleed incident (CMT-1125): an autonomous session silently
+credited its operator's decisions to a different real principal, in the agent's
+own output, where no inbound gate watched.
+
+## API
+
+- **`establishOperator(authenticatedUid, displayName?)` → `VerifiedOperator | null`**
+  Establish a topic's operator ONLY from the platform-verified sender id. There
+  is no path that accepts a name from content as the operator — the Caroline
+  failure mode is impossible by type. A blank uid yields `null` (an unbound
+  topic, which the evaluator treats as "everything is unverifiable").
+
+- **`detectAttributions(text)` → `Attribution[]`**
+  Find operator-role-decision shapes in agent-authored text: `mandate`,
+  `approval`, `lock`, `credential`, `acting-for` (e.g. "Mandate (X)", "X
+  approved", "locked with X", "X dropped a token", "on behalf of X"). The
+  principal NAME must be capitalized; capitalized non-names ("Production
+  approved", "The Board approved") are not flagged.
+
+- **`evaluatePrincipalCoherence(text, operator, knownUserNames?)` → `PrincipalFinding[]`**
+  Flag any attribution to a principal who is neither the bound operator nor a
+  known user (from `UserManager`). Authority/credential misattributions
+  (`mandate`, `credential`) → **block**; prose → **warn**. An attribution to the
+  bound operator or any known user resolves cleanly and is not flagged.
+
+## Status
+
+Pure logic, deterministic, no I/O — **no runtime consumers yet**. The later
+increments wire it into the topic-operator binding, the session-start
+"who is my operator" injection, and the outbound/at-rest review path. Verified
+by `tests/unit/principal-guard.test.ts` (13 tests) including the incident-replay
+regression: the real Caroline doc lines are all caught with the topic bound to
+the operator, and the same lines crediting the bound operator all pass.

--- a/site/src/content/docs/concepts/know-your-principal.md
+++ b/site/src/content/docs/concepts/know-your-principal.md
@@ -1,0 +1,40 @@
+---
+title: Know Your Principal
+description: How Instar verifies who an agent is serving and acting for — and catches it when an agent credits a decision to the wrong person.
+---
+
+## An unverified identity is a guess
+
+Instar agents act on behalf of a **principal** — the operator they serve, whose
+decisions they carry out. "Know Your Principal" is the constitution standard
+(and the structure enforcing it) that keeps that relationship honest: an
+unrecognized party appearing in a user, operator, or decision role is a
+**question to resolve**, never a fact to accept. It binds not only inbound
+messages (who may speak to the agent) but the agent's own reasoning and output
+(whom it credits, vouches for, or seats in the operator's chair).
+
+## Why it exists
+
+On a shared machine running several agents, an autonomous session once silently
+adopted a *different real person* as its operator — crediting its actual
+operator's decisions to her across several documents — and nothing noticed,
+because the mix-up lived entirely in the agent's own writing, where no inbound
+gate watched. The existing onboarding gate guards the front door; this guards
+the agent's own head.
+
+## How it works
+
+- **Hard operator binding.** A topic's operator is established only from the
+  platform-verified sender id — never from a name read in content or ambient
+  machine state — and injected at session start, immutable for the session.
+- **The cross-principal detector (`PrincipalGuard`).** It reads agent-authored
+  text for operator-role decision shapes ("X approved", "Mandate (X)", "locked
+  with X", "X dropped a token") and flags any credited to a principal who is
+  neither the bound operator nor a known user. Authority and credential
+  misattributions are blocked; ordinary prose is warned. `PrincipalGuard` is
+  the deterministic core; the user registry is the authoritative source of who
+  a real principal is.
+
+The principle: don't rely on an agent *happening* to feel suspicious of an
+unfamiliar name. The suspicion is structural — resolve against the registry, or
+treat as unknown and stop.

--- a/src/core/PrincipalGuard.ts
+++ b/src/core/PrincipalGuard.ts
@@ -1,0 +1,165 @@
+/**
+ * PrincipalGuard — cross-principal attribution detector (EXO 3.0 / "Know Your
+ * Principal" standard, Phase 1 brain).
+ *
+ * The "Caroline" incident (2026-06-05, topic 19437): an autonomous session
+ * silently adopted a real OTHER principal as its operator and credited the
+ * actual operator's decisions to her across three docs — and no gate watched,
+ * because the contamination was in the agent's OWN output, not an inbound
+ * message. This module is the pure-logic detector for that failure: given a
+ * piece of agent-authored text, it finds operator-ROLE-decision attributions
+ * ("X approved", "locked with X", "mandate (X)", "X dropped a token") and
+ * flags any whose attributed principal is NOT the topic's bound operator and
+ * does NOT resolve to a known user.
+ *
+ * Pure + deterministic so it is unit-testable in isolation; it performs no I/O
+ * and is not wired into the live request path here (that is a later increment).
+ * The constitution standard it enforces: "Know Your Principal — An Unverified
+ * Identity Is a Guess" (docs/STANDARDS-REGISTRY.md). Spec:
+ * docs/specs/OPERATOR-IDENTITY-BINDING-SPEC.md.
+ */
+
+/** A verified operator, established ONLY from an authenticated channel — never
+ *  from a name read in content (that is the whole point). */
+export interface VerifiedOperator {
+  /** The platform-verified sender id (e.g. Telegram uid). */
+  uid: string;
+  /** Display name(s) the operator is known by, lowercased for matching. */
+  names: string[];
+}
+
+/**
+ * Establish a topic's operator from the AUTHENTICATED sender — never from a
+ * content name. The uid is the authority; names are only for matching the
+ * agent's prose against the verified principal. A blank uid yields no operator
+ * (an unbound topic), which the guard treats as "everything is unverified".
+ */
+export function establishOperator(authenticatedUid: string, displayName?: string): VerifiedOperator | null {
+  const uid = String(authenticatedUid ?? '').trim();
+  if (!uid) return null;
+  const names = (displayName ?? '').trim() ? [displayName!.trim().toLowerCase()] : [];
+  return { uid, names };
+}
+
+/** The kind of operator-role decision an attribution carries — drives warn vs block. */
+export type AttributionKind =
+  | 'approval' // "X approved", "blessed by X"
+  | 'mandate' // "mandate (X)", "X authorized"
+  | 'credential' // "X dropped a token", "X's credentials"
+  | 'lock' // "locked with X", "standing requirement from X"
+  | 'acting-for'; // "acting on X's behalf", "on X's say-so"
+
+export interface Attribution {
+  /** The principal name the decision was attributed to (lowercased). */
+  principal: string;
+  kind: AttributionKind;
+  /** The matched snippet, for the audit trail. */
+  snippet: string;
+}
+
+// ── Detection patterns ───────────────────────────────────────────────
+// Each captures a person-like principal NAME in group 1. Kept conservative:
+// a name is 1-3 capitalized-ish words (so "the team" / "prod" don't match).
+// NAME requires a real capital first letter (case-SENSITIVE — no `i` flag — so
+// "have"/"production" can never be captured as a principal). Only the keyword
+// LEADS are made case-flexible ([Mm]andate, [Ll]ock…) so a sentence-initial
+// "Mandate" matches as well as a mid-sentence "mandate".
+const NAME = String.raw`([A-Z][a-zA-Z]+(?:\s+[A-Z][a-zA-Z]+){0,2})`;
+// Bounded gap that lets a date/short clause sit between a keyword and the name
+// ("Locked 2026-06-04 with Caroline") without swallowing a sentence.
+const GAP = String.raw`[^.\n]{0,40}?`;
+const PATTERNS: Array<{ re: RegExp; kind: AttributionKind }> = [
+  { re: new RegExp(String.raw`\b[Mm]andate\s*\(\s*${NAME}\s*\)`, 'g'), kind: 'mandate' },
+  { re: new RegExp(String.raw`\b${NAME}\s+[Aa]uthoriz(?:ed|es)\b`, 'g'), kind: 'mandate' },
+  { re: new RegExp(String.raw`\b${NAME}\s+[Aa]pprov(?:ed|es)\b`, 'g'), kind: 'approval' },
+  { re: new RegExp(String.raw`\b(?:[Bb]lessed|[Ss]igned[- ]off)\s+by\s+${NAME}`, 'g'), kind: 'approval' },
+  { re: new RegExp(String.raw`\b[Ll]ock(?:ed)?\b${GAP}\b(?:with|by)\s+${NAME}`, 'g'), kind: 'lock' },
+  { re: new RegExp(String.raw`\b[Ss]tanding requirement from\s+${NAME}`, 'g'), kind: 'lock' },
+  { re: new RegExp(String.raw`\b${NAME}\s+(?:dropped|drop)\s+(?:a|the)\s+(?:token|credential|secret|key)`, 'g'), kind: 'credential' },
+  { re: new RegExp(String.raw`\b${NAME}['’]s\s+(?:credential|token|git\s+cred)`, 'g'), kind: 'credential' },
+  { re: new RegExp(String.raw`\b[Oo]n\s+behalf\s+of\s+${NAME}`, 'g'), kind: 'acting-for' },
+  { re: new RegExp(String.raw`\b[Oo]n\s+${NAME}['’]s\s+(?:say-so|behalf|authority)`, 'g'), kind: 'acting-for' },
+];
+
+// Words that look capitalized but are never principals (sentence-start nouns,
+// product/role terms). Keeps the detector from flagging "Production approved".
+const NON_PRINCIPALS = new Set([
+  'the', 'a', 'an', 'prod', 'production', 'ci', 'team', 'board', 'ops', 'staging',
+  'github', 'telegram', 'slack', 'dawn', 'echo', 'i', 'we', 'you', 'they', 'it',
+  'have', 'has', 'this', 'that', 'every', 'all',
+]);
+
+function isPersonLike(name: string): boolean {
+  const firstWord = name.split(/\s+/)[0];
+  // The `i` flag lets [A-Z] match lowercase too, so require an actual capital
+  // first letter here — a real person name is capitalized; "production" is not.
+  const startsCapital = /^[A-Z]/.test(firstWord);
+  return startsCapital && !NON_PRINCIPALS.has(firstWord.toLowerCase());
+}
+
+/** Find every operator-role-decision attribution in agent-authored text. */
+export function detectAttributions(text: string): Attribution[] {
+  const out: Attribution[] = [];
+  const seen = new Set<string>();
+  for (const { re, kind } of PATTERNS) {
+    re.lastIndex = 0;
+    let m: RegExpExecArray | null;
+    while ((m = re.exec(text)) !== null) {
+      const principal = (m[1] ?? '').trim();
+      if (!principal || !isPersonLike(principal)) continue;
+      const key = `${kind}:${principal.toLowerCase()}:${m.index}`;
+      if (seen.has(key)) continue;
+      seen.add(key);
+      out.push({ principal: principal.toLowerCase(), kind, snippet: m[0] });
+    }
+  }
+  return out;
+}
+
+export type Verdict = 'ok' | 'warn' | 'block';
+
+export interface PrincipalFinding {
+  attribution: Attribution;
+  verdict: Verdict;
+  reason: string;
+}
+
+/** Credential/authority-bearing kinds BLOCK when misattributed; the rest WARN. */
+const BLOCK_KINDS = new Set<AttributionKind>(['mandate', 'credential']);
+
+/**
+ * Evaluate a piece of agent-authored text against the topic's verified
+ * operator and the known-user registry. An attribution to the bound operator
+ * (or any known user) is fine; an attribution to anyone else is the Caroline
+ * failure — warn for prose, block for authority/credential decisions.
+ *
+ * `knownUserNames` are lowercased display names from UserManager (the
+ * authoritative registry). Resolution against it is what the "Know Your
+ * Principal" standard requires before any principal is accepted.
+ */
+export function evaluatePrincipalCoherence(
+  text: string,
+  operator: VerifiedOperator | null,
+  knownUserNames: string[] = [],
+): PrincipalFinding[] {
+  const known = new Set<string>([
+    ...(operator?.names ?? []),
+    ...knownUserNames.map((n) => n.trim().toLowerCase()).filter(Boolean),
+  ]);
+  const findings: PrincipalFinding[] = [];
+  for (const attribution of detectAttributions(text)) {
+    if (known.has(attribution.principal)) continue; // resolves to a verified principal — fine
+    const verdict: Verdict = BLOCK_KINDS.has(attribution.kind) ? 'block' : 'warn';
+    findings.push({
+      attribution,
+      verdict,
+      reason:
+        `Operator-role ${attribution.kind} attributed to "${attribution.principal}", who is ` +
+        (operator
+          ? `not this topic's bound operator and does not resolve to a known user`
+          : `unverifiable — this topic has no bound operator`) +
+        `. Know Your Principal: an unrecognized party in a decision role is a question to resolve, not a fact to accept.`,
+    });
+  }
+  return findings;
+}

--- a/tests/unit/principal-guard.test.ts
+++ b/tests/unit/principal-guard.test.ts
@@ -1,0 +1,119 @@
+/**
+ * Unit tests — PrincipalGuard (Know Your Principal standard, Phase 1).
+ *
+ * Covers both sides of every boundary, and the INCIDENT-REPLAY regression test
+ * the spec mandates: the three real "Caroline" doc lines, with the topic bound
+ * to Justin, must all be caught (block for mandate/credential, warn for prose);
+ * the same lines attributed to the bound operator must all pass.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  establishOperator,
+  detectAttributions,
+  evaluatePrincipalCoherence,
+} from '../../src/core/PrincipalGuard.js';
+
+describe('establishOperator', () => {
+  it('establishes from an authenticated uid (the authority)', () => {
+    const op = establishOperator('7812716706', 'Justin');
+    expect(op?.uid).toBe('7812716706');
+    expect(op?.names).toEqual(['justin']);
+  });
+  it('returns null for a blank uid (unbound topic) — never invents an operator', () => {
+    expect(establishOperator('', 'Justin')).toBeNull();
+    expect(establishOperator('   ')).toBeNull();
+  });
+  it('a content name can never BECOME the operator — only the uid does', () => {
+    // establishOperator takes the authenticated uid; there is no code path that
+    // accepts a name from text. (The whole Caroline failure.)
+    const op = establishOperator('7812716706'); // no display name
+    expect(op?.names).toEqual([]);
+    expect(op?.uid).toBe('7812716706');
+  });
+});
+
+describe('detectAttributions', () => {
+  it('catches the operator-role decision shapes', () => {
+    const kinds = detectAttributions(
+      'Mandate (Caroline). Locked with Caroline. Caroline approved it. ' +
+        'Standing requirement from Caroline. Caroline dropped a token. on behalf of Caroline.',
+    ).map((a) => a.kind);
+    expect(kinds).toContain('mandate');
+    expect(kinds).toContain('lock');
+    expect(kinds).toContain('approval');
+    expect(kinds).toContain('credential');
+    expect(kinds).toContain('acting-for');
+  });
+  it('does NOT flag non-principal capitalized nouns', () => {
+    expect(detectAttributions('Production approved the deploy.')).toHaveLength(0);
+    expect(detectAttributions('The Board approved it.')).toHaveLength(0);
+    expect(detectAttributions('CI approved the merge.')).toHaveLength(0);
+  });
+  it('does NOT flag ordinary prose with no decision attribution', () => {
+    expect(detectAttributions('We shipped the feature and ran the tests.')).toHaveLength(0);
+  });
+});
+
+describe('evaluatePrincipalCoherence — the boundary', () => {
+  const justin = establishOperator('7812716706', 'Justin');
+
+  it('PASSES when the decision is attributed to the bound operator', () => {
+    expect(evaluatePrincipalCoherence('Justin approved it.', justin)).toHaveLength(0);
+    expect(evaluatePrincipalCoherence('Mandate (Justin).', justin)).toHaveLength(0);
+  });
+
+  it('PASSES when attributed to another KNOWN user (resolves in the registry)', () => {
+    expect(evaluatePrincipalCoherence('Dana approved it.', justin, ['dana'])).toHaveLength(0);
+  });
+
+  it('FLAGS an unknown principal; BLOCKS authority/credential, WARNS prose', () => {
+    const f = evaluatePrincipalCoherence(
+      'Mandate (Caroline). Caroline approved the page. Caroline dropped a token.',
+      justin,
+      ['dana'],
+    );
+    const byKind = Object.fromEntries(f.map((x) => [x.attribution.kind, x.verdict]));
+    expect(byKind['mandate']).toBe('block');
+    expect(byKind['credential']).toBe('block');
+    expect(byKind['approval']).toBe('warn');
+  });
+
+  it('treats EVERY attribution as unverifiable when the topic has no bound operator', () => {
+    const f = evaluatePrincipalCoherence('Caroline approved it.', null);
+    expect(f).toHaveLength(1);
+    expect(f[0].reason).toMatch(/no bound operator/);
+  });
+});
+
+// ── The incident-replay regression test (spec §test plan) ────────────
+describe('Caroline incident replay — would this have caught it?', () => {
+  const justin = establishOperator('7812716706', 'Justin');
+  const realDocLines = [
+    'Mandate (Caroline): every EXO 3.0 feature must pass a Tier-4 verification.',
+    'Locked 2026-06-04 with Caroline.',
+    'Standing requirement from Caroline (2026-06-04): unit/integration/e2e do not prove agent behavior.',
+    'have Caroline drop a token via Secret Drop.',
+  ];
+
+  it('catches ALL three+ real Caroline doc lines with the topic bound to Justin', () => {
+    for (const line of realDocLines) {
+      const f = evaluatePrincipalCoherence(line, justin, ['dana', 'codey']);
+      expect(f.length, `should flag: ${line}`).toBeGreaterThan(0);
+      expect(f[0].attribution.principal).toBe('caroline');
+    }
+  });
+
+  it('the mandate + credential lines BLOCK (authority-bearing)', () => {
+    const mandate = evaluatePrincipalCoherence(realDocLines[0], justin);
+    const cred = evaluatePrincipalCoherence(realDocLines[3], justin);
+    expect(mandate[0].verdict).toBe('block');
+    expect(cred[0].verdict).toBe('block');
+  });
+
+  it('the SAME lines attributed to the bound operator all pass (no false positives)', () => {
+    for (const line of realDocLines) {
+      const asJustin = line.replace(/Caroline/g, 'Justin');
+      expect(evaluatePrincipalCoherence(asJustin, justin), `should pass: ${asJustin}`).toHaveLength(0);
+    }
+  });
+});

--- a/upgrades/next/principal-guard-phase1.md
+++ b/upgrades/next/principal-guard-phase1.md
@@ -1,0 +1,34 @@
+---
+bump: minor
+audience: agent-only
+maturity: experimental
+---
+
+## What Changed
+
+Added `src/core/PrincipalGuard.ts` — the pure-logic brain of the "Know Your
+Principal" cross-principal coherence guard (constitution standard ratified in
+#898). It establishes a topic's operator only from the authenticated sender,
+detects operator-role-decision attributions in agent-authored text ("X
+approved", "Mandate (X)", "locked with X", "X dropped a token"), and flags any
+credited to a principal who is neither the bound operator nor a known user —
+blocking authority/credential misattributions, warning on prose. No runtime
+consumers yet (the wiring is a later increment).
+
+## What to Tell Your User
+
+Nothing user-facing changes. This is foundation code (experimental) for the
+security fix behind the Caroline identity-bleed incident — it does not alter any
+current behavior.
+
+## Summary of New Capabilities
+
+- `PrincipalGuard` (experimental, no runtime consumers yet): `establishOperator`,
+  `detectAttributions`, `evaluatePrincipalCoherence`.
+
+## Evidence
+
+Net-new capability. Verified by 13 unit tests including the incident-replay
+regression test (the three real Caroline doc lines all caught with the topic
+bound to the operator; the same lines crediting the operator all pass) and a
+clean `tsc --noEmit`.

--- a/upgrades/side-effects/principal-guard-phase1.md
+++ b/upgrades/side-effects/principal-guard-phase1.md
@@ -1,0 +1,39 @@
+# Side-effects review — PrincipalGuard (Phase 1 brain)
+
+## What this change is
+A new pure-logic module `src/core/PrincipalGuard.ts` (operator establishment +
+cross-principal attribution detector + warn/block evaluator) and its unit test.
+Implements the detector half of the just-ratified "Know Your Principal" standard
+(the cross-principal coherence guard from OPERATOR-IDENTITY-BINDING-SPEC.md §2).
+
+## Blast radius
+- **Runtime impact: none.** Nothing imports `PrincipalGuard` at boot or in any
+  route/job/sentinel yet. Adding the file cannot change live behavior. It is the
+  testable brain; wiring it into the topic-operator binding, session-start
+  injection, and the outbound/at-rest review path are explicit later increments.
+- **No I/O, no network, no new config/route/migration surface.** Pure functions
+  over strings + a `VerifiedOperator` value object.
+- **Establishment is uid-only by construction:** `establishOperator` takes the
+  authenticated sender uid; there is NO code path that accepts a name from
+  content as the operator (the Caroline failure mode is impossible by type).
+
+## Security review
+- The detector is conservative: a name must be capitalized (case-sensitive,
+  not the `i` flag) and not in a non-principal stop-set, so "Production
+  approved" / "The Board approved" do not flag. False positives warn (prose) or
+  block (authority/credential) — they never silently pass a misattribution.
+- No payload/secret handling; operates only on already-authored text.
+
+## Framework generality
+Pure logic, no session-launch/inject/message-delivery surface — framework-agnostic.
+
+## Test coverage
+13 unit tests covering both sides of every boundary: uid-only establishment
+(incl. blank → null), each detection shape, non-principal rejection,
+bound-operator pass, known-user pass, unknown-principal flag with block-vs-warn
+tiering, no-operator case, and the **incident-replay regression test** — the
+three real Caroline doc lines all caught (block for mandate/credential), and the
+same lines crediting the bound operator all pass. `tsc --noEmit` clean.
+
+## Rollback
+Delete the module + test; zero runtime consequence (no consumers).


### PR DESCRIPTION
## What
The pure-logic **detector brain** of the "Know Your Principal" cross-principal coherence guard — the first implementation increment of the ratified standard (#898) and its spec (#897). Implements the §2 detector from `OPERATOR-IDENTITY-BINDING-SPEC.md`.

`src/core/PrincipalGuard.ts`:
- `establishOperator(uid, name?)` — a topic's operator is established **only from the authenticated sender id**; there is no code path that accepts a name from content (the Caroline failure mode is impossible by type).
- `detectAttributions(text)` — finds operator-role-decision shapes in agent-authored text: `Mandate (X)`, `X approved`, `locked with X`, `standing requirement from X`, `X dropped a token`, `on behalf of X`.
- `evaluatePrincipalCoherence(text, operator, knownUserNames)` — flags any attribution to a principal who is neither the bound operator nor a known user; **blocks** authority/credential misattributions (mandate, credential), **warns** on prose.

## The incident-replay regression test (spec §test-plan)
The three real Caroline doc lines, with the topic bound to the operator, are all caught (block for the mandate + credential lines); and the **same lines crediting the bound operator all pass** (no false positives). Capitalized non-names ("Production approved", "The Board approved") are not flagged.

## Scope
Pure logic, **no runtime consumers yet** — adding the file cannot change live behavior (see `upgrades/side-effects/principal-guard-phase1.md`). The later increments wire it into the topic-operator binding, the session-start "who is my operator" injection, and the outbound/at-rest review path. 13 unit tests, `tsc` clean.

## ELI16
A detector that reads the agent's own writing and flags it whenever the agent credits a decision to a person who isn't the verified operator and isn't a known user — the structural catch for the Caroline failure, where my session credited my operator's decisions to a different real person and nothing noticed. It establishes who the operator is only from the platform-verified sender (never a name in a document), and it ships with a replay test built from the actual incident's three document lines.

Incident: CMT-1125. Standard: #898. Spec: #897.

🤖 Generated with [Claude Code](https://claude.com/claude-code)