### PR TITLE
feat(coordination): user→agent authority grants in the Coordination Mandate

### DIFF
--- a/.instar/instar-dev-decisions/2026-06-09T08-41-34-088Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-06-09T08-41-34-088Z-unknown.json
@@ -1,0 +1,16 @@
+{
+  "ts": "2026-06-09T08:41:34.088Z",
+  "slug": "unknown",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "new capability: new route (router.<verb>() added",
+    "new capability: new exported class / subsystem added"
+  ],
+  "belowFloor": true,
+  "files": 7,
+  "loc": 305,
+  "causalAutopsy": null,
+  "verdict": "pass"
+}

--- a/docs/specs/MANDATE-USER-GRANTS.eli16.md
+++ b/docs/specs/MANDATE-USER-GRANTS.eli16.md
@@ -1,0 +1,25 @@
+# ELI16 — Coordination Mandate user→agent grants
+
+## What this is, in one breath
+
+The agent already has a tamper-proof "permission slip" system (the Coordination Mandate — a signed, audited document the operator issues). This change lets one of those slips also say "this specific Slack person is allowed to do this specific high-risk action" — signed in, so nobody can fake it.
+
+## What already existed
+
+A Coordination Mandate is a document the operator mints (behind their dashboard PIN) that says "these two agents may do these things until this date." It's HMAC-signed, so it can't be forged or widened by an agent, and every decision against it is written to a tamper-evident audit log. Separately, the Slack permission gate already had a slot — "is there an active grant letting this user do this floor action?" — but no real, signed thing filling that slot.
+
+## What's new
+
+1. **Grants live inside the signed mandate.** A grant says: *this Slack user* may do *this floor action* (e.g. a production deploy), until *this date*, authorized by *this operator*. Because the grant is folded into the bytes the mandate's signature covers, you can't bolt a grant onto a mandate without re-signing it — and only the PIN-gated path can re-sign. A faked grant fails verification.
+2. **The gate reads those signed grants.** When the (dark) Slack gate sees a non-owner ask for a floor action, it now checks for a valid, signed, unexpired grant for that exact person and action. No grant → refused, exactly as before.
+
+## The safeguards, in plain terms
+
+- **Backward-compatible by construction.** A mandate with no grants is signed exactly as it was before this change, so every permission slip already out there (including the ones the agent shares with Dawn) keeps verifying. This was the #1 risk and it's covered by a test that signs a no-grant mandate the *old* way and confirms it still verifies.
+- **Can't be forged.** A grant added without re-signing fails verification — proven by a "bolt on a grant without re-signing → must be rejected" test.
+- **Can't outlive its slip.** A grant's expiry is clamped so it can never last longer than the mandate that carries it; expired or revoked mandates yield no grants.
+- **Deny-by-default + audited.** No grant exists until the operator mints one on the PIN-gated route, and every grant decision (allow and deny) is written to the tamper-evident audit log.
+
+## What you actually need to decide
+
+Whether to merge the mechanism that lets your verified operator delegate a specific floor authority to a specific Slack user, signed so it can't be faked. It changes nothing until a grant is actually minted (PIN-gated), and the Slack gate that consumes it is still dark. It ships with an independent adversarial security review because it's signing/authority crypto.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "instar",
-  "version": "1.3.441",
+  "version": "1.3.442",
   "description": "Coherence infrastructure for self-evolving AI agents — on the Claude Code or Codex subscription you already have.",
   "type": "module",
   "main": "dist/index.js",

--- a/src/commands/server.ts
+++ b/src/commands/server.ts
@@ -4595,10 +4595,41 @@ export async function startServer(options: StartOptions): Promise<void> {
               RolePolicy,
               HeuristicIntentClassifier,
               HeuristicAnomalyScorer,
+              MandateBackedGrantStore,
             } = await import('../permissions/index.js');
             // Own UserManager instance for verified-principal resolution (the
             // Telegram-block userManager is out of scope here). Reads users.json.
             const slackUserManager = new UserManager(config.stateDir, config.users);
