### PR TITLE
feat(coherence): P2 Working-Set Handoff spec (converged, 4 rounds) + P2.1 manifest

### DIFF
--- a/.instar/instar-dev-decisions/2026-06-06T10-48-50-021Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-06-06T10-48-50-021Z-unknown.json
@@ -1,0 +1,15 @@
+{
+  "ts": "2026-06-06T10:48:50.021Z",
+  "slug": "unknown",
+  "suggestedTier": 2,
+  "declaredTier": 2,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "new capability: new config key added"
+  ],
+  "belowFloor": false,
+  "files": 2,
+  "loc": 406,
+  "causalAutopsy": null,
+  "verdict": "pass"
+}

--- a/docs/specs/WORKING-SET-HANDOFF-SPEC.eli16.md
+++ b/docs/specs/WORKING-SET-HANDOFF-SPEC.eli16.md
@@ -1,0 +1,26 @@
+# Moving a conversation finally moves its desk too (P2)
+
+Until now, when one of my conversations moved from the Laptop to the Mini, it was like an employee changing offices but leaving every paper on the old desk: the chat continued, but the working files — the overnight analysis, the run's notes — stayed behind. That's exactly what bit us in the EXO incident. P1 made the files FINDABLE; this phase makes them FOLLOW.
+
+How it works, plainly: each machine can compute, on demand, "what files make up this conversation's workspace" — from durable evidence (the run's own file, anything matching the topic's file-naming convention, and every path the diary recorded), never from anyone remembering to declare anything. When a conversation moves, the receiving machine asks the machines that actually produced the work — not just the last owner, who may have produced nothing — "send me that workspace." Files travel in small one-megabyte slices (the review caught that my draft's single 32MB response would have re-created this laptop's famous freeze-under-load incident), each slice fingerprint-checked, the whole file verified before a single byte lands in place.
+
+The review round earned its keep on this one — the biggest catches, all now in the design:
+
+- **The asleep-machine case — the actual EXO failure — is now solved, not retried-then-abandoned.** If the machine holding the files is offline (or was wrongly evicted from the mesh, like the Mini was for ten hours), the request is written down durably and fires automatically the moment that machine comes back. It survives restarts. After a week unrecovered, you get one honest notice instead of eternal silence.
+- **Files containing pasted secrets don't travel.** The category being "working files" doesn't make the contents safe — every file's actual bytes are scanned for credential shapes before serving; flagged files are refused out loud, never silently shipped or silently skipped.
+- **A still-running job's file isn't snapshotted mid-sentence.** If the run is live, its file is marked "still being written" and the fetch fires when the run finishes.
+- **Nothing is ever overwritten, and nothing can be deleted.** A genuinely different local version gets the incoming copy saved ALONGSIDE it (capped at two, identical arrivals collapse to one) plus one calm notice — real divergence gets seen, not coin-flipped.
+- **Rapid back-and-forth moves can't corrupt anything**: only the CURRENT owner's fetch ever writes, one fetch per topic at a time, and a fetch superseded by a newer move aborts quietly.
+
+Round two of review caught three more, now also designed in:
+
+- **A returning machine isn't mobbed.** If the Mini wakes up holding files for ten conversations, the fetches line up single-file behind each other instead of all ten slamming a machine that's still booting.
+- **A file changing mid-transfer can't produce a Frankenstein copy.** Each slice carries a fingerprint of the whole file it was cut from; if that changes mid-transfer, the fetch starts the file over (three tries, then one honest "this file won't sit still" note — never an infinite loop).
+- **The "files I still owe you" notebook can't lose entries.** All six things that write to it go through one single-file line (the exact lost-update race that caused a notification flood last week), and if the notebook is ever corrupted you get one notice — it's never silently read as empty.
+- **Honesty about the secret scan**: it catches things SHAPED like keys and tokens, not every possible secret in prose. That's acceptable only because both machines are yours — and the design says so out loud instead of overclaiming.
+
+Also riding along, earned the hard way: the mesh-health guard. A machine that's been improperly evicted (a revocation with no who-or-why recorded — exactly what happened to the Mini) gets flagged the moment it's seen; a machine that should be in the pool but has gone missing for half an hour produces one calm notice naming it AND naming any stranded workspaces sitting on it. Flapping machines get one "it's flapping" notice, not a stream.
+
+And the ask-me-anytime move: if you mention work this machine can't find, I can trigger the fetch reflex — "who made artifacts for this topic? go get them" — the EXO failure as a one-call recovery.
+
+Activates only where machine-to-machine diary sync is already on (your Laptop+Mini pair today; dark everywhere else). The build starts after this spec finishes the four-round review gauntlet, under your standing 24-hour directive.

