### PR TITLE
fix(transcripts): manage Claude Code cleanupPeriodDays (14d) to cap fleet pile-up

### DIFF
--- a/.instar/instar-dev-decisions/2026-06-07T21-48-40-639Z-transcript-cleanup-period.json
+++ b/.instar/instar-dev-decisions/2026-06-07T21-48-40-639Z-transcript-cleanup-period.json
@@ -1,0 +1,19 @@
+{
+  "ts": "2026-06-07T21:48:40.639Z",
+  "slug": "transcript-cleanup-period",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "irreversibility: src/core/PostUpdateMigrator.ts touches PostUpdateMigrator",
+    "migration / fleet-rollout surface: src/core/PostUpdateMigrator.ts touches PostUpdateMigrator (fleet migration machinery)"
+  ],
+  "belowFloor": true,
+  "files": 2,
+  "loc": 19,
+  "causalAutopsy": {
+    "origin": "latent",
+    "notes": "instar has never managed Claude Code's cleanupPeriodDays — every agent silently ran the unset 30-day default since the project began. A latent disk-hygiene gap, surfaced 2026-06-07 during the macOS resource investigation: ~/.claude/projects reached ~322k files/18GB, with ~289k files 7-30d old = fleet background claude -p one-shots (each writes a transcript) within the default window. NOT a regression from any prior PR; the default was simply never tuned for a multi-agent fleet's session volume. Item 3 of the operator's 5-item macOS-resource tracking (the minor/hygiene one — transcripts were already Spotlight-excluded and the box has no Time Machine, so this was never a CPU trigger). Recorded in docs/MACOS-RESOURCE-BATTLES.md."
+  },
+  "verdict": "pass"
+}

--- a/.instar/instar-dev-decisions/2026-06-07T21-56-43-822Z-transcript-cleanup-period.json
+++ b/.instar/instar-dev-decisions/2026-06-07T21-56-43-822Z-transcript-cleanup-period.json
@@ -1,0 +1,19 @@
+{
+  "ts": "2026-06-07T21:56:43.822Z",
+  "slug": "transcript-cleanup-period",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "irreversibility: src/core/PostUpdateMigrator.ts touches PostUpdateMigrator",
+    "migration / fleet-rollout surface: src/core/PostUpdateMigrator.ts touches PostUpdateMigrator (fleet migration machinery)"
+  ],
+  "belowFloor": true,
+  "files": 2,
+  "loc": 19,
+  "causalAutopsy": {
+    "origin": "latent",
+    "notes": "instar has never managed Claude Code's cleanupPeriodDays — every agent silently ran the unset 30-day default since the project began. A latent disk-hygiene gap, surfaced 2026-06-07 during the macOS resource investigation: ~/.claude/projects reached ~322k files/18GB, with ~289k files 7-30d old = fleet background claude -p one-shots (each writes a transcript) within the default window. NOT a regression from any prior PR; the default was simply never tuned for a multi-agent fleet's session volume. Item 3 of the operator's 5-item macOS-resource tracking (the minor/hygiene one — transcripts were already Spotlight-excluded and the box has no Time Machine, so this was never a CPU trigger). Recorded in docs/MACOS-RESOURCE-BATTLES.md."
+  },
+  "verdict": "pass"
+}

