### PR TITLE
feat(feedback-factory): Phase-3 dual-forward emitter + client (Dawn-locked contract)

### DIFF
--- a/.instar/instar-dev-decisions/2026-06-08T22-34-03-702Z-feedback-parity-phase3-dual-forward.json
+++ b/.instar/instar-dev-decisions/2026-06-08T22-34-03-702Z-feedback-parity-phase3-dual-forward.json
@@ -1,0 +1,15 @@
+{
+  "ts": "2026-06-08T22:34:03.702Z",
+  "slug": "feedback-parity-phase3-dual-forward",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "new capability: new exported class / subsystem added"
+  ],
+  "belowFloor": true,
+  "files": 2,
+  "loc": 291,
+  "causalAutopsy": null,
+  "verdict": "pass"
+}

--- a/src/feedback-factory/processor/paritySubmit.ts
+++ b/src/feedback-factory/processor/paritySubmit.ts
@@ -1,0 +1,95 @@
+/**
+ * paritySubmit.ts — Phase-3 dual-forward emitter.
+ *
+ * Builds the parity-submit request payload Echo POSTs to the Portal's
+ * `POST /api/instar/feedback-factory/parity-submit` endpoint during the
+ * feedback-process migration's Phase-3 dual-forward. Echo computes cluster
+ * decisions locally (processUnprocessed → ClusterResult[]); Portal runs its own
+ * processor on the same batch and returns matched/diverged.
+ *
+ * Payload shape is LOCKED with Dawn (Portal owner), 2026-06-08:
+ *   { batchId, items: [{ feedbackId, action, clusterId, fingerprint, similarity, clusterTitle?, note? }] }
+ *
+ * Per-item `fingerprint` is INCLUDED on the wire (Dawn's call): Portal should not
+ * re-implement clusterFingerprint('type|component|normalized_title') — the canonical
+ * value is computed here (single source of truth) and Portal may re-derive to validate.
+ * For both 'merge' and 'create', the fingerprint is that of the cluster named by
+ * `clusterId` (merged cluster's fp / new cluster's fp respectively).
+ *
+ * This module is the deterministic emitter only — the HTTP POST + matched/diverged
+ * response handling is the dual-forward client (added when Portal's endpoint is live).
+ */
+
+import { clusterFingerprint } from './parity.js';
+import type { ClusterResult, Cluster } from './types.js';
+
+/** One item in the parity-submit payload (Dawn-locked wire shape). */
+export interface ParitySubmitItem {
+  feedbackId: string;
+  action: 'merge' | 'create';
+  clusterId: string;
+  /** Canonical clusterFingerprint of the cluster at `clusterId`. Computed here, not Portal-side. */
+  fingerprint: string;
+  similarity: number;
+  clusterTitle?: string;
+  note?: string;
+}
+
+/** The full parity-submit request body. */
+export interface ParitySubmitRequest {
+  batchId: string;
+  items: ParitySubmitItem[];
+}
+
+/** Minimal cluster identity the emitter needs to compute a fingerprint. */
+export type ClusterIdentity = Pick<Cluster, 'type' | 'title'>;
+
+export interface BuildParitySubmitOptions {
+  batchId: string;
+}
+
+/**
+ * Map a batch of local clustering decisions to the Dawn-locked parity-submit payload.
+ *
+ * @param results  the ClusterResult[] from processUnprocessed for this batch
+ * @param clusters resolver clusterId → cluster identity ({type,title}); a Map, or a
+ *                 function. Must resolve EVERY clusterId referenced by `results`.
+ * @param opts     { batchId }
+ * @throws if any result references a clusterId the resolver can't resolve (a missing
+ *         cluster is a real integrity error — never silently drop an item).
+ */
+export function buildParitySubmitPayload(
+  results: ClusterResult[],
+  clusters: Map<string, ClusterIdentity> | ((clusterId: string) => ClusterIdentity | undefined),
+  opts: BuildParitySubmitOptions,
+): ParitySubmitRequest {
+  if (!opts || typeof opts.batchId !== 'string' || opts.batchId.length === 0) {
+    throw new Error('buildParitySubmitPayload: opts.batchId is required');
+  }
+  const resolve = (clusterId: string): ClusterIdentity | undefined =>
+    typeof clusters === 'function' ? clusters(clusterId) : clusters.get(clusterId);
+
+  const items: ParitySubmitItem[] = results.map((r) => {
+    const cluster = resolve(r.clusterId);
+    if (!cluster) {
+      throw new Error(
+        `buildParitySubmitPayload: no cluster identity for clusterId=${r.clusterId} ` +
+          `(feedbackId=${r.feedbackId}) — cannot compute fingerprint`,
+      );
+    }
+    const fingerprint = clusterFingerprint({ type: cluster.type ?? '', title: cluster.title });
+    const item: ParitySubmitItem = {
+      feedbackId: r.feedbackId,
+      action: r.action,
+      clusterId: r.clusterId,
+      fingerprint,
+      similarity: r.similarity,
+    };
+    // Optional fields: include only when present (omit, never null — Portal treats absent as unset).
+    if (r.clusterTitle !== undefined) item.clusterTitle = r.clusterTitle;
+    if (r.note !== undefined) item.note = r.note;
+    return item;
+  });
+
+  return { batchId: opts.batchId, items };
+}

