### PR TITLE
fix(quota): run the collector regardless of Telegram-polling ownership (live-matrix finding A1)

### DIFF
--- a/.instar/instar-dev-decisions/2026-06-06T21-42-59-060Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-06-06T21-42-59-060Z-unknown.json
@@ -1,0 +1,13 @@
+{
+  "ts": "2026-06-06T21:42:59.060Z",
+  "slug": "unknown",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 138,
+  "causalAutopsy": null,
+  "verdict": "pass"
+}

--- a/.instar/instar-dev-traces/2026-06-06T21-42-29-218Z-quota-collector-polling-independence-69349ca5.json
+++ b/.instar/instar-dev-traces/2026-06-06T21-42-29-218Z-quota-collector-polling-independence-69349ca5.json
@@ -1,0 +1,18 @@
+{
+  "version": 2,
+  "sessionId": "cbdc2d51-a6de-446b-8215-773ec12f8e0b",
+  "timestamp": "2026-06-06T21:42:29.218Z",
+  "artifactPath": "upgrades/side-effects/quota-collector-polling-independence.md",
+  "artifactSha256": "3bc335a11fc158fb1d894c7892da5299a54a7e82b41fac42fb6dbdb97652733c",
+  "coveredFiles": [
+    "src/commands/server.ts",
+    "tests/unit/quota-collector-polling-independence-wiring.test.ts"
+  ],
+  "phase": "complete",
+  "tier": 1,
+  "tierReasoning": "Boot-ordering fix grounded in live evidence (echo logs lifeline-owns-polling + no-quota-state-file fail-open): hoists the existing quota collector pipeline out of the Telegram-polling conditional to top scope after scheduler, gated only on quotaTracker; behavior is a strict superset (collector runs in more cases), single-construction asserted, tsc-verified scope resolution; structural wiring test locks it.",
+  "eli16Path": "upgrades/next/quota-collector-polling-independence.md",
+  "sideEffectsPath": "upgrades/side-effects/quota-collector-polling-independence.md",
+  "secondPass": "not-required",
+  "reviewerConcurred": null
+}

--- a/src/commands/server.ts
+++ b/src/commands/server.ts
@@ -3538,6 +3538,10 @@ export async function startServer(options: StartOptions): Promise<void> {
       });
       console.log(pc.green(`  Quota tracking enabled (${quotaFile})`));
     }
+    // NOTE (A1): the account switcher + quota collector pipeline are set up
+    // below, AFTER the scheduler exists, but OUTSIDE the Telegram-polling block
+    // (see the "Account switcher + quota collector pipeline" section) so the
+    // collector runs regardless of who owns Telegram polling.
 
     // Set up opt-in telemetry heartbeat.
     // ALWAYS construct, even when disabled — fixes the chicken-and-egg deadlock
