### PR TITLE
fix(reaper): idle-detection uses live-only markers — the reaper read every idle session as working

### DIFF
--- a/.instar/instar-dev-decisions/2026-06-07T16-56-26-961Z-reaper-live-activity-idle.json
+++ b/.instar/instar-dev-decisions/2026-06-07T16-56-26-961Z-reaper-live-activity-idle.json
@@ -1,0 +1,18 @@
+{
+  "ts": "2026-06-07T16:56:26.961Z",
+  "slug": "reaper-live-activity-idle",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "safety-invariant proximity: src/monitoring/SessionReaper.ts matches session reaper"
+  ],
+  "belowFloor": true,
+  "files": 2,
+  "loc": 43,
+  "causalAutopsy": {
+    "origin": "latent",
+    "notes": "isPositivelyIdle has used the scrollback-matching toolCallOrSpinner (incl. bare 'claude' + tool-call names like Read(/Write(/Bash() since it was written — always wrong for 'is it active NOW' because those persist in an idle session's 200-line buffer, but never hit because earlier KEEP-guards (open-commitment, active-process) short-circuited before the positive-idle check ran. The 2026-06-07 #955/#958/#961 chain peeled those layers and #961 made transcripts resolve, so the reaper finally REACHED the positive-idle check and the latent bug surfaced as 0 reaps in 9.5h live / universal no-positive-idle. Grounded on a real idle echo pane: 2 bare 'claude' + 10 scrollback tool-names, 0 live spinner/esc. The bare-'claude' half is the exact analogue of the already-documented+fixed codex bare-word bug. No prior PR regressed it; deepest layer of the same conservatism stack."
+  },
+  "verdict": "pass"
+}

--- a/.instar/instar-dev-traces/2026-06-07T17-00-00-000Z-reaper-live-activity-idle.json
+++ b/.instar/instar-dev-traces/2026-06-07T17-00-00-000Z-reaper-live-activity-idle.json
@@ -1,0 +1,23 @@
+{
+    "slug": "reaper-live-activity-idle",
+    "sessionId": "96c61421-860a-48f9-92b4-26328f5640f1",
+    "timestamp": "2026-06-07T17:00:00.000Z",
+    "artifactPath": "upgrades/side-effects/reaper-live-activity-idle.md",
+    "artifactSha256": "b268ea7a3ba745e793c954a58aa690963f2a627a5ade32d934398432b948b2f1",
+    "coveredFiles": [
+        "src/monitoring/frameworkActivitySignals.ts",
+        "src/monitoring/SessionReaper.ts",
+        "tests/unit/session-reaper.test.ts"
+    ],
+    "phase": "complete",
+    "tier": 1,
+    "tierReasoning": "Classifier fix: SessionReaper.isPositivelyIdle used toolCallOrSpinner (matches tool-call names + bare 'claude' that persist in idle scrollback) so every idle session read as working → reaper never reaped. Adds a live-only liveActivity signal (spinner + Working-status + generating) used by isPositivelyIdle, and removes bare 'claude' from the Claude toolCallOrSpinner (documented codex lesson). One-directional: only lets the reaper correctly recognize idle; transcript-growth + confirmObservations + 8h gates downstream backstop any momentary live-marker miss, so it cannot cause a wrong kill. No API/route/state/migration. Reaper opt-in + dry-run-first. Both sides unit-tested (idle-with-scrollback vs live-spinner). No converged spec required for Tier 1.",
+    "eli16Path": "docs/eli16/reaper-live-activity-idle.eli16.md",
+    "sideEffectsPath": "upgrades/side-effects/reaper-live-activity-idle.md",
+    "causalAutopsy": {
+        "origin": "latent",
+        "notes": "isPositivelyIdle has used the scrollback-matching toolCallOrSpinner (incl. bare 'claude' + tool-call names like Read(/Write(/Bash() since it was written — always wrong for 'is it active NOW' because those persist in an idle session's 200-line buffer, but never hit because earlier KEEP-guards (open-commitment, active-process) short-circuited before the positive-idle check ran. The 2026-06-07 #955/#958/#961 chain peeled those layers and #961 made transcripts resolve, so the reaper finally REACHED the positive-idle check and the latent bug surfaced as 0 reaps in 9.5h live / universal no-positive-idle. Grounded on a real idle echo pane: 2 bare 'claude' + 10 scrollback tool-names, 0 live spinner/esc. The bare-'claude' half is the exact analogue of the already-documented+fixed codex bare-word bug. No prior PR regressed it; deepest layer of the same conservatism stack."
+    },
+    "secondPass": "not-required",
+    "reviewerConcurred": null
+}

