### PR TITLE
feat(dashboard): pool-stream phase 2a — serving endpoint (ticket auth + /pool-stream)

### DIFF
--- a/.instar/instar-dev-decisions/2026-06-07T06-49-18-953Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-06-07T06-49-18-953Z-unknown.json
@@ -1,0 +1,15 @@
+{
+  "ts": "2026-06-07T06:49:18.953Z",
+  "slug": "unknown",
+  "suggestedTier": 2,
+  "declaredTier": 2,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "new capability: new exported class / subsystem added"
+  ],
+  "belowFloor": false,
+  "files": 7,
+  "loc": 340,
+  "causalAutopsy": null,
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-06-07T06-49-39-727Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-06-07T06-49-39-727Z-unknown.json
@@ -1,0 +1,15 @@
+{
+  "ts": "2026-06-07T06:49:39.727Z",
+  "slug": "unknown",
+  "suggestedTier": 2,
+  "declaredTier": 2,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "new capability: new exported class / subsystem added"
+  ],
+  "belowFloor": false,
+  "files": 7,
+  "loc": 340,
+  "causalAutopsy": null,
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-06-07T06-50-41-477Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-06-07T06-50-41-477Z-unknown.json
@@ -1,0 +1,15 @@
+{
+  "ts": "2026-06-07T06:50:41.477Z",
+  "slug": "unknown",
+  "suggestedTier": 2,
+  "declaredTier": 2,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "new capability: new exported class / subsystem added"
+  ],
+  "belowFloor": false,
+  "files": 7,
+  "loc": 340,
+  "causalAutopsy": null,
+  "verdict": "pass"
+}

--- a/.instar/instar-dev-traces/2026-06-07T06-47-23-890Z-dashboard-stream-phase2a-serving-fb85320d.json
+++ b/.instar/instar-dev-traces/2026-06-07T06-47-23-890Z-dashboard-stream-phase2a-serving-fb85320d.json
@@ -1,0 +1,22 @@
+{
+  "version": 2,
+  "sessionId": "cbdc2d51-a6de-446b-8215-773ec12f8e0b",
+  "timestamp": "2026-06-07T06:47:23.890Z",
+  "artifactPath": "upgrades/side-effects/dashboard-stream-phase2a-serving.md",
+  "artifactSha256": "25acef61806ac62d5f6f20513e21cfb658d55d0297e8b2aca36e2414fde140c1",
+  "specPath": "docs/specs/POOL-DASHBOARD-STREAM-SPEC.md",
+  "coveredFiles": [
+    "src/commands/server.ts",
+    "src/core/MeshRpc.ts",
+    "src/server/AgentServer.ts",
+    "src/server/StreamTicketStore.ts",
+    "src/server/WebSocketManager.ts",
+    "tests/e2e/pool-stream-serving-alive.test.ts",
+    "tests/unit/StreamTicketStore.test.ts"
+  ],
+  "phase": "complete",
+  "tier": 2,
+  "tierReasoning": "Serving side of the approved dashboard-streaming spec: new StreamTicketStore subsystem + /pool-stream WS endpoint + pool-stream-ticket mesh verb + serving-side input/name gates. Reuses existing WSManager client path + mesh auth (no new auth surface). 11 ticket-store unit tests + 6 real-server feature-alive e2e tests covering every security boundary (single-use, expiry, replay-across-restart, input-default-off, tmux-injection-refused).",
+  "secondPass": "not-required",
+  "reviewerConcurred": null
+}

--- a/.instar/instar-dev-traces/2026-06-07T06-49-54-780Z-dashboard-stream-phase2a-serving-ee08a5b7.json
+++ b/.instar/instar-dev-traces/2026-06-07T06-49-54-780Z-dashboard-stream-phase2a-serving-ee08a5b7.json
@@ -1,0 +1,25 @@
+{
+  "version": 2,
+  "sessionId": "cbdc2d51-a6de-446b-8215-773ec12f8e0b",
+  "timestamp": "2026-06-07T06:49:54.780Z",
+  "artifactPath": "upgrades/side-effects/dashboard-stream-phase2a-serving.md",
+  "artifactSha256": "25acef61806ac62d5f6f20513e21cfb658d55d0297e8b2aca36e2414fde140c1",
+  "specPath": "docs/specs/POOL-DASHBOARD-STREAM-SPEC.md",
+  "coveredFiles": [
+    "src/commands/server.ts",
+    "src/core/MeshRpc.ts",
+    "src/core/types.ts",
+    "src/data/state-coherence-registry.json",
+    "src/server/AgentServer.ts",
+    "src/server/StreamTicketStore.ts",
+    "src/server/WebSocketManager.ts",
+    "tests/e2e/pool-stream-serving-alive.test.ts",
+    "tests/unit/StreamTicketStore.test.ts",
+    "tests/unit/WebSocketManager.test.ts"
+  ],
+  "phase": "complete",
+  "tier": 2,
+  "tierReasoning": "Serving side of the approved dashboard-streaming spec: StreamTicketStore subsystem + /pool-stream WS endpoint + pool-stream-ticket mesh verb + serving-side input/name gates + config type + state-registry entry. Reuses existing WSManager client path + mesh auth (no new auth surface). 11 ticket-store unit tests + 6 real-server feature-alive e2e tests covering every security boundary.",
+  "secondPass": "not-required",
+  "reviewerConcurred": null
+}

--- a/docs/specs/POOL-DASHBOARD-STREAM-SPEC.eli16.md
+++ b/docs/specs/POOL-DASHBOARD-STREAM-SPEC.eli16.md
@@ -44,3 +44,9 @@ The design is written and reviewed. Building it is the next phase — it's a rea
 feature (a new streaming relay, the secure pass, and the dashboard screens for
 every state), so it goes through the full build-and-test pipeline like everything
 else, not a quick patch. I've registered it so it doesn't get lost.
