### PR TITLE
fix(subscription-auth): carry conversation transcript across an account swap

### DIFF
--- a/.instar/instar-dev-decisions/2026-06-08T05-45-44-493Z-subscription-swap-transcript-continuity.json
+++ b/.instar/instar-dev-decisions/2026-06-08T05-45-44-493Z-subscription-swap-transcript-continuity.json
@@ -1,0 +1,13 @@
+{
+  "ts": "2026-06-08T05:45:44.493Z",
+  "slug": "subscription-swap-transcript-continuity",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 79,
+  "causalAutopsy": null,
+  "verdict": "pass"
+}

--- a/docs/specs/_drafts/subscription-swap-transcript-continuity.eli16.md
+++ b/docs/specs/_drafts/subscription-swap-transcript-continuity.eli16.md
@@ -1,0 +1,20 @@
+# Account-swap conversation continuity — Plain-English Overview
+
+> The one-line version: when a session moves to another account, it now copies the conversation history over first — so it actually picks up where it left off instead of starting blank.
+
+## The problem in one breath
+
+Each account's login lives in its own folder, and Claude keeps the conversation history in that same per-account folder. The quota swap switched which account a session uses, but left the conversation behind — so resuming on the new account said "no conversation found" and the session would start fresh. The whole point of the "never lose your session" guarantee was quietly broken.
+
+## How it was missed
+
+The automated test that ships with the feature SIMULATED the restart — it never moved a real conversation between two real account folders. So it passed while the real thing was broken. The live test caught it immediately.
+
+## The fix
+
+Right before a swapped session resumes under the new account, I copy its conversation history file into that account's folder. Then `--resume` finds it and the session continues exactly where it left off. It's safe: it only runs during an account swap, only copies (never deletes), and if anything goes wrong it just falls back to today's behavior (a fresh start) instead of erroring.
+
+## Proven
+
+- A focused test covers the copy (source→target, no-op when already there, default-folder source, not-found case).
+- And end-to-end on your real accounts: a conversation started on SageMind, after the copy, resumed on the Justin account and correctly recalled its test marker.

--- a/src/core/SessionRefresh.ts
+++ b/src/core/SessionRefresh.ts
@@ -25,10 +25,69 @@
  * { ok: false, code: 'not_telegram_bound' } and remain a follow-up.
  */
 
+import fs from 'node:fs';
+import path from 'node:path';
 import type { SessionManager } from './SessionManager.js';
 import type { StateManager } from './StateManager.js';
 import type { TelegramAdapter } from '../messaging/TelegramAdapter.js';
 import type { TopicResumeMap } from './TopicResumeMap.js';
