### PR TITLE
fix(spec-converge): report-backed converging audit + formal convergence-gate tag-format bug (spec #4)

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,14 @@
 npm run lint
+
+# Report-Backed Converging Audit (docs/specs/CONVERGING-AUDIT-DEFAULT.md, Part B).
+# The precommit script reads no config (it runs pre-compile), so we export the
+# specReview.requireConvergenceReport flag as an env var here. Fail-open: any read
+# error leaves the var unset → the precommit's report branch stays inert (today's
+# behavior). Reads .instar/config.json first, then instar.config.json.
+if node -e 'const fs=require("fs");for(const p of [".instar/config.json","instar.config.json"]){try{const c=JSON.parse(fs.readFileSync(p,"utf8"));if(c&&c.specReview&&c.specReview.requireConvergenceReport===true)process.exit(0)}catch{}}process.exit(1)' 2>/dev/null; then
+  export INSTAR_DEV_REQUIRE_CONVERGENCE_REPORT=1
+fi
+
 node scripts/instar-dev-precommit.js
 node scripts/check-rule3-coverage.cjs
 node scripts/protect-migration-guarantee.js

--- a/.instar/instar-dev-decisions/2026-06-10T19-04-09-614Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-06-10T19-04-09-614Z-unknown.json
@@ -1,0 +1,15 @@
+{
+  "ts": "2026-06-10T19:04:09.614Z",
+  "slug": "unknown",
+  "suggestedTier": 2,
+  "declaredTier": 2,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "new capability: new config key added"
+  ],
+  "belowFloor": false,
+  "files": 6,
+  "loc": 258,
+  "causalAutopsy": null,
+  "verdict": "pass"
+}

--- a/.instar/instar-dev-decisions/2026-06-10T19-05-34-940Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-06-10T19-05-34-940Z-unknown.json
@@ -1,0 +1,15 @@
+{
+  "ts": "2026-06-10T19:05:34.940Z",
+  "slug": "unknown",
+  "suggestedTier": 2,
+  "declaredTier": 2,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "new capability: new config key added"
+  ],
+  "belowFloor": false,
+  "files": 6,
+  "loc": 258,
+  "causalAutopsy": null,
+  "verdict": "pass"
+}

--- a/.instar/instar-dev-decisions/2026-06-10T19-20-55-199Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-06-10T19-20-55-199Z-unknown.json
@@ -1,0 +1,15 @@
+{
+  "ts": "2026-06-10T19:20:55.199Z",
+  "slug": "unknown",
+  "suggestedTier": 2,
+  "declaredTier": 2,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "new capability: new config key added"
+  ],
+  "belowFloor": false,
+  "files": 6,
+  "loc": 258,
+  "causalAutopsy": null,
+  "verdict": "pass"
+}

--- a/docs/specs/CONVERGING-AUDIT-DEFAULT.md
+++ b/docs/specs/CONVERGING-AUDIT-DEFAULT.md
@@ -1,0 +1,168 @@
+---
+title: "Report-Backed Converging Audit — the Default Convergence Gate"
+slug: "converging-audit-default"
+author: "echo"
+parent-principle: "Iterative Audit to Convergence"
+eli16-overview: "converging-audit-default.eli16.md"
+status: "approved"
+approved: true
+project: "cartographer-conformance"
+spec_number: 4
+depends-on: "spec-converge skill, StageTransitionValidator, instar-dev-precommit gate"
+review-convergence: "2026-06-10T18:10:05Z"
+review-iterations: 1
+review-completed-at: "2026-06-10T18:10:05Z"
+---
+
+# Report-Backed Converging Audit — the Default Convergence Gate
+
+> Spec #4 of `cartographer-conformance`. Goal (operator): "make the
+> iterative-converging-audit the default path — not just the formal initiative
+> state machine." Grounding the goal against real code revealed two things:
+> **(1) a genuine BUG** — the formal convergence gate is broken; **(2)** convergence
+> is ALREADY effectively required for any spec that ships code (the instar-dev
+> precommit gate blocks an un-converged spec). So the real, valuable work is not
+> *new* enforcement — it is making the gate **correct, consistent, and
+> report-backed** (proving the converging audit actually RAN, not that a tag was
+> hand-added).
+
+## Problem statement (grounded, verified against source)
+
+The convergence gate exists in two places that DISAGREE:
+
+1. **`StageTransitionValidator`** (the formal initiative state machine, behind
+   `POST /projects/:id/advance`) blocks `spec-drafted → spec-converged` unless
+   `data['review-convergence'] === true` — a **boolean** (`StageTransitionValidator.ts:155`).
+   But the canonical converging-audit tooling (`skills/spec-converge/scripts/
+   write-convergence-tag.mjs:175`) writes `review-convergence: "<ISO timestamp>"` — a
+   **string**. So `"2026-06-10T…" !== true` and the formal gate **REJECTS every
+   properly-converged spec**. The formal convergence gate is broken for real specs.
+   (Verified: lines quoted above.)
+
+2. **The instar-dev precommit gate** (`scripts/instar-dev-precommit.js`, the ad-hoc
+   path that blocks a commit touching source) recognizes `review-convergence` via a
+   lenient regex — it accepts the timestamp (so it is NOT broken), but it accepts
+   ANY truthy value, including a hand-added tag with **no convergence report behind
+   it**. "Converged" there can mean "added a tag," not "ran the audit."
+
+So: the formal gate is **broken**, the two gates are **inconsistent**, and neither
+verifies that the converging audit ACTUALLY RAN (its report artifact exists).
+
+## Proposed design
+
+### Part A — Fix the formal gate's tag-format bug (unconditional)
+
+`StageTransitionValidator`'s `spec-drafted → spec-converged` check accepts the
+**canonical convergence tag**: a non-empty `review-convergence` value that is either
+the ISO-timestamp string the tooling writes OR boolean `true` (back-compat). A new
+pure recognizer `isConvergenceTagPresent(value)` (a tiny, dependency-free predicate)
+is the single definition of "the tag is present," exported from the validator's
+module and unit-tested against both formats + the empty/false cases. This fixes the
+formal gate so it can advance a real converged spec.
+
+### Part B — Make the converging audit the DEFAULT by requiring its REPORT (dark-flagged)
+
+The converging audit's real proof-of-work is its **report** at
+`docs/specs/reports/<slug>-convergence.md` (written by the spec-converge skill,
+Phase 5). Requiring the tag without the report lets a spec fake convergence. So:
+
+- A new config flag **`specReview.requireConvergenceReport`** (default **false** —
+  current behavior, dark-safe) added to `ConfigDefaults` beside the existing
+  `specReview.conformance` block (deep-merge backfill).
+- **The precommit `.js` reads the flag via an ENV VAR, not config** (verified at
+  convergence: the precommit script reads NO config file and runs pre-compile, so it
+  cannot import the TS config loader). Thread it as
+  `process.env.INSTAR_DEV_REQUIRE_CONVERGENCE_REPORT === '1'`, mirroring the existing
+  in-file `INSTAR_DEV_ALLOW_ORPHAN_DEFERRALS === '1'` pattern. The husky `.husky/
+  pre-commit` hook exports it from config (a one-line read), so config remains the
+  source of truth while the script stays config-loader-free. When unset, the new
+  precommit branch never executes → byte-identical to today.
+- **The formal validator's report check stays UNCONDITIONAL** (verified: it ALREADY
+  requires the report via `CONVERGENCE_REPORT_MISSING`, independent of any flag). Part
+  B does NOT flag-gate that existing check (doing so would WEAKEN the formal gate).
+  The flag's effect is therefore asymmetric and additive: it adds a report check ONLY
+  to the **precommit** gate, bringing it UP to the formal gate's strictness when on.
+- **Tier-1 exemption (verified):** the precommit has a `tier1-lite` path that exits
+  BEFORE the convergence/approval check (a Tier-1 commit needs no converged spec). The
+  new report check sits in the same Step-6 (tier-2/3) region, so it correctly does NOT
+  apply to Tier-1 commits — and the consistency test (Part C) scopes its precommit
+  fixtures to the tier-2/3 path.
+
+### Part C — Gate consistency (Structure beats Willpower)
+
+The precommit gate (a pre-compile `.js`, so it CANNOT import the TS validator) and
+the TS validator must AGREE on "is this spec converged?". They cannot share a TS
+module across the compile boundary, so consistency is enforced **by a test**, not by
+hope: a unit test feeds a shared table of spec-frontmatter fixtures (timestamp tag /
+boolean tag / no tag / report-present / report-missing) to BOTH the validator's
+`isConvergenceTagPresent` + report check AND the precommit's recognition logic, and
+asserts they return the SAME converged verdict for every fixture (under both flag
+states). A drift between the two gates fails CI. (The precommit's recognition is
+factored into a tiny pure exported function so the test can call it directly.)
+
+### Part D — Surface the cross-model-review status (observe-only)
+
+The converging audit records a `cross-model-review` frontmatter flag
+(`codex-cli:<model>` | `degraded-all-rounds` | `unavailable` | `skipped-abbreviated`).
+The gates' diagnostic output SURFACES this value (e.g. "converged — cross-model:
+unavailable") so an operator/agent sees whether external review actually ran — never
+blocking on it (Signal vs. Authority), just making the audit's depth visible.
+
+## Security & data-egress
+
+None — this is a build-time gate change. No network, no LLM in the gate path
+(the converging audit's LLM calls are upstream, in the spec-converge skill). The
+report-existence check is a local `fs.existsSync`.
+
+## Migration & Deployment / Agent Awareness
+
+- **Config:** `specReview.requireConvergenceReport` (default false) added to
+  `ConfigDefaults` `SHARED_DEFAULTS` (deep-merge backfill; existence-checked).
+- **Not an agent-facing capability:** the convergence gate is a dev-process gate
+  (precommit hook + the formal state machine), NOT a user-invokable runtime
+  capability — so no CLAUDE.md template / migrateClaudeMd section is required (the
+  feature-completeness test only governs agent-facing capabilities). No new route.
+- **Back-compat (critical — this gate ships every commit):** with the flag default
+  false, the precommit gate's behavior is **byte-identical to today** (the report
+  requirement is inert) — verified by a test that the default path accepts a
+  timestamp-tagged, approved spec with no report (today's specs). The formal-gate
+  bug-fix is purely additive (it accepts MORE than before — the timestamp it should
+  always have accepted — and never less).
+- **Rollback:** the flag default-false IS the rollback; no migration reversal.
+
+## Test plan (3 tiers)
+
+- **Tier 1 (unit):**
+  - `isConvergenceTagPresent`: true for a timestamp string + boolean true; false for
+    empty / false / missing.
+  - **StageTransitionValidator bug-fix**: a spec with `review-convergence:
+    "<timestamp>"` + a present report now PASSES `spec-drafted → spec-converged`
+    (previously rejected); a spec with no tag still fails; a spec with the tag but a
+    MISSING report fails (the existing `CONVERGENCE_REPORT_MISSING` path).
+  - **precommit recognition (pure fn)**: accepts a timestamp-tagged + approved spec
+    with the flag off (today's behavior); with the flag ON, rejects the same spec if
+    its report is missing, accepts it if the report exists.
+  - **gate-consistency**: the shared fixture table yields IDENTICAL converged
+    verdicts from the validator path and the precommit path, under both flag states.
+- **Tier 2 (integration):** `POST /projects/:id/advance` advances a real
+  timestamp-tagged + reported child spec from `spec-drafted → spec-converged`
+  (proving the bug-fix works through the real route) — mirror an existing `/advance`
+  test; and is still blocked when the report is missing.
+- **Tier 3 (E2E):** run the REAL `scripts/instar-dev-precommit.js` (as the hook does)
+  in a fixture repo: with the flag off, a timestamp-tagged+approved spec + staged
+  source commits cleanly; with `requireConvergenceReport` on, the same commit is
+  BLOCKED until the report file is present. Proves the shipped gate behaves correctly
+  end-to-end under both flag states.
+
+## Open questions (resolved by decision)
+
+- **(Resolved — decided)** Consistency enforced by a cross-gate test, not a shared TS
+  module (the precommit runs pre-compile and cannot import TS).
+- **(Resolved — dark-safe)** Report requirement ships behind a default-false flag;
+  today's workflow is unchanged until an operator opts in.
+- **(Resolved — out of scope)** Auto-registering ad-hoc specs into the formal
+  InitiativeTracker, and a proactive session-start un-converged-spec nudge, are
+  larger workflow changes not owed here — the bug-fix + report-backing + consistency
+  are the grounded, valuable core. The cross-model-review *default-on* enforcement is
+  also out of scope (cross-model availability is host-dependent; forcing it would
+  block on a missing codex login — Signal vs. Authority keeps it observe-only).

--- a/docs/specs/converging-audit-default.eli16.md
+++ b/docs/specs/converging-audit-default.eli16.md
@@ -1,0 +1,57 @@
+# Report-Backed Converging Audit — Plain-English Overview
+
+## The one-sentence version
+
+Fix the broken check that's supposed to confirm a design doc was properly reviewed,
+and make "properly reviewed" mean the review actually ran (and left its report) — not
+that someone just typed a tag.
+
+## Why we need it
+
+Before any design (a "spec") turns into shipped code, it's supposed to go through a
+converging review — multiple angles, until no new problems turn up. Two separate
+guards are supposed to enforce that. Grounding the work against the real code turned
+up a genuine, quietly-broken guard:
+
+- The **formal** guard checks for a review tag that equals the word `true`. But the
+  actual review tool writes a **timestamp** instead. A timestamp isn't the word
+  `true`, so the formal guard **rejects every properly-reviewed spec** — it's been
+  broken.
+- The **commit-time** guard isn't broken, but it's loose: it accepts any review tag at
+  all, even one a person typed by hand with no real review behind it.
+
+So one guard is broken, the two disagree, and neither confirms the review *actually
+happened*.
+
+## How it works
+
+1. **Fix the broken guard.** Accept the timestamp the real tool writes (and still
+   accept the old `true`, so nothing else breaks). One tiny shared definition of "the
+   review tag is present," used everywhere and tested against every form.
+2. **Make it mean something.** Add an opt-in switch: when it's on, both guards also
+   require the review's **report file** to exist — the proof the review actually ran,
+   not just a tag. That makes the real, report-backed review the default standard.
+3. **Keep the two guards honest with each other.** The commit-time guard is a script
+   that runs before the code is even compiled, so it can't share code with the formal
+   guard. Instead a test feeds the same examples to both and fails the build if they
+   ever disagree — so they can't quietly drift apart.
+
+## What changed for users
+
+Almost nothing, unless you turn the switch on — it ships **off by default**, and with
+it off, today's commit workflow behaves exactly as before. The only unconditional
+change is the bug fix, which only makes the formal guard accept the reviews it should
+always have accepted. Turn the switch on and the standard tightens: a spec counts as
+reviewed only when its review report is actually there.
+
+## The main tradeoffs
+
+- **Don't break the thing that ships everything.** The commit guard runs on every
+  commit, so a mistake there could block all work. The report requirement is behind an
+  off-by-default switch, and there's an end-to-end test proving the default path still
+  commits cleanly.
+- **Two guards, one truth.** They can't literally share code (one runs before
+  compilation), so a test enforces that they always agree — structure, not willpower.
+- **Surface, don't force.** Whether an outside model also reviewed the spec is shown,
+  not required — forcing it would block anyone whose outside-model tool isn't logged
+  in, which isn't the point.

--- a/scripts/instar-dev-precommit.js
+++ b/scripts/instar-dev-precommit.js
@@ -31,6 +31,15 @@ import { fileURLToPath } from 'node:url';
 import { checkEli16Overview, MIN_ELI16_CHARS } from './eli16-overview-check.mjs';
 import { verifyProposalDerivedRunbooks } from '../skills/instar-dev/scripts/verify-proposal-derived-runbook.mjs';
 import { classifyTier, decideRequirementSet } from './lib/classify-tier.mjs';
+import { recognizeConvergence } from './lib/convergence-recognition.mjs';
+
+// Report-Backed Converging Audit (docs/specs/CONVERGING-AUDIT-DEFAULT.md, Part B).
+// The precommit reads NO config file and runs pre-compile, so it cannot import
+// the TS config loader. The flag specReview.requireConvergenceReport is threaded
+// in as an ENV VAR by the .husky/pre-commit hook, mirroring the existing in-file
+// INSTAR_DEV_ALLOW_ORPHAN_DEFERRALS pattern. When unset, the new report-backing
+// branch never runs → byte-identical to today's precommit behavior.
+const REQUIRE_CONVERGENCE_REPORT = process.env.INSTAR_DEV_REQUIRE_CONVERGENCE_REPORT === '1';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -521,10 +530,34 @@ if (!specFmMatch) {
   );
 }
 const specFm = specFmMatch[1];