--- a/src/feedback-factory/processor/paritySubmitClient.ts
+++ b/src/feedback-factory/processor/paritySubmitClient.ts
@@ -1,0 +1,196 @@
+/**
+ * paritySubmitClient.ts — Phase-3 dual-forward HTTP client.
+ *
+ * POSTs the emitter payload (buildParitySubmitPayload) to the Portal's
+ * `POST /api/instar/feedback-factory/parity-submit` and parses the LOCKED
+ * response shape Dawn deployed 2026-06-08:
+ *
+ *   { batchId, processed, matched, diverged, errors,
+ *     results: [{ feedbackId, action, status, clusterId?, divergenceReason?, error? }] }
+ *
+ * `status` is the per-item branch predicate (Dawn: "the status field is the branch
+ * predicate") — matched | diverged | not_found | error. The verdict is derived from
+ * results[] (authoritative per-item), keyed by feedbackId; top-level counts are
+ * surfaced for reporting.
+ *
+ * FAIL-CLOSED (no-silent-degradation standard): a non-2xx response, non-JSON body,
+ * or a body that does not match the locked shape THROWS — the dual-forward
+ * orchestration must never silently treat a failed/garbled submit as "matched/done".
+ * Auth: Bearer <INSTAR_ECHO_READ_TOKEN> (Portal also accepts X-Internal-Key).
+ */
+
+import type { ParitySubmitRequest } from './paritySubmit.js';
+
+export const DEFAULT_PARITY_SUBMIT_ENDPOINT =
+  'https://dawn.bot-me.ai/api/instar/feedback-factory/parity-submit';
+
+/** Per-item outcome status (Dawn-locked). */
+export type ParityItemStatus = 'matched' | 'diverged' | 'not_found' | 'error';
+
+const VALID_STATUSES: ReadonlySet<string> = new Set<ParityItemStatus>([
+  'matched',
+  'diverged',
+  'not_found',
+  'error',
+]);
+
+/** One result row (Dawn-locked). */
+export interface ParitySubmitResultItem {
+  feedbackId: string;
+  action: 'merge' | 'create';
+  status: ParityItemStatus;
+  clusterId?: string;
+  /** Present when status='diverged': "Fingerprint mismatch — Echo: …, Portal: …". */
+  divergenceReason?: string;
+  /** Present when status='error': the unexpected-failure message. */
+  error?: string;
+}
+
+/** The full parity-submit response body (Dawn-locked). */
+export interface ParitySubmitResponse {
+  batchId: string;
+  processed: number;
+  matched: number;
+  diverged: number;
+  errors: number;
+  results: ParitySubmitResultItem[];
+}
+
+/** Derived verdict — branch on this, keyed by feedbackId. */
+export interface ParitySubmitVerdict {
+  response: ParitySubmitResponse;
+  /** True iff EVERY result is status='matched' (the clean done-state). */
+  allMatched: boolean;
+  /** Items needing attention: status 'diverged' or 'not_found' (carry divergenceReason). */
+  diverged: ParitySubmitResultItem[];
+  /** Items that hit an unexpected Portal-side failure (status='error'). */
+  errored: ParitySubmitResultItem[];
+  /** Every result keyed by feedbackId for O(1) lookup. */
+  byFeedbackId: Map<string, ParitySubmitResultItem>;
+}
+
+export interface SubmitParityOptions {
+  /** INSTAR_ECHO_READ_TOKEN — sent as `Authorization: Bearer <token>`. Required. */
+  token: string;
+  /** Override the endpoint (default = the Portal production path). */
+  endpoint?: string;
+  /** Inject a fetch implementation (for tests / non-global-fetch runtimes). */
+  fetchImpl?: typeof fetch;
+  /** Abort the request after this many ms (default 30s). */
+  timeoutMs?: number;
+}
+
+/** Thrown on any fail-closed condition (HTTP error, non-JSON, shape drift). */
+export class ParitySubmitError extends Error {
+  constructor(
+    message: string,
+    readonly kind: 'http' | 'network' | 'parse' | 'shape',
+    readonly detail?: unknown,
+  ) {
+    super(message);
+    this.name = 'ParitySubmitError';
+  }
+}
+
+function assert(cond: unknown, kind: ParitySubmitError['kind'], message: string, detail?: unknown): asserts cond {
+  if (!cond) throw new ParitySubmitError(message, kind, detail);
+}
+
+/** Validate a parsed body against the locked shape; throws ParitySubmitError('shape') on drift. */
+export function parseParitySubmitResponse(data: unknown): ParitySubmitResponse {
+  assert(data && typeof data === 'object', 'shape', 'parity-submit: response is not an object', data);
+  const d = data as Record<string, unknown>;
+  assert(typeof d.batchId === 'string', 'shape', 'parity-submit: missing/invalid batchId');
+  for (const k of ['processed', 'matched', 'diverged', 'errors'] as const) {
+    assert(typeof d[k] === 'number', 'shape', `parity-submit: missing/invalid count "${k}"`);
+  }
+  assert(Array.isArray(d.results), 'shape', 'parity-submit: results is not an array');
+  const results: ParitySubmitResultItem[] = (d.results as unknown[]).map((r, i) => {
+    assert(r && typeof r === 'object', 'shape', `parity-submit: results[${i}] is not an object`);
+    const row = r as Record<string, unknown>;
+    assert(typeof row.feedbackId === 'string', 'shape', `parity-submit: results[${i}].feedbackId missing`);
+    assert(row.action === 'merge' || row.action === 'create', 'shape', `parity-submit: results[${i}].action invalid (${String(row.action)})`);
+    assert(typeof row.status === 'string' && VALID_STATUSES.has(row.status), 'shape', `parity-submit: results[${i}].status unrecognized (${String(row.status)}) — contract drift`);
+    const item: ParitySubmitResultItem = {
+      feedbackId: row.feedbackId as string,
+      action: row.action as 'merge' | 'create',
+      status: row.status as ParityItemStatus,
+    };
+    if (typeof row.clusterId === 'string') item.clusterId = row.clusterId;
+    if (typeof row.divergenceReason === 'string') item.divergenceReason = row.divergenceReason;
+    if (typeof row.error === 'string') item.error = row.error;
+    return item;
+  });
+  return {
+    batchId: d.batchId as string,
+    processed: d.processed as number,
+    matched: d.matched as number,
+    diverged: d.diverged as number,
+    errors: d.errors as number,
+    results,
+  };
+}
+
+/** Build the derived verdict from a validated response (per-item status is authoritative). */
+export function verdictFromResponse(response: ParitySubmitResponse): ParitySubmitVerdict {
+  const byFeedbackId = new Map<string, ParitySubmitResultItem>();
+  const diverged: ParitySubmitResultItem[] = [];
+  const errored: ParitySubmitResultItem[] = [];
+  for (const r of response.results) {
+    byFeedbackId.set(r.feedbackId, r);
+    if (r.status === 'diverged' || r.status === 'not_found') diverged.push(r);
+    else if (r.status === 'error') errored.push(r);
+  }
+  const allMatched =
+    response.results.length > 0 && response.results.every((r) => r.status === 'matched');
+  return { response, allMatched, diverged, errored, byFeedbackId };
+}
+
+/**
+ * POST a parity-submit batch and return the derived verdict.
+ *
+ * @throws ParitySubmitError — fail-closed on HTTP error / network failure / non-JSON /
+ *         shape drift. The caller decides retry/escalate; a failed submit is NEVER
+ *         silently treated as success.
+ */
+export async function submitParityBatch(
+  payload: ParitySubmitRequest,
+  opts: SubmitParityOptions,
+): Promise<ParitySubmitVerdict> {
+  assert(opts && typeof opts.token === 'string' && opts.token.length > 0, 'http', 'submitParityBatch: opts.token (INSTAR_ECHO_READ_TOKEN) is required');
+  assert(payload && typeof payload.batchId === 'string' && payload.batchId.length > 0, 'shape', 'submitParityBatch: payload.batchId is required');
+  const endpoint = opts.endpoint ?? DEFAULT_PARITY_SUBMIT_ENDPOINT;
+  const f = opts.fetchImpl ?? (globalThis.fetch as typeof fetch | undefined);
+  assert(typeof f === 'function', 'network', 'submitParityBatch: no fetch implementation available');
+  const timeoutMs = opts.timeoutMs ?? 30_000;
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  let res: Response;
+  try {
+    res = await f(endpoint, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${opts.token}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(payload),
+      signal: controller.signal,
+    });
+  } catch (err) {
+    throw new ParitySubmitError(`parity-submit network error: ${(err as Error).message}`, 'network', err);
+  } finally {
+    clearTimeout(timer);
+  }
+
+  assert(res.ok, 'http', `parity-submit returned HTTP ${res.status}`, res.status);
+
+  let data: unknown;
+  try {
+    data = await res.json();
+  } catch (err) {
+    throw new ParitySubmitError(`parity-submit: response was not valid JSON: ${(err as Error).message}`, 'parse', err);
+  }
+
+  return verdictFromResponse(parseParitySubmitResponse(data));
+}

