### PR TITLE
fix(sessions): supersede ghost registry records — one running record per tmux name

### DIFF
--- a/.instar/instar-dev-decisions/2026-06-12T04-20-51-056Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-06-12T04-20-51-056Z-unknown.json
@@ -1,0 +1,13 @@
+{
+  "ts": "2026-06-12T04:20:51.056Z",
+  "slug": "unknown",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 2,
+  "loc": 48,
+  "causalAutopsy": null,
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-06-12T04-21-01-500Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-06-12T04-21-01-500Z-unknown.json
@@ -1,0 +1,13 @@
+{
+  "ts": "2026-06-12T04:21:01.500Z",
+  "slug": "unknown",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 2,
+  "loc": 48,
+  "causalAutopsy": null,
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-06-12T04-21-09-833Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-06-12T04-21-09-833Z-unknown.json
@@ -1,0 +1,13 @@
+{
+  "ts": "2026-06-12T04:21:09.833Z",
+  "slug": "unknown",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 2,
+  "loc": 48,
+  "causalAutopsy": null,
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-06-12T04-21-31-735Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-06-12T04-21-31-735Z-unknown.json
@@ -1,0 +1,16 @@
+{
+  "ts": "2026-06-12T04:21:31.735Z",
+  "slug": "unknown",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 2,
+  "loc": 48,
+  "causalAutopsy": {
+    "origin": "latent",
+    "notes": "Latent registry-hygiene gap present since the original session registry: no path ever closed an old running record when a respawn reused its tmux name. Surfaced only under the June 2026 crisis respawn churn on the Mac Mini (5 ghosts on one name) and noticed by the operator on the dashboard 2026-06-11. Lesson: every create-with-reused-natural-key path needs an explicit supersede step, enforced at the write funnel."
+  },
+  "verdict": "pass"
+}

--- a/docs/specs/session-ghost-records.eli16.md
+++ b/docs/specs/session-ghost-records.eli16.md
@@ -1,0 +1,25 @@
+# Duplicate sessions on the dashboard — the ghost-record fix, in plain English
+
+## What you saw
+
+Your dashboard showed six copies of the same session on the Mac Mini ("Resource Limitation Mitigation", over and over). There was really only ONE terminal running — the other five entries were ghosts: leftover bookkeeping records from old restarts that nobody ever cleaned up.
+
+## Why it happened
+
+Every session has two parts: the real terminal (a tmux session) and a small bookkeeping record the dashboard reads. When a session gets restarted, the system creates a fresh bookkeeping record for the new terminal. During the stability crisis in early June, sessions on the Mini were restarted again and again — and each restart left the OLD record behind, still marked "running." Five restarts, five ghosts. The dashboard faithfully showed every record it found, so one terminal looked like six sessions.
+
+## The fix
+
+Terminal names are unique — there can never be two live terminals with the same name on one machine. So the fix enforces exactly that rule on the bookkeeping: the moment a new record registers as "running" for a terminal name, any OTHER record still claiming to be "running" for that same name is closed out and stamped with a note saying which record replaced it. The rule lives in the ONE place every session registration already passes through, so no restart path — present or future — can forget to clean up after itself.
+
+## What it does NOT do
+
+It never touches the real terminals — it closes paperwork, not programs. It can't close the wrong thing across machines (each machine keeps its own books, and the rule only applies within one machine's records). And if the cleanup itself ever hits an error, the new session still registers fine — the hygiene step is never allowed to break a real launch.
+
+## How the old ghosts get cleaned
+
+Ghosts already sitting on your machines collapse automatically the next time each session name restarts (which happens naturally). The five on the Mini were already cleaned by hand today.
+
+## What you'll notice
+
+The dashboard shows one entry per real terminal. That's it — no settings, no migration, nothing to turn on.

--- a/src/core/StateManager.ts
+++ b/src/core/StateManager.ts
@@ -202,6 +202,19 @@ export class StateManager {
   saveSession(session: Session): void {
     this.guardWrite('saveSession', { sessionScoped: true });
     this.validateKey(session.id, 'sessionId');
+    // One-running-record-per-tmux invariant (ghost-record fix): registering a
+    // record as live for a tmux name supersedes any OTHER record still marked
+    // live for the same name. tmux session names are unique among live
+    // sessions, so two live records for one name are definitionally stale —
+    // crisis respawns leaked one ghost per respawn and the dashboard rendered
+    // each as a separate "duplicate session" (2026-06-11 Mac Mini: 5 running
+    // records all pointing at the single tmux session
+    // echo-resource-limitation-mitigation). Enforced HERE because saveSession
+    // is the single funnel every spawn site already passes through — the same
+    // rationale as the journal funnel below.
+    if (session.status === 'running' || session.status === 'starting') {
+      this.supersedeStaleLiveRecords(session);
+    }
     const filePath = path.join(this.stateDir, 'state', 'sessions', `${session.id}.json`);
     // Coherence-journal lifecycle funnel (COHERENCE-JOURNAL-SPEC §3.3): EVERY
     // session status transition passes through saveSession — deriving the
@@ -212,6 +225,33 @@ export class StateManager {
     this.atomicWrite(filePath, JSON.stringify(session, null, 2));
     this.invalidateSessionsCache(); // a write must be visible to the next list
     this.recordLifecycleTransition(prevStatus, session);
+  }
+
+  /**
+   * Close every OTHER record still marked live for the same tmux session name
+   * (ghost-record supersession). Each ghost is closed through saveSession
+   * itself so the journal funnel records its completed transition — the
+   * reentry terminates because a 'completed' save never enters this path.
+   * Best-effort: a failure here must never endanger the spawn being saved.
+   */
+  private supersedeStaleLiveRecords(next: Session): void {
+    try {
+      const ghosts = this.listSessions().filter(
+        (s) =>
+          s.id !== next.id &&
+          s.tmuxSession === next.tmuxSession &&
+          (s.status === 'running' || s.status === 'starting'),
+      );
+      for (const ghost of ghosts) {
+        this.saveSession({
+          ...ghost,
+          status: 'completed',
+          endedAt: new Date().toISOString(),
+          endedReason: 'superseded',
+          supersededBy: next.id,
+        });
+      }
+    } catch { /* @silent-fallback-ok: supersession is registry hygiene — it must never block the live spawn being registered */ }
   }
 
   /** Best-effort read of an existing session record's status (funnel diff input). */

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -78,6 +78,14 @@ export interface Session {
    *  (e.g. 'idle-zombie', 'reaped-idle', 'manual-kill'). Undefined on records
    *  ended before this field existed. */
   endedReason?: string;
+  /** Ghost-record supersession (one-running-record-per-tmux invariant): when a
+   *  NEW record registers as running for a tmux session name, any OTHER record
+   *  still marked running/starting for that same name is closed with this field
+   *  set to the new record's id. tmux names are unique among live sessions, so
+   *  two live records for one name are definitionally stale — the leak that
+   *  showed N "duplicate sessions" on the dashboard after crisis respawns
+   *  (2026-06-11 Mac Mini: 5 records × 1 tmux session). */
+  supersededBy?: string;
   /**
    * How this session signals task completion (june15-headless-spawn-reroute, PR2).
    * - undefined/'exit': today's behavior — a headless one-shot signals completion

--- a/tests/unit/StateManager.test.ts
+++ b/tests/unit/StateManager.test.ts
@@ -46,9 +46,11 @@ describe('StateManager', () => {
     });
 
     it('lists sessions by status', () => {
-      state.saveSession(makeSession({ id: 'a', status: 'running' }));
-      state.saveSession(makeSession({ id: 'b', status: 'completed' }));
-      state.saveSession(makeSession({ id: 'c', status: 'running' }));
+      // Distinct tmux names: two RUNNING records sharing one tmux name is the
+      // ghost-record case the supersession invariant (below) now closes.
+      state.saveSession(makeSession({ id: 'a', status: 'running', tmuxSession: 'tmux-a' }));
+      state.saveSession(makeSession({ id: 'b', status: 'completed', tmuxSession: 'tmux-b' }));
+      state.saveSession(makeSession({ id: 'c', status: 'running', tmuxSession: 'tmux-c' }));
 
       const running = state.listSessions({ status: 'running' });
       expect(running).toHaveLength(2);
@@ -56,11 +58,82 @@ describe('StateManager', () => {
     });
 
     it('lists all sessions without filter', () => {
-      state.saveSession(makeSession({ id: 'a', status: 'running' }));
-      state.saveSession(makeSession({ id: 'b', status: 'completed' }));
+      state.saveSession(makeSession({ id: 'a', status: 'running', tmuxSession: 'tmux-a' }));
+      state.saveSession(makeSession({ id: 'b', status: 'completed', tmuxSession: 'tmux-b' }));
 
       const all = state.listSessions();
       expect(all).toHaveLength(2);
+    });
+  });
+
+  describe('Ghost-record supersession (one running record per tmux name)', () => {
+    const makeSession = (overrides?: Partial<Session>): Session => ({
+      id: 'test-123',
+      name: 'test-session',
+      status: 'running',
+      tmuxSession: 'project-test-session',
+      startedAt: new Date().toISOString(),
+      ...overrides,
+    });
+
+    it('a new running record supersedes an older running record with the same tmux name', () => {
+      state.saveSession(makeSession({ id: 'old', status: 'running' }));
+      state.saveSession(makeSession({ id: 'new', status: 'running' }));
+
+      const oldRec = state.getSession('old')!;
+      expect(oldRec.status).toBe('completed');
+      expect(oldRec.endedReason).toBe('superseded');
+      expect(oldRec.supersededBy).toBe('new');
+      expect(oldRec.endedAt).toBeTruthy();
+      expect(state.getSession('new')!.status).toBe('running');
+      // The dashboard's view: exactly ONE running record for the tmux name.
+      expect(state.listSessions({ status: 'running' })).toHaveLength(1);
+    });
+
+    it('collapses MULTIPLE accumulated ghosts in one registration (the Mac Mini case)', () => {
+      // Simulate the pre-fix corruption: ghost files written directly on disk
+      // (the state these agents are already in), then one fresh respawn.
+      for (const id of ['g1', 'g2', 'g3', 'g4']) {
+        fs.writeFileSync(
+          path.join(tmpDir, 'state', 'sessions', `${id}.json`),
+          JSON.stringify(makeSession({ id, status: 'running' })),
+        );
+      }
+      state.saveSession(makeSession({ id: 'fresh', status: 'running' }));
+
+      const running = state.listSessions({ status: 'running' });
+      expect(running.map(s => s.id)).toEqual(['fresh']);
+      for (const id of ['g1', 'g2', 'g3', 'g4']) {
+        expect(state.getSession(id)!.supersededBy).toBe('fresh');
+      }
+    });
+
+    it('a stale STARTING record is superseded too', () => {
+      state.saveSession(makeSession({ id: 'stuck', status: 'starting' }));
+      state.saveSession(makeSession({ id: 'new', status: 'running' }));
+      expect(state.getSession('stuck')!.status).toBe('completed');
+      expect(state.getSession('stuck')!.supersededBy).toBe('new');
+    });
+
+    it('re-saving the SAME record (status update / metadata save) never supersedes itself', () => {
+      state.saveSession(makeSession({ id: 'a', status: 'running' }));
+      state.saveSession(makeSession({ id: 'a', status: 'running', model: 'opus' }));
+      const rec = state.getSession('a')!;
+      expect(rec.status).toBe('running');
+      expect(rec.supersededBy).toBeUndefined();
+    });
+
+    it('records for DIFFERENT tmux names are untouched', () => {
+      state.saveSession(makeSession({ id: 'a', status: 'running', tmuxSession: 'tmux-a' }));
+      state.saveSession(makeSession({ id: 'b', status: 'running', tmuxSession: 'tmux-b' }));
+      expect(state.getSession('a')!.status).toBe('running');
+      expect(state.getSession('b')!.status).toBe('running');
+    });
+
+    it('a COMPLETED save never triggers supersession (terminal saves are not registrations)', () => {
+      state.saveSession(makeSession({ id: 'a', status: 'running' }));
+      state.saveSession(makeSession({ id: 'b', status: 'completed' }));
+      expect(state.getSession('a')!.status).toBe('running');
     });
   });
 

--- a/tests/unit/state-manager-listsessions-cache.test.ts
+++ b/tests/unit/state-manager-listsessions-cache.test.ts
@@ -67,9 +67,11 @@ describe('StateManager.listSessions cache', () => {
   });
 
   it('applies the status filter to the cached list', () => {
-    sm.saveSession(mkSession({ id: 'a', status: 'running' }));
-    sm.saveSession(mkSession({ id: 'b', status: 'completed' }));
-    sm.saveSession(mkSession({ id: 'c', status: 'running' }));
+    // Distinct tmux names: two RUNNING records sharing one name would now be
+    // collapsed by the ghost-record supersession invariant (saveSession).
+    sm.saveSession(mkSession({ id: 'a', status: 'running', tmuxSession: 'tmux-a' }));
+    sm.saveSession(mkSession({ id: 'b', status: 'completed', tmuxSession: 'tmux-b' }));
+    sm.saveSession(mkSession({ id: 'c', status: 'running', tmuxSession: 'tmux-c' }));
     expect(sm.listSessions({ status: 'running' }).map(s => s.id).sort()).toEqual(['a', 'c']);
     // second call (cache hit) returns the same filtered result
     expect(sm.listSessions({ status: 'completed' }).map(s => s.id)).toEqual(['b']);

--- a/upgrades/next/session-ghost-records.md
+++ b/upgrades/next/session-ghost-records.md
@@ -1,0 +1,26 @@
+# Upgrade Guide — Session ghost-record supersession (no more duplicate dashboard sessions)
+
+<!-- bump: patch -->
+
+## What Changed
+
+Fixes the registry leak that made the dashboard show N "duplicate sessions" that were really one terminal plus N−1 stale bookkeeping records (2026-06-11 Mac Mini: 5 `running` records all pointing at the single tmux session `echo-resource-limitation-mitigation`, leaked one-per-respawn during the June crisis).
+
+`StateManager.saveSession` — the single funnel every spawn/update callsite passes through — now enforces *one live record per tmux session name*: a record registering as `running`/`starting` supersedes any OTHER record still marked live for the same `tmuxSession` (closed as `completed` with `endedReason: 'superseded'` + new additive `Session.supersededBy` field naming the replacement). Ghosts close through `saveSession` itself, so the coherence journal records each transition. Best-effort + fail-open: hygiene can never block the live registration. Per-machine registries only — a tmux name legitimately reused on another machine collides with nothing. Existing on-disk ghosts self-heal on each name's next respawn.
+
+## What to Tell Your User
+
+- "The dashboard no longer shows duplicate copies of one session — each real terminal appears exactly once. Leftover duplicates from old restarts clean themselves up the next time that session restarts."
+
+## Summary of New Capabilities
+
+| Capability | How to Use |
+|-----------|-----------|
+| One dashboard entry per real terminal | Automatic — no settings, no migration |
+| Ghost forensics | A superseded record carries `supersededBy` (the replacing record's id) + `endedReason: 'superseded'` |
+
+## Evidence
+
+- 6 new unit tests (3 behavior — proven failing on the unfixed code first, including the exact 5-ghost Mac Mini shape — + 3 no-op guards: same-id re-saves, distinct names, terminal saves). One existing fixture updated (it unknowingly relied on two running records sharing one tmux name — the bug shape itself).
+- StateManager test family (7 files, 96 tests) green; full unit suite green; `pnpm build` clean.
+- Independent second-pass review (session-lifecycle adjacency) appended to the side-effects artifact.

--- a/upgrades/side-effects/session-ghost-records.md
+++ b/upgrades/side-effects/session-ghost-records.md
@@ -1,0 +1,79 @@
+# Side-Effects Review — Session ghost-record supersession (one running record per tmux name)
+
+**Version / slug:** `session-ghost-records`
+**Date:** `2026-06-11`
+**Author:** `echo (instar-dev agent)`
+**Second-pass reviewer:** `subagent (session-lifecycle adjacency)` — see appended verdict
+
+## Summary of the change
+
+Closes the registry leak that made the dashboard show N "duplicate sessions" that were really one terminal plus N−1 stale records (live-observed 2026-06-11 on the Mac Mini: 5 `running` records all pointing at the single tmux session `echo-resource-limitation-mitigation`, accumulated across crisis respawns June 5–7). `StateManager.saveSession` — the single funnel all eleven spawn/update callsites already pass through — now enforces the invariant *one live record per tmux session name*: when a record registers as `running`/`starting`, any OTHER record still marked live for the same `tmuxSession` is closed (`status: 'completed'`, `endedReason: 'superseded'`, `supersededBy: <new id>`, `endedAt` stamped), each through `saveSession` itself so the coherence-journal funnel records the transition. New optional `Session.supersededBy` field (additive). Files: `src/core/StateManager.ts`, `src/core/types.ts`, `tests/unit/StateManager.test.ts`, `tests/unit/state-manager-listsessions-cache.test.ts`.
+
+## Decision-point inventory
+
+- `StateManager.saveSession` — modify — registry bookkeeping decision (which records count as live); NOT a process-level authority: it never touches tmux, never kills a process, never blocks a spawn.
+- `supersedeStaleLiveRecords` — add — best-effort hygiene wrapped in try/catch; a failure can never block the live spawn being registered.
+- Spawn/kill/reap authorities (`SessionManager.terminateSession`, reaper, watchdog) — pass-through, untouched.
+
+---
+
+## 1. Over-block
+
+**What legitimate inputs does this change reject that it shouldn't?**
+
+Nothing is rejected — the change never refuses a save. The risk shape is mis-CLASSIFICATION, not blocking: could a genuinely live record be wrongly closed? Only if TWO records claim the same tmux name as live, which the tmux layer makes impossible for real sessions (`tmux new-session` with an existing name fails, and every spawn site creates tmux BEFORE saving the record — a `running` save therefore implies the name was just (re)created, so any older claimant's terminal is gone or replaced). Cross-machine names are out of scope by construction: the registry is per-machine local state, so e.g. `echo-instar-exo` existing on both laptop and Mini collides with nothing.
+
+## 2. Under-block
+
+**What failure modes does this still miss?**
+
+- Ghosts created WITHOUT passing through `saveSession` (a crash after tmux creation but before the save, or hand-written records) are not retro-collapsed until the next live registration for that name. Existing on-disk ghosts on deployed agents collapse on each tmux name's NEXT respawn, not at update time — accepted: a migration sweep was considered and rejected because the next-registration path covers it with zero migration risk, and the dashboard cost of a stale ghost until then is cosmetic.
+- A ghost whose tmux name never spawns again is never superseded (it just ages as a stale `running` record, exactly as today). The reaper's registry-vs-tmux zombie reconciliation remains the owner of that case.
+- **Transitional window on deployed agents** (second-pass finding): until each name's first post-fix registration, pre-existing ghosts are still on disk, and the two find-by-tmuxSession re-save paths (`renameSessionByTmux`, `ModelSwapService`) can `find()` a ghost and re-save it as running — promoting the ghost and superseding the REAL record. Nothing strands (both records point at the same live terminal, and the very re-save collapses the duplicate set to one), id-keyed tracking degrades only until that session's next respawn, and the state is no worse than the pre-fix corruption it inherits. Bounded, transient, self-healing — accepted.
+
+## 3. Level-of-abstraction fit
+
+Correct layer. The invariant is a REGISTRY truth ("at most one live record per tmux name"), so it lives at the registry write funnel — the same single-funnel rationale as the coherence-journal derivation directly below it in the same function. Putting it at the spawn callsites (eleven of them) is the drift-prone shape this codebase explicitly rejects; putting it in the reaper would conflate hygiene-at-write with liveness-policy-at-tick.
+
+## 4. Signal vs authority compliance
+
+**Required reference:** [docs/signal-vs-authority.md](../../docs/signal-vs-authority.md)
+
+- [x] No — this change has no block/allow surface.
+
+Pure data hygiene: it corrects bookkeeping about which record represents a tmux session; it holds no authority over processes, messages, or spawns. The supersession write path is fail-open (try/catch; a hygiene failure never endangers the registration being saved).
+
+## 5. Interactions
+
+- **Reaper / sentinels / monitor loop** (consumers of `listSessions({status:'running'})`): they now see ONE record per live tmux name instead of N duplicates — strictly more accurate input. The reaper's per-id observation maps (`obs`) keyed on ghost ids simply stop being fed; entries age out.
+- **Kill/refresh flows** (account swap, SessionRefresh, fresh-respawn): these kill-then-respawn under the same tmux name; when their kill bookkeeping runs, the old record is already terminal (no supersession fires — terminal saves never enter the path). Supersession only catches the CRASH variants where kill bookkeeping never ran — the exact leak.
+- **Order-of-writes race**: a later save of a just-superseded record (e.g. a swap path stamping the old record `killed` after the new spawn registered) overwrites `completed/superseded` with `killed` — both terminal, both truthful; no flapping (terminal saves trigger nothing).
+- **Journal funnel**: each ghost closes through `saveSession`, so the coherence journal records a real `completed` transition per ghost (reentry terminates: a `completed` save never re-enters supersession). No double-fire: one transition per ghost, once.
+- **listSessions cache**: each supersession save invalidates the cache via the existing path — visible immediately.
+
+## 6. External surfaces
+
+- `GET /sessions` (and the pool-merged `?scope=pool`) stops showing duplicates — the user-visible fix.
+- `Session.supersededBy` + `endedReason: 'superseded'` are additive record fields; no consumer parses an exhaustive `endedReason` enum (it is a free-form string by type).
+- No config, no migration, no template change (Migration Parity: behavior ships in code; existing agents get it with the update; existing ghosts self-heal on next respawn per §2).
+- Multi-machine: per-machine registries; no cross-machine write, no mesh surface.
+
+## 7. Rollback cost
+
+Pure code change: revert and ship a patch. Records already marked `superseded` stay terminal after rollback — correct (they were ghosts; the live terminal's record remains running). No data migration, no state repair.
+
+---
+
+## Conclusion
+
+The review sharpened one decision: ghosts are closed THROUGH `saveSession` (not direct file writes) specifically so the coherence journal sees the transitions — an earlier draft wrote files directly and would have silently skipped journaling. Three behavior tests were proven failing on the unfixed code first (supersede-on-respawn, multi-ghost collapse of the real Mac Mini shape, stale-starting supersession), plus three no-op guards (same-id re-save, different names, terminal saves). Clear to ship.
+
+**Phase 1 principle check (recorded):** registry bookkeeping with no gate/block surface; signal-vs-authority applies as a constraint check only — no brittle logic gains blocking authority.
+
+**Phase 2 plan (recorded):** fresh worktree `.worktrees/fix-session-ghost-records` off `JKHeadley/main` @ `e6c21fa8e` (v1.3.487), identity `Instar Agent (echo) <echo@instar.local>`, canonical remote verified. Rollback: revert (above).
+
+---
+
+## Second-pass review (session-lifecycle adjacency)
+
+**Concur with the review.** Independently verified: (1) all four running-status spawn callsites create tmux inside a throwing try/catch BEFORE `saveSession`, and `tmux new-session` fails on duplicate names — so a running save provably implies the prior claimant's terminal is gone/replaced; supersession can only swap which record represents a terminal, never strand one. (2) Reentry is strict depth-1 (ghost saves are `completed`, skipping the live branch; `id !== next.id` prevents self-supersession). (3) Each ghost emits exactly one `running→completed` journal event; `endedReason` has no enum parser anywhere. (4) Swap/refresh paths kill (terminal save) before respawn — no double-kill; `terminateSession`'s CAS guard means a superseded ghost can no longer be a vector for killing the live terminal — strictly safer than pre-fix. (5) No boot path re-saves running records, so no boot-time wrong-record supersession. One non-blocking transitional-window observation recorded in §2.


### PR DESCRIPTION
## Summary

Fixes the session-registry ghost-record leak (multi-machine gap #1, operator-approved topic 13481): crisis respawns leaked one stale `running` registry record per respawn, and the dashboard rendered each ghost as a separate "duplicate session" — live-observed 2026-06-11 on the Mac Mini as **5 running records all pointing at the single tmux session** `echo-resource-limitation-mitigation`.

**The invariant:** one live record per tmux session name, enforced at `StateManager.saveSession` — the single funnel every spawn/update callsite already passes through (same rationale as the coherence-journal funnel living in the same function). A record registering as `running`/`starting` supersedes any OTHER record still marked live for the same `tmuxSession`: closed as `completed`, `endedReason: 'superseded'`, additive `Session.supersededBy` naming the replacement, `endedAt` stamped. Ghosts close **through `saveSession` itself** so the journal records each transition (reentry is strict depth-1 — terminal saves never re-enter). Fail-open: hygiene can never block the live registration. Per-machine registries only — the same tmux name legitimately existing on two machines collides with nothing. Existing on-disk ghosts self-heal at each name's next respawn.

## Evidence

- 6 new unit tests: 3 behavior tests **proven failing on the unfixed code first** (supersede-on-respawn; the exact 5-ghost Mac Mini collapse; stale-`starting` supersession) + 3 no-op guards (same-id re-save, distinct names, terminal saves). Two existing fixtures updated — they unknowingly relied on two running records sharing one tmux name, i.e. the bug shape itself.
- StateManager family (7 files / 96 tests) green; full unit suite green (exit 0); build + lint clean.
- **Independent second-pass review concurred** (session-lifecycle adjacency): verified all four running-status spawn callsites create tmux inside a throwing try/catch BEFORE saving (a running save provably implies the prior claimant's terminal is gone), depth-1 reentry, exactly one journal event per ghost, no boot path re-saves running records, and the superseded-ghost path is strictly safer than pre-fix for `terminateSession`. One transitional-window observation recorded in the artifact (§2) — bounded, self-healing, accepted.
- Side-effects artifact: `upgrades/side-effects/session-ghost-records.md`.

## ELI16

Your dashboard showed six copies of one session on the Mac Mini — but only ONE terminal was really running. The other five entries were ghosts: every time a session got restarted during the June stability crisis, the system wrote a fresh bookkeeping record for the new terminal but never closed the old record, which kept claiming to be "running" forever. The dashboard faithfully drew every record it found. The fix teaches the bookkeeping a rule the terminals already obey: there can never be two live terminals with the same name on one machine, so the moment a new record registers for a name, any older record still claiming that name is closed out and stamped with a note saying who replaced it. The rule lives in the single doorway every registration already walks through, so no restart path can forget to clean up. It closes paperwork, never programs — and if the cleanup step itself ever fails, the real launch still goes through untouched.
