### PR TITLE
feat(dev-gate): dev-gated-feature registry + both-sides wiring test (Slice 2)

### DIFF
--- a/.instar/instar-dev-decisions/2026-06-10T01-38-16-734Z-dev-gated-features-registry.json
+++ b/.instar/instar-dev-decisions/2026-06-10T01-38-16-734Z-dev-gated-features-registry.json
@@ -1,0 +1,15 @@
+{
+  "ts": "2026-06-10T01:38:16.734Z",
+  "slug": "dev-gated-features-registry",
+  "suggestedTier": 2,
+  "declaredTier": null,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "new capability: new config key added"
+  ],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 86,
+  "causalAutopsy": null,
+  "verdict": "pass"
+}

--- a/src/core/devGatedFeatures.ts
+++ b/src/core/devGatedFeatures.ts
@@ -1,0 +1,86 @@
+/**
+ * devGatedFeatures.ts — the registry of features that follow the
+ * standard_development_agent_dark_feature_gate convention: config OMITS
+ * `enabled`, the runtime resolves it via `resolveDevAgentGate` (live on a
+ * development agent, dark on the fleet).
+ *
+ * WHY (DEV-AGENT-DARK-GATE-CONFORMANCE-SPEC, Slice 2): Slice 1's lint catches a
+ * hand-rolled gate and a hardcoded `enabled: false` under a marker comment, but
+ * it cannot prove that a feature's *actual config + construction* resolves live
+ * on a dev agent. This registry drives the both-sides wiring test
+ * (`tests/unit/devGatedFeatures-wiring.test.ts`): for each entry, the REAL
+ * ConfigDefaults are applied and `resolveDevAgentGate(<configPath>)` must be
+ * true under a dev-agent config and false under a fleet config. A feature whose
+ * default hardcodes `enabled: false` (the literal #1001 mechanism — `applyDefaults`
+ * would inject the `false`) fails the test. Adding a dev-gated feature here is
+ * the natural checklist step; the test then guards it permanently.
+ *
+ * NOT every site that calls `resolveDevAgentGate` belongs here — only features
+ * whose intent is "dark fleet / LIVE on dev". Deliberately EXCLUDED:
+ *   - `monitoring.mcpProcessReaper` — destructive (kills processes); ships OFF +
+ *     dry-run for EVERYONE incl. dev agents by design (`enabled: false` default).
+ *   - `monitoring.resourceLedger` — the ledger itself defaults `enabled: true`
+ *     (on for everyone); only its sampling rides the gate off the same key, so
+ *     it is not cleanly a dark-on-fleet feature.
+ */
+
+/** A feature governed by the developmentAgent dark-feature gate. */
+export interface DevGatedFeature {
+  /** Stable identifier (matches the feature's name in code/docs). */
+  name: string;
+  /** Dotted path to the feature's `enabled` flag in the agent config. */
+  configPath: string;
+  /** One-line description of what runs live on a dev agent. */
+  description: string;
+}
+
+export const DEV_GATED_FEATURES: DevGatedFeature[] = [
+  {
+    name: 'growthAnalyst',
+    configPath: 'monitoring.growthAnalyst.enabled',
+    description: 'Proactive growth & milestone analyst (/growth/*).',
+  },
+  {
+    name: 'coherenceJournal',
+    configPath: 'multiMachine.coherenceJournal.enabled',
+    description: 'Cross-machine coherence journal.',
+  },
+  {
+    name: 'warmSessionA2A',
+    configPath: 'threadline.warmSessionA2A.enabled',
+    description: 'Warm-session pool for agent-to-agent delivery.',
+  },
+  {
+    name: 'secretSync',
+    configPath: 'multiMachine.secretSync.enabled',
+    description: 'Cross-machine secret sync (receive side).',
+  },
+  {
+    name: 'geminiLoopDriver',
+    configPath: 'autonomousSessions.geminiLoopDriver.enabled',
+    description: 'Gemini autonomous-loop driver.',
+  },
+  {
+    name: 'respawnBuildContext',
+    configPath: 'sessions.respawnBuildContext.enabled',
+    description: 'Respawn build-context capture on session restart.',
+  },
+  {
+    name: 'selfKnowledgeSessionContext',
+    configPath: 'selfKnowledge.sessionContext.enabled',
+    description: 'Session-boot self-knowledge context injection.',
+  },
+];
+
+/**
+ * Read a dotted path off a config object, returning the value or undefined.
+ * Used by the wiring test and the spec-intent cross-check (Slice 3).
+ */
+export function getConfigByPath(config: unknown, dottedPath: string): unknown {
+  let cur: unknown = config;
+  for (const key of dottedPath.split('.')) {
+    if (cur == null || typeof cur !== 'object') return undefined;
+    cur = (cur as Record<string, unknown>)[key];
+  }
+  return cur;
+}

