### PR TITLE
feat(lint): ban synchronous process scans on the runtime hot path (post-mortem #3)

### DIFF
--- a/.instar/instar-dev-decisions/2026-06-07T22-49-52-318Z-lint-no-blocking-process-scans.json
+++ b/.instar/instar-dev-decisions/2026-06-07T22-49-52-318Z-lint-no-blocking-process-scans.json
@@ -1,0 +1,13 @@
+{
+  "ts": "2026-06-07T22:49:52.318Z",
+  "slug": "lint-no-blocking-process-scans",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 4,
+  "loc": 126,
+  "causalAutopsy": null,
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-06-07T22-51-08-667Z-lint-no-blocking-process-scans.json
+++ b/.instar/instar-dev-decisions/2026-06-07T22-51-08-667Z-lint-no-blocking-process-scans.json
@@ -1,0 +1,16 @@
+{
+  "ts": "2026-06-07T22:51:08.667Z",
+  "slug": "lint-no-blocking-process-scans",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 4,
+  "loc": 126,
+  "causalAutopsy": {
+    "origin": "latent",
+    "notes": "Preventive gate for a LATENT class: synchronous process-enumeration scans (ps/pgrep/lsof) on a cadence were always present in monitors but dormant — they only became harmful on 2026-06-07 (topic 21816, docs/postmortems/2026-06-07-server-temporarily-down.md, root cause #4) when CPU/IO load made them run long enough to block the single-threaded event loop and starve /health, so the supervisor judged an alive server unresponsive and restarted it -> the restart loop. PR #972 converted the worst offender (SessionWatchdog) to async; this lint is the Structure>Willpower ratchet that stops the latent class from being re-introduced. Not a regression of a prior PR — a preventive gate closing the door behind the fix."
+  },
+  "verdict": "pass"
+}

--- a/docs/eli16/lint-no-blocking-process-scans.eli16.md
+++ b/docs/eli16/lint-no-blocking-process-scans.eli16.md
@@ -1,0 +1,31 @@
+# Lint: no blocking process scans on the hot path — Plain-English Overview
+
+> One line: the server is single-threaded, so when it runs a slow command like `ps` or `lsof` and waits for it, it can't do anything else — including answer "am I alive?". Under load those commands get slow, the health check times out, and the watchdog restarts a server that was actually fine. This adds a build check that stops anyone from re-introducing that pattern.
+
+## The problem this guards against
+
+A background monitor that runs `ps` / `pgrep` / `lsof` *synchronously* on a timer freezes the whole server for as long as that command takes. On a busy machine `ps`/`lsof` can take seconds. Stack a few of those up and the server can't answer its health check in time — so the watchdog thinks it's dead and restarts it. That was a direct contributor to the 2026-06-07 "server temporarily down" restart loop (root cause #4 in the post-mortem).
+
+## What already happened
+
+PR #972 already converted the worst offender (the SessionWatchdog) to run those scans *asynchronously*, so they yield the event loop instead of freezing it. But nothing stopped the pattern from creeping back into a new monitor. That's what this check is for.
+
+## What this adds
+
+A CI lint: in the runtime directories (`src/monitoring`, `src/server`), a synchronous `ps`/`pgrep`/`lsof`/`pkill` call now fails the build. The fix is to use the async version (`execFileAsync`), which doesn't block the event loop.
+
+## The escape hatch
+
+A genuinely one-shot, bounded call (not on a timer) can opt out with a one-line comment explaining why: `// lint-allow-blocking-scan: <reason>`. It requires a written reason, so the exception is a reviewed decision, not a silent one. Two existing `lsof` calls use this — one is a targeted single-process check during recovery; the other is in a reaper that ships off-by-default.
+
+## What it does NOT cover
+
+It deliberately ignores tmux and git calls (those are fast and bounded — not the load-sensitive enumeration commands this incident was about), and it can't catch a scan whose command is passed through a variable. It's a ratchet against the common, easy-to-copy mistake, not a complete static proof.
+
+## Why a lint and not just a note
+
+Structure > Willpower: a comment in a doc is a wish; a build check is a guarantee. A future periodic `spawnSync('ps')` now fails CI instead of being discovered as a production stall.
+
+## Evidence
+
+`tests/unit/lint-no-blocking-process-scans.test.ts` (5 tests): flags a sync `ps`; flags `spawnSync('pgrep')` and `execSync('lsof …')`; honours the inline allow comment; ignores comment-only mentions and async/tmux calls; the real tree is clean. CI-only change; no runtime behavior change (the two source edits are comments).

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "test:contract": "node scripts/run-contract-tests.js",
     "test:contract:raw": "vitest run --config vitest.contract.config.ts",
     "test:all": "vitest run && vitest run --config vitest.integration.config.ts && vitest run --config vitest.e2e.config.ts",
-    "lint": "tsc --noEmit && node scripts/lint-no-direct-destructive.js && node scripts/lint-no-direct-llm-http.js && node scripts/lint-no-direct-url-log.js && node scripts/lint-no-unfunneled-topic-creation.js && node scripts/lint-no-unfunneled-headless-launch.js && node scripts/lint-state-registry.js && node scripts/lint-cas-emit-placement.js && node scripts/lint-journal-actuation-ban.js && node scripts/check-codex-rule1-drift.js",
+    "lint": "tsc --noEmit && node scripts/lint-no-direct-destructive.js && node scripts/lint-no-direct-llm-http.js && node scripts/lint-no-direct-url-log.js && node scripts/lint-no-unfunneled-topic-creation.js && node scripts/lint-no-unfunneled-headless-launch.js && node scripts/lint-state-registry.js && node scripts/lint-cas-emit-placement.js && node scripts/lint-journal-actuation-ban.js && node scripts/lint-no-blocking-process-scans.js && node scripts/check-codex-rule1-drift.js",
     "lint:destructive": "node scripts/lint-no-direct-destructive.js",
     "lint:destructive:staged": "node scripts/lint-no-direct-destructive.js --staged",
     "lint:llm-http": "node scripts/lint-no-direct-llm-http.js",

--- a/scripts/lint-no-blocking-process-scans.js
+++ b/scripts/lint-no-blocking-process-scans.js
@@ -1,0 +1,115 @@
+#!/usr/bin/env node
+/**
+ * lint-no-blocking-process-scans.js — refuses SYNCHRONOUS process-enumeration
+ * scans (`ps`/`pgrep`/`lsof`/`pkill`) on the runtime hot path.
+ *
+ * Earned 2026-06-07 (topic 21816 post-mortem, docs/postmortems/2026-06-07-server-temporarily-down.md).
+ * Root cause #4 of the "server temporarily down" incident: monitors ran
+ * `spawnSync('ps' …)` / `execFileSync('lsof' …)` on a cadence. A single-threaded
+ * Node process BLOCKS its event loop for the duration of a synchronous child
+ * process — and `ps`/`lsof` get slow under CPU/IO load, exactly when monitors
+ * fire most. The cumulative stall starved `/health`, which made the supervisor
+ * declare the (alive) server unresponsive and restart it → the restart loop.
+ * #972 converted SessionWatchdog to async; this lint stops the class from being
+ * RE-INTRODUCED anywhere in the runtime dirs.
+ *
+ * Rule: in src/monitoring/ and src/server/, no synchronous child-process call
+ * (`spawnSync` / `execSync` / `execFileSync`) may invoke a process-enumeration
+ * command (`ps`, `pgrep`, `lsof`, `pkill`) given as a string literal. Use the
+ * async equivalent (`promisify(execFile)` / `execFileAsync`) so the scan yields
+ * the event loop. tmux/git/etc. calls are NOT covered (they are bounded and not
+ * the load-sensitive enumeration commands this incident was about).
+ *
+ * Escape hatch (closed, reviewed): a genuinely one-shot, bounded call that
+ * cannot run on a cadence may carry an inline justification comment on the same
+ * line or the line directly above:
+ *     // lint-allow-blocking-scan: <why this can't run periodically>
+ *
+ * Exit codes: 0 — clean; 1 — at least one violation.
+ *
+ * Usage:
+ *   node scripts/lint-no-blocking-process-scans.js            # full repo
+ *   node scripts/lint-no-blocking-process-scans.js --staged   # staged files
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { execSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const ROOT = path.resolve(path.dirname(__filename), '..');
+
+// Only the runtime hot dirs — where a periodic monitor stalling the loop is the
+// documented failure. (src/core has tmux-heavy session plumbing that is a
+// separate, bigger conversion tracked in the post-mortem follow-up.)
+const SCAN_DIRS = ['src/monitoring', 'src/server'];
+const EXTENSIONS = new Set(['.ts', '.tsx', '.js', '.mjs', '.cjs']);
+
+// A synchronous child-process call whose command literal is a process-scan tool.
+// Matches e.g.  spawnSync('pgrep', …)   execFileSync('lsof', …)   execSync('ps …')
+const VIOLATION = /\b(spawnSync|execSync|execFileSync)\s*\(\s*['"`]\s*(ps|pgrep|lsof|pkill)\b/;
+const ALLOW = /lint-allow-blocking-scan:/;
+
+const inScanDir = (p) => SCAN_DIRS.some((d) => p.startsWith(d + '/'));
+
+function listFiles() {
+  if (process.argv.includes('--staged')) {
+    const out = execSync('git diff --cached --name-only', { cwd: ROOT, encoding: 'utf-8' });
+    // Only the runtime hot dirs are enforced for staged scans.
+    return out.split('\n').filter(Boolean).filter((p) => inScanDir(p.split(path.sep).join('/')));
+  }
+  // Explicit file args are checked as-given (targeted use / self-tests).
+  const explicit = process.argv.slice(2).filter((a) => !a.startsWith('--'));
+  if (explicit.length) return explicit;
+
+  const files = [];
+  const walk = (dir) => {
+    let entries;
+    try { entries = fs.readdirSync(dir, { withFileTypes: true }); } catch { return; }
+    for (const e of entries) {
+      if (e.name === 'node_modules' || e.name === '.git' || e.name === 'dist') continue;
+      const full = path.join(dir, e.name);
+      if (e.isDirectory()) walk(full);
+      else if (EXTENSIONS.has(path.extname(e.name))) files.push(path.relative(ROOT, full));
+    }
+  };
+  for (const d of SCAN_DIRS) walk(path.join(ROOT, d));
+  return files;
+}
+
+let violations = 0;
+for (const rel of listFiles()) {
+  const normalized = rel.split(path.sep).join('/');
+  if (!EXTENSIONS.has(path.extname(normalized))) continue;
+  const full = path.isAbsolute(normalized) ? normalized : path.join(ROOT, normalized);
+  let content;
+  try { content = fs.readFileSync(full, 'utf-8'); } catch { continue; }
+  const lines = content.split('\n');
+  for (let i = 0; i < lines.length; i++) {
+    const trimmed = lines[i].trimStart();
+    if (/^(\/\/|\*|\/\*)/.test(trimmed)) continue; // comment-only mention
+    if (!VIOLATION.test(lines[i])) continue;
+    // Inline justification on this line or within the comment block directly
+    // above (scan back up to 4 lines so a multi-line reason is honoured).
+    let allowed = false;
+    for (let j = i; j >= Math.max(0, i - 6); j--) {
+      if (ALLOW.test(lines[j])) { allowed = true; break; }
+    }
+    if (allowed) continue;
+    console.error(
+      `${normalized}:${i + 1} — synchronous process scan (ps/pgrep/lsof/pkill) on the runtime hot path. ` +
+      `Blocks the event loop and starves /health under load (topic 21816 root cause #4). ` +
+      `Use an async exec (promisify(execFile)/execFileAsync), or, if it is a genuinely one-shot bounded call, ` +
+      `add an inline "// lint-allow-blocking-scan: <reason>".`,
+    );
+    violations++;
+  }
+}
+
+if (violations > 0) {
+  console.error(`\nlint-no-blocking-process-scans: ${violations} violation(s). ` +
+    `See docs/postmortems/2026-06-07-server-temporarily-down.md (root cause #4).`);
+  process.exit(1);
+}
+console.log('lint-no-blocking-process-scans: clean');

--- a/scripts/lint-no-direct-destructive.js
+++ b/scripts/lint-no-direct-destructive.js
@@ -77,6 +77,9 @@ const ALLOWLIST = new Set([
   // Same bootstrap-escape pattern (june15-headless-spawn-reroute funnel
   // lint) — read-only `git diff --cached --name-only` only.
   'scripts/lint-no-unfunneled-headless-launch.js',
+  // Same bootstrap-escape pattern (blocking-process-scan lint, topic 21816
+  // post-mortem #3) — read-only `git diff --cached --name-only` only.
+  'scripts/lint-no-blocking-process-scans.js',
   // Postinstall bootstrap script — runs before TypeScript is compiled and
   // before SafeFsExecutor is available. CommonJS, can't use ESM imports.
   'scripts/fix-better-sqlite3.cjs',

--- a/src/monitoring/SessionRecovery.ts
+++ b/src/monitoring/SessionRecovery.ts
@@ -768,6 +768,10 @@ export class SessionRecovery extends EventEmitter {
       const pid = this.deps.getPanePid(sessionName);
       if (pid) {
         try {
+          // lint-allow-blocking-scan: targeted `lsof -p <pid>` (one specific process,
+          // not a full enumeration), 5s timeout, runs once during a session's JSONL
+          // recovery — not on a cadence, so it can't starve /health the way the #972
+          // every-tick scans did.
           const output = execFileSync('lsof', ['-p', String(pid), '-Fn'], {
             encoding: 'utf-8',
             timeout: 5000,

--- a/src/monitoring/agentWorktreeGit.ts
+++ b/src/monitoring/agentWorktreeGit.ts
@@ -100,6 +100,10 @@ export function makeAgentWorktreeReaperDeps(opts: {
   const defaultCwdRoots = (): Set<string> => {
     const roots = new Set<string>();
     let out: string;
+    // lint-allow-blocking-scan: AgentWorktreeReaper ships dark + dry-run + reviewed
+    // (off by default), so this full-cwd `lsof` is not on any live agent's hot path;
+    // bounded by a 15s timeout. Async conversion is tracked as a post-mortem
+    // follow-up (docs/postmortems/2026-06-07-server-temporarily-down.md, root cause #4).
     try {
       out = execFileSync('lsof', ['-w', '-d', 'cwd', '-Fn'], { encoding: 'utf-8', timeout: 15_000, maxBuffer: 32 * 1024 * 1024 });
     } catch { return roots; } // @silent-fallback-ok — no cwd signal ⇒ rely on locks

--- a/tests/unit/lint-no-blocking-process-scans.test.ts
+++ b/tests/unit/lint-no-blocking-process-scans.test.ts
@@ -1,0 +1,102 @@
+// Self-test for the blocking-process-scan lint (topic 21816 post-mortem, root
+// cause #4): a synchronous ps/pgrep/lsof/pkill on the runtime hot path blocks
+// the event loop and starves /health under load. The lint must flag a fresh
+// sync scan, honour an inline justification, ignore comment-only mentions and
+// async/tmux calls, and stay clean on the real tree.
+import { describe, it, expect, afterEach } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { fileURLToPath } from 'node:url';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const REPO_ROOT = path.resolve(path.dirname(__filename), '..', '..');
+const LINT_SCRIPT = path.join(REPO_ROOT, 'scripts', 'lint-no-blocking-process-scans.js');
+
+interface RunResult { code: number; stdout: string; stderr: string }
+
+function runLint(...args: string[]): RunResult {
+  try {
+    const stdout = execFileSync('node', [LINT_SCRIPT, ...args], {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    return { code: 0, stdout, stderr: '' };
+  } catch (err) {
+    const e = err as { status?: number; stdout?: string; stderr?: string };
+    return { code: e.status ?? 1, stdout: e.stdout ?? '', stderr: e.stderr ?? '' };
+  }
+}
+
+const tmpFiles: string[] = [];
+function tmpFixture(body: string): string {
+  const file = path.join(
+    fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'scanlint-'))),
+    'fixture.ts',
+  );
+  fs.writeFileSync(file, body);
+  tmpFiles.push(file);
+  return file;
+}
+
+afterEach(() => {
+  for (const f of tmpFiles.splice(0)) {
+    try {
+      SafeFsExecutor.safeRmSync(path.dirname(f), {
+        recursive: true,
+        force: true,
+        operation: 'tests/unit/lint-no-blocking-process-scans.test.ts:cleanup',
+      });
+    } catch { /* best-effort */ }
+  }
+});
+
+describe('lint-no-blocking-process-scans', () => {
+  it('flags a synchronous ps scan', () => {
+    const fx = tmpFixture(
+      `import { execFileSync } from 'node:child_process';\n` +
+      `export const out = execFileSync('ps', ['aux']);\n`,
+    );
+    const r = runLint(fx);
+    expect(r.code).toBe(1);
+    expect(r.stderr).toContain('synchronous process scan');
+  });
+
+  it('flags spawnSync pgrep and execSync lsof too', () => {
+    const fx = tmpFixture(
+      `import { spawnSync, execSync } from 'node:child_process';\n` +
+      `export const a = spawnSync('pgrep', ['-x', 'foo']);\n` +
+      `export const b = execSync('lsof -p 123');\n`,
+    );
+    const r = runLint(fx);
+    expect(r.code).toBe(1);
+  });
+
+  it('honours an inline lint-allow-blocking-scan justification', () => {
+    const fx = tmpFixture(
+      `import { execFileSync } from 'node:child_process';\n` +
+      `// lint-allow-blocking-scan: one-shot, bounded, not on a cadence\n` +
+      `export const out = execFileSync('lsof', ['-p', '1']);\n`,
+    );
+    const r = runLint(fx);
+    expect(r.code).toBe(0);
+  });
+
+  it('does NOT flag comment-only mentions or async/tmux calls', () => {
+    const fx = tmpFixture(
+      `import { execFile } from 'node:child_process';\n` +
+      `// we used to call execFileSync('ps', ...) here — now async\n` +
+      `export const x = execFile('tmux', ['list-sessions']);\n`,
+    );
+    const r = runLint(fx);
+    expect(r.code).toBe(0);
+  });
+
+  it('the real runtime tree (src/monitoring + src/server) is clean', () => {
+    const r = runLint();
+    expect(r.stderr).toBe('');
+    expect(r.code).toBe(0);
+  });
+});

