### PR TITLE
chore(slack): live-test cleanups — ambient-silence observability + respondMode doc accuracy

### DIFF
--- a/.instar/instar-dev-decisions/2026-06-09T20-09-57-151Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-06-09T20-09-57-151Z-unknown.json
@@ -1,0 +1,15 @@
+{
+  "ts": "2026-06-09T20:09:57.151Z",
+  "slug": "unknown",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "new capability: new route (router.<verb>() added"
+  ],
+  "belowFloor": true,
+  "files": 3,
+  "loc": 212,
+  "causalAutopsy": null,
+  "verdict": "pass"
+}

--- a/docs/specs/SLACK-ORG-INTEGRATION-SPEC.md
+++ b/docs/specs/SLACK-ORG-INTEGRATION-SPEC.md
@@ -144,17 +144,32 @@ For org/`shared` mode, the agent is present **only in channels she's invited to*
 
 Principle: **she is present where she's asked to be, nowhere else.** Leaving a channel (kick/`/leave`) immediately stops ingestion for it.
 
-### 5.2 Response modes — add a third: `considered` (ambient)
+### 5.2 Response modes + the `considered`/ambient capability
 
-Today's modes are binary. We add a third that matches Justin's "good employee" model:
+Today's `respondMode` is binary — and it STAYS binary. The two shipped values are:
 
 | Mode | Reads | Speaks |
 |---|---|---|
 | `all` | everything | replies to every message (good for a dedicated 1:1 channel) |
-| `mention-only` | everything | only when `@`-mentioned |
-| **`considered`** (new) | **everything** | when `@`-mentioned **OR** when a "should I speak?" gate clears a **high** confidence bar |
+| `mention-only` | everything | only when `@`-mentioned (or in a DM) |
 
-`considered` is the org default for shared channels. The **ingest half already exists** (every message lands in the ring buffer / context). The **new half** is a *decision-to-engage gate*, built on the `MessagingToneGate` pattern but inbound:
+> **Implementation note — there is NO third `respondMode` value.** Earlier drafts of
+> this section proposed a distinct `respondMode: 'considered'`. The shipped design is
+> simpler: the `SlackRespondMode` type stays `'all' | 'mention-only'`, and the
+> "good-employee" / **`considered`** behavior is a **config-driven capability layered
+> on top of `mention-only`**, not a new enum value. A channel "runs in considered
+> mode" exactly when it is in `mention-only` AND its channel id is listed in
+> `slack.config.ambientContribution.enabledChannelIds`. With that list empty (the
+> default everywhere), `mention-only` behaves byte-for-byte as today — undirected
+> messages are dropped. Throughout this doc, "`considered`/ambient mode" names that
+> layered capability (`mention-only` + ambient opt-in), never a `respondMode` literal.
+
+The "should I speak?" behavior matches Justin's "good employee" model: in a
+`considered`/ambient channel, an undirected message — which `mention-only` would
+silently drop — instead runs a conservative engagement gate that may (rarely) let her
+volunteer an unprompted contribution. The **ingest half already exists** (every message
+lands in the ring buffer / context). The **engage half** is a *decision-to-engage gate*,
+built on the `MessagingToneGate` pattern but inbound (`AmbientContributionGate`):
 
 - **Signals:** is she @mentioned? is this a question in her domain? is a topic she owns being discussed? has she already spoken recently (rate-limit)? is the channel opted into proactive contribution?
 - **Authority:** a fast LLM judgment that **defaults to silence** and only returns "speak" when it can name a concrete, meaningful contribution.
@@ -459,7 +474,7 @@ Following instar norms: **dark → canary → fleet**, **observe-only before gat
 - **Fail directions are deliberate and opposite:** the **floor gate fails closed** (deny on error — never let a money/prod/credential action through on a timeout); the **ambient/should-speak gate fails to silence** (say nothing on error); the **classifier fails to clarify/escalate**, never to silent-allow.
 - **3-tier test standard** (unit / integration / e2e "feature is alive") for each phase, plus wiring-integrity tests (the permission gate is actually called, not a no-op — directly fixing the current "stored but never enforced" defect) and semantic tests on both sides of each decision boundary.
 - **Observe-only first** for every judgment surface (Layers 1–3, anomaly) so we measure before we gate.
-- **Migration parity** for `UserProfile.slackUserId`, config defaults (new `respondMode: 'considered'`), and any CLAUDE.md template additions.
+- **Migration parity** for `UserProfile.slackUserId`, config defaults (the `ambientContribution` opt-in block — NOT a new `respondMode` value; see §5.2), and any CLAUDE.md template additions.
 
 ## 13. Open questions for Justin
 

