### PR TITLE
fix(core): revoked machines stay revoked across re-register (no resurrection)

### DIFF
--- a/.instar/instar-dev-decisions/2026-06-07T19-31-23-591Z-revoked-peers-stay-revoked.json
+++ b/.instar/instar-dev-decisions/2026-06-07T19-31-23-591Z-revoked-peers-stay-revoked.json
@@ -1,0 +1,16 @@
+{
+  "ts": "2026-06-07T19:31:23.591Z",
+  "slug": "revoked-peers-stay-revoked",
+  "suggestedTier": 1,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 15,
+  "causalAutopsy": {
+    "origin": "latent",
+    "notes": "registerMachine has always rebuilt the registry entry as { ...(existing ?? {}), status: 'active', ... }, unconditionally forcing status to 'active'. Latent because it only matters when an EXISTING entry is revoked AND something calls registerMachine again for it. It surfaced 2026-06-07 when the stale Mac Mini, revoked earlier, re-registered itself after an update and was flipped back to active, resuming mesh/live-tail chatter. The merge path was made revocation-sticky in an earlier change (mergeRegistry.mergeEntry) but the direct re-register path was never guarded — this closes that symmetric gap. No prior PR regressed it; deepest 'a re-register is always a fresh active machine' assumption surfacing under the revoke+update sequence."
+  },
+  "verdict": "pass"
+}

--- a/docs/eli16/revoked-peers-stay-revoked.eli16.md
+++ b/docs/eli16/revoked-peers-stay-revoked.eli16.md
@@ -1,0 +1,33 @@
+# Revoked machines stay revoked — Plain-English Overview
+
+> The one-line version: you'd kicked the stale Mac Mini off the mesh (revoked it), but after an update it quietly came back and started chattering again — because the code that re-adds a machine to the roster just stamped it "active" without noticing it had been revoked. Now re-adding a revoked machine is refused; it stays kicked off until you explicitly let it back in.
+
+## The problem in one breath
+
+When a machine joins (or re-joins, or re-registers itself after an update), the registry code wrote its entry as "active." If that machine had previously been **revoked**, the re-write silently flipped it back to active — so a machine you'd deliberately removed resurrected itself on the next update and resumed sending mesh/live-tail traffic.
+
+## What already exists
+
+- **The machine registry** — the roster of machines in the mesh, each with a status (active / revoked) and, when revoked, who revoked it and why.
+- **Revoke** — removes a machine from the mesh (`revokeMachine`).
+- **Sticky-merge** — when two copies of the registry are merged (e.g. after a git sync conflict), a revocation on either side already wins, so a merge can't un-revoke a machine. That door was already closed.
+
+## What this adds
+
+It closes the **other** door: the direct re-register. `registerMachine` now checks, before writing, whether the machine already has a revoked entry. If it does, it refuses — it logs a clear warning and leaves the revoked entry exactly as it was, instead of stamping it "active." So a revoked machine that boots up after an update and tries to re-register itself stays revoked.
+
+## The safeguards
+
+**Normal joins are untouched.** The refusal only triggers for an existing *revoked* entry. A brand-new machine joins normally; an already-active machine re-registering (a routine role/nickname/last-seen refresh) is unaffected.
+
+**You can still bring a machine back.** Revocation is sticky against *silent* resurrection, not against a deliberate decision: the explicit un-revoke path clears the revoked state, after which the machine registers normally. So intended restoration still works — only the accidental comeback is blocked.
+
+**The refusal is loud.** It logs a warning naming the machine, so if a revoked machine keeps trying to re-join you can see it (rather than it silently succeeding).
+
+## What ships when
+
+One PR, one guard in one file plus its tests. Multi-machine only — a single-machine agent never hits this path. No new API, config, or migration.
+
+## Evidence
+
+`machine-identity.test.ts` (new cases): a revoked machine, re-registered, stays revoked (its status, role, and revocation metadata are preserved — not resurrected); a brand-new machine still registers active. 75 machine-identity unit tests green; `tsc --noEmit` clean. causalAutopsy: latent — `registerMachine` has always rebuilt the entry with `status: 'active'`; it only mattered once a revoked machine re-registered after an update, which is exactly the 2026-06-07 Mac Mini case. The merge path was made sticky earlier; this is the symmetric fix for the direct-register path.

