### PR TITLE
fix(lifeline): stop dropping real messages under server overload + close untracked-loss in replay

### DIFF
--- a/.instar/instar-dev-decisions/2026-06-07T05-52-45-336Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-06-07T05-52-45-336Z-unknown.json
@@ -1,0 +1,18 @@
+{
+  "ts": "2026-06-07T05:52:45.336Z",
+  "slug": "unknown",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "new capability: new config key added"
+  ],
+  "belowFloor": true,
+  "files": 3,
+  "loc": 320,
+  "causalAutopsy": {
+    "origin": "latent",
+    "notes": "Two latent flaws surfaced (not caused) by the 2026-06-06 macOS CPU-starvation environment shift. (1) The down-server replay guard added 2026-06-05 (codey incident), `msg.replayFailures = this.supervisor.healthy ? failures + 1 : failures`, fixed the 'server fully DOWN during a restart' case but used `supervisor.healthy` as a coarse proxy for 'transient vs message-specific'. Under the 2026-06-06 macOS CPU-starvation episode the server was supervisor.healthy===true but too slow to accept forwards, so forwards timed out, all 3 attempts burned in ~90s, and real messages were dropped (32 'Handoff to server failed after 3 replay attempts' records on echo, incl. live operator messages on topics 20905 and 13435). The untracked-loss (topic 21487, message gone with no dropped-record) is an older latent flaw: MessageQueue.drain() emptied the persisted queue before delivery confirmed, so a mid-replay process exit (update/version-skew/launchd restart) lost in-memory messages. Surfaced by Justin's 2026-06-06 topic-21555 report ('incoherent scope creep — topic had one message, reply had nothing to do with it'), which grounding traced to a dropped substantive message + confabulation on the later thin nudge. Fix replaces the coarse proxy with a typed forward classification + durable peek/remove consume."
+  },
+  "verdict": "pass"
+}

--- a/docs/eli16/lifeline-replay-budget-classification.eli16.md
+++ b/docs/eli16/lifeline-replay-budget-classification.eli16.md
@@ -1,0 +1,38 @@
+# Lifeline replay: stop dropping real messages — Plain-English Overview
+
+> The one-line version: when the server is slow or restarting, a user's message must wait in line and be retried — never be thrown away as if it were a bad message.
+
+## The problem in one breath
+
+When my server gets overloaded (the recent macOS CPU pileup), the piece that catches your Telegram messages while the server is busy ("the lifeline") would try to hand a message over, time out a few times in ~90 seconds, and then **throw the message away** — treating "the server is too busy right now" exactly like "this message is broken." On top of that, the waiting line emptied itself to disk *before* confirming delivery, so a restart at the wrong moment could lose a message with no record at all. That combination is why a real question vanished and a later "checking in" got an unrelated reply.
+
+## What already exists
+
+- **The lifeline** — a small always-on process that receives your Telegram messages and forwards them to the main server. If the server is down, it parks the message in a queue and retries later.
+- **The drop log** — when the lifeline finally gives up on a message it writes a record and tries to tell you "I lost that, please resend."
+- **The retry budget** — each message got 3 tries before being dropped.
+
+## What this adds
+
+The lifeline now tells two very different failures apart. A **bad message** (the server looks at it and says "no, this is malformed" — an HTTP 400) is the only thing that can use up the 3-try drop budget. A **busy/slow/restarting server** (a timeout, a 5xx, a dropped connection) no longer counts against that budget at all — the message simply stays in line and is retried when the server recovers. A separate, very generous safety limit still stops the queue from growing forever if a server is broken for hours.
+
+## The new pieces
+
+- **A small decision module (`decideReplay`)** — given the result of one delivery attempt, it returns one of: delivered, keep-in-line-and-retry, or drop. It is pure logic with no side effects, so it is easy to test exhaustively. Its whole job is to make sure only a genuinely bad message can ever be dropped.
+- **A durable waiting line** — a message now leaves the queue only *after* it is actually delivered (or deliberately dropped). A restart in the middle of catching up can no longer lose anything; the leftovers are still on disk for the next try.
+
+## The safeguards
+
+**Prevents a busy server from eating your messages.** Timeouts and server-busy errors never burn the drop budget, so an overloaded box just delays delivery instead of discarding it.
+
+**Prevents silent, trace-less loss.** Because the queue keeps a message until delivery is confirmed, a mid-restart crash leaves the message safely on disk instead of vanishing.
+
+**Prevents an infinite backlog.** If a server is genuinely unreachable for a very long time (hundreds of attempts), the message is finally dropped *with* an honest record and a resend notice — never silently.
+
+## What ships when
+
+One change, one PR: the classification + the durable queue land together, behind comprehensive tests. No config to flip, no migration — existing queued messages keep working.
+
+## What you actually need to decide
+
+Whether to ship this fix now on your existing approval, or run it through the heavier multi-reviewer spec process first for extra rigor.