--- a/tests/unit/devGatedFeatures-wiring.test.ts
+++ b/tests/unit/devGatedFeatures-wiring.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from 'vitest';
+import { applyDefaults, getMigrationDefaults } from '../../src/config/ConfigDefaults.js';
+import { resolveDevAgentGate } from '../../src/core/devAgentGate.js';
+import { DEV_GATED_FEATURES, getConfigByPath } from '../../src/core/devGatedFeatures.js';
+
+/**
+ * Build the config a real agent would run with: the explicit developmentAgent
+ * flag, then the REAL ConfigDefaults applied (add-missing semantics, exactly as
+ * PostUpdateMigrator does). This is the point — if a dev-gated feature's default
+ * ever hardcodes `enabled: false` (the literal #1001 mechanism), applyDefaults
+ * injects that `false` and the LIVE-on-dev assertion below fails.
+ */
+function buildConfig(developmentAgent: boolean): Record<string, unknown> {
+  const cfg: Record<string, unknown> = { developmentAgent };
+  applyDefaults(cfg, getMigrationDefaults('standalone'));
+  return cfg;
+}
+
+describe('DEV_GATED_FEATURES — both-sides wiring (live on dev, dark on fleet)', () => {
+  it('the registry is non-empty (guards against an accidentally-emptied registry)', () => {
+    expect(DEV_GATED_FEATURES.length).toBeGreaterThan(0);
+  });
+
+  for (const feature of DEV_GATED_FEATURES) {
+    it(`${feature.name} (${feature.configPath}) resolves LIVE on a dev agent`, () => {
+      const devCfg = buildConfig(true);
+      const resolved = resolveDevAgentGate(
+        getConfigByPath(devCfg, feature.configPath) as boolean | undefined,
+        devCfg as { developmentAgent?: boolean },
+      );
+      // If this fails, the feature's default hardcodes `enabled: false` (or the
+      // gate path is wrong) — it would ship dark on dev agents (the #1001 bug).
+      expect(resolved).toBe(true);
+    });
+
+    it(`${feature.name} (${feature.configPath}) resolves DARK on the fleet`, () => {
+      const fleetCfg = buildConfig(false);
+      const resolved = resolveDevAgentGate(
+        getConfigByPath(fleetCfg, feature.configPath) as boolean | undefined,
+        fleetCfg as { developmentAgent?: boolean },
+      );
+      // If this fails, the feature's default hardcodes `enabled: true` — it would
+      // ship live on the whole fleet rather than dark-until-flipped.
+      expect(resolved).toBe(false);
+    });
+  }
+
+  it('has teeth — a regressed hardcoded `enabled: false` default would FAIL the live-on-dev assertion (the #1001 mechanism)', () => {
+    // Simulate the literal #1001 bug: a dev-gated feature's default hardcodes
+    // enabled:false. Inject it at a registered path on a dev-agent config and
+    // confirm the gate resolves DARK — i.e., the per-feature LIVE-on-dev test
+    // above would have failed loudly, which is the whole point of the registry.
+    const feature = DEV_GATED_FEATURES[0];
+    const devCfg = buildConfig(true) as Record<string, any>;
+    const keys = feature.configPath.split('.');
+    let cur: Record<string, any> = devCfg;
+    for (const k of keys.slice(0, -1)) {
+      cur[k] = cur[k] ?? {};
+      cur = cur[k];
+    }
+    cur[keys[keys.length - 1]] = false; // the regression
+
+    const resolved = resolveDevAgentGate(
+      getConfigByPath(devCfg, feature.configPath) as boolean | undefined,
+      devCfg as { developmentAgent?: boolean },
+    );
+    expect(resolved).toBe(false); // caught: dark on a dev agent
+  });
+});

