### PR TITLE
fix(providers): interactive-pool startup canary degrades gracefully (no refuse-to-start)

### DIFF
--- a/.instar/instar-dev-decisions/2026-06-07T19-20-42-026Z-pool-canary-graceful-degradation.json
+++ b/.instar/instar-dev-decisions/2026-06-07T19-20-42-026Z-pool-canary-graceful-degradation.json
@@ -1,0 +1,16 @@
+{
+  "ts": "2026-06-07T19:20:42.026Z",
+  "slug": "pool-canary-graceful-degradation",
+  "suggestedTier": 1,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 31,
+  "causalAutopsy": {
+    "origin": "latent",
+    "notes": "spawnOne's startup empty-prompt canary has thrown on a structured status:'fail' since it was written, while the adjacent canary-infrastructure-error branch (a thrown exception from the canary itself) was deliberately non-fatal ('missing canary is protection-in-depth, not a primary failure path'). That inconsistency was latent: when the canary passes (normal), it never mattered. It surfaced on 2026-06-07 when CPU starvation made the canary's empty-prompt round-trip slow/garbled enough to return a structured fail, which threw, which rejected start()'s Promise.all, which made the whole subscription-path pool refuse to start — re-failing every spawn and tripping the LLM circuit in a loop. No prior PR regressed it; it is the deepest 'is the canary load-bearing?' assumption surfacing under load. Justin stabilized it live during the incident; this is the durable code fix."
+  },
+  "verdict": "pass"
+}

--- a/docs/eli16/pool-canary-graceful-degradation.eli16.md
+++ b/docs/eli16/pool-canary-graceful-degradation.eli16.md
@@ -1,0 +1,35 @@
+# Interactive-pool canary graceful degradation — Plain-English Overview
+
+> The one-line version: when my server starts a pool of reusable Claude sessions (the cheaper "subscription" path), it runs a tiny self-test on the first one. If that self-test failed, the WHOLE pool refused to start — which dumped all my AI work onto the pay-per-use credit pot and, on a busy machine where the self-test was just slow, kept failing and tripping a circuit breaker over and over. Now a failed self-test just logs a warning and lets the pool start anyway.
+
+## The problem in one breath
+
+There's a startup "empty-prompt canary": send a trivial prompt to a freshly-spawned pool session and check the reply, to learn how that session signals an empty/no-op response. If the canary returned a failure, the code **threw an error** — and because all the pool sessions are started together, one failure made the entire pool fail to start. With no pool, my Anthropic work fell back to the metered Agent-SDK credits, and under load (where the canary's round-trip was just slow/garbled, not truly broken) it re-failed on every start attempt and tripped the "pause all LLM work" circuit breaker in a loop.
+
+## What already exists
+
+- **The interactive pool** — a set of reusable Claude REPL sessions that serve my background AI calls off my subscription instead of metered credits. Opt-in; dark by default; live on this agent.
+- **The empty-prompt canary** — a startup self-test that derives how a session reports an empty response. It's a quality/detection aid, not the thing that makes the session able to answer real prompts.
+- **Per-call resilience** — if an actual prompt to a pool session fails, the pool already retires that session and spawns a replacement, and emits degradation events.
+
+## What this adds
+
+It changes one decision: **a failed startup canary no longer refuses the whole pool.** Instead of throwing (which killed pool startup), the code now reports the degradation and brings the session ready anyway. The empty-prompt detection runs in best-effort mode for that lifetime; the pool serves real work normally.
+
+This simply makes the *structured-failure* path behave like the *canary-crashed* path right next to it, which was **already** non-fatal — the code there literally says "missing canary is protection-in-depth, not a primary failure path." The two paths are now consistent.
+
+## The safeguards
+
+**A genuinely broken session is still caught.** Not killing it at startup doesn't mean a dead session lingers: the first real prompt that fails triggers the existing retire-and-replace path, and the recurring canary keeps probing. So "truly broken" is handled by the per-call machinery instead of by refusing service to everyone.
+
+**The failure is still surfaced, not swallowed.** A canary fail still reports to the DegradationReporter, so the unverified-signature state is visible — it's just no longer fatal.
+
+**Normal operation is untouched.** When the canary passes (the common case), nothing changes. Only the fail-at-startup behavior changed, and only to stop the total outage.
+
+## What ships when
+
+One PR, one file plus its test. The pool stays opt-in. No new API, config, or migration.
+
+## Evidence
+
+`pool-canary-graceful.test.ts`: source guards that the canary-fail branch no longer throws, no longer kills/deletes the session, still reports a degradation, and that `spawnOne` reaches the ready transition after the canary block. The existing 53 interactive-pool unit tests pass unchanged; `tsc --noEmit` clean. causalAutopsy: latent — the structured-fail branch was fatal from the start while the adjacent infra-error branch was non-fatal; the inconsistency only surfaced as a circuit-tripping outage once a busy box made the canary round-trip slow enough to "fail."

