### PR TITLE
feat(permissions): deepen Slack relationship-anomaly baseline-poisoning resistance (observe-only, dark)

### DIFF
--- a/.instar/instar-dev-decisions/2026-06-09T19-06-23-356Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-06-09T19-06-23-356Z-unknown.json
@@ -1,0 +1,13 @@
+{
+  "ts": "2026-06-09T19:06:23.356Z",
+  "slug": "unknown",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 3,
+  "loc": 510,
+  "causalAutopsy": null,
+  "verdict": "pass"
+}

--- a/docs/specs/SLACK-ORG-INTEGRATION-SPEC.md
+++ b/docs/specs/SLACK-ORG-INTEGRATION-SPEC.md
@@ -325,6 +325,20 @@ Dawn has actually stress-tested relationship infrastructure; ours exists but has
 
 The anomaly detector ships **dark / observe-only**: it logs would-be step-ups and scores against real traffic so we can measure its false-positive rate before it ever interrupts a real request. Nothing in Pillar 3 gates until the FP rate is known-good.
 
+### 7.7 Baseline-poisoning resistance (Phase-3 adversarial follow-ups)
+
+The behavioral baseline is the thing an attacker would attack. The threat: a *patient attacker* or *slowly-compromised account* injects many normal-looking observations (and/or a burst) to reshape the baseline so a later out-of-character request scores low. Three additive, backward-compatible, observe-only hardenings defend it. All are config-driven with conservative defaults and **never lower** a bar — they only ever *add* resistance (a hardening must never disarm a signal the pre-hardening cumulative baseline would have fired).
+
+- **#1 Share-floor out-of-character (already landed):** the out-of-character signal fires when the requested action's *share* of history is below `rareActionShareFloor` (default 0.10), not only when never-seen — so seeding a single prior observation can't zero out a `seen===0` check and disable the highest-weight signal.
+
+- **#2 Recency / decay weighting:** `RelationshipBehaviorStore` keeps optional time-bucketed history (one bucket per rolling window, `bucketMs`, default 1 day). At scoring time the scorer computes a *decayed view* — bucket counts weighted by `0.5^(ageWindows / decayHalfLifeWindows)` (default half-life 30 windows) plus the pre-bucketing "legacy base" at full weight. Each established signal evaluates **both** the cumulative view and the decayed view and fires on the *more anomalous* one. This makes a one-time burst **non-durable** (once the attacker stops and genuine traffic resumes, the burst decays back below the floor and the signal re-arms) while preserving the whole-relationship rarity the cumulative view encodes (which a rate-capped burst cannot erase). A pre-hardening profile (no buckets) yields a decayed view *identical* to its cumulative form — perfect backward-compat.
+
+- **#3a Minimum-baseline-AGE for "established":** a baseline counts as "established" only when **both** `interactionCount >= establishedMin` (default 5) **and** `firstSeen` is older than `minBaselineAgeDays` (default 7) — so a high-COUNT but YOUNG baseline (a rapid burst) is *not* trusted: the action/tier/style signals stay suppressed and confidence is capped at `low`. An attacker can't manufacture a trusted baseline in a burst. Set `minBaselineAgeDays: 0` to restore the legacy count-only behavior.
+
+- **#3b Per-principal observation-rate cap:** the store caps observations RECORDED per principal per rolling window (`maxObservationsPerWindow`, default 50/window). Excess observations in the window are **dropped** (logged via `onCapDrop`, not recorded — the cumulative counts are not touched either, so the buckets-sum invariant holds). One session can't hammer the histogram to shift it; combined with #1 this keeps a burst's *share* small relative to an established baseline so the share-floor signal survives. Set a non-positive value to disable.
+
+Config surface (`permissionGate.relationshipAnomaly.poisoningResistance`, all optional): `minBaselineAgeDays`, `maxObservationsPerWindow`, `decayHalfLifeWindows`, `bucketMs`. Defaults are baked into the store/scorer; absence preserves shipped behavior. The SHAPE-only / privacy / observe-only / never-lower invariants of §7.1–7.4 are unchanged.
+
 ---
 
 ## 8. Pillar 4 — Demonstration & verification (test-as-self for Slack)

--- a/docs/specs/slack-anomaly-poisoning-resistance.eli16.md
+++ b/docs/specs/slack-anomaly-poisoning-resistance.eli16.md
@@ -1,0 +1,43 @@
+# Slack Anomaly Baseline-Poisoning Resistance — Plain-English Overview
+
+> The one-line version: we make it much harder for a bad actor to slowly "train" a person's behavior profile so that a later out-of-character request (like an urgent money transfer at 3am) sneaks past as normal.
+
+## The problem in one breath
+
+Instar's Slack permission system learns what each person *normally* does — what kinds of requests, at what hours, how long their messages are — and quietly notices when a new request feels off (this only watches and logs today; it never blocks). But a learned profile is itself a target: a patient attacker, or someone whose Slack account got compromised, could feed the system lots of normal-looking activity (or one big burst) to reshape that profile, so the suspicious request that comes later no longer looks suspicious. This change closes three ways that "training the profile" attack could work.
+
+## What already exists
+
+- **The behavioral baseline** — a small, privacy-respecting record per person of the *shape* of their requests (which action, which sensitivity tier, what hour, how long the message, whether it sounded urgent). It never stores the actual message text. It is fed only from real, directed requests, and it ships off by default.
+- **The anomaly scorer** — reads that baseline and produces a 0-to-1 "this feels out of character" score with plain reasons, across five signals (out-of-character action, tier escalation, odd hour, sudden urgency, unusual message length). It is a *detector*: it raises a flag, it does not block anything.
+- **The permission gate** — the one place that actually decides allow / refuse / step-up. The anomaly score can only ever ask it to *raise* the bar on a request that would otherwise be allowed; it can never lower a bar. The whole thing is observe-only right now (decisions are logged, not enforced) so we can measure how often it false-alarms before it's ever turned on.
+- **The first poisoning fix (already shipped)** — the out-of-character signal now fires when an action is *rare* for a person, not only when it's literally never been seen — so seeding a single fake prior request can't switch that signal off.
+
+## What this adds
+
+Three more defenses, all additive and all still observe-only. The headline one: the scorer now looks at a person's history through **two lenses at once** — their whole-relationship history AND a recency-weighted "lately" view — and treats a request as anomalous if it looks off through *either* lens. This is deliberately a "can only add suspicion, never remove it" rule, so the new logic can never accidentally make a previously-flagged request look safe.
+
+- **Recency weighting** so a recent flood of attacker activity can't permanently dominate the profile — and once the attacker stops and real activity resumes, the flood fades and the genuine profile re-asserts.
+- **A minimum profile age** so a profile that was built up in a fast burst (lots of activity, but only over the last day or two) is *not* trusted as "established" yet.
+- **A recording rate cap** so one session can't hammer thousands of fake observations into a profile to shift it.
+
+## The new pieces
+
+- **Time-bucketed history (in the baseline store)** — alongside the running totals it already kept, the store now also keeps the same counts sliced into rolling day-windows. This is what lets the scorer weight recent vs. old behavior, and lets the store enforce a per-day recording limit. It's an optional extra field: a profile saved by an older version (with no buckets) is read and scored exactly as before.
+- **The decayed view (in the scorer)** — at scoring time, the scorer fades older day-buckets with a half-life (default ~30 days) and keeps any pre-existing "legacy" history at full weight, then compares the request against both this faded view and the full-history view, taking whichever is more suspicious.
+- **The minimum-age check (in the scorer)** — a profile only counts as "established" when it has both enough interactions *and* enough calendar age behind it. A young-but-busy profile stays low-confidence, and the strongest signals stay switched off for it.
+- **The rate cap (in the store)** — observations beyond the per-window limit are dropped and logged, never recorded. The dropped ones touch neither the totals nor the buckets, so the two always stay in lock-step.
+
+## The safeguards
+
+**Prevents a single big burst from re-shaping a profile.** The rate cap limits how many observations land per person per day-window; excess is dropped and logged. A counter-test in the suite proves the earlier "rare action" defense is actually defeated by an uncapped 100-observation burst, and that the cap is what keeps that burst small enough for the defense to keep working.
+
+**Prevents a fast-built profile from being trusted.** The minimum-age requirement means an attacker can't manufacture a deep-looking profile in a day or two and then ride it; the high-value signals (out-of-character action, tier escalation, message-style) stay suppressed and confidence stays "low" until the profile has real calendar age.
+
+**Prevents a recent flood from permanently winning.** Recency decay means a one-time poisoning burst is temporary: as it ages and genuine activity continues, its weight collapses and the real baseline comes back. And because every signal is judged on the more-suspicious of the full-history and recent views, a flood can't quietly erase the fact that an action is rare across the whole relationship.
+
+**Keeps every existing guarantee.** Still shape-only (never message content), still observe-only/dark by default, still "anomaly can only raise the bar, never lower it." Existing saved profiles keep working unchanged, and nothing here can break the message path (recording is best-effort and swallows its own errors).
+
+## What ships when
+
+One change, one commit, behind the existing dark flag. There are no phases: the store changes, the scorer changes, the config wiring, the spec section (§7.7), and the tests all land together. The feature stays off (the anomaly scorer defaults to the no-op Null scorer) until an operator explicitly enables Pillar 3, and even then it only logs would-be step-ups until the false-positive rate is measured good. All three knobs (minimum age, rate cap, decay half-life) are config-overridable with conservative defaults, and each can be turned off individually for a clean fallback to the prior behavior.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "instar",
-  "version": "1.3.448",
+  "version": "1.3.449",
   "description": "Coherence infrastructure for self-evolving AI agents — on the Claude Code or Codex subscription you already have.",
   "type": "module",
   "main": "dist/index.js",

