### PR TITLE
fix(subscription-pool): onboarding-safe config homes for session pin/swap

### DIFF
--- a/.instar/instar-dev-decisions/2026-06-10T06-46-33-433Z-onboarding-safe-pinswap.json
+++ b/.instar/instar-dev-decisions/2026-06-10T06-46-33-433Z-onboarding-safe-pinswap.json
@@ -1,0 +1,20 @@
+{
+  "ts": "2026-06-10T06:46:33.433Z",
+  "slug": "onboarding-safe-pinswap",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "irreversibility: src/core/PostUpdateMigrator.ts touches PostUpdateMigrator",
+    "migration / fleet-rollout surface: src/core/PostUpdateMigrator.ts touches PostUpdateMigrator (fleet migration machinery)",
+    "new capability: new config key added"
+  ],
+  "belowFloor": true,
+  "files": 6,
+  "loc": 282,
+  "causalAutopsy": {
+    "origin": "latent",
+    "notes": "The headless-home requirement was known (claude auth login stores tokens only; interactive first-launch needs the onboarding flags) but the pin/swap launch paths never enforced it. The gap sat latent until the proactive swap moved ~8 interactive sessions onto headless-enrolled homes at once (2026-06-09, topic 20905)."
+  },
+  "verdict": "pass"
+}

--- a/docs/specs/_drafts/onboarding-safe-pinswap.eli16.md
+++ b/docs/specs/_drafts/onboarding-safe-pinswap.eli16.md
@@ -1,0 +1,29 @@
+# ELI16 — Stop account-swapped sessions from wedging on the "first launch" screens
+
+## The plain-English version
+
+The agent can run on a pool of Claude accounts. When one account runs out of weekly quota, the agent moves a session onto another account ("swap"), and new sessions get launched on whichever account has the most room ("pinning"). On 2026-06-09 that machinery moved ~8 live sessions at once — and every one of them froze on Claude Code's *first-launch welcome screens*, spamming browser sign-in tabs until the operator logged in by hand.
+
+## Why it happened
+
+Each pool account lives in its own little config folder. Those folders were created by a *headless* login command (`claude auth login`), which stores the OAuth sign-in tokens — and nothing else. But when Claude Code starts *interactively* (a real terminal session, the kind the agent uses to talk to you), it also checks three little "the human already said yes" switches in that folder's `.claude.json`: *finished onboarding?*, *accepted bypass-permissions mode?*, *accepted the trust dialog?*. The headless login never flips those switches. So the relaunched session had perfectly valid credentials and STILL got marched through the welcome wizard — which no one was there to click through. The tokens were never the problem; three missing booleans were.
+
+## What this change does
+
+One small, careful utility — `ensureInteractiveReady(configHome)` — flips exactly those three switches in a config folder's `.claude.json`, and nothing else. It is:
+
+- **Surgical.** It parses the existing file, sets the three flags, and writes everything else back untouched. It never reads, writes, or even looks at `oauthAccount` or any token field.
+- **Paranoid about corruption.** If the file can't be parsed, it REFUSES to rewrite it (a broken-looking file might still hold recoverable credentials) and just reports why. Writes are atomic (temp file + rename), so a crash can't leave a half-written file.
+- **Fail-safe.** It never throws into a launch. Worst case, you get the old behavior — never a dead spawn path.
+- **Idempotent and cheap.** Calling it twice does nothing the second time, so we call it *everywhere it matters* without worrying.
+
+Then we call it at every door a session can walk through into a pool account's folder:
+
+1. **At enrollment** — the moment a new account finishes logging in, its folder is made interactive-ready, so the problem can't exist for new accounts.
+2. **At every pinned launch** — both the headless and interactive launch lanes in SessionManager seed the flags right before setting `CLAUDE_CONFIG_DIR`.
+3. **At every swap** — SessionRefresh seeds the target folder *before* killing and respawning the session, and the interactive respawn lane seeds it again (belt and braces).
+4. **One migration sweep** — existing agents have pool folders enrolled *before* this fix; a PostUpdateMigrator pass seeds every claude-code account's existing folder once on update. Stale registry entries pointing at deleted folders are skipped, never created.
+
+## Why it's safe
+
+The flags are local "the human already accepted this" acknowledgements, not credentials — and on this machine the operator already accepted them manually during the incident recovery, which is exactly the state this code reproduces. Only claude-code accounts are touched (codex/gemini homes are skipped by construction). And every write path either succeeds, or reports a reason and gets out of the way.

--- a/src/core/EnrollmentWizard.ts
+++ b/src/core/EnrollmentWizard.ts
@@ -26,6 +26,10 @@ import {
   type LoginFlowKind,
   type LoginProvider,
 } from './PendingLoginStore.js';
