### PR TITLE
feat(cred-isolation): Inc-P3d credential-resolution audit + boot coherence sample

### DIFF
--- a/.instar/instar-dev-decisions/2026-06-06T10-53-47-734Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-06-06T10-53-47-734Z-unknown.json
@@ -1,0 +1,16 @@
+{
+  "ts": "2026-06-06T10:53:47.734Z",
+  "slug": "unknown",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "safety-invariant proximity: src/core/SafeGitExecutor.ts matches SafeGitExecutor (destructive-git funnel)",
+    "new capability: new config key added"
+  ],
+  "belowFloor": true,
+  "files": 2,
+  "loc": 226,
+  "causalAutopsy": null,
+  "verdict": "pass"
+}

--- a/docs/specs/cred-isolation-p3d.eli16.md
+++ b/docs/specs/cred-isolation-p3d.eli16.md
@@ -1,0 +1,52 @@
+# Credential-resolution audit + boot coherence sample, increment P3d — ELI16
+
+## What this is
+
+Increments P3a–P3c make sure an agent on a shared computer always acts as
+ITSELF — never as another person whose identity happened to be lying around
+in the environment. P3d adds the part that lets you SEE that machinery
+working: a small, append-only record of every identity decision instar's git
+funnel makes, plus a one-line health sample taken every time the server
+boots.
+
+Think of it like the access log next to a door lock. The lock (P3a) already
+keeps the wrong identity out. The log (P3d) tells you the wrong identity
+TRIED — which is exactly the information that was missing during the
+"Caroline" incident: the bleed was only discovered by reading prose, not by
+any machine record.
+
+## What changed, concretely
+
+Two additions, both observe-only:
+
+1. **Resolution audit.** Inside the git funnel's environment-sanitization
+   step, the two interesting decisions are now recorded to
+   `.instar/audit/credential-resolution.jsonl`:
+   - *repo-local-strip* — an inherited identity (for example a
+     `GIT_AUTHOR_NAME` exported by whatever shell spawned the agent) was
+     stripped because the repo has its own agent identity. This is the
+     Caroline-class moment, now durably visible.
+   - *host-identity-inject* — a repo without its own identity had the host's
+     identity filled in (the long-standing behavior for non-agent installs).
+   A recurring identical decision (a sync loop hitting the same repo every
+   few minutes) is recorded once per process, not flooded.
+
+2. **Boot coherence sample.** When the server starts, it reads the agent's
+   expected identity from its own repo-local git config and compares the
+   machine's other identity surfaces against it: inherited identity
+   environment variables, the machine-global `~/.gitconfig`, and whether a
+   machine-global gh CLI login exists at all. Divergences are written as one
+   `boot-coherence` line in the same file, and a single console warning
+   points at it. Nothing is blocked — the server always boots.
+
+## Why it's safe
+
+Everything is signal-only by construction: the audit writer swallows its own
+failures (an unwritable disk can never break a git operation), the boot
+sampler never throws (a broken sample can never block boot — proven by an
+end-to-end test that boots a real server with auditing disabled), and all
+probes are pure file reads — no subprocesses, so test suites that script
+child-process call sequences are untouched (the lesson CI taught us in P3a).
+There are no new routes, no config flags, no migrations: the same
+`INSTAR_AUDIT_LOG_DIR` / `INSTAR_AUDIT_LOG_DISABLED` overrides that govern
+the existing destructive-ops audit govern this file too.

--- a/src/core/SafeGitExecutor.ts
+++ b/src/core/SafeGitExecutor.ts
@@ -40,6 +40,7 @@ import {
   type SpawnOptions,
 } from 'node:child_process';
 import fs from 'node:fs';