--- a/upgrades/next/lint-no-blocking-process-scans.md
+++ b/upgrades/next/lint-no-blocking-process-scans.md
@@ -1,0 +1,40 @@
+<!-- bump: patch -->
+<!-- change_type: fix -->
+
+## What Changed
+
+New CI lint `scripts/lint-no-blocking-process-scans.js` (wired into `npm run lint`):
+in `src/monitoring/` and `src/server/`, a synchronous `ps`/`pgrep`/`lsof`/`pkill`
+call (`spawnSync`/`execSync`/`execFileSync` with a literal command) now fails the
+build. This is post-mortem standard #3 from the 2026-06-07 "server temporarily
+down" incident (topic 21816): synchronous process-enumeration scans on a cadence
+blocked the event loop and starved `/health` under load, which made the supervisor
+restart an alive server → the restart loop. #972 fixed the SessionWatchdog; this
+lint stops the class from being re-introduced anywhere in the runtime dirs.
+
+## What to Tell Your User
+
+Internal hardening — nothing user-visible. It makes a specific cause of the
+"server temporarily down under load" problem impossible to reintroduce.
+
+## Summary of New Capabilities
+
+- `npm run lint` now fails on a synchronous process scan in the runtime hot dirs.
+  Use the async exec (`promisify(execFile)`/`execFileAsync`) instead, or — for a
+  genuinely one-shot bounded call — add an inline `// lint-allow-blocking-scan:
+  <reason>` (a written, reviewed exception).
+
+## Scope (honest)
+
+CI-only; no runtime behavior change (the two source edits are comment annotations
+allowlisting existing bounded `lsof` one-shots). Does not cover tmux/git calls
+(bounded, out of scope) or scans whose command is passed via a variable
+(pre-existing, tracked). A ratchet, not a complete static proof.
+
+## Evidence
+
+`tests/unit/lint-no-blocking-process-scans.test.ts` (5 tests, all passing); the
+lint runs clean on the real tree and flags synthetic violations. tsc clean.
+causalAutopsy: incident-derived — direct implementation of post-mortem standard #3
+(docs/postmortems/2026-06-07-server-temporarily-down.md, root cause #4); the prior
+#972 fix addressed one offender, this prevents recurrence of the class.

--- a/upgrades/side-effects/lint-no-blocking-process-scans.md
+++ b/upgrades/side-effects/lint-no-blocking-process-scans.md
@@ -1,0 +1,73 @@
+# Side-Effects Review — lint: ban blocking process scans on the runtime hot path
+
+**Version / slug:** `lint-no-blocking-process-scans`
+**Date:** `2026-06-07`
+**Author:** `Echo`
+**Tier:** 1 (a new CI lint + comment-only src annotations + a test; no behavior change, no API/route/config/migration)
+**Second-pass reviewer:** `Echo (self) — Tier-1; preventive gate, no runtime behavior change`
+
+## Summary of the change
+
+Adds `scripts/lint-no-blocking-process-scans.js` (wired into `npm run lint`): in
+`src/monitoring/` and `src/server/`, a SYNCHRONOUS child-process call
+(`spawnSync`/`execSync`/`execFileSync`) whose command literal is a process-
+enumeration tool (`ps`/`pgrep`/`lsof`/`pkill`) now fails CI. This is post-mortem
+standard #3 for the 2026-06-07 "server temporarily down" incident (topic 21816):
+synchronous `ps`/`lsof` scans on a cadence blocked the event loop and starved
+`/health` under load → the supervisor restarted an alive server → the loop.
+#972 fixed SessionWatchdog; this lint stops the class from being re-introduced.
+
+The two existing in-dir call sites are `lsof` one-shots, allowlisted with inline
+`// lint-allow-blocking-scan:` justifications (comment-only edits):
+- `SessionRecovery.ts` — targeted `lsof -p <pid>` (single process, 5s timeout),
+  runs once during a session's JSONL recovery, not on a cadence.
+- `agentWorktreeGit.ts` — full-cwd `lsof` in AgentWorktreeReaper, which ships
+  dark + dry-run by default (not on any live agent's hot path); 15s timeout;
+  async conversion noted as a follow-up.
+
+## Decision-point inventory
+
+- The only decision: which sync calls to fail CI on. Scoped to the documented
+  load-sensitive enumeration commands (`ps`/`pgrep`/`lsof`/`pkill`) in the two
+  runtime hot dirs. tmux/git calls are deliberately NOT covered (bounded, fast,
+  ubiquitous — converting them is a separate, bigger concern and not this
+  incident's cause).
+
+## 1. False positives (flagging a safe call)
+
+A genuinely one-shot, bounded sync scan is excused by an inline
+`// lint-allow-blocking-scan: <reason>` (scanned up to 6 lines above the call to
+allow a multi-line justification). The escape hatch requires a written reason, so
+the decision is reviewed, not silent. Two current sites use it.
+
+## 2. False negatives (missing a real one)
+
+Static detection matches a string-literal command. A sync scan that passes the
+command via a variable (e.g. `execFileSync(file, args)` in `mcpProcessReaperDeps`)
+is not caught — accepted: the lint is a ratchet against the common, copy-pasted
+literal form; the variable-indirection cases are pre-existing and tracked. tmux
+is intentionally out of scope.
+
+## 3. Level-of-abstraction fit
+
+Correct: a CI lint in the existing `lint-no-*` family, modeled on
+`lint-no-unfunneled-headless-launch.js`. Structure > Willpower — a future periodic
+`spawnSync('ps')` fails the build instead of being discovered as a stall in prod.
+
+## 4. Blast radius
+
+CI-only. No runtime code changes (the two src edits are comments). Cannot affect a
+running agent. Worst case of a bug in the lint = a spurious CI failure, fixed by an
+allowlist comment or a lint tweak — never a production impact.
+
+## 5. Rollback
+
+Remove the script + the one `package.json` chain entry; revert the two comment
+annotations. No state/format change.
+
+## 6. Tests
+
+`tests/unit/lint-no-blocking-process-scans.test.ts` (5): flags sync ps; flags
+spawnSync pgrep + execSync lsof; honours the inline allow justification; ignores
+comment-only mentions + async/tmux calls; the real runtime tree is clean. The lint
+also self-validated against a synthetic violation. tsc clean.


### PR DESCRIPTION
## ELI16

The server is single-threaded, so when it runs a slow command like `ps` or `lsof` and waits for it, it can't do anything else — including answer "am I alive?". Under load those get slow, the health check times out, and the watchdog restarts a server that was actually fine. That was a direct contributor to the 2026-06-07 "server temporarily down" restart loop. This adds a build check so that pattern can't be re-introduced into the runtime monitors.

## What this is

Post-mortem standard #3 (topic 21816, root cause #4). New CI lint `scripts/lint-no-blocking-process-scans.js` (wired into `npm run lint`): in `src/monitoring/` and `src/server/`, a synchronous `spawnSync`/`execSync`/`execFileSync` of a literal `ps`/`pgrep`/`lsof`/`pkill` fails CI. The fix is the async exec (`execFileAsync`), which yields the event loop. #972 already converted the worst offender (SessionWatchdog); this stops the class from creeping back.

**Escape hatch:** a genuinely one-shot bounded call may carry an inline `// lint-allow-blocking-scan: <reason>` (a written, reviewed exception). Two existing `lsof` one-shots use it (SessionRecovery's targeted `lsof -p <pid>`; agentWorktreeGit's full-cwd lsof in the dark/dry-run AgentWorktreeReaper — async conversion is a tracked follow-up).

**Out of scope:** tmux/git calls (bounded, fast) and scans whose command is passed via a variable. A ratchet, not a complete static proof.

## Tier / scope

Tier 1 — CI-only, no runtime behavior change (the two src edits are comment annotations). Also added to `lint-no-direct-destructive`'s allowlist for its own read-only `git diff --cached` bootstrap, same as the other lint scripts.

## Tests

`tests/unit/lint-no-blocking-process-scans.test.ts` (5): flags sync `ps`; flags `spawnSync('pgrep')` + `execSync('lsof …')`; honours the inline allow comment; ignores comment-only mentions + async/tmux; real tree clean. `tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)