+            // ── Floor-action grants are read from the SIGNED Coordination Mandate ──
+            // A MandateStore reader over the SAME file + SAME HMAC sign/verify deps as
+            // the coordination engine in AgentServer (which is constructed later, so we
+            // can't share the instance) — a stateless reader, so a second instance over
+            // the same on-disk mandates is correct. With no stateDir, leave grants
+            // unset (deny-by-default: the gate then refuses every floor action).
+            let grantStore: import('../permissions/index.js').GrantStore | undefined;
+            if (config.stateDir) {
+              try {
+                const { MandateStore } = await import('../coordination/MandateStore.js');
+                const cryptoMod = await import('node:crypto');
+                const issuanceKey = config.authToken || 'mandate-issuance-unsigned-dev-key';
+                const mSign = (canonical: string) => cryptoMod.createHmac('sha256', issuanceKey).update(canonical).digest('hex');
+                const mVerify = (canonical: string, proof: string) => {
+                  const expected = mSign(canonical);
+                  try {
+                    return expected.length === proof.length
+                      && cryptoMod.timingSafeEqual(Buffer.from(expected), Buffer.from(proof));
+                  } catch { /* @silent-fallback-ok — a malformed proof must verify FALSE (deny-safe), never throw */ return false; }
+                };
+                const mandateStore = new MandateStore({
+                  filePath: path.join(config.stateDir, 'state', 'coordination-mandates.json'),
+                  sign: mSign,
+                  verifySig: mVerify,
+                });
+                grantStore = new MandateBackedGrantStore({ store: mandateStore });
+              } catch (ge) {
+                console.warn('[slack] mandate-backed grant store wiring skipped:', (ge as Error).message);
+              }
+            }
             const observer = new SlackPermissionObserver({
               resolver: new SlackPrincipalResolver({
                 resolveFromSlackUserId: (id: string) => slackUserManager.resolveFromSlackUserId(id),
@@ -4607,6 +4638,7 @@ export async function startServer(options: StartOptions): Promise<void> {
                 rolePolicy: new RolePolicy(),
                 classifier: new HeuristicIntentClassifier(),
                 anomalyScorer: new HeuristicAnomalyScorer(),
+                grants: grantStore,
               }),
               ledger: new PermissionDecisionLedger(config.stateDir),
               enforce: pgCfg.enforce === true,

--- a/src/coordination/MandateStore.ts
+++ b/src/coordination/MandateStore.ts
@@ -19,7 +19,7 @@
 
 import fs from 'node:fs';
 import path from 'node:path';
-import type { Authority, CoordinationMandate } from './types.js';
+import type { Authority, CoordinationMandate, UserAuthorityGrant } from './types.js';
 
 /** Deterministic, key-sorted serialization so the proof survives JSON round-trips
  *  and key reordering. */
@@ -31,13 +31,28 @@ function stableStringify(value: unknown): string {
   return '{' + keys.map((k) => JSON.stringify(k) + ':' + stableStringify(obj[k])).join(',') + '}';
 }
 
-/** Canonical bytes the authProof covers — the AUTHORED fields only (proof + revoked excluded). */
+/**
+ * Canonical bytes the authProof covers — the AUTHORED fields only (proof + revoked excluded).
+ *
+ * BACKWARD-COMPAT (non-negotiable): `grants` is appended to the byte sequence ONLY
+ * when it is present AND non-empty. A mandate with no grants (the pre-extension shape,
+ * `grants` undefined OR `[]`) therefore canonicalizes to the EXACT same bytes as before
+ * this extension existed — so every previously-signed mandate's stored `authProof`
+ * keeps verifying. When grants ARE present, they extend the canonical bytes (each grant
+ * as a field-ordered tuple), so the proof covers them and a grant cannot be forged or
+ * added without re-signing through the PIN-gated path.
+ */
 export function canonicalMandate(m: Omit<CoordinationMandate, 'authProof' | 'revoked'>): string {
-  return stableStringify([
+  const base: unknown[] = [
     m.id, m.scope, m.agents,
     m.authorities.map((a) => [a.action, a.bounds, a.requiresCondition ?? '']),
     m.author, m.createdAt, m.expiresAt,
-  ]);
+  ];
+  // Append-only-when-non-empty: no grants → identical bytes to a pre-extension mandate.
+  if (Array.isArray(m.grants) && m.grants.length > 0) {
+    base.push(m.grants.map((g) => [g.floorAction, g.grantedTo, g.authorizedBy, g.expiresAt, g.bounds ?? {}]));
+  }
+  return stableStringify(base);
 }
 
 export interface MandateStoreDeps {
@@ -60,6 +75,8 @@ export interface IssueMandateInput {
   expiresAt: string;
   id?: string;
   createdAt?: string;
+  /** Optional user→agent authority grants signed into the mandate at issuance. */
+  grants?: UserAuthorityGrant[];
 }
 
 export class MandateStore {
@@ -91,9 +108,32 @@ export class MandateStore {
   issue(input: IssueMandateInput): CoordinationMandate {
     const id = input.id ?? (this.d.genId ? this.d.genId() : `mandate-${Math.random().toString(36).slice(2, 10)}`);
     const createdAt = input.createdAt ?? this.nowIso();
+    // Defense-in-depth (second-pass hardening): grants issued WITH the mandate are
+    // validated + expiry-clamped the SAME way addGrants() validates them, so a grant
+    // can never outlive the mandate that carries it regardless of caller. The HTTP
+    // issue route drops grants today; this keeps the library contract uniformly safe
+    // for any future caller, not relying solely on the query-side clamp.
+    if (input.grants && input.grants.length > 0) {
+      const mandateExpiryMs = Date.parse(input.expiresAt);
+      for (const g of input.grants) {
+        if (!g || typeof g.floorAction !== 'string' || !g.floorAction
+          || typeof g.grantedTo !== 'string' || !g.grantedTo
+          || typeof g.authorizedBy !== 'string' || !g.authorizedBy
+          || typeof g.expiresAt !== 'string' || isNaN(Date.parse(g.expiresAt))) {
+          throw new Error('each grant needs a non-empty floorAction, grantedTo, authorizedBy, and a valid ISO expiresAt');
+        }
+        if (Date.parse(g.expiresAt) > mandateExpiryMs) {
+          throw new Error(`grant expiresAt (${g.expiresAt}) must be <= mandate expiresAt (${input.expiresAt})`);
+        }
+      }
+    }
     const authored: Omit<CoordinationMandate, 'authProof' | 'revoked'> = {
       id, scope: input.scope, agents: input.agents, authorities: input.authorities,
       author: input.author, createdAt, expiresAt: input.expiresAt,
+      // Append-only-when-non-empty: never set `grants` for a no-grant issuance, so the
+      // canonical bytes (and thus the proof) are byte-for-byte identical to before this
+      // extension existed.
+      ...(input.grants && input.grants.length > 0 ? { grants: input.grants } : {}),
     };
     const mandate: CoordinationMandate = {
       ...authored,
@@ -104,6 +144,57 @@ export class MandateStore {
     all.push(mandate);
     this.writeAll(all);
     return mandate;
+  }
+
+  /**
+   * Add user→agent authority grant(s) to an existing mandate and RE-SIGN it so the
+   * `authProof` covers the new grants (the only path that can sign a grant in — the
+   * PIN-gated route is the sole caller). Grants are validated and clamped against the
+   * mandate's own expiry: a grant's `expiresAt` may never exceed the mandate's.
+   *
+   * Returns `{ ok: false }` with a reason for a missing/revoked mandate or an invalid
+   * grant; `{ ok: true, mandate }` on success. Never partially applies.
+   */
+  addGrants(
+    id: string,
+    grants: UserAuthorityGrant[],
+  ): { ok: true; mandate: CoordinationMandate } | { ok: false; reason: string } {
+    const all = this.readAll();
+    const idx = all.findIndex((m) => m.id === id);
+    if (idx < 0) return { ok: false, reason: 'mandate not found' };
+    const existing = all[idx];
+    if (existing.revoked) return { ok: false, reason: 'mandate is revoked' };
+    if (!Array.isArray(grants) || grants.length === 0) return { ok: false, reason: 'no grants provided' };
+
+    const mandateExpiry = Date.parse(existing.expiresAt);
+    for (const g of grants) {
+      if (!g || typeof g.floorAction !== 'string' || !g.floorAction
+        || typeof g.grantedTo !== 'string' || !g.grantedTo
+        || typeof g.authorizedBy !== 'string' || !g.authorizedBy
+        || typeof g.expiresAt !== 'string' || isNaN(Date.parse(g.expiresAt))) {
+        return { ok: false, reason: 'each grant needs non-empty floorAction, grantedTo, authorizedBy, and a valid ISO expiresAt' };
+      }
+      // A grant can NEVER outlive the delegation that carries it.
+      if (Date.parse(g.expiresAt) > mandateExpiry) {
+        return { ok: false, reason: `grant expiresAt (${g.expiresAt}) must be <= mandate expiresAt (${existing.expiresAt})` };
+      }
+    }
+
+    const mergedGrants = [...(existing.grants ?? []), ...grants];
+    const authored: Omit<CoordinationMandate, 'authProof' | 'revoked'> = {
+      id: existing.id, scope: existing.scope, agents: existing.agents,
+      authorities: existing.authorities, author: existing.author,
+      createdAt: existing.createdAt, expiresAt: existing.expiresAt,
+      grants: mergedGrants,
+    };
+    const resigned: CoordinationMandate = {
+      ...authored,
+      revoked: existing.revoked,
+      authProof: this.d.sign(canonicalMandate(authored)),
+    };
+    all[idx] = resigned;
+    this.writeAll(all);
+    return { ok: true, mandate: resigned };
   }
 
   /** Verify a mandate's authorship proof (T1/T2). */

--- a/src/coordination/types.ts
+++ b/src/coordination/types.ts
@@ -26,6 +26,35 @@ export interface Authority {
   requiresCondition?: string;
 }
 
+/**
+ * A user→agent authority grant carried INSIDE a signed mandate. This is the
+ * extension that lets the human (the mandate author) delegate a Slack FLOOR
+ * action (money / prod-deploy / credentials / destructive / external / grant)
+ * to a SPECIFIC verified Slack user for a bounded time — the same deny-by-default,
+ * signed, expiring, revocable model the mandate already enforces for A2A authority.
+ *
+ * The grant is covered by the mandate's `authProof` (it is appended to the canonical
+ * byte sequence when present), so an agent cannot mint or widen a grant: only the
+ * PIN-gated issuance path can sign one in.
+ *
+ * `expiresAt` is independent of (and MUST be <= ) the mandate's own `expiresAt` —
+ * the grant can never outlive the delegation that carries it. The store-side query
+ * clamps to the mandate expiry, so a grant is void the moment EITHER clock passes.
+ */
+export interface UserAuthorityGrant {
+  /** The Slack FLOOR action this grant authorizes (e.g. 'prod-deploy'). Matched
+   *  against the gate's `scope` (the floorAction) on lookup. */
+  floorAction: string;
+  /** The VERIFIED Slack user id (U…) this grant is for — never a content name. */
+  grantedTo: string;
+  /** Who authorized it (the human author / operator). Requester ≠ authorizer. */
+  authorizedBy: string;
+  /** ISO timestamp after which the grant is void. MUST be <= the mandate's expiresAt. */
+  expiresAt: string;
+  /** Optional bounds carried for audit/future enforcement (advisory at the floor). */
+  bounds?: Record<string, unknown>;
+}
+
 /** The human-authored delegation. `authProof` covers all other fields. */
 export interface CoordinationMandate {
   id: string;
@@ -40,6 +69,13 @@ export interface CoordinationMandate {
   expiresAt: string;
   /** Set when revoked; checked on every action. */
   revoked: { at: string; reason: string } | null;
+  /**
+   * Optional user→agent authority grants (the Slack-floor delegation extension).
+   * Covered by `authProof` ONLY when present and non-empty — a mandate with no
+   * grants canonicalizes byte-for-byte identically to a pre-extension mandate, so
+   * existing signed mandates keep verifying (backward-compat is non-negotiable).
+   */
+  grants?: UserAuthorityGrant[];
   /** Authorship proof — an HMAC over the canonical (proof-excluded) mandate bytes,
    *  produced ONLY by the PIN-gated issuance path. An agent cannot mint or widen its
    *  own mandate without it; a forged/edited mandate fails verification. */

--- a/src/permissions/MandateBackedGrantStore.ts
+++ b/src/permissions/MandateBackedGrantStore.ts
@@ -1,0 +1,78 @@
+/**
+ * MandateBackedGrantStore — resolves a Slack FLOOR-action grant for a verified
+ * principal from the SIGNED Coordination Mandate(s).
+ *
+ * This is the production `GrantStore` for `SlackPermissionGate`: instead of an
+ * ad-hoc grant table, a floor-action grant is a `UserAuthorityGrant` carried inside
+ * a mandate and covered by the mandate's `authProof`. That makes the grant:
+ *   - deny-by-default     (no mandate / no matching grant → undefined → refuse)
+ *   - signed              (an agent cannot mint or widen a grant; only the PIN-gated
+ *                          issuance/grant route can sign one in)
+ *   - bounded + expiring  (the grant has its own expiry, clamped to never outlive the
+ *                          mandate that carries it)
+ *   - revocable           (revoking the mandate voids every grant it carries)
+ *
+ * `activeGrant` returns a grant ONLY when, for a mandate that is authorship-valid,
+ * not expired, and not revoked, there exists a grant whose `grantedTo` equals the
+ * verified Slack user id, whose `floorAction` equals the requested scope, and whose
+ * effective expiry (min of grant.expiresAt and mandate.expiresAt) is still in the
+ * future. Otherwise `undefined` — the gate then falls back to the role floor.
+ *
+ * Design: docs/specs/SLACK-ORG-INTEGRATION-SPEC.md (Pillar 2, floor grants) +
+ * docs/specs/coordination-mandate.md (the signed-delegation model the grant rides on).
+ */
+
+import type { GrantStore } from './SlackPermissionGate.js';
+import type { AuthorityGrant, FloorAction, SensitivityTier } from './types.js';
+import type { MandateStore } from '../coordination/MandateStore.js';
+
+export interface MandateBackedGrantStoreDeps {
+  /** The signed mandate store the grants live in. */
+  store: MandateStore;
+}
+
+export class MandateBackedGrantStore implements GrantStore {
+  private readonly store: MandateStore;
+  constructor(deps: MandateBackedGrantStoreDeps) {
+    this.store = deps.store;
+  }
+
+  /**
+   * Resolve an active floor-action grant for `slackUserId` + `scope` as of `now` (ms).
+   * Returns the FIRST matching grant across all mandates; `undefined` if none.
+   */
+  activeGrant(slackUserId: string, scope: string, now: number): AuthorityGrant | undefined {
+    if (!slackUserId || !scope) return undefined;
+
+    for (const mandate of this.store.list()) {
+      // Deny-by-default: a mandate must be authorship-valid, unrevoked, and unexpired
+      // before ANY grant it carries can be honored.
+      if (mandate.revoked) continue;
+      if (!this.store.verifyAuthorship(mandate)) continue;
+      const mandateExpiryMs = Date.parse(mandate.expiresAt);
+      if (isNaN(mandateExpiryMs) || mandateExpiryMs <= now) continue;
+
+      const grants = mandate.grants;
+      if (!Array.isArray(grants) || grants.length === 0) continue;
+
+      for (const g of grants) {
+        if (g.grantedTo !== slackUserId) continue;
+        if (g.floorAction !== scope) continue;
+        const grantExpiryMs = Date.parse(g.expiresAt);
+        if (isNaN(grantExpiryMs)) continue;
+        // The grant is void the moment EITHER clock passes — clamp to the mandate.
+        const effectiveExpiryMs = Math.min(grantExpiryMs, mandateExpiryMs);
+        if (effectiveExpiryMs <= now) continue;
+
+        return {
+          scope: scope as FloorAction | `tier:${SensitivityTier}`,
+          grantedTo: g.grantedTo,
+          authorizedBy: g.authorizedBy,
+          expiresAt: effectiveExpiryMs,
+        };
+      }
+    }
+
+    return undefined;
+  }
+}

--- a/src/permissions/index.ts
+++ b/src/permissions/index.ts
@@ -8,6 +8,7 @@ export * from './IntentClassifier.js';
 export * from './AnomalyScorer.js';
 export * from './PermissionDecisionLedger.js';
 export * from './SlackPermissionGate.js';
+export * from './MandateBackedGrantStore.js';
 export * from './SlackPrincipalResolver.js';
 export * from './SlackPermissionObserver.js';
 export * from './SlackUserRegistry.js';

--- a/src/server/CapabilityIndex.ts
+++ b/src/server/CapabilityIndex.ts
@@ -650,6 +650,7 @@ export const CAPABILITY_INDEX: readonly CapabilityEntry[] = [
         'GET /mandate/audit?limit=N — the chained decision audit (chain.ok:false = tampering — surface it)',
         'POST /mandate/issue — PIN-GATED (operator only; agent Bearer token is refused)',
         'POST /mandate/:id/revoke — PIN-GATED (the operator kill switch)',
+        'POST /mandate/:id/grants — PIN-GATED: sign user→agent floor-action grant(s) into a mandate { grants:[{floorAction,grantedTo,authorizedBy,expiresAt}] } (expiresAt MUST be <= mandate.expiresAt); re-signs so authProof covers them',
       ],
     }),
   },

--- a/src/server/routes.ts
+++ b/src/server/routes.ts
@@ -5586,6 +5586,64 @@ export function createRoutes(ctx: RouteContext): Router {
     res.json({ revoked: true, mandate: m });
   });
 
+  // Add user→agent authority grant(s) to a mandate — PIN-GATED (the same human-
+  // authenticated surface as issuance; an agent's Bearer token cannot mint a grant).
+  // Re-signs the mandate so `authProof` covers the new grant(s); each grant decision
+  // (accepted or rejected) lands in the SAME hash-chained MandateAudit. The grant rides
+  // the signed, expiring, revocable mandate model — deny-by-default is inherited.
+  // Design: docs/specs/SLACK-ORG-INTEGRATION-SPEC.md (floor grants) + coordination-mandate.md.
+  router.post('/mandate/:id/grants', (req, res) => {
+    if (!ctx.coordination) {
+      res.status(503).json({ error: 'coordination mandate engine unavailable (no stateDir or init failed)' });
+      return;
+    }
+    if (!checkMandatePin(req, res)) return;
+    const b = req.body ?? {};
+    // Accept either a single grant or an array.
+    const rawGrants = Array.isArray(b.grants) ? b.grants : (b.grant ? [b.grant] : []);
+    if (!Array.isArray(rawGrants) || rawGrants.length === 0) {
+      res.status(400).json({ error: 'grants (array) or grant (object) is required' });
+      return;
+    }
+    // Shallow shape check at the boundary; MandateStore.addGrants is the authoritative
+    // validator (incl. the expiresAt <= mandate.expiresAt clamp).
+    const grants = rawGrants.map((g: any) => ({
+      floorAction: typeof g?.floorAction === 'string' ? g.floorAction : '',
+      grantedTo: typeof g?.grantedTo === 'string' ? g.grantedTo : '',
+      authorizedBy: typeof g?.authorizedBy === 'string' ? g.authorizedBy : '',
+      expiresAt: typeof g?.expiresAt === 'string' ? g.expiresAt : '',
+      ...(g?.bounds && typeof g.bounds === 'object' ? { bounds: g.bounds } : {}),
+    }));
+
+    const result = ctx.coordination.store.addGrants(req.params.id, grants);
+    if (!result.ok) {
+      // Audit the rejection so a refused grant is reconstructable too.
+      for (const g of grants) {
+        ctx.coordination.audit.record({
+          mandateId: req.params.id,
+          agentFp: g.grantedTo || 'unknown',
+          action: `grant-floor:${g.floorAction || 'unknown'}`,
+          decision: 'deny',
+          reason: `grant rejected: ${result.reason}`,
+        });
+      }
+      const status = result.reason === 'mandate not found' ? 404 : 400;
+      res.status(status).json({ error: result.reason });
+      return;
+    }
+    // Audit each accepted grant.
+    for (const g of grants) {
+      ctx.coordination.audit.record({
+        mandateId: req.params.id,
+        agentFp: g.grantedTo,
+        action: `grant-floor:${g.floorAction}`,
+        decision: 'allow',
+        reason: `grant signed by ${g.authorizedBy} until ${g.expiresAt}`,
+      });
+    }
+    res.status(201).json({ granted: true, mandate: { ...result.mandate, authorshipValid: ctx.coordination.store.verifyAuthorship(result.mandate) } });
+  });
+
   // ── ReviewExchange — autonomous code-review protocol (coordination-mandate spec §7 G2.3) ──
   // One mutual, MANDATE-GATED sign-off of a review artifact between the two agents named
   // in a mandate. Both sign-offs run through /the same/ MandateGate (named party, bounds,

--- a/tests/e2e/coordination-mandate-lifecycle.test.ts
+++ b/tests/e2e/coordination-mandate-lifecycle.test.ts
@@ -135,6 +135,46 @@ describe('Coordination Mandate E2E lifecycle — feature is alive + deny-by-defa
     expect(audit.body.chain).toEqual({ ok: true });
   });
 
+  it('user→agent grants: PIN-issue → PIN-grant alive (201) → grant signed in, authProof still verifies via the production signer', async () => {
+    // Issue a fresh mandate.
+    const issued = await request(app).post('/mandate/issue').set(auth()).send({
+      pin: PIN, scope: 'slack-floor', agents: [ECHO, DAWN],
+      authorities: [{ action: 'sign-code-review', bounds: {} }], expiresAt: FUTURE,
+    });
+    expect(issued.status).toBe(201);
+    const id = issued.body.mandate.id;
+
+    // SECURITY: Bearer alone cannot add a grant — the PIN is required on the prod path.
+    const noPin = await request(app).post(`/mandate/${id}/grants`).set(auth()).send({
+      grants: [{ floorAction: 'prod-deploy', grantedTo: 'U_AMIR', authorizedBy: 'justin', expiresAt: '2998-01-01T00:00:00Z' }],
+    });
+    expect(noPin.status).toBe(403);
+
+    // PIN-gated grant lands (201) and re-signs the mandate.
+    const granted = await request(app).post(`/mandate/${id}/grants`).set(auth()).send({
+      pin: PIN, grants: [{ floorAction: 'prod-deploy', grantedTo: 'U_AMIR', authorizedBy: 'justin', expiresAt: '2998-01-01T00:00:00Z' }],
+    });
+    expect(granted.status).toBe(201);
+    expect(granted.body.mandate.authorshipValid).toBe(true);
+    expect(granted.body.mandate.grants).toHaveLength(1);
+
+    // The persisted, grant-bearing mandate verifies against an INDEPENDENT production
+    // signer (HMAC over authToken) — the re-sign is real, not a no-op.
+    const file = path.join(stateDir, 'state', 'coordination-mandates.json');
+    const sign = (c: string) => createHmac('sha256', AUTH).update(c).digest('hex');
+    const verifySig = (c: string, p: string) => {
+      const e = sign(c);
+      try { return e.length === p.length && timingSafeEqual(Buffer.from(e), Buffer.from(p)); } catch { return false; }
+    };
+    const independent = new MandateStore({ filePath: file, sign, verifySig });
+    const m = independent.get(id)!;
+    expect(m.grants).toHaveLength(1);
+    expect(independent.verifyAuthorship(m)).toBe(true);
+    // Tampering the grant's grantee breaks the proof.
+    const tampered = { ...m, grants: [{ ...m.grants![0], grantedTo: 'U_ATTACKER' }] };
+    expect(independent.verifyAuthorship(tampered)).toBe(false);
+  });
+
   it('WIRING-INTEGRITY: the production issuance signer is real — the persisted authProof verifies, a widened mandate fails', async () => {
     const file = path.join(stateDir, 'state', 'coordination-mandates.json');
     const sign = (c: string) => createHmac('sha256', AUTH).update(c).digest('hex');

--- a/tests/integration/mandate-routes.test.ts
+++ b/tests/integration/mandate-routes.test.ts
@@ -178,8 +178,81 @@ describe('Coordination Mandate routes (spec §4)', () => {
       expect((await fetch(`${s2.url}/mandate`)).status).toBe(503);
       expect((await fetch(`${s2.url}/mandate/audit`)).status).toBe(503);
       expect((await fetch(`${s2.url}/mandate/evaluate`, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ action: 'a', agentFp: 'f', mandateId: 'm' }) })).status).toBe(503);
+      expect((await fetch(`${s2.url}/mandate/m/grants`, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ pin: PIN, grants: [] }) })).status).toBe(503);
     } finally {
       await s2.close();
     }
+  });
+
+  // ── user→agent grants route ──
+
+  const VALID_GRANT = { floorAction: 'prod-deploy', grantedTo: 'U_AMIR', authorizedBy: 'justin', expiresAt: '2998-01-01T00:00:00Z' };
+
+  async function addGrant(body: object) {
+    return fetch(`${server.url}/mandate/m-test/grants`, {
+      method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(body),
+    });
+  }
+
+  it('SECURITY: adding a grant WITHOUT the operator PIN is refused (Bearer alone cannot grant)', async () => {
+    await issueWithPin(PIN);
+    const res = await addGrant({ grants: [VALID_GRANT] });
+    expect(res.status).toBe(403);
+    expect((await res.json()).error).toMatch(/PIN required/i);
+  });
+
+  it('adds a grant with the PIN (201), re-signs so authorshipValid stays true, and the grant is on the mandate', async () => {
+    await issueWithPin(PIN);
+    const res = await addGrant({ pin: PIN, grants: [VALID_GRANT] });
+    expect(res.status).toBe(201);
+    const body = await res.json();
+    expect(body.granted).toBe(true);
+    expect(body.mandate.authorshipValid).toBe(true);
+    expect(body.mandate.grants).toHaveLength(1);
+    expect(body.mandate.grants[0].grantedTo).toBe('U_AMIR');
+    // Lists back still verified.
+    const list = await (await fetch(`${server.url}/mandate`)).json();
+    expect(list.mandates[0].authorshipValid).toBe(true);
+    expect(list.mandates[0].grants).toHaveLength(1);
+  });
+
+  it('accepts a single grant via the `grant` field too', async () => {
+    await issueWithPin(PIN);
+    const res = await addGrant({ pin: PIN, grant: VALID_GRANT });
+    expect(res.status).toBe(201);
+    expect((await res.json()).mandate.grants).toHaveLength(1);
+  });
+
+  it('rejects a grant whose expiresAt exceeds the mandate expiresAt (400) and audits the rejection', async () => {
+    await issueWithPin(PIN); // mandate expires FUTURE = 2999-01-01
+    const beforeAudit = (await (await fetch(`${server.url}/mandate/audit`)).json()).total;
+    const res = await addGrant({ pin: PIN, grants: [{ ...VALID_GRANT, expiresAt: '3000-01-01T00:00:00Z' }] });
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toMatch(/must be <= mandate expiresAt/);
+    const afterAudit = await (await fetch(`${server.url}/mandate/audit`)).json();
+    expect(afterAudit.total).toBe(beforeAudit + 1);
+    expect(afterAudit.entries[0].decision).toBe('deny'); // rejection audited
+    expect(afterAudit.chain).toEqual({ ok: true });
+  });
+
+  it('404 for a grant on a non-existent mandate; 400 for an empty grants payload', async () => {
+    const notFound = await fetch(`${server.url}/mandate/ghost/grants`, {
+      method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ pin: PIN, grants: [VALID_GRANT] }),
+    });
+    expect(notFound.status).toBe(404);
+    await issueWithPin(PIN);
+    const empty = await addGrant({ pin: PIN, grants: [] });
+    expect(empty.status).toBe(400);
+  });
+
+  it('a granted floor action verifies through evaluate-style flow: the grant is audited on accept', async () => {
+    await issueWithPin(PIN);
+    const before = (await (await fetch(`${server.url}/mandate/audit`)).json()).total;
+    await addGrant({ pin: PIN, grants: [VALID_GRANT] });
+    const auditRes = await (await fetch(`${server.url}/mandate/audit`)).json();
+    expect(auditRes.total).toBe(before + 1);
+    expect(auditRes.entries[0].decision).toBe('allow');
+    expect(auditRes.entries[0].action).toBe('grant-floor:prod-deploy');
+    expect(auditRes.chain).toEqual({ ok: true });
   });
 });