--- a/docs/specs/WORKING-SET-HANDOFF-SPEC.md
+++ b/docs/specs/WORKING-SET-HANDOFF-SPEC.md
@@ -1,0 +1,535 @@
+---
+title: "Working-Set Handoff — topic moves carry their files (P2 of multi-machine coherence)"
+slug: "working-set-handoff"
+author: "echo"
+eli16-overview: "WORKING-SET-HANDOFF-SPEC.eli16.md"
+status: "converged-approved"
+approved: true
+approved-by: "justin (standing directive)"
+approved-evidence: "Topic 13481, 2026-06-06 ~03:05 PDT: 'Yes, please enter a 24 hour autonomy session and continue to proceed through each project step making sure you implement each one and tested extremely thoroughly' — covers per-step convergence, build, all-tier testing, live verify on the echo pair. ELI16 sent to topic 13481 at approval."
+layer: "core-instar-primitive"
+parent-principle: "Structure beats Willpower — a moved topic's workspace follows it by machinery, not by anyone remembering to copy files"
+parent-spec: "MULTI-MACHINE-COHERENCE-MASTER-SPEC.md"
+project: "multimachine-coherence"
+project-items: "P2.1 topic-working-set-manifest, P2.2 working-set-pull-on-move"
+supervision: "tier0 — deterministic file transfer with jailed paths, chunked bounded responses, and content verification; no policy decisions. Justified per LLM-Supervised Execution."
+inherited-invariants: >
+  This spec INHERITS the converged P1 invariants by reference
+  (COHERENCE-JOURNAL-SPEC, review-convergence 2026-06-06): no synchronous
+  I/O in hot paths; canonicalized path jails enforced at the data's birth;
+  first-hop-only trust; bounded loops/backoff/breaker on every repeating
+  behavior; ack-after-durable-commit on receive; observability never
+  endangers the observed operation; replicated/remote data is SIGNAL, never
+  actuation authority; operation-keyed idempotency that survives restarts.
+  Reviewers: treat violations of these as material without re-deriving them.
+review-convergence: "2026-06-06T10:36:47.927Z"
+review-iterations: 4
+review-completed-at: "2026-06-06T10:36:47.927Z"
+review-report: "docs/specs/reports/working-set-handoff-convergence.md"
+cross-model-review: "codex-cli:gpt-5.5"
+---
+
+# Working-Set Handoff (P2)
+
+> **One sentence:** when a topic moves between machines, the receiving
+> machine PULLS the topic's working files from whichever machines produced
+> them — durably, in small chunks, surviving the producer being asleep —
+> so transfer stops meaning "you get the conversation but lose the
+> workspace."
+
+## 1. Motivation (inherited)
+
+Master spec §5-P2. The EXO incident, mechanized away: the Mini's overnight
+gap-analysis lived in machine-local autonomous files; the topic's
+conversation moved but its workspace did not — **and the machine holding
+the files was asleep when they were wanted** (the durable pending-pull in
+§3.4 exists because of exactly this). P1 made the files' location knowable
+(live-proven 2026-06-06); P2 makes the files follow. Justin's locked
+decision: peer-HTTP pull primary (git unavailable on dev-agent homes).
+
+## 2. Scope
+
+**In (P2.1–P2.2):**
+- P2.1 — the **working-set manifest**: pure, on-demand computation of a
+  topic's working files on this machine.
+- P2.2 — **pull-on-move**: a chunked `working-set-pull` mesh verb, the
+  receiver-side trigger, a **durable pending-pull ledger** (the
+  offline-producer case), and the **evidence-driven fetch reflex**
+  (`POST /coherence/fetch-working-set`).
+- The **peer-visibility guard** (rider, earned 2026-06-06): improper
+  revocations and silently-missing peers must surface loudly. Kept in P2
+  because it shares the implementation area (machines registry +
+  presence-pull) and the pending-pull ledger depends on its re-peer signal.
+
+**Out (explicitly):**
+- Background digest/anti-entropy over all state categories
+  <!-- tracked: multimachine-coherence-pool-wide-cross-topic-awareness -->.
+- Semantic merging of diverged file contents (whole-file never-clobber
+  only, §3.5).
+- Sync of categories beyond topic working sets.
+- Live `artifacts-updated` declarations — SUPERSEDED: the manifest
+  computes from durable evidence + a filesystem convention (§3.1), not
+  willpower-dependent declarations.
+- Per-response envelope signatures (responses inherit transport auth;
+  stated honestly in §5 — per-entry signatures remain P1's named upgrade
+  path <!-- tracked: multimachine-coherence-threadline-conversation-registry -->).
+
+## 3. Design
+
+**Glossary (cross-model reviewer ask):** *first-hop* = data is accepted
+only from the machine that produced it, never relayed peer-to-peer-to-peer
+(P1 §3.9). *OWN-stream* = a machine's own journal entries (`entry.machine
+=== ownMachineId`), as opposed to replicas of peers' streams. *same-
+operator* = every registered peer belongs to the same human operator —
+the trust posture all disclosure acceptances in this spec rest on.
+*liveOwner authority* = the live ownership store (SessionOwnershipRegistry
+CAS state) is the only actuation authority; journal/replica data only
+nominates (Signal vs Authority).
+
+**Why a custom verb, not a standard transfer protocol:** HTTP range
+requests + ETags, rsync, tus, or SFTP would each need a NEW
+transport/auth surface alongside the mesh (new port/daemon/credential
+class — a second boundary to harden). The mesh RPC path already carries
+machine-auth Ed25519 envelopes, RBAC, registered-peer gating, and the
+P1-proven bounded-batch pattern; `working-set-pull` reuses ALL of it.
+The offset-cursor + fstat-anchor design IS range-GET + ETag semantics,
+expressed over the existing authenticated channel. (Standard protocols
+revisited if a non-mesh peer class ever exists.)
+
+### 3.1 The manifest (P2.1) — computed, never declared
+
+`computeWorkingSet(stateDir, topic): WorkingSetEntry[]` — pure function,
+no new persistent store. Sources, deduped:
+
+1. **Filesystem convention** (freshness-independent of the journal — a
+   file created after the journaled `started` is still found):
+   `autonomous/<topic>.local.md` and any file matching
+   `autonomous/<topic>.*` (bounded glob, no recursion outside the
+   convention dir).
+2. **Journal evidence**: `artifactPaths` from the topic's OWN-stream
+   `autonomous-run` entries — read via a new
+   `CoherenceJournalReader.readOwnAutonomousRuns(topic)` method (own
+   stream only by construction; `query()`'s merged own+replica view is NOT
+   used here), the machine's own id threaded from the server's
+   `cjOwnMachineId`.
+3. Every candidate canonicalized + jailed (P1 §3.1 jail, same roots); each
+   surviving entry = `{ relPath, bytes, sha256, mtime }` where **mtime is
+   DISPLAY-ONLY** (P1's `ts` treatment) — every diff/skip decision keys on
+   sha256 exclusively, never mtime/bytes.
+4. **Secret-content posture** (category intent ≠ content reality: working
+   files can contain pasted credentials): the serve side runs the
+   credential-shape scan over each file's BYTES; a flagged file is listed
+   `secretFlagged: true` and NOT transferred — an honest, surfaced refusal
+   (counted + named in the pull report), never a silent skip.
+   **Honesty about what the scan is (Signal vs Authority, P1 §3.1
+   verbatim):** the credential-shape enum is BEST-EFFORT — it matches
+   shaped credentials (token/key patterns) and cannot see content-shaped
+   secrets (a password in prose, a key body, a high-entropy blob). P1
+   could declare it a secondary pass because the typed-schema boundary
+   upstream structurally excluded free text; P2 has NO such upstream
+   boundary (working files are arbitrary content). The scan is therefore
+   a LEAK-REDUCTION filter, never the security boundary — **the actual
+   boundary is the same-operator peer posture itself** (the peer is the
+   same operator's machine, not an untrusted exfiltration target). That
+   posture, not the scanner, is what makes the residual content-leak
+   risk acceptable — restated in §5 and revisited before any
+   non-same-operator peer class exists.
+
+Caps: `maxFileBytes` 4 MiB — except the autonomous `<topic>.local.md`,
+exempt up to 16 MiB (it is the headline artifact); `maxFiles` 64;
+`maxTotalBytes` 32 MiB (a TOTAL-SET budget across chunked requests, never
+a single-response size — §3.2). Over-cap entries are LISTED
+`tooLarge: true`; a tooLarge HEADLINE file additionally raises one
+Agent-Health notice naming the source machine + path — observability is
+not delivery, and the operator must know the deliverable did not move.
+
+**Disclosure note (see §5):** the manifest (including tooLarge /
+secretFlagged entries) reveals relPath + size + sha256 of jailed working
+files to any registered peer. Acceptable: first-hop, own-files-only,
+same-operator peers. Revisit if non-same-operator peers become a class.
+
+### 3.2 The verb (P2.2) — `working-set-pull`, chunked and bounded
+
+New MeshCommand
+`{ type: 'working-set-pull'; topic: number; manifestOnly?: boolean; want?: { relPath: string; offset: number }[] }`.
+**Three lockstep edits**, mirroring journal-sync: the `MeshCommand` union
+member, the RBAC read/observe case (alongside `journal-sync`), and the
+dispatcher `handlers` registration. Mixed-version: an old peer answers
+**403 OR 501** (RBAC default-deny vs no-handler) — the caller treats both
+as "verb unsupported, quiet back-off" (P1 rule 6).
+
+**Chunking (the load-bearing transport rule):** every response carries at
+most `workingSetPullMaxBatchBytes` (default **1 MiB**) of base64 content —
+deliberately far under the mesh endpoint's `express.json({limit:'12mb'})`
+body ceiling and the MeshRpcClient 5s per-attempt timeout. The named
+reason: a single 32 MiB JSON.stringify is the host's DOCUMENTED
+event-loop-starvation root cause, and P1 capped journal-sync at 256 KB for
+exactly this. A large file transfers as multiple `want` requests with
+`offset` cursors; the receiver assembles chunks and verifies the whole
+file's sha256 before any write. `maxTotalBytes` is the TOTAL-SET budget
+across all chunks, never one response.
+
+**Cross-chunk consistency anchor (a multi-chunk file is one snapshot,
+not N):** per-chunk atomic-read-then-hash protects one chunk, not the
+assembly — chunk 1 at version A + chunk 3 at version B assembles a
+chimera matching NO real version. Anchor mechanics (cheap by
+construction — the serve side stays stateless and never re-reads the
+whole file per chunk): the **offset-0 response alone** carries the
+whole-file `sha256` (ONE full read+hash, amortized across the transfer)
+plus a **cheap fstat anchor** `{ bytes, mtimeNs, ino }`; every
+subsequent chunk response carries ONLY the fstat anchor re-read from the
+open fd (`O_NOFOLLOW` + fd-verify per §TOCTOU, then `fstat` — no
+content re-hash). The puller compares anchors per chunk: mismatch →
+abort the file and restart FROM OFFSET 0 (never a blind re-pull of the
+failed chunk), bounded at `chunkRestartCap` (default 3) per file per
+pull attempt — exhausted restarts mark the file `unstable` in the pull
+report (counted, surfaced) rather than livelocking against a file being
+actively rewritten. The assembled whole is verified against the
+offset-0 `sha256` before any write — the fstat anchor is a fast
+tear-detector, the assembly hash is the authority (an mtime-preserving
+rewrite that dodges fstat still fails assembly verification and
+restarts, bounded).
+
+**Puller-side chunk cadence (pinned, not assumed):** chunk requests are
+sequential (never parallel per file), with an event-loop yield between
+chunks and a `chunksPerTick` cap (default 8 — ~8 MiB per scheduler tick);
+under measured host pressure (the same load signal §3.3 uses) the
+inter-chunk delay stretches (base 50ms, ×4 under pressure). The serve
+side protects itself symmetrically: at most `serveConcurrency` (default
+2) working-set-pull requests are served concurrently; excess requests
+get an honest `busy` response (the caller backs off — bounded, counted).
+**`busy` is a retry-without-penalty signal**: it does NOT increment the
+`(peer,topic,epoch)` attempt cap and does not advance the breaker —
+only genuine failures (offline / unreachable / refused / verify-failed)
+consume failure budget. Otherwise the staggered drain's own throttling
+would exhaust the very records it exists to recover (the just-woke
+producer answers `busy` by design). `busy` retries are themselves
+bounded (`busyRetryCap` 10 per pull attempt, exponential back-off);
+exhaustion re-files the pending-pull intact, breaker untouched. Both
+bounds are asserted in the §6 storm test.
+
+**Budget accounting (pinned):** `maxTotalBytes` counts **assembled,
+verification-passed file bytes** — never raw wire bytes. Chunks of a
+file later discarded by an anchor restart do not count; up to 3
+restarts of a near-budget file cannot starve the set's remaining,
+never-attempted files.
+
+**Serve-side rules:**
+- The manifest is the allowlist and is **recomputed fresh on every
+  request** (never cached across calls) — `want` paths outside the fresh
+  manifest are refused per-entry (`refusedPolicy`, counted). There is no
+  generic file-read surface.
+- **TOCTOU defense at read time**: the compute-time jail verdict is not
+  trusted at read time. Files are opened `O_NOFOLLOW` via root-relative
+  traversal (no symlink component), then `fstat`-verified (regular file;
+  the OPEN FD's realpath still inside the jail) BEFORE bytes are read — a
+  symlink swapped in after manifest computation reads nothing.
+- **Atomic read-then-hash**: bytes are read once and hashed from those
+  exact bytes (never stat-hash-then-reread). If the file changed since the
+  requester's manifest, the response carries the CURRENT bytes + hash +
+  `changedSinceManifest: true` — the served hash is authoritative for
+  verification; the manifest hash was advisory for selection. A path that
+  vanished between calls returns `goneSinceManifest` (distinct from
+  `refusedPolicy` — benign evolution is never logged as an attack).
+- **Live-source honesty**: if the topic's OWN journal stream shows the
+  autonomous run still active, EVERY manifest entry for that topic — the
+  headline `<topic>.local.md` AND any convention-glob or `artifactPaths`
+  file (all are plausibly mid-write by the live run) — is listed
+  `liveSource: true` and not transferred — a mid-run snapshot would be a
+  torn fork of a still-growing file. The pending-pull (§3.4) re-fires
+  when the run's `stopped` lands. (The generation anchor above is the
+  backstop for files that change WITHOUT a live run — e.g. an editor —
+  not a substitute for this skip.)
+
+**Receive-side rules:**
+- **Response ceiling BEFORE parse**: the raw response body is bounded at
+  the transport layer (`workingSetPullMaxBatchBytes × 4/3 + slack`);
+  oversize aborts the read before JSON.parse. Per-blob ordering is
+  bound → decode → verify declared bytes → hash → write; never
+  decode-everything-then-measure.
+- **Peer-supplied relPath is hostile input**: validated BEFORE any join —
+  relative only, no `..` segment, no absolute/drive/UNC prefix (P1 §3.1
+  rules verbatim); destination resolved under the jail root with
+  parent-directory realpath containment; never create-through a
+  peer-supplied symlink/junction chain (`O_NOFOLLOW`, temp-file + rename
+  inside the jail). The absent-destination write is subject to the FULL
+  jail, not only the divergent case.
+- Hash verified before the rename lands the file; mismatch discards
+  (counted), never a partial write.
+
+### 3.3 The trigger — receiver-side, epoch-gated, single-flight
+
+The pull is scheduled on the RECEIVING machine's **owner-side
+`deliverMessage` `onAccepted` resume hook** (the
+`createDeliverMessageHandler` seam) — the one place the receiver knows it
+now owns the topic. NOT `ownAction`/`confirmClaim`: those run on the
+ROUTER, which confirms claims on the target's behalf in the single-router
+topology; instrumenting them would schedule the pull on the wrong machine.
+
+Discipline (all inherited-invariant applications):
+- **Operation key `(topic, epoch)`** — at most one pull scheduled per key,
+  deduped against a durable recent-key window (restart-proof). Skipped
+  entirely when `owner === prevOwner` (placing-confirm, no real move) or
+  `prevOwner === thisMachine` (nothing to fetch from ourselves).
+- **Single-flight per topic** — a superseding transfer cancels/supersedes
+  the in-flight pull; before EVERY file write the puller rechecks
+  `liveOwner(topic) === thisMachine && currentEpoch === scheduledEpoch`
+  against the live ownership store (the authority). Ownership advanced →
+  abort quietly (counted) — the newer owner's own pull covers current
+  truth. This kills the ping-pong races (stale writes onto a non-owner,
+  mutual alongside-copy generation).
+- **Load-aware**: scheduling defers under host pressure (master §6.2);
+  the pull is always async, NEVER in the message-delivery path.
+
+**Nomination — plural, bounded, reconciled:** candidates are EVERY machine
+the journal (own + replicas) shows as an artifact-producer for the topic,
+deduped, capped at 3, ordered most-recent-first — NOT "the prior owner"
+(a pass-through owner may never have produced anything; the producer may
+be two hops back). When the cap excludes producers, the pull report
+names them (`cappedNominees` — "not contacted", honestly distinct from
+"contacted, nothing found"); the REFLEX route may expand past the cap on
+explicit demand (still bounded by the registered-peer ∩
+journal-evidenced set — never a fan-out beyond machines the records
+actually name). Replicas NOMINATE only (P1 §3.9); each nominee's LIVE
+manifest is the authority. When a journal-nominated path is absent from
+the live manifest, ONE honest signal is recorded ("journal expected
+<path> on <machine>; live manifest does not list it — rotated, deleted,
+or never durable"), counted, distinct from a clean nothing-to-fetch — the
+operator can distinguish "work is gone" from "work transferred".
+
+**The reflex**: `POST /coherence/fetch-working-set { topic }` (Bearer;
+503 when the journal is dark; rate-limited per topic with concurrent
+calls coalesced into the single-flight pull) runs the same
+nominate→verify→pull pipeline on demand. The contact set is bounded to
+the topic's ownership history ∪ journal-nominated producers — a poisoned
+replica can never widen the fan-out beyond registered peers that actually
+appear in those records.
+
+### 3.4 The durable pending-pull ledger (the EXO case, solved)
+
+A pull whose nominee is offline/unreachable/revoked does NOT die at the
+breaker — it persists as a pending-pull record
+(`state/coherence-journal/pending-pulls.json`, registered in the
+State-Coherence Registry, machine-local):
+`{ topic, epoch, nominee, reason, createdAt, attempts, lastAttemptAt }`.
+
+**Single-writer discipline (the flood-#3 lesson, applied at birth):** the
+ledger has SIX mutators (onAccepted scheduler, reappearance re-arm,
+run-stopped re-arm, attempt/breaker update, reflex route, TTL sweep) that
+can overlap on one tick. ALL mutations route through ONE in-process
+serialized `mutate(fn)` funnel (async queue; read-modify-write never
+interleaves) with temp-file + atomic-rename persistence — the same CAS
+chokepoint posture P1's sibling store earned from the lost-update race
+that caused topic-flood #3. **Parse-failure posture** (the flood's second
+root): a corrupt/unparseable ledger is NEVER read as "no pending pulls" —
+the file is quarantined aside (`.corrupt-<ts>`), ONE agent-health notice
+fires ("pending-pull ledger unreadable — stranded-recovery records may be
+lost"), and a fresh ledger starts. A unit test asserts concurrent
+`mutate()` calls drop no record.
+
+- **Re-armed by reappearance — staggered, never a herd**: when the
+  presence-pull records a peer coming online (the same 30s cadence
+  journal-sync rides) — INCLUDING after an un-revocation — outstanding
+  pending-pulls for that peer re-fire as a **staggered drain**: at most
+  `rearmConcurrency` (default 1) topic-pull in flight per peer, the rest
+  queued behind it most-recent-epoch-first. The EXO shape is ONE machine
+  holding MANY topics' files; N simultaneous pulls would slam a box that
+  just woke (and is busy booting) — the serve-side `serveConcurrency`
+  bound (§3.2) is the producer's own backstop. The 2026-06-06 incident
+  shape (files on a machine improperly revoked for 10 hours) still
+  recovers automatically the moment the peer is back — sequentially.
+- **Re-armed by run-completion**: a `liveSource` skip re-fires when the
+  topic's journal shows the run `stopped`.
+- **Bounded**: superseded by a newer epoch for the topic — supersession
+  clears **ALL records for that topic with `epoch < new`, across all
+  nominees** (plural nominees per epoch exist by §3.3; a partial clear
+  must never strand a sibling record); TTL 7 days; per-record attempt cap
+  with the breaker keyed `(peer, topic, epoch)` — a NEW epoch resets it,
+  so an old move's exhausted breaker never suppresses a fresh, warranted
+  pull. Episodes surfaced once on TTL-expiry ("topic T's working set on
+  <machine> was never recovered") via the Agent-Health lane.
+
+### 3.5 Never-clobber (the one conflict rule)
+
+The receiving side NEVER overwrites a local file that differs:
+
+- Destination absent → write (fully jailed, §3.2).
+- Destination byte-identical (sha256) → skip (`skippedExisting`).
+- Destination differs → write alongside as
+  `<sanitizedBasename>.from-<senderShortId>-<hash8><ext>` — the basename
+  sanitized (no path separators), the sender id derived ONLY from
+  `env.sender`, the 8-char content-hash suffix making repeated divergent
+  arrivals naturally idempotent (the same divergent content produces ONE
+  alongside file, not N) — plus the full jail recheck on the final
+  alongside path. Surfaced as ONE Agent-Health notice per topic per
+  episode listing the divergent files.
+- **Bounded (resolves old OQ1)**: at most 2 alongside copies retained per
+  base file (oldest evicted); a degradation counter watches `.from-*`
+  count + bytes (the P1 archive-growth-watch pattern). An eviction IS a
+  deletion of divergent content and is treated as one: it is counted and
+  named in the same per-topic Agent-Health divergence notice (never
+  silent), and is acceptable only because the evicted copy's content
+  still exists on its producer machine (first-hop provenance — nothing
+  is lost to the fleet, only to this replica).
+- No deletion path exists anywhere in this feature (eviction of alongside
+  copies above is the single, narrow exception — alongside files only,
+  inside the jail, through SafeFsExecutor).
+
+### 3.6 Peer-visibility guard (the rider)
+
+Earned 2026-06-06 (the Mini: revoked with NO `revokedBy`/`revokeReason`,
+invisible for ~10 hours):
+
+1. **Pure detection, surfaced by the right consumer**: a pure helper
+   `detectImproperRevocations(registry)` (an entry with `revokedAt` set
+   but `revokedBy`/`revokeReason` missing) — NOT inside `loadRegistry()`
+   (a hot, dependency-free read called 41+ times per boot; it stays
+   pure). The MultiMachineCoordinator's boot/refresh path calls the
+   helper and surfaces findings via `POST /attention` with
+   `lane: 'agent-health'` (the existing coalescing lane — never a
+   topic-per-event), deduped ACROSS boots keyed on the entry's
+   `revokedAt` (a crash-loop cannot re-spam it). HYGIENE SIGNAL ONLY: it
+   detects sloppy revocation, not malicious revocation — populated
+   fields are NOT authenticated and must never be read as "this
+   revocation is legitimate".
+2. **Peer-disappearance notice**: pool transitions from N≥2 online to
+   fewer and stays past a 30-min grace → ONE agent-health-lane notice
+   naming the machine + last known reason (revoked / heartbeat-silent /
+   url-unreachable), and — when pending-pulls reference that machine —
+   naming the stranded topic working sets ("topic T's files are on
+   <machine>; recover by bringing it back / un-revoking"). Coalesced per
+   machine per episode; **flap-bounded**: after 3 episodes for one
+   machine in 24h, collapse to a single "machine X is flapping" notice
+   and stop re-notifying until operator ack (Bounded Notification
+   Surface). Clears silently on stable re-peer.
+
+### 3.7 Config & rollout
+
+Two concrete edits (Migration Parity): `CoherenceJournalUserConfig` in
+`types.ts` gains `workingSet?: {...}`, and the `coherenceJournal` literal
+in `ConfigDefaults.ts` gains:
+`workingSet: { maxFileBytes: 4194304, headlineFileBytes: 16777216, maxFiles: 64, maxTotalBytes: 33554432, pullMaxBatchBytes: 1048576, pullOnMove: true, pendingPullTtlDays: 7, chunkRestartCap: 3, chunksPerTick: 8, serveConcurrency: 2, rearmConcurrency: 1, busyRetryCap: 10 }`.
+**Gate (unambiguous):** the working-set feature activates IFF
+`multiMachine.coherenceJournal.replication.enabled === true` — the same
+explicit gate as the replication transport it rides (NOT the journal's
+`?? developmentAgent` dark-ship gate; the pull is meaningless without
+replication's mesh path and must never out-activate it). Live on the echo
+pair (replication on since the 2026-06-06 proof); dark everywhere else.
+Single-machine agents: manifest + reflex API answer locally; pull paths
+no-op. `applyDefaults` add-missing backfills existing agents; no new
+hooks; CLAUDE.md template gains the reflex-API entry + the proactive
+trigger ("user references files/work not on this machine →
+POST /coherence/fetch-working-set") + migrateClaudeMd content-sniffed
+section, in the same PR as the route.
+
+## 4. Degradation requirements (inherited P1 §4, plus)
+
+1. A pull failure NEVER affects the transfer itself; retries are bounded
+   per `(peer, topic, epoch)` with the durable pending-pull (§3.4) as the
+   long-tail recovery — never an infinite loop, never a silent abandon.
+2. Every byte written passes hash verification first; temp-file + rename;
+   no partial writes survive kill-9 (re-pull is idempotent via
+   skippedExisting).
+3. Serve side bounded per response (1 MiB batch), per file, per set;
+   manifest computation is O(topic's journal entries + convention-dir
+   listing), never a scan outside the jail.
+4. Mixed-version: 403 OR 501 → quiet back-off (P1 rule 6).
+5. Integrity honesty: responses are NOT envelope-signed; content integrity
+   rests on (a) the authenticated, registered-peer transport and (b)
+   per-file/per-chunk sha256 against transport corruption. A transport
+   able to rewrite bytes AND hashes together is detected only by the
+   transport's own auth — acceptable because §3.9 (nothing actuates off
+   pulled files), first-hop, same-operator; per-entry signatures are the
+   named upgrade path (§2 Out).
+
+## 5. Security
+
+- FIRST-HOP + fresh-manifest-as-allowlist: no generic remote file read;
+  own files only; jailed paths only; TOCTOU defeated at read time via
+  `O_NOFOLLOW` + fd-verify (§3.2).
+- Receive side treats relPath as hostile (full validation before join;
+  jail on absent-destination writes; sanitized alongside naming derived
+  from `env.sender` only).
+- Response ceiling enforced before parse; bound → decode → hash → write.
+- Secret-content scan over served BYTES (not category intent);
+  `secretFlagged` files never transferred, refusal surfaced. **The scan
+  is best-effort, not a boundary** (§3.1 item 4): shaped credentials
+  only; content-shaped secrets pass it. Unlike P1 there is no upstream
+  typed-schema boundary, so the residual content-leak risk is accepted
+  strictly under the first-hop + same-operator posture and MUST be
+  re-evaluated before any non-same-operator peer class.
+- The reflex route is Bearer-gated, rate-limited, single-flight, and its
+  contact set is bounded to ownership-history ∪ journal-producers.
+- Manifest metadata disclosure acknowledged (§3.1 note).
+- No deletion capability (single narrow alongside-eviction exception via
+  SafeFsExecutor inside the jail).
+
+## 6. Testing (all three tiers + independent oracles)
+
+- **Unit:** manifest (convention + journal sources, jail cases, caps,
+  tooLarge + headline exemption, secretFlagged listing, dedupe, mtime
+  display-only, liveSource covering ALL of a live run's entries); chunk
+  assembly + whole-file hash; **generation-anchor matrix** (mid-file
+  anchor change → restart-from-0; chunkRestartCap exhausted → `unstable`
+  surfaced, never a livelock); relPath hostile-input matrix (`..`,
+  absolute, separators-in-basename, symlinked parent); alongside naming
+  (sanitization, hash-suffix idempotency, cap-2 eviction); never-clobber
+  matrix; operation-key dedupe surviving restart; pending-pull ledger
+  (persist, re-arm on reappearance + on run-stopped + after un-revoke,
+  **staggered drain honors rearmConcurrency**, supersede clears ALL
+  lower-epoch records across nominees, TTL expiry notice, breaker keyed
+  per (peer,topic,epoch) + reset on new epoch, **concurrent mutate()
+  drops no record**, **corrupt ledger → quarantine + notice, never
+  silent-empty**); detectImproperRevocations (improper flagged, proper
+  not, cross-boot dedupe key).
+- **Integration:** full chunked round-trip through the REAL
+  `express.json` + MeshRpcClient path at near-cap sizes (the body-parser
+  and 5s-timeout interaction exercised for real, not mocked);
+  TOCTOU symlink-swap between manifest and read → nothing leaves the
+  jail; want-outside-fresh-manifest refused; changedSinceManifest /
+  goneSinceManifest semantics; oversized response aborted pre-parse
+  without OOM; declared-bytes mismatch discarded; liveSource skip;
+  mixed-version 403/501 back-off; reflex route (200 + report / 503 dark /
+  rate-limit coalescing); ping-pong storm → single-flight + bounded
+  concurrent pulls + ownership-recheck aborts; **storm bounds asserted**:
+  serve side answers `busy` above serveConcurrency, puller honors
+  chunksPerTick + pressure-stretched inter-chunk delay, reappearance with
+  N pending topics drains sequentially (rearmConcurrency), never N-wide;
+  **`busy` responses leave the (peer,topic,epoch) attempt cap untouched**
+  (drain against a busy producer never exhausts its own records);
+  **maxTotalBytes counts assembled bytes only** (anchor restarts of a
+  near-budget file don't starve the set's remaining files).
+- **E2E:** two production-shaped servers; transfer a topic with a real
+  working file → receiving side holds it, content cross-checked against
+  the SOURCE machine's on-disk original read directly by the test (an
+  oracle independent of both the puller's report and the server's
+  self-reported hash); divergent-file case surfaces the alongside copy;
+  kill-9 mid-pull → re-pull idempotent, no partial files; offline-nominee
+  → pending-pull persists a restart and re-fires on the peer's return.
+- **Wiring-integrity:** drive the receiver's `onAccepted` seam and assert
+  the pull was scheduled by observing FILES + counters (not the puller's
+  report); peer-visibility guard fires on a synthetic improper revocation
+  in a temp registry and routes through the agent-health lane exactly
+  once across two simulated boots.
+
+## 7. Work breakdown
+
+1. **P2.1** `WorkingSetManifest` (pure module) +
+   `CoherenceJournalReader.readOwnAutonomousRuns` + unit tests.
+2. **P2.2a** `working-set-pull` verb (three lockstep edits) + chunked
+   serve/receive + never-clobber + pending-pull ledger + integration
+   tests.
+3. **P2.2b** the `onAccepted` trigger + reflex route + CLAUDE.md template
+   + migrateClaudeMd + e2e + peer-visibility guard + live two-machine
+   verification on the echo pair (move a quiet test topic with a real
+   working file; show the file arriving on the receiving machine,
+   hash-verified against the source).
+
+## 8. Open questions for Justin
+
+1. ~~Alongside-copy accumulation~~ — RESOLVED in convergence: cap 2 per
+   base file + content-hash idempotent naming + growth counter (§3.5).
+2. ~~Live verification approval~~ — RESOLVED: covered by the standing
+   24h full-sweep directive (2026-06-06): each step implemented, tested
+   thoroughly, live-verified. The P2 live proof uses a quiet test topic,
+   never 13481.

--- a/docs/specs/reports/working-set-handoff-convergence.md
+++ b/docs/specs/reports/working-set-handoff-convergence.md
@@ -1,0 +1,80 @@
+# Convergence Report — Working-Set Handoff (P2)
+
+Spec: `docs/specs/WORKING-SET-HANDOFF-SPEC.md`
+Converged: 2026-06-06 (4 rounds)
+Reviewers: 4 internal lenses (security, adversarial, integration,
+lessons-aware+scalability — lessons mandatory every round) + cross-model
+`codex-cli:gpt-5.5`.
+
+## Round summary
+
+| Round | Material findings | Outcome |
+|-------|-------------------|---------|
+| 1 | ~25 across 5 reviewers + codex (MINOR ISSUES) | Full spec rewrite |
+| 2 | 5 material + 1 minor (integration CONVERGED) | 6 fixes folded |
+| 3 | 2 material (interaction-induced) + 6 codex folds | 8 deltas folded |
+| 4 | 0 | **CONVERGED** |
+
+## Material findings caught on paper (would have been production bugs)
+
+**Round 1 (criticals):**
+- Offline-prior-owner = the EXO case itself: a pull that dies at the
+  breaker while the producer is asleep is the incident, unrecovered →
+  durable pending-pull ledger (§3.4).
+- Single 32 MiB JSON response = the host's documented event-loop
+  starvation root cause re-created → 1 MiB chunked transport (§3.2).
+- 12mb body-parser + 5s MeshRpcClient timeout would reject/abort large
+  transfers → chunk size pinned far under both, near-cap test through
+  the REAL express path (§6).
+- Wrong trigger seam (ownAction/confirmClaim run on the ROUTER in the
+  single-router topology) → pull scheduled on the wrong machine; fixed
+  to the receiver's deliverMessage onAccepted hook (§3.3).
+- TOCTOU symlink swap between manifest computation and serve-time read
+  → O_NOFOLLOW + fd-verify (§3.2).
+
+**Round 2:**
+- Secret-scan overclaim: P1 declared the credential-shape enum
+  "not the boundary"; P2 had silently promoted it to primary content
+  barrier → honesty block: leak-reduction filter; boundary = the
+  same-operator posture (§3.1/§5).
+- Re-arm thundering herd: one returning machine holding N topics' files
+  would take N concurrent pulls while booting → staggered drain
+  (rearmConcurrency 1) + serve-side serveConcurrency 2 (§3.2/§3.4).
+- Cross-chunk chimera: chunk 1 of version A + chunk 3 of version B
+  assembles a file matching NO real version, livelocking on re-pull →
+  generation anchor + bounded restart-from-0 + `unstable` surfacing
+  (§3.2); liveSource skip extended to ALL of a live run's entries.
+- pending-pulls.json lost-update race — the EXACT shape that caused
+  topic-flood #3 → serialized mutate() funnel + corrupt-parse
+  quarantine, never silent-empty (§3.4).
+- Puller chunk cadence unspecified → pinned: sequential, yield, 
+  chunksPerTick 8, pressure-stretched delay (§3.2).
+- Supersede granularity: plural nominees per epoch; partial clear could
+  strand a sibling record → clears ALL lower-epoch records (§3.4).
+
+**Round 3 (interaction-induced by the round-2 fixes):**
+- `busy` counting against the (peer,topic,epoch) attempt cap would let
+  the staggered drain exhaust the very records it exists to recover →
+  busy = retry-without-penalty, busyRetryCap 10, exhaustion re-files
+  intact (§3.2).
+- maxTotalBytes on wire-bytes basis + restart-from-0 double-counts
+  discarded chunks, starving never-attempted files → pinned to
+  assembled, verification-passed bytes (§3.2).
+- Codex: generation anchor implied a whole-file hash per chunk request
+  → offset-0-only full hash + cheap fstat anchor per chunk, assembly
+  hash authoritative (§3.2). Plus: glossary, why-not-standard-protocols
+  note, cappedNominees disclosure, eviction-is-deletion honesty.
+
+**Round 4:** all deltas verified present + coherent; emergent
+interactions (busy-exhaustion ↔ drain, offset-0 hash cost under
+serveConcurrency, restart re-hash worst case 4×16 MiB bounded by
+chunkRestartCap) all resolve sanely. No material findings.
+
+## Approval
+
+Standing directive (Justin, topic 13481, 2026-06-06 ~03:05 PDT): "Yes,
+please enter a 24 hour autonomy session and continue to proceed through
+each project step making sure you implement each one and tested
+extremely thoroughly." — covers spec convergence, build, all-tier
+testing, and live verification on the echo pair for each project step.
+ELI16 companion rendered and sent to topic 13481 at approval time.

--- a/site/src/content/docs/architecture/under-the-hood.md
+++ b/site/src/content/docs/architecture/under-the-hood.md
@@ -116,6 +116,24 @@ Automatic git-based state synchronization for multi-machine setups. Debounces co
 ### CoherenceJournal
 The multi-machine "diary" writer (P1 of the coherence initiative). Each machine appends per-kind event streams — topic placement (with the reason it moved), session open/close/reap, autonomous runs with their artifact paths — so "what happened where, and where are the files?" is answerable from local disk. Emits are non-blocking memory hand-offs (a background flusher owns all disk I/O), crash repairs are counted, restores-from-backup are detected via incarnation tokens, and a strict per-kind schema keeps free text and secrets out. Signal-only by design: nothing ever kills, spawns, or moves anything based on journal data — the companion `CoherenceJournalReader` (a deliberately separate module, so a lint can ban actuators from importing it) serves the merged bounded read view behind `GET /coherence/journal`. Ships dark; per-kind retention keeps placement history effectively forever.
 
+### JournalSyncApplier
+The receive/serve engine of coherence-journal replication (P1.3). On the serve side it reads THIS machine's own durably-flushed stream from a peer-requested sequence number and returns a bounded batch (256KB cap — never a giant single response). On the receive side it durably appends a peer's entries under that peer's machine id, binding every entry to the AUTHENTICATED envelope sender — an entry claiming to be from a machine other than the one that sent it is counted as forged and dropped (first-hop-only trust: no machine can relay or invent another machine's history). Gap detection marks a replica stream `suspect` rather than silently skipping sequence numbers.
+
+### PeerPresencePuller
+The 30-second heartbeat that keeps a machine's view of its peers honest. Each tick it pulls every registered peer's session-status over the signed mesh channel, records who answered (feeding "is the Mini actually reachable?" rather than guessing), and piggybacks the coherence-journal advert exchange — a peer's response carries its own stream heads, so delta requests ride an existing cadence instead of a new polling loop. A peer coming back online after an outage is observed HERE, which is what re-arms recovery work that was waiting for it.
+
+### WorkingSetManifest
+The pure "what files make up this conversation's workspace on this machine?" computation (P2.1 of the coherence initiative). Candidates come from durable evidence only — the `autonomous/<topic>.*` filesystem convention plus every artifact path the topic's own journal stream recorded — never from anyone remembering to declare anything. Every candidate is canonicalized and jailed (symlinks at the final component refused; escapes counted, never served), hashed (sha256 is the only decision key; mtime is display-only), scanned for credential shapes (flagged files are listed but never transferred — an honest refusal, not a silent skip), and capped (per-file, headline exemption for the topic's own `.local.md`, max 64 files). When the topic's run is still live, every entry is marked "still being written" so a mid-run snapshot is never served.
+
+### AutonomousSessions
+The shared helpers behind multi-session autonomy: which topics have an active autonomous job right now (each topic's run lives at `.instar/autonomous/<topicId>.local.md`), the stable run-id derivation that lets monitors and the coherence journal name a specific run, and the parsing of run state (goal, duration, end time) that the can-start gate, the session clock, and the stop hook all share. One source of truth for "what's running" instead of three slightly-different parsers.
+
+### ApprovalLedger
+The durable record of operator approvals (PIN-gated decisions like mandate issuance). Every approval is appended with what was approved, when, and under which authority — so "did the operator actually authorize this?" is answerable from disk long after the chat scrolled away. Append-only and hash-chained: a tampered entry breaks the chain visibly rather than rewriting history silently.
+
+### MeshUrlAdvertiser
+Keeps each machine's reachable URL fresh in the machines registry. Tunnel URLs rotate (quick tunnels get a new hostname every restart), so peers would otherwise keep dialing a dead address; the advertiser publishes the current URL on a cadence and peers pick it up on their next presence pull. The reason "the Mini moved networks" doesn't mean "the Mini vanished."
+
 ### LiveConfig
 Watches `config.json` every 5 seconds for changes. When a value changes, it emits events so other systems can hot-reload without a server restart.
 

--- a/src/core/CoherenceJournalReader.ts
+++ b/src/core/CoherenceJournalReader.ts
@@ -89,6 +89,23 @@ export interface ReaderQueryResult {
   truncated: boolean;
 }
 
+/**
+ * Own-stream autonomous-run evidence for ONE topic (P2 §3.1 source 2).
+ * Own stream ONLY by construction — `query()`'s merged own+replica view is
+ * deliberately not used: replicas NOMINATE, they never feed THIS machine's
+ * manifest (WORKING-SET-HANDOFF-SPEC §3.1).
+ */
+export interface OwnAutonomousRuns {
+  /** Own-stream autonomous-run entries for the topic, newest-first. */
+  entries: ReaderEntry[];
+  /** True when the newest `started` run has no matching `stopped`. */
+  liveRun: boolean;
+  /** Union of jailed artifactPaths across the entries, deduped, order-stable. */
+  artifactPaths: string[];
+  /** Byte/archive bound hit — the answer may be missing older evidence. */
+  truncated: boolean;
+}
+
 export interface CoherenceJournalReaderConfig {
   /** Absolute path to the agent's `.instar/` directory (the stateDir). */
   stateDir: string;
@@ -359,6 +376,81 @@ export class CoherenceJournalReader {
       skippedCorrupt,
       truncated,
     };
+  }
+
+  /**
+   * P2 §3.1: the working-set manifest's journal-evidence source. Reads the
+   * OWN stream only (source === 'own', machineId === ownMachineId — never a
+   * replica, never a peer's stream that happens to sit in our own dir),
+   * kind `autonomous-run`, filtered to `topic`. Bounded exactly like query()
+   * (shared byte ceiling + archive cap); over-bound → truncated: true, the
+   * caller treats the evidence as partial rather than failing.
+   */
+  readOwnAutonomousRuns(topic: number, ownMachineId: string): OwnAutonomousRuns {
+    const streams = this.enumerate(ownMachineId, 'autonomous-run').filter(
+      (s) => s.source === 'own',
+    );
+
+    const collected: ReaderEntry[] = [];
+    let truncated = false;
+    let bytesRemaining = this.byteCeiling;
+
+    for (const group of this.groupStreams(streams)) {
+      const ordered = this.orderNewestFirst(group.files);
+      let archivesScanned = 0;
+      for (const f of ordered) {
+        if (bytesRemaining <= 0) {
+          truncated = true;
+          break;
+        }
+        if (f.isArchive && archivesScanned >= this.archiveCap) {
+          truncated = true;
+          break;
+        }
+        if (f.isArchive) archivesScanned++;
+        const read = readTailTolerant(this.io, f.file, READER_MAX_LIMIT, bytesRemaining);
+        if (read.truncated) truncated = true;
+        bytesRemaining -= Math.min(this.safeSize(f.file), bytesRemaining);
+        for (const e of read.entries) {
+          if (e.topic !== topic) continue;
+          collected.push({ ...e, source: 'own' });
+        }
+      }
+    }
+
+    const sorted = this.sortMerged(collected, false); // newest-first, (ts, machineId, seq)
+
+    // liveRun: the newest run's `started` with no `stopped` for the same runId.
+    // Scanning newest-first, the first action we see per runId is its LATEST
+    // state — a runId whose first-seen action is 'started' is still running.
+    let liveRun = false;
+    const seenRuns = new Set<string>();
+    for (const e of sorted) {
+      const runId = typeof e.data?.runId === 'string' ? (e.data.runId as string) : '';
+      const action = e.data?.action;
+      if (!runId || seenRuns.has(runId)) continue;
+      seenRuns.add(runId);
+      if (action === 'started') {
+        liveRun = true;
+        break;
+      }
+      if (action === 'stopped') break; // newest run is finished → not live
+    }
+
+    // artifactPaths union (write-time jailed already), deduped, newest-first
+    // stable order.
+    const seenPaths = new Set<string>();
+    const artifactPaths: string[] = [];
+    for (const e of sorted) {
+      const paths = Array.isArray(e.data?.artifactPaths) ? (e.data.artifactPaths as unknown[]) : [];
+      for (const p of paths) {
+        if (typeof p !== 'string' || !p || seenPaths.has(p)) continue;
+        seenPaths.add(p);
+        artifactPaths.push(p);
+      }
+    }
+
+    return { entries: sorted, liveRun, artifactPaths, truncated };
   }
 
   /** The opaque cursor for the LAST entry of a page (callers echo it back). */

--- a/src/core/WorkingSetManifest.ts
+++ b/src/core/WorkingSetManifest.ts
@@ -1,0 +1,314 @@
+/**
+ * WorkingSetManifest — P2.1 of multi-machine coherence: pure, on-demand
+ * computation of "what files make up this topic's workspace on THIS machine".
+ *
+ * Spec: docs/specs/WORKING-SET-HANDOFF-SPEC.md §3.1 (manifest — computed,
+ * never declared). No new persistent store; no willpower-dependent
+ * declarations. Sources, deduped:
+ *   1. Filesystem convention: `autonomous/<topic>.local.md` + `autonomous/
+ *      <topic>.*` (bounded readdir of the convention dir — never recursion).
+ *   2. Journal evidence: jailed `artifactPaths` from the topic's OWN-stream
+ *      autonomous-run entries (CoherenceJournalReader.readOwnAutonomousRuns —
+ *      injected by the caller so this module stays pure).
+ *
+ * Discipline (§3.1):
+ *  - Every candidate is canonicalized + re-jailed HERE even though journal
+ *    paths were jailed at write time (jails are enforced at the data's birth
+ *    AND at every serve boundary — defense in depth, P1 invariant).
+ *  - `mtime` is DISPLAY-ONLY (P1's `ts` treatment): every diff/skip decision
+ *    downstream keys on sha256 exclusively.
+ *  - The credential-shape scan runs over each candidate file's BYTES; a
+ *    flagged file is LISTED `secretFlagged: true` and never transferred — an
+ *    honest, surfaced refusal, never a silent skip. The scan is a
+ *    LEAK-REDUCTION filter, not the security boundary (the boundary is the
+ *    same-operator peer posture — §3.1/§5).
+ *  - When the topic's own journal shows a live autonomous run, EVERY entry is
+ *    `liveSource: true` (any of them is plausibly mid-write) — the pull
+ *    re-fires on the run's `stopped` (§3.4).
+ *  - Bounded everywhere: per-file caps (headline exemption for the topic's
+ *    `.local.md`), maxFiles, hash ceiling. Over-cap entries are LISTED
+ *    `tooLarge: true` — observability is not delivery.
+ */
+
+import crypto from 'node:crypto';
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { redactForLiveTail } from './liveTailRedaction.js';
+import type { OwnAutonomousRuns } from './CoherenceJournalReader.js';
+
+/** §3.7 defaults (mirrored in ConfigDefaults.coherenceJournal.workingSet). */
+export const DEFAULT_WORKING_SET_CAPS: WorkingSetCaps = {
+  maxFileBytes: 4 * 1024 * 1024,
+  headlineFileBytes: 16 * 1024 * 1024,
+  maxFiles: 64,
+  maxTotalBytes: 32 * 1024 * 1024,
+};
+
+/**
+ * Above this, a file's sha256 is reported `null` rather than paying an
+ * unbounded hash at manifest time (a tooLarge file never transfers anyway,
+ * so the hash is disclosure metadata, not verification material).
+ */
+export const HASH_BYTE_CEILING = 64 * 1024 * 1024;
+
+export interface WorkingSetCaps {
+  maxFileBytes: number;
+  headlineFileBytes: number;
+  maxFiles: number;
+  /** TOTAL-SET transfer budget — enforced by the PULL layer, carried here so
+   *  both sides quote one number (§3.2 assembled-bytes basis). */
+  maxTotalBytes: number;
+}
+
+export interface WorkingSetEntry {
+  /** Relative to the stateDir; receiver treats it as hostile input (§3.2). */
+  relPath: string;
+  bytes: number;
+  /** null only above HASH_BYTE_CEILING (honest, bounded compute). */
+  sha256: string | null;
+  /** ISO — DISPLAY-ONLY, never a decision key (§3.1). */
+  mtime: string;
+  tooLarge?: boolean;
+  secretFlagged?: boolean;
+  liveSource?: boolean;
+}
+
+export interface WorkingSetManifestResult {
+  topic: number;
+  computedAt: string;
+  entries: WorkingSetEntry[];
+  /** The topic's own journal shows a still-active autonomous run. */
+  liveRun: boolean;
+  /** Journal evidence was byte/archive-bounded — older artifacts may be missing. */
+  evidenceTruncated: boolean;
+  /** Candidates dropped past maxFiles (counted, never silent — §3.1). */
+  filesTruncated: number;
+  /** Candidates rejected by the compute-time jail. */
+  jailRejected: number;
+  /** Journal-evidenced paths no longer on disk (rotated/deleted/never durable). */
+  goneFromDisk: number;
+  /** Sum of bytes the pull layer may actually move (excludes tooLarge /
+   *  secretFlagged / liveSource entries). */
+  transferableBytes: number;
+}
+
+/** Minimal fs seam (tests). */
+export interface WorkingSetFs {
+  readdirSync: (dir: string) => string[];
+  lstatSync: (p: string) => { isFile(): boolean; isSymbolicLink(): boolean; size: number; mtimeMs: number };
+  existsSync: (p: string) => boolean;
+  realpathSync: (p: string) => string;
+  readFileSync: (p: string) => Buffer;
+}
+
+export interface ComputeWorkingSetOpts {
+  /** Absolute path to the agent's `.instar/` directory. */
+  stateDir: string;
+  topic: number;
+  /** Own-stream journal evidence, injected by the caller (keeps this pure). */
+  runs: OwnAutonomousRuns;
+  caps?: Partial<WorkingSetCaps>;
+  now?: () => Date;
+  fsImpl?: WorkingSetFs;
+  /** Secret-content scan seam; defaults to the versioned credential-shape enum. */
+  secretScan?: (content: Buffer) => boolean;
+}
+
+function realFs(): WorkingSetFs {
+  return {
+    readdirSync: (dir) => fs.readdirSync(dir),
+    lstatSync: (p) => fs.lstatSync(p),
+    existsSync: (p) => fs.existsSync(p),
+    realpathSync: (p) => fs.realpathSync(p),
+    readFileSync: (p) => fs.readFileSync(p),
+  };
+}
+
+function defaultSecretScan(content: Buffer): boolean {
+  return redactForLiveTail(content.toString('utf-8')).redactedCount > 0;
+}
+
+/** One candidate before stat/hash. */
+interface Candidate {
+  abs: string;
+  fromJournal: boolean;
+}
+
+export function computeWorkingSet(opts: ComputeWorkingSetOpts): WorkingSetManifestResult {
+  const io = opts.fsImpl ?? realFs();
+  const caps: WorkingSetCaps = { ...DEFAULT_WORKING_SET_CAPS, ...opts.caps };
+  const now = opts.now ?? (() => new Date());
+  const scan = opts.secretScan ?? defaultSecretScan;
+
+  // Realpath the stateDir itself so the jail roots and the realpathed
+  // candidates live in one namespace (macOS: /var/folders → /private/var).
+  let stateDir = path.resolve(opts.stateDir);
+  try {
+    stateDir = io.realpathSync(stateDir);
+  } catch { /* @silent-fallback-ok: a not-yet-existing stateDir keeps its lexical path; containment still bounds it (WORKING-SET-HANDOFF-SPEC §3.1) */
+  }
+  const conventionDir = path.join(stateDir, 'autonomous');
+  // Same roots as the journal writer's artifactRoots default (§3.1).
+  const jailRoots = [conventionDir, stateDir];
+
+  let jailRejected = 0;
+  let goneFromDisk = 0;
+
+  // ---- gather candidates (deduped on canonical absolute path) -------------
+  const candidates = new Map<string, Candidate>();
+
+  // Source 1: filesystem convention — bounded readdir, no recursion. Names
+  // are matched with a `<topic>.` prefix so topic 134 never matches 13481.
+  let names: string[] = [];
+  try {
+    names = io.readdirSync(conventionDir);
+  } catch { /* @silent-fallback-ok: convention dir absent = no convention files; journal evidence still applies (WORKING-SET-HANDOFF-SPEC §3.1) */
+    names = [];
+  }
+  const prefix = `${opts.topic}.`;
+  for (const name of names) {
+    if (!name.startsWith(prefix)) continue;
+    candidates.set(path.join(conventionDir, name), {
+      abs: path.join(conventionDir, name),
+      fromJournal: false,
+    });
+  }
+
+  // Source 2: journal evidence (already write-time jailed; re-jailed below).
+  for (const p of opts.runs.artifactPaths) {
+    const abs = path.isAbsolute(p) ? path.resolve(p) : path.resolve(stateDir, p);
+    if (!candidates.has(abs)) candidates.set(abs, { abs, fromJournal: true });
+  }
+
+  // ---- jail + stat + hash + scan -------------------------------------------
+  const headlineAbs = path.join(conventionDir, `${opts.topic}.local.md`);
+  const surviving: WorkingSetEntry[] = [];
+
+  const seenJailed = new Set<string>();
+  for (const cand of candidates.values()) {
+    // Jail FIRST (works on nonexistent paths too) — an escape-shaped path is
+    // jailRejected even when nothing exists at it; only an in-jail path that
+    // has vanished counts as benign goneFromDisk.
+    const jailed = jailContained(io, jailRoots, cand.abs);
+    if (jailed === null) {
+      jailRejected++;
+      continue;
+    }
+    // Regular files only — lstat the ORIGINAL path (not the realpathed one) so
+    // a symlink at the FINAL component is refused even when its target
+    // realpaths inside the jail (serve-time O_NOFOLLOW will refuse it anyway;
+    // the manifest must not promise what serve refuses).
+    let st: ReturnType<WorkingSetFs['lstatSync']>;
+    try {
+      st = io.lstatSync(cand.abs);
+    } catch { /* @silent-fallback-ok: a journal-evidenced path that vanished is benign evolution, counted as goneFromDisk — never an error (WORKING-SET-HANDOFF-SPEC §3.1) */
+      goneFromDisk++;
+      continue;
+    }
+    if (st.isSymbolicLink() || !st.isFile()) {
+      jailRejected++;
+      continue;
+    }
+    // Dedupe on the CANONICAL path — a journal path and a convention hit that
+    // resolve to the same file are one entry, whatever spelling each used.
+    if (seenJailed.has(jailed)) continue;
+    seenJailed.add(jailed);
+
+    const isHeadline = jailed === headlineAbs;
+    const cap = isHeadline ? caps.headlineFileBytes : caps.maxFileBytes;
+    const tooLarge = st.size > cap;
+
+    let sha256: string | null = null;
+    let secretFlagged = false;
+    if (st.size <= HASH_BYTE_CEILING) {
+      try {
+        const content = io.readFileSync(jailed);
+        sha256 = crypto.createHash('sha256').update(content).digest('hex');
+        // Scan only what could transfer — a tooLarge file never moves, so the
+        // read above is its last touch.
+        if (!tooLarge) secretFlagged = scan(content);
+      } catch { /* @silent-fallback-ok: file vanished between lstat and read — benign evolution, counted as goneFromDisk (WORKING-SET-HANDOFF-SPEC §3.1) */
+        goneFromDisk++;
+        continue;
+      }
+    }
+
+    surviving.push({
+      relPath: path.relative(stateDir, jailed),
+      bytes: st.size,
+      sha256,
+      mtime: new Date(st.mtimeMs).toISOString(),
+      ...(tooLarge ? { tooLarge: true } : {}),
+      ...(secretFlagged ? { secretFlagged: true } : {}),
+    });
+  }
+
+  // ---- deterministic order + maxFiles ---------------------------------------
+  // Headline first, then alpha on relPath — so truncation at maxFiles never
+  // drops the headline and is stable across recomputations.
+  const headlineRel = path.relative(stateDir, headlineAbs);
+  surviving.sort((a, b) => {
+    if (a.relPath === headlineRel) return -1;
+    if (b.relPath === headlineRel) return 1;
+    return a.relPath < b.relPath ? -1 : a.relPath > b.relPath ? 1 : 0;
+  });
+  const filesTruncated = Math.max(0, surviving.length - caps.maxFiles);
+  const kept = surviving.slice(0, caps.maxFiles);
+
+  // ---- liveSource (§3.2 live-source honesty — ALL of a live run's entries) --
+  if (opts.runs.liveRun) {
+    for (const e of kept) e.liveSource = true;
+  }
+
+  let transferableBytes = 0;
+  for (const e of kept) {
+    if (!e.tooLarge && !e.secretFlagged && !e.liveSource) transferableBytes += e.bytes;
+  }
+
+  return {
+    topic: opts.topic,
+    computedAt: now().toISOString(),
+    entries: kept,
+    liveRun: opts.runs.liveRun,
+    evidenceTruncated: opts.runs.truncated,
+    filesTruncated,
+    jailRejected,
+    goneFromDisk,
+    transferableBytes,
+  };
+}
+
+/**
+ * Compute-time jail: realpath the deepest existing ancestor (symlink-escape
+ * protection on the existing prefix), require containment under one of the
+ * allowlisted roots for BOTH the resolved ancestor and the final path.
+ * Mirrors CoherenceJournal's write-time jail (§3.1 — same rules at every
+ * boundary).
+ */
+function jailContained(io: WorkingSetFs, roots: string[], candidate: string): string | null {
+  let existing = candidate;
+  const tail: string[] = [];
+  while (!io.existsSync(existing)) {
+    const parent = path.dirname(existing);
+    if (parent === existing) break;
+    tail.unshift(path.basename(existing));
+    existing = parent;
+  }
+  let realExisting: string;
+  try {
+    realExisting = io.realpathSync(existing);
+  } catch { /* @silent-fallback-ok: realpath failure on a vanishing path falls back to the lexical path, which containment still bounds (WORKING-SET-HANDOFF-SPEC §3.1) */
+    realExisting = existing;
+  }
+  const finalPath = tail.length ? path.join(realExisting, ...tail) : realExisting;
+  for (const root of roots) {
+    if (isContained(root, realExisting) && isContained(root, finalPath)) return finalPath;
+  }
+  return null;
+}
+
+function isContained(root: string, p: string): boolean {
+  const rel = path.relative(root, p);
+  return rel === '' || (!rel.startsWith('..') && !path.isAbsolute(rel));
+}

--- a/tests/unit/WorkingSetManifest.test.ts
+++ b/tests/unit/WorkingSetManifest.test.ts
@@ -1,0 +1,289 @@
+// safe-git-allow: test fixture cleanup uses fs.rmSync on tmp dirs only.
+// safe-fs-allow: test fixture cleanup uses fs.rmSync on tmp dirs only.
+/**
+ * Tier-1 unit tests for WorkingSetManifest (P2.1) +
+ * CoherenceJournalReader.readOwnAutonomousRuns — WORKING-SET-HANDOFF-SPEC §3.1.
+ *
+ * Covers (per §6 Unit): convention + journal sources deduped; topic-prefix
+ * exactness (134 never matches 13481); jail cases (escape via `..`-shaped
+ * journal path, symlink at final component, symlinked parent escape); caps
+ * (tooLarge, headline 16MiB exemption, maxFiles truncation keeps the
+ * headline); secretFlagged listing (flagged file listed + excluded from
+ * transferableBytes — honest refusal, not a silent skip); mtime display-only
+ * (an mtime-only change leaves sha256 the decision key); liveSource covering
+ * ALL of a live run's entries; goneFromDisk counting; reader own-stream-only
+ * + liveRun semantics + artifactPaths union.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import crypto from 'node:crypto';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import {
+  computeWorkingSet,
+  DEFAULT_WORKING_SET_CAPS,
+  type WorkingSetManifestResult,
+} from '../../src/core/WorkingSetManifest.js';
+import {
+  CoherenceJournalReader,
+  type OwnAutonomousRuns,
+} from '../../src/core/CoherenceJournalReader.js';
+import type { JournalEntry } from '../../src/core/CoherenceJournal.js';
+
+let tmpDir: string;
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'working-set-manifest-test-'));
+  fs.mkdirSync(path.join(tmpDir, 'autonomous'), { recursive: true });
+});
+
+afterEach(() => {
+  try {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  } catch {
+    /* best-effort */
+  }
+});
+
+const TOPIC = 134;
+
+function noRuns(over: Partial<OwnAutonomousRuns> = {}): OwnAutonomousRuns {
+  return { entries: [], liveRun: false, artifactPaths: [], truncated: false, ...over };
+}
+
+function writeConvention(name: string, content: string | Buffer): string {
+  const p = path.join(tmpDir, 'autonomous', name);
+  fs.writeFileSync(p, content);
+  return p;
+}
+
+function compute(over: Partial<Parameters<typeof computeWorkingSet>[0]> = {}): WorkingSetManifestResult {
+  return computeWorkingSet({ stateDir: tmpDir, topic: TOPIC, runs: noRuns(), ...over });
+}
+
+function sha(content: string | Buffer): string {
+  return crypto.createHash('sha256').update(content).digest('hex');
+}
+
+describe('WorkingSetManifest — sources + dedupe', () => {
+  it('lists convention files for the topic, with correct bytes/sha256', () => {
+    writeConvention(`${TOPIC}.local.md`, 'headline content');
+    writeConvention(`${TOPIC}.notes.md`, 'side notes');
+    const m = compute();
+    expect(m.entries).toHaveLength(2);
+    const headline = m.entries[0];
+    expect(headline.relPath).toBe(path.join('autonomous', `${TOPIC}.local.md`));
+    expect(headline.bytes).toBe(Buffer.byteLength('headline content'));
+    expect(headline.sha256).toBe(sha('headline content'));
+    expect(m.transferableBytes).toBe(headline.bytes + m.entries[1].bytes);
+  });
+
+  it('topic prefix is exact — topic 134 never matches 13481 files', () => {
+    writeConvention(`13481.local.md`, 'other topic');
+    writeConvention(`${TOPIC}.local.md`, 'mine');
+    const m = compute();
+    expect(m.entries).toHaveLength(1);
+    expect(m.entries[0].relPath).toContain(`${TOPIC}.local.md`);
+  });
+
+  it('journal artifactPaths merge in, deduped against convention hits', () => {
+    const conv = writeConvention(`${TOPIC}.local.md`, 'headline');
+    const extra = path.join(tmpDir, 'analysis.md');
+    fs.writeFileSync(extra, 'journal-evidenced artifact');
+    const m = compute({ runs: noRuns({ artifactPaths: [conv, extra] }) });
+    expect(m.entries).toHaveLength(2); // conv deduped, extra added
+    const rels = m.entries.map((e) => e.relPath);
+    expect(rels).toContain('analysis.md');
+  });
+
+  it('journal path no longer on disk counts goneFromDisk, never errors', () => {
+    const m = compute({ runs: noRuns({ artifactPaths: [path.join(tmpDir, 'vanished.md')] }) });
+    expect(m.entries).toHaveLength(0);
+    expect(m.goneFromDisk).toBe(1);
+  });
+});
+
+describe('WorkingSetManifest — jail', () => {
+  it('rejects a journal path escaping the stateDir', () => {
+    const outside = path.join(os.tmpdir(), 'outside-jail.md');
+    const m = compute({ runs: noRuns({ artifactPaths: [outside, '../outside-rel.md'] }) });
+    expect(m.entries).toHaveLength(0);
+    expect(m.jailRejected).toBe(2);
+  });
+
+  it('rejects a symlink at the final component even when its target is inside the jail', () => {
+    const real = writeConvention(`${TOPIC}.real.md`, 'real');
+    const link = path.join(tmpDir, 'autonomous', `${TOPIC}.link.md`);
+    fs.symlinkSync(real, link);
+    const m = compute();
+    expect(m.entries.map((e) => e.relPath)).toEqual([path.join('autonomous', `${TOPIC}.real.md`)]);
+    expect(m.jailRejected).toBe(1);
+  });
+
+  it('rejects a symlinked-parent escape from a journal path', () => {
+    const outsideDir = fs.mkdtempSync(path.join(os.tmpdir(), 'outside-'));
+    fs.writeFileSync(path.join(outsideDir, 'secret.md'), 'outside');
+    const linkDir = path.join(tmpDir, 'escape');
+    fs.symlinkSync(outsideDir, linkDir);
+    const m = compute({ runs: noRuns({ artifactPaths: [path.join(linkDir, 'secret.md')] }) });
+    expect(m.entries).toHaveLength(0);
+    expect(m.jailRejected).toBe(1);
+    fs.rmSync(outsideDir, { recursive: true, force: true });
+  });
+});
+
+describe('WorkingSetManifest — caps', () => {
+  it('marks a non-headline file over maxFileBytes tooLarge (listed, hashed, excluded from transferable)', () => {
+    const big = Buffer.alloc(64, 'x');
+    writeConvention(`${TOPIC}.big.bin`, big);
+    const m = compute({ caps: { maxFileBytes: 32 } });
+    expect(m.entries).toHaveLength(1);
+    expect(m.entries[0].tooLarge).toBe(true);
+    expect(m.entries[0].sha256).toBe(sha(big)); // still disclosed
+    expect(m.transferableBytes).toBe(0);
+  });
+
+  it('headline exemption: <topic>.local.md is allowed past maxFileBytes up to headlineFileBytes', () => {
+    writeConvention(`${TOPIC}.local.md`, Buffer.alloc(64, 'h'));
+    const m = compute({ caps: { maxFileBytes: 32, headlineFileBytes: 128 } });
+    expect(m.entries[0].tooLarge).toBeUndefined();
+    const m2 = compute({ caps: { maxFileBytes: 32, headlineFileBytes: 48 } });
+    expect(m2.entries[0].tooLarge).toBe(true);
+  });
+
+  it('maxFiles truncation is counted, deterministic, and never drops the headline', () => {
+    writeConvention(`${TOPIC}.local.md`, 'headline');
+    for (let i = 0; i < 5; i++) writeConvention(`${TOPIC}.f${i}.md`, `f${i}`);
+    const m = compute({ caps: { maxFiles: 3 } });
+    expect(m.entries).toHaveLength(3);
+    expect(m.filesTruncated).toBe(3);
+    expect(m.entries[0].relPath).toContain('.local.md'); // headline survives
+  });
+});
+
+describe('WorkingSetManifest — secretFlagged + mtime + liveSource', () => {
+  it('flags credential-shaped content, lists it, and excludes it from transferableBytes', () => {
+    writeConvention(`${TOPIC}.creds.md`, 'token = "abcdef123456789012345"');
+    writeConvention(`${TOPIC}.clean.md`, 'no secrets here');
+    const m = compute();
+    const flagged = m.entries.find((e) => e.relPath.includes('creds'))!;
+    const clean = m.entries.find((e) => e.relPath.includes('clean'))!;
+    expect(flagged.secretFlagged).toBe(true); // LISTED — honest refusal, not a silent skip
+    expect(clean.secretFlagged).toBeUndefined();
+    expect(m.transferableBytes).toBe(clean.bytes);
+  });
+
+  it('mtime is display-only: touching a file changes mtime but sha256 stays the decision key', () => {
+    const p = writeConvention(`${TOPIC}.stable.md`, 'same content');
+    const before = compute().entries[0];
+    fs.utimesSync(p, new Date(Date.now() + 60_000), new Date(Date.now() + 60_000));
+    const after = compute().entries[0];
+    expect(after.mtime).not.toBe(before.mtime);
+    expect(after.sha256).toBe(before.sha256);
+  });
+
+  it('liveRun marks EVERY entry liveSource and zeroes transferableBytes', () => {
+    writeConvention(`${TOPIC}.local.md`, 'headline');
+    writeConvention(`${TOPIC}.notes.md`, 'notes');
+    const m = compute({ runs: noRuns({ liveRun: true }) });
+    expect(m.liveRun).toBe(true);
+    expect(m.entries.every((e) => e.liveSource === true)).toBe(true);
+    expect(m.transferableBytes).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// CoherenceJournalReader.readOwnAutonomousRuns
+// ---------------------------------------------------------------------------
+
+const OWN = 'm_own';
+const PEER = 'm_peer';
+
+function journalDir(): string {
+  return path.join(tmpDir, 'state', 'coherence-journal');
+}
+
+function writeStream(
+  scope: 'own' | 'peers',
+  machine: string,
+  entries: JournalEntry[],
+): void {
+  const dir = scope === 'own' ? journalDir() : path.join(journalDir(), 'peers');
+  fs.mkdirSync(dir, { recursive: true });
+  const file = path.join(dir, `${machine}.autonomous-run.jsonl`);
+  fs.writeFileSync(file, entries.map((e) => JSON.stringify(e)).join('\n') + '\n');
+}
+
+function runEntry(
+  machine: string,
+  seq: number,
+  topic: number,
+  action: 'started' | 'stopped',
+  runId: string,
+  artifactPaths: string[] = [],
+): JournalEntry {
+  return {
+    seq,
+    ts: `2026-06-06T00:00:${String(seq).padStart(2, '0')}.000Z`,
+    machine,
+    kind: 'autonomous-run',
+    topic,
+    data: { action, runId, artifactPaths },
+  };
+}
+
+describe('CoherenceJournalReader.readOwnAutonomousRuns', () => {
+  it('reads OWN stream only — a replica with matching machineId never feeds the manifest', () => {
+    writeStream('own', OWN, [runEntry(OWN, 1, TOPIC, 'started', 'r1', ['/tmp/own.md'])]);
+    writeStream('peers', PEER, [runEntry(PEER, 1, TOPIC, 'started', 'r9', ['/tmp/peer.md'])]);
+    const reader = new CoherenceJournalReader({ stateDir: tmpDir });
+    const own = reader.readOwnAutonomousRuns(TOPIC, OWN);
+    expect(own.entries).toHaveLength(1);
+    expect(own.artifactPaths).toEqual(['/tmp/own.md']);
+    // The peer's machine id yields nothing from the own dir either:
+    const peerAsOwn = reader.readOwnAutonomousRuns(TOPIC, PEER);
+    expect(peerAsOwn.entries).toHaveLength(0);
+  });
+
+  it('liveRun true when the newest run has started without stopped', () => {
+    writeStream('own', OWN, [
+      runEntry(OWN, 1, TOPIC, 'started', 'r1'),
+      runEntry(OWN, 2, TOPIC, 'stopped', 'r1'),
+      runEntry(OWN, 3, TOPIC, 'started', 'r2'),
+    ]);
+    const reader = new CoherenceJournalReader({ stateDir: tmpDir });
+    expect(reader.readOwnAutonomousRuns(TOPIC, OWN).liveRun).toBe(true);
+  });
+
+  it('liveRun false when the newest run is stopped (an older crashed run does not resurrect it)', () => {
+    writeStream('own', OWN, [
+      runEntry(OWN, 1, TOPIC, 'started', 'r0'), // never stopped (crash) — older
+      runEntry(OWN, 2, TOPIC, 'started', 'r1'),
+      runEntry(OWN, 3, TOPIC, 'stopped', 'r1'),
+    ]);
+    const reader = new CoherenceJournalReader({ stateDir: tmpDir });
+    expect(reader.readOwnAutonomousRuns(TOPIC, OWN).liveRun).toBe(false);
+  });
+
+  it('filters by topic and unions artifactPaths deduped, newest-first', () => {
+    writeStream('own', OWN, [
+      runEntry(OWN, 1, TOPIC, 'started', 'r1', ['/a.md', '/b.md']),
+      runEntry(OWN, 2, 999, 'started', 'rX', ['/other-topic.md']),
+      runEntry(OWN, 3, TOPIC, 'stopped', 'r1', ['/b.md', '/c.md']),
+    ]);
+    const reader = new CoherenceJournalReader({ stateDir: tmpDir });
+    const own = reader.readOwnAutonomousRuns(TOPIC, OWN);
+    expect(own.entries).toHaveLength(2);
+    expect(own.artifactPaths).toEqual(['/b.md', '/c.md', '/a.md']); // newest entry's paths first
+  });
+
+  it('empty stream set → empty result, liveRun false, no throw', () => {
+    const reader = new CoherenceJournalReader({ stateDir: tmpDir });
+    const own = reader.readOwnAutonomousRuns(TOPIC, OWN);
+    expect(own.entries).toHaveLength(0);
+    expect(own.liveRun).toBe(false);
+    expect(own.artifactPaths).toEqual([]);
+    expect(own.truncated).toBe(false);
+  });
+});

--- a/upgrades/next/working-set-manifest-p21.md
+++ b/upgrades/next/working-set-manifest-p21.md
@@ -1,0 +1,58 @@
+# Working-set manifest (P2.1) — a topic's workspace becomes computable
+
+## What Changed
+
+First slice of the converged Working-Set Handoff spec (P2 of multi-machine
+coherence): a machine can now compute, on demand and from durable evidence,
+"what files make up topic T's workspace here" — never from anyone remembering
+to declare anything.
+
+- `src/core/WorkingSetManifest.ts` — `computeWorkingSet()`: candidates from
+  the filesystem convention (`autonomous/<topic>.*`, bounded readdir, exact
+  topic-prefix so 134 never matches 13481) + the topic's own-stream journal
+  `artifactPaths`; every candidate compute-time jailed (realpath containment,
+  final-component symlinks refused), sha256-hashed, scanned for credential
+  shapes via the versioned redaction enum, and capped (4MiB per file, 16MiB
+  headline exemption for `<topic>.local.md`, 64 files). Over-cap and flagged
+  entries are LISTED with honest flags (`tooLarge` / `secretFlagged` /
+  `liveSource`) — never silently skipped. `mtime` is display-only; sha256 is
+  the only decision key.
+- `CoherenceJournalReader.readOwnAutonomousRuns(topic, ownMachineId)` — the
+  own-stream-only evidence source (replicas nominate; they never feed THIS
+  machine's manifest). `liveRun` derives from the newest run's state, so a
+  still-writing run marks every entry "still being written" rather than
+  serving a torn snapshot.
+
+Pure module — nothing constructs it at boot yet. The P2.2 transfer verb,
+receiver trigger, and pending-pull ledger wire it into the move path next.
+
+## What to Tell Your User
+
+Nothing user-visible yet. This is the foundation slice of "moving a
+conversation between your machines moves its working files too" — the part
+that lets a machine reliably answer what those files are. The transfer itself
+lands in the next slice.
+
+## Summary of New Capabilities
+
+- `computeWorkingSet(opts)` (`src/core/WorkingSetManifest.ts`) — pure,
+  bounded, jailed manifest computation for one topic's working files, with
+  honest per-entry flags and counted degradations (`jailRejected`,
+  `goneFromDisk`, `filesTruncated`).
+- `CoherenceJournalReader.readOwnAutonomousRuns(topic, ownMachineId)` —
+  own-stream autonomous-run evidence: newest-first entries, `liveRun`,
+  deduped `artifactPaths`, bounded with `truncated` honesty.
+- Spec: `docs/specs/WORKING-SET-HANDOFF-SPEC.md` (converged 2026-06-06,
+  4 rounds, cross-model codex-cli:gpt-5.5; report at
+  `docs/specs/reports/working-set-handoff-convergence.md`).
+
+## Evidence
+
+- `tests/unit/WorkingSetManifest.test.ts` — 18 passing: sources + canonical
+  dedupe, jail matrix (escape-shaped path, final-component symlink,
+  symlinked-parent escape), caps (tooLarge listed+hashed, headline exemption,
+  maxFiles truncation keeps the headline), secretFlagged honest listing +
+  transferableBytes exclusion, mtime display-only, liveSource covers ALL of a
+  live run's entries, reader own-stream-only + liveRun semantics.
+- `tests/unit/CoherenceJournalReader.test.ts` — 15 passing unchanged.
+- Full typecheck clean.

--- a/upgrades/side-effects/working-set-manifest-p21.md
+++ b/upgrades/side-effects/working-set-manifest-p21.md
@@ -1,0 +1,89 @@
+# Side-Effects Review — Working-Set Manifest (P2.1 of multi-machine coherence)
+
+**Version / slug:** `working-set-manifest-p21`
+**Date:** `2026-06-06`
+**Author:** `echo`
+**Second-pass reviewer:** `not required (pure read-only module + reader method; no actuation, no routes, no persistence)`
+
+## Summary of the change
+
+P2.1 of the converged WORKING-SET-HANDOFF-SPEC: the pure, on-demand computation
+of "what files make up topic T's workspace on THIS machine". Two pieces:
+
+1. `src/core/WorkingSetManifest.ts` — `computeWorkingSet()`: candidates from the
+   filesystem convention (`autonomous/<topic>.*`, bounded readdir) + the topic's
+   own-stream journal `artifactPaths`; every candidate compute-time jailed
+   (realpath containment + final-component symlink refusal), hashed, scanned for
+   credential shapes (reusing the versioned `redactForLiveTail` enum), capped
+   (per-file / headline-exempt / maxFiles), and listed with honest flags
+   (`tooLarge`, `secretFlagged`, `liveSource`) — never silently skipped.
+2. `CoherenceJournalReader.readOwnAutonomousRuns(topic, ownMachineId)` — the
+   own-stream-only journal evidence source (replicas nominate, they never feed
+   this machine's manifest), with `liveRun` derived from the NEWEST run's state.
+
+Ships as a pure module: nothing constructs it at boot yet (the P2.2 verb +
+trigger wire it). Zero behavior change for any running agent.
+
+## Decision-point inventory
+
+- **Jail verdict** (escape vs contained): mirrored from the P1 write-time jail;
+  both the realpathed ancestor AND the final path must sit under
+  `[autonomous/, stateDir]`. Jail runs BEFORE existence checks so an
+  escape-shaped path is `jailRejected` even when nothing exists at it; only an
+  in-jail vanished path counts `goneFromDisk` (benign evolution, never an attack
+  log).
+- **Final-component symlink**: refused via lstat on the ORIGINAL path even when
+  its target realpaths inside the jail — the manifest must not promise what the
+  serve-side `O_NOFOLLOW` will refuse.
+- **liveRun**: the NEWEST runId's first-seen action decides (started→live,
+  stopped→not). An older crashed run (started, never stopped) does NOT
+  resurrect liveness — newest evidence wins; the §3.4 pending-pull re-fire on
+  `stopped` covers the re-arm.
+- **secretFlagged**: scan only what could transfer (tooLarge files never move,
+  so they are hashed for disclosure but not scanned).
+
+## 1. Over-block
+
+**What legitimate inputs does this change reject?** A symlink whose target is a
+legitimate in-jail file is refused (deliberate — serve-time parity). A topic's
+file larger than its cap is listed-not-transferable (deliberate; headline gets
+the 16MiB exemption + the §3.1 Agent-Health notice lands with P2.2). Files past
+maxFiles=64 are dropped from the manifest with a count — deterministic order
+keeps the headline always inside the cap.
+
+## 2. Under-block
+
+**What does this still miss?** The credential-shape scan is a LEAK-REDUCTION
+filter, not a boundary (stated in spec §3.1/§5) — content-shaped secrets pass
+it; acceptable strictly under the same-operator peer posture. `sha256: null`
+above the 64MiB hash ceiling keeps compute bounded at the cost of disclosure
+completeness for absurd files (which never transfer anyway). TOCTOU between
+manifest compute and serve-time read is NOT this module's job — §3.2's
+O_NOFOLLOW + fd-verify at the verb layer (P2.2) is.
+
+## 3. Level-of-abstraction fit
+
+**Right layer?** Yes. The manifest is a pure function over (stateDir, topic,
+injected journal evidence) — the reader call happens at the caller so the
+module has no journal dependency; the jail logic mirrors `CoherenceJournal`'s
+write-time jail (same rules at every boundary, P1 invariant). The reader
+method lives on `CoherenceJournalReader` because that is the ONLY module the
+§3.9 actuation-ban lint tracks for journal reads.
+
+## 4. Blast radius
+
+Nothing imports either addition yet. No routes, no config, no persistence, no
+hooks, no migrations. A bug here can only mis-list files once P2.2 wires it —
+and the pull layer re-verifies every byte against served hashes.
+
+## Evidence
+
+- `tests/unit/WorkingSetManifest.test.ts` — 18 passing: sources+dedupe (incl.
+  topic-prefix exactness: 134 never matches 13481), jail matrix (escape,
+  final-component symlink, symlinked-parent), caps (tooLarge, headline
+  exemption, maxFiles keeps headline), secretFlagged honest listing, mtime
+  display-only, liveSource covers ALL live-run entries, reader own-stream-only
+  + liveRun semantics + artifactPaths union.
+- `tests/unit/CoherenceJournalReader.test.ts` — 15 passing unchanged (no
+  regression from the new method).
+- Full typecheck clean.


### PR DESCRIPTION
## ELI16

Until now, when one of my conversations moved from the Laptop to the Mini, it was like an employee changing offices but leaving every paper on the old desk: the chat continued, but the working files — the overnight analysis, the run's notes — stayed behind. That's exactly what bit us in the EXO incident. P1 made the files FINDABLE; P2 makes them FOLLOW. This PR ships the fully-reviewed design plus the first piece: each machine can now compute, on demand, "what files make up this conversation's workspace here" — from durable evidence (the run's own file, the topic's file-naming convention, and every path the diary recorded), never from anyone remembering to declare anything. Files with pasted secrets are flagged and never travel; a still-running job's file is marked "still being written" instead of being snapshotted mid-sentence; everything is size-capped and locked inside the agent's own state directory.

## What

P2 of the multimachine-coherence initiative: **Working-Set Handoff** — when a topic moves between machines, its working files follow. This PR ships the converged spec + the first build slice (P2.1, the manifest).

### The spec (docs/specs/WORKING-SET-HANDOFF-SPEC.md)
- Converged 2026-06-06 over **4 rounds**: 4 internal lenses (security / adversarial / integration / lessons-aware) + cross-model `codex-cli:gpt-5.5` each round; ~32 material findings caught on paper. Report: `docs/specs/reports/working-set-handoff-convergence.md`.
- Headline catches: the offline-producer EXO case → durable pending-pull ledger; a 32MiB single response would have re-created the documented event-loop starvation → 1MiB chunking; cross-chunk chimera files → generation anchor + bounded restart; pending-pulls.json lost-update race (the topic-flood-#3 shape) → serialized mutate() funnel; re-arm thundering herd → staggered drain.
- Approved under Justin's standing 24h directive (topic 13481, 2026-06-06): per-step convergence → build → all-tier tests → live verify on the echo pair.

### P2.1 build (this PR)
- `src/core/WorkingSetManifest.ts` — `computeWorkingSet()`: pure, bounded, jailed manifest of a topic's working files (filesystem convention + own-stream journal artifactPaths), honest flags (`tooLarge`/`secretFlagged`/`liveSource`), counted degradations, mtime display-only, sha256 the only decision key.
- `CoherenceJournalReader.readOwnAutonomousRuns(topic, ownMachineId)` — own-stream-only evidence; `liveRun` from the newest run's state.
- Pure module: nothing constructs it at boot. P2.2 (follow-up PR) wires the `working-set-pull` verb, receiver trigger, pending-pull ledger, and reflex route.
- Plus: under-the-hood doc sections for the P1/P2 coherence classes (docs-coverage floor).

## Tests
- `tests/unit/WorkingSetManifest.test.ts` — 18 passing: jail matrix (escape-shaped path, final-component symlink, symlinked-parent), caps + headline exemption + maxFiles keeps the headline, secretFlagged honest listing, liveSource covers ALL live-run entries, reader own-stream-only + liveRun semantics, topic-prefix exactness (134 never matches 13481).
- Existing reader tests: 15 passing unchanged. Full typecheck + lint chain clean. Pre-push suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