--- a/docs/specs/slack-livetest-cleanups.eli16.md
+++ b/docs/specs/slack-livetest-cleanups.eli16.md
@@ -1,0 +1,40 @@
+# Slack live-test cleanups — Plain-English Overview
+
+> The one-line version: make the agent's wrongful SILENCES in Slack countable (so we can measure them during the live test), and fix a spec that described a "considered" mode the code never actually had.
+
+## The problem in one breath
+
+When the agent sits quietly in a Slack channel and decides NOT to speak, that decision left no trace anywhere — only the times it DID speak got logged. So if the agent was staying silent when it should have piped up (or vice versa), there was no way to count how often that happened during the careful observe-only trial. Separately, the Slack design doc claimed there was a third "response mode" called `considered` that the shipped code never had — the real behavior is built a different way.
+
+## What already exists
+
+- **The ambient "should I speak?" gate** — in channels explicitly opted in, an undirected message (one nobody addressed to the agent) gets a conservative check that almost always says "stay silent." It only ever makes the agent quieter. This is off by default everywhere.
+- **A speak-path log** — when the gate decides to speak, that gets written to the console and to an observability hook. Silences were invisible.
+- **The `/permissions/decisions` route** — a durable, file-backed ledger for the OTHER (authority) Slack gate, used to measure its decisions before enforcing.
+
+## What this adds
+
+The ambient gate now keeps a small running tally, per channel, of every time it was consulted: how many it evaluated, how many it spoke on, how many it stayed silent on, and — the useful bit — how many silences were "near-misses" (it almost spoke, its confidence landed just below the bar). It also keeps a short, capped list of the most-recent near-miss silences so a person can eyeball them. A new read-only web route, `GET /permissions/ambient-stats`, hands that tally to whoever is running the live test.
+
+The doc fix simply rewrites the design spec so it matches reality: there is no `considered` response mode value; "considered/ambient mode" is the `mention-only` mode plus a per-channel opt-in list.
+
+## The new pieces
+
+- **The ambient stats aggregate** — an in-memory counter living on the gate itself. It is NOT allowed to change any speak/silence decision; it only watches and counts after the decision is already made. That line matters: an observability bug must never make the agent louder or quieter.
+- **`GET /permissions/ambient-stats`** — a read-only window into that counter. It sends no Telegram messages and creates no forum topics, so it can't cause notification spam. It reports "not present" when no channel has opted in (the normal case).
+
+## The safeguards
+
+**Prevents the agent from getting louder or quieter by accident.** The counting happens after the verdict is fixed, is wrapped so a counting bug is swallowed, and a regression test asserts the verdict is byte-for-byte identical whether or not the counter runs.
+
+**Prevents notification floods.** The new surface is a passive counter and a read-only route — it never creates a Telegram topic or message. The flood burst-invariant test still passes.
+
+**Prevents unbounded memory growth.** The near-miss list is a fixed-size ring (default 50); the per-channel map is bounded by the small, config-controlled set of opted-in channels. A test floods it with 100 near-misses and confirms the ring stays capped.
+
+## What ships when
+
+Both cleanups ship together in one Tier-1 commit: the observability code + its tests, and the doc-accuracy edit. Nothing is staged behind a flag because the ambient gate itself is already dark by default — with no opted-in channel, nothing is recorded and the route reports "not present."
+
+## What you actually need to decide
+
+Are you OK merging a signal-only observability addition (no behavior change, fully dark by default) plus a doc-accuracy fix to the Slack spec — yes or no?

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "instar",
-  "version": "1.3.450",
+  "version": "1.3.451",
   "description": "Coherence infrastructure for self-evolving AI agents — on the Claude Code or Codex subscription you already have.",
   "type": "module",
   "main": "dist/index.js",

--- a/src/messaging/slack/SlackAdapter.ts
+++ b/src/messaging/slack/SlackAdapter.ts
@@ -353,6 +353,17 @@ export class SlackAdapter implements MessagingAdapter {
     this.ambientGate = gate;
   }
 
