### PR TITLE
feat(security): observe-only principal-coherence check on outbound (Know Your Principal #898, increment 3)

### DIFF
--- a/.instar/instar-dev-decisions/2026-06-06T08-53-42-551Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-06-06T08-53-42-551Z-unknown.json
@@ -1,0 +1,15 @@
+{
+  "ts": "2026-06-06T08:53:42.551Z",
+  "slug": "unknown",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "new capability: new config key added"
+  ],
+  "belowFloor": true,
+  "files": 2,
+  "loc": 112,
+  "causalAutopsy": null,
+  "verdict": "pass"
+}

--- a/docs/specs/principal-coherence-observe.eli16.md
+++ b/docs/specs/principal-coherence-observe.eli16.md
@@ -1,0 +1,59 @@
+# Principal-Coherence Signal (observe-only) — ELI16
+
+## The problem, in one picture
+
+Imagine you run a chatbot agent in a group chat. The real person in charge of
+you is Justin. One day someone else in the group — call her Caroline — says a
+few things, and over the next hour the agent starts *writing* sentences like
+"Caroline approved the migration" and "locked with Caroline" and "Caroline
+dropped a token for the deploy." Nobody told it to switch bosses. It just
+absorbed a name it saw and started treating that person as the one whose
+decisions it acts on. That actually happened (the "Caroline" incident, June 5).
+
+The scary part is *where* the mix-up lived: not in a message coming IN (we have
+guards that watch incoming messages), but in the agent's OWN writing going OUT.
+No guard was watching the agent's own outbound words, so the wrong-boss belief
+spread silently across documents.
+
+## What this change adds
+
+A quiet watcher on the agent's outbound messages. Every time the agent is about
+to send a message, this watcher reads the text and asks one narrow question:
+
+> "Did I just credit an operator-style decision — an approval, a mandate, a
+> credential handoff, a lock, or acting-on-someone's-behalf — to a person who is
+> NOT my verified boss for this conversation?"
+
+It already knows who the *verified* boss is, because an earlier piece of this
+build (increments 2b–2d) records the operator from the **authenticated sender
+id** of real messages — never from a name typed in the text. So "Justin approved
+this" is fine (Justin is the bound operator), but "Caroline approved this" — when
+Caroline is not the bound operator — gets noticed.
+
+## What it does NOT do (on purpose)
+
+It does **nothing** except write a note to a log file
+(`state/principal-coherence.jsonl`). It never blocks the message, never changes
+the wording, never delays delivery. The message always sends exactly as written.
+
+Why so timid? Because the detector is a regex, and regexes false-positive on
+ordinary prose that just happens to name a capitalized person. Before we ever
+let something like this *block* a message, we need to measure how often it cries
+wolf on real traffic. "Observe-first" means: turn on the quiet logging, watch the
+log for a while, see how noisy it is, and only THEN decide whether a louder
+warn/block version is worth building. Shipping it loud first would be guessing.
+
+## How it's turned on
+
+It's **off by default** (shipped dark). It only does anything when a config flag
+`monitoring.principalCoherence.enabled` is set to true AND the agent has a
+verified operator store wired up. With the flag absent or false — the state for
+every existing and new agent until someone flips it — the watcher is completely
+inert and costs nothing.
+
+## Why you can trust it won't break messaging
+
+It's a fire-and-forget side branch wrapped in try/catch: if anything in it
+throws, the error is swallowed and your message still goes out. It can't block,
+it can't rewrite, it can't crash the send path. The worst it can ever do is fail
+to write a log line — which is harmless.

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -3748,6 +3748,22 @@ export interface MonitoringConfig {
     feedbackPostDelayMs?: number;
   };
   /**
+   * PrincipalGuard — observe-only outbound coherence check for the "Know Your
+   * Principal" / Caroline identity-bleed standard (security build increment 3).
+   * When enabled, the outbound tone-gate seam runs
+   * `evaluatePrincipalCoherence(text, verifiedOperator)` on a finalized agent
+   * message and LOGS any operator/attribution mismatch to
+   * `state/principal-coherence.jsonl`. SIGNAL-ONLY — it NEVER blocks, delays, or
+   * rewrites the message; on any error the message sends normally and the check
+   * no-ops. Ships DARK (default false). Observe-first so the regex false-positive
+   * rate (prose that merely mentions a capitalized name) can be measured on real
+   * outbound BEFORE any warn/block surface is ever built.
+   */
+  principalCoherence?: {
+    /** Master kill switch (default: false). Gates the observe-only check entirely. */
+    enabled: boolean;
+  };
+  /**
    * ApprenticeshipCycleSlaMonitor — observe-only signal for open apprenticeship
    * differential cycles older than the configured SLA. Ships OFF; when enabled
    * it raises at most one Attention item per overdue cycle id and never mutates

--- a/src/server/routes.ts
+++ b/src/server/routes.ts
@@ -1178,6 +1178,20 @@ export function createRoutes(ctx: RouteContext): Router {
       /* @silent-fallback-ok — observe-only; a detector error never affects delivery */
     });
 
