### PR TITLE
fix(config): carry sessions.componentFrameworks from config.json into the loaded config

### DIFF
--- a/.instar/instar-dev-decisions/2026-06-06T09-58-02-675Z-componentframeworks-load-fix.json
+++ b/.instar/instar-dev-decisions/2026-06-06T09-58-02-675Z-componentframeworks-load-fix.json
@@ -1,0 +1,16 @@
+{
+  "ts": "2026-06-06T09:58:02.675Z",
+  "slug": "componentframeworks-load-fix",
+  "suggestedTier": 1,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 12,
+  "causalAutopsy": {
+    "origin": "latent",
+    "notes": "Latent since per-component-framework-routing shipped: feature tests built config objects in-memory, never exercising the file-load path, so the documented .instar/config.json surface was dead fleet-wide. Surfaced 2026-06-06 when the first real file-config swap (sentinels->codex on Echo) was VERIFIED against GET /intelligence/routing instead of assumed."
+  },
+  "verdict": "pass"
+}

--- a/docs/eli16/componentframeworks-load-fix.eli16.md
+++ b/docs/eli16/componentframeworks-load-fix.eli16.md
@@ -1,0 +1,34 @@
+# componentFrameworks Load Fix — ELI16
+
+## What this fixes
+
+instar has a feature that lets different background workers run on different
+AI providers — e.g. "run all my sentinels on Codex instead of Claude" — and
+the docs tell you to turn it on with one setting in the agent's config file.
+Tonight we actually tried to use that setting for real, on a live agent, and
+discovered it does NOTHING: the part of instar that reads the config file
+never copied that setting into the running program. The feature itself works
+fine — but the documented switch for it was a dead wire, on every agent,
+since the feature shipped.
+
+## Why nobody noticed
+
+The feature's tests built their configuration in memory (directly in code),
+which skips the file-reading step entirely. So every test passed while the
+real-world path — write the setting in the file, boot the agent — silently
+dropped it. Classic wiring gap: each half works, the connection between them
+was never tested.
+
+## The fix
+
+One small change: the config loader now carries the setting from the file
+into the running config, exactly like it does for its neighbors. Plus two
+new tests that do what the old tests never did — write a REAL config file
+with the setting, load it the REAL way, and check the setting survived. One
+test proves it's carried; one proves nothing phantom appears when the
+setting is absent.
+
+## What changes for users
+
+If you set componentFrameworks in your config file, it now actually works
+after the next update. Nothing changes for anyone who never set it.