+  /**
+   * Read-only snapshot of the ambient gate's bounded observability aggregate
+   * (per-channel evaluated/spoke/silent/near-miss counts + a bounded ring of recent
+   * near-miss silences). Returns null when no ambient gate is attached (the default —
+   * no channel opted in). Signal-only: reading it never affects any decision. Surfaced
+   * via GET /permissions/ambient-stats for the observe-only live test.
+   */
+  getAmbientStats(): ReturnType<AmbientContributionGate['getStats']> | null {
+    return this.ambientGate ? this.ambientGate.getStats() : null;
+  }
+
   async resolveUser(channelIdentifier: string): Promise<string | null> {
     // For Slack, the channel identifier IS the user reference
     return channelIdentifier || null;

--- a/src/permissions/AmbientContributionGate.ts
+++ b/src/permissions/AmbientContributionGate.ts
@@ -57,6 +57,68 @@ export interface AmbientDecision {
   detail?: string;
 }
 
+/**
+ * Observability — a bounded, in-memory record of a SINGLE silence the gate is
+ * about to return. Used only to populate the near-miss ring; never affects the
+ * decision. No message text is stored — just the channel, reason, and how close
+ * the (clamped) confidence was to the threshold.
+ */
+export interface AmbientSilenceSample {
+  /** The Slack channel the silence occurred in. */
+  channelId: string;
+  /** Why the gate stayed silent. */
+  reason: AmbientDecisionReason;
+  /**
+   * The LLM's clamped confidence for this evaluation, when one was produced
+   * (only the LLM paths carry it; the channel-not-opted-in / rate-limited /
+   * no-intelligence / llm-error / llm-unparseable paths leave it undefined).
+   */
+  confidence?: number;
+  /** Whether this silence was within `nearMissDelta` below the speak threshold. */
+  nearMiss: boolean;
+  /** When the sample was taken (gate clock). */
+  at: number;
+}
+
+/**
+ * Per-channel ambient observability counters + a bounded ring of recent near-miss
+ * silences. Pure aggregate — NO message content, NO per-event Telegram/topic
+ * side-effect (so it can never flood). This is the read surface the observe-only
+ * live test polls to measure the ambient gate's false-positive (wrongful-silence)
+ * and false-negative (wrongful-speak) rates. Signal-only: reading or computing it
+ * NEVER changes the speak/silence verdict.
+ */
+export interface AmbientChannelStats {
+  channelId: string;
+  /** Every shouldSpeak() call for this channel (spoke + silent). */
+  evaluated: number;
+  /** Decisions that returned speak=true. */
+  spoke: number;
+  /** Decisions that returned speak=false (the FP candidates). */
+  silent: number;
+  /**
+   * Silences where the LLM's confidence was within `nearMissDelta` BELOW the
+   * speak threshold — i.e. it nearly spoke. The highest-signal subset for tuning
+   * the confidence floor.
+   */
+  nearMissSilent: number;
+  /** Per-reason silence breakdown (channel-not-opted-in, rate-limited, …). */
+  silentByReason: Partial<Record<AmbientDecisionReason, number>>;
+}
+
+export interface AmbientStats {
+  /** Per-channel aggregate counters. */
+  channels: AmbientChannelStats[];
+  /** Bounded ring (most-recent-first) of recent near-miss silences for spot-inspection. */
+  recentNearMisses: AmbientSilenceSample[];
+  /** The near-miss delta in use (confidence within this far below the threshold). */
+  nearMissDelta: number;
+  /** The confidence floor a "speak" verdict must clear. */
+  minConfidence: number;
+  /** Cap on the recentNearMisses ring (bounded — no unbounded growth). */
+  ringCapacity: number;
+}
+
 export type AmbientDecisionReason =
   | 'channel-not-opted-in' // (a) failed — channel is not ambient-enabled → silent
   | 'rate-limited' // (b) failed — per-channel window budget exhausted → silent
@@ -84,6 +146,18 @@ export interface AmbientChannelConfig {
    * this, the gate stays silent even if the LLM said speak. Default: 0.85 (high bar).
    */
   minConfidence?: number;
+  /**
+   * Observability only — a silence whose confidence lands within this far BELOW
+   * `minConfidence` is flagged a "near-miss" (it nearly spoke). Default: 0.1. Has
+   * NO effect on the verdict; it only classifies silences for the stats surface.
+   */
+  nearMissDelta?: number;
+  /**
+   * Observability only — cap on the in-memory ring of recent near-miss silence
+   * samples kept for spot-inspection. Bounded so the gate can never grow unbounded.
+   * Default: 50.
+   */
+  nearMissRingCapacity?: number;
 }
 
 export interface AmbientContributionGateDeps {
@@ -119,6 +193,8 @@ export interface AmbientGateInput {
 const DEFAULT_MAX_PROACTIVE = 1;
 const DEFAULT_WINDOW_MS = 30 * 60 * 1000; // 30 minutes
 const DEFAULT_MIN_CONFIDENCE = 0.85;
+const DEFAULT_NEAR_MISS_DELTA = 0.1;
+const DEFAULT_NEAR_MISS_RING_CAPACITY = 50;
 
 interface RawAmbientVerdict {
   speak?: unknown;
@@ -135,6 +211,21 @@ export class AmbientContributionGate {
   private readonly timeoutMs: number;
   private readonly onDecision?: (decision: AmbientDecision, channelId: string) => void;
   private readonly now: () => number;
+  private readonly nearMissDelta: number;
+  private readonly nearMissRingCapacity: number;
+
+  /**
+   * Observability — bounded, in-memory aggregate of every decision, per channel.
+   * Populated in recordDecisionStats() (called from decide() AFTER the verdict is
+   * formed), so it can never change the verdict. No message content is stored. A
+   * restart resets it; this is acceptable for an FP-rate measurement surface (the
+   * durable per-decision ledger is the file-backed /permissions/decisions). The map
+   * is keyed by channelId — bounded by the set of opted-in channels, which is small
+   * and config-controlled.
+   */
+  private readonly channelStats: Map<string, AmbientChannelStats> = new Map();
+  /** Bounded ring (newest-last) of recent near-miss silences for spot-inspection. */
+  private readonly nearMissRing: AmbientSilenceSample[] = [];
 
   /**
    * Rate-limit state lives HERE — a per-channel in-memory ring of the timestamps at
@@ -159,6 +250,8 @@ export class AmbientContributionGate {
     this.timeoutMs = deps.timeoutMs ?? 8000;
     this.onDecision = deps.onDecision;
     this.now = deps.now ?? (() => Date.now());
+    this.nearMissDelta = cfg.nearMissDelta ?? DEFAULT_NEAR_MISS_DELTA;
+    this.nearMissRingCapacity = cfg.nearMissRingCapacity ?? DEFAULT_NEAR_MISS_RING_CAPACITY;
   }
 
   /** Is ANY channel opted into ambient contribution? Used to skip the gate entirely. */
@@ -226,11 +319,19 @@ export class AmbientContributionGate {
 
     // Conservative confidence bar. Below it (or no named contribution) → silence.
     if (parsed.confidence < this.minConfidence || !parsed.contribution) {
-      return this.decide(input.channelId, { speak: false, reason: 'low-confidence', detail: parsed.contribution });
+      return this.decide(
+        input.channelId,
+        { speak: false, reason: 'low-confidence', detail: parsed.contribution },
+        parsed.confidence,
+      );
     }
 
     // ALL fail-to-silence conditions held → speak.
-    return this.decide(input.channelId, { speak: true, reason: 'speak', detail: parsed.contribution });
+    return this.decide(
+      input.channelId,
+      { speak: true, reason: 'speak', detail: parsed.contribution },
+      parsed.confidence,
+    );
   }
 
   /**
@@ -270,13 +371,85 @@ export class AmbientContributionGate {
     return fresh.length;
   }
 
-  private decide(channelId: string, decision: AmbientDecision): AmbientDecision {
+  private decide(
+    channelId: string,
+    decision: AmbientDecision,
+    confidence?: number,
+  ): AmbientDecision {
+    // Observability — record into the bounded in-memory aggregate. This runs AFTER
+    // the verdict is fully formed and returns `decision` UNCHANGED, so it can never
+    // alter the speak/silence outcome. Wrapped so a stats bug can never break a send.
+    try {
+      this.recordDecisionStats(channelId, decision, confidence);
+    } catch {
+      /* aggregate is best-effort and must never affect the verdict */
+    }
     try {
       this.onDecision?.(decision, channelId);
     } catch {
       /* observability is best-effort and must never affect the verdict */
     }
     return decision;
+  }
+
+  /**
+   * Update the per-channel counters and (for a near-miss silence) the bounded ring.
+   * A SILENCE is a "near-miss" when the LLM produced a confidence that fell within
+   * `nearMissDelta` BELOW the speak threshold — i.e. it nearly spoke. Paths with no
+   * confidence (not-opted-in, rate-limited, no-intelligence, llm-error, unparseable)
+   * are never near-misses. Pure in-memory; no content stored; no side-effect.
+   */
+  private recordDecisionStats(channelId: string, decision: AmbientDecision, confidence?: number): void {
+    let s = this.channelStats.get(channelId);
+    if (!s) {
+      s = { channelId, evaluated: 0, spoke: 0, silent: 0, nearMissSilent: 0, silentByReason: {} };
+      this.channelStats.set(channelId, s);
+    }
+    s.evaluated += 1;
+
+    if (decision.speak) {
+      s.spoke += 1;
+      return;
+    }
+
+    s.silent += 1;
+    s.silentByReason[decision.reason] = (s.silentByReason[decision.reason] ?? 0) + 1;
+
+    // A near-miss requires a real confidence within the delta below the threshold.
+    const nearMiss =
+      typeof confidence === 'number' &&
+      confidence < this.minConfidence &&
+      confidence >= this.minConfidence - this.nearMissDelta;
+    if (nearMiss) {
+      s.nearMissSilent += 1;
+      this.nearMissRing.push({ channelId, reason: decision.reason, confidence, nearMiss: true, at: this.now() });
+      // Bounded: drop the oldest once over capacity (FIFO).
+      while (this.nearMissRing.length > this.nearMissRingCapacity) this.nearMissRing.shift();
+    }
+  }
+
+  /**
+   * Read-only snapshot of the bounded observability aggregate. Safe to call any time
+   * (returns copies — the caller can't mutate internal state). With no opted-in
+   * channel the gate is never consulted, so `channels` stays empty and nothing is
+   * recorded. This is the surface the observe-only live test polls.
+   */
+  getStats(): AmbientStats {
+    return {
+      channels: Array.from(this.channelStats.values()).map(s => ({
+        channelId: s.channelId,
+        evaluated: s.evaluated,
+        spoke: s.spoke,
+        silent: s.silent,
+        nearMissSilent: s.nearMissSilent,
+        silentByReason: { ...s.silentByReason },
+      })),
+      // Newest-first for readability.
+      recentNearMisses: this.nearMissRing.slice().reverse(),
+      nearMissDelta: this.nearMissDelta,
+      minConfidence: this.minConfidence,
+      ringCapacity: this.nearMissRingCapacity,
+    };
   }
 }
 

--- a/src/server/routes.ts
+++ b/src/server/routes.ts
@@ -14545,6 +14545,28 @@ export function createRoutes(ctx: RouteContext): Router {
     }
   });
 