--- a/tests/unit/feedback-factory/parity-submit-client.test.ts
+++ b/tests/unit/feedback-factory/parity-submit-client.test.ts
@@ -1,0 +1,165 @@
+/**
+ * Unit tests (Tier 1) — Phase-3 dual-forward client (submitParityBatch + helpers).
+ *
+ * Covers both sides of every decision boundary against Dawn's LOCKED response shape:
+ *   - all-matched batch → allMatched=true, no diverged/errored
+ *   - diverged item carries divergenceReason; not_found counts as diverged
+ *   - error item → errored[]; mixed batch partitions correctly
+ *   - verdict keyed by feedbackId
+ *   - FAIL-CLOSED: non-2xx HTTP, non-JSON body, shape drift (unknown status / missing
+ *     fields / results-not-array), network throw, missing token — each THROWS
+ *     ParitySubmitError (never silently treated as success)
+ *   - request: correct endpoint, Bearer auth header, JSON body = the emitter payload
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  submitParityBatch,
+  parseParitySubmitResponse,
+  verdictFromResponse,
+  ParitySubmitError,
+  DEFAULT_PARITY_SUBMIT_ENDPOINT,
+  type ParitySubmitResponse,
+} from '../../../src/feedback-factory/processor/paritySubmitClient.js';
+import type { ParitySubmitRequest } from '../../../src/feedback-factory/processor/paritySubmit.js';
+
+const REQUEST: ParitySubmitRequest = {
+  batchId: 'batch-1',
+  items: [
+    { feedbackId: 'fb-1', action: 'merge', clusterId: 'c-1', fingerprint: 'a1b2', similarity: 0.9 },
+  ],
+};
+
+/** Build a fake fetch returning a given status + body (string or object). */
+function fakeFetch(status: number, body: unknown, opts: { notJson?: boolean } = {}): typeof fetch {
+  return (async () =>
+    ({
+      ok: status >= 200 && status < 300,
+      status,
+      json: async () => {
+        if (opts.notJson) throw new Error('Unexpected token < in JSON');
+        return body;
+      },
+    }) as unknown as Response) as unknown as typeof fetch;
+}
+
+const OK_BODY: ParitySubmitResponse = {
+  batchId: 'batch-1',
+  processed: 3,
+  matched: 2,
+  diverged: 1,
+  errors: 0,
+  results: [
+    { feedbackId: 'fb-1', action: 'merge', status: 'matched', clusterId: 'c-1' },
+    { feedbackId: 'fb-2', action: 'create', status: 'matched', clusterId: 'c-2' },
+    { feedbackId: 'fb-3', action: 'merge', status: 'diverged', clusterId: 'c-1', divergenceReason: 'Fingerprint mismatch — Echo: a1.., Portal: d4..' },
+  ],
+};
+
+describe('submitParityBatch — request shape', () => {
+  it('POSTs to the default endpoint with Bearer auth + JSON emitter payload', async () => {
+    let captured: { url?: string; init?: RequestInit } = {};
+    const fetchImpl = (async (url: string, init: RequestInit) => {
+      captured = { url, init };
+      return { ok: true, status: 200, json: async () => OK_BODY } as unknown as Response;
+    }) as unknown as typeof fetch;
+
+    await submitParityBatch(REQUEST, { token: 'tok-xyz', fetchImpl });
+
+    expect(captured.url).toBe(DEFAULT_PARITY_SUBMIT_ENDPOINT);
+    expect(captured.init?.method).toBe('POST');
+    const headers = captured.init?.headers as Record<string, string>;
+    expect(headers.Authorization).toBe('Bearer tok-xyz');
+    expect(headers['Content-Type']).toBe('application/json');
+    expect(JSON.parse(captured.init?.body as string)).toEqual(REQUEST);
+  });
+
+  it('honors a custom endpoint', async () => {
+    let url = '';
+    const fetchImpl = (async (u: string) => {
+      url = u;
+      return { ok: true, status: 200, json: async () => OK_BODY } as unknown as Response;
+    }) as unknown as typeof fetch;
+    await submitParityBatch(REQUEST, { token: 't', endpoint: 'https://staging.example/parity', fetchImpl });
+    expect(url).toBe('https://staging.example/parity');
+  });
+});
+
+describe('submitParityBatch — verdict derivation', () => {
+  it('partitions matched / diverged and keys by feedbackId', async () => {
+    const v = await submitParityBatch(REQUEST, { token: 't', fetchImpl: fakeFetch(200, OK_BODY) });
+    expect(v.allMatched).toBe(false); // one diverged
+    expect(v.diverged.map((r) => r.feedbackId)).toEqual(['fb-3']);
+    expect(v.diverged[0].divergenceReason).toContain('Fingerprint mismatch');
+    expect(v.errored).toEqual([]);
+    expect(v.byFeedbackId.get('fb-2')?.status).toBe('matched');
+    expect(v.response.processed).toBe(3);
+  });
+
+  it('allMatched=true only when every item matched', async () => {
+    const body: ParitySubmitResponse = {
+      batchId: 'b', processed: 2, matched: 2, diverged: 0, errors: 0,
+      results: [
+        { feedbackId: 'fb-1', action: 'merge', status: 'matched', clusterId: 'c-1' },
+        { feedbackId: 'fb-2', action: 'create', status: 'matched', clusterId: 'c-2' },
+      ],
+    };
+    const v = await submitParityBatch(REQUEST, { token: 't', fetchImpl: fakeFetch(200, body) });
+    expect(v.allMatched).toBe(true);
+    expect(v.diverged).toEqual([]);
+  });
+
+  it('treats not_found as diverged and error as errored', async () => {
+    const body: ParitySubmitResponse = {
+      batchId: 'b', processed: 2, matched: 0, diverged: 1, errors: 1,
+      results: [
+        { feedbackId: 'fb-nf', action: 'merge', status: 'not_found' },
+        { feedbackId: 'fb-er', action: 'create', status: 'error', error: 'boom' },
+      ],
+    };
+    const v = await submitParityBatch(REQUEST, { token: 't', fetchImpl: fakeFetch(200, body) });
+    expect(v.allMatched).toBe(false);
+    expect(v.diverged.map((r) => r.feedbackId)).toEqual(['fb-nf']);
+    expect(v.errored.map((r) => r.feedbackId)).toEqual(['fb-er']);
+    expect(v.errored[0].error).toBe('boom');
+  });
+
+  it('allMatched is false for an empty results array (nothing proven)', () => {
+    const v = verdictFromResponse({ batchId: 'b', processed: 0, matched: 0, diverged: 0, errors: 0, results: [] });
+    expect(v.allMatched).toBe(false);
+  });
+});
+
+describe('submitParityBatch — FAIL-CLOSED (never silent success)', () => {
+  it('throws on non-2xx HTTP', async () => {
+    await expect(submitParityBatch(REQUEST, { token: 't', fetchImpl: fakeFetch(500, '') })).rejects.toMatchObject({ kind: 'http' });
+    await expect(submitParityBatch(REQUEST, { token: 't', fetchImpl: fakeFetch(404, '') })).rejects.toBeInstanceOf(ParitySubmitError);
+  });
+
+  it('throws on non-JSON body', async () => {
+    await expect(submitParityBatch(REQUEST, { token: 't', fetchImpl: fakeFetch(200, null, { notJson: true }) })).rejects.toMatchObject({ kind: 'parse' });
+  });
+
+  it('throws on a network failure', async () => {
+    const fetchImpl = (async () => {
+      throw new Error('ECONNRESET');
+    }) as unknown as typeof fetch;
+    await expect(submitParityBatch(REQUEST, { token: 't', fetchImpl })).rejects.toMatchObject({ kind: 'network' });
+  });
+
+  it('throws on shape drift — unknown status value (contract drift)', async () => {
+    const drifted = { ...OK_BODY, results: [{ feedbackId: 'fb-1', action: 'merge', status: 'PARTIALLY_OK' }] };
+    await expect(submitParityBatch(REQUEST, { token: 't', fetchImpl: fakeFetch(200, drifted) })).rejects.toMatchObject({ kind: 'shape' });
+  });
+
+  it('throws on shape drift — results not an array / missing counts', () => {
+    expect(() => parseParitySubmitResponse({ batchId: 'b', processed: 0, matched: 0, diverged: 0, errors: 0, results: {} })).toThrow(/results is not an array/);
+    expect(() => parseParitySubmitResponse({ batchId: 'b', results: [] })).toThrow(/count/);
+    expect(() => parseParitySubmitResponse('nope')).toThrow(/not an object/);
+  });
+
+  it('throws when token is missing', async () => {
+    // @ts-expect-error — exercising the runtime guard
+    await expect(submitParityBatch(REQUEST, { fetchImpl: fakeFetch(200, OK_BODY) })).rejects.toBeInstanceOf(ParitySubmitError);
+  });
+});