--- a/src/providers/adapters/anthropic-interactive-pool/pool.ts
+++ b/src/providers/adapters/anthropic-interactive-pool/pool.ts
@@ -356,25 +356,32 @@ export class InteractivePool extends EventEmitter {
         console.error('[interactive-pool] canary infrastructure error:', canaryErr);
       }
       if (canaryResult?.status === 'fail') {
-        // Canary returned a structured failure — surface and refuse to
-        // bring the session ready. Report to DegradationReporter so the
-        // surface lands in the right place (echo Telegram by default).
+        // Graceful degradation (2026-06-07 incident, topic 21816): a canary
+        // failure must NOT refuse the whole pool. Throwing here rejected
+        // start()'s Promise.all → the entire subscription-path pool failed to
+        // start → ALL Anthropic work stranded on the SDK credit pot, and under
+        // transient load (a slow/garbled empty-prompt round-trip during CPU
+        // starvation) it re-failed every spawn and tripped the LLM circuit in a
+        // loop. The empty-prompt detector is protection-in-depth (exactly as the
+        // infra-error branch above already states: "missing canary is
+        // protection-in-depth, not a primary failure path") — a session that
+        // can't verify the empty-prompt SIGNATURE can still serve real prompts.
+        // So: report the degradation, keep the canary marked as run (don't retry
+        // it on every spawn), and bring the session READY anyway. A genuinely
+        // broken session is caught by the per-call retire/replace path, not by
+        // refusing service to everyone.
         const { DegradationReporter } = await import('../../../monitoring/DegradationReporter.js');
         DegradationReporter.getInstance().report({
           feature: 'anthropic-interactive-pool.empty-prompt-canary',
           primary: 'Empty-prompt detector verified by startup canary',
-          fallback: 'Pool refuses to start; consumers route to anthropic-headless via registry',
+          fallback: 'Canary unverified — pool starts anyway; empty-prompt detection is best-effort this lifetime',
           reason: canaryResult.message,
           impact:
-            'Subscription-path pool unavailable — Anthropic work routes through the Agent SDK '
-            + 'credit pot instead. May exhaust credits faster than usual.',
+            'Empty-prompt detection runs in best-effort mode until the next successful canary. '
+            + 'The pool still serves real prompts (no SDK-credit fallback, no circuit trip).',
         });
-        session.state = 'dead';
-        this.sessions.delete(id);
-        this.emit('session:died', session);
-        throw new UnexpectedError(
-          `Pool session ${id} failed empty-prompt canary: ${canaryResult.message}`,
-          ANTHROPIC_INTERACTIVE_POOL_ID,
+        console.warn(
+          `[interactive-pool] empty-prompt canary failed (non-fatal — pool starts anyway): ${canaryResult.message}`,
         );
       }
       if (canaryResult?.status === 'self-healed') {

--- a/tests/unit/providers/adapters/anthropic-interactive-pool/pool-canary-graceful.test.ts
+++ b/tests/unit/providers/adapters/anthropic-interactive-pool/pool-canary-graceful.test.ts
@@ -1,0 +1,62 @@
+/**
+ * Pool startup canary — graceful degradation (2026-06-07 incident, topic 21816).
+ *
+ * The startup empty-prompt canary in spawnOne USED to `throw` on a structured
+ * `status: 'fail'`, which rejected start()'s Promise.all → the ENTIRE
+ * subscription-path pool refused to start → all Anthropic work stranded on the
+ * SDK credit pot, and under transient CPU starvation (a slow/garbled canary
+ * round-trip) it re-failed every spawn and tripped the LLM circuit in a loop.
+ *
+ * The empty-prompt detector is protection-in-depth, not a primary failure path
+ * (a session that can't verify the empty-prompt SIGNATURE can still serve real
+ * prompts). So a canary fail must DEGRADE GRACEFULLY: report it, bring the
+ * session ready, let the pool start. These guards pin that the refuse-to-start
+ * throw can't come back.
+ */
+
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const poolSrc = fs.readFileSync(
+  path.resolve(
+    __dirname,
+    '../../../../../src/providers/adapters/anthropic-interactive-pool/pool.ts',
+  ),
+  'utf-8',
+);
+
+/** The `if (canaryResult?.status === 'fail')` block in spawnOne, up to the next `if`. */
+function canaryFailBlock(): string {
+  const start = poolSrc.indexOf("if (canaryResult?.status === 'fail')");
+  expect(start).toBeGreaterThan(0);
+  // up to the self-healed branch that follows it
+  const end = poolSrc.indexOf("if (canaryResult?.status === 'self-healed')", start);
+  expect(end).toBeGreaterThan(start);
+  return poolSrc.slice(start, end);
+}
+
+describe('InteractivePool startup canary — graceful degradation', () => {
+  it('a canary fail does NOT throw (no refuse-to-start)', () => {
+    expect(canaryFailBlock()).not.toMatch(/throw\s+new/);
+  });
+
+  it('a canary fail does NOT kill or delete the session (it still comes ready)', () => {
+    const block = canaryFailBlock();
+    expect(block).not.toContain("session.state = 'dead'");
+    expect(block).not.toContain('this.sessions.delete(');
+    expect(block).not.toContain("this.emit('session:died'");
+  });
+
+  it('a canary fail still reports a degradation (the failure is surfaced, not swallowed)', () => {
+    expect(canaryFailBlock()).toContain('DegradationReporter');
+  });
+
+  it('spawnOne brings the session ready unconditionally after the canary block', () => {
+    // The READY transition lives AFTER the canary handling, with no early throw
+    // in the fail path, so a canary fail falls through to ready.
+    const canaryIdx = poolSrc.indexOf("if (!this.canaryHasRunInCurrentLifetime)");
+    const readyIdx = poolSrc.indexOf("session.state = 'ready';", canaryIdx);
+    expect(readyIdx).toBeGreaterThan(canaryIdx);
+  });
+});

--- a/upgrades/next/pool-canary-graceful-degradation.md
+++ b/upgrades/next/pool-canary-graceful-degradation.md
@@ -1,0 +1,46 @@
+<!-- bump: patch -->
+<!-- change_type: fix -->
+
+## What Changed
+
+The subscription-path interactive pool's startup empty-prompt canary used to `throw` on
+a structured failure, which rejected `start()`'s `Promise.all` and made the **entire
+pool refuse to start** — stranding all Anthropic work onto the SDK credit pot and, under
+transient CPU starvation (a slow/garbled canary round-trip), re-failing every spawn and
+tripping the LLM circuit breaker in a loop (2026-06-07 "server temporarily down on every
+message", topic 21816). A canary failure now **degrades gracefully**: it reports the
+degradation and brings the session ready anyway, so the pool serves real prompts and
+empty-prompt detection runs best-effort for that lifetime. This makes the structured-fail
+path consistent with the adjacent canary-infra-error path, which was already non-fatal.
+
+## What to Tell Your User
+
+If the cheaper subscription path went dark and everything fell back to metered credits
+(with repeated "pausing all LLM work" circuit trips) during a busy period: a failed pool
+self-test no longer takes the whole pool down. Nothing for them to do.
+
+## Summary of New Capabilities
+
+- `InteractivePool.spawnOne` treats a startup empty-prompt canary `status: 'fail'` as
+  non-fatal: report the degradation, keep the canary marked as run, bring the session
+  ready (no throw, no session kill). A genuinely broken session is still caught by the
+  existing per-call retire/replace path.
+
+## Scope (honest)
+
+Contained Tier-1 change to one conditional in one file
+(`src/providers/adapters/anthropic-interactive-pool/pool.ts`). The pool is opt-in
+(subscription-path). Normal (canary-passes) operation is unchanged. No new API/route/
+config/migration. Note: Justin already stabilized this live during the incident; this is
+the durable code fix so it can't recur.
+
+## Evidence
+
+`pool-canary-graceful.test.ts`: source guards that the canary-fail branch no longer
+throws, no longer kills/deletes the session, still reports a degradation, and that
+`spawnOne` reaches the ready transition after the canary block. The existing 53
+interactive-pool unit tests pass unchanged; `tsc --noEmit` clean; no-silent-fallbacks
+budget unaffected (removes a throw, adds no catch). causalAutopsy: latent — the
+structured-fail branch was fatal from the start while the adjacent infra-error branch
+was non-fatal; surfaced as a circuit-tripping outage only once a busy box made the canary
+round-trip slow enough to "fail."

--- a/upgrades/side-effects/pool-canary-graceful-degradation.md
+++ b/upgrades/side-effects/pool-canary-graceful-degradation.md
@@ -1,0 +1,71 @@
+# Side-Effects Review — Interactive-pool startup canary graceful degradation
+
+**Version / slug:** `pool-canary-graceful-degradation`
+**Date:** `2026-06-07`
+**Author:** `Echo`
+**Tier:** 1 (one-branch behavior change in a dark provider; no API/route/config/migration)
+**Second-pass reviewer:** `Echo (self) — Tier-1; the "what does a canary fail now mean" analysis below is load-bearing`
+
+## Summary of the change
+
+The subscription-path interactive pool's startup empty-prompt canary (`spawnOne` in
+`pool.ts`) USED to `throw` on a structured `canaryResult.status === 'fail'`. That throw
+rejected `start()`'s `Promise.all`, so the **entire pool refused to start** — stranding
+all Anthropic work onto the SDK credit pot and, under transient CPU starvation (a
+slow/garbled empty-prompt round-trip), re-failing every spawn and tripping the LLM
+circuit in a loop (2026-06-07 topic 21816). The canary-fail branch now degrades
+gracefully: it reports the degradation and brings the session **ready** anyway, instead
+of throwing / killing the session. File: `src/providers/adapters/anthropic-interactive-pool/pool.ts`.
+
+## Decision-point inventory
+
+- `spawnOne` canary-fail branch — modify — was "report + kill session + throw"; now
+  "report + continue to ready". The only decision: does a failed empty-prompt-signature
+  verification refuse the whole pool, or degrade detection to best-effort. It now degrades.
+- The canary **infra-error** branch (an exception from the canary itself) was ALREADY
+  non-fatal (logged, didn't block) — this change makes the structured-fail branch
+  consistent with it.
+- No message block/allow surface. No new route/config/migration.
+
+## 1. Over-refuse (the bug being fixed)
+
+Previously a single canary fail refused ALL pool service. Now it never does. This is
+strictly safer for availability: the worst outcome of an unverified empty-prompt
+signature is degraded empty-response DETECTION (best-effort) — not a total outage that
+burns SDK credits and trips the circuit.
+
+## 2. Under-protect (does keeping a "failed" session risk bad output?)
+
+A canary fail means the empty-prompt SIGNATURE couldn't be verified for this lifetime —
+the session can still serve real prompts. If a session is GENUINELY broken (can't
+respond at all), the canary-fail no longer kills it at startup, but the existing
+per-call path handles that: a failed allocate/prompt retires + replaces the session
+(`pool:degraded` / retire-on-error), and the recurring canary keeps probing. So a truly
+dead session is still caught — just by the per-call machinery, not by refusing everyone.
+The degradation is reported (DegradationReporter) so the unverified state is visible.
+
+## 3. Level-of-abstraction fit
+
+Correct. This is a single conditional's failure policy. No LLM, no new dependency. It
+aligns the structured-fail policy with the already-existing infra-error policy in the
+same method ("missing canary is protection-in-depth, not a primary failure path").
+
+## 4. Blast radius
+
+The interactive pool is opt-in (subscription-path; dark by default, active on this
+agent). When the canary passes (the normal case) behavior is unchanged. Only the
+fail-at-startup path changed, and only to stop refusing service. `canaryHasRunInCurrentLifetime`
+is still set (the structured result returned normally), so the canary isn't re-run every
+spawn. No change to the recurring canary, allocation, or retire/replace.
+
+## 5. Rollback
+
+Pure code revert. No state/config/format change.
+
+## 6. Tests
+
+`pool-canary-graceful.test.ts` (new): source guards that the canary-fail branch does NOT
+throw, does NOT kill/delete the session, still reports a degradation, and that spawnOne
+reaches the ready transition after the canary block. The existing 53 interactive-pool
+unit tests pass unchanged; `tsc --noEmit` clean; no-silent-fallbacks budget unaffected
+(the change removes a throw, adds no catch).


### PR DESCRIPTION
## ELI16 — a failed pool self-test no longer takes the whole pool down

When my server starts a pool of reusable Claude sessions (the cheaper subscription path), it runs a tiny self-test ("empty-prompt canary") on the first one. If that self-test failed, the code **threw** — and because all the pool sessions start together, one failure made the **entire pool refuse to start**. That dumped all my AI work onto the metered credit pot and, on a busy machine where the self-test was merely slow/garbled (not truly broken), it re-failed on every start and tripped the "pause all LLM work" circuit breaker in a loop. Now a failed self-test logs a warning, reports the degradation, and lets the pool start anyway — the empty-prompt detection just runs best-effort for that lifetime. A genuinely broken session is still caught by the existing per-call retire-and-replace path.

## Problem (topic 21816)

`spawnOne`'s startup empty-prompt canary `throw`s on `canaryResult.status === 'fail'`, rejecting `start()`'s `Promise.all` → the entire subscription-path pool refuses to start → all Anthropic work strands on the SDK credit pot, and under transient CPU starvation it re-fails every spawn and trips the LLM circuit in a loop.

## Fix

A canary fail now degrades gracefully: report the degradation (kept) and bring the session **ready** anyway — no `throw`, no session kill. This makes the structured-fail branch consistent with the adjacent canary-**infra**-error branch, which the code already treats as non-fatal ("missing canary is protection-in-depth, not a primary failure path"). The empty-prompt detector verifies a *signature*; a session that can't verify it still serves real prompts.

**Safeguards:** a genuinely broken session is still caught by the per-call retire/replace path (and the recurring canary keeps probing); the failure is still surfaced via DegradationReporter (not swallowed); normal canary-passes operation is unchanged.

## Tier / scope

Tier 1 — one conditional in one file (`src/providers/adapters/anthropic-interactive-pool/pool.ts`). The pool is opt-in (subscription-path). No new API/route/config/migration. Justin already stabilized this live during the incident; this is the durable code fix.

## Tests

`pool-canary-graceful.test.ts`: source guards that the canary-fail branch no longer throws, no longer kills/deletes the session, still reports a degradation, and that `spawnOne` reaches the ready transition after the canary block. Existing 53 interactive-pool unit tests pass unchanged; `tsc --noEmit` clean; no-silent-fallbacks budget unaffected (removes a throw, adds no catch). causalAutopsy: latent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)