### PR TITLE
feat(dev-gate): enforce dark-feature gate + cartographer conformance

### DIFF
--- a/.instar/instar-dev-decisions/2026-06-10T21-55-45-885Z-dev-agent-dark-gate-enforcement.json
+++ b/.instar/instar-dev-decisions/2026-06-10T21-55-45-885Z-dev-agent-dark-gate-enforcement.json
@@ -1,0 +1,17 @@
+{
+  "ts": "2026-06-10T21:55:45.885Z",
+  "slug": "dev-agent-dark-gate-enforcement",
+  "suggestedTier": 2,
+  "declaredTier": 3,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "irreversibility: src/core/PostUpdateMigrator.ts touches PostUpdateMigrator",
+    "migration / fleet-rollout surface: src/core/PostUpdateMigrator.ts touches PostUpdateMigrator (fleet migration machinery)",
+    "new capability: new config key added"
+  ],
+  "belowFloor": false,
+  "files": 7,
+  "loc": 615,
+  "causalAutopsy": null,
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-06-10T21-57-34-597Z-dev-agent-dark-gate-enforcement.json
+++ b/.instar/instar-dev-decisions/2026-06-10T21-57-34-597Z-dev-agent-dark-gate-enforcement.json
@@ -1,0 +1,17 @@
+{
+  "ts": "2026-06-10T21:57:34.597Z",
+  "slug": "dev-agent-dark-gate-enforcement",
+  "suggestedTier": 2,
+  "declaredTier": 3,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "irreversibility: src/core/PostUpdateMigrator.ts touches PostUpdateMigrator",
+    "migration / fleet-rollout surface: src/core/PostUpdateMigrator.ts touches PostUpdateMigrator (fleet migration machinery)",
+    "new capability: new config key added"
+  ],
+  "belowFloor": false,
+  "files": 7,
+  "loc": 615,
+  "causalAutopsy": null,
+  "verdict": "pass"
+}