+import os from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import {
@@ -337,17 +338,51 @@ function sanitizeEnv(callerEnv?: NodeJS.ProcessEnv, cwd?: string): NodeJS.Proces
   // to the repo-local config (the agent's identity), never a name that
   // leaked in from the spawning shell or another principal on the machine.
   if (repoHasLocalIdentity(cwd ?? process.cwd())) {
+    const stripped = IDENTITY_ENV_VARS.filter((k) => merged[k] !== undefined);
     for (const k of IDENTITY_ENV_VARS) delete merged[k];
+    if (stripped.length > 0) {
+      // Inc-P3d observability: this is the Caroline-class moment — an inherited
+      // identity tried to ride into a repo that has its own. Record it.
+      appendCredentialResolutionEntry({
+        timestamp: new Date().toISOString(),
+        kind: 'resolution',
+        decision: 'repo-local-strip',
+        strippedKeys: stripped,
+        cwd: cwd ?? process.cwd(),
+      });
+    }
   } else {
     // Preserve host git identity before we neutralize global config — without
     // this, every commit through SafeGitExecutor would fail with "Author
     // identity unknown" because the global config is at /dev/null. Identity is
     // not an alias-attack vector; alias rebinding is.
     const id = getHostGitIdentity();
-    if (id.name && !merged.GIT_AUTHOR_NAME) merged.GIT_AUTHOR_NAME = id.name;
-    if (id.email && !merged.GIT_AUTHOR_EMAIL) merged.GIT_AUTHOR_EMAIL = id.email;
-    if (id.name && !merged.GIT_COMMITTER_NAME) merged.GIT_COMMITTER_NAME = id.name;
-    if (id.email && !merged.GIT_COMMITTER_EMAIL) merged.GIT_COMMITTER_EMAIL = id.email;
+    const injected: string[] = [];
+    if (id.name && !merged.GIT_AUTHOR_NAME) {
+      merged.GIT_AUTHOR_NAME = id.name;
+      injected.push('GIT_AUTHOR_NAME');
+    }
+    if (id.email && !merged.GIT_AUTHOR_EMAIL) {
+      merged.GIT_AUTHOR_EMAIL = id.email;
+      injected.push('GIT_AUTHOR_EMAIL');
+    }
+    if (id.name && !merged.GIT_COMMITTER_NAME) {
+      merged.GIT_COMMITTER_NAME = id.name;
+      injected.push('GIT_COMMITTER_NAME');
+    }
+    if (id.email && !merged.GIT_COMMITTER_EMAIL) {
+      merged.GIT_COMMITTER_EMAIL = id.email;
+      injected.push('GIT_COMMITTER_EMAIL');
+    }
+    if (injected.length > 0) {
+      appendCredentialResolutionEntry({
+        timestamp: new Date().toISOString(),
+        kind: 'resolution',
+        decision: 'host-identity-inject',
+        injectedKeys: injected,
+        cwd: cwd ?? process.cwd(),
+      });
+    }
   }
   // Inject unconditional config disables.
   merged.GIT_CONFIG_GLOBAL = '/dev/null';
@@ -708,6 +743,166 @@ function captureCallerFrame(): string {
   return frame.trim();
 }
 
+// ── Credential-resolution audit (Caroline-class observability, Inc-P3d) ──
+//
+// Observe-only record of the identity-resolution decisions the funnel makes
+// (which identity surface won and why), plus a boot-time coherence sample of
+// the machine's credential surfaces. Signal-only by construction: a write
+// problem never affects the git operation or server boot. Same dir + env
+// overrides as the destructive-ops audit (INSTAR_AUDIT_LOG_DIR /
+// INSTAR_AUDIT_LOG_DISABLED).
+
+export interface CredentialResolutionEntry {
+  timestamp: string;
+  kind: 'resolution' | 'boot-coherence';
+  /** For kind 'resolution': which way sanitizeEnv resolved identity. */
+  decision?: 'repo-local-strip' | 'host-identity-inject';
+  /** Identity env vars deleted because the repo-local identity is authoritative. */
+  strippedKeys?: string[];
+  /** Identity env vars injected from the host identity (repo had none). */
+  injectedKeys?: string[];
+  cwd?: string;
+  /** For kind 'boot-coherence': the agent's expected identity and its source. */
+  expected?: { name?: string; email?: string; source: string };
+  /** Surfaces whose identity disagrees with (or shadows) the expected one. */
+  divergences?: Array<{ surface: string; detail: string }>;
+  /** Whether a machine-global gh CLI auth state file exists (presence only). */
+  ghHostsPresent?: boolean;
+}
+
+function credentialAuditPath(): string | null {
+  if (process.env.INSTAR_AUDIT_LOG_DISABLED === '1') return null;
+  const overrideDir = process.env.INSTAR_AUDIT_LOG_DIR;
+  const dir = overrideDir ?? path.join(process.cwd(), '.instar', 'audit');
+  return path.join(dir, 'credential-resolution.jsonl');
+}
+
+// Per-process dedupe so a recurring resolution (e.g. a sync loop hitting the
+// same repo every few minutes) is recorded once, not flooded. Boot-coherence
+// entries are always written (one per boot by construction).
+const _credentialAuditSeen = new Set<string>();
+function _resetCredentialAuditDedupeForTest(): void {
+  _credentialAuditSeen.clear();
+}
+
+export function appendCredentialResolutionEntry(entry: CredentialResolutionEntry): void {
+  const file = credentialAuditPath();
+  if (!file) return;
+  if (entry.kind === 'resolution') {
+    const dedupeKey = `${entry.decision}|${entry.cwd}|${(entry.strippedKeys || entry.injectedKeys || []).join(',')}`;
+    if (_credentialAuditSeen.has(dedupeKey)) return;
+    _credentialAuditSeen.add(dedupeKey);
+  }
+  try {
+    fs.mkdirSync(path.dirname(file), { recursive: true });
+    fs.appendFileSync(file, JSON.stringify(entry) + '\n');
+  } catch {
+    /* @silent-fallback-ok — observe-only record; a write problem must never affect the git operation */
+  }
+}
+
+/** Minimal git-config parse: the VALUE of `key` in the [user] section, if any. */
+function configGet(file: string, key: 'name' | 'email'): string | undefined {
+  let content: string;
+  try {
+    content = fs.readFileSync(file, 'utf-8');
+  } catch {
+    return undefined; /* @silent-fallback-ok — absent candidate file is simply not a source */
+  }
+  let inUser = false;
+  for (const raw of content.split('\n')) {
+    const line = raw.trim();
+    if (line.startsWith('[')) {
+      inUser = /^\[user\]/i.test(line);
+      continue;
+    }
+    if (!inUser) continue;
+    const m = new RegExp(`^${key}\\s*=\\s*(.+)$`).exec(line);
+    if (m) return m[1].trim();
+  }
+  return undefined;
+}
+
+export interface BootCredentialCoherenceReport {
+  expected: { name?: string; email?: string; source: string };
+  divergences: Array<{ surface: string; detail: string }>;
+  ghHostsPresent: boolean;
+  sampledAt: string;
+}
+
+/**
+ * Boot-time credential coherence sample (Inc-P3d). Reads the agent's
+ * EXPECTED identity from the repo-local git config of `agentDir`, compares
+ * the machine's other identity surfaces against it (inherited identity env
+ * vars, the machine-global ~/.gitconfig), and notes whether a machine-global
+ * gh CLI auth state exists. Pure fs reads — no subprocess (the P3a lesson:
+ * funnel-adjacent probes must not consume mocked child_process sequences).
+ * Records one 'boot-coherence' line in credential-resolution.jsonl and
+ * returns the report. Never throws; returns null if sampling itself broke.
+ */
+export function auditBootCredentialCoherence(
+  agentDir?: string,
+  homeDirOverride?: string,
+): BootCredentialCoherenceReport | null {
+  try {
+    const dir = path.resolve(agentDir ?? process.cwd());
+    const candidates = localConfigCandidates(dir);
+    const name = candidates.map((f) => configGet(f, 'name')).find((v) => v !== undefined);
+    const email = candidates.map((f) => configGet(f, 'email')).find((v) => v !== undefined);
+    const expected = { name, email, source: 'repo-local-config' };
+    const divergences: Array<{ surface: string; detail: string }> = [];
+    for (const k of IDENTITY_ENV_VARS) {
+      const v = process.env[k];
+      if (!v) continue;
+      const expectedVal = k.endsWith('EMAIL') ? email : name;
+      if (expectedVal === undefined) {
+        divergences.push({
+          surface: `env:${k}`,
+          detail: 'identity env var inherited but the agent dir has no repo-local identity to anchor against',
+        });
+      } else if (v !== expectedVal) {
+        divergences.push({
+          surface: `env:${k}`,
+          detail: 'inherited identity env var differs from the repo-local agent identity',
+        });
+      }
+    }
+    const home = homeDirOverride ?? os.homedir();
+    const gName = configGet(path.join(home, '.gitconfig'), 'name');
+    const gEmail = configGet(path.join(home, '.gitconfig'), 'email');
+    if (gName !== undefined && name !== undefined && gName !== name) {
+      divergences.push({
+        surface: 'global-gitconfig:user.name',
+        detail: 'machine-global git identity differs from the repo-local agent identity',
+      });
+    }
+    if (gEmail !== undefined && email !== undefined && gEmail !== email) {
+      divergences.push({
+        surface: 'global-gitconfig:user.email',
+        detail: 'machine-global git identity differs from the repo-local agent identity',
+      });
+    }
+    const ghHostsPresent = fs.existsSync(path.join(home, '.config', 'gh', 'hosts.yml'));
+    const report: BootCredentialCoherenceReport = {
+      expected,
+      divergences,
+      ghHostsPresent,
+      sampledAt: new Date().toISOString(),
+    };
+    appendCredentialResolutionEntry({
+      timestamp: report.sampledAt,
+      kind: 'boot-coherence',
+      cwd: dir,
+      expected,
+      divergences,
+      ghHostsPresent,
+    });
+    return report;
+  } catch {
+    return null; /* @silent-fallback-ok — a broken sample must never affect server boot */
+  }
+}
+
 // ── Public types ────────────────────────────────────────────────────
 
 export interface SafeGitOptions {
@@ -1061,6 +1256,8 @@ export const _internal = {
   GIT_ENV_DENYLIST,
   repoHasLocalIdentity,
   _resetLocalIdentityCacheForTest,
+  _resetCredentialAuditDedupeForTest,
+  configGet,
 };
 
 // Suppress unused-export warnings for the convenience re-exports. The

--- a/src/server/AgentServer.ts
+++ b/src/server/AgentServer.ts
@@ -66,7 +66,7 @@ import { ApprenticeshipProgram } from '../core/ApprenticeshipProgram.js';
 import { ApprenticeshipCycleStore } from '../monitoring/ApprenticeshipCycleStore.js';
 import { ApprenticeshipCycleSlaMonitor } from '../monitoring/ApprenticeshipCycleSlaMonitor.js';
 import { GeminiCapacityEscalationMonitor } from '../monitoring/GeminiCapacityEscalationMonitor.js';
-import { SafeGitExecutor } from '../core/SafeGitExecutor.js';
+import { SafeGitExecutor, auditBootCredentialCoherence } from '../core/SafeGitExecutor.js';
 import { createSpecReviewRoutes } from './specReviewRoutes.js';
 import { createUsherRoutes } from './usherRoutes.js';
 import { createHandoffInitiateRoutes } from './handoffInitiateRoutes.js';
@@ -2524,6 +2524,25 @@ export class AgentServer {
       }
     } catch (err) {
       console.warn('[instar] boot.id creation raised (sentinel will fail to start):', err);
+    }
+
+    // Inc-P3d boot credential-coherence sample (Caroline-class observability).
+    // Signal-only: compares the agent's repo-local identity against the
+    // machine's other identity surfaces (inherited env, global gitconfig) and
+    // records one boot-coherence line in credential-resolution.jsonl. Pure fs
+    // reads; never throws; never blocks boot.
+    try {
+      // stateDir is <projectDir>/.instar — the repo whose local identity is
+      // the agent's expected identity is its PARENT.
+      const agentRepoDir = this.config.stateDir ? path.dirname(this.config.stateDir) : process.cwd();
+      const coherence = auditBootCredentialCoherence(agentRepoDir);
+      if (coherence && coherence.divergences.length > 0) {
+        console.warn(
+          `[instar] credential-coherence: ${coherence.divergences.length} identity surface(s) diverge from the agent's repo-local identity (see .instar/audit/credential-resolution.jsonl)`,
+        );
+      }
+    } catch (err) {
+      console.warn('[instar] boot credential-coherence sample raised:', err);
     }
 
     return new Promise((resolve, reject) => {

--- a/tests/e2e/credential-coherence-boot.test.ts
+++ b/tests/e2e/credential-coherence-boot.test.ts
@@ -1,0 +1,167 @@
+// safe-git-allow: e2e test for the boot credential-coherence sample; direct git usage is for fixture setup only.
+/**
+ * E2E lifecycle — boot credential-coherence sample (Phase-3 Inc-P3d).
+ *
+ * Tier 3 of the Testing Integrity Standard, on the PRODUCTION initialization
+ * path: a REAL AgentServer.start() (the same call src/commands/server.ts
+ * makes) under a polluted environment must
+ *   Phase 1 — Feature is alive: write exactly one boot-coherence line to
+ *             credential-resolution.jsonl whose expected identity was read
+ *             from the agent repo's local git config, flagging the inherited
+ *             identity env var as a divergent surface.
+ *   Phase 2 — Signal-only invariant: the divergence NEVER blocks boot — the
+ *             server comes up and serves authed requests (200, not 503), and
+ *             a second boot with auditing disabled also comes up clean.
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import request from 'supertest';
+import { AgentServer } from '../../src/server/AgentServer.js';
+import { StateManager } from '../../src/core/StateManager.js';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+import { createMockSessionManager } from '../helpers/setup.js';
+import { sanitizedGitEnv } from '../helpers/git-test-env.js';
+import type { InstarConfig } from '../../src/core/types.js';
+
+const AUTH = 'test-cred-coherence-e2e';
+const auth = () => ({ Authorization: `Bearer ${AUTH}` });
+
+describe('boot credential-coherence E2E lifecycle (Inc-P3d)', () => {
+  let tmpDir: string;
+  let stateDir: string;
+  let auditDir: string;
+  let server: AgentServer;
+  let app: ReturnType<AgentServer['getApp']>;
+  let savedAuthorName: string | undefined;
+
+  beforeAll(async () => {
+    tmpDir = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'cred-coherence-e2e-')));
+    stateDir = path.join(tmpDir, '.instar');
+    auditDir = path.join(tmpDir, 'audit-out');
+    fs.mkdirSync(path.join(stateDir, 'state', 'sessions'), { recursive: true });
+    fs.mkdirSync(path.join(stateDir, 'logs'), { recursive: true });
+    fs.writeFileSync(
+      path.join(stateDir, 'config.json'),
+      JSON.stringify({ port: 0, projectName: 'cred-coherence-e2e' }),
+    );
+    // The agent repo: tmpDir is a git repo with its OWN local identity — the
+    // production shape of an agent home (stateDir's parent).
+    const env = sanitizedGitEnv();
+    execFileSync('git', ['init', '--initial-branch=main'], { cwd: tmpDir, stdio: 'ignore', env });
+    execFileSync('git', ['config', 'user.name', 'Instar Agent (e2e)'], { cwd: tmpDir, stdio: 'ignore', env });
+    execFileSync('git', ['config', 'user.email', 'e2e@instar.local'], { cwd: tmpDir, stdio: 'ignore', env });
+
+    // The Caroline shape: the spawning environment carries another
+    // principal's identity at the moment the server boots.
+    savedAuthorName = process.env.GIT_AUTHOR_NAME;
+    process.env.GIT_AUTHOR_NAME = 'Caroline';
+    process.env.INSTAR_AUDIT_LOG_DIR = auditDir;
+
+    const config = {
+      projectName: 'cred-coherence-e2e',
+      projectDir: tmpDir,
+      stateDir,
+      port: 0,
+      authToken: AUTH,
+      requestTimeoutMs: 10000,
+      version: '0.0.0',
+      sessions: { claudePath: '/usr/bin/echo', maxSessions: 3, defaultMaxDurationMinutes: 30, protectedSessions: [], monitorIntervalMs: 5000 },
+      scheduler: { enabled: false, jobsFile: '', maxParallelJobs: 1 },
+      messaging: [],
+      monitoring: {},
+      updates: {},
+    } as InstarConfig;
+    server = new AgentServer({
+      config,
+      sessionManager: createMockSessionManager() as any,
+      state: new StateManager(stateDir),
+    });
+    await server.start();
+    app = server.getApp();
+  });
+
+  afterAll(async () => {
+    try {
+      await server.stop();
+    } catch {
+      /* already stopped */
+    }
+    delete process.env.INSTAR_AUDIT_LOG_DIR;
+    if (savedAuthorName === undefined) delete process.env.GIT_AUTHOR_NAME;
+    else process.env.GIT_AUTHOR_NAME = savedAuthorName;
+    SafeFsExecutor.safeRmSync(tmpDir, { recursive: true, force: true, operation: 'tests/e2e/credential-coherence-boot.test.ts' });
+  });
+
+  // ── Phase 1: feature is alive on the production boot path ──
+
+  it('start() wrote exactly one boot-coherence line with the repo-local expected identity', () => {
+    const file = path.join(auditDir, 'credential-resolution.jsonl');
+    expect(fs.existsSync(file)).toBe(true);
+    const entries = fs
+      .readFileSync(file, 'utf-8')
+      .split('\n')
+      .filter(Boolean)
+      .map((l) => JSON.parse(l))
+      .filter((e: { kind: string }) => e.kind === 'boot-coherence');
+    expect(entries).toHaveLength(1);
+    expect(entries[0].expected.name).toBe('Instar Agent (e2e)');
+    expect(entries[0].expected.email).toBe('e2e@instar.local');
+    expect(entries[0].expected.source).toBe('repo-local-config');
+    expect(entries[0].cwd).toBe(tmpDir);
+  });
+
+  it('flagged the inherited identity env var as a divergent surface', () => {
+    const file = path.join(auditDir, 'credential-resolution.jsonl');
+    const entry = fs
+      .readFileSync(file, 'utf-8')
+      .split('\n')
+      .filter(Boolean)
+      .map((l) => JSON.parse(l))
+      .find((e: { kind: string }) => e.kind === 'boot-coherence');
+    const surfaces = entry.divergences.map((d: { surface: string }) => d.surface);
+    expect(surfaces).toContain('env:GIT_AUTHOR_NAME');
+  });
+
+  // ── Phase 2: signal-only — divergence never blocks boot ──
+
+  it('the server booted and serves authed requests despite the divergence (200, not 503)', async () => {
+    const res = await request(app).get('/health').set(auth());
+    expect(res.status).toBe(200);
+  });
+
+  it('a boot with auditing disabled still comes up (the sample is pure observability)', async () => {
+    process.env.INSTAR_AUDIT_LOG_DISABLED = '1';
+    const tmp2 = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'cred-coherence-e2e2-')));
+    const stateDir2 = path.join(tmp2, '.instar');
+    fs.mkdirSync(path.join(stateDir2, 'state', 'sessions'), { recursive: true });
+    fs.writeFileSync(path.join(stateDir2, 'config.json'), JSON.stringify({ port: 0, projectName: 'e2e2' }));
+    const config2 = {
+      projectName: 'e2e2',
+      projectDir: tmp2,
+      stateDir: stateDir2,
+      port: 0,
+      authToken: AUTH,
+      requestTimeoutMs: 10000,
+      version: '0.0.0',
+      sessions: { claudePath: '/usr/bin/echo', maxSessions: 3, defaultMaxDurationMinutes: 30, protectedSessions: [], monitorIntervalMs: 5000 },
+      scheduler: { enabled: false, jobsFile: '', maxParallelJobs: 1 },
+      messaging: [],
+      monitoring: {},
+      updates: {},
+    } as InstarConfig;
+    const server2 = new AgentServer({
+      config: config2,
+      sessionManager: createMockSessionManager() as any,
+      state: new StateManager(stateDir2),
+    });
+    await server2.start();
+    const res = await request(server2.getApp()).get('/health').set(auth());
+    expect(res.status).toBe(200);
+    await server2.stop();
+    delete process.env.INSTAR_AUDIT_LOG_DISABLED;
+    SafeFsExecutor.safeRmSync(tmp2, { recursive: true, force: true, operation: 'tests/e2e/credential-coherence-boot.test.ts' });
+  });
+});

