### PR TITLE
feat(growth-digest): proactive growth-digest publisher (Slice 2 — cadence + delivery)

### DIFF
--- a/.instar/instar-dev-decisions/2026-06-10T18-08-56-958Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-06-10T18-08-56-958Z-unknown.json
@@ -1,0 +1,16 @@
+{
+  "ts": "2026-06-10T18:08:56.958Z",
+  "slug": "unknown",
+  "suggestedTier": 2,
+  "declaredTier": 2,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "new capability: new exported class / subsystem added",
+    "new capability: new config key added"
+  ],
+  "belowFloor": false,
+  "files": 5,
+  "loc": 824,
+  "causalAutopsy": null,
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-06-10T18-09-49-295Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-06-10T18-09-49-295Z-unknown.json
@@ -1,0 +1,16 @@
+{
+  "ts": "2026-06-10T18:09:49.295Z",
+  "slug": "unknown",
+  "suggestedTier": 2,
+  "declaredTier": 2,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "new capability: new exported class / subsystem added",
+    "new capability: new config key added"
+  ],
+  "belowFloor": false,
+  "files": 5,
+  "loc": 824,
+  "causalAutopsy": null,
+  "verdict": "pass"
+}

--- a/.instar/instar-dev-decisions/2026-06-10T18-28-14-488Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-06-10T18-28-14-488Z-unknown.json
@@ -1,0 +1,13 @@
+{
+  "ts": "2026-06-10T18:28:14.488Z",
+  "slug": "unknown",
+  "suggestedTier": 1,
+  "declaredTier": 2,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 2,
+  "loc": 17,
+  "causalAutopsy": null,
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-06-10T18-29-13-870Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-06-10T18-29-13-870Z-unknown.json
@@ -1,0 +1,16 @@
+{
+  "ts": "2026-06-10T18:29:13.870Z",
+  "slug": "unknown",
+  "suggestedTier": 2,
+  "declaredTier": 2,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "new capability: new exported class / subsystem added",
+    "new capability: new config key added"
+  ],
+  "belowFloor": false,
+  "files": 5,
+  "loc": 835,
+  "causalAutopsy": null,
+  "verdict": "pass"
+}

--- a/docs/specs/PROACTIVE-GROWTH-DIGEST-PUBLISHER-SLICE2-SPEC.eli16.md
+++ b/docs/specs/PROACTIVE-GROWTH-DIGEST-PUBLISHER-SLICE2-SPEC.eli16.md
@@ -1,0 +1,74 @@
+# Growth Digest Publisher (Slice 2) — plain-English overview
+
+## What is this?
+
+Echo already has a "growth analyst" — a piece of code that quietly watches whether
+your projects are stalling, whether dark features have proven themselves enough to
+turn on, how often you change a spec the same way, and how often you correct Echo.
+Today it *computes* all of that and you can read it on demand (a web route), but it
+never **tells you** anything on its own. You opened this whole thread asking for the
+opposite: *"I have YET to have an agent proactively check in with me about ANY of
+these."*
+
+This slice builds the part that speaks: a small component that, on a schedule
+(default: Monday 11am), takes the analyst's already-computed picture, writes ONE
+short "growth check-in" message, and posts it to your Agent Updates topic on
+Telegram. That's it. It adds no new spying — it just gives the existing analysis a
+voice, once a week, in one place.
+
+## What changes for you if it ships?
+
+Once it's turned on, you get a single weekly message like: "📊 Growth check-in — 3
+initiatives waiting on you, 1 feature ready to promote, 2 stalling." The big list
+(you currently have 205 stalling initiatives) is summarized to the top few with a
+"+200 more" line, so it's never a wall of text. The important stuff (a feature
+that's ready to promote, a misconfigured dark feature) is always shown in full and
+never cut off.
+
+Crucially: **on a quiet week where nothing needs your attention, it stays silent by
+default.** You killed the burn-detector alerts because they were noisy, so a weekly
+"all healthy, nothing to do" message would be the same mistake. It only speaks when
+there's something worth speaking about (you can opt into a steady heartbeat if you
+ever want one).
+
+## How it rolls out (safely)
+
+It ships turned **off**. Then on Echo only, it goes to "dry-run" — it writes the
+exact message it *would* send into a log file so you can see a real sample without
+being buzzed. You read the sample, and if you like it, we flip it to "live." The
+fleet stays off. The feature literally follows the same dark → try-it → turn-it-on
+maturity path it reports on.
+
+## What the review process changed
+
+The first draft was sound but the multi-reviewer convergence (security, scalability,
+adversarial, integration, lessons-aware, plus an outside model) caught three things
+worth knowing about:
+
+1. **It would have double-sent on your two-machine setup.** The old job it replaces
+   only ran on the "awake" machine; the new in-process timer would have run on both,
+   sending the check-in twice. Now it only sends from the machine holding the lease.
+2. **It could have accidentally bypassed the spam guards.** The shared "is this
+   message OK to send" check was tangled up with the web-request code. We untangled
+   it into one clean function that both the web route and this publisher call, so
+   there's provably one chokepoint, not two.
+3. **The quiet-week silence** described above — the reviewers flagged that a weekly
+   no-action message would re-create the noise you already rejected, so the default
+   is now "stay quiet unless there's something to say."
+
+A late mechanical fix: the wiring snippet had used a wrong API name for the
+"which machine is awake" check; the integration reviewer caught it by reading the
+real code, and it's corrected.
+
+## The tradeoffs
+
+- **Weekly vs. some other rhythm** — weekly Monday is the default; you can change the
+  day/time, and the timezone is configurable so "Monday 11am" is *your* 11am.
+- **One bounded edge case**: if the two machines hand off control at exactly the
+  wrong moment, you might get one check-in twice. That's deliberate — the whole point
+  is "the check-in arrives," so we bias toward a rare duplicate over a silent miss.
+- **It replaces the old near-silent initiative digest** so you don't get two voices
+  on the same initiatives.
+
+Nothing here can block, delay, or rewrite anything — it only ever *sends a message or
+stays quiet*. It's a voice, not a gate.

