### PR TITLE
fix(reaper): stale-commitment override — open commitment stops pinning a 24h-idle session

### DIFF
--- a/.instar/instar-dev-decisions/2026-06-07T03-50-03-245Z-reaper-stale-commitment-override.json
+++ b/.instar/instar-dev-decisions/2026-06-07T03-50-03-245Z-reaper-stale-commitment-override.json
@@ -1,0 +1,18 @@
+{
+  "ts": "2026-06-07T03:50:03.245Z",
+  "slug": "reaper-stale-commitment-override",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "safety-invariant proximity: src/monitoring/SessionReaper.ts matches session reaper"
+  ],
+  "belowFloor": true,
+  "files": 4,
+  "loc": 37,
+  "causalAutopsy": {
+    "origin": "latent",
+    "notes": "The open-commitment KEEP-guard has unconditionally protected commitment-bearing sessions since it was added — correct when sessions were short-lived and commitments closed promptly. As the fleet grew to dozens of multi-day sessions with commitments left open, the unconditional veto became the dominant blocker to idle-session reaping: 2026-06-06 grounding during a load-avg-30 overload (a SessionReaper dry-run on echo) showed 19 of 26 session-evaluations kept by open-commitment, many on sessions the user had not messaged in 26h. No prior PR regressed this; an always-on protection simply never had a staleness bound. This adds the bound (Justin's 'no message today -> reap' rule)."
+  },
+  "verdict": "pass"
+}

--- a/.instar/instar-dev-traces/2026-06-07T03-50-00-000Z-reaper-stale-commitment-override.json
+++ b/.instar/instar-dev-traces/2026-06-07T03-50-00-000Z-reaper-stale-commitment-override.json
@@ -1,0 +1,26 @@
+{
+    "slug": "reaper-stale-commitment-override",
+    "sessionId": "96c61421-860a-48f9-92b4-26328f5640f1",
+    "timestamp": "2026-06-07T03:50:00.000Z",
+    "artifactPath": "upgrades/side-effects/reaper-stale-commitment-override.md",
+    "artifactSha256": "5d327eb5a8ee90950496c291b6993aca3b2994454776e11438d540d973465fa4",
+    "coveredFiles": [
+        "src/core/ReapGuard.ts",
+        "src/monitoring/SessionReaper.ts",
+        "src/core/types.ts",
+        "src/config/ConfigDefaults.ts",
+        "tests/unit/reap-guard.test.ts",
+        "tests/unit/session-reaper.test.ts"
+    ],
+    "phase": "complete",
+    "tier": 1,
+    "tierReasoning": "Single guard-loosening in the stateless ReapGuard: the open-commitment KEEP-guard gains a staleness bound (staleCommitmentWindowMs, default 24h) so an abandoned commitment stops pinning an inactive session. One-directional (only widens reap-eligibility, never the reverse), only affects sessions that are BOTH commitment-pinned AND 24h-user-silent, reuses the existing recentUserMessage dep, no new I/O, no API route, no persistent state. The reaper it feeds is itself opt-in + dry-run-first, and the change was validated with the dry-run that surfaced the problem. Both sides of the new boundary unit-tested. No converged spec required for Tier 1.",
+    "eli16Path": "docs/eli16/reaper-stale-commitment-override.eli16.md",
+    "sideEffectsPath": "upgrades/side-effects/reaper-stale-commitment-override.md",
+    "causalAutopsy": {
+        "origin": "latent",
+        "notes": "The open-commitment KEEP-guard has unconditionally protected commitment-bearing sessions since it was added — correct when sessions were short-lived and commitments closed promptly. As the fleet grew to dozens of multi-day sessions with commitments left open, the unconditional veto became the dominant blocker to idle-session reaping: 2026-06-06 grounding during a load-avg-30 overload (a SessionReaper dry-run on echo) showed 19 of 26 session-evaluations kept by open-commitment, many on sessions the user had not messaged in 26h. No prior PR regressed this; an always-on protection simply never had a staleness bound. This adds the bound (Justin's 'no message today -> reap' rule)."
+    },
+    "secondPass": "not-required",
+    "reviewerConcurred": null
+}