--- a/.instar/instar-dev-traces/2026-06-07T21-45-00-000Z-transcript-cleanup-period.json
+++ b/.instar/instar-dev-traces/2026-06-07T21-45-00-000Z-transcript-cleanup-period.json
@@ -1,0 +1,19 @@
+{
+    "slug": "transcript-cleanup-period",
+    "sessionId": "96c61421-860a-48f9-92b4-26328f5640f1",
+    "timestamp": "2026-06-07T21:45:00.000Z",
+    "artifactPath": "upgrades/side-effects/transcript-cleanup-period.md",
+    "artifactSha256": "809cfd12b83895f1bda6edfcb75b6213ac2a52efa4dc2ae918a791a4dbd4ea48",
+    "coveredFiles": ["src/commands/init.ts","src/core/PostUpdateMigrator.ts","tests/unit/PostUpdateMigrator-cleanupPeriodDays.test.ts"],
+    "phase": "complete",
+    "tier": 1,
+    "tierReasoning": "Sets cleanupPeriodDays:14 in .claude/settings.json for new agents (init.ts) and existing agents (PostUpdateMigrator.migrateSettings, set-if-unset with a nullish guard so an operator value incl explicit 0 is never overwritten). Caps Claude Code's transcript pile-up (observed ~322k files/18GB from fleet background claude -p one-shots under the unset 30d default). Pure Claude-client disk-hygiene setting — no API/route/state-schema, no runtime/session/hook/MCP change. Migration-Parity: both new-agent (init) and existing-agent (migrateSettings) paths covered. Both sides unit-tested (set-when-absent / no-override-7 / respect-explicit-0 / idempotent); adjacent migrateSettings suites still green. No converged spec required for Tier 1.",
+    "eli16Path": "docs/eli16/transcript-cleanup-period.eli16.md",
+    "sideEffectsPath": "upgrades/side-effects/transcript-cleanup-period.md",
+    "causalAutopsy": {
+        "origin": "latent",
+        "notes": "instar has never managed Claude Code's cleanupPeriodDays — every agent silently ran the unset 30-day default since the project began. A latent disk-hygiene gap, surfaced 2026-06-07 during the macOS resource investigation: ~/.claude/projects reached ~322k files/18GB, with ~289k files 7-30d old = fleet background claude -p one-shots (each writes a transcript) within the default window. NOT a regression from any prior PR; the default was simply never tuned for a multi-agent fleet's session volume. Item 3 of the operator's 5-item macOS-resource tracking (the minor/hygiene one — transcripts were already Spotlight-excluded and the box has no Time Machine, so this was never a CPU trigger). Recorded in docs/MACOS-RESOURCE-BATTLES.md."
+    },
+    "secondPass": "not-required",
+    "reviewerConcurred": null
+}

