### PR TITLE
feat(core): vault-backed GH_TOKEN injection at spawn (Phase-3 P3b, option C)

### DIFF
--- a/.instar/instar-dev-decisions/2026-06-06T19-40-02-124Z-gh-token-vault-spawn-p3b.json
+++ b/.instar/instar-dev-decisions/2026-06-06T19-40-02-124Z-gh-token-vault-spawn-p3b.json
@@ -1,0 +1,16 @@
+{
+  "ts": "2026-06-06T19:40:02.124Z",
+  "slug": "gh-token-vault-spawn-p3b",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "safety-invariant proximity: src/core/ghToken.ts matches token handling",
+    "new capability: new config key added"
+  ],
+  "belowFloor": true,
+  "files": 2,
+  "loc": 89,
+  "causalAutopsy": null,
+  "verdict": "pass"
+}

--- a/src/core/SessionManager.ts
+++ b/src/core/SessionManager.ts
@@ -15,6 +15,7 @@ import os from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { SessionLivenessOracle, type SessionLivenessOracleConfig } from './SessionLivenessOracle.js';
+import { resolveGhTokenFromVault } from './ghToken.js';
 import type { ReapGuard } from './ReapGuard.js';
 import { paneShowsClaudeWorking } from './claudeActivityIndicators.js';
 import { extractGeminiFinalAssistantBlock, meaningfulTail } from './paneText.js';
