### PR TITLE
fix(messaging): bound outbound tone gate to the route budget so post-update/reply can't hang

### DIFF
--- a/.instar/instar-dev-decisions/2026-06-08T18-09-29-314Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-06-08T18-09-29-314Z-unknown.json
@@ -1,0 +1,15 @@
+{
+  "ts": "2026-06-08T18:09:29.314Z",
+  "slug": "unknown",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "new capability: new config key added"
+  ],
+  "belowFloor": true,
+  "files": 5,
+  "loc": 145,
+  "causalAutopsy": null,
+  "verdict": "pass"
+}

--- a/docs/specs/outbound-gate-budget.eli16.md
+++ b/docs/specs/outbound-gate-budget.eli16.md
@@ -1,0 +1,29 @@
+# Outbound Gate Budget — Plain-English Overview
+
+> The one-line version: the quality checkpoint every outgoing message passes through could get stuck for 2–3 minutes under load and miss the delivery deadline, so we give it a short fixed deadline and let messages through if it can't decide in time.
+
+## The problem in one breath
+
+Imagine every message your agent sends has to pass one checkpoint that asks "is this relevant and well-written?" before it leaves. Normally that takes a couple of seconds. But when the AI service is overloaded, the checkpoint can get stuck waiting in line for two to three minutes — and the delivery truck only holds the door for two minutes before giving up. So the message got stranded at the checkpoint, the send "failed," and the agent shoved the announcement into whatever chat it happened to be in. That's exactly why update notes kept landing in the wrong topic.
+
+## What already exists
+
+- **The outbound checkpoint (the tone/relevance gate)** — every reply, attention item, and update post runs through it. It is *designed* to wave a message through if it can't decide quickly (it "fails open"), so it never silently swallows a real message.
+- **The delivery deadline** — outbound routes are allowed 120 seconds total; after that the request times out and reports failure.
+- **A faster sibling check (ArcCheck)** — already guards itself with a tiny 200ms deadline so a slow version of it can never stall the message. The fix copies that proven pattern.
+
+## What this adds
+
+We give the checkpoint its own short, fixed deadline (20 seconds) that is safely shorter than the 120-second delivery deadline. If the checkpoint answers in time, its decision is used exactly as before — including blocking a genuinely bad message. If it can't answer in 20 seconds, the message is waved through (delivered) instead of being held until the delivery truck leaves. Because the deadline lives at the route, this works no matter how the underlying AI service behaves — a future change to it can't bring the stall back.
+
+## The new pieces
+
+- **`reviewWithinBudget`** — a tiny helper that runs the checkpoint against a stopwatch. It is NOT allowed to change the checkpoint's actual verdict; it only decides "did the checkpoint answer before the stopwatch ran out?" If yes, use the real answer; if no, deliver the message and note that it timed out.
+- **`OUTBOUND_GATE_REVIEW_BUDGET_MS`** — the 20-second stopwatch value, kept right next to the 120-second delivery deadline so the two can never drift into conflict (a test enforces that the stopwatch is always shorter).
+
+## The safeguards
+
+- Real blocks still block — a message the checkpoint rejects in time is still rejected (a test proves a bad "Gemini is fully ready!" message still gets stopped).
+- Failing open faster is strictly safer than today: a timeout used to mean the message went unreviewed AND landed in the wrong chat; now it just means a fast, in-the-right-place delivery.
+- Existing agents get the fix automatically on update — the deadline lives in code, so there's nothing for anyone to configure. An optional knob exists for operators who want to tune it.
+- This does NOT fix the separate habit of an agent re-posting a failed update into a working chat; it removes the cause (the stall) so that rarely happens, and the habit is tracked as a follow-up.

