### PR TITLE
feat(security): auto-bind the verified topic operator from authorized inbound (Know Your Principal #898, increment 2d)

### DIFF
--- a/.instar/instar-dev-decisions/2026-06-06T08-15-39-604Z-topic-operator-autobind-inc2d.json
+++ b/.instar/instar-dev-decisions/2026-06-06T08-15-39-604Z-topic-operator-autobind-inc2d.json
@@ -1,0 +1,15 @@
+{
+  "ts": "2026-06-06T08:15:39.604Z",
+  "slug": "topic-operator-autobind-inc2d",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "safety-invariant proximity: src/messaging/TelegramAdapter.ts matches Telegram adapter"
+  ],
+  "belowFloor": true,
+  "files": 2,
+  "loc": 40,
+  "causalAutopsy": null,
+  "verdict": "pass"
+}

--- a/src/messaging/TelegramAdapter.ts
+++ b/src/messaging/TelegramAdapter.ts
@@ -2030,6 +2030,22 @@ export class TelegramAdapter implements MessagingAdapter {
   }
 
   /**
+   * Public read-only authorization check for a sender id (Know Your Principal #898,
+   * increment 2d). Wraps the private `isAuthorized` so the lifeline-forward route can
+   * decide whether an inbound sender is an authorized operator BEFORE binding them as
+   * the topic operator — an UNAUTHORIZED sender must never become the operator
+   * (that would re-open the "Caroline" cross-principal bug). Accepts number|string
+   * (the route carries the id as a string); a blank/non-numeric id returns false.
+   * Same trust model as `isAuthorized`: with no `authorizedUserIds` allowlist, every
+   * authenticated sender is accepted (the agent already serves everyone there).
+   */
+  isAuthorizedSender(userId: number | string): boolean {
+    const n = typeof userId === 'number' ? userId : Number(String(userId).trim());
+    if (!Number.isFinite(n)) return false;
+    return this.isAuthorized(n);
+  }
+
+  /**
    * Handle a message from an unknown/unauthorized Telegram user.
    * Checks the registration policy and responds appropriately:
    * - admin-only: Gated message + notify admin

--- a/src/server/routes.ts
+++ b/src/server/routes.ts
@@ -11193,6 +11193,30 @@ export function createRoutes(ctx: RouteContext): Router {
       }
     }
 
+    // Topic-operator auto-bind (Know Your Principal #898, increment 2d — the WRITE
+    // side). Record the VERIFIED operator of this topic from the AUTHENTICATED +
+    // AUTHORIZED sender of this real user inbound, so the session-start hook (#908)
+    // can inject it. ONLY an AUTHORIZED sender becomes the operator — an unauthorized
+    // sender in the bot's group must NEVER be seated (that re-opens the cross-principal
+    // "Caroline" bug). Placed AFTER the a2a-hook short-circuit so agent-to-agent bot
+    // messages never bind. Fail-soft: no store / unauthorized / error -> no-op and
+    // routing continues; setOperator is idempotent on the same uid.
+    if (ctx.topicOperatorStore && fromUserId !== undefined && fromUserId !== null
+        && typeof topicId === 'number') {
+      try {
+        if (ctx.telegram?.isAuthorizedSender?.(fromUserId)) {
+          ctx.topicOperatorStore.setOperator(topicId, {
+            platform: 'telegram',
+            uid: String(fromUserId),
+            displayName: typeof fromFirstName === 'string' ? fromFirstName : undefined,
+          });
+        }
+      } catch (err) {
+        // @silent-fallback-ok — an auto-bind failure must never break message routing.
+        console.error(`[telegram-forward] topic-operator auto-bind error (non-fatal): ${err instanceof Error ? err.message : err}`);
+      }
+    }
+
     // Build a Message object and fire the onTopicMessage callback
     if (ctx.telegram?.onTopicMessage) {
       const message = {

--- a/tests/integration/topic-operator-autobind-route.test.ts
+++ b/tests/integration/topic-operator-autobind-route.test.ts
@@ -1,0 +1,106 @@
+/**
+ * Tier-2 integration test — topic-operator auto-bind on /internal/telegram-forward
+ * (Know Your Principal #898, increment 2d — the WRITE side).
+ *
+ * Asserts, over the full HTTP pipeline, that the lifeline-forward route binds the
+ * topic operator FROM THE AUTHENTICATED + AUTHORIZED sender — and ONLY then:
+ *   1. authorized sender   → operator bound in the durable TopicOperatorStore.
+ *   2. unauthorized sender → NOTHING bound (the Caroline-class guard over the wire).
+ *   3. agent-to-agent bot  → short-circuits before the bind; nothing bound.
+ *   4. no store wired      → no crash; routing proceeds (pure additive change).
+ *
+ * Mirrors the telegram-forward-a2a-dispatch integration precedent (ProcessIntegrity
+ * frozen so the version handshake is bypassed; a stub adapter + a real store).
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import express from 'express';
+import request from 'supertest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { createRoutes } from '../../src/server/routes.js';
+import type { RouteContext } from '../../src/server/routes.js';
+import { ProcessIntegrity } from '../../src/core/ProcessIntegrity.js';
+import { TopicOperatorStore } from '../../src/users/TopicOperatorStore.js';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+
+let tmpDir: string;
+let store: TopicOperatorStore | null;
+
+/** A stub adapter exposing exactly what the auto-bind + routing path touches. */
+function makeAdapter(authorized: Array<number | string>) {
+  return {
+    isAuthorizedSender: (uid: number | string) => authorized.map(String).includes(String(uid)),
+    logInboundMessage: () => undefined,
+    onTopicMessage: () => undefined,
+    dispatchAgentMessageHook: async (m: { text: string }) => /^\[a2a:/.test(m.text),
+  };
+}
+
+function mountForwardRoute(telegram: unknown, withStore: boolean): express.Express {
+  store = withStore ? new TopicOperatorStore(path.join(tmpDir, '.instar', 'state')) : null;
+  const ctx = {
+    config: { projectName: 't', projectDir: tmpDir, stateDir: path.join(tmpDir, '.instar'), port: 0, authToken: '' } as any,
+    sessionManager: { listRunningSessions: () => [], isSessionAlive: () => false } as any,
+    state: { getJobState: () => null, getSession: () => null } as any,
+    scheduler: null, telegram, relationships: null, feedback: null, dispatches: null,
+    updateChecker: null, autoUpdater: null, autoDispatcher: null, quotaTracker: null,
+    publisher: null, viewer: null, tunnel: null, evolution: null, watchdog: null,
+    triageNurse: null, topicMemory: null, discoveryEvaluator: null, startTime: new Date(),
+    mentorRunner: null, currentInboundByTopic: new Map(), topicOperatorStore: store,
+  } as unknown as RouteContext;
+  const app = express();
+  app.use(express.json());
+  app.use('/', createRoutes(ctx));
+  return app;
+}
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'topic-op-autobind-'));
+  fs.mkdirSync(path.join(tmpDir, '.instar', 'state'), { recursive: true });
+  ProcessIntegrity.reset();
+  ProcessIntegrity.initialize('1.3.49', null);
+});
+afterEach(() => {
+  ProcessIntegrity.reset();
+  SafeFsExecutor.safeRmSync(tmpDir, { recursive: true, force: true, operation: 'tests/integration/topic-operator-autobind-route.test.ts' });
+});
+
+describe('/internal/telegram-forward → topic-operator auto-bind (integration)', () => {
+  it('BINDS the operator from an AUTHORIZED sender', async () => {
+    const app = mountForwardRoute(makeAdapter([7812716706]), true);
+    const res = await request(app).post('/internal/telegram-forward').set('Authorization', 'Bearer test')
+      .send({ topicId: 19437, text: 'hello', fromUserId: 7812716706, fromFirstName: 'Justin', messageId: 700 });
+    expect(res.status).toBe(200);
+    const op = store!.getOperator(19437);
+    expect(op?.uid).toBe('7812716706');
+    expect(op?.names).toEqual(['justin']);
+    expect(op?.boundFrom).toBe('authenticated-inbound');
+  });
+
+  it('does NOT bind an UNAUTHORIZED sender (the Caroline-class guard over the wire)', async () => {
+    const app = mountForwardRoute(makeAdapter([7812716706]), true);
+    const res = await request(app).post('/internal/telegram-forward').set('Authorization', 'Bearer test')
+      .send({ topicId: 19437, text: 'hi', fromUserId: 999, fromFirstName: 'Caroline', messageId: 701 });
+    expect(res.status).toBe(200);
+    expect(store!.getOperator(19437)).toBeNull();
+  });
+
+  it('does NOT bind an agent-to-agent bot message (short-circuits before the bind)', async () => {
+    // Even an "authorized" bot id is ignored: the a2a hook claims the message first.
+    const app = mountForwardRoute(makeAdapter([8781020500]), true);
+    const res = await request(app).post('/internal/telegram-forward').set('Authorization', 'Bearer test')
+      .send({ topicId: 458, text: '[a2a:from=echo to=codey role=mentor id=a corr=a ts=1 v=1]\nhi',
+        fromUserId: 8781020500, fromFirstName: 'Echo Mentor', messageId: 702, senderIsBot: true, senderBotId: '8781020500' });
+    expect(res.status).toBe(200);
+    expect(res.body.agentMessage).toBe(true);
+    expect(store!.getOperator(458)).toBeNull();
+  });
+
+  it('does not crash when no store is wired (pure additive change)', async () => {
+    const app = mountForwardRoute(makeAdapter([7812716706]), false);
+    const res = await request(app).post('/internal/telegram-forward').set('Authorization', 'Bearer test')
+      .send({ topicId: 19437, text: 'hello', fromUserId: 7812716706, messageId: 703 });
+    expect(res.status).toBe(200);
+  });
+});

