### PR TITLE
fix(autonomous): write per-topic state file at skill setup — close concurrent-session boot race

### DIFF
--- a/.claude/skills/autonomous/SKILL.md
+++ b/.claude/skills/autonomous/SKILL.md
@@ -75,7 +75,20 @@ if json.dumps(hooks) != before:
 
 **2b. Write the state file DIRECTLY** (do NOT shell out to bash — the session ID env var is only available inside Claude Code):
 
-Use the **Write tool** to create `.instar/autonomous-state.local.md` with this content:
+Use the **Write tool** to create the **per-topic** state file `.instar/autonomous/<topicId>.local.md`,
+where `<topicId>` is the `report_topic` value you set below (the Telegram topic id you already know
+in-context). For example, if `report_topic` is `19437`, write `.instar/autonomous/19437.local.md`.
+
+**WHY PER-TOPIC (setup-race hardening):** the stop hook reads this per-topic file **directly**
+(`.instar/autonomous/<topicId>.local.md`) — it is the canonical state path, keyed on topic so
+multiple topics run concurrent autonomous jobs without collision. Writing the per-topic path here
+closes a boot-window race: two autonomous sessions starting near-simultaneously must NOT both write
+the single legacy file `.instar/autonomous-state.local.md` (the hook still migrates that legacy file
+for in-flight older jobs, but new jobs write the per-topic file from the start so there is nothing to
+collide on). If you somehow have no `report_topic`, fall back to `.instar/autonomous-state.local.md`
+(one-at-a-time, back-compat only).
+
+Write this content:
 
 ```markdown
 ---
@@ -197,17 +210,20 @@ The stop hook detects the promise and allows exit.
 The user can always stop autonomous mode:
 
 1. **Via messaging**: Send "stop everything" or "emergency stop" — the MessageSentinel intercepts
-2. **Via file**: `touch .instar/autonomous-emergency-stop` — the stop hook checks for this
-3. **Via cancel**: `/cancel-autonomous` — removes the state file
+2. **Via file**: `touch .instar/autonomous-emergency-stop` — the stop hook checks for this (this flag is
+   global, so it halts EVERY topic's autonomous job at once)
+3. **Via cancel**: `/cancel-autonomous` — removes this topic's state file
 
 The stop hook checks for emergency stop on EVERY iteration. User safety is never compromised.
 
 ### /cancel-autonomous
 
-To manually cancel:
+To manually cancel THIS topic's job, remove its per-topic state file (substitute the topic id):
 ```bash
