### PR TITLE
feat(autonomous): idle backoff — consecutive quick stops pace frame re-injection

### DIFF
--- a/.claude/skills/autonomous/hooks/autonomous-stop-hook.sh
+++ b/.claude/skills/autonomous/hooks/autonomous-stop-hook.sh
@@ -542,6 +542,122 @@ if [[ "$STATE_SESSION" != "$HOOK_SESSION" ]]; then
   record_session_id "$HOOK_SESSION"
 fi
 
+# ── IDLE_BACKOFF — consecutive quick stops back off before re-injecting the frame ──
+# Every block-decision below re-feeds the FULL frame + context to the model. When the
+# session is idle/holding (nothing actionable), stops arrive back-to-back (~4s apart)
+# and the loop re-injects thousands of tokens ~15×/min, all night — the 2026-06-06
+# rapid-idle-refire waste. Backoff: measure the agent's ACTIVE time since the last
+# re-injection (gap = stop arrival − last resume; slept time never counts toward the
+# gap, so a long sleep can't masquerade as productive work). gap < QUICK_SECS ⇒ an
+# idle cycle ⇒ the consecutive counter rises ⇒ tiered sleep (3+ quick stops → T1 30s,
+# 6+ → T2 120s, 10+ → T3 300s) BEFORE the next re-injection. Any real work makes the
+# gap long and resets the counter to zero — productive loops never wait at all.
+# RESPONSIVENESS: the sleep polls every POLL_SECS and breaks EARLY on (a) a new
+# inbound message for this topic, (b) the emergency-stop flag, (c) the state file
+# vanishing (stop/stop-all) — a user message cuts the wait to ≤POLL_SECS.
+# SAFETY (fail-toward-noise, never toward strand): the total sleep self-clamps to a
+# third of THIS hook's own registered Stop timeout, read live from settings.json —
+# a host-killed Stop hook fails OPEN and strands the loop, which is categorically
+# worse than refire noise. Unreadable/missing timeout ⇒ conservative 20s cap; codex
+# registrations (.codex/hooks.json, different timeout semantics) ⇒ same 20s cap.
+BACKOFF_STATE="${STATE_FILE%.md}.backoff.json"
+BACKOFF_SLEPT=0
+if [[ "${INSTAR_HOOK_BACKOFF_DISABLE:-0}" != "1" ]]; then
+  BK_QUICK_SECS="${INSTAR_HOOK_BACKOFF_QUICK_SECS:-120}"
+  BK_T1="${INSTAR_HOOK_BACKOFF_T1:-30}"
+  BK_T2="${INSTAR_HOOK_BACKOFF_T2:-120}"
+  BK_T3="${INSTAR_HOOK_BACKOFF_T3:-300}"
+  BK_POLL="${INSTAR_HOOK_BACKOFF_POLL_SECS:-5}"
+
+  # Self-clamp: never sleep past a third of the registered hook timeout.
+  BK_MAX="${INSTAR_HOOK_BACKOFF_MAX_SLEEP:-}"
+  if [[ -z "$BK_MAX" ]]; then
+    if [[ "$IS_CODEX" == "1" ]]; then
+      BK_MAX=20
+    else
+      BK_REG_TIMEOUT=$(python3 -c "
+import json
+try:
+    s = json.load(open('.claude/settings.json'))
+    for grp in (s.get('hooks', {}).get('Stop') or []):
+        for h in (grp.get('hooks') or []):
+            if 'autonomous-stop-hook.sh' in (h.get('command') or ''):
+                t = h.get('timeout')
+                print(int(t) if isinstance(t, (int, float)) and t > 0 else '')
+                raise SystemExit
+except SystemExit:
+    pass
+except Exception:
+    pass
+" 2>/dev/null || echo "")
+      if [[ "$BK_REG_TIMEOUT" =~ ^[0-9]+$ ]] && [[ $BK_REG_TIMEOUT -ge 60 ]]; then
+        BK_MAX=$(( BK_REG_TIMEOUT / 3 ))
+      else
+        BK_MAX=20
+      fi
+    fi
+  fi
+
+  # Read sidecar (per-topic). A new run (different started_at) resets the counter.
+  BK_PREV_RESUMED=$(jq -r '.lastResumedAt // 0' "$BACKOFF_STATE" 2>/dev/null || echo 0)
+  BK_PREV_QUICK=$(jq -r '.quickStops // 0' "$BACKOFF_STATE" 2>/dev/null || echo 0)
+  BK_PREV_RUN=$(jq -r '.runStartedAt // ""' "$BACKOFF_STATE" 2>/dev/null || echo "")
+  [[ "$BK_PREV_RESUMED" =~ ^[0-9]+$ ]] || BK_PREV_RESUMED=0
+  [[ "$BK_PREV_QUICK" =~ ^[0-9]+$ ]] || BK_PREV_QUICK=0
+  if [[ "$BK_PREV_RUN" != "$STARTED_AT" ]]; then
+    BK_PREV_RESUMED=0; BK_PREV_QUICK=0
+  fi
+
+  BK_NOW=$(date +%s)
+  BK_GAP=-1
+  BK_QUICK=0
+  if [[ $BK_PREV_RESUMED -gt 0 ]]; then
+    BK_GAP=$(( BK_NOW - BK_PREV_RESUMED ))
+    if [[ $BK_GAP -lt $BK_QUICK_SECS ]]; then
+      BK_QUICK=$(( BK_PREV_QUICK + 1 ))
+    fi
+  fi
+
+  BK_SLEEP=0
+  if   [[ $BK_QUICK -ge 10 ]]; then BK_SLEEP=$BK_T3
+  elif [[ $BK_QUICK -ge 6  ]]; then BK_SLEEP=$BK_T2
+  elif [[ $BK_QUICK -ge 3  ]]; then BK_SLEEP=$BK_T1
+  fi
+  [[ $BK_SLEEP -gt $BK_MAX ]] && BK_SLEEP=$BK_MAX
+
+  if [[ $BK_SLEEP -gt 0 ]]; then
+    bk_inbound_latest() { ls -t .instar/telegram-inbound/msg-"${REPORT_TOPIC:-none}"-* 2>/dev/null | head -1; }
+    BK_MARK_IN=$(bk_inbound_latest)
+    while [[ $BACKOFF_SLEPT -lt $BK_SLEEP ]]; do
+      BK_CHUNK=$(( BK_SLEEP - BACKOFF_SLEPT ))
+      [[ $BK_CHUNK -gt $BK_POLL ]] && BK_CHUNK=$BK_POLL
+      sleep "$BK_CHUNK"
+      BACKOFF_SLEPT=$(( BACKOFF_SLEPT + BK_CHUNK ))
+      [[ -f ".instar/autonomous-emergency-stop" ]] && break
+      [[ ! -f "$STATE_FILE" ]] && break
+      [[ "$(bk_inbound_latest)" != "$BK_MARK_IN" ]] && break
+    done
+    echo "[autonomous] idle backoff: quickStops=$BK_QUICK gap=${BK_GAP}s slept=${BACKOFF_SLEPT}s (cap=${BK_MAX}s)" >&2
+
+    # Re-check terminal conditions that may have arrived during the sleep.
+    if [[ ! -f "$STATE_FILE" ]]; then
+      rm -f "$BACKOFF_STATE" 2>/dev/null || true
+      echo "[autonomous] state file removed during idle backoff — allowing exit" >&2
+      exit 0
+    fi
+    if [[ -f ".instar/autonomous-emergency-stop" ]]; then
+      emit "🛑 Autonomous mode: Emergency stop detected (during idle backoff)."
+      notify_terminal_stop "🛑 My autonomous run on \"$(goal_snippet)\" was stopped (emergency stop)."
+      rm -f "$STATE_FILE" "$BACKOFF_STATE" 2>/dev/null || true
+      exit 0
+    fi
+  fi
+
+  BK_RESUMED=$(date +%s)
+  printf '{"runStartedAt":"%s","lastResumedAt":%s,"quickStops":%s,"lastSleepSecs":%s}\n' \
+    "$STARTED_AT" "$BK_RESUMED" "$BK_QUICK" "$BACKOFF_SLEPT" > "$BACKOFF_STATE" 2>/dev/null || true
+fi
+
 # ── Continue the job: increment iteration, feed the task back. ────────
 NEXT_ITERATION=$((ITERATION + 1))
 

--- a/.instar/instar-dev-decisions/2026-06-06T11-13-37-466Z-stop-hook-idle-backoff.json
+++ b/.instar/instar-dev-decisions/2026-06-06T11-13-37-466Z-stop-hook-idle-backoff.json
@@ -1,0 +1,16 @@
+{
+  "ts": "2026-06-06T11:13:37.466Z",
+  "slug": "stop-hook-idle-backoff",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "irreversibility: src/core/PostUpdateMigrator.ts touches PostUpdateMigrator",
+    "migration / fleet-rollout surface: src/core/PostUpdateMigrator.ts touches PostUpdateMigrator (fleet migration machinery)"
+  ],
+  "belowFloor": true,
+  "files": 1,
+  "loc": 14,
+  "causalAutopsy": null,
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-06-06T11-14-13-607Z-stop-hook-idle-backoff.json
+++ b/.instar/instar-dev-decisions/2026-06-06T11-14-13-607Z-stop-hook-idle-backoff.json
@@ -1,0 +1,19 @@
+{
+  "ts": "2026-06-06T11:14:13.607Z",
+  "slug": "stop-hook-idle-backoff",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "irreversibility: src/core/PostUpdateMigrator.ts touches PostUpdateMigrator",
+    "migration / fleet-rollout surface: src/core/PostUpdateMigrator.ts touches PostUpdateMigrator (fleet migration machinery)"
+  ],
+  "belowFloor": true,
+  "files": 1,
+  "loc": 14,
+  "causalAutopsy": {
+    "origin": "latent",
+    "notes": "The autonomous stop-hook has re-injected the full frame immediately on every non-terminal stop since the skill's creation — pacing was never designed in. The cost stayed invisible until two usage shifts surfaced it: long idle HOLDS became a normal loop state (sessions waiting on operator decisions / budget windows / peer agents), and overnight operator absence stretched those holds to 6-8h (observed live 2026-06-06: ~15 re-injections/min while idle, flagged by Justin as a resource concern at the LLM-token layer). No prior PR caused it; sibling #914 silenced the loop's USER-facing restart noise, this paces its MODEL-facing re-injection."
+  },
+  "verdict": "pass"
+}