--- a/upgrades/next/dev-gated-features-registry.md
+++ b/upgrades/next/dev-gated-features-registry.md
@@ -1,0 +1,25 @@
+## What Changed
+
+Added Slice 2 of the dev-agent dark-gate conformance guard: a
+`DEV_GATED_FEATURES` registry (`src/core/devGatedFeatures.ts`) and a both-sides
+wiring test that applies the REAL config defaults and asserts each registered
+dev-gated feature resolves LIVE under a `developmentAgent: true` config and DARK
+under a fleet config. This catches the half of the #1001 bug that Slice 1's lint
+can't see — a feature whose shipped default hardcodes `enabled: false` (so
+`applyDefaults` injects it) now fails the build, because the feature would be dark
+on dev agents. Seven features are registered; two (`mcpProcessReaper`,
+`resourceLedger`) are deliberately excluded with documented reasons (intentionally
+not dark-on-fleet).
+
+## What to Tell Your User
+
+Nothing user-facing — internal developer/CI tooling (audience: agent-only). No
+runtime behavior changes; it only adds a test that guards the dev-gate convention.
+
+## Summary of New Capabilities
+
+- `DEV_GATED_FEATURES` registry + `getConfigByPath` (`src/core/devGatedFeatures.ts`).
+- `tests/unit/devGatedFeatures-wiring.test.ts` — both-sides wiring test (+ a teeth
+  test proving it catches a planted `enabled: false` regression).
+- Honest limit: Slice 3 (spec-intent cross-check) still catches the
+  forgot-the-gate-entirely case; tracked as CMT-1253. <!-- tracked: CMT-1253 -->

--- a/upgrades/next/dev-gated-features-registry.md
+++ b/upgrades/next/dev-gated-features-registry.md
@@ -11,6 +11,21 @@ on dev agents. Seven features are registered; two (`mcpProcessReaper`,
 `resourceLedger`) are deliberately excluded with documented reasons (intentionally
 not dark-on-fleet).
 
+## Evidence
+
+This is a preventive CI guard, not a runtime bug fix — so "evidence" is a
+demonstration that the guard has teeth on the #1001 mechanism:
+- **Before (no guard):** a dev-gated feature whose shipped default hardcodes
+  `enabled: false` ships dark on dev agents undetected — exactly #1001, which was
+  caught only by operator review.
+- **Reproduction (guard fires):** copied `src/config/ConfigDefaults.ts`, injected
+  `enabled: false` as the first field of the real `growthAnalyst` block, and ran
+  the both-sides test → the live-on-dev assertion **FAILS** (red). A baked-in
+  `enabled: true` would fail the dark-on-fleet assertion instead.
+- **After (clean tree):** the unmodified tree → **16/16 green** (no registered
+  feature currently hardcodes a default). So the guard fires on the regression and
+  stays quiet otherwise.
+
 ## What to Tell Your User
 
 Nothing user-facing — internal developer/CI tooling (audience: agent-only). No

