### PR TITLE
fix(safety): fail-closed for the 2 LLM-gating fallbacks + No-Silent-Degradation standard

### DIFF
--- a/.instar/instar-dev-decisions/2026-06-08T03-05-52-671Z-llm-fallback-failclosed.json
+++ b/.instar/instar-dev-decisions/2026-06-08T03-05-52-671Z-llm-fallback-failclosed.json
@@ -1,0 +1,16 @@
+{
+  "ts": "2026-06-08T03:05:52.671Z",
+  "slug": "llm-fallback-failclosed",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 2,
+  "loc": 52,
+  "causalAutopsy": {
+    "origin": "latent",
+    "notes": "Both gates shipped with a DELIBERATE fail-open ('availability > security' / '@silent-fallback-ok' comments) — a latent safety gap that looked fine but silently downgrades real protection to none whenever the LLM is unavailable. Surfaced live by the EXO 3.0 harness rate-limit (the refusal judge degrading to the brittle keyword check), which prompted Justin's 'No Silent Degradation to Brittle Fallback' standard. Now reversed to fail-closed."
+  },
+  "verdict": "pass"
+}

--- a/docs/specs/no-silent-degradation-to-brittle-fallback.md
+++ b/docs/specs/no-silent-degradation-to-brittle-fallback.md
@@ -1,0 +1,53 @@
+# No Silent Degradation to Brittle Fallback (+ Iterative Audit to Convergence)
+
+**Status:** active initiative · **Owner:** Echo · **Origin:** Justin, 2026-06-07, topic 19437 (surfaced by the EXO 3.0 harness work, where an LLM refusal-judge fell back to a brittle keyword check under rate-limit and missed the very reworded forbidden actions it existed to catch).
+
+## Standard 1 — No Silent Degradation to Brittle Fallback
+
+**When an LLM makes a judgment that gates a real action, it must NEVER silently fall back to a brittle heuristic on LLM failure (rate-limit, circuit-open, timeout, unparseable reply).** Silently degrading to a weak check is worse than no check — it *looks* protected while the real protection is gone. On LLM failure a safety-gating path must do one of:
+
+1. **SWAP PROVIDER** — try another configured LLM provider (e.g. Codex) before degrading at all; or
+2. **FAIL CLOSED** — block / require-approval / hold, never the permissive verdict; never a brittle heuristic standing in for the LLM.
+
+Provider-swap is the *preferred* response; fail-closed is the **all-providers-down backstop**. Falling back to a heuristic is acceptable ONLY for genuinely **advisory / observability** paths that do not gate a real action (a metric, a digest, a signal-only sentinel) — and even then it must be logged, never silent.
+
+### Classification rule (how to triage a fallback site)
+- **SAFETY-GATING** (the LLM decision blocks/allows a real action, message, or external call) → MUST swap-provider or fail-closed.
+- **ADVISORY / OBSERVABILITY** (read-only; informs but does not gate) → may degrade, but must log the degradation.
+
+### Enforcement
+- A lint (`lint-no-silent-llm-fallback`, joining the `lint-no-*` family) flags any new `catch`/parse-fail near an LLM call that returns a permissive verdict in a gating path.
+- Every fallback site carries an explicit comment declaring its classification + behavior (`FAIL-CLOSED:` / `SWAP-PROVIDER:` / `@advisory-degrade-ok`). The legacy `@silent-fallback-ok` marker is banned in gating paths.
+
+## Standard 2 — Iterative Audit to Convergence
+
+**An audit is never one-off.** A single pass has blind spots, and the fixes themselves reveal or introduce new issues. The standard cycle is:
+
+> audit → fix → **RE-audit** → fix → … until a clean pass returns **zero new discoveries**.
+
+Only a converged audit (a re-run that finds nothing new) may be called "thorough." This applies to security audits, safety audits, and any "find all instances of X" sweep. Track the rounds; do not declare an audit complete on round 1.
+
+## Audit (round 1) — LLM-fallback-to-brittle-code
+
+~20 LLM-fallback sites found. Most are advisory (safe to degrade). **2 are safety-gating AND fail OPEN** (the dangerous ones); 3 more are safety-gating but mitigated.
+
+| Site | On LLM failure (before) | Class | Action |
+|---|---|---|---|
+| `ExternalOperationGate.consultLLM` (catch) | returned `proceed` (fail-OPEN) | SAFETY-GATING | **FIXED → `show-plan`** |
+| `ContentClassifier` parse-fail + error catch | returned `safe` (fail-OPEN) | SAFETY-GATING | **FIXED → `sensitive`** |
+| `MessagingToneGate` | fail-open after 120s rate-limit wait | gating (mitigated) | provider-swap candidate |
+| `MessageSentinel` | pass-through (deterministic fast-path floor) | gating (mitigated) | provider-swap candidate |
+| `InputGuard` | warn + degradation-log + attention escalate | gating (mitigated) | already loud |
+| `IntentLlmJudge`, redteam pack, RelationshipManager, PromptGate, SalienceGate, … | heuristic / null | ADVISORY | degrade-ok (log) |
+
+Right-pattern templates already in the tree: **`AnthropicSubscriptionRouter`** (try primary → swap to fallback on error → throw if both fail) and **`LLMSanitizer`** (fail-closed by default).
+
+## Implementation plan
+1. ✅ **Gate-flips** — `ExternalOperationGate` (`proceed`→`show-plan`) + `ContentClassifier` (`safe`→`sensitive`) fail-closed. Regression tests updated. (This PR.)
+2. **Shared provider-swap-then-fail-closed at `IntelligenceRouter.evaluate`** — on a per-component circuit trip, try the default framework once before propagating; the whole fleet inherits swap-before-degrade. (Structure > Willpower.)
+3. **Lint** `lint-no-silent-llm-fallback` + ban `@silent-fallback-ok` in gating paths.
+4. **Re-audit to convergence** (Standard 2) — re-sweep until a pass finds nothing new.
+5. **Throwaway sandbox agent** for adversarial behavioral testing (separate initiative — identical org-intent, no real powers; never test forbidden-action behaviors against the live production agent).
+
+## Constitution
+Both standards belong in `docs/STANDARDS-REGISTRY.md` / the constitution. They are safety standards: the first prevents fake-safety from a degraded gate; the second makes "thorough" mean "converged."

