### PR TITLE
feat(spec-converge): cross-model hardening — mandatory, dynamic, family-diverse externals (Piece 3)

### DIFF
--- a/.instar/instar-dev-decisions/2026-06-10T23-37-28-911Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-06-10T23-37-28-911Z-unknown.json
@@ -1,0 +1,13 @@
+{
+  "ts": "2026-06-10T23:37:28.911Z",
+  "slug": "unknown",
+  "suggestedTier": 2,
+  "declaredTier": 2,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 3,
+  "loc": 595,
+  "causalAutopsy": null,
+  "verdict": "pass"
+}

--- a/.instar/instar-dev-decisions/2026-06-10T23-50-58-886Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-06-10T23-50-58-886Z-unknown.json
@@ -1,0 +1,13 @@
+{
+  "ts": "2026-06-10T23:50:58.886Z",
+  "slug": "unknown",
+  "suggestedTier": 2,
+  "declaredTier": 2,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 3,
+  "loc": 600,
+  "causalAutopsy": null,
+  "verdict": "pass"
+}

--- a/skills/spec-converge/SKILL.md
+++ b/skills/spec-converge/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: spec-converge
-description: Iteratively review an instar-development spec with multi-angle internal reviewers (security, scalability, adversarial, integration, decision-completeness, lessons-aware) and a real cross-model external reviewer routed through the agent's own installed codex CLI (GPT-tier) until convergence, then produce a comprehensive ELI10 convergence report. Output is a spec tagged review-convergence — one of the two tags /instar-dev requires before it will touch instar source. NOT user-invocable; run by the instar-developing agent before any spec-driven /instar-dev work.
+description: Iteratively review an instar-development spec with multi-angle internal reviewers (security, scalability, adversarial, integration, decision-completeness, lessons-aware) and real cross-model external reviewers routed through the agent's own installed CLIs (codex → GPT-tier, gemini → Gemini-tier; one pass per available family) until convergence, then produce a comprehensive ELI10 convergence report. Output is a spec tagged review-convergence — one of the two tags /instar-dev requires before it will touch instar source. NOT user-invocable; run by the instar-developing agent before any spec-driven /instar-dev work.
 metadata:
   user_invocable: "false"
   audience: "instar-developing agent only — NOT end users"
@@ -72,29 +72,37 @@ The skill spawns reviewers in parallel:
 - **Decision-Completeness.** (Autonomy Principle 2 — `docs/specs/AUTONOMY-PRINCIPLES-ENFORCEMENT-SPEC.md` Piece 2.) Enumerates every point where the building agent would have to **stop mid-run and ask the user**. Each must be either **frontloaded** into a `## Frontloaded Decisions` section or explicitly tagged **cheap-to-change-after** because the work ships behind a named dark/dry-run/read-only phase. The reviewer **CONTESTS every cheap tag** — it independently asserts reversibility, and a closed non-cheap taxonomy overrides any tag: anything touching **durable external side-effects, money, identity, or a published/user-visible interface is NEVER cheap**, regardless of a "ships dark" label. A contested tag the reviewer rejects is a **material finding that blocks convergence**. Prompt: `templates/reviewer-decision-completeness.md`. Applies to ALL specs through this skill (D7) — no size gate, no per-spec override (D11; the rejected `disposition: override` escape hatch would reopen the exact skip-hatch Principle 2 closes).
 - **Lessons-aware.** Loads the canonical Instar Design Principles + Lessons Learned index (`docs/INSTAR-DESIGN-PRINCIPLES-AND-LESSONS.md`) plus the running agent's local `.instar/memory/feedback_*.md` entries, then checks the spec for (a) direct contradictions of documented principles/lessons, (b) applicable lessons the spec fails to engage with, (c) behavioral lessons violated by agent-facing surfaces the spec proposes, and **(d) FOUNDATION/SUBSYSTEM AUDIT — the design the spec TESTS, EXTENDS, or BUILDS ON, not just the spec's own surface: does that foundation violate a known standard or repeat a known mistake?** The audit MUST reach one layer below the spec boundary. A spec can be internally clean while faithfully testing or extending a flawed foundation — e.g. a test-harness spec that correctly proves a permission gate which *itself* holds brittle blocking authority in violation of Signal-vs-Authority, or an extension spec built on a subsystem with an unaddressed gap. Taking the underlying subsystem "as given" is exactly how a standards violation survives review: the spec passes, the foundation's flaw is never weighed. When the foundation is flawed, the finding is "this spec is sound but the subsystem it depends on violates standard X / repeats mistake Y — surface it before building on/around it." Catches the "Phase 2" anti-pattern, the spec-converge-pre-auth-circular failure mode (see `feedback_spec_converge_pre_auth_circular`), and the foundation-not-audited gap (the Slack-permission-gate brittle-enum-as-authority that the harness convergence cleared because it audited only the harness, 2026-06-09).
 
