### PR TITLE
fix(subscription-auth): either-window quota pressure (not weekly-only)

### DIFF
--- a/.instar/instar-dev-decisions/2026-06-08T00-52-06-147Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-06-08T00-52-06-147Z-unknown.json
@@ -1,0 +1,13 @@
+{
+  "ts": "2026-06-08T00:52:06.147Z",
+  "slug": "unknown",
+  "suggestedTier": 1,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 16,
+  "causalAutopsy": null,
+  "verdict": "pass"
+}

--- a/docs/specs/_drafts/subscription-either-window-pressure.eli16.md
+++ b/docs/specs/_drafts/subscription-either-window-pressure.eli16.md
@@ -1,0 +1,21 @@
+# Either-window quota pressure — Plain-English Overview
+
+> The one-line version: an account now counts as "at its limit" if EITHER its 5-hour OR its weekly window is nearly full — not just the weekly one.
+
+## The problem in one breath
+
+Each Claude account has two separate limits: a 5-hour rolling one and a weekly one. The swap logic was only really watching the weekly number. So an account that was slammed on its 5-hour limit (say 95%) but fine for the week (40%) looked "fine" — and wouldn't trigger a swap, even though you'd actually be locked out for the next few hours.
+
+## What changed
+
+The "is this account under pressure?" check now looks at whichever window is MORE used — the max of the two. So if either the 5-hour or the weekly is near the threshold (90%), the account counts as under pressure: it won't be picked for new work, and a session on it should move to another account.
+
+## What did NOT change
+
+- The threshold is still 90%, the swap mechanism is unchanged, and automatic swapping still ships off by default.
+- If only one window's data is available, it behaves exactly as before.
+- Picking which account to drain first (by reset time) already looked at both windows — untouched.
+
+## Proven
+
+Four new tests: 5-hour maxed (weekly low) → at pressure; weekly maxed (5-hour low) → at pressure; both below → not; and selection skips a 5-hour-maxed account in favor of one with room. All scheduler tests stay green; type-check clean.

--- a/src/core/QuotaAwareScheduler.ts
+++ b/src/core/QuotaAwareScheduler.ts
@@ -44,12 +44,20 @@ function isEligibleStatus(a: SubscriptionAccount): boolean {
   return a.status === 'active' || a.status === 'warming';
 }
 
-/** Binding-window utilization (7-day); falls back to 5-hour, else 0 (unknown = empty). */
+/**
+ * Most-constrained-window utilization: the MAX across the account's known
+ * windows (5-hour AND weekly). Taking the max means EITHER window crossing the
+ * threshold counts as pressure — the 5-hour limit blocks you independently of
+ * the weekly (you can be locked out for hours with plenty of weekly headroom
+ * left), so the binding constraint is whichever window is the most used. 0 when
+ * there is no reading yet (unknown = treated as empty / still selectable).
+ */
 function bindingUtilization(snap: AccountQuotaSnapshot | null | undefined): number {
   if (!snap) return 0;
-  if (snap.sevenDay) return snap.sevenDay.utilizationPct;
-  if (snap.fiveHour) return snap.fiveHour.utilizationPct;
-  return 0;
+  const utils: number[] = [];
+  if (snap.sevenDay) utils.push(snap.sevenDay.utilizationPct);
+  if (snap.fiveHour) utils.push(snap.fiveHour.utilizationPct);
+  return utils.length ? Math.max(...utils) : 0;
 }
 
 /** Soonest reset across the account's known windows (ms epoch), or +Infinity. */

--- a/tests/unit/quota-aware-scheduler.test.ts
+++ b/tests/unit/quota-aware-scheduler.test.ts
@@ -134,3 +134,42 @@ describe('QuotaAwareScheduler — the continuity guarantee', () => {
     expect(sched.placeNewSession(NOW)?.id).toBe('b'); // sooner reset, same headroom
   });
 });