--- a/tests/unit/mandate-user-grants.test.ts
+++ b/tests/unit/mandate-user-grants.test.ts
@@ -1,0 +1,364 @@
+/**
+ * Tier-1 tests for the user→agent authority-grant extension to the Coordination
+ * Mandate (SECURITY-CRITICAL: this touches the signed `authProof` over a live type).
+ *
+ * The whole point is the security boundary:
+ *   - BACKWARD-COMPAT: a NO-grant mandate canonicalizes byte-for-byte identically to
+ *     a pre-extension mandate, so its existing authProof still verifies.
+ *   - FORGED-GRANT TAMPER: adding a grant WITHOUT re-signing fails verification; a
+ *     grant added through the issuance path (addGrants, which re-signs) verifies.
+ *   - GRANT QUERY (MandateBackedGrantStore): active resolves; expired/revoked/
+ *     overlong-expiry do NOT.
+ *   - WIRING: SlackPermissionGate floor check allows WITH a grant, refuses WITHOUT.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { MandateStore, canonicalMandate } from '../../src/coordination/MandateStore.js';
+import type { Authority, UserAuthorityGrant, CoordinationMandate } from '../../src/coordination/types.js';
+import { MandateBackedGrantStore } from '../../src/permissions/MandateBackedGrantStore.js';
+import { SlackPermissionGate } from '../../src/permissions/SlackPermissionGate.js';
+import { HeuristicIntentClassifier } from '../../src/permissions/IntentClassifier.js';
+import { NullAnomalyScorer } from '../../src/permissions/AnomalyScorer.js';
+import type { Principal } from '../../src/permissions/types.js';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+
+const sign = (c: string) => `proof::${c}`;
+const verifySig = (c: string, s: string) => s === `proof::${c}`;
+
+const ECHO = 'fp-echo';
+const DAWN = 'fp-dawn';
+const FUTURE = '2999-01-01T00:00:00Z';
+const MANDATE_EXP = '2999-06-01T00:00:00Z';
+const PAST = '2000-01-01T00:00:00Z';
+
+const FIRST_MANDATE_AUTHORITIES: Authority[] = [
+  { action: 'exchange-read-credential', bounds: { credentialScope: 'read-only', onMachine: true } },
+  { action: 'sign-code-review', bounds: { artifact: 'migration-port', mutual: true } },
+];
+
+describe('Mandate user→agent grants — signing & backward-compat (security-critical)', () => {
+  let dir: string;
+  let store: MandateStore;
+  let n: number;
+
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'mandate-grants-'));
+    n = 0;
+    const now = () => 1_700_000_000_000 + (n++);
+    store = new MandateStore({ filePath: path.join(dir, 'mandates.json'), sign, verifySig, now, genId: () => `m-${n}` });
+  });
+  afterEach(() => SafeFsExecutor.safeRmSync(dir, { recursive: true, force: true, operation: 'tests/unit/mandate-user-grants.test.ts' }));
+
+  // ── BACKWARD-COMPAT (MUST) ──
+
+  it('a NO-grant mandate canonicalizes to the EXACT pre-extension bytes', () => {
+    // This is the recorded baseline: the literal canonical bytes the OLD code produced
+    // for this mandate (id/scope/agents/authorities/author/createdAt/expiresAt). If the
+    // extension altered the no-grant byte sequence, existing signed mandates break.
+    const authored = {
+      id: 'mig-1', scope: 'feedback-migration', agents: [ECHO, DAWN] as [string, string],
+      authorities: FIRST_MANDATE_AUTHORITIES, author: 'justin',
+      createdAt: '2026-06-09T00:00:00.000Z', expiresAt: FUTURE,
+    };
+    // The OLD canonical form, computed inline exactly as the pre-extension code did.
+    const stableStringify = (value: unknown): string => {
+      if (value === null || typeof value !== 'object') return JSON.stringify(value);
+      if (Array.isArray(value)) return '[' + value.map(stableStringify).join(',') + ']';
+      const obj = value as Record<string, unknown>;
+      const keys = Object.keys(obj).sort();
+      return '{' + keys.map((k) => JSON.stringify(k) + ':' + stableStringify(obj[k])).join(',') + '}';
+    };
+    const oldCanonical = stableStringify([
+      authored.id, authored.scope, authored.agents,
+      authored.authorities.map((a) => [a.action, a.bounds, a.requiresCondition ?? '']),
+      authored.author, authored.createdAt, authored.expiresAt,
+    ]);
+    // No grants → identical bytes.
+    expect(canonicalMandate(authored)).toBe(oldCanonical);
+    // grants:[] (empty) → STILL identical (append-only-when-non-empty).
+    expect(canonicalMandate({ ...authored, grants: [] })).toBe(oldCanonical);
+    // grants:undefined → identical.
+    expect(canonicalMandate({ ...authored, grants: undefined })).toBe(oldCanonical);
+  });
+
+  it('an EXISTING signed mandate (no grants field) still verifies after the extension', () => {
+    // Simulate a mandate signed by the OLD code: no `grants` key on disk at all.
+    const authored = {
+      id: 'legacy-1', scope: 'feedback-migration', agents: [ECHO, DAWN] as [string, string],
+      authorities: FIRST_MANDATE_AUTHORITIES, author: 'justin',
+      createdAt: '2026-06-09T00:00:00.000Z', expiresAt: FUTURE,
+    };
+    const legacy: CoordinationMandate = {
+      ...authored,
+      revoked: null,
+      authProof: sign(canonicalMandate(authored)), // signed WITHOUT any grants concept
+    };
+    fs.writeFileSync(path.join(dir, 'mandates.json'), JSON.stringify([legacy], null, 2));
+    const loaded = store.get('legacy-1')!;
+    expect('grants' in loaded).toBe(false); // proves no grants field crept in
+    expect(store.verifyAuthorship(loaded)).toBe(true); // existing proof STILL valid
+  });
+
+  it('a NON-empty grant changes the canonical bytes (so the proof must cover them)', () => {
+    const authored = {
+      id: 'mig-1', scope: 's', agents: [ECHO, DAWN] as [string, string],
+      authorities: FIRST_MANDATE_AUTHORITIES, author: 'justin', createdAt: 't', expiresAt: FUTURE,
+    };
+    const grant: UserAuthorityGrant = { floorAction: 'prod-deploy', grantedTo: 'U_AMIR', authorizedBy: 'justin', expiresAt: FUTURE };
+    expect(canonicalMandate({ ...authored, grants: [grant] })).not.toBe(canonicalMandate(authored));
+  });
+
+  // ── FORGED-GRANT TAMPER (MUST) ──
+
+  it('adding a grant to a signed mandate WITHOUT re-signing fails verification', () => {
+    const m = store.issue({
+      id: 'mig-1', scope: 'feedback-migration', agents: [ECHO, DAWN],
+      authorities: FIRST_MANDATE_AUTHORITIES, author: 'justin', expiresAt: MANDATE_EXP,
+    });
+    expect(store.verifyAuthorship(m)).toBe(true);
+    // Attacker bolts a grant onto the object but keeps the old proof.
+    const forged: CoordinationMandate = {
+      ...m,
+      grants: [{ floorAction: 'prod-deploy', grantedTo: 'U_ATTACKER', authorizedBy: 'justin', expiresAt: MANDATE_EXP }],
+    };
+    expect(store.verifyAuthorship(forged)).toBe(false); // the proof no longer covers the bytes
+  });
+
+  it('a grant added through the issuance path (addGrants re-signs) verifies TRUE', () => {
+    store.issue({
+      id: 'mig-1', scope: 'feedback-migration', agents: [ECHO, DAWN],
+      authorities: FIRST_MANDATE_AUTHORITIES, author: 'justin', expiresAt: MANDATE_EXP,
+    });
+    const res = store.addGrants('mig-1', [{ floorAction: 'prod-deploy', grantedTo: 'U_AMIR', authorizedBy: 'justin', expiresAt: FUTURE /* 2999-01 < MANDATE_EXP 2999-06 → within bounds */ }]);
+    expect(res.ok).toBe(true);
+    if (res.ok) {
+      expect(store.verifyAuthorship(res.mandate)).toBe(true);
+      expect(res.mandate.grants).toHaveLength(1);
+    }
+    // And the persisted copy verifies (proof survives the round-trip).
+    expect(store.verifyAuthorship(store.get('mig-1')!)).toBe(true);
+  });
+
+  it('issuing a mandate WITH grants at creation verifies, and that proof covers the grants', () => {
+    const m = store.issue({
+      id: 'mig-1', scope: 'feedback-migration', agents: [ECHO, DAWN],
+      authorities: FIRST_MANDATE_AUTHORITIES, author: 'justin', expiresAt: MANDATE_EXP,
+      grants: [{ floorAction: 'prod-deploy', grantedTo: 'U_AMIR', authorizedBy: 'justin', expiresAt: MANDATE_EXP }],
+    });
+    expect(store.verifyAuthorship(m)).toBe(true);
+    // Swap the grant's grantee → proof must break.
+    const tampered: CoordinationMandate = { ...m, grants: [{ ...m.grants![0], grantedTo: 'U_ATTACKER' }] };
+    expect(store.verifyAuthorship(tampered)).toBe(false);
+  });
+
+  // ── addGrants validation / expiry clamp ──
+
+  it('addGrants rejects a grant whose expiresAt exceeds the mandate expiresAt', () => {
+    // MANDATE_EXP = 2999-06-01; a grant expiring 3000 is past it → rejected.
+    store.issue({ id: 'mig-1', scope: 's', agents: [ECHO, DAWN], authorities: FIRST_MANDATE_AUTHORITIES, author: 'justin', expiresAt: MANDATE_EXP });
+    const res = store.addGrants('mig-1', [{ floorAction: 'prod-deploy', grantedTo: 'U_AMIR', authorizedBy: 'justin', expiresAt: '3000-01-01T00:00:00Z' /* > MANDATE_EXP */ }]);
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.reason).toMatch(/must be <= mandate expiresAt/);
+  });
+
+  it('issue() with grants applies the SAME expiry clamp as addGrants (second-pass hardening — uniform library contract)', () => {
+    // The HTTP issue route drops grants today; this guards any future caller so a
+    // grant issued WITH the mandate can never outlive it.
+    expect(() => store.issue({
+      id: 'mig-iss-clamp', scope: 's', agents: [ECHO, DAWN], authorities: FIRST_MANDATE_AUTHORITIES,
+      author: 'justin', expiresAt: MANDATE_EXP,
+      grants: [{ floorAction: 'prod-deploy', grantedTo: 'U_AMIR', authorizedBy: 'justin', expiresAt: '3000-01-01T00:00:00Z' /* > MANDATE_EXP */ }],
+    })).toThrow(/must be <= mandate expiresAt/);
+    // a within-bounds grant at issuance is signed in and verifies.
+    const ok = store.issue({
+      id: 'mig-iss-ok', scope: 's', agents: [ECHO, DAWN], authorities: FIRST_MANDATE_AUTHORITIES,
+      author: 'justin', expiresAt: MANDATE_EXP,
+      grants: [{ floorAction: 'prod-deploy', grantedTo: 'U_AMIR', authorizedBy: 'justin', expiresAt: MANDATE_EXP }],
+    });
+    expect(store.verifyAuthorship(ok)).toBe(true);
+    expect(ok.grants?.length).toBe(1);
+  });
+
+  it('addGrants rejects a missing / revoked mandate and a malformed grant', () => {
+    expect(store.addGrants('nope', [{ floorAction: 'prod-deploy', grantedTo: 'U_A', authorizedBy: 'justin', expiresAt: MANDATE_EXP }]))
+      .toEqual({ ok: false, reason: 'mandate not found' });
+    store.issue({ id: 'mig-1', scope: 's', agents: [ECHO, DAWN], authorities: FIRST_MANDATE_AUTHORITIES, author: 'justin', expiresAt: MANDATE_EXP });
+    store.revoke('mig-1', 'kill');
+    const revRes = store.addGrants('mig-1', [{ floorAction: 'prod-deploy', grantedTo: 'U_A', authorizedBy: 'justin', expiresAt: MANDATE_EXP }]);
+    expect(revRes).toEqual({ ok: false, reason: 'mandate is revoked' });
+    store.issue({ id: 'mig-2', scope: 's', agents: [ECHO, DAWN], authorities: FIRST_MANDATE_AUTHORITIES, author: 'justin', expiresAt: MANDATE_EXP });
+    const badRes = store.addGrants('mig-2', [{ floorAction: '', grantedTo: 'U_A', authorizedBy: 'justin', expiresAt: MANDATE_EXP } as UserAuthorityGrant]);
+    expect(badRes.ok).toBe(false);
+  });
+});
+
+describe('MandateBackedGrantStore.activeGrant — grant query (both sides)', () => {
+  let dir: string;
+  let store: MandateStore;
+  let grantStore: MandateBackedGrantStore;
+  let n: number;
+  const T0 = 1_700_000_000_000;
+
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'mandate-grantq-'));
+    n = 0;
+    const now = () => T0 + (n++);
+    store = new MandateStore({ filePath: path.join(dir, 'mandates.json'), sign, verifySig, now, genId: () => `m-${n}` });
+    grantStore = new MandateBackedGrantStore({ store });
+  });
+  afterEach(() => SafeFsExecutor.safeRmSync(dir, { recursive: true, force: true, operation: 'tests/unit/mandate-user-grants.test.ts' }));
+
+  // mandate expiry far in the future (ms); grant within it
+  const MANDATE_EXP_ISO = new Date(T0 + 30 * 24 * 3600_000).toISOString(); // +30d
+  const GRANT_EXP_ISO = new Date(T0 + 7 * 24 * 3600_000).toISOString();    // +7d
+  const NOW = T0 + 1000;
+
+  function issueWithGrant(g: Partial<UserAuthorityGrant> = {}, mandateExp = MANDATE_EXP_ISO) {
+    store.issue({
+      id: 'mig-1', scope: 'feedback-migration', agents: [ECHO, DAWN],
+      authorities: FIRST_MANDATE_AUTHORITIES, author: 'justin', expiresAt: mandateExp,
+      grants: [{ floorAction: 'prod-deploy', grantedTo: 'U_AMIR', authorizedBy: 'justin', expiresAt: GRANT_EXP_ISO, ...g }],
+    });
+  }
+
+  it('resolves an active grant for the right user + scope', () => {
+    issueWithGrant();
+    const g = grantStore.activeGrant('U_AMIR', 'prod-deploy', NOW);
+    expect(g).toBeDefined();
+    expect(g!.grantedTo).toBe('U_AMIR');
+    expect(g!.authorizedBy).toBe('justin');
+    expect(g!.scope).toBe('prod-deploy');
+    expect(g!.expiresAt).toBe(Date.parse(GRANT_EXP_ISO)); // grant earlier than mandate → grant wins
+  });
+
+  it('returns undefined for the wrong user or the wrong scope', () => {
+    issueWithGrant();
+    expect(grantStore.activeGrant('U_OTHER', 'prod-deploy', NOW)).toBeUndefined();
+    expect(grantStore.activeGrant('U_AMIR', 'money-movement', NOW)).toBeUndefined();
+  });
+
+  it('does NOT resolve an expired grant (now past grant.expiresAt)', () => {
+    issueWithGrant();
+    const afterGrant = Date.parse(GRANT_EXP_ISO) + 1;
+    expect(grantStore.activeGrant('U_AMIR', 'prod-deploy', afterGrant)).toBeUndefined();
+  });
+
+  it('does NOT resolve grants on a REVOKED mandate', () => {
+    issueWithGrant();
+    store.revoke('mig-1', 'kill');
+    expect(grantStore.activeGrant('U_AMIR', 'prod-deploy', NOW)).toBeUndefined();
+  });
+
+  it('does NOT resolve grants on an EXPIRED mandate (even if the grant itself is unexpired)', () => {
+    // Mandate expires +1d; grant expires +7d — but addGrants forbids that, so build it
+    // on-disk directly to prove the query-side clamp is independent of the issuance clamp.
+    const mandateExp = new Date(T0 + 1 * 24 * 3600_000).toISOString();
+    const grant: UserAuthorityGrant = { floorAction: 'prod-deploy', grantedTo: 'U_AMIR', authorizedBy: 'justin', expiresAt: GRANT_EXP_ISO };
+    const authored = {
+      id: 'mig-1', scope: 's', agents: [ECHO, DAWN] as [string, string],
+      authorities: FIRST_MANDATE_AUTHORITIES, author: 'justin', createdAt: new Date(T0).toISOString(),
+      expiresAt: mandateExp, grants: [grant],
+    };
+    const onDisk: CoordinationMandate = { ...authored, revoked: null, authProof: sign(canonicalMandate(authored)) };
+    fs.writeFileSync(path.join(dir, 'mandates.json'), JSON.stringify([onDisk], null, 2));
+    const afterMandate = Date.parse(mandateExp) + 1;
+    expect(grantStore.activeGrant('U_AMIR', 'prod-deploy', afterMandate)).toBeUndefined();
+  });
+
+  it('clamps the effective expiry to the mandate when the mandate ends first', () => {
+    // grant +30d, mandate +7d (on-disk so we can force grant > mandate)
+    const mandateExp = new Date(T0 + 7 * 24 * 3600_000).toISOString();
+    const grantExp = new Date(T0 + 30 * 24 * 3600_000).toISOString();
+    const grant: UserAuthorityGrant = { floorAction: 'prod-deploy', grantedTo: 'U_AMIR', authorizedBy: 'justin', expiresAt: grantExp };
+    const authored = {
+      id: 'mig-1', scope: 's', agents: [ECHO, DAWN] as [string, string],
+      authorities: FIRST_MANDATE_AUTHORITIES, author: 'justin', createdAt: new Date(T0).toISOString(),
+      expiresAt: mandateExp, grants: [grant],
+    };
+    const onDisk: CoordinationMandate = { ...authored, revoked: null, authProof: sign(canonicalMandate(authored)) };
+    fs.writeFileSync(path.join(dir, 'mandates.json'), JSON.stringify([onDisk], null, 2));
+    const g = grantStore.activeGrant('U_AMIR', 'prod-deploy', NOW);
+    expect(g).toBeDefined();
+    expect(g!.expiresAt).toBe(Date.parse(mandateExp)); // clamped to mandate, not the longer grant
+  });
+
+  it('does NOT resolve grants on a mandate whose authorship proof is invalid', () => {
+    issueWithGrant();
+    // Corrupt the proof on disk.
+    const file = path.join(dir, 'mandates.json');
+    const arr = JSON.parse(fs.readFileSync(file, 'utf8'));
+    arr[0].authProof = 'forged';
+    fs.writeFileSync(file, JSON.stringify(arr));
+    expect(grantStore.activeGrant('U_AMIR', 'prod-deploy', NOW)).toBeUndefined();
+  });
+
+  it('empty inputs and an empty store → undefined (deny-by-default)', () => {
+    expect(grantStore.activeGrant('', 'prod-deploy', NOW)).toBeUndefined();
+    expect(grantStore.activeGrant('U_AMIR', '', NOW)).toBeUndefined();
+    expect(grantStore.activeGrant('U_AMIR', 'prod-deploy', NOW)).toBeUndefined(); // empty store
+  });
+});
+
+describe('SlackPermissionGate wiring — floor allowed WITH grant, refused WITHOUT', () => {
+  let dir: string;
+  let store: MandateStore;
+  let grantStore: MandateBackedGrantStore;
+  let n: number;
+  const T0 = 1_700_000_000_000;
+
+  const principal = (over: Partial<Principal>): Principal => ({
+    userId: 'u-amir', name: 'Amir', slackUserId: 'U_AMIR', role: 'admin', registered: true, ...over,
+  });
+
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'mandate-gatewire-'));
+    n = 0;
+    const now = () => T0 + (n++);
+    store = new MandateStore({ filePath: path.join(dir, 'mandates.json'), sign, verifySig, now, genId: () => `m-${n}` });
+    grantStore = new MandateBackedGrantStore({ store });
+  });
+  afterEach(() => SafeFsExecutor.safeRmSync(dir, { recursive: true, force: true, operation: 'tests/unit/mandate-user-grants.test.ts' }));
+
+  const MANDATE_EXP_ISO = new Date(T0 + 30 * 24 * 3600_000).toISOString();
+  const GRANT_EXP_ISO = new Date(T0 + 7 * 24 * 3600_000).toISOString();
+
+  function gate(now: number) {
+    return new SlackPermissionGate({
+      classifier: new HeuristicIntentClassifier(),
+      anomalyScorer: new NullAnomalyScorer(),
+      grants: grantStore,
+      now: () => now,
+    });
+  }
+
+  it('refuses a floor action for a non-owner WITHOUT a grant (floor-no-grant)', async () => {
+    const v = await gate(T0 + 1000).evaluate({ principal: principal({}), text: 'deploy to prod', directed: true });
+    expect(v.decision).toBe('refuse');
+    expect(v.basis).toBe('floor-no-grant');
+  });
+
+  it('ALLOWS a floor action for that same non-owner WITH a valid mandate-backed grant', async () => {
+    store.issue({
+      id: 'mig-1', scope: 'feedback-migration', agents: [ECHO, DAWN],
+      authorities: FIRST_MANDATE_AUTHORITIES, author: 'justin', expiresAt: MANDATE_EXP_ISO,
+      grants: [{ floorAction: 'prod-deploy', grantedTo: 'U_AMIR', authorizedBy: 'justin', expiresAt: GRANT_EXP_ISO }],
+    });
+    const v = await gate(T0 + 1000).evaluate({ principal: principal({}), text: 'deploy to prod', directed: true });
+    expect(v.decision).toBe('allow');
+    expect(v.basis).toBe('floor-granted');
+  });
+
+  it('refuses again once the grant has expired (the grant is time-boxed)', async () => {
+    store.issue({
+      id: 'mig-1', scope: 'feedback-migration', agents: [ECHO, DAWN],
+      authorities: FIRST_MANDATE_AUTHORITIES, author: 'justin', expiresAt: MANDATE_EXP_ISO,
+      grants: [{ floorAction: 'prod-deploy', grantedTo: 'U_AMIR', authorizedBy: 'justin', expiresAt: GRANT_EXP_ISO }],
+    });
+    const afterGrant = Date.parse(GRANT_EXP_ISO) + 1;
+    const v = await gate(afterGrant).evaluate({ principal: principal({}), text: 'deploy to prod', directed: true });
+    expect(v.decision).toBe('refuse');
+    expect(v.basis).toBe('floor-no-grant');
+  });
+});