+import {
+  ensureInteractiveReady,
+  type EnsureInteractiveReadyResult,
+} from './ensureInteractiveReady.js';
 
 /** The public artifact a framework login yields (no secret). */
 export interface LoginArtifact {
@@ -49,6 +53,14 @@ export interface EnrollmentWizardConfig {
   driveLogin: LoginDriver;
   now?: () => number;
   logger?: { log: (m: string) => void; warn: (m: string) => void };
+  /**
+   * Onboarding-readiness seeder run when a claude-code enrollment completes
+   * (2026-06-09 incident: `claude auth login` is headless-only — it stores
+   * tokens but never sets the interactive first-launch flags, so the new
+   * home wedges the first interactive session pinned/swapped onto it).
+   * Injectable for hermetic tests; production uses the real util.
+   */
+  ensureReady?: (configHome: string) => EnsureInteractiveReadyResult;
 }
 
 export interface StartEnrollmentInput {
@@ -66,11 +78,13 @@ export class EnrollmentWizard {
   private readonly store: PendingLoginStore;
   private readonly driveLogin: LoginDriver;
   private readonly logger: { log: (m: string) => void; warn: (m: string) => void };
+  private readonly ensureReady: (configHome: string) => EnsureInteractiveReadyResult;
 
   constructor(cfg: EnrollmentWizardConfig) {
     this.store = cfg.store;
     this.driveLogin = cfg.driveLogin;
     this.logger = cfg.logger ?? { log: () => {}, warn: () => {} };
+    this.ensureReady = cfg.ensureReady ?? ensureInteractiveReady;
   }
 
   /** Default flow kind per provider: Codex/OpenAI = device-code (its endorsed
@@ -164,9 +178,25 @@ export class EnrollmentWizard {
     return reissued;
   }
 
-  /** Mark a login completed once the operator approved + the account enrolled. */
+  /**
+   * Mark a login completed once the operator approved + the account enrolled.
+   * For a claude-code enrollment with a per-account config home, also seed the
+   * interactive onboarding flags — the login itself was headless, so without
+   * this the freshly-enrolled home wedges the first interactive session that
+   * pins/swaps onto it (2026-06-09 incident). Fail-safe: a seeding failure is
+   * logged, never blocks completion (the launch paths re-ensure defensively).
+   */
   complete(id: string): PendingLogin | null {
-    return this.store.complete(id);
+    const login = this.store.complete(id);
+    if (login && login.framework === 'claude-code' && login.configHome) {
+      const ready = this.ensureReady(login.configHome);
+      if (ready.patched) {
+        this.logger.log(`[EnrollmentWizard] made ${login.configHome} interactive-ready (${ready.reason})`);
+      } else if (ready.reason !== 'already interactive-ready') {
+        this.logger.warn(`[EnrollmentWizard] could not verify ${login.configHome} interactive-ready — ${ready.reason}`);
+      }
+    }
+    return login;
   }
 
   /** The phone surface: still-valid logins awaiting approval. */

--- a/src/core/PostUpdateMigrator.ts
+++ b/src/core/PostUpdateMigrator.ts
@@ -51,6 +51,8 @@ import {
   PR_GATE_SETUP_MD_SHA256,
 } from '../data/pr-gate-artifacts.js';
 import { SafeFsExecutor } from './SafeFsExecutor.js';
+import { SubscriptionPool } from './SubscriptionPool.js';
+import { ensureInteractiveReady } from './ensureInteractiveReady.js';
 import { installCodexHooks } from './installCodexHooks.js';
 import { armCodexHooks, makeTmuxTrustDriver } from './codexHookArm.js';
 import { detectCodexPath, detectTmuxPath } from './Config.js';
@@ -267,8 +269,65 @@ export class PostUpdateMigrator {
     this.migrateThreadlineConversationStore(result);
     this.migrateThreadlineAgentInfoIdentity(result);
     this.migrateWorktreeMisplacedFloodItems(result);
+    this.migrateSubscriptionPoolInteractiveReady(result);
 
     return result;
+  }
+
+  /**
+   * Seed the interactive first-launch onboarding flags into every EXISTING
+   * claude-code subscription-pool config home (2026-06-09 incident, topic
+   * 20905). Pool homes are enrolled via headless `claude auth login`, which
+   * stores OAuth tokens but never sets `hasCompletedOnboarding` /
+   * `bypassPermissionsModeAccepted` / `hasTrustDialogAccepted` — so the first
+   * interactive session pinned or quota-swapped onto such a home wedged on the
+   * first-launch onboarding screens (~8 live sessions at once). New
+   * enrollments are seeded by EnrollmentWizard.complete() and every pinned/
+   * swapped launch re-ensures defensively; this migration is the one-time
+   * sweep that makes homes enrolled BEFORE the fix safe.
+   *
+   * Idempotent (ensureInteractiveReady only writes missing flags) and
+   * fail-safe (the util never throws; per-home failures are reported, never
+   * abort the sweep). Only flags are ever written — oauthAccount/tokens are
+   * untouched by construction, and an unparseable `.claude.json` is refused,
+   * not rewritten. `requireExistingHome` keeps a stale registry entry from
+   * littering $HOME with empty credential-less homes.
+   */
+  private migrateSubscriptionPoolInteractiveReady(result: MigrationResult): void {
+    const poolPath = path.join(this.config.stateDir, 'subscription-pool.json');
+    if (!fs.existsSync(poolPath)) {
+      result.skipped.push('subscription-pool interactive-ready: no pool store');
+      return;
+    }
+    try {
+      const pool = new SubscriptionPool({ stateDir: this.config.stateDir });
+      const claudeAccounts = pool.list().filter((a) => a.framework === 'claude-code');
+      if (claudeAccounts.length === 0) {
+        result.skipped.push('subscription-pool interactive-ready: no claude-code accounts');
+        return;
+      }
+      for (const acct of claudeAccounts) {
+        const ready = ensureInteractiveReady(acct.configHome, { requireExistingHome: true });
+        if (ready.patched) {
+          result.upgraded.push(
+            `subscription-pool interactive-ready: ${acct.id} (${acct.configHome}) — ${ready.reason}`,
+          );
+        } else if (
+          ready.reason === 'already interactive-ready' ||
+          ready.reason.includes('does not exist')
+        ) {
+          result.skipped.push(`subscription-pool interactive-ready: ${acct.id} — ${ready.reason}`);
+        } else {
+          result.errors.push(
+            `subscription-pool interactive-ready: ${acct.id} (${acct.configHome}) — ${ready.reason}`,
+          );
+        }
+      }
+    } catch (err) {
+      result.errors.push(
+        `subscription-pool interactive-ready: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
   }
 
   /**

--- a/src/core/ProactiveSwapMonitor.ts
+++ b/src/core/ProactiveSwapMonitor.ts
@@ -236,6 +236,13 @@ export class ProactiveSwapMonitor {
     // sessions, so under the per-cycle cap it is rescued first.
     eligible.sort((a, b) => b.startedMs - a.startedMs);
 
+    // TODO(follow-up, 2026-06-09 incident): a proactive cycle moving MANY
+    // sessions at once is itself disruptive — every swap is a kill+respawn
+    // ("Session respawned" + interruption) even when it succeeds. Beyond the
+    // per-cycle cap + cooldown, consider gating on session ACTIVITY: only
+    // swap sessions that are actually burning quota (recent pane activity),
+    // and let idle sessions wall reactively instead of being preemptively
+    // interrupted in bulk.
     const toSwap = eligible.slice(0, this.maxSwapsPerCycle);
     const swapped: string[] = [];
     for (const c of toSwap) {

--- a/src/core/SessionManager.ts
+++ b/src/core/SessionManager.ts
@@ -19,6 +19,7 @@ import { resolveGhTokenFromVault } from './ghToken.js';
 import type { ReapGuard } from './ReapGuard.js';
 import { paneShowsClaudeWorking } from './claudeActivityIndicators.js';
 import { extractGeminiFinalAssistantBlock, meaningfulTail } from './paneText.js';
+import { ensureInteractiveReady } from './ensureInteractiveReady.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -541,6 +542,24 @@ rm()  { "${shimRunner}" rm  "$@"; }
    */
   setSpawnAccountResolver(resolver: () => { configHome: string; accountId: string } | null): void {
     this.spawnAccountResolver = resolver;
+  }
+
+  /**
+   * Defensive onboarding-readiness seed before any launch under a pool
+   * account's CLAUDE_CONFIG_DIR (2026-06-09 incident): a headless-enrolled
+   * home is missing the interactive first-launch flags, so an interactive
+   * relaunch into it wedges on the onboarding screens. Cheap + idempotent —
+   * safe to call on every pinned/swapped launch. Never throws (fail-safe by
+   * the util's contract); failures are logged, not fatal, because the worst
+   * case is the pre-fix behavior, not a dead spawn path.
+   */
+  private ensurePinnedHomeInteractiveReady(configHome: string, lane: string): void {
+    const ready = ensureInteractiveReady(configHome);
+    if (ready.patched) {
+      console.log(`[SessionManager] ${lane}: made ${configHome} interactive-ready (${ready.reason})`);
+    } else if (ready.reason !== 'already interactive-ready') {
+      console.warn(`[SessionManager] ${lane}: could not verify ${configHome} interactive-ready — ${ready.reason}`);
+    }
   }
 
   /**
@@ -1670,6 +1689,7 @@ rm()  { "${shimRunner}" rm  "$@"; }
       : null;
     if (pinnedAccount) {
       headlessSpec.envOverrides.CLAUDE_CONFIG_DIR = pinnedAccount.configHome;
+      this.ensurePinnedHomeInteractiveReady(pinnedAccount.configHome, 'headless pin');
     }
     const frameworkEnvFlags: string[] = [];
     for (const [k, v] of Object.entries(headlessSpec.envOverrides)) {
@@ -1932,6 +1952,7 @@ rm()  { "${shimRunner}" rm  "$@"; }
     const pinnedAccount = this.spawnAccountResolver?.() ?? null;
     if (pinnedAccount) {
       launchSpec.envOverrides.CLAUDE_CONFIG_DIR = pinnedAccount.configHome;
+      this.ensurePinnedHomeInteractiveReady(pinnedAccount.configHome, 'interactive-reroute pin');
     }
     const frameworkEnvFlags: string[] = [];
     for (const [k, v] of Object.entries(launchSpec.envOverrides)) {
@@ -2999,6 +3020,13 @@ rm()  { "${shimRunner}" rm  "$@"; }
     // Codex rate-limit model-swap (see resolveCodexLaunchModel) — applies to the
     // interactive (user-facing) codex session too, not just headless spawns.
     const launchDefaultModel = await this.resolveCodexLaunchModel(framework, defaultModel);
+    // Account-swap lane (Subscription & Auth P1.3): this interactive session is
+    // about to launch under a pool account's config home — seed the onboarding
+    // flags first or a headless-enrolled home wedges it on first-launch
+    // onboarding (2026-06-09 incident).
+    if (options?.configHome && framework === 'claude-code') {
+      this.ensurePinnedHomeInteractiveReady(options.configHome, 'interactive account-swap');
+    }
     const launchSpec = buildInteractiveLaunch(framework, {
       binaryPath,
       ...(options?.resumeSessionId ? { resumeSessionId: options.resumeSessionId } : {}),

--- a/src/core/SessionRefresh.ts
+++ b/src/core/SessionRefresh.ts
@@ -27,6 +27,7 @@
 
 import fs from 'node:fs';
 import path from 'node:path';
+import { ensureInteractiveReady } from './ensureInteractiveReady.js';
 import type { SessionManager } from './SessionManager.js';
 import type { StateManager } from './StateManager.js';
 import type { TelegramAdapter } from '../messaging/TelegramAdapter.js';
@@ -293,6 +294,21 @@ export class SessionRefresh {
       const accountSwap = (opts.configHome || opts.accountId)
         ? { configHome: opts.configHome, accountId: opts.accountId }
         : undefined;
+
+      // Onboarding-safe swap (2026-06-09 incident): the target config home was
+      // enrolled headlessly, so it has OAuth tokens but NOT the interactive
+      // first-launch flags — relaunching an interactive session into it would
+      // wedge on the onboarding screens. Seed the flags BEFORE the respawn.
+      // Applies to `fresh` too (the new session is interactive either way).
+      // Idempotent + fail-safe: a failure here is logged and the respawn
+      // proceeds (worst case is the pre-fix behavior, not a dead refresh).
+      if (accountSwap?.configHome) {
+        const ready = ensureInteractiveReady(accountSwap.configHome);
+        console.log(
+          `[SessionRefresh] account-swap onboarding-readiness: ${accountSwap.configHome} ` +
+          `${ready.patched ? `patched (${ready.reason})` : ready.reason} (sessionName=${sessionName})`,
+        );
+      }
 
       // Account-swap continuity: claude stores transcripts per config home, so a
       // swap to a new CLAUDE_CONFIG_DIR must carry the conversation transcript

--- a/src/core/ensureInteractiveReady.ts
+++ b/src/core/ensureInteractiveReady.ts
@@ -1,0 +1,138 @@
+/**
+ * ensureInteractiveReady — onboarding-safe config homes for the subscription
+ * pool (2026-06-09 incident, topic 20905).
+ *
+ * Pool-account config homes are created via `claude auth login`, which stores
+ * OAuth tokens but is HEADLESS-ONLY: it never sets the interactive first-launch
+ * onboarding flags. Relaunching an INTERACTIVE Claude Code session into such a
+ * home (session pinning, proactive/reactive account swap) re-runs first-launch
+ * onboarding — the OAuth-authorize URL + the "Bypass Permissions mode" accept
+ * screen — and the session wedges. The tokens were present; the onboarding
+ * FLAGS were the missing piece (~8 live sessions wedged, browser-tab spam,
+ * a manual operator login to recover).
+ *
+ * This util makes pin/swap onboarding-safe by construction: idempotently seed
+ * the three local trust-acknowledgement flags in `<configHome>/.claude.json`,
+ * preserving every other key byte-for-byte.
+ *
+ * Structural invariants:
+ *   - NEVER touches `oauthAccount` or any token/credential field — only the
+ *     three onboarding flags are ever written, onto the parsed existing object.
+ *   - NEVER rewrites a file it cannot parse — an unparseable `.claude.json`
+ *     may still hold the account's credentials in a salvageable form, so we
+ *     refuse and report rather than clobber.
+ *   - Fail-safe: never throws into the caller. A launch must not crash on
+ *     this; the worst case is the pre-fix behavior (onboarding wedge), not a
+ *     dead spawn path. All failures return `{ patched: false, reason }`.
+ *   - Idempotent + cheap (one stat/read; a write only when a flag is missing),
+ *     so calling it defensively on every pinned/swapped launch is fine.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+
+/**
+ * The interactive first-launch flags `claude auth login` (headless) never
+ * sets. All three are LOCAL trust acknowledgements — seeding them to `true`
+ * asserts nothing about credentials, only that first-launch onboarding and
+ * the bypass-permissions/trust dialogs are accepted for this home.
+ */
+export const INTERACTIVE_ONBOARDING_FLAGS = [
+  'hasCompletedOnboarding',
+  'bypassPermissionsModeAccepted',
+  'hasTrustDialogAccepted',
+] as const;
+
+export interface EnsureInteractiveReadyResult {
+  /** True when this call wrote one or more missing flags. */
+  patched: boolean;
+  /** Why nothing was written (or which flags were seeded when patched). */
+  reason: string;
+}
+
+export interface EnsureInteractiveReadyOptions {
+  /**
+   * When true, a config home whose directory does not exist is left alone
+   * (`patched: false`) instead of being created. Used by the one-time
+   * migration sweep so a stale pool entry never litters $HOME with empty
+   * credential-less homes; launch paths keep the default (create/merge —
+   * the account was just selected, so its home is expected to exist).
+   */
+  requireExistingHome?: boolean;
+}
+
+function errMsg(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+/**
+ * Idempotently mark `<configHome>/.claude.json` interactive-ready. Returns
+ * `{ patched: true }` only when a missing flag was actually written.
+ */
+export function ensureInteractiveReady(
+  configHome: string,
+  opts?: EnsureInteractiveReadyOptions,
+): EnsureInteractiveReadyResult {
+  try {
+    const trimmed = (configHome ?? '').trim();
+    if (!trimmed) return { patched: false, reason: 'empty configHome' };
+
+    // Expand a `~` prefix the same way the swap-continuity path does — pool
+    // entries are operator-entered and may be tilde-relative.
+    const home = trimmed.startsWith('~')
+      ? path.join(process.env.HOME ?? '', trimmed.slice(1))
+      : trimmed;
+    const filePath = path.join(home, '.claude.json');
+
+    if (opts?.requireExistingHome && !fs.existsSync(home)) {
+      return { patched: false, reason: `config home ${home} does not exist` };
+    }
+
+    let existing: Record<string, unknown> = {};
+    if (fs.existsSync(filePath)) {
+      let raw: string;
+      try {
+        raw = fs.readFileSync(filePath, 'utf-8');
+      } catch (err) {
+        return { patched: false, reason: `unreadable ${filePath}: ${errMsg(err)}` };
+      }
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(raw);
+      } catch (err) {
+        // Refuse to rewrite what we can't parse — the file may still hold the
+        // account's oauthAccount/credentials in a recoverable form.
+        return {
+          patched: false,
+          reason: `unparseable ${filePath} — refusing to rewrite: ${errMsg(err)}`,
+        };
+      }
+      if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+        return {
+          patched: false,
+          reason: `${filePath} is not a JSON object — refusing to rewrite`,
+        };
+      }
+      existing = parsed as Record<string, unknown>;
+    }
+
+    const missing = INTERACTIVE_ONBOARDING_FLAGS.filter((f) => existing[f] !== true);
+    if (missing.length === 0) {
+      return { patched: false, reason: 'already interactive-ready' };
+    }
+    for (const f of missing) existing[f] = true;
+
+    // Atomic tmp+rename write (the repo's durable-registry idiom) so a crash
+    // mid-write can never leave a half-written `.claude.json` — that file
+    // also carries the account's oauthAccount, which we must never corrupt.
+    fs.mkdirSync(home, { recursive: true });
+    const tmpPath = `${filePath}.${process.pid}.interactive-ready.tmp`;
+    fs.writeFileSync(tmpPath, JSON.stringify(existing, null, 2) + '\n');
+    fs.renameSync(tmpPath, filePath);
+    return { patched: true, reason: `seeded ${missing.join(', ')}` };
+  } catch (err) {
+    // @silent-fallback-ok: fail-safe by contract — a launch path must never
+    // crash on readiness seeding; the caller logs the reason.
+    return { patched: false, reason: `ensureInteractiveReady failed: ${errMsg(err)}` };
+  }
+}

--- a/tests/e2e/subscription-enrollment-lifecycle.test.ts
+++ b/tests/e2e/subscription-enrollment-lifecycle.test.ts
@@ -84,4 +84,39 @@ describe('/subscription-pool enrollment — E2E feature-alive', () => {
     expect(body.logins.map((l: any) => l.id)).toEqual(['codex-1']);
     expect(body.logins[0].userCode).toBe('AAAA-BBBB');
   });
+
+  it('FEATURE ALIVE: completing a claude-code enrollment leaves its config home interactive-ready (2026-06-09 incident)', async () => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'enroll-e2e-ready-'));
+    // The home exactly as headless `claude auth login` leaves it: an
+    // oauthAccount, NO interactive first-launch flags — the state that wedged
+    // ~8 live sessions when pin/swap relaunched into it.
+    const configHome = path.join(dir, '.claude-new-account');
+    fs.mkdirSync(configHome);
+    const oauthAccount = { accountUuid: 'u-e2e', emailAddress: 'e2e@example.com' };
+    fs.writeFileSync(path.join(configHome, '.claude.json'), JSON.stringify({ oauthAccount }));
+
+    // Production wiring: real store + real wizard with the DEFAULT seeding path.
+    const store = new PendingLoginStore({ stateDir: dir });
+    const wizard = new EnrollmentWizard({
+      store,
+      driveLogin: async () => ({ verificationUrl: 'https://claude.com/oauth/authorize', ttlMs: 15 * 60_000 }),
+    });
+    server = await bootApp({ config: { authToken: 't', stateDir: dir, port: 0 }, startTime: new Date(), enrollmentWizard: wizard });
+
+    const started = await fetch(server.url + '/subscription-pool/enroll', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ id: 'sm-1', label: 'SageMind - Justin', provider: 'anthropic', framework: 'claude-code', configHome }),
+    });
+    expect(started.status).toBe(201);
+
+    const completed = await fetch(server.url + '/subscription-pool/enroll/sm-1/complete', { method: 'POST' });
+    expect(completed.status).toBe(200);
+
+    const cfg = JSON.parse(fs.readFileSync(path.join(configHome, '.claude.json'), 'utf-8'));
+    expect(cfg.hasCompletedOnboarding).toBe(true);
+    expect(cfg.bypassPermissionsModeAccepted).toBe(true);
+    expect(cfg.hasTrustDialogAccepted).toBe(true);
+    expect(cfg.oauthAccount).toEqual(oauthAccount); // credentials byte-identical
+  });
 });

--- a/tests/integration/subscription-enrollment-interactive-ready.test.ts
+++ b/tests/integration/subscription-enrollment-interactive-ready.test.ts
@@ -1,0 +1,99 @@
+/**
+ * Integration test — enrollment seeds the interactive onboarding flags
+ * (2026-06-09 incident). Full HTTP pipeline: the real enrollment routes over a
+ * real EnrollmentWizard + real PendingLoginStore with the DEFAULT (real)
+ * ensureInteractiveReady, against a real temp config home. Proves that
+ * completing a claude-code enrollment over the API leaves the new account's
+ * home interactive-ready — tokens untouched, flags present — so the first
+ * pinned/swapped interactive session can never wedge on first-launch
+ * onboarding.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import express from 'express';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import type { AddressInfo } from 'node:net';
+import { createRoutes } from '../../src/server/routes.js';
+import { PendingLoginStore } from '../../src/core/PendingLoginStore.js';
+import { EnrollmentWizard } from '../../src/core/EnrollmentWizard.js';
+import { INTERACTIVE_ONBOARDING_FLAGS } from '../../src/core/ensureInteractiveReady.js';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+
+interface TestServer { url: string; close: () => Promise<void>; }
+async function listen(app: express.Express): Promise<TestServer> {
+  return new Promise((resolve) => {
+    const srv = app.listen(0, () => {
+      const port = (srv.address() as AddressInfo).port;
+      resolve({ url: `http://127.0.0.1:${port}`, close: () => new Promise<void>((r) => srv.close(() => r())) });
+    });
+  });
+}
+
+describe('enrollment → interactive-ready config home (integration)', () => {
+  let server: TestServer;
+  let dir: string;
+
+  beforeEach(async () => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'enroll-ready-'));
+    const store = new PendingLoginStore({ stateDir: dir });
+    // Real wizard, DEFAULT ensureReady (the real util) — the production wiring.
+    const wizard = new EnrollmentWizard({
+      store,
+      // userCode satisfies the device-code (codex) flow; the claude
+      // url-code-paste flow ignores it.
+      driveLogin: async () => ({ verificationUrl: 'https://claude.com/oauth/authorize', userCode: 'AAAA-BBBB', ttlMs: 15 * 60_000 }),
+    });
+    const app = express();
+    app.use(express.json());
+    app.use(createRoutes({ config: { authToken: 't', stateDir: dir, port: 0 }, startTime: new Date(), enrollmentWizard: wizard } as never));
+    server = await listen(app);
+  });
+
+  afterEach(async () => {
+    await server?.close();
+    try { SafeFsExecutor.safeRmSync(dir, { recursive: true, force: true, operation: 'tests/integration/subscription-enrollment-interactive-ready.test.ts:cleanup' }); } catch { /* @silent-fallback-ok */ }
+  });
+
+  it('POST enroll + complete seeds the onboarding flags into the new home (tokens untouched)', async () => {
+    // The home as `claude auth login` leaves it: tokens, no onboarding flags.
+    const configHome = path.join(dir, '.claude-new-account');
+    fs.mkdirSync(configHome);
+    const oauthAccount = { accountUuid: 'u-1', emailAddress: 'new@example.com' };
+    fs.writeFileSync(path.join(configHome, '.claude.json'), JSON.stringify({ oauthAccount }));
+
+    const started = await fetch(server.url + '/subscription-pool/enroll', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ id: 'sm-1', label: 'SageMind - Justin', provider: 'anthropic', framework: 'claude-code', configHome }),
+    });
+    expect(started.status).toBe(201);
+
+    // Flags must NOT land at start — only on completion (the login isn't
+    // approved yet; seeding early would be premature but harmless, this
+    // pins the contract).
+    let cfg = JSON.parse(fs.readFileSync(path.join(configHome, '.claude.json'), 'utf-8'));
+    expect(cfg.hasCompletedOnboarding).toBeUndefined();
+
+    const completed = await fetch(server.url + '/subscription-pool/enroll/sm-1/complete', { method: 'POST' });
+    expect(completed.status).toBe(200);
+
+    cfg = JSON.parse(fs.readFileSync(path.join(configHome, '.claude.json'), 'utf-8'));
+    for (const f of INTERACTIVE_ONBOARDING_FLAGS) expect(cfg[f]).toBe(true);
+    expect(cfg.oauthAccount).toEqual(oauthAccount);
+  });
+
+  it('completing a codex enrollment touches no config home (claude-code only)', async () => {
+    const configHome = path.join(dir, '.codex-home');
+    fs.mkdirSync(configHome);
+    await fetch(server.url + '/subscription-pool/enroll', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ id: 'cx-1', label: 'codex', provider: 'openai', framework: 'codex-cli', configHome }),
+    });
+    const completed = await fetch(server.url + '/subscription-pool/enroll/cx-1/complete', { method: 'POST' });
+    expect(completed.status).toBe(200);
+    expect(fs.existsSync(path.join(configHome, '.claude.json'))).toBe(false);
+  });
+});