+
+// Either-window pressure (the gap surfaced in live testing 2026-06-07): an
+// account is "at pressure" when EITHER the 5-hour OR the weekly window crosses
+// the threshold — the 5-hour limit blocks independently of the weekly.
+function acct2(
+  id: string,
+  fiveHourPct: number,
+  weeklyPct: number,
+  resetsAt = '2026-06-12T00:00:00Z',
+): SubscriptionAccount {
+  return {
+    id, nickname: id, provider: 'anthropic', framework: 'claude-code',
+    configHome: `/h/.claude-${id}`, status: 'active',
+    lastQuota: {
+      fiveHour: { utilizationPct: fiveHourPct, resetsAt },
+      sevenDay: { utilizationPct: weeklyPct, resetsAt },
+      source: 'oauth-usage-endpoint-fallback',
+    },
+    enrolledAt: '2026-06-01T00:00:00Z', version: 1,
+  };
+}
+
+describe('QuotaAwareScheduler — either-window pressure', () => {
+  it('at pressure when the 5-HOUR window is maxed even if weekly has room', () => {
+    expect(accountAtPressure(acct2('x', 95, 40), 90)).toBe(true);
+  });
+  it('at pressure when the WEEKLY window is maxed even if 5-hour has room', () => {
+    expect(accountAtPressure(acct2('x', 10, 95), 90)).toBe(true);
+  });
+  it('NOT at pressure when BOTH windows are below the threshold', () => {
+    expect(accountAtPressure(acct2('x', 80, 88), 90)).toBe(false);
+  });
+  it('selection excludes an account maxed on 5-hour, picks the one with room on both', () => {
+    const hot = acct2('hot', 95, 40);   // 5h maxed
+    const cool = acct2('cool', 30, 50); // both fine
+    expect(selectAccount([hot, cool], { nowMs: NOW, softThresholdPct: 90 })?.id).toBe('cool');
+    expect(selectAccount([hot], { nowMs: NOW, softThresholdPct: 90 })).toBeNull();
+  });
+});

--- a/upgrades/next/subscription-either-window-pressure.md
+++ b/upgrades/next/subscription-either-window-pressure.md
@@ -13,6 +13,26 @@ key on the most-constrained window. Fixes a gap where an account maxed on its
 5-hour limit but low for the week was wrongly treated as having room. Threshold,
 swap mechanism, and dark-by-default auto-swap are unchanged.
 
+## Evidence
+
+Found during live testing (topic 20905) when the operator asked whether the swap
+trigger considers both windows. Reading `QuotaAwareScheduler` confirmed it did not:
+`bindingUtilization` returned the weekly (`sevenDay`) utilization when present and
+only fell back to the 5-hour value when weekly was absent.
+
+Reproduction — an account with `lastQuota: { fiveHour: 95%, sevenDay: 40% }`, soft
+threshold 90%:
+- **Before:** `accountAtPressure` → `false` (it read the weekly 40%), so a session
+  walled on the 5-hour limit would NOT be swapped and `selectAccount` still treated
+  the account as eligible.
+- **After:** `accountAtPressure` → `true` (it reads `max(95,40)=95`), and
+  `selectAccount` excludes the account.
+
+The divergence is real in practice: at discovery, the two live accounts read
+SageMind - Justin 5h 46% / weekly 60% and Justin 5h 0% / weekly 76% — the windows
+genuinely differ, which is exactly when the old weekly-only logic misfires. Locked
+in by 4 new `quota-aware-scheduler.test.ts` cases.
+
 ## What to Tell Your User
 
 When I balance across your subscription accounts, I now treat an account as "full"

--- a/upgrades/next/subscription-either-window-pressure.md
+++ b/upgrades/next/subscription-either-window-pressure.md
@@ -1,0 +1,27 @@
+# Either-window quota pressure (Subscription pool)
+
+<!-- bump: patch -->
+
+## What Changed
+
+The quota-aware scheduler's "at pressure" check now considers BOTH per-account
+windows: an account counts as at its limit when EITHER the 5-hour OR the weekly
+utilization crosses the threshold (90%), instead of keying only on the weekly
+window. `bindingUtilization` now returns the max across the account's known
+windows, so pressure, selection-eligibility, and use-before-reset headroom all
+key on the most-constrained window. Fixes a gap where an account maxed on its
+5-hour limit but low for the week was wrongly treated as having room. Threshold,
+swap mechanism, and dark-by-default auto-swap are unchanged.
+
+## What to Tell Your User
+
+When I balance across your subscription accounts, I now treat an account as "full"
+if EITHER its 5-hour or its weekly limit is nearly maxed — not just the weekly one.
+So a session won't get stuck on an account that's hit its short-term limit even if
+the week still has room.
+
+## Summary of New Capabilities
+
+- **Either-window pressure** — an account is "at its limit" when the 5-hour OR the
+  weekly window crosses the threshold (the 5-hour limit blocks independently).
+- No behavior change when only one window is known; auto-swap stays opt-in.

