### PR TITLE
fix(messaging): stop re-running already-handled messages + preserve sender in replay

### DIFF
--- a/.instar/instar-dev-decisions/2026-06-07T18-33-36-347Z-url-pathname-path-encoding-fix.json
+++ b/.instar/instar-dev-decisions/2026-06-07T18-33-36-347Z-url-pathname-path-encoding-fix.json
@@ -1,0 +1,13 @@
+{
+  "ts": "2026-06-07T18:33:36.347Z",
+  "slug": "url-pathname-path-encoding-fix",
+  "suggestedTier": 2,
+  "declaredTier": null,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 7,
+  "loc": 200,
+  "causalAutopsy": null,
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-06-07T18-37-38-607Z-stuck-recovery-replay-dedupe.json
+++ b/.instar/instar-dev-decisions/2026-06-07T18-37-38-607Z-stuck-recovery-replay-dedupe.json
@@ -1,0 +1,16 @@
+{
+  "ts": "2026-06-07T18:37:38.607Z",
+  "slug": "stuck-recovery-replay-dedupe",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 7,
+  "loc": 200,
+  "causalAutopsy": {
+    "origin": "latent",
+    "notes": "The exactly-once stuck-recovery (spec §8 G3a) shipped with a no-loss re-run that gated only on 'entry stuck in processing past maxProcessingMs' + an attempts cap — it never checked whether the topic had actually been answered. Latent because in normal operation the reply path commits the entry (reply_committed) before the recovery tick, so the stuck set is empty. The 2026-06-07 server flap (CPU starvation → /health timeouts → restart loop) made genuine replies fail to commit (HTTP 408/500) and orphaned same-topic duplicates via the currentInboundByTopic overwrite, so handled entries accumulated in 'processing' and the latent gap surfaced as a ~10-min replay loop. The 'from Unknown' half is the same identity-loss class as the documented stuck-recovery rerun finding (sender envelope never stored, reinject hardcoded userId:'unknown'). No prior PR regressed it; it is the deepest assumption (stuck == unanswered) of the recovery design surfacing under sustained starvation."
+  },
+  "verdict": "pass"
+}

--- a/docs/eli16/stuck-recovery-replay-dedupe.eli16.md
+++ b/docs/eli16/stuck-recovery-replay-dedupe.eli16.md
@@ -1,0 +1,43 @@
+# Stuck-recovery / replay dedupe — Plain-English Overview
+
+> The one-line version: a message you'd already been answered kept getting "re-delivered" to me every ~10 minutes (showing "from Unknown"), and each re-delivery woke up a fresh session — so the very thing meant to recover *lost* messages was instead replaying *handled* ones and piling load onto an already-struggling machine. This stops that.
+
+## The problem in one breath
+
+When my server crashes mid-reply, a safety net re-runs the message I never got to answer, so nothing is lost. But the net couldn't tell "I never answered this" from "I answered this, but the reply failed to record because the server was flapping." So during the morning incident it kept re-running messages I'd already handled — every ~10 minutes, tagged "from Unknown" because the re-run threw away who sent it — and each replay spawned a session, adding to the overload.
+
+## What already exists
+
+- **Exactly-once ingress (the message ledger)** — a durable record of every inbound message's life: received → being-worked-on → answered → done. A redelivery of an already-answered message is dropped. This part works.
+- **Stuck-message recovery** — if a message is stuck at "being-worked-on" too long (the server crashed mid-turn), the current machine re-runs it from the stored text. This is the no-loss net.
+- **The lifeline queue** — when the server is down, incoming messages are parked here and replayed when it recovers.
+
+## What this adds
+
+The recovery net now **looks before it leaps**: before re-running a stuck message, it checks whether I actually replied to that conversation since the message arrived. If I did, the message was effectively handled (its own "answered" mark just failed to save during the flap, or it was a duplicate) — so it's marked done instead of being replayed. The check reads the durable ledger, so it survives restarts.
+
+It also **keeps the sender's identity** through a re-run, so a legitimate replay no longer shows "from Unknown" — which matters because acting on a message from an unknown principal is exactly what "Know Your Principal" warns against.
+
+Finally, the **lifeline queue refuses to re-park a message it already delivered**: enqueue is now idempotent on the message id and skips ids it already delivered or dropped this run. That kills the "stale duplicate kept getting retried" half of the loop.
+
+## The new pieces
+
+- **Reply-evidence guard** — a ledger query, "was a reply committed on this topic at or after this message arrived?" If yes, the stuck entry is committed, not re-injected. It can only *suppress* a re-run, never cause one.
+- **Sender envelope on the ledger** — captured at ingress (an additive, nullable column added in place; old rows simply read back empty and fall back to today's behavior), replayed so the `[telegram:N … from NAME]` prefix is right.
+- **Queue dedup** — `enqueue` skips a duplicate id; the replay loop records delivered/dropped ids so a redelivery can't re-queue them.
+
+## The safeguards
+
+**Prevents replaying a handled message.** The guard is the whole point: an answered conversation can't be re-run into a loop.
+
+**Prevents losing a genuinely unanswered message.** If there's no reply on the topic since the message arrived, it still re-runs exactly as before — the no-loss guarantee is untouched. The false-negative case (two distinct rapid questions, the second crashes before the first's answer records) is bounded: that message was already routed to the session once, so it isn't lost — only a redundant re-run is skipped.
+
+**Prevents identity bleed.** Re-runs carry the real sender; no more "from Unknown."
+
+## What ships when
+
+One PR. It's a contained behavior fix to an existing (dark-by-default, but live on this agent) subsystem — no new API, config, or migration. Unit-tested on both sides of every branch (handled vs unanswered, dedup hit vs miss), plus source-level wiring guards so the sender-capture and the dedup can't silently regress.
+
+## Evidence
+
+`tests/unit/stuck-message-recovery.test.ts`, `MessageProcessingLedger.test.ts`, `lifeline/MessageQueue-durability.test.ts`: reply-evidence guard commits-not-reruns an already-answered topic; a genuinely-unanswered entry still re-runs; sender round-trips through a recovered replay; the queue refuses to re-enqueue an already-delivered id. 603 messaging/lifeline unit tests green; `tsc --noEmit` clean.

--- a/src/commands/server.ts
+++ b/src/commands/server.ts
@@ -11973,15 +11973,30 @@ export async function startServer(options: StartOptions): Promise<void> {
     if (messageLedger && currentInboundByTopic && telegram) {
       const ledgerForRecovery = messageLedger;
       const inboundMap = currentInboundByTopic;
-      const reinjectStuck = (topicId: string, dedupeKey: string, replayText: string): void => {
+      const reinjectStuck = (
+        topicId: string,
+        dedupeKey: string,
+        replayText: string,
+        sender: import('../messaging/MessageProcessingLedger.js').SenderEnvelope | null,
+      ): void => {
         inboundMap.set(topicId, dedupeKey); // so the eventual reply commits THIS entry
+        // Preserve the original sender so the replay routes as the real user, not
+        // "from Unknown" (Know Your Principal). messageToPipeline reads these
+        // metadata fields to build the [telegram:N "topic" from NAME] prefix.
         void telegram.onTopicMessage?.({
           id: `replay-${dedupeKey}`,
-          userId: 'unknown',
+          userId: sender?.userId != null ? String(sender.userId) : 'unknown',
           content: replayText,
           channel: { type: 'telegram', identifier: topicId },
           receivedAt: new Date().toISOString(),
-          metadata: { messageThreadId: Number(topicId), viaLifeline: true, replay: true },
+          metadata: {
+            messageThreadId: Number(topicId),
+            viaLifeline: true,
+            replay: true,
+            ...(sender?.userId != null ? { telegramUserId: Number(sender.userId) } : {}),
+            ...(sender?.firstName ? { firstName: sender.firstName } : {}),
+            ...(sender?.username ? { username: sender.username } : {}),
+          },
         } as Message);
       };
       const runStuckRecovery = (): void => {

--- a/src/lifeline/MessageQueue.ts
+++ b/src/lifeline/MessageQueue.ts
@@ -30,9 +30,20 @@ export interface QueuedMessage {
   transientReplayFailures?: number;
 }
 
+/** Max delivered-ids remembered (bounded so the guard can't grow without limit). */
+const MAX_DELIVERED_IDS = 2000;
+
 export class MessageQueue {
   private queuePath: string;
   private queue: QueuedMessage[] = [];
+  /**
+   * Bounded FIFO set of ids already delivered (or deliberately dropped) in this
+   * process. enqueue() consults it so a message that was already delivered can't
+   * be re-queued and retried — the 2026-06-07 "stale already-delivered copies
+   * kept getting retried, pushing the server into a restart loop" bug. Insertion
+   * order = eviction order (oldest dropped first past the cap).
+   */
+  private deliveredIds = new Set<string>();
 
   constructor(stateDir: string) {
     this.queuePath = path.join(stateDir, 'lifeline-queue.json');
@@ -40,11 +51,39 @@ export class MessageQueue {
   }
 
   /**
-   * Add a message to the queue.
+   * Add a message to the queue. Idempotent on `id`:
+   *  - skips a message whose id is already queued (no duplicate copies to retry), and
+   *  - skips a message whose id was already delivered/dropped this process (the
+   *    replay-of-already-delivered loop).
+   * Returns true if the message was actually added.
    */
-  enqueue(msg: QueuedMessage): void {
+  enqueue(msg: QueuedMessage): boolean {
+    if (this.deliveredIds.has(msg.id)) return false;       // already handled — never re-queue
+    if (this.queue.some(m => m.id === msg.id)) return false; // already queued — no duplicate copy
     this.queue.push(msg);
     this.save();
+    return true;
+  }
+
+  /**
+   * Record that a message id was delivered (or deliberately dropped) so a later
+   * redelivery of the SAME id is recognized and not re-queued. Also removes it
+   * from the queue. Use this on the replay success/drop path instead of bare
+   * remove() so the dedup guard is fed.
+   */
+  markDelivered(id: string): void {
+    this.remember(id);
+    this.remove(id);
+  }
+
+  private remember(id: string): void {
+    if (this.deliveredIds.has(id)) return;
+    this.deliveredIds.add(id);
+    if (this.deliveredIds.size > MAX_DELIVERED_IDS) {
+      // Evict oldest (Set preserves insertion order).
+      const oldest = this.deliveredIds.values().next().value;
+      if (oldest !== undefined) this.deliveredIds.delete(oldest);
+    }
   }
 
   /**

--- a/src/lifeline/TelegramLifeline.ts
+++ b/src/lifeline/TelegramLifeline.ts
@@ -1860,7 +1860,7 @@ export class TelegramLifeline {
       });
 
       if (decision.action === 'delivered') {
-        this.queue.remove(msg.id);
+        this.queue.markDelivered(msg.id); // remember id so a redelivery can't re-queue it
         replayed++;
         deliveredByTopic.set(msg.topicId, (deliveredByTopic.get(msg.topicId) ?? 0) + 1);
       } else if (decision.action === 'drop') {
@@ -1885,7 +1885,7 @@ export class TelegramLifeline {
           console.error(`[Lifeline] notifyMessageDropped threw for ${msg.id}:`, err instanceof Error ? err.message : err);
         }
         console.warn(`[Lifeline] Dropping message ${msg.id}: ${decision.dropReason} — ${msg.text.slice(0, 80)}`);
-        this.queue.remove(msg.id);
+        this.queue.markDelivered(msg.id); // deliberately handled — don't let a redelivery re-queue it
       } else {
         // requeue — persist the updated strike counters IN PLACE; the message
         // stays on disk for the next replay tick. A transient failure NEVER

--- a/src/messaging/MessageProcessingLedger.ts
+++ b/src/messaging/MessageProcessingLedger.ts
@@ -46,6 +46,19 @@ export interface LedgerEntry {
   replyEpoch: number | null;
   inputSnapshot: string | null;
   attempts: number;
+  /**
+   * The inbound sender, captured at ingress so a stuck-recovery re-run replays
+   * the message AS the real sender — not "from Unknown" (the 2026-06-07
+   * identity-loss bug). JSON `{ userId, username?, firstName? }` or null.
+   */
+  senderEnvelope: SenderEnvelope | null;
+}
+
+/** Inbound sender identity, stored so a replay preserves "Know Your Principal". */
+export interface SenderEnvelope {
+  userId?: string | number;
+  username?: string;
+  firstName?: string;
 }
 
 const SCHEMA = `
@@ -61,10 +74,30 @@ CREATE TABLE IF NOT EXISTS message_ledger (
   reply_idempotency_key TEXT,
   reply_epoch INTEGER,
   input_snapshot TEXT,
-  attempts INTEGER NOT NULL DEFAULT 0
+  attempts INTEGER NOT NULL DEFAULT 0,
+  sender_envelope TEXT
 );
 CREATE INDEX IF NOT EXISTS idx_message_ledger_state ON message_ledger(state);
+CREATE INDEX IF NOT EXISTS idx_message_ledger_topic_committed ON message_ledger(topic, reply_committed_at);
 `;
+
+/**
+ * Apply the schema, then idempotently add columns introduced after a DB was
+ * first created. ALTER TABLE ADD COLUMN throws "duplicate column name" on a DB
+ * that already has it — caught and ignored. This keeps existing agents' ledgers
+ * upgrading in place with no PostUpdateMigrator step (SQLite schema, per the
+ * file-header contract).
+ */
+function ensureSchema(db: BetterSqliteDatabase): void {
+  db.exec(SCHEMA);
+  for (const col of ['sender_envelope TEXT']) {
+    try {
+      db.exec(`ALTER TABLE message_ledger ADD COLUMN ${col}`);
+    } catch {
+      /* column already exists — idempotent */
+    }
+  }
+}
 
 export function resolveMessageLedgerPath(stateDir: string, agentId: string): string {
   const safe = agentId.replace(/[^A-Za-z0-9._-]/g, '_') || 'default';
@@ -100,7 +133,7 @@ export class MessageProcessingLedger {
     db.pragma('journal_mode = WAL');
     db.pragma('synchronous = NORMAL');
     db.pragma('busy_timeout = 5000');
-    db.exec(SCHEMA);
+    ensureSchema(db);
     return new MessageProcessingLedger(db, dbPath);
   }
 
@@ -108,7 +141,7 @@ export class MessageProcessingLedger {
   static openMemory(): MessageProcessingLedger {
     const db = new Database(':memory:');
     db.pragma('busy_timeout = 5000');
-    db.exec(SCHEMA);
+    ensureSchema(db);
     return new MessageProcessingLedger(db, ':memory:');
   }
 
@@ -117,17 +150,18 @@ export class MessageProcessingLedger {
    * Returns whether this is the first time we've seen it + the current state.
    * A caller seeing firstSeen:false with an acted-on state must DROP the event.
    */
-  record(dedupeKey: string, opts: { platform: string; topic?: string | null; input?: string }): {
+  record(dedupeKey: string, opts: { platform: string; topic?: string | null; input?: string; sender?: SenderEnvelope | null }): {
     firstSeen: boolean;
     state: LedgerState;
   } {
     const now = new Date().toISOString();
+    const senderJson = opts.sender ? JSON.stringify(opts.sender) : null;
     const info = this.db
       .prepare(
-        `INSERT OR IGNORE INTO message_ledger (dedupe_key, platform, topic, state, received_at, input_snapshot)
-         VALUES (?, ?, ?, 'received', ?, ?)`,
+        `INSERT OR IGNORE INTO message_ledger (dedupe_key, platform, topic, state, received_at, input_snapshot, sender_envelope)
+         VALUES (?, ?, ?, 'received', ?, ?, ?)`,
       )
-      .run(dedupeKey, opts.platform, opts.topic ?? null, now, opts.input ?? null);
+      .run(dedupeKey, opts.platform, opts.topic ?? null, now, opts.input ?? null, senderJson);
     const row = this.get(dedupeKey)!;
     return { firstSeen: info.changes === 1, state: row.state };
   }
@@ -221,6 +255,28 @@ export class MessageProcessingLedger {
       });
   }
 
+  /**
+   * Reply-evidence check (the no-DUPLICATE-re-run half of stuck recovery): has
+   * ANY inbound on this topic been reply_committed at/after `sinceISO`? If so the
+   * agent already answered this topic since the stuck entry arrived, so re-running
+   * it would re-deliver an already-handled message (the 2026-06-07 every-~10-min
+   * "from Unknown" replay loop). Durable across restarts (reads the ledger, not
+   * in-memory state). Cheap: indexed on (topic, reply_committed_at).
+   */
+  hasReplyCommittedForTopicSince(topic: string, sinceISO: string): boolean {
+    const row = this.db
+      .prepare(
+        `SELECT 1 FROM message_ledger
+         WHERE topic = ?
+           AND state IN ('reply_committed','cursor_advanced')
+           AND reply_committed_at IS NOT NULL
+           AND reply_committed_at >= ?
+         LIMIT 1`,
+      )
+      .get(topic, sinceISO);
+    return !!row;
+  }
+
   get(dedupeKey: string): LedgerEntry | null {
     const row = this.db.prepare(`SELECT * FROM message_ledger WHERE dedupe_key = ?`).get(dedupeKey) as any;
     return row ? rowToEntry(row) : null;
@@ -245,5 +301,16 @@ function rowToEntry(row: any): LedgerEntry {
     replyEpoch: row.reply_epoch ?? null,
     inputSnapshot: row.input_snapshot ?? null,
     attempts: row.attempts ?? 0,
+    senderEnvelope: parseSender(row.sender_envelope),
   };
+}
+
+function parseSender(raw: unknown): SenderEnvelope | null {
+  if (typeof raw !== 'string' || !raw) return null;
+  try {
+    const v = JSON.parse(raw);
+    return v && typeof v === 'object' ? (v as SenderEnvelope) : null;
+  } catch {
+    return null;
+  }
 }

--- a/src/messaging/ingressDedup.ts
+++ b/src/messaging/ingressDedup.ts
@@ -25,6 +25,7 @@
 import {
   MessageProcessingLedger,
   computeReplyIdempotencyKey,
+  type SenderEnvelope,
 } from './MessageProcessingLedger.js';
 
 /** Stable provider-level identity for an inbound event (spec §2 contract item 4). */
@@ -45,6 +46,8 @@ export interface DecideIngressOpts {
   topic?: string | null;
   /** The raw inbound text/context, stored so a future replay can re-run it. */
   input?: string;
+  /** Inbound sender, stored so a stuck re-run replays as the real user (not "Unknown"). */
+  sender?: SenderEnvelope | null;
   /** The lease fencing epoch this machine holds (0 if no lease). */
   epoch: number;
   /** A 'processing' entry older than this was abandoned by a fenced holder. */
@@ -64,7 +67,7 @@ export function decideIngress(
 ): IngressDecision {
   const now = opts.now ?? Date.now;
   // Idempotent insert — firstSeen tells us if this is a brand-new event.
-  ledger.record(dedupeKey, { platform: opts.platform, topic: opts.topic ?? null, input: opts.input });
+  ledger.record(dedupeKey, { platform: opts.platform, topic: opts.topic ?? null, input: opts.input, sender: opts.sender ?? null });
 
   const entry = ledger.get(dedupeKey);
   // Defensive: record() just inserted-or-found it, so entry is non-null.

--- a/src/messaging/stuckMessageRecovery.ts
+++ b/src/messaging/stuckMessageRecovery.ts
@@ -18,7 +18,8 @@
  * answered is not re-run forever). Lease-gated: a standby never re-injects.
  */
 
-import type { MessageProcessingLedger } from './MessageProcessingLedger.js';
+import type { MessageProcessingLedger, SenderEnvelope } from './MessageProcessingLedger.js';
+import { computeReplyIdempotencyKey } from './MessageProcessingLedger.js';
 
 export interface StuckRecoveryDeps {
   ledger: MessageProcessingLedger;
@@ -30,8 +31,17 @@ export interface StuckRecoveryDeps {
   maxProcessingMs: number;
   /** Give up re-running an entry after this many attempts (avoid storms). Default 3. */
   maxReplayAttempts?: number;
+  /**
+   * Reply-evidence guard (no-DUPLICATE-re-run half): true if the agent already
+   * replied to `topic` at/after `sinceISO`. When true, a stuck entry is treated
+   * as already-handled — committed, NOT re-injected. Defaults to the ledger's own
+   * `hasReplyCommittedForTopicSince`; injectable for tests. This is what stops the
+   * 2026-06-07 "re-run an already-answered message every ~10 min" loop, even when
+   * the original reply failed to commit its own entry (server flap / dup orphan).
+   */
+  hasRepliedSince?: (topic: string, sinceISO: string) => boolean;
   /** Re-route the stored input as the holder (set current-inbound key, then inject). */
-  reinject: (topicId: string, dedupeKey: string, text: string) => void;
+  reinject: (topicId: string, dedupeKey: string, text: string, sender: SenderEnvelope | null) => void;
   now?: () => number;
   logger?: (msg: string) => void;
 }
@@ -39,6 +49,8 @@ export interface StuckRecoveryDeps {
 export interface StuckRecoveryResult {
   recovered: number;
   skipped: number;
+  /** Entries recognized as already-answered (reply evidence) and committed, not re-run. */
+  alreadyHandled: number;
 }
 
 /**
@@ -48,14 +60,30 @@ export interface StuckRecoveryResult {
  */
 export function recoverStuckMessages(deps: StuckRecoveryDeps): StuckRecoveryResult {
   const maxAttempts = deps.maxReplayAttempts ?? 3;
-  if (!deps.holdsLease()) return { recovered: 0, skipped: 0 };
+  if (!deps.holdsLease()) return { recovered: 0, skipped: 0, alreadyHandled: 0 };
+
+  const repliedSince =
+    deps.hasRepliedSince ?? ((topic, sinceISO) => deps.ledger.hasReplyCommittedForTopicSince(topic, sinceISO));
 
   const stuck = deps.ledger.reclaimStuck(deps.maxProcessingMs, deps.now ? deps.now() : undefined);
   let recovered = 0;
   let skipped = 0;
+  let alreadyHandled = 0;
   for (const entry of stuck) {
     if (!entry.inputSnapshot || !entry.topic) {
       skipped++;
+      continue;
+    }
+    // Reply-evidence guard: if the agent already answered this topic since the
+    // stuck entry arrived, the entry is a duplicate/superseded inbound that was
+    // effectively handled (its own reply just failed to commit — server flap, or
+    // a same-topic dup orphaned by the current-inbound overwrite). Commit it so
+    // it leaves 'processing' for good; do NOT re-inject (that is the replay loop).
+    if (repliedSince(entry.topic, entry.receivedAt)) {
+      deps.ledger.commitReply(entry.dedupeKey, computeReplyIdempotencyKey(entry.dedupeKey, 0), deps.epoch);
+      deps.ledger.advanceCursor(entry.dedupeKey);
+      deps.logger?.(`stuck-recovery: ${entry.dedupeKey} already answered on its topic since receipt — committing, not re-running`);
+      alreadyHandled++;
       continue;
     }
     if (entry.attempts >= maxAttempts) {
@@ -65,11 +93,12 @@ export function recoverStuckMessages(deps: StuckRecoveryDeps): StuckRecoveryResu
       skipped++;
       continue;
     }
-    // Re-claim under the current epoch (bumps attempts) and re-route the turn.
+    // Re-claim under the current epoch (bumps attempts) and re-route the turn,
+    // preserving the real sender so the replay is not "from Unknown".
     deps.ledger.beginProcessing(entry.dedupeKey, deps.epoch);
-    deps.reinject(entry.topic, entry.dedupeKey, entry.inputSnapshot);
+    deps.reinject(entry.topic, entry.dedupeKey, entry.inputSnapshot, entry.senderEnvelope);
     deps.logger?.(`stuck-recovery: re-ran ${entry.dedupeKey} (attempt ${entry.attempts + 1})`);
     recovered++;
   }
-  return { recovered, skipped };
+  return { recovered, skipped, alreadyHandled };
 }

--- a/src/server/routes.ts
+++ b/src/server/routes.ts
@@ -11539,6 +11539,11 @@ export function createRoutes(ctx: RouteContext): Router {
           platform: 'telegram',
           topic: String(topicId),
           input: text,
+          sender: {
+            userId: fromUserId,
+            username: fromUsername,
+            firstName: fromFirstName,
+          },
           epoch,
           maxProcessingMs: ctx.config.multiMachine?.maxProcessingMs ?? 5 * 60_000,
         });

--- a/tests/unit/MessageProcessingLedger.test.ts
+++ b/tests/unit/MessageProcessingLedger.test.ts
@@ -118,4 +118,42 @@ describe('MessageProcessingLedger', () => {
     expect(computeReplyIdempotencyKey('upd-x', 0)).toBe(computeReplyIdempotencyKey('upd-x', 0));
     expect(computeReplyIdempotencyKey('upd-x', 0)).not.toBe(computeReplyIdempotencyKey('upd-x', 1));
   });
+
+  // ── sender envelope (Know Your Principal: a re-run replays as the real user) ──
+  it('stores and returns the sender envelope captured at ingress', () => {
+    ledger = MessageProcessingLedger.openMemory();
+    ledger.record('upd-s', {
+      platform: 'telegram', topic: '13481', input: 'hi',
+      sender: { userId: 7812716706, username: 'justin', firstName: 'Justin' },
+    });
+    expect(ledger.get('upd-s')!.senderEnvelope).toEqual({ userId: 7812716706, username: 'justin', firstName: 'Justin' });
+  });
+
+  it('sender envelope is null when none was captured', () => {
+    ledger = MessageProcessingLedger.openMemory();
+    ledger.record('upd-ns', { platform: 'telegram', topic: '13481', input: 'hi' });
+    expect(ledger.get('upd-ns')!.senderEnvelope).toBeNull();
+  });
+
+  // ── reply-evidence query (the no-duplicate-re-run half of stuck recovery) ──
+  it('hasReplyCommittedForTopicSince: true once any inbound on the topic is committed at/after the mark', () => {
+    ledger = MessageProcessingLedger.openMemory();
+    ledger.record('upd-r1', { platform: 'telegram', topic: '99', input: 'q1' });
+    ledger.beginProcessing('upd-r1', 1);
+    const before = new Date(Date.now() - 60_000).toISOString();
+    expect(ledger.hasReplyCommittedForTopicSince('99', before)).toBe(false);
+    ledger.commitReply('upd-r1', computeReplyIdempotencyKey('upd-r1', 0), 1);
+    expect(ledger.hasReplyCommittedForTopicSince('99', before)).toBe(true);
+  });
+
+  it('hasReplyCommittedForTopicSince: scoped to the topic and the time bound', () => {
+    ledger = MessageProcessingLedger.openMemory();
+    ledger.record('upd-a', { platform: 'telegram', topic: 'A', input: 'a' });
+    ledger.beginProcessing('upd-a', 1);
+    ledger.commitReply('upd-a', computeReplyIdempotencyKey('upd-a', 0), 1);
+    const past = new Date(Date.now() - 60_000).toISOString();
+    const future = new Date(Date.now() + 60_000).toISOString();
+    expect(ledger.hasReplyCommittedForTopicSince('B', past)).toBe(false); // other topic
+    expect(ledger.hasReplyCommittedForTopicSince('A', future)).toBe(false); // committed before the bound
+  });
 });

--- a/tests/unit/lifeline/MessageQueue-durability.test.ts
+++ b/tests/unit/lifeline/MessageQueue-durability.test.ts
@@ -129,3 +129,32 @@ describe('durable consume survives a mid-replay process exit', () => {
     expect(got[0].replayFailures).toBe(0); // poison budget never touched
   });
 });
+
+// ── 1C: replay dedupe (2026-06-07 "stale already-delivered copies kept retrying") ──
+describe('MessageQueue dedup', () => {
+  it('enqueue skips a duplicate id already in the queue (no duplicate copy to retry)', () => {
+    const q = new MessageQueue(stateDir);
+    expect(q.enqueue(msg('tg-1'))).toBe(true);
+    expect(q.enqueue(msg('tg-1'))).toBe(false); // same id — not added again
+    expect(q.peek().map(m => m.id)).toEqual(['tg-1']);
+  });
+
+  it('markDelivered removes the message AND blocks any later re-enqueue of that id', () => {
+    const q = new MessageQueue(stateDir);
+    q.enqueue(msg('tg-1'));
+    q.markDelivered('tg-1');
+    expect(q.peek()).toHaveLength(0);
+    // A redelivery of the SAME id (provider retry / re-poll) must not re-queue it —
+    // this is the loop that pushed the server into restart churn.
+    expect(q.enqueue(msg('tg-1'))).toBe(false);
+    expect(q.peek()).toHaveLength(0);
+  });
+
+  it('distinct ids are unaffected by the delivered guard', () => {
+    const q = new MessageQueue(stateDir);
+    q.enqueue(msg('tg-1'));
+    q.markDelivered('tg-1');
+    expect(q.enqueue(msg('tg-2'))).toBe(true);
+    expect(q.peek().map(m => m.id)).toEqual(['tg-2']);
+  });
+});

--- a/tests/unit/lifeline/version-skew-recovery.test.ts
+++ b/tests/unit/lifeline/version-skew-recovery.test.ts
@@ -203,9 +203,12 @@ describe('Replay drop-policy — only a message-specific (HTTP 400) failure may 
       8000,
     );
     expect(replayLoop).toBeTruthy();
-    // A message leaves the persisted queue only after delivery/drop.
+    // A message leaves the persisted queue only after delivery/drop — now via
+    // markDelivered(), which removes it AND records the id so an already-delivered
+    // copy can't be re-queued (2026-06-07 replay-dedupe). markDelivered() calls
+    // remove() internally, so the durable-consume guarantee is preserved.
     expect(replayLoop).toContain('this.queue.peek()');
-    expect(replayLoop).toContain('this.queue.remove(');
+    expect(replayLoop).toContain('this.queue.markDelivered(');
     expect(replayLoop).toContain('this.queue.updateReplayCounters(');
     // The destructive up-front drain() must NOT be used by replay.
     expect(replayLoop).not.toContain('this.queue.drain()');

--- a/tests/unit/no-silent-fallbacks.test.ts
+++ b/tests/unit/no-silent-fallbacks.test.ts
@@ -273,7 +273,16 @@ describe('No Silent Fallbacks', () => {
     // is being torn down regardless). Carries an in-brace @silent-fallback-ok;
     // not a real degradation (the close is best-effort cleanup, the link's
     // demise is already surfaced to clients via peer-stream-lost/unreachable).
-    const BASELINE = 462;
+    //
+    // 462 -> 463 by stuck-recovery replay dedupe (MessageProcessingLedger):
+    // one parser-counted catch — parseSender's JSON.parse guard, which returns
+    // null on a malformed/absent sender_envelope column (an old row, or
+    // corrupt JSON) so a replay falls back to today's "unknown sender" behavior
+    // rather than crashing the ledger read. Not a real degradation — a missing
+    // sender envelope is an expected pre-migration state, and the replay path
+    // already tolerates a null sender. (The sibling ALTER-TABLE idempotency
+    // catch carries an in-brace @silent-fallback-ok and is exempt.)
+    const BASELINE = 463;
 
     if (silentFallbacks.length > 0) {
       const report = silentFallbacks.map(fb =>

--- a/tests/unit/stuck-message-recovery.test.ts
+++ b/tests/unit/stuck-message-recovery.test.ts
@@ -43,7 +43,7 @@ describe('recoverStuckMessages', () => {
       ledger: led, holdsLease: () => false, epoch: 2, maxProcessingMs: -1,
       reinject: () => reinjected.push(1),
     });
-    expect(res).toEqual({ recovered: 0, skipped: 0 });
+    expect(res).toEqual({ recovered: 0, skipped: 0, alreadyHandled: 0 });
     expect(reinjected).toHaveLength(0);
   });
 
@@ -100,6 +100,76 @@ describe('recoverStuckMessages', () => {
     expect(res.recovered).toBe(0);
     expect(res.skipped).toBe(1);
   });
+
+  // ── 1A: reply-evidence guard (the 2026-06-07 every-~10-min "from Unknown" loop) ──
+  it('does NOT re-run a stuck entry whose topic was already answered since it arrived (commits it instead)', () => {
+    const led = MessageProcessingLedger.openMemory();
+    claim(led); // entry stuck in processing, its own reply never committed
+    const reinjected: unknown[] = [];
+    const res = recoverStuckMessages({
+      ledger: led, holdsLease: () => true, epoch: 2, maxProcessingMs: -1,
+      // The agent DID reply to this topic since the entry arrived — evidence the
+      // message was effectively handled (a duplicate / a reply that failed to commit).
+      hasRepliedSince: () => true,
+      reinject: () => reinjected.push(1),
+    });
+    expect(res.recovered).toBe(0);
+    expect(res.alreadyHandled).toBe(1);
+    expect(reinjected).toHaveLength(0);
+    // Committed so it leaves 'processing' for good — no more ~10-min re-runs.
+    expect(led.isActedOn(KEY)).toBe(true);
+  });
+
+  it('reply-evidence guard defaults to the ledger: a reply committed on the topic AFTER the stuck entry arrived suppresses the re-run', () => {
+    const led = MessageProcessingLedger.openMemory();
+    // The stuck entry (a duplicate / a turn whose own reply failed to commit) arrives FIRST.
+    claim(led);
+    // THEN the agent answers the topic (commits a sibling inbound) — exactly the
+    // real incident: the report arrived, then I replied to the topic repeatedly.
+    const sibling = dedupeKeyFor('telegram', TOPIC, 6000);
+    decideIngress(led, sibling, { platform: 'telegram', topic: TOPIC, input: 'later', epoch: 1, maxProcessingMs: 300_000 });
+    commitInboundReply(led, sibling, 1); // reply_committed_at >= the stuck entry's receivedAt
+    const reinjected: unknown[] = [];
+    const res = recoverStuckMessages({
+      ledger: led, holdsLease: () => true, epoch: 2, maxProcessingMs: -1,
+      reinject: () => reinjected.push(1), // NO explicit hasRepliedSince → uses ledger query
+    });
+    expect(res.alreadyHandled).toBe(1);
+    expect(reinjected).toHaveLength(0);
+    expect(led.isActedOn(KEY)).toBe(true);
+  });
+
+  it('still re-runs a genuinely unanswered stuck entry (no reply evidence on the topic)', () => {
+    const led = MessageProcessingLedger.openMemory();
+    claim(led);
+    const reinjected: unknown[] = [];
+    const res = recoverStuckMessages({
+      ledger: led, holdsLease: () => true, epoch: 2, maxProcessingMs: -1,
+      hasRepliedSince: () => false, // no reply since the entry arrived → legitimately lost
+      reinject: () => reinjected.push(1),
+    });
+    expect(res.recovered).toBe(1);
+    expect(res.alreadyHandled).toBe(0);
+    expect(reinjected).toHaveLength(1);
+  });
+
+  // ── 1B: sender preservation (no "from Unknown" on a legitimate re-run) ──
+  it('preserves the original sender envelope when re-injecting a recovered entry', () => {
+    const led = MessageProcessingLedger.openMemory();
+    decideIngress(led, KEY, {
+      platform: 'telegram', topic: TOPIC, input: 'do the thing',
+      sender: { userId: 7812716706, username: 'justin', firstName: 'Justin' },
+      epoch: 1, maxProcessingMs: 300_000,
+    });
+    const reinjected: Array<[string, string, string, unknown]> = [];
+    const res = recoverStuckMessages({
+      ledger: led, holdsLease: () => true, epoch: 2, maxProcessingMs: -1,
+      hasRepliedSince: () => false,
+      reinject: (t, k, text, sender) => reinjected.push([t, k, text, sender]),
+    });
+    expect(res.recovered).toBe(1);
+    expect(reinjected[0][3]).toEqual({ userId: 7812716706, username: 'justin', firstName: 'Justin' });
+  });
 });
 
 /**
@@ -123,5 +193,36 @@ describe('stuck-message recovery — boot wiring integrity', () => {
     const block = src.slice(startIdx, callIdx + 400);
     expect(block).toMatch(/if \(messageLedger && currentInboundByTopic && telegram\)/);
     expect(block).toMatch(/holdsLease: \(\) => coordinator\.holdsLease\(\)/);
+  });
+
+  it('reinjectStuck forwards the stored sender (no "from Unknown") into the replayed message metadata', () => {
+    // The replay must carry the real sender into the metadata fields
+    // messageToPipeline reads (firstName/username/telegramUserId), not a hardcoded
+    // userId:'unknown'. This is the identity-loss half of the 2026-06-07 fix.
+    const reinjectIdx = src.indexOf('const reinjectStuck =');
+    expect(reinjectIdx).toBeGreaterThan(0);
+    const block = src.slice(reinjectIdx, reinjectIdx + 1200);
+    expect(block).toMatch(/sender\??\.userId/);     // uses the preserved sender id
+    expect(block).toMatch(/firstName: sender\.firstName/); // sets the prefix name
+  });
+});
+
+/**
+ * Wiring-integrity: the forward route must CAPTURE the sender into the ledger at
+ * ingress — otherwise a recovery re-run has nothing to replay as and falls back
+ * to "Unknown". Source-level guard against the capture silently regressing.
+ */
+describe('exactly-once ingress — sender capture wiring', () => {
+  const src = fs.readFileSync(
+    path.join(__dirname, '..', '..', 'src', 'server', 'routes.ts'),
+    'utf-8',
+  );
+  it('decideIngress is called with a sender envelope built from the inbound', () => {
+    const callIdx = src.indexOf('decideIngress(ctx.messageLedger, dedupeKey, {');
+    expect(callIdx).toBeGreaterThan(0);
+    const block = src.slice(callIdx, callIdx + 400);
+    expect(block).toMatch(/sender:\s*\{/);
+    expect(block).toMatch(/userId: fromUserId/);
+    expect(block).toMatch(/firstName: fromFirstName/);
   });
 });

--- a/upgrades/next/stuck-recovery-replay-dedupe.md
+++ b/upgrades/next/stuck-recovery-replay-dedupe.md
@@ -1,0 +1,57 @@
+<!-- bump: patch -->
+<!-- change_type: fix -->
+
+## What Changed
+
+The exactly-once message recovery re-ran an already-answered Telegram message every
+~10 minutes — tagged "from Unknown" — re-spawning a session each cycle and piling load
+onto an already-overloaded machine (the 2026-06-07 "server temporarily down on every
+message" incident, topic 21816). Three fixes, all "don't replay a handled message":
+
+1. **Reply-evidence guard** — before re-running a message stuck in `processing`,
+   stuck-recovery now checks the durable ledger for a reply committed on that topic
+   at/after the message arrived. If found, the entry is committed (it was effectively
+   handled — its own reply just failed to record during the server flap, or it was a
+   duplicate) instead of being re-injected. The no-loss path (re-running a genuinely
+   unanswered turn) is unchanged.
+2. **Sender preserved through replay** — the inbound sender is captured at ingress and
+   replayed, so a legitimate re-run no longer shows "from Unknown" (Know Your Principal).
+3. **Lifeline queue dedup** — `MessageQueue.enqueue` is idempotent on message id and
+   refuses to re-queue an id already delivered/dropped this run, killing the "stale
+   already-delivered copies kept getting retried" half.
+
+## What to Tell Your User
+
+If they saw the same message echoed back repeatedly, or "server temporarily down" on
+nearly every message during an overload: that replay loop is fixed — an already-answered
+message is no longer re-run, and the queue won't re-deliver something it already sent.
+Nothing for them to do; their messages were never lost (they queued and delivered).
+
+## Summary of New Capabilities
+
+- `MessageProcessingLedger.hasReplyCommittedForTopicSince(topic, sinceISO)` — durable
+  reply-evidence query used to recognize an already-answered topic.
+- `MessageProcessingLedger` stores the inbound sender envelope (additive, nullable
+  column; idempotent in-place schema upgrade — no migrator step).
+- `recoverStuckMessages` reply-evidence guard + `alreadyHandled` result counter;
+  re-injection preserves the real sender.
+- `MessageQueue.enqueue` is id-idempotent (returns boolean); `MessageQueue.markDelivered`
+  records delivered/dropped ids so a redelivery can't re-queue them.
+
+## Scope (honest)
+
+Contained Tier-1 fix to the existing exactly-once ingress + lifeline replay subsystems.
+No new HTTP route, config default, or migration step. The reply-evidence false-negative
+case (two distinct rapid questions, the second crashes before the first's reply commits)
+is bounded — that message was already routed once, so it isn't lost, only a redundant
+re-run is skipped. 603 messaging/lifeline unit tests green; `tsc --noEmit` clean.
+
+## Evidence
+
+`tests/unit/stuck-message-recovery.test.ts`, `MessageProcessingLedger.test.ts`,
+`lifeline/MessageQueue-durability.test.ts`, `lifeline/version-skew-recovery.test.ts`:
+reply-evidence guard commits-not-reruns an answered topic; a genuinely-unanswered entry
+still re-runs; sender round-trips through a recovered replay; the queue refuses to
+re-enqueue an already-delivered id; wiring guards assert routes.ts captures the sender
+and reinjectStuck forwards it. causalAutopsy: latent (the stuck==unanswered assumption
+surfaced under sustained CPU starvation that made replies fail to commit).

--- a/upgrades/side-effects/stuck-recovery-replay-dedupe.md
+++ b/upgrades/side-effects/stuck-recovery-replay-dedupe.md
@@ -1,0 +1,88 @@
+# Side-Effects Review — Stuck-recovery / replay dedupe + sender preservation
+
+**Version / slug:** `stuck-recovery-replay-dedupe`
+**Date:** `2026-06-07`
+**Author:** `Echo`
+**Tier:** 1 (contained fix to an existing dark feature; no API/route/config/migration surface)
+**Second-pass reviewer:** `Echo (self) — Tier-1; the over/under-block analysis below is the load-bearing part`
+
+## Summary of the change
+
+The exactly-once ingress subsystem (spec §8 G3a) re-ran an already-answered Telegram
+message every ~10 min, tagged "from Unknown", re-spawning a session each cycle —
+during the very load incident it stemmed from (topic 21816). Three changes, all
+"don't replay an already-handled message":
+
+1. **`stuckMessageRecovery.recoverStuckMessages`** — before re-injecting a stuck
+   `processing` entry, a reply-evidence guard checks whether the topic was already
+   answered (a reply committed at/after the entry arrived). If so the entry is
+   committed (`commitReply`+`advanceCursor`), NOT re-injected. Default backing is the
+   ledger query `hasReplyCommittedForTopicSince`; injectable for tests.
+2. **`MessageProcessingLedger`** — stores the inbound sender envelope (idempotent
+   `ALTER TABLE … ADD COLUMN sender_envelope`, no PostUpdateMigrator step per the
+   SQLite-self-init contract) and exposes `hasReplyCommittedForTopicSince`.
+   `ingressDedup.decideIngress` + `routes.ts` thread the sender from the inbound;
+   `server.ts reinjectStuck` replays with the real sender so the prefix is correct.
+3. **`lifeline/MessageQueue`** — `enqueue` is idempotent on `id` and skips ids already
+   delivered/dropped this process; the replay loop feeds the guard via
+   `markDelivered()` (remove + remember). Kills the "stale already-delivered copies
+   kept getting retried" half.
+
+## Decision-point inventory
+
+- `recoverStuckMessages` (per stuck entry) — modify — re-run vs commit-as-handled.
+  The new branch only ADDS a "commit, don't re-run" path; it never causes a re-run
+  that wasn't already going to happen.
+- `MessageQueue.enqueue` — modify — add vs skip a queue entry. Now returns boolean.
+- No message block/allow surface. No kill/terminate surface. No new HTTP route, no
+  config default, no CLAUDE.md/template change.
+
+## 1. Over-block (suppressing a re-run that SHOULD happen)
+
+The reply-evidence guard could, in principle, skip re-running a genuinely-unanswered
+message. Bound: the guard fires only when a reply was committed on the SAME topic at
+or after the entry's `receivedAt`. The false-negative case is "two distinct questions
+arrive close together, the first is answered, the second crashed mid-turn and arrived
+before that answer committed." Cost is bounded and small: the second message was
+already ROUTED to the session once (recovery only re-runs crash-mid-turn turns, not
+lost deliveries), so it is not lost from the conversation — only a redundant re-run is
+skipped. The far larger, observed harm (re-running an already-answered message every
+10 min, forever-bounded only by the 3-attempt cap, each re-run spawning a session
+under load) is eliminated. Net strictly safer. The attempts-cap backstop remains.
+
+## 2. Under-block (still re-running when we shouldn't)
+
+A genuinely lost turn (claimed, never answered, no reply on the topic since) still
+re-runs exactly as before — verified by the "still re-runs a genuinely unanswered
+stuck entry" test. The change does not weaken the no-LOSS guarantee.
+
+## 3. Level-of-abstraction fit
+
+Correct layer. The reply-evidence signal is an objective, durable ledger read
+(indexed on `topic, reply_committed_at`), not an LLM call. The sender envelope is
+captured at the same ingress point that already logs sender for the message log. The
+queue dedup is a pure in-memory id check. No new external dependency.
+
+## 4. Blast radius
+
+The exactly-once ledger + stuck-recovery is gated behind `multiMachine` wiring
+(`ctx.messageLedger`); agents without it are unaffected (the code paths no-op when the
+ledger is null). The sender-envelope column is additive and nullable — old rows read
+back `senderEnvelope: null` (→ replay falls back to "unknown", i.e. today's behavior,
+never worse). `MessageQueue.enqueue`'s new boolean return is ignored by existing
+call sites (statement context). `markDelivered` is a strict superset of the prior
+`remove` on the replay path.
+
+## 5. Rollback
+
+Pure code revert — no data migration to undo. The `sender_envelope` column is left in
+place harmlessly on rollback (unused). No state-file format change beyond the additive
+nullable column. No config flag introduced or flipped.
+
+## 6. Tests
+
+Unit: reply-evidence guard (both branches + ledger-default), sender round-trip,
+ledger `hasReplyCommittedForTopicSince` (topic+time scoping), `MessageQueue` id-dedup
++ delivered-guard, and source-level wiring guards (routes.ts captures the sender;
+`reinjectStuck` forwards it; replay loop uses `markDelivered`). 603 messaging/lifeline
+unit tests green; `tsc --noEmit` clean.


### PR DESCRIPTION
## ELI16 — stop replaying messages I already answered

A message you'd already been answered kept getting "re-delivered" to me every ~10 minutes (showing "from Unknown"), and each re-delivery woke a fresh session — so the safety net meant to recover *lost* messages was instead replaying *handled* ones and piling load onto an already-struggling machine. The fix: before re-running a stuck message, check whether I actually replied to that conversation since it arrived; if I did, mark it done instead of replaying it. Keep the real sender on any genuine re-run (no more "from Unknown"). And make the lifeline queue refuse to re-send something it already delivered. Nothing is lost — genuinely-unanswered messages still re-run exactly as before.

## Problem (topic 21816)

During the 2026-06-07 CPU-starvation incident, an **already-answered** Telegram message was re-run by stuck-recovery **every ~10 minutes**, tagged **"from Unknown"**, re-spawning a session each cycle — adding load to the overloaded machine.

## Root causes & fixes

1. **Stuck-recovery re-ran handled messages.** It re-ran any ledger entry stuck in `processing` past `maxProcessingMs` with no check for whether the topic was already answered. During the flap, genuine replies failed to commit (HTTP 408/500) and same-topic duplicates were orphaned by the `currentInboundByTopic` overwrite. **Fix:** a reply-evidence guard (`hasReplyCommittedForTopicSince`) — before re-running, check the ledger for a reply committed on that topic at/after the entry arrived; if so, commit it instead of re-injecting. Durable across restarts.
2. **"from Unknown".** Re-injection hardcoded `userId: 'unknown'` and the ledger never stored the sender. **Fix:** capture the sender envelope at ingress (idempotent in-place SQLite column — no migrator step) and replay with the real sender.
3. **Lifeline queue retried delivered copies.** `MessageQueue.enqueue` had no id-dedup. **Fix:** `enqueue` is id-idempotent; the replay loop records delivered/dropped ids via `markDelivered()`.

## Tests

603 messaging/lifeline unit tests green; `tsc --noEmit` clean. Reply-evidence guard (both branches + ledger default), sender round-trip, ledger reply-evidence query, `MessageQueue` id-dedup + delivered-guard, source-level wiring guards. Tier 1; no API/route/config/migration. causalAutopsy: latent (the `stuck == unanswered` assumption surfaced under sustained starvation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