--- a/tests/integration/subscription-pin-sessions.test.ts
+++ b/tests/integration/subscription-pin-sessions.test.ts
@@ -102,4 +102,48 @@ describe('subscription-pool session pinning (integration)', () => {
     expect(session.subscriptionAccountId).toBeUndefined();
     expect(newSessionArgs().some((a) => typeof a === 'string' && a.startsWith('CLAUDE_CONFIG_DIR='))).toBe(false);
   });
+
+  // ── Onboarding-safe pinning (2026-06-09 incident) ─────────────────
+  // Pool homes are enrolled via headless `claude auth login` — tokens present,
+  // interactive first-launch flags absent. A launch pinned/swapped onto such a
+  // home must seed the flags or the session wedges on the onboarding screens.
+
+  const readConfig = (home: string): Record<string, unknown> =>
+    JSON.parse(fs.readFileSync(path.join(home, '.claude.json'), 'utf-8'));
+
+  it('makes the pinned account\'s headless config home interactive-ready at spawn', async () => {
+    const home = path.join(dir, '.claude-headless');
+    fs.mkdirSync(home);
+    fs.writeFileSync(path.join(home, '.claude.json'), JSON.stringify({ oauthAccount: { accountUuid: 'u-1' } }));
+    pool.add({ id: 'headless-acct', nickname: 'headless', provider: 'anthropic', framework: 'claude-code', configHome: home });
+
+    wireResolver();
+    const session = await manager.spawnSession({ name: 'pin-ready', prompt: 'p' });
+
+    expect(session.subscriptionAccountId).toBe('headless-acct');
+    const cfg = readConfig(home);
+    expect(cfg.hasCompletedOnboarding).toBe(true);
+    expect(cfg.bypassPermissionsModeAccepted).toBe(true);
+    expect(cfg.hasTrustDialogAccepted).toBe(true);
+    expect(cfg.oauthAccount).toEqual({ accountUuid: 'u-1' }); // never touched
+  });
+
+  it('makes the account-swap target home interactive-ready on an interactive launch (configHome option)', async () => {
+    const home = path.join(dir, '.claude-swap-target');
+    fs.mkdirSync(home);
+    fs.writeFileSync(path.join(home, '.claude.json'), JSON.stringify({ oauthAccount: { accountUuid: 'u-2' } }));
+
+    // The swap respawn lane: respawnSessionForTopic → spawnInteractiveSession
+    // with the target account's configHome (no resolver involved).
+    await manager.spawnInteractiveSession(undefined, 'swap-ready', {
+      configHome: home,
+      subscriptionAccountId: 'swap-acct',
+    });
+
+    const cfg = readConfig(home);
+    expect(cfg.hasCompletedOnboarding).toBe(true);
+    expect(cfg.bypassPermissionsModeAccepted).toBe(true);
+    expect(cfg.hasTrustDialogAccepted).toBe(true);
+    expect(cfg.oauthAccount).toEqual({ accountUuid: 'u-2' });
+  });
 });