--- a/upgrades/side-effects/subscription-either-window-pressure.md
+++ b/upgrades/side-effects/subscription-either-window-pressure.md
@@ -1,0 +1,51 @@
+# Side-Effects Review — either-window quota pressure (QuotaAwareScheduler)
+
+## Scope of change
+
+- `src/core/QuotaAwareScheduler.ts` — `bindingUtilization()` now returns the MAX
+  utilization across the account's known windows (5-hour AND weekly), instead of
+  preferring the weekly window (and only falling back to 5-hour when weekly was
+  absent). One function body; the comment is updated. Tests added.
+
+## Why (live-test finding, 2026-06-07)
+
+The operator asked whether the swap trigger considers BOTH the 5-hour and weekly
+limits. It did not: `bindingUtilization` returned the weekly utilization if present,
+so an account maxed on its 5-HOUR window (e.g. 95%) but low for the week (40%) read
+as 40% and was NOT flagged at pressure — even though the 5-hour limit blocks you
+independently for the next hours. The correct rule is "either window crosses the
+threshold." Taking the max across windows makes pressure, selection-eligibility, and
+the use-before-reset headroom all key on the most-constrained window.
+
+## Behavior change
+
+`accountAtPressure` (>= threshold), `selectAccount` eligibility (< threshold), and
+`scoreAccount` headroom (100 - it) all flow through `bindingUtilization`, so all three
+now use either-window semantics. The change only matters when BOTH windows are present
+AND the 5-hour is higher than the weekly — exactly the previously-missed case. When only
+one window is present, behavior is identical to before. Reset-timing (`soonestResetMs`)
+already scanned both windows; unchanged.
+
+## Authority / autonomy
+
+No new authority. Auto-swap still ships dark behind `subscriptionPool.autoSwapOnRateLimit`.
+This corrects WHEN an account is considered at-pressure; it does not change the swap
+mechanism or make anything fire on its own that didn't before (other than now correctly
+recognizing 5-hour-window pressure).
+
+## Framework generality
+
+Provider-agnostic in shape: `bindingUtilization` operates on whatever windows an
+`AccountQuotaSnapshot` carries (5-hour / weekly today). Any provider whose snapshot
+exposes multiple windows gets correct either-window pressure for free.
+
+## Failure modes considered
+
+- Only one window present → max of one value = that value (identical to before).
+- No quota yet → 0 (selectable), unchanged.
+- Both windows present, 5-hour higher → NOW flagged at pressure (the fix).
+
+## Migration / parity
+
+Pure in-memory logic on data the QuotaPoller already writes — no migration, no config,
+no stored-shape change. Ships via dist.


### PR DESCRIPTION
## What this is (ELI16)

Each Claude account has two limits — a 5-hour rolling one and a weekly one. The swap "at pressure" check was only really watching the **weekly** number, so an account slammed on its **5-hour** limit (95%) but fine for the week (40%) looked "fine" and wouldn't trigger a swap — even though you'd be locked out for hours. Surfaced by Justin during live testing (topic 20905).

## Fix

`bindingUtilization()` now returns the **max** across the account's known windows (5-hour AND weekly) instead of preferring the weekly window. Since `accountAtPressure` (≥ threshold), `selectAccount` eligibility (< threshold), and `scoreAccount` headroom (100 − it) all flow through it, all three now use **either-window** semantics — EITHER window crossing the 90% threshold counts as pressure (the 5-hour limit blocks independently).

## Invariants

- Threshold (90%), swap mechanism, and dark-by-default auto-swap **unchanged**.
- Behavior only differs when **both** windows are present and 5h > weekly (the previously-missed case); identical when only one window is known.
- Reset-timing (`soonestResetMs`) already scanned both windows — untouched.
- No new route/class/authority. Tier-1.

## Tests

15 scheduler tests, incl. 4 new either-window cases (5h-maxed → at pressure; weekly-maxed → at pressure; both-low → not; selection skips a 5h-maxed account). tsc clean; docs-coverage unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)