--- a/docs/eli16/reaper-stale-commitment-override.eli16.md
+++ b/docs/eli16/reaper-stale-commitment-override.eli16.md
@@ -1,0 +1,32 @@
+# Reaper stale-commitment override — ELI16
+
+> The one-line version: idle sessions never got cleaned up because each one had a "promise" (commitment) left open on it, and the safety rule "never kill a session with an open promise" protected it forever — even after the user hadn't touched it in days. Now an open promise only protects a session while it's still recently active; after a day of silence the promise counts as abandoned and the session can be reaped.
+
+## The problem (found 2026-06-06 during a load-average-30 overload)
+
+The machine kept getting overloaded. Root: dozens of Claude sessions, some 26+ hours old, each holding a heavy MCP server stack, never cleaned up. Instar HAS an idle-session reaper — but a 15-minute dry-run showed it would reap NOTHING. The reason breakdown across 26 sessions: **19 were kept by "open-commitment"**. Almost every session had a commitment (a tracked promise to the user) still marked open, and the reaper's safety rule is "never reap a session with an open commitment." So a commitment left open for days on a silent session pinned that session alive forever.
+
+That guard is correct in spirit (don't kill a session mid-promise) but too blunt: a promise sitting open on a session the user hasn't messaged in a day is itself abandoned — it shouldn't keep a dead session running.
+
+## What this changes
+
+One guard, made activity-aware. The open-commitment KEEP-guard now protects a session **only if a user message arrived within a staleness window** (default 24h — the operator's "no message today → reap" rule). Past that window the commitment is treated as stale and no longer vetoes reaping; the session falls through to the normal activeness checks (active processes, recent output, etc.) like any other.
+
+- New option `staleCommitmentWindowMs` on `ReapGuard` (default 24h; `Infinity` restores the old always-protect behavior).
+- New config `monitoring.sessionReaper.staleCommitmentWindowMinutes` (default 1440).
+- Threaded through `SessionReaper` → `ReapGuard`; the terminate-time authority guard picks up the 24h default too.
+
+## Why it's safe
+
+- It only ever makes MORE sessions reap-eligible, and ONLY ones that are both (a) commitment-pinned AND (b) untouched by the user for 24h — i.e. genuinely abandoned. Every active session, every session with recent activity, and every session with a recent commitment stays exactly as protected as before.
+- It changes nothing else in the guard chain — recent-user-message, active-process, active-subagent, protected-set, pending-injection, etc. all still fire first/after exactly as before.
+- A session must STILL clear all the other activeness guards after this to actually be reaped; this only removes the stale-commitment veto.
+- Default 24h is conservative; set `Infinity` to disable entirely.
+
+## Honest scope
+
+This unblocks the reaper from doing its job; it's paired with enabling the reaper + MCP reaper + sleep controller (which ship opt-in and were off fleet-wide). Validated with the same dry-run that found the problem. Does not by itself reduce a live count — it changes which sessions become eligible; the reaper (in dry-run first, then live) acts on them.
+
+## Evidence
+
+`tests/unit/reap-guard.test.ts`: both sides of the new boundary — stale commitment (no message in window) falls through to reap-eligible; fresh commitment (message within window) still keeps as "open-commitment"; a custom window is honored; `Infinity` restores always-protect. Plus the existing open-commitment case updated to the window-aware mock. 19/19 green. `tsc --noEmit` clean.

--- a/src/config/ConfigDefaults.ts
+++ b/src/config/ConfigDefaults.ts
@@ -104,6 +104,8 @@ const SHARED_DEFAULTS: Record<string, unknown> = {
       maxReapsPerHour: 12,
       finalGraceSec: 60,
       protectOpenCommitments: true,
+      staleCommitmentWindowMinutes: 1440, // 24h — open commitment stops pinning an inactive session past a day
+
       // CPU pressure: overall tier = WORST of memory (free %) and CPU (1-min load
       // ÷ cores), so a CPU-bound box raises pressure even when memory is fine.
       cpuModerateLoadPerCore: 1.0,

--- a/src/core/ReapGuard.ts
+++ b/src/core/ReapGuard.ts
@@ -61,12 +61,23 @@ export interface ReapGuardOptions {
   recentUserWindowMs: number;
   /** Whether an open commitment on the bound topic blocks reaping. */
   protectOpenCommitments: boolean;
+  /**
+   * Staleness horizon for the open-commitment veto. An open commitment protects a
+   * session ONLY while there has been a user message within this window; past it
+   * the commitment is treated as abandoned and no longer blocks reaping. A
+   * commitment left open for days on a session the user hasn't touched is itself
+   * stale — without this bound it pins the dead session forever (the dominant
+   * keep-reason behind un-reaped idle sessions). Set to `Infinity` to restore the
+   * always-protect behavior. Must be ≥ `recentUserWindowMs`.
+   */
+  staleCommitmentWindowMs: number;
 }
 
 export const DEFAULT_REAP_GUARD_OPTIONS: ReapGuardOptions = {
   minAgeMs: 30 * 60_000,
   recentUserWindowMs: 30 * 60_000,
   protectOpenCommitments: true,
+  staleCommitmentWindowMs: 24 * 60 * 60_000, // 24h — "no user message today ⇒ commitment is stale"
 };
 
 export class ReapGuard {
@@ -125,9 +136,19 @@ export class ReapGuard {
     if (topicId != null && this.deps.recentUserMessage(topicId, this.opts.recentUserWindowMs)) {
       return keep('recent-user-message');
     }
-    // J. Open commitment on the bound topic.
+    // J. Open commitment on the bound topic — but only while still recently active.
+    //    Guard I above already kept on a message within `recentUserWindowMs`; this
+    //    widens the commitment veto to the longer `staleCommitmentWindowMs` horizon.
+    //    Past that horizon (no user message — Justin's "no message today" rule) the
+    //    commitment is abandoned and must NOT pin the dead session, so we fall
+    //    through to the activeness guards below. (2026-06-06 grounding: open-commitment
+    //    was the dominant keep-reason — 19/26 sessions, many 26h-idle — that blocked
+    //    all idle-session reaping.)
     if (this.opts.protectOpenCommitments && topicId != null && this.deps.activeCommitmentForTopic(topicId)) {
-      return keep('open-commitment');
+      if (this.deps.recentUserMessage(topicId, this.opts.staleCommitmentWindowMs)) {
+        return keep('open-commitment');
+      }
+      // else: stale commitment — do not veto; continue to activeness guards.
     }
     // K. Active subagent spawned by this session.
     if (this.deps.activeSubagentCount(session.claudeSessionId) > 0) return keep('active-subagent');

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -3560,6 +3560,11 @@ export interface MonitoringConfig {
     maxReapsPerHour?: number;
     finalGraceSec?: number;
     protectOpenCommitments?: boolean;
+    /** Staleness horizon (minutes) for the open-commitment veto: an open commitment
+     *  protects a session only while a user message arrived within this window; past
+     *  it the commitment is treated as abandoned and no longer blocks reaping.
+     *  Default 1440 (24h) — "no message today ⇒ reapable even with an open commitment". */
+    staleCommitmentWindowMinutes?: number;
     /** CPU pressure: 1-min load ÷ cores at/above which pressure is `moderate`
      *  (overall tier = worst of memory and CPU). Default 1.0. */
     cpuModerateLoadPerCore?: number;

--- a/src/monitoring/SessionReaper.ts
+++ b/src/monitoring/SessionReaper.ts
@@ -44,6 +44,9 @@ export interface SessionReaperConfig {
   maxReapsPerHour: number;
   finalGraceSec: number;
   protectOpenCommitments: boolean;
+  /** Staleness horizon (minutes) for the open-commitment veto; past it a commitment
+   *  no longer pins an inactive session. Default 1440 (24h) = "no message today". */
+  staleCommitmentWindowMinutes: number;
   /** CPU pressure: 1-min load ÷ cores at/above which pressure is `moderate`.
    *  The overall tier is the WORST of the memory tier and this CPU tier, so a
    *  CPU-bound box raises pressure even when free memory is fine. */
@@ -109,6 +112,7 @@ export const DEFAULT_SESSION_REAPER_CONFIG: SessionReaperConfig = {
   maxReapsPerHour: 12,
   finalGraceSec: 60,
   protectOpenCommitments: true,
+  staleCommitmentWindowMinutes: 1440, // 24h
   cpuModerateLoadPerCore: 1.0,
   cpuCriticalLoadPerCore: 1.5,
   cpuAwareActiveProcessKeep: false,
@@ -291,6 +295,7 @@ export class SessionReaper extends EventEmitter {
       minAgeMs: this.cfg.minAgeMinutes * 60_000,
       recentUserWindowMs: this.cfg.recentUserWindowMinutes * 60_000,
       protectOpenCommitments: this.cfg.protectOpenCommitments,
+      staleCommitmentWindowMs: this.cfg.staleCommitmentWindowMinutes * 60_000,
     });
   }
 

--- a/tests/unit/reap-guard.test.ts
+++ b/tests/unit/reap-guard.test.ts
@@ -53,7 +53,14 @@ describe('ReapGuard — each guard blocks with its reason', () => {
     ['pending-injection', { hasPendingInjection: () => true }],
     ['relay-lease', { isRelayLeaseActive: () => true }],
     ['recent-user-message', { topicBinding: () => 42, recentUserMessage: () => true }],
-    ['open-commitment', { topicBinding: () => 42, activeCommitmentForTopic: () => true }],
+    // Open commitment keeps ONLY while a message arrived within the staleness window
+    // (here: within 24h but NOT within the 30min recent-user window, so guard I above
+    // doesn't pre-empt it). A window-aware mock distinguishes the two horizons.
+    ['open-commitment', {
+      topicBinding: () => 42,
+      activeCommitmentForTopic: () => true,
+      recentUserMessage: (_t, withinMs) => withinMs >= 24 * 60 * 60_000,
+    }],
     ['active-subagent', { activeSubagentCount: () => 2 }],
     ['structural-long-work', { buildOrAutonomousActive: () => true }],
     ['active-process', { hasActiveProcesses: () => true }],
@@ -71,6 +78,54 @@ describe('ReapGuard — each guard blocks with its reason', () => {
     expect(new ReapGuard(clearDeps()).blockedReason(young)?.reason).toBe('spawn-grace');
     // A caller that wants no spawn grace (e.g. boot purge reaping a dead session) sets minAgeMs:0.
     expect(new ReapGuard(clearDeps(), { minAgeMs: 0 }).blockedReason(young)).toBeNull();
+  });
+});
+
+describe('ReapGuard — stale-commitment override (2026-06-06: open-commitment was pinning 26h-idle sessions)', () => {
+  // An open commitment + NO user message within the staleness window ⇒ the commitment
+  // is abandoned and must NOT keep the session. Other guards clear ⇒ reap-eligible.
+  it('does NOT keep on an open commitment when no user message within the stale window', () => {
+    const g = new ReapGuard(clearDeps({
+      topicBinding: () => 42,
+      activeCommitmentForTopic: () => true,
+      recentUserMessage: () => false, // no message in any window — the commitment is stale
+    }));
+    expect(g.blockedReason(mkSession())).toBeNull(); // falls through, reap-eligible
+  });
+
+  it('STILL keeps on an open commitment while a message is within the stale window (default 24h)', () => {
+    const g = new ReapGuard(clearDeps({
+      topicBinding: () => 42,
+      activeCommitmentForTopic: () => true,
+      recentUserMessage: (_t, withinMs) => withinMs >= 24 * 60 * 60_000, // active within 24h, not 30min
+    }));
+    expect(g.blockedReason(mkSession())?.reason).toBe('open-commitment');
+  });
+
+  it('honors a custom staleCommitmentWindowMs (a message just outside it ⇒ stale ⇒ reapable)', () => {
+    // Window = 2h. A message within 2h keeps; one only within 24h is now stale.
+    const within2h = new ReapGuard(clearDeps({
+      topicBinding: () => 42,
+      activeCommitmentForTopic: () => true,
+      recentUserMessage: (_t, withinMs) => withinMs >= 2 * 60 * 60_000,
+    }), { staleCommitmentWindowMs: 2 * 60 * 60_000 });
+    expect(within2h.blockedReason(mkSession())?.reason).toBe('open-commitment');
+
+    const only24h = new ReapGuard(clearDeps({
+      topicBinding: () => 42,
+      activeCommitmentForTopic: () => true,
+      recentUserMessage: (_t, withinMs) => withinMs >= 24 * 60 * 60_000, // not within 2h
+    }), { staleCommitmentWindowMs: 2 * 60 * 60_000 });
+    expect(only24h.blockedReason(mkSession())).toBeNull();
+  });
+
+  it('Infinity restores always-protect (any open commitment keeps, regardless of activity)', () => {
+    const g = new ReapGuard(clearDeps({
+      topicBinding: () => 42,
+      activeCommitmentForTopic: () => true,
+      recentUserMessage: (_t, withinMs) => Number.isFinite(withinMs) ? false : true,
+    }), { staleCommitmentWindowMs: Infinity });
+    expect(g.blockedReason(mkSession())?.reason).toBe('open-commitment');
   });
 });
 

--- a/tests/unit/session-reaper.test.ts
+++ b/tests/unit/session-reaper.test.ts
@@ -113,7 +113,9 @@ describe('SessionReaper — protect-gates each force KEEP', () => {
     ['active subagent', { activeSubagentCount: () => 1 }, 'active-subagent'],
     ['build/autonomous', { buildOrAutonomousActive: () => true }, 'structural-long-work'],
     ['recent user msg', { topicBinding: () => 42, recentUserMessage: () => true }, 'recent-user-message'],
-    ['open commitment', { topicBinding: () => 42, activeCommitmentForTopic: () => true }, 'open-commitment'],
+    // Open commitment keeps only while a message is within the staleness window (24h)
+    // but outside the 30min recent-user window — a window-aware mock distinguishes them.
+    ['open commitment', { topicBinding: () => 42, activeCommitmentForTopic: () => true, recentUserMessage: (_t, withinMs) => withinMs >= 24 * 60 * 60_000 }, 'open-commitment'],
   ];
   for (const [name, deps, expectedGate] of cases) {
     it(`KEEPs on ${name}`, () => {

--- a/upgrades/next/reaper-stale-commitment-override.md
+++ b/upgrades/next/reaper-stale-commitment-override.md
@@ -1,0 +1,47 @@
+<!-- bump: patch -->
+<!-- change_type: fix -->
+
+## What Changed
+
+The idle-session reaper's "never reap a session with an open commitment" safety
+guard is now activity-aware. An open commitment protects a session only while a
+user message arrived within a staleness window (default 24h); past that the
+commitment is treated as abandoned and no longer blocks reaping. Found 2026-06-06
+during a load-avg-30 overload: a reaper dry-run would have reaped NOTHING because
+19 of 26 sessions were pinned by `open-commitment`, many on sessions untouched for
+26h. The unconditional veto was the dominant blocker to idle-session cleanup.
+
+New `staleCommitmentWindowMs` on `ReapGuard` (default 24h; `Infinity` = old
+always-protect) + `monitoring.sessionReaper.staleCommitmentWindowMinutes`
+(default 1440), threaded through to the terminate-time authority guard too.
+
+## What to Tell Your User
+
+Nothing required — internal reaper policy, and the reaper itself remains opt-in.
+For operators turning the reaper on: idle sessions that have an open commitment
+but no user message for 24h+ will now become reap-eligible (they previously stayed
+alive forever). Active sessions and recently-touched sessions are unaffected.
+
+## Summary of New Capabilities
+
+- `ReapGuard.staleCommitmentWindowMs` — bounds the open-commitment KEEP-guard so a
+  stale commitment stops pinning an inactive session. Default 24h; `Infinity`
+  restores always-protect.
+- `sessionReaper.staleCommitmentWindowMinutes` config (default 1440). Internal
+  reaper policy; no agent-facing API/CLI surface.
+
+## Scope (honest)
+
+UNBLOCKS the reaper — it changes which sessions are eligible, it does not by itself
+kill anything (the reaper is opt-in + dry-run-first). Pairs with enabling
+sessionReaper + mcpProcessReaper + SleepController (which ship opt-in and were off
+fleet-wide). Does NOT auto-expire the commitments themselves (separate follow-up);
+it only stops a stale commitment from vetoing a reap.
+
+## Evidence
+
+`tests/unit/reap-guard.test.ts` + `tests/unit/session-reaper.test.ts`: both sides
+of the boundary (stale commitment ⇒ falls through to reap-eligible; fresh
+commitment within window ⇒ still keeps; custom window honored; `Infinity` restores
+always-protect; existing open-commitment cases updated to window-aware mocks).
+49/49 green. `tsc --noEmit` clean.

--- a/upgrades/side-effects/reaper-stale-commitment-override.md
+++ b/upgrades/side-effects/reaper-stale-commitment-override.md
@@ -1,0 +1,46 @@
+# Side-Effects Review - Reaper stale-commitment override
+
+**Version / slug:** `reaper-stale-commitment-override`
+**Date:** `2026-06-06`
+**Author:** `echo`
+**Second-pass reviewer:** `not required (Tier 1)`
+
+## Summary of the change
+
+The `ReapGuard` open-commitment KEEP-guard now protects a session only while a user message arrived within a staleness window (`staleCommitmentWindowMs`, default 24h). Past that window the open commitment is treated as abandoned and no longer vetoes reaping. Surfaced because a 2026-06-06 dry-run (during a load-avg-30 overload investigation) showed the idle-session reaper would reap NOTHING — 19 of 26 sessions were pinned by `open-commitment`, many on sessions the user hadn't touched in 26h. Adds `staleCommitmentWindowMs` to `ReapGuardOptions` (+ `DEFAULT_REAP_GUARD_OPTIONS`), `staleCommitmentWindowMinutes` to `SessionReaperConfig` + `ConfigDefaults` + the `InstarConfig` type, threaded `SessionReaper`→`ReapGuard`.
+
+## Decision-point inventory
+
+- `ReapGuard.evaluate()` guard J (open-commitment): now gated on `recentUserMessage(topicId, staleCommitmentWindowMs)`. Fresh ⇒ keep('open-commitment'); stale ⇒ fall through to the activeness guards (unchanged).
+- `ReapGuardOptions.staleCommitmentWindowMs` (new; default 24h; `Infinity` = old always-protect).
+- `SessionReaperConfig.staleCommitmentWindowMinutes` (new; default 1440) → mapped to ms in the `SessionReaper` constructor's `new ReapGuard(...)`.
+- `ConfigDefaults` + `types.ts` `sessionReaper` block gain `staleCommitmentWindowMinutes`.
+
+## 1. Behavior change / gating
+
+This is a guard-loosening, in ONE direction only: it makes MORE sessions reap-ELIGIBLE, and only those that are BOTH commitment-pinned AND have had no user message for ≥24h. It never makes a session that was reapable into kept. Every other KEEP-guard (protected, spawn-grace, recovery, pending-injection, relay-lease, recent-user-message, active-subagent, structural-long-work, active-process, main-process) is unchanged and still fires in the same order. A session must STILL clear all remaining activeness guards (and, in the reaper, transcript-growth + positive-idle + confirmObservations) before it is actually reaped — this only removes the stale-commitment veto.
+
+## 2. Over/under-signal
+
+The risk direction is OVER-reaping a session whose commitment is genuinely active but whose user simply hasn't messaged in 24h. Mitigations: (a) 24h is a long, conservative horizon — Justin's explicit "no message today" intent; (b) the session must additionally have NO active processes, NO active subagent, NO recent transcript growth, and be positively idle to actually reap; (c) `Infinity` disables entirely; (d) the terminate-time authority guard uses the same default so a single chokepoint enforces it. UNDER-signal (failing to reap) is the prior behavior being fixed.
+
+## 3. Blast radius
+
+Pure in-memory guard logic; no I/O, no new deps (reuses the existing `recentUserMessage` dep with a longer window). Affects only the reap-eligibility decision for commitment-pinned, 24h-silent sessions. Ships behind the sessionReaper (which is itself opt-in + dry-run-first). No API route, no persistent state, no migration of data.
+
+## 4. Failure modes
+
+`recentUserMessage` throwing is already caught by `blockedReason()`'s try/catch → KEEP ('guard-error'), so a signal failure fails SAFE (never reaps). `staleCommitmentWindowMs` defaults are always present (DEFAULT_REAP_GUARD_OPTIONS / DEFAULT_SESSION_REAPER_CONFIG), so an old config missing the field gets 24h, not 0. `Infinity` is honored (any finite withinMs < Infinity ⇒ a correct mock keeps).
+
+## 5. Migration parity
+
+`staleCommitmentWindowMinutes` is an OPTIONAL config field with a code default (1440) in both `DEFAULT_SESSION_REAPER_CONFIG` and `ConfigDefaults`, so existing agents whose config omits it get the 24h behavior automatically — no `PostUpdateMigrator` entry needed (absence ⇒ default, the established pattern for sessionReaper sub-fields). No agent-installed file (hooks/skills/CLAUDE.md) changes; this is internal reaper policy with no agent-facing surface. The reaper remains opt-in (enabled:false default), so this changes nothing until an operator enables it.
+
+## 6. Scope honesty (what this is NOT)
+
+- This UNBLOCKS the reaper; it does not by itself reduce a live process count. It changes which sessions are eligible; the reaper (dry-run first, then live) acts on them. It's paired with enabling sessionReaper + mcpProcessReaper + SleepController (which ship opt-in and were off fleet-wide — the 2026-06-06 finding).
+- It does NOT touch the commitments themselves (no auto-expiry of stale commitments — that's a separate follow-up). It only stops a stale commitment from VETOING a reap.
+
+## 7. Causal autopsy
+
+Origin: **latent**. The open-commitment guard has unconditionally protected commitment-bearing sessions since it was added; that was correct when sessions were short-lived and commitments closed promptly. As the fleet grew to dozens of multi-day sessions with commitments left open, the unconditional veto became the dominant blocker to idle-session reaping (grounded 2026-06-06: 19/26 keeps were open-commitment, many 26h-idle). No prior PR regressed it; an always-on protection simply never had a staleness bound. This adds the bound.


### PR DESCRIPTION
## ELI16

Idle sessions never got cleaned up because each one had a "promise" (commitment) left open on it, and the reaper's safety rule "never kill a session with an open promise" protected it forever — even after the user hadn't touched it in days. A 2026-06-06 load-average-30 overload investigation made this concrete: a SessionReaper dry-run on Echo would have reaped NOTHING, and the reason breakdown across 26 sessions was **19 kept by "open-commitment"**, many on sessions idle for 26 hours. The guard is right in spirit (don't kill a session mid-promise) but too blunt: a promise sitting open on a session the user hasn't messaged in a day is itself abandoned and shouldn't pin a dead session alive. This change makes that one guard activity-aware — an open commitment protects a session only while a user message arrived within a staleness window (default 24h, the operator's "no message today → reap" rule); past it the commitment is stale and the session falls through to the normal activeness checks like any other. It only ever makes MORE sessions reap-eligible, and only ones that are both commitment-pinned AND 24h-user-silent; every active or recently-touched session stays exactly as protected as before.

## The finding (grounded)

15-min `SessionReaper` dry-run on echo → 26 session-evals, **0 reap-eligible**. keep-reason breakdown: `open-commitment:19` (dominant), active-process:4, spawn-grace:2, pending-injection:1. The unconditional open-commitment veto was the dominant blocker to idle-session cleanup → dozens of multi-day sessions × heavy MCP stacks accumulating → load 21-30.

## The change

- `ReapGuard` guard J (open-commitment) now keeps only if `recentUserMessage(topicId, staleCommitmentWindowMs)`; else falls through to the activeness guards.
- New `ReapGuardOptions.staleCommitmentWindowMs` (default 24h; `Infinity` = old always-protect) + `DEFAULT_REAP_GUARD_OPTIONS`.
- New `monitoring.sessionReaper.staleCommitmentWindowMinutes` (default 1440) in `SessionReaperConfig`, `ConfigDefaults`, and the `InstarConfig` type; threaded `SessionReaper`→`ReapGuard`. The terminate-time authority guard inherits the 24h default.

## Safety

One-directional (only widens reap-eligibility). A session must STILL clear every other guard (protected, recovery, pending-injection, recent-user, active-subagent, structural-long-work, active-process) plus the reaper's transcript-growth + positive-idle + confirmObservations before it's actually reaped. `recentUserMessage` throwing fails safe (KEEP via the existing try/catch). The reaper is itself opt-in + dry-run-first. `Infinity` disables the bound entirely.

## Scope (honest)

This UNBLOCKS the reaper — it changes which sessions are eligible, it does not by itself kill anything. Pairs with enabling sessionReaper + mcpProcessReaper + SleepController (which ship opt-in and were off fleet-wide — the root finding). Does NOT auto-expire the commitments themselves (separate follow-up); it only stops a stale commitment from vetoing a reap.

## Tests / evidence

`tests/unit/reap-guard.test.ts` + `tests/unit/session-reaper.test.ts`: both sides of the boundary (stale commitment → reap-eligible; fresh commitment within window → still keeps; custom window honored; `Infinity` restores always-protect; existing open-commitment cases updated to window-aware mocks). 49/49 green. `tsc --noEmit` clean. causalAutopsy: **latent**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)