### PR TITLE
fix(security): per-agent identity isolation in SafeGitExecutor — repo-local identity beats inherited env (Inc-P3a)

### DIFF
--- a/.instar/instar-dev-decisions/2026-06-06T10-03-48-363Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-06-06T10-03-48-363Z-unknown.json
@@ -1,0 +1,15 @@
+{
+  "ts": "2026-06-06T10:03:48.363Z",
+  "slug": "unknown",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "safety-invariant proximity: src/core/SafeGitExecutor.ts matches SafeGitExecutor (destructive-git funnel)"
+  ],
+  "belowFloor": true,
+  "files": 1,
+  "loc": 88,
+  "causalAutopsy": null,
+  "verdict": "pass"
+}

--- a/.instar/instar-dev-decisions/2026-06-06T10-19-42-324Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-06-06T10-19-42-324Z-unknown.json
@@ -1,0 +1,15 @@
+{
+  "ts": "2026-06-06T10:19:42.324Z",
+  "slug": "unknown",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "safety-invariant proximity: src/core/SafeGitExecutor.ts matches SafeGitExecutor (destructive-git funnel)"
+  ],
+  "belowFloor": true,
+  "files": 1,
+  "loc": 80,
+  "causalAutopsy": null,
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-06-06T10-20-25-750Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-06-06T10-20-25-750Z-unknown.json
@@ -1,0 +1,15 @@
+{
+  "ts": "2026-06-06T10:20:25.750Z",
+  "slug": "unknown",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "safety-invariant proximity: src/core/SafeGitExecutor.ts matches SafeGitExecutor (destructive-git funnel)"
+  ],
+  "belowFloor": true,
+  "files": 1,
+  "loc": 80,
+  "causalAutopsy": null,
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-06-06T10-21-17-763Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-06-06T10-21-17-763Z-unknown.json
@@ -1,0 +1,15 @@
+{
+  "ts": "2026-06-06T10:21:17.763Z",
+  "slug": "unknown",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "safety-invariant proximity: src/core/SafeGitExecutor.ts matches SafeGitExecutor (destructive-git funnel)"
+  ],
+  "belowFloor": true,
+  "files": 1,
+  "loc": 80,
+  "causalAutopsy": null,
+  "verdict": "pass"
+}

--- a/docs/specs/cred-isolation-p3a.eli16.md
+++ b/docs/specs/cred-isolation-p3a.eli16.md
@@ -1,0 +1,46 @@
+# Per-agent identity isolation, increment P3a — ELI16
+
+## What this is
+
+When several AI agents (and several people) share one computer, git has a
+dangerous habit: an environment variable like `GIT_AUTHOR_NAME`, set by
+whatever shell happened to launch the agent, silently outranks the identity
+configured inside the agent's own repository. That is exactly how the
+"Caroline" incident started — an agent on a shared Mac picked up another
+person's identity from machine-global state and carried it as its own.
+
+Instar already routes every dangerous git command through one funnel
+(SafeGitExecutor). This change teaches that funnel a simple rule: **if the
+repository being operated on has its own local identity configured — which
+every agent worktree and agent home does — that local identity always wins.**
+Any `GIT_AUTHOR_*` / `GIT_COMMITTER_*` variables that leaked in from the
+spawning shell are stripped before git runs, so git falls through to the
+repo's own config: the agent's name, the agent's email.
+
+## What changed, concretely
+
+One file of logic (`src/core/SafeGitExecutor.ts`):
+
+1. A new check asks the target repository: "do you have a LOCAL `user.name`
+   and `user.email`?" (read with `git config --local`, cached per directory).
+2. If yes — the four identity environment variables are deleted from the
+   child environment. The repo-local identity is now the only identity git
+   can see.
+3. If no — nothing changes from before: the funnel keeps injecting the host
+   machine's identity as a fallback so ordinary (non-agent) installs don't
+   suddenly fail with "Author identity unknown".
+
+Five new unit tests cover both sides of the boundary, including a literal
+"Caroline replay": a commit made through the funnel with a fully polluted
+environment (`GIT_AUTHOR_NAME=Caroline`, etc.) and the test asserts the
+commit lands as the repo's local identity — not Caroline.
+
+## Why it's safe
+
+The change is scoped to the funnel and conditioned on the repo having a
+local identity. Repos without one keep byte-for-byte the previous behavior.
+Raw `git` commands an agent types in a shell are not affected (they never
+were the funnel's job); this closes the path where instar's own machinery
+could be tricked into committing as the wrong principal. No config flag, no
+route, no migration — pure hardening at the single choke point that already
+exists for exactly this kind of rule.

--- a/docs/specs/cred-isolation-p3a.eli16.md
+++ b/docs/specs/cred-isolation-p3a.eli16.md
@@ -44,3 +44,14 @@ were the funnel's job); this closes the path where instar's own machinery
 could be tricked into committing as the wrong principal. No config flag, no
 route, no migration — pure hardening at the single choke point that already
 exists for exactly this kind of rule.
+
+## Addendum — how the repo is probed (CI-hardening revision)
+
+The "does this repo have its own identity?" check reads the repository's
+config file directly from disk (following the worktree pointer file when the
+repo is a linked worktree) instead of spawning a git subprocess. Two reasons:
+it is faster and has no side effects, and — discovered by CI — several unit
+tests script the exact sequence of git subprocess calls they expect, so an
+extra probe subprocess from inside the funnel would silently shift those
+sequences and break unrelated tests. Reading the file can't interfere with
+anything.

--- a/src/core/SafeGitExecutor.ts
+++ b/src/core/SafeGitExecutor.ts
@@ -216,7 +216,59 @@ function getHostGitIdentity(): { name?: string; email?: string } {
   };
 }
 
