### PR TITLE
fix(projects): resolve canonical-main ref for the merged gate (#866 sibling)

### DIFF
--- a/.instar/instar-dev-decisions/2026-06-06T09-14-42-034Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-06-06T09-14-42-034Z-unknown.json
@@ -1,0 +1,13 @@
+{
+  "ts": "2026-06-06T09:14:42.034Z",
+  "slug": "unknown",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 2,
+  "loc": 73,
+  "causalAutopsy": null,
+  "verdict": "pass"
+}

--- a/.instar/instar-dev-decisions/2026-06-06T09-24-36-635Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-06-06T09-24-36-635Z-unknown.json
@@ -1,0 +1,13 @@
+{
+  "ts": "2026-06-06T09:24:36.635Z",
+  "slug": "unknown",
+  "suggestedTier": 1,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 2,
+  "causalAutopsy": null,
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-06-06T09-27-28-259Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-06-06T09-27-28-259Z-unknown.json
@@ -1,0 +1,13 @@
+{
+  "ts": "2026-06-06T09:27:28.259Z",
+  "slug": "unknown",
+  "suggestedTier": 1,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 2,
+  "causalAutopsy": null,
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-06-06T09-27-56-750Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-06-06T09-27-56-750Z-unknown.json
@@ -1,0 +1,13 @@
+{
+  "ts": "2026-06-06T09:27:56.750Z",
+  "slug": "unknown",
+  "suggestedTier": 1,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 2,
+  "causalAutopsy": null,
+  "verdict": "pass"
+}

--- a/src/core/StageTransitionValidator.ts
+++ b/src/core/StageTransitionValidator.ts
@@ -56,6 +56,13 @@ export interface ValidationContext {
   readSpecFrontmatter?: (absPath: string) => Promise<unknown>;
   ghPrView?: (prNumber: number) => Promise<GhPrView>;
   gitMergeBaseIsAncestor?: (sha: string, branch: string) => boolean;
+  /**
+   * The canonical-main ref the merge commit must be reachable from. Defaults to
+   * `origin/main`. On a fork-origin checkout (dev-agent home: origin = the
+   * fork, merges on the upstream remote) the route resolves the upstream
+   * remote and passes `<remote>/main` here. (#866 sibling fix.)
+   */
+  mergeBaseBranch?: string;
 }
 
 export interface GhPrView {
@@ -248,11 +255,19 @@ export async function validateStageTransition(
         code: 'MERGE_BASE_HELPER_UNAVAILABLE',
       };
     }
-    const ancestor = ctx.gitMergeBaseIsAncestor(oid, 'origin/main');
+    // The canonical-main ref defaults to `origin/main`, but on a dev-agent
+    // home `origin` is the agent's FORK (instar-echo) while merges land on the
+    // upstream remote (JKHeadley/instar) — so origin/main never contains the
+    // merge commit and every advance failed MERGE_COMMIT_UNREACHABLE. The
+    // route now resolves the remote whose URL matches the gh-resolved PR repo
+    // and passes it as `mergeBaseBranch`; this default preserves prior behavior
+    // for canonical-origin installs.
+    const mergeBaseBranch = ctx.mergeBaseBranch ?? 'origin/main';
+    const ancestor = ctx.gitMergeBaseIsAncestor(oid, mergeBaseBranch);
     if (!ancestor) {
       return {
         ok: false,
-        reason: `mergeCommit.oid ${oid} is not reachable from origin/main`,
+        reason: `mergeCommit.oid ${oid} is not reachable from ${mergeBaseBranch}`,
         code: 'MERGE_COMMIT_UNREACHABLE',
       };
     }

--- a/src/server/routes.ts
+++ b/src/server/routes.ts
@@ -874,6 +874,54 @@ function hashAuthHeader(header: unknown): string {
 }
 
 /**
+ * Resolve the canonical-main ref a merged PR's commit must be reachable from,
+ * for the projects `building → merged` gate (StageTransitionValidator).
+ *
+ * Default is `origin/main`. But on a dev-agent home `origin` is the agent's
+ * FORK (e.g. instar-echo) while PRs merge on the UPSTREAM repo (JKHeadley/instar),
+ * so origin/main never contains the merge commit → every advance failed
+ * MERGE_COMMIT_UNREACHABLE. We ask gh which repo it resolves for this cwd
+ * (the same repo `gh pr view` reads), then find the LOCAL remote whose URL
+ * points at that repo and return `<remote>/main`. Falls back to `origin/main`
+ * when gh or the remote mapping is unavailable (canonical-origin installs).
+ *
+ * READ-ONLY: `gh repo view` + `git remote -v` (the latter via
+ * SafeGitExecutor.readSync — `remote` is a READONLY_GIT_VERB, shape-checked
+ * to list/get-url only).
+ */
+function resolveCanonicalMainRef(repoPath: string): string {
+  const FALLBACK = 'origin/main';
+  try {
+    const ghRepo = execFileSync('gh', ['repo', 'view', '--json', 'nameWithOwner', '-q', '.nameWithOwner'], {
+      cwd: repoPath,
+      encoding: 'utf-8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    }).trim();
+    if (!ghRepo) return FALLBACK;
+    // `git remote -v` is read-only (shape-checked by readSync). Find the remote
+    // whose fetch URL contains the gh-resolved "owner/repo".
+    const remotesOut = SafeGitExecutor.readSync(['remote', '-v'], {
+      cwd: repoPath,
+      operation: 'projects.advance.resolveCanonicalMainRef',
+      encoding: 'utf-8',
+    });
+    for (const line of remotesOut.split('\n')) {
+      // format: "<name>\t<url> (fetch)"
+      const m = /^(\S+)\s+(\S+)\s+\(fetch\)/.exec(line.trim());
+      if (!m) continue;
+      const [, name, url] = m;
+      // match owner/repo with or without a trailing .git
+      if (url.includes(ghRepo) || url.includes(`${ghRepo}.git`)) {
+        return `${name}/main`;
+      }
+    }
+    return FALLBACK;
+  } catch {
+    return FALLBACK; // gh missing / not a gh repo / git error → preserve default
+  }
+}
+
+/**
  * Read-check-increment for the per-token projects-creation counter.
  * Returns `{ok: true}` if the request is within the 5/hour window, or
  * `{ok: false, windowEnds}` if the limit is reached.
@@ -8298,6 +8346,12 @@ export function createRoutes(ctx: RouteContext): Router {
           return false; // exit 1 = not an ancestor; any other failure = treat as not-ancestor (validator re-checks)
         }
       },
+      // Resolve the canonical-main ref the merge commit must be reachable from.
+      // The validator defaults to `origin/main`, but on a dev-agent home `origin`
+      // is the agent's FORK while merges land on the upstream remote — so we map
+      // the gh-resolved PR repo (e.g. JKHeadley/instar) to the LOCAL remote whose
+      // URL points at it and use `<remote>/main`. Falls back to `origin/main`.
+      mergeBaseBranch: resolveCanonicalMainRef(project.targetRepoPath),
     };
 
     const fromStage =

--- a/src/server/routes.ts
+++ b/src/server/routes.ts
@@ -916,7 +916,7 @@ function resolveCanonicalMainRef(repoPath: string): string {
       }
     }
     return FALLBACK;
-  } catch {
+  } catch { /* @silent-fallback-ok: resolving the canonical-main ref is best-effort — gh missing / not-a-gh-repo / git error falls back to the documented `origin/main` default (the prior behavior), which the merge-base gate then re-validates. Not a degradation: it's the conservative default this resolver exists to refine, not replace. */
     return FALLBACK; // gh missing / not a gh repo / git error → preserve default
   }
 }

--- a/tests/unit/StageTransitionValidator.test.ts
+++ b/tests/unit/StageTransitionValidator.test.ts
@@ -227,6 +227,50 @@ describe('StageTransitionValidator', () => {
     if (!r.ok) expect(r.code).toBe('MERGE_COMMIT_UNREACHABLE');
   });
 
+  it('building → merged: uses ctx.mergeBaseBranch when provided (fork-origin agent home) [#866 sibling]', async () => {
+    // On a dev-agent home, origin = the fork; merges land on upstream. The
+    // route resolves the upstream remote and passes mergeBaseBranch; the
+    // helper must be called with THAT ref, not the hardcoded origin/main.
+    let seenBranch = '';
+    const ctx: ValidationContext = {
+      targetRepoPath: tmpRepo,
+      prNumber: 42,
+      mergeBaseBranch: 'upstream/main',
+      ghPrView: async () => ({
+        state: 'MERGED',
+        mergeCommit: { oid: 'a1b2c3d4e5f60708' },
+        statusCheckRollup: [{ conclusion: 'SUCCESS' }],
+      }),
+      gitMergeBaseIsAncestor: (sha, branch) => {
+        seenBranch = branch;
+        return sha === 'a1b2c3d4e5f60708' && branch === 'upstream/main';
+      },
+    };
+    const r = await validateStageTransition('building', 'merged', ctx);
+    expect(seenBranch).toBe('upstream/main'); // not the origin/main default
+    expect(r.ok).toBe(true);
+  });
+
+  it('building → merged: unreachable error names the configured branch', async () => {
+    const ctx: ValidationContext = {
+      targetRepoPath: tmpRepo,
+      prNumber: 42,
+      mergeBaseBranch: 'upstream/main',
+      ghPrView: async () => ({
+        state: 'MERGED',
+        mergeCommit: { oid: 'aaaaaaa' },
+        statusCheckRollup: [{ conclusion: 'SUCCESS' }],
+      }),
+      gitMergeBaseIsAncestor: () => false,
+    };
+    const r = await validateStageTransition('building', 'merged', ctx);
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.code).toBe('MERGE_COMMIT_UNREACHABLE');
+      expect(r.reason).toContain('upstream/main');
+    }
+  });
+
   it('building → merged: rejects when state is OPEN', async () => {
     const ctx: ValidationContext = {
       targetRepoPath: tmpRepo,

--- a/upgrades/next/projects-mergebranch-resolve.md
+++ b/upgrades/next/projects-mergebranch-resolve.md
@@ -1,0 +1,30 @@
+<!-- bump: patch -->
+
+## What Changed
+
+Sibling fix to #866: the projects `building → merged` gate's merge-base check
+was hardcoded to `origin/main`, which broke on dev-agent homes where `origin`
+is the agent's fork and merges land on the upstream remote (every advance
+failed MERGE_COMMIT_UNREACHABLE despite the PR merging). The validator now
+reads `ctx.mergeBaseBranch` (default `origin/main` preserved) and the route
+resolves it via `resolveCanonicalMainRef()` — maps the gh-resolved PR repo to
+the local remote whose URL matches and uses `<remote>/main`. Read-only
+(gh repo view + git remote -v through SafeGitExecutor.readSync).
+
+## What to Tell Your User
+
+On the machines you actually develop on, the projects pipeline can now record
+a step as "merged" correctly — before, it always errored because it checked
+the wrong copy of the main branch. Canonical installs are unaffected.
+
+## Summary of New Capabilities
+
+- The `building → merged` project advance now works on fork-origin dev-agent
+  checkouts (resolves the real upstream main), in addition to canonical-origin
+  installs. No new endpoint — completes #866's pipeline fix.
+
+## Evidence
+
+- tests/unit/StageTransitionValidator.test.ts: helper is called with the
+  configured mergeBaseBranch (not the origin/main default); unreachable error
+  names it. 28 validator + 45 projects-api tests green; tsc + lint clean.

--- a/upgrades/projects-mergebranch-resolve.eli16.md
+++ b/upgrades/projects-mergebranch-resolve.eli16.md
@@ -7,3 +7,5 @@ This is a sibling of the same class as #866: code that assumed the common-case e
 The fix: instead of hardcoding "origin/main", the route now asks GitHub which repo it's actually talking to (the same repo the PR-view reads), finds the LOCAL remote whose URL points at that repo, and checks "<that-remote>/main". On a normal install that resolves right back to origin/main (unchanged behavior); on a fork-origin agent home it correctly resolves to the upstream remote where the merges live. Both lookups are read-only (a GitHub repo-view and a git remote listing).
 
 With this, the projects pipeline can finally record merged steps on the machines we actually develop on — which is the whole point of being able to track an initiative through to "merged."
+
+_Follow-up note: on any lookup error the resolver simply uses the standard default — by design, not as a failure._

--- a/upgrades/projects-mergebranch-resolve.eli16.md
+++ b/upgrades/projects-mergebranch-resolve.eli16.md
@@ -1,0 +1,9 @@
+# Projects "merged" check now works on dev-agent homes too
+
+Tonight's #866 fix wired the GitHub-PR verification into the projects pipeline's "building → merged" step — and it works: it resolves the PR, confirms it merged, gets the merge commit. But the very next check then failed on a dev-agent machine: the validator confirms the merge commit is actually on the main branch by checking "origin/main". On a normal install that's right. On a developer agent's home checkout, though, "origin" points at the agent's personal FORK, while the real merges land on the UPSTREAM repo under a differently-named remote. So origin/main never contains the commit, and every attempt to record a step as merged failed with "commit not reachable from origin/main" — even though the PR genuinely merged.
+
+This is a sibling of the same class as #866: code that assumed the common-case environment and broke on the dev-agent's fork-origin layout. I hit it the moment #866's fix let me get that far — trying to mark this very initiative's own rounds merged.
+
+The fix: instead of hardcoding "origin/main", the route now asks GitHub which repo it's actually talking to (the same repo the PR-view reads), finds the LOCAL remote whose URL points at that repo, and checks "<that-remote>/main". On a normal install that resolves right back to origin/main (unchanged behavior); on a fork-origin agent home it correctly resolves to the upstream remote where the merges live. Both lookups are read-only (a GitHub repo-view and a git remote listing).
+
+With this, the projects pipeline can finally record merged steps on the machines we actually develop on — which is the whole point of being able to track an initiative through to "merged."

--- a/upgrades/side-effects/projects-mergebranch-resolve.md
+++ b/upgrades/side-effects/projects-mergebranch-resolve.md
@@ -49,3 +49,5 @@ Completes the #866 chain: the projects pipeline can now record merged steps on d
 
 ## Evidence pointers
 - `tests/unit/StageTransitionValidator.test.ts` — new cases: helper called with the configured `mergeBaseBranch` (not origin/main); unreachable error names the configured branch. 28 validator tests + 45 projects-api green; tsc + destructive-lint clean.
+
+_Follow-up: the resolver catch carries an `@silent-fallback-ok` note — falling back to the `origin/main` default is the conservative behavior this resolver refines, not a swallowed error._

--- a/upgrades/side-effects/projects-mergebranch-resolve.md
+++ b/upgrades/side-effects/projects-mergebranch-resolve.md
@@ -1,0 +1,51 @@
+# Side-Effects Review — projects merge-base branch resolution (#866 sibling)
+
+**Version / slug:** `projects-mergebranch-resolve`
+**Date:** `2026-06-06`
+**Author:** `echo`
+**Second-pass reviewer:** `not required — small read-only environment fix + unit coverage`
+
+## Summary of the change
+
+After #866 wired ghPrView, the `building → merged` gate's NEXT check —
+`gitMergeBaseIsAncestor(oid, 'origin/main')` — failed on fork-origin dev-agent
+homes: `origin` is the agent's fork (instar-echo) while merges land on the
+upstream remote (JKHeadley/instar), so origin/main never contains the merge
+commit (MERGE_COMMIT_UNREACHABLE). Fix: `StageTransitionValidator` reads the
+branch from a new `ctx.mergeBaseBranch` (default `origin/main`, behavior
+preserved); the route computes it via `resolveCanonicalMainRef()` — asks gh
+which repo it resolves for the cwd, maps that to the local remote whose URL
+matches, returns `<remote>/main`, falling back to `origin/main`.
+
+## Decision-point inventory
+- `building → merged` merge-base check — was hardcoded `origin/main`, now uses the resolved canonical-main ref. The check's logic is unchanged; only the ref it compares against is now environment-correct.
+
+## 1. Over-block
+Before: fork-origin homes 100% over-blocked (every merged transition rejected though the PR merged). After: rejects only when the commit truly isn't on the canonical main. Strict improvement. Canonical-origin installs unchanged (resolves to origin/main).
+
+## 2. Under-block
+If gh/remote resolution misfires it falls back to `origin/main` (the prior behavior) — never a more-permissive ref, so no new under-block. The resolved remote must actually contain the commit or the gate still rejects.
+
+## 3. Level-of-abstraction fit
+Validator stays pure (takes the branch as input); the environment resolution lives in the route (where gh/git + cwd are). Right seam — mirrors how #866 injected the helpers.
+
+## 4. Signal vs authority compliance
+**Required reference:** [docs/signal-vs-authority.md](../../docs/signal-vs-authority.md)
+- [x] No — the gate remains a real check (commit reachability on canonical main); this only supplies the correct ref.
+
+## 5. Interactions
+- `resolveCanonicalMainRef` is read-only: `gh repo view` (gh, not funnel-gated) + `git remote -v` via SafeGitExecutor.readSync (`remote` is a READONLY_GIT_VERB, shape-checked list/get-url only).
+- Any failure → fallback `origin/main`; never throws into the route.
+- No interaction with the other advance edges (outline→spec, etc.) — only the merged edge reads mergeBaseBranch.
+
+## 6. External surfaces
+- Spawns `gh repo view` + `git remote -v` against the project target repo when a merged transition is attempted. No persistent state, no messaging, no fleet surface.
+
+## 7. Rollback cost
+Pure code revert + patch. No state.
+
+## Conclusion
+Completes the #866 chain: the projects pipeline can now record merged steps on dev-agent homes (fork-origin) as well as canonical-origin installs. Clear to ship.
+
+## Evidence pointers
+- `tests/unit/StageTransitionValidator.test.ts` — new cases: helper called with the configured `mergeBaseBranch` (not origin/main); unreachable error names the configured branch. 28 validator tests + 45 projects-api green; tsc + destructive-lint clean.


### PR DESCRIPTION
## ELI16 overview (plain English)

#866 wired the GitHub-PR check into the projects "building → merged" step and it works — resolves the PR, confirms merged, gets the commit. But the very next check then failed on a dev-agent machine: it confirms the merge commit is on main by checking "origin/main", and on a developer's home checkout "origin" is the agent's personal FORK while the real merges land on the UPSTREAM remote. So origin/main never has the commit and every merged-advance failed "not reachable from origin/main" — though the PR genuinely merged. Same class as #866: assumed the common environment, broke on the fork-origin dev layout. Hit it the moment #866 let the advance get that far.

Fix: instead of hardcoding origin/main, the route asks gh which repo it resolves for the cwd, finds the local remote whose URL points there, and checks "<that-remote>/main". Canonical installs resolve right back to origin/main (unchanged); fork-origin agent homes resolve to the upstream remote. Both lookups read-only (gh repo view + git remote -v via SafeGitExecutor.readSync). The validator now takes the branch as input (default origin/main preserved).

## Evidence

- tests/unit/StageTransitionValidator.test.ts — new cases: the merge-base helper is called with the configured branch (not the origin/main default); the unreachable error names the configured branch. 28 validator + 45 projects-api tests green; tsc + destructive-lint clean.

🤖 Generated with Claude Code