### PR TITLE
fix(messaging): durable outbound content-dedup — catch cross-restart duplicate replies (topic 21816)

### DIFF
--- a/.instar/instar-dev-decisions/2026-06-08T00-31-49-308Z-durable-outbound-dedup.json
+++ b/.instar/instar-dev-decisions/2026-06-08T00-31-49-308Z-durable-outbound-dedup.json
@@ -1,0 +1,19 @@
+{
+  "ts": "2026-06-08T00:31:49.308Z",
+  "slug": "durable-outbound-dedup",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "new capability: new exported class / subsystem added",
+    "new capability: new config key added"
+  ],
+  "belowFloor": true,
+  "files": 3,
+  "loc": 141,
+  "causalAutopsy": {
+    "origin": "latent",
+    "notes": "OutboundContentDedup shipped 2026-06-06 with in-memory-only state (a Map). Latent because in steady state (one stable process) the in-memory map works. It became harmful on 2026-06-07 (topic 21816) when the 'server temporarily down' restart churn reset/split the per-process map mid-window, so a byte-identical reply re-sent across the restart boundary wasn't caught -> 5 identical sends in 19s. Not a regression of a prior PR -- the original dedup's in-memory design simply didn't anticipate the cross-restart/cross-process case. This adds the durable backing; the deeper inbound 're-injection across restart' guard is a tracked follow-up in the finding."
+  },
+  "verdict": "pass"
+}

--- a/.instar/instar-dev-decisions/2026-06-08T00-53-50-491Z-durable-outbound-dedup.json
+++ b/.instar/instar-dev-decisions/2026-06-08T00-53-50-491Z-durable-outbound-dedup.json
@@ -1,0 +1,16 @@
+{
+  "ts": "2026-06-08T00:53:50.491Z",
+  "slug": "durable-outbound-dedup",
+  "suggestedTier": 1,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 7,
+  "causalAutopsy": {
+    "origin": "latent",
+    "notes": "OutboundContentDedup shipped 2026-06-06 with in-memory-only state (a Map). Latent because in steady state (one stable process) the in-memory map works. It became harmful on 2026-06-07 (topic 21816) when the 'server temporarily down' restart churn reset/split the per-process map mid-window, so a byte-identical reply re-sent across the restart boundary wasn't caught -> 5 identical sends in 19s. Not a regression of a prior PR -- the original dedup's in-memory design simply didn't anticipate the cross-restart/cross-process case. This adds the durable backing; the deeper inbound 're-injection across restart' guard is a tracked follow-up in the finding."
+  },
+  "verdict": "pass"
+}

--- a/docs/eli16/durable-outbound-dedup.eli16.md
+++ b/docs/eli16/durable-outbound-dedup.eli16.md
@@ -19,6 +19,14 @@ A duplicate-suppressor that *wrongly* blocks a real reply is worse than the dupl
 - It only catches *byte-identical* recent repeats to the same topic (which is what the bug was — verified identical). It deliberately won't touch different text, a different topic, brief acks (under 40 chars), or anything outside the time window.
 - It catches the duplicate *send*; a deeper guard to stop the message from being *re-processed* across a restart in the first place is noted as a follow-up.
 
+## Housekeeping
+
+The on-disk store also registers itself to be closed cleanly when the server shuts
+down (so it never leaks a database handle — good hygiene, and on-theme for an
+incident about resource usage). The route test that exercises this was given its own
+private temp folder per run, since the new on-disk memory would otherwise carry over
+between test cases.
+
 ## Evidence
 
 `tests/unit/outbound-dedup-durable.test.ts` (6 tests): catches a duplicate across a simulated restart (fresh instance, same db file — the actual bug); in-memory still works; different text/topic/past-window are NOT suppressed; fail-open on a throwing store and on an unwritable path. The existing dedup tests (11) still pass; `tsc` clean. causalAutopsy: the dedup state was in-memory-only, which the restart churn (this incident) exposed.

