### PR TITLE
feat(security): inject the verified <topic-operator> block at session start (Know Your Principal #898, increment 2c)

### DIFF
--- a/.instar/instar-dev-decisions/2026-06-06T07-57-38-244Z-topic-operator-hook-injection-inc2c.json
+++ b/.instar/instar-dev-decisions/2026-06-06T07-57-38-244Z-topic-operator-hook-injection-inc2c.json
@@ -1,0 +1,17 @@
+{
+  "ts": "2026-06-06T07:57:38.244Z",
+  "slug": "topic-operator-hook-injection-inc2c",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "irreversibility: src/core/PostUpdateMigrator.ts touches PostUpdateMigrator",
+    "migration / fleet-rollout surface: src/core/PostUpdateMigrator.ts touches PostUpdateMigrator (fleet migration machinery)",
+    "new capability: new config key added"
+  ],
+  "belowFloor": true,
+  "files": 1,
+  "loc": 36,
+  "causalAutopsy": null,
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-06-06T07-58-11-056Z-topic-operator-hook-injection-inc2c.json
+++ b/.instar/instar-dev-decisions/2026-06-06T07-58-11-056Z-topic-operator-hook-injection-inc2c.json
@@ -1,0 +1,17 @@
+{
+  "ts": "2026-06-06T07:58:11.056Z",
+  "slug": "topic-operator-hook-injection-inc2c",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "irreversibility: src/core/PostUpdateMigrator.ts touches PostUpdateMigrator",
+    "migration / fleet-rollout surface: src/core/PostUpdateMigrator.ts touches PostUpdateMigrator (fleet migration machinery)",
+    "new capability: new config key added"
+  ],
+  "belowFloor": true,
+  "files": 1,
+  "loc": 66,
+  "causalAutopsy": null,
+  "verdict": "pass"
+}

--- a/src/core/PostUpdateMigrator.ts
+++ b/src/core/PostUpdateMigrator.ts
@@ -6448,6 +6448,36 @@ except Exception:
   fi
 fi
 
