### PR TITLE
fix(sentinel): self-heal a deleted lifeline topic instead of swallowing escalation send errors

### DIFF
--- a/.instar/instar-dev-decisions/2026-06-10T03-27-37-821Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-06-10T03-27-37-821Z-unknown.json
@@ -1,0 +1,13 @@
+{
+  "ts": "2026-06-10T03:27:37.821Z",
+  "slug": "unknown",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 2,
+  "loc": 124,
+  "causalAutopsy": null,
+  "verdict": "pass"
+}

--- a/src/commands/server.ts
+++ b/src/commands/server.ts
@@ -56,6 +56,7 @@ import { TopicMemory } from '../memory/TopicMemory.js';
 import { SemanticMemory } from '../memory/SemanticMemory.js';
 import { WorkingMemoryAssembler } from '../memory/WorkingMemoryAssembler.js';
 import { QuotaTracker } from '../monitoring/QuotaTracker.js';
+import { sendConsolidatedWithSelfHeal } from '../monitoring/sentinelConsolidatedSend.js';
 import { AccountSwitcher } from '../monitoring/AccountSwitcher.js';
 import { QuotaNotifier } from '../monitoring/QuotaNotifier.js';
 import { QuotaManager } from '../monitoring/QuotaManager.js';
@@ -6985,17 +6986,17 @@ export async function startServer(options: StartOptions): Promise<void> {
       // Consolidated Telegram delivery — reuses the existing system (lifeline)
       // topic. When telegramEscalation is off, this callback is never invoked.
       const localTelegram = telegram;
+      // Self-healing consolidated delivery: if the lifeline/system topic was
+      // deleted on the Telegram side, recreate it and retry instead of silently
+      // swallowing the "message thread not found" error (incident 2026-06-09:
+      // 41 stall escalations black-holed against a dead lifeline topic).
       const sendConsolidated = localTelegram
-        ? async (text: string): Promise<boolean> => {
-            const topicId = localTelegram.getLifelineTopicId();
-            if (!topicId) return false;
-            try {
-              await localTelegram.sendToTopic(topicId, text);
-              return true;
-            } catch {
-              return false;
-            }
-          }
+        ? (text: string): Promise<boolean> =>
+            sendConsolidatedWithSelfHeal(
+              localTelegram,
+              text,
+              (line) => console.warn(pc.yellow(`  [sentinel-notify] ${line}`)),
+            )
         : undefined;
 
       const telegramEscalation = config.monitoring?.sentinelTelegramEscalation === true;
@@ -9685,11 +9686,12 @@ export async function startServer(options: StartOptions): Promise<void> {
         const stopLog = (entry: { kind: string; sessionName: string; detail?: string }): void => {
           try { fs.appendFileSync(stopLogPath, JSON.stringify({ ...entry, sentinel: 'stop-notify', ts: new Date().toISOString() }) + '\n'); } catch { /* best-effort */ }
         };
-        const send = async (text: string): Promise<boolean> => {
-          const topicId = localTg.getLifelineTopicId();
-          if (!topicId) return false;
-          try { await localTg.sendToTopic(topicId, text); return true; } catch { return false; }
-        };
+        const send = (text: string): Promise<boolean> =>
+          sendConsolidatedWithSelfHeal(
+            localTg,
+            text,
+            (line) => console.warn(pc.yellow(`  [stop-notify] ${line}`)),
+          );
         const { SentinelNotifier } = await import('../monitoring/SentinelNotifier.js');
         const stopSink = new SentinelNotifier(
           { log: stopLog, sendConsolidated: send },

--- a/src/monitoring/sentinelConsolidatedSend.ts
+++ b/src/monitoring/sentinelConsolidatedSend.ts
@@ -1,0 +1,92 @@
+/**
+ * Robust consolidated-escalation send for SentinelNotifier.
+ *
+ * Background (incident 2026-06-09): the sentinel's `sendConsolidated` closures
+ * did `try { sendToTopic(lifelineTopicId) } catch { return false }`. The
+ * configured lifeline/system topic had been DELETED on the Telegram side, so
+ * every send returned `400: message thread not found` — and the bare `catch`
+ * black-holed it. 41 stall escalations in one day failed silently; the user got
+ * pure silence and could not tell a stalled session from a working one.
+ *
+ * `TelegramAdapter.ensureLifelineTopic()` already knows how to recreate a
+ * deleted lifeline topic and persist the new id — the send path just never
+ * invoked it. This helper closes that gap: send to the lifeline topic; on
+ * failure, self-heal via ensureLifelineTopic() and retry once; and NEVER
+ * swallow the error silently (it is always logged).
+ *
+ * Pure + adapter-injected so it is unit-testable without a live Telegram.
+ */
+
+export interface ConsolidatedSendTelegram {
+  getLifelineTopicId(): number | undefined | null;
+  sendToTopic(topicId: number, text: string): Promise<unknown>;
+  /** Recreates the lifeline/system topic if deleted, persists the new id, returns it (or null). */
+  ensureLifelineTopic(): Promise<number | null>;
+}
+
+function errMsg(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+/**
+ * True when the send error means the target topic is GONE (deleted/closed) — the
+ * only case where the message definitely did NOT land, so recreating + retrying
+ * is safe. We deliberately do NOT retry other (transient/network) errors: those
+ * may have landed at Telegram before the response was lost, and a blind retry
+ * would double-post the escalation (this path bypasses the /telegram/reply
+ * content-dedup). A transient failure is recovered by the sentinel's next sweep.
+ */
+function isTopicGone(msg: string): boolean {
+  return /message thread not found|thread not found|topic[ _-]?deleted|topic[ _-]?closed|chat not found/i.test(msg);
+}
+
+export async function sendConsolidatedWithSelfHeal(
+  tg: ConsolidatedSendTelegram,
+  text: string,
+  log: (line: string) => void,
+): Promise<boolean> {
+  const topicId = tg.getLifelineTopicId();
+
+  // Fast path: send to the currently-configured lifeline topic.
+  if (topicId) {
+    try {
+      await tg.sendToTopic(topicId, text);
+      return true;
+    } catch (err) {
+      // De-swallow (the original `catch { return false }` black-holed this).
+      const msg = errMsg(err);
+      if (!isTopicGone(msg)) {
+        // Not a deleted-topic error — could be transient and may have partially
+        // landed. Do NOT retry (avoid a duplicate escalation); the sentinel
+        // re-escalates on its next sweep if the condition persists.
+        log(`escalation send to lifeline topic ${topicId} failed (${msg}) — transient/non-topic-gone, not retrying`);
+        return false;
+      }
+      log(`escalation send to lifeline topic ${topicId} failed (${msg}: topic gone) — self-healing`);
+    }
+  } else {
+    log('escalation has no lifeline topic configured — establishing one');
+  }
+
+  // Self-heal: (re)establish the lifeline/system topic (recreates if deleted,
+  // persists the new id) and retry the send once.
+  let healed: number | null;
+  try {
+    healed = await tg.ensureLifelineTopic();
+  } catch (err) {
+    log(`escalation self-heal (ensureLifelineTopic) threw (${errMsg(err)}) — alert NOT delivered`);
+    return false;
+  }
+  if (!healed) {
+    log('escalation self-heal could not establish a lifeline topic — alert NOT delivered');
+    return false;
+  }
+
+  try {
+    await tg.sendToTopic(healed, text);
+    return true;
+  } catch (err) {
+    log(`escalation retry to healed lifeline topic ${healed} failed (${errMsg(err)}) — alert NOT delivered`);
+    return false;
+  }
+}

--- a/tests/unit/sentinel-consolidated-send.test.ts
+++ b/tests/unit/sentinel-consolidated-send.test.ts
@@ -1,0 +1,109 @@
+/**
+ * Unit tests for sendConsolidatedWithSelfHeal — the self-healing sentinel
+ * escalation delivery.
+ *
+ * Incident 2026-06-09: the lifeline/system topic was deleted on Telegram; every
+ * `sendToTopic(lifelineTopicId)` returned `400: message thread not found`, and
+ * the old `catch { return false }` swallowed it — 41 stall escalations black-holed
+ * in one day. This helper de-swallows the error and self-heals via
+ * ensureLifelineTopic() + one retry. Both sides of every boundary below.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { sendConsolidatedWithSelfHeal } from '../../src/monitoring/sentinelConsolidatedSend.js';
+
+function makeTg(opts: {
+  lifelineTopicId?: number | null;
+  sendToTopic: (topicId: number, text: string) => Promise<unknown>;
+  ensureLifelineTopic?: () => Promise<number | null>;
+}) {
+  return {
+    getLifelineTopicId: () => opts.lifelineTopicId ?? null,
+    sendToTopic: vi.fn(opts.sendToTopic),
+    ensureLifelineTopic: vi.fn(opts.ensureLifelineTopic ?? (async () => null)),
+  };
+}
+
+const THREAD_GONE = new Error('Telegram API error (400): Bad Request: message thread not found');
+
+describe('sendConsolidatedWithSelfHeal', () => {
+  it('happy path: sends to the configured lifeline topic, never touches ensureLifelineTopic', async () => {
+    const tg = makeTg({ lifelineTopicId: 2, sendToTopic: async () => ({ message_id: 1 }) });
+    const logs: string[] = [];
+    const ok = await sendConsolidatedWithSelfHeal(tg, 'hi', (l) => logs.push(l));
+    expect(ok).toBe(true);
+    expect(tg.sendToTopic).toHaveBeenCalledWith(2, 'hi');
+    expect(tg.ensureLifelineTopic).not.toHaveBeenCalled();
+    expect(logs).toHaveLength(0);
+  });
+
+  it('THE FIX: dead lifeline topic → self-heals (recreate) and retries on the new id', async () => {
+    let calls = 0;
+    const tg = makeTg({
+      lifelineTopicId: 2,
+      sendToTopic: async (id) => {
+        calls++;
+        if (id === 2) throw THREAD_GONE; // dead topic
+        return { message_id: 7 }; // succeeds on the recreated id
+      },
+      ensureLifelineTopic: async () => 99,
+    });
+    const logs: string[] = [];
+    const ok = await sendConsolidatedWithSelfHeal(tg, 'session X went quiet', (l) => logs.push(l));
+    expect(ok).toBe(true);
+    expect(tg.ensureLifelineTopic).toHaveBeenCalledOnce();
+    expect(tg.sendToTopic).toHaveBeenNthCalledWith(1, 2, 'session X went quiet');
+    expect(tg.sendToTopic).toHaveBeenNthCalledWith(2, 99, 'session X went quiet');
+    // De-swallow: the original failure was logged, not silently dropped.
+    expect(logs.join('\n')).toMatch(/lifeline topic 2 failed.*message thread not found/i);
+  });
+
+  it('transient (non-topic-gone) send error → does NOT retry (avoids duplicate), returns false, logs, never recreates', async () => {
+    const tg = makeTg({
+      lifelineTopicId: 2,
+      sendToTopic: async () => { throw new Error('Telegram API error (429): Too Many Requests'); },
+      ensureLifelineTopic: async () => 99,
+    });
+    const logs: string[] = [];
+    const ok = await sendConsolidatedWithSelfHeal(tg, 'x', (l) => logs.push(l));
+    expect(ok).toBe(false);
+    expect(tg.sendToTopic).toHaveBeenCalledOnce(); // exactly one attempt — no double-post
+    expect(tg.ensureLifelineTopic).not.toHaveBeenCalled(); // not a dead topic → no recreate
+    expect(logs.join('\n')).toMatch(/transient.*not retrying/i);
+  });
+
+  it('no lifeline topic configured → establishes one via ensureLifelineTopic, then sends', async () => {
+    const tg = makeTg({
+      lifelineTopicId: null,
+      sendToTopic: async () => ({ message_id: 3 }),
+      ensureLifelineTopic: async () => 55,
+    });
+    const ok = await sendConsolidatedWithSelfHeal(tg, 'x', () => {});
+    expect(ok).toBe(true);
+    expect(tg.ensureLifelineTopic).toHaveBeenCalledOnce();
+    expect(tg.sendToTopic).toHaveBeenCalledWith(55, 'x');
+  });
+
+  it('cannot establish a lifeline topic (ensureLifelineTopic returns null) → returns false, logs', async () => {
+    const tg = makeTg({ lifelineTopicId: 2, sendToTopic: async () => { throw THREAD_GONE; }, ensureLifelineTopic: async () => null });
+    const logs: string[] = [];
+    const ok = await sendConsolidatedWithSelfHeal(tg, 'x', (l) => logs.push(l));
+    expect(ok).toBe(false);
+    expect(logs.join('\n')).toMatch(/could not establish a lifeline topic/i);
+  });
+
+  it('ensureLifelineTopic throws → returns false, logs (never throws to caller)', async () => {
+    const tg = makeTg({ lifelineTopicId: 2, sendToTopic: async () => { throw THREAD_GONE; }, ensureLifelineTopic: async () => { throw new Error('telegram down'); } });
+    const logs: string[] = [];
+    const ok = await sendConsolidatedWithSelfHeal(tg, 'x', (l) => logs.push(l));
+    expect(ok).toBe(false);
+    expect(logs.join('\n')).toMatch(/self-heal \(ensureLifelineTopic\) threw/i);
+  });
+
+  it('retry to the healed topic also fails → returns false, logs (no silent swallow)', async () => {
+    const tg = makeTg({ lifelineTopicId: 2, sendToTopic: async () => { throw THREAD_GONE; }, ensureLifelineTopic: async () => 99 });
+    const logs: string[] = [];
+    const ok = await sendConsolidatedWithSelfHeal(tg, 'x', (l) => logs.push(l));
+    expect(ok).toBe(false);
+    expect(logs.join('\n')).toMatch(/retry to healed lifeline topic 99 failed/i);
+  });
+});

--- a/upgrades/next/sentinel-escalation-selfheal.eli16.md
+++ b/upgrades/next/sentinel-escalation-selfheal.eli16.md
@@ -1,0 +1,60 @@
+# ELI16 — Why stall alerts vanished into silence
+
+## The problem
+
+The operator couldn't tell whether a session had stalled or was just working —
+because for almost an hour it heard nothing. Here's what was actually happening
+under the hood, and it's worse than "the agent didn't notice."
+
+The agent's stall-detector **did** notice. It saw a session go quiet, gave it a
+nudge, and tried to send the operator a message: "this session went quiet ~16
+minutes ago, want me to dig in?" That message goes to a dedicated "Lifeline"
+system topic in Telegram.
+
+But that Lifeline topic had been **deleted** on the Telegram side, while the
+config still pointed at it. So every send came back with `message thread not
+found` — and the code did `catch { return false }`, i.e. it threw the error in
+the trash and moved on. **41 times in one day** the system had something
+important to tell the operator and it silently failed to send. The operator got
+pure silence, which looks exactly like "nothing's wrong."
+
+So the real bug wasn't a missing alert — it was a generated alert dying on the
+way out the door, invisibly.
+
+## What already exists
+
+The Telegram adapter already has a method, `ensureLifelineTopic()`, that knows
+how to **recreate** a deleted Lifeline topic and remember the new one. The alert
+path just never called it — and worse, it hid the failure instead of reacting to
+it.
+
+## What's new
+
+One small, shared helper that both alert paths now use. When it tries to send an
+alert and the send fails, it:
+
+1. **Logs the real error** instead of swallowing it — so a delivery failure can
+   never again be invisible.
+2. **Heals the topic** — calls `ensureLifelineTopic()` to recreate the deleted
+   topic, then retries the send once.
+
+If the topic is fine, nothing changes — it sends and returns immediately. Only on
+a failure does the heal-and-retry kick in.
+
+## The safeguards in plain terms
+
+- **No silent failures, ever.** Every send failure is now logged with the real
+  reason, so the next time something can't be delivered, it's diagnosable in
+  seconds instead of invisible for hours.
+- **Self-healing, not just louder.** A deleted system topic now repairs itself
+  and the alert still gets through.
+- **Zero change on the happy path.** A working topic behaves exactly as before —
+  the heal logic only runs when a send actually fails.
+- **Bounded.** It retries once, never loops.
+
+## What you need to decide
+
+Nothing — it ships as a normal patch with safe behavior. This is the foundation
+under the bigger piece you asked for (stall alerts that land in the *stalled
+session's own topic*, and auto-recovering the session, not just alerting): step
+one was making sure these alerts can't silently disappear in the first place.

--- a/upgrades/next/sentinel-escalation-selfheal.md
+++ b/upgrades/next/sentinel-escalation-selfheal.md
@@ -1,0 +1,21 @@
+<!-- bump: patch -->
+
+## What Changed
+
+Makes the SentinelNotifier's consolidated-escalation delivery **self-heal a deleted lifeline/system topic instead of silently swallowing the error**. Both `sendConsolidated` closures in `server.ts` (the sentinel-notify path and the stop-notify path) did `try { telegram.sendToTopic(lifelineTopicId, text) } catch { return false }`. When the lifeline/system topic is deleted on the Telegram side, every send returns `400: message thread not found`, and the bare `catch` black-holed it — so stall/stop escalations the system generated never reached the user, with zero log trace. New shared helper `sendConsolidatedWithSelfHeal` (`src/monitoring/sentinelConsolidatedSend.ts`): sends to the lifeline topic; on failure it (1) logs the real error (de-swallow) and (2) calls the adapter's existing `ensureLifelineTopic()` — which recreates a deleted topic and persists the new id — then retries the send once. Both call sites now use it. No behavior change on the happy path (a working topic sends and returns immediately, never touching `ensureLifelineTopic`).
+
+## What to Tell Your User
+
+If your "Lifeline"/system topic ever gets deleted, the alerts the system tries to send you there (a session went quiet, a session stopped) used to vanish without a trace — you'd just get silence. Now those alerts heal themselves: the system recreates the topic and delivers the alert, and any delivery failure is logged instead of disappearing. (This is the foundation under the broader "tell me when a session stalls, in that session's own topic, and auto-recover it" work.)
+
+## Summary of New Capabilities
+
+| Capability | How to Use |
+|-----------|-----------|
+| Sentinel/stop escalations self-heal a deleted lifeline topic + never swallow the send error | automatic — no config |
+
+## Evidence
+
+Reproduction (live, 2026-06-09): the configured lifeline topic (`lifelineTopicId: 2`, "Lifeline") had been deleted on Telegram. `logs/sentinel-events.jsonl` showed the active-silence sentinel correctly detecting stalled sessions and emitting `escalated` ("session went quiet ~16 min ago, want me to dig in?") — immediately followed by `notify-error: sendConsolidated returned false`, **41 times in one day**. A direct probe (`POST /telegram/reply/2`) returned exactly `400: Bad Request: message thread not found`, confirming the dead topic. The user received pure silence, so a stalled session was indistinguishable from a working one.
+
+After the fix: `tests/unit/sentinel-consolidated-send.test.ts` (7 cases) pins the happy path (no ensureLifelineTopic call), the dead-topic self-heal (recreate id 2→new, retry, deliver), the no-topic-configured path, and all three failure modes (ensure returns null / ensure throws / retry fails) — each returning false WITH a logged reason, never a silent swallow. tsc + repo lint clean. (The 15 unrelated A2ARedeliverySentinel / SessionActivitySentinel local failures are pre-existing on main, not introduced here.)

--- a/upgrades/side-effects/sentinel-escalation-selfheal.md
+++ b/upgrades/side-effects/sentinel-escalation-selfheal.md
@@ -1,0 +1,65 @@
+# Side-Effects Review — sentinel escalation self-heal (no silent swallow)
+
+**Version / slug:** `sentinel-escalation-selfheal`
+**Date:** `2026-06-09`
+**Author:** `Instar Agent (echo)`
+**Second-pass reviewer:** `independent reviewer subagent — concern raised, addressed in code`
+
+## Summary of the change
+
+Both `sendConsolidated` closures in `server.ts` (sentinel-notify ~6988, stop-notify ~9689) used `try { telegram.sendToTopic(lifelineTopicId) } catch { return false }`. A deleted lifeline/system topic made every send throw `message thread not found`, swallowed silently — 41 stall/stop escalations black-holed in one day. New helper `src/monitoring/sentinelConsolidatedSend.ts#sendConsolidatedWithSelfHeal(tg, text, log)`: send to the lifeline topic; on failure, log the real error and call the adapter's existing `ensureLifelineTopic()` (recreates a deleted topic + persists the new id), then retry once. Both sites now delegate to it. Files: `src/monitoring/sentinelConsolidatedSend.ts` (new), `src/commands/server.ts` (import + 2 call sites), `tests/unit/sentinel-consolidated-send.test.ts` (new).
+
+## Decision-point inventory
+
+- Sentinel/stop escalation DELIVERY (not a block/allow gate) — **modify** — adds a self-heal + retry + de-swallow around the existing send. No new gating decision; it only changes how a notification is delivered and whether failures are visible.
+
+## 1. Over-block
+
+No block/allow surface — this is a delivery path, not a gate. It cannot reject any input. (Over-block N/A.)
+
+## 2. Under-block
+
+N/A (no gate). Residual delivery risk: if `ensureLifelineTopic()` can't create a topic (non-forum chat, Telegram down), the alert still isn't delivered — but now it returns false WITH a logged reason (previously silent). The SentinelNotifier's own escalation-state handling of a false return is unchanged.
+
+## 3. Level-of-abstraction fit
+
+Correct layer. The fix lives at the escalation-delivery callback where the swallow was, and reuses the adapter's existing `ensureLifelineTopic()` (the right owner of topic lifecycle) rather than re-implementing topic creation. Extracted to a small injected-dependency module so it's unit-testable without a live Telegram (the inline closures were untestable, which is why the swallow shipped).
+
+## 4. Signal vs authority compliance
+
+**Required reference:** [docs/signal-vs-authority.md](../../docs/signal-vs-authority.md)
+
+- [x] No — this has no block/allow surface; it is a delivery mechanism. It adds no authority; it makes an existing best-effort send self-heal and stop hiding failures.
+
+## 5. Interactions
+
+- **Shadowing / double-fire:** retries the send at most once, and ONLY when the first error matches a topic-gone signature (`message thread not found` / topic deleted/closed / chat not found) — the only case where the message definitely did NOT land. A transient/other error (e.g. 429, network blip that may have landed at Telegram before the response was lost) is NOT retried — it logs and returns false, and the sentinel re-escalates on its next sweep. This eliminates the double-post window: a blind retry would NOT be caught by the `/telegram/reply` ~15-min content-dedup, because this helper calls `sendToTopic` directly (bypassing that route). No loop.
+- **ensureLifelineTopic side effect:** it creates a Telegram topic + persists `lifelineTopicId` (via `persistLifelineTopicId`). This is the SAME self-heal it already performs on startup; invoking it on send-failure is the intended use ("called on startup and can be called periodically"). It runs only on a failure path (rare), so no topic-creation spam.
+- **Two call sites, one helper:** both sentinel-notify and stop-notify now share identical, tested behavior (previously duplicated inline). No behavior divergence.
+- **Races:** the helper is stateless; `ensureLifelineTopic` owns its own concurrency. No new shared state.
+
+## 6. External surfaces
+
+- **Users:** ships to the install base via normal release. Visible effect: system escalations (session-quiet, session-stopped) now actually arrive even if the Lifeline topic was deleted, and never silently fail. A recreated Lifeline topic appears once if the old one was deleted (expected, one-time).
+- **Persistent state:** `ensureLifelineTopic` persists the new `lifelineTopicId` — same as its existing startup behavior. No new state shape.
+- **Telegram:** one extra API call (`ensureLifelineTopic`) only on a send failure.
+
+## 7. Rollback cost
+
+Pure code change (new module + 2 call-site swaps), no migration. Back-out = revert; behavior returns to the prior silent-swallow. Low. (The original incident — a dead topic 2 — self-heals on the first escalation after deploy; no manual topic surgery needed.)
+
+## Conclusion
+
+A focused robustness fix: it converts a 100%-silent escalation-delivery failure (dead lifeline topic, error swallowed) into self-heal-and-retry with full logging, reusing the adapter's existing topic-recreation. No gating surface, signal-vs-authority compliant, no migration. It is the foundation for the follow-on work the operator requested (route stall alerts to the stalled session's own topic + confidence-gated auto-recovery of the session) — tracked separately. Because it touches the messaging-escalation delivery path, a Phase-5 second-pass review is requested.
+
+## Second-pass review (if required)
+
+**Reviewer:** independent reviewer subagent (general-purpose)
+**Independent read of the artifact: concern raised → addressed in code**
+
+The reviewer confirmed the self-heal flow is correct on all 7 paths (happy path doesn't call ensureLifelineTopic; dead-topic heals+retries on the new id; no-topic-configured establishes one; all three failure modes return false + log, never throw to the caller; bounded single retry; both call sites converted with the old swallow gone; tsc-clean type compatibility; ensureLifelineTopic only on failure). It raised ONE valid concern: the original artifact claimed the ~15-min `/telegram/reply` content-dedup covered the partial-send-then-throw duplicate window, but this helper calls `sendToTopic` directly and bypasses that dedup — so a blind retry on a transient (non-topic-gone) error that had actually landed could double-post one escalation. **Addressed in code** (the reviewer's recommended belt-and-suspenders): the retry is now gated on an `isTopicGone(err)` signature check — only deleted/closed-topic errors (where the message definitely didn't land) self-heal + retry; transient errors log + return false (no retry), recovered by the next sentinel sweep. Eliminates the duplicate window entirely. New test case `transient (non-topic-gone) send error → does NOT retry` pins it (exactly one send attempt, ensureLifelineTopic not called). 7/7 helper tests green; tsc clean.
+
+## Evidence pointers
+
+- Live: `logs/sentinel-events.jsonl` — 41 × `notify-error: sendConsolidated returned false` paired with `active-silence`/`stop` escalations on 2026-06-09; `POST /telegram/reply/2` → `400: message thread not found`; config `lifelineTopicId: 2` (deleted on Telegram).
+- Tests: `tests/unit/sentinel-consolidated-send.test.ts` (6 cases, both sides incl. all failure modes). tsc + lint clean. (15 unrelated A2A/SessionActivity sentinel test failures are pre-existing on main, verified by stash-compare.)


### PR DESCRIPTION
## What & why

The operator couldn't tell a stalled session from a working one — for ~an hour, silence. The stall-detector was actually *working*: it detected quiet sessions, nudged them, and tried to send "session X went quiet ~16 min ago, want me to dig in?" But the **lifeline/system topic those alerts post to had been deleted on Telegram**, while config still pointed at it (`lifelineTopicId: 2`). Every send returned `400: message thread not found`, and both `sendConsolidated` closures did `catch { return false }` — black-holing it. **41 stall/stop escalations were lost in one day**, with no log trace.

Confirmed live: `POST /telegram/reply/2` → `400: Bad Request: message thread not found`; `logs/sentinel-events.jsonl` shows 41 × `notify-error: sendConsolidated returned false` paired with `escalated` events.

## The fix

New shared helper `sendConsolidatedWithSelfHeal` (`src/monitoring/sentinelConsolidatedSend.ts`), used by both the sentinel-notify and stop-notify paths:
1. Send to the lifeline topic. On success, return — never touches the heal path.
2. On failure, **log the real error** (de-swallow) and, **only if it's a topic-gone error** (`message thread not found` / topic deleted/closed / chat not found — i.e. the message definitely didn't land), call the adapter's existing `ensureLifelineTopic()` (recreates the deleted topic + persists the new id) and **retry once**.
3. A transient/other error (e.g. 429, a network blip that may have landed before the response was lost) is logged and NOT retried — the sentinel re-escalates on its next sweep. This avoids a double-post, since this helper calls `sendToTopic` directly and bypasses the `/telegram/reply` content-dedup.

No behavior change on the happy path. Bounded single retry, never loops, always resolves to a boolean (never throws into the monitoring tick).

## Tests

`tests/unit/sentinel-consolidated-send.test.ts` (7 cases): happy path (ensureLifelineTopic not called), dead-topic self-heal (recreate + retry on new id), transient error → no retry (one send, no recreate), no-topic-configured, and all three failure modes (ensure returns null / ensure throws / retry fails) — each returns false WITH a logged reason. tsc + repo lint clean. Independent second-pass review concurred after a duplicate-window concern was addressed in code (the topic-gone gating). (15 unrelated A2A/SessionActivity sentinel test failures are pre-existing on main, verified by stash-compare.)

## ELI16

The operator got an hour of silence and couldn't tell if a session was stalled or just working. The agent's stall-detector *had* noticed and tried to send an alert — but the "Lifeline" system topic it sends to had been deleted, so every alert bounced with "message thread not found," and the code threw the error in the trash (`catch { return false }`). 41 alerts vanished in a day. The fix: when sending an alert fails because the topic was deleted, recreate the topic and resend — and never throw away a send error silently again (it's always logged). It only recreates on a genuine "topic is gone" error (where the message definitely didn't arrive); for a flaky network error it doesn't blindly resend (that could double-post), and just lets the detector try again next round. On a healthy topic nothing changes. This is the foundation for the bigger ask — putting stall alerts in the stalled session's *own* topic and auto-recovering the session, not just alerting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