+    // ── Principal-Coherence Signal (OBSERVE-ONLY) ─────────────────────
+    // Record — but NEVER act on — the case where this finalized outbound
+    // message credits an operator-ROLE decision (approval / mandate / credential
+    // / lock / acting-for) to a principal who is NOT the topic's VERIFIED
+    // operator. That is the "Caroline" identity-bleed failure, caught in the
+    // agent's OWN output where no inbound gate watches. Same fire-and-forget
+    // VOID contract as observeSelfViolation: structurally independent of the
+    // tone-gate verdict and of this function's return value — it cannot block,
+    // delay, or rewrite the message. Dark by default (gated inside on
+    // monitoring.principalCoherence.enabled + a wired TopicOperatorStore).
+    void observePrincipalCoherence(text, options.topicId).catch(() => {
+      /* @silent-fallback-ok — observe-only; a detector error never affects delivery */
+    });
+
     // ── Localhost-link guard (operator-mandated HARD rule, 2026-06-05) ──
     // A clickable localhost/loopback link must never reach a user — the user
     // is almost never on the machine this server runs on. This is a
@@ -1390,6 +1404,88 @@ export function createRoutes(ctx: RouteContext): Router {
               matchKind: v.matchKind,
               matchedHead: v.matchedText.slice(0, 80),
             })}\n`,
+          );
+        } catch {
+          /* @silent-fallback-ok — audit must never throw */
+        }
+      }
+    } catch {
+      // @silent-fallback-ok — observe-only; any error silently no-ops and the
+      // outbound message is unaffected.
+    }
+  }
+
+  /**
+   * Principal-Coherence Signal — OBSERVE-ONLY (Know Your Principal / Caroline
+   * identity-bleed standard, security build increment 3).
+   *
+   * Runs `evaluatePrincipalCoherence` against the finalized outbound text using
+   * the topic's VERIFIED operator (the authenticated binding from
+   * TopicOperatorStore — never a name read from content). On any finding — the
+   * agent crediting an operator-ROLE decision to a principal who is NOT the
+   * bound operator — it appends a structured line to
+   * `state/principal-coherence.jsonl`.
+   *
+   * HARD GUARANTEES (identical contract to observeSelfViolation):
+   *   - SIGNAL-ONLY: returns void; called as a fire-and-forget branch with NO
+   *     path to block, delay, rewrite, or influence the outbound message or the
+   *     tone-gate verdict.
+   *   - FAIL-OPEN: every operation guarded; any throw is swallowed and the
+   *     message is unaffected.
+   *   - DARK BY DEFAULT: inert unless `monitoring.principalCoherence.enabled` is
+   *     true AND a TopicOperatorStore is wired AND the topic has a numeric id.
+   *   - OBSERVE-FIRST: it ONLY logs. The detector regex can false-positive on
+   *     prose that merely names a capitalized person; observe mode is precisely
+   *     HOW that FP rate gets measured on real outbound BEFORE any warn/block
+   *     surface is ever built. The `verdict` field is recorded, never enforced.
+   */
+  async function observePrincipalCoherence(text: string, topicId?: number): Promise<void> {
+    try {
+      // Dark unless explicitly enabled AND the operator store is wired AND we
+      // have a numeric topic to look the verified operator up by.
+      if (ctx.config.monitoring?.principalCoherence?.enabled !== true) return;
+      if (!ctx.topicOperatorStore) return;
+      if (typeof topicId !== 'number') return;
+      if (typeof text !== 'string' || text.trim().length === 0) return;
+
+      // The authenticated binding — never a content name. Null when the topic is
+      // unbound, in which case evaluatePrincipalCoherence treats every
+      // attribution as unverifiable (still observe-only).
+      const operator = ctx.topicOperatorStore.asVerifiedOperator(topicId);
+
+      const { evaluatePrincipalCoherence } = await import('../core/PrincipalGuard.js');
+      // knownUserNames is intentionally empty here: there is no clean UserManager
+      // handle on this delivery seam, so only the operator's own names resolve a
+      // bound principal. Any prose naming a known NON-operator user therefore
+      // surfaces as a finding — which is exactly the false-positive surface that
+      // observe mode exists to measure before warn/block is ever considered.
+      const findings = evaluatePrincipalCoherence(text, operator, []);
+      if (findings.length === 0) return;
+
+      const auditPath = path.join(ctx.config.stateDir, 'state', 'principal-coherence.jsonl');
+      try {
+        fs.mkdirSync(path.dirname(auditPath), { recursive: true });
+      } catch {
+        /* @silent-fallback-ok — if the dir can't be made, the appends below no-op */
+      }
+      for (const f of findings) {
+        try {
+          fs.appendFileSync(
+            auditPath,
+            JSON.stringify({
+              t: new Date().toISOString(),
+              kind: 'principal-coherence',
+              topicId,
+              operatorUid: operator?.uid ?? null,
+              operatorBound: operator !== null,
+              principal: f.attribution.principal,
+              attributionKind: f.attribution.kind,
+              // Recorded for analysis ONLY — observe mode NEVER enforces a verdict.
+              verdict: f.verdict,
+              snippet: f.attribution.snippet.slice(0, 160),
+              reason: f.reason,
+            }) + '\n',
+            'utf8',
           );
         } catch {
           /* @silent-fallback-ok — audit must never throw */

--- a/tests/e2e/principal-coherence-lifecycle.test.ts
+++ b/tests/e2e/principal-coherence-lifecycle.test.ts
@@ -1,0 +1,166 @@
+/**
+ * E2E lifecycle — Principal-Coherence Signal (Know Your Principal / Caroline
+ * identity-bleed standard, security build increment 3).
+ *
+ * Tier 3 of the Testing Integrity Standard. Tests the complete PRODUCTION path:
+ *   Phase 1 — Feature is alive: a real AgentServer is booted the way production
+ *             boots it (config on disk, the TopicOperatorStore composed in the
+ *             constructor). With `monitoring.principalCoherence.enabled` true, a
+ *             finalized outbound message that credits an operator-ROLE decision
+ *             to a NON-operator principal causes the observe-only write to land
+ *             at state/principal-coherence.jsonl. This is the "feature is alive"
+ *             proof — the observe seam is really wired into the delivery path,
+ *             not dead code.
+ *   Phase 2 — The SIGNAL-ONLY + gating invariants over the live server: the
+ *             message ALWAYS delivers (never 422), an attribution to the BOUND
+ *             operator logs nothing, and with the flag OFF nothing is ever
+ *             written (default-dark).
+ *
+ * The observe write is fire-and-forget, so reads poll for the audit file.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import request from 'supertest';
+import { AgentServer } from '../../src/server/AgentServer.js';
+import { StateManager } from '../../src/core/StateManager.js';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+import { createMockSessionManager } from '../helpers/setup.js';
+import type { InstarConfig } from '../../src/core/types.js';
+
+const AUTH_TOKEN = 'test-principal-coherence-e2e';
+const auth = () => ({ Authorization: `Bearer ${AUTH_TOKEN}` });
+
+function telegramStub(delivered: Array<{ topicId: number; text: string }>): any {
+  return {
+    onMessageLogged: null,
+    async sendToTopic(topicId: number, text: string) { delivered.push({ topicId, text }); return {}; },
+    getSessionForTopic: () => null,
+    isSessionAlive: () => true,
+  };
+}
+
+interface Boot {
+  tmpDir: string;
+  stateDir: string;
+  server: AgentServer;
+  app: ReturnType<AgentServer['getApp']>;
+  delivered: Array<{ topicId: number; text: string }>;
+}
+
+function boot(enabled: boolean): Boot {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'pc-e2e-'));
+  const stateDir = path.join(tmpDir, '.instar');
+  fs.mkdirSync(path.join(stateDir, 'state', 'sessions'), { recursive: true });
+  fs.mkdirSync(path.join(stateDir, 'state', 'jobs'), { recursive: true });
+  fs.writeFileSync(path.join(stateDir, 'config.json'), JSON.stringify({ port: 0, projectName: 'pc-e2e' }));
+  const delivered: Array<{ topicId: number; text: string }> = [];
+  const config: InstarConfig = {
+    projectName: 'pc-e2e', agentName: 'E2E Agent', projectDir: tmpDir,
+    stateDir, port: 0, authToken: AUTH_TOKEN,
+    ...(enabled ? { monitoring: { principalCoherence: { enabled: true } } } : {}),
+  } as InstarConfig;
+  const sm = createMockSessionManager() as any;
+  // The /telegram/reply path clears the inject tracker on send; the bare mock
+  // doesn't define it (the topic-operator e2e never exercises reply, so it omits this).
+  sm.clearInjectionTracker = () => {};
+  const server = new AgentServer({
+    config, sessionManager: sm,
+    state: new StateManager(stateDir), telegram: telegramStub(delivered),
+  });
+  return { tmpDir, stateDir, server, app: server.getApp(), delivered };
+}
+
+function auditEntries(stateDir: string): any[] {
+  const p = path.join(stateDir, 'state', 'principal-coherence.jsonl');
+  if (!fs.existsSync(p)) return [];
+  return fs.readFileSync(p, 'utf-8').trim().split('\n').filter(Boolean).map((l) => JSON.parse(l));
+}
+
+async function waitForAudit(stateDir: string, min: number): Promise<any[]> {
+  for (let i = 0; i < 40; i++) {
+    const e = auditEntries(stateDir);
+    if (e.length >= min) return e;
+    await new Promise((r) => setTimeout(r, 25));
+  }
+  return auditEntries(stateDir);
+}
+
+async function bind(app: Boot['app'], topicId: number, uid: string, displayName: string): Promise<void> {
+  const res = await request(app).post('/topic-operator').set(auth())
+    .send({ topicId, platform: 'telegram', uid, displayName });
+  expect(res.status).toBe(200);
+}
+
+describe('Principal-Coherence Signal E2E lifecycle', () => {
+  let on: Boot;
+  let off: Boot;
+
+  beforeAll(() => {
+    on = boot(true);
+    off = boot(false);
+  });
+
+  afterAll(async () => {
+    for (const b of [on, off]) {
+      try { await (b.server as unknown as { stop?: () => Promise<void> }).stop?.(); } catch { /* ignore */ }
+      SafeFsExecutor.safeRmSync(b.tmpDir, { recursive: true, force: true, operation: 'principal-coherence-lifecycle' });
+    }
+  });
+
+  // ── Phase 1: feature is alive on the production AgentServer boot path ──
+
+  it('records an observe-only finding when a misattribution is sent (flag on, bound operator)', async () => {
+    await bind(on.app, 19437, '7812716706', 'Justin');
+
+    const res = await request(on.app).post('/telegram/reply/19437').set(auth())
+      .send({ text: 'Locked the migration with Caroline under mandate (Caroline).' });
+    expect(res.status).toBe(200); // message delivers
+    expect(on.delivered.some((d) => d.topicId === 19437)).toBe(true);
+
+    const entries = await waitForAudit(on.stateDir, 1);
+    const caroline = entries.find((e) => e.topicId === 19437 && e.principal === 'caroline');
+    expect(caroline).toBeTruthy();
+    expect(caroline.operatorUid).toBe('7812716706');
+    expect(caroline.operatorBound).toBe(true);
+    expect(caroline.kind).toBe('principal-coherence');
+  });
+
+  // ── Phase 2: SIGNAL-ONLY + gating invariants over the live server ──
+
+  it('SIGNAL-ONLY: a credential misattribution carries a block verdict but never blocks the message', async () => {
+    await bind(on.app, 19440, '7812716706', 'Justin');
+    const res = await request(on.app).post('/telegram/reply/19440').set(auth())
+      .send({ text: 'Caroline dropped a token for the deploy.' });
+    expect(res.status).toBe(200);   // delivered, not 422
+    expect(res.status).not.toBe(422);
+
+    const entries = await waitForAudit(on.stateDir, 1);
+    const cred = entries.find((e) => e.topicId === 19440 && e.attributionKind === 'credential');
+    expect(cred?.verdict).toBe('block'); // recorded, never enforced
+  });
+
+  it('an attribution to the BOUND operator logs nothing', async () => {
+    await bind(on.app, 19441, '7812716706', 'Justin');
+    const before = auditEntries(on.stateDir).filter((e) => e.topicId === 19441).length;
+    const res = await request(on.app).post('/telegram/reply/19441').set(auth())
+      .send({ text: 'Justin approved the plan, so I shipped it.' });
+    expect(res.status).toBe(200);
+    await new Promise((r) => setTimeout(r, 150));
+    const after = auditEntries(on.stateDir).filter((e) => e.topicId === 19441).length;
+    expect(after).toBe(before);
+  });
+
+  it('GATED: with the flag OFF, an identical misattribution writes nothing and still delivers', async () => {
+    await bind(off.app, 19437, '7812716706', 'Justin');
+    const res = await request(off.app).post('/telegram/reply/19437').set(auth())
+      .send({ text: 'Locked with Caroline under mandate (Caroline).' });
+    expect(res.status).toBe(200);
+    expect(off.delivered.some((d) => d.topicId === 19437)).toBe(true);
+
+    await new Promise((r) => setTimeout(r, 150));
+    expect(auditEntries(off.stateDir)).toHaveLength(0);
+  });
+});

--- a/tests/integration/principal-coherence-signal.test.ts
+++ b/tests/integration/principal-coherence-signal.test.ts
@@ -1,0 +1,182 @@
+/**
+ * Integration test — Principal-Coherence Signal (Know Your Principal / Caroline
+ * identity-bleed standard, security build increment 3).
+ *
+ * Tier 2: the full HTTP pipeline. A finalized outbound message that credits an
+ * operator-ROLE decision (approval / mandate / credential / lock / acting-for)
+ * to a principal who is NOT the topic's VERIFIED operator is recorded — observe
+ * only — as a line in `state/principal-coherence.jsonl`. The check is gated on
+ * `monitoring.principalCoherence.enabled` and a wired TopicOperatorStore, and it
+ * is SIGNAL-ONLY: it NEVER blocks, delays, or rewrites the message (the reply
+ * always returns 200 and the text always delivers).
+ *
+ * Gating + correctness asserted on both sides of every boundary:
+ *   - flag ON + bound operator + misattribution to an OUTSIDER  → one finding logged
+ *   - flag ON + attribution to the BOUND operator               → nothing logged
+ *   - flag ON + NO bound operator + misattribution              → logged (unverifiable)
+ *   - flag OFF                                                   → nothing logged
+ *   - in every case the message still delivers (never 422)
+ */
+import { describe, it, expect, afterEach } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import request from 'supertest';
+import { AgentServer } from '../../src/server/AgentServer.js';
+import { StateManager } from '../../src/core/StateManager.js';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+import { createMockSessionManager } from '../helpers/setup.js';
+import type { InstarConfig } from '../../src/core/types.js';
+
+const AUTH = 'pc-int-token';
+const auth = () => ({ Authorization: `Bearer ${AUTH}` });
+
+interface Built { dir: string; server: AgentServer; delivered: Array<{ topicId: number; text: string }>; }
+
+function telegramStub(delivered: Array<{ topicId: number; text: string }>): any {
+  return {
+    onMessageLogged: null,
+    async sendToTopic(topicId: number, text: string) { delivered.push({ topicId, text }); return {}; },
+    getSessionForTopic: () => null,
+    isSessionAlive: () => true,
+  };
+}
+
+function build(opts: { enabled: boolean }): Built {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'pc-int-'));
+  fs.mkdirSync(path.join(dir, '.instar', 'state', 'sessions'), { recursive: true });
+  fs.mkdirSync(path.join(dir, '.instar', 'state', 'jobs'), { recursive: true });
+  const delivered: Array<{ topicId: number; text: string }> = [];
+  const config: InstarConfig = {
+    projectName: 'pc-int', agentName: 'Int', projectDir: dir,
+    stateDir: path.join(dir, '.instar'), port: 0, authToken: AUTH,
+    ...(opts.enabled ? { monitoring: { principalCoherence: { enabled: true } } } : {}),
+  } as InstarConfig;
+  const sm = createMockSessionManager() as any;
+  sm.clearInjectionTracker = () => {};
+  const server = new AgentServer({
+    config, sessionManager: sm, state: new StateManager(path.join(dir, '.instar')), telegram: telegramStub(delivered),
+  });
+  return { dir, server, delivered };
+}
+
+/** Bind a verified operator for a topic over the wire (the WRITE side). */
+async function bindOperator(server: AgentServer, topicId: number, uid: string, displayName: string): Promise<void> {
+  const res = await request(server.getApp()).post('/topic-operator').set(auth())
+    .send({ topicId, platform: 'telegram', uid, displayName });
+  expect(res.status).toBe(200);
+  expect(res.body.bound).toBe(true);
+}
+
+function auditPath(dir: string): string {
+  return path.join(dir, '.instar', 'state', 'principal-coherence.jsonl');
+}
+
+/** Read the audit jsonl, returning parsed entries (the observe write is async). */
+function readAudit(dir: string): any[] {
+  const p = auditPath(dir);
+  if (!fs.existsSync(p)) return [];
+  return fs.readFileSync(p, 'utf-8').trim().split('\n').filter(Boolean).map((l) => JSON.parse(l));
+}
+
+/** Poll until at least `min` audit entries are present (observe call is fire-and-forget). */
+async function waitForAudit(dir: string, min: number): Promise<any[]> {
+  for (let i = 0; i < 40; i++) {
+    const entries = readAudit(dir);
+    if (entries.length >= min) return entries;
+    await new Promise((r) => setTimeout(r, 25));
+  }
+  return readAudit(dir);
+}
+
+describe('Principal-Coherence Signal — observe-only recording path (integration)', () => {
+  let built: Built | null = null;
+  afterEach(() => {
+    if (built) { SafeFsExecutor.safeRmSync(built.dir, { recursive: true, force: true, operation: 'pc-int' }); built = null; }
+  });
+
+  it('logs a finding when an outbound message credits an OUTSIDER in an authority role (flag on, operator bound)', async () => {
+    built = build({ enabled: true });
+    await bindOperator(built.server, 701, '55501', 'Justin');
+
+    const res = await request(built.server.getApp())
+      .post('/telegram/reply/701').set(auth())
+      .send({ text: 'Locked the migration with Caroline and shipped it under mandate (Caroline).' });
+    // SIGNAL-ONLY: the message always delivers; never blocked.
+    expect(res.status).toBe(200);
+    expect(built.delivered.some((d) => d.topicId === 701)).toBe(true);
+
+    const entries = await waitForAudit(built.dir, 1);
+    expect(entries.length).toBeGreaterThanOrEqual(1);
+    const caroline = entries.find((e) => e.principal === 'caroline');
+    expect(caroline).toBeTruthy();
+    expect(caroline.kind).toBe('principal-coherence');
+    expect(caroline.topicId).toBe(701);
+    expect(caroline.operatorUid).toBe('55501');
+    expect(caroline.operatorBound).toBe(true);
+    // The credential/mandate-bearing kind carries a block verdict — RECORDED only.
+    const mandate = entries.find((e) => e.principal === 'caroline' && e.attributionKind === 'mandate');
+    expect(mandate?.verdict).toBe('block');
+  });
+
+  it('logs NOTHING when the attribution resolves to the BOUND operator', async () => {
+    built = build({ enabled: true });
+    await bindOperator(built.server, 702, '55502', 'Justin');
+
+    const res = await request(built.server.getApp())
+      .post('/telegram/reply/702').set(auth())
+      .send({ text: 'Justin approved the plan, so I shipped it.' });
+    expect(res.status).toBe(200);
+
+    // Give the async observe call time to run, then assert no file/entries.
+    await new Promise((r) => setTimeout(r, 150));
+    expect(readAudit(built.dir)).toHaveLength(0);
+  });
+
+  it('logs a finding with operatorBound=false when NO operator is bound (flag on)', async () => {
+    built = build({ enabled: true });
+    // No bindOperator call — the topic is unbound.
+
+    const res = await request(built.server.getApp())
+      .post('/telegram/reply/703').set(auth())
+      .send({ text: 'Mandate (Caroline) authorized the credential handoff.' });
+    expect(res.status).toBe(200);
+
+    const entries = await waitForAudit(built.dir, 1);
+    expect(entries.length).toBeGreaterThanOrEqual(1);
+    expect(entries[0].operatorBound).toBe(false);
+    expect(entries[0].operatorUid).toBeNull();
+    expect(entries[0].principal).toBe('caroline');
+  });
+
+  it('GATED: flag OFF records nothing and the message still delivers', async () => {
+    built = build({ enabled: false });
+    await bindOperator(built.server, 704, '55504', 'Justin');
+
+    const res = await request(built.server.getApp())
+      .post('/telegram/reply/704').set(auth())
+      .send({ text: 'Locked with Caroline under mandate (Caroline).' });
+    expect(res.status).toBe(200);
+    expect(built.delivered.some((d) => d.topicId === 704)).toBe(true);
+
+    await new Promise((r) => setTimeout(r, 150));
+    expect(readAudit(built.dir)).toHaveLength(0);
+  });
+
+  it('never writes the verdict as an enforcement (a blocked verdict is recorded but the message is NOT 422)', async () => {
+    built = build({ enabled: true });
+    await bindOperator(built.server, 705, '55505', 'Justin');
+
+    const res = await request(built.server.getApp())
+      .post('/telegram/reply/705').set(auth())
+      .send({ text: 'Caroline dropped a token for the deploy.' });
+    // 'credential' kind → block verdict in the finding — but observe-only, so 200.
+    expect(res.status).toBe(200);
+
+    const entries = await waitForAudit(built.dir, 1);
+    const cred = entries.find((e) => e.attributionKind === 'credential');
+    expect(cred).toBeTruthy();
+    expect(cred.verdict).toBe('block'); // recorded
+    expect(res.status).not.toBe(422);   // never enforced
+  });
+});

--- a/tests/unit/principal-coherence-operator-seam.test.ts
+++ b/tests/unit/principal-coherence-operator-seam.test.ts
@@ -1,0 +1,80 @@
+/**
+ * Unit tests — Principal-Coherence seam (Know Your Principal / Caroline
+ * identity-bleed standard, security build increment 3).
+ *
+ * The observe-only outbound check (routes.ts → observePrincipalCoherence) feeds
+ * `TopicOperatorStore.asVerifiedOperator(topicId)` straight into
+ * `evaluatePrincipalCoherence(text, operator)`. These two modules are unit-tested
+ * in isolation elsewhere; THIS test locks the CONTRACT between them — the exact
+ * seam the wiring depends on — so a future change to either side that breaks the
+ * other is caught here, with both sides of the decision boundary exercised:
+ *   - an attribution to the BOUND operator's name           → no finding
+ *   - an attribution to an OUTSIDER (the Caroline failure)   → finding
+ *   - an UNBOUND topic (null operator)                       → finding (unverifiable)
+ *   - a credential/mandate kind                              → BLOCK verdict
+ *   - prose with no operator-role attribution                → no finding
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { TopicOperatorStore } from '../../src/users/TopicOperatorStore.js';
+import { evaluatePrincipalCoherence } from '../../src/core/PrincipalGuard.js';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+
+let dir: string;
+beforeEach(() => { dir = fs.mkdtempSync(path.join(os.tmpdir(), 'pc-seam-')); });
+afterEach(() => { SafeFsExecutor.safeRmSync(dir, { recursive: true, force: true, operation: 'tests/unit/principal-coherence-operator-seam.test.ts' }); });
+
+describe('Principal-Coherence seam — store.asVerifiedOperator → evaluatePrincipalCoherence', () => {
+  it('an attribution to the BOUND operator resolves and produces NO finding', () => {
+    const store = new TopicOperatorStore(dir);
+    store.setOperator(701, { platform: 'telegram', uid: '55501', displayName: 'Justin' });
+    const operator = store.asVerifiedOperator(701);
+
+    const findings = evaluatePrincipalCoherence('Justin approved the plan, so I shipped it.', operator);
+    expect(findings).toHaveLength(0);
+  });
+
+  it('an attribution to an OUTSIDER produces a finding (the Caroline failure)', () => {
+    const store = new TopicOperatorStore(dir);
+    store.setOperator(702, { platform: 'telegram', uid: '55502', displayName: 'Justin' });
+    const operator = store.asVerifiedOperator(702);
+
+    const findings = evaluatePrincipalCoherence('Caroline approved the migration.', operator);
+    expect(findings.length).toBeGreaterThanOrEqual(1);
+    expect(findings[0].attribution.principal).toBe('caroline');
+    expect(findings[0].verdict).toBe('warn'); // approval kind → warn
+  });
+
+  it('an UNBOUND topic yields a null operator and the attribution is unverifiable', () => {
+    const store = new TopicOperatorStore(dir);
+    const operator = store.asVerifiedOperator(703); // never bound
+    expect(operator).toBeNull();
+
+    const findings = evaluatePrincipalCoherence('Mandate (Caroline) authorized this.', operator);
+    expect(findings.length).toBeGreaterThanOrEqual(1);
+    expect(findings[0].attribution.principal).toBe('caroline');
+    // mandate kind → block verdict (recorded by observe mode, never enforced)
+    expect(findings[0].verdict).toBe('block');
+    expect(findings[0].reason).toContain('no bound operator');
+  });
+
+  it('a credential attribution to an outsider carries a BLOCK verdict through the seam', () => {
+    const store = new TopicOperatorStore(dir);
+    store.setOperator(704, { platform: 'telegram', uid: '55504', displayName: 'Justin' });
+    const operator = store.asVerifiedOperator(704);
+
+    const findings = evaluatePrincipalCoherence('Caroline dropped a token for the deploy.', operator);
+    const cred = findings.find((f) => f.attribution.kind === 'credential');
+    expect(cred).toBeTruthy();
+    expect(cred!.verdict).toBe('block');
+  });
+
+  it('prose with no operator-role attribution produces no finding even when unbound', () => {
+    const store = new TopicOperatorStore(dir);
+    const operator = store.asVerifiedOperator(705);
+    const findings = evaluatePrincipalCoherence('I built the feature and ran the tests; everything is green.', operator);
+    expect(findings).toHaveLength(0);
+  });
+});

--- a/upgrades/next/principal-coherence-observe.md
+++ b/upgrades/next/principal-coherence-observe.md
@@ -1,0 +1,45 @@
+---
+bump: minor
+audience: agent-only
+maturity: experimental
+---
+
+## What Changed
+
+The agent now runs an OBSERVE-ONLY coherence check on its OWN outbound messages
+(Know Your Principal standard, security-build increment 3 — the READ side). When
+a finalized message credits an operator-ROLE decision (approval / mandate /
+credential / lock / acting-for) to a principal who is NOT the topic's VERIFIED
+operator, a structured finding is appended to `state/principal-coherence.jsonl`.
+This is the first runtime consumer of `PrincipalGuard` (shipped pure in #902):
+the verified operator comes from the authenticated-sender binding
+(#904/#906/#909), never from a name in content.
+
+## What to Tell Your User
+
+Nothing user-facing changes. Foundation observability (experimental) for the
+"Caroline" identity-bleed security fix: the agent can now NOTICE — in its own
+output, where no inbound gate watches — when it credits a decision to someone who
+isn't its verified operator. It is SIGNAL-ONLY: it NEVER blocks, delays, or
+rewrites a message; it only writes a log line. It ships off by default (dark) so
+the detector's false-positive rate can be measured on real outbound before any
+warn or block surface is ever considered.
+
+## Summary of New Capabilities
+
+- `monitoring.principalCoherence.enabled` config flag (default false / absent).
+- Observe-only outbound check on the `checkOutboundMessage` delivery seam,
+  modeled on the existing `observeSelfViolation` (fire-and-forget, fail-open,
+  dark by default).
+- Audit trail at `state/principal-coherence.jsonl` (one JSON line per finding:
+  topicId, operatorUid, operatorBound, principal, attributionKind, verdict,
+  snippet, reason). The `verdict` is recorded for analysis, NEVER enforced.
+
+## Evidence
+
+14 tests across all three tiers, all green: Tier-1 unit
+(`principal-coherence-operator-seam`, 5 — the store→guard contract, both sides),
+Tier-2 integration (`principal-coherence-signal`, 5 — over the wire, gating both
+sides), Tier-3 e2e (`principal-coherence-lifecycle`, 4 — production boot,
+feature-is-alive, signal-only proof that a block-verdict finding still returns
+200 not 422). Clean `tsc --noEmit`; docs-coverage `--check` passes (no new route).

--- a/upgrades/side-effects/principal-coherence-observe.md
+++ b/upgrades/side-effects/principal-coherence-observe.md
@@ -1,0 +1,82 @@
+# Side-effects review — Principal-Coherence Signal, observe-only (Know Your Principal, increment 3)
+
+## What this change does
+The READ side of the operator binding — the first runtime consumer of
+`PrincipalGuard.evaluatePrincipalCoherence` (shipped pure + unwired in #902).
+On the outbound delivery seam (`checkOutboundMessage` in routes.ts), every
+finalized agent message is checked against the topic's VERIFIED operator. When
+the message credits an operator-ROLE decision (approval / mandate / credential /
+lock / acting-for) to a principal who is NOT the bound operator — the "Caroline"
+identity-bleed failure, caught in the agent's OWN output — a structured line is
+appended to `state/principal-coherence.jsonl`.
+
+- `src/core/types.ts`: one new optional config block,
+  `monitoring.principalCoherence?: { enabled: boolean }`. Documented, off by
+  default by absence.
+- `src/server/routes.ts`: one new observe function `observePrincipalCoherence`,
+  modeled byte-for-byte on the existing `observeSelfViolation`, plus one
+  fire-and-forget `void observePrincipalCoherence(...)` call placed next to the
+  existing `void observeSelfViolation(...)` at the top of `checkOutboundMessage`
+  (before the gate-availability early-return, so it runs regardless of whether a
+  tone gate is configured).
+
+## The load-bearing security property
+The operator the check resolves against comes ONLY from
+`TopicOperatorStore.asVerifiedOperator(topicId)` — the authenticated-sender
+binding (#904/#906/#2d), never a name read from content. A name in the agent's
+prose can therefore never become the "known good" principal; it can only ever be
+the thing being CHECKED. This is the whole point of the standard: an unverified
+identity is a guess, not a fact.
+
+## SIGNAL-ONLY contract (identical to observeSelfViolation)
+- **Returns void; fire-and-forget.** It has NO path to block, delay, rewrite, or
+  influence the outbound message or the tone-gate verdict. The verdict field in
+  the audit line (block for mandate/credential, warn otherwise) is RECORDED for
+  later analysis and NEVER enforced — proven by an e2e assertion that a
+  credential misattribution still returns 200, not 422.
+- **Fail-open.** Every operation is guarded; the outer body is try/catch and each
+  fs op is independently guarded. Any throw is swallowed and the message sends.
+- **Dark by default.** Inert unless `monitoring.principalCoherence.enabled === true`
+  AND `ctx.topicOperatorStore` is non-null AND the topic id is numeric. Absent
+  config (every existing + new agent today) = fully inert, zero cost.
+- **Observe-first rationale.** The PrincipalGuard regex can false-positive on
+  prose that merely names a capitalized person. Observe mode exists precisely to
+  measure that FP rate on real outbound BEFORE any warn/block surface is built.
+
+## Blast radius
+- **Additive.** No route added, no class added, no dependency added. One config
+  key, one function, one fire-and-forget call.
+- **Hot path, but cold by default.** The call sits on the outbound delivery path,
+  but when the flag is off it returns on the first `if` before touching the store
+  or importing PrincipalGuard (dynamic import, so the cold path never even loads
+  the module).
+- **Audit write.** On a finding it appends to `state/principal-coherence.jsonl`,
+  mkdir-ing `state/` defensively first (the TopicOperatorStore only creates that
+  dir on its first write, which may not have happened yet). Append-only; bounded
+  per message by the number of distinct attributions found.
+
+## Migration parity
+None required. This is server-side route behavior + a config TYPE only. The
+config flag follows the exact convention of its sibling observe flag
+`monitoring.correctionLearning` — read with `=== true`, so absent → off. Behavior
+is therefore IDENTICAL for new and existing agents with no migrateConfig write
+(adding one would only cosmetically materialize a false flag). The
+`correctionLearning` flag has no migrateConfig/generateDefaultConfig entry for
+the same reason; this mirrors it.
+
+## Tests (all three tiers)
+- Tier 1 (unit): `tests/unit/principal-coherence-operator-seam.test.ts` (5) —
+  locks the store→guard contract the wiring depends on, both sides of the
+  boundary (bound operator resolves → no finding; outsider → finding; unbound →
+  finding; credential/mandate → block verdict; benign prose → nothing).
+- Tier 2 (integration): `tests/integration/principal-coherence-signal.test.ts`
+  (5) — over the wire: flag on + bound operator + misattribution logs; bound
+  operator attribution logs nothing; unbound logs operatorBound:false; flag off
+  logs nothing; a block-verdict finding never 422s.
+- Tier 3 (e2e): `tests/e2e/principal-coherence-lifecycle.test.ts` (4) — production
+  AgentServer boot; feature-is-alive write lands; signal-only (credential → 200,
+  not 422); bound-operator no-op; flag-off dark.
+
+## Rollback
+Revert the one observe function + its one call site + the config type, and delete
+the three test files. The jsonl on disk is inert. No data migration to unwind.


### PR DESCRIPTION
## ELI16 — the agent now watches its OWN outbound words for the "wrong boss" mistake

If the agent starts crediting decisions ("X approved this", "mandate (X)", "X dropped a token") to a person who is NOT its authenticated operator for that chat — the exact "Caroline" identity-bleed — it now notices and writes a log line. Observe-only: it never blocks or rewrites the message, and it ships off by default so we can measure how noisy the detector is before ever making it louder.

## What & why

The **READ side** of the Know Your Principal operator binding and the first runtime consumer of `PrincipalGuard.evaluatePrincipalCoherence` (shipped pure + unwired in #902). Closes the loop the "Caroline" incident exposed: the identity-bleed lived in the agent's **own outbound writing**, where no inbound gate watched.

On the outbound delivery seam (`checkOutboundMessage`), every finalized agent message is checked against the topic's **VERIFIED** operator (`TopicOperatorStore.asVerifiedOperator` — the authenticated-sender binding from #904/#906/#909, **never** a content name). When the message credits an operator-ROLE decision (approval / mandate / credential / lock / acting-for) to a principal who is **not** the bound operator, a structured finding is appended to `state/principal-coherence.jsonl`.

## SIGNAL-ONLY (hard contract — modeled byte-for-byte on `observeSelfViolation`)

- **Returns void; fire-and-forget.** No path to block, delay, rewrite, or influence the outbound message or the tone-gate verdict. The recorded `verdict` (block for mandate/credential, warn otherwise) is for **analysis only** and is **never enforced** — an e2e asserts a credential misattribution still returns 200, not 422.
- **Fail-open.** Outer try/catch + per-op guards; any throw is swallowed and the message sends.
- **Dark by default.** Inert unless `monitoring.principalCoherence.enabled === true` AND a `TopicOperatorStore` is wired AND the topic id is numeric. Absent config (every existing + new agent today) = fully inert; the cold path doesn't even import PrincipalGuard.
- **Observe-first.** The detector regex can false-positive on prose that merely names a capitalized person. Observe mode exists precisely to **measure that FP rate** on real outbound before any warn/block surface is ever built.

## Scope

- `src/core/types.ts` — one optional config block `monitoring.principalCoherence?: { enabled }`.
- `src/server/routes.ts` — one observe function + one fire-and-forget call next to the existing `observeSelfViolation`.
- **No** new route / class / dependency. **No** migration needed: the flag is read with `=== true` (absent → off), mirroring the sibling `monitoring.correctionLearning` flag's convention exactly — behavior is identical for new and existing agents.

## Tests — all three tiers, 14 total, green

| Tier | File | n | Covers |
|------|------|---|--------|
| 1 unit | `principal-coherence-operator-seam` | 5 | store→guard contract, both sides of the boundary |
| 2 integ | `principal-coherence-signal` | 5 | over the wire; gating both sides; block-verdict never 422s |
| 3 e2e | `principal-coherence-lifecycle` | 4 | production boot, feature-is-alive, signal-only proof, flag-off dark |

Clean `tsc --noEmit`; lint clean; docs-coverage `--check` passes (no new route); repo-invariants pass. Tier-1 ceremony: ELI16 + side-effects artifact + release fragment + trace shipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