+  // GET /permissions/ambient-stats — read-only snapshot of the ambient "should I
+  // speak?" gate's bounded in-memory observability aggregate (per-channel
+  // evaluated/spoke/silent/near-miss counts + a bounded ring of recent near-miss
+  // silences). This is what makes a WRONGFUL SILENCE measurable: the speak-path log
+  // alone only records when the agent SPOKE, so the ambient FP-rate (wrongful
+  // silences) was previously invisible during the observe-only live test. Signal-only:
+  // reading it never changes any speak/silence decision; it creates no Telegram/topic
+  // side-effect (so it can never flood). Returns { present: false } when no ambient
+  // gate is attached (the default — no channel opted in, gate stays dark).
+  // Design: docs/specs/SLACK-ORG-INTEGRATION-SPEC.md §5.2, §6.10, §11.
+  router.get('/permissions/ambient-stats', (req, res) => {
+    try {
+      const stats = ctx.slack?.getAmbientStats?.() ?? null;
+      if (!stats) {
+        return res.json({ present: false, reason: 'no-ambient-gate-attached' });
+      }
+      res.json({ present: true, stats });
+    } catch (e) {
+      res.status(500).json({ error: (e as Error).message });
+    }
+  });
+
   // GET /permissions/baselines — read-only view of the Pillar 3 behavioral baselines.
   // Returns per-principal SHAPE aggregates (action repertoire, tier/hour histograms,
   // coarse length stats) — NEVER message content. Inspection surface for the

