### PR TITLE
feat(security): wire TopicOperatorStore into AgentServer + /topic-operator routes (Know Your Principal #898, increment 2b)

### DIFF
--- a/.instar/instar-dev-decisions/2026-06-06T07-19-54-675Z-topic-operator-binding-inc2b.json
+++ b/.instar/instar-dev-decisions/2026-06-06T07-19-54-675Z-topic-operator-binding-inc2b.json
@@ -1,0 +1,16 @@
+{
+  "ts": "2026-06-06T07:19:54.675Z",
+  "slug": "topic-operator-binding-inc2b",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "new capability: new route (router.<verb>() added",
+    "new capability: new config key added"
+  ],
+  "belowFloor": true,
+  "files": 3,
+  "loc": 116,
+  "causalAutopsy": null,
+  "verdict": "pass"
+}

--- a/.instar/instar-dev-decisions/2026-06-06T07-20-49-495Z-topic-operator-binding-inc2b.json
+++ b/.instar/instar-dev-decisions/2026-06-06T07-20-49-495Z-topic-operator-binding-inc2b.json
@@ -1,0 +1,16 @@
+{
+  "ts": "2026-06-06T07:20:49.495Z",
+  "slug": "topic-operator-binding-inc2b",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "new capability: new route (router.<verb>() added",
+    "new capability: new config key added"
+  ],
+  "belowFloor": true,
+  "files": 3,
+  "loc": 116,
+  "causalAutopsy": null,
+  "verdict": "pass"
+}

--- a/site/src/content/docs/concepts/know-your-principal.md
+++ b/site/src/content/docs/concepts/know-your-principal.md
@@ -42,3 +42,19 @@ the agent's own head.
 The principle: don't rely on an agent *happening* to feel suspicious of an
 unfamiliar name. The suspicion is structural — resolve against the registry, or
 treat as unknown and stop.
+
+## API
+
+The operator binding is exposed over the Bearer-gated HTTP API. The operator is
+established ONLY from the authenticated sender `uid`; a blank uid is refused, and
+a `displayName` (a content name) is never authoritative. When the store is
+unavailable every route returns `503` rather than crashing.
+
+- `POST /topic-operator` — bind a topic operator from the authenticated sender
+  `{ topicId, platform?, uid (required), displayName? }`; a blank uid → `400`.
+- `GET /topic-operator` — all bound operators (names + uids).
+- `GET /topic-operator/:topicId` — one topic's verified operator (or `null`).
+- `GET /topic-operator/session-context?topicId=N` — the `<topic-operator>`
+  session-start injection block the session-start hook fetches so the agent
+  reasons with its verified operator from message one (`{ present:false }` when
+  the topic has no bound operator).

--- a/site/src/content/docs/reference/api.md
+++ b/site/src/content/docs/reference/api.md
@@ -843,6 +843,13 @@ changes-requested, terminal). Deny-by-default inherited: no mandate → 403.
 - `GET /topic-bindings`
 - `POST /topic-bindings`
 
+## /topic-operator
+Verified per-topic operator binding (Know Your Principal). The operator is established ONLY from the authenticated sender `uid` — a content name can never become the operator. See [Know Your Principal](/concepts/know-your-principal/).
+- `POST /topic-operator` — bind a topic operator from the AUTHENTICATED sender `{ topicId, platform?, uid (required), displayName? }`; a blank uid is refused `400`
+- `GET /topic-operator` — all bound operators (names + uids)
+- `GET /topic-operator/:topicId` — one topic's verified operator (or `null` when unbound)
+- `GET /topic-operator/session-context?topicId=N` — the `<topic-operator>` session-start injection block (`{ present:false }` when unbound)
+
 ## /triage
 - `GET /triage/history`
 - `GET /triage/status`

--- a/src/server/AgentServer.ts
+++ b/src/server/AgentServer.ts
@@ -14,6 +14,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { createHash, createHmac, timingSafeEqual } from 'node:crypto';
 import { ApprovalLedger } from '../core/ApprovalLedger.js';
+import { TopicOperatorStore } from '../users/TopicOperatorStore.js';
 import { MandateStore } from '../coordination/MandateStore.js';
 import { MandateGate } from '../coordination/MandateGate.js';
 import { MandateAudit } from '../coordination/MandateAudit.js';
