### PR TITLE
feat(subscription-auth): per-account email (auto-filled from the real login)

### DIFF
--- a/.instar/instar-dev-decisions/2026-06-07T22-40-35-819Z-url-pathname-path-encoding-fix.json
+++ b/.instar/instar-dev-decisions/2026-06-07T22-40-35-819Z-url-pathname-path-encoding-fix.json
@@ -1,0 +1,13 @@
+{
+  "ts": "2026-06-07T22:40:35.819Z",
+  "slug": "url-pathname-path-encoding-fix",
+  "suggestedTier": 2,
+  "declaredTier": null,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 3,
+  "loc": 52,
+  "causalAutopsy": null,
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-06-07T22-41-44-347Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-06-07T22-41-44-347Z-unknown.json
@@ -1,0 +1,13 @@
+{
+  "ts": "2026-06-07T22:41:44.347Z",
+  "slug": "unknown",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 3,
+  "loc": 52,
+  "causalAutopsy": null,
+  "verdict": "pass"
+}

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -3250,7 +3250,8 @@
       .sub-account-head { display:flex; justify-content:space-between; align-items:baseline; gap:12px; }
       .sub-account-nick { font-weight:600; font-size:15px; }
       .sub-account-status { font-size:12px; opacity:.75; }
-      .sub-account-meta { font-size:12px; opacity:.6; margin:2px 0 10px; }
+      .sub-account-meta { font-size:12px; opacity:.6; margin:2px 0 2px; }
+      .sub-account-email { font-size:12px; opacity:.5; margin:0 0 10px; }
       .sub-account-noquota { font-size:12px; opacity:.6; }
       .sub-quota { margin:8px 0; }
       .sub-quota-head { display:flex; justify-content:space-between; font-size:12px; margin-bottom:4px; }

--- a/dashboard/subscriptions.js
+++ b/dashboard/subscriptions.js
@@ -132,6 +132,9 @@ export function renderAccounts(doc, target, accounts, now = Date.now()) {
     card.appendChild(head);
     card.appendChild(el(doc, 'div', 'sub-account-meta',
       `${friendlyProvider(a && a.provider)} · ${sanitizeForDisplay(a && a.framework, 'label')}`));
+    if (a && a.email) {
+      card.appendChild(el(doc, 'div', 'sub-account-email', sanitizeForDisplay(a.email, 'label')));
+    }
     const q = (a && a.lastQuota) || null;
     if (q && (q.fiveHour || q.sevenDay)) {
       if (q.fiveHour) card.appendChild(quotaBar(doc, '5-hour', q.fiveHour.utilizationPct, q.fiveHour.resetsAt, now));

--- a/docs/specs/_drafts/subscription-account-email.eli16.md
+++ b/docs/specs/_drafts/subscription-account-email.eli16.md
@@ -1,0 +1,27 @@
+# Per-account email on the Subscription Pool — Plain-English Overview
+
+> The one-line version: each subscription account now carries its email, filled in automatically from the real login — so you can tell "SageMind - Justin" from "SageMind - Adriana" at a glance, and a wrong-account login can't hide.
+
+## The problem in one breath
+
+You'll have several accounts on the same org — "SageMind - Justin", "SageMind - Adriana", "SageMind - Dawn". A nickname alone isn't enough to be sure which real account is which; you asked that each be identified by nickname AND email.
+
+## What this adds
+
+- Each account in the pool now has an **email** alongside its nickname.
+- I don't make you type it: when I read an account's quota, I also read the email straight from that account's own sign-in record and store it. So the email always reflects the account that actually logged in.
+- The dashboard shows the email under the nickname.
+
+## Why the auto-fill matters (the safety bit)
+
+Because the email comes from the *real* login, not from what someone typed, it acts as a check: if a login ever signs into the wrong account, the email won't match what you expected — it shows the mistake instead of burying it. That's exactly the mislabeling risk you flagged.
+
+## What does NOT change
+
+- It's optional and additive — accounts without an email work exactly as before; nothing about how accounts are selected, swapped, or polled changes.
+- The email is a public identifier, never a token or password.
+- No new endpoints, no new powers.
+
+## Proven
+
+Unit tests cover storing/patching the email, reading it from a login record, and the poller auto-filling it from the real account; the dashboard render test confirms it shows. Type-check clean; existing pool/poller/route tests stay green.

--- a/src/core/QuotaPoller.ts
+++ b/src/core/QuotaPoller.ts
@@ -132,6 +132,32 @@ function expandHome(p: string): string {
 }
 
 /**
+ * Read the account email (`oauthAccount.emailAddress`) Claude Code records for a
+ * config home. This is a PUBLIC account identifier (not a secret) — it lets the
+ * pool show WHICH account a slot actually authenticated as, so a login into the
+ * wrong account surfaces instead of hiding. Tries `<configHome>/.claude.json`,
+ * then (for the default home) the home-root `~/.claude.json`. Null if unreadable.
+ */
+export function readAccountEmail(configHome: string): string | null {
+  const home = expandHome(configHome);
+  const candidates = [path.join(home, '.claude.json')];
+  if (home === expandHome('~/.claude')) {
+    candidates.push(path.join(process.env.HOME ?? '', '.claude.json'));
+  }
+  for (const f of candidates) {
+    try {
+      if (!fs.existsSync(f)) continue;
+      const j = JSON.parse(fs.readFileSync(f, 'utf-8'));
+      const email = j?.oauthAccount?.emailAddress;
+      if (typeof email === 'string' && email.includes('@')) return email;
+    } catch {
+      // @silent-fallback-ok: missing/unreadable config → no email (null)
+    }
+  }
+  return null;
+}
+
+/**
  * Map the REAL /api/oauth/usage response (verified live 2026-06-06) into an
  * AccountQuotaSnapshot. The live shape is `five_hour: {utilization, resets_at}`,
  * `seven_day: {utilization, resets_at}`, `seven_day_sonnet`, `seven_day_opus`,
@@ -292,6 +318,11 @@ export class QuotaPoller {
       const patch: Parameters<SubscriptionPool['update']>[1] = { lastQuota: snap };
       // A clean read on an account previously flagged needs-reauth restores it.
       if (account.status === 'needs-reauth') patch.status = 'active';
+      // Auto-populate the account email from the config home's own login record,
+      // so the stored email always reflects which account actually authenticated
+      // (a login into the wrong account surfaces here instead of hiding).
+      const email = readAccountEmail(account.configHome);
+      if (email && email !== account.email) patch.email = email;
       try {
         this.pool.update(account.id, patch);
       } catch {

--- a/src/core/SubscriptionPool.ts
+++ b/src/core/SubscriptionPool.ts
@@ -86,6 +86,11 @@ export interface SubscriptionAccount {
   id: string;
   /** Operator-facing handle (editable), like a machine nickname. */
   nickname: string;
+  /** Account email — the disambiguator across same-org accounts (e.g.
+   *  "SageMind - Justin" vs "SageMind - Adriana"). Auto-populated from the
+   *  account's own login (oauthAccount.emailAddress) on poll, so the stored email
+   *  always reflects which account actually authenticated. NEVER a secret. */
+  email?: string;
   /** Billing provider. */
   provider: SubscriptionProvider;
   /** Framework client that drives this account. */
@@ -126,6 +131,8 @@ export interface AddAccountInput {
   framework: SubscriptionFramework;
   configHome: string;
   status?: SubscriptionAccountStatus;
+  /** Optional at add time; auto-populated from the account's login on poll. */
+  email?: string;
 }
 
 /** Fields an operator may patch. id/provider/enrolledAt/version are immutable here. */
@@ -136,6 +143,7 @@ export interface UpdateAccountInput {
   status?: SubscriptionAccountStatus;
   lastQuota?: AccountQuotaSnapshot | null;
   lastUsedAt?: string;
+  email?: string;
 }
 
 const ID_RE = /^[a-z0-9-]+$/;
@@ -248,6 +256,7 @@ export class SubscriptionPool {
     const account: SubscriptionAccount = {
       id,
       nickname,
+      ...(input.email?.trim() ? { email: input.email.trim() } : {}),
       provider: input.provider,
       framework: input.framework,
       configHome,
@@ -300,6 +309,10 @@ export class SubscriptionPool {
     }
     if (patch.lastUsedAt !== undefined) {
       acct.lastUsedAt = patch.lastUsedAt;
+    }
+    if (patch.email !== undefined) {
+      const em = patch.email.trim();
+      acct.email = em || undefined;
     }
 
     acct.version += 1;

--- a/src/server/routes.ts
+++ b/src/server/routes.ts
@@ -15697,7 +15697,7 @@ export function createRoutes(ctx: RouteContext): Router {
       res.status(404).json({ error: 'SubscriptionPool not configured' });
       return;
     }
-    const { id, nickname, provider, framework, configHome, status } = req.body ?? {};
+    const { id, nickname, provider, framework, configHome, status, email } = req.body ?? {};
     if (!id || !nickname || !provider || !framework || !configHome) {
       res.status(400).json({
         error: 'id, nickname, provider, framework, and configHome are required',
@@ -15708,7 +15708,7 @@ export function createRoutes(ctx: RouteContext): Router {
       // Pass the full body as rawExtra so the credential-field guard rejects any
       // attempt to smuggle a token into the registry (structural invariant).
       const account = ctx.subscriptionPool.add(
-        { id, nickname, provider, framework, configHome, status },
+        { id, nickname, provider, framework, configHome, status, email },
         req.body,
       );
       res.status(201).json(account);
@@ -15725,11 +15725,11 @@ export function createRoutes(ctx: RouteContext): Router {
       res.status(404).json({ error: 'SubscriptionPool not configured' });
       return;
     }
-    const { nickname, framework, configHome, status, lastQuota, lastUsedAt } = req.body ?? {};
+    const { nickname, framework, configHome, status, lastQuota, lastUsedAt, email } = req.body ?? {};
     try {
       const updated = ctx.subscriptionPool.update(
         req.params.id,
-        { nickname, framework, configHome, status, lastQuota, lastUsedAt },
+        { nickname, framework, configHome, status, lastQuota, lastUsedAt, email },
         req.body,
       );
       if (!updated) {

--- a/tests/unit/subscription-account-email.test.ts
+++ b/tests/unit/subscription-account-email.test.ts
@@ -1,0 +1,79 @@
+/**
+ * Unit tests for the per-account email field (Subscription & Auth follow-up).
+ * Covers: the registry stores/patches email; readAccountEmail reads the PUBLIC
+ * oauthAccount.emailAddress from a config home; and the QuotaPoller auto-populates
+ * account.email from the config home's own login on poll (so the stored email
+ * always reflects which account actually authenticated). Hermetic — no network,
+ * no keychain, no spawning (injected fetch + token resolver + temp config home).
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { SubscriptionPool } from '../../src/core/SubscriptionPool.js';
+import { QuotaPoller, readAccountEmail, type FetchImpl } from '../../src/core/QuotaPoller.js';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+
+let dir: string;
+beforeEach(() => { dir = fs.mkdtempSync(path.join(os.tmpdir(), 'sub-email-')); });
+afterEach(() => {
+  try { SafeFsExecutor.safeRmSync(dir, { recursive: true, force: true, operation: 'tests/unit/subscription-account-email.test.ts:cleanup' }); } catch { /* @silent-fallback-ok */ }
+});
+
+describe('SubscriptionPool email field', () => {
+  it('add() stores the email; list() reflects it', () => {
+    const pool = new SubscriptionPool({ stateDir: dir });
+    const a = pool.add({ id: 'sm-justin', nickname: 'SageMind - Justin', provider: 'anthropic', framework: 'claude-code', configHome: '/h/.c', email: 'justin@sagemindai.io' });
+    expect(a.email).toBe('justin@sagemindai.io');
+    expect(pool.get('sm-justin')?.email).toBe('justin@sagemindai.io');
+  });
+
+  it('add() without email leaves it undefined (back-compat)', () => {
+    const pool = new SubscriptionPool({ stateDir: dir });
+    const a = pool.add({ id: 'x', nickname: 'x', provider: 'anthropic', framework: 'claude-code', configHome: '/h/.c' });
+    expect(a.email).toBeUndefined();
+  });
+
+  it('update() patches the email; empty string clears it', () => {
+    const pool = new SubscriptionPool({ stateDir: dir });
+    pool.add({ id: 'x', nickname: 'x', provider: 'anthropic', framework: 'claude-code', configHome: '/h/.c' });
+    expect(pool.update('x', { email: 'a@b.com' })?.email).toBe('a@b.com');
+    expect(pool.update('x', { email: '' })?.email).toBeUndefined();
+  });
+
+  it('email is not a credential field — add does not throw on it', () => {
+    const pool = new SubscriptionPool({ stateDir: dir });
+    expect(() => pool.add({ id: 'y', nickname: 'y', provider: 'anthropic', framework: 'claude-code', configHome: '/h/.c', email: 'z@z.com' }, { email: 'z@z.com' })).not.toThrow();
+  });
+});
+
+describe('readAccountEmail', () => {
+  it('reads oauthAccount.emailAddress from <configHome>/.claude.json', () => {
+    fs.writeFileSync(path.join(dir, '.claude.json'), JSON.stringify({ oauthAccount: { emailAddress: 'me@org.com' } }));
+    expect(readAccountEmail(dir)).toBe('me@org.com');
+  });
+  it('returns null when no config / no email', () => {
+    expect(readAccountEmail(dir)).toBeNull();
+    fs.writeFileSync(path.join(dir, '.claude.json'), JSON.stringify({ oauthAccount: {} }));
+    expect(readAccountEmail(dir)).toBeNull();
+  });
+});
+
+describe('QuotaPoller auto-populates account.email from the real login', () => {
+  const USAGE = { five_hour: { utilization: 10, resets_at: '2026-06-07T01:00:00Z' }, seven_day: { utilization: 40, resets_at: '2026-06-12T00:00:00Z' } };
+  const okFetch: FetchImpl = async () => ({ ok: true, status: 200, json: async () => USAGE });
+
+  it('writes the email read from the config home onto the account', async () => {
+    // config home whose login record says a specific account
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), 'cfg-home-'));
+    fs.writeFileSync(path.join(home, '.claude.json'), JSON.stringify({ oauthAccount: { emailAddress: 'real@account.com' } }));
+    const pool = new SubscriptionPool({ stateDir: dir });
+    // registered with NO email (or a stale one) — poll should fill it from reality
+    pool.add({ id: 'acc', nickname: 'Acc', provider: 'anthropic', framework: 'claude-code', configHome: home });
+    const poller = new QuotaPoller({ pool, fetchImpl: okFetch, tokenResolver: () => 'sk-ant-oat01-x' });
+    await poller.pollAll();
+    expect(pool.get('acc')?.email).toBe('real@account.com');
+    try { SafeFsExecutor.safeRmSync(home, { recursive: true, force: true, operation: 'test:cleanup-home' }); } catch { /* @silent-fallback-ok */ }
+  });
+});

--- a/tests/unit/subscriptions-render.test.ts
+++ b/tests/unit/subscriptions-render.test.ts
@@ -100,10 +100,11 @@ describe('renderAccounts', () => {
   it('renders nickname, status, and two quota bars', () => {
     const t = el();
     renderAccounts(doc, t, [{
-      id: 'a1', nickname: 'personal', provider: 'anthropic', framework: 'claude-code', status: 'active',
+      id: 'a1', nickname: 'personal', provider: 'anthropic', framework: 'claude-code', status: 'active', email: 'justin@sagemindai.io',
       lastQuota: { fiveHour: { utilizationPct: 10, resetsAt: '2026-06-07T01:00:00Z' }, sevenDay: { utilizationPct: 71, resetsAt: '2026-06-12T00:00:00Z' } },
     }], NOW);
     expect(t.querySelector('.sub-account-nick')!.textContent).toBe('personal');
+    expect(t.querySelector('.sub-account-email')!.textContent).toBe('justin@sagemindai.io');
     expect(t.querySelector('.sub-account-status')!.textContent).toBe('Active');
     expect(t.querySelectorAll('.sub-quota').length).toBe(2);
   });

--- a/upgrades/next/subscription-account-email.md
+++ b/upgrades/next/subscription-account-email.md
@@ -1,0 +1,31 @@
+# Per-account email on the Subscription Pool
+
+<!-- bump: patch -->
+
+## What Changed
+
+Each subscription account now carries an optional `email`, alongside its nickname,
+so same-org accounts are distinguishable (e.g. "SageMind - Justin" vs
+"SageMind - Adriana"). The email is **auto-populated from the account's own login
+record** (`oauthAccount.emailAddress` in its config home) on each quota poll — so
+the stored email always reflects which account actually authenticated, and a login
+into the wrong account surfaces instead of hiding. Added: `email` on
+`SubscriptionAccount` / add / update (additive-optional), a `readAccountEmail`
+helper + poll-time auto-fill in `QuotaPoller`, pass-through on the POST/PATCH
+`/subscription-pool` routes, and the email rendered under the nickname on the
+dashboard Subscriptions tab. The email is a public identifier — never a token.
+
+## What to Tell Your User
+
+Your subscription accounts now show their email next to the nickname, so when you
+have several on the same org you can tell them apart at a glance. I fill the email
+in automatically from the real login, so it always matches the account that
+actually signed in.
+
+## Summary of New Capabilities
+
+- **Account email** — each pool account stores its email (the disambiguator across
+  same-org accounts), shown on the dashboard.
+- **Auto-filled from reality** — the email comes from the account's own login
+  record on each poll, so it reflects the truly-authenticated account (catches a
+  wrong-account login rather than hiding it).

--- a/upgrades/side-effects/subscription-account-email.md
+++ b/upgrades/side-effects/subscription-account-email.md
@@ -1,0 +1,58 @@
+# Side-Effects Review — per-account email on the Subscription Pool
+
+## Scope of change
+
+- `src/core/SubscriptionPool.ts` — add optional `email` to `SubscriptionAccount`,
+  `AddAccountInput`, `UpdateAccountInput`; `add()`/`update()` store/patch it.
+- `src/core/QuotaPoller.ts` — new exported `readAccountEmail(configHome)` (reads the
+  PUBLIC `oauthAccount.emailAddress` from the config home's `.claude.json`); `pollAll()`
+  auto-populates `account.email` from it on each poll.
+- `src/server/routes.ts` — POST/PATCH `/subscription-pool` pass `email` through.
+- `dashboard/subscriptions.js` + `dashboard/index.html` — render the email under the
+  account nickname. Tests (unit + render assertion).
+
+## Why
+
+Operator requirement (Justin, topic 20905): accounts must be identified by nickname
+AND email — e.g. "SageMind - Justin" vs "SageMind - Adriana" vs "SageMind - Dawn"
+are the same org, so the email is the disambiguator. The pool previously stored only
+nickname + login location.
+
+## The safety property (load-bearing)
+
+The email is **auto-populated from the account's own login record** (`oauthAccount.
+emailAddress` in the config home), not just operator-typed. So the stored email
+always reflects WHICH account actually authenticated under that config home — a
+login into the wrong account *surfaces* (the email won't match the nickname's intent)
+instead of hiding. This directly serves the operator's stated worry about mislabeling
+accounts. The email is a PUBLIC identifier — never a token/secret.
+
+## What does NOT change
+
+- Additive-optional everywhere: `email` is optional; existing accounts and existing
+  add/update calls (no email) behave exactly as before (`email` stays undefined).
+- No new route, no new authority, no behavior change to selection/swap/poll beyond
+  writing one extra public field. The credential-field guard is unaffected (`email`
+  is not a forbidden field name).
+
+## Framework generality
+
+`readAccountEmail` reads claude-code's `oauthAccount.emailAddress` (the Claude config
+layout), matching the standard's Claude-first scope. The `email` field itself is
+framework-agnostic (any provider's account can carry one); only the auto-populate
+reader is claude-code-specific today. A non-claude account simply gets no auto-filled
+email (operators can still set one via the route) — no behavior regression, and the
+reader extends per-framework when those logins are wired.
+
+## Failure modes considered
+
+- Config home has no `.claude.json` / no `oauthAccount` → `readAccountEmail` returns
+  null → poll leaves `email` unchanged (no throw).
+- Operator passes `email` at add time → stored as-is; a later poll overwrites it with
+  the real logged-in email (reality wins — the safety property).
+- `update({ email: '' })` clears the email (explicit unset).
+
+## Migration / parity
+
+Additive-optional field on an existing store — no migration needed (old records load
+with `email` undefined; the next poll fills it). Ships via dist.


### PR DESCRIPTION
## What this is (ELI16)

Each subscription account now carries its **email** alongside the nickname — and I fill it in automatically from the account's real sign-in record, so "SageMind - Justin" vs "SageMind - Adriana" vs "SageMind - Dawn" (same org, different people) are unambiguous. Operator requirement from topic 20905.

## The safety property

The email is **auto-populated from the account's own login** (`oauthAccount.emailAddress` in its config home) on each quota poll — not just operator-typed. So the stored email always reflects WHICH account actually authenticated under that config home. A login into the wrong account *surfaces* (email won't match the nickname's intent) instead of hiding — directly serving the operator's stated mislabeling worry. The email is a PUBLIC identifier, never a token.

## What changed

- `SubscriptionAccount` / `AddAccountInput` / `UpdateAccountInput` gain an optional `email`; `add()`/`update()` store + patch it (additive-optional, back-compat).
- `QuotaPoller`: new exported `readAccountEmail(configHome)` + poll-time auto-fill.
- POST/PATCH `/subscription-pool` pass `email` through; dashboard renders it under the nickname.

## Invariants

Additive-optional everywhere; no new route, no new authority, no behavior change beyond writing one public field. Credential-field guard unaffected (`email` isn't a forbidden field). tsc clean; email/render/pool/poller/integration/e2e tests green; docs-coverage unchanged. Tier-1-lite (risk floor 1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)