### PR TITLE
fix(dashboard): pool-stream cross-machine history relay + closed-proxy recovery

### DIFF
--- a/.instar/instar-dev-decisions/2026-06-11T21-19-07-742Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-06-11T21-19-07-742Z-unknown.json
@@ -1,0 +1,13 @@
+{
+  "ts": "2026-06-11T21:19:07.742Z",
+  "slug": "unknown",
+  "suggestedTier": 2,
+  "declaredTier": 2,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 2,
+  "loc": 41,
+  "causalAutopsy": null,
+  "verdict": "pass"
+}

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -4236,7 +4236,10 @@
       }
       historyLoading = true;
       showHistorySpinner();
-      wsSend({ type: 'history', session: activeSession, lines: nextBatch });
+      // Remote sessions carry their machineId so the server relays the
+      // scrollback fetch to the owning machine (§2.2) instead of capturing
+      // locally (which can only ever return empty for a remote session).
+      wsSend({ type: 'history', session: activeSession, lines: nextBatch, ...(activeMachineId ? { machineId: activeMachineId } : {}) });
     }
 
     function showHistorySpinner() {

--- a/src/server/PeerStreamProxy.ts
+++ b/src/server/PeerStreamProxy.ts
@@ -178,9 +178,19 @@ export class PeerStreamProxy {
 
   /** Forward an input/key frame for a session (caller already gated allowRemoteInput). */
   relayInput(frame: Record<string, unknown>): void {
-    if (this.state === 'active') this.transport?.send(frame);
+    this.relayFrame(frame);
     // Not active → input is dropped (caller's terminal shows the live state);
     // we never queue keystrokes across a reconnect (stale input is worse than none).
+  }
+
+  /** Forward a read-only request frame (e.g. a `history` scrollback fetch) to
+   *  the owning machine. Spec §2.2: capture happens ONLY on the owning machine
+   *  — history for a remote session must travel upstream, never hit local
+   *  tmux. Dropped unless the link is active (a request racing a reconnect is
+   *  simply re-issued by the user's next scroll; stale queued requests are
+   *  worse than none). */
+  relayFrame(frame: Record<string, unknown>): void {
+    if (this.state === 'active') this.transport?.send(frame);
   }
 
   // ── connection lifecycle ───────────────────────────────────────────────

--- a/src/server/WebSocketManager.ts
+++ b/src/server/WebSocketManager.ts
@@ -287,10 +287,20 @@ export class WebSocketManager {
     return !local;
   }
 
-  /** Get-or-create the one multiplexed upstream proxy for a peer machine. */
+  /** Get-or-create the one multiplexed upstream proxy for a peer machine.
+   *
+   *  A cached proxy that reached `closed` (idle-grace close after the last
+   *  viewer left, or machine-unreachable after the bounded reconnect failed)
+   *  is EVICTED and replaced: a closed PeerStreamProxy ignores every further
+   *  subscribe by design, so returning it made the peer permanently
+   *  unstreamable until a server restart — the 2026-06-08 live bug ("connects
+   *  but the terminal stays blank, and never recovers after a hiccup"). A
+   *  fresh user-initiated subscribe is a fresh episode with its own bounded
+   *  reconnect budget, so P19 (no reconnect storms) is preserved. */
   private peerProxyFor(machineId: string): PeerStreamProxy {
     let proxy = this.peerProxies.get(machineId);
-    if (proxy) return proxy;
+    if (proxy && proxy.currentState !== 'closed') return proxy;
+    if (proxy) this.peerProxies.delete(machineId);
     proxy = new PeerStreamProxy({
       peerMachineId: machineId,
       // The connector owns URL resolution; a non-null sentinel keeps the proxy's
@@ -435,13 +445,26 @@ export class WebSocketManager {
           this.send(client.ws, { type: 'error', message: 'Missing session name' });
           return;
         }
+        // §2.2: capture happens ONLY on the owning machine. A history request
+        // for a remote-subscribed session relays upstream like input/key —
+        // the peer's reply (a `history` frame carrying the session name) fans
+        // back through onUpstreamFrame. Capturing locally here returned null
+        // for every remote session (2026-06-08 live bug: the screen-text
+        // fetch "only ever looked on the local machine").
+        const histMachine = typeof msg.machineId === 'string' ? msg.machineId : undefined;
+        if (histMachine && client.remoteSubs?.has(`${histMachine}::${session}`)) {
+          this.peerProxies.get(histMachine)?.relayFrame({ type: 'history', session, lines });
+          break;
+        }
         const historyOutput = this.sessionManager.captureOutput(session, lines);
         if (historyOutput) {
           // Update the cache so streaming doesn't immediately overwrite with fewer lines
           this.sessionOutputCache.set(`${this.clientId(client)}:${session}`, historyOutput);
           this.send(client.ws, { type: 'history', session, data: historyOutput, lines });
         } else {
-          this.send(client.ws, { type: 'error', message: `No output for session "${session}"` });
+          // Carry session + code so the frame is relayable (a sessionless
+          // error is dropped by the peer fan-out) and renders honestly.
+          this.send(client.ws, { type: 'error', code: 'session-not-found', session, message: `No output for session "${session}"` });
         }
         break;
       }

--- a/tests/unit/PeerStreamProxy.test.ts
+++ b/tests/unit/PeerStreamProxy.test.ts
@@ -223,3 +223,27 @@ describe('PeerStreamProxy — input relay + close', () => {
     expect(() => h.proxy.close()).not.toThrow();
   });
 });
+
+describe('PeerStreamProxy — read-only frame relay (history, §2.2)', () => {
+  it('relayFrame forwards a history request only while active; dropped while connecting or closed', () => {
+    const h = harness();
+    h.proxy.subscribe('s1', 'c1');
+    h.proxy.relayFrame({ type: 'history', session: 's1', lines: 5000 }); // connecting → dropped
+    h.last().handlers.onOpen();
+    h.proxy.relayFrame({ type: 'history', session: 's1', lines: 7000 }); // active → sent
+    h.proxy.close();
+    h.proxy.relayFrame({ type: 'history', session: 's1', lines: 9000 }); // closed → dropped
+    const hist = h.last().sent.filter((f) => f.type === 'history');
+    expect(hist).toEqual([{ type: 'history', session: 's1', lines: 7000 }]);
+  });
+
+  it('a history reply frame from the peer fans out to local clients like output', () => {
+    const h = harness();
+    h.proxy.subscribe('s1', 'c1');
+    h.last().handlers.onOpen();
+    h.last().handlers.onFrame({ type: 'history', session: 's1', data: 'scrollback', lines: 5000 });
+    expect(h.framesToClients).toEqual([
+      { session: 's1', frame: { type: 'history', session: 's1', data: 'scrollback', lines: 5000 } },
+    ]);
+  });
+});

--- a/tests/unit/WebSocketManager.test.ts
+++ b/tests/unit/WebSocketManager.test.ts
@@ -654,4 +654,88 @@ describe('WebSocketManager — remote session routing (requesting side)', () => 
     sendMessage(client, { type: 'unsubscribe', session: 'mini-sess', machineId: 'm_mini' });
     expect(client.remoteSubs.has('m_mini::mini-sess')).toBe(false);
   });
+
+  // ── 2026-06-08 live bug #2: no recovery after a hiccup ──────────────────
+  // A proxy that reached `closed` (failed bounded reconnect, or idle-grace
+  // close) was cached forever; every later subscribe was silently ignored
+  // while the server still answered `subscribed` — a permanent blank terminal
+  // until server restart. peerProxyFor must EVICT a closed proxy.
+  describe('closed-proxy eviction (recovery after a dead upstream)', () => {
+    it('after the bounded reconnect fails (two drops), a NEW subscribe opens a FRESH upstream and streams again', () => {
+      const { connector, state } = fakeConnector();
+      const { connectClient, sendMessage } = createTestManager({ poolStreamConnector: connector, selfMachineId: 'm_self' });
+      const { ws, client } = connectClient();
+
+      sendMessage(client, { type: 'subscribe', session: 'mini-sess', machineId: 'm_mini' });
+      state.handlers.onOpen();
+      state.handlers.onClose();                 // drop #1 → bounded reconnect (connect #2)
+      expect(state.connectCount).toBe(2);
+      state.handlers.onClose();                 // drop #2 → machine-unreachable → proxy closed
+      expect(ws.sentMessages.some(m => m.type === 'error' && m.code === 'machine-unreachable')).toBe(true);
+
+      // The user clicks the tile again — a fresh episode must open a fresh link.
+      sendMessage(client, { type: 'subscribe', session: 'mini-sess', machineId: 'm_mini' });
+      expect(state.connectCount).toBe(3);       // EVICTED + recreated, not the dead cached proxy
+      state.handlers.onOpen();
+      state.handlers.onFrame({ type: 'output', session: 'mini-sess', data: 'back alive' });
+      const out = ws.sentMessages.filter(m => m.type === 'output' && m.session === 'mini-sess');
+      expect(out.some(m => m.data === 'back alive')).toBe(true);
+    });
+
+    it('after a force-closed proxy (idle-grace path), a NEW subscribe recreates the proxy', () => {
+      const { connector, state } = fakeConnector();
+      const { manager, connectClient, sendMessage } = createTestManager({ poolStreamConnector: connector, selfMachineId: 'm_self' });
+      const { client } = connectClient();
+      sendMessage(client, { type: 'subscribe', session: 'mini-sess', machineId: 'm_mini' });
+      expect(state.connectCount).toBe(1);
+      (manager as any).peerProxies.get('m_mini').close();   // what the idle-grace timer does
+      sendMessage(client, { type: 'subscribe', session: 'mini-sess', machineId: 'm_mini' });
+      expect(state.connectCount).toBe(2);                   // fresh proxy, fresh upstream
+    });
+  });
+
+  // ── 2026-06-08 live bug #1: the screen-text fetch only looked locally ──
+  describe('cross-machine history relay (§2.2 capture only on the owning machine)', () => {
+    it('a history request for a remote-subscribed session relays upstream and never captures locally', () => {
+      const sm = createMockSessionManager();
+      const { connector, state } = fakeConnector();
+      const { connectClient, sendMessage } = createTestManager({ sessionManager: sm, poolStreamConnector: connector, selfMachineId: 'm_self' });
+      const { ws, client } = connectClient();
+      sendMessage(client, { type: 'subscribe', session: 'mini-sess', machineId: 'm_mini' });
+      state.handlers.onOpen();
+      sm.captureOutput.mockClear();
+
+      sendMessage(client, { type: 'history', session: 'mini-sess', machineId: 'm_mini', lines: 7000 });
+      expect(state.sent.some((f: any) => f.type === 'history' && f.session === 'mini-sess' && f.lines === 7000)).toBe(true);
+      expect(sm.captureOutput).not.toHaveBeenCalled();      // capture happens ONLY on the owning machine
+
+      // The owning machine replies — the history frame fans back, machine-tagged.
+      state.handlers.onFrame({ type: 'history', session: 'mini-sess', data: 'remote scrollback', lines: 7000 });
+      const hist = ws.sentMessages.find(m => m.type === 'history' && m.session === 'mini-sess');
+      expect(hist).toBeDefined();
+      expect(hist!.data).toBe('remote scrollback');
+      expect(hist!.machineId).toBe('m_mini');
+    });
+
+    it('a history request WITHOUT a machineId stays on the local capture path (regression)', () => {
+      const sm = createMockSessionManager({ captureOutput: vi.fn(() => 'local scrollback') });
+      const { connector, state } = fakeConnector();
+      const { connectClient, sendMessage } = createTestManager({ sessionManager: sm, poolStreamConnector: connector, selfMachineId: 'm_self' });
+      const { ws, client } = connectClient();
+      sendMessage(client, { type: 'history', session: 'local-sess', lines: 5000 });
+      expect(sm.captureOutput).toHaveBeenCalledWith('local-sess', 5000);
+      expect(ws.sentMessages.some(m => m.type === 'history' && m.data === 'local scrollback')).toBe(true);
+      expect(state.sent).toHaveLength(0);                   // nothing relayed upstream
+    });
+
+    it('a local history miss answers an honest, relayable error (session + code, never a sessionless frame)', () => {
+      const sm = createMockSessionManager({ captureOutput: vi.fn(() => null) });
+      const { connectClient, sendMessage } = createTestManager({ sessionManager: sm });
+      const { ws, client } = connectClient();
+      sendMessage(client, { type: 'history', session: 'gone-sess', lines: 5000 });
+      const err = ws.sentMessages.find(m => m.type === 'error' && m.session === 'gone-sess');
+      expect(err).toBeDefined();
+      expect(err!.code).toBe('session-not-found');
+    });
+  });
 });

