### PR TITLE
fix(subscription-pool): auto-refresh expired OAuth access tokens instead of false needs-reauth

### DIFF
--- a/.instar/instar-dev-decisions/2026-06-08T20-17-04-503Z-subscription-token-autorefresh.json
+++ b/.instar/instar-dev-decisions/2026-06-08T20-17-04-503Z-subscription-token-autorefresh.json
@@ -1,0 +1,16 @@
+{
+  "ts": "2026-06-08T20:17:04.503Z",
+  "slug": "subscription-token-autorefresh",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 3,
+  "loc": 466,
+  "causalAutopsy": {
+    "origin": "new-code",
+    "notes": "The P1.2 QuotaPoller mapped any usage-endpoint 401/403 straight to needs-reauth without attempting an OAuth refresh-token exchange. A routine access-token expiry (~8-12h) with a still-valid refresh token was therefore mislabeled as a dead login, flipping healthy accounts to needs-reauth daily."
+  },
+  "verdict": "pass"
+}

--- a/dashboard/subscriptions.js
+++ b/dashboard/subscriptions.js
@@ -90,6 +90,20 @@ export function countdown(iso, now = Date.now(), { expiredWord = 'expired' } = {
   return `${sec}s`;
 }
 
+/** A coarse "N ago" for a PAST ISO timestamp (token-refresh recency). '' if invalid. */
+export function relativeAge(iso, now = Date.now()) {
+  const t = typeof iso === 'string' ? Date.parse(iso) : NaN;
+  if (Number.isNaN(t)) return '';
+  const sec = Math.floor((now - t) / 1000);
+  if (sec < 0) return 'just now';
+  if (sec < 60) return 'just now';
+  const min = Math.floor(sec / 60);
+  if (min < 60) return `${min}m ago`;
+  const hr = Math.floor(min / 60);
+  if (hr < 24) return `${hr}h ago`;
+  return `${Math.floor(hr / 24)}d ago`;
+}
+
 // ── DOM helpers (textContent ONLY — never innerHTML) ────────────────────────
 function el(doc, tag, cls, text) {
   const node = doc.createElement(tag);
@@ -141,6 +155,13 @@ export function renderAccounts(doc, target, accounts, now = Date.now()) {
       if (q.sevenDay) card.appendChild(quotaBar(doc, 'Weekly', q.sevenDay.utilizationPct, q.sevenDay.resetsAt, now));
     } else {
       card.appendChild(el(doc, 'div', 'sub-account-noquota', 'No quota reading yet.'));
+    }
+    // Token health: when the poller silently refreshed the access token from the
+    // refresh token, show it — so a routine access-token expiry reads as healthy
+    // (auto-handled) rather than looking like a re-auth event.
+    const refAge = a && a.lastRefreshAt ? relativeAge(a.lastRefreshAt, now) : null;
+    if (refAge) {
+      card.appendChild(el(doc, 'div', 'sub-account-refresh', `Token auto-refreshed ${refAge}`));
     }
     target.appendChild(card);
   }

--- a/docs/specs/_drafts/subscription-token-autorefresh.eli16.md
+++ b/docs/specs/_drafts/subscription-token-autorefresh.eli16.md
@@ -1,0 +1,30 @@
+# ELI16 — Stop crying "sign in again" when the login is actually fine
+
+## The plain-English version
+
+When you log into Claude, your computer gets two keys, not one:
+
+- A **short-lived key** (the "access token"). It only works for about 8–12 hours, then it goes stale. This is normal and happens every single day.
+- A **long-lived key** (the "refresh token"). It lasts weeks to months. Whenever the short-lived key goes stale, your Claude app quietly uses the long-lived key to mint a brand-new short-lived one. You never see this happen — it's automatic.
+
+So the long-lived key is the real "I am logged in." The short-lived one is just a daily disposable.
+
+## What was broken
+
+We have a background checker (the quota poller) that peeks at each account to see how much of your usage limit is left. To do that it grabs the short-lived key and asks Anthropic's servers. **But it never did the "use the long-lived key to get a fresh short-lived key" step.** So every day, the moment the short-lived key went stale, the checker got a "not allowed" answer and concluded: *"this login is dead — the user has to sign in again."*
+
+That was wrong. The login was perfectly fine. Only the disposable daily key had expired. The result: accounts showed "needs sign-in" overnight even though nothing was actually wrong — exactly the confusing thing you ran into ("how did they go stale already? I thought this was a one-time thing").
+
+## What this change does
+
+Now, when the checker gets that "not allowed" answer, it first tries the same automatic refresh the Claude app does: it uses the long-lived key to mint a fresh short-lived key, saves it, and tries again. If that works, the account just keeps working — no sign-in prompt, nothing for you to do. Only if the **long-lived** key is genuinely dead (you changed your password, signed out, or a new login elsewhere bumped it) does it say "needs sign-in" — which is what that label was always supposed to mean.
+
+It also shows a small "token auto-refreshed" note on the dashboard so you can SEE it's handling this for you, instead of guessing.
+
+## Why it's safe
+
+The only risky part is saving the new key back. If it saved a bad key, it could break a working login. So the save only happens after the new key passes a strict shape check, and it's a read-merge-write that keeps every other field exactly as it was. If anything about the refresh fails — wrong answer, network blip, anything — it writes nothing and falls back to the old "needs sign-in" behavior. Worst case is "no improvement," never "broke your login."
+
+## What you need to decide
+
+Nothing to configure. This is automatic and on by default for the quota checker. The real-world question is just whether the refresh actually succeeds against your live accounts — which is verified by watching a currently-stale account recover after this ships.

--- a/src/core/OAuthRefresher.ts
+++ b/src/core/OAuthRefresher.ts
@@ -1,0 +1,287 @@
+/**
+ * OAuthRefresher — mint a fresh Claude Code OAuth access token from its stored
+ * refresh token, so the QuotaPoller never falsely flags a still-valid login as
+ * `needs-reauth` (P1.2 hardening of the Subscription & Auth Standard).
+ *
+ * ── Why this exists (the bug it fixes) ──
+ * A Claude Code login holds TWO tokens in its config home's credential store:
+ *   - a short-lived ACCESS token (`sk-ant-oat…`, ~8–12h), and
+ *   - a long-lived REFRESH token (`sk-ant-ort…`, weeks→months).
+ * The `claude` client silently exchanges the refresh token for a new access
+ * token on every real use. The QuotaPoller reads the access token out-of-band
+ * and calls the usage endpoint directly — so when the access token has expired
+ * (which is routine, daily) but the refresh token is still perfectly valid, the
+ * usage read returns 401 and the poller wrongly marks the account `needs-reauth`.
+ * That cried wolf: the login is intact, only the access token lapsed. This module
+ * performs the same refresh-token exchange the client does, so a routine expiry
+ * recovers silently and `needs-reauth` is reserved for a genuinely dead login
+ * (refresh token revoked / password change) — exactly what SubscriptionPool's
+ * status comment already promises.
+ *
+ * ── Corruption safety (the load-bearing invariant) ──
+ * The ONLY way this module could harm a working login is by writing a bad
+ * credential back. So the write is gated three ways:
+ *   1. it happens ONLY on a fully-validated 200 response (new access token shaped
+ *      `sk-ant-oat…`, a positive numeric `expires_in`);
+ *   2. it is a READ-MERGE-WRITE — the existing credential JSON is re-read and only
+ *      the access token / refresh token / expiry are overwritten, so scopes,
+ *      subscriptionType, rateLimitTier and any unknown fields are preserved; and
+ *   3. if the server rotates the refresh token, the NEW one is persisted; if the
+ *      response omits a refresh token (non-rotating server), the existing one is
+ *      kept — never dropped.
+ * A wrong endpoint / client id / network failure can therefore only ever make the
+ * exchange FAIL (→ the caller's existing `needs-reauth` path), never corrupt.
+ *
+ * Token values are NEVER logged or returned to any persisted surface. The OAuth
+ * token endpoint + client id are the public Claude Code values, extracted from
+ * the official client binary (verified 2026-06-08).
+ *
+ * Testability: the credential store, the fetch surface, and the clock are all
+ * injectable, so the whole refresh runs hermetically with zero keychain, zero
+ * network, and a deterministic clock in tests.
+ */
+
+import { execFileSync } from 'node:child_process';
+import crypto from 'node:crypto';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+/** Public Claude Code OAuth token endpoint (from the official client binary). */
+export const CLAUDE_TOKEN_URL = 'https://platform.claude.com/v1/oauth/token';
+/** Public Claude Code OAuth client id (from the official client binary). */
+export const CLAUDE_CODE_CLIENT_ID = '9d1c250a-e61b-44d9-88ed-5944d1962f5e';
+
+const ACCESS_PREFIX = 'sk-ant-oat';
+const REFRESH_PREFIX = 'sk-ant-ort';
+
+export type RefreshFailReason =
+  | 'unsupported-account' // not an anthropic/claude-code account
+  | 'read-failed' // credential store unreadable / unparseable
+  | 'no-refresh-token' // no refresh token present → genuine re-auth needed
+  | 'exchange-failed' // the OAuth token endpoint rejected / was unreachable
+  | 'malformed-response' // 200 but the response wasn't a usable credential
+  | 'write-failed'; // exchange ok but the new credential couldn't be persisted
+
+export type RefreshResult =
+  | { ok: true; accessToken: string; expiresAt: number; rotated: boolean }
+  | { ok: false; reason: RefreshFailReason; status?: number };
+
+/** The OAuth access + refresh tokens parsed out of a credential store entry. */
+export interface ClaudeOauth {
+  accessToken?: string;
+  refreshToken?: string;
+  expiresAt?: number;
+  [k: string]: unknown;
+}
+
+/**
+ * A credential store for one config home. `read` returns the RAW JSON string of
+ * the stored entry (so the refresher can merge-preserve every field); `write`
+ * persists a replacement raw JSON string. Injectable so tests use a fake.
+ */
+export interface CredentialStore {
+  read(configHome: string): string | null;
+  write(configHome: string, rawJson: string): boolean;
+}
+
+/** POST-capable fetch surface (distinct from QuotaPoller's GET-only FetchImpl). */
+export type RefreshFetch = (
+  url: string,
+  init: { method: string; headers: Record<string, string>; body: string },
+) => Promise<{ ok: boolean; status: number; json: () => Promise<unknown> }>;
+
+export interface RefreshDeps {
+  store?: CredentialStore;
+  fetchImpl?: RefreshFetch;
+  now?: () => number;
+  tokenUrl?: string;
+  clientId?: string;
+}
+
+export function expandHome(p: string): string {
+  if (p === '~' || p.startsWith('~/')) {
+    return path.join(process.env.HOME ?? '', p.slice(1));
+  }
+  return p;
+}
+
+/**
+ * macOS keychain service name for a config home's Claude Code credentials.
+ * The default home (`~/.claude`) has no hash suffix; every other config home is
+ * suffixed with the first 8 hex of sha256(configHome) — verified empirically and
+ * matched by the official client.
+ */
+export function claudeCredentialService(configHome: string): string {
+  const home = expandHome(configHome);
+  const defaultHome = expandHome('~/.claude');
+  return home === defaultHome
+    ? 'Claude Code-credentials'
+    : `Claude Code-credentials-${crypto.createHash('sha256').update(home).digest('hex').slice(0, 8)}`;
+}
+
+/** Non-darwin credential file for a config home. */
+export function claudeCredentialFilePath(configHome: string): string {
+  return path.join(expandHome(configHome), '.credentials.json');
+}
+
+/** Default store: macOS keychain, else a per-config-home credentials file. */
+export const defaultCredentialStore: CredentialStore = {
+  read(configHome: string): string | null {
+    if (process.platform === 'darwin') {
+      try {
+        const raw = execFileSync(
+          'security',
+          ['find-generic-password', '-s', claudeCredentialService(configHome), '-w'],
+          { encoding: 'utf-8', stdio: ['ignore', 'pipe', 'ignore'] },
+        ).trim();
+        return raw || null;
+      } catch {
+        return null; // @silent-fallback-ok: no keychain entry → unreadable
+      }
+    }
+    try {
+      const p = claudeCredentialFilePath(configHome);
+      return fs.existsSync(p) ? fs.readFileSync(p, 'utf-8') : null;
+    } catch {
+      return null; // @silent-fallback-ok: missing/unreadable creds file
+    }
+  },
+  write(configHome: string, rawJson: string): boolean {
+    if (process.platform === 'darwin') {
+      try {
+        execFileSync(
+          'security',
+          [
+            'add-generic-password',
+            '-U', // update the existing entry in place
+            '-a',
+            os.userInfo().username,
+            '-s',
+            claudeCredentialService(configHome),
+            '-w',
+            rawJson,
+          ],
+          { stdio: ['ignore', 'ignore', 'ignore'] },
+        );
+        return true;
+      } catch {
+        return false; // @silent-fallback-ok: keychain write failed → caller falls to needs-reauth
+      }
+    }
+    try {
+      const p = claudeCredentialFilePath(configHome);
+      fs.mkdirSync(path.dirname(p), { recursive: true });
+      fs.writeFileSync(p, rawJson, { mode: 0o600 });
+      return true;
+    } catch {
+      return false; // @silent-fallback-ok: file write failed
+    }
+  },
+};
+
+/** Parse the `claudeAiOauth` block out of a config home's credential store. */
+export function readClaudeOauth(
+  configHome: string,
+  store: CredentialStore = defaultCredentialStore,
+): ClaudeOauth | null {
+  const raw = store.read(configHome);
+  if (!raw) return null;
+  try {
+    const parsed = JSON.parse(raw) as Record<string, unknown>;
+    const oauth = parsed?.claudeAiOauth;
+    return oauth && typeof oauth === 'object' ? (oauth as ClaudeOauth) : null;
+  } catch {
+    return null; // @silent-fallback-ok: unparseable entry
+  }
+}
+
+/**
+ * Refresh a config home's Claude Code access token from its stored refresh token.
+ * Returns the new access token + expiry on success; otherwise a typed failure
+ * reason the caller maps to its `needs-reauth` decision. Writes NOTHING on any
+ * failure — a working login is never put at risk by an unsuccessful refresh.
+ */
+export async function refreshClaudeToken(
+  configHome: string,
+  deps: RefreshDeps = {},
+): Promise<RefreshResult> {
+  const store = deps.store ?? defaultCredentialStore;
+  const fetchImpl: RefreshFetch =
+    deps.fetchImpl ??
+    ((url, init) => fetch(url, init as RequestInit) as unknown as ReturnType<RefreshFetch>);
+  const now = deps.now ?? (() => Date.now());
+  const tokenUrl = deps.tokenUrl ?? CLAUDE_TOKEN_URL;
+  const clientId = deps.clientId ?? CLAUDE_CODE_CLIENT_ID;
+
+  const raw = store.read(configHome);
+  if (!raw) return { ok: false, reason: 'read-failed' };
+  let parsed: Record<string, unknown>;
+  try {
+    parsed = JSON.parse(raw) as Record<string, unknown>;
+  } catch {
+    return { ok: false, reason: 'read-failed' };
+  }
+  const oauth = (parsed?.claudeAiOauth ?? null) as ClaudeOauth | null;
+  const refreshToken = oauth?.refreshToken;
+  if (typeof refreshToken !== 'string' || !refreshToken) {
+    return { ok: false, reason: 'no-refresh-token' };
+  }
+
+  let res: { ok: boolean; status: number; json: () => Promise<unknown> };
+  try {
+    res = await fetchImpl(tokenUrl, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        grant_type: 'refresh_token',
+        refresh_token: refreshToken,
+        client_id: clientId,
+      }),
+    });
+  } catch {
+    return { ok: false, reason: 'exchange-failed' };
+  }
+  if (!res.ok) return { ok: false, reason: 'exchange-failed', status: res.status };
+
+  let data: Record<string, unknown>;
+  try {
+    data = (await res.json()) as Record<string, unknown>;
+  } catch {
+    return { ok: false, reason: 'malformed-response' };
+  }
+
+  const newAccess = data?.access_token;
+  const expiresIn = data?.expires_in;
+  if (typeof newAccess !== 'string' || !newAccess.startsWith(ACCESS_PREFIX)) {
+    return { ok: false, reason: 'malformed-response' };
+  }
+  if (typeof expiresIn !== 'number' || !Number.isFinite(expiresIn) || expiresIn <= 0) {
+    return { ok: false, reason: 'malformed-response' };
+  }
+
+  const newRefresh = data?.refresh_token;
+  const rotated =
+    typeof newRefresh === 'string' &&
+    newRefresh.startsWith(REFRESH_PREFIX) &&
+    newRefresh !== refreshToken;
+
+  const expiresAt = now() + expiresIn * 1000;
+  // READ-MERGE-WRITE: preserve every existing field, overwrite only the tokens
+  // + expiry. Keep the old refresh token if the server didn't rotate.
+  const updatedOauth: ClaudeOauth = {
+    ...oauth,
+    accessToken: newAccess,
+    refreshToken:
+      typeof newRefresh === 'string' && newRefresh.startsWith(REFRESH_PREFIX)
+        ? newRefresh
+        : refreshToken,
+    expiresAt,
+  };
+  const updatedRaw = { ...parsed, claudeAiOauth: updatedOauth };
+
+  if (!store.write(configHome, JSON.stringify(updatedRaw))) {
+    return { ok: false, reason: 'write-failed' };
+  }
+  return { ok: true, accessToken: newAccess, expiresAt, rotated };
+}