--- a/src/core/Config.ts
+++ b/src/core/Config.ts
@@ -852,6 +852,18 @@ export function loadConfig(projectDir?: string): InstarConfig {
     anthropicApiKey: fileConfig.sessions?.anthropicApiKey as string | undefined,
     anthropicBaseUrl: fileConfig.sessions?.anthropicBaseUrl as string | undefined,
     credentials: buildCredentialsMap(fileConfig.sessions as Record<string, unknown> | undefined),
+    // Per-component framework routing (docs/specs/per-component-framework-routing.md).
+    // LOAD-PATH FIX (2026-06-06): this field was documented + consumed
+    // (IntelligenceRouter's resolveConfig reads config.sessions.componentFrameworks
+    // live) but NEVER copied from the config FILE here — so the documented
+    // `.instar/config.json` surface was silently dead on every deployed agent
+    // (the feature's tests built config objects in-memory, which is why the
+    // file-load gap never surfaced). Pass it through; the router validates
+    // values per-call (unknown frameworks degrade to the default + report).
+    ...(fileConfig.sessions?.componentFrameworks &&
+    typeof fileConfig.sessions.componentFrameworks === 'object'
+      ? { componentFrameworks: fileConfig.sessions.componentFrameworks }
+      : {}),
     // pi-cli subscription-guard override (PI-HARNESS-INTEGRATION-SPEC §4.3).
     // Config surface: top-level `piCli.allowAnthropicProviders` — file-config
     // only, deliberately NOT an env var (no per-boot bypass surface).

--- a/tests/unit/Config.test.ts
+++ b/tests/unit/Config.test.ts
@@ -48,6 +48,55 @@ describe('Config', () => {
       SafeFsExecutor.safeRmSync(tmpDir, { recursive: true, force: true, operation: 'tests/unit/Config.test.ts:48' });
     });
 
+    it('carries sessions.componentFrameworks from config.json into the loaded config (load-path wiring)', () => {
+      // REGRESSION (2026-06-06): the per-component framework routing feature
+      // read config.sessions.componentFrameworks live (IntelligenceRouter
+      // resolveConfig), and the docs told users to set it in
+      // `.instar/config.json` — but Config.load never copied the field from
+      // the file, so the documented surface was silently DEAD on every
+      // deployed agent. This is the exact-gap test: a FILE-loaded config must
+      // carry the routing table.
+      const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'instar-config-test-'));
+      const stateDir = path.join(tmpDir, '.instar');
+      fs.mkdirSync(stateDir, { recursive: true });
+
+      const routing = {
+        categories: { sentinel: 'codex-cli' },
+        overrides: { CoherenceReviewer: 'claude-code' },
+      };
+      fs.writeFileSync(
+        path.join(stateDir, 'config.json'),
+        JSON.stringify({
+          sessions: {
+            framework: 'claude-code',
+            claudePath: '/usr/local/bin/claude',
+            tmuxPath: '/usr/bin/tmux',
+            componentFrameworks: routing,
+          },
+        }),
+      );
+
+      const config = loadConfig(tmpDir);
+      expect(config.sessions.componentFrameworks).toEqual(routing);
+
+      SafeFsExecutor.safeRmSync(tmpDir, { recursive: true, force: true, operation: 'tests/unit/Config.test.ts:componentFrameworks' });
+    });
+
+    it('omits componentFrameworks when absent from the file (no phantom field)', () => {
+      const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'instar-config-test-'));
+      const stateDir = path.join(tmpDir, '.instar');
+      fs.mkdirSync(stateDir, { recursive: true });
+      fs.writeFileSync(
+        path.join(stateDir, 'config.json'),
+        JSON.stringify({
+          sessions: { framework: 'claude-code', claudePath: '/usr/local/bin/claude', tmuxPath: '/usr/bin/tmux' },
+        }),
+      );
+      const config = loadConfig(tmpDir);
+      expect(config.sessions.componentFrameworks).toBeUndefined();
+      SafeFsExecutor.safeRmSync(tmpDir, { recursive: true, force: true, operation: 'tests/unit/Config.test.ts:componentFrameworks-absent' });
+    });
+
     it('respects sessions.tmuxPath from config.json instead of auto-detecting', () => {
       const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'instar-config-test-'));
       const stateDir = path.join(tmpDir, '.instar');

--- a/upgrades/next/componentframeworks-load-fix.md
+++ b/upgrades/next/componentframeworks-load-fix.md
@@ -24,3 +24,22 @@ original in-memory-config tests never exercised.
 Only if they previously tried per-component framework routing and concluded it
 didn't work: it was a config-loading bug, now fixed — their config.json
 setting will take effect after this update.
+
+## Evidence
+
+Reproduced LIVE on the echo agent (v1.3.360, 2026-06-06 ~09:50Z):
+1. Wrote `{"sessions": {"componentFrameworks": {"categories": {"sentinel":
+   "codex-cli"}}}}` into `.instar/config.json` (verified on disk, mtime
+   confirmed surviving the restart).
+2. Restarted the server (launchd kickstart; fresh boot read the file).
+3. **Before fix:** `GET /intelligence/routing` still reported all 13 sentinel
+   components on `claude-code` — the file field never reached the router
+   (`grep componentFrameworks dist/core/Config.js` → 0 matches in the
+   deployed loader; the field is consumed in IntelligenceRouter.js +
+   commands/server.js but never loaded).
+4. **After fix (this branch):** the new exact-gap regression test loads a
+   REAL config file through `loadConfig()` and the returned
+   `config.sessions.componentFrameworks` carries the table — failing on
+   pre-fix code, passing post-fix. (Live post-fix routing verification on
+   echo happens after this releases and is the first task of the observation
+   session tracking the swap.)