--- a/docs/specs/outbound-gate-budget.md
+++ b/docs/specs/outbound-gate-budget.md
@@ -1,0 +1,88 @@
+# Outbound Gate Budget — the tone/relevance gate must never outlast its route
+
+## The bug (2026-06-08)
+
+Every outbound message — a Telegram reply, a Slack reply, an **update posted to
+the Agent Updates topic** — passes through `checkOutboundMessage` in
+`src/server/routes.ts`, which invokes the single messaging authority,
+`MessagingToneGate.review`. That review makes an LLM call.
+
+The gate is **fail-open by design**: if the LLM is unavailable or errors, it
+returns `failedOpen: true` and the message is delivered un-reviewed. The problem
+is *timing*, not *errors*:
+
+- `MessagingToneGate.review` passes `rateLimitWaitMs: RATE_LIMIT_WAIT_MS`
+  (`120_000`). Under rate-limit pressure the provider **waits up to 120s for a
+  window to clear** rather than failing open — a deliberate choice for internal,
+  non-time-critical gate calls.
+- That whole wait sat inside a single un-raced `await` in
+  `checkOutboundMessage`.
+- The outbound routes carry a hard request budget,
+  `OUTBOUND_MESSAGING_TIMEOUT_MS = 120_000`. After it, the `requestTimeout`
+  middleware returns **408**.
+
+So under sustained rate-limit pressure the gate routinely finished at
+**121s–185s** (observed in `[tone-gate]` decision logs, all `failedOpen`),
+**past** the 120s route budget. The route 408'd before the gate ever resolved.
+
+A 408 here is the **worst** outcome:
+
+1. The message bypasses the gate anyway (it was never reviewed).
+2. Because the proactive send "failed", the calling session falls back to
+   posting the update as a **normal reply in whatever topic it is active in** —
+   which is how patch/upgrade notes ended up flooding a *working* topic
+   (the user's Invoices topic) instead of the Updates topic.
+
+The dedicated Updates topic and its routing were fine. The channel into it was
+**hanging**, and the hang came from an unbounded quality gate, not from the
+delivery layer.
+
+## The fix
+
+Bound the gate review **at the route seam** with a budget comfortably below the
+route timeout, and **fail open past it** (same contract as the ArcCheck 200ms
+race that already guards signal collection in the same function).
+
+- `OUTBOUND_GATE_REVIEW_BUDGET_MS = 20_000` (`src/server/middleware.ts`), the
+  single source of truth alongside `OUTBOUND_MESSAGING_TIMEOUT_MS`. A wiring test
+  asserts the invariant `OUTBOUND_GATE_REVIEW_BUDGET_MS <
+  OUTBOUND_MESSAGING_TIMEOUT_MS` so the two budgets can never drift into conflict.
+- `reviewWithinBudget(reviewPromise, budgetMs, now?, schedule?)`
+  (`src/server/outboundGateBudget.ts`) races the in-flight review against the
+  budget. On time → the real verdict (pass **or** block — real blocks are never
+  weakened). On budget elapse → a `budgetExceeded` fail-open result
+  (`pass: true, failedOpen: true, budgetExceeded: true`), logged so the latency
+  audit can see how often the gate is too slow to run in budget.
+- This is a **structural** guarantee independent of provider internals: a future
+  provider or rate-limit change can never re-introduce the hang, because the
+  route enforces its own budget rather than trusting the gate to respect it.
+- Optional per-agent override: `config.outboundGateReviewBudgetMs` (ms). Absent →
+  the code default applies, so existing agents get the fix on update with **no
+  config change** (no migration needed).
+
+## Why fail-open-faster is strictly better here
+
+The gate prefers to *wait* for a rate-limit window rather than fail open. That is
+correct for internal callers with no hard deadline. It is **wrong** for a
+user-facing outbound route that dies at 120s: by the time the window clears the
+route is already dead, the message went un-reviewed regardless, AND it landed in
+the wrong place. Delivering at 20s un-reviewed is the gate's *designed* degraded
+behaviour and is strictly better than 408 → wrong-topic dump.
+
+## What this fix does NOT cover
+
+The **behavioural** fallback — a session, on a failed `/telegram/post-update`,
+choosing to re-send the note as a plain reply into its active topic — is a
+separate "structure > willpower" gap. This fix removes the *cause* of that
+failure (the hang), so the fallback rarely triggers. Making the fallback
+structurally impossible (e.g. the gate detecting update-class content addressed
+to a non-Updates topic) is tracked as a follow-up.
+
+## Tests
+
+- `tests/unit/outbound-gate-budget.test.ts` — `reviewWithinBudget` semantics
+  (pass-through, block-through, hang → budgetExceeded fail-open, latency,
+  rejection propagation) + the budget < route-timeout invariant.
+- `tests/unit/post-update-gate-budget-route.test.ts` — route-level wiring on
+  `POST /telegram/post-update`: a hanging gate delivers (200, fast) instead of
+  408; a fast block still blocks (422, no delivery); a fast pass delivers.

--- a/src/core/MessagingToneGate.ts
+++ b/src/core/MessagingToneGate.ts
@@ -47,6 +47,14 @@ export interface ToneReviewResult {
   failedOpen?: boolean;
   /** True if the LLM's rule citation was invalid (not in B1..B18) — gate failed open. */
   invalidRule?: boolean;
+  /**
+   * True if the gate review exceeded the outbound route's hard budget and the
+   * route failed it open without waiting for the verdict. Distinguishes a
+   * budget-cap fail-open (gate too slow under load) from an error fail-open
+   * (`failedOpen`) in the latency/over-block audit. Set by the route seam, not
+   * by `review()` itself.
+   */
+  budgetExceeded?: boolean;
 }
 
 const VALID_RULES = new Set([

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -2681,6 +2681,15 @@ export interface InstarConfig {
    * When undefined/empty the style rule does not apply (behavior unchanged).
    */
   messagingStyle?: string;
+  /**
+   * Optional override (ms) for how long the outbound tone/relevance gate may run
+   * before the route fails it OPEN and delivers the message un-reviewed. Defaults
+   * to OUTBOUND_GATE_REVIEW_BUDGET_MS in code, so existing agents get the fix with
+   * no config change. Must stay below OUTBOUND_MESSAGING_TIMEOUT_MS (120s) — values
+   * <= 0 or out of range fall back to the code default. See
+   * docs/specs/outbound-gate-budget.md.
+   */
+  outboundGateReviewBudgetMs?: number;
   /** HMAC signing key for context file integrity verification (auto-generated, 32-byte hex) */
   contextSigningKey?: string;
   /** MoltBridge integration — trust network for agent discovery and credibility */

--- a/src/server/middleware.ts
+++ b/src/server/middleware.ts
@@ -357,6 +357,27 @@ export function rateLimiter(windowMs: number = 60_000, maxRequests: number = 10)
 export const OUTBOUND_MESSAGING_TIMEOUT_MS = 120_000;
 
 /**
+ * Hard budget (ms) the outbound tone/relevance gate is allowed to spend BEFORE
+ * the route fails it open and delivers the message un-reviewed.
+ *
+ * This MUST stay comfortably below OUTBOUND_MESSAGING_TIMEOUT_MS. The reason is
+ * a real production failure (2026-06-08): the tone gate is FAIL-OPEN by design,
+ * but `MessagingToneGate.review` will wait up to RATE_LIMIT_WAIT_MS (120s) for a
+ * rate-limit window PLUS the call itself — and that whole wait sat inside an
+ * un-raced `await` in `checkOutboundMessage`. Under rate-limit pressure the gate
+ * routinely finished at 121s–185s (observed in the tone-gate decision log, all
+ * failedOpen), blowing past the 120s route budget. The route then 408s, which is
+ * the WORST outcome: the message both bypasses the gate AND, because the send
+ * "failed", the calling session dumps the note into whatever topic it is active
+ * in (the "patch notes landing in the Invoices topic" bug). Capping the gate at
+ * this budget — and failing OPEN past it (same contract as the ArcCheck 200ms
+ * race) — guarantees the route always returns a verdict in budget. The invariant
+ * `OUTBOUND_GATE_REVIEW_BUDGET_MS < OUTBOUND_MESSAGING_TIMEOUT_MS` is asserted in
+ * the wiring test so the two budgets can never drift into conflict again.
+ */
+export const OUTBOUND_GATE_REVIEW_BUDGET_MS = 20_000;
+
+/**
  * Extended budget for the standards-conformance gate route (`/spec/conformance-check`).
  * It makes a single heavy top-tier review call over a full spec; the 30s default
  * 408s on any real spec. Set ABOVE the reviewer's inner CONFORMANCE_REVIEW_TIMEOUT_MS

--- a/src/server/outboundGateBudget.ts
+++ b/src/server/outboundGateBudget.ts
@@ -1,0 +1,65 @@
+import type { ToneReviewResult } from '../core/MessagingToneGate.js';
+
+/**
+ * Race a tone/relevance-gate review against the outbound route's budget.
+ *
+ * Background — the production failure this exists to prevent (2026-06-08):
+ * `MessagingToneGate.review` is FAIL-OPEN by design, but it will wait up to
+ * RATE_LIMIT_WAIT_MS (120s) for a rate-limit window PLUS the call itself, all
+ * inside a single `await`. Under sustained rate-limit pressure the gate
+ * routinely finished at 121s–185s (observed in the tone-gate decision log, all
+ * failedOpen) — past the 120s outbound route budget. The route then 408s, which
+ * is the WORST outcome: the message both bypasses the gate AND, because the send
+ * "failed", the calling session falls back to dumping the note into whatever
+ * topic it is active in (the "patch notes landing in a working topic" bug).
+ *
+ * This helper makes the fail-open a STRUCTURAL guarantee at the route seam: it
+ * resolves to the real verdict if the gate answers within `budgetMs`, otherwise
+ * to a `budgetExceeded` fail-open result (pass=true) so the route delivers the
+ * message rather than holding it past the route budget. The behaviour is
+ * independent of provider internals, so a future provider/rate-limit change can
+ * never re-introduce the hang. Same contract as the ArcCheck 200ms race that
+ * already guards the signal-collection phase.
+ *
+ * Pure + injectable (`budgetMs`, `now`, `schedule`) so the budget semantics are
+ * unit-tested deterministically without a real 20s wait.
+ *
+ * @param reviewPromise the in-flight `MessagingToneGate.review(...)` promise
+ * @param budgetMs       hard budget; pass OUTBOUND_GATE_REVIEW_BUDGET_MS
+ * @param now            clock injection (defaults to Date.now)
+ * @param schedule       timer injection (defaults to setTimeout) — lets tests
+ *                       fire the budget deterministically
+ */
+export async function reviewWithinBudget(
+  reviewPromise: Promise<ToneReviewResult>,
+  budgetMs: number,
+  now: () => number = Date.now,
+  schedule: (cb: () => void, ms: number) => void = (cb, ms) => {
+    // unref so a pending budget timer never keeps the process alive
+    const t = setTimeout(cb, ms);
+    if (typeof (t as { unref?: () => void }).unref === 'function') {
+      (t as { unref: () => void }).unref();
+    }
+  },
+): Promise<ToneReviewResult> {
+  const start = now();
+  const BUDGET_EXCEEDED = Symbol('outbound-gate-budget-exceeded');
+  const outcome = await Promise.race<ToneReviewResult | typeof BUDGET_EXCEEDED>([
+    reviewPromise,
+    new Promise<typeof BUDGET_EXCEEDED>((resolve) =>
+      schedule(() => resolve(BUDGET_EXCEEDED), budgetMs),
+    ),
+  ]);
+  if (outcome === BUDGET_EXCEEDED) {
+    return {
+      pass: true,
+      rule: '',
+      issue: '',
+      suggestion: '',
+      latencyMs: now() - start,
+      failedOpen: true,
+      budgetExceeded: true,
+    };
+  }
+  return outcome;
+}

--- a/src/server/routes.ts
+++ b/src/server/routes.ts
@@ -25,7 +25,8 @@ import { IntelligenceRouter } from '../core/IntelligenceRouter.js';
 import { knownComponents } from '../core/componentCategories.js';
 import { SecretStore } from '../core/SecretStore.js';
 import { writeConfigAtomic, readSelfKnowledgeFlags } from '../core/BootSelfKnowledge.js';
-import { rateLimiter, signViewPath } from './middleware.js';
+import { rateLimiter, signViewPath, OUTBOUND_GATE_REVIEW_BUDGET_MS } from './middleware.js';
+import { reviewWithinBudget } from './outboundGateBudget.js';
 import type { WriteOperation, WriteToken } from '../core/StateWriteAuthority.js';
 import { writeLifelineRestartSignal } from '../core/version-skew.js';
 import { readSessionClocks } from '../core/SessionClockReader.js';
@@ -1392,18 +1393,38 @@ export function createRoutes(ctx: RouteContext): Router {
         }
       }
 
-      // ── Invoke the single authority ──
-      const result = await ctx.messagingToneGate.review(text, {
-        channel,
-        recentMessages,
-        signals,
-        targetStyle: ctx.config.messagingStyle,
-        messageKind: options.messageKind,
-      });
+      // ── Invoke the single authority, bounded by the route budget ──
+      // The gate is FAIL-OPEN by design, but under rate-limit pressure its
+      // provider call can wait up to RATE_LIMIT_WAIT_MS for a window PLUS the
+      // call itself — exceeding the outbound route's hard request budget
+      // (OUTBOUND_MESSAGING_TIMEOUT_MS). When that happens the route 408s, which
+      // is the WORST outcome: the message bypasses the gate AND the failed send
+      // gets dumped into whatever topic the session is active in. `reviewWithinBudget`
+      // races the review against OUTBOUND_GATE_REVIEW_BUDGET_MS and fails OPEN
+      // past it — a STRUCTURAL guarantee at the route seam that holds regardless
+      // of provider internals. Spec: docs/specs/outbound-gate-budget.md.
+      const configuredBudget = ctx.config.outboundGateReviewBudgetMs;
+      const gateBudgetMs =
+        typeof configuredBudget === 'number' &&
+        Number.isFinite(configuredBudget) &&
+        configuredBudget > 0
+          ? configuredBudget
+          : OUTBOUND_GATE_REVIEW_BUDGET_MS;
+      const result = await reviewWithinBudget(
+        ctx.messagingToneGate.review(text, {
+          channel,
+          recentMessages,
+          signals,
+          targetStyle: ctx.config.messagingStyle,
+          messageKind: options.messageKind,
+        }),
+        gateBudgetMs,
+      );
 
       // Structured observability: log every decision the authority made. This is
       // the "why I blocked" log — over-block audits read this. Invalid-rule
-      // citations (authority drift) are also logged so patterns become visible.
+      // citations (authority drift) and budgetExceeded fail-opens are logged so
+      // the latency audit can see when the gate is too slow to run in budget.
       logToneGateDecision({
         text,
         channel,
@@ -1615,6 +1636,7 @@ export function createRoutes(ctx: RouteContext): Router {
         rule: entry.result.rule || null,
         failedOpen: entry.result.failedOpen || false,
         invalidRule: entry.result.invalidRule || false,
+        budgetExceeded: entry.result.budgetExceeded || false,
         latencyMs: entry.result.latencyMs,
         signals: {
           junk: entry.signals.junk?.detected ?? null,

--- a/tests/unit/outbound-gate-budget.test.ts
+++ b/tests/unit/outbound-gate-budget.test.ts
@@ -1,0 +1,136 @@
+/**
+ * Unit tests for the outbound tone/relevance-gate budget (reviewWithinBudget).
+ *
+ * Regression context (2026-06-08): the outbound message gate is FAIL-OPEN by
+ * design, but `MessagingToneGate.review` will wait up to RATE_LIMIT_WAIT_MS
+ * (120s) for a rate-limit window PLUS the call, all inside a single un-raced
+ * `await` in `checkOutboundMessage`. Under rate-limit pressure the gate finished
+ * at 121s–185s (observed live, all failedOpen), past the 120s outbound route
+ * budget — so `/telegram/post-update` and `/telegram/reply` 408'd, and the
+ * calling session fell back to dumping the update note into whatever topic it
+ * was active in. `reviewWithinBudget` caps the gate at a budget well under the
+ * route's and fails OPEN past it.
+ *
+ * The budget/timer are injected so the fail-open semantics are proven instantly
+ * and deterministically — no real 20s wait.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { reviewWithinBudget } from '../../src/server/outboundGateBudget.js';
+import type { ToneReviewResult } from '../../src/core/MessagingToneGate.js';
+import {
+  OUTBOUND_GATE_REVIEW_BUDGET_MS,
+  OUTBOUND_MESSAGING_TIMEOUT_MS,
+} from '../../src/server/middleware.js';
+
+const PASS_RESULT: ToneReviewResult = {
+  pass: true,
+  rule: '',
+  issue: '',
+  suggestion: '',
+  latencyMs: 12,
+};
+
+const BLOCK_RESULT: ToneReviewResult = {
+  pass: false,
+  rule: 'B3_OVERSELL',
+  issue: 'Overstates a dark feature as finished',
+  suggestion: 'Label it experimental',
+  latencyMs: 34,
+};
+
+/** A schedule that never fires — forces the review promise to win the race. */
+const neverSchedule = (_cb: () => void, _ms: number) => {
+  /* intentionally never invokes cb */
+};
+
+/** A schedule that fires synchronously — forces the budget to win the race. */
+const immediateSchedule = (cb: () => void, _ms: number) => {
+  cb();
+};
+
+describe('reviewWithinBudget — outbound gate budget', () => {
+  it('returns the PASS verdict unchanged when the gate answers within budget', async () => {
+    const result = await reviewWithinBudget(
+      Promise.resolve(PASS_RESULT),
+      20_000,
+      () => 1000,
+      neverSchedule,
+    );
+    expect(result).toEqual(PASS_RESULT);
+    expect(result.budgetExceeded).toBeUndefined();
+  });
+
+  it('returns the BLOCK verdict unchanged when the gate answers within budget (blocks still work)', async () => {
+    const result = await reviewWithinBudget(
+      Promise.resolve(BLOCK_RESULT),
+      20_000,
+      () => 1000,
+      neverSchedule,
+    );
+    // A real block must survive the budget wrapper — the wrapper only protects
+    // against SLOW gates, it must never weaken a gate that actually decided.
+    expect(result.pass).toBe(false);
+    expect(result.rule).toBe('B3_OVERSELL');
+    expect(result.budgetExceeded).toBeUndefined();
+  });
+
+  it('FAILS OPEN with budgetExceeded when the gate hangs past budget', async () => {
+    // A review promise that never resolves — the hang the fix exists to survive.
+    const neverResolves = new Promise<ToneReviewResult>(() => {});
+    let clock = 1000;
+    const result = await reviewWithinBudget(
+      neverResolves,
+      20_000,
+      () => {
+        const t = clock;
+        clock += 20_000; // advance the clock between start and timeout reads
+        return t;
+      },
+      immediateSchedule,
+    );
+    expect(result.pass).toBe(true); // delivered, not blocked
+    expect(result.failedOpen).toBe(true);
+    expect(result.budgetExceeded).toBe(true);
+    expect(result.rule).toBe('');
+  });
+
+  it('records a non-negative latencyMs on the budget-exceeded fail-open', async () => {
+    const neverResolves = new Promise<ToneReviewResult>(() => {});
+    let clock = 5000;
+    const result = await reviewWithinBudget(
+      neverResolves,
+      20_000,
+      () => {
+        const t = clock;
+        clock += 19_500;
+        return t;
+      },
+      immediateSchedule,
+    );
+    expect(result.budgetExceeded).toBe(true);
+    expect(result.latencyMs).toBeGreaterThanOrEqual(0);
+  });
+
+  it('a gate that rejects propagates (the route catch fails open) — wrapper does not swallow rejections silently as pass', async () => {
+    // reviewWithinBudget does not catch; MessagingToneGate.review never rejects
+    // (it catches internally and returns failedOpen). But if a future provider
+    // surfaced a rejection, it must propagate to the route's try/catch — not be
+    // silently converted to a pass here. Documents the contract.
+    await expect(
+      reviewWithinBudget(
+        Promise.reject(new Error('provider exploded')),
+        20_000,
+        () => 1000,
+        neverSchedule,
+      ),
+    ).rejects.toThrow('provider exploded');
+  });
+
+  it('INVARIANT: the gate budget is strictly below the outbound route timeout', () => {
+    // This is the whole point — if the two ever cross, the route 408s before the
+    // gate fails open and the original hang returns. Guard it structurally.
+    expect(OUTBOUND_GATE_REVIEW_BUDGET_MS).toBeLessThan(OUTBOUND_MESSAGING_TIMEOUT_MS);
+    expect(OUTBOUND_GATE_REVIEW_BUDGET_MS).toBeGreaterThan(0);
+  });
+});

--- a/tests/unit/post-update-gate-budget-route.test.ts
+++ b/tests/unit/post-update-gate-budget-route.test.ts
@@ -1,0 +1,150 @@
+/**
+ * Route-level wiring test for the outbound gate budget on POST /telegram/post-update.
+ *
+ * Proves the fix is actually WIRED into the production update path (not dead
+ * code): a tone gate that HANGS must not stall the route past its budget — the
+ * route fails the gate open and delivers the update to the Updates topic, rather
+ * than 408ing (which is what made the calling session dump patch notes into a
+ * working topic). And a gate that BLOCKS fast must still block (422) — the
+ * budget wrapper protects against slow gates without weakening real verdicts.
+ *
+ * The budget is set tiny via ctx.config.outboundGateReviewBudgetMs so the hang
+ * case resolves in ~50ms instead of the 20s production default.
+ */
+
+import { describe, it, expect, afterEach } from 'vitest';
+import express from 'express';
+import type { AddressInfo } from 'node:net';
+import { createRoutes } from '../../src/server/routes.js';
+import type { ToneReviewResult } from '../../src/core/MessagingToneGate.js';
+
+interface TestServer { url: string; close: () => Promise<void>; }
+async function listen(app: express.Express): Promise<TestServer> {
+  return new Promise((resolve) => {
+    const srv = app.listen(0, () => {
+      const port = (srv.address() as AddressInfo).port;
+      resolve({
+        url: `http://127.0.0.1:${port}`,
+        close: () => new Promise<void>((r) => srv.close(() => r())),
+      });
+    });
+  });
+}
+
+const UPDATES_TOPIC_ID = 777;
+
+function buildApp(opts: {
+  review: (text: string) => Promise<ToneReviewResult>;
+  sends: { topicId: number; text: string }[];
+  budgetMs?: number;
+}): express.Express {
+  const app = express();
+  app.use(express.json());
+
+  const ctx: any = {
+    config: {
+      authToken: 'test',
+      stateDir: '/tmp',
+      port: 0,
+      outboundGateReviewBudgetMs: opts.budgetMs ?? 50,
+    },
+    state: {
+      get: (key: string) => (key === 'agent-updates-topic' ? UPDATES_TOPIC_ID : undefined),
+    },
+    messagingToneGate: {
+      review: (text: string) => opts.review(text),
+    },
+    telegram: {
+      sendToTopic: async (topicId: number, text: string) => {
+        opts.sends.push({ topicId, text });
+      },
+    },
+  };
+
+  const router = createRoutes(ctx);
+  app.use(router);
+  return app;
+}
+
+describe('POST /telegram/post-update — outbound gate budget wiring', () => {
+  let server: TestServer;
+
+  afterEach(async () => {
+    await server?.close();
+  });
+
+  async function postUpdate(text: string) {
+    const res = await fetch(server.url + '/telegram/post-update', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ text }),
+    });
+    const body = await res.json().catch(() => ({}));
+    return { status: res.status, body };
+  }
+
+  it('delivers the update (200) when the gate HANGS past budget — does not 408 or stall', async () => {
+    const sends: { topicId: number; text: string }[] = [];
+    // The hang the fix exists to survive: review never resolves.
+    server = await listen(
+      buildApp({
+        review: () => new Promise<ToneReviewResult>(() => {}),
+        sends,
+        budgetMs: 50,
+      }),
+    );
+
+    const started = Date.now();
+    const r = await postUpdate('Shipped a small reliability fix to the update notifier.');
+    const elapsed = Date.now() - started;
+
+    expect(r.status).toBe(200);
+    expect(r.body.ok).toBe(true);
+    expect(r.body.topicId).toBe(UPDATES_TOPIC_ID);
+    // The message was actually delivered to the Updates topic — not dropped.
+    expect(sends).toHaveLength(1);
+    expect(sends[0].topicId).toBe(UPDATES_TOPIC_ID);
+    // Resolved fast (budget ~50ms), nowhere near the 120s route timeout.
+    expect(elapsed).toBeLessThan(5_000);
+  });
+
+  it('still BLOCKS (422) and does not deliver when the gate decides fast', async () => {
+    const sends: { topicId: number; text: string }[] = [];
+    server = await listen(
+      buildApp({
+        review: async () => ({
+          pass: false,
+          rule: 'B3_OVERSELL',
+          issue: 'Oversells a dark feature as finished',
+          suggestion: 'Label it experimental',
+          latencyMs: 10,
+        }),
+        sends,
+      }),
+    );
+
+    const r = await postUpdate('Gemini support is fully ready and production-grade now!');
+
+    expect(r.status).toBe(422);
+    expect(r.body.error).toBe('tone-gate-blocked');
+    expect(r.body.rule).toBe('B3_OVERSELL');
+    // A real block must prevent delivery.
+    expect(sends).toHaveLength(0);
+  });
+
+  it('delivers (200) when the gate passes fast', async () => {
+    const sends: { topicId: number; text: string }[] = [];
+    server = await listen(
+      buildApp({
+        review: async () => ({ pass: true, rule: '', issue: '', suggestion: '', latencyMs: 8 }),
+        sends,
+      }),
+    );
+
+    const r = await postUpdate('Quick heads-up: your dashboard now loads faster on mobile.');
+
+    expect(r.status).toBe(200);
+    expect(sends).toHaveLength(1);
+    expect(sends[0].topicId).toBe(UPDATES_TOPIC_ID);
+  });
+});

--- a/upgrades/next/outbound-gate-budget.md
+++ b/upgrades/next/outbound-gate-budget.md
@@ -1,0 +1,51 @@
+# Upgrade Guide — vNEXT
+
+<!-- bump: patch -->
+
+## What Changed
+
+The outbound messaging quality gate (`MessagingToneGate.review`, reached via
+`checkOutboundMessage`) is now bounded by a route-budget timeout that fails OPEN.
+Previously the gate ran inside a single un-raced `await`; under rate-limit pressure
+`review()` waits up to `RATE_LIMIT_WAIT_MS` (120s) for a window plus the call, which
+exceeds the 120s outbound route budget (`OUTBOUND_MESSAGING_TIMEOUT_MS`). The route
+then returns 408 and the calling session falls back to posting the message into
+whatever topic it is active in — which is how update notes ended up in working topics.
+
+A new helper `reviewWithinBudget` (`src/server/outboundGateBudget.ts`) races the
+review against `OUTBOUND_GATE_REVIEW_BUDGET_MS` (20s, defined in `middleware.ts`,
+asserted to be strictly below the route timeout). On time → the real verdict (pass or
+block, unchanged). On budget elapse → a `budgetExceeded` fail-open (delivered,
+logged). This is a structural guarantee at the route seam, covering every outbound
+path that shares the chokepoint (`/telegram/reply`, `/telegram/post-update`,
+`/slack/reply`, `/attention`, …). An optional per-agent override
+`outboundGateReviewBudgetMs` exists; the default lives in code, so existing agents get
+the fix on update with no config change (no migration).
+
+## What to Tell Your User
+
+- **Messages no longer get stuck behind the quality check**: "If you ever saw my
+  updates land in the wrong chat, or replies feel stuck for a minute or two when
+  things are busy — that's fixed. The check that reviews my messages now has a short
+  deadline, so a slow moment can't strand a message anymore."
+
+## Summary of New Capabilities
+
+A behind-the-scenes reliability fix to outbound messaging — no new user-facing
+surface. The message-review gate can no longer outlast its delivery deadline, so
+outbound messages (replies and update posts) can't hang or get misrouted under load.
+
+## Evidence
+
+- Root cause verified in this agent's live `[tone-gate]` decision log: reviews
+  finishing at 121s / 135s / 157s / 170s / 185s, all `failedOpen`, alongside repeated
+  `429` rate-limit events — all past the 120s route budget.
+- `tests/unit/outbound-gate-budget.test.ts` — `reviewWithinBudget` semantics
+  (pass-through, block-through, hang → `budgetExceeded` fail-open, latency, rejection
+  propagation) + the budget-below-route-timeout invariant.
+- `tests/unit/post-update-gate-budget-route.test.ts` — route-level: a hanging gate
+  delivers (200, fast) instead of 408; a fast block still blocks (422, no delivery);
+  a fast pass delivers.
+- Full lint clean; 71 existing related tone-gate/outbound/route tests green.
+- Spec + side-effects review: `docs/specs/outbound-gate-budget.md`,
+  `upgrades/side-effects/outbound-gate-budget.md`.

--- a/upgrades/side-effects/outbound-gate-budget.md
+++ b/upgrades/side-effects/outbound-gate-budget.md
@@ -1,0 +1,109 @@
+# Side-Effects Review — Outbound tone-gate budget (fail-open within the route budget)
+
+**Version / slug:** `outbound-gate-budget`
+**Date:** `2026-06-08`
+**Author:** `echo`
+**Second-pass reviewer:** `not required (Tier-1, additive + localized)`
+
+## Summary of the change
+
+Every outbound message (telegram/slack reply, attention item, `/telegram/post-update`)
+passes through `checkOutboundMessage` in `src/server/routes.ts`, which calls
+`MessagingToneGate.review` — an LLM call. The gate is fail-open by design, but under
+rate-limit pressure `review()` waits up to `RATE_LIMIT_WAIT_MS` (120s) for a window
+plus the call, all inside one un-raced `await`, exceeding the 120s outbound route
+budget (`OUTBOUND_MESSAGING_TIMEOUT_MS`). The route then 408s and the calling session
+dumps the note into its active topic. This change wraps the review call in
+`reviewWithinBudget` (new file `src/server/outboundGateBudget.ts`), racing it against
+`OUTBOUND_GATE_REVIEW_BUDGET_MS` (20s, new const in `middleware.ts`) and failing OPEN
+past it. Touches: `routes.ts` (one call wrapped + one log field), `MessagingToneGate.ts`
+(+1 optional result field), `types.ts` (+1 optional config field), `middleware.ts`
+(+1 const), new helper + 2 tests + spec.
+
+## Decision-point inventory
+
+- `checkOutboundMessage → tone-gate verdict` — **modify** — the gate verdict is now
+  bounded by a route-budget timeout that fails OPEN; the pass/block decision itself is
+  unchanged when the gate answers in time.
+- `OUTBOUND_GATE_REVIEW_BUDGET_MS vs OUTBOUND_MESSAGING_TIMEOUT_MS` — **add** — a budget
+  invariant (gate budget < route timeout) asserted in tests.
+
+## 1. Over-block
+
+**What legitimate inputs does this change reject that it shouldn't?**
+
+None — the change can only move the gate from "block/hold" toward "deliver". A real
+block returned within budget is passed through unchanged (covered by the route test:
+a fast B3 block still returns 422). The only new outcome is a budget-exceeded
+fail-open, which DELIVERS (pass=true). So over-block strictly decreases; it never
+increases.
+
+## 2. Under-block
+
+**What failure modes does this still miss?**
+
+Under sustained rate-limit pressure a message can now be delivered un-reviewed after
+the 20s budget (an intentional, designed fail-open). This is the same outcome the gate
+already produced via its internal `failedOpen` path — just reached deterministically in
+budget instead of after 2–3 minutes. The change does NOT make the gate review more
+content (no new bypass). It does not address the separate behavioral fallback (a
+session re-sending a failed update into a working topic) — tracked as a follow-up.
+
+## 3. Level-of-abstraction fit
+
+The budget is enforced at the route seam (`checkOutboundMessage`), the same layer that
+already bounds the ArcCheck signal with a 200ms race — the correct altitude, because the
+budget is a property of the OUTBOUND ROUTE (its 120s limit), not of the gate. The gate
+stays a general authority usable by callers with different budgets.
+
+## 4. Signal vs authority compliance
+
+The tone gate remains the single authority; this does not add a competing gate. The
+budget wrapper is a timeout, not a second opinion — when the authority answers in time
+its verdict is used verbatim (pass AND block). On timeout the documented fail-open
+contract applies (deliver). No signal is promoted to authority and no authority is
+demoted to signal.
+
+## 5. Interactions
+
+- Shares the chokepoint with `/telegram/reply`, `/slack/reply`, `/whatsapp/send`,
+  `/imessage/reply`, `/attention` — all inherit the bound (verified: their existing
+  route tests still pass).
+- The abandoned review promise keeps running after a budget timeout (Node has no
+  cancel); it resolves/ignored, and `MessagingToneGate.review` never rejects (internal
+  catch), so no unhandled rejection. `Promise.race` keeps a reaction attached to the
+  review promise, so even a hypothetical late rejection is considered handled.
+- `logToneGateDecision` gains a `budgetExceeded` boolean — additive, back-compatible
+  with existing log consumers.
+
+## 6. External surfaces
+
+No new routes, no new external calls, no auth/permission change, no Telegram/Slack API
+shape change. Adds one optional config field `outboundGateReviewBudgetMs` (absent →
+code default; no migration). No state files written or read.
+
+## 7. Rollback cost
+
+Trivial and low-risk. Revert the commit; the gate returns to its prior un-raced await.
+Or set `config.outboundGateReviewBudgetMs` very high to effectively disable the cap
+without code change. No data migration, no schema, no persisted state to unwind.
+
+## Conclusion
+
+Net safety improvement: the change strictly reduces the worst-case behavior (a 408 that
+both bypasses the gate AND misroutes the message) and never introduces a new block. The
+only new behavior — faster fail-open delivery under sustained rate-limit pressure — is
+the gate's already-documented degraded mode, reached in budget. Safe to ship.
+
+## Second-pass review (if required)
+
+Not required — Tier-1, additive and localized to one already-fail-open seam, full lint
+green, 9 new + 71 existing related tests green.
+
+## Evidence pointers
+
+- Live `[tone-gate]` decision log latencies: 121s / 135s / 157s / 170s / 185s, all
+  `failedOpen`, alongside repeated `429` events (this agent, 2026-06-07/08).
+- Tests: `tests/unit/outbound-gate-budget.test.ts`,
+  `tests/unit/post-update-gate-budget-route.test.ts`.
+- Spec: `docs/specs/outbound-gate-budget.md`.


### PR DESCRIPTION
## What & why

**The bug Justin's been chasing in the Agent Updates thread has a concrete root cause, and this fixes it at the source.**

An external agent diagnosed that its update notes were landing in a *working* topic (the Invoices topic) instead of the dedicated Updates topic, because "the internal channel I'm supposed to use to post there is currently hanging — every call times out and returns nothing." That diagnosis is correct about the symptom. This PR fixes the cause.

Every outbound message — a Telegram/Slack reply, an attention item, **and an update posted via `/telegram/post-update`** — flows through `checkOutboundMessage`, which calls the single messaging authority `MessagingToneGate.review`. That review makes an LLM call. The gate is **fail-open by design**, but the failure here is *timing*, not *errors*:

- `MessagingToneGate.review` passes `rateLimitWaitMs: 120_000` — under rate-limit pressure the provider **waits up to 120s for a window** rather than failing open.
- That wait sat inside a single **un-raced `await`** in `checkOutboundMessage`.
- The outbound routes have a hard 120s budget (`OUTBOUND_MESSAGING_TIMEOUT_MS`); after it, the middleware returns **408**.

So under sustained rate-limit pressure the gate routinely finished at **121s–185s** — verified in this agent's own `[tone-gate]` decision logs, all `failedOpen` — *past* the 120s route budget. The route 408'd before the gate resolved. A 408 here is the worst outcome: the message bypasses the gate anyway **and** the failed proactive send makes the calling session fall back to dumping the note into whatever topic it's active in.

Evidence (this agent's logs):
```
latencyMs":185747 ... "failedOpen":true
latencyMs":170378 ... "failedOpen":true
latencyMs":157655 ... "failedOpen":true
latencyMs":135343 ... "failedOpen":true
latencyMs":121237 ... "failedOpen":true
```
(alongside repeated `429` rate-limit events in the same window.)

## The fix

Bound the gate review **at the route seam** and fail OPEN past the budget — the same contract as the ArcCheck 200ms race that already guards signal collection in the same function.

- `OUTBOUND_GATE_REVIEW_BUDGET_MS = 20_000` in `middleware.ts` (single source of truth alongside the route timeout). A test asserts the invariant `OUTBOUND_GATE_REVIEW_BUDGET_MS < OUTBOUND_MESSAGING_TIMEOUT_MS` so they can never drift into conflict.
- `reviewWithinBudget(...)` (`src/server/outboundGateBudget.ts`) races the in-flight review against the budget: on time → the real verdict (pass **or** block — real blocks are never weakened); on budget elapse → a `budgetExceeded` fail-open (`pass:true, failedOpen:true, budgetExceeded:true`), logged so the latency audit can see how often the gate is too slow.
- **Structural, not behavioural**: the route enforces its own budget regardless of provider internals — a future provider/rate-limit change can't re-introduce the hang.
- Covers **every** outbound path (reply/post-update/slack/attention) because they all share `checkOutboundMessage`.
- Optional per-agent override `config.outboundGateReviewBudgetMs`; the default lives in code, so existing agents get the fix on update with **no config change** (no migration needed).

## What this does NOT cover

The *behavioural* fallback — a session, on a failed post-update, re-sending the note as a plain reply into its active topic — is a separate "structure > willpower" gap. This PR removes the **cause** (the hang), so that fallback rarely triggers. Making it structurally impossible is tracked as a follow-up.

## Tests

- `tests/unit/outbound-gate-budget.test.ts` — `reviewWithinBudget` semantics (pass-through, block-through, hang→budgetExceeded fail-open, latency, rejection propagation) + the budget<timeout invariant.
- `tests/unit/post-update-gate-budget-route.test.ts` — route-level: a hanging gate delivers (200, fast) instead of 408; a fast block still blocks (422, no delivery); a fast pass delivers.
- Full lint + full unit suite green.

Spec: `docs/specs/outbound-gate-budget.md`.

## ELI16

Imagine every message your agent sends has to pass through one security checkpoint before it goes out the door. The checkpoint's job is to ask "is this message relevant and well-written?" Normally it answers in a couple of seconds. But when the AI service is overloaded (rate-limited), the checkpoint can get stuck waiting in line for two to three minutes. Meanwhile, the delivery truck waiting outside only holds the door for two minutes before it gives up and leaves. So the message got stuck at the checkpoint, the truck left empty (a timeout), and the agent — not knowing what else to do — shoved the announcement into whatever room it happened to be standing in. That's why update notes kept landing in the wrong chat. The checkpoint was *designed* to just wave messages through if it can't decide fast enough — but the "wait in line" timer was longer than the "truck leaves" timer, so it never got the chance. This change makes the checkpoint give up and wave the message through after a short, fixed wait that's safely shorter than the truck's deadline. Messages still get checked when the checkpoint is fast (the normal case), real problem-messages are still blocked, but a slow checkpoint can never again strand a message past the delivery deadline and send it to the wrong room.