-function sanitizeEnv(callerEnv?: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
+// ── Per-agent identity isolation (Caroline-class gap 1, Phase-3 Inc-P3a) ──
+//
+// Git's native precedence puts GIT_AUTHOR_*/GIT_COMMITTER_* env vars ABOVE
+// repo-local config. On a shared machine that precedence is exactly the
+// credential/identity-bleed exposure: an agent spawned from a shell that
+// exports another person's GIT_AUTHOR_NAME silently commits as that person,
+// even though the agent's worktree has its own local user.name/user.email
+// (set by `instar worktree create` / init). The fix: when the target repo
+// HAS a local identity configured, the funnel strips inherited identity env
+// vars so the repo-local identity — the per-agent identity — always wins.
+// Repos WITHOUT a local identity keep the long-standing fallback behavior
+// (host identity injected only-if-empty) so non-agent installs don't break
+// with "Author identity unknown".
+const IDENTITY_ENV_VARS = [
+  'GIT_AUTHOR_NAME',
+  'GIT_AUTHOR_EMAIL',
+  'GIT_COMMITTER_NAME',
+  'GIT_COMMITTER_EMAIL',
+] as const;
+
+// Cache of "does this repo have a local user.name AND user.email" keyed on
+// the directory we run git in. Local config is stable for the life of a
+// process; tests reset via _resetLocalIdentityCacheForTest.
+const _localIdentityCache = new Map<string, boolean>();
+function repoHasLocalIdentity(cwd: string): boolean {
+  let key: string;
+  try {
+    key = path.resolve(cwd);
+  } catch {
+    return false;
+  }
+  const cached = _localIdentityCache.get(key);
+  if (cached !== undefined) return cached;
+  let has = false;
+  try {
+    const name = execFileSync('git', ['config', '--local', '--get', 'user.name'], {
+      cwd: key, encoding: 'utf-8', stdio: ['pipe', 'pipe', 'ignore'],
+    }).toString().trim();
+    const email = execFileSync('git', ['config', '--local', '--get', 'user.email'], {
+      cwd: key, encoding: 'utf-8', stdio: ['pipe', 'pipe', 'ignore'],
+    }).toString().trim();
+    has = Boolean(name && email);
+  } catch {
+    has = false; // not a repo / no local identity — fall back to host behavior
+  }
+  _localIdentityCache.set(key, has);
+  return has;
+}
+function _resetLocalIdentityCacheForTest(): void {
+  _localIdentityCache.clear();
+}
+
+function sanitizeEnv(callerEnv?: NodeJS.ProcessEnv, cwd?: string): NodeJS.ProcessEnv {
   // Start from a copy of process.env, then strip the denylist, then strip
   // anything the caller supplied that's on the denylist or that matches
   // GIT_CONFIG_KEY_* / GIT_CONFIG_VALUE_*.
@@ -230,15 +282,23 @@ function sanitizeEnv(callerEnv?: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
       delete merged[k];
     }
   }
-  // Preserve host git identity before we neutralize global config — without
-  // this, every commit through SafeGitExecutor would fail with "Author
-  // identity unknown" because the global config is at /dev/null. Identity is
-  // not an alias-attack vector; alias rebinding is.
-  const id = getHostGitIdentity();
-  if (id.name && !merged.GIT_AUTHOR_NAME) merged.GIT_AUTHOR_NAME = id.name;
-  if (id.email && !merged.GIT_AUTHOR_EMAIL) merged.GIT_AUTHOR_EMAIL = id.email;
-  if (id.name && !merged.GIT_COMMITTER_NAME) merged.GIT_COMMITTER_NAME = id.name;
-  if (id.email && !merged.GIT_COMMITTER_EMAIL) merged.GIT_COMMITTER_EMAIL = id.email;
+  // Per-agent identity isolation: a repo with its OWN local identity is
+  // authoritative — strip inherited identity env vars so git falls through
+  // to the repo-local config (the agent's identity), never a name that
+  // leaked in from the spawning shell or another principal on the machine.
+  if (repoHasLocalIdentity(cwd ?? process.cwd())) {
+    for (const k of IDENTITY_ENV_VARS) delete merged[k];
+  } else {
+    // Preserve host git identity before we neutralize global config — without
+    // this, every commit through SafeGitExecutor would fail with "Author
+    // identity unknown" because the global config is at /dev/null. Identity is
+    // not an alias-attack vector; alias rebinding is.
+    const id = getHostGitIdentity();
+    if (id.name && !merged.GIT_AUTHOR_NAME) merged.GIT_AUTHOR_NAME = id.name;
+    if (id.email && !merged.GIT_AUTHOR_EMAIL) merged.GIT_AUTHOR_EMAIL = id.email;
+    if (id.name && !merged.GIT_COMMITTER_NAME) merged.GIT_COMMITTER_NAME = id.name;
+    if (id.email && !merged.GIT_COMMITTER_EMAIL) merged.GIT_COMMITTER_EMAIL = id.email;
+  }
   // Inject unconditional config disables.
   merged.GIT_CONFIG_GLOBAL = '/dev/null';
   merged.GIT_CONFIG_SYSTEM = '/dev/null';
@@ -706,7 +766,7 @@ export class SafeGitExecutor {
       );
     }
 
