### PR TITLE
feat(dashboard): per-machine empty-state + converged multi-machine-seamlessness spec (WS4.2, F7)

### DIFF
--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -217,6 +217,20 @@
        already names the machine, so a slightly dimmed row is enough hint. */
     .session-item.remote { opacity: 0.9; cursor: pointer; }
     .session-item.remote:hover { opacity: 1; }
+    /* WS4.2: explicit per-machine state when a pool machine has no session
+       tiles — an idle machine must never look identical to a broken one.
+       Plain flex row; inherits the sidebar width (mobile-safe). */
+    .machine-status-row {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      padding: 8px 12px;
+      font-size: 11px;
+      color: var(--text-dim, #8b8fa3);
+      border-top: 1px dashed rgba(139, 143, 163, 0.25);
+    }
+    .machine-status-row.offline .machine-status-text { color: #f87171; }
+    .machine-status-row.online .machine-status-text { opacity: 0.85; }
 
     .type-badge {
       padding: 1px 6px;
@@ -3697,6 +3711,10 @@
     // Kept separate from `sessions` because the WebSocket replaces that array
     // with LOCAL sessions on every broadcast — merging would be wiped each tick.
     let remoteSessions = [];
+    // WS4.2 (multi-machine-seamlessness spec, F7): pool machine inventory for the
+    // per-machine empty-state strip. Populated only when the pool is enabled with
+    // 2+ machines — single-machine agents never see the strip (strict no-op).
+    let poolMachinesView = [];
     let selfMachineNickname = null;
     let activeSession = null;
     let activeMachineId = null; // non-null when the active session streams from a peer (§2.2)
@@ -3958,6 +3976,9 @@
         empty.style.display = 'flex';
         // Clear any existing session items
         list.querySelectorAll('.session-item').forEach(el => el.remove());
+        // WS4.2: even with zero sessions anywhere, each pool machine still gets
+        // an explicit state row — an idle machine must never look broken.
+        renderMachineStatusStrip(list, all);
         return;
       }
 
@@ -4044,6 +4065,37 @@
           </div>
           ${telemetryHtml}
         `;
+      }
+
+      // WS4.2: per-machine state strip after the tiles.
+      renderMachineStatusStrip(list, all);
+    }
+
+    // WS4.2 (multi-machine-seamlessness spec, F7 — 2026-06-12 live incident):
+    // a machine with zero running sessions used to render as NOTHING, identical
+    // to a broken or unreachable machine. Render an explicit state row per pool
+    // machine that has no session tiles: "online — no active sessions" when its
+    // heartbeat is live, "not reachable — last seen <t>" when it is not. Pool
+    // disabled or single-machine → poolMachinesView is empty → zero rows, zero
+    // behavior change (single-machine strict no-op, spec invariant 6).
+    function machineStatusInfo(m) {
+      if (m.online) return { cls: 'online', text: 'online — no active sessions' };
+      const seen = m.selfReportedLastSeen ? new Date(m.selfReportedLastSeen).getTime() : null;
+      const rel = seen ? fmtRelTime(seen) : 'unknown';
+      return { cls: 'offline', text: `not reachable — last seen ${rel}` };
+    }
+    function renderMachineStatusStrip(list, allSessions) {
+      list.querySelectorAll('.machine-status-row').forEach(el => el.remove());
+      if (!poolMachinesView.length) return;
+      const busy = new Set(allSessions.map(s => s.machineNickname || s.machineId).filter(Boolean));
+      for (const m of poolMachinesView) {
+        const label = m.nickname || m.machineId || 'unnamed machine';
+        if (busy.has(m.nickname) || busy.has(m.machineId)) continue; // has tiles — badge already names it
+        const info = machineStatusInfo(m);
+        const row = document.createElement('div');
+        row.className = `machine-status-row ${info.cls}`;
+        row.innerHTML = `<span class="machine-badge">${escapeHtml(label)}</span><span class="machine-status-text">${escapeHtml(info.text)}</span>`;
+        list.appendChild(row);
       }
     }
 
@@ -4600,6 +4652,15 @@
         remoteSessions = (j.sessions || []).filter(s => s.remote === true && (s.status === 'running' || s.status === 'starting'));
         renderSessionList();
       } catch { /* best-effort — peers may be offline; next tick retries */ }
+      // WS4.2: refresh the machine inventory on the same cadence so the sessions
+      // view can say "online — no active sessions" vs "not reachable" per machine.
+      try {
+        const pool = await apiFetch('/pool');
+        poolMachinesView = (pool && pool.enabled && Array.isArray(pool.machines) && pool.machines.length >= 2)
+          ? pool.machines
+          : [];
+        renderSessionList();
+      } catch { /* best-effort — strip simply stays absent until the next tick */ }
     }
     function startPoolSessionsPolling() {
       if (poolPollTimer) return;

--- a/docs/research/multi-machine-ux-gap-audit-2026-06-12.md
+++ b/docs/research/multi-machine-ux-gap-audit-2026-06-12.md
@@ -1,0 +1,156 @@
+# Multi-Machine UX Gap Audit — working draft (2026-06-12, autonomous run, topic 13481)
+
+Goal frame (Justin): "multi-machine support should be as seamless as possible from the
+user's perspective" — one coherent being across machines. Every finding below is a place
+the seam shows.
+
+## Confirmed live findings (verified today on the real pool)
+
+### F1 — Inbound delivery ignores topic ownership (CRITICAL, partially covered by existing spec)
+- Evidence: src/commands/server.ts onTopicMessage → `telegram.getSessionForTopic(topicId)` →
+  inject locally. No placement/ownership consultation anywhere in the path.
+  Live-proven 2026-06-12: topic 13481 pinned+owned by Mac Mini at 20:03Z; messages at
+  20:16Z and 20:17Z injected into the laptop session (`[telegram→session] Injecting into
+  echo-instar-exo` in logs/server.log).
+- Consequence: a transferred topic keeps being served by the OLD machine while the
+  ownership/pin layers claim otherwise. The "move" flips paperwork, not the conversation.
+- Coverage: the durable-inbound-message-queue spec (converged, .worktrees/durable-msg-queue,
+  CMT-1118) owns the queue + hold-still policy and the wrong-place-delivery diagnosis.
+  REMAINING for unified spec: the dispatch-to-owner integration — route() placement must be
+  consulted at delivery time and the message must travel to the owner machine (mesh), not
+  just queue locally. Verify scope boundary against that spec's "what we're building".
+
+### F2 — Live transfer of an actively-used topic never completes (CRITICAAL)
+- Evidence: reap-log 20:03→20:25Z, ~every 2min: post-transfer closeout tries to close
+  echo-instar-exo ("topic moved to Mac Mini"), refused each tick (active-process /
+  pending-injection / structural-long-work). Because F1 keeps feeding the old session,
+  it stays active forever → closeout can never fire → session never migrates.
+- Consequence: for the user, "move this conversation to the mini" silently does nothing
+  observable (worse: the system internally disagrees with itself for hours).
+- Also: the closeout reaper takes 2-minute swings at a session doing real work — only
+  the keep-guards protect it. With F1 fixed (messages stop feeding the old session),
+  the closeout completes naturally; the spec should also define "drain + handoff" for an
+  ACTIVE session (planned-handoff semantics) rather than waiting for idleness.
+
+### F3 — Transfer-back cannot re-place ownership; pin/owner diverge silently
+- Evidence: POST /pool/transfer {topic:13481,to:"Laptop"} twice → ok:true but
+  placedOwnership:false both times; placement stuck at owner=Mac Mini, pinnedTo=Laptop
+  for 10+ minutes. By design `place` CAS refuses to steal an active record; the pin only
+  drives re-placement on the NEXT inbound message — but nothing surfaces this pending
+  state, and consumers disagree meanwhile: the closeout reaper keys on OWNER (kept
+  attacking the laptop session) while routing keys on PIN.
+- Consequence: a "move it back" lands in a half-state with no convergence deadline and
+  no honest status surface. Need: a reconcile step (owner machine releases on seeing a
+  conflicting pin) or transfer API draining the release through the owner via mesh, plus
+  a `pendingReplacement` flag in GET /pool/placement.
+- Follow-up evidence (20:42Z same day): the divergence persisted 20+ minutes with the
+  post-transfer closeout still firing every 2 minutes against the working session
+  (held off only by keep-guards + manual session protection). The documented self-heal
+  ("the pin drives re-placement on the next real message") never fired — no inbound
+  arrived after the transfer-back, and the delivery path that would carry one is the
+  same path F1 shows ignores placement. In practice the half-state has NO bounded
+  convergence path.
+
+### F4 — Subscription-account pool is machine-local (known, from this conversation)
+- The 5-account pool (registry .instar/subscription-pool.json, configHome paths) exists
+  on the laptop only. The Mini has a single login: no swap cushion, no continuity
+  guarantee at a quota wall there. Quota-aware placement DOES work pool-wide (heartbeats
+  carry quotaState — verified live).
+- Spec item: account-pool follow-me — per-machine enrollment inventory surfaced in /pool,
+  placement aware of per-machine pool DEPTH (not just current blocked state), and a
+  security-reviewed design for syncing/enrolling logins across machines.
+
+### F5 — Attention queue is machine-local and unmerged
+- Evidence: GET /attention has no machine field, no ?scope=pool (83 local items).
+  An attention item raised on the Mini (e.g. its guard-posture tripwire) is invisible on
+  the laptop dashboard and to the laptop agent.
+- Spec item: pool-scope merged read (like /sessions?scope=pool, /guards?scope=pool),
+  machine-tagged items; decide single-surface story for /ack.
+
+### F6 — The named tunnel fronts ONE machine; cross-machine links break
+- Evidence: GET /tunnel → https://echo.dawn-tunnel.dev fronts the laptop. Private views,
+  dashboard links, secret-drop URLs generated on the Mini are unreachable through it.
+- Spec item: either tunnel-aware routing (the fronting machine proxies /view/:id and
+  dashboard traffic to the owning machine — streaming relay already proves the path) or
+  per-machine tunnels with honest URL selection. Decide; ship dark.
+
+### F7 — Idle machine vs broken machine are indistinguishable on the dashboard sessions view
+- Evidence: 2026-06-12 12:10 PDT — Justin read "no Mini sessions" as a regression after
+  the stale-tiles fix; the Mini was healthy but idle. The sessions view shows nothing for
+  a machine with zero running sessions.
+- Spec item: explicit per-machine empty-state ("Mac Mini — online, no active sessions",
+  "offline since …"). Small, high-trust win.
+
+### F8 — Mini scheduler had zero jobs after incident recovery (2026-06-11 finding)
+- One machine's scheduled jobs are invisible to and unreconciled with the pool: nothing
+  noticed a standby machine running NO jobs for a week (incident fallout), and there is
+  no cross-machine view of "which jobs run where".
+- Spec item: jobs surface with machine attribution + pool-scope read; posture-style
+  divergence detection ("machine X runs 0 jobs but its config declares N").
+
+## State-store inventory (code sweep, 2026-06-12 — swept the agent-home checkout which
+## trails main; items below were re-calibrated against what is KNOWN shipped on main:
+## secretSync, commitments sync (P1.5), working-set handoff (P2) exist and are NOT gaps)
+
+### Machine-local stores with user-experience impact (gap candidates for the spec)
+- F9  Correction/preference learning (`.instar/correction-ledger.db`, `.instar/preferences.json`)
+      — preferences learned on one machine don't follow to the other; the agent "forgets
+      who you are" after a machine handoff. HIGH user-visibility.
+- F10 Learnings / semantic memory (`.instar/semantic.jsonl` + `.db`) — lessons learned on
+      machine A never reach machine B.
+- F11 Knowledge base (ingested docs + search index) — "what do we know about X?" answers
+      differently per machine.
+- F12 Relationships + user registry (`.instar/state/relationships/`, `.instar/users.json`)
+      — the agent's model of WHO PEOPLE ARE diverges across machines. HIGH.
+- F13 Evolution action queue + TaskFlow registry (`.instar/task-flows.db`, explicit
+      v1 no-sync) — self-improvement items invisible across machines.
+- F14 Topic resume map — standby machine doesn't know a topic is active elsewhere
+      (interacts with F1-F3).
+- F15 Playbook context items — adaptive context doesn't follow.
+- F16 A2A sent/received logs — machine-local by partial design (P3 names the holder
+      honestly); keep as by-design with the mesh view, NOT a spec item.
+
+### Per-machine BY DESIGN (do not spec): identity files snapshot, config, security log,
+### nonce store, job RUN history, telemetry/observability ledgers, Telegraph registry
+### (public URLs), self-knowledge facts (machine-specific truths), shared-state ledger
+### (documented design decision).
+
+## Behavioral sweep findings (calibrated against current main — sweep ran on the
+## agent-home checkout which trails main; items already fixed on main were dropped:
+## pool-scope sessions dashboard, capacity heartbeats)
+
+- F17 Autonomous runs are machine-local; topic transfer mid-run = stranded state +
+      double-spawn risk (`.instar/autonomous/<topicId>.local.md`, AutonomousSessions).
+      LIVE-RELEVANT: this very run sat in that exact hazard today (topic pinned to Mini
+      while an autonomous run executes on the laptop). Spec item: autonomous-run
+      ownership rides the coherence journal (category exists: autonomous-run) +
+      transfer-time check: refuse or migrate an active run, never strand it.
+- F18 PresenceProxy (the 🔭 standby voice) has no machine-ownership gate (PromiseBeacon
+      HAS one at emission time) — both machines can answer for the same topic =
+      double-voice. Spec item: same ownership filter as PromiseBeacon.
+- F19 PromiseBeacon's gate compares ownerMachineId but commitments may be created
+      without it populated — gate silently inert. Spec item: populate at creation +
+      backfill.
+- F20 Topic→session registry is per-machine with no transfer-time dedup of the
+      auto-spawn path: a message arriving on the new owner spawns a NEW session while
+      the old machine still holds one (post-transfer closeout helps but is reactive and
+      blockable — see F2). Spec item folds into F1/F2 dispatch design.
+- F21 Job double-run protection is best-effort (claims broadcast fire-and-forget;
+      partition = run independently) + jobs without `machines` scope run on EVERY
+      machine; a standby machine's read-only StateManager makes state-writing jobs
+      crash mid-run. Spec items: machine-role check at spawn; claim durability;
+      explicit per-job placement policy surfaced to the user (ties F8).
+- F22 Model-tier escalation + job model severity files are /tmp-local per machine —
+      an escalated topic that moves de-escalates silently. Spec item: escalation state
+      rides the topic (topic-profile carrier exists — "[topic-profile-pull] transfer
+      carrier wired" already in logs; verify coverage includes escalation + thinking).
+- F23 RateLimitSentinel recovery state is in-memory per machine — failover can
+      double-notify "rate limited". LOW. Spec item: optional; fold into double-voice
+      family (F18).
+
+## Already covered / by design (do NOT re-spec)
+- Durable inbound queue + hold-for-stability: converged spec in flight (other session).
+- Working-set file handoff (P2), commitments merge/forward (P1.5), threadline holder
+  honesty (P3), secrets sync, exactly-once ingress, session streaming + remote close +
+  guard posture (shipped #1061/#1067/#1068/#1072/#1075).
+- Self-knowledge facts: per-machine BY DESIGN (machine-specific truths).

--- a/docs/specs/MULTI-MACHINE-SEAMLESSNESS-SPEC.md
+++ b/docs/specs/MULTI-MACHINE-SEAMLESSNESS-SPEC.md
@@ -1,0 +1,513 @@
+---
+title: "Multi-Machine Seamlessness — Unified Gap-Closure Spec"
+slug: "multi-machine-seamlessness"
+author: "echo"
+eli16-overview: "multi-machine-seamlessness.eli16.md"
+principal-deferral-approval:
+  - deferral: "WS5.2 account follow-me (credential-bearing cross-machine enrollment)"
+    sign-off: "operator pre-approval, topic 13481, 2026-06-12 13:16 PDT (Justin: full pre-approval for this initiative's decisions)"
+    commitment: "CMT-1413"
+    plan: "own focused security convergence round before ANY credential-bearing code; flag multiMachine.accountFollowMe reserved-dark"
+  - deferral: "WS2.3 PII transport/at-rest details (relationships + user registry replication)"
+    sign-off: "operator pre-approval, topic 13481, 2026-06-12 13:16 PDT"
+    commitment: "CMT-1413"
+    plan: "own security convergence round before the WS2.3 store ships; boundary (encrypted transit, receiver revalidation, origin-tagged rollback) fixed in this spec"
+lessons-engaged:
+  - "P3 Migration Parity: every flag via migrateConfig(); WS3.2 backfill ships its PostUpdateMigrator entry in the same PR; CLAUDE.md additions via migrateClaudeMd() (see Migration & Awareness)"
+  - "P8 UX & Agent Agency: WS1.4 needsConfirmation is context-before-consent; every refusal pairs with a recovery path (WS4.3 re-route-or-attention, WS1.2 honest forced-close notice, WS5.1 agent-driven enrollment) — no dead ends"
+  - "P4 Testing Integrity: three tiers per workstream + named invariant tests (exactly-one-owner, exactly-one-speaks, single-machine no-op, burst-invariant, P19 sustained-failure)"
+  - "P5 Agent Awareness: every agent-facing surface ships generateClaudeMd() + migrateClaudeMd() entries with proactive triggers"
+  - "P7 Observable Intelligence: every autonomous decision (forward, drain, reconcile, merge, refusal) emits feature metrics + audit lines"
+  - "P10 Comprehensive-First: WS5.2 and WS2.3-transport are principal-approved deferrals to focused convergence rounds; NO recurrence-risking credential/PII code ships from THIS spec's PRs"
+  - "P17 Bounded Notification Surface: pool-merged attention engages the budget AT THE MERGE POINT; all new notices carry pool-deduped episode keys + burst-invariant tests"
+  - "P19 No Unbounded Loops: this spec PATCHES the closeout reaper foundation (breaker added); every new loop declares backoff/breaker/cap in-component with sustained-failure tests"
+  - "L8 Active Follow-Through: WS3 fails toward speech-with-dedup, never silence"
+  - "L13 Zombie-cleanup lesson: drain/closeout act only on ownership signals, never blind ticks"
+  - "L15 Authorization: every new mesh verb gets an explicit RBAC class; reach ≠ authority (receiver revalidates)"
+review-convergence: "2026-06-12T20:55:25.113Z"
+review-iterations: 3
+review-completed-at: "2026-06-12T20:55:25.113Z"
+review-report: "docs/specs/reports/multi-machine-seamlessness-convergence.md"
+approved: true
+approved-by: "operator pre-approval — Justin, topic 13481, 2026-06-12 13:16 PDT: 'You have my pre-approval for all decisions needed... proceed with implementing all of these and building them out' (exercised by Echo in the pre-approved autonomous run; operator may revoke)"
+---
+
+# Multi-Machine Seamlessness — Unified Gap-Closure Spec
+
+**Status:** converged (3 iterations, 2026-06-12) — see `docs/specs/reports/multi-machine-seamlessness-convergence.md`
+**Owner:** Echo (autonomous run, topic 13481, 2026-06-12 — operator pre-approved)
+**Source audit:** `docs/research/multi-machine-ux-gap-audit-2026-06-12.md` (findings F1–F23)
+**Parent project:** `org-ready-agent-employee` (Phase A item 1)
+
+## The unifying goal (operator's words)
+
+> "An agent having multiple machines it can run on should NOT affect the user
+> experience. From the user's perspective interacting with the agent should still be
+> an experience of interacting with a single, coherent being."
+
+The operator's four-goal frame (2026-06-11): invisible to the user · one dashboard ·
+intelligent secure syncing · all channels.
+
+## Boundary with the Durable Inbound Message Queue spec (NO overlap)
+
+`docs/specs/durable-inbound-message-queue.md` (converged, in flight) owns: durable
+custody of inbound messages, the hold-for-stability policy, drain ordering, loss
+reporting. This spec builds the layers AROUND that queue. **Hard dependency gate:**
+WS1.1 attaches to that spec's `dispatchInbound()` seam and MUST NOT start until the
+durable-queue implementation is merged to main and `dispatchInbound(msg, opts)` is the
+canonical inbound entry point — if the seam's shape changes at merge, WS1.1 follows
+the merged shape. A CI precondition (grep-gate for the seam symbol) guards the WS1.1
+branch. WS1.1 extends the seam's verdict handling; it never re-implements routing in
+`onTopicMessage`.
+
+## Custody & identity invariants (cross-cutting, normative)
+
+These bind every workstream:
+
+1. **Single custody.** At every instant, exactly one machine holds durable custody of
+   an inbound message. A forward is an acknowledged custody transfer: the sender
+   retains its durable copy until the receiver durably accepts (queue-write or
+   inject-receipt), then deletes. A receiver that is releasing ownership REJECTS
+   custody (bounce to sender's queue) — never a silent swallow.
+2. **One logical message id.** The platform event id threads the entire custody chain
+   — ingress ledger, forward, queue, drain, spawn-inject — and EVERY domain dedups on
+   that same id. Idempotency is asserted end-to-end (one test drives a message through
+   forward→queue→transfer→drain→inject and asserts exactly-once delivery).
+3. **Exactly one owner.** After any reconcile/transfer/release sequence, every topic
+   with queued or pending messages has exactly one owner (or a tombstone with a named
+   adopter — see WS1.3). Invariant test required.
+4. **Epoch fencing.** Every cross-machine ownership-bearing operation (forward, drain,
+   release, ack-route) carries the ownership epoch; receivers reject stale-epoch
+   operations (bounce, never act).
+5. **Pool flag coherence (WS1/WS3/WS4.3 + journal kinds).** Correctness-critical
+   workstreams cannot be half-enabled across a pool. The capacity heartbeat
+   (`MachineCapacity`) gains a bounded `seamlessnessFlags` summary field; **absent =
+   the peer predates this spec = flag-state-off for every workstream** (a
+   never-reporting peer is a non-participant, not a match). The advertisement rides
+   the same authenticated (Ed25519) envelope as mesh RPC — a forged downgrade is not
+   possible from an unauthenticated source — and every flag flip is audited (P7), so
+   a pool-wide downgrade is detectable, never silent. A machine participates in
+   mesh-forward/owner-gating ONLY with peers advertising the same flag state. Flag
+   coherence ALSO gates replicated-journal-kind emission: the journal applier silently
+   drops unknown kinds (forward-compat), so a new kind is emitted only to peers
+   advertising the matching `stateSync.<store>` / `seamlessness.<ws>` flag — "silently
+   dropped by an old peer" is the NAMED skew-failure mode these gates exist to
+   prevent. Mixed pools degrade to the conservative side: durable queue where
+   available, else today's exact behavior — never naive inject alongside forwarding
+   and never gates without a speaker. A boot-time pool-flag-coherence check logs (and
+   surfaces once) any mixed state.
+6. **Single-machine strict no-op.** On an agent with no registered peers (pool dark or
+   size 1), no workstream's code path is ENTERED (guard on pool membership, not just
+   the flag). One no-op test per workstream proves zero behavior delta single-machine.
+
+## Workstream 1 — The conversation follows ownership (correctness core)
+
+**WS1.1 Dispatch-to-owner integration (closes F1, F20).**
+At delivery time the inbound path consults topic placement BEFORE selecting a session:
+
+- **Ownership resolution is a LOCAL read** (the journal-backed placement view) with a
+  hot-path budget of sub-millisecond in-memory access — NEVER a synchronous mesh call.
+  A placement record is usable only if fresh by epoch (within the current lease epoch
+  or explicitly re-confirmed); an older record means "unknown".
+- **owner == local** → inject locally (today's path). The local topic→session registry
+  is consulted only AFTER ownership says local; auto-spawn fires only on the owner.
+- **owner == another live machine** → async bounded forward over the mesh
+  (transport decided: the mesh RPC lane the pool transfer planner uses — see Decisions)
+  under the custody contract (invariant 1). The forward NEVER blocks the ingress loop:
+  it is handed to an async forwarder with a per-forward timeout; on timeout or
+  saturation the message spills to the durable queue (`queued`).
+- **ownership unknown / mid-move / disputed** → durable queue. **Fail-safe is the
+  QUEUE, not local inject.** "Classification failed" and "ownership says local" are
+  distinct verdicts; only the latter injects. (Round-1 critical: the old fail-open
+  default silently re-opened F1.)
+- **Forward TTL:** every forwarded message carries a hop counter, max 2 hops. On
+  exceeding it (placement ping-pong — two machines disagree), the message goes to the
+  durable queue with reason `placement-disputed` and ONE deduped attention item is
+  raised ("machines disagree on owner for topic N"). Never a third forward.
+- **Custody bounce discipline:** a custody-rejection bounce (receiver is releasing)
+  counts against the same hop budget, AND the bounced message is parked in the durable
+  queue with reason `owner-releasing` — it is NOT re-forwarded until a NEW placement
+  epoch is observed. Bounce↔forward cycling against the same epoch is impossible by
+  construction.
+- **Transport note:** the forward reuses the existing `deliverMessage` mesh verb
+  (which already carries `ownershipEpoch`); no new verb for the forward itself.
+- **Version skew:** forwards carry the mesh protocol version; if the owner peer does
+  not advertise the WS1.1 receive capability (old version), the sender degrades to
+  TODAY'S behavior (local inject) — the pre-WS1.1 pool-wide semantics, never a drop.
+  The skew matrix (new→old, old→new, mixed-flag) is part of the test plan.
+
+**WS1.2 Active-topic transfer completes (closes F2).**
+Transfer of a topic with a live session becomes a planned handoff:
+
+1. Pin + ownership move (today), 2. inbound redirects to the new owner (WS1.1) so the
+old session stops accruing work, 3. the old session gets a **drain signal**, 4. the
+new owner spawns on first delivered message with CONTINUATION context.
+
+- **Drain is a barrier:** inbound arriving during drain is QUEUED (not delivered to
+  the new owner) until the old session's final context flush is durably replicated;
+  then the queue releases to the new owner. No stale-checkpoint continuation.
+- **Drain authorization:** the drain signal is issued only by the transfer planner
+  (router-authority), epoch-bound to the specific transfer; a stale or replayed drain
+  (e.g. after a transfer-back) is rejected by epoch fencing. **Protocol surface:** the
+  drain is a NEW mesh verb with its own router-only RBAC case (`drain-unauthorized`
+  refusal reason) and bumps the seamlessness protocol version. Skew degrade: an old
+  peer that 501s the unknown drain verb → the transfer falls back to today's
+  idle-closeout-only behavior (the topic is never stranded; the WS1.2 guarantees
+  simply wait for the pool to finish updating).
+- **Drain terminal semantics:** the drain has a hard bound. If the old session reaches
+  a turn boundary within it → clean close. If not (wedged, infinite tool chain): the
+  session is force-closed at the next safe write boundary (hard-kill if wedged), the
+  transfer COMPLETES, the partial state rides the carrier marked
+  `interrupted-mid-task`, and ONE honest notice reports it. "Half-transferred forever"
+  is not a terminal state.
+- **Emergency stop during drain:** aborts the drain, the topic stays on the OLD
+  machine (transfer marked failed-needs-retry), nothing is left split.
+- **Closeout coupling + P19 foundation patch:** the old-session closeout fires on the
+  ownership-moved signal gated on drain completion — not on an independent reaper-tick
+  cadence. The existing closeout retry loop (SessionReaper) gets the missing P19
+  breaker IN THIS WORKSTREAM: after N consecutive vetoed closeout attempts on the same
+  session, retries stop and ONE degradation notice surfaces ("topic moved to X but the
+  old session won't drain — still finishing Y"). Sustained-failure test required
+  (permanently-vetoing session → bounded attempts + one escalation).
+
+**WS1.3 Ownership reconcile + honest pending state (closes F3).**
+
+- `GET /pool/placement` grows `pendingReplacement: true` + `reason` whenever pin and
+  owner disagree.
+- **Authenticated pin provenance:** a pin can trigger owner self-release ONLY when its
+  provenance is the router/operator transfer path (the `transfer` verb is already
+  router-only); a pin merely present in the replicated journal is NEVER sufficient.
+  (Round-1 critical: forged-pin ownership theft.)
+- **Reconcile rules:** only the CURRENT owner releases; it acts on the LATEST pin by
+  lease-epoch/sequence with a debounce window (topic-profile debounce pattern); the
+  release is CAS-conditional on still-being-owner. Release is a transfer-of-custody to
+  the named successor (place→claim for the pinned machine), or — if the successor is
+  unreachable — an explicit `unowned` tombstone that the LEASE-HOLDER is responsible
+  for adopting within a bound. Exactly-one-owner invariant test (invariant 3).
+- **Convergence deadline:** `pendingReplacement` carries `since`. The force-win path
+  is tightly conditioned: it requires (a) the SAME authenticated pin provenance as
+  self-release — an unauthenticated journal pin can never force-win, even after
+  timeout — and (b) POSITIVE evidence of owner death: the owner's lease has lapsed /
+  N missed heartbeats / a failed direct liveness probe. A reachable-but-slow owner
+  (GC pause, heavy turn) is NEVER fenced out mid-turn — it gets the WS1.2 drain
+  handoff instead. When force-win fires, the authority is the LEASE-HOLDER (the
+  tombstone-adoption path), executed as a fenced epoch increment the stale owner
+  cannot override on return. Tombstone adoption is CAS-conditional on an EPOCH-STABLE
+  lease — adoption defers (bounded backoff) while the lease epoch is advancing or
+  contested. If the lease-holder itself is partitioned away past the adoption
+  deadline, a quorum member may attempt the fenced claim (arbitrated by the
+  replicated journal under the exactly-one-owner invariant). Pin≠owner divergence
+  cannot outlive the bound. Consumers that key on ownership (closeout) treat
+  pin-conflict as "do not act" — bounded by the same deadline, after which they
+  follow the converged owner.
+- **"Next safe point"** is bounded: end of current turn or T seconds, whichever first.
+
+**WS1.4 Autonomous runs survive (or veto) topic moves (closes F17).**
+
+- **Precedence (decided):** the autonomous-run veto is evaluated FIRST, at
+  transfer-request time, BEFORE any drain begins. Default = REFUSE with
+  `needsConfirmation` ("autonomous run in flight on <machine>, N minutes remaining —
+  move anyway?").
+- Confirmed/forced move: the old machine's run stops at a turn boundary; the state
+  file is captured ATOMICALLY (fsync'd snapshot + content hash — never a live
+  mid-write file) and rides the working-set carrier. The receiving machine verifies
+  hash + schema before resuming and REFUSES a torn file with an honest report
+  ("resumed from last consistent checkpoint; final turn may be lost") rather than
+  resuming corrupt state. Forced-move-while-wedged: kill + ship last consistent
+  checkpoint with the same marker. Never strand a `.local.md` on a non-owner; never
+  double-spawn (the run registry keys on topic ownership).
+
+## Workstream 2 — One memory (the agent's mind follows the user)
+
+One generic **replicated-store layer** on the coherence-journal replication, with
+per-store merge semantics. SQLite stores replicate at record level via their JSONL
+source-of-truth or an export feed — never file-level copy.
+
+**Normative mechanics (all stores):**
+
+- **Ordering: hybrid logical clocks (HLC), never raw wall-clock.** Merges order by
+  HLC; any incoming record whose timestamp exceeds the receiver's clock by more than
+  the pool's measured skew bound is flagged skew-suspicious and quarantined for the
+  divergence surface. (Round-1 critical: a fast clock must not win every merge.)
+- **Receiver-side validation gate:** every inbound replicated record passes
+  schema/integrity validation BEFORE merge; failures are QUARANTINED. Replication
+  carries reach, not authority: a peer can only replicate records IT authored for its
+  own store (first-hop binding + receiver revalidation); a peer-supplied channel-uid
+  remap or identity-bearing field is revalidated and NEVER accepted as authoritative
+  on its own (L15).
+- **Quarantine is itself bounded:** a ring store with max entries/bytes,
+  oldest-eviction plus a loss counter; quarantined records COALESCE by
+  (peer, failure-class) signature — a stuck clock produces one growing counter, not N
+  rows — and surface as ONE rate-limited attention item per (peer, failure-class),
+  never per record. A peer exceeding a quarantine-rate threshold trips the per-peer
+  sustained-failure breaker (its replication stops being accepted) rather than
+  accumulating forever.
+- **Origin tags + rollback:** every merged record carries its origin machine id, and
+  replicated records live in namespaced storage that local reads UNION. Disabling
+  `multiMachine.stateSync.<store>` atomically drops the foreign namespace — a real
+  un-merge, not a flag wish. (Round-1 critical: merged-store rollback.)
+- **Divergence handling:** concurrent edits to the same record discovered at
+  partition-heal are APPEND-BOTH-AND-FLAG for the high-impact stores (preferences,
+  relationships) — both versions preserved, conflict marked, ONE deduped attention
+  item raised (not a 24h-latent digest line). Lower-impact stores (scores, manifests)
+  may use field-level HLC-wins with the divergence flag. Append-both is IDEMPOTENT on
+  (record-key, version-pair) — re-discovering the same unresolved conflict never
+  appends a third copy — and a conflict recurring past a threshold escalates to a
+  forced operator resolution rather than re-appending. **Resolution path:** every
+  flagged conflict carries a stable conflict id; an authenticated
+  `POST /state/resolve-conflict` lets the operator designate a winner or supply a
+  merged version, with a dashboard surface exposing open conflicts. Unresolved
+  conflicts are bounded, visible, and resolvable — never an accumulating contradiction
+  in the agent's identity.
+- **Bounds (per store, in-component, tested):** max entries per sync batch, max bytes
+  per store, replication rate cap with coalescing (replicate latest state per record
+  per interval, not every intermediate write). **Journal-kind discipline:** each new
+  replicated store/record class is a NEW JournalKind whose retention + rate-cap entry
+  ships in the same PR — and this governs EVERY new replicated kind in this spec (WS2
+  stores, WS4.1 ack records, WS4.3 claim leases, WS1.3 ownership/reconcile records,
+  WS1.4 autonomous-run ownership), all counted inside ONE aggregate replicated-journal
+  budget (config-declared ceiling) with a test enforcing the budget across kinds.
+  Sustained-failure breaker when a peer rejects repeatedly.
+- **Dark-peer accumulation:** replication to an unreachable peer does NOT buffer
+  unbounded history; past the retention window the recovering peer re-syncs via
+  snapshot-then-tail (pull a compacted snapshot from the live peer, then tail the
+  journal). Snapshot build and replay run OFF the event loop (worker/chunked, bounded
+  batches) — the instar#1069 lesson applied at design time. Snapshots are REUSED
+  within a minimum-rebuild window (a flapping peer reconnecting repeatedly serves the
+  cached snapshot) with a per-peer snapshot-build-frequency breaker.
+- **Union-reader discipline:** the local+replicated UNION is implemented at the LOWEST
+  store-access primitive for each store, so no existing caller can bypass it — per
+  store, an audit confirms every read callsite routes through the union layer, locked
+  by a wiring-integrity test (no direct-path reader remains). This is what makes the
+  namespaced un-merge rollback real for every consumer.
+- **Dry-run:** every store's merge path has a dry-run mode (log intended merges
+  without writing) on the graduated rollout track.
+
+**Stores:** WS2.1 preferences+corrections (F9; self-violation signals stay local) ·
+WS2.2 learnings/semantic memory (F10) · WS2.3 relationships+user registry (F12 — see
+PII note) · WS2.4 knowledge base (F11 — manifests replicate; bodies fetch on demand
+via working-set pull, HOLDER-AUTHORIZED: the holder decides whether to serve each
+body, same posture as WS4.4's holder-authorizes rule, inheriting the working-set
+carrier's size/concurrency/credential-flag refusals — manifest visibility is NOT body
+entitlement; a body whose holder is offline returns an honest "temporarily
+unavailable from <machine>", never a silent miss) · WS2.5 evolution queue (F13 —
+append-only, observe/merge ONLY: an action authored on machine A is NEVER auto-executed
+on machine B; TaskFlow v2 sync out of scope) · WS2.6 playbook items (F15 — scores
+merge by max).
+
+**PII & content safety:** WS2.3 records ride the per-recipient e2e-encrypted
+secret-sync transport. This is TRANSIT confidentiality only — at rest the replicated
+records carry the same protection as locally-originated PII; replication widens the
+number of machines holding PII and that exposure delta is accepted explicitly by the
+operator (deferral note below). Replicated knowledge-base bodies and evolution-action
+text are quoted UNTRUSTED DATA on the receiving machine (cartographer-style
+neutralization), never instructions.
+
+**Phasing:** 2.1+2.3 first, then 2.2, then 2.4–2.6, each dark behind
+`multiMachine.stateSync.<store>`.
+
+## Workstream 3 — One voice (never two machines answering)
+
+- **Exactly-one-speaks invariant (both directions).** The owner machine speaks for a
+  topic. If ownership is unknown, orphaned, or mid-flip at emission time, the gate
+  FAILS TOWARD SPEECH-WITH-DEDUP: the lease-holder speaks (deterministic tiebreak:
+  lowest machineId if the lease is also ambiguous). "Unknown owner" never maps to
+  pool-wide silence. **Lease-stability dwell:** while the lease epoch is advancing or
+  contested (a flap), emission is DEFERRED with bounded backoff rather than spoken on
+  a transient lease read, and once a speaker is chosen its identity is HELD for a
+  dwell window — a mid-flap flip cannot hand the microphone back and forth across
+  successive emissions. Invariant test asserts ≥1 AND ≤1 speaker for every due
+  commitment/presence emission, including under a flapping lease. (Round-1 critical:
+  the silent-agent dual of double-voice.)
+- **WS3.1 PresenceProxy machine gate (F18):** ownership filter at emission time, same
+  pattern as PromiseBeacon, with the fail-toward-speech rule above. Single-machine
+  no-op: gate inert when `currentMachineId` unset or pool size 1.
+- **WS3.2 PromiseBeacon owner population (F19):** commitments record `ownerMachineId`
+  at creation. Owner is RE-RESOLVED live at speak-time from placement (the stamp is
+  the fallback when placement is unavailable), so a backfill racing a transfer cannot
+  wedge the gate. The PostUpdateMigrator backfill (from topic placement at a stable
+  epoch) ships IN THE SAME PR (P3), with a migration test and dry-run report mode.
+- **WS3.3 Notification dedup family (F23):** rate-limit/recovery notices carry a
+  pool-deduped episode key keyed on (topic, episode) — NOT (topic, machine) — so a
+  cross-machine failover of one episode produces ONE notice. Burst-invariant test per
+  notice path.
+
+## Workstream 4 — One pane of glass
+
+- **WS4.1 Attention queue pool scope (F5):** items grow `machineId`;
+  `GET /attention?scope=pool` merges peers with per-peer timeout, partial-result
+  degradation (`failed` markers, sessions-scope precedent), and a short-TTL cache so
+  dashboard polling doesn't re-fan-out per request. **P17 at the merge point:** the
+  merged surface applies a pool-wide coalesce key (the WS3.3 episode-key pattern) so N
+  machines raising the same episode (e.g. each machine's tripwire for one pool-wide
+  event) present as ONE item; the merge is read-only and per-machine budgets remain
+  the write-side bound — the burst test drives N machines × budget and asserts the
+  merged view stays within the pool bound. **/ack is durable and machine-independent:**
+  the ack writes a replicated ack record (user intent survives the owner being dark);
+  the owning machine reconciles on return. The ack record BINDS the authenticated
+  OPERATOR principal that performed it (the same audience-bound assertion pattern as
+  WS4.4 — never a bare peer-authored record), is epoch-fenced and idempotent, and the
+  owner REVALIDATES that operator binding at reconcile before applying it. Reconcile
+  precedence: the owner's CURRENT item state wins — a stale resolve against an item
+  that has since escalated to HIGH/URGENT is rejected (and surfaced), never applied.
+  Ack replication is governed by the WS2 replicated-store mechanics (HLC ordering,
+  retention/rate-cap, the aggregate journal budget). Remote ack is a MUTATING mesh
+  verb with its own RBAC class (authenticated same-operator peer + receiver
+  revalidation); HIGH/URGENT items (split-brain demotion, guard tripwires) are never
+  remotely resolvable without operator-authenticated action.
+- **WS4.2 Idle vs broken machine empty-state (F7):** sessions view renders explicit
+  per-machine states: "online — no active sessions" / "offline since <t>" /
+  "unreachable (last seen <t>)". Mobile-responsive like the rest of the dashboard.
+- **WS4.3 Jobs placement visibility + role guard (F8, F21):** `GET /jobs?scope=pool`
+  (same Bearer auth as local `/jobs`) shows which machine runs each job. A
+  machine-role check at spawn refuses state-writing jobs on a read-only standby — and
+  a refusal is never the end of the story: the job re-routes to the writable owner
+  when one exists, else ONE deduped attention item ("job X could not run — no writable
+  machine"). The posture-style divergence detector ("machine X runs 0 jobs but its
+  config declares N") closes the F8 blindness. Job claims upgrade from best-effort
+  broadcast to a durable lease through the replicated journal (prevention, with
+  partition behavior documented: claims are leases with fenced epochs; a partition
+  double-run is structurally prevented when the journal is reachable and VISIBLY
+  reported when partition forced independence). **Cutover discipline:** journal-lease
+  claiming engages ONLY when invariant-5 flag coherence confirms EVERY pool peer
+  advertises the WS4.3 capability; until then the machine stays on the legacy
+  AgentBus broadcast path. There is never a window where one machine leases via the
+  journal while a peer broadcasts via the bus for the same job set — two
+  non-interoperating claim mechanisms running simultaneously is the named migration
+  hazard this rule closes. Claim records store metadata only (machine, job id, epoch)
+  — never job payloads.
+- **WS4.4 Links that survive machine boundaries (F6):** the tunnel-fronting machine
+  proxies `/view/:id` + dashboard asset routes to the content's HOLDER. Normative:
+  (a) view-id ownership ≠ topic ownership — the proxy resolves the actual holder of
+  the view id; (b) the END-USER credential (PIN session / view token) is enforced
+  end-to-end and the HOLDER makes the authorization decision — the fronting machine is
+  a dumb relay that never substitutes machine/mesh credentials for user credentials,
+  never logs tokens, never caches private content; (c) responses are STREAMED with a
+  concurrency cap on in-flight proxied requests; static dashboard assets may be cached
+  at the fronting machine (they are not private), private bodies never; (d) a holder
+  that is offline yields an honest "content temporarily unavailable — its machine is
+  offline", never stale content or a bare 404; (e) PIN auth across the proxy: the
+  user's PIN session is validated by the fronting machine AND the proxied request
+  carries a short-lived assertion of that user authentication — not the raw PIN — so
+  each machine's PIN secret never crosses the boundary. The assertion is
+  AUDIENCE-BOUND (target holder fingerprint + the specific view-id + method) and
+  SINGLE-USE (nonce/jti recorded by the holder within the TTL), signed by the
+  fronting machine's mesh key and verified by the holder against the EXPECTED
+  fronting machine — a captured assertion cannot be replayed against another
+  resource, another holder, or reused within its window; (f) fronting-edge load
+  posture: merged pool views (attention/jobs/sessions/guards) are served from ONE
+  shared per-peer poll cache (one fan-out per interval feeds all pool-scope surfaces
+  — never per-route, per-client re-fan-out), and when the fronting machine is over a
+  CPU threshold, dashboard poll responses serve last-cached data with an explicit
+  staleness tag instead of re-fanning (load-shed, honestly labeled).
+
+## Workstream 5 — Account & model continuity
+
+- **WS5.1 Subscription-pool awareness (F4 phase 1):** `GET
+  /subscription-pool?scope=pool` reports each machine's enrolled-account DEPTH +
+  quota. The capacity heartbeat carries only a small fixed-size summary (account
+  count + blocked bool per provider) — the inventory is fetched on demand. Placement
+  uses depth as a TIE-BREAKER only in v1 (never overriding load). **Honest
+  disclosure with an agent-driven path:** when a machine's depth is low, the agent
+  OFFERS to drive the existing enrollment flow itself (`POST /subscription-pool/enroll`
+  — the public-code login wizard the agent initiates and walks the operator through)
+  — never a bare "use the wizard" instruction to the user, and never implying an
+  auto-sync exists (P8 no-dead-ends; B2 no CLI instructions to users).
+- **WS5.2 Account follow-me (F4 phase 2 — deferred, boundary fixed here):**
+  cross-machine enrollment is OPERATOR-INITIATED and PIN/operator-authenticated
+  (mandate-issuance precedent); a peer machine can NEVER initiate enrollment of an
+  account onto itself via the mesh. Explicitly NOT login-file sync — OAuth
+  config-homes never cross machines. The flag `multiMachine.accountFollowMe` is
+  reserved-dark now; ALL design and build happens in its own convergence round
+  (principal-approved deferral — no credential-bearing code ships from this spec).
+- **WS5.3 Escalation rides the topic (F22):** the topic-profile transfer carrier
+  (already wired) carries live escalation/thinking state; `/tmp` severity files become
+  per-topic state included in the carrier.
+
+## Migration & Awareness (P3 + P5, per workstream)
+
+- Every new config flag lands via `migrateConfig()` with existence checks; defaults
+  preserve today's behavior exactly.
+- The `MachineCapacity.seamlessnessFlags` heartbeat field follows the
+  quotaState/guardPosture precedent: absent = unknown/pre-spec = non-participant; no
+  wire-format migration needed beyond additive-field handling, locked by a skew test.
+- WS3.2's commitment backfill ships as a PostUpdateMigrator migration in the same PR.
+- Every agent-facing surface (`/attention?scope=pool`, `/jobs?scope=pool`,
+  `pendingReplacement`, pool-stable view URLs, WS4.2 empty-state semantics, WS1.4
+  transfer confirmation) ships `generateClaudeMd()` + `migrateClaudeMd()` entries with
+  proactive triggers in the same PR.
+- Idempotency required on every migration.
+
+## Safety & rollout posture
+
+Every workstream ships dark behind `multiMachine.seamlessness.<ws>` (graduated rollout
+track), defaults preserving today's behavior exactly. Dry-run modes for EVERY
+state-mutating path: WS1 (log intended forward/drain/reconcile), WS2 (log intended
+merges), WS3.2 (backfill report mode), WS4.3 (log intended refusals/claims), WS5.3
+(log intended carrier writes). WS2.3 (PII) and WS5.2 (credentials) are
+principal-approved deferrals to their own security convergence rounds — nothing
+recurrence-risking ships before those rounds converge. All loops carry the three
+brakes IN-COMPONENT with sustained-failure tests. Every new surface is observable
+(feature metrics + audit lines per P7). New mesh verbs get explicit RBAC classes
+(read/observe vs mutating) — named per verb in the build plan.
+
+## Test plan (P4, per workstream)
+
+Three tiers (unit / integration / E2E feature-alive) per workstream, PLUS the named
+invariant tests: exactly-once delivery end-to-end across custody domains;
+exactly-one-owner after any reconcile sequence; exactly-one-speaks (≥1 and ≤1);
+single-machine strict no-op per workstream; burst-invariant for every new notice path
+(N-machine episode storm → one notice); P19 sustained-failure for the closeout breaker
+and every replication loop; version-skew matrix for WS1.1 (new→old, old→new,
+mixed-flag); WS1.4 torn-state-file refusal; WS2 quarantine + rollback-unmerge; WS4.4
+auth-preservation (user credential required end-to-end, machine credential never
+substituted).
+
+## Build order (highest leverage ÷ risk first)
+
+1. WS4.2 (empty-state — tiny, immediate trust win)
+2. WS3.1 + WS3.2 (one-voice gates + backfill migration)
+3. WS1.3 (ownership reconcile + honest pending + convergence deadline). **Honesty
+   note:** shipped before WS1.1, WS1.3 fixes the status surface and the placement
+   RECORD convergence only — the user-visible conversation move still does not
+   complete until WS1.1 is live (delivery is what honors the record). Ship messaging
+   for WS1.3 must say so.
+4. WS1.1 (dispatch-to-owner — AFTER the durable-queue merge gate)
+5. WS1.2 + WS1.4 (transfer completion + closeout breaker + autonomous guard)
+6. WS4.1, WS4.3, WS4.4 (pane-of-glass family)
+7. WS2.1 + WS2.3, then rest of WS2 (memory family)
+8. WS5.1, WS5.3, then WS5.2's own round (accounts family)
+
+## Non-goals
+
+Durable custody/queueing of inbound messages (owned by durable-inbound-message-queue);
+TaskFlow v2 cross-machine sync; Slack-specific multi-machine verification (Phase A
+item 4 of the parent project — separate spec after this lands); cross-machine custody
+replication of queued messages; multi-agent (cross-AGENT) anything.
+
+## Decision points touched
+
+- WS1.1 inbound route decision (local-inject / mesh-forward / queue-handoff).
+  **Fail-safe: ownership-unknown → durable queue.** Local inject happens ONLY on a
+  resolved "owner == local"; degraded-version pools fall back to today's pool-wide
+  local-inject semantics (never drop, never half-forward).
+- WS1.4 transfer-time refusal (`needsConfirmation`) when an autonomous run is live —
+  consent-shaped, never silent, evaluated before drain.
+- WS3 gates sentinel SPEECH only, failing toward speech-with-dedup — never recovery
+  actions, never silence.
+- WS4.3 spawn-time refusal for state-writing jobs on read-only standby — refusal
+  always pairs with re-route-or-attention, never a silent skip.
+- No gate in this spec blocks a user-initiated action without a confirmation path.
+
+## Decisions (formerly open questions — resolved for build)
+
+1. **WS1.1 forward transport: mesh RPC lane** (the pool transfer planner's lane),
+   inheriting its auth, breaker, and version-skew handling — with explicit
+   backpressure: on saturation, forwards spill to the durable queue, never block
+   ingress, never drop.
+2. **WS2 divergent concurrent edits (high-impact stores): append-both-and-flag** with
+   ONE deduped attention item; field-level HLC-wins only for low-impact stores.
+3. **WS4.4: proxy through the fronting machine**, gated on the auth-preservation
+   constraints above (revisit toward per-machine tunnels only if relay load proves
+   prohibitive — the streamed+capped design bounds the risk).
+4. **WS5.1 placement weight: tie-breaker only in v1.**

--- a/docs/specs/multi-machine-seamlessness.eli16.md
+++ b/docs/specs/multi-machine-seamlessness.eli16.md
@@ -1,0 +1,88 @@
+# Multi-Machine Seamlessness — Plain-English Overview
+
+## The problem, in one story
+
+You asked one simple thing of the multi-machine project: "talking to my agent should
+feel like talking to ONE being, no matter how many computers it lives on." Today we
+tested that promise by moving a live conversation from the laptop to the Mac Mini —
+and the seams showed. The paperwork moved instantly (every machine agreed the Mini now
+owned the conversation), but your messages kept landing on the laptop, the laptop kept
+answering, and the system spent the next hour politely trying to close the laptop's
+copy every two minutes while it was actively working. The move flipped a label, not
+the conversation.
+
+We then audited EVERYTHING with that same question — "where else does the seam show?"
+— and found about twenty places. They group into five families.
+
+## The five families of seams
+
+**1. The conversation doesn't actually follow the move.** Message delivery never asks
+"which machine owns this conversation?" — it just hands the message to whatever copy
+is closest. Fix: delivery consults ownership first; a move of a busy conversation
+becomes a polite handoff (finish the sentence, pass the baton) instead of an endless
+tug-of-war. A half-moved state becomes honest and visible instead of silently stuck.
+
+**2. The agent's memory doesn't follow you.** What I've learned about you — your
+preferences, the corrections you've given me, who the people in your life are, the
+knowledge base you've built with me — all of it lives on whichever machine learned it.
+After a handoff I'd partially forget who you are. Fix: those memories replicate
+between machines over the same encrypted channel secrets already use, with careful
+merging when both machines learned something at once.
+
+**3. Two machines, one mouth.** Some of my background voices (the "I'm still working
+on it" standby notices) don't check which machine should speak — both machines could
+answer you about the same conversation, or each could assume the other will and
+neither speaks. Fix: exactly one machine speaks for each conversation, the same rule
+my promise-reminders already follow.
+
+**4. One pane of glass, some panes missing.** The dashboard now shows sessions and
+safety systems across all machines — but attention items (things needing your
+decision) are still per-machine, scheduled jobs have no cross-machine view, links to
+private pages break if the content lives on the other machine, and an idle machine
+looks identical to a broken one. Fix: merge those views the same way sessions were
+merged, make links work regardless of which machine holds the content, and say
+"online — nothing running" out loud.
+
+**5. The account cushion doesn't travel.** The laptop holds your 5-account
+subscription pool; the Mini has one login and no fallback at a quota wall. Fix, in two
+careful steps: first make the pool's depth visible everywhere and let placement prefer
+machines with cushion; later (with its own security review) make enrolling an account
+onto another machine a one-tap flow — never by copying login files around.
+
+## What the review process is for
+
+This spec went through the full multi-reviewer convergence gauntlet (security,
+scalability, adversarial, integration, lessons-learned, plus an outside AI model)
+before any code gets written. The review's job is to catch the "cure becomes the
+disease" failures: a message forwarded to the wrong machine, two machines merging your
+preferences with skewed clocks, a proxy that quietly overloads the one machine
+fronting your dashboard.
+
+## What changes for you when it ships
+
+Nothing, at first — every piece ships dark behind its own switch, with dry-run modes
+for the correctness-critical parts, and a single-machine setup is untouched by all of
+it. As pieces graduate: moving a conversation between machines will actually move it
+(and tell you honestly while it's mid-move), I'll remember you identically on every
+machine, exactly one voice will answer, the dashboard becomes genuinely one pane of
+glass, and quota walls stop being a single-machine problem.
+
+## Open questions (decided by default, flag if you disagree)
+
+1. Cross-machine message forwarding rides the same internal lane machine-moves already
+   use (simplest, proven) — not a new channel.
+2. If both machines learned conflicting things about the same person during a network
+   split, the newer fact wins field-by-field and the conflict is flagged in your daily
+   digest rather than silently discarded.
+3. Links keep ONE address (your existing dashboard hostname); the fronting machine
+   quietly fetches content from whichever machine holds it.
+4. Account-cushion awareness only breaks ties in placement at first — it never
+   overrides load-balancing on its own.
+
+## The honest costs
+
+Replicating memories means more disk and network between your machines (bounded, with
+caps and compaction). The one-address link design concentrates traffic on the fronting
+machine (streamed, capped, and it can be revisited). And the account-enrollment
+follow-me is deliberately deferred to its own security review — the convenience is not
+worth rushing credentials handling.

--- a/docs/specs/reports/multi-machine-seamlessness-convergence.md
+++ b/docs/specs/reports/multi-machine-seamlessness-convergence.md
@@ -1,0 +1,138 @@
+# Convergence Report — Multi-Machine Seamlessness (Unified Gap-Closure Spec)
+
+**Spec:** `docs/specs/MULTI-MACHINE-SEAMLESSNESS-SPEC.md`
+**Plain-English companion:** `docs/specs/multi-machine-seamlessness.eli16.md`
+**Source audit:** `docs/research/multi-machine-ux-gap-audit-2026-06-12.md` (F1–F23)
+**Run:** autonomous, topic 13481, 2026-06-12 (operator pre-approved)
+
+## ELI10 Overview
+
+You run one agent on more than one computer, and you asked for one thing: talking to
+it should feel like talking to ONE being, no matter which machine answers. Today we
+tested that by moving a live conversation from the laptop to the Mac Mini — and found
+the move only flips a label. Messages kept landing on the laptop, the laptop kept
+answering, and the system spent an hour politely trying (and correctly failing) to
+close the laptop's copy while it was busy working. We then audited everything else
+with the same question and found about twenty places where the seam between machines
+shows: the agent's memories of you don't follow you between machines, things needing
+your attention on one machine are invisible from the other, links break if content
+lives on the other machine, two machines could both speak for the same conversation
+(or both stay silent), and an idle machine looks identical to a broken one.
+
+This spec closes all of it in five workstreams: the conversation actually follows a
+move (with a polite finish-your-sentence handoff), the agent's memory replicates
+between machines (encrypted, carefully merged, fully reversible), exactly one machine
+ever speaks for a conversation, the dashboard becomes genuinely one pane of glass,
+and quota/account awareness spans the pool. Everything ships dark behind switches,
+with dry-run modes, and a single-machine setup is structurally untouched.
+
+The main tradeoffs: replicating memories costs disk and network (bounded, with caps,
+compaction, and a quarantine for suspicious records); keeping one web address for all
+machines concentrates traffic on the fronting machine (streamed, capped, cached, with
+honest load-shedding); and the two security-heavy pieces — syncing the agent's model
+of PEOPLE (PII) and enrolling subscription accounts across machines — are deliberately
+deferred to their own focused security reviews with formal sign-off, so nothing risky
+ships from this spec.
+
+## Original vs Converged
+
+The review process changed this design substantially:
+
+- **Originally**, if message routing failed to classify a message, it fell back to
+  "deliver locally like today." Reviewers proved that silently re-opens the exact
+  wrong-place-delivery bug being fixed. **Now** an unresolvable message goes to the
+  durable on-disk queue — local delivery happens only when ownership positively says
+  "local."
+- **Originally**, a machine could take over a conversation from an unreachable owner
+  after a timer. Reviewers showed a merely-SLOW machine looks identical to a dead one
+  — the timer would steal live conversations mid-sentence. **Now** takeover requires
+  positive evidence of death (lapsed lease, missed heartbeats, failed probe), with
+  authenticated provenance, and a slow-but-alive owner gets a polite handoff instead.
+- **Originally**, memory merges used "newest timestamp wins." Reviewers showed a
+  machine with a fast clock would win every merge forever — silent corruption of the
+  agent's model of you. **Now** merges use logical clocks, suspicious records are
+  quarantined (in a bounded, coalescing store — reviewers then bounded the quarantine
+  itself), conflicting versions are both preserved and flagged, and an authenticated
+  resolve-conflict endpoint with a dashboard surface lets you settle disagreements.
+- **Originally**, "one machine speaks" gates could leave BOTH machines silent when
+  ownership was unclear — worse than double-talk. **Now** the rule fails toward
+  speech with a deterministic tiebreak and a stability dwell so a flapping lease can't
+  bounce the microphone, with a test asserting exactly one speaker always.
+- **Originally**, turning memory-sync off was a flag flip. Reviewers showed merged
+  foreign records would simply stay. **Now** replicated records live in origin-tagged
+  namespaces that local reads union — disabling a store atomically un-merges it.
+- **Reviewers also grounded the spec against the real code**: the replication layer
+  silently DROPS record types it doesn't know, so new record types are only sent to
+  peers that advertise support; the job-claim upgrade got a strict cutover rule so two
+  claim mechanisms never run side by side; the cross-machine drain is a new
+  authenticated verb with a version bump and an honest old-version fallback; and the
+  build order now says plainly that the status-surface fix shipping before the
+  delivery fix does NOT yet move conversations.
+
+## Iteration Summary
+
+| Iteration | Reviewers | Material findings | Outcome |
+|-----------|-----------|-------------------|---------|
+| 1 | security 9 · scalability 9 · adversarial 18 · integration 11 · lessons-aware 8 · Gemini 7 | **62** | Full spec rewrite (custody invariants, fail-to-queue, HLC merges, origin-tag rollback, one-voice invariant, pool flag coherence, migration/awareness section, test plan) |
+| 2 | security 5 · scalability 5 · adversarial 7 · integration 7 · lessons-aware 3 · Gemini 2 | **29** | Targeted hardening of round-1 mechanisms (owner-death evidence for force-win, bounded quarantine, audience-bound assertions, operator-bound acks, journal-kind discipline, claim cutover, deferral frontmatter) |
+| 3 | security 0 · adversarial 0 · integration+scalability 0 · lessons-aware 0 · Gemini 0 | **0** | Converged |
+
+External reviewer note: GPT-tier and Grok-tier CLIs are not installed on this machine;
+Gemini (gemini-2.5-pro) served as the external cross-model reviewer in every round.
+All five internal perspectives ran in every round, including the mandatory
+lessons-aware pass with foundation audit.
+
+## Full Findings Catalog
+
+The complete per-reviewer finding texts (91 findings: 62 round-1, 29 round-2) with
+their resolutions are preserved in the autonomous run transcript (topic 13481,
+2026-06-12). Catalog highlights by theme:
+
+**Correctness/custody (adversarial+Gemini):** fail-open re-opened F1 → fail-to-queue;
+double/zero delivery across ownership flips → single-custody contract + acknowledged
+transfer; forward ping-pong → hop-TTL 2 + placement-disputed; bounce↔forward cycling →
+bounce counts against hop budget + parks until a new epoch; drain timeout undefined →
+force-close terminal semantics + barrier + emergency-stop rule; simultaneous release →
+orphan tombstone + lease-holder adoption + exactly-one-owner invariant + quorum
+fallback; closeout reaper unbounded retry (P19 foundation violation) → breaker added.
+
+**Security:** WS2 replication = write surface → receiver revalidation + own-authored
+only; forged pin → authenticated provenance (both normal and force-win paths);
+WS4.4 proxy → end-user credential end-to-end + audience-bound single-use assertions;
+remote ack → mutating RBAC class + operator-principal binding + current-class-wins;
+heartbeat flag advertisement → authenticated envelope + audited; KB bodies →
+holder-authorized; WS5.2 boundary → operator-initiated, PIN-gated, no peer
+self-enrollment.
+
+**Data integrity (all):** wall-clock merges corrupt under skew → HLC + skew
+quarantine; quarantine itself unbounded → bounded ring + coalesce by (peer,
+failure-class) + per-peer breaker; append-both floods → idempotent on (record-key,
+version-pair) + operator escalation + POST /state/resolve-conflict; merged-store
+rollback → origin-tagged namespaces with atomic un-merge + union-reader at the lowest
+primitive with wiring-integrity tests.
+
+**Deployment (integration):** dispatchInbound seam exists only on the unmerged
+durable-queue branch → hard dependency gate + CI precondition; journal applier
+silently drops unknown kinds → flag-gated kind emission; MachineCapacity needs the
+seamlessnessFlags field with absent=non-participant; JobClaimManager two-mechanism
+window → all-peers-advertise cutover; drain = new mesh verb + protocol bump + 501
+degrade; WS1.3-before-WS1.1 ships only the honest surface (build-order note);
+migration parity + CLAUDE.md awareness per workstream; single-machine strict no-op.
+
+**Performance (scalability):** placement reads local-only sub-ms; forwards async +
+bounded + spill-to-queue; per-store bounds/retention/compaction + ONE aggregate
+journal budget across ALL new kinds; snapshot-then-tail off the event loop + reuse
+window + rebuild breaker; pool-scope reads share one per-peer poll cache; fronting
+machine load-sheds to last-cached-with-staleness.
+
+**Process (lessons-aware):** principal-deferral-approval frontmatter for the two
+recurrence-risking deferrals (tracked: CMT-1413); P8 engaged (consent-before-context,
+no dead ends); P17 engaged at the pool-merge point; lessons-engaged frontmatter added
+and verified honest in round 3.
+
+## Convergence verdict
+
+Converged at iteration 3. No material findings in the final round from any of the
+five perspectives (security, adversarial, integration+scalability, lessons-aware,
+external/Gemini), with every round-2 fix verified present in the text by quotation.
+Spec is ready for operator review and approval.

--- a/tests/integration/pool-routes.test.ts
+++ b/tests/integration/pool-routes.test.ts
@@ -94,6 +94,11 @@ describe('Session Pool API — GET /pool + PATCH /pool/machines/:id (§L2)', () 
     expect(byId.m_a.clockSkewStatus).toBe('ok');
     expect(byId.m_b.nickname).toBe('Laptop');
     expect(byId.m_b.online).toBe(false); // never sent a heartbeat
+    // WS4.2 contract: the dashboard's per-machine empty-state strip consumes
+    // nickname + online + selfReportedLastSeen — lock the last-seen field for
+    // a machine that HAS heartbeated, so "not reachable — last seen <t>" can
+    // always be rendered honestly.
+    expect(typeof byId.m_a.selfReportedLastSeen).toBe('string');
   });
 
   it('PATCH /pool/machines/:id renames a machine; GET reflects it', async () => {

--- a/tests/unit/dashboard-machineEmptyState.test.ts
+++ b/tests/unit/dashboard-machineEmptyState.test.ts
@@ -1,0 +1,58 @@
+/**
+ * WS4.2 — per-machine empty-state strip (MULTI-MACHINE-SEAMLESSNESS-SPEC, F7).
+ *
+ * 2026-06-12 live incident (topic 13481): after the pool-tile status filter
+ * shipped, an idle Mac Mini rendered as NOTHING in the sessions view —
+ * indistinguishable from a broken or unreachable machine, and the operator
+ * read it as a regression. The sessions view must render an explicit state
+ * row per pool machine with no session tiles: "online — no active sessions"
+ * vs "not reachable — last seen <t>".
+ *
+ * Inspects the HTML/JS at rest (no browser), following the
+ * dashboard-poolTileStatusFilter.test.ts pattern.
+ */
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const html = fs.readFileSync(path.join(__dirname, '..', '..', 'dashboard', 'index.html'), 'utf-8');
+
+describe('dashboard sessions view — per-machine empty-state strip (WS4.2)', () => {
+  it('keeps a pool machine inventory gated to enabled pools with 2+ machines (single-machine strict no-op)', () => {
+    const gate = html.match(/poolMachinesView\s*=\s*\(pool && pool\.enabled[^;]+;/);
+    expect(gate, 'poolMachinesView gate not found — WS4.2 strip restructured? update this test').toBeTruthy();
+    expect(gate![0]).toContain('pool.machines.length >= 2');
+  });
+
+  it('renders both honest states: online-but-idle and not-reachable-with-last-seen', () => {
+    expect(html).toContain('online — no active sessions');
+    expect(html).toContain('not reachable — last seen');
+  });
+
+  it('renders the strip even when there are zero sessions anywhere (the empty branch)', () => {
+    // The early-return empty branch must call the strip renderer before returning,
+    // otherwise an all-idle pool regresses to the F7 blank view.
+    const emptyBranch = html.match(/if \(all\.length === 0\) \{[\s\S]{0,600}?return;\s*\}/);
+    expect(emptyBranch, 'renderSessionList empty branch not found').toBeTruthy();
+    expect(emptyBranch![0]).toContain('renderMachineStatusStrip(');
+  });
+
+  it('clears prior strip rows on every render (no duplicate accumulation)', () => {
+    expect(html).toMatch(/querySelectorAll\('\.machine-status-row'\)\.forEach\(el => el\.remove\(\)\)/);
+  });
+
+  it('a machine that has session tiles gets no redundant status row', () => {
+    const fn = html.match(/function renderMachineStatusStrip\([\s\S]+?\n    \}/);
+    expect(fn, 'renderMachineStatusStrip not found').toBeTruthy();
+    expect(fn![0]).toContain('continue');
+    expect(fn![0]).toContain('busy.has(');
+  });
+
+  it('escapes machine-provided strings (nickname/status) before injecting into the DOM', () => {
+    const fn = html.match(/function renderMachineStatusStrip\([\s\S]+?\n    \}/)![0];
+    expect(fn).toContain('escapeHtml(label)');
+    expect(fn).toContain('escapeHtml(info.text)');
+  });
+});

--- a/upgrades/next/multi-machine-seamlessness-ws42.md
+++ b/upgrades/next/multi-machine-seamlessness-ws42.md
@@ -1,0 +1,48 @@
+# Upgrade Guide — Dashboard: idle machine vs broken machine, finally distinguishable
+
+<!-- bump: patch -->
+
+## What Changed
+
+The dashboard sessions view rendered NOTHING for a pool machine with zero running
+sessions — visually identical to a machine that is offline or unreachable. Live
+incident 2026-06-12 (topic 13481): minutes after the pool-tile status filter shipped,
+an idle-but-healthy Mac Mini disappeared from the sessions view entirely and the
+operator reasonably read it as a regression.
+
+The sessions view now renders an explicit state row for every pool machine that has
+no session tiles: **"online — no active sessions"** when its heartbeat is live, or
+**"not reachable — last seen <t>"** when it is not. Data comes from the existing
+`GET /pool` machine inventory on the existing 15-second pool poll — no new routes, no
+server changes. Machines that have session tiles get no redundant row (their tiles
+already carry the machine badge). Pool disabled or single-machine: the strip is never
+rendered — strict no-op, locked by test. This is WS4.2 of the converged
+multi-machine-seamlessness spec (`docs/specs/MULTI-MACHINE-SEAMLESSNESS-SPEC.md`,
+3-round convergence, 91 findings addressed), whose audit and ELI16 companion ship in
+this same PR.
+
+## What to Tell Your User
+
+- "Your dashboard's session list now tells you the state of every machine, even the
+  quiet ones — an idle machine says 'online — no active sessions' instead of showing
+  nothing, so you can always tell a resting machine from a broken one."
+
+## Summary of New Capabilities
+
+| Capability | How to Use |
+|-----------|-----------|
+| Per-machine empty-state in the sessions view | Automatic — open the dashboard sessions list on any multi-machine pool |
+
+## Evidence
+
+- New test file `tests/unit/dashboard-machineEmptyState.test.ts` (6 tests, at-rest
+  HTML/JS assertions following the established dashboard test pattern) — proven
+  failing 6/6 against the pre-change file, all pass on the fix. Covers: the
+  single-machine no-op gate, both honest state strings, the zero-sessions branch,
+  no-duplicate-rows reconciliation, no redundant rows for busy machines, and HTML
+  escaping of machine-provided strings.
+- `tests/integration/pool-routes.test.ts` extended to lock the `/pool` contract field
+  (`selfReportedLastSeen`) the strip consumes.
+- Side-effects artifact: `upgrades/side-effects/multi-machine-seamlessness-ws42.md`.
+- Spec: `docs/specs/MULTI-MACHINE-SEAMLESSNESS-SPEC.md` (converged + approved) with
+  convergence report `docs/specs/reports/multi-machine-seamlessness-convergence.md`.

--- a/upgrades/side-effects/multi-machine-seamlessness-ws42.md
+++ b/upgrades/side-effects/multi-machine-seamlessness-ws42.md
@@ -1,0 +1,59 @@
+# Side-Effects Review — WS4.2 per-machine empty-state strip (dashboard sessions view)
+
+**Spec:** docs/specs/MULTI-MACHINE-SEAMLESSNESS-SPEC.md (converged 2026-06-12, 3 iterations; approved)
+**Change:** dashboard/index.html (+ tests). The sessions view renders an explicit state
+row for every pool machine that has no session tiles: "online — no active sessions"
+when its heartbeat is live, "not reachable — last seen <t>" when not. Data: the
+existing `GET /pool` machines array, fetched on the existing 15s pool poll cadence.
+Closes audit finding F7 (2026-06-12 live incident: idle Mini rendered as nothing and
+read as a regression).
+
+## 1. Over-block
+No issue identified — the change blocks nothing. It is a read-only presentation
+addition; no input is rejected anywhere.
+
+## 2. Under-block
+No issue identified — there is no blocking surface. Honesty boundary worth naming:
+`online:false` cannot distinguish "deliberately shut down" from "network-unreachable",
+so the row says "not reachable — last seen <t>" (data-honest) rather than claiming to
+know which. The spec's three-state wording maps onto the two states the data supports;
+this is recorded as the deliberate build decision the converged spec's round-3
+adversarial pass classified as adequately constrained.
+
+## 3. Level-of-abstraction fit
+Right layer. The dashboard already consumes `/pool` (Machines tab) and
+`/sessions?scope=pool` (tiles); the strip is pure client-side composition of data both
+endpoints already serve. No new route, no server change. A server-side "empty
+machines" field would duplicate client-known state at a worse layer.
+
+## 4. Signal vs authority compliance
+Compliant by vacuity: the change introduces NO decision point — it gates no flow,
+filters no message, constrains no behavior. (Phase-1 principle check recorded the
+same conclusion in the build transcript.)
+
+## 5. Interactions
+- The strip renders AFTER session tiles and clears its own rows per render — no
+  interference with tile add/remove reconciliation (verified by test: no duplicate
+  accumulation).
+- The zero-sessions early-return branch now also renders the strip; the existing
+  #emptyState banner still shows alongside it (intended: "no sessions" + per-machine
+  states are complementary, not contradictory).
+- A machine WITH tiles gets no row (its tiles' machine badge already names it) —
+  prevents double-labeling.
+- The extra `GET /pool` per 15s poll tick matches the Machines tab's existing call
+  pattern and is auth'd identically (apiFetch). Failure is swallowed best-effort: the
+  strip simply stays absent until the next tick — degraded view, never an error loop.
+
+## 6. External surfaces
+None beyond the operator's own PIN-gated dashboard. No new data is exposed: nickname,
+online, lastSeen are already rendered on the Machines tab. Machine-provided strings
+are escaped before DOM injection (tested). Single-machine agents: `poolMachinesView`
+is populated only when the pool is enabled with 2+ machines — strict no-op, tested.
+
+## 7. Rollback cost
+Trivial: revert the dashboard/index.html hunk (static asset; no data, no migration,
+no state). Ships with the next release; rollback is a one-commit revert and re-release.
+
+## Second-pass review
+Not required — no block/allow decisions, no session lifecycle, no
+gate/sentinel/watchdog surface. (Phase-5 trigger list consulted; none match.)


### PR DESCRIPTION
## What

Two things ride together (the spec docs anchor the change they authorize):

1. **The converged Multi-Machine Seamlessness spec** — the unified gap-closure spec for the ~20 UX seams found in today's live audit (topic 13481): `docs/specs/MULTI-MACHINE-SEAMLESSNESS-SPEC.md` + ELI16 companion + 3-round convergence report (62 → 29 → 0 material findings; security/scalability/adversarial/integration/lessons + Gemini external) + the source audit `docs/research/multi-machine-ux-gap-audit-2026-06-12.md`.

2. **WS4.2, the spec's first build item**: the dashboard sessions view renders an explicit per-machine state row — **"online — no active sessions"** vs **"not reachable — last seen \<t\>"** — for any pool machine with no session tiles. Closes audit finding F7 (live incident 2026-06-12: an idle-but-healthy Mac Mini rendered as nothing and read as a regression).

## How

Client-side only: the existing `GET /pool` machine inventory on the existing 15s pool poll. No new routes. Machines with tiles get no redundant row; pool-disabled/single-machine is a strict no-op (tested); machine-provided strings escaped (tested).

## Evidence

- `tests/unit/dashboard-machineEmptyState.test.ts` — 6 at-rest tests, proven failing 6/6 against the pre-change file, green on the fix.
- `tests/integration/pool-routes.test.ts` — locks the `selfReportedLastSeen` contract field the strip consumes.
- Side-effects review: `upgrades/side-effects/multi-machine-seamlessness-ws42.md` (no decision points; second-pass not-required).
- Release-note fragment: `upgrades/next/multi-machine-seamlessness-ws42.md`.

Plain-English overview of the whole initiative: `docs/specs/multi-machine-seamlessness.eli16.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## ELI16 — the dashboard now tells you when a machine is just resting

Your agent can run on several computers at once, and the dashboard lists every
running session across all of them. But a machine with NOTHING running showed
nothing at all — so a perfectly healthy, idle Mac Mini looked exactly like one
that had crashed or fallen off the network. This happened for real today: the
operator saw an empty list and reasonably thought the feature had broken.

This change gives every quiet machine an explicit line in the sessions list:
"online — no active sessions" when it's healthy and just idle, or "not
reachable — last seen 20 minutes ago" when it actually can't be contacted.
The data was already there (the same heartbeat info the Machines tab uses);
the dashboard just never said it out loud. Nothing changes for anyone running
on a single machine, and nothing new can be clicked or broken — it's purely
honest labeling. The bundled spec documents (the multi-machine "seamlessness"
plan this is the first piece of) describe the rest of the roadmap; they're
documentation only and change no behavior in this PR.