--- a/src/lifeline/MessageQueue.ts
+++ b/src/lifeline/MessageQueue.ts
@@ -20,8 +20,14 @@ export interface QueuedMessage {
   photoPath?: string;
   documentPath?: string;
   documentName?: string;
-  /** Number of times this message has been replayed and failed to deliver. */
+  /**
+   * Strikes from genuine HTTP-400 rejections (message-specific / "poison").
+   * Named `replayFailures` for on-disk back-compat with queues written before
+   * the transient/poison split (2026-06-06); semantically the poison counter.
+   */
   replayFailures?: number;
+  /** Strikes from transient capacity/availability failures (timeout/5xx/down). */
+  transientReplayFailures?: number;
 }
 
 export class MessageQueue {
@@ -56,6 +62,40 @@ export class MessageQueue {
    */
   peek(): QueuedMessage[] {
     return [...this.queue];
+  }
+
+  /**
+   * Remove a single message by id and persist. Used by durable replay: a
+   * message is removed from the persisted queue ONLY after it has been
+   * delivered or deliberately dropped — so a process exit mid-replay can never
+   * lose an undelivered message (the 2026-06-06 topic-21487 untracked-loss bug,
+   * where drain() emptied the disk queue before delivery confirmed).
+   * Returns true if a message was removed.
+   */
+  remove(id: string): boolean {
+    const before = this.queue.length;
+    this.queue = this.queue.filter(m => m.id !== id);
+    if (this.queue.length !== before) {
+      this.save();
+      return true;
+    }
+    return false;
+  }
+
+  /**
+   * Patch the replay-strike counters of a queued message in place and persist.
+   * Leaves the message ON DISK (durable) — used when a forward fails and the
+   * message must be retried on the next replay tick. No-op if the id is gone.
+   */
+  updateReplayCounters(
+    id: string,
+    counters: { replayFailures: number; transientReplayFailures: number },
+  ): void {
+    const msg = this.queue.find(m => m.id === id);
+    if (!msg) return;
+    msg.replayFailures = counters.replayFailures;
+    msg.transientReplayFailures = counters.transientReplayFailures;
+    this.save();
   }
 
   get length(): number {

--- a/src/lifeline/TelegramLifeline.ts
+++ b/src/lifeline/TelegramLifeline.ts
@@ -58,6 +58,7 @@ import {
   isTerminalForwardError,
   type VersionSkewBody,
 } from './forwardErrors.js';
+import { decideReplay, type ForwardOutcome } from './replayPolicy.js';
 import { writeStartupMarker } from './startupMarker.js';
 import { shouldOwnTelegramPoll } from './telegramPollOwnership.js';
 import { writeLease as writePollOwnerLease } from './TelegramPollOwnerLease.js';
@@ -1394,11 +1395,30 @@ export class TelegramLifeline {
     }
   }
 
+  /**
+   * Boolean façade kept for the inbound-handler callers that only care whether
+   * the forward landed. Replay uses {@link forwardToServerClassified} so it can
+   * tell a message-specific rejection (poison) from a transient outage.
+   */
   private async forwardToServer(
     topicId: number,
     text: string,
     rawMsg: NonNullable<TelegramUpdate['message']>,
   ): Promise<boolean> {
+    return (await this.forwardToServerClassified(topicId, text, rawMsg)) === 'ok';
+  }
+
+  /**
+   * Forward a message to the server and classify the result so replay can
+   * budget correctly: only a genuine HTTP-400 rejection ('poison') burns the
+   * drop budget; timeout / 5xx / 503-boot / network refusal are 'transient'
+   * (never drop a real message), and 426 is 'skew' (coordinated restart).
+   */
+  private async forwardToServerClassified(
+    topicId: number,
+    text: string,
+    rawMsg: NonNullable<TelegramUpdate['message']>,
+  ): Promise<ForwardOutcome> {
     // a2a spoof-defense fields (MENTOR-LIVE-READINESS-SPEC §Recipient side). The
     // server's /internal/telegram-forward handler passes these to
     // `TelegramAdapter.dispatchAgentMessageHook` so the a2a hook can distinguish
@@ -1508,15 +1528,21 @@ export class TelegramLifeline {
       // gets its own user-visible notification.
       this.versionSkewActive = false;
       this.versionSkewAlertSentAt = 0;
-      return true;
+      return 'ok';
     } catch (err) {
       // Version-skew handler: emit signal + request restart via orchestrator.
       if (err instanceof ForwardVersionSkewError) {
         this.handleVersionSkew(err, topicId);
-        return false;
+        return 'skew';
       }
       this.consecutiveForwardFailures++;
-      return false;
+      // A genuine HTTP-400 is the ONLY message-specific ("poison") failure —
+      // the server looked at this message and refused it. Everything else
+      // (transient 5xx, 503 boot, fetch timeout/AbortError, network refusal)
+      // is a capacity/availability failure that says nothing about the message
+      // and must NOT burn the replay drop budget.
+      if (err instanceof ForwardBadRequestError) return 'poison';
+      return 'transient';
     }
   }
 
@@ -1790,62 +1816,32 @@ export class TelegramLifeline {
 
   // ── Queue Replay ──────────────────────────────────────────
 
-  /** Max times a message can fail replay before being dropped. */
-  private static readonly MAX_REPLAY_FAILURES = 3;
-
   private async replayQueue(): Promise<void> {
-    const messages = this.queue.drain();
+    // Durable consume: work from a SNAPSHOT and remove a message from the
+    // PERSISTED queue only after it is delivered or deliberately dropped. The
+    // old drain() emptied the on-disk queue up front, so a process exit
+    // mid-replay (update / version-skew / launchd restart — all common during
+    // the very episodes that trigger queuing) lost the in-memory messages with
+    // no trace. That is the 2026-06-06 topic-21487 untracked-loss: a real user
+    // question vanished without even a dropped-messages.json record.
+    const messages = this.queue.peek();
     if (messages.length === 0) return;
 
     console.log(`[Lifeline] Replaying ${messages.length} queued messages`);
     let replayed = 0;
     let failed = 0;
     let dropped = 0;
+    const deliveredByTopic = new Map<number, number>();
 
     for (const msg of messages) {
-      // Drop messages that have failed too many times — they likely cause crashes
-      const failures = msg.replayFailures ?? 0;
-      // CRITICAL: never drop while a version-skew episode is in flight.
-      // The drop policy assumes failures are transient or message-specific;
-      // a hard incompatibility (HTTP 426) makes EVERY forward fail for a
-      // reason unrelated to the message. Dropping under skew turns a
-      // recoverable outage into silent data loss (the 2026-05-20
-      // b2lead-insights failure mode). Re-queue without incrementing the
-      // failure counter until the lifeline restarts onto a compatible
-      // version and forward starts succeeding again.
-      if (this.versionSkewActive) {
-        this.queue.enqueue(msg);
-        // Don't count toward replay-budget; the next replay tick will
-        // try again after the orchestrator-driven restart.
-        failed++;
-        continue;
-      }
-      if (failures >= TelegramLifeline.MAX_REPLAY_FAILURES) {
-        dropped++;
-        // Before the drop becomes silent: persist the record, report a
-        // degradation, and tell the original sender their message was lost.
-        try {
-          await notifyMessageDropped({
-            stateDir: this.projectConfig.stateDir,
-            topicId: msg.topicId,
-            messageId: msg.id,
-            senderName: msg.fromFirstName ?? msg.fromUsername ?? String(msg.fromUserId),
-            text: msg.text,
-            retryCount: failures,
-            reason: `Handoff to server failed after ${failures} replay attempts`,
-            sendToTopic: (topicId, body) => this.sendToTopic(topicId, body),
-          });
-        } catch (err) {
-          // notifyMessageDropped only throws on true disk failure after the notice/report paths
-          // had their chance — surface and continue; we still want to drop this message so
-          // the queue doesn't stall.
-          console.error(`[Lifeline] notifyMessageDropped threw for ${msg.id}:`, err instanceof Error ? err.message : err);
-        }
-        console.warn(`[Lifeline] Dropping message ${msg.id} after ${failures} replay failures: ${msg.text.slice(0, 80)}`);
-        continue;
-      }
+      // CRITICAL: never drop while a version-skew episode is in flight. A hard
+      // incompatibility (HTTP 426) makes EVERY forward fail for a reason
+      // unrelated to the message; the coordinated restart resolves it. Stop
+      // replaying and leave every remaining message safely on disk (the
+      // 2026-05-20 b2lead-insights silent-drop failure mode).
+      if (this.versionSkewActive) break;
 
-      const forwarded = await this.forwardToServer(msg.topicId, msg.text, {
+      const outcome = await this.forwardToServerClassified(msg.topicId, msg.text, {
         message_id: parseInt(msg.id.replace('tg-', ''), 10) || 0,
         from: {
           id: msg.fromUserId,
@@ -1858,34 +1854,56 @@ export class TelegramLifeline {
         date: Math.floor(new Date(msg.timestamp).getTime() / 1000),
       });
 
-      if (forwarded) {
+      const decision = decideReplay(outcome, {
+        poisonFailures: msg.replayFailures ?? 0,
+        transientFailures: msg.transientReplayFailures ?? 0,
+      });
+
+      if (decision.action === 'delivered') {
+        this.queue.remove(msg.id);
         replayed++;
+        deliveredByTopic.set(msg.topicId, (deliveredByTopic.get(msg.topicId) ?? 0) + 1);
+      } else if (decision.action === 'drop') {
+        dropped++;
+        // Before the drop becomes silent: persist the record, report a
+        // degradation, and tell the original sender their message was lost.
+        try {
+          await notifyMessageDropped({
+            stateDir: this.projectConfig.stateDir,
+            topicId: msg.topicId,
+            messageId: msg.id,
+            senderName: msg.fromFirstName ?? msg.fromUsername ?? String(msg.fromUserId),
+            text: msg.text,
+            retryCount: decision.poisonFailures + decision.transientFailures,
+            reason: decision.dropReason ?? 'Message could not be delivered',
+            sendToTopic: (topicId, body) => this.sendToTopic(topicId, body),
+          });
+        } catch (err) {
+          // notifyMessageDropped only throws on true disk failure after the notice/report paths
+          // had their chance — surface and continue; we still want to drop this message so
+          // the queue doesn't stall.
+          console.error(`[Lifeline] notifyMessageDropped threw for ${msg.id}:`, err instanceof Error ? err.message : err);
+        }
+        console.warn(`[Lifeline] Dropping message ${msg.id}: ${decision.dropReason} — ${msg.text.slice(0, 80)}`);
+        this.queue.remove(msg.id);
       } else {
-        // Re-queue — but only burn replay budget when the server is believed
-        // HEALTHY and still refused the message (a message-specific/poison
-        // failure, which is what the drop policy exists for). A forward that
-        // fails because the server is DOWN (update restart, crash window) says
-        // nothing about the message — same class as the versionSkewActive
-        // exemption above. Without this guard, a multi-minute restart window
-        // with 30s replay ticks burned all 3 attempts in ~90s and dropped
-        // head-of-queue messages (live: 39 dropped on codey, 9 on 2026-06-05
-        // alone, every one "Handoff to server failed" during a bounce).
-        msg.replayFailures = this.supervisor.healthy ? failures + 1 : failures;
-        this.queue.enqueue(msg);
+        // requeue — persist the updated strike counters IN PLACE; the message
+        // stays on disk for the next replay tick. A transient failure NEVER
+        // burns the poison budget, so a slow / overloaded / restarting server
+        // can no longer drop a real message (the 2026-06-06 topic-21487
+        // false-drop bug, where a CPU-starved-but-up server burned all 3
+        // attempts in ~90s and dropped the user's question).
+        this.queue.updateReplayCounters(msg.id, {
+          replayFailures: decision.poisonFailures,
+          transientReplayFailures: decision.transientFailures,
+        });
         failed++;
-        // If the server just went down during replay, stop replaying —
-        // remaining messages will be replayed on next recovery
-        if (!this.supervisor.healthy) {
+        // If the server is unavailable, stop replaying — the remaining messages
+        // are already safely persisted (we only remove on delivery/drop) and
+        // will be retried on the next recovery.
+        if (outcome === 'transient' && !this.supervisor.healthy) {
           const remaining = messages.length - replayed - failed - dropped;
-          if (remaining > 0) {
-            console.log(`[Lifeline] Server went down during replay — re-queuing ${remaining} remaining messages`);
-            // Re-queue remaining unprocessed messages (preserve their failure counts)
-            const currentIndex = messages.indexOf(msg);
-            for (let i = currentIndex + 1; i < messages.length; i++) {
-              this.queue.enqueue(messages[i]);
-            }
-            failed += remaining;
-          }
+          console.log(`[Lifeline] Server unavailable during replay — ${remaining} message(s) remain queued`);
           break;
         }
       }
@@ -1898,15 +1916,10 @@ export class TelegramLifeline {
       console.log(`[Lifeline] Replay complete: ${replayed} delivered, ${failed} re-queued, ${dropped} dropped`);
     }
 
-    // Notify the user that their queued messages were delivered
+    // Notify the user that their queued messages were delivered.
     if (replayed > 0) {
-      // Collect unique topics that received replayed messages
-      const replayedTopics = new Set(
-        messages.filter((_, i) => i < replayed + failed + dropped).map(m => m.topicId)
-      );
-      for (const topicId of replayedTopics) {
+      for (const [topicId, count] of deliveredByTopic) {
         try {
-          const count = messages.filter(m => m.topicId === topicId).length;
           await this.sendToTopic(topicId,
             count === 1
               ? '✓ Server recovered — your queued message has been delivered.'

--- a/src/lifeline/replayPolicy.ts
+++ b/src/lifeline/replayPolicy.ts
@@ -1,0 +1,113 @@
+/**
+ * replayPolicy — the pure decision for what to do with a queued message after
+ * one forward attempt during lifeline queue replay.
+ *
+ * Why this exists (2026-06-06 incident, topic 21487 "Initiatives and maturation
+ * check-ins"): a user's substantive message was queued while the server was
+ * CPU-starved (up enough to pass health, too slow to accept the forward). The
+ * old policy used a single counter and incremented it on EVERY failure while
+ * `supervisor.healthy` was true — so a slow-but-up server burned all 3 attempts
+ * in ~90s and the real message was DROPPED. The user then sent a short nudge,
+ * a fresh session spawned with no context, and it confabulated an unrelated
+ * status report — the "incoherent reply to a one-message topic" symptom.
+ *
+ * The fix: distinguish WHY a forward failed.
+ *   - 'poison'    → the server actively rejected THIS message (HTTP 400
+ *                   bad-request). Message-specific. This — and only this — is
+ *                   what the drop budget exists for.
+ *   - 'transient' → timeout / 5xx / 503-boot / network refusal / server down.
+ *                   A capacity/availability failure that says NOTHING about the
+ *                   message. Must NOT burn the poison budget (the false-drop bug).
+ *   - 'skew'      → version skew (HTTP 426). Handled out-of-band by a coordinated
+ *                   restart; re-queue without burning anything.
+ *   - 'ok'        → delivered.
+ *
+ * A generous transient backstop still bounds unbounded queue growth against a
+ * PERMANENT outage (a server that is unreachable forever), but it is set far
+ * above any normal restart/starvation window so it never false-drops a real
+ * message during a transient episode.
+ */
+
+/** Classification of a single forward attempt's result. */
+export type ForwardOutcome = 'ok' | 'poison' | 'transient' | 'skew';
+
+/** Replay strike counters carried on a queued message. */
+export interface ReplayBudget {
+  /** Strikes from genuine HTTP-400 rejections (message-specific / poison). */
+  poisonFailures: number;
+  /** Strikes from transient capacity/availability failures. */
+  transientFailures: number;
+}
+
+/** What replay should do with the message after this attempt. */
+export interface ReplayDecision {
+  action: 'delivered' | 'requeue' | 'drop';
+  /** Counters to persist when the action is 'requeue'. */
+  poisonFailures: number;
+  transientFailures: number;
+  /** Honest, human-readable reason when the action is 'drop'. */
+  dropReason?: string;
+}
+
+/**
+ * Max times the SERVER may actively reject a specific message (HTTP 400) before
+ * we give up on it. Small — a genuinely malformed forward won't get better.
+ */
+export const MAX_POISON_REPLAY_FAILURES = 3;
+
+/**
+ * Max transient (capacity/availability) failures before we stop re-queuing a
+ * message against a PERMANENTLY unreachable server. Deliberately generous: a
+ * normal restart or CPU-starvation episode accrues at most a handful of strikes
+ * (replay ticks are seconds-to-minutes apart), so this never trips during a
+ * real transient outage — it only bounds the pathological forever-down case.
+ */
+export const MAX_TRANSIENT_REPLAY_FAILURES = 100;
+
+/**
+ * Decide the fate of a queued message after one forward attempt. Pure — no I/O,
+ * no clock, no instance state. Both sides of every boundary are unit-tested.
+ */
+export function decideReplay(outcome: ForwardOutcome, budget: ReplayBudget): ReplayDecision {
+  const poison = budget.poisonFailures ?? 0;
+  const transient = budget.transientFailures ?? 0;
+
+  switch (outcome) {
+    case 'ok':
+      return { action: 'delivered', poisonFailures: poison, transientFailures: transient };
+
+    case 'skew':
+      // Version skew is resolved by a coordinated restart, not by dropping the
+      // message. Re-queue without burning any budget (mirrors the in-flight
+      // versionSkewActive guard in replayQueue).
+      return { action: 'requeue', poisonFailures: poison, transientFailures: transient };
+
+    case 'poison': {
+      const next = poison + 1;
+      if (next >= MAX_POISON_REPLAY_FAILURES) {
+        return {
+          action: 'drop',
+          poisonFailures: next,
+          transientFailures: transient,
+          dropReason: `Server rejected the message ${next} times (bad request) — it cannot be delivered as-is`,
+        };
+      }
+      return { action: 'requeue', poisonFailures: next, transientFailures: transient };
+    }
+
+    case 'transient': {
+      const next = transient + 1;
+      if (next >= MAX_TRANSIENT_REPLAY_FAILURES) {
+        return {
+          action: 'drop',
+          poisonFailures: poison,
+          transientFailures: next,
+          dropReason: `Server was unreachable across ${next} delivery attempts`,
+        };
+      }
+      // The crucial fix: a transient failure NEVER burns the poison budget, so a
+      // slow/overloaded/restarting server can no longer drop a real message.
+      return { action: 'requeue', poisonFailures: poison, transientFailures: next };
+    }
+  }
+}

--- a/tests/unit/lifeline/MessageQueue-durability.test.ts
+++ b/tests/unit/lifeline/MessageQueue-durability.test.ts
@@ -1,0 +1,131 @@
+/**
+ * MessageQueue durability — closes the 2026-06-06 topic-21487 untracked-loss.
+ *
+ * Failure shape: replayQueue used drain(), which emptied the on-disk queue up
+ * front and held the messages only in memory. A process exit mid-replay
+ * (update / version-skew / launchd restart — common during the exact episodes
+ * that trigger queuing) lost the undelivered messages with NO record — not
+ * delivered, not re-queued, not in dropped-messages.json. The user's real
+ * question simply vanished.
+ *
+ * Fix: durable consume — a message leaves the persisted queue only via
+ * remove() (after delivery/drop). updateReplayCounters() persists strike
+ * counts in place. An exit mid-replay leaves undelivered messages on disk for
+ * the next replay.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { MessageQueue, type QueuedMessage } from '../../../src/lifeline/MessageQueue.js';
+import { SafeFsExecutor } from '../../../src/core/SafeFsExecutor.js';
+
+let stateDir: string;
+
+function msg(id: string, topicId = 100): QueuedMessage {
+  return {
+    id,
+    topicId,
+    text: `text-${id}`,
+    fromUserId: 1,
+    fromFirstName: 'Justin',
+    timestamp: '2026-06-06T02:08:00.000Z',
+  };
+}
+
+beforeEach(() => {
+  stateDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mq-durability-'));
+});
+
+afterEach(() => {
+  SafeFsExecutor.safeRmSync(stateDir, {
+    recursive: true,
+    force: true,
+    operation: 'tests/unit/lifeline/MessageQueue-durability.test.ts:afterEach',
+  });
+});
+
+describe('MessageQueue.remove', () => {
+  it('removes only the targeted message and persists to disk', () => {
+    const q = new MessageQueue(stateDir);
+    q.enqueue(msg('tg-1'));
+    q.enqueue(msg('tg-2'));
+    q.enqueue(msg('tg-3'));
+
+    expect(q.remove('tg-2')).toBe(true);
+    expect(q.peek().map(m => m.id)).toEqual(['tg-1', 'tg-3']);
+
+    // Persisted: a fresh queue on the same dir (a new process) sees the change.
+    const reopened = new MessageQueue(stateDir);
+    expect(reopened.peek().map(m => m.id)).toEqual(['tg-1', 'tg-3']);
+  });
+
+  it('returns false and changes nothing for an unknown id', () => {
+    const q = new MessageQueue(stateDir);
+    q.enqueue(msg('tg-1'));
+    expect(q.remove('tg-nope')).toBe(false);
+    expect(q.peek().map(m => m.id)).toEqual(['tg-1']);
+  });
+});
+
+describe('MessageQueue.updateReplayCounters', () => {
+  it('patches strike counters in place and persists; message stays queued', () => {
+    const q = new MessageQueue(stateDir);
+    q.enqueue(msg('tg-1'));
+
+    q.updateReplayCounters('tg-1', { replayFailures: 1, transientReplayFailures: 4 });
+
+    const reopened = new MessageQueue(stateDir);
+    const got = reopened.peek()[0];
+    expect(got.id).toBe('tg-1'); // still on disk
+    expect(got.replayFailures).toBe(1);
+    expect(got.transientReplayFailures).toBe(4);
+  });
+
+  it('is a no-op for an unknown id (no throw)', () => {
+    const q = new MessageQueue(stateDir);
+    q.enqueue(msg('tg-1'));
+    expect(() =>
+      q.updateReplayCounters('tg-gone', { replayFailures: 9, transientReplayFailures: 9 }),
+    ).not.toThrow();
+    expect(q.peek()[0].replayFailures).toBeUndefined();
+  });
+});
+
+describe('durable consume survives a mid-replay process exit', () => {
+  it('delivering one message and exiting leaves the rest on disk (no untracked loss)', () => {
+    // Replay handles tg-1 (delivered → remove), then the process dies before
+    // tg-2/tg-3 are touched. The persisted queue must still hold tg-2, tg-3.
+    const q = new MessageQueue(stateDir);
+    q.enqueue(msg('tg-1'));
+    q.enqueue(msg('tg-2'));
+    q.enqueue(msg('tg-3'));
+
+    // Snapshot (peek, NOT drain) — disk still holds all three.
+    const snapshot = q.peek();
+    expect(snapshot).toHaveLength(3);
+
+    // Deliver the first, then "crash" — simulate by constructing a brand-new
+    // queue from the same dir, as a restarted process would.
+    q.remove('tg-1');
+
+    const afterRestart = new MessageQueue(stateDir);
+    expect(afterRestart.peek().map(m => m.id)).toEqual(['tg-2', 'tg-3']);
+  });
+
+  it('a transient failure persists the strike but keeps the message recoverable after restart', () => {
+    const q = new MessageQueue(stateDir);
+    q.enqueue(msg('tg-1'));
+
+    // Transient failure → bump transient counter in place, leave on disk.
+    q.updateReplayCounters('tg-1', { replayFailures: 0, transientReplayFailures: 1 });
+
+    // Process restarts before delivery — the message and its strike survive.
+    const afterRestart = new MessageQueue(stateDir);
+    const got = afterRestart.peek();
+    expect(got.map(m => m.id)).toEqual(['tg-1']);
+    expect(got[0].transientReplayFailures).toBe(1);
+    expect(got[0].replayFailures).toBe(0); // poison budget never touched
+  });
+});

--- a/tests/unit/lifeline/replayPolicy.test.ts
+++ b/tests/unit/lifeline/replayPolicy.test.ts
@@ -1,0 +1,133 @@
+/**
+ * replayPolicy — both sides of every decision boundary.
+ *
+ * Regression target: the 2026-06-06 topic-21487 "incoherent scope creep"
+ * incident. A CPU-starved-but-up server made every forward time out; the old
+ * single-counter policy burned all 3 attempts in ~90s and DROPPED the user's
+ * real question. The fix: only a genuine HTTP-400 ('poison') burns the drop
+ * budget; transient capacity failures never do.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  decideReplay,
+  MAX_POISON_REPLAY_FAILURES,
+  MAX_TRANSIENT_REPLAY_FAILURES,
+  type ReplayBudget,
+} from '../../../src/lifeline/replayPolicy.js';
+
+const fresh: ReplayBudget = { poisonFailures: 0, transientFailures: 0 };
+
+describe('decideReplay — delivered', () => {
+  it('ok → delivered, counters untouched', () => {
+    const d = decideReplay('ok', { poisonFailures: 1, transientFailures: 5 });
+    expect(d.action).toBe('delivered');
+    expect(d.poisonFailures).toBe(1);
+    expect(d.transientFailures).toBe(5);
+    expect(d.dropReason).toBeUndefined();
+  });
+});
+
+describe('decideReplay — transient (capacity/availability) NEVER burns the poison budget', () => {
+  it('a single transient failure re-queues and increments ONLY the transient counter', () => {
+    const d = decideReplay('transient', fresh);
+    expect(d.action).toBe('requeue');
+    expect(d.transientFailures).toBe(1);
+    expect(d.poisonFailures).toBe(0); // the whole point — poison budget untouched
+  });
+
+  it('THE INCIDENT: many transient failures never trigger a drop and never touch poison', () => {
+    // Replays a CPU-starvation episode: forward keeps timing out for a long
+    // time. Under the OLD policy this dropped the message at 3. Now: never.
+    let budget: ReplayBudget = { ...fresh };
+    for (let i = 0; i < MAX_TRANSIENT_REPLAY_FAILURES - 1; i++) {
+      const d = decideReplay('transient', budget);
+      expect(d.action).toBe('requeue'); // never dropped through the whole episode
+      expect(d.poisonFailures).toBe(0); // poison budget stays pristine
+      budget = { poisonFailures: d.poisonFailures, transientFailures: d.transientFailures };
+    }
+    expect(budget.transientFailures).toBe(MAX_TRANSIENT_REPLAY_FAILURES - 1);
+  });
+
+  it('transient backstop: at the generous cap it finally drops with an honest reason', () => {
+    const d = decideReplay('transient', {
+      poisonFailures: 0,
+      transientFailures: MAX_TRANSIENT_REPLAY_FAILURES - 1,
+    });
+    expect(d.action).toBe('drop');
+    expect(d.transientFailures).toBe(MAX_TRANSIENT_REPLAY_FAILURES);
+    expect(d.dropReason).toMatch(/unreachable/i);
+    expect(d.poisonFailures).toBe(0); // still never burned poison
+  });
+
+  it('one strike below the transient cap still re-queues', () => {
+    const d = decideReplay('transient', {
+      poisonFailures: 0,
+      transientFailures: MAX_TRANSIENT_REPLAY_FAILURES - 2,
+    });
+    expect(d.action).toBe('requeue');
+  });
+});
+
+describe('decideReplay — poison (HTTP 400, message-specific) DOES burn the drop budget', () => {
+  it('first and second poison strike re-queue', () => {
+    const d1 = decideReplay('poison', fresh);
+    expect(d1.action).toBe('requeue');
+    expect(d1.poisonFailures).toBe(1);
+
+    const d2 = decideReplay('poison', { poisonFailures: 1, transientFailures: 0 });
+    expect(d2.action).toBe('requeue');
+    expect(d2.poisonFailures).toBe(2);
+  });
+
+  it('the Nth poison strike drops with a bad-request reason', () => {
+    const d = decideReplay('poison', {
+      poisonFailures: MAX_POISON_REPLAY_FAILURES - 1,
+      transientFailures: 0,
+    });
+    expect(d.action).toBe('drop');
+    expect(d.poisonFailures).toBe(MAX_POISON_REPLAY_FAILURES);
+    expect(d.dropReason).toMatch(/bad request|rejected/i);
+  });
+
+  it('poison strikes do NOT touch the transient counter', () => {
+    const d = decideReplay('poison', { poisonFailures: 0, transientFailures: 7 });
+    expect(d.transientFailures).toBe(7);
+  });
+});
+
+describe('decideReplay — skew (HTTP 426) re-queues without burning anything', () => {
+  it('skew always re-queues and never increments either counter', () => {
+    const d = decideReplay('skew', { poisonFailures: 2, transientFailures: 9 });
+    expect(d.action).toBe('requeue');
+    expect(d.poisonFailures).toBe(2);
+    expect(d.transientFailures).toBe(9);
+  });
+
+  it('skew never drops even at counts that would otherwise be at the poison cap', () => {
+    const d = decideReplay('skew', {
+      poisonFailures: MAX_POISON_REPLAY_FAILURES,
+      transientFailures: MAX_TRANSIENT_REPLAY_FAILURES,
+    });
+    expect(d.action).toBe('requeue');
+  });
+});
+
+describe('decideReplay — the two budgets are independent', () => {
+  it('a message that mixes transient + poison only drops when POISON hits its (small) cap', () => {
+    // Accrue lots of transient strikes, then poison strikes; the poison cap is
+    // the small one and governs the message-specific drop.
+    let budget: ReplayBudget = { poisonFailures: 0, transientFailures: 40 };
+    const p1 = decideReplay('poison', budget);
+    budget = { poisonFailures: p1.poisonFailures, transientFailures: p1.transientFailures };
+    expect(p1.action).toBe('requeue');
+
+    const p2 = decideReplay('poison', budget);
+    budget = { poisonFailures: p2.poisonFailures, transientFailures: p2.transientFailures };
+    expect(p2.action).toBe('requeue');
+
+    const p3 = decideReplay('poison', budget);
+    expect(p3.action).toBe('drop'); // poison cap (3) reached despite 40 transient
+    expect(p3.transientFailures).toBe(40);
+  });
+});

--- a/tests/unit/lifeline/version-skew-recovery.test.ts
+++ b/tests/unit/lifeline/version-skew-recovery.test.ts
@@ -105,12 +105,12 @@ describe('Version-skew recovery — replay drop-policy', () => {
       src.indexOf('private async replayQueue(') + 6000,
     );
     expect(replayLoop).toContain('versionSkewActive');
-    // Drop branch must come AFTER the versionSkew bypass in the loop body.
+    // The per-message replay decision must come AFTER the versionSkew bypass.
     const skewIdx = replayLoop.indexOf('versionSkewActive');
-    const dropIdx = replayLoop.indexOf('MAX_REPLAY_FAILURES');
+    const decisionIdx = replayLoop.indexOf('decideReplay(');
     expect(skewIdx).toBeGreaterThan(0);
-    expect(dropIdx).toBeGreaterThan(0);
-    expect(skewIdx).toBeLessThan(dropIdx);
+    expect(decisionIdx).toBeGreaterThan(0);
+    expect(skewIdx).toBeLessThan(decisionIdx);
   });
 
   it('handleVersionSkew sets the active flag + alert dedupe', () => {
@@ -162,17 +162,17 @@ describe('Version-skew recovery — stuck-lock detection', () => {
   });
 });
 
-describe('Down-server replay drop-policy — restart windows must not burn replay budget', () => {
-  // Failure shape (2026-06-05, codey): each fleet-release restart window made
-  // every forwardToServer fail; 30s replay ticks burned all 3 replay attempts
-  // in ~90s and DROPPED head-of-queue messages. 39 records in codey's
-  // dropped-messages.json, 9 on 2026-06-05 alone, every one
-  // "Handoff to server failed after 3 replay attempts" — including the
-  // mentor's coaching messages. The drop policy exists for message-specific
-  // (poison) failures; a down server says nothing about the message — the
-  // same class the versionSkewActive exemption already covers.
+describe('Replay drop-policy — only a message-specific (HTTP 400) failure may drop a message', () => {
+  // Failure shape (2026-06-05 codey; 2026-06-06 topic-21487): a restart /
+  // CPU-starvation window made every forward fail transiently; the old
+  // single-counter policy (`supervisor.healthy ? failures + 1 : failures`)
+  // burned all 3 attempts and DROPPED real messages. The classified policy
+  // (replayPolicy.decideReplay) only burns the drop budget on a genuine 400
+  // ('poison'); timeout / 5xx / 503-boot / network refusal are 'transient' and
+  // never drop a real message. The behavioral coverage lives in
+  // tests/unit/lifeline/replayPolicy.test.ts — these assertions pin the wiring.
 
-  it('replay failure increments the budget ONLY when the supervisor believes the server is healthy', () => {
+  it('replayQueue routes failures through the classified forward + decideReplay (not the old healthy-gated counter)', () => {
     const src = fs.readFileSync(
       path.join(repoRoot, 'src', 'lifeline', 'TelegramLifeline.ts'),
       'utf-8',
@@ -183,15 +183,16 @@ describe('Down-server replay drop-policy — restart windows must not burn repla
       8000,
     );
     expect(replayLoop).toBeTruthy();
-    // The healthy-gated increment must be present in the failure branch…
-    expect(replayLoop).toMatch(
-      /replayFailures\s*=\s*this\.supervisor\.healthy\s*\?\s*failures\s*\+\s*1\s*:\s*failures/,
+    // New policy is wired in…
+    expect(replayLoop).toContain('forwardToServerClassified(');
+    expect(replayLoop).toContain('decideReplay(');
+    // …and the old coarse single-counter increment is GONE.
+    expect(replayLoop).not.toMatch(
+      /replayFailures\s*=\s*this\.supervisor\.healthy\s*\?\s*failures\s*\+\s*1/,
     );
-    // …and the old unconditional increment must be gone.
-    expect(replayLoop).not.toMatch(/replayFailures\s*=\s*failures\s*\+\s*1\s*;/);
   });
 
-  it('the healthy-gated increment lives in the same loop as the drop check (one policy, one place)', () => {
+  it('replay consumes the queue DURABLY (peek + remove), never drain() — no untracked loss', () => {
     const src = fs.readFileSync(
       path.join(repoRoot, 'src', 'lifeline', 'TelegramLifeline.ts'),
       'utf-8',
@@ -202,12 +203,29 @@ describe('Down-server replay drop-policy — restart windows must not burn repla
       8000,
     );
     expect(replayLoop).toBeTruthy();
-    const guardIdx = replayLoop!.indexOf('this.supervisor.healthy ? failures + 1');
-    const dropIdx = replayLoop!.indexOf('MAX_REPLAY_FAILURES');
-    expect(guardIdx).toBeGreaterThan(0);
-    expect(dropIdx).toBeGreaterThan(0);
-    // Drop check first (top of loop), guarded increment in the failure branch.
-    expect(dropIdx).toBeLessThan(guardIdx);
+    // A message leaves the persisted queue only after delivery/drop.
+    expect(replayLoop).toContain('this.queue.peek()');
+    expect(replayLoop).toContain('this.queue.remove(');
+    expect(replayLoop).toContain('this.queue.updateReplayCounters(');
+    // The destructive up-front drain() must NOT be used by replay.
+    expect(replayLoop).not.toContain('this.queue.drain()');
+  });
+
+  it('forwardToServerClassified maps a 400 to poison and everything else to transient/skew', () => {
+    const src = fs.readFileSync(
+      path.join(repoRoot, 'src', 'lifeline', 'TelegramLifeline.ts'),
+      'utf-8',
+    );
+    const fn = extractSectionAroundFirstMatch(
+      src,
+      /private async forwardToServerClassified\(/,
+      8000,
+    );
+    expect(fn).toBeTruthy();
+    expect(fn).toMatch(/ForwardBadRequestError\)\s*return 'poison'/);
+    expect(fn).toContain("return 'transient'");
+    expect(fn).toContain("return 'skew'");
+    expect(fn).toContain("return 'ok'");
   });
 });
 

--- a/upgrades/next/lifeline-replay-budget-classification.md
+++ b/upgrades/next/lifeline-replay-budget-classification.md
@@ -1,0 +1,28 @@
+<!-- bump: patch -->
+
+## What Changed
+
+Fixes two real defects in the Telegram lifeline's queue-replay path that, together, caused the "incoherent reply to a one-message topic" symptom (2026-06-06, topic 21487): a user's substantive message was lost during a server CPU-starvation episode, then a later short nudge spawned a session with no context that confabulated an unrelated status report.
+
+1. **False-drop fix.** `replayQueue` previously burned a single failure counter on every forward failure while `supervisor.healthy` was true. Under CPU starvation the server is healthy-but-too-slow, so forwards time out, all 3 attempts burn in ~90s, and the real message is dropped ("Handoff to server failed after 3 replay attempts" — 32 such drops on echo, including live operator messages). A new `forwardToServerClassified` distinguishes a genuine HTTP-400 rejection (`poison` — the only message-specific failure) from transient timeout/5xx/503/network/skew failures. A new pure `decideReplay` policy (`src/lifeline/replayPolicy.ts`) burns the small poison drop-budget only on a 400; transient failures never drop a real message. A generous transient backstop still bounds a permanently-unreachable server.
+
+2. **Untracked-loss fix.** `MessageQueue.drain()` emptied the persisted queue up front, holding messages only in memory; a process exit mid-replay (update / version-skew / launchd restart) lost undelivered messages with no record — not even in `dropped-messages.json`. `replayQueue` now consumes durably: it works from `peek()` and removes a message from the persisted queue only after delivery or a deliberate drop, persisting strike counters in place via `updateReplayCounters()`. A mid-replay restart can no longer lose a message.
+
+The persisted queue gains an additive, back-compatible `transientReplayFailures` field; no migration is needed.
+
+## What to Tell Your User
+
+Nothing required — this is a behind-the-scenes reliability fix. If your machine was overloaded, the part of me that catches your messages while the server is busy could, in rare cases, give up on a message and throw it away as if it were broken — or lose one entirely if I restarted at the wrong moment. That is now fixed: a busy or restarting server makes your message wait in line and get retried instead of being discarded, and a message only leaves the line once it is actually delivered. The practical effect is that you should stop seeing replies that have nothing to do with what you asked.
+
+## Summary of New Capabilities
+
+- The lifeline now classifies a failed message handoff as either a genuinely-bad message (only an HTTP-400 server rejection) or a transient capacity failure (timeout, server-busy, network) — and only a genuinely-bad message can ever exhaust the drop budget.
+- Queued messages are consumed durably: a message leaves the on-disk queue only after it is delivered or deliberately dropped, so a restart mid-replay cannot silently lose it.
+- A generous transient backstop drops a message only after a server has been unreachable across many attempts, always with an honest record and a resend notice — never silently.
+
+## Evidence
+
+- `tests/unit/lifeline/replayPolicy.test.ts` — both sides of every decision boundary, including the incident regression: many consecutive transient failures never drop a message and never touch the poison budget.
+- `tests/unit/lifeline/MessageQueue-durability.test.ts` — `remove`/`updateReplayCounters` persist correctly; a simulated mid-replay process exit leaves undelivered messages on disk (no untracked loss).
+- `tests/unit/lifeline/version-skew-recovery.test.ts` — updated to pin the new wiring (classified forward + `decideReplay` + durable peek/remove).
+- Local verification: `tsc --noEmit` clean, all 9 lint gates clean, 157/157 lifeline unit tests + the stage-c chaos integration test green, 28 new/updated targeted tests green. Full unit suite deferred to CI (timed out locally under the live CPU-starvation episode this fix addresses).

--- a/upgrades/side-effects/lifeline-replay-budget-classification.md
+++ b/upgrades/side-effects/lifeline-replay-budget-classification.md
@@ -1,0 +1,97 @@
+# Side-Effects Review — Lifeline replay budget classification + durable consume
+
+**Version / slug:** `lifeline-replay-budget-classification`
+**Date:** `2026-06-06`
+**Author:** `echo`
+**Second-pass reviewer:** `not required`
+
+## Summary of the change
+
+The Telegram lifeline's queue-replay path was dropping legitimate user messages during server-overload/restart windows, and could also lose a queued message with no record at all if the process exited mid-replay. Two fixes:
+
+1. `forwardToServerClassified()` (new) returns a classification (`ok` | `poison` | `transient` | `skew`) instead of a bare boolean, so replay can tell a message-specific HTTP-400 rejection ("poison") from a transient capacity/availability failure (timeout / 5xx / 503-boot / network refusal / 426 skew). A new pure module `src/lifeline/replayPolicy.ts` (`decideReplay`) burns the small poison drop-budget ONLY on a 400; transient failures never drop a real message (a generous transient backstop bounds a permanently-unreachable server).
+2. `replayQueue()` now consumes the queue durably: it works from `queue.peek()` and removes a message from the persisted queue only after delivery or a deliberate drop (`queue.remove()`), persisting strike counters in place via `queue.updateReplayCounters()`. The old `queue.drain()` emptied the on-disk queue up front, so a mid-replay process exit lost in-memory messages untracked.
+
+Files touched: `src/lifeline/replayPolicy.ts` (new), `src/lifeline/MessageQueue.ts` (`remove`, `updateReplayCounters`, `transientReplayFailures` field), `src/lifeline/TelegramLifeline.ts` (`forwardToServerClassified` + rewritten `replayQueue`). Tests: `tests/unit/lifeline/replayPolicy.test.ts`, `tests/unit/lifeline/MessageQueue-durability.test.ts`, updated `tests/unit/lifeline/version-skew-recovery.test.ts`.
+
+## Decision-point inventory
+
+- `replayQueue drop budget` — **modify** — was a single `replayFailures` counter incremented whenever `supervisor.healthy`; now a classified poison/transient split via `decideReplay`.
+- `forwardToServer result` — **add** — new `forwardToServerClassified` returns a 4-way classification; the boolean `forwardToServer` is now a façade over it (unchanged for its inbound-handler callers).
+- `MessageQueue consume semantics` — **modify** — replay switched from destructive `drain()` to durable `peek()` + `remove()`/`updateReplayCounters()`.
+
+---
+
+## 1. Over-block
+
+**What legitimate inputs does this change reject that it shouldn't?**
+
+This change makes the path strictly MORE accepting, not less — its purpose is to stop wrongly discarding legitimate messages. The only message that can still be dropped on the poison path is one the server itself rejects with HTTP 400 three times, which is the same threshold as before (just now scoped to 400 instead of any failure). No legitimate message is newly rejected.
+
+---
+
+## 2. Under-block
+
+**What failure modes does this still miss?**
+
+- A message that genuinely crashes the SERVER on forward would surface as a network error / 5xx → classified transient → retried rather than dropped. Mitigation: the generous `MAX_TRANSIENT_REPLAY_FAILURES` backstop eventually drops it (with an honest "server unreachable" record). In practice the forward handler only persists/queues the inbound — it does not execute message-specific logic — so a single user message crashing the forward path is not a realistic vector; the real message-specific signal is the 400, which is still budgeted.
+- A permanently-unreachable server delays delivery up to the transient backstop before dropping. Acceptable: late delivery beats false drop, and the drop is loud (record + resend notice) when it finally happens.
+
+---
+
+## 3. Level-of-abstraction fit
+
+`decideReplay` is a pure decision function (no I/O, no clock, no instance state) — the correct layer for an exhaustively-testable policy. It is consumed by `replayQueue` (the orchestrator that owns the queue and the side effects). The classification lives where the forward already knows the HTTP outcome (`forwardToServerClassified`), reusing the existing typed `forwardErrors` (`ForwardBadRequestError` etc.) rather than re-deriving status. No higher-level gate is bypassed; this is internal to the lifeline process.
+
+---
+
+## 4. Signal vs authority compliance
+
+**Required reference:** [docs/signal-vs-authority.md](../../docs/signal-vs-authority.md)
+
+- [x] No — this change has no user-facing block/allow surface. It governs whether an undeliverable queued message is retried or dropped; the "authority" is a deterministic, exhaustively-tested pure function over a typed HTTP-outcome classification, not a brittle content heuristic. It can only make delivery more robust than the prior single-counter policy.
+
+---
+
+## 5. Interactions
+
+- **Shadowing:** the `versionSkewActive` top-of-loop guard still precedes the per-message decision (asserted in `version-skew-recovery.test.ts`); a skew episode stops replay and leaves messages on disk, unchanged in spirit.
+- **Double-fire:** `forwardToServer` (boolean façade) and `forwardToServerClassified` share one implementation, so no path forwards twice. Inbound-handler callers (`handleMessage`/photo/doc) are unchanged.
+- **Races:** durable consume is id-based (`remove(id)`, `updateReplayCounters(id)`), so a message enqueued concurrently during replay is untouched and picked up next tick. `MessageQueue` ops are synchronous (no await between read and save).
+- **Feedback loops:** none — replay does not feed its own input.
+
+---
+
+## 6. External surfaces
+
+- **Telegram:** the "✓ Server recovered — N delivered" notice now counts only ACTUALLY-delivered messages per topic (previously counted all batch messages for the topic, including failed/dropped). Strictly more accurate; no format change. The dropped-message "please resend" notice is unchanged.
+- **Persistent state:** `lifeline-queue.json` gains an optional `transientReplayFailures` field per message. Additive, back-compatible — old queue files (with only `replayFailures`) load and default the new field to 0. `replayFailures` retains its on-disk name (now the poison counter). No migration needed.
+- **Other agents/users:** none — this is per-agent lifeline behavior.
+
+---
+
+## 7. Rollback cost
+
+Pure code change. Revert and ship as the next patch. The added `transientReplayFailures` field is additive and ignored by older code on downgrade (it only reads `replayFailures`). No data migration, no agent-state repair, no user-visible regression during the rollback window.
+
+---
+
+## Conclusion
+
+The review surfaced one residual (a server-crashing message classified transient) and confirmed it is covered by the transient backstop and is not a realistic vector given the forward handler's role. The change is monotonically safer for delivery, fully reversible, and back-compatible on disk. Clear to ship. Classified Tier 1 (delivery-path risk floor is 2; declared below floor with this artifact + exhaustive both-sides tests + reversibility as the compensating rigor — recorded as `belowFloor` in the gate audit and disclosed to the operator).
+
+---
+
+## Second-pass review (if required)
+
+**Reviewer:** not required (Tier 1)
+**Independent read of the artifact: not required**
+
+---
+
+## Evidence pointers
+
+- `tests/unit/lifeline/replayPolicy.test.ts` — both sides of every boundary incl. the incident regression (many transient failures never drop, never touch poison).
+- `tests/unit/lifeline/MessageQueue-durability.test.ts` — remove/update persist; mid-replay restart loses nothing.
+- `tests/unit/lifeline/version-skew-recovery.test.ts` — updated wiring assertions (classified forward + decideReplay + durable peek/remove).
+- Local: tsc clean, all 9 lint gates clean, 157/157 lifeline unit tests + chaos integration green, 28 new/updated targeted tests green. Full unit suite deferred to CI (timed out locally under the live CPU-starvation episode this fix addresses).


### PR DESCRIPTION
## ELI16 — when the server is slow, your message waits in line; it never gets thrown away

When my server gets overloaded (the recent macOS CPU pileup), the piece that catches your Telegram messages while the server is busy would try to hand a message over, time out a few times in about 90 seconds, and then **throw the message away** — treating "the server is too busy right now" exactly like "this message is broken." Worse, the waiting line emptied itself to disk *before* confirming delivery, so a restart at the wrong moment could lose a message with no record at all. That combination is why a real question vanished and a later "checking in" got an unrelated reply. This PR makes the lifeline tell those two failures apart: only a message the server actively rejects (an HTTP 400) can ever be dropped; a busy/slow/restarting server just keeps the message in line and retries it, and a message leaves the line only once it's actually delivered.

## Problem

Justin flagged "incoherent scope creep" (2026-06-06, topic 21555): a Telegram topic had **one** substantive message, and the agent's reply had **nothing to do with it**. Grounding traced it to a real defect chain, not an off-topic LLM:

1. The user's substantive question (topic 21487, 6:08pm) arrived during a macOS CPU-starvation episode. The lifeline queued it ("queued, 2 in queue").
2. The server was `supervisor.healthy === true` but too slow to accept the forward, so it timed out. **All 3 replay attempts burned in ~90s and the message was dropped** — `dropped-messages.json` holds 32 such "Handoff to server failed after 3 replay attempts" records on echo, including live operator messages on topics 20905 ("C, and yes proceed") and 13435.
3. The substantive message for topic 21487 wasn't even in the dropped log — it **vanished untracked** (the `drain()` hole below).
4. An hour later a short "checking in here" nudge spawned a fresh session with no context, which confabulated a generic status report — the symptom Justin saw.

## Two defects, both fixed

**1. False-drop.** `replayQueue` burned a single failure counter on *every* forward failure while `supervisor.healthy` was true (a coarse proxy added in the 2026-06-05 down-server guard). Under CPU starvation the server is healthy-but-too-slow, so transient timeouts exhausted the budget and dropped real messages.

- New `forwardToServerClassified()` returns `ok | poison | transient | skew` instead of a bare boolean, reusing the existing typed `forwardErrors`.
- New pure module `src/lifeline/replayPolicy.ts` (`decideReplay`): only a genuine HTTP-400 (`poison`) burns the small drop budget; timeout/5xx/503/network/skew are `transient` and **never** drop a real message. A generous transient backstop bounds a permanently-unreachable server.

**2. Untracked-loss.** `MessageQueue.drain()` emptied the persisted queue up front, holding messages only in memory — a process exit mid-replay (update / version-skew / launchd restart) lost undelivered messages with no record. `replayQueue` now consumes **durably**: works from `peek()`, removes a message only after delivery or a deliberate drop, persists strike counters in place via `updateReplayCounters()`. The queue gains an additive, back-compatible `transientReplayFailures` field — no migration.

## Tests

- `tests/unit/lifeline/replayPolicy.test.ts` — both sides of every boundary incl. the incident regression (many transient failures never drop, never touch poison).
- `tests/unit/lifeline/MessageQueue-durability.test.ts` — remove/update persist; a simulated mid-replay restart loses nothing.
- `tests/unit/lifeline/version-skew-recovery.test.ts` — updated wiring assertions.
- Local: tsc clean, all 9 lint gates clean, **157/157 lifeline unit tests + chaos integration green, 28 new/updated targeted tests green**. Full unit suite deferred to CI (timed out locally under the live CPU-starvation episode this fixes).

## Tier / process

Classified **Tier 1** with a declared, audited below-floor override (the delivery path carries `riskFloor ≥ 2`): the change is monotonically safer for delivery, reversible, additive-on-disk, and exhaustively tested on both boundaries — heightened care met by tests + reversibility rather than a full converged spec. Side-effects artifact + ELI16 companion shipped; `belowFloor:true` recorded in the gate audit. The operator was told and can request the heavier spec review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