--- a/src/commands/server.ts
+++ b/src/commands/server.ts
@@ -4650,6 +4650,24 @@ export async function startServer(options: StartOptions): Promise<void> {
               enabled?: boolean;
               useLlmStyleCheck?: boolean;
               stepUpThreshold?: number;
+              /**
+               * Baseline-poisoning resistance knobs (Phase-3 follow-ups #2/#3).
+               * All optional with conservative defaults baked into the store/scorer:
+               *   - minBaselineAgeDays (#3a, default 7): a baseline isn't "established"
+               *     until BOTH a calendar age AND interaction count are met — a burst
+               *     can't manufacture trust.
+               *   - maxObservationsPerWindow (#3b, default 50/day): per-principal cap
+               *     on observations recorded per rolling window — excess is dropped.
+               *   - decayHalfLifeWindows (#2, default 30): recency decay so a recent
+               *     attacker burst can't durably dominate the histogram.
+               *   - bucketMs (default 1 day): the rolling-window length both use.
+               */
+              poisoningResistance?: {
+                minBaselineAgeDays?: number;
+                maxObservationsPerWindow?: number;
+                decayHalfLifeWindows?: number;
+                bucketMs?: number;
+              };
             };
           } | undefined;
           if (pgCfg && (pgCfg.observeOnly || pgCfg.enforce)) {
@@ -4728,14 +4746,33 @@ export async function startServer(options: StartOptions): Promise<void> {
             let anomalyScorer: import('../permissions/index.js').AnomalyScorer = new HeuristicAnomalyScorer();
             let behaviorStore: import('../permissions/index.js').RelationshipBehaviorStore | undefined;
             if (raCfg?.enabled && config.stateDir) {
-              behaviorStore = new RelationshipBehaviorStore(config.stateDir);
+              const pr = raCfg.poisoningResistance ?? {};
+              behaviorStore = new RelationshipBehaviorStore(
+                config.stateDir,
+                () => new Date().toISOString(),
+                {
+                  // #3b observation-rate cap + #2 decay bucket sizing. Undefined →
+                  // the store's conservative defaults (50/day, 1-day buckets).
+                  maxObservationsPerWindow: pr.maxObservationsPerWindow,
+                  bucketMs: pr.bucketMs,
+                  onCapDrop: (uid, windowStartMs, dropped) => {
+                    console.log(
+                      `[slack] behavior-baseline rate cap: dropped ${dropped} observation(s) for principal in window ${new Date(windowStartMs).toISOString()} (poisoning resistance #3b)`,
+                    );
+                  },
+                },
+              );
               anomalyScorer = new RelationshipAnomalyScorer(behaviorStore, {
                 useLlmStyleCheck: raCfg.useLlmStyleCheck === true,
                 // Fail-closed LLM style check uses the shared internal provider when present.
                 intelligence: sharedIntelligence ?? undefined,
+                // #3a min-age + #2 decay half-life — undefined → scorer defaults (7d, 30 windows).
+                minBaselineAgeDays: pr.minBaselineAgeDays,
+                decayHalfLifeWindows: pr.decayHalfLifeWindows,
+                bucketMs: pr.bucketMs,
               });
               console.log(
-                `[slack] relationship-aware anomaly scorer attached (observe-only baseline; LLM style check ${raCfg.useLlmStyleCheck ? 'ON' : 'off'})`,
+                `[slack] relationship-aware anomaly scorer attached (observe-only baseline; LLM style check ${raCfg.useLlmStyleCheck ? 'ON' : 'off'}; poisoning-resistance: min-age ${pr.minBaselineAgeDays ?? 7}d, rate-cap ${pr.maxObservationsPerWindow ?? 50}/window, decay ${pr.decayHalfLifeWindows ?? 30}w)`,
               );
             }
             const observer = new SlackPermissionObserver({

--- a/src/permissions/RelationshipAnomalyScorer.ts
+++ b/src/permissions/RelationshipAnomalyScorer.ts
@@ -48,10 +48,14 @@ import type { Principal, RequestIntent, AnomalyAssessment } from './types.js';
 import type { IntelligenceProvider } from '../core/types.js';
 import {
   RelationshipBehaviorStore,
-  meanLength,
-  stdLength,
-  hourFraction,
+  baselineAgeMs,
+  decayedView,
+  decayedMeanLength,
+  decayedStdLength,
+  decayedHourFraction,
+  DEFAULT_BUCKET_MS,
   type PrincipalBehaviorProfile,
+  type DecayedProfileView,
 } from './RelationshipBehaviorStore.js';
 
 const URGENCY =
@@ -75,6 +79,30 @@ export interface RelationshipAnomalyConfig {
    * (no character yet → no out-of-character). Default 5.
    */
   establishedMin?: number;
+  /**
+   * Minimum baseline calendar AGE (days) before a baseline counts as "established"
+   * (poisoning-resistance #3a). "Established" now requires BOTH this age AND
+   * `establishedMin` count — so a patient attacker can't rapidly manufacture a
+   * trusted baseline in a single burst (a high COUNT accrued in minutes is still
+   * YOUNG → not established → the action/tier/style signals stay suppressed, and the
+   * scorer never gains false confidence from a rapid burst). Default 7 days.
+   * Set to 0 to require count only (legacy behavior). Backward-compat: a profile
+   * whose firstSeen predates the request by ≥ this age satisfies it automatically.
+   */
+  minBaselineAgeDays?: number;
+  /**
+   * Decay half-life in bucket-windows for the recency weighting (#2). A recent burst
+   * of attacker observations decays relative to long-standing behavior. Default 30
+   * (≈30 days at the store's 1-day bucket). Larger = slower decay (older behavior
+   * keeps weight longer). Read-time only; the store records raw counts.
+   */
+  decayHalfLifeWindows?: number;
+  /**
+   * Bucket-window length (ms) the baseline was recorded with. Must match the store's
+   * `bucketWindowMs`. Default reads from the store; falls back to 1 day. Exposed for
+   * tests that inject a custom window.
+   */
+  bucketMs?: number;
   /**
    * Share floor for the out-of-character-action signal (poisoning resistance).
    * The signal fires when the requested action's SHARE of the principal's history is
@@ -122,6 +150,11 @@ export class RelationshipAnomalyScorer {
       urgencyWeight: config.urgencyWeight ?? 0.25,
       styleWeight: config.styleWeight ?? 0.2,
       establishedMin: config.establishedMin ?? 5,
+      // #3a: default 7 calendar days. Nullish-coalescing so a deliberate 0 means
+      // "count only" (the legacy pre-hardening behavior).
+      minBaselineAgeDays: config.minBaselineAgeDays ?? 7,
+      decayHalfLifeWindows: config.decayHalfLifeWindows && config.decayHalfLifeWindows > 0 ? config.decayHalfLifeWindows : 30,
+      bucketMs: config.bucketMs && config.bucketMs > 0 ? config.bucketMs : store.bucketWindowMs ?? DEFAULT_BUCKET_MS,
       rareActionShareFloor: config.rareActionShareFloor ?? 0.1,
       styleZThreshold: config.styleZThreshold ?? 2.5,
       offCadenceHourFraction: config.offCadenceHourFraction ?? 0.02,
@@ -187,7 +220,47 @@ export class RelationshipAnomalyScorer {
       return { score: 0, reasons: [], confidence: 'none' };
     }
 
-    const established = profile.interactionCount >= this.cfg.establishedMin;
+    const nowMs = this.cfg.now().getTime();
+
+    // ── Recency/decay view (#2): a decay-weighted SHAPE so a recent attacker burst that
+    // tries to NORMALIZE a rare action is caught — under decay the burst can't durably
+    // dominate, and once it ages out the genuine baseline re-asserts. A pre-hardening
+    // profile (no buckets) yields a decayed view IDENTICAL to its cumulative form. ──
+    const view = decayedView(profile, {
+      nowMs,
+      bucketMs: this.cfg.bucketMs ?? DEFAULT_BUCKET_MS,
+      halfLifeWindows: this.cfg.decayHalfLifeWindows,
+    });
+
+    // ── The CUMULATIVE view (as a DecayedProfileView with weight 1.0 everywhere) ──
+    // Each established signal evaluates BOTH views and fires on the MORE anomalous one.
+    // This is the load-bearing poisoning-resistance invariant: the hardening only ever
+    // ADDS resistance — it must never DISARM a signal the pre-hardening cumulative baseline
+    // would have fired. A recent rate-capped burst can raise a rare action's *decayed*
+    // share above the floor, but it cannot erase its rarity across the WHOLE relationship
+    // (the cap bounds how much it can inject); the cumulative view preserves that. The
+    // decayed view, conversely, catches "this used to be normal but the recent pattern is
+    // off". Taking the max of the two is strictly stronger than either alone. ──
+    const cumulative: DecayedProfileView = {
+      effectiveCount: profile.interactionCount,
+      actionCounts: profile.actionCounts,
+      tierCounts: profile.tierCounts,
+      hourCounts: profile.hourCounts,
+      lengthSum: profile.lengthSum,
+      lengthSqSum: profile.lengthSqSum,
+      urgentCount: profile.urgentCount,
+    };
+
+    // ── "Established" now requires BOTH count AND calendar age (#3a) ──
+    // A high-COUNT but YOUNG baseline (a rapid burst) is NOT established → the
+    // action/tier/style signals stay suppressed (no false confidence from a burst).
+    const countEstablished = profile.interactionCount >= this.cfg.establishedMin;
+    const ageDays = baselineAgeMs(profile, nowMs) / (24 * 60 * 60 * 1000);
+    const ageEstablished = this.cfg.minBaselineAgeDays <= 0 || ageDays >= this.cfg.minBaselineAgeDays;
+    const established = countEstablished && ageEstablished;
+
+    // Confidence reflects depth, but a young baseline is capped at 'low' (we don't trust
+    // a burst-built baseline even if its count is high).
     const confidence: 'low' | 'medium' | 'high' = !established
       ? 'low'
       : profile.interactionCount >= this.cfg.establishedMin * 4
@@ -198,31 +271,35 @@ export class RelationshipAnomalyScorer {
 
     // ── 1. Out-of-character ACTION (only when the baseline is established) ──
     if (established) {
-      const seen = profile.actionCounts[intent.action] ?? 0;
-      const total = profile.interactionCount || 1;
-      const share = seen / total;
       const floor = this.cfg.rareActionShareFloor;
-      // Poisoning resistance (Phase-3 adversarial fix): fire when the action is RARE
-      // (share below the floor), not only when never-seen. A patient attacker / slowly-
-      // compromised account can seed a single prior observation to zero out a `seen===0`
-      // check and permanently disable this highest-weight signal; a share floor keeps a
-      // rare-but-poisoned action flagged. Weight scales by how far below the floor the
-      // share sits (full at never-seen, →0 as share→floor) so a genuinely-routine action
-      // never trips it.
-      if (share < floor) {
-        const rarity = 1 - share / floor; // 1.0 when never seen; →0 as share→floor
+      const neverSeen = (profile.actionCounts[intent.action] ?? 0) === 0;
+      // Rarity in each view; fire on the MORE anomalous (lower share = higher rarity).
+      const shareCum = (cumulative.actionCounts[intent.action] ?? 0) / (cumulative.effectiveCount || 1);
+      const shareDec = (view.actionCounts[intent.action] ?? 0) / (view.effectiveCount || 1);
+      const minShare = Math.min(shareCum, shareDec);
+      // Poisoning resistance (#1 share-floor + #2 dual-view max): the action is flagged if it
+      // is rare in EITHER the whole-relationship history OR the recent-weighted window. A
+      // patient attacker can seed a prior observation (defeats `seen===0`) or burst recently
+      // (raises the decayed share), but cannot make the action non-rare in BOTH views without
+      // a sustained campaign the rate cap (#3b) throttles. Weight scales by how far below the
+      // floor the more-anomalous share sits, so a genuinely-routine action never trips it.
+      if (minShare < floor) {
+        const rarity = 1 - minShare / floor; // 1.0 when never seen; →0 as share→floor
         hits.push({
           weight: this.cfg.atypicalActionWeight * rarity,
-          reason: seen === 0
+          reason: neverSeen
             ? `out-of-character: established history (${profile.interactionCount} interactions) but never requested "${intent.action}"`
-            : `out-of-character: "${intent.action}" is rare for this principal (${seen}/${profile.interactionCount} ≈ ${Math.round(share * 100)}%, below the ${Math.round(floor * 100)}% floor)`,
+            : `out-of-character: "${intent.action}" is rare for this principal (≈ ${Math.round(minShare * 100)}% of history, below the ${Math.round(floor * 100)}% floor)`,
         });
       }
     }
 
     // ── 2. Tier ESCALATION — request tier far above the principal's normal ceiling ──
     if (established) {
-      const normalMaxTier = highestRoutineTier(profile);
+      // Use the LOWER ceiling across both views: a recent burst of high-tier obs can't
+      // silently raise the "normal ceiling" and disarm this signal (it stays armed as long
+      // as EITHER the whole-relationship OR the recent-weighted ceiling is low).
+      const normalMaxTier = Math.min(highestRoutineTier(view), highestRoutineTier(cumulative));
       if (intent.tier >= 4 && normalMaxTier <= 2) {
         hits.push({
           weight: this.cfg.tierEscalationWeight,
@@ -234,7 +311,10 @@ export class RelationshipAnomalyScorer {
     // ── 3. Off-CADENCE timing — arrival hour this principal almost never uses ──
     if (established) {
       const hour = this.cfg.now().getHours();
-      if (hourFraction(profile, hour) <= this.cfg.offCadenceHourFraction) {
+      // Off-cadence if the hour is rare in EITHER view (a burst at an odd hour can't make
+      // that hour look routine across the whole relationship).
+      const minHourFrac = Math.min(decayedHourFraction(view, hour), decayedHourFraction(cumulative, hour));
+      if (minHourFrac <= this.cfg.offCadenceHourFraction) {
         hits.push({
           weight: this.cfg.offCadenceWeight,
           reason: `off-cadence: request at ${pad2(hour)}:00, an hour this principal almost never operates in`,
@@ -244,8 +324,12 @@ export class RelationshipAnomalyScorer {
 
     // ── 4. Sudden URGENCY/pressure from someone normally calm ──
     if (isUrgent) {
-      const baselineUrgentRate = profile.interactionCount > 0 ? profile.urgentCount / profile.interactionCount : 0;
-      if (baselineUrgentRate <= 0.15) {
+      // Use the LOWER urgent rate across both views — a recent burst of urgent obs can't
+      // raise the baseline urgent rate enough to mask sudden pressure from a normally-calm
+      // principal (the whole-relationship rate stays low).
+      const urgentRateDec = view.effectiveCount > 0 ? view.urgentCount / view.effectiveCount : 0;
+      const urgentRateCum = cumulative.effectiveCount > 0 ? cumulative.urgentCount / cumulative.effectiveCount : 0;
+      if (Math.min(urgentRateDec, urgentRateCum) <= 0.15) {
         hits.push({
           weight: this.cfg.urgencyWeight,
           reason: 'sudden urgency/pressure language from a normally-calm principal',
@@ -254,17 +338,17 @@ export class RelationshipAnomalyScorer {
     }
 
     // ── 5. STYLE deviation — message length far outside the normal envelope ──
+    // Fire if the message length is deviant in EITHER view (a recent burst of off-style
+    // messages can't widen the envelope enough to hide a deviation from the whole history).
     if (established) {
-      const mean = meanLength(profile);
-      const std = stdLength(profile);
-      if (mean !== undefined && std !== undefined && std > 0) {
-        const z = Math.abs(((text || '').length - mean) / std);
-        if (z >= this.cfg.styleZThreshold) {
-          hits.push({
-            weight: this.cfg.styleWeight,
-            reason: `style deviation: message length is ${z.toFixed(1)}σ from this principal's norm`,
-          });
-        }
+      const zDec = lengthZ(text, decayedMeanLength(view), decayedStdLength(view));
+      const zCum = lengthZ(text, decayedMeanLength(cumulative), decayedStdLength(cumulative));
+      const z = Math.max(zDec ?? 0, zCum ?? 0);
+      if (z >= this.cfg.styleZThreshold) {
+        hits.push({
+          weight: this.cfg.styleWeight,
+          reason: `style deviation: message length is ${z.toFixed(1)}σ from this principal's norm`,
+        });
       }
     }
 
@@ -284,7 +368,9 @@ export class RelationshipAnomalyScorer {
     const intel = this.cfg.intelligence;
     if (!intel) return null; // no provider → fail closed (no contribution)
     try {
-      const mean = meanLength(profile);
+      // Coarse style summary for the LLM — cumulative mean is fine here (it's a prose hint,
+      // not a scoring input; the deterministic signals already use the decayed view).
+      const mean = profile.interactionCount > 0 ? profile.lengthSum / profile.interactionCount : undefined;
       const topActions = Object.entries(profile.actionCounts)
         .sort((a, b) => b[1] - a[1])
         .slice(0, 5)
@@ -318,14 +404,25 @@ export class RelationshipAnomalyScorer {
   }
 }
 
-/** The highest tier this principal has used in more than a trivial share of interactions. */
-function highestRoutineTier(profile: PrincipalBehaviorProfile): number {
+/**
+ * The highest tier this principal has used in more than a trivial share of interactions,
+ * computed over the DECAYED view so a recent attacker burst of high-tier observations
+ * doesn't silently raise the "normal ceiling" and disarm tier-escalation (#2).
+ */
+function highestRoutineTier(view: DecayedProfileView): number {
   let max = 0;
+  const total = view.effectiveCount || 1;
   for (let t = 0; t <= 4; t++) {
-    const c = profile.tierCounts[t] ?? 0;
-    if (c > 0 && c / profile.interactionCount > 0.02) max = t;
+    const c = view.tierCounts[t] ?? 0;
+    if (c > 0 && c / total > 0.02) max = t;
   }
   return max;
+}
+
+/** |z| of a message length against a view's mean/std, or undefined when not computable. */
+function lengthZ(text: string, mean: number | undefined, std: number | undefined): number | undefined {
+  if (mean === undefined || std === undefined || std <= 0) return undefined;
+  return Math.abs(((text || '').length - mean) / std);
 }
 
 function clamp01(x: number): number {

--- a/src/permissions/RelationshipBehaviorStore.ts
+++ b/src/permissions/RelationshipBehaviorStore.ts
@@ -39,6 +39,32 @@ export interface BehaviorObservation {
 }
 
 /**
+ * A time-bucketed slice of a principal's history (poisoning-resistance, Phase-3
+ * follow-ups #2/#3b). One bucket per rolling window (`bucketMs`, default 1 day).
+ * Holds the SAME SHAPE counts as the cumulative profile, scoped to a window — so
+ * the scorer can apply recency/decay weighting (a RECENT attacker burst can't durably
+ * dominate the histogram) and the store can enforce a per-window observation-rate cap
+ * (one session can't hammer the histogram to reshape it).
+ *
+ * Buckets are ADDITIVE: the cumulative `actionCounts`/`tierCounts`/`hourCounts`/length
+ * sums on the profile are kept in lock-step so an old reader (or a downgrade) still sees
+ * the same numbers it always did. A profile written before this hardening simply has no
+ * `buckets` field and degrades to its cumulative form everywhere.
+ */
+export interface BehaviorBucket {
+  /** Window start (epoch ms, floored to the bucket boundary) — drives decay weighting. */
+  startMs: number;
+  /** Observations recorded in this window (drives the per-window rate cap). */
+  count: number;
+  actionCounts: Record<string, number>;
+  tierCounts: number[];
+  hourCounts: number[];
+  lengthSum: number;
+  lengthSqSum: number;
+  urgentCount: number;
+}
+
+/**
  * The aggregated, privacy-respecting baseline for one principal. All counts; no
  * content. Persisted as JSON; cheap to read and update.
  */
@@ -60,6 +86,34 @@ export interface PrincipalBehaviorProfile {
   /** First / last observation ISO timestamps. */
   firstSeen: string;
   lastSeen: string;
+  /**
+   * OPTIONAL time-bucketed history (poisoning-resistance #2/#3b). Newest bucket last.
+   * Absent on a pre-hardening profile — the scorer degrades to the cumulative counts.
+   * When present, the cumulative counts above remain the exact sum of all buckets'
+   * counts (backward-compat invariant), so old readers are unaffected.
+   */
+  buckets?: BehaviorBucket[];
+}
+
+/** Recording knobs for the rate-cap (#3b) + decay bucket sizing (#2). All optional. */
+export interface BehaviorStoreOptions {
+  /**
+   * Length of one decay/rate-cap bucket window (ms). Default 1 day. The recency-decay
+   * weighting (applied at scoring time) and the per-window observation cap are both
+   * keyed off this window.
+   */
+  bucketMs?: number;
+  /**
+   * Per-principal observation-rate cap (#3b): the MAX observations RECORDED into a
+   * single bucket window. Excess observations in the window are DROPPED (logged via
+   * `onCapDrop`), not recorded — so one session can't hammer the histogram to reshape
+   * it. Default 50/day. Set to a falsy/non-positive value to disable the cap.
+   */
+  maxObservationsPerWindow?: number;
+  /** Cap how many buckets are retained (bounds file growth). Default 90 (≈90 days). */
+  maxBuckets?: number;
+  /** Best-effort callback when an observation is dropped by the rate cap (for logging). */
+  onCapDrop?: (slackUserId: string, windowStartMs: number, droppedCount: number) => void;
 }
 
 function emptyProfile(slackUserId: string, now: string): PrincipalBehaviorProfile {
@@ -74,8 +128,26 @@ function emptyProfile(slackUserId: string, now: string): PrincipalBehaviorProfil
     urgentCount: 0,
     firstSeen: now,
     lastSeen: now,
+    buckets: [],
   };
 }
+
+function emptyBucket(startMs: number): BehaviorBucket {
+  return {
+    startMs,
+    count: 0,
+    actionCounts: {},
+    tierCounts: [0, 0, 0, 0, 0],
+    hourCounts: new Array(24).fill(0),
+    lengthSum: 0,
+    lengthSqSum: 0,
+    urgentCount: 0,
+  };
+}
+
+export const DEFAULT_BUCKET_MS = 24 * 60 * 60 * 1000; // 1 day
+export const DEFAULT_MAX_OBSERVATIONS_PER_WINDOW = 50;
+export const DEFAULT_MAX_BUCKETS = 90;
 
 /** Validate a slackUserId for safe use as a filename key (prevents path traversal). */
 function isSafeKey(id: string): boolean {
@@ -85,11 +157,30 @@ function isSafeKey(id: string): boolean {
 export class RelationshipBehaviorStore {
   private readonly file: string;
   private readonly now: () => string;
+  private readonly bucketMs: number;
+  private readonly maxObservationsPerWindow: number;
+  private readonly maxBuckets: number;
+  private readonly onCapDrop?: (slackUserId: string, windowStartMs: number, droppedCount: number) => void;
 
-  constructor(stateDir: string, now: () => string = () => new Date().toISOString()) {
+  constructor(
+    stateDir: string,
+    now: () => string = () => new Date().toISOString(),
+    options: BehaviorStoreOptions = {},
+  ) {
     /* state-registry: slack-relationship-baselines */
     this.file = path.join(stateDir, 'slack-relationship-baselines.json');
     this.now = now;
+    // Nullish-coalescing (not ||) so a deliberate 0 disables the cap (per Dawn key-pattern).
+    this.bucketMs = options.bucketMs && options.bucketMs > 0 ? options.bucketMs : DEFAULT_BUCKET_MS;
+    this.maxObservationsPerWindow =
+      options.maxObservationsPerWindow ?? DEFAULT_MAX_OBSERVATIONS_PER_WINDOW;
+    this.maxBuckets = options.maxBuckets && options.maxBuckets > 0 ? options.maxBuckets : DEFAULT_MAX_BUCKETS;
+    this.onCapDrop = options.onCapDrop;
+  }
+
+  /** The bucket-window length (ms) this store records into — read by the scorer for decay. */
+  get bucketWindowMs(): number {
+    return this.bucketMs;
   }
 
   get path(): string {
@@ -106,23 +197,82 @@ export class RelationshipBehaviorStore {
     try {
       const all = this.readAll();
       const now = this.now();
+      const nowMs = Date.parse(now);
       const prof = all[slackUserId] ?? emptyProfile(slackUserId, now);
+
+      // ── #3b: per-window observation-rate cap ──────────────────────────────────────
+      // Resolve the current bucket. If recording this observation would exceed the
+      // per-window cap, DROP it (log via onCapDrop) — the cumulative counts are NOT
+      // touched either, so the buckets-sum invariant holds and the cap actually bites.
+      const bucket = this.currentBucket(prof, nowMs);
+      if (
+        this.maxObservationsPerWindow > 0 &&
+        bucket.count >= this.maxObservationsPerWindow
+      ) {
+        // Over the cap for this window — drop, don't record. lastSeen is intentionally
+        // NOT advanced for a dropped observation (a dropped obs is not "an interaction").
+        try {
+          this.onCapDrop?.(slackUserId, bucket.startMs, 1);
+        } catch {
+          /* logging must never break the path */
+        }
+        all[slackUserId] = prof; // persist any bucket pruning done while resolving
+        this.writeAll(all);
+        return;
+      }
+
+      const tier = Math.max(0, Math.min(4, Math.floor(obs.tier)));
+      const hour = Math.max(0, Math.min(23, Math.floor(obs.hour)));
+      const len = Math.max(0, Math.floor(obs.length));
+
+      // Cumulative counts (backward-compat — old readers see the same numbers).
       prof.interactionCount += 1;
       prof.actionCounts[obs.action] = (prof.actionCounts[obs.action] ?? 0) + 1;
-      const tier = Math.max(0, Math.min(4, Math.floor(obs.tier)));
       prof.tierCounts[tier] = (prof.tierCounts[tier] ?? 0) + 1;
-      const hour = Math.max(0, Math.min(23, Math.floor(obs.hour)));
       prof.hourCounts[hour] = (prof.hourCounts[hour] ?? 0) + 1;
-      const len = Math.max(0, Math.floor(obs.length));
       prof.lengthSum += len;
       prof.lengthSqSum += len * len;
       if (obs.urgent) prof.urgentCount += 1;
       prof.lastSeen = now;
+
+      // Time-bucketed counts (kept in lock-step with the cumulative totals).
+      bucket.count += 1;
+      bucket.actionCounts[obs.action] = (bucket.actionCounts[obs.action] ?? 0) + 1;
+      bucket.tierCounts[tier] = (bucket.tierCounts[tier] ?? 0) + 1;
+      bucket.hourCounts[hour] = (bucket.hourCounts[hour] ?? 0) + 1;
+      bucket.lengthSum += len;
+      bucket.lengthSqSum += len * len;
+      if (obs.urgent) bucket.urgentCount += 1;
+
       all[slackUserId] = prof;
       this.writeAll(all);
     } catch {
       // Observe-only baseline must NEVER break the message path.
     }
+  }
+
+  /**
+   * Resolve (and lazily migrate) the bucket covering `nowMs`, pruning to `maxBuckets`.
+   * Backfills a missing `buckets` array on a pre-hardening profile WITHOUT moving its
+   * cumulative counts into a bucket (those counts predate bucketing and have unknown
+   * timestamps — they keep weight as the un-decayable "legacy" base; see the scorer's
+   * decay logic). New observations land in fresh, timestamped buckets.
+   */
+  private currentBucket(prof: PrincipalBehaviorProfile, nowMs: number): BehaviorBucket {
+    if (!Array.isArray(prof.buckets)) prof.buckets = [];
+    const ms = Number.isFinite(nowMs) ? nowMs : Date.now();
+    const start = Math.floor(ms / this.bucketMs) * this.bucketMs;
+    let bucket = prof.buckets.find((b) => b.startMs === start);
+    if (!bucket) {
+      bucket = emptyBucket(start);
+      prof.buckets.push(bucket);
+      prof.buckets.sort((a, b) => a.startMs - b.startMs);
+      // Prune oldest buckets beyond the retention bound (file-growth guard).
+      if (prof.buckets.length > this.maxBuckets) {
+        prof.buckets.splice(0, prof.buckets.length - this.maxBuckets);
+      }
+    }
+    return bucket;
   }
 
   /** The current baseline for a principal, or undefined if none recorded yet. */
@@ -181,6 +331,146 @@ export function hourFraction(prof: PrincipalBehaviorProfile, hour: number): numb
   if (prof.interactionCount <= 0) return 0;
   const h = Math.max(0, Math.min(23, Math.floor(hour)));
   return (prof.hourCounts[h] ?? 0) / prof.interactionCount;
+}
+
+/** Baseline calendar age in milliseconds (now − firstSeen), or 0 when unknown. */
+export function baselineAgeMs(prof: PrincipalBehaviorProfile, nowMs: number): number {
+  const first = Date.parse(prof.firstSeen);
+  if (!Number.isFinite(first) || !Number.isFinite(nowMs)) return 0;
+  return Math.max(0, nowMs - first);
+}
+
+// ── Recency / decay weighting (poisoning-resistance #2) ──────────────────────────
+// A RECENT burst of attacker-controlled observations must not durably dominate the
+// histogram, while genuine long-standing behavior keeps weight. We sum the per-bucket
+// counts weighted by an exponential decay on bucket AGE (newer buckets weigh ~1.0,
+// older buckets fade with a configurable half-life). The "legacy" cumulative counts on
+// a pre-hardening profile (no buckets, or counts that predate bucketing) are treated as
+// an UN-decayable established base — they keep full weight, so an existing baseline
+// degrades gracefully and old long-standing behavior is never erased.
+
+/**
+ * The decayed-effective SHAPE view a scorer should read instead of raw cumulative
+ * counts. Same fields as the profile, but every count is the decay-weighted sum across
+ * buckets PLUS the legacy (pre-bucketing) base at full weight.
+ */
+export interface DecayedProfileView {
+  effectiveCount: number;
+  actionCounts: Record<string, number>;
+  tierCounts: number[];
+  hourCounts: number[];
+  lengthSum: number;
+  lengthSqSum: number;
+  urgentCount: number;
+}
+
+export interface DecayOptions {
+  /** Now (epoch ms) — drives bucket age. */
+  nowMs: number;
+  /** One bucket window length (ms). Must match the store's bucketMs. */
+  bucketMs: number;
+  /** Decay half-life in bucket-windows. Default 30 (≈30 days at a 1-day bucket). */
+  halfLifeWindows?: number;
+}
+
+/**
+ * Compute the decay-weighted effective baseline. The legacy base = cumulative totals
+ * MINUS the sum of all buckets (i.e. the part of history that predates bucketing). That
+ * base keeps full weight (weight 1.0); each bucket is weighted by 0.5^(ageWindows/halfLife).
+ *
+ * A profile with no buckets → its entire cumulative form is the legacy base at full
+ * weight → the decayed view equals the cumulative view (perfect backward-compat). A
+ * fully-bucketed profile decays purely on bucket age.
+ */
+export function decayedView(prof: PrincipalBehaviorProfile, opts: DecayOptions): DecayedProfileView {
+  const halfLife = opts.halfLifeWindows && opts.halfLifeWindows > 0 ? opts.halfLifeWindows : 30;
+  const bucketMs = opts.bucketMs && opts.bucketMs > 0 ? opts.bucketMs : DEFAULT_BUCKET_MS;
+  const buckets = Array.isArray(prof.buckets) ? prof.buckets : [];
+
+  const view: DecayedProfileView = {
+    effectiveCount: 0,
+    actionCounts: {},
+    tierCounts: [0, 0, 0, 0, 0],
+    hourCounts: new Array(24).fill(0),
+    lengthSum: 0,
+    lengthSqSum: 0,
+    urgentCount: 0,
+  };
+
+  // ── Legacy (pre-bucketing) base: cumulative totals minus what the buckets hold ──
+  // Kept at full weight so old established behavior is never decayed away.
+  const bucketedCount = buckets.reduce((s, b) => s + b.count, 0);
+  const legacyCount = Math.max(0, prof.interactionCount - bucketedCount);
+  if (legacyCount > 0 && prof.interactionCount > 0) {
+    // Reconstruct the legacy base by subtracting bucket sums from cumulative sums.
+    const legacyActions: Record<string, number> = { ...prof.actionCounts };
+    const legacyTiers = prof.tierCounts.slice();
+    const legacyHours = prof.hourCounts.slice();
+    let legacyLenSum = prof.lengthSum;
+    let legacyLenSq = prof.lengthSqSum;
+    let legacyUrgent = prof.urgentCount;
+    for (const b of buckets) {
+      for (const [a, c] of Object.entries(b.actionCounts)) {
+        legacyActions[a] = (legacyActions[a] ?? 0) - c;
+      }
+      for (let t = 0; t < 5; t++) legacyTiers[t] = (legacyTiers[t] ?? 0) - (b.tierCounts[t] ?? 0);
+      for (let h = 0; h < 24; h++) legacyHours[h] = (legacyHours[h] ?? 0) - (b.hourCounts[h] ?? 0);
+      legacyLenSum -= b.lengthSum;
+      legacyLenSq -= b.lengthSqSum;
+      legacyUrgent -= b.urgentCount;
+    }
+    accumulate(view, 1.0, {
+      count: legacyCount,
+      actionCounts: legacyActions,
+      tierCounts: legacyTiers,
+      hourCounts: legacyHours,
+      lengthSum: Math.max(0, legacyLenSum),
+      lengthSqSum: Math.max(0, legacyLenSq),
+      urgentCount: Math.max(0, legacyUrgent),
+      startMs: 0,
+    });
+  }
+
+  // ── Decayed buckets ──
+  for (const b of buckets) {
+    const ageWindows = Math.max(0, (opts.nowMs - b.startMs) / bucketMs);
+    const weight = Math.pow(0.5, ageWindows / halfLife);
+    accumulate(view, weight, b);
+  }
+
+  return view;
+}
+
+function accumulate(view: DecayedProfileView, weight: number, b: BehaviorBucket): void {
+  view.effectiveCount += b.count * weight;
+  for (const [a, c] of Object.entries(b.actionCounts)) {
+    if (c > 0) view.actionCounts[a] = (view.actionCounts[a] ?? 0) + c * weight;
+  }
+  for (let t = 0; t < 5; t++) view.tierCounts[t] += (b.tierCounts[t] ?? 0) * weight;
+  for (let h = 0; h < 24; h++) view.hourCounts[h] += (b.hourCounts[h] ?? 0) * weight;
+  view.lengthSum += b.lengthSum * weight;
+  view.lengthSqSum += b.lengthSqSum * weight;
+  view.urgentCount += b.urgentCount * weight;
+}
+
+/** Mean message length from a decayed view, or undefined when there is no weight. */
+export function decayedMeanLength(view: DecayedProfileView): number | undefined {
+  return view.effectiveCount > 0 ? view.lengthSum / view.effectiveCount : undefined;
+}
+
+/** Population std of message length from a decayed view, or undefined when <2 effective. */
+export function decayedStdLength(view: DecayedProfileView): number | undefined {
+  if (view.effectiveCount < 2) return undefined;
+  const mean = view.lengthSum / view.effectiveCount;
+  const variance = view.lengthSqSum / view.effectiveCount - mean * mean;
+  return variance > 0 ? Math.sqrt(variance) : 0;
+}
+
+/** Fraction of decayed interactions in a given hour (0..1). */
+export function decayedHourFraction(view: DecayedProfileView, hour: number): number {
+  if (view.effectiveCount <= 0) return 0;
+  const h = Math.max(0, Math.min(23, Math.floor(hour)));
+  return (view.hourCounts[h] ?? 0) / view.effectiveCount;
 }
 
 // ── Bridge to the simpler BaselineProvider interface ─────────────────────────────

--- a/tests/unit/slack-relationship-anomaly.test.ts
+++ b/tests/unit/slack-relationship-anomaly.test.ts
@@ -21,6 +21,9 @@ import {
   meanLength,
   stdLength,
   hourFraction,
+  decayedView,
+  baselineAgeMs,
+  type BehaviorObservation,
 } from '../../src/permissions/RelationshipBehaviorStore.js';
 import { RelationshipAnomalyScorer } from '../../src/permissions/RelationshipAnomalyScorer.js';
 import { SlackPermissionGate } from '../../src/permissions/SlackPermissionGate.js';
@@ -48,20 +51,55 @@ afterEach(() => {
   SafeFsExecutor.safeRmSync(tmp, { recursive: true, force: true, operation: 'tests/unit/slack-relationship-anomaly.test.ts' });
 });
 
-/** Build an established owner baseline: 50 morning reads/deploys, calm, ~30-char messages. */
-function seedEstablishedOwner(store: RelationshipBehaviorStore): void {
+/**
+ * The reference "now" the scorers in this file are pinned to. Seeded baselines must
+ * accrue calendar AGE relative to this instant to count as "established" once the
+ * minimum-baseline-age hardening (#3a) is in force.
+ */
+const SCORE_NOW = new Date(2026, 5, 9, 10, 0, 0);
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * A store whose clock is parked `daysAgo` before SCORE_NOW, so that records it writes
+ * carry a `firstSeen` old enough to be "established" by age. Mirrors how a REAL baseline
+ * forms over weeks of traffic — the existing fixtures used real-now, which is only an
+ * artifact of an instant-seed test. (Backward-compat for the merged tests: the assertions
+ * are unchanged; only the seed's calendar age is made realistic.)
+ */
+function agedStore(tmp: string, daysAgo = 30, opts?: ConstructorParameters<typeof RelationshipBehaviorStore>[2]): RelationshipBehaviorStore {
+  const at = new Date(SCORE_NOW.getTime() - daysAgo * DAY_MS).toISOString();
+  return new RelationshipBehaviorStore(tmp, () => at, opts);
+}
+
+/**
+ * Record `count` observations for a principal at `daysAgo` before SCORE_NOW, capped at
+ * the store's per-window limit so a single day never trips the rate cap (#3b). Used to
+ * spread a baseline across calendar days the way real traffic accrues — giving both the
+ * age (#3a) and a decay-relevant history (#2) without dropping seeded observations.
+ */
+function recordAt(tmp: string, slackUserId: string, daysAgo: number, count: number, obs: BehaviorObservation): void {
+  const at = new Date(SCORE_NOW.getTime() - daysAgo * DAY_MS).toISOString();
+  const s = new RelationshipBehaviorStore(tmp, () => at);
+  for (let i = 0; i < count; i++) s.record(slackUserId, obs);
+}
+
+/**
+ * Build an established owner baseline spread over ~50 calendar days (≤1/day) so it is
+ * established by AGE and COUNT and is decay-stable: 30 morning reads + 20 deploys.
+ */
+function seedEstablishedOwner(tmp: string): void {
+  // 30 reads across days 50..21, 20 deploys across days 20..1 — all ≤1/day (under the cap).
   for (let i = 0; i < 30; i++) {
-    store.record('U_OLIVIA', { action: 'read', tier: 1, hour: 10, length: 30, urgent: false });
+    recordAt(tmp, 'U_OLIVIA', 50 - i, 1, { action: 'read', tier: 1, hour: 10, length: 30, urgent: false });
   }
   for (let i = 0; i < 20; i++) {
-    store.record('U_OLIVIA', { action: 'prod-deploy', tier: 4, hour: 11, length: 35, urgent: false });
+    recordAt(tmp, 'U_OLIVIA', 20 - i, 1, { action: 'prod-deploy', tier: 4, hour: 11, length: 35, urgent: false });
   }
 }
 
 describe('RelationshipBehaviorStore', () => {
   it('records SHAPE only and aggregates a baseline that survives a reload', () => {
-    const store = new RelationshipBehaviorStore(tmp);
-    seedEstablishedOwner(store);
+    seedEstablishedOwner(tmp);
 
     // Fresh instance reads from disk — durable.
     const reloaded = new RelationshipBehaviorStore(tmp);
@@ -95,8 +133,8 @@ describe('RelationshipBehaviorStore', () => {
   });
 
   it('StoreBaselineProvider bridges the durable store to the simpler BaselineProvider', () => {
+    seedEstablishedOwner(tmp);
     const store = new RelationshipBehaviorStore(tmp);
-    seedEstablishedOwner(store);
     const provider = new StoreBaselineProvider(store);
     const baseline = provider.baselineFor(OLIVIA)!;
     expect(baseline.interactionCount).toBe(50);
@@ -108,17 +146,18 @@ describe('RelationshipBehaviorStore', () => {
 
 describe('RelationshipAnomalyScorer — deterministic signals', () => {
   it('a request matching the baseline scores LOW anomaly', async () => {
+    seedEstablishedOwner(tmp);
     const store = new RelationshipBehaviorStore(tmp);
-    seedEstablishedOwner(store);
-    const scorer = new RelationshipAnomalyScorer(store, { now: () => new Date(2026, 5, 9, 10, 0, 0) });
+    const scorer = new RelationshipAnomalyScorer(store, { now: () => SCORE_NOW });
     const a = await scorer.assess(OLIVIA, intent('prod-deploy', 4, 'prod-deploy'), 'push the hotfix to prod');
     expect(a.score).toBeLessThan(0.5);
   });
 
   it('an out-of-character request (off-cadence + tier-escalation + urgency + style) scores HIGH', async () => {
+    // Baseline: low-tier, calm, short, daytime reads — spread over 40 calendar days so it is
+    // established by AGE and COUNT.
+    for (let i = 0; i < 40; i++) recordAt(tmp, 'U_OLIVIA', 40 - i, 1, { action: 'read', tier: 1, hour: 10, length: 30, urgent: false });
     const store = new RelationshipBehaviorStore(tmp);
-    // Baseline: low-tier, calm, short, daytime reads.
-    for (let i = 0; i < 40; i++) store.record('U_OLIVIA', { action: 'read', tier: 1, hour: 10, length: 30, urgent: false });
     const scorer = new RelationshipAnomalyScorer(store, { now: () => new Date(2026, 5, 9, 3, 0, 0) }); // 03:00 — off-cadence
     // A money transfer (never made, tier 4 vs normal ceiling 1), urgent, much longer message.
     const longUrgent = 'wire $40k urgently to this brand new vendor account before EOD please this cannot wait at all';
@@ -128,14 +167,15 @@ describe('RelationshipAnomalyScorer — deterministic signals', () => {
     expect(a.reasons.join(' ')).toMatch(/out-of-character|tier escalation|off-cadence|urgency|style/i);
   });
 
-  it('POISONING RESISTANCE: a few seeded money-movement obs do NOT disable the out-of-character signal (share floor, Phase-3 adversarial fix)', async () => {
-    const store = new RelationshipBehaviorStore(tmp);
+  it('POISONING RESISTANCE (share floor #1): a few seeded money-movement obs do NOT disable the out-of-character signal', async () => {
     // Attacker poisons the baseline so a `seen === 0` check would be disabled: 50 normal
-    // daytime reads + 2 seeded money-movement observations → money-movement share = 2/52
+    // daytime reads + 2 seeded money-movement observations → money-movement share ≈ 2/52
     // ≈ 0.04, BELOW the 0.10 floor → the out-of-character signal must STILL fire (scaled).
-    for (let i = 0; i < 50; i++) store.record('U_OLIVIA', { action: 'read', tier: 1, hour: 10, length: 30, urgent: false });
-    store.record('U_OLIVIA', { action: 'money-movement', tier: 4, hour: 10, length: 30, urgent: false });
-    store.record('U_OLIVIA', { action: 'money-movement', tier: 4, hour: 10, length: 30, urgent: false });
+    // Spread over calendar days so the baseline is age-established and rate-cap-clean.
+    for (let i = 0; i < 50; i++) recordAt(tmp, 'U_OLIVIA', 50 - i, 1, { action: 'read', tier: 1, hour: 10, length: 30, urgent: false });
+    recordAt(tmp, 'U_OLIVIA', 30, 1, { action: 'money-movement', tier: 4, hour: 10, length: 30, urgent: false });
+    recordAt(tmp, 'U_OLIVIA', 25, 1, { action: 'money-movement', tier: 4, hour: 10, length: 30, urgent: false });
+    const store = new RelationshipBehaviorStore(tmp);
     const scorer = new RelationshipAnomalyScorer(store, { now: () => new Date(2026, 5, 9, 3, 0, 0) }); // 03:00 off-cadence
     const longUrgent = 'URGENT: wire $50k to a brand new vendor account right now, this absolutely cannot wait until morning';
     const a = await scorer.assess(OLIVIA, intent('money-movement', 4, 'money-movement'), longUrgent);
@@ -170,11 +210,11 @@ describe('RelationshipAnomalyScorer — deterministic signals', () => {
   });
 
   it('confidence scales with baseline depth', () => {
+    seedEstablishedOwner(tmp); // 50 interactions over ~50 calendar days
     const store = new RelationshipBehaviorStore(tmp);
-    seedEstablishedOwner(store); // 50 interactions
-    const scorer = new RelationshipAnomalyScorer(store, { now: () => new Date(2026, 5, 9, 10, 0, 0) });
+    const scorer = new RelationshipAnomalyScorer(store, { now: () => SCORE_NOW });
     const det = scorer.deterministicScore(store.profileFor('U_OLIVIA'), intent('read', 1), 'morning summary');
-    expect(det.confidence).toBe('high'); // 50 >= establishedMin(5)*4
+    expect(det.confidence).toBe('high'); // 50 >= establishedMin(5)*4 AND age >= 7d
   });
 });
 
@@ -189,10 +229,10 @@ describe('RelationshipAnomalyScorer — optional LLM style check (fail-closed)',
   }
 
   it('an LLM MISMATCH ADDS to the score (raises the bar)', async () => {
+    seedEstablishedOwner(tmp);
     const store = new RelationshipBehaviorStore(tmp);
-    seedEstablishedOwner(store);
     const scorer = new RelationshipAnomalyScorer(store, {
-      now: () => new Date(2026, 5, 9, 10, 0, 0),
+      now: () => SCORE_NOW,
       useLlmStyleCheck: true,
       intelligence: provider('MISMATCH'),
     });
@@ -203,8 +243,8 @@ describe('RelationshipAnomalyScorer — optional LLM style check (fail-closed)',
   });
 
   it('an LLM failure FAILS CLOSED — it never widens (no contribution)', async () => {
+    seedEstablishedOwner(tmp);
     const store = new RelationshipBehaviorStore(tmp);
-    seedEstablishedOwner(store);
     const throwing = scorerWithThrowingLlm(store);
     const a = await throwing.assess(OLIVIA, intent('prod-deploy', 4, 'prod-deploy'), 'push the hotfix to prod');
     // Deterministic score stands; the failed LLM adds nothing.
@@ -213,10 +253,10 @@ describe('RelationshipAnomalyScorer — optional LLM style check (fail-closed)',
   });
 
   it('an LLM MATCH adds nothing', async () => {
+    seedEstablishedOwner(tmp);
     const store = new RelationshipBehaviorStore(tmp);
-    seedEstablishedOwner(store);
     const scorer = new RelationshipAnomalyScorer(store, {
-      now: () => new Date(2026, 5, 9, 10, 0, 0),
+      now: () => SCORE_NOW,
       useLlmStyleCheck: true,
       intelligence: provider('MATCH'),
     });
@@ -226,7 +266,7 @@ describe('RelationshipAnomalyScorer — optional LLM style check (fail-closed)',
 
   function scorerWithThrowingLlm(store: RelationshipBehaviorStore): RelationshipAnomalyScorer {
     return new RelationshipAnomalyScorer(store, {
-      now: () => new Date(2026, 5, 9, 10, 0, 0),
+      now: () => SCORE_NOW,
       useLlmStyleCheck: true,
       intelligence: {
         async evaluate() {
@@ -239,10 +279,11 @@ describe('RelationshipAnomalyScorer — optional LLM style check (fail-closed)',
 
 describe('SlackPermissionGate × RelationshipAnomalyScorer composition (observe-only)', () => {
   it('HIGH anomaly on a would-be-allowed FLOOR action → step-up (the spoofed-CEO case)', async () => {
+    // Olivia is an owner whose normal repertoire is daytime deploys/reads, calm, short —
+    // accrued over calendar days so the baseline is age-established.
+    for (let i = 0; i < 40; i++) recordAt(tmp, 'U_OLIVIA', 60 - i, 1, { action: 'prod-deploy', tier: 4, hour: 11, length: 30, urgent: false });
+    for (let i = 0; i < 20; i++) recordAt(tmp, 'U_OLIVIA', 20 - i, 1, { action: 'read', tier: 1, hour: 10, length: 28, urgent: false });
     const store = new RelationshipBehaviorStore(tmp);
-    // Olivia is an owner whose normal repertoire is daytime deploys/reads, calm, short.
-    for (let i = 0; i < 40; i++) store.record('U_OLIVIA', { action: 'prod-deploy', tier: 4, hour: 11, length: 30, urgent: false });
-    for (let i = 0; i < 20; i++) store.record('U_OLIVIA', { action: 'read', tier: 1, hour: 10, length: 28, urgent: false });
     const gate = new SlackPermissionGate({
       classifier: new HeuristicIntentClassifier(),
       anomalyScorer: new RelationshipAnomalyScorer(store, { now: () => new Date(2026, 5, 9, 3, 0, 0) }),
@@ -261,8 +302,8 @@ describe('SlackPermissionGate × RelationshipAnomalyScorer composition (observe-
   });
 
   it('in-character FLOOR request from the SAME owner → allow (anomaly does not raise the bar)', async () => {
+    for (let i = 0; i < 40; i++) recordAt(tmp, 'U_OLIVIA', 40 - i, 1, { action: 'prod-deploy', tier: 4, hour: 11, length: 30, urgent: false });
     const store = new RelationshipBehaviorStore(tmp);
-    for (let i = 0; i < 40; i++) store.record('U_OLIVIA', { action: 'prod-deploy', tier: 4, hour: 11, length: 30, urgent: false });
     const gate = new SlackPermissionGate({
       classifier: new HeuristicIntentClassifier(),
       anomalyScorer: new RelationshipAnomalyScorer(store, { now: () => new Date(2026, 5, 9, 11, 0, 0) }),
@@ -273,8 +314,8 @@ describe('SlackPermissionGate × RelationshipAnomalyScorer composition (observe-
   });
 
   it('anomaly can only RAISE the bar — a member floor request stays a refuse', async () => {
+    for (let i = 0; i < 40; i++) recordAt(tmp, 'U_MAYA', 40 - i, 1, { action: 'read', tier: 1, hour: 10, length: 30, urgent: false });
     const store = new RelationshipBehaviorStore(tmp);
-    for (let i = 0; i < 40; i++) store.record('U_MAYA', { action: 'read', tier: 1, hour: 10, length: 30, urgent: false });
     const gate = new SlackPermissionGate({
       classifier: new HeuristicIntentClassifier(),
       anomalyScorer: new RelationshipAnomalyScorer(store, { now: () => new Date(2026, 5, 9, 3, 0, 0) }),
@@ -347,5 +388,266 @@ describe('SlackPermissionObserver feeds the behavioral baseline (observe-only)',
     expect(v).not.toBeNull();
     // No baseline file should have been created by the relationship store.
     expect(fs.existsSync(path.join(tmp, 'slack-relationship-baselines.json'))).toBe(false);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────────
+// Phase-3 follow-ups #2/#3: deeper baseline-poisoning resistance.
+// The attack: a patient attacker / slowly-compromised account injects many normal-
+// looking observations (and/or a burst) to reshape the baseline so a later out-of-
+// character request scores LOW. Three additive, observe-only hardenings defeat it:
+//   #2  recency/decay weighting    — a recent burst can't durably dominate the histogram
+//   #3a minimum-baseline-AGE       — a burst can't rapidly manufacture an "established" baseline
+//   #3b per-principal rate cap     — one session can't hammer the histogram to shift it
+// Each test below would FAIL against the pre-hardening code (noted inline).
+// ─────────────────────────────────────────────────────────────────────────────────
+
+describe('Poisoning resistance #3b — per-principal observation-rate cap', () => {
+  it('a burst of N observations in one window records only the cap; the histogram is not shifted past it', () => {
+    const dropped: number[] = [];
+    const at = new Date(2026, 5, 9, 12, 0, 0).toISOString();
+    const store = new RelationshipBehaviorStore(tmp, () => at, {
+      maxObservationsPerWindow: 10,
+      bucketMs: DAY_MS,
+      onCapDrop: (_uid, _ws, n) => dropped.push(n),
+    });
+    // Attacker hammers 100 money-movement observations into a single day window.
+    for (let i = 0; i < 100; i++) {
+      store.record('U_ATTACK', { action: 'money-movement', tier: 4, hour: 12, length: 30, urgent: false });
+    }
+    const prof = store.profileFor('U_ATTACK')!;
+    // PRE-HARDENING: interactionCount would be 100 (no cap). With the cap it is exactly 10.
+    expect(prof.interactionCount).toBe(10);
+    expect(prof.actionCounts['money-movement']).toBe(10);
+    // 90 observations were dropped + logged (not recorded).
+    expect(dropped.length).toBe(90);
+    // The bucketed history mirrors the cumulative totals (buckets-sum invariant holds).
+    const bucketCount = (prof.buckets ?? []).reduce((s, b) => s + b.count, 0);
+    expect(bucketCount).toBe(10);
+  });
+
+  it('the cap is PER-WINDOW: a fresh window admits another capped batch (sustained traffic is not starved)', () => {
+    const day1 = new Date(2026, 4, 1, 12, 0, 0).toISOString();
+    const day2 = new Date(2026, 4, 2, 12, 0, 0).toISOString();
+    const s1 = new RelationshipBehaviorStore(tmp, () => day1, { maxObservationsPerWindow: 5, bucketMs: DAY_MS });
+    for (let i = 0; i < 20; i++) s1.record('U_X', { action: 'read', tier: 1, hour: 12, length: 20, urgent: false });
+    const s2 = new RelationshipBehaviorStore(tmp, () => day2, { maxObservationsPerWindow: 5, bucketMs: DAY_MS });
+    for (let i = 0; i < 20; i++) s2.record('U_X', { action: 'read', tier: 1, hour: 12, length: 20, urgent: false });
+    // 5 admitted in each of the two windows = 10 total (not 40, not 5).
+    expect(s2.profileFor('U_X')!.interactionCount).toBe(10);
+  });
+
+  it('a non-positive cap disables the rate cap (records everything — opt-out)', () => {
+    const at = new Date(2026, 5, 9, 12, 0, 0).toISOString();
+    const store = new RelationshipBehaviorStore(tmp, () => at, { maxObservationsPerWindow: 0, bucketMs: DAY_MS });
+    for (let i = 0; i < 80; i++) store.record('U_X', { action: 'read', tier: 1, hour: 12, length: 20, urgent: false });
+    expect(store.profileFor('U_X')!.interactionCount).toBe(80);
+  });
+});
+
+describe('Poisoning resistance #3a — minimum baseline AGE for "established"', () => {
+  it('a high-COUNT but YOUNG baseline (rapid burst, recent firstSeen) is NOT established → action/tier/style signals suppressed', async () => {
+    // Attacker rapidly accrues a deep-LOOKING baseline of reads TODAY (firstSeen ≈ now),
+    // spread across days to dodge the rate cap but all within the last ~3 days, then tries
+    // a money-movement. Count is high (well over establishedMin) but the baseline is YOUNG.
+    const now = new Date(2026, 5, 9, 3, 0, 0);
+    for (let d = 0; d < 3; d++) {
+      const at = new Date(now.getTime() - d * DAY_MS).toISOString();
+      const s = new RelationshipBehaviorStore(tmp, () => at, { bucketMs: DAY_MS });
+      for (let i = 0; i < 15; i++) s.record('U_YOUNG', { action: 'read', tier: 1, hour: 10, length: 30, urgent: false });
+    }
+    const store = new RelationshipBehaviorStore(tmp);
+    const prof = store.profileFor('U_YOUNG')!;
+    expect(prof.interactionCount).toBe(45); // count is plenty (>> establishedMin 5)
+    expect(baselineAgeMs(prof, now.getTime())).toBeLessThan(7 * DAY_MS); // but YOUNG (<7d)
+
+    const principal: Principal = { ...OLIVIA, slackUserId: 'U_YOUNG' };
+    const scorer = new RelationshipAnomalyScorer(store, { now: () => now, minBaselineAgeDays: 7, bucketMs: DAY_MS });
+    const det = scorer.deterministicScore(prof, intent('money-movement', 4, 'money-movement'), 'wire $40k right now urgently');
+    // PRE-HARDENING (count-only "established"): out-of-character + tier-escalation would fire
+    // → false confidence from a burst-built baseline. With min-age, the burst is NOT trusted:
+    expect(det.confidence).toBe('low');
+    expect(det.reasons.join(' ')).not.toMatch(/out-of-character|tier escalation|style deviation/i);
+    void principal;
+  });
+
+  it('the SAME-shaped baseline, once AGED past the min-age, IS established → out-of-character fires', async () => {
+    // Identical shape, but firstSeen is 40 days back: now established by age AND count.
+    const now = new Date(2026, 5, 9, 3, 0, 0);
+    for (let i = 0; i < 45; i++) {
+      recordAt(tmp, 'U_AGED', 45 - i, 1, { action: 'read', tier: 1, hour: 10, length: 30, urgent: false });
+    }
+    const store = new RelationshipBehaviorStore(tmp);
+    const scorer = new RelationshipAnomalyScorer(store, { now: () => now, minBaselineAgeDays: 7, bucketMs: DAY_MS });
+    const det = scorer.deterministicScore(store.profileFor('U_AGED'), intent('money-movement', 4, 'money-movement'), 'wire $40k');
+    expect(det.confidence).not.toBe('low'); // age + count both satisfied
+    expect(det.reasons.join(' ')).toMatch(/out-of-character|tier escalation/i);
+  });
+
+  it('minBaselineAgeDays: 0 restores legacy count-only "established" (opt-out / backward-compat)', async () => {
+    // A young burst with the age gate OFF behaves like the pre-hardening scorer.
+    const now = new Date(2026, 5, 9, 3, 0, 0);
+    const at = new Date(now.getTime() - 1 * DAY_MS).toISOString();
+    const s = new RelationshipBehaviorStore(tmp, () => at, { bucketMs: DAY_MS });
+    for (let i = 0; i < 20; i++) s.record('U_NOW', { action: 'read', tier: 1, hour: 10, length: 30, urgent: false });
+    const store = new RelationshipBehaviorStore(tmp);
+    const scorer = new RelationshipAnomalyScorer(store, { now: () => now, minBaselineAgeDays: 0, bucketMs: DAY_MS });
+    const det = scorer.deterministicScore(store.profileFor('U_NOW'), intent('money-movement', 4, 'money-movement'), 'wire $40k');
+    expect(det.reasons.join(' ')).toMatch(/out-of-character/i); // age gate disabled → fires on count alone
+  });
+});
+
+describe('Poisoning resistance #2 — recency/decay weighting', () => {
+  it('DURABILITY: a one-time poisoning burst FADES as genuine traffic continues — the burst decays back below the out-of-character floor', () => {
+    // The headline anti-poisoning property of decay: a one-time burst cannot DURABLY reshape
+    // the baseline once genuine traffic resumes. The attacker bursts money-movement once; the
+    // owner's genuine reads continue for months after, diluting the (decaying) burst.
+    const burstDay = new Date(2026, 4, 1, 12, 0, 0).getTime();
+    // The single capped burst on burstDay.
+    {
+      const s = new RelationshipBehaviorStore(tmp, () => new Date(burstDay).toISOString(), { bucketMs: DAY_MS, maxObservationsPerWindow: 5 });
+      for (let i = 0; i < 20; i++) s.record('U_BURST', { action: 'money-movement', tier: 4, hour: 12, length: 30, urgent: false });
+    }
+    const floor = 0.1;
+    const store = new RelationshipBehaviorStore(tmp);
+
+    // Right after the burst (before genuine traffic resumes), money-movement is the only
+    // recent behavior → its decayed share is high (the in-the-moment window the rate cap bounds).
+    const justAfter = decayedView(store.profileFor('U_BURST')!, { nowMs: burstDay + 1 * DAY_MS, bucketMs: DAY_MS, halfLifeWindows: 10 });
+    const shareJustAfter = (justAfter.actionCounts['money-movement'] ?? 0) / (justAfter.effectiveCount || 1);
+    expect(shareJustAfter).toBeGreaterThan(floor); // fresh burst dominates the moment
+
+    // Genuine reads resume daily for 60 days after the burst.
+    for (let d = 1; d <= 60; d++) {
+      const at = new Date(burstDay + d * DAY_MS).toISOString();
+      const s = new RelationshipBehaviorStore(tmp, () => at, { bucketMs: DAY_MS });
+      s.record('U_BURST', { action: 'read', tier: 1, hour: 10, length: 30, urgent: false });
+    }
+    const store2 = new RelationshipBehaviorStore(tmp);
+    // 60 days later the burst has decayed (half-life 10 windows → 0.5^6 ≈ 0.016) while 60 fresh
+    // reads carry near-full weight: money-movement's decayed share collapses BELOW the floor.
+    const muchLater = decayedView(store2.profileFor('U_BURST')!, { nowMs: burstDay + 61 * DAY_MS, bucketMs: DAY_MS, halfLifeWindows: 10 });
+    const shareMuchLater = (muchLater.actionCounts['money-movement'] ?? 0) / muchLater.effectiveCount;
+    expect(shareMuchLater).toBeLessThan(shareJustAfter); // it faded
+    expect(shareMuchLater).toBeLessThan(floor); // back under the out-of-character floor → fires again
+  });
+
+  it('a CAPPED burst stays RARE against an established baseline: out-of-character still clears step-up', async () => {
+    // The rate cap (#3b) keeps an attacker burst's SHARE small relative to a long-standing
+    // baseline, so the share-floor out-of-character signal survives. 100 genuine reads over
+    // 100 days, then the attacker hammers money-movement but a 3/window cap admits ≤6 total.
+    const now = new Date(2026, 5, 9, 3, 0, 0).getTime();
+    for (let i = 0; i < 100; i++) {
+      const at = new Date(now - (110 - i) * DAY_MS).toISOString(); // days 110..11 ago
+      const s = new RelationshipBehaviorStore(tmp, () => at, { bucketMs: DAY_MS });
+      s.record('U_VICTIM', { action: 'read', tier: 1, hour: 10, length: 30, urgent: false });
+    }
+    // Attacker hammers money-movement over the last 2 days; the 3/window cap admits ≤3/day.
+    for (let d = 0; d < 2; d++) {
+      const at = new Date(now - d * DAY_MS).toISOString();
+      const s = new RelationshipBehaviorStore(tmp, () => at, { bucketMs: DAY_MS, maxObservationsPerWindow: 3 });
+      for (let i = 0; i < 50; i++) s.record('U_VICTIM', { action: 'money-movement', tier: 4, hour: 11, length: 30, urgent: false });
+    }
+    const store = new RelationshipBehaviorStore(tmp);
+    // Cap held: at most 3/window across 2 windows (≤6), regardless of the 50 attempts/day.
+    const mmCount = store.profileFor('U_VICTIM')!.actionCounts['money-movement']!;
+    expect(mmCount).toBeLessThanOrEqual(6);
+    // money-movement cumulative share ≈ 6/106 ≈ 0.057 < 0.10 floor → still rare → out-of-character fires.
+    const scorer = new RelationshipAnomalyScorer(store, { now: () => new Date(2026, 5, 9, 3, 0, 0), bucketMs: DAY_MS });
+    const principal: Principal = { ...OLIVIA, slackUserId: 'U_VICTIM' };
+    const longUrgent = 'URGENT: wire $50k to a brand new vendor account right now, this absolutely cannot wait until morning';
+    const a = await scorer.assess(principal, intent('money-movement', 4, 'money-movement'), longUrgent);
+    expect(a.reasons.join(' ')).toMatch(/out-of-character|rare/i);
+    expect(a.score).toBeGreaterThanOrEqual(0.5);
+  });
+
+  it('WITHOUT the rate cap, the SAME burst normalizes the action — demonstrating the cap is load-bearing', async () => {
+    // Counter-test: the identical scenario with the cap DISABLED lets the attacker inject 100
+    // money-movement obs, pushing its cumulative AND recent-weighted share well over the floor →
+    // out-of-character no longer fires from the action signal. (This is the pre-#3b behavior the
+    // cap defends against; here it proves the cap — not luck — is what kept the burst rare above.)
+    const now = new Date(2026, 5, 9, 3, 0, 0).getTime();
+    for (let i = 0; i < 100; i++) {
+      const at = new Date(now - (110 - i) * DAY_MS).toISOString();
+      const s = new RelationshipBehaviorStore(tmp, () => at, { bucketMs: DAY_MS });
+      s.record('U_VICTIM2', { action: 'read', tier: 1, hour: 10, length: 30, urgent: false });
+    }
+    // Cap DISABLED (0) → all 100 money-movement obs land in one recent window.
+    const s = new RelationshipBehaviorStore(tmp, () => new Date(now).toISOString(), { bucketMs: DAY_MS, maxObservationsPerWindow: 0 });
+    for (let i = 0; i < 100; i++) s.record('U_VICTIM2', { action: 'money-movement', tier: 4, hour: 11, length: 30, urgent: false });
+    const store = new RelationshipBehaviorStore(tmp);
+    expect(store.profileFor('U_VICTIM2')!.actionCounts['money-movement']).toBe(100); // no cap
+    const scorer = new RelationshipAnomalyScorer(store, { now: () => new Date(2026, 5, 9, 3, 0, 0), bucketMs: DAY_MS });
+    const principal: Principal = { ...OLIVIA, slackUserId: 'U_VICTIM2' };
+    const det = scorer.deterministicScore(store.profileFor('U_VICTIM2'), intent('money-movement', 4, 'money-movement'), 'wire $50k');
+    // money-movement is now 100/200 = 50% (both views) → NOT rare → the action signal is gone.
+    expect(det.reasons.join(' ')).not.toMatch(/out-of-character/i);
+  });
+});
+
+describe('Backward-compat — a pre-hardening baseline (no buckets) scores sensibly', () => {
+  /** Write a profile in the OLD on-disk shape (no `buckets` field, only cumulative counts). */
+  function writeLegacyProfile(firstSeenDaysAgo: number): void {
+    const firstSeen = new Date(new Date(2026, 5, 9, 3, 0, 0).getTime() - firstSeenDaysAgo * DAY_MS).toISOString();
+    const legacy = {
+      U_LEGACY: {
+        slackUserId: 'U_LEGACY',
+        interactionCount: 50,
+        actionCounts: { read: 40, 'prod-deploy': 10 },
+        tierCounts: [0, 40, 0, 0, 10],
+        hourCounts: (() => { const h = new Array(24).fill(0); h[10] = 40; h[11] = 10; return h; })(),
+        lengthSum: 50 * 30,
+        lengthSqSum: 50 * 30 * 30,
+        urgentCount: 0,
+        firstSeen,
+        lastSeen: new Date(2026, 5, 5, 10, 0, 0).toISOString(),
+        // NOTE: no `buckets` field — this is the pre-hardening shape.
+      },
+    };
+    fs.mkdirSync(tmp, { recursive: true });
+    fs.writeFileSync(path.join(tmp, 'slack-relationship-baselines.json'), JSON.stringify(legacy, null, 2));
+  }
+
+  it('a legacy profile decays to its cumulative form (decayedView == cumulative) — no buckets, full weight', () => {
+    writeLegacyProfile(60);
+    const store = new RelationshipBehaviorStore(tmp);
+    const prof = store.profileFor('U_LEGACY')!;
+    expect(prof.buckets).toBeUndefined(); // genuinely the old shape
+    const view = decayedView(prof, { nowMs: new Date(2026, 5, 9, 3, 0, 0).getTime(), bucketMs: DAY_MS });
+    // Legacy base is kept at full weight → effective counts equal cumulative counts.
+    expect(view.effectiveCount).toBe(50);
+    expect(view.actionCounts.read).toBe(40);
+    expect(view.actionCounts['prod-deploy']).toBe(10);
+    expect(view.tierCounts[4]).toBe(10);
+  });
+
+  it('a legacy (aged) profile still flags an out-of-character floor request', async () => {
+    writeLegacyProfile(60); // 60 days old → age-established
+    const store = new RelationshipBehaviorStore(tmp);
+    const scorer = new RelationshipAnomalyScorer(store, { now: () => new Date(2026, 5, 9, 3, 0, 0), bucketMs: DAY_MS });
+    const det = scorer.deterministicScore(store.profileFor('U_LEGACY'), intent('money-movement', 4, 'money-movement'), 'wire $40k urgently right now');
+    // money-movement never seen in the legacy repertoire → out-of-character still fires;
+    // 03:00 is off-cadence (legacy hours are 10/11 only).
+    expect(det.reasons.join(' ')).toMatch(/out-of-character|off-cadence/i);
+    expect(det.confidence).not.toBe('none');
+  });
+
+  it('recording onto a legacy profile backfills buckets WITHOUT moving the legacy cumulative counts', () => {
+    writeLegacyProfile(60);
+    const at = new Date(2026, 5, 9, 12, 0, 0).toISOString();
+    const store = new RelationshipBehaviorStore(tmp, () => at, { bucketMs: DAY_MS });
+    store.record('U_LEGACY', { action: 'read', tier: 1, hour: 12, length: 30, urgent: false });
+    const prof = store.profileFor('U_LEGACY')!;
+    // Cumulative grew by 1 (51); buckets now exist holding ONLY the new observation (count 1).
+    expect(prof.interactionCount).toBe(51);
+    expect(Array.isArray(prof.buckets)).toBe(true);
+    const bucketCount = prof.buckets!.reduce((s, b) => s + b.count, 0);
+    expect(bucketCount).toBe(1); // the 50 legacy obs stay as the un-bucketed legacy base
+    // The decayed view sees the 50 legacy obs at FULL weight + the 1 fresh bucket at near-1
+    // (the fresh bucket carries a sub-window intra-day age, so its weight is just under 1.0).
+    const view = decayedView(prof, { nowMs: new Date(at).getTime(), bucketMs: DAY_MS });
+    expect(view.effectiveCount).toBeGreaterThan(50.9);
+    expect(view.effectiveCount).toBeLessThanOrEqual(51);
+    expect(view.actionCounts.read).toBeGreaterThan(40); // 40 legacy + ~1 fresh
   });
 });

--- a/upgrades/next/slack-anomaly-poisoning-resistance.md
+++ b/upgrades/next/slack-anomaly-poisoning-resistance.md
@@ -1,0 +1,21 @@
+## What Changed
+
+feat(permissions): deeper **baseline-poisoning resistance** for the Slack relationship anomaly detector — the pre-enforce follow-ups (#2/#3) from the Phase-3 adversarial review. **Observe-only / dark, additive, backward-compatible.**
+
+- **Recency/decay (dual-view max):** the behavior store keeps optional day-bucketed counts; the scorer computes a decay-weighted view AND keeps the cumulative view, and scores each signal as the **more-suspicious of the two** (max anomaly / lower normal-ceiling / lower normal-rate). Decay can only ADD suspicion, never disarm a cumulative signal — so the never-lower invariant holds; its real job is durability (a one-time burst fades once genuine traffic resumes). Default half-life 30 day-windows.
+- **Minimum-baseline-age (#3a):** "established" now requires `firstSeen` older than `minBaselineAgeDays` (default 7) AND `interactionCount >= establishedMin` — a high-count-but-young burst stays low-confidence (action/tier/style signals suppressed). `0` restores legacy count-only behavior.
+- **Per-principal rate cap (#3b):** `maxObservationsPerWindow` (default 50/day-window); excess observations are dropped + logged (`onCapDrop`), never recorded — cumulative + bucket counts stay in lock-step. `0` disables.
+- All under `permissionGate.relationshipAnomaly.poisoningResistance`; absence preserves shipped behavior. Decay is read-time only (raw counts persist) → retune/revert needs no migration. Legacy profiles (no `buckets` field) score identically (decayed view degrades to cumulative).
+
+## What to Tell Your User
+
+Nothing changes by default. This hardens the (still-dark) relationship anomaly detector against a patient attacker who tries to "train" the baseline — by slowly feeding normal-looking activity, or a burst of it — so a later out-of-character request looks normal. Three additive defenses: recent activity can't durably overwrite long-standing behavior, a freshly-created baseline isn't trusted until it's both old enough and large enough, and no single account can flood the baseline faster than a capped rate. It can still only ever ask for *more* verification, never less. Needed before the anomaly layer is ever switched from observe-only to enforcing.
+
+## Summary of New Capabilities
+
+- **`permissionGate.relationshipAnomaly.poisoningResistance: { decayHalfLifeWindows, minBaselineAgeDays, maxObservationsPerWindow, bucketMs }`** (opt-in; the whole anomaly feature stays dark by default) — recency-decay + minimum-baseline-age + per-principal observation-rate-cap, so a poisoned baseline can't disarm the detector.
+
+## Evidence
+
+- 32 anomaly tests (12 new): rate-cap burst / per-window / opt-out; min-age young-vs-aged / opt-out; decay durability + a "without the rate cap" counter-test proving the cap is load-bearing; backward-compat (legacy-profile decay/scoring/backfill). Counterfactuals confirm each hardening is load-bearing (with it off, the poisoning attack succeeds; on, it's caught). 61/61 with the permission-gate + routes integration. `tsc --noEmit` clean; full lint chain clean (state-registry, silent-fallback ratchet, topic-creation). (Full unit suite runs in CI, sharded — local run blocked by host CPU starvation.)
+- Side-effects review (`upgrades/side-effects/slack-anomaly-poisoning-resistance.md`); deterministic (no LLM-in-gate-path) so reviewed by me + the counterfactual tests, never-lower preserved by the dual-view-max design.

--- a/upgrades/side-effects/slack-anomaly-poisoning-resistance.md
+++ b/upgrades/side-effects/slack-anomaly-poisoning-resistance.md
@@ -1,0 +1,52 @@
+# Side-Effects Review — Slack relationship-anomaly baseline-poisoning resistance (Phase-3 follow-ups #2/#3)
+
+**Version / slug:** `slack-anomaly-poisoning-resistance`
+**Date:** 2026-06-09
+**Author:** Instar Agent (echo)
+**Second-pass reviewer:** not required (see §5 — detector-only, observe-only/dark; no blocking authority added)
+
+## Summary of the change
+
+Deepens baseline-poisoning resistance for the Slack relationship-aware anomaly detector (Pillar 3, SLACK-ORG-INTEGRATION-SPEC.md §7), the pre-enforce follow-ups #2/#3 flagged by the Phase-3 adversarial review (PR #1022). The threat is a patient attacker / slowly-compromised account that injects many normal-looking observations (and/or a burst) to reshape a principal's behavioral baseline so a later out-of-character request scores low. Three additive, backward-compatible, observe-only hardenings: (#2) recency/decay weighting via optional time-bucketed history + exponential bucket-age decay, scored as the max-anomaly across BOTH the cumulative and the decayed view so the hardening only ever adds resistance; (#3a) a minimum-baseline-AGE requirement (a baseline is "established" only when firstSeen is older than N days AND interactionCount ≥ establishedMin); (#3b) a per-principal observation-rate cap (excess observations in a rolling window are dropped + logged, never recorded). Files: `src/permissions/RelationshipBehaviorStore.ts` (buckets, decay helpers, rate cap), `src/permissions/RelationshipAnomalyScorer.ts` (dual-view max-anomaly scoring + min-age gate), `src/commands/server.ts` (wire `permissionGate.relationshipAnomaly.poisoningResistance` config), `docs/specs/SLACK-ORG-INTEGRATION-SPEC.md` (§7.7), `tests/unit/slack-relationship-anomaly.test.ts` (12 new tests + aged-seed fixtures). The decision point touched is the anomaly SCORER (a detector), not any authority.
+
+## Decision-point inventory
+
+- `RelationshipAnomalyScorer.assess/deterministicScore` — modify — strengthens the anomaly SCORE (a signal); produces no block/allow. The consuming SlackPermissionGate (the authority) is unchanged.
+- `RelationshipBehaviorStore.record` — modify — adds a structural write-bound (rate cap) on what SHAPE gets recorded; produces no block/allow on the message path.
+- `permissionGate.relationshipAnomaly.poisoningResistance` config (server.ts) — add — optional knobs; absence preserves shipped defaults.
+
+---
+
+## 1. Over-block
+
+No block/allow surface — over-block not applicable. The scorer produces a 0..1 anomaly score + reasons (a signal); the whole Pillar-3 feature ships observe-only/dark (§7.6: would-be step-ups are logged, never live-challenged). The closest analog to "over-fire" is a false-positive anomaly. The min-age gate (#3a) and the never-lower invariant make the hardening *more* conservative about firing on thin/young baselines, not less; the dual-view max-anomaly never invents a step-up on a no/thin baseline (a new principal still scores 0, confidence 'none'). The rate cap drops *recording*, not requests — a dropped observation never affects the message path; at worst the baseline grows slightly slower, which only lowers anomaly confidence (more conservative).
+
+## 2. Under-block
+
+No block/allow surface — under-block not applicable. As a detector, the residual gaps are: (a) a *very* slow attacker who stays under the rate cap for many windows AND sustains a campaign long enough that the action's share rises above the floor in BOTH views can still normalize an action — but this requires a sustained multi-week campaign the cap throttles, far harder than the single-burst / single-seeded-observation attacks #1/#2/#3 close; (b) decay half-life is a tuning choice — too short helps a recent burst, too long lets stale behavior dominate; default 30 windows is conservative and config-overridable. The floor protection (RolePolicy / Layer-0 grants) protects dangerous actions regardless of anomaly, so an under-fire is harmless (nothing is blocked in observe mode, and a floor action still needs a grant when enforcement is on).
+
+## 3. Level-of-abstraction fit
+
+Correct layer. The hardening lives in the same module that owns the baseline (the store) and the same scorer that owns the signal — it does not reach up into the gate/authority or down into transport. The rate cap belongs in `record()` (the single write funnel for the baseline) and the decay/age logic belongs in the scorer's read path (pure, deterministic, testable). No higher layer should own per-principal histogram robustness; no lower layer sees principal identity. The decayed-view computation is a pure read-time function — the store still persists raw counts, so the model can be retuned without a data migration.
+
+## 4. Signal vs authority compliance
+
+Compliant (the load-bearing question). Per `docs/signal-vs-authority.md`: the scorer is a DETECTOR — it surfaces an anomaly score + human-readable reasons and holds zero blocking power. The single authority for the permission decision (SlackPermissionGate) is untouched and still the only thing that can raise a verdict to step-up, and only ever to RAISE a would-be-allowed floor action (§7.4 never-lower). The dual-view max-anomaly design is explicitly an "only add" rule: a hardening must never DISARM a signal the pre-hardening cumulative baseline would have fired (the cumulative view is always evaluated alongside the decayed view and the more-anomalous wins). The rate cap is a structural write-bound (a validator on recorded SHAPE), not a brittle blocker on inputs. No new brittle authority is introduced.
+
+## 5. Interactions
+
+- **With mitigation #1 (share-floor, already merged):** complementary. #1 made out-of-character fire on low SHARE not only never-seen; #3b's rate cap keeps a burst's share *small* so #1's floor keeps biting; #2's decayed view re-arms #1 once a burst ages out. The counter-test (`WITHOUT the rate cap … demonstrating the cap is load-bearing`) proves #1 alone is defeated by an uncapped 100-obs burst and that #3b is what preserves it.
+- **With the LLM style check (optional, fail-closed):** unchanged. It still adds-only and fails closed; it reads a coarse cumulative summary (a prose hint), not the scoring path.
+- **Buckets-sum invariant:** the cumulative counts remain the exact sum of bucket counts + the legacy (pre-bucketing) base, so an old reader of the persisted profile sees identical numbers. A dropped observation touches NEITHER the cumulative nor the bucket counts, so the cap can't desync them.
+- **No double-fire / no race:** `record()` is the existing single write funnel (best-effort, swallows errors, atomic temp+rename write). The rate cap adds one branch inside it; no new writer, no new file, no new timer.
+
+## 6. External surfaces
+
+- **Persisted state:** the `slack-relationship-baselines.json` profile gains an OPTIONAL `buckets` array (additive field under the existing `slack-relationship-baselines` state-registry category — lint-state-registry clean, no new category). A profile written by an older build (no `buckets`) is read and scored identically (degrades to its cumulative form at full weight). A profile written by this build is still readable by an older build (it ignores the unknown field).
+- **API:** `GET /permissions/baselines` is unchanged (it serializes the profile as-is, including the new optional field). No new route.
+- **Config:** new optional `permissionGate.relationshipAnomaly.poisoningResistance` sub-config; absence preserves shipped behavior. Feature stays dark (Null scorer default).
+- **Cross-agent / cross-machine:** none. No Threadline, no messaging, no spawn surface touched.
+
+## 7. Rollback cost
+
+Low. The feature ships dark (observe-only; off unless `relationshipAnomaly.enabled` + a non-Null scorer). Back-out is a code revert of the five files — no release-incident class, no agent-state repair. The persisted `buckets` field is forward/backward-compatible, so a revert leaves existing baseline files readable by the reverted code (the extra field is ignored). The decay model is read-time only (raw counts persist), so a retune or revert needs no data migration. To disable the hardenings without reverting: `minBaselineAgeDays: 0` (legacy count-only established), `maxObservationsPerWindow: 0` (cap off), and a large `decayHalfLifeWindows` (decay ≈ off / cumulative).


### PR DESCRIPTION
## What & why

The pre-enforce follow-ups (#2/#3) flagged by the Phase-3 (#1022) adversarial review, which found that a patient attacker could "train" the SHAPE-only baseline so a later out-of-character request scores low. Mitigation #1 (rare-action share floor) already landed in #1022; this adds the deeper, schema-touching defenses. **Observe-only / dark, additive, backward-compatible.**

## The three hardenings
- **Recency/decay — dual-view max (the key design call):** pure age-decay would *help* a recent burst (recency wins), so instead the scorer keeps BOTH the cumulative view and a decay-weighted view and scores each signal as the **more-suspicious of the two** (`Math.max` z-score, *lower* normal-ceiling, *lower* normal-rate). Decay can only ADD suspicion, never disarm a cumulative signal — **never-lower preserved**. Its real role is durability: a one-time burst fades once genuine traffic resumes. Default half-life 30 day-windows.
- **Minimum-baseline-age (#3a):** "established" now requires `firstSeen` older than `minBaselineAgeDays` (default 7) AND `interactionCount >= establishedMin` — a high-count-but-*young* burst stays low-confidence (action/tier/style suppressed). `0` = legacy behavior.
- **Per-principal rate cap (#3b):** `maxObservationsPerWindow` (default 50/day-window); excess observations dropped + logged (`onCapDrop`), never recorded; cumulative + bucket counts stay in lock-step. `0` disables.

All under `permissionGate.relationshipAnomaly.poisoningResistance`; absence preserves shipped behavior. Decay is read-time only (raw counts persist) → retune/revert needs no migration. **Backward-compat:** a legacy profile (no `buckets` field) scores identically (decayed view degrades to cumulative); new profiles still readable by old builds.

## Review
Deterministic (no LLM-in-gate-path) → reviewed by me + counterfactual tests, not an adversarial subagent. The never-lower invariant is preserved by construction (every signal takes the more-suspicious view). Residual (documented in the side-effects doc): a *very* slow multi-week attacker staying under the cap could still raise an action's share in both views — throttled far below the single-burst attacks this closes, and the Layer-0 floor (role/grants) protects dangerous actions regardless of anomaly.

## Tests
32 anomaly tests (12 new): rate-cap burst / per-window / opt-out; min-age young-vs-aged / opt-out; decay durability + a "without the rate cap" **counter-test proving the cap is load-bearing**; backward-compat (legacy-profile decay/scoring/backfill). Counterfactuals confirm each hardening is load-bearing. 61/61 with the permission-gate + routes integration. `tsc --noEmit` clean; full lint chain clean. (Full unit suite runs sharded in CI — local run blocked by host CPU starvation.)

## ELI16
This hardens the (still-off-by-default) "is this really you?" detector against being slowly fooled. The detector learns the *shape* of how each person normally behaves; a patient attacker could try to reshape that — feeding lots of normal-looking activity over time, or a sudden burst of it — so a later sketchy request from a hijacked account looks in-character. Three new guards stop that: recent activity can't durably overwrite long-standing history (so a burst fades), a brand-new baseline isn't trusted until it's both old enough and big enough (so an attacker can't quickly manufacture a "normal"), and no single account can dump observations faster than a capped rate (so it can't flood the picture). Crucially it can still only ever ask for *more* verification, never less, and a hijacked account still has to get past the hard role/permission floor regardless. It's defense-in-depth we want in place before this detector is ever switched from "just watching" to actually enforcing. Off by default; nothing changes until enabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)