-**External reviewer (cross-model, via the agent's own installed codex CLI):**
+**External reviewers (cross-model, via the agent's own installed CLIs — one pass PER AVAILABLE FAMILY):**
 
-The external "cross-model" pass is a single independent GPT-tier read that sits *outside* the Claude family to catch the blind spots Claude models share. It is **real**, routed through the agent's own `codex login` (no new API key, no new network dependency), and implemented in code — NOT a hand-wave. Run it like this:
+The external "cross-model" pass is a set of independent non-Claude reads that sit *outside* the Claude family to catch the blind spots Claude models share. It is **real**, routed through the agent's own CLI logins (`codex login` → GPT-tier, gemini OAuth → Gemini-tier; no new API key, no new network dependency), and implemented in code — NOT a hand-wave. **Family diversity is the point**: GPT and Gemini catch different failure classes, so the pass runs ONE review per available family (detect-all), not first-match-only. Run it like this:
 
-1. **Detect** whether a supported reviewer framework is installed + authed:
+1. **Detect** every supported reviewer framework that is installed + authed:
    ```bash
-   node skills/spec-converge/scripts/cross-model-review.mjs --spec <spec-path> --detect-only
+   node skills/spec-converge/scripts/cross-model-review.mjs --spec <spec-path> --detect-only --state-dir .instar
    ```
-   Returns `{ available, framework?, model?, reason? }`. `available:false` → skip the external pass, set the fallback flag (see §"No-codex fallback" below / Phase 5), and continue internal-only. **Never block.**
+   Returns `{ available, frameworks: [...all available...], framework?, model?, reason? }` (the single-framework fields remain for back-compat). `--state-dir` records the detection into the **durable framework-activation history** (`state/framework-activation-history.jsonl`) — the standing-framework baseline the mandatory-check in Phase 3 reads. `available:false` → set the fallback flag (see Phase 5) and continue internal-only **only if the mandatory-check permits it** (Phase 3). **Never block.**
 
-2. **Run** the external review when available — pass the spec plus the same architectural context docs the internal reviewers receive (the docs the spec references):
+2. **Run** one external review per available family — pass the spec plus the same architectural context docs the internal reviewers receive (the docs the spec references):
    ```bash
    node skills/spec-converge/scripts/cross-model-review.mjs \
-     --spec <spec-path> \
+     --spec <spec-path> --family codex-cli \
+     --context docs/foo.md --context docs/bar.md
+   node skills/spec-converge/scripts/cross-model-review.mjs \
+     --spec <spec-path> --family gemini-cli \
      --context docs/foo.md --context docs/bar.md
    ```
-   It emits a JSON `ReviewerResult` on stdout: `{ status, framework?, model?, verdict?, findings?, reason?, flag }`. Fold its `findings` into the round alongside the internal reviewers'. `status:'degraded'` (codex present but the call failed — timeout / error / rate-limited) is a *partial* cross-model pass for the round: fold in whatever came back and record the `degraded` flag — it does **not** collapse to `unavailable`.
+   Each emits a JSON `ReviewerResult` on stdout: `{ status, framework?, model?, verdict?, findings?, reason?, flag }`. Fold each `findings` into the round alongside the internal reviewers'. `status:'degraded'` (framework present but the call failed — timeout / error / rate-limited) is a *partial* cross-model pass for the round: fold in whatever came back and record the `degraded` flag — it does **not** collapse to `unavailable`. (Omitting `--family` keeps the old single-pass first-match behavior for existing callers.)
 
-The detection + invocation + parsing live in the unit-tested `src/core/crossModelReviewer.ts` module (built to `dist/core/crossModelReviewer.js`); the script is a thin file-I/O wrapper. codex is the **first** supported framework in an extensible registry (`SUPPORTED_REVIEWER_FRAMEWORKS`) — gemini-cli and others plug in there later with **no skill change**.
+Two structural guards on the pass:
+
+- **Fail-loud model canary.** Model selection is dynamic (the `'capable'` tier resolved per framework — never a pinned name), and a tier word that falls through resolution (`'capable'` is not a model) is caught by `isConcreteReviewerModel` BEFORE the provider is invoked: the round degrades loudly with reason `model-resolution-canary` instead of silently selecting a dead reviewer.
+- **Trusted-provider allowlist.** `--family` only accepts frameworks on `TRUSTED_REVIEWER_FRAMEWORKS` (`codex-cli`, `gemini-cli` — first-party OAuth CLI adapters). The full spec text is handed to the reviewer, so it must NEVER be sent to a custom/base-URL endpoint; **pi-cli is deliberately excluded** from cross-model review for this reason (its provider may be a custom endpoint). An untrusted family is refused with `reason: 'untrusted-framework'`.
+
+The detection + invocation + parsing live in the unit-tested `src/core/crossModelReviewer.ts` module (built to `dist/core/crossModelReviewer.js`); the script is a thin file-I/O wrapper. codex and gemini are the supported frameworks in an extensible registry (`SUPPORTED_REVIEWER_FRAMEWORKS`) — further first-party CLIs plug in there with **no skill change**.
 
 Each internal reviewer receives the spec, the architectural context docs referenced in the spec (`docs/signal-vs-authority.md`, `docs/integrated-being.md`, relevant subsystem docs), and a prompt specific to their perspective. Each produces a structured finding list.
 
-The **six internal reviewers + the cross-model external pass** run in parallel (the external pass is one cross-model read through the first available supported framework — the honest mechanism, not three phantom API models). Their findings are collected.
+The **six internal reviewers + the cross-model external passes** run in parallel (one external read per available supported family — the honest mechanism, not three phantom API models). Their findings are collected.
 
 **Code-backed reviewer — the Standards-Conformance Gate (auto-invoked).** Alongside the internal reviewers + the cross-model external pass, call the live gate: `POST /spec/conformance-check` with the spec (body `{ "specPath": "<path-within-specsDir>" }`, or `{ "markdown": "<spec text>" }`). Unlike the prompt-driven reviewers, the gate is *code that reads the living constitution* (`docs/STANDARDS-REGISTRY.md`) and returns a per-standard report — `ok` / `at-risk` / `n/a` + a reason for every standing standard. Fold its `at-risk` entries into the round's findings. It is the structural complement to the Lessons-aware reviewer: lessons-aware reads the lessons doc + local memory (prompt-driven); the gate reads the constitution itself (code), so a registry edit can never be silently missed. **Signal-only:** advisory — it surfaces violations, it does not block (blocking authority is the separate, later `scg-blocking-authority` follow-up, per *Signal vs. Authority*). **Fail-open:** if the gate is disabled/unreachable (503) or returns `degraded: true`, note that the constitutional pass was not authoritative and continue — a down gate must never stall spec review. (This auto-invocation is the dogfood-to-ship enforcement of the **Self-Hosting** standard — the gate now *runs* at spec-review rather than being a step the author must remember.)
 
@@ -110,7 +118,26 @@ Every update preserves the spec's structure. Changes are additive (new sections 
 
 ### Phase 3 — Convergence check
 
-After the spec is updated, the skill runs another full review round (the six internal reviewers + the cross-model external pass, in parallel, on the updated spec).
+After the spec is updated, the skill runs another full review round (the six internal reviewers + the cross-model external passes, in parallel, on the updated spec).
+
+#### Delta-gating the external passes (mandatory, but not blindly every round)
+
+The externals are **MANDATORY on round 1 and on any round where the spec's reviewable body changed** since the last external pass. "Changed" is decided by content hash, not memory:
+
+```bash
+node skills/spec-converge/scripts/cross-model-review.mjs --spec <spec-path> --hash-only
+```
+
+prints `{ hash }` — `hashSpecReviewableBody`'s sha256 of the spec with the leading YAML frontmatter stripped and line endings normalized, so tag-writes and approval edits never change it. Record the hash alongside each external pass; when a later round's hash equals the last external pass's hash, the externals for that round are **skipped-with-logged-note** (the iteration log records "externals delta-skipped: body unchanged since round N, hash <prefix>"). This is the cost answer — redundant re-reviews of an unchanged spec are killed — and it does **NOT** count as `skipped-abbreviated`: the spec still received its external review of this exact content.
+
+#### The mandatory-check (durable standing-framework baseline)
+
+The external passes are **NON-SKIPPABLE** whenever a non-Claude framework was **active at ANY point in the last 7 days** per the durable activation history:
+
+- The check is `wasNonClaudeFrameworkActiveWithin(stateDir, 7)` (exported from `src/core/crossModelReviewer.ts`), read from `state/framework-activation-history.jsonl` — the file every `--detect-only --state-dir` invocation appends to.
+- A **just-before-converge deactivation does not exempt the spec**: activation is judged against the recorded lookback window, never a just-in-time reading. A framework deactivated inside the window keeps externals mandatory.
+- A **mid-converge deactivation** (frameworks available at round 1, gone at round N) is logged in the iteration log and **fails report validation**.
+- The advisory "externals unavailable" floor (Phase 5's `unavailable` flag) is legitimate ONLY for an agent that has been genuinely single-framework across the whole lookback — a recorded standing fact, not a 30-second-old flip.
 
 Convergence criteria (BOTH must hold — additive, per Autonomy Principle 2):
 
@@ -186,7 +213,7 @@ review-convergence: "<ISO timestamp>"
 review-iterations: <N>
 review-completed-at: "<ISO timestamp>"
 review-report: "docs/specs/reports/<slug>-convergence.md"
-cross-model-review: "<flag>"          # codex-cli:<model> | unavailable | degraded-all-rounds | skipped-abbreviated
+cross-model-review: "<flag>"          # codex-cli:<model> | gemini-cli:<model> | unavailable | degraded-all-rounds | skipped-abbreviated
 cross-model-review-reason: "<reason>" # only when unavailable / degraded / degraded-all-rounds
 single-run-completable: true          # earned, not minted — written only when Open questions reached zero
 frontloaded-decisions: <N>            # count from the Decision-Completeness reviewer's final round
@@ -253,7 +280,7 @@ The convergence check is structural. If the LLM comparator finds new material is
 A smaller finding count is NOT convergence. Convergence is zero material findings in a new round.
 
 ### Skipping a reviewer perspective to ship faster
-All six internal reviewers (security, scalability, adversarial, integration, decision-completeness, lessons-aware) AND the cross-model external pass run on every round. Skipping is visible in the iteration log and fails the report validation. During pattern-instance abbreviated convergence, the external cross-model pass may be skipped to save cost — record that honestly as `cross-model-review: skipped-abbreviated` (distinct from `unavailable`: the framework may be present, but the author chose the fast path) — but the lessons-aware reviewer MUST run; it's the only structural defense against the spec-converge-pre-auth-circular failure mode.
+All six internal reviewers (security, scalability, adversarial, integration, decision-completeness, lessons-aware) AND the cross-model external passes run on every round (subject to Phase 3's delta-gating — an unchanged-body round delta-skips with a logged note, which is NOT a skip of the perspective). Skipping is visible in the iteration log and fails the report validation. **Abbreviated convergence may NO LONGER skip the external pass when the 7-day activation history shows a non-Claude framework** (`wasNonClaudeFrameworkActiveWithin` — see Phase 3's mandatory-check): a framework that was active at any point in the lookback makes externals mandatory, and a just-before-converge deactivation does not exempt the spec. `cross-model-review: skipped-abbreviated` remains a legitimate record ONLY for genuinely single-framework agents (no non-Claude framework anywhere in the lookback; distinct from `unavailable`). In ALL abbreviated runs the lessons-aware AND decision-completeness reviewers MUST still run; lessons-aware is the only structural defense against the spec-converge-pre-auth-circular failure mode.
 
 ### Rewriting the spec between iterations to hide findings
 Spec edits must address findings, not evade them. The iteration log records both the finding and the resolution. An edit that changes the spec to make the finding "not applicable" without actually solving the concern is caught at the next review round.

--- a/skills/spec-converge/scripts/cross-model-review.mjs
+++ b/skills/spec-converge/scripts/cross-model-review.mjs
@@ -15,20 +15,37 @@
  * access, so context must be inlined before the spawn.
  *
  * Modes:
- *   --detect-only            Print detection JSON and exit (no codex spawn).
- *                            { available, framework?, model?, reason? }
+ *   --detect-only            Print detection JSON and exit (no spawn).
+ *                            { available, frameworks: [...all available...],
+ *                              framework?, model?, reason? } — the `frameworks`
+ *                            array is the Piece-3 family-diverse collection;
+ *                            the single-framework fields stay for back-compat.
+ *                            With --state-dir <dir>, also records the
+ *                            activation observation to the durable
+ *                            framework-activation history (the standing-
+ *                            framework baseline for the mandatory check).
+ *   --hash-only              Print { hash } — sha256 of the spec's reviewable
+ *                            body (frontmatter-stripped, CRLF-normalized) for
+ *                            the skill's delta-gating. Requires --spec.
  *   (default)                Detect; if available, assemble the prompt + run
- *                            the codex review; print the ReviewerResult JSON.
+ *                            the review; print the ReviewerResult JSON. With
+ *                            --family <id>, run through THAT framework
+ *                            specifically (must be on the trusted first-party
+ *                            allowlist — spec text is never sent to a custom/
+ *                            base-URL endpoint; pi-cli is excluded by design).
  *
  * Usage:
  *   node skills/spec-converge/scripts/cross-model-review.mjs \
  *     --spec docs/specs/<slug>.md \
  *     [--context docs/foo.md --context docs/bar.md ...] \
- *     [--detect-only] \
+ *     [--detect-only] [--state-dir .instar] \
+ *     [--hash-only] \
+ *     [--family codex-cli|gemini-cli] \
  *     [--timeout-ms 120000]
  *
  * Output: a single JSON object on stdout (machine-readable for the skill).
- *   On detect-only: the CrossModelDetectionResult.
+ *   On detect-only: the detection JSON above.
+ *   On hash-only:   { hash }.
  *   On full run:    the ReviewerResult ({ status, framework?, model?, verdict?,
  *                   findings?, reason?, flag }).
  *
@@ -60,19 +77,30 @@ function fail(msg) {
 
 function parseArgs() {
   const args = process.argv.slice(2);
-  const out = { spec: null, context: [], detectOnly: false, timeoutMs: null };
+  const out = {
+    spec: null,
+    context: [],
+    detectOnly: false,
+    hashOnly: false,
+    family: null,
+    stateDir: null,
+    timeoutMs: null,
+  };
   for (let i = 0; i < args.length; i++) {
     const a = args[i];
     if (a === '--spec') out.spec = args[++i];
     else if (a === '--context') out.context.push(args[++i]);
     else if (a === '--detect-only') out.detectOnly = true;
+    else if (a === '--hash-only') out.hashOnly = true;
+    else if (a === '--family') out.family = args[++i];
+    else if (a === '--state-dir') out.stateDir = args[++i];
     else if (a === '--timeout-ms') out.timeoutMs = parseInt(args[++i], 10);
     else fail(`Unknown arg: ${a}`);
   }
   if (!out.detectOnly && !out.spec) {
     fail(
       'Usage: cross-model-review.mjs --spec PATH [--context PATH ...] ' +
-        '[--detect-only] [--timeout-ms N]',
+        '[--detect-only] [--hash-only] [--family ID] [--state-dir DIR] [--timeout-ms N]',
     );
   }
   return out;
@@ -98,16 +126,80 @@ function readRepoFile(rel) {
 }
 
 async function main() {
-  const { spec, context, detectOnly, timeoutMs } = parseArgs();
+  const { spec, context, detectOnly, hashOnly, family, stateDir, timeoutMs } = parseArgs();
   const mod = await loadModule();
 
-  // Detection is the same in both modes.
-  const detection = mod.detectCrossModelReviewer();
-
-  if (detectOnly) {
-    process.stdout.write(JSON.stringify(detection) + '\n');
+  // ── --hash-only: the delta-gating hash of the spec's reviewable body ──
+  if (hashOnly) {
+    if (!spec) fail('--hash-only requires --spec PATH');
+    const specMarkdown = readRepoFile(spec);
+    process.stdout.write(JSON.stringify({ hash: mod.hashSpecReviewableBody(specMarkdown) }) + '\n');
     process.exit(0);
   }
+
+  // ── --detect-only: report ALL available families (Piece 3) ──
+  if (detectOnly) {
+    const all = mod.detectAllCrossModelReviewers();
+    // Back-compat: keep the old single-framework fields (first-match shape).
+    const first = mod.detectCrossModelReviewer();
+    const report = {
+      available: all.length > 0,
+      frameworks: all,
+      ...(first.framework ? { framework: first.framework } : {}),
+      ...(first.model ? { model: first.model } : {}),
+      ...(first.reason ? { reason: first.reason } : {}),
+    };
+    // Record the activation observation into the durable standing-framework
+    // baseline when a state dir was provided. A record failure is surfaced in
+    // the JSON (fail-loud), never silently swallowed — a missing baseline
+    // would quietly weaken the externals-mandatory check.
+    if (stateDir) {
+      const frameworks = {};
+      for (const entry of mod.SUPPORTED_REVIEWER_FRAMEWORKS) {
+        frameworks[entry.id] = all.some((d) => d.framework === entry.id);
+      }
+      try {
+        mod.recordFrameworkActivationObservation(stateDir, { frameworks });
+        report.activationRecorded = true;
+      } catch (err) {
+        report.activationRecorded = false;
+        report.activationRecordError =
+          err instanceof Error ? err.message.slice(0, 200) : String(err);
+      }
+    }
+    process.stdout.write(JSON.stringify(report) + '\n');
+    process.exit(0);
+  }
+
+  // ── full run ──
+  // --family: run through ONE specific framework. Allowlist-gated — the full
+  // spec text is never sent to a custom/base-URL endpoint (pi-cli excluded).
+  let familyEntry = null;
+  if (family) {
+    if (!mod.isTrustedReviewerFramework(family)) {
+      process.stdout.write(
+        JSON.stringify({
+          status: 'unavailable',
+          reason: 'untrusted-framework',
+          flag: 'cross-model-review: unavailable',
+        }) + '\n',
+      );
+      process.exit(0);
+    }
+    familyEntry = mod.SUPPORTED_REVIEWER_FRAMEWORKS.find((f) => f.id === family) ?? null;
+    if (!familyEntry) {
+      process.stdout.write(
+        JSON.stringify({
+          status: 'unavailable',
+          reason: 'no-supported-framework',
+          flag: 'cross-model-review: unavailable',
+        }) + '\n',
+      );
+      process.exit(0);
+    }
+  }
+
+  const detection = familyEntry ? familyEntry.detect() : mod.detectCrossModelReviewer();
 
   // Unavailable → print the unavailable flag, exit 0. Never block.
   if (!detection.available) {
@@ -130,10 +222,16 @@ async function main() {
     context: contextDocs,
   });
 
-  const result = await mod.runCrossModelReview({
-    assembled,
-    ...(Number.isFinite(timeoutMs) ? { timeoutMs } : {}),
-  });
+  const result = familyEntry
+    ? await familyEntry.review({
+        promptText: assembled.promptText,
+        timeoutMs: Number.isFinite(timeoutMs) ? timeoutMs : mod.REVIEW_TIMEOUT_MS,
+        detectionOverride: detection,
+      })
+    : await mod.runCrossModelReview({
+        assembled,
+        ...(Number.isFinite(timeoutMs) ? { timeoutMs } : {}),
+      });
 
   // Surface truncation in the emitted result so the skill/report can note it.
   process.stdout.write(JSON.stringify({ ...result, promptTruncated: assembled.truncated }) + '\n');

--- a/src/core/crossModelReviewer.ts
+++ b/src/core/crossModelReviewer.ts
@@ -22,18 +22,37 @@
  *     from `degraded` (framework present, this call failed) and
  *     `skipped-abbreviated` (author chose the fast path).
  *
- * codex is the FIRST supported framework; the registry
- * (`SUPPORTED_REVIEWER_FRAMEWORKS`) is the single seam for gemini-cli and
- * others to plug in later (Out of Scope here). Adding a framework is one
- * registry entry + one `id`-union extension — no skill change.
+ * codex is the FIRST supported framework; gemini-cli is the SECOND (Piece 3 of
+ * docs/specs/AUTONOMY-PRINCIPLES-ENFORCEMENT-SPEC.md — cross-model convergence
+ * hardening). The registry (`SUPPORTED_REVIEWER_FRAMEWORKS`) remains the single
+ * seam for further frameworks. Adding a framework is one registry entry + one
+ * `id`-union extension — no skill change.
+ *
+ * Piece 3 additions (all signal-only, never-throw, same invariants as above):
+ *   - `detectGeminiReviewer` + the gemini registry entry (family diversity).
+ *   - `detectAllCrossModelReviewers` — collect EVERY available framework, not
+ *     just the first match, so the skill runs one external pass per family.
+ *   - `isConcreteReviewerModel` — the fail-loud model canary: a tier word
+ *     ('capable', 'fast', …) falling through model resolution degrades the
+ *     review LOUDLY instead of silently selecting a dead reviewer.
+ *   - `hashSpecReviewableBody` — delta-gating: externals re-run only when the
+ *     spec's reviewable body (frontmatter stripped) actually changed.
+ *   - `recordFrameworkActivationObservation` / `wasNonClaudeFrameworkActiveWithin`
+ *     — the durable standing-framework baseline: activation is judged against
+ *     a lookback window of recorded observations, not a just-in-time reading,
+ *     so a just-before-converge framework deactivation cannot exempt a spec.
+ *   - `TRUSTED_REVIEWER_FRAMEWORKS` — the provider allowlist (no spec egress
+ *     to untrusted/custom endpoints).
  */
 
+import crypto from 'node:crypto';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
-import { detectCodexPath } from './Config.js';
+import { detectCodexPath, detectGeminiPath } from './Config.js';
 import { validateRule1 } from '../providers/adapters/openai-codex/credentials.js';
 import { resolveCliModelFlag } from '../providers/adapters/openai-codex/models.js';
+import { resolveCliModelFlag as resolveGeminiModelFlag } from '../providers/adapters/gemini-cli/models.js';
 import {
   buildIntelligenceProvider,
   type IntelligenceFramework,
@@ -122,6 +141,8 @@ export type CrossModelUnavailableReason =
   | 'codex-not-installed'
   | 'codex-not-authed'
   | 'codex-auth-apikey-forbidden'
+  | 'gemini-not-installed'
+  | 'gemini-not-authed'
   | 'no-supported-framework';
 
 export interface CrossModelDetectionResult {
@@ -153,6 +174,16 @@ export interface CrossModelDetectInputs {
   env?: NodeJS.ProcessEnv;
   /** Clock injection for the Rule-1 killswitch sunset check. */
   now?: Date;
+  /**
+   * Path to the gemini binary if detected, else null. Defaults to
+   * `detectGeminiPath()` (PATH + known-location resolution).
+   */
+  geminiPathDetected?: string | null;
+  /**
+   * Path to the gemini CLI's cached OAuth credentials. Defaults to
+   * `${GEMINI_HOME || ~/.gemini}/oauth_creds.json`.
+   */
+  geminiOauthCredsPath?: string;
 }
 
 /** Resolve the default codex auth.json path (CODEX_HOME-aware). */
@@ -219,6 +250,75 @@ export function detectCodexReviewer(
   };
 }
 
+/**
+ * Resolve the default gemini oauth_creds.json path. DELIBERATELY no env-var
+ * override: the gemini CLI (verified v0.25.2) resolves creds at
+ * `~/.gemini/oauth_creds.json` UNCONDITIONALLY — there is no GEMINI_HOME.
+ * Honoring one here would make detection probe a path the CLI never reads
+ * (false-unavailable on an authed host -> the gemini pass silently skipped AND
+ * a false `gemini-cli:false` recorded into the activation baseline — the exact
+ * suppression Piece 3 exists to prevent). Tests inject `geminiOauthCredsPath`.
+ */
+function defaultGeminiOauthCredsPath(): string {
+  return path.join(os.homedir(), '.gemini', 'oauth_creds.json');
+}
+
+/**
+ * Is the gemini CLI's cached OAuth credentials file an authed shape? Authed
+ * iff the file parses as JSON with a non-empty string `access_token` OR
+ * `refresh_token` (the CLI refreshes an expired access token from the refresh
+ * token, so either is a usable seat). A missing / unreadable / malformed file
+ * → false (not authed). Never throws.
+ */
+function geminiOauthCredsAuthed(credsPath: string): boolean {
+  try {
+    const raw = fs.readFileSync(credsPath, 'utf-8');
+    const parsed = JSON.parse(raw) as { access_token?: unknown; refresh_token?: unknown };
+    const nonEmptyString = (v: unknown): boolean => typeof v === 'string' && v.length > 0;
+    return nonEmptyString(parsed?.access_token) || nonEmptyString(parsed?.refresh_token);
+  } catch {
+    // @silent-fallback-ok — deny-safe: missing/unreadable/malformed creds mean
+    // "not authed" (the reviewer is reported unavailable with a named reason);
+    // mirrors the codex auth probe above.
+    return false;
+  }
+}
+
+/**
+ * Detect a gemini reviewer (Piece 3 — the second family in the registry).
+ * Returns `{ available: true, framework, model }` iff BOTH of: gemini binary
+ * detected, cached OAuth credentials present (`access_token` or
+ * `refresh_token`). Any miss → a specific reason.
+ *
+ * Pure-ish: all external inputs are injectable (mirrors
+ * `detectCodexReviewer`). With no inputs it probes the real host. It NEVER
+ * throws.
+ */
+export function detectGeminiReviewer(
+  inputs: CrossModelDetectInputs = {},
+): CrossModelDetectionResult {
+  const env = inputs.env ?? process.env;
+  const geminiPath =
+    inputs.geminiPathDetected !== undefined ? inputs.geminiPathDetected : detectGeminiPath();
+  const credsPath = inputs.geminiOauthCredsPath ?? defaultGeminiOauthCredsPath();
+
+  // 1. Binary present?
+  if (!geminiPath) {
+    return { available: false, reason: 'gemini-not-installed' };
+  }
+
+  // 2. Authed via the CLI's cached OAuth?
+  if (!geminiOauthCredsAuthed(credsPath)) {
+    return { available: false, reason: 'gemini-not-authed' };
+  }
+
+  return {
+    available: true,
+    framework: 'gemini-cli',
+    model: resolveGeminiModelFlag(REVIEW_MODEL_TIER),
+  };
+}
+
 // ── Supported-reviewer registry (the extension point) ───────────────────
 
 export interface ReviewerResult {
@@ -273,6 +373,31 @@ export interface ReviewerInvokeArgs {
    * happens. Production passes nothing and the factory builds the real one.
    */
   providerOverride?: { evaluate(prompt: string, options?: { model?: 'fast' | 'balanced' | 'capable'; timeoutMs?: number }): Promise<string> };
+  /**
+   * Optional detection override — `runCrossModelReview` passes the detection
+   * it already computed (so review never re-probes the host), and tests inject
+   * synthetic detections (e.g. a tier-word model to exercise the canary).
+   * Absent → the entry runs its own real-host detect, as before (back-compat).
+   */
+  detectionOverride?: CrossModelDetectionResult;
+}
+
+/**
+ * Fail-loud model canary (Piece 3). A cross-model review must run on a
+ * CONCRETE model id — never a bare tier word that fell through a
+ * tier→model resolution map (the `resolveModelForFramework` fall-through
+ * failure class: the literal string 'capable' is not a model, and silently
+ * passing it selects a dead reviewer). Returns false for undefined/empty
+ * strings and for bare tier words (case-insensitive). Both registry entries
+ * check this BEFORE invoking the provider and degrade LOUDLY
+ * (`model-resolution-canary`) on a failure.
+ */
+export function isConcreteReviewerModel(model: string | undefined): boolean {
+  if (typeof model !== 'string') return false;
+  const trimmed = model.trim();
+  if (trimmed.length === 0) return false;
+  const TIER_WORDS = new Set(['fast', 'balanced', 'capable', 'haiku', 'sonnet', 'opus']);
+  return !TIER_WORDS.has(trimmed.toLowerCase());
 }
 
 /**
@@ -283,9 +408,21 @@ const codexReviewer: SupportedReviewerFramework = {
   id: 'codex-cli',
   detect: (inputs) => detectCodexReviewer(inputs),
   review: async (args) => {
-    const detection = detectCodexReviewer();
+    const detection = args.detectionOverride ?? detectCodexReviewer();
     const model = detection.model ?? resolveCliModelFlag(REVIEW_MODEL_TIER);
     const tag = `cross-model:codex-cli:${model}`;
+
+    // Fail-loud model canary (Piece 3): NEVER silently review with a
+    // tier-word model — a fall-through 'capable' is a dead reviewer.
+    if (!isConcreteReviewerModel(model)) {
+      return {
+        status: 'degraded',
+        framework: 'codex-cli',
+        model,
+        reason: 'model-resolution-canary',
+        flag: `cross-model-review: codex-cli:${model} (degraded: model-resolution-canary)`,
+      };
+    }
 
     // Build (or accept an injected) provider. The factory wraps it in the
     // account-global circuit breaker, so a rate-limited review degrades the
@@ -337,16 +474,115 @@ const codexReviewer: SupportedReviewerFramework = {
 };
 
 /**
- * The supported-reviewer registry. codex first — the order IS the preference
- * order. gemini-cli and others land here as later steps (Out of Scope).
+ * The gemini reviewer entry (Piece 3 — family diversity: a second non-Claude
+ * model family alongside GPT). Detection delegates to `detectGeminiReviewer`;
+ * `review` routes through the factory-built `GeminiCliIntelligenceProvider`
+ * (same circuit-breaker wrapping, same degraded semantics as codex).
  */
-export const SUPPORTED_REVIEWER_FRAMEWORKS: SupportedReviewerFramework[] = [codexReviewer];
+const geminiReviewer: SupportedReviewerFramework = {
+  id: 'gemini-cli',
+  detect: (inputs) => detectGeminiReviewer(inputs),
+  review: async (args) => {
+    const detection = args.detectionOverride ?? detectGeminiReviewer();
+    const model = detection.model ?? resolveGeminiModelFlag(REVIEW_MODEL_TIER);
+    const tag = `cross-model:gemini-cli:${model}`;
+
+    // Fail-loud model canary (Piece 3): NEVER silently review with a
+    // tier-word model — a fall-through 'capable' is a dead reviewer.
+    if (!isConcreteReviewerModel(model)) {
+      return {
+        status: 'degraded',
+        framework: 'gemini-cli',
+        model,
+        reason: 'model-resolution-canary',
+        flag: `cross-model-review: gemini-cli:${model} (degraded: model-resolution-canary)`,
+      };
+    }
+
+    // Build (or accept an injected) provider. The factory wraps it in the
+    // account-global circuit breaker, so a rate-limited review degrades the
+    // same way every other instar LLM call does.
+    const provider =
+      args.providerOverride ??
+      buildIntelligenceProvider({ framework: 'gemini-cli' });
+
+    if (!provider) {
+      // Binary vanished between detect and review (or detection said
+      // unavailable and review was called anyway). Degraded, not a throw.
+      return {
+        status: 'degraded',
+        framework: 'gemini-cli',
+        model,
+        reason: 'provider-unavailable',
+        flag: `cross-model-review: gemini-cli:${model} (degraded: provider-unavailable)`,
+      };
+    }
+
+    let raw: string;
+    try {
+      raw = await provider.evaluate(args.promptText, {
+        model: REVIEW_MODEL_TIER,
+        timeoutMs: args.timeoutMs,
+        attribution: { component: 'crossModelReviewer' }, // attribution for /metrics/features
+      });
+    } catch (err) {
+      const reason = classifyReviewFailure(err);
+      return {
+        status: 'degraded',
+        framework: 'gemini-cli',
+        model,
+        reason,
+        flag: `cross-model-review: gemini-cli:${model} (degraded: ${reason})`,
+      };
+    }
+
+    const parsed = parseReviewerReply(raw, tag);
+    return {
+      status: 'ok',
+      framework: 'gemini-cli',
+      model,
+      verdict: parsed.verdict,
+      findings: [parsed],
+      flag: `cross-model-review: gemini-cli:${model}`,
+    };
+  },
+};
+
+/**
+ * The supported-reviewer registry. codex first — the order IS the preference
+ * order. gemini second (Piece 3). Further frameworks land here as later
+ * registry entries. NOTE: the registry only ever carries first-party OAuth
+ * CLI adapters — see `TRUSTED_REVIEWER_FRAMEWORKS` below.
+ */
+export const SUPPORTED_REVIEWER_FRAMEWORKS: SupportedReviewerFramework[] = [
+  codexReviewer,
+  geminiReviewer,
+];
+
+/**
+ * Trusted-provider allowlist (Piece 3 — no spec egress to untrusted
+ * endpoints). The registry only ever carries FIRST-PARTY OAuth CLI adapters:
+ * the full spec text is handed to the reviewer model, so it must NEVER be
+ * sent to a custom/base-URL endpoint an operator (or attacker) pointed a
+ * framework at. The pi-cli multi-provider case is deliberately EXCLUDED from
+ * cross-model review for exactly this reason — its provider may be a custom
+ * endpoint. A framework id outside this list is refused by the script
+ * wrapper (`--family`) with reason `untrusted-framework`.
+ */
+export const TRUSTED_REVIEWER_FRAMEWORKS: readonly string[] = ['codex-cli', 'gemini-cli'];
+
+/** Is `id` on the trusted first-party reviewer allowlist? */
+export function isTrustedReviewerFramework(id: string): boolean {
+  return TRUSTED_REVIEWER_FRAMEWORKS.includes(id);
+}
 
 /**
  * Walk the registry in preference order and return the FIRST available
- * framework's detection result. If none is available, returns the codex
- * reason when there's exactly one entry (so the report can be specific), else
- * the generic `no-supported-framework`.
+ * framework's detection result (back-compat single-reviewer entry point —
+ * the multi-family collection is `detectAllCrossModelReviewers`). If none is
+ * available, returns the preference-leader's specific reason (codex today) so
+ * the report can render a concrete remediation, rather than the generic
+ * `no-supported-framework`.
  *
  * SIGNAL-ONLY: never throws, never blocks. A `false` simply routes the skill
  * to the internal-only fallback (spec §4).
@@ -358,12 +594,29 @@ export function detectCrossModelReviewer(
     const result = framework.detect(inputs);
     if (result.available) return result;
   }
-  // Nothing available. Surface the single framework's specific reason when
-  // there's only one entry (codex today); otherwise the generic reason.
-  if (SUPPORTED_REVIEWER_FRAMEWORKS.length === 1) {
-    return SUPPORTED_REVIEWER_FRAMEWORKS[0].detect(inputs);
-  }
+  // Nothing available. Surface the preference-leader's specific reason.
+  const leader = SUPPORTED_REVIEWER_FRAMEWORKS[0];
+  if (leader) return leader.detect(inputs);
   return { available: false, reason: 'no-supported-framework' };
+}
+
+/**
+ * Collect EVERY available reviewer framework, in registry preference order
+ * (Piece 3 — family diversity: GPT and Gemini catch different failure
+ * classes, so the externals pass runs one review PER available family, not
+ * first-match-only). Returns an empty array when none is available.
+ *
+ * SIGNAL-ONLY: never throws, never blocks.
+ */
+export function detectAllCrossModelReviewers(
+  inputs: CrossModelDetectInputs = {},
+): CrossModelDetectionResult[] {
+  const available: CrossModelDetectionResult[] = [];
+  for (const framework of SUPPORTED_REVIEWER_FRAMEWORKS) {
+    const result = framework.detect(inputs);
+    if (result.available) available.push(result);
+  }
+  return available;
 }
 
 // ── Failure classification ──────────────────────────────────────────────
@@ -708,6 +961,138 @@ export async function runCrossModelReview(args: {
   return framework.review({
     promptText: args.assembled.promptText,
     timeoutMs: args.timeoutMs ?? REVIEW_TIMEOUT_MS,
+    // Hand the already-computed detection down so the entry never re-probes
+    // the host (and tests stay hermetic to the injected inputs).
+    detectionOverride: detection,
     ...(args.providerOverride ? { providerOverride: args.providerOverride } : {}),
   });
+}
+
+// ── Delta-gating (reviewable-body hash) ─────────────────────────────────
+
+/**
+ * Hash the spec's REVIEWABLE body (Piece 3 delta-gating): sha256 hex of the
+ * spec text with the leading YAML frontmatter block stripped and line endings
+ * normalized (\r\n → \n). Frontmatter is excluded so tag-writes
+ * (`review-convergence`, `approved: true`, cross-model flags) and other
+ * metadata edits do NOT change the hash — externals re-run only when the
+ * content a reviewer would actually read changed. The skill runs externals on
+ * round 1 and on any round where this hash differs from the last external
+ * pass's hash; an unchanged round records a skip-with-logged-note.
+ */
+export function hashSpecReviewableBody(specText: string): string {
+  const normalized = (specText ?? '').replace(/\r\n/g, '\n');
+  // Strip ONE leading frontmatter block: `---\n ... \n---` at the very top,
+  // where the close fence is a WHOLE line (anchored `(\n|$)`) — `\n---\n?`
+  // could terminate mid-line on `--- text` / `----` inside the block
+  // (second-pass finding, PR 3).
+  const body = normalized.replace(/^---\n[\s\S]*?\n---(\n|$)/, '');
+  return crypto.createHash('sha256').update(body, 'utf-8').digest('hex');
+}
+
+// ── Durable framework-activation history ────────────────────────────────
+
+/**
+ * One recorded observation of which reviewer frameworks were available at a
+ * moment in time. Appended (JSONL) to
+ * `<stateDir>/state/framework-activation-history.jsonl` by the script
+ * wrapper's `--detect-only --state-dir` path on every detection.
+ */
+export interface FrameworkActivationObservation {
+  /** ISO timestamp; defaults to now. */
+  ts?: string;
+  /** framework id → was it available/active at observation time. */
+  frameworks: Record<string, boolean>;
+}
+
+/** Max JSONL lines retained in the activation-history file. */
+const ACTIVATION_HISTORY_MAX_LINES = 2000;
+
+function activationHistoryPath(stateDir: string): string {
+  return path.join(stateDir, 'state', 'framework-activation-history.jsonl');
+}
+
+/**
+ * Append ONE observation line to the durable framework-activation history
+ * (Piece 3 — the standing-framework baseline). The externals-mandatory check
+ * is judged against this recorded history over a lookback window, NOT a
+ * just-in-time reading — so deactivating a framework right before converging
+ * cannot present the agent as "genuinely single-framework."
+ *
+ * mkdir -p's the state dir; caps the file at the most recent
+ * `ACTIVATION_HISTORY_MAX_LINES` lines on every write. Filesystem errors
+ * propagate — a silently-unrecorded baseline would quietly weaken the
+ * mandatory check (fail-loud).
+ */
+export function recordFrameworkActivationObservation(
+  stateDir: string,
+  observation: FrameworkActivationObservation,
+): void {
+  const file = activationHistoryPath(stateDir);
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  const entry = JSON.stringify({
+    ts: observation.ts ?? new Date().toISOString(),
+    frameworks: observation.frameworks,
+  });
+  let lines: string[] = [];
+  try {
+    lines = fs.readFileSync(file, 'utf-8').split('\n').filter((l) => l.trim().length > 0);
+  } catch {
+    // No file yet — first observation.
+  }
+  lines.push(entry);
+  if (lines.length > ACTIVATION_HISTORY_MAX_LINES) {
+    lines = lines.slice(-ACTIVATION_HISTORY_MAX_LINES);
+  }
+  fs.writeFileSync(file, lines.join('\n') + '\n', 'utf-8');
+}
+
+/**
+ * Was ANY non-Claude reviewer framework active at ANY point within the
+ * lookback window, per the durable activation history? This is the
+ * externals-mandatory check (Piece 3): `true` means the cross-model pass is
+ * NON-SKIPPABLE for the spec — including when a framework was deactivated
+ * inside the window (a just-before-converge deactivation does not exempt the
+ * spec). The advisory "externals unavailable" floor is legitimate only when
+ * this returns `false` across the whole lookback.
+ *
+ * NEVER throws: a missing file → false; corrupt lines are skipped.
+ */
+export function wasNonClaudeFrameworkActiveWithin(
+  stateDir: string,
+  lookbackDays: number,
+  now?: Date,
+): boolean {
+  try {
+    const file = activationHistoryPath(stateDir);
+    const raw = fs.readFileSync(file, 'utf-8');
+    const cutoff = (now ?? new Date()).getTime() - lookbackDays * 24 * 60 * 60 * 1000;
+    for (const line of raw.split('\n')) {
+      if (!line.trim()) continue;
+      try {
+        const parsed = JSON.parse(line) as { ts?: unknown; frameworks?: unknown };
+        const ts = typeof parsed.ts === 'string' ? Date.parse(parsed.ts) : NaN;
+        if (!Number.isFinite(ts) || ts < cutoff) continue;
+        const frameworks = parsed.frameworks;
+        if (frameworks && typeof frameworks === 'object') {
+          // Only TRUSTED reviewer framework ids count toward the baseline — a
+          // stray/hand-written key (e.g. "claude-code": true) must not flip
+          // the externals-mandatory decision (second-pass finding, PR 3).
+          const entries = Object.entries(frameworks as Record<string, unknown>);
+          if (entries.some(([id, v]) => v === true && isTrustedReviewerFramework(id))) {
+            return true;
+          }
+        }
+      } catch {
+        // @silent-fallback-ok — a corrupt history line is skipped (never throws);
+        // the read is a union-over-time, so a lost line can only UNDER-report
+        // activation, which keeps externals mandatory-safe, never lies them off.
+      }
+    }
+    return false;
+  } catch {
+    // @silent-fallback-ok — a missing/unreadable history file is the expected
+    // pre-first-run state: no recorded activation is the correct answer.
+    return false;
+  }
 }

--- a/tests/integration/cross-model-review-flow.test.ts
+++ b/tests/integration/cross-model-review-flow.test.ts
@@ -159,13 +159,17 @@ describe('cross-model review flow — codex PRESENT', () => {
 
 describe('cross-model review flow — codex ABSENT', () => {
   it('returns unavailable, completes internal-only, banner reads UNAVAILABLE, spec STILL taggable (never blocks)', async () => {
-    const detection = detectCrossModelReviewer({ codexPathDetected: null, env: {} });
+    const detection = detectCrossModelReviewer({
+      codexPathDetected: null,
+      geminiPathDetected: null,
+      env: {},
+    });
     expect(detection.available).toBe(false);
     expect(detection.reason).toBe('codex-not-installed');
 
     const result = await runCrossModelReview({
       assembled: { promptText: 'unused', truncated: false, bytes: 6 },
-      detectInputs: { codexPathDetected: null, env: {} },
+      detectInputs: { codexPathDetected: null, geminiPathDetected: null, env: {} },
     });
     expect(result.status).toBe('unavailable');
     expect(result.flag).toBe('cross-model-review: unavailable');

--- a/tests/unit/crossModelReviewer-piece3.test.ts
+++ b/tests/unit/crossModelReviewer-piece3.test.ts
@@ -1,0 +1,445 @@
+/**
+ * Unit tests for the Piece 3 cross-model convergence hardening
+ * (docs/specs/AUTONOMY-PRINCIPLES-ENFORCEMENT-SPEC.md — Piece 3) additions to
+ * crossModelReviewer:
+ *
+ *   - detectGeminiReviewer: not-installed / not-authed (missing file,
+ *     malformed JSON, empty tokens) / available — and that available returns
+ *     a CONCRETE model (the canary contract).
+ *   - detectAllCrossModelReviewers: both / one / none → 2 / 1 / 0 entries.
+ *   - isConcreteReviewerModel (the fail-loud model canary): rejects tier
+ *     words + undefined/empty, accepts concrete ids.
+ *   - hashSpecReviewableBody (delta-gating): frontmatter-insensitive,
+ *     body-sensitive, CRLF-insensitive.
+ *   - Durable activation history: write+read roundtrip, lookback window
+ *     semantics, corrupt-line skipping, the 2000-line cap.
+ *   - TRUSTED_REVIEWER_FRAMEWORKS allowlist: codex/gemini trusted, pi-cli +
+ *     arbitrary ids not.
+ *   - geminiReviewer.review: ok path (stub provider), degraded path via a
+ *     throwing providerOverride (classifyReviewFailure mapping), and the
+ *     canary-degraded path via an injected detection carrying a tier-word
+ *     model.
+ *
+ * NO real spawns — detection uses injected inputs, invocation uses a stubbed
+ * provider override + an injected detectionOverride (so the registry entry
+ * never re-probes the host).
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+import {
+  detectGeminiReviewer,
+  detectAllCrossModelReviewers,
+  isConcreteReviewerModel,
+  hashSpecReviewableBody,
+  recordFrameworkActivationObservation,
+  wasNonClaudeFrameworkActiveWithin,
+  TRUSTED_REVIEWER_FRAMEWORKS,
+  isTrustedReviewerFramework,
+  SUPPORTED_REVIEWER_FRAMEWORKS,
+} from '../../src/core/crossModelReviewer.js';
+
+// ── helpers ──────────────────────────────────────────────────────────────
+
+let tmpDir: string;
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'crossmodel-piece3-'));
+});
+
+afterEach(() => {
+  SafeFsExecutor.safeRmSync(tmpDir, {
+    recursive: true,
+    force: true,
+    operation: 'tests/unit/crossModelReviewer-piece3.test.ts tmpdir cleanup',
+  });
+});
+
+function writeGeminiCreds(json: unknown): string {
+  const p = path.join(tmpDir, 'oauth_creds.json');
+  fs.writeFileSync(p, typeof json === 'string' ? json : JSON.stringify(json), 'utf-8');
+  return p;
+}
+
+function writeCodexAuth(): string {
+  const p = path.join(tmpDir, 'auth.json');
+  fs.writeFileSync(p, JSON.stringify({ tokens: { access_token: 'oauth-token' } }), 'utf-8');
+  return p;
+}
+
+const geminiEntry = SUPPORTED_REVIEWER_FRAMEWORKS.find((f) => f.id === 'gemini-cli')!;
+
+function stubProvider(reply: string) {
+  return { evaluate: async () => reply };
+}
+function throwingProvider(err: Error) {
+  return {
+    evaluate: async () => {
+      throw err;
+    },
+  };
+}
+
+// ── detectGeminiReviewer ─────────────────────────────────────────────────
+
+describe('detectGeminiReviewer', () => {
+  it('returns gemini-not-installed when the binary is missing', () => {
+    const r = detectGeminiReviewer({ geminiPathDetected: null, env: {} });
+    expect(r).toEqual({ available: false, reason: 'gemini-not-installed' });
+  });
+
+  it('returns gemini-not-authed when oauth_creds.json is missing', () => {
+    const r = detectGeminiReviewer({
+      geminiPathDetected: '/usr/bin/gemini',
+      geminiOauthCredsPath: path.join(tmpDir, 'does-not-exist.json'),
+      env: {},
+    });
+    expect(r).toEqual({ available: false, reason: 'gemini-not-authed' });
+  });
+
+  it('returns gemini-not-authed when oauth_creds.json is malformed JSON', () => {
+    const credsPath = writeGeminiCreds('{ this is not json');
+    const r = detectGeminiReviewer({
+      geminiPathDetected: '/usr/bin/gemini',
+      geminiOauthCredsPath: credsPath,
+      env: {},
+    });
+    expect(r).toEqual({ available: false, reason: 'gemini-not-authed' });
+  });
+
+  it('returns gemini-not-authed when both tokens are empty/absent', () => {
+    const credsPath = writeGeminiCreds({ access_token: '', refresh_token: '' });
+    const r = detectGeminiReviewer({
+      geminiPathDetected: '/usr/bin/gemini',
+      geminiOauthCredsPath: credsPath,
+      env: {},
+    });
+    expect(r).toEqual({ available: false, reason: 'gemini-not-authed' });
+
+    const credsPath2 = writeGeminiCreds({ scope: 'openid' });
+    const r2 = detectGeminiReviewer({
+      geminiPathDetected: '/usr/bin/gemini',
+      geminiOauthCredsPath: credsPath2,
+      env: {},
+    });
+    expect(r2).toEqual({ available: false, reason: 'gemini-not-authed' });
+  });
+
+  it('returns available with a CONCRETE model when binary + access_token are present', () => {
+    const credsPath = writeGeminiCreds({ access_token: 'ya29.gemini-access-token' });
+    const r = detectGeminiReviewer({
+      geminiPathDetected: '/usr/bin/gemini',
+      geminiOauthCredsPath: credsPath,
+      env: {},
+    });
+    expect(r.available).toBe(true);
+    expect(r.framework).toBe('gemini-cli');
+    // capable tier → gemini-2.5-pro per gemini-cli/models.ts.
+    expect(r.model).toBe('gemini-2.5-pro');
+    // The canary contract: detection NEVER emits a bare tier word.
+    expect(isConcreteReviewerModel(r.model)).toBe(true);
+  });
+
+  it('accepts a refresh_token-only credential (the CLI refreshes from it)', () => {
+    const credsPath = writeGeminiCreds({ refresh_token: '1//gemini-refresh-token' });
+    const r = detectGeminiReviewer({
+      geminiPathDetected: '/usr/bin/gemini',
+      geminiOauthCredsPath: credsPath,
+      env: {},
+    });
+    expect(r.available).toBe(true);
+    expect(r.framework).toBe('gemini-cli');
+  });
+
+  it('never throws on any input', () => {
+    expect(() => detectGeminiReviewer({ geminiPathDetected: undefined as unknown as null, env: {} })).not.toThrow();
+    expect(() => detectGeminiReviewer({ geminiPathDetected: null })).not.toThrow();
+  });
+});
+
+// ── detectAllCrossModelReviewers ─────────────────────────────────────────
+
+describe('detectAllCrossModelReviewers (family-diverse collection)', () => {
+  it('returns BOTH frameworks when codex and gemini are both available', () => {
+    const authPath = writeCodexAuth();
+    const credsPath = writeGeminiCreds({ access_token: 'ya29.token' });
+    const all = detectAllCrossModelReviewers({
+      codexPathDetected: '/usr/bin/codex',
+      authJsonPath: authPath,
+      geminiPathDetected: '/usr/bin/gemini',
+      geminiOauthCredsPath: credsPath,
+      env: {},
+    });
+    expect(all).toHaveLength(2);
+    expect(all.map((d) => d.framework)).toEqual(['codex-cli', 'gemini-cli']);
+    expect(all.every((d) => d.available)).toBe(true);
+  });
+
+  it('returns ONE entry when only one framework is available', () => {
+    const credsPath = writeGeminiCreds({ access_token: 'ya29.token' });
+    const all = detectAllCrossModelReviewers({
+      codexPathDetected: null,
+      geminiPathDetected: '/usr/bin/gemini',
+      geminiOauthCredsPath: credsPath,
+      env: {},
+    });
+    expect(all).toHaveLength(1);
+    expect(all[0].framework).toBe('gemini-cli');
+  });
+
+  it('returns an EMPTY array when none is available (never throws)', () => {
+    const all = detectAllCrossModelReviewers({
+      codexPathDetected: null,
+      geminiPathDetected: null,
+      env: {},
+    });
+    expect(all).toEqual([]);
+  });
+});
+
+// ── isConcreteReviewerModel (the fail-loud canary) ───────────────────────
+
+describe('isConcreteReviewerModel (fail-loud model canary)', () => {
+  it('rejects undefined and empty/blank strings', () => {
+    expect(isConcreteReviewerModel(undefined)).toBe(false);
+    expect(isConcreteReviewerModel('')).toBe(false);
+    expect(isConcreteReviewerModel('   ')).toBe(false);
+  });
+
+  it('rejects bare tier words, case-insensitively', () => {
+    for (const tier of ['fast', 'balanced', 'capable', 'haiku', 'sonnet', 'opus']) {
+      expect(isConcreteReviewerModel(tier)).toBe(false);
+      expect(isConcreteReviewerModel(tier.toUpperCase())).toBe(false);
+    }
+    expect(isConcreteReviewerModel('Capable')).toBe(false);
+  });
+
+  it('accepts concrete model ids', () => {
+    expect(isConcreteReviewerModel('gpt-5.5')).toBe(true);
+    expect(isConcreteReviewerModel('gemini-2.5-pro')).toBe(true);
+  });
+});
+
+// ── hashSpecReviewableBody (delta-gating) ────────────────────────────────
+
+describe('hashSpecReviewableBody (delta-gating hash)', () => {
+  const body = '# Spec\n\n## Problem statement\nThe body under review.\n';
+
+  it('is STABLE when only the frontmatter changes (tag-writes do not retrigger externals)', () => {
+    const before = `---\ntitle: "X"\n---\n${body}`;
+    const after = `---\ntitle: "X"\nreview-convergence: "2026-06-10T00:00:00Z"\napproved: true\n---\n${body}`;
+    expect(hashSpecReviewableBody(before)).toBe(hashSpecReviewableBody(after));
+  });
+
+  it('CHANGES when the reviewable body changes', () => {
+    const a = `---\ntitle: "X"\n---\n${body}`;
+    const b = `---\ntitle: "X"\n---\n${body}\n## New section\nNew design content.\n`;
+    expect(hashSpecReviewableBody(a)).not.toBe(hashSpecReviewableBody(b));
+  });
+
+  it('is CRLF-insensitive (\\r\\n and \\n bodies hash identically)', () => {
+    const lf = `---\ntitle: "X"\n---\n${body}`;
+    const crlf = lf.replace(/\n/g, '\r\n');
+    expect(hashSpecReviewableBody(lf)).toBe(hashSpecReviewableBody(crlf));
+  });
+
+  it('hashes a spec with no frontmatter as-is (no accidental stripping)', () => {
+    expect(hashSpecReviewableBody(body)).toBe(hashSpecReviewableBody(body));
+    // A body that merely CONTAINS a later `---` rule is not frontmatter-stripped
+    // differently from itself.
+    const withRule = `${body}\n---\n\nMore text.\n`;
+    expect(hashSpecReviewableBody(withRule)).not.toBe(hashSpecReviewableBody(body));
+  });
+});
+
+// ── Durable activation history ───────────────────────────────────────────
+
+describe('framework activation history (durable standing-framework baseline)', () => {
+  const historyFile = () => path.join(tmpDir, 'state', 'framework-activation-history.jsonl');
+
+  it('write+read roundtrip: a recorded non-Claude activation is found within the lookback', () => {
+    recordFrameworkActivationObservation(tmpDir, {
+      frameworks: { 'codex-cli': false, 'gemini-cli': true },
+    });
+    expect(fs.existsSync(historyFile())).toBe(true);
+    expect(wasNonClaudeFrameworkActiveWithin(tmpDir, 7)).toBe(true);
+  });
+
+  it('returns false when all recorded observations show no active framework', () => {
+    recordFrameworkActivationObservation(tmpDir, {
+      frameworks: { 'codex-cli': false, 'gemini-cli': false },
+    });
+    expect(wasNonClaudeFrameworkActiveWithin(tmpDir, 7)).toBe(false);
+  });
+
+  it('lookback window: an activation INSIDE the window counts, one OUTSIDE does not', () => {
+    const now = new Date('2026-06-10T12:00:00Z');
+    const tenDaysAgo = new Date(now.getTime() - 10 * 24 * 60 * 60 * 1000).toISOString();
+    const twoDaysAgo = new Date(now.getTime() - 2 * 24 * 60 * 60 * 1000).toISOString();
+
+    recordFrameworkActivationObservation(tmpDir, {
+      ts: tenDaysAgo,
+      frameworks: { 'gemini-cli': true },
+    });
+    // 7-day lookback misses the 10-day-old activation.
+    expect(wasNonClaudeFrameworkActiveWithin(tmpDir, 7, now)).toBe(false);
+    // A wider lookback finds it.
+    expect(wasNonClaudeFrameworkActiveWithin(tmpDir, 14, now)).toBe(true);
+
+    // A deactivation INSIDE the window does not erase the earlier in-window
+    // activation: record active 2 days ago, then inactive now.
+    recordFrameworkActivationObservation(tmpDir, {
+      ts: twoDaysAgo,
+      frameworks: { 'gemini-cli': true },
+    });
+    recordFrameworkActivationObservation(tmpDir, {
+      ts: now.toISOString(),
+      frameworks: { 'gemini-cli': false },
+    });
+    expect(wasNonClaudeFrameworkActiveWithin(tmpDir, 7, now)).toBe(true);
+  });
+
+  it('returns false (never throws) when no history file exists', () => {
+    expect(wasNonClaudeFrameworkActiveWithin(tmpDir, 7)).toBe(false);
+  });
+
+  it('skips corrupt lines without throwing', () => {
+    recordFrameworkActivationObservation(tmpDir, { frameworks: { 'codex-cli': true } });
+    fs.appendFileSync(historyFile(), 'this is { not json\n', 'utf-8');
+    recordFrameworkActivationObservation(tmpDir, { frameworks: { 'gemini-cli': false } });
+    expect(() => wasNonClaudeFrameworkActiveWithin(tmpDir, 7)).not.toThrow();
+    expect(wasNonClaudeFrameworkActiveWithin(tmpDir, 7)).toBe(true);
+  });
+
+  it('caps the file at the most recent 2000 lines on write', () => {
+    // Seed well past the cap, then verify the file holds exactly 2000 lines
+    // and that the OLDEST lines were dropped (most-recent retained).
+    for (let i = 0; i < 2005; i++) {
+      recordFrameworkActivationObservation(tmpDir, {
+        ts: new Date(Date.UTC(2026, 0, 1, 0, 0, i % 60, i)).toISOString(),
+        frameworks: { seq: false, [`marker-${i}`]: false },
+      });
+    }
+    const lines = fs
+      .readFileSync(historyFile(), 'utf-8')
+      .split('\n')
+      .filter((l) => l.trim().length > 0);
+    expect(lines).toHaveLength(2000);
+    expect(lines[0]).toContain('marker-5'); // 0..4 dropped
+    expect(lines[lines.length - 1]).toContain('marker-2004');
+  });
+});
+
+// ── Trusted-provider allowlist ───────────────────────────────────────────
+
+describe('TRUSTED_REVIEWER_FRAMEWORKS (no spec egress to untrusted endpoints)', () => {
+  it('trusts exactly the first-party OAuth CLI adapters', () => {
+    expect(TRUSTED_REVIEWER_FRAMEWORKS).toEqual(['codex-cli', 'gemini-cli']);
+    expect(isTrustedReviewerFramework('codex-cli')).toBe(true);
+    expect(isTrustedReviewerFramework('gemini-cli')).toBe(true);
+  });
+
+  it('excludes pi-cli (multi-provider — may be a custom endpoint) and arbitrary ids', () => {
+    expect(isTrustedReviewerFramework('pi-cli')).toBe(false);
+    expect(isTrustedReviewerFramework('evil-proxy')).toBe(false);
+    expect(isTrustedReviewerFramework('')).toBe(false);
+  });
+
+  it('every registry entry is on the allowlist (registry carries first-party adapters only)', () => {
+    for (const entry of SUPPORTED_REVIEWER_FRAMEWORKS) {
+      expect(isTrustedReviewerFramework(entry.id)).toBe(true);
+    }
+  });
+});
+
+// ── geminiReviewer registry entry ────────────────────────────────────────
+
+describe('geminiReviewer registry entry', () => {
+  it('is the second registry entry (codex stays the preference leader)', () => {
+    expect(SUPPORTED_REVIEWER_FRAMEWORKS.map((f) => f.id)).toEqual(['codex-cli', 'gemini-cli']);
+  });
+
+  it('ok: stub provider returns a structured review → status ok, gemini flag', async () => {
+    const r = await geminiEntry.review({
+      promptText: 'PROMPT',
+      timeoutMs: 1000,
+      detectionOverride: { available: true, framework: 'gemini-cli', model: 'gemini-2.5-pro' },
+      providerOverride: stubProvider('Verdict: MINOR ISSUES\n- §2 tighten the auth probe.'),
+    });
+    expect(r.status).toBe('ok');
+    expect(r.framework).toBe('gemini-cli');
+    expect(r.model).toBe('gemini-2.5-pro');
+    expect(r.verdict).toBe('MINOR ISSUES');
+    expect(r.findings).toHaveLength(1);
+    expect(r.findings![0].reviewer).toBe('cross-model:gemini-cli:gemini-2.5-pro');
+    expect(r.flag).toBe('cross-model-review: gemini-cli:gemini-2.5-pro');
+  });
+
+  it('degraded: provider throws → classifyReviewFailure mapping, gemini degraded flag', async () => {
+    const r = await geminiEntry.review({
+      promptText: 'PROMPT',
+      timeoutMs: 1000,
+      detectionOverride: { available: true, framework: 'gemini-cli', model: 'gemini-2.5-pro' },
+      providerOverride: throwingProvider(new Error('Command timed out after 120000ms')),
+    });
+    expect(r.status).toBe('degraded');
+    expect(r.reason).toBe('timeout');
+    expect(r.flag).toBe('cross-model-review: gemini-cli:gemini-2.5-pro (degraded: timeout)');
+  });
+
+  it('degraded: rate-limit error classifies as rate-limited', async () => {
+    const r = await geminiEntry.review({
+      promptText: 'PROMPT',
+      timeoutMs: 1000,
+      detectionOverride: { available: true, framework: 'gemini-cli', model: 'gemini-2.5-pro' },
+      providerOverride: throwingProvider(new Error('429 Too Many Requests')),
+    });
+    expect(r.status).toBe('degraded');
+    expect(r.reason).toBe('rate-limited');
+  });
+
+  it('CANARY: a tier-word model degrades loudly BEFORE the provider is ever invoked', async () => {
+    let providerInvoked = false;
+    const spyProvider = {
+      evaluate: async () => {
+        providerInvoked = true;
+        return 'Verdict: CLEAN';
+      },
+    };
+    const r = await geminiEntry.review({
+      promptText: 'PROMPT',
+      timeoutMs: 1000,
+      // A detection whose model resolution fell through to the bare tier word.
+      detectionOverride: { available: true, framework: 'gemini-cli', model: 'capable' },
+      providerOverride: spyProvider,
+    });
+    expect(r.status).toBe('degraded');
+    expect(r.reason).toBe('model-resolution-canary');
+    expect(r.flag).toBe('cross-model-review: gemini-cli:capable (degraded: model-resolution-canary)');
+    // NEVER silently review with a tier-word model.
+    expect(providerInvoked).toBe(false);
+  });
+
+  it('CANARY: the codex entry enforces the same check', async () => {
+    const codexEntry = SUPPORTED_REVIEWER_FRAMEWORKS.find((f) => f.id === 'codex-cli')!;
+    let providerInvoked = false;
+    const spyProvider = {
+      evaluate: async () => {
+        providerInvoked = true;
+        return 'Verdict: CLEAN';
+      },
+    };
+    const r = await codexEntry.review({
+      promptText: 'PROMPT',
+      timeoutMs: 1000,
+      detectionOverride: { available: true, framework: 'codex-cli', model: 'capable' },
+      providerOverride: spyProvider,
+    });
+    expect(r.status).toBe('degraded');
+    expect(r.reason).toBe('model-resolution-canary');
+    expect(providerInvoked).toBe(false);
+  });
+});

--- a/tests/unit/crossModelReviewer.test.ts
+++ b/tests/unit/crossModelReviewer.test.ts
@@ -148,7 +148,7 @@ describe('detectCodexReviewer', () => {
 // ── Registry walk ────────────────────────────────────────────────────────
 
 describe('detectCrossModelReviewer (registry walk)', () => {
-  it('has codex as the first (and currently only) registry entry', () => {
+  it('has codex as the first registry entry (the order IS the preference order)', () => {
     expect(SUPPORTED_REVIEWER_FRAMEWORKS.length).toBeGreaterThanOrEqual(1);
     expect(SUPPORTED_REVIEWER_FRAMEWORKS[0].id).toBe('codex-cli');
   });
@@ -159,15 +159,20 @@ describe('detectCrossModelReviewer (registry walk)', () => {
       codexPathDetected: '/usr/bin/codex',
       authJsonPath: authPath,
       env: {},
+      geminiPathDetected: null,
     });
     expect(r.available).toBe(true);
     expect(r.framework).toBe('codex-cli');
   });
 
-  it('returns the specific codex reason when nothing is available (single-entry registry)', () => {
-    const r = detectCrossModelReviewer({ codexPathDetected: null, env: {} });
+  it('returns the specific preference-leader (codex) reason when nothing is available', () => {
+    const r = detectCrossModelReviewer({
+      codexPathDetected: null,
+      geminiPathDetected: null,
+      env: {},
+    });
     expect(r.available).toBe(false);
-    // single-entry registry surfaces codex's own reason, not a generic one.
+    // the preference-leader's own reason surfaces, not a generic one.
     expect(r.reason).toBe('codex-not-installed');
   });
 });
@@ -287,7 +292,7 @@ describe('runCrossModelReview — the three outcome states', () => {
   it('unavailable: no framework → status unavailable, never throws/blocks', async () => {
     const r = await runCrossModelReview({
       assembled,
-      detectInputs: { codexPathDetected: null, env: {} },
+      detectInputs: { codexPathDetected: null, geminiPathDetected: null, env: {} },
     });
     expect(r.status).toBe('unavailable');
     expect(r.flag).toBe('cross-model-review: unavailable');

--- a/upgrades/next/cross-model-hardening.md
+++ b/upgrades/next/cross-model-hardening.md
@@ -1,0 +1,36 @@
+# Upgrade Guide — Cross-Model Convergence Hardening (Piece 3)
+
+<!-- bump: minor -->
+
+## What Changed
+
+Implements Piece 3 (final piece) of `docs/specs/AUTONOMY-PRINCIPLES-ENFORCEMENT-SPEC.md`. The spec-converge skill's external (non-Claude) review pass becomes mandatory with teeth, dynamic, and safe:
+
+- **gemini-cli joins the reviewer registry** (`src/core/crossModelReviewer.ts`) — the registry seam's first extension beyond codex: never-throws detection (binary + cached OAuth at the path the CLI actually reads), provider via the existing factory with its own circuit breaker, identical degraded semantics.
+- **Family-diverse**: one external pass per AVAILABLE family (detect-all), not first-match-only.
+- **Delta-gated**: a content hash of the spec's reviewable body (frontmatter-stripped) decides when externals must re-run — round 1 and any changed round; unchanged rounds record a skip-with-logged-note instead of burning external quota.
+- **Durable activation baseline**: framework availability observations are recorded to `state/framework-activation-history.jsonl`; externals are non-skippable whenever a non-Claude framework was active within a 7-day lookback — deactivating a framework just before converging no longer exempts a spec.
+- **Trusted-provider allowlist**: only first-party OAuth CLIs (codex-cli, gemini-cli) can receive spec text; pi-cli/custom endpoints are structurally excluded (`untrusted-framework` refusal).
+- **Fail-loud model canary**: a review pass degrades loudly (`model-resolution-canary`) rather than silently running with an unresolved tier-word model.
+
+Honest scope notes: the spec's "broken `resolveModelForFramework` foundation" was already fixed on main before this build (recorded at PR #1055); the Claude-only-agent different-family floor + tracked-gap signal are disclosed residuals (see the side-effects artifact).
+
+## What to Tell Your User
+
+- "When I review a spec before building, I now get a second opinion from EVERY non-Claude AI family I have access to (GPT via codex, Gemini via the gemini CLI) — automatically, on every round where the spec actually changed. I can't quietly skip it anymore: a record of which frameworks I've had active in the last week keeps the outside-opinion requirement honest."
+- "Your spec text only ever goes to first-party AI providers you've logged into — never to custom or unknown endpoints."
+
+## Summary of New Capabilities
+
+| Capability | How to Use |
+|-----------|-----------|
+| Gemini external reviewer | Automatic in spec-converge when the gemini CLI is installed + authed |
+| Family-diverse external pass | Automatic — one pass per available family per changed round |
+| Delta-gated externals | Automatic — unchanged rounds log a skip note instead of re-reviewing |
+| 7-day activation baseline | Automatic — recorded on every detection; read at convergence |
+
+## Evidence
+
+- 32 new unit tests (`crossModelReviewer-piece3.test.ts`) + 45 existing (`crossModelReviewer.test.ts`) + 3 integration (`cross-model-review-flow.test.ts`) — all green; `tsc` exit 0; full lint clean.
+- Live smoke on the dev machine: detect-all reported codex-cli:gpt-5.5 AND gemini-cli:gemini-2.5-pro; `--family pi-cli` refused with `untrusted-framework`; the activation observation landed in the JSONL.
+- Independent second-pass review verified the egress allowlist end-to-end and caught a real bug (a `GEMINI_HOME` env var the CLI doesn't actually honor) — fixed before ship.

--- a/upgrades/side-effects/cross-model-hardening.md
+++ b/upgrades/side-effects/cross-model-hardening.md
@@ -1,0 +1,93 @@
+# Side-Effects Review — Cross-Model Convergence Hardening (Autonomy Principles Enforcement, Piece 3)
+
+**Version / slug:** `cross-model-hardening`
+**Date:** `2026-06-10`
+**Author:** `echo`
+**Second-pass reviewer:** `independent reviewer subagent (see appended verdict)`
+
+## Summary of the change
+
+Implements Piece 3 of `docs/specs/AUTONOMY-PRINCIPLES-ENFORCEMENT-SPEC.md`: cross-model convergence becomes **mandatory (with a durable activation baseline), dynamic (no pinning), family-diverse, delta-gated, allowlist-constrained, and fail-loud**. Honest scope note: the spec's headline "broken foundation" claim (`resolveModelForFramework` returning a dead tier string for gemini/pi) was **already fixed on main** before this build — recorded at PR #1055; this PR implements everything else.
+
+- **gemini-cli reviewer registry entry** (`src/core/crossModelReviewer.ts`) — the registry seam's first extension beyond codex: injectable never-throws detection (binary + cached OAuth creds), provider via the existing factory (own circuit breaker), identical degraded semantics.
+- **Family-diverse collection** — `detectAllCrossModelReviewers()` returns ALL available frameworks; the skill now runs one external pass per available family instead of first-match-only.
+- **Delta-gating** — `hashSpecReviewableBody()` (sha256, frontmatter-stripped, CRLF-normalized); externals are mandatory on round 1 + any round where the reviewable body changed; an unchanged round records a skip-with-logged-note (≠ skipped-abbreviated).
+- **Durable activation baseline** — `recordFrameworkActivationObservation()` / `wasNonClaudeFrameworkActiveWithin()` (JSONL at `state/framework-activation-history.jsonl`, 2000-line cap): externals are non-skippable whenever a non-Claude framework was active at any point in a 7-day lookback — a just-before-converge deactivation no longer exempts a spec (round-2 adversarial F-R2-3).
+- **Trusted-provider allowlist** — `TRUSTED_REVIEWER_FRAMEWORKS = ['codex-cli','gemini-cli']`; the registry constructively carries only first-party OAuth CLIs; `--family pi-cli` (or any unlisted id) is refused (`untrusted-framework`) so the full spec text is never sent to a custom/base-URL endpoint.
+- **Fail-loud canary** — `isConcreteReviewerModel()`: both entries degrade LOUDLY (`model-resolution-canary`) rather than silently reviewing with a bare tier word.
+
+Files: `src/core/crossModelReviewer.ts`, `skills/spec-converge/scripts/cross-model-review.mjs`, `skills/spec-converge/SKILL.md`, `tests/unit/crossModelReviewer-piece3.test.ts` (new, 32 tests), hermeticity fixes in 2 existing test files.
+
+## Decision-point inventory
+
+- Cross-model framework detection/selection — **modify** — first-match → all-available (collection only; no blocking authority).
+- `--family` allowlist guard — **add** — hard-invariant refusal of an untrusted framework id at the script edge (egress protection, enumerable set).
+- Externals-mandatory check (SKILL.md + `wasNonClaudeFrameworkActiveWithin`) — **add** — a deterministic read over the durable history that decides whether the SKILL FLOW may skip an external pass. Process-gating inside spec review; blocks no agent action or message.
+- Model canary — **add** — degrades a review pass; blocks nothing.
+
+---
+
+## 1. Over-block
+
+The allowlist refusing `pi-cli` could be seen as over-blocking a legitimate reviewer — deliberate: pi is multi-provider by design (its model flag may resolve to a custom endpoint), and the cost of a wrongly-allowed egress (full spec text to an attacker-controlled model) dwarfs the cost of one fewer reviewer family. The activation lookback could keep externals mandatory for an agent that genuinely uninstalled a framework yesterday — accepted: the 7-day tail is the entire point (anti-gaming), and the pass degrades to advisory-unavailable rather than hard-failing when the framework is truly gone.
+
+## 2. Under-block
+
+The activation history only records when `--detect-only`/review runs execute — an agent that NEVER ran spec-converge in the lookback has an empty history and presents as single-framework. Acceptable: the first detect of the current convergence records the observation, so the gaming window is "deactivate before the FIRST round" — and a genuinely deactivated-everywhere agent degrades to the advisory floor exactly as specced. The history is also local-file mutable by the agent itself (not tamper-proof) — consistent with every other instar state file; the report banner + frontmatter flag remain the human-visible disclosure.
+
+## 3. Level-of-abstraction fit
+
+Correct: detection/selection/hash/history are cheap structural helpers in the existing crossModelReviewer module (the registry's documented extension point); the SKILL owns the flow policy; nothing re-implements the provider factory, circuit breaker, or aggregation (`aggregateRoundOutcomes` unchanged and still computes the spec-level flag).
+
+## 4. Signal vs authority compliance
+
+**Required reference:** docs/signal-vs-authority.md
+
+- [x] No — no block/allow surface over agent behavior or messages. The two refusal points (allowlist, canary) are **hard-invariant validation** over enumerable sets (the principle's explicitly-allowed class — egress protection is the "safety guards on irreversible actions" case). Review outcomes only ever DEGRADE with logged reasons; judgment stays with the reviewers and the convergence process.
+
+## 5. Interactions
+
+- **Back-compat:** `detectCrossModelReviewer` (first-match) and the script's default single-pass mode are unchanged; existing callers/tests pass (hermeticity fixes only — the suite previously assumed gemini absent, false on hosts with gemini installed).
+- **Aggregation:** per-family results feed the existing per-round → spec-level aggregation unchanged; a delta-skip is recorded as a logged note, not a round outcome, so `degraded-all-rounds` semantics are preserved.
+- **Double-fire/races:** the activation JSONL is append-with-cap from a single skill flow; worst case under concurrent convergences is a lost observation line (history is a union-over-time read, so this cannot flip mandatory→optional within the lookback).
+- **Circuit breakers:** each framework keeps its own breaker via the factory — a rate-limited codex degrades that pass; gemini still runs (the family-diversity goal).
+
+## 6. External surfaces
+
+- **LLM egress:** spec text now also flows to gemini (first-party Google OAuth CLI) when available — the same egress class as the existing codex pass, now explicitly allowlist-bounded. No new third-party endpoints; pi/custom endpoints structurally excluded.
+- **Persistent state:** `state/framework-activation-history.jsonl` (capped). No fleet surface: spec-converge remains agent-private (decision recorded in the Piece-2 artifact); no `src/` runtime route/config change — `crossModelReviewer.ts` is library code consumed by the skill script.
+
+## 7. Rollback cost
+
+Revert the commit. The history file is inert if orphaned. No migration, no API, no fleet propagation.
+
+## Conclusion
+
+Piece 3 closes the spec: externals can no longer be quietly skipped (durable 7-day baseline + delta-gating with logged notes), selection is dynamic and family-diverse with zero pinned model names, and the two real security findings from convergence (spec egress to untrusted endpoints; silent dead-model reviews) are structurally closed (allowlist + canary). Verified: tsc clean, full lint clean, 77 unit (45 existing + 32 new) + 3 integration green, live smoke on this host detected both codex + gemini and refused pi-cli. Clear to ship as the final PR of the spec.
+
+---
+
+## Scope disclosure (honest residual)
+
+Two spec clauses are NOT implemented in this PR and are tracked, not orphaned <!-- tracked: CMT-1317 -->: (a) the Claude-only-agent floor reaching a *different-family* model via the subscription-path/provider-registry fallback — a single-framework agent currently gets the honest advisory `unavailable` flag (the pre-existing behavior, loudly disclosed in the report banner), and (b) surfacing "no external family reachable at all" as a HumanAsDetector-style tracked-gap signal rather than the advisory note. Both need provider-registry plumbing that doesn't belong in this hardening pass.
+
+## Second-pass review
+
+**Reviewer:** independent reviewer subagent (verified findings against the actually-installed gemini CLI v0.25.2).
+**Independent read of the artifact: concern raised → all resolved this pass.**
+
+- MUST-FIX (resolved): `GEMINI_HOME` is not a real gemini CLI env var (zero occurrences in the CLI dist; creds are unconditionally `~/.gemini/oauth_creds.json`). Honoring it made detection probe a path the CLI never reads — a false-unavailable would silently skip the gemini pass AND poison the activation baseline with `gemini-cli:false`, the exact suppression Piece 3 prevents. Fixed: env lookup dropped; injectable test seam kept.
+- NICE-TO-HAVE (applied): frontmatter-strip close anchor tightened to a whole-line fence (`\n---(\n|$)`) so `--- text`/`----` inside the block can't terminate the strip mid-line.
+- INFORMATIONAL (applied anyway): `wasNonClaudeFrameworkActiveWithin` now counts only TRUSTED reviewer framework ids, so a stray `{"claude-code":true}` line can't flip the externals-mandatory decision.
+- HONESTY (applied): the scope disclosure above was added at the reviewer's prompting — the artifact previously implied full Piece-3 coverage.
+- Confirmed clean: `--family` allowlist guard sits before any detect/provider call; no path (default, detect-all, or detectionOverride) can route spec text to a non-registry framework — the registry⊆allowlist invariant is itself unit-tested; `buildIntelligenceProvider({framework:'gemini-cli'})` cannot reach a custom base-URL (allowlisted child env); refresh-token-only IS authed for this CLI; the canary precedes provider construction in both entries; the 2000-line cap keeps the most recent lines; the reader never throws on corruption; the existing-test edits weaken no assertion.
+
+After fixes: tsc exit 0, 77/77 unit + 3/3 integration green.
+
+---
+
+## Evidence pointers
+
+- `tests/unit/crossModelReviewer-piece3.test.ts` (32): gemini detect triad, detect-all cardinality, canary accept/reject, hash frontmatter/CRLF stability, activation write/read/lookback/corrupt-line/cap, allowlist, gemini degraded paths.
+- Live smoke: `--detect-only --state-dir` → codex-cli:gpt-5.5 + gemini-cli:gemini-2.5-pro both detected + observation written; `--family pi-cli` → `untrusted-framework`; `--hash-only` → stable hash.
+- `npx tsc --noEmit` exit 0; `npm run lint` exit 0.


### PR DESCRIPTION
## ELI16 — the outside second opinion can't be quietly skipped anymore

Before building anything big, specs get reviewed — including by AI models OUTSIDE the Claude family, because different families catch different mistakes. Two problems: that outside pass was easy to skip, and it only ever asked ONE outside model even when more were available. This PR fixes both. Now every available outside family (GPT via codex, Gemini via the gemini CLI) reviews every spec — automatically re-running whenever the spec's actual content changes (and politely skipping, with a logged note, when nothing changed, so it doesn't waste quota). A 7-day record of which AI tools were active keeps it honest: turning a tool off right before review no longer exempts you. And two safety rails: spec text can only ever go to first-party providers you've logged into (never a custom endpoint), and a review that failed to resolve a real model name fails loudly instead of pretending it ran.

## What & why

PR 3 of 3 — the final piece of the **approved, convergence-tagged** spec `docs/specs/AUTONOMY-PRINCIPLES-ENFORCEMENT-SPEC.md`.

- **gemini-cli reviewer registry entry** — the seam's first extension beyond codex (never-throws detection at the path the CLI actually reads; provider via the existing factory + own circuit breaker; identical degraded semantics).
- **Family-diverse**: `detectAllCrossModelReviewers()` — one pass per available family.
- **Delta-gated**: `hashSpecReviewableBody()` — externals mandatory on round 1 + changed rounds; unchanged rounds = skip-with-logged-note (≠ skipped-abbreviated).
- **Durable activation baseline**: observations to `state/framework-activation-history.jsonl`; `wasNonClaudeFrameworkActiveWithin(7d)` defeats the deactivate-just-before-converge dodge (round-2 adversarial F-R2-3).
- **Egress allowlist**: `TRUSTED_REVIEWER_FRAMEWORKS` — pi-cli/custom endpoints structurally excluded from receiving spec text.
- **Fail-loud canary**: `isConcreteReviewerModel()` — loud `model-resolution-canary` degradation, never a silent tier-word review.

## Second-pass review (concern raised → all resolved)

The independent reviewer verified findings against the actually-installed gemini CLI and caught a real bug: I honored a `GEMINI_HOME` env var the CLI doesn't have — a set var would have silently skipped the gemini pass AND poisoned the activation baseline. Fixed, plus a frontmatter-strip anchor tightening and a trusted-ids-only filter on the baseline reader. Honest residuals disclosed + tracked (CMT-1317: the Claude-only different-family floor via provider-registry fallback + the tracked-gap signal). Full record: `upgrades/side-effects/cross-model-hardening.md`.

## Tests

32 new unit (`crossModelReviewer-piece3.test.ts`) + 45 existing + 3 integration — all green; tsc + full lint clean. Live smoke: detect-all found codex-cli:gpt-5.5 AND gemini-cli:gemini-2.5-pro on this host; `--family pi-cli` refused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