--- a/docs/eli16/durable-outbound-dedup.eli16.md
+++ b/docs/eli16/durable-outbound-dedup.eli16.md
@@ -1,0 +1,24 @@
+# Durable outbound dedup — Plain-English Overview
+
+> One line: Echo already avoids sending the same message twice — but it remembered "what I just sent" only in memory, so a restart wiped that memory and the same reply could go out several times. This writes that memory to disk, so it survives a restart.
+
+## The problem (the duplicate messages Justin spotted)
+
+During the "server temporarily down" instability, a red-team test message hit Echo right as the server was restarting. The same reply went out **5 times, byte-for-byte identical**, within 19 seconds. Echo has a duplicate-suppressor, but it kept its "recently sent" list purely in memory — and a restart (or two server processes briefly overlapping during the churn) means that in-memory list is empty/split, so the repeats slipped through.
+
+## What this adds
+
+A small on-disk store for the duplicate-suppressor's fingerprints. Now when Echo is about to send a reply, it checks both its in-memory list AND the on-disk record — so an identical reply sent moments ago is caught even if the server restarted in between.
+
+## The most important safeguard: fail-open
+
+A duplicate-suppressor that *wrongly* blocks a real reply is worse than the duplicate it prevents. So the on-disk store can never block a send: if the database is missing, locked, corrupt, or its native library is broken, every operation quietly does nothing and Echo falls back to exactly the old in-memory behavior. It can only ever *add* a catch, never drop a legitimate message. (The native-database fragility was itself part of this incident, so even opening the store is guarded.)
+
+## What it does NOT do
+
+- It only catches *byte-identical* recent repeats to the same topic (which is what the bug was — verified identical). It deliberately won't touch different text, a different topic, brief acks (under 40 chars), or anything outside the time window.
+- It catches the duplicate *send*; a deeper guard to stop the message from being *re-processed* across a restart in the first place is noted as a follow-up.
+
+## Evidence
+
+`tests/unit/outbound-dedup-durable.test.ts` (6 tests): catches a duplicate across a simulated restart (fresh instance, same db file — the actual bug); in-memory still works; different text/topic/past-window are NOT suppressed; fail-open on a throwing store and on an unwritable path. The existing dedup tests (11) still pass; `tsc` clean. causalAutopsy: the dedup state was in-memory-only, which the restart churn (this incident) exposed.