@@ -341,6 +342,11 @@ export class SessionManager extends EventEmitter {
    *  framework; value is the resolved path string. */
   private lastRerouteDecision = new Map<string, 'headless' | 'rerouted-interactive'>();
 
+  /** State root for the per-agent encrypted vault (P3b gh-token resolution —
+   *  same derivation as the pending-inject ledger: StateManager.baseDir when
+   *  present, else `<projectDir>/.instar`). */
+  private vaultStateDir: string;
+
   constructor(config: SessionManagerConfig, state: StateManager) {
     super();
     this.config = config;
@@ -354,6 +360,7 @@ export class SessionManager extends EventEmitter {
       ? (state as { baseDir: string }).baseDir
       : path.join(config.projectDir, '.instar');
     this.pendingInjects = new PendingInjectStore(path.join(stateBase, 'state'));
+    this.vaultStateDir = stateBase;
     // Age-gate kill back-off: default 10 min between re-requests for a kept session
     // (config.ageKillBackoffMinutes; 0 disables → legacy every-tick behavior).
     const backoffMin = typeof config.ageKillBackoffMinutes === 'number' ? config.ageKillBackoffMinutes : 10;
@@ -363,6 +370,18 @@ export class SessionManager extends EventEmitter {
         maxAgeMs: config.respawnBuildContext.maxAgeMs,
       });
     }
+  }
+
+  /** Per-agent GitHub token env flags for spawned sessions (Phase-3 increment
+   *  P3b, option C — per-agent credential isolation). Resolves the agent's OWN
+   *  token from its encrypted vault at spawn time; when the vault holds none,
+   *  returns [] and the spawn env is unchanged (machine-global gh behavior,
+   *  exactly as before). Mirrors the existing credential-injection art
+   *  (INSTAR_AUTH_TOKEN / ANTHROPIC_API_KEY via tmux -e). The hardened triage
+   *  spawn deliberately does NOT call this — it scrubs credentials. */
+  private ghTokenEnvFlags(): string[] {
+    const token = resolveGhTokenFromVault(this.vaultStateDir);
+    return token ? ['-e', `GH_TOKEN=${token}`] : [];
   }
 
   /** Lazily-constructed tri-state liveness oracle (UNIFIED-SESSION-LIFECYCLE §P1).
@@ -1635,6 +1654,7 @@ rm()  { "${shimRunner}" rm  "$@"; }
         '-e', `INSTAR_SERVER_URL=http://localhost:${this.config.port}`,
         '-e', `INSTAR_AUTH_TOKEN=${this.config.authToken}`,
         '-e', `INSTAR_AGENT_ID=${this.config.projectName}`,
+        ...this.ghTokenEnvFlags(), // P3b: per-agent vault GitHub token (empty when no vault token)
         ...(workTreeFencingToken ? ['-e', `INSTAR_FENCING_TOKEN=${workTreeFencingToken}`] : []),
         ...(workTreeFencingToken ? ['-e', `INSTAR_WORKTREE_PATH=${resolvedCwd}`] : []),
         ...(shimDir ? ['-e', `PATH=${shimmedPath}`, '-e', `BASH_ENV=${path.join(shimDir, '.shellrc')}`] : []),
@@ -1886,6 +1906,7 @@ rm()  { "${shimRunner}" rm  "$@"; }
         '-e', `INSTAR_SERVER_URL=http://localhost:${this.config.port}`,
         '-e', `INSTAR_AUTH_TOKEN=${this.config.authToken}`,
         '-e', `INSTAR_AGENT_ID=${this.config.projectName}`,
+        ...this.ghTokenEnvFlags(), // P3b: per-agent vault GitHub token (empty when no vault token)
         ...(workTreeFencingToken ? ['-e', `INSTAR_FENCING_TOKEN=${workTreeFencingToken}`] : []),
         ...(workTreeFencingToken ? ['-e', `INSTAR_WORKTREE_PATH=${resolvedCwd}`] : []),
         ...(shimDir ? ['-e', `PATH=${shimmedPath}`, '-e', `BASH_ENV=${path.join(shimDir, '.shellrc')}`] : []),
@@ -2951,6 +2972,7 @@ rm()  { "${shimRunner}" rm  "$@"; }
         '-e', `INSTAR_AUTH_TOKEN=${this.config.authToken}`,
         '-e', `INSTAR_AGENT_ID=${this.config.projectName}`,
         '-e', `INSTAR_FRAMEWORK=${framework}`,
+        ...this.ghTokenEnvFlags(), // P3b: per-agent vault GitHub token (empty when no vault token)
         // Framework-specific env additions/clears (e.g., CLAUDECODE=)
         ...Object.entries(launchSpec.envOverrides).flatMap(([k, v]) => ['-e', `${k}=${v}`]),
         // OAuth tokens (sk-ant-oat01-...) go in CLAUDE_CODE_OAUTH_TOKEN to enable

--- a/src/core/ghToken.ts
+++ b/src/core/ghToken.ts
@@ -1,0 +1,67 @@
+/**
+ * Vault-backed GitHub token resolution for spawned sessions — Phase-3
+ * increment P3b (per-agent credential isolation, the 2026-06-05 shared-machine
+ * identity-bleed incident; operator-selected design: option C).
+ *
+ * On a shared machine, the `gh` CLI reads the machine-global
+ * `~/.config/gh/hosts.yml` seat — which may belong to a DIFFERENT principal
+ * than the agent doing the work. This module resolves the agent's OWN GitHub
+ * token from its per-agent encrypted SecretStore so spawned sessions
+ * authenticate as the agent (the vault is per-agent by construction and
+ * already syncs across the agent's machines).
+ *
+ * Deliberately narrow (vault-only): when the vault holds no token the
+ * resolver returns null and the caller injects nothing — installs that have
+ * not adopted vault tokens keep today's machine-global behavior
+ * byte-for-byte. There is no `~/.config/gh/hosts.yml` parsing here by design.
+ *
+ * Pure fs/crypto read — no subprocess. A subprocess inside a spawn-path
+ * helper would consume queued child_process mock values in downstream test
+ * suites (the P3a GitSync mock-sequence lesson).
+ */
+import { SecretStore } from './SecretStore.js';
+
+/**
+ * Vault key paths checked, in order. `github_token` is the fleet's canonical
+ * flat name (the session-boot self-knowledge convention; deployed vaults use
+ * it today); `github.token` is the nested dot-notation variant.
+ */
+export const GH_TOKEN_VAULT_KEYS = ['github_token', 'github.token'] as const;
+
+export interface ResolveGhTokenOptions {
+  /** Test seam: route the master key to the file backend (never the real
+   *  keychain). Production callers omit this. */
+  forceFileKey?: boolean;
+}
+
+/**
+ * Resolve the agent's GitHub token from the encrypted vault at
+ * `<stateDir>/secrets/config.secrets.enc`.
+ *
+ * Returns the trimmed token string, or null when the vault is absent, holds
+ * no GitHub token, or cannot be read. Never throws: session spawning must
+ * proceed regardless of vault state.
+ */
+export function resolveGhTokenFromVault(
+  stateDir: string,
+  options?: ResolveGhTokenOptions,
+): string | null {
+  try {
+    const store = new SecretStore({ stateDir, forceFileKey: options?.forceFileKey });
+    for (const keyPath of GH_TOKEN_VAULT_KEYS) {
+      const value = store.get(keyPath);
+      if (typeof value === 'string' && value.trim().length > 0) {
+        return value.trim();
+      }
+    }
+    return null;
+  } catch (err) {
+    // @silent-fallback-ok — a vault read problem must never break session
+    // spawning; the spawn proceeds without an injected GH_TOKEN (machine-global
+    // gh behavior, exactly as before this increment).
+    console.warn(
+      `[ghToken] vault read failed (non-fatal; spawn proceeds without GH_TOKEN): ${err instanceof Error ? err.message : String(err)}`,
+    );
+    return null;
+  }
+}

