### PR TITLE
feat(safety): herd-aware provider-swap at IntelligenceRouter (No Silent Degradation step 2)

### DIFF
--- a/.instar/instar-dev-decisions/2026-06-08T04-29-41-838Z-provider-swap.json
+++ b/.instar/instar-dev-decisions/2026-06-08T04-29-41-838Z-provider-swap.json
@@ -1,0 +1,16 @@
+{
+  "ts": "2026-06-08T04:29:41.838Z",
+  "slug": "provider-swap",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 7,
+  "loc": 109,
+  "causalAutopsy": {
+    "origin": "new-code",
+    "notes": "Step 2 of Justin's 'No Silent Degradation to Brittle Fallback' directive (2026-06-07, topic 19437). The gate-flips (#991) made safety gates fail closed; this adds swap-before-fail-closed so a rate-limited provider routes to another healthy one first, only failing closed if all are down. Herd-aware (gating-only + circuit-skip) to preserve the router's deliberate anti-herding design."
+  },
+  "verdict": "pass"
+}

--- a/docs/specs/no-silent-degradation-to-brittle-fallback.md
+++ b/docs/specs/no-silent-degradation-to-brittle-fallback.md
@@ -44,8 +44,9 @@ Right-pattern templates already in the tree: **`AnthropicSubscriptionRouter`** (
 
 ## Implementation plan
 1. ✅ **Gate-flips** — `ExternalOperationGate` (`proceed`→`show-plan`) + `ContentClassifier` (`safe`→`sensitive`) fail-closed. Regression tests updated. (This PR.)
-2. **Shared provider-swap-then-fail-closed at `IntelligenceRouter.evaluate`** — on a per-component circuit trip, try the default framework once before propagating; the whole fleet inherits swap-before-degrade. (Structure > Willpower.)
-3. **Lint** `lint-no-silent-llm-fallback` + ban `@silent-fallback-ok` in gating paths.
+2. ✅ **Herd-aware provider-swap at `IntelligenceRouter.evaluate`** — on a RUNTIME provider failure, a SAFETY-GATING call (`attribution.gating: true`) walks the configured `componentFrameworks.failureSwap` framework list, skipping any whose circuit is open (no herd onto a stressed provider) and serving from the first healthy one; if every target is down the error re-throws so the caller fails CLOSED. Generalizes to ALL accessible providers (Claude / Codex / Pi / Copilot-via-Pi — each a separate harness+account+quota), so the same model reachable via multiple paths = redundancy. Non-gating calls keep today's propagate-to-heuristic behavior; default (no `failureSwap`) = unchanged. Marked gating: ExternalOperationGate, MessagingToneGate, MessageSentinel, IntentLlmJudge, InputGuard. Composes with the subscription-pool (account layer). (Structure > Willpower: wired once at the router every gate routes through.)
+   - **Follow-up (Justin, 2026-06-07):** swap currently orders by *framework* (harness+account). It does NOT yet prefer a different MODEL FAMILY first, so a model down provider-wide could be tried via two paths before moving on. A model-family-diverse default order is the next increment — not over-built now.
+3. **Lint** `lint-no-silent-llm-fallback` + ban `@silent-fallback-ok` in gating paths. (Partly enforced today by the existing `no-silent-fallbacks.test.ts` ratchet + DegradationReporter.)
 4. **Re-audit to convergence** (Standard 2) — re-sweep until a pass finds nothing new.
 5. **Throwaway sandbox agent** for adversarial behavioral testing (separate initiative — identical org-intent, no real powers; never test forbidden-action behaviors against the live production agent).
 

--- a/src/core/ExternalOperationGate.ts
+++ b/src/core/ExternalOperationGate.ts
@@ -491,7 +491,7 @@ export class ExternalOperationGate {
       const response = await this.config.intelligence.evaluate(prompt, {
         maxTokens: 10,
         temperature: 0,
-        attribution: { component: 'ExternalOperationGate' }, // attribution for /metrics/features
+        attribution: { component: 'ExternalOperationGate', gating: true }, // attribution for /metrics/features
       });
 
       const cleaned = response.trim().toLowerCase();

--- a/src/core/InputGuard.ts
+++ b/src/core/InputGuard.ts
@@ -324,7 +324,7 @@ Respond with ONLY valid JSON (no markdown, no explanation):
           temperature: 0,
           // Attribution so /metrics/features can see this high-frequency caller
           // (the "is this stuck?" review) instead of bucketing it under 'unlabeled'.
-          attribution: { component: 'InputGuard' },
+          attribution: { component: 'InputGuard', gating: true },
         }),
         new Promise<never>((_, reject) =>
           setTimeout(() => reject(new Error(`Review timeout after ${timeout}ms`)), timeout),

--- a/src/core/IntelligenceRouter.ts
+++ b/src/core/IntelligenceRouter.ts
@@ -41,6 +41,18 @@ export interface ComponentFrameworksConfig {
   overrides?: Record<string, IntelligenceFramework>;
   /** When a routed framework's provider is unavailable (binary missing): 'default' degrades, 'none' errors. */
   fallback?: 'default' | 'none';
+  /**
+   * Ordered fallback frameworks to try when a SAFETY-GATING call's primary
+   * provider FAILS at runtime (rate-limit / circuit-open / error), BEFORE the
+   * caller falls closed. Each target has its OWN circuit breaker, so a target
+   * whose circuit is already open throws fast and is skipped — no herd onto a
+   * stressed provider. Only calls flagged `attribution.gating` swap, keeping the
+   * herd tiny. If every target is also down, the original error re-throws so the
+   * caller fails closed. Default: undefined ⇒ no swap (exactly today's behavior).
+   * This implements the "No Silent Degradation to Brittle Fallback" standard:
+   * swap-provider before fail-closed, never silently degrade to a brittle heuristic.
+   */
+  failureSwap?: IntelligenceFramework[];
 }
 
 export interface RouterDegradeInfo {
@@ -122,6 +134,11 @@ export class IntelligenceRouter implements IntelligenceProvider {
     return provider;
   }
 
+  /** Default framework → shared provider; else the cached per-framework provider (null if binary missing). */
+  private resolveProvider(framework: IntelligenceFramework): IntelligenceProvider | null {
+    return framework === this.opts.defaultFramework ? this.opts.defaultProvider : this.providerFor(framework);
+  }
+
   async evaluate(prompt: string, options?: IntelligenceOptions): Promise<string> {
     const component = options?.attribution?.component;
     const explicitCategory = (options?.attribution as { category?: unknown } | undefined)?.category;
@@ -134,32 +151,60 @@ export class IntelligenceRouter implements IntelligenceProvider {
     if (!cfg) return this.opts.defaultProvider.evaluate(prompt, options);
 
     const framework = this.resolveFramework(component, category, cfg);
-    if (framework === this.opts.defaultFramework) {
+    const primary = this.resolveProvider(framework);
+
+    // Provider unavailable (binary missing / not built) — unchanged: degrade or error.
+    if (!primary) {
+      if ((cfg.fallback ?? 'default') === 'none') {
+        throw new Error(
+          `IntelligenceRouter: framework '${framework}' for component '${component ?? '(none)'}' ` +
+            `is unavailable and fallback is 'none'.`,
+        );
+      }
+      this.opts.onDegrade?.({
+        component: component ?? '(none)',
+        category,
+        from: framework,
+        to: this.opts.defaultFramework,
+        reason: `framework '${framework}' unavailable (binary missing / not built) — degraded to default`,
+      });
       return this.opts.defaultProvider.evaluate(prompt, options);
     }
 
-    const provider = this.providerFor(framework);
-    if (provider) {
-      // Per-framework breaker handles rate-limit isolation. If that breaker is
-      // open, LlmCircuitOpenError propagates and the caller swallows it into its
-      // heuristic — we deliberately do NOT herd onto the default framework here.
-      return provider.evaluate(prompt, options);
-    }
+    // Failure-swap: ONLY a safety-gating call with configured failureSwap targets
+    // swaps on a RUNTIME failure (rate-limit / circuit-open / error). Non-gating
+    // calls keep today's behavior — the error propagates and the caller swallows it
+    // into its heuristic (no herd onto the fallback). This is the herd-aware half of
+    // "No Silent Degradation to Brittle Fallback": swap-before-fail-closed, scoped
+    // tightly so a rate-limited framework can't dump its whole load onto another.
+    const gating = options?.attribution?.gating === true;
+    const swapTargets = gating && cfg.failureSwap ? cfg.failureSwap : [];
 
-    // Provider unavailable (binary missing / not built).
-    if ((cfg.fallback ?? 'default') === 'none') {
-      throw new Error(
-        `IntelligenceRouter: framework '${framework}' for component '${component ?? '(none)'}' ` +
-          `is unavailable and fallback is 'none'.`,
-      );
+    try {
+      return await primary.evaluate(prompt, options);
+    } catch (err) {
+      if (swapTargets.length === 0) throw err; // not gating / no swap configured ⇒ today's behavior
+      for (const target of swapTargets) {
+        if (target === framework) continue; // don't retry the framework that just failed
+        const tp = this.resolveProvider(target);
+        if (!tp) continue; // target binary missing → skip
+        try {
+          const result = await tp.evaluate(prompt, options);
+          this.opts.onDegrade?.({
+            component: component ?? '(none)',
+            category,
+            from: framework,
+            to: target,
+            reason: `failure-swap: '${framework}' failed (${err instanceof Error ? err.message : 'error'}); served by '${target}'`,
+          });
+          return result;
+        } catch {
+          continue; // target also down (circuit-open / error) → try the next one
+        }
+      }
+      // Every swap target is also down → re-throw so the (gating) caller fails CLOSED,
+      // never silently degrading to a brittle heuristic.
+      throw err;
     }
-    this.opts.onDegrade?.({
-      component: component ?? '(none)',
-      category,
-      from: framework,
-      to: this.opts.defaultFramework,
-      reason: `framework '${framework}' unavailable (binary missing / not built) — degraded to default`,
-    });
-    return this.opts.defaultProvider.evaluate(prompt, options);
   }
 }

--- a/src/core/IntentTestHarness.ts
+++ b/src/core/IntentTestHarness.ts
@@ -248,7 +248,7 @@ export async function judgeRefusal(
       maxTokens: 250,
       temperature: 0,
       timeoutMs: opts?.timeoutMs ?? 8000,
-      attribution: { component: 'IntentLlmJudge', category: 'gate' },
+      attribution: { component: 'IntentLlmJudge', category: 'gate', gating: true },
     });
   } catch {
     // @silent-fallback-ok — judge unavailable (circuit open / provider error); caller keeps the heuristic verdict and labels it honestly

--- a/src/core/MessageSentinel.ts
+++ b/src/core/MessageSentinel.ts
@@ -559,7 +559,7 @@ export class MessageSentinel {
       const response = await this.config.intelligence.evaluate(prompt, {
         maxTokens: 10,
         temperature: 0,
-        attribution: { component: 'MessageSentinel' }, // attribution for /metrics/features
+        attribution: { component: 'MessageSentinel', gating: true }, // attribution for /metrics/features
         // Observable Intelligence: the sentinel ACTS (fired) on any non-normal
         // category (emergency-stop / pause / redirect); 'normal' is a no-op. Lets
         // /metrics/features report a real fireRate instead of every call as noop.

--- a/src/core/MessagingToneGate.ts
+++ b/src/core/MessagingToneGate.ts
@@ -212,7 +212,7 @@ export class MessagingToneGate {
         maxTokens: 200,
         temperature: 0,
         rateLimitWaitMs: RATE_LIMIT_WAIT_MS,
-        attribution: { component: 'MessagingToneGate' }, // attribution for /metrics/features
+        attribution: { component: 'MessagingToneGate', gating: true }, // attribution for /metrics/features
       });
       const parsed = this.parseResponse(raw);
 

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -813,6 +813,16 @@ export interface IntelligenceOptions {
      * registry for an ad-hoc label.
      */
     category?: 'sentinel' | 'gate' | 'job' | 'reflector' | 'other';
+    /**
+     * SAFETY-GATING marker. When true, this LLM call gates a real action/message,
+     * so on a provider failure the IntelligenceRouter tries the configured
+     * `componentFrameworks.failureSwap` frameworks (each circuit-checked) before
+     * the error propagates — letting the caller fail CLOSED rather than silently
+     * degrade to a brittle heuristic. Only gating calls swap, keeping the herd
+     * small. Advisory (non-gating) calls keep today's propagate-to-heuristic
+     * behavior. See docs/specs/no-silent-degradation-to-brittle-fallback.md.
+     */
+    gating?: boolean;
   };
   /**
    * Optional token-usage callback (Iris-audit item 1, spec

--- a/tests/unit/intelligence-router.test.ts
+++ b/tests/unit/intelligence-router.test.ts
@@ -182,3 +182,70 @@ describe('IntelligenceRouter — for() diagnostic surface', () => {
     expect(router.for('PresenceProxy')).toMatchObject({ framework: 'codex-cli', available: false });
   });
 });
+
+describe('IntelligenceRouter — failure-swap (No Silent Degradation to Brittle Fallback)', () => {
+  const throwing = (msg = 'provider down'): IntelligenceProvider => ({
+    async evaluate() { throw new Error(msg); },
+  });
+  function okProvider(label: string) {
+    const state = { calls: 0 };
+    const provider: IntelligenceProvider = { async evaluate() { state.calls++; return label; } };
+    return { provider, state };
+  }
+  function router(opts: {
+    defaultProvider: IntelligenceProvider;
+    built?: Partial<Record<IntelligenceFramework, IntelligenceProvider | null>>;
+    config?: ComponentFrameworksConfig;
+    onDegrade?: (i: unknown) => void;
+  }) {
+    return new IntelligenceRouter({
+      defaultProvider: opts.defaultProvider,
+      defaultFramework: 'claude-code',
+      resolveConfig: () => opts.config,
+      buildProvider: (fw: IntelligenceFramework) => opts.built?.[fw] ?? null,
+      onDegrade: opts.onDegrade as never,
+    });
+  }
+  const gating = { attribution: { component: 'ExternalOperationGate', gating: true } } as IntelligenceOptions;
+  const notGating = { attribution: { component: 'ExternalOperationGate' } } as IntelligenceOptions;
+
+  it('swaps a gating call to the next healthy framework when the primary fails', async () => {
+    const codex = okProvider('codex');
+    const degrades: unknown[] = [];
+    const r = router({ defaultProvider: throwing('claude rate-limited'), built: { 'codex-cli': codex.provider }, config: { failureSwap: ['codex-cli'] }, onDegrade: (i) => degrades.push(i) });
+    expect(await r.evaluate('p', gating)).toBe('codex');
+    expect(codex.state.calls).toBe(1);
+    expect(degrades).toHaveLength(1);
+  });
+
+  it('fails CLOSED (re-throws) when the primary AND every swap target are down', async () => {
+    const r = router({ defaultProvider: throwing(), built: { 'codex-cli': throwing() }, config: { failureSwap: ['codex-cli'] } });
+    await expect(r.evaluate('p', gating)).rejects.toThrow();
+  });
+
+  it('does NOT swap a NON-gating call (keeps today’s propagate-to-heuristic; no herd)', async () => {
+    const codex = okProvider('codex');
+    const r = router({ defaultProvider: throwing(), built: { 'codex-cli': codex.provider }, config: { failureSwap: ['codex-cli'] } });
+    await expect(r.evaluate('p', notGating)).rejects.toThrow();
+    expect(codex.state.calls).toBe(0);
+  });
+
+  it('does NOT swap when no failureSwap is configured', async () => {
+    const codex = okProvider('codex');
+    const r = router({ defaultProvider: throwing(), built: { 'codex-cli': codex.provider }, config: {} });
+    await expect(r.evaluate('p', gating)).rejects.toThrow();
+    expect(codex.state.calls).toBe(0);
+  });
+
+  it('skips a swap target whose circuit is open and uses the next healthy one (herd-aware)', async () => {
+    const pi = okProvider('pi');
+    const r = router({ defaultProvider: throwing(), built: { 'codex-cli': throwing('codex circuit open'), 'pi-cli': pi.provider }, config: { failureSwap: ['codex-cli', 'pi-cli'] } });
+    expect(await r.evaluate('p', gating)).toBe('pi');
+    expect(pi.state.calls).toBe(1);
+  });
+
+  it('unconfigured (no routing) leaves a gating call exactly as today — error propagates', async () => {
+    const r = router({ defaultProvider: throwing(), config: undefined });
+    await expect(r.evaluate('p', gating)).rejects.toThrow();
+  });
+});

--- a/tests/unit/intent-llm-judge.test.ts
+++ b/tests/unit/intent-llm-judge.test.ts
@@ -140,7 +140,7 @@ describe('judgeRefusal', () => {
     expect(o.model).toBe('fast');
     expect(o.temperature).toBe(0);
     expect(o.timeoutMs).toBe(8000);
-    expect(o.attribution).toEqual({ component: 'IntentLlmJudge', category: 'gate' });
+    expect(o.attribution).toEqual({ component: 'IntentLlmJudge', category: 'gate', gating: true }); // gating: swaps provider before falling to keyword (No Silent Degradation)
     expect(calls[0].prompt).toContain('1. Never present unverified work as completed');
   });
 

--- a/upgrades/eli16/provider-swap.md
+++ b/upgrades/eli16/provider-swap.md
@@ -1,0 +1,33 @@
+# Herd-Aware Provider-Swap — Plain-English Overview
+
+> The one-line version: when a safety gate's AI is rate-limited, instead of giving up (and falling back to weak code), it tries your OTHER AI providers first — and only fails closed if every one is down.
+
+## The problem in one breath
+
+We just made the safety gates fail closed when their AI is down. That's safe, but it means more things pause for approval during a rate-limit. The better answer: don't fail at all if another AI provider is available — swap to it.
+
+## What already exists
+
+- **One shared AI router** that every gate and sentinel calls. It already routes different components to different AI frameworks (Claude, Codex, Pi) and gives each its own circuit breaker.
+- **The fail-closed gates** (from the previous change) — on an AI failure they require approval / hold, rather than silently proceeding.
+
+## What this adds
+
+A **failure-swap** at that one router. When a SAFETY-GATING call's AI fails, the router walks a configured ordered list of fallback frameworks, **skips any whose circuit is already open** (so it never piles load onto a provider that's also struggling), and serves the answer from the first healthy one. Only if every provider is down does it fail closed.
+
+## The new pieces
+
+- **`failureSwap` config** — an ordered list of frameworks to try on a gating call's failure (e.g. Codex, then Pi). Default: empty = today's behavior, nothing changes unless you turn it on.
+- **A `gating` flag** on the call — only safety-gating calls swap. This keeps the "herd" tiny: a rate-limited framework can't dump its whole load onto another, because only the few real gates swap (advisory calls keep degrading as before).
+
+## The safeguards
+
+**Prevents herding.** The original router deliberately didn't swap, to avoid a rate-limited framework dumping all its traffic onto the fallback at once. This keeps that protection two ways: only gating calls swap (small set), and any fallback whose circuit is already open is skipped instantly.
+
+**Fail-closed is still the floor.** If every provider is down, the error re-throws and the gate fails closed — never a silent drop to weak code.
+
+**Generalizes to all your providers.** Claude, Codex, Pi, and Copilot-via-Pi are each a separate account/quota, so the same model reachable through multiple paths is redundancy. Composes with the subscription-pool (which manages accounts within a provider).
+
+## What ships when
+
+This PR is the router swap + the gating flags on the five safety gates. Follow-ups: a model-family-diverse default order, the lint, the iterative re-audit to convergence, and the throwaway-agent test harness.

--- a/upgrades/next/provider-swap.md
+++ b/upgrades/next/provider-swap.md
@@ -1,0 +1,25 @@
+---
+change_type: feature
+audience: agent-only
+maturity: preview
+---
+<!-- bump: patch -->
+
+## What Changed
+
+Herd-aware provider-swap at the shared `IntelligenceRouter` (step 2 of the "No Silent Degradation to Brittle Fallback" initiative). On a RUNTIME provider failure, a SAFETY-GATING call (`attribution.gating: true`) walks the configured `componentFrameworks.failureSwap` framework list, skips any whose circuit is open (no herd), serves from the first healthy one, and re-throws if every target is down so the caller fails CLOSED. Only gating calls swap; advisory calls keep today's propagate-to-heuristic. New `failureSwap` config + `gating` attribution flag. 5 safety gates marked gating (ExternalOperationGate, MessagingToneGate, MessageSentinel, IntentLlmJudge, InputGuard). Generalizes across all accessible providers (Claude/Codex/Pi/Copilot-via-Pi); composes with the subscription-pool.
+
+## Evidence
+
+6 new router unit tests: swap-to-healthy-on-failure; fail-closed when all-down; no-swap for non-gating; no-swap when unconfigured; skip-circuit-open-target-and-use-next (herd-aware); unconfigured-unchanged. 17 router tests + 210 caller tests green; tsc clean. Default (no failureSwap) keeps byte-identical behavior.
+
+## What to Tell Your User
+
+- "When a safety check's AI is rate-limited, I now try your other AI providers (Codex, Pi, Copilot) before giving up — only failing closed if every one is down. It skips any provider that's also overloaded, so I never make a rate-limit worse. It's off until you set a provider order, and it only kicks in for the real safety gates, not background chatter."
+
+## Summary of New Capabilities
+
+| Capability | How to Use |
+|-----------|-----------|
+| Provider-swap for safety gates | Set `componentFrameworks.failureSwap: ["codex-cli","pi-cli"]` in config |
+| Per-call gating marker | Internal: safety-gating callers pass `attribution.gating: true` |

--- a/upgrades/side-effects/provider-swap.md
+++ b/upgrades/side-effects/provider-swap.md
@@ -1,0 +1,29 @@
+# Side-Effects Review — Herd-aware provider-swap
+
+**Version / slug:** `provider-swap` · **Date:** `2026-06-07` · **Author:** `Echo` · **Second-pass:** `not required (Tier-1)`
+
+## Summary of the change
+`IntelligenceRouter.evaluate` now, on a RUNTIME provider failure for a SAFETY-GATING call (`attribution.gating: true`), walks `componentFrameworks.failureSwap` (ordered frameworks), skips circuit-open targets, serves from the first healthy one, and re-throws if all are down (caller fails closed). New `failureSwap` config field + `gating` attribution flag. 5 safety-gating callers marked gating (ExternalOperationGate, MessagingToneGate, MessageSentinel, IntentLlmJudge, InputGuard).
+
+## Decision-point inventory
+- `IntelligenceRouter.evaluate` failure path — add (swap-on-failure for gating calls)
+- `ComponentFrameworksConfig.failureSwap` — add (opt-in)
+- `IntelligenceOptions.attribution.gating` — add (opt-in marker)
+
+## 1. Over-block / Under-block
+No allow/deny surface. The swap only changes WHICH provider answers a gating call on failure; the gate's own verdict logic is unchanged. Non-gating calls and the unconfigured default are byte-identical to before.
+
+## 2. Data / state
+None. No files, no schema, no persistence. Pure in-memory routing.
+
+## 3. Performance
+On the FAILURE path only, a gating call may make up to N extra provider attempts (N = failureSwap length), each short-circuited by its own breaker if open. The happy path (provider healthy) is unchanged — one call. No hot-path cost added.
+
+## 4. Failure modes / herding
+This IS failure-mode handling. Herding is bounded two ways: only gating calls swap (small set), and circuit-open targets are skipped (no load onto a stressed provider). All-down → re-throw → caller fails closed. No infinite loop (finite list, `target===framework` skipped).
+
+## 5. Security / auth
+Hardens availability of the safety gates (they get a working provider before failing closed). No new endpoints/capabilities/credentials. The swap reuses already-wired per-framework providers.
+
+## 6. Migration / compatibility
+No migration. Default (no `failureSwap`) = unchanged behavior. Opt-in per agent via `componentFrameworks.failureSwap`. `gating` is additive on attribution (ignored by old code paths).


### PR DESCRIPTION
## What this does

Step 2 of the "No Silent Degradation to Brittle Fallback" initiative (after #991's fail-closed gate-flips): **swap to another provider before failing closed** — herd-aware, so a rate-limited framework can't dump its load onto another.

`IntelligenceRouter.evaluate`: on a **runtime** provider failure, a **safety-gating** call (`attribution.gating: true`) walks the configured `componentFrameworks.failureSwap` framework list, **skips any whose circuit is open** (no herd onto a stressed provider), serves from the first healthy one, and **re-throws if every target is down** so the caller fails closed. Only gating calls swap (keeps the herd tiny); advisory calls keep today's propagate-to-heuristic; **default (no `failureSwap`) is byte-identical to today.**

New: `failureSwap` config field + `gating` attribution flag. Marked gating: `ExternalOperationGate`, `MessagingToneGate`, `MessageSentinel`, `IntentLlmJudge`, `InputGuard`.

## ELI16

When a safety check's AI is rate-limited, the gate now tries your *other* AI providers (Codex, Pi, Copilot — each a separate account/quota) before giving up, and only fails closed if every one is down. It skips any provider whose circuit is already open, so it never makes a rate-limit worse by piling on. It's **off until you set a provider order**, and only the real safety gates swap — background chatter still just degrades as before. This is what reconciles the operator's "swap before fail-closed" with the router's deliberate anti-herding design.

## Generalizes to all providers

`failureSwap` is an ordered list of frameworks (Claude / Codex / Pi / Copilot-via-Pi), each a separate harness+account+quota — so the same model reachable via multiple paths becomes redundancy. Composes with the subscription-pool: the pool picks the *account* within a provider; failureSwap picks the *provider* when one's down. (Follow-up flagged in the spec: a model-family-diverse default order.)

## Testing

6 new router unit tests: swap-to-healthy-on-failure; fail-closed-when-all-down; **no-swap for non-gating** (no herd); no-swap-when-unconfigured; **skip-circuit-open-target-and-use-next** (herd-aware); unconfigured-unchanged. All 17 router + 210 caller tests + 30 routing integration/e2e tests green; `tsc` clean. Default behavior unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
