### PR TITLE
feat(dashboard): pool-stream phase 1 — PeerStreamProxy relay (spec + module + tests)

### DIFF
--- a/.instar/instar-dev-decisions/2026-06-07T00-28-28-362Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-06-07T00-28-28-362Z-unknown.json
@@ -1,0 +1,15 @@
+{
+  "ts": "2026-06-07T00:28:28.362Z",
+  "slug": "unknown",
+  "suggestedTier": 2,
+  "declaredTier": 2,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "new capability: new exported class / subsystem added"
+  ],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 312,
+  "causalAutopsy": null,
+  "verdict": "pass"
+}

--- a/.instar/instar-dev-traces/2026-06-07T00-28-00-011Z-dashboard-stream-phase1-proxy-a4e10e88.json
+++ b/.instar/instar-dev-traces/2026-06-07T00-28-00-011Z-dashboard-stream-phase1-proxy-a4e10e88.json
@@ -1,0 +1,17 @@
+{
+  "version": 2,
+  "sessionId": "cbdc2d51-a6de-446b-8215-773ec12f8e0b",
+  "timestamp": "2026-06-07T00:28:00.011Z",
+  "artifactPath": "upgrades/side-effects/dashboard-stream-phase1-proxy.md",
+  "artifactSha256": "b5ff06e03e8c008ee4d2a96ffabc15010108cec953972a731f2b1652d87e5698",
+  "specPath": "docs/specs/POOL-DASHBOARD-STREAM-SPEC.md",
+  "coveredFiles": [
+    "src/server/PeerStreamProxy.ts",
+    "tests/unit/PeerStreamProxy.test.ts"
+  ],
+  "phase": "complete",
+  "tier": 2,
+  "tierReasoning": "New exported subsystem (PeerStreamProxy class) → Tier 2, driven by the converged + Justin-approved POOL-DASHBOARD-STREAM-SPEC (approved 'Go' 2026-06-06, remote-input OFF by default). Phase 1 ships the module ONLY, transport/timer/clock-injected, NOT wired to live boot (E2E-pairing exempt in-file; route lands phase 2); 13 deterministic tests cover every spec-flagged race.",
+  "secondPass": "not-required",
+  "reviewerConcurred": null
+}

--- a/docs/specs/POOL-DASHBOARD-STREAM-SPEC.eli16.md
+++ b/docs/specs/POOL-DASHBOARD-STREAM-SPEC.eli16.md
@@ -1,0 +1,46 @@
+# One dashboard for every machine — the plan
+
+## What you asked for
+
+Right now your dashboard lists sessions from all your machines, but you can only
+click into and watch the ones running on the SAME machine you opened the
+dashboard on. A session on the Mac mini, viewed from the laptop dashboard, is a
+dead tile. You said: everything should be in one dashboard, and this isn't
+scalable. Agreed.
+
+## The plan, in plain terms
+
+Teach the dashboard to fetch the live terminal stream from whichever machine
+actually has the session — quietly, in the background — so you click any tile
+and it just streams. You never have to know or care which machine it's on.
+
+Three things the design pins down (after three independent reviewers — one for
+security, one for scale, one for honest-screens — picked the draft apart):
+
+1. **Watching is on everywhere; TYPING into a remote machine is off by default.**
+   Reading a remote terminal is safe. But letting one machine send keystrokes to
+   another is a real security risk (a compromised machine could type commands
+   into a clean one). So remote viewing works out of the box; remote typing is a
+   deliberate per-machine opt-in.
+
+2. **The machine-to-machine link uses a one-time, short-lived pass.** Instead of
+   one login that stays valid for the whole connection (which a thief could
+   replay), each stream gets a fresh pass that expires in under a minute and
+   can't be reused — even across a restart.
+
+3. **Every screen state tells the truth.** Offline machine → the tile says
+   "unreachable," not a frozen black box. Stream drops → "reconnecting…", then
+   either it recovers or it honestly says "lost." Typing where typing is
+   disabled → you see why, never a silent swallow. Session moved to another
+   machine while you watched → "moved to <machine>," not a confusing "ended."
+
+It's also built to scale: the heavy work (capturing each terminal) stays on the
+machine that owns the session; your dashboard just receives the picture. Adding
+more machines doesn't multiply the cost.
+
+## Where this is
+
+The design is written and reviewed. Building it is the next phase — it's a real
+feature (a new streaming relay, the secure pass, and the dashboard screens for
+every state), so it goes through the full build-and-test pipeline like everything
+else, not a quick patch. I've registered it so it doesn't get lost.