+
+/**
+ * Account-swap conversation continuity. Claude stores conversation transcripts
+ * PER CONFIG HOME (`<CLAUDE_CONFIG_DIR>/projects/<projectDir>/<uuid>.jsonl`), so a
+ * quota swap that changes CLAUDE_CONFIG_DIR and then runs `claude --resume <uuid>`
+ * finds "No conversation found" — the transcript is still in the OLD account's
+ * config home. (The resume UUID is account-agnostic, but the transcript STORAGE
+ * is config-home-local — the gap a mocked refresh test can't see.) Before the
+ * respawn, copy the transcript into the target config home so --resume succeeds.
+ *
+ * Self-contained: finds the transcript by uuid across the user's `~/.claude*`
+ * config homes (default + enrollment-wizard slots) and copies it, preserving the
+ * `projects/<projectDir>/` relative path. Idempotent (no-op if already present),
+ * best-effort (never throws). Returns true if the transcript is in the target
+ * afterward.
+ */
+function transcriptRelPath(projectsDir: string, uuid: string): string | null {
+  try {
+    for (const proj of fs.readdirSync(projectsDir)) {
+      const f = path.join(projectsDir, proj, `${uuid}.jsonl`);
+      if (fs.existsSync(f)) return path.join(proj, `${uuid}.jsonl`);
+    }
+  } catch { /* @silent-fallback-ok: missing/unreadable projects dir */ }
+  return null;
+}
+
+export function ensureResumeTranscriptInConfigHome(uuid: string, targetConfigHome: string): boolean {
+  try {
+    const home = process.env.HOME || '';
+    const target = targetConfigHome.startsWith('~')
+      ? path.join(home, targetConfigHome.slice(1))
+      : targetConfigHome;
+    const targetProjects = path.join(target, 'projects');
+    if (transcriptRelPath(targetProjects, uuid)) return true; // already there → no-op
+    let homes: string[] = [];
+    try {
+      homes = fs.readdirSync(home)
+        .filter((n) => n === '.claude' || n.startsWith('.claude-'))
+        .map((n) => path.join(home, n));
+    } catch { /* @silent-fallback-ok: HOME unreadable */ }
+    for (const ch of homes) {
+      if (path.resolve(ch) === path.resolve(target)) continue;
+      const rel = transcriptRelPath(path.join(ch, 'projects'), uuid);
+      if (rel) {
+        const dst = path.join(targetProjects, rel);
+        fs.mkdirSync(path.dirname(dst), { recursive: true });
+        fs.copyFileSync(path.join(ch, 'projects', rel), dst);
+        return true;
+      }
+    }
+    return false;
+  } catch {
+    // @silent-fallback-ok: continuity-copy is best-effort; a failure means the
+    // swap may start fresh (logged by the caller), not crash the refresh.
+    return false;
+  }
+}
 
 export interface SessionRefreshDeps {
   sessionManager: SessionManager;
@@ -234,6 +293,26 @@ export class SessionRefresh {
       const accountSwap = (opts.configHome || opts.accountId)
         ? { configHome: opts.configHome, accountId: opts.accountId }
         : undefined;
+
+      // Account-swap continuity: claude stores transcripts per config home, so a
+      // swap to a new CLAUDE_CONFIG_DIR must carry the conversation transcript
+      // across or `--resume` finds nothing. Skip on `fresh` (we intentionally
+      // start a new conversation then). Best-effort: a miss just means the
+      // resumed session starts fresh — logged, never fatal.
+      if (accountSwap?.configHome && !fresh) {
+        const resumeUuid = stateSession.claudeSessionId;
+        if (resumeUuid) {
+          const ok = ensureResumeTranscriptInConfigHome(resumeUuid, accountSwap.configHome);
+          console.log(
+            `[SessionRefresh] account-swap continuity: transcript ${ok ? 'ensured in' : 'NOT found for'} ${accountSwap.configHome} (uuid=${resumeUuid}, sessionName=${sessionName})`,
+          );
+        } else {
+          console.log(
+            `[SessionRefresh] account-swap continuity: no claudeSessionId on session "${sessionName}" — cannot pre-copy transcript; resumed session may start fresh`,
+          );
+        }
+      }
+
       const newSessionName = await this.deps.respawner(sessionName, topicId, followUpPrompt, accountSwap);
 
       // ── verify + finalize ────────────────────────────────────────────

--- a/tests/unit/session-refresh-account-swap-transcript.test.ts
+++ b/tests/unit/session-refresh-account-swap-transcript.test.ts
@@ -1,0 +1,71 @@
+/**
+ * Unit test for ensureResumeTranscriptInConfigHome (account-swap continuity).
+ * Claude stores conversation transcripts per config home, so a quota swap must
+ * copy the transcript into the new account's config home or `claude --resume`
+ * finds nothing. This is the gap the live swap test caught (the mocked e2e
+ * couldn't). Hermetic: a temp HOME with two fake config homes, no real claude.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { ensureResumeTranscriptInConfigHome } from '../../src/core/SessionRefresh.js';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+
+const UUID = 'fcbd48ba-348f-4831-965f-bf6646f9898c';
+const PROJ = '-Users-justin--instar-agents-echo';
+
+describe('ensureResumeTranscriptInConfigHome', () => {
+  let home: string;
+  let origHome: string | undefined;
+
+  beforeEach(() => {
+    home = fs.mkdtempSync(path.join(os.tmpdir(), 'swap-home-'));
+    origHome = process.env.HOME;
+    process.env.HOME = home;
+  });
+  afterEach(() => {
+    process.env.HOME = origHome;
+    try { SafeFsExecutor.safeRmSync(home, { recursive: true, force: true, operation: 'tests/unit/session-refresh-account-swap-transcript.test.ts:cleanup' }); } catch { /* @silent-fallback-ok */ }
+  });
+
+  function writeTranscript(configHomeName: string) {
+    const dir = path.join(home, configHomeName, 'projects', PROJ);
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, `${UUID}.jsonl`), '{"type":"summary"}\n');
+  }
+
+  it('copies the transcript from the source config home into the target', () => {
+    writeTranscript('.claude-echo-sagemind'); // source account has the conversation
+    const targetHome = path.join(home, '.claude-echo-justin-gmail');
+    expect(ensureResumeTranscriptInConfigHome(UUID, targetHome)).toBe(true);
+    expect(fs.existsSync(path.join(targetHome, 'projects', PROJ, `${UUID}.jsonl`))).toBe(true);
+  });
+
+  it('is a no-op when the transcript is already in the target', () => {
+    writeTranscript('.claude-echo-justin-gmail'); // already there
+    const targetHome = path.join(home, '.claude-echo-justin-gmail');
+    expect(ensureResumeTranscriptInConfigHome(UUID, targetHome)).toBe(true);
+  });
+
+  it('returns false when the transcript exists nowhere', () => {
+    const targetHome = path.join(home, '.claude-echo-justin-gmail');
+    expect(ensureResumeTranscriptInConfigHome(UUID, targetHome)).toBe(false);
+  });
+
+  it('finds the source under the default ~/.claude too', () => {
+    writeTranscript('.claude'); // conversation ran under the default config home
+    const targetHome = path.join(home, '.claude-echo-justin-gmail');
+    expect(ensureResumeTranscriptInConfigHome(UUID, targetHome)).toBe(true);
+    expect(fs.existsSync(path.join(targetHome, 'projects', PROJ, `${UUID}.jsonl`))).toBe(true);
+  });
+
+  it('preserves the project-dir relative path', () => {
+    writeTranscript('.claude-echo-sagemind');
+    const targetHome = path.join(home, '.claude-echo-justin-gmail');
+    ensureResumeTranscriptInConfigHome(UUID, targetHome);
+    // copied to the SAME projects/<projectDir>/ path, not flattened
+    expect(fs.existsSync(path.join(targetHome, 'projects', PROJ, `${UUID}.jsonl`))).toBe(true);
+  });
+});

