### PR TITLE
feat(subscription-pool): pin sessions to a pool account — makes auto-swap functional

### DIFF
--- a/.instar/instar-dev-decisions/2026-06-09T06-07-50-850Z-subscription-pin-sessions.json
+++ b/.instar/instar-dev-decisions/2026-06-09T06-07-50-850Z-subscription-pin-sessions.json
@@ -1,0 +1,16 @@
+{
+  "ts": "2026-06-09T06:07:50.850Z",
+  "slug": "subscription-pin-sessions",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 3,
+  "loc": 66,
+  "causalAutopsy": {
+    "origin": "latent",
+    "notes": "Auto-swap shipped wired to `session.subscriptionAccountId` (it does `if (!accountId) return;`), but no spawn path ever WROTE that field — sessions launched on the default config, not via the pool. The gap sat latent: auto-swap looked enabled but was a structural no-op, surfacing only when a session actually hit a quota wall (2026-06-08 incident). This change writes the tag + launches on a pool account, the missing prerequisite."
+  },
+  "verdict": "pass"
+}

--- a/docs/specs/_drafts/subscription-pin-sessions.eli16.md
+++ b/docs/specs/_drafts/subscription-pin-sessions.eli16.md
@@ -1,0 +1,28 @@
+# ELI16 — Make load-balancing actually work (pin sessions to a pool account)
+
+## The plain-English version
+
+You have five Claude accounts in a pool, and you turned on "auto-swap" — the idea that when one account hits its weekly limit, the agent moves its work onto a fresh account instead of getting stuck. But it didn't work: a session hit its limit and just died. This change is the missing piece that makes auto-swap actually do its job.
+
+## Why auto-swap was secretly broken
+
+Auto-swap works like this: when a session gets rate-limited, it asks "which account is this session running on?" so it can move it to a *different* one. The problem: it asked, and the answer was always "I don't know." Why? Because the agent's sessions don't actually launch on a *chosen* pool account — they launch on the computer's default Claude login, with no record of which account that even is. So every session was an untagged orphan, and auto-swap, finding no account to move *from*, silently gave up. We verified it: zero of sixty running sessions carried an account tag.
+
+So "auto-swap is on" was a comforting label on a switch wired to nothing.
+
+## What this change does
+
+Two things, both at the moment a session is created:
+
+1. **Launch it on a chosen account.** Instead of the murky default login, a new session launches on a specific pool account picked by the scheduler — the one with the most room left and the soonest reset (so we drain quota before it's wasted). It does this by setting the account's "config home" for that session.
+2. **Tag it.** The session records which account it's on. Now when it hits a wall, auto-swap can read that tag and move it to a fresh account.
+
+Together, that's the link that was missing. With it, the chain finally connects: pick an account → run on it → tag it → swap it when it walls.
+
+## Why it's safe
+
+This touches the most sensitive code in the system — how every session is started — so it's built to be a complete no-op by default. There's a switch (`pinSessionsToPool`) that's OFF unless you turn it on. While it's off, sessions launch exactly as they always have: no account override, no tag, byte-for-byte the old behavior. Only when you flip it on does the new path kick in, and even then it only ever runs for Claude sessions (not Codex/Gemini), and if no account is available it quietly falls back to the default. So the risk surface is gated behind a switch you control.
+
+## What you'll do with it
+
+Once this ships, you turn the switch on and set the agent's account to one with headroom (e.g. SageMind - Adriana). From then on the agent runs on a real pool account, and auto-swap actually moves it when that account hits its weekly cap — which is the whole point of the load-balancing standard.

--- a/src/commands/server.ts
+++ b/src/commands/server.ts
@@ -10048,6 +10048,21 @@ export async function startServer(options: StartOptions): Promise<void> {
           });
         });
       }