--- a/tests/unit/PostUpdateMigrator-subscriptionPoolInteractiveReady.test.ts
+++ b/tests/unit/PostUpdateMigrator-subscriptionPoolInteractiveReady.test.ts
@@ -1,0 +1,162 @@
+/**
+ * Verifies PostUpdateMigrator.migrateSubscriptionPoolInteractiveReady — the
+ * one-time sweep that seeds interactive onboarding flags into EXISTING
+ * claude-code subscription-pool config homes (2026-06-09 incident: pool homes
+ * enrolled via headless `claude auth login` had tokens but not the
+ * first-launch flags, so pinned/swapped interactive sessions wedged on
+ * onboarding screens).
+ *
+ * Migration Parity Standard: new enrollments get seeding via
+ * EnrollmentWizard.complete(); this migration is the only path for homes
+ * enrolled BEFORE the fix. Covers both sides of every boundary: no store,
+ * no claude accounts, headless home patched, ready home skipped, missing
+ * home skipped (no $HOME littering), corrupt config reported as error with
+ * bytes preserved, idempotency, and oauthAccount preservation.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { PostUpdateMigrator } from '../../src/core/PostUpdateMigrator.js';
+import { SubscriptionPool } from '../../src/core/SubscriptionPool.js';
+import { INTERACTIVE_ONBOARDING_FLAGS } from '../../src/core/ensureInteractiveReady.js';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+
+type MigrationResult = { upgraded: string[]; skipped: string[]; errors: string[] };
+
+describe('PostUpdateMigrator — subscription-pool interactive-ready sweep', () => {
+  let projectDir: string;
+  let stateDir: string;
+
+  function newMigrator(): PostUpdateMigrator {
+    return new PostUpdateMigrator({
+      projectDir,
+      stateDir,
+      port: 4042,
+      hasTelegram: false,
+      projectName: 'test',
+    });
+  }
+
+  function runMigration(): MigrationResult {
+    const result: MigrationResult = { upgraded: [], skipped: [], errors: [] };
+    (newMigrator() as unknown as {
+      migrateSubscriptionPoolInteractiveReady(r: MigrationResult): void;
+    }).migrateSubscriptionPoolInteractiveReady(result);
+    return result;
+  }
+
+  function addAccount(id: string, configHome: string, framework: 'claude-code' | 'codex-cli' = 'claude-code') {
+    const pool = new SubscriptionPool({ stateDir });
+    pool.add({
+      id,
+      nickname: id,
+      provider: framework === 'claude-code' ? 'anthropic' : 'openai',
+      framework,
+      configHome,
+    });
+  }
+
+  beforeEach(() => {
+    projectDir = fs.mkdtempSync(path.join(os.tmpdir(), 'instar-pool-ready-'));
+    stateDir = path.join(projectDir, '.instar');
+    fs.mkdirSync(stateDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    SafeFsExecutor.safeRmSync(projectDir, {
+      recursive: true,
+      force: true,
+      operation: 'tests/unit/PostUpdateMigrator-subscriptionPoolInteractiveReady.test.ts:cleanup',
+    });
+  });
+
+  it('skips cleanly when no subscription-pool store exists (dark default)', () => {
+    const r = runMigration();
+    expect(r.upgraded).toEqual([]);
+    expect(r.errors).toEqual([]);
+    expect(r.skipped.some((s) => s.includes('no pool store'))).toBe(true);
+  });
+
+  it('skips when the pool has no claude-code accounts', () => {
+    addAccount('codex-1', path.join(projectDir, '.codex-home'), 'codex-cli');
+    const r = runMigration();
+    expect(r.upgraded).toEqual([]);
+    expect(r.skipped.some((s) => s.includes('no claude-code accounts'))).toBe(true);
+  });
+
+  it('seeds the flags into a headless-enrolled home, preserving oauthAccount', () => {
+    const home = path.join(projectDir, '.claude-sagemind');
+    fs.mkdirSync(home);
+    const oauthAccount = { accountUuid: 'u-1', emailAddress: 'a@b.c' };
+    fs.writeFileSync(path.join(home, '.claude.json'), JSON.stringify({ oauthAccount }));
+    addAccount('sagemind-justin', home);
+
+    const r = runMigration();
+    expect(r.errors).toEqual([]);
+    expect(r.upgraded.some((s) => s.includes('sagemind-justin'))).toBe(true);
+    const cfg = JSON.parse(fs.readFileSync(path.join(home, '.claude.json'), 'utf-8'));
+    for (const f of INTERACTIVE_ONBOARDING_FLAGS) expect(cfg[f]).toBe(true);
+    expect(cfg.oauthAccount).toEqual(oauthAccount);
+  });
+
+  it('is idempotent: a second run reports the home as already ready', () => {
+    const home = path.join(projectDir, '.claude-sagemind');
+    fs.mkdirSync(home);
+    addAccount('sagemind-justin', home);
+
+    expect(runMigration().upgraded.length).toBe(1);
+    const second = runMigration();
+    expect(second.upgraded).toEqual([]);
+    expect(second.errors).toEqual([]);
+    expect(second.skipped.some((s) => s.includes('already interactive-ready'))).toBe(true);
+  });
+
+  it('leaves a stale registry entry alone (missing home is skipped, not created)', () => {
+    const home = path.join(projectDir, '.claude-gone');
+    addAccount('stale-acct', home);
+    const r = runMigration();
+    expect(r.errors).toEqual([]);
+    expect(r.skipped.some((s) => s.includes('does not exist'))).toBe(true);
+    expect(fs.existsSync(home)).toBe(false);
+  });
+
+  it('reports a corrupt .claude.json as an error and preserves its bytes', () => {
+    const home = path.join(projectDir, '.claude-corrupt');
+    fs.mkdirSync(home);
+    const corrupt = '{"oauthAccount": TRUNCATED';
+    fs.writeFileSync(path.join(home, '.claude.json'), corrupt);
+    addAccount('corrupt-acct', home);
+
+    const r = runMigration();
+    expect(r.errors.some((e) => e.includes('corrupt-acct'))).toBe(true);
+    expect(fs.readFileSync(path.join(home, '.claude.json'), 'utf-8')).toBe(corrupt);
+  });
+
+  it('one bad home never aborts the sweep (the good home still gets seeded)', () => {
+    const bad = path.join(projectDir, '.claude-bad');
+    fs.mkdirSync(bad);
+    fs.writeFileSync(path.join(bad, '.claude.json'), 'NOT JSON');
+    addAccount('bad-acct', bad);
+    const good = path.join(projectDir, '.claude-good');
+    fs.mkdirSync(good);
+    addAccount('good-acct', good);
+
+    const r = runMigration();
+    expect(r.errors.some((e) => e.includes('bad-acct'))).toBe(true);
+    expect(r.upgraded.some((s) => s.includes('good-acct'))).toBe(true);
+    const cfg = JSON.parse(fs.readFileSync(path.join(good, '.claude.json'), 'utf-8'));
+    for (const f of INTERACTIVE_ONBOARDING_FLAGS) expect(cfg[f]).toBe(true);
+  });
+
+  it('is wired into the full migrate() pass (not just callable in isolation)', () => {
+    const home = path.join(projectDir, '.claude-sagemind');
+    fs.mkdirSync(home);
+    addAccount('sagemind-justin', home);
+    const result = newMigrator().migrate();
+    expect(result.upgraded.some((s) => s.includes('subscription-pool interactive-ready: sagemind-justin'))).toBe(true);
+    const cfg = JSON.parse(fs.readFileSync(path.join(home, '.claude.json'), 'utf-8'));
+    for (const f of INTERACTIVE_ONBOARDING_FLAGS) expect(cfg[f]).toBe(true);
+  });
+});

--- a/tests/unit/SessionRefresh.test.ts
+++ b/tests/unit/SessionRefresh.test.ts
@@ -7,8 +7,12 @@
  * silently absent because respawnSessionForTopic doesn't kill, only spawns).
  */
 
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
 import { SessionRefresh } from '../../src/core/SessionRefresh.js';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
 import type { SessionManager } from '../../src/core/SessionManager.js';
 import type { StateManager } from '../../src/core/StateManager.js';
 import type { TelegramAdapter } from '../../src/messaging/TelegramAdapter.js';
