### PR TITLE
fix(sleepwake): suppress consecutive-drift bursts to stop tunnel-restart storm

### DIFF
--- a/.instar/instar-dev-decisions/2026-06-07T20-03-00-573Z-sleepwake-drift-burst-suppression.json
+++ b/.instar/instar-dev-decisions/2026-06-07T20-03-00-573Z-sleepwake-drift-burst-suppression.json
@@ -1,0 +1,16 @@
+{
+  "ts": "2026-06-07T20:03:00.573Z",
+  "slug": "sleepwake-drift-burst-suppression",
+  "suggestedTier": 1,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 37,
+  "causalAutopsy": {
+    "origin": "latent",
+    "notes": "SleepWakeDetector has inferred sleep from timer drift since it was written; #867 added the load-ratio starvation guard (short drift + high 1-min load ratio => suppress). That guard is correct but the 1-min load average lags and fluctuates, leaving a latent gap: on a box bouncing between load ~8 and ~20, a lag-drift landing during a momentary dip below maxLoadRatio still fired a wake. 2026-06-07 grounding: a tunnel-restart storm every 1-3min (some timing out) under exactly this churn. No prior PR regressed it; #867 improved the common case and this completes it for the fluctuating-load case. Fix B of the operator-requested A+B pair (A = #975 durable reaper candidacy, which survives whatever restart churn remains; B reduces the churn at its source). Related prior work: #867 (laptop-eventloop-stall load-ratio guard)."
+  },
+  "verdict": "pass"
+}

--- a/.instar/instar-dev-traces/2026-06-07T20-30-00-000Z-sleepwake-drift-burst-suppression.json
+++ b/.instar/instar-dev-traces/2026-06-07T20-30-00-000Z-sleepwake-drift-burst-suppression.json
@@ -1,0 +1,19 @@
+{
+    "slug": "sleepwake-drift-burst-suppression",
+    "sessionId": "96c61421-860a-48f9-92b4-26328f5640f1",
+    "timestamp": "2026-06-07T20:30:00.000Z",
+    "artifactPath": "upgrades/side-effects/sleepwake-drift-burst-suppression.md",
+    "artifactSha256": "a7d553444a9d23a4e91531600d658c7ba3cad2efd6367b5ca300f6754a1e7697",
+    "coveredFiles": ["src/core/SleepWakeDetector.ts","tests/unit/sleep-wake-starvation-guard.test.ts"],
+    "phase": "complete",
+    "tier": 1,
+    "tierReasoning": "Adds a load-independent consecutive-drift burst guard to SleepWakeDetector: count back-to-back drift ticks (reset by any on-time tick); the Nth+ consecutive SHORT drift is suppressed as CPU starvation regardless of the lagging/fluctuating 1-min load ratio. This closes the gap the maxLoadRatio guard (#867) missed — on a load-churning box, 10-42s lag-drifts fired wakes whenever the 1-min average momentarily dipped below maxLoadRatio, producing a tunnel-restart storm. New optional config field driftBurstSuppressFloor (default 2; 0 disables) → absent restores prior behavior. Long sleeps (>= longSleepFloorSeconds) are exempt; the first drift in any burst still falls through to the existing checks, so an isolated real wake is unaffected. No API/route/state-schema/migration; suppressions counted under existing cpu-starvation reason. Both sides unit-tested incl. the floor-0 contrast proving the guard, the counter-reset, and the long-sleep exemption. No converged spec required for Tier 1.",
+    "eli16Path": "docs/eli16/sleepwake-drift-burst-suppression.eli16.md",
+    "sideEffectsPath": "upgrades/side-effects/sleepwake-drift-burst-suppression.md",
+    "causalAutopsy": {
+        "origin": "latent",
+        "notes": "SleepWakeDetector has inferred sleep from timer drift since it was written; #867 added the load-ratio starvation guard (short drift + high 1-min load ratio => suppress). That guard is correct but the 1-min load average lags and fluctuates, leaving a latent gap: on a box bouncing between load ~8 and ~20, a lag-drift landing during a momentary dip below maxLoadRatio still fired a wake. 2026-06-07 grounding: a tunnel-restart storm every 1-3min (some timing out) under exactly this churn. No prior PR regressed it; #867 improved the common case and this completes it for the fluctuating-load case. Fix B of the operator-requested A+B pair (A = #975 durable reaper candidacy, which survives whatever restart churn remains; B reduces the churn at its source). Related prior work: #867 (laptop-eventloop-stall load-ratio guard)."
+    },
+    "secondPass": "not-required",
+    "reviewerConcurred": null
+}