--- a/tests/unit/telegram-isauthorizedsender.test.ts
+++ b/tests/unit/telegram-isauthorizedsender.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { TelegramAdapter } from '../../src/messaging/TelegramAdapter.js';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+
+/**
+ * Unit tests — TelegramAdapter.isAuthorizedSender (Know Your Principal #898,
+ * increment 2d). The public wrapper the lifeline-forward route uses to decide
+ * whether an inbound sender is an authorized operator BEFORE binding them as the
+ * topic operator. Covers both sides of the boundary + number/string ids + the
+ * blank/non-numeric guard + the no-allowlist trust model.
+ */
+describe('TelegramAdapter.isAuthorizedSender', () => {
+  const dirs: string[] = [];
+
+  function makeAdapter(authorizedUserIds: unknown): TelegramAdapter {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'instar-tg-authsender-'));
+    dirs.push(tmpDir);
+    return new TelegramAdapter(
+      { token: 'test-token-123', chatId: '-100123456', pollIntervalMs: 100, authorizedUserIds: authorizedUserIds as number[] },
+      tmpDir,
+    );
+  }
+
+  afterEach(() => {
+    for (const d of dirs.splice(0)) {
+      SafeFsExecutor.safeRmSync(d, { recursive: true, force: true, operation: 'tests/unit/telegram-isauthorizedsender.test.ts' });
+    }
+  });
+
+  it('authorizes a sender in the allowlist (number id, number config)', () => {
+    expect(makeAdapter([7812716706]).isAuthorizedSender(7812716706)).toBe(true);
+  });
+
+  it('authorizes a sender whose id the route carries as a STRING (the route\'s shape)', () => {
+    // The lifeline-forward route holds fromUserId; it may arrive numeric or string.
+    expect(makeAdapter([7812716706]).isAuthorizedSender('7812716706')).toBe(true);
+    expect(makeAdapter(['7812716706']).isAuthorizedSender('7812716706')).toBe(true);
+  });
+
+  it('REJECTS an unauthorized sender — they must never become the operator', () => {
+    expect(makeAdapter([7812716706]).isAuthorizedSender(999)).toBe(false);
+    expect(makeAdapter(['7812716706']).isAuthorizedSender('999')).toBe(false);
+  });
+
+  it('returns false for a blank / non-numeric id (no operator from garbage)', () => {
+    const a = makeAdapter([7812716706]);
+    expect(a.isAuthorizedSender('')).toBe(false);
+    expect(a.isAuthorizedSender('   ')).toBe(false);
+    expect(a.isAuthorizedSender('not-a-number')).toBe(false);
+  });
+
+  it('accepts any authenticated sender when no allowlist is configured (existing trust model)', () => {
+    expect(makeAdapter([]).isAuthorizedSender(999)).toBe(true);
+    expect(makeAdapter(undefined).isAuthorizedSender('12345')).toBe(true);
+  });
+});