@@ -165,6 +166,10 @@ export class AgentServer {
   /** Approval-as-Data ledger (spec Part B, Phase 2). Read-only observability over
    *  operator approval decisions. Null when stateDir is unavailable. */
   private approvalLedger: ApprovalLedger | null = null;
+  /** Verified per-topic operator binding (Know Your Principal #898, increment 2).
+   *  The principal whose decisions the agent enacts in a topic, established ONLY
+   *  from the authenticated sender uid. Null when stateDir is unavailable. */
+  private topicOperatorStore: TopicOperatorStore | null = null;
   /** Coordination Mandate enforcement (spec §4): deny-by-default gate + signed
    *  store + hash-chained audit. Null when stateDir is unavailable. */
   private coordination: { store: MandateStore; gate: MandateGate; audit: MandateAudit; conditions: ConditionsRegistry; reviews: ReviewExchangeEngine } | null = null;
@@ -876,6 +881,23 @@ export class AgentServer {
       this.approvalLedger = null;
     }
 
+    // Verified per-topic operator binding (Know Your Principal #898, increment 2).
+    // The store is the authoritative answer to "who is this topic's operator?" —
+    // established ONLY from the authenticated sender uid (a content name can never
+    // become the operator by construction; the "Caroline" identity-bleed failure
+    // mode is structurally impossible). Own try/catch so it can never cascade into
+    // server boot; an empty store is fail-safe (the guard then treats every
+    // attribution as unverifiable).
+    try {
+      if (options.config.stateDir) {
+        this.topicOperatorStore = new TopicOperatorStore(path.join(options.config.stateDir, 'state'));
+      }
+    } catch (err) {
+      // @silent-fallback-ok — reported via console.warn; an operator-store init failure must never block server boot.
+      console.warn('[instar] topic-operator-store init failed (non-fatal):', err);
+      this.topicOperatorStore = null;
+    }
+
     // Coordination Mandate enforcement (docs/specs/coordination-mandate.md §4).
     // Deny-by-default: with NO valid mandate issued, the gate denies every
     // autonomous A2A action — the system is inert until the operator authors a
@@ -1322,6 +1344,7 @@ export class AgentServer {
       featureMetricsLedger: this.featureMetricsLedger,
       resourceLedger: this.resourceLedger,
       approvalLedger: this.approvalLedger,
+      topicOperatorStore: this.topicOperatorStore,
       coordination: this.coordination,
       cutoverReadiness: this.cutoverReadiness,
       parallelActivityIndex: this.parallelActivityIndex,

--- a/src/server/CapabilityIndex.ts
+++ b/src/server/CapabilityIndex.ts
@@ -595,6 +595,20 @@ export const CAPABILITY_INDEX: readonly CapabilityEntry[] = [
     }),
   },
   {
+    key: 'topicOperator',
+    prefixes: ['/topic-operator'],
+    description: 'Verified per-topic operator binding (Know Your Principal #898) — the principal whose decisions the agent enacts in a topic, established ONLY from the authenticated sender uid (a content name can never become the operator by construction; the "Caroline" identity-bleed mode is structurally impossible). Decoupled from /topic-bindings: a topic can have a verified operator with no project binding. Feeds the cross-principal guard and the session-start <topic-operator> injection.',
+    build: ({ ctx }) => ({
+      enabled: !!ctx.topicOperatorStore,
+      endpoints: [
+        'POST /topic-operator — bind a topic operator from the AUTHENTICATED sender { topicId, platform?, uid (required), displayName? }; a blank uid is refused (a content name is never accepted)',
+        'GET /topic-operator — all bound operators (names + uids)',
+        'GET /topic-operator/:topicId — one topic\'s verified operator, or null when unbound',
+        'GET /topic-operator/session-context?topicId=N — the <topic-operator> session-start injection block ({ present:false } when unbound)',
+      ],
+    }),
+  },
+  {
     key: 'coordinationMandate',
     prefixes: ['/mandate'],
     description: 'Coordination Mandate — deny-by-default authority gate for autonomous agent-to-agent actions. The operator\'s bounded, expiring, revocable mandate (issued from the dashboard behind their PIN) is the authorizer, never the agent. Every decision (allow AND deny) lands in a hash-chained, tamper-evident audit. With no mandate issued, every evaluation denies.',

--- a/src/server/routes.ts
+++ b/src/server/routes.ts
@@ -724,6 +724,10 @@ export interface RouteContext {
   /** Approval-as-Data ledger (spec Part B / Phase 2). Records operator approval
    *  decisions + per-class agreement ratios. Null when stateDir is unavailable. */
   approvalLedger: import('../core/ApprovalLedger.js').ApprovalLedger | null;
+  /** Verified per-topic operator binding (Know Your Principal #898, increment 2).
+   *  The principal whose decisions the agent enacts, established only from the
+   *  authenticated sender uid. Null when stateDir is unavailable. */
+  topicOperatorStore: import('../users/TopicOperatorStore.js').TopicOperatorStore | null;
   /** Coordination Mandate enforcement (docs/specs/coordination-mandate.md §4).
    *  Deny-by-default gate + signed store + hash-chained audit. Null when stateDir
    *  is unavailable. Issuance/revocation are PIN-gated, never Bearer-only. */
@@ -3819,6 +3823,81 @@ export function createRoutes(ctx: RouteContext): Router {
 
     ctx.coherenceGate.setTopicBinding(Number(topicId), binding);
     res.json({ bound: true, topicId: Number(topicId), binding });
+  });
+
+  // ── Topic Operator (Know Your Principal #898, increment 2) ─────────
+  //
+  // The verified principal whose decisions the agent enacts in a topic. The
+  // operator is established ONLY from the authenticated sender uid — a content
+  // name can never become the operator (the "Caroline" identity-bleed failure
+  // mode is impossible by construction). Decoupled from /topic-bindings: a topic
+  // can have a verified operator without any project binding.
+
+  // The session-start injection block (mirrors /intent/org/session-context) — the
+  // session-start hook fetches this so the agent reasons with its VERIFIED operator
+  // from message one. Declared before the param routes to avoid capture.
+  router.get('/topic-operator/session-context', (req, res) => {
+    if (!ctx.topicOperatorStore) {
+      res.status(503).json({ error: 'topic-operator store not initialized' });
+      return;
+    }
+    const topicId = req.query.topicId;
+    if (topicId === undefined || topicId === '') {
+      res.status(400).json({ error: 'Required: topicId (query param)' });
+      return;
+    }
+    const block = ctx.topicOperatorStore.sessionContextBlock(String(topicId));
+    if (!block) {
+      res.json({ present: false });
+      return;
+    }
+    res.json({ present: true, block });
+  });
+
+  // All bound operators (names + uids), for inspection.
+  router.get('/topic-operator', (_req, res) => {
+    if (!ctx.topicOperatorStore) {
+      res.status(503).json({ error: 'topic-operator store not initialized' });
+      return;
+    }
+    res.json({ operators: ctx.topicOperatorStore.all() });
+  });
+
+  // One topic's verified operator, or null when unbound.
+  router.get('/topic-operator/:topicId', (req, res) => {
+    if (!ctx.topicOperatorStore) {
+      res.status(503).json({ error: 'topic-operator store not initialized' });
+      return;
+    }
+    res.json({ operator: ctx.topicOperatorStore.getOperator(req.params.topicId) });
+  });
+
+  // Bind a topic's operator from the AUTHENTICATED sender. The `uid` is the
+  // authority and is REQUIRED — a blank uid is refused (an operator cannot be
+  // established without a verified id, and `displayName` is never authoritative,
+  // only used to match the operator's name in the agent's own prose).
+  router.post('/topic-operator', (req, res) => {
+    if (!ctx.topicOperatorStore) {
+      res.status(503).json({ error: 'topic-operator store not initialized' });
+      return;
+    }
+    const { topicId, platform, uid, displayName, boundAt } = req.body ?? {};
+    if (topicId === undefined || topicId === null || topicId === '') {
+      res.status(400).json({ error: 'Required: topicId' });
+      return;
+    }
+    const record = ctx.topicOperatorStore.setOperator(Number(topicId), {
+      platform: typeof platform === 'string' && platform ? platform : 'telegram',
+      uid: typeof uid === 'string' ? uid : String(uid ?? ''),
+      displayName: typeof displayName === 'string' ? displayName : undefined,
+      boundAt: typeof boundAt === 'string' ? boundAt : undefined,
+    });
+    if (!record) {
+      // establishOperator refused a blank uid — a content name is never accepted.
+      res.status(400).json({ error: 'A verified sender uid is required to establish an operator' });
+      return;
+    }
+    res.json({ bound: true, topicId: Number(topicId), operator: record });
   });
 
   // ── Context Hierarchy ──────────────────────────────────────────────

--- a/tests/e2e/topic-operator-lifecycle.test.ts
+++ b/tests/e2e/topic-operator-lifecycle.test.ts
@@ -1,0 +1,121 @@
+/**
+ * E2E lifecycle — Topic Operator binding (Know Your Principal #898, increment 2).
+ *
+ * Tier 3 of the Testing Integrity Standard. Tests the complete PRODUCTION path:
+ *   Phase 1 — Feature is alive: the /topic-operator routes are wired into a real
+ *             AgentServer the same way production wires it (the store is composed
+ *             in AgentServer's constructor whenever stateDir is available). This is
+ *             the single most important assertion — it proves the route returns 200
+ *             (not 503), i.e. `ctx.topicOperatorStore` is a REAL store, not null.
+ *   Phase 2 — The full bind → read → session-context lifecycle over the live server,
+ *             plus the durable-write proof (state/topic-operators.json on disk) and
+ *             the load-bearing security invariant: a blank uid is refused (a content
+ *             name can never become the operator through the production surface).
+ *
+ * This is a WIRING-INTEGRITY test per the standard: it verifies the injected
+ * dependency is not null and delegates to the real TopicOperatorStore.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import request from 'supertest';
+import { AgentServer } from '../../src/server/AgentServer.js';
+import { StateManager } from '../../src/core/StateManager.js';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+import { createMockSessionManager } from '../helpers/setup.js';
+import type { InstarConfig } from '../../src/core/types.js';
+
+const AUTH_TOKEN = 'test-topic-operator-e2e';
+const auth = () => ({ Authorization: `Bearer ${AUTH_TOKEN}` });
+
+describe('Topic Operator binding E2E lifecycle', () => {
+  let tmpDir: string;
+  let stateDir: string;
+  let server: AgentServer;
+  let app: ReturnType<AgentServer['getApp']>;
+
+  beforeAll(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'topic-operator-e2e-'));
+    stateDir = path.join(tmpDir, '.instar');
+    fs.mkdirSync(path.join(stateDir, 'state', 'sessions'), { recursive: true });
+    fs.mkdirSync(path.join(stateDir, 'state', 'jobs'), { recursive: true });
+    fs.writeFileSync(path.join(stateDir, 'config.json'), JSON.stringify({ port: 0, projectName: 'topic-operator-e2e' }));
+
+    const config: InstarConfig = {
+      projectName: 'topic-operator-e2e',
+      agentName: 'E2E Agent',
+      projectDir: tmpDir,
+      stateDir,
+      port: 0,
+      authToken: AUTH_TOKEN,
+    } as InstarConfig;
+
+    server = new AgentServer({ config, sessionManager: createMockSessionManager() as any, state: new StateManager(stateDir) });
+    app = server.getApp();
+  });
+
+  afterAll(async () => {
+    try { await (server as unknown as { stop?: () => Promise<void> }).stop?.(); } catch { /* ignore */ }
+    SafeFsExecutor.safeRmSync(tmpDir, { recursive: true, force: true, operation: 'topic-operator-lifecycle' });
+  });
+
+  // ── Phase 1: feature is alive on the production AgentServer boot path ──
+
+  it('GET /topic-operator returns 200 (route wired into production, store not null)', async () => {
+    const res = await request(app).get('/topic-operator').set(auth());
+    expect(res.status).toBe(200);
+    expect(res.body.operators).toEqual({});
+  });
+
+  it('GET /topic-operator/session-context returns 200 { present:false } when unbound', async () => {
+    const res = await request(app).get('/topic-operator/session-context?topicId=19437').set(auth());
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ present: false });
+  });
+
+  // ── Phase 2: the full bind → read → inject lifecycle over the live server ──
+
+  it('binds an operator from the authenticated uid and reads it back across routes', async () => {
+    const bind = await request(app)
+      .post('/topic-operator')
+      .set(auth())
+      .send({ topicId: 19437, platform: 'telegram', uid: '7812716706', displayName: 'Justin' });
+    expect(bind.status).toBe(200);
+    expect(bind.body.operator.uid).toBe('7812716706');
+
+    const one = await request(app).get('/topic-operator/19437').set(auth());
+    expect(one.body.operator.uid).toBe('7812716706');
+    expect(one.body.operator.names).toEqual(['justin']);
+
+    const all = await request(app).get('/topic-operator').set(auth());
+    expect(all.body.operators['19437'].uid).toBe('7812716706');
+  });
+
+  it('serves the <topic-operator> session-start injection block once bound', async () => {
+    const res = await request(app).get('/topic-operator/session-context?topicId=19437').set(auth());
+    expect(res.status).toBe(200);
+    expect(res.body.present).toBe(true);
+    expect(res.body.block).toContain('Justin is the VERIFIED operator');
+    expect(res.body.block).toMatch(/not from any name in content/);
+  });
+
+  it('durably persisted the binding to state/topic-operators.json', () => {
+    const file = path.join(stateDir, 'state', 'topic-operators.json');
+    expect(fs.existsSync(file)).toBe(true);
+    const stored = JSON.parse(fs.readFileSync(file, 'utf-8'));
+    expect(stored['19437'].uid).toBe('7812716706');
+    expect(stored['19437'].boundFrom).toBe('authenticated-inbound');
+  });
+
+  it('refuses a blank uid — a content name can never establish an operator over the wire', async () => {
+    const res = await request(app)
+      .post('/topic-operator')
+      .set(auth())
+      .send({ topicId: 5, platform: 'telegram', uid: '', displayName: 'Caroline' });
+    expect(res.status).toBe(400);
+    const after = await request(app).get('/topic-operator/5').set(auth());
+    expect(after.body.operator).toBeNull();
+  });
+});