--- a/tests/integration/credential-resolution-funnel.test.ts
+++ b/tests/integration/credential-resolution-funnel.test.ts
@@ -1,0 +1,139 @@
+// safe-git-allow: integration test for the credential-resolution audit; direct git+fs usage is for fixture setup and verification only.
+//
+// Inc-P3d Tier-2 — the OBSERVED Caroline replay: a real commit through the
+// real funnel under a fully polluted environment must (a) land as the
+// repo-local agent identity (the P3a guarantee) AND (b) leave a durable
+// repo-local-strip line in credential-resolution.jsonl (the P3d guarantee).
+// Also proves the audit is signal-only: with the audit disabled the same
+// operation still succeeds — observability never gates the operation.
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import {
+  SafeGitExecutor,
+  _internal,
+  type CredentialResolutionEntry,
+} from '../../src/core/SafeGitExecutor.js';
+import { sanitizedGitEnv } from '../helpers/git-test-env.js';
+
+function mkSandbox(prefix: string): string {
+  return fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), prefix)));
+}
+
+function rmrf(p: string): void {
+  try {
+    fs.rmSync(p, { recursive: true, force: true });
+  } catch {
+    /* best-effort */
+  }
+}
+
+function initAgentRepo(dir: string): void {
+  const env = sanitizedGitEnv();
+  execFileSync('git', ['init', '--initial-branch=main'], { cwd: dir, stdio: 'ignore', env });
+  execFileSync('git', ['config', 'user.name', 'Instar Agent (itest)'], { cwd: dir, stdio: 'ignore', env });
+  execFileSync('git', ['config', 'user.email', 'itest@instar.local'], { cwd: dir, stdio: 'ignore', env });
+  fs.writeFileSync(path.join(dir, 'seed'), 'seed');
+  execFileSync('git', ['add', 'seed'], { cwd: dir, stdio: 'ignore', env });
+  execFileSync('git', ['commit', '-m', 'seed'], { cwd: dir, stdio: 'ignore', env });
+}
+
+function readEntries(dir: string): CredentialResolutionEntry[] {
+  const file = path.join(dir, 'credential-resolution.jsonl');
+  if (!fs.existsSync(file)) return [];
+  return fs
+    .readFileSync(file, 'utf-8')
+    .split('\n')
+    .filter(Boolean)
+    .map((l) => JSON.parse(l) as CredentialResolutionEntry);
+}
+
+const POLLUTED = {
+  GIT_AUTHOR_NAME: 'Caroline',
+  GIT_AUTHOR_EMAIL: 'caroline@other.example',
+  GIT_COMMITTER_NAME: 'Caroline',
+  GIT_COMMITTER_EMAIL: 'caroline@other.example',
+};
+
+let auditDir: string;
+let repo: string;
+
+beforeEach(() => {
+  auditDir = mkSandbox('crf-audit-');
+  repo = mkSandbox('crf-repo-');
+  process.env.INSTAR_AUDIT_LOG_DIR = auditDir;
+  delete process.env.INSTAR_AUDIT_LOG_DISABLED;
+  initAgentRepo(repo);
+  _internal._resetLocalIdentityCacheForTest();
+  _internal._resetCredentialAuditDedupeForTest();
+});
+
+afterEach(() => {
+  delete process.env.INSTAR_AUDIT_LOG_DIR;
+  rmrf(auditDir);
+  rmrf(repo);
+});
+
+describe('credential-resolution audit — observed Caroline replay (Inc-P3d)', () => {
+  it('a real funnel commit under a polluted env lands as the agent AND is recorded', () => {
+    fs.writeFileSync(path.join(repo, 'work.txt'), 'phase-3d');
+    execFileSync('git', ['add', 'work.txt'], { cwd: repo, stdio: 'ignore', env: sanitizedGitEnv() });
+    SafeGitExecutor.execSync(['commit', '-m', 'agent work'], {
+      cwd: repo,
+      operation: 'inc-p3d-test-commit',
+      env: POLLUTED,
+    });
+    // (a) The P3a guarantee still holds: the commit is the agent's.
+    const author = execFileSync('git', ['log', '-1', '--format=%an <%ae>'], {
+      cwd: repo, encoding: 'utf-8', env: sanitizedGitEnv(),
+    }).trim();
+    expect(author).toBe('Instar Agent (itest) <itest@instar.local>');
+    // (b) The P3d guarantee: the strip decision is durably observable.
+    const entries = readEntries(auditDir).filter((e) => e.kind === 'resolution');
+    expect(entries.length).toBeGreaterThanOrEqual(1);
+    const strip = entries.find((e) => e.decision === 'repo-local-strip');
+    expect(strip).toBeDefined();
+    expect(strip!.strippedKeys).toEqual(
+      expect.arrayContaining([
+        'GIT_AUTHOR_NAME',
+        'GIT_AUTHOR_EMAIL',
+        'GIT_COMMITTER_NAME',
+        'GIT_COMMITTER_EMAIL',
+      ]),
+    );
+    expect(strip!.cwd).toBe(repo);
+  });
+
+  it('the audit is signal-only: with auditing disabled the same operation still succeeds', () => {
+    process.env.INSTAR_AUDIT_LOG_DISABLED = '1';
+    fs.writeFileSync(path.join(repo, 'work2.txt'), 'phase-3d');
+    execFileSync('git', ['add', 'work2.txt'], { cwd: repo, stdio: 'ignore', env: sanitizedGitEnv() });
+    SafeGitExecutor.execSync(['commit', '-m', 'agent work 2'], {
+      cwd: repo,
+      operation: 'inc-p3d-test-commit-disabled',
+      env: POLLUTED,
+    });
+    const author = execFileSync('git', ['log', '-1', '--format=%an'], {
+      cwd: repo, encoding: 'utf-8', env: sanitizedGitEnv(),
+    }).trim();
+    expect(author).toBe('Instar Agent (itest)');
+    expect(readEntries(auditDir)).toHaveLength(0);
+    delete process.env.INSTAR_AUDIT_LOG_DISABLED;
+  });
+
+  it('a recurring sync-style resolution is recorded once, not flooded', () => {
+    for (let i = 0; i < 5; i++) {
+      fs.writeFileSync(path.join(repo, `w${i}.txt`), String(i));
+      execFileSync('git', ['add', `w${i}.txt`], { cwd: repo, stdio: 'ignore', env: sanitizedGitEnv() });
+      SafeGitExecutor.execSync(['commit', '-m', `work ${i}`], {
+        cwd: repo,
+        operation: 'inc-p3d-sync-loop',
+        env: POLLUTED,
+      });
+    }
+    const strips = readEntries(auditDir).filter((e) => e.decision === 'repo-local-strip');
+    expect(strips).toHaveLength(1);
+  });
+});