--- a/upgrades/next/subscription-swap-transcript-continuity.md
+++ b/upgrades/next/subscription-swap-transcript-continuity.md
@@ -1,0 +1,46 @@
+# Account-swap conversation continuity (transcript copy)
+
+<!-- bump: patch -->
+
+## What Changed
+
+Fixes a gap in the quota-swap continuity guarantee: Claude stores conversation
+transcripts per config home, so a swap that changed `CLAUDE_CONFIG_DIR` and then
+ran `claude --resume <uuid>` found "no conversation" — the transcript was still in
+the OLD account's config home, so the conversation was lost (resume → fresh start).
+`SessionRefresh.refreshSession` now copies the transcript into the target account's
+config home (via `ensureResumeTranscriptInConfigHome`) before the `--resume`
+respawn. Best-effort + idempotent; only runs on an account swap; skipped on a
+`fresh` respawn; never throws (a miss falls back to today's fresh-start behavior).
+
+## Evidence
+
+Caught by live testing (topic 20905) — the merged e2e passed only because it mocked
+the refresh and never moved a real conversation between real config homes.
+
+Reproduction (real accounts):
+- Started a conversation under the SageMind config home (it recalled a test marker).
+- Tried to resume that session id under the Justin config home (as a swap would):
+  **Before:** `claude --resume <uuid>` → "No conversation found with session ID …"
+  — the conversation is lost.
+  **After:** the shipped `ensureResumeTranscriptInConfigHome` copies the transcript
+  into the Justin config home, then `claude --resume <uuid>` → succeeds and correctly
+  recalls the marker (verified end-to-end with marker SWAP-FIX-VERIFY-8852).
+
+Confirmed transcripts are config-home-local: a conversation run under
+`~/.claude-echo-sagemind` wrote to `~/.claude-echo-sagemind/projects/…`, not the
+default `~/.claude/projects`.
+
+## What to Tell Your User
+
+When I balance a session across your subscription accounts and one account hits
+its limit, the session now moves to another account AND keeps its conversation —
+it picks up exactly where it left off instead of starting blank. Earlier, the
+move worked but the conversation history didn't follow it across, so a swapped
+session would have lost its context. That gap is closed.
+
+## Summary of New Capabilities
+
+- **Conversation survives an account swap** — the transcript is carried into the new
+  account's config home before resume, so a swapped session continues intact instead
+  of starting fresh.

--- a/upgrades/side-effects/subscription-swap-transcript-continuity.md
+++ b/upgrades/side-effects/subscription-swap-transcript-continuity.md
@@ -1,0 +1,55 @@
+# Side-Effects Review — account-swap conversation continuity (transcript copy)
+
+## Scope of change
+
+- `src/core/SessionRefresh.ts` — new exported `ensureResumeTranscriptInConfigHome(uuid,
+  targetConfigHome)` + a guarded call in `refreshSession`, just before the respawner,
+  when `accountSwap.configHome` is set and not a `fresh` respawn. Copies the conversation
+  transcript into the target account's config home so `claude --resume` finds it.
+
+## The gap (caught by live testing, not the mocked e2e)
+
+Claude stores transcripts PER CONFIG HOME: `<CLAUDE_CONFIG_DIR>/projects/<projectDir>/
+<uuid>.jsonl`. The P1.3 swap changes `CLAUDE_CONFIG_DIR` to the new account then runs
+`claude --resume <uuid>` — which looks in the NEW config home and finds nothing, because
+the transcript is still in the OLD account's config home. So the "continuity guarantee"
+(the headline feature) would silently LOSE the conversation (resume → fresh start). The
+P1.3 comment "the resume UUID is account-agnostic" was right about the UUID but missed
+that transcript STORAGE is config-home-local. The merged e2e passed only because it
+mocked the refresh — it never moved a real conversation between real config homes.
+
+## The fix
+
+Before the `--resume` respawn under the new config home, find the transcript by uuid
+across the user's `~/.claude*` config homes (default + enrollment-wizard slots) and copy
+it into the target config home, preserving the `projects/<projectDir>/` relative path.
+Idempotent (no-op if already present), best-effort (never throws — a miss is logged and
+the session simply starts fresh, the prior behavior).
+
+## Authority / autonomy
+
+No new authority. Only runs on an account swap (`accountSwap.configHome` set), which is
+itself opt-in/dark. Touches only the per-account `projects/` transcript files (copy, never
+delete). When no swap is requested — every existing refresh/recovery — this code does not
+run; behaviour is byte-for-byte unchanged.
+
+## Framework generality
+
+Claude-code-specific by nature (the `<CLAUDE_CONFIG_DIR>/projects/.../<uuid>.jsonl` layout
+is Claude's), matching the standard's Claude-first scope. The account-swap path is only
+taken for claude-code sessions; other frameworks don't set `configHome`.
+
+## Failure modes considered
+
+- `fresh` respawn → skipped (we intentionally start a new conversation).
+- No `claudeSessionId` on the session → logged, skipped (can't know the uuid); resumed
+  session may start fresh — same as today, not a regression.
+- Transcript exists nowhere / unreadable → returns false, logged; respawn proceeds (fresh).
+- Already in the target → no-op (idempotent).
+- Config home outside `~/.claude*` → not found by the search (documented limitation; all
+  current config homes — default + wizard slots — live under HOME).
+
+## Migration / parity
+
+Pure additive logic on files claude already writes — no migration, no config, no stored
+shape change. Ships via dist.


### PR DESCRIPTION
## What this is (ELI16)

Each account's login lives in its own folder, and Claude keeps the **conversation history** in that same per-account folder. The quota swap switched which account a session uses but left the conversation behind — so resuming on the new account said *"No conversation found"* and the session would start blank. The headline "never lose your session" guarantee was quietly broken. **Caught by live testing** (the shipped e2e mocked the restart, so it never moved a real conversation between real account folders).

## Fix

New `ensureResumeTranscriptInConfigHome(uuid, targetConfigHome)` finds the transcript by uuid across the user's `~/.claude*` config homes and copies it into the target account's config home (preserving `projects/<projectDir>/`) before the `--resume` respawn. Called in `SessionRefresh.refreshSession` only when `accountSwap.configHome` is set and it's not a `fresh` respawn. Idempotent, best-effort (never throws — a miss logs and falls back to today's fresh-start). **Additive:** when no swap is requested, the restart path is byte-for-byte unchanged.

## Evidence

Reproduced + fixed on the real accounts:
- Conversation under `~/.claude-echo-sagemind` → resume under `~/.claude-echo-justin-gmail`: **before** → "No conversation found"; **after** the shipped helper copies the transcript → resume **succeeds** and recalls the marker (`SWAP-FIX-VERIFY-8852`). Confirmed transcripts are config-home-local.

## Tests

5 hermetic unit tests (copy source→target, no-op-if-present, default-`~/.claude` source, not-found, path-preservation) + the 20 existing SessionRefresh tests green; tsc clean. Tier-1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)