@@ -352,6 +356,87 @@ describe('SessionRefresh', () => {
       });
       expect(respawner).not.toHaveBeenCalled();
       expect(sessionManager.killSession).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('account-swap onboarding readiness (2026-06-09 incident)', () => {
+    // A quota swap relaunches the session INTERACTIVELY under the target
+    // account's config home. A headless-enrolled home (tokens, no onboarding
+    // flags) wedges that relaunch on the first-launch screens — so the
+    // refresh must seed the flags BEFORE the respawner runs.
+    let tmpHome: string;
+    beforeEach(() => {
+      tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), 'refresh-swap-home-'));
+    });
+    afterEach(() => {
+      try { SafeFsExecutor.safeRmSync(tmpHome, { recursive: true, force: true, operation: 'tests/unit/SessionRefresh.test.ts:cleanup' }); } catch { /* @silent-fallback-ok */ }
+    });
+
+    function flagsOnDisk(): Record<string, unknown> | null {
+      try {
+        return JSON.parse(fs.readFileSync(path.join(tmpHome, '.claude.json'), 'utf-8'));
+      } catch {
+        return null;
+      }
+    }
+
+    it('seeds the onboarding flags in the target config home BEFORE the respawn', async () => {
+      // headless-enrolled home: tokens present, flags absent
+      fs.writeFileSync(path.join(tmpHome, '.claude.json'), JSON.stringify({ oauthAccount: { accountUuid: 'u-1' } }));
+      let flagsAtRespawnTime: Record<string, unknown> | null = null;
+      const { refresh } = makeDeps({
+        respawnerImpl: async () => {
+          flagsAtRespawnTime = flagsOnDisk();
+          return 'new-tmux-session';
+        },
+      });
+      const result = await refresh.refreshSession({
+        sessionName: 'echo-qalatra',
+        configHome: tmpHome,
+        accountId: 'acct-2',
+      });
+      expect(result.ok).toBe(true);
+      // Order is load-bearing: the new session launches into this home, so
+      // the flags must already be on disk when the respawner fires.
+      expect(flagsAtRespawnTime).toMatchObject({
+        hasCompletedOnboarding: true,
+        bypassPermissionsModeAccepted: true,
+        hasTrustDialogAccepted: true,
+        oauthAccount: { accountUuid: 'u-1' }, // never touched
+      });
+    });
+
+    it('seeds the flags on a FRESH swap too (the relaunch is interactive either way)', async () => {
+      const { refresh } = makeDeps();
+      const result = await refresh.refreshSession({
+        sessionName: 'echo-qalatra',
+        fresh: true,
+        configHome: tmpHome,
+        accountId: 'acct-2',
+      });
+      expect(result.ok).toBe(true);
+      expect(flagsOnDisk()).toMatchObject({ hasCompletedOnboarding: true });
+    });
+
+    it('a refresh with NO account swap touches no config home', async () => {
+      const { refresh } = makeDeps();
+      const result = await refresh.refreshSession({ sessionName: 'echo-qalatra' });
+      expect(result.ok).toBe(true);
+      expect(flagsOnDisk()).toBeNull();
+    });
+
+    it('a seeding failure never aborts the refresh (fail-safe)', async () => {
+      // Make the config home unwritable-as-a-home: a FILE in its place.
+      const fileAsHome = path.join(tmpHome, 'not-a-dir');
+      fs.writeFileSync(fileAsHome, 'x');
+      const { refresh, respawner } = makeDeps();
+      const result = await refresh.refreshSession({
+        sessionName: 'echo-qalatra',
+        configHome: fileAsHome,
+        accountId: 'acct-2',
+      });
+      expect(result.ok).toBe(true);
+      expect(respawner).toHaveBeenCalled();
     });
   });
 });