--- a/tests/unit/credential-resolution-audit.test.ts
+++ b/tests/unit/credential-resolution-audit.test.ts
@@ -1,0 +1,223 @@
+// safe-git-allow: this is a test file for SafeGitExecutor's credential audit; direct git+fs usage is for fixture setup only.
+//
+// Inc-P3d — credential-resolution audit (observe-only).
+// Covers BOTH sides of every decision boundary:
+//   - repo-local-strip entry emitted when inherited identity is stripped
+//   - NO entry when there was nothing to strip
+//   - host-identity-inject entry emitted when host identity fills gaps
+//   - per-process dedupe (recurring resolution recorded once)
+//   - INSTAR_AUDIT_LOG_DISABLED suppresses writes entirely
+//   - boot coherence: divergence detected, expected identity read from the
+//     repo-local config, clean sample has no divergences (deterministic via
+//     homeDirOverride), broken input never throws
+import { describe, it, expect, beforeAll, beforeEach, afterAll } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import {
+  _internal,
+  auditBootCredentialCoherence,
+  type CredentialResolutionEntry,
+} from '../../src/core/SafeGitExecutor.js';
+import { sanitizedGitEnv } from '../helpers/git-test-env.js';
+
+function mkSandbox(prefix = 'cra-'): string {
+  return fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), prefix)));
+}
+
+function rmrf(p: string): void {
+  try {
+    fs.rmSync(p, { recursive: true, force: true });
+  } catch {
+    /* best-effort */
+  }
+}
+
+function initRepo(dir: string, withIdentity = true): void {
+  const env = sanitizedGitEnv();
+  execFileSync('git', ['init', '--initial-branch=main'], { cwd: dir, stdio: 'ignore', env });
+  if (withIdentity) {
+    execFileSync('git', ['config', 'user.email', 'agent@instar.local'], { cwd: dir, stdio: 'ignore', env });
+    execFileSync('git', ['config', 'user.name', 'Instar Agent (test)'], { cwd: dir, stdio: 'ignore', env });
+  }
+}
+
+function readEntries(dir: string): CredentialResolutionEntry[] {
+  const file = path.join(dir, 'credential-resolution.jsonl');
+  if (!fs.existsSync(file)) return [];
+  return fs
+    .readFileSync(file, 'utf-8')
+    .split('\n')
+    .filter(Boolean)
+    .map((l) => JSON.parse(l) as CredentialResolutionEntry);
+}
+
+const IDENTITY_KEYS = [
+  'GIT_AUTHOR_NAME',
+  'GIT_AUTHOR_EMAIL',
+  'GIT_COMMITTER_NAME',
+  'GIT_COMMITTER_EMAIL',
+] as const;
+
+let auditDir: string;
+let savedIdentityEnv: Record<string, string | undefined>;
+
+beforeAll(() => {
+  savedIdentityEnv = {};
+  for (const k of IDENTITY_KEYS) savedIdentityEnv[k] = process.env[k];
+});
+
+beforeEach(() => {
+  auditDir = mkSandbox('cra-audit-');
+  process.env.INSTAR_AUDIT_LOG_DIR = auditDir;
+  delete process.env.INSTAR_AUDIT_LOG_DISABLED;
+  for (const k of IDENTITY_KEYS) delete process.env[k];
+  _internal._resetLocalIdentityCacheForTest();
+  _internal._resetCredentialAuditDedupeForTest();
+});
+
+afterAll(() => {
+  delete process.env.INSTAR_AUDIT_LOG_DIR;
+  for (const k of IDENTITY_KEYS) {
+    if (savedIdentityEnv[k] === undefined) delete process.env[k];
+    else process.env[k] = savedIdentityEnv[k];
+  }
+});
+
+describe('credential-resolution audit — sanitizeEnv emit (Inc-P3d)', () => {
+  it('records a repo-local-strip entry when inherited identity is stripped', () => {
+    const repo = mkSandbox('cra-repo-');
+    initRepo(repo, true);
+    const env = _internal.sanitizeEnv(
+      { GIT_AUTHOR_NAME: 'Caroline', GIT_AUTHOR_EMAIL: 'caroline@example.com' },
+      repo,
+    );
+    expect(env.GIT_AUTHOR_NAME).toBeUndefined();
+    const entries = readEntries(auditDir).filter((e) => e.kind === 'resolution');
+    expect(entries).toHaveLength(1);
+    expect(entries[0].decision).toBe('repo-local-strip');
+    expect(entries[0].strippedKeys).toEqual(
+      expect.arrayContaining(['GIT_AUTHOR_NAME', 'GIT_AUTHOR_EMAIL']),
+    );
+    expect(entries[0].cwd).toBe(repo);
+    rmrf(repo);
+  });
+
+  it('records NOTHING when the env carried no identity to strip', () => {
+    const repo = mkSandbox('cra-repo-');
+    initRepo(repo, true);
+    _internal.sanitizeEnv({}, repo);
+    expect(readEntries(auditDir).filter((e) => e.kind === 'resolution')).toHaveLength(0);
+    rmrf(repo);
+  });
+
+  it('records a host-identity-inject entry when host identity fills missing vars', () => {
+    const repo = mkSandbox('cra-repo-');
+    initRepo(repo, false); // no local identity → inject path
+    // Author vars present in process.env feed getHostGitIdentity; committer
+    // vars are absent from the caller env so the funnel injects them.
+    process.env.GIT_AUTHOR_NAME = 'Host User';
+    process.env.GIT_AUTHOR_EMAIL = 'host@example.com';
+    const env = _internal.sanitizeEnv({}, repo);
+    expect(env.GIT_COMMITTER_NAME).toBe('Host User');
+    const entries = readEntries(auditDir).filter((e) => e.kind === 'resolution');
+    expect(entries).toHaveLength(1);
+    expect(entries[0].decision).toBe('host-identity-inject');
+    expect(entries[0].injectedKeys).toEqual(
+      expect.arrayContaining(['GIT_COMMITTER_NAME', 'GIT_COMMITTER_EMAIL']),
+    );
+    rmrf(repo);
+  });
+
+  it('dedupes a recurring identical resolution within the process', () => {
+    const repo = mkSandbox('cra-repo-');
+    initRepo(repo, true);
+    _internal.sanitizeEnv({ GIT_AUTHOR_NAME: 'Caroline' }, repo);
+    _internal.sanitizeEnv({ GIT_AUTHOR_NAME: 'Caroline' }, repo);
+    expect(readEntries(auditDir).filter((e) => e.kind === 'resolution')).toHaveLength(1);
+    _internal._resetCredentialAuditDedupeForTest();
+    _internal.sanitizeEnv({ GIT_AUTHOR_NAME: 'Caroline' }, repo);
+    expect(readEntries(auditDir).filter((e) => e.kind === 'resolution')).toHaveLength(2);
+    rmrf(repo);
+  });
+
+  it('writes nothing at all when INSTAR_AUDIT_LOG_DISABLED=1', () => {
+    const repo = mkSandbox('cra-repo-');
+    initRepo(repo, true);
+    process.env.INSTAR_AUDIT_LOG_DISABLED = '1';
+    _internal.sanitizeEnv({ GIT_AUTHOR_NAME: 'Caroline' }, repo);
+    expect(readEntries(auditDir)).toHaveLength(0);
+    delete process.env.INSTAR_AUDIT_LOG_DISABLED;
+    rmrf(repo);
+  });
+});
+
+describe('boot credential-coherence sample (Inc-P3d)', () => {
+  it('reads the expected identity from the repo-local config and flags a divergent env var', () => {
+    const repo = mkSandbox('cra-boot-');
+    initRepo(repo, true);
+    const fakeHome = mkSandbox('cra-home-'); // empty home → no global surface
+    process.env.GIT_AUTHOR_NAME = 'Caroline';
+    const report = auditBootCredentialCoherence(repo, fakeHome);
+    expect(report).not.toBeNull();
+    expect(report!.expected.name).toBe('Instar Agent (test)');
+    expect(report!.expected.email).toBe('agent@instar.local');
+    expect(report!.divergences.map((d) => d.surface)).toContain('env:GIT_AUTHOR_NAME');
+    const entries = readEntries(auditDir).filter((e) => e.kind === 'boot-coherence');
+    expect(entries).toHaveLength(1);
+    expect(entries[0].expected?.name).toBe('Instar Agent (test)');
+    rmrf(repo);
+    rmrf(fakeHome);
+  });
+
+  it('reports zero divergences on a clean machine surface', () => {
+    const repo = mkSandbox('cra-boot-');
+    initRepo(repo, true);
+    const fakeHome = mkSandbox('cra-home-');
+    const report = auditBootCredentialCoherence(repo, fakeHome);
+    expect(report).not.toBeNull();
+    expect(report!.divergences).toHaveLength(0);
+    rmrf(repo);
+    rmrf(fakeHome);
+  });
+
+  it('flags a machine-global gitconfig identity that differs from the agent identity', () => {
+    const repo = mkSandbox('cra-boot-');
+    initRepo(repo, true);
+    const fakeHome = mkSandbox('cra-home-');
+    fs.writeFileSync(
+      path.join(fakeHome, '.gitconfig'),
+      '[user]\n\tname = Caroline\n\temail = caroline@example.com\n',
+    );
+    const report = auditBootCredentialCoherence(repo, fakeHome);
+    expect(report).not.toBeNull();
+    expect(report!.divergences.map((d) => d.surface)).toEqual(
+      expect.arrayContaining(['global-gitconfig:user.name', 'global-gitconfig:user.email']),
+    );
+    rmrf(repo);
+    rmrf(fakeHome);
+  });
+
+  it('reports gh CLI auth-state presence from the home surface', () => {
+    const repo = mkSandbox('cra-boot-');
+    initRepo(repo, true);
+    const fakeHome = mkSandbox('cra-home-');
+    fs.mkdirSync(path.join(fakeHome, '.config', 'gh'), { recursive: true });
+    fs.writeFileSync(path.join(fakeHome, '.config', 'gh', 'hosts.yml'), 'github.com:\n');
+    const report = auditBootCredentialCoherence(repo, fakeHome);
+    expect(report!.ghHostsPresent).toBe(true);
+    rmrf(repo);
+    rmrf(fakeHome);
+  });
+
+  it('never throws on a directory that is not a repo', () => {
+    const notRepo = mkSandbox('cra-bare-');
+    const fakeHome = mkSandbox('cra-home-');
+    const report = auditBootCredentialCoherence(notRepo, fakeHome);
+    expect(report).not.toBeNull();
+    expect(report!.expected.name).toBeUndefined();
+    rmrf(notRepo);
+    rmrf(fakeHome);
+  });
+});

