### PR TITLE
feat(subscription): pin the interactive session lane to a pool account (B1)

### DIFF
--- a/.instar/instar-dev-decisions/2026-06-10T17-49-05-275Z-pin-interactive-session-lane.json
+++ b/.instar/instar-dev-decisions/2026-06-10T17-49-05-275Z-pin-interactive-session-lane.json
@@ -1,0 +1,19 @@
+{
+  "ts": "2026-06-10T17:49:05.275Z",
+  "slug": "pin-interactive-session-lane",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 55,
+  "causalAutopsy": {
+    "origin": "prior-pr",
+    "relatedPrs": [
+      1035
+    ],
+    "notes": "B1 was explicitly logged as the follow-up to the proactive pre-limit swap (PR #1035): the ProactiveSwapMonitor covered the UNTAGGED interactive session only via a default-login fallback. This pins the interactive lane natively so the user's conversation is first-class for swap, closing that gap."
+  },
+  "verdict": "pass"
+}

--- a/docs/specs/_drafts/pin-interactive-session-lane.eli16.md
+++ b/docs/specs/_drafts/pin-interactive-session-lane.eli16.md
@@ -1,0 +1,47 @@
+# ELI16 — Pin the interactive session lane to a pool account (B1)
+
+## The setup
+
+You can give the agent several Claude logins and pool them. Each login has its own
+usage limit. To spread work across the pool — and to rescue a session when the
+login it's on fills up — every session needs a little tag that says *which login it
+is running on*. Without that tag, the auto-swapper has nothing to grab onto: it
+can't move a session it can't identify.
+
+## The gap this fixes
+
+When pooling is turned on, the agent's *background* sessions (scheduled jobs,
+helper one-shots) already launched under a chosen pool login and got that tag. But
+the **session you actually chat with over Telegram** did not. It launched on the
+default login with no tag. So if that login was the one getting full, your own
+conversation was the one session the swapper couldn't directly move — it could only
+be rescued by a slower fallback that figures out the account after the fact. The
+session you talk to most was the least protected.
+
+## What changed
+
+The user-facing interactive session now pins exactly like the background ones do.
+At launch, when pooling is on, it asks the same account-picker the background lane
+uses, launches under that login's home, and records the tag. Now your conversation
+is first-class: the swapper can move it directly the moment its login gets close to
+full, instead of waiting for the fallback.
+
+## The safety details
+
+- If the agent explicitly asked for a specific login (the mid-conversation account
+  swap already does this), that choice always wins — the picker is only consulted
+  when nobody pinned a login.
+- It only applies to Claude sessions — a Codex or Pi session is never put on a
+  Claude pool login.
+- It does nothing at all unless pooling is turned on. With pooling off, your
+  conversation launches on the default login exactly as before.
+- Before launching on a pool login, the agent makes sure that login's home is
+  ready for an interactive window (the onboarding flags are seeded), so it can't
+  get stuck on a first-launch wizard — the failure we hit and fixed earlier.
+
+## Why it's safe to ship on
+
+It reuses machinery that's already live and proven (the same picker, the same
+onboarding-safety seeding, the same tagging the background lane uses). No new
+on-by-default behavior, no new switch — it rides the existing pooling switch. With
+pooling off it is a complete no-op.

--- a/src/core/SessionManager.ts
+++ b/src/core/SessionManager.ts
@@ -2956,9 +2956,14 @@ rm()  { "${shimRunner}" rm  "$@"; }
     sessionId?: string;
     /** Subscription & Auth Standard P1.3 (claude-code only): launch this session
      *  under the given account's config home (CLAUDE_CONFIG_DIR) — the account-swap
-     *  mechanism. Additive; unset = inherit the parent's login (unchanged). */
+     *  mechanism. Additive; an explicit value always wins. When unset AND the
+     *  spawn-account resolver is wired (pinSessionsToPool), B1 resolves the
+     *  scheduler-picked pool home automatically so the interactive lane pins like
+     *  the headless lane; unset + no resolver = inherit the parent's login. */
     configHome?: string;