--- a/src/core/QuotaPoller.ts
+++ b/src/core/QuotaPoller.ts
@@ -32,8 +32,6 @@
  * poller runs hermetically with zero credentials and zero network in tests.
  */
 
-import { execFileSync } from 'node:child_process';
-import crypto from 'node:crypto';
 import fs from 'node:fs';
 import path from 'node:path';
 import type {
@@ -41,9 +39,22 @@ import type {
   SubscriptionAccount,
   AccountQuotaSnapshot,
 } from './SubscriptionPool.js';
+import {
+  readClaudeOauth,
+  refreshClaudeToken,
+  expandHome,
+  type RefreshResult,
+} from './OAuthRefresher.js';
 
 /** Injectable token resolver — returns an account's OAuth access token or null. */
 export type TokenResolver = (account: SubscriptionAccount) => string | null;
+
+/**
+ * Injectable account refresher — exchanges a config home's stored refresh token
+ * for a fresh access token (see OAuthRefresher). Defaults to the real keychain/
+ * file-backed refresh; tests inject a stub so the poller runs hermetically.
+ */
+export type AccountRefresher = (account: SubscriptionAccount) => Promise<RefreshResult>;
 
 /** Minimal fetch surface so tests inject a stub (no global fetch dependency). */
 export type FetchImpl = (
@@ -59,9 +70,20 @@ export interface QuotaPollerConfig {
   fetchImpl?: FetchImpl;
   /** Injected for tests; defaults to the config-home credential resolver. */
   tokenResolver?: TokenResolver;
+  /**
+   * Injected for tests; defaults to the real OAuth refresh-token exchange. On a
+   * usage-read auth failure the poller calls this BEFORE declaring needs-reauth,
+   * so a routine access-token expiry recovers silently instead of crying wolf.
+   */
+  refresher?: AccountRefresher;
   /** Logger (defaults to console). */
   logger?: { log: (m: string) => void; warn: (m: string) => void };
 }
+
+/** Outcome of a single usage read (internal). */
+type UsageRead =
+  | { authFailed: false; body: Record<string, unknown> | null }
+  | { authFailed: true };
 
 export interface BurnRate {
   /** Utilization points per hour on the binding (7-day) window. */
@@ -76,59 +98,20 @@ const USAGE_URL = 'https://api.anthropic.com/api/oauth/usage';
 
 /**
  * Resolve a claude-code account's OAuth access token from its config home,
- * TRANSIENTLY. Never persisted, never logged. macOS: the per-config-home
- * keychain entry `Claude Code-credentials-<sha256(configHome)[0:8]>` (verified
- * empirically). Linux/other: `<configHome>/.credentials.json`. The default
- * (`~/.claude`) keychain entry has no hash suffix.
+ * TRANSIENTLY. Never persisted, never logged. Reads via the shared OAuthRefresher
+ * locator (macOS keychain `Claude Code-credentials-<sha256(configHome)[0:8]>`,
+ * else `<configHome>/.credentials.json`) so the resolver and the refresher always
+ * agree on WHERE a config home's credentials live. NOTE: an EXPIRED access token
+ * is still returned here (it's a valid string) — expiry is detected by the usage
+ * read's 401 and recovered by the refresher, not by this resolver.
  */
 export function defaultTokenResolver(account: SubscriptionAccount): string | null {
   if (account.provider !== 'anthropic' || account.framework !== 'claude-code') {
     return null;
   }
-  const configHome = expandHome(account.configHome);
-
-  // Linux / non-darwin: per-config-home credentials file.
-  if (process.platform !== 'darwin') {
-    try {
-      const credPath = path.join(configHome, '.credentials.json');
-      if (fs.existsSync(credPath)) {
-        const data = JSON.parse(fs.readFileSync(credPath, 'utf-8'));
-        const tok = data?.claudeAiOauth?.accessToken;
-        return typeof tok === 'string' && tok.startsWith('sk-ant-oat') ? tok : null;
-      }
-    } catch {
-      // @silent-fallback-ok: missing/unreadable creds → unresolvable token (null)
-    }
-    return null;
-  }
-
-  // macOS: keychain service name, hash-suffixed by config-home path.
-  const defaultHome = expandHome('~/.claude');
-  const service =
-    configHome === defaultHome
-      ? 'Claude Code-credentials'
-      : `Claude Code-credentials-${crypto.createHash('sha256').update(configHome).digest('hex').slice(0, 8)}`;
-  try {
-    const raw = execFileSync(
-      'security',
-      ['find-generic-password', '-s', service, '-w'],
-      { encoding: 'utf-8', stdio: ['ignore', 'pipe', 'ignore'] },
-    ).trim();
-    if (!raw) return null;
-    const data = JSON.parse(raw);
-    const tok = data?.claudeAiOauth?.accessToken;
-    return typeof tok === 'string' && tok.startsWith('sk-ant-oat') ? tok : null;
-  } catch {
-    // @silent-fallback-ok: no keychain entry for this config home → null
-    return null;
-  }
-}
-
-function expandHome(p: string): string {
-  if (p === '~' || p.startsWith('~/')) {
-    return path.join(process.env.HOME ?? '', p.slice(1));
-  }
-  return p;
+  const oauth = readClaudeOauth(account.configHome);
+  const tok = oauth?.accessToken;
+  return typeof tok === 'string' && tok.startsWith('sk-ant-oat') ? tok : null;
 }
 
 /**
@@ -216,6 +199,7 @@ export class QuotaPoller {
   private readonly pollIntervalMs: number;
   private readonly fetchImpl: FetchImpl;
   private readonly tokenResolver: TokenResolver;
+  private readonly refresher: AccountRefresher;
   private readonly logger: { log: (m: string) => void; warn: (m: string) => void };
   private interval: ReturnType<typeof setInterval> | null = null;
   /** Most-recent snapshot per account id. */
@@ -230,6 +214,8 @@ export class QuotaPoller {
       config.fetchImpl ??
       ((url, init) => fetch(url, init as RequestInit) as unknown as ReturnType<FetchImpl>);
     this.tokenResolver = config.tokenResolver ?? defaultTokenResolver;
+    this.refresher =
+      config.refresher ?? ((account) => refreshClaudeToken(expandHome(account.configHome)));
     this.logger = config.logger ?? { log: () => {}, warn: () => {} };
   }
 
@@ -249,18 +235,11 @@ export class QuotaPoller {
   }
 
   /**
-   * Poll one account: resolve token transiently, read usage, map to snapshot.
-   * Returns null when the token is unresolvable or the read fails. NEVER logs
-   * or returns the token.
+   * One usage read. Returns the parsed body (or null body on a non-auth non-ok),
+   * an auth-failed marker (401/403), or null on a network failure. NEVER logs the
+   * token.
    */
-  async pollAccount(account: SubscriptionAccount): Promise<AccountQuotaSnapshot | null> {
-    const token = this.tokenResolver(account);
-    if (!token) {
-      this.logger.warn(`[QuotaPoller] no resolvable token for account ${account.id} — skipping`);
-      return null;
-    }
-    let body: Record<string, unknown> | null = null;
-    let authFailed = false;
+  private async readUsage(token: string): Promise<UsageRead | null> {
     try {
       const res = await this.fetchImpl(USAGE_URL, {
         headers: {
@@ -270,24 +249,73 @@ export class QuotaPoller {
         },
       });
       if (res.ok) {
-        body = (await res.json()) as Record<string, unknown>;
-      } else if (res.status === 401 || res.status === 403) {
-        authFailed = true;
+        return { authFailed: false, body: (await res.json()) as Record<string, unknown> };
       }
+      if (res.status === 401 || res.status === 403) return { authFailed: true };
+      return { authFailed: false, body: null }; // 5xx etc. → no snapshot, not auth
     } catch {
       // @silent-fallback-ok: network failure → no snapshot this cycle (retry next)
       return null;
     }
-    if (authFailed) {
-      // Genuine auth failure (revoked / password change) — surface for re-auth.
-      try {
-        this.pool.update(account.id, { status: 'needs-reauth' });
-      } catch {
-        // @silent-fallback-ok: pool update best-effort; status reflects next read
-      }
-      this.logger.warn(`[QuotaPoller] account ${account.id} usage read returned auth error → needs-reauth`);
+  }
+
+  private markNeedsReauth(account: SubscriptionAccount, reason: string): void {
+    try {
+      this.pool.update(account.id, { status: 'needs-reauth' });
+    } catch {
+      // @silent-fallback-ok: pool update best-effort; status reflects next read
+    }
+    this.logger.warn(`[QuotaPoller] account ${account.id} → needs-reauth (${reason})`);
+  }
+
+  /**
+   * Poll one account: resolve token transiently, read usage, map to snapshot.
+   * On a usage-read auth failure (401/403) the access token may simply have
+   * EXPIRED while the refresh token is still valid — so the poller attempts a
+   * refresh-token exchange and ONE retry BEFORE declaring needs-reauth. Only a
+   * genuinely dead login (no refresh token / refresh rejected / still 401 after
+   * a fresh token) yields needs-reauth. Returns null when the token is
+   * unresolvable or the read fails. NEVER logs or returns the token.
+   */
+  async pollAccount(account: SubscriptionAccount): Promise<AccountQuotaSnapshot | null> {
+    const token = this.tokenResolver(account);
+    if (!token) {
+      this.logger.warn(`[QuotaPoller] no resolvable token for account ${account.id} — skipping`);
       return null;
     }
+
+    const read = await this.readUsage(token);
+    if (read === null) return null; // network failure
+
+    let body: Record<string, unknown> | null;
+    if (read.authFailed) {
+      const refreshed = await this.refresher(account);
+      if (!refreshed.ok) {
+        // No refresh token, or the exchange was rejected — genuine re-auth.
+        this.markNeedsReauth(account, refreshed.reason);
+        return null;
+      }
+      const retry = await this.readUsage(refreshed.accessToken);
+      if (retry === null) return null; // network blip on the retry → next cycle
+      if (retry.authFailed) {
+        // Fresh token still rejected — treat as genuinely failed.
+        this.markNeedsReauth(account, 'usage still auth-failed after refresh');
+        return null;
+      }
+      // Recovered silently — no operator action needed. Record for visibility.
+      try {
+        this.pool.update(account.id, { lastRefreshAt: new Date().toISOString() });
+      } catch {
+        // @silent-fallback-ok: visibility-only write
+      }
+      this.logger.log(
+        `[QuotaPoller] account ${account.id} access token refreshed silently (no re-auth needed)`,
+      );
+      body = retry.body;
+    } else {
+      body = read.body;
+    }
+
     if (!body) return null;
 
     const snap = mapUsageResponse(body, 'oauth-usage-endpoint-fallback', new Date().toISOString());

--- a/src/core/SubscriptionPool.ts
+++ b/src/core/SubscriptionPool.ts
@@ -109,6 +109,13 @@ export interface SubscriptionAccount {
   enrolledAt: string;
   /** ISO timestamp the account was last selected for a session. */
   lastUsedAt?: string;
+  /**
+   * ISO timestamp the poller last silently refreshed this account's access token
+   * from its refresh token (P1.2 hardening). Visibility only — lets the dashboard
+   * show "token auto-refreshed" so a routine access-token expiry reads as healthy
+   * rather than a re-auth event.
+   */
+  lastRefreshAt?: string;
   /** Monotonic version for optimistic CAS in update(). */
   version: number;
 }
@@ -143,6 +150,7 @@ export interface UpdateAccountInput {
   status?: SubscriptionAccountStatus;
   lastQuota?: AccountQuotaSnapshot | null;
   lastUsedAt?: string;
+  lastRefreshAt?: string;
   email?: string;
 }
 
@@ -309,6 +317,9 @@ export class SubscriptionPool {
     }
     if (patch.lastUsedAt !== undefined) {
       acct.lastUsedAt = patch.lastUsedAt;
+    }
+    if (patch.lastRefreshAt !== undefined) {
+      acct.lastRefreshAt = patch.lastRefreshAt;
     }
     if (patch.email !== undefined) {
       const em = patch.email.trim();

--- a/tests/e2e/subscription-quota-lifecycle.test.ts
+++ b/tests/e2e/subscription-quota-lifecycle.test.ts
@@ -73,4 +73,35 @@ describe('/subscription-pool quota — E2E feature-alive', () => {
     const onDisk = JSON.parse(fs.readFileSync(path.join(dir, 'subscription-pool.json'), 'utf-8'));
     expect(onDisk.accounts[0].lastQuota.sevenDay.utilizationPct).toBe(42);
   });
+
+  it('LIVE: an expired access token auto-refreshes end-to-end (account stays active, stamped on disk)', async () => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'qpoll-e2e-ref-'));
+    const pool = new SubscriptionPool({ stateDir: dir });
+    pool.add({ id: 'claude-primary', nickname: 'primary', provider: 'anthropic', framework: 'claude-code', configHome: path.join(dir, '.claude-primary'), status: 'active' });
+    // First usage read 401 (access token expired); after the refresh, 200.
+    let calls = 0;
+    const expiredThenOk: FetchImpl = async () => {
+      calls += 1;
+      return calls === 1
+        ? { ok: false, status: 401, json: async () => ({}) }
+        : { ok: true, status: 200, json: async () => USAGE };
+    };
+    const quotaPoller = new QuotaPoller({
+      pool,
+      fetchImpl: expiredThenOk,
+      tokenResolver: () => 'sk-ant-oat01-EXPIRED',
+      refresher: async () => ({ ok: true, accessToken: 'sk-ant-oat01-FRESH', expiresAt: 9e12, rotated: true }),
+    });
+    server = await boot({ config: { authToken: 't', stateDir: dir, port: 0 }, startTime: new Date(), subscriptionPool: pool, quotaPoller });
+
+    const poll = await fetch(server.url + '/subscription-pool/poll', { method: 'POST' });
+    expect((await poll.json())).toMatchObject({ enabled: true, polled: 1, failed: 0 });
+
+    const acct = await (await fetch(server.url + '/subscription-pool/claude-primary')).json();
+    expect(acct.status).toBe('active'); // recovered silently, NOT needs-reauth
+
+    const onDisk = JSON.parse(fs.readFileSync(path.join(dir, 'subscription-pool.json'), 'utf-8'));
+    expect(onDisk.accounts[0].status).toBe('active');
+    expect(onDisk.accounts[0].lastRefreshAt).toBeTruthy(); // auto-refresh recorded durably
+  });
 });

--- a/tests/integration/subscription-quota-routes.test.ts
+++ b/tests/integration/subscription-quota-routes.test.ts
@@ -88,3 +88,83 @@ describe('/subscription-pool quota routes (integration)', () => {
     expect(r.status).toBe(404);
   });
 });
+
+// ── Token-refresh recovery through the live HTTP poll route (P1.2 hardening) ──
+describe('/subscription-pool/poll auto-refresh recovery (integration)', () => {
+  let server: TestServer;
+  let dir: string;
+  let pool: SubscriptionPool;
+
+  async function boot(opts: {
+    fetchImpl: FetchImpl;
+    refresher: ConstructorParameters<typeof QuotaPoller>[0]['refresher'];
+    status?: 'active' | 'needs-reauth';
+  }): Promise<void> {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'qpoll-rec-'));
+    pool = new SubscriptionPool({ stateDir: dir });
+    pool.add({
+      id: 'claude-1',
+      nickname: 'primary',
+      provider: 'anthropic',
+      framework: 'claude-code',
+      configHome: '/h/.claude-1',
+      status: opts.status ?? 'active',
+    });
+    const quotaPoller = new QuotaPoller({
+      pool,
+      fetchImpl: opts.fetchImpl,
+      tokenResolver: () => 'sk-ant-oat01-EXPIRED',
+      refresher: opts.refresher,
+    });
+    const app = express();
+    app.use(express.json());
+    const ctx: any = { config: { authToken: 't', stateDir: dir, port: 0 }, startTime: new Date(), subscriptionPool: pool, quotaPoller };
+    app.use(createRoutes(ctx));
+    server = await listen(app);
+  }
+
+  afterEach(async () => {
+    await server?.close();
+    try { SafeFsExecutor.safeRmSync(dir, { recursive: true, force: true, operation: 'tests/integration/subscription-quota-routes.test.ts:rec-cleanup' }); } catch { /* @silent-fallback-ok */ }
+  });
+
+  const api = (p: string, init?: RequestInit) =>
+    fetch(server.url + p, { headers: { 'Content-Type': 'application/json' }, ...init })
+      .then(async (r) => ({ status: r.status, body: await r.json().catch(() => ({})) }));
+
+  it('an expired access token recovers via refresh — account stays active, not needs-reauth', async () => {
+    let calls = 0;
+    const fetchImpl: FetchImpl = async () => {
+      calls += 1;
+      return calls === 1
+        ? { ok: false, status: 401, json: async () => ({}) }
+        : { ok: true, status: 200, json: async () => USAGE };
+    };
+    await boot({
+      fetchImpl,
+      refresher: async () => ({ ok: true, accessToken: 'sk-ant-oat01-FRESH', expiresAt: 9e12, rotated: true }),
+    });
+
+    const poll = await api('/subscription-pool/poll', { method: 'POST' });
+    expect(poll.status).toBe(200);
+    expect(poll.body).toMatchObject({ enabled: true, polled: 1, failed: 0 });
+
+    const acct = await api('/subscription-pool/claude-1');
+    expect(acct.body.status).toBe('active'); // recovered, NOT needs-reauth
+    expect(acct.body.lastQuota.sevenDay.utilizationPct).toBe(71);
+    expect(acct.body.lastRefreshAt).toBeTruthy(); // visible "auto-refreshed" stamp
+  });
+
+  it('a genuinely dead login (refresh rejected) still flips to needs-reauth', async () => {
+    await boot({
+      fetchImpl: async () => ({ ok: false, status: 401, json: async () => ({}) }),
+      refresher: async () => ({ ok: false, reason: 'no-refresh-token' }),
+    });
+
+    const poll = await api('/subscription-pool/poll', { method: 'POST' });
+    expect(poll.body).toMatchObject({ enabled: true, polled: 0, failed: 1 });
+
+    const acct = await api('/subscription-pool/claude-1');
+    expect(acct.body.status).toBe('needs-reauth');
+  });
+});

