### PR TITLE
fix(resource-hygiene): exclude Claude transcripts from Spotlight (the ~18GB mds_stores churn)

### DIFF
--- a/.instar/instar-dev-decisions/2026-06-06T06-39-23-558Z-spotlight-resource-hygiene.json
+++ b/.instar/instar-dev-decisions/2026-06-06T06-39-23-558Z-spotlight-resource-hygiene.json
@@ -1,0 +1,20 @@
+{
+  "ts": "2026-06-06T06:39:23.558Z",
+  "slug": "spotlight-resource-hygiene",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "irreversibility: src/core/PostUpdateMigrator.ts touches PostUpdateMigrator",
+    "migration / fleet-rollout surface: src/core/PostUpdateMigrator.ts touches PostUpdateMigrator (fleet migration machinery)",
+    "new capability: new config key added"
+  ],
+  "belowFloor": true,
+  "files": 2,
+  "loc": 57,
+  "causalAutopsy": {
+    "origin": "latent",
+    "notes": "Not a prior-PR regression. The transcript-indexing cost has existed since Claude Code began writing JSONL session transcripts; the recent node_modules + worktree Spotlight-exclusion PRs addressed the static/throwaway trees but never extended to the constantly-churning transcript set (~18GB), which 2026-06-06 grounding (ps/mds_stores census during Justin's resource-hogging investigation) showed is the single largest mds_stores consumer. This closes that latent gap by reusing the same marker mechanism. Fix 1 of 4 in the resource-efficiency initiative."
+  },
+  "verdict": "pass"
+}

--- a/.instar/instar-dev-decisions/2026-06-06T06-41-32-638Z-spotlight-resource-hygiene.json
+++ b/.instar/instar-dev-decisions/2026-06-06T06-41-32-638Z-spotlight-resource-hygiene.json
@@ -1,0 +1,20 @@
+{
+  "ts": "2026-06-06T06:41:32.638Z",
+  "slug": "spotlight-resource-hygiene",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "irreversibility: src/core/PostUpdateMigrator.ts touches PostUpdateMigrator",
+    "migration / fleet-rollout surface: src/core/PostUpdateMigrator.ts touches PostUpdateMigrator (fleet migration machinery)",
+    "new capability: new config key added"
+  ],
+  "belowFloor": true,
+  "files": 2,
+  "loc": 57,
+  "causalAutopsy": {
+    "origin": "latent",
+    "notes": "Not a prior-PR regression. The transcript-indexing cost has existed since Claude Code began writing JSONL session transcripts; the recent node_modules + worktree Spotlight-exclusion PRs addressed the static/throwaway trees but never extended to the constantly-churning transcript set (~18GB), which 2026-06-06 grounding (ps/mds_stores census during Justin's resource-hogging investigation) showed is the single largest mds_stores consumer. This closes that latent gap by reusing the same marker mechanism. Fix 1 of 4 in the resource-efficiency initiative."
+  },
+  "verdict": "pass"
+}

--- a/.instar/instar-dev-traces/2026-06-06T23-30-00-000Z-spotlight-resource-hygiene.json
+++ b/.instar/instar-dev-traces/2026-06-06T23-30-00-000Z-spotlight-resource-hygiene.json
@@ -1,0 +1,24 @@
+{
+    "version": 2,
+    "slug": "spotlight-resource-hygiene",
+    "sessionId": "96c61421-860a-48f9-92b4-26328f5640f1",
+    "timestamp": "2026-06-06T23:30:00.000Z",
+    "artifactPath": "upgrades/side-effects/spotlight-resource-hygiene.md",
+    "artifactSha256": "fe98422d9baf8e68bce09288084d816e12a171a25f140bc0d025759df690d666",
+    "coveredFiles": [
+        "src/core/InstarWorktreeManager.ts",
+        "src/core/PostUpdateMigrator.ts",
+        "tests/unit/worktree-spotlight-exclusion.test.ts"
+    ],
+    "phase": "complete",
+    "tier": 1,
+    "tierReasoning": "Small, low-risk OS resource-hygiene addition that mirrors the existing node_modules/worktree Spotlight-exclusion pattern exactly: one pure-ish helper that drops a .metadata_never_index marker at the agent's Claude transcript dir + an idempotent PostUpdateMigrator backfill. No gate, no message-flow change, no persistent-state change, no API route. Filesystem-additive only (one empty marker file), reversible, graceful no-op on failure/non-macOS. Unit + migration tests cover both sides of every boundary. No converged spec required for Tier 1.",
+    "eli16Path": "docs/eli16/spotlight-resource-hygiene.eli16.md",
+    "sideEffectsPath": "upgrades/side-effects/spotlight-resource-hygiene.md",
+    "causalAutopsy": {
+        "origin": "latent",
+        "notes": "Not a prior-PR regression. The transcript-indexing cost has existed since Claude Code began writing JSONL session transcripts; the recent node_modules + worktree Spotlight-exclusion PRs addressed the static/throwaway trees but never extended to the constantly-churning transcript set (~18GB), which 2026-06-06 grounding (ps/mds_stores census during Justin's resource-hogging investigation) showed is the single largest mds_stores consumer. This closes that latent gap by reusing the same marker mechanism. Fix 1 of 4 in the resource-efficiency initiative."
+    },
+    "secondPass": "not-required",
+    "reviewerConcurred": null
+}