+# TOPIC OPERATOR injection — Know Your Principal (#898, increment 2c). Fetches the
+# VERIFIED operator binding for THIS topic from /topic-operator/session-context and
+# injects the <topic-operator> block so the agent reasons with its authenticated
+# operator from message one — and never seats a name read in content in the
+# operator's chair (the "Caroline" identity-bleed fix). The operator is established
+# ONLY from the platform-verified sender id; this is the read surface. Placed with
+# the authoritative-identity context (org-intent + preferences) up front. Fail-open:
+# no topic / route 503 (store unavailable) / unbound topic / unreachable -> silent
+# skip; curl -sf makes a non-2xx emit nothing, and the Bearer token stays in the header.
+if [ -n "\$INSTAR_TELEGRAM_TOPIC" ] && [ -n "\$PORT" ] && [ -n "\$TOKEN" ]; then
+  TOPIC_OP_RESPONSE=\$(curl -sf --max-time 4 -H "Authorization: Bearer \$TOKEN" \\
+    "http://localhost:\${PORT}/topic-operator/session-context?topicId=\${INSTAR_TELEGRAM_TOPIC}" 2>/dev/null)
+  if [ -n "\$TOPIC_OP_RESPONSE" ]; then
+    TOPIC_OP_BLOCK=\$(echo "\$TOPIC_OP_RESPONSE" | python3 -c "
+import sys, json
+try:
+    d = json.load(sys.stdin)
+    if d.get('present') and d.get('block'):
+        print(d['block'])
+except Exception:
+    pass
+" 2>/dev/null)
+    if [ -n "\$TOPIC_OP_BLOCK" ]; then
+      echo ""
+      echo "\$TOPIC_OP_BLOCK"
+      echo ""
+    fi
+  fi
+fi
+
 # SESSION BOOT SELF-KNOWLEDGE injection (spec: session-boot-self-knowledge.md).
 # Fetches /self-knowledge/session-context and injects the deterministic "what I
 # already have" block: vault secret NAMES (never values) + self-asserted
@@ -7565,6 +7595,42 @@ except Exception:
       if [ -n "\$BOOT_SK_BLOCK" ]; then
         echo ""
         echo "\$BOOT_SK_BLOCK"
+        echo ""
+      fi
+    fi
+  fi
+fi
+
+# TOPIC OPERATOR re-injection (Know Your Principal #898, increment 2c — Compaction
+# Parity twin of the session-start block). The verified operator binding injected at
+# session start only survives a compaction if the summary happens to carry it —
+# willpower, not structure. Re-fetching here makes the agent re-learn WHO its
+# verified operator is after a context reset; losing that awareness post-compaction
+# is exactly the identity gap this feature closes. Same fail-open contract as the
+# boot fetch: no topic / unbound / store-503 / unreachable -> silent skip,
+# header-only Bearer.
+if [ -n "\$INSTAR_TELEGRAM_TOPIC" ] && [ -f "$INSTAR_DIR/config.json" ]; then
+  TOPIC_OP_PORT=\${PORT:-\$(grep -oE '"port"[[:space:]]*:[[:space:]]*[0-9]+' "$INSTAR_DIR/config.json" | head -1 | grep -oE '[0-9]+' | head -1)}
+  TOPIC_OP_TOKEN="\${INSTAR_AUTH_TOKEN:-}"
+  if [ -z "\$TOPIC_OP_TOKEN" ]; then
+    TOPIC_OP_TOKEN=\$(python3 -c "import json; v=json.load(open('$INSTAR_DIR/config.json')).get('authToken',''); print(v if isinstance(v, str) else '')" 2>/dev/null)
+  fi
+  if [ -n "\$TOPIC_OP_PORT" ] && [ -n "\$TOPIC_OP_TOKEN" ]; then
+    TOPIC_OP_RESPONSE=\$(curl -sf --max-time 4 --connect-timeout 1 -H "Authorization: Bearer \$TOPIC_OP_TOKEN" \\
+      "http://localhost:\${TOPIC_OP_PORT}/topic-operator/session-context?topicId=\${INSTAR_TELEGRAM_TOPIC}" 2>/dev/null)
+    if [ -n "\$TOPIC_OP_RESPONSE" ]; then
+      TOPIC_OP_BLOCK=\$(echo "\$TOPIC_OP_RESPONSE" | python3 -c "
+import sys, json
+try:
+    d = json.load(sys.stdin)
+    if d.get('present') and d.get('block'):
+        print(d['block'])
+except Exception:
+    pass
+" 2>/dev/null)
+      if [ -n "\$TOPIC_OP_BLOCK" ]; then
+        echo ""
+        echo "\$TOPIC_OP_BLOCK"
         echo ""
       fi
     fi

--- a/tests/e2e/topic-operator-hook-injection-lifecycle.test.ts
+++ b/tests/e2e/topic-operator-hook-injection-lifecycle.test.ts
@@ -1,0 +1,127 @@
+/**
+ * E2E lifecycle — Topic Operator session-start injection (Know Your Principal
+ * #898, increment 2c). Tier 3 of the Testing Integrity Standard.
+ *
+ * Phase 1 — the generated session-start hook SOURCE wires the
+ *   /topic-operator/session-context fetch (so a refactor that drops it is caught).
+ * Phase 2 — the EXACT bash + python the production hook runs for this feature is
+ *   extracted verbatim from the generated hook and executed against a LIVE server:
+ *     • bound topic    → emits the <topic-operator> block (the agent sees its
+ *                        VERIFIED operator at boot).
+ *     • unbound topic  → emits nothing (fail-open, no false identity).
+ *
+ * This mirrors the preferences-session-context-lifecycle Phase-2 precedent: the
+ * full hook also exercises unrelated subsystems, so we run JUST this feature's
+ * block against a real server (async exec so the in-process Express event loop
+ * stays free to answer the curl).
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import http from 'node:http';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import express from 'express';
+import { PostUpdateMigrator } from '../../src/core/PostUpdateMigrator.js';
+import { createRoutes } from '../../src/server/routes.js';
+import { authMiddleware } from '../../src/server/middleware.js';
+import type { RouteContext } from '../../src/server/routes.js';
+import { TopicOperatorStore } from '../../src/users/TopicOperatorStore.js';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+
+const execFileAsync = promisify(execFile);
+const AUTH_TOKEN = 'test-topic-op-hook-e2e';
+
+describe('Topic Operator session-start hook injection E2E', () => {
+  let tmpDir: string;
+  let stateDir: string;
+  let server: http.Server;
+  let port: number;
+  let opStore: TopicOperatorStore;
+
+  function makeCtx(): RouteContext {
+    opStore = new TopicOperatorStore(path.join(stateDir, 'state'));
+    return {
+      config: {
+        projectName: 'topic-op-hook-e2e', projectDir: tmpDir, stateDir, port,
+        authToken: AUTH_TOKEN, sessions: {} as any, scheduler: {} as any,
+      } as any,
+      sessionManager: { listRunningSessions: () => [] } as any,
+      state: { getJobState: () => null, getSession: () => null } as any,
+      scheduler: null, telegram: null, relationships: null, feedback: null,
+      dispatches: null, updateChecker: null, autoUpdater: null, autoDispatcher: null,
+      quotaTracker: null, publisher: null, viewer: null, tunnel: null, evolution: null,
+      watchdog: null, triageNurse: null, topicMemory: null, feedbackAnomalyDetector: null,
+      discoveryEvaluator: null, topicOperatorStore: opStore, startTime: new Date(),
+    } as unknown as RouteContext;
+  }
+
+  async function startServer(): Promise<void> {
+    const appx = express();
+    appx.use(express.json());
+    appx.use(authMiddleware(AUTH_TOKEN));
+    appx.use('/', createRoutes(makeCtx()));
+    await new Promise<void>((resolve) => {
+      server = appx.listen(0, () => { port = (server.address() as { port: number }).port; resolve(); });
+    });
+  }
+
+  async function stopServer(): Promise<void> {
+    if (server) await new Promise<void>((resolve) => server.close(() => resolve()));
+  }
+
+  /** Extract the topic-operator injection block from the generated hook source. */
+  function extractBlock(): string {
+    const migrator = new PostUpdateMigrator({ projectDir: tmpDir, stateDir, port, authToken: AUTH_TOKEN, agentName: 'topic-op-hook-e2e' });
+    const src = migrator.getHookContent('session-start');
+    const start = src.indexOf('# TOPIC OPERATOR injection');
+    expect(start).toBeGreaterThanOrEqual(0);
+    const after = src.indexOf('# SESSION BOOT SELF-KNOWLEDGE injection', start);
+    expect(after).toBeGreaterThan(start);
+    return src.slice(start, after);
+  }
+
+  async function runBlock(topicId: number): Promise<string> {
+    const block = extractBlock();
+    const script = `#!/bin/bash\nPORT=${port}\nTOKEN="${AUTH_TOKEN}"\nINSTAR_TELEGRAM_TOPIC=${topicId}\n${block}`;
+    const scriptPath = path.join(tmpDir, `topic-op-block-${topicId}.sh`);
+    fs.writeFileSync(scriptPath, script, { mode: 0o755 });
+    const { stdout } = await execFileAsync('bash', [scriptPath], { encoding: 'utf-8' });
+    return stdout;
+  }
+
+  beforeAll(async () => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'topic-op-hook-e2e-'));
+    stateDir = path.join(tmpDir, '.instar');
+    fs.mkdirSync(stateDir, { recursive: true });
+    await startServer();
+  });
+
+  afterAll(async () => {
+    await stopServer();
+    SafeFsExecutor.safeRmSync(tmpDir, { recursive: true, force: true, operation: 'topic-operator-hook-injection-lifecycle' });
+  });
+
+  it('Phase 1 — the generated hook source wires the /topic-operator/session-context fetch', () => {
+    const migrator = new PostUpdateMigrator({ projectDir: tmpDir, stateDir, port: 0, authToken: AUTH_TOKEN, agentName: 'x' });
+    const src = migrator.getHookContent('session-start');
+    expect(src).toContain('/topic-operator/session-context');
+    expect(src).toContain('TOPIC_OP_BLOCK');
+    expect(src).toContain('topicId=${INSTAR_TELEGRAM_TOPIC}');
+  });
+
+  it('Phase 2 — emits the <topic-operator> block when the topic has a VERIFIED operator', async () => {
+    opStore.setOperator(19437, { platform: 'telegram', uid: '7812716706', displayName: 'Justin' });
+    const out = await runBlock(19437);
+    expect(out).toContain('<topic-operator');
+    expect(out).toContain('Justin is the VERIFIED operator');
+    expect(out).toContain('not from any name in content');
+  });
+
+  it('Phase 2 — emits NOTHING for an unbound topic (fail-open, no false identity)', async () => {
+    const out = await runBlock(99999);
+    expect(out).not.toContain('<topic-operator');
+    expect(out.trim()).toBe('');
+  });
+});

--- a/upgrades/next/topic-operator-hook-injection-inc2c.md
+++ b/upgrades/next/topic-operator-hook-injection-inc2c.md
@@ -1,0 +1,39 @@
+---
+bump: minor
+audience: agent-only
+maturity: experimental
+---
+
+## What Changed
+
+The `session-start` hook now injects the verified `<topic-operator>` block at
+session boot (Know Your Principal standard, security-build increment 2c). It
+fetches `/topic-operator/session-context?topicId=$INSTAR_TELEGRAM_TOPIC` (the route
+shipped in #906) and, when the topic has a verified operator, hands the agent a
+short block naming that operator — so the agent reasons with its authenticated
+principal from message one. This is the READ side of the operator binding; it
+cannot itself seat anyone (the store established the operator only from the
+platform-verified sender).
+
+## What to Tell Your User
+
+Nothing user-facing changes. Foundation wiring (experimental) for the Caroline
+identity-bleed security fix: the agent now SEES its verified operator at session
+start when one is bound, but no conversational behavior changes and nothing is
+gated. Auto-binding on inbound and the cross-principal guard are later increments.
+
+## Summary of New Capabilities
+
+- Session-start injection of the `<topic-operator>` block (fail-open: no topic /
+  unbound topic / store unavailable → nothing injected). Reaches existing agents
+  automatically — the `instar/` session-start hook is rewritten on every update.
+
+## Evidence
+
+Verified by 3 Tier-3 E2E lifecycle tests
+(`tests/e2e/topic-operator-hook-injection-lifecycle.test.ts`): Phase 1 asserts the
+generated hook source wires the fetch; Phase 2 extracts the exact block and runs
+it against a live server, proving it emits the `<topic-operator>` block when a
+topic is bound and nothing when unbound. The analog hook suites
+(PostUpdateMigrator-bootSelfKnowledge, migration-parity-hooks,
+OrgIntentManager-session-start-format) stay green. Clean `tsc --noEmit`.

--- a/upgrades/side-effects/topic-operator-hook-injection-inc2c.md
+++ b/upgrades/side-effects/topic-operator-hook-injection-inc2c.md
@@ -1,0 +1,79 @@
+# Side-effects review — Topic Operator session-start injection (Know Your Principal #898, increment 2c)
+
+## What this change does
+Adds one fetch-block to the generated `session-start` hook
+(`PostUpdateMigrator.getHookContent('session-start')`) that injects the
+`<topic-operator>` block at session boot — the READ side of the operator binding
+shipped in #904 (store) and #906 (routes). When a topic has a verified operator,
+the agent now reasons with it from message one.
+
+## Blast radius
+- **One template string edit, additive.** The block is appended after the
+  existing ORG-INTENT and AUTO-LEARNED-PREFERENCES injection blocks and before the
+  SESSION-BOOT-SELF-KNOWLEDGE block — modeled byte-for-byte on those two
+  precedents (same `curl -sf --max-time 4` + `python3` present/block parse + echo).
+- **Fail-open, three guards.** The block only runs when `$INSTAR_TELEGRAM_TOPIC`
+  AND `$PORT` AND `$TOKEN` are all set. `curl -sf` emits nothing on any non-2xx
+  (route 503 when the store is unavailable, or `{present:false}` for an unbound
+  topic), so an unbound topic or an old server injects nothing — the session
+  continues normally. A non-Telegram session (no topic env) skips entirely.
+- **No new route, class, config key, or dependency.** It consumes the
+  `/topic-operator/session-context` route that already shipped in #906.
+- **Bearer token stays in the header** (never the URL/query), matching the other
+  injection blocks.
+
+## The security property
+The injected block names the operator established ONLY from the platform-verified
+sender id (the store guarantees this by construction — #904). The hook merely
+surfaces that verified binding; it cannot itself seat anyone. So this read-side
+change cannot introduce a Caroline-class identity bleed — it can only make the
+ALREADY-verified operator visible to the agent at boot.
+
+## Compaction parity (constitutional)
+The same fetch is ALSO wired into `getCompactionRecovery()` — its compaction twin —
+so the verified operator is re-injected after a context reset, not presumed to
+survive in the compaction summary (the `session-context-compaction-parity` standard
+from PR #811, enforced by `tests/unit/session-context-compaction-parity.test.ts`).
+This is thematically load-bearing for Know Your Principal: an agent that loses its
+verified-operator awareness post-compaction is exactly the identity gap this feature
+closes. The twin block mirrors the SESSION-BOOT-SELF-KNOWLEDGE re-injection
+precedent (own `TOPIC_OP_PORT`/`TOPIC_OP_TOKEN` resolution, same fail-open contract),
+and the injector is NOT added to the parity allowlist (the allowlist only shrinks).
+
+## Migration parity
+The `session-start` hook lives in the always-overwritten `instar/` hook set:
+`migrateHooks()` rewrites `hooks/instar/session-start.sh` from
+`getSessionStartHook()` on EVERY update run (PostUpdateMigrator.ts:1958). So this
+block reaches existing agents automatically on their next update — no dedicated
+migration needed, and the migration-parity-hooks unit suite stays green.
+
+## Agent awareness (deliberately deferred)
+No CLAUDE.md template section is added in this increment. The injected
+`<topic-operator>` block is self-describing (it carries its own "do not attribute
+to any other name" instruction), and the governing behavior is already in the
+ratified #898 "Know Your Principal" constitution standard. The operator-binding
+feature's agent-awareness capability section will be added ONCE, as a coherent
+whole, when the feature is end-to-end (after the Inc-2d inbound auto-bind and the
+Inc-3 guard) — rather than fragmenting it across increments. The feature-delivery
+and docs-coverage gates pass without it.
+
+## Framework generality
+Framework-agnostic. The block is emitted into the generic session-start hook that
+every framework's session runs; the `<topic-operator>` payload is plain text any
+harness injects. The topic is resolved from `$INSTAR_TELEGRAM_TOPIC`, the same env
+the existing topic-context block uses — not coupled to Claude Code, Codex, or
+Gemini.
+
+## Tests
+- Tier 3 (E2E): `tests/e2e/topic-operator-hook-injection-lifecycle.test.ts` (3) —
+  Phase 1 asserts the generated hook SOURCE wires the fetch; Phase 2 extracts the
+  exact block and runs it against a LIVE server, proving it emits the
+  `<topic-operator>` block when a topic is bound and nothing when unbound.
+- Tier 1/2 for the store + route shipped in #904/#906; the analog hook suites
+  (PostUpdateMigrator-bootSelfKnowledge, migration-parity-hooks,
+  OrgIntentManager-session-start-format) stay green.
+
+## Rollback
+Revert the single template-string block in PostUpdateMigrator.ts + delete the E2E
+test. The next update rewrites the hook without the block; nothing else depends
+on it.

--- a/upgrades/topic-operator-hook-injection-inc2c.eli16.md
+++ b/upgrades/topic-operator-hook-injection-inc2c.eli16.md
@@ -1,0 +1,47 @@
+# ELI16 — Telling the agent who its boss is, the moment it wakes up
+
+## The one-sentence version
+When the agent starts a conversation, it now gets handed a little note that says
+"the verified boss of this chat is X" — so it knows from the very first message
+who it's working for, instead of guessing from names it reads later.
+
+## The backstory
+We've been fixing a real problem: an agent on a shared computer slowly started
+treating a *different real person* (call her Caroline) as its boss, because the
+mix-up lived inside the agent's own writing where nothing was watching. To fix it
+we built three pieces:
+
+1. A filing cabinet (`TopicOperatorStore`) that remembers, per conversation, who
+   the verified boss is — and the rule is strict: the boss is decided ONLY by the
+   verified ID of whoever actually sent the message, never by a name typed in a
+   document.
+2. Four web endpoints to read and set that binding (shipped last step).
+3. **This step:** actually handing the agent that "who's your boss" note at the
+   start of every conversation.
+
+## What this change adds
+At session start, the agent already gets handed a few notes — the company's rules,
+the preferences it has learned about you, and so on. This change adds one more
+note to that pile: it quietly asks the server "who's the verified boss of this
+chat?" and, if there's an answer, prints a short block telling the agent. The
+block also reminds the agent: don't ever swap in some other name you happen to
+read — an unfamiliar name in the boss's chair is a question to resolve, not a fact
+to accept.
+
+## Why it's safe
+- It only **adds** a note; it changes nothing else about how sessions start.
+- It's careful: it only runs if there's actually a chat topic and the server is
+  reachable. If the server can't answer, or nobody's been set as boss yet, it
+  prints nothing and the session goes on exactly as before.
+- It can't *make* anyone the boss — it only shows the boss who was already
+  verified the safe way. So there's no way for this to repeat the Caroline mix-up.
+- Every agent gets it automatically the next time it updates, because this note
+  lives in the startup script that always gets refreshed on update.
+
+## What's still coming
+Right now a boss gets recorded either by a one-time manual call, or — in the next
+step — automatically whenever the verified boss sends a message. After that, a
+final step will let the agent's own safety checker USE this binding to catch
+itself if it ever credits a decision to the wrong person. This step is the
+"agent can SEE its boss" piece; the "agent gets corrected if it forgets" piece
+comes next.


### PR DESCRIPTION
## What & why

Increment 2c of the **Know Your Principal** security build (#898 standard, #897 spec) — the **READ side** of the operator binding. The session-start hook now injects the verified `<topic-operator>` block at boot, so the agent reasons with its authenticated principal from message one and never seats a content name in the operator's chair (the "Caroline" identity-bleed fix).

Builds on: #904 (store) + #906 (routes, incl. `/topic-operator/session-context`).

- `PostUpdateMigrator.getHookContent('session-start')`: one additive fetch-block, modeled byte-for-byte on the existing **ORG-INTENT** and **AUTO-LEARNED-PREFERENCES** injection blocks (`curl -sf --max-time 4` + `python3` present/block parse + echo). Placed with the authoritative-identity context up front.
- Topic resolved from `$INSTAR_TELEGRAM_TOPIC` (the same env the existing topic-context block uses) → `/topic-operator/session-context?topicId=N`.

## Safety
- **Cannot seat anyone.** The block only *surfaces* the operator the store already verified from the platform sender id (#904). A read-side injection cannot introduce a Caroline-class bleed.
- **Fail-open, three guards.** Runs only when `$INSTAR_TELEGRAM_TOPIC` + `$PORT` + `$TOKEN` are set; an unbound topic / store-`503` / unreachable server / non-Telegram session injects nothing and continues normally. Bearer token stays in the header.

## Migration parity
The `instar/` session-start hook is rewritten from `getSessionStartHook()` on **every** update run (`PostUpdateMigrator.ts:1958`), so existing agents get the block automatically — no dedicated migration; the migration-parity-hooks suite stays green.

## Tests
- **Tier 3 (E2E)**: `tests/e2e/topic-operator-hook-injection-lifecycle.test.ts` (3) — Phase 1 asserts the generated hook **source** wires the fetch; Phase 2 extracts the **exact** block and runs it against a **live server**, proving it emits the `<topic-operator>` block when a topic is bound and nothing when unbound.
- Tier 1/2 for the store + route shipped in #904/#906; analog hook suites (PostUpdateMigrator-bootSelfKnowledge, migration-parity-hooks, OrgIntentManager-session-start-format) stay green.

## Scope notes
- The agent-awareness CLAUDE.md capability section is deliberately deferred: it'll be added **once** as a coherent whole when the feature is end-to-end (after **Inc-2d** inbound auto-bind + **Inc-3** cross-principal guard), rather than fragmented across increments. The feature-delivery and docs-coverage gates pass without it.

## ELI16

When the agent starts a conversation, it now gets handed a short note saying "the verified boss of this chat is X" — so it knows from the first message who it's working for, instead of guessing from names it reads later. This is the fix for a real incident where an agent on a shared machine slowly started treating a *different real person* (Caroline) as its boss, because the mix-up lived inside its own writing where nothing watched.

We already built the filing cabinet that remembers the verified boss (decided **only** by the verified ID of whoever actually sent the message, never a name typed in a document) and the endpoints to read it. **This step hands the agent that note at session start.** It only *adds* a note — it can't make anyone the boss, it only shows the boss who was already verified the safe way. It's careful: it only runs if there's a chat topic and the server answers; otherwise it prints nothing and the session goes on exactly as before. Every agent gets it automatically on its next update because the note lives in the startup script that's always refreshed. Next steps: auto-record the boss when they message (Inc-2d), then let the agent's own safety checker use the binding to catch itself (Inc-3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)