--- a/tests/unit/feedback-factory/parity-submit.test.ts
+++ b/tests/unit/feedback-factory/parity-submit.test.ts
@@ -1,0 +1,111 @@
+/**
+ * Unit tests (Tier 1) — Phase-3 parity-submit emitter (buildParitySubmitPayload).
+ *
+ * Covers both sides of every decision boundary:
+ *   - action merge / create both map faithfully
+ *   - per-item fingerprint is the canonical clusterFingerprint (correct by construction)
+ *   - optional clusterTitle/note: included when present, OMITTED when absent
+ *   - cluster resolver accepts both a Map and a function form
+ *   - integrity: a result referencing an unresolvable clusterId THROWS (never silently dropped)
+ *   - batchId is required and passed through
+ *
+ * Expected fingerprints are computed with the real `clusterFingerprint` so the test
+ * stays valid if the fingerprint logic legitimately changes.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { clusterFingerprint } from '../../../src/feedback-factory/processor/parity.js';
+import {
+  buildParitySubmitPayload,
+  type ClusterIdentity,
+} from '../../../src/feedback-factory/processor/paritySubmit.js';
+import type { ClusterResult } from '../../../src/feedback-factory/processor/types.js';
+
+const clusters = new Map<string, ClusterIdentity>([
+  ['c-merge', { type: 'bug', title: 'telegram relay drops message' }],
+  ['c-create', { type: 'feature', title: 'add slack adapter' }],
+  ['c-notype', { title: 'cluster with no type' }], // type undefined → defaults to ''
+]);
+
+describe('buildParitySubmitPayload', () => {
+  it('maps a merge decision to the Dawn-locked item shape with canonical fingerprint', () => {
+    const results: ClusterResult[] = [
+      { feedbackId: 'fb-1', action: 'merge', clusterId: 'c-merge', similarity: 0.87, clusterTitle: 'telegram relay drops message', note: 'jaccard 0.87' },
+    ];
+    const out = buildParitySubmitPayload(results, clusters, { batchId: 'batch-1' });
+    expect(out.batchId).toBe('batch-1');
+    expect(out.items).toHaveLength(1);
+    expect(out.items[0]).toEqual({
+      feedbackId: 'fb-1',
+      action: 'merge',
+      clusterId: 'c-merge',
+      fingerprint: clusterFingerprint({ type: 'bug', title: 'telegram relay drops message' }),
+      similarity: 0.87,
+      clusterTitle: 'telegram relay drops message',
+      note: 'jaccard 0.87',
+    });
+  });
+
+  it('maps a create decision and computes the new cluster fingerprint', () => {
+    const results: ClusterResult[] = [
+      { feedbackId: 'fb-2', action: 'create', clusterId: 'c-create', similarity: 0 },
+    ];
+    const out = buildParitySubmitPayload(results, clusters, { batchId: 'batch-2' });
+    expect(out.items[0].action).toBe('create');
+    expect(out.items[0].fingerprint).toBe(clusterFingerprint({ type: 'feature', title: 'add slack adapter' }));
+    expect(out.items[0].similarity).toBe(0);
+  });
+
+  it('OMITS optional clusterTitle/note when absent (does not emit undefined/null keys)', () => {
+    const results: ClusterResult[] = [
+      { feedbackId: 'fb-3', action: 'create', clusterId: 'c-create', similarity: 0.0 },
+    ];
+    const out = buildParitySubmitPayload(results, clusters, { batchId: 'b' });
+    expect('clusterTitle' in out.items[0]).toBe(false);
+    expect('note' in out.items[0]).toBe(false);
+  });
+
+  it('defaults a missing cluster type to empty string for the fingerprint', () => {
+    const results: ClusterResult[] = [
+      { feedbackId: 'fb-4', action: 'merge', clusterId: 'c-notype', similarity: 0.5 },
+    ];
+    const out = buildParitySubmitPayload(results, clusters, { batchId: 'b' });
+    expect(out.items[0].fingerprint).toBe(clusterFingerprint({ type: '', title: 'cluster with no type' }));
+  });
+
+  it('accepts a function resolver as well as a Map', () => {
+    const results: ClusterResult[] = [
+      { feedbackId: 'fb-5', action: 'merge', clusterId: 'c-merge', similarity: 0.9 },
+    ];
+    const fnResolver = (id: string): ClusterIdentity | undefined => clusters.get(id);
+    const out = buildParitySubmitPayload(results, fnResolver, { batchId: 'b' });
+    expect(out.items[0].fingerprint).toBe(clusterFingerprint({ type: 'bug', title: 'telegram relay drops message' }));
+  });
+
+  it('preserves order and handles a multi-item batch', () => {
+    const results: ClusterResult[] = [
+      { feedbackId: 'fb-a', action: 'create', clusterId: 'c-create', similarity: 0 },
+      { feedbackId: 'fb-b', action: 'merge', clusterId: 'c-merge', similarity: 0.4 },
+    ];
+    const out = buildParitySubmitPayload(results, clusters, { batchId: 'b' });
+    expect(out.items.map((i) => i.feedbackId)).toEqual(['fb-a', 'fb-b']);
+  });
+
+  it('THROWS on an unresolvable clusterId (never silently drops an item)', () => {
+    const results: ClusterResult[] = [
+      { feedbackId: 'fb-x', action: 'merge', clusterId: 'c-missing', similarity: 0.7 },
+    ];
+    expect(() => buildParitySubmitPayload(results, clusters, { batchId: 'b' })).toThrow(/no cluster identity for clusterId=c-missing/);
+  });
+
+  it('THROWS when batchId is missing or empty', () => {
+    expect(() => buildParitySubmitPayload([], clusters, { batchId: '' })).toThrow(/batchId is required/);
+    // @ts-expect-error — exercising the runtime guard with a bad opts
+    expect(() => buildParitySubmitPayload([], clusters, {})).toThrow(/batchId is required/);
+  });
+
+  it('returns an empty items array for an empty batch', () => {
+    const out = buildParitySubmitPayload([], clusters, { batchId: 'empty' });
+    expect(out).toEqual({ batchId: 'empty', items: [] });
+  });
+});

--- a/upgrades/eli16/feedback-parity-phase3-dual-forward.md
+++ b/upgrades/eli16/feedback-parity-phase3-dual-forward.md
@@ -1,0 +1,19 @@
+# ELI16 — Feedback parity Phase-3 dual-forward (emitter + client)
+
+## The situation
+
+Feedback about Instar agents currently lives in Dawn's Portal (a Python service backed by Postgres). We're migrating that whole feedback-processing pipeline over to Instar/Echo in reversible phases. Before Instar can be trusted to OWN the processing, it has to PROVE — against the Portal's live data — that it groups feedback into the same "clusters" the Portal does and reaches the same verdicts. "Phase-3 dual-forward" is the step where Echo computes a cluster verdict and forwards it to the Portal, which independently re-checks it before applying anything. This PR adds the two client-side building blocks for that forward.
+
+## What the two pieces do
+
+**The emitter** (`buildParitySubmitPayload`) takes Echo's cluster decisions — an array of `ClusterResult` (each says "this feedback item should merge into cluster X" or "create a new cluster") — and packs them into the exact request shape the Portal's `parity-submit` endpoint expects: `{ batchId, items: [{ feedbackId, action, clusterId, fingerprint, similarity, clusterTitle?, note? }] }`. The `fingerprint` is the cluster's identity hash, computed ONE way (the canonical `clusterFingerprint({type, title})` already used everywhere else in the processor) so there is a single source of truth; the Portal re-derives it only to confirm agreement, never to override. If a cluster id can't be resolved to a real cluster, or the batch id is empty, the emitter THROWS instead of quietly emitting a malformed batch.
+
+**The client** (`submitParityBatch`) sends that payload to the Portal over HTTPS with a Bearer token, then reads the reply. The Portal answers with a per-item `status`: `matched` (fingerprints agreed, applied), `diverged` (mismatch — NOT applied, with a reason), `not_found`, or `error`. The client turns that into a tidy verdict keyed by `feedbackId`, and only reports `allMatched` when every single item matched.
+
+## The one rule that matters most
+
+If anything goes wrong on the wire — the server returns a non-200, the network drops, the body isn't valid JSON, or the reply's shape doesn't match the locked contract — the client THROWS a `ParitySubmitError`. It NEVER silently treats a broken or garbled submit as "matched / done." Silent success on a failed write is exactly how a data migration corrupts the canonical store, so we fail loudly and hand the decision (retry / escalate) back to the caller. This is the project's no-silent-degradation standard applied at the one network boundary.
+
+## Why it's safe to ship now
+
+Nothing is wired into a live pipeline yet — no production feedback traffic flows through these, and there are no database writes. They are the deterministic building blocks the later, operator-gated cutover step will call. They're covered by 21 unit tests (both sides of every decision boundary, including every fail-closed path) and were verified end-to-end against the Portal's live endpoint with an empty-batch round-trip (HTTP 200, locked shape parsed, correct verdict). The actual cutover to live dual-forward remains a separate, deliberate, operator-approved step.

--- a/upgrades/next/feedback-parity-phase3-dual-forward.md
+++ b/upgrades/next/feedback-parity-phase3-dual-forward.md
@@ -1,0 +1,24 @@
+<!-- bump: patch -->
+<!-- audience: agent-only -->
+
+## What Changed
+
+Phase-3 dual-forward of the feedback-process migration (Dawn Portal → Echo/Instar) gains its two deterministic client-side pieces, both built to the Portal's locked parity-submit contract:
+
+- **Emitter** (`buildParitySubmitPayload`, `src/feedback-factory/processor/paritySubmit.ts`) — turns an array of `ClusterResult` + a cluster-resolver into the locked request payload `{ batchId, items: [{ feedbackId, action, clusterId, fingerprint, similarity, clusterTitle?, note? }] }`. The per-item `fingerprint` is computed echo-side via the canonical `clusterFingerprint({type, title})` (single source of truth — the Portal re-derives only to validate). Throws on an unresolvable `clusterId` or an empty `batchId` (no silent drop); optional fields are omitted when absent.
+- **Client** (`submitParityBatch` + `parseParitySubmitResponse` + `verdictFromResponse`, `src/feedback-factory/processor/paritySubmitClient.ts`) — POSTs the emitter payload to `POST /api/instar/feedback-factory/parity-submit` (Bearer `INSTAR_ECHO_READ_TOKEN`, 30s AbortController timeout) and parses the locked response `{ batchId, processed, matched, diverged, errors, results: [{ feedbackId, action, status, clusterId?, divergenceReason?, error? }] }`. `status` (`matched|diverged|not_found|error`) is the per-item branch predicate; the derived verdict is keyed by `feedbackId`, with `allMatched` true only when every result is `matched`. **Fail-closed (no-silent-degradation standard):** a non-2xx response, network error, non-JSON body, or any shape drift THROWS `ParitySubmitError` — a failed/garbled submit is never silently treated as "matched/done".
+
+## What to Tell Your User
+
+Internal migration infrastructure — nothing to configure, and no production feedback traffic flows through it yet. This is the client half of the parity dual-forward: Echo computes a feedback cluster verdict and submits it to the Portal, which re-derives the fingerprint to confirm agreement before applying. Cutover to live dual-forward remains a later, operator-gated step.
+
+## Summary of New Capabilities
+
+| Capability | How to use |
+|-----------|-----------|
+| Build the locked parity-submit payload from cluster results | `buildParitySubmitPayload(results, clusterResolver, { batchId })` |
+| Submit a parity batch + get a fail-closed verdict | `submitParityBatch(payload, { token })` → `{ allMatched, diverged, errored, byFeedbackId, response }` |
+
+## Evidence
+
+Unit tests green: emitter 9/9 (`tests/unit/feedback-factory/parity-submit.test.ts` — both sides of every boundary: merge/create, fingerprint-correct-by-construction, optional-field present/absent, Map+fn resolver, throw-on-missing-cluster, throw-on-empty-batchId) and client 12/12 (`parity-submit-client.test.ts` — request shape incl. Bearer auth + default endpoint, verdict partitioning, and every FAIL-CLOSED path: non-2xx, non-JSON, shape drift, network throw, missing token). `tsc --noEmit` clean. **Live-verified:** the real `submitParityBatch` ran end-to-end against Dawn's live prod endpoint (empty-batch round-trip) → HTTP 200, locked shape parsed with no drift-throw, verdict `allMatched=false` (correct for empty results), `batchId` echoed. Tier-1 change; side-effects review at `upgrades/side-effects/feedback-parity-phase3-dual-forward.md`. Earned from topic 12476 (feedback-process migration, Dawn-coordinated; response contract locked by Dawn 2026-06-08).

--- a/upgrades/side-effects/feedback-parity-phase3-dual-forward.md
+++ b/upgrades/side-effects/feedback-parity-phase3-dual-forward.md
@@ -1,0 +1,76 @@
+# Side-Effects Review — Feedback parity Phase-3 dual-forward (emitter + client)
+
+**Version / slug:** `feedback-parity-phase3-dual-forward`
+**Date:** `2026-06-08`
+**Author:** `echo`
+**Second-pass reviewer:** `not required`
+
+## Summary of the change
+
+Adds the two deterministic client-side pieces of the feedback-process migration's
+Phase-3 dual-forward: an **emitter** (`buildParitySubmitPayload`) that builds the
+Portal's locked parity-submit request payload from `ClusterResult[]`, and an HTTP
+**client** (`submitParityBatch` + `parseParitySubmitResponse` + `verdictFromResponse`)
+that POSTs it to `/api/instar/feedback-factory/parity-submit` and parses the locked
+response into a fail-closed verdict keyed by `feedbackId`. No call sites wire these
+into a running pipeline yet — they are the building blocks the later cutover step will
+invoke. No production feedback traffic flows through them.
+
+## Decision-point inventory
+
+1. **Emitter — `clusterId` resolves to a cluster?** Unresolvable → THROW (no silent drop).
+2. **Emitter — `batchId` non-empty?** Empty → THROW.
+3. **Client — HTTP status 2xx?** Non-2xx → THROW `ParitySubmitError('http')`.
+4. **Client — body is JSON?** Non-JSON → THROW `('parse')`.
+5. **Client — body matches the locked shape?** Drift (unknown `status`, missing
+   counts, results-not-array, bad `action`) → THROW `('shape')`.
+6. **Client — network/timeout?** fetch throws/aborts → THROW `('network')`.
+7. **Verdict — `allMatched`?** True iff `results.length > 0` AND every `status==='matched'`.
+
+## 1. Over-block
+
+**What legitimate inputs does this change reject?** The emitter throws on an
+unresolvable `clusterId` or empty `batchId` — both are genuine programmer errors that
+must surface, not silently emit a malformed/partial batch; this is intended strictness,
+not over-block. The client throws on any non-2xx / non-JSON / shape-drift / network
+condition. A `diverged`, `not_found`, or `error` *item* inside a well-formed 200 is NOT
+a throw — it is a normal verdict outcome surfaced in `diverged`/`errored`; only a
+transport/contract failure throws. So a real divergence report is never mistaken for an
+error. The 30s timeout could abort a legitimately slow Portal response — acceptable: a
+fail-closed throw is the correct outcome (caller retries/escalates), never a silent
+"done".
+
+## 2. Under-block
+
+**What does this still miss?** The client validates structural shape, not semantic
+correctness of Portal-computed verdicts — if the Portal returns a well-formed but
+wrong `status`, the client trusts it (correct: the Portal is the reference authority
+for apply/diverge). `allMatched=false` on an empty `results[]` is deliberate (an empty
+batch proves nothing). The emitter does not dedupe `feedbackId`s within a batch (caller's
+responsibility; the Portal keys results by `feedbackId`). No retry/backoff is built in —
+fail-closed surfaces the error to the caller, which owns the retry policy.
+
+## 3. Level-of-abstraction fit
+
+**Right layer?** Yes. The emitter lives beside the existing `processor/parity.ts`
+(reusing its canonical `clusterFingerprint` — no second fingerprint implementation), and
+the client is a thin, injectable (`fetchImpl`) transport wrapper over the locked contract.
+Fingerprint stays single-source-of-truth (computed once, echo-side; Portal re-derives only
+to validate). The fail-closed policy is enforced at the one ingress/egress boundary
+(`submitParityBatch`/`parseParitySubmitResponse`), not scattered across callers.
+
+## 4. Blast radius
+
+**What breaks if this is wrong?** Effectively nothing today: no call site invokes these
+yet, no traffic, no DB writes, no migration to existing agents (pure new source under
+`src/feedback-factory/processor/`, ships in dist). A bug would surface only when the later
+cutover step wires `submitParityBatch` in — and the fail-closed design means a wrong/garbled
+submit throws (caller halts) rather than silently corrupting the canonical store. Reversible
+by not invoking it / reverting the two files.
+
+## 5. Failure mode
+
+**Fail-open or fail-closed?** Fail-CLOSED by construction — every transport/contract
+anomaly throws `ParitySubmitError`; the dual-forward orchestration can never read a failed
+submit as success. Verified live: the real client ran against Dawn's prod endpoint
+(empty-batch round-trip) → 200, locked shape parsed, verdict `allMatched=false`, no throw.


### PR DESCRIPTION
## ELI16

When the feedback system moves from Dawn's Portal to Echo, we need to PROVE Echo groups feedback into the same "clusters" the Portal does before trusting it. This PR adds the two client-side pieces that let Echo tell the Portal "here's how I'd group these" and get back a clean yes/no per item. The **emitter** packs Echo's cluster decisions into the exact message shape the Portal expects (including a fingerprint Echo computes itself, which the Portal re-checks). The **client** sends that message and reads the reply, sorting every item into matched / diverged / errored. The most important rule: if anything goes wrong on the wire — the server errors, the reply isn't valid JSON, or its shape doesn't match the locked contract — the client THROWS instead of pretending the submit succeeded. A silent "looks fine" on a broken submit is exactly how migrations corrupt data, so we fail loudly and let the caller decide to retry. Nothing is wired into live traffic yet — these are the building blocks the later, operator-gated cutover step will use.

## What

Phase-3 dual-forward of the feedback-process migration (topic 12476), two deterministic pieces built to the Portal's **locked** parity-submit contract:

- **Emitter** `buildParitySubmitPayload(results, clusterResolver, { batchId })` (`src/feedback-factory/processor/paritySubmit.ts`) → `{ batchId, items: [{ feedbackId, action, clusterId, fingerprint, similarity, clusterTitle?, note? }] }`. Per-item `fingerprint` = canonical `clusterFingerprint({type, title})` (single source of truth, computed echo-side; Portal re-derives only to validate). Throws on unresolvable `clusterId` / empty `batchId`; omits absent optional fields.
- **Client** `submitParityBatch` + `parseParitySubmitResponse` + `verdictFromResponse` (`paritySubmitClient.ts`) → POSTs to `/api/instar/feedback-factory/parity-submit` (Bearer `INSTAR_ECHO_READ_TOKEN`, 30s timeout), parses the locked response, derives a verdict keyed by `feedbackId`. `status` (`matched|diverged|not_found|error`) is the branch predicate; `allMatched` iff `results.length>0 && every matched`.

## Why

The migration spec requires Echo's parity verdicts to flow to the Portal for confirmation before any cutover. This is the client half. **Fail-closed** (no-silent-degradation standard): non-2xx / network / non-JSON / shape-drift all THROW `ParitySubmitError` — a failed submit is never silently treated as success.

## Test

- Emitter 9/9 + client 12/12 unit tests (both sides of every boundary; all fail-closed paths). `tsc --noEmit` clean. Lint + path-scoped e2e gate green (pre-push).
- **Live-verified:** the real `submitParityBatch` ran end-to-end against Dawn's live prod endpoint (empty-batch round-trip) → HTTP 200, locked shape parsed with no drift-throw, verdict `allMatched=false` (correct for empty results), `batchId` echoed.

## Notes

No call site wires these into a running pipeline yet (no traffic, no DB writes). Response contract locked by Dawn 2026-06-08. Tier-1 ceremony artifacts: `upgrades/next/feedback-parity-phase3-dual-forward.md` + `upgrades/side-effects/feedback-parity-phase3-dual-forward.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