--- a/upgrades/next/cred-isolation-p3d.md
+++ b/upgrades/next/cred-isolation-p3d.md
@@ -1,0 +1,44 @@
+---
+bump: patch
+audience: agent-only
+maturity: stable
+---
+
+## What Changed
+
+Phase-3 increment P3d (per-agent credential isolation, Caroline infra-gap
+trio): the SafeGitExecutor funnel now records its identity-resolution
+decisions — inherited identity stripped in favor of the repo-local agent
+identity, or host identity injected for repos without one — to an
+append-only audit file, and the server takes a one-line credential
+coherence sample at every boot comparing the agent's repo-local identity
+against the machine's other identity surfaces (inherited identity env vars,
+machine-global gitconfig, gh CLI auth-state presence). Signal-only by
+construction: a write failure never affects a git operation and a broken
+sample never blocks boot.
+
+## What to Tell Your User
+
+Nothing changes in day-to-day behavior. On shared machines there is now a
+permanent record of every moment another person's identity tried to ride
+into the agent's git work and was kept out, plus a quick health note at
+startup if the machine's identity surfaces disagree with who the agent is
+supposed to be. This is the visibility that was missing during the original
+identity-bleed incident.
+
+## Summary of New Capabilities
+
+- Credential-resolution audit at .instar/audit/credential-resolution.jsonl
+  with per-process flood control.
+- Boot-time credential coherence sample with a single console warning when
+  identity surfaces diverge; never blocks boot.
+- Same audit-dir and disable overrides as the existing destructive-ops
+  audit.
+
+## Evidence
+
+tests/unit/credential-resolution-audit.test.ts (10), tests/integration/
+credential-resolution-funnel.test.ts (3, including the observed Caroline
+replay through a real funnel commit), tests/e2e/credential-coherence-boot.test.ts
+(4, real AgentServer.start on the production path). Regression canaries
+SafeGitExecutor + GitSync + no-silent-fallbacks all green; clean tsc.