-    const env = sanitizeEnv(opts.env);
+    const env = sanitizeEnv(opts.env, opts.cwd);
 
     let stdout: string;
     try {
@@ -753,7 +813,7 @@ export class SafeGitExecutor {
       );
     }
 
-    const env = sanitizeEnv(opts.env);
+    const env = sanitizeEnv(opts.env, opts.cwd);
     const spawnOpts: SpawnOptions = {
       cwd: opts.cwd,
       stdio: opts.stdio ?? 'pipe',
@@ -800,7 +860,7 @@ export class SafeGitExecutor {
       audit('git', opts.operation, verb, targets[0], 'allowed', 'sourceTree-bypass');
     }
 
-    const env = sanitizeEnv(opts.env);
+    const env = sanitizeEnv(opts.env, opts.cwd);
     let stdout: string;
     try {
       stdout = execFileSync('git', args as string[], {
@@ -949,6 +1009,8 @@ export const _internal = {
   isReadOnlyShape,
   sanitizeEnv,
   GIT_ENV_DENYLIST,
+  repoHasLocalIdentity,
+  _resetLocalIdentityCacheForTest,
 };
 
 // Suppress unused-export warnings for the convenience re-exports. The

--- a/src/core/SafeGitExecutor.ts
+++ b/src/core/SafeGitExecutor.ts
@@ -226,8 +226,8 @@ function getHostGitIdentity(): { name?: string; email?: string } {
 // (set by `instar worktree create` / init). The fix: when the target repo
 // HAS a local identity configured, the funnel strips inherited identity env
 // vars so the repo-local identity — the per-agent identity — always wins.
-// Repos WITHOUT a local identity keep the long-standing fallback behavior
-// (host identity injected only-if-empty) so non-agent installs don't break
+// Repos WITHOUT a local identity keep the long-standing host-identity
+// behavior (injected only-if-empty) so non-agent installs don't break
 // with "Author identity unknown".
 const IDENTITY_ENV_VARS = [
   'GIT_AUTHOR_NAME',
@@ -239,28 +239,78 @@ const IDENTITY_ENV_VARS = [
 // Cache of "does this repo have a local user.name AND user.email" keyed on
 // the directory we run git in. Local config is stable for the life of a
 // process; tests reset via _resetLocalIdentityCacheForTest.
+//
+// IMPORTANT: this probe reads .git/config via fs, NOT via a git subprocess.
+// Spawning `git config --local` here would route through child_process — and
+// unit tests that mock node:child_process with scripted mockReturnValueOnce
+// sequences (e.g. GitSync.test.ts) would have those sequences consumed and
+// misaligned by the probe. The fs read is also faster and side-effect-free.
 const _localIdentityCache = new Map<string, boolean>();
+
+/** Candidate config files that hold "repo-local" identity for `dir`. */
+function localConfigCandidates(dir: string): string[] {
+  const dotGit = path.join(dir, '.git');
+  let st: fs.Stats;
+  try {
+    st = fs.statSync(dotGit);
+  } catch {
+    return []; /* @silent-fallback-ok — not a git repo: legacy host-identity behavior applies */
+  }
+  if (st.isDirectory()) return [path.join(dotGit, 'config')];
+  // Linked worktree: .git is a file containing "gitdir: <path>". Its local
+  // config is the COMMON repo config (and config.worktree when the
+  // extensions.worktreeConfig overlay is enabled) — check both.
+  try {
+    const m = /^gitdir:\s*(.+?)\s*$/m.exec(fs.readFileSync(dotGit, 'utf-8'));
+    if (!m) return [];
+    const gitdir = path.resolve(dir, m[1]);
+    const candidates: string[] = [path.join(gitdir, 'config.worktree')];
+    const commondirFile = path.join(gitdir, 'commondir');
+    if (fs.existsSync(commondirFile)) {
+      const common = path.resolve(gitdir, fs.readFileSync(commondirFile, 'utf-8').trim());
+      candidates.push(path.join(common, 'config'));
+    } else {
+      candidates.push(path.join(gitdir, 'config'));
+    }
+    return candidates;
+  } catch {
+    return []; /* @silent-fallback-ok — unreadable worktree pointer: legacy host-identity behavior applies */
+  }
+}
+
+/** Minimal git-config parse: does the [user] section define `key`? */
+function configDefines(file: string, key: 'name' | 'email'): boolean {
+  let content: string;
+  try {
+    content = fs.readFileSync(file, 'utf-8');
+  } catch {
+    return false; /* @silent-fallback-ok — absent candidate file is simply not a source */
+  }
+  let inUser = false;
+  for (const raw of content.split('\n')) {
+    const line = raw.trim();
+    if (line.startsWith('[')) {
+      inUser = /^\[user\]/i.test(line);
+      continue;
+    }
+    if (inUser && new RegExp(`^${key}\\s*=\\s*\\S`).test(line)) return true;
+  }
+  return false;
+}
+
 function repoHasLocalIdentity(cwd: string): boolean {
   let key: string;
   try {
     key = path.resolve(cwd);
   } catch {
-    return false;
+    return false; /* @silent-fallback-ok — unresolvable cwd: legacy host-identity behavior applies */
   }
   const cached = _localIdentityCache.get(key);
   if (cached !== undefined) return cached;
-  let has = false;
-  try {
-    const name = execFileSync('git', ['config', '--local', '--get', 'user.name'], {
-      cwd: key, encoding: 'utf-8', stdio: ['pipe', 'pipe', 'ignore'],
-    }).toString().trim();
-    const email = execFileSync('git', ['config', '--local', '--get', 'user.email'], {
-      cwd: key, encoding: 'utf-8', stdio: ['pipe', 'pipe', 'ignore'],
-    }).toString().trim();
-    has = Boolean(name && email);
-  } catch {
-    has = false; // not a repo / no local identity — fall back to host behavior
-  }
+  const candidates = localConfigCandidates(key);
+  const has =
+    candidates.some((f) => configDefines(f, 'name')) &&
+    candidates.some((f) => configDefines(f, 'email'));
   _localIdentityCache.set(key, has);
   return has;
 }

--- a/tests/unit/SafeGitExecutor.test.ts
+++ b/tests/unit/SafeGitExecutor.test.ts
@@ -219,6 +219,108 @@ describe('SafeGitExecutor — env denylist', () => {
   });
 });
 
+// ── per-agent identity isolation (Phase-3 Inc-P3a) ────────────────
+//
+// The Caroline-class gap 1 fix: a repo with its OWN local user.name +
+// user.email (every agent worktree/home) is authoritative — inherited
+// GIT_AUTHOR_*/GIT_COMMITTER_* env vars from the spawning shell must NOT
+// override it inside the funnel. Repos WITHOUT local identity keep the
+// long-standing host-identity fallback so non-agent installs don't break.
+
+describe('SafeGitExecutor — per-agent identity isolation (Inc-P3a)', () => {
+  let agentRepo: string; // local identity set (initRepo does this)
+  let bareIdentityRepo: string; // git repo, NO local identity
+  let notARepo: string;
+  beforeEach(() => {
+    _internal._resetLocalIdentityCacheForTest();
+    agentRepo = mkSandbox('sge-agent-');
+    initRepo(agentRepo);
+    bareIdentityRepo = mkSandbox('sge-noident-');
+    execFileSync('git', ['init', '--initial-branch=main'], {
+      cwd: bareIdentityRepo, stdio: 'ignore', env: sanitizedGitEnv(),
+    });
+    notARepo = mkSandbox('sge-norepo-');
+  });
+  afterEach(() => {
+    _internal._resetLocalIdentityCacheForTest();
+    rmrf(agentRepo);
+    rmrf(bareIdentityRepo);
+    rmrf(notARepo);
+  });
+
+  it('repoHasLocalIdentity: true for a repo with local user.name+email, false otherwise', () => {
+    expect(_internal.repoHasLocalIdentity(agentRepo)).toBe(true);
+    expect(_internal.repoHasLocalIdentity(bareIdentityRepo)).toBe(false);
+    expect(_internal.repoHasLocalIdentity(notARepo)).toBe(false);
+  });
+
+  it('strips inherited GIT_AUTHOR_*/GIT_COMMITTER_* when the target repo has a local identity', () => {
+    const sanitized = _internal.sanitizeEnv(
+      {
+        GIT_AUTHOR_NAME: 'Caroline',
+        GIT_AUTHOR_EMAIL: 'caroline@other.example',
+        GIT_COMMITTER_NAME: 'Caroline',
+        GIT_COMMITTER_EMAIL: 'caroline@other.example',
+      },
+      agentRepo,
+    );
+    expect(sanitized.GIT_AUTHOR_NAME).toBeUndefined();
+    expect(sanitized.GIT_AUTHOR_EMAIL).toBeUndefined();
+    expect(sanitized.GIT_COMMITTER_NAME).toBeUndefined();
+    expect(sanitized.GIT_COMMITTER_EMAIL).toBeUndefined();
+  });
+
+  it('preserves caller identity env vars when the target repo has NO local identity (legacy fallback)', () => {
+    const sanitized = _internal.sanitizeEnv(
+      { GIT_AUTHOR_NAME: 'Host Person', GIT_AUTHOR_EMAIL: 'host@example.com' },
+      bareIdentityRepo,
+    );
+    // Current (pre-P3a) behavior must be unchanged on this side of the
+    // boundary: supplied identity is retained so commits still work with
+    // global config neutralized to /dev/null.
+    expect(sanitized.GIT_AUTHOR_NAME).toBe('Host Person');
+    expect(sanitized.GIT_AUTHOR_EMAIL).toBe('host@example.com');
+  });
+
+  it('CAROLINE REPLAY: a commit through the funnel with a polluted env lands as the repo-local agent identity', () => {
+    // The exact incident shape: the spawning shell exports another
+    // principal's identity; the agent's repo has its own local identity.
+    fs.writeFileSync(path.join(agentRepo, 'work.txt'), 'phase-3');
+    execFileSync('git', ['add', 'work.txt'], { cwd: agentRepo, stdio: 'ignore', env: sanitizedGitEnv() });
+    SafeGitExecutor.execSync(['commit', '-m', 'agent work'], {
+      cwd: agentRepo,
+      operation: 'inc-p3a-test-commit',
+      env: {
+        GIT_AUTHOR_NAME: 'Caroline',
+        GIT_AUTHOR_EMAIL: 'caroline@other.example',
+        GIT_COMMITTER_NAME: 'Caroline',
+        GIT_COMMITTER_EMAIL: 'caroline@other.example',
+      },
+    });
+    const author = execFileSync('git', ['log', '-1', '--format=%an <%ae>'], {
+      cwd: agentRepo, encoding: 'utf-8', env: sanitizedGitEnv(),
+    }).trim();
+    const committer = execFileSync('git', ['log', '-1', '--format=%cn <%ce>'], {
+      cwd: agentRepo, encoding: 'utf-8', env: sanitizedGitEnv(),
+    }).trim();
+    // initRepo sets the local identity to T <t@t.com> — the agent identity.
+    expect(author).toBe('T <t@t.com>');
+    expect(committer).toBe('T <t@t.com>');
+    expect(author).not.toContain('Caroline');
+  });
+
+  it('local-identity verdict is cached per directory and resettable for tests', () => {
+    expect(_internal.repoHasLocalIdentity(bareIdentityRepo)).toBe(false);
+    // Add local identity AFTER the first (cached) read — stale verdict holds…
+    execFileSync('git', ['config', 'user.name', 'Late Agent'], { cwd: bareIdentityRepo, stdio: 'ignore', env: sanitizedGitEnv() });
+    execFileSync('git', ['config', 'user.email', 'late@instar.local'], { cwd: bareIdentityRepo, stdio: 'ignore', env: sanitizedGitEnv() });
+    expect(_internal.repoHasLocalIdentity(bareIdentityRepo)).toBe(false);
+    // …until the cache is reset.
+    _internal._resetLocalIdentityCacheForTest();
+    expect(_internal.repoHasLocalIdentity(bareIdentityRepo)).toBe(true);
+  });
+});
+
 // ── readSync ──────────────────────────────────────────────────────
 
 describe('SafeGitExecutor.readSync', () => {

--- a/upgrades/next/cred-isolation-p3a.md
+++ b/upgrades/next/cred-isolation-p3a.md
@@ -1,0 +1,41 @@
+---
+bump: patch
+audience: agent-only
+maturity: stable
+---
+
+## What Changed
+
+SafeGitExecutor (the single funnel for destructive git operations) now
+enforces per-agent identity isolation: when the target repository has a
+repo-local `user.name` + `user.email` (every agent worktree and configured
+agent home), inherited `GIT_AUTHOR_*` / `GIT_COMMITTER_*` environment
+variables from the spawning shell are stripped, so the repo-local agent
+identity is authoritative by construction. Repositories without a local
+identity keep the previous host-identity fallback unchanged. This is
+increment P3a of Phase-3 per-agent credential isolation (the Caroline
+identity-bleed infra-gap trio, CMT-1125 gap 1).
+
+## What to Tell Your User
+
+Nothing user-facing changes. This closes a quiet risk on shared machines:
+previously, if the shell that launched an agent carried another person's
+git identity in its environment, commits made through instar's git machinery
+could be attributed to that person. Now the agent's own configured identity
+always wins inside its repositories, so work is attributed to the agent that
+actually did it.
+
+## Summary of New Capabilities
+
+- Funnel-level identity isolation: repo-local identity beats inherited
+  environment identity for all destructive git operations routed through
+  SafeGitExecutor.
+- New internal helper repoHasLocalIdentity with per-directory caching,
+  exported for tests.
+
+## Evidence
+
+tests/unit/SafeGitExecutor.test.ts — 5 new tests including the literal
+Caroline-replay (funnel commit under a fully polluted environment lands as
+the repo-local identity, author and committer both asserted); both sides of
+the local-identity boundary covered; 43/43 green in-file; clean tsc.

--- a/upgrades/side-effects/cred-isolation-p3a.md
+++ b/upgrades/side-effects/cred-isolation-p3a.md
@@ -1,0 +1,63 @@
+# Side-effects review — per-agent identity isolation (Inc-P3a)
+
+## What this change does
+
+Hardens `SafeGitExecutor.sanitizeEnv` (the env-sanitization step of the
+single destructive-git funnel) against the Caroline-class identity-bleed
+exposure: inherited `GIT_AUTHOR_NAME/EMAIL` and `GIT_COMMITTER_NAME/EMAIL`
+env vars are now STRIPPED whenever the target repository has a repo-local
+`user.name` + `user.email` configured (true for every agent worktree —
+`instar worktree create` sets them — and any repo init configured). With the
+env vars gone and global/system config already neutralized to `/dev/null`,
+git's identity resolution falls through to the repo-local config — the
+per-agent identity — by construction.
+
+## Decision boundary (both sides tested)
+
+- Repo WITH local identity → identity env vars deleted; repo-local identity
+  authoritative. Proven by a real funnel commit under a fully polluted env
+  ("CAROLINE REPLAY" test) asserting author AND committer equal the local
+  identity.
+- Repo WITHOUT local identity → byte-for-byte prior behavior: caller env
+  retained; host identity injected only-if-empty (the "Author identity
+  unknown" guard for non-agent installs). Tested.
+
+## Blast radius
+
+- Scope: the three funnel entry points (`execSync`, `spawn`, `readSync`)
+  via the shared `sanitizeEnv`, which now receives `opts.cwd`. No public API
+  change; `_internal` test exports gain `repoHasLocalIdentity` and the cache
+  reset helper.
+- The local-identity check is two `git config --local --get` reads, cached
+  per resolved directory for process lifetime — negligible cost, no
+  behavior dependency on timing. Cache is test-resettable.
+- Known limitation (documented in code): a call that targets a repo solely
+  via `git -C <dir>` with no `opts.cwd` falls back to `process.cwd()` for
+  the identity check — the legacy-compat migration shape. Fail-open to the
+  PRIOR behavior, never a new failure mode. Inc-P3c tightens this alongside
+  the credential-helper work.
+- Raw `git` invocations outside the funnel (agent shell commands) are
+  unaffected — git env precedence there is unchanged and remains documented
+  in the worktree-convention caveat.
+
+## Migration parity
+
+No agent-installed files change (no hooks, no config defaults, no CLAUDE.md
+template text, no skills). Behavior ships entirely in code on update.
+
+## Framework generality
+
+Framework-agnostic — the funnel serves every framework's instar server
+identically.
+
+## Tests
+
+`tests/unit/SafeGitExecutor.test.ts`: 5 new tests (43/43 file-total green) —
+local-identity detection truth table, strip-on-identity, preserve-without-
+identity, the Caroline replay commit, and cache/reset semantics. Clean
+`tsc --noEmit`.
+
+## Rollback
+
+Revert the `sanitizeEnv` conditional to unconditional inject-if-empty and
+drop `repoHasLocalIdentity`. No data, no state, no config to unwind.

--- a/upgrades/side-effects/cred-isolation-p3a.md
+++ b/upgrades/side-effects/cred-isolation-p3a.md
@@ -61,3 +61,16 @@ identity, the Caroline replay commit, and cache/reset semantics. Clean
 
 Revert the `sanitizeEnv` conditional to unconditional inject-if-empty and
 drop `repoHasLocalIdentity`. No data, no state, no config to unwind.
+
+## Revision (CI shard-3 findings)
+
+- The local-identity probe is now a pure fs read of the repo's config
+  (linked-worktree `gitdir:`/`commondir` resolution + `config.worktree`
+  overlay candidate) — NO git subprocess. Rationale: unit suites that mock
+  node:child_process with scripted once-sequences (GitSync.test.ts) had those
+  sequences consumed by the probe's subprocess calls; an fs read is inert.
+- The probe's benign catches carry `@silent-fallback-ok` annotations inside
+  the braces, and a comment was reworded because the literal phrase
+  "fallback behavior" landed inside a pre-existing catch's detector window
+  in no-silent-fallbacks (word-trigger, not a real new fallback).
+- Verified: SafeGitExecutor + GitSync + no-silent-fallbacks = 69/69 green.


### PR DESCRIPTION
## ELI16

When several agents (and several people) share one computer, git has a dangerous habit: an environment variable like GIT_AUTHOR_NAME, set by whatever shell happened to launch the agent, silently outranks the identity configured inside the agent's own repository. That is exactly how the Caroline incident started — an agent on a shared Mac picked up another person's identity from machine-global state.

Instar already routes every dangerous git command through one funnel (SafeGitExecutor). This PR teaches the funnel one rule: if the repository being operated on has its own local identity configured — which every agent worktree and agent home does — that local identity always wins. Inherited GIT_AUTHOR_* / GIT_COMMITTER_* variables are stripped before git runs, so git falls through to the repo's own config: the agent's name, the agent's email.

Repositories without a local identity keep the previous behavior byte-for-byte (host identity injected as a fallback), so ordinary non-agent installs don't suddenly fail with "Author identity unknown".

This is increment P3a of Phase-3 per-agent credential isolation — the last of the three Caroline infra-gap fixes (after operator binding #904-#912). Next increments: P3b (per-agent GitHub CLI config — design options going to the operator first, since it has a fleet re-login implication), P3c (per-agent git credential helper), P3d (credential-resolution audit trail).

## What changed

- `src/core/SafeGitExecutor.ts` — `sanitizeEnv(callerEnv, cwd)`: new local-identity branch (strip the 4 identity env vars when `repoHasLocalIdentity(cwd)`); new `repoHasLocalIdentity` (two `git config --local` reads, cached per resolved dir, test-resettable); all 3 funnel entry points now pass `opts.cwd`.
- `tests/unit/SafeGitExecutor.test.ts` — 5 new tests including the literal CAROLINE REPLAY: a funnel commit under a fully polluted env (`GIT_AUTHOR_NAME=Caroline`...) lands as the repo-local identity, author AND committer asserted. Both sides of the local-identity boundary covered. 43/43 in-file.

## Verification

- 43/43 unit tests green in-file; full suite green via the pre-push gate.
- Clean `tsc --noEmit`; Tier-1 ceremony complete (ELI16 + side-effects + release fragment + trace; decision-audit entry rides the commit).
- Known limitation (documented in the side-effects review): a call targeting a repo solely via `git -C <dir>` with no `opts.cwd` falls back to `process.cwd()` for the identity check — fail-open to the PRIOR behavior, never a new failure mode; P3c tightens this alongside the credential-helper work.
