### PR TITLE
fix(slack): epoch + socket-identity guards stop the reconnect websocket leak (#1076)

### DIFF
--- a/.instar/instar-dev-decisions/2026-06-12T19-45-32-973Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-06-12T19-45-32-973Z-unknown.json
@@ -1,0 +1,13 @@
+{
+  "ts": "2026-06-12T19:45:32.973Z",
+  "slug": "unknown",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 117,
+  "causalAutopsy": null,
+  "verdict": "pass"
+}

--- a/docs/specs/socketmode-ws-leak-fix.eli16.md
+++ b/docs/specs/socketmode-ws-leak-fix.eli16.md
@@ -1,0 +1,34 @@
+# Slack connection storms after laptop sleep — the websocket leak fix
+
+## What you saw
+
+On 2026-06-12 the echo agent's Slack connection went into a silent storm: Slack kicked it off 5,075 times in 73 minutes (~70 times a minute) with the reason "too many websockets," while Slack's API rate-limited the reconnect calls. Messages mostly still flowed between churns, so nobody noticed for over an hour. Only a full server restart cleared it.
+
+## Why it happened
+
+The agent holds one live "phone line" (a websocket) to Slack. After the laptop sleeps and wakes, the agent deliberately hangs up and redials — that part is correct. The bug: when you hang up a websocket, the "line is now closed" notification arrives a moment LATER, not instantly. The old code tried to handle that with a synchronous flag — set a "don't react" flag, hang up, clear the flag — but because the notification arrives after the flag is already cleared, the protection never actually protected anything.
+
+So every redial went like this: hang up the old line, dial a new one... then the OLD line's late "closed!" notification arrives, and the code — thinking the CURRENT line just died — throws away its handle to the NEW line (which stays open, now untracked) and dials a THIRD one. Each sleep/wake leaked one live, invisible connection. Slack allows about 10 per app. The laptop registered 33 wake events that day — short 10-second naps every few minutes each count — so the cap blew within two hours, and from then on every redial was immediately rejected with "too many websockets," forever, until a restart dropped all the leaked lines at once.
+
+A second, rarer race made it worse: if a retry timer was already sleeping when an explicit redial came in, the timer would later wake up and dial yet another line on top of the one the redial had just opened.
+
+## The fix
+
+Two structural changes inside the Slack socket client, no behavior changes anywhere else:
+
+1. **Each line knows whether it's still "the" line.** Every notification handler is bound to its own specific socket and first checks "am I still the connection the client is tracking?" A late "closed!" from an already-replaced line is recognized as stale and ignored — it can no longer orphan the new line or trigger an extra dial.
+2. **An epoch counter supersedes in-flight work.** Every deliberate hang-up bumps a counter; any sleeping retry timer or in-progress dial remembers the counter from when it started and quietly stands down if it changed. Two dialing paths can never run to completion on top of each other.
+
+The net invariant: the client tracks at most ONE live connection, ever, no matter how reconnect triggers interleave.
+
+## What proved it
+
+Five behavioral tests with a fake Slack websocket reproduce the exact failure first (three failed on the old code — one path opened FOUR connections), then pass on the fix: the late-close leak, the stale-retry race, the "too many websockets" handling, plus regression guards proving normal disconnects still reconnect and a deliberate shutdown stays shut down.
+
+## What you'll notice
+
+Nothing — that's the point. Sleep/wake cycles no longer accumulate leaked Slack connections, so the storms (and the rate-limiting, and the restart-to-fix ritual) are gone. No configuration, no API change, no migration.
+
+## What this does NOT fix
+
+The wake detector itself fires on ~10-second gaps every few minutes (453 wake events in one day), which makes the agent redial Slack and restart its tunnel far more often than real sleeps justify. With the leak fixed those redials are now harmless, but the trigger-happiness is a separate issue tracked in JKHeadley/instar#1077.

--- a/src/messaging/slack/SocketModeClient.ts
+++ b/src/messaging/slack/SocketModeClient.ts
@@ -43,6 +43,12 @@ export class SocketModeClient {
   private ws: WebSocket | null = null;
   private started = false;
   private reconnecting = false;
+  // Bumped on every deliberate teardown (disconnect / reconnect / forced /
+  // Slack-requested). In-flight async work (an awaited apps.connections.open,
+  // a sleeping backoff, a delayed too_many_websockets retry) captures the
+  // epoch when it starts and aborts if it changed — a superseded path can
+  // never open a connection the client no longer tracks (#1076).
+  private epoch = 0;
   private consecutiveErrors = 0;
   private heartbeatTimer: ReturnType<typeof setTimeout> | null = null;
   private lastEventAt = 0;
@@ -59,35 +65,46 @@ export class SocketModeClient {
   }
 
   async connect(): Promise<void> {
+    // Defensive: connect() on an already-live client is a reconnect. Without
+    // this, a failing dial here would arm a backoff sleeper while the old
+    // socket + heartbeat stay live, and the heartbeat's _forceReconnect would
+    // then skip dialing (reconnecting=true) while the sleeper stands down on
+    // epoch mismatch — no path left to re-dial.
+    if (this.ws) this._teardownSocket(1000, 'superseded by connect()');
     this.started = true;
     await this._openConnection();
   }
 
   async disconnect(): Promise<void> {
     this.started = false;
-    this._clearHeartbeat();
-    if (this.ws) {
-      this.ws.close(1000, 'client disconnect');
-      this.ws = null;
-    }
+    this._teardownSocket(1000, 'client disconnect');
   }
 
   /** Force-reconnect: tear down existing connection and establish a new one. */
   async reconnect(): Promise<void> {
-    this._clearHeartbeat();
     this.reconnecting = false;
     this.consecutiveErrors = 0;
-    if (this.ws) {
-      // Temporarily clear started to prevent the close handler from
-      // triggering its own reconnect (we're already handling it).
-      const wasStarted = this.started;
-      this.started = false;
-      try { this.ws.close(1000, 'reconnect'); } catch { /* ok */ }
-      this.ws = null;
-      this.started = wasStarted;
-    }
+    this._teardownSocket(1000, 'reconnect');
     this.started = true;
     await this._openConnection();
+  }
+
+  /**
+   * Deliberately tear down the tracked socket. Bumps the epoch (so any
+   * in-flight open/backoff aborts) and nulls `this.ws` BEFORE closing — the
+   * socket's close event fires on a later tick, and the identity guard in the
+   * close handler (`this.ws !== sock`) is what keeps that stale event from
+   * touching whatever connection is current by then. A synchronous flag
+   * save/restore cannot do this (#1076).
+   */
+  private _teardownSocket(code?: number, reason?: string): void {
+    this.epoch++;
+    this._clearHeartbeat();
+    const sock = this.ws;
+    this.ws = null;
+    if (sock) {
+      try { sock.close(code, reason); } catch { /* already dead */ }
+    }
   }
 
   /** Queue an outbound message for sending (or send immediately if connected). */
@@ -103,6 +120,7 @@ export class SocketModeClient {
   }
 
   private async _openConnection(): Promise<void> {
+    const myEpoch = this.epoch;
     try {
       const response = await this.apiClient.call(
         'apps.connections.open',
@@ -110,11 +128,16 @@ export class SocketModeClient {
         { useAppToken: true },
       ) as unknown as SocketModeConnectionInfo;
 
+      if (myEpoch !== this.epoch) return; // superseded while awaiting the API
+
       if (!response.url) {
         throw new Error('No WebSocket URL in apps.connections.open response');
       }
 
       this.connectionTime = response.approximate_connection_time ?? null;
+      // Invariant: at most one tracked socket. If something is still here,
+      // tear it down before replacing it rather than silently orphaning it.
+      if (this.ws) this._teardownSocket(1000, 'superseded');
       this._connectWebSocket(response.url);
       this.consecutiveErrors = 0;
     } catch (err) {
@@ -124,38 +147,52 @@ export class SocketModeClient {
         return;
       }
       this.handlers.onError(err as Error, false);
-      if (this.started) {
+      if (this.started && myEpoch === this.epoch) {
         await this._backoffReconnect();
       }
     }
   }
 
   private _connectWebSocket(url: string): void {
-    this.ws = new WebSocket(url);
+    // Handlers are bound to THIS socket instance, not to `this.ws` — close
+    // (and open/message) events fire on a later tick, by which time the
+    // tracked socket may already be a replacement. Events from a socket that
+    // is no longer current are stale and must be ignored, otherwise a late
+    // close orphans the live replacement and double-reconnects (#1076).
+    const sock = new WebSocket(url);
+    this.ws = sock;
 
-    this.ws.addEventListener('open', () => {
+    sock.addEventListener('open', () => {
+      if (this.ws !== sock) return; // stale socket — replaced while connecting
       this.lastEventAt = Date.now();
       this._startHeartbeat();
       this._drainQueue();
       this.handlers.onConnected();
     });
 
-    this.ws.addEventListener('message', (event: MessageEvent) => {
+    sock.addEventListener('message', (event: MessageEvent) => {
+      if (this.ws !== sock) return; // stale socket — never ack/process on it
       this.lastEventAt = Date.now();
       this._handleRawMessage(typeof event.data === 'string' ? event.data : String(event.data));
     });
 
-    this.ws.addEventListener('close', (event: Event & { reason?: string; code?: number }) => {
+    sock.addEventListener('close', (event: Event & { reason?: string; code?: number }) => {
+      if (this.ws !== sock) return; // stale socket — its teardown already ran
+      // A natural close deliberately does NOT bump the epoch: if a backoff
+      // sleeper is already in flight, the call below returns early
+      // (reconnecting=true) and that sleeper must stay valid to perform the
+      // re-dial — bumping here would strand the only reconnect path.
       this._clearHeartbeat();
       this.ws = null;
       this.handlers.onDisconnected(event.reason || 'connection closed');
       if (this.started) {
+        const myEpoch = this.epoch;
         this._backoffReconnect().catch((err) => {
           console.error('[slack-socket] Reconnect failed:', (err as Error).message);
           // Schedule one more attempt after MAX_BACKOFF to avoid permanent death
           if (this.started) {
             setTimeout(() => {
-              if (this.started && !this.reconnecting) {
+              if (this.started && !this.reconnecting && this.epoch === myEpoch) {
                 this._backoffReconnect().catch(() => {});
               }
             }, MAX_BACKOFF_MS);
@@ -164,7 +201,7 @@ export class SocketModeClient {
       }
     });
 
-    this.ws.addEventListener('error', () => {
+    sock.addEventListener('error', () => {
       // Error event is always followed by close event — handle reconnection there
     });
   }
@@ -221,18 +258,13 @@ export class SocketModeClient {
   }
 
   private _handleDisconnect(reason: string): void {
-    this._clearHeartbeat();
-    // Prevent close event handler from triggering a second reconnect
-    const wasStarted = this.started;
-    this.started = false;
-    if (this.ws) {
-      this.ws.close();
-      this.ws = null;
-    }
-    this.started = wasStarted;
+    // Deliberate teardown — bumps the epoch, so the socket's late close event
+    // (identity-guarded) and any in-flight open/backoff are all superseded.
+    this._teardownSocket(1000, reason);
     this.handlers.onDisconnected(reason);
 
     if (!this.started) return;
+    const myEpoch = this.epoch;
 
     if (reason === 'refresh_requested') {
       // Slack container rotation — reconnect immediately
@@ -240,7 +272,7 @@ export class SocketModeClient {
     } else if (reason === 'too_many_websockets') {
       // Wait 30s before reconnecting
       setTimeout(() => {
-        if (this.started) this._openConnection();
+        if (this.started && this.epoch === myEpoch) this._openConnection();
       }, TOO_MANY_WS_DELAY_MS);
     } else {
       this._backoffReconnect();
@@ -249,6 +281,7 @@ export class SocketModeClient {
 
   private async _backoffReconnect(): Promise<void> {
     if (this.reconnecting || !this.started) return;
+    const myEpoch = this.epoch;
     this.reconnecting = true;
     this.consecutiveErrors++;
 
@@ -257,7 +290,9 @@ export class SocketModeClient {
     await new Promise(r => setTimeout(r, delay));
 
     this.reconnecting = false;
-    if (this.started) {
+    // An explicit reconnect()/disconnect() may have superseded this sleeper —
+    // opening here anyway would create a second, untracked connection (#1076).
+    if (this.started && this.epoch === myEpoch) {
       await this._openConnection();
     }
   }
@@ -296,17 +331,9 @@ export class SocketModeClient {
   }
 
   private _forceReconnect(): void {
-    this._clearHeartbeat();
-    if (this.ws) {
-      // Temporarily clear started to prevent the close handler from
-      // triggering its own reconnect (same pattern as reconnect()).
-      const wasStarted = this.started;
-      this.started = false;
-      try { this.ws.close(); } catch { /* ok */ }
-      this.ws = null;
-      this.started = wasStarted;
-    }
-    // Trigger reconnect directly instead of relying on close event
+    this._teardownSocket(1000, 'force reconnect');
+    // Trigger reconnect directly instead of relying on close event — the
+    // torn-down socket's close is identity-guarded and will be ignored.
     if (this.started && !this.reconnecting) {
       this._backoffReconnect().catch(() => {});
     }

--- a/tests/unit/slack-socket-heartbeat.test.ts
+++ b/tests/unit/slack-socket-heartbeat.test.ts
@@ -70,14 +70,14 @@ describe('_forceReconnect method', () => {
     expect(socketClientSource).toMatch(/_forceReconnect\(\)[\s\S]*?_clearHeartbeat\(\)/);
   });
 
-  it('temporarily clears started to prevent close handler race condition', () => {
-    // Same pattern as reconnect(): prevents the old ws close event from
-    // triggering a second reconnect that would clobber the new connection
-    expect(socketClientSource).toMatch(/_forceReconnect\(\)[\s\S]*?wasStarted = this\.started[\s\S]*?this\.started = false[\s\S]*?ws\.close\(\)/);
+  it('tears down via the epoch-bumping teardown (stale close events are identity-guarded)', () => {
+    // Same pattern as reconnect(): the old ws close event must not be able to
+    // orphan the new connection or trigger a second reconnect (#1076).
+    expect(socketClientSource).toMatch(/_forceReconnect\(\)[\s\S]*?this\._teardownSocket\(/);
   });
 
   it('closes the websocket', () => {
-    expect(socketClientSource).toMatch(/_forceReconnect\(\)[\s\S]*?this\.ws\.close\(\)/);
+    expect(socketClientSource).toMatch(/_teardownSocket\([\s\S]*?sock\.close\(/);
   });
 
   it('triggers _backoffReconnect if still started', () => {

--- a/tests/unit/slack-socket-leak.test.ts
+++ b/tests/unit/slack-socket-leak.test.ts
@@ -1,0 +1,227 @@
+/**
+ * SocketModeClient connection-leak tests (JKHeadley/instar#1076) — verifies that:
+ * 1. A late close event from a replaced socket cannot orphan the new connection
+ *    or trigger an extra reconnect (the sleep/wake leak).
+ * 2. An in-flight backoff sleeper superseded by an explicit reconnect() does
+ *    not open a second, untracked connection.
+ * 3. A Slack-initiated `too_many_websockets` disconnect reconnects exactly
+ *    once, after the mandated delay — a stale close event can't add another.
+ * 4. A natural unsolicited close still reconnects (regression guard).
+ *
+ * Root cause: WebSocket close events fire on a later tick. The old
+ * "temporarily clear `started`" save/restore was synchronous, so by the time
+ * the old socket's close handler ran, `started` was restored and `this.ws`
+ * pointed at the replacement socket. The handler then nulled `this.ws`
+ * (orphaning the replacement — it stayed OPEN, untracked, counting against
+ * Slack's ~10-connection Socket Mode cap) and fired another reconnect.
+ * Every sleep/wake reconnect leaked one live websocket; after ~10 wakes the
+ * cap was hit and the client churned with too_many_websockets forever
+ * (observed live: 5,075 disconnects in 73 minutes, ~70/min).
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { SocketModeClient, type SocketModeHandlers } from '../../src/messaging/slack/SocketModeClient.js';
+
+class FakeWebSocket {
+  static CONNECTING = 0;
+  static OPEN = 1;
+  static CLOSING = 2;
+  static CLOSED = 3;
+  static instances: FakeWebSocket[] = [];
+
+  url: string;
+  readyState = FakeWebSocket.CONNECTING;
+  closeCalls: Array<{ code?: number; reason?: string }> = [];
+  private listeners: Record<string, Array<(ev: unknown) => void>> = {};
+
+  constructor(url: string) {
+    this.url = url;
+    FakeWebSocket.instances.push(this);
+  }
+
+  addEventListener(type: string, fn: (ev: unknown) => void): void {
+    (this.listeners[type] ??= []).push(fn);
+  }
+
+  send(_data: string): void {
+    if (this.readyState !== FakeWebSocket.OPEN) throw new Error('not open');
+  }
+
+  // Like the real thing, close() transitions state but the close EVENT fires
+  // on a later tick — tests fire it explicitly to simulate that async gap.
+  close(code?: number, reason?: string): void {
+    this.closeCalls.push({ code, reason });
+    this.readyState = FakeWebSocket.CLOSING;
+  }
+
+  fire(type: string, ev: Record<string, unknown> = {}): void {
+    for (const fn of this.listeners[type] ?? []) fn(ev);
+  }
+
+  fireOpen(): void {
+    this.readyState = FakeWebSocket.OPEN;
+    this.fire('open');
+  }
+
+  fireClose(reason = 'connection closed'): void {
+    this.readyState = FakeWebSocket.CLOSED;
+    this.fire('close', { reason, code: 1000 });
+  }
+}
+
+function makeHandlers(): SocketModeHandlers {
+  return {
+    onEvent: vi.fn(async () => {}),
+    onInteraction: vi.fn(async () => {}),
+    onConnected: vi.fn(),
+    onDisconnected: vi.fn(),
+    onError: vi.fn(),
+  };
+}
+
+function makeApi(): { call: ReturnType<typeof vi.fn> } {
+  let n = 0;
+  return {
+    call: vi.fn(async () => ({ ok: true, url: `wss://fake.slack/${++n}` })),
+  };
+}
+
+function trackedWs(client: SocketModeClient): FakeWebSocket | null {
+  return (client as unknown as { ws: FakeWebSocket | null }).ws;
+}
+
+async function handleRaw(client: SocketModeClient, raw: string): Promise<void> {
+  await (client as unknown as { _handleRawMessage(raw: string): Promise<void> })._handleRawMessage(raw);
+}
+
+const realWebSocket = globalThis.WebSocket;
+
+describe('SocketModeClient connection leak (#1076)', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    FakeWebSocket.instances = [];
+    // The client resolves WebSocket from the global at construction time of
+    // each socket, so swapping the global is enough.
+    (globalThis as Record<string, unknown>).WebSocket = FakeWebSocket;
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    (globalThis as Record<string, unknown>).WebSocket = realWebSocket;
+  });
+
+  it('a late close event from the replaced socket does not orphan the new connection or open another', async () => {
+    const api = makeApi();
+    const client = new SocketModeClient(api as never, makeHandlers());
+
+    await client.connect();
+    const a = FakeWebSocket.instances[0];
+    a.fireOpen();
+
+    await client.reconnect(); // e.g. the SleepWake handler after a wake
+    expect(FakeWebSocket.instances.length).toBe(2);
+    const b = FakeWebSocket.instances[1];
+    b.fireOpen();
+    expect(api.call).toHaveBeenCalledTimes(2);
+    expect(a.closeCalls.length).toBe(1); // old socket genuinely closed
+
+    // The old socket's close event arrives on a later tick — the bug's trigger.
+    a.fireClose('reconnect');
+    await vi.advanceTimersByTimeAsync(120_000);
+
+    // No third connection may be opened, and the replacement must stay tracked.
+    expect(api.call).toHaveBeenCalledTimes(2);
+    expect(FakeWebSocket.instances.length).toBe(2);
+    expect(trackedWs(client)).toBe(b);
+    expect(b.closeCalls.length).toBe(0);
+  });
+
+  it('an in-flight backoff superseded by reconnect() does not open a second connection', async () => {
+    const api = makeApi();
+    let failFirst = true;
+    api.call.mockImplementation(async () => {
+      if (failFirst) {
+        failFirst = false;
+        throw new Error('network not ready');
+      }
+      return { ok: true, url: 'wss://fake.slack/ok' };
+    });
+    const client = new SocketModeClient(api as never, makeHandlers());
+
+    // First open fails → a backoff sleeper is now armed (1s).
+    const connectPromise = client.connect();
+    await vi.advanceTimersByTimeAsync(0);
+
+    // An explicit reconnect lands while the sleeper is still in flight.
+    await client.reconnect();
+    const b = FakeWebSocket.instances[0];
+    b.fireOpen();
+    expect(api.call).toHaveBeenCalledTimes(2);
+
+    // The stale sleeper wakes — it must NOT open a third connection.
+    await vi.advanceTimersByTimeAsync(120_000);
+    await connectPromise;
+
+    expect(api.call).toHaveBeenCalledTimes(2);
+    expect(FakeWebSocket.instances.length).toBe(1);
+    expect(trackedWs(client)).toBe(b);
+    expect(b.closeCalls.length).toBe(0);
+  });
+
+  it('too_many_websockets reconnects exactly once after the delay; the stale close adds nothing', async () => {
+    const api = makeApi();
+    const client = new SocketModeClient(api as never, makeHandlers());
+
+    await client.connect();
+    const a = FakeWebSocket.instances[0];
+    a.fireOpen();
+    expect(api.call).toHaveBeenCalledTimes(1);
+
+    // Slack tells us to back off via a disconnect envelope.
+    await handleRaw(client, JSON.stringify({ type: 'disconnect', payload: { reason: 'too_many_websockets' } }));
+    // The torn-down socket's close event arrives late.
+    a.fireClose('too_many_websockets');
+
+    // Inside the 30s mandated delay nothing may reconnect — including via the stale close.
+    await vi.advanceTimersByTimeAsync(29_000);
+    expect(api.call).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(2_000);
+    expect(api.call).toHaveBeenCalledTimes(2);
+    expect(FakeWebSocket.instances.length).toBe(2);
+  });
+
+  it('a natural unsolicited close still reconnects (regression guard)', async () => {
+    const api = makeApi();
+    const client = new SocketModeClient(api as never, makeHandlers());
+
+    await client.connect();
+    const a = FakeWebSocket.instances[0];
+    a.fireOpen();
+
+    // Slack drops the connection without warning — the close IS current.
+    a.fireClose('connection closed');
+    await vi.advanceTimersByTimeAsync(120_000);
+
+    expect(api.call).toHaveBeenCalledTimes(2);
+    expect(FakeWebSocket.instances.length).toBe(2);
+    expect(trackedWs(client)).toBe(FakeWebSocket.instances[1]);
+  });
+
+  it('disconnect() stops everything — a late close event triggers no reconnect', async () => {
+    const api = makeApi();
+    const client = new SocketModeClient(api as never, makeHandlers());
+
+    await client.connect();
+    const a = FakeWebSocket.instances[0];
+    a.fireOpen();
+
+    await client.disconnect();
+    a.fireClose('client disconnect');
+    await vi.advanceTimersByTimeAsync(120_000);
+
+    expect(api.call).toHaveBeenCalledTimes(1);
+    expect(FakeWebSocket.instances.length).toBe(1);
+    expect(trackedWs(client)).toBe(null);
+  });
+});

--- a/tests/unit/slack-socket-reconnect.test.ts
+++ b/tests/unit/slack-socket-reconnect.test.ts
@@ -55,11 +55,15 @@ describe('SocketModeClient reconnection', () => {
     expect(socketClientSource).toMatch(/reconnect\(\)[\s\S]*?this\.started = true[\s\S]*?this\._openConnection/);
   });
 
-  it('reconnect() temporarily clears started to prevent double-reconnect from close handler', () => {
-    // The reconnect method should set started=false before closing the old ws,
-    // then restore it — preventing the close event handler from triggering
-    // its own _backoffReconnect() simultaneously.
-    expect(socketClientSource).toMatch(/reconnect\(\)[\s\S]*?this\.started = false[\s\S]*?this\.ws\.close/);
+  it('reconnect() tears down via the epoch-bumping teardown (stale close events are identity-guarded)', () => {
+    // The old "temporarily clear started" save/restore was synchronous, but
+    // close events fire on a later tick — it never actually suppressed the
+    // stale handler and leaked one live websocket per reconnect (#1076).
+    // The teardown must bump the epoch and null this.ws BEFORE closing, and
+    // the close handler must ignore sockets that are no longer current.
+    expect(socketClientSource).toMatch(/reconnect\(\)[\s\S]*?this\._teardownSocket\(/);
+    expect(socketClientSource).toMatch(/_teardownSocket\([\s\S]*?this\.epoch\+\+/);
+    expect(socketClientSource).toMatch(/addEventListener\('close'[\s\S]*?if \(this\.ws !== sock\) return/);
   });
 });
 

--- a/upgrades/next/socketmode-ws-leak-fix.md
+++ b/upgrades/next/socketmode-ws-leak-fix.md
@@ -1,0 +1,26 @@
+# Upgrade Guide — Slack Socket Mode: no more leaked websockets after sleep/wake
+
+<!-- bump: patch -->
+
+## What Changed
+
+`SocketModeClient` leaked one live websocket on every deliberate `reconnect()` (JKHeadley/instar#1076). The old "temporarily clear `started`" save/restore was synchronous, but websocket close events fire on a later tick — by the time the old socket's close handler ran, the flag was restored and `this.ws` pointed at the freshly-opened replacement. The stale handler nulled `this.ws` (orphaning the replacement: still OPEN, untracked, counting against Slack's ~10-connection Socket Mode cap) and fired another reconnect. The SleepWake handler calls `reconnect()` on every wake, so after ~10 wakes the cap blew and the client churned with `too_many_websockets` permanently (observed live 2026-06-12: 5,075 disconnects in 73 minutes, plus sustained `apps.connections.open` rate-limiting; only a server restart cleared it). A second race let a sleeping backoff retry open a connection on top of one an explicit `reconnect()` had just opened.
+
+The fix is structural, confined to `src/messaging/slack/SocketModeClient.ts`: (1) every socket's event handlers are closure-bound to that socket and ignore events when it is no longer the tracked connection (`this.ws !== sock`); (2) a connection epoch is bumped on every deliberate teardown, and every in-flight async path (awaited `apps.connections.open`, sleeping backoff, delayed `too_many_websockets` retry) captures the epoch at start and stands down if superseded. Invariant: at most one tracked, live connection regardless of how reconnect triggers interleave. The wake-detector trigger-happiness that amplified this (453 wake events/day on ~10s gaps) is tracked separately in JKHeadley/instar#1077.
+
+## What to Tell Your User
+
+- "Fixed a bug where laptop sleep/wake cycles slowly leaked Slack connections until Slack started kicking the agent off ('too many websockets') — Slack now stays cleanly connected through any number of sleep/wake cycles, no restart ritual needed."
+
+## Summary of New Capabilities
+
+| Capability | How to Use |
+|-----------|-----------|
+| Leak-free Slack reconnects across sleep/wake | Automatic |
+
+## Evidence
+
+- New behavioral test file `tests/unit/slack-socket-leak.test.ts` (fake-websocket harness, 5 tests) proven failing on the unfixed client first (3/5 fail — the stale-backoff race opened FOUR connections), all pass on the fix; includes regression guards for natural-close reconnect and deliberate disconnect.
+- Updated source-assert tests in `slack-socket-reconnect.test.ts` / `slack-socket-heartbeat.test.ts` now pin the epoch + identity-guard pattern instead of the broken save/restore pattern.
+- Live incident evidence in JKHeadley/instar#1076 (log counts, onset timeline, post-restart stability).
+- Side-effects artifact: `upgrades/side-effects/socketmode-ws-leak-fix.md`.

--- a/upgrades/side-effects/socketmode-ws-leak-fix.md
+++ b/upgrades/side-effects/socketmode-ws-leak-fix.md
@@ -1,0 +1,74 @@
+# Side-Effects Review — SocketModeClient websocket leak fix (#1076)
+
+**Version / slug:** `socketmode-ws-leak-fix`
+**Date:** `2026-06-12`
+**Author:** `Instar Agent (echo)`
+**Second-pass reviewer:** `reviewer subagent (connection-recovery path — see appended response)`
+
+## Summary of the change
+
+Fixes JKHeadley/instar#1076: `SocketModeClient` leaked one live websocket per deliberate `reconnect()` because the "temporarily clear `started`" save/restore was synchronous while websocket close events fire on a later tick — the stale close handler orphaned the replacement socket and double-reconnected. Two mechanisms replace it, both confined to `src/messaging/slack/SocketModeClient.ts`: (1) socket event handlers are closure-bound to their own socket and ignore events when that socket is no longer `this.ws`; (2) a connection `epoch` is bumped on every deliberate teardown (`disconnect()`, `reconnect()`, `_forceReconnect()`, `_handleDisconnect()`, all funneled through a new `_teardownSocket()`), and every in-flight async path (awaited `apps.connections.open`, sleeping `_backoffReconnect`, delayed `too_many_websockets` retry, post-failure MAX_BACKOFF retry) captures the epoch at start and stands down if superseded. Tests: new behavioral file `tests/unit/slack-socket-leak.test.ts` (proven failing first), pattern updates in `slack-socket-reconnect.test.ts` and `slack-socket-heartbeat.test.ts`. No decision-point (gate/sentinel/block-allow) surface is touched; this is transport-lifecycle correctness.
+
+## Decision-point inventory
+
+No decision points touched. The change gates no information flow, blocks no actions, filters no messages, and constrains no agent behavior — it manages the lifecycle of a transport connection. The nearest decision-shaped logic is "should this stale event trigger a reconnect?", which is connection bookkeeping, not agent-behavior authority.
+
+---
+
+## 1. Over-block
+
+**What legitimate inputs does this change reject that it shouldn't?**
+
+The new guards drop two classes of events: (a) events from a socket that is no longer tracked, (b) scheduled reconnects whose epoch was superseded. Class (a) risk: a `message` event from a just-replaced socket carrying a real Slack envelope is now ignored instead of processed. This is correct, not over-block: processing it would ack on a dead/stale socket (the un-acked event is redelivered by Slack on the live connection — Slack's documented Socket Mode behavior, and the adapter already dedupes redelivered events). Class (b) risk: a superseded backoff stands down — by construction another path has already opened (or is opening) the connection, so dropping the duplicate dial is the fix itself. No legitimate input is rejected.
+
+## 2. Under-block
+
+**What failure modes does this still miss?**
+
+- A socket that dies without EVER emitting close (silent TCP death) is unchanged — that's the existing heartbeat/liveness-probe path, untouched and still covering it.
+- The SleepWake detector's spurious ~10s-gap wakes still trigger frequent (now harmless) redials and tunnel restarts — explicitly out of scope, tracked in JKHeadley/instar#1077. <!-- tracked: JKHeadley/instar#1077 -->
+- If Slack's `apps.connections.open` itself returns errors indefinitely, behavior is the existing backoff loop (unchanged semantics, now epoch-guarded).
+
+## 3. Level-of-abstraction fit
+
+**Is this at the right layer?**
+
+Yes. The leak is intrinsic to the socket-lifecycle bookkeeping inside `SocketModeClient`; neither `SlackAdapter.reconnect()` (a one-line delegate) nor the SleepWake handler in `server.ts` can fix it — they cannot see which socket an event belongs to. Rate-limiting wake events at the server layer (#1077) is complementary, not a substitute: any caller may legitimately call `reconnect()` at any frequency and the client must stay leak-free.
+
+## 4. Signal vs authority compliance
+
+**Does this hold blocking authority with brittle logic?**
+
+Not applicable in the gate sense — the change is not a detector or an authority over agent behavior (see decision-point inventory). Reference reviewed: `docs/signal-vs-authority.md`. The identity/epoch guards are deterministic bookkeeping over objects the module itself owns, the category where plain code is the correct tool.
+
+## 5. Interactions
+
+**Does it shadow another check, get shadowed, double-fire, race with adjacent cleanup?**
+
+- The previous behavior DOUBLE-FIRED `handlers.onDisconnected` for Slack-initiated disconnect envelopes (once from `_handleDisconnect`, once from the late close handler) — visible as duplicated `[slack] Disconnected:` log lines in the incident. The identity guard removes the duplicate; `SlackAdapter`'s `onDisconnected` only stamps `_lastDisconnectedAt` and logs. Honest coverage note (raised by the second-pass reviewer): client-initiated teardowns (`reconnect()`, `_forceReconnect()`) now fire ZERO `onDisconnected` where the old code accidentally fired one via the late close — so `_lastDisconnectedAt` is no longer stamped on those cycles and `_recoverMissedMessages` won't trigger for them. Accepted: the old stamp landed at teardown time (never covering the actual outage window, so the "recovery" it triggered re-read a window with nothing in it), the dominant disconnect paths (natural close, Slack envelopes) still stamp, and Slack redelivers un-acked envelopes on the new connection.
+- `_startHeartbeat()` already self-clears before starting; with the open-handler guard a stale socket can no longer restart the heartbeat for an orphan. The heartbeat's `_forceReconnect` now funnels through `_teardownSocket` like every other teardown — one code path, no divergent cleanup to race.
+- `connect()` on an already-connected client now tears down a pre-existing socket via the `_openConnection` invariant check instead of silently orphaning it (defensive; no current caller does this).
+
+## 6. External surfaces
+
+**Anything visible to other agents/users/systems? Timing/state dependencies?**
+
+No API, config, message-format, or scaffold/template surface changes; no migration needed (pure `src/` behavior fix shipped by version update). Externally visible effect on Slack's side: the app stops accumulating phantom Socket Mode connections and stops hammering `apps.connections.open` — strictly closer to intended behavior. The fix inherently depends on event ordering (that's its subject); the test harness models the real ordering (close events fired manually on a later tick) rather than assuming benign timing.
+
+## 7. Rollback cost
+
+**If this turns out wrong in production, what's the back-out?**
+
+Revert the single source file (+ tests) and release a patch — no data, state, config, or migration coupling. Worst plausible failure mode of the fix itself would be an ignored close event on a socket that IS current (impossible by construction: the guard compares against `this.ws`, and only `_teardownSocket`/the close handler itself clear it), with the existing heartbeat as the independent backstop that force-reconnects any non-OPEN tracked socket within 30s. Cheap, clean rollback.
+
+---
+
+## Second-pass review
+
+**Reviewer:** independent reviewer subagent (id a494a8c1260cacf70), 2026-06-12
+**Verdict (verbatim):** "Concur with the review." — after walking every requested interleaving class (dual dials at the same epoch resolve via the `_openConnection` invariant teardown; the `reconnecting` flag cannot stick true since `_backoffReconnect` resets it unconditionally after the sleep and before the epoch check; the natural-close-while-sleeper-in-flight case is safe precisely because natural closes don't bump the epoch).
+
+Observations (all non-blocking), and disposition:
+1. Section 5's onDisconnected claim was correct as scoped but incomplete — client-initiated teardowns now fire zero `onDisconnected`, reducing `_recoverMissedMessages` trigger coverage on those cycles. **Disposition: section 5 reworded honestly (above); behavior accepted for the reasons stated there.**
+2. Theoretical permanent-death strand via a defensive double-`connect()` with a failing API. **Disposition: hardened — `connect()` now tears down any pre-existing socket first (see `connect()` comment).**
+3. The epoch deliberately not bumping on natural closes is load-bearing for liveness. **Disposition: documented with a comment in the close handler so a future "bump everywhere for symmetry" refactor can't introduce the permanent-death path.**


### PR DESCRIPTION
Closes #1076.

## What

Every deliberate `SocketModeClient.reconnect()` leaked one live websocket. The old "temporarily clear `started`" save/restore was synchronous, but websocket close events fire on a later tick — the stale close handler saw `started` already restored and `this.ws` pointing at the freshly-opened replacement socket, nulled it (orphaning a live, untracked connection that counts against Slack's ~10-connection Socket Mode cap), and fired another reconnect. The SleepWake handler reconnects on every wake (33 that day, amplified by #1077's spurious ~10s wakes), so the cap blew within ~2h of boot and the client churned permanently with `too_many_websockets` — observed live 2026-06-12: **5,075 disconnects in 73 minutes (~70/min)** plus sustained `apps.connections.open` rate-limiting; only a full server restart cleared it. A second race let a sleeping backoff retry dial on top of an explicit `reconnect()` (the reproduction test shows that path opening FOUR connections).

## How

Structure instead of flag choreography, confined to `src/messaging/slack/SocketModeClient.ts`:
- Every socket's event handlers are closure-bound to that socket and ignore events once it is no longer the tracked connection (`this.ws !== sock`).
- A connection **epoch** bumps on every deliberate teardown (all funneled through one `_teardownSocket()`); every in-flight async path (awaited `apps.connections.open`, sleeping backoff, delayed `too_many_websockets` retry, post-failure MAX_BACKOFF retry) captures the epoch at start and stands down when superseded.
- `connect()` on an already-live client tears down first (second-pass-reviewer-found hardening of a theoretical permanent-death strand).
- Natural closes deliberately do NOT bump the epoch — an in-flight backoff sleeper must stay valid to perform the re-dial (documented in-code; load-bearing for liveness).

**Invariant: at most one tracked, live connection, regardless of how reconnect triggers interleave.**

## Evidence

- New behavioral harness `tests/unit/slack-socket-leak.test.ts` (fake websocket whose close events fire on a later tick, like reality) — proven failing on the unfixed client first (3/5 fail), all green on the fix; includes regression guards (natural close still reconnects; `disconnect()` stays down).
- Source-assert tests updated to pin the new pattern instead of the broken one.
- Slack API **contract tests run against the real API** (token from the live test workspace): 6 passed.
- Full local unit suite: 32,296 passed; 2 unrelated failures re-verified passing in isolation (flake protocol), CI shards are the authority.
- Tier 1 (declared): single transport-client file, no decision-point surface, trivially revertible. Side-effects artifact: `upgrades/side-effects/socketmode-ws-leak-fix.md` (second-pass reviewer concurred; all 3 observations dispositioned).

## ELI16

The agent keeps one phone line open to Slack. After your laptop wakes from sleep it hangs up and redials — but the "line closed" notification from the old call arrives a moment late, and the old code mistook it for the NEW call dying: it threw away its handle to the new line (which stayed open, invisible) and dialed a third one. Every sleep/wake leaked one invisible open line; Slack allows about ten, so within a couple of hours Slack started rejecting every call with "too many websockets," forever, until a restart hung them all up at once. The fix gives each line a name tag: a late "closed" notice from an old, replaced line is recognized and ignored, and any retry that was waiting from before a redial stands down instead of dialing a duplicate. Now there is exactly one live line, no matter how messy the timing gets. Full plain-English writeup: `docs/specs/socketmode-ws-leak-fix.eli16.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)