-const convergenceMatch = specFm.match(/^\s*review-convergence\s*:\s*["']?([^"'\n]+)/m);
-const approvedMatch = specFm.match(/^\s*approved\s*:\s*(true|"true"|'true')/m);
 
-if (!convergenceMatch) {
+// Convergence / approval / report recognition is factored into a pure,
+// dependency-free module (scripts/lib/convergence-recognition.mjs) that a unit
+// test cross-checks against the TS validator's `isConvergenceTagPresent` —
+// keeping the two gates in agreement (CONVERGING-AUDIT-DEFAULT.md, Part C). The
+// report-existence input depends on the spec's slug + the env flag, computed
+// just below; the recognizer does no I/O of its own.
+
+// Slug → report path, matching StageTransitionValidator's derivation exactly.
+const specSlugMatch = specFm.match(/^\s*slug\s*:\s*["']?([a-z0-9][a-z0-9-]{0,63})["']?\s*$/m);
+const specSlug = specSlugMatch ? specSlugMatch[1] : '';
+const convergenceReportRel = specSlug
+  ? path.join('docs/specs/reports', `${specSlug}-convergence.md`)
+  : '';
+// Only probe the filesystem when the report requirement is actually on. With
+// the flag unset, reportExists stays false but is never consulted (the
+// recognizer's reportBacked is vacuously true), so this branch is byte-inert.
+const convergenceReportExists =
+  REQUIRE_CONVERGENCE_REPORT && convergenceReportRel
+    ? fs.existsSync(path.resolve(ROOT, convergenceReportRel))
+    : false;
+
+const recognition = recognizeConvergence(specFm, {
+  requireReport: REQUIRE_CONVERGENCE_REPORT,
+  reportExists: convergenceReportExists,
+});
+
+if (!recognition.converged) {
   blockCommit(
     inScopeFiles,
     [
@@ -534,7 +567,7 @@ if (!convergenceMatch) {
   );
 }
 
-if (!approvedMatch) {
+if (!recognition.approved) {
   blockCommit(
     inScopeFiles,
     [
@@ -544,6 +577,35 @@ if (!approvedMatch) {
     ].join('\n'),
   );
 }
+
+// ── Report-backing (Part B — dark, env-gated) ──
+// When INSTAR_DEV_REQUIRE_CONVERGENCE_REPORT=1, a converged + approved spec must
+// ALSO have its converging-audit report on disk (proving the audit RAN, not just
+// that a tag was added). This brings the precommit UP to the formal validator's
+// strictness (which requires the report unconditionally). With the env unset,
+// recognition.reportBacked is always true and this branch never blocks.
+if (!recognition.reportBacked) {
+  blockCommit(
+    inScopeFiles,
+    [
+      `Spec ${spec} is tagged review-convergence + approved, but its converging-audit`,
+      `report is missing: ${convergenceReportRel || '(spec has no valid slug to locate a report)'}`,
+      '',
+      'INSTAR_DEV_REQUIRE_CONVERGENCE_REPORT is on (specReview.requireConvergenceReport:',
+      'true) — a convergence tag without its report can fake convergence. The report is',
+      'the audit\'s proof-of-work; run /spec-converge to produce it (Phase 5 writes',
+      `docs/specs/reports/<slug>-convergence.md), then commit. To turn this requirement`,
+      'off, set specReview.requireConvergenceReport: false in your instar config.',
+    ].join('\n'),
+  );
+}
+
+// ── Part D: surface cross-model-review depth (observe-only, never blocks) ──
+// The converging audit records how much external (cross-model) review actually
+// ran. Surfacing it here makes the audit's depth visible to the operator/agent
+// reading the gate output, without ever gating on it (Signal vs. Authority).
+const crossModelMatch = specFm.match(/^\s*cross-model-review\s*:\s*["']?([^"'\n]+)/m);
+const crossModelReview = crossModelMatch ? crossModelMatch[1].trim() : 'not-recorded';
 
 // ─── Step 7: ELI16 overview verification ─────────────────────────────────
 // Every approved spec must ship with a plain-English ELI16 overview. The
@@ -824,7 +886,9 @@ if (!promotionGateResult.ok) {
 assertFrameworkGenerality(inScopeFiles, validTrace.trace);
 
 console.error(
-  `[instar-dev-precommit] OK — trace ${path.basename(validTrace.entry.file)} covers ${inScopeFiles.length} in-scope file(s), artifact ${validTrace.trace.artifactPath} verified, spec ${spec} is converged + approved, ELI16 overview ${eli16Rel} present (${eli16Result.charCount} chars), promotion-gate: ${promotionGateResult.reason}.`,
+  `[instar-dev-precommit] OK — trace ${path.basename(validTrace.entry.file)} covers ${inScopeFiles.length} in-scope file(s), artifact ${validTrace.trace.artifactPath} verified, spec ${spec} is converged + approved` +
+    `${REQUIRE_CONVERGENCE_REPORT ? ` + report-backed (${convergenceReportRel})` : ''}` +
+    ` [cross-model: ${crossModelReview}], ELI16 overview ${eli16Rel} present (${eli16Result.charCount} chars), promotion-gate: ${promotionGateResult.reason}.`,
 );
 process.exit(0);
 

--- a/scripts/lib/convergence-recognition.mjs
+++ b/scripts/lib/convergence-recognition.mjs
@@ -1,0 +1,126 @@
+/**
+ * convergence-recognition.mjs — the PRECOMMIT gate's pure recognizer for a
+ * spec's convergence / approval / report-backing state.
+ *
+ * Spec: docs/specs/CONVERGING-AUDIT-DEFAULT.md (Part C — gate consistency).
+ *
+ * WHY a separate pure module: the precommit (scripts/instar-dev-precommit.js)
+ * runs PRE-COMPILE and CANNOT import the TS StageTransitionValidator across the
+ * compile boundary, so the two gates cannot share a single source of truth in
+ * code. Instead, the precommit's recognition logic is factored HERE, into a
+ * tiny dependency-free function, and a unit test
+ * (tests/unit/convergence-gate-consistency.test.ts) feeds the SAME fixture
+ * table to both this recognizer and the validator's `isConvergenceTagPresent`
+ * + report logic, asserting they agree. A drift between the two gates fails CI.
+ *
+ * This module does NO I/O: callers pass the frontmatter text and the
+ * report-existence boolean. It is the precommit-side mirror of the validator's
+ * pure predicate — same convergence-tag rule (non-empty string OR boolean
+ * true), same report-backing rule (report must exist when required).
+ */
+
+/**
+ * Recognize the convergence tag in a `review-convergence` frontmatter VALUE.
+ *
+ * Mirror of StageTransitionValidator.isConvergenceTagPresent: a non-empty
+ * string (the ISO timestamp the converging-audit tooling writes) OR boolean
+ * `true` (the legacy/hand-added form) counts as present. Empty string, false,
+ * null/undefined, and any other type do NOT.
+ *
+ * @param {unknown} value
+ * @returns {boolean}
+ */
+export function isConvergenceTagPresent(value) {
+  if (value === true) return true;
+  if (typeof value === 'string' && value.trim().length > 0) return true;
+  return false;
+}
+
+/**
+ * Parse the raw `review-convergence` value out of a YAML frontmatter BLOCK
+ * (the text between the `---` fences, NOT including the fences). Mirrors the
+ * precommit's existing lenient regex exactly so recognition stays identical.
+ *
+ * Returns the matched string value (quotes stripped, trimmed) when the line is
+ * present, or `undefined` when the key is absent. Note: this returns a STRING
+ * for both `review-convergence: true` and `review-convergence: "<ts>"` — the
+ * precommit's regex captures the literal token; `isConvergenceTagPresent`
+ * treats any non-empty captured token as present, which matches the validator's
+ * acceptance of both the boolean-true and timestamp-string forms.
+ *
+ * @param {string} frontmatterText
+ * @returns {string | undefined}
+ */
+export function parseConvergenceValue(frontmatterText) {
+  const m = String(frontmatterText).match(
+    /^\s*review-convergence\s*:\s*["']?([^"'\n]+)/m,
+  );
+  if (!m) return undefined;
+  return m[1].trim();
+}
+
+/**
+ * Parse whether the spec carries an `approved: true` tag (precommit's regex).
+ *
+ * @param {string} frontmatterText
+ * @returns {boolean}
+ */
+export function isApprovedTagPresent(frontmatterText) {
+  return /^\s*approved\s*:\s*(true|"true"|'true')/m.test(String(frontmatterText));
+}
+
+/**
+ * The precommit's verdict for "is this spec converged + approved (+ report-backed
+ * when required)?" — the same question the formal validator answers, expressed
+ * over frontmatter text + a report-existence boolean.
+ *
+ * @param {string} frontmatterText — the YAML frontmatter block (between the `---` fences).
+ * @param {{ requireReport?: boolean, reportExists?: boolean }} [opts]
+ *   requireReport — true when INSTAR_DEV_REQUIRE_CONVERGENCE_REPORT=1.
+ *   reportExists  — whether docs/specs/reports/<slug>-convergence.md exists.
+ * @returns {{ converged: boolean, approved: boolean, reportBacked: boolean,
+ *             accepted: boolean, reason: string }}
+ *   - converged:    the convergence tag is present.
+ *   - approved:     the approved tag is present.
+ *   - reportBacked: the report requirement is satisfied (vacuously true when
+ *                   requireReport is false).
+ *   - accepted:     converged AND approved AND reportBacked — the precommit's
+ *                   Step-6 verdict for a tier-2/3 spec.
+ *   - reason:       a short machine-stable reason for the verdict.
+ */
+export function recognizeConvergence(frontmatterText, opts = {}) {
+  const requireReport = opts.requireReport === true;
+  const reportExists = opts.reportExists === true;
+
+  const convergenceValue = parseConvergenceValue(frontmatterText);
+  const converged = isConvergenceTagPresent(convergenceValue);
+  const approved = isApprovedTagPresent(frontmatterText);
+  const reportBacked = !requireReport || reportExists;
+
+  let reason;
+  if (!converged) reason = 'convergence-tag-missing';
+  else if (!approved) reason = 'approved-tag-missing';
+  else if (!reportBacked) reason = 'convergence-report-missing';
+  else reason = 'accepted';
+
+  const accepted = converged && approved && reportBacked;
+  return { converged, approved, reportBacked, accepted, reason };
+}
+
+/**
+ * Convenience: the precommit-side answer to "is this spec CONVERGED?" in the
+ * exact sense the consistency test compares against the validator's converged
+ * verdict (convergence tag present AND report-backed when required). Approval
+ * is a separate downstream gate in BOTH paths, so it is NOT folded in here.
+ *
+ * @param {string} frontmatterText
+ * @param {{ requireReport?: boolean, reportExists?: boolean }} [opts]
+ * @returns {boolean}
+ */
+export function isSpecConverged(frontmatterText, opts = {}) {
+  const requireReport = opts.requireReport === true;
+  const reportExists = opts.reportExists === true;
+  const converged = isConvergenceTagPresent(parseConvergenceValue(frontmatterText));
+  const reportBacked = !requireReport || reportExists;
+  return converged && reportBacked;
+}

--- a/src/config/ConfigDefaults.ts
+++ b/src/config/ConfigDefaults.ts
@@ -458,6 +458,19 @@ const SHARED_DEFAULTS: Record<string, unknown> = {
     conformance: {
       enabled: true,
     },
+    // Report-Backed Converging Audit (docs/specs/CONVERGING-AUDIT-DEFAULT.md).
+    // When true, the instar-dev PRECOMMIT gate ADDITIONALLY requires the
+    // converging-audit report file (docs/specs/reports/<slug>-convergence.md) to
+    // exist for each in-scope spec — proving the audit actually RAN, not that a
+    // tag was hand-added. Default FALSE = byte-identical to today's precommit
+    // behavior (the report requirement is inert). The precommit script reads NO
+    // config (it runs pre-compile), so the .husky/pre-commit hook exports this
+    // as the env var INSTAR_DEV_REQUIRE_CONVERGENCE_REPORT=1 when true. The
+    // FORMAL StageTransitionValidator already requires the report
+    // unconditionally; this flag only brings the precommit UP to that strictness.
+    // applyDefaults is add-missing-only deep-merge, so this backfills into every
+    // existing agent on update with no separate migrateConfig block.
+    requireConvergenceReport: false,
   },
   // Usher (rung 4) — signal-only mid-task re-surface watcher. Default-on: it only
   // writes suggestions to a read-only pull surface (never injects, never pushes to

--- a/src/core/StageTransitionValidator.ts
+++ b/src/core/StageTransitionValidator.ts
@@ -74,6 +74,26 @@ export interface GhPrView {
 const SLUG_RE = /^[a-z0-9][a-z0-9-]{0,63}$/;
 
 /**
+ * The single definition of "the convergence tag is present" — used by the
+ * formal gate (here) AND mirrored by the precommit's recognizer
+ * (scripts/lib/convergence-recognition.mjs), cross-checked for agreement by
+ * tests/unit/convergence-gate-consistency.test.ts.
+ *
+ * The canonical converging-audit tooling
+ * (skills/spec-converge/scripts/write-convergence-tag.mjs) writes
+ * `review-convergence: "<ISO timestamp>"` — a NON-EMPTY STRING. The legacy /
+ * hand-added form is boolean `true`. Both count as present. Empty string,
+ * `false`, `undefined`, and any other type do NOT.
+ *
+ * Pure, dependency-free, no I/O — exported so it can be unit-tested directly.
+ */
+export function isConvergenceTagPresent(value: unknown): boolean {
+  if (value === true) return true;
+  if (typeof value === 'string' && value.trim().length > 0) return true;
+  return false;
+}
+
+/**
  * Validate a `from → to` transition under the given context.
  *
  * `from === undefined` is treated as "creation lands directly at `to`" and
@@ -152,10 +172,11 @@ export async function validateStageTransition(
     const fm = await loadFrontmatter(jailed.absPath, ctx.readSpecFrontmatter);
     if (!fm.ok) return { ok: false, reason: fm.error, code: 'SPEC_FRONTMATTER_INVALID' };
     const data = fm.data;
-    if (data['review-convergence'] !== true) {
+    if (!isConvergenceTagPresent(data['review-convergence'])) {
       return {
         ok: false,
-        reason: 'spec frontmatter must have `review-convergence: true`',
+        reason:
+          'spec frontmatter must have a `review-convergence` tag (the ISO timestamp the converging-audit tooling writes, or boolean `true`)',
         code: 'CONVERGENCE_TAG_MISSING',
       };
     }

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -2410,6 +2410,16 @@ export interface InstarConfig {
     conformance?: {
       enabled?: boolean;
     };
+    /**
+     * Report-Backed Converging Audit (docs/specs/CONVERGING-AUDIT-DEFAULT.md).
+     * Default false (dark-safe). When true, the instar-dev precommit gate also
+     * requires the converging-audit report file
+     * (`docs/specs/reports/<slug>-convergence.md`) to exist for each in-scope
+     * spec. The precommit reads this via the env var
+     * `INSTAR_DEV_REQUIRE_CONVERGENCE_REPORT=1`, exported from this flag by the
+     * `.husky/pre-commit` hook (the script itself reads no config).
+     */
+    requireConvergenceReport?: boolean;
   };
   /**
    * Usher (rung 4) — the signal-only mid-task re-surface watcher. `enabled`

--- a/tests/e2e/converging-audit-precommit-report-backing.test.ts
+++ b/tests/e2e/converging-audit-precommit-report-backing.test.ts
@@ -1,0 +1,243 @@
+// safe-git-allow: test file — execFileSync('git') builds the fixture repo; fs.rmSync is per-test tmpdir cleanup.
+/**
+ * Tier 3 (E2E) — runs the REAL scripts/instar-dev-precommit.js in a fixture git
+ * repo and proves the Report-Backed Converging Audit
+ * (docs/specs/CONVERGING-AUDIT-DEFAULT.md, Part B) behaves correctly under both
+ * flag states — and is BYTE-IDENTICAL to today when the flag is unset.
+ *
+ * The precommit hardcodes ROOT to its own parent dir (path.resolve(__dirname,
+ * '..')), so to exercise it against a fixture we COPY the real script + its tiny
+ * dependency set into the fixture's scripts/ tree (preserving the relative
+ * import layout) and invoke the COPY. The copy is the real, unmodified gate
+ * logic — only its ROOT relocates to the fixture.
+ *
+ * Three assertions, all driving the actual gate:
+ *   1. env UNSET            → a timestamp-tagged + approved spec + staged source
+ *                            COMMITS cleanly (today's behavior, byte-identical).
+ *   2. env=1, NO report     → the same commit is BLOCKED (report required).
+ *   3. env=1, report PRESENT → the commit succeeds again.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import crypto from 'node:crypto';
+import { fileURLToPath } from 'node:url';
+import { execFileSync } from 'node:child_process';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, '../..');
+
+// The real gate script + its self-contained dependency set (no node_modules).
+const COPY_FILES = [
+  'scripts/instar-dev-precommit.js',
+  'scripts/eli16-overview-check.mjs',
+  'scripts/lib/classify-tier.mjs',
+  'scripts/lib/convergence-recognition.mjs',
+  'skills/instar-dev/scripts/verify-proposal-derived-runbook.mjs',
+  'docs/STANDARDS-REGISTRY.md',
+];
+
+const PARENT_PRINCIPLE = 'Structure beats Willpower'; // resolves to a real registry heading
+
+function git(cwd: string, args: string[]): void {
+  execFileSync('git', args, {
+    cwd,
+    stdio: 'pipe',
+    env: { ...process.env, GIT_AUTHOR_NAME: 't', GIT_AUTHOR_EMAIL: 't@t', GIT_COMMITTER_NAME: 't', GIT_COMMITTER_EMAIL: 't@t' },
+  });
+}
+
+let repo: string;
+
+beforeEach(() => {
+  repo = fs.mkdtempSync(path.join(os.tmpdir(), 'converge-precommit-'));
+
+  // Copy the real gate script + deps into the fixture, preserving layout so the
+  // script's relative imports + ROOT resolution land inside the fixture.
+  for (const rel of COPY_FILES) {
+    const src = path.join(REPO_ROOT, rel);
+    const dest = path.join(repo, rel);
+    fs.mkdirSync(path.dirname(dest), { recursive: true });
+    fs.copyFileSync(src, dest);
+  }
+
+  git(repo, ['init', '-q', '-b', 'main']);
+  // A non-fix branch so the causal-autopsy advisory stays quiet (it never blocks
+  // anyway, but keeps the gate output clean).
+  git(repo, ['checkout', '-q', '-b', 'feature/converge-test']);
+  git(repo, ['add', '-A']);
+  git(repo, ['commit', '-q', '-m', 'scaffold gate + deps']);
+});
+
+afterEach(() => {
+  fs.rmSync(repo, { recursive: true, force: true });
+});
+
+/** Lay out a converged + approved spec, its ELI16 companion, a side-effects
+ * artifact, a fresh complete trace, and a staged in-scope source file. Returns
+ * the report-file path so a test can create/omit it. */
+function stageConvergedChange(): { reportRel: string } {
+  const slug = 'fixture-feature';
+  const specRel = `docs/specs/${slug}.md`;
+  const eli16Rel = `docs/specs/${slug}.eli16.md`;
+  const artifactRel = `upgrades/side-effects/${slug}.md`;
+  const reportRel = `docs/specs/reports/${slug}-convergence.md`;
+  const sourceRel = 'src/FixtureFeature.ts';
+
+  // Canonical converging-audit format: timestamp STRING tag (not boolean true).
+  const specBody =
+    `---\n` +
+    `title: Fixture Feature\n` +
+    `slug: ${slug}\n` +
+    `parent-principle: "${PARENT_PRINCIPLE}"\n` +
+    `review-convergence: "2026-06-10T18:10:05Z"\n` +
+    `cross-model-review: "codex-cli:gpt-5.5"\n` +
+    `approved: true\n` +
+    `approved-by: Justin\n` +
+    `approved-date: 2026-06-10\n` +
+    `---\n\n# Fixture Feature\n\nA complete feature with no deferrals.\n`;
+  writeFixture(specRel, specBody);
+
+  // ELI16 ≥ 800 chars of trimmed content.
+  writeFixture(eli16Rel, '# Fixture Feature — plain English\n\n' + 'This change adds a small fixture feature. '.repeat(40) + '\n');
+
+  // Side-effects artifact ≥ 200 chars.
+  writeFixture(artifactRel, '# Side effects\n\n' + 'No external side effects; this is a pure in-repo fixture used only by a test. '.repeat(6) + '\n');
+
+  // The in-scope source file.
+  writeFixture(sourceRel, 'export const fixtureFeature = () => 42;\n');
+
+  // Compute the artifact sha for the trace.
+  const artifactSha = crypto.createHash('sha256').update(fs.readFileSync(path.join(repo, artifactRel), 'utf8')).digest('hex');
+
+  // Fresh, complete trace (mtime is now → within the 60-min window).
+  const trace = {
+    phase: 'complete',
+    slug,
+    coveredFiles: [sourceRel],
+    artifactPath: artifactRel,
+    sideEffectsPath: artifactRel,
+    artifactSha256: artifactSha,
+    specPath: specRel,
+    createdAt: new Date().toISOString(),
+  };
+  writeFixture(`.instar/instar-dev-traces/${slug}.json`, JSON.stringify(trace, null, 2) + '\n');
+
+  // Stage everything EXCEPT the report (tests control the report's presence).
+  git(repo, ['add', specRel, eli16Rel, artifactRel, sourceRel, `.instar/instar-dev-traces/${slug}.json`]);
+
+  return { reportRel };
+}
+
+function writeFixture(rel: string, content: string): void {
+  const abs = path.join(repo, rel);
+  fs.mkdirSync(path.dirname(abs), { recursive: true });
+  fs.writeFileSync(abs, content);
+}
+
+/** Run the copied real precommit; return { code, out }. The gate writes its
+ * diagnostics to STDERR (both on pass and block), so we MERGE stderr into stdout
+ * (`2>&1`) to capture the success-path "OK …" line too — execFileSync otherwise
+ * returns only stdout on a clean exit. */
+function runPrecommit(env: Record<string, string> = {}): { code: number; out: string } {
+  const childEnv = {
+    ...process.env,
+    GIT_AUTHOR_NAME: 't', GIT_AUTHOR_EMAIL: 't@t',
+    GIT_COMMITTER_NAME: 't', GIT_COMMITTER_EMAIL: 't@t',
+    ...env,
+  };
+  try {
+    const out = execFileSync(
+      'sh',
+      ['-c', 'node "$0" 2>&1', path.join(repo, 'scripts/instar-dev-precommit.js')],
+      { cwd: repo, encoding: 'utf8', env: childEnv },
+    );
+    return { code: 0, out };
+  } catch (e) {
+    const err = e as { status?: number; stderr?: string; stdout?: string };
+    return { code: err.status ?? 1, out: `${err.stdout ?? ''}${err.stderr ?? ''}` };
+  }
+}
+
+describe('E2E: instar-dev-precommit report-backing (Report-Backed Converging Audit)', () => {
+  it('env UNSET: a timestamp-tagged + approved spec with NO report COMMITS cleanly (byte-identical to today)', () => {
+    stageConvergedChange();
+    // No report file on disk; env is unset.
+    const r = runPrecommit();
+    expect(r.code).toBe(0);
+    expect(r.out).toContain('OK');
+    // The default path must NOT mention the report requirement at all.
+    expect(r.out).not.toContain('report-backed');
+    expect(r.out).not.toContain('converging-audit\nreport is missing');
+  });
+
+  it('env=1, NO report: the SAME commit is BLOCKED for the missing report', () => {
+    stageConvergedChange(); // report deliberately not created
+    const r = runPrecommit({ INSTAR_DEV_REQUIRE_CONVERGENCE_REPORT: '1' });
+    expect(r.code).toBe(1);
+    expect(r.out).toContain('converging-audit');
+    expect(r.out).toContain('report is missing');
+    expect(r.out).toContain('fixture-feature-convergence.md');
+  });
+
+  it('env=1, report PRESENT: the commit succeeds again', () => {
+    const { reportRel } = stageConvergedChange();
+    writeFixture(reportRel, '# Convergence report\n\n' + 'Round 1 converged. '.repeat(20) + '\n');
+    git(repo, ['add', reportRel]);
+    const r = runPrecommit({ INSTAR_DEV_REQUIRE_CONVERGENCE_REPORT: '1' });
+    expect(r.code).toBe(0);
+    expect(r.out).toContain('OK');
+    expect(r.out).toContain('report-backed');
+  });
+
+  it('Part D: the success diagnostic surfaces the cross-model-review value (observe-only)', () => {
+    stageConvergedChange();
+    const r = runPrecommit();
+    expect(r.code).toBe(0);
+    expect(r.out).toContain('cross-model: codex-cli:gpt-5.5');
+  });
+
+  it('env=1 but spec NOT converged: still blocks on the convergence tag (not the report) — same as today', () => {
+    // Replace the spec with one that has NO convergence tag.
+    const slug = 'fixture-feature';
+    const specRel = `docs/specs/${slug}.md`;
+    writeFixture(
+      specRel,
+      `---\ntitle: Fixture Feature\nslug: ${slug}\nparent-principle: "${PARENT_PRINCIPLE}"\napproved: true\napproved-by: Justin\napproved-date: 2026-06-10\n---\n\n# body\n`,
+    );
+    stageConvergedChangeReusing(specRel);
+    const r = runPrecommit({ INSTAR_DEV_REQUIRE_CONVERGENCE_REPORT: '1' });
+    expect(r.code).toBe(1);
+    expect(r.out).toContain('not tagged review-convergence');
+  });
+});
+
+/** Variant of stageConvergedChange that keeps a caller-written spec but stages
+ * the rest of the support files + trace. */
+function stageConvergedChangeReusing(specRel: string): void {
+  const slug = 'fixture-feature';
+  const eli16Rel = `docs/specs/${slug}.eli16.md`;
+  const artifactRel = `upgrades/side-effects/${slug}.md`;
+  const sourceRel = 'src/FixtureFeature.ts';
+
+  writeFixture(eli16Rel, '# Fixture Feature — plain English\n\n' + 'This change adds a small fixture feature. '.repeat(40) + '\n');
+  writeFixture(artifactRel, '# Side effects\n\n' + 'No external side effects; this is a pure in-repo fixture used only by a test. '.repeat(6) + '\n');
+  writeFixture(sourceRel, 'export const fixtureFeature = () => 42;\n');
+
+  const artifactSha = crypto.createHash('sha256').update(fs.readFileSync(path.join(repo, artifactRel), 'utf8')).digest('hex');
+
+  const trace = {
+    phase: 'complete',
+    slug,
+    coveredFiles: [sourceRel],
+    artifactPath: artifactRel,
+    sideEffectsPath: artifactRel,
+    artifactSha256: artifactSha,
+    specPath: specRel,
+    createdAt: new Date().toISOString(),
+  };
+  writeFixture(`.instar/instar-dev-traces/${slug}.json`, JSON.stringify(trace, null, 2) + '\n');
+  git(repo, ['add', specRel, eli16Rel, artifactRel, sourceRel, `.instar/instar-dev-traces/${slug}.json`]);
+}

--- a/tests/integration/projects-api.test.ts
+++ b/tests/integration/projects-api.test.ts
@@ -491,6 +491,72 @@ goal: try escape
     expect(tracker.get(itemId)?.pipelineStage).toBe('spec-drafted');
   });
 
+  it('POST /projects/:id/advance — spec-drafted → spec-converged accepts the canonical TIMESTAMP tag + report (Part A bug-fix through the real route)', async () => {
+    const { projectVersion, itemId } = await seedProject('adv-converge');
+    // The canonical converging-audit format: review-convergence is the ISO
+    // TIMESTAMP STRING the tooling writes — NOT boolean true. Pre-fix this
+    // advance was REJECTED with CONVERGENCE_TAG_MISSING (`"<ts>" !== true`).
+    fs.writeFileSync(
+      path.join(targetRepo, 'docs/specs/a.md'),
+      `---\ntitle: a\nslug: a\nreview-convergence: "2026-06-10T18:10:05Z"\n---\n\n# spec body\n`,
+    );
+    fs.mkdirSync(path.join(targetRepo, 'docs/specs/reports'), { recursive: true });
+    fs.writeFileSync(path.join(targetRepo, 'docs/specs/reports/a-convergence.md'), '# convergence report\n');
+
+    // Step 1: outline → spec-drafted.
+    const drafted = await request(app)
+      .post('/projects/adv-converge/advance')
+      .set('Authorization', `Bearer ${AUTH_TOKEN}`)
+      .set('If-Match', String(projectVersion))
+      .send({ itemId, targetStage: 'spec-drafted', artifact: { specPath: 'docs/specs/a.md' } });
+    expect(drafted.status).toBe(200);
+
+    // Step 2: spec-drafted → spec-converged (the bug-fix path).
+    const v2 = tracker.get('adv-converge')!.version;
+    const converged = await request(app)
+      .post('/projects/adv-converge/advance')
+      .set('Authorization', `Bearer ${AUTH_TOKEN}`)
+      .set('If-Match', String(v2))
+      .send({ itemId, fromStage: 'spec-drafted', targetStage: 'spec-converged', artifact: { specPath: 'docs/specs/a.md' } });
+    expect(converged.status).toBe(200);
+    expect(converged.body.item.pipelineStage).toBe('spec-converged');
+    expect(tracker.get(itemId)?.pipelineStage).toBe('spec-converged');
+
+    // Restore the empty spec for subsequent tests.
+    fs.writeFileSync(path.join(targetRepo, 'docs/specs/a.md'), '');
+  });
+
+  it('POST /projects/:id/advance — spec-drafted → spec-converged with timestamp tag but MISSING report returns 409 (report check stays unconditional)', async () => {
+    const { projectVersion, itemId } = await seedProject('adv-converge-noreport');
+    fs.writeFileSync(
+      path.join(targetRepo, 'docs/specs/a.md'),
+      `---\ntitle: a\nslug: a\nreview-convergence: "2026-06-10T18:10:05Z"\n---\n\n# spec body\n`,
+    );
+    // The reports/ dir exists but the specific report file for slug `a` does
+    // not → CONVERGENCE_REPORT_MISSING (not ESCAPE, which is the dir-absent case).
+    fs.mkdirSync(path.join(targetRepo, 'docs/specs/reports'), { recursive: true });
+    SafeFsExecutor.safeRmSync(path.join(targetRepo, 'docs/specs/reports/a-convergence.md'), { force: true, operation: 'tests/integration/projects-api.test.ts:advance-converge-noreport' });
+
+    const drafted = await request(app)
+      .post('/projects/adv-converge-noreport/advance')
+      .set('Authorization', `Bearer ${AUTH_TOKEN}`)
+      .set('If-Match', String(projectVersion))
+      .send({ itemId, targetStage: 'spec-drafted', artifact: { specPath: 'docs/specs/a.md' } });
+    expect(drafted.status).toBe(200);
+
+    const v2 = tracker.get('adv-converge-noreport')!.version;
+    const converged = await request(app)
+      .post('/projects/adv-converge-noreport/advance')
+      .set('Authorization', `Bearer ${AUTH_TOKEN}`)
+      .set('If-Match', String(v2))
+      .send({ itemId, fromStage: 'spec-drafted', targetStage: 'spec-converged', artifact: { specPath: 'docs/specs/a.md' } });
+    expect(converged.status).toBe(409);
+    expect(converged.body.code).toBe('CONVERGENCE_REPORT_MISSING');
+
+    // Restore the empty spec for subsequent tests.
+    fs.writeFileSync(path.join(targetRepo, 'docs/specs/a.md'), '');
+  });
+
   it('POST /projects/:id/advance — missing If-Match returns 428', async () => {
     const { itemId } = await seedProject('adv-2');
     const res = await request(app)

--- a/tests/unit/StageTransitionValidator.test.ts
+++ b/tests/unit/StageTransitionValidator.test.ts
@@ -17,6 +17,7 @@ import path from 'node:path';
 import {
   validateStageTransition,
   jailPath,
+  isConvergenceTagPresent,
   type ValidationContext,
 } from '../../src/core/StageTransitionValidator.js';
 import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
@@ -26,6 +27,13 @@ describe('StageTransitionValidator', () => {
   let goodSpecRel: string;
   let convergedSpecRel: string;
   let approvedSpecRel: string;
+  // Canonical converging-audit format: review-convergence is the ISO TIMESTAMP
+  // STRING that write-convergence-tag.mjs writes — NOT boolean true. This is the
+  // Part-A bug-fix case (previously rejected as `"<ts>" !== true`).
+  let timestampConvergedSpecRel: string;
+  // Same timestamp tag, but NO report file → still fails the unconditional
+  // CONVERGENCE_REPORT_MISSING check.
+  let timestampNoReportSpecRel: string;
 
   beforeAll(() => {
     tmpRepo = fs.mkdtempSync(path.join(os.tmpdir(), 'stage-validator-'));
@@ -33,6 +41,8 @@ describe('StageTransitionValidator', () => {
     goodSpecRel = 'docs/specs/example-feature.md';
     convergedSpecRel = 'docs/specs/converged-feature.md';
     approvedSpecRel = 'docs/specs/approved-feature.md';
+    timestampConvergedSpecRel = 'docs/specs/timestamp-converged.md';
+    timestampNoReportSpecRel = 'docs/specs/timestamp-no-report.md';
 
     fs.writeFileSync(
       path.join(tmpRepo, goodSpecRel),
@@ -45,6 +55,20 @@ describe('StageTransitionValidator', () => {
     fs.writeFileSync(
       path.join(tmpRepo, 'docs/specs/reports/converged-feature-convergence.md'),
       `# convergence report\n`
+    );
+    // Timestamp-string convergence tag (the real tooling output) + present report.
+    fs.writeFileSync(
+      path.join(tmpRepo, timestampConvergedSpecRel),
+      `---\ntitle: ts converged\nslug: timestamp-converged\nreview-convergence: "2026-06-10T18:10:05Z"\n---\n\n# body\n`
+    );
+    fs.writeFileSync(
+      path.join(tmpRepo, 'docs/specs/reports/timestamp-converged-convergence.md'),
+      `# convergence report for the timestamp-tagged spec\n`
+    );
+    // Timestamp tag but NO report file on disk.
+    fs.writeFileSync(
+      path.join(tmpRepo, timestampNoReportSpecRel),
+      `---\ntitle: ts no report\nslug: timestamp-no-report\nreview-convergence: "2026-06-10T18:10:05Z"\n---\n\n# body\n`
     );
     fs.writeFileSync(
       path.join(tmpRepo, approvedSpecRel),
@@ -111,6 +135,39 @@ describe('StageTransitionValidator', () => {
       specPath: convergedSpecRel,
     });
     expect(r.ok).toBe(true);
+  });
+
+  it('spec-drafted → spec-converged: accepts the canonical ISO-TIMESTAMP tag + report (Part A bug-fix)', async () => {
+    // Previously REJECTED because `"<ts>" !== true`. The tooling writes the
+    // timestamp string, so this is the real-world converged spec.
+    const r = await validateStageTransition('spec-drafted', 'spec-converged', {
+      targetRepoPath: tmpRepo,
+      specPath: timestampConvergedSpecRel,
+    });
+    expect(r.ok).toBe(true);
+  });
+
+  it('spec-drafted → spec-converged: timestamp tag but MISSING report still fails (report check stays unconditional)', async () => {
+    const r = await validateStageTransition('spec-drafted', 'spec-converged', {
+      targetRepoPath: tmpRepo,
+      specPath: timestampNoReportSpecRel,
+    });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.code).toBe('CONVERGENCE_REPORT_MISSING');
+  });
+
+  it('spec-drafted → spec-converged: rejects an EMPTY-string review-convergence tag', async () => {
+    const emptyTagSpec = 'docs/specs/empty-convergence-tag.md';
+    fs.writeFileSync(
+      path.join(tmpRepo, emptyTagSpec),
+      `---\ntitle: empty\nslug: empty-convergence-tag\nreview-convergence: ""\n---\n# body\n`
+    );
+    const r = await validateStageTransition('spec-drafted', 'spec-converged', {
+      targetRepoPath: tmpRepo,
+      specPath: emptyTagSpec,
+    });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.code).toBe('CONVERGENCE_TAG_MISSING');
   });
 
   it('spec-drafted → spec-converged: rejects when review-convergence missing', async () => {
@@ -411,5 +468,43 @@ describe('jailPath helper', () => {
     expect(r.ok).toBe(false);
     SafeFsExecutor.safeRmSync(symRoot, { recursive: true, force: true, operation: 'tests/unit/StageTransitionValidator.test.ts:symlinks-symRoot' });
     SafeFsExecutor.safeRmSync(outside, { recursive: true, force: true, operation: 'tests/unit/StageTransitionValidator.test.ts:symlinks-outside' });
+  });
+});
+
+describe('isConvergenceTagPresent predicate (Part A)', () => {
+  it('accepts boolean true (legacy / hand-added form)', () => {
+    expect(isConvergenceTagPresent(true)).toBe(true);
+  });
+
+  it('accepts a non-empty ISO timestamp string (canonical tooling form)', () => {
+    expect(isConvergenceTagPresent('2026-06-10T18:10:05Z')).toBe(true);
+  });
+
+  it('accepts any non-empty string (lenient like the precommit regex)', () => {
+    expect(isConvergenceTagPresent('yes')).toBe(true);
+  });
+
+  it('rejects the empty string', () => {
+    expect(isConvergenceTagPresent('')).toBe(false);
+  });
+
+  it('rejects a whitespace-only string', () => {
+    expect(isConvergenceTagPresent('   ')).toBe(false);
+  });
+
+  it('rejects boolean false', () => {
+    expect(isConvergenceTagPresent(false)).toBe(false);
+  });
+
+  it('rejects undefined and null', () => {
+    expect(isConvergenceTagPresent(undefined)).toBe(false);
+    expect(isConvergenceTagPresent(null)).toBe(false);
+  });
+
+  it('rejects non-string / non-boolean types', () => {
+    expect(isConvergenceTagPresent(0)).toBe(false);
+    expect(isConvergenceTagPresent(1)).toBe(false);
+    expect(isConvergenceTagPresent({})).toBe(false);
+    expect(isConvergenceTagPresent([])).toBe(false);
   });
 });

--- a/tests/unit/convergence-gate-consistency.test.ts
+++ b/tests/unit/convergence-gate-consistency.test.ts
@@ -1,0 +1,166 @@
+/**
+ * Convergence Gate Consistency (CONVERGING-AUDIT-DEFAULT.md, Part C).
+ *
+ * The two convergence gates live on opposite sides of the TS compile boundary:
+ *   - the FORMAL gate: src/core/StageTransitionValidator.ts (TS) — its pure
+ *     predicate `isConvergenceTagPresent` + its unconditional report-existence
+ *     check decide "is this spec converged?".
+ *   - the PRECOMMIT gate: scripts/instar-dev-precommit.js (pre-compile .js) —
+ *     its recognition is factored into scripts/lib/convergence-recognition.mjs
+ *     (`recognizeConvergence` / `isSpecConverged`).
+ *
+ * They cannot share a single module across the boundary, so this test enforces
+ * agreement: a SHARED fixture table (timestamp tag / boolean tag / no tag /
+ * report-present / report-missing) is fed to BOTH the validator's logic AND the
+ * precommit's recognizer, and we assert they return the SAME converged verdict
+ * for every fixture, under BOTH flag states. Drift fails CI.
+ *
+ * "Converged" here is defined identically on both sides: the convergence TAG is
+ * present AND (when the report requirement is on) the report exists. Approval is
+ * a separate downstream gate in BOTH paths, so it is not folded into the
+ * converged verdict compared here (it is asserted independently below).
+ */
+
+import { describe, it, expect } from 'vitest';
+import { isConvergenceTagPresent } from '../../src/core/StageTransitionValidator.js';
+// @ts-expect-error — .mjs script, no type declarations; runtime import is fine under vitest
+import {
+  recognizeConvergence,
+  isSpecConverged,
+  parseConvergenceValue,
+} from '../../scripts/lib/convergence-recognition.mjs';
+
+/**
+ * A fixture describes a spec's frontmatter shape and whether its report exists.
+ * `tagText` is the literal `review-convergence` frontmatter line value (or null
+ * for "no tag at all"). `expectedTagPresent` is the ground-truth answer that
+ * BOTH gates must agree on for the tag alone.
+ */
+interface Fixture {
+  name: string;
+  tagText: string | null;
+  reportExists: boolean;
+  approved: boolean;
+  expectedTagPresent: boolean;
+}
+
+const FIXTURES: Fixture[] = [
+  { name: 'canonical ISO timestamp tag', tagText: '"2026-06-10T18:10:05Z"', reportExists: true, approved: true, expectedTagPresent: true },
+  { name: 'canonical timestamp tag, report MISSING', tagText: '"2026-06-10T18:10:05Z"', reportExists: false, approved: true, expectedTagPresent: true },
+  { name: 'legacy boolean true tag', tagText: 'true', reportExists: true, approved: true, expectedTagPresent: true },
+  { name: 'boolean true, not approved', tagText: 'true', reportExists: true, approved: false, expectedTagPresent: true },
+  { name: 'no convergence tag', tagText: null, reportExists: false, approved: true, expectedTagPresent: false },
+  { name: 'empty-string tag', tagText: '""', reportExists: true, approved: true, expectedTagPresent: false },
+];
+
+/** Build a YAML frontmatter BLOCK (between the fences) for a fixture. */
+function frontmatterFor(f: Fixture): string {
+  const lines = ['title: fixture', 'slug: fixture-spec'];
+  if (f.tagText !== null) lines.push(`review-convergence: ${f.tagText}`);
+  if (f.approved) lines.push('approved: true');
+  return lines.join('\n');
+}
+
+/**
+ * The VALIDATOR-side converged verdict, expressed over the same inputs the
+ * precommit recognizer sees. The validator parses the raw frontmatter value and
+ * runs `isConvergenceTagPresent`; its report check is UNCONDITIONAL in the
+ * formal gate. To compare apples-to-apples under both flag states, we model the
+ * validator's converged verdict as: tag present AND (report required ? report
+ * exists : tag present) — i.e. when the precommit's flag is OFF, the validator's
+ * unconditional report check is the stricter side, so we compare the TAG verdict
+ * there and the FULL (tag + report) verdict when the flag is ON. The fixtures
+ * with a missing report exercise both.
+ */
+function validatorTagVerdict(f: Fixture): boolean {
+  // The validator reads the parsed frontmatter value. We reproduce parsing via
+  // the recognizer's parser (the precommit's exact regex) so we compare the
+  // SAME extracted token — then run the validator's OWN predicate on it.
+  const value = parseConvergenceValue(frontmatterFor(f));
+  return isConvergenceTagPresent(value);
+}
+
+describe('Convergence gate consistency (validator ↔ precommit recognizer)', () => {
+  describe('tag recognition agrees for every fixture', () => {
+    for (const f of FIXTURES) {
+      it(`${f.name}: both gates agree the tag is ${f.expectedTagPresent ? 'PRESENT' : 'ABSENT'}`, () => {
+        const fm = frontmatterFor(f);
+        // Validator side.
+        const validatorSays = validatorTagVerdict(f);
+        // Precommit side (tag only, report not required).
+        const precommitSays = isConvergenceTagPresent(parseConvergenceValue(fm));
+        expect(validatorSays).toBe(f.expectedTagPresent);
+        expect(precommitSays).toBe(f.expectedTagPresent);
+        expect(validatorSays).toBe(precommitSays);
+      });
+    }
+  });
+
+  describe('converged verdict agrees under BOTH flag states', () => {
+    for (const requireReport of [false, true]) {
+      for (const f of FIXTURES) {
+        it(`flag=${requireReport} / ${f.name}: validator & precommit converged verdicts match`, () => {
+          const fm = frontmatterFor(f);
+
+          // Precommit recognizer's converged verdict (tag + report-backing).
+          const precommitConverged = isSpecConverged(fm, {
+            requireReport,
+            reportExists: f.reportExists,
+          });
+
+          // Validator-modeled converged verdict for the SAME inputs:
+          //  - flag OFF: the precommit does NOT require the report, so its
+          //    converged verdict is the TAG verdict. The formal validator would
+          //    additionally require the report, but Part B keeps the precommit
+          //    asymmetric — so under flag-OFF the agreeing surface is the tag.
+          //  - flag ON: the precommit matches the formal validator exactly —
+          //    tag present AND report exists.
+          const validatorConverged = requireReport
+            ? validatorTagVerdict(f) && f.reportExists
+            : validatorTagVerdict(f);
+
+          expect(precommitConverged).toBe(validatorConverged);
+        });
+      }
+    }
+  });
+
+  describe('recognizeConvergence full verdict (tag + approved + report)', () => {
+    it('flag OFF: a timestamp-tagged + approved spec is accepted even with no report (today\'s behavior)', () => {
+      const f = FIXTURES.find((x) => x.name === 'canonical timestamp tag, report MISSING')!;
+      const r = recognizeConvergence(frontmatterFor(f), { requireReport: false, reportExists: false });
+      expect(r.accepted).toBe(true);
+      expect(r.reason).toBe('accepted');
+    });
+
+    it('flag ON: the same spec is REJECTED for the missing report', () => {
+      const f = FIXTURES.find((x) => x.name === 'canonical timestamp tag, report MISSING')!;
+      const r = recognizeConvergence(frontmatterFor(f), { requireReport: true, reportExists: false });
+      expect(r.accepted).toBe(false);
+      expect(r.reason).toBe('convergence-report-missing');
+    });
+
+    it('flag ON: the same spec is ACCEPTED once the report exists', () => {
+      const f = FIXTURES.find((x) => x.name === 'canonical timestamp tag, report MISSING')!;
+      const r = recognizeConvergence(frontmatterFor(f), { requireReport: true, reportExists: true });
+      expect(r.accepted).toBe(true);
+      expect(r.reason).toBe('accepted');
+    });
+
+    it('a converged spec missing the approved tag is rejected (approved-tag-missing) regardless of flag', () => {
+      const f = FIXTURES.find((x) => x.name === 'boolean true, not approved')!;
+      for (const requireReport of [false, true]) {
+        const r = recognizeConvergence(frontmatterFor(f), { requireReport, reportExists: true });
+        expect(r.accepted).toBe(false);
+        expect(r.reason).toBe('approved-tag-missing');
+      }
+    });
+
+    it('a spec with no convergence tag is rejected (convergence-tag-missing)', () => {
+      const f = FIXTURES.find((x) => x.name === 'no convergence tag')!;
+      const r = recognizeConvergence(frontmatterFor(f), { requireReport: false, reportExists: false });
+      expect(r.accepted).toBe(false);
+      expect(r.reason).toBe('convergence-tag-missing');
+    });
+  });
+});

--- a/tests/unit/instar-dev-precommit-audit-staging.test.ts
+++ b/tests/unit/instar-dev-precommit-audit-staging.test.ts
@@ -84,9 +84,12 @@ describe('instar-dev pre-commit — decision-audit line rides the commit (self-s
       path.join(sandbox, 'skills', 'instar-dev', 'scripts', 'verify-proposal-derived-runbook.mjs'),
       'export function verifyProposalDerivedRunbooks() { return { ok: true, reason: "ok" }; }\n',
     );
-    fs.copyFileSync(
-      path.join(path.dirname(HOOK_SCRIPT), 'lib', 'classify-tier.mjs'),
-      path.join(sandbox, 'scripts', 'lib', 'classify-tier.mjs'),
+    // Copy the whole scripts/lib dir so all of the hook's pure lib imports
+    // (classify-tier.mjs, convergence-recognition.mjs, …) resolve in the sandbox.
+    fs.cpSync(
+      path.join(path.dirname(HOOK_SCRIPT), 'lib'),
+      path.join(sandbox, 'scripts', 'lib'),
+      { recursive: true },
     );
     fs.copyFileSync(HOOK_SCRIPT, path.join(sandbox, 'scripts', 'instar-dev-precommit.js'));
   });
@@ -279,9 +282,12 @@ describe('instar-dev pre-commit — causalAutopsy (advisory slice)', () => {
       path.join(sandbox, 'skills', 'instar-dev', 'scripts', 'verify-proposal-derived-runbook.mjs'),
       'export function verifyProposalDerivedRunbooks() { return { ok: true, reason: "ok" }; }\n',
     );
-    fs.copyFileSync(
-      path.join(path.dirname(HOOK_SCRIPT), 'lib', 'classify-tier.mjs'),
-      path.join(sandbox, 'scripts', 'lib', 'classify-tier.mjs'),
+    // Copy the whole scripts/lib dir so all of the hook's pure lib imports
+    // (classify-tier.mjs, convergence-recognition.mjs, …) resolve in the sandbox.
+    fs.cpSync(
+      path.join(path.dirname(HOOK_SCRIPT), 'lib'),
+      path.join(sandbox, 'scripts', 'lib'),
+      { recursive: true },
     );
     fs.copyFileSync(HOOK_SCRIPT, path.join(sandbox, 'scripts', 'instar-dev-precommit.js'));
   });

--- a/tests/unit/instar-dev-precommit-deferrals.test.ts
+++ b/tests/unit/instar-dev-precommit-deferrals.test.ts
@@ -77,13 +77,16 @@ describe('instar-dev pre-commit — orphan deferrals enforcement', () => {
       'export function verifyProposalDerivedRunbooks() { return { ok: true, reason: "no-proposal-derived-runbooks-or-all-verified" }; }\n',
     );
 
-    // Copy the hook script under test + its new pure tier classifier dependency
-    // (scripts/lib/classify-tier.mjs) into the sandbox.
+    // Copy the hook script under test + its pure lib dependencies
+    // (scripts/lib/classify-tier.mjs + scripts/lib/convergence-recognition.mjs)
+    // into the sandbox so the spawned hook's relative imports resolve.
     fs.mkdirSync(path.join(sandbox, 'scripts', 'lib'), { recursive: true });
-    fs.copyFileSync(
-      path.join(path.dirname(HOOK_SCRIPT), 'lib', 'classify-tier.mjs'),
-      path.join(sandbox, 'scripts', 'lib', 'classify-tier.mjs'),
-    );
+    for (const lib of ['classify-tier.mjs', 'convergence-recognition.mjs']) {
+      fs.copyFileSync(
+        path.join(path.dirname(HOOK_SCRIPT), 'lib', lib),
+        path.join(sandbox, 'scripts', 'lib', lib),
+      );
+    }
     fs.copyFileSync(HOOK_SCRIPT, path.join(sandbox, 'scripts', 'instar-dev-precommit.js'));
   });
 

--- a/tests/unit/instar-dev-precommit-sha-error.test.ts
+++ b/tests/unit/instar-dev-precommit-sha-error.test.ts
@@ -71,9 +71,12 @@ describe('instar-dev pre-commit — artifact sha-mismatch error message', () => 
     );
     // Copy the hook + its new pure tier classifier dependency into the sandbox.
     fs.mkdirSync(path.join(sandbox, 'scripts', 'lib'), { recursive: true });
-    fs.copyFileSync(
-      path.join(path.dirname(HOOK_SCRIPT), 'lib', 'classify-tier.mjs'),
-      path.join(sandbox, 'scripts', 'lib', 'classify-tier.mjs'),
+    // Copy the whole scripts/lib dir so all of the hook's pure lib imports
+    // (classify-tier.mjs, convergence-recognition.mjs, …) resolve in the sandbox.
+    fs.cpSync(
+      path.join(path.dirname(HOOK_SCRIPT), 'lib'),
+      path.join(sandbox, 'scripts', 'lib'),
+      { recursive: true },
     );
     fs.copyFileSync(HOOK_SCRIPT, path.join(sandbox, 'scripts', 'instar-dev-precommit.js'));
   });

--- a/upgrades/next/converging-audit-default.md
+++ b/upgrades/next/converging-audit-default.md
@@ -1,0 +1,60 @@
+<!-- bump: minor -->
+
+## What Changed
+
+Spec #4 of the cartographer-conformance project — **fixes a real defect in the
+convergence gate and makes the report-backed converging audit the structural
+default** (dark, off by default).
+
+The defect: the formal initiative gate (`StageTransitionValidator`) required the
+`review-convergence` frontmatter tag to equal the boolean `true`, but the actual
+converging-audit tooling writes an ISO **timestamp string**. A timestamp is not the
+boolean `true`, so the formal gate **rejected every properly-converged spec** at the
+`spec-drafted → spec-converged` transition — quietly broken. This change adds a pure
+`isConvergenceTagPresent` predicate that accepts the canonical timestamp (and still
+the legacy boolean), used as the single definition of "the tag is present."
+
+On top of the defect repair, a new default-off flag `specReview.requireConvergenceReport`
+makes the converging audit's **report** (the proof it actually ran) a requirement of
+the commit-time gate when enabled — so "converged" can mean "the audit ran and left a
+report," not just "a tag was added." The commit-time gate reads the flag via an
+environment variable (it runs before compilation and reads no config), exported from
+config by the husky hook; when unset, the commit-time gate behaves exactly as before.
+The formal gate's existing report requirement is left unconditional, so enabling the
+flag brings the two gates into agreement — and a cross-gate consistency test makes it
+impossible for them to drift apart. Whether an outside model also reviewed a spec is
+surfaced in the gate's diagnostics, never required.
+
+## Evidence
+
+- **Before:** a spec converged via the real tooling carries
+  `review-convergence: "2026-06-10T…"`. Feeding it to the formal gate returned
+  `CONVERGENCE_TAG_MISSING` because `"2026-06-10T…" !== true` — the `spec-drafted →
+  spec-converged` transition could not advance any real spec. (The existing tests only
+  ever fed the boolean `true`, which is why the defect shipped unnoticed.)
+- **After:** the same timestamp-tagged + reported spec advances through the real
+  `POST /projects/:id/advance` route (new integration test); a timestamp-tagged spec
+  with a MISSING report still returns `CONVERGENCE_REPORT_MISSING` (the existing,
+  unchanged check); and a new predicate test covers timestamp / boolean / empty /
+  missing.
+- **Back-compat verified end-to-end:** a test runs the real commit-time gate script —
+  with the flag unset, a timestamp-tagged + approved spec with no report commits
+  cleanly (identical to today); with the flag on and no report, it is blocked; with
+  the report present, it commits. This PR's own commit passes through the modified gate
+  with the flag off.
+
+## What to Tell Your User
+
+- **The review gate was quietly broken — now it's fixed and means something**: "The
+  check that confirms a design was properly reviewed before it ships had a bug — it was
+  looking for the wrong marker, so it actually rejected every correctly-reviewed
+  design. I repaired it, and added an opt-in setting that makes 'reviewed' require the
+  review's report to actually exist, not just a tag. It's off by default, so nothing in
+  your current workflow changes until you turn it on."
+
+## Summary of New Capabilities
+
+| Capability | How to Use |
+|-----------|-----------|
+| Report-backed convergence gate | `specReview.requireConvergenceReport: true` in config (opt-in; off by default) |
+| Correct convergence-tag recognition | automatic — the formal gate now accepts the canonical timestamp tag |

--- a/upgrades/side-effects/converging-audit-default.md
+++ b/upgrades/side-effects/converging-audit-default.md
@@ -1,0 +1,82 @@
+# Side-Effects Review — Report-Backed Converging Audit (spec #4, Tier 2)
+
+**Version / slug:** `converging-audit-default`
+**Date:** `2026-06-10`
+**Author:** `Echo`
+**Spec:** `docs/specs/CONVERGING-AUDIT-DEFAULT.md` (converged 1 round + a focused buildability/back-compat review, approved)
+**Second-pass reviewer:** `not required — a focused convergence review verified the bug + the byte-identical back-compat + pinned the env-var threading; this review covers the seven dimensions on the as-built code`
+
+## Summary of the change
+
+Fixes the convergence gate and makes the report-backed converging audit the default
+(dark): **(A)** `StageTransitionValidator` checked `review-convergence === true`
+(boolean) but the real tooling writes a timestamp string — so the formal gate
+**rejected every properly-converged spec**; fixed via a pure `isConvergenceTagPresent`
+predicate that accepts the canonical timestamp (and boolean `true` for back-compat).
+**(B)** A default-off `specReview.requireConvergenceReport` flag that, when on, makes
+the precommit gate also require the convergence **report** file (proof the audit ran)
+— the precommit reads it via an env var (it runs pre-compile and reads no config).
+**(C)** A cross-gate consistency test so the formal validator and the precommit gate
+cannot drift apart. **(D)** Surfaces the `cross-model-review` value in diagnostics
+(observe-only).
+
+## Files touched
+
+- `src/core/StageTransitionValidator.ts` — `isConvergenceTagPresent` predicate (Part A). The existing `CONVERGENCE_REPORT_MISSING` check is UNCHANGED + unconditional.
+- `src/config/ConfigDefaults.ts` + `src/core/types.ts` — `specReview.requireConvergenceReport: false` (deep-merge backfill).
+- `scripts/instar-dev-precommit.js` — Step-6 recognition routed through the new pure module; env-gated report check (Part B); cross-model surfacing (Part D).
+- `.husky/pre-commit` — fail-open one-liner exporting the env from config.
+- NEW `scripts/lib/convergence-recognition.mjs` — the pure recognizer both the precommit and the consistency test use.
+- Tests: validator (timestamp acceptance), consistency, `/projects/:id/advance` integration, the real-precommit E2E.
+
+## 1. Over-block
+
+Part A makes the formal gate accept MORE (the timestamp it should always have
+accepted) — it can never over-block more than before. Part B's report requirement can
+over-block only when the flag is ON (default off); and the formal gate already
+required the report unconditionally, so Part B merely brings the precommit to parity.
+
+## 2. Under-block
+
+Could a spec fake convergence? With the flag on, the report file must exist — a
+hand-added tag alone no longer passes the precommit. With the flag off, behavior is
+unchanged from today (the report requirement is inert). The predicate rejects
+empty/false/missing tags (tested).
+
+## 3. Level-of-abstraction fit
+
+The recognition logic is factored into one pure module (`convergence-recognition.mjs`)
+the precommit imports; the validator has its own pure predicate; a consistency test
+binds them. This is the right shape given the compile boundary (the precommit `.js`
+cannot import the TS validator).
+
+## 4. Back-compat safety (the critical dimension — this gate runs on every commit)
+
+The flag defaults false and the precommit's new branch is gated on the env var being
+`1`; when unset, the report `fs.existsSync` probe is skipped and the Step-6 checks
+reuse the IDENTICAL regexes as before — byte-identical. The `.husky/pre-commit` config
+read is fail-open (any error → env unset → today's behavior). **An E2E test runs the
+REAL precommit script and proves: env unset → a timestamp-tagged+approved spec with no
+report commits cleanly; env=1 + no report → blocked; env=1 + report → commits.** This
+very PR's own commit goes through the modified precommit with the flag off — a live
+proof the default path works.
+
+## 5. Tier-1 exemption
+
+The precommit's `tier1-lite` path exits before Step 6, so the new report check
+correctly does not apply to Tier-1 commits; the consistency test scopes its precommit
+fixtures to the tier-2/3 path.
+
+## 6. Security / load
+
+None — build-time gate only. The new checks are local `fs.existsSync`; no network, no
+LLM in-gate. No load impact.
+
+## 7. Migration / compatibility
+
+`specReview.requireConvergenceReport` rides `applyDefaults` add-missing deep-merge
+(Migration Parity automatic — no `migrateConfig` block). This is a dev-process gate,
+NOT an agent-facing runtime capability — so no CLAUDE.md template / migrateClaudeMd
+section is required (the feature-completeness test governs only agent-facing
+capabilities; verified it stays green) and no new route. Rollback: the flag
+default-false IS the rollback.


### PR DESCRIPTION
Spec #4 of **cartographer-conformance**. Fixes a genuine defect in the convergence gate and makes the report-backed converging audit the structural default (dark, off by default).

## The bug (verified, grounded)

`StageTransitionValidator` blocked `spec-drafted → spec-converged` unless `review-convergence === true` (a **boolean**) — but the converging-audit tooling (`write-convergence-tag.mjs`) writes `review-convergence: "<ISO timestamp>"` (a **string**). Since `"2026-…" !== true`, the formal gate **rejected every properly-converged spec**. It had been quietly broken (the existing tests only ever fed the boolean `true`, which is why it shipped unnoticed). Fixed via a pure `isConvergenceTagPresent` predicate that accepts the canonical timestamp (and the legacy boolean). The existing unconditional `CONVERGENCE_REPORT_MISSING` check is untouched.

## Make it the default (dark)

A default-off `specReview.requireConvergenceReport` flag: when on, the commit-time gate ALSO requires the convergence **report** file (proof the audit ran, not a fakeable tag), bringing it to parity with the formal gate (which already requires the report). The precommit reads the flag via env var `INSTAR_DEV_REQUIRE_CONVERGENCE_REPORT` (it runs pre-compile / reads no config; the husky hook exports it from config, fail-open). **Flag off → the commit-time gate is byte-identical to today** (proven by an E2E running the real script). A cross-gate consistency test binds the formal validator and the precommit recognition so they cannot drift apart. The `cross-model-review` status is surfaced in diagnostics (observe-only, never blocks).

This is a dev-process gate, not an agent-facing runtime capability — no CLAUDE.md/route change.

## Tests (green locally)
Validator (timestamp acceptance + the predicate, existing boolean tests stay green), cross-gate consistency (shared fixture table under both flag states), `/projects/:id/advance` integration (the bug-fix through the real route + still-blocks-on-missing-report), and an E2E running the REAL precommit proving the default-off path commits cleanly + the flag-on path blocks without a report.

## ELI16 — Report-Backed Converging Audit

The check that confirms a design was properly reviewed before it ships had a bug: it looked for the word `true`, but the review tool writes a timestamp — so it rejected every correctly-reviewed design. This repairs it (accept the timestamp, still accept the old `true`), and adds an opt-in switch that makes "reviewed" require the review's report file to actually exist, not just a tag anyone could type. It's off by default, so today's commit workflow is unchanged until you turn it on. The two guards (the formal one and the commit-time one) can't share code — one runs before compilation — so a test feeds both the same examples and fails the build if they ever disagree. Structure, not willpower.

🤖 Generated with [Claude Code](https://claude.com/claude-code)