--- a/src/core/ExternalOperationGate.ts
+++ b/src/core/ExternalOperationGate.ts
@@ -21,6 +21,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import type { IntelligenceProvider } from './types.js';
 import { maybeRotateJsonl } from '../utils/jsonl-rotation.js';
+import { DegradationReporter } from '../monitoring/DegradationReporter.js';
 
 // ── Types ────────────────────────────────────────────────────────────
 
@@ -499,9 +500,24 @@ export class ExternalOperationGate {
       }
       // If LLM response is unparseable, default to cautious
       return 'show-plan';
-    } catch {
-      // @silent-fallback-ok — LLM fails, proceed (fail-open)
-      return 'proceed';
+    } catch (err) {
+      // FAIL-CLOSED: the LLM is the proportionality-escalation layer for
+      // medium/high-risk ops; when it's unavailable (rate-limit, circuit-open,
+      // error) we must NOT silently 'proceed' — that silently downgrades the
+      // gate to its deterministic floor and lets a risky op the LLM would have
+      // escalated sail through (the exact incident this gate exists to prevent).
+      // Require a plan/approval instead, and REPORT the degradation (never silent).
+      // (No Silent Degradation to Brittle Fallback — constitution standard.)
+      // Provider-swap upstream reduces how often this fires; this is the
+      // all-providers-down backstop.
+      DegradationReporter.getInstance().report({
+        feature: 'ExternalOperationGate.consultLLM',
+        primary: 'LLM proportionality judgment for a medium/high-risk operation',
+        fallback: 'fail-closed to show-plan (require operator approval)',
+        reason: `LLM unavailable: ${err instanceof Error ? err.message : 'unknown'}`,
+        impact: 'risky operations require a plan/approval while the LLM is down instead of silently proceeding',
+      });
+      return 'show-plan';
     }
   }
 

--- a/src/threadline/ContentClassifier.ts
+++ b/src/threadline/ContentClassifier.ts
@@ -14,6 +14,8 @@
  * Part of PROP-relay-auto-connect, Layer 5.
  */
 
+import { DegradationReporter } from '../monitoring/DegradationReporter.js';
+
 // ── Types ────────────────────────────────────────────────────────────
 
 export type ContentClassification = 'safe' | 'sensitive' | 'blocked';