--- a/docs/eli16/spotlight-resource-hygiene.eli16.md
+++ b/docs/eli16/spotlight-resource-hygiene.eli16.md
@@ -1,0 +1,34 @@
+# Spotlight resource hygiene — exclude Claude transcripts - ELI16
+
+> The one-line version: macOS Spotlight was burning ~60-90% of a CPU core constantly because it kept re-indexing Instar's Claude session transcripts — ~18 GB of files that grow with every single message. This tells Spotlight to skip them, so it stops.
+
+## The problem (found 2026-06-06 while chasing fleet-wide resource hogging)
+
+Justin flagged that the machine regularly hits "resource hogging" and suspected Instar. Grounding it with `ps`/`mds_stores` showed the single biggest non-agent CPU consumer was `mds_stores` — that's macOS Spotlight, the thing that indexes your files so you can search them. It was pinned at 60-90% of a core, *constantly*.
+
+Why constantly? Every Claude Code session writes a running transcript to `~/.claude/projects/<project>/<session>.jsonl`, and **appends to it on every single turn**. Across a busy fleet that's ~18 GB of files that change every few seconds. Spotlight re-indexes a file whenever it changes — so it was endlessly re-reading 18 GB of transcripts that nobody ever Spotlight-searches.
+
+## What already existed
+
+Instar already drops a tiny `.metadata_never_index` marker (the standard macOS "don't index this folder" hint) on two things: the `.worktrees/` folder and `node_modules/`. Both are big, both are pointless to index. But the **transcripts were never excluded** — and they're the bigger, constantly-churning set. The earlier exclusion fixed the static trees and missed the moving one.
+
+## What this adds
+
+One more exclusion, following the exact same pattern: drop the `.metadata_never_index` marker at the agent's Claude transcript directory (`~/.claude/projects/<encoded-agent-home>`). 
+
+- A new `ensureClaudeTranscriptSpotlightExclusion(agentHome)` helper computes where Claude stores this agent's transcripts (Claude encodes the home path by turning every non-letter/number into `-`, e.g. `/Users/justin/.instar/agents/echo` → `-Users-justin--instar-agents-echo`) and drops the marker there.
+- A `PostUpdateMigrator` migration runs it on every update, so existing agents get the relief automatically (new agents get it on their first update once they have transcripts).
+
+## Why it's safe
+
+- The marker is the documented Apple way to say "don't index this." It's harmless on non-macOS, idempotent, and reversible (delete the file).
+- Nothing useful is lost: nobody Spotlight-searches a raw Claude JSONL transcript. Instar reads them directly (the TokenLedger), which is unaffected by Spotlight.
+- It only ever *adds* a marker file; it never deletes or moves a transcript. A write failure is a silent no-op (Spotlight just keeps indexing, the prior behavior) — it can never block an update.
+
+## Honest scope
+
+This is **one** of four resource-efficiency fixes Justin asked for, and it's the biggest single lever (the 18 GB transcript churn). It does NOT, by itself, instantly drop `mds_stores` — the marker stops *future* re-indexing, but Spotlight only fully releases already-indexed content on its own schedule (forcing immediate eviction needs a one-time `sudo mdutil` the operator runs). The durable win is that no agent, new or existing, keeps feeding the transcript churn going forward.
+
+## Evidence
+
+Three boundaries covered by unit tests (marker dropped when transcripts exist; correct non-alphanumeric encoding; graceful no-op for a brand-new agent with no transcripts yet; idempotent) plus migration tests (backfills on update, skips cleanly when absent, idempotent). 15/15 green in the spotlight-exclusion suite. `tsc --noEmit` clean. Mirrors the existing node_modules/worktree exclusion pattern exactly.