--- a/docs/eli16/reaper-live-activity-idle.eli16.md
+++ b/docs/eli16/reaper-live-activity-idle.eli16.md
@@ -1,0 +1,32 @@
+# Reaper live-activity idle detection — ELI16
+
+> The one-line version: the reaper decided "is this session working?" by scanning the whole visible terminal for tool names (Read(/Bash(/…) and the word "claude" — but those stay on screen in an IDLE session's history long after the work finished. So every idle session looked "busy" forever and the reaper never reaped one. Now it only looks for markers that mean working RIGHT NOW (the spinner animation, "Working (Ns", "esc to interrupt"), which disappear the moment a turn ends.
+
+## The problem (found 2026-06-07, "make the reaper work correctly and robustly")
+
+After the transcript-resolution fix (#961), the reaper could finally read transcripts — but it STILL reaped nothing (0 in 9.5h live). Grounding it on a genuinely-idle Claude session showed why: the reaper's "is it active?" check matched the bare word **"claude"** AND tool-call names like **Read(/Write(/Bash(** anywhere in the captured 200-line buffer. An idle Claude session's screen is full of both (its past work history, plus the word "claude" everywhere). So `isPositivelyIdle` always saw "activity" → never positively idle → kept every session forever.
+
+This is the SAME bug the code already fixed once for Codex — there's a literal comment: "do NOT match the bare word 'codex' — it made every idle session read as working." The Claude side had the identical flaw; it was never caught because the earlier reaper layers (open-commitment, active-process, transcript) short-circuited before this check ever ran. The #955/#958/#961 chain peeled those away and exposed it.
+
+## What this changes
+
+Splits "activity signals" into two kinds and uses the right one for idle-detection:
+- **Live-only markers** (new `liveActivity`): the animated braille spinner, "Working (Ns", "generating" — these appear ONLY while a turn is generating and vanish when it ends.
+- **Scrollback-persistent markers** (the existing `toolCallOrSpinner`): tool-call names + the framework word — these linger in idle history.
+
+`isPositivelyIdle` now uses `liveActivity` (+ "esc to interrupt" + "(running)"), not `toolCallOrSpinner`. Also removed the bare word "claude" from the Claude `toolCallOrSpinner` entirely (the documented codex lesson, so other detectors stop mis-reading idle Claude sessions too).
+
+## Why it's safe
+
+- It only makes the reaper able to correctly RECOGNIZE an idle session; it does not weaken any other gate. A session still must be 8h-silent + transcript-flat + confirmed across 3 ticks before it's reaped.
+- The transcript-growth check is a backstop: if a session is genuinely working but its frame momentarily lacks a spinner (e.g. between tool calls), its transcript is growing → kept by transcript-grew. So a momentary live-marker miss can't cause a wrong kill.
+- Reaper stays opt-in + dry-run-first; this is validated by watching the dry-run correctly flag idle sessions before any real kill.
+- Removing bare "claude" is strictly more correct (it never should have matched an omnipresent word); 57 unit tests pass including the framework-signal suite.
+
+## Honest scope
+
+This is the final functional fix in the chain (#952 → #955 → #958 → #961 → this): with it, the reaper can finally tell an idle session from a working one and actually reclaim. Separately, the transcript pile-up (151k files / 5.9 GB) still needs its own retention fix.
+
+## Evidence
+
+`tests/unit/session-reaper.test.ts`: an idle Claude pane (scrollback tool-names + "claude", no live marker) → positively idle; a working pane (spinner, or spinner+esc) → not idle; bare "claude" alone no longer forces not-idle. 57/57 green. `tsc --noEmit` clean.

--- a/src/monitoring/SessionReaper.ts
+++ b/src/monitoring/SessionReaper.ts
@@ -356,8 +356,13 @@ export class SessionReaper extends EventEmitter {
   static isPositivelyIdle(framework: 'claude-code' | 'codex-cli' | 'gemini-cli' | 'pi-cli' | undefined, frame: string): boolean {
     if (!framework) return false; // unknown framework → cannot positively assert idle
     const sig = getActivitySignal(framework);
-    // Any active marker anywhere in the captured buffer ⇒ not idle.
-    if (sig.toolCallOrSpinner.test(frame) || sig.escapeToInterrupt.test(frame) || sig.runningIndicator.test(frame)) {
+    // Any LIVE-generation marker anywhere in the captured buffer ⇒ not idle. Uses
+    // `liveActivity` (spinner / "Working (Ns" / "generating"), NOT toolCallOrSpinner:
+    // the latter matches tool-call names + the bare framework word that PERSIST in an
+    // idle session's scrollback, which made every idle session read as "working" so
+    // the reaper never reaped (2026-06-07 root cause). The transcript-growth +
+    // confirmObservations gates downstream backstop any momentary live-marker miss.
+    if (sig.liveActivity.test(frame) || sig.escapeToInterrupt.test(frame) || sig.runningIndicator.test(frame)) {
       return false;
     }
     // Positive ready-prompt signatures (conservative; tunable via dry-run).

--- a/src/monitoring/frameworkActivitySignals.ts
+++ b/src/monitoring/frameworkActivitySignals.ts
@@ -33,6 +33,21 @@ export interface FrameworkActivitySignal {
    */
   readonly toolCallOrSpinner: RegExp;
   /**
+   * LIVE-generation markers ONLY — the subset of activity signals that appear
+   * exclusively WHILE a turn is generating and vanish the instant it ends (the
+   * animated braille spinner, the "Working (Ns" status line, "generating"). It
+   * deliberately EXCLUDES the scrollback-persistent markers in toolCallOrSpinner —
+   * tool-call names (Read(/Write(/Bash(/exec(/…) and the bare framework word
+   * (e.g. "claude") — which linger in an IDLE session's visible history long after
+   * the turn finished. The SessionReaper's positive-idle proof must use THIS, not
+   * toolCallOrSpinner: a 200-line capture of an idle Claude session is full of past
+   * tool-names + "claude", so toolCallOrSpinner mis-read every idle session as
+   * "working" and the reaper could never reap (2026-06-07 grounding; same class as
+   * the codex "do not match bare 'codex'" lesson). Other consumers that genuinely
+   * want "is this a tool-using framework" keep using toolCallOrSpinner.
+   */
+  readonly liveActivity: RegExp;
+  /**
    * Matches text the framework shows when it wants the user to interrupt
    * a long-running tool call (e.g., Claude's "esc to interrupt").
    */
@@ -53,7 +68,14 @@ const CLAUDE_CODE_SIGNAL: FrameworkActivitySignal = {
   displayName: 'Claude Code',
   // Tool names from Claude Code's display, plus the Braille spinner
   // glyphs Claude renders while thinking.
-  toolCallOrSpinner: /claude|Read\(|Write\(|Edit\(|Bash\(|Grep\(|Glob\(|⠋|⠙|⠹|⠸|⠼|⠴|⠦|⠧|⠇|⠏/,
+  // NOTE: the bare word "claude" was REMOVED (2026-06-07) — it matched the
+  // omnipresent tool name in every Claude Code pane, making idle sessions read as
+  // working (the documented codex "do not match bare 'codex'" lesson, never applied
+  // here). Tool-call names remain for consumers that want "is this tool-using".
+  toolCallOrSpinner: /Read\(|Write\(|Edit\(|Bash\(|Grep\(|Glob\(|⠋|⠙|⠹|⠸|⠼|⠴|⠦|⠧|⠇|⠏/,
+  // Live-only: the animated braille spinner. Tool-names + "claude" persist in idle
+  // scrollback, so they are NOT live markers (see FrameworkActivitySignal.liveActivity).
+  liveActivity: /⠋|⠙|⠹|⠸|⠼|⠴|⠦|⠧|⠇|⠏/,
   escapeToInterrupt: /esc to interrupt/i,
   runningIndicator: /\(running\)/i,
   promptSignaturesLine:
@@ -87,6 +109,10 @@ const CODEX_CLI_SIGNAL: FrameworkActivitySignal = {
   // Tracker's observed-change requirement still gates "frozen before we watched").
   // These are structured JSON markers, not idle status text.
   toolCallOrSpinner: /Working\s*\(\d+\s*s|•\s*Ran\b|exec\(|shell\(|apply_patch\(|⠋|⠙|⠹|⠸|⠼|⠴|⠦|⠧|⠇|⠏|\bgenerating\b|"type":\s*"(thread|turn|item)\./i,
+  // Live-only: the working status line + spinner + "generating". Excludes "• Ran"
+  // and exec(/shell(/apply_patch( + the event-stream markers, which persist in
+  // scrollback / the JSONL after a turn ends.
+  liveActivity: /Working\s*\(\d+\s*s|⠋|⠙|⠹|⠸|⠼|⠴|⠦|⠧|⠇|⠏|\bgenerating\b/i,
   // Codex shows a BARE "esc to interrupt" (no "press"/"hit" prefix) inside
   // its working status line, so the Claude-style prefixed pattern never
   // matched a real Codex pane. Match the bare form.
@@ -108,6 +134,9 @@ const GEMINI_CLI_SIGNAL: FrameworkActivitySignal = {
   // the bare word "gemini" (which appears in idle status / the model name) to
   // avoid the codex idle-status false-positive that hid stuck sessions.
   toolCallOrSpinner: /⠋|⠙|⠹|⠸|⠼|⠴|⠦|⠧|⠇|⠏|\b(generating|thinking)\b/i,
+  // Gemini's toolCallOrSpinner is already live-only (spinner + generating/thinking,
+  // no scrollback-persistent tool-names), so liveActivity mirrors it.
+  liveActivity: /⠋|⠙|⠹|⠸|⠼|⠴|⠦|⠧|⠇|⠏|\b(generating|thinking)\b/i,
   escapeToInterrupt: /esc to interrupt/i,
   runningIndicator: /\((running|executing|streaming)\)/i,
   promptSignaturesLine:
@@ -126,6 +155,9 @@ const PI_CLI_SIGNAL: FrameworkActivitySignal = {
   // near boot even when idle — matching it would recreate the codex
   // idle-status false-positive that hid stuck sessions).
   toolCallOrSpinner: /⠋|⠙|⠹|⠸|⠼|⠴|⠦|⠧|⠇|⠏|^\s*\$\s\S|\bTook \d+(\.\d+)?s\b|\b(generating|thinking|streaming)\b/im,
+  // Live-only: spinner + generating/thinking/streaming. Excludes the "$ cmd" shell
+  // echo and "Took Ns" completion line, which persist in scrollback after a turn.
+  liveActivity: /⠋|⠙|⠹|⠸|⠼|⠴|⠦|⠧|⠇|⠏|\b(generating|thinking|streaming)\b/i,
   // pi's interrupt hint is the banner's "escape interrupt", but that banner is
   // visible while IDLE too — so it is NOT a reliable in-flight indicator. Use a
   // deliberately unmatchable pattern until a live-provider pane characterizes a

--- a/tests/unit/session-reaper.test.ts
+++ b/tests/unit/session-reaper.test.ts
@@ -411,3 +411,37 @@ describe('SessionReaper.probe fallback resolves the transcript via session.proje
     SafeFsExecutor.safeRmSync(home, { recursive: true, force: true, operation: 'tests/unit/session-reaper.test.ts' });
   });
 });
+
+describe('SessionReaper.isPositivelyIdle — live markers vs scrollback (2026-06-07 bug)', () => {
+  // An IDLE Claude pane: its scrollback is full of PAST tool-names + the word
+  // "claude", and the footer shows the ready-prompt — but NO live spinner/esc. This
+  // is the case that mis-read as "working" (toolCallOrSpinner matched the scrollback),
+  // so the reaper never reaped. It MUST now read as positively idle.
+  const IDLE_CLAUDE = [
+    'Read(src/foo.ts)',
+    'Bash(npm test)  ⎿ ok',
+    'claude finished the task; nothing pending.',
+    '✻ Cooked for 7m 8s · 1 shell still running',
+    '❯ ',
+    '⏵⏵ bypass permissions on · 1 shell · ← for agents · ↓ to manage   new task? /clear to save 193.3k tokens',
+  ].join('\n');
+
+  it('idle Claude pane (scrollback tool-names + "claude", no live marker) → positively idle', () => {
+    expect(SessionReaper.isPositivelyIdle('claude-code', IDLE_CLAUDE)).toBe(true);
+  });
+
+  it('working Claude pane (live spinner) → NOT idle', () => {
+    const working = 'Bash(npm test)\n⠹ Crunching the numbers…\nesc to interrupt';
+    expect(SessionReaper.isPositivelyIdle('claude-code', working)).toBe(false);
+  });
+
+  it('working Claude pane (spinner glyph only, no esc) → NOT idle', () => {
+    const spinning = 'Read(x.ts)\nbypass permissions on\n⠼ generating';
+    expect(SessionReaper.isPositivelyIdle('claude-code', spinning)).toBe(false);
+  });
+
+  it('the bare word "claude" alone no longer forces NOT-idle (the removed false match)', () => {
+    // Ready-prompt present, "claude" in scrollback, no live marker → idle.
+    expect(SessionReaper.isPositivelyIdle('claude-code', 'claude\nbypass permissions on\n❯ ')).toBe(true);
+  });
+});

--- a/upgrades/next/reaper-live-activity-idle.md
+++ b/upgrades/next/reaper-live-activity-idle.md
@@ -1,0 +1,42 @@
+<!-- bump: patch -->
+<!-- change_type: fix -->
+
+## What Changed
+
+The idle-session reaper checked "is this session working?" with a pattern that matched
+tool-call names (Read(/Write(/Bash() and the bare word "claude" anywhere in the captured
+terminal — but those persist in an IDLE session's scrollback, so every idle Claude
+session read as "working" and the reaper never reaped one (0 reaps in 9.5h live; the
+residual blocker after #961). Fix: `isPositivelyIdle` now uses a new live-only signal
+(`liveActivity`: spinner glyphs + "Working (Ns" + "generating"), which vanish when a turn
+ends), not the scrollback-persistent `toolCallOrSpinner`. Also removed the bare word
+"claude" from the Claude activity pattern (the documented codex "do not match bare
+'codex'" lesson).
+
+## What to Tell Your User
+
+Nothing required — internal reaper classifier; reaper stays opt-in. For operators who
+enable it: the reaper can now correctly recognize a genuinely-idle session and reclaim it
+(it previously could not). The change also makes the silence/presence sentinels stop
+mis-reading idle Claude sessions as "working".
+
+## Summary of New Capabilities
+
+- `FrameworkActivitySignal.liveActivity` — live-generation-only markers per framework, so
+  callers that need "working RIGHT NOW" don't trip over scrollback history.
+- `SessionReaper.isPositivelyIdle` uses `liveActivity`; bare "claude" removed from the
+  Claude `toolCallOrSpinner`.
+
+## Scope (honest)
+
+Final functional fix in the chain (#952 → #955 → #958 → #961 → this): the reaper can now
+tell idle from working and actually reclaim. Validated by dry-run before any live flip.
+Does NOT address the transcript pile-up (151k files / 5.9 GB) — separate retention
+follow-up.
+
+## Evidence
+
+`tests/unit/session-reaper.test.ts`: idle Claude pane (scrollback tool-names + "claude",
+no live marker) → positively idle; working pane (spinner / spinner+esc) → not idle; bare
+"claude" alone no longer forces not-idle. 57/57 green. `tsc --noEmit` clean. causalAutopsy:
+latent (exposed by the #955/#958/#961 chain reaching the positive-idle check).

--- a/upgrades/side-effects/reaper-live-activity-idle.md
+++ b/upgrades/side-effects/reaper-live-activity-idle.md
@@ -1,0 +1,46 @@
+# Side-Effects Review - Reaper live-activity idle detection
+
+**Version / slug:** `reaper-live-activity-idle`
+**Date:** `2026-06-07`
+**Author:** `echo`
+**Second-pass reviewer:** `not required (Tier 1)`
+
+## Summary of the change
+
+`SessionReaper.isPositivelyIdle` used `sig.toolCallOrSpinner` to decide "is this session active?", but that regex matches tool-call names (Read(/Write(/Bash(/…) and the bare word "claude" — both of which PERSIST in an idle session's 200-line scrollback. So every idle Claude session read as active → never positively idle → reaper kept everything (0 reaps in 9.5h live; the residual blocker after #961 made transcripts resolve). Adds a `liveActivity` regex to `FrameworkActivitySignal` (live-generation-only: spinner glyphs + "Working (Ns" + "generating") and uses it in `isPositivelyIdle`; removes the bare `claude|` from the Claude `toolCallOrSpinner` (the documented codex "do not match bare 'codex'" lesson).
+
+## Decision-point inventory
+
+- `FrameworkActivitySignal.liveActivity` (new field) on all 4 signals (claude/codex/gemini/pi) — live-only markers.
+- `SessionReaper.isPositivelyIdle`: active-check now `sig.liveActivity || sig.escapeToInterrupt || sig.runningIndicator` (was `sig.toolCallOrSpinner || …`).
+- `CLAUDE_CODE_SIGNAL.toolCallOrSpinner`: bare `claude|` removed (tool-names + spinner retained).
+
+## 1. Behavior change / gating
+
+This makes `isPositivelyIdle` correctly recognize idle sessions; it does not change any other gate. The only behavioral effect: the reaper can now reach reap-eligibility for genuinely-idle sessions (it previously could not). Removing bare "claude" from toolCallOrSpinner also makes OTHER consumers (silence/presence sentinels) stop mis-reading idle Claude sessions as working — strictly more correct, matching the existing codex behavior. No API/route/state change.
+
+## 2. Over/under-signal
+
+Direction of risk: a session genuinely working but whose captured frame momentarily shows no live marker (between tool calls) could read idle. Mitigations: (a) transcript-growth fires first and KEEPS anything whose JSONL is growing — a working session is growing its transcript; (b) confirmObservations (3 ticks / render-stasis) requires sustained idle; (c) 8h-silence + the full guard chain still apply. So a momentary live-marker miss cannot produce a wrong reap. UNDER-signal (the prior "never recognizes idle") is the bug being fixed. `liveActivity` deliberately keeps every genuine live marker per framework (spinner always; +Working-status for codex; +generating/thinking for gemini/pi).
+
+## 3. Blast radius
+
+Pure regex/classifier logic in the shared signal module + one call-site in the reaper. No I/O, no new deps, no persistent state, no migration. Other consumers of `toolCallOrSpinner` are unaffected except they no longer match the bare word "claude" (a correctness improvement, not a regression — no test depended on it; 57 unit tests incl. the framework-signal suite pass).
+
+## 4. Failure modes
+
+`liveActivity` is a required field with a concrete regex on every signal (tsc-enforced — a missing one is a compile error). A malformed frame is just text the regexes test against; no throw path. The reaper's downstream stateful checks (transcript-growth, positive-idle prompt match, confirmObservations) all still run after this gate.
+
+## 5. Migration parity
+
+No agent-installed file changes; internal classifier logic shipped in code, effective on next server start. No config surface. The reaper remains opt-in + dry-run-first, so nothing changes for an operator until they enable it.
+
+## 6. Scope honesty (what this is NOT)
+
+- Final functional fix in the chain (#952 → #955 → #958 → #961 → this). With it the reaper can distinguish idle from working and actually reclaim; validated by dry-run before any live flip.
+- Does NOT touch the gemini/codex/pi live-marker sets beyond adding the live-only subset (codex/gemini/pi toolCallOrSpinner were already largely live-only or carefully tuned; only Claude carried the bare-word + tool-name-in-idle bug at the reaper call-site).
+- Does NOT address the transcript pile-up (151k files / 5.9 GB) — separate retention follow-up.
+
+## 7. Causal autopsy
+
+Origin: **latent**. The reaper's idle-check has used the scrollback-matching `toolCallOrSpinner` (incl. bare "claude") since `isPositivelyIdle` was written — always wrong for the "is it active NOW" question, but never hit because the earlier KEEP-guards short-circuited before the positive-idle check ran. The 2026-06-07 #955/#958/#961 chain peeled those layers (and #961 made transcripts resolve), so the reaper finally REACHED the positive-idle check and the latent bug surfaced as 0 reaps / universal `no-positive-idle`. No prior PR regressed it; it is the deepest layer of the same conservatism stack. The bare-"claude" half is the exact analogue of the already-fixed codex bare-word bug.


### PR DESCRIPTION
## ELI16

The idle-session reaper decided "is this session working?" by scanning the visible terminal for tool names (Read(/Write(/Bash(…) and the word "claude" — but those stay on screen in an IDLE session's history long after the work finished. So every idle Claude session looked "busy" forever and the reaper never reaped a single one. Grounded on a real idle session: 0 live-work markers (no spinner, no "esc to interrupt") but 2 "claude" + 10 old tool-names in the buffer → mis-read as working. This is the SAME bug the code already fixed for Codex (there's a literal comment: "do NOT match the bare word 'codex' — it made every idle session read as working"); the Claude side had the identical flaw, never caught because the earlier reaper layers short-circuited before this check ever ran. The fix: only count markers that mean working RIGHT NOW (the spinner animation, "Working (Ns", "esc to interrupt"), which disappear the moment a turn ends — not tool-names or "claude" that linger in scrollback. That lets the reaper finally tell an idle session from a working one.

## The chain (this is the last functional piece)

#952 (Spotlight) → #955 (stale-commitment veto) → #958 (stale-idle/active-process veto) → #961 (transcript resolution) → **this** (idle vs working detection). Each peeled a layer; this one makes the reaper actually able to recognize idle and reclaim. Dry-run grounding on echo after #961: 0 reap-eligible, 100% `no-positive-idle` — exactly this gap.

## The change

- New `FrameworkActivitySignal.liveActivity` (all 4 frameworks): live-generation-only markers (spinner glyphs, "Working (Ns", "generating") — excludes the scrollback-persistent tool-names + framework word in `toolCallOrSpinner`.
- `SessionReaper.isPositivelyIdle` now uses `liveActivity` (+ "esc to interrupt" + "(running)") instead of `toolCallOrSpinner`.
- Removed the bare `claude|` from the Claude `toolCallOrSpinner` (documented codex lesson; also fixes the silence/presence sentinels mis-reading idle Claude sessions).

## Safety

One-directional — it only lets the reaper correctly RECOGNIZE idle; it weakens no other gate. A session still must be 8h-silent + transcript-flat + confirmed across 3 ticks to reap. The transcript-growth check backstops any momentary live-marker miss (a genuinely-working session is growing its transcript → kept). Reaper stays opt-in + dry-run-first.

## Tests / evidence

`tests/unit/session-reaper.test.ts`: idle Claude pane (scrollback tool-names + "claude", no live marker) → positively idle; working pane (spinner / spinner+esc) → not idle; bare "claude" alone no longer forces not-idle. 57/57 green (incl. the framework-signal suite). `tsc --noEmit` clean. causalAutopsy: **latent** (the scrollback-matching idle-check was always wrong; the #955/#958/#961 chain reaching the positive-idle check surfaced it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)