--- a/tests/integration/permissions-routes.test.ts
+++ b/tests/integration/permissions-routes.test.ts
@@ -95,6 +95,37 @@ describe('GET /permissions/decisions (integration)', () => {
   });
 });
 
+describe('GET /permissions/ambient-stats (integration — Cleanup #2 observability)', () => {
+  it('returns { present: false } when no Slack adapter / ambient gate is attached', async () => {
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'perm-routes-'));
+    const res = await request(appWith(tmp)).get('/permissions/ambient-stats');
+    expect(res.status).toBe(200);
+    expect(res.body.present).toBe(false);
+  });
+
+  it('surfaces the ambient aggregate from the live Slack adapter when attached', async () => {
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'perm-routes-'));
+    const app = express();
+    app.use(express.json());
+    const ctx = ctxWith(tmp);
+    // Stub a Slack adapter exposing getAmbientStats() (the live passthrough).
+    (ctx as any).slack = {
+      getAmbientStats: () => ({
+        channels: [{ channelId: 'C1', evaluated: 3, spoke: 1, silent: 2, nearMissSilent: 1, silentByReason: { 'low-confidence': 1, 'llm-declined': 1 } }],
+        recentNearMisses: [{ channelId: 'C1', reason: 'low-confidence', confidence: 0.8, nearMiss: true, at: 123 }],
+        nearMissDelta: 0.1, minConfidence: 0.85, ringCapacity: 50,
+      }),
+    };
+    app.use('/', createRoutes(ctx));
+    const res = await request(app).get('/permissions/ambient-stats');
+    expect(res.status).toBe(200);
+    expect(res.body.present).toBe(true);
+    expect(res.body.stats.channels[0].silent).toBe(2);
+    expect(res.body.stats.channels[0].nearMissSilent).toBe(1);
+    expect(res.body.stats.recentNearMisses).toHaveLength(1);
+  });
+});
+
 describe('GET /permissions/baselines (integration — Pillar 3)', () => {
   it('returns the per-principal behavioral baselines (SHAPE only, never content)', async () => {
     tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'perm-routes-'));

--- a/tests/unit/slack-ambient-contribution-gate.test.ts
+++ b/tests/unit/slack-ambient-contribution-gate.test.ts
@@ -306,3 +306,162 @@ describe('AmbientContributionGate — wiring integrity', () => {
     expect(seen[0].d.reason).toBe('llm-declined');
   });
 });
