### PR TITLE
fix(reaper): stale-idle override + 8h window — idle MCP children stop pinning an abandoned session

### DIFF
--- a/.instar/instar-dev-decisions/2026-06-07T05-15-56-226Z-reaper-stale-idle-override.json
+++ b/.instar/instar-dev-decisions/2026-06-07T05-15-56-226Z-reaper-stale-idle-override.json
@@ -1,0 +1,15 @@
+{
+  "ts": "2026-06-07T05:15:56.226Z",
+  "slug": "reaper-stale-idle-override",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "safety-invariant proximity: src/monitoring/SessionReaper.ts matches session reaper"
+  ],
+  "belowFloor": true,
+  "files": 4,
+  "loc": 56,
+  "causalAutopsy": null,
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-06-07T05-16-55-071Z-reaper-stale-idle-override.json
+++ b/.instar/instar-dev-decisions/2026-06-07T05-16-55-071Z-reaper-stale-idle-override.json
@@ -1,0 +1,21 @@
+{
+  "ts": "2026-06-07T05:16:55.071Z",
+  "slug": "reaper-stale-idle-override",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "safety-invariant proximity: src/monitoring/SessionReaper.ts matches session reaper"
+  ],
+  "belowFloor": true,
+  "files": 4,
+  "loc": 56,
+  "causalAutopsy": {
+    "origin": "prior-pr",
+    "relatedPrs": [
+      955
+    ],
+    "notes": "Latent veto exposed BY #955. The active-process existence-veto has unconditionally kept any session with a live child since it was added (correct for short-lived sessions). #955 removed the open-commitment veto that was the outer blocker; a post-#955-deploy dry-run on echo (v1.3.391) then showed idle sessions moved 100% to keep-reason active-process (their own idle MCP servers), 0 reap-eligible — and the McpProcessReaper correctly refuses to kill MCP procs under a live session, so idle-MCP-heavy sessions sat in a gap neither reaper would touch. This adds the matching staleness bound to the active-process veto and lowers the shared window 24h->8h at the operator's request (so many resource issues; restarts are cheap). Not a regression — #955 peeled the outer layer and revealed this inner one."
+  },
+  "verdict": "pass"
+}

--- a/.instar/instar-dev-traces/2026-06-07T05-15-00-000Z-reaper-stale-idle-override.json
+++ b/.instar/instar-dev-traces/2026-06-07T05-15-00-000Z-reaper-stale-idle-override.json
@@ -1,0 +1,27 @@
+{
+    "slug": "reaper-stale-idle-override",
+    "sessionId": "96c61421-860a-48f9-92b4-26328f5640f1",
+    "timestamp": "2026-06-07T05:15:00.000Z",
+    "artifactPath": "upgrades/side-effects/reaper-stale-idle-override.md",
+    "artifactSha256": "0313b308c04dcb099fba1be8d2c34e7edc337fe978fa042ec12b8754cdea4bcc",
+    "coveredFiles": [
+        "src/monitoring/SessionReaper.ts",
+        "src/core/ReapGuard.ts",
+        "src/core/types.ts",
+        "src/config/ConfigDefaults.ts",
+        "tests/unit/session-reaper.test.ts",
+        "tests/unit/reap-guard.test.ts"
+    ],
+    "phase": "complete",
+    "tier": 1,
+    "tierReasoning": "Completes the #955 staleness pattern for the active-process veto in the multi-tick SessionReaper.evaluate (NOT the terminate authority, which stays conservative): a stale-idle session (no user msg within the staleness window) has its active-process existence-veto relaxed, still gated by positive-idle + flat-transcript + confirmObservations. One-directional (only widens reap-eligibility), config-gated (reapStaleIdleWithActiveChildren default true) + disable-able, observability flag for kill clarity. Also lowers the shared staleness default 24h->8h per operator. No API route, no persistent state, no migration. Both sides of every boundary unit-tested. No converged spec required for Tier 1.",
+    "eli16Path": "docs/eli16/reaper-stale-idle-override.eli16.md",
+    "sideEffectsPath": "upgrades/side-effects/reaper-stale-idle-override.md",
+    "causalAutopsy": {
+        "origin": "prior-pr",
+        "relatedPrs": [955],
+        "notes": "Latent veto exposed BY #955. The active-process existence-veto has unconditionally kept any session with a live child since it was added (correct for short-lived sessions). #955 removed the open-commitment veto that was the outer blocker; a post-#955-deploy dry-run on echo (v1.3.391) then showed idle sessions moved 100% to keep-reason active-process (their own idle MCP servers), 0 reap-eligible — and the McpProcessReaper correctly refuses to kill MCP procs under a live session, so idle-MCP-heavy sessions sat in a gap neither reaper would touch. This adds the matching staleness bound to the active-process veto and lowers the shared window 24h->8h at the operator's request (so many resource issues; restarts are cheap). Not a regression — #955 peeled the outer layer and revealed this inner one."
+    },
+    "secondPass": "not-required",
+    "reviewerConcurred": null
+}

