### PR TITLE
fix(cutover-readiness): wall-clock max-hold on the live-fetch single-flight lock (#948)

### DIFF
--- a/.instar/instar-dev-decisions/2026-06-07T00-28-43-383Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-06-07T00-28-43-383Z-unknown.json
@@ -1,0 +1,13 @@
+{
+  "ts": "2026-06-07T00:28:43.383Z",
+  "slug": "unknown",
+  "suggestedTier": 2,
+  "declaredTier": null,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 47,
+  "causalAutopsy": null,
+  "verdict": "pass"
+}

--- a/src/feedback-factory/cutoverReadiness.ts
+++ b/src/feedback-factory/cutoverReadiness.ts
@@ -107,10 +107,26 @@ export interface CutoverReadinessDeps {
   runImportDryRun?: (() => Promise<ImportRunResult>) | null;
   /** Freshness bound for the parity window (default 6h). */
   maxPassStalenessMs?: number;
+  /**
+   * Wall-clock max-hold for a single live fetch (parity pass OR import dry-run),
+   * enforced at the single-flight-lock boundary (default 12m). This is a
+   * defense-in-depth backstop ON TOP OF whatever internal timeout the injected
+   * fetch carries: if that fetch ever fails to settle (e.g. an AbortSignal that
+   * doesn't fire on a stalled socket, or a compare step with no timeout of its
+   * own), the lock would otherwise be held forever and every subsequent pass +
+   * dry-run is refused with "already in flight" — exactly the ~85-minute stuck
+   * lock observed in #948. The max-hold guarantees the lock releases within a
+   * bounded time so the next sweep can retry; it sits comfortably above
+   * HttpParitySource's 600s total budget so it only fires when that inner budget
+   * has genuinely failed, never on a legitimately-slow-but-working pass. */
+  maxLiveFetchMs?: number;
   now?: () => number;
 }
 
 const DEFAULT_MAX_PASS_STALENESS_MS = 6 * 60 * 60 * 1000;
+/** 12m — above HttpParitySource's 600s total budget + a working pass's compare,
+ *  so the lock-boundary max-hold is a true backstop, not a false-abort risk. */
+const DEFAULT_MAX_LIVE_FETCH_MS = 12 * 60 * 1000;
 
 interface PersistedIntegrityEnvelope {
   generatedAt: string;
@@ -126,6 +142,7 @@ interface PersistedDryRunEnvelope {
 export class CutoverReadiness {
   private readonly d: CutoverReadinessDeps;
   private readonly maxStaleMs: number;
+  private readonly maxLiveFetchMs: number;
   /**
    * Single-flight guard over the LIVE SOURCE FETCH — shared by the parity pass
    * and the import dry-run because both page the full live source. Without it,
@@ -146,10 +163,36 @@ export class CutoverReadiness {
     }
     this.d = deps;
     this.maxStaleMs = deps.maxPassStalenessMs ?? DEFAULT_MAX_PASS_STALENESS_MS;
+    this.maxLiveFetchMs = deps.maxLiveFetchMs ?? DEFAULT_MAX_LIVE_FETCH_MS;
   }
 
   private nowMs(): number {
     return this.d.now ? this.d.now() : Date.now();
+  }
+
+  /**
+   * Race an injected live-fetch promise against a wall-clock max-hold so the
+   * single-flight lock can NEVER be held indefinitely by a fetch that fails to
+   * settle (#948). On timeout this rejects (the caller's `finally` then releases
+   * the lock and the next sweep retries); the orphaned work is abandoned — a
+   * re-attempt is cheap and idempotent, an unreleasable lock is not. Uses real
+   * wall-clock time (NOT `nowMs()`), since the bug is a promise that never
+   * settles in real time regardless of an injected clock. */
+  private async withMaxHold<T>(work: Promise<T>, op: string): Promise<T> {
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    const guard = new Promise<never>((_resolve, reject) => {
+      timer = setTimeout(() => {
+        reject(new Error(
+          `live ${op} fetch exceeded the max-hold budget (${this.maxLiveFetchMs}ms) — releasing the single-flight lock so a later sweep can retry; the underlying fetch did not settle within budget (see #948)`,
+        ));
+      }, this.maxLiveFetchMs);
+      if (typeof timer.unref === 'function') timer.unref();
+    });
+    try {
+      return await Promise.race([work, guard]);
+    } finally {
+      if (timer) clearTimeout(timer);
+    }
   }
 
   /** Persist an import IntegrityReport (server-side import tooling only). */
@@ -213,7 +256,7 @@ export class CutoverReadiness {
     this.liveFetchInFlight = { op: 'parity-pass', startedAt: new Date(this.nowMs()).toISOString() };
     let result: ParityResult;
     try {
-      result = await this.d.runParityCheck();
+      result = await this.withMaxHold(this.d.runParityCheck(), 'parity-pass');
     } catch (err) {
       return { ok: false, reason: `parity check failed: ${err instanceof Error ? err.message : String(err)}` };
     } finally {
@@ -245,7 +288,7 @@ export class CutoverReadiness {
     this.liveFetchInFlight = { op: 'import-dry-run', startedAt: new Date(this.nowMs()).toISOString() };
     let result: ImportRunResult;
     try {
-      result = await this.d.runImportDryRun();
+      result = await this.withMaxHold(this.d.runImportDryRun(), 'import-dry-run');
     } catch (err) {
       return { ok: false, reason: `import dry-run failed: ${err instanceof Error ? err.message : String(err)}` };
     } finally {

--- a/tests/unit/cutover-readiness.test.ts
+++ b/tests/unit/cutover-readiness.test.ts
@@ -149,6 +149,56 @@ describe('CutoverReadiness (spec §7 G2.4)', () => {
     }
   });
 
+  // ── single-flight lock max-hold (#948 regression) ──
+
+  it('runParityPass: a live fetch that NEVER settles hits the max-hold, returns ok:false, and RELEASES the lock so a later pass proceeds (#948)', async () => {
+    feedCleanWindow();
+    const fed = monitor.passes.length; // 3
+    let call = 0;
+    const r = new CutoverReadiness({
+      parityMonitor: monitor,
+      integrityReportPath: path.join(dir, 'integrity-report.json'),
+      // First trigger: a fetch that never settles (the #948 stall — an AbortSignal
+      // that didn't fire, or a compare with no timeout). Later: a normal clean check.
+      runParityCheck: () => (++call === 1 ? new Promise<ParityResult>(() => {}) : Promise.resolve(CLEAN)),
+      maxLiveFetchMs: 40,
+      now: () => nowMs,
+    });
+    const stuck = await r.runParityPass();
+    expect(stuck.ok).toBe(false);
+    if (!stuck.ok) expect(stuck.reason).toMatch(/max-hold budget|#948/);
+    expect(monitor.passes.length).toBe(fed); // the stalled pass recorded NOTHING
+
+    // THE FIX: the lock is released, so the next pass is NOT refused with
+    // "already in flight" (pre-fix it was stuck for ~85 minutes) — it runs.
+    const after = await r.runParityPass();
+    expect(after.ok).toBe(true);
+    expect(monitor.passes.length).toBe(fed + 1); // the recovered pass actually recorded
+  });
+
+  it('runImportDryRunPass: a live fetch that NEVER settles hits the max-hold and releases the lock (#948)', async () => {
+    let call = 0;
+    const r = new CutoverReadiness({
+      parityMonitor: monitor,
+      integrityReportPath: path.join(dir, 'integrity-report.json'),
+      runParityCheck: null,
+      importDryRunReportPath: path.join(dir, 'import-dryrun.json'),
+      runImportDryRun: ((): Promise<typeof PASSED_RUN> =>
+        (++call === 1 ? new Promise<typeof PASSED_RUN>(() => {}) : Promise.resolve(PASSED_RUN))),
+      maxLiveFetchMs: 40,
+      now: () => nowMs,
+    });
+    const stuck = await r.runImportDryRunPass();
+    expect(stuck.ok).toBe(false);
+    if (!stuck.ok) expect(stuck.reason).toMatch(/max-hold budget|#948/);
+    expect(fs.existsSync(path.join(dir, 'import-dryrun.json'))).toBe(false); // nothing recorded
+
+    // Lock released → the next dry-run proceeds (not refused as in-flight).
+    const after = await r.runImportDryRunPass();
+    expect(after.ok).toBe(true);
+    expect(fs.existsSync(path.join(dir, 'import-dryrun.json'))).toBe(true);
+  });
+
   // ── the composed signal + the door ──
 
   it('ready ONLY when integrity passed AND parity cleared AND fresh; door is machine-readably manual', () => {

--- a/upgrades/next/cutover-parity-lock-maxhold.md
+++ b/upgrades/next/cutover-parity-lock-maxhold.md
@@ -1,0 +1,18 @@
+## What Changed
+
+Fixed a liveness bug in the cutover-readiness checker (#948): `CutoverReadiness`'s single-flight lock over the live source fetch (used by both the parity pass and the import dry-run) could be held **indefinitely** if the injected fetch never settled. In production the lock stuck for ~85 minutes (`logs/server.log`), so every subsequent parity pass and dry-run was refused with "live source fetch already in flight" — the parity-pass feeder kept no-opping and the cutover parity window went stale and never refreshed.
+
+`src/feedback-factory/cutoverReadiness.ts` now wraps the awaited live fetch in a wall-clock **max-hold guard** (`withMaxHold`, new optional `maxLiveFetchMs` dep, default 12 minutes) at the lock boundary. The lock is released in a `finally`, but a `finally` can't run while the awaited promise never settles — so the guard races the fetch against a timer and guarantees the lock releases within a bounded time regardless of *why* the fetch stalled (an `AbortSignal.timeout` that didn't fire on a stalled socket, or the un-timed compare step). The default sits comfortably above `HttpParitySource`'s 600s total budget, so it only fires when that inner budget has genuinely failed — never on a slow-but-working pass.
+
+## Evidence
+
+Before: a single stalled live fetch held the single-flight lock until the next server restart (~85 min observed), starving the parity feeder. After: the lock releases within `maxLiveFetchMs` and the next sweep retries. Pinned by a Tier-1 regression (`tests/unit/cutover-readiness.test.ts`): a `runParityCheck` (and `runImportDryRun`) that never settles now returns `ok:false` AND a subsequent pass on the same instance is NOT refused as in-flight — it runs and records normally. 22 cutover-readiness unit tests green (2 new + 20 existing through the new path); `tsc --noEmit` clean.
+
+## What to Tell Your User
+
+If you were ever told the feedback-migration "cutover readiness" check was stuck or its parity window had gone stale, this fixes the underlying cause: a single slow/hung check could jam the checker until the next restart. Now a check that takes too long is abandoned cleanly and the next one runs on schedule. It ships on by default with a safe 12-minute backstop and needs no configuration.
+
+## Summary of New Capabilities
+
+- A wall-clock max-hold backstop on the cutover-readiness live-fetch single-flight lock — a stalled parity pass or import dry-run can no longer hang the checker indefinitely.
+- New optional `maxLiveFetchMs` knob (default 12m); the default IS the fix, so existing agents get it automatically on update with no config change.

--- a/upgrades/side-effects/cutover-parity-lock-maxhold.md
+++ b/upgrades/side-effects/cutover-parity-lock-maxhold.md
@@ -1,0 +1,95 @@
+# Side-Effects Review — Cutover-readiness live-fetch max-hold (lock-boundary backstop, #948)
+
+**Version / slug:** `cutover-parity-lock-maxhold`
+**Date:** `2026-06-07`
+**Author:** `echo`
+**Second-pass reviewer:** `self-review (single-file behavioral hardening; both branches — stalled and healthy — covered by Tier-1 tests over the real CutoverReadiness)`
+
+## Summary of the change
+
+Fixes #948: `CutoverReadiness`'s single-flight lock (`liveFetchInFlight`) could be held
+indefinitely when an injected live fetch (parity pass or import dry-run) never settled —
+observed ~85 minutes in production (`logs/server.log`), permanently refusing every
+subsequent parity pass + dry-run with "live source fetch already in flight" and starving
+the parity feeder (so the cutover window went stale and never refreshed).
+
+Root: the lock is released in a `finally`, which is correct — but a `finally` cannot run
+while the awaited promise never settles. `HttpParitySource.prepare()` has per-page +
+between-page bounds, so the stall is either an `AbortSignal.timeout` that doesn't fire on a
+particular socket stall, or the un-timed compare step. Rather than chase the sub-cause, the
+fix adds a wall-clock **max-hold guard at the lock boundary** (`withMaxHold`, default 12m):
+the awaited fetch is raced against a timer, so the lock ALWAYS releases within a bounded
+time regardless of why the fetch stalled. Structure > willpower — the lock-holder enforces
+its own max-hold, independent of the injected fetch's internal timeouts.
+
+Files: `src/feedback-factory/cutoverReadiness.ts` (+ `tests/unit/cutover-readiness.test.ts`).
+
+## Decision-point inventory
+
+- `withMaxHold` — add — a private timeout-race helper. NO decision authority: it only
+  bounds how long the single-flight lock can be held; it never decides parity/integrity.
+- `maxLiveFetchMs` config (default 12m) — add — a backstop dial, set comfortably above
+  `HttpParitySource`'s 600s total budget so it only fires when that inner budget genuinely
+  failed (never a false-abort of a slow-but-working pass).
+
+## 1. Over-block
+
+The only thing the max-hold can "block" is a live fetch that exceeds 12 minutes. A healthy
+parity pass (~15s/page, 600s inner budget) is far under that, so a working pass is never
+aborted. Default chosen above the inner budget specifically to avoid over-block.
+
+## 2. Under-block
+
+If a stall somehow resolved at exactly the budget edge, the worst case is one wasted sweep
+(recorded nothing) and a retry next tick — strictly better than the pre-fix infinite hold.
+
+## 3. Level-of-abstraction fit
+
+Correct. The guard sits at the single-flight-lock boundary it protects, not inside the
+fetch (which already has its own, evidently-insufficient, internal timeouts). It is a
+backstop, not a replacement — the inner budgets still do the primary bounding.
+
+## 4. Signal vs authority compliance
+
+- [x] No block/allow authority. The change only ensures a lock releases; it never gates a
+  parity/integrity decision. `runParityPass` still records nothing on failure (a max-hold
+  timeout is a failed check = absence of evidence, exactly as a fetch error already was).
+
+## 5. Interactions
+
+- **Orphaned work:** when the max-hold fires, the abandoned fetch promise keeps running but
+  is harmless — its later settlement is ignored (control already left the `await`; the
+  `recordResult` line after it is never reached for the timed-out call), so it cannot
+  double-record or re-acquire the lock. It holds at most one connection until it aborts or
+  the process restarts — a bounded, acceptable cost versus an unreleasable lock.
+- **Double-fire:** none — `Promise.race` settles once; `clearTimeout` in `finally` disarms
+  the timer on the happy path.
+- **Clock:** the guard uses real `setTimeout` (NOT the injected `now()`), because the bug is
+  a promise that never settles in REAL time; an injected test clock must not disarm it.
+
+## 6. External surfaces
+
+- **Install base:** `maxLiveFetchMs` is a new OPTIONAL dep with a safe default → existing
+  agents get the backstop automatically on update, no config change required (Migration
+  Parity: the default IS the fix; nothing to migrate).
+- **Persistent state:** none new.
+- **Other agents / attention queue:** unchanged.
+
+## 7. Rollback cost
+
+Pure additive hardening. Back-out = revert the commit. No persistent-state cleanup; healthy
+passes behave identically with or without the guard.
+
+## Conclusion
+
+A wall-clock backstop on a single-flight lock, proven by a Tier-1 regression that a
+never-settling fetch now releases the lock (a later pass proceeds) instead of hanging it
+for ~85 minutes. No new authority; safe default; auto-applies to existing agents.
+
+## Evidence pointers
+
+- Tier 1: `tests/unit/cutover-readiness.test.ts` — 2 new (#948 regression for both
+  `runParityPass` and `runImportDryRunPass`: a never-settling fetch hits the max-hold,
+  returns `ok:false`, and the lock releases so the next pass records normally) + the 20
+  existing cutover tests still green through the new code path (22 total).
+- tsc `--noEmit` clean.


### PR DESCRIPTION
## ELI16 — a stuck "is the migration ready to cut over?" check can no longer freeze the checker; a slow check is abandoned cleanly and the next one runs

The feedback-migration "cutover readiness" checker only lets one live source fetch run at a time. A single fetch that hung (never finished, never errored) held that one-at-a-time lock forever — so every later check was refused as "already in flight" until the next server restart (~85 minutes observed). Now a check that exceeds a 12-minute wall-clock backstop is abandoned and the lock is freed, so the next check runs on schedule. Ships on by default; no configuration needed.

## What

Fixes #948. `CutoverReadiness`'s `liveFetchInFlight` single-flight lock (shared by the parity pass and the import dry-run) could be held indefinitely when the injected live fetch never settled. The lock is released in a `finally` — but a `finally` cannot run while the awaited promise never settles, so the lock stuck (~85 min in prod, `logs/server.log`), refusing every subsequent parity pass + dry-run and starving the parity-pass feeder (the cutover window then went stale and never refreshed).

Fix: `withMaxHold` races the awaited live fetch against a wall-clock timer (new optional `maxLiveFetchMs` dep, **default 12m**), so the lock ALWAYS releases within a bounded time regardless of the stall sub-cause. The default sits above `HttpParitySource`'s 600s total budget, so it only fires on a genuine stall, never on a slow-but-working pass. Failure semantics are unchanged: a max-hold timeout is a failed check = absence of evidence (records nothing, doesn't extend or reset the parity window).

## Causal autopsy (origin: latent)

The single-flight lock was added (CMT-1071) to stop concurrent full fetches piling onto a degraded source; its `finally`-release assumed the awaited fetch always settles. `HttpParitySource` later gained per-page + between-page budgets (CMT-1096) — but those bound neither a socket stall whose `AbortSignal.timeout` fails to fire, nor the un-timed compare step. That left a **latent never-settle path** where the `finally` never runs. The fix closes it at the lock boundary (defense-in-depth, independent of the fetch's internal timeouts) rather than chasing each sub-cause. Tooling note: `write-trace.mjs` has no `--causal-autopsy` flag, so the structured field was patched into the trace JSON manually — a small follow-up could add the flag.

## Tests

- **Tier 1 (2 new + 20 existing = 22 green):** `tests/unit/cutover-readiness.test.ts` — `runParityPass` AND `runImportDryRunPass`: a never-settling fetch now hits the max-hold, returns `ok:false`, and the lock RELEASES so the next pass is not refused as in-flight (it runs and records). The 20 existing cutover tests still pass through the new code path.
- `tsc --noEmit` clean. Scoped to one src file (`src/feedback-factory/cutoverReadiness.ts`); no new exported class.

🤖 Generated with [Claude Code](https://claude.com/claude-code)