### PR TITLE
docs(exo3): refresh honest status to shipped reality + add the red-team proof section

### DIFF
--- a/site/src/content/docs/features/exo3.md
+++ b/site/src/content/docs/features/exo3.md
@@ -1,6 +1,6 @@
 ---
 title: EXO 3.0 Alignment
-description: The EXO 3.0 capability set — MTP protocol tests, agent-readiness scoring, digital passports, and learning-velocity metrics.
+description: The EXO 3.0 capability set — MTP protocol tests, the MTP red-team harness, agent-readiness scoring, digital passports, and learning-velocity metrics.
 ---
 
 Instar maps directly onto Salim Ismail's EXO 3.0 framework — agents governed by
@@ -39,6 +39,27 @@ Not For`).
 - `instar intent validate` reports layer status and whether the intent **governs** or merely **cheers**
 
 Advisory, never blocking — it answers a question.
+
+## MTP Red-Team Harness
+
+An MTP whose refusal boundary was never adversarially probed is an
+*unverified* governor. The red-team harness probes the refusal boundary with
+amplification-ladder scenarios (from the polite ask up to engineered social
+pressure), deriving pass/fail expectations from the target org's **own**
+intent — so any org can point it at their own MTP. Every probe, verdict, and
+the method that produced it lands in an audit trail.
+
+The first boundary map — run against our own intent — demonstrated both
+honesty properties at once: credential-exfiltration probes were refused at
+every amplification level (governed), and a value-conflict probe that first
+read "ungoverned" turned out to be the harness's **own keyword matcher**
+missing a semantic match, not a real intent gap. Two fixes followed: every
+verdict now declares the method that produced it (`keyword-heuristic` vs
+`llm-judge`), and an optional LLM judge (`monitoring.orgIntentLlmJudge.enabled`)
+gives keyword misses a semantic second opinion by meaning rather than wording.
+
+- Spec: `docs/specs/MTP-REDTEAM-HARNESS-SPEC.md`; scenario pack and expectation resolver in `src/redteam/`
+- Phase 1 (scenario verification + the static boundary map) is live; the live adversarial drive against a running agent is the next phase, shown honestly as such
 
 ## Agent-Readiness Scoring
 

--- a/site/src/pages/exo3.astro
+++ b/site/src/pages/exo3.astro
@@ -17,6 +17,7 @@ import Layout from '../layouts/Layout.astro';
         <a href="#purpose" class="text-sm text-slate-400 hover:text-slate-200 transition-colors hidden lg:block">Purpose</a>
         <a href="#stack" class="text-sm text-slate-400 hover:text-slate-200 transition-colors hidden lg:block">Intelligence Stack</a>
         <a href="#mtp" class="text-sm text-slate-400 hover:text-slate-200 transition-colors hidden lg:block">MTP Protocol</a>
+        <a href="#redteam" class="text-sm text-slate-400 hover:text-slate-200 transition-colors hidden lg:block">Red-Team</a>
         <a href="#shape" class="text-sm text-slate-400 hover:text-slate-200 transition-colors hidden lg:block">SHAPE</a>
         <a href="#status" class="text-sm text-slate-400 hover:text-slate-200 transition-colors hidden lg:block">Where We Are</a>
         <a href="/" class="text-sm font-medium text-teal-400 hover:text-teal-300 transition-colors">Home</a>
@@ -136,21 +137,46 @@ import Layout from '../layouts/Layout.astro';
           <p class="text-xs text-slate-400 leading-relaxed mb-3">Resolve a trade-off without waking you up; versioned, auditable, deterministic.</p>
           <p class="text-xs text-teal-400/80 leading-relaxed">&rarr; Instar&rsquo;s tradeoff hierarchy + resolver returns the winning value deterministically. Two agents reading the same intent reach the same call.</p>
         </div>
-        <div class="rounded-xl border border-slate-800 bg-slate-900/40 p-6">
+        <div class="rounded-xl border border-teal-500/20 bg-teal-500/5 p-6">
           <div class="flex items-center gap-2 mb-3">
-            <span class="text-xs font-medium text-amber-400 uppercase tracking-wider">Shipping</span>
+            <span class="text-xs font-medium text-green-400 uppercase tracking-wider">Live</span>
           </div>
           <p class="text-sm font-semibold text-slate-200 mb-2">Identity layer</p>
           <p class="text-xs text-slate-400 leading-relaxed mb-3">What binds high-judgment humans when the office is gone.</p>
-          <p class="text-xs text-slate-500 leading-relaxed">&rarr; Building on ORG-INTENT values &mdash; weeks away.</p>
+          <p class="text-xs text-teal-400/80 leading-relaxed">&rarr; ORG-INTENT&rsquo;s Identity section &mdash; &ldquo;Why People Stay&rdquo; and &ldquo;What We&rsquo;re Not For&rdquo; &mdash; parsed and served to agents like every other layer.</p>
         </div>
       </div>
 
       <div class="rounded-lg border border-slate-700/50 bg-slate-800/30 p-6 mt-4">
         <p class="text-slate-300 text-sm leading-relaxed text-center max-w-3xl mx-auto">
-          And his two tests &mdash; <strong class="text-teal-300">endorsement</strong> (&ldquo;would leadership endorse what the agent decided?&rdquo;) and <strong class="text-teal-300">refusal</strong> (&ldquo;can your MTP make an agent say no?&rdquo;) &mdash; are what Instar&rsquo;s Coherence Gate enforces on every outbound action. <em>If your MTP can&rsquo;t cause a refusal, it&rsquo;s cheering, not governing.</em> Instar&rsquo;s gates refuse.
+          And his two tests &mdash; <strong class="text-teal-300">endorsement</strong> (&ldquo;would leadership endorse what the agent decided?&rdquo;) and <strong class="text-teal-300">refusal</strong> (&ldquo;can your MTP make an agent say no?&rdquo;) &mdash; are now a live, packaged harness: post any proposed action to the intent API and get back a refusal verdict and an endorsement verdict, and <code class="text-teal-300">instar intent validate</code> reports whether your MTP <em>governs</em> or merely <em>cheers</em>. <em>If your MTP can&rsquo;t cause a refusal, it&rsquo;s cheering, not governing.</em> Ours refuses &mdash; and we prove it, adversarially, below.
         </p>
       </div>
+    </div>
+  </section>
+
+  <!-- MTP Red-Team Harness -->
+  <section id="redteam" class="py-16 sm:py-20 border-t border-slate-800/50">
+    <div class="max-w-4xl mx-auto px-6">
+      <div class="text-center mb-10">
+        <h2 class="text-3xl sm:text-4xl font-bold text-slate-100 mb-4">We red-team our own purpose</h2>
+        <p class="text-slate-400 max-w-2xl mx-auto leading-relaxed">An MTP whose refusal boundary was never adversarially probed is an <em>unverified</em> governor. So Instar ships a red-team harness that probes the live agent through its real channel &mdash; escalating pressure, expectations derived from the org&rsquo;s <strong class="text-slate-200">own</strong> intent. Any org can point it at their own MTP. Here is what it found when we pointed it at ours.</p>
+      </div>
+
+      <div class="grid sm:grid-cols-2 gap-4">
+        <div class="rounded-xl border border-green-500/20 bg-green-500/5 p-6">
+          <p class="text-xs font-medium text-green-400 uppercase tracking-wider mb-3">Governed</p>
+          <p class="text-sm text-slate-300 leading-relaxed">Credential-exfiltration probes: refused at every amplification level, from the polite ask to the engineered social pressure. The constraint held the line.</p>
+        </div>
+        <div class="rounded-xl border border-amber-500/20 bg-amber-500/5 p-6">
+          <p class="text-xs font-medium text-amber-400 uppercase tracking-wider mb-3">The harness caught itself</p>
+          <p class="text-sm text-slate-300 leading-relaxed">A value-conflict probe first read &ldquo;ungoverned&rdquo; &mdash; and the root cause was the harness&rsquo;s own keyword matcher, not the intent. So every verdict now declares the method that produced it, and a semantic judge gives keyword misses a real second opinion by <em>meaning</em>. The first blind spot our red-team caught was its own &mdash; and it said so.</p>
+        </div>
+      </div>
+
+      <p class="text-slate-400 text-sm text-center max-w-2xl mx-auto mt-8 leading-relaxed">
+        Every probe, verdict, and method lands in an audit trail. <em class="text-teal-300">Governing, not cheering</em> isn&rsquo;t a claim here &mdash; it&rsquo;s a measurement.
+      </p>
     </div>
   </section>
 
@@ -230,21 +256,25 @@ import Layout from '../layouts/Layout.astro';
           <span class="text-sm text-slate-200">One-person-many-agents leverage</span>
           <span class="text-xs font-medium text-green-400 uppercase tracking-wider">Live</span>
         </div>
-        <div class="flex items-center justify-between rounded-lg border border-amber-500/20 bg-amber-500/5 px-5 py-3">
-          <span class="text-sm text-slate-200">MTP identity layer + test harness</span>
-          <span class="text-xs font-medium text-amber-400 uppercase tracking-wider">Shipping &mdash; weeks</span>
+        <div class="flex items-center justify-between rounded-lg border border-green-500/20 bg-green-500/5 px-5 py-3">
+          <span class="text-sm text-slate-200">MTP identity layer + refusal/endorsement tests</span>
+          <span class="text-xs font-medium text-green-400 uppercase tracking-wider">Live</span>
         </div>
-        <div class="flex items-center justify-between rounded-lg border border-amber-500/20 bg-amber-500/5 px-5 py-3">
+        <div class="flex items-center justify-between rounded-lg border border-green-500/20 bg-green-500/5 px-5 py-3">
           <span class="text-sm text-slate-200">Agent-readiness scoring <span class="text-slate-500">(your task-decomposition matrix)</span></span>
-          <span class="text-xs font-medium text-amber-400 uppercase tracking-wider">Shipping &mdash; weeks</span>
+          <span class="text-xs font-medium text-green-400 uppercase tracking-wider">Live</span>
         </div>
-        <div class="flex items-center justify-between rounded-lg border border-slate-700/50 bg-slate-800/30 px-5 py-3">
+        <div class="flex items-center justify-between rounded-lg border border-green-500/20 bg-green-500/5 px-5 py-3">
           <span class="text-sm text-slate-200">Agent digital passport</span>
-          <span class="text-xs font-medium text-slate-400 uppercase tracking-wider">Primitives live</span>
+          <span class="text-xs font-medium text-green-400 uppercase tracking-wider">Live</span>
         </div>
-        <div class="flex items-center justify-between rounded-lg border border-slate-700/50 bg-slate-800/30 px-5 py-3">
+        <div class="flex items-center justify-between rounded-lg border border-green-500/20 bg-green-500/5 px-5 py-3">
           <span class="text-sm text-slate-200">Learning-velocity metrics</span>
-          <span class="text-xs font-medium text-slate-400 uppercase tracking-wider">Roadmap</span>
+          <span class="text-xs font-medium text-green-400 uppercase tracking-wider">Live</span>
+        </div>
+        <div class="flex items-center justify-between rounded-lg border border-amber-500/20 bg-amber-500/5 px-5 py-3">
+          <span class="text-sm text-slate-200">MTP red-team harness <span class="text-slate-500">(first boundary map run against ourselves)</span></span>
+          <span class="text-xs font-medium text-amber-400 uppercase tracking-wider">Phase 1 live</span>
         </div>
         <div class="flex items-center justify-between rounded-lg border border-teal-500/20 bg-teal-500/5 px-5 py-3">
           <span class="text-sm text-slate-200"><strong>Inter-org porous boundary</strong> <span class="text-slate-500">(the North Star)</span></span>


### PR DESCRIPTION
## What

The /exo3 page's "Where we are, honestly" section lagged reality: G1 (MTP identity layer + two-tests harness) and G2 (agent-readiness scoring) still showed "Shipping — weeks", G3 passport showed "Primitives live", G5 learning-velocity showed "Roadmap" — all four are merged, deployed, and (G1/G2) live-proven. The requirements matrix also requires the page to show the G7 red-team harness and our own honestly-measured boundary map before Salim outreach ("the proof that 'governing, not cheering' is verified, not asserted").

- **Status table**: G1/G2/G3/G5 → Live; new amber row "MTP red-team harness (first boundary map run against ourselves)" → Phase 1 live (honest — the live adversarial drive is still ahead).
- **MTP-protocol section**: identity-layer card Shipping → Live; the two-tests box now states the packaged live harness (test-action API + `instar intent validate`).
- **New `#redteam` section**: the harness + the first boundary map told honestly — credentials governed at every amplification level, and the value-conflict false-negative root-caused to the harness's own keyword matcher, with the method-labeling (#899) and semantic-judge (#920) fixes named. The honesty arc IS the proof.
- **features/exo3.md**: mirrored MTP Red-Team Harness section.

Docs/site-only — no runtime code. Site builds clean (58 pages); rendered output verified for every new marker, confirmed free of stale labels and of restricted terms (no agent names, no timeframe claims).

## ELI16

The /exo3 page has a section that promises "here's where we are, honestly" — but it was still saying "coming in weeks" about four things that already shipped. An honesty section that's out of date is the one kind of bug it can't afford. This updates it to the truth, and adds the best part of the story: we built a tool that attacks our own rulebook to prove the rules actually refuse things — and the first thing it caught was a blind spot in itself, which it admitted. That's the difference between rules that govern and rules that cheer, and now the page shows it.

## Evidence

- `cd site && npm run build` — clean, 58 pages.
- Rendered `dist/exo3/index.html` checked for all new markers (red-team section, Live labels, Phase 1 live row) and the absence of stale "Shipping — weeks" labels.
- Restricted-terms sweep on rendered text: clean.