--- a/src/core/InstarWorktreeManager.ts
+++ b/src/core/InstarWorktreeManager.ts
@@ -809,6 +809,36 @@ export function ensureWorktreeSpotlightExclusion(worktreesDir: string): boolean 
   }
 }
 
+/**
+ * Drop a `.metadata_never_index` marker at this agent's Claude Code transcript
+ * directory (`<claudeHome>/projects/<encoded-agent-home>`) so macOS Spotlight
+ * (mds_stores) stops re-indexing the constantly-appended JSONL session
+ * transcripts. These are the single largest Spotlight churn source on a busy
+ * agent: every assistant/user turn appends to them and an active home accumulates
+ * many GB (measured ~18GB on a busy fleet box), which Spotlight re-indexes on
+ * every change — pinning mds_stores at 60-90% of a core. instar already READS
+ * these transcripts (TokenLedger / CompactionSentinel), so excluding them from
+ * indexing is the matching OS hygiene; nothing usefully Spotlight-searches a
+ * Claude JSONL transcript. Claude encodes the project dir by mapping every
+ * non-alphanumeric char to '-' (`/Users/justin/.instar/agents/echo` ->
+ * `-Users-justin--instar-agents-echo`); we mirror that. Graceful no-op when the
+ * transcript dir doesn't exist yet (no sessions run) or on non-macOS; idempotent.
+ * Returns true iff it created the marker.
+ *
+ * Part of the Responsible Resource Usage standard — OS resource hygiene.
+ */
+export function ensureClaudeTranscriptSpotlightExclusion(
+  agentHome: string,
+  claudeHome?: string,
+): boolean {
+  const home = claudeHome ?? path.join(process.env.HOME || os.homedir(), '.claude');
+  const encoded = agentHome.replace(/[^a-zA-Z0-9]/g, '-');
+  const transcriptDir = path.join(home, 'projects', encoded);
+  if (!fs.existsSync(transcriptDir)) return false;
+  // Reuse the generic marker-dropper (dir-agnostic despite the name).
+  return ensureWorktreeSpotlightExclusion(transcriptDir);
+}
+
 // ── Audit ledger ─────────────────────────────────────────────────────────
 
 export interface LedgerEntry {

--- a/src/core/PostUpdateMigrator.ts
+++ b/src/core/PostUpdateMigrator.ts
@@ -26,7 +26,7 @@ import { execFileSync } from 'node:child_process';
 import crypto from 'node:crypto';
 import { SafeGitExecutor } from './SafeGitExecutor.js';
 import { ensureInstarBashPreToolUseHooks, type SettingsMatcherEntry } from './instarSettingsHooks.js';
-import { resolveAgentHome as resolveAgentHomeForWorktree, ensureWorktreeSpotlightExclusion } from './InstarWorktreeManager.js';
+import { resolveAgentHome as resolveAgentHomeForWorktree, ensureWorktreeSpotlightExclusion, ensureClaudeTranscriptSpotlightExclusion } from './InstarWorktreeManager.js';
 import { fileURLToPath } from 'node:url';
 import { TreeGenerator } from '../knowledge/TreeGenerator.js';
 import { HTTP_HOOK_TEMPLATES, buildHttpHookSettings } from '../data/http-hook-templates.js';
@@ -249,6 +249,7 @@ export class PostUpdateMigrator {
     this.migrateWorktreeConvention(result);
     this.migrateWorktreeSpotlightExclusion(result);
     this.migrateNodeModulesSpotlightExclusion(result);
+    this.migrateClaudeTranscriptSpotlightExclusion(result);
     this.migrateBootWrapperToCjs(result);
     this.migrateBootWrapperAbiCheck(result);
     this.migrateStaleLifelineSignal(result);
@@ -822,6 +823,30 @@ export class PostUpdateMigrator {
       } catch (err) {
         result.errors.push(`node-modules-spotlight-exclusion: ${err instanceof Error ? err.message : String(err)}`);
       }
+    }
+  }
+
+  /**
+   * OS resource hygiene (Responsible Resource Usage standard): exclude this
+   * agent's Claude Code transcript directory (`~/.claude/projects/<encoded-home>`)
+   * from macOS Spotlight. The node_modules + worktree exclusions above cover the
+   * static/throwaway trees, but the BIGGEST churning set was never excluded — the
+   * JSONL session transcripts grow on every assistant/user turn and an active home
+   * accumulates many GB (measured ~18GB on a busy fleet box), which Spotlight
+   * (mds_stores) re-indexes on every change, a top OS-level CPU consumer. instar
+   * already READS these transcripts (TokenLedger), so excluding them from indexing
+   * is the matching hygiene; nothing usefully Spotlight-searches a Claude JSONL.
+   * Honored recursively, harmless on non-macOS, idempotent, and a graceful no-op
+   * when the transcript dir doesn't exist yet (a brand-new agent with no sessions).
+   */
+  private migrateClaudeTranscriptSpotlightExclusion(result: MigrationResult): void {
+    const agentHome = path.dirname(this.config.stateDir);
+    try {
+      if (ensureClaudeTranscriptSpotlightExclusion(agentHome)) {
+        result.upgraded.push('claude-transcript-spotlight-exclusion: dropped .metadata_never_index at ~/.claude/projects/<agent> (excludes Claude session transcripts from Spotlight indexing)');
+      }
+    } catch (err) {
+      result.errors.push(`claude-transcript-spotlight-exclusion: ${err instanceof Error ? err.message : String(err)}`);
     }
   }
 

