### PR TITLE
fix(session): disambiguate getTopicBinding on topic-name collision (silently-unresponsive session root cause)

### DIFF
--- a/.instar/instar-dev-decisions/2026-06-09T23-16-14-701Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-06-09T23-16-14-701Z-unknown.json
@@ -1,0 +1,13 @@
+{
+  "ts": "2026-06-09T23:16:14.701Z",
+  "slug": "unknown",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 47,
+  "causalAutopsy": null,
+  "verdict": "pass"
+}

--- a/src/core/SessionManager.ts
+++ b/src/core/SessionManager.ts
@@ -880,7 +880,7 @@ rm()  { "${shimRunner}" rm  "$@"; }
    * Look up the topic binding for a tmux session from the topic-session registry.
    * Returns null if the session is not bound to any topic.
    */
-  private getTopicBinding(tmuxSession: string): TopicBinding | null {
+  private getTopicBinding(tmuxSession: string, preferTopicId?: number | null): TopicBinding | null {
     if (!this.registryPath) return null;
     try {
       if (!fs.existsSync(this.registryPath)) return null;
@@ -888,19 +888,33 @@ rm()  { "${shimRunner}" rm  "$@"; }
       const topicToSession = registry.topicToSession || {};
       const topicToName = registry.topicToName || {};
 
-      // Reverse lookup: find which topic maps to this session
+      // Reverse lookup: collect ALL topics mapping to this session. Two topics
+      // whose names slug to the same tmux session name COLLIDE here — e.g.
+      // "Initiatives and maturation check-ins" (#21487) and the case-variant
+      // "initiatives and maturation check-ins" (#21624) both produce
+      // `echo-initiatives-and-maturation-check-ins`. With a single-match reverse
+      // lookup that returned the FIRST entry, a legitimate message from the OTHER
+      // colliding topic was blocked by the InputGuard as cross-topic (incident
+      // 2026-06-09: topic 21624 silently unresponsive — every message dropped).
+      const matches: number[] = [];
       for (const [topicIdStr, sessionName] of Object.entries(topicToSession)) {
-        if (sessionName === tmuxSession) {
-          const topicId = parseInt(topicIdStr, 10);
-          return {
-            topicId,
-            topicName: (topicToName[topicIdStr] as string) || `Topic ${topicId}`,
-            channel: 'telegram', // Currently only Telegram uses the registry
-            sessionName: tmuxSession,
-          };
-        }
+        if (sessionName === tmuxSession) matches.push(parseInt(topicIdStr, 10));
       }
-      return null;
+      if (matches.length === 0) return null;
+
+      // Disambiguate on collision: if the incoming message names one of the
+      // colliding topics (preferTopicId, parsed from its [telegram:N] tag),
+      // bind to THAT topic so the provenance check passes. Otherwise fall back
+      // to the first match (single-topic case is unchanged).
+      const topicId = (preferTopicId != null && matches.includes(preferTopicId))
+        ? preferTopicId
+        : matches[0];
+      return {
+        topicId,
+        topicName: (topicToName[String(topicId)] as string) || `Topic ${topicId}`,
+        channel: 'telegram', // Currently only Telegram uses the registry
+        sessionName: tmuxSession,
+      };
     } catch {
       // Registry read failure — fail open (no binding = no check)
       return null;
@@ -3672,7 +3686,14 @@ rm()  { "${shimRunner}" rm  "$@"; }
   injectMessage(tmuxSession: string, text: string): boolean {
     // ── Input Guard: Layer 1 + 1.5 (deterministic, synchronous) ──
     if (this.inputGuard) {
-      const binding = this.getTopicBinding(tmuxSession);
+      // Parse the message's own [telegram:N] tag so getTopicBinding can
+      // disambiguate when multiple topics collide onto one tmux session name
+      // (case-variant topic names). Without this, a colliding session binds to
+      // the first-registered topic and legitimate messages from the other topic
+      // are dropped as cross-topic.
+      const tagMatch = text.match(/^\[telegram:(\d+)/);
+      const preferTopicId = tagMatch ? parseInt(tagMatch[1], 10) : null;
+      const binding = this.getTopicBinding(tmuxSession, preferTopicId);
       if (binding) {
         const provenance = this.inputGuard.checkProvenance(text, binding);
 

--- a/tests/unit/topic-collision-binding.test.ts
+++ b/tests/unit/topic-collision-binding.test.ts
@@ -1,0 +1,99 @@
+/**
+ * Unit test — SessionManager.getTopicBinding() topic-name collision disambiguation.
+ *
+ * Bug (2026-06-09): two Telegram topics whose names differ only by case
+ * ("Initiatives…" #21487 vs "initiatives…" #21624) slug to the SAME tmux session
+ * name. The reverse-lookup in getTopicBinding returned the FIRST matching topic
+ * (21487), so the InputGuard blocked every message from the live topic (21624)
+ * as cross-topic — the session was silently unresponsive.
+ *
+ * Fix: getTopicBinding takes an optional preferTopicId (parsed from the message's
+ * own [telegram:N] tag at the injectMessage call site). When multiple topics
+ * collide onto one session, it binds to the one the message names.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { SessionManager } from '../../src/core/SessionManager.js';
+import { StateManager } from '../../src/core/StateManager.js';
+import { InputGuard } from '../../src/core/InputGuard.js';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+import type { SessionManagerConfig } from '../../src/core/types.js';
+
+const SESSION = 'echo-initiatives-and-maturation-check-ins';
+
+describe('SessionManager.getTopicBinding — topic-name collision disambiguation', () => {
+  let tmpDir: string;
+  let sm: SessionManager;
+
+  const getBinding = (session: string, prefer?: number | null) =>
+    (sm as unknown as { getTopicBinding(s: string, p?: number | null): { topicId: number; topicName: string } | null })
+      .getTopicBinding(session, prefer);
+
+  const writeRegistry = (topicToSession: Record<string, string>, topicToName: Record<string, string>) => {
+    const p = path.join(tmpDir, 'topic-session-registry.json');
+    fs.writeFileSync(p, JSON.stringify({ topicToSession, topicToName }, null, 2));
+    return p;
+  };
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'topic-collision-test-'));
+    const stateDir = path.join(tmpDir, 'state');
+    fs.mkdirSync(stateDir, { recursive: true });
+    const state = new StateManager(stateDir);
+    const config: SessionManagerConfig = {
+      tmuxPath: '/usr/bin/tmux',
+      claudePath: '/usr/local/bin/claude',
+      projectDir: tmpDir,
+      maxSessions: 3,
+      protectedSessions: [],
+      completionPatterns: [],
+      framework: 'claude-code',
+    };
+    sm = new SessionManager(config, state);
+    const guard = new InputGuard({ config: { enabled: true } as never, stateDir });
+    // Collision: two case-variant topics map to the SAME session name.
+    const reg = writeRegistry(
+      { '21487': SESSION, '21624': SESSION },
+      { '21487': 'Initiatives and maturation check-ins', '21624': 'initiatives and maturation check-ins' },
+    );
+    sm.setInputGuard(guard, reg);
+  });
+
+  afterEach(() => {
+    SafeFsExecutor.safeRmSync(tmpDir, { recursive: true, force: true, operation: 'tests/unit/topic-collision-binding.test.ts:cleanup' });
+  });
+
+  it('THE FIX: binds to the topic the incoming tag names (live topic 21624), not the first (stale 21487)', () => {
+    const b = getBinding(SESSION, 21624);
+    expect(b?.topicId).toBe(21624);
+    expect(b?.topicName).toBe('initiatives and maturation check-ins');
+  });
+
+  it('also resolves the other colliding topic by its tag (21487)', () => {
+    expect(getBinding(SESSION, 21487)?.topicId).toBe(21487);
+  });
+
+  it('falls back to the first match when no tag is provided (back-compat)', () => {
+    const b = getBinding(SESSION, null);
+    expect([21487, 21624]).toContain(b?.topicId);
+    expect(getBinding(SESSION)?.topicId).toBe(b?.topicId);
+  });
+
+  it('falls back to the first match when the tag names a topic NOT mapped to this session', () => {
+    const b = getBinding(SESSION, 99999);
+    expect([21487, 21624]).toContain(b?.topicId);
+  });
+
+  it('single-topic (no collision) session is unchanged regardless of preferTopicId', () => {
+    const reg = writeRegistry({ '777': 'echo-solo' }, { '777': 'Solo topic' });
+    (sm as unknown as { registryPath: string }).registryPath = reg;
+    expect(getBinding('echo-solo', 12345)?.topicId).toBe(777);
+    expect(getBinding('echo-solo')?.topicId).toBe(777);
+  });
+
+  it('returns null for a session not in the registry', () => {
+    expect(getBinding('echo-nonexistent', 21624)).toBeNull();
+  });
+});

--- a/upgrades/next/topic-collision-binding.eli16.md
+++ b/upgrades/next/topic-collision-binding.eli16.md
@@ -1,0 +1,60 @@
+# ELI16 — Why a session went silent: two topics, one name
+
+## The problem
+
+A conversation (Telegram topic 21624) stopped responding. Messages showed
+"Delivered" but the agent never replied, and even restarting the session didn't
+fix it. It looked dead, but it wasn't — its messages were being silently thrown
+away before they ever reached it.
+
+Here's the cause. Each running session lives in a "tmux session", and its name
+is made by simplifying the topic's NAME into a slug. The trouble: there were two
+Telegram topics with essentially the same name —
+
+- #21487 "**I**nitiatives and maturation check-ins" (old, last used days ago)
+- #21624 "**i**nitiatives and maturation check-ins" (your live one)
+
+They differ only by one capital letter, so they slug to the **same** tmux name.
+Two topics, one underlying session.
+
+Now there's a safety guard whose whole job is to stop a message meant for topic A
+from landing in topic B's session. When it asked "which topic does this session
+belong to?", the lookup just returned the **first** one it found — the stale
+21487. So when you messaged from 21624, the guard saw "this session belongs to
+21487, but this message is tagged 21624 — mismatch!" and **dropped it**. Every
+time. The session sat there, perfectly healthy, never hearing you.
+
+## What already exists
+
+- The reverse lookup `getTopicBinding(session)` that answers "which topic owns
+  this session?"
+- The InputGuard that compares a message's `[telegram:N]` tag to that answer and
+  drops mismatches. Each part is correct on its own — the bug was only that the
+  lookup couldn't handle two topics sharing one session.
+
+## What's new
+
+The lookup is now collision-aware. Instead of returning the first topic it finds,
+it collects **all** topics that map to the session, and — because every message
+carries its own `[telegram:N]` tag — it binds to the topic the message actually
+names. So a message tagged 21624 now correctly resolves to 21624 and sails
+through the guard, even though 21487 also shares that session.
+
+## The safeguards in plain terms
+
+- **No renaming, no migration.** This doesn't touch session names or rewrite any
+  stored state — it just resolves the lookup more precisely at message time. So
+  there's nothing to migrate and nothing to break for existing sessions.
+- **Single-topic sessions are untouched.** When only one topic maps to a session
+  (the normal case), behavior is identical to before.
+- **Safe fallback.** If a message has no tag, or its tag names a topic that
+  isn't on this session, it falls back to the old first-match behavior — never
+  worse than before.
+- **The guard still guards.** A genuinely cross-topic message (tag names a topic
+  that does NOT share this session) is still blocked, exactly as intended.
+
+## What you need to decide
+
+Nothing — it ships as a normal patch with safe fallbacks. The earlier incident
+was already recovered by clearing the stale topic by hand; this is the durable
+fix so the collision can't silently eat messages again.

--- a/upgrades/next/topic-collision-binding.md
+++ b/upgrades/next/topic-collision-binding.md
@@ -1,0 +1,21 @@
+<!-- bump: patch -->
+
+## What Changed
+
+Makes `SessionManager.getTopicBinding()` collision-aware so a session shared by two same-named topics no longer drops one topic's messages. The tmux session name is derived by slugifying the topic NAME, so two Telegram topics whose names differ only by case ("Initiatives and maturation check-ins" #21487 vs "initiatives and maturation check-ins" #21624) collapse to one session name. `getTopicBinding` did a single-match reverse lookup over `topicToSession` and returned the FIRST topic — so the InputGuard bound the shared session to the older topic (21487) and blocked every message from the live topic (21624) as cross-topic. The session looked alive but was silently unresponsive (messages showed "Delivered" but never reached it). The fix: `getTopicBinding` now collects ALL topics mapping to the session and takes an optional `preferTopicId`; the `injectMessage` call site parses the message's own `[telegram:N]` tag and passes it, so a colliding session binds to the topic the message actually names. Single-topic sessions and the no-tag path are unchanged (fall back to first match). Migration-free — no session renaming, no registry rewrite.
+
+## What to Tell Your User
+
+If a session ever goes silent — messages show "Delivered" but it never replies, and restarting it doesn't help — one cause was two topics with near-identical names (e.g. differing only in capitalization) colliding onto the same underlying session, where a safety guard then blocked one of them. That's fixed: the agent now routes each message to the right topic by the tag the message carries, so the collision no longer eats messages.
+
+## Summary of New Capabilities
+
+| Capability | How to Use |
+|-----------|-----------|
+| Message routing survives same-name (case-variant) topic collisions | automatic — messages bind to the topic named by their own tag |
+
+## Evidence
+
+Reproduction (live, 2026-06-09): topic 21624 was unresponsive across multiple user messages and a respawn. Server logs showed `[InputGuard] BLOCKED cross-topic injection … session "echo-initiatives-and-maturation-check-ins" is bound to topic 21487` on every inbound 21624 message; the registry confirmed both 21487 ("Initiatives…") and 21624 ("initiatives…") mapped to that one session, and `getTopicBinding`'s reverse lookup returned the first (21487). Immediate recovery was an operator-authorized `/unlink` of the stale 21487; this PR is the durable fix.
+
+After the fix: `tests/unit/topic-collision-binding.test.ts` (6 cases) pins both sides — a tagged message binds to the topic it names (21624 and 21487 each resolve correctly), the no-tag and unknown-tag paths fall back to first match, single-topic sessions are unchanged, and an unknown session returns null. tsc + lint clean; 63 existing SessionManager + InputGuard tests green.

--- a/upgrades/side-effects/topic-collision-binding.md
+++ b/upgrades/side-effects/topic-collision-binding.md
@@ -1,0 +1,68 @@
+# Side-Effects Review — getTopicBinding collision disambiguation
+
+**Version / slug:** `topic-collision-binding`
+**Date:** `2026-06-09`
+**Author:** `Instar Agent (echo)`
+**Second-pass reviewer:** `independent reviewer subagent — concurred`
+
+## Summary of the change
+
+`SessionManager.getTopicBinding(tmuxSession)` did a single-match reverse lookup over `registry.topicToSession` and returned the FIRST topic mapping to the session. When two topics whose names slug to the same tmux name collide onto one session, this returned the wrong (first-registered) topic, so the InputGuard's provenance check blocked the other topic's messages as cross-topic (session silently unresponsive). The fix: `getTopicBinding` now collects ALL matching topics and accepts an optional `preferTopicId`; if that topic is among the matches it binds to it, else falls back to the first match. The `injectMessage` call site parses the message's own `[telegram:N]` tag (`/^\[telegram:(\d+)/`) and passes it. Files: `src/core/SessionManager.ts` (getTopicBinding + injectMessage call site), `tests/unit/topic-collision-binding.test.ts` (new, 6 cases).
+
+## Decision-point inventory
+
+- `SessionManager.getTopicBinding` (feeds the InputGuard cross-topic provenance decision) — **modify** — single-match → all-matches + tag-preferred disambiguation. Single-topic behavior unchanged.
+- `injectMessage` InputGuard provenance check — **pass-through (caller updated)** — now passes the parsed tag so the binding can disambiguate; the provenance comparison logic itself is unchanged.
+
+## 1. Over-block
+
+This change strictly REDUCES over-block. Before, a legitimate message from a colliding topic was blocked (the bug). After, it binds to the correct topic and passes. No new legitimate input is now blocked. The InputGuard's actual block decision (`checkProvenance`) is untouched — only the binding it is handed is now correct on collision.
+
+## 2. Under-block
+
+Could this let a genuinely cross-topic message through? No. `preferTopicId` only changes the binding when the named topic is ACTUALLY in the set of topics mapped to this session. A message whose tag names a topic NOT mapped to this session falls back to the first match, and the InputGuard then still detects the mismatch and blocks — identical to today. So the cross-topic protection is preserved; only the legitimate-collision false-positive is removed. (Edge: if two colliding topics are both legitimately the "same" conversation split across ids, binding to whichever the message names is correct by construction.)
+
+## 3. Level-of-abstraction fit
+
+Correct layer. The collision is a registry-reverse-lookup ambiguity; resolving it where the lookup happens (`getTopicBinding`), using a signal already present at the call site (the message tag), is the right altitude. The alternative — making tmux session names unique per topic — is a larger, migration-bearing change to session-name derivation affecting every session; this binding-layer fix is migration-free and lower-risk, and is the proportionate fix for the observed failure. (The name-uniqueness change remains a possible future hardening but is not required to close this bug.)
+
+## 4. Signal vs authority compliance
+
+**Required reference:** [docs/signal-vs-authority.md](../../docs/signal-vs-authority.md)
+
+- [x] No — this change has no block/allow surface of its own; it corrects the INPUT (the binding) to the existing InputGuard authority so that authority decides on accurate data.
+
+It does not add or weaken any gate. It makes the existing cross-topic authority decide against the correct topic binding instead of an arbitrary first-match. Compliant.
+
+## 5. Interactions
+
+- **Shadowing:** none — same call order; `getTopicBinding` → `checkProvenance` unchanged in sequence.
+- **Double-fire:** none.
+- **Races:** `getTopicBinding` reads the registry file fresh each call (unchanged); no new shared state. The disambiguation is pure over the read snapshot.
+- **Other callers:** the only caller of `SessionManager.getTopicBinding` is `injectMessage` (the new optional param defaults to undefined → first-match, so any future caller is back-compatible). `ScopeVerifier.getTopicBinding` is a DIFFERENT method (topic→project) and is untouched.
+
+## 6. External surfaces
+
+- **Agents/users:** ships to the install base via the normal release. User-visible effect: messages to a topic that shares a session name with another topic now reach the session instead of being silently dropped. No API/format change.
+- **Persistent state:** none — reads the existing registry; writes nothing.
+- **Timing:** depends only on the message text tag (already present at injectMessage) and the registry snapshot (already read).
+
+## 7. Rollback cost
+
+Pure code change, no persistent state, no migration. Back-out = revert the commit, ship a patch; behavior returns to first-match reverse lookup. Low. (The original incident's manual recovery — `/unlink` of the stale topic — is independent and already applied.)
+
+## Conclusion
+
+A migration-free, scope-narrowing fix: it removes a false cross-topic block on legitimately-colliding topics by handing the existing InputGuard authority an accurate binding (resolved via the message's own tag), while fully preserving genuine cross-topic protection and single-topic behavior. Because it feeds a message-dispatch/session-lifecycle decision point, a Phase-5 second-pass review is requested.
+
+## Second-pass review (if required)
+
+**Reviewer:** independent reviewer subagent (general-purpose)
+**Independent read of the artifact: concur**
+
+Concur. The reviewer traced all three resolution cases against the code (tagged→tagged topic, null→first, unknown→first) and confirmed they match the tests. Critically, it verified the security invariant cannot be bypassed: `preferTopicId` only wins via `matches.includes(preferTopicId)` — i.e. only when the tagged topic is genuinely served by THIS session — so a crafted/foreign tag falls through to first-match and InputGuard.checkProvenance still detects the mismatch and blocks (the change can only NARROW the binding to an already-served topic, never widen the served set). Tag parsing `/^\[telegram:(\d+)/` is byte-identical to InputGuard's `extractTelegramTag`, so the select-value and verify-value can never diverge. Back-compat confirmed: optional param defaults to undefined→first-match; the public `injectMessage` signature is unchanged so its external callers (mostly non-Telegram-tagged `/compact`/bootstrap text) get `preferTopicId=null` → identical old behavior; `ScopeVerifier.getTopicBinding` is a different method, untouched. `preferTopicId != null` correctly admits 0 (no zero-is-falsy bug). Two non-blocking notes: (1) "first match" is V8 lowest-numbered-integer-key order, not literally first-registered — only the pre-existing fallback, acceptable; (2) registry-read fail-open is pre-existing and out of scope.
+
+## Evidence pointers
+
+- Live incident: 2026-06-09, topic 2169/21624 — `[InputGuard] BLOCKED cross-topic injection … bound to topic 21487`; registry showed 21487+21624 → one session; first-match returned 21487.
+- Tests: `tests/unit/topic-collision-binding.test.ts` (6 cases, both sides). 63 existing SessionManager + InputGuard tests green; tsc + lint clean.


### PR DESCRIPTION
## What & why

A conversation (Telegram topic 21624) went silently unresponsive — messages showed "Delivered" but never reached the session, and a respawn didn't help. Root cause: **two topics whose names differ only by case collide onto one tmux session name.**

The tmux session name is derived by slugifying the topic NAME, so:
- #21487 "**I**nitiatives and maturation check-ins" (stale, last used Jun 7)
- #21624 "**i**nitiatives and maturation check-ins" (live)

both produce `echo-initiatives-and-maturation-check-ins` → both map to one session in `registry.topicToSession`. `SessionManager.getTopicBinding` did a single-match reverse lookup and returned the FIRST topic (21487), so the InputGuard blocked every message from the live topic (21624) as cross-topic:

```
[InputGuard] BLOCKED cross-topic injection … session "echo-initiatives-and-maturation-check-ins" is bound to topic 21487
```

Immediate recovery was an operator-authorized `/unlink` of the stale topic; this PR is the durable fix.

## The fix

`getTopicBinding` now collects **all** topics mapping to the session and takes an optional `preferTopicId`. The `injectMessage` call site parses the message's own `[telegram:N]` tag (the same `/^\[telegram:(\d+)/` extraction the InputGuard uses) and passes it, so a colliding session binds to the topic the message actually names.

**Security invariant (verified by second-pass review):** `preferTopicId` only wins via `matches.includes(preferTopicId)` — it can only select a topic the session **already serves**. A message tagged for a topic the session does NOT serve falls through to first-match and the InputGuard still blocks it. The change can only *narrow* the binding to an already-served topic, never widen the served set. Single-topic sessions and untagged text are unchanged (first-match). **Migration-free** — no session renaming, no registry rewrite.

## Tests

`tests/unit/topic-collision-binding.test.ts` (6 cases): tagged message binds to the topic it names (21624 and 21487 each resolve correctly); no-tag and unknown-tag fall back to first-match; single-topic session unchanged; unknown session → null. 63 existing SessionManager + InputGuard tests green; tsc + lint clean. Independent second-pass review concurred on the cross-topic-protection invariant.

## ELI16

A conversation stopped responding — "Delivered" but no reply, and restarting didn't help. It looked dead but wasn't: its messages were being thrown away before reaching it. Each session lives in a "tmux session" whose name is made from the topic's name. There were two Telegram topics with the same name except one capital letter ("Initiatives…" vs "initiatives…"), so they collapsed to the same session name — two topics, one session. A safety guard whose job is to stop a message meant for topic A landing in topic B's session asked "which topic owns this session?" and the lookup just returned the first one it found (the stale topic). So every message from the live topic looked like a mismatch and got dropped.

The fix: the lookup now gathers all topics sharing the session and binds to the one the message's own tag names, so a message tagged for the live topic resolves correctly and passes the guard. It's safe — a tag can only select a topic the session already serves, so the guard still blocks genuinely cross-topic messages; single-topic sessions are untouched; and there's no renaming or migration, just a more precise lookup at message time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