-    /** P1.3: record which subscription-pool account this session runs under. */
+    /** P1.3: record which subscription-pool account this session runs under. An
+     *  explicit value wins; otherwise B1 fills it from the resolver-pinned account
+     *  (kept in lockstep with configHome). */
     subscriptionAccountId?: string;
   }): Promise<string> {
     const sanitized = name
@@ -3046,12 +3051,35 @@ rm()  { "${shimRunner}" rm  "$@"; }
     // Codex rate-limit model-swap (see resolveCodexLaunchModel) — applies to the
     // interactive (user-facing) codex session too, not just headless spawns.
     const launchDefaultModel = await this.resolveCodexLaunchModel(framework, defaultModel);
-    // Account-swap lane (Subscription & Auth P1.3): this interactive session is
-    // about to launch under a pool account's config home — seed the onboarding
-    // flags first or a headless-enrolled home wedges it on first-launch
-    // onboarding (2026-06-09 incident).
-    if (options?.configHome && framework === 'claude-code') {
-      this.ensurePinnedHomeInteractiveReady(options.configHome, 'interactive account-swap');
+    // Subscription-pool pinning for the INTERACTIVE (user-facing) lane (B1).
+    // Mirrors the headless lane (spawnSession): when pinSessionsToPool wired the
+    // spawn-account resolver, launch this claude-code session under the
+    // scheduler-picked optimal account's config home and TAG it. That makes the
+    // user's own conversation first-class for auto-swap — it can be moved when
+    // its account walls — instead of riding the default login untagged, where
+    // only ProactiveSwapMonitor's default-login fallback could rescue it.
+    //   • An explicit caller-supplied configHome ALWAYS wins (the account-swap
+    //     path, SessionRefresh, passes one) — the resolver is only consulted when
+    //     the caller didn't pin a home itself.
+    //   • claude-code only: the pool holds claude logins; a pool configHome is
+    //     meaningless for a codex/pi launch.
+    //   • No-op unless the resolver is wired (pinSessionsToPool) and returns an
+    //     account → default-login behavior is exactly unchanged when off.
+    const explicitConfigHome = options?.configHome;
+    const pinnedAccount = (!explicitConfigHome && framework === 'claude-code')
+      ? (this.spawnAccountResolver?.() ?? null)
+      : null;
+    const effectiveConfigHome = explicitConfigHome ?? pinnedAccount?.configHome;
+    const effectiveAccountId = options?.subscriptionAccountId ?? pinnedAccount?.accountId;
+    // This interactive session is about to launch under a pool account's config
+    // home — seed the onboarding flags first or a headless-enrolled home wedges
+    // it on the first-launch onboarding wizard (2026-06-09 incident). Applies to
+    // both the explicit account-swap target and a resolver-pinned home.
+    if (effectiveConfigHome && framework === 'claude-code') {
+      this.ensurePinnedHomeInteractiveReady(
+        effectiveConfigHome,
+        explicitConfigHome ? 'interactive account-swap' : 'interactive pin',
+      );
     }
     const launchSpec = buildInteractiveLaunch(framework, {
       binaryPath,
@@ -3063,7 +3091,8 @@ rm()  { "${shimRunner}" rm  "$@"; }
       ...(options?.codexLocalProvider ? { codexLocalProvider: options.codexLocalProvider } : {}),
       // Subscription & Auth Standard P1.3: per-account config home (claude-only,
       // ignored by other builders) → CLAUDE_CONFIG_DIR for the launched session.
-      ...(options?.configHome ? { configHome: options.configHome } : {}),
+      // effectiveConfigHome = explicit caller home, else the resolver-pinned one.
+      ...(effectiveConfigHome ? { configHome: effectiveConfigHome } : {}),
       // Per-agent codex threadline MCP override (ignored by non-codex builders).
       ...(this.config.codexThreadlineMcp ? { codexThreadlineMcp: this.config.codexThreadlineMcp } : {}),
       // pi-cli: pin session transcripts into the agent state dir so they are
@@ -3168,9 +3197,11 @@ rm()  { "${shimRunner}" rm  "$@"; }
       // account default).
       framework,
       ...(resolveModelForFramework(framework, launchDefaultModel) ? { model: resolveModelForFramework(framework, launchDefaultModel) } : {}),
-      // P1.3: which subscription-pool account this session runs under (set on a
-      // quota-aware account swap / placement). Undefined for single-account agents.
-      ...(options?.subscriptionAccountId ? { subscriptionAccountId: options.subscriptionAccountId } : {}),
+      // P1.3: which subscription-pool account this session runs under (an explicit
+      // quota-aware swap/placement, OR the resolver-pinned account for B1 — the
+      // user-facing interactive lane is now tagged just like the headless lane).
+      // Undefined for single-account agents (resolver unwired → no pin).
+      ...(effectiveAccountId ? { subscriptionAccountId: effectiveAccountId } : {}),
       prompt: effectiveInitialMessage,
       maxDurationMinutes: this.effectiveMaxDurationMinutes,
     };

--- a/tests/e2e/session-management-e2e.test.ts
+++ b/tests/e2e/session-management-e2e.test.ts
@@ -383,6 +383,47 @@ describeMaybe('Session Management E2E', () => {
     });
   });
 
+  // ── Feature: Subscription-pool pinning of the interactive lane (B1) ──
+  // Tier-3 with a REAL tmux session: when the spawn-account resolver is wired
+  // (pinSessionsToPool, exactly as server.ts does it), the user-facing
+  // interactive session launches TAGGED under the resolved pool account — so
+  // auto-swap can move the user's own conversation, instead of it riding the
+  // default login untagged. Proves the behavior is alive end-to-end, not just
+  // in a hand-wired unit harness.
+
+  describe('Feature: Subscription-pool pinning (B1, interactive lane)', () => {
+    it('tags a real interactive session with the resolver-picked account + seeds its home onboarding-ready', async () => {
+      const claudePath = createMockClaudeInteractive(project.dir);
+      const sm = createManager(project, claudePath);
+      managers.push(sm);
+
+      // A headless-enrolled pool home: tokens present, interactive flags absent.
+      const home = path.join(project.dir, '.claude-pool-home');
+      fs.mkdirSync(home, { recursive: true });
+      fs.writeFileSync(path.join(home, '.claude.json'), JSON.stringify({ oauthAccount: { accountUuid: 'u-e2e' } }));
+
+      // Wire the resolver exactly as server.ts does under pinSessionsToPool.
+      sm.setSpawnAccountResolver(() => ({ configHome: home, accountId: 'pool-acct-e2e' }));
+
+      // When the user's interactive session spawns (no explicit configHome)
+      const tmuxSession = await sm.spawnInteractiveSession(undefined, `${TMUX_PREFIX}pin-b1`);
+      await new Promise(r => setTimeout(r, 1500));
+      expect(sm.isSessionAlive(tmuxSession)).toBe(true);
+
+      // Then the persisted record is tagged with the pool account
+      const rec = project.state.listSessions({ status: 'running' }).find(s => s.tmuxSession === tmuxSession);
+      expect(rec?.subscriptionAccountId).toBe('pool-acct-e2e');
+
+      // And the headless home was seeded onboarding-ready (tokens untouched) so
+      // the interactive launch can't wedge on the first-launch wizard.
+      const cfg = JSON.parse(fs.readFileSync(path.join(home, '.claude.json'), 'utf-8'));
+      expect(cfg.hasCompletedOnboarding).toBe(true);
+      expect(cfg.bypassPermissionsModeAccepted).toBe(true);
+      expect(cfg.hasTrustDialogAccepted).toBe(true);
+      expect(cfg.oauthAccount).toEqual({ accountUuid: 'u-e2e' });
+    });
+  });
+
   // ── Feature: Prompt Detection ─────────────────────────────────────
 
   describe('Feature: Claude prompt detection', () => {

--- a/tests/integration/subscription-pin-sessions.test.ts
+++ b/tests/integration/subscription-pin-sessions.test.ts
@@ -146,4 +146,36 @@ describe('subscription-pool session pinning (integration)', () => {
     expect(cfg.hasTrustDialogAccepted).toBe(true);
     expect(cfg.oauthAccount).toEqual({ accountUuid: 'u-2' });
   });
+
+  // ── B1: the INTERACTIVE (user-facing) lane pins via the resolver too ──────
+  // The user's own Telegram conversation must be tagged under a pool account so
+  // auto-swap can move it — not ride the default login untagged. Same resolver
+  // wiring server.ts performs under pinSessionsToPool, now consulted by the
+  // interactive lane just like the headless lane.
+
+  const interactiveRecord = (tmux: string) =>
+    state.listSessions({ status: 'running' }).find((s) => s.tmuxSession === tmux);
+
+  it('pins the interactive session to the scheduler-picked account, end to end', async () => {
+    pool.add({ id: 'gmail-justin', nickname: 'Justin', provider: 'anthropic', framework: 'claude-code', configHome: '/h/.claude-echo-justin-gmail', email: 'headley.justin@gmail.com' });
+    pool.add({ id: 'sagemind-adriana', nickname: 'SageMind - Adriana', provider: 'anthropic', framework: 'claude-code', configHome: '/h/.claude-echo-6', email: 'adriana@sagemindai.io' });
+    pool.update('gmail-justin', { lastQuota: { sevenDay: { utilizationPct: 95, resetsAt: '2026-06-20T00:00:00Z' } } });
+    pool.update('sagemind-adriana', { lastQuota: { sevenDay: { utilizationPct: 0, resetsAt: '2026-06-11T00:00:00Z' } } });
+
+    wireResolver();
+    vi.mocked(execFileSync).mockClear();
+    const tmux = await manager.spawnInteractiveSession(undefined, 'pin-interactive');
+
+    expect(interactiveRecord(tmux)?.subscriptionAccountId).toBe('sagemind-adriana');
+    expect(newSessionArgs()).toContain('CLAUDE_CONFIG_DIR=/h/.claude-echo-6');
+  });
+
+  it('does not pin the interactive session when the pool is empty (default config)', async () => {
+    wireResolver(); // wired, but pool has no accounts → selectAccount returns null
+    vi.mocked(execFileSync).mockClear();
+    const tmux = await manager.spawnInteractiveSession(undefined, 'empty-interactive');
+
+    expect(interactiveRecord(tmux)?.subscriptionAccountId).toBeUndefined();
+    expect(newSessionArgs().some((a) => typeof a === 'string' && a.startsWith('CLAUDE_CONFIG_DIR='))).toBe(false);
+  });
 });

--- a/tests/unit/interactive-session-pin.test.ts
+++ b/tests/unit/interactive-session-pin.test.ts
@@ -1,0 +1,137 @@
+/**
+ * Unit test — B1: the INTERACTIVE (user-facing) spawn lane pins to a pool
+ * account too. `spawnInteractiveSession` already honored an explicit caller
+ * `configHome` (the account-swap path); B1 makes it ALSO consult the wired
+ * spawn-account resolver (pinSessionsToPool) when the caller didn't pin a home —
+ * so the user's own Telegram conversation launches TAGGED under a pool account,
+ * exactly like the headless lane, instead of riding the default login untagged.
+ *
+ * Covers both sides of every decision boundary: resolver-pin vs. unwired,
+ * explicit-home-wins, empty-pool no-op, codex-not-pinned, and the onboarding-safe
+ * seeding of a resolver-pinned headless home. tmux is mocked (no real sessions);
+ * spawned with no initial message so no async ready-and-inject runs.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+
+const mockTmuxSessions = new Set<string>();
+vi.mock('node:child_process', () => ({
+  execFileSync: vi.fn().mockImplementation((_cmd: string, args?: string[]) => {
+    if (!args) return '';
+    if (args[0] === 'has-session') {
+      const target = args[2]?.replace(/^=/, '');
+      if (!mockTmuxSessions.has(target)) throw new Error(`session not found: ${target}`);
+      return '';
+    }
+    if (args[0] === 'new-session') {
+      const sIdx = args.indexOf('-s');
+      if (sIdx >= 0 && args[sIdx + 1]) mockTmuxSessions.add(args[sIdx + 1]);
+      return '';
+    }
+    return '';
+  }),
+  execFile: vi.fn().mockImplementation((_c: string, _a: string[], _o: unknown, cb?: (e: Error | null, r: { stdout: string }) => void) => {
+    const done = typeof _o === 'function' ? (_o as typeof cb) : cb;
+    if (done) done(null, { stdout: '' });
+  }),
+}));
+
+import { execFileSync } from 'node:child_process';
+import { SessionManager } from '../../src/core/SessionManager.js';
+import { StateManager } from '../../src/core/StateManager.js';
+import type { SessionManagerConfig } from '../../src/core/types.js';
+
+describe('interactive session pinning (B1) — unit', () => {
+  let dir: string;
+  let state: StateManager;
+  let manager: SessionManager;
+
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'pin-interactive-'));
+    fs.mkdirSync(path.join(dir, 'state'), { recursive: true });
+    state = new StateManager(path.join(dir, 'state'));
+    const config: SessionManagerConfig = {
+      tmuxPath: '/usr/bin/tmux', claudePath: '/usr/local/bin/claude',
+      projectDir: dir, maxSessions: 5, protectedSessions: [],
+      completionPatterns: ['done'], framework: 'claude-code',
+    };
+    manager = new SessionManager(config, state);
+    mockTmuxSessions.clear();
+    vi.mocked(execFileSync).mockClear();
+  });
+  afterEach(() => {
+    manager.stopMonitoring();
+    SafeFsExecutor.safeRmSync(dir, { recursive: true, force: true, operation: 'tests/unit/interactive-session-pin.test.ts:cleanup' });
+  });
+
+  const newSessionArgs = (): string[] => {
+    const call = vi.mocked(execFileSync).mock.calls.find((c) => Array.isArray(c[1]) && (c[1] as string[])[0] === 'new-session');
+    return (call?.[1] as string[]) ?? [];
+  };
+  const recordFor = (tmux: string) =>
+    state.listSessions({ status: 'running' }).find((s) => s.tmuxSession === tmux);
+  const hasConfigDir = () => newSessionArgs().some((a) => typeof a === 'string' && a.startsWith('CLAUDE_CONFIG_DIR='));
+
+  it('pins to the resolver-picked account when no explicit configHome is passed', async () => {
+    manager.setSpawnAccountResolver(() => ({ configHome: '/h/.claude-pool-a', accountId: 'acct-a' }));
+    const tmux = await manager.spawnInteractiveSession(undefined, 'pin-resolver');
+
+    expect(recordFor(tmux)?.subscriptionAccountId).toBe('acct-a');
+    expect(newSessionArgs()).toContain('CLAUDE_CONFIG_DIR=/h/.claude-pool-a');
+  });
+
+  it('an explicit caller configHome/accountId WINS over the resolver (account-swap path)', async () => {
+    // Resolver would pick acct-a, but the caller explicitly pins acct-swap.
+    manager.setSpawnAccountResolver(() => ({ configHome: '/h/.claude-pool-a', accountId: 'acct-a' }));
+    const tmux = await manager.spawnInteractiveSession(undefined, 'explicit-wins', {
+      configHome: '/h/.claude-swap', subscriptionAccountId: 'acct-swap',
+    });
+
+    expect(recordFor(tmux)?.subscriptionAccountId).toBe('acct-swap');
+    expect(newSessionArgs()).toContain('CLAUDE_CONFIG_DIR=/h/.claude-swap');
+    expect(newSessionArgs()).not.toContain('CLAUDE_CONFIG_DIR=/h/.claude-pool-a');
+  });
+
+  it('does NOT pin when the resolver is unwired (pinSessionsToPool off → default login)', async () => {
+    const tmux = await manager.spawnInteractiveSession(undefined, 'no-resolver');
+
+    expect(recordFor(tmux)?.subscriptionAccountId).toBeUndefined();
+    expect(hasConfigDir()).toBe(false);
+  });
+
+  it('does NOT pin when the resolver returns null (empty pool)', async () => {
+    manager.setSpawnAccountResolver(() => null);
+    const tmux = await manager.spawnInteractiveSession(undefined, 'empty-pool');
+
+    expect(recordFor(tmux)?.subscriptionAccountId).toBeUndefined();
+    expect(hasConfigDir()).toBe(false);
+  });
+
+  it('does NOT pin a non-claude (codex) interactive session even with the resolver wired', async () => {
+    manager.setSpawnAccountResolver(() => ({ configHome: '/h/.claude-pool-a', accountId: 'acct-a' }));
+    const tmux = await manager.spawnInteractiveSession(undefined, 'codex-no-pin', { framework: 'codex-cli' });
+
+    expect(recordFor(tmux)?.subscriptionAccountId).toBeUndefined();
+    expect(hasConfigDir()).toBe(false);
+  });
+
+  it('seeds onboarding flags on a resolver-pinned headless home, never touching tokens', async () => {
+    const home = path.join(dir, '.claude-headless');
+    fs.mkdirSync(home);
+    fs.writeFileSync(path.join(home, '.claude.json'), JSON.stringify({ oauthAccount: { accountUuid: 'u-9' } }));
+    manager.setSpawnAccountResolver(() => ({ configHome: home, accountId: 'acct-headless' }));
+
+    const tmux = await manager.spawnInteractiveSession(undefined, 'pin-onboard');
+
+    expect(recordFor(tmux)?.subscriptionAccountId).toBe('acct-headless');
+    const cfg = JSON.parse(fs.readFileSync(path.join(home, '.claude.json'), 'utf-8'));
+    expect(cfg.hasCompletedOnboarding).toBe(true);
+    expect(cfg.bypassPermissionsModeAccepted).toBe(true);
+    expect(cfg.hasTrustDialogAccepted).toBe(true);
+    expect(cfg.oauthAccount).toEqual({ accountUuid: 'u-9' }); // never touched
+  });
+});

--- a/upgrades/next/pin-interactive-session-lane.md
+++ b/upgrades/next/pin-interactive-session-lane.md
@@ -1,0 +1,37 @@
+<!-- bump: patch -->
+
+## What Changed
+
+The interactive (user-facing) session lane now pins to a subscription-pool account,
+mirroring the headless lane. When `subscriptionPool.pinSessionsToPool` is enabled,
+`SessionManager.spawnInteractiveSession` consults the same spawn-account resolver
+that `spawnSession` uses (unless the caller passed an explicit `configHome`, e.g. the
+account-swap path, which still wins). The session launches under the scheduler-picked
+pool account's config home and is tagged with `subscriptionAccountId` — making the
+user's own conversation directly eligible for proactive and reactive auto-swap,
+instead of riding the default login untagged (rescuable only by the
+ProactiveSwapMonitor's default-login fallback). The resolver-pinned home is seeded
+onboarding-ready first, so a headless-enrolled home can't wedge the launch on the
+first-launch wizard. Claude-code only; complete no-op when pinning is off.
+
+## What to Tell Your User
+
+The conversation you actually chat with is now protected the same first-class way
+your background sessions are. When you pool several logins, your own chat session is
+tagged to whichever login it is running on, so the moment that login gets close to
+full I can move your conversation to a fresh login before it ever stalls — not just
+rescue it after the fact. Nothing changes unless you have pooling turned on.
+
+## Summary of New Capabilities
+
+- The interactive session lane pins to a pool account and carries its account tag,
+  so the user's conversation is first-class for both proactive and reactive swap.
+
+## Evidence
+
+- `tests/unit/interactive-session-pin.test.ts` — 6 cases: resolver-pin, explicit
+  home wins, unwired no-op, empty-pool no-op, codex-not-pinned, onboarding-safe seeding.
+- `tests/integration/subscription-pin-sessions.test.ts` — interactive lane pins via
+  the real `selectAccount`-wired resolver; empty-pool no-op.
+- `tests/e2e/session-management-e2e.test.ts` — real tmux: an interactive session is
+  tagged with the resolver-picked account and its home is seeded onboarding-ready.

--- a/upgrades/side-effects/pin-interactive-session-lane.md
+++ b/upgrades/side-effects/pin-interactive-session-lane.md
@@ -1,0 +1,47 @@
+# Side-effects review — Pin the interactive session lane (B1)
+
+**Change:** `SessionManager.spawnInteractiveSession` now consults the wired
+spawn-account resolver (set under `subscriptionPool.pinSessionsToPool`) when the
+caller did not pass an explicit `configHome`. The interactive (user-facing) lane
+launches under, and is tagged with, the scheduler-picked pool account — mirroring
+the headless lane (`spawnSession`). One file: `src/core/SessionManager.ts`.
+
+## Blast radius
+
+- **Scope is gated three ways.** No-op unless (a) `pinSessionsToPool` wired the
+  resolver, (b) the framework is `claude-code`, and (c) the caller passed no
+  explicit `configHome`. With pooling off the resolver is never set → `pinnedAccount`
+  is null → `effectiveConfigHome`/`effectiveAccountId` are undefined → byte-for-byte
+  the prior default-login behavior.
+- **Explicit configHome still wins.** The account-swap path (SessionRefresh) passes
+  a `configHome`; that suppresses the resolver, so a swap target is never overridden.
+- **Non-claude lanes untouched.** Codex/Pi interactive sessions are never put on a
+  Claude pool home (the `framework === 'claude-code'` guard).
+
+## Interactions considered
+
+- **Onboarding-safe seeding (#1043):** `ensurePinnedHomeInteractiveReady` is now
+  invoked for the resolver-pinned home too (not only explicit-configHome), so a
+  headless-enrolled pool home is seeded interactive-ready before the launch — the
+  2026-06-09 wizard-wedge cannot recur via this new path. Tokens/oauthAccount are
+  never read or written by that helper.
+- **ProactiveSwapMonitor / autoSwapOnRateLimit:** these key on
+  `session.subscriptionAccountId`. B1 makes the interactive session carry that tag,
+  so it becomes directly swap-eligible. The monitor's default-login resolution
+  remains the safety net for the still-untagged case (pooling off / empty pool).
+- **`tmuxSessionExists` early-return:** an already-running session is reused and not
+  re-pinned — correct; live sessions are moved by the swap engine, not re-tagged here.
+- **Fail-safe:** `ensureInteractiveReady` logs and continues on a missing/unwritable
+  home; a launch never crashes on it (verified by the unit case using a fake path).
+
+## Migration / awareness
+
+- No config default, hook, skill, or CLAUDE.md template change → no `PostUpdateMigrator`
+  entry required. B1 rides the existing `pinSessionsToPool` flag; the user-facing
+  continuity capability is already documented (template "Pre-limit (proactive) swap"
+  bullet). Existing agents pick up the behavior on the normal code update.
+
+## Tests
+
+Unit (6), integration (+2 interactive cases in the existing pin suite), e2e (+1 real
+tmux case). Full sibling spawn/session/wiring suites green (96 tests). tsc clean.


### PR DESCRIPTION
## What & why

Follow-up to **#1035** (proactive pre-limit swap). That PR rescued the user's own interactive session only via a *default-login fallback*, because the interactive (user-facing) spawn lane never tagged the session with a pool account. The headless lane (`spawnSession`) already pinned via the wired spawn-account resolver under `subscriptionPool.pinSessionsToPool` — the interactive lane (`spawnInteractiveSession`) did not.

This pins the interactive lane the same way: when the resolver is wired and the caller didn't pass an explicit `configHome`, the user's conversation launches under, and is tagged with, the scheduler-picked pool account. Now it's **first-class** for both proactive (`ProactiveSwapMonitor`) and reactive (`autoSwapOnRateLimit`) swap — it can be moved *before* its login walls — instead of riding the default login untagged.

## ELI16

You can pool several Claude logins; each has its own usage limit. To move a session off a login that's filling up, the swapper needs the session tagged with which login it's on. Background sessions already got that tag — but the session you actually chat with did not, so it was the one session the swapper couldn't directly move (only a slower fallback could). This change tags your conversation at launch, exactly like the background sessions, so the moment its login gets close to full I can move it to a fresh login before it stalls. An explicit account-swap target still wins; it's Claude-only; and it's a complete no-op unless pooling is turned on. The target login's home is seeded onboarding-ready first so an interactive launch can't wedge on the first-launch wizard (the 2026-06-09 incident).

## Scope / safety

Gated three ways → no-op unless **(a)** `pinSessionsToPool` wired the resolver, **(b)** framework is `claude-code`, **(c)** caller passed no explicit `configHome` (the account-swap path still wins). One src file: `src/core/SessionManager.ts`. No config/hook/skill/template change, no new route. `ensurePinnedHomeInteractiveReady` runs for the resolver-pinned home too, so a headless-enrolled home is seeded interactive-ready before launch (tokens never touched).

## Tests (3 tiers)

- **Unit** `tests/unit/interactive-session-pin.test.ts` (6): resolver-pin, explicit-home-wins, unwired no-op, empty-pool no-op, codex-not-pinned, onboarding-safe seeding.
- **Integration** `tests/integration/subscription-pin-sessions.test.ts` (+2): interactive lane pins via the real `selectAccount`-wired resolver; empty-pool no-op.
- **E2E** `tests/e2e/session-management-e2e.test.ts` (+1): real tmux — interactive session tagged with the resolver-picked account + home seeded onboarding-ready.
- Sibling spawn/session/wiring suites green (96); tsc + repo lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