--- a/tests/unit/worktree-spotlight-exclusion.test.ts
+++ b/tests/unit/worktree-spotlight-exclusion.test.ts
@@ -9,7 +9,7 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
-import { ensureWorktreeSpotlightExclusion } from '../../src/core/InstarWorktreeManager.js';
+import { ensureWorktreeSpotlightExclusion, ensureClaudeTranscriptSpotlightExclusion } from '../../src/core/InstarWorktreeManager.js';
 import { PostUpdateMigrator } from '../../src/core/PostUpdateMigrator.js';
 import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
 
@@ -140,5 +140,94 @@ describe('PostUpdateMigrator.migrateNodeModulesSpotlightExclusion', () => {
     const result2 = makeMigrator(stateDir).migrate();
     expect(result2.errors).toEqual([]);
     expect(result2.upgraded.some((s) => s.includes('node-modules-spotlight-exclusion'))).toBe(false);
+  });
+});
+
+// ── Claude transcript exclusion (the ~18GB JSONL churn — the dominant lever) ──
+
+describe('ensureClaudeTranscriptSpotlightExclusion', () => {
+  let claudeHome: string;
+  let agentHome: string;
+  beforeEach(() => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'claude-transcript-'));
+    claudeHome = path.join(root, '.claude');
+    agentHome = path.join(root, '.instar', 'agents', 'echo');
+  });
+  afterEach(() => {
+    SafeFsExecutor.safeRmSync(path.dirname(claudeHome), { recursive: true, force: true, operation: OP });
+  });
+
+  function transcriptDir(): string {
+    const encoded = agentHome.replace(/[^a-zA-Z0-9]/g, '-');
+    return path.join(claudeHome, 'projects', encoded);
+  }
+
+  it('drops the marker at the encoded transcript dir when it exists', () => {
+    fs.mkdirSync(transcriptDir(), { recursive: true });
+    expect(ensureClaudeTranscriptSpotlightExclusion(agentHome, claudeHome)).toBe(true);
+    expect(fs.existsSync(path.join(transcriptDir(), '.metadata_never_index'))).toBe(true);
+  });
+
+  it('encodes the agent home with non-alphanumerics -> "-" (matches Claude Code)', () => {
+    // The encoded dir name must collapse every "/" and "." to "-".
+    const encoded = agentHome.replace(/[^a-zA-Z0-9]/g, '-');
+    expect(encoded).not.toMatch(/[/.]/);
+    fs.mkdirSync(transcriptDir(), { recursive: true });
+    ensureClaudeTranscriptSpotlightExclusion(agentHome, claudeHome);
+    expect(fs.existsSync(path.join(claudeHome, 'projects', encoded, '.metadata_never_index'))).toBe(true);
+  });
+
+  it('is a graceful no-op when the transcript dir does not exist yet (new agent, no sessions)', () => {
+    // No mkdir — the transcript dir is absent.
+    expect(ensureClaudeTranscriptSpotlightExclusion(agentHome, claudeHome)).toBe(false);
+    expect(fs.existsSync(transcriptDir())).toBe(false);
+  });
+
+  it('is idempotent — returns false on the second run', () => {
+    fs.mkdirSync(transcriptDir(), { recursive: true });
+    expect(ensureClaudeTranscriptSpotlightExclusion(agentHome, claudeHome)).toBe(true);
+    expect(ensureClaudeTranscriptSpotlightExclusion(agentHome, claudeHome)).toBe(false);
+  });
+});
+
+describe('PostUpdateMigrator.migrateClaudeTranscriptSpotlightExclusion', () => {
+  beforeEach(() => {
+    tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), 'claude-transcript-mig-'));
+    setHome(tmpHome);
+    originalAuditDir = process.env.INSTAR_AUDIT_LOG_DIR;
+    process.env.INSTAR_AUDIT_LOG_DIR = path.join(tmpHome, 'audit');
+  });
+  afterEach(() => {
+    if (originalAuditDir === undefined) delete process.env.INSTAR_AUDIT_LOG_DIR;
+    else process.env.INSTAR_AUDIT_LOG_DIR = originalAuditDir;
+    restoreHome();
+    SafeFsExecutor.safeRmSync(tmpHome, { recursive: true, force: true, maxRetries: 5, retryDelay: 100, operation: OP });
+  });
+
+  it('drops the marker at the transcript dir on update when transcripts exist', () => {
+    const { agentHome } = setupAgentHome('echo-transcript');
+    const encoded = agentHome.replace(/[^a-zA-Z0-9]/g, '-');
+    const transcriptDir = path.join(tmpHome, '.claude', 'projects', encoded);
+    fs.mkdirSync(transcriptDir, { recursive: true });
+    const result = makeMigrator(path.join(agentHome, '.instar')).migrate();
+    expect(result.upgraded.some((s) => s.includes('claude-transcript-spotlight-exclusion'))).toBe(true);
+    expect(fs.existsSync(path.join(transcriptDir, '.metadata_never_index'))).toBe(true);
+  });
+
+  it('skips without error when the transcript dir is absent (brand-new agent)', () => {
+    const { agentHome } = setupAgentHome('echo-transcript-none');
+    const result = makeMigrator(path.join(agentHome, '.instar')).migrate();
+    expect(result.errors).toEqual([]);
+    expect(result.upgraded.some((s) => s.includes('claude-transcript-spotlight-exclusion'))).toBe(false);
+  });
+
+  it('is idempotent — second run does not re-report the exclusion', () => {
+    const { agentHome } = setupAgentHome('echo-transcript-idem');
+    const encoded = agentHome.replace(/[^a-zA-Z0-9]/g, '-');
+    fs.mkdirSync(path.join(tmpHome, '.claude', 'projects', encoded), { recursive: true });
+    makeMigrator(path.join(agentHome, '.instar')).migrate();
+    const result2 = makeMigrator(path.join(agentHome, '.instar')).migrate();
+    expect(result2.errors).toEqual([]);
+    expect(result2.upgraded.some((s) => s.includes('claude-transcript-spotlight-exclusion'))).toBe(false);
   });
 });