--- a/src/core/MachineIdentity.ts
+++ b/src/core/MachineIdentity.ts
@@ -347,6 +347,21 @@ export class MachineIdentityManager {
     // re-register), else auto-assign a friendly, collision-free one derived from
     // the machine's own properties. Collision set = every OTHER machine's nickname.
     const existing = registry.machines[identity.machineId];
+
+    // Sticky revocation (2026-06-07 Mac Mini resurrection, topic 21816): a revoked
+    // machine must NOT be silently brought back to 'active' by a re-register
+    // (re-join / re-pair / post-update self-registration). The merge path already
+    // keeps revocation sticky (mergeRegistry.mergeEntry); this is the OTHER door —
+    // a direct re-register would clobber `status` to 'active' via the spread below.
+    // Staying revoked across updates is the requirement; the only path back to
+    // active is an explicit un-revoke. Refuse loudly and leave the entry untouched.
+    if (existing && (existing.status === 'revoked' || existing.revokedAt)) {
+      console.warn(
+        `[MachineIdentity] Refusing to re-register revoked machine ${identity.machineId} `
+        + `(${identity.name}) as active — it stays revoked across updates. Un-revoke explicitly to restore.`,
+      );
+      return;
+    }
     const existingNicknames = Object.entries(registry.machines)
       .filter(([id]) => id !== identity.machineId)
       .map(([, e]) => e.nickname)

--- a/tests/unit/machine-identity.test.ts
+++ b/tests/unit/machine-identity.test.ts
@@ -464,6 +464,48 @@ describe('MachineIdentityManager', () => {
     });
   });
 