--- a/docs/specs/DEV-AGENT-DARK-GATE-ENFORCEMENT-SPEC.md
+++ b/docs/specs/DEV-AGENT-DARK-GATE-ENFORCEMENT-SPEC.md
@@ -1,0 +1,284 @@
+---
+title: Dev-Agent Dark-Gate Enforcement — deliberate-classification guard + cartographer conformance
+status: draft
+parent-principle: "Structure beats Willpower"
+tags: [side-effects]
+author: echo
+created: 2026-06-10
+eli16-overview: dev-agent-dark-gate-enforcement.eli16.md
+relates_to:
+  - DEV-AGENT-DARK-GATE-CONFORMANCE-SPEC.md
+  - STANDARDS-REGISTRY.md (standard_development_agent_dark_feature_gate)
+  - CARTOGRAPHER-DOC-FRESHNESS.md
+  - CARTOGRAPHER-CONFORMANCE-AUDIT.md
+  - CARTOGRAPHER-SUBTREE-NAV.md
+review-convergence: "2026-06-10T21:26:30.795Z"
+review-iterations: 3
+review-completed-at: "2026-06-10T21:26:30.795Z"
+review-report: "docs/specs/reports/dev-agent-dark-gate-enforcement-convergence.md"
+cross-model-review: "skipped-abbreviated"
+cross-model-review-reason: "external CLIs (codex/gemini/grok) unavailable on host this session; 5 internal reviewers incl. mandatory lessons-aware ran every round"
+approved: true
+approved-by: "Justin (topic 22726) — explicit greenlight 'yes, lets do what we can to enforce the disabled:false for developer agents'; approval model B (agent applies approved on converged spec, operator merge is the gate)"
+approved-at: "2026-06-10T21:26:30Z"
+---
+
+# Dev-Agent Dark-Gate Enforcement
+
+## ELI16 — One deliberate choice per dark feature, enforced; cartographer's zero-cost surfaces dogfood live on dev agents; the one cost-bearing surface stays an explicit opt-in.
+
+## Why this exists (grounded requirement)
+
+Justin, 2026-06-10, topic 22726 — after noticing the just-shipped cartographer
+features were OFF even on Echo (a development agent):
+
+> "this is not just an 'Echo' issue. The 'default: enabled' for new features
+> should be the case for ALL 'developer' agents … obviously it didn't get
+> encoded/enforced."
+
+And, correcting a bad framing of mine in the same thread:
+
+> "there's no difference between sending code to an 'outside' model like Codex
+> than sending it to you. This seems silly."
+
+Two true things:
+
+1. **The dev-agent dark-gate standard already exists and is enforced** —
+   `resolveDevAgentGate` (`src/core/devAgentGate.ts`), the `DEV_GATED_FEATURES`
+   registry + both-sides wiring test, and `scripts/lint-dev-agent-dark-gate.js`
+   (born from PR #1001). My earlier claim that it was "wired to nothing" was
+   wrong — I grepped a stale branch.
+
+2. **The guard has a hole, and cartographer fell through it.** The lint's
+   assertion B only fires when a `ConfigDefaults` block carries a comment
+   *referencing* the gate convention. A feature that hardcodes `enabled: false`
+   with no such marker — exactly the cartographer specs (#2/#3/#5) — is invisible
+   to the guard. It shipped dark for EVERYONE, dev agents included, no CI failure.
+   The lint can't tell *"deliberately off for everyone"* (the destructive
+   `mcpProcessReaper`) from *"forgot to opt in"* (cartographer). That is the hole.
+
+### The egress correction → decouple privacy from cost (the load-bearing design decision)
+
+I had gated cartographer's summary-authoring behind a separate
+`egressAcknowledged` consent switch framed as "sending source to codex is a
+privacy danger." Justin is right that the *privacy* framing is incoherent: the
+agent sends the operator's source to an outside model (Anthropic) every turn by
+design; a second provider seeing it is a trust *preference*, not a novel
+boundary. **So the privacy gate goes.**
+
+But round-1 convergence (all five reviewers) caught that `egressAcknowledged` was
+silently doing a SECOND job: it was the only per-feature consent for an
+**ongoing-cost** background process — the freshness sweep makes cadenced
+off-Claude (codex) calls that bill a third-party account. Collapsing it into the
+dev-gate would **auto-arm recurring third-party spend on every dev agent at once**
+the moment they update — precisely the P19 "no auto-armed background loop /
+rollout blast radius" mistake (earned from the #867 live-tail spiral and the
+listSessions / reaper-kill hot-loops).
+
+**Resolution — separate the two axes the old flag conflated:**
+
+| Surface | Egress? | Ongoing cost? | Default on a DEV agent | Default on the fleet |
+|---|---|---|---|---|
+| doc-tree / `GET /cartographer/*` read, subtree navigate | local-only, **zero** | none | **LIVE** (dev-gated) | dark |
+| conformance-coverage audit (deterministic core) | local-only, **zero** | none | **LIVE** (dev-gated) | dark |
+| **freshness sweep** (authors summaries via codex) | yes | **yes (off-Claude spend)** | **OFF — explicit one-line opt-in** | dark |
+| llmEnrichment / llmRerank | n/a — **unwired stubs** | none | OFF (excluded: no pipeline) | OFF |
+
+The zero-cost read surfaces dogfood live on dev agents automatically (Justin's
+actual complaint — the bulk of cartographer was dark on Echo). The **one**
+cost-bearing surface (the sweep) stays an explicit opt-in EVEN on a dev agent —
+not because of privacy (that gate is gone) but because auto-arming recurring
+third-party spend across an agent class is a P19 blast-radius decision, not a
+per-pass-bounds decision. Because the sweep is now an explicit single honest flag
+(`freshnessSweep.enabled: true`), the redundant `egressAcknowledged` second gate
+is removed entirely (Justin's "silly" — correct, once cost is handled by the
+explicit opt-in). The off-Claude **routing probe stays** (the sweep refuses to
+author on Claude) — that guard is about cost, and cost still matters.
+
+> **Open decision #2 is hereby RESOLVED in-spec** (per P3/P10 — decided here, in
+> this change): the sweep is an explicit opt-in even on dev agents. If
+> Justin wants it auto-armed on dev agents too, that is a one-line change (move
+> `freshnessSweep.enabled` into `DEV_GATED_FEATURES`), but this spec ships the
+> safer default.
+
+## The standard being enforced (unchanged)
+
+```ts
+const enabled = cfg?.enabled ?? !!config.developmentAgent;  // resolveDevAgentGate
+```
+
+A dev-gated dark feature OMITS `enabled`; the runtime resolves it through
+`resolveDevAgentGate`. Live on `developmentAgent: true`, dark on the fleet,
+explicit `enabled` always wins.
+
+## Slice A — Cartographer conformance (dogfood the zero-cost surfaces)
+
+**A1. Gate the umbrella.** `ConfigDefaults.ts` cartographer block: remove
+`enabled: false` (OMIT). `src/commands/server.ts` (~L8415): replace
+`(config as …).cartographer?.enabled ?? false` with
+`resolveDevAgentGate(config.cartographer?.enabled, config)`. Register
+`cartographer.enabled` in `DEV_GATED_FEATURES`.
+
+**A2. Gate the conformance audit (zero-cost deterministic core).** OMIT
+`cartographer.conformanceAudit.enabled` from defaults; register it. **Fix the
+route gate:** `src/server/routes.ts:~4303` currently `if (cfg?.enabled !== true)
+… 503`. A strict `!== true` returns 503 on a dev agent (undefined !== true) even
+after registration — a wiring-test-green / feature-dark divergence. Change every
+such cartographer gate site to `if (!resolveDevAgentGate(cfg?.enabled, ctx.config))`.
+Enumerate ALL strict `=== true` / `!== true` cartographer enable checks (audit
+routes.ts + server.ts) and convert each; the build must grep-verify none remain.
+
+**A3. The freshness sweep stays an explicit opt-in (NOT dev-gated).**
+`freshnessSweep.enabled` keeps its `enabled: false` default and is placed in
+`DARK_GATE_EXCLUSIONS` (category `cost-bearing`). **Remove the
+`&& fsCfg?.egressAcknowledged` term** from the single construction site
+(`server.ts:8435`) so the sweep needs only the one honest `enabled: true`. The
+off-Claude routing probe and all per-pass bounds (`maxNodesPerPass`,
+`maxCentsPerPass`, CPU-pressure yield, lease-gating, breaker) are UNCHANGED.
+
+**A4. Exclude the unwired stubs.** `conformanceAudit.llmEnrichment.enabled` and
+`subtreeNav.llmRerank.enabled` have **no runtime consumer** (confirmed: the
+shipped auditor/navigator make no LLM calls). Do NOT register them — a gate over
+a dead flag asserts nonexistent behavior. Place both in `DARK_GATE_EXCLUSIONS`
+(category `structural-stub`, reason "no LLM pipeline wired").
+
+## Slice B — Close the hole (deliberate-classification guard)
+
+Every `enabled: false` in `ConfigDefaults.ts` must be a DECLARED choice.
+
+**B1. Exclusion registry with a quality bar.** Add `DARK_GATE_EXCLUSIONS` to
+`src/core/devGatedFeatures.ts`: `{ configPath, category, reason }[]`, where
+`category` is a CLOSED enum — `destructive` | `optional-integration` |
+`cost-bearing` | `structural-stub` | `deliberate-fleet-default` — and `reason` is
+free text. The lint REJECTS an entry with an unknown category or a reason shorter
+than 12 non-whitespace chars (defeats `reason:'x'` placeholders).
+
+**B2. Lint assertion C — no unclassified dark default.** For every
+`enabled: false` in `ConfigDefaults.ts`, the enclosing feature's config path must
+be EITHER registered in `DEV_GATED_FEATURES` (→ surfaced as "registered but still
+hardcodes false: OMIT it") OR in `DARK_GATE_EXCLUSIONS`. Neither → violation.
+Retain assertions A and B.
+
+  - **Path attribution discipline (explicit, tested, honest about its limit).**
+    The brace-tracker that maps an `enabled:` line to its dotted path MUST reuse
+    the existing `codeOnly()` helper so braces inside `//` comments (e.g. the
+    `{ran:false}` literal at L423) and trailing-comment braces never count toward
+    depth. **`codeOnly()` strips `//` line-comments only — it does NOT skip
+    braces inside string/template literals** (verified: lint script L73). Rather
+    than claim a coverage the helper lacks (P2 Signal-vs-Authority — the same
+    honesty bar assertion C is held to), the lint adds a **loud-fail guard**: if
+    any line in the `SHARED_DEFAULTS` region contains a `{` or `}` inside a
+    string/template literal, the lint ERRORS ("brace-in-string in the defaults
+    block can desync path attribution — split the value or extend the parser")
+    instead of silently desyncing. Today zero such lines exist in the block
+    region (the `${path}.${key}` template literals are after the last
+    `enabled:false`), so the guard is dormant; it fires the instant the
+    unhandled case is introduced.
+  - **Golden-path drift canary — hand-authored, regeneration-forbidden.** A test
+    asserts the resolver returns the EXACT expected dotted path for every current
+    `enabled:` line. The expected `{line → dottedPath}` map is a **hand-maintained
+    literal in the test file — NOT a vitest/jest snapshot artifact and NEVER
+    derived from the resolver's own output** (a snapshot regenerated from the
+    resolver asserts `output == output` and blesses any misattribution). A
+    comment forbids regeneration-from-resolver; updating the map is a hand edit on
+    a CODEOWNERS-reviewed path. This is what makes a deterministic-but-wrong
+    attributor fail CI instead of passing it.
+
+  - **Declared limitation (P2 Signal-vs-Authority — do NOT claim full closure).**
+    Assertion C matches the literal `enabled: false` spelling only. A non-literal
+    default (`enabled: someFlag ?? false`) evades it — the same miss named in the
+    prior conformance spec's Layer-2 row. This spec **carries that miss forward
+    explicitly**: C closes the literal-false hole (which is what cartographer and
+    #1001 were), not the non-literal-expression hole. The lint prints this limit
+    in its failure header so no future reader treats C as total coverage.
+
+**B3. Classify the existing 21 as an auditable table.** A one-time pass sorts
+every current `enabled: false` to gate-vs-exclude. Because the wiring test
+*confirms* gating but cannot *validate* it (a wrongly-gated feature passes its
+live-on-dev/dark-on-fleet assertions), the classification ships as a single
+reviewable table (configPath, category, reason) in the PR body AND as the seeded
+registries. **Safety guard (a marker denylist — limit declared, human gate is the real
+backstop).** The assertion-C tests assert that any block whose body contains a
+destructive/credentialed marker (`dryRun`, kill/delete verbs, a third-party
+`framework`/credential key) is NOT in `DEV_GATED_FEATURES` — so a future attempt
+to silently dev-gate a marker-bearing destructive feature (e.g.
+`mcpProcessReaper`, which carries `dryRun: true`) trips a test, not just review.
+**This is a denylist, not a structural property** (P2 — same limit class as
+assertion C): a destructive feature that omits those markers (no dry-run mode, a
+synonym like `simulate`/`safeMode`, or destructiveness behind a neutrally-named
+flag) would NOT trip it. So the **real backstop is the human gate, named as
+such**: `DEV_GATED_FEATURES` and `DARK_GATE_EXCLUSIONS` are CODEOWNERS-reviewed
+paths, and every addition to `DEV_GATED_FEATURES` must carry a one-line
+"non-destructive, safe-to-run-live-on-dev" justification in the entry. The lint
+denylist is a tripwire over the common case, not a proof. Known excludes seeded
+with reasons: `mcpProcessReaper` (destructive), the cartographer sweep + stubs
+(above), and the optional integrations.
+
+## Migration Parity (SHIPPED in this PR — P3/P10)
+
+Existing dev agents already have `cartographer.enabled: false` on disk, so
+`applyDefaults` add-missing leaves them DARK after update — the motivating case
+(Echo) would not light up. A feature that only works for new agents is broken.
+**Ship a scoped, one-shot migration** in `PostUpdateMigrator`:
+
+- Runs ONLY when `config.developmentAgent === true`.
+- Gated by a one-shot migration-version marker (`_instar_migrations` /
+  equivalent) so it executes exactly once and can NEVER re-strip a value the
+  operator later re-adds — this is the provenance discriminator (value alone
+  can't distinguish a deliberate operator `false` from the old default `false`;
+  the run-once marker means we only ever touch the original default, once).
+- Strips a default-shaped `cartographer.enabled: false` and
+  `cartographer.conformanceAudit.enabled: false` (the ZERO-COST read surfaces)
+  so the gate now decides them live on the dev agent.
+- **Never touches `freshnessSweep.enabled`** — the cost-bearing surface is never
+  auto-armed by an update (the P19 / Migration-Parity "no surprise activation on
+  update" guard; the zombie-cleanup precedent).
+- Idempotent, existence-checked, records the change in `result.upgraded`.
+
+No `generateClaudeMd` change — confirmed: the cartographer CLAUDE.md sections
+already exist and describe the capability; this changes WHEN dark resolves to
+live, not the capability surface. The `egressAcknowledged` neutralization is noted
+in the upgrade-guide fragment as a deliberate behavior change (No Silent
+Degradation: an operator who set it `false` should be told it's now inert; since
+the sweep still needs explicit `enabled:true`, no surprise spend results).
+
+## Testing (three tiers)
+
+- **Unit:** (1) the new `cartographer.enabled` + `conformanceAudit.enabled`
+  registry entries drive `devGatedFeatures-wiring.test.ts` (live-on-dev /
+  dark-on-fleet auto-asserted). (2) Assertion-C tests: an unclassified
+  `enabled:false` FAILS; same path added to exclusions PASSES; a registered path
+  that still hardcodes `false` FAILS; an exclusion with junk/short reason or
+  unknown category FAILS. (3) Golden-path drift-canary: a HAND-AUTHORED literal
+  `{line → dottedPath}` map for ALL current `enabled:` blocks (NOT a vitest
+  snapshot, NEVER regenerated from the resolver) — the resolver must match it.
+  (3b) Brace-in-string loud-fail: a fixture with a `{`-bearing string default in
+  the block region makes the lint ERROR, not silently desync. (4) Destructive-
+  not-gated guard test (mcpProcessReaper stays excluded). (5) The B3 invariant —
+  every current `enabled:false` is classified.
+- **Integration:** with `developmentAgent:true`, `GET /cartographer/health` AND
+  `GET /conformance/coverage` return **200** (not 503) through the real server
+  wiring; with a fleet config both 503. Asserts the route-gate fix (A2), the live
+  failure mode the strict `!== true` would have produced.
+- **E2E:** production init path with `developmentAgent:true` vs fleet config —
+  cartographer read routes live in the former, 503 in the latter; the sweep poller
+  is NOT started in either without explicit `freshnessSweep.enabled:true` (proves
+  the cost surface is not auto-armed).
+
+## Security / adversarial (round-1 hardening folded in)
+
+- `developmentAgent` is operator-set, runtime-read-only, not API-mutable, not
+  auto-derived — the gate can't be flipped by a token holder or malicious input.
+- Cost/spend can no longer be auto-armed across the dev fleet (A3): the one
+  cost-bearing surface needs an explicit flag everywhere.
+- The exclusion registry's value is **diffability + a category/reason quality
+  bar**, not prevention — stated plainly so reviewers aren't lulled. The
+  destructive-not-gated test is the structural backstop. Adding to
+  `DARK_GATE_EXCLUSIONS` should be a CODEOWNERS-reviewed path.
+- The lint is deterministic, parses only the one defaults file, no egress/LLM.
+
+## Open decisions for the operator
+
+1. **Auto-arm the sweep on dev agents too?** This spec defaults it to explicit
+   opt-in even on dev agents (P19-safer). Flip = one line (move
+   `freshnessSweep.enabled` to `DEV_GATED_FEATURES`). Operator's call.

--- a/docs/specs/dev-agent-dark-gate-enforcement.eli16.md
+++ b/docs/specs/dev-agent-dark-gate-enforcement.eli16.md
@@ -1,0 +1,65 @@
+# Dev-Agent Dark-Gate Enforcement — Plain-English Overview
+
+## The one-sentence version
+
+Make sure new features that are supposed to "run for the people building Instar
+but stay off for everyone else" actually do that — and make it impossible to
+forget the rule again — while also fixing the cartographer features, which forgot
+it.
+
+## Why we need this
+
+Instar has a deliberate pattern: a brand-new feature ships **dark** (off) for the
+whole fleet of agents, but runs **live** for "development agents" — the ones
+whose operators opted in to dogfood unproven features so they can mature before
+everyone gets them. There's already machinery for this: a helper that decides
+on/off, a list of features that follow the pattern, a test, and a lint.
+
+The problem Justin caught: the cartographer features I just shipped **bypassed**
+that machinery. They hardcoded themselves "off," with no marker the lint looks
+for, so they shipped dark for *everyone* — including the dev agent that was
+supposed to be dogfooding them. The lint couldn't catch it because it can't tell
+"deliberately off for everyone" (like a process-killer that should never auto-run)
+from "oops, forgot to opt in."
+
+## What this changes
+
+Two things:
+
+1. **Cartographer dogfoods properly.** Its read-only surfaces (the codebase map,
+   the navigator, the standards audit — none of which send anything off your
+   machine and none of which cost anything) now run live on a dev agent
+   automatically. The one surface that *does* cost money — a background "sweep"
+   that pays an outside model to write summaries — stays an explicit one-line
+   opt-in, even on a dev agent.
+
+2. **The rule gets teeth.** Every feature that ships "off" must now make a
+   *declared* choice: either it's dev-gated (dogfooded), or it's on a documented
+   "off for everyone, on purpose" list with a category and a real reason. A
+   feature that just quietly hardcodes "off" now fails the build — the exact way
+   cartographer slipped through is closed.
+
+## The egress thing (and the correction)
+
+I had originally treated "this feature sends your code to an outside model
+(Codex)" as a scary privacy danger needing its own consent switch. Justin pointed
+out that's silly: the agent sends your code to an outside model (me, Anthropic)
+on *every* turn already. A second provider seeing it is a preference, not a new
+danger. So that privacy gate is gone.
+
+But review caught that the same switch was *also* quietly serving as the "yes, I
+accept the ongoing cost" confirmation for that background sweep. So we split the
+two ideas apart: the privacy gate is deleted (Justin's right), but the sweep
+still needs one honest "turn this on" flag — not for privacy, purely so an update
+can never silently start spending money on every dev agent at once.
+
+## The main tradeoff
+
+Dogfood-by-default is good (features mature instead of rotting dark), but
+"on-by-default across a whole class of agents" is exactly how Instar has burned
+itself before with runaway background jobs. The resolution: the free, read-only
+surfaces go live automatically; the one money-spending surface stays a deliberate
+flip. That gives the dogfooding benefit without arming a background spender behind
+anyone's back. Existing dev agents (like Echo) get the read surfaces switched on
+by a one-time, run-once migration so the fix reaches them too — not just
+freshly-installed agents.

--- a/docs/specs/reports/dev-agent-dark-gate-enforcement-convergence.md
+++ b/docs/specs/reports/dev-agent-dark-gate-enforcement-convergence.md
@@ -1,0 +1,128 @@
+# Convergence Report — Dev-Agent Dark-Gate Enforcement
+
+## ELI10 Overview
+
+Instar ships new features "dark" — off for the whole fleet, but live for
+*development agents* (the ones opted in to dogfood unproven features). There's
+already machinery enforcing this (a resolver helper, a registry, a test, a lint).
+The cartographer features shipped recently **bypassed** it — they hardcoded
+themselves off with no marker, so they shipped dark for *everyone*, including the
+dev agent meant to be dogfooding them. The lint couldn't catch it because it
+can't distinguish "deliberately off for everyone" (a destructive process-killer)
+from "forgot to opt in" (cartographer).
+
+This spec does two things: (A) routes cartographer's *zero-cost* surfaces through
+the existing gate so they run live on dev agents, while keeping the one
+*cost-bearing* surface (a background sweep that pays an outside model) an explicit
+opt-in; and (B) closes the lint hole so every "off by default" feature must make a
+*declared* choice — dev-gated, or on a documented exclusion list with a category
+and a real reason.
+
+## Original vs Converged
+
+The first draft was directionally right but review changed it substantially in
+ways that mattered:
+
+- **It would have auto-armed third-party spend on every dev agent.** The original
+  draft "neutralized" a separate egress-consent switch and let the dev-gate alone
+  turn on the cost-bearing background sweep. Killing the *privacy* framing was
+  correct (the agent sends source to an outside model every turn anyway), but that
+  switch was *also* the only "I accept the ongoing cost" confirmation. Collapsing
+  it meant a routine update would silently start a money-spending background job
+  across the whole dev fleet — the exact "runaway background loop" mistake Instar
+  has been burned by. **Converged: split privacy from cost.** The free read
+  surfaces go live on dev agents; the one spending surface stays an explicit
+  one-line opt-in everywhere; the redundant privacy switch is removed.
+- **It would have shipped a feature that's dark on a route even after "fixing" it.**
+  The conformance audit's route gate uses a strict `!== true` check, so omitting
+  the default would 503 on a dev agent while the wiring test passed — a
+  green-test/dark-feature divergence. **Converged: every strict gate site is
+  converted to the resolver, with a build-time grep-verify and a 200-not-503
+  integration test.**
+- **It would have gated two dead flags.** Two egress sub-flags
+  (`llmEnrichment`, `llmRerank`) have no runtime consumer — registering them would
+  assert behavior that doesn't exist. **Converged: excluded as structural stubs.**
+- **Its enforcement was gameable and its test was self-defeating.** The exclusion
+  list had no quality bar (a one-word reason passed); the path-attribution parser
+  was claimed to skip strings when it doesn't; and the "drift canary" test was a
+  snapshot regenerated from the very resolver it was meant to check (asserting
+  output == output). **Converged: a closed category enum + minimum reason length;
+  an honest declaration that the parser only strips comments plus a loud-fail
+  guard for the unhandled case; and a hand-authored (never regenerated) golden
+  path map.**
+- **It left Migration Parity as an open question.** Existing dev agents already
+  have the feature hardcoded off on disk, so they'd stay dark after update — the
+  motivating agent (Echo) wouldn't light up. **Converged: ship a scoped, one-shot,
+  dev-agent-only migration that strips only the zero-cost defaults and never the
+  sweep.**
+
+## Iteration Summary
+
+| Iteration | Reviewers who flagged | Material findings | Spec changes |
+|-----------|-----------------------|-------------------|--------------|
+| 1 | security, scalability, adversarial, integration, lessons-aware | ~13 (multiple high: auto-armed sweep spend across dev fleet; strict `!== true` route gate darks dev agents; unwired stubs; exclusion-list no quality bar; Migration Parity left open; brace-tracker fragility) | Full v2 rewrite: privacy/cost decoupling (sweep stays explicit opt-in, not dev-gated); route-gate conversion + grep-verify; stubs excluded; category-enum + min-reason quality bar; SHIPPED scoped one-shot migration; declared assertion-C literal-only limit; golden-path drift canary |
+| 2 | adversarial (3 new) | 3 (golden-path snapshot self-defeating; codeOnly() string-skip overclaim; destructive-not-gated denylist evadable) | v3 honesty/precision: hand-authored regeneration-forbidden canary; drop false string-skip claim + add loud-fail brace-in-string guard; declare denylist limit + name CODEOWNERS human backstop |
+| 3 | (converged) | 0 | none |
+
+Security, scalability, integration, and lessons-aware all reached convergence at
+iteration 2 (each verified against live code — including confirming routes.ts:4169
+`=== true` is a status field, NOT a gate, and must not be converted). Iteration 3
+was driven solely by the adversarial reviewer's three round-2 precision findings;
+v3 folded all three as honesty/precision changes (no design change), and both the
+adversarial and lessons-aware reviewers confirmed zero material findings.
+
+## Full Findings Catalog
+
+**Iteration 1 (material):**
+- *Security:* migrateConfig auto-strip would silently activate the off-Claude
+  sweep on existing dev agents at update (→ migration never touches the sweep);
+  exclusion reasons unvalidated + nothing stops dev-gating a destructive feature
+  (→ category enum + destructive-not-gated test).
+- *Scalability:* sweep's only cumulative ceiling is the shared LlmQueue cap →
+  auto-enabling crowds out other background work (→ sweep no longer auto-armed);
+  per-tick cents-cap vs config mismatch (noted); multi-machine poller cost
+  (bounded by lease gate, confirmed).
+- *Adversarial:* exclusion list trivial bypass (→ quality bar); egress
+  neutralization auto-starts cost sweep (→ decoupled); brace-tracker desync (→
+  codeOnly discipline + golden path); 21-way mis-classification unguarded (→
+  auditable table + destructive guard).
+- *Integration:* conformanceAudit route uses strict `!== true` → 503 on dev agent
+  (→ convert all strict gate sites + grep-verify + 200 test); llmEnrichment/
+  llmRerank unwired (→ exclude as stubs); egressAcknowledged read at ONE site not
+  five (→ named); migration provenance (→ one-shot marker).
+- *Lessons-aware:* Migration Parity left open violates P3/P10 (→ shipped);
+  auto-live cost sweep repeats background-loop mistake P19 (→ explicit opt-in);
+  assertion C literal-only blind spot must be declared not claimed closed P2 (→
+  declared); brace-tracker needs drift canary L5 (→ golden path); egressAck
+  silently inert = No Silent Degradation (→ upgrade-guide note).
+
+**Iteration 2 (material, all adversarial):**
+- Golden-path canary trivially defeated by blind snapshot regeneration (HIGH) →
+  hand-authored literal, regeneration forbidden, CODEOWNERS-reviewed.
+- Spec falsely claims codeOnly() skips string/template contents (MED) → corrected
+  to "strips // comments only" + loud-fail brace-in-string lint guard.
+- Destructive-not-gated guard is an evadable marker denylist (MED) → limit
+  declared (P2); CODEOWNERS human gate + required per-entry justification named as
+  the real backstop.
+
+**Iteration 3:** zero material findings; adversarial + lessons-aware confirmed.
+
+## Convergence verdict
+
+**Converged at iteration 3.** No material findings in the final round, verified
+against live source (devAgentGate.ts, devGatedFeatures.ts, the lint, routes.ts,
+server.ts, PostUpdateMigrator one-shot-marker pattern). The spec is ready for user
+review and approval.
+
+**Convergence method note:** abbreviated convergence — the external cross-model
+reviewers (GPT/codex, Gemini, Grok) were unavailable on the host this session, so
+the five internal reviewers (security, scalability, adversarial, integration, and
+the mandatory lessons-aware pass) ran every round. The lessons-aware reviewer's
+one-layer-below foundation audit and the adversarial reviewer's round-2
+precision pass carried the convergence — exactly the circular-self-verify defense
+they exist to provide, since the spec author ran their own convergence.
+
+**One open decision carried to the operator (does not block convergence):** whether
+the cost-bearing freshness sweep should ALSO auto-arm on dev agents. The spec
+defaults it to explicit opt-in even on dev agents (the P19-safer choice); flipping
+it is a one-line change (move `freshnessSweep.enabled` into `DEV_GATED_FEATURES`).

--- a/scripts/lib/dark-gate-attribution.js
+++ b/scripts/lib/dark-gate-attribution.js
@@ -1,0 +1,148 @@
+/**
+ * dark-gate-attribution.js — the path-attribution + registry-extraction core
+ * shared by scripts/lint-dev-agent-dark-gate.js (assertion C) and its golden-path
+ * drift-canary test. Extracted so there is ONE attributor implementation: the
+ * lint and the test agree by construction (the test asserts THIS resolver
+ * reproduces a hand-authored map — never the resolver's own output).
+ */
+
+import fs from 'node:fs';
+
+/** Strip a `//` line comment; return null if the line is a pure comment line. */
+export function codeOnly(line) {
+  const trimmed = line.trim();
+  if (trimmed.startsWith('*') || trimmed.startsWith('//') || trimmed.startsWith('/*')) {
+    return null; // comment line — no code
+  }
+  const idx = line.indexOf('//');
+  return idx >= 0 ? line.slice(0, idx) : line;
+}
+
+/**
+ * Does a code-stripped line contain a `{` or `}` inside a string or template
+ * literal? codeOnly() does not strip string contents, so such a brace would
+ * desync the depth counter.
+ */
+export function braceInString(code) {
+  let inStr = false;
+  let quote = '';
+  for (let i = 0; i < code.length; i++) {
+    const ch = code[i];
+    if (inStr) {
+      if (ch === '\\') { i++; continue; } // skip escaped char
+      if (ch === quote) { inStr = false; quote = ''; }
+    } else if (ch === '"' || ch === "'" || ch === '`') {
+      inStr = true;
+      quote = ch;
+    }
+    if (inStr && (ch === '{' || ch === '}')) return true;
+  }
+  return false;
+}
+
+/**
+ * Attribute every `enabled: false` line in a ConfigDefaults.ts to a dotted config
+ * path by brace-tracking from the top of the SHARED_DEFAULTS object literal.
+ * Returns { paths: [{ line, dottedPath }], error }.
+ */
+export function attributeEnabledFalsePaths(absPath) {
+  const lines = fs.readFileSync(absPath, 'utf-8').split('\n');
+  const startIdx = lines.findIndex((l) => /const\s+SHARED_DEFAULTS\b[^=]*=\s*{/.test(l));
+  if (startIdx < 0) {
+    return { paths: [], error: 'could not locate `const SHARED_DEFAULTS = {` in ConfigDefaults.ts' };
+  }
+
+  // Stack of { key } — key is null for an anonymous `{` (array element object
+  // etc.). depth starts at 0; the SHARED_DEFAULTS `{` takes it to 1 (the root
+  // object body lives at depth 1).
+  const stack = [];
+  let depth = 0;
+  const results = [];
+  const ENABLED_FALSE = /(["']?)enabled\1\s*:\s*false\b/;
+  const KEY_LINE = /^\s*(["']?)([A-Za-z_$][\w$-]*)\1\s*:/;
+
+  for (let i = startIdx; i < lines.length; i++) {
+    const code = codeOnly(lines[i]);
+    if (code === null) continue; // pure comment line
+
+    if (braceInString(code)) {
+      return {
+        paths: [],
+        error: `brace-in-string in defaults block can desync path attribution (line ${i + 1}) — split the value or extend the parser`,
+      };
+    }
+
+    const isEnabledFalse = ENABLED_FALSE.test(code);
+    const keyMatch = code.match(KEY_LINE);
+    const keyCandidate = keyMatch ? keyMatch[2] : null;
+
+    if (isEnabledFalse) {
+      const dottedPath = stack.map((s) => s.key).filter(Boolean).join('.') + '.enabled';
+      results.push({ line: i + 1, dottedPath });
+    }
+
+    let firstOpenOnLine = true;
+    for (const ch of code) {
+      if (ch === '{') {
+        if (firstOpenOnLine && keyCandidate && depth >= 1) {
+          stack.push({ key: keyCandidate });
+        } else {
+          stack.push({ key: null });
+        }
+        firstOpenOnLine = false;
+        depth++;
+      } else if (ch === '}') {
+        depth--;
+        stack.pop();
+        if (depth <= 0) {
+          return { paths: results, error: null };
+        }
+      }
+    }
+  }
+  return { paths: results, error: null };
+}
+
+const VALID_CATEGORIES = new Set([
+  'destructive',
+  'optional-integration',
+  'cost-bearing',
+  'structural-stub',
+  'deliberate-fleet-default',
+]);
+
+export { VALID_CATEGORIES };
+
+/**
+ * Extract configPath literals + exclusion entries from a devGatedFeatures.ts.
+ * The file is hand-authored with a stable shape; the lint runs as plain JS
+ * (importing the TS registry directly won't work), so we regex the source.
+ */
+export function extractRegistry(absPath) {
+  const src = fs.readFileSync(absPath, 'utf-8');
+  const configPathOf = (arrName) => {
+    const m = src.match(new RegExp(`export const ${arrName}[^=]*=\\s*\\[([\\s\\S]*?)\\n\\];`));
+    if (!m) return [];
+    const body = m[1];
+    const paths = [];
+    const re = /configPath:\s*(['"])([^'"]+)\1/g;
+    let mm;
+    while ((mm = re.exec(body)) !== null) paths.push(mm[2]);
+    return paths;
+  };
+  const exclBody = (() => {
+    const m = src.match(/export const DARK_GATE_EXCLUSIONS[^=]*=\s*\[([\s\S]*?)\n\];/);
+    return m ? m[1] : '';
+  })();
+  const exclusionEntries = [];
+  const entryRe = /\{\s*configPath:\s*(['"])([^'"]+)\1\s*,\s*category:\s*(['"])([^'"]+)\3\s*,\s*reason:\s*(['"])((?:[^'"\\]|\\.)*)\5\s*,?\s*\}/g;
+  let em;
+  while ((em = entryRe.exec(exclBody)) !== null) {
+    exclusionEntries.push({ configPath: em[2], category: em[4], reason: em[6] });
+  }
+  return {
+    gatedPaths: configPathOf('DEV_GATED_FEATURES'),
+    exclusionPaths: configPathOf('DARK_GATE_EXCLUSIONS'),
+    exclusionEntries,
+  };
+}

--- a/scripts/lint-dev-agent-dark-gate.js
+++ b/scripts/lint-dev-agent-dark-gate.js
@@ -8,7 +8,7 @@
  * (dev agents included), silently contradicting the standard. Caught only by
  * operator review — there was no structural guard. This is that guard.
  *
- * Two assertions over `src/`:
+ * Three assertions over `src/`:
  *
  *   A. FUNNEL — every dev-agent gate resolution must go through
  *      `resolveDevAgentGate` (src/core/devAgentGate.ts). A hand-rolled
@@ -25,6 +25,15 @@
  *      is NOT flagged — that is an allowed deliberate fleet-flip. Comment prose is
  *      skipped so the convention's own documentation never trips the check.
  *
+ *   C. NO UNCLASSIFIED DARK DEFAULT (DEV-AGENT-DARK-GATE-ENFORCEMENT B2) — every
+ *      literal `enabled: false` in src/config/ConfigDefaults.ts must be a DECLARED
+ *      choice: its brace-attributed config path is EITHER in DEV_GATED_FEATURES
+ *      (and then must NOT also hardcode false — a dev-gated feature OMITS enabled)
+ *      OR in DARK_GATE_EXCLUSIONS with a valid category + a ≥12-char reason. This
+ *      closes the hole assertion B left: a marker-less hardcoded `enabled: false`
+ *      (exactly the cartographer specs) shipped dark for everyone, invisibly.
+ *      LIMITATION: C matches the literal `enabled: false` spelling only.
+ *
  * Exit codes:
  *   0 — no violations.
  *   1 — at least one violation.
@@ -39,6 +48,12 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { execSync } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
+import {
+  codeOnly,
+  attributeEnabledFalsePaths,
+  extractRegistry,
+  VALID_CATEGORIES,
+} from './lib/dark-gate-attribution.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -68,16 +83,6 @@ const HARDCODED_ENABLED = /(["']?)enabled\1\s*:\s*false\b/;
 // block out of range, the bug that let a regressed growthAnalyst slip through).
 const BLOCK_OPEN_SEARCH = 15; // max non-code lines between marker and the block's `{`
 const BLOCK_MAX_LINES = 120; // safety bound on block-body scan
-
-/** Strip a `//` line comment; return null if the line is a pure comment line. */
-function codeOnly(line) {
-  const trimmed = line.trim();
-  if (trimmed.startsWith('*') || trimmed.startsWith('//') || trimmed.startsWith('/*')) {
-    return null; // comment line — no code
-  }
-  const idx = line.indexOf('//');
-  return idx >= 0 ? line.slice(0, idx) : line;
-}
 
 /** Is this line (trimmed) a comment line? */
 function isCommentLine(line) {
@@ -117,6 +122,47 @@ function resolveTargets() {
 }
 
 const violations = [];
+
+// Paths used by assertions B (skip-classified) and C (classification check).
+// Tests inject fixtures via env overrides (the C-assertion reads the registry +
+// ConfigDefaults directly, independent of the file args, so without an override a
+// test could not exercise C's failure modes). Absolute paths only; default to the
+// real repo files.
+const CONFIG_DEFAULTS_REL = 'src/config/ConfigDefaults.ts';
+const DEV_GATED_FEATURES_REL = 'src/core/devGatedFeatures.ts';
+const CONFIG_DEFAULTS_ABS = process.env.INSTAR_DARKGATE_CONFIG_DEFAULTS
+  ? path.resolve(process.env.INSTAR_DARKGATE_CONFIG_DEFAULTS)
+  : path.join(ROOT, CONFIG_DEFAULTS_REL);
+const REGISTRY_ABS = process.env.INSTAR_DARKGATE_REGISTRY
+  ? path.resolve(process.env.INSTAR_DARKGATE_REGISTRY)
+  : path.join(ROOT, DEV_GATED_FEATURES_REL);
+
+// Precompute the registry + path attribution so assertion B can SKIP a hardcoded
+// `enabled: false` whose attributed path is a DELIBERATE classification (a nested
+// DARK_GATE_EXCLUSIONS entry under a gate-marker comment, e.g. the cost-bearing
+// cartographer sweep). Without this, B false-flags a declared dark default that a
+// parent block's gate-marker comment happens to enclose. The full classification
+// check is assertion C below; B only needs the exclusion line-set to stay quiet on
+// already-classified lines.
+const _configDefaultsAbs = CONFIG_DEFAULTS_ABS;
+const _registryAbs = REGISTRY_ABS;
+let _exclusionClassifiedLines = new Set(); // 1-based ConfigDefaults.ts line numbers
+if (fs.existsSync(_configDefaultsAbs) && fs.existsSync(_registryAbs)) {
+  try {
+    const { exclusionPaths } = extractRegistry(_registryAbs);
+    const exclSet = new Set(exclusionPaths);
+    const { paths: attributed, error } = attributeEnabledFalsePaths(_configDefaultsAbs);
+    if (!error) {
+      for (const { line, dottedPath } of attributed) {
+        if (exclSet.has(dottedPath)) _exclusionClassifiedLines.add(line);
+      }
+    }
+  } catch {
+    // If precompute fails, B falls back to its original behavior (flag all);
+    // assertion C reports the real desync/error loudly.
+    _exclusionClassifiedLines = new Set();
+  }
+}
 
 for (const file of resolveTargets()) {
   if (!fs.existsSync(file)) continue;
@@ -163,7 +209,15 @@ for (const file of resolveTargets()) {
       for (let j = openIdx; j <= Math.min(openIdx + BLOCK_MAX_LINES, lines.length - 1); j++) {
         const codeJ = codeOnly(lines[j]);
         if (codeJ === null) continue;
-        if (HARDCODED_ENABLED.test(codeJ) && !reportedB.has(j)) {
+        // Skip a line that is a DELIBERATE DARK_GATE_EXCLUSIONS classification
+        // (a nested dark default that a parent block's gate-marker comment merely
+        // encloses — e.g. the cost-bearing cartographer sweep). Assertion C still
+        // requires it to be classified; B should not double-flag it.
+        if (
+          HARDCODED_ENABLED.test(codeJ) &&
+          !reportedB.has(j) &&
+          !(rel === CONFIG_DEFAULTS_REL && _exclusionClassifiedLines.has(j + 1))
+        ) {
           reportedB.add(j);
           violations.push({
             file: rel, line: j + 1, kind: 'B: hardcoded enabled under gate marker',
@@ -181,16 +235,107 @@ for (const file of resolveTargets()) {
   }
 }
 
+// ════════════════════════════════════════════════════════════════════════════
+// Assertion C — NO UNCLASSIFIED DARK DEFAULT (DEV-AGENT-DARK-GATE-ENFORCEMENT B2)
+//
+// Every literal `enabled: false` in src/config/ConfigDefaults.ts must be a
+// DECLARED choice: its attributed config path is EITHER registered in
+// DEV_GATED_FEATURES (→ but then it must NOT also hardcode `enabled: false`; a
+// dev-gated feature OMITS enabled) OR classified in DARK_GATE_EXCLUSIONS with a
+// category + reason. Neither → violation. This closes the cartographer hole:
+// assertion B only fires under a comment marker; a marker-less hardcoded
+// `enabled: false` (exactly the cartographer specs) was invisible.
+//
+// LIMITATION (P2 Signal-vs-Authority — do NOT claim full closure): assertion C
+// matches the LITERAL `enabled: false` spelling ONLY. A non-literal default
+// (`enabled: someFlag ?? false`) evades it — the same miss named in the prior
+// conformance spec's Layer-2 row. C closes the literal-false hole (cartographer +
+// #1001), not the non-literal-expression hole.
+//
+// Path attribution reuses codeOnly() for depth (shared with the golden-path test
+// via scripts/lib/dark-gate-attribution.js — ONE attributor implementation).
+// codeOnly() strips `//` comments but does NOT skip braces inside string/template
+// literals — so a loud-fail guard in attributeEnabledFalsePaths errors if any line
+// in the defaults-block region carries a `{`/`}` inside a string, rather than
+// silently desyncing.
+// ════════════════════════════════════════════════════════════════════════════
+
+// Run assertion C only on a full-tree / explicit run that includes ConfigDefaults
+// (the path attribution needs the whole file; a --staged run that doesn't touch
+// it is a no-op for C, which is fine — CI runs the full tree).
+(() => {
+  const configDefaultsAbs = CONFIG_DEFAULTS_ABS;
+  const registryAbs = REGISTRY_ABS;
+  if (!fs.existsSync(configDefaultsAbs) || !fs.existsSync(registryAbs)) return;
+
+  const { gatedPaths, exclusionPaths, exclusionEntries } = extractRegistry(registryAbs);
+  const gatedSet = new Set(gatedPaths);
+  const exclusionSet = new Set(exclusionPaths);
+
+  // Validate exclusion-entry quality (closed enum + reason length).
+  for (const e of exclusionEntries) {
+    if (!VALID_CATEGORIES.has(e.category)) {
+      violations.push({
+        file: DEV_GATED_FEATURES_REL, line: 0, kind: 'C: invalid exclusion category',
+        text: `${e.configPath} → category '${e.category}'`,
+        fix: `category must be one of: ${[...VALID_CATEGORIES].join(', ')}`,
+      });
+    }
+    const reasonLen = (e.reason || '').replace(/\s/g, '').length;
+    if (reasonLen < 12) {
+      violations.push({
+        file: DEV_GATED_FEATURES_REL, line: 0, kind: 'C: exclusion reason too short',
+        text: `${e.configPath} → reason '${e.reason}' (${reasonLen} non-ws chars)`,
+        fix: 'a DARK_GATE_EXCLUSIONS reason must be ≥12 non-whitespace chars (defeats placeholder reasons)',
+      });
+    }
+  }
+
+  const { paths: attributed, error } = attributeEnabledFalsePaths(configDefaultsAbs);
+  if (error) {
+    violations.push({
+      file: CONFIG_DEFAULTS_REL, line: 0, kind: 'C: path-attribution error',
+      text: error,
+      fix: 'resolve the desync condition before the lint can attribute dark defaults',
+    });
+    return;
+  }
+
+  for (const { line, dottedPath } of attributed) {
+    const inGated = gatedSet.has(dottedPath);
+    const inExcluded = exclusionSet.has(dottedPath);
+    if (inGated) {
+      // Registered as dev-gated but still hardcodes `enabled: false` — the #1001
+      // shape. A dev-gated feature OMITS enabled.
+      violations.push({
+        file: CONFIG_DEFAULTS_REL, line, kind: 'C: registered but hardcodes false',
+        text: `${dottedPath} is in DEV_GATED_FEATURES but still hardcodes \`enabled: false\``,
+        fix: 'OMIT `enabled` from the default so the gate decides (resolved as enabled ?? !!developmentAgent)',
+      });
+    } else if (!inExcluded) {
+      violations.push({
+        file: CONFIG_DEFAULTS_REL, line, kind: 'C: unclassified dark default',
+        text: `${dottedPath} has \`enabled: false\` but is in NEITHER DEV_GATED_FEATURES NOR DARK_GATE_EXCLUSIONS`,
+        fix: 'dev-gate it (omit `enabled` + register in DEV_GATED_FEATURES) OR add it to DARK_GATE_EXCLUSIONS with a category+reason',
+      });
+    }
+  }
+})();
+
 if (violations.length === 0) {
   console.log('lint-dev-agent-dark-gate: clean');
   process.exit(0);
 }
 
 console.error('\n❌ lint-dev-agent-dark-gate found violations of the developmentAgent dark-feature gate standard:\n');
+console.error('NOTE: assertion C matches the literal `enabled: false` spelling only — a non-literal');
+console.error('default (`enabled: someFlag ?? false`) evades it. C closes the literal-false hole');
+console.error('(cartographer + #1001), not the non-literal-expression hole.\n');
 for (const v of violations) {
-  console.error(`  ${v.file}:${v.line}  [${v.kind}]`);
+  const loc = v.line ? `${v.file}:${v.line}` : v.file;
+  console.error(`  ${loc}  [${v.kind}]`);
   console.error(`    ${v.text}`);
   console.error(`    fix: ${v.fix}\n`);
 }
-console.error('Standard: a dev-gated feature OMITS `enabled` and resolves it through resolveDevAgentGate so it runs LIVE on dev agents and DARK on the fleet. Spec: docs/specs/DEV-AGENT-DARK-GATE-CONFORMANCE-SPEC.md\n');
+console.error('Standard: a dev-gated feature OMITS `enabled` and resolves it through resolveDevAgentGate so it runs LIVE on dev agents and DARK on the fleet; every other `enabled: false` default must be classified in DARK_GATE_EXCLUSIONS. Spec: docs/specs/DEV-AGENT-DARK-GATE-ENFORCEMENT-SPEC.md\n');
 process.exit(1);

--- a/src/commands/server.ts
+++ b/src/commands/server.ts
@@ -8412,8 +8412,10 @@ export async function startServer(options: StartOptions): Promise<void> {
     // Cartographer doc-tree — hierarchical semantic map with git-hash staleness
     // (cartographer-doc-tree-schema spec #1). Ships dark behind cartographer.enabled;
     // null → /cartographer/* routes return 503.
-    const cartographerEnabled =
-      (config as { cartographer?: { enabled?: boolean } }).cartographer?.enabled ?? false;
+    const cartographerEnabled = resolveDevAgentGate(
+      (config as { cartographer?: { enabled?: boolean } }).cartographer?.enabled,
+      config,
+    );
     const cartographer = cartographerEnabled
       ? new CartographerTree({ projectDir: config.projectDir, stateDir: config.stateDir })
       : null;
@@ -8421,18 +8423,21 @@ export async function startServer(options: StartOptions): Promise<void> {
 
     // Cartographer doc-freshness sweep (spec #2). In-process poller that authors
     // stale/never-authored node summaries on a LIGHT model routed OFF Claude.
-    // Ships dark behind freshnessSweep.enabled AND egressAcknowledged (off-Claude
-    // authoring transmits source content to a third-party framework — a separate
-    // consent gate). The off-Claude guarantee needs the IntelligenceRouter
-    // (router.for + defaultFramework); if routing is an unrouted provider the
-    // sweep refuses to start (it could not enforce off-Claude).
+    // Ships dark behind freshnessSweep.enabled ONLY — the redundant egressAcknowledged
+    // second gate was removed (DEV-AGENT-DARK-GATE-ENFORCEMENT Slice A3): one honest
+    // opt-in flag, not two. This is the one cost-bearing cartographer surface and stays
+    // an explicit opt-in EVEN on a dev agent (it bills a third-party account every pass),
+    // so it is in DARK_GATE_EXCLUSIONS (cost-bearing), NOT dev-gated. The off-Claude
+    // guarantee still needs the IntelligenceRouter (router.for + defaultFramework); if
+    // routing is an unrouted provider the sweep refuses to start (it could not enforce
+    // off-Claude) — that cost-protecting probe is UNCHANGED.
     let cartographerSweepPoller: import('../monitoring/CartographerSweepPoller.js').CartographerSweepPoller | null = null;
     if (cartographer) {
       const fsCfg = (config as {
         cartographer?: { freshnessSweep?: Record<string, unknown> & { enabled?: boolean; egressAcknowledged?: boolean } };
       }).cartographer?.freshnessSweep;
       const num = (v: unknown, d: number): number => (typeof v === 'number' && Number.isFinite(v) ? v : d);
-      if (fsCfg?.enabled && fsCfg?.egressAcknowledged && sharedLlmQueue) {
+      if (fsCfg?.enabled && sharedLlmQueue) {
         const routerLike =
           sharedIntelligence &&
           typeof (sharedIntelligence as { for?: unknown }).for === 'function' &&

--- a/src/config/ConfigDefaults.ts
+++ b/src/config/ConfigDefaults.ts
@@ -679,9 +679,13 @@ const SHARED_DEFAULTS: Record<string, unknown> = {
     },
   },
   // Cartographer doc-tree — hierarchical semantic map with git-hash staleness
-  // (cartographer-doc-tree-schema spec #1). Ships dark; routes 503 when disabled.
+  // (cartographer-doc-tree-schema spec #1). `enabled` is deliberately OMITTED so
+  // the runtime resolves it through the standard developmentAgent dark-feature
+  // gate (`enabled ?? !!developmentAgent`, standard_development_agent_dark_feature_gate):
+  // LIVE on a dev agent (the zero-cost read surfaces dogfood there), DARK fleet-wide.
+  // Registered in DEV_GATED_FEATURES (src/core/devGatedFeatures.ts). The live-fleet
+  // flip is registering `enabled: true` here. Spec: DEV-AGENT-DARK-GATE-ENFORCEMENT.
   cartographer: {
-    enabled: false,
     maxDepth: 12,
     // Doc-freshness sweep (spec #2). A nested key under cartographer so the
     // deep-merge add-missing path backfills it to existing agents (no migrateConfig
@@ -713,13 +717,15 @@ const SHARED_DEFAULTS: Record<string, unknown> = {
     },
     // Standards Enforcement-Coverage Audit (cartographer-conformance-audit spec #3).
     // A nested key under cartographer so the deep-merge add-missing path backfills
-    // it to existing agents (no migrateConfig block needed). Ships dark behind BOTH
-    // cartographer.enabled AND conformanceAudit.enabled. The deterministic core reads
-    // local files only (zero egress); the OPTIONAL llmEnrichment path is the only
-    // egress and ships OFF (it additionally requires egressAcknowledged:true). The
-    // value shipped today is the deterministic coverage map — the LLM path is dark.
+    // it to existing agents (no migrateConfig block needed). `enabled` is deliberately
+    // OMITTED so the runtime resolves it through the developmentAgent dark-feature gate
+    // (`enabled ?? !!developmentAgent`, standard_development_agent_dark_feature_gate):
+    // LIVE on a dev agent (zero-egress deterministic core dogfoods there), DARK fleet-wide.
+    // Registered in DEV_GATED_FEATURES. The deterministic core reads local files only
+    // (zero egress); the OPTIONAL llmEnrichment path is the only egress and ships OFF
+    // (an unwired structural stub — see DARK_GATE_EXCLUSIONS). The value shipped today
+    // is the deterministic coverage map — the LLM path is dark.
     conformanceAudit: {
-      enabled: false,
       llmEnrichment: {
         enabled: false,
         egressAcknowledged: false,

--- a/src/core/PostUpdateMigrator.ts
+++ b/src/core/PostUpdateMigrator.ts
@@ -271,8 +271,98 @@ export class PostUpdateMigrator {
     this.migrateThreadlineAgentInfoIdentity(result);
     this.migrateWorktreeMisplacedFloodItems(result);
     this.migrateSubscriptionPoolInteractiveReady(result);
+    this.migrateCartographerDevGate(result);
 
     return result;
+  }
+
+  // ── Cartographer dev-gate (DEV-AGENT-DARK-GATE-ENFORCEMENT, Migration Parity) ──
+  //
+  // The zero-cost cartographer READ surfaces (doc-tree/navigate + the deterministic
+  // conformance-coverage audit) are now dev-gated: their config defaults OMIT
+  // `enabled`, so a dev agent resolves them LIVE via resolveDevAgentGate. But an
+  // EXISTING dev agent already has `cartographer.enabled: false` (and
+  // `conformanceAudit.enabled: false`) on disk from the old hardcoded default —
+  // applyDefaults add-missing leaves those stale `false`s in place, so the gate
+  // never gets to decide and Echo (the motivating case) stays DARK. This one-shot,
+  // dev-agent-only migration strips a DEFAULT-SHAPED `false` at exactly those two
+  // ZERO-COST paths so the gate resolves them live.
+  //
+  // Provenance discriminator (the run-once marker): value alone can't tell a
+  // deliberate operator `false` from the old default `false`. The `_instar_migrations`
+  // marker means we only ever touch the ORIGINAL default, ONCE — if the operator
+  // later re-adds `false`, this never re-strips it.
+  //
+  // NEVER touches `freshnessSweep.enabled` — the cost-bearing surface is never
+  // auto-armed by an update (P19 / "no surprise activation on update"). Idempotent,
+  // existence-checked, dev-agent-only.
+  private migrateCartographerDevGate(result: MigrationResult): void {
+    const configPath = path.join(this.config.stateDir, 'config.json');
+    if (!fs.existsSync(configPath)) {
+      result.skipped.push('cartographer-dev-gate: config.json not found');
+      return;
+    }
+
+    let config: Record<string, unknown>;
+    try {
+      config = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+    } catch (err) {
+      result.errors.push(`cartographer-dev-gate: config.json read failed: ${err instanceof Error ? err.message : String(err)}`);
+      return;
+    }
+
+    const migrations = (config._instar_migrations ?? []) as string[];
+    const marker = 'cartographer-dev-gate-strip';
+    if (migrations.some(m => m.startsWith(marker))) {
+      result.skipped.push('cartographer-dev-gate: already migrated');
+      return;
+    }
+
+    // Dev-agent-only: a fleet agent's `false` is the correct dark default and is
+    // left untouched. (The marker is NOT set here, so if the agent is later
+    // promoted to developmentAgent the migration can still run once.)
+    if (config.developmentAgent !== true) {
+      result.skipped.push('cartographer-dev-gate: not a development agent');
+      return;
+    }
+
+    const cartographer = config.cartographer;
+    const stripped: string[] = [];
+    if (cartographer && typeof cartographer === 'object' && !Array.isArray(cartographer)) {
+      const cart = cartographer as Record<string, unknown>;
+      // Strip a DEFAULT-SHAPED (exactly `false`) cartographer.enabled.
+      if (cart.enabled === false) {
+        delete cart.enabled;
+        stripped.push('cartographer.enabled');
+      }
+      // Strip a DEFAULT-SHAPED conformanceAudit.enabled === false.
+      const ca = cart.conformanceAudit;
+      if (ca && typeof ca === 'object' && !Array.isArray(ca)) {
+        const caObj = ca as Record<string, unknown>;
+        if (caObj.enabled === false) {
+          delete caObj.enabled;
+          stripped.push('cartographer.conformanceAudit.enabled');
+        }
+      }
+    }
+
+    // Record the marker even when nothing was stripped, so it runs exactly once
+    // (the value-already-absent / operator-set-true cases are terminal too).
+    const now = new Date().toISOString();
+    migrations.push(`${marker}-${now}`);
+    config._instar_migrations = migrations;
+    try {
+      fs.writeFileSync(configPath, JSON.stringify(config, null, 2));
+    } catch (err) {
+      result.errors.push(`cartographer-dev-gate: config.json write failed: ${err instanceof Error ? err.message : String(err)}`);
+      return;
+    }
+
+    if (stripped.length > 0) {
+      result.upgraded.push(`cartographer-dev-gate: stripped default-shaped \`enabled: false\` at ${stripped.join(', ')} so the developmentAgent gate resolves them live`);
+    } else {
+      result.skipped.push('cartographer-dev-gate: no default-shaped false to strip (marker set)');
+    }
   }
 
   /**

--- a/src/core/devGatedFeatures.ts
+++ b/src/core/devGatedFeatures.ts
@@ -32,6 +32,14 @@ export interface DevGatedFeature {
   configPath: string;
   /** One-line description of what runs live on a dev agent. */
   description: string;
+  /**
+   * One-line "non-destructive, safe-to-run-live-on-dev" rationale. REQUIRED on
+   * every entry (DEV-AGENT-DARK-GATE-ENFORCEMENT Slice B): the human gate is the
+   * real backstop — dev-gating a feature live means it runs unattended on the dev
+   * agent, so each entry must carry an explicit justification a CODEOWNERS reviewer
+   * can check. A destructive/cost-bearing feature does NOT belong here.
+   */
+  justification: string;
 }
 
 export const DEV_GATED_FEATURES: DevGatedFeature[] = [
@@ -39,36 +47,187 @@ export const DEV_GATED_FEATURES: DevGatedFeature[] = [
     name: 'growthAnalyst',
     configPath: 'monitoring.growthAnalyst.enabled',
     description: 'Proactive growth & milestone analyst (/growth/*).',
+    justification: 'Read/observe analyst; sends nothing by default (digestDelivery off); no destructive action, no spend.',
   },
   {
     name: 'coherenceJournal',
     configPath: 'multiMachine.coherenceJournal.enabled',
     description: 'Cross-machine coherence journal.',
+    justification: 'Append-only local journal of content-free lifecycle events; no egress, no spend, no destructive action.',
   },
   {
     name: 'warmSessionA2A',
     configPath: 'threadline.warmSessionA2A.enabled',
     description: 'Warm-session pool for agent-to-agent delivery.',
+    justification: 'Bounded warm-session pool (global/per-peer caps + TTL); no destructive action, no third-party spend.',
   },
   {
     name: 'secretSync',
     configPath: 'multiMachine.secretSync.enabled',
     description: 'Cross-machine secret sync (receive side).',
+    justification: 'Receive-only by default (push needs pushEnabled); encrypted-per-peer; no destructive action, no spend.',
   },
   {
     name: 'geminiLoopDriver',
     configPath: 'autonomousSessions.geminiLoopDriver.enabled',
     description: 'Gemini autonomous-loop driver.',
+    justification: 'Drives the dev agent\'s own autonomous loop; bounded, no destructive action against the source tree.',
   },
   {
     name: 'respawnBuildContext',
     configPath: 'sessions.respawnBuildContext.enabled',
     description: 'Respawn build-context capture on session restart.',
+    justification: 'Captures build context on restart; read-only observability, no destructive action, no spend.',
   },
   {
     name: 'selfKnowledgeSessionContext',
     configPath: 'selfKnowledge.sessionContext.enabled',
     description: 'Session-boot self-knowledge context injection.',
+    justification: 'Injects vault secret NAMES (never values) + facts at boot; read-only, no egress, no destructive action.',
+  },
+  {
+    name: 'cartographer',
+    configPath: 'cartographer.enabled',
+    description: 'Cartographer doc-tree + navigation read surfaces (zero egress).',
+    justification: 'Read-only local-index surfaces; no egress, no spend.',
+  },
+  {
+    name: 'cartographerConformanceAudit',
+    configPath: 'cartographer.conformanceAudit.enabled',
+    description: 'Standards enforcement-coverage audit (deterministic, zero egress).',
+    justification: 'Deterministic local audit; no LLM, no egress, no spend.',
+  },
+];
+
+/**
+ * An `enabled: false` config default that is DELIBERATELY dark for EVERYONE (dev
+ * agents included) — the opposite of a DEV_GATED_FEATURES entry. The lint
+ * (scripts/lint-dev-agent-dark-gate.js, assertion C) requires every literal
+ * `enabled: false` in ConfigDefaults.ts to be EITHER dev-gated (registered above,
+ * with `enabled` omitted) OR classified here, so no dark default can ship by
+ * accident (the cartographer hole this spec closed).
+ *
+ * The registry's value is diffability + a category/reason quality bar — NOT
+ * prevention. It is a CODEOWNERS-reviewed path; the human gate is the real
+ * backstop. The lint REJECTS an entry with an unknown category or a reason
+ * shorter than 12 non-whitespace chars.
+ */
+export type DarkGateCategory =
+  | 'destructive'
+  | 'optional-integration'
+  | 'cost-bearing'
+  | 'structural-stub'
+  | 'deliberate-fleet-default';
+
+export interface DarkGateExclusion {
+  /** Dotted path to the feature's `enabled` flag in the agent config. */
+  configPath: string;
+  /** Why it is NOT dev-gated (closed enum). */
+  category: DarkGateCategory;
+  /** Human-readable rationale (≥12 non-whitespace chars; the lint enforces this). */
+  reason: string;
+}
+
+export const DARK_GATE_EXCLUSIONS: DarkGateExclusion[] = [
+  // ── destructive — kills/deletes on a heuristic; off + dry-run for EVERYONE ──
+  {
+    configPath: 'monitoring.sessionReaper.enabled',
+    category: 'destructive',
+    reason: 'kills idle sessions; off+dry-run for everyone',
+  },
+  {
+    configPath: 'monitoring.agentWorktreeReaper.enabled',
+    category: 'destructive',
+    reason: 'deletes git worktrees; off+dry-run for everyone',
+  },
+  {
+    configPath: 'monitoring.mcpProcessReaper.enabled',
+    category: 'destructive',
+    reason: 'kills MCP processes; off+dry-run for everyone',
+  },
+  // ── cost-bearing — ongoing third-party / LLM spend; explicit opt-in ──
+  {
+    configPath: 'mentor.autonomousFix.enabled',
+    category: 'cost-bearing',
+    reason: 'spawns full-tool Opus fix sessions; ongoing spend',
+  },
+  {
+    configPath: 'cartographer.freshnessSweep.enabled',
+    category: 'cost-bearing',
+    reason: 'authors summaries via off-Claude codex; ongoing third-party spend; explicit opt-in even on dev',
+  },
+  // ── structural-stub — no runtime consumer wired; a gate would assert dead behavior ──
+  {
+    configPath: 'cartographer.conformanceAudit.llmEnrichment.enabled',
+    category: 'structural-stub',
+    reason: 'no LLM pipeline wired; dark stub',
+  },
+  {
+    configPath: 'cartographer.subtreeNav.llmRerank.enabled',
+    category: 'structural-stub',
+    reason: 'no LLM pipeline wired; dark stub',
+  },
+  {
+    configPath: 'monitoring.agentSleep.enabled',
+    category: 'structural-stub',
+    reason: 'sleep/respawn mechanism is a later slice; not wired',
+  },
+  // ── optional-integration — opt-in per deployment ──
+  {
+    configPath: 'multiMachine.sessionPool.enabled',
+    category: 'optional-integration',
+    reason: 'multi-machine pooling; opt-in per deployment',
+  },
+  // ── deliberate-fleet-default — off for everyone by design (incl. dev) ──
+  {
+    configPath: 'monitoring.bootHealthBeacon.enabled',
+    category: 'deliberate-fleet-default',
+    reason: 'minimal boot /health responder; deliberate fleet default, off until a supervisor needs it',
+  },
+  {
+    configPath: 'monitoring.parallelWorkSentinel.enabled',
+    category: 'deliberate-fleet-default',
+    reason: 'observe-only overlap councilor; candidate for dev-gating in a follow-up audit',
+  },
+  {
+    configPath: 'monitoring.failureLearning.enabled',
+    category: 'deliberate-fleet-default',
+    reason: 'observe-only failure-learning loop; candidate for dev-gating in a follow-up audit',
+  },
+  {
+    configPath: 'monitoring.correctionLearning.enabled',
+    category: 'deliberate-fleet-default',
+    reason: 'observe-only correction/preference sentinel; candidate for dev-gating in a follow-up audit',
+  },
+  {
+    configPath: 'monitoring.apprenticeshipCycleSla.enabled',
+    category: 'deliberate-fleet-default',
+    reason: 'observe-only overdue-cycle signal; candidate for dev-gating in a follow-up audit',
+  },
+  {
+    configPath: 'monitoring.geminiCapacityEscalation.enabled',
+    category: 'deliberate-fleet-default',
+    reason: 'observe-only capacity-block escalation; candidate for dev-gating in a follow-up audit',
+  },
+  {
+    configPath: 'monitoring.releaseReadiness.enabled',
+    category: 'deliberate-fleet-default',
+    reason: 'observe-only release-readiness sentinel; repo-gated; candidate for dev-gating in a follow-up audit',
+  },
+  {
+    configPath: 'threadline.a2aCheckIn.enabled',
+    category: 'deliberate-fleet-default',
+    reason: 'A2A check-in summarizer; deliberate fleet default, opt-in to keep the operator un-flooded',
+  },
+  {
+    configPath: 'mentor.enabled',
+    category: 'deliberate-fleet-default',
+    reason: 'framework-onboarding mentor system; deliberate fleet default, off until the human advances rollout',
+  },
+  {
+    configPath: 'mentee.enabled',
+    category: 'deliberate-fleet-default',
+    reason: 'mentee receiver wiring; deliberate fleet default, off until an allowlisted mentor is configured',
   },
 ];
 

--- a/src/server/routes.ts
+++ b/src/server/routes.ts
@@ -4300,7 +4300,7 @@ export function createRoutes(ctx: RouteContext): Router {
     if (!ctx.cartographer) { res.status(503).json({ error: 'Cartographer not enabled' }); return false; }
     const cfg = (ctx.config as { cartographer?: { conformanceAudit?: { enabled?: boolean } } })
       .cartographer?.conformanceAudit;
-    if (cfg?.enabled !== true) { res.status(503).json({ error: 'Conformance audit not enabled' }); return false; }
+    if (!resolveDevAgentGate(cfg?.enabled, ctx.config)) { res.status(503).json({ error: 'Conformance audit not enabled' }); return false; }
     if (req.headers['x-instar-request'] !== '1') {
       res.status(403).json({ error: 'GET /conformance/coverage requires the X-Instar-Request: 1 intent header' });
       return false;

--- a/tests/e2e/cartographer-dev-gate-lifecycle.test.ts
+++ b/tests/e2e/cartographer-dev-gate-lifecycle.test.ts
@@ -1,0 +1,126 @@
+// safe-git-allow: test file — execFileSync('git') builds the fixture repo; fs.rmSync is per-test tmpdir cleanup.
+/**
+ * Tier 3 (E2E "feature is alive") for DEV-AGENT-DARK-GATE-ENFORCEMENT.
+ *
+ * Mirrors the PRODUCTION init path (src/commands/server.ts ~L8415 + ~L8435):
+ *   - cartographer construction:  resolveDevAgentGate(config.cartographer?.enabled, config)
+ *   - sweep-start predicate:      fsCfg?.enabled && sharedLlmQueue   (no egressAcknowledged)
+ *
+ * Proves, end-to-end against the REAL ConfigDefaults + REAL routes:
+ *   1. A developmentAgent:true agent (defaults OMIT cartographer.enabled) constructs
+ *      a real CartographerTree → /cartographer/health is 200 (the zero-cost read
+ *      surface is LIVE — Justin's actual complaint, that cartographer was dark on Echo).
+ *   2. A fleet agent gets null → 503.
+ *   3. The cost-bearing sweep poller is NOT started in EITHER case without an
+ *      explicit freshnessSweep.enabled:true (the cost surface is never auto-armed).
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import express from 'express';
+import request from 'supertest';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { execFileSync } from 'node:child_process';
+import { createRoutes, type RouteContext } from '../../src/server/routes.js';
+import { authMiddleware } from '../../src/server/middleware.js';
+import { CartographerTree } from '../../src/core/CartographerTree.js';
+import { resolveDevAgentGate } from '../../src/core/devAgentGate.js';
+import { applyDefaults, getMigrationDefaults } from '../../src/config/ConfigDefaults.js';
+
+const AUTH = 'test-bearer-token';
+
+function git(cwd: string, args: string[]): void {
+  execFileSync('git', args, {
+    cwd, stdio: 'pipe',
+    env: { ...process.env, GIT_AUTHOR_NAME: 't', GIT_AUTHOR_EMAIL: 't@t', GIT_COMMITTER_NAME: 't', GIT_COMMITTER_EMAIL: 't@t' },
+  });
+}
+
+let repo: string;
+let stateDir: string;
+
+beforeEach(() => {
+  repo = fs.mkdtempSync(path.join(os.tmpdir(), 'carto-devgate-e2e-'));
+  stateDir = path.join(repo, '.instar');
+  fs.mkdirSync(stateDir, { recursive: true });
+  git(repo, ['init', '-q', '-b', 'main']);
+  fs.mkdirSync(path.join(repo, 'src'), { recursive: true });
+  fs.writeFileSync(path.join(repo, 'src', 'index.ts'), 'export const a = 1;\n');
+  git(repo, ['add', '-A']);
+  git(repo, ['commit', '-q', '-m', 'init']);
+});
+
+afterEach(() => {
+  fs.rmSync(repo, { recursive: true, force: true });
+});
+
+/** Build the config a real agent would run with: REAL defaults applied. */
+function buildAgentConfig(developmentAgent: boolean): Record<string, unknown> {
+  const cfg: Record<string, unknown> = { developmentAgent, projectName: 't', projectDir: repo, stateDir, port: 0, authToken: AUTH };
+  applyDefaults(cfg, getMigrationDefaults('standalone'));
+  return cfg;
+}
+
+/** Reproduce server.ts ~L8415: construct (or not) the CartographerTree. */
+function constructCartographerLikeServer(config: Record<string, unknown>): CartographerTree | null {
+  const cartographerEnabled = resolveDevAgentGate(
+    (config as { cartographer?: { enabled?: boolean } }).cartographer?.enabled,
+    config as { developmentAgent?: boolean },
+  );
+  return cartographerEnabled ? new CartographerTree({ projectDir: repo, stateDir }) : null;
+}
+
+/** Reproduce server.ts ~L8435: would the sweep poller start? */
+function sweepWouldStart(config: Record<string, unknown>, hasLlmQueue: boolean): boolean {
+  const cartographer = constructCartographerLikeServer(config);
+  if (!cartographer) return false;
+  const fsCfg = (config as { cartographer?: { freshnessSweep?: { enabled?: boolean } } }).cartographer?.freshnessSweep;
+  return Boolean(fsCfg?.enabled && hasLlmQueue);
+}
+
+function appFor(config: Record<string, unknown>): express.Express {
+  const a = express();
+  a.use(express.json());
+  a.use(authMiddleware(() => AUTH, 'test'));
+  a.use('/', createRoutes({
+    config: { ...config, sessions: {} as any, scheduler: {} as any } as any,
+    cartographer: constructCartographerLikeServer(config),
+    startTime: new Date(),
+  } as unknown as RouteContext));
+  return a;
+}
+const bearer = (r: request.Test) => r.set('Authorization', `Bearer ${AUTH}`);
+
+describe('Cartographer dev-gate — feature is alive (Tier 3 E2E, production init path)', () => {
+  it('developmentAgent:true → the zero-cost read surface is LIVE: /cartographer/health 200 (not 503)', async () => {
+    const cfg = buildAgentConfig(true);
+    // Sanity: the REAL defaults OMIT cartographer.enabled (dev-gate decides).
+    expect((cfg.cartographer as { enabled?: unknown })?.enabled).toBeUndefined();
+    const res = await bearer(request(appFor(cfg)).get('/cartographer/health'));
+    expect(res.status).toBe(200);
+    expect(res.body.enabled).toBe(true);
+    expect(res.body.nodeCount).toBeGreaterThanOrEqual(1);
+  });
+
+  it('fleet config → cartographer is null: /cartographer/health 503', async () => {
+    const cfg = buildAgentConfig(false);
+    const res = await bearer(request(appFor(cfg)).get('/cartographer/health'));
+    expect(res.status).toBe(503);
+    expect(res.body.error).toMatch(/not enabled/i);
+  });
+
+  it('the cost-bearing sweep poller is NOT started without explicit freshnessSweep.enabled:true (no auto-arm), on dev OR fleet', () => {
+    // dev agent, default freshnessSweep.enabled:false → no sweep even with an LLM queue.
+    expect(sweepWouldStart(buildAgentConfig(true), /* hasLlmQueue */ true)).toBe(false);
+    // fleet agent → no cartographer at all → no sweep.
+    expect(sweepWouldStart(buildAgentConfig(false), true)).toBe(false);
+
+    // Only an EXPLICIT freshnessSweep.enabled:true (plus an LLM queue) starts it,
+    // even on a dev agent — and crucially WITHOUT egressAcknowledged (removed in A3).
+    const dev = buildAgentConfig(true);
+    (dev.cartographer as { freshnessSweep: { enabled: boolean } }).freshnessSweep.enabled = true;
+    expect(sweepWouldStart(dev, true)).toBe(true);
+    // No egressAcknowledged was set — the A3 removal of that second gate is proven.
+    expect((dev.cartographer as { freshnessSweep: { egressAcknowledged?: unknown } }).freshnessSweep.egressAcknowledged).toBe(false);
+  });
+});

--- a/tests/integration/conformance-dev-gate-route.test.ts
+++ b/tests/integration/conformance-dev-gate-route.test.ts
@@ -1,0 +1,115 @@
+// safe-git-allow: test file — execFileSync('git') builds the fixture repo; fs.rmSync is per-test tmpdir cleanup.
+/**
+ * Tier 2 (integration) for the DEV-AGENT-DARK-GATE-ENFORCEMENT route-gate fix
+ * (Slice A2). The conformance-coverage gate now resolves via resolveDevAgentGate
+ * instead of a strict `cfg?.enabled !== true`, so:
+ *   - developmentAgent: true  + conformanceAudit.enabled OMITTED → LIVE (200)
+ *   - fleet config (developmentAgent unset/false), enabled OMITTED → 503
+ *   - explicit enabled: false force-darks even a dev agent → 503
+ * Exercised through the REAL CartographerTree + REAL Express routes + REAL auth.
+ * This catches the live failure mode the strict `!== true` would have produced
+ * (undefined !== true → 503 on a dev agent despite the registry being green).
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import express from 'express';
+import request from 'supertest';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { execFileSync } from 'node:child_process';
+import { createRoutes, type RouteContext } from '../../src/server/routes.js';
+import { authMiddleware } from '../../src/server/middleware.js';
+import { CartographerTree } from '../../src/core/CartographerTree.js';
+
+const AUTH = 'test-bearer-token';
+
+function git(cwd: string, args: string[]): void {
+  execFileSync('git', args, {
+    cwd, stdio: 'pipe',
+    env: { ...process.env, GIT_AUTHOR_NAME: 't', GIT_AUTHOR_EMAIL: 't@t', GIT_COMMITTER_NAME: 't', GIT_COMMITTER_EMAIL: 't@t' },
+  });
+}
+
+let repo: string;
+let stateDir: string;
+
+beforeEach(() => {
+  repo = fs.mkdtempSync(path.join(os.tmpdir(), 'conf-devgate-'));
+  stateDir = path.join(repo, '.instar');
+  fs.mkdirSync(stateDir, { recursive: true });
+  git(repo, ['init', '-q', '-b', 'main']);
+  // Minimal docs/STANDARDS-REGISTRY.md so the coverage compute has something to read.
+  fs.mkdirSync(path.join(repo, 'docs'), { recursive: true });
+  fs.writeFileSync(path.join(repo, 'docs', 'STANDARDS-REGISTRY.md'), '# Standards Registry\n\nNo standards yet.\n');
+  fs.mkdirSync(path.join(repo, 'src'), { recursive: true });
+  fs.writeFileSync(path.join(repo, 'src', 'index.ts'), 'export const a = 1;\n');
+  git(repo, ['add', '-A']);
+  git(repo, ['commit', '-q', '-m', 'init']);
+});
+
+afterEach(() => {
+  fs.rmSync(repo, { recursive: true, force: true });
+});
+
+function ctxWith(cfgExtra: Record<string, unknown>): RouteContext {
+  return {
+    config: {
+      projectName: 't', projectDir: repo, stateDir, port: 0, authToken: AUTH,
+      sessions: {} as any, scheduler: {} as any,
+      ...cfgExtra,
+    } as any,
+    cartographer: new CartographerTree({ projectDir: repo, stateDir }),
+    startTime: new Date(),
+  } as unknown as RouteContext;
+}
+
+function appWith(cfgExtra: Record<string, unknown>): express.Express {
+  const app = express();
+  app.use(express.json());
+  app.use(authMiddleware(() => AUTH, 'test'));
+  app.use('/', createRoutes(ctxWith(cfgExtra)));
+  return app;
+}
+
+const get = (app: express.Express) =>
+  request(app).get('/conformance/coverage')
+    .set('Authorization', `Bearer ${AUTH}`)
+    .set('X-Instar-Request', '1');
+
+describe('GET /conformance/coverage — dev-agent dark-gate (Tier 2 integration)', () => {
+  it('developmentAgent:true + conformanceAudit.enabled OMITTED → LIVE (200)', async () => {
+    // No cartographer.conformanceAudit.enabled set → the gate must resolve via
+    // developmentAgent. This is the exact case the old strict `!== true` broke.
+    const res = await get(appWith({ developmentAgent: true, cartographer: { conformanceAudit: {} } }));
+    expect(res.status).toBe(200);
+    expect(res.body.standards).toBeDefined();
+  });
+
+  it('fleet config (developmentAgent unset) + enabled OMITTED → 503', async () => {
+    const res = await get(appWith({ cartographer: { conformanceAudit: {} } }));
+    expect(res.status).toBe(503);
+    expect(res.body.error).toMatch(/not enabled/i);
+  });
+
+  it('developmentAgent:false + enabled OMITTED → 503', async () => {
+    const res = await get(appWith({ developmentAgent: false, cartographer: { conformanceAudit: {} } }));
+    expect(res.status).toBe(503);
+  });
+
+  it('explicit enabled:false force-darks even a dev agent → 503', async () => {
+    const res = await get(appWith({ developmentAgent: true, cartographer: { conformanceAudit: { enabled: false } } }));
+    expect(res.status).toBe(503);
+  });
+
+  it('explicit enabled:true is the fleet-flip → 200 even without developmentAgent', async () => {
+    const res = await get(appWith({ cartographer: { conformanceAudit: { enabled: true } } }));
+    expect(res.status).toBe(200);
+  });
+
+  it('missing the X-Instar-Request intent header → 403 (even on a dev agent)', async () => {
+    const res = await request(appWith({ developmentAgent: true, cartographer: { conformanceAudit: {} } }))
+      .get('/conformance/coverage')
+      .set('Authorization', `Bearer ${AUTH}`);
+    expect(res.status).toBe(403);
+  });
+});

--- a/tests/unit/PostUpdateMigrator-cartographerDevGate.test.ts
+++ b/tests/unit/PostUpdateMigrator-cartographerDevGate.test.ts
@@ -1,0 +1,134 @@
+/**
+ * Verifies PostUpdateMigrator.migrateCartographerDevGate — the one-shot,
+ * dev-agent-only migration that strips a DEFAULT-SHAPED `cartographer.enabled:
+ * false` and `cartographer.conformanceAudit.enabled: false` from an EXISTING dev
+ * agent's config so the developmentAgent gate resolves the zero-cost cartographer
+ * read surfaces LIVE (DEV-AGENT-DARK-GATE-ENFORCEMENT, Migration Parity).
+ *
+ * Covers both sides of every boundary: dev-agent strip, fleet-agent no-op,
+ * NEVER-touches freshnessSweep.enabled (the cost-bearing surface), idempotency via
+ * the _instar_migrations run-once marker (so a re-added operator `false` is never
+ * re-stripped), no-config skip, and corrupt-config error with bytes preserved.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { PostUpdateMigrator } from '../../src/core/PostUpdateMigrator.js';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+
+type MigrationResult = { upgraded: string[]; skipped: string[]; errors: string[] };
+
+describe('PostUpdateMigrator — cartographer dev-gate strip', () => {
+  let projectDir: string;
+  let stateDir: string;
+
+  function configPath(): string {
+    return path.join(stateDir, 'config.json');
+  }
+
+  function writeConfig(cfg: Record<string, unknown>): void {
+    fs.writeFileSync(configPath(), JSON.stringify(cfg, null, 2));
+  }
+
+  function readConfig(): Record<string, unknown> {
+    return JSON.parse(fs.readFileSync(configPath(), 'utf-8'));
+  }
+
+  function runMigration(): MigrationResult {
+    const result: MigrationResult = { upgraded: [], skipped: [], errors: [] };
+    const migrator = new PostUpdateMigrator({
+      projectDir, stateDir, port: 4042, hasTelegram: false, projectName: 'test',
+    });
+    (migrator as unknown as { migrateCartographerDevGate(r: MigrationResult): void })
+      .migrateCartographerDevGate(result);
+    return result;
+  }
+
+  beforeEach(() => {
+    projectDir = fs.mkdtempSync(path.join(os.tmpdir(), 'carto-mig-'));
+    stateDir = projectDir; // migrator reads config.json at stateDir/config.json
+  });
+
+  afterEach(() => {
+    SafeFsExecutor.safeRmSync(projectDir, { recursive: true, force: true, operation: 'tests/unit/PostUpdateMigrator-cartographerDevGate.test.ts' });
+  });
+
+  it('dev agent: strips the two default-shaped `false`s and records upgraded', () => {
+    writeConfig({
+      developmentAgent: true,
+      cartographer: {
+        enabled: false,
+        conformanceAudit: { enabled: false },
+        freshnessSweep: { enabled: false },
+      },
+    });
+    const result = runMigration();
+    const cfg = readConfig();
+    const cart = cfg.cartographer as Record<string, any>;
+    expect(cart.enabled).toBeUndefined();
+    expect(cart.conformanceAudit.enabled).toBeUndefined();
+    // NEVER touch the cost-bearing surface.
+    expect(cart.freshnessSweep.enabled).toBe(false);
+    expect(result.upgraded.some((u) => u.includes('cartographer-dev-gate'))).toBe(true);
+  });
+
+  it('fleet agent: no-op (the dark default is correct for the fleet)', () => {
+    writeConfig({
+      cartographer: { enabled: false, conformanceAudit: { enabled: false } },
+    });
+    const result = runMigration();
+    const cfg = readConfig();
+    const cart = cfg.cartographer as Record<string, any>;
+    expect(cart.enabled).toBe(false);
+    expect(cart.conformanceAudit.enabled).toBe(false);
+    expect(result.upgraded.length).toBe(0);
+    expect(result.skipped.some((s) => s.includes('not a development agent'))).toBe(true);
+    // The marker is NOT set, so a later promotion to dev agent can still strip once.
+    expect((cfg._instar_migrations as string[] | undefined) ?? []).not.toContainEqual(
+      expect.stringContaining('cartographer-dev-gate-strip'),
+    );
+  });
+
+  it('NEVER strips an EXPLICIT operator value that is not exactly false', () => {
+    // An operator who set enabled:true keeps it; the migration only strips false.
+    writeConfig({
+      developmentAgent: true,
+      cartographer: { enabled: true, conformanceAudit: { enabled: true } },
+    });
+    runMigration();
+    const cart = readConfig().cartographer as Record<string, any>;
+    expect(cart.enabled).toBe(true);
+    expect(cart.conformanceAudit.enabled).toBe(true);
+  });
+
+  it('idempotent: a re-added operator `false` is NOT re-stripped after the marker is set', () => {
+    writeConfig({
+      developmentAgent: true,
+      cartographer: { enabled: false, conformanceAudit: { enabled: false } },
+    });
+    runMigration(); // first run strips + sets marker
+    // Operator deliberately re-adds false later.
+    const cfg = readConfig();
+    (cfg.cartographer as Record<string, any>).enabled = false;
+    writeConfig(cfg);
+    const result2 = runMigration();
+    const cart = readConfig().cartographer as Record<string, any>;
+    // The run-once marker means the deliberate `false` is preserved.
+    expect(cart.enabled).toBe(false);
+    expect(result2.skipped.some((s) => s.includes('already migrated'))).toBe(true);
+  });
+
+  it('no config.json: skips cleanly without error', () => {
+    const result = runMigration();
+    expect(result.errors.length).toBe(0);
+    expect(result.skipped.some((s) => s.includes('config.json not found'))).toBe(true);
+  });
+
+  it('corrupt config.json: reports an error and preserves bytes', () => {
+    fs.writeFileSync(configPath(), '{ not valid json');
+    const result = runMigration();
+    expect(result.errors.length).toBeGreaterThanOrEqual(1);
+    expect(fs.readFileSync(configPath(), 'utf-8')).toBe('{ not valid json');
+  });
+});

--- a/tests/unit/lint-dev-agent-dark-gate.test.ts
+++ b/tests/unit/lint-dev-agent-dark-gate.test.ts
@@ -5,19 +5,78 @@ import os from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+// The SAME attributor the lint's assertion C uses — the golden-path test asserts
+// THIS resolver reproduces a hand-authored map (never the resolver's own output).
+import { attributeEnabledFalsePaths } from '../../scripts/lib/dark-gate-attribution.js';
+import { DEV_GATED_FEATURES, DARK_GATE_EXCLUSIONS } from '../../src/core/devGatedFeatures.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, '../..');
 const LINT = path.join(ROOT, 'scripts', 'lint-dev-agent-dark-gate.js');
 
+/** Run the lint's real attributor over the REAL ConfigDefaults.ts → { line→path }. */
+function attributeRealConfigDefaults(): Record<string, string> {
+  const { paths, error } = attributeEnabledFalsePaths(
+    path.join(ROOT, 'src', 'config', 'ConfigDefaults.ts'),
+  );
+  if (error) throw new Error(`attribution error: ${error}`);
+  const out: Record<string, string> = {};
+  for (const { line, dottedPath } of paths) out[String(line)] = dottedPath;
+  return out;
+}
+
 /** Run the lint; return { code, out }. Never throws on non-zero exit. */
-function runLint(args: string[]): { code: number; out: string } {
+function runLint(args: string[], env?: Record<string, string>): { code: number; out: string } {
   try {
-    const out = execFileSync('node', [LINT, ...args], { cwd: ROOT, encoding: 'utf-8' });
+    const out = execFileSync('node', [LINT, ...args], {
+      cwd: ROOT,
+      encoding: 'utf-8',
+      env: { ...process.env, ...(env ?? {}) },
+    });
     return { code: 0, out };
   } catch (e: any) {
     return { code: e.status ?? 1, out: `${e.stdout ?? ''}${e.stderr ?? ''}` };
   }
+}
+
+/**
+ * Build a minimal-but-valid fixture pair (a ConfigDefaults.ts with a
+ * SHARED_DEFAULTS literal + a devGatedFeatures.ts registry) in a tmpdir, and
+ * return the env overrides that point the lint's assertion-C at them. The lint's
+ * C-assertion reads these two files directly (independent of the file args), so
+ * the overrides are the only way to exercise C's failure modes.
+ */
+function writeCFixture(opts: {
+  defaultsBody: string;       // contents INSIDE the SHARED_DEFAULTS `{ ... }`
+  gatedEntries?: string;      // contents INSIDE DEV_GATED_FEATURES `[ ... ]`
+  exclusionEntries?: string;  // contents INSIDE DARK_GATE_EXCLUSIONS `[ ... ]`
+}): { dir: string; env: Record<string, string> } {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'darkgate-C-'));
+  const configDefaults = `const SHARED_DEFAULTS = {\n${opts.defaultsBody}\n};\nexport { SHARED_DEFAULTS };\n`;
+  const registry = [
+    'export const DEV_GATED_FEATURES = [',
+    opts.gatedEntries ?? '',
+    '];',
+    'export const DARK_GATE_EXCLUSIONS = [',
+    opts.exclusionEntries ?? '',
+    '];',
+    '',
+  ].join('\n');
+  const cdPath = path.join(dir, 'ConfigDefaults.ts');
+  const regPath = path.join(dir, 'devGatedFeatures.ts');
+  fs.writeFileSync(cdPath, configDefaults);
+  fs.writeFileSync(regPath, registry);
+  return {
+    dir,
+    env: {
+      INSTAR_DARKGATE_CONFIG_DEFAULTS: cdPath,
+      INSTAR_DARKGATE_REGISTRY: regPath,
+    },
+  };
+}
+
+function cleanup(dir: string) {
+  SafeFsExecutor.safeRmSync(dir, { recursive: true, force: true, operation: 'tests/unit/lint-dev-agent-dark-gate.test.ts' });
 }
 
 describe('lint-dev-agent-dark-gate', () => {
@@ -136,6 +195,163 @@ describe('lint-dev-agent-dark-gate', () => {
       expect(out).toContain('B: hardcoded enabled under gate marker');
     } finally {
       SafeFsExecutor.safeRmSync(dir, { recursive: true, force: true, operation: 'tests/unit/lint-dev-agent-dark-gate.test.ts' });
+    }
+  });
+
+  // ── Assertion C — no unclassified dark default (DEV-AGENT-DARK-GATE-ENFORCEMENT) ──
+
+  it('Assertion C (a): an unclassified `enabled: false` FAILS', () => {
+    const { dir, env } = writeCFixture({
+      defaultsBody: '  myFeature: {\n    enabled: false,\n  },',
+      // registries empty — myFeature is in NEITHER → violation
+    });
+    try {
+      const { code, out } = runLint([path.join(dir, 'ConfigDefaults.ts')], env);
+      expect(code).toBe(1);
+      expect(out).toContain('C: unclassified dark default');
+      expect(out).toContain('myFeature.enabled');
+    } finally {
+      cleanup(dir);
+    }
+  });
+
+  it('Assertion C (b): the same path added to DARK_GATE_EXCLUSIONS PASSES', () => {
+    const { dir, env } = writeCFixture({
+      defaultsBody: '  myFeature: {\n    enabled: false,\n  },',
+      exclusionEntries:
+        "  { configPath: 'myFeature.enabled', category: 'destructive', reason: 'kills things; off for everyone by design' },",
+    });
+    try {
+      const { code } = runLint([path.join(dir, 'ConfigDefaults.ts')], env);
+      expect(code).toBe(0);
+    } finally {
+      cleanup(dir);
+    }
+  });
+
+  it('Assertion C (c): a path registered in DEV_GATED_FEATURES that STILL hardcodes `enabled: false` FAILS', () => {
+    const { dir, env } = writeCFixture({
+      defaultsBody: '  myFeature: {\n    enabled: false,\n  },',
+      gatedEntries:
+        "  { name: 'myFeature', configPath: 'myFeature.enabled', description: 'x', justification: 'read-only, no spend, safe on dev' },",
+    });
+    try {
+      const { code, out } = runLint([path.join(dir, 'ConfigDefaults.ts')], env);
+      expect(code).toBe(1);
+      expect(out).toContain('C: registered but hardcodes false');
+    } finally {
+      cleanup(dir);
+    }
+  });
+
+  it('Assertion C (d-category): an exclusion with an UNKNOWN category FAILS', () => {
+    const { dir, env } = writeCFixture({
+      defaultsBody: '  myFeature: {\n    enabled: false,\n  },',
+      exclusionEntries:
+        "  { configPath: 'myFeature.enabled', category: 'not-a-real-category', reason: 'this reason is plenty long enough' },",
+    });
+    try {
+      const { code, out } = runLint([path.join(dir, 'ConfigDefaults.ts')], env);
+      expect(code).toBe(1);
+      expect(out).toContain('C: invalid exclusion category');
+    } finally {
+      cleanup(dir);
+    }
+  });
+
+  it('Assertion C (d-reason): an exclusion with a <12-char reason FAILS', () => {
+    const { dir, env } = writeCFixture({
+      defaultsBody: '  myFeature: {\n    enabled: false,\n  },',
+      exclusionEntries:
+        "  { configPath: 'myFeature.enabled', category: 'destructive', reason: 'too short' },",
+    });
+    try {
+      const { code, out } = runLint([path.join(dir, 'ConfigDefaults.ts')], env);
+      expect(code).toBe(1);
+      expect(out).toContain('C: exclusion reason too short');
+    } finally {
+      cleanup(dir);
+    }
+  });
+
+  it('Assertion C (f-brace-in-string): a `{`-bearing string default in the block region makes the lint ERROR (loud-fail, not silent desync)', () => {
+    const { dir, env } = writeCFixture({
+      // A string value containing a brace — codeOnly() does not strip string
+      // contents, so the brace would desync depth attribution if not guarded.
+      defaultsBody: "  label: 'a value with a { brace inside a string',\n  myFeature: {\n    enabled: false,\n  },",
+      exclusionEntries:
+        "  { configPath: 'myFeature.enabled', category: 'destructive', reason: 'kills things; off for everyone by design' },",
+    });
+    try {
+      const { code, out } = runLint([path.join(dir, 'ConfigDefaults.ts')], env);
+      expect(code).toBe(1);
+      expect(out).toContain('brace-in-string in defaults block');
+    } finally {
+      cleanup(dir);
+    }
+  });
+
+  it('Assertion C (e) golden-path: the resolver reproduces the HAND-AUTHORED dotted-path map for EVERY current `enabled:` line in the real ConfigDefaults (regeneration FORBIDDEN — edit by hand)', () => {
+    // ────────────────────────────────────────────────────────────────────────
+    // DRIFT CANARY. This map is HAND-AUTHORED by reading src/config/ConfigDefaults.ts
+    // directly. It is NOT a vitest snapshot and MUST NEVER be regenerated from the
+    // resolver's own output (a snapshot regenerated from the resolver asserts
+    // output == output and would bless any misattribution). Updating it is a manual
+    // edit on a CODEOWNERS-reviewed path. If this fails, EITHER ConfigDefaults
+    // changed (update the map by hand after verifying the new paths) OR the
+    // attributor regressed (fix the attributor).
+    // ────────────────────────────────────────────────────────────────────────
+    const EXPECTED: Record<string, string> = {
+      '39': 'monitoring.bootHealthBeacon.enabled',
+      '58': 'monitoring.parallelWorkSentinel.enabled',
+      '129': 'monitoring.sessionReaper.enabled',
+      '177': 'monitoring.agentWorktreeReaper.enabled',
+      '191': 'monitoring.mcpProcessReaper.enabled',
+      '205': 'monitoring.agentSleep.enabled',
+      '228': 'monitoring.failureLearning.enabled',
+      '254': 'monitoring.correctionLearning.enabled',
+      '326': 'monitoring.apprenticeshipCycleSla.enabled',
+      '334': 'monitoring.geminiCapacityEscalation.enabled',
+      '342': 'monitoring.releaseReadiness.enabled',
+      '383': 'threadline.a2aCheckIn.enabled',
+      '427': 'mentor.enabled',
+      '438': 'mentor.autonomousFix.enabled',
+      '453': 'mentee.enabled',
+      '538': 'multiMachine.sessionPool.enabled',
+      '696': 'cartographer.freshnessSweep.enabled',
+      '730': 'cartographer.conformanceAudit.llmEnrichment.enabled',
+      '755': 'cartographer.subtreeNav.llmRerank.enabled',
+    };
+    const actual = attributeRealConfigDefaults();
+    expect(actual).toEqual(EXPECTED);
+  });
+
+  it('Assertion C (g) destructive-not-gated: the three reapers are in DARK_GATE_EXCLUSIONS and NOT in DEV_GATED_FEATURES', () => {
+    const gatedPaths = new Set(DEV_GATED_FEATURES.map((f) => f.configPath));
+    const excludedPaths = new Set(DARK_GATE_EXCLUSIONS.map((e) => e.configPath));
+    for (const p of [
+      'monitoring.mcpProcessReaper.enabled',
+      'monitoring.sessionReaper.enabled',
+      'monitoring.agentWorktreeReaper.enabled',
+    ]) {
+      expect(excludedPaths.has(p), `${p} must be in DARK_GATE_EXCLUSIONS`).toBe(true);
+      expect(gatedPaths.has(p), `${p} must NOT be in DEV_GATED_FEATURES (it is destructive)`).toBe(false);
+    }
+    // And each is classified `destructive`.
+    for (const p of [
+      'monitoring.mcpProcessReaper.enabled',
+      'monitoring.sessionReaper.enabled',
+      'monitoring.agentWorktreeReaper.enabled',
+    ]) {
+      const entry = DARK_GATE_EXCLUSIONS.find((e) => e.configPath === p)!;
+      expect(entry.category).toBe('destructive');
+    }
+  });
+
+  it('every DEV_GATED_FEATURES entry carries a non-trivial justification (the human-gate backstop)', () => {
+    for (const f of DEV_GATED_FEATURES) {
+      expect(typeof f.justification, `${f.name} justification`).toBe('string');
+      expect(f.justification.replace(/\s/g, '').length, `${f.name} justification length`).toBeGreaterThanOrEqual(12);
     }
   });
 });

--- a/upgrades/next/dev-agent-dark-gate-enforcement.md
+++ b/upgrades/next/dev-agent-dark-gate-enforcement.md
@@ -1,0 +1,35 @@
+# Upgrade Guide — Dev-Agent Dark-Gate Enforcement
+
+<!-- bump: minor -->
+<!-- Valid values: patch, minor, major -->
+
+## What Changed
+
+Closes the hole that let the cartographer features ship dark for **everyone** — including the development agents meant to dogfood them — and makes the dev-agent dark-gate convention structurally enforceable.
+
+- **Cartographer dogfoods on dev agents.** `cartographer.enabled` and `cartographer.conformanceAudit.enabled` now resolve through the existing `resolveDevAgentGate` (omit `enabled` in defaults → live on `developmentAgent:true`, dark on the fleet). The conformance route's strict `!== true` gate is converted to the resolver so it no longer 503s on a dev agent. A one-shot, dev-agent-only migration strips the default-shaped `false` on existing dev agents so they light up on update (never the cost-bearing sweep).
+- **The freshness sweep stays an explicit opt-in** (`cartographer.freshnessSweep.enabled: true`) even on dev agents — it is the one ongoing-cost surface (off-Claude codex calls). The redundant `egressAcknowledged` second gate is removed (the privacy framing was incoherent — source already egresses to a model every turn); the off-Claude routing probe is unchanged (cost guard, not privacy).
+- **Lint assertion C** (`scripts/lint-dev-agent-dark-gate.js`): every `enabled: false` default in `ConfigDefaults.ts` must now be DECLARED — either dev-gated (omit + register in `DEV_GATED_FEATURES`) or listed in the new `DARK_GATE_EXCLUSIONS` registry with a closed-enum `category` and a ≥12-char `reason`. A brace-in-string loud-fail guard, a hand-authored golden-path drift canary, and a required `justification` on every dev-gated entry back it up. All 21 existing dark defaults are classified, so the exact way cartographer slipped through cannot recur silently.
+
+🧪 **Mostly internal.** On the fleet nothing changes (cartographer stays dark). On a development agent, cartographer's zero-cost read surfaces (map, navigation, conformance audit) now run live. The `egressAcknowledged` field is retained for back-compat but is now inert on the sweep (which still needs explicit `enabled:true`).
+
+## What to Tell Your User
+
+- "Cartographer's read-only surfaces (the codebase map, navigation, and the standards audit) now run live on me as a development agent so they actually get dogfooded — they stay off for everyone else until you flip them on. The one part that spends money (the summary sweep) still needs an explicit one-line opt-in even on me."
+- "I also closed a gap that let those features ship off-for-everyone by accident: every 'off by default' feature now has to declare itself, or the build fails."
+
+## Summary of New Capabilities
+
+| Capability | How to Use |
+|-----------|-----------|
+| Cartographer live on dev agents | Automatic on `developmentAgent:true` (read surfaces); existing dev agents lit up by a one-shot migration on update |
+| Freshness sweep opt-in | `cartographer.freshnessSweep.enabled: true` (explicit, even on dev agents — ongoing off-Claude spend) |
+| Dark-gate enforcement lint | `node scripts/lint-dev-agent-dark-gate.js` (in `npm run lint`) — fails on any unclassified `enabled:false` default |
+| `DARK_GATE_EXCLUSIONS` registry | Declare a deliberately-off-for-everyone feature with `{configPath, category, reason}` in `src/core/devGatedFeatures.ts` |
+
+## Evidence
+
+- Unit (42): `devGatedFeatures` both-sides wiring auto-covers the two new entries (live-on-dev / dark-on-fleet); lint assertion-C cases (unclassified FAILS, excluded PASSES, registered-but-hardcoded FAILS, junk/short reason + unknown category FAIL); hand-authored golden-path drift canary; brace-in-string loud-fail fixture; destructive-not-gated guard (mcpProcessReaper stays excluded); one-shot dev-agent-only migration.
+- Integration (6): `GET /conformance/coverage` returns 200 under a `developmentAgent:true` config and 503 under a fleet config (the route-gate fix).
+- E2E (3): production init path — cartographer read routes live on a dev agent (200, not 503), 503 on the fleet, and the cost-bearing sweep poller is NOT started without explicit `freshnessSweep.enabled:true`.
+- `npx tsc --noEmit` exit 0; full `npm run lint` chain clean. Spec converged 3 rounds + approved (see `upgrades/side-effects/dev-agent-dark-gate-enforcement.md` and `docs/specs/reports/dev-agent-dark-gate-enforcement-convergence.md`).

--- a/upgrades/side-effects/dev-agent-dark-gate-enforcement.md
+++ b/upgrades/side-effects/dev-agent-dark-gate-enforcement.md
@@ -1,0 +1,95 @@
+# Side-Effects Review — Dev-Agent Dark-Gate Enforcement
+
+**Version / slug:** `dev-agent-dark-gate-enforcement`
+**Date:** 2026-06-10
+**Author:** echo (Instar Agent)
+**Spec:** `docs/specs/DEV-AGENT-DARK-GATE-ENFORCEMENT-SPEC.md` (converged 3 rounds, approved)
+
+## Summary of the change
+
+Two slices. **Slice A** routes the cartographer *zero-cost read surfaces* through
+the existing `resolveDevAgentGate` so they run LIVE on development agents and DARK
+on the fleet (the doc-tree/navigation read + the deterministic conformance audit),
+and removes the redundant `egressAcknowledged` second gate from the freshness
+sweep (the sweep remains an explicit `enabled:true` opt-in even on dev agents —
+NOT dev-gated — because it is the one ongoing-cost surface). **Slice B** closes the
+lint hole that let cartographer ship dark-for-everyone: every `enabled: false` in
+`ConfigDefaults.ts` must now be DECLARED — either dev-gated (omit `enabled` +
+register) or listed in a new `DARK_GATE_EXCLUSIONS` registry with a closed-enum
+category and a ≥12-char reason. A one-shot, dev-agent-only migration lights up
+existing dev agents on update.
+
+**Files changed (source):**
+- `src/config/ConfigDefaults.ts` — OMIT `enabled` from `cartographer` and
+  `cartographer.conformanceAudit` (gate decides at runtime); comments updated.
+  `freshnessSweep`/`llmEnrichment`/`llmRerank` `enabled:false` left as-is.
+- `src/commands/server.ts` — `cartographerEnabled` now via `resolveDevAgentGate`;
+  freshness-sweep start predicate drops the `&& egressAcknowledged` term (now
+  `enabled` alone). Off-Claude routing probe + per-pass bounds untouched.
+- `src/server/routes.ts` — conformance route gate `cfg?.enabled !== true` →
+  `!resolveDevAgentGate(cfg?.enabled, ctx.config)` (the only cartographer/
+  conformance ACCESS gate; the `sweepEnabled` status field at ~L4169 is a response
+  field, not a gate, deliberately untouched).
+- `src/core/devGatedFeatures.ts` — required `justification` field on
+  `DevGatedFeature` (+ on every existing entry); two new dev-gated entries
+  (`cartographer`, `cartographerConformanceAudit`); new `DarkGateCategory`,
+  `DarkGateExclusion`, `DARK_GATE_EXCLUSIONS` (all 19 remaining dark defaults
+  classified).
+- `src/core/PostUpdateMigrator.ts` — `migrateCartographerDevGate`: one-shot
+  (`_instar_migrations` marker), dev-agent-only, strips a default-shaped
+  `false` at `cartographer.enabled` + `cartographer.conformanceAudit.enabled`
+  ONLY; never touches `freshnessSweep`; records `result.upgraded`.
+
+**Files changed (lint/infra):**
+- `scripts/lint-dev-agent-dark-gate.js` — Assertion C (unclassified-dark-default +
+  registered-but-hardcoded-false), exclusion quality validation (closed category
+  enum + ≥12-char reason), brace-in-string loud-fail guard, literal-only limit
+  printed in failure header.
+- `scripts/lib/dark-gate-attribution.js` (NEW) — single path-attribution module
+  shared by the lint and the golden-path test (so the canary checks the SAME
+  attributor the lint uses).
+
+**Files changed (tests):** `tests/unit/lint-dev-agent-dark-gate.test.ts`
+(extended: assertion-C cases, hand-authored golden-path map, brace-in-string,
+destructive-not-gated, exclusion-quality), `tests/unit/PostUpdateMigrator-cartographerDevGate.test.ts`
+(NEW), `tests/integration/conformance-dev-gate-route.test.ts` (NEW),
+`tests/e2e/cartographer-dev-gate-lifecycle.test.ts` (NEW).
+
+**Files added (docs):** the spec, its `.eli16.md` companion, and the convergence report.
+
+## Decision-point inventory
+
+- **`cartographer.enabled`, `cartographer.conformanceAudit.enabled`** → dev-gate
+  (omit + register). Zero egress, zero spend — safe to dogfood live on dev agents.
+- **`cartographer.freshnessSweep.enabled`** → NOT dev-gated; explicit opt-in
+  everywhere (DARK_GATE_EXCLUSIONS, category `cost-bearing`). Auto-arming recurring
+  third-party spend across the dev fleet is a P19 blast-radius risk.
+- **`egressAcknowledged`** → neutralized as a second gate (privacy framing was
+  incoherent: source already egresses to a model every turn). Field retained for
+  back-compat; now inert on the sweep. Noted in the upgrade guide.
+- **The other 18 existing `enabled:false` blocks** → classified into
+  `DARK_GATE_EXCLUSIONS` (destructive / cost-bearing / structural-stub /
+  optional-integration / deliberate-fleet-default). NONE retroactively dev-gated
+  in this PR — that is a deliberate, bounded scope. Each observe-only sentinel
+  would need its own safety judgment before going live on dev agents; this change
+  makes that an explicit, lint-visible decision rather than a silent default.
+
+## 1–7. Analysis
+
+- **Behavioral change:** on a `developmentAgent:true` agent, cartographer's
+  read-only surfaces resolve LIVE (previously dark for everyone). On the fleet,
+  unchanged (still dark). The freshness sweep's activation is UNCHANGED for
+  everyone except that it no longer requires the second `egressAcknowledged` flag.
+- **Migration:** existing dev agents have `cartographer.enabled:false` on disk; the
+  one-shot migration strips the default-shaped value so the gate decides. Run-once
+  marker prevents ever re-stripping an operator's later deliberate `false`. Never
+  touches the cost-bearing sweep — no surprise spend on update.
+- **Security/cost:** no new egress path (the sweep was already the only egress, and
+  its activation conditions only got simpler, not broader — it still needs explicit
+  `enabled:true`). No new spend can be auto-armed. The new lint is deterministic,
+  reads one file, no network.
+- **Reversibility:** fully reversible by reverting the commit. The migration is
+  additive (deletes a default-shaped key); reverting restores prior behavior on the
+  next update for agents that hadn't yet run it.
+- **New failure modes:** none introduced. The lint's brace-in-string guard fails
+  LOUD (not silent) if an unhandled case is introduced — a safety improvement.


### PR DESCRIPTION
## ELI16 — Make dark features actually dogfood on dev agents, and make "off by default" a declared, enforced choice.

Instar ships new features "dark" (off for the whole fleet), but they're supposed to run **live** on development agents so they get exercised and mature before everyone receives them. The cartographer features forgot to opt into that gate — they hardcoded themselves off, so they shipped off for *everyone*, including the dev agent meant to dogfood them. This change routes cartographer's zero-cost read surfaces through the gate so they run live on dev agents (dark on the fleet), keeps the one cost-bearing surface an explicit opt-in even on dev agents, and closes the lint hole so every "off by default" feature must now declare itself — dev-gated, or on a documented exclusion list with a category and a reason. The exact way cartographer slipped through silently can't recur.

## What this does

The dev-agent dark-gate convention (`enabled ?? !!developmentAgent` via `resolveDevAgentGate`) already exists with a registry + wiring test + lint. The cartographer features (#1045/#1047/#1053) **bypassed** it — hardcoded `enabled: false`, so they shipped dark for *everyone* including dev agents, with no CI failure (the lint's assertion B only fires under a gate-marker comment).

**Slice A — cartographer dogfoods on dev agents:**
- `cartographer.enabled` + `cartographer.conformanceAudit.enabled` now resolve via `resolveDevAgentGate` (omit `enabled` in defaults → live on `developmentAgent:true`, dark on fleet); registered in `DEV_GATED_FEATURES`.
- Conformance route gate `cfg?.enabled !== true` → `!resolveDevAgentGate(...)` (a strict check would 503 on a dev agent even after registering).
- Freshness sweep stays an explicit opt-in (NOT dev-gated; `DARK_GATE_EXCLUSIONS` category `cost-bearing`) — the one ongoing-cost surface; auto-arming spend across the dev fleet is a P19 blast-radius risk. The redundant `egressAcknowledged` second gate is removed (privacy framing was incoherent — source egresses to a model every turn); off-Claude routing probe unchanged.
- One-shot, dev-agent-only migration strips the default-shaped `false` on existing dev agents so they light up on update (never the sweep).

**Slice B — close the lint hole:**
- Lint assertion C: every `enabled: false` in `ConfigDefaults.ts` must be DECLARED — dev-gated (omit + register) or in `DARK_GATE_EXCLUSIONS` with a closed-enum `category` + ≥12-char `reason`. Brace-in-string loud-fail guard; literal-only limit declared (P2 — non-literal `?? false` still evades, carried forward honestly).
- `DARK_GATE_EXCLUSIONS` classifies all 19 remaining dark defaults; required `justification` on every dev-gated entry (CODEOWNERS human backstop). Destructive-not-gated test (mcpProcessReaper stays excluded). Hand-authored golden-path drift canary (not a regenerable snapshot).

## Convergence

Spec converged over **3 rounds** (5 internal reviewers incl. mandatory lessons-aware; externals unavailable this session → abbreviated). Caught: the auto-armed-spend blast radius, the strict route-gate divergence, unwired-stub flags, and a self-defeating test canary — all before code. Report: `docs/specs/reports/dev-agent-dark-gate-enforcement-convergence.md`. Approved (model B).

## Tests

- Unit (42): wiring (auto-covers new entries), lint assertion-C/golden-path/brace-in-string/destructive-not-gated/exclusion-quality, one-shot migration.
- Integration (6): `GET /conformance/coverage` 200 under dev config, 503 under fleet config.
- E2E (3): production init — cartographer read routes live on dev (200, not 503), 503 on fleet, sweep NOT auto-armed.
- `tsc --noEmit` clean; full `npm run lint` chain clean; CI: all unit shards (node 20+22) + integration + e2e green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Spec converged 3 rounds + approved; all required CI green (unit shards node 20+22, integration, e2e, type-check)._