--- a/tests/unit/codex-model-swap-wiring.test.ts
+++ b/tests/unit/codex-model-swap-wiring.test.ts
@@ -103,7 +103,12 @@ describe('codex model-swap wiring — both spawn paths consume the helper', () =
   it('interactive spawn (buildInteractiveLaunch) launches with the resolved model', () => {
     const idx = src.indexOf('buildInteractiveLaunch(framework');
     expect(idx).toBeGreaterThan(0);
-    const before = src.slice(Math.max(0, idx - 400), idx);
+    // Same rationale as the headless case above: legitimate code can sit between
+    // resolution and the build — e.g. the subscription account-swap lane seeds a
+    // pool home's onboarding flags here (ensurePinnedHomeInteractiveReady) before
+    // launch. The invariant is "resolved before, passed as launchModel", not
+    // literal proximity, so use the same widened look-back window.
+    const before = src.slice(Math.max(0, idx - 2500), idx);
     expect(before).toContain('this.resolveCodexLaunchModel(framework');
     expect(src.slice(idx, idx + 250)).toContain('launchDefaultModel');
   });

--- a/tests/unit/enrollment-wizard.test.ts
+++ b/tests/unit/enrollment-wizard.test.ts
@@ -121,4 +121,71 @@ describe('EnrollmentWizard', () => {
     expect(w.complete('codex-1')?.status).toBe('completed');
     expect(w.pending()).toEqual([]);
   });
+
+  // ── Onboarding-safe enrollment (2026-06-09 incident) ──────────────
+  // `claude auth login` is headless-only: it stores tokens but never sets the
+  // interactive first-launch flags, so a freshly-enrolled home wedges the
+  // first interactive session pinned/swapped onto it. complete() must seed
+  // the flags for claude-code enrollments with a config home.
+
+  function wizardWithReadySpy(artifacts: LoginArtifact[], ready?: (h: string) => { patched: boolean; reason: string }) {
+    const readyCalls: string[] = [];
+    const queue = [...artifacts];
+    const w = new EnrollmentWizard({
+      store,
+      driveLogin: async () => queue.shift() ?? { verificationUrl: 'https://u', ttlMs: 15 * 60_000 },
+      now: () => clock,
+      ensureReady: (h: string) => {
+        readyCalls.push(h);
+        return ready ? ready(h) : { patched: true, reason: 'seeded' };
+      },
+    });
+    return { w, readyCalls };
+  }
+
+  it('complete seeds interactive-readiness for a claude-code login with a configHome', async () => {
+    const { w, readyCalls } = wizardWithReadySpy([{ verificationUrl: 'https://claude.com/oauth', ttlMs: 15 * 60_000 }]);
+    await w.start({ id: 'sm-1', label: 'SageMind - Justin', provider: 'anthropic', framework: 'claude-code', configHome: '/Users/x/.claude-sm' });
+    expect(w.complete('sm-1')?.status).toBe('completed');
+    expect(readyCalls).toEqual(['/Users/x/.claude-sm']);
+  });
+
+  it('complete does NOT seed for a codex login or a login without a configHome', async () => {
+    const { w, readyCalls } = wizardWithReadySpy([
+      { verificationUrl: 'https://auth.openai.com/codex/device', userCode: 'AAAA-BBBB', ttlMs: 15 * 60_000 },
+      { verificationUrl: 'https://claude.com/oauth', ttlMs: 15 * 60_000 },
+    ]);
+    await w.start({ id: 'codex-1', label: 'codex', provider: 'openai', framework: 'codex-cli', configHome: '/Users/x/.codex-2' });
+    await w.start({ id: 'claude-default', label: 'claude', provider: 'anthropic', framework: 'claude-code' });
+    w.complete('codex-1');
+    w.complete('claude-default');
+    expect(readyCalls).toEqual([]);
+  });
+
+  it('a seeding failure never blocks completion (fail-safe — launch paths re-ensure)', async () => {
+    const { w } = wizardWithReadySpy(
+      [{ verificationUrl: 'https://claude.com/oauth', ttlMs: 15 * 60_000 }],
+      () => ({ patched: false, reason: 'unreadable' }),
+    );
+    await w.start({ id: 'sm-1', label: 'SageMind', provider: 'anthropic', framework: 'claude-code', configHome: '/Users/x/.claude-sm' });
+    expect(w.complete('sm-1')?.status).toBe('completed');
+  });
+
+  it('default ensureReady is the REAL util: complete() lands the flags on disk', async () => {
+    const configHome = path.join(dir, '.claude-enrolled');
+    fs.mkdirSync(configHome);
+    fs.writeFileSync(path.join(configHome, '.claude.json'), JSON.stringify({ oauthAccount: { accountUuid: 'u-1' } }));
+    const w = new EnrollmentWizard({
+      store,
+      driveLogin: async () => ({ verificationUrl: 'https://claude.com/oauth', ttlMs: 15 * 60_000 }),
+      now: () => clock,
+    });
+    await w.start({ id: 'sm-1', label: 'SageMind', provider: 'anthropic', framework: 'claude-code', configHome });
+    w.complete('sm-1');
+    const cfg = JSON.parse(fs.readFileSync(path.join(configHome, '.claude.json'), 'utf-8'));
+    expect(cfg.hasCompletedOnboarding).toBe(true);
+    expect(cfg.bypassPermissionsModeAccepted).toBe(true);
+    expect(cfg.hasTrustDialogAccepted).toBe(true);
+    expect(cfg.oauthAccount).toEqual({ accountUuid: 'u-1' }); // untouched
+  });
 });