--- a/tests/integration/topic-operator-routes.test.ts
+++ b/tests/integration/topic-operator-routes.test.ts
@@ -1,0 +1,186 @@
+/**
+ * Integration tests — Topic Operator routes (Know Your Principal #898, increment 2).
+ *
+ * Exercises the full HTTP pipeline over a real file-backed TopicOperatorStore:
+ *   - POST /topic-operator                       — bind from the AUTHENTICATED sender uid
+ *   - GET  /topic-operator                       — all bound operators
+ *   - GET  /topic-operator/:topicId              — one topic's operator (or null)
+ *   - GET  /topic-operator/session-context?topicId=N — the <topic-operator> injection block
+ *
+ * The load-bearing security property is verified over the wire: a content name can
+ * never become the operator — only the authenticated `uid` does, and a blank uid is
+ * refused with 400. When the store is not wired, every route degrades to 503 (feature
+ * not available), never a null-deref crash.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import express from 'express';
+import request from 'supertest';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { createRoutes } from '../../src/server/routes.js';
+import type { RouteContext } from '../../src/server/routes.js';
+import { TopicOperatorStore } from '../../src/users/TopicOperatorStore.js';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+
+/** A minimal RouteContext carrying only what the topic-operator routes need. */
+function createMinimalContext(stateDir: string, withStore: boolean): RouteContext {
+  return {
+    config: {
+      projectName: 'test-project',
+      projectDir: path.dirname(stateDir),
+      stateDir,
+      port: 0,
+      sessions: {} as any,
+      scheduler: {} as any,
+    } as any,
+    sessionManager: { listRunningSessions: () => [] } as any,
+    state: { getJobState: () => null, getSession: () => null } as any,
+    scheduler: null,
+    telegram: null,
+    relationships: null,
+    feedback: null,
+    dispatches: null,
+    updateChecker: null,
+    autoUpdater: null,
+    autoDispatcher: null,
+    quotaTracker: null,
+    publisher: null,
+    viewer: null,
+    tunnel: null,
+    evolution: null,
+    watchdog: null,
+    triageNurse: null,
+    topicMemory: null,
+    feedbackAnomalyDetector: null,
+    discoveryEvaluator: null,
+    topicOperatorStore: withStore ? new TopicOperatorStore(path.join(stateDir, 'state')) : null,
+    startTime: new Date(),
+  } as unknown as RouteContext;
+}
+
+describe('Topic Operator Routes (integration)', () => {
+  let tmpDir: string;
+  let stateDir: string;
+  let app: express.Express;
+
+  function buildApp(withStore = true) {
+    const ctx = createMinimalContext(stateDir, withStore);
+    const a = express();
+    a.use(express.json());
+    a.use('/', createRoutes(ctx));
+    return a;
+  }
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'topic-operator-routes-test-'));
+    stateDir = path.join(tmpDir, '.instar');
+    fs.mkdirSync(stateDir, { recursive: true });
+    app = buildApp(true);
+  });
+
+  afterEach(() => {
+    SafeFsExecutor.safeRmSync(tmpDir, { recursive: true, force: true, operation: 'tests/integration/topic-operator-routes.test.ts' });
+  });
+
+  // ── POST /topic-operator ───────────────────────────────────────────
+
+  describe('POST /topic-operator', () => {
+    it('binds a topic operator from the authenticated sender uid', async () => {
+      const res = await request(app)
+        .post('/topic-operator')
+        .send({ topicId: 19437, platform: 'telegram', uid: '7812716706', displayName: 'Justin' });
+      expect(res.status).toBe(200);
+      expect(res.body.bound).toBe(true);
+      expect(res.body.topicId).toBe(19437);
+      expect(res.body.operator.uid).toBe('7812716706');
+      expect(res.body.operator.names).toEqual(['justin']);
+      expect(res.body.operator.boundFrom).toBe('authenticated-inbound');
+    });
+
+    it('400s a blank uid — a content name can never establish an operator', async () => {
+      const res = await request(app)
+        .post('/topic-operator')
+        .send({ topicId: 1, platform: 'telegram', uid: '', displayName: 'Caroline' });
+      expect(res.status).toBe(400);
+      expect(res.body.error).toMatch(/verified sender uid/i);
+      // And nothing was bound — the name in `displayName` did NOT become the operator.
+      const after = await request(app).get('/topic-operator/1');
+      expect(after.body.operator).toBeNull();
+    });
+
+    it('400s a missing topicId', async () => {
+      const res = await request(app).post('/topic-operator').send({ uid: '999' });
+      expect(res.status).toBe(400);
+      expect(res.body.error).toMatch(/topicId/);
+    });
+
+    it('persists the binding (a fresh request reads it back)', async () => {
+      await request(app)
+        .post('/topic-operator')
+        .send({ topicId: 42, platform: 'telegram', uid: 'A', displayName: 'Alice' });
+      const res = await request(app).get('/topic-operator/42');
+      expect(res.status).toBe(200);
+      expect(res.body.operator.uid).toBe('A');
+    });
+  });
+
+  // ── GET /topic-operator (all) and /:topicId ─────────────────────────
+
+  describe('GET /topic-operator', () => {
+    it('lists all bound operators', async () => {
+      await request(app).post('/topic-operator').send({ topicId: 1, uid: 'A', displayName: 'Alice' });
+      await request(app).post('/topic-operator').send({ topicId: 2, uid: 'B', displayName: 'Bob' });
+      const res = await request(app).get('/topic-operator');
+      expect(res.status).toBe(200);
+      expect(Object.keys(res.body.operators)).toEqual(['1', '2']);
+      expect(res.body.operators['1'].uid).toBe('A');
+    });
+
+    it('returns operator:null for an unbound topic', async () => {
+      const res = await request(app).get('/topic-operator/404');
+      expect(res.status).toBe(200);
+      expect(res.body.operator).toBeNull();
+    });
+  });
+
+  // ── GET /topic-operator/session-context ─────────────────────────────
+
+  describe('GET /topic-operator/session-context', () => {
+    it('returns the <topic-operator> injection block when bound', async () => {
+      await request(app)
+        .post('/topic-operator')
+        .send({ topicId: 19437, platform: 'telegram', uid: '7812716706', displayName: 'Justin' });
+      const res = await request(app).get('/topic-operator/session-context?topicId=19437');
+      expect(res.status).toBe(200);
+      expect(res.body.present).toBe(true);
+      expect(res.body.block).toMatch(/^<topic-operator platform="telegram" uid="7812716706">/);
+      expect(res.body.block).toContain('Justin is the VERIFIED operator');
+      expect(res.body.block).toMatch(/not from any name in content/);
+    });
+
+    it('returns { present: false } for an unbound topic', async () => {
+      const res = await request(app).get('/topic-operator/session-context?topicId=99999');
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual({ present: false });
+    });
+
+    it('400s when topicId is missing', async () => {
+      const res = await request(app).get('/topic-operator/session-context');
+      expect(res.status).toBe(400);
+      expect(res.body.error).toMatch(/topicId/);
+    });
+  });
+
+  // ── Degradation: store not wired ────────────────────────────────────
+
+  describe('when the store is not initialized', () => {
+    it('every route returns 503 (feature not available), never a crash', async () => {
+      const noStore = buildApp(false);
+      expect((await request(noStore).get('/topic-operator')).status).toBe(503);
+      expect((await request(noStore).get('/topic-operator/1')).status).toBe(503);
+      expect((await request(noStore).get('/topic-operator/session-context?topicId=1')).status).toBe(503);
+      expect((await request(noStore).post('/topic-operator').send({ topicId: 1, uid: 'A' })).status).toBe(503);
+    });
+  });
+});