+
+## Phase 2a shipped — the serving side (the machine that HAS the session)
+
+The machine that owns a session can now safely hand its live terminal to another of your machines. When your laptop wants to watch a session running on the Mini, it first asks the Mini (over the already-secure machine-to-machine channel) for a one-time pass. The Mini hands back a single-use ticket that expires in a minute and can't be reused — even if the Mini restarts in between. The laptop opens a streaming connection to the Mini using that ticket; the Mini checks it once, then streams the terminal.
+
+Two safety rails are live and tested: typing into a remote machine's session is OFF by default (you opt in per machine), so by default another machine can only WATCH, never type; and a session name is checked against a strict safe-character list and confirmed to actually be running before anything touches the terminal — so a malformed or made-up name can never reach the machine's shell. Six real end-to-end tests prove all of this over actual sockets (valid ticket streams, bad ticket rejected, ticket can't be reused, typing blocked by default, typing works when enabled, malformed name refused). Still to come: the laptop side that opens these connections automatically when you click a tile (phase 2b) and the on-screen states (phase 3).

--- a/src/commands/server.ts
+++ b/src/commands/server.ts
@@ -385,6 +385,10 @@ let _resolvePeerUrls: (() => Array<{ machineId: string; url: string }>) | null =
 let _topicPinStore: import('../core/TopicPlacementPinStore.js').TopicPlacementPinStore | null = null;
 /** Cross-machine secret-sync (spec Phase 4): route-facing handle (push lever + read-only status). */
 let _secretSyncHandle: import('../core/SecretSync.js').SecretSyncHandle | null = null;
+/** Pool Dashboard Streaming (POOL-DASHBOARD-STREAM-SPEC §2.3): shared single-use
+ *  ticket store — minted by the `pool-stream-ticket` mesh verb, consumed by the
+ *  WebSocketManager's /pool-stream upgrade. Constructed in the mesh-setup block. */
+let _streamTicketStore: import('../server/StreamTicketStore.js').StreamTicketStore | null = null;
 /** Recognize + apply a "move/run this on <nickname>" relocation on inbound; returns handled=true when the message WAS a relocation command (so it must not also be dispatched). */
 let _tryNicknameRelocation: ((topicId: number, text: string) => Promise<{ handled: boolean }>) | null = null;
 /** Per-topic framework override (claude-code | codex-cli). Populated from
@@ -10500,6 +10504,20 @@ export async function startServer(options: StartOptions): Promise<void> {
         ?? (meshIdMgr?.hasIdentity() ? meshIdMgr.loadIdentity().machineId : null);
       if (meshIdMgr && meshSelfId) {
         const meshClockToleranceMs = config.multiMachine?.sessionPool?.meshRpcClockToleranceMs ?? 30000;
+        // Pool Dashboard Streaming (§2.3): the shared single-use ticket store —
+        // the `pool-stream-ticket` verb mints into it; the WS /pool-stream
+        // upgrade consumes from it. Crypto-random tickets; persisted so a
+        // captured ticket can't replay across a restart.
+        {
+          const stsMod = await import('../server/StreamTicketStore.js');
+          const cryptoMod = await import('node:crypto');
+          _streamTicketStore = new stsMod.StreamTicketStore({
+            filePath: path.join(config.stateDir, 'state', 'stream-tickets.json'),
+            now: () => Date.now(),
+            mintId: () => cryptoMod.randomBytes(32).toString('hex'),
+            logger: (m) => console.log(pc.dim(`  ${m}`)),
+          });
+        }
         const seenMeshNonces = new Map<string, number>(); // `${sender}:${nonce}` → ts, age-pruned
         const meshPruneMs = Math.max(meshClockToleranceMs * 4, 120_000);
         // SessionOwnership registry (§L3) — in-memory store (single-machine correct;
@@ -10720,6 +10738,17 @@ export async function startServer(options: StartOptions): Promise<void> {
                 ? commitmentTracker.getReplicationAdvert() ?? undefined
                 : undefined;
               return { ...base, journalAdvert, ...(commitmentsAdvert ? { commitmentsAdvert } : {}) };
+            },
+            // Pool Dashboard Streaming (§2.3): mint a single-use bearer ticket
+            // for the authenticated peer so it may open a /pool-stream WS to
+            // watch `session`. verifyEnvelope already proved the peer's identity;
+            // the ticket is bound to that sender and consumed once on upgrade.
+            'pool-stream-ticket': (cmd, sender) => {
+              const c = cmd as import('../core/MeshRpc.js').MeshCommand & { type: 'pool-stream-ticket' };
+              if (!_streamTicketStore) return { ok: false, reason: 'pool-stream disabled' };
+              if (!c.session || typeof c.session !== 'string') return { ok: false, reason: 'session required' };
+              const minted = _streamTicketStore.mint(sender);
+              return { ok: true, ticket: minted.ticket, expiresAtMs: minted.expiresAtMs };
             },
             // COHERENCE-JOURNAL-SPEC §3.4 — always-registered journal-sync verb
             // (harmless when no peer sends): serve our OWN stream on `request`
@@ -11711,7 +11740,7 @@ export async function startServer(options: StartOptions): Promise<void> {
       console.log(pc.dim(`  [session-pool] rollout gate not wired: ${err instanceof Error ? err.message : String(err)}`));
     }
 
-    const server = new AgentServer({ config, sessionManager, state, scheduler, telegram, relationships, feedback, feedbackAnomalyDetector, dispatches, updateChecker, autoUpdater, autoDispatcher, quotaTracker, quotaManager, publisher, viewer, tunnel, evolution, watchdog, topicMemory, triageNurse, projectMapper, coherenceGate: scopeVerifier, contextHierarchy, canonicalState, operationGate, sentinel, adaptiveTrust, memoryMonitor, orphanReaper, coherenceMonitor, commitmentTracker, subscriptionPool, quotaPoller, semanticMemory, activitySentinel, rateLimitSentinel, releaseReadinessSentinel: releaseReadinessSentinel ?? undefined, messageRouter, summarySentinel, spawnManager, systemReviewer, capabilityMapper, selfKnowledgeTree, coverageAuditor, topicResumeMap: _topicResumeMap ?? undefined, sessionRefresh: _sessionRefresh ?? undefined, autonomyManager, trustElevationTracker, autonomousEvolution, coordinator: coordinator.enabled ? coordinator : undefined, localSigningKeyPem, leaseTransport, onLeasePullRequest: () => leaseCoordinatorRef?.currentLease() ?? null, liveTailReceiver, handoffWireTransport, onHandoffBegin, onHandoffInitiate: handoffInitiate, handoffInProgress: handoffSentinelInProgress, messageLedger, currentInboundByTopic, replyMarkerTransport, onReplyMarker: messageLedger ? (marker: unknown) => { const m = marker as { dedupeKey: string; platform: string; replyIdempotencyKey: string; epoch: number; topic?: string | null }; messageLedger!.applyRemoteReplyMarker(m.dedupeKey, { platform: m.platform, replyIdempotencyKey: m.replyIdempotencyKey, epoch: m.epoch, topic: m.topic ?? null }); } : undefined, whatsapp: whatsappAdapter, slack: slackAdapter, imessage: imessageAdapter, whatsappBusinessBackend, messageBridge, hookEventReceiver, worktreeMonitor, subagentTracker, instructionsVerifier, handshakeManager: threadlineHandshake, threadlineRouter, conversationStore, warrantsReplyGate, collaborationSurfacer, threadResumeMap, topicLinkageHandler: topicLinkageHandler ?? undefined, threadlineRelayClient, threadlineReplyWaiters, listenerManager: listenerManager ?? undefined, a2aDeliveryTracker: a2aDeliveryTracker ?? undefined, responseReviewGate, messagingToneGate, outboundDedupGate, telemetryHeartbeat, pasteManager, featureRegistry, discoveryEvaluator, completionEvaluator, unifiedTrust, liveConfig, sharedStateLedger, ledgerSessionRegistry, worktreeManager, oidcEnrolledRepos: parallelDevConfig?.oidcEnrolledRepos, initiativeTracker, projectRoundRunner, projectDriftChecker, machineHeartbeat, machinePoolRegistry, meshRpcDispatcher, workingSetPullCoordinator, commitmentReplicaStore, forwardCommitmentMutate, sessionOwnershipRegistry, topicPinStore: _topicPinStore ?? undefined, secretSync: _secretSyncHandle ?? undefined, meshSelfId: _meshSelfId ?? undefined, resolveRouterUrl: _resolveRouterUrl ?? undefined, resolvePeerUrls: _resolvePeerUrls ?? undefined, sessionPoolE2EResultStore, proxyCoordinator, topicIntentStore, topicIntentArcCheck, usherSignalStore, intelligence: sharedIntelligence ?? undefined, telegramBridgeConfig, telegramBridge: telegramBridge ?? undefined, threadlineObservability, briefDeps, workingMemory, taskFlowRegistry, threadlineFlowBridge, sessionReaper, agentWorktreeReaper, mcpProcessReaper, geminiLoopRunner, sleepController, agentActivityState, reapLog, sleepWakeDetector, unjustifiedStopGate, stopGateDb, stopNotifier });
+    const server = new AgentServer({ config, sessionManager, state, scheduler, telegram, relationships, feedback, feedbackAnomalyDetector, dispatches, updateChecker, autoUpdater, autoDispatcher, quotaTracker, quotaManager, publisher, viewer, tunnel, evolution, watchdog, topicMemory, triageNurse, projectMapper, coherenceGate: scopeVerifier, contextHierarchy, canonicalState, operationGate, sentinel, adaptiveTrust, memoryMonitor, orphanReaper, coherenceMonitor, commitmentTracker, subscriptionPool, quotaPoller, semanticMemory, activitySentinel, rateLimitSentinel, releaseReadinessSentinel: releaseReadinessSentinel ?? undefined, messageRouter, summarySentinel, spawnManager, systemReviewer, capabilityMapper, selfKnowledgeTree, coverageAuditor, topicResumeMap: _topicResumeMap ?? undefined, sessionRefresh: _sessionRefresh ?? undefined, autonomyManager, trustElevationTracker, autonomousEvolution, coordinator: coordinator.enabled ? coordinator : undefined, localSigningKeyPem, leaseTransport, onLeasePullRequest: () => leaseCoordinatorRef?.currentLease() ?? null, liveTailReceiver, handoffWireTransport, onHandoffBegin, onHandoffInitiate: handoffInitiate, handoffInProgress: handoffSentinelInProgress, messageLedger, currentInboundByTopic, replyMarkerTransport, onReplyMarker: messageLedger ? (marker: unknown) => { const m = marker as { dedupeKey: string; platform: string; replyIdempotencyKey: string; epoch: number; topic?: string | null }; messageLedger!.applyRemoteReplyMarker(m.dedupeKey, { platform: m.platform, replyIdempotencyKey: m.replyIdempotencyKey, epoch: m.epoch, topic: m.topic ?? null }); } : undefined, whatsapp: whatsappAdapter, slack: slackAdapter, imessage: imessageAdapter, whatsappBusinessBackend, messageBridge, hookEventReceiver, worktreeMonitor, subagentTracker, instructionsVerifier, handshakeManager: threadlineHandshake, threadlineRouter, conversationStore, warrantsReplyGate, collaborationSurfacer, threadResumeMap, topicLinkageHandler: topicLinkageHandler ?? undefined, threadlineRelayClient, threadlineReplyWaiters, listenerManager: listenerManager ?? undefined, a2aDeliveryTracker: a2aDeliveryTracker ?? undefined, responseReviewGate, messagingToneGate, outboundDedupGate, telemetryHeartbeat, pasteManager, featureRegistry, discoveryEvaluator, completionEvaluator, unifiedTrust, liveConfig, sharedStateLedger, ledgerSessionRegistry, worktreeManager, oidcEnrolledRepos: parallelDevConfig?.oidcEnrolledRepos, initiativeTracker, projectRoundRunner, projectDriftChecker, machineHeartbeat, machinePoolRegistry, meshRpcDispatcher, workingSetPullCoordinator, commitmentReplicaStore, forwardCommitmentMutate, sessionOwnershipRegistry, topicPinStore: _topicPinStore ?? undefined, streamTicketStore: _streamTicketStore ?? undefined, poolStreamAllowRemoteInput: (config as { dashboard?: { poolStream?: { allowRemoteInput?: boolean } } }).dashboard?.poolStream?.allowRemoteInput ?? false, secretSync: _secretSyncHandle ?? undefined, meshSelfId: _meshSelfId ?? undefined, resolveRouterUrl: _resolveRouterUrl ?? undefined, resolvePeerUrls: _resolvePeerUrls ?? undefined, sessionPoolE2EResultStore, proxyCoordinator, topicIntentStore, topicIntentArcCheck, usherSignalStore, intelligence: sharedIntelligence ?? undefined, telegramBridgeConfig, telegramBridge: telegramBridge ?? undefined, threadlineObservability, briefDeps, workingMemory, taskFlowRegistry, threadlineFlowBridge, sessionReaper, agentWorktreeReaper, mcpProcessReaper, geminiLoopRunner, sleepController, agentActivityState, reapLog, sleepWakeDetector, unjustifiedStopGate, stopGateDb, stopNotifier });
     // Resolve the late-bound topic-operator getter (increment 2e): routing was
     // wired before the server existed; from here on inbound binds use the
     // server's own store instance.

--- a/src/core/MeshRpc.ts
+++ b/src/core/MeshRpc.ts
@@ -34,6 +34,12 @@ export type MeshCommand =
   | { type: 'capacity-report' }
   | { type: 'session-status'; session?: string }
   | { type: 'secret-share'; encrypted: string }
+  // Pool Dashboard Streaming (POOL-DASHBOARD-STREAM-SPEC §2.3): a peer asks this
+  // machine to mint a single-use bearer ticket so it may open a /pool-stream WS
+  // and watch `session`. Read/observe class — minting a ticket discloses
+  // nothing; the ticket is consumed once, and any keystrokes are gated
+  // serving-side by allowRemoteInput (default off).
+  | { type: 'pool-stream-ticket'; session: string }
   | {
       // Coherence-journal replication transport (COHERENCE-JOURNAL-SPEC §3.4).
       // Read/observe class — any registered peer may issue it (same RBAC as
@@ -208,6 +214,7 @@ export function checkCommandRBAC(command: MeshCommand, sender: MachineId, deps: 
       return { ok: true, reason: 'ok' };
     case 'capacity-report':
     case 'session-status':
+    case 'pool-stream-ticket':
     case 'journal-sync':
     case 'working-set-pull':
     case 'commitments-sync':

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -2943,6 +2943,17 @@ export interface LedgerSessionRegistration {
 export interface DashboardConfig {
   /** File viewer configuration */
   fileViewer?: FileViewerConfig;
+  /** Pool Dashboard Streaming (POOL-DASHBOARD-STREAM-SPEC §2.3) — cross-machine
+   *  session streaming from one dashboard. */
+  poolStream?: PoolStreamConfig;
+}
+
+export interface PoolStreamConfig {
+  /** May a PEER machine send keystrokes (input/key) to a session on THIS
+   *  machine over /pool-stream? Default false — remote keystroke forwarding is
+   *  a lateral-movement vector (security review §2.3). Watching is always on;
+   *  remote typing is per-machine opt-in. */
+  allowRemoteInput?: boolean;
 }
 
 export interface FileViewerConfig {

--- a/src/data/state-coherence-registry.json
+++ b/src/data/state-coherence-registry.json
@@ -959,6 +959,18 @@
         "state/session-monitor-ctx-notified.json"
       ],
       "grandfathered": false
