### PR TITLE
feat(subscription-auth): warn about the Claude two-code login flow during enrollment

### DIFF
--- a/.instar/instar-dev-decisions/2026-06-08T06-28-58-305Z-enroll-two-code-warning.json
+++ b/.instar/instar-dev-decisions/2026-06-08T06-28-58-305Z-enroll-two-code-warning.json
@@ -1,0 +1,13 @@
+{
+  "ts": "2026-06-08T06:28:58.305Z",
+  "slug": "enroll-two-code-warning",
+  "suggestedTier": 1,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 2,
+  "loc": 29,
+  "causalAutopsy": null,
+  "verdict": "pass"
+}

--- a/dashboard/subscriptions.js
+++ b/dashboard/subscriptions.js
@@ -161,6 +161,11 @@ export function renderPendingLogins(doc, target, logins, now = Date.now()) {
     const ttl = l && l.ttlExpiresAt ? countdown(l.ttlExpiresAt, now) : '';
     head.appendChild(el(doc, 'span', 'sub-pending-ttl', ttl ? `expires in ${ttl}` : 'expired'));
     row.appendChild(head);
+    // Flow heads-up (e.g. the Claude two-code sequence) — shown before the code so
+    // the operator knows what to expect. Plain text, sanitized; never a live href.
+    if (l && l.notice) {
+      row.appendChild(el(doc, 'div', 'sub-pending-notice', sanitizeForDisplay(l.notice, 'summary')));
+    }
     if (l && l.userCode) {
       row.appendChild(el(doc, 'div', 'sub-pending-code', `Code: ${sanitizeForDisplay(l.userCode, 'code')}`));
     }

--- a/docs/specs/_drafts/enroll-two-code-warning.eli16.md
+++ b/docs/specs/_drafts/enroll-two-code-warning.eli16.md
@@ -1,0 +1,48 @@
+# ELI16 — Warn the operator about Claude's two-code login
+
+## The one-sentence version
+
+When I start enrolling a new Claude subscription account, the pending-login card
+now tells you up front that Claude will ask for TWO codes in a row — so the second
+prompt doesn't catch you off guard.
+
+## What problem is this fixing?
+
+To enroll a new Claude account, I drive Claude's login and show you a sign-in link
+plus (for some flows) a code. You open the link on your phone, approve, and you're
+in. That's the happy path.
+
+But for a **brand-new** Claude login, Anthropic adds a step: it first emails you an
+**email-verification code**, and only after you enter that does it show you the
+actual **sign-in code**. So you end up dealing with two different codes, one after
+the other. During live testing (topic 20905) this was genuinely confusing — you got
+a second code when you thought you were done, with nothing explaining why.
+
+## What I actually changed
+
+I taught the enrollment flow to attach a short heads-up to the pending login that
+says, in plain words: "a brand-new Claude login often asks for two codes in order —
+first the email-verification code, then the sign-in code; enter the email one
+first." Three small parts:
+
+1. The pending-login record can now carry an optional `notice` (a plain-text
+   heads-up — never a secret).
+2. The enrollment wizard fills that notice in for the Claude-style flow
+   (`url-code-paste`). The Codex-style flow (`device-code`) is a single code, so it
+   gets no notice.
+3. The dashboard's Pending Logins panel shows the notice on the card, above the
+   code, so you read the warning before you start.
+
+## How do I know it works?
+
+New tests check all three layers: the wizard's `flowNotice` returns the two-code
+text for the Claude flow and nothing for Codex; starting a Claude enrollment stores
+that notice on the pending login and it survives onto the phone surface; and the
+dashboard renders a notice row when one is present and omits it when there isn't.
+
+## Who gets this and is anything risky?
+
+It ships with the normal instar update (server code + dashboard), so every agent
+gets it without any manual step. The notice is static guidance text rendered as
+inert, sanitized text — it can't be a link or run anything, and accounts without a
+notice render exactly as before. Codex enrollment is untouched.

--- a/src/core/EnrollmentWizard.ts
+++ b/src/core/EnrollmentWizard.ts
@@ -80,6 +80,27 @@ export class EnrollmentWizard {
   }
 
   /**
+   * Operator-facing heads-up about a flow's quirks, surfaced on the pending login.
+   * The url-code-paste (Claude) flow on a brand-new account slot frequently issues
+   * TWO codes in sequence: Anthropic first emails an email-VERIFICATION code, then
+   * (after that's accepted) the page shows the sign-in code to paste back. Enrolling
+   * is always a new slot, so the operator should expect — and not be confused by —
+   * the two-step sequence (this confusion was flagged in live testing, topic 20905).
+   * device-code (Codex) is a single code, so no notice. Returns undefined when there
+   * is nothing to warn about.
+   */
+  static flowNotice(kind: LoginFlowKind): string | undefined {
+    if (kind === 'url-code-paste') {
+      return (
+        'Heads up: a brand-new Claude login often asks for TWO codes in order — ' +
+        'first an email-verification code Anthropic sends you, then the sign-in code ' +
+        'shown after that. Enter the email code first; the sign-in code comes next.'
+      );
+    }
+    return undefined;
+  }
+
+  /**
    * Start an enrollment: drive the login, capture the public code/URL, store it
    * as a pending login (TTL visible). Returns the stored PendingLogin — the
    * surface the operator's phone shows.
@@ -101,6 +122,7 @@ export class EnrollmentWizard {
       configHome: input.configHome,
       verificationUrl: artifact.verificationUrl,
       userCode: artifact.userCode,
+      notice: EnrollmentWizard.flowNotice(kind),
       ttlMs: artifact.ttlMs,
     });
     this.logger.log(`[EnrollmentWizard] started ${kind} login for ${input.label} (${input.provider})`);

--- a/src/core/PendingLoginStore.ts
+++ b/src/core/PendingLoginStore.ts
@@ -53,6 +53,10 @@ export interface PendingLogin {
   verificationUrl: string;
   /** Device-code (e.g. "7DAU-W4XJA") for device-code flows; absent for url-code-paste. */
   userCode?: string;
+  /** Operator-facing heads-up about this flow's quirks (never a secret) — e.g. the
+   *  Claude two-code sequence (email-verification code first, then the sign-in code).
+   *  Surfaced on the pending-login so the operator knows what to expect. */
+  notice?: string;
   /** ISO timestamp the code/URL expires. */
   ttlExpiresAt: string;
   status: PendingLoginStatus;
@@ -85,6 +89,8 @@ export interface IssueLoginInput {
   configHome?: string;
   verificationUrl: string;
   userCode?: string;
+  /** Operator-facing flow heads-up (e.g. the Claude two-code sequence). */
+  notice?: string;
   /** TTL in ms from now (default 15 min — the observed Codex device-code TTL). */
   ttlMs?: number;
 }
@@ -165,6 +171,7 @@ export class PendingLoginStore {
       ...(input.configHome ? { configHome: input.configHome } : {}),
       verificationUrl: input.verificationUrl.trim(),
       ...(input.userCode ? { userCode: input.userCode.trim() } : {}),
+      ...(input.notice?.trim() ? { notice: input.notice.trim() } : {}),
       ttlExpiresAt: new Date(this.now() + (input.ttlMs ?? DEFAULT_TTL_MS)).toISOString(),
       status: 'pending',
       reissueCount: 0,

--- a/tests/unit/enrollment-wizard.test.ts
+++ b/tests/unit/enrollment-wizard.test.ts
@@ -47,6 +47,30 @@ describe('EnrollmentWizard', () => {
     expect(EnrollmentWizard.defaultKind('github-copilot')).toBe('url-code-paste');
   });
 
+  it('flowNotice: url-code-paste (Claude) warns about the two-code sequence; device-code does not', () => {
+    const claude = EnrollmentWizard.flowNotice('url-code-paste');
+    expect(claude).toBeTruthy();
+    expect(claude).toMatch(/two codes/i);
+    expect(claude).toMatch(/email/i);
+    expect(EnrollmentWizard.flowNotice('device-code')).toBeUndefined();
+  });
+
+  it('start attaches the two-code notice on a Claude (url-code-paste) enrollment', async () => {
+    const w = wizard([{ verificationUrl: 'https://claude.com/oauth/authorize?code=abc', ttlMs: 15 * 60_000 }]);
+    const l = await w.start({ id: 'sagemind-1', label: 'SageMind - Justin', provider: 'anthropic', framework: 'claude-code' });
+    expect(l.kind).toBe('url-code-paste');
+    expect(l.notice).toMatch(/two codes/i);
+    // it survives the store round-trip onto the phone surface
+    expect(w.pending()[0].notice).toMatch(/two codes/i);
+  });
+
+  it('start attaches NO notice on a device-code (Codex) enrollment', async () => {
+    const w = wizard([{ verificationUrl: 'https://auth.openai.com/codex/device', userCode: '7DAU-W4XJA', ttlMs: 15 * 60_000 }]);
+    const l = await w.start({ id: 'codex-1', label: 'codex', provider: 'openai', framework: 'codex-cli' });
+    expect(l.kind).toBe('device-code');
+    expect(l.notice).toBeUndefined();
+  });
+
   it('start drives the login + stores the public code/URL with TTL', async () => {
     const w = wizard([{ verificationUrl: 'https://auth.openai.com/codex/device', userCode: '7DAU-W4XJA', ttlMs: 15 * 60_000 }]);
     const l = await w.start({ id: 'codex-1', label: 'codex', provider: 'openai', framework: 'codex-cli' });

--- a/tests/unit/subscriptions-render.test.ts
+++ b/tests/unit/subscriptions-render.test.ts
@@ -145,6 +145,24 @@ describe('renderPendingLogins', () => {
     expect(t.querySelector('a')).toBeNull();
     expect(t.querySelector('.sub-pending-url')!.textContent).toContain('javascript:alert(1)');
   });
+  it('renders the flow notice (two-code heads-up) when present', () => {
+    const t = el();
+    renderPendingLogins(doc, t, [{
+      id: 'sagemind-1', label: 'SageMind - Justin', kind: 'url-code-paste',
+      verificationUrl: 'https://claude.com/oauth/authorize?code=abc',
+      notice: 'Heads up: a brand-new Claude login often asks for TWO codes in order — first an email-verification code, then the sign-in code.',
+      ttlExpiresAt: '2026-06-07T00:12:00Z', reissueCount: 0,
+    }], NOW);
+    expect(t.querySelector('.sub-pending-notice')!.textContent).toContain('TWO codes');
+  });
+  it('omits the notice element when there is none', () => {
+    const t = el();
+    renderPendingLogins(doc, t, [{
+      id: 'codex-1', label: 'codex', kind: 'device-code', userCode: '7DAU-W4XJA',
+      verificationUrl: 'https://auth.openai.com/codex/device', ttlExpiresAt: '2026-06-07T00:12:00Z', reissueCount: 0,
+    }], NOW);
+    expect(t.querySelector('.sub-pending-notice')).toBeNull();
+  });
 });
 
 describe('renderDisabled', () => {

--- a/upgrades/next/enroll-two-code-warning.md
+++ b/upgrades/next/enroll-two-code-warning.md
@@ -1,0 +1,46 @@
+# Enrollment two-code heads-up (Claude login)
+
+<!-- bump: patch -->
+
+## What Changed
+
+The enrollment wizard now attaches an operator-facing heads-up to a pending Claude
+login, warning that a brand-new Claude account login asks for TWO codes in sequence
+— an email-verification code first, then the sign-in code. `PendingLogin` gains an
+optional `notice` field; `EnrollmentWizard.flowNotice(kind)` produces the warning
+for the `url-code-paste` (Claude) flow and nothing for `device-code` (Codex); the
+dashboard's Pending Logins panel renders it above the code. Codex enrollment is
+unchanged.
+
+## Evidence
+
+Found during live enrollment (topic 20905): enrolling a fresh Claude account, the
+operator was asked for an email-verification code first and then a separate sign-in
+code, with nothing explaining the second prompt — reported as confusing.
+
+Reproduction / before-after:
+- **Before:** starting a `url-code-paste` enrollment produced a pending login with
+  only a code + URL; the two-code sequence was undocumented, so the operator hit an
+  unexplained second code prompt.
+- **After:** the same enrollment produces a pending login whose `notice` reads
+  "a brand-new Claude login often asks for TWO codes in order — first an
+  email-verification code … then the sign-in code …", shown on the dashboard card.
+  A `device-code` (Codex) enrollment still carries no notice.
+
+Locked in by new `enrollment-wizard.test.ts`, `pending-login-store.test.ts`, and
+`subscriptions-render.test.ts` cases (notice present for Claude / absent for Codex;
+rendered when present / element omitted when not).
+
+## What to Tell Your User
+
+When I set up a new Claude account for you, the login card now warns you up front
+that Claude will ask for two codes in a row — the email-verification code first,
+then the sign-in code. No more being surprised by the second prompt.
+
+## Summary of New Capabilities
+
+- **Two-code heads-up on Claude enrollment** — the pending-login card explains the
+  email-code-then-sign-in-code sequence before you start.
+- **`PendingLogin.notice`** — an optional, sanitized, operator-facing flow heads-up
+  (extensible to other flow quirks later); Codex/device-code flows carry none.
+- Ships with the normal instar update (server + dashboard); no migration needed.

--- a/upgrades/side-effects/enroll-two-code-warning.md
+++ b/upgrades/side-effects/enroll-two-code-warning.md
@@ -1,0 +1,42 @@
+# Side-effects review — enrollment two-code heads-up
+
+## Change
+
+Surfaces an operator-facing heads-up on a pending login about the Claude
+url-code-paste flow's two-code sequence (email-verification code first, then the
+sign-in code). Three pieces:
+- `PendingLoginStore`: new optional `notice?: string` on `PendingLogin` +
+  `IssueLoginInput`; `issue()` persists it when present (omitted otherwise).
+- `EnrollmentWizard`: new `static flowNotice(kind)` returns the two-code warning
+  for `url-code-paste` and `undefined` for `device-code`; `start()` attaches it.
+- `dashboard/subscriptions.js`: `renderPendingLogins` shows a `sub-pending-notice`
+  row (sanitized text) when a notice is present.
+
+## Why
+
+Live enrollment testing (topic 20905): enrolling a fresh Claude account makes
+Anthropic ask for TWO codes in sequence — an email-verification code, then the
+sign-in code — and the operator found the unexplained second prompt confusing. The
+wizard now tells them what to expect up front.
+
+## Side effects considered
+
+- **Backward compatibility / persistence.** `notice` is optional and omitted when
+  absent, so existing pending-login JSON records (written before this change) load
+  unchanged — no migration. `issue()` only adds the key when a non-empty notice is
+  passed, matching the file's existing `...(x ? {x} : {})` style.
+- **Not a secret.** The notice is static guidance text — never a credential, code,
+  or URL. It passes the store's `assertNoCredentialFields` (it's a fixed string set
+  by the wizard, not derived from login input).
+- **XSS / display safety.** Rendered through the existing `sanitizeForDisplay`
+  (NFKC + control/bidi strip + grapheme cap) as inert text in a `div` — never an
+  href or innerHTML. Covered by the render tests (notice present → shown; absent →
+  element omitted) alongside the existing javascript:-URL inertness test.
+- **device-code (Codex) flows are unchanged** — `flowNotice('device-code')` is
+  undefined, so no notice is attached and the row renders exactly as before.
+- **Reach to existing agents.** Server code (PendingLoginStore/EnrollmentWizard)
+  and the dashboard asset ship with the instar package, so agents get this on the
+  normal package update — no `.instar/`-copied file and no PostUpdateMigrator entry
+  required.
+- **Blast radius:** one optional field + one pure static method + one conditional
+  render row. Reversible by dropping the field.


### PR DESCRIPTION
## ELI16 — Warn you that a new Claude login asks for two codes

When I enroll a brand-new Claude subscription account, Claude doesn't just give you one code. It first emails you an email-verification code, and only after you enter that does it show the actual sign-in code. In live testing that second code was confusing — you thought you were done, then got another code with nothing explaining why. This change makes the enrollment wizard attach a short heads-up to the pending-login card that says, in plain words, "expect two codes in order: the email-verification code first, then the sign-in code." It only does this for the Claude-style flow; the Codex-style single-code flow is unchanged. The heads-up shows on the dashboard card above the code, so you read it before you start. New tests cover all three layers (wizard, store, dashboard render) on both sides of the boundary.

## What

When I enroll a new Claude subscription account, the pending-login now carries an operator-facing heads-up that a brand-new Claude login asks for TWO codes in sequence — an email-verification code first, then the sign-in code.

- `PendingLogin` / `IssueLoginInput` gain an optional `notice?: string` (sanitized, never a secret; omitted when absent).
- `EnrollmentWizard.flowNotice(kind)` returns the two-code warning for `url-code-paste` (Claude) and `undefined` for `device-code` (Codex); `start()` attaches it.
- `dashboard/subscriptions.js` → `renderPendingLogins` shows a `sub-pending-notice` row (inert sanitized text) above the code when present.

## Why

Surfaced in live enrollment testing (topic 20905): enrolling a fresh Claude account, the operator was asked for an email-verification code and then a separate sign-in code, with nothing explaining the second prompt — flagged as confusing.

## Tests

- `enrollment-wizard.test.ts` — `flowNotice` returns the two-code text for Claude / undefined for Codex; `start()` attaches the notice on a Claude enrollment and it survives onto the phone surface; a Codex enrollment carries none.
- `pending-login-store.test.ts` — the `notice` field round-trips through `issue()`.
- `subscriptions-render.test.ts` — the notice renders (`.sub-pending-notice`) when present and the element is omitted when absent.
- tsc clean; all three touched suites green (37/37).

## Compatibility / reach

Additive and backward-compatible: `notice` is optional and omitted when absent, so existing pending-login JSON loads unchanged — no migration. Ships with the normal instar package update (server code + dashboard asset). Codex/device-code flows are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