--- a/docs/eli16/reaper-stale-idle-override.eli16.md
+++ b/docs/eli16/reaper-stale-idle-override.eli16.md
@@ -1,0 +1,30 @@
+# Reaper stale-idle override — ELI16
+
+> The one-line version: idle sessions still never got cleaned up — even after the last fix — because each one keeps its own little helper programs (MCP servers) running, and the reaper's rule "never kill a session that still has any program running" treated those idle helpers as "this session is busy." Now, if a session has had NO message from you in 8h AND is just sitting at an idle prompt producing nothing, the reaper stops counting its own idle helpers as "busy" and can finally reap it.
+
+## The problem (found 2026-06-06, after #955 deployed)
+
+A load-average-30 overload traced to dozens of multi-day Claude sessions, each holding a heavy MCP server stack. #955 fixed one blocker (stale commitments pinning sessions). But a dry-run after #955 deployed showed the reaper STILL reaps nothing — the same idle sessions just moved to the next keep-reason: **active-process (the idle MCP servers each session runs)**. The reaper treats any live child process as "this session is working," so an idle session is shielded by its own idle tools. And the MCP-process reaper refuses to kill an MCP server whose session is still alive (correct — it only cleans up dead/orphaned ones). So idle-but-MCP-heavy sessions sat in a gap neither reaper would touch.
+
+## What this changes
+
+The active-process veto gets the SAME staleness logic #955 gave the commitment veto. A session that has had no user message within the staleness window (default 8h — your "no message today" rule) is treated as abandoned, so its idle children stop shielding it. Crucially, the session must STILL clear every other check after that — it has to be sitting at a positive idle prompt AND producing no new transcript output AND be confirmed across multiple ticks — before it's actually reaped. So this only catches "silent for a day + idle + producing nothing," never anything genuinely working.
+
+- New config `monitoring.sessionReaper.reapStaleIdleWithActiveChildren` (default true).
+- Reuses the existing 8h `staleCommitmentWindowMinutes` as the "abandoned" threshold.
+- Audited via a new `staleIdleRelaxed` flag so a kill's reason is explicit (relaxed-because-CPU-flat vs relaxed-because-8h-silent).
+
+## Why it's safe
+
+- It only ever makes MORE sessions reap-eligible, and ONLY ones that are ALL of: 8h-user-silent, bound to a topic (so we can time-bound it — unbindable sessions are never relaxed), positively idle at the prompt, producing no transcript output, and confirmed across the reaper's multi-tick window.
+- Every other guard (protected, recovery, pending-injection, recent-user, open-commitment, active-subagent, structural-long-work, main-process) is unchanged and still fires.
+- `reapStaleIdleWithActiveChildren: false` restores the old conservative behavior exactly.
+- The reaper is itself opt-in + dry-run-first, so nothing changes until an operator enables it.
+
+## Honest scope
+
+This is the third and final unblock in the chain (worktree/Spotlight #952 → stale-commitment #955 → stale-idle here) so the idle-session reaper can actually do its job. The operator asked to be "slightly aggressive" given repeated overloads; this is that, bounded by the four combined safety conditions. Validated with the dry-run that surfaced each layer.
+
+## Evidence
+
+`tests/unit/session-reaper.test.ts`: reaps a stale-idle idle-child session (flags staleIdleRelaxed); keeps when the session is NOT stale (message within window); keeps when the flag is off; keeps when stale-but-not-positively-idle (safety holds after relax); keeps when no bound topic. 35/35 green. `tsc --noEmit` clean.

--- a/src/config/ConfigDefaults.ts
+++ b/src/config/ConfigDefaults.ts
@@ -104,7 +104,8 @@ const SHARED_DEFAULTS: Record<string, unknown> = {
       maxReapsPerHour: 12,
       finalGraceSec: 60,
       protectOpenCommitments: true,
-      staleCommitmentWindowMinutes: 1440, // 24h — open commitment stops pinning an inactive session past a day
+      staleCommitmentWindowMinutes: 480, // 8h — silent 8h stops an open commitment/idle children from pinning a session (operator: restarts are cheap)
+      reapStaleIdleWithActiveChildren: true, // 24h-silent + idle + flat-transcript reaps even with idle children (e.g. idle MCP servers)
 
       // CPU pressure: overall tier = WORST of memory (free %) and CPU (1-min load
       // ÷ cores), so a CPU-bound box raises pressure even when memory is fine.

--- a/src/core/ReapGuard.ts
+++ b/src/core/ReapGuard.ts
@@ -77,7 +77,7 @@ export const DEFAULT_REAP_GUARD_OPTIONS: ReapGuardOptions = {
   minAgeMs: 30 * 60_000,
   recentUserWindowMs: 30 * 60_000,
   protectOpenCommitments: true,
-  staleCommitmentWindowMs: 24 * 60 * 60_000, // 24h — "no user message today ⇒ commitment is stale"
+  staleCommitmentWindowMs: 8 * 60 * 60_000, // 8h — "silent 8h ⇒ stale" (operator: restarts are cheap, prefer free resources)
 };
 
 export class ReapGuard {

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -3563,8 +3563,13 @@ export interface MonitoringConfig {
     /** Staleness horizon (minutes) for the open-commitment veto: an open commitment
      *  protects a session only while a user message arrived within this window; past
      *  it the commitment is treated as abandoned and no longer blocks reaping.
-     *  Default 1440 (24h) — "no message today ⇒ reapable even with an open commitment". */
+     *  Default 480 (8h) — "no message today ⇒ reapable even with an open commitment". */
     staleCommitmentWindowMinutes?: number;
+    /** When true, a stale-idle session (no user message within staleCommitmentWindowMinutes)
+     *  also has its `active-process` existence-veto relaxed, so its own idle children
+     *  (e.g. idle MCP servers) stop shielding a 24h-abandoned session. It STILL must be
+     *  positively idle + flat-transcript + confirmed across ticks to reap. Default true. */
+    reapStaleIdleWithActiveChildren?: boolean;
     /** CPU pressure: 1-min load ÷ cores at/above which pressure is `moderate`
      *  (overall tier = worst of memory and CPU). Default 1.0. */
     cpuModerateLoadPerCore?: number;

--- a/src/monitoring/SessionReaper.ts
+++ b/src/monitoring/SessionReaper.ts
@@ -45,8 +45,15 @@ export interface SessionReaperConfig {
   finalGraceSec: number;
   protectOpenCommitments: boolean;
   /** Staleness horizon (minutes) for the open-commitment veto; past it a commitment
-   *  no longer pins an inactive session. Default 1440 (24h) = "no message today". */
+   *  no longer pins an inactive session. Default 480 (8h). */
   staleCommitmentWindowMinutes: number;
+  /** When true, the `active-process` existence-veto is ALSO relaxed for a stale-idle
+   *  session (no user message within staleCommitmentWindowMinutes), so a session's own
+   *  idle children (e.g. idle MCP servers) stop shielding a 8h-abandoned session. The
+   *  session STILL must clear positive-idle + flat-transcript + confirmObservations to
+   *  reap — this only drops the existence-veto. The active-process analogue of the
+   *  stale-commitment override. Default true (operator wants idle sessions reclaimed). */
+  reapStaleIdleWithActiveChildren: boolean;
   /** CPU pressure: 1-min load ÷ cores at/above which pressure is `moderate`.
    *  The overall tier is the WORST of the memory tier and this CPU tier, so a
    *  CPU-bound box raises pressure even when free memory is fine. */
@@ -112,7 +119,8 @@ export const DEFAULT_SESSION_REAPER_CONFIG: SessionReaperConfig = {
   maxReapsPerHour: 12,
   finalGraceSec: 60,
   protectOpenCommitments: true,
-  staleCommitmentWindowMinutes: 1440, // 24h
+  staleCommitmentWindowMinutes: 480, // 8h
+  reapStaleIdleWithActiveChildren: true,
   cpuModerateLoadPerCore: 1.0,
   cpuCriticalLoadPerCore: 1.5,
   cpuAwareActiveProcessKeep: false,
@@ -191,6 +199,12 @@ export interface SessionEvaluation {
    *  transcript). Observe-only — the verdict is unchanged; tick() tracks the dwell
    *  and emits a `busy-orphan-suspected` audit row past busyOrphanConfirmTicks. */
   busyOrphanSuspect?: boolean;
+  /** True when the `active-process` existence-veto was relaxed this eval because the
+   *  session is stale-idle — no user message within `staleCommitmentWindowMinutes`
+   *  (reapStaleIdleWithActiveChildren). The session STILL had to clear the stateful
+   *  transcript-growth + positive-idle checks to be reap-eligible; this only drops the
+   *  "it has idle children" shield for an 8h-silent session. Audited for kill clarity. */
+  staleIdleRelaxed?: boolean;
 }
 
 export interface PressureReading {
@@ -365,9 +379,19 @@ export class SessionReaper extends EventEmitter {
     const transcript = this.probe(session);
     let cpuTightened = false;
     let busyOrphanSuspect = false;
+    let staleIdleRelaxed = false;
 
     const keep = (reason: string, confidence: Confidence = 'high'): SessionEvaluation =>
-      ({ verdict: 'keep', keptBy: reason, confidence, frame, transcript, cpuTightened, busyOrphanSuspect });
+      ({ verdict: 'keep', keptBy: reason, confidence, frame, transcript, cpuTightened, busyOrphanSuspect, staleIdleRelaxed });
+
+    // Stale-idle: no user message within the staleness window on the bound topic.
+    // An 8h-silent session is treated as abandoned (Justin's "no message today"
+    // rule) — see the active-process relax below. Unbindable topic ⇒ NOT stale
+    // (conservative: never relax a veto on a session we can't time-bound).
+    const staleTopicId = this.deps.topicBinding(session.tmuxSession);
+    const staleIdle = this.cfg.reapStaleIdleWithActiveChildren
+      && staleTopicId != null
+      && !this.deps.recentUserMessage(staleTopicId, this.cfg.staleCommitmentWindowMinutes * 60_000);
 
     // ── Stateless KEEP-guards (§P2): protected, spawn-grace, recovery,
     //    pending-injection, relay-lease, recent-user, open-commitment,
@@ -384,8 +408,16 @@ export class SessionReaper extends EventEmitter {
       // growth + positive-idle checks below, which STILL must all clear before
       // the session is reap-eligible. Every other keep-reason — and the
       // off-pressure / can't-measure cases (cpuFlat !== true) — is unchanged.
-      if (blocked.reason === 'active-process' && opts?.cpuFlat === true) {
-        cpuTightened = true; // relax this veto only; fall through (no return)
+      if (blocked.reason === 'active-process' && (opts?.cpuFlat === true || staleIdle)) {
+        // Relax the active-process veto and fall through (no return) to the stateful
+        // transcript-growth + positive-idle checks, which STILL must all clear before
+        // the session is reap-eligible. Two independent reasons to relax:
+        //   • cpuFlat — the child exists but burns ~no CPU under pressure (wedged/idle).
+        //   • staleIdle — no user message in 8h (abandoned); its idle children (e.g. the
+        //     session's own idle MCP servers) must not shield a dead session forever.
+        //     This is the active-process analogue of the #955 stale-commitment override.
+        if (opts?.cpuFlat === true) cpuTightened = true;
+        if (staleIdle) staleIdleRelaxed = true;
       } else {
         // OBSERVE-ONLY busy-orphan detection — the inverse of the relax above.
         // A child is keeping this session, but if that child is provably BURNING
@@ -421,7 +453,7 @@ export class SessionReaper extends EventEmitter {
     if (!SessionReaper.isPositivelyIdle(framework, frame)) return keep('no-positive-idle');
 
     // All gates clear: this tick the session is a reap candidate.
-    return { verdict: 'reap-eligible', keptBy: 'all-clear', confidence: 'high', frame, transcript, cpuTightened, busyOrphanSuspect };
+    return { verdict: 'reap-eligible', keptBy: 'all-clear', confidence: 'high', frame, transcript, cpuTightened, busyOrphanSuspect, staleIdleRelaxed };
   }
 
   /**

--- a/tests/unit/reap-guard.test.ts
+++ b/tests/unit/reap-guard.test.ts
@@ -54,12 +54,12 @@ describe('ReapGuard — each guard blocks with its reason', () => {
     ['relay-lease', { isRelayLeaseActive: () => true }],
     ['recent-user-message', { topicBinding: () => 42, recentUserMessage: () => true }],
     // Open commitment keeps ONLY while a message arrived within the staleness window
-    // (here: within 24h but NOT within the 30min recent-user window, so guard I above
-    // doesn't pre-empt it). A window-aware mock distinguishes the two horizons.
+    // but NOT within the 30min recent-user window (so guard I above doesn't pre-empt
+    // it). A window-aware mock distinguishes the two horizons, robust to the default.
     ['open-commitment', {
       topicBinding: () => 42,
       activeCommitmentForTopic: () => true,
-      recentUserMessage: (_t, withinMs) => withinMs >= 24 * 60 * 60_000,
+      recentUserMessage: (_t, withinMs) => withinMs > 60 * 60_000,
     }],
     ['active-subagent', { activeSubagentCount: () => 2 }],
     ['structural-long-work', { buildOrAutonomousActive: () => true }],
@@ -93,11 +93,11 @@ describe('ReapGuard — stale-commitment override (2026-06-06: open-commitment w
     expect(g.blockedReason(mkSession())).toBeNull(); // falls through, reap-eligible
   });
 
-  it('STILL keeps on an open commitment while a message is within the stale window (default 24h)', () => {
+  it('STILL keeps on an open commitment while a message is within the stale window (default 8h)', () => {
     const g = new ReapGuard(clearDeps({
       topicBinding: () => 42,
       activeCommitmentForTopic: () => true,
-      recentUserMessage: (_t, withinMs) => withinMs >= 24 * 60 * 60_000, // active within 24h, not 30min
+      recentUserMessage: (_t, withinMs) => withinMs > 60 * 60_000, // active within the stale window, not the 30min recent-user window
     }));
     expect(g.blockedReason(mkSession())?.reason).toBe('open-commitment');
   });

--- a/tests/unit/session-reaper.test.ts
+++ b/tests/unit/session-reaper.test.ts
@@ -115,7 +115,7 @@ describe('SessionReaper — protect-gates each force KEEP', () => {
     ['recent user msg', { topicBinding: () => 42, recentUserMessage: () => true }, 'recent-user-message'],
     // Open commitment keeps only while a message is within the staleness window (24h)
     // but outside the 30min recent-user window — a window-aware mock distinguishes them.
-    ['open commitment', { topicBinding: () => 42, activeCommitmentForTopic: () => true, recentUserMessage: (_t, withinMs) => withinMs >= 24 * 60 * 60_000 }, 'open-commitment'],
+    ['open commitment', { topicBinding: () => 42, activeCommitmentForTopic: () => true, recentUserMessage: (_t, withinMs) => withinMs > 60 * 60_000 }, 'open-commitment'],
   ];
   for (const [name, deps, expectedGate] of cases) {
     it(`KEEPs on ${name}`, () => {
@@ -170,6 +170,55 @@ describe('SessionReaper — positive-evidence & confidence contract', () => {
     const e = h.reaper.evaluate(mkSession());
     expect(e.verdict).toBe('reap-eligible');
     expect(e.keptBy).toBe('all-clear');
+  });
+});
+
+describe('SessionReaper — stale-idle active-process override (reapStaleIdleWithActiveChildren)', () => {
+  // A 24h-silent session whose ONLY "activity" is idle children (e.g. idle MCP servers)
+  // is abandoned: relax the active-process veto, but it STILL must be positively idle +
+  // transcript-flat to reap. The active-process analogue of the #955 stale-commitment override.
+  const staleIdleDeps = {
+    topicBinding: () => 42,
+    recentUserMessage: () => false, // no message in any window ⇒ stale-idle
+    hasActiveProcesses: () => true, // idle MCP children keep it "active"
+  };
+
+  it('REAPS a stale-idle session held only by idle children (and flags staleIdleRelaxed)', () => {
+    const h = harness({ deps: staleIdleDeps });
+    const e = h.reaper.evaluate(mkSession());
+    expect(e.verdict).toBe('reap-eligible');
+    expect(e.staleIdleRelaxed).toBe(true);
+  });
+
+  it('KEEPs on active-process when the session is NOT stale (message within the window)', () => {
+    // Active within 24h (not 30min) ⇒ not stale ⇒ veto stands. (Window-aware mock so the
+    // 30min recent-user guard doesn't pre-empt with recent-user-message.)
+    const h = harness({ deps: { topicBinding: () => 42, hasActiveProcesses: () => true, recentUserMessage: (_t, withinMs) => withinMs > 60 * 60_000 } });
+    const e = h.reaper.evaluate(mkSession());
+    expect(e.verdict).toBe('keep');
+    expect(e.keptBy).toBe('active-process');
+  });
+
+  it('does NOT relax when reapStaleIdleWithActiveChildren is off (old conservative behavior)', () => {
+    const h = harness({ cfg: { reapStaleIdleWithActiveChildren: false }, deps: staleIdleDeps });
+    const e = h.reaper.evaluate(mkSession());
+    expect(e.verdict).toBe('keep');
+    expect(e.keptBy).toBe('active-process');
+  });
+
+  it('STILL keeps a stale-idle session that is not positively idle (safety holds after relax)', () => {
+    const h = harness({ deps: staleIdleDeps });
+    h.setFrame(WORKING_FRAME); // pane shows work in progress, not a ready prompt
+    const e = h.reaper.evaluate(mkSession());
+    expect(e.verdict).toBe('keep');
+    expect(e.keptBy).toBe('no-positive-idle');
+  });
+
+  it('does NOT relax a stale-idle session with NO bound topic (cannot time-bound ⇒ conservative)', () => {
+    const h = harness({ deps: { topicBinding: () => null, recentUserMessage: () => false, hasActiveProcesses: () => true } });
+    const e = h.reaper.evaluate(mkSession());
+    expect(e.verdict).toBe('keep');
+    expect(e.keptBy).toBe('active-process');
   });
 });
 

--- a/upgrades/next/reaper-stale-idle-override.md
+++ b/upgrades/next/reaper-stale-idle-override.md
@@ -1,0 +1,49 @@
+<!-- bump: patch -->
+<!-- change_type: fix -->
+
+## What Changed
+
+The idle-session reaper's `active-process` veto ("never reap a session with any live
+child") is now staleness-aware, completing the chain after #955. A session with no
+user message within the staleness window (default lowered to 8h) is treated as
+abandoned, so its OWN idle children (e.g. idle MCP servers) stop shielding it. Found
+because a post-#955 dry-run showed idle sessions just moved from keep-reason
+`open-commitment` to `active-process` — and the MCP reaper correctly won't kill an MCP
+server under a live session, so idle-MCP-heavy sessions sat in a gap.
+
+The session must STILL be positively idle + producing no transcript output + confirmed
+across multiple ticks to actually reap — this only drops the "it has idle children"
+shield for an 8h-silent session. Also lowers the shared staleness window from 24h → 8h
+(operator: restarts are cheap, prefer free resources), covering both this and the #955
+commitment override.
+
+New `monitoring.sessionReaper.reapStaleIdleWithActiveChildren` (default true);
+`staleCommitmentWindowMinutes` default 480 (8h).
+
+## What to Tell Your User
+
+Nothing required — internal reaper policy, reaper still opt-in. For operators enabling
+the reaper: a session silent for 8h+ that's sitting idle and producing nothing will now
+become reap-eligible even if it still has idle MCP servers running. Active runs and
+anything producing output are untouched.
+
+## Summary of New Capabilities
+
+- `reapStaleIdleWithActiveChildren` (default true) — relaxes the active-process veto for
+  an 8h-silent, positively-idle, transcript-flat session so its idle children stop
+  pinning it. Audited via a `staleIdleRelaxed` flag.
+- Staleness window default 24h → 8h (one knob; covers commitment + idle-session vetoes).
+
+## Scope (honest)
+
+Third and final unblock in the chain (#952 Spotlight, #955 stale-commitment, this). Makes
+idle sessions reap-ELIGIBLE; the opt-in reaper (dry-run first) acts on them. Pairs with
+enabling sessionReaper + mcpProcessReaper + SleepController (were off fleet-wide). Leaves
+the terminate-time authority guard conservative.
+
+## Evidence
+
+`tests/unit/session-reaper.test.ts` + `tests/unit/reap-guard.test.ts`: reaps a stale-idle
+idle-child session (flags staleIdleRelaxed); keeps when not stale, when the flag is off,
+when not positively idle (safety after relax), and when no bound topic; commitment
+override tests updated to default-robust window mocks. 54/54 green. `tsc --noEmit` clean.

--- a/upgrades/side-effects/reaper-stale-idle-override.md
+++ b/upgrades/side-effects/reaper-stale-idle-override.md
@@ -1,0 +1,46 @@
+# Side-Effects Review - Reaper stale-idle active-process override
+
+**Version / slug:** `reaper-stale-idle-override`
+**Date:** `2026-06-06`
+**Author:** `echo`
+**Second-pass reviewer:** `not required (Tier 1)`
+
+## Summary of the change
+
+`SessionReaper.evaluate()` now relaxes the `active-process` existence-veto for a stale-idle session (no user message within `staleCommitmentWindowMinutes`, default 8h), falling through to the existing stateful transcript-growth + positive-idle gates which STILL must clear. The active-process analogue of the #955 stale-commitment override. Found because a post-#955 dry-run showed idle sessions just moved from keep-reason `open-commitment` to `active-process` (their own idle MCP servers), and the McpProcessReaper correctly won't kill MCP procs under a live session — so idle-MCP-heavy sessions sat in a gap. Adds `reapStaleIdleWithActiveChildren` (default true) to `SessionReaperConfig` + `ConfigDefaults` + the `InstarConfig` type, and a `staleIdleRelaxed` observability flag to `SessionEvaluation`.
+
+## Decision-point inventory
+
+- `SessionReaper.evaluate()`: computes `staleIdle = reapStaleIdleWithActiveChildren && topicBinding != null && !recentUserMessage(topicId, staleCommitmentWindowMinutes*60_000)`; the active-process relax now fires on `cpuFlat===true OR staleIdle`. Sets `staleIdleRelaxed` for the audit.
+- `SessionReaperConfig.reapStaleIdleWithActiveChildren` (new; default true).
+- `SessionEvaluation.staleIdleRelaxed` (new; observability — parallels `cpuTightened`).
+- `ConfigDefaults` + `types.ts` `sessionReaper` block gain `reapStaleIdleWithActiveChildren`.
+
+## 1. Behavior change / gating
+
+A guard-loosening in ONE direction: more sessions become reap-ELIGIBLE, and only those that are ALL of — 8h-user-silent, topic-bound, positively idle, transcript-flat, and confirmed across the reaper's multi-tick window. It never makes a reapable session kept. The relax is implemented in `evaluate()` (NOT in the shared `ReapGuard`), so the terminate-time authority guard is UNCHANGED — it still honors the active-process veto unconditionally; only the careful multi-tick reaper relaxes it, and only with the stateful idle proof behind it.
+
+## 2. Over/under-signal
+
+OVER-reap risk: a session whose user simply hasn't messaged in 8h but is mid-long-autonomous-run. Mitigations: (a) `buildOrAutonomousActive` (structural-long-work) fires BEFORE active-process and is unchanged — an active autonomous run is kept; (b) transcript-growth keeps anything producing output; (c) positive-idle is required; (d) confirmObservations multi-tick; (e) topic-bound requirement excludes sessions we can't time-bound; (f) `reapStaleIdleWithActiveChildren:false` disables. UNDER-signal (the prior "reaps nothing") is the bug being fixed.
+
+## 3. Blast radius
+
+Pure in-memory eval logic; reuses the existing `recentUserMessage` + `topicBinding` deps (no new I/O). Affects only the reap-eligibility decision in the multi-tick reaper. No API route, no persistent state, no migration of data. Ships behind the sessionReaper (opt-in + dry-run-first).
+
+## 4. Failure modes
+
+`recentUserMessage` / `topicBinding` throwing: `topicBinding` is called outside the guard's try/catch in `evaluate`, but a throw there would propagate to `tick()`'s per-session try/catch which records KEEP ('eval-error') — fail-safe (never reaps). A null topic ⇒ staleIdle false ⇒ veto stands (conservative). Missing config field ⇒ default true via DEFAULT_SESSION_REAPER_CONFIG, OR explicit false to disable.
+
+## 5. Migration parity
+
+`reapStaleIdleWithActiveChildren` is optional with a code default (true) in both `DEFAULT_SESSION_REAPER_CONFIG` and `ConfigDefaults`, so existing agents get the behavior automatically when they enable the reaper — no `PostUpdateMigrator` entry needed (absence ⇒ default, the established sessionReaper-subfield pattern). No agent-installed file changes; internal reaper policy, no agent-facing surface. The reaper stays opt-in (enabled:false default) so nothing changes until an operator turns it on.
+
+## 6. Scope honesty (what this is NOT)
+
+- Third unblock in the chain (#952 Spotlight, #955 stale-commitment, this). It makes idle sessions reap-ELIGIBLE; the reaper (dry-run first, then live) acts on them. Pairs with enabling sessionReaper + mcpProcessReaper + SleepController (opt-in, were off fleet-wide).
+- Does NOT touch the terminate-time authority guard (kept conservative). Does NOT change CPU-flat handling (cpuAwareActiveProcessKeep) — it adds a SECOND, independent relax reason.
+
+## 7. Causal autopsy
+
+Origin: **latent** (compounded by #955's own staleness fix surfacing it). The active-process existence-veto has unconditionally kept any session with a live child since it was added — correct when sessions were short-lived. As the fleet grew to dozens of multi-day sessions each running an idle MCP stack, that veto became the residual blocker once #955 removed the open-commitment one. No prior PR regressed it; #955 simply peeled the outer layer and exposed this inner one. 2026-06-06 dry-run grounding: post-#955 keeps were 100% active-process with 0 reap-eligible. This adds the matching staleness bound. The operator explicitly requested a "slightly aggressive" posture given repeated overloads.


### PR DESCRIPTION
## ELI16

Idle sessions still never got cleaned up — even after #955 — because each one keeps its own little helper programs (MCP servers) running, and the reaper's rule "never kill a session that still has any program running" treated those idle helpers as "this session is busy." A dry-run right after #955 deployed proved it: the idle sessions just moved from one keep-reason (stale commitments, which #955 fixed) to the next one (active-process — their own idle MCP servers), so the reaper still reaped nothing. And the MCP-process reaper correctly refuses to kill an MCP server whose session is still alive, so those idle-but-MCP-heavy sessions sat in a gap neither reaper would touch. This change gives the active-process veto the same staleness logic #955 gave the commitment veto: if a session has had NO message from you within the window AND is sitting at an idle prompt producing nothing, the reaper stops counting its own idle helpers as "busy" and can finally reap it. It still must be positively idle + producing no output + confirmed across multiple ticks, so it only catches genuinely-abandoned sessions. Per the operator ("restarts are cheap, prefer free resources") the shared staleness window is also lowered from 24h to 8h, covering both this and the #955 commitment override.

## The chain

1. #952 — exclude agent `.instar/` data from Spotlight/mediaanalysisd.
2. #955 — stale **open-commitment** veto no longer pins idle sessions.
3. **this** — stale **active-process** veto no longer pins idle sessions held only by their own idle MCP children.

Dry-run grounding (echo, v1.3.391, post-#955): keeps were 100% `active-process`, 0 reap-eligible — exactly the gap this closes.

## The change

- `SessionReaper.evaluate()`: relaxes the `active-process` existence-veto for a stale-idle session (no user message within `staleCommitmentWindowMinutes`), falling through to the existing transcript-growth + positive-idle gates which STILL must clear. Implemented in the multi-tick reaper only — the terminate-time authority guard stays conservative.
- New `monitoring.sessionReaper.reapStaleIdleWithActiveChildren` (default true; `false` restores old behavior).
- `staleIdleRelaxed` observability flag on `SessionEvaluation` so a kill's reason is explicit (CPU-flat vs stale-idle).
- Staleness window default `24h → 8h` (one knob; covers commitment + idle vetoes).

## Safety

One-directional (only widens reap-eligibility). A stale-idle session must additionally be topic-bound (so it can be time-bounded — unbindable sessions are never relaxed), positively idle, transcript-flat, and confirmed across the reaper's multi-tick window. `buildOrAutonomousActive` (structural-long-work) fires before active-process and is unchanged, so active autonomous runs are kept. The reaper is opt-in + dry-run-first.

## Tests / evidence

`tests/unit/session-reaper.test.ts` + `tests/unit/reap-guard.test.ts`: reaps a stale-idle idle-child session (flags `staleIdleRelaxed`); keeps when not stale / flag off / not positively idle / no bound topic; commitment-override tests updated to default-robust window mocks. 54/54 green. `tsc --noEmit` clean. causalAutopsy: **prior-pr #955** (exposed the inner veto layer).

🤖 Generated with [Claude Code](https://claude.com/claude-code)