--- a/upgrades/side-effects/dev-gated-features-registry.md
+++ b/upgrades/side-effects/dev-gated-features-registry.md
@@ -1,0 +1,70 @@
+# Side-Effects Review — Dev-Gated-Feature Registry + Both-Sides Wiring Test (Slice 2)
+
+**Change:** Slice 2 of DEV-AGENT-DARK-GATE-CONFORMANCE-SPEC (the converged +
+operator-approved spec). Adds the layer that catches a dev-gated feature wired to
+resolve **dark on a dev agent** — the gap Slice 1's lint cannot see.
+
+- `src/core/devGatedFeatures.ts` (new) — `DEV_GATED_FEATURES` registry (name +
+  config path + description) and a `getConfigByPath` reader.
+- `tests/unit/devGatedFeatures-wiring.test.ts` (new) — for each registered
+  feature, applies the REAL `getMigrationDefaults` and asserts
+  `resolveDevAgentGate(<configPath>)` is **true** under a `developmentAgent: true`
+  config and **false** under a fleet config, plus a "teeth" test confirming an
+  injected `enabled: false` default fails the live-on-dev assertion (the literal
+  #1001 mechanism).
+
+**Registry membership (the design decision in this slice):** only features whose
+intent is "dark fleet / LIVE on dev" are included (growthAnalyst, coherenceJournal,
+warmSessionA2A, secretSync, geminiLoopDriver, respawnBuildContext,
+selfKnowledgeSessionContext — verified to omit `enabled` in defaults). Deliberately
+EXCLUDED, with reasons in code: `monitoring.mcpProcessReaper` (destructive — ships
+OFF + dry-run for everyone incl. dev by design) and `monitoring.resourceLedger`
+(ledger defaults `enabled: true`; only sampling rides the gate off the same key).
+
+## 1. Over-block — what legitimate inputs does this reject that it shouldn't?
+The test asserts every registered feature is live-on-dev / dark-on-fleet. A
+feature that legitimately ships dark-everywhere or live-everywhere would fail if
+wrongly added to the registry — but membership is a deliberate, reviewed choice
+(the two non-conforming features are explicitly excluded with documented reasons),
+so the test only constrains features that genuinely follow the convention.
+
+## 2. Under-block — what failure modes does this still miss?
+Catches the hardcoded-default half of the #1001 shape (a `false` baked into the
+feature's default → `applyDefaults` injects it → live-on-dev assertion fails) for
+**registered** features. Still misses: (a) a dev-gated feature never added to the
+registry; (b) the construction-side half where a site reads `enabled === true`
+without any gate (no default to catch) — that is Slice 3's spec-intent cross-check.
+Both limits are named in the spec's layer table.
+
+## 3. Level-of-abstraction fit — right layer?
+Yes — a unit test over the real config-default assembly (`applyDefaults` +
+`getMigrationDefaults`), the same path PostUpdateMigrator uses. It exercises the
+actual default→gate resolution, not a source regex, so it catches the mechanism
+rather than a spelling.
+
+## 4. Signal vs authority compliance
+The test is CI authority (fails the build) over a deterministic, mechanical
+property — same posture as the rest of the suite. The registry is inert data; it
+holds no runtime authority (Slice 3 consumes it read-only).
+
+## 5. Interactions — shadowing, double-fire, races?
+None. `devGatedFeatures.ts` is pure data + a pure path reader; the test builds
+throwaway config objects. No shared state, no runtime wiring in this slice.
+
+## 6. External surfaces — visible to other agents/users/systems?
+None. No routes, no config, no agent-installed files. Repo-internal source + test.
+No Migration Parity entry needed.
+
+## 7. Rollback cost — back-out if wrong?
+Trivial — delete the two files. No runtime behavior, no state, no deployed artifact.
+
+## No deferrals
+Slice 3 (spec-intent cross-check) is the next slice of the same approved spec,
+tracked under CMT-1253 — not a deferral of this slice's scope. <!-- tracked: CMT-1253 -->
+
+## Second-pass review (independent)
+The registry membership was derived by auditing each `resolveDevAgentGate` site's
+default against the convention: the 7 included features verified to omit `enabled`
+(test green on all = no hidden hardcoded default); the 2 excluded features
+(mcpProcessReaper, resourceLedger) inspected and confirmed intentionally NOT
+dark-on-fleet. The teeth test confirms the guard fires on a planted regression.


### PR DESCRIPTION
## What this does

Slice 2 of the dev-agent dark-gate conformance guard (`DEV-AGENT-DARK-GATE-CONFORMANCE-SPEC`, already converged + operator-approved). It adds the layer that catches a dev-gated feature wired to resolve **dark on a dev agent** — the half of the #1001 bug that Slice 1's lint can't see.

- **`src/core/devGatedFeatures.ts`** — `DEV_GATED_FEATURES` registry (name + config path + description) + `getConfigByPath`.
- **`tests/unit/devGatedFeatures-wiring.test.ts`** — for each registered feature, applies the **real** `getMigrationDefaults` and asserts `resolveDevAgentGate(<configPath>)` is `true` under a `developmentAgent: true` config and `false` under a fleet config. Plus a "teeth" test confirming a planted `enabled: false` default fails the live-on-dev assertion.

Why this catches #1001: if a feature's shipped default hardcodes `enabled: false`, `applyDefaults` injects it, so the live-on-dev assertion fails — the exact mechanism that shipped #1001 dark for everyone.

## Registry membership

7 features registered (verified to omit `enabled` in defaults): growthAnalyst, coherenceJournal, warmSessionA2A, secretSync, geminiLoopDriver, respawnBuildContext, selfKnowledgeSessionContext. Two deliberately excluded with reasons in code: `mcpProcessReaper` (destructive — ships OFF + dry-run for everyone by design) and `resourceLedger` (ledger defaults `enabled: true`).

## Tests

16 tests (7×2 sides + registry-non-empty + teeth), tsc clean, full lint clean (incl. the Slice-1 dark-gate lint). Side-effects: `upgrades/side-effects/dev-gated-features-registry.md`.

## Honest limit (tracked)

Still misses a dev-gated feature never added to the registry, and the construction-side `=== true` half (no default to catch). That's Slice 3 (spec-intent cross-check via `FeatureRolloutReconciler`), tracked as **CMT-1253**.

## ELI16

Instar runs some features "dark" (off for everyone) except on development agents like Echo, where they run live so we can dogfood them. The rule is to leave the on/off switch out of the config defaults and let the code decide ("on for a dev agent"). Slice 1 added a lint that catches obvious mistakes in how that switch is written. This slice adds the deeper check: it builds the real config a dev agent would get, applies the actual defaults, and verifies each dev-gated feature actually ends up "on" for a dev agent and "off" for the fleet. If someone accidentally bakes "off" into the defaults — the exact thing that caused the original bug — the build now fails. It changes nothing at runtime; it's a safety net. It still can't catch a feature nobody registered or one that forgets the switch entirely with no hint — that's the next and final layer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