--- a/tests/e2e/june15-headless-spawn-reroute.test.ts
+++ b/tests/e2e/june15-headless-spawn-reroute.test.ts
@@ -79,6 +79,12 @@ function stubReadyWait(manager: SessionManager): void {
   // tmux it must resolve immediately so spawns don't leak timers.
   (manager as unknown as { waitForClaudeReadyWithRetry: () => Promise<boolean> })
     .waitForClaudeReadyWithRetry = async () => true;
+  // Deterministic reroute gate regardless of the host machine's live memory
+  // state: the gate legitimately refuses force-mode spawns when the REAL host
+  // is under pressure, which made this suite fail on loaded dev machines while
+  // passing in CI. These tests assert reroute logic, not host pressure.
+  (manager as unknown as { currentMemoryPressure: () => string })
+    .currentMemoryPressure = () => 'normal';
 }
 
 describe('Headless-spawn reroute E2E (V6)', () => {

--- a/tests/unit/gh-token-vault.test.ts
+++ b/tests/unit/gh-token-vault.test.ts
@@ -1,0 +1,85 @@
+/**
+ * Vault-backed GitHub token resolution (Phase-3 increment P3b, option C —
+ * per-agent credential isolation, CMT-1125 gap 1).
+ *
+ * Exercises resolveGhTokenFromVault against a REAL SecretStore on disk: both
+ * canonical key paths, precedence, trimming, and every failure shape resolving
+ * to null WITHOUT throwing (session spawning must never depend on vault
+ * health). Vaults are written with forceFileKey so tests never touch the real
+ * keychain; one test reads through the production path (no forceFileKey) to
+ * prove the dual-key file-candidate read (CMT-1038) covers it.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { SecretStore } from '../../src/core/SecretStore.js';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+import { resolveGhTokenFromVault, GH_TOKEN_VAULT_KEYS } from '../../src/core/ghToken.js';
+
+let dir: string;
+beforeEach(() => { dir = fs.mkdtempSync(path.join(os.tmpdir(), 'ghtok-')); });
+afterEach(() => { SafeFsExecutor.safeRmSync(dir, { recursive: true, force: true, operation: 'tests/unit/gh-token-vault.test.ts' }); });
+
+function writeVault(entries: Record<string, unknown>): void {
+  const store = new SecretStore({ stateDir: dir, forceFileKey: true });
+  for (const [k, v] of Object.entries(entries)) store.set(k, v);
+}
+
+describe('resolveGhTokenFromVault', () => {
+  it('resolves the canonical flat github_token key', () => {
+    writeVault({ github_token: 'ghp_flat_token_value' });
+    expect(resolveGhTokenFromVault(dir, { forceFileKey: true })).toBe('ghp_flat_token_value');
+  });
+
+  it('resolves the nested github.token variant', () => {
+    writeVault({ 'github.token': 'ghp_nested_token_value' });
+    expect(resolveGhTokenFromVault(dir, { forceFileKey: true })).toBe('ghp_nested_token_value');
+  });
+
+  it('flat github_token takes precedence over the nested variant (documented key order)', () => {
+    writeVault({ github_token: 'ghp_flat_wins', 'github.token': 'ghp_nested_loses' });
+    expect(GH_TOKEN_VAULT_KEYS[0]).toBe('github_token');
+    expect(resolveGhTokenFromVault(dir, { forceFileKey: true })).toBe('ghp_flat_wins');
+  });
+
+  it('trims surrounding whitespace from the stored token', () => {
+    writeVault({ github_token: '  ghp_padded_token  \n' });
+    expect(resolveGhTokenFromVault(dir, { forceFileKey: true })).toBe('ghp_padded_token');
+  });
+
+  it('returns null when no vault exists (machine-global gh behavior preserved)', () => {
+    expect(resolveGhTokenFromVault(dir, { forceFileKey: true })).toBeNull();
+  });
+
+  it('returns null when the vault has secrets but no GitHub token', () => {
+    writeVault({ 'telegram.token': 'tg-something' });
+    expect(resolveGhTokenFromVault(dir, { forceFileKey: true })).toBeNull();
+  });
+
+  it('returns null for an empty or whitespace-only stored value', () => {
+    writeVault({ github_token: '   ' });
+    expect(resolveGhTokenFromVault(dir, { forceFileKey: true })).toBeNull();
+  });
+
+  it('returns null for a non-string value at the key', () => {
+    writeVault({ github_token: { oops: 'object' } });
+    expect(resolveGhTokenFromVault(dir, { forceFileKey: true })).toBeNull();
+  });
+
+  it('returns null (never throws) when the vault file is corrupt', () => {
+    writeVault({ github_token: 'ghp_will_be_corrupted' });
+    const encPath = path.join(dir, 'secrets', 'config.secrets.enc');
+    fs.writeFileSync(encPath, Buffer.from('not-an-encrypted-vault'));
+    expect(() => resolveGhTokenFromVault(dir, { forceFileKey: true })).not.toThrow();
+    expect(resolveGhTokenFromVault(dir, { forceFileKey: true })).toBeNull();
+  });
+
+  it('production path (no forceFileKey) still reads a file-keyed vault via the dual-key candidates', () => {
+    writeVault({ github_token: 'ghp_prod_path_token' });
+    // No forceFileKey here — the resolver tries the keychain candidate first
+    // (absent for this throwaway stateDir) and reads via the file key
+    // candidate, the CMT-1038 dual-key guarantee.
+    expect(resolveGhTokenFromVault(dir)).toBe('ghp_prod_path_token');
+  });
+});

--- a/tests/unit/headless-spawn-reroute.test.ts
+++ b/tests/unit/headless-spawn-reroute.test.ts
@@ -119,6 +119,12 @@ function makeManager(opts: {
   // synchronously at new-session, so this never affects the pin assertions.
   (manager as unknown as { waitForClaudeReadyWithRetry: () => Promise<boolean> })
     .waitForClaudeReadyWithRetry = async () => true;
+  // Deterministic reroute gate regardless of the host machine's live memory
+  // state: the gate legitimately refuses force-mode spawns when the REAL host
+  // is under pressure, which made this suite fail on loaded dev machines while
+  // passing in CI. These tests assert the reroute logic, not host pressure.
+  (manager as unknown as { currentMemoryPressure: () => string })
+    .currentMemoryPressure = () => 'normal';
   if (opts.credit) {
     manager.setSdkCreditReader(opts.credit as never);
   }

--- a/tests/unit/session-spawn-gh-token.test.ts
+++ b/tests/unit/session-spawn-gh-token.test.ts
@@ -1,0 +1,176 @@
+/**
+ * Spawn-time GH_TOKEN injection (Phase-3 increment P3b, option C — per-agent
+ * credential isolation).
+ *
+ * Verifies SessionManager injects the agent's OWN vault GitHub token into the
+ * spawned-session env — and, just as load-bearing, that an install WITHOUT a
+ * vault token spawns byte-for-byte as before (no GH_TOKEN flag at all; the
+ * machine-global gh seat keeps working untouched).
+ *
+ * REAL modules throughout (StateManager, SecretStore vault on disk, the real
+ * resolver) — only node:child_process is stubbed with the argv-capturing tmux
+ * handle (the headless-spawn-reroute.test.ts pattern), so the assertion is on
+ * the exact tmux argv production would execute.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+
+const mockTmuxSessions = new Set<string>();
+/** Every `new-session` argv captured, in call order. */
+const newSessionArgvs: string[][] = [];
+
+vi.mock('node:child_process', () => {
+  const handle = (args?: string[]) => {
+    if (!args) return '';
+    if (args[0] === 'new-session') {
+      newSessionArgvs.push([...args]);
+      const sIdx = args.indexOf('-s');
+      if (sIdx >= 0 && args[sIdx + 1]) mockTmuxSessions.add(args[sIdx + 1]);
+      return '';
+    }
+    if (args[0] === 'kill-session') {
+      const target = args[2]?.replace(/^=/, '').replace(/:$/, '');
+      if (target) mockTmuxSessions.delete(target);
+      return '';
+    }
+    if (args[0] === 'has-session') {
+      const target = args[2]?.replace(/^=/, '').replace(/:$/, '');
+      if (target && !mockTmuxSessions.has(target)) throw new Error('no session');
+      return '';
+    }
+    if (args[0] === 'display-message') {
+      return 'claude||claude';
+    }
+    return '';
+  };
+  return {
+    execFileSync: vi.fn().mockImplementation((_cmd: string, args?: string[]) => handle(args)),
+    execFile: vi.fn().mockImplementation(
+      (_cmd: string, args: string[], _opts: unknown, cb?: (e: Error | null, r: { stdout: string }) => void) => {
+        if (typeof _opts === 'function') cb = _opts as typeof cb;
+        try { const out = handle(args); if (cb) cb(null, { stdout: String(out) }); }
+        catch (e) { if (cb) cb(e as Error, { stdout: '' }); }
+      },
+    ),
+  };
+});
+
+import { SessionManager } from '../../src/core/SessionManager.js';
+import { StateManager } from '../../src/core/StateManager.js';
+import { SecretStore } from '../../src/core/SecretStore.js';
+import type { SessionManagerConfig } from '../../src/core/types.js';
+
+const CLAUDE = '/usr/local/bin/claude';
+
+function lastNewSessionArgv(): string[] {
+  return newSessionArgvs[newSessionArgvs.length - 1];
+}
+
+/** All `-e KEY=...` env assignments in a captured tmux argv. */
+function envAssignments(argv: string[]): string[] {
+  const out: string[] = [];
+  for (let i = 0; i < argv.length - 1; i++) {
+    if (argv[i] === '-e') out.push(argv[i + 1]);
+  }
+  return out;
+}
+
+function makeManager(tmpDir: string, opts?: { mode?: 'force' }): SessionManager {
+  const stateDir = path.join(tmpDir, 'state');
+  fs.mkdirSync(stateDir, { recursive: true });
+  const state = new StateManager(stateDir);
+  const config: SessionManagerConfig = {
+    tmuxPath: '/usr/bin/tmux',
+    claudePath: CLAUDE,
+    projectName: 'proj',
+    projectDir: tmpDir,
+    maxSessions: 10,
+    protectedSessions: [],
+    completionPatterns: ['has been automatically paused'],
+    ...(opts?.mode ? { subscriptionPathMode: opts.mode } : {}),
+  };
+  const manager = new SessionManager(config, state);
+  (manager as unknown as { waitForClaudeReadyWithRetry: () => Promise<boolean> })
+    .waitForClaudeReadyWithRetry = async () => true;
+  // Deterministic reroute gate regardless of the host machine's live memory
+  // state (the gate legitimately refuses force-mode spawns under pressure).
+  (manager as unknown as { currentMemoryPressure: () => string })
+    .currentMemoryPressure = () => 'normal';
+  return manager;
+}
+
+/** Seed the vault SessionManager resolves from: StateManager.baseDir (the
+ *  `<tmpDir>/state` dir) is the vault state root by construction. */
+function seedVault(tmpDir: string, token: string): void {
+  new SecretStore({ stateDir: path.join(tmpDir, 'state'), forceFileKey: true })
+    .set('github_token', token);
+}
+
+describe('spawn-time GH_TOKEN injection (P3b)', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'instar-ghtok-spawn-'));
+    mockTmuxSessions.clear();
+    newSessionArgvs.length = 0;
+  });
+
+  afterEach(() => {
+    SafeFsExecutor.safeRmSync(tmpDir, { recursive: true, force: true, operation: 'tests/unit/session-spawn-gh-token.test.ts' });
+  });
+
+  it('vault token → headless spawn env carries GH_TOKEN (and the existing INSTAR env is intact)', async () => {
+    seedVault(tmpDir, 'ghp_spawn_test_token');
+    const manager = makeManager(tmpDir);
+    await manager.spawnSession({ name: 'job-tok', prompt: 'p' });
+
+    const env = envAssignments(lastNewSessionArgv());
+    expect(env).toContain('GH_TOKEN=ghp_spawn_test_token');
+    // Canary: the pre-existing credential-injection art is untouched.
+    expect(env.some((e) => e.startsWith('INSTAR_AUTH_TOKEN='))).toBe(true);
+    expect(env.some((e) => e.startsWith('INSTAR_AGENT_ID='))).toBe(true);
+  });
+
+  it('no vault → spawn env has NO GH_TOKEN flag (machine-global behavior preserved byte-for-byte)', async () => {
+    const manager = makeManager(tmpDir);
+    await manager.spawnSession({ name: 'job-none', prompt: 'p' });
+
+    const env = envAssignments(lastNewSessionArgv());
+    expect(env.some((e) => e.startsWith('GH_TOKEN='))).toBe(false);
+  });
+
+  it('corrupt vault → spawn still succeeds with no GH_TOKEN flag (fail-soft end to end)', async () => {
+    seedVault(tmpDir, 'ghp_to_be_corrupted');
+    fs.writeFileSync(path.join(tmpDir, 'state', 'secrets', 'config.secrets.enc'), Buffer.from('garbage'));
+
+    const manager = makeManager(tmpDir);
+    const s = await manager.spawnSession({ name: 'job-corrupt', prompt: 'p' });
+    expect(s).toBeTruthy();
+    const env = envAssignments(lastNewSessionArgv());
+    expect(env.some((e) => e.startsWith('GH_TOKEN='))).toBe(false);
+  });
+
+  it('whitespace-only vault token → treated as absent (no GH_TOKEN flag)', async () => {
+    seedVault(tmpDir, '   ');
+    const manager = makeManager(tmpDir);
+    await manager.spawnSession({ name: 'job-blank', prompt: 'p' });
+
+    const env = envAssignments(lastNewSessionArgv());
+    expect(env.some((e) => e.startsWith('GH_TOKEN='))).toBe(false);
+  });
+
+  it('rerouted interactive spawn (subscriptionPathMode force) also carries the vault GH_TOKEN', async () => {
+    seedVault(tmpDir, 'ghp_interactive_token');
+    const manager = makeManager(tmpDir, { mode: 'force' });
+    await manager.spawnSession({ name: 'job-int', prompt: 'p' });
+
+    const argv = lastNewSessionArgv();
+    // Interactive lane confirmed by the wide-pane geometry the reroute pins.
+    expect(argv).toContain('200');
+    const env = envAssignments(argv);
+    expect(env).toContain('GH_TOKEN=ghp_interactive_token');
+  });
+});