--- a/upgrades/next/topic-operator-autobind-inc2d.md
+++ b/upgrades/next/topic-operator-autobind-inc2d.md
@@ -1,0 +1,41 @@
+---
+bump: minor
+audience: agent-only
+maturity: experimental
+---
+
+## What Changed
+
+The verified topic operator is now recorded AUTOMATICALLY (Know Your Principal
+standard, security-build increment 2d — the WRITE side). On the lifeline-forward
+inbound path (`POST /internal/telegram-forward`), a real user message from an
+AUTHENTICATED + AUTHORIZED sender binds that sender as the topic's operator, so
+the session-start hook (#908) injects it without a manual `POST /topic-operator`.
+Added a public `TelegramAdapter.isAuthorizedSender()` (the authorized-only gate)
+wrapping the private `isAuthorized`.
+
+## What to Tell Your User
+
+Nothing user-facing changes. Foundation wiring (experimental) for the Caroline
+identity-bleed security fix: the agent now learns its verified operator on its own
+from authorized inbound messages. ONLY authorized senders are recorded — an
+unauthorized party in the group is never seated as operator. Fail-soft: a bind
+failure never affects message handling.
+
+## Summary of New Capabilities
+
+- Auto-bind of the topic operator on `/internal/telegram-forward` (authorized
+  senders only; a2a bot messages and unauthorized senders never bind; fail-soft;
+  idempotent).
+- `TelegramAdapter.isAuthorizedSender(number|string)` — public read-only auth check.
+- Known gap (tracked for Inc-2e): the adapter long-poll (no-lifeline) path is not
+  yet covered; a no-lifeline install has no auto-bind (fail-safe).
+
+## Evidence
+
+Verified by 5 Tier-1 unit tests (`telegram-isauthorizedsender`: both sides of the
+boundary, number/string ids, blank/NaN guard, no-allowlist model) and 4 Tier-2
+integration tests (`topic-operator-autobind-route`: over the wire — authorized
+binds, unauthorized doesn't, a2a bot doesn't, null store no-op). The 14 existing
+`/internal/telegram-forward` integration tests stay green (no regression). Clean
+`tsc --noEmit`.

--- a/upgrades/side-effects/topic-operator-autobind-inc2d.md
+++ b/upgrades/side-effects/topic-operator-autobind-inc2d.md
@@ -1,0 +1,70 @@
+# Side-effects review — Topic Operator inbound auto-bind (Know Your Principal #898, increment 2d)
+
+## What this change does
+The WRITE side of the operator binding. On the lifeline-forward inbound path
+(`POST /internal/telegram-forward`), the verified operator of a topic is now
+recorded automatically from the AUTHENTICATED + AUTHORIZED sender of a real user
+message — so the session-start hook (#908) and the future cross-principal guard
+have a populated binding instead of relying on a manual `POST /topic-operator`.
+
+- `TelegramAdapter`: new public `isAuthorizedSender(number|string): boolean`,
+  wrapping the private `isAuthorized` (number/string tolerant; blank/non-numeric
+  → false). Read-only; no behavior change to the private path.
+- `routes.ts` `/internal/telegram-forward`: one additive block, placed AFTER the
+  a2a-hook short-circuit and BEFORE `onTopicMessage`, that binds the operator iff
+  `ctx.telegram.isAuthorizedSender(fromUserId)` is true.
+
+## The load-bearing security property
+ONLY an authorized sender becomes the operator. An unauthorized party in the
+bot's group is never seated — that is exactly the cross-principal ("Caroline")
+bug, and the integration test proves the over-the-wire refusal (a `fromUserId`
+outside the allowlist, even with `fromFirstName: "Caroline"`, binds nothing).
+The uid is the platform-authenticated sender id; a content name is never the
+source (`TopicOperatorStore.setOperator` enforces this by construction, #904).
+
+## Blast radius (hot path — reviewed carefully)
+- **Additive + fail-soft.** The block is wrapped in try/catch and only runs when
+  `ctx.topicOperatorStore` is non-null, `fromUserId` is present, and `topicId` is
+  a number. Any error is logged and swallowed — an auto-bind failure can NEVER
+  break message routing. `setOperator` is a fast local JSON write, idempotent on
+  the same uid (a redelivered message re-binds the same operator harmlessly).
+- **a2a-safe.** Placed after the a2a short-circuit, so agent-to-agent bot messages
+  return before the bind; a bot id is also not in `authorizedUserIds` anyway. The
+  14 existing `/internal/telegram-forward` integration tests stay green (no
+  regression to the version handshake, exactly-once, sentinel, or a2a paths).
+- **No new route / class / config key / dependency.** It consumes the store +
+  routes shipped in #904/#906 and the injection from #908.
+
+## No-allowlist trust model (documented)
+`isAuthorizedSender` mirrors `isAuthorized`: with NO `authorizedUserIds` allowlist
+configured, every authenticated sender is accepted (the agent already serves
+everyone in that mode), so the operator becomes the most-recent authenticated
+sender. This is consistent with the existing trust model and is NOT a
+Caroline-class bleed (the uid is Telegram-authenticated, not a content name). A
+secure deployment configures `authorizedUserIds`, and then only those uids bind.
+
+## Scope (deliberate) + the known gap
+This binds on the **lifeline-forward path only** — the instar fleet's primary
+inbound route. The adapter's own long-poll path (`onTopicMessage`, the
+no-lifeline case) is NOT covered here, because its single shared callback is
+defined in `src/commands/server.ts` (the production composition root, not
+route-testable). That gap is tracked for a follow-up (Inc-2e): bind in the shared
+`onTopicMessage` handler to cover both paths with one change. Until then, a
+no-lifeline install simply has no auto-bind (fail-safe: no binding → no injection
+→ no false identity), and `POST /topic-operator` remains the manual path.
+
+## Migration parity
+None required — server-side route behavior + an in-process adapter method reach
+existing agents on the next server update (the Migration Parity Standard governs
+agent-installed FILES; this touches none).
+
+## Tests
+- Tier 1 (unit): `tests/unit/telegram-isauthorizedsender.test.ts` (5) — both sides
+  of the boundary, number/string ids, blank/NaN guard, no-allowlist model.
+- Tier 2 (integration): `tests/integration/topic-operator-autobind-route.test.ts`
+  (4) — over the wire: authorized binds, unauthorized doesn't, a2a bot doesn't,
+  null store no-op. Existing telegram-forward suites (14) stay green.
+
+## Rollback
+Revert the one route block + the `isAuthorizedSender` method + delete the two
+tests. The store on disk is inert without the bind.

--- a/upgrades/topic-operator-autobind-inc2d.eli16.md
+++ b/upgrades/topic-operator-autobind-inc2d.eli16.md
@@ -1,0 +1,46 @@
+# ELI16 — Automatically remembering who the boss is
+
+## The one-sentence version
+When the verified boss sends a message, the agent now automatically writes down
+"this is the boss of this chat" — so it no longer has to be told by hand.
+
+## The backstory
+We've been fixing a real problem: an agent on a shared computer slowly started
+treating a *different real person* (call her Caroline) as its boss, because the
+mix-up lived inside the agent's own writing where nothing was watching. To fix it
+we built three pieces:
+
+1. A filing cabinet that remembers, per chat, who the verified boss is — and the
+   rule is strict: the boss is decided ONLY by the verified ID of whoever actually
+   sent the message, never a name typed in a document.
+2. A startup note that hands the agent that "who's your boss" info when it wakes
+   up (shipped last step).
+3. **This step:** actually filling in the filing cabinet automatically.
+
+## What this change adds
+Before, the filing cabinet only got filled in by a manual one-time call. Now,
+whenever a message comes in through the agent's main message pipe, the system
+checks: "is this sender on the allowed list?" If yes, it quietly writes them down
+as the verified boss of that chat. If no, it does NOTHING — an outsider in the
+group can never become the boss. That "only allowed senders count" rule is the
+whole point: it's what stops the Caroline mix-up from happening again. We prove it
+with a test that sends a message from an *un*-allowed person literally named
+"Caroline" and checks that nobody gets written down.
+
+## Why it's safe
+- It only **adds** a step, wrapped so that if anything ever goes wrong, the message
+  still gets handled normally — recording the boss can never break the chat.
+- It ignores robot-to-robot messages (those get handled earlier), and it ignores
+  anyone not on the allowed list.
+- Writing the same boss twice is harmless, so a re-delivered message can't cause
+  trouble.
+
+## What's deliberately left for next time
+This fills in the cabinet on the agent's **main** message pipe (the one the whole
+fleet uses). There's a second, simpler pipe (used when the agent talks to Telegram
+directly without the relay) that this step doesn't cover yet, because that one's
+wiring lives in a harder-to-test startup file. That's tracked as a small follow-up.
+Until then, an agent on that simpler setup just doesn't auto-fill the cabinet —
+which is safe, because no entry means no false boss. The final step after that
+lets the agent's own safety checker USE the binding to catch itself if it ever
+credits a decision to the wrong person.


