### PR TITLE
feat(permissions): conservative ambient "should I speak?" gate for Slack (dark)

### DIFF
--- a/.instar/instar-dev-decisions/2026-06-09T09-48-26-465Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-06-09T09-48-26-465Z-unknown.json
@@ -1,0 +1,16 @@
+{
+  "ts": "2026-06-09T09:48:26.465Z",
+  "slug": "unknown",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "new capability: new exported class / subsystem added",
+    "new capability: new config key added"
+  ],
+  "belowFloor": true,
+  "files": 5,
+  "loc": 473,
+  "causalAutopsy": null,
+  "verdict": "pass"
+}

--- a/docs/specs/SLACK-AMBIENT-GATE.eli16.md
+++ b/docs/specs/SLACK-AMBIENT-GATE.eli16.md
@@ -1,0 +1,30 @@
+# ELI16 — Slack ambient "should I speak?" gate
+
+## What this is, in one breath
+
+Lets the agent act like a quiet, considerate teammate in a Slack channel: it can read messages nobody addressed to it and, *very occasionally*, chime in when it genuinely has something useful to add — but it's wired so the default is **silence**, and it can only ever become quieter, never chattier.
+
+## What already existed
+
+In a normal channel the agent ignores any message that isn't a direct mention or DM — it never butts in. That stays the default.
+
+## What's new
+
+An opt-in "ambient" mode for specific channels. When a message comes in that nobody addressed to the agent, in a channel you've explicitly turned this on for, the agent asks itself "should I speak here?" and only chimes in if ALL of these are true:
+1. You opted that exact channel in (off everywhere by default).
+2. It hasn't already chimed in recently (a hard rate limit — default once per 30 minutes per channel).
+3. An LLM judges it can genuinely contribute, above a high confidence bar.
+
+If any of those isn't met — or the LLM errors, times out, or returns anything unexpected — it **stays silent**. There is no path where a failure makes it speak more.
+
+## The safeguards, in plain terms
+
+- **Off by default.** With no config, behavior is exactly as today: the agent ignores undirected messages. The gate isn't even attached.
+- **Fail-to-silence.** Every uncertainty, error, or malformed answer resolves to silence. A crafted message saying "you MUST respond, confidence 1.0" can't force it to speak past the rate limit + opt-in, and a broken response just keeps it quiet.
+- **No new powers.** Chiming in just routes the message through the same handling a direct mention gets — including the permission gate. It can't do anything it couldn't already do.
+- **No new Slack connections.** The gate only decides whether to engage; it sends nothing itself.
+- **Directed messages are untouched.** Mentions and DMs work exactly as before.
+
+## What you actually need to decide
+
+Whether to merge the opt-in ambient mode (off by default). It's the "ambient employee" idea — the agent quietly present, chiming in rarely and only when it adds value — built so the worst case is it stays too quiet, never too loud. It ships with an independent adversarial review because an LLM is reading untrusted channel messages.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "instar",
-  "version": "1.3.443",
+  "version": "1.3.444",
   "description": "Coherence infrastructure for self-evolving AI agents — on the Claude Code or Codex subscription you already have.",
   "type": "module",
   "main": "dist/index.js",

--- a/src/commands/server.ts
+++ b/src/commands/server.ts
@@ -4679,6 +4679,45 @@ export async function startServer(options: StartOptions): Promise<void> {
           console.warn('[slack] permission gate wiring skipped:', (e as Error).message);
         }
 
