### PR TITLE
docs(readme): surface EXO 3.0 alignment + link to the proof page

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 </p>
 
 <p align="center">
-  <a href="https://www.npmjs.com/package/instar">npm</a> · <a href="https://github.com/JKHeadley/instar">GitHub</a> · <a href="https://instar.sh">instar.sh</a> · <a href="https://instar.sh/introduction/">Docs</a>
+  <a href="https://www.npmjs.com/package/instar">npm</a> · <a href="https://github.com/JKHeadley/instar">GitHub</a> · <a href="https://instar.sh">instar.sh</a> · <a href="https://instar.sh/introduction/">Docs</a> · <a href="https://instar.sh/exo3">EXO&nbsp;3.0</a>
 </p>
 
 ---
@@ -115,6 +115,14 @@ An agent that forgets what you discussed yesterday, doesn't recognize someone it
 | **Growth** | Evolves its capabilities and understanding over time | Evolution system: proposals, learnings, gap tracking, follow-through |
 
 > **Deep dive:** [The Coherence Problem](https://instar.sh/concepts/coherence/) · [Values & Identity](https://instar.sh/concepts/values/) · [Coherence Is Safety](https://instar.sh/concepts/safety/)
+
+## EXO 3.0 — governed by your organization's intent
+
+Instar independently converged on Salim Ismail's **EXO 3.0 / "The Organizational Singularity"** framework: the idea that an organization's purpose should be encoded as *machine-readable* intent — "in code, not culture" — that actually **governs** its agents rather than just inspiring them. Instar was built around coherence before the framework existed, and the overlap turned out to be close to the line.
+
+We didn't just claim it works. We ran controlled experiments — same model, same requests, with the organization's intent switched off as the control — to show the intent itself is what changes the agent's behavior. The engine stays **neutral**: it enforces whatever intent a deploying organization gives it, never Instar's own values. Two case studies enforce two very different fictional companies' values equally well, neither of them ours.
+
+> **See the controlled proof → [instar.sh/exo3](https://instar.sh/exo3)** — two governed-vs-ungoverned case studies, with full transcripts.
 
 ## Features
 


### PR DESCRIPTION
## What

Surfaces the EXO 3.0 alignment in the README so anyone landing on the repo — including from the EXO 3.0 outreach — immediately sees it, instead of a generic README.

- New **"EXO 3.0 — governed by your organization's intent"** section (after "Why Coherence Is the Foundation", before Features): a short, understated description of how Instar independently converged on EXO 3.0's machine-readable-intent governance, the neutral-substrate point (it enforces *your* intent, not Instar's), and a link to the controlled proof at instar.sh/exo3.
- Adds an **EXO 3.0** link to the header nav row.

Docs-only change. Written understated (no hype) so it reads as substance, and it's genuinely useful for any visitor, not just the outreach context.

## ELI16

If Salim Ismail (the author of the EXO 3.0 framework) or his team clicks through to the GitHub repo — which is exactly what the outreach is nudging them to do — the first thing they'd see is the README. Right now that README says nothing about EXO 3.0, so the most relevant proof would be invisible to the one audience most likely to look for it. This change fixes that: it adds a short, honest section near the top explaining that Instar arrived at the same core ideas as EXO 3.0 on its own, that we proved it with a controlled experiment rather than just asserting it, and that the engine is neutral (it enforces whatever values a company gives it, not ours). It links straight to the proof page. It's deliberately written plainly, not as a sales pitch, because for a technical, framework-literate reader, understatement and a link to real evidence land harder than hype.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