+
+      // Subscription-pool session PINNING (Subscription & Auth Standard): when
+      // enabled, new claude-code spawns launch on the scheduler-picked optimal
+      // account (reset-date / headroom score) and carry its id. This is the
+      // prerequisite that makes auto-swap functional — without a session→account
+      // tag, the swap engine has nothing to move. Default off → spawns use the
+      // default config exactly as before (the resolver stays unwired).
+      if (config.subscriptionPool?.pinSessionsToPool) {
+        const { selectAccount } = await import('../core/QuotaAwareScheduler.js');
+        sessionManager.setSpawnAccountResolver(() => {
+          const acct = selectAccount(subscriptionPool.list(), { nowMs: Date.now() });
+          return acct ? { configHome: acct.configHome, accountId: acct.id } : null;
+        });
+        console.log(pc.green('  Subscription-pool session pinning enabled'));
+      }
     }
 
     // ── SessionReaper (SESSION-REAPER-SPEC) ──────────────────────────────

--- a/src/core/SessionManager.ts
+++ b/src/core/SessionManager.ts
@@ -258,6 +258,17 @@ export class SessionManager extends EventEmitter {
    *  `effectiveBoundIdleKillMinutes` since "idle at prompt" is the healthy waiting state. */
   private topicBindingChecker?: (tmuxSession: string) => string | number | null;
 
+  /**
+   * Subscription-pool pinning resolver (Subscription & Auth Standard). When set,
+   * a new claude-code spawn launches under the returned account's config home
+   * (`CLAUDE_CONFIG_DIR`) and the session is tagged with `subscriptionAccountId`
+   * — which is the linkage auto-swap needs to move a session when its account
+   * hits a quota wall. Null/unset → spawns use the default config exactly as
+   * before (the gate: this stays unset unless `subscriptionPool.pinSessionsToPool`
+   * is enabled, so it is a strict no-op by default). Returns null per-call when
+   * no eligible account exists. */
+  private spawnAccountResolver?: () => { configHome: string; accountId: string } | null;
+
   /** Prompt Gate InputDetector — monitors terminal output for interactive prompts */
   private promptDetector?: InputDetector;
 
@@ -519,6 +530,17 @@ rm()  { "${shimRunner}" rm  "$@"; }
    */
   setTopicBindingChecker(checker: (tmuxSession: string) => string | number | null): void {
     this.topicBindingChecker = checker;
+  }
+
+  /**
+   * Wire the subscription-pool pinning resolver (Subscription & Auth Standard).
+   * Called from server startup ONLY when `subscriptionPool.pinSessionsToPool` is
+   * enabled, so leaving it unwired keeps spawns on the default config (no-op).
+   * The resolver picks the optimal pool account (the scheduler's reset-date /
+   * headroom score) at spawn time and returns its configHome + id, or null.
+   */
+  setSpawnAccountResolver(resolver: () => { configHome: string; accountId: string } | null): void {
+    this.spawnAccountResolver = resolver;
   }
 
   /**
@@ -1625,6 +1647,16 @@ rm()  { "${shimRunner}" rm  "$@"; }
     // for Codex, the env-allowlist enforcement happens inside Codex CLI's
     // process tree via Spec 12 Rule 1a, not via tmux -e flags (which
     // would be unscrubbed parent inheritance).
+    // Subscription-pool pinning (Subscription & Auth Standard): launch this
+    // claude-code session under a chosen pool account's config home and tag it,
+    // so auto-swap can move it when that account walls. No-op unless the resolver
+    // is wired (pinSessionsToPool enabled) and returns an account.
+    const pinnedAccount = headlessFramework === 'claude-code'
+      ? (this.spawnAccountResolver?.() ?? null)
+      : null;
+    if (pinnedAccount) {
+      headlessSpec.envOverrides.CLAUDE_CONFIG_DIR = pinnedAccount.configHome;
+    }
     const frameworkEnvFlags: string[] = [];
     for (const [k, v] of Object.entries(headlessSpec.envOverrides)) {
       frameworkEnvFlags.push('-e', `${k}=${v}`);
@@ -1699,6 +1731,9 @@ rm()  { "${shimRunner}" rm  "$@"; }
       framework: headlessFramework,
       prompt: options.prompt,
       maxDurationMinutes: options.maxDurationMinutes,
+      // Subscription-pool pinning: tag the session with the account it launched
+      // under, so auto-swap can move it when that account hits a quota wall.
+      ...(pinnedAccount ? { subscriptionAccountId: pinnedAccount.accountId } : {}),
       // Positive-lane observability (june15-headless-spawn-reroute O4): always
       // populated now, so the soak's "zero headless under force" criterion is
       // machine-checkable from GET /sessions. completionMode stays 'exit' (the
@@ -1877,6 +1912,13 @@ rm()  { "${shimRunner}" rm  "$@"; }
     const inheritedPath = process.env.PATH ?? '';
     const shimmedPath = shimDir ? `${shimDir}:${inheritedPath}` : inheritedPath;
 
+    // Subscription-pool pinning (Subscription & Auth Standard): this lane is
+    // always claude-code, so launch under the chosen pool account's config home
+    // and tag the session. No-op unless the resolver is wired + returns an account.
+    const pinnedAccount = this.spawnAccountResolver?.() ?? null;
+    if (pinnedAccount) {
+      launchSpec.envOverrides.CLAUDE_CONFIG_DIR = pinnedAccount.configHome;
+    }
     const frameworkEnvFlags: string[] = [];
     for (const [k, v] of Object.entries(launchSpec.envOverrides)) {
       frameworkEnvFlags.push('-e', `${k}=${v}`);
@@ -1943,6 +1985,9 @@ rm()  { "${shimRunner}" rm  "$@"; }
       framework: 'claude-code',
       prompt: options.prompt,
       maxDurationMinutes: options.maxDurationMinutes,
+      // Subscription-pool pinning: tag with the account this launched under, so
+      // auto-swap can move it when that account hits a quota wall.
+      ...(pinnedAccount ? { subscriptionAccountId: pinnedAccount.accountId } : {}),
       // The reroute's completion contract (spec O1 + O4):
       launchLane: 'rerouted-interactive',
       completionMode: 'pattern',

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -2548,6 +2548,12 @@ export interface InstarConfig {
      *  pool-managed session auto-swaps it to another account. Opt-in (auto-
      *  swapping live sessions is real authority — tier-2). */
     autoSwapOnRateLimit?: boolean;
+    /** DARK by default: when true, new claude-code session spawns launch under
+     *  the optimal pool account's config home (scheduler-picked) and are tagged
+     *  with `subscriptionAccountId`. This is the prerequisite that makes
+     *  auto-swap functional (a session must carry which account it's on for the
+     *  swap engine to move it). Unset → spawns use the default config (no-op). */
+    pinSessionsToPool?: boolean;
     /** P2.1 enrollment wizard knobs (all optional). */
     enrollment?: {
       /** Per-framework login command override (defaults: claude-code →

--- a/tests/integration/subscription-pin-sessions.test.ts
+++ b/tests/integration/subscription-pin-sessions.test.ts
@@ -1,0 +1,105 @@
+/**
+ * Integration test — the full session-pinning chain (Subscription & Auth
+ * Standard): a real SubscriptionPool + the real scheduler `selectAccount` wired
+ * as the spawn-account resolver EXACTLY as server.ts does, driving a real
+ * SessionManager.spawnSession. Proves the wiring server.ts performs picks the
+ * optimal account and that the spawned session launches under it + is tagged —
+ * the linkage auto-swap needs. tmux is mocked (no real sessions).
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+
+const mockTmuxSessions = new Set<string>();
+vi.mock('node:child_process', () => ({
+  execFileSync: vi.fn().mockImplementation((_cmd: string, args?: string[]) => {
+    if (!args) return '';
+    if (args[0] === 'has-session') {
+      const target = args[2]?.replace(/^=/, '');
+      if (!mockTmuxSessions.has(target)) throw new Error(`session not found: ${target}`);
+      return '';
+    }
+    if (args[0] === 'new-session') {
+      const sIdx = args.indexOf('-s');
+      if (sIdx >= 0 && args[sIdx + 1]) mockTmuxSessions.add(args[sIdx + 1]);
+      return '';
+    }
+    return '';
+  }),
+  execFile: vi.fn().mockImplementation((_c: string, _a: string[], _o: unknown, cb?: (e: Error | null, r: { stdout: string }) => void) => {
+    const done = typeof _o === 'function' ? (_o as typeof cb) : cb;
+    if (done) done(null, { stdout: '' });
+  }),
+}));
+
+import { execFileSync } from 'node:child_process';
+import { SessionManager } from '../../src/core/SessionManager.js';
+import { StateManager } from '../../src/core/StateManager.js';
+import { SubscriptionPool } from '../../src/core/SubscriptionPool.js';
+import { selectAccount } from '../../src/core/QuotaAwareScheduler.js';
+import type { SessionManagerConfig } from '../../src/core/types.js';
+
+describe('subscription-pool session pinning (integration)', () => {
+  let dir: string;
+  let state: StateManager;
+  let pool: SubscriptionPool;
+  let manager: SessionManager;
+
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'pin-int-'));
+    fs.mkdirSync(path.join(dir, 'state'), { recursive: true });
+    state = new StateManager(path.join(dir, 'state'));
+    pool = new SubscriptionPool({ stateDir: dir });
+    const config: SessionManagerConfig = {
+      tmuxPath: '/usr/bin/tmux', claudePath: '/usr/local/bin/claude',
+      projectDir: dir, maxSessions: 5, protectedSessions: [],
+      completionPatterns: ['done'], framework: 'claude-code',
+    };
+    manager = new SessionManager(config, state);
+    mockTmuxSessions.clear();
+  });
+  afterEach(() => {
+    manager.stopMonitoring();
+    SafeFsExecutor.safeRmSync(dir, { recursive: true, force: true, operation: 'tests/integration/subscription-pin-sessions.test.ts:cleanup' });
+  });
+
+  // Wire the resolver exactly as src/commands/server.ts does under pinSessionsToPool.
+  const wireResolver = () =>
+    manager.setSpawnAccountResolver(() => {
+      const a = selectAccount(pool.list(), { nowMs: Date.parse('2026-06-10T00:00:00Z') });
+      return a ? { configHome: a.configHome, accountId: a.id } : null;
+    });
+
+  const newSessionArgs = (): string[] => {
+    const call = vi.mocked(execFileSync).mock.calls.find((c) => Array.isArray(c[1]) && (c[1] as string[])[0] === 'new-session');
+    return (call?.[1] as string[]) ?? [];
+  };
+
+  it('pins a spawn to the scheduler-picked optimal account, end to end', async () => {
+    // Two accounts; the one with MORE unused headroom + a sooner reset scores higher.
+    pool.add({ id: 'gmail-justin', nickname: 'Justin', provider: 'anthropic', framework: 'claude-code', configHome: '/h/.claude-echo-justin-gmail', email: 'headley.justin@gmail.com' });
+    pool.add({ id: 'sagemind-adriana', nickname: 'SageMind - Adriana', provider: 'anthropic', framework: 'claude-code', configHome: '/h/.claude-echo-6', email: 'adriana@sagemindai.io' });
+    // gmail nearly exhausted + far reset; adriana fresh + soon reset → adriana wins.
+    pool.update('gmail-justin', { lastQuota: { sevenDay: { utilizationPct: 95, resetsAt: '2026-06-20T00:00:00Z' } } });
+    pool.update('sagemind-adriana', { lastQuota: { sevenDay: { utilizationPct: 0, resetsAt: '2026-06-11T00:00:00Z' } } });
+
+    wireResolver();
+    vi.mocked(execFileSync).mockClear();
+    const session = await manager.spawnSession({ name: 'pin-int', prompt: 'p' });
+
+    expect(session.subscriptionAccountId).toBe('sagemind-adriana');
+    expect(newSessionArgs()).toContain('CLAUDE_CONFIG_DIR=/h/.claude-echo-6');
+    expect(state.getSession(session.id)!.subscriptionAccountId).toBe('sagemind-adriana');
+  });
+
+  it('does not pin when the pool is empty (resolver returns null → default config)', async () => {
+    wireResolver(); // wired, but pool has no accounts → selectAccount returns null
+    vi.mocked(execFileSync).mockClear();
+    const session = await manager.spawnSession({ name: 'empty-int', prompt: 'p' });
+    expect(session.subscriptionAccountId).toBeUndefined();
+    expect(newSessionArgs().some((a) => typeof a === 'string' && a.startsWith('CLAUDE_CONFIG_DIR='))).toBe(false);
+  });
+});

--- a/tests/unit/session-manager-behavioral.test.ts
+++ b/tests/unit/session-manager-behavioral.test.ts
@@ -89,6 +89,7 @@ vi.mock('node:child_process', () => {
 });
 
 // Import after mock
+import { execFileSync } from 'node:child_process';
 import { SessionManager } from '../../src/core/SessionManager.js';
 import { StateManager } from '../../src/core/StateManager.js';
 import type { SessionManagerConfig } from '../../src/core/types.js';
@@ -144,6 +145,40 @@ describe('SessionManager behavioral tests', () => {
       const saved = state.getSession(session.id);
       expect(saved).not.toBeNull();
       expect(saved!.name).toBe('test-job');
+    });
+
+    // ── Subscription-pool pinning (Subscription & Auth Standard) ──
+    const newSessionArgs = (): string[] => {
+      const call = vi.mocked(execFileSync).mock.calls.find(
+        (c) => Array.isArray(c[1]) && (c[1] as string[])[0] === 'new-session',
+      );
+      return (call?.[1] as string[]) ?? [];
+    };
+
+    it('pins a claude-code spawn to the resolved pool account (CLAUDE_CONFIG_DIR + subscriptionAccountId)', async () => {
+      manager.setSpawnAccountResolver(() => ({ configHome: '/h/.claude-echo-6', accountId: 'sagemind-adriana' }));
+      vi.mocked(execFileSync).mockClear(); // isolate THIS spawn's tmux calls
+      const session = await manager.spawnSession({ name: 'pin-job', prompt: 'p' });
+      expect(session.subscriptionAccountId).toBe('sagemind-adriana');
+      // the launched tmux session carries the account's config home
+      expect(newSessionArgs()).toContain('CLAUDE_CONFIG_DIR=/h/.claude-echo-6');
+      // and it's persisted, so auto-swap can read it
+      expect(state.getSession(session.id)!.subscriptionAccountId).toBe('sagemind-adriana');
+    });
+
+    it('does NOT pin when no resolver is set (default config, no tag)', async () => {
+      vi.mocked(execFileSync).mockClear();
+      const session = await manager.spawnSession({ name: 'nopin-job', prompt: 'p' });
+      expect(session.subscriptionAccountId).toBeUndefined();
+      expect(newSessionArgs().some((a) => typeof a === 'string' && a.startsWith('CLAUDE_CONFIG_DIR='))).toBe(false);
+    });
+
+    it('does NOT pin when the resolver returns null (no eligible account)', async () => {
+      manager.setSpawnAccountResolver(() => null);
+      vi.mocked(execFileSync).mockClear();
+      const session = await manager.spawnSession({ name: 'nullpin-job', prompt: 'p' });
+      expect(session.subscriptionAccountId).toBeUndefined();
+      expect(newSessionArgs().some((a) => typeof a === 'string' && a.startsWith('CLAUDE_CONFIG_DIR='))).toBe(false);
     });
 
     it('throws when max sessions reached', async () => {

--- a/upgrades/next/subscription-pin-sessions.md
+++ b/upgrades/next/subscription-pin-sessions.md
@@ -1,0 +1,22 @@
+<!-- bump: minor -->
+
+## What Changed
+
+Adds subscription-pool **session pinning** — the prerequisite that makes auto-swap functional. New `subscriptionPool.pinSessionsToPool` config (default off): when enabled, a new claude-code session launches under the scheduler-picked optimal pool account's config home (`CLAUDE_CONFIG_DIR`, chosen by reset-date/headroom score) and the session record is tagged with `subscriptionAccountId`. `SessionManager` gains an injectable `spawnAccountResolver` (set by the server only when the flag is on); both initial-spawn lanes (headless + rerouted-interactive) consume it, guarded to claude-code. This fixes a structural no-op: auto-swap only moves sessions carrying `subscriptionAccountId`, but no spawn ever wrote that field, so a session that hit its account's quota wall just died instead of swapping. Gated to a strict no-op by default (resolver unset → byte-identical behavior); the account-swap restart path already tagged swapped sessions and is untouched.
+
+## What to Tell Your User
+
+Load-balancing across your accounts now actually works. Before, "auto-swap" was on but did nothing — your sessions ran on a default login with no record of which account they were using, so when one hit its weekly limit the work just stopped instead of moving to a fresh account. Now I can launch the agent on a specific account from your pool and tag it, so when that account walls I move the work to one with headroom. It's behind a switch that's off by default, and when you turn it on I'll point the agent at an account with room to spare.
+
+## Summary of New Capabilities
+
+| Capability | How to Use |
+|-----------|-----------|
+| Pin sessions to a pool account (enables auto-swap) | set `subscriptionPool.pinSessionsToPool: true` (then restart) |
+| Session carries its account | `subscriptionAccountId` on GET /sessions records |
+
+## Evidence
+
+Reproduction (live, 2026-06-08): a session hit "You've hit your weekly limit" on the Justin (headley.justin@gmail.com) account and died — no swap. Root cause verified directly: auto-swap's handler does `if (!session.subscriptionAccountId) return;`, and a live query showed **0 of 60 running sessions carried `subscriptionAccountId`** (the field was never written — sessions spawned on the default config, not via the pool). So auto-swap was a no-op.
+
+After the fix: the unit suite (`session-manager-behavioral.test.ts`) asserts a pinned spawn's real tmux `new-session` argv contains `CLAUDE_CONFIG_DIR=<account home>` and the session record + persisted state carry `subscriptionAccountId` — and that NEITHER appears when the resolver is unset or returns null. The integration test (`subscription-pin-sessions.test.ts`) drives the full production chain (real SubscriptionPool + the real `selectAccount` resolver wired as server.ts does) and confirms the spawn pins to the higher-headroom/sooner-reset account. tsc + repo lint clean; 73-test regression sweep green.

--- a/upgrades/side-effects/subscription-pin-sessions.md
+++ b/upgrades/side-effects/subscription-pin-sessions.md
@@ -1,0 +1,25 @@
+# Side-effects review — subscription-pool session pinning (makes auto-swap functional)
+
+## What changed
+- `src/core/SessionManager.ts`: new optional `spawnAccountResolver` dep + `setSpawnAccountResolver()` setter (mirrors `setTopicBindingChecker`). In BOTH initial-spawn lanes (headless `spawnSession` + the rerouted-interactive spawn), when the resolver returns an account AND the launching framework is claude-code, set `spec.envOverrides.CLAUDE_CONFIG_DIR = account.configHome` and tag the session record `subscriptionAccountId: account.id`.
+- `src/core/types.ts`: new `subscriptionPool.pinSessionsToPool?: boolean` (default off).
+- `src/commands/server.ts`: when `pinSessionsToPool` is enabled, wire `setSpawnAccountResolver` to `selectAccount(pool.list(), {nowMs})` (the scheduler's reset-date/headroom score).
+
+## Why (the bug it fixes)
+Auto-swap (`server.ts` `rate-limit:escalated` handler) does `if (!session.subscriptionAccountId) return;` — it only moves sessions tagged with an account. But NO spawn ever wrote that field (0/60 live), because sessions launch on the default config, not via the pool. So auto-swap was a structural no-op and a session that hit its account's quota wall just died (live incident 2026-06-08). This change writes the tag (and launches on a real pool account), which is the missing prerequisite that makes auto-swap function.
+
+## Blast radius — CRITICAL PATH, gated to a strict no-op by default
+- This touches session SPAWNING (the most critical path). It is gated three ways so the default is byte-identical: (1) `pinSessionsToPool` defaults off → server never calls the setter → `spawnAccountResolver` stays unset; (2) with the resolver unset, both lanes take the `pinnedAccount = null` branch → no `CLAUDE_CONFIG_DIR` added, no `subscriptionAccountId` set — exactly today's behavior; (3) the claude-code guard means a codex/gemini spawn is never given a Claude config home.
+- When ENABLED: claude-code spawns launch under the scheduler-picked account's config home. The config homes come from the pool (real enrolled accounts), so the spawn authenticates correctly. If `selectAccount` finds no eligible account, the resolver returns null → falls back to the default config (no breakage).
+- The account-swap restart method (`SessionManager` ~line 3057) ALREADY set `subscriptionAccountId` + configHome for swaps — untouched; this only adds the same tagging to INITIAL spawns.
+
+## Framework generality
+- Pinning is claude-code-specific by design (CLAUDE_CONFIG_DIR is a Claude env var; the headless lane guards on `headlessFramework === 'claude-code'`, the interactive reroute lane is always claude-code). Codex/Gemini spawns are unaffected — they never receive a config-home override.
+
+## Migration parity
+- No agent-installed files change. New config field (`pinSessionsToPool`) is optional, default off → existing agents unaffected until explicitly enabled. No `PostUpdateMigrator` entry needed.
+
+## Tests
+- Unit (`session-manager-behavioral.test.ts`): spawnSession pins (CLAUDE_CONFIG_DIR flag + subscriptionAccountId, persisted) when the resolver is set; does NOT pin when unset or when the resolver returns null. Inspects the real tmux `new-session` argv via the execFileSync mock.
+- Integration (`subscription-pin-sessions.test.ts`): the full production chain — real SubscriptionPool + the real `selectAccount` resolver wired exactly as server.ts → spawnSession pins to the optimal account (the higher-headroom/sooner-reset one wins); empty pool → no pin.
+- No HTTP route, so the standard's Tier-3 "route alive (200 not 503)" form does not apply; the integration test exercises the production wiring shape (the server.ts resolver closure) instead.


### PR DESCRIPTION
## What this fixes

Auto-swap was a structural no-op. Its handler does `if (!session.subscriptionAccountId) return;` — it only moves sessions tagged with an account. But **no spawn ever wrote that field** (verified live: 0 of 60 running sessions carried `subscriptionAccountId`), because sessions launch on the default Claude config, not via the pool. So when a session hit its account's weekly cap, auto-swap found no account to move *from* and silently bailed — the session just died (live incident 2026-06-08). Turning auto-swap "on" looked ready but was wired to nothing.

## The fix

New `subscriptionPool.pinSessionsToPool` config (**default off**). When enabled:
- **`SessionManager`** gains an injectable `spawnAccountResolver` (+ `setSpawnAccountResolver()`, mirroring `setTopicBindingChecker`). Both initial-spawn lanes (headless `spawnSession` + the rerouted-interactive spawn) consume it: when it returns an account AND the framework is claude-code, the spawn launches under `CLAUDE_CONFIG_DIR=<account.configHome>` and the session record is tagged `subscriptionAccountId`.
- **`server.ts`** wires the resolver to `selectAccount(pool.list(), {nowMs})` — the scheduler's reset-date/headroom score (use-before-reset).

That's the missing link: pick an account → run on it → tag it → auto-swap can now move it when it walls. The account-swap restart path already tagged swapped sessions; this adds the same to *initial* spawns.

## Safety (critical path, gated to a strict no-op)

This touches session spawning — the most critical path — so it's gated three ways to byte-identical default behavior: (1) `pinSessionsToPool` off by default → server never sets the resolver; (2) resolver unset → both lanes take the `null` branch (no env override, no tag) = today's behavior exactly; (3) claude-code-guarded → Codex/Gemini spawns never get a Claude config home. Resolver returning null (no eligible account) falls back to the default config.

## Tests (unit + integration, green; lint + tsc clean)

- Unit (`session-manager-behavioral.test.ts`): asserts a pinned spawn's real tmux `new-session` argv contains `CLAUDE_CONFIG_DIR=<home>` and the record + persisted state carry `subscriptionAccountId`; and that NEITHER appears when the resolver is unset or returns null.
- Integration (`subscription-pin-sessions.test.ts`): the full production chain (real SubscriptionPool + the real `selectAccount` resolver wired as server.ts) → spawn pins to the higher-headroom/sooner-reset account; empty pool → no pin.
- No HTTP route → the Tier-3 "route alive" form doesn't apply; the integration test exercises the production wiring shape.

## ELI16 — Make load-balancing actually work (pin sessions to a pool account)

You turned on "auto-swap" so that when one Claude account hits its weekly limit, the agent moves its work to a fresh account. But it didn't work — a session hit its limit and just died. The reason: auto-swap moves a session by asking "which account is this on?", and the answer was always "unknown," because sessions launched on the computer's default login with no record of which pool account that was (zero of sixty sessions had a tag). So the switch was wired to nothing. This change makes a new session launch on a *chosen* pool account (the one with the most room and soonest reset) and *tag itself* with that account — so auto-swap can finally read the tag and move it when the account walls. It's behind an off-by-default switch; while off, sessions launch exactly as before. Once on, you point the agent at an account with headroom and load-balancing works end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