--- a/docs/eli16/sleepwake-drift-burst-suppression.eli16.md
+++ b/docs/eli16/sleepwake-drift-burst-suppression.eli16.md
@@ -1,0 +1,23 @@
+# SleepWake drift-burst suppression — ELI16
+
+> The one-line version: the server kept "restarting its tunnel" every couple minutes because a detector mistook event-loop lag (the machine being busy) for the machine going to sleep. It already ignored lag when CPU load was clearly high — but load fluctuates, so lag bursts slipped through whenever the 1-minute load average momentarily dipped. This adds a simpler, load-independent rule: a real sleep is ONE isolated hiccup; a string of back-to-back hiccups is the CPU choking, not repeated sleeps — so ignore the 2nd-and-onward.
+
+## The problem (found 2026-06-07)
+
+The SleepWakeDetector infers sleep from timer drift (timers freeze during real sleep). Under heavy load the event loop also lags, producing false "drift." #867 added a guard: short drift while the 1-min load ratio is high → suppressed as starvation. But the load average lags and fluctuates, so on a box bouncing between load ~8 and ~20, a 10-42s lag-drift that landed during a momentary dip below the threshold still fired a "wake" → a tunnel restart. Result: a tunnel-restart storm every 1-3 min (some timing out), churning recovery and piling on more load.
+
+## What this adds
+
+A load-independent signal: count consecutive drift ticks. A genuine sleep is a single isolated drift (the next on-time tick resets the counter); sustained CPU starvation produces back-to-back drifts. The 2nd+ consecutive SHORT drift is suppressed as a starvation burst — no matter what the (lagging) load average happens to read at that instant. Genuine long sleeps (≥5 min) are exempt and always emit (real-sleep recovery is essential), and the first drift in any burst still falls through to the existing checks, so an isolated real wake is unaffected.
+
+- New `driftBurstSuppressFloor` (default 2; set 0 to disable).
+
+## Why it's safe
+
+- It only ever suppresses MORE false wakes, and only the 2nd-and-onward back-to-back SHORT drift. A single isolated drift still emits. A genuine long sleep is exempt.
+- A suppressed false wake just means a tunnel restart that wasn't needed is skipped (the tunnel was never disconnected — there was no real sleep). The only cost is a delayed reconnect after a genuine short sleep that happens mid-starvation-burst — rare, and self-heals on the next on-time tick / activity.
+- Pairs with fix A (durable reaper candidacy): A makes the reaper survive restarts, B reduces the restarts.
+
+## Evidence
+
+`tests/unit/sleep-wake-starvation-guard.test.ts`: 2nd consecutive short drift suppressed even under NORMAL load (the gap maxLoadRatio missed) and past the cooldown; with the guard off the same drift WOULD emit (proving the guard did it); an on-time tick resets the counter (isolated drifts both emit); a genuine long sleep is exempt. 13/13 green. `tsc --noEmit` clean.

