### PR TITLE
fix(dashboard): render only LIVE remote sessions as pool tiles

### DIFF
--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -4493,7 +4493,13 @@
           if (!r.ok) return;
           const j = await r.json();
           selfMachineNickname = (j.pool && j.pool.selfMachineNickname) || null;
-          remoteSessions = (j.sessions || []).filter(s => s.remote === true);
+          // LIVE remote sessions only: a peer's plain /sessions returns its FULL
+          // registry (completed/killed records included), while the local sidebar
+          // is built from listRunningSessions(). Without this status filter,
+          // long-dead peer sessions render as live "click to stream" tiles
+          // (2026-06-11: five closed Mac Mini sessions reappeared on the laptop
+          // dashboard hours after they were closed).
+          remoteSessions = (j.sessions || []).filter(s => s.remote === true && (s.status === 'running' || s.status === 'starting'));
           renderSessionList();
         } catch { /* best-effort — peers may be offline; next tick retries */ }
       };

--- a/docs/specs/pool-tile-status-filter.eli16.md
+++ b/docs/specs/pool-tile-status-filter.eli16.md
@@ -1,0 +1,21 @@
+# Dead sessions showing up as live tiles — the dashboard filter fix
+
+## What you saw
+
+Hours after five old Mac Mini sessions were closed, they showed up AGAIN on the laptop's dashboard as clickable "running on Mac Mini" tiles. Clicking one would try to stream a terminal that no longer exists.
+
+## Why it happened
+
+The dashboard builds its session list from two sources. For THIS machine, it asks "what's running right now?" and only shows live sessions. But for OTHER machines, it asked for the full history book — every session record the other machine has ever kept, including finished and closed ones — and drew a live-looking tile for each. So closed sessions on the Mini kept appearing on the laptop as if they were running.
+
+## The fix
+
+One line: when drawing tiles for another machine's sessions, only draw the ones whose records actually say "running" (or "starting"), exactly the same rule the local list has always used. The behind-the-scenes data is untouched — the full history is still there for anything that needs it; it just doesn't masquerade as live anymore.
+
+## How this relates to the other duplicate-session fix
+
+Two layers of the same symptom, fixed separately: one fix (the ghost-record one) makes sure old records stop CLAIMING to be running; this fix makes sure the dashboard only DRAWS records that claim to be running. Either alone closes most of it; together the dashboard simply tells the truth.
+
+## What you'll notice
+
+The dashboard shows only genuinely live sessions for every machine. Nothing to configure.