--- a/upgrades/next/mandate-user-grants.md
+++ b/upgrades/next/mandate-user-grants.md
@@ -1,0 +1,23 @@
+## What Changed
+
+feat(coordination): user→agent authority grants in the Coordination Mandate — a verified operator can grant a specific floor action to a specific Slack user, **signed into the mandate** so it can't be forged. Completes the Slack-permission floor-authorization path (the gate's `GrantStore.activeGrant` now has a signature-backed implementation).
+
+- `canonicalMandate()` appends grants to the signed bytes **only when non-empty**, so every existing no-grant mandate serializes byte-for-byte as before and its `authProof` still verifies (backward-compatible by construction).
+- `addGrants()` re-signs through the PIN-gated path and rejects any grant whose expiry exceeds the mandate's (a grant can't outlive its delegation); `issue()` enforces the same clamp.
+- `MandateBackedGrantStore` reads grants deny-by-default: authorship + mandate-revocation + mandate-expiry + grant-expiry all checked before a grant clears a floor action.
+- New PIN-gated route `POST /mandate/:id/grants`; every grant decision audited through the hash-chained `MandateAudit`.
+
+Dark/no-op until an operator mints a grant; the Slack gate that consumes it is still observe-only.
+
+## What to Tell Your User
+
+Nothing changes for you right now — this ships dark. It's an operator capability that becomes useful once the Slack permission gate is enabled: from then on you (the verified operator) can grant a *specific* Slack person permission for a *specific* high-risk action (e.g. a production deploy), time-boxed, signed so it can't be forged, and minted only behind your dashboard PIN. Until you mint a grant and turn the gate on, agent behavior is unchanged.
+
+## Summary of New Capabilities
+
+- **PIN-gated `POST /mandate/:id/grants`** — your verified operator grants a Slack user a specific floor authority, signed into the Coordination Mandate (can't be forged or widened by an agent; can't outlive its mandate; every grant decision is written to the tamper-evident audit log). Operator/internal — not surfaced in `/capabilities` while the Slack gate is dark.
+
+## Evidence
+
+- 19 new unit tests incl. the backward-compat test (legacy no-grant mandate verifies) + the forged-grant tamper test (grant added without re-signing → verification FAILS) + expiry-clamp/revoke/expiry-bypass coverage. `tsc --noEmit` clean; lint clean; 130/130 in the related coordination/permission sweep.
+- Side-effects review (`upgrades/side-effects/mandate-user-grants.md`) + an independent adversarial Phase-5 second-pass on the signing path.

