### PR TITLE
feat(users): topic-operator auto-bind on the polling ingress path (Know Your Principal increment 2e)

### DIFF
--- a/.instar/instar-dev-decisions/2026-06-06T17-08-38-735Z-topic-operator-polling-bind-inc2e.json
+++ b/.instar/instar-dev-decisions/2026-06-06T17-08-38-735Z-topic-operator-polling-bind-inc2e.json
@@ -1,0 +1,13 @@
+{
+  "ts": "2026-06-06T17:08:38.735Z",
+  "slug": "topic-operator-polling-bind-inc2e",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 3,
+  "loc": 66,
+  "causalAutopsy": null,
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-06-06T17-09-10-542Z-topic-operator-polling-bind-inc2e.json
+++ b/.instar/instar-dev-decisions/2026-06-06T17-09-10-542Z-topic-operator-polling-bind-inc2e.json
@@ -1,0 +1,13 @@
+{
+  "ts": "2026-06-06T17:09:10.542Z",
+  "slug": "topic-operator-polling-bind-inc2e",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 3,
+  "loc": 66,
+  "causalAutopsy": null,
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-06-06T17-09-45-504Z-topic-operator-polling-bind-inc2e.json
+++ b/.instar/instar-dev-decisions/2026-06-06T17-09-45-504Z-topic-operator-polling-bind-inc2e.json
@@ -1,0 +1,13 @@
+{
+  "ts": "2026-06-06T17:09:45.504Z",
+  "slug": "topic-operator-polling-bind-inc2e",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 3,
+  "loc": 66,
+  "causalAutopsy": null,
+  "verdict": "pass"
+}

--- a/src/commands/server.ts
+++ b/src/commands/server.ts
@@ -350,6 +350,11 @@ function isAutostartInstalled(projectName: string): boolean {
 let _orphanReaper: import('../monitoring/OrphanProcessReaper.js').OrphanProcessReaper | null = null;
 let _memoryMonitor: import('../monitoring/MemoryPressureMonitor.js').MemoryPressureMonitor | null = null;
 let _fixDeps: FixCommandDeps | null = null;
+// Late-bound ref to the running AgentServer: wireTelegramRouting's
+// topic-operator getter (Know Your Principal increment 2e) resolves the
+// server's store at message-time — the server is constructed long after
+// routing is wired, and the store must be the server's OWN instance.
+let _agentServerRef: import('../server/AgentServer.js').AgentServer | null = null;
 
 // Module-level reference for session resume mapping.
 // Set once in startServer() and used by spawnSessionForTopic/respawnSessionForTopic.
@@ -1210,7 +1215,7 @@ function messageToPipeline(msg: Message, topicName?: string): PipelineMessage {
   };
 }
 
-function wireTelegramRouting(
+export function wireTelegramRouting(
   telegram: TelegramAdapter,
   sessionManager: SessionManager,
   quotaTracker?: QuotaTracker,
@@ -1220,6 +1225,11 @@ function wireTelegramRouting(
   // Late-bound: the threadline hub deps are constructed AFTER this is wired, so
   // resolve them at message-time (CMT-529 deterministic "open this" intercept).
   getHubDeps?: () => import('../threadline/hubCommands.js').HubBindDeps | null,
+  // Late-bound (same reason as getHubDeps): the AgentServer's TopicOperatorStore —
+  // the SAME instance the routes use (a second instance on the same file would
+  // lose updates between the two in-memory caches). Know Your Principal #898,
+  // increment 2e: the polling-path operator auto-bind.
+  getTopicOperatorStore?: () => import('../users/TopicOperatorStore.js').TopicOperatorStore | null,
 ): void {
   // Guard: tracks which topic IDs have a spawn in progress.
   // Prevents duplicate concurrent spawns for the same topic when messages
@@ -1237,6 +1247,30 @@ function wireTelegramRouting(
     const resolvedUser = telegramUserId && userManager
       ? userManager.resolveFromTelegramUserId(telegramUserId)
       : null;
+
+    // Topic-operator auto-bind (Know Your Principal #898, increment 2e — the
+    // POLLING-path writer; the lifeline-forward path already binds in routes.ts
+    // #909). This onTopicMessage seam is the convergence BOTH ingress paths
+    // reach, so binding here closes the no-lifeline gap; the routes-side bind
+    // stays (idempotent — same store instance, identical record skips the
+    // write). The isAuthorizedSender check is LOAD-BEARING: the lifeline path
+    // fires this callback for unauthorized senders too (it only skips its own
+    // bind), so without the check here an unauthorized group member could seat
+    // themselves as operator — the cross-principal "Caroline" bug. Fail-soft:
+    // no store / unauthorized / error → no-op and routing continues.
+    try {
+      const opStore = getTopicOperatorStore?.() ?? null;
+      if (opStore && telegramUserId && telegram.isAuthorizedSender(telegramUserId)) {
+        opStore.setOperator(topicId, {
+          platform: 'telegram',
+          uid: String(telegramUserId),
+          displayName: (msg.metadata?.firstName as string) ?? undefined,
+        });
+      }
+    } catch (err) {
+      // @silent-fallback-ok — an auto-bind failure must never break message routing.
+      console.error(`[telegram] topic-operator auto-bind error (non-fatal): ${err instanceof Error ? err.message : err}`);
+    }
 
     // In lifeline-owned polling mode (deep-signal, echo) TelegramAdapter's
     // own poll loop never runs, so its handleCommand() never fires on forwarded
@@ -3879,7 +3913,8 @@ export async function startServer(options: StartOptions): Promise<void> {
       _fixDeps = { state, liveConfig, sessionManager, telegram, config };
       wireTelegramRouting(telegram, sessionManager, quotaTracker, topicMemory, userManagerSendOnly,
         (topicId, text) => handleFixCommand(topicId, text, _fixDeps!),
-        () => (collaborationSurfacer && conversationStore && telegram) ? { collaborationSurfacer, conversationStore, commitmentTracker, telegram, brief: briefDeps } : null);
+        () => (collaborationSurfacer && conversationStore && telegram) ? { collaborationSurfacer, conversationStore, commitmentTracker, telegram, brief: briefDeps } : null,
+        () => _agentServerRef?.getTopicOperatorStore() ?? null);
       wireTelegramCallbacks(telegram, sessionManager, state, quotaTracker, undefined, config.sessions.claudePath, topicMemory);
       console.log(pc.green('  Telegram routing + command callbacks wired (send-only)'));
     }
@@ -4084,7 +4119,8 @@ export async function startServer(options: StartOptions): Promise<void> {
       // Wire up topic → session routing and session management callbacks
       wireTelegramRouting(telegram, sessionManager, quotaTracker, topicMemory, userManager,
         (topicId, text) => handleFixCommand(topicId, text, _fixDeps!),
-        () => (collaborationSurfacer && conversationStore && telegram) ? { collaborationSurfacer, conversationStore, commitmentTracker, telegram, brief: briefDeps } : null);
+        () => (collaborationSurfacer && conversationStore && telegram) ? { collaborationSurfacer, conversationStore, commitmentTracker, telegram, brief: briefDeps } : null,
+        () => _agentServerRef?.getTopicOperatorStore() ?? null);
       wireTelegramCallbacks(telegram, sessionManager, state, quotaTracker, accountSwitcher, config.sessions.claudePath, topicMemory);
 
       // Wire up unknown-user handling (Multi-User Setup Wizard Phase 4.5)
@@ -11497,6 +11533,11 @@ export async function startServer(options: StartOptions): Promise<void> {
     }
 
     const server = new AgentServer({ config, sessionManager, state, scheduler, telegram, relationships, feedback, feedbackAnomalyDetector, dispatches, updateChecker, autoUpdater, autoDispatcher, quotaTracker, quotaManager, publisher, viewer, tunnel, evolution, watchdog, topicMemory, triageNurse, projectMapper, coherenceGate: scopeVerifier, contextHierarchy, canonicalState, operationGate, sentinel, adaptiveTrust, memoryMonitor, orphanReaper, coherenceMonitor, commitmentTracker, semanticMemory, activitySentinel, rateLimitSentinel, releaseReadinessSentinel: releaseReadinessSentinel ?? undefined, messageRouter, summarySentinel, spawnManager, systemReviewer, capabilityMapper, selfKnowledgeTree, coverageAuditor, topicResumeMap: _topicResumeMap ?? undefined, sessionRefresh: _sessionRefresh ?? undefined, autonomyManager, trustElevationTracker, autonomousEvolution, coordinator: coordinator.enabled ? coordinator : undefined, localSigningKeyPem, leaseTransport, onLeasePullRequest: () => leaseCoordinatorRef?.currentLease() ?? null, liveTailReceiver, handoffWireTransport, onHandoffBegin, onHandoffInitiate: handoffInitiate, handoffInProgress: handoffSentinelInProgress, messageLedger, currentInboundByTopic, replyMarkerTransport, onReplyMarker: messageLedger ? (marker: unknown) => { const m = marker as { dedupeKey: string; platform: string; replyIdempotencyKey: string; epoch: number; topic?: string | null }; messageLedger!.applyRemoteReplyMarker(m.dedupeKey, { platform: m.platform, replyIdempotencyKey: m.replyIdempotencyKey, epoch: m.epoch, topic: m.topic ?? null }); } : undefined, whatsapp: whatsappAdapter, slack: slackAdapter, imessage: imessageAdapter, whatsappBusinessBackend, messageBridge, hookEventReceiver, worktreeMonitor, subagentTracker, instructionsVerifier, handshakeManager: threadlineHandshake, threadlineRouter, conversationStore, warrantsReplyGate, collaborationSurfacer, threadResumeMap, topicLinkageHandler: topicLinkageHandler ?? undefined, threadlineRelayClient, threadlineReplyWaiters, listenerManager: listenerManager ?? undefined, responseReviewGate, messagingToneGate, outboundDedupGate, telemetryHeartbeat, pasteManager, featureRegistry, discoveryEvaluator, completionEvaluator, unifiedTrust, liveConfig, sharedStateLedger, ledgerSessionRegistry, worktreeManager, oidcEnrolledRepos: parallelDevConfig?.oidcEnrolledRepos, initiativeTracker, projectRoundRunner, projectDriftChecker, machineHeartbeat, machinePoolRegistry, meshRpcDispatcher, workingSetPullCoordinator, commitmentReplicaStore, forwardCommitmentMutate, sessionOwnershipRegistry, topicPinStore: _topicPinStore ?? undefined, secretSync: _secretSyncHandle ?? undefined, meshSelfId: _meshSelfId ?? undefined, resolveRouterUrl: _resolveRouterUrl ?? undefined, resolvePeerUrls: _resolvePeerUrls ?? undefined, sessionPoolE2EResultStore, proxyCoordinator, topicIntentStore, topicIntentArcCheck, usherSignalStore, intelligence: sharedIntelligence ?? undefined, telegramBridgeConfig, telegramBridge: telegramBridge ?? undefined, threadlineObservability, briefDeps, workingMemory, taskFlowRegistry, threadlineFlowBridge, sessionReaper, agentWorktreeReaper, mcpProcessReaper, geminiLoopRunner, sleepController, agentActivityState, reapLog, sleepWakeDetector, unjustifiedStopGate, stopGateDb, stopNotifier });
+    // Resolve the late-bound topic-operator getter (increment 2e): routing was
+    // wired before the server existed; from here on inbound binds use the
+    // server's own store instance.
+    _agentServerRef = server;
+
     // Boot-recovery (tunnel-failure-resilience spec Part 6): if the agent
     // died mid-relay-episode, the persisted tunnel.json carries
     // rotationPending=true. Rotate the dashboard PIN + authToken BEFORE

--- a/src/server/AgentServer.ts
+++ b/src/server/AgentServer.ts
@@ -2949,4 +2949,15 @@ export class AgentServer {
   getParallelWorkSentinel(): ParallelWorkSentinel | null {
     return this.parallelWorkSentinel;
   }
+
+  /**
+   * The topic-operator store (Know Your Principal #898). Exposed so the inbound
+   * routing seam (`wireTelegramRouting`, increment 2e) binds the operator on the
+   * POLLING ingress path with the SAME instance the routes use — the store caches
+   * its map in memory, so constructing a second instance on the same file would
+   * lose updates between the two caches.
+   */
+  getTopicOperatorStore(): TopicOperatorStore | null {
+    return this.topicOperatorStore;
+  }
 }

--- a/src/users/TopicOperatorStore.ts
+++ b/src/users/TopicOperatorStore.ts
@@ -86,6 +86,14 @@ export class TopicOperatorStore {
       boundAt: input.boundAt ?? '',
       boundFrom: 'authenticated-inbound',
     };
+    // Idempotency guard: both inbound ingress paths (lifeline-forward #909 and
+    // the polling seam, increment 2e) re-bind on EVERY message from the operator.
+    // When the stored record is already identical, skip the disk write — the
+    // re-bind is then a pure read, not a per-message file rewrite.
+    const existing = this.load()[String(topicId)];
+    if (existing && JSON.stringify(existing) === JSON.stringify(record)) {
+      return existing;
+    }
     const map = { ...this.load() };
     map[String(topicId)] = record;
     this.save(map);

--- a/tests/integration/topic-operator-polling-bind.test.ts
+++ b/tests/integration/topic-operator-polling-bind.test.ts
@@ -1,0 +1,98 @@
+/**
+ * Integration tests — polling-path operator auto-bind (Know Your Principal,
+ * Phase-1 increment 2e) with the REAL TopicOperatorStore + REAL PrincipalGuard
+ * establishOperator under the wired seam.
+ *
+ * Covers the cross-increment invariants the unit tier can't: the Caroline
+ * replay through the full bind path, the single-store-instance no-clobber
+ * guarantee (the reason the seam resolves the SERVER'S store late-bound
+ * instead of constructing its own), and the pre-construction lifecycle
+ * (messages arriving before the AgentServer exists bind nothing, fail-safe).
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { wireTelegramRouting } from '../../src/commands/server.js';
+import { TopicOperatorStore } from '../../src/users/TopicOperatorStore.js';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+import type { TelegramAdapter } from '../../src/messaging/TelegramAdapter.js';
+import type { SessionManager } from '../../src/core/SessionManager.js';
+import type { Message } from '../../src/core/types.js';
+
+let dir: string;
+beforeEach(() => { dir = fs.mkdtempSync(path.join(os.tmpdir(), 'topop2e-int-')); });
+afterEach(() => { SafeFsExecutor.safeRmSync(dir, { recursive: true, force: true, operation: 'tests/integration/topic-operator-polling-bind.test.ts' }); });
+
+const OPERATOR_UID = 7812716706;
+
+function makeAdapter(authorizedUids: Array<number | string>) {
+  const adapter = {
+    onTopicMessage: null as null | ((msg: Message) => Promise<void> | void),
+    handleCommand: async () => true,
+    isAuthorizedSender: (id: number | string) => authorizedUids.map(String).includes(String(id)),
+  };
+  return { adapter: adapter as unknown as TelegramAdapter, raw: adapter };
+}
+
+function inbound(uid: number, firstName: string, topicId = 19437): Message {
+  return {
+    id: `tg-${uid}`,
+    userId: String(uid),
+    content: '/status',
+    channel: { type: 'telegram', identifier: String(topicId) },
+    receivedAt: '2026-06-06T00:00:00Z',
+    metadata: { telegramUserId: uid, firstName, messageThreadId: topicId },
+  } as Message;
+}
+
+describe('increment 2e — polling-path bind, integration', () => {
+  it('CAROLINE REPLAY: the authorized operator binds; an unauthorized "Caroline" in the same topic cannot displace them', async () => {
+    const store = new TopicOperatorStore(dir);
+    const { adapter, raw } = makeAdapter([OPERATOR_UID]);
+    wireTelegramRouting(adapter, {} as SessionManager, undefined, undefined, undefined, undefined, undefined, () => store);
+
+    await raw.onTopicMessage!(inbound(OPERATOR_UID, 'Justin'));
+    expect(store.getOperator(19437)?.names).toEqual(['justin']);
+
+    // The unauthorized party — her name appears in content metadata, but the
+    // authenticated uid is not authorized, so the binding must not move.
+    await raw.onTopicMessage!(inbound(999, 'Caroline'));
+    const op = store.getOperator(19437);
+    expect(op?.uid).toBe(String(OPERATOR_UID));
+    expect(op?.names).toEqual(['justin']);
+  });
+
+  it('single-instance no-clobber: a seam bind never loses a record written through the same store', async () => {
+    const store = new TopicOperatorStore(dir);
+    // Pre-existing binding made through the server's instance (e.g. the
+    // POST /topic-operator route or the lifeline auto-bind).
+    store.setOperator(111, { platform: 'telegram', uid: '555', displayName: 'Alice' });
+
+    const { adapter, raw } = makeAdapter([OPERATOR_UID]);
+    wireTelegramRouting(adapter, {} as SessionManager, undefined, undefined, undefined, undefined, undefined, () => store);
+    await raw.onTopicMessage!(inbound(OPERATOR_UID, 'Justin', 222));
+
+    // Both bindings coexist — nothing clobbered.
+    expect(store.getOperator(111)?.uid).toBe('555');
+    expect(store.getOperator(222)?.uid).toBe(String(OPERATOR_UID));
+    // And the durable file carries both.
+    const onDisk = JSON.parse(fs.readFileSync(path.join(dir, 'topic-operators.json'), 'utf-8'));
+    expect(Object.keys(onDisk).sort()).toEqual(['111', '222']);
+  });
+
+  it('pre-construction lifecycle: messages before the server exists bind nothing (fail-safe); after late-bind resolution they bind', async () => {
+    const store = new TopicOperatorStore(dir);
+    let serverReady = false; // mirrors _agentServerRef being null until construction
+    const { adapter, raw } = makeAdapter([OPERATOR_UID]);
+    wireTelegramRouting(adapter, {} as SessionManager, undefined, undefined, undefined, undefined, undefined,
+      () => (serverReady ? store : null));
+
+    await raw.onTopicMessage!(inbound(OPERATOR_UID, 'Justin'));
+    expect(store.getOperator(19437)).toBeNull(); // fail-safe: no binding yet
+
+    serverReady = true;
+    await raw.onTopicMessage!(inbound(OPERATOR_UID, 'Justin'));
+    expect(store.getOperator(19437)?.uid).toBe(String(OPERATOR_UID));
+  });
+});

--- a/tests/unit/topic-operator-polling-bind.test.ts
+++ b/tests/unit/topic-operator-polling-bind.test.ts
@@ -1,0 +1,121 @@
+/**
+ * Unit tests — polling-path topic-operator auto-bind (Know Your Principal,
+ * Phase-1 increment 2e).
+ *
+ * The `onTopicMessage` seam wired by `wireTelegramRouting` is the convergence
+ * BOTH ingress paths reach (lifeline-forward AND server-polling). Increment 2d
+ * (#909) binds the verified operator on the lifeline-forward route only; this
+ * increment binds at the seam so the no-lifeline polling path is covered too.
+ * The bind MUST re-check `isAuthorizedSender` — the lifeline path fires this
+ * callback for unauthorized senders as well (it only skips its own bind), so
+ * an unchecked seam bind would re-open the cross-principal "Caroline" bug.
+ *
+ * Messages here are slash-commands with a handleCommand that reports handled,
+ * so the callback early-returns right after the bind block — the session
+ * routing tail never runs and needs no stubbing.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { wireTelegramRouting } from '../../src/commands/server.js';
+import { TopicOperatorStore } from '../../src/users/TopicOperatorStore.js';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+import type { TelegramAdapter } from '../../src/messaging/TelegramAdapter.js';
+import type { SessionManager } from '../../src/core/SessionManager.js';
+import type { Message } from '../../src/core/types.js';
+
+let dir: string;
+beforeEach(() => { dir = fs.mkdtempSync(path.join(os.tmpdir(), 'topop2e-')); });
+afterEach(() => { SafeFsExecutor.safeRmSync(dir, { recursive: true, force: true, operation: 'tests/unit/topic-operator-polling-bind.test.ts' }); });
+
+/** Minimal fake adapter: captures the wired onTopicMessage and exposes the
+ *  two methods the bind path touches. Cast via unknown — the callback only
+ *  reaches handleCommand/isAuthorizedSender on the slash-command path. */
+function makeAdapter(authorized: (id: number | string) => boolean) {
+  const calls: { handleCommand: number } = { handleCommand: 0 };
+  const adapter = {
+    onTopicMessage: null as null | ((msg: Message) => Promise<void> | void),
+    handleCommand: async () => { calls.handleCommand += 1; return true; },
+    isAuthorizedSender: authorized,
+  };
+  return { adapter: adapter as unknown as TelegramAdapter, raw: adapter, calls };
+}
+
+function makeMessage(opts: { uid?: number; firstName?: string; topicId?: number; text?: string }): Message {
+  return {
+    id: 'tg-1',
+    userId: String(opts.uid ?? 0),
+    content: opts.text ?? '/status',
+    channel: { type: 'telegram', identifier: String(opts.topicId ?? 19437) },
+    receivedAt: '2026-06-06T00:00:00Z',
+    metadata: {
+      telegramUserId: opts.uid,
+      firstName: opts.firstName,
+      messageThreadId: opts.topicId ?? 19437,
+    },
+  } as Message;
+}
+
+describe('polling-path operator auto-bind (increment 2e)', () => {
+  it('binds an AUTHORIZED sender as the verified operator', async () => {
+    const store = new TopicOperatorStore(dir);
+    const { adapter, raw } = makeAdapter(() => true);
+    wireTelegramRouting(adapter, {} as SessionManager, undefined, undefined, undefined, undefined, undefined, () => store);
+
+    await raw.onTopicMessage!(makeMessage({ uid: 7812716706, firstName: 'Justin' }));
+
+    const op = store.getOperator(19437);
+    expect(op?.uid).toBe('7812716706');
+    expect(op?.names).toEqual(['justin']);
+    expect(op?.boundFrom).toBe('authenticated-inbound');
+  });
+
+  it('does NOT bind an UNAUTHORIZED sender — the Caroline invariant at the seam', async () => {
+    const store = new TopicOperatorStore(dir);
+    const { adapter, raw } = makeAdapter(() => false);
+    wireTelegramRouting(adapter, {} as SessionManager, undefined, undefined, undefined, undefined, undefined, () => store);
+
+    await raw.onTopicMessage!(makeMessage({ uid: 999, firstName: 'Caroline' }));
+
+    expect(store.getOperator(19437)).toBeNull();
+  });
+
+  it('no store available (getter returns null) → no-op, routing continues', async () => {
+    const { adapter, raw, calls } = makeAdapter(() => true);
+    wireTelegramRouting(adapter, {} as SessionManager, undefined, undefined, undefined, undefined, undefined, () => null);
+
+    await raw.onTopicMessage!(makeMessage({ uid: 7812716706 }));
+
+    expect(calls.handleCommand).toBe(1); // reached the slash-command handler
+  });
+
+  it('getter THROWS → caught, routing continues (fail-soft)', async () => {
+    const { adapter, raw, calls } = makeAdapter(() => true);
+    wireTelegramRouting(adapter, {} as SessionManager, undefined, undefined, undefined, undefined, undefined, () => { throw new Error('boom'); });
+
+    await raw.onTopicMessage!(makeMessage({ uid: 7812716706 }));
+
+    expect(calls.handleCommand).toBe(1);
+  });
+
+  it('store.setOperator THROWS → caught, routing continues (fail-soft)', async () => {
+    const { adapter, raw, calls } = makeAdapter(() => true);
+    const broken = { setOperator: () => { throw new Error('disk full'); } } as unknown as TopicOperatorStore;
+    wireTelegramRouting(adapter, {} as SessionManager, undefined, undefined, undefined, undefined, undefined, () => broken);
+
+    await raw.onTopicMessage!(makeMessage({ uid: 7812716706 }));
+
+    expect(calls.handleCommand).toBe(1);
+  });
+
+  it('missing telegramUserId → no bind even with a permissive authorizer', async () => {
+    const store = new TopicOperatorStore(dir);
+    const { adapter, raw } = makeAdapter(() => true);
+    wireTelegramRouting(adapter, {} as SessionManager, undefined, undefined, undefined, undefined, undefined, () => store);
+
+    await raw.onTopicMessage!(makeMessage({ uid: undefined }));
+
+    expect(store.getOperator(19437)).toBeNull();
+  });
+});

--- a/tests/unit/topic-operator-store.test.ts
+++ b/tests/unit/topic-operator-store.test.ts
@@ -90,3 +90,28 @@ describe('TopicOperatorStore.sessionContextBlock', () => {
     expect(s.sessionContextBlock(7)).toContain('uid 999 is the VERIFIED operator');
   });
 });
+
+describe('TopicOperatorStore.setOperator idempotency (increment 2e)', () => {
+  // Both ingress paths re-bind on EVERY message from the operator; an identical
+  // record must be a pure read, not a per-message file rewrite.
+  it('skips the disk write when the stored record is identical', () => {
+    const s = new TopicOperatorStore(dir);
+    s.setOperator(19437, { platform: 'telegram', uid: '7812716706', displayName: 'Justin' });
+    const file = path.join(dir, 'topic-operators.json');
+    // Remove the file: if the identical re-bind skips save(), it stays absent.
+    SafeFsExecutor.safeRmSync(file, { force: true, operation: 'tests/unit/topic-operator-store.test.ts' });
+    const rec = s.setOperator(19437, { platform: 'telegram', uid: '7812716706', displayName: 'Justin' });
+    expect(rec?.uid).toBe('7812716706');
+    expect(fs.existsSync(file)).toBe(false);
+  });
+
+  it('still writes when the record actually changes', () => {
+    const s = new TopicOperatorStore(dir);
+    s.setOperator(19437, { platform: 'telegram', uid: '7812716706', displayName: 'Justin' });
+    const file = path.join(dir, 'topic-operators.json');
+    SafeFsExecutor.safeRmSync(file, { force: true, operation: 'tests/unit/topic-operator-store.test.ts' });
+    s.setOperator(19437, { platform: 'telegram', uid: '42', displayName: 'Other' });
+    expect(fs.existsSync(file)).toBe(true);
+    expect(s.getOperator(19437)?.uid).toBe('42');
+  });
+});

--- a/upgrades/next/topic-operator-polling-bind-inc2e.md
+++ b/upgrades/next/topic-operator-polling-bind-inc2e.md
@@ -1,0 +1,47 @@
+---
+bump: patch
+audience: agent-only
+maturity: experimental
+---
+
+## What Changed
+
+The verified topic operator is now recorded automatically on BOTH inbound
+ingress paths (Know Your Principal standard, security-build increment 2e — the
+final operator-binding gap). Increment 2d covered only the lifeline-forward
+route; the adapter long-poll (no-lifeline) path never bound. The bind now lives
+at the shared `onTopicMessage` seam (`wireTelegramRouting`), guarded by
+`isAuthorizedSender` — load-bearing there, because the seam also fires for
+unauthorized senders. The seam resolves the server's own store instance
+late-bound (a second instance on the same file would lose updates between the
+two in-memory caches), and `TopicOperatorStore.setOperator` now skips the disk
+write when the record is unchanged (per-message re-binds become pure reads).
+
+## What to Tell Your User
+
+Nothing user-facing changes. Foundation wiring (experimental) for the identity
+isolation security work: the agent now learns its verified operator from
+authorized inbound messages no matter how its Telegram connection is set up.
+Only authorized senders are ever recorded, and a recording failure never
+affects message handling.
+
+## Summary of New Capabilities
+
+- Operator auto-bind at the `onTopicMessage` convergence seam (covers the
+  polling path; authorized senders only; fail-soft; pre-boot messages bind
+  nothing, fail-safe).
+- `AgentServer.getTopicOperatorStore()` — public accessor for the seam's
+  late-bound store resolution.
+- `TopicOperatorStore.setOperator` idempotency: identical record → no disk
+  write.
+
+## Evidence
+
+Verified by 6 Tier-1 unit tests (`topic-operator-polling-bind`: authorized
+binds, unauthorized Caroline refusal, null store / getter throw / setOperator
+throw all fail-soft with routing continuing, missing uid no-op), 2 Tier-1 store
+tests (idempotent skip both sides), and 3 Tier-2 integration tests
+(`topic-operator-polling-bind`: full Caroline replay through the seam,
+single-instance no-clobber across two topics on disk, pre-construction →
+post-construction lifecycle). All 60 existing topic-operator/session-context
+canaries and 13 e2e lifecycle tests stay green. Clean `tsc --noEmit`.

--- a/upgrades/side-effects/topic-operator-polling-bind-inc2e.md
+++ b/upgrades/side-effects/topic-operator-polling-bind-inc2e.md
@@ -1,0 +1,62 @@
+# Side-effects review — Topic Operator polling-path auto-bind (Know Your Principal #898, increment 2e)
+
+## What this change does
+Closes the auto-bind gap #909 documented: the adapter long-poll (no-lifeline)
+ingress path never bound the verified operator. The bind now lives at the
+`onTopicMessage` seam in `wireTelegramRouting` (src/commands/server.ts) — the
+convergence point BOTH ingress paths reach — so a no-lifeline install learns its
+operator too. Three coordinated pieces:
+
+- `wireTelegramRouting` gains a late-bound `getTopicOperatorStore` parameter
+  (the `getHubDeps` precedent in the same function) and an additive bind block
+  early in the callback: an AUTHENTICATED + AUTHORIZED sender is recorded as the
+  topic's verified operator.
+- `AgentServer.getTopicOperatorStore()` — public read-only accessor so the seam
+  resolves the server's OWN store instance at message-time.
+- `TopicOperatorStore.setOperator` idempotency guard: an identical record skips
+  the disk write (both paths re-bind per message; unchanged = pure read).
+
+## The load-bearing security property
+The seam fires for unauthorized senders too — the lifeline path only skips its
+own bind, it does not drop the message. So the `isAuthorizedSender` check INSIDE
+the seam bind is load-bearing: without it, an unauthorized group member could
+seat themselves as operator (the cross-principal "Caroline" bug). The
+integration Caroline replay proves the refusal — an unauthorized sender with
+`firstName: "Caroline"` cannot displace the bound operator.
+
+## Why the SAME store instance (the lost-update hazard)
+`TopicOperatorStore` caches its map in memory (`this.cache`). A second instance
+on the same file would hold a divergent cache: a record written through one
+instance disappears from the other's next full-map save. The original Inc-2e
+scout suggested constructing a fresh store inside the callback — that design is
+REJECTED here for exactly this reason. Instead the seam resolves
+`AgentServer.getTopicOperatorStore()` late-bound (module-level `_agentServerRef`
+assigned right after construction; the server is built long after routing is
+wired). The integration no-clobber test pins the invariant.
+
+## Blast radius (hot path — reviewed carefully)
+- **Additive + fail-soft.** The bind block is wrapped in try/catch; a getter
+  error, store error, or missing uid logs and falls through — message routing
+  is never affected. Proven by unit tests (getter throws / setOperator throws /
+  null store → handleCommand still runs).
+- **Pre-construction window.** Messages arriving before `_agentServerRef` is
+  assigned bind nothing (getter → null). Fail-safe: no binding means "unknown",
+  never a wrong operator. Lifecycle test covers the transition.
+- **Lifeline double-bind.** On the lifeline path both the routes-side bind
+  (#909) and the seam bind run — same instance, same record; the new
+  idempotency guard makes the second a no-op read.
+- **Disk-write reduction (behavior change, benign).** `setOperator` with a
+  byte-identical record no longer rewrites the file. Callers only ever read the
+  returned record or the store state — both unchanged. Existing store tests
+  (12) stay green; 2 new tests pin both sides (identical skips, changed
+  writes).
+- **No new route / config key / dependency.** `wireTelegramRouting` is now
+  exported (test seam only; no runtime caller change beyond the two existing
+  callsites gaining the getter argument).
+
+## No-allowlist trust model (unchanged, documented)
+`isAuthorizedSender` semantics are #909's: with no `authorizedUserIds`
+allowlist, every authenticated sender is accepted, so the operator is the
+most-recent authenticated sender. Consistent with the existing trust model;
+the uid is Telegram-authenticated, never a content name
+(`TopicOperatorStore.setOperator` enforces that by construction, #904).

--- a/upgrades/topic-operator-polling-bind-inc2e.eli16.md
+++ b/upgrades/topic-operator-polling-bind-inc2e.eli16.md
@@ -1,0 +1,56 @@
+# ELI16 — Remembering the boss on the simpler phone line too
+
+## The one-sentence version
+The agent now writes down "this is the verified boss of this chat" no matter
+which of its two message pipes the boss's message arrived through — before, one
+pipe did this and the other forgot.
+
+## The backstory
+We've been closing a real security hole: an agent on a shared computer slowly
+started treating a *different real person* (call her Caroline) as its boss. The
+fix was a filing cabinet that records, per chat, who the verified boss is —
+decided ONLY by the verified ID of whoever actually sent the message, never by a
+name typed in a document. The last step (increment 2d) made the cabinet fill in
+automatically — but only on the agent's MAIN message pipe (the relay most of the
+fleet uses). A simpler setup, where the agent talks to Telegram directly without
+the relay, still never filled in the cabinet. That was safe (an empty cabinet
+just means "I don't know," never a wrong answer), but it meant some agents never
+learned who their boss was.
+
+## What this change adds
+Both pipes eventually flow through one shared doorway in the code (the
+`onTopicMessage` seam). This change puts the "write down the boss" step at that
+doorway, so it runs no matter which pipe delivered the message. Two careful
+details:
+
+1. **The doorway still checks the allowed list.** The main pipe lets messages
+   from non-allowed people *through the doorway* (it just refuses to bind them
+   earlier) — so the doorway check is load-bearing. Without it, an outsider in
+   the group could seat themselves as boss — the exact Caroline bug. We test
+   this with a literal unauthorized "Caroline" message and prove nobody gets
+   written down.
+2. **One cabinet, not two.** The cabinet keeps a copy of its contents in memory.
+   If the doorway opened its OWN second cabinet on the same file, the two copies
+   could silently overwrite each other's entries. So the doorway asks the server
+   for its existing cabinet (resolved late, because the server is built after
+   the doorway is wired) — same instance, no lost entries. A test proves an
+   entry written one way survives an entry written the other way.
+
+## A small bonus fix
+Since both pipes now re-write the boss on every message, the cabinet learned to
+notice "this is exactly what I already have" and skip the disk write — a
+re-delivered or repeated message is now a pure read instead of a pointless file
+rewrite.
+
+## Why it's safe
+- Wrapped so any failure is logged and swallowed — recording the boss can never
+  break message handling.
+- Before the server finishes booting, the doorway just skips the step (no
+  cabinet yet = nothing written = fail-safe).
+- On the main pipe both the old write (increment 2d) and the new doorway write
+  run — same cabinet, same record, harmless.
+
+## What's deliberately left for next time
+Nothing in this family — the operator-binding loop is now closed on every
+ingress path. The remaining Know Your Principal work is elsewhere (per-agent
+credential isolation, Phase 3).


### PR DESCRIPTION
## What

Closes the final operator-binding gap (#909 documented it): the adapter long-poll (no-lifeline) ingress path never auto-bound the verified topic operator. The bind now lives at the shared `onTopicMessage` seam in `wireTelegramRouting` — the convergence point BOTH ingress paths reach — so every install learns its operator regardless of Telegram wiring.

- **Seam bind, authorized-only**: guarded by `isAuthorizedSender` — load-bearing there, because the lifeline path fires the seam for unauthorized senders too (it only skips its own bind). Without the check, an unauthorized group member could seat themselves as operator (the cross-principal "Caroline" bug).
- **Same store instance, late-bound**: `AgentServer.getTopicOperatorStore()` + a late-bound getter through `wireTelegramRouting` (the `getHubDeps` precedent). The scouted construct-a-fresh-store design is rejected: `TopicOperatorStore` caches its map in memory, so a second instance on the same file loses updates between the two caches.
- **Idempotency**: `setOperator` with a byte-identical record now skips the disk write — per-message re-binds on both paths become pure reads.
- **Fail-soft everywhere**: getter error / store error / missing uid / pre-construction (null getter) → no-op, routing continues. Pre-boot messages bind nothing (fail-safe).

## ELI16

The agent has a filing cabinet that remembers, per chat, who its verified boss is — decided only by the verified ID of whoever actually sent a message, never a name typed in a document. The last step filled the cabinet in automatically, but only on the agent's main message pipe; the simpler direct-to-Telegram pipe still forgot. Both pipes flow through one shared doorway in the code, so this change puts the "write down the boss" step at that doorway — with two careful details: the doorway still checks the allowed list (the main pipe lets non-allowed people's messages through the doorway, so the check there is what stops an outsider literally named "Caroline" from seating herself — we test exactly that), and the doorway asks the server for its existing cabinet instead of opening a second one (two cabinets on the same file would silently overwrite each other's entries — we test that too). Bonus: the cabinet now notices "this is exactly what I already have" and skips pointless disk rewrites. Any failure is logged and swallowed — recording the boss can never break the chat.

## Tests

- **Unit 6** (`tests/unit/topic-operator-polling-bind.test.ts`): authorized binds / unauthorized-Caroline refused / null store / getter throws / setOperator throws (all fail-soft, routing continues) / missing uid no-op.
- **Store idempotency 2** (`tests/unit/topic-operator-store.test.ts`): identical record skips the write; changed record still writes.
- **Integration 3** (`tests/integration/topic-operator-polling-bind.test.ts`): Caroline replay through the seam; single-instance no-clobber proven on disk; pre-construction → post-construction lifecycle.
- Canaries: 60 topic-operator/session-context + 13 e2e lifecycle + no-silent-fallbacks all green; `tsc --noEmit` clean; pre-push full suite green.

## Ceremony

Tier-1 trace + decision entry rode the commit; eli16 + side-effects + release fragment (patch / agent-only / experimental) staged with the change.