--- a/tests/unit/ensure-interactive-ready.test.ts
+++ b/tests/unit/ensure-interactive-ready.test.ts
@@ -1,0 +1,214 @@
+/**
+ * Unit tests for ensureInteractiveReady (onboarding-safe config homes,
+ * 2026-06-09 incident). Module in isolation with a real filesystem (temp
+ * dirs). Covers both sides of every boundary: missing-file create, partial
+ * merge, idempotency, oauthAccount/token preservation, tilde expansion, the
+ * fail-safe lanes (empty home, unreadable, unparseable, non-object), and the
+ * requireExistingHome migration gate.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import {
+  ensureInteractiveReady,
+  INTERACTIVE_ONBOARDING_FLAGS,
+} from '../../src/core/ensureInteractiveReady.js';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+
+describe('ensureInteractiveReady', () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'interactive-ready-'));
+  });
+  afterEach(() => {
+    try { SafeFsExecutor.safeRmSync(dir, { recursive: true, force: true, operation: 'tests/unit/ensure-interactive-ready.test.ts:cleanup' }); } catch { /* @silent-fallback-ok */ }
+  });
+
+  function home(name = '.claude-acct'): string {
+    return path.join(dir, name);
+  }
+  function readConfig(h: string): Record<string, unknown> {
+    return JSON.parse(fs.readFileSync(path.join(h, '.claude.json'), 'utf-8'));
+  }
+
+  // ── create / merge ────────────────────────────────────────────────
+
+  it('creates .claude.json with all three flags when the file is missing', () => {
+    const h = home();
+    fs.mkdirSync(h);
+    const r = ensureInteractiveReady(h);
+    expect(r.patched).toBe(true);
+    const cfg = readConfig(h);
+    for (const f of INTERACTIVE_ONBOARDING_FLAGS) expect(cfg[f]).toBe(true);
+  });
+
+  it('creates the config home directory itself when missing (enrollment ordering)', () => {
+    const h = home('.claude-not-yet');
+    const r = ensureInteractiveReady(h);
+    expect(r.patched).toBe(true);
+    for (const f of INTERACTIVE_ONBOARDING_FLAGS) expect(readConfig(h)[f]).toBe(true);
+  });
+
+  it('merges missing flags into an existing config, preserving ALL other keys', () => {
+    // The justin-gmail live state at the incident: onboarded=true, bypass missing.
+    const h = home();
+    fs.mkdirSync(h);
+    const before = {
+      hasCompletedOnboarding: true,
+      numStartups: 42,
+      installMethod: 'native',
+      oauthAccount: { accountUuid: 'uuid-1', emailAddress: 'user@example.com' },
+      projects: { '/some/dir': { allowedTools: [] } },
+    };
+    fs.writeFileSync(path.join(h, '.claude.json'), JSON.stringify(before));
+    const r = ensureInteractiveReady(h);
+    expect(r.patched).toBe(true);
+    expect(r.reason).toContain('bypassPermissionsModeAccepted');
+    expect(r.reason).toContain('hasTrustDialogAccepted');
+    expect(r.reason).not.toContain('hasCompletedOnboarding');
+    const cfg = readConfig(h);
+    for (const f of INTERACTIVE_ONBOARDING_FLAGS) expect(cfg[f]).toBe(true);
+    // every pre-existing key survives byte-for-byte
+    expect(cfg.numStartups).toBe(42);
+    expect(cfg.installMethod).toBe('native');
+    expect(cfg.projects).toEqual(before.projects);
+  });
+
+  it('treats a flag explicitly set to false as missing (seeds it true)', () => {
+    const h = home();
+    fs.mkdirSync(h);
+    fs.writeFileSync(path.join(h, '.claude.json'), JSON.stringify({
+      hasCompletedOnboarding: true,
+      bypassPermissionsModeAccepted: false,
+      hasTrustDialogAccepted: true,
+    }));
+    const r = ensureInteractiveReady(h);
+    expect(r.patched).toBe(true);
+    expect(readConfig(h).bypassPermissionsModeAccepted).toBe(true);
+  });
+
+  // ── NEVER touches credentials ─────────────────────────────────────
+
+  it('NEVER touches oauthAccount or token-bearing fields', () => {
+    const h = home();
+    fs.mkdirSync(h);
+    const oauthAccount = {
+      accountUuid: 'cafe-babe',
+      emailAddress: 'sagemind-justin@example.com',
+      organizationUuid: 'org-1',
+    };
+    fs.writeFileSync(path.join(h, '.claude.json'), JSON.stringify({
+      oauthAccount,
+      customApiKeyResponses: { approved: ['sk-redacted-hash'] },
+    }));
+    const r = ensureInteractiveReady(h);
+    expect(r.patched).toBe(true);
+    const cfg = readConfig(h);
+    expect(cfg.oauthAccount).toEqual(oauthAccount);
+    expect(cfg.customApiKeyResponses).toEqual({ approved: ['sk-redacted-hash'] });
+  });
+
+  // ── idempotency ───────────────────────────────────────────────────
+
+  it('is idempotent: a second call writes nothing and reports already-ready', () => {
+    const h = home();
+    const first = ensureInteractiveReady(h);
+    expect(first.patched).toBe(true);
+    const statBefore = fs.statSync(path.join(h, '.claude.json')).mtimeMs;
+    const second = ensureInteractiveReady(h);
+    expect(second.patched).toBe(false);
+    expect(second.reason).toBe('already interactive-ready');
+    expect(fs.statSync(path.join(h, '.claude.json')).mtimeMs).toBe(statBefore);
+  });
+
+  it('reports already-ready for a fully onboarded home without rewriting it', () => {
+    const h = home();
+    fs.mkdirSync(h);
+    const full = {
+      hasCompletedOnboarding: true,
+      bypassPermissionsModeAccepted: true,
+      hasTrustDialogAccepted: true,
+      oauthAccount: { accountUuid: 'u' },
+    };
+    const raw = JSON.stringify(full); // deliberately NOT pretty-printed
+    fs.writeFileSync(path.join(h, '.claude.json'), raw);
+    const r = ensureInteractiveReady(h);
+    expect(r.patched).toBe(false);
+    // untouched byte-for-byte (no reformat write)
+    expect(fs.readFileSync(path.join(h, '.claude.json'), 'utf-8')).toBe(raw);
+  });
+
+  // ── tilde expansion ───────────────────────────────────────────────
+
+  it('expands a ~ prefix against $HOME (pool entries are operator-entered)', () => {
+    const origHome = process.env.HOME;
+    process.env.HOME = dir;
+    try {
+      const r = ensureInteractiveReady('~/.claude-tilde');
+      expect(r.patched).toBe(true);
+      expect(readConfig(path.join(dir, '.claude-tilde')).hasCompletedOnboarding).toBe(true);
+    } finally {
+      process.env.HOME = origHome;
+    }
+  });
+
+  // ── fail-safe lanes (never throw into a launch path) ──────────────
+
+  it('fail-safe: empty configHome returns patched:false, never throws', () => {
+    expect(ensureInteractiveReady('')).toEqual({ patched: false, reason: 'empty configHome' });
+    expect(ensureInteractiveReady('   ').patched).toBe(false);
+  });
+
+  it('fail-safe: refuses to rewrite an UNPARSEABLE .claude.json (may hold salvageable credentials)', () => {
+    const h = home();
+    fs.mkdirSync(h);
+    const corrupt = '{"oauthAccount": {"accountUuid": "u", TRUNCATED';
+    fs.writeFileSync(path.join(h, '.claude.json'), corrupt);
+    const r = ensureInteractiveReady(h);
+    expect(r.patched).toBe(false);
+    expect(r.reason).toContain('refusing to rewrite');
+    // the corrupt-but-maybe-salvageable bytes are preserved exactly
+    expect(fs.readFileSync(path.join(h, '.claude.json'), 'utf-8')).toBe(corrupt);
+  });
+
+  it('fail-safe: refuses a .claude.json that parses to a non-object', () => {
+    const h = home();
+    fs.mkdirSync(h);
+    fs.writeFileSync(path.join(h, '.claude.json'), '["not", "an", "object"]');
+    const r = ensureInteractiveReady(h);
+    expect(r.patched).toBe(false);
+    expect(r.reason).toContain('not a JSON object');
+    expect(JSON.parse(fs.readFileSync(path.join(h, '.claude.json'), 'utf-8'))).toEqual(['not', 'an', 'object']);
+  });
+
+  it('fail-safe: an unreadable/unwritable home returns patched:false, never throws', () => {
+    // A FILE where the config home directory should be makes every fs op on
+    // `<home>/.claude.json` fail — exercising the catch-all lane.
+    const h = home('.claude-is-a-file');
+    fs.writeFileSync(h, 'not a directory');
+    const r = ensureInteractiveReady(h);
+    expect(r.patched).toBe(false);
+    expect(r.reason).toBeTruthy();
+  });
+
+  // ── requireExistingHome (migration gate) ──────────────────────────
+
+  it('requireExistingHome: leaves a nonexistent home alone (no $HOME littering)', () => {
+    const h = home('.claude-stale-entry');
+    const r = ensureInteractiveReady(h, { requireExistingHome: true });
+    expect(r.patched).toBe(false);
+    expect(r.reason).toContain('does not exist');
+    expect(fs.existsSync(h)).toBe(false);
+  });
+
+  it('requireExistingHome: still patches a home that DOES exist', () => {
+    const h = home();
+    fs.mkdirSync(h);
+    const r = ensureInteractiveReady(h, { requireExistingHome: true });
+    expect(r.patched).toBe(true);
+    expect(readConfig(h).hasTrustDialogAccepted).toBe(true);
+  });
+});

--- a/upgrades/next/onboarding-safe-pinswap.md
+++ b/upgrades/next/onboarding-safe-pinswap.md
@@ -1,0 +1,78 @@
+<!-- bump: patch -->
+<!-- change_type: fix -->
+
+## What Changed
+
+Fixes the 2026-06-09 incident where subscription-pool **pinning** and **account
+swap** relaunched interactive sessions into pool-account config homes that were
+enrolled via headless `claude auth login` — homes with valid OAuth tokens but
+WITHOUT the interactive first-launch onboarding flags. Every relaunched session
+wedged on Claude Code's onboarding screens (OAuth-authorize browser-tab spam +
+the Bypass-Permissions accept screen); ~8 live sessions froze at once until the
+operator logged in manually.
+
+New util `ensureInteractiveReady(configHome)` idempotently seeds the three
+local trust-acknowledgement flags (`hasCompletedOnboarding`,
+`bypassPermissionsModeAccepted`, `hasTrustDialogAccepted`) in
+`<configHome>/.claude.json`, preserving every other key and **never touching
+`oauthAccount`/tokens** (an unparseable file is refused, not rewritten; writes
+are atomic). It is fail-safe by contract — a launch can never crash on it.
+
+Called everywhere a session can enter a pool home, so the wedge is impossible
+by construction:
+
+1. **Enrollment** — `EnrollmentWizard.complete()` seeds a freshly-enrolled
+   claude-code home immediately.
+2. **Pinned launches** — both SessionManager pin lanes (headless +
+   interactive-reroute) and the interactive account-swap lane seed before
+   setting `CLAUDE_CONFIG_DIR`.
+3. **Swaps** — `SessionRefresh` seeds the target home BEFORE the kill+respawn.
+4. **Existing homes** — a `PostUpdateMigrator` sweep seeds every claude-code
+   pool account's existing home once on update (stale entries skipped, never
+   created).
+
+## What to Tell Your User
+
+If I run on a pool of Claude accounts, moving my sessions between accounts
+(when one hits its weekly limit) used to be able to freeze them on Claude's
+"first launch" welcome screens — the account was logged in, but nobody had
+ever clicked through the one-time setup dialogs for that account's config
+folder. That's fixed at every layer now: new accounts are made
+interactive-ready the moment they're enrolled, every launch double-checks, and
+existing accounts get fixed automatically on this update. Account swaps should
+now be invisible — same conversation, different account, no frozen sessions
+and no browser-tab spam.
+
+## Summary of New Capabilities
+
+| Capability | How to Use |
+|-----------|-----------|
+| Pool config homes are onboarding-safe by construction (enrollment + every pinned/swapped launch) | automatic — no config |
+| Existing pool homes seeded once on update | automatic — PostUpdateMigrator sweep |
+| `ensureInteractiveReady(configHome)` util for any future launch lane | `src/core/ensureInteractiveReady.ts` |
+
+## Evidence
+
+Live state at the incident (this machine): `sagemind-justin` and `sagemind-dawn`
+homes were fully headless (no flags), `justin-gmail` had onboarded=true but
+bypass=false — exactly the homes whose sessions wedged; the two complete homes'
+sessions were unaffected. The OAuth tokens were present in every case.
+
+After the change:
+- `tests/unit/ensure-interactive-ready.test.ts` — 14 cases: missing-file
+  create, partial merge, flag-false reseed, idempotency (mtime-stable second
+  call), oauthAccount/token preservation, tilde expansion, unparseable/
+  non-object refusal with bytes preserved, unreadable fail-safe,
+  requireExistingHome both sides.
+- `tests/unit/PostUpdateMigrator-subscriptionPoolInteractiveReady.test.ts` — 8
+  cases incl. one-bad-home-never-aborts-the-sweep and full-migrate() wiring.
+- `tests/unit/SessionRefresh.test.ts` — flags land BEFORE the respawner fires
+  (ordering pinned), fresh swaps too, no-swap untouched, fail-safe.
+- `tests/integration/subscription-pin-sessions.test.ts` — both launch lanes
+  land the flags on disk through the real SessionManager.
+- `tests/integration/subscription-enrollment-interactive-ready.test.ts` +
+  `tests/e2e/subscription-enrollment-lifecycle.test.ts` — full HTTP
+  enroll→complete leaves the home interactive-ready, credentials
+  byte-identical.
+- `npm run lint` (tsc + all custom lints) clean; subscription/quota regression
+  suites green.

