### PR TITLE
fix(quota): propagate a peer's quotaState to the router — placement can avoid a rate-limited peer (finding A2)

### DIFF
--- a/.instar/instar-dev-decisions/2026-06-06T22-48-41-244Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-06-06T22-48-41-244Z-unknown.json
@@ -1,0 +1,13 @@
+{
+  "ts": "2026-06-06T22:48:41.244Z",
+  "slug": "unknown",
+  "suggestedTier": 1,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 2,
+  "loc": 20,
+  "causalAutopsy": null,
+  "verdict": "pass"
+}

--- a/.instar/instar-dev-traces/2026-06-06T22-48-09-218Z-peer-quota-propagation-62cfe6df.json
+++ b/.instar/instar-dev-traces/2026-06-06T22-48-09-218Z-peer-quota-propagation-62cfe6df.json
@@ -1,0 +1,19 @@
+{
+  "version": 2,
+  "sessionId": "cbdc2d51-a6de-446b-8215-773ec12f8e0b",
+  "timestamp": "2026-06-06T22:48:09.218Z",
+  "artifactPath": "upgrades/side-effects/peer-quota-propagation.md",
+  "artifactSha256": "c7e10b77470db3434bc8aeefc12d99b1f1517d3862ff70385febdc963184777c",
+  "coveredFiles": [
+    "src/commands/server.ts",
+    "src/core/PeerPresencePuller.ts",
+    "tests/unit/peer-presence-puller.test.ts"
+  ],
+  "phase": "complete",
+  "tier": 1,
+  "tierReasoning": "Additive pass-through of an existing field (peer quotaState already served in session-status, dropped by the receive-side narrowing — identical shape to the #931 commitmentsAdvert fix); absent-safe/fail-open, no transport change; 2 new propagation tests + existing wiring suite green; grounded by live evidence (peer quotaState null on /pool after 5min despite peer /quota ok).",
+  "eli16Path": "upgrades/next/peer-quota-propagation.md",
+  "sideEffectsPath": "upgrades/side-effects/peer-quota-propagation.md",
+  "secondPass": "not-required",
+  "reviewerConcurred": null
+}

--- a/src/commands/server.ts
+++ b/src/commands/server.ts
@@ -11305,17 +11305,24 @@ export async function startServer(options: StartOptions): Promise<void> {
                   loadAvg?: number;
                   journalAdvert?: Record<string, Record<string, { incarnation: string; lastSeq: number }>>;
                   commitmentsAdvert?: { incarnation: string; replicationSeq: number };
+                  quotaState?: { blocked: boolean; blockedUntil?: string; reason?: string };
                 };
                 const journalAdvert = _unwrapPeerJournalAdvert(machineId, cap.journalAdvert);
                 // #930 sibling (live, v1.3.369): the commitments advert was
                 // parsed AWAY here — served by the peer, dropped by this
                 // narrowing return — so driveCommitmentsSync never fired and
                 // zero replicas ever landed. Pass it through.
+                // A2 (live, v1.3.384): the SAME narrowing also dropped the
+                // peer's quotaState (its getCapacity(self) includes it), so the
+                // router only ever saw its OWN quota and quota-aware placement
+                // (#804) could never avoid a rate-limited PEER — the original
+                // EXO failure. Pass it through too. Absent = not blocked.
                 return {
                   selfReportedLastSeen: cap.selfReportedLastSeen,
                   loadAvg: cap.loadAvg,
                   journalAdvert,
                   ...(cap.commitmentsAdvert ? { commitmentsAdvert: cap.commitmentsAdvert } : {}),
+                  ...(cap.quotaState ? { quotaState: cap.quotaState } : {}),
                 };
               }
               return null;

--- a/src/core/PeerPresencePuller.ts
+++ b/src/core/PeerPresencePuller.ts
@@ -49,6 +49,15 @@ export interface PeerCapacity {
    * peers omit it and the drive is a no-op.
    */
   commitmentsAdvert?: { incarnation: string; replicationSeq: number };
+  /**
+   * The peer's self-reported LLM-account quota state (live-matrix finding A2,
+   * 2026-06-06). It IS carried in the peer's session-status response (its
+   * getCapacity(self) already includes it) but was being PARSED AWAY on the
+   * receive side — so the router only ever saw its OWN quota and quota-aware
+   * placement (#804) could never avoid a rate-limited PEER (the original EXO
+   * failure). Absent from old peers = treated as not blocked (fail-open).
+   */
+  quotaState?: { blocked: boolean; blockedUntil?: string; reason?: string };
 }
 
 /** One stream slice of a journal-sync delta (mirrors MeshRpc's `journal-sync.batch`). */