--- a/upgrades/next/spotlight-resource-hygiene.md
+++ b/upgrades/next/spotlight-resource-hygiene.md
@@ -1,0 +1,43 @@
+<!-- bump: patch -->
+<!-- change_type: fix -->
+
+## What Changed
+
+macOS Spotlight (`mds_stores`) was a top constant CPU consumer on busy fleet
+boxes because it re-indexed the Claude Code session transcripts on every turn —
+~18 GB of JSONL that grows with every message. Instar already excluded
+`.worktrees/` and `node_modules/` from Spotlight; this extends the same
+`.metadata_never_index` exclusion to the agent's Claude transcript directory
+(`~/.claude/projects/<encoded-agent-home>`), the largest churning set.
+
+New `ensureClaudeTranscriptSpotlightExclusion()` helper + a `PostUpdateMigrator`
+backfill so existing agents get the relief on their next update.
+
+## What to Tell Your User
+
+Nothing required — this is silent OS-level resource hygiene. If they've noticed
+the Mac running hot, part of the cause was Spotlight endlessly re-indexing
+session transcripts; this stops that going forward.
+
+## Summary of New Capabilities
+
+- `ensureClaudeTranscriptSpotlightExclusion()` — drops a `.metadata_never_index`
+  marker at the agent's Claude transcript dir so macOS Spotlight stops
+  re-indexing the constantly-appended JSONL session transcripts (~18GB churn).
+- `PostUpdateMigrator` backfill — existing agents get the exclusion on their next
+  update; new agents get it once they have transcripts. Internal OS hygiene; no
+  agent-facing API or config surface.
+
+## Scope (honest)
+
+This prevents FUTURE re-indexing. It does not instantly drop `mds_stores` —
+Spotlight releases already-indexed content on its own schedule; forcing
+immediate eviction needs a one-time `sudo mdutil -E ~/.claude/projects` the
+operator runs. One of several resource-efficiency fixes (2026-06-06).
+
+## Evidence
+
+Unit + migration tests (both sides of every boundary: marker dropped when
+transcripts exist, correct encoding, graceful no-op for a new agent, idempotent;
+migration backfills/skips/idempotent). 15/15 green. `tsc --noEmit` clean.
+Mirrors the existing node_modules/worktree exclusion pattern.