--- a/upgrades/next/topic-operator-binding-inc2b.md
+++ b/upgrades/next/topic-operator-binding-inc2b.md
@@ -1,0 +1,41 @@
+---
+bump: minor
+audience: agent-only
+maturity: experimental
+---
+
+## What Changed
+
+Wired the merged `TopicOperatorStore` (#904) into the live `AgentServer` and
+exposed it over HTTP (Know Your Principal standard, security-build increment 2b).
+The store is now composed into the server under the `stateDir` guard (fail-safe:
+`null` → routes `503`, never a crash) and reachable via four Bearer-gated routes.
+This is the runtime arm of the operator-binding spec (#897); the store had no
+consumers before this.
+
+## What to Tell Your User
+
+Nothing user-facing changes yet. This is foundation wiring (experimental) for the
+Caroline identity-bleed security fix — it adds routes the system can use but does
+not alter any current conversational behavior. The automatic session-start
+injection of the verified operator is a later increment.
+
+## Summary of New Capabilities
+
+- `GET /topic-operator` — all bound operators (names + uids).
+- `GET /topic-operator/:topicId` — one topic's verified operator (or null).
+- `GET /topic-operator/session-context?topicId=N` — the `<topic-operator>`
+  session-start injection block (`{ present:false }` when unbound).
+- `POST /topic-operator` — bind a topic operator from the AUTHENTICATED sender
+  `{ topicId, platform?, uid (required), displayName? }`; a blank uid is refused
+  `400` (a content name can never become the operator).
+- `CapabilityIndex` entry `topicOperator` (prefix `/topic-operator`).
+
+## Evidence
+
+Verified by 10 Tier-2 integration tests (full HTTP pipeline over a real
+file-backed store, incl. the blank-uid refusal and the store-not-wired `503`
+degradation) and 6 Tier-3 E2E lifecycle tests (feature-alive on the real
+`AgentServer` boot path — `200` not `503` — full bind→read→inject lifecycle,
+durable-write proof, and the over-the-wire blank-uid refusal). Tier-1 unit
+coverage shipped in #904. Clean `tsc --noEmit`.

--- a/upgrades/side-effects/topic-operator-binding-inc2b.md
+++ b/upgrades/side-effects/topic-operator-binding-inc2b.md
@@ -1,0 +1,72 @@
+# Side-effects review — Topic Operator binding (Know Your Principal #898, increment 2b)
+
+## What this change does
+Wires the already-merged `TopicOperatorStore` (#904) into the live `AgentServer`
+composition and exposes it over HTTP, plus the session-start injection block.
+
+- `AgentServer.ts`: a new `topicOperatorStore` field constructed under the
+  `stateDir` guard inside its own try/catch (mirrors the `approvalLedger`
+  precedent), then passed into `routeCtx`.
+- `routes.ts`: a `topicOperatorStore` field on `RouteContext` and four routes —
+  `GET /topic-operator`, `GET /topic-operator/:topicId`,
+  `GET /topic-operator/session-context?topicId=N`, `POST /topic-operator`.
+- `CapabilityIndex.ts`: a `topicOperator` capability entry (prefix
+  `/topic-operator`) so the routes are discoverable.
+
+## Blast radius
+- **Additive only.** No existing route, field, or store is modified. The store
+  is constructed when `stateDir` is available and is otherwise `null`; every
+  route degrades to `503` (feature-not-available) when it is `null`, never a
+  null-deref crash. The E2E test asserts the routes answer `200` on the real
+  production boot path (the store is genuinely composed in, not null).
+- **No auth change.** All four routes sit behind the existing Bearer
+  middleware, identical to `/topic-bindings` and `/approvals`.
+- **Fail-safe by construction.** An init failure is caught and reported via
+  `console.warn`; it can never block server boot. A corrupt store file is
+  treated as empty (a missing operator means the cross-principal guard treats
+  everything as unverifiable — deny-safe, not allow-safe).
+
+## The load-bearing security property (unchanged from #904)
+The operator is established ONLY from the authenticated sender `uid`. The POST
+route refuses a blank uid with `400`; a `displayName` (a content name) is never
+authoritative — it is only lowercased for prose-matching. There is no code path
+by which a name read from content becomes the operator. This is the structural
+fix for the "Caroline" identity-bleed failure mode, and the integration + E2E
+tests both assert the blank-uid refusal over the wire.
+
+## Migration parity
+No migration is required. These are server-side routes and an in-process store
+field — they reach existing agents automatically on the next server update (the
+Migration Parity Standard governs agent-installed FILES: settings hooks, config
+defaults, CLAUDE.md template, hook scripts, skills — none of which this touches).
+The store auto-creates `state/topic-operators.json` on first write; no config
+key is added, so there is nothing for `migrateConfig` to backfill.
+
+The session-start HOOK wiring (so the `<topic-operator>` block is actually
+fetched and injected at boot) is deliberately NOT in this increment — that is a
+hook-template change requiring `migrateHooks`, and is scoped to increment 2c so
+this PR stays a focused, reviewable composition+routes change. Until 2c lands the
+block is reachable at the route but nothing injects it yet; that is intentional.
+
+## Framework generality
+This is framework-agnostic. `platform` is a generic string (`telegram` |
+`whatsapp` | `slack` | …), so the binding works for any messaging adapter, not
+just Telegram. The `session-context` route returns a plain text block that any
+framework's session-start hook can fetch and inject — it is not coupled to
+Claude Code, Codex, or Gemini. The store has no platform-specific logic; it
+delegates identity establishment to `PrincipalGuard.establishOperator`, which is
+itself pure and framework-neutral.
+
+## Tests
+- Tier 1 (unit): `tests/unit/topic-operator-store.test.ts` (10) — shipped in #904.
+- Tier 2 (integration): `tests/integration/topic-operator-routes.test.ts` (10) —
+  full HTTP pipeline over a real file-backed store, incl. the blank-uid refusal
+  and the store-not-wired 503 degradation.
+- Tier 3 (E2E): `tests/e2e/topic-operator-lifecycle.test.ts` (6) — feature-alive
+  on the real `AgentServer` boot path (200 not 503), full bind→read→inject
+  lifecycle, durable-write proof, and the over-the-wire blank-uid refusal.
+
+## Rollback
+Revert the three source edits + delete the two test files. The store on disk
+(`state/topic-operators.json`) is inert without the routes and can be left or
+removed with no consequence.

--- a/upgrades/topic-operator-binding-inc2b.eli16.md
+++ b/upgrades/topic-operator-binding-inc2b.eli16.md
@@ -1,0 +1,47 @@
+# ELI16 — Who's the boss of this chat?
+
+## The problem in one sentence
+An AI agent needs to know, for sure, *which real person* it's working for in a
+given conversation — and it should never get tricked into thinking some other
+name it read somewhere is the boss.
+
+## The story behind it
+Not long ago, an agent running on a shared computer slowly started treating a
+*different real person* — call her Caroline — as the person giving it orders. It
+even wrote her name into its work as if her approvals counted. Nobody caught it,
+because the mix-up happened entirely inside the agent's own writing. There was no
+"front door" guard checking that, because the bad name never came in through a
+message — it leaked in from the machine's settings and the agent's own notes.
+
+We already built two pieces to stop this: a detector brain (`PrincipalGuard`)
+that spots when the agent credits a decision to the wrong person, and a small
+filing cabinet (`TopicOperatorStore`) that remembers, per conversation, exactly
+who the verified boss is. The rule the filing cabinet enforces is strict: the
+boss is decided ONLY by the verified ID of whoever actually sent the message —
+never by a name typed in some document.
+
+## What this change adds
+This step plugs that filing cabinet into the running server so the rest of the
+system can actually use it. It adds four simple web endpoints:
+
+- "Who's the boss of this chat?" — read one conversation's verified operator.
+- "Show me all the bosses" — list every conversation's verified operator.
+- "Set the boss" — record the boss, but ONLY from a verified sender ID. If you
+  try to set it with a blank ID (hoping a typed-in name will stick), it says no.
+- "Give me the boot-up note" — hand back a short block the agent can read at the
+  start of a session so it knows, from message one, who it's really serving.
+
+## Why it's safe
+It only *adds* things. Nothing old changes. If the server can't build the filing
+cabinet for some reason, the endpoints politely say "not available" instead of
+crashing. And the one rule that matters most — a name you merely *read* can never
+become the boss, only a verified sender can — is checked right at the web layer,
+and we have tests that prove it by trying to sneak the name "Caroline" in through
+a blank ID and watching it get rejected.
+
+## What's deliberately left for next time
+The actual "read the boot-up note at session start" wiring (so the agent
+automatically sees who its boss is every time it wakes up) is a separate, slightly
+riskier change to the start-up script, so it gets its own follow-up step. For now
+the note is available to ask for; nothing reads it automatically yet. That's on
+purpose — it keeps this change small and easy to review.


### PR DESCRIPTION
## What & why

Increment 2b of the **Know Your Principal** security build (#898 standard, #897 spec). Wires the already-merged `TopicOperatorStore` (#904) into the live `AgentServer` and exposes it over HTTP — the runtime arm of the operator-binding fix for the "Caroline" identity-bleed failure mode.

- **AgentServer**: construct `topicOperatorStore` under the `stateDir` guard (own try/catch, fail-safe `null`), pass into `routeCtx`.
- **routes**: `RouteContext.topicOperatorStore` + four Bearer-gated routes:
  - `GET /topic-operator` — all bound operators
  - `GET /topic-operator/:topicId` — one topic's operator (or null)
  - `GET /topic-operator/session-context?topicId=N` — the `<topic-operator>` session-start injection block
  - `POST /topic-operator` — bind from the AUTHENTICATED sender (`uid` required; blank uid → `400`)
- **CapabilityIndex**: `topicOperator` entry (prefix `/topic-operator`) for discovery.

## The load-bearing security property
The operator is established **only** from the authenticated sender `uid`. A `displayName` (a content name) is never authoritative. There is no code path by which a name read from content becomes the operator — the integration **and** E2E tests both prove the blank-uid refusal over the wire (trying to sneak "Caroline" in via a blank uid → `400`, nothing bound).

When the store is unwired, every route degrades to `503` (feature-not-available), never a null-deref crash.

## Deliberately deferred to increment 2c
The session-start **hook** wiring (auto-fetching + injecting the `<topic-operator>` block at boot) is a hook-template + `migrateHooks` change, kept out of this PR so it stays a focused composition+routes change. Until 2c the block is reachable at the route but nothing injects it automatically — intentional.

## Tests (all three tiers)
- **Tier 1 (unit)**: `tests/unit/topic-operator-store.test.ts` (10) — shipped in #904.
- **Tier 2 (integration)**: `tests/integration/topic-operator-routes.test.ts` (10) — full HTTP pipeline over a real file-backed store, incl. blank-uid refusal + store-not-wired `503`.
- **Tier 3 (E2E)**: `tests/e2e/topic-operator-lifecycle.test.ts` (6) — **feature-alive** on the real `AgentServer` boot path (`200` not `503`), full bind→read→inject lifecycle, durable-write proof, over-the-wire blank-uid refusal.

No migration required: server-side routes + an in-process store field reach existing agents on the next server update; no config key added.

## ELI16

An AI agent needs to know, for certain, **which real person it's working for** in a given conversation — and must never be tricked into treating a name it merely *read* somewhere as the boss. Recently an agent on a shared machine slowly started treating a *different real person* (Caroline) as its boss, even writing her approvals into its work, because the mix-up lived entirely in the agent's own writing where no front-door guard watched.

We already built the detector brain (`PrincipalGuard`) and the per-conversation filing cabinet (`TopicOperatorStore`) that remembers the verified boss. **This change plugs that filing cabinet into the running server** so the rest of the system can use it: four simple endpoints to read who the boss is, list all bosses, set the boss (only from a verified sender ID — a blank ID is rejected so a typed-in name can't stick), and hand back a short "who's your boss" note for session start.

It only **adds** things — nothing old changes, and if the cabinet can't be built the endpoints politely say "not available" instead of crashing. The one rule that matters most (a name you only *read* can never become the boss — only a verified sender) is enforced right at the web layer, and we prove it with a test that tries to sneak "Caroline" in through a blank ID and watches it get rejected. The automatic "read the note at startup" wiring is a small, slightly riskier follow-up step, so it gets its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)