@@ -135,8 +137,12 @@ function parseLLMResponse(response: string): ClassificationResult {
   const reasonLine = response.match(/REASON:\s*(.+)/i);
 
   if (!classLine) {
-    // If LLM didn't follow format, default to safe (fail-open for availability)
-    return { classification: 'safe' };
+    // FAIL-CLOSED: an unparseable LLM reply is NOT evidence the content is safe.
+    // The LLM is the layer that catches subtle outbound leaks (system prompts,
+    // business logic, contextual PII); defaulting to 'safe' silently ships them.
+    // Treat as 'sensitive' (blockSensitive policy escalates to blocked). See the
+    // "No Silent Degradation to Brittle Fallback" standard.
+    return { classification: 'sensitive', reason: 'Unparseable classifier reply — fail-closed to sensitive' };
   }
 
   const classification = classLine[1].toLowerCase() as ContentClassification;
@@ -247,11 +253,23 @@ export class ContentClassifier {
       return { classification: 'safe' };
     } catch (err) {
       this.metrics.errors++;
-      // Fail-open: classification errors don't block messages
-      // (availability > perfect security for a behavioral layer)
+      // FAIL-CLOSED: a classification error (LLM rate-limit, circuit-open, timeout)
+      // is NOT evidence the content is safe to send to an external peer. Defaulting
+      // to 'safe' silently downgrades real leak-protection to none. Treat as
+      // 'sensitive' (blockSensitive escalates to blocked) so unverifiable content
+      // is held, not leaked, and REPORT the degradation (never silent).
+      // ("No Silent Degradation to Brittle Fallback" standard; provider-swap
+      // upstream reduces how often this fires.)
+      DegradationReporter.getInstance().report({
+        feature: 'ContentClassifier.classify',
+        primary: 'LLM outbound-leak classification for an A2A message',
+        fallback: 'fail-closed to sensitive (held; blockSensitive escalates to blocked)',
+        reason: `Classification error: ${err instanceof Error ? err.message : 'unknown'}`,
+        impact: 'unverifiable outbound content is held as sensitive instead of silently shipped to a peer',
+      });
       return {
-        classification: 'safe',
-        reason: `Classification error (fail-open): ${err instanceof Error ? err.message : 'unknown'}`,
+        classification: 'sensitive',
+        reason: `Classification error (fail-closed to sensitive): ${err instanceof Error ? err.message : 'unknown'}`,
       };
     }
   }

--- a/tests/unit/ContentClassifier.test.ts
+++ b/tests/unit/ContentClassifier.test.ts
@@ -376,12 +376,14 @@ describe('ContentClassifier', () => {
       expect(result.classification).toBe('blocked');
     });
 