### PR DESCRIPTION
## What & why

Increment 2d of the **Know Your Principal** security build — the **WRITE side** of the operator binding. On the lifeline-forward inbound path (`POST /internal/telegram-forward`), a real user message from an **authenticated + authorized** sender now binds that sender as the topic's verified operator, so the session-start hook (#908) injects it without a manual `POST /topic-operator`.

Completes the loop with #904 (store) + #906 (routes) + #908 (session-start read).

- **`TelegramAdapter`**: new public `isAuthorizedSender(number|string): boolean` wrapping the private `isAuthorized` (number/string tolerant; blank/NaN → false).
- **`routes.ts` `/internal/telegram-forward`**: one additive block, **after** the a2a-hook short-circuit and **before** `onTopicMessage`, binding the operator iff `ctx.telegram.isAuthorizedSender(fromUserId)`.

## Security invariant
**ONLY an authorized sender becomes the operator** — an unauthorized party in the bot's group is never seated (that re-opens the cross-principal "Caroline" bug). Proven over the wire: a `fromUserId` outside the allowlist, even with `fromFirstName: "Caroline"`, binds nothing.

## Hot-path safety
Additive + **fail-soft** (try/catch; runs only with a store + present `fromUserId` + numeric `topicId`) — an auto-bind failure can never break message routing. **a2a-safe** (after the a2a short-circuit, so bot messages never bind). `setOperator` is idempotent on the same uid. The **14 existing** `/internal/telegram-forward` integration tests stay green.