+    },
+    {
+      "category": "stream-tickets",
+      "description": "Pool Dashboard Streaming single-use bearer tickets (POOL-DASHBOARD-STREAM-SPEC \u00a72.3). Minted by the pool-stream-ticket mesh verb, consumed once on the /pool-stream WS upgrade. Persisted so a captured ticket cannot replay across a serving-machine restart (consumed-set survives). Machine-local; single-writer (the store's own funnel); TTL-bounded + GC'd.",
+      "scope": "machine-local",
+      "freshness": "live",
+      "conflictShape": "single-writer",
+      "transport": "none",
+      "paths": [
+        "state/stream-tickets.json"
+      ],
+      "grandfathered": false
     }
   ]
 }

--- a/src/server/AgentServer.ts
+++ b/src/server/AgentServer.ts
@@ -155,6 +155,8 @@ export class AgentServer {
   private sessionManager: SessionManager;
   private state: StateManager;
   private hookEventReceiver?: import('../monitoring/HookEventReceiver.js').HookEventReceiver;
+  private streamTicketStore?: import('./StreamTicketStore.js').StreamTicketStore;
+  private poolStreamAllowRemoteInput = false;
   private routeContext: { wsManager: import('./WebSocketManager.js').WebSocketManager | null } | null = null;
   private deliverySentinel: DeliveryFailureSentinel | null = null;
   private deliveryStore: PendingRelayStore | null = null;
@@ -294,6 +296,13 @@ export class AgentServer {
     sessionOwnershipRegistry?: import('../core/SessionOwnershipRegistry.js').SessionOwnershipRegistry;
     /** Topic placement pin store (§L4) — backs GET /pool/placement + POST /pool/transfer. */
     topicPinStore?: import('../core/TopicPlacementPinStore.js').TopicPlacementPinStore;
+    /** Pool Dashboard Streaming (§2.3) — shared single-use ticket store the
+     *  WebSocketManager's /pool-stream upgrade consumes. */
+    streamTicketStore?: import('./StreamTicketStore.js').StreamTicketStore;
+    /** Pool Dashboard Streaming (§2.3) — may a PEER send input to a local
+     *  session over /pool-stream? Default false (keystroke-forwarding is a
+     *  lateral-movement vector). */
+    poolStreamAllowRemoteInput?: boolean;
     /** Cross-machine secret-sync (spec Phase 4) — backs GET /secrets/sync-status + POST /secrets/sync-now. */
     secretSync?: import('../core/SecretSync.js').SecretSyncHandle;
     /** This machine's mesh id. */
@@ -479,6 +488,8 @@ export class AgentServer {
     this.telegramAdapter = options.telegram ?? null;
     this.startTime = new Date();
     this.sessionManager = options.sessionManager;
+    this.streamTicketStore = options.streamTicketStore;
+    this.poolStreamAllowRemoteInput = options.poolStreamAllowRemoteInput ?? false;
     this.state = options.state;
     this.hookEventReceiver = options.hookEventReceiver ?? undefined;
     this.toneGate = options.messagingToneGate ?? null;
@@ -2597,6 +2608,8 @@ export class AgentServer {
           authToken: this.config.authToken,
           instarDir: this.config.stateDir,
           hookEventReceiver: this.hookEventReceiver,
+          streamTicketStore: this.streamTicketStore,
+          poolStreamAllowRemoteInput: this.poolStreamAllowRemoteInput,
         });
 
         // Update route context with WebSocket manager (deferred — created after routes)

--- a/src/server/StreamTicketStore.ts
+++ b/src/server/StreamTicketStore.ts
@@ -1,0 +1,178 @@
+/**
+ * StreamTicketStore — phase 2 of Pool Dashboard Streaming
+ * (POOL-DASHBOARD-STREAM-SPEC §2.3, the auth boundary).
+ *
+ * Lives on the SERVING machine (the one that holds the session). When a peer
+ * wants to stream a remote session it first calls the serving machine's
+ * machine-authed `POST /pool-stream/ticket` (proving its identity via the mesh
+ * signing scheme); the serving machine mints a SHORT-LIVED, SINGLE-USE ticket
+ * and returns it. The peer presents that ticket on the `/pool-stream` WS
+ * upgrade; the serving machine consumes it (one-time) and binds the resulting
+ * connection to a server-issued id.
+ *
+ * Why a ticket and not signed-headers-at-upgrade (security review sec#1): a
+ * long-lived WS authenticated only once at upgrade lets a captured upgrade be
+ * replayed for the whole connection. A ticket is bounded (TTL), single-use, and
+ * its consumed-set is PERSISTED so a captured ticket cannot be replayed even
+ * across a serving-machine restart (sec#4).
+ *
+ * Pure + injected (clock, randomness via `mintId`, fs path) so the whole
+ * lifecycle — mint / consume / expiry / replay-across-restart — is
+ * deterministically unit-testable.
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+
+export interface StreamTicket {
+  ticket: string;
+  /** The peer this ticket was minted FOR (must match the WS upgrade's authed sender). */
+  forMachineId: string;
+  /** ms epoch when the ticket stops being valid. */
+  expiresAtMs: number;
+}
+
+export type ConsumeResult =
+  | { ok: true; forMachineId: string }
+  | { ok: false; reason: 'unknown' | 'expired' | 'already-consumed' | 'wrong-machine' };
+
+interface TicketRecord {
+  forMachineId: string;
+  expiresAtMs: number;
+  consumed: boolean;
+}
+
+interface StoreFileShape {
+  version: 1;
+  tickets: Record<string, TicketRecord>;
+}
+
+export interface StreamTicketStoreDeps {
+  /** Absolute path to the persistence file. */
+  filePath: string;
+  now: () => number;
+  /** Mint a fresh opaque ticket string (crypto-random in prod; deterministic in tests). */
+  mintId: () => string;
+  /** Ticket lifetime (ms). Default 60_000. */
+  ttlMs?: number;
+  /** How long a CONSUMED/expired record is retained for replay rejection before GC (ms). Default 1h. */
+  retentionMs?: number;
+  logger?: (line: string) => void;
+}
+
+const DEFAULT_TTL_MS = 60_000;
+const DEFAULT_RETENTION_MS = 60 * 60 * 1000;
+
+export class StreamTicketStore {
+  private tickets = new Map<string, TicketRecord>();
+  private loaded = false;
+
+  constructor(private readonly d: StreamTicketStoreDeps) {}
+
+  private ttl(): number { return this.d.ttlMs ?? DEFAULT_TTL_MS; }
+  private retention(): number { return this.d.retentionMs ?? DEFAULT_RETENTION_MS; }
+
+  private ensureLoaded(): void {
+    if (this.loaded) return;
+    this.loaded = true;
+    try {
+      if (fs.existsSync(this.d.filePath)) {
+        const body = JSON.parse(fs.readFileSync(this.d.filePath, 'utf-8')) as StoreFileShape;
+        if (body && body.tickets) {
+          for (const [t, r] of Object.entries(body.tickets)) {
+            if (r && typeof r.forMachineId === 'string' && typeof r.expiresAtMs === 'number') {
+              this.tickets.set(t, { forMachineId: r.forMachineId, expiresAtMs: r.expiresAtMs, consumed: !!r.consumed });
+            }
+          }
+        }
+      }
+    } catch (e) {
+      // A corrupt store must FAIL CLOSED (lose pending tickets) rather than
+      // crash — re-minting a ticket is a cheap one-round-trip retry, but a
+      // crash would take the serving endpoint down. Persisted consumed-records
+      // are the replay defense; losing them only widens the replay window to
+      // pre-restart tickets that are TTL-bounded anyway.
+      this.d.logger?.(`[stream-ticket] store unreadable, starting empty: ${(e as Error)?.message ?? e}`);
+      this.tickets.clear();
+    }
+    this.gc();
+  }
+
+  /** Mint a single-use ticket for `forMachineId`. */
+  mint(forMachineId: string): StreamTicket {
+    this.ensureLoaded();
+    this.gc();
+    const ticket = this.d.mintId();
+    const expiresAtMs = this.d.now() + this.ttl();
+    this.tickets.set(ticket, { forMachineId, expiresAtMs, consumed: false });
+    this.persist();
+    return { ticket, forMachineId, expiresAtMs };
+  }
+
+  /**
+   * Consume a ticket presented on the WS upgrade. The ticket is an unguessable
+   * single-use bearer credential minted ONLY to an authenticated peer (over the
+   * machine-authed `pool-stream-ticket` mesh verb), so possession authorizes;
+   * the consumed `forMachineId` (bound at mint) tells the server which peer it
+   * is — never an unverified claim from the upgrade. `presentedBy` is OPTIONAL
+   * defense-in-depth: when the upgrade independently proves identity, the ticket
+   * must also have been minted for exactly that machine (rejects a stolen ticket
+   * replayed by a different authenticated machine).
+   */
+  consume(ticket: string, presentedBy?: string): ConsumeResult {
+    this.ensureLoaded();
+    const rec = this.tickets.get(ticket);
+    if (!rec) return { ok: false, reason: 'unknown' };
+    if (rec.consumed) return { ok: false, reason: 'already-consumed' };
+    if (this.d.now() >= rec.expiresAtMs) return { ok: false, reason: 'expired' };
+    if (presentedBy !== undefined && rec.forMachineId !== presentedBy) return { ok: false, reason: 'wrong-machine' };
+    // Mark consumed (NOT delete) + persist BEFORE returning ok, so a crash
+    // mid-consume can never yield a second successful consume of the same ticket.
+    rec.consumed = true;
+    this.persist();
+    return { ok: true, forMachineId: rec.forMachineId };
+  }
+
+  /** Drop expired-past-retention and consumed-past-retention records. */
+  private gc(): void {
+    const cutoff = this.d.now() - this.retention();
+    let changed = false;
+    for (const [t, r] of this.tickets) {
+      // Keep a consumed/expired record until retention elapses (replay window),
+      // then it's safe to forget (its TTL long passed — re-presenting it fails
+      // 'expired' anyway, but GC keeps the map bounded).
+      if (r.expiresAtMs < cutoff) {
+        this.tickets.delete(t);
+        changed = true;
+      }
+    }
+    if (changed) this.persist();
+  }
+
+  /** Count of live (unconsumed, unexpired) tickets — tests/observability. */
+  liveCount(): number {
+    this.ensureLoaded();
+    const now = this.d.now();
+    let n = 0;
+    for (const r of this.tickets.values()) if (!r.consumed && now < r.expiresAtMs) n++;
+    return n;
+  }
+
+  private persist(): void {
+    try {
+      const dir = path.dirname(this.d.filePath);
+      fs.mkdirSync(dir, { recursive: true });
+      const tickets: Record<string, TicketRecord> = {};
+      for (const [t, r] of this.tickets) tickets[t] = r;
+      const body: StoreFileShape = { version: 1, tickets };
+      const tmp = `${this.d.filePath}.tmp-${process.pid}`;
+      fs.writeFileSync(tmp, JSON.stringify(body, null, 2));
+      fs.renameSync(tmp, this.d.filePath);
+    } catch (e) {
+      // @silent-fallback-ok: a persistence failure degrades replay-across-restart
+      // protection for in-flight tickets only (all TTL-bounded); it must not
+      // crash the mint/consume path. The in-memory consumed-set still blocks
+      // replay within this process lifetime (POOL-DASHBOARD-STREAM-SPEC §2.3).
+      this.d.logger?.(`[stream-ticket] persist failed: ${(e as Error)?.message ?? e}`);
+    }
+  }
+}

--- a/src/server/WebSocketManager.ts
+++ b/src/server/WebSocketManager.ts
@@ -34,11 +34,21 @@ import path from 'node:path';
 import type { SessionManager } from '../core/SessionManager.js';
 import type { StateManager } from '../core/StateManager.js';
 import type { HookEventReceiver } from '../monitoring/HookEventReceiver.js';
+import type { StreamTicketStore } from './StreamTicketStore.js';
+
+/** Pool Dashboard Streaming §2.1: only tmux-safe session names ever reach tmux. */
+const SAFE_SESSION_NAME = /^[A-Za-z0-9_.:@-]+$/;
 
 interface ClientState {
   ws: WebSocket;
   subscriptions: Set<string>;
   isAlive: boolean;
+  /** True when this connection is a PEER machine streaming over /pool-stream
+   *  (not a local browser dashboard on /ws). Peer input is gated by
+   *  poolStreamAllowRemoteInput (default off). */
+  isPeer?: boolean;
+  /** The authenticated peer machine id (from the consumed stream ticket). */
+  peerMachineId?: string;
 }
 
 export class WebSocketManager {
@@ -53,6 +63,12 @@ export class WebSocketManager {
   private authToken?: string;
   private registryPath?: string;
   private hookEventReceiver?: HookEventReceiver;
+  /** Pool Dashboard Streaming (serving side): consumes one-time tickets on the
+   *  /pool-stream upgrade. Absent → /pool-stream is refused (feature dark). */
+  private streamTicketStore?: StreamTicketStore;
+  /** Serving-side gate: may a PEER machine send input/key to a local session?
+   *  Default false (security: keystroke forwarding is a lateral-movement vector). */
+  private poolStreamAllowRemoteInput = false;
 
   constructor(options: {
     server: HttpServer;
@@ -61,11 +77,15 @@ export class WebSocketManager {
     authToken?: string;
     instarDir?: string;
     hookEventReceiver?: HookEventReceiver;
+    streamTicketStore?: StreamTicketStore;
+    poolStreamAllowRemoteInput?: boolean;
   }) {
     this.sessionManager = options.sessionManager;
     this.state = options.state;
     this.authToken = options.authToken;
     this.hookEventReceiver = options.hookEventReceiver;
+    this.streamTicketStore = options.streamTicketStore;
+    this.poolStreamAllowRemoteInput = options.poolStreamAllowRemoteInput ?? false;
     if (options.instarDir) {
       this.registryPath = path.join(options.instarDir, 'topic-session-registry.json');
     }
@@ -76,8 +96,33 @@ export class WebSocketManager {
 
     // Handle upgrade manually for auth
     options.server.on('upgrade', (request, socket, head) => {
-      // Only handle /ws path
       const url = new URL(request.url || '/', `http://${request.headers.host || 'localhost'}`);
+
+      // ── /pool-stream: a PEER machine streaming a remote session (§2.3) ──
+      // Authenticated by a single-use bearer ticket minted over the machine-
+      // authed `pool-stream-ticket` mesh verb; identity comes from the ticket's
+      // mint record, never an unverified upgrade claim.
+      if (url.pathname === '/pool-stream') {
+        if (!this.streamTicketStore) {
+          socket.write('HTTP/1.1 503 Service Unavailable\r\n\r\n');
+          socket.destroy();
+          return;
+        }
+        const ticket = url.searchParams.get('ticket') || (request.headers['x-pool-stream-ticket'] as string) || '';
+        const res = this.streamTicketStore.consume(ticket);
+        if (!res.ok) {
+          socket.write('HTTP/1.1 401 Unauthorized\r\n\r\n');
+          socket.destroy();
+          return;
+        }
+        const peerMachineId = res.forMachineId;
+        this.wss.handleUpgrade(request, socket, head, (ws) => {
+          this.wss.emit('connection', ws, request, { isPeer: true, peerMachineId });
+        });
+        return;
+      }
+
+      // ── /ws: a local browser dashboard ──
       if (url.pathname !== '/ws') {
         socket.destroy();
         return;
@@ -95,11 +140,12 @@ export class WebSocketManager {
       });
     });
 
-    this.wss.on('connection', (ws) => {
+    this.wss.on('connection', (ws, _request, peerCtx?: { isPeer: boolean; peerMachineId: string }) => {
       const client: ClientState = {
         ws,
         subscriptions: new Set(),
         isAlive: true,
+        ...(peerCtx?.isPeer ? { isPeer: true, peerMachineId: peerCtx.peerMachineId } : {}),
       };
       this.clients.set(ws, client);
 
@@ -176,12 +222,46 @@ export class WebSocketManager {
     return timingSafeEqual(ha, hb);
   }
 
+  /** §2.1: a session name must be tmux-safe before it ever reaches send-keys. */
+  private isValidSessionName(session: string): boolean {
+    return SAFE_SESSION_NAME.test(session);
+  }
+
+  /**
+   * Gate a write (input/key) before it reaches tmux. Returns true if allowed.
+   * On rejection it sends the honest error frame and returns false.
+   *  - invalid name  → invalid-session (§2.1 injection guard);
+   *  - PEER client + remote input disabled → input-not-allowed (§2.3 default-off);
+   *  - session not running locally → session-not-found (never relay to tmux blind).
+   */
+  private gateWrite(client: ClientState, session: string): boolean {
+    if (!this.isValidSessionName(session)) {
+      this.send(client.ws, { type: 'error', code: 'invalid-session', session });
+      return false;
+    }
+    if (client.isPeer && !this.poolStreamAllowRemoteInput) {
+      this.send(client.ws, { type: 'error', code: 'input-not-allowed', session });
+      return false;
+    }
+    const exists = this.sessionManager.listRunningSessions().some((s) => s.tmuxSession === session);
+    if (!exists) {
+      this.send(client.ws, { type: 'error', code: 'session-not-found', session });
+      return false;
+    }
+    return true;
+  }
+
   private handleMessage(client: ClientState, msg: Record<string, unknown>): void {
     switch (msg.type) {
       case 'subscribe': {
         const session = String(msg.session || '');
         if (!session) {
           this.send(client.ws, { type: 'error', message: 'Missing session name' });
+          return;
+        }
+        // §2.1: never let a crafted session name reach tmux (target injection).
+        if (!this.isValidSessionName(session)) {
+          this.send(client.ws, { type: 'error', code: 'invalid-session', session });
           return;
         }
         client.subscriptions.add(session);
@@ -210,6 +290,7 @@ export class WebSocketManager {
           this.send(client.ws, { type: 'error', message: 'Missing session or text' });
           return;
         }
+        if (!this.gateWrite(client, session)) return;
         const success = this.sessionManager.sendInput(session, text);
         this.send(client.ws, { type: 'input_ack', session, success });
         break;
@@ -222,6 +303,7 @@ export class WebSocketManager {
           this.send(client.ws, { type: 'error', message: 'Missing session or key' });
           return;
         }
+        if (!this.gateWrite(client, session)) return;
         const success = this.sessionManager.sendKey(session, key);
         this.send(client.ws, { type: 'input_ack', session, success });
         break;

--- a/tests/e2e/pool-stream-serving-alive.test.ts
+++ b/tests/e2e/pool-stream-serving-alive.test.ts
@@ -1,0 +1,138 @@
+// safe-fs-allow: test fixture cleanup uses fs.rmSync on tmp dirs only.
+/**
+ * Tier-2/3 ("feature is alive") test for the Pool Dashboard Streaming SERVING
+ * side (POOL-DASHBOARD-STREAM-SPEC §2.3): a real http.Server + WebSocketManager
+ * + StreamTicketStore. A peer mints a single-use ticket, opens a REAL
+ * `/pool-stream` WebSocket with it, subscribes to a session, and is correctly
+ * gated on input (default-off). Exercises the whole upgrade→consume→peer-client
+ * →gate chain over a live socket — not mocks.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import http from 'node:http';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import type { AddressInfo } from 'node:net';
+import { WebSocket } from 'ws';
+
+import { WebSocketManager } from '../../src/server/WebSocketManager.js';
+import { StreamTicketStore } from '../../src/server/StreamTicketStore.js';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+
+let dir: string;
+let server: http.Server;
+let wsm: WebSocketManager;
+let port: number;
+let store: StreamTicketStore;
+
+function fakeSessionManager(running: string[] = ['proj-alpha']) {
+  return {
+    captureOutput: () => 'hello from alpha',
+    listRunningSessions: () => running.map((tmuxSession) => ({ tmuxSession, name: tmuxSession })),
+    sendInput: () => true,
+    sendKey: () => true,
+  } as any;
+}
+
+async function startServer(opts: { allowRemoteInput?: boolean } = {}): Promise<void> {
+  server = http.createServer();
+  await new Promise<void>((r) => server.listen(0, '127.0.0.1', r));
+  port = (server.address() as AddressInfo).port;
+  store = new StreamTicketStore({
+    filePath: path.join(dir, 'stream-tickets.json'),
+    now: () => Date.now(),
+    mintId: () => `tkt-${Math.random().toString(36).slice(2)}`,
+  });
+  wsm = new WebSocketManager({
+    server,
+    sessionManager: fakeSessionManager(),
+    state: {} as any,
+    streamTicketStore: store,
+    poolStreamAllowRemoteInput: opts.allowRemoteInput ?? false,
+  });
+}
+
+/** Open a ws and collect frames until `predicate` matches or it times out. */
+function openAndCollect(url: string, send: Record<string, unknown>[] = []): Promise<{ frames: any[]; code?: number; opened: boolean }> {
+  return new Promise((resolve) => {
+    const frames: any[] = [];
+    const ws = new WebSocket(url);
+    let opened = false;
+    const done = (code?: number) => { try { ws.close(); } catch { /* noop */ } resolve({ frames, code, opened }); };
+    ws.on('open', () => { opened = true; for (const m of send) ws.send(JSON.stringify(m)); setTimeout(() => done(), 200); });
+    ws.on('message', (d) => { try { frames.push(JSON.parse(d.toString())); } catch { /* noop */ } });
+    ws.on('unexpected-response', (_req, res) => done(res.statusCode));
+    ws.on('error', () => { if (!opened) done(0); });
+    setTimeout(() => done(), 1500);
+  });
+}
+
+beforeEach(() => { dir = fs.mkdtempSync(path.join(os.tmpdir(), 'pool-stream-')); });
+afterEach(async () => {
+  try { wsm?.shutdown?.(); } catch { /* noop */ }
+  await new Promise<void>((r) => server?.close(() => r()));
+  SafeFsExecutor.safeRmSync(dir, { recursive: true, force: true, operation: 'tests/e2e/pool-stream-serving-alive.test.ts:cleanup' });
+});
+
+describe('Pool dashboard streaming — serving endpoint (feature alive)', () => {
+  it('a valid ticket opens /pool-stream and a subscribe streams output', async () => {
+    await startServer();
+    const t = store.mint('m_peer');
+    const { frames, opened } = await openAndCollect(
+      `ws://127.0.0.1:${port}/pool-stream?ticket=${t.ticket}`,
+      [{ type: 'subscribe', session: 'proj-alpha' }],
+    );
+    expect(opened).toBe(true);
+    expect(frames.some((f) => f.type === 'output' && f.session === 'proj-alpha')).toBe(true);
+    expect(frames.some((f) => f.type === 'subscribed' && f.session === 'proj-alpha')).toBe(true);
+  });
+
+  it('an invalid/absent ticket is rejected at the upgrade (401, never opens)', async () => {
+    await startServer();
+    const r = await openAndCollect(`ws://127.0.0.1:${port}/pool-stream?ticket=bogus`);
+    expect(r.opened).toBe(false);
+    expect(r.code).toBe(401);
+  });
+
+  it('a ticket is single-use — the second upgrade with the same ticket is rejected', async () => {
+    await startServer();
+    const t = store.mint('m_peer');
+    const first = await openAndCollect(`ws://127.0.0.1:${port}/pool-stream?ticket=${t.ticket}`);
+    expect(first.opened).toBe(true);
+    const second = await openAndCollect(`ws://127.0.0.1:${port}/pool-stream?ticket=${t.ticket}`);
+    expect(second.opened).toBe(false);
+    expect(second.code).toBe(401);
+  });
+
+  it('peer input is gated OFF by default — input yields input-not-allowed, never reaches tmux', async () => {
+    await startServer({ allowRemoteInput: false });
+    const t = store.mint('m_peer');
+    const { frames } = await openAndCollect(
+      `ws://127.0.0.1:${port}/pool-stream?ticket=${t.ticket}`,
+      [{ type: 'input', session: 'proj-alpha', text: 'whoami\n' }],
+    );
+    expect(frames.some((f) => f.type === 'error' && f.code === 'input-not-allowed')).toBe(true);
+    expect(frames.some((f) => f.type === 'input_ack')).toBe(false);
+  });
+
+  it('with allowRemoteInput ON, peer input is accepted', async () => {
+    await startServer({ allowRemoteInput: true });
+    const t = store.mint('m_peer');
+    const { frames } = await openAndCollect(
+      `ws://127.0.0.1:${port}/pool-stream?ticket=${t.ticket}`,
+      [{ type: 'input', session: 'proj-alpha', text: 'ls\n' }],
+    );
+    expect(frames.some((f) => f.type === 'input_ack' && f.success === true)).toBe(true);
+  });
+
+  it('a crafted (tmux-unsafe) session name is refused with invalid-session', async () => {
+    await startServer({ allowRemoteInput: true });
+    const t = store.mint('m_peer');
+    const { frames } = await openAndCollect(
+      `ws://127.0.0.1:${port}/pool-stream?ticket=${t.ticket}`,
+      [{ type: 'input', session: 'a; touch /tmp/pwned #', text: 'x' }],
+    );
+    expect(frames.some((f) => f.type === 'error' && f.code === 'invalid-session')).toBe(true);
+    expect(frames.some((f) => f.type === 'input_ack')).toBe(false);
+  });
+});

--- a/tests/unit/StreamTicketStore.test.ts
+++ b/tests/unit/StreamTicketStore.test.ts
@@ -1,0 +1,136 @@
+// safe-fs-allow: test fixture cleanup uses fs.rmSync on tmp dirs only.
+/**
+ * Tier-1 tests for StreamTicketStore (Pool Dashboard Streaming phase 2,
+ * POOL-DASHBOARD-STREAM-SPEC §2.3 — the auth boundary). Security-critical:
+ * single-use, TTL-bounded, machine-bound, and replay-proof ACROSS a restart
+ * (the persisted consumed-set). Deterministic clock + counter-based mintId.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { StreamTicketStore } from '../../src/server/StreamTicketStore.js';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+
+let dir: string;
+let nowMs: number;
+let seq: number;
+
+function makeStore(over: { ttlMs?: number; retentionMs?: number } = {}) {
+  return new StreamTicketStore({
+    filePath: path.join(dir, 'stream-tickets.json'),
+    now: () => nowMs,
+    mintId: () => `tkt-${++seq}`,
+    ttlMs: over.ttlMs ?? 60_000,
+    retentionMs: over.retentionMs,
+  });
+}
+
+beforeEach(() => {
+  dir = fs.mkdtempSync(path.join(os.tmpdir(), 'stream-ticket-'));
+  nowMs = 1_000_000;
+  seq = 0;
+});
+afterEach(() => {
+  SafeFsExecutor.safeRmSync(dir, { recursive: true, force: true, operation: 'tests/unit/StreamTicketStore.test.ts:cleanup' });
+});
+
+describe('StreamTicketStore — mint + consume happy path', () => {
+  it('mints a ticket for a machine and consumes it exactly once', () => {
+    const s = makeStore();
+    const t = s.mint('m_peer');
+    expect(t.ticket).toBe('tkt-1');
+    expect(t.forMachineId).toBe('m_peer');
+    const r1 = s.consume('tkt-1', 'm_peer');
+    expect(r1).toEqual({ ok: true, forMachineId: 'm_peer' });
+  });
+
+  it('liveCount reflects unconsumed, unexpired tickets', () => {
+    const s = makeStore();
+    s.mint('m_peer'); s.mint('m_peer');
+    expect(s.liveCount()).toBe(2);
+    s.consume('tkt-1', 'm_peer');
+    expect(s.liveCount()).toBe(1);
+  });
+});
+
+describe('StreamTicketStore — every rejection mode', () => {
+  it('rejects an unknown ticket', () => {
+    expect(makeStore().consume('nope', 'm_peer')).toEqual({ ok: false, reason: 'unknown' });
+  });
+
+  it('rejects a SECOND consume of the same ticket (single-use)', () => {
+    const s = makeStore();
+    s.mint('m_peer');
+    expect(s.consume('tkt-1', 'm_peer').ok).toBe(true);
+    expect(s.consume('tkt-1', 'm_peer')).toEqual({ ok: false, reason: 'already-consumed' });
+  });
+
+  it('rejects an expired ticket (past TTL)', () => {
+    const s = makeStore({ ttlMs: 30_000 });
+    s.mint('m_peer');
+    nowMs += 30_001;
+    expect(s.consume('tkt-1', 'm_peer')).toEqual({ ok: false, reason: 'expired' });
+  });
+
+  it('rejects a ticket presented by a DIFFERENT machine than it was minted for (when identity is proven)', () => {
+    const s = makeStore();
+    s.mint('m_peerA');
+    expect(s.consume('tkt-1', 'm_peerB')).toEqual({ ok: false, reason: 'wrong-machine' });
+    // and the legit machine can still use it (the failed attempt did not consume it)
+    expect(s.consume('tkt-1', 'm_peerA').ok).toBe(true);
+  });
+
+  it('bearer mode: consume with no presentedBy validates the ticket and returns the bound machine', () => {
+    const s = makeStore();
+    s.mint('m_peerA');
+    // The WS upgrade carries only the single-use ticket; identity comes from the
+    // mint record, not the upgrade.
+    expect(s.consume('tkt-1')).toEqual({ ok: true, forMachineId: 'm_peerA' });
+    expect(s.consume('tkt-1')).toEqual({ ok: false, reason: 'already-consumed' });
+  });
+});
+
+describe('StreamTicketStore — replay-proof across restart (sec#4)', () => {
+  it('a consumed ticket stays consumed after a fresh store loads the persisted file', () => {
+    const file = path.join(dir, 'stream-tickets.json');
+    const s1 = new StreamTicketStore({ filePath: file, now: () => nowMs, mintId: () => 'tkt-X', ttlMs: 60_000 });
+    s1.mint('m_peer');
+    expect(s1.consume('tkt-X', 'm_peer').ok).toBe(true);
+    // "restart": brand-new instance over the SAME file.
+    const s2 = new StreamTicketStore({ filePath: file, now: () => nowMs, mintId: () => 'tkt-Y', ttlMs: 60_000 });
+    expect(s2.consume('tkt-X', 'm_peer')).toEqual({ ok: false, reason: 'already-consumed' });
+  });
+
+  it('an UNconsumed ticket survives a restart and is still usable until its TTL', () => {
+    const file = path.join(dir, 'stream-tickets.json');
+    const s1 = new StreamTicketStore({ filePath: file, now: () => nowMs, mintId: () => 'tkt-Z', ttlMs: 60_000 });
+    s1.mint('m_peer');
+    const s2 = new StreamTicketStore({ filePath: file, now: () => nowMs, mintId: () => 'q', ttlMs: 60_000 });
+    expect(s2.consume('tkt-Z', 'm_peer').ok).toBe(true);
+  });
+
+  it('a corrupt store file fails closed (empty) without throwing', () => {
+    const file = path.join(dir, 'stream-tickets.json');
+    fs.writeFileSync(file, '{ this is not json');
+    const s = new StreamTicketStore({ filePath: file, now: () => nowMs, mintId: () => 'tkt-1', ttlMs: 60_000 });
+    expect(() => s.consume('anything', 'm_peer')).not.toThrow();
+    expect(s.consume('anything', 'm_peer')).toEqual({ ok: false, reason: 'unknown' });
+    // still usable afterward
+    s.mint('m_peer');
+    expect(s.consume('tkt-1', 'm_peer').ok).toBe(true);
+  });
+});
+
+describe('StreamTicketStore — GC bounds the map', () => {
+  it('drops records past retention', () => {
+    const file = path.join(dir, 'stream-tickets.json');
+    const s = new StreamTicketStore({ filePath: file, now: () => nowMs, mintId: () => `g-${++seq}`, ttlMs: 1_000, retentionMs: 5_000 });
+    s.mint('m_peer'); // g-1, expires nowMs+1000
+    nowMs += 10_000;  // past expiry + retention
+    s.mint('m_peer'); // g-2 triggers gc()
+    // g-1 should be GC'd; presenting it reads as unknown (forgotten), not consumed.
+    expect(s.consume('g-1', 'm_peer')).toEqual({ ok: false, reason: 'unknown' });
+  });
+});

--- a/tests/unit/WebSocketManager.test.ts
+++ b/tests/unit/WebSocketManager.test.ts
@@ -214,7 +214,9 @@ describe('WebSocketManager', () => {
     });
 
     it('input forwards to sessionManager.sendInput and returns ack', () => {
-      const { connectClient, sendMessage, sessionManager } = createTestManager();
+      // §2.1: input only reaches tmux for a session that actually exists locally.
+      const sm = createMockSessionManager({ listRunningSessions: vi.fn(() => [{ tmuxSession: 'sess-1', name: 'sess-1' } as any]) });
+      const { connectClient, sendMessage, sessionManager } = createTestManager({ sessionManager: sm });
       sessionManager.sendInput.mockReturnValue(true);
       const { ws, client } = connectClient();
 
@@ -238,7 +240,8 @@ describe('WebSocketManager', () => {
     });
 
     it('key forwards to sessionManager.sendKey and returns ack', () => {
-      const { connectClient, sendMessage, sessionManager } = createTestManager();
+      const sm = createMockSessionManager({ listRunningSessions: vi.fn(() => [{ tmuxSession: 'sess-1', name: 'sess-1' } as any]) });
+      const { connectClient, sendMessage, sessionManager } = createTestManager({ sessionManager: sm });
       sessionManager.sendKey.mockReturnValue(true);
       const { ws, client } = connectClient();
 

--- a/upgrades/next/dashboard-stream-phase2a-serving.md
+++ b/upgrades/next/dashboard-stream-phase2a-serving.md
@@ -1,0 +1,27 @@
+# Pool dashboard streaming — phase 2a: the serving endpoint
+
+## What Changed
+
+The machine that owns a session can now serve its live terminal stream to a peer machine, securely. A peer requests a single-use bearer ticket over the existing machine-authed mesh channel (`pool-stream-ticket` verb); the serving machine mints it via the new StreamTicketStore (60s TTL, single-use, persisted so a captured ticket can't replay across a restart). The peer opens a `/pool-stream` WebSocket carrying that ticket; the serving machine consumes it once and treats the peer as a streaming client. Remote keystroke input is OFF by default (per-machine opt-in); session names are validated (tmux-safe charset + must be running) before anything reaches the shell.
+
+This is the serving (has-the-session) half. The requesting half (the dashboard auto-opening these connections) and the on-screen UI are phases 2b and 3.
+
+## What to Tell Your User
+
+Nothing changes on screen yet — this is the secure plumbing the click-to-stream feature will use. Default posture: other machines can watch, not type, unless you opt in.
+
+- audience: agent-only
+- maturity: preview
+
+## Summary of New Capabilities
+
+- `StreamTicketStore` — single-use, TTL-bounded, restart-replay-proof stream tickets.
+- `pool-stream-ticket` mesh verb — mints a ticket for an authenticated peer.
+- `/pool-stream` WebSocket serving endpoint — ticket-gated; peer streams a session.
+- Serving-side guards: `dashboard.poolStream.allowRemoteInput` (default false); session-name validation (`^[A-Za-z0-9_.:@-]+$` + must-be-running) before tmux.
+
+## Evidence
+
+- `tests/unit/StreamTicketStore.test.ts` (11): single-use, expiry, wrong-machine, bearer mode, replay-across-restart, corrupt-fail-closed, GC.
+- `tests/e2e/pool-stream-serving-alive.test.ts` (6, real http server + real ws): valid ticket streams; bad ticket → 401; single-use enforced; input gated off by default; input accepted when on; tmux-unsafe name refused.
+- `tests/unit/WebSocketManager.test.ts` updated for the new existence-before-input guard. tsc clean; state registry + MeshRpc RBAC updated.

--- a/upgrades/side-effects/dashboard-stream-phase2a-serving.md
+++ b/upgrades/side-effects/dashboard-stream-phase2a-serving.md
@@ -1,0 +1,69 @@
+# Side-Effects Review — Pool dashboard streaming phase 2a (serving endpoint)
+
+**Version / slug:** `dashboard-stream-phase2a-serving`
+**Date:** `2026-06-07`
+**Author:** `echo`
+**Second-pass reviewer:** `not required`
+
+## Summary of the change
+
+Serving side of cross-machine streaming: StreamTicketStore (single-use ticket),
+`pool-stream-ticket` mesh verb (mint), `/pool-stream` WS endpoint (ticket-gated
+peer streaming reusing the existing WSManager client path), serving-side input
+gate (allowRemoteInput default-off) + session-name validation.
+
+## Decision-point inventory
+
+(1) Ticket auth vs signed-headers-at-upgrade → ticket (bounded, single-use,
+restart-replay-proof). (2) Remote input default → OFF (lateral-movement). (3)
+Session-name handling → strict charset + must-be-running before tmux.
+
+## 1. Over-block
+
+Remote input is refused by default (input-not-allowed) — intended; watching is
+unaffected. A session-name that isn't tmux-safe OR isn't running is refused
+(invalid-session / session-not-found) — correct, never relay blind.
+
+## 2. Under-block
+
+The minted ticket is a bearer credential: anyone holding it (within 60s,
+once) can open the stream. Mitigated: minted only to an authenticated peer
+(mesh verb), single-use, short TTL, optional wrong-machine defense-in-depth. A
+peer that can watch a session sees its output (disclosure accepted for
+same-operator peers, per spec §2.3).
+
+## 3. Level-of-abstraction fit
+
+The peer reuses the existing WSManager client/handleMessage path (one streaming
+implementation, not a fork); only the upgrade (ticket consume) and the
+write-gate differ. Ticket minting rides the existing mesh dispatcher (no new
+auth surface). Store persistence matches the PendingPullLedger idiom.
+
+## 4. Signal vs authority compliance
+
+**Required reference:** [docs/signal-vs-authority.md](../../docs/signal-vs-authority.md)
+
+The new authority (ticket consume, input gate, name validation) is structural
+and fail-closed: no ticket → 503/401; bad name → refused; peer input off →
+refused. Identity comes from the mint record / mesh-auth, never an unverified
+upgrade claim.
+
+## 5. Interactions
+
+- WebSocketManager local (/ws) path: unchanged except the new existence-before-
+  input guard (a real improvement; the two existing input/key tests updated to
+  register the session).
+- MeshRpc RBAC: pool-stream-ticket joins the read/observe class (mint discloses
+  nothing; ticket+gate are the controls).
+- StreamTicketStore persistence: new durable category `stream-tickets`
+  registered in state-coherence-registry.
+- Config: `dashboard.poolStream.allowRemoteInput` (absent = false = safe, so no
+  migrateConfig needed — absence is correct).
+- Phases 2b (requesting side) + 3 (UI) consume this; not wired to the dashboard
+  UI yet.
+
+## 6. External surfaces
+
+New WS path `/pool-stream` (ticket-gated) + new mesh verb `pool-stream-ticket`.
+No new HTTP route, no Telegram, no notifications. One new durable state file
+(stream-tickets.json, names+expiry only — no secrets).


### PR DESCRIPTION
## What

Phase 2a of single-dashboard cross-machine streaming (Justin's ask; design approved). The **serving side** — the machine that owns a session can now stream its terminal to a peer machine, securely.

- **StreamTicketStore** — single-use, 60s-TTL bearer tickets, persisted so a captured ticket can't replay across a serving-machine restart (sec#4).
- **`pool-stream-ticket` mesh verb** — mints a ticket for an authenticated peer over the existing machine-authed `/mesh/rpc` (no new auth surface; identity bound at mint).
- **`/pool-stream` WS endpoint** — consumes the ticket once on upgrade, then reuses the existing WebSocketManager client path to stream the session.
- **Serving-side guards** — remote keystroke input OFF by default (`dashboard.poolStream.allowRemoteInput`; lateral-movement vector); session-name validated (tmux-safe charset + must-be-running) before anything reaches the shell.

Reuses the local streaming path + mesh auth; identity comes from the ticket mint record, never an unverified upgrade claim. The requesting side (dashboard auto-opening streams) and the on-screen UI are phases 2b/3.

## Tests

- `tests/unit/StreamTicketStore.test.ts` (11): single-use, expiry, wrong-machine, bearer mode, replay-across-restart, corrupt-fail-closed, GC.
- `tests/e2e/pool-stream-serving-alive.test.ts` (6, real http server + real ws): valid ticket streams; bad ticket → 401; single-use enforced; input gated off by default; input accepted when on; tmux-unsafe name refused.
- `tests/unit/WebSocketManager.test.ts` updated for the existence-before-input guard. Full suite green on pre-push.

## ELI16

The machine that owns a session can now safely hand its live terminal to another of your machines. The laptop asks the Mini (over the secure machine-to-machine channel) for a one-time pass; the Mini hands back a single-use ticket that expires in a minute and can't be reused even across a restart; the laptop streams using it. Typing into a remote machine is OFF by default (watch-only unless you opt in), and a session name is strictly checked before anything touches the shell. Six real end-to-end tests prove all of it over actual sockets. The click-to-stream UI is the next phases.