@@ -3774,6 +3778,66 @@ export async function startServer(options: StartOptions): Promise<void> {
       }
     } else if (config.scheduler.enabled && !coordinator.isAwake) {
       console.log(pc.yellow('  Scheduler skipped (standby mode)'));
+    }
+
+    // Account switcher + quota collector pipeline (live-matrix finding A1,
+    // 2026-06-06). The collector that WRITES quota-state.json — and the
+    // QuotaManager that drives its adaptive polling — were previously nested
+    // inside the `!lifelineOwnsPolling` Telegram block, so on any agent whose
+    // LIFELINE owns Telegram polling (the normal production topology) the
+    // collector never started: quota-state.json was never written, the tracker
+    // read an absent file, and quota-aware placement (#804) stayed permanently
+    // fail-open — the exact EXO rate-limit-stall hazard it exists to prevent.
+    // Collecting quota is independent of who polls Telegram, so it lives here
+    // at top scope (after the scheduler exists so migration wiring is real),
+    // gated only on quotaTracker. accountSwitcher is also consumed by
+    // wireTelegramCallbacks in the polling block; constructing it here keeps it
+    // in scope for both the polling and send-only paths.
+    const accountSwitcher = new AccountSwitcher();
+    if (quotaTracker) {
+      const quotaNotifier = new QuotaNotifier(config.stateDir);
+      const alertTopicId = state.get<number>('agent-attention-topic') ?? null;
+      quotaNotifier.configure(
+        async (_topicId, text) => {
+          const tier: NotificationTier = text.includes('EXHAUSTED') || text.includes('critical') ? 'IMMEDIATE' : 'SUMMARY';
+          notify(tier, 'quota', text);
+        },
+        alertTopicId,
+      );
+
+      let collector: InstanceType<typeof import('../monitoring/QuotaCollector.js').QuotaCollector> | null = null;
+      let migrator: InstanceType<typeof import('../monitoring/SessionMigrator.js').SessionMigrator> | null = null;
+      try {
+        const { QuotaCollector } = await import('../monitoring/QuotaCollector.js');
+        const { createDefaultProvider } = await import('../monitoring/CredentialProvider.js');
+        if (resolvedFramework === 'claude-code') {
+          const provider = createDefaultProvider();
+          collector = new QuotaCollector(provider, quotaTracker);
+        } else {
+          console.log(pc.yellow(`  QuotaCollector skipped for ${resolvedFramework} (no framework usage meter)`));
+        }
+      } catch (err) {
+        console.log(pc.yellow(`  QuotaCollector not available: ${err instanceof Error ? err.message : err}`));
+      }
+      try {
+        const { SessionMigrator } = await import('../monitoring/SessionMigrator.js');
+        migrator = new SessionMigrator({ stateDir: config.stateDir });
+      } catch (err) {
+        console.log(pc.yellow(`  SessionMigrator not available: ${err instanceof Error ? err.message : err}`));
+      }
+
+      quotaManager = new QuotaManager(
+        { stateDir: config.stateDir },
+        { tracker: quotaTracker, collector, switcher: accountSwitcher, migrator, notifier: quotaNotifier },
+      );
+      quotaManager.setSessionManager(sessionManager);
+      if (scheduler) quotaManager.setScheduler(scheduler);
+      quotaManager.setNotificationSender(async (message) => {
+        const tier: NotificationTier = message.includes('❌') || message.includes('EXHAUSTED') ? 'IMMEDIATE' : 'SUMMARY';
+        notify(tier, 'quota', message);
+      });
+      quotaManager.start();
+      console.log(pc.green('  QuotaManager started (adaptive polling) — runs regardless of Telegram-polling ownership (A1)'));
     }
 
     // Start telemetry heartbeat (deferred to here so collector can be wired first)