--- a/docs/specs/PROACTIVE-GROWTH-DIGEST-PUBLISHER-SLICE2-SPEC.md
+++ b/docs/specs/PROACTIVE-GROWTH-DIGEST-PUBLISHER-SLICE2-SPEC.md
@@ -1,0 +1,485 @@
+---
+title: "Proactive Growth Digest Publisher — Slice 2 (cadence + delivery)"
+slug: "proactive-growth-digest-publisher-slice2"
+author: "echo"
+parent-spec: "docs/specs/PROACTIVE-GROWTH-MILESTONE-ANALYST-SPEC.md"
+parent-principle: "Close the Loop"
+origin-commitment: "CMT-1151"
+review-convergence: "2026-06-10T16:09:20.821Z"
+review-iterations: 3
+review-completed-at: "2026-06-10T16:09:20.821Z"
+review-report: "docs/specs/reports/proactive-growth-digest-publisher-slice2-convergence.md"
+approved: true
+approved-by: "justin"
+approved-at: "2026-06-10T17:34:00Z"
+---
+
+# Proactive Growth Digest Publisher — Slice 2 SPEC (cadence + delivery)
+
+Status: **proposed** — the unbuilt "Cadence + delivery" slice (§5) of
+`PROACTIVE-GROWTH-MILESTONE-ANALYST-SPEC.md`. Slice 1 (the analyst that COMPUTES
+the digest + read routes) is shipped and live on the dev agent. This slice wires
+the already-existing-but-unwired `monitoring.growthAnalyst.digestCron` to an
+in-process publisher that, on a cadence, composes ONE consolidated "growth
+check-in" and routes it through the existing flood-guarded post-update path.
+
+Parent spec: `docs/specs/PROACTIVE-GROWTH-MILESTONE-ANALYST-SPEC.md` (§5, §7, §10).
+Origin ask: Justin, 2026-06-06, topic 21624 — *"I have YET to have an agent
+proactively check in with me about ANY of these."* Origin commitment: CMT-1151.
+
+This slice is **flood-sensitive** (it is the first thing in the growth feature
+that actually SENDS), so per the parent spec it gets its own cross-model
+convergence review + operator approval before any code ships.
+
+**Convergence note:** this spec was hardened by a Round-1 review panel (security,
+scalability, adversarial, integration, lessons-aware + gemini external). The
+biggest change vs the first draft: a **multi-machine lease gate** (the in-process
+cron would otherwise double-send on a paired agent — the superseded job was
+lease-gated and this slice must not silently drop that), a **pure res-free
+outbound-guard funnel** (so the publisher provably cannot bypass the dedup/budget/
+tone chokepoint), and **calm-week sends suppressed by default** (a weekly
+"all healthy" with no action is the exact noise the operator killed burnDetection
+for). See §9 for the original-vs-converged diff.
+
+---
+
+## 1. Problem (grounded, verified on disk @ upstream/main v1.3.469)
+
+- `GrowthMilestoneAnalyst.buildDigest()` returns a complete `GrowthDigest`
+  (`{ generatedAt, calm, summary, findings[], counts, nextWindowClosesInDays }`)
+  — verified at `src/monitoring/GrowthMilestoneAnalyst.ts:577-610`. It already
+  AGGREGATES a burst of N expiries into ONE digest object + counts (unit-tested
+  at N=500). It computes R1–R6 (R1/R2 maturity, R3 stalling, R4 spec-pattern,
+  R5 correction-pattern, R6 dev-gate conformance). It is genuinely observe-only
+  (every error path returns a SMALLER digest in the safe direction; it never
+  gates an action).
+- The analyst is wired LIVE on dev agents behind `resolveDevAgentGate`
+  (`src/server/AgentServer.ts:1299-1328`); `/growth/digest|status|findings|tick`
+  serve it; `POST /growth/tick` runs observe+compute.
+- **The gap:** nothing consumes the digest on a cadence and sends it. The config
+  field `monitoring.growthAnalyst.digestCron` (default `"0 11 * * 1"`, Mon 11:00)
+  exists in `src/core/types.ts` but is wired to NO sender (`git grep digestCron`
+  outside types/ConfigDefaults → empty). The operator never gets a proactive
+  growth check-in — the exact silence the parent spec set out to end.
+- `initiative-digest-review` (a Sonnet prompt-job, `0 11 * * 1,4` = Mon AND Thu
+  11:00 — `src/scaffold/templates/jobs/instar/initiative-digest-review.md:4`)
+  nominally covers R3 but is "near-silent — posts ONLY when a genuinely-new
+  decision is waiting"; that bar ~never trips, so it effectively never speaks.
+  **It runs only on the awake machine** (scheduler is lease-gated:
+  `server.ts:3801` `if (config.scheduler.enabled && coordinator.isAwake)`). The
+  unified digest supersedes it — and MUST preserve that single-machine property
+  (§3.7), which an in-process cron does not get for free.
+
+## 2. Goal
+
+ONE consolidated proactive "growth check-in," on a regular cadence, delivered to
+the operator through the existing budget/dedup-guarded surface — reversing the
+over-silence WITHOUT overshooting into flood OR into no-action noise. Honors the
+same dark → dry-run → live → default-on maturity path the analyst itself reports
+on, and is exactly-once across a multi-machine pairing.
+
+## 3. Design
+
+### 3.1 `GrowthDigestPublisher` (`src/monitoring/GrowthDigestPublisher.ts`)
+
+A small in-process component (model after `SessionReaper`'s audit-sink shape and
+`PromiseBeacon`'s injected-`sendMessage` shape). It owns NO analysis — it is a
+cadence + lease-check + decide-to-speak + format + deliver + audit wrapper around
+the analyst.
+
+Constructor deps (all injected — pure, testable):
+- `buildDigest: (now: Date) => GrowthDigest` — bound to the live analyst.
+- `cron: string` — `monitoring.growthAnalyst.digestCron`.
+- `timezone?: string` — IANA tz for both the cron fire AND the rendered date
+  (§3.2); default `'UTC'` (croner default), documented.
+- `mode: 'off' | 'dry-run' | 'live'` — the rollout stage (§3.4).
+- `sendOnCalmWeeks: boolean` — delivery-level calm behavior (§3.4); default
+  **false** (do NOT send a no-action heartbeat every week).
+- `send: (text: string) => Promise<DeliveryResult>` — the SINGLE funnel to the
+  guarded updates-topic path (§3.3). `DeliveryResult = { ok: boolean; reason?: string }`.
+- `isAwake: () => boolean` — the multi-machine lease gate (§3.7); default
+  `() => true` (single-machine no-op).
+- `lastPublishedAt: () => string | null` + the audit log double as the durable
+  "did we already publish this window?" record for missed-run catch-up (§3.1).
+- `audit: (entry: GrowthDigestAuditEntry) => void` — append-one-JSON-line sink
+  (default → `logs/growth-digest.jsonl`), mirroring the sentinel audit pattern.
+- `now?: () => Date`, `onError?: (where, err) => void`.
+
+Lifecycle:
+- `.start()` — creates `new Cron(cron, { timezone, protect: true, unref: true },
+  onFire)` via **croner** (the lib JobScheduler already uses:
+  `src/scheduler/JobScheduler.ts:11,263`). No new dep. `protect:true` blocks
+  overlapping fires; `unref:true` keeps the timer from holding the process open.
+  On `.start()` it ALSO runs a **missed-run catch-up** (below).
+- `.stop()` — `task.stop()`; idempotent. Wired into `AgentServer.stop()`
+  alongside the other monitors (`AgentServer.ts:3092`), reference nulled.
+- `onFire()` → `await this.publishOnce(this.now(), 'cron')`.
+- `.publishOnce(now, trigger)` is PUBLIC so a test (and a future
+  `POST /growth/publish` debug route, out of scope here) can drive one cycle
+  deterministically.
+
+`publishOnce(now, trigger)` algorithm (deterministic, NO LLM):
+1. **Lease gate** — `if (!this.isAwake())` → record `{ action: 'skipped-standby' }`,
+   return. (A standby machine never sends; mirrors the scheduler gating the
+   superseded job had — §3.7.)
+2. `mode === 'off'` → record `{ action: 'skipped-off' }`, return. (Belt: the
+   publisher is only constructed when mode ≠ 'off', but guard anyway.)
+3. **In-flight guard** — if a previous `publishOnce` is still running (sync
+   buildDigest is heavy — §3-perf), record `{ action: 'skipped-overlap' }`,
+   return. (Belt-and-suspenders with croner `protect:true`, because `publishOnce`
+   is also publicly callable.)
+4. `digest = buildDigest(now)`.
+5. Decide to speak:
+   - `!digest.calm` → speak (there are real findings).
+   - `digest.calm && sendOnCalmWeeks` → speak (operator opted into heartbeats).
+   - `digest.calm && !sendOnCalmWeeks` → record `{ action: 'skipped-calm' }`,
+     return. (Default: a no-action week is silent — respects the documented
+     burnDetection-noise correction.)
+6. `text = formatDigest(digest, { timezone })` (§3.2) — scrubbed + clamped ≤4096.
+7. `mode === 'dry-run'` → record `{ action: 'dry-run', wouldSend: text, counts,
+   trigger }`, do NOT send, return. The exact would-send message lands in the
+   audit log for operator inspection (this is how we show a real sample before
+   going live).
+8. `mode === 'live'` → `r = await send(text)`. Record `{ action: r.ok ? 'sent' :
+   'send-blocked', reason: r.reason, counts, trigger }`. A block (dedup/budget/
+   tone) is a NORMAL outcome, never an error, and is never re-acted on (the
+   publisher adds a delivery surface, never any authority).
+All branches are wrapped so a failure is audited via `onError` and never throws
+out of the cron callback (an observe-only-derived component must never crash the
+server). The audit entry always carries the digest `counts` so a skipped/blocked
+cycle is still inspectable.
+
+**Missed-run catch-up (Scalability S3 — the "check-in never arrives" failure).**
+croner schedules only a single `setTimeout` to the next match; it does NOT replay
+a fire time that elapsed while the box was asleep or the server was down (unlike
+JobScheduler's `checkMissedJobs`). For the proactive check-in that is the exact
+failure this slice exists to fix. So on `.start()`, after a settle delay (default
+60s — long enough for the multi-machine lease to settle so a machine that boots
+`isAwake:false` then acquires the lease isn't wrongly skipped, and the awake
+machine doesn't record a premature `skipped-standby` window entry), the publisher
+computes the most-recent scheduled fire time at/under `now` (croner
+`previousRun()`); if that time is in the past AND the audit log shows no
+publish/skip for that window, it runs one catch-up `publishOnce(now, 'catchup')`.
+Idempotent: the window key (the missed fire's ISO) is recorded ONLY on a real
+send/skip-decision (never on a pre-lease check) so a restart loop can't re-fire
+the same window. The catch-up itself still passes the lease gate (only the awake
+machine catches up). The settle delay is configurable; the cron sanity-floor
+(§3.4) guarantees windows are ≥1h apart so a 60s settle can never straddle two.
+
+### 3.2 `formatDigest(digest, { timezone }): string` — deterministic, pure, exported
+
+Turns a `GrowthDigest` into a compact, readable Telegram message. NO LLM — the
+analyst already decided what crosses a rule; the formatter only renders it.
+
+Render rules (all enforced, not hinted):
+- **Priority-first, never-truncate-critical** (gemini #2 / parent §10 Q3 → hard
+  requirement): findings are ordered by priority (`high` → `normal` → `low`) and
+  ALL `priority:'high'` findings + the maturity actions that demand a decision
+  (R1 promote, R6 dev-gate-dark) are rendered IN FULL, never capped. Only the
+  `low`/`normal` BULK (R3 stalling is the volume driver, 205 today) is capped at
+  **K per rule** (default 5) with a "+N more (see full digest)" overflow line.
+- **Cap-before-concat**: the formatter applies the per-rule caps and stops
+  appending once the running length nears 4096 — it NEVER materializes the full
+  500-line string and then slices (Security #3). The whole message is hard-clamped
+  to 4096 (post-update's own limit) with a final "…(truncated — full digest at
+  /growth)" only if the high-priority set alone somehow exceeds it.
+- **Render-boundary scrub (defense-in-depth, Security #1)**: every rendered
+  `detail` and `title` is passed through `scrubSecrets()` (`src/monitoring/
+  scrubSecrets.ts`) AT THE RENDER BOUNDARY before inclusion. The analyst's
+  "HTTP-safe" guarantee is about the pull API; a push channel (chat, phone
+  notification preview, screenshot, forward) warrants its own scrub. Each
+  rendered `detail` is hard-capped to ≤200 chars (a real cap, not a hint). This
+  covers the dry-run `wouldSend` text automatically (same formatter output).
+- **Timezone**: the header date is rendered in the injected `timezone` (the SAME
+  zone the cron fires in) so "Monday 11:00" and the printed date agree.
+- **Calm render**: header + `digest.summary` ("All healthy — N incubating, next
+  window closes in Xd"). Note the calm summary carries the changing
+  `nextWindowClosesInDays`/counts, so even when calm sends are enabled they are
+  not byte-identical week-over-week.
+
+Shape:
+```
+📊 Growth check-in — <generatedAt in timezone>
+
+<digest.summary>
+
+<high-priority findings, IN FULL, grouped by rule>
+<then low/normal bulk, capped K per rule with "+N more">
+
+Read the full digest anytime: GET /growth/digest (or the dashboard).
+```
+
+`formatDigest` is pure and exported → unit-tested on calm, single-rule, all-six-
+rules, the priority-never-truncate guarantee (a high-priority finding survives
+alongside 500 low ones), the scrub pass, and overflow (K+1, 500).
+
+### 3.3 Delivery path — ONE res-free outbound-guard funnel (no second send path)
+
+The digest is a proactive broadcast about the agent's own maturation → it belongs
+in the **Agent Updates topic**, NOT the active session topic (same rule as
+`/telegram/post-update`). It MUST pass through the SAME guards that route uses.
+Grounded constraint (Security #2, Integration MINOR, Lessons F2): the current
+`checkOutboundMessage(text, channel, res, opts)` (`src/server/routes.ts:1276`) is
+**Express-`res`-coupled** — on a block it calls `res.status(422).json(...)` and
+returns a boolean. The publisher's cron callback has NO `res`. So the funnel
+extraction is NOT a trivial wrapper; it must DECOUPLE the guard decision from the
+response writing, or the path of least resistance during build is the publisher
+calling a raw un-guarded `sendToTopic` — silently creating a SECOND send path and
+defeating the entire §4 anti-flood guarantee (the Structure-beats-Willpower
+failure: two chokepoints instead of one).
+
+Required extraction (the funnel contract):
+1. Introduce a pure `evaluateOutbound(text, channel, opts): Promise<{ ok: boolean;
+   reason?: string; status?: number }>` carved out of `checkOutboundMessage` —
+   the dedup + per-source topic budget + tone-gate + localhost-guard DECISION
+   logic, with NO `res`. Behavior byte-identical to today's checks. NOTE: the two
+   fire-and-forget observers at the top of `checkOutboundMessage`
+   (`observeSelfViolation`, `observePrincipalCoherence` — both observe-only, they
+   credit operator-role / principal claims) STAY in the thin route adapter, not in
+   `evaluateOutbound`. A proactive growth digest credits no operator role and is
+   authored by no principal, so there is nothing for those observers to catch on
+   the publisher path; keeping them route-side preserves byte-identical behavior
+   for existing callers without emitting meaningless telemetry for the digest.
+2. `checkOutboundMessage` becomes a thin route-only adapter: `const v = await
+   evaluateOutbound(...); if (!v.ok) { res.status(v.status).json(...); return true }`.
+   Existing callers and tests unchanged in behavior.
+3. `postToUpdatesTopic(text, { allowDuplicate? }): Promise<DeliveryResult>` (the
+   helper the publisher's `send` is wired to): resolve `agent-updates-topic`
+   server-side → `{ ok:false, reason:'no-updates-topic' }` if absent (NEVER a
+   fallback topic, mirroring the route's 400); else `await evaluateOutbound(...)`
+   → `{ ok:false, reason:'guard-blocked' }` on block; else `sendToTopic` →
+   `{ ok:true }`.
+4. `POST /telegram/post-update` is refactored to call `postToUpdatesTopic`
+   (behavior-identical; covered by existing tests + the §5 regression assertions
+   on the 400/422/dedup branches).
+The publisher's `send` is attached at route-registration time (where `ctx` lives),
+e.g. `ctx.growthDigestPublisher?.attachSender(postToUpdatesTopic)`. **The publisher
+must never reach `sendToTopic` without going through the shared guard** — asserted
+in the wiring-integrity test (§5): the publisher path and the route path invoke
+the IDENTICAL `evaluateOutbound`, not two copies.
+
+### 3.4 Rollout mode + config
+
+Per parent §7 (`dark → dry-run → live → default-on`, flag-path
+`monitoring.growthAnalyst`). Config fields under `monitoring.growthAnalyst`
+(add to BOTH `src/config/ConfigDefaults.ts` AND the `growthAnalyst` type in
+`src/core/types.ts:4234-4264`):
+
+- `digestDelivery: 'off' | 'dry-run' | 'live'` — default **`'off'`**, even on a
+  dev agent. Deliberate: Slice 1's COMPUTE+EXPOSE is already live on dev agents;
+  this slice's new SEND behavior stays opt-in until explicitly advanced, so
+  merging the code does not start buzzing anyone. The publisher is constructed
+  only when the analyst exists AND `digestDelivery !== 'off'`.
+- `digestCron: string` — cadence (already present); default `"0 11 * * 1"`
+  (Mon 11:00). **Sanity-floor (Scalability S2)**: at construction, a `digestCron`
+  whose two soonest fires are < 1h apart is REFUSED (logged + the publisher does
+  not start, treated as misconfig) — `buildDigest` is a synchronous,
+  event-loop-blocking pass (~8 InitiativeTracker scans + a full stage-journal
+  rewrite each call), fine weekly, a CPU/disk churner per-minute. A fat-finger
+  must not turn an observe-only-derived component into a per-minute load.
+- `digestTimezone?: string` — IANA tz for cron + render; default `'UTC'`.
+- `digestSendOnCalmWeeks: boolean` — default **`false`**. When false, a fully-calm
+  week is silent (`skipped-calm`); the operator opts in to a steady "all healthy"
+  heartbeat. (Decouples the analyst's `digestEvenWhenCalm` — which governs whether
+  the digest OBJECT/API renders a calm summary, fine at its `true` default — from
+  whether the publisher SENDS on a calm week. Resolves the calm-nag finding.)
+
+Dogfood path on echo: ship merged at `digestDelivery:'off'` → operator sets
+`'dry-run'` → inspect the would-send sample in `logs/growth-digest.jsonl` →
+operator sets `'live'`. Fleet stays `'off'` (and analyst itself stays dark
+fleet-wide). The live-flip is tracked as the CMT-1151 follow-through so it cannot
+silently stall at `off` (close-the-loop).
+
+### 3.5 Supersede `initiative-digest-review` (durable + atomic)
+
+When `digestDelivery === 'live'`, the unified digest is the single voice on
+initiatives (R3). Two grounded hazards (Integration NOTE + Adversarial #1):
+
+- **Durability**: disabling the job via the *deployed* `.instar/jobs/instar/`
+  manifest REGRESSES on the next instar update (built-in job templates are
+  always-overwritten — the exact analyzer-job-revert class). The durable
+  supersede is to flip `enabled: false` in the **source template**
+  `src/scaffold/templates/jobs/instar/initiative-digest-review.md` at the
+  live-flip, so it survives updates. (This ships in the SAME PR that flips echo
+  live, not before — while `digestDelivery` is `off`/`dry-run` the unified digest
+  doesn't send, so the job must stay enabled until the flip.)
+- **Atomicity / two-voice race**: `initiative-digest-review` fires `0 11 * * 1,4`
+  — exactly colliding with the publisher's default Monday 11:00. To avoid both
+  speaking in the first live window, the source-template disable and the
+  `digestDelivery:'live'` flip are ONE change. **Belt (P2-clean close-the-loop):**
+  on its first `live` send the publisher checks whether `initiative-digest-review`
+  is still enabled and, if so, emits ONE signal line into its audit log +ONE
+  low-priority growth finding ("initiative-digest-review still enabled — disable
+  to avoid a double initiative voice"). A SIGNAL, never a cross-component
+  mutation (the publisher never disables another component's job itself).
+
+### 3.6 Wiring (AgentServer + multi-machine)
+
+Construct the publisher right after the analyst block (`AgentServer.ts:1324`),
+gated on the analyst + the delivery mode (telegram / Updates-topic availability is
+NOT a construction gate — it is enforced at SEND time by `postToUpdatesTopic`,
+§3.3, which returns `{ ok:false, reason:'no-updates-topic' }`; this lets the
+publisher boot before the Updates topic is provisioned and simply skip-send until
+it exists, and gives the construction-gate wiring test a concrete predicate —
+`analyst && digestDelivery !== 'off'`):
+
+```
+const digestDelivery = options.config.monitoring?.growthAnalyst?.digestDelivery ?? 'off';
+if (this.growthMilestoneAnalyst && digestDelivery !== 'off') {
+  this.growthDigestPublisher = new GrowthDigestPublisher({
+    buildDigest: (now) => this.growthMilestoneAnalyst!.buildDigest(now),
+    cron: ...digestCron, timezone: ...digestTimezone,
+    mode: digestDelivery, sendOnCalmWeeks: ...digestSendOnCalmWeeks,
+    // GROUNDED API: MultiMachineCoordinator.isAwake is a GETTER (not a method),
+    // and the coordinator is `options.coordinator` (not `this.coordinator`). The
+    // single-machine no-op keys on `.enabled` exactly like the server.ts
+    // precedents (server.ts:3801, 5730 use `coordinator.enabled && ... isAwake`).
+    isAwake: () => options.coordinator?.enabled ? options.coordinator.isAwake : true,  // §3.7
+    audit: appendGrowthDigestAudit, onError: console.warn, ...
+  });
+  this.growthDigestPublisher.start();  // sender attached at route registration
+}
+```
+Own try/catch (an init failure here can never cascade). `.stop()` in
+`AgentServer.stop()`.
+
+### 3.7 Multi-machine: lease-gated delivery (SERIOUS — was missing in draft)
+
+`AgentServer` (and its in-process monitors) is constructed on BOTH the awake and
+the standby machine of a pairing (`server.ts` — construction is not gated by
+`coordinator.isAwake`). The §4 "one message per cadence" guarantee holds
+PER-PROCESS, not PER-AGENT — so two machines' croner tasks would each fire the
+weekly digest → the operator gets it twice (the ~15-min dedup window catches an
+exactly-simultaneous duplicate but NOT two sends minutes apart, and is
+bypassable). The job this supersedes is immune because the SCHEDULER is
+lease-gated (`server.ts:3801`). Moving the work into an in-process cron silently
+drops that safety unless we re-add it.
+
+Fix (precedent: ActivitySentinel `server.ts:5729-5730` — "Only the awake machine
+scans … so standby machines don't double-digest"): the publisher's `publishOnce`
+short-circuits with a `skipped-standby` audit entry when the injected `isAwake()`
+returns false. GROUNDED API: `MultiMachineCoordinator.isAwake` is a **getter**
+(`get isAwake(): boolean`, `MultiMachineCoordinator.ts:160`), NOT a method — so
+the injected thunk is `() => options.coordinator?.enabled ? options.coordinator.isAwake
+: true` (single-machine no-op keys on `.enabled`, matching the `server.ts`
+precedents). The catch-up path (§3.1) is gated the same way. Asserted by a
+wiring-integrity test: a standby coordinator yields ZERO `send` calls.
+
+**Residual handoff edge (bounded, deliberate safe direction).** The audit log
+that records "this window was published" is per-machine (`logs/growth-digest.jsonl`).
+If a lease handoff falls between a window's fire time and the newly-awake
+machine's next `.start()`/catch-up, the new machine — with no local record of the
+old machine's send — can re-send that ONE window once. This is bounded (a single
+re-send, not a flood), absorbed by the shared `evaluateOutbound` dedup for a
+near-simultaneous case, and is the deliberately-chosen direction (the slice's
+whole point is "the check-in arrives" over "silently dropped"). Accepted, not
+fixed, by design.
+
+## 4. Anti-flood + anti-noise guarantees (non-negotiable)
+
+1. **One message per cadence period, per AGENT** — single `publishOnce` → at most
+   one send, AND only the lease-holding machine sends (§3.7).
+2. **Object-level aggregation** — analyst collapses N into one digest.
+3. **Render-level aggregation** — `formatDigest` caps low/normal per-rule with
+   overflow lines (205 stalling → ~5 lines + "+200 more"); high-priority findings
+   are rendered in full, never truncated.
+4. **Single guarded funnel** — every send goes through the shared res-free
+   `evaluateOutbound` (dedup + per-source budget + tone) via `postToUpdatesTopic`;
+   the publisher has no second send path. Source label `growth-digest-publisher`.
+5. **No per-element topics** — ONE message into the existing Updates topic; never
+   a topic per finding. (Bounded Notification Surface ceiling never engages, but
+   the burst-invariant CI test still asserts it.)
+6. **No no-action noise** — a fully-calm week is silent by default
+   (`digestSendOnCalmWeeks:false`); the operator opts into heartbeats.
+7. **Off by default** — merging the code sends nothing; delivery is opt-in with a
+   tracked live-flip so it can't silently stall dark.
+
+## 5. Test plan (3-tier + burst invariant — Testing Integrity Standard)
+
+- **Unit** (`tests/unit/GrowthDigestPublisher.test.ts`):
+  - `publishOnce` matrix over `isAwake × mode × calm × sendOnCalmWeeks ×
+    send-ok/blocked` → correct action + audit entry on BOTH sides of every branch.
+  - `isAwake:false` (standby) → ZERO `send` calls, `skipped-standby` audit.
+  - `mode:'off'`/`'dry-run'`/calm-suppressed NEVER call `send` (spy = 0);
+    `'live'` + non-calm calls it exactly once.
+  - In-flight guard: a slow `publishOnce` re-entered → `skipped-overlap`.
+  - Missed-run catch-up: with a past-due window and no prior audit entry, `.start()`
+    fires exactly one `catchup` publish; a second `.start()` (restart loop) does
+    NOT re-fire the same window.
+  - Cadence sanity-floor: a sub-hourly `digestCron` → publisher refuses to start.
+  - `formatDigest` purity: calm, single-rule, all-six-rules; priority-never-
+    truncate (one `high` finding survives among 500 `low`); scrubSecrets applied
+    to a `detail` carrying a token shape; overflow (K+1, 500 → capped + "+N more",
+    whole message ≤4096); timezone-rendered header date.
+- **Integration** (`tests/integration/growth-digest-publisher.test.ts`):
+  - Real HTTP pipeline: `digestDelivery:'live'` + Updates topic + seeded finding
+    → exactly one `sendToTopic(updatesTopicId, …)` + `sent` audit; NO Updates
+    topic → `send-blocked reason:'no-updates-topic'`, nothing sent.
+  - `digestDelivery:'dry-run'` → `dry-run` audit carrying `wouldSend`, `sendToTopic`
+    never called.
+  - Refactored `POST /telegram/post-update` behaves identically — assert the
+    400 (no topic) / 422 (tone/localhost) / dedup branches, not just 200/!200.
+- **Wiring-integrity** (`tests/integration/growth-digest-publisher-wiring.test.ts`):
+  - The publisher path and the route path invoke the IDENTICAL `evaluateOutbound`
+    (a dedup-duplicate is actually suppressed for the publisher; a missing Updates
+    topic actually blocks) — deps are not no-ops.
+  - Standby coordinator → publisher makes zero sends.
+  - Construction gate: analyst-null OR `digestDelivery:'off'` → publisher null,
+    no cron task.
+- **E2E** (`tests/e2e/growth-digest-publisher-lifecycle.test.ts`):
+  - Production init path: dev-agent config + `digestDelivery:'live'` + Updates
+    topic + a seeded past-window proved feature → exactly one growth check-in lands
+    in the Updates topic end-to-end; `digestDelivery:'off'` → nothing sent, no
+    cron task.
+- **Burst invariant** (extend `tests/integration/notification-flood-burst-invariant.test.ts`):
+  - 500 findings → exactly ONE message, ≤4096 chars, zero per-finding topics, and
+    any `high`-priority finding present is NOT truncated.
+
+## 6. Migration parity (Migration Parity Standard)
+
+- **Config defaults**: add `digestDelivery:'off'`, `digestTimezone` (optional),
+  `digestSendOnCalmWeeks:false` to the `growthAnalyst` defaults in `ConfigDefaults`
+  AND the `growthAnalyst` type in `types.ts:4234-4264`. `applyDefaults`
+  add-missing-only deep-merge backfills existing agents on update (verified:
+  `PostUpdateMigrator.migrateConfig` → `applyDefaults`/`deepMerge`) — no separate
+  `migrateConfig` block, matching the rest of the block. `digestCron` default
+  already present.
+- **CLAUDE.md template** (`generateClaudeMd`): when this goes LIVE (not at merge),
+  add a one-liner that the agent sends a (default-weekly, calm-suppressed) growth
+  check-in to the Updates topic + the `digestDelivery`/`digestSendOnCalmWeeks`
+  knobs + `GET /growth/digest` for on-demand. Add a `migrateClaudeMd`
+  content-sniff so existing agents gain the awareness. (A dark/off-by-default
+  merge needs no live-agent awareness migration; it rides the live-flip, parent
+  §9.)
+- **Supersede**: at the live-flip, `enabled:false` in the SOURCE template
+  `initiative-digest-review.md` (durable across updates — §3.5). No NEW job
+  template (cadence is in-process, consuming the existing `digestCron`).
+
+## 7. Rollout
+
+`off` (merge — sends nothing) → `dry-run` on echo (would-send sample to
+`logs/growth-digest.jsonl`; operator reviews the real text) → `live` on echo
+(single weekly voice; `initiative-digest-review` disabled in source template) →
+`default-on` for the fleet only after it proves itself AND the analyst itself is
+flipped live fleet-wide (a separate, later decision). Dogfood on echo first — the
+feature honors the very maturity path it reports on. The live-flip is the CMT-1151
+follow-through (tracked, so the `off` rung can't become a silent-forever dark
+ship — the parent feature's own origin bug).
+
+## 8. Open questions (resolved in this revision unless noted)
+
+1. **Sender wiring layering** — RESOLVED: extract pure `evaluateOutbound` +
+   `postToUpdatesTopic` helper; attach the sender from route registration so the
+   publisher stays in `src/monitoring/` (§3.3).
+2. **Supersede vs co-run `initiative-digest-review`** — RESOLVED: supersede via
+   source-template disable at the live-flip + a one-time signal if still enabled
+   (§3.5). Auto-disable from code rejected (surprising cross-component mutation).
+3. **Per-rule cap K + priority** — RESOLVED: K=5 for low/normal bulk; high-priority
+   (R1/R6/`priority:high`) NEVER truncated (§3.2).
+4. **Cadence + calm cadence** — default weekly Mon 11:00, calm weeks silent
+   (`digestSendOnCalmWeeks:false`). OPEN for operator: confirm weekly is the right
+   active rhythm, and whether a periodic calm heartbeat (e.g. monthly) is wanted
+   despite the default-silent stance.
+5. **Timezone default** — `'UTC'` unless `digestTimezone` set; the rendered date
+   uses the same zone. OPEN for operator: set `digestTimezone` to their local zone
+   so "Monday 11:00" is local.

--- a/docs/specs/reports/proactive-growth-digest-publisher-slice2-convergence.md
+++ b/docs/specs/reports/proactive-growth-digest-publisher-slice2-convergence.md
@@ -1,0 +1,137 @@
+# Convergence Report — Proactive Growth Digest Publisher (Slice 2)
+
+Spec: `docs/specs/PROACTIVE-GROWTH-DIGEST-PUBLISHER-SLICE2-SPEC.md`
+Converged at iteration **3**. Panel: security, scalability, adversarial,
+integration, lessons-aware (internal Claude subagents) + gemini (external
+cross-model). Origin commitment: CMT-1151.
+
+## ELI10 Overview
+
+Echo already has a "growth analyst" that quietly watches your projects — what's
+stalling, what dark feature has earned its way to "turn it on," how often you
+change a spec the same way, how often you correct Echo. It computes all that, but
+it never *tells* you anything. This change builds the part that speaks: a small
+component that, on a schedule (default Monday 11am), takes the analyst's
+already-computed picture, writes ONE short "growth check-in," and posts it to your
+Agent Updates topic on Telegram. No new watching — just a voice for the analysis
+that's already running.
+
+It's careful about noise. On a quiet week with nothing to act on, it stays silent
+by default (you killed the burn alerts for being noisy; a weekly "all healthy"
+would be the same mistake). The big lists (you have 205 stalling initiatives today)
+get summarized to the top few with a "+200 more," while the important items
+(promote-this, a misconfigured dark feature) are always shown in full. And it can
+never block or rewrite anything — it only sends a message or stays quiet.
+
+It ships **off**, then goes to **dry-run on Echo only** (it logs the exact message
+it *would* send so you can read a real sample without being buzzed), then **live**
+after you approve the sample. The fleet stays off. The feature follows the same
+maturity path it reports on.
+
+## Original vs Converged
+
+The first draft had the right shape but three real gaps that the review caught:
+
+1. **It would have double-sent on your two-machine setup.** The job it replaces ran
+   only on the "awake" machine; an in-process timer runs on *both*. Converged: the
+   publisher only sends from the machine holding the lease (`isAwake` gate),
+   mirroring the precedent already used by the scheduler and ActivitySentinel.
+
+2. **It could have quietly grown a second, unguarded send path.** The "is this
+   message OK to send" guard (dedup + spam-budget + tone) was tangled into the web
+   handler. The draft hand-waved "just reuse it." Converged: we carve out a pure
+   `evaluateOutbound` function that both the web route and the publisher call, with
+   a test that asserts they call the *identical* function — one chokepoint, not two.
+
+3. **A weekly "all healthy" message would re-create the noise you rejected.**
+   Converged: quiet weeks are silent by default; you opt into a heartbeat if you
+   ever want one. The analyst still computes everything; only the *no-action send*
+   is suppressed.
+
+Plus hardening: cron re-entrancy/overlap protection, a sanity-floor that refuses a
+misconfigured sub-hourly cadence (the digest is a heavy synchronous pass),
+catch-up after the laptop was asleep at fire time (so the check-in isn't silently
+skipped for a week), timezone correctness, a render-boundary secret-scrub for the
+push channel, never-truncate-critical findings, and a durable supersede of the old
+initiative-digest job (flip it off in the *source template*, not the deployed copy
+that an update would overwrite). A final mechanical fix corrected a wrong
+coordinator API name in the wiring snippet (a getter, not a method), caught by the
+integration reviewer reading the real code.
+
+## Iteration Summary
+
+| Iteration | Reviewers who flagged material issues | Material findings | Spec changes |
+|-----------|----------------------------------------|-------------------|--------------|
+| 1 | integration (SERIOUS), security, scalability, adversarial, lessons-aware, gemini | 1 serious + ~11 minor/medium (high consensus on 3) | Added §3.7 multi-machine lease gate; §3.3 pure res-free `evaluateOutbound` funnel; §3.4 `digestSendOnCalmWeeks:false`; cron `protect`/`unref` + in-flight guard; cadence sanity-floor; missed-run catch-up; timezone; render-scrub + ≤200-char cap + priority-never-truncate; durable+atomic supersede; types.ts/teardown |
+| 2 | integration (1 material: wrong coordinator API) | 1 material + 3 non-blocking notes | Corrected `isAwake` getter + `options.coordinator` + `.enabled` gate; concrete construction predicate; observer-placement note; 60s settle-delay + post-lease window-key; §3.7 bounded-handoff-resend note |
+| 3 | (converged) | 0 | none |
+
+## Full Findings Catalog
+
+### Iteration 1
+
+**SERIOUS — Integration: multi-machine double-send.** In-process croner runs on
+awake AND standby machines; the superseded job was scheduler-lease-gated
+(`server.ts:3801`). → §3.7 lease gate (`isAwake` dep, `skipped-standby` audit),
+precedent ActivitySentinel `server.ts:5730`; wiring test asserts standby → zero
+sends.
+
+**Medium/consensus — Security #2 / Integration / Lessons F2: `checkOutboundMessage`
+is `res`-coupled.** The funnel extraction must split a pure `evaluateOutbound →
+{ok,reason}` from the response-writing or the publisher grows a second un-guarded
+send path. → §3.3 rewritten with the pure-funnel contract + wiring-integrity test
+(identical `evaluateOutbound`, not two copies).
+
+**Medium/consensus — Adversarial #2 / Lessons F1: calm-week weekly nag.** Default
+`digestEvenWhenCalm:true` → a no-action "all healthy" every week = the noise
+burnDetection was killed for. → §3.4 `digestSendOnCalmWeeks:false` (delivery-level,
+decoupled from the analyst's API-level calm render); §3.1 `skipped-calm`; §4.6.
+
+**Scalability S1 — cron re-entrancy.** → `new Cron(cron, {protect:true,unref:true},
+…)` + in-flight guard (`skipped-overlap`).
+**Scalability S2 — buildDigest is sync/heavy (~8 tracker scans + journal rewrite);
+misconfigured per-minute cadence churns disk/CPU.** → §3.4 cadence sanity-floor
+(refuse <1h between fires).
+**Scalability S3 / Gemini — missed-run after sleep silently dropped.** → §3.1
+catch-up on `.start()` via `previousRun()`, idempotent window-key.
+**Scalability S4 / Gemini #1 — timezone unspecified.** → `digestTimezone` dep,
+same zone for cron fire + render.
+**Security #1 — push channel needs its own scrub.** → §3.2 `scrubSecrets()` at
+render boundary + hard ≤200-char detail cap (covers dry-run text).
+**Security #3 — cap-before-concat.** → §3.2 stops appending near 4096, never
+materializes the full string.
+**Gemini #2 / parent §10 Q3 — critical findings hidden by cap.** → §3.2 priority-
+never-truncate (R1/R6/high always full; cap only low/normal bulk).
+**Integration NOTE / Lessons F3 — supersede durability + atomicity.** Deployed-
+manifest disable reverts on update; the job collides Mon 11:00. → §3.5 disable in
+SOURCE template + atomic with live-flip + one-time signal if still enabled.
+**Integration — add `digestDelivery` to types.ts; teardown `.stop()`.** → §3.4/§3.6.
+
+### Iteration 2
+
+**Material — Integration: wrong coordinator API in wiring snippet.**
+`coordinator.isAwake()` called as a method (it's a getter `get isAwake()`) and via
+`this.coordinator` (it's `options.coordinator`). Would not compile. → §3.6/§3.7
+corrected to `isAwake: () => options.coordinator?.enabled ? options.coordinator.isAwake
+: true`, matching `server.ts` precedents; construction gate made concrete
+(`analyst && digestDelivery !== 'off'`, telegram availability at send-time).
+
+Non-blocking notes folded in: observer placement (`observeSelfViolation`/
+`observePrincipalCoherence` stay route-side — §3.3); concrete 60s settle-delay +
+window-key only post-lease (§3.1); §3.7 bounded-handoff-resend disclosure.
+
+### Iteration 3
+
+All five internal reviewers + gemini: **CONVERGED.** Integration verified the
+coordinator API fix against real code (`MultiMachineCoordinator.ts:160` getter,
+`server.ts` getter-style callsites). Lessons-aware confirmed the bounded-handoff-
+resend tradeoff is defensible against the anti-flood lessons (single bounded
+re-send through the aggregating/budgeted/deduped funnel, biased toward the slice's
+reason to exist — delivery over silence). No material findings.
+
+## Convergence verdict
+
+**Converged at iteration 3. No material findings in the final round.** The spec is
+ready for operator review and approval. Approval (`approved: true`) is the
+operator's structural step; this report and the `review-convergence` tag are
+written by /spec-converge.

--- a/src/config/ConfigDefaults.ts
+++ b/src/config/ConfigDefaults.ts
@@ -298,6 +298,13 @@ const SHARED_DEFAULTS: Record<string, unknown> = {
     // Spec: docs/specs/PROACTIVE-GROWTH-MILESTONE-ANALYST-SPEC.md
     growthAnalyst: {
       digestCron: '0 11 * * 1',
+      // Slice 2 (GrowthDigestPublisher) ships dark even on a dev agent: COMPUTE +
+      // EXPOSE is already live, but the new SEND behavior stays opt-in until the
+      // operator advances it, so merging the code buzzes no one.
+      digestDelivery: 'off',
+      // A fully-calm week is silent by default (no "all healthy" heartbeat — the
+      // exact noise burnDetection was killed for).
+      digestSendOnCalmWeeks: false,
       incubationWindows: { lowRisk: 3, standard: 7, highRisk: 7 },
       proofOfLifeMinActivations: 1,
       rules: {

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -4236,6 +4236,19 @@ export interface MonitoringConfig {
     enabled?: boolean;
     /** Cron for the weekly digest (later slice; default '0 11 * * 1'). */
     digestCron?: string;
+    /** Slice 2 (GrowthDigestPublisher) delivery stage: 'off' (default — merging
+     *  the code sends nothing), 'dry-run' (log the would-send sample to
+     *  logs/growth-digest.jsonl, no Telegram), 'live' (send one weekly check-in to
+     *  the Agent Updates topic). Honors dark → dry-run → live maturity. */
+    digestDelivery?: 'off' | 'dry-run' | 'live';
+    /** IANA timezone for the digest cron fire AND the rendered header date
+     *  (default 'UTC') so "Monday 11:00" and the printed date agree. */
+    digestTimezone?: string;
+    /** Send the weekly digest on a fully-calm week (default false — a no-action
+     *  "all healthy" heartbeat is the exact noise burnDetection was killed for;
+     *  opt in for a steady heartbeat). Decoupled from `digestEvenWhenCalm`, which
+     *  only governs whether the digest OBJECT/API renders a calm summary. */
+    digestSendOnCalmWeeks?: boolean;
     /** Incubation windows in DAYS per risk tier (defaults 3 / 7 / 7). */
     incubationWindows?: {
       lowRisk?: number;

--- a/src/monitoring/GrowthDigestPublisher.ts
+++ b/src/monitoring/GrowthDigestPublisher.ts
@@ -1,0 +1,574 @@
+/**
+ * GrowthDigestPublisher — Slice 2 of the proactive growth analyst.
+ *
+ * WHY THIS EXISTS (Justin, 2026-06-06, topic 21624): "I have YET to have an agent
+ * proactively check in with me about ANY of these." Slice 1
+ * (GrowthMilestoneAnalyst) already COMPUTES the growth picture (R1–R6) and exposes
+ * it via read routes — but nothing ever SENDS it. This component is the voice:
+ * on a cadence it takes the analyst's already-computed `GrowthDigest`, decides
+ * whether there is anything worth saying, formats ONE consolidated "growth
+ * check-in," and routes it through the SAME flood-guarded post-update funnel the
+ * `/telegram/post-update` route uses.
+ *
+ * It owns NO analysis. It is a cadence + lease-check + decide-to-speak + format +
+ * deliver + audit wrapper. It can never block, delay, or rewrite anything — it
+ * only sends a message or stays quiet. Spec:
+ * docs/specs/PROACTIVE-GROWTH-DIGEST-PUBLISHER-SLICE2-SPEC.md.
+ *
+ * Hardened by the Slice-2 convergence review (§9):
+ *  - MULTI-MACHINE: an in-process croner runs on BOTH the awake and the standby
+ *    machine, so the digest would double-send. The publisher is lease-gated
+ *    (`isAwake`) — only the awake machine sends (mirrors the scheduler /
+ *    ActivitySentinel precedent the superseded job relied on).
+ *  - SINGLE FUNNEL: the `send` dep is the shared res-free `evaluateOutbound` path
+ *    (`postToUpdatesTopic`), never a raw `sendToTopic` — one guarded chokepoint,
+ *    not two.
+ *  - NO CALM NOISE: a fully-calm week is silent by default
+ *    (`sendOnCalmWeeks:false`) — a weekly "all healthy" is the exact noise the
+ *    operator killed burnDetection for.
+ *  - MISSED-RUN CATCH-UP: croner schedules only the next fire; a fire that elapsed
+ *    while the box was asleep is replayed once on `.start()` (the proactive
+ *    check-in must not be silently dropped for a week). Idempotent on the window
+ *    ISO so a restart loop can't re-fire the same window.
+ */
+
+import { Cron } from 'croner';
+import fs from 'node:fs';
+import path from 'node:path';
+import { scrubSecrets } from './scrubSecrets.js';
+import type { GrowthDigest, GrowthFinding, GrowthRuleId } from './GrowthMilestoneAnalyst.js';
+
+export type GrowthDigestDelivery = 'off' | 'dry-run' | 'live';
+
+export type GrowthDigestTrigger = 'cron' | 'catchup' | 'manual';
+
+export interface DeliveryResult {
+  ok: boolean;
+  /** Why a non-send happened (dedup/budget/tone block, no-updates-topic, …). A
+   *  block is a NORMAL outcome, never an error — the publisher never re-acts. */
+  reason?: string;
+}
+
+export interface GrowthDigestAuditEntry {
+  ts: string;
+  action:
+    | 'sent'
+    | 'send-blocked'
+    | 'dry-run'
+    | 'skipped-standby'
+    | 'skipped-off'
+    | 'skipped-overlap'
+    | 'skipped-calm'
+    | 'error';
+  trigger?: GrowthDigestTrigger;
+  /** ISO of the scheduled window this cycle belongs to. The idempotency key for
+   *  catch-up: recorded ONLY on a real post-lease decision (never on a pre-lease
+   *  `skipped-standby`), so the awake machine still owns an un-consumed window. */
+  window?: string;
+  reason?: string;
+  counts?: GrowthDigest['counts'];
+  /** For `dry-run`: the EXACT message that WOULD have been sent (how the operator
+   *  inspects a real sample before going live). */
+  wouldSend?: string;
+  /** §3.5 belt: on a live send while `initiative-digest-review` is still enabled,
+   *  a SIGNAL (never a cross-component mutation) that the old voice should be
+   *  disabled to avoid two voices on the same initiatives. */
+  supersedeConflict?: boolean;
+}
+
+/** Refuse a cadence whose two soonest fires are < 1h apart — `buildDigest` is a
+ *  synchronous, event-loop-blocking pass; a fat-fingered per-minute cron must not
+ *  turn an observe-only-derived component into a CPU/disk churner (Scalability S2). */
+const SANITY_FLOOR_MS = 60 * 60 * 1000;
+const DEFAULT_SETTLE_MS = 60 * 1000;
+const DEFAULT_PER_RULE_CAP = 5;
+const DEFAULT_DETAIL_CAP = 200;
+const TELEGRAM_MAX = 4096;
+
+export interface GrowthDigestPublisherDeps {
+  /** Bound to the live analyst (`(now) => analyst.buildDigest(now)`). */
+  buildDigest: (now: Date) => GrowthDigest;
+  /** `monitoring.growthAnalyst.digestCron` (default '0 11 * * 1'). */
+  cron: string;
+  /** Rollout stage. The publisher is only constructed when mode !== 'off'. */
+  mode: GrowthDigestDelivery;
+  /** IANA tz for BOTH the cron fire and the rendered header date (default UTC). */
+  timezone?: string;
+  /** Send on a fully-calm week? Default false (no "all healthy" heartbeat). */
+  sendOnCalmWeeks?: boolean;
+  /** The SINGLE guarded funnel to the Updates topic. Attached at route
+   *  registration via `attachSender` (where `ctx`/the route helper lives). */
+  send?: (text: string) => Promise<DeliveryResult>;
+  /** Multi-machine lease gate — only the awake machine sends. Default no-op. */
+  isAwake?: () => boolean;
+  /** Append-one-JSON-line audit sink (default → logs/growth-digest.jsonl). */
+  audit?: (entry: GrowthDigestAuditEntry) => void;
+  /** The set of window ISOs already decided (for catch-up idempotency). */
+  recordedWindows?: () => Set<string>;
+  /** §3.5 belt: is the superseded `initiative-digest-review` job still enabled? */
+  supersededJobStillEnabled?: () => boolean;
+  now?: () => Date;
+  onError?: (where: string, err: unknown) => void;
+  /** Settle delay before the missed-run catch-up (default 60s — long enough for
+   *  the multi-machine lease to settle so a freshly-booted machine that acquires
+   *  the lease isn't wrongly skipped). */
+  settleMs?: number;
+  /** Formatter: low/normal bulk cap per rule (default 5). */
+  perRuleCap?: number;
+  /** Formatter: per-detail char cap (default 200). */
+  detailCap?: number;
+}
+
+export class GrowthDigestPublisher {
+  private readonly deps: GrowthDigestPublisherDeps;
+  private readonly cron: string;
+  private readonly mode: GrowthDigestDelivery;
+  private readonly timezone?: string;
+  private readonly sendOnCalmWeeks: boolean;
+  private readonly settleMs: number;
+  private readonly perRuleCap: number;
+  private readonly detailCap: number;
+
+  private sender?: (text: string) => Promise<DeliveryResult>;
+  private cronTask: Cron | null = null;
+  private settleTimer: ReturnType<typeof setTimeout> | null = null;
+  private running = false;
+
+  constructor(deps: GrowthDigestPublisherDeps) {
+    this.deps = deps;
+    this.cron = deps.cron;
+    this.mode = deps.mode;
+    this.timezone = deps.timezone;
+    this.sendOnCalmWeeks = deps.sendOnCalmWeeks === true;
+    this.sender = deps.send;
+    this.settleMs = deps.settleMs ?? DEFAULT_SETTLE_MS;
+    this.perRuleCap = deps.perRuleCap ?? DEFAULT_PER_RULE_CAP;
+    this.detailCap = deps.detailCap ?? DEFAULT_DETAIL_CAP;
+  }
+
+  private nowFn(): Date {
+    return this.deps.now ? this.deps.now() : new Date();
+  }
+
+  /** Attach the guarded sender after construction (route-registration time). */
+  attachSender(send: (text: string) => Promise<DeliveryResult>): void {
+    this.sender = send;
+  }
+
+  /** True once the cron task is scheduled (false if refused by the sanity-floor
+   *  or an invalid cron). Used by wiring tests. */
+  isStarted(): boolean {
+    return this.cronTask !== null;
+  }
+
+  /**
+   * Schedule the cadence + arm the missed-run catch-up. Idempotent. Refuses a
+   * sub-hourly cadence (sanity-floor) and an invalid cron (both logged via
+   * onError; the publisher simply does not start, which is the safe direction —
+   * an observe-only-derived component never crashes the server).
+   */
+  start(): void {
+    if (this.cronTask) return;
+    if (!this.cadenceWithinFloor()) {
+      this.deps.onError?.(
+        'start',
+        new Error(`digestCron '${this.cron}' fires more often than the 1h sanity-floor — refusing to start`),
+      );
+      return;
+    }
+    try {
+      this.cronTask = new Cron(
+        this.cron,
+        { timezone: this.timezone, protect: true, unref: true },
+        () => {
+          void this.publishOnce(this.nowFn(), 'cron');
+        },
+      );
+    } catch (err) {
+      this.deps.onError?.('cron-construct', err);
+      this.cronTask = null;
+      return;
+    }
+    // Missed-run catch-up after the settle delay (so the lease has time to settle).
+    this.settleTimer = setTimeout(() => {
+      void this.catchUp();
+    }, this.settleMs);
+    if (typeof this.settleTimer.unref === 'function') this.settleTimer.unref();
+  }
+
+  /** Stop the cron + cancel a pending catch-up. Idempotent. */
+  stop(): void {
+    try {
+      this.cronTask?.stop();
+    } catch {
+      /* @silent-fallback-ok — teardown is best-effort at shutdown */
+    }
+    this.cronTask = null;
+    if (this.settleTimer) {
+      try {
+        clearTimeout(this.settleTimer);
+      } catch {
+        /* @silent-fallback-ok — teardown is best-effort at shutdown */
+      }
+      this.settleTimer = null;
+    }
+  }
+
+  /** Replay a single fire time that elapsed while the box was down/asleep. */
+  private async catchUp(): Promise<void> {
+    const now = this.nowFn();
+    const missed = this.previousScheduledFire(now);
+    if (!missed) return;
+    const key = missed.toISOString();
+    let recorded: Set<string>;
+    try {
+      recorded = this.deps.recordedWindows ? this.deps.recordedWindows() : new Set<string>();
+    } catch (err) {
+      this.deps.onError?.('recordedWindows', err);
+      recorded = new Set<string>();
+    }
+    if (recorded.has(key)) return; // this window was already published/decided
+    await this.publishOnce(now, 'catchup', key);
+  }
+
+  /**
+   * Run ONE cadence cycle. PUBLIC so tests (and a future debug route) can drive a
+   * cycle deterministically. Never throws — an observe-only-derived component must
+   * never crash the server, so every branch is wrapped and audited.
+   */
+  async publishOnce(now: Date, trigger: GrowthDigestTrigger, windowKey?: string): Promise<void> {
+    // 1. Lease gate (pre-lease check — a standby machine never sends and never
+    //    consumes the window; the awake machine still owns it).
+    let awake = true;
+    try {
+      awake = this.deps.isAwake ? this.deps.isAwake() : true;
+    } catch (err) {
+      this.deps.onError?.('isAwake', err);
+      awake = true; // fail-open toward delivery (the slice's reason to exist)
+    }
+    if (!awake) {
+      this.record({ action: 'skipped-standby', trigger });
+      return;
+    }
+
+    // Window key for idempotency (the scheduled fire this cycle covers).
+    let window = windowKey;
+    if (window === undefined) {
+      window = this.previousScheduledFire(now)?.toISOString();
+    }
+
+    // 2. Mode off (belt — the publisher is only constructed when mode !== 'off').
+    if (this.mode === 'off') {
+      this.record({ action: 'skipped-off', trigger, window });
+      return;
+    }
+
+    // 3. In-flight guard (belt-and-suspenders with croner protect:true, because
+    //    publishOnce is also publicly callable).
+    if (this.running) {
+      this.record({ action: 'skipped-overlap', trigger, window });
+      return;
+    }
+    this.running = true;
+    try {
+      // 4. Build the digest (heavy synchronous pass).
+      let digest: GrowthDigest;
+      try {
+        digest = this.deps.buildDigest(now);
+      } catch (err) {
+        this.deps.onError?.('buildDigest', err);
+        // No window recorded → catch-up may retry next boot (safe direction).
+        this.record({ action: 'error', trigger, reason: 'build-error' });
+        return;
+      }
+
+      // 5. Decide to speak.
+      if (digest.calm && !this.sendOnCalmWeeks) {
+        this.record({ action: 'skipped-calm', trigger, window, counts: digest.counts });
+        return;
+      }
+
+      // 6. Format (scrubbed + capped + clamped).
+      let text: string;
+      try {
+        text = formatDigest(digest, {
+          timezone: this.timezone,
+          perRuleCap: this.perRuleCap,
+          detailCap: this.detailCap,
+        });
+      } catch (err) {
+        this.deps.onError?.('formatDigest', err);
+        this.record({ action: 'error', trigger, reason: 'format-error' });
+        return;
+      }
+
+      // 7. Dry-run — record the would-send sample, never send.
+      if (this.mode === 'dry-run') {
+        this.record({ action: 'dry-run', trigger, window, counts: digest.counts, wouldSend: text });
+        return;
+      }
+
+      // 8. Live — go through the shared guarded funnel.
+      let result: DeliveryResult;
+      try {
+        result = this.sender ? await this.sender(text) : { ok: false, reason: 'no-sender' };
+      } catch (err) {
+        this.deps.onError?.('send', err);
+        result = { ok: false, reason: 'send-threw' };
+      }
+      const entry: GrowthDigestAuditEntry = {
+        ts: now.toISOString(),
+        action: result.ok ? 'sent' : 'send-blocked',
+        trigger,
+        window,
+        reason: result.reason,
+        counts: digest.counts,
+      };
+      // §3.5 belt: a SIGNAL (never a mutation) that the old voice is still on.
+      if (result.ok && this.deps.supersededJobStillEnabled) {
+        try {
+          if (this.deps.supersededJobStillEnabled()) entry.supersedeConflict = true;
+        } catch (err) {
+          this.deps.onError?.('supersededJobStillEnabled', err);
+        }
+      }
+      this.record(entry);
+    } finally {
+      this.running = false;
+    }
+  }
+
+  // ── helpers ───────────────────────────────────────────────────────────────
+
+  private record(e: Partial<GrowthDigestAuditEntry> & { action: GrowthDigestAuditEntry['action'] }): void {
+    const entry: GrowthDigestAuditEntry = {
+      ts: e.ts ?? this.nowFn().toISOString(),
+      action: e.action,
+      ...(e.trigger ? { trigger: e.trigger } : {}),
+      ...(e.window ? { window: e.window } : {}),
+      ...(e.reason ? { reason: e.reason } : {}),
+      ...(e.counts ? { counts: e.counts } : {}),
+      ...(e.wouldSend ? { wouldSend: e.wouldSend } : {}),
+      ...(e.supersedeConflict ? { supersedeConflict: true } : {}),
+    };
+    try {
+      this.deps.audit?.(entry);
+    } catch (err) {
+      this.deps.onError?.('audit', err);
+    }
+  }
+
+  /** True if the cadence's two soonest fires are ≥1h apart (or not computable). */
+  private cadenceWithinFloor(): boolean {
+    try {
+      const c = new Cron(this.cron, this.timezone ? { timezone: this.timezone } : {});
+      const f1 = c.nextRun(this.nowFn());
+      if (!f1) return true;
+      const f2 = c.nextRun(f1);
+      if (!f2) return true;
+      return f2.getTime() - f1.getTime() >= SANITY_FLOOR_MS;
+    } catch {
+      // @silent-fallback-ok — an invalid cron is re-caught + logged by start()'s
+      // own `new Cron` (the authoritative report path); returning true here just
+      // defers to it. Not a degradation — the floor check is a guard, not a sink.
+      return true;
+    }
+  }
+
+  /**
+   * The most-recent scheduled fire time at/under `now`. croner's `previousRun()`
+   * only tracks the instance's own executions (null on a fresh instance), so we
+   * derive the cadence interval from two future `nextRun` probes and scan forward
+   * from a bounded lookback to find the last fire ≤ now.
+   */
+  private previousScheduledFire(now: Date): Date | null {
+    try {
+      const c = new Cron(this.cron, this.timezone ? { timezone: this.timezone } : {});
+      const f1 = c.nextRun(now);
+      if (!f1) return null;
+      const f2 = c.nextRun(f1);
+      const intervalMs = f2 ? f2.getTime() - f1.getTime() : 7 * 86_400_000;
+      const probe = new Date(now.getTime() - intervalMs * 2 - 60_000);
+      let last: Date | null = null;
+      let n = c.nextRun(probe);
+      let guard = 0;
+      while (n && n.getTime() <= now.getTime() && guard++ < 5000) {
+        last = n;
+        n = c.nextRun(n);
+      }
+      return last;
+    } catch (err) {
+      // @silent-fallback-ok — onError-surfaced; an uncomputable previous fire only
+      // skips one catch-up (the safe direction for this observe-only-derived
+      // publisher), never a wrong action. The weekly cron still fires normally.
+      this.deps.onError?.('previousScheduledFire', err);
+      return null;
+    }
+  }
+}
+
+// ── Formatter (pure, exported, NO LLM) ────────────────────────────────────────
+
+export interface FormatDigestOptions {
+  timezone?: string;
+  perRuleCap?: number;
+  detailCap?: number;
+}
+
+const RULE_ORDER: GrowthRuleId[] = ['R1', 'R6', 'R2', 'R3', 'R4', 'R5'];
+
+const RULE_HEADER: Record<GrowthRuleId, string> = {
+  R1: '🔸 Ready to promote',
+  R2: '🔸 Incubation expired (unproven)',
+  R3: '🔸 Stalling — waiting on you / drifting',
+  R4: '🔸 Spec patterns',
+  R5: '🔸 Recurring corrections',
+  R6: '🔸 Dev-gated features still dark',
+};
+
+const FOOTER = 'Read the full digest anytime: GET /growth/digest (or the dashboard).';
+
+/**
+ * Render a `GrowthDigest` into ONE compact Telegram message. The analyst already
+ * decided what crosses a rule — the formatter only renders it. Guarantees:
+ *  - Priority-never-truncate: every `priority:'high'` finding and every
+ *    decision-demanding maturity action (R1 promote, R6 dev-gate-dark) is rendered
+ *    IN FULL, never capped.
+ *  - Only the low/normal BULK is capped at `perRuleCap` per rule with a "+N more".
+ *  - Cap-before-concat: bulk sections stop appending as the running length nears
+ *    4096 — the full N-line string is never materialised then sliced.
+ *  - Render-boundary scrub: every title/detail passes through `scrubSecrets`, and
+ *    each detail is hard-capped to `detailCap` chars (covers dry-run text too).
+ */
+export function formatDigest(digest: GrowthDigest, opts: FormatDigestOptions = {}): string {
+  const perRuleCap = opts.perRuleCap ?? DEFAULT_PER_RULE_CAP;
+  const detailCap = opts.detailCap ?? DEFAULT_DETAIL_CAP;
+
+  const header = `📊 Growth check-in — ${formatHeaderDate(digest.generatedAt, opts.timezone)}`;
+  const summary = scrubSecrets(digest.summary);
+
+  // Calm digest: header + summary only (the summary already carries the changing
+  // incubating count + next-window-closes, so it is not byte-identical week/week).
+  if (digest.calm || digest.findings.length === 0) {
+    return clampToTelegram([header, '', summary].join('\n'));
+  }
+
+  // "Always full" = high-priority + decision-demanding (R1/R6). The rest is the
+  // cappable bulk (R3 stalling is the volume driver).
+  const alwaysFull = digest.findings.filter(isAlwaysFull);
+  const bulk = digest.findings.filter((f) => !isAlwaysFull(f));
+
+  const parts: string[] = [header, '', summary];
+
+  // Mandatory sections first (never capped, never dropped).
+  for (const rule of RULE_ORDER) {
+    const rows = alwaysFull.filter((f) => f.rule === rule);
+    if (rows.length === 0) continue;
+    parts.push('', RULE_HEADER[rule] + ':');
+    for (const f of rows) parts.push(renderFinding(f, detailCap));
+  }
+
+  // Bulk sections — capped per rule, and cap-before-concat against 4096.
+  const footerReserve = FOOTER.length + 8;
+  let truncatedBulk = false;
+  for (const rule of RULE_ORDER) {
+    const rows = bulk.filter((f) => f.rule === rule);
+    if (rows.length === 0) continue;
+    const sectionLines: string[] = ['', RULE_HEADER[rule] + ':'];
+    const shown = rows.slice(0, perRuleCap);
+    for (const f of shown) sectionLines.push(renderFinding(f, detailCap));
+    if (rows.length > perRuleCap) {
+      sectionLines.push(`  +${rows.length - perRuleCap} more (see full digest)`);
+    }
+    const projected = parts.join('\n').length + sectionLines.join('\n').length + 1 + footerReserve;
+    if (projected > TELEGRAM_MAX) {
+      truncatedBulk = true;
+      break;
+    }
+    parts.push(...sectionLines);
+  }
+
+  if (truncatedBulk) {
+    parts.push('', '…(more findings — full digest at /growth/digest)');
+  }
+  parts.push('', FOOTER);
+
+  return clampToTelegram(parts.join('\n'));
+}
+
+function isAlwaysFull(f: GrowthFinding): boolean {
+  return f.priority === 'high' || f.rule === 'R1' || f.rule === 'R6';
+}
+
+function renderFinding(f: GrowthFinding, detailCap: number): string {
+  const title = scrubSecrets(f.title);
+  let detail = scrubSecrets(f.detail);
+  if (detail.length > detailCap) detail = detail.slice(0, detailCap - 1) + '…';
+  return `• ${title} — ${detail}`;
+}
+
+function formatHeaderDate(iso: string, timezone?: string): string {
+  const d = new Date(iso);
+  if (!Number.isFinite(d.getTime())) return iso;
+  try {
+    return new Intl.DateTimeFormat('en-US', {
+      weekday: 'short',
+      month: 'short',
+      day: 'numeric',
+      year: 'numeric',
+      timeZone: timezone || 'UTC',
+    }).format(d);
+  } catch {
+    return d.toISOString().slice(0, 10);
+  }
+}
+
+/** Hard-clamp to Telegram's 4096 limit. Only engages if the mandatory (always-full)
+ *  set alone somehow exceeds it — bulk is already cap-before-concat'd. */
+function clampToTelegram(text: string): string {
+  if (text.length <= TELEGRAM_MAX) return text;
+  const note = '\n…(truncated — full digest at /growth/digest)';
+  return text.slice(0, TELEGRAM_MAX - note.length) + note;
+}
+
+/** Default audit sink + window-reader over logs/growth-digest.jsonl. The publisher
+ *  injects `audit` (write) and `recordedWindows` (read) from this so the same file
+ *  is the durable "did we publish this window?" record. */
+export function createGrowthDigestAuditSink(stateDir: string): {
+  write: (entry: GrowthDigestAuditEntry) => void;
+  recordedWindows: () => Set<string>;
+  logPath: string;
+} {
+  const logPath = path.join(stateDir, 'logs', 'growth-digest.jsonl');
+  return {
+    logPath,
+    write(entry: GrowthDigestAuditEntry): void {
+      try {
+        fs.mkdirSync(path.dirname(logPath), { recursive: true });
+        fs.appendFileSync(logPath, JSON.stringify(entry) + '\n');
+      } catch {
+        /* never throw from the audit sink */
+      }
+    },
+    recordedWindows(): Set<string> {
+      const out = new Set<string>();
+      let raw: string;
+      try {
+        raw = fs.readFileSync(logPath, 'utf-8');
+      } catch {
+        return out; // no log yet → no windows decided
+      }
+      for (const line of raw.split('\n')) {
+        const t = line.trim();
+        if (!t) continue;
+        try {
+          const e = JSON.parse(t) as Partial<GrowthDigestAuditEntry>;
+          if (e && typeof e.window === 'string') out.add(e.window);
+        } catch {
+          /* skip a corrupt/partial line */
+        }
+      }
+      return out;
+    },
+  };
+}

--- a/src/server/AgentServer.ts
+++ b/src/server/AgentServer.ts
@@ -64,6 +64,7 @@ import { CiFailurePoller } from '../monitoring/CiFailurePoller.js';
 import { RevertDetector } from '../monitoring/RevertDetector.js';
 import { CorrectionLedger } from '../monitoring/CorrectionLedger.js';
 import { GrowthMilestoneAnalyst, resolveGrowthSettings } from '../monitoring/GrowthMilestoneAnalyst.js';
+import { GrowthDigestPublisher, createGrowthDigestAuditSink } from '../monitoring/GrowthDigestPublisher.js';
 import { ApprenticeshipProgram } from '../core/ApprenticeshipProgram.js';
 import { ApprenticeshipCycleStore } from '../monitoring/ApprenticeshipCycleStore.js';
 import { ApprenticeshipCycleSlaMonitor } from '../monitoring/ApprenticeshipCycleSlaMonitor.js';
@@ -219,6 +220,7 @@ export class AgentServer {
   private revertDetector: RevertDetector | null = null;
   private correctionLedger: CorrectionLedger | null = null;
   private growthMilestoneAnalyst: GrowthMilestoneAnalyst | null = null;
+  private growthDigestPublisher: GrowthDigestPublisher | null = null;
   private apprenticeshipProgram: ApprenticeshipProgram | null = null;
   private apprenticeshipCycleStore: ApprenticeshipCycleStore | null = null;
   private apprenticeshipCycleSlaMonitor: ApprenticeshipCycleSlaMonitor | null = null;
@@ -1327,6 +1329,61 @@ export class AgentServer {
       this.growthMilestoneAnalyst = null;
     }
 
+    // GrowthDigestPublisher (Slice 2 — docs/specs/PROACTIVE-GROWTH-DIGEST-PUBLISHER-SLICE2-SPEC.md)
+    // — the cadence + delivery VOICE for the analyst above. Constructed ONLY when
+    // the analyst exists AND digestDelivery !== 'off' (the default 'off' means
+    // merging the code sends nothing). Lease-gated so only the awake machine sends
+    // (an in-process cron runs on BOTH the awake and standby machine — §3.7). The
+    // guarded sender (postToUpdatesTopic) is attached later at route registration,
+    // so the publisher can never reach sendToTopic without the shared
+    // evaluateOutbound funnel. Own try/catch so an init failure can never cascade.
+    const digestDelivery = options.config.monitoring?.growthAnalyst?.digestDelivery ?? 'off';
+    try {
+      if (this.growthMilestoneAnalyst && digestDelivery !== 'off' && options.config.stateDir) {
+        const analyst = this.growthMilestoneAnalyst;
+        const stateRoot = options.config.stateDir;
+        const auditSink = createGrowthDigestAuditSink(stateRoot);
+        const supersededJobPath = path.join(stateRoot, 'jobs', 'schedule', 'initiative-digest-review.json');
+        this.growthDigestPublisher = new GrowthDigestPublisher({
+          buildDigest: (now) => analyst.buildDigest(now),
+          cron: options.config.monitoring?.growthAnalyst?.digestCron ?? '0 11 * * 1',
+          timezone: options.config.monitoring?.growthAnalyst?.digestTimezone,
+          mode: digestDelivery,
+          sendOnCalmWeeks: options.config.monitoring?.growthAnalyst?.digestSendOnCalmWeeks === true,
+          // Multi-machine lease gate. MultiMachineCoordinator.isAwake is a GETTER
+          // (not a method); the single-machine no-op keys on `.enabled`, matching
+          // the server.ts scheduler / ActivitySentinel precedents.
+          isAwake: () => (options.coordinator?.enabled ? options.coordinator.isAwake : true),
+          audit: auditSink.write,
+          recordedWindows: auditSink.recordedWindows,
+          // §3.5 belt: a SIGNAL (never a mutation) on a live send while the
+          // superseded initiative-digest-review job is still enabled. The durable
+          // supersede flips the SOURCE template at the live-flip (a later change);
+          // this read is the awareness backstop. Enabled flag lives in the
+          // schedule manifest (the update-preserved one), not the .md template.
+          supersededJobStillEnabled: () => {
+            try {
+              const m = JSON.parse(fs.readFileSync(supersededJobPath, 'utf-8')) as { enabled?: boolean };
+              return m.enabled === true;
+            } catch {
+              // @silent-fallback-ok — a missing/unreadable supersede manifest is an
+              // expected state (no job installed); not-conflicting is the correct
+              // read, not a degradation. The belt is a one-time awareness signal only.
+              return false;
+            }
+          },
+          onError: (where, err) => console.warn(`[GrowthDigestPublisher] ${where}:`, err),
+        });
+        this.growthDigestPublisher.start(); // sender attached at route registration
+      }
+    } catch (err) {
+      // @silent-fallback-ok — mirrors the sibling component-init guards above; the
+      // publisher is a non-critical observe-only-derived component, so nulling it on
+      // an init failure (logged here) is the safe direction, never a degradation.
+      console.warn('[instar] growth-digest-publisher init failed (non-fatal):', err);
+      this.growthDigestPublisher = null;
+    }
+
     // Apprenticeship Program (Step 1) — the instance-as-project registry + the
     // retro-gate (pending→active) and doc-as-required-artifact gate
     // (active→complete). Ships ON (additive, passive registry; no config flag —
@@ -1647,6 +1704,7 @@ export class AgentServer {
       failureAttributionEngine: this.failureAttributionEngine,
       correctionLedger: this.correctionLedger,
       growthMilestoneAnalyst: this.growthMilestoneAnalyst,
+      growthDigestPublisher: this.growthDigestPublisher,
       apprenticeshipProgram: this.apprenticeshipProgram,
       apprenticeshipCycleStore: this.apprenticeshipCycleStore,
       apprenticeshipCycleSlaMonitor: this.apprenticeshipCycleSlaMonitor,
@@ -3175,6 +3233,11 @@ export class AgentServer {
     if (this.parallelWorkSentinelTimer) {
       try { clearInterval(this.parallelWorkSentinelTimer); } catch { /* best-effort */ }
       this.parallelWorkSentinelTimer = null;
+    }
+    // Stop the growth-digest publisher's cron + pending catch-up timer.
+    if (this.growthDigestPublisher) {
+      try { this.growthDigestPublisher.stop(); } catch { /* @silent-fallback-ok — best-effort teardown at shutdown */ }
+      this.growthDigestPublisher = null;
     }
     this.parallelWorkSentinel = null;
     if (this.resourceLedger) {

--- a/src/server/routes.ts
+++ b/src/server/routes.ts
@@ -805,6 +805,11 @@ export interface RouteContext {
    *  /growth/* 503s. Powers GET /growth/digest, GET /growth/findings,
    *  GET /growth/status, POST /growth/tick. */
   growthMilestoneAnalyst?: import('../monitoring/GrowthMilestoneAnalyst.js').GrowthMilestoneAnalyst | null;
+  /** Slice-2 proactive growth-digest publisher (cadence + delivery). Null/absent
+   *  when digestDelivery is 'off' or the analyst is unwired. The route layer
+   *  attaches its guarded sender (`postToUpdatesTopic`) via `attachSender` at
+   *  registration so the publisher shares the single `evaluateOutbound` funnel. */
+  growthDigestPublisher?: import('../monitoring/GrowthDigestPublisher.js').GrowthDigestPublisher | null;
   /** Apprenticeship Program registry + lifecycle gates (Apprenticeship Step 1).
    *  Null when stateDir is unavailable → /apprenticeship/* 503s. Powers the
    *  instance-as-project registry, the retro-gate (pending→active) and the
@@ -1278,10 +1283,24 @@ export function createRoutes(ctx: RouteContext): Router {
    *
    * Returns true if blocked (response already sent as 422). False if safe.
    */
-  async function checkOutboundMessage(
+  /**
+   * Outbound-message DECISION — the pure, res-free chokepoint. Both the route
+   * adapter (`checkOutboundMessage`) and the proactive publisher
+   * (`postToUpdatesTopic`) call THIS identical function, so there is provably ONE
+   * guarded path, not two (Slice-2 spec §3.3 — the Structure-beats-Willpower fix
+   * against a second un-guarded send path). It performs the localhost-link guard +
+   * the tone-gate review and RETURNS a decision; it never writes a response and
+   * never fires the observe-only observers. The observers (operator-role /
+   * principal coherence) have nothing to catch on the proactive-digest path, so
+   * they stay route-side in `checkOutboundMessage` — byte-identical for callers.
+   */
+  type OutboundEvaluation =
+    | { ok: true }
+    | { ok: false; status: number; reason: string; body: Record<string, unknown> };
+
+  async function evaluateOutbound(
     text: string,
     channel: string,
-    res: import('express').Response,
     options: {
       topicId?: number;
       allowDebugText?: boolean;
@@ -1290,33 +1309,7 @@ export function createRoutes(ctx: RouteContext): Router {
       messageKind?: 'reply' | 'health-alert' | 'unknown';
       jargon?: boolean;
     },
-  ): Promise<boolean> {
-    // ── Self-Violation Signal (OBSERVE-ONLY) ──────────────────────────
-    // Record — but NEVER act on — the case where this finalized outbound
-    // message contradicts a stored preference. This runs as a fire-and-forget
-    // VOID call that is structurally independent of the tone-gate verdict and
-    // of this function's return value: it cannot block, delay, or rewrite the
-    // message. It runs FIRST (before the gate-availability early-return below)
-    // so the observation happens regardless of whether the tone gate exists or
-    // what it decides. Dark by default (gated inside on enabled+selfViolationSignal).
-    void observeSelfViolation(text, options.topicId).catch(() => {
-      /* @silent-fallback-ok — observe-only; a detector error never affects delivery */
-    });
-
-    // ── Principal-Coherence Signal (OBSERVE-ONLY) ─────────────────────
-    // Record — but NEVER act on — the case where this finalized outbound
-    // message credits an operator-ROLE decision (approval / mandate / credential
-    // / lock / acting-for) to a principal who is NOT the topic's VERIFIED
-    // operator. That is the "Caroline" identity-bleed failure, caught in the
-    // agent's OWN output where no inbound gate watches. Same fire-and-forget
-    // VOID contract as observeSelfViolation: structurally independent of the
-    // tone-gate verdict and of this function's return value — it cannot block,
-    // delay, or rewrite the message. Dark by default (gated inside on
-    // monitoring.principalCoherence.enabled + a wired TopicOperatorStore).
-    void observePrincipalCoherence(text, options.topicId).catch(() => {
-      /* @silent-fallback-ok — observe-only; a detector error never affects delivery */
-    });
-
+  ): Promise<OutboundEvaluation> {
     // ── Localhost-link guard (operator-mandated HARD rule, 2026-06-05) ──
     // A clickable localhost/loopback link must never reach a user — the user
     // is almost never on the machine this server runs on. This is a
@@ -1328,19 +1321,23 @@ export function createRoutes(ctx: RouteContext): Router {
     if (!options.allowLocalhostLink) {
       const localLink = detectLocalhostLink(text);
       if (localLink.detected) {
-        res.status(422).json({
-          error:
-            `Message blocked: contains a machine-local link (${localLink.match}) that the user cannot open from their device. ` +
-            `Replace it with the public tunnel URL (GET /tunnel → url + path), or omit the link and say it will follow. ` +
-            `If the operator explicitly asked for the raw local URL, resend with metadata.allowLocalhostLink: true.`,
-          blockedBy: 'localhost-link-guard',
-          match: localLink.match,
-        });
-        return true;
+        return {
+          ok: false,
+          status: 422,
+          reason: 'localhost-link-guard',
+          body: {
+            error:
+              `Message blocked: contains a machine-local link (${localLink.match}) that the user cannot open from their device. ` +
+              `Replace it with the public tunnel URL (GET /tunnel → url + path), or omit the link and say it will follow. ` +
+              `If the operator explicitly asked for the raw local URL, resend with metadata.allowLocalhostLink: true.`,
+            blockedBy: 'localhost-link-guard',
+            match: localLink.match,
+          },
+        };
       }
     }
 
-    if (!ctx.messagingToneGate) return false; // No authority configured — pass through
+    if (!ctx.messagingToneGate) return { ok: true }; // No authority configured — pass through
 
     try {
       // ── Collect signals from upstream detectors ──
@@ -1463,20 +1460,107 @@ export function createRoutes(ctx: RouteContext): Router {
       });
 
       if (!result.pass) {
-        res.status(422).json({
-          error: 'tone-gate-blocked',
-          rule: result.rule,
-          issue: result.issue,
-          suggestion: result.suggestion,
-          latencyMs: result.latencyMs,
-        });
-        return true;
+        return {
+          ok: false,
+          status: 422,
+          reason: 'tone-gate-blocked',
+          body: {
+            error: 'tone-gate-blocked',
+            rule: result.rule,
+            issue: result.issue,
+            suggestion: result.suggestion,
+            latencyMs: result.latencyMs,
+          },
+        };
       }
     } catch {
       // Fail-open — any error short of a clean block lets the message through.
     }
+    return { ok: true };
+  }
+
+  /**
+   * Route adapter — fires the observe-only observers (route-side) then delegates
+   * the block/allow decision to the shared res-free `evaluateOutbound`. Returns
+   * true if blocked (the mapped status/body already written). Behavior is
+   * byte-identical to the pre-extraction function for every existing caller.
+   */
+  async function checkOutboundMessage(
+    text: string,
+    channel: string,
+    res: import('express').Response,
+    options: {
+      topicId?: number;
+      allowDebugText?: boolean;
+      allowDuplicate?: boolean;
+      allowLocalhostLink?: boolean;
+      messageKind?: 'reply' | 'health-alert' | 'unknown';
+      jargon?: boolean;
+    },
+  ): Promise<boolean> {
+    // ── Self-Violation Signal (OBSERVE-ONLY) ──────────────────────────
+    // Record — but NEVER act on — the case where this finalized outbound message
+    // contradicts a stored preference. Fire-and-forget VOID, structurally
+    // independent of the decision and of this function's return value: it cannot
+    // block, delay, or rewrite the message. Stays route-side (NOT in
+    // evaluateOutbound) — there is nothing for it to catch on the proactive-digest
+    // path, and keeping it here preserves byte-identical behavior for callers.
+    void observeSelfViolation(text, options.topicId).catch(() => {
+      /* @silent-fallback-ok — observe-only; a detector error never affects delivery */
+    });
+    // ── Principal-Coherence Signal (OBSERVE-ONLY) ─────────────────────
+    // Same fire-and-forget VOID contract for the operator-role / principal
+    // identity-bleed ("Caroline") case. Route-side for the same reason.
+    void observePrincipalCoherence(text, options.topicId).catch(() => {
+      /* @silent-fallback-ok — observe-only; a detector error never affects delivery */
+    });
+
+    const decision = await evaluateOutbound(text, channel, options);
+    if (!decision.ok) {
+      res.status(decision.status).json(decision.body);
+      return true;
+    }
     return false;
   }
+
+  /**
+   * Shared guarded delivery to the Agent Updates topic — the proactive growth
+   * digest publisher's `send`. Resolves the Updates topic server-side (never a
+   * fallback topic, mirroring the /telegram/post-update 400), runs the SAME
+   * `evaluateOutbound` chokepoint as the route, then sends. Returns a flat
+   * DeliveryResult and never throws — a guard block is a normal, non-error
+   * outcome that the publisher records and never re-acts on.
+   */
+  async function postToUpdatesTopic(
+    text: string,
+    opts?: { allowDuplicate?: boolean; allowDebugText?: boolean },
+  ): Promise<{ ok: boolean; reason?: string }> {
+    if (!ctx.telegram) return { ok: false, reason: 'telegram-not-configured' };
+    const updatesTopicId = ctx.state.get<number>('agent-updates-topic');
+    if (!updatesTopicId || typeof updatesTopicId !== 'number') {
+      return { ok: false, reason: 'no-updates-topic' };
+    }
+    if (typeof text !== 'string' || text.length === 0) return { ok: false, reason: 'empty-text' };
+    if (text.length > 4096) return { ok: false, reason: 'too-long' };
+    const decision = await evaluateOutbound(text, 'telegram', {
+      topicId: updatesTopicId,
+      allowDebugText: opts?.allowDebugText === true,
+      allowDuplicate: opts?.allowDuplicate === true,
+    });
+    if (!decision.ok) return { ok: false, reason: decision.reason };
+    try {
+      await ctx.telegram.sendToTopic(updatesTopicId, text);
+      return { ok: true };
+    } catch (err) {
+      return { ok: false, reason: err instanceof Error ? err.message : 'send-error' };
+    }
+  }
+
+  // Attach the shared guarded sender to the growth-digest publisher (if wired).
+  // Runs once at route registration — the publisher was constructed + started in
+  // AgentServer; this is the §3.3 single-funnel hookup, so the publisher can never
+  // reach sendToTopic without passing through the identical evaluateOutbound.
+  ctx.growthDigestPublisher?.attachSender((text: string) => postToUpdatesTopic(text));
 
   /**
    * Self-Violation Signal — OBSERVE-ONLY (Correction & Preference Learning

--- a/tests/e2e/growth-digest-publisher-lifecycle.test.ts
+++ b/tests/e2e/growth-digest-publisher-lifecycle.test.ts
@@ -1,0 +1,143 @@
+// safe-fs-allow: test file — SafeFsExecutor used for tmpdir cleanup.
+
+/**
+ * Tier-3 E2E "feature is alive" lifecycle test for the GrowthDigestPublisher
+ * (Slice 2). Boots the REAL AgentServer (the path server.ts uses) and proves the
+ * publisher is constructed + started + wired to the REAL analyst on the production
+ * init path — and that the construction gate (analyst present AND digestDelivery
+ * !== 'off') holds on both sides.
+ *
+ *  - LIVE: dev-agent config + digestDelivery:'live' + Updates topic + a seeded
+ *    stalling initiative → driving one cycle lands exactly one growth check-in in
+ *    the Updates topic, end-to-end through the production guarded funnel.
+ *  - OFF: digestDelivery:'off' → the publisher is NOT constructed (null).
+ *  - NO ANALYST: no initiativeTracker → analyst null → publisher null even at
+ *    digestDelivery:'live'.
+ */
+
+import { describe, it, expect, afterEach } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { AgentServer } from '../../src/server/AgentServer.js';
+import { StateManager } from '../../src/core/StateManager.js';
+import type { InstarConfig } from '../../src/core/types.js';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+
+const UPDATES_TOPIC_ID = 9091;
+
+function createMockSessionManager() {
+  return { listRunningSessions: () => [], getSession: () => null, getRunningSessionPanePids: () => [] };
+}
+
+// A stalling-initiative tracker (only the analyst's Pick<list|digest> surface is
+// used; failureLearning stays off so nothing else touches it).
+function fakeTracker() {
+  return {
+    list: () => [],
+    digest: (now: Date) => ({
+      generatedAt: now.toISOString(),
+      items: [{ initiativeId: 'feat-x', title: 'Feature X', reason: 'stale', detail: 'No movement in 18 days.' }],
+    }),
+  } as never;
+}
+
+function bootConfig(tmpDir: string, stateDir: string, digestDelivery: 'off' | 'dry-run' | 'live'): InstarConfig {
+  return {
+    projectName: 'e2e',
+    projectDir: tmpDir,
+    stateDir,
+    port: 0,
+    authToken: 'test-e2e-growth-digest',
+    requestTimeoutMs: 10000,
+    version: '0.0.0',
+    developmentAgent: true, // gate the analyst LIVE (dev-agent dark-feature gate)
+    sessions: { claudePath: '/usr/bin/echo', maxSessions: 3, defaultMaxDurationMinutes: 30, protectedSessions: [], monitorIntervalMs: 5000 },
+    scheduler: { enabled: false, jobsFile: '', maxParallelJobs: 1 },
+    messaging: [],
+    monitoring: { growthAnalyst: { digestDelivery, digestTimezone: 'UTC' } },
+    updates: {},
+  } as unknown as InstarConfig;
+}
+
+interface Booted {
+  server: AgentServer;
+  stateDir: string;
+  tmpDir: string;
+  sends: { topicId: number; text: string }[];
+}
+
+async function boot(digestDelivery: 'off' | 'dry-run' | 'live', opts: { withTracker?: boolean; withTopic?: boolean } = {}): Promise<Booted> {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'growth-digest-e2e-'));
+  const stateDir = path.join(tmpDir, '.instar');
+  fs.mkdirSync(path.join(stateDir, 'state', 'sessions'), { recursive: true });
+  fs.mkdirSync(path.join(stateDir, 'logs'), { recursive: true });
+  fs.writeFileSync(path.join(stateDir, 'config.json'), JSON.stringify({ port: 0, projectName: 'e2e', agentName: 'E2E' }));
+
+  const state = new StateManager(stateDir);
+  if (opts.withTopic !== false) state.set('agent-updates-topic', UPDATES_TOPIC_ID);
+
+  const sends: { topicId: number; text: string }[] = [];
+  const telegram = {
+    sendToTopic: async (topicId: number, text: string) => { sends.push({ topicId, text }); },
+    sendMessage: async () => ({}),
+    getTopicHistory: () => [],
+    on: () => {},
+    start: async () => {},
+    stop: async () => {},
+  } as never;
+
+  const config = bootConfig(tmpDir, stateDir, digestDelivery);
+  const server = new AgentServer({
+    config,
+    sessionManager: createMockSessionManager() as never,
+    state,
+    telegram,
+    ...(opts.withTracker === false ? {} : { initiativeTracker: fakeTracker() }),
+  } as never);
+  await server.start();
+  return { server, stateDir, tmpDir, sends };
+}
+
+describe('GrowthDigestPublisher E2E lifecycle — feature is alive', () => {
+  let booted: Booted | undefined;
+  afterEach(async () => {
+    if (booted) {
+      await booted.server.stop();
+      SafeFsExecutor.safeRmSync(booted.tmpDir, { recursive: true, force: true, operation: 'tests/e2e/growth-digest-publisher-lifecycle.test.ts' });
+      booted = undefined;
+    }
+  });
+
+  it('LIVE: constructed + started on the production path, sends one check-in to the Updates topic', async () => {
+    booted = await boot('live');
+    const pub = (booted.server as unknown as { growthDigestPublisher: { isStarted(): boolean; publishOnce: (n: Date, t: string) => Promise<void> } | null }).growthDigestPublisher;
+    expect(pub).not.toBeNull();
+    expect(pub!.isStarted()).toBe(true);
+
+    // Drive one cycle through the REAL analyst + real guarded funnel.
+    await pub!.publishOnce(new Date('2026-06-10T17:30:00.000Z'), 'manual');
+
+    expect(booted.sends).toHaveLength(1);
+    expect(booted.sends[0].topicId).toBe(UPDATES_TOPIC_ID);
+    expect(booted.sends[0].text).toContain('Growth check-in');
+    expect(booted.sends[0].text).toContain('Feature X');
+
+    // The real audit sink wrote the durable record.
+    const auditPath = path.join(booted.stateDir, 'logs', 'growth-digest.jsonl');
+    const lines = fs.readFileSync(auditPath, 'utf-8').trim().split('\n').map((l) => JSON.parse(l));
+    expect(lines.some((e: { action: string }) => e.action === 'sent')).toBe(true);
+  });
+
+  it('OFF: digestDelivery:"off" → the publisher is NOT constructed (construction gate)', async () => {
+    booted = await boot('off');
+    const pub = (booted.server as unknown as { growthDigestPublisher: unknown }).growthDigestPublisher;
+    expect(pub).toBeNull();
+  });
+
+  it('NO ANALYST: no initiativeTracker → analyst null → publisher null even at "live"', async () => {
+    booted = await boot('live', { withTracker: false });
+    const pub = (booted.server as unknown as { growthDigestPublisher: unknown }).growthDigestPublisher;
+    expect(pub).toBeNull();
+  });
+});

--- a/tests/integration/growth-digest-publisher-wiring.test.ts
+++ b/tests/integration/growth-digest-publisher-wiring.test.ts
@@ -1,0 +1,116 @@
+/**
+ * Wiring-integrity test for the GrowthDigestPublisher (Testing Integrity Standard
+ * — DI deps are not null, not no-ops, and delegate to the real implementations).
+ *
+ * Proves the three things the Slice-2 convergence review hardened:
+ *  1. SINGLE FUNNEL — the publisher's sender is the SAME guarded path the route
+ *     uses: the identical ctx.messagingToneGate that blocks the route's
+ *     post-update also blocks the publisher's send (no un-guarded second path).
+ *  2. SENDER NOT A NO-OP — `attachSender` actually wires the guarded sender:
+ *     before registration a live send is 'no-sender'; after createRoutes it
+ *     reaches telegram.sendToTopic.
+ *  3. LEASE GATE WIRED — a standby coordinator (isAwake:false) yields ZERO sends.
+ */
+
+import { describe, it, expect } from 'vitest';
+import express from 'express';
+import type { AddressInfo } from 'node:net';
+import { createRoutes } from '../../src/server/routes.js';
+import { GrowthDigestPublisher, type GrowthDigestAuditEntry } from '../../src/monitoring/GrowthDigestPublisher.js';
+import type { GrowthDigest } from '../../src/monitoring/GrowthMilestoneAnalyst.js';
+import type { ToneReviewResult } from '../../src/core/MessagingToneGate.js';
+
+const UPDATES_TOPIC_ID = 4242;
+const NOW = new Date('2026-06-10T17:30:00.000Z');
+
+function digest(): GrowthDigest {
+  return {
+    generatedAt: '2026-06-08T11:00:00.000Z',
+    calm: false,
+    summary: 'Growth digest: 1 stalling.',
+    findings: [{ rule: 'R3', priority: 'normal', subjectId: 's1', title: 'Stalled thing', detail: 'No movement.', suggestedAction: 'review' }],
+    counts: { incubating: 0, promotionReady: 0, expiredUnproven: 0, stalling: 1, specPatterns: 0, correctionPatterns: 0, devGateDark: 0 },
+  };
+}
+
+function mkPublisher(opts: { isAwake?: () => boolean } = {}): { pub: GrowthDigestPublisher; audits: GrowthDigestAuditEntry[] } {
+  const audits: GrowthDigestAuditEntry[] = [];
+  const pub = new GrowthDigestPublisher({
+    buildDigest: () => digest(),
+    cron: '0 11 * * 1',
+    mode: 'live',
+    now: () => NOW,
+    isAwake: opts.isAwake,
+    audit: (e) => audits.push(e),
+  });
+  return { pub, audits };
+}
+
+function mkCtx(pub: GrowthDigestPublisher | null, opts: { toneBlock?: boolean } = {}) {
+  const sends: { topicId: number; text: string }[] = [];
+  const review = async (): Promise<ToneReviewResult> =>
+    opts.toneBlock
+      ? { pass: false, rule: 'B2', issue: 'blocked', suggestion: 'x', latencyMs: 1 }
+      : { pass: true, rule: '', issue: '', suggestion: '', latencyMs: 1 };
+  const ctx = {
+    config: { authToken: 'test', stateDir: '/tmp', port: 0 },
+    state: { get: (k: string) => (k === 'agent-updates-topic' ? UPDATES_TOPIC_ID : undefined) },
+    messagingToneGate: { review },
+    telegram: { sendToTopic: async (topicId: number, text: string) => { sends.push({ topicId, text }); } },
+    growthDigestPublisher: pub,
+  };
+  return { ctx, sends };
+}
+
+describe('GrowthDigestPublisher — wiring integrity', () => {
+  it('SINGLE FUNNEL: the same tone gate that blocks the route ALSO blocks the publisher', async () => {
+    const { pub, audits } = mkPublisher();
+    const { ctx, sends } = mkCtx(pub, { toneBlock: true });
+
+    // Route path: POST /telegram/post-update is blocked 422 by this gate.
+    const app = express();
+    app.use(express.json());
+    app.use(createRoutes(ctx as never));
+    const srv = await new Promise<{ url: string; close: () => Promise<void> }>((resolve) => {
+      const s = app.listen(0, () => {
+        const port = (s.address() as AddressInfo).port;
+        resolve({ url: `http://127.0.0.1:${port}`, close: () => new Promise<void>((r) => s.close(() => r())) });
+      });
+    });
+    const routeRes = await fetch(srv.url + '/telegram/post-update', {
+      method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ text: 'weekly check-in' }),
+    });
+    expect(routeRes.status).toBe(422);
+
+    // Publisher path: the SAME gate blocks it — proving one shared chokepoint.
+    await pub.publishOnce(NOW, 'manual');
+    expect(sends).toHaveLength(0);
+    expect(audits.find((a) => a.action === 'send-blocked')?.reason).toBe('tone-gate-blocked');
+    await srv.close();
+  });
+
+  it('SENDER NOT A NO-OP: unattached → no-sender; after createRoutes → reaches telegram', async () => {
+    // Unattached publisher (createRoutes never ran) → 'no-sender'.
+    const lone = mkPublisher();
+    await lone.pub.publishOnce(NOW, 'manual');
+    expect(lone.audits.find((a) => a.action === 'send-blocked')?.reason).toBe('no-sender');
+
+    // Attached via route registration → a live send reaches telegram.sendToTopic.
+    const { pub, audits } = mkPublisher();
+    const { ctx, sends } = mkCtx(pub);
+    createRoutes(ctx as never); // registration attaches the guarded sender
+    await pub.publishOnce(NOW, 'manual');
+    expect(sends).toHaveLength(1);
+    expect(sends[0].topicId).toBe(UPDATES_TOPIC_ID);
+    expect(audits.find((a) => a.action === 'sent')).toBeDefined();
+  });
+
+  it('LEASE GATE WIRED: a standby coordinator (isAwake:false) yields ZERO sends', async () => {
+    const { pub, audits } = mkPublisher({ isAwake: () => false });
+    const { ctx, sends } = mkCtx(pub);
+    createRoutes(ctx as never);
+    await pub.publishOnce(NOW, 'cron');
+    expect(sends).toHaveLength(0);
+    expect(audits.find((a) => a.action === 'skipped-standby')).toBeDefined();
+  });
+});

--- a/tests/integration/growth-digest-publisher.test.ts
+++ b/tests/integration/growth-digest-publisher.test.ts
@@ -1,0 +1,166 @@
+/**
+ * Tier-2 integration test for the GrowthDigestPublisher delivery path.
+ *
+ * Exercises the REAL route-layer funnel: createRoutes attaches the production
+ * `postToUpdatesTopic` (which runs the shared `evaluateOutbound` chokepoint) to a
+ * real publisher via `attachSender`. Then we drive the publisher's `publishOnce`
+ * and assert what actually reaches telegram.sendToTopic — proving the publisher
+ * delivers through the guarded Updates-topic path, never a raw second send path.
+ *
+ * Also a regression on the funnel extraction: POST /telegram/post-update still
+ * 400s with no Updates topic and 422s on a localhost link (the route adapter still
+ * maps evaluateOutbound's decision to the same statuses/bodies).
+ */
+
+import { describe, it, expect, afterEach } from 'vitest';
+import express from 'express';
+import type { AddressInfo } from 'node:net';
+import { createRoutes } from '../../src/server/routes.js';
+import {
+  GrowthDigestPublisher,
+  type GrowthDigestAuditEntry,
+} from '../../src/monitoring/GrowthDigestPublisher.js';
+import type { GrowthDigest } from '../../src/monitoring/GrowthMilestoneAnalyst.js';
+import type { ToneReviewResult } from '../../src/core/MessagingToneGate.js';
+
+const UPDATES_TOPIC_ID = 777;
+const NOW = new Date('2026-06-10T17:30:00.000Z');
+
+function activeDigest(): GrowthDigest {
+  return {
+    generatedAt: '2026-06-08T11:00:00.000Z',
+    calm: false,
+    summary: 'Growth digest: 1 stalling.',
+    findings: [
+      { rule: 'R3', priority: 'normal', subjectId: 'feat-x', title: 'Feature X', detail: 'No movement in 18 days.', suggestedAction: 'review' },
+    ],
+    counts: { incubating: 1, promotionReady: 0, expiredUnproven: 0, stalling: 1, specPatterns: 0, correctionPatterns: 0, devGateDark: 0 },
+  };
+}
+
+interface Built {
+  publisher: GrowthDigestPublisher;
+  audits: GrowthDigestAuditEntry[];
+  sends: { topicId: number; text: string }[];
+  ctx: Record<string, unknown>;
+}
+
+function build(opts: {
+  mode?: 'off' | 'dry-run' | 'live';
+  noTopic?: boolean;
+  toneBlock?: boolean;
+  digest?: GrowthDigest;
+} = {}): Built {
+  const audits: GrowthDigestAuditEntry[] = [];
+  const sends: { topicId: number; text: string }[] = [];
+  const publisher = new GrowthDigestPublisher({
+    buildDigest: () => opts.digest ?? activeDigest(),
+    cron: '0 11 * * 1',
+    mode: opts.mode ?? 'live',
+    now: () => NOW,
+    audit: (e) => audits.push(e),
+    // send intentionally NOT set — createRoutes attaches the guarded sender.
+  });
+  const review = async (): Promise<ToneReviewResult> =>
+    opts.toneBlock
+      ? { pass: false, rule: 'B1', issue: 'blocked', suggestion: 'fix', latencyMs: 1 }
+      : { pass: true, rule: '', issue: '', suggestion: '', latencyMs: 1 };
+  const ctx: Record<string, unknown> = {
+    config: { authToken: 'test', stateDir: '/tmp', port: 0 },
+    state: { get: (k: string) => (k === 'agent-updates-topic' && !opts.noTopic ? UPDATES_TOPIC_ID : undefined) },
+    messagingToneGate: { review },
+    telegram: { sendToTopic: async (topicId: number, text: string) => { sends.push({ topicId, text }); } },
+    growthDigestPublisher: publisher,
+  };
+  // Registering the routes attaches postToUpdatesTopic to the publisher.
+  createRoutes(ctx as never);
+  return { publisher, audits, sends, ctx };
+}
+
+describe('GrowthDigestPublisher — guarded delivery path (integration)', () => {
+  it('live + Updates topic → exactly one send to the Updates topic + "sent" audit', async () => {
+    const b = build({ mode: 'live' });
+    await b.publisher.publishOnce(NOW, 'manual');
+    expect(b.sends).toHaveLength(1);
+    expect(b.sends[0].topicId).toBe(UPDATES_TOPIC_ID);
+    expect(b.sends[0].text).toContain('Growth check-in');
+    expect(b.sends[0].text).toContain('Feature X');
+    expect(b.audits.find((a) => a.action === 'sent')).toBeDefined();
+  });
+
+  it('no Updates topic → publisher records send-blocked(no-updates-topic), nothing sent (never a fallback topic)', async () => {
+    const b = build({ mode: 'live', noTopic: true });
+    await b.publisher.publishOnce(NOW, 'manual');
+    expect(b.sends).toHaveLength(0);
+    expect(b.audits.find((a) => a.action === 'send-blocked')?.reason).toBe('no-updates-topic');
+  });
+
+  it('dry-run → nothing sent, "dry-run" audit carries the would-send text', async () => {
+    const b = build({ mode: 'dry-run' });
+    await b.publisher.publishOnce(NOW, 'manual');
+    expect(b.sends).toHaveLength(0);
+    const dry = b.audits.find((a) => a.action === 'dry-run');
+    expect(dry?.wouldSend).toContain('Growth check-in');
+  });
+
+  it('tone gate blocks → publisher records send-blocked(tone-gate-blocked), nothing sent', async () => {
+    const b = build({ mode: 'live', toneBlock: true });
+    await b.publisher.publishOnce(NOW, 'manual');
+    expect(b.sends).toHaveLength(0);
+    expect(b.audits.find((a) => a.action === 'send-blocked')?.reason).toBe('tone-gate-blocked');
+  });
+});
+
+// ── Route regression: POST /telegram/post-update after the funnel extraction ──
+
+describe('POST /telegram/post-update — behavior preserved by the funnel extraction', () => {
+  let srv: { url: string; close: () => Promise<void> } | undefined;
+  afterEach(async () => {
+    await srv?.close();
+    srv = undefined;
+  });
+
+  async function listen(ctx: Record<string, unknown>) {
+    const app = express();
+    app.use(express.json());
+    app.use(createRoutes(ctx as never));
+    return new Promise<{ url: string; close: () => Promise<void> }>((resolve) => {
+      const s = app.listen(0, () => {
+        const port = (s.address() as AddressInfo).port;
+        resolve({ url: `http://127.0.0.1:${port}`, close: () => new Promise<void>((r) => s.close(() => r())) });
+      });
+    });
+  }
+
+  it('400s when no Updates topic is configured (never a fallback topic)', async () => {
+    const ctx = {
+      config: { authToken: 'test', stateDir: '/tmp', port: 0 },
+      state: { get: () => undefined },
+      telegram: { sendToTopic: async () => {} },
+    };
+    srv = await listen(ctx);
+    const res = await fetch(srv.url + '/telegram/post-update', {
+      method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ text: 'hi' }),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it('422s on a localhost link (localhost-link-guard still wired through evaluateOutbound)', async () => {
+    const sends: unknown[] = [];
+    const ctx = {
+      config: { authToken: 'test', stateDir: '/tmp', port: 0 },
+      state: { get: (k: string) => (k === 'agent-updates-topic' ? UPDATES_TOPIC_ID : undefined) },
+      telegram: { sendToTopic: async () => { sends.push(1); } },
+    };
+    srv = await listen(ctx);
+    const res = await fetch(srv.url + '/telegram/post-update', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ text: 'open http://localhost:4040/dashboard now' }),
+    });
+    const body = await res.json().catch(() => ({}));
+    expect(res.status).toBe(422);
+    expect(body.blockedBy).toBe('localhost-link-guard');
+    expect(sends).toHaveLength(0);
+  });
+});

--- a/tests/integration/notification-flood-burst-invariant.test.ts
+++ b/tests/integration/notification-flood-burst-invariant.test.ts
@@ -32,6 +32,8 @@ import path from 'node:path';
 import { TelegramAdapter } from '../../src/messaging/TelegramAdapter.js';
 import { TopicFloodBudgetError, DEFAULT_ATTENTION_TOPIC_GUARD } from '../../src/messaging/AttentionTopicGuard.js';
 import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+import { formatDigest } from '../../src/monitoring/GrowthDigestPublisher.js';
+import type { GrowthDigest, GrowthFinding } from '../../src/monitoring/GrowthMilestoneAnalyst.js';
 
 interface Recorder {
   forumTopicsCreated: number;
@@ -212,5 +214,42 @@ describe('Notification-flood burst invariant (production-default budgets)', () =
     expect(rec.forumTopicsCreated).toBe(before + 1); // its own topic, no refusal
     expect(urgent.topicId).toBeDefined();
     expect(urgent.coalesced).not.toBe(true);
+  });
+});
+
+// ── Growth digest — aggregation invariant ─────────────────────────────────────
+//
+// The GrowthDigestPublisher is exactly the "feature that notifies per-element over
+// a collection" the Bounded Notification Surface standard targets. It MUST
+// aggregate: ONE message for a 500-finding burst, never one-per-finding (and it
+// has no per-element topic path at all — it sends ONE message into the existing
+// Updates topic). This pins the render-level invariant that protects the bound.
+
+describe('Growth digest aggregation invariant (500 findings → one bounded message)', () => {
+  function finding(rule: GrowthFinding['rule'], priority: GrowthFinding['priority'], i: number): GrowthFinding {
+    return { rule, priority, subjectId: `${rule}-${i}`, title: `${rule} item ${i}`, detail: 'No movement.', suggestedAction: 'review' };
+  }
+  function burstDigest(): GrowthDigest {
+    const bulk = Array.from({ length: 500 }, (_, i) => finding('R3', 'low', i));
+    const high = finding('R3', 'high', 9999);
+    high.title = 'CRITICAL — decide now';
+    return {
+      generatedAt: '2026-06-08T11:00:00.000Z',
+      calm: false,
+      summary: 'Growth digest: 501 stalling.',
+      findings: [...bulk, high],
+      counts: { incubating: 0, promotionReady: 0, expiredUnproven: 0, stalling: 501, specPatterns: 0, correctionPatterns: 0, devGateDark: 0 },
+    };
+  }
+
+  it('renders exactly ONE message, ≤4096 chars, with the high-priority finding never truncated', () => {
+    const text = formatDigest(burstDigest());
+    // ONE message (a single string — not an array/stream of per-finding messages).
+    expect(typeof text).toBe('string');
+    expect(text.length).toBeLessThanOrEqual(4096);
+    // The bulk overflowed into a "+N more" summary line, never a wall of 500.
+    expect(text).toContain('more (see full digest)');
+    // The high-priority finding is rendered in full despite the burst.
+    expect(text).toContain('CRITICAL — decide now');
   });
 });

--- a/tests/unit/GrowthDigestPublisher.test.ts
+++ b/tests/unit/GrowthDigestPublisher.test.ts
@@ -1,0 +1,387 @@
+// safe-fs-allow: test file — SafeFsExecutor used for tmpdir cleanup.
+
+/**
+ * Tier-1 tests for GrowthDigestPublisher (Slice 2 — the proactive growth-digest
+ * voice). Pure logic with injected deps; both sides of every decision boundary:
+ *  - the publishOnce matrix (isAwake × mode × calm × sendOnCalmWeeks × ok/blocked)
+ *  - lease-gated delivery (standby → zero sends)
+ *  - the in-flight (overlap) guard
+ *  - missed-run catch-up + its idempotency on the window key
+ *  - the cadence sanity-floor refusal
+ *  - formatDigest: calm, single/all-rules, priority-never-truncate, scrub, overflow
+ */
+
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+import {
+  GrowthDigestPublisher,
+  formatDigest,
+  createGrowthDigestAuditSink,
+  type GrowthDigestAuditEntry,
+  type DeliveryResult,
+} from '../../src/monitoring/GrowthDigestPublisher.js';
+import type {
+  GrowthDigest,
+  GrowthFinding,
+  GrowthFindingPriority,
+  GrowthRuleId,
+} from '../../src/monitoring/GrowthMilestoneAnalyst.js';
+
+// ── fixtures ─────────────────────────────────────────────────────────────────
+
+const COUNTS = {
+  incubating: 0,
+  promotionReady: 0,
+  expiredUnproven: 0,
+  stalling: 0,
+  specPatterns: 0,
+  correctionPatterns: 0,
+  devGateDark: 0,
+};
+
+function calmDigest(): GrowthDigest {
+  return {
+    generatedAt: '2026-06-08T11:00:00.000Z',
+    calm: true,
+    summary: 'All healthy — 2 feature(s) incubating, nothing past its window. Next window closes in 3d.',
+    findings: [],
+    counts: { ...COUNTS, incubating: 2 },
+    nextWindowClosesInDays: 3,
+  };
+}
+
+function finding(
+  rule: GrowthRuleId,
+  priority: GrowthFindingPriority,
+  i: number,
+  detail = 'A short detail.',
+): GrowthFinding {
+  return {
+    rule,
+    priority,
+    subjectId: `${rule}-${i}`,
+    title: `${rule} item ${i}`,
+    detail,
+    suggestedAction: 'review',
+  };
+}
+
+function activeDigest(findings: GrowthFinding[] = [finding('R3', 'normal', 1)]): GrowthDigest {
+  return {
+    generatedAt: '2026-06-08T11:00:00.000Z',
+    calm: false,
+    summary: `Growth digest: ${findings.length} item(s).`,
+    findings,
+    counts: { ...COUNTS, stalling: findings.filter((f) => f.rule === 'R3').length },
+  };
+}
+
+interface Harness {
+  pub: GrowthDigestPublisher;
+  sends: string[];
+  audits: GrowthDigestAuditEntry[];
+}
+
+function makePublisher(over: Partial<Parameters<typeof newPub>[0]> = {}): Harness {
+  return newPub(over);
+}
+
+function newPub(over: {
+  digest?: GrowthDigest;
+  mode?: 'off' | 'dry-run' | 'live';
+  isAwake?: () => boolean;
+  sendOnCalmWeeks?: boolean;
+  sendResult?: DeliveryResult;
+  cron?: string;
+  now?: Date;
+}): Harness {
+  const sends: string[] = [];
+  const audits: GrowthDigestAuditEntry[] = [];
+  const pub = new GrowthDigestPublisher({
+    buildDigest: () => over.digest ?? activeDigest(),
+    cron: over.cron ?? '0 11 * * 1',
+    mode: over.mode ?? 'live',
+    sendOnCalmWeeks: over.sendOnCalmWeeks,
+    isAwake: over.isAwake,
+    now: () => over.now ?? new Date('2026-06-10T17:30:00.000Z'),
+    send: async (t: string) => {
+      sends.push(t);
+      return over.sendResult ?? { ok: true };
+    },
+    audit: (e) => audits.push(e),
+  });
+  return { pub, sends, audits };
+}
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+// ── publishOnce decision matrix ──────────────────────────────────────────────
+
+describe('GrowthDigestPublisher.publishOnce — decision matrix', () => {
+  it('live + non-calm + awake → sends exactly once, audits "sent"', async () => {
+    const h = makePublisher({ mode: 'live' });
+    await h.pub.publishOnce(new Date('2026-06-10T17:30:00Z'), 'manual');
+    expect(h.sends.length).toBe(1);
+    const sent = h.audits.find((a) => a.action === 'sent');
+    expect(sent).toBeDefined();
+    expect(sent!.counts).toBeDefined();
+  });
+
+  it('standby (isAwake:false) → ZERO sends, audits "skipped-standby", no window consumed', async () => {
+    const h = makePublisher({ mode: 'live', isAwake: () => false });
+    await h.pub.publishOnce(new Date('2026-06-10T17:30:00Z'), 'cron');
+    expect(h.sends.length).toBe(0);
+    expect(h.audits.length).toBe(1);
+    expect(h.audits[0].action).toBe('skipped-standby');
+    // Pre-lease check never records a window — the awake machine still owns it.
+    expect(h.audits[0].window).toBeUndefined();
+  });
+
+  it('mode "off" → ZERO sends, audits "skipped-off"', async () => {
+    const h = makePublisher({ mode: 'off' });
+    await h.pub.publishOnce(new Date('2026-06-10T17:30:00Z'), 'cron');
+    expect(h.sends.length).toBe(0);
+    expect(h.audits[0].action).toBe('skipped-off');
+  });
+
+  it('dry-run → ZERO sends, audits "dry-run" carrying the would-send text', async () => {
+    const h = makePublisher({ mode: 'dry-run' });
+    await h.pub.publishOnce(new Date('2026-06-10T17:30:00Z'), 'cron');
+    expect(h.sends.length).toBe(0);
+    const dry = h.audits.find((a) => a.action === 'dry-run');
+    expect(dry).toBeDefined();
+    expect(dry!.wouldSend).toContain('Growth check-in');
+  });
+
+  it('calm + sendOnCalmWeeks:false (default) → ZERO sends, audits "skipped-calm"', async () => {
+    const h = makePublisher({ mode: 'live', digest: calmDigest() });
+    await h.pub.publishOnce(new Date('2026-06-10T17:30:00Z'), 'cron');
+    expect(h.sends.length).toBe(0);
+    expect(h.audits.find((a) => a.action === 'skipped-calm')).toBeDefined();
+  });
+
+  it('calm + sendOnCalmWeeks:true → SENDS the calm heartbeat', async () => {
+    const h = makePublisher({ mode: 'live', digest: calmDigest(), sendOnCalmWeeks: true });
+    await h.pub.publishOnce(new Date('2026-06-10T17:30:00Z'), 'cron');
+    expect(h.sends.length).toBe(1);
+    expect(h.audits.find((a) => a.action === 'sent')).toBeDefined();
+  });
+
+  it('live but guard blocks (send → {ok:false}) → audits "send-blocked" with reason, not an error', async () => {
+    const h = makePublisher({ mode: 'live', sendResult: { ok: false, reason: 'guard-blocked' } });
+    await h.pub.publishOnce(new Date('2026-06-10T17:30:00Z'), 'cron');
+    expect(h.sends.length).toBe(1); // send WAS attempted
+    const blocked = h.audits.find((a) => a.action === 'send-blocked');
+    expect(blocked).toBeDefined();
+    expect(blocked!.reason).toBe('guard-blocked');
+  });
+
+  it('in-flight (overlap) guard → a re-entrant publishOnce audits "skipped-overlap"', async () => {
+    const audits: GrowthDigestAuditEntry[] = [];
+    let release!: () => void;
+    const gate = new Promise<void>((r) => (release = r));
+    const pub = new GrowthDigestPublisher({
+      buildDigest: () => activeDigest(),
+      cron: '0 11 * * 1',
+      mode: 'live',
+      now: () => new Date('2026-06-10T17:30:00Z'),
+      send: async () => {
+        await gate; // hold the first cycle open
+        return { ok: true };
+      },
+      audit: (e) => audits.push(e),
+    });
+    const first = pub.publishOnce(new Date('2026-06-10T17:30:00Z'), 'cron');
+    const second = pub.publishOnce(new Date('2026-06-10T17:30:00Z'), 'cron'); // re-enters while first is mid-send
+    await second;
+    expect(audits.find((a) => a.action === 'skipped-overlap')).toBeDefined();
+    release();
+    await first;
+  });
+});
+
+// ── sanity-floor + start ─────────────────────────────────────────────────────
+
+describe('GrowthDigestPublisher.start — cadence sanity-floor', () => {
+  it('refuses to start a sub-hourly cadence', () => {
+    const onError = vi.fn();
+    const pub = new GrowthDigestPublisher({
+      buildDigest: () => activeDigest(),
+      cron: '*/30 * * * *', // 30-minute cadence — under the 1h floor
+      mode: 'live',
+      now: () => new Date('2026-06-10T17:30:00Z'),
+      onError,
+    });
+    pub.start();
+    expect(pub.isStarted()).toBe(false);
+    expect(onError).toHaveBeenCalledWith('start', expect.any(Error));
+    pub.stop();
+  });
+
+  it('starts a weekly cadence', () => {
+    const pub = new GrowthDigestPublisher({
+      buildDigest: () => activeDigest(),
+      cron: '0 11 * * 1',
+      mode: 'live',
+      now: () => new Date('2026-06-10T17:30:00Z'),
+      settleMs: 60_000,
+    });
+    pub.start();
+    expect(pub.isStarted()).toBe(true);
+    pub.stop();
+    expect(pub.isStarted()).toBe(false);
+  });
+});
+
+// ── missed-run catch-up ──────────────────────────────────────────────────────
+
+describe('GrowthDigestPublisher — missed-run catch-up', () => {
+  it('replays the most-recent missed window once on start, then is idempotent across restarts', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-06-10T17:30:00.000Z')); // Wed — last Mon 11:00 fire elapsed
+
+    const recorded = new Set<string>();
+    const audits: GrowthDigestAuditEntry[] = [];
+    const sends: string[] = [];
+    const mk = () =>
+      new GrowthDigestPublisher({
+        buildDigest: () => activeDigest(),
+        cron: '0 11 * * 1',
+        mode: 'live',
+        now: () => new Date('2026-06-10T17:30:00.000Z'),
+        send: async (t: string) => {
+          sends.push(t);
+          return { ok: true };
+        },
+        audit: (e) => {
+          audits.push(e);
+          if (e.window) recorded.add(e.window); // emulate the durable window record
+        },
+        recordedWindows: () => recorded,
+        settleMs: 1_000,
+      });
+
+    const pub1 = mk();
+    pub1.start();
+    await vi.advanceTimersByTimeAsync(1_200);
+    const catchup = audits.find((a) => a.trigger === 'catchup');
+    expect(catchup).toBeDefined();
+    expect(catchup!.action).toBe('sent');
+    expect(catchup!.window).toBeDefined();
+    expect(sends.length).toBe(1);
+    pub1.stop();
+
+    // Restart: the window is now in `recorded` → catch-up must NOT re-fire it.
+    const pub2 = mk();
+    pub2.start();
+    await vi.advanceTimersByTimeAsync(1_200);
+    expect(sends.length).toBe(1); // unchanged — no double-send across the restart
+    pub2.stop();
+  });
+});
+
+// ── formatDigest ─────────────────────────────────────────────────────────────
+
+describe('formatDigest — deterministic render', () => {
+  it('calm digest renders header + summary only', () => {
+    const text = formatDigest(calmDigest());
+    expect(text).toContain('📊 Growth check-in');
+    expect(text).toContain('All healthy');
+    expect(text).not.toContain('🔸');
+  });
+
+  it('single-rule digest renders the rule section + footer', () => {
+    const text = formatDigest(activeDigest([finding('R3', 'normal', 1)]));
+    expect(text).toContain('🔸 Stalling');
+    expect(text).toContain('R3 item 1');
+    expect(text).toContain('GET /growth/digest');
+  });
+
+  it('renders all six rules', () => {
+    const all: GrowthFinding[] = [
+      finding('R1', 'normal', 1),
+      finding('R2', 'normal', 1),
+      finding('R3', 'normal', 1),
+      finding('R4', 'low', 1),
+      finding('R5', 'low', 1),
+      finding('R6', 'normal', 1),
+    ];
+    const text = formatDigest(activeDigest(all));
+    for (const rule of ['R1', 'R2', 'R3', 'R4', 'R5', 'R6']) {
+      expect(text).toContain(`${rule} item 1`);
+    }
+  });
+
+  it('priority-never-truncate: a high-priority finding survives among 500 low ones, ≤4096 chars', () => {
+    const bulk = Array.from({ length: 500 }, (_, i) => finding('R3', 'low', i));
+    const high = finding('R3', 'high', 9999, 'CRITICAL — decide now.');
+    high.title = 'HIGH-PRIORITY SENTINEL';
+    const text = formatDigest(activeDigest([...bulk, high]));
+    expect(text).toContain('HIGH-PRIORITY SENTINEL'); // never dropped
+    expect(text.length).toBeLessThanOrEqual(4096);
+    expect(text).toContain('more (see full digest)'); // bulk overflowed
+  });
+
+  it('R1 (promote) and R6 (dev-gate-dark) are always rendered in full even amid bulk', () => {
+    const bulk = Array.from({ length: 50 }, (_, i) => finding('R3', 'low', i));
+    const promote = finding('R1', 'normal', 1);
+    promote.title = 'PROMOTE-ME';
+    const dark = finding('R6', 'normal', 1);
+    dark.title = 'DARK-GATE-ME';
+    const text = formatDigest(activeDigest([...bulk, promote, dark]));
+    expect(text).toContain('PROMOTE-ME');
+    expect(text).toContain('DARK-GATE-ME');
+  });
+
+  it('scrubs secret shapes from titles and details at the render boundary', () => {
+    const f = finding('R3', 'normal', 1, 'token=ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZ012345 here');
+    const text = formatDigest(activeDigest([f]));
+    expect(text).not.toContain('ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZ012345');
+    expect(text).toContain('REDACTED');
+  });
+
+  it('caps the low/normal bulk at K per rule with a "+N more" overflow line', () => {
+    const six = Array.from({ length: 6 }, (_, i) => finding('R3', 'normal', i));
+    const text = formatDigest(activeDigest(six), { perRuleCap: 5 });
+    expect(text).toContain('+1 more (see full digest)');
+    // exactly 5 bullet rows for R3
+    const bulletCount = text.split('\n').filter((l) => l.startsWith('• R3 item')).length;
+    expect(bulletCount).toBe(5);
+  });
+
+  it('renders the header date in the injected timezone', () => {
+    // 2026-06-09T02:00:00Z is Jun 8 18:00 in Los Angeles.
+    const d: GrowthDigest = { ...activeDigest(), generatedAt: '2026-06-09T02:00:00.000Z' };
+    expect(formatDigest(d, { timezone: 'UTC' })).toContain('Jun 9');
+    expect(formatDigest(d, { timezone: 'America/Los_Angeles' })).toContain('Jun 8');
+  });
+
+  it('caps each detail at the detailCap with an ellipsis', () => {
+    const long = 'x'.repeat(500);
+    const text = formatDigest(activeDigest([finding('R3', 'normal', 1, long)]), { detailCap: 50 });
+    expect(text).toContain('…');
+    expect(text).not.toContain('x'.repeat(60));
+  });
+});
+
+// ── default audit sink ───────────────────────────────────────────────────────
+
+describe('createGrowthDigestAuditSink', () => {
+  it('writes JSONL and reads back only window-bearing entries', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'gdp-audit-'));
+    const sink = createGrowthDigestAuditSink(dir);
+    sink.write({ ts: 't1', action: 'skipped-standby' }); // no window
+    sink.write({ ts: 't2', action: 'sent', window: '2026-06-08T11:00:00.000Z' });
+    sink.write({ ts: 't3', action: 'skipped-calm', window: '2026-06-15T11:00:00.000Z' });
+    const wins = sink.recordedWindows();
+    expect(wins.has('2026-06-08T11:00:00.000Z')).toBe(true);
+    expect(wins.has('2026-06-15T11:00:00.000Z')).toBe(true);
+    expect(wins.size).toBe(2); // the windowless entry is not counted
+    SafeFsExecutor.safeRmSync(dir, { recursive: true, force: true, operation: 'tests/unit/GrowthDigestPublisher.test.ts' });
+  });
+});

--- a/upgrades/next/proactive-growth-digest-publisher-slice2.md
+++ b/upgrades/next/proactive-growth-digest-publisher-slice2.md
@@ -1,0 +1,63 @@
+# The growth analyst can now proactively check in (ships dark)
+
+## What Changed
+
+The growth analyst (`GrowthMilestoneAnalyst`) has, since Slice 1, *computed* a full growth
+picture — stalling initiatives (R3), features that earned promotion (R1), incubation
+windows that expired unproven (R2), spec approve-vs-change patterns (R4), recurring
+corrections (R5), and dev-gate conformance (R6) — but nothing ever *sent* it. This slice
+adds the voice: `GrowthDigestPublisher` (`src/monitoring/GrowthDigestPublisher.ts`), an
+in-process component that, on the existing `monitoring.growthAnalyst.digestCron` cadence
+(default Monday 11:00), formats ONE consolidated "growth check-in" and routes it to the
+Agent Updates topic through the same flood-guarded path `/telegram/post-update` uses.
+
+To guarantee the publisher cannot bypass the dedup/budget/tone guards, the change carves a
+pure `res`-free `evaluateOutbound` funnel out of `checkOutboundMessage` and adds a
+`postToUpdatesTopic` helper the route and the publisher both share — one guarded chokepoint,
+not two. Hardening from the 8-reviewer convergence: a multi-machine lease gate (`isAwake`)
+so an in-process cron never double-sends on a paired agent, calm-week silence by default,
+missed-run catch-up (idempotent on the window ISO), a cadence sanity-floor, an in-flight
+guard, and a render-boundary secret-scrub with high-priority findings never abbreviated.
+
+It ships **dark**: `monitoring.growthAnalyst.digestDelivery` defaults to `'off'` — even on a
+development agent — so merging the code sends nothing. The rollout path is
+`off → dry-run (logs the would-send sample to logs/growth-digest.jsonl) → live`, opt-in by
+the operator, dogfooded on Echo first. The fleet stays off.
+
+## What to Tell Your User
+
+Nothing changes yet — this ships off by default, so no message is sent when it merges. Once
+you ask me to turn it on, I'll start in a quiet "show me what you'd send" mode and only go
+live once you're happy with a sample. From then on I post one short weekly growth check-in to
+your Agent Updates topic: a consolidated summary of what's waiting on you, what's ready to
+promote, and what's drifting — never a wall of items (big lists collapse to the top few with
+a "plus N more"), and I stay silent on a fully-calm week unless you ask me to send a steady
+heartbeat. I can only send the message or stay quiet — I never block or rewrite anything. You
+can also just ask me for the same picture on demand any time.
+
+## Summary of New Capabilities
+
+- `GrowthDigestPublisher` — cadenced, lease-gated, deterministic-format proactive growth
+  check-in to the Agent Updates topic (ships dark behind `digestDelivery`).
+- `monitoring.growthAnalyst.digestDelivery` (`off` | `dry-run` | `live`, default `off`),
+  `digestSendOnCalmWeeks` (default `false`), `digestTimezone` (default `UTC`).
+- A shared, `res`-free `evaluateOutbound` outbound-guard funnel + `postToUpdatesTopic`
+  helper — one chokepoint the route and the publisher both pass through.
+
+## Evidence
+
+- `src/monitoring/GrowthDigestPublisher.ts` — the publisher, pure `formatDigest`, and the
+  `logs/growth-digest.jsonl` audit sink.
+- `src/server/routes.ts` — `evaluateOutbound` (pure funnel), `checkOutboundMessage` (thin
+  adapter), `postToUpdatesTopic` (the publisher's guarded sender), `attachSender` hookup.
+- `src/server/AgentServer.ts` — construction gate (`analyst && digestDelivery !== 'off'`),
+  lease gate (`isAwake`), `.stop()` teardown.
+- 3-tier tests + wiring-integrity + burst-invariant: `tests/unit/GrowthDigestPublisher.test.ts`
+  (21), `tests/integration/growth-digest-publisher{,-wiring}.test.ts` (10),
+  `tests/e2e/growth-digest-publisher-lifecycle.test.ts` (3), and the growth-digest aggregation
+  block added to `tests/integration/notification-flood-burst-invariant.test.ts`.
+- The pre-existing outbound-guard route suites (`post-update-gate-budget-route`,
+  `localhost-link-guard-route`, `outbound-content-dedup-route`, `outbound-gate-budget`) pass
+  unchanged — the `evaluateOutbound` extraction is behavior-preserving.
+- Side-effects review: `upgrades/side-effects/proactive-growth-digest-publisher-slice2.md`.
+- Spec: `docs/specs/PROACTIVE-GROWTH-DIGEST-PUBLISHER-SLICE2-SPEC.md` (converged + approved).

--- a/upgrades/side-effects/proactive-growth-digest-publisher-slice2.md
+++ b/upgrades/side-effects/proactive-growth-digest-publisher-slice2.md
@@ -1,0 +1,201 @@
+# Side-Effects Review — Proactive Growth Digest Publisher (Slice 2)
+
+**Version / slug:** `proactive-growth-digest-publisher-slice2`
+**Date:** `2026-06-10`
+**Author:** `echo`
+**Second-pass reviewer:** `not required (Tier 2 — converged + approved spec, 8-reviewer panel, 3 iterations)`
+
+## Summary of the change
+
+Adds `GrowthDigestPublisher` (`src/monitoring/GrowthDigestPublisher.ts`): an in-process
+component that consumes the existing `monitoring.growthAnalyst.digestCron` and, on that
+cadence, formats ONE consolidated "growth check-in" from the already-computed
+`GrowthMilestoneAnalyst.buildDigest()` and routes it through the existing flood-guarded
+post-update path. It is the cadence + delivery half (Slice 2) of the growth analyst;
+Slice 1 (compute + read routes) already shipped. To give the publisher a delivery path
+that provably cannot bypass the dedup/budget/tone guards, the change carves a pure,
+`res`-free `evaluateOutbound` funnel out of `checkOutboundMessage` in
+`src/server/routes.ts` and adds a `postToUpdatesTopic` helper both the route and the
+publisher share. New config keys (`digestDelivery`, `digestTimezone`,
+`digestSendOnCalmWeeks`) land in `ConfigDefaults.ts` + `types.ts`; wiring + teardown in
+`AgentServer.ts`. Ships dark (`digestDelivery: 'off'` by default, even on a dev agent).
+
+## Decision-point inventory
+
+- `evaluateOutbound` (`src/server/routes.ts`) — **add** — pure res-free extraction of the
+  localhost-link guard + tone-gate decision out of `checkOutboundMessage`. Both the route
+  adapter and the publisher's `postToUpdatesTopic` call this single function.
+- `checkOutboundMessage` (`src/server/routes.ts`) — **modify** — now a thin route adapter:
+  fires the two observe-only observers (route-side) + delegates the decision to
+  `evaluateOutbound` + maps the decision to res. Behavior byte-identical for callers.
+- `postToUpdatesTopic` (`src/server/routes.ts`) — **add** — the publisher's guarded sender:
+  resolve Updates topic → `evaluateOutbound` → `sendToTopic`. Returns a flat DeliveryResult.
+- `GrowthDigestPublisher.publishOnce` — **add** — the lease-gate → mode → in-flight →
+  calm → format → deliver decision chain. The publisher holds NO authority: it only sends
+  a message or stays quiet; a guard block is a normal, non-error outcome it never re-acts on.
+- `digestDelivery` / `digestSendOnCalmWeeks` / `digestTimezone` config — **add** — the
+  rollout + cadence dials under `monitoring.growthAnalyst`.
+
+---
+
+## 1. Over-block
+
+**What legitimate inputs does this change reject that it shouldn't?**
+
+The `evaluateOutbound` extraction preserves the EXACT block/allow logic of the prior
+`checkOutboundMessage` (localhost-link guard + tone gate). No new block surface is added;
+the decision function returns the same 422 bodies for the same inputs (verified by the
+existing `post-update-gate-budget-route`, `localhost-link-guard-route`, and
+`outbound-content-dedup-route` suites — all 20 tests pass unchanged). The publisher itself
+adds no block/allow surface — it is a sender, not a gate. Over-block: not applicable to the
+new code; preserved for the refactored code.
+
+---
+
+## 2. Under-block
+
+**What failure modes does this still miss?**
+
+The publisher's bounded multi-machine handoff edge (§3.7): if a lease handoff falls between
+a window's fire time and the newly-awake machine's `.start()`/catch-up, that one window can
+be re-sent once (the per-machine audit log has no record of the old machine's send). This is
+a deliberately-accepted under-guard in the SAFE direction — a single bounded re-send through
+the same aggregating/budgeted/deduped funnel, biased toward "the check-in arrives" over
+"silently dropped," which is the slice's entire reason to exist. The near-simultaneous case
+is absorbed by the shared `evaluateOutbound` dedup. No new under-block in the message-gate
+logic (the refactor is behavior-preserving).
+
+---
+
+## 3. Level-of-abstraction fit
+
+**Is this at the right layer?**
+
+Correct layers. The publisher is a thin cadence/delivery wrapper (low-level orchestration)
+that DELEGATES the block/allow decision to the existing smart gate via the shared
+`evaluateOutbound` — it does not re-implement guarding. The formatter is a pure render with
+no decision authority (the analyst already decided what crosses a rule). The funnel
+extraction is specifically a level-of-abstraction fix: it ensures the publisher FEEDS the
+existing chokepoint rather than running a parallel un-guarded `sendToTopic`. The two
+observe-only observers (`observeSelfViolation`, `observePrincipalCoherence`) deliberately
+stay route-side, not in `evaluateOutbound` — they have nothing to catch on a proactive
+digest (it credits no operator role and is authored by no principal), so keeping them out
+of the shared funnel both preserves byte-identical caller behavior and avoids meaningless
+telemetry.
+
+---
+
+## 4. Signal vs authority compliance
+
+**Required reference:** [docs/signal-vs-authority.md](../../docs/signal-vs-authority.md)
+
+**Does this change hold blocking authority with brittle logic?**
+
+- [x] No — this change has no block/allow surface (the publisher is a sender; the
+  refactored `evaluateOutbound` keeps the SAME smart gate — `messagingToneGate`, an
+  LLM-backed authority with recent conversational context — as the sole decider).
+
+The publisher produces a message or stays silent; it never blocks, delays, or rewrites
+anything. The §3.5 superseded-job belt is a SIGNAL (an audit line), never a cross-component
+mutation — the publisher never disables another component's job. The funnel extraction
+keeps the single smart authority (`messagingToneGate`) and merely makes the publisher route
+through it rather than around it. No brittle detector gains block authority.
+
+---
+
+## 5. Interactions
+
+**Does this interact with existing checks, recovery paths, or infrastructure?**
+
+- **Shadowing:** `evaluateOutbound` runs the same localhost-guard-then-tone-gate order as
+  before; `checkOutboundMessage` still fires the two observers FIRST (route-side), so no
+  existing route caller's observation is shadowed. The publisher path intentionally does NOT
+  fire those observers (nothing to catch) — confirmed not relied on for the digest path.
+- **Double-fire:** the in-process cron runs on BOTH the awake and standby machine → the
+  lease gate (`isAwake`) ensures only the awake machine sends (mirrors the
+  scheduler/ActivitySentinel precedent the superseded `initiative-digest-review` relied on).
+  The superseded job + the publisher both fire `0 11 * * 1` — handled by §3.5 (durable
+  source-template disable at the live-flip, NOT at this dark merge; while `digestDelivery`
+  is `off`/`dry-run` the publisher doesn't send, so the job stays the sole voice).
+- **Races:** the in-flight guard + croner `protect:true` prevent overlapping `publishOnce`
+  passes. The audit log is the single shared state; window-key idempotency is recorded only
+  on a real post-lease decision.
+- **Feedback loops:** none — the digest reads analyst state and emits one message; it feeds
+  no system that feeds back into the analyst.
+
+---
+
+## 6. External surfaces
+
+**Does this change anything visible outside the immediate code path?**
+
+- **Other agents on the same machine:** none — internal component, no shared external state.
+- **Install base:** none at merge — ships `digestDelivery: 'off'`; existing agents get the
+  three new config defaults via `applyDefaults` add-missing-only deep-merge (no migrateConfig
+  needed, matching the rest of the `growthAnalyst` block). No CLAUDE.md template change at
+  this dark merge (it rides the live-flip per the Agent Awareness Standard, parent §9).
+- **External systems (Telegram):** only when an operator flips `digestDelivery` to
+  `dry-run`/`live` — and then it sends ONE message into the EXISTING Agent Updates topic via
+  the same guarded path as `/telegram/post-update`. Never a new topic, never per-finding.
+- **Persistent state:** a new append-only audit log at `logs/growth-digest.jsonl`
+  (best-effort, never throws). No DB, no schema change.
+- **Timing:** the weekly cron + a 60s settle-delayed catch-up; the cadence sanity-floor
+  refuses a sub-hourly `digestCron`.
+
+---
+
+## 7. Rollback cost
+
+**If this turns out wrong in production, what's the back-out?**
+
+Pure code change shipping dark — revert and ship a patch. No persistent state needs cleanup
+(`logs/growth-digest.jsonl` is an inert append-only log; leaving it is harmless). No agent
+state repair (the publisher is simply not constructed when `digestDelivery: 'off'`). No
+user-visible regression during the rollback window, because at merge nothing is sent
+(default off). The `evaluateOutbound` extraction is behavior-preserving and covered by the
+pre-existing route suites, so reverting it carries no caller-facing risk either.
+
+---
+
+## Conclusion
+
+This review found no new block/allow surface and no signal-vs-authority violation: the
+publisher is a sender that delegates every guard decision to the existing smart gate via a
+deliberately-extracted single funnel, closing off the "second un-guarded send path" the
+review flagged in the draft. The multi-machine double-send (the one SERIOUS finding from
+convergence) is fixed by the lease gate; the bounded handoff re-send is an accepted,
+SAFE-direction tradeoff. The change ships dark with zero user-facing surface at merge, so
+rollback is a plain revert. Clear to ship.
+
+---
+
+## Second-pass review (if required)
+
+**Reviewer:** not required
+
+The change carries a converged + approved Tier-2 spec
+(`docs/specs/PROACTIVE-GROWTH-DIGEST-PUBLISHER-SLICE2-SPEC.md`) reviewed by an 8-reviewer
+panel (security, scalability, adversarial, integration, lessons-aware + gemini) over 3
+iterations; the convergence report is the independent-read record.
+
+---
+
+## Evidence pointers
+
+- `src/monitoring/GrowthDigestPublisher.ts` — the publisher + pure `formatDigest` +
+  `createGrowthDigestAuditSink`.
+- `src/server/routes.ts` — `evaluateOutbound` (pure funnel), `checkOutboundMessage`
+  (thin adapter), `postToUpdatesTopic` (publisher sender), `attachSender` hookup.
+- `src/server/AgentServer.ts` — construction gate (`analyst && digestDelivery !== 'off'`),
+  lease gate (`isAwake`), `.stop()` teardown.
+- `tests/unit/GrowthDigestPublisher.test.ts` — 21 tests (publishOnce matrix, lease gate,
+  in-flight guard, missed-run catch-up idempotency, sanity-floor, formatter guarantees).
+- `tests/integration/growth-digest-publisher.test.ts` +
+  `tests/integration/growth-digest-publisher-wiring.test.ts` — guarded delivery + single-
+  funnel + sender-not-a-no-op + lease-gate wiring (10 tests).
+- `tests/e2e/growth-digest-publisher-lifecycle.test.ts` — boots the real AgentServer:
+  LIVE lands one check-in in the Updates topic; OFF / no-analyst → publisher null (3 tests).
+- `tests/integration/notification-flood-burst-invariant.test.ts` — 500-finding burst → one
+  bounded message, high-priority finding rendered in full.
+- `npm run lint` clean (incl. dev-agent-dark-gate); analyst + ConfigDefaults regression
+  suites green (80 tests).


### PR DESCRIPTION
## ELI16 — the growth analyst can finally talk

Echo has a "growth analyst" that quietly watches your projects — what's stalling, which dark feature has earned its way to "turn it on," how often you change a spec the same way, how often you correct Echo. It computes all of that but never *tells* you anything. This change adds the voice: a small component that, on a weekly schedule, takes that already-computed picture, writes ONE short "growth check-in," and posts it to your Agent Updates topic on Telegram. It can only ever send a message or stay quiet — it never blocks or rewrites anything. It ships off; you turn it on when you want it (with a "show me a sample first" dry-run step), big lists collapse to the top few with a "plus N more," and a fully-calm week stays silent by default.

## What & why

Slice 2 of the proactive growth analyst. Slice 1 (`GrowthMilestoneAnalyst`) computes the full growth picture (R1–R6: stalling initiatives, promote-ready features, expired-unproven incubations, spec approve-vs-change patterns, recurring corrections, dev-gate conformance) but **nothing ever sent it**. This adds the voice: `GrowthDigestPublisher` formats ONE consolidated weekly "growth check-in" and routes it to the Agent Updates topic through the existing flood-guarded path.

Origin: Justin, 2026-06-06 — *"I have YET to have an agent proactively check in with me about ANY of these."* (CMT-1151). Parent-principle: **Close the Loop** (re-surface open loops on a cadence until deliberately closed).

## Design highlights (hardened by the 8-reviewer convergence)

- **Single guarded funnel** — carves a pure `res`-free `evaluateOutbound` out of `checkOutboundMessage`; the route and the publisher's `postToUpdatesTopic` share ONE dedup/budget/tone chokepoint (no second un-guarded send path).
- **Multi-machine lease gate** (`isAwake`) — an in-process cron runs on awake + standby; only the lease-holder sends (the superseded `initiative-digest-review` was scheduler-lease-gated and this must not silently drop that).
- **Calm weeks silent by default** (`digestSendOnCalmWeeks: false`) — no "all healthy" heartbeat noise.
- Missed-run catch-up (idempotent on the window ISO), cadence sanity-floor (refuses sub-hourly), in-flight guard, render-boundary secret-scrub, high-priority findings never abbreviated, aggregation cap with "+N more".

## Rollout — ships dark

`monitoring.growthAnalyst.digestDelivery` defaults to `'off'` even on a dev agent. Path: `off → dry-run` (logs the would-send sample to `logs/growth-digest.jsonl`) `→ live`, dogfooded on Echo first. Fleet stays off.

## Tests

- Unit (21): publishOnce matrix, lease gate, in-flight guard, missed-run catch-up idempotency, sanity-floor, formatter guarantees.
- Integration + wiring (10): guarded delivery, single-funnel, sender-not-a-no-op, lease-gate wiring + the `/telegram/post-update` regression.
- E2E (3): boots the real AgentServer — LIVE lands one check-in in the Updates topic; OFF / no-analyst → publisher null.
- Burst-invariant: 500 findings → one bounded message, high-priority rendered in full.
- Pre-existing outbound-guard route suites pass unchanged (the `evaluateOutbound` extraction is behavior-preserving).

Spec: `docs/specs/PROACTIVE-GROWTH-DIGEST-PUBLISHER-SLICE2-SPEC.md` (converged, 3 iterations + operator-approved). Side-effects review: `upgrades/side-effects/proactive-growth-digest-publisher-slice2.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