--- a/upgrades/side-effects/onboarding-safe-pinswap.md
+++ b/upgrades/side-effects/onboarding-safe-pinswap.md
@@ -1,0 +1,49 @@
+# Side-Effects Review — onboarding-safe config homes for subscription pin/swap
+
+**Version / slug:** `onboarding-safe-pinswap`
+**Date:** `2026-06-09`
+**Author:** `echo (Fable 5 build session)`
+**Second-pass reviewer:** `self-review under the Tier-1 lite lane; every write path to .claude.json walked below`
+
+## Summary of the change
+
+2026-06-09 incident (topic 20905): pin/swap relaunched ~8 interactive sessions into pool-account config homes created by headless `claude auth login` — tokens present, interactive first-launch flags absent — so every one wedged on the onboarding screens. New util `ensureInteractiveReady(configHome)` idempotently seeds `hasCompletedOnboarding` / `bypassPermissionsModeAccepted` / `hasTrustDialogAccepted` in `<configHome>/.claude.json`, called at enrollment completion (EnrollmentWizard), defensively at every pinned/swapped launch (SessionManager headless-pin, interactive-reroute-pin, interactive configHome lanes; SessionRefresh before the swap respawn), and once for existing homes via a PostUpdateMigrator sweep.
+
+## Decision-point inventory
+
+- `src/core/ensureInteractiveReady.ts` — NEW — the only writer. Sets exactly the three flags; preserves every other key; refuses unparseable/non-object files (never clobbers a file that may hold salvageable credentials); atomic tmp+rename write; never throws (fail-safe contract); `requireExistingHome` gate for the migration sweep.
+- `SessionManager.ensurePinnedHomeInteractiveReady` — NEW private helper — log-and-continue on failure; called in the headless pin lane, the interactive-reroute pin lane, and `spawnInteractiveSession` when `options.configHome` is set (claude-code only).
+- `SessionRefresh.refreshSession` — seeds the target home whenever `accountSwap.configHome` is present (fresh and resume swaps both relaunch interactively), BEFORE the respawner fires.
+- `EnrollmentWizard.complete()` — seeds for claude-code logins with a configHome; injectable `ensureReady` seam (default = real util). A seeding failure never blocks completion.
+- `PostUpdateMigrator.migrateSubscriptionPoolInteractiveReady` — one-time sweep over `SubscriptionPool.list()` claude-code accounts; `requireExistingHome:true` so a stale registry entry never litters $HOME; per-home failures reported in `result.errors`, never abort the sweep.
+- `ProactiveSwapMonitor` — comment-only TODO for active-session-only gating (secondary incident finding, deferred to a follow-up).
+
+## Could this corrupt credentials? (the load-bearing question)
+
+The util never touches `oauthAccount` or any token field — it sets three booleans on the parsed object and writes the rest back. Unparseable or non-object files are REFUSED, not rewritten (bytes preserved exactly — pinned by unit tests). Writes are atomic (tmp+rename) so a crash mid-write cannot truncate `.claude.json`. The Monroe homes (`~/.claude`, `~/.claude-monroe`) are not in any subscription pool registry and no new code path enumerates $HOME — only registry/launch-provided configHome values are ever touched.
+
+## Could the seeding itself break a launch?
+
+No — fail-safe by contract: every failure lane returns `{patched:false, reason}`; callers log and proceed. Worst case is byte-identical to the pre-fix behavior (the onboarding wedge), never a dead spawn/refresh path. Pinned-spawn behavior when the resolver returns null, and refreshes without an account swap, are unchanged (covered by existing + new tests).
+
+## Framework generality
+
+Seeding is gated to claude-code everywhere: the SessionManager lanes only run for claude-code launches, EnrollmentWizard checks `login.framework === 'claude-code'`, and the migrator filters `framework === 'claude-code'`. codex-cli / gemini-cli / pi-cli homes are never touched — `.claude.json` onboarding flags are a Claude Code concept by construction.
+
+## Over-permit
+
+The three flags are local trust acknowledgements (the operator manually accepted the same dialogs during incident recovery — this reproduces that state for pool homes). `bypassPermissionsModeAccepted` does not ENABLE bypass mode; it records that the mode's accept-screen was answered, which is precisely what an unattended relaunch cannot do itself. No trust scope widens beyond what every pre-incident pool home already required to function.
+
+## Migration parity
+
+Handled IN this change: existing agents get the sweep via `PostUpdateMigrator.migrate()` on update; new enrollments are seeded at completion; every launch re-ensures defensively (triple coverage). No CLAUDE.md/template surface changes — the feature is structural (Structure > Willpower), not agent-invoked.
+
+## Token/cost impact
+
+None. One stat + one small JSON read per pinned/swapped launch (write only when flags are missing — i.e., at most once per home). No LLM calls, no new polling.
+
+## Test coverage
+
+- Unit: `tests/unit/ensure-interactive-ready.test.ts` (14 — both sides of every boundary), `PostUpdateMigrator-subscriptionPoolInteractiveReady.test.ts` (8), `SessionRefresh.test.ts` (+4 ordering/fail-safe), `enrollment-wizard.test.ts` (+4 seam/wiring).
+- Integration: `subscription-pin-sessions.test.ts` (+2 — both launch lanes land the flags on disk), `subscription-enrollment-interactive-ready.test.ts` (2 — full HTTP enroll→complete seeds flags, codex untouched).
+- E2E: `subscription-enrollment-lifecycle.test.ts` (+1 feature-alive — real server, headless-state home becomes interactive-ready with credentials byte-identical).


### PR DESCRIPTION
## What & why

Fixes the 2026-06-09 incident (topic 20905) where subscription session **pinning + proactive/reactive account swap** wedged ~8 live interactive sessions on the Claude Code first-launch onboarding screens (OAuth-authorize URL + "Bypass Permissions" accept), forcing a manual operator login.

**Root cause:** pool account config homes are created via `claude auth login`, which stores OAuth tokens but is **headless-only** — it never sets the interactive first-launch onboarding flags (`hasCompletedOnboarding`, `bypassPermissionsModeAccepted`, `hasTrustDialogAccepted`). Relaunching an *interactive* session into such a home re-runs first-launch onboarding and wedges. The tokens were present; the onboarding *flags* were the missing piece.

**Fix:** a small, structurally token-safe util `ensureInteractiveReady(configHome)` that idempotently seeds *only* those three flags onto the parsed `.claude.json` (never reads or writes `oauthAccount`/credentials, refuses to rewrite an unparseable file, atomic write, fail-safe — a launch never crashes on it). It's called at the four points that can put an interactive session on a pool home: enrollment, the session-pinning launch lane (SessionManager), the swap/SessionRefresh path, and a one-time migration that seeds every existing pool home.

## ELI16

When you pool several Claude logins, the agent can run a session on any of them. Each login lives in its own config folder. Logging in via the command line saves the password-equivalent (the token) but skips the one-time "welcome" setup screens you normally click through the first time you open Claude Code. So when the agent moved a *live* session into one of those folders, Claude Code thought it was a brand-new install and threw up the login + "accept bypass permissions" screens — and the session got stuck there. The fix is a tiny helper that ticks those one-time setup boxes ahead of time (and *only* those boxes — it never touches the saved token), so moving a session into any pooled account is smooth and never asks anyone to log in again. It runs when an account is first added, again right before any session is placed on it, and a migration ticks the boxes on every account already in the pool.

## Test plan

- **Unit** (`ensure-interactive-ready.test.ts`, 14): idempotency, token/oauthAccount preservation, unparseable-file refusal, non-object refusal, missing-file create, tilde expansion, fail-safe. `PostUpdateMigrator-subscriptionPoolInteractiveReady.test.ts` (8): the migration sweep, `requireExistingHome`. Plus additions to `enrollment-wizard.test.ts` and `SessionRefresh.test.ts`.
- **Integration** (`subscription-enrollment-interactive-ready.test.ts`, `subscription-pin-sessions.test.ts`): enrollment + the pinning lane seed the flags with tokens untouched.
- **E2E** (`subscription-enrollment-lifecycle.test.ts`): feature-alive.
- Verified locally (touched suites, run clean): 58 unit + 9 integration/e2e green.

## Notes

- Built on Claude Fable 5; independently reviewed + re-verified by the overseeing session before push.
- instar-dev Tier-1-lite ceremony included (trace, ELI16 draft, side-effects artifact, release fragment); `causalAutopsy` origin=latent (the headless-home requirement was known but pin/swap didn't enforce it).
- After this merges + deploys, pin/swap (currently disabled post-incident) can be safely re-enabled — unlocking reliable parallel long-running sessions spread across accounts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