-    it('handles malformed LLM response gracefully (fail-open)', async () => {
+    it('handles malformed LLM response by FAILING CLOSED to sensitive', async () => {
+      // Regression for "No Silent Degradation to Brittle Fallback": an unparseable
+      // classifier reply is not evidence the content is safe to send to a peer.
       const mockLLM = vi.fn().mockResolvedValue('I am not sure about this content.');
       const classifier = createClassifier({ llmClassify: mockLLM });
 
       const result = await classifier.classify('Some text', defaultContext);
-      expect(result.classification).toBe('safe'); // Fail-open
+      expect(result.classification).toBe('sensitive'); // fail-CLOSED, not 'safe'
     });
 
     it('applies blockSensitive to LLM-classified sensitive', async () => {
@@ -399,13 +401,16 @@ describe('ContentClassifier', () => {
   // ── Error Handling (Fail-Open) ─────────────────────────────────
 
   describe('error handling', () => {
-    it('fails open when LLM throws', async () => {
+    it('FAILS CLOSED to sensitive when LLM throws (never silently safe)', async () => {
+      // Regression: a classification error (rate-limit, circuit-open, timeout) must
+      // NOT downgrade outbound-leak protection to "safe" — hold the content as
+      // sensitive instead. ("No Silent Degradation to Brittle Fallback".)
       const mockLLM = vi.fn().mockRejectedValue(new Error('LLM API timeout'));
       const classifier = createClassifier({ llmClassify: mockLLM });
 
       const result = await classifier.classify('Some text', defaultContext);
-      expect(result.classification).toBe('safe');
-      expect(result.reason).toContain('fail-open');
+      expect(result.classification).toBe('sensitive'); // fail-CLOSED, not 'safe'
+      expect(result.reason).toContain('fail-closed');
       expect(result.reason).toContain('LLM API timeout');
     });
 

--- a/tests/unit/ExternalOperationGate.test.ts
+++ b/tests/unit/ExternalOperationGate.test.ts
@@ -530,7 +530,11 @@ describe('ExternalOperationGate', () => {
       expect(result.llmEvaluated).toBe(true);
     });
 
-    it('LLM failure falls back to programmatic decision', async () => {
+    it('LLM failure FAILS CLOSED to show-plan (never silently proceeds)', async () => {
+      // Regression for "No Silent Degradation to Brittle Fallback": when the LLM
+      // (the proportionality-escalation layer) is unavailable, the gate must NOT
+      // return 'proceed' — it requires a plan/approval. Silent 'proceed' on LLM
+      // failure is the exact incident this gate exists to prevent.
       const gate = createGate({
         intelligence: {
           evaluate: async () => { throw new Error('LLM down'); },
@@ -542,8 +546,8 @@ describe('ExternalOperationGate', () => {
         reversibility: 'irreversible',
         description: 'Send email',
       });
-      // Should not block on LLM failure
-      expect(result.action).not.toBe('block');
+      expect(result.action).toBe('show-plan'); // fail-CLOSED, not 'proceed'
+      expect(result.action).not.toBe('proceed');
       expect(result.llmEvaluated).toBe(true);
     });
   });

--- a/tests/unit/no-silent-fallbacks.test.ts
+++ b/tests/unit/no-silent-fallbacks.test.ts
@@ -282,6 +282,13 @@ describe('No Silent Fallbacks', () => {
     // sender envelope is an expected pre-migration state, and the replay path
     // already tolerates a null sender. (The sibling ALTER-TABLE idempotency
     // catch carries an in-brace @silent-fallback-ok and is exempt.)
+    //
+    // 463 unchanged by the fail-closed gate-flips ("No Silent Degradation to
+    // Brittle Fallback" standard): ExternalOperationGate.consultLLM swapped its
+    // exemption from an in-brace @silent-fallback-ok to a real fail-closed
+    // (show-plan) that REPORTS via DegradationReporter — still exempt, net zero.
+    // ContentClassifier.classify also now reports its fail-closed degradation (it
+    // was already not parser-counted). Both LLM-failure paths are now non-silent.
     const BASELINE = 463;
 
     if (silentFallbacks.length > 0) {

--- a/upgrades/eli16/llm-fallback-failclosed.md
+++ b/upgrades/eli16/llm-fallback-failclosed.md
@@ -1,0 +1,33 @@
+# Fail-Closed for LLM Safety Gates — Plain-English Overview
+
+> The one-line version: two safety gates that asked an AI for a yes/no were quietly saying "yes, go ahead" whenever the AI was unavailable — now they say "wait for approval" instead.
+
+## The problem in one breath
+
+When an AI model makes a safety decision and the model is rate-limited or down, the worst possible answer is to silently fall back to a permissive default — it looks protected but isn't. Two of our gates did exactly that: on an AI failure they returned the *go-ahead* answer.
+
+## What already exists
+
+- **The operations safety-gate** — checks risky external operations (sending email, deleting things) and decides: proceed, show-a-plan-first, or block. It was built after an agent autonomously deleted 200 emails.
+- **The outbound-leak gate** — checks content an agent is about to send to another agent for leaks (secrets, system prompts, private data) and decides: safe, sensitive, or blocked.
+
+## What this adds
+
+Both gates now **fail closed** when the AI can't answer:
+
+- The operations gate, on AI failure, returns **"show a plan first"** (require approval) instead of **"proceed"**. A risky operation the AI would have escalated can no longer slip through silently while the AI is down.
+- The outbound-leak gate, on AI failure (unparseable reply OR error), returns **"sensitive"** instead of **"safe"**, so unverifiable content is held instead of silently shipped to a peer.
+
+It also lands the **"No Silent Degradation to Brittle Fallback"** standard (when an AI gates a real action, swap providers or fail closed — never silently degrade to a weak check) and the **"Iterative Audit to Convergence"** standard (audit → fix → re-audit until a pass finds nothing new).
+
+## The safeguards
+
+**Prevents fake-safety.** A gate that silently downgrades to a permissive default is more dangerous than no gate, because it looks like it's protecting you. Failing closed removes that illusion.
+
+**No behavior change when the AI is healthy.** A complete, parseable AI verdict behaves exactly as before — these changes only affect the failure path.
+
+**Honest tradeoff.** During a heavy AI rate-limit, more operations will pause for approval instead of silently proceeding. That's the safe direction, and the planned provider-swap (try another AI before failing) will shrink how often it happens.
+
+## What ships when
+
+This PR is the two gate-flips + the standard. Next: a shared provider-swap so gates try another AI provider before failing closed, a lint that flags new silent-fallbacks in gating paths, a re-audit to convergence, and a throwaway sandbox agent for adversarial behavioral testing.

--- a/upgrades/next/llm-fallback-failclosed.md
+++ b/upgrades/next/llm-fallback-failclosed.md
@@ -1,0 +1,30 @@
+---
+change_type: fix
+audience: agent-only
+maturity: stable
+---
+<!-- bump: patch -->
+
+## What Changed
+
+Two safety-gating LLM fallbacks flipped from fail-OPEN to fail-CLOSED, implementing the new "No Silent Degradation to Brittle Fallback" standard:
+- `ExternalOperationGate.consultLLM`: on LLM failure (rate-limit/circuit-open/timeout) it returned `proceed` — now returns `show-plan` (require approval). A risky op the LLM would have escalated can no longer slip through while the LLM is down.
+- `ContentClassifier` (A2A outbound-leak gate): on parse-fail or error it returned `safe` — now returns `sensitive`, so unverifiable content is held, not shipped to a peer.
+
+Also lands `docs/specs/no-silent-degradation-to-brittle-fallback.md`: the standard + the "Iterative Audit to Convergence" standard + round-1 audit (2 dangerous fail-open gates fixed here; provider-swap + lint + re-audit + throwaway-agent are the follow-ups).
+
+## Evidence
+
+Before: with the LLM rate-limited (circuit open), `ExternalOperationGate` returned `proceed` for any op its deterministic floor didn't catch, and `ContentClassifier` returned `safe` for any content it couldn't classify. Surfaced live during the EXO 3.0 harness rate-limit. After: both fail closed (`show-plan` / `sensitive`). Regression tests: ExternalOperationGate "FAILS CLOSED to show-plan", ContentClassifier "FAILS CLOSED to sensitive" (parse-fail + throw). 98 unit tests green; tsc clean.
+
+## What to Tell Your User
+
+- "I hardened two safety checks: when the AI behind them is rate-limited or down, they now pause for your approval (or hold the content) instead of silently allowing the action. The honest tradeoff is that during a heavy AI rate-limit, a few more operations will wait for your OK — that's the safe direction, and I'm adding an automatic swap-to-another-AI-provider so it happens less often."
+
+## Summary of New Capabilities
+
+| Capability | How to Use |
+|-----------|-----------|
+| Operations gate fails closed on LLM failure | Automatic. On AI failure the gate requires a plan/approval instead of proceeding. |
+| A2A leak gate fails closed on LLM failure | Automatic. Unverifiable outbound content is held as sensitive, not shipped. |
+| No-Silent-Degradation + Iterative-Audit standards | docs/specs/no-silent-degradation-to-brittle-fallback.md |

--- a/upgrades/side-effects/llm-fallback-failclosed.md
+++ b/upgrades/side-effects/llm-fallback-failclosed.md
@@ -1,0 +1,37 @@
+# Side-Effects Review — Fail-closed for LLM safety gates
+
+**Version / slug:** `llm-fallback-failclosed`
+**Date:** `2026-06-07`
+**Author:** `Echo`
+**Second-pass reviewer:** `not required (Tier-1)`
+
+## Summary of the change
+Two safety-gating LLM fallbacks flipped from fail-OPEN to fail-CLOSED:
+`src/core/ExternalOperationGate.ts` `consultLLM` catch: `proceed` → `show-plan`.
+`src/threadline/ContentClassifier.ts` parse-fail + error catch: `safe` → `sensitive`.
+Plus `docs/specs/no-silent-degradation-to-brittle-fallback.md` (the standard + round-1 audit). Regression tests updated in both unit suites.
+
+## Decision-point inventory
+- `ExternalOperationGate.consultLLM` LLM-failure branch — modify (proceed→show-plan)
+- `ContentClassifier` parse-fail + error branches — modify (safe→sensitive)
+
+## 1. Over-block
+On LLM failure (rate-limit/circuit-open/timeout), operations now require a plan/approval and outbound A2A content is held as sensitive. During a heavy LLM outage this WILL pause more ops for approval and hold more A2A messages than before — intentional (fail-closed). Healthy-LLM behavior is unchanged. The planned provider-swap reduces failure frequency.
+
+## 2. Under-block
+Strictly reduces under-block: the previous fail-open silently allowed risky ops / shipped unverifiable content when the LLM was down. That hole is closed.
+
+## 3. Data / state
+None. Pure decision-value changes; no new files (except docs), no schema, no migration.
+
+## 4. Performance
+None. Same code path; only the returned verdict on the already-existing failure branch changes.
+
+## 5. Failure modes
+This change IS the failure-mode hardening. The fail-closed verdicts (show-plan, sensitive) are existing valid values handled downstream. No new throw paths.
+
+## 6. Security / auth
+Hardens two trust boundaries: the external-operation gate (autonomous-deletion incident origin) and the A2A outbound-leak gate. No new endpoints/capabilities.
+
+## 7. Migration / compatibility
+No migration. Behavior takes effect on next deploy; existing agents get the safer fail-closed posture automatically. No agent-installed file changes.


### PR DESCRIPTION
## What this does

Implements the first step of Justin's "No Silent Degradation to Brittle Fallback" directive: flip the **2 safety-gating LLM fallbacks that fail OPEN** to fail CLOSED, and land the standard.

1. **`ExternalOperationGate.consultLLM`** (the gate born from the autonomous-email-deletion incident) — its `catch` returned `proceed` (fail-open) on LLM failure. Now returns **`show-plan`** (require approval). The deterministic floor still applies, but the LLM is the *proportionality-escalation* layer for medium/high-risk ops; on LLM failure a risky op it would have escalated no longer silently proceeds.
2. **`ContentClassifier`** (Threadline A2A outbound-leak gate) — its parse-fail *and* error `catch` returned `safe` (fail-open). Now returns **`sensitive`** (held, and `blockSensitive` escalates to blocked), so unverifiable content isn't silently shipped to a peer.

Plus `docs/specs/no-silent-degradation-to-brittle-fallback.md` — the **"No Silent Degradation to Brittle Fallback"** standard (LLM safety gates must swap-provider or fail-closed, never silently degrade to a brittle heuristic) + the **"Iterative Audit to Convergence"** standard (audit → fix → re-audit until a pass finds nothing new) + the round-1 audit.

## ELI16

Two safety gates that ask an AI for a yes/no were quietly answering "yes, go ahead" whenever the AI was rate-limited or down. That's the worst kind of failure — it looks protected but isn't. Now they fail the safe way: the operations gate says "show me a plan / get approval" instead of "proceed," and the leak gate says "treat this as sensitive" instead of "safe." Nothing changes when the AI is healthy — only the failure path. Honest tradeoff: during a heavy AI rate-limit, a few more operations will pause for the user's OK; that's the safe direction, and the next PR adds an automatic swap-to-another-AI so it happens less.

## Causal autopsy

`origin: latent`. Both gates shipped with a *deliberate* fail-open ("availability > security" / `@silent-fallback-ok`) — a latent safety gap that's invisible until the LLM is down. The EXO 3.0 harness rate-limit made it visible (the refusal judge degrading to a brittle keyword check), which prompted the standard.

## Testing

- `tests/unit/ExternalOperationGate.test.ts` — "FAILS CLOSED to show-plan (never silently proceeds)" (was "falls back to programmatic decision").
- `tests/unit/ContentClassifier.test.ts` — "FAILS CLOSED to sensitive" for both the malformed-reply and the LLM-throws paths (were fail-open).
- 98 unit tests green; `tsc --noEmit` clean. Tier-1, full gate ceremony (ELI16 + side-effects).

## Follow-ups (tracked in the spec)

Shared provider-swap-then-fail-closed at `IntelligenceRouter.evaluate` (whole fleet inherits swap-before-degrade); a `lint-no-silent-llm-fallback`; re-audit to convergence; a throwaway sandbox agent for adversarial behavioral testing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
