### PR TITLE
feat(subscription-auth): P2.2 dashboard Subscriptions tab + Pending Logins panel

### DIFF
--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -2692,6 +2692,7 @@
           <button class="tab" data-tab="threadline" onclick="switchTab('threadline')">Threadline</button>
           <button class="tab" data-tab="evidence" onclick="switchTab('evidence')">Evidence</button>
           <button class="tab" data-tab="process-health" onclick="switchTab('process-health')">Process Health</button>
+          <button class="tab" data-tab="subscriptions" onclick="switchTab('subscriptions')">Subscriptions</button>
           <button class="tab" data-tab="preferences-learning" onclick="switchTab('preferences-learning')">Preferences</button>
           <button class="tab" data-tab="machines" onclick="switchTab('machines')">Machines</button>
           <button class="tab" data-tab="mandates" onclick="switchTab('mandates')">Mandates</button>
@@ -3241,6 +3242,44 @@
         <summary class="ph-detail-summary">More detail</summary>
         <div id="phDetail" class="ph-detail-body"></div>
       </details>
+    </div>
+
+    <!-- subscriptions tab (Subscription & Auth Standard P2.2 — live quota + pending logins) -->
+    <style>
+      .sub-account { border:1px solid var(--border,#2a2a2a); border-radius:10px; padding:14px 16px; margin-bottom:12px; }
+      .sub-account-head { display:flex; justify-content:space-between; align-items:baseline; gap:12px; }
+      .sub-account-nick { font-weight:600; font-size:15px; }
+      .sub-account-status { font-size:12px; opacity:.75; }
+      .sub-account-meta { font-size:12px; opacity:.6; margin:2px 0 10px; }
+      .sub-account-noquota { font-size:12px; opacity:.6; }
+      .sub-quota { margin:8px 0; }
+      .sub-quota-head { display:flex; justify-content:space-between; font-size:12px; margin-bottom:4px; }
+      .sub-quota-label { opacity:.8; }
+      .sub-quota-pct { opacity:.65; }
+      .sub-quota-track { height:8px; border-radius:4px; background:var(--border,#2a2a2a); overflow:hidden; }
+      .sub-quota-fill { height:100%; background:linear-gradient(90deg,#4caf80,#3a9); }
+      .sub-pending { border:1px solid var(--border,#2a2a2a); border-radius:10px; padding:12px 16px; margin-bottom:10px; }
+      .sub-pending-head { display:flex; justify-content:space-between; align-items:baseline; gap:12px; }
+      .sub-pending-label { font-weight:600; }
+      .sub-pending-ttl { font-size:12px; opacity:.7; }
+      .sub-pending-code { font-family:monospace; font-size:14px; margin-top:6px; }
+      .sub-pending-url { font-size:12px; opacity:.7; word-break:break-all; margin-top:4px; }
+      .sub-pending-reissue { font-size:11px; opacity:.55; margin-top:4px; }
+      .sub-empty, .sub-disabled { font-size:13px; opacity:.7; padding:8px 0; }
+    </style>
+    <div id="subscriptionsPanel" class="ph-root" style="display:none;flex-direction:column;padding:28px;gap:24px;overflow-y:auto">
+      <h2 class="ph-title">Subscriptions</h2>
+      <p class="ph-intro">Your subscription accounts and how much of each is left before it resets — plus any logins waiting for you to approve on your phone.</p>
+      <section class="ph-section">
+        <h3 class="ph-h">Accounts</h3>
+        <p class="ph-h-sub">Each account’s live usage (5-hour and weekly) and when it resets.</p>
+        <div id="subAccounts"></div>
+      </section>
+      <section class="ph-section">
+        <h3 class="ph-h">Pending logins</h3>
+        <p class="ph-h-sub">Logins waiting for approval — open the link on your phone and confirm. An expired code is re-issued automatically.</p>
+        <div id="subPending"></div>
+      </section>
     </div>
 
     <!-- mandates tab (coordination-mandate spec, decision 2A — the operator's PIN-gated surface) -->
@@ -4649,6 +4688,13 @@
         display: ['flex'],
         onActivate: () => { if (typeof startProcessHealth === 'function') startProcessHealth(); },
         onDeactivate: () => { if (typeof stopProcessHealth === 'function') stopProcessHealth(); },
+      },
+      {
+        id: 'subscriptions',
+        panels: ['subscriptionsPanel'],
+        display: ['flex'],
+        onActivate: () => { if (typeof startSubscriptions === 'function') startSubscriptions(); },
+        onDeactivate: () => { if (typeof stopSubscriptions === 'function') stopSubscriptions(); },
       },
       {
         id: 'preferences-learning',
@@ -8600,6 +8646,34 @@
     }
     function stopProcessHealth() {
       if (__phController) __phController.stop();
+    }
+
+    // ── Subscriptions tab (Subscription & Auth Standard P2.2) ──
+    // Same lazy dynamic-import pattern as Process Health: the controller lives in
+    // this (classic) scope so it can read `token`; the module ships the pure
+    // renderers + the polling controller.
+    let __subController = null;
+    let __subModule = null;
+    async function startSubscriptions() {
+      if (!__subModule) {
+        try { __subModule = await import('/dashboard/subscriptions.js'); }
+        catch (e) { console.error('[subscriptions] module load failed', e); return; }
+      }
+      if (!__subController) {
+        const els = {
+          accounts: document.getElementById('subAccounts'),
+          pending: document.getElementById('subPending'),
+        };
+        const fetchImpl = (url, opts = {}) => fetch(url, {
+          headers: { 'Authorization': `Bearer ${token}`, ...(opts.headers || {}) },
+          signal: opts.signal,
+        });
+        __subController = __subModule.createController({ doc: document, els, fetchImpl });
+      }
+      __subController.start();
+    }
+    function stopSubscriptions() {
+      if (__subController) __subController.stop();
     }
 
     // ── Mandates tab (coordination-mandate spec, decision 2A) ──

--- a/dashboard/subscriptions.js
+++ b/dashboard/subscriptions.js
@@ -1,0 +1,264 @@
+// Subscriptions tab — a read surface for the multi-account Subscription & Auth
+// pool: per-account live quota bars (5h / weekly + reset countdown), status, and
+// the Pending Logins panel (device codes / verification URLs awaiting approval,
+// with TTL). Spec: docs/specs/_drafts/subscription-auth-standard-master-spec.md.
+//
+// Browser-native ESM (no build step; served at /dashboard/subscriptions.js and
+// loaded by index.html via <script type="module">). The pure functions are
+// exported so the 3-tier jsdom tests exercise the SHIPPED code, not a copy; the
+// controller is attached to window.Subscriptions so index.html drives start/stop
+// on tab activation.
+//
+// Load-bearing safety contract (mirrors the Process Health tab §4.6): every
+// dynamic value flows through sanitizeForDisplay before the DOM; all DOM writes
+// are textContent only (never innerHTML); the only dynamic ATTRIBUTE written is a
+// quota-bar width, set from a clamped NUMBER (0–100) — never a string from data.
+// No verification URL is ever rendered as a live href (defense-in-depth): it is
+// shown as sanitized TEXT for the operator to copy.
+
+const CAPS = { label: 64, code: 48, url: 320, summary: 240 };
+
+// Structural presentation-glyph class (NFKC-fold THEN strip), identical to the
+// Process Health tab: \p{So} + arrows + geometric + box-drawing + dingbats +
+// variation-selectors + bullet/middot — so a confusable can't impersonate chrome.
+const CHROME_GLYPH_RE = new RegExp(
+  '[\\p{So}\\u2190-\\u21FF\\u25A0-\\u25FF\\u2500-\\u257F\\u2700-\\u27BF\\uFE00-\\uFE0F\\u2022\\u00B7\\u2027\\u2043]',
+  'gu',
+);
+const CONTROL_RE = new RegExp('[\\u0000-\\u0008\\u000B\\u000C\\u000E-\\u001F\\u007F-\\u009F]', 'g');
+const BIDI_RE = new RegExp('[\\u202A-\\u202E\\u2066-\\u2069]', 'g');
+
+/** Sanitize a dynamic value before it touches the DOM (see contract above). */
+export function sanitizeForDisplay(value, fieldKind = 'summary') {
+  let s = value == null ? '' : String(value);
+  s = s.normalize('NFKC');
+  s = s.replace(CONTROL_RE, '');
+  s = s.replace(BIDI_RE, '');
+  s = s.replace(/\n{2,}/g, '\n').replace(/[ \t]{5,}/g, '    ');
+  s = s.replace(CHROME_GLYPH_RE, '');
+  s = capGraphemes(s, CAPS[fieldKind] ?? CAPS.summary);
+  return s;
+}
+
+function capGraphemes(s, max) {
+  if (s.length <= max) return s;
+  if (typeof Intl !== 'undefined' && Intl.Segmenter) {
+    const arr = Array.from(new Intl.Segmenter(undefined, { granularity: 'grapheme' }).segment(s), (x) => x.segment);
+    if (arr.length <= max) return s;
+    return arr.slice(0, max - 1).join('') + '…';
+  }
+  let cut = max - 1;
+  const c = s.charCodeAt(cut - 1);
+  if (c >= 0xd800 && c <= 0xdbff) cut -= 1;
+  return s.slice(0, cut) + '…';
+}
+
+/** Clamp a utilization value to an integer 0–100 (the only dynamic attribute). */
+export function clampPct(value) {
+  const n = Number(value);
+  if (!Number.isFinite(n)) return 0;
+  return Math.max(0, Math.min(100, Math.round(n)));
+}
+
+const STATUS_WORDS = {
+  active: 'Active',
+  warming: 'Warming up',
+  'rate-limited': 'At its limit',
+  'needs-reauth': 'Needs sign-in',
+  disabled: 'Disabled',
+};
+export function friendlyStatus(status) {
+  return STATUS_WORDS[typeof status === 'string' ? status : ''] || 'Unknown';
+}
+
+const PROVIDER_WORDS = { anthropic: 'Claude', openai: 'Codex', 'github-copilot': 'Copilot', google: 'Gemini' };
+export function friendlyProvider(provider) {
+  return PROVIDER_WORDS[typeof provider === 'string' ? provider : ''] || sanitizeForDisplay(provider, 'label');
+}
+
+/** Human countdown to a reset/expiry instant: "resets in 2h 15m" / "expired". */
+export function countdown(iso, now = Date.now(), { expiredWord = 'expired' } = {}) {
+  const t = typeof iso === 'string' ? Date.parse(iso) : NaN;
+  if (Number.isNaN(t)) return '';
+  const sec = Math.floor((t - now) / 1000);
+  if (sec <= 0) return expiredWord;
+  const hr = Math.floor(sec / 3600);
+  const min = Math.floor((sec % 3600) / 60);
+  if (hr >= 24) { const d = Math.floor(hr / 24); return `${d}d ${hr % 24}h`; }
+  if (hr >= 1) return `${hr}h ${min}m`;
+  if (min >= 1) return `${min}m`;
+  return `${sec}s`;
+}
+
+// ── DOM helpers (textContent ONLY — never innerHTML) ────────────────────────
+function el(doc, tag, cls, text) {
+  const node = doc.createElement(tag);
+  if (cls) node.setAttribute('class', cls); // static literal
+  if (text != null) node.textContent = text; // dynamic text → textContent ONLY
+  return node;
+}
+
+/** A labelled quota bar. `pct` is clamped to a 0–100 NUMBER before it reaches the
+ *  only dynamic attribute (style width); the percent text is also from that number. */
+export function quotaBar(doc, label, pct, resetIso, now = Date.now()) {
+  const wrap = el(doc, 'div', 'sub-quota');
+  const used = clampPct(pct);
+  const head = el(doc, 'div', 'sub-quota-head');
+  head.appendChild(el(doc, 'span', 'sub-quota-label', sanitizeForDisplay(label, 'label')));
+  const resetTxt = resetIso ? countdown(resetIso, now, { expiredWord: 'resetting' }) : '';
+  head.appendChild(el(doc, 'span', 'sub-quota-pct', `${used}% used${resetTxt ? ` · resets in ${resetTxt}` : ''}`));
+  wrap.appendChild(head);
+  const track = el(doc, 'div', 'sub-quota-track');
+  const fill = el(doc, 'div', 'sub-quota-fill');
+  fill.style.width = `${used}%`; // safe: `used` is a clamped integer
+  track.appendChild(fill);
+  wrap.appendChild(track);
+  return wrap;
+}
+
+/** Per-account rows: nickname, status, provider·framework, 5h + weekly quota bars. */
+export function renderAccounts(doc, target, accounts, now = Date.now()) {
+  if (!target) return;
+  target.replaceChildren();
+  if (!Array.isArray(accounts) || accounts.length === 0) {
+    target.appendChild(el(doc, 'div', 'sub-empty', 'No subscription accounts enrolled yet.'));
+    return;
+  }
+  for (const a of accounts) {
+    const card = el(doc, 'div', 'sub-account');
+    const head = el(doc, 'div', 'sub-account-head');
+    head.appendChild(el(doc, 'span', 'sub-account-nick', sanitizeForDisplay(a && a.nickname, 'label')));
+    head.appendChild(el(doc, 'span', 'sub-account-status', friendlyStatus(a && a.status)));
+    card.appendChild(head);
+    card.appendChild(el(doc, 'div', 'sub-account-meta',
+      `${friendlyProvider(a && a.provider)} · ${sanitizeForDisplay(a && a.framework, 'label')}`));
+    const q = (a && a.lastQuota) || null;
+    if (q && (q.fiveHour || q.sevenDay)) {
+      if (q.fiveHour) card.appendChild(quotaBar(doc, '5-hour', q.fiveHour.utilizationPct, q.fiveHour.resetsAt, now));
+      if (q.sevenDay) card.appendChild(quotaBar(doc, 'Weekly', q.sevenDay.utilizationPct, q.sevenDay.resetsAt, now));
+    } else {
+      card.appendChild(el(doc, 'div', 'sub-account-noquota', 'No quota reading yet.'));
+    }
+    target.appendChild(card);
+  }
+}
+
+/** Pending Logins panel: device code / verification URL (as TEXT) + TTL + reissues. */
+export function renderPendingLogins(doc, target, logins, now = Date.now()) {
+  if (!target) return;
+  target.replaceChildren();
+  if (!Array.isArray(logins) || logins.length === 0) {
+    target.appendChild(el(doc, 'div', 'sub-empty', 'No logins waiting for approval.'));
+    return;
+  }
+  for (const l of logins) {
+    const row = el(doc, 'div', 'sub-pending');
+    const head = el(doc, 'div', 'sub-pending-head');
+    head.appendChild(el(doc, 'span', 'sub-pending-label', sanitizeForDisplay(l && l.label, 'label')));
+    const ttl = l && l.ttlExpiresAt ? countdown(l.ttlExpiresAt, now) : '';
+    head.appendChild(el(doc, 'span', 'sub-pending-ttl', ttl ? `expires in ${ttl}` : 'expired'));
+    row.appendChild(head);
+    if (l && l.userCode) {
+      row.appendChild(el(doc, 'div', 'sub-pending-code', `Code: ${sanitizeForDisplay(l.userCode, 'code')}`));
+    }
+    // Verification URL shown as TEXT for the operator to copy — never a live href.
+    row.appendChild(el(doc, 'div', 'sub-pending-url', sanitizeForDisplay(l && l.verificationUrl, 'url')));
+    const rc = l && Number(l.reissueCount);
+    if (Number.isFinite(rc) && rc > 0) {
+      row.appendChild(el(doc, 'div', 'sub-pending-reissue', `Re-issued ${rc} time${rc === 1 ? '' : 's'}`));
+    }
+    target.appendChild(row);
+  }
+}
+
+export function renderDisabled(doc, els) {
+  if (els && els.accounts) {
+    els.accounts.replaceChildren(
+      el(doc, 'div', 'sub-disabled', 'The subscription pool isn’t set up yet. Enroll an account to get started.'),
+    );
+  }
+  if (els && els.pending) els.pending.replaceChildren();
+}
+
+// ── Controller (fetch /subscription-pool + /pending-logins, render) ─────────
+const URLS = {
+  accounts: '/subscription-pool',
+  pending: '/subscription-pool/pending-logins',
+};
+
+export function createController(opts) {
+  const {
+    doc,
+    els = {},
+    fetchImpl,
+    now = () => Date.now(),
+    cadenceMs = 30_000,
+    schedule = (fn, ms) => setTimeout(fn, ms),
+    cancel = (id) => clearTimeout(id),
+  } = opts;
+
+  const state = { timerId: null, active: false, inFlight: null };
+
+  async function fetchJson(url, controller) {
+    const resp = await fetchImpl(url, { signal: controller.signal });
+    if (!resp.ok) throw new Error(`${url} ${resp.status}`);
+    return resp.json();
+  }
+
+  async function tick() {
+    if (!state.active) return;
+    if (state.inFlight) { try { state.inFlight.abort(); } catch { /* superseded */ } }
+    const controller = typeof AbortController !== 'undefined' ? new AbortController() : { signal: undefined, abort() {} };
+    state.inFlight = controller;
+    let accountsBody, pendingBody;
+    try {
+      [accountsBody, pendingBody] = await Promise.all([
+        fetchJson(URLS.accounts, controller),
+        fetchJson(URLS.pending, controller),
+      ]);
+    } catch {
+      if (controller.signal && controller.signal.aborted) return;
+      state.inFlight = null;
+      reschedule();
+      return;
+    }
+    if (controller.signal && controller.signal.aborted) return;
+    state.inFlight = null;
+    // Feature dark → both routes answer { enabled:false }. Show the friendly copy.
+    if (accountsBody && accountsBody.enabled === false && pendingBody && pendingBody.enabled === false) {
+      renderDisabled(doc, els);
+      reschedule();
+      return;
+    }
+    render(accountsBody, pendingBody);
+    reschedule();
+  }
+
+  function render(accountsBody, pendingBody) {
+    const accounts = accountsBody && Array.isArray(accountsBody.accounts) ? accountsBody.accounts : [];
+    const logins = pendingBody && Array.isArray(pendingBody.logins) ? pendingBody.logins : [];
+    renderAccounts(doc, els.accounts, accounts, now());
+    renderPendingLogins(doc, els.pending, logins, now());
+  }
+
+  function reschedule() {
+    if (!state.active) return;
+    if (state.timerId != null) cancel(state.timerId);
+    state.timerId = schedule(() => { void tick(); }, cadenceMs);
+  }
+
+  function start() { if (state.active) return; state.active = true; void tick(); }
+  function stop() {
+    state.active = false;
+    if (state.timerId != null) { cancel(state.timerId); state.timerId = null; }
+    if (state.inFlight) { try { state.inFlight.abort(); } catch { /* ignore */ } state.inFlight = null; }
+  }
+  function onVisible() { if (!state.active) start(); }
+  function onHidden() { stop(); }
+
+  return { start, stop, onVisible, onHidden, tick, render, _state: state };
+}
+
+if (typeof window !== 'undefined') {
+  window.Subscriptions = { createController, sanitizeForDisplay, renderAccounts, renderPendingLogins };
+}

--- a/tests/e2e/subscriptions-tab-lifecycle.test.ts
+++ b/tests/e2e/subscriptions-tab-lifecycle.test.ts
@@ -1,0 +1,105 @@
+/**
+ * E2E lifecycle test — Subscriptions dashboard tab (P2.2).
+ *
+ * Boots a REAL Express server with the inline /subscription-pool routes from
+ * createRoutes() (the production path AgentServer uses), mounts the tab markup in
+ * jsdom with the SHIPPED element ids, and drives the SHIPPED controller's
+ * fetchImpl against the live HTTP server. Asserts the feature is genuinely alive
+ * end-to-end:
+ *   - feature ON (pool + wizard wired): accounts render with quota bars, pending
+ *     logins render with the device code; no injected <script>/<a> survives
+ *   - feature OFF (neither wired → routes 200 { enabled:false }): the friendly
+ *     "not set up" copy, never a 503 / crash
+ */
+// @ts-nocheck — the tab controller is browser-native ESM.
+import { describe, it, expect, afterEach } from 'vitest';
+import express from 'express';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import type { AddressInfo } from 'node:net';
+import { createRoutes } from '../../src/server/routes.js';
+import { SubscriptionPool } from '../../src/core/SubscriptionPool.js';
+import { PendingLoginStore } from '../../src/core/PendingLoginStore.js';
+import { EnrollmentWizard } from '../../src/core/EnrollmentWizard.js';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+import { JSDOM } from 'jsdom';
+import { createController } from '../../dashboard/subscriptions.js';
+
+interface TestServer { url: string; close: () => Promise<void>; }
+async function listen(app: express.Express): Promise<TestServer> {
+  return new Promise((resolve) => {
+    const srv = app.listen(0, () => {
+      const port = (srv.address() as AddressInfo).port;
+      resolve({ url: `http://127.0.0.1:${port}`, close: () => new Promise<void>((r) => srv.close(() => r())) });
+    });
+  });
+}
+function bootApp(ctx: any): Promise<TestServer> {
+  const app = express();
+  app.use(express.json());
+  app.use(createRoutes(ctx));
+  return listen(app);
+}
+
+// Mirrors dashboard/index.html element ids for the Subscriptions tab.
+const PANEL_HTML = `<!doctype html><body>
+  <div id="subscriptionsPanel">
+    <div id="subAccounts"></div>
+    <div id="subPending"></div>
+  </div>
+</body>`;
+
+function mountTab(baseUrl: string) {
+  const doc = new JSDOM(PANEL_HTML).window.document;
+  const els = { accounts: doc.getElementById('subAccounts'), pending: doc.getElementById('subPending') };
+  const fetchImpl = (url: string, init?: any) => fetch(baseUrl + url, init);
+  const c = createController({ doc, els, fetchImpl, now: () => Date.parse('2026-06-07T00:00:00Z') });
+  c._state.active = true; // enable a manual tick() (start() would also schedule)
+  return { doc, els, c };
+}
+
+describe('/subscription-pool — Subscriptions tab E2E feature-alive', () => {
+  let server: TestServer;
+  let dir: string;
+
+  afterEach(async () => {
+    await server?.close();
+    try { if (dir) SafeFsExecutor.safeRmSync(dir, { recursive: true, force: true, operation: 'tests/e2e/subscriptions-tab-lifecycle.test.ts:cleanup' }); } catch { /* @silent-fallback-ok */ }
+  });
+
+  it('feature ON: accounts + pending logins render through the live server', async () => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'sub-tab-e2e-'));
+    const pool = new SubscriptionPool({ stateDir: dir });
+    pool.add({ id: 'a1', nickname: 'personal', provider: 'anthropic', framework: 'claude-code', configHome: '/h/.c1' });
+    pool.update('a1', { lastQuota: { fiveHour: { utilizationPct: 12, resetsAt: '2026-06-07T01:00:00Z' }, sevenDay: { utilizationPct: 71, resetsAt: '2026-06-12T00:00:00Z' } } });
+    const store = new PendingLoginStore({ stateDir: dir, now: () => Date.parse('2026-06-07T00:00:00Z') });
+    const wizard = new EnrollmentWizard({ store, now: () => Date.parse('2026-06-07T00:00:00Z'),
+      driveLogin: async () => ({ verificationUrl: 'https://auth.openai.com/codex/device', userCode: '7DAU-W4XJA', ttlMs: 15 * 60_000 }) });
+    await wizard.start({ id: 'codex-1', label: 'codex', provider: 'openai', framework: 'codex-cli' });
+
+    server = await bootApp({ config: { authToken: 't', stateDir: dir, port: 0 }, startTime: new Date(), subscriptionPool: pool, enrollmentWizard: wizard });
+    const { els, c } = mountTab(server.url);
+    await c.tick();
+
+    expect(els.accounts.querySelector('.sub-account-nick')!.textContent).toBe('personal');
+    expect(els.accounts.querySelectorAll('.sub-quota').length).toBe(2);
+    expect(els.pending.querySelector('.sub-pending-code')!.textContent).toContain('7DAU-W4XJA');
+    // safety: no live link / injected element survived the round-trip
+    expect(els.pending.querySelector('a')).toBeNull();
+    expect(els.accounts.querySelector('script')).toBeNull();
+  });
+
+  it('feature OFF: both routes 200 { enabled:false } → friendly not-set-up copy', async () => {
+    server = await bootApp({ config: { authToken: 't', stateDir: '/tmp/.instar', port: 0 }, startTime: new Date() });
+    // Routes are alive (not 503).
+    const acc = await fetch(server.url + '/subscription-pool');
+    const pend = await fetch(server.url + '/subscription-pool/pending-logins');
+    expect(acc.status).toBe(200);
+    expect(pend.status).toBe(200);
+    expect((await pend.json()).enabled).toBe(false);
+    const { els, c } = mountTab(server.url);
+    await c.tick();
+    expect(els.accounts.querySelector('.sub-disabled')).toBeTruthy();
+  });
+});

--- a/tests/integration/subscriptions-tab.test.ts
+++ b/tests/integration/subscriptions-tab.test.ts
@@ -1,0 +1,132 @@
+/**
+ * Integration tests for the Subscriptions tab POLLING CONTROLLER (jsdom, P2.2).
+ * Drives the SHIPPED createController() against a real jsdom DOM with injected
+ * fetch + manual timers + a controllable clock — every invariant deterministic,
+ * no wall-clock, no real network:
+ *   - both endpoints render into the real tab DOM (accounts + pending logins)
+ *   - feature-dark (both routes { enabled:false }) → the disabled copy, not a crash
+ *   - XSS safety holds through the full controller path (no injected element)
+ *   - visibility-gating: hidden clears the timer + aborts in-flight; visible re-arms
+ *   - a fetch failure drops the tick + keeps the prior paint (no exception escapes)
+ */
+// @ts-nocheck — exercises the browser-native ESM module.
+import { describe, it, expect, beforeEach } from 'vitest';
+import { JSDOM } from 'jsdom';
+import { createController } from '../../dashboard/subscriptions.js';
+
+const flush = () => new Promise((r) => setTimeout(r, 0));
+
+function makeEls(doc: Document) {
+  const accounts = doc.createElement('div');
+  const pending = doc.createElement('div');
+  const root = doc.createElement('div');
+  root.appendChild(accounts);
+  root.appendChild(pending);
+  doc.body.appendChild(root);
+  return { els: { accounts, pending }, root };
+}
+
+/** A scriptable fetch keyed by URL pathname; records abort signals. */
+function makeFetch() {
+  const script: Record<string, { status?: number; body?: unknown; throw?: boolean }> = {};
+  const signals: AbortSignal[] = [];
+  const fetchImpl = async (url: string, init?: { signal?: AbortSignal }) => {
+    if (init?.signal) signals.push(init.signal);
+    const key = url.replace(/^https?:\/\/[^/]+/, '');
+    const entry = script[key] ?? { status: 200, body: { enabled: true } };
+    if (entry.throw) throw new Error(`network ${key}`);
+    return {
+      ok: (entry.status ?? 200) < 400,
+      status: entry.status ?? 200,
+      json: async () => entry.body ?? {},
+    };
+  };
+  return { fetchImpl, script, signals };
+}
+
+const ACCOUNTS_OK = {
+  enabled: true,
+  accounts: [{ id: 'a1', nickname: 'personal', provider: 'anthropic', framework: 'claude-code', status: 'active', lastQuota: { fiveHour: { utilizationPct: 12, resetsAt: '2026-06-07T01:00:00Z' }, sevenDay: { utilizationPct: 71, resetsAt: '2026-06-12T00:00:00Z' } } }],
+};
+const PENDING_OK = {
+  enabled: true,
+  logins: [{ id: 'codex-1', label: 'codex', kind: 'device-code', userCode: '7DAU-W4XJA', verificationUrl: 'https://auth.openai.com/codex/device', ttlExpiresAt: '2026-06-07T00:12:00Z', reissueCount: 0 }],
+};
+
+describe('Subscriptions tab controller (integration)', () => {
+  let doc: Document;
+  let els: any;
+  let timers: Array<{ fn: () => void; ms: number }>;
+  let nowMs: number;
+  let fx: ReturnType<typeof makeFetch>;
+
+  beforeEach(() => {
+    doc = new JSDOM('<!doctype html><body></body>').window.document;
+    ({ els } = makeEls(doc));
+    timers = [];
+    nowMs = Date.parse('2026-06-07T00:00:00Z');
+    fx = makeFetch();
+  });
+
+  function ctl(extra?: any) {
+    return createController({
+      doc, els, fetchImpl: fx.fetchImpl, now: () => nowMs,
+      schedule: (fn: () => void, ms: number) => { timers.push({ fn, ms }); return timers.length - 1; },
+      cancel: (id: number) => { if (timers[id]) timers[id] = { fn: () => {}, ms: 0 }; },
+      ...extra,
+    });
+  }
+
+  it('renders both panes from the two endpoints', async () => {
+    fx.script['/subscription-pool'] = { body: ACCOUNTS_OK };
+    fx.script['/subscription-pool/pending-logins'] = { body: PENDING_OK };
+    const c = ctl();
+    c._state.active = true;
+    await c.tick();
+    expect(els.accounts.querySelector('.sub-account-nick')!.textContent).toBe('personal');
+    expect(els.accounts.querySelectorAll('.sub-quota').length).toBe(2);
+    expect(els.pending.querySelector('.sub-pending-code')!.textContent).toContain('7DAU-W4XJA');
+  });
+
+  it('feature-dark (both enabled:false) → the disabled copy, no crash', async () => {
+    fx.script['/subscription-pool'] = { body: { enabled: false, accounts: [] } };
+    fx.script['/subscription-pool/pending-logins'] = { body: { enabled: false, logins: [] } };
+    const c = ctl();
+    c._state.active = true;
+    await c.tick();
+    expect(els.accounts.querySelector('.sub-disabled')).toBeTruthy();
+  });
+
+  it('XSS payload in a nickname never becomes an element through the controller', async () => {
+    fx.script['/subscription-pool'] = { body: { enabled: true, accounts: [{ id: 'x', nickname: '<script>alert(1)</script>', provider: 'anthropic', framework: 'claude-code', status: 'active' }] } };
+    fx.script['/subscription-pool/pending-logins'] = { body: PENDING_OK };
+    const c = ctl();
+    c._state.active = true;
+    await c.tick();
+    expect(els.accounts.querySelector('script')).toBeNull();
+    expect(els.accounts.querySelector('.sub-account-nick')!.textContent).toContain('<script>');
+  });
+
+  it('a fetch failure drops the tick without throwing + reschedules', async () => {
+    fx.script['/subscription-pool'] = { throw: true };
+    fx.script['/subscription-pool/pending-logins'] = { body: PENDING_OK };
+    const c = ctl();
+    c._state.active = true;
+    await expect(c.tick()).resolves.toBeUndefined();
+    // nothing painted, but a retry is armed
+    expect(timers.length).toBeGreaterThan(0);
+  });
+
+  it('visibility gating: hidden stops the timer + aborts in-flight; visible re-arms', async () => {
+    fx.script['/subscription-pool'] = { body: ACCOUNTS_OK };
+    fx.script['/subscription-pool/pending-logins'] = { body: PENDING_OK };
+    const c = ctl();
+    c.start();
+    await flush();
+    expect(c._state.active).toBe(true);
+    c.onHidden();
+    expect(c._state.active).toBe(false);
+    c.onVisible();
+    expect(c._state.active).toBe(true);
+  });
+});

--- a/tests/unit/subscriptions-render.test.ts
+++ b/tests/unit/subscriptions-render.test.ts
@@ -1,0 +1,162 @@
+/**
+ * Unit tests for the Subscriptions tab's pure functions + renderers (P2.2).
+ * Exercises the SHIPPED module (dashboard/subscriptions.js) against a real jsdom
+ * DOM and asserts the load-bearing safety contract:
+ *   - every dynamic value is sanitized (NFKC fold, control/bidi/chrome-glyph
+ *     strip, grapheme cap) before the DOM
+ *   - all dynamic writes are textContent only → no injected element survives
+ *   - the only dynamic attribute (quota-bar width) comes from a clamped 0–100 int
+ *   - a verification URL is rendered as TEXT, never a live <a href>
+ */
+// @ts-nocheck — the module is browser-native ESM (.js), no types.
+import { describe, it, expect, beforeEach } from 'vitest';
+import { JSDOM } from 'jsdom';
+import {
+  sanitizeForDisplay,
+  clampPct,
+  friendlyStatus,
+  friendlyProvider,
+  countdown,
+  quotaBar,
+  renderAccounts,
+  renderPendingLogins,
+  renderDisabled,
+} from '../../dashboard/subscriptions.js';
+
+let doc: Document;
+beforeEach(() => {
+  doc = new JSDOM('<!doctype html><body></body>').window.document;
+});
+
+const NOW = Date.parse('2026-06-07T00:00:00Z');
+
+describe('sanitizeForDisplay', () => {
+  it('null/undefined → empty string', () => {
+    expect(sanitizeForDisplay(null)).toBe('');
+    expect(sanitizeForDisplay(undefined)).toBe('');
+  });
+  it('NFKC-folds full-width confusables', () => {
+    expect(sanitizeForDisplay('ＡＢＣ')).toBe('ABC');
+  });
+  it('strips bidi-control + C0 controls', () => {
+    expect(sanitizeForDisplay('a‮bc')).toBe('abc');
+  });
+  it('strips chrome glyphs (so a code can never impersonate a bar/marker)', () => {
+    expect(sanitizeForDisplay('●→✓ ok')).toBe(' ok');
+  });
+  it('caps a long code', () => {
+    expect(sanitizeForDisplay('x'.repeat(200), 'code').length).toBeLessThanOrEqual(48);
+  });
+});
+
+describe('clampPct', () => {
+  it('clamps to 0–100 and rounds', () => {
+    expect(clampPct(-5)).toBe(0);
+    expect(clampPct(150)).toBe(100);
+    expect(clampPct(71.6)).toBe(72);
+    expect(clampPct('nope')).toBe(0);
+    expect(clampPct(NaN)).toBe(0);
+  });
+});
+
+describe('countdown', () => {
+  it('future instants render h/m', () => {
+    expect(countdown('2026-06-07T02:15:00Z', NOW)).toBe('2h 15m');
+  });
+  it('past instants render the expired word', () => {
+    expect(countdown('2026-06-06T23:00:00Z', NOW)).toBe('expired');
+    expect(countdown('2026-06-06T23:00:00Z', NOW, { expiredWord: 'resetting' })).toBe('resetting');
+  });
+  it('invalid → empty', () => {
+    expect(countdown('not-a-date', NOW)).toBe('');
+  });
+});
+
+describe('friendly wording', () => {
+  it('maps status + provider to plain words', () => {
+    expect(friendlyStatus('rate-limited')).toBe('At its limit');
+    expect(friendlyStatus('weird')).toBe('Unknown');
+    expect(friendlyProvider('anthropic')).toBe('Claude');
+    expect(friendlyProvider('openai')).toBe('Codex');
+  });
+});
+
+describe('quotaBar', () => {
+  it('fill width is a clamped integer percent (only dynamic attribute)', () => {
+    const bar = quotaBar(doc, '5-hour', 171.6, '2026-06-07T02:00:00Z', NOW);
+    const fill = bar.querySelector('.sub-quota-fill') as HTMLElement;
+    expect(fill.style.width).toBe('100%'); // clamped from 171.6
+    expect(bar.querySelector('.sub-quota-pct')!.textContent).toContain('100% used');
+    expect(bar.querySelector('.sub-quota-pct')!.textContent).toContain('resets in 2h');
+  });
+});
+
+describe('renderAccounts', () => {
+  it('empty → friendly empty message', () => {
+    const t = el();
+    renderAccounts(doc, t, [], NOW);
+    expect(t.querySelector('.sub-empty')).toBeTruthy();
+  });
+  it('renders nickname, status, and two quota bars', () => {
+    const t = el();
+    renderAccounts(doc, t, [{
+      id: 'a1', nickname: 'personal', provider: 'anthropic', framework: 'claude-code', status: 'active',
+      lastQuota: { fiveHour: { utilizationPct: 10, resetsAt: '2026-06-07T01:00:00Z' }, sevenDay: { utilizationPct: 71, resetsAt: '2026-06-12T00:00:00Z' } },
+    }], NOW);
+    expect(t.querySelector('.sub-account-nick')!.textContent).toBe('personal');
+    expect(t.querySelector('.sub-account-status')!.textContent).toBe('Active');
+    expect(t.querySelectorAll('.sub-quota').length).toBe(2);
+  });
+  it('a malicious nickname survives only as inert text (no element injected)', () => {
+    const t = el();
+    renderAccounts(doc, t, [{ id: 'x', nickname: '<img src=x onerror=alert(1)>', provider: 'anthropic', framework: 'claude-code', status: 'active' }], NOW);
+    expect(t.querySelector('img')).toBeNull(); // textContent only — no element parsed
+    expect(t.querySelector('.sub-account-nick')!.textContent).toContain('<img');
+  });
+  it('no quota → "No quota reading yet"', () => {
+    const t = el();
+    renderAccounts(doc, t, [{ id: 'a', nickname: 'n', provider: 'anthropic', framework: 'claude-code', status: 'warming' }], NOW);
+    expect(t.querySelector('.sub-account-noquota')).toBeTruthy();
+  });
+});
+
+describe('renderPendingLogins', () => {
+  it('empty → friendly empty message', () => {
+    const t = el();
+    renderPendingLogins(doc, t, [], NOW);
+    expect(t.querySelector('.sub-empty')).toBeTruthy();
+  });
+  it('renders code + url-as-text + TTL + reissue count; never a live href', () => {
+    const t = el();
+    renderPendingLogins(doc, t, [{
+      id: 'codex-1', label: 'codex', kind: 'device-code', userCode: '7DAU-W4XJA',
+      verificationUrl: 'https://auth.openai.com/codex/device', ttlExpiresAt: '2026-06-07T00:12:00Z', reissueCount: 2,
+    }], NOW);
+    expect(t.querySelector('.sub-pending-code')!.textContent).toContain('7DAU-W4XJA');
+    expect(t.querySelector('.sub-pending-url')!.textContent).toContain('auth.openai.com');
+    expect(t.querySelector('a')).toBeNull(); // URL is TEXT, never a live link
+    expect(t.querySelector('.sub-pending-ttl')!.textContent).toBe('expires in 12m');
+    expect(t.querySelector('.sub-pending-reissue')!.textContent).toContain('2 times');
+  });
+  it('a javascript: URL renders as inert text, not an anchor', () => {
+    const t = el();
+    renderPendingLogins(doc, t, [{ id: 'x', label: 'l', kind: 'url-code-paste', verificationUrl: 'javascript:alert(1)', ttlExpiresAt: '2026-06-07T00:12:00Z', reissueCount: 0 }], NOW);
+    expect(t.querySelector('a')).toBeNull();
+    expect(t.querySelector('.sub-pending-url')!.textContent).toContain('javascript:alert(1)');
+  });
+});
+
+describe('renderDisabled', () => {
+  it('shows the friendly not-set-up copy in the accounts pane + clears pending', () => {
+    const accounts = el();
+    const pending = el();
+    pending.appendChild(doc.createElement('div'));
+    renderDisabled(doc, { accounts, pending });
+    expect(accounts.querySelector('.sub-disabled')).toBeTruthy();
+    expect(pending.children.length).toBe(0);
+  });
+});
+
+function el(): HTMLElement {
+  return doc.createElement('div');
+}

--- a/upgrades/next/subscription-dashboard-tab.md
+++ b/upgrades/next/subscription-dashboard-tab.md
@@ -1,0 +1,49 @@
+# Dashboard Subscriptions tab + Pending Logins panel (P2.2)
+
+<!-- bump: minor -->
+
+## What Changed
+
+Added a **Subscriptions** tab to the dashboard — the visual surface for the
+multi-account Subscription & Auth pool (P1.1–P2.1). It shows, per account: the
+nickname, a friendly status, and live quota bars for the 5-hour and weekly
+windows with a "resets in …" countdown. A **Pending Logins** panel below lists
+any in-flight enrollment — the device code / verification URL (shown as copyable
+text, never a live link) with its TTL countdown and how many times it has been
+re-issued.
+
+The tab is a self-contained browser-native ESM module (`dashboard/subscriptions.js`)
+served statically, registered in `index.html` exactly like the Process Health and
+Preferences tabs (lazy dynamic-import, start/stop on tab activation, polled every
+30s). It consumes the existing `GET /subscription-pool` and
+`GET /subscription-pool/pending-logins` routes — no new server routes, no `src/`
+change. When the pool isn't set up the routes answer `{ enabled:false }` and the
+tab shows a friendly "not set up yet" message (never an error).
+
+It carries the same load-bearing display-safety contract as the Process Health
+tab: every dynamic value is sanitized (NFKC fold + control/bidi/chrome-glyph
+strip + grapheme cap) before the DOM, all writes are `textContent` only, and the
+only dynamic attribute (a quota-bar width) comes from a clamped 0–100 integer.
+
+Coverage: 26 tests across three tiers — render unit tests (sanitize/clamp/
+countdown/renderers + XSS-survives-as-inert-text), a controller integration test
+(jsdom + injected fetch/timers: render, feature-dark, XSS through the controller,
+fetch-failure resilience, visibility gating), and an e2e feature-alive test that
+boots a real server with the production routes and drives the shipped controller
+against it (accounts + pending logins render; feature-off → friendly copy).
+
+## What to Tell Your User
+
+There's a new **Subscriptions** tab on your dashboard. It shows each of your
+subscription accounts, how much of each is left (5-hour and weekly) and when it
+resets, and any logins still waiting for you to approve on your phone — with the
+code and a countdown. Open it from any device with your dashboard PIN.
+
+## Summary of New Capabilities
+
+- **Subscriptions dashboard tab** — per-account live quota bars (5h + weekly) with
+  reset countdowns + friendly status, on any device behind the dashboard PIN.
+- **Pending Logins panel** — in-flight enrollment codes / verification URLs (as
+  copyable text) with TTL countdown + re-issue count.
+- **Mobile-responsive + safe** — sanitized, `textContent`-only rendering; no live
+  links; reuses the Process Health tab's hardened display contract.


### PR DESCRIPTION
## What this is (ELI16)

A new **Subscriptions** tab on the dashboard — the visual surface for the multi-account Subscription & Auth pool (P1.1–P2.1). Per account: nickname, status, and live quota bars (5-hour + weekly) with a "resets in …" countdown. Below, a **Pending Logins** panel: any enrollment still waiting for approval — the device code / verification URL (as copyable text, never a live link), its TTL countdown, and how many times it's been re-issued. Open it from any device with the dashboard PIN.

## What changed

- **`dashboard/subscriptions.js`** — self-contained browser-native ESM module (pure renderers + a polling controller), registered in `index.html` exactly like the Process Health and Preferences tabs (lazy dynamic-import, start/stop on tab activation, 30s poll).
- **`dashboard/index.html`** — tab button, content pane (+ scoped CSS), `tabRegistry` entry, and the `startSubscriptions`/`stopSubscriptions` wiring.
- Consumes the **existing** `GET /subscription-pool` + `GET /subscription-pool/pending-logins` — **no new routes, no `src/` change** (served statically via `express.static`). Feature-dark → friendly "not set up yet" copy, never a 503.

## Safety

Carries the Process Health tab's load-bearing display contract: every dynamic value is sanitized (NFKC fold + control/bidi/chrome-glyph strip + grapheme cap) before the DOM, all writes are `textContent` only, and the only dynamic attribute (a quota-bar width) comes from a clamped 0–100 integer. No verification URL is ever a live `<a href>`.

## Tests (three tiers)

26 tests: **render** units (sanitize/clamp/countdown/renderers + XSS-survives-as-inert-text + javascript:-URL-stays-text), a **controller integration** test (jsdom + injected fetch/timers: render, feature-dark, XSS through the controller, fetch-failure resilience, visibility gating), and an **e2e feature-alive** test that boots a real server with the production routes and drives the shipped controller against it (accounts + pending logins render; feature-off → friendly copy).

Builds on P1.1 (#956), P1.2 (#959), P1.3 (#963), P2.1 (#966).

🤖 Generated with [Claude Code](https://claude.com/claude-code)