--- a/docs/specs/POOL-DASHBOARD-STREAM-SPEC.md
+++ b/docs/specs/POOL-DASHBOARD-STREAM-SPEC.md
@@ -1,0 +1,176 @@
+---
+title: "Pool Dashboard Streaming — click + stream any machine's session from one dashboard"
+slug: "pool-dashboard-stream"
+author: "echo"
+eli16-overview: "POOL-DASHBOARD-STREAM-SPEC.eli16.md"
+status: "converged-approved"
+review-convergence: "2026-06-06 (3 independent lenses: security / ops-scalability / UX-truthfulness)"
+approved: true
+approved-by: "justin"
+approved-evidence: "Topic 13481, 2026-06-06 ~17:0x PDT: asked to improve the dashboard ('everything should be accessible from one single dashboard … this is not scalable'); after I sent the converged plan and surfaced the one product decision (remote-input default), he replied 'Go' — confirming the design incl. remote-input OFF by default."
+layer: "core-instar-primitive"
+parent-principle: "Structure beats Willpower — one dashboard streams every machine's session by machinery, not by the operator remembering which machine owns which session"
+project: "multimachine-coherence"
+project-items: "dashboard-stream P1 peer-stream-proxy, P2 wsmanager-wiring + ticket-auth, P3 dashboard-error-state-ui"
+supervision: "tier0 — deterministic frame relay over an authenticated upstream; auth (one-time ticket) and input gating (allowRemoteInput default-off) are structural, not LLM decisions."
+---
+
+# Pool Dashboard Streaming — click + stream ANY machine's session from one dashboard
+
+**Status:** converged round 2 (3 independent lenses: security / ops-scalability / UX-truthfulness)
+**Author:** echo, 2026-06-06
+**Origin:** Justin (topic 13481, 2026-06-06 ~13:36 PDT): "everything should be
+accessible from one single dashboard — right now if I access the dashboard for
+the laptop, it does show sessions for the Mac mini but I can't click and stream
+those sessions. This is not scalable."
+
+## 1. Problem
+
+`GET /sessions?scope=pool` folds every machine's sessions into one machine-tagged
+list and the dashboard renders them — but terminal streaming (`WebSocketManager`:
+subscribe / output / history / input / key over one WS) only reaches LOCAL tmux
+sessions. A Mini tile on the laptop dashboard is a dead tile (read-only,
+un-clickable). The user must know which machine owns a session and open that
+machine's dashboard — the per-machine fragmentation the pool exists to remove.
+
+## 2. Shape
+
+When a dashboard client subscribes to a session this machine does not host, the
+WebSocketManager relays the subscription to the owning machine over an
+authenticated upstream WebSocket and relays frames both ways. The machine hop is
+invisible to the click, surfaced only where honesty requires (§2.4).
+
+```
+[browser] --WS (PIN-gated, unchanged)--> [laptop WSManager]
+                                            | local session? -> existing path
+                                            | remote session?
+                                            +--upstream WS (ticket-auth)--> [mini /ws/pool-stream]
+```
+
+### 2.1 Session->machine resolution + name validation
+- The pool fold tags each session with `machineId`; the dashboard passes it in
+  the subscribe frame (`{ type:'subscribe', session, machineId? }`).
+- `machineId` absent or == self -> existing local path, byte-for-byte.
+- RE-RESOLVE, NEVER TRUST THE HINT (sec#3, ops#9): on EVERY frame carrying a
+  session name (subscribe AND input/key), resolve against the LOCAL running set
+  first: local -> serve locally (covers a session that moved here); not local +
+  reachable peer -> relay; not local + no/unreachable machine -> machine-unreachable.
+- SESSION-NAME VALIDATION (sec#3, CRIT for input): before any name reaches tmux
+  (local OR proxied) it must (a) match `^[A-Za-z0-9_.:@-]+$` and (b) exist in
+  `listRunningSessions()`. Failing -> `{type:'error',session,code:'invalid-session'}`,
+  never passed to send-keys/capture-pane. Closes tmux target injection via a
+  crafted proxied session (e.g. `s; touch /tmp/pwned #`).
+
+### 2.2 Upstream proxy lifecycle (the scalability core)
+- ONE multiplexed upstream WS per peer (`PeerStreamProxy`), lazily opened on the
+  first remote subscription, shared by all clients and all sessions on that peer;
+  reference-counted, closed after a 60s idle grace.
+- TAP POINT (ops#1, CRIT): remote subscriptions are intercepted at the SUBSCRIBE
+  handler and tracked in a SEPARATE remote-subscription map — they never enter
+  the local polling/diff loop. Capture+diff for a session happens ONLY on its
+  owning machine; this machine just fans relayed frames to its local subscribers.
+  (Without this the relay double-polls every remote session — O(sessions x
+  clients x peers); with it the fleet cost is O(subscriptions).)
+- STATE MACHINE (ops#2/3/4): `PeerStreamProxy` owns an atomic state+refcount
+  (`idle-scheduled -> active -> closing -> closed`). A subscribe during the idle
+  grace CAS-reactivates to `active`; the idle timer only closes when refcount==0
+  at fire time. A reconnect keeps pending subscriptions in a queue merged into
+  the resubscribe batch (a subscribe arriving mid-reconnect is never lost). On
+  each subscribe the peer URL is re-resolved from the registry; a changed URL
+  closes the old proxy and opens a new one (no stale-URL duplicate proxies).
+- Frames relay 1:1 with the session name unchanged; output/history/session_ended
+  fan out to every local client subscribed to that (peer, session).
+- Upstream drop -> every affected client gets
+  `{type:'error',code:'peer-stream-lost',session}` + ONE bounded reconnect with
+  resubscribe; a 10s reconnect timeout or a second failure surfaces
+  `machine-unreachable` (no reconnect storms — P19).
+- Backpressure: per-client bounded output (drop-oldest, max 1 in-flight frame
+  per (client,session), keyed on a per-client UUID — ops#8, NOT `_socket.remotePort`).
+  NOTE (ops#6): the LOCAL path today does NOT drop-oldest (it relies on the OS
+  socket buffer); this proxy ADDS the bounded queue rather than claiming parity.
+
+### 2.3 Auth — the security boundary
+- Browser side unchanged: dashboard PIN/session gating exactly as today. The PIN
+  never crosses machines; no Bearer token ever appears in a URL.
+- UPSTREAM AUTH = SHORT-LIVED TICKET (sec#1, CRIT; resolves R1-Q3): the peer
+  requests an ephemeral one-time stream ticket via an existing machine-auth-signed
+  HTTP POST (`/pool-stream/ticket`), valid ~30-60s, single-use. The WS upgrade
+  carries the ticket in a header; the serving side validates+consumes it and
+  attaches a SERVER-GENERATED session id to the WS. This gives bounded lifetime,
+  revocability, and avoids authenticating a long-lived WS once at upgrade then
+  trusting every later frame (the signed-headers-at-upgrade replay window). The
+  ticket nonce store is persisted so a captured ticket can't be replayed across a
+  restart (sec#4).
+- INPUT FORWARDING DEFAULT-OFF (sec#2, HIGH; resolves R1-Q2): remote keystroke
+  forwarding is a lateral-movement / credential-exfil vector (a compromised peer
+  could type `cat ~/.ssh/...` into a clean machine's session). It is OFF by
+  default; an operator opts in per machine via
+  `dashboard.poolStream.allowRemoteInput: true`. Read-only streaming is the safe
+  default; this is the one place the spec overrides "both machines are the same
+  operator's" convenience for safety.
+- The serving side treats proxied subscriptions exactly like local dashboard
+  clients (rate limits, per-session existence checks); machine trust never
+  bypasses a per-session guard.
+
+### 2.4 Failure honesty (UX — every state visually distinct; no lying terminal)
+New error `code`s the dashboard MUST render distinctly (UX review):
+- `machine-unreachable` — peer offline at subscribe: tile shows
+  "unreachable — <nickname>", terminal prints a red notice, never a black box.
+- `peer-stream-lost` — mid-stream drop: terminal prints "[reconnecting...]" +
+  RECONNECTING badge; on timeout/2nd-fail -> "[stream lost]" + UNREACHABLE badge;
+  input disabled until recovery.
+- `input-not-allowed` — peer has remote input off: input box rendered read-only
+  with a tooltip ("this machine doesn't allow remote control"); a typed attempt
+  shows a toast, never a silent swallow.
+- `session-transferred` (carries `newMachineId`) — session moved mid-view:
+  "[moved to <nickname>] — reload to follow", not a bare `session_ended`.
+- A live remote tile shows a STREAMING indicator + the machine badge so the user
+  can tell live-now from stale, and that latency applies (a remote hop).
+
+### 2.5 Restart resilience (ops#5)
+- Browser: on local-WS close (laptop restarts ~hourly on release), the client
+  clears the terminal, reconnects with backoff, requests the session list, and
+  resubscribes — a release wave must not strand tiles. CLIENT responsibility,
+  REQUIRED by this spec.
+- Serving peer restart mid-relay: upstream frames stop -> `peer-stream-lost` ->
+  bounded reconnect -> recovers or honest UNREACHABLE.
+
+### 2.6 Activation
+- Active only when the session pool is live (registry + peer URLs exist);
+  single-machine installs no-op at zero cost. Read streaming is intrinsic to
+  "the dashboard shows pool sessions" (a dead tile is a bug, not a gated
+  feature); INPUT across machines is the only gated part (§2.3, default-off).
+  (Resolves R1-Q1.)
+
+## 3. Non-goals
+- No cross-machine session CONTROL beyond local dashboard parity (kill/restart
+  stay on the owning machine for v1 — natural v2, same ticket-auth pattern).
+- No recording/replay; no multi-hop relay (peers must be directly reachable via
+  registered URLs, as for every pool feature).
+- No change to lifeline/standby streaming.
+
+## 4. Test plan (three tiers)
+- Tier 1: PeerStreamProxy state machine (multiplex/refcount/idle-close races,
+  reconnect-queue merge, peer-URL change), hint-staleness re-resolution,
+  session-name validation (injection rejected), input-default-off gate, ticket
+  one-time-use + expiry + cross-restart replay rejection, bounded-queue drop-oldest.
+- Tier 2: two WSManager instances back-to-back in-process (upstream transport
+  injected) — subscribe->output->input round trip, fan-out to 2 clients,
+  unsubscribe refcounting, peer-drop -> error frame -> reconnect.
+- Tier 3: feature-alive — dashboard WS against the full server with a fake peer:
+  remote subscribe yields output OR honest machine-unreachable; single-machine
+  boot unaffected; ticket endpoint requires machine-auth.
+
+## 5. Convergence log
+- R1-Q1 (flag vs intrinsic): RESOLVED — read streaming intrinsic when pool live;
+  remote INPUT gated default-off.
+- R1-Q2 (input default): RESOLVED — DEFAULT-OFF (security: lateral movement).
+- R1-Q3 (WS upgrade auth): RESOLVED — short-lived one-time ticket over the
+  machine-authed HTTP channel + server-issued session id; persisted nonce store.
+- Security findings folded: sec#1 ticket, sec#2 default-off, sec#3 name
+  validation, sec#4 persisted nonce, sec#5 redact machineId in routine logs.
+- Ops findings folded: ops#1 tap-at-subscribe, ops#2-4 proxy state machine,
+  ops#5 browser reconnect, ops#6 honest backpressure, ops#7 O(subscriptions),
+  ops#8 UUID client key.
+- UX findings folded: all error-code states + live/latency/input-disabled/
+  transferred presentations (§2.4).

--- a/src/server/PeerStreamProxy.ts
+++ b/src/server/PeerStreamProxy.ts
@@ -1,0 +1,312 @@
+/**
+ * PeerStreamProxy — phase 1 of Pool Dashboard Streaming
+ * (POOL-DASHBOARD-STREAM-SPEC §2.2, the scalability core).
+ *
+ * ONE multiplexed upstream connection per PEER machine, shared by every local
+ * dashboard client and every remote session on that peer. The local
+ * WebSocketManager (phase 2) owns local clients and the browser WS; this class
+ * owns ONLY the single upstream link and the bookkeeping that makes it correct:
+ *
+ *  - reference-counted subscriptions (per (session) → set of local clientIds);
+ *  - a 60s idle grace after the last unsubscribe, cancelled if a subscribe
+ *    arrives during it (no thrash opening/closing on a flapping client);
+ *  - ONE bounded reconnect on an upstream drop, resubscribing every current
+ *    subscription; a reconnect that does not open within reconnectTimeoutMs, or
+ *    a second drop, surfaces `machine-unreachable` (P19 — never a reconnect
+ *    storm);
+ *  - subscriptions that arrive mid-(re)connect are QUEUED and merged into the
+ *    resubscribe batch the moment the link opens — never lost;
+ *  - the peer URL is re-resolved on every subscribe; a changed URL tears the
+ *    old link down and opens a new one (no stale-URL duplicate links).
+ *
+ * Everything external is injected (transport, timers, clock) so the whole state
+ * machine is deterministically unit-testable without real sockets or wall time.
+ * This module performs NO tmux capture and NO local fan-out polling — capture
+ * happens only on the owning machine; fan-out to local clients is the injected
+ * `onFrameToClients`. (TAP POINT, ops#1: remote subs never enter the local
+ * polling loop.)
+ */
+
+// E2E-PAIRING: EXEMPT — phase-1 module with NO route/boot wiring (zero runtime
+// reachability yet). The Tier-3 "feature is alive" e2e lands in phase 2, when
+// the WebSocketManager consumes this proxy and the /pool-stream route exists.
+// Phase 1 is exhaustively covered at Tier 1 (tests/unit/PeerStreamProxy.test.ts).
+export type ProxyState = 'idle' | 'connecting' | 'active' | 'idle-scheduled' | 'closing' | 'closed';
+
+/** A live upstream connection handle (one peer's /ws/pool-stream). */
+export interface UpstreamTransport {
+  /** Send a frame to the peer (subscribe/unsubscribe/input/key/history). */
+  send(frame: Record<string, unknown>): void;
+  /** Tear the connection down. Idempotent. */
+  close(): void;
+}
+
+/** Handlers the proxy gives the transport at connect time. */
+export interface UpstreamHandlers {
+  /** The link opened and is ready to carry frames. */
+  onOpen(): void;
+  /** A frame arrived from the peer (output/history/session_ended/error/…). */
+  onFrame(frame: Record<string, unknown>): void;
+  /** The link closed (clean or error). */
+  onClose(): void;
+}
+
+export type TimerHandle = { __brand: 'PeerStreamProxyTimer' };
+
+export interface PeerStreamProxyDeps {
+  peerMachineId: string;
+  /** Resolve the peer's CURRENT url (re-read each subscribe for URL-change detection). */
+  resolveUrl: () => string | null;
+  /** Open an upstream link to `url`; the returned transport drives `handlers`. */
+  connect: (url: string, handlers: UpstreamHandlers) => UpstreamTransport;
+  /** Fan a peer frame out to every LOCAL client subscribed to (session). */
+  onFrameToClients: (session: string, frame: Record<string, unknown>) => void;
+  /** Surface an error to every local client subscribed to (session). */
+  onError: (session: string, code: 'peer-stream-lost' | 'machine-unreachable', detail?: string) => void;
+  now: () => number;
+  setTimer: (ms: number, fn: () => void) => TimerHandle;
+  clearTimer: (t: TimerHandle) => void;
+  /** Idle grace before closing an unsubscribed link (default 60_000). */
+  idleGraceMs?: number;
+  /** Reconnect open deadline (default 10_000). */
+  reconnectTimeoutMs?: number;
+  logger?: (line: string) => void;
+}
+
+const DEFAULT_IDLE_GRACE_MS = 60_000;
+const DEFAULT_RECONNECT_TIMEOUT_MS = 10_000;
+
+export class PeerStreamProxy {
+  private state: ProxyState = 'idle';
+  private transport: UpstreamTransport | null = null;
+  private connectedUrl: string | null = null;
+  /** session → set of local clientIds subscribed to it. THE source of truth:
+   *  on every (re)open we resubscribe from this map, so a subscribe that
+   *  arrives mid-connect is never lost and a mid-connect unsubscribe is never
+   *  replayed. */
+  private readonly subs = new Map<string, Set<string>>();
+  private idleTimer: TimerHandle | null = null;
+  private reconnectTimer: TimerHandle | null = null;
+  private reconnectUsed = false;
+
+  constructor(private readonly d: PeerStreamProxyDeps) {}
+
+  get currentState(): ProxyState {
+    return this.state;
+  }
+  /** Total live subscriptions across all sessions (refcount). */
+  get refCount(): number {
+    let n = 0;
+    for (const set of this.subs.values()) n += set.size;
+    return n;
+  }
+  /** Snapshot of session → clientIds (tests / introspection). */
+  sessionsView(): Record<string, string[]> {
+    const out: Record<string, string[]> = {};
+    for (const [s, set] of this.subs) out[s] = [...set];
+    return out;
+  }
+
+  private log(line: string): void {
+    this.d.logger?.(`[peer-stream-proxy ${this.d.peerMachineId}] ${line}`);
+  }
+
+  // ── subscribe / unsubscribe (refcounted) ───────────────────────────────
+
+  /** A local client subscribes to a remote session on this peer. */
+  subscribe(session: string, clientId: string): void {
+    if (this.state === 'closed') {
+      this.log('subscribe after close — ignored');
+      return;
+    }
+    // Cancel a pending idle close — we have demand again.
+    if (this.idleTimer) {
+      this.d.clearTimer(this.idleTimer);
+      this.idleTimer = null;
+      if (this.state === 'idle-scheduled') this.state = 'active';
+    }
+    let set = this.subs.get(session);
+    if (!set) {
+      set = new Set();
+      this.subs.set(session, set);
+    }
+    const firstForSession = set.size === 0;
+    set.add(clientId);
+
+    // URL re-resolution (stale-URL guard): if the peer moved, reconnect fresh.
+    const url = this.d.resolveUrl();
+    if (this.state === 'active' && this.connectedUrl && url && url !== this.connectedUrl) {
+      this.log(`peer url changed (${this.connectedUrl} → ${url}); reconnecting`);
+      this.teardownTransport();
+      this.openFresh(url);
+      return; // openFresh replays ALL current subs (incl. this one) on open
+    }
+
+    if (this.state === 'idle' || this.state === 'closing') {
+      // No link yet → open one; openFresh flushes all subs on open.
+      if (!url) {
+        // No reachable URL — honest failure, drop the just-added sub for it.
+        set.delete(clientId);
+        if (set.size === 0) this.subs.delete(session);
+        this.d.onError(session, 'machine-unreachable', 'no url for peer');
+        return;
+      }
+      this.openFresh(url);
+      return;
+    }
+    if (this.state === 'active') {
+      // Link is live → forward only when this is the first client for the
+      // session (the upstream is already streaming it for any later client).
+      if (firstForSession) this.transport?.send({ type: 'subscribe', session });
+      return;
+    }
+    // connecting → the sub is now in `subs`; onUpstreamOpen resubscribes from
+    // `subs`, so it is automatically included in the batch (never lost).
+  }
+
+  /** A local client unsubscribes (or disconnects). */
+  unsubscribe(session: string, clientId: string): void {
+    const set = this.subs.get(session);
+    if (!set) return;
+    set.delete(clientId);
+    if (set.size === 0) {
+      this.subs.delete(session);
+      if (this.state === 'active') this.transport?.send({ type: 'unsubscribe', session });
+    }
+    if (this.refCount === 0) this.scheduleIdleClose();
+  }
+
+  /** Forward an input/key frame for a session (caller already gated allowRemoteInput). */
+  relayInput(frame: Record<string, unknown>): void {
+    if (this.state === 'active') this.transport?.send(frame);
+    // Not active → input is dropped (caller's terminal shows the live state);
+    // we never queue keystrokes across a reconnect (stale input is worse than none).
+  }
+
+  // ── connection lifecycle ───────────────────────────────────────────────
+
+  private openFresh(url: string, reconnect = false): void {
+    // A user-initiated open resets the one-shot reconnect budget; a reconnect
+    // leaves `reconnectUsed` true so a further drop → machine-unreachable.
+    if (!reconnect) this.reconnectUsed = false;
+    this.state = 'connecting';
+    this.connectedUrl = url;
+    const handlers: UpstreamHandlers = {
+      onOpen: () => this.onUpstreamOpen(),
+      onFrame: (f) => this.onUpstreamFrame(f),
+      onClose: () => this.onUpstreamClose(),
+    };
+    try {
+      this.transport = this.d.connect(url, handlers);
+    } catch (e) {
+      this.log(`connect threw: ${(e as Error)?.message ?? e}`);
+      this.onUpstreamClose();
+    }
+  }
+
+  private onUpstreamOpen(): void {
+    if (this.state === 'closed') {
+      this.transport?.close();
+      return;
+    }
+    this.state = 'active';
+    if (this.reconnectTimer) {
+      this.d.clearTimer(this.reconnectTimer);
+      this.reconnectTimer = null;
+    }
+    // Resubscribe from `subs` (the source of truth) — this naturally includes
+    // any subscribe that arrived mid-connect and excludes any mid-connect
+    // unsubscribe. No stale snapshot to lose.
+    for (const session of this.subs.keys()) this.transport?.send({ type: 'subscribe', session });
+    // If nothing is subscribed anymore (all unsubscribed during connect), idle-close.
+    if (this.refCount === 0) this.scheduleIdleClose();
+  }
+
+  private onUpstreamFrame(frame: Record<string, unknown>): void {
+    const session = typeof frame.session === 'string' ? frame.session : null;
+    if (!session) return; // peer frames without a session are not fan-out-able
+    // Only fan out to sessions we still have local subscribers for.
+    if (!this.subs.has(session)) return;
+    this.d.onFrameToClients(session, frame);
+  }
+
+  private onUpstreamClose(): void {
+    if (this.state === 'closed' || this.state === 'closing') {
+      this.state = 'closed';
+      return;
+    }
+    this.transport = null;
+    // Nothing subscribed → just go idle, no reconnect.
+    if (this.refCount === 0) {
+      this.state = 'idle';
+      return;
+    }
+    if (this.reconnectUsed) {
+      // Second failure → declare the peer unreachable for every affected session.
+      this.log('second upstream drop → machine-unreachable');
+      this.failAll('machine-unreachable', 'peer unreachable after reconnect');
+      return;
+    }
+    // First drop → tell clients, attempt ONE bounded reconnect.
+    for (const session of this.subs.keys()) this.d.onError(session, 'peer-stream-lost', 'upstream dropped');
+    this.reconnectUsed = true;
+    const url = this.d.resolveUrl();
+    if (!url) {
+      this.failAll('machine-unreachable', 'no url on reconnect');
+      return;
+    }
+    this.openFresh(url, true);
+    // Bound the reconnect: if it doesn't open in time, declare unreachable.
+    this.reconnectTimer = this.d.setTimer(this.d.reconnectTimeoutMs ?? DEFAULT_RECONNECT_TIMEOUT_MS, () => {
+      this.reconnectTimer = null;
+      if (this.state !== 'active') {
+        this.log('reconnect timed out → machine-unreachable');
+        this.teardownTransport();
+        this.failAll('machine-unreachable', 'reconnect timed out');
+      }
+    });
+  }
+
+  private scheduleIdleClose(): void {
+    if (this.idleTimer || this.state === 'closed') return;
+    if (this.state === 'active') this.state = 'idle-scheduled';
+    this.idleTimer = this.d.setTimer(this.d.idleGraceMs ?? DEFAULT_IDLE_GRACE_MS, () => {
+      this.idleTimer = null;
+      if (this.refCount === 0) {
+        this.log('idle grace elapsed → closing');
+        this.teardownTransport();
+        this.state = 'closed';
+      }
+    });
+  }
+
+  private failAll(code: 'machine-unreachable' | 'peer-stream-lost', detail: string): void {
+    for (const session of this.subs.keys()) this.d.onError(session, code, detail);
+    this.subs.clear();
+    this.teardownTransport();
+    this.state = 'closed';
+  }
+
+  private teardownTransport(): void {
+    if (this.reconnectTimer) {
+      this.d.clearTimer(this.reconnectTimer);
+      this.reconnectTimer = null;
+    }
+    try {
+      this.transport?.close();
+    } catch { /* @silent-fallback-ok: closing an already-dead upstream is best-effort */ }
+    this.transport = null;
+    this.connectedUrl = null;
+  }
+
+  /** Force-close (peer removed, server shutdown). Idempotent. */
+  close(): void {
+    if (this.idleTimer) {
+      this.d.clearTimer(this.idleTimer);
+      this.idleTimer = null;
+    }
+    this.subs.clear();
+    this.teardownTransport();
+    this.state = 'closed';
+  }
+}

--- a/tests/unit/PeerStreamProxy.test.ts
+++ b/tests/unit/PeerStreamProxy.test.ts
@@ -1,0 +1,225 @@
+/**
+ * Tier-1 tests for PeerStreamProxy (Pool Dashboard Streaming phase 1,
+ * POOL-DASHBOARD-STREAM-SPEC §2.2). The whole state machine is exercised
+ * deterministically: a fake upstream transport + a manual timer queue + a
+ * manual clock, so refcount / idle-close / reconnect / url-change races are
+ * tested without sockets or wall time.
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+
+import { PeerStreamProxy, type UpstreamHandlers, type UpstreamTransport, type TimerHandle } from '../../src/server/PeerStreamProxy.js';
+
+// ── deterministic harness ───────────────────────────────────────────────
+class FakeUpstream implements UpstreamTransport {
+  sent: Array<Record<string, unknown>> = [];
+  closed = false;
+  constructor(public url: string, public handlers: UpstreamHandlers) {}
+  send(frame: Record<string, unknown>): void { this.sent.push(frame); }
+  close(): void { this.closed = true; }
+}
+
+function harness(opts: { url?: string | null } = {}) {
+  let url: string | null = 'url' in opts ? (opts.url ?? null) : 'wss://peer/ws';
+  const connects: FakeUpstream[] = [];
+  const framesToClients: Array<{ session: string; frame: Record<string, unknown> }> = [];
+  const errors: Array<{ session: string; code: string; detail?: string }> = [];
+  let nowMs = 1_000;
+  let timerSeq = 0;
+  const timers = new Map<TimerHandle, { fireAt: number; fn: () => void }>();
+
+  const proxy = new PeerStreamProxy({
+    peerMachineId: 'm_peer',
+    resolveUrl: () => url,
+    connect: (u, handlers) => {
+      const t = new FakeUpstream(u, handlers);
+      connects.push(t);
+      return t;
+    },
+    onFrameToClients: (session, frame) => framesToClients.push({ session, frame }),
+    onError: (session, code, detail) => errors.push({ session, code, detail }),
+    now: () => nowMs,
+    setTimer: (ms, fn) => {
+      const h = { __brand: 'PeerStreamProxyTimer' as const, id: ++timerSeq } as unknown as TimerHandle;
+      timers.set(h, { fireAt: nowMs + ms, fn });
+      return h;
+    },
+    clearTimer: (t) => { timers.delete(t); },
+    idleGraceMs: 60_000,
+    reconnectTimeoutMs: 10_000,
+  });
+
+  return {
+    proxy,
+    connects,
+    framesToClients,
+    errors,
+    last: () => connects[connects.length - 1],
+    setUrl: (u: string | null) => { url = u; },
+    advance: (ms: number) => {
+      nowMs += ms;
+      for (const [h, t] of [...timers]) {
+        if (t.fireAt <= nowMs) { timers.delete(h); t.fn(); }
+      }
+    },
+    pendingTimers: () => timers.size,
+  };
+}
+
+describe('PeerStreamProxy — open + multiplex', () => {
+  let h: ReturnType<typeof harness>;
+  beforeEach(() => { h = harness(); });
+
+  it('first subscribe opens one upstream and subscribes on open', () => {
+    h.proxy.subscribe('s1', 'c1');
+    expect(h.proxy.currentState).toBe('connecting');
+    expect(h.connects).toHaveLength(1);
+    h.last().handlers.onOpen();
+    expect(h.proxy.currentState).toBe('active');
+    expect(h.last().sent).toContainEqual({ type: 'subscribe', session: 's1' });
+  });
+
+  it('multiplexes: a second session reuses the one upstream; a second client on the same session does NOT re-subscribe', () => {
+    h.proxy.subscribe('s1', 'c1');
+    h.last().handlers.onOpen();
+    h.last().sent.length = 0;
+    h.proxy.subscribe('s2', 'c1');      // new session → subscribe sent
+    h.proxy.subscribe('s1', 'c2');      // same session, new client → NO new subscribe
+    expect(h.connects).toHaveLength(1);
+    expect(h.last().sent).toEqual([{ type: 'subscribe', session: 's2' }]);
+    expect(h.proxy.refCount).toBe(3);
+  });
+
+  it('fans peer frames out only for sessions with local subscribers', () => {
+    h.proxy.subscribe('s1', 'c1');
+    h.last().handlers.onOpen();
+    h.last().handlers.onFrame({ type: 'output', session: 's1', data: 'hi' });
+    h.last().handlers.onFrame({ type: 'output', session: 'ghost', data: 'x' }); // not subscribed
+    expect(h.framesToClients).toEqual([{ session: 's1', frame: { type: 'output', session: 's1', data: 'hi' } }]);
+  });
+});
+
+describe('PeerStreamProxy — idle close + reactivate', () => {
+  let h: ReturnType<typeof harness>;
+  beforeEach(() => { h = harness(); });
+
+  it('last unsubscribe schedules idle close; the grace elapsing closes the upstream', () => {
+    h.proxy.subscribe('s1', 'c1');
+    h.last().handlers.onOpen();
+    h.proxy.unsubscribe('s1', 'c1');
+    expect(h.proxy.currentState).toBe('idle-scheduled');
+    expect(h.last().closed).toBe(false);
+    h.advance(60_000);
+    expect(h.proxy.currentState).toBe('closed');
+    expect(h.last().closed).toBe(true);
+  });
+
+  it('a subscribe DURING the idle grace cancels the close and reactivates the same upstream', () => {
+    h.proxy.subscribe('s1', 'c1');
+    h.last().handlers.onOpen();
+    h.proxy.unsubscribe('s1', 'c1');
+    expect(h.proxy.currentState).toBe('idle-scheduled');
+    h.proxy.subscribe('s2', 'c1');     // demand returns mid-grace
+    expect(h.proxy.currentState).toBe('active');
+    expect(h.connects).toHaveLength(1); // SAME upstream, not reopened
+    h.advance(60_000);                  // the old timer must NOT close us
+    expect(h.proxy.currentState).toBe('active');
+    expect(h.last().closed).toBe(false);
+  });
+});
+
+describe('PeerStreamProxy — reconnect (P19 bounded)', () => {
+  let h: ReturnType<typeof harness>;
+  beforeEach(() => { h = harness(); });
+
+  it('first drop emits peer-stream-lost, reconnects once, and resubscribes every session on open', () => {
+    h.proxy.subscribe('s1', 'c1');
+    h.proxy.subscribe('s2', 'c1');
+    h.last().handlers.onOpen();
+    h.proxy.unsubscribe('s2', 'c1'); h.proxy.subscribe('s2', 'c1'); // keep s2; noise
+    h.last().handlers.onClose();      // upstream drops
+    expect(h.errors.filter((e) => e.code === 'peer-stream-lost').map((e) => e.session).sort()).toEqual(['s1', 's2']);
+    expect(h.connects).toHaveLength(2); // reconnect opened
+    h.last().handlers.onOpen();
+    const subs = h.last().sent.filter((f) => f.type === 'subscribe').map((f) => f.session).sort();
+    expect(subs).toEqual(['s1', 's2']);
+    expect(h.proxy.currentState).toBe('active');
+  });
+
+  it('a SECOND drop surfaces machine-unreachable (no reconnect storm)', () => {
+    h.proxy.subscribe('s1', 'c1');
+    h.last().handlers.onOpen();
+    h.last().handlers.onClose();      // first drop → reconnect
+    h.last().handlers.onOpen();       // reconnect succeeds
+    h.last().handlers.onClose();      // second drop
+    expect(h.errors.some((e) => e.code === 'machine-unreachable' && e.session === 's1')).toBe(true);
+    expect(h.proxy.currentState).toBe('closed');
+  });
+
+  it('a reconnect that does NOT open within the timeout surfaces machine-unreachable', () => {
+    h.proxy.subscribe('s1', 'c1');
+    h.last().handlers.onOpen();
+    h.last().handlers.onClose();      // drop → reconnect attempt (stays connecting)
+    expect(h.proxy.currentState).toBe('connecting');
+    h.advance(10_000);                // reconnect deadline passes, never opened
+    expect(h.errors.some((e) => e.code === 'machine-unreachable')).toBe(true);
+    expect(h.proxy.currentState).toBe('closed');
+  });
+
+  it('a subscribe arriving mid-reconnect is merged into the resubscribe batch (never lost)', () => {
+    h.proxy.subscribe('s1', 'c1');
+    h.last().handlers.onOpen();
+    h.last().handlers.onClose();      // drop → reconnect (connecting)
+    h.proxy.subscribe('s2', 'c1');    // arrives while connecting
+    h.last().handlers.onOpen();
+    const subs = h.last().sent.filter((f) => f.type === 'subscribe').map((f) => f.session).sort();
+    expect(subs).toEqual(['s1', 's2']);
+  });
+});
+
+describe('PeerStreamProxy — url change + no-url', () => {
+  it('a changed peer url on subscribe tears down the old link and opens a fresh one', () => {
+    const h = harness({ url: 'wss://old/ws' });
+    h.proxy.subscribe('s1', 'c1');
+    h.last().handlers.onOpen();
+    const old = h.last();
+    h.setUrl('wss://new/ws');
+    h.proxy.subscribe('s2', 'c1');    // re-resolves url → changed → reconnect
+    expect(old.closed).toBe(true);
+    expect(h.connects).toHaveLength(2);
+    expect(h.last().url).toBe('wss://new/ws');
+    h.last().handlers.onOpen();
+    const subs = h.last().sent.filter((f) => f.type === 'subscribe').map((f) => f.session).sort();
+    expect(subs).toEqual(['s1', 's2']); // both replayed on the fresh link
+  });
+
+  it('subscribe with no resolvable url errors machine-unreachable and opens nothing', () => {
+    const h = harness({ url: null });
+    h.proxy.subscribe('s1', 'c1');
+    expect(h.connects).toHaveLength(0);
+    expect(h.errors).toEqual([{ session: 's1', code: 'machine-unreachable', detail: 'no url for peer' }]);
+    expect(h.proxy.refCount).toBe(0);
+  });
+});
+
+describe('PeerStreamProxy — input relay + close', () => {
+  it('relays input only while active; never queues keystrokes', () => {
+    const h = harness();
+    h.proxy.subscribe('s1', 'c1');
+    h.proxy.relayInput({ type: 'input', session: 's1', text: 'x' }); // connecting → dropped
+    h.last().handlers.onOpen();
+    h.proxy.relayInput({ type: 'input', session: 's1', text: 'y' }); // active → sent
+    const inputs = h.last().sent.filter((f) => f.type === 'input');
+    expect(inputs).toEqual([{ type: 'input', session: 's1', text: 'y' }]);
+  });
+
+  it('close() is idempotent, clears subs, and closes the upstream', () => {
+    const h = harness();
+    h.proxy.subscribe('s1', 'c1');
+    h.last().handlers.onOpen();
+    h.proxy.close();
+    expect(h.proxy.currentState).toBe('closed');
+    expect(h.last().closed).toBe(true);
+    expect(h.proxy.refCount).toBe(0);
+    expect(() => h.proxy.close()).not.toThrow();
+  });
+});

--- a/tests/unit/no-silent-fallbacks.test.ts
+++ b/tests/unit/no-silent-fallbacks.test.ts
@@ -266,7 +266,14 @@ describe('No Silent Fallbacks', () => {
     // failure it absorbs is counted in the pull report (goneFromDisk /
     // refusal counters) rather than swallowed. Verified: the PR adds zero
     // unjustified swallows; honest degradations surface as counted outcomes.
-    const BASELINE = 461;
+    //
+    // 461 -> 462 by dashboard-stream phase 1 (PeerStreamProxy): one
+    // parser-counted catch — teardownTransport's `transport?.close()` guard,
+    // which swallows an error from closing an ALREADY-dead upstream (the link
+    // is being torn down regardless). Carries an in-brace @silent-fallback-ok;
+    // not a real degradation (the close is best-effort cleanup, the link's
+    // demise is already surfaced to clients via peer-stream-lost/unreachable).
+    const BASELINE = 462;
 
     if (silentFallbacks.length > 0) {
       const report = silentFallbacks.map(fb =>

--- a/upgrades/next/dashboard-stream-phase1-proxy.md
+++ b/upgrades/next/dashboard-stream-phase1-proxy.md
@@ -1,0 +1,42 @@
+# Pool dashboard streaming — phase 1: the peer-stream relay core
+
+## What Changed
+
+First building block of the single-dashboard cross-machine streaming feature
+(POOL-DASHBOARD-STREAM-SPEC): the `PeerStreamProxy` — one multiplexed upstream
+connection per peer machine that the dashboard's WebSocket layer will use
+(phase 2) to relay a remote session's terminal stream. This phase ships the
+state machine ONLY; it is not yet wired to the live WebSocketManager, so it
+changes no user-visible behavior on its own.
+
+The proxy is the scalability + correctness core the reviewers stressed:
+reference-counted subscriptions, a 60s idle grace (cancelled if demand
+returns), ONE bounded reconnect on a drop with full resubscribe (a second drop
+or a reconnect timeout → machine-unreachable, never a reconnect storm),
+mid-reconnect subscribes merged from the source-of-truth subscription map (never
+lost), and peer-URL-change detection (stale-URL links are torn down). Capture
+stays on the owning machine; this only relays — so fleet cost is
+O(subscriptions), not O(sessions × clients × peers).
+
+## What to Tell Your User
+
+Nothing yet — this is internal plumbing. The visible result (click any
+machine's session and it streams) lands when phases 2–3 wire it to the
+dashboard.
+
+- audience: agent-only
+- maturity: preview
+
+## Summary of New Capabilities
+
+- `src/server/PeerStreamProxy.ts` — the per-peer upstream relay state machine,
+  fully transport/timer/clock-injected (no live wiring yet).
+
+## Evidence
+
+- `tests/unit/PeerStreamProxy.test.ts` (13 tests, deterministic): open+multiplex
+  (one upstream, no double-subscribe for a second client), idle-close +
+  mid-grace reactivate, bounded reconnect + resubscribe, second-drop →
+  unreachable, reconnect-timeout → unreachable, mid-reconnect subscribe merged,
+  url-change reopen, no-url → machine-unreachable, input-relay-only-when-active,
+  idempotent close.

--- a/upgrades/side-effects/dashboard-stream-phase1-proxy.md
+++ b/upgrades/side-effects/dashboard-stream-phase1-proxy.md
@@ -1,0 +1,61 @@
+# Side-Effects Review — Pool dashboard streaming phase 1 (PeerStreamProxy)
+
+**Version / slug:** `dashboard-stream-phase1-proxy`
+**Date:** `2026-06-06`
+**Author:** `echo`
+**Second-pass reviewer:** `not required`
+
+## Summary of the change
+
+A NEW, self-contained module (`PeerStreamProxy`) — phase 1 of the converged
+POOL-DASHBOARD-STREAM-SPEC. The per-peer upstream relay state machine, with all
+external surfaces (transport, timers, clock) injected. NOT wired into the live
+WebSocketManager or server boot in this phase, so it has zero runtime effect
+until phase 2 consumes it.
+
+## Decision-point inventory
+
+The state machine's transitions: open / multiplex / idle-close / reactivate /
+bounded-reconnect / second-drop-unreachable / reconnect-timeout / url-change /
+no-url. Each is covered both-sides by a deterministic test.
+
+## 1. Over-block
+
+N/A — no gating; a relay. The conservative reconnect policy (one attempt per
+episode, then machine-unreachable) could declare a flaky-but-recoverable peer
+unreachable, but the user simply re-subscribes (re-click), which opens fresh
+and resets the budget. Storm-proof beats persistent.
+
+## 2. Under-block
+
+Keystrokes are never queued across a (re)connect — stale input is worse than
+none. Acceptable: the dashboard shows the live link state (phase 3) so the user
+knows when input is live.
+
+## 3. Level-of-abstraction fit
+
+Pure module under src/server/, no I/O of its own. The WebSocketManager (phase 2)
+owns local clients + the browser WS and injects the transport; this owns only
+the single upstream link + its bookkeeping. Matches the P2 precedent of
+shipping a tested building block before its consumer.
+
+## 4. Signal vs authority compliance
+
+**Required reference:** [docs/signal-vs-authority.md](../../docs/signal-vs-authority.md)
+
+No authority. A transport relay; all auth (ticket) + input gating
+(allowRemoteInput) live in phase 2 at the WSManager/upgrade boundary per spec
+§2.3.
+
+## 5. Interactions
+
+- WebSocketManager (phase 2): the future consumer; unaffected now (no import).
+- Local polling loop: untouched — remote subs never enter it (TAP POINT). This
+  module does no tmux capture.
+- P19 (No Unbounded Loops): the reconnect is a single bounded attempt; tests
+  assert the second-drop and timeout both terminate to machine-unreachable.
+
+## 6. External surfaces
+
+None in this phase. No routes, config, notifications, or wiring. A new source
+file + its test only.


### PR DESCRIPTION
## What

Phase 1 of single-dashboard cross-machine streaming (Justin's ask, topic 13481; design approved "Go" 2026-06-06, remote-input OFF by default). Ships the 3-lens-converged + approved spec AND its phase-1 implementation.

`PeerStreamProxy` — the per-peer multiplexed upstream relay state machine: refcounted subscriptions, 60s idle grace with mid-grace reactivate, ONE bounded reconnect + full resubscribe (second drop or reconnect timeout → machine-unreachable, no storm — P19), mid-reconnect subscribes merged from the source-of-truth sub map, peer URL-change reopen. Capture stays on the owning machine; this only relays (fleet cost O(subscriptions)).

Phase 1 is the state machine ONLY — fully transport/timer/clock injected, **not wired** to the live WebSocketManager (zero runtime effect until phase 2; E2E-pairing exempt in-file, the route + Tier-3 feature-alive test land in phase 2).

## Tests

`tests/unit/PeerStreamProxy.test.ts` — 13 deterministic tests covering every spec-flagged race. `no-silent-fallbacks` baseline 461→462 (one justified best-effort upstream-close guard). Full suite green on pre-push.

## ELI16

Phase 1 builds the "relay engine" that will let your laptop dashboard show a terminal actually running on the Mac mini — it carries the live screen between machines and handles the messy cases (link dropping, machine going quiet, opening/closing the same session). It's not plugged into the dashboard yet (next step); this PR is the engine on its own, with 13 tests proving it behaves under every dropout/reconnect case. Nothing changes on your screen until the next phase wires it in.

## Phases remaining (CMT-1147)

P2: WSManager wiring (session→machine routing, `/pool-stream` serving endpoint, one-time ticket auth, allowRemoteInput default-off gate, session-name validation). P3: dashboard JS error-state UI.