@@ -4032,76 +4096,10 @@ export async function startServer(options: StartOptions): Promise<void> {
       notificationBatcher.start();
       console.log(pc.green('  Notification batcher enabled (SUMMARY: 30m, DIGEST: 2h)'));
 
-      // Set up account switcher (Keychain-based OAuth account swapping)
-      const accountSwitcher = new AccountSwitcher();
-
-      // Set up quota notifier (Telegram alerts on threshold crossings)
-      const quotaNotifier = new QuotaNotifier(config.stateDir);
-      const alertTopicId = state.get<number>('agent-attention-topic') ?? null;
-      quotaNotifier.configure(
-        async (_topicId, text) => {
-          // Quota exhaustion is IMMEDIATE; warnings are SUMMARY
-          const tier: NotificationTier = text.includes('EXHAUSTED') || text.includes('critical') ? 'IMMEDIATE' : 'SUMMARY';
-          notify(tier, 'quota', text);
-        },
-        alertTopicId,
-      );
-
-      // Set up QuotaManager orchestration hub (Phase 4)
-      if (quotaTracker) {
-        // Try to set up the full collector-driven pipeline
-        let collector: InstanceType<typeof import('../monitoring/QuotaCollector.js').QuotaCollector> | null = null;
-        let migrator: InstanceType<typeof import('../monitoring/SessionMigrator.js').SessionMigrator> | null = null;
-
-        try {
-          const { QuotaCollector } = await import('../monitoring/QuotaCollector.js');
-          const { createDefaultProvider } = await import('../monitoring/CredentialProvider.js');
-          if (resolvedFramework === 'claude-code') {
-            const provider = createDefaultProvider();
-            collector = new QuotaCollector(provider, quotaTracker);
-          } else {
-            console.log(pc.yellow(`  QuotaCollector skipped for ${resolvedFramework} (no framework usage meter)`));
-          }
-        } catch (err) {
-          console.log(pc.yellow(`  QuotaCollector not available: ${err instanceof Error ? err.message : err}`));
-        }
-
-        try {
-          const { SessionMigrator } = await import('../monitoring/SessionMigrator.js');
-          migrator = new SessionMigrator({ stateDir: config.stateDir });
-        } catch (err) {
-          console.log(pc.yellow(`  SessionMigrator not available: ${err instanceof Error ? err.message : err}`));
-        }
-
-        quotaManager = new QuotaManager(
-          { stateDir: config.stateDir },
-          {
-            tracker: quotaTracker,
-            collector,
-            switcher: accountSwitcher,
-            migrator,
-            notifier: quotaNotifier,
-          },
-        );
-
-        // Wire session manager and scheduler for migration support
-        quotaManager.setSessionManager(sessionManager);
-        if (scheduler) {
-          quotaManager.setScheduler(scheduler);
-        }
-
-        // Wire Telegram notifications
-        quotaManager.setNotificationSender(async (message) => {
-          const tier: NotificationTier = message.includes('❌') || message.includes('EXHAUSTED') ? 'IMMEDIATE' : 'SUMMARY';
-          notify(tier, 'quota', message);
-        });
-
-        // Start adaptive polling (replaces the 10-min setInterval)
-        quotaManager.start();
-        console.log(pc.green('  QuotaManager started (adaptive polling, auto-migration)'));
-      } else {
-        console.log(pc.yellow('  QuotaManager skipped (no quota tracker)'));
-      }
+      // accountSwitcher + the QuotaManager/collector pipeline were hoisted OUT
+      // of this Telegram-polling block to top scope (finding A1) so the quota
+      // collector runs even when the lifeline owns Telegram polling. See the
+      // "Account switcher + quota collector pipeline" section above.
 
       // Initialize persistent UserManager for user identity resolution (Gap 8)
       const userManager = new UserManager(config.stateDir, config.users);

--- a/tests/unit/quota-collector-polling-independence-wiring.test.ts
+++ b/tests/unit/quota-collector-polling-independence-wiring.test.ts
@@ -1,0 +1,53 @@
+/**
+ * Wiring-integrity test for live-matrix finding A1 (2026-06-06):
+ *
+ * The quota COLLECTOR (which WRITES quota-state.json) and the QuotaManager that
+ * drives its adaptive polling were nested inside the
+ * `if (telegramConfig && !skipTelegram && !isStandbyTelegram && !lifelineOwnsPolling)`
+ * server-owns-Telegram-polling block. On any agent whose LIFELINE owns polling
+ * (the normal production topology — echo logs "lifeline owns polling"), that
+ * block is skipped, so the collector never started, quota-state.json was never
+ * written, and quota-aware placement (#804) stayed permanently fail-open — the
+ * exact EXO rate-limit-stall hazard it exists to prevent.
+ *
+ * This test structurally guarantees the pipeline lives OUTSIDE that block, so a
+ * future refactor can't silently re-nest it. (Source-structure assertion — the
+ * same technique session-pool-activation-wiring.test.ts uses, because the boot
+ * path is one monolithic async function not unit-instantiable in isolation.)
+ */
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const SERVER = path.join(process.cwd(), 'src/commands/server.ts');
+
+describe('A1 — quota collector runs independent of Telegram-polling ownership', () => {
+  const src = fs.readFileSync(SERVER, 'utf-8');
+
+  it('quotaManager.start() is reached OUTSIDE (before) the !lifelineOwnsPolling Telegram block', () => {
+    const startIdx = src.indexOf('quotaManager.start()');
+    const blockIdx = src.indexOf('if (telegramConfig && !skipTelegram && !isStandbyTelegram && !lifelineOwnsPolling)');
+    expect(startIdx).toBeGreaterThan(0);
+    expect(blockIdx).toBeGreaterThan(0);
+    // The collector pipeline must run before the polling-ownership gate, so a
+    // send-only (lifeline-owns-polling) server still collects quota.
+    expect(startIdx).toBeLessThan(blockIdx);
+  });
+
+  it('the collector pipeline is gated only on quotaTracker, with the A1 rationale recorded', () => {
+    expect(src).toContain('finding A1');
+    // The construction must sit after the scheduler exists (migration wiring is
+    // real) but its only runtime gate is the tracker. Anchor on the actual
+    // construction line, not the doc comment.
+    const ctorIdx = src.indexOf('const accountSwitcher = new AccountSwitcher();');
+    const schedIdx = src.indexOf('scheduler = new JobScheduler(');
+    expect(ctorIdx).toBeGreaterThan(0);
+    expect(schedIdx).toBeGreaterThan(0);
+    expect(ctorIdx).toBeGreaterThan(schedIdx);
+  });
+
+  it('does NOT re-construct the QuotaManager a second time inside the Telegram block (no double-start)', () => {
+    const occurrences = src.split('quotaManager = new QuotaManager(').length - 1;
+    expect(occurrences).toBe(1);
+  });
+});

--- a/upgrades/next/quota-collector-polling-independence.md
+++ b/upgrades/next/quota-collector-polling-independence.md
@@ -1,0 +1,42 @@
+# Quota collector now runs even when the lifeline owns Telegram polling
+
+## What Changed
+
+The quota collector (which writes quota-state.json) and the QuotaManager that
+drives its adaptive polling were nested inside the server's
+"I own Telegram polling" block. On any agent whose LIFELINE owns polling — the
+normal production topology — that block is skipped, so the collector never ran:
+quota-state.json was never written, the tracker read an absent file, and
+quota-aware placement stayed permanently fail-open (the exact rate-limit-stall
+hazard from the EXO incident it exists to prevent). Turning on quotaTracking
+alone could not fix it; the writer was gated behind an unrelated condition.
+
+The account switcher + collector + QuotaManager pipeline now live at top scope
+(after the scheduler is constructed, so migration wiring is real), gated only on
+the quota tracker — so the collector runs regardless of who polls Telegram.
+
+## What to Tell Your User
+
+If you run a lifeline-driven agent and turned on quota tracking but never saw
+quota data, this is why — now it collects. Quota-aware placement (routing work
+away from a rate-limited machine) actually has data to act on.
+
+- audience: agent-only
+- maturity: stable
+
+## Summary of New Capabilities
+
+- Quota collection + adaptive polling run independent of Telegram-polling
+  ownership (was send-only-server dead).
+- accountSwitcher hoisted to top scope (still consumed by the polling block's
+  wireTelegramCallbacks when that path runs).
+
+## Evidence
+
+- `tests/unit/quota-collector-polling-independence-wiring.test.ts` (new, 3
+  tests): quotaManager.start() is reached before the !lifelineOwnsPolling
+  block; the pipeline is constructed after the scheduler; no second
+  QuotaManager construction (no double-start).
+- Live: echo logs "Telegram send-only mode (lifeline owns polling)" + "No quota
+  state file found — fail-open" pre-fix; quota-state.json + real GET /quota data
+  post-fix (live re-verify after release).

--- a/upgrades/side-effects/quota-collector-polling-independence.md
+++ b/upgrades/side-effects/quota-collector-polling-independence.md
@@ -1,0 +1,62 @@
+# Side-Effects Review — Quota collector polling independence (finding A1)
+
+**Version / slug:** `quota-collector-polling-independence`
+**Date:** `2026-06-06`
+**Author:** `echo`
+**Second-pass reviewer:** `not required`
+
+## Summary of the change
+
+The QuotaManager/collector/accountSwitcher pipeline was hoisted out of the
+`if (telegramConfig && !skipTelegram && !isStandbyTelegram && !lifelineOwnsPolling)`
+block to top scope (after the scheduler exists), gated only on quotaTracker.
+On lifeline-owns-polling agents the collector never started → fail-open
+placement (finding A1).
+
+## Decision-point inventory
+
+One: WHERE the pipeline runs. Now: top scope, after scheduler, gated on
+quotaTracker. Before: inside the server-owns-polling block.
+
+## 1. Over-block
+
+None. The pipeline now runs in MORE cases (send-only servers too), never fewer.
+
+## 2. Under-block
+
+The collector still no-ops for non-claude-code frameworks (unchanged) and when
+quotaTracking is off (unchanged). A missing OAuth credential still degrades to
+JSONL estimation inside QuotaCollector (unchanged).
+
+## 3. Level-of-abstraction fit
+
+Quota collection is independent of Telegram-polling ownership; placing it with
+the other top-scope monitoring setup (after scheduler, beside telemetry
+heartbeat) is the correct layer. accountSwitcher moves with it; its later
+consumer (wireTelegramCallbacks, inside the polling block) resolves it from the
+enclosing scope — verified by tsc.
+
+## 4. Signal vs authority compliance
+
+**Required reference:** [docs/signal-vs-authority.md](../../docs/signal-vs-authority.md)
+
+No authority change. quota-aware placement remains fail-open on absent data;
+this fix simply lets the data exist.
+
+## 5. Interactions
+
+- Scheduler: the pipeline now runs after `scheduler` is constructed, so
+  setScheduler() wires a real scheduler (was already conditional on `scheduler`).
+- wireTelegramCallbacks (polling block): consumes the hoisted accountSwitcher
+  from the enclosing scope — only runs in the polling path, harmless otherwise.
+- notify(): defined at outer scope (function decl), called lazily on threshold
+  crossings — safe to construct the notifier earlier.
+- Double-start: the old in-block copy was REMOVED (test asserts a single
+  QuotaManager construction) — no risk of two pollers.
+- guard-posture tripwire: already observed quotaTracking re-enabled; this fix
+  makes that enablement actually produce data.
+
+## 6. External surfaces
+
+No new routes/config/notifications. `GET /quota` now returns real data on
+lifeline-driven agents instead of `no_data`.


### PR DESCRIPTION
## What

The quota **collector** (writes `quota-state.json`) and the QuotaManager that drives its adaptive polling were nested inside the `if (telegramConfig && !skipTelegram && !isStandbyTelegram && !lifelineOwnsPolling)` server-owns-Telegram-polling block. On any agent whose **lifeline** owns polling — the normal production topology (echo logs `Telegram send-only mode (lifeline owns polling)`) — that block is skipped, so the collector never started: `quota-state.json` was never written, the tracker logged `No quota state file found — fail-open`, and quota-aware placement (#804) stayed **permanently fail-open** — the exact EXO rate-limit-stall hazard it exists to prevent. Enabling `quotaTracking` alone could not fix it.

## How

The `accountSwitcher` + collector + QuotaManager pipeline now live at top scope (after the scheduler is constructed so migration wiring is real), gated only on `quotaTracker`. The in-block copy is removed (single construction, no double-start). `accountSwitcher`'s later consumer (`wireTelegramCallbacks`, inside the polling block) resolves it from the enclosing scope (tsc-verified).

## Tests

`tests/unit/quota-collector-polling-independence-wiring.test.ts` (new, 3): `quotaManager.start()` is reached before the `!lifelineOwnsPolling` block; constructed after the scheduler; exactly one QuotaManager construction. Full suite green on pre-push.

## ELI16

The part of me that checks "how much usage budget is left" wasn't running on machines where a background helper handles the chat connection — the normal setup. So the feature meant to steer work away from a maxed-out machine had no numbers to look at. Now it runs everywhere.

## Live verify

After release: laptop writes `quota-state.json`, `GET /quota` returns real data instead of `no_data`, `GET /pool` shows per-machine `quotaState`.