--- a/upgrades/next/componentframeworks-load-fix.md
+++ b/upgrades/next/componentframeworks-load-fix.md
@@ -1,0 +1,26 @@
+<!-- bump: patch -->
+
+## What Changed
+
+Fixed a fleet-wide silent config drop: `sessions.componentFrameworks` (the
+documented `.instar/config.json` surface for per-component framework routing —
+"run my sentinels on Codex") was never copied from the config file by
+`Config.load`, so the IntelligenceRouter's live read always saw undefined and
+the file setting did NOTHING on every deployed agent since the feature
+shipped. The loader now carries the field (object-typed values only; absent →
+omitted, pinned by a no-phantom-field test), with an exact-gap regression test
+that loads a REAL config file through `loadConfig()` — the path the feature's
+original in-memory-config tests never exercised.
+
+## Summary of New Capabilities
+
+- **componentFrameworks file-config now works** — setting
+  `sessions.componentFrameworks` in `.instar/config.json` (e.g.
+  `{"categories": {"sentinel": "codex-cli"}}`) actually routes internal
+  components after a server restart, as the docs always claimed.
+
+## What to Tell Your User
+
+Only if they previously tried per-component framework routing and concluded it
+didn't work: it was a config-loading bug, now fixed — their config.json
+setting will take effect after this update.

--- a/upgrades/side-effects/componentframeworks-load-fix.md
+++ b/upgrades/side-effects/componentframeworks-load-fix.md
@@ -1,0 +1,34 @@
+# Side-Effects Review — componentFrameworks load-path fix
+
+## Blast radius
+
+One field passthrough in `Config.load`'s sessions construction:
+`fileConfig.sessions.componentFrameworks` → `config.sessions.componentFrameworks`
+(object-typed values only; absent/invalid → field omitted, exactly as today).
+
+- Agents that never set the field: byte-identical loaded config (the
+  no-phantom-field test pins this).
+- Agents that set it (per the docs): the IntelligenceRouter's
+  `resolveConfig()` now actually sees it — the documented behavior finally
+  happens. The router already validates per-call: unknown/unavailable
+  frameworks degrade to the default framework WITH a DegradationReporter
+  emission, so a bad value cannot break the LLM path.
+
+## Framework generality
+
+The fix is framework-agnostic by construction — it carries the whole routing
+table (categories/overrides/default for any of claude-code / codex-cli /
+gemini-cli / pi-cli) without interpreting it; per-framework validation stays
+in the router where it already lives.
+
+## Why it was missed (causal)
+
+Latent since the per-component-framework-routing feature shipped: its tests
+constructed config OBJECTS in memory, never exercising the file-load path.
+The exact-gap regression test added here loads a REAL file through
+`loadConfig()`.
+
+## Rollback
+
+Revert the commit — the field returns to being dropped (the pre-fix
+behavior). No data migrations, no state changes.


### PR DESCRIPTION
## The bug (fleet-wide silent config drop)

`sessions.componentFrameworks` — the documented `.instar/config.json` surface for per-component framework routing ("run my sentinels on Codex") — was never copied from the config file by `Config.load`. The IntelligenceRouter's `resolveConfig: () => config.sessions?.componentFrameworks` always saw `undefined`, so the file setting did NOTHING on every deployed agent since the feature shipped. The feature's tests built config objects in-memory, which is why the file-load gap never surfaced.

**Surfaced + reproduced live tonight** (topic 20390, echo @ v1.3.360): config written + verified on disk → server restarted → `GET /intelligence/routing` still showed all 13 sentinels on claude-code; `grep componentFrameworks dist/core/Config.js` → 0 matches in the deployed loader.

## The fix

Object-guarded passthrough in the sessions construction + two exact-gap regression tests through `loadConfig()` on a REAL file (field carried; absent field stays absent — no phantom). The router already validates values per-call (unknown/unavailable frameworks degrade to default + DegradationReporter), so bad values can't break the LLM path. No behavior change for configs that never set the field.

## ELI16

instar has a switch in its config file that's supposed to let background workers run on a different AI provider (e.g. sentinels on Codex). We flipped it for real tonight and discovered the switch was a dead wire — the config reader never picked it up, on every agent, since the feature shipped. The feature worked; the documented way to turn it on didn't. This fix connects the wire and adds the test the original feature never had: write the setting in a real file, load it the real way, check it survived. Nothing changes for anyone who never touched the setting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)