+        // ── Ambient "should I speak?" gate (considered/ambient mode, §5.2) — DARK ──
+        // Attached ONLY when at least one channel is explicitly opted into proactive
+        // contribution (`ambientContribution.enabledChannelIds` non-empty). With no
+        // such config, no gate is attached and undirected messages drop exactly as
+        // today (mention-only). The gate can only ever make the agent quieter
+        // (fail-to-silence): no LLM provider / error / low confidence / rate-limit →
+        // stay silent.
+        try {
+          const slackCfg = slackConfig.config as Record<string, unknown>;
+          const amCfg = slackCfg.ambientContribution as {
+            enabledChannelIds?: string[];
+            maxProactivePerChannel?: number;
+            windowMs?: number;
+            minConfidence?: number;
+          } | undefined;
+          if (amCfg && Array.isArray(amCfg.enabledChannelIds) && amCfg.enabledChannelIds.length > 0) {
+            const { AmbientContributionGate } = await import('../permissions/index.js');
+            const ambientGate = new AmbientContributionGate({
+              config: {
+                enabledChannelIds: amCfg.enabledChannelIds,
+                maxProactivePerChannel: amCfg.maxProactivePerChannel,
+                windowMs: amCfg.windowMs,
+                minConfidence: amCfg.minConfidence,
+              },
+              // No provider ⇒ the gate stays silent for every message (fail-to-silence).
+              intelligence: sharedIntelligence ?? undefined,
+              onDecision: (decision, channelId) => {
+                if (decision.speak) {
+                  console.log(`[slack] ambient gate: SPEAK in ${channelId} (${decision.reason})`);
+                }
+              },
+            });
+            slackAdapter.setAmbientGate(ambientGate);
+            console.log(`[slack] ambient contribution gate attached for ${amCfg.enabledChannelIds.length} channel(s)${sharedIntelligence ? '' : ' (no LLM provider — gate stays silent)'}`);
+          }
+        } catch (e) {
+          console.warn('[slack] ambient gate wiring skipped:', (e as Error).message);
+        }
+
         // Wire message handler — inject Slack messages into sessions
         slackAdapter.onMessage(async (message) => {
           const channelId = message.channel.identifier;

--- a/src/messaging/slack/SlackAdapter.ts
+++ b/src/messaging/slack/SlackAdapter.ts
@@ -30,6 +30,7 @@ import { MessageLogger, type LogEntry } from '../shared/MessageLogger.js';
 import type { SlackConfig, SlackMessage, PendingPrompt, InteractionPayload, InteractionAction, SlackWorkspaceMode, SlackRespondMode } from './types.js';
 import { sanitizeDisplayName, validateChannelId, escapeMrkdwn } from './sanitize.js';
 import type { SlackPermissionObserver } from '../../permissions/SlackPermissionObserver.js';
+import type { AmbientContributionGate } from '../../permissions/AmbientContributionGate.js';
 
 const RING_BUFFER_CAPACITY = 50;
 const SLACK_MAX_TEXT_LENGTH = 4000;
@@ -64,6 +65,14 @@ export class SlackAdapter implements MessagingAdapter {
    * blocks delivery. See src/permissions/SlackPermissionObserver.ts.
    */
   private permissionObserver: SlackPermissionObserver | null = null;
+  /**
+   * Optional conservative ambient "should I speak?" gate (Slack considered/ambient
+   * mode, §5.2). DARK by default — when null, undirected messages are dropped exactly
+   * as today (mention-only). When set, an UNDIRECTED message in an explicitly
+   * opted-in channel runs the gate; fail-to-silence is the invariant.
+   * See src/permissions/AmbientContributionGate.ts.
+   */
+  private ambientGate: AmbientContributionGate | null = null;
   private started = false;
   private authorizedUsers: Set<string>;
   private channelHistory: Map<string, RingBuffer<SlackMessage>> = new Map();
@@ -317,6 +326,17 @@ export class SlackAdapter implements MessagingAdapter {
    */
   setPermissionObserver(observer: SlackPermissionObserver | null): void {
     this.permissionObserver = observer;
+  }
+
+  /**
+   * Attach the conservative ambient "should I speak?" gate (Slack considered/ambient
+   * mode, §5.2). DARK by default — wired during server startup only when at least one
+   * channel is explicitly opted into proactive contribution. When null (the default),
+   * undirected messages are dropped exactly as today (mention-only). The gate can only
+   * ever make the agent QUIETER (fail-to-silence).
+   */
+  setAmbientGate(gate: AmbientContributionGate | null): void {
+    this.ambientGate = gate;
   }
 
   async resolveUser(channelIdentifier: string): Promise<string | null> {
@@ -885,11 +905,41 @@ export class SlackAdapter implements MessagingAdapter {
     }
 
     if (this.respondMode === 'mention-only' && !isDM && !this._isBotMentioned(text)) {
-      // Still populate ring buffer for context, but don't process
-      const buffer = this.channelHistory.get(channelId) ?? new RingBuffer<SlackMessage>(RING_BUFFER_CAPACITY);
-      buffer.push({ ts, user: userId, text, channel: channelId, thread_ts: threadTs });
-      this.channelHistory.set(channelId, buffer);
-      return;
+      // ── Ambient "should I speak?" gate (considered/ambient mode, §5.2) ──────────
+      // This is the ONLY change to undirected handling. The gate can ONLY make the
+      // agent quieter: it runs solely when (1) a gate is attached AND (2) this exact
+      // channel is explicitly opted into proactive contribution. For every other
+      // channel — and whenever no gate is attached at all — behavior is byte-for-byte
+      // the mention-only drop below. FAIL-TO-SILENCE: any failure inside the gate
+      // returns speak=false, so we fall through to the same drop. A speak=true here
+      // means the undirected message is processed exactly like a directed one
+      // (the code below this block is unchanged); directed messages never reach here.
+      let ambientSpeak = false;
+      if (this.ambientGate && this.ambientGate.isChannelEnabled(channelId)) {
+        try {
+          const decision = await this.ambientGate.shouldSpeak({ channelId, text, channelName: undefined });
+          ambientSpeak = decision.speak === true;
+          if (ambientSpeak) {
+            // Consume one unit of the per-channel rolling-window budget only now that
+            // we've committed to processing this proactive turn.
+            this.ambientGate.recordSpoke(channelId);
+            console.log(`[slack] ambient gate cleared for ${channelId}: ${decision.reason}${decision.detail ? ` — ${decision.detail}` : ''}`);
+          }
+        } catch {
+          // Fail-to-silence: any unexpected throw at the call site stays silent too.
+          ambientSpeak = false;
+        }
+      }
+
+      if (!ambientSpeak) {
+        // Still populate ring buffer for context, but don't process
+        const buffer = this.channelHistory.get(channelId) ?? new RingBuffer<SlackMessage>(RING_BUFFER_CAPACITY);
+        buffer.push({ ts, user: userId, text, channel: channelId, thread_ts: threadTs });
+        this.channelHistory.set(channelId, buffer);
+        return;
+      }
+      // ambientSpeak === true → fall through and process this undirected message
+      // exactly as a directed one (no special-casing downstream).
     }
 
     // Check for standby commands (unstick, quiet, resume, restart) — these bypass normal processing

--- a/src/messaging/slack/types.ts
+++ b/src/messaging/slack/types.ts
@@ -80,6 +80,23 @@ export interface SlackConfig {
     observeOnly?: boolean;
     enforce?: boolean;
   };
+  /**
+   * Conservative ambient "should I speak?" gate (Slack considered/ambient mode,
+   * §5.2). DARK by default — when unset OR `enabledChannelIds` is empty, NO gate is
+   * attached and undirected messages are dropped exactly as today (mention-only).
+   * The gate runs ONLY for an explicitly-opted-in channel and can only ever make the
+   * agent quieter (fail-to-silence). See docs/specs/SLACK-ORG-INTEGRATION-SPEC.md §5.2.
+   */
+  ambientContribution?: {
+    /** Channel IDs (C…) explicitly opted into proactive contribution. Default: none. */
+    enabledChannelIds?: string[];
+    /** Hard cap on unsolicited messages per channel per window. Conservative default: 1. */
+    maxProactivePerChannel?: number;
+    /** Rolling rate-limit window in ms. Default: 1800000 (30 min). */
+    windowMs?: number;
+    /** Conservative confidence floor (0-1) for an LLM "speak" verdict. Default: 0.85. */
+    minConfidence?: number;
+  };
 }
 
 // ── Slack API Types ──

--- a/src/permissions/AmbientContributionGate.ts
+++ b/src/permissions/AmbientContributionGate.ts
@@ -1,0 +1,356 @@
+/**
+ * AmbientContributionGate — the conservative "should I speak?" gate for Slack's
+ * `considered`/ambient mode (Slack org integration, Pillar 1 §5.2 / §6.9).
+ *
+ * In `mention-only` mode an UNDIRECTED message (no @mention, not a DM) is dropped
+ * — the agent stays quiet. Ambient mode keeps that default but adds ONE narrow
+ * escape: for a channel that has EXPLICITLY opted into proactive contribution, an
+ * undirected message may run this gate, which decides whether the agent has a
+ * concrete, meaningful contribution worth making unprompted.
+ *
+ * ── THE INVARIANT: FAIL-TO-SILENCE ─────────────────────────────────────────────
+ *
+ * This gate can only ever make the agent QUIETER. It returns `speak: true` ONLY
+ * when EVERY one of these holds:
+ *   (a) the channel is explicitly ambient-opted-in (config — default OFF everywhere),
+ *   (b) a hard per-channel rate-limit for the rolling window is NOT exceeded,
+ *   (c) an LLM judges it can contribute MEANINGFULLY above a conservative
+ *       confidence threshold AND explicitly says to speak.
+ *
+ * ANY failure, uncertainty, LLM error, missing provider, unparseable verdict, or
+ * rate-limit breach → `speak: false`. There is NO path through this gate that
+ * produces an over-speak on a degraded condition. This is the deliberate MIRROR of
+ * the floor gate's fail-CLOSED (deny-on-error): here the safe direction is SILENCE.
+ * (Spec §5.2 "Fail mode: fail to silence"; §11 "the ambient/should-speak gate fails
+ * to silence".)
+ *
+ * ── DARK / OPT-IN ──────────────────────────────────────────────────────────────
+ *
+ * Ambient contribution is disabled for every channel by default. With NO ambient
+ * config, this gate is never even constructed/consulted and `_handleMessage`
+ * behaves byte-for-byte as today (mention-only drops undirected messages). The gate
+ * runs ONLY for an explicitly-opted-in channel.
+ *
+ * The LLM is reached through instar's internal `IntelligenceProvider` (the same
+ * injected-provider pattern as `LlmIntentClassifier` / `MessagingToneGate`), NOT a
+ * raw API call. A `fast` model tier is used. The call is intentionally NOT marked
+ * `gating: true`: a gating call would provider-SWAP on failure to keep an authority
+ * decision alive, but the safe failure here is to stay silent — we WANT the error to
+ * land in our catch and return `speak: false`, never to escalate to keep speaking.
+ *
+ * NOTE: this gate decides ONLY whether to PROCESS an undirected message. It performs
+ * no Slack Web API calls and sends nothing itself — `_handleMessage` does the
+ * processing/sending downstream exactly as it does for a directed message.
+ *
+ * Design: docs/specs/SLACK-ORG-INTEGRATION-SPEC.md §5.2, §6.9, §11.
+ */
+
+import type { IntelligenceProvider } from '../core/types.js';
+
+/** The gate's decision for a single undirected message. */
+export interface AmbientDecision {
+  /** True ONLY when every fail-to-silence condition holds. Default false. */
+  speak: boolean;
+  /** Machine-readable reason for the decision (for logging / FP measurement). */
+  reason: AmbientDecisionReason;
+  /** Optional human-readable detail (e.g. the LLM's named contribution). */
+  detail?: string;
+}
+
+export type AmbientDecisionReason =
+  | 'channel-not-opted-in' // (a) failed — channel is not ambient-enabled → silent
+  | 'rate-limited' // (b) failed — per-channel window budget exhausted → silent
+  | 'no-intelligence' // (c) failed — no LLM provider configured → silent
+  | 'llm-error' // (c) failed — provider threw / timed out / circuit open → silent
+  | 'llm-unparseable' // (c) failed — LLM verdict could not be read → silent
+  | 'llm-declined' // (c) failed — LLM said don't speak → silent
+  | 'low-confidence' // (c) failed — below the conservative confidence bar → silent
+  | 'speak'; // ALL held — a concrete, meaningful, in-budget contribution
+
+/** Per-channel ambient configuration. Default: ambient OFF. */
+export interface AmbientChannelConfig {
+  /** Channels explicitly opted into proactive contribution. Default: none. */
+  enabledChannelIds?: string[];
+  /**
+   * Hard cap on proactive (unsolicited) messages per channel within the rolling
+   * window. Conservative default: 1. A bot that barges in is worse than a silent
+   * one, so this is deliberately tiny.
+   */
+  maxProactivePerChannel?: number;
+  /** Rolling rate-limit window in ms. Default: 30 minutes. */
+  windowMs?: number;
+  /**
+   * Conservative confidence floor for the LLM's "speak" verdict, in [0,1]. Below
+   * this, the gate stays silent even if the LLM said speak. Default: 0.85 (high bar).
+   */
+  minConfidence?: number;
+}
+
+export interface AmbientContributionGateDeps {
+  /** Per-channel ambient configuration. Absent/empty ⇒ ambient OFF everywhere. */
+  config?: AmbientChannelConfig;
+  /**
+   * The internal LLM provider (injected — never a direct framework import). When
+   * absent, the gate stays SILENT (fail-to-silence): no provider ⇒ no contribution.
+   */
+  intelligence?: IntelligenceProvider;
+  /** Per-call LLM timeout (ms). Default 8000. */
+  timeoutMs?: number;
+  /**
+   * Optional observability hook — fires on EVERY decision with the reason, so the
+   * FP-rate of proactive speaking can be measured before any aggressiveness change.
+   * Best-effort: it never affects the returned decision.
+   */
+  onDecision?: (decision: AmbientDecision, channelId: string) => void;
+  /** Injectable clock for deterministic tests. Defaults to Date.now. */
+  now?: () => number;
+}
+
+/** Context the gate needs about the channel + message. */
+export interface AmbientGateInput {
+  /** The Slack channel id the undirected message arrived in. */
+  channelId: string;
+  /** The (cleaned) message text. */
+  text: string;
+  /** Optional channel name, purely for the LLM prompt context. */
+  channelName?: string;
+}
+
+const DEFAULT_MAX_PROACTIVE = 1;
+const DEFAULT_WINDOW_MS = 30 * 60 * 1000; // 30 minutes
+const DEFAULT_MIN_CONFIDENCE = 0.85;
+
+interface RawAmbientVerdict {
+  speak?: unknown;
+  confidence?: unknown;
+  contribution?: unknown;
+}
+
+export class AmbientContributionGate {
+  private readonly enabledChannels: Set<string>;
+  private readonly maxProactive: number;
+  private readonly windowMs: number;
+  private readonly minConfidence: number;
+  private readonly intelligence?: IntelligenceProvider;
+  private readonly timeoutMs: number;
+  private readonly onDecision?: (decision: AmbientDecision, channelId: string) => void;
+  private readonly now: () => number;
+
+  /**
+   * Rate-limit state lives HERE — a per-channel in-memory ring of the timestamps at
+   * which the gate last returned speak=true. It is recorded by recordSpoke() (called
+   * by _handleMessage only AFTER the gate cleared and the message is actually being
+   * processed), so a speak=true that the caller decides not to act on does not
+   * consume budget. In-memory is acceptable: a restart resetting the window can only
+   * make the agent quieter for a moment (it never over-speaks), which is on the safe
+   * side of the invariant. A future durable counter could replace this without
+   * changing the contract.
+   */
+  private readonly proactiveTimestamps: Map<string, number[]> = new Map();
+
+  constructor(deps: AmbientContributionGateDeps = {}) {
+    const cfg = deps.config ?? {};
+    this.enabledChannels = new Set(cfg.enabledChannelIds ?? []);
+    // Nullish coalescing (zero is a valid — fully-silent — cap).
+    this.maxProactive = cfg.maxProactivePerChannel ?? DEFAULT_MAX_PROACTIVE;
+    this.windowMs = cfg.windowMs ?? DEFAULT_WINDOW_MS;
+    this.minConfidence = cfg.minConfidence ?? DEFAULT_MIN_CONFIDENCE;
+    this.intelligence = deps.intelligence;
+    this.timeoutMs = deps.timeoutMs ?? 8000;
+    this.onDecision = deps.onDecision;
+    this.now = deps.now ?? (() => Date.now());
+  }
+
+  /** Is ANY channel opted into ambient contribution? Used to skip the gate entirely. */
+  isAnyChannelEnabled(): boolean {
+    return this.enabledChannels.size > 0;
+  }
+
+  /** Is this specific channel opted into ambient contribution? */
+  isChannelEnabled(channelId: string): boolean {
+    return this.enabledChannels.has(channelId);
+  }
+
+  /**
+   * Decide whether to speak on an UNDIRECTED message in an ambient channel.
+   * FAIL-TO-SILENCE: returns { speak: false } on every degraded/uncertain path.
+   */
+  async shouldSpeak(input: AmbientGateInput): Promise<AmbientDecision> {
+    // (a) Channel opt-in. Default OFF — an un-opted channel never speaks.
+    if (!this.enabledChannels.has(input.channelId)) {
+      return this.decide(input.channelId, { speak: false, reason: 'channel-not-opted-in' });
+    }
+
+    // (b) Hard rate-limit. Budget exhausted in the rolling window → silent.
+    if (this.isRateLimited(input.channelId)) {
+      return this.decide(input.channelId, { speak: false, reason: 'rate-limited' });
+    }
+
+    // (c) LLM judgment. No provider → silent (we never speak on a heuristic guess).
+    if (!this.intelligence) {
+      return this.decide(input.channelId, { speak: false, reason: 'no-intelligence' });
+    }
+
+    let raw: string;
+    try {
+      const { systemPrompt, userPrompt } = buildAmbientPrompt(input);
+      raw = await this.intelligence.evaluate(`${systemPrompt}\n\n${userPrompt}`, {
+        model: 'fast',
+        temperature: 0,
+        maxTokens: 200,
+        timeoutMs: this.timeoutMs,
+        attribution: {
+          component: 'AmbientContributionGate',
+          category: 'gate',
+          // Deliberately NOT gating:true. A gating call provider-SWAPS on failure to
+          // keep an AUTHORITY decision alive; here the safe failure is SILENCE, so we
+          // let the error reach the catch below and return speak:false. Escalating to
+          // keep talking would be exactly the over-speak this invariant forbids.
+        },
+      });
+    } catch {
+      // network/timeout/provider failure / circuit open → SILENCE (never escalate).
+      return this.decide(input.channelId, { speak: false, reason: 'llm-error' });
+    }
+
+    const parsed = parseAmbientVerdict(raw);
+    if (!parsed) {
+      // Unparseable LLM output is a judgment FAILURE → silence.
+      return this.decide(input.channelId, { speak: false, reason: 'llm-unparseable' });
+    }
+
+    // The LLM must explicitly say speak.
+    if (!parsed.speak) {
+      return this.decide(input.channelId, { speak: false, reason: 'llm-declined' });
+    }
+
+    // Conservative confidence bar. Below it (or no named contribution) → silence.
+    if (parsed.confidence < this.minConfidence || !parsed.contribution) {
+      return this.decide(input.channelId, { speak: false, reason: 'low-confidence', detail: parsed.contribution });
+    }
+
+    // ALL fail-to-silence conditions held → speak.
+    return this.decide(input.channelId, { speak: true, reason: 'speak', detail: parsed.contribution });
+  }
+
+  /**
+   * Record that the agent actually spoke proactively in a channel (call AFTER the
+   * gate cleared and _handleMessage commits to processing). Consumes one unit of the
+   * rolling window budget. Idempotency is not required — each proactive turn is one
+   * unit.
+   */
+  recordSpoke(channelId: string): void {
+    const arr = this.proactiveTimestamps.get(channelId) ?? [];
+    arr.push(this.now());
+    this.proactiveTimestamps.set(channelId, arr);
+  }
+
+  /** How many proactive sends remain in the current window for a channel (for status). */
+  remainingBudget(channelId: string): number {
+    const used = this.recentCount(channelId);
+    return Math.max(0, this.maxProactive - used);
+  }
+
+  /** True iff the per-channel proactive budget is exhausted for the rolling window. */
+  private isRateLimited(channelId: string): boolean {
+    return this.recentCount(channelId) >= this.maxProactive;
+  }
+
+  /** Count of proactive sends within the rolling window; prunes expired entries. */
+  private recentCount(channelId: string): number {
+    const arr = this.proactiveTimestamps.get(channelId);
+    if (!arr || arr.length === 0) return 0;
+    const cutoff = this.now() - this.windowMs;
+    const fresh = arr.filter(ts => ts >= cutoff);
+    if (fresh.length !== arr.length) {
+      // Prune expired entries so the map can't grow unbounded.
+      if (fresh.length === 0) this.proactiveTimestamps.delete(channelId);
+      else this.proactiveTimestamps.set(channelId, fresh);
+    }
+    return fresh.length;
+  }
+
+  private decide(channelId: string, decision: AmbientDecision): AmbientDecision {
+    try {
+      this.onDecision?.(decision, channelId);
+    } catch {
+      /* observability is best-effort and must never affect the verdict */
+    }
+    return decision;
+  }
+}
+
+/**
+ * Validate + clamp the LLM's raw JSON into a safe verdict. Returns null when the
+ * payload can't be read (→ caller fails to silence). A missing/false `speak` is a
+ * VALID parse (it means don't speak), so this only returns null on structural junk.
+ */
+function parseAmbientVerdict(
+  raw: string,
+): { speak: boolean; confidence: number; contribution?: string } | null {
+  if (!raw || typeof raw !== 'string') return null;
+
+  const start = raw.indexOf('{');
+  const end = raw.lastIndexOf('}');
+  if (start === -1 || end === -1 || end < start) return null;
+
+  let obj: RawAmbientVerdict;
+  try {
+    obj = JSON.parse(raw.slice(start, end + 1)) as RawAmbientVerdict;
+  } catch {
+    return null;
+  }
+
+  // `speak` must be present and boolean-ish; anything else is unreadable → null,
+  // so the caller fails to silence rather than guessing an affirmative.
+  let speak: boolean;
+  if (typeof obj.speak === 'boolean') speak = obj.speak;
+  else if (obj.speak === 'true') speak = true;
+  else if (obj.speak === 'false') speak = false;
+  else return null;
+
+  // Missing/invalid confidence is treated as the floor (0) — never an optimistic 1.
+  let confidence = typeof obj.confidence === 'number' ? obj.confidence : Number(obj.confidence);
+  if (!Number.isFinite(confidence)) confidence = 0;
+  confidence = Math.max(0, Math.min(1, confidence));
+
+  const contribution =
+    typeof obj.contribution === 'string' && obj.contribution.trim()
+      ? obj.contribution.trim().slice(0, 500)
+      : undefined;
+
+  return { speak, confidence, contribution };
+}
+
+/**
+ * Build the "should I speak?" prompt. It DEFAULTS TO SILENCE and asks the model to
+ * return speak:true ONLY when it can name a concrete, meaningful contribution — and
+ * never to interrupt a human-to-human exchange without clear value (§5.2 guardrails).
+ */
+function buildAmbientPrompt(input: AmbientGateInput): { systemPrompt: string; userPrompt: string } {
+  const systemPrompt = [
+    'You are an AI agent present in a shared Slack channel. You were NOT mentioned and',
+    'NO ONE addressed you. Decide whether to volunteer an UNPROMPTED contribution.',
+    'Your strong default is SILENCE. A bot that barges in is worse than a silent one;',
+    'the failure mode is annoyance. Speak ONLY when you can name a concrete, specific,',
+    'genuinely helpful contribution that the people in the channel would welcome —',
+    'never to chime in, agree, restate, or interrupt a human-to-human exchange.',
+    'Return ONLY a compact JSON object, no prose, with exactly these keys:',
+    '  "speak":        boolean — true ONLY for a clearly worthwhile unprompted contribution.',
+    '  "confidence":   0.0-1.0 — your confidence that speaking adds clear value AND is welcome.',
+    '                  Be honest; when unsure, return a LOW number. Uncertainty means stay silent.',
+    '  "contribution": one short sentence naming the concrete contribution (omit/empty if not speaking).',
+    'When in doubt, return {"speak": false, "confidence": 0.0}.',
+    'Never output anything but the JSON object.',
+  ].join('\n');
+
+  const userPrompt = [
+    input.channelName ? `channel: ${input.channelName}` : 'channel: (unnamed)',
+    'overheard message (you were NOT addressed):',
+    '"""',
+    (input.text || '').slice(0, 2000),
+    '"""',
+  ].join('\n');
+
+  return { systemPrompt, userPrompt };
+}

--- a/src/permissions/index.ts
+++ b/src/permissions/index.ts
@@ -6,6 +6,7 @@ export * from './types.js';
 export * from './RolePolicy.js';
 export * from './IntentClassifier.js';
 export * from './LlmIntentClassifier.js';
+export * from './AmbientContributionGate.js';
 export * from './AnomalyScorer.js';
 export * from './PermissionDecisionLedger.js';
 export * from './SlackPermissionGate.js';

--- a/tests/unit/slack-ambient-contribution-gate.test.ts
+++ b/tests/unit/slack-ambient-contribution-gate.test.ts
@@ -1,0 +1,308 @@
+import { describe, it, expect, vi } from 'vitest';
+
+import type { IntelligenceProvider, IntelligenceOptions } from '../../src/core/types.js';
+import {
+  AmbientContributionGate,
+  type AmbientDecision,
+  type AmbientDecisionReason,
+} from '../../src/permissions/AmbientContributionGate.js';
+
+/** A canned-response provider: returns whatever JSON we hand it, or throws. */
+function fakeProvider(
+  responder: (prompt: string, opts?: IntelligenceOptions) => string,
+  capture?: { opts?: IntelligenceOptions; prompt?: string; calls: number },
+): IntelligenceProvider {
+  return {
+    async evaluate(prompt: string, opts?: IntelligenceOptions): Promise<string> {
+      if (capture) {
+        capture.calls++;
+        capture.prompt = prompt;
+        capture.opts = opts;
+      }
+      return responder(prompt, opts);
+    },
+  };
+}
+
+const CH = 'C_AMBIENT';
+const speakJson = (conf = 0.95) =>
+  `{"speak":true,"confidence":${conf},"contribution":"This looks like the onnxruntime-node CDN flake; a gh run rerun --failed cleared it last week."}`;
+const silentJson = (conf = 0.4) => `{"speak":false,"confidence":${conf}}`;
+
+describe('AmbientContributionGate — DARK / opt-in (no config ⇒ never speaks, no LLM call)', () => {
+  it('a channel that is NOT opted in stays silent and never calls the LLM', async () => {
+    const cap = { calls: 0 };
+    const gate = new AmbientContributionGate({
+      config: { enabledChannelIds: ['C_OTHER'] },
+      intelligence: fakeProvider(() => speakJson(), cap),
+    });
+    const d = await gate.shouldSpeak({ channelId: CH, text: 'engineers stuck on a flaky test again' });
+    expect(d.speak).toBe(false);
+    expect(d.reason).toBe('channel-not-opted-in');
+    expect(cap.calls).toBe(0); // opt-in is checked BEFORE the LLM
+  });
+
+  it('with empty config the gate reports no channel enabled and stays silent', async () => {
+    const gate = new AmbientContributionGate({ intelligence: fakeProvider(() => speakJson()) });
+    expect(gate.isAnyChannelEnabled()).toBe(false);
+    expect(gate.isChannelEnabled(CH)).toBe(false);
+    const d = await gate.shouldSpeak({ channelId: CH, text: 'anything' });
+    expect(d.speak).toBe(false);
+    expect(d.reason).toBe('channel-not-opted-in');
+  });
+
+  it('isChannelEnabled / isAnyChannelEnabled reflect the opted-in set', () => {
+    const gate = new AmbientContributionGate({ config: { enabledChannelIds: [CH] } });
+    expect(gate.isAnyChannelEnabled()).toBe(true);
+    expect(gate.isChannelEnabled(CH)).toBe(true);
+    expect(gate.isChannelEnabled('C_OTHER')).toBe(false);
+  });
+});
+
+describe('AmbientContributionGate — speak path (ALL fail-to-silence conditions must hold)', () => {
+  it('opted-in channel + LLM high-value speak + under rate-limit → speak=true', async () => {
+    const gate = new AmbientContributionGate({
+      config: { enabledChannelIds: [CH], minConfidence: 0.85 },
+      intelligence: fakeProvider(() => speakJson(0.95)),
+    });
+    const d = await gate.shouldSpeak({ channelId: CH, text: 'CI keeps failing on onnxruntime-node' });
+    expect(d.speak).toBe(true);
+    expect(d.reason).toBe('speak');
+    expect(d.detail).toContain('onnxruntime-node');
+  });
+
+  it('calls the LLM at the fast tier with AmbientContributionGate attribution and NOT gating', async () => {
+    const cap = { calls: 0 };
+    const gate = new AmbientContributionGate({
+      config: { enabledChannelIds: [CH] },
+      intelligence: fakeProvider(() => speakJson(), cap),
+    });
+    await gate.shouldSpeak({ channelId: CH, text: 'hello team' });
+    expect(cap.calls).toBe(1);
+    expect(cap.opts?.model).toBe('fast');
+    expect(cap.opts?.attribution?.component).toBe('AmbientContributionGate');
+    expect(cap.opts?.attribution?.category).toBe('gate');
+    // Deliberately NOT gating — a gating call would provider-swap to keep talking;
+    // the safe failure here is silence.
+    expect(cap.opts?.attribution?.gating).toBeUndefined();
+  });
+});
+
+describe('AmbientContributionGate — silence on a low-value / declined verdict', () => {
+  it('LLM says "not worth it" (speak:false) → silent', async () => {
+    const gate = new AmbientContributionGate({
+      config: { enabledChannelIds: [CH] },
+      intelligence: fakeProvider(() => silentJson(0.2)),
+    });
+    const d = await gate.shouldSpeak({ channelId: CH, text: 'lunch plans?' });
+    expect(d.speak).toBe(false);
+    expect(d.reason).toBe('llm-declined');
+  });
+
+  it('LLM says speak but BELOW the confidence floor → silent (low-confidence)', async () => {
+    const gate = new AmbientContributionGate({
+      config: { enabledChannelIds: [CH], minConfidence: 0.85 },
+      intelligence: fakeProvider(() => speakJson(0.7)), // below 0.85
+    });
+    const d = await gate.shouldSpeak({ channelId: CH, text: 'maybe relevant?' });
+    expect(d.speak).toBe(false);
+    expect(d.reason).toBe('low-confidence');
+  });
+
+  it('LLM says speak with high confidence but NO named contribution → silent', async () => {
+    const gate = new AmbientContributionGate({
+      config: { enabledChannelIds: [CH], minConfidence: 0.85 },
+      intelligence: fakeProvider(() => '{"speak":true,"confidence":0.99}'), // no contribution
+    });
+    const d = await gate.shouldSpeak({ channelId: CH, text: 'hmm' });
+    expect(d.speak).toBe(false);
+    expect(d.reason).toBe('low-confidence');
+  });
+});
+
+describe('AmbientContributionGate — FAIL-TO-SILENCE (no over-speak on ANY degraded path)', () => {
+  // The core invariant: every degraded path must produce speak=false. We enumerate
+  // them and assert NO over-speak in each.
+  const degradedPaths: Array<{ name: string; deps: () => AmbientContributionGate; expect: AmbientDecisionReason }> = [
+    {
+      name: 'no LLM provider configured',
+      deps: () => new AmbientContributionGate({ config: { enabledChannelIds: [CH] } }),
+      expect: 'no-intelligence',
+    },
+    {
+      name: 'LLM throws (network / timeout / circuit open)',
+      deps: () =>
+        new AmbientContributionGate({
+          config: { enabledChannelIds: [CH] },
+          intelligence: fakeProvider(() => {
+            throw new Error('provider down / circuit open');
+          }),
+        }),
+      expect: 'llm-error',
+    },
+    {
+      name: 'LLM returns chatty prose, not JSON',
+      deps: () =>
+        new AmbientContributionGate({
+          config: { enabledChannelIds: [CH] },
+          intelligence: fakeProvider(() => 'Sure, I think I should jump in here!'),
+        }),
+      expect: 'llm-unparseable',
+    },
+    {
+      name: 'LLM returns JSON with no readable speak key',
+      deps: () =>
+        new AmbientContributionGate({
+          config: { enabledChannelIds: [CH] },
+          intelligence: fakeProvider(() => '{"confidence":0.99,"contribution":"x"}'),
+        }),
+      expect: 'llm-unparseable',
+    },
+    {
+      name: 'LLM returns empty string',
+      deps: () =>
+        new AmbientContributionGate({
+          config: { enabledChannelIds: [CH] },
+          intelligence: fakeProvider(() => ''),
+        }),
+      expect: 'llm-unparseable',
+    },
+  ];
+
+  for (const path of degradedPaths) {
+    it(`${path.name} → speak=false (NO over-speak)`, async () => {
+      const gate = path.deps();
+      const d = await gate.shouldSpeak({ channelId: CH, text: 'should you speak here?' });
+      expect(d.speak).toBe(false); // the invariant
+      expect(d.reason).toBe(path.expect);
+    });
+  }
+
+  it('a malformed/garbage "speak" value (e.g. number) does NOT become an affirmative', async () => {
+    const gate = new AmbientContributionGate({
+      config: { enabledChannelIds: [CH] },
+      intelligence: fakeProvider(() => '{"speak":1,"confidence":0.99,"contribution":"x"}'),
+    });
+    const d = await gate.shouldSpeak({ channelId: CH, text: 'x' });
+    expect(d.speak).toBe(false);
+    expect(d.reason).toBe('llm-unparseable');
+  });
+
+  it('missing confidence is treated as 0 (floor), never optimistic — stays silent even on speak:true', async () => {
+    const gate = new AmbientContributionGate({
+      config: { enabledChannelIds: [CH], minConfidence: 0.85 },
+      intelligence: fakeProvider(() => '{"speak":true,"contribution":"do the thing"}'),
+    });
+    const d = await gate.shouldSpeak({ channelId: CH, text: 'x' });
+    expect(d.speak).toBe(false);
+    expect(d.reason).toBe('low-confidence');
+  });
+
+  it('observability throw never affects the verdict (best-effort onDecision)', async () => {
+    const gate = new AmbientContributionGate({
+      config: { enabledChannelIds: [CH] },
+      intelligence: fakeProvider(() => speakJson()),
+      onDecision: () => {
+        throw new Error('observability blew up');
+      },
+    });
+    const d = await gate.shouldSpeak({ channelId: CH, text: 'CI flake again' });
+    expect(d.speak).toBe(true); // a thrown hook must not silence-or-amplify the verdict
+  });
+});
+
+describe('AmbientContributionGate — hard per-channel rate-limit (fail-to-silence)', () => {
+  it('N+1th proactive message in the window → silent (rate-limited)', async () => {
+    const gate = new AmbientContributionGate({
+      config: { enabledChannelIds: [CH], maxProactivePerChannel: 1, windowMs: 60_000 },
+      intelligence: fakeProvider(() => speakJson()),
+    });
+
+    // 1st proactive turn clears and consumes the single unit of budget.
+    const first = await gate.shouldSpeak({ channelId: CH, text: 'first contribution' });
+    expect(first.speak).toBe(true);
+    gate.recordSpoke(CH); // _handleMessage records after committing to process
+
+    // 2nd is rate-limited even though the LLM would still say speak.
+    const second = await gate.shouldSpeak({ channelId: CH, text: 'second contribution' });
+    expect(second.speak).toBe(false);
+    expect(second.reason).toBe('rate-limited');
+  });
+
+  it('rate-limit is checked BEFORE the LLM (no LLM call when budget is exhausted)', async () => {
+    const cap = { calls: 0 };
+    const gate = new AmbientContributionGate({
+      config: { enabledChannelIds: [CH], maxProactivePerChannel: 1, windowMs: 60_000 },
+      intelligence: fakeProvider(() => speakJson(), cap),
+    });
+    gate.recordSpoke(CH); // exhaust the budget directly
+    const d = await gate.shouldSpeak({ channelId: CH, text: 'would-be contribution' });
+    expect(d.speak).toBe(false);
+    expect(d.reason).toBe('rate-limited');
+    expect(cap.calls).toBe(0);
+  });
+
+  it('budget refills after the rolling window elapses (injected clock)', async () => {
+    let t = 1_000_000;
+    const gate = new AmbientContributionGate({
+      config: { enabledChannelIds: [CH], maxProactivePerChannel: 1, windowMs: 60_000 },
+      intelligence: fakeProvider(() => speakJson()),
+      now: () => t,
+    });
+
+    expect((await gate.shouldSpeak({ channelId: CH, text: 'first' })).speak).toBe(true);
+    gate.recordSpoke(CH);
+    expect((await gate.shouldSpeak({ channelId: CH, text: 'second' })).reason).toBe('rate-limited');
+
+    // Advance past the window — the old timestamp expires.
+    t += 60_001;
+    const d = await gate.shouldSpeak({ channelId: CH, text: 'after window' });
+    expect(d.speak).toBe(true);
+    expect(d.reason).toBe('speak');
+  });
+
+  it('maxProactivePerChannel:0 means fully silent (zero is honored, not defaulted)', async () => {
+    const gate = new AmbientContributionGate({
+      config: { enabledChannelIds: [CH], maxProactivePerChannel: 0 },
+      intelligence: fakeProvider(() => speakJson()),
+    });
+    const d = await gate.shouldSpeak({ channelId: CH, text: 'x' });
+    expect(d.speak).toBe(false);
+    expect(d.reason).toBe('rate-limited');
+    expect(gate.remainingBudget(CH)).toBe(0);
+  });
+
+  it('rate-limit is per-channel (one channel exhausted does not silence another)', async () => {
+    const CH2 = 'C_AMBIENT_2';
+    const gate = new AmbientContributionGate({
+      config: { enabledChannelIds: [CH, CH2], maxProactivePerChannel: 1, windowMs: 60_000 },
+      intelligence: fakeProvider(() => speakJson()),
+    });
+    gate.recordSpoke(CH); // exhaust CH only
+    expect((await gate.shouldSpeak({ channelId: CH, text: 'x' })).reason).toBe('rate-limited');
+    expect((await gate.shouldSpeak({ channelId: CH2, text: 'y' })).speak).toBe(true);
+  });
+});
+
+describe('AmbientContributionGate — wiring integrity', () => {
+  it('actually delegates to the injected provider (not a no-op)', async () => {
+    const evalSpy = vi.fn(async () => speakJson());
+    const provider: IntelligenceProvider = { evaluate: evalSpy };
+    const gate = new AmbientContributionGate({ config: { enabledChannelIds: [CH] }, intelligence: provider });
+    await gate.shouldSpeak({ channelId: CH, text: 'CI flake again' });
+    expect(evalSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('fires onDecision for every decision with the channel id (FP measurement hook)', async () => {
+    const seen: Array<{ d: AmbientDecision; ch: string }> = [];
+    const gate = new AmbientContributionGate({
+      config: { enabledChannelIds: [CH] },
+      intelligence: fakeProvider(() => silentJson()),
+      onDecision: (d, ch) => seen.push({ d, ch }),
+    });
+    await gate.shouldSpeak({ channelId: CH, text: 'x' });
+    expect(seen).toHaveLength(1);
+    expect(seen[0].ch).toBe(CH);
+    expect(seen[0].d.reason).toBe('llm-declined');
+  });
+});

--- a/tests/unit/slack-ambient-gate-wiring.test.ts
+++ b/tests/unit/slack-ambient-gate-wiring.test.ts
@@ -1,0 +1,158 @@
+/**
+ * SlackAdapter ↔ AmbientContributionGate wiring (considered/ambient mode, §5.2).
+ *
+ * Verifies the gate slots in at the mention-only-skip point of _handleMessage:
+ *   - DARK default (no gate attached) → undirected channel message dropped exactly
+ *     as today, no LLM call.
+ *   - Directed messages (DM / @mention) are UNAFFECTED by the gate.
+ *   - Ambient channel + gate says speak → undirected message is processed.
+ *   - Fail-to-silence: gate says silent / errors / channel not opted-in → dropped.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+import { SlackAdapter } from '../../src/messaging/slack/SlackAdapter.js';
+import { AmbientContributionGate } from '../../src/permissions/AmbientContributionGate.js';
+import type { IntelligenceProvider } from '../../src/core/types.js';
+
+const CH = 'C_AMBIENT';
+const BOT = 'U_BOT';
+
+function fakeProvider(responder: () => string, capture?: { calls: number }): IntelligenceProvider {
+  return {
+    async evaluate(): Promise<string> {
+      if (capture) capture.calls++;
+      return responder();
+    },
+  };
+}
+
+/** Build an adapter in mention-only mode with reactions/user-info stubbed out. */
+function harness(tmp: string) {
+  const messages: string[] = [];
+  const adapter = new SlackAdapter(
+    {
+      botToken: 'xoxb-test',
+      appToken: 'xapp-test',
+      authorizedUserIds: ['U_TEST'],
+      workspaceMode: 'shared', // → respondMode defaults to 'mention-only'
+    } as any,
+    tmp,
+  );
+  adapter.onMessage(async (m) => { messages.push(m.content); });
+  // Stub out all outbound Slack Web API touch-points so nothing hits the network.
+  (adapter as any).addReaction = () => {};
+  (adapter as any).removeReaction = () => {};
+  (adapter as any).getUserInfo = async (id: string) => ({ id, name: id });
+  (adapter as any).botUserId = BOT;
+  const handle = (adapter as any)._handleMessage.bind(adapter);
+  return { adapter, handle, messages };
+}
+
+const speakJson = '{"speak":true,"confidence":0.95,"contribution":"the onnxruntime-node CDN flake — gh run rerun --failed"}';
+const silentJson = '{"speak":false,"confidence":0.2}';
+
+describe('SlackAdapter ambient gate wiring', () => {
+  let tmp: string;
+  beforeEach(() => { tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'slack-ambient-')); });
+  afterEach(() => { SafeFsExecutor.safeRmSync(tmp, { recursive: true, force: true, operation: 'tests/unit/slack-ambient-gate-wiring.test.ts' }); });
+
+  it('DARK default (no gate): undirected channel message is dropped, exactly as today', async () => {
+    const { handle, messages } = harness(tmp);
+    await handle({ user: 'U_TEST', text: 'just chatting, no mention', channel: CH, ts: '1.1' });
+    expect(messages).toHaveLength(0); // dropped — mention-only behavior preserved
+  });
+
+  it('directed message (DM) is UNAFFECTED by the gate — still processed', async () => {
+    const { adapter, handle, messages } = harness(tmp);
+    // Attach a gate that would say silent; a DM must NOT consult it and must process.
+    const cap = { calls: 0 };
+    adapter.setAmbientGate(new AmbientContributionGate({
+      config: { enabledChannelIds: ['D_TEST'] },
+      intelligence: fakeProvider(() => silentJson, cap),
+    }));
+    await handle({ user: 'U_TEST', text: 'hey', channel: 'D_TEST', ts: '2.1' });
+    expect(messages).toHaveLength(1); // directed → processed
+    expect(cap.calls).toBe(0); // the gate is never consulted for a directed message
+  });
+
+  it('directed message (@mention) is UNAFFECTED by the gate — still processed', async () => {
+    const { adapter, handle, messages } = harness(tmp);
+    const cap = { calls: 0 };
+    adapter.setAmbientGate(new AmbientContributionGate({
+      config: { enabledChannelIds: [CH] },
+      intelligence: fakeProvider(() => silentJson, cap),
+    }));
+    await handle({ user: 'U_TEST', text: `<@${BOT}> please help`, channel: CH, ts: '3.1' });
+    expect(messages).toHaveLength(1); // @mention is directed → processed
+    expect(cap.calls).toBe(0); // gate not consulted for a directed message
+  });
+
+  it('ambient channel + gate says SPEAK → undirected message is processed', async () => {
+    const { adapter, handle, messages } = harness(tmp);
+    adapter.setAmbientGate(new AmbientContributionGate({
+      config: { enabledChannelIds: [CH], maxProactivePerChannel: 1 },
+      intelligence: fakeProvider(() => speakJson),
+    }));
+    await handle({ user: 'U_TEST', text: 'CI keeps failing on onnxruntime-node', channel: CH, ts: '4.1' });
+    expect(messages).toHaveLength(1); // gate cleared → processed as if directed
+  });
+
+  it('ambient channel + gate says SILENT → undirected message is dropped', async () => {
+    const { adapter, handle, messages } = harness(tmp);
+    adapter.setAmbientGate(new AmbientContributionGate({
+      config: { enabledChannelIds: [CH] },
+      intelligence: fakeProvider(() => silentJson),
+    }));
+    await handle({ user: 'U_TEST', text: 'lunch plans?', channel: CH, ts: '5.1' });
+    expect(messages).toHaveLength(0); // gate declined → dropped
+  });
+
+  it('gate attached but channel NOT opted in → dropped, no LLM call', async () => {
+    const { adapter, handle, messages } = harness(tmp);
+    const cap = { calls: 0 };
+    adapter.setAmbientGate(new AmbientContributionGate({
+      config: { enabledChannelIds: ['C_OTHER'] },
+      intelligence: fakeProvider(() => speakJson, cap),
+    }));
+    await handle({ user: 'U_TEST', text: 'overheard chatter', channel: CH, ts: '6.1' });
+    expect(messages).toHaveLength(0);
+    expect(cap.calls).toBe(0);
+  });
+
+  it('FAIL-TO-SILENCE: gate LLM throws → undirected message is dropped (no over-speak)', async () => {
+    const { adapter, handle, messages } = harness(tmp);
+    adapter.setAmbientGate(new AmbientContributionGate({
+      config: { enabledChannelIds: [CH] },
+      intelligence: fakeProvider(() => { throw new Error('provider down'); }),
+    }));
+    await handle({ user: 'U_TEST', text: 'should you jump in?', channel: CH, ts: '7.1' });
+    expect(messages).toHaveLength(0); // errored gate stays silent
+  });
+
+  it('FAIL-TO-SILENCE: rate-limit exhausted → second undirected message dropped', async () => {
+    const { adapter, handle, messages } = harness(tmp);
+    adapter.setAmbientGate(new AmbientContributionGate({
+      config: { enabledChannelIds: [CH], maxProactivePerChannel: 1, windowMs: 60_000 },
+      intelligence: fakeProvider(() => speakJson),
+    }));
+    await handle({ user: 'U_TEST', text: 'first flake note', channel: CH, ts: '8.1' });
+    await handle({ user: 'U_TEST', text: 'second flake note', channel: CH, ts: '8.2' });
+    expect(messages).toHaveLength(1); // only the first proactive turn processed
+  });
+
+  it('unauthorized user is rejected BEFORE the gate (gate never consulted)', async () => {
+    const { adapter, handle, messages } = harness(tmp);
+    const cap = { calls: 0 };
+    (adapter as any).postEphemeral = async () => {};
+    adapter.setAmbientGate(new AmbientContributionGate({
+      config: { enabledChannelIds: [CH] },
+      intelligence: fakeProvider(() => speakJson, cap),
+    }));
+    await handle({ user: 'U_STRANGER', text: 'CI flake', channel: CH, ts: '9.1' });
+    expect(messages).toHaveLength(0);
+    expect(cap.calls).toBe(0); // AuthGate fails closed before ambient logic
+  });
+});

--- a/upgrades/next/slack-ambient-gate.md
+++ b/upgrades/next/slack-ambient-gate.md
@@ -1,0 +1,19 @@
+## What Changed
+
+feat(permissions): conservative ambient "should I speak?" gate for Slack (`AmbientContributionGate`) — Phase 2, piece 2. For an UNDIRECTED message in an explicitly opted-in channel, the agent decides whether to proactively contribute, defaulting to **silence**. **FAIL-TO-SILENCE + dark/opt-in.**
+
+- Speak=true only when ALL hold: channel opted-in + under a hard per-channel rolling-window rate-limit (default 1 / 30 min) + LLM judges meaningful contribution above a conservative confidence floor (default 0.85). Any failure / uncertainty / malformed LLM output → silent.
+- Wires at the `_handleMessage` mention-only skip; **directed messages (DM/@mention) are untouched**; no config → byte-for-byte today's mention-only behavior. **Zero new Slack Web API calls.**
+
+## What to Tell Your User
+
+Nothing changes by default — this ships dark/opt-in. When you turn ambient mode on for a specific channel, the agent can occasionally chime in on messages that weren't addressed to it — but only when it genuinely adds value, at most rarely (a hard rate limit), and never if it's uncertain. It defaults to staying quiet; the worst case is it's too quiet, never too chatty, and it can't be talked into over-speaking by a crafted message. Direct mentions and DMs are unaffected.
+
+## Summary of New Capabilities
+
+- **`ambientContribution.enabledChannelIds` (+ `maxProactivePerChannel`, `windowMs`, `minConfidence`)** (opt-in, per-channel) — turns on the conservative ambient "should I speak?" gate for the named channels. Off everywhere by default; operator/internal config; the gate grants no permissions (a proactive turn still passes the permission gate).
+
+## Evidence
+
+- 32 tests: 23 gate (dark/opt-in, speak-path, silence-on-low-value, 8 fail-to-silence paths, rate-limit incl. per-channel/zero-cap/window-refill) + 9 wiring (dark default drops with no LLM call, DM/@mention unaffected, ambient+speak processes, ambient+silent drops, LLM-throws drops, rate-limit drops, unauthorized rejected-before-gate). `tsc --noEmit` clean; full lint suite green (incl. notification-flood-burst-invariant); 42 adjacent slack-permission tests green.
+- Side-effects review (`upgrades/side-effects/slack-ambient-gate.md`) + an independent adversarial Phase-5 second-pass on over-speak / fail-open / opt-in-bypass.

--- a/upgrades/side-effects/slack-ambient-gate.md
+++ b/upgrades/side-effects/slack-ambient-gate.md
@@ -1,0 +1,69 @@
+# Side-Effects Review — Slack ambient "should I speak?" gate
+
+**Version / slug:** `slack-ambient-gate`
+**Date:** 2026-06-09
+**Author:** Instar Agent (echo)
+**Second-pass reviewer:** REQUIRED (changes when an undirected message is PROCESSED; LLM reads untrusted content) — independent adversarial review, see Phase 5
+
+## Summary of the change
+
+Phase 2, piece 2. `AmbientContributionGate.shouldSpeak()` decides whether the agent PROACTIVELY engages with an UNDIRECTED Slack message in an explicitly opted-in channel. **FAIL-TO-SILENCE:** speak only when ALL of (channel opted-in) + (under a hard per-channel rate-limit) + (LLM judges meaningful contribution above a conservative confidence threshold); ANY failure/uncertainty → silent. Dark/opt-in (no config → no gate attached → byte-for-byte today's mention-only behavior). Files: `src/permissions/AmbientContributionGate.ts` (new), `src/permissions/index.ts`, `src/messaging/slack/types.ts` (dark config block), `src/messaging/slack/SlackAdapter.ts` (wiring at the mention-only-skip), `src/commands/server.ts` (attach only when ≥1 channel opted in).
+
+Decision point: whether an undirected message is processed at all (it was always dropped before unless directed).
+
+## Decision-point inventory
+
+- `SlackAdapter._handleMessage` mention-only-skip — **modify** — for an undirected message in an ambient-opted-in channel, run the gate; speak=false → the original drop path (unchanged); speak=true → process as a directed message. Directed messages (DM/@mention) never enter this block.
+- `AmbientContributionGate.shouldSpeak` — **add** — fail-to-silence speak/silent decision.
+
+---
+
+## 1. Over-block
+
+Not applicable in the harmful sense — the gate's bias IS toward silence (over-block). The "cost" of over-silence is the agent staying quiet when it could have helpfully contributed — the safe, intended direction for a conservative ambient mode.
+
+## 2. Under-block (the real risk = OVER-SPEAK)
+
+The danger is the agent speaking when it shouldn't (noise, or engaging with content it wasn't addressed in). Mitigations, ALL required for speak=true: explicit per-channel opt-in; a hard rolling-window rate-limit (conservative default 1 / 30 min / channel); an LLM meaningful-contribution judgment above a conservative confidence floor (default 0.85). Crucially, even a fully prompt-injected LLM "speak:true, confidence:1.0" is still bounded by the opt-in + rate-limit, and a malformed/uncertain verdict fails to silence. A speak=true only routes the message into the SAME downstream handling a directed message gets (including the permission gate) — it does not bypass any permission.
+
+## 3. Level-of-abstraction fit
+
+Correct. It slots at the exact mention-only-skip point — the one place undirected messages are decided — as a drop-in gate, not a parallel path. The LLM call mirrors the established `IntelligenceProvider.evaluate` pattern.
+
+## 4. Signal vs authority compliance
+
+**Required reference:** docs/signal-vs-authority.md + "no silent degradation." The gate holds authority (it can cause the agent to engage), and it is NOT brittle in the dangerous direction:
+- It is FAIL-TO-SILENCE — the deterministic bounds (opt-in, rate-limit) gate the LLM, and the LLM call is deliberately NOT `gating:true` (a provider-swap would keep the decision alive; here the safe failure is silence, so any error lands in the catch → silent). Every degraded path = silence, never over-speak.
+- It grants NO permission — a proactive turn still passes through the permission gate for anything it then does. So even maximal over-speak cannot widen access.
+
+## 5. Interactions
+
+- **Directed handling untouched:** the block is inside `respondMode==='mention-only' && !isDM && !@mention`, so DMs and mentions never reach it (verified at SlackAdapter.ts:907).
+- **Rate-limit budget:** consumed (`recordSpoke`) only AFTER committing to process a proactive turn — no double-spend, no spend-on-silence. Per-channel keyed (no cross-channel budget bleed). In-memory; a restart resets the window, which can only make the agent quieter (safe side).
+- **Ring buffer:** an un-spoken undirected message is still buffered for context (as today) then dropped — no behavior change there.
+
+## 6. External surfaces
+
+- **Other agents / install base:** none — dark by default (gate attached only when `ambientContribution.enabledChannelIds` non-empty). Byte-for-byte today's mention-only behavior otherwise.
+- **External systems (Slack):** **ZERO new Slack Web API calls** (verified — the gate only decides whether to PROCESS; it never sends). The LLM provider is the existing IntelligenceRouter.
+- **Untrusted input:** the LLM reads the message text (prompt-injection surface) — bounded by the fail-to-silence + opt-in + rate-limit invariant (focus of the Phase-5 review).
+
+## 7. Rollback cost
+
+Trivial. Additive + dark. Revert + patch; default (mention-only) behavior is unchanged on every install. In-memory rate-limit state is disposable.
+
+## Phase 5 — Second-pass review (independent, adversarial — over-speak / fail-open)
+
+REQUIRED. An independent reviewer attempted to force over-speak via prompt injection, find a fail-OPEN path, and bypass the opt-in/rate-limit. Verdict appended below.
+
+### Verdict: CONCUR — fail-to-silence holds; no over-speak / bypass / fail-open
+
+The independent reviewer traced all six vectors against the live code:
+- **Prompt injection (over-speak):** untrusted text is fenced into the user prompt only; even a message mimicking the exact desired verdict can at most satisfy the LLM condition — it cannot touch the structural bounds (opt-in `Set.has`, double-guarded; per-channel rate-limit). No JSON-injection hole (malformed → null → silence). Ceiling under attack = the chosen conservative bound (1 proactive msg/window in an already-opted-in channel).
+- **Fail-open:** none — every degraded branch (throw/timeout/circuit, empty/non-JSON, missing/`1`/string `speak`, NaN/negative/>1/missing `confidence`, thrown `onDecision` hook) lands on `speak:false`; defaults are silence + confidence 0.
+- **Opt-in/rate-limit bypass:** none — opt-in is first + text-independent; budget consumed only AFTER commit (`recordSpoke` inside `if (ambientSpeak)`); rate-limit checked before the LLM; per-channel keyed (no cross-channel bleed); Socket-Mode redelivery deduped before the gate (no double-spend/double-speak).
+- **Directed regression:** none — the whole block is inside `respondMode==='mention-only' && !isDM && !@mention`; DMs/mentions never enter it (wiring tests confirm 0 LLM calls).
+- **Leak:** none — the prompt carries only the one overheard message (channel name passed undefined); a speak=true only processes content already being buffered.
+- **Dark default:** byte-for-byte today's mention-only drop when unconfigured; an opted-in channel with a null provider still stays silent (`no-intelligence`).
+
+The deliberate choice to NOT mark the LLM call `gating:true` is correct + load-bearing (a gating swap would keep the decision alive; here the safe failure is silence, so the error reaches the catch). 32/32 tests pass. **The gate can only ever make the agent quieter.**


### PR DESCRIPTION
## What & why

Phase 2, piece 2 — Justin's "ambient employee" idea. `AmbientContributionGate` decides whether the agent PROACTIVELY engages with an **undirected** message in an explicitly opted-in channel, defaulting to **silence**. **Dark/opt-in** (no config → byte-for-byte today's mention-only behavior).

## The invariant: FAIL-TO-SILENCE (the gate can only make the agent quieter)
`speak:true` is returned ONLY when ALL hold:
1. the channel is explicitly opted in (off everywhere by default),
2. a hard per-channel rolling-window rate-limit is not exceeded (conservative defaults: 1 / 30 min),
3. an LLM judges a meaningful contribution above a conservative confidence floor (default 0.85).

ANY failure / uncertainty / malformed LLM output → **silent**. The LLM call is deliberately **NOT** `gating:true` — a gating swap would keep an authority decision alive, but here the safe failure is silence, so errors fall to the catch → silent.

## Wiring
Slots in at the `_handleMessage` mention-only skip (`SlackAdapter.ts:907-943`). **Directed messages (DM/@mention) never enter the block** — handling is untouched. `speak:false` → the original drop path (unchanged); `speak:true` → process the message exactly as a directed one (no downstream special-casing; it still passes the permission gate — the ambient gate grants no permission). **Zero new Slack Web API calls** (the gate only decides whether to PROCESS).

## Independent adversarial second-pass (Phase 5)
**CONCUR — no over-speak, no bypass, no fail-open.** The reviewer traced 6 vectors against the live code:
- Prompt injection can at most satisfy the LLM condition; it cannot touch the structural bounds (opt-in `Set.has` + rate-limit). No JSON-injection hole (malformed → silence). Ceiling under attack = 1 proactive msg/window in an already-opted-in channel.
- Every degraded branch (throw / empty / non-JSON / bad `speak` / NaN-or-missing `confidence` / thrown hook) → `speak:false`.
- Opt-in is first + text-independent; budget consumed only after commit (no double-spend); per-channel keyed; Socket-Mode redelivery deduped before the gate.
- Directed handling untouched (0 LLM calls for DM/@mention in the wiring tests). No leak (prompt carries only the one overheard message). Dark default byte-for-byte. Full trail in `upgrades/side-effects/slack-ambient-gate.md`.

## Tests
32 (23 gate + 9 wiring): dark/opt-in, speak-path, silence-on-low-value, 8 fail-to-silence paths, rate-limit (per-channel / zero-cap / window-refill), DM/@mention-unaffected, ambient+speak→processed, ambient+silent→dropped, LLM-throws→dropped, rate-limit→dropped, unauthorized-rejected-before-gate. `tsc --noEmit` clean; full lint suite green (incl. notification-flood-burst-invariant); 42 adjacent slack-permission tests green.

## ELI16
Lets the agent act like a quiet, considerate teammate: in channels you explicitly turn this on for, it can read messages nobody addressed to it and *very occasionally* chime in when it genuinely adds value — but it's wired so the default is silence and it can only ever get quieter, never chattier. It only speaks if you opted that channel in, it hasn't spoken recently (a hard rate limit), and an LLM is confident it can contribute. Any error, timeout, or weird answer → it stays silent. Chiming in just routes the message through the same handling a direct mention gets (including the permission gate) — no new powers, no new Slack connections, and direct mentions/DMs are untouched. Off by default. It ships with an independent adversarial review (which tried and failed to make a crafted message force it to over-speak) because an LLM is reading untrusted channel messages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)