--- a/src/core/SleepWakeDetector.ts
+++ b/src/core/SleepWakeDetector.ts
@@ -60,6 +60,14 @@ export interface SleepWakeDetectorConfig {
    * recovery storms. Long sleeps bypass the cooldown. Default: 60000 (1 min).
    */
   minWakeIntervalMs?: number;
+  /**
+   * Number of BACK-TO-BACK drift ticks at/above which a drift is treated as a CPU-
+   * starvation burst and suppressed — regardless of duration or the (lagging) load
+   * ratio. A genuine sleep is a single isolated drift (the next tick is on-time, which
+   * resets the counter); sustained starvation produces consecutive drifts. Default: 2
+   * (the 2nd consecutive drift is already a storm). Set 0 to disable.
+   */
+  driftBurstSuppressFloor?: number;
   /** Injectable system-load source (testing). Default: os.loadavg. */
   loadAvgProvider?: () => number[];
   /** Injectable CPU-count source (testing). Default: os.cpus().length. */
@@ -102,6 +110,14 @@ export class SleepWakeDetector extends EventEmitter {
   private maxLoadRatio: number;
   private longSleepFloorSeconds: number;
   private minWakeIntervalMs: number;
+  private driftBurstSuppressFloor: number;
+  /** Count of BACK-TO-BACK drift ticks (reset by any on-time tick). A real sleep is
+   *  ONE isolated drift; sustained CPU starvation produces consecutive drifts. The
+   *  Nth+ consecutive drift is a storm, not a sleep, and is suppressed regardless of
+   *  the (lagging, fluctuating) 1-min load ratio — the gap maxLoadRatio alone missed
+   *  (2026-06-07: tunnel-restart storm from 10-42s drifts firing whenever loadRatio
+   *  momentarily dipped below maxLoadRatio). */
+  private consecutiveDrifts = 0;
   private loadAvgProvider: () => number[];
   private cpuCountProvider: () => number;
   private now: () => number;
@@ -115,6 +131,7 @@ export class SleepWakeDetector extends EventEmitter {
     this.maxLoadRatio = config.maxLoadRatio ?? 1.5;
     this.longSleepFloorSeconds = config.longSleepFloorSeconds ?? 300;
     this.minWakeIntervalMs = config.minWakeIntervalMs ?? 60000;
+    this.driftBurstSuppressFloor = config.driftBurstSuppressFloor ?? 2;
     this.loadAvgProvider = config.loadAvgProvider ?? (() => os.loadavg());
     this.cpuCountProvider = config.cpuCountProvider ?? (() => os.cpus().length);
     this.now = config.nowProvider ?? (() => Date.now());
@@ -130,11 +147,29 @@ export class SleepWakeDetector extends EventEmitter {
       const elapsed = now - this.lastTick;
       this.lastTick = now;
 
-      if (elapsed <= this.driftThresholdMs) return;
+      if (elapsed <= this.driftThresholdMs) { this.consecutiveDrifts = 0; return; } // on-time tick → not starving
 
       const sleepDuration = Math.round((elapsed - this.checkIntervalMs) / 1000);
       const isLongSleep = sleepDuration >= this.longSleepFloorSeconds;
       const loadRatio = this.currentLoadRatio();
+      this.consecutiveDrifts += 1;
+
+      // Consecutive-drift burst = sustained CPU starvation, not sleep. A genuine sleep
+      // is ONE isolated drift (the next on-time tick resets the counter); the 2nd+
+      // back-to-back SHORT drift is a storm. Suppress it regardless of the (lagging,
+      // fluctuating) load ratio — this catches the drifts maxLoadRatio missed when the
+      // 1-min average momentarily dipped below the threshold (2026-06-07 tunnel-restart
+      // storm). A genuine LONG sleep (>= longSleepFloorSeconds) is exempt — it always
+      // emits (real-sleep recovery is essential), and the FIRST short drift still falls
+      // through to the checks below, so an isolated real wake is unaffected.
+      if (!isLongSleep && this.driftBurstSuppressFloor > 0 && this.consecutiveDrifts >= this.driftBurstSuppressFloor) {
+        this.recordSuppression('cpu-starvation', sleepDuration, loadRatio, now);
+        console.warn(
+          `[SleepWakeDetector] Drift ~${sleepDuration}s — consecutive drift #${this.consecutiveDrifts} ` +
+            `(>= ${this.driftBurstSuppressFloor}) = starvation burst, suppressing wake`,
+        );
+        return;
+      }
 
       // Short drift under heavy CPU load = event-loop starvation, not sleep.
       if (!isLongSleep && loadRatio > this.maxLoadRatio) {

--- a/tests/unit/sleep-wake-starvation-guard.test.ts
+++ b/tests/unit/sleep-wake-starvation-guard.test.ts
@@ -186,4 +186,52 @@ describe('SleepWakeDetector — CPU-starvation guard', () => {
     expect(detector.getCumulativeSleepMsBetween(startQuery, fakeNow + 1)).toBe(0);
     expect(detector.getStats(0).wakeCount).toBe(0);
   });
+
+  describe('consecutive-drift burst suppression (2026-06-07 tunnel-restart storm)', () => {
+    it('suppresses the 2nd consecutive short drift even under NORMAL load (the gap maxLoadRatio missed)', () => {
+      load = [0, 0, 0]; // normal load — load-suppress would NOT catch this; only the burst guard does
+      detector = makeDetector();
+      const wakes: unknown[] = [];
+      detector.on('wake', (e) => wakes.push(e));
+      detector.start();
+      tick(90_000); // 1st short drift (90s < 300s long-sleep floor), isolated → emits
+      tick(90_000); // 2nd consecutive drift; 90s apart > 60s cooldown, so cooldown does NOT suppress → burst guard does
+      expect(wakes.length).toBe(1);
+      expect(detector.getStats(0).suppressedByReason['cpu-starvation']).toBeGreaterThanOrEqual(1);
+    });
+
+    it('WITHOUT the burst guard (floor 0) the same 2nd drift WOULD emit — proving the guard did it', () => {
+      load = [0, 0, 0];
+      detector = makeDetector({ driftBurstSuppressFloor: 0 });
+      const wakes: unknown[] = [];
+      detector.on('wake', (e) => wakes.push(e));
+      detector.start();
+      tick(90_000); // drift 1 → emit
+      tick(90_000); // drift 2, past the 60s cooldown, no burst guard → emit
+      expect(wakes.length).toBe(2);
+    });
+
+    it('an on-time tick resets the burst counter (genuinely-isolated drifts both emit)', () => {
+      load = [0, 0, 0];
+      detector = makeDetector();
+      const wakes: unknown[] = [];
+      detector.on('wake', (e) => wakes.push(e));
+      detector.start();
+      tick(90_000); // drift 1 → emit, consecutiveDrifts=1
+      tick(1_000);  // on-time tick (1s ≤ 5s threshold) → resets the counter
+      tick(90_000); // drift 2, isolated again + past cooldown → emit
+      expect(wakes.length).toBe(2);
+    });
+
+    it('a genuine LONG sleep is exempt from the burst guard (real-sleep recovery preserved)', () => {
+      load = [0, 0, 0];
+      detector = makeDetector();
+      const wakes: unknown[] = [];
+      detector.on('wake', (e) => wakes.push(e));
+      detector.start();
+      tick(600_000); // long sleep 1 (600s ≥ 300s) → emit
+      tick(600_000); // consecutive long sleep → exempt from burst (isLongSleep) → still emits
+      expect(wakes.length).toBe(2);
+    });
+  });
 });

--- a/upgrades/next/sleepwake-drift-burst-suppression.md
+++ b/upgrades/next/sleepwake-drift-burst-suppression.md
@@ -1,0 +1,35 @@
+<!-- bump: patch -->
+<!-- change_type: fix -->
+
+## What Changed
+
+The SleepWakeDetector mistook event-loop lag for sleep when the 1-min load average
+momentarily dipped below its starvation threshold (which lags + fluctuates), firing
+false wakes → a tunnel-restart storm every 1-3 min on a load-churning box. Adds a
+load-independent consecutive-drift guard: a real sleep is one isolated drift, but
+sustained starvation produces back-to-back drifts — so the 2nd+ consecutive SHORT drift
+is suppressed regardless of the load reading. Genuine long sleeps (≥5min) are exempt.
+
+New `driftBurstSuppressFloor` (default 2; 0 disables).
+
+## What to Tell Your User
+
+Nothing required — internal stability fix. If they saw the tunnel/dashboard flapping or
+frequent restarts under load, this calms it.
+
+## Summary of New Capabilities
+
+- `SleepWakeDetectorConfig.driftBurstSuppressFloor` — suppress the Nth+ back-to-back
+  drift as a CPU-starvation burst (load-independent). Default 2.
+
+## Scope (honest)
+
+Fix B of the operator's A+B pair (A = durable reaper candidacy). B reduces the restart
+churn; A makes the reaper survive whatever churn remains. Targets the SHORT-drift storm;
+genuine long sleeps still emit. Does not change the existing load-ratio or cooldown guards.
+
+## Evidence
+
+`tests/unit/sleep-wake-starvation-guard.test.ts`: 2nd consecutive short drift suppressed
+under normal load + past cooldown; floor-0 contrast proves the guard; on-time tick resets;
+long sleep exempt. 13/13 green. `tsc --noEmit` clean.

--- a/upgrades/side-effects/sleepwake-drift-burst-suppression.md
+++ b/upgrades/side-effects/sleepwake-drift-burst-suppression.md
@@ -1,0 +1,42 @@
+# Side effects — SleepWake drift-burst suppression
+
+## Change
+
+`SleepWakeDetector` gains a load-independent consecutive-drift guard. It counts
+back-to-back drift ticks (`consecutiveDrifts`); any on-time tick resets the count. The
+Nth+ consecutive SHORT drift (N = `driftBurstSuppressFloor`, default 2) is suppressed as
+a CPU-starvation burst regardless of the (lagging, fluctuating) 1-min load ratio — closing
+the gap the `maxLoadRatio` guard alone missed when load momentarily dipped below threshold.
+
+## Behavioral surface
+
+- **New config field** `SleepWakeDetectorConfig.driftBurstSuppressFloor` (number, default 2;
+  0 disables). Absent → default 2, so the burst guard is ON by default.
+- **What changes at runtime**: on a load-churning box, the 2nd-and-onward back-to-back short
+  drift no longer emits a `wake` event → no tunnel/recovery restart for it. Suppressions are
+  counted under the existing `cpu-starvation` reason in `getStats()` and excluded from
+  cumulative-sleep accounting (same path as the load-ratio suppression).
+- **What does NOT change**: the first drift in any burst still falls through to the existing
+  load-ratio + cooldown checks; a genuine LONG sleep (≥ `longSleepFloorSeconds`, default 300s)
+  is exempt and always emits; an isolated real short wake still emits.
+
+## Migration / compatibility
+
+- No migration needed. The field is optional with an in-code default; existing callers that
+  never set it get the (safe, more-suppressing) default-2 behavior. No config-schema change is
+  shipped to agents — the default lives in the constructor.
+- No API route, no persisted state, no on-disk format change.
+- Rollback: set `driftBurstSuppressFloor: 0` to restore the exact pre-change behavior (load-ratio
+  + cooldown guards only).
+
+## Risk
+
+Low. The guard only ever suppresses MORE false wakes, and only the 2nd+ back-to-back short
+drift. Worst case is a delayed reconnect after a genuine short sleep that lands mid-starvation-
+burst (rare; self-heals on the next on-time tick / activity). Long-sleep recovery is untouched.
+
+## Tests
+
+`tests/unit/sleep-wake-starvation-guard.test.ts` — 4 new cases (2nd consecutive short drift
+suppressed under NORMAL load; floor-0 contrast proves the guard fired; on-time tick resets the
+counter; long sleep exempt). 13/13 file-green; `tsc --noEmit` clean.


### PR DESCRIPTION
## What & why

`SleepWakeDetector` infers sleep from timer drift (timers freeze during real sleep). PR #867 added a guard: short drift while the 1-min load ratio is high → suppress as event-loop starvation. That guard is correct, but the 1-min load average **lags and fluctuates**, leaving a gap: on a box bouncing between load ~8 and ~20, a 10-42s lag-drift that landed during a momentary dip below `maxLoadRatio` still fired a "wake" → a **tunnel-restart storm every 1-3 min** (some restarts timing out), churning recovery and piling on more load. Observed live 2026-06-07.

This adds a **load-independent** signal: a genuine sleep is ONE isolated drift (the next on-time tick resets the counter); sustained CPU starvation produces **back-to-back** drifts. Suppress the Nth+ (default 2) consecutive **short** drift regardless of the load reading.

- New optional `SleepWakeDetectorConfig.driftBurstSuppressFloor` (default 2; `0` disables → restores prior behavior).
- Genuine **long** sleeps (≥ `longSleepFloorSeconds`, default 300s) are **exempt** — they always emit (real-sleep recovery preserved).
- The **first** drift in any burst still falls through to the existing load-ratio + cooldown checks, so an isolated real wake is unaffected.
- No API / route / persisted-state / migration. Suppressions counted under the existing `cpu-starvation` reason and excluded from cumulative-sleep accounting.

Fix **B** of the operator-requested A+B pair — **A = #975** (durable reaper candidacy, survives whatever restart churn remains); **B reduces the churn at its source**.

## Tests

`tests/unit/sleep-wake-starvation-guard.test.ts` — 4 new cases:
- 2nd consecutive short drift suppressed even under NORMAL load (the gap `maxLoadRatio` missed)
- floor-0 contrast proves the guard fired (same 2nd drift WOULD emit without it)
- an on-time tick resets the counter (genuinely-isolated drifts both emit)
- a genuine long sleep is exempt

13/13 file-green; `tsc --noEmit` clean; full pre-commit lint + instar-dev gate (Tier 1) passed.

## ELI16

The server kept "restarting its tunnel" every couple minutes because a detector mistook the machine being *busy* (event-loop lag) for the machine *going to sleep*. It already ignored that lag when CPU load was clearly high — but load fluctuates, so lag bursts slipped through whenever the 1-minute load average momentarily dipped below the threshold. This adds a simpler, load-independent rule: a real sleep is ONE isolated hiccup; a string of back-to-back hiccups is the CPU choking, not the machine sleeping over and over — so ignore the 2nd-and-onward. Genuine long sleeps (5+ min) are never ignored, so waking the machine after a real sleep still works. Result: the restart storm stops, the tunnel stays up, and recovery stops piling more load onto an already-busy box.

🤖 Generated with [Claude Code](https://claude.com/claude-code)