--- a/upgrades/side-effects/cred-isolation-p3d.md
+++ b/upgrades/side-effects/cred-isolation-p3d.md
@@ -1,0 +1,82 @@
+# Side-effects review — credential-resolution audit + boot coherence (Inc-P3d)
+
+## What this change does
+
+Adds Caroline-class OBSERVABILITY to the per-agent credential-isolation
+work: (1) the SafeGitExecutor funnel now records its identity-resolution
+decisions (repo-local-strip / host-identity-inject) to
+`.instar/audit/credential-resolution.jsonl`, and (2) `AgentServer.start()`
+takes a one-line boot coherence sample comparing the agent's repo-local
+identity against the machine's other identity surfaces (inherited identity
+env vars, machine-global gitconfig, gh CLI auth-state presence). Both are
+signal-only.
+
+## Decision boundary (both sides tested)
+
+- Identity stripped (Caroline shape) → one `resolution` entry with
+  `decision: repo-local-strip` and the stripped keys. Proven by a REAL
+  funnel commit under a fully polluted env (integration tier).
+- Nothing to strip → NO entry (unit tier).
+- Host identity injected (repo without local identity) → one
+  `host-identity-inject` entry with the injected keys (unit tier).
+- Boot with divergent surfaces → one `boot-coherence` entry + one console
+  warning; boot proceeds (e2e tier, real `AgentServer.start()`).
+- Boot with clean surfaces → zero divergences (unit tier, deterministic via
+  a homeDir override so the host machine's real `~/.gitconfig` can't leak
+  into assertions).
+- `INSTAR_AUDIT_LOG_DISABLED=1` → no writes anywhere; operations and boot
+  unaffected (unit + integration + e2e).
+
+## Blast radius
+
+- `src/core/SafeGitExecutor.ts`: new exported `appendCredentialResolutionEntry`,
+  `auditBootCredentialCoherence`, `CredentialResolutionEntry`,
+  `BootCredentialCoherenceReport`; emit calls inside `sanitizeEnv` (both
+  branches). All probes and writes are pure `node:fs` — NO subprocess
+  (the P3a lesson: funnel-internal subprocess calls consume mocked
+  child_process sequences in downstream suites; verified GitSync.test.ts
+  stays green).
+- `src/server/AgentServer.ts`: one fail-soft try/catch block in `start()`
+  calling the boot sampler with the stateDir's PARENT (the agent repo).
+  Console warning only when divergences exist.
+- Write volume: resolution entries are deduped per process on
+  (decision, cwd, keys) — a sync loop records once, not per tick.
+  Boot-coherence is one line per server boot.
+- Same `INSTAR_AUDIT_LOG_DIR` / `INSTAR_AUDIT_LOG_DISABLED` env overrides
+  as the existing destructive-ops audit; tests use them for isolation.
+- No new routes (docs-coverage route floor untouched), no new core class
+  files (class floor untouched), no config flag, no migration surface.
+
+## Migration parity
+
+No agent-installed files change (no hooks, no config defaults, no CLAUDE.md
+template text, no skills). Behavior ships entirely in code on update.
+
+## Framework generality
+
+Framework-agnostic — the funnel and the server boot path serve every
+framework's instar install identically.
+
+## Tests
+
+- `tests/unit/credential-resolution-audit.test.ts` — 10 tests: emit truth
+  table both sides, dedupe + reset, disable switch, boot coherence
+  (divergent env, clean surfaces, global-gitconfig divergence, gh
+  presence, not-a-repo never throws).
+- `tests/integration/credential-resolution-funnel.test.ts` — 3 tests: the
+  OBSERVED Caroline replay (real funnel commit lands as the agent AND is
+  recorded), signal-only with auditing disabled, flood-control under a
+  sync-style loop.
+- `tests/e2e/credential-coherence-boot.test.ts` — 4 tests: real
+  `AgentServer.start()` writes exactly one boot-coherence line with the
+  repo-local expected identity, flags the inherited env var, serves authed
+  requests despite divergence (200 not 503), boots clean with auditing
+  disabled.
+- Regression canaries green: SafeGitExecutor (48), GitSync (16),
+  no-silent-fallbacks (5) — 69/69; tsc clean.
+
+## Rollback
+
+Delete the emit calls in `sanitizeEnv`, the credential-audit block in
+SafeGitExecutor, and the boot-sample block in `AgentServer.start()`. The
+JSONL file is inert data; no state or config to unwind.