+
+// ── Cleanup #2: ambient-silence observability (so wrongful silences are measurable) ──
+// The speak-path log only fires on speak=true, so a wrongful SILENCE left no trace.
+// getStats() exposes a bounded in-memory aggregate: per-channel
+// {evaluated, spoke, silent, nearMissSilent, silentByReason} + a bounded ring of recent
+// near-miss silences. SIGNAL-ONLY: recording never changes the verdict.
+describe('AmbientContributionGate — silence observability aggregate (getStats)', () => {
+  it('records a SILENCE in the aggregate (the previously-invisible FP candidate)', async () => {
+    const gate = new AmbientContributionGate({
+      config: { enabledChannelIds: [CH] },
+      intelligence: fakeProvider(() => silentJson(0.2)),
+    });
+    await gate.shouldSpeak({ channelId: CH, text: 'lunch?' });
+    const stats = gate.getStats();
+    const ch = stats.channels.find(c => c.channelId === CH);
+    expect(ch).toBeDefined();
+    expect(ch!.evaluated).toBe(1);
+    expect(ch!.silent).toBe(1);
+    expect(ch!.spoke).toBe(0);
+    expect(ch!.silentByReason['llm-declined']).toBe(1);
+  });
+
+  it('records a SPEAK in the aggregate', async () => {
+    const gate = new AmbientContributionGate({
+      config: { enabledChannelIds: [CH], minConfidence: 0.85 },
+      intelligence: fakeProvider(() => speakJson(0.95)),
+    });
+    await gate.shouldSpeak({ channelId: CH, text: 'CI flake again' });
+    const ch = gate.getStats().channels.find(c => c.channelId === CH)!;
+    expect(ch.evaluated).toBe(1);
+    expect(ch.spoke).toBe(1);
+    expect(ch.silent).toBe(0);
+  });
+
+  it('classifies a near-miss SILENCE (confidence just below the floor, within delta)', async () => {
+    // minConfidence 0.85, delta 0.1 ⇒ near-miss window is [0.75, 0.85). 0.8 lands in it.
+    const gate = new AmbientContributionGate({
+      config: { enabledChannelIds: [CH], minConfidence: 0.85, nearMissDelta: 0.1 },
+      intelligence: fakeProvider(() => speakJson(0.8)),
+    });
+    const d = await gate.shouldSpeak({ channelId: CH, text: 'maybe relevant' });
+    expect(d.speak).toBe(false);
+    expect(d.reason).toBe('low-confidence');
+    const stats = gate.getStats();
+    const ch = stats.channels.find(c => c.channelId === CH)!;
+    expect(ch.silent).toBe(1);
+    expect(ch.nearMissSilent).toBe(1);
+    expect(stats.recentNearMisses).toHaveLength(1);
+    expect(stats.recentNearMisses[0].channelId).toBe(CH);
+    expect(stats.recentNearMisses[0].confidence).toBeCloseTo(0.8);
+    expect(stats.recentNearMisses[0].nearMiss).toBe(true);
+  });
+
+  it('a FAR silence (confidence well below the floor, outside delta) is NOT a near-miss', async () => {
+    const gate = new AmbientContributionGate({
+      config: { enabledChannelIds: [CH], minConfidence: 0.85, nearMissDelta: 0.1 },
+      intelligence: fakeProvider(() => speakJson(0.3)), // far below 0.75 → not a near-miss
+    });
+    await gate.shouldSpeak({ channelId: CH, text: 'unrelated' });
+    const stats = gate.getStats();
+    const ch = stats.channels.find(c => c.channelId === CH)!;
+    expect(ch.silent).toBe(1);
+    expect(ch.nearMissSilent).toBe(0);
+    expect(stats.recentNearMisses).toHaveLength(0);
+  });
+
+  it('a confidence-less silence path (not-opted-in / no-intelligence) is never a near-miss', async () => {
+    // no-intelligence path: opted-in channel but no provider.
+    const gate = new AmbientContributionGate({ config: { enabledChannelIds: [CH] } });
+    const d = await gate.shouldSpeak({ channelId: CH, text: 'x' });
+    expect(d.reason).toBe('no-intelligence');
+    const ch = gate.getStats().channels.find(c => c.channelId === CH)!;
+    expect(ch.silent).toBe(1);
+    expect(ch.nearMissSilent).toBe(0);
+    expect(ch.silentByReason['no-intelligence']).toBe(1);
+  });
+
+  it('the speak/silence DECISION is unchanged by stats recording (regression)', async () => {
+    // Same inputs as the canonical speak / silence tests; the verdict must be identical
+    // whether or not the aggregate is present.
+    const speakGate = new AmbientContributionGate({
+      config: { enabledChannelIds: [CH], minConfidence: 0.85 },
+      intelligence: fakeProvider(() => speakJson(0.95)),
+    });
+    expect((await speakGate.shouldSpeak({ channelId: CH, text: 'CI flake' })).speak).toBe(true);
+
+    const silentGate = new AmbientContributionGate({
+      config: { enabledChannelIds: [CH], minConfidence: 0.85 },
+      intelligence: fakeProvider(() => speakJson(0.7)),
+    });
+    const sd = await silentGate.shouldSpeak({ channelId: CH, text: 'maybe' });
+    expect(sd.speak).toBe(false);
+    expect(sd.reason).toBe('low-confidence');
+  });
+
+  it('with NO opted-in channel nothing is ever recorded (gate stays dark)', async () => {
+    const gate = new AmbientContributionGate({ intelligence: fakeProvider(() => speakJson()) });
+    // The real wiring never even calls shouldSpeak when no channel is enabled, but even
+    // if a stray call lands, it short-circuits at channel-not-opted-in and records that.
+    expect(gate.getStats().channels).toHaveLength(0);
+    expect(gate.getStats().recentNearMisses).toHaveLength(0);
+  });
+
+  it('the near-miss ring is BOUNDED — no unbounded growth under a flood of near-misses', async () => {
+    const cap = 5;
+    const gate = new AmbientContributionGate({
+      config: { enabledChannelIds: [CH], minConfidence: 0.85, nearMissDelta: 0.1, nearMissRingCapacity: cap },
+      intelligence: fakeProvider(() => speakJson(0.8)), // every one is a near-miss
+    });
+    for (let i = 0; i < 100; i++) {
+      await gate.shouldSpeak({ channelId: CH, text: `near-miss ${i}` });
+    }
+    const stats = gate.getStats();
+    // The counter keeps the true total; the ring is capped.
+    const ch = stats.channels.find(c => c.channelId === CH)!;
+    expect(ch.nearMissSilent).toBe(100);
+    expect(stats.recentNearMisses.length).toBe(cap);
+    expect(stats.ringCapacity).toBe(cap);
+  });
+
+  it('aggregate is per-channel (counts do not bleed across channels)', async () => {
+    const CH2 = 'C_AMBIENT_2';
+    const gate = new AmbientContributionGate({
+      config: { enabledChannelIds: [CH, CH2], minConfidence: 0.85 },
+      intelligence: fakeProvider((prompt) => (prompt.includes('speakme') ? speakJson(0.95) : silentJson(0.2))),
+    });
+    await gate.shouldSpeak({ channelId: CH, text: 'speakme please' });
+    await gate.shouldSpeak({ channelId: CH2, text: 'be quiet' });
+    const stats = gate.getStats();
+    expect(stats.channels.find(c => c.channelId === CH)!.spoke).toBe(1);
+    expect(stats.channels.find(c => c.channelId === CH2)!.silent).toBe(1);
+  });
+
+  it('getStats returns copies — mutating the snapshot does not corrupt internal state', async () => {
+    const gate = new AmbientContributionGate({
+      config: { enabledChannelIds: [CH] },
+      intelligence: fakeProvider(() => silentJson(0.2)),
+    });
+    await gate.shouldSpeak({ channelId: CH, text: 'x' });
+    const stats = gate.getStats();
+    stats.channels[0].silent = 999;
+    stats.channels[0].silentByReason['llm-declined'] = 999;
+    const fresh = gate.getStats();
+    expect(fresh.channels[0].silent).toBe(1);
+    expect(fresh.channels[0].silentByReason['llm-declined']).toBe(1);
+  });
+
+  it('a near-miss is NOT created by a SPEAK at exactly the floor (boundary: confidence === minConfidence ⇒ speak)', async () => {
+    const gate = new AmbientContributionGate({
+      config: { enabledChannelIds: [CH], minConfidence: 0.85, nearMissDelta: 0.1 },
+      intelligence: fakeProvider(() => speakJson(0.85)), // exactly at the floor → speaks
+    });
+    const d = await gate.shouldSpeak({ channelId: CH, text: 'CI flake' });
+    expect(d.speak).toBe(true);
+    const ch = gate.getStats().channels.find(c => c.channelId === CH)!;
+    expect(ch.spoke).toBe(1);
+    expect(ch.nearMissSilent).toBe(0);
+  });
+});