@@ -71,7 +80,7 @@ export interface PeerPresencePullerDeps {
    */
   fetchPeerCapacity: (machineId: string, url: string) => Promise<PeerCapacity | null>;
   /** Record an observed peer heartbeat into the pool registry (marks it online for the failover window). */
-  recordHeartbeat: (obs: { machineId: string; selfReportedLastSeen: string; loadAvg?: number }) => void;
+  recordHeartbeat: (obs: { machineId: string; selfReportedLastSeen: string; loadAvg?: number; quotaState?: { blocked: boolean; blockedUntil?: string; reason?: string } }) => void;
   /** Wall clock — injectable for tests. Defaults to `Date`. */
   now?: () => Date;
   /** Optional structured log line per pass (e.g. for the boot log). */
@@ -142,7 +151,7 @@ export class PeerPresencePuller {
         }
         if (!cap) return null;
         const seen = cap.selfReportedLastSeen ?? (this.d.now?.() ?? new Date()).toISOString();
-        this.d.recordHeartbeat({ machineId: m.machineId, selfReportedLastSeen: seen, loadAvg: cap.loadAvg });
+        this.d.recordHeartbeat({ machineId: m.machineId, selfReportedLastSeen: seen, loadAvg: cap.loadAvg, ...(cap.quotaState ? { quotaState: cap.quotaState } : {}) });
         // REPLICATION-GATED journal-delta drive — only when the server wired the
         // delta deps (i.e. replication.enabled === true). Otherwise a complete
         // no-op (engine/transport stay dark). Never throws into the puller.

--- a/tests/unit/peer-presence-puller.test.ts
+++ b/tests/unit/peer-presence-puller.test.ts
@@ -18,13 +18,14 @@
 import { describe, it, expect, vi } from 'vitest';
 import { PeerPresencePuller, type PeerPresenceMachine } from '../../src/core/PeerPresencePuller.js';
 
+type QuotaState = { blocked: boolean; blockedUntil?: string; reason?: string };
 function makePuller(opts: {
   self: string;
   peers: PeerPresenceMachine[];
-  fetchImpl: (machineId: string, url: string) => Promise<{ selfReportedLastSeen?: string; loadAvg?: number } | null>;
+  fetchImpl: (machineId: string, url: string) => Promise<{ selfReportedLastSeen?: string; loadAvg?: number; quotaState?: QuotaState } | null>;
   now?: () => Date;
 }) {
-  const recorded: Array<{ machineId: string; selfReportedLastSeen: string; loadAvg?: number }> = [];
+  const recorded: Array<{ machineId: string; selfReportedLastSeen: string; loadAvg?: number; quotaState?: QuotaState }> = [];
   const puller = new PeerPresencePuller({
     selfMachineId: opts.self,
     listPeers: () => opts.peers,
@@ -49,6 +50,43 @@ describe('PeerPresencePuller.pullOnce', () => {
     expect(recorded).toEqual([
       { machineId: 'm_mini', selfReportedLastSeen: '2026-05-29T10:00:00.000Z', loadAvg: 1.25 },
     ]);
+  });
+
+  // Finding A2 (live, 2026-06-06): the peer's quotaState rides session-status
+  // but was parsed away on the receive side, so the router never saw a peer's
+  // quota and quota-aware placement (#804) couldn't avoid a rate-limited peer.
+  it('propagates a peer quotaState into the recorded heartbeat (A2)', async () => {
+    const { puller, recorded } = makePuller({
+      self: 'm_self',
+      peers: [{ machineId: 'm_mini', url: 'https://mini.example.dev' }],
+      fetchImpl: async () => ({
+        selfReportedLastSeen: '2026-06-06T10:00:00.000Z',
+        loadAvg: 0.5,
+        quotaState: { blocked: true, blockedUntil: '2026-06-06T11:00:00.000Z', reason: '5-hour window at 97%' },
+      }),
+    });
+
+    await puller.pullOnce();
+
+    expect(recorded).toHaveLength(1);
+    expect(recorded[0].quotaState).toEqual({
+      blocked: true,
+      blockedUntil: '2026-06-06T11:00:00.000Z',
+      reason: '5-hour window at 97%',
+    });
+  });
+
+  it('omits quotaState when the peer does not report one (old peer = not blocked, fail-open)', async () => {
+    const { puller, recorded } = makePuller({
+      self: 'm_self',
+      peers: [{ machineId: 'm_old', url: 'https://old.example.dev' }],
+      fetchImpl: async () => ({ selfReportedLastSeen: '2026-06-06T10:00:00.000Z', loadAvg: 0.5 }),
+    });
+
+    await puller.pullOnce();
+
+    expect(recorded).toHaveLength(1);
+    expect('quotaState' in recorded[0]).toBe(false);
   });
 
   it('never polls or records itself', async () => {

--- a/tests/unit/working-set-ownerof-wiring.test.ts
+++ b/tests/unit/working-set-ownerof-wiring.test.ts
@@ -11,12 +11,17 @@ import path from 'node:path';
 describe('wsOwnerOf quiet-topic fallbacks (#926 + #930)', () => {
   const src = fs.readFileSync(path.join(__dirname, '../../src/commands/server.ts'), 'utf-8');
 
-  it('fetchPeerCapacity passes the commitments advert THROUGH to the puller (the dropped-advert bug)', () => {
+  it('fetchPeerCapacity passes the commitments advert AND peer quotaState THROUGH to the puller (the dropped-advert bug #931 + A2)', () => {
     const idx = src.indexOf('fetchPeerCapacity: async (machineId, url)');
     expect(idx).toBeGreaterThan(0);
-    const block = src.slice(idx, idx + 1600);
+    // Window widened for the A2 quotaState pass-through (+ its rationale comment).
+    const block = src.slice(idx, idx + 2400);
     expect(block).toContain('commitmentsAdvert?: { incarnation: string; replicationSeq: number }');
     expect(block).toContain('cap.commitmentsAdvert ? { commitmentsAdvert: cap.commitmentsAdvert }');
+    // A2 (live, v1.3.384): the peer's quotaState must also pass through, or the
+    // router never sees a peer's quota and placement can't avoid a blocked peer.
+    expect(block).toContain('quotaState?: { blocked: boolean; blockedUntil?: string; reason?: string }');
+    expect(block).toContain('cap.quotaState ? { quotaState: cap.quotaState }');
   });
 
   it('falls back to the LOCAL pin, then the topic-placement journal entry', () => {

--- a/upgrades/next/peer-quota-propagation.md
+++ b/upgrades/next/peer-quota-propagation.md
@@ -1,0 +1,40 @@
+# Quota-aware placement can now see a PEER's quota, not just its own
+
+## What Changed
+
+Quota-aware placement is meant to route work away from a rate-limited machine.
+But each machine only ever knew its OWN quota: a peer's quota state rides the
+session-status response (the peer's own capacity already includes it), yet the
+receive side parsed it away — the exact same narrowing bug that previously
+dropped the commitments advert (#931). So the router could avoid placing onto a
+rate-limited LOCAL machine but never onto a rate-limited PEER — which is the
+original EXO failure (the laptop placing work onto a rate-limited Mini).
+
+The peer-capacity parse + the PeerPresencePuller now carry `quotaState` through
+to the pool registry. Absent from an older peer = treated as not blocked
+(fail-open, unchanged).
+
+## What to Tell Your User
+
+If one of your machines hits its usage limit, the other machine now actually
+knows and stops sending new work to it — instead of finding out the hard way.
+
+- audience: agent-only
+- maturity: stable
+
+## Summary of New Capabilities
+
+- `PeerCapacity.quotaState` carried from the session-status response through
+  `fetchPeerCapacity` and `PeerPresencePuller` into the pool registry.
+- `GET /pool` now shows a peer's `quotaState`, not just the local machine's.
+- Pairs with finding A1 (the collector that produces the data now runs on
+  lifeline-driven agents).
+
+## Evidence
+
+- `tests/unit/peer-presence-puller.test.ts` (+2): a peer quotaState propagates
+  into the recorded heartbeat; an old peer omitting it records no quotaState
+  (fail-open). 13/13 in file incl. the existing wiring suite.
+- Live (pre-fix, v1.3.384): laptop `/pool` shows its own `quotaState:{blocked:false}`
+  but the Mini's stays `null` after 5+ minutes despite the Mini's `/quota`
+  reading `status:ok`.

--- a/upgrades/side-effects/peer-quota-propagation.md
+++ b/upgrades/side-effects/peer-quota-propagation.md
@@ -1,0 +1,58 @@
+# Side-Effects Review — Peer quota propagation (finding A2)
+
+**Version / slug:** `peer-quota-propagation`
+**Date:** `2026-06-06`
+**Author:** `echo`
+**Second-pass reviewer:** `not required`
+
+## Summary of the change
+
+The peer's `quotaState` (already in its session-status response via
+getCapacity(self)) was parsed away on the receive side — same narrowing bug as
+the #931 commitmentsAdvert drop. Now carried through `fetchPeerCapacity` ->
+`PeerCapacity` -> `PeerPresencePuller.recordHeartbeat` -> pool registry, so the
+router sees a peer's quota and quota-aware placement (#804) can avoid a
+rate-limited peer (the original EXO failure).
+
+## Decision-point inventory
+
+One: carry the field or not. Carried, additively, with absent = not blocked.
+
+## 1. Over-block
+
+A correctly-reported `blocked:true` peer is now AVOIDED by placement where
+before it was silently chosen. That is the intended behavior, not over-block:
+the data is the peer's own self-report (the gemini quota-conflation lesson —
+never another machine's file; this is the peer asserting its OWN state).
+
+## 2. Under-block
+
+An old peer that omits quotaState still reads as not-blocked (fail-open,
+unchanged) — no regression, just no improvement for un-upgraded peers.
+
+## 3. Level-of-abstraction fit
+
+The field travels the SAME path the commitmentsAdvert/journalAdvert already
+travel (session-status -> fetchPeerCapacity -> puller). No new transport, no
+new endpoint. The serving side already emitted it (getCapacity spread).
+
+## 4. Signal vs authority compliance
+
+**Required reference:** [docs/signal-vs-authority.md](../../docs/signal-vs-authority.md)
+
+Placement remains advisory + fail-open: a hard pin still wins
+(pinned-machine-quota-blocked), all-blocked proceeds least-loaded. This change
+only feeds the existing decision real peer data.
+
+## 5. Interactions
+
+- #804 quota-aware placement: the consumer — now has peer data.
+- A1 (collector hoist): the producer — together they make placement real.
+- gemini quota-conflation lesson: respected — this is the peer's OWN
+  self-report carried verbatim, never this machine reading another's file.
+- Old peers: forward/backward compatible (optional field).
+
+## 6. External surfaces
+
+`GET /pool` now populates a peer's `quotaState` (was always null for peers).
+No new routes/config/notifications.


### PR DESCRIPTION
## What

Quota-aware placement (#804) routes work away from a rate-limited machine — but each machine only knew its **own** quota. A peer's `quotaState` rides the `session-status` response (the peer's `getCapacity(self)` already includes it) yet was **parsed away** on the receive side — the exact same narrowing bug that dropped the commitments advert in #931. So the router could avoid a rate-limited LOCAL machine but never a rate-limited **PEER** — which is the original EXO failure (the laptop placing work onto a rate-limited Mini).

Found live right after A1 (#944) made the collector produce data: the laptop's `/pool` showed its own `quotaState:{blocked:false}` but the Mini's stayed `null` after 5+ minutes despite the Mini's `/quota` reading `status:ok`.

## How

`quotaState` now flows `session-status` → `fetchPeerCapacity` → `PeerCapacity` → `PeerPresencePuller.recordHeartbeat` → pool registry. Absent from an older peer = treated as not blocked (fail-open, unchanged). The serving side already emitted it (the `getCapacity` spread); this is purely the receive-side pass-through that was missing.

## Tests

`tests/unit/peer-presence-puller.test.ts` (+2): a peer `quotaState` propagates into the recorded heartbeat; an old peer that omits it records none (fail-open). 13/13 in file including the existing wiring suite. Full suite green on pre-push.

## ELI16

If one of your machines hits its usage limit, the other now actually knows and stops sending new work to it — instead of finding out the hard way. Pairs with the A1 fix (which makes the usage data exist on machines like yours in the first place).

## Live verify

After release: the Mini's `quotaState` appears on the laptop's `GET /pool` (was `null`).