--- a/tests/unit/oauth-refresher.test.ts
+++ b/tests/unit/oauth-refresher.test.ts
@@ -1,0 +1,192 @@
+/**
+ * Unit tests for OAuthRefresher (P1.2 hardening of the Subscription & Auth
+ * Standard). Fully hermetic: an in-memory CredentialStore + injected fetch +
+ * fixed clock → zero keychain, zero network. The load-bearing property under
+ * test is CORRUPTION SAFETY: the credential is written back ONLY on a fully
+ * valid exchange, as a read-merge-write that preserves every existing field, and
+ * NEVER on any failure path.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  refreshClaudeToken,
+  readClaudeOauth,
+  claudeCredentialService,
+  type CredentialStore,
+  type RefreshFetch,
+} from '../../src/core/OAuthRefresher.js';
+
+function credRaw(over: Record<string, unknown> = {}): string {
+  return JSON.stringify({
+    claudeAiOauth: {
+      accessToken: 'sk-ant-oat0-OLD',
+      refreshToken: 'sk-ant-ort0-OLD',
+      expiresAt: 1000,
+      scopes: ['user:inference', 'user:profile'],
+      subscriptionType: 'max',
+      rateLimitTier: 'default_claude_max_20x',
+      ...over,
+    },
+  });
+}
+
+function fakeStore(initial: Record<string, string> = {}) {
+  const m: Record<string, string> = { ...initial };
+  let writes = 0;
+  const store: CredentialStore = {
+    read: (ch) => (ch in m ? m[ch] : null),
+    write: (ch, raw) => {
+      m[ch] = raw;
+      writes += 1;
+      return true;
+    },
+  };
+  return { store, dump: () => ({ ...m }), writeCount: () => writes };
+}
+
+function tokenFetch(status: number, body: unknown): RefreshFetch {
+  return async () => ({ ok: status >= 200 && status < 300, status, json: async () => body });
+}
+
+const HOME = '/h/.claude-a';
+const FIXED_NOW = () => 5_000_000;
+
+describe('OAuthRefresher.refreshClaudeToken', () => {
+  it('refreshes + persists a rotated refresh token, preserving all other fields', async () => {
+    const fs = fakeStore({ [HOME]: credRaw() });
+    const res = await refreshClaudeToken(HOME, {
+      store: fs.store,
+      now: FIXED_NOW,
+      fetchImpl: tokenFetch(200, {
+        access_token: 'sk-ant-oat0-NEW',
+        refresh_token: 'sk-ant-ort0-NEW',
+        expires_in: 28800,
+      }),
+    });
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    expect(res.accessToken).toBe('sk-ant-oat0-NEW');
+    expect(res.expiresAt).toBe(5_000_000 + 28800 * 1000);
+    expect(res.rotated).toBe(true);
+
+    const written = JSON.parse(fs.dump()[HOME]).claudeAiOauth;
+    expect(written.accessToken).toBe('sk-ant-oat0-NEW');
+    expect(written.refreshToken).toBe('sk-ant-ort0-NEW'); // rotated token persisted
+    expect(written.expiresAt).toBe(5_000_000 + 28800 * 1000);
+    // every non-token field preserved verbatim
+    expect(written.scopes).toEqual(['user:inference', 'user:profile']);
+    expect(written.subscriptionType).toBe('max');
+    expect(written.rateLimitTier).toBe('default_claude_max_20x');
+  });
+
+  it('keeps the existing refresh token when the server does not rotate it', async () => {
+    const fs = fakeStore({ [HOME]: credRaw() });
+    const res = await refreshClaudeToken(HOME, {
+      store: fs.store,
+      now: FIXED_NOW,
+      fetchImpl: tokenFetch(200, { access_token: 'sk-ant-oat0-NEW2', expires_in: 100 }),
+    });
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    expect(res.rotated).toBe(false);
+    const written = JSON.parse(fs.dump()[HOME]).claudeAiOauth;
+    expect(written.accessToken).toBe('sk-ant-oat0-NEW2');
+    expect(written.refreshToken).toBe('sk-ant-ort0-OLD'); // old one preserved, never dropped
+  });
+
+  it('returns no-refresh-token and writes NOTHING when no refresh token exists', async () => {
+    const fs = fakeStore({ [HOME]: credRaw({ refreshToken: undefined }) });
+    const res = await refreshClaudeToken(HOME, { store: fs.store, fetchImpl: tokenFetch(200, {}) });
+    expect(res).toEqual({ ok: false, reason: 'no-refresh-token' });
+    expect(fs.writeCount()).toBe(0);
+    // original credential is untouched
+    expect(JSON.parse(fs.dump()[HOME]).claudeAiOauth.accessToken).toBe('sk-ant-oat0-OLD');
+  });
+
+  it('returns exchange-failed and writes NOTHING on a non-200 (existing login intact)', async () => {
+    const fs = fakeStore({ [HOME]: credRaw() });
+    const res = await refreshClaudeToken(HOME, { store: fs.store, fetchImpl: tokenFetch(400, { error: 'invalid_grant' }) });
+    expect(res).toEqual({ ok: false, reason: 'exchange-failed', status: 400 });
+    expect(fs.writeCount()).toBe(0);
+    expect(JSON.parse(fs.dump()[HOME]).claudeAiOauth.refreshToken).toBe('sk-ant-ort0-OLD');
+  });
+
+  it('returns exchange-failed when the network throws', async () => {
+    const fs = fakeStore({ [HOME]: credRaw() });
+    const throwFetch: RefreshFetch = async () => {
+      throw new Error('network down');
+    };
+    const res = await refreshClaudeToken(HOME, { store: fs.store, fetchImpl: throwFetch });
+    expect(res).toEqual({ ok: false, reason: 'exchange-failed' });
+    expect(fs.writeCount()).toBe(0);
+  });
+
+  it('rejects a malformed 200 (missing / wrong-shaped access token) and writes NOTHING', async () => {
+    for (const body of [
+      {}, // no access_token
+      { access_token: 'not-an-oauth-token', expires_in: 100 }, // wrong prefix
+      { access_token: 'sk-ant-oat0-NEW' }, // no expires_in
+      { access_token: 'sk-ant-oat0-NEW', expires_in: -5 }, // non-positive expiry
+      { access_token: 'sk-ant-oat0-NEW', expires_in: 'soon' }, // non-numeric expiry
+    ]) {
+      const fs = fakeStore({ [HOME]: credRaw() });
+      const res = await refreshClaudeToken(HOME, { store: fs.store, fetchImpl: tokenFetch(200, body) });
+      expect(res).toEqual({ ok: false, reason: 'malformed-response' });
+      expect(fs.writeCount()).toBe(0);
+    }
+  });
+
+  it('returns read-failed when the credential store is empty / unparseable', async () => {
+    const empty = fakeStore({});
+    expect(await refreshClaudeToken(HOME, { store: empty.store, fetchImpl: tokenFetch(200, {}) })).toEqual({
+      ok: false,
+      reason: 'read-failed',
+    });
+    const garbage = fakeStore({ [HOME]: 'not json' });
+    expect(await refreshClaudeToken(HOME, { store: garbage.store, fetchImpl: tokenFetch(200, {}) })).toEqual({
+      ok: false,
+      reason: 'read-failed',
+    });
+  });
+
+  it('returns write-failed (not ok) when persistence fails after a valid exchange', async () => {
+    const store: CredentialStore = { read: () => credRaw(), write: () => false };
+    const res = await refreshClaudeToken(HOME, {
+      store,
+      now: FIXED_NOW,
+      fetchImpl: tokenFetch(200, { access_token: 'sk-ant-oat0-NEW', expires_in: 100 }),
+    });
+    expect(res).toEqual({ ok: false, reason: 'write-failed' });
+  });
+
+  it('sends the OAuth refresh-token grant with the client id', async () => {
+    let captured: { url: string; body: unknown } | null = null;
+    const spyFetch: RefreshFetch = async (url, init) => {
+      captured = { url, body: JSON.parse(init.body) };
+      return { ok: true, status: 200, json: async () => ({ access_token: 'sk-ant-oat0-NEW', expires_in: 100 }) };
+    };
+    await refreshClaudeToken(HOME, { store: fakeStore({ [HOME]: credRaw() }).store, fetchImpl: spyFetch });
+    expect(captured!.url).toContain('/oauth/token');
+    expect(captured!.body).toMatchObject({ grant_type: 'refresh_token', refresh_token: 'sk-ant-ort0-OLD' });
+    expect((captured!.body as { client_id: string }).client_id).toMatch(/^[0-9a-f-]{36}$/);
+  });
+});
+
+describe('OAuthRefresher locator + reader', () => {
+  it('claudeCredentialService is bare for the default home, hash-suffixed otherwise', () => {
+    expect(claudeCredentialService('~/.claude')).toBe('Claude Code-credentials');
+    const a = claudeCredentialService('/h/.claude-a');
+    const b = claudeCredentialService('/h/.claude-b');
+    expect(a).toMatch(/^Claude Code-credentials-[0-9a-f]{8}$/);
+    expect(b).toMatch(/^Claude Code-credentials-[0-9a-f]{8}$/);
+    expect(a).not.toBe(b); // distinct homes → distinct entries
+    expect(claudeCredentialService('/h/.claude-a')).toBe(a); // stable for the same home
+  });
+
+  it('readClaudeOauth parses the oauth block and tolerates junk', () => {
+    const fs = fakeStore({ [HOME]: credRaw() });
+    expect(readClaudeOauth(HOME, fs.store)?.accessToken).toBe('sk-ant-oat0-OLD');
+    expect(readClaudeOauth('/nope', fs.store)).toBeNull();
+    expect(readClaudeOauth(HOME, { read: () => 'not json', write: () => true })).toBeNull();
+  });
+});

--- a/tests/unit/quota-poller.test.ts
+++ b/tests/unit/quota-poller.test.ts
@@ -93,11 +93,52 @@ describe('QuotaPoller', () => {
     expect(await p.pollAccount(pool.get('claude-1')!)).toBeNull();
   });
 
-  it('pollAccount flags needs-reauth on a 401/403', async () => {
-    const p = new QuotaPoller({ pool, fetchImpl: statusFetch(401), tokenResolver: () => 'sk-ant-oat01-x' });
+  it('pollAccount flags needs-reauth on a 401 when the refresh token is dead', async () => {
+    // 401 AND the refresher reports no usable refresh token → genuine re-auth.
+    const p = new QuotaPoller({
+      pool,
+      fetchImpl: statusFetch(401),
+      tokenResolver: () => 'sk-ant-oat01-x',
+      refresher: async () => ({ ok: false, reason: 'no-refresh-token' }),
+    });
     pool.add({ ...ACCT });
     const snap = await p.pollAccount(pool.get('claude-1')!);
     expect(snap).toBeNull();
+    expect(pool.get('claude-1')!.status).toBe('needs-reauth');
+  });
+
+  it('pollAccount refreshes silently and recovers on a 401 with a live refresh token', async () => {
+    // First usage read 401 (access token expired), then 200 after the refresh.
+    let calls = 0;
+    const fetchImpl: FetchImpl = async () => {
+      calls += 1;
+      return calls === 1
+        ? { ok: false, status: 401, json: async () => ({}) }
+        : { ok: true, status: 200, json: async () => LIVE_USAGE_BODY };
+    };
+    const p = new QuotaPoller({
+      pool,
+      fetchImpl,
+      tokenResolver: () => 'sk-ant-oat01-EXPIRED',
+      refresher: async () => ({ ok: true, accessToken: 'sk-ant-oat01-FRESH', expiresAt: 9e12, rotated: true }),
+    });
+    pool.add({ ...ACCT, status: 'active' });
+    const snap = await p.pollAccount(pool.get('claude-1')!);
+    expect(snap?.sevenDay?.utilizationPct).toBe(71); // recovered: got the usage
+    expect(pool.get('claude-1')!.status).toBe('active'); // NOT needs-reauth
+    expect(pool.get('claude-1')!.lastRefreshAt).toBeTruthy(); // visibility stamp set
+    expect(calls).toBe(2); // one failed read + one successful retry
+  });
+
+  it('pollAccount marks needs-reauth when the usage read still 401s after a refresh', async () => {
+    const p = new QuotaPoller({
+      pool,
+      fetchImpl: statusFetch(401), // always 401, even with a fresh token
+      tokenResolver: () => 'sk-ant-oat01-x',
+      refresher: async () => ({ ok: true, accessToken: 'sk-ant-oat01-FRESH', expiresAt: 9e12, rotated: false }),
+    });
+    pool.add({ ...ACCT });
+    expect(await p.pollAccount(pool.get('claude-1')!)).toBeNull();
     expect(pool.get('claude-1')!.status).toBe('needs-reauth');
   });
 

--- a/tests/unit/subscriptions-render.test.ts
+++ b/tests/unit/subscriptions-render.test.ts
@@ -17,6 +17,7 @@ import {
   friendlyStatus,
   friendlyProvider,
   countdown,
+  relativeAge,
   quotaBar,
   renderAccounts,
   renderPendingLogins,
@@ -118,6 +119,32 @@ describe('renderAccounts', () => {
     const t = el();
     renderAccounts(doc, t, [{ id: 'a', nickname: 'n', provider: 'anthropic', framework: 'claude-code', status: 'warming' }], NOW);
     expect(t.querySelector('.sub-account-noquota')).toBeTruthy();
+  });
+  it('shows a token-health line when the account was auto-refreshed', () => {
+    const t = el();
+    renderAccounts(doc, t, [{
+      id: 'a1', nickname: 'personal', provider: 'anthropic', framework: 'claude-code', status: 'active',
+      lastRefreshAt: new Date(NOW - 5 * 60_000).toISOString(),
+    }], NOW);
+    const line = t.querySelector('.sub-account-refresh');
+    expect(line).toBeTruthy();
+    expect(line!.textContent).toContain('auto-refreshed');
+    expect(line!.textContent).toContain('5m ago');
+  });
+  it('omits the token-health line when never refreshed', () => {
+    const t = el();
+    renderAccounts(doc, t, [{ id: 'a', nickname: 'n', provider: 'anthropic', framework: 'claude-code', status: 'active' }], NOW);
+    expect(t.querySelector('.sub-account-refresh')).toBeNull();
+  });
+});
+
+describe('relativeAge', () => {
+  it('formats coarse past ages and tolerates junk', () => {
+    expect(relativeAge(new Date(NOW - 30_000).toISOString(), NOW)).toBe('just now');
+    expect(relativeAge(new Date(NOW - 5 * 60_000).toISOString(), NOW)).toBe('5m ago');
+    expect(relativeAge(new Date(NOW - 3 * 3600_000).toISOString(), NOW)).toBe('3h ago');
+    expect(relativeAge(new Date(NOW - 2 * 86_400_000).toISOString(), NOW)).toBe('2d ago');
+    expect(relativeAge('not-a-date', NOW)).toBe('');
   });
 });
 

--- a/upgrades/next/subscription-token-autorefresh.md
+++ b/upgrades/next/subscription-token-autorefresh.md
@@ -1,0 +1,24 @@
+<!-- bump: patch -->
+
+## What Changed
+
+The subscription-pool quota poller now auto-refreshes an expired OAuth access token from its stored refresh token before declaring an account `needs-reauth`. Previously any 401/403 from the usage endpoint was treated as a dead login — but a Claude Code access token expires routinely (~8–12h) while its refresh token stays valid for weeks, so the poller was wrongly flagging healthy accounts as needing re-authentication every time the short-lived token lapsed.
+
+New `OAuthRefresher` performs the `refresh_token` grant against the public Claude Code OAuth token endpoint and writes the rotated credential back corruption-safely (validated-200 only, read-merge-write preserving all fields, fail-closed on any error). `QuotaPoller` calls it on a 401 and retries once; only a genuinely dead refresh token now yields `needs-reauth`. A new optional `lastRefreshAt` field plus a dashboard "Token auto-refreshed" line make the silent refresh visible.
+
+## What to Tell Your User
+
+Your accounts no longer ask you to sign in again just because a day went by. A Claude login actually holds two keys — a short-lived one that turns over every several hours, and a long-lived one that lasts weeks. I now renew the short-lived key automatically using the long-lived one, exactly the way the Claude app does, so a routine daily expiry is invisible to you. I'll only ask you to sign in again when the real login is genuinely gone — a password change, a sign-out, or a new login elsewhere. The dashboard also shows a small "token auto-refreshed" note so you can see I'm handling it.
+
+## Summary of New Capabilities
+
+| Capability | How to Use |
+|-----------|-----------|
+| Auto-refresh of expired access tokens | automatic (subscription-pool quota poller) |
+| Token-health visibility | Subscriptions dashboard tab — "Token auto-refreshed" line |
+
+## Evidence
+
+Reproduction (live, 2026-06-08, echo's two enrolled max accounts): both showed `status: needs-reauth` and a fresh `POST /subscription-pool/poll` failed 2/2. Inspecting the macOS keychain entries (`Claude Code-credentials-5939f6c8` / `-63465191`) showed `hasRefreshToken: true` with the access token `expiresAt` ~11–12h in the past — i.e. only the short-lived token had lapsed; the login was intact. The old code path mapped that 401 straight to `needs-reauth`.
+
+After the fix: the unit/integration/e2e suites reproduce the exact sequence (usage read 401 → refresh-token exchange → retry 200) and assert the account stays `active` with a `lastRefreshAt` stamp rather than flipping to `needs-reauth`; the dead-refresh-token case still flips to `needs-reauth`. All three tiers green (`tests/unit/oauth-refresher.test.ts`, `tests/unit/quota-poller.test.ts`, `tests/integration/subscription-quota-routes.test.ts`, `tests/e2e/subscription-quota-lifecycle.test.ts`), tsc + repo lint clean.

--- a/upgrades/side-effects/subscription-token-autorefresh.md
+++ b/upgrades/side-effects/subscription-token-autorefresh.md
@@ -1,0 +1,29 @@
+# Side-effects review — subscription-pool OAuth access-token auto-refresh
+
+## What changed
+- New `src/core/OAuthRefresher.ts`: a corruption-safe refresh-token→access-token exchange for a config home's Claude Code credential (keychain on macOS, `<configHome>/.credentials.json` elsewhere). Endpoint + client id are the public Claude Code values extracted from the official client binary.
+- `src/core/QuotaPoller.ts`: on a usage-read 401/403 the poller now attempts a refresh + one retry BEFORE marking the account `needs-reauth`. `defaultTokenResolver` refactored to share the OAuthRefresher locator (single source of truth for where a config home's credential lives).
+- `src/core/SubscriptionPool.ts`: new optional `lastRefreshAt` field (visibility only).
+- `dashboard/subscriptions.js`: a "Token auto-refreshed <ago>" line + `relativeAge()` helper.
+
+## Blast radius / who is affected
+- Only anthropic/claude-code accounts in a SubscriptionPool. A pool of zero accounts (single-account agents) is entirely unaffected — the poller only runs when accounts are enrolled.
+- Behavior change is strictly a NARROWING of when `needs-reauth` fires: it no longer fires on a recoverable access-token expiry. Genuinely dead logins still flip to `needs-reauth` exactly as before.
+
+## Corruption safety (the load-bearing concern)
+- The ONLY mutation is the credential write-back. It is gated three ways: (1) only on a fully-validated 200 (new access token shaped `sk-ant-oat…`, positive numeric `expires_in`); (2) read-merge-write that preserves every existing field (scopes, subscriptionType, rateLimitTier, unknown fields); (3) refresh-token rotation persisted when present, old token kept when the server doesn't rotate — never dropped.
+- Any failure (wrong endpoint, wrong client id, network error, malformed body, write failure) writes NOTHING and returns a typed failure → the caller's existing `needs-reauth` path. A misconfiguration can only ever fail to improve, never corrupt a working login. This is fail-CLOSED, not silent-degrade-to-heuristic (consistent with the no-silent-llm-fallback standard, though this path is auth not inference).
+
+## Secrets handling
+- Token values are never logged and never returned to any persisted surface. The pool registry's existing `assertNoCredentialFields` guard still rejects any credential-bearing field name; `lastRefreshAt` is a timestamp, not a secret.
+
+## Framework generality
+- Scoped to claude-code OAuth specifically (the refresh-token grant is provider/framework-specific). It does NOT touch the session launch/inject abstraction (frameworkSessionLaunch / MessageDelivery), so it cannot regress codex-cli / gemini-cli / pi-cli. Non-claude-code accounts are skipped by the same provider/framework guard the poller already applies.
+
+## Migration parity
+- No agent-installed files change (no settings.json hooks, no config defaults, no CLAUDE.md template, no hook scripts, no skills). This is an in-process monitoring component; existing agents pick it up on the next server update. The new `lastRefreshAt` field is optional and back-compatible with existing `subscription-pool.json` on disk.
+
+## Tests
+- Tier 1: `tests/unit/oauth-refresher.test.ts` (rotation, no-rotation, no-refresh-token, exchange-failed, malformed, read-failed, write-failed, locator, request shape) + extended `tests/unit/quota-poller.test.ts` (refresh-recovers, still-401-after-refresh, dead-refresh-token) + `tests/unit/subscriptions-render.test.ts` (token-health line + relativeAge).
+- Tier 2: `tests/integration/subscription-quota-routes.test.ts` — recovery + dead-login through the real `/subscription-pool/poll` HTTP route.
+- Tier 3: `tests/e2e/subscription-quota-lifecycle.test.ts` — expired token auto-refreshes end-to-end, account stays active, stamped to the on-disk registry.


### PR DESCRIPTION
## What this fixes

The subscription-pool quota poller mapped **any** usage-endpoint 401/403 to `needs-reauth`. But a Claude Code login holds two tokens: a short-lived **access token** (~8–12h) and a long-lived **refresh token** (weeks→months). When the access token expired routinely — refresh token still perfectly valid — the poller got a 401 and wrongly flagged a healthy account as `needs-reauth`. Operators saw "needs sign-in" overnight on accounts that were never actually signed out.

## The fix

- **`src/core/OAuthRefresher.ts` (new):** performs the `refresh_token` grant against the public Claude Code OAuth token endpoint (`platform.claude.com/v1/oauth/token`, client id from the official client binary) and writes the rotated credential back **corruption-safely**: only on a fully-validated 200 (`sk-ant-oat…` access token + positive numeric `expires_in`), a read-merge-write preserving every existing field (scopes / subscriptionType / rateLimitTier / unknowns), keeping the old refresh token when the server doesn't rotate. Any failure writes **nothing** and returns a typed reason → the caller's existing `needs-reauth` path. A misconfiguration can only ever fail-to-improve, never corrupt a working login.
- **`src/core/QuotaPoller.ts`:** on a usage-read 401, attempt a refresh + one retry **before** declaring `needs-reauth`. Only a genuinely dead refresh token (revoked / password change / no refresh token) now yields `needs-reauth` — matching the status's own documented intent. `defaultTokenResolver` refactored to share the refresher's credential locator (single source of truth).
- **`src/core/SubscriptionPool.ts`:** new optional `lastRefreshAt` (visibility only).
- **`dashboard/subscriptions.js`:** a "Token auto-refreshed <ago>" line + `relativeAge()` helper.

## Tests (all three tiers, green)

- Unit: `oauth-refresher.test.ts` (rotation / no-rotation / no-refresh-token / exchange-failed / malformed / read-failed / write-failed / locator / request shape), extended `quota-poller.test.ts` (refresh-recovers / still-401-after-refresh / dead-refresh-token), `subscriptions-render.test.ts` (token-health line + relativeAge).
- Integration: `subscription-quota-routes.test.ts` — recovery + dead-login through the real `/subscription-pool/poll` HTTP route.
- E2E: `subscription-quota-lifecycle.test.ts` — expired token auto-refreshes end-to-end, account stays `active`, stamped to the on-disk registry.

## ELI16 — Stop crying "sign in again" when the login is actually fine

A Claude login gives your computer two keys: a short-lived one that turns over every several hours, and a long-lived one that lasts weeks. The long-lived key is the real "I am logged in"; the short-lived one is a daily disposable that the Claude app silently renews using the long-lived key. Our quota checker grabbed the short-lived key and asked Anthropic's servers, but never did the silent-renew step — so every day, the moment the short-lived key went stale, it concluded "this login is dead, the user must sign in again." That was wrong: the login was fine, only the disposable daily key had expired. This change makes the checker do the same automatic renewal the Claude app does — use the long-lived key to mint a fresh short-lived one, save it, retry — so a routine daily expiry is invisible. It only says "needs sign-in" when the long-lived key is genuinely gone (password change, sign-out, login bumped elsewhere). The save-back is gated behind a strict validity check and a read-merge-write, so a failed refresh can never corrupt a working login — worst case is "no improvement," never "broke your login."

🤖 Generated with [Claude Code](https://claude.com/claude-code)
