### PR TITLE
fix(exo3): close 3 harness-surfaced capability bugs (passport-verify 500, tradeoff parser, learning-velocity sources)

### DIFF
--- a/.instar/instar-dev-decisions/2026-06-07T23-26-28-511Z-exo3-harness-gap-fixes.json
+++ b/.instar/instar-dev-decisions/2026-06-07T23-26-28-511Z-exo3-harness-gap-fixes.json
@@ -1,0 +1,16 @@
+{
+  "ts": "2026-06-07T23:26:28.511Z",
+  "slug": "exo3-harness-gap-fixes",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 3,
+  "loc": 68,
+  "causalAutopsy": {
+    "origin": "latent",
+    "notes": "All three are latent bugs surfaced by the new exo3-harness from-every-angle probing. They shipped because the existing tests encoded the SAME wrong assumptions as the code: the learning-velocity integration test wrote fixtures to the buggy paths (so route+test were wrong together and stayed green); the passport tests always sent complete passports via buildPassport (never a partial peer card); the org-intent tests never exercised the documented chained tradeoff format. The harness broke that symmetry by hitting the real endpoints with realistic + adversarial inputs."
+  },
+  "verdict": "pass"
+}

--- a/src/core/AgentPassport.ts
+++ b/src/core/AgentPassport.ts
@@ -91,7 +91,14 @@ export function buildPassport(input: PassportInput): AgentPassport {
  * capability-scope (if scoped, the action must be in scope) → ok.
  */
 export function permits(passport: AgentPassport, action: string): PermitVerdict {
-  for (const f of passport.forbiddenActions) {
+  // A passport supplied by a PEER may be partial/malformed — its whole purpose is
+  // that another agent reads it. Default the array fields so a missing field yields
+  // a verdict, never a crash (was: HTTP 500 "Cannot read properties of undefined
+  // (reading 'length')" when allowedCapabilities was omitted; forbiddenActions was
+  // likewise unguarded → "not iterable"). See exo3-harness passport-verify-robustness.
+  const forbiddenActions = passport.forbiddenActions ?? [];
+  const allowedCapabilities = passport.allowedCapabilities ?? [];
+  for (const f of forbiddenActions) {
     if (overlap(action, f) >= MATCH) {
       return { permitted: false, basis: 'forbidden-action', reason: `Forbidden by the passport: "${f}".`, matched: f };
     }
@@ -99,8 +106,8 @@ export function permits(passport: AgentPassport, action: string): PermitVerdict 
   if (passport.trustLevel === 'untrusted' && isActing(action)) {
     return { permitted: false, basis: 'trust-floor', reason: 'Untrusted passport may observe but not act.' };
   }
-  if (passport.allowedCapabilities.length > 0) {
-    const inScope = passport.allowedCapabilities.some((c) => overlap(action, c) >= MATCH);
+  if (allowedCapabilities.length > 0) {
+    const inScope = allowedCapabilities.some((c) => overlap(action, c) >= MATCH);
     if (!inScope) {
       return { permitted: false, basis: 'out-of-scope', reason: 'Action is outside the passport\'s allowed capabilities.' };
     }

--- a/src/core/OrgIntentManager.ts
+++ b/src/core/OrgIntentManager.ts
@@ -280,7 +280,20 @@ export class OrgIntentManager {
       : [];
 
     const values = valuesSection ? extractListItems(valuesSection) : [];
-    const tradeoffHierarchy = tradeoffSection ? extractListItems(tradeoffSection) : [];
+    let tradeoffHierarchy = tradeoffSection ? extractListItems(tradeoffSection) : [];
+    // The Tradeoff Hierarchy is documented (and scaffolded by `instar intent org-init`)
+    // as a single chained line — "Safety > Operator trust > Correctness > ..." — not a
+    // bulleted list, so extractListItems returns []. Accept the chained form too so the
+    // resolver actually sees the order. (exo3-harness mtp-tradeoff: was "no hierarchy".)
+    if (tradeoffHierarchy.length === 0 && tradeoffSection) {
+      const chain = tradeoffSection
+        .replace(/<!--[\s\S]*?-->/g, '')
+        .split('\n').map(l => l.trim()).filter(Boolean)
+        .find(l => /[>›»]/.test(l));
+      if (chain) {
+        tradeoffHierarchy = chain.split(/\s*[>›»]\s*/).map(s => s.trim()).filter(Boolean);
+      }
+    }
     const identity = parseIdentityLayer(raw) ?? undefined;
 
     // If all sections are empty after parsing, treat as template-only

--- a/src/server/routes.ts
+++ b/src/server/routes.ts
@@ -5194,34 +5194,42 @@ export function createRoutes(ctx: RouteContext): Router {
       const path = await import('node:path');
       const events: { timestamp: string; type: string }[] = [];
       const tsField = (o: Record<string, unknown>): unknown =>
-        o.createdAt ?? o.timestamp ?? o.date ?? o.ts ?? o.loggedAt ?? o.addedAt;
+        o.createdAt ?? o.timestamp ?? o.date ?? o.ts ?? o.loggedAt ?? o.addedAt ?? o.discoveredAt;
       const push = (ts: unknown, type: string) => {
         if (ts === undefined || ts === null) return;
         const iso = typeof ts === 'number' ? new Date(ts).toISOString() : String(ts);
         events.push({ timestamp: iso, type });
       };
-      // learning-registry.json → registered learnings
+      // (1) Registered learnings — EvolutionManager writes to state/evolution/, and the
+      // timestamp lives at source.discoveredAt (not a top-level field). The old path
+      // (stateDir/learning-registry.json) and top-level tsField both missed → 0 events.
       try {
-        const p = path.join(ctx.config.stateDir, 'learning-registry.json');
+        const p = path.join(ctx.config.stateDir, 'state', 'evolution', 'learning-registry.json');
         if (fs.existsSync(p)) {
           const reg = JSON.parse(fs.readFileSync(p, 'utf-8'));
-          for (const l of (reg.learnings ?? [])) push(tsField(l), 'learning');
+          for (const l of (reg.learnings ?? [])) {
+            const src = (l && typeof l === 'object' ? (l as Record<string, unknown>).source : null) as Record<string, unknown> | null;
+            push(src?.discoveredAt ?? tsField(l), 'learning');
+          }
         }
       } catch { /* skip unreadable source */ }
-      // best-effort JSONL sources
-      const jsonlSources: [string, string][] = [
-        ['state/corrections.jsonl', 'correction'],
-        ['logs/evolution-actions.jsonl', 'evolution'],
-      ];
-      for (const [rel, type] of jsonlSources) {
+      // (2) Evolution actions — a JSON array under .actions (each with top-level
+      // createdAt), NOT a logs/*.jsonl stream.
+      try {
+        const p = path.join(ctx.config.stateDir, 'state', 'evolution', 'action-queue.json');
+        if (fs.existsSync(p)) {
+          const aq = JSON.parse(fs.readFileSync(p, 'utf-8'));
+          for (const a of (aq.actions ?? [])) push(tsField(a), 'evolution');
+        }
+      } catch { /* skip unreadable source */ }
+      // (3) Corrections — persisted in the SQLite CorrectionLedger, not a JSONL file.
+      // Guarded: correctionLearning ships off on many agents (ledger may be absent).
+      if (ctx.correctionLedger) {
         try {
-          const p = path.join(ctx.config.stateDir, rel);
-          if (!fs.existsSync(p)) continue;
-          for (const line of fs.readFileSync(p, 'utf-8').split('\n')) {
-            if (!line.trim()) continue;
-            try { push(tsField(JSON.parse(line)), type); } catch { /* skip bad line */ }
+          for (const r of ctx.correctionLedger.list({ limit: 1000 })) {
+            push((r as { detectedAt?: string; createdAt?: string }).detectedAt ?? (r as { createdAt?: string }).createdAt, 'correction');
           }
-        } catch { /* skip unreadable source */ }
+        } catch { /* skip ledger error */ }
       }
       res.json(computeLearningVelocity(events, new Date().toISOString(), windowDays));
     } catch (err) {

--- a/tests/e2e/learning-velocity-lifecycle.test.ts
+++ b/tests/e2e/learning-velocity-lifecycle.test.ts
@@ -33,11 +33,15 @@ describe('GET /metrics/learning-velocity — (E2E over HTTP)', () => {
   beforeEach(async () => {
     tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'learnvel-e2e-'));
     stateDir = path.join(tmpDir, '.instar');
-    fs.mkdirSync(stateDir, { recursive: true });
-    fs.writeFileSync(path.join(stateDir, 'learning-registry.json'), JSON.stringify({
+    // Seed the REAL learnings source the live agent writes: state/evolution/
+    // learning-registry.json with the timestamp at source.discoveredAt (not a
+    // top-level field, not stateDir root). Mirrors the route + integration test.
+    const evoDir = path.join(stateDir, 'state', 'evolution');
+    fs.mkdirSync(evoDir, { recursive: true });
+    fs.writeFileSync(path.join(evoDir, 'learning-registry.json'), JSON.stringify({
       learnings: [
-        { createdAt: agoIso(18) }, { createdAt: agoIso(12) },
-        { createdAt: agoIso(6) }, { createdAt: agoIso(2) },
+        { source: { discoveredAt: agoIso(18) } }, { source: { discoveredAt: agoIso(12) } },
+        { source: { discoveredAt: agoIso(6) } }, { source: { discoveredAt: agoIso(2) } },
       ],
     }));
     const app = express();

--- a/tests/integration/learning-velocity-routes.test.ts
+++ b/tests/integration/learning-velocity-routes.test.ts
@@ -1,8 +1,16 @@
 /**
  * Integration tests for GET /metrics/learning-velocity (EXO 3.0 KPI inversion).
- * Tier-2: the route over the real HTTP pipeline, reading a real
- * learning-registry.json from file-based state. Fixture timestamps are anchored
- * to the actual "now" (the route uses real time) so they land inside the window.
+ * Tier-2: the route over the real HTTP pipeline, reading the REAL learning sources
+ * from file-based state — the same paths/shapes the live agent writes:
+ *   - registered learnings: state/evolution/learning-registry.json (ts at source.discoveredAt)
+ *   - evolution actions:     state/evolution/action-queue.json  (.actions[].createdAt)
+ *   - corrections:           the SQLite CorrectionLedger (ctx.correctionLedger.list())
+ * Fixture timestamps are anchored to the actual "now" so they land inside the window.
+ *
+ * Regression: a prior version of this test (and the route) used the WRONG paths
+ * (stateDir/learning-registry.json + state/corrections.jsonl + logs/evolution-actions.jsonl)
+ * — none of which the live agent writes — so the metric read 0 events on real agents
+ * while the test stayed green. See exo3-harness learning-velocity finding.
  */
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
@@ -18,11 +26,12 @@ import type { RouteContext } from '../../src/server/routes.js';
 const DAY = 24 * 60 * 60 * 1000;
 const agoIso = (days: number) => new Date(Date.now() - days * DAY).toISOString();
 
-function ctxFor(stateDir: string): RouteContext {
+function ctxFor(stateDir: string, corrections: { detectedAt: string }[] = []): RouteContext {
   return {
     config: { projectName: 'echo', projectDir: path.dirname(stateDir), stateDir, port: 0 } as any,
     sessionManager: { listRunningSessions: () => [] } as any,
     state: { getJobState: () => null, getSession: () => null } as any,
+    correctionLedger: corrections.length ? ({ list: () => corrections } as any) : null,
     scheduler: null, telegram: null, relationships: null, feedback: null, dispatches: null,
     updateChecker: null, autoUpdater: null, autoDispatcher: null, quotaTracker: null,
     publisher: null, viewer: null, tunnel: null, evolution: null, watchdog: null,
@@ -31,55 +40,84 @@ function ctxFor(stateDir: string): RouteContext {
   } as any;
 }
 
+function evoDir(stateDir: string): string {
+  const d = path.join(stateDir, 'state', 'evolution');
+  fs.mkdirSync(d, { recursive: true });
+  return d;
+}
+
 describe('GET /metrics/learning-velocity (integration)', () => {
-  let tmpDir: string, stateDir: string, app: express.Express;
+  let tmpDir: string, stateDir: string;
 
   beforeEach(() => {
     tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'learnvel-test-'));
     stateDir = path.join(tmpDir, '.instar');
     fs.mkdirSync(path.join(stateDir, 'state'), { recursive: true });
-    app = express();
-    app.use(express.json());
-    app.use('/', createRoutes(ctxFor(stateDir)));
   });
 
-  afterEach(() => { SafeFsExecutor.safeRmSync(tmpDir, { recursive: true, force: true, operation: 'tests/integration/learning-velocity-routes.test.ts:45' }); });
+  afterEach(() => { SafeFsExecutor.safeRmSync(tmpDir, { recursive: true, force: true, operation: 'tests/integration/learning-velocity-routes.test.ts' }); });
+
+  function appWith(corrections: { detectedAt: string }[] = []): express.Express {
+    const app = express();
+    app.use(express.json());
+    app.use('/', createRoutes(ctxFor(stateDir, corrections)));
+    return app;
+  }
 
   it('returns zero + insufficient-data when there are no learning sources', async () => {
-    const res = await request(app).get('/metrics/learning-velocity');
+    const res = await request(appWith()).get('/metrics/learning-velocity');
     expect(res.status).toBe(200);
     expect(res.body.totalEvents).toBe(0);
     expect(res.body.trend).toBe('insufficient-data');
   });
 
-  it('reads learnings from learning-registry.json and computes velocity', async () => {
-    fs.writeFileSync(path.join(stateDir, 'learning-registry.json'), JSON.stringify({
+  it('reads learnings (source.discoveredAt), evolution actions, and corrections', async () => {
+    // (1) registered learnings — timestamp at source.discoveredAt (the real shape)
+    fs.writeFileSync(path.join(evoDir(stateDir), 'learning-registry.json'), JSON.stringify({
       learnings: [
-        { createdAt: agoIso(20), content: 'a' },
-        { createdAt: agoIso(15), content: 'b' },
-        { createdAt: agoIso(8), content: 'c' },
-        { createdAt: agoIso(3), content: 'd' },
+        { id: 'LRN-1', source: { discoveredAt: agoIso(20) } },
+        { id: 'LRN-2', source: { discoveredAt: agoIso(15) } },
+        { id: 'LRN-3', source: { discoveredAt: agoIso(8) } },
       ],
     }));
-    // a correction in the recent half too
-    fs.writeFileSync(path.join(stateDir, 'state', 'corrections.jsonl'),
-      JSON.stringify({ timestamp: agoIso(2), pattern: 'x' }) + '\n');
+    // (2) evolution actions — JSON array under .actions, top-level createdAt
+    fs.writeFileSync(path.join(evoDir(stateDir), 'action-queue.json'), JSON.stringify({
+      actions: [
+        { id: 'ACT-1', createdAt: agoIso(10) },
+        { id: 'ACT-2', createdAt: agoIso(2) },
+      ],
+    }));
+    // (3) corrections — from the SQLite ledger (mocked), detectedAt
+    const res = await request(appWith([{ detectedAt: agoIso(1) }])).get('/metrics/learning-velocity?windowDays=30');
 
-    const res = await request(app).get('/metrics/learning-velocity?windowDays=30');
     expect(res.status).toBe(200);
-    expect(res.body.totalEvents).toBe(5);
-    expect(res.body.byType.learning).toBe(4);
+    expect(res.body.totalEvents).toBe(6);
+    expect(res.body.byType.learning).toBe(3);
+    expect(res.body.byType.evolution).toBe(2);
     expect(res.body.byType.correction).toBe(1);
-    expect(res.body.typeDiversity).toBe(2);
+    expect(res.body.typeDiversity).toBe(3);
     expect(res.body.adaptabilityScore).toBeGreaterThan(0);
     expect(['accelerating', 'steady', 'declining']).toContain(res.body.trend);
   });
 
   it('excludes events outside the window', async () => {
-    fs.writeFileSync(path.join(stateDir, 'learning-registry.json'), JSON.stringify({
-      learnings: [{ createdAt: agoIso(90), content: 'old' }, { createdAt: agoIso(5), content: 'recent' }],
+    fs.writeFileSync(path.join(evoDir(stateDir), 'learning-registry.json'), JSON.stringify({
+      learnings: [
+        { id: 'old', source: { discoveredAt: agoIso(90) } },
+        { id: 'recent', source: { discoveredAt: agoIso(5) } },
+      ],
     }));
-    const res = await request(app).get('/metrics/learning-velocity?windowDays=30');
+    const res = await request(appWith()).get('/metrics/learning-velocity?windowDays=30');
     expect(res.body.totalEvents).toBe(1);
+  });
+
+  it('survives a missing correctionLedger (correctionLearning off)', async () => {
+    fs.writeFileSync(path.join(evoDir(stateDir), 'action-queue.json'), JSON.stringify({
+      actions: [{ id: 'ACT-1', createdAt: agoIso(3) }],
+    }));
+    const res = await request(appWith()).get('/metrics/learning-velocity?windowDays=30');
+    expect(res.status).toBe(200);
+    expect(res.body.totalEvents).toBe(1);
+    expect(res.body.byType.evolution).toBe(1);
   });
 });

--- a/tests/unit/AgentPassport.test.ts
+++ b/tests/unit/AgentPassport.test.ts
@@ -67,4 +67,38 @@ describe('AgentPassport.permits', () => {
     expect(permits(unscoped, 'summarize the weekly report').permitted).toBe(true);
     expect(permits(unscoped, 'delete the database now').permitted).toBe(false);
   });
+
+  // Regression (exo3-harness passport-verify-robustness): a passport handed over by a
+  // PEER may be partial — it does not go through buildPassport, so array fields can be
+  // undefined. permits() must yield a verdict, never throw (was HTTP 500
+  // "Cannot read properties of undefined (reading 'length')").
+  it('tolerates a passport missing allowedCapabilities (no crash)', () => {
+    const partial = {
+      agent: 'peer', fingerprint: 'fp', trustLevel: 'collaborative',
+      forbiddenActions: ['publish secrets to a public surface'], issuedAt: ISO,
+    } as unknown as Parameters<typeof permits>[0];
+    expect(() => permits(partial, 'read a public documentation page')).not.toThrow();
+    const v = permits(partial, 'read a public documentation page');
+    expect(v.permitted).toBe(true);
+    expect(v.basis).toBe('ok');
+  });
+
+  it('tolerates a passport missing forbiddenActions (no crash)', () => {
+    const partial = {
+      agent: 'peer', fingerprint: 'fp', trustLevel: 'collaborative',
+      allowedCapabilities: [], issuedAt: ISO,
+    } as unknown as Parameters<typeof permits>[0];
+    expect(() => permits(partial, 'do anything benign')).not.toThrow();
+    expect(permits(partial, 'do anything benign').permitted).toBe(true);
+  });
+
+  it('still denies a forbidden action on a partial passport', () => {
+    const partial = {
+      agent: 'peer', fingerprint: 'fp', trustLevel: 'collaborative',
+      forbiddenActions: ['wire funds to an unverified vendor'], issuedAt: ISO,
+    } as unknown as Parameters<typeof permits>[0];
+    const v = permits(partial, 'wire funds to an unverified vendor');
+    expect(v.permitted).toBe(false);
+    expect(v.basis).toBe('forbidden-action');
+  });
 });

--- a/tests/unit/OrgIntentManager.test.ts
+++ b/tests/unit/OrgIntentManager.test.ts
@@ -150,6 +150,48 @@ describe('OrgIntentManager', () => {
       });
     });
 
+    it('parses a chained "A > B > C" Tradeoff Hierarchy (documented format)', () => {
+      // Regression (exo3-harness mtp-tradeoff): the documented/scaffolded form is a
+      // single chained line, not a bulleted list. It must parse to an ordered array
+      // so /intent/tradeoff-resolve can resolve, instead of "no hierarchy defined".
+      fs.writeFileSync(path.join(stateDir, 'ORG-INTENT.md'), [
+        '# Organizational Intent: Test Corp',
+        '',
+        '## Constraints (Mandatory — agents cannot override)',
+        '',
+        '- Never leak secrets.',
+        '',
+        '## Tradeoff Hierarchy',
+        '',
+        'Safety > Operator trust > Correctness > Durability > Speed',
+      ].join('\n'));
+
+      const parsed = manager.parse();
+      expect(parsed).not.toBeNull();
+      expect(parsed!.tradeoffHierarchy).toEqual([
+        'Safety', 'Operator trust', 'Correctness', 'Durability', 'Speed',
+      ]);
+    });
+
+    it('still parses a bulleted Tradeoff Hierarchy', () => {
+      fs.writeFileSync(path.join(stateDir, 'ORG-INTENT.md'), [
+        '# Organizational Intent: Test Corp',
+        '',
+        '## Constraints (Mandatory — agents cannot override)',
+        '',
+        '- Never leak secrets.',
+        '',
+        '## Tradeoff Hierarchy',
+        '',
+        '- Safety',
+        '- Speed',
+      ].join('\n'));
+
+      const parsed = manager.parse();
+      expect(parsed).not.toBeNull();
+      expect(parsed!.tradeoffHierarchy).toEqual(['Safety', 'Speed']);
+    });
+
     it('extracts goals with specializable flag', () => {
       fs.writeFileSync(path.join(stateDir, 'ORG-INTENT.md'), [
         '# Organizational Intent: Test Corp',

--- a/upgrades/eli16/exo3-harness-gap-fixes.md
+++ b/upgrades/eli16/exo3-harness-gap-fixes.md
@@ -1,0 +1,33 @@
+# EXO 3.0 Harness Gap Fixes — Plain-English Overview
+
+> The one-line version: a new from-every-angle test harness for our EXO 3.0 features found three small, real bugs that shipped because the old tests checked the wrong things — this fixes all three.
+
+## The problem in one breath
+
+We built a harness that probes every EXO 3.0 capability through its real endpoint, from several angles. It surfaced three genuine bugs that were invisible before because the existing tests quietly encoded the same wrong assumptions the code had. None of them are big — but each made a real capability lie about itself.
+
+## What already exists
+
+- **Agent Passport** — a portable card that says what an agent may and may not do; a peer can check an action against it before trusting it.
+- **Org-Intent / tradeoff hierarchy** — our purpose file lists, in priority order, which value wins when two collide (Safety first, then Operator trust, and so on).
+- **Learning-velocity metric** — a read-only number meant to show how fast the agent is actually learning, by counting real learning events.
+
+## What this adds
+
+This is three surgical fixes, no new features:
+
+- **Passport verify no longer crashes on a partial card.** A peer's passport that omits a field (it didn't go through our builder) used to make the verifier throw a 500 error. Now any missing list defaults to empty, so the verifier always returns a clean yes/no verdict instead of crashing.
+- **The tradeoff hierarchy now actually parses.** Our purpose file writes the hierarchy the documented way — one line, "Safety > Operator trust > Correctness > …". The parser only understood bullet lists, so it read an empty hierarchy and the resolver said "no hierarchy defined." Now it understands the chained form too.
+- **Learning-velocity reads the real event sources.** The metric was reading three file paths the agent never actually writes to (wrong directory, wrong timestamp field, and a JSONL file for data that lives in a database). So it always reported zero. Now it reads the registered-learnings registry (with the right timestamp), the evolution action queue, and the corrections database.
+
+## The safeguards
+
+**Prevents the verifier from crashing on untrusted input.** A passport is, by design, handed over by another agent — so it must be treated as possibly-partial. Defaulting the array fields means a malformed card produces a verdict, never an exception.
+
+**Prevents silent zero-reporting.** The learning-velocity test used to write fixtures to the same wrong paths the route read, so both were wrong together and the test stayed green. The test now seeds the REAL paths and shapes the live agent writes, so it can never again pass while the live metric reads zero.
+
+**No behavior change for healthy inputs.** A complete passport, a bulleted hierarchy, and an agent with no learning events all behave exactly as before. These fixes only add tolerance and correct paths.
+
+## What ships when
+
+One PR, all three fixes together — they were all surfaced by the same harness run and share the same root (latent bugs masked by tests that encoded the same wrong assumptions). Regression tests ship alongside each fix.

--- a/upgrades/next/exo3-harness-gap-fixes.md
+++ b/upgrades/next/exo3-harness-gap-fixes.md
@@ -1,0 +1,32 @@
+---
+change_type: fix
+audience: agent-only
+maturity: stable
+---
+<!-- bump: patch -->
+
+## What Changed
+
+Three latent bugs in EXO 3.0 capabilities, surfaced by a new from-every-angle test harness, are fixed — each with a regression test:
+
+- Agent-passport verification no longer returns a 500 when a peer's passport omits a field. `permits()` defaults `forbiddenActions`/`allowedCapabilities` to `[]`, so a partial peer card yields a verdict instead of throwing "Cannot read properties of undefined (reading 'length')".
+- The org-intent Tradeoff Hierarchy parser now accepts the documented single-line `Safety > Operator trust > ...` chained form, not only bullet lists. The resolver previously saw an empty hierarchy and reported "no tradeoff hierarchy defined".
+- The learning-velocity metric now reads its three real event sources — the registered-learnings registry under `state/evolution/` (timestamp at `source.discoveredAt`), the `action-queue.json` evolution actions, and the SQLite correction ledger — instead of three paths the agent never writes. It previously always reported zero events.
+
+## Evidence
+
+Before: `POST /passport/verify` with a passport missing `allowedCapabilities` returned HTTP 500 "Cannot read properties of undefined (reading 'length')". `POST /intent/tradeoff-resolve` returned "no tradeoff hierarchy defined" even though the hierarchy was present in the org-intent file. `GET /metrics/learning-velocity` returned `totalEvents: 0` / `insufficient-data` on an agent with hundreds of real evolution actions and registered learnings on disk.
+
+After: the same partial-passport request returns a 200 verdict (covered by a unit test, plus a regression test that still denies a forbidden action on a partial card). tradeoff-resolve resolves a value pair against the parsed order (unit test asserts the chained line parses to the ordered array; the bulleted form still parses). learning-velocity returns the real event count across learnings, evolution actions, and corrections (integration test seeds the real source paths/shapes and asserts a non-zero total). The pre-existing learning-velocity integration test had encoded the buggy paths, which is why the bug stayed green — it now seeds the real paths.
+
+## What to Tell Your User
+
+- "I found and fixed three small internal bugs in my EXO 3.0 self-checks, each surfaced by a new test harness that probes every capability from several angles. A peer-passport check could crash on an incomplete card; a value-priority list wasn't being read; and a learning-pace number was stuck at zero because it looked in the wrong places. These are correctness fixes with no change to how I behave for you — the learning-pace number will now reflect my real activity."
+
+## Summary of New Capabilities
+
+| Capability | How to Use |
+|-----------|-----------|
+| Passport verify tolerates a partial peer passport | Automatic. A passport missing a field yields a verdict instead of a 500. |
+| Tradeoff Hierarchy chained-form parsing | Automatic. The org-intent A-greater-than-B line now resolves via the tradeoff endpoint. |
+| Learning-velocity real sources | Automatic. The metric reads the real learnings / evolution-actions / corrections stores. |

--- a/upgrades/side-effects/exo3-harness-gap-fixes.md
+++ b/upgrades/side-effects/exo3-harness-gap-fixes.md
@@ -1,0 +1,69 @@
+# Side-Effects Review — EXO 3.0 harness gap fixes
+
+**Version / slug:** `exo3-harness-gap-fixes`
+**Date:** `2026-06-07`
+**Author:** `Echo (Instar dev agent)`
+**Second-pass reviewer:** `not required (Tier-1)`
+
+## Summary of the change
+
+Three surgical bug fixes surfaced by the new `exo3-harness` from-every-angle verification:
+(1) `src/core/AgentPassport.ts` `permits()` — default `forbiddenActions`/`allowedCapabilities` to `[]`
+so a partial peer passport yields a verdict instead of an HTTP 500; (2) `src/core/OrgIntentManager.ts`
+`parse()` — accept the documented chained `A > B > C` Tradeoff Hierarchy form in addition to bullets;
+(3) `src/server/routes.ts` `/metrics/learning-velocity` — read the REAL event sources
+(`state/evolution/learning-registry.json` with `source.discoveredAt`, `state/evolution/action-queue.json`
+`.actions[].createdAt`, and the SQLite `correctionLedger`) instead of three paths the agent never writes.
+Regression tests extended in the matching unit + integration suites.
+
+## Decision-point inventory
+
+- `AgentPassport.permits()` — modify (add input-tolerance; verdict logic unchanged)
+- `OrgIntentManager.parse()` tradeoff parsing — modify (add chained-line acceptance; bullets unchanged)
+- `/metrics/learning-velocity` event gathering — modify (correct source paths; scorer untouched)
+
+## 1. Over-block
+
+**What legitimate inputs does this change reject that it shouldn't?**
+None. Passport `permits()` becomes MORE permissive of input shapes (defaults missing arrays) but the
+allow/deny verdict for any complete passport is byte-identical. The tradeoff parser only ADDS a format;
+a bulleted hierarchy parses exactly as before. No block/allow surface added.
+
+## 2. Under-block
+
+**What does this change now allow that it shouldn't?**
+Nothing new is allowed. A partial passport that omits `forbiddenActions` is treated as "no forbidden
+actions" — which is the correct, safe reading of an absent list (the verifier still applies trust-floor
+and capability-scope). A forbidden action present in a partial passport is still denied (covered by a
+regression test).
+
+## 3. Data / state
+
+**What persistent state does this read or write?**
+Read-only. The learning-velocity route only READS `state/evolution/*.json` and the correction ledger;
+it never writes. No new files, no schema changes, no migrations.
+
+## 4. Performance
+
+The learning-velocity route now reads `action-queue.json` (can be ~hundreds of KB) once per request.
+This endpoint is a low-frequency, on-demand observability call (not a hot path); a single synchronous
+JSON parse per call is acceptable and bounded. No new work on any per-message or per-tick path.
+
+## 5. Failure modes
+
+Every new source read is wrapped in try/catch and skips on error (unreadable/malformed file → that
+source contributes zero, never a 500). The correction ledger read is guarded by `if (ctx.correctionLedger)`
+so agents with correction-learning off (ledger absent) are unaffected. The passport guard removes a
+crash failure mode entirely.
+
+## 6. Security / auth
+
+No auth surface change. The passport fix HARDENS a trust boundary (a peer-supplied passport can no
+longer crash the verifier — a malformed/hostile card now produces a clean verdict). No new endpoints,
+no new capabilities, no credential handling.
+
+## 7. Migration / compatibility
+
+No migration needed. The learning-velocity path correction means existing agents' metric starts
+reflecting real events on the next deploy (it read zero before). No config, no on-disk format, no
+agent-installed file changes. Pure runtime behavior correction.


### PR DESCRIPTION
## What this does

Three latent bugs in EXO 3.0 capabilities — surfaced by a new from-every-angle test harness (`exo3-harness`) — each fixed with a regression test.

1. **`AgentPassport.permits()` no longer 500s on a partial peer passport.** A passport handed over by a peer doesn't go through `buildPassport()`, so its array fields can be `undefined`. The verifier dereferenced `passport.allowedCapabilities.length` (and iterated `forbiddenActions`) unguarded → HTTP 500 `Cannot read properties of undefined (reading 'length')`. Now both default to `[]` → always a verdict, never a crash. The whole point of a passport is that an *untrusted peer* supplies it, so input-tolerance is correct here.
2. **`OrgIntentManager.parse()` accepts the documented chained Tradeoff Hierarchy.** The hierarchy is documented and scaffolded as a single line — `Safety > Operator trust > Correctness > ...` — but the parser only read bullet lists, so it produced `[]` and `/intent/tradeoff-resolve` reported "no tradeoff hierarchy defined". Now the chained form parses to the ordered array (bulleted form still works).
3. **`/metrics/learning-velocity` reads the real event sources.** The route read three paths the agent never writes (`stateDir/learning-registry.json` instead of `state/evolution/learning-registry.json` + top-level timestamp instead of `source.discoveredAt`; `state/corrections.jsonl` instead of the SQLite ledger; `logs/evolution-actions.jsonl` instead of `state/evolution/action-queue.json`). So it always returned 0 events. Now it reads the registered-learnings registry, the evolution action queue, and the correction ledger.

## ELI16

We built a test harness that pokes every one of our EXO 3.0 features through its real endpoint, from a bunch of angles. It found three small, real bugs that were invisible before because the old tests quietly checked the wrong things. Fix 1: a peer's ID card with a missing field used to crash the checker — now it just gives a clean yes/no. Fix 2: our list of which value wins when two collide ("safety beats speed") was written the documented one-line way, but the reader only understood bullet points, so it acted like the list was empty — now it reads both. Fix 3: the "how fast am I learning" number was looking in three folders the agent never actually uses, so it always said zero — now it looks in the right places. None of these change behavior for healthy inputs; they add tolerance and correct paths.

## Causal autopsy

`origin: latent`. All three shipped because the existing tests encoded the *same* wrong assumptions as the code: the learning-velocity integration test wrote fixtures to the buggy paths (route + test wrong together, stayed green); passport tests always sent complete passports via `buildPassport`; org-intent tests never used the documented chained tradeoff format. The harness broke that symmetry by hitting the real endpoints with realistic + adversarial inputs.

## Testing

- `tests/unit/AgentPassport.test.ts` — partial passport (missing `allowedCapabilities` / `forbiddenActions`) yields a verdict, not a throw; still denies a forbidden action on a partial card.
- `tests/unit/OrgIntentManager.test.ts` — chained `A > B > C` parses to the ordered array; bulleted form still parses.
- `tests/integration/learning-velocity-routes.test.ts` — rewritten to seed the REAL source paths/shapes (this test previously encoded the buggy paths — the reason the bug stayed green); asserts non-zero events across learnings/actions/corrections, and survives a missing correction ledger.
- Tier-1. `tsc --noEmit` clean, all lint gates clean. ELI16 + side-effects artifacts shipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
