### PR TITLE
fix(sessions): sentinel recovery verification survives conversation-UUID rotation

### DIFF
--- a/.instar/instar-dev-decisions/2026-06-06T17-49-46-974Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-06-06T17-49-46-974Z-unknown.json
@@ -1,0 +1,13 @@
+{
+  "ts": "2026-06-06T17:49:46.974Z",
+  "slug": "unknown",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 2,
+  "loc": 44,
+  "causalAutopsy": null,
+  "verdict": "pass"
+}

--- a/.instar/instar-dev-decisions/2026-06-06T17-50-54-536Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-06-06T17-50-54-536Z-unknown.json
@@ -1,0 +1,13 @@
+{
+  "ts": "2026-06-06T17:50:54.536Z",
+  "slug": "unknown",
+  "suggestedTier": 1,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 2,
+  "loc": 28,
+  "causalAutopsy": null,
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-06-06T17-51-18-501Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-06-06T17-51-18-501Z-unknown.json
@@ -1,0 +1,13 @@
+{
+  "ts": "2026-06-06T17:51:18.501Z",
+  "slug": "unknown",
+  "suggestedTier": 1,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 2,
+  "loc": 28,
+  "causalAutopsy": null,
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-06-06T17-51-48-112Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-06-06T17-51-48-112Z-unknown.json
@@ -1,0 +1,13 @@
+{
+  "ts": "2026-06-06T17:51:48.112Z",
+  "slug": "unknown",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 4,
+  "loc": 72,
+  "causalAutopsy": null,
+  "verdict": "pass"
+}

--- a/src/core/SessionManager.ts
+++ b/src/core/SessionManager.ts
@@ -796,16 +796,36 @@ rm()  { "${shimRunner}" rm  "$@"; }
 
   /**
    * Associate a Claude Code session UUID with an instar session.
-   * Called when the first hook event arrives from a Claude Code session,
-   * allowing SubagentTracker lookups to bridge the two ID spaces.
+   * Called on hook events from a Claude Code session, allowing
+   * SubagentTracker lookups to bridge the two ID spaces.
+   *
+   * Last-writer-wins, NOT write-once: a fresh respawn or `claude --resume`
+   * rotates the conversation UUID, and every subsequent hook event carries
+   * the NEW id. The old write-once guard froze the first-ever UUID, so after
+   * any respawn the record pointed at a transcript that no longer grew (or
+   * never existed) — which made both sentinels' jsonl-growth recovery
+   * verification permanently fail and falsely escalate healthy sessions
+   * ("no jsonl growth after 6 attempts" on a session that was actively
+   * answering). 2026-06-06 echo-api-errors incident.
+   *
+   * Safe because every hook event's session_id is the MAIN conversation's
+   * UUID (subagents are identified by separate agent_id/agent_transcript_path
+   * fields, never by swapping session_id), and a dead conversation emits no
+   * further events to flip the value back.
    */
   setClaudeSessionId(instarSessionId: string, claudeSessionId: string): void {
+    if (!claudeSessionId) return;
     const sessions = this.state.listSessions({ status: 'running' });
     const session = sessions.find(s => s.id === instarSessionId);
-    if (session && !session.claudeSessionId) {
-      session.claudeSessionId = claudeSessionId;
-      this.state.saveSession(session);
+    if (!session || session.claudeSessionId === claudeSessionId) return;
+    if (session.claudeSessionId) {
+      console.log(
+        `[SessionManager] claudeSessionId rotated for "${session.tmuxSession}": ` +
+        `${session.claudeSessionId} → ${claudeSessionId} (respawn/resume)`,
+      );
     }
+    session.claudeSessionId = claudeSessionId;
+    this.state.saveSession(session);
   }
 
   /**

--- a/src/monitoring/CompactionSentinel.ts
+++ b/src/monitoring/CompactionSentinel.ts
@@ -471,10 +471,18 @@ export class CompactionSentinel extends EventEmitter {
           const st = fs.statSync(exact);
           return { path: exact, size: st.size, mtime: st.mtimeMs };
         }
-        // If uuid is known but file doesn't exist, return null rather than
-        // falling through — the session genuinely has no jsonl, and picking
-        // a sibling's file would be a false signal.
-        return null;
+        // Stale claudeSessionId: the stored UUID has no transcript on disk
+        // (conversation rotated via respawn/--resume and the record lagged).
+        // The old "return null — the session genuinely has no jsonl" reasoning
+        // assumed the mapping was always fresh; a write-once bridge made it
+        // permanently stale instead, so null here meant recovery verification
+        // could NEVER succeed (2026-06-06 false-escalation incident, mirrored
+        // in RateLimitSentinel). Degrade to the same newest-jsonl heuristic
+        // the no-uuid case already uses.
+        console.log(
+          `[CompactionSentinel] stale claudeSessionId for "${sessionName}" ` +
+          `(${uuid}.jsonl missing) — falling back to newest jsonl in project root`,
+        );
       }
 
       // Fallback: most-recently-modified jsonl in the project.

--- a/src/monitoring/RateLimitSentinel.ts
+++ b/src/monitoring/RateLimitSentinel.ts
@@ -508,7 +508,17 @@ export class RateLimitSentinel extends EventEmitter {
           const st = fs.statSync(exact);
           return { path: exact, size: st.size, mtime: st.mtimeMs };
         }
-        return null;
+        // Stale claudeSessionId: the stored UUID has no transcript on disk
+        // (conversation rotated via respawn/--resume and the record lagged).
+        // Returning null here made verification PERMANENTLY unable to succeed
+        // → 6 futile nudges → false "no jsonl growth" escalation on a healthy,
+        // actively-answering session (2026-06-06 echo-api-errors incident).
+        // Degrade to the same newest-jsonl heuristic the no-uuid case already
+        // uses — identical risk profile, strictly better than guaranteed-wrong.
+        console.log(
+          `[RateLimitSentinel] stale claudeSessionId for "${sessionName}" ` +
+          `(${uuid}.jsonl missing) — falling back to newest jsonl in project root`,
+        );
       }
 
       const entries = fs.readdirSync(root).filter(f => f.endsWith('.jsonl'));

--- a/src/server/routes.ts
+++ b/src/server/routes.ts
@@ -2489,12 +2489,20 @@ export function createRoutes(ctx: RouteContext): Router {
 
     // Bridge instar session ID ↔ Claude Code session ID.
     // Hook URLs include ?instar_sid=<INSTAR_SESSION_ID> set via tmux env var.
-    // On the first hook event from a session, this populates claudeSessionId on
-    // the instar Session record, enabling SubagentTracker lookups.
+    // Populates claudeSessionId on the instar Session record (enabling
+    // SubagentTracker lookups + sentinel jsonl-growth verification) and KEEPS
+    // it current: a respawn/--resume rotates the conversation UUID, and the
+    // first event carrying the new id updates the record (last-writer-wins —
+    // see SessionManager.setClaudeSessionId). The old `!session.claudeSessionId`
+    // guard here made the bridge write-once, leaving records pointing at dead
+    // transcripts after every respawn (2026-06-06 false-escalation incident).
     const instarSid = typeof req.query.instar_sid === 'string' ? req.query.instar_sid : '';
+    // Every Claude Code hook event carries the MAIN conversation's session_id
+    // (subagents are identified by separate agent_id/agent_transcript_path
+    // fields). Missing/empty session_id = malformed or custom event — skip.
     if (instarSid && payload.session_id && ctx.sessionManager) {
       const session = ctx.sessionManager.getSessionById(instarSid);
-      if (session && !session.claudeSessionId) {
+      if (session && session.claudeSessionId !== payload.session_id) {
         ctx.sessionManager.setClaudeSessionId(instarSid, payload.session_id);
       }
     }

--- a/tests/unit/CompactionSentinel.test.ts
+++ b/tests/unit/CompactionSentinel.test.ts
@@ -238,6 +238,39 @@ describe('CompactionSentinel', () => {
     expect(events.find(e => e.type === 'compaction:recovered')).toBeDefined();
   });
 
+  // REGRESSION (2026-06-06 incident, mirrored from RateLimitSentinel): when the
+  // stored claudeSessionId has NO transcript on disk (UUID rotated on respawn/
+  // --resume; the bridge record went stale), returning null made recovery
+  // verification permanently unable to succeed. A stale uuid must degrade to
+  // the newest-jsonl heuristic instead of guaranteeing a false failure.
+  it('falls back to newest jsonl when the stored claudeSessionId transcript is missing (phantom uuid)', async () => {
+    jsonl.write('live-conversation.jsonl', 100); // the REAL transcript (different uuid)
+
+    sentinel.stop();
+    sentinel = new CompactionSentinel(
+      {
+        recoverFn: recoverFn as any,
+        projectDir: '/fake/project',
+        jsonlRoot: jsonl.root,
+        getClaudeSessionId: () => '563a7027-432d-4b46-9706-caf43daa1016', // no such file
+      },
+      { dedupeWindowMs: 60_000, verifyWindowMs: 25_000, maxInjectAttempts: 3, recoveryGuardMs: 10 * 60_000 },
+    );
+    events = [];
+    for (const e of ['compaction:detected', 'compaction:inject-attempted', 'compaction:recovered', 'compaction:failed']) {
+      sentinel.on(e as any, (p: any) => events.push({ type: e, payload: p }));
+    }
+
+    sentinel.report('echo-api-errors', 'watchdog-poll');
+    await vi.advanceTimersByTimeAsync(0);
+
+    // The live transcript grows — the session genuinely recovered.
+    jsonl.write('live-conversation.jsonl', 900);
+    await vi.advanceTimersByTimeAsync(25_500);
+    expect(events.find(e => e.type === 'compaction:recovered')).toBeDefined();
+    expect(events.find(e => e.type === 'compaction:failed')).toBeUndefined();
+  });
+
   it('detects growth via mtime change on a fixed-size jsonl', async () => {
     jsonl.write('foo.jsonl', 100);
     sentinel.report('s1', 'watchdog-poll');

--- a/tests/unit/RateLimitSentinel.test.ts
+++ b/tests/unit/RateLimitSentinel.test.ts
@@ -92,6 +92,39 @@ describe('RateLimitSentinel', () => {
     expect(sentinel.isRecoveryActive('s1')).toBe(false);
   });
 
+  // REGRESSION (2026-06-06 echo-api-errors incident): the session record's
+  // claudeSessionId pointed at a transcript that did not exist (conversation
+  // UUID rotated on a fresh respawn; the bridge was write-once). The exact-path
+  // lookup returned null on every verify, so recovery could NEVER be observed —
+  // the sentinel ran the full ladder against an actively-answering session and
+  // falsely escalated "no jsonl growth after 6 attempts". A stale uuid must
+  // degrade to the newest-jsonl heuristic (same as the no-uuid case).
+  it('falls back to newest jsonl when the stored claudeSessionId transcript is missing (phantom uuid)', async () => {
+    build({}, { getClaudeSessionId: () => '563a7027-432d-4b46-9706-caf43daa1016' });
+    jsonl.write('live-conversation.jsonl', 100); // the REAL transcript (different uuid)
+    sentinel.report('echo-api-errors', 'watchdog-poll');
+    await vi.advanceTimersByTimeAsync(FIRST_BACKOFF + 100); // nudge fires
+    jsonl.write('live-conversation.jsonl', 900);            // session is alive and answering
+    await vi.advanceTimersByTimeAsync(VERIFY + 500);
+    expect(events.some(e => e.type === 'rate-limit:recovered')).toBe(true);
+    expect(events.some(e => e.type === 'rate-limit:escalated')).toBe(false);
+    expect(sentinel.isRecoveryActive('echo-api-errors')).toBe(false);
+  });
+
+  it('still prefers the exact uuid transcript when it exists — sibling growth alone does not count', async () => {
+    // Both sides of the boundary: with a VALID uuid mapping, growth in a
+    // sibling session's jsonl must NOT be read as this session's recovery.
+    build({ maxAttempts: 2, backoffScheduleMs: [1000, 1000, 1000] },
+          { getClaudeSessionId: () => 'my-uuid' });
+    jsonl.write('my-uuid.jsonl', 100);     // this session's transcript (flat)
+    jsonl.write('sibling.jsonl', 100);
+    sentinel.report('s1', 'watchdog-poll');
+    await vi.advanceTimersByTimeAsync(1000 + 100); // nudge 1
+    jsonl.write('sibling.jsonl', 5000);            // ANOTHER session produces output
+    await vi.advanceTimersByTimeAsync(VERIFY + 500);
+    expect(events.some(e => e.type === 'rate-limit:recovered')).toBe(false);
+  });
+
   // ─── Escalation ───
 
   it('escalates after maxAttempts with no jsonl growth', async () => {

--- a/tests/unit/claude-session-id-bridge.test.ts
+++ b/tests/unit/claude-session-id-bridge.test.ts
@@ -10,6 +10,15 @@
  * - Session resume: beforeSessionKill uses claudeSessionId to save the correct UUID
  * - Cross-contamination prevention: without claudeSessionId, the mtime heuristic
  *   guesses wrong when multiple sessions are active
+ * - Sentinel recovery verification: RateLimit/Compaction sentinels resolve the
+ *   session's transcript via claudeSessionId to check jsonl growth
+ *
+ * The bridge is LAST-WRITER-WINS, not write-once: a fresh respawn or
+ * `claude --resume` rotates the conversation UUID, and the first hook event
+ * carrying the new id must update the record. The old write-once guard froze
+ * the first-ever UUID, leaving records pointing at dead transcripts after any
+ * respawn — which made sentinel jsonl-growth verification permanently fail and
+ * falsely escalate healthy sessions (2026-06-06 echo-api-errors incident).
  *
  * Previously, HTTP hooks (type: "http") were supposed to do this, but they silently
  * failed to fire in Claude Code <=2.1.78. Now command hooks (hook-event-reporter.js)
@@ -35,6 +44,7 @@ interface MockSession {
 
 class MockSessionManager {
   private sessions: Map<string, MockSession> = new Map();
+  saveCount = 0;
 
   addSession(id: string, name: string): void {
     this.sessions.set(id, { id, name });
@@ -45,10 +55,12 @@ class MockSessionManager {
   }
 
   setClaudeSessionId(instarSid: string, claudeSessionId: string): void {
+    // Mirrors SessionManager.setClaudeSessionId (last-writer-wins).
+    if (!claudeSessionId) return;
     const session = this.sessions.get(instarSid);
-    if (session) {
-      session.claudeSessionId = claudeSessionId;
-    }
+    if (!session || session.claudeSessionId === claudeSessionId) return;
+    session.claudeSessionId = claudeSessionId;
+    this.saveCount += 1;
   }
 }
 
@@ -75,11 +87,11 @@ function buildTestApp(opts: {
     opts.hookEventReceiver.receive(payload);
 
     // Bridge instar session ID ↔ Claude Code session ID
-    // (mirrors the logic in routes.ts)
+    // (mirrors the logic in routes.ts — last-writer-wins on rotation)
     const instarSid = typeof req.query.instar_sid === 'string' ? req.query.instar_sid : '';
     if (instarSid && payload.session_id) {
       const session = opts.sessionManager.getSessionById(instarSid);
-      if (session && !session.claudeSessionId) {
+      if (session && session.claudeSessionId !== payload.session_id) {
         opts.sessionManager.setClaudeSessionId(instarSid, payload.session_id);
       }
     }
@@ -122,7 +134,10 @@ describe('claudeSessionId bridge via /hooks/events', () => {
     expect(session?.claudeSessionId).toBe('claude-uuid-123');
   });
 
-  it('does not overwrite claudeSessionId on subsequent events', async () => {
+  it('updates claudeSessionId when the conversation UUID rotates (respawn/--resume)', async () => {
+    // REGRESSION (2026-06-06 echo-api-errors): the bridge was write-once, so a
+    // fresh respawn left the record pointing at a dead transcript and sentinel
+    // jsonl-growth verification could never succeed → false escalations.
     sessionManager.addSession('instar-abc', 'test-session');
 
     // First event sets it
@@ -130,13 +145,30 @@ describe('claudeSessionId bridge via /hooks/events', () => {
       .post('/hooks/events?instar_sid=instar-abc')
       .send({ event: 'PostToolUse', session_id: 'first-uuid', tool_name: 'Bash' });
 
-    // Second event should NOT overwrite
+    // Session respawns → new conversation UUID → next event must update
     await request(app)
       .post('/hooks/events?instar_sid=instar-abc')
       .send({ event: 'PostToolUse', session_id: 'second-uuid', tool_name: 'Read' });
 
     const session = sessionManager.getSessionById('instar-abc');
-    expect(session?.claudeSessionId).toBe('first-uuid');
+    expect(session?.claudeSessionId).toBe('second-uuid');
+  });
+
+  it('does not re-save when session_id is unchanged (idempotent per event)', async () => {
+    sessionManager.addSession('instar-abc', 'test-session');
+
+    await request(app)
+      .post('/hooks/events?instar_sid=instar-abc')
+      .send({ event: 'PostToolUse', session_id: 'same-uuid', tool_name: 'Bash' });
+    await request(app)
+      .post('/hooks/events?instar_sid=instar-abc')
+      .send({ event: 'PostToolUse', session_id: 'same-uuid', tool_name: 'Read' });
+    await request(app)
+      .post('/hooks/events?instar_sid=instar-abc')
+      .send({ event: 'Stop', session_id: 'same-uuid' });
+
+    expect(sessionManager.getSessionById('instar-abc')?.claudeSessionId).toBe('same-uuid');
+    expect(sessionManager.saveCount).toBe(1); // only the first event persisted anything
   });
 
   it('does not set claudeSessionId when instar_sid is missing', async () => {

--- a/tests/unit/session-manager-behavioral.test.ts
+++ b/tests/unit/session-manager-behavioral.test.ts
@@ -446,4 +446,35 @@ describe('SessionManager behavioral tests', () => {
       // No error, no hanging interval
     });
   });
+
+  describe('setClaudeSessionId (conversation-UUID bridge)', () => {
+    // REGRESSION (2026-06-06 echo-api-errors incident): the bridge was
+    // write-once, so a respawn/--resume rotating the conversation UUID left
+    // the record pointing at a dead transcript forever — sentinel jsonl-growth
+    // recovery verification could never succeed and falsely escalated healthy
+    // sessions. The bridge must be last-writer-wins.
+    it('first-set populates, rotation updates, identical/empty ids no-op', async () => {
+      const session = await manager.spawnSession({ name: 'bridge-test', prompt: 'p' });
+
+      // First-set (unchanged behavior)
+      manager.setClaudeSessionId(session.id, 'first-uuid');
+      expect(state.getSession(session.id)?.claudeSessionId).toBe('first-uuid');
+
+      // Rotation (the fix): respawn/--resume rotates the conversation UUID
+      manager.setClaudeSessionId(session.id, 'second-uuid');
+      expect(state.getSession(session.id)?.claudeSessionId).toBe('second-uuid');
+
+      // Identical id: no-op (idempotent)
+      manager.setClaudeSessionId(session.id, 'second-uuid');
+      expect(state.getSession(session.id)?.claudeSessionId).toBe('second-uuid');
+
+      // Empty id: ignored, never clears the stored value
+      manager.setClaudeSessionId(session.id, '');
+      expect(state.getSession(session.id)?.claudeSessionId).toBe('second-uuid');
+    });
+
+    it('unknown instar session id is a safe no-op', () => {
+      expect(() => manager.setClaudeSessionId('no-such-id', 'some-uuid')).not.toThrow();
+    });
+  });
 });

--- a/upgrades/next/sentinel-stale-uuid-fallback.md
+++ b/upgrades/next/sentinel-stale-uuid-fallback.md
@@ -1,0 +1,69 @@
+# Sentinel recovery verification survives conversation-UUID rotation
+
+## What Changed
+
+The claudeSessionId bridge (instar session record ↔ Claude Code conversation
+UUID) was write-once: the first hook event froze the UUID forever. A fresh
+respawn or `claude --resume` rotates the conversation UUID, so after any
+respawn the record pointed at a transcript that never grew — or never existed
+(6 of 7 inspected records on the dev box were phantom). Both sentinels that
+verify recovery by transcript growth (RateLimitSentinel, CompactionSentinel)
+resolved that exact file, got null, and could NEVER observe a recovery: the
+result was 6 futile resume nudges against actively-answering sessions and a
+false "no jsonl growth after 6 attempts" escalation (2026-06-06 echo-api-errors
+and echo-exo-3-0 incidents).
+
+Fixes, root cause first:
+
+1. The bridge is now last-writer-wins — every hook event carries the live
+   conversation UUID, and the record updates on rotation (logged old → new).
+   This also freshens every other claudeSessionId consumer (topic resume saves,
+   reap guards) that always wanted the live conversation's id.
+2. Both sentinels degrade a stale uuid (recorded transcript missing) to the
+   newest-jsonl heuristic the no-uuid case already uses, instead of returning
+   null — guaranteed-unverifiable is strictly worse than the shared accepted
+   heuristic. Exact-uuid behavior when the file exists is byte-for-byte
+   unchanged (sibling growth still doesn't count).
+
+Regression tests replay the live incident on both sentinels plus the bridge
+rotation; the sibling-precision guard is tested on the valid-uuid arm.
+
+## What to Tell Your User
+
+Nothing — housekeeping. The visible effect is the ABSENCE of noise: no more
+repeated "throttle should have cleared — please continue" nudges landing in a
+session that's already working, and no more false "still can't get through
+after 6 tries" alerts on sessions that recovered fine.
+
+## Summary of New Capabilities
+
+- claudeSessionId bridge follows conversation rotation (last-writer-wins, logged).
+- RateLimitSentinel + CompactionSentinel: stale-uuid → newest-jsonl fallback in
+  recovery verification; false-escalation class on healthy sessions closed.
+
+## Evidence
+
+Reproduced live in production on 2026-06-06 (the bug was diagnosed FROM the
+affected session):
+
+- **Before:** `logs/sentinel-events.jsonl` 16:47:12Z→17:11Z — `throttle-detected`
+  on echo-api-errors, then the full resume-nudge ladder (attempts 1–6, each
+  "resume nudge injected via internal recovery channel") against a session that
+  was actively answering its operator the entire time; the episode ends
+  `throttle-escalated: "no jsonl growth after 6 attempts"`. The session record
+  held `claudeSessionId = 563a7027-…` with NO such transcript on disk while the
+  live transcript `a538d58f-….jsonl` grew throughout. Same morning, 09:26Z:
+  echo-exo-3-0 falsely escalated `"no jsonl growth after 6 attempts over 22m"`.
+  6 of 7 inspected exo-family session records pointed at phantom transcripts.
+- **After (mechanism):** with the fallback, `readJsonlBaseline` resolves the
+  growing live transcript (logged "stale claudeSessionId … falling back to
+  newest jsonl"), so the first nudge's verify window observes growth and the
+  episode finalizes `recovered` — regression tests replay exactly this shape on
+  both sentinels (phantom uuid + growing sibling file ⇒ recovered, never
+  escalated; verified to FAIL on pre-fix code). The bridge fix is additionally
+  proven on the real SessionManager: rotation `first-uuid → second-uuid`
+  persists (previously refused by the write-once guard).
+- Post-deploy wild proof: the next real throttle on a respawned session should
+  log `throttle-recovered` instead of a false escalation; the rotation log line
+  (`claudeSessionId rotated for "<session>": old → new`) will appear on the
+  first hook event after any respawn.

--- a/upgrades/sentinel-stale-uuid-fallback.eli16.md
+++ b/upgrades/sentinel-stale-uuid-fallback.eli16.md
@@ -1,0 +1,15 @@
+# Sentinels stop failing healthy sessions over a stale transcript pointer
+
+When a session gets throttled by the API, a watchdog (the RateLimitSentinel) nudges it back awake and then checks "did it actually recover?" by watching the session's transcript file grow — output means alive. Same trick for compaction recovery (CompactionSentinel).
+
+The bug: the server remembers WHICH transcript file belongs to a session by its conversation ID — but that memory was write-once. The first time a session ever reported its ID, it was frozen forever. When a session later respawned or resumed (which gives the conversation a NEW ID and a NEW transcript file), the record kept pointing at the OLD file — one that never grows again, or never even existed. On this box, 6 of 7 checked session records pointed at transcripts that didn't exist.
+
+The consequence: for any such session, "did it recover?" could literally never come back yes. The watchdog would nudge 6 times over ~20 minutes — against a session that was actively answering the user the whole time — then falsely declare it stuck ("no jsonl growth after 6 attempts"). This happened live on 2026-06-06: one session got 6 pointless wake-up nudges mid-conversation, and another was falsely escalated at 2am.
+
+Two fixes, root cause first:
+
+1. **The pointer now follows the conversation.** Every hook event a session sends carries its current conversation ID; the record now updates whenever that ID changes (a respawn/resume rotates it), instead of refusing to ever change. A rotation is logged so drift is diagnosable.
+
+2. **A stale pointer degrades instead of failing.** If the recorded ID's transcript file is missing, both sentinels now fall back to watching the newest transcript in the project — the exact same heuristic they already use when no ID is known at all — instead of returning "no file, recovery unverifiable, forever." When the exact file exists, behavior is byte-for-byte unchanged (a sibling session's output still doesn't count as your recovery).
+
+Regression tests replay the live incident: phantom ID + a growing real transcript must produce "recovered", never a false escalation.

--- a/upgrades/side-effects/sentinel-stale-uuid-fallback.md
+++ b/upgrades/side-effects/sentinel-stale-uuid-fallback.md
@@ -1,0 +1,75 @@
+# Side-Effects Review — Sentinel stale-uuid fallback + last-writer-wins bridge
+
+**Version / slug:** `sentinel-stale-uuid-fallback`
+**Date:** `2026-06-06`
+**Author:** `echo`
+**Second-pass reviewer:** `pending (Phase 3 review agents)`
+
+## Summary of the change
+
+Two-layer fix for the 2026-06-06 false-escalation incident (echo-api-errors: 6
+futile resume nudges against an actively-answering session; echo-exo-3-0: false
+"no jsonl growth after 6 attempts over 22m" escalation at 02:26 PDT):
+
+1. `SessionManager.setClaudeSessionId` + the `/hooks/events` route guard change
+   from write-once to last-writer-wins, so the claudeSessionId record follows
+   conversation-UUID rotation (fresh respawn / `claude --resume`).
+2. `RateLimitSentinel.readJsonlBaseline` + `CompactionSentinel.readJsonlBaseline`
+   degrade a stale uuid (recorded transcript missing on disk) to the existing
+   newest-jsonl heuristic instead of returning null (which made recovery
+   verification permanently unable to succeed).
+
+## Decision-point inventory
+
+- Bridge update condition: `session.claudeSessionId !== payload.session_id`
+  (route) / identical-id no-op (manager). Both sides tested.
+- Sentinel baseline resolution: exact-uuid file exists → exact (unchanged);
+  uuid recorded but file missing → newest-jsonl fallback (NEW); no uuid →
+  newest-jsonl (unchanged). All three arms tested.
+
+## 1. Over-block
+
+Nothing new is rejected. The bridge accepts strictly MORE updates than before
+(rotations were previously dropped). The sentinels accept strictly MORE
+verification evidence than before.
+
+## 2. Under-block / residual risk
+
+- **Sibling false-positive on the fallback arm:** in a multi-session project
+  root, the newest jsonl can belong to ANOTHER session, so a genuinely-stuck
+  session with a stale pointer could be falsely marked "recovered" when a
+  sibling produces output. This is the SAME accepted risk profile as the
+  pre-existing no-uuid arm, it only applies while the pointer is stale (layer 1
+  re-freshens it on the next hook event, typically within seconds on an active
+  session), and the failure mode it replaces — guaranteed false escalation +
+  6 wasted nudge-refires on healthy sessions — is strictly worse. A falsely
+  "recovered" stuck session is still backstopped by ActiveWorkSilenceSentinel.
+- **Stale event flip-back:** a late-arriving hook event from a dying old
+  conversation could briefly flip the pointer backwards; the next event from
+  the live conversation flips it forward again, and all consumers re-resolve
+  per call (no cached snapshot), so the effect is transient.
+- Sessions that emit no hook events (none expected — the reporter fires on
+  every tool use/stop) keep whatever pointer they have; the sentinel fallback
+  covers them.
+
+## 3. Level-of-abstraction fit
+
+The rotation fix lives at the single bridge chokepoint both consumers share
+(`setClaudeSessionId` + its one route caller). The degrade-not-fail fix lives
+inside each sentinel's existing `readJsonlBaseline`, the single resolution
+point per sentinel; codex/gemini framework arms are untouched (they never used
+the uuid path). No migration needed: the fix is pure server code; existing
+stale records self-heal on the first post-deploy hook event per session.
+
+## Rollback
+
+Single revert of the PR restores write-once + null-on-missing exactly (no
+state-shape changes, no config, no new files).
+
+## Blast radius
+
+Server-side only. No agent-installed files, no hook templates, no config
+defaults, no CLAUDE.md template changes → no Migration Parity obligations.
+Consumers of `claudeSessionId` (session resume save, reaper guards,
+TopicResumeMap, sentinels) now see a FRESHER value — the value they were
+always designed to expect.


### PR DESCRIPTION
## ELI16

When a session gets throttled, a watchdog nudges it awake and checks "did it recover?" by watching the session's transcript file grow — output means alive. The server remembers which transcript belongs to a session by its conversation ID. Problem: that memory was write-once — frozen the first time it was ever set. But every respawn or resume gives the conversation a NEW ID and a NEW file, so the record kept pointing at a file that never grows again (or never existed — 6 of 7 checked records on the dev box were phantoms). Result: "did it recover?" could literally never come back yes. The watchdog nudged a perfectly healthy, actively-answering session 6 times over 20 minutes, then falsely declared it stuck. This happened live on 2026-06-06, in the very session that diagnosed it. Fix: the pointer now follows the conversation (it updates whenever the ID rotates), and if the recorded file is missing anyway, the watchdogs fall back to watching the newest transcript instead of failing forever.

## What

Two-layer fix, root cause first:

1. **Last-writer-wins claudeSessionId bridge** (`SessionManager.setClaudeSessionId` + the `/hooks/events` route guard): every hook event carries the live conversation UUID; the record now updates on rotation (logged `old → new`) instead of refusing to ever change. Safe because hook events always carry the MAIN conversation's session_id (subagents are identified by separate `agent_id`/`agent_transcript_path` fields), and a dead conversation emits no further events to flip the value back. This also freshens every other claudeSessionId consumer (topic resume saves, reap guards, TopicResumeMap) — all of which always wanted the live conversation's id.
2. **Stale-uuid degrade-not-fail in both sentinels** (`RateLimitSentinel.readJsonlBaseline`, `CompactionSentinel.readJsonlBaseline`): when the recorded UUID's transcript is missing on disk, fall through to the newest-jsonl heuristic the no-uuid arm already uses (same accepted risk profile), with a log line naming the stale uuid — instead of returning null, which made recovery verification permanently unable to succeed. Exact-uuid behavior when the file exists is byte-for-byte unchanged (sibling growth still doesn't count). codex/gemini framework arms untouched.

## The live incident (evidence)

- `logs/sentinel-events.jsonl` 2026-06-06T16:47:12Z→17:11Z: `throttle-detected` on echo-api-errors → full nudge ladder (attempts 1–6) against a session that was actively answering its operator the entire time.
- The session record held `claudeSessionId = 563a7027-…` — no such transcript on disk; the live transcript (`a538d58f-…`) was growing the whole time.
- Same morning, 09:26Z: echo-exo-3-0 falsely escalated `"no jsonl growth after 6 attempts over 22m"`.
- 6 of 7 inspected exo-family session records pointed at phantom transcripts.

## Migration parity

None needed — pure server-side code; no agent-installed files, hooks, config defaults, or CLAUDE.md template changes. Existing phantom records self-heal on each session's first post-deploy hook event; until then the sentinel fallback covers reads.

## Causal autopsy

**origin: latent design assumption.** The write-once bridge ("called when the FIRST hook event arrives") was correct when conversations never rotated within a session record's lifetime. Two later, individually-correct developments broke the assumption's preconditions: (a) respawn/resume became a routine recovery action (fresh-respawn recovery, context-wedge recovery, conversation-too-long respawns), rotating UUIDs frequently; (b) v1.3.111's settled-throttle verification (and CompactionSentinel before it) made the pointer load-bearing for recovery verdicts. No single prior PR caused it; the class is "a frozen identity consumed by later features that assumed freshness." CompactionSentinel's null-on-missing comment ("the session genuinely has no jsonl") documents the era when the assumption held.

## Evidence

- `tests/unit/session-manager-behavioral.test.ts` — real-SessionManager bridge tests (first-set / rotation / idempotent / empty-id / unknown-session), in a non-quarantined suite.
- `tests/unit/claude-session-id-bridge.test.ts` — route-guard mirror updated to last-writer-wins; rotation regression + saveCount idempotency.
- `tests/unit/RateLimitSentinel.test.ts` + `tests/unit/CompactionSentinel.test.ts` — incident regression on both sentinels (phantom uuid + growing live transcript ⇒ recovered, never escalated) + sibling-precision guard on the valid-uuid arm (both sides of the boundary).
- All regression tests verified to FAIL on pre-fix code by three independent review agents (correctness / gaps / untested-paths), all of which returned clean.
- Typecheck clean; touched suites green (20 + 14 + 28 + 25 tests); full unit suite green in worktree.

**Held for Justin's word before merge** — per the approvals-only protocol.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