--- a/tests/unit/dashboard-poolTileStatusFilter.test.ts
+++ b/tests/unit/dashboard-poolTileStatusFilter.test.ts
@@ -1,0 +1,33 @@
+/**
+ * Pool-tile status filter (2026-06-11 live finding, topic 13481): a peer's
+ * plain GET /sessions returns its FULL registry — completed/killed records
+ * included — while the local sidebar is built from listRunningSessions().
+ * The dashboard's pool poll must therefore filter remote sessions to LIVE
+ * statuses, or long-dead peer sessions render as live "click to stream"
+ * tiles (five closed Mac Mini sessions reappeared on the laptop dashboard
+ * hours after they were closed). Inspects the HTML/JS at rest (no browser),
+ * following the dashboard-sessionMachineBadge.test.ts pattern.
+ */
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const html = fs.readFileSync(path.join(__dirname, '..', '..', 'dashboard', 'index.html'), 'utf-8');
+
+describe('dashboard pool poll — remote tile status filter', () => {
+  it('filters remote sessions to live statuses (running/starting), never raw remote===true alone', () => {
+    // The assignment that feeds renderSessionList's remote tiles.
+    const assign = html.match(/remoteSessions\s*=\s*\(j\.sessions[^;]+;/);
+    expect(assign, 'remoteSessions assignment not found — pool poll restructured? update this test').toBeTruthy();
+    const expr = assign![0];
+    expect(expr).toContain("s.remote === true");
+    expect(expr).toContain("s.status === 'running'");
+    expect(expr).toContain("s.status === 'starting'");
+  });
+
+  it('the unfiltered shape (remote===true with no status check) is gone', () => {
+    expect(html).not.toMatch(/remoteSessions\s*=\s*\(j\.sessions \|\| \[\]\)\.filter\(s => s\.remote === true\);/);
+  });
+});

--- a/tests/unit/dashboard-sessionMachineBadge.test.ts
+++ b/tests/unit/dashboard-sessionMachineBadge.test.ts
@@ -26,7 +26,9 @@ describe('dashboard: sessions list — machine badges + pool-wide visibility', (
 
   it('keeps remote sessions separate from the WebSocket-replaced local array', () => {
     expect(HTML).toContain('let remoteSessions = []');
-    expect(HTML).toMatch(/remoteSessions = \(j\.sessions \|\| \[\]\)\.filter\(s => s\.remote === true\)/);
+    // The remote merge also status-filters to LIVE sessions (running/starting) —
+    // see dashboard-poolTileStatusFilter.test.ts for the dedicated assertions.
+    expect(HTML).toMatch(/remoteSessions = \(j\.sessions \|\| \[\]\)\.filter\(s => s\.remote === true && /);
   });
 
   it('renders a machine badge stating where the session runs (XSS-escaped)', () => {

--- a/upgrades/next/pool-tile-status-filter.md
+++ b/upgrades/next/pool-tile-status-filter.md
@@ -1,0 +1,22 @@
+# Upgrade Guide — Pool dashboard tiles: live remote sessions only
+
+<!-- bump: patch -->
+
+## What Changed
+
+The dashboard's pool poll rendered EVERY record a peer's `GET /sessions` returned — including completed/killed registry records — as live "click to stream" tiles, while local tiles come from `listRunningSessions()` (2026-06-11: five closed Mac Mini sessions reappeared on the laptop dashboard hours after closure). The remote merge in `dashboard/index.html` now filters to `running`/`starting`, matching the local sidebar's definition of live. API unchanged (the pool response remains a faithful full-registry view). Complements the registry-side ghost-record supersession fix — together: records stop claiming to be running, and the dashboard only draws records that claim to be running.
+
+## What to Tell Your User
+
+- "The dashboard now only shows sessions that are actually running on each machine — closed sessions on another machine no longer reappear as clickable tiles."
+
+## Summary of New Capabilities
+
+| Capability | How to Use |
+|-----------|-----------|
+| Truthful remote session tiles | Automatic |
+
+## Evidence
+
+- New source-assert test `tests/unit/dashboard-poolTileStatusFilter.test.ts` (established at-rest inspection pattern), proven failing on the unfixed HTML first (2/2 fail → 2/2 pass).
+- Side-effects artifact: `upgrades/side-effects/pool-tile-status-filter.md`.

--- a/upgrades/side-effects/pool-tile-status-filter.md
+++ b/upgrades/side-effects/pool-tile-status-filter.md
@@ -1,0 +1,46 @@
+# Side-Effects Review — Pool dashboard tiles: filter remote sessions to live statuses
+
+**Version / slug:** `pool-tile-status-filter`
+**Date:** `2026-06-11`
+**Author:** `echo (instar-dev agent)`
+**Second-pass reviewer:** `not required` (one-line client-side display filter; no lifecycle, no gates, no messaging surface)
+
+## Summary of the change
+
+The dashboard's pool poll fed `renderSessionList` every record a peer's plain `GET /sessions` returned — and that endpoint returns the peer's FULL registry, completed/killed records included — while local tiles are built from `listRunningSessions()` (running only). Result, observed live 2026-06-11 (topic 13481): five Mac Mini sessions closed hours earlier reappeared on the laptop dashboard as live "click to stream" tiles. One-line fix in `dashboard/index.html`: the remote merge now filters to `status === 'running' || status === 'starting'`, matching the local sidebar's definition of "live". New source-assert test (`tests/unit/dashboard-poolTileStatusFilter.test.ts`, following the established `dashboard-sessionMachineBadge.test.ts` at-rest inspection pattern) proven failing on the unfixed HTML first.
+
+## Decision-point inventory
+
+No decision points. A client-side display filter; the API response is unchanged and remains faithful (full registry, accurate statuses).
+
+---
+
+## 1. Over-block
+A peer session in a transient status other than running/starting would be hidden — the only other statuses are terminal (`completed`/`failed`/`killed`), which is exactly what should be hidden. No issue identified.
+
+## 2. Under-block
+A peer whose registry wrongly marks a dead session `running` still renders a tile — that is the upstream ghost-record problem, fixed separately at the registry funnel (PR #1067); the two fixes are complementary layers, not overlap.
+
+## 3. Level-of-abstraction fit
+Correct layer: the SERVER's pool response stays a faithful full-registry view (other consumers may legitimately want terminal records, e.g. forensics); "which records are live tiles" is a display decision, made where display happens, identically to how local tiles already decide it.
+
+## 4. Signal vs authority compliance
+- [x] No — this change has no block/allow surface. (Display filtering only.)
+
+## 5. Interactions
+The remote-tile click path, machine badges, row namespacing, and stream subscriptions all operate on the filtered set — strictly fewer dead tiles to mis-click. The 15s pool poll cadence is unchanged. No shadowing/double-fire/races (pure pure-function filter on a fetch result).
+
+## 6. External surfaces
+`dashboard/index.html` ships in the npm package and replaces wholesale on update; no API change, no config, no migration. Mixed-version: an updated dashboard against any peer version works (the filter only reads fields every version already returns).
+
+## 7. Rollback cost
+Revert the one line, ship a patch. No state, no migration. Symptom during rollback window: dead peer tiles reappear (cosmetic).
+
+---
+
+## Conclusion
+
+Minimal display-truthfulness fix; the registry-side ghost cleanup (PR #1067) and this filter together close both layers of the "dead sessions on the dashboard" symptom: records that should not say running, and tiles that should not render non-running records. Clear to ship.
+
+**Phase 1 principle check (recorded):** no decision point — display filter.
+**Phase 2 plan (recorded):** fresh worktree `.worktrees/fix-pool-tile-status-filter` off `JKHeadley/main` @ `e6c21fa8e` (v1.3.487), agent identity set, canonical remote verified. Rollback: revert (above).


### PR DESCRIPTION
## Summary

One-line dashboard truthfulness fix (multi-machine gap #5, found live 2026-06-11 topic 13481): the pool poll rendered EVERY record a peer's plain `GET /sessions` returned — the peer's FULL registry, completed/killed records included — as live "click to stream" tiles, while local tiles are built from `listRunningSessions()`. Five Mac Mini sessions closed hours earlier reappeared on the laptop dashboard as clickable live tiles.

The remote merge in `dashboard/index.html` now filters to `status === 'running' || status === 'starting'` — the local sidebar's existing definition of "live". The API is unchanged (the pool response remains a faithful full-registry view for consumers that want terminal records). Complements #1067 (registry-side ghost-record supersession): records stop wrongly CLAIMING to be running, and the dashboard only DRAWS records that claim to be running — the two layers of the duplicate/dead-session symptom.

## Evidence

- New source-assert test `tests/unit/dashboard-poolTileStatusFilter.test.ts` (the established `dashboard-sessionMachineBadge.test.ts` at-rest inspection pattern): proven failing on the unfixed HTML first (2/2 fail → 2/2 pass with the fix).
- Side-effects artifact: `upgrades/side-effects/pool-tile-status-filter.md` (no decision points; display filter only).

## ELI16

Your dashboard builds its session list from two sources. For the machine you're on, it asks "what's running right now?" and shows only live sessions. But for your OTHER machines, it was asking for the full history book — every session record ever kept, including closed ones — and drawing a live-looking clickable tile for each. That's why sessions closed on the Mac Mini hours earlier kept showing up on the laptop as if they were still running. The fix is one line: when drawing another machine's sessions, only draw the ones whose records actually say "running," exactly the rule the local list already uses. The underlying data isn't touched — finished sessions are still recorded for history — they just don't masquerade as alive anymore.