--- a/upgrades/side-effects/mandate-user-grants.md
+++ b/upgrades/side-effects/mandate-user-grants.md
@@ -1,0 +1,78 @@
+# Side-Effects Review — Coordination Mandate user→agent authority grants
+
+**Version / slug:** `mandate-user-grants`
+**Date:** 2026-06-09
+**Author:** Instar Agent (echo)
+**Second-pass reviewer:** REQUIRED (authority/signing crypto — trust-level decision) — independent adversarial review, see Phase 5
+
+## Summary of the change
+
+Extends the Coordination Mandate so a verified operator can grant a SPECIFIC floor authority to a SPECIFIC Slack user, signed into the mandate so it cannot be forged. This is what lets a non-owner be permitted a floor action (e.g. a prod-deploy) — the Slack permission gate's floor check already calls `GrantStore.activeGrant(slackUserId, scope, now)`; this provides the production, signature-backed implementation.
+
+Files: `src/coordination/types.ts` (the `UserAuthorityGrant` type + optional `grants?` on `CoordinationMandate`), `src/coordination/MandateStore.ts` (the security-critical `canonicalMandate()` change + `addGrants()` re-sign path + `issue()` carrying grants), `src/permissions/MandateBackedGrantStore.ts` (new — reads signed grants, deny-by-default), `src/permissions/index.ts`, `src/server/routes.ts` (PIN-gated `POST /mandate/:id/grants`), `src/server/CapabilityIndex.ts` (route registration), `src/commands/server.ts` (wire the store into the gate).
+
+Decision points touched: the floor-authorization decision (a grant can now clear a floor action for a non-owner) — but only via a SIGNED grant minted on the PIN-gated path.
+
+## Decision-point inventory
+
+- `MandateBackedGrantStore.activeGrant` — **add** — resolves a signed grant → clears a floor action for the named user. Deny-by-default; authorship + mandate-expiry + mandate-revocation + grant-expiry all checked before a grant is honored.
+- `canonicalMandate()` — **modify (security-critical)** — grants are now part of the signed bytes (append-only-when-non-empty for backward-compat).
+- `POST /mandate/:id/grants` — **add** — PIN-gated issuance (re-signs the mandate with the grant); mirrors `issue`/`revoke`.
+
+---
+
+## 1. Over-block
+
+The grant store is the ALLOW side (it clears a floor action). Over-allow, not over-block, is the risk here — see §4. No legitimate input is wrongly blocked: absent a valid grant, the gate's pre-existing behavior (owner authorizes floor / others refused) is unchanged.
+
+## 2. Under-block (the real risk for an allow-path)
+
+The danger is honoring a grant that shouldn't be honored. Mitigations, all enforced before a grant clears a floor:
+- The mandate's `authProof` must verify (the grant is part of the signed bytes — a forged/added grant fails).
+- The mandate must not be revoked and not be expired.
+- The grant itself must not be expired, and its `expiresAt` is clamped to never exceed the mandate's `expiresAt` (a grant cannot outlive its delegation — enforced at `addGrants` AND at `issue`).
+- Match is exact on `grantedTo` (slackUserId) and `floorAction` (no substring/coercion).
+Deny-by-default: any check failing → no grant returned.
+
+## 3. Level-of-abstraction fit
+
+Correct. The mandate is already the audited, HMAC-signed authority primitive (requester ≠ authorizer; PIN-gated issuance). User→agent grants are a natural extension of the same signed object — NOT a new parallel authority. The gate consumes grants via the existing `GrantStore` interface (Slice 0), so this is the consume side of an established seam.
+
+## 4. Signal vs authority compliance
+
+**Required reference:** docs/signal-vs-authority.md. This IS an authority (a grant clears a floor action), and it is NOT brittle:
+- A grant only has force if it is covered by the mandate's HMAC `authProof`, which is only produced by the PIN-gated issuance path (`MandateStore.sign`). An agent cannot mint or widen its own grant.
+- `MandateBackedGrantStore` verifies authorship BEFORE trusting `grants` — it never reads a grant off an unverified mandate.
+- The expiry clamp + revoke + mandate-expiry checks are deterministic (no LLM, no heuristic in the authorization path). Fail-closed.
+
+## 5. Interactions
+
+- **Backward-compat (the #1 interaction):** existing signed mandates have no `grants` field; `canonicalMandate()` appends grants ONLY when present + non-empty, so a no-grant mandate serializes byte-for-byte as before → every previously-signed mandate (incl. Dawn's live ones) still verifies. Proven by the backward-compat test (legacy on-disk mandate with no `grants` key verifies TRUE) + the append-only guard in `issue()`.
+- **Two `MandateStore` instances:** the gate (built in `commands/server.ts` before AgentServer) uses a second, stateless, READ-ONLY `MandateStore` reader over the same file with the same HMAC derivation (`config.authToken`). It only reads/verifies — no writes — so there's no write race; the writer is the AgentServer/route path.
+- **Audit:** every grant decision (allow on accept, deny on reject) is recorded through the existing hash-chained `MandateAudit`.
+
+## 6. External surfaces
+
+- **Other agents / install base:** none by default — no grants exist until an operator mints one on the PIN-gated route; the Slack gate is dark/observe-only. Pure no-op for existing agents.
+- **External systems:** none (no new outbound calls).
+- **Persistent state:** grants live inside the existing `state/coordination-mandates.json` (no new state file); the field is optional + append-only-when-non-empty.
+- **HTTP:** one new PIN-gated route `POST /mandate/:id/grants` (registered INTERNAL in CapabilityIndex + documented).
+
+## 7. Rollback cost
+
+Low / additive. Back-out = revert + patch. Because `canonicalMandate` is append-only-when-non-empty, reverting it does NOT invalidate existing no-grant mandates. The only durable artifact is grants inside mandates; if reverted, a grant-bearing mandate would fail to verify (its proof covers grants the reverted code wouldn't serialize) — but NO deployed mandate carries grants yet, so there is no live signed-grant data to break. No agent-state repair needed for the no-grant fleet.
+
+## Phase 5 — Second-pass review (independent, adversarial)
+
+REQUIRED (authority/signing crypto). An independent reviewer attempted to forge a grant, break backward-compat, and escape the expiry/revoke checks. Verdict appended below.
+
+### Verdict: CONCUR — no exploitable issue found (independent adversarial review)
+
+The reviewer attempted 9 distinct attacks against the live source (forge-a-grant, backward-compat break, expiry-clamp escape, revoke/expiry bypass, privilege confusion, issuance-auth bypass) via a standalone probe script + the full test suite, and could not land an exploit:
+- **Forge:** `MandateBackedGrantStore.activeGrant` calls `verifyAuthorship(mandate)` BEFORE reading `mandate.grants` — no path trusts grants off an unverified mandate; a re-signed-with-attacker-key mandate is rejected by the HMAC `timingSafeEqual`.
+- **Backward-compat:** `grants` undefined / `[]` / no-key all canonicalize byte-identically to the pre-extension baseline; a legacy on-disk no-grant mandate verifies TRUE.
+- **Expiry/revoke:** `activeGrant` skips revoked + expired mandates and past-expiry grants; the effective expiry is `min(grant, mandate)`.
+- **Privilege confusion:** strict `!==` equality on `grantedTo` + `floorAction` (no substring/coercion).
+- **Issuance auth:** `POST /mandate/:id/grants` is PIN-gated (same timing-safe gate as issue/revoke); Bearer-only → 403.
+
+**One hardening the reviewer flagged — IMPLEMENTED in this change:** the `issue()` library path originally did not enforce the `grant.expiresAt <= mandate.expiresAt` clamp that `addGrants()` does (it was unreachable from any untrusted surface — the issue route drops grants — and neutralized by the query-side clamp, so "hardening, not a blocker"). To make the library contract uniformly safe for any future caller, `issue()` now applies the same validation + clamp (throws on an over-long or malformed grant), covered by a new test (`issue() with grants applies the SAME expiry clamp as addGrants`). Total unit tests: 20.


### PR DESCRIPTION
## What & why

Lets a verified operator grant a SPECIFIC floor authority to a SPECIFIC Slack user, **signed into the Coordination Mandate** so it can't be forged. This completes the Slack-permission floor-authorization path: the gate's `GrantStore.activeGrant(slackUserId, scope, now)` now has a production, signature-backed implementation. Dark/no-op until an operator mints a grant (the Slack gate that consumes it is observe-only).

## The security-critical change (`canonicalMandate()`)
Grants are folded into the bytes the mandate's HMAC `authProof` covers — but **append-only-when-non-empty**: a mandate with no grants (`grants` undefined OR `[]`) serializes **byte-for-byte identically** to before this extension existed, so **every previously-signed mandate (including Dawn's live ones) still verifies**. A grant only has force if covered by the proof, and only the PIN-gated re-sign path produces the proof.

## Changes
- `src/coordination/types.ts` — `UserAuthorityGrant` + optional `grants?` on `CoordinationMandate`
- `src/coordination/MandateStore.ts` — `canonicalMandate()` append-only-when-non-empty; `addGrants()` re-sign path; `issue()` carries grants — **both `addGrants` and `issue` enforce `grant.expiresAt <= mandate.expiresAt`** (a grant can't outlive its delegation)
- `src/permissions/MandateBackedGrantStore.ts` (new) — deny-by-default; verifies `authProof` BEFORE reading grants; checks mandate-revoke + mandate-expiry + grant-expiry; effective expiry = `min(grant, mandate)`
- `src/server/routes.ts` — PIN-gated `POST /mandate/:id/grants` (same timing-safe gate as issue/revoke); audited via `MandateAudit`
- `src/server/CapabilityIndex.ts`, `src/permissions/index.ts`, `src/commands/server.ts` (wiring)

## Independent adversarial second-pass (Phase 5 — signing/authority crypto)
**CONCUR — no exploitable issue found.** An independent reviewer attempted 9 attacks (forge a grant, backward-compat break, expiry-clamp escape, revoke/expiry bypass, privilege confusion, issuance-auth bypass) via a standalone probe script + the test suite, and could not land an exploit. The one hardening it flagged — `issue()` didn't enforce the expiry clamp `addGrants()` does (unreachable from untrusted surfaces; neutralized by the query-side clamp) — **is implemented in this PR** (with a dedicated test) so the library contract is uniformly safe. Full verdict in `upgrades/side-effects/mandate-user-grants.md`.

## Tests
20 unit (incl. **backward-compat**: legacy no-grant mandate verifies TRUE; **forged-grant tamper**: a grant added without re-signing → verification FALSE; expiry-clamp on both `addGrants` and `issue`; revoke/expiry bypass; privilege-confusion) + integration (PIN-gated route, deny without PIN) + e2e. `tsc --noEmit` clean; lint clean; 130/130 in the related coordination/permission sweep.

## ELI16
The agent already has a tamper-proof permission slip the operator issues (the Coordination Mandate — signed, audited, PIN-gated). This change lets a slip also say "this specific Slack person may do this specific high-risk action, until this date" — folded into the signature so nobody can fake it or add it without re-signing through the PIN-gated path. The gate then reads those signed grants to decide if a non-owner may do a floor action; no valid grant → refused, exactly as before. The most important safety property: a mandate with no grants is signed exactly as it was before, so every permission slip already out there (including the ones shared with Dawn) keeps verifying — proven by a test that signs a no-grant mandate the OLD way and confirms it still verifies. A grant can never outlive its slip, expired/revoked slips yield nothing, and it's all deny-by-default. It changes nothing until the operator mints a grant (PIN-gated) and the Slack gate is enabled, and it ships with an independent adversarial security review because it's signing/authority crypto.

🤖 Generated with [Claude Code](https://claude.com/claude-code)