### PR TITLE
fix(dashboard): pool-stream connector observability + bounded mint (live-verify)

### DIFF
--- a/.instar/instar-dev-decisions/2026-06-07T17-05-26-152Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-06-07T17-05-26-152Z-unknown.json
@@ -1,0 +1,13 @@
+{
+  "ts": "2026-06-07T17:05:26.152Z",
+  "slug": "unknown",
+  "suggestedTier": 1,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 26,
+  "causalAutopsy": null,
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-06-07T17-06-18-565Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-06-07T17-06-18-565Z-unknown.json
@@ -1,0 +1,13 @@
+{
+  "ts": "2026-06-07T17:06:18.565Z",
+  "slug": "unknown",
+  "suggestedTier": 1,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 26,
+  "causalAutopsy": null,
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-06-07T17-06-56-823Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-06-07T17-06-56-823Z-unknown.json
@@ -1,0 +1,13 @@
+{
+  "ts": "2026-06-07T17:06:56.823Z",
+  "slug": "unknown",
+  "suggestedTier": 1,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 26,
+  "causalAutopsy": null,
+  "verdict": "pass"
+}

--- a/.instar/instar-dev-traces/2026-06-07T17-04-29-882Z-pool-stream-connector-observability-91d4e2eb.json
+++ b/.instar/instar-dev-traces/2026-06-07T17-04-29-882Z-pool-stream-connector-observability-91d4e2eb.json
@@ -1,0 +1,17 @@
+{
+  "version": 2,
+  "sessionId": "cbdc2d51-a6de-446b-8215-773ec12f8e0b",
+  "timestamp": "2026-06-07T17:04:29.882Z",
+  "artifactPath": "upgrades/side-effects/pool-stream-connector-observability.md",
+  "artifactSha256": "f055478d038ec45fe4ba99ff8f2c4919bd53086d782acfc01bca559e404265f4",
+  "coveredFiles": [
+    "src/commands/server.ts"
+  ],
+  "phase": "complete",
+  "tier": 1,
+  "tierReasoning": "Diagnostic + robustness fix for the live cross-machine stream path: explicit 10s timeout on the connector's ticket-mint (was unbounded → silent indefinite hang found in live-verify) + per-step logging on the connector and serving mint verb. Removes a silent-swallow; no new route/capability; tsc clean.",
+  "eli16Path": "docs/specs/POOL-DASHBOARD-STREAM-SPEC.eli16.md",
+  "sideEffectsPath": "upgrades/side-effects/pool-stream-connector-observability.md",
+  "secondPass": "not-required",
+  "reviewerConcurred": null
+}

--- a/docs/specs/POOL-DASHBOARD-STREAM-SPEC.eli16.md
+++ b/docs/specs/POOL-DASHBOARD-STREAM-SPEC.eli16.md
@@ -58,3 +58,7 @@ Now the other half: when you're on the laptop dashboard and click a session that
 ## Phase 3 shipped — the on-screen part (it's now usable)
 
 The feature is now real on your screen: in the dashboard, a session running on another machine is no longer a dead tile — click it and its live terminal streams right there, with a small note telling you which machine it's coming from. Typing works too (if you've turned remote typing on for that machine); if you haven't, you get a clear "remote typing is disabled" message instead of your keystrokes vanishing. Every failure tells the truth on screen: an unreachable machine says so, a dropped stream says "reconnecting", a session that moved says "reselect it to follow" — never a frozen black box. And if the dashboard's own connection blips (e.g. a server restart), it reconnects and re-opens whatever you were watching automatically. One dashboard, every machine's sessions, click to watch.
+
+## Live-verify fix — making the cross-machine link observable
+
+First live test on the real machines caught the stream not coming through: the request started but nothing arrived, and nothing errored either — because the code that opens the machine-to-machine link kept all its problems to itself (no logging) and had no time limit on getting the one-time pass, so it could quietly hang forever. Fixed: the pass-fetch now gives up after 10 seconds (so a failure shows up as "reconnecting/unreachable" instead of an eternal blank), and every step now reports what it's doing — so the exact break can be pinpointed and fixed.

--- a/src/commands/server.ts
+++ b/src/commands/server.ts
@@ -10882,9 +10882,10 @@ export async function startServer(options: StartOptions): Promise<void> {
             // the ticket is bound to that sender and consumed once on upgrade.
             'pool-stream-ticket': (cmd, sender) => {
               const c = cmd as import('../core/MeshRpc.js').MeshCommand & { type: 'pool-stream-ticket' };
-              if (!_streamTicketStore) return { ok: false, reason: 'pool-stream disabled' };
+              if (!_streamTicketStore) { console.log(pc.dim(`  [pool-stream-ticket] mint request from ${sender} REFUSED: store disabled`)); return { ok: false, reason: 'pool-stream disabled' }; }
               if (!c.session || typeof c.session !== 'string') return { ok: false, reason: 'session required' };
               const minted = _streamTicketStore.mint(sender);
+              console.log(pc.dim(`  [pool-stream-ticket] minted ticket for ${sender}`));
               return { ok: true, ticket: minted.ticket, expiresAtMs: minted.expiresAtMs };
             },
             // COHERENCE-JOURNAL-SPEC §3.4 — always-registered journal-sync verb
@@ -11016,26 +11017,35 @@ export async function startServer(options: StartOptions): Promise<void> {
           // bounded reconnect → machine-unreachable).
           {
             const { WebSocket: WsClient } = await import('ws');
+            const psLog = (m: string) => console.log(pc.dim(`  [pool-stream-connector] ${m}`));
             _poolStreamConnector = {
               connect: (machineId, handlers) => {
                 const httpUrl = peerUrl(machineId);
-                if (!httpUrl) return null;
+                if (!httpUrl) { psLog(`connect ${machineId}: no peer url → unreachable`); return null; }
                 let ws: import('ws').WebSocket | null = null;
                 let open = false;
                 let closed = false;
                 const pending: string[] = [];
                 (async () => {
                   try {
-                    const r = await meshClient.send({ machineId, url: httpUrl }, { type: 'pool-stream-ticket', session: '*' }, 0);
+                    psLog(`minting ticket from ${machineId} (${httpUrl})`);
+                    // EXPLICIT 10s timeout (live-verify finding 2026-06-07): without
+                    // it a wedged mint hung indefinitely — the stream never opened
+                    // AND never errored (the connector's onClose never fired), so the
+                    // dashboard sat silent forever. A bounded send fails honestly →
+                    // onClose → the proxy surfaces peer-stream-lost / unreachable.
+                    const r = await meshClient.send({ machineId, url: httpUrl }, { type: 'pool-stream-ticket', session: '*' }, 0, { timeoutMs: 10_000 });
                     const ticket = r.ok && r.result && typeof r.result === 'object' ? (r.result as { ticket?: string }).ticket : undefined;
-                    if (!ticket || closed) { if (!closed) handlers.onClose(); return; }
+                    if (!ticket) { psLog(`mint failed for ${machineId}: ok=${r.ok} status=${r.status} reason=${r.reason ?? ''} hasTicket=${!!ticket}`); if (!closed) handlers.onClose(); return; }
+                    if (closed) return;
                     const wsUrl = httpUrl.replace(/^http/, 'ws').replace(/\/$/, '') + `/pool-stream?ticket=${encodeURIComponent(ticket)}`;
+                    psLog(`ticket ok; opening upstream ws to ${machineId}`);
                     ws = new WsClient(wsUrl);
-                    ws.on('open', () => { open = true; for (const m of pending) ws!.send(m); pending.length = 0; handlers.onOpen(); });
+                    ws.on('open', () => { open = true; psLog(`upstream OPEN to ${machineId}`); for (const m of pending) ws!.send(m); pending.length = 0; handlers.onOpen(); });
                     ws.on('message', (d: unknown) => { try { handlers.onFrame(JSON.parse(String(d))); } catch { /* @silent-fallback-ok: a non-JSON peer frame is dropped; the stream protocol is JSON-only (§2.2) */ } });
-                    ws.on('close', () => handlers.onClose());
-                    ws.on('error', () => { if (!open) handlers.onClose(); });
-                  } catch { if (!closed) handlers.onClose(); }
+                    ws.on('close', (code: number) => { psLog(`upstream CLOSE from ${machineId} (code ${code}, wasOpen ${open})`); handlers.onClose(); });
+                    ws.on('error', (e: Error) => { psLog(`upstream ERROR to ${machineId}: ${e?.message ?? e}`); if (!open) handlers.onClose(); });
+                  } catch (e) { psLog(`connect to ${machineId} threw: ${(e as Error)?.message ?? e}`); if (!closed) handlers.onClose(); }
                 })();
                 return {
                   send: (frame: Record<string, unknown>) => { const s = JSON.stringify(frame); if (open && ws) ws.send(s); else pending.push(s); },

--- a/upgrades/next/pool-stream-connector-observability.md
+++ b/upgrades/next/pool-stream-connector-observability.md
@@ -1,0 +1,22 @@
+# Pool-stream connector — observability + bounded mint (live-verify fix)
+
+## What Changed
+
+Live verification of cross-machine dashboard streaming found the request starting but no terminal output ever arriving — and no error either: the connector that opens the upstream link to a peer swallowed every outcome silently, and its ticket-mint call had no explicit timeout, so a wedged mint could hang indefinitely (the stream never opened AND never errored, leaving the dashboard silent forever). This adds (a) an explicit 10s timeout on the mint so it fails honestly instead of hanging — a bounded failure surfaces peer-stream-lost / unreachable to the user — and (b) per-step logging (mint attempt/result, upstream open/close/error) on both the requesting connector and the serving mint verb, so the live path is finally observable.
+
+## What to Tell Your User
+
+Nothing user-facing — this makes the cross-machine streaming path debuggable and stops a silent hang. (The click-to-stream feature itself is being finished; this is the diagnostic that unblocks it.)
+
+- audience: agent-only
+- maturity: stable
+
+## Summary of New Capabilities
+
+- Explicit 10s timeout on the connector's `pool-stream-ticket` mint (no more silent indefinite hang).
+- Per-step connector logging (`[pool-stream-connector]`) + serving-side mint-verb logging (`[pool-stream-ticket]`).
+
+## Evidence
+
+- Live-verify (2026-06-07): laptop /ws remote subscribe returned `subscribed` then 22s of silence (no output, no error); the Mini had no `stream-tickets.json` (never minted). Root: silent-hang + no observability. This fix makes the failure visible and bounded; re-verify reads the new logs.
+- tsc clean. Behavior change is limited to bounding a previously-unbounded call + logging.

--- a/upgrades/side-effects/pool-stream-connector-observability.md
+++ b/upgrades/side-effects/pool-stream-connector-observability.md
@@ -1,0 +1,53 @@
+# Side-Effects Review — Pool-stream connector observability + bounded mint
+
+**Version / slug:** `pool-stream-connector-observability`
+**Date:** `2026-06-07`
+**Author:** `echo`
+**Second-pass reviewer:** `not required`
+
+## Summary of the change
+
+Adds an explicit 10s timeout to the requesting connector's pool-stream-ticket
+mint (was unbounded → could hang silently) and per-step logging to both the
+connector and the serving mint verb. Diagnostic + robustness for the live
+cross-machine streaming path; found by live-verify (no output, no error,
+no ticket minted on the peer).
+
+## Decision-point inventory
+
+One: bound the mint with a timeout (10s) so a wedge fails honestly →
+peer-stream-lost/unreachable, instead of hanging the stream forever silently.
+
+## 1. Over-block
+
+A genuinely-slow mint (>10s) now fails where it might previously have eventually
+succeeded — acceptable: 10s is far beyond a healthy mesh round-trip, and an
+honest failure the user can retry beats an indefinite silent hang.
+
+## 2. Under-block
+
+Logging only observes; the timeout only bounds. No new gating.
+
+## 3. Level-of-abstraction fit
+
+The timeout uses the existing MeshRpcClient per-call `{ timeoutMs }` (the T1
+mechanism). Logging matches the `[subsystem]` dim-log idiom used across the
+mesh wiring.
+
+## 4. Signal vs authority compliance
+
+**Required reference:** [docs/signal-vs-authority.md](../../docs/signal-vs-authority.md)
+
+This REMOVES a silent-swallow (the connector previously hid every failure) —
+moving toward the no-silent-fallbacks standard, not away.
+
+## 5. Interactions
+
+- PeerStreamProxy: a bounded mint failure now reliably reaches onClose →
+  peer-stream-lost → bounded reconnect → machine-unreachable (the designed
+  path, previously unreachable when the mint hung).
+- No change to the serving endpoint, ticket store, or WSManager routing.
+
+## 6. External surfaces
+
+Log lines only. No route/config/notification change.


### PR DESCRIPTION
## What

Live verification of cross-machine dashboard streaming found the request **starting but no output arriving — and no error either**: the connector that opens the upstream link swallowed every outcome (no logging) and its ticket-mint had no explicit timeout, so a wedged mint could hang indefinitely (the stream never opened AND never errored → dashboard silent forever; the peer never minted a ticket).

- **Explicit 10s timeout** on the connector's `pool-stream-ticket` mint, so a wedge fails honestly → `peer-stream-lost`/`machine-unreachable` instead of an indefinite silent hang.
- **Per-step logging** on the requesting connector (`[pool-stream-connector]`: mint attempt/result, upstream open/close/error) and the serving mint verb (`[pool-stream-ticket]`).

Removes a silent-swallow (toward the no-silent-fallbacks standard). This is the diagnostic that unblocks pinpointing the live mint failure; re-verification reads the new logs.

## ELI16

First live test caught the stream not coming through — request started, nothing arrived, nothing errored — because the machine-to-machine link code kept its problems to itself and had no time limit on getting the one-time pass, so it could quietly hang forever. Now the pass-fetch gives up after 10s (failure shows as "reconnecting/unreachable" instead of a blank screen) and every step reports what it's doing, so the exact break can be found and fixed.
