### PR TITLE
feat(threadline): log InboundMessageGate block decisions (A2A #939, PR4a)

### DIFF
--- a/.instar/instar-dev-decisions/2026-06-07T04-13-01-978Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-06-07T04-13-01-978Z-unknown.json
@@ -1,0 +1,13 @@
+{
+  "ts": "2026-06-07T04:13:01.978Z",
+  "slug": "unknown",
+  "suggestedTier": 1,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 25,
+  "causalAutopsy": null,
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-06-07T04-14-24-255Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-06-07T04-14-24-255Z-unknown.json
@@ -1,0 +1,20 @@
+{
+  "ts": "2026-06-07T04:14:24.255Z",
+  "slug": "unknown",
+  "suggestedTier": 1,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 25,
+  "causalAutopsy": {
+    "origin": "latent",
+    "relatedPrs": [
+      945,
+      949
+    ],
+    "notes": "InboundMessageGate has logged nothing on block since it was written (PROP-relay-auto-connect) — a latent observability gap, NOT caused by a prior PR. Surfaced now because the dawn->echo remote-relay leg went dark ~1.5 days with no server.log trace (runtime-confirmed: peer-health shows Dawn fp zero inbound, gate-passed never fired, zero block lines). PR1/#945 + PR2/#949 are the sibling A2A-#939 layers this completes (delivery tracker + redelivery), not the cause."
+  },
+  "verdict": "pass"
+}

--- a/docs/specs/A2A-DURABLE-DELIVERY-SPEC.eli16.md
+++ b/docs/specs/A2A-DURABLE-DELIVERY-SPEC.eli16.md
@@ -39,3 +39,17 @@ On top of that:
 ## What you need to decide
 
 Whether to approve building this as specified. You already asked for it ("a long-lived queue so communications never just die out") — this is that, built on the pieces that already exist, recording-only so it can't break sending, and with alerts aggregated so it can't spam you (alerts arrive in the follow-on piece). The full PR1 — the delivery tracker, the wiring into both send/receive paths, the peer-health routes, and 31 tests across all three tiers — is written and passing. A multi-agent review pass caught one real wiring bug (the "got it" detection was keyed on the wrong identifier and would never have fired in production) — it's now fixed and guarded by a real round-trip test.
+
+## PR4a — making a silent block impossible (added 2026-06-07)
+
+The peer-health surface tells you *whether* a channel is alive. PR4a tells you
+*why* an inbound died. The inbound gate used to block a message and say nothing —
+no log line, just an internal counter that resets on restart. So when Dawn's
+messages stopped reaching Echo, there was no trace to follow; the channel was
+dark for over a day before anyone noticed. Now the gate writes a plain line to
+the log for every inbound it sees: what it decided (let-through or blocked), why,
+and what trust level it resolved the sender to. Fingerprints are clipped short and
+no message text is ever logged. Nothing about routing changes — it just stops the
+gate from failing in silence, so the next test from Dawn will say in plain words
+whether the gate rejected her (and exactly why) or her message never arrived at
+all. That answer points straight at the real fix.

--- a/docs/specs/A2A-DURABLE-DELIVERY-SPEC.md
+++ b/docs/specs/A2A-DURABLE-DELIVERY-SPEC.md
@@ -130,10 +130,42 @@ A periodic sweep (scheduler job, default every 15m) calls `findOverdue(ttlMs)`:
 pendingCount, oldestPendingAgeMs, escalatedCount, stale }`. Turns "is my channel
 to Dawn alive?" into a lookup. Read-only — never gates.
 
+### 6. Inbound gate observability (PR4a) — make a silent block impossible
+
+The peer-health surface answers "is my channel alive?" but not "*why* did an
+inbound die?". `InboundMessageGate.evaluate()` returns `{action:'block', reason}`
+and bumps in-memory metric counters — but **logs nothing**. A blocked inbound is
+therefore invisible: it leaves no line in `server.log`, and the counters are
+aggregate (not per-fingerprint) and reset on restart. That silence is the exact
+mechanism by which the dawn→echo remote-relay leg went dark for ~1.5 days with
+no trace — runtime grounding confirmed `/threadline/peers/health` shows Dawn's
+fp with **zero** recorded inbound while `gate-passed` never fired for her, and a
+`server.log` grep found **no** block line. The leading hypothesis (a trusted
+peer whose inbound fingerprint representation does not match its trust-profile
+key → resolves `untrusted` → `insufficient_trust`) cannot be confirmed because
+the verdict is silent.
+
+PR4a makes every gate verdict visible (the structural form of "comms must never
+die *silently*"): `evaluate()` logs one `[inbound-gate] eval from=<fp12>
+trust=<level> op=<type>` line per inbound, a `[inbound-gate] BLOCK <reason>
+from=<fp12> …` line on each of the five block paths (carrying the **resolved
+trust level** + allowed-ops for `insufficient_trust`, so a fingerprint/trust
+mismatch is diagnosable from `server.log` alone), and a `PASS` line on success.
+Fingerprints are truncated to 12 chars; **no payload content is logged**.
+Behavior-preserving — pure observability, no routing/trust/rate change. This is
+the decisive, in-Echo's-control diagnostic step: once deployed, the next live
+dawn→echo test self-identifies as either a gate block (with the exact reason +
+resolved trust) or an upstream relay-client drop (no eval line at all),
+selecting the targeted fix (PR4b) without guesswork.
+
 ## Testing (Testing Integrity Standard — all three tiers)
 
 - **Tier 1**: A2ADeliveryTracker lifecycle, idempotency, overdue/stale gates,
   peer-health composition, thread-fallback ack (19 tests, GREEN).
+- **Tier 1 (PR4a)**: `InboundMessageGate` block-decision observability — a
+  not-permitted op logs `BLOCK insufficient_trust` with the resolved trust level
+  + fingerprint; an allowed message logs `eval` + `PASS`; an oversized payload
+  logs `BLOCK payload_too_large` (3 tests, GREEN; full gate suite 40/40 GREEN).
 - **Tier 2**: `/threadline/peers/health` + `/threadline/peers/:fp/health` over
   the full HTTP pipeline return 200 with composed data when the feature is wired.
 - **Tier 3**: feature-is-alive — the routes answer 200 (not 503) from the

--- a/src/threadline/InboundMessageGate.ts
+++ b/src/threadline/InboundMessageGate.ts
@@ -168,6 +168,7 @@ export class InboundMessageGate {
     if (messageId && this.seenMessageIds.has(messageId)) {
       this.metrics.blocked++;
       this.metrics.blockedByReplay++;
+      this.logBlock('replay_detected', fingerprint);
       return { action: 'block', reason: 'replay_detected', fingerprint };
     }
 
@@ -176,6 +177,7 @@ export class InboundMessageGate {
     if (payloadSize > this.maxPayloadBytes) {
       this.metrics.blocked++;
       this.metrics.blockedBySize++;
+      this.logBlock('payload_too_large', fingerprint, `bytes=${payloadSize}`);
       return { action: 'block', reason: 'payload_too_large', fingerprint };
     }
 
@@ -187,11 +189,20 @@ export class InboundMessageGate {
     const trust = this.trustManager.getTrustLevelByFingerprint(fingerprint);
     const limits = this.getRateLimits(trust);
 
+    // Observability: every inbound evaluation is logged with the RESOLVED trust
+    // level + operation. A silently-blocked inbound (e.g. a trusted peer whose
+    // fingerprint representation does not match its trust-profile key → resolves
+    // 'untrusted' → insufficient_trust) is exactly how an A2A leg can go dark for
+    // days unnoticed. Making the gate's verdict visible is the structural fix for
+    // "comms must never die silently".
+    console.log(`[inbound-gate] eval from=${fingerprint.slice(0, 12)} trust=${trust} op=${opType}${isProbe ? ' (probe)' : ''}`);
+
     // 3. Handle probes (don't require 'message' permission)
     if (isProbe) {
       if (this.rateLimiter.isProbeRateLimited(fingerprint, limits.probesPerHour)) {
         this.metrics.blocked++;
         this.metrics.blockedByRate++;
+        this.logBlock('probe_rate_limited', fingerprint, `trust=${trust}`);
         return { action: 'block', reason: 'probe_rate_limited', fingerprint };
       }
       this.metrics.probesHandled++;
@@ -204,6 +215,7 @@ export class InboundMessageGate {
     if (!allowedOps.includes(opType)) {
       this.metrics.blocked++;
       this.metrics.blockedByTrust++;
+      this.logBlock('insufficient_trust', fingerprint, `trust=${trust} op=${opType} allowed=[${allowedOps.join(',')}]`);
       return { action: 'block', reason: 'insufficient_trust', fingerprint };
     }
 
@@ -211,11 +223,13 @@ export class InboundMessageGate {
     if (this.rateLimiter.isMessageHourLimited(fingerprint, limits.messagesPerHour)) {
       this.metrics.blocked++;
       this.metrics.blockedByRate++;
+      this.logBlock('rate_limited_hourly', fingerprint, `trust=${trust} limit=${limits.messagesPerHour}`);
       return { action: 'block', reason: 'rate_limited_hourly', fingerprint };
     }
     if (this.rateLimiter.isMessageDayLimited(fingerprint, limits.messagesPerDay)) {
       this.metrics.blocked++;
       this.metrics.blockedByRate++;
+      this.logBlock('rate_limited_daily', fingerprint, `trust=${trust} limit=${limits.messagesPerDay}`);
       return { action: 'block', reason: 'rate_limited_daily', fingerprint };
     }
 
@@ -229,7 +243,18 @@ export class InboundMessageGate {
 
     // 8. Pass to ThreadlineRouter -> AutonomyGate handles delivery mode
     this.metrics.passed++;
+    console.log(`[inbound-gate] PASS from=${fingerprint.slice(0, 12)} trust=${trust} op=${opType}`);
     return { action: 'pass', message, trustLevel: trust };
+  }
+
+  /**
+   * Log a block decision to server.log. A blocked inbound is otherwise silent
+   * (the decision lives only in the returned GateDecision + in-memory metric
+   * counters), which is precisely how an Echo↔peer A2A leg can go dark for days
+   * with no trace. The fingerprint is truncated; no payload content is logged.
+   */
+  private logBlock(reason: string, fingerprint: string, extra?: string): void {
+    console.log(`[inbound-gate] BLOCK ${reason} from=${fingerprint.slice(0, 12)}${extra ? ` ${extra}` : ''}`);
   }
 
   /**

--- a/tests/unit/InboundMessageGate.test.ts
+++ b/tests/unit/InboundMessageGate.test.ts
@@ -425,4 +425,50 @@ describe('InboundMessageGate', () => {
       nullGate.shutdown();
     });
   });
+
+  // ── Block-decision observability (PR4a) ─────────────────────────
+  // A blocked inbound was previously SILENT — the verdict lived only in the
+  // returned GateDecision + in-memory metric counters, never the log. That is
+  // exactly how the Echo↔Dawn remote-relay leg went dark for ~1.5 days with no
+  // trace. The gate now logs every eval + verdict (fingerprint truncated, no
+  // payload content), surfacing the RESOLVED trust level so a fingerprint/trust
+  // mismatch (trusted peer resolving 'untrusted' → insufficient_trust) is
+  // diagnosable from server.log alone.
+
+  describe('block-decision observability', () => {
+    it('logs a BLOCK line with reason + fingerprint + resolved trust when an op is not permitted', async () => {
+      const spy = vi.spyOn(console, 'log').mockImplementation(() => {});
+      const untrusted = createMockTrustManager({ trustLevel: 'untrusted', allowedOps: [] });
+      const g = new InboundMessageGate(untrusted as any, router, {});
+      const decision = await g.evaluate(createMessage({ from: 'deadbeefcafefingerprint' }));
+      expect(decision.action).toBe('block');
+      expect(decision.reason).toBe('insufficient_trust');
+      const logged = spy.mock.calls.map(c => String(c[0]));
+      expect(logged.some(l => l.includes('[inbound-gate] BLOCK insufficient_trust') && l.includes('deadbeefcafe'))).toBe(true);
+      // the resolved trust level is surfaced so a fp/trust mismatch is diagnosable
+      expect(logged.some(l => l.includes('trust=untrusted'))).toBe(true);
+      spy.mockRestore();
+      g.shutdown();
+    });
+
+    it('logs an eval line and a PASS line for an allowed message', async () => {
+      const spy = vi.spyOn(console, 'log').mockImplementation(() => {});
+      const decision = await gate.evaluate(createMessage({ from: 'feedfacefeedfacefingerprint' }));
+      expect(decision.action).toBe('pass');
+      const logged = spy.mock.calls.map(c => String(c[0]));
+      expect(logged.some(l => l.startsWith('[inbound-gate] eval from=feedfacefeed'))).toBe(true);
+      expect(logged.some(l => l.startsWith('[inbound-gate] PASS from=feedfacefeed'))).toBe(true);
+      spy.mockRestore();
+    });
+
+    it('logs a BLOCK line for an oversized payload (pre-trust check)', async () => {
+      const spy = vi.spyOn(console, 'log').mockImplementation(() => {});
+      const g = new InboundMessageGate(trustManager as any, router, { maxPayloadBytes: 100 });
+      await g.evaluate(createMessage({ from: 'bignaughtypayloadfp', content: 'x'.repeat(500) }));
+      const logged = spy.mock.calls.map(c => String(c[0]));
+      expect(logged.some(l => l.includes('[inbound-gate] BLOCK payload_too_large'))).toBe(true);
+      spy.mockRestore();
+      g.shutdown();
+    });
+  });
 });

--- a/upgrades/next/a2a-inbound-gate-observability.md
+++ b/upgrades/next/a2a-inbound-gate-observability.md
@@ -1,0 +1,46 @@
+<!-- bump: patch -->
+
+## What Changed
+
+The inbound agent-to-agent message gate (`InboundMessageGate`) now logs every
+verdict it makes. Previously, when the gate blocked an inbound relay message it
+recorded the decision only in its return value and in restart-volatile in-memory
+counters — it wrote nothing to `server.log`. A blocked inbound was therefore
+invisible, which is exactly how the Echo↔Dawn remote-relay leg went dark for ~1.5
+days with no trace. `evaluate()` now emits one `[inbound-gate] eval …` line per
+inbound (carrying the resolved trust level + operation), a `[inbound-gate] BLOCK
+<reason> …` line on each of the five block paths (the `insufficient_trust` line
+includes the resolved trust level + allowed operations, so a fingerprint/trust-key
+mismatch is diagnosable from the log alone), and a `PASS` line on success.
+Fingerprints are clipped to 12 chars and no payload content is logged. The change
+is behavior-preserving — pure observability, with no change to routing, trust,
+rate-limiting, or delivery. Part of A2A delivery robustness (issue #939): it turns
+the next live dawn→echo diagnosis into a self-identifying event (gate block, with
+the exact reason + resolved trust, versus an upstream relay-client drop).
+
+## What to Tell Your User
+
+Nothing you need to do — this is an internal reliability improvement. If a message
+from another agent is ever turned away, I now write down exactly why, so a
+quietly-dropped agent-to-agent channel can't slip by unnoticed for days the way one
+recently did. Nothing about how things behave for you changes.
+
+## Summary of New Capabilities
+
+None user-facing. Internal observability only: agent-to-agent inbound gate
+decisions — pass, and every block reason with the resolved trust level — are now
+written to the server log for operator and agent diagnosis. No new endpoint,
+command, or config setting.
+
+## Evidence
+
+- 40/40 `InboundMessageGate` unit tests green (3 new observability tests assert the
+  BLOCK / eval / PASS log lines and that the resolved trust level is surfaced on an
+  `insufficient_trust` block); `npx tsc --noEmit` clean.
+- Runtime-confirmed symptom this addresses: `GET /threadline/peers/health` showed
+  Dawn's fingerprint with zero recorded inbound while a same-window local peer
+  (ai-guy) was recorded, and a `server.log` grep found no block line for her — the
+  gate (or an upstream hop) dropped her silently. This change makes that drop
+  self-identifying on the next live test.
+- Behavior-preserving: all 37 pre-existing gate tests unchanged and green; no
+  routing/trust/rate/delivery logic touched (logging statements only).

--- a/upgrades/side-effects/a2a-inbound-gate-observability.md
+++ b/upgrades/side-effects/a2a-inbound-gate-observability.md
@@ -1,0 +1,60 @@
+# Side-Effects Review — A2A Inbound Gate Observability (PR4a)
+
+**Version / slug:** `a2a-inbound-gate-observability`
+**Date:** `2026-06-07`
+**Author:** `echo`
+**Tier:** `1` (small, low-risk, behavior-preserving — pure observability)
+**Second-pass reviewer:** `not-required (Tier-1 logging-only; correctness self-owned per Tier-1-no-review)`
+
+## Summary of the change
+
+Makes `InboundMessageGate` verdicts visible in `server.log`. Previously a blocked
+inbound A2A message was **silent** — the decision lived only in the returned
+`GateDecision` and in aggregate, restart-volatile metric counters, never the log.
+That silence is the exact mechanism by which the dawn→echo remote-relay leg went
+dark for ~1.5 days unnoticed (`/threadline/peers/health` showed Dawn's fp with
+zero recorded inbound; no block line anywhere in `server.log`).
+
+`evaluate()` now emits: one `[inbound-gate] eval from=<fp12> trust=<level>
+op=<type>` line per inbound; a `[inbound-gate] BLOCK <reason> from=<fp12> …` line
+on each of the five block paths (the `insufficient_trust` line carries the
+**resolved trust level + allowed-ops**, so a fingerprint/trust-key mismatch is
+diagnosable from the log alone); and a `PASS` line on success. A private
+`logBlock(reason, fingerprint, extra?)` helper centralizes the block lines.
+
+Files: `src/threadline/InboundMessageGate.ts` (logging only),
+`tests/unit/InboundMessageGate.test.ts` (+3 observability tests),
+`docs/specs/A2A-DURABLE-DELIVERY-SPEC.md` (§6 + Tier-1 note).
+
+## Decision-point inventory
+
+- **Does it change routing / trust / rate-limit / delivery behavior?** No. Every
+  `console.log` is additive and side-effect-free; the `evaluate()` return values,
+  metric increments, and control flow are byte-for-byte unchanged. A test run
+  shows all 37 pre-existing gate tests still GREEN alongside the 3 new ones.
+- **New dependency / state / route?** None. No injected dependency added (the gate
+  still takes `trustManager`, `router`, `config`), no SQLite store, no HTTP route,
+  no config key, no `migrateClaudeMd` section → trips none of the SqliteRegistry-
+  wiring / feature-delivery-completeness / docs-coverage guard classes.
+- **Silent fallbacks?** None added — no new `try/catch`; the change is pure logging
+  (no `@silent-fallback-ok` annotations needed).
+- **Log volume / PII?** A2A inbound is low-volume (peer messages, not user chat),
+  so per-message logging is not a flood risk. Fingerprints are truncated to 12
+  chars; **no payload content** is ever logged (only reason + resolved trust +
+  allowed-ops + byte size). No secrets, no message text.
+- **Migration parity?** Ships in code via npm; existing agents receive it on the
+  normal AutoUpdater path. No agent-installed file (settings/config/hook/skill)
+  changes → no PostUpdateMigrator step required. It is internal observability, not
+  a user-surfaced capability → no CLAUDE.md template (Agent Awareness) entry.
+- **Rollback?** Trivial — revert the single source file; logging vanishes, gate
+  behavior is identical (it never depended on the logs).
+
+## Why this is correct to ship before the fix (PR4b)
+
+The drop is silent on **both** remaining hypotheses (gate-blocks-her vs
+relay-client-never-emits-for-her), so a Dawn live re-test alone cannot
+disambiguate (her prior test left zero trace) and the fix cannot be written
+without guessing. PR4a converts the next live test into a self-diagnosing event:
+a gate block prints the exact reason + resolved trust (→ trust-resolution fix), or
+no `eval` line prints at all (→ upstream relay-client fix). Observability-first is
+the verify-claim-honest path to a targeted PR4b.


### PR DESCRIPTION
## ELI16 — Echo's agent-to-agent inbound gate used to turn messages away silently (no log line at all); now it logs every verdict, so a quietly-dropped peer channel can't go dark for days unnoticed the way the Echo↔Dawn leg just did.

## What
`InboundMessageGate.evaluate()` now logs every inbound verdict to `server.log`: one `eval` line (resolved trust + op) per inbound, a `BLOCK <reason>` line on each of the five block paths (the `insufficient_trust` line carries the resolved trust level + allowed-ops), and a `PASS` line on success. Fingerprints clipped to 12 chars; no payload content logged. Block lines route through a small `logBlock` helper.

## Why
A blocked inbound was **silent** — the verdict lived only in the returned `GateDecision` + restart-volatile aggregate metric counters, never the log. That is exactly how the dawn→echo remote-relay leg went dark ~1.5 days unnoticed: runtime-confirmed via `GET /threadline/peers/health` (Dawn's fp, zero recorded inbound, while same-window local peer ai-guy was recorded), `gate-passed` never fired for her, and a `server.log` grep found no block line. The leading hypothesis — a trusted peer whose inbound fingerprint representation doesn't match its trust-profile key → resolves `untrusted` → `insufficient_trust` — cannot be confirmed while the verdict is silent. This makes it visible and self-diagnosing.

## Scope / safety
- **Behavior-preserving**: pure observability — no change to routing, trust, rate-limiting, or delivery. All 37 pre-existing gate tests unchanged + green; +3 new observability tests = 40/40. `tsc --noEmit` clean.
- **Tier 1** (logging-only). No new dependency/route/store/try-catch → trips none of the SqliteRegistry-wiring / feature-delivery-completeness / no-silent-fallbacks / docs-coverage guard classes.
- Part of A2A delivery robustness (issue #939). The next step (PR4b) is the targeted fix the next live dawn→echo test will point at — a gate block (exact reason + resolved trust) vs an upstream relay-client drop (no eval line).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