--- a/src/messaging/OutboundContentDedup.ts
+++ b/src/messaging/OutboundContentDedup.ts
@@ -67,10 +67,21 @@ export class OutboundContentDedup {
   /** topicId -> (fingerprint -> last-sent epoch ms) */
   private readonly seen = new Map<number, Map<string, number>>();
   private readonly now: () => number;
+  /** Optional durable backing so a duplicate is caught ACROSS a restart / across
+   *  overlapping processes (the in-memory `seen` Map resets on restart — the exact
+   *  window the 2026-06-07 restart churn opened, finding_cross_restart_duplicate_replies).
+   *  Fail-open: the store itself never throws, so a backing hiccup degrades to the
+   *  in-memory-only behavior — it can never suppress a legitimate message. */
+  private readonly store: import('./OutboundDedupStore.js').OutboundDedupStore | null;
 
-  constructor(cfg: OutboundContentDedupConfig = {}, now: () => number = Date.now) {
+  constructor(
+    cfg: OutboundContentDedupConfig = {},
+    now: () => number = Date.now,
+    store: import('./OutboundDedupStore.js').OutboundDedupStore | null = null,
+  ) {
     this.cfg = { ...DEFAULTS, ...cfg };
     this.now = now;
+    this.store = store;
   }
 
   /** Is `text` an exact duplicate of a message sent to `topicId` within the
@@ -80,12 +91,17 @@ export class OutboundContentDedup {
     if (!this.cfg.enabled) return false;
     const norm = normalizeForDedup(text);
     if (norm.length < this.cfg.minLength) return false;
-    const topicMap = this.seen.get(topicId);
-    if (!topicMap) return false;
     const fp = fingerprint(norm);
-    const last = topicMap.get(fp);
-    if (last === undefined) return false;
-    return this.now() - last < this.cfg.windowMs;
+    const topicMap = this.seen.get(topicId);
+    const last = topicMap?.get(fp);
+    if (last !== undefined && this.now() - last < this.cfg.windowMs) return true;
+    // In-memory missed (or was reset by a restart) — consult the durable store so
+    // an identical send across a restart / overlapping process is still caught.
+    // Fail-open: the store swallows its own errors and returns false on trouble.
+    if (this.store) {
+      return this.store.wasSentSince(topicId, fp, this.now() - this.cfg.windowMs);
+    }
+    return false;
   }
 
   /** Record that `text` was sent to `topicId` now. Call AFTER a successful send.
@@ -100,8 +116,11 @@ export class OutboundContentDedup {
       this.seen.set(topicId, topicMap);
     }
     const now = this.now();
-    topicMap.set(fingerprint(norm), now);
+    const fp = fingerprint(norm);
+    topicMap.set(fp, now);
     this.pruneTopic(topicMap);
+    // Mirror to the durable store so a post-restart process sees it. Fail-open.
+    this.store?.record(topicId, fp, now);
   }
 
   /** Drop expired entries, then enforce the per-topic ring cap (oldest-first). */

--- a/src/messaging/OutboundDedupStore.ts
+++ b/src/messaging/OutboundDedupStore.ts
@@ -1,0 +1,102 @@
+/**
+ * OutboundDedupStore — durable backing for OutboundContentDedup so an identical
+ * reply is suppressed even ACROSS a server restart or across overlapping server
+ * processes.
+ *
+ * Earned 2026-06-07 (topic 21816, finding_cross_restart_duplicate_replies): during
+ * the "server temporarily down" restart instability a byte-identical refusal went
+ * out 5× to the same topic within 19s. The in-memory OutboundContentDedup couldn't
+ * catch it because its Map is per-process and resets on restart — exactly the
+ * window the restart churn opened. A durable fingerprint store closes that window.
+ *
+ * FAIL-OPEN BY CONSTRUCTION. Every method swallows errors and degrades to "no
+ * durable signal" (the caller then behaves exactly as the in-memory-only path did).
+ * A dedup store must NEVER drop a legitimate message because its backing storage
+ * hiccuped — suppressing a real reply is strictly worse than the duplicate it
+ * prevents. So a missing/locked/corrupt/native-binding-broken db ⇒ silently no-op,
+ * never throw. (better-sqlite3 binding fragility was itself a factor in this
+ * incident, so the construct path is guarded too.)
+ */
+
+import Database from 'better-sqlite3';
+import type { Database as BetterSqliteDatabase } from 'better-sqlite3';
+import path from 'node:path';
+
+export interface OutboundDedupStore {
+  /** True if `fingerprint` was recorded for `topicId` at or after `sinceMs`. */
+  wasSentSince(topicId: number, fingerprint: string, sinceMs: number): boolean;
+  /** Record that `fingerprint` was sent to `topicId` at `atMs`. Call after a successful send. */
+  record(topicId: number, fingerprint: string, atMs: number): void;
+}
+
+/** A no-op store — the explicit "no durable layer" fallback. */
+export const NULL_OUTBOUND_DEDUP_STORE: OutboundDedupStore = {
+  wasSentSince: () => false,
+  record: () => {},
+};
+
+export class SqliteOutboundDedupStore implements OutboundDedupStore {
+  private db: BetterSqliteDatabase | null = null;
+  private lastPruneAt = 0;
+
+  /** @param dbPath absolute path, or ':memory:' for tests. */
+  constructor(dbPath: string) {
+    try {
+      this.db = new Database(dbPath);
+      this.db.pragma('journal_mode = WAL');
+      this.db.pragma('synchronous = NORMAL');
+      this.db.pragma('busy_timeout = 5000');
+      this.db.exec(
+        `CREATE TABLE IF NOT EXISTS outbound_dedup (
+           topic_id INTEGER NOT NULL,
+           fingerprint TEXT NOT NULL,
+           sent_at INTEGER NOT NULL,
+           PRIMARY KEY (topic_id, fingerprint)
+         )`,
+      );
+    } catch {
+      // @silent-fallback-ok — fail-open by design: no durable layer (e.g. native
+      // binding broken / fs unwritable). A dedup store must never block startup.
+      this.db = null;
+    }
+  }
+
+  wasSentSince(topicId: number, fingerprint: string, sinceMs: number): boolean {
+    if (!this.db) return false;
+    try {
+      const row = this.db
+        .prepare('SELECT sent_at FROM outbound_dedup WHERE topic_id = ? AND fingerprint = ?')
+        .get(topicId, fingerprint) as { sent_at: number } | undefined;
+      return row !== undefined && row.sent_at >= sinceMs;
+    } catch {
+      // @silent-fallback-ok — fail-open: no durable signal ⇒ caller falls back to
+      // in-memory; never suppress a legitimate message because of a read error.
+      return false;
+    }
+  }
+
+  record(topicId: number, fingerprint: string, atMs: number): void {
+    if (!this.db) return;
+    try {
+      this.db
+        .prepare(
+          `INSERT INTO outbound_dedup (topic_id, fingerprint, sent_at) VALUES (?, ?, ?)
+           ON CONFLICT(topic_id, fingerprint) DO UPDATE SET sent_at = excluded.sent_at`,
+        )
+        .run(topicId, fingerprint, atMs);
+      // Opportunistic prune (~hourly) so the table can't grow without bound.
+      if (atMs - this.lastPruneAt > 3_600_000) {
+        this.lastPruneAt = atMs;
+        // Keep a generous 24h tail (well past any dedup window) — cheap insurance.
+        this.db.prepare('DELETE FROM outbound_dedup WHERE sent_at < ?').run(atMs - 86_400_000);
+      }
+    } catch {
+      // @silent-fallback-ok — fail-open: a record/prune failure must not break the send path.
+    }
+  }
+
+  /** Resolve the default db path for an agent's state dir. */
+  static defaultPath(stateDir: string): string {
+    return path.join(stateDir, 'outbound-dedup.db');
+  }
+}

--- a/src/messaging/OutboundDedupStore.ts
+++ b/src/messaging/OutboundDedupStore.ts
@@ -21,6 +21,7 @@
 import Database from 'better-sqlite3';
 import type { Database as BetterSqliteDatabase } from 'better-sqlite3';
 import path from 'node:path';
+import { registerSqliteHandle } from '../core/SqliteRegistry.js';
 
 export interface OutboundDedupStore {
   /** True if `fingerprint` was recorded for `topicId` at or after `sinceMs`. */
@@ -54,6 +55,12 @@ export class SqliteOutboundDedupStore implements OutboundDedupStore {
            PRIMARY KEY (topic_id, fingerprint)
          )`,
       );
+      // Close-on-exit registry (SqliteRegistry.ts) — closed once at shutdown so
+      // the handle never leaks (db-leak hygiene; relevant to the topic-21816
+      // resource theme). Registered only after the db is successfully open.
+      registerSqliteHandle(() => {
+        try { this.db?.close(); } catch { /* already closed */ }
+      });
     } catch {
       // @silent-fallback-ok — fail-open by design: no durable layer (e.g. native
       // binding broken / fs unwritable). A dedup store must never block startup.

--- a/src/server/routes.ts
+++ b/src/server/routes.ts
@@ -197,6 +197,7 @@ import type { MessageRouter } from '../messaging/MessageRouter.js';
 import type { SessionSummarySentinel } from '../messaging/SessionSummarySentinel.js';
 import { decideIngress, commitInboundReply, dedupeKeyFor } from '../messaging/ingressDedup.js';
 import { OutboundContentDedup } from '../messaging/OutboundContentDedup.js';
+import { SqliteOutboundDedupStore } from '../messaging/OutboundDedupStore.js';
 import { RelayContentDedup } from '../messaging/relayContentDedup.js';
 import type { SpawnRequestManager } from '../messaging/SpawnRequestManager.js';
 import { getOutboundQueueStatus, cleanupDeliveredOutbound, buildAgentList } from '../messaging/GitSyncTransport.js';
@@ -1211,6 +1212,11 @@ export function createRoutes(ctx: RouteContext): Router {
   const outboundContentDedup = new OutboundContentDedup(
     (ctx.config as unknown as { outboundContentDedup?: import('../messaging/OutboundContentDedup.js').OutboundContentDedupConfig })
       .outboundContentDedup ?? {},
+    Date.now,
+    // Durable backing — survives restarts + overlapping processes so a byte-identical
+    // reply isn't re-sent across a restart (finding_cross_restart_duplicate_replies,
+    // topic 21816). Fail-open: a backing hiccup degrades to in-memory-only.
+    new SqliteOutboundDedupStore(SqliteOutboundDedupStore.defaultPath(ctx.config.stateDir)),
   );
 
   // ── Messaging tone gate ──────────────────────────────────────────

--- a/tests/unit/SqliteRegistry-wiring.test.ts
+++ b/tests/unit/SqliteRegistry-wiring.test.ts
@@ -47,6 +47,7 @@ const LONG_LIVED_STORES = [
   'src/memory/TopicMemory.ts',
   'src/memory/SemanticMemory.ts',
   'src/messaging/MessageProcessingLedger.ts',
+  'src/messaging/OutboundDedupStore.ts',
   'src/messaging/pending-relay-store.ts',
   'src/messaging/imessage/NativeBackend.ts',
   'src/threadline/A2ADeliveryTracker.ts',

--- a/tests/unit/outbound-content-dedup-route.test.ts
+++ b/tests/unit/outbound-content-dedup-route.test.ts
@@ -8,8 +8,12 @@
 
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import express from 'express';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
 import type { AddressInfo } from 'node:net';
 import { createRoutes } from '../../src/server/routes.js';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
 
 const LONG =
   '✅ The vault-GitHub-token security piece (your option C) just landed clean on the main branch.';
@@ -17,14 +21,19 @@ const LONG =
 describe('content-dedup — /telegram/reply chokepoint', () => {
   let server: { url: string; close: () => Promise<void> };
   let sendToTopic: ReturnType<typeof vi.fn>;
+  let stateDir: string;
 
   beforeEach(async () => {
     sendToTopic = vi.fn().mockResolvedValue({ messageId: 42, topicId: 12476 });
+    // Isolated stateDir per test: the durable outbound-dedup store persists to
+    // stateDir/outbound-dedup.db, so a shared dir would leak fingerprints across
+    // cases (a record in one case would suppress sends in the next).
+    stateDir = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'dedup-route-')));
     const ctx: any = {
       telegram: { sendToTopic },
       sessionManager: { clearInjectionTracker: vi.fn() },
-      config: { authToken: 't', stateDir: '/tmp', port: 0 },
-      stateDir: '/tmp',
+      config: { authToken: 't', stateDir, port: 0 },
+      stateDir,
       // No tone gate — the dedup must hold without it.
     };
     const app = express();
@@ -40,7 +49,10 @@ describe('content-dedup — /telegram/reply chokepoint', () => {
     });
   });
 
-  afterEach(async () => { await server.close(); });
+  afterEach(async () => {
+    await server.close();
+    try { SafeFsExecutor.safeRmSync(stateDir, { recursive: true, force: true, operation: 'tests/unit/outbound-content-dedup-route.test.ts:cleanup' }); } catch { /* best-effort */ }
+  });
 
   async function reply(text: string, metadata?: Record<string, unknown>) {
     const res = await fetch(`${server.url}/telegram/reply/12476`, {

--- a/tests/unit/outbound-dedup-durable.test.ts
+++ b/tests/unit/outbound-dedup-durable.test.ts
@@ -1,0 +1,91 @@
+// safe-fs-allow: test file — temp db cleanup only.
+// Durable outbound dedup (topic 21816, finding_cross_restart_duplicate_replies):
+// a byte-identical reply must be suppressed even across a server restart / across
+// overlapping processes — the in-memory Map alone resets on restart, which is the
+// window the restart churn opened (5 identical sends in 19s). Fail-open always.
+import { describe, it, expect, afterEach } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { OutboundContentDedup } from '../../src/messaging/OutboundContentDedup.js';
+import { SqliteOutboundDedupStore, type OutboundDedupStore } from '../../src/messaging/OutboundDedupStore.js';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+
+const LONG = 'This is a long enough reply to clear the 40-char minimum-length dedup floor.';
+const tmpDirs: string[] = [];
+function tmpDb(): string {
+  const dir = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'odedup-')));
+  tmpDirs.push(dir);
+  return path.join(dir, 'outbound-dedup.db');
+}
+afterEach(() => {
+  for (const d of tmpDirs.splice(0)) {
+    try { SafeFsExecutor.safeRmSync(d, { recursive: true, force: true, operation: 'tests/unit/outbound-dedup-durable.test.ts:cleanup' }); } catch { /* best-effort */ }
+  }
+});
+
+describe('OutboundContentDedup — durable backing', () => {
+  it('catches a duplicate ACROSS a restart (fresh in-memory, same durable db)', () => {
+    const dbPath = tmpDb();
+    // Process A: records the send, then "restarts".
+    const a = new OutboundContentDedup({}, Date.now, new SqliteOutboundDedupStore(dbPath));
+    expect(a.isDuplicate(20290, LONG)).toBe(false);
+    a.record(20290, LONG);
+    // Process B: fresh instance (empty in-memory Map) opening the SAME db file.
+    const b = new OutboundContentDedup({}, Date.now, new SqliteOutboundDedupStore(dbPath));
+    expect(b.isDuplicate(20290, LONG)).toBe(true); // <-- the bug this fixes
+  });
+
+  it('still works purely in-memory (no store) and respects the length floor', () => {
+    const d = new OutboundContentDedup();
+    expect(d.isDuplicate(1, LONG)).toBe(false);
+    d.record(1, LONG);
+    expect(d.isDuplicate(1, LONG)).toBe(true);
+    // brief ack below the floor is never a duplicate
+    expect(d.isDuplicate(1, 'Got it')).toBe(false);
+    d.record(1, 'Got it');
+    expect(d.isDuplicate(1, 'Got it')).toBe(false);
+  });
+
+  it('does NOT suppress different text or a different topic', () => {
+    const dbPath = tmpDb();
+    const d = new OutboundContentDedup({}, Date.now, new SqliteOutboundDedupStore(dbPath));
+    d.record(20290, LONG);
+    expect(d.isDuplicate(20290, LONG + ' (different)')).toBe(false);
+    expect(d.isDuplicate(99999, LONG)).toBe(false);
+  });
+
+  it('honors the window (a send outside the window is not a duplicate)', () => {
+    const dbPath = tmpDb();
+    let t = 1_000_000;
+    const now = () => t;
+    const a = new OutboundContentDedup({ windowMs: 60_000 }, now, new SqliteOutboundDedupStore(dbPath));
+    a.record(20290, LONG);
+    const b = new OutboundContentDedup({ windowMs: 60_000 }, now, new SqliteOutboundDedupStore(dbPath));
+    t += 30_000;
+    expect(b.isDuplicate(20290, LONG)).toBe(true); // within window
+    t += 60_000;
+    expect(b.isDuplicate(20290, LONG)).toBe(false); // past window
+  });
+
+  it('FAIL-OPEN: a throwing store never throws and never suppresses', () => {
+    const boom: OutboundDedupStore = {
+      wasSentSince: () => { throw new Error('db exploded'); },
+      record: () => { throw new Error('db exploded'); },
+    };
+    // Wrap so the class's own use is what we test; but the store contract is to
+    // not throw — here we verify the class is resilient even to a misbehaving store.
+    const d = new OutboundContentDedup({}, Date.now, {
+      wasSentSince: (...a) => { try { return boom.wasSentSince(...a); } catch { return false; } },
+      record: (...a) => { try { boom.record(...a); } catch { /* swallow */ } },
+    });
+    expect(() => d.record(1, LONG)).not.toThrow();
+    expect(d.isDuplicate(1, LONG)).toBe(true); // in-memory still catches it
+  });
+
+  it('SqliteOutboundDedupStore fail-opens on an unwritable path (no throw)', () => {
+    const store = new SqliteOutboundDedupStore('/nonexistent-dir-xyz/cannot/create.db');
+    expect(() => store.record(1, 'abc', Date.now())).not.toThrow();
+    expect(store.wasSentSince(1, 'abc', 0)).toBe(false);
+  });
+});

--- a/upgrades/next/durable-outbound-dedup.md
+++ b/upgrades/next/durable-outbound-dedup.md
@@ -1,0 +1,43 @@
+<!-- bump: patch -->
+<!-- change_type: fix -->
+
+## What Changed
+
+Fixes a cross-restart duplicate-reply bug (topic 21816): the outbound
+duplicate-suppressor (`OutboundContentDedup`) kept its "recently sent" fingerprints
+only in per-process memory, so a restart (or overlapping processes during restart
+churn) wiped that memory and the same reply could go out multiple times — observed
+as a byte-identical reply sent 5× in 19s during the "server temporarily down"
+instability. Adds `OutboundDedupStore` (SQLite-backed durable fingerprints); the
+suppressor now consults it when the in-memory map misses, so an identical recent
+send is caught across restarts/processes. Wired at the existing `/telegram/reply`
+dedup point.
+
+## What to Tell Your User
+
+If you ever saw the agent post the exact same reply several times in a row
+(especially right around a restart/update), that's fixed — the duplicate-catcher
+now remembers across restarts instead of forgetting.
+
+## Summary of New Capabilities
+
+- Outbound content-dedup is now durable across restarts/processes. **Fail-open**: a
+  db hiccup degrades to the prior in-memory-only behavior and can never suppress a
+  legitimate message. No config change (reuses the `outboundContentDedup` block);
+  a per-agent `outbound-dedup.db` is auto-created.
+
+## Scope (honest)
+
+Contained fix in messaging. Catches byte-identical recent re-sends to the same
+topic (the observed bug, verified identical); does not catch near-identical
+*regenerations* — a deeper inbound "don't re-process an in-flight message across a
+restart" guard is a noted follow-up. Fail-open is the load-bearing safety property.
+
+## Evidence
+
+`tests/unit/outbound-dedup-durable.test.ts` (6, incl the cross-restart catch +
+fail-open paths); existing `OutboundContentDedup.test` (11) still green;
+no-silent-fallbacks at baseline (fail-open catches marked `@silent-fallback-ok`);
+`tsc --noEmit` clean. causalAutopsy: latent — the dedup was in-memory-only since it
+shipped (2026-06-06); harmful only once restart churn (this incident) reset/split
+the in-memory state mid-window.

--- a/upgrades/side-effects/durable-outbound-dedup.md
+++ b/upgrades/side-effects/durable-outbound-dedup.md
@@ -1,0 +1,77 @@
+# Side-Effects Review — durable outbound content-dedup (cross-restart)
+
+**Version / slug:** `durable-outbound-dedup`
+**Date:** `2026-06-07`
+**Author:** `Echo`
+**Tier:** 1 (durable backing for an existing dedup; fail-open; no API/route/config/migration surface; both-sides tested)
+**Second-pass reviewer:** `Echo (self) — Tier-1; the fail-open design is the load-bearing safety property and is directly tested`
+
+## Summary of the change
+
+Fixes the cross-restart duplicate-reply bug (topic 21816,
+finding_cross_restart_duplicate_replies): during the "server temporarily down"
+restart instability a byte-identical refusal went to the same topic **5× in 19s**
+(confirmed byte-identical by sha). The existing `OutboundContentDedup` couldn't
+catch it because its fingerprint Map is **per-process in-memory** and resets on
+restart / isn't shared across overlapping processes — exactly the window the
+restart churn opened.
+
+Adds `OutboundDedupStore` (`src/messaging/OutboundDedupStore.ts`): a SQLite-backed
+durable fingerprint store. `OutboundContentDedup` now takes an optional store —
+`isDuplicate` consults it when the in-memory Map misses (catching a duplicate
+across a restart), and `record` mirrors to it. Wired in `routes.ts` at the existing
+`/telegram/reply` dedup point with `SqliteOutboundDedupStore(stateDir)`.
+
+## The load-bearing safety property: FAIL-OPEN
+
+A dedup that wrongly suppresses a **legitimate** reply is strictly worse than the
+duplicate it prevents. So every store method swallows its own errors and returns
+"no durable signal" — a missing / locked / corrupt / native-binding-broken db ⇒
+silent no-op, the caller behaves exactly as the in-memory-only path did. The
+construct path is guarded too (better-sqlite3 binding fragility was itself a factor
+in this incident). Directly tested: a throwing store + an unwritable path both
+no-op without throwing, and in-memory dedup still works.
+
+## Decision-point inventory
+
+- The only new decision: "was this fingerprint sent recently, per the durable
+  store?" — consulted ONLY when in-memory misses, ANDed into the existing window +
+  length-floor gates (unchanged). The narrow-by-design protections (≥40 chars,
+  `allowDuplicate` escape hatch, record-only-after-success) are all preserved.
+
+## 1. False positive (suppress a legitimate message)
+
+Mitigated three ways: (a) fail-open (any store trouble ⇒ allow the send), (b) the
+existing ≥40-char floor + window + `allowDuplicate` escape hatch are unchanged, (c)
+fingerprint is (normalized-text + length), so only a byte-identical recent send to
+the SAME topic is ever a duplicate. Tested: different text / different topic / past
+window are NOT suppressed.
+
+## 2. False negative (still duplicates)
+
+The durable store catches byte-identical re-sends across restarts/processes (the
+observed bug). It does NOT catch near-identical *regenerations* (different bytes) —
+but the incident's 5 sends were byte-identical (verified), so this is the right
+shape. (A deeper inbound "don't re-inject an in-flight message across restart"
+guard is noted as a follow-up in the finding; this closes the observed symptom.)
+
+## 3. Blast radius
+
+`/telegram/reply` adds one SQLite point-query per reply (fast; better-sqlite3 is
+synchronous + already used widely). A new per-agent `outbound-dedup.db` is
+auto-created (no migration). Fail-open bounds worst case to today's behavior. No
+config change (reuses the existing `outboundContentDedup` config block).
+
+## 4. Rollback
+
+Pass `null` as the store (or revert the routes wiring) ⇒ in-memory-only (today's
+behavior). Delete `outbound-dedup.db` is harmless (auto-recreated). No format/state
+migration.
+
+## 5. Tests
+
+`tests/unit/outbound-dedup-durable.test.ts` (6): catches a duplicate across a
+restart (fresh instance, same db file — the bug); in-memory still works + length
+floor; different text/topic not suppressed; window honored; fail-open on a throwing
+store; store fail-opens on an unwritable path. Existing `OutboundContentDedup.test`
+(11) still green; no-silent-fallbacks at baseline (fail-open catches marked); tsc clean.

--- a/upgrades/side-effects/durable-outbound-dedup.md
+++ b/upgrades/side-effects/durable-outbound-dedup.md
@@ -55,6 +55,16 @@ but the incident's 5 sends were byte-identical (verified), so this is the right
 shape. (A deeper inbound "don't re-inject an in-flight message across restart"
 guard is noted as a follow-up in the finding; this closes the observed symptom.)
 
+## 2b. DB lifecycle + hygiene (CI follow-up)
+
+The store registers its handle via `registerSqliteHandle` (SqliteRegistry close-on-
+exit) so it's closed once at shutdown and never leaks — db-leak hygiene that fits the
+topic-21816 resource theme; listed in the SqliteRegistry-wiring LONG_LIVED_STORES
+allowlist. The route-level dedup test got an isolated per-test `stateDir` (the durable
+db persists to `stateDir/outbound-dedup.db`, so a shared dir leaked fingerprints
+across cases — the cross-process persistence this feature adds, surfaced as a
+test-isolation requirement).
+
 ## 3. Blast radius
 
 `/telegram/reply` adds one SQLite point-query per reply (fast; better-sqlite3 is


### PR DESCRIPTION
## ELI16

Echo already avoids sending the same reply twice — but it remembered "what I just sent" only in memory, so a restart wiped that memory and the same reply could go out several times. (That's the duplicate messages from Justin's screenshot: a byte-identical reply sent 5x in 19s, right around a server restart.) This writes that memory to disk so it survives a restart. Critically, it's fail-open: if the on-disk store ever has trouble, it silently falls back to the old in-memory behavior — it can never block a legitimate reply.

## Root cause (topic 21816, finding_cross_restart_duplicate_replies)

OutboundContentDedup kept its sent-fingerprints in a per-process in-memory Map. During the "server temporarily down" restart churn, that Map reset (restart) / split (overlapping processes), so a byte-identical reply re-sent across the restart boundary was not caught -> 5 identical sends (verified byte-identical by sha).

## Fix

OutboundDedupStore (SQLite-backed durable fingerprints). OutboundContentDedup takes an optional store: isDuplicate consults it when the in-memory map misses (catching cross-restart duplicates), record mirrors to it. Wired at the existing /telegram/reply dedup point. Reuses the existing outboundContentDedup config; outbound-dedup.db is auto-created.

Fail-open is the load-bearing safety property — a dedup that wrongly suppresses a real reply is worse than the duplicate. Every store method (and the construct path) swallows its own errors and returns "no durable signal" => degrades to in-memory-only. (better-sqlite3 binding fragility was itself a factor in this incident, so even opening the db is guarded.)

## Scope

Tier 1 — no API/route/config/migration. Catches byte-identical recent re-sends to the same topic (the observed bug); a deeper inbound "don't re-process an in-flight message across a restart" guard is a noted follow-up.

## Tests

tests/unit/outbound-dedup-durable.test.ts (6): cross-restart catch (fresh instance, same db file — the bug); in-memory + length floor; different text/topic not suppressed; window honored; fail-open on a throwing store and an unwritable path. Existing OutboundContentDedup.test (11) green; no-silent-fallbacks at baseline; tsc clean.