--- a/upgrades/next/pool-stream-cross-machine-fix.md
+++ b/upgrades/next/pool-stream-cross-machine-fix.md
@@ -1,0 +1,30 @@
+# Upgrade Guide — Pool Dashboard Streaming: remote scrollback + post-hiccup recovery
+
+<!-- bump: patch -->
+
+## What Changed
+
+Fixes the two live bugs from 2026-06-08 testing that left cross-machine dashboard streaming connecting-but-blank with no recovery (POOL-DASHBOARD-STREAM-SPEC, shipped #950–#970):
+
+- **Closed-proxy eviction** (`WebSocketManager.peerProxyFor`): a peer's stream proxy that reached `closed` — after the bounded reconnect failed, or after the 60s idle grace once the last viewer left — stayed cached forever, and a closed proxy silently ignores every later subscribe while the server still answered `subscribed`. One hiccup (or one minute of nobody watching) made that machine permanently unstreamable until a server restart. The get-or-create chokepoint now evicts a closed proxy and opens a fresh episode with its own bounded reconnect budget (P19 no-storm guarantee preserved: reconnects remain one-per-episode, new episodes only on explicit user subscribes).
+- **Cross-machine scrollback** (`history` relay): the terminal-history fetch only ever captured locally — structurally empty for a session owned by another machine. It now relays upstream for remote-subscribed sessions exactly like input/key (spec §2.2: capture happens ONLY on the owning machine), via a new read-only `PeerStreamProxy.relayFrame`; the dashboard client sends `machineId` on history requests for remote tiles.
+- **Honest history miss**: the "no output for session" reply was a sessionless error frame, which the peer fan-out structurally drops; it now carries `session` + `code:'session-not-found'` and renders in the terminal (§2.4 failure honesty).
+
+The serving side of the protocol is unchanged — an updated machine streaming from a not-yet-updated peer degrades to exactly today's behavior at worst. The remote-input default-off security gate is untouched.
+
+## What to Tell Your User
+
+- "Watching one machine's terminal from another machine's dashboard now actually shows the terminal — including scrolling back through its history — and if the link between machines hiccups, clicking the session again recovers it instead of staying dead until a restart."
+
+## Summary of New Capabilities
+
+| Capability | How to Use |
+|-----------|-----------|
+| Remote session scrollback | Automatic — scroll up in any remote session's terminal in the dashboard |
+| Stream recovery after a dropped peer link | Automatic — re-clicking the session tile opens a fresh, bounded connection episode |
+
+## Evidence
+
+- 7 new unit tests (5 behavior + 2 regression guards) across `tests/unit/WebSocketManager.test.ts` and `tests/unit/PeerStreamProxy.test.ts`; each behavior test was run against the UNFIXED code first and failed for the stated reason (missing relayFrame, ignored re-subscribe after closed, sessionless error), then green with the fix.
+- Full unit suite green in the worktree; `pnpm build` clean.
+- Live verification on the real laptop + Mac Mini (a Mini session terminal rendering on the laptop dashboard, then recovery after an induced link drop) — performed post-deploy, results recorded in topic 13481.

--- a/upgrades/side-effects/pool-stream-cross-machine-fix.md
+++ b/upgrades/side-effects/pool-stream-cross-machine-fix.md
@@ -1,0 +1,94 @@
+# Side-Effects Review — Pool Dashboard Streaming: cross-machine history relay + closed-proxy recovery
+
+**Version / slug:** `pool-stream-cross-machine-fix`
+**Date:** `2026-06-11`
+**Author:** `echo (instar-dev agent)`
+**Second-pass reviewer:** `not required` (no block/allow surface on messaging/dispatch, no session lifecycle, no sentinel/gate/watchdog logic — see Phase-5 assessment in Conclusion)
+
+## Summary of the change
+
+Fixes the two live bugs found during 2026-06-08 live testing of Pool Dashboard Streaming (POOL-DASHBOARD-STREAM-SPEC, converged-approved 2026-06-06), which left a remote (Mac Mini) session tile connecting but rendering a blank terminal, with no recovery until server restart:
+
+1. **Closed-proxy eviction** (`src/server/WebSocketManager.ts` → `peerProxyFor`): a `PeerStreamProxy` that reached `closed` (idle-grace close after the last viewer left, or `machine-unreachable` after the bounded reconnect failed) stayed cached in `peerProxies` forever. A closed proxy ignores every further subscribe by design, while the subscribe handler still answered `subscribed` — so one upstream hiccup (or 60s of nobody watching) made that peer permanently unstreamable, silently. `peerProxyFor` now evicts a closed proxy and creates a fresh one; a fresh user-initiated subscribe is a fresh episode with its own bounded reconnect budget (P19 preserved).
+2. **Cross-machine history relay** (`src/server/WebSocketManager.ts` `history` case, `src/server/PeerStreamProxy.ts` `relayFrame`, `dashboard/index.html` `loadMoreHistory`): the scrollback fetch (`{type:'history'}`) had no remote branch — it always called local `captureOutput`, which can only return empty for a session owned by another machine (spec §2.2: capture happens ONLY on the owning machine). The handler now relays history upstream for a remote-subscribed session exactly like input/key, the proxy gained a read-only `relayFrame` (relayInput delegates to it), and the dashboard client sends `machineId` on history requests for remote sessions.
+3. **Relayable history miss** (same `history` case): the local "no output" reply was `{type:'error', message}` with NO session field — the peer fan-out drops sessionless frames, so the error could never travel. It now carries `session` + `code:'session-not-found'`, which the dashboard already renders honestly (§2.4).
+
+Files: `src/server/WebSocketManager.ts`, `src/server/PeerStreamProxy.ts`, `dashboard/index.html`, `tests/unit/WebSocketManager.test.ts`, `tests/unit/PeerStreamProxy.test.ts`.
+
+## Decision-point inventory
+
+- `WebSocketManager.peerProxyFor` — modify — get-or-create now evicts a `closed` proxy; routing decision (which proxy serves a peer), not a block/allow decision.
+- `WebSocketManager.handleMessage 'history'` — modify — adds the remote-routing branch (same shape as the existing `input`/`key` remote branches); read-only data fetch, no authority.
+- `PeerStreamProxy.relayFrame` — add — forwards a read-only frame while the link is active; drops otherwise (same drop semantics relayInput always had).
+- `gateWrite` (remote input authority, `poolStreamAllowRemoteInput`) — **pass-through, untouched** — history is read-only and never reaches `gateWrite`; the input default-off security gate is not modified by this change.
+- Stream ticket auth (`StreamTicketStore`, `/pool-stream` upgrade) — **pass-through, untouched**.
+
+---
+
+## 1. Over-block
+
+**What legitimate inputs does this change reject that it shouldn't?**
+
+No issue identified. The change adds no new rejection. The history remote branch only triggers when the client explicitly sent a `machineId` AND that client already holds a live remote subscription for exactly that `(machine, session)` pair (`client.remoteSubs.has(...)`) — a history request for a never-subscribed remote session falls through to the local path and answers `session-not-found`, which is the honest answer (you cannot scroll back a session you are not watching). Local history requests (no machineId) are byte-for-byte unchanged.
+
+---
+
+## 2. Under-block
+
+**What failure modes does this still miss?**
+
+- A history request relayed while the upstream is `connecting` (mid-reconnect) is dropped, not queued — the user's infinite-scroll simply doesn't load that batch and re-fires on the next scroll (the client re-requests on scroll position). Stale queued requests racing a reconnect would be worse. Accepted, documented in `relayFrame`'s contract.
+- The history reply fans to EVERY local client subscribed to that (machine, session), not just the requester — same multiplexing behavior the spec defines for all frames (§2.2 "frames relay 1:1"); clients gate rendering on `activeSession`, so a non-requesting viewer at most refreshes its scrollback.
+- The 2026-06-07 mint-timeout failure class (wedged ticket mint) is already handled by the explicit 10s timeout shipped in #970, upstream of this change.
+
+---
+
+## 3. Level-of-abstraction fit
+
+**Is this at the right layer?**
+
+Yes. The history relay is placed at exactly the layer the spec assigned it: the SUBSCRIBE-side routing chokepoint in `WebSocketManager.handleMessage`, parallel to the existing `input`/`key` remote branches — not a new parallel path. `relayFrame` lives in `PeerStreamProxy` because that class owns "is the upstream link usable" state; the manager owns "is this session remote for this client" state. The eviction lives in `peerProxyFor` (the single get-or-create chokepoint) rather than inside the proxy (e.g. a self-reopening proxy), keeping the proxy's one-shot bounded-reconnect state machine — and its P19 guarantee — untouched.
+
+---
+
+## 4. Signal vs authority compliance
+
+**Required reference:** [docs/signal-vs-authority.md](../../docs/signal-vs-authority.md)
+
+- [x] No — this change has no block/allow surface.
+
+The change is pure data-plane plumbing (routing read-only frames to the machine that owns the data, and replacing a dead connection object). The ONLY authority in this subsystem — the serving machine's `poolStreamAllowRemoteInput` gate on remote keystrokes — is not touched, weakened, or bypassed: history never reaches `gateWrite` because it is a read, and reads were already permitted to any authenticated peer link (the initial subscribe capture has always shipped full screen content to the peer). No new information becomes visible to any principal that could not already see it.
+
+---
+
+## 5. Interactions
+
+- **Shadowing:** the remote history branch runs BEFORE the local capture path, gated on `client.remoteSubs` — the local path is unreachable only for sessions the client explicitly subscribed remotely, which is exactly the set local capture could never serve (it returned null for them). Nothing that previously worked is shadowed.
+- **Double-fire:** none — a history request takes exactly one branch (remote XOR local). Eviction cannot double-open: `peerProxyFor` is synchronous, and only a `closed` proxy (no live transport, no pending timers except a fired/cleared one) is evicted, so no second live upstream to the same peer can exist.
+- **Races:** a client disconnect between failAll and re-subscribe calls `dropRemoteSubsForClient`, which looks up the CURRENT map entry — if eviction already replaced the proxy, the unsubscribe lands on the fresh proxy where `unsubscribe()` of an unknown clientId is a documented no-op. An old evicted proxy holds no timers and no transport (failAll/idle-close tear both down), so it is plain garbage, not a leak.
+- **Feedback loops:** none — the eviction does not auto-reconnect; it only acts on the next explicit user subscribe, so a permanently-down peer costs one bounded reconnect cycle per user click, never a storm.
+
+---
+
+## 6. External surfaces
+
+- **Other machines:** the serving side of the protocol is UNCHANGED — an updated laptop streaming from a not-yet-updated Mini works (the Mini's serving side always answered history requests arriving on a peer link; the bug was the laptop never sending them). Mixed-version fleets degrade to exactly today's behavior at worst.
+- **Protocol:** no new frame types; `history` was already in the documented protocol and in `UpstreamTransport.send`'s doc comment ("subscribe/unsubscribe/input/key/history"). The local history-miss error gains `code` + `session` fields (additive; the dashboard's existing `error` handler renders `code`-carrying frames and still `console.error`s unknown shapes).
+- **Persistent state:** none touched. No config, no migrations, no ledgers.
+- **Timing:** `relayFrame` depends on the upstream being `active` — bounded, observable via the existing `[pool-stream-connector]` log lines.
+
+---
+
+## 7. Rollback cost
+
+Pure code change in three files with no persistent state: revert the commit, ship as the next patch. During a rollback window the symptom is exactly the pre-fix behavior (blank remote scrollback, no post-hiccup recovery) — degraded, not destructive. No data migration, no agent state repair, no template/hook migration (dashboard/index.html ships in the npm package and replaces wholesale on update).
+
+---
+
+## Conclusion
+
+Review produced one design adjustment: the local history-miss error was originally left sessionless; the relay analysis (§5 fan-out drops sessionless frames) surfaced that it could never travel cross-machine, so it now carries `session` + `code` — that is also what makes the dashboard render it honestly instead of burying it in the console. Phase-5 second-pass assessment: the change touches none of the listed high-risk surfaces (no outbound/inbound messaging block decisions, no session spawn/restart/kill/recovery, no compaction, no coherence gates/idempotency/trust, no sentinel/guard/gate/watchdog logic — the one gate in this subsystem, remote-input default-off, is untouched pass-through), so a dedicated reviewer subagent is not required; the artifact stands on the three-tier test evidence. Clear to ship.
+
+**Phase 1 principle check (recorded):** the change involves no new decision point that gates information flow or constrains behavior — it repairs the data plane of an approved feature to match its converged spec (§2.2 capture-on-owner, §2.4 failure honesty, P19 bounded reconnect). Signal-vs-authority applies as a constraint check only: confirmed no brittle logic gained blocking authority.
+
+**Phase 2 plan (recorded):** built in a FRESH worktree `.worktrees/fix-pool-stream-cross-machine` off `JKHeadley/main` @ `60c4e3a3c` (v1.3.484), canonical remote verified (`JKHeadley → github.com/JKHeadley/instar.git`), per-worktree identity `Instar Agent (echo) <echo@instar.local>`. Acceptance criteria: (a) new unit tests fail on unfixed code for the stated reasons — verified (5 failures: missing relayFrame ×2, ignored re-subscribe ×2 → silent blank, sessionless error ×1); (b) all green with fix; (c) full suite green; (d) live verify on the real laptop+Mini after deploy. Rollback: revert commit (see §7).


### PR DESCRIPTION
## Summary

Fixes the two live bugs found during 2026-06-08 live testing of Pool Dashboard Streaming (POOL-DASHBOARD-STREAM-SPEC, converged-approved; shipped in #950/#962/#964/#965/#970) that left a remote (Mac Mini) session tile **connecting but rendering a blank terminal, with no recovery until server restart**:

1. **Closed-proxy eviction** (`WebSocketManager.peerProxyFor`) — a `PeerStreamProxy` that reached `closed` (60s idle-grace close after the last viewer left, or `machine-unreachable` after the bounded reconnect failed) stayed cached forever. A closed proxy ignores every further subscribe by design, while the subscribe handler still answered `subscribed` — one hiccup or one minute of nobody watching made that peer permanently unstreamable, silently. The get-or-create chokepoint now evicts a closed proxy; a fresh user-initiated subscribe is a fresh episode with its own bounded reconnect budget (**P19 no-storm guarantee preserved**).
2. **Cross-machine history relay** — the scrollback fetch (`{type:'history'}`) had no remote branch: it always called local `captureOutput`, structurally empty for a session owned by another machine (spec §2.2: capture happens ONLY on the owning machine). Now relays upstream for remote-subscribed sessions exactly like input/key, via a new read-only `PeerStreamProxy.relayFrame`; the dashboard client sends `machineId` on history requests for remote tiles.
3. **Relayable history miss** — the local "no output" reply was a sessionless error frame, which the peer fan-out structurally drops; it now carries `session` + `code:'session-not-found'` and renders honestly in the terminal (§2.4).

**Security surface untouched:** the remote-input default-off gate (`poolStreamAllowRemoteInput` / `gateWrite`) is pass-through; history is a read, and reads were already permitted to authenticated peer links. Serving side of the protocol unchanged — mixed-version fleets degrade to exactly today's behavior at worst.

## Evidence

- 7 new unit tests (`tests/unit/WebSocketManager.test.ts`, `tests/unit/PeerStreamProxy.test.ts`); the 5 behavior tests were run against the UNFIXED code first and failed for the stated reasons (missing `relayFrame` ×2, silently-ignored re-subscribe after `closed` ×2, sessionless error ×1), then all green with the fix.
- Full unit suite green (exit 0); `pnpm build` clean; full lint chain clean.
- Side-effects artifact: `upgrades/side-effects/pool-stream-cross-machine-fix.md` (7-question review; one design adjustment came out of it — the relayable history-miss error).
- Live verification on the real laptop + Mac Mini follows deploy (a Mini terminal rendering on the laptop dashboard + post-hiccup recovery) — tracked in topic 13481.

## ELI16

Your dashboard can list the sessions running on your other computers, and clicking one is supposed to stream that terminal live. Two bugs broke this. First, when the connection between two computers dropped once — or just sat unused for a minute — the "phone line" object between them was retired, but the dashboard kept dialing the retired phone forever: it told your browser "connected!" while nothing could ever arrive. That's why a clicked session showed a blank black box and stayed dead until a full restart. Second, scrolling back through a remote terminal's history only ever looked on YOUR computer's screen buffer — the history lives on the OTHER computer, so it always came back empty. The fix: throw away a retired phone line and dial a fresh one when you click again (with the same strict no-redial-storm limits as before), and send history requests across to the computer that actually owns the terminal. Watching is still read-only by default — the switch that lets one machine type into another stays off unless you turn it on.