--- a/upgrades/gh-token-vault-spawn-p3b.eli16.md
+++ b/upgrades/gh-token-vault-spawn-p3b.eli16.md
@@ -1,0 +1,66 @@
+# ELI16 — The agent brings its own GitHub key
+
+## The one-sentence version
+When an agent starts a work session, it now slips its OWN GitHub key (from its
+locked per-agent safe) into that session's pocket — instead of every agent on
+the computer reaching for the one shared key hanging by the door.
+
+## The backstory
+This is the third installment of the "shared computer" security fix. A real
+incident showed what goes wrong when several agents (working for different
+people) share one machine: one agent ended up using a DIFFERENT person's
+GitHub seat, because the GitHub command-line tool reads one machine-wide
+login file (`~/.config/gh`) no matter who is asking. Earlier installments
+locked down git *identity* (whose name goes on commits). This one starts on
+git *credentials* (whose key opens the door).
+
+The design the operator picked (option C): don't force everyone to re-log-in
+with separate config folders — instead use the per-agent encrypted safe
+(the SecretStore vault) that already exists, already holds secrets like
+`github_token` for some agents, and already syncs between an agent's own
+machines.
+
+## What this change does
+At the moment a session is spawned, the agent's vault is checked for a GitHub
+token (`github_token`, or the nested `github.token`). If one is there, the
+session's environment gets `GH_TOKEN=<that token>` — and the GitHub CLI
+prefers `GH_TOKEN` over the machine-wide login file, so everything the
+session does on GitHub happens as THIS agent. If the vault has no token,
+nothing is added and the session behaves exactly as before.
+
+Three careful details:
+
+1. **No token, no change.** Installs that never set up a vault token keep
+   today's behavior byte-for-byte. We prove this with a test that spawns
+   without a vault and checks the environment has no GH_TOKEN at all.
+2. **A broken safe can't break work.** If the vault can't be read (corrupted,
+   wrong key, whatever), the spawn logs one warning and proceeds without the
+   token. A test corrupts the vault on purpose and proves the session still
+   starts.
+3. **The hardened triage session is deliberately skipped.** That special spawn
+   scrubs credentials from its environment by design — we don't hand it a
+   GitHub key.
+
+## Why it's safe
+- The injection rides the exact same mechanism the system already uses to
+  hand sessions their other credentials (the Anthropic key travels the same
+  way) — no new transport invented.
+- The resolver never throws and never runs a subprocess, so it can't wedge a
+  spawn or trip the test suites that script subprocess call sequences.
+- Reading the vault uses the dual-key fallback shipped earlier, so a vault
+  written with a file key still opens even when the keychain is unavailable.
+
+## A bonus fix that rode along
+The existing spawn-reroute test suite secretly depended on the DEVELOPER'S
+machine having free memory (the reroute gate genuinely refuses when the real
+host is loaded). On a busy machine, 8 tests failed before this change touched
+anything. The suite now pins the pressure reading to "normal," because those
+tests assert reroute logic, not host health.
+
+## What's deliberately left for next time
+- **P3c**: the git credential helper side (plain `git push` over https still
+  uses the machine keychain — `gh` operations are covered now, raw git isn't).
+- Server-side `gh` calls (CI polling, repo lookups) still use the machine
+  seat; they can adopt the same resolver later.
+- An agent-awareness section once Phase 3 is complete, so agents know a vault
+  `github_token` flows to their sessions automatically.

--- a/upgrades/next/gh-token-vault-spawn-p3b.md
+++ b/upgrades/next/gh-token-vault-spawn-p3b.md
@@ -1,0 +1,47 @@
+---
+bump: patch
+audience: agent-only
+maturity: experimental
+---
+
+## What Changed
+
+Spawned sessions now receive the agent's OWN GitHub token from its encrypted
+per-agent vault (Phase-3 increment P3b, option C — per-agent credential
+isolation). At spawn, `SessionManager` resolves `github_token` (or
+`github.token`) from the SecretStore and injects `GH_TOKEN` into the session
+environment, which the GitHub CLI prefers over the machine-global
+`~/.config/gh` seat. With no vault token the spawn is unchanged byte-for-byte;
+a vault read problem is fail-soft (one warning, spawn proceeds). The hardened
+triage spawn is deliberately excluded — it scrubs credentials by design.
+
+## What to Tell Your User
+
+Nothing user-facing changes. Foundation work (experimental) for credential
+isolation on shared machines: when an agent has its own GitHub token stored in
+its encrypted vault, work sessions automatically use that token instead of the
+computer-wide GitHub login, so agents on a shared machine stop borrowing each
+other's GitHub identity. Agents without a stored token keep working exactly as
+before.
+
+## Summary of New Capabilities
+
+- Vault-backed GH_TOKEN injection at all three real spawn sites (headless,
+  rerouted-interactive, warm interactive); triage spawn excluded by design.
+- `resolveGhTokenFromVault(stateDir)` in `src/core/ghToken.ts` — pure-fs,
+  never-throws vault resolution (canonical key `github_token`, nested
+  `github.token` variant).
+- Deflake: the headless-spawn-reroute suite no longer depends on the dev
+  machine's live memory pressure.
+
+## Evidence
+
+Verified by 10 unit tests on the resolver (`gh-token-vault`: both key paths,
+precedence, trimming, absent vault, non-string, whitespace, corrupt vault
+never throws, production dual-key read) and 5 spawn tests
+(`session-spawn-gh-token`: real vault to real tmux argv — token present with
+INSTAR canaries intact, no-vault byte-for-byte unchanged, corrupt vault
+fail-soft, whitespace treated as absent, rerouted lane covered). Canary
+suites green: headless-spawn-reroute, session-manager behavioral, terminate,
+injection, SecretStore, GitSync, no-silent-fallbacks — 119 of 119. Clean
+type-check; docs-coverage floors hold.

--- a/upgrades/side-effects/gh-token-vault-spawn-p3b.md
+++ b/upgrades/side-effects/gh-token-vault-spawn-p3b.md
@@ -1,0 +1,76 @@
+# Side-effects review — Vault-backed GH_TOKEN at spawn (Phase-3 increment P3b, option C)
+
+## What this change does
+Per-agent GitHub credential isolation for spawned sessions (CMT-1125 gap 1,
+operator-selected design option C). At spawn time, `SessionManager` resolves
+the agent's GitHub token from its encrypted per-agent SecretStore
+(`github_token`, then `github.token`) and injects `GH_TOKEN=<token>` into the
+tmux session environment. The `gh` CLI prefers `GH_TOKEN` over the
+machine-global `~/.config/gh/hosts.yml` seat, so a session's GitHub actions
+authenticate as THIS agent — the shared-machine cross-principal exposure
+behind the 2026-06-05 identity-bleed incident.
+
+Three pieces:
+- `src/core/ghToken.ts` — `resolveGhTokenFromVault(stateDir)`: pure fs/crypto
+  vault read; trims; returns null on absent vault / absent key / non-string /
+  whitespace / any read error. Never throws. No subprocess (the P3a
+  GitSync mock-sequence lesson: spawn-path helpers must not consume scripted
+  child_process mock values).
+- `SessionManager.ghTokenEnvFlags()` — private helper used by THREE spawn
+  sites (headless, rerouted-interactive, warm interactive). Returns
+  `['-e', 'GH_TOKEN=…']` or `[]`.
+- `vaultStateDir` — same derivation as the pending-inject ledger
+  (StateManager.baseDir, else `<projectDir>/.instar`).
+
+## Blast radius
+- **Additive + dark-by-default-shaped.** No config flag, no migration, no new
+  route: with no vault token the resolver returns null and the spawn argv is
+  unchanged byte-for-byte (tested: env has no `GH_TOKEN=` entry at all).
+- **Fail-soft end to end.** A corrupt vault logs one console.warn and the
+  spawn proceeds tokenless (tested with a deliberately garbaged vault file).
+- **The hardened triage spawn is EXCLUDED on purpose.** That site scrubs
+  credentials (`ANTHROPIC_API_KEY=`, `DATABASE_URL=` …); handing it a GitHub
+  token would invert its security posture. Reviewed and deliberately skipped.
+- **Token visibility (same posture as existing art).** The token rides the
+  tmux `new-session -e` argv — momentarily visible in the process list and
+  in tmux's session environment, exactly like the existing
+  `INSTAR_AUTH_TOKEN` and `ANTHROPIC_API_KEY`/`CLAUDE_CODE_OAUTH_TOKEN`
+  injections at the same sites. This increment deliberately matches that
+  established posture rather than inventing a second transport; tightening
+  all of them together is its own future increment if wanted.
+- **Per-spawn vault read.** One decrypt per spawn (and on macOS possibly one
+  read-only keychain probe via the dual-key candidates). Spawns are seconds-
+  long, rare operations; no caching added (a fresh read also means a newly
+  dropped token is picked up by the very next spawn with no restart).
+
+## Why vault-only (no hosts.yml fallback parsing)
+Option C's value is the agent using ITS OWN seat. Parsing the machine-global
+hosts.yml and injecting THAT token would re-create the exposure this exists
+to close — so when the vault has no token we inject nothing and let `gh`
+behave exactly as today. Phase-2 candidates (server-side `gh` calls in
+routes.ts/CiFailurePoller, git-credential-helper for raw https pushes) are
+catalogued in the increment ladder, not smuggled in here.
+
+## Deflake that rode along (test-only)
+Both reroute suites — `tests/unit/headless-spawn-reroute.test.ts` and
+`tests/e2e/june15-headless-spawn-reroute.test.ts` — read the REAL host memory
+pressure through the reroute gate: on a loaded dev machine they failed on a
+PRISTINE tree (verified by stashing this change and re-running; unit 8 fails,
+e2e 3 fails). Both now stub `currentMemoryPressure` to 'normal' — they assert
+reroute logic, not host health. No production code touched by the deflake; no
+test in either file asserts the pressure refusal.
+
+## Test evidence
+- `tests/unit/gh-token-vault.test.ts` (10): both key paths, precedence,
+  trimming, absent vault, wrong-key, non-string, whitespace, corrupt-vault
+  never-throws, production-path dual-key file-candidate read.
+- `tests/unit/session-spawn-gh-token.test.ts` (5): REAL StateManager + REAL
+  vault + REAL resolver, argv-capturing tmux mock — token present in headless
+  env + INSTAR canaries intact; no vault → no flag; corrupt vault → spawn
+  succeeds, no flag; whitespace token → no flag; rerouted-interactive lane
+  carries the token too.
+- Canaries green: headless-spawn-reroute (23), session-manager behavioral /
+  terminate / injection, SecretStore, GitSync, no-silent-fallbacks — 119/119.
+- `tsc --noEmit` clean; `docs-coverage --check` floors hold (no new routes,
+  no new PascalCase core class file — `ghToken.ts` is a lowercase module by
+  design).


### PR DESCRIPTION
Per-agent GitHub credential isolation for spawned sessions (CMT-1125 gap 1, operator-selected option C). Closes the last shared-machine credential-bleed gap on the `gh` CLI path.

## What changed
At spawn time, `SessionManager` resolves the agent's OWN GitHub token from its encrypted per-agent vault (`github_token`, then `github.token`) and injects `GH_TOKEN` into the session environment. The `gh` CLI prefers `GH_TOKEN` over the machine-global `~/.config/gh/hosts.yml` seat, so a session's GitHub actions authenticate as THIS agent — the cross-principal exposure behind the 2026-06-05 identity-bleed incident.

Vault-only by design: with no vault token the spawn argv is unchanged byte-for-byte (machine-global behavior preserved). A vault read problem is fail-soft (one warning, spawn proceeds). The hardened triage spawn is deliberately excluded — it scrubs credentials.

- `src/core/ghToken.ts` — `resolveGhTokenFromVault(stateDir)`: pure-fs vault read, never throws, no subprocess (the P3a GitSync mock-sequence lesson).
- `SessionManager.ghTokenEnvFlags()` at the three real spawn sites (headless, rerouted-interactive, warm-interactive).

## Tests
- 10 resolver units (both key paths, precedence, trimming, corrupt-vault never-throws, production dual-key read) + 5 spawn tests (real vault → real tmux argv; no-vault byte-for-byte; corrupt-vault fail-soft; rerouted lane).
- Deflake riding along (test-only): both reroute suites (`headless-spawn-reroute` unit + `june15-headless-spawn-reroute` e2e) read the REAL host memory pressure through the reroute gate and failed on a loaded dev machine on a pristine tree; both now stub `currentMemoryPressure` — they assert reroute logic, not host health.
- 119/119 canaries; clean type-check; docs-coverage floors hold.

## ELI16
When an agent starts a work session, it now uses its OWN GitHub key — pulled from its locked per-agent vault — instead of whatever GitHub login happens to be set up machine-wide. On a shared computer, that stops one agent from borrowing a different person's GitHub identity. If an agent has no vault token, nothing changes and it behaves exactly as before. A broken or unreadable vault can never block a session from starting — it just proceeds without the token and logs a warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)