--- a/upgrades/side-effects/spotlight-resource-hygiene.md
+++ b/upgrades/side-effects/spotlight-resource-hygiene.md
@@ -1,0 +1,45 @@
+# Side-Effects Review - Spotlight resource hygiene (Claude transcript exclusion)
+
+**Version / slug:** `spotlight-resource-hygiene`
+**Date:** `2026-06-06`
+**Author:** `echo`
+**Second-pass reviewer:** `not required (Tier 1)`
+
+## Summary of the change
+
+Extends Instar's existing macOS Spotlight exclusion (currently covers `.worktrees/` + `node_modules/`) to the agent's Claude Code transcript directory (`~/.claude/projects/<encoded-agent-home>`). The JSONL session transcripts grow on every turn and a busy fleet box accumulates ~18 GB of them — measured as the single largest `mds_stores` (Spotlight) CPU consumer (60-90% of a core, constantly), because Spotlight re-indexes each file on every append. Adds `ensureClaudeTranscriptSpotlightExclusion()` (reuses the generic marker-dropper) + a `PostUpdateMigrator` backfill.
+
+## Decision-point inventory
+
+- `ensureClaudeTranscriptSpotlightExclusion(agentHome, claudeHome?)` (new, exported) — pure-ish: computes the encoded transcript dir, drops `.metadata_never_index` if the dir exists. Reuses `ensureWorktreeSpotlightExclusion` (the dir-agnostic dropper).
+- `PostUpdateMigrator.migrateClaudeTranscriptSpotlightExclusion` (new, private) — runs the helper on every update, pushes an `upgraded`/`errors` entry.
+- Wired into the migrate() sequence right after `migrateNodeModulesSpotlightExclusion`.
+
+## 1. Behavior change / gating
+
+NONE that affects message flow, sessions, or any gate. The only effect is writing one empty marker file into the agent's Claude transcript dir, which tells macOS Spotlight to stop indexing that subtree. No runtime behavior of the agent changes; instar's own transcript reads (TokenLedger) are unaffected (Spotlight indexing is orthogonal to file reads).
+
+## 2. Over/under-signal
+
+N/A — not a signal/gate. The only "decision" is whether the transcript dir exists (drop the marker) or not (skip). Both branches are covered.
+
+## 3. Blast radius
+
+Filesystem only, additive: writes `~/.claude/projects/<encoded>/.metadata_never_index`. This reaches OUTSIDE the agent home (into `~/.claude`), which is deliberate and bounded: (a) instar already READS that exact directory (TokenLedger/CompactionSentinel), so it is not new territory; (b) the path is scoped to THIS agent's own transcript dir via the home-path encoding, never all of `~/.claude/projects`; (c) the write is a single empty marker, idempotent, reversible. No state, no migration of data, no config. On a non-macOS host the marker is inert.
+
+## 4. Failure modes
+
+The underlying `ensureWorktreeSpotlightExclusion` swallows write errors (`@silent-fallback-ok`) and returns false — a failed marker write just means Spotlight keeps indexing (status quo), and can never block the migration or an update. `existsSync` guards the absent-dir case (brand-new agent, no sessions). The encoding is a pure string transform with no throw path.
+
+## 5. Migration parity
+
+Covered: the `PostUpdateMigrator` backfill means existing agents get the marker on their next update (the fast release cadence drops it within minutes once transcripts exist). New agents get it on their first post-session update. No agent-installed config/hooks/skills/CLAUDE.md change — this is internal OS hygiene with no agent-facing surface (consistent with the precedent: the node_modules + worktree exclusions also have no CLAUDE.md template line, as they are not capabilities the agent surfaces to a user). No init-path call is needed because the transcript dir does not exist at init time (no sessions yet) — it would no-op; the migration is the correct single mechanism.
+
+## 6. Scope honesty (what this is NOT)
+
+- This is fix 1 of 4 in the resource-efficiency initiative (Justin, 2026-06-06). It is the biggest single lever (the 18 GB transcript churn) but does NOT instantly drop `mds_stores`: the marker prevents FUTURE re-indexing; Spotlight releases already-indexed content on its own schedule, and forcing immediate eviction needs a one-time `sudo mdutil -E` the operator runs (instar cannot run sudo). The durable guarantee is that no agent keeps feeding the churn.
+- `mediaanalysisd` (macOS media/photo analysis) is a separate high-CPU process NOT addressed here and likely not Instar-triggered.
+
+## 7. Causal autopsy
+
+Origin: **latent** (not a prior-PR regression). The transcript-indexing cost has existed since Claude Code began writing JSONL transcripts; the recent node_modules/worktree exclusion PRs addressed the static trees but never extended to the constantly-churning transcript set, which grounding showed is the larger consumer. This PR closes that gap by reusing the same marker mechanism. No behavior was broken by a prior change; an existing cost was simply never excluded.