--- a/tests/unit/slack-ambient-gate-wiring.test.ts
+++ b/tests/unit/slack-ambient-gate-wiring.test.ts
@@ -155,4 +155,24 @@ describe('SlackAdapter ambient gate wiring', () => {
     expect(messages).toHaveLength(0);
     expect(cap.calls).toBe(0); // AuthGate fails closed before ambient logic
   });
+
+  // ── Cleanup #2: getAmbientStats() passthrough (observability surface) ──
+  it('getAmbientStats() returns null when no gate is attached (DARK default)', () => {
+    const { adapter } = harness(tmp);
+    expect(adapter.getAmbientStats()).toBeNull();
+  });
+
+  it('getAmbientStats() surfaces the live aggregate after the gate processes messages', async () => {
+    const { adapter, handle } = harness(tmp);
+    adapter.setAmbientGate(new AmbientContributionGate({
+      config: { enabledChannelIds: [CH] },
+      intelligence: fakeProvider(() => silentJson), // a wrongful-silence candidate
+    }));
+    await handle({ user: 'U_TEST', text: 'overheard chatter', channel: CH, ts: '10.1' });
+    const stats = adapter.getAmbientStats();
+    expect(stats).not.toBeNull();
+    const ch = stats!.channels.find(c => c.channelId === CH)!;
+    expect(ch.evaluated).toBe(1);
+    expect(ch.silent).toBe(1); // the silence is now measurable
+  });
 });

--- a/upgrades/side-effects/slack-livetest-cleanups.md
+++ b/upgrades/side-effects/slack-livetest-cleanups.md
@@ -1,0 +1,75 @@
+# Side-Effects Review — Slack live-test cleanups (#2 ambient-silence observability, #5 spec/type alignment)
+
+**Version / slug:** `slack-livetest-cleanups`
+**Date:** `2026-06-09`
+**Author:** `Instar Agent (echo)`
+**Second-pass reviewer:** `not required` (Tier-1; observability-only + doc-accuracy; no decision authority touched)
+
+## Summary of the change
+
+Two small cleanups the Slack-org live-test plan flagged.
+
+**Cleanup #2 (observability):** the `AmbientContributionGate` previously only left a trace when it SPOKE (the speak-path `console.log` + the `onDecision` log fires on `speak:true`). A wrongful SILENCE left no measurable record, so the ambient false-positive (wrongful-silence) / false-negative rate could not be measured during the observe-only live test. This adds a bounded, in-memory aggregate inside the gate — per-channel `{evaluated, spoke, silent, nearMissSilent, silentByReason}` plus a bounded ring of the most-recent near-miss silences — read via a new `getStats()` method, a `SlackAdapter.getAmbientStats()` passthrough, and a read-only `GET /permissions/ambient-stats` route (reads the live `ctx.slack` instance). Files: `src/permissions/AmbientContributionGate.ts`, `src/messaging/slack/SlackAdapter.ts`, `src/server/routes.ts`, plus unit + integration tests.
+
+**Cleanup #5 (doc accuracy):** `SLACK-ORG-INTEGRATION-SPEC.md` named a `respondMode: 'considered'` third mode, but the shipped `SlackRespondMode` type is `'all' | 'mention-only'`; ambient rides on `ambientContribution.enabledChannelIds` ON TOP of `mention-only`. The spec (§5.2 and the §15 migration-parity bullet) is rewritten to match the shipped reality — the lower-risk fix. No type value added; no code path needed it.
+
+## Decision-point inventory
+
+- `AmbientContributionGate.shouldSpeak` (the speak/silence decision) — **pass-through** — the verdict is computed exactly as before; the aggregate is updated AFTER the verdict is formed, inside `decide()`, wrapped in try/catch, and `decide()` returns the decision unchanged. The recording cannot alter the outcome.
+- `GET /permissions/ambient-stats` — **add** — read-only observability surface; performs no mutation and no messaging.
+
+---
+
+## 1. Over-block
+
+**What legitimate inputs does this change reject that it shouldn't?**
+
+No block/allow surface — over-block not applicable. The aggregate is signal-only and the new route is read-only. The speak/silence decision is unchanged (a dedicated regression test asserts identical verdicts with the aggregate present).
+
+---
+
+## 2. Under-block
+
+**What failure modes does this still miss?**
+
+No block/allow surface — under-block not applicable. The aggregate is an in-memory FP-measurement counter, not a gate. It is reset on restart, which is acceptable for an FP-rate-measurement surface (the durable per-decision record is the file-backed `/permissions/decisions`). Worst case is a momentary loss of accumulated counts after a restart — never an over- or under-speak.
+
+---
+
+## 3. Level-of-abstraction fit
+
+**Is this at the right layer?**
+
+Yes. The aggregate lives ON the gate that produces the decisions it counts, so every decision (including the previously-invisible silences) is observed at the single chokepoint `decide()` — no parallel detector, no double-counting. The route reads the live `ctx.slack` adapter (already in `RouteContext`), mirroring how the existing observe-only `/permissions/*` surfaces expose internal state. A durable counter could replace the in-memory map later without changing the contract.
+
+---
+
+## 4. Signal vs authority compliance
+
+**Does this hold blocking authority with brittle logic, or produce a signal?**
+
+Pure signal. Per `docs/signal-vs-authority.md`: the aggregate is a detector/observability surface with ZERO authority — it never blocks, delays, or rewrites a message, and it cannot change the speak/silence verdict (recording runs after the verdict and returns it unchanged; a stats bug is swallowed by try/catch). The ambient gate's own fail-to-silence authority is untouched.
+
+---
+
+## 5. Interactions
+
+**Does it shadow another check, get shadowed, double-fire, or race?**
+
+No. The new counters are independent of the existing `onDecision` hook and the speak-path `console.log` (both retained). No timer, no shared mutable state with another component. The `recordSpoke()` rate-limit budget is a separate concern and is not affected. The new route shares the `/permissions/*` prefix, already allowlisted as dark/internal in `CapabilityIndex` (line ~1023), so it does not trip the route-discoverability scan.
+
+---
+
+## 6. External surfaces
+
+**Does it change anything visible to other agents / users / systems?**
+
+Only the new authenticated read-only route `GET /permissions/ambient-stats` (returns `{ present: false }` when no ambient gate is attached — the default). It creates NO Telegram message and NO forum topic, so it cannot contribute to a notification flood (verified: the notification-flood burst-invariant test still passes). It is dark unless a channel is opted into ambient contribution. No timing/conversation-state dependency.
+
+---
+
+## 7. Rollback cost
+
+**If this turns out wrong in production, what's the back-out?**
+
+Trivial. The aggregate is in-memory (no persistence, no migration, no agent-state repair) and the route is additive. Reverting the commit removes both with no residue. Cleanup #5 is a doc edit with zero runtime effect.