### PR DESCRIPTION
Phase-3 per-agent credential isolation (Caroline infra-gap trio, CMT-1125 gap 1), increment P3d — the observability layer. Observe-only; signal-only by construction.

## What

- **Credential-resolution audit**: `SafeGitExecutor.sanitizeEnv` now records its identity-resolution decisions (`repo-local-strip` / `host-identity-inject`) to `.instar/audit/credential-resolution.jsonl`, deduped per process so sync loops record once, not per tick. Pure fs writes — no subprocess (the P3a lesson: funnel-internal subprocess calls consume mocked child_process sequences downstream).
- **Boot credential-coherence sample**: `AgentServer.start()` compares the agent's repo-local identity against the machine's other identity surfaces (inherited identity env vars, machine-global gitconfig, gh CLI auth-state presence). One console warning on divergence; never blocks boot.
- Same `INSTAR_AUDIT_LOG_DIR` / `INSTAR_AUDIT_LOG_DISABLED` overrides as the destructive-ops audit. No routes, no config flag, no migration surface.

## ELI16

Increments P3a–P3c make sure an agent on a shared computer always acts as ITSELF — never as another person whose identity happened to be lying around in the environment. P3d adds the part that lets you SEE that machinery working: a small append-only record of every identity decision instar's git funnel makes, plus a one-line health sample taken every time the server boots. Think of it like the access log next to a door lock: the lock (P3a) keeps the wrong identity out, the log (P3d) tells you the wrong identity TRIED — exactly the information that was missing during the Caroline incident, where the bleed was only discovered by reading prose, not by any machine record. Everything is observe-only: a write failure can never break a git operation, and a broken sample can never block the server from starting (both proven by tests).

## Tests

- Unit (10): emit truth table both sides, dedupe + reset, disable switch, boot coherence (divergent env / clean surfaces / global-gitconfig divergence / gh presence / not-a-repo never throws; deterministic via a homeDir override).
- Integration (3): the OBSERVED Caroline replay — a real funnel commit under a fully polluted env lands as the agent AND is durably recorded; signal-only with auditing disabled; flood control under a sync-style loop.
- E2E (4): real `AgentServer.start()` on the production path writes exactly one boot-coherence line with the repo-local expected identity, flags the inherited env var, serves authed requests despite divergence (200 not 503), and boots clean with auditing disabled.
- Canaries green: SafeGitExecutor + GitSync + no-silent-fallbacks 69/69; tsc clean; docs-coverage --check passes (no new routes/classes).