### PR DESCRIPTION
## ELI16 — macOS Spotlight was burning a whole CPU core constantly re-indexing 18 GB of Claude session transcripts (they grow with every message); this tells Spotlight to skip them, the same way Instar already skips node_modules and worktrees.

## What & why

macOS Spotlight (`mds_stores`) was a top *constant* CPU consumer (60-90% of a core) on busy fleet boxes — grounded during Justin's 2026-06-06 resource-hogging investigation. Root cause: Spotlight re-indexes Claude Code session transcripts on every turn, and a busy fleet accumulates **~18 GB** of JSONL that grows with every message.

Instar already excludes `.worktrees/` + `node_modules/` from Spotlight (`.metadata_never_index`), but never the transcripts — the larger, constantly-churning set. This extends the same exclusion to the agent's Claude transcript dir.

## Change
- `ensureClaudeTranscriptSpotlightExclusion(agentHome)` — drops the marker at `~/.claude/projects/<encoded-agent-home>`. Reuses the generic dir-agnostic marker-dropper.
- `PostUpdateMigrator.migrateClaudeTranscriptSpotlightExclusion` — backfills existing agents on update.

## Safety
Filesystem-additive only (one empty marker), idempotent, reversible, graceful no-op on failure / non-macOS / brand-new agent. instar's transcript reads (TokenLedger) are unaffected. Reaches into `~/.claude` deliberately + bounded (instar already reads that exact dir; scoped to this agent's own transcript dir).

## Causal autopsy
**latent** — not a prior-PR regression; the transcript-indexing cost predates and was never covered by the node_modules/worktree exclusions. Fix **1 of 4** in the resource-efficiency initiative.

## Scope honesty
Prevents FUTURE re-indexing. Does not instantly drop `mds_stores` — immediate eviction of already-indexed content needs a one-time operator `sudo mdutil -E ~/.claude/projects`.

## Tests
15/15 green (unit + migration). `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