--- a/docs/eli16/stop-hook-idle-backoff.eli16.md
+++ b/docs/eli16/stop-hook-idle-backoff.eli16.md
@@ -1,0 +1,55 @@
+# ELI16 — Stop poking the model every 4 seconds while it's waiting
+
+## The problem, like you're 16
+
+The autonomous loop works like this: the agent finishes a turn, a "stop hook"
+catches the stop and re-feeds the ENTIRE mission briefing (the frame) plus all
+context back to the model so it keeps going. That's the right move when there's
+work to do.
+
+But when the agent is *waiting* — holding for the operator to wake up, for a
+budget window to reset, for another agent to finish — each turn is just "still
+holding." The turn takes ~4 seconds, stops, and the hook instantly re-injects
+the full briefing again. ~15 times a minute. All night. Thousands of tokens per
+poke, for an agent that has nothing to do. That's the rapid-idle-refire waste
+Justin flagged on 2026-06-06: an operator's 6–8 hour sleep = thousands of
+token-heavy no-op re-injections.
+
+## The fix
+
+The hook now *paces itself* when the loop looks idle:
+
+- **It measures the agent's ACTIVE time** between re-injections (stop arrival
+  minus the last resume — sleep time never counts, so a long wait can't
+  masquerade as work). A short gap = the agent did basically nothing = an idle
+  cycle.
+- **Consecutive idle cycles back off**: 3 in a row → wait 30s before the next
+  re-injection; 6 → 2 minutes; 10+ → 5 minutes. One real burst of work makes
+  the gap long and resets the counter to zero instantly — a productive loop
+  never waits at all.
+- **It stays responsive**: during the wait it checks every 5 seconds for a new
+  inbound message on its topic, the emergency-stop flag, or its job being
+  stopped — any of those cuts the wait short immediately. A user message gets
+  through in ≤5s, not 5 minutes.
+- **It can never strand the loop**: the wait self-clamps to a third of the
+  hook's own registered timeout (read live from settings.json; unreadable →
+  conservative 20s). A timed-out Stop hook fails OPEN — the session would just
+  exit and the loop would die silently — so the clamp guarantees we always err
+  toward a little noise rather than a dead loop.
+
+State lives in a tiny per-topic sidecar (`<topic>.local.backoff.json`) next to
+the job's state file — invisible to the server (which only reads `*.local.md`),
+reset automatically when a new run starts.
+
+## What did NOT change
+
+- A busy loop is untouched: real work = long gaps = counter stays 0 = zero
+  added latency.
+- The frame content, iteration counting, progress-report cadence, completion /
+  duration / emergency handling — all identical. The backoff only inserts a
+  wait BEFORE the re-injection when the recent history is all idle cycles.
+- Existing agents get the paced hook automatically via the migration marker
+  bump (`RESTART_NOTE_SILENT` → `IDLE_BACKOFF`); customized hooks are left
+  untouched, as always.
+- `INSTAR_HOOK_BACKOFF_DISABLE=1` (or the env tier/clamp seams) gives tests and
+  operators an instant off-switch.