-rm -f .instar/autonomous-state.local.md
+rm -f .instar/autonomous/<topicId>.local.md
 ```
+(Older one-at-a-time jobs may still live at the legacy `.instar/autonomous-state.local.md` — remove
+that instead if the per-topic file is absent.)
 
 ---
 
@@ -259,7 +275,9 @@ Feeling tired (as an AI) and deferring. **You don't get tired. The hook knows th
 
 The stop hook is at `.claude/skills/autonomous/hooks/autonomous-stop-hook.sh`.
 
-It reads state from `.instar/autonomous-state.local.md` and:
+It reads state from the per-topic file `.instar/autonomous/<topicId>.local.md` (resolving the topic
+from the tmux session), and migrates the legacy single file `.instar/autonomous-state.local.md` into
+the per-topic path on first run for any in-flight older job. It then:
 - Blocks exit if tasks are incomplete
 - Feeds the task list + goal back as the next prompt
 - Increments the iteration counter

--- a/.instar/instar-dev-decisions/2026-06-09T06-01-15-305Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-06-09T06-01-15-305Z-unknown.json
@@ -1,0 +1,16 @@
+{
+  "ts": "2026-06-09T06:01:15.305Z",
+  "slug": "unknown",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "irreversibility: src/core/PostUpdateMigrator.ts touches PostUpdateMigrator",
+    "migration / fleet-rollout surface: src/core/PostUpdateMigrator.ts touches PostUpdateMigrator (fleet migration machinery)"
+  ],
+  "belowFloor": true,
+  "files": 1,
+  "loc": 32,
+  "causalAutopsy": null,
+  "verdict": "pass"
+}

--- a/docs/specs/autonomous-setup-race-hardening.eli16.md
+++ b/docs/specs/autonomous-setup-race-hardening.eli16.md
@@ -1,0 +1,26 @@
+# ELI16 — Autonomous setup-race hardening
+
+## What this is
+
+Instar agents can run "autonomous sessions" — long-running jobs that work on a goal for hours and keep themselves going. Each such job keeps a little notes file (its "state file") describing what it's working on, how long it has left, and whether it's still active. A background hook reads that notes file every time the session tries to stop, and uses it to decide whether to keep the job going.
+
+## What already exists
+
+The system was **already** smart about running several autonomous jobs at once: the hook gives every job its **own** notes file, named after the chat topic it belongs to — `.instar/autonomous/<topicId>.local.md`. So two jobs running side by side normally never touch the same file. The hook also knows how to migrate an older single shared file into the per-topic layout when it sees one.
+
+## What's new (the one small gap this closes)
+
+There was a tiny timing gap. Right when a job **first started up**, the setup instructions told it to write into a single **shared** notes file (`.instar/autonomous-state.local.md`) first, and only a moment later did the hook move that into the job's own per-topic file. If two jobs happened to start in the same split-second, they could both scribble into that shared file and overwrite each other in that brief window — one job's notes could be lost before the move happened.
+
+This change makes each job write **straight into its own topic-named notes file from the very first moment**, so there is no shared file to collide on at all. The part that reads the notes (the hook) didn't need to change — it already knew how to find each job's own file, and it keeps its safety net that migrates any old shared file left behind by an in-flight older job.
+
+## The safeguards, in plain terms
+
+- The hook (the thing that actually makes decisions about keeping a job alive) is **completely untouched** — only the skill's setup instruction changed.
+- Agents that are **already installed** pick up this fix the next time they update (a migration re-deploys the corrected instructions), not just brand-new agents.
+- The migration is safe to run over and over (it does nothing if the fix is already present) and never touches a skill someone has customized.
+- If this turned out wrong, backing it out is a simple revert — nothing gets corrupted, because the hook's old-file migration safety net means a mixed fleet keeps working either way.
+
+## What you actually need to decide
+
+Whether to merge a small, internal robustness fix so concurrent autonomous jobs can never collide on a shared state file at startup. There is no user-facing behavior change.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "instar",
-  "version": "1.3.437",
+  "version": "1.3.438",
   "description": "Coherence infrastructure for self-evolving AI agents — on the Claude Code or Codex subscription you already have.",
   "type": "module",
   "main": "dist/index.js",

--- a/src/core/PostUpdateMigrator.ts
+++ b/src/core/PostUpdateMigrator.ts
@@ -1748,20 +1748,30 @@ export class PostUpdateMigrator {
       'autonomous-state.local.md',
       'skills/autonomous/scripts/setup-autonomous.sh (codex native /goal auto-wire)',
     );
-    // SKILL.md Step 2a registration-path fix: the prior bundled SKILL.md registered the
-    // stop hook at `.instar/hooks/instar/autonomous-stop-hook.sh` (a path where the hook is
-    // never deployed → silent Stop-hook failure → the autonomous loop never re-engaged and
-    // the session went idle). The fixed SKILL.md registers the deployed skill path and
-    // self-heals any stale entry. Marker `Stop hook registered (correct skill path)` is
-    // present ONLY in the fixed version (the old printed plain `Stop hook registered`), so
-    // bumping to it re-deploys the corrected prompt to existing agents; customized SKILL.md
-    // files (missing the stock `ALL_TASKS_COMPLETE` fingerprint) are left untouched. Pairs
-    // with the settings.json wrong-path repair in ensureAutonomousStopHook().
+    // SKILL.md fixes (cumulative — the upgrade re-deploys the whole bundled SKILL.md, so a
+    // single marker bump carries every fix to date):
+    //   (1) Step 2a registration-path fix: the prior bundled SKILL.md registered the stop hook
+    //       at `.instar/hooks/instar/autonomous-stop-hook.sh` (a path where the hook is never
+    //       deployed → silent Stop-hook failure → the autonomous loop never re-engaged). The
+    //       fixed SKILL.md registers the deployed skill path and self-heals any stale entry.
+    //   (2) Step 2b per-topic state-file write (setup-race hardening): the prior SKILL.md told
+    //       the agent to Write the single legacy file `.instar/autonomous-state.local.md`. The
+    //       hook migrates that on first run, but in the boot window before migration two
+    //       sessions starting near-simultaneously can both write the legacy file and collide.
+    //       The fixed SKILL.md instructs writing the per-topic file the hook reads directly,
+    //       `.instar/autonomous/<topicId>.local.md` (keyed on report_topic), so new jobs never
+    //       touch the shared legacy path. The hook's reading logic is unchanged (per-topic
+    //       preferred, legacy fallback + migrate for in-flight older jobs).
+    // Marker bumped `Stop hook registered (correct skill path)` → `PER-TOPIC (setup-race hardening)`:
+    // the new marker is present ONLY in fix (2)'s version, so an agent that already received
+    // fix (1) (it carries the old marker but not the new one) still gets re-deployed to fix (2).
+    // Customized SKILL.md files (missing the stock `ALL_TASKS_COMPLETE` fingerprint) are left
+    // untouched (idempotent — a second run finds the new marker and no-ops).
     upgrade(
       '.claude/skills/autonomous/SKILL.md',
-      'Stop hook registered (correct skill path)',
+      'PER-TOPIC (setup-race hardening)',
       'ALL_TASKS_COMPLETE',
-      'skills/autonomous/SKILL.md (autonomous stop-hook registration path fix — loop re-engages)',
+      'skills/autonomous/SKILL.md (per-topic state-file write at setup — closes boot-window race)',
     );
   }
 

--- a/tests/unit/PostUpdateMigrator-autonomousHookPath.test.ts
+++ b/tests/unit/PostUpdateMigrator-autonomousHookPath.test.ts
@@ -164,6 +164,21 @@ describe('autonomous SKILL.md — Step 2a registers the deployed skill path', ()
   });
 });
 
+describe('autonomous SKILL.md — Step 2b writes the per-topic state file (setup-race hardening)', () => {
+  it('the bundled SKILL.md instructs writing the per-topic file the hook reads directly', () => {
+    const skillMd = path.resolve(__dirname, '../../.claude/skills/autonomous/SKILL.md');
+    const content = fs.readFileSync(skillMd, 'utf8');
+    // Step 2b must instruct the per-topic write (closes the boot-window race) and carry the marker.
+    expect(content).toContain('PER-TOPIC (setup-race hardening)');
+    expect(content).toContain('.instar/autonomous/<topicId>.local.md');
+    // The legacy single file may still be MENTIONED (back-compat fallback + the hook's own
+    // migration of in-flight older jobs), but it must NOT be the primary Write instruction:
+    // the Write-tool step must name the per-topic path.
+    const writeStep = content.slice(content.indexOf('Use the **Write tool**'));
+    expect(writeStep.slice(0, 200)).toContain('.instar/autonomous/<topicId>.local.md');
+  });
+});
+
 describe('PostUpdateMigrator — migrateAutonomousStopHookTopicKeyed re-deploys fixed SKILL.md', () => {
   let projectDir: string;
   let skillMd: string;
@@ -198,7 +213,49 @@ describe('PostUpdateMigrator — migrateAutonomousStopHookTopicKeyed re-deploys 
 
     const after = fs.readFileSync(skillMd, 'utf8');
     expect(after).toContain('Stop hook registered (correct skill path)');
+    // The re-deployed bundled SKILL.md also carries the per-topic setup-race fix.
+    expect(after).toContain('PER-TOPIC (setup-race hardening)');
+    expect(after).toContain('.instar/autonomous/<topicId>.local.md');
     expect(result.upgraded.some(u => u.includes('SKILL.md'))).toBe(true);
+  });
+
+  it('re-deploys a fix-1 SKILL.md (has the old marker, lacks the per-topic marker) → per-topic fix lands', () => {
+    // An agent that already received the Step-2a registration-path fix carries the old marker
+    // `Stop hook registered (correct skill path)` but NOT the new per-topic marker. The bumped
+    // marker must still re-deploy so the setup-race (per-topic write) fix reaches it.
+    fs.writeFileSync(skillMd, [
+      '# Autonomous Mode',
+      'Completion promise: "ALL_TASKS_COMPLETE"',
+      "    print('Stop hook registered (correct skill path)')",
+      'Use the Write tool to create `.instar/autonomous-state.local.md`',
+    ].join('\n'));
+    const before = fs.readFileSync(skillMd, 'utf8');
+    expect(before).toContain('Stop hook registered (correct skill path)');
+    expect(before).not.toContain('PER-TOPIC (setup-race hardening)');
+
+    const result = runTopicKeyed(newMigrator(projectDir));
+
+    const after = fs.readFileSync(skillMd, 'utf8');
+    expect(after).toContain('PER-TOPIC (setup-race hardening)');           // per-topic fix present
+    expect(after).toContain('.instar/autonomous/<topicId>.local.md');     // per-topic write instruction
+    expect(result.upgraded.some(u => u.includes('SKILL.md'))).toBe(true);
+  });
+
+  it('is idempotent — a second run over the per-topic SKILL.md makes no change and reports nothing', () => {
+    // Seed a stock fix-1 copy, run once to upgrade, then run again.
+    fs.writeFileSync(skillMd, [
+      '# Autonomous Mode',
+      'Completion promise: "ALL_TASKS_COMPLETE"',
+      'Use the Write tool to create `.instar/autonomous-state.local.md`',
+    ].join('\n'));
+    runTopicKeyed(newMigrator(projectDir)); // first run upgrades to the bundled (per-topic) version
+    const afterFirst = fs.readFileSync(skillMd, 'utf8');
+    expect(afterFirst).toContain('PER-TOPIC (setup-race hardening)');
+
+    const second = runTopicKeyed(newMigrator(projectDir));
+    expect(fs.readFileSync(skillMd, 'utf8')).toBe(afterFirst); // unchanged second time
+    expect(second.upgraded.some(u => u.includes('SKILL.md'))).toBe(false);
+    expect(second.errors).toEqual([]);
   });
 
   it('leaves a customized SKILL.md (missing the stock fingerprint) untouched', () => {

--- a/upgrades/next/autonomous-setup-race-hardening.md
+++ b/upgrades/next/autonomous-setup-race-hardening.md
@@ -1,0 +1,18 @@
+## What Changed
+
+fix(autonomous): close the autonomous-skill **setup-race** so concurrent autonomous sessions never collide on a shared state file. The stop-hook already resolves a per-topic state file (`.instar/autonomous/<topicId>.local.md`) and migrates the legacy single file — but the *skill's* setup step still wrote the legacy single file `.instar/autonomous-state.local.md`, so two sessions booting near-simultaneously could race on it in the window before the hook migrates. The skill now writes the per-topic file **directly** at setup, skipping the shared path entirely. The hook's reading logic is unchanged (per-topic preferred, legacy fallback + migrate retained for in-flight older jobs).
+
+## What to Tell Your User
+
+Nothing user-facing. This is an internal robustness fix so multiple autonomous sessions run cleanly side by side without clobbering each other's state.
+
+## Summary of New Capabilities
+
+- `.claude/skills/autonomous/SKILL.md` — setup step writes the per-topic state file `.instar/autonomous/<topicId>.local.md` directly (keyed on `report_topic`); cancel + hook-config sections updated to match.
+- `PostUpdateMigrator` — the existing autonomous-SKILL.md migration marker is bumped so existing agents re-deploy the corrected skill on update (idempotent; customized skills left untouched).
+- The autonomous stop-hook is **unchanged** (it already reads per-topic + migrates legacy).
+
+## Evidence
+
+- Migration suite + autonomous sweep green: `PostUpdateMigrator-autonomousHookPath` (12), plus `PostUpdateMigrator-autonomousStopHook` / `autonomous-skill-deployment` / `migration-parity` (47 total), and `autonomous-state-location` / `autonomous-multi-session` / `autonomous-stop-hook-topic-keyed` (41). `tsc --noEmit` clean.
+- New tests assert: a fix-1 SKILL.md (old marker, no per-topic marker) re-deploys to per-topic; second run is a no-op (idempotent); the bundled SKILL.md instructs writing the per-topic file the hook reads.

--- a/upgrades/side-effects/autonomous-setup-race-hardening.md
+++ b/upgrades/side-effects/autonomous-setup-race-hardening.md
@@ -1,0 +1,56 @@
+# Side-Effects Review — Autonomous setup-race hardening (per-topic state write)
+
+**Version / slug:** `autonomous-setup-race-hardening`
+**Date:** 2026-06-08
+**Author:** Instar Agent (echo)
+**Second-pass reviewer:** not required (see Phase 5 note below)
+
+## Summary of the change
+
+The autonomous stop-hook already resolves a **per-topic** state file (`.instar/autonomous/<topicId>.local.md`) and migrates the legacy single file into it. The only gap was that the autonomous **skill's** setup step still instructed writing the legacy single file `.instar/autonomous-state.local.md` — so two autonomous sessions booting near-simultaneously could both write that shared file and clobber each other in the window before the hook migrates. This change makes the skill write the per-topic file **directly** at setup. Files: `.claude/skills/autonomous/SKILL.md` (the setup write step + cancel/hook-config references), `src/core/PostUpdateMigrator.ts` (bumps the existing autonomous-SKILL.md upgrade marker so existing agents re-deploy the corrected skill), `tests/unit/PostUpdateMigrator-autonomousHookPath.test.ts` (+3 tests). The stop-hook's reading/decision logic is **untouched**.
+
+## Decision-point inventory
+
+- `autonomous-stop-hook.sh` state resolution (per-topic read + legacy migrate) — **pass-through** — unchanged; it already prefers the per-topic file and keeps the legacy fallback for in-flight older jobs.
+- `PostUpdateMigrator` autonomous-SKILL.md upgrade — **modify (marker bump only)** — re-deploys the corrected bundled SKILL.md to existing agents; same idempotent `upgrade()` mechanism, no new migration machinery.
+- Skill setup state-file write — **modify** — writes the per-topic path instead of the legacy single path. This is instruction content, not runtime decision logic.
+
+---
+
+## 1. Over-block
+
+**What legitimate inputs does this change reject that it shouldn't?** No block/allow surface — over-block not applicable. The change relocates where a state file is written; it gates nothing.
+
+## 2. Under-block
+
+**What failure modes does this still miss?** None introduced. The one residual it does NOT address: a session with no resolvable `report_topic` still falls back to the legacy single file (documented in the skill) — that path is rare and the hook's legacy migrate still handles it. This is intentional back-compat, not a missed failure.
+
+## 3. Level-of-abstraction fit
+
+Correct layer. The race was created by the **skill** writing the shared path; the fix is in the skill (write per-topic directly). The hook already owned per-topic resolution at the right layer and is left untouched — we feed it the file it already prefers rather than adding a parallel mechanism.
+
+## 4. Signal vs authority compliance
+
+Compliant. No blocking authority is added or changed. The decision-making authority (the stop-hook, which blocks/allows session exit) is untouched. This change only changes which file the skill writes and re-deploys that instruction — it adds no brittle check with blocking power. (`docs/signal-vs-authority.md`.)
+
+## 5. Interactions
+
+- Does NOT shadow or get shadowed by the hook (the hook reads the same per-topic file the skill now writes — they agree).
+- The migration marker bump rides the existing `upgrade('.claude/skills/autonomous/SKILL.md', …)` call; it does not double-fire (one marker carries cumulative SKILL.md fixes because `upgrade()` re-deploys the whole bundled file). Idempotent: a second run finds the new marker and no-ops.
+- `setup-autonomous.sh` already wrote the per-topic path when `REPORT_TOPIC` is set — unchanged, no race with the skill's in-context write.
+
+## 6. External surfaces
+
+No user-facing surface. Internal robustness only. Existing agents receive the corrected skill on their next update via the migration; new agents get it via `init`. No new config, route, or API. No dependence on timing beyond the boot window it closes.
+
+## 7. Rollback cost
+
+Low. Back-out is a revert of 3 files + a marker re-bump (or simply shipping a follow-up that restores the prior marker). No data migration, no agent-state repair: the hook's legacy fallback + migrate path means even a mixed fleet (some agents on the old skill writing legacy, some on the new writing per-topic) keeps working — the hook migrates legacy regardless. Worst case is the narrow boot-race returns until re-fixed; nothing is corrupted.
+
+## Phase 1 — Principle check
+
+The change involves **no new decision point**. It relocates a state-file write and re-deploys that instruction; the gate/authority that makes the session-continuation decision (the stop-hook) is unchanged. Signal-vs-authority therefore applies only as "no new authority added."
+
+## Phase 5 — Second-pass note
+
+The Phase-5 trigger list includes session-lifecycle changes. This change is session-lifecycle **adjacent** (it affects where the autonomous loop's state file lives) but changes **no decision logic** — the stop-hook that drives spawn/continue/exit is byte-for-byte unchanged (verified against the diff). Declared **not-required**: there is no new or modified block/allow decision for a reviewer to audit. The substantive review above stands on the verified diff.


### PR DESCRIPTION
## What & why

Closes a **setup-race** in the autonomous skill so concurrent autonomous sessions never collide on a shared state file.

The autonomous stop-hook **already** resolves a per-topic state file (`.instar/autonomous/<topicId>.local.md`) and migrates the legacy single file into it. But the *skill's* setup step still instructed writing the legacy single file `.instar/autonomous-state.local.md`. The hook migrates that on first run, but in the boot window before migration, two sessions starting near-simultaneously could both write the legacy file and clobber each other. The skill now writes the **per-topic file directly** at setup, skipping the shared path.

(Justin approved this as decision **(a)** in topic 22367, 2026-06-08; decision (b) — reducing concurrency — was declined.)

## Changes (3 files)
- `.claude/skills/autonomous/SKILL.md` — setup step writes `.instar/autonomous/<topicId>.local.md` directly (keyed on `report_topic`); cancel + hook-config sections updated. Legacy path retained only as a fallback mention.
- `src/core/PostUpdateMigrator.ts` — bumps the existing autonomous-SKILL.md upgrade marker (`Stop hook registered (correct skill path)` → `PER-TOPIC (setup-race hardening)`) so existing agents re-deploy the corrected skill. `upgrade()` re-deploys the whole bundled file, so one marker carries cumulative SKILL.md fixes.
- `tests/unit/PostUpdateMigrator-autonomousHookPath.test.ts` — +3 tests.

## Hook unchanged
The stop-hook's per-topic resolution + legacy fallback + migrate is **untouched** — the legacy migration safety net for in-flight older jobs stays intact. `setup-autonomous.sh` already wrote per-topic when `REPORT_TOPIC` is set, so it's unchanged too.

## Migration / blast-radius (fleet-touching)
- **Idempotent**: `upgrade()` no-ops if the deployed file already has the new marker; leaves customized skills (missing the stock `ALL_TASKS_COMPLETE` fingerprint) untouched; re-deploys agents that have the prior fix's marker but not the new one.
- Reaches existing agents via the already-tested `migrateAutonomousStopHookTopicKeyed()` in the `run()` sequence (`installBuiltinSkills` is install-if-missing, so this dedicated migration is the only on-disk update path).

## Tests
- `PostUpdateMigrator-autonomousHookPath` (12) + `PostUpdateMigrator-autonomousStopHook` / `autonomous-skill-deployment` / `migration-parity` (47 total) green; `autonomous-state-location` / `autonomous-multi-session` / `autonomous-stop-hook-topic-keyed` (41) green. `tsc --noEmit` clean.

## ELI16
Each long-running autonomous job keeps a little notes file describing what it's working on. The system was already smart enough to give every job its OWN notes file, named after the chat topic it belongs to — so two jobs running at once normally don't step on each other. But there was one tiny gap: right when a job first starts up, it briefly wrote into a single shared notes file, and only a moment later did the system move that into its own topic file. If two jobs happened to start at the exact same second, they could both scribble in that shared file and overwrite each other in that split-second window. This change makes each job write straight into its own topic-named notes file from the very first moment, so there's no shared file to collide on at all. The part that reads the notes didn't need to change — it already knew how to find each job's own file. And a migration makes sure agents that are already installed pick up this fix the next time they update, not just brand-new ones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)