--- a/docs/eli16/transcript-cleanup-period.eli16.md
+++ b/docs/eli16/transcript-cleanup-period.eli16.md
@@ -1,0 +1,43 @@
+# Transcript cleanup-period — ELI16
+
+> One line: Claude Code keeps a log file for every session it ever runs, and on a
+> machine running a whole fleet of agents those logs pile up into hundreds of thousands
+> of files. Claude already deletes ones older than 30 days — this just tells it to keep
+> 14 days instead, so the pile stays small. One setting, fleet-wide.
+
+## The problem (2026-06-07)
+
+Claude Code writes a transcript (`~/.claude/projects/<proj>/<session>.jsonl`) for every
+session — including every background `claude -p` one-shot a fleet agent fires (sentinels,
+gates, extractors). It auto-deletes transcripts older than `cleanupPeriodDays` (default 30
+when unset). On one dogfooding box this reached **~322,000 files / 18 GB**, of which ~289k
+were 7–30 days old — i.e. within the default retention window, just sheer volume from the
+fleet's background activity.
+
+instar did not manage `cleanupPeriodDays` at all, so every agent silently ran the 30-day
+default.
+
+## What this changes
+
+Sets `cleanupPeriodDays: 14` in `.claude/settings.json`:
+- **New agents** — written into the initial settings.json at `init`.
+- **Existing fleet** — `PostUpdateMigrator.migrateSettings()` sets it on update, **only when
+  the key is unset** (an operator's hand-tuned value is never overwritten; a nullish guard
+  means an explicit `0` — Claude's "don't clean" value — is also respected).
+
+14 days keeps ample `--resume` headroom (and instar's CONTINUATION mechanism reconstructs
+context across longer gaps), while halving the worst-case pile-up.
+
+## Why it's safe / honest scope
+
+- It is NOT a CPU fix. The transcripts were already excluded from Spotlight, and the box had
+  no Time Machine — so they were never a macOS-activity trigger. This is pure disk/file-count
+  hygiene.
+- Set-if-unset + nullish guard → idempotent, and never clobbers an operator's choice.
+- Tunable per-agent (just edit settings.json). Reversible.
+
+## Evidence
+
+`tests/unit/PostUpdateMigrator-cleanupPeriodDays.test.ts` — sets 14 when absent; does NOT
+override 7; respects explicit 0; idempotent (no re-report on second pass). 4/4 green. Adjacent
+migrateSettings tests (autonomous-hook-path, migration-parity ×2) still green (27/27). `tsc` clean.

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -1073,6 +1073,12 @@ async function initStandaloneAgent(agentName: string, options: InitOptions): Pro
     fs.mkdirSync(path.join(claudeDir, 'scripts'), { recursive: true });
     fs.mkdirSync(path.join(claudeDir, 'skills'), { recursive: true });
     fs.writeFileSync(path.join(claudeDir, 'settings.json'), JSON.stringify({
+      // Claude Code retains chat transcripts under ~/.claude/projects for
+      // cleanupPeriodDays (default 30). On a multi-agent fleet, every background
+      // `claude -p` one-shot (sentinels/gates) writes a transcript, so 30 days
+      // accumulates hundreds of thousands of files. 14 days keeps ample --resume
+      // headroom while capping the pile-up. Tunable per-agent in settings.json.
+      cleanupPeriodDays: 14,
       hooks: {
         PreToolUse: [],
         PostToolUse: [],

--- a/src/core/PostUpdateMigrator.ts
+++ b/src/core/PostUpdateMigrator.ts
@@ -5565,6 +5565,19 @@ Create worktrees for collaborator repos with \`instar worktree create <branch>\`
       patched = true;
     }
 
+    // Cap Claude Code transcript retention. Claude retains chat transcripts under
+    // ~/.claude/projects for `cleanupPeriodDays` (default 30 when unset). On a
+    // multi-agent fleet every background `claude -p` one-shot (sentinels/gates)
+    // writes a transcript, so 30 days accumulates hundreds of thousands of files
+    // (observed: ~322k files / 18 GB on one box). 14 days keeps ample --resume
+    // headroom while capping the pile-up. Set-if-unset only — never overrides an
+    // operator's explicit value (respects a hand-tuned retention).
+    if (settings.cleanupPeriodDays === undefined) {
+      settings.cleanupPeriodDays = 14;
+      patched = true;
+      result.upgraded.push('.claude/settings.json: set cleanupPeriodDays=14 (transcript retention)');
+    }
+
     if (patched) {
       try {
         fs.writeFileSync(settingsPath, JSON.stringify(settings, null, 2));

--- a/tests/unit/PostUpdateMigrator-cleanupPeriodDays.test.ts
+++ b/tests/unit/PostUpdateMigrator-cleanupPeriodDays.test.ts
@@ -1,0 +1,96 @@
+/**
+ * Verifies the transcript-retention migration: migrateSettings() sets
+ * `cleanupPeriodDays` on existing agents' .claude/settings.json so the whole
+ * fleet caps Claude Code's transcript pile-up on update.
+ *
+ * Background (2026-06-07): Claude Code retains chat transcripts under
+ * ~/.claude/projects for `cleanupPeriodDays` (default 30 when unset). On a
+ * multi-agent fleet every background `claude -p` one-shot (sentinels/gates)
+ * writes a transcript, so 30 days accumulates hundreds of thousands of files
+ * (observed: ~322k files / 18 GB on one box). instar did not manage this
+ * setting at all. The migration sets it to 14 — but ONLY when unset, so an
+ * operator's hand-tuned value is never clobbered (Migration-Parity idempotency).
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { PostUpdateMigrator } from '../../src/core/PostUpdateMigrator.js';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+
+type MigrationResult = { upgraded: string[]; skipped: string[]; errors: string[] };
+
+function newMigrator(projectDir: string): PostUpdateMigrator {
+  return new PostUpdateMigrator({
+    projectDir,
+    stateDir: path.join(projectDir, '.instar'),
+    port: 4042,
+    hasTelegram: false,
+    projectName: 'test',
+  });
+}
+
+function runMigrateSettings(migrator: PostUpdateMigrator): MigrationResult {
+  const result: MigrationResult = { upgraded: [], skipped: [], errors: [] };
+  (migrator as unknown as { migrateSettings(r: MigrationResult): void }).migrateSettings(result);
+  return result;
+}
+
+describe('PostUpdateMigrator — cleanupPeriodDays transcript retention', () => {
+  let projectDir: string;
+  let settingsPath: string;
+
+  beforeEach(() => {
+    projectDir = fs.mkdtempSync(path.join(os.tmpdir(), 'instar-cleanup-period-'));
+    fs.mkdirSync(path.join(projectDir, '.instar'), { recursive: true });
+    fs.mkdirSync(path.join(projectDir, '.claude'), { recursive: true });
+    settingsPath = path.join(projectDir, '.claude', 'settings.json');
+  });
+
+  afterEach(() => {
+    SafeFsExecutor.safeRmSync(projectDir, { recursive: true, force: true, operation: 'tests/unit/PostUpdateMigrator-cleanupPeriodDays.test.ts' });
+  });
+
+  function readSettings(): Record<string, unknown> {
+    return JSON.parse(fs.readFileSync(settingsPath, 'utf8'));
+  }
+
+  it('sets cleanupPeriodDays=14 when the key is absent', () => {
+    fs.writeFileSync(settingsPath, JSON.stringify({ hooks: { PreToolUse: [], PostToolUse: [] } }, null, 2));
+
+    const result = runMigrateSettings(newMigrator(projectDir));
+
+    expect(readSettings().cleanupPeriodDays).toBe(14);
+    expect(result.upgraded.some(u => u.includes('cleanupPeriodDays'))).toBe(true);
+  });
+
+  it('does NOT override an operator-set value (respects a hand-tuned retention)', () => {
+    fs.writeFileSync(settingsPath, JSON.stringify({ cleanupPeriodDays: 7, hooks: {} }, null, 2));
+
+    const result = runMigrateSettings(newMigrator(projectDir));
+
+    expect(readSettings().cleanupPeriodDays).toBe(7); // unchanged
+    expect(result.upgraded.some(u => u.includes('cleanupPeriodDays'))).toBe(false);
+  });
+
+  it('treats an explicit 0 as set (does not overwrite — 0 is a real Claude value meaning "no retention cleanup")', () => {
+    fs.writeFileSync(settingsPath, JSON.stringify({ cleanupPeriodDays: 0, hooks: {} }, null, 2));
+
+    runMigrateSettings(newMigrator(projectDir));
+
+    expect(readSettings().cleanupPeriodDays).toBe(0); // nullish guard — 0 stays 0
+  });
+
+  it('is idempotent: a second pass makes no further change and does not re-report', () => {
+    fs.writeFileSync(settingsPath, JSON.stringify({ hooks: {} }, null, 2));
+    const migrator = newMigrator(projectDir);
+
+    runMigrateSettings(migrator);
+    const after1 = fs.readFileSync(settingsPath, 'utf8');
+    const result2 = runMigrateSettings(migrator);
+
+    expect(fs.readFileSync(settingsPath, 'utf8')).toBe(after1);
+    expect(result2.upgraded.some(u => u.includes('cleanupPeriodDays'))).toBe(false);
+  });
+});

--- a/upgrades/next/transcript-cleanup-period.md
+++ b/upgrades/next/transcript-cleanup-period.md
@@ -1,0 +1,30 @@
+<!-- bump: patch -->
+<!-- change_type: fix -->
+
+## What Changed
+
+instar now manages Claude Code's transcript retention (`cleanupPeriodDays`), setting it to
+14 days for new agents (init) and existing agents (migration, set-if-unset). Claude writes a
+transcript per session — including every fleet background `claude -p` one-shot — and the
+unset default of 30 days let them accumulate (observed ~322k files / 18 GB on one box). This
+caps the pile-up fleet-wide.
+
+## What to Tell Your User
+
+Nothing required — internal disk hygiene. Chat transcripts older than 14 days are pruned by
+Claude automatically; recent ones (and the ability to resume them) are unaffected. If you set
+your own retention period, it is left as-is.
+
+## Summary of New Capabilities
+
+- `.claude/settings.json` `cleanupPeriodDays` is now instar-managed (default 14; set-if-unset).
+
+## Scope (honest)
+
+Pure disk/file-count hygiene, NOT a CPU fix — transcripts were already Spotlight-excluded.
+Tunable per-agent; reversible.
+
+## Evidence
+
+`tests/unit/PostUpdateMigrator-cleanupPeriodDays.test.ts` 4/4; adjacent migrateSettings suites
+27/27; `tsc` clean.

--- a/upgrades/side-effects/transcript-cleanup-period.md
+++ b/upgrades/side-effects/transcript-cleanup-period.md
@@ -1,0 +1,31 @@
+# Side effects — transcript cleanup-period (cleanupPeriodDays)
+
+## Change
+
+Sets `cleanupPeriodDays: 14` in `.claude/settings.json` — for new agents (init.ts) and
+existing agents (`PostUpdateMigrator.migrateSettings()`, set-if-unset).
+
+## Behavioral surface
+
+- **New behavior**: Claude Code now prunes chat transcripts under `~/.claude/projects`
+  older than 14 days (was the unset default of 30). Caps the per-fleet transcript pile-up.
+- **What does NOT change**: nothing about runtime sessions, hooks, MCP, or the server. This
+  is a Claude Code client setting only. Recent transcripts (≤14d) are untouched, so active
+  and recently-idle sessions keep full `--resume` support.
+
+## Migration / compatibility
+
+- Migration is **set-if-unset** (`settings.cleanupPeriodDays === undefined`) — an operator's
+  explicit value (including `0` = no cleanup) is never overwritten. Idempotent.
+- No config-schema change, no API, no state. Reversible by editing settings.json.
+
+## Risk
+
+Low. Worst case: a conversation left idle 14–30 days loses its Claude `--resume` transcript;
+instar's CONTINUATION mechanism reconstructs context across such gaps, so the conversation
+still resumes. Tunable up per-agent if any agent needs longer retention.
+
+## Tests
+
+`tests/unit/PostUpdateMigrator-cleanupPeriodDays.test.ts` (4/4): set-when-absent, no-override-7,
+respect-explicit-0, idempotent. Adjacent migrateSettings suites green (27/27). `tsc` clean.


### PR DESCRIPTION
## What & why

Item 3 of the macOS-resource tracking (the minor/hygiene one). Claude Code writes a transcript per session under `~/.claude/projects` — including every fleet background `claude -p` one-shot (sentinels/gates) — and auto-deletes only those older than `cleanupPeriodDays` (default **30** when unset). instar never managed this setting, so every agent silently ran the 30-day default. One dogfooding box reached **~322,000 files / 18 GB**, of which ~289k were 7–30 days old (within the window — just fleet volume).

This sets `cleanupPeriodDays: 14`:
- **New agents** — in the initial `.claude/settings.json` (`init.ts`).
- **Existing fleet** — `PostUpdateMigrator.migrateSettings()`, **set-if-unset** with a nullish guard so an operator's explicit value (including `0` = no cleanup) is never overwritten.

**Honest scope:** this is **disk/file-count hygiene, NOT a CPU fix** — the transcripts were already Spotlight-excluded and the box has no Time Machine, so they were never a macOS-activity trigger. 14 days keeps ample `--resume` headroom (and instar's CONTINUATION reconstructs context across longer gaps). Tunable per-agent; reversible.

Recorded in `docs/MACOS-RESOURCE-BATTLES.md`.

## Tests

`tests/unit/PostUpdateMigrator-cleanupPeriodDays.test.ts` (4/4): sets 14 when absent; does NOT override 7; respects explicit 0 (nullish guard); idempotent (no re-report on second pass). Adjacent migrateSettings suites green (autonomous-hook-path + migration-parity ×2 = 27/27). `tsc` clean.

## ELI16

Claude keeps a log file for every session it runs, and on a machine running a whole fleet of agents those pile up into hundreds of thousands of files. Claude already deletes ones older than 30 days; this just tells it to keep 14 instead, so the pile stays small. One setting, applied to new agents and rolled out to existing ones on update — and it won't touch the value if you've set your own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)