--- a/src/core/PostUpdateMigrator.ts
+++ b/src/core/PostUpdateMigrator.ts
@@ -1685,11 +1685,21 @@ export class PostUpdateMigrator {
     // churn). The durable record remains the recovery-audit JSONL + stderr. Bumping
     // re-deploys the silenced hook to every existing agent (which carries CLOCK_SEG
     // but not RESTART_NOTE_SILENT); customized hooks are still left untouched.
+    // Marker bumped `RESTART_NOTE_SILENT` → `IDLE_BACKOFF`: the bundled hook now
+    // paces frame re-injection when consecutive stops arrive quickly (an idle/
+    // holding loop) — 3+ quick stops sleep 30s, 6+ 120s, 10+ 300s — with early-break
+    // on a new inbound message / emergency stop / state-file removal, and a
+    // self-clamp to a third of the hook's own registered Stop timeout (a host-killed
+    // Stop hook fails OPEN and strands the loop, which is worse than refire noise).
+    // Fixes the 2026-06-06 rapid-idle-refire waste: an idle autonomous session
+    // re-injected the full frame ~15×/min all night. Bumping re-deploys the paced
+    // hook to every existing agent (which carries RESTART_NOTE_SILENT but not
+    // IDLE_BACKOFF); customized hooks are still left untouched.
     upgrade(
       '.claude/skills/autonomous/hooks/autonomous-stop-hook.sh',
-      'RESTART_NOTE_SILENT',
+      'IDLE_BACKOFF',
       'Autonomous Mode Stop Hook',
-      'skills/autonomous/hooks/autonomous-stop-hook.sh (restart-resume note silenced — audit-only; self-lifecycle narration is housekeeping)',
+      'skills/autonomous/hooks/autonomous-stop-hook.sh (idle backoff — consecutive quick stops pace frame re-injection; early-break on inbound/emergency/stop)',
     );
     // setup-autonomous.sh marker bumped `native-goal/set` → `IS_CODEX_AGENT`: the bundled
     // setup now ALSO auto-delegates to native /goal for CODEX agents (the prior native /goal

--- a/tests/e2e/autonomous-restart-resume-lifecycle.test.ts
+++ b/tests/e2e/autonomous-restart-resume-lifecycle.test.ts
@@ -69,7 +69,7 @@ function fire(sessionId: string, lastText = ''): { decision: string | null; exit
     stdout = execFileSync('bash', [HOOK_PATH], {
       cwd: home,
       input,
-      env: { ...process.env, INSTAR_HOOK_TMUX_SESSION: TMUX },
+      env: { ...process.env, INSTAR_HOOK_TMUX_SESSION: TMUX, INSTAR_HOOK_BACKOFF_DISABLE: '1' },
       encoding: 'utf-8',
       stdio: ['pipe', 'pipe', 'pipe'],
     });

--- a/tests/unit/autonomous-completion-condition.test.ts
+++ b/tests/unit/autonomous-completion-condition.test.ts
@@ -31,7 +31,7 @@ function writeTranscript(): string {
 function statePresent() { return fs.existsSync(path.join(tmp, '.instar', 'autonomous-state.local.md')); }
 
 function runHook(evalOverride?: string): { decision: string | null; exit: number } {
-  const env: NodeJS.ProcessEnv = { ...process.env, INSTAR_HOOK_NO_TMUX: '1', INSTAR_HOOK_TMUX_SESSION: '' };
+  const env: NodeJS.ProcessEnv = { ...process.env, INSTAR_HOOK_NO_TMUX: '1', INSTAR_HOOK_TMUX_SESSION: '', INSTAR_HOOK_BACKOFF_DISABLE: '1' };
   if (evalOverride !== undefined) env.INSTAR_HOOK_EVAL_OVERRIDE = evalOverride;
   let stdout = ''; let exit = 0;
   try {

--- a/tests/unit/autonomous-multi-session.test.ts
+++ b/tests/unit/autonomous-multi-session.test.ts
@@ -72,7 +72,7 @@ function runHook(opts: { sessionId: string; tmuxSession: string }): { decision: 
     stdout = execFileSync('bash', [HOOK_PATH], {
       cwd: tmp,
       input,
-      env: { ...process.env, INSTAR_HOOK_TMUX_SESSION: opts.tmuxSession },
+      env: { ...process.env, INSTAR_HOOK_TMUX_SESSION: opts.tmuxSession, INSTAR_HOOK_BACKOFF_DISABLE: '1' },
       encoding: 'utf-8',
       stdio: ['pipe', 'pipe', 'pipe'],
     });

--- a/tests/unit/autonomous-stop-hook-codex-gate.test.ts
+++ b/tests/unit/autonomous-stop-hook-codex-gate.test.ts
@@ -47,6 +47,7 @@ function runHook(opts: { codex: boolean; tmuxSession: string; emergencyStop?: bo
   const env: NodeJS.ProcessEnv = {
     ...process.env,
     INSTAR_HOOK_TMUX_SESSION: opts.tmuxSession,
+    INSTAR_HOOK_BACKOFF_DISABLE: '1',
     CLAUDE_PROJECT_DIR: homeDir, // anchor to the test home (prod codex uses the $0 fallback)
   };
   const args = opts.codex ? [HOOK_PATH, '--codex'] : [HOOK_PATH];

--- a/tests/unit/autonomous-stop-hook-cwd-anchor.test.ts
+++ b/tests/unit/autonomous-stop-hook-cwd-anchor.test.ts
@@ -42,7 +42,7 @@ function runHook(opts: { cwd: string; projectDir?: string; tmuxSession: string }
   exitCode: number;
   decision: string | null;
 } {
-  const env: NodeJS.ProcessEnv = { ...process.env, INSTAR_HOOK_TMUX_SESSION: opts.tmuxSession };
+  const env: NodeJS.ProcessEnv = { ...process.env, INSTAR_HOOK_TMUX_SESSION: opts.tmuxSession, INSTAR_HOOK_BACKOFF_DISABLE: '1' };
   if (opts.projectDir) env.CLAUDE_PROJECT_DIR = opts.projectDir;
   else delete env.CLAUDE_PROJECT_DIR;
   let stdout = '';

--- a/tests/unit/autonomous-stop-hook-idle-backoff.test.ts
+++ b/tests/unit/autonomous-stop-hook-idle-backoff.test.ts
@@ -1,0 +1,295 @@
+// safe-git-allow: test-tmpdir-cleanup — afterEach removes per-test mkdtempSync tmpdir; SafeFsExecutor migration tracked separately.
+/**
+ * IDLE_BACKOFF — consecutive quick stops pace frame re-injection.
+ *
+ * Every block-decision the autonomous stop-hook emits re-feeds the FULL frame +
+ * context to the model. When the session is idle/holding, stops arrive back-to-back
+ * (~4s apart) and the loop re-injects thousands of tokens ~15×/min all night — the
+ * 2026-06-06 rapid-idle-refire waste. The hook now measures the agent's ACTIVE time
+ * since the last re-injection (gap = stop arrival − last resume; slept time never
+ * counts) and sleeps on a tier schedule (3+ quick stops → T1, 6+ → T2, 10+ → T3)
+ * before emitting the block. Real work makes the gap long and resets the counter.
+ *
+ * Verified here (executing the REAL hook against a temp working dir):
+ *   (1) first stops never sleep; the sidecar counter rises across quick stops;
+ *   (2) the 3rd consecutive quick stop engages T1 (measured wall-time);
+ *   (3) a long gap (real work) resets the counter to zero — no sleep;
+ *   (4) a NEW run (different started_at) resets a stale sidecar;
+ *   (5) a new inbound message for the topic breaks the sleep early (responsiveness);
+ *   (6) the emergency-stop flag appearing mid-sleep exits 0 + clears state;
+ *   (7) INSTAR_HOOK_BACKOFF_MAX_SLEEP clamps the tier; DISABLE skips everything;
+ *   (8) existing agents receive the paced hook via the IDLE_BACKOFF marker bump.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { execFileSync, execFile } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { PostUpdateMigrator } from '../../src/core/PostUpdateMigrator.js';
+
+const HOOK_REL = path.join('.claude', 'skills', 'autonomous', 'hooks', 'autonomous-stop-hook.sh');
+const HOOK_PATH = path.join(process.cwd(), HOOK_REL);
+const UUID_A = '04db2de7-8e82-4baf-9136-7a067bb2ec53';
+const TOPIC = '13435';
+const STARTED = '2026-06-06T10:00:00Z';
+
+let tmp: string;
+
+function stateFile(): string {
+  return path.join(tmp, '.instar', 'autonomous', `${TOPIC}.local.md`);
+}
+function backoffFile(): string {
+  return path.join(tmp, '.instar', 'autonomous', `${TOPIC}.local.backoff.json`);
+}
+
+function writeState(opts: { startedAt?: string } = {}) {
+  fs.mkdirSync(path.join(tmp, '.instar', 'autonomous'), { recursive: true });
+  fs.writeFileSync(stateFile(), `---
+active: true
+iteration: 1
+session_id: "${UUID_A}"
+goal: "idle-backoff test job"
+duration_seconds: 0
+started_at: "${opts.startedAt ?? STARTED}"
+report_topic: "${TOPIC}"
+report_channel: "telegram"
+report_interval: "2h"
+completion_promise: "DONE"
+---
+
+Keep working.
+`);
+}
+
+function writeRegistry() {
+  fs.writeFileSync(
+    path.join(tmp, '.instar', 'topic-session-registry.json'),
+    JSON.stringify({ topicToSession: { [TOPIC]: 'sess-A' }, topicToName: {} }),
+  );
+}
+
+function writeSidecar(opts: { lastResumedAt: number; quickStops: number; runStartedAt?: string }) {
+  fs.writeFileSync(backoffFile(), JSON.stringify({
+    runStartedAt: opts.runStartedAt ?? STARTED,
+    lastResumedAt: opts.lastResumedAt,
+    quickStops: opts.quickStops,
+    lastSleepSecs: 0,
+  }));
+}
+
+function readSidecar(): { lastResumedAt: number; quickStops: number; lastSleepSecs: number; runStartedAt: string } {
+  return JSON.parse(fs.readFileSync(backoffFile(), 'utf8'));
+}
+
+const FAST_ENV = {
+  // 1s tiers + 1s polling keep the suite fast while exercising the real sleep path.
+  INSTAR_HOOK_BACKOFF_T1: '2',
+  INSTAR_HOOK_BACKOFF_T2: '3',
+  INSTAR_HOOK_BACKOFF_T3: '4',
+  INSTAR_HOOK_BACKOFF_POLL_SECS: '1',
+  INSTAR_HOOK_BACKOFF_MAX_SLEEP: '10',
+};
+
+function runHook(extraEnv: Record<string, string> = {}): { decision: string | null; exitCode: number; elapsedMs: number } {
+  const input = JSON.stringify({ session_id: UUID_A, transcript_path: '' });
+  let stdout = '';
+  let exitCode = 0;
+  const t0 = Date.now();
+  try {
+    stdout = execFileSync('bash', [HOOK_PATH], {
+      cwd: tmp,
+      input,
+      env: { ...process.env, INSTAR_HOOK_TMUX_SESSION: 'sess-A', ...FAST_ENV, ...extraEnv },
+      encoding: 'utf-8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+  } catch (err: any) {
+    exitCode = err.status ?? 1;
+    stdout = err.stdout?.toString() ?? '';
+  }
+  const elapsedMs = Date.now() - t0;
+  let decision: string | null = null;
+  try { decision = JSON.parse(stdout.trim()).decision ?? null; } catch { /* allow-exit */ }
+  return { decision, exitCode, elapsedMs };
+}
+
+function runHookAsync(extraEnv: Record<string, string> = {}): Promise<{ exitCode: number; elapsedMs: number }> {
+  const input = JSON.stringify({ session_id: UUID_A, transcript_path: '' });
+  const t0 = Date.now();
+  return new Promise((resolve) => {
+    const child = execFile('bash', [HOOK_PATH], {
+      cwd: tmp,
+      env: { ...process.env, INSTAR_HOOK_TMUX_SESSION: 'sess-A', ...FAST_ENV, ...extraEnv },
+      encoding: 'utf-8',
+    }, (err: any) => {
+      resolve({ exitCode: err?.code ?? 0, elapsedMs: Date.now() - t0 });
+    });
+    child.stdin?.write(input);
+    child.stdin?.end();
+  });
+}
+
+beforeEach(() => {
+  tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'instar-backoff-'));
+  fs.mkdirSync(path.join(tmp, '.instar'), { recursive: true });
+  writeRegistry();
+  writeState();
+});
+afterEach(() => {
+  fs.rmSync(tmp, { recursive: true, force: true });
+});
+
+describe('IDLE_BACKOFF — counter evolution without sleep', () => {
+  it('first stop: no sidecar history → quickStops 0, no sleep, still blocks', () => {
+    const r = runHook();
+    expect(r.decision).toBe('block');
+    expect(r.elapsedMs).toBeLessThan(1900); // no tier engaged (T1=2s)
+    const sc = readSidecar();
+    expect(sc.quickStops).toBe(0);
+    expect(sc.lastSleepSecs).toBe(0);
+    expect(sc.runStartedAt).toBe(STARTED);
+  });
+
+  it('quick consecutive stops raise the counter (0 → 1 → 2) without sleeping', () => {
+    runHook();
+    runHook();
+    const r3 = runHook();
+    expect(r3.decision).toBe('block');
+    expect(readSidecar().quickStops).toBe(2); // 3rd run = 2nd quick gap; tier starts at 3
+  });
+
+  it('a long gap (real work) resets the counter to zero — no sleep', () => {
+    const now = Math.floor(Date.now() / 1000);
+    writeSidecar({ lastResumedAt: now - 3600, quickStops: 9 }); // long-idle history
+    const r = runHook();
+    expect(r.decision).toBe('block');
+    expect(r.elapsedMs).toBeLessThan(1900);
+    expect(readSidecar().quickStops).toBe(0);
+  });
+
+  it('a NEW run (different started_at) resets a stale sidecar', () => {
+    const now = Math.floor(Date.now() / 1000);
+    writeSidecar({ lastResumedAt: now, quickStops: 11, runStartedAt: '2026-01-01T00:00:00Z' });
+    const r = runHook();
+    expect(r.decision).toBe('block');
+    expect(r.elapsedMs).toBeLessThan(1900); // would have slept T3 if the stale counter survived
+    expect(readSidecar().quickStops).toBe(0);
+  });
+});
+
+describe('IDLE_BACKOFF — tiered sleep engages', () => {
+  it('the 3rd consecutive quick stop sleeps T1 before blocking', () => {
+    const now = Math.floor(Date.now() / 1000);
+    writeSidecar({ lastResumedAt: now, quickStops: 2 }); // this stop is quick #3
+    const r = runHook();
+    expect(r.decision).toBe('block');
+    expect(r.elapsedMs).toBeGreaterThanOrEqual(1900); // slept ~T1 (2s, 1s poll chunks)
+    const sc = readSidecar();
+    expect(sc.quickStops).toBe(3);
+    expect(sc.lastSleepSecs).toBeGreaterThanOrEqual(2);
+  });
+
+  it('MAX_SLEEP clamps the tier', () => {
+    const now = Math.floor(Date.now() / 1000);
+    writeSidecar({ lastResumedAt: now, quickStops: 10 }); // T3 territory (4s)
+    const r = runHook({ INSTAR_HOOK_BACKOFF_MAX_SLEEP: '1' });
+    expect(r.decision).toBe('block');
+    expect(r.elapsedMs).toBeLessThan(2500); // clamped to 1s, not 4s
+    expect(readSidecar().lastSleepSecs).toBe(1);
+  });
+
+  it('DISABLE skips the backoff machinery entirely (no sidecar, no sleep)', () => {
+    const now = Math.floor(Date.now() / 1000);
+    writeSidecar({ lastResumedAt: now, quickStops: 10 });
+    const before = fs.readFileSync(backoffFile(), 'utf8');
+    const r = runHook({ INSTAR_HOOK_BACKOFF_DISABLE: '1' });
+    expect(r.decision).toBe('block');
+    expect(r.elapsedMs).toBeLessThan(1900);
+    expect(fs.readFileSync(backoffFile(), 'utf8')).toBe(before); // untouched
+  });
+});
+
+describe('IDLE_BACKOFF — early breaks (responsiveness + safety)', () => {
+  it('a new inbound message for the topic breaks the sleep early', async () => {
+    fs.mkdirSync(path.join(tmp, '.instar', 'telegram-inbound'), { recursive: true });
+    const now = Math.floor(Date.now() / 1000);
+    writeSidecar({ lastResumedAt: now, quickStops: 12 }); // T3 = 4s
+    const pending = runHookAsync();
+    await new Promise((res) => setTimeout(res, 1200));
+    fs.writeFileSync(path.join(tmp, '.instar', 'telegram-inbound', `msg-${TOPIC}-999-test.txt`), 'hi');
+    const r = await pending;
+    expect(r.exitCode).toBe(0);
+    expect(r.elapsedMs).toBeLessThan(3800); // broke before the full 4s sleep
+  });
+
+  it('the emergency-stop flag appearing mid-sleep exits 0 and clears state', async () => {
+    const now = Math.floor(Date.now() / 1000);
+    writeSidecar({ lastResumedAt: now, quickStops: 12 }); // T3 = 4s
+    const pending = runHookAsync();
+    await new Promise((res) => setTimeout(res, 1200));
+    fs.writeFileSync(path.join(tmp, '.instar', 'autonomous-emergency-stop'), '');
+    const r = await pending;
+    expect(r.exitCode).toBe(0);
+    expect(fs.existsSync(stateFile())).toBe(false);   // job cleared
+    expect(fs.existsSync(backoffFile())).toBe(false); // sidecar cleared
+  });
+
+  it('the state file vanishing mid-sleep (stop/stop-all) exits 0 without re-injecting', async () => {
+    const now = Math.floor(Date.now() / 1000);
+    writeSidecar({ lastResumedAt: now, quickStops: 12 });
+    const pending = runHookAsync();
+    await new Promise((res) => setTimeout(res, 1200));
+    fs.rmSync(stateFile());
+    const r = await pending;
+    expect(r.exitCode).toBe(0);
+    expect(fs.existsSync(backoffFile())).toBe(false);
+  });
+});
+
+describe('IDLE_BACKOFF — safety properties (static)', () => {
+  it('self-clamps to a third of the registered Stop timeout; conservative 20s when unreadable', () => {
+    const src = fs.readFileSync(HOOK_PATH, 'utf8');
+    expect(src).toContain('IDLE_BACKOFF');
+    expect(src).toMatch(/BK_MAX=\$\(\( BK_REG_TIMEOUT \/ 3 \)\)/);
+    expect(src).toMatch(/BK_MAX=20/); // the conservative fallback exists
+  });
+
+  it('the sidecar is invisible to the server (does not end in .local.md)', () => {
+    expect(backoffFile().endsWith('.local.md')).toBe(false);
+    expect(backoffFile().endsWith('.backoff.json')).toBe(true);
+  });
+});
+
+describe('IDLE_BACKOFF — existing agents receive the paced hook (migration)', () => {
+  it('upgrades a RESTART_NOTE_SILENT-era stock hook so it gains IDLE_BACKOFF', () => {
+    const projectDir = fs.mkdtempSync(path.join(os.tmpdir(), 'backoff-mig-'));
+    try {
+      fs.mkdirSync(path.join(projectDir, '.instar'), { recursive: true });
+      const dst = path.join(projectDir, HOOK_REL);
+      fs.mkdirSync(path.dirname(dst), { recursive: true });
+      // Prior-era stock hook: carries the fingerprint + the previous marker, lacks IDLE_BACKOFF.
+      fs.writeFileSync(dst, [
+        '#!/bin/bash',
+        '# Autonomous Mode Stop Hook',
+        '# RESTART_NOTE_SILENT — self-lifecycle narration is housekeeping; default-silent.',
+        'exit 0',
+        '',
+      ].join('\n'));
+
+      const migrator = new PostUpdateMigrator({
+        projectDir, stateDir: path.join(projectDir, '.instar'), port: 4042, hasTelegram: false, projectName: 'test',
+      });
+      const result = { upgraded: [] as string[], skipped: [] as string[], errors: [] as string[] };
+      (migrator as unknown as { migrateAutonomousStopHookTopicKeyed(r: typeof result): void })
+        .migrateAutonomousStopHookTopicKeyed(result);
+
+      const upgraded = fs.readFileSync(dst, 'utf8');
+      expect(upgraded).toContain('IDLE_BACKOFF');
+      expect(upgraded).toContain('RESTART_NOTE_SILENT'); // prior capability not lost
+      expect(result.errors).toEqual([]);
+    } finally {
+      fs.rmSync(projectDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/unit/autonomous-stop-hook-notify.test.ts
+++ b/tests/unit/autonomous-stop-hook-notify.test.ts
@@ -71,8 +71,9 @@ describe('Layer A — notify_terminal_stop wiring in the bundled hook', () => {
     const src = readHook();
     const calls = src.split('\n').filter((l) => /^\s*notify_terminal_stop "/.test(l));
     // 2 native-mode (emergency, duration) + 4 legacy (duration, emergency,
-    // completion-condition, completion-promise) = 6.
-    expect(calls.length).toBe(6);
+    // completion-condition, completion-promise) + 1 idle-backoff emergency
+    // re-check (the flag can arrive DURING the backoff sleep) = 7.
+    expect(calls.length).toBe(7);
     // Each terminal-exit message is plain-English and references the run.
     for (const c of calls) {
       expect(c).toMatch(/autonomous run/i);
@@ -180,10 +181,12 @@ describe('Layer A — existing agents receive the notify-enabled hook (migration
     // → `p13_stop_allowed` (P13 stop-reason guard) → `CLOCK_SEG` (SESSION CLOCK injection)
     // → `RESTART_NOTE_SILENT` (the restart-resume note is no longer delivered to the
     // user's topic — self-lifecycle narration is housekeeping/default-silent; the
-    // recovery-audit JSONL remains the durable record). The bundled hook still contains
+    // recovery-audit JSONL remains the durable record) → `IDLE_BACKOFF` (consecutive
+    // quick stops pace frame re-injection — the 2026-06-06 rapid-idle-refire waste).
+    // The bundled hook still contains
     // notify_terminal_stop — asserted above — so that capability is not lost on upgrade.
     const src = fs.readFileSync(path.join(REPO_ROOT, 'src', 'core', 'PostUpdateMigrator.ts'), 'utf8');
-    expect(src).toMatch(/upgrade\(\s*'\.claude\/skills\/autonomous\/hooks\/autonomous-stop-hook\.sh',\s*'RESTART_NOTE_SILENT'/);
+    expect(src).toMatch(/upgrade\(\s*'\.claude\/skills\/autonomous\/hooks\/autonomous-stop-hook\.sh',\s*'IDLE_BACKOFF'/);
   });
 
   it('restart-resume note is SILENT to the user — audit + stderr only (RESTART_NOTE_SILENT)', () => {

--- a/tests/unit/autonomous-stop-hook-session-clock.test.ts
+++ b/tests/unit/autonomous-stop-hook-session-clock.test.ts
@@ -42,7 +42,7 @@ function writeTranscript(): string {
   return p;
 }
 function runHook(): { decision: string | null; reason: string; exit: number } {
-  const env: NodeJS.ProcessEnv = { ...process.env, INSTAR_HOOK_NO_TMUX: '1', INSTAR_HOOK_TMUX_SESSION: '' };
+  const env: NodeJS.ProcessEnv = { ...process.env, INSTAR_HOOK_NO_TMUX: '1', INSTAR_HOOK_TMUX_SESSION: '', INSTAR_HOOK_BACKOFF_DISABLE: '1' };
   let stdout = ''; let exit = 0;
   try {
     stdout = execFileSync('bash', [HOOK], {

--- a/tests/unit/autonomous-stop-hook-topic-keyed.test.ts
+++ b/tests/unit/autonomous-stop-hook-topic-keyed.test.ts
@@ -120,7 +120,7 @@ function runHook(opts: {
     session_id: opts.sessionId,
     transcript_path: opts.transcriptPath ?? '',
   });
-  const env: NodeJS.ProcessEnv = { ...process.env };
+  const env: NodeJS.ProcessEnv = { ...process.env, INSTAR_HOOK_BACKOFF_DISABLE: '1' };
   if (opts.tmuxSession !== undefined) {
     env.INSTAR_HOOK_TMUX_SESSION = opts.tmuxSession;
   } else {

--- a/upgrades/next/stop-hook-idle-backoff.md
+++ b/upgrades/next/stop-hook-idle-backoff.md
@@ -1,0 +1,56 @@
+# Autonomous stop-hook idle backoff — pace frame re-injection while holding
+
+## What Changed
+
+The autonomous loop's Stop hook re-feeds the full frame + context to the model
+after every turn. When a session was idle/holding (waiting on the operator, a
+budget window, or a peer), turns completed in ~4s and the hook re-injected
+~15×/min — thousands of token-heavy no-op re-injections over one operator
+sleep (the 2026-06-06 rapid-idle-refire waste).
+
+The hook now measures the agent's ACTIVE time between re-injections (slept
+time never counts) and backs off when consecutive stops arrive quickly: 3+
+quick stops → 30s wait, 6+ → 2 min, 10+ → 5 min, before the next re-injection.
+One real burst of work resets the counter instantly — a productive loop never
+waits. During a wait it polls every 5s and breaks early on a new inbound
+message for its topic, the emergency-stop flag, or its job being stopped — a
+user message gets through in ≤5s. The wait self-clamps to a third of the
+hook's own registered Stop timeout (a host-killed Stop hook fails OPEN and
+strands the loop; the clamp guarantees noise over strand).
+
+State is a per-topic sidecar (`.instar/autonomous/<topic>.local.backoff.json`)
+invisible to the server. Existing agents receive the paced hook via a
+PostUpdateMigrator marker bump (`RESTART_NOTE_SILENT` → `IDLE_BACKOFF`);
+customized hooks are left untouched.
+
+## What to Tell Your User
+
+Idle autonomous sessions now sip tokens instead of gulping them — an agent
+holding overnight re-checks roughly every 5 minutes instead of every 4
+seconds, and still reacts to your message within ~5 seconds. Busy sessions
+are completely unaffected.
+
+## Summary of New Capabilities
+
+- Autonomous stop-hook idle backoff: tiered pacing (30s/120s/300s) of frame
+  re-injection after 3/6/10 consecutive quick stops; instant reset on real work.
+- Early-break responsiveness: new inbound message / emergency stop / job stop
+  cut any backoff wait to ≤5s.
+- Timeout self-clamp: the backoff reads its own Stop-hook registration and
+  never sleeps past a third of it (20s conservative fallback) — fail-toward-
+  noise, never toward a stranded loop.
+- Env seams for operators/tests: `INSTAR_HOOK_BACKOFF_DISABLE`, `_QUICK_SECS`,
+  `_T1/_T2/_T3`, `_POLL_SECS`, `_MAX_SLEEP`.
+- Migration: existing agents get the paced hook automatically (marker bump
+  `RESTART_NOTE_SILENT` → `IDLE_BACKOFF`).
+
+## Evidence
+
+- `tests/unit/autonomous-stop-hook-idle-backoff.test.ts` — 13 tests executing
+  the REAL hook: counter evolution, tier engagement (measured wall-time),
+  long-gap + new-run resets, MAX_SLEEP clamp, DISABLE seam, async early-breaks
+  (inbound / emergency / state-removal), static safety assertions, migration
+  upgrade path.
+- 57 tests across the 8 pre-existing hook suites pass (disable seam added to
+  their harnesses so repeated hook execs never sleep).
+- Typecheck clean; `bash -n` clean.

--- a/upgrades/side-effects/stop-hook-idle-backoff.md
+++ b/upgrades/side-effects/stop-hook-idle-backoff.md
@@ -1,0 +1,30 @@
+# Side Effects — stop-hook-idle-backoff
+
+## Files touched
+
+- `.claude/skills/autonomous/hooks/autonomous-stop-hook.sh` — new IDLE_BACKOFF block between the session-id reconcile and the iteration increment: measures the agent's active gap since the last re-injection via a per-topic sidecar (`<topic>.local.backoff.json`), counts consecutive quick stops, and sleeps tiered (3+ → 30s, 6+ → 120s, 10+ → 300s) before emitting the block decision. Poll-sleeps in 5s chunks with early-break on new inbound message / emergency-stop flag / state-file removal; re-checks terminal conditions after the sleep (emergency → notify + clear + exit; state gone → exit). Sleep self-clamps to a third of the hook's own registered Stop timeout read from `.claude/settings.json` (unreadable or codex-mode → conservative 20s). Env seams: `INSTAR_HOOK_BACKOFF_DISABLE`, `_QUICK_SECS`, `_T1/_T2/_T3`, `_POLL_SECS`, `_MAX_SLEEP`.
+- `src/core/PostUpdateMigrator.ts` — stop-hook migration marker bumped `RESTART_NOTE_SILENT` → `IDLE_BACKOFF` so existing agents receive the paced hook (customized hooks still untouched).
+- `tests/unit/autonomous-stop-hook-idle-backoff.test.ts` — new (13 tests; executes the real hook).
+- 7 existing hook-exec test harnesses (`autonomous-completion-condition`, `autonomous-stop-hook-cwd-anchor`, `-codex-gate`, `-topic-keyed`, `-session-clock`, `autonomous-multi-session`, e2e `autonomous-restart-resume-lifecycle`) — gain `INSTAR_HOOK_BACKOFF_DISABLE: '1'` in their env so suites that exec the hook repeatedly never hit a real sleep.
+- `tests/unit/autonomous-stop-hook-notify.test.ts` — terminal-notify call-site count 6 → 7 (the backoff's mid-sleep emergency re-check adds one) + marker-history assertion advanced to `IDLE_BACKOFF`.
+
+## Behavioral side effects
+
+1. **An idle autonomous session re-injects its frame ~once per 5 minutes instead of ~15×/min** — ≥98% reduction in idle-loop token burn (the 2026-06-06 rapid-idle-refire waste: thousands of no-op re-injections over one operator sleep).
+2. **A productive loop is untouched**: any iteration whose active time exceeds QUICK_SECS (120s) resets the counter; tiers only engage after 3+ consecutive quick stops.
+3. **Reaction to a new user message while idle-deep**: ≤ POLL_SECS (5s) — the sleep breaks early on a new inbound file for the topic. Emergency stop and job stop/stop-all break the same way.
+4. **One new sidecar file per topic** in `.instar/autonomous/` (`<topic>.local.backoff.json`). The server's autonomous-dir enumeration filters on `.local.md`, so the sidecar is invisible to it. Stale sidecars self-reset on the next run (runStartedAt mismatch) and are removed on the backoff's own terminal exits; sidecars left by other terminal paths are inert.
+5. **Migration**: every existing agent's stock stop-hook is overwritten at next migration run (marker bump). Customized hooks (no stock fingerprint) skipped, as before.
+
+## Risks / blast radius
+
+- **Hook timeout vs sleep** (the strand-class risk): a Stop hook killed by the host fails OPEN → session exits → loop strands silently. Mitigated three ways: the sleep self-clamps to registered-timeout/3 (live read of settings.json; the shipped registration is 10000s, so the clamp is far above T3); unreadable/missing registration falls back to a 20s cap; codex registrations get the same 20s cap. Worst case is therefore reduced pacing, never a stranded loop.
+- **Sentinel interplay**: a session sleeping inside its Stop hook shows no pane activity for up to 5 min. The silence/socket sentinels target sessions with active work or dropped sockets, not completed turns awaiting the next injection; observed-not-theorized verification rides the dogfood loop after deploy.
+- **Delayed sentinel/tmux-injected text** (not Telegram-routed): anything typed directly into the pane during a sleep sits in the input buffer until the next turn — bounded by T3 (5 min). Telegram messages are NOT affected (early-break).
+- **Counter semantics during conversation**: replying to a user message usually takes < QUICK_SECS, so the counter can keep rising across an active conversation — but each new inbound message breaks the sleep within 5s, so perceived latency stays ≤5s; pacing only persists between messages, which is the desired behavior.
+
+## Tests
+
+- `tests/unit/autonomous-stop-hook-idle-backoff.test.ts` (13): counter evolution (first-stop zero, quick-rise, long-gap reset, new-run reset), tier engagement + MAX_SLEEP clamp + DISABLE seam, early-breaks (inbound / emergency / state-removal, real async timing), static safety properties (timeout self-clamp present, sidecar suffix invisible to server), migration upgrade path (prior-era hook gains IDLE_BACKOFF, retains RESTART_NOTE_SILENT).
+- All 8 pre-existing hook suites pass with the disable seam (57 tests across the affected files).
+- Full typecheck clean; `bash -n` clean.


### PR DESCRIPTION
## ELI16

Imagine a friend who texts you "anything new?" every 4 seconds, all night, even though you told them you're asleep until morning. Each text costs real money. That was the autonomous loop: every time the agent finished saying "still waiting," the loop instantly re-sent it the ENTIRE mission briefing — thousands of tokens — ~15 times a minute, for hours.

The fix teaches the loop to read the room: if the agent keeps coming back with nothing new (3 quick "nothing yet" turns in a row), wait 30 seconds before the next nudge. Still nothing after 6? Wait 2 minutes. After 10? Check every 5 minutes. The moment the agent does real work, the waiting resets to zero — a busy agent is never slowed down. And if YOU text the agent during a wait, it wakes up within 5 seconds. One hard safety rule: the wait must never run longer than the system allows a hook to run, because a hook killed mid-wait would silently kill the whole loop — so the wait always stays well under that limit, preferring a little noise over a dead loop.

## What

The autonomous stop-hook re-injected the full frame + context immediately on every non-terminal stop — **~15×/min while a session was idle/holding**, thousands of token-heavy no-op re-injections over one operator sleep (the 2026-06-06 rapid-idle-refire waste, flagged by Justin as a resource concern at the LLM-token layer).

The hook now paces itself when the loop looks idle:

- **Active-gap measurement**: gap = stop arrival − last resume; slept time never counts, so a long wait can't masquerade as work. Short gap ⇒ idle cycle.
- **Tiered backoff**: 3+ consecutive quick stops → 30s, 6+ → 120s, 10+ → 300s before the next re-injection. One real burst of work resets the counter instantly — a productive loop never waits.
- **Early-break responsiveness**: the sleep polls every 5s and breaks on a new inbound message for the topic / emergency-stop flag / state-file removal. A user message gets through in ≤5s.
- **Strand-proof self-clamp**: the sleep clamps to a third of the hook's own registered Stop timeout (read live from settings.json; unreadable or codex-mode → conservative 20s). A host-killed Stop hook fails OPEN and strands the loop — the clamp guarantees fail-toward-noise, never toward strand.
- **State**: per-topic sidecar `.instar/autonomous/<topic>.local.backoff.json` — invisible to the server (`.local.md` filter), self-resets on a new run.

## Migration parity

PostUpdateMigrator stop-hook marker bumped `RESTART_NOTE_SILENT` → `IDLE_BACKOFF`; existing agents receive the paced hook on next migration run; customized hooks untouched.

## Causal autopsy

**origin: latent** — pacing was never designed into the loop; the cost surfaced when long idle holds became a normal loop state and operator-overnight stretched them to 6–8h. No prior PR caused it. Sibling #914 silenced the loop's USER-facing restart noise; this paces its MODEL-facing re-injection.

## Evidence

- `tests/unit/autonomous-stop-hook-idle-backoff.test.ts` — 13 tests executing the REAL hook: counter evolution, tier engagement (measured wall-time), long-gap + new-run resets, MAX_SLEEP clamp, DISABLE seam, async early-breaks (inbound/emergency/state-removal), static safety assertions, migration upgrade path.
- 57 tests across the 8 pre-existing hook suites pass (harnesses gain `INSTAR_HOOK_BACKOFF_DISABLE` so repeated execs never sleep); notify call-site count 6 → 7 (mid-sleep emergency re-check).
- Typecheck clean; `bash -n` clean. Gate artifacts: eli16 + side-effects + Tier-1 trace with causalAutopsy.

**Held for Justin's word before merge** — this changes the driver of every autonomous loop; deliberately not self-merged on green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