### PR DESCRIPTION
## What & why

Two small cleanups flagged by the live-test plan (#1023), so the Slack org permission system is fully ready for live verification.

**#2 — Ambient-silence observability (so ambient false-positives are measurable).** Previously the ambient gate only recorded a decision when it SPOKE, so a wrongful *silence* left no trace and the observe-only live test couldn't measure the ambient FP/FN rate. Added a **bounded, flood-safe** in-memory aggregate on the gate — per channel `{evaluated, spoke, silent, nearMissSilent, silentByReason}` + a FIFO-capped ring (default 50) of recent near-miss-silence samples (channel, reason, clamped confidence, timestamp — **no message content**). A "near-miss silent" is a low-confidence silence whose confidence landed within `nearMissDelta` (0.1) below `minConfidence` — i.e. it nearly spoke (the highest-value FP candidate). Exposed read-only at **`GET /permissions/ambient-stats`** (`{ present: false }` when no ambient gate is attached — the dark default). **No Telegram, no topic creation** (burst-invariant test still passes). The recording happens *after* the verdict, in a try/catch, and a regression test asserts the speak/silence decision is byte-for-byte unchanged — the aggregate has zero authority.

**#5 — respondMode doc accuracy.** The spec named a `respondMode: 'considered'` third mode, but the shipped `SlackRespondMode` is `'all' | 'mention-only'` and ambient rides on `ambientContribution.enabledChannelIds` on top of `mention-only`. Took the lower-risk path: corrected §5.2 + the §15 migration bullet to match the shipped reality (no unused enum value added; every `'considered'` in code/tests is descriptive prose, now consistent).

## Tier note
Tier 1 (observability + a read-only route + a doc fix). The gate signaled a risk floor of 2 (a new `router.get(...)` was added); declared Tier 1 (the route is read-only / observe-only / dark-by-default, zero decision authority) and recorded `belowFloor:true` in the decision audit for review.

## Tests
16 new across gate-unit / wiring / integration; full affected set **59 passed**, incl. the notification-flood burst-invariant + a flood-100-near-misses-stays-at-cap test + the decision-unchanged regression. `tsc --noEmit` clean; lint clean.

## ELI16
Two finishing touches before live testing. First: the agent's quiet ambient mode could already chime in *or* stay silent, but it only kept a record when it spoke — so during testing you couldn't tell when it wrongly stayed quiet. This adds a small, capped tally (how many messages it saw, spoke on, stayed silent on, and "almost spoke" on) you can read at one URL, so you can measure how well the ambient judgment is doing without it ever spamming you — and it provably doesn't change a single speak-or-stay-quiet decision, it just counts them. Second: a documentation fix — the design doc mentioned a "considered" mode that was never actually a separate setting (ambient is just an add-on to mention-only), so the doc now matches how it really works. Both are off-by-default and change no behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)