+  describe('registerMachine — sticky revocation (no resurrection across updates)', () => {
+    // 2026-06-07 (topic 21816): a revoked Mac Mini peer came back "active" after
+    // an update because a re-register clobbered status to 'active' via the spread.
+    // A revoked machine must STAY revoked across updates; only an explicit
+    // un-revoke restores it. (mergeRegistry already keeps the merge path sticky;
+    // this guards the direct re-register door.)
+    function peerIdentity(machineId: string, name: string): any {
+      return {
+        machineId,
+        name,
+        platform: 'darwin',
+        signingPublicKey: 'pk',
+        encryptionPublicKey: 'ek',
+        createdAt: new Date().toISOString(),
+        capabilities: ['relay'],
+      };
+    }
+    const MINI = 'm_' + '1'.repeat(32);
+    const FRESH = 'm_' + '2'.repeat(32);
+
+    it('refuses to re-register a revoked machine as active', async () => {
+      await manager.generateIdentity(); // self (awake)
+      manager.registerMachine(peerIdentity(MINI, 'mac-mini'), 'standby');
+      manager.revokeMachine(MINI, 'm_operator', 'stale peer');
+
+      // A post-update re-join attempts to register the same machine again.
+      manager.registerMachine(peerIdentity(MINI, 'mac-mini'), 'standby');
+
+      const entry = manager.loadRegistry().machines[MINI];
+      expect(entry.status).toBe('revoked');   // still revoked — NOT resurrected
+      expect(entry.role).toBe('standby');
+      expect(entry.revokedAt).toBeTruthy();    // revocation metadata preserved
+      expect(entry.revokedBy).toBe('m_operator');
+    });
+
+    it('still registers a brand-new (never-revoked) machine normally', async () => {
+      await manager.generateIdentity();
+      manager.registerMachine(peerIdentity(FRESH, 'fresh-box'), 'standby');
+      expect(manager.loadRegistry().machines[FRESH].status).toBe('active');
+    });
+  });
+
   describe('ensureSelfRegistered', () => {
     it('self-registers when machine missing from registry (registry wiped scenario)', async () => {
       // Generate identity (this also registers it once), then simulate a wiped registry

--- a/upgrades/next/revoked-peers-stay-revoked.md
+++ b/upgrades/next/revoked-peers-stay-revoked.md
@@ -1,0 +1,43 @@
+<!-- bump: patch -->
+<!-- change_type: fix -->
+
+## What Changed
+
+A revoked mesh machine (the stale Mac Mini) came back **active** after an update
+(2026-06-07, topic 21816) and resumed sending mesh/live-tail chatter. Root cause:
+`MachineIdentityManager.registerMachine` rebuilt the entry with `status: 'active'`, so a
+re-register (re-join / re-pair / post-update self-registration) clobbered a `revoked`
+status back to active. The merge path (`mergeRegistry`) already kept revocation sticky;
+this was the other door. Fix: `registerMachine` now refuses to resurrect a revoked entry
+— if the existing entry is `status: 'revoked'` or has `revokedAt`, it logs loudly and
+leaves the entry untouched. A revoked machine stays revoked across updates; the only path
+back to active is an explicit un-revoke.
+
+## What to Tell Your User
+
+If they revoked a machine and it kept coming back after updates: it won't anymore. A
+revoked machine stays revoked until they explicitly un-revoke it. Nothing to do.
+
+## Summary of New Capabilities
+
+- `MachineIdentityManager.registerMachine` is now revocation-sticky: re-registering a
+  machine whose existing entry is revoked is refused (logged, entry left intact) instead
+  of silently flipping it back to active. `ensureSelfRegistered` already no-ops on any
+  existing entry; explicit un-revoke remains the deliberate restore path.
+
+## Scope (honest)
+
+Contained Tier-1 guard in one method (`src/core/MachineIdentity.ts`). Multi-machine only
+(a single-machine agent never hits this). Normal joins / active re-registers are
+unaffected; only resurrection of a revoked entry is blocked. No new API/route/config/
+migration. Justin already re-quarantined the Mini live during the incident; this is the
+durable code fix so it can't recur.
+
+## Evidence
+
+`machine-identity.test.ts` (new cases): a revoked machine re-registered stays revoked
+(status/role/revokedAt/revokedBy preserved); a brand-new machine still registers active.
+75 machine-identity unit tests green; `tsc --noEmit` clean; no-silent-fallbacks budget
+unaffected (the guard adds a `return`, no catch). causalAutopsy: latent — registerMachine
+always rebuilt with `status: 'active'`; only surfaced once a revoked machine re-registered
+after an update (the Mac Mini case). Symmetric with the already-sticky merge path.

--- a/upgrades/side-effects/revoked-peers-stay-revoked.md
+++ b/upgrades/side-effects/revoked-peers-stay-revoked.md
@@ -1,0 +1,70 @@
+# Side-Effects Review — Revoked machines stay revoked across re-register
+
+**Version / slug:** `revoked-peers-stay-revoked`
+**Date:** `2026-06-07`
+**Author:** `Echo`
+**Tier:** 1 (one guard in one registry method; no API/route/config/migration)
+**Second-pass reviewer:** `Echo (self) — Tier-1; the "which doors can resurrect a revocation" analysis below is load-bearing`
+
+## Summary of the change
+
+A revoked mesh machine (the stale Mac Mini) came back **active** after an update
+(2026-06-07 topic 21816): it kept sending mesh/live-tail chatter. Root cause:
+`MachineIdentityManager.registerMachine` rebuilt the entry as
+`{ ...(existing ?? {}), status: 'active', ... }` — so a re-register (re-join / re-pair /
+post-update self-registration) **clobbered a `revoked` status back to `active`**. The
+merge path (`mergeRegistry.mergeEntry`) already keeps revocation sticky; this was the
+OTHER door. Fix: `registerMachine` now refuses to resurrect a revoked entry — if the
+existing entry is `status === 'revoked'` or has `revokedAt`, it logs loudly and returns
+without touching the entry. File: `src/core/MachineIdentity.ts`.
+
+## Decision-point inventory
+
+- `registerMachine` — modify — add a pre-write guard: a revoked existing entry is left
+  untouched (no resurrection). The only decision: does a re-register override a
+  revocation. It no longer does.
+- `ensureSelfRegistered` — unchanged — it already no-ops when ANY entry exists (line:
+  `if (registry.machines[id]) return false`), so a revoked self never reaches
+  registerMachine through it; the guard is belt-and-suspenders for direct callers.
+- `revokeMachine` / un-revoke — unchanged — explicit un-revoke remains the deliberate
+  path back to active.
+- No message block/allow surface. No new route/config/migration.
+
+## 1. Over-block (refusing a legitimate registration)
+
+The guard fires ONLY when an entry already exists AND is revoked. A brand-new machine
+(no entry) and a normal active re-register (idempotent role/nickname/lastSeen refresh)
+are unaffected — verified by the "still registers a brand-new machine normally" test and
+the existing register/updateRole suite. So no legitimate join is blocked.
+
+## 2. Under-block (a machine that SHOULD come back can't)
+
+A deliberately un-revoked machine: un-revoke clears `status: 'revoked'` / `revokedAt`
+(the explicit operator path), after which registerMachine proceeds normally. So intended
+restoration still works; only SILENT resurrection-by-re-register is blocked. This is the
+requirement ("revoked peers stay revoked across updates").
+
+## 3. Level-of-abstraction fit
+
+Correct layer. The registry is the authority for machine membership; the guard sits at
+the single write that was clobbering status. Deterministic, no I/O beyond the existing
+load/save, no LLM.
+
+## 4. Blast radius
+
+Single method in a multi-machine-only path (a single-machine agent never revokes/
+re-registers a peer). When no revocation exists (the overwhelming common case) behavior
+is identical. The guard returns early (void) — callers that ignored the return value
+(it was already `void`) are unaffected.
+
+## 5. Rollback
+
+Pure code revert. No state/format/config change. A registry that already has a
+correctly-revoked entry stays correct.
+
+## 6. Tests
+
+`machine-identity.test.ts` (new cases): a revoked machine re-registered stays revoked
+(status/role/revokedAt/revokedBy preserved, not resurrected); a brand-new machine still
+registers active. 75 machine-identity unit tests green; `tsc --noEmit` clean;
+no-silent-fallbacks budget unaffected (the guard adds a `return`, no catch).


### PR DESCRIPTION
## ELI16 — a kicked-off machine can't sneak back after an update

You'd revoked the stale Mac Mini (kicked it off the mesh), but after an update it quietly came back and resumed sending mesh/live-tail traffic — because the code that re-adds a machine to the roster stamped it "active" without checking it had been revoked. Now re-adding a revoked machine is refused: it stays revoked across updates, and the only way back is an explicit un-revoke. Normal joins and routine re-registers of active machines are completely unaffected.

## Problem (topic 21816)

`MachineIdentityManager.registerMachine` rebuilt the entry as `{ ...(existing ?? {}), status: 'active', ... }`, so a re-register (re-join / re-pair / post-update self-registration) clobbered a `revoked` status back to `active`. The merge path (`mergeRegistry.mergeEntry`) already keeps revocation sticky — this was the **other door** (the direct re-register).

## Fix

`registerMachine` now refuses to resurrect a revoked entry: if the existing entry is `status: 'revoked'` or has `revokedAt`, it logs loudly and returns without touching the entry. `ensureSelfRegistered` already no-ops when any entry exists, so a revoked self never reaches `registerMachine` through it; explicit un-revoke remains the deliberate restore path.

**Safeguards:** the guard fires only for an existing *revoked* entry — a brand-new machine and an active re-register are unaffected; un-revoke still restores; the refusal is logged (visible if a revoked machine keeps trying to re-join).

## Tier / scope

Tier 1 — one guard in one method (`src/core/MachineIdentity.ts`), multi-machine-only path. No new API/route/config/migration (pure runtime code). Justin already re-quarantined the Mini live during the incident; this is the durable code fix.

## Tests

`machine-identity.test.ts` (new cases): a revoked machine re-registered stays revoked (status/role/revokedAt/revokedBy preserved, not resurrected); a brand-new machine still registers active. 75 machine-identity unit tests green; `tsc --noEmit` clean; no-silent-fallbacks budget unaffected (the guard adds a `return`, no catch). causalAutopsy: latent — symmetric with the already-sticky merge path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)