## Scope + tracked gap
Binds on the **lifeline-forward path only** (the fleet's primary inbound route). The adapter long-poll (no-lifeline) path is **not** covered here — its single shared `onTopicMessage` callback lives in `src/commands/server.ts` (the production composition root, not route-testable) — tracked for **Inc-2e**. Until then a no-lifeline install simply has no auto-bind (**fail-safe**: no binding → no injection → no false identity), and `POST /topic-operator` remains the manual path.

No migration required (server-side route behavior + an in-process adapter method reach existing agents on the next server update).

## Tests
- **Tier 1 (unit)** `telegram-isauthorizedsender` (5): both sides of the boundary, number/string ids, blank/NaN guard, no-allowlist trust model.
- **Tier 2 (integration)** `topic-operator-autobind-route` (4): over the wire — authorized binds, unauthorized doesn't, a2a bot doesn't, null store no-op.

## ELI16

When the verified boss sends a message, the agent now automatically writes down "this is the boss of this chat" — so it no longer has to be told by hand. The whole point is the gate: it checks "is this sender on the allowed list?" — if yes, it records them as the verified boss; if no, it does **nothing**, so an outsider in the group can never become the boss. That's what stops the "Caroline" mix-up (where an agent slowly started treating a different real person as its boss) from happening again — and we prove it with a test that sends a message from an *un*-allowed person literally named "Caroline" and checks nobody gets recorded. It only **adds** a step, wrapped so that if anything goes wrong the message still gets handled normally; it ignores robot-to-robot messages and anyone off the list; and writing the same boss twice is harmless. This fills in the binding on the agent's main message pipe (the whole fleet uses it); a second simpler pipe is a small tracked follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)