### PR TITLE
feat(dispatch): WS1.1 dispatch-to-owner hardening — spawn re-check, capability flags, skew gate (F1/F20)

### DIFF
--- a/.instar/instar-dev-decisions/2026-06-12T23-59-09-166Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-06-12T23-59-09-166Z-unknown.json
@@ -1,0 +1,13 @@
+{
+  "ts": "2026-06-12T23:59:09.166Z",
+  "slug": "unknown",
+  "suggestedTier": 2,
+  "declaredTier": 2,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 4,
+  "loc": 79,
+  "causalAutopsy": null,
+  "verdict": "pass"
+}

--- a/docs/eli16/multi-machine-seamlessness-ws11.md
+++ b/docs/eli16/multi-machine-seamlessness-ws11.md
@@ -1,0 +1,41 @@
+# Messages That Find Their Owner — Plain-English Overview
+
+## Where this fits
+
+The big queue that merged earlier today gave conversations a safe waiting room:
+messages that can't be delivered right now sit safely on disk instead of getting
+lost or delivered to the wrong machine. It even shipped the "receiving dock" — a
+machine can accept a forwarded message with proof of ownership and a durable
+receipt. This change adds the three guards that complete the delivery story.
+
+## The three guards
+
+**1. No more accidental twins.** Between "this message should spawn a session here"
+and the session actually spawning, ownership of the conversation can move to
+another machine. Before: the spawn happened anyway — two machines, two sessions,
+same conversation. Now the spawn re-checks ownership at the last moment and sends
+the message back to the waiting room if the answer changed.
+
+**2. Machines now advertise what they can safely receive.** Each machine's
+heartbeat carries a tiny capability note: "I can durably receive forwarded
+messages." A machine that can't (older version, or its queue is switched off)
+simply doesn't advertise — and that absence is itself the safety signal.
+
+**3. Never rob a healthy machine.** Without guard 2, forwarding a message to a
+machine that can't receive it would fail repeatedly — and the failure handler
+would conclude the machine was dead and TAKE the conversation from it. A perfectly
+healthy machine, robbed because it hadn't upgraded yet. Now the sender checks the
+advertisement first: can't receive → the message waits safely in the queue, and
+delivery resumes the moment the machine upgrades (its next heartbeat says so).
+
+## Phase C note
+
+The capability note is the same fixed size whether the pool has 2 machines or 200
+cloud VMs; the checks are instant local reads; nothing assumes machines share a
+network or have a human at the keyboard.
+
+## What changes for you
+
+Nothing visible — all of this lives inside the multi-machine layer, which still
+ships dark. When the layer lights up, conversations move between machines without
+twins, theft, or losses — which is the whole point of the seamless experience.

--- a/src/commands/server.ts
+++ b/src/commands/server.ts
@@ -451,6 +451,9 @@ let _inboundQueueStop: ((sessionKey: string) => void) | null = null;
  *  (forward/spawn on another machine → must NOT also dispatch locally) from a
  *  self placement. Set once in startServer()'s mesh block. */
 let _meshSelfId: string | null = null;
+/** WS1.1: read-only ownership lookup for the drain's spawn-boundary re-check
+ *  (the registry is constructed later in startServer's pool block). */
+let _ownershipReadForDrain: ((sessionKey: string) => import('../core/SessionOwnership.js').SessionOwnershipRecord | null) | null = null;
 /** Resolve the current router (Telegram-owning lease holder)'s base URL, or null if
  *  this machine IS the router / none is known. Used by the owner-side resume to fetch
  *  a moved topic's prior history from the router (bug #2). Set in the mesh block where
@@ -2184,6 +2187,22 @@ export function wireTelegramRouting(
       }
     }
 
+    // WS1.1 (MULTI-MACHINE-SEAMLESSNESS-SPEC): ownership re-check at the SPAWN
+    // boundary. route() consulted ownership above, but ownership can move in
+    // the window between that verdict and this spawn (entry queued under owner
+    // A, transferred to B mid-queue, drained on A) — a non-owner spawn is the
+    // double-session bug (audit F20). Bounce to un-routable: the entry
+    // re-queues and the next drain pass re-routes against FRESH ownership
+    // (forward to the real owner / queue). Direct-inject into an EXISTING
+    // local session above is not gated — a live local session for the topic is
+    // itself the strongest local-serving signal, and the reconciler/closeout
+    // own its lifecycle.
+    if (_ownershipReadForDrain && _meshSelfId) {
+      const ownRec = _ownershipReadForDrain(dmsg.sessionKey);
+      if (ownRec && ownRec.status === 'active' && ownRec.ownerMachineId !== _meshSelfId) {
+        return { kind: 'un-routable', reason: 'ownership-moved-before-spawn' };
+      }
+    }
     // Respawn / auto-spawn path. The spawn-in-progress guard maps to
     // un-routable (§3.1) — never a silent skip.
     if (spawningTopics.has(topicId)) {
@@ -12631,6 +12650,10 @@ export async function startServer(options: StartOptions): Promise<void> {
                 loadAvg: osMod.loadavg()[0],
                 quotaState: selfQuotaState(),
                 guardPosture: selfGuardPosture(),
+                // WS1.1 capability advertisement (spec invariant 5): a bounded
+                // fixed-size summary, never an inventory. Reported live each
+                // heartbeat so a queue going dark withdraws the capability.
+                seamlessnessFlags: { ws11DeliverReceive: !!_inboundQueue },
                 // Durable Inbound Message Queue §5.1: depth + oldest + tenure +
                 // bounded top-K — the survivor's loss-SUSPECTED item, capped
                 // re-placement arm, and supersede-dedupe key all read these.
@@ -12717,6 +12740,10 @@ export async function startServer(options: StartOptions): Promise<void> {
           logger: (m: string) => console.log(pc.dim(`  ${m}`)),
         });
         const ownReg = sessionOwnershipRegistry;
+        // WS1.1: expose a read-only ownership lookup to the drain's
+        // spawn-boundary re-check (module-scope; the drain closure is defined
+        // before this block runs).
+        _ownershipReadForDrain = (sk) => ownReg.read(sk);
         // ── WS3 one-voice: bind the election's late pool deps ──
         // From here on the SpeakerElection sees the real pool: online machine
         // ids from the capacity registry and live topic ownership from the
@@ -13719,6 +13746,16 @@ export async function startServer(options: StartOptions): Promise<void> {
             // sending its sessions down the existing failover re-place path
             // without each message re-paying the retry tax.
             isMachineAlive: (m) => m === meshSelfId || ((machinePoolRegistry?.getCapacity(m)?.online ?? false) && !ownerSuspectBreaker.isSuspect(m)),
+            // WS1.1 skew gate: read the owner's advertised receive capability
+            // from its last heartbeat. A peer with NO flags field is an older
+            // version → false (the conservative side: queue, don't forward into
+            // a 501→failover steal). A peer the registry doesn't know → null
+            // (unknown; the alive-check upstream already filters those).
+            ownerSupportsForward: (m) => {
+              const cap = machinePoolRegistry?.getCapacity(m);
+              if (!cap) return null;
+              return cap.seamlessnessFlags?.ws11DeliverReceive === true;
+            },
             markOwnerSuspect: (m) => ownerSuspectBreaker.markSuspect(m),
             onOwnerResponsive: (m) => ownerSuspectBreaker.recordSuccess(m),
             casClaimOwnership: (sk, machineId) => {

--- a/src/core/MachinePoolRegistry.ts
+++ b/src/core/MachinePoolRegistry.ts
@@ -109,6 +109,10 @@ export interface HeartbeatObservation {
   /** The machine's self-reported LLM-account quota state (quota-aware placement,
    *  2026-06-05). Absent = unknown (older heartbeats) = treated as not blocked. */
   quotaState?: MachineCapacity['quotaState'];
+  /** WS1.1 (MULTI-MACHINE-SEAMLESSNESS-SPEC invariant 5): the machine's
+   *  self-advertised seamlessness capabilities. Absent = pre-spec peer or
+   *  feature dark = non-participant (the conservative side). */
+  seamlessnessFlags?: MachineCapacity['seamlessnessFlags'];
   /** Compact guard-posture summary (GUARD-POSTURE-ENDPOINT-SPEC §2.3). The
    *  caller keys the observation on the REGISTRY's machine identity — this
    *  field is the peer's self-reported DATA, never its identity. Absent =
@@ -263,6 +267,10 @@ export class MachinePoolRegistry {
       clockSkewStatus: live?.skew.status ?? 'ok',
       quotaState: live?.obs.quotaState,
       inboundQueue: live?.obs.inboundQueue,
+      // WS1.1: capability advertisement passthrough. LIVE observation only —
+      // a peer that goes dark stops advertising (no durable fallback), which
+      // is the safe direction: senders queue instead of forwarding blind.
+      seamlessnessFlags: live?.obs.seamlessnessFlags,
       // Guard posture: live observation first, durable last-known second —
       // a machine with no posture EVER received carries neither field
       // (renders "guards: unknown", never "0 on / 0 off").

--- a/src/core/SessionRouter.ts
+++ b/src/core/SessionRouter.ts
@@ -128,6 +128,17 @@ export interface SessionRouterDeps {
   machineRegistry: () => MachineCapacity[];
   resolveOwnership: (sessionKey: string) => OwnershipView;
   isMachineAlive: (machineId: string) => boolean;
+  /** WS1.1 (MULTI-MACHINE-SEAMLESSNESS-SPEC invariant 5): does the owner peer
+   *  advertise the ws11DeliverReceive capability in its heartbeat?
+   *  true  → forward normally.
+   *  false → the peer is ALIVE but cannot durably receive (older version or
+   *          its queue is dark): forwarding would 501→retry→failover-STEAL
+   *          from a live owner — instead the message waits in OUR durable
+   *          queue (the conservative side; bounded by the queue's own shelf
+   *          life + the owner's flags flipping true on upgrade/next heartbeat).
+   *  null  → unknown (no flags signal wired) — proceed as before (back-compat).
+   *  Absent dep → proceed as before. */
+  ownerSupportsForward?: (machineId: string) => boolean | null;
   /** SYNCHRONOUS per-session CAS-claim (the §L−1 single-ref fast-forward push). */
   casClaimOwnership: (sessionKey: string, machineId: string, expectedEpoch: number) => { ok: boolean; epoch: number };
   /** ONE deliverMessage attempt over MeshRpc; throws on transport error/timeout. */
@@ -222,6 +233,16 @@ export class SessionRouter {
         return { action: 'handled-locally', owner: own.owner, acked: true };
       }
       if (this.deps.isMachineAlive(own.owner)) {
+        // WS1.1 skew gate: a live owner that does NOT advertise the durable
+        // receive capability must not be forwarded to (501→retry→failover
+        // would STEAL from a live machine). The message waits in OUR durable
+        // queue until the owner's flags flip (upgrade / queue re-enabled) or
+        // ownership genuinely moves. Unknown (null) proceeds — back-compat.
+        const supports = this.deps.ownerSupportsForward?.(own.owner) ?? null;
+        if (supports === false) {
+          const q = this.deps.queueMessage(msg, 'owner-lacks-ws11-receive');
+          return { action: 'queued', detail: 'owner-lacks-ws11-receive', acked: q === 'queued' || q === 'already-queued' };
+        }
         return this.forwardToOwner(msg, own.owner, own.epoch, 0);
       }
       // Owner is not alive → owner-dead re-placement (§L4 fallback).

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -1904,6 +1904,19 @@ export interface MachineCapacity {
     tenure: string | null;
     topK: Array<{ sessionKey: string; depth: number }>;
   };
+  /** WS1.1 (MULTI-MACHINE-SEAMLESSNESS-SPEC invariant 5): bounded summary of
+   *  this machine's seamlessness capabilities, advertised in the capacity
+   *  heartbeat (rides the same authenticated envelope as the rest of the
+   *  report). ABSENT = the peer predates this spec OR the feature is dark =
+   *  non-participant for every gated workstream (the conservative side —
+   *  senders never forward to a peer that cannot durably receive; the journal
+   *  applier's silently-drop-unknown-kinds behavior is the named skew-failure
+   *  mode this gate prevents). Fixed-size booleans only — never an inventory. */
+  seamlessnessFlags?: {
+    /** This machine can durably RECEIVE forwarded inbound messages (the
+     *  'deliverMessage' receiver handler + live durable queue). */
+    ws11DeliverReceive?: boolean;
+  };
   /** Compact guard-posture summary self-reported in the capacity heartbeat
    *  (GUARD-POSTURE-ENDPOINT-SPEC §2.3). Bound to the AUTHENTICATED sender at
    *  ingestion (a body-claimed machineId can never overwrite another machine's

--- a/tests/unit/SessionRouter.test.ts
+++ b/tests/unit/SessionRouter.test.ts
@@ -257,3 +257,48 @@ describe('isRemotelyHandled (inbound dispatch short-circuit — bug #8)', () => 
     expect(isRemotelyHandled(oc('spawned', null), null)).toBe(false);
   });
 });
+
+// ── WS1.1 (MULTI-MACHINE-SEAMLESSNESS-SPEC invariant 5): the version-skew gate ──
+// A LIVE owner that does not advertise the ws11DeliverReceive capability must
+// never be forwarded to: the forward would 501 → retry → failover-STEAL from a
+// live machine. The message waits in OUR durable queue instead.
+describe('SessionRouter — ownerSupportsForward skew gate (WS1.1)', () => {
+  const remoteOwned = () => ({ owner: 'm_remote', epoch: 7, status: 'active' }) as OwnershipView;
+
+  it('owner advertises support (true) → forwards normally', async () => {
+    const deliver = vi.fn(async () => ({ messageId: 'evt-1', accepted: 'queued' }) as DeliverAck);
+    const { router } = makeRouter({ resolveOwnership: remoteOwned, deliverMessage: deliver, ownerSupportsForward: () => true });
+    const out = await router.route(msg());
+    expect(out).toMatchObject({ action: 'forwarded', acked: true });
+    expect(deliver).toHaveBeenCalled();
+  });
+
+  it('owner does NOT advertise support (false) → message queues durably, NO forward, NO ownership steal', async () => {
+    const deliver = vi.fn(async () => ({ messageId: 'evt-1', accepted: 'queued' }) as DeliverAck);
+    const queue = vi.fn(() => 'queued' as const);
+    const cas = vi.fn((_s: string, _m: string, e: number) => ({ ok: true, epoch: e + 1 }));
+    const { router } = makeRouter({
+      resolveOwnership: remoteOwned, deliverMessage: deliver,
+      ownerSupportsForward: () => false, queueMessage: queue, casClaimOwnership: cas,
+    });
+    const out = await router.route(msg());
+    expect(out).toMatchObject({ action: 'queued', detail: 'owner-lacks-ws11-receive', acked: true });
+    expect(deliver).not.toHaveBeenCalled(); // never a doomed forward
+    expect(cas).not.toHaveBeenCalled();     // never a steal from a live owner
+  });
+
+  it('capability unknown (null) → proceeds to forward (back-compat)', async () => {
+    const deliver = vi.fn(async () => ({ messageId: 'evt-1', accepted: 'queued' }) as DeliverAck);
+    const { router } = makeRouter({ resolveOwnership: remoteOwned, deliverMessage: deliver, ownerSupportsForward: () => null });
+    const out = await router.route(msg());
+    expect(out).toMatchObject({ action: 'forwarded' });
+    expect(deliver).toHaveBeenCalled();
+  });
+
+  it('dep absent → exactly today\'s behavior (forwards)', async () => {
+    const deliver = vi.fn(async () => ({ messageId: 'evt-1', accepted: 'queued' }) as DeliverAck);
+    const { router } = makeRouter({ resolveOwnership: remoteOwned, deliverMessage: deliver });
+    const out = await router.route(msg());
+    expect(out).toMatchObject({ action: 'forwarded' });
+  });
+});

--- a/tests/unit/session-pool-activation-wiring.test.ts
+++ b/tests/unit/session-pool-activation-wiring.test.ts
@@ -38,12 +38,12 @@ describe('Session Pool activation wiring (§L4)', () => {
   it('the SessionRouter is constructed with the real registry/ownership/placement + outbound mesh client', () => {
     const idx = src.indexOf('new routerMod.SessionRouter({');
     expect(idx).toBeGreaterThan(0);
-    // Window 4000 (was 3200, was 2000): the coherence-journal emitPlacement
-    // pairing (spec §3.3, enforced by lint-cas-emit-placement) and then the
-    // TOPIC-PROFILE-SPEC §5.3 acquire seam (the `_topicProfileCarrier?.onTopicAcquired`
-    // pull inside casClaimOwnership) added lines inside the construction, pushing
-    // the later assertions out.
-    const block = src.slice(idx, idx + 4000);
+    // Window 5000 (was 4000, 3200, 2000): the coherence-journal emitPlacement
+    // pairing (spec §3.3), the TOPIC-PROFILE-SPEC §5.3 acquire seam, and then
+    // the WS1.1 ownerSupportsForward skew gate (MULTI-MACHINE-SEAMLESSNESS-SPEC)
+    // added lines inside the construction, pushing the later assertions out
+    // (deliverMessage: now sits ~4200 chars in).
+    const block = src.slice(idx, idx + 5000);
     // The registry dep filters suspect machines from placement candidates
     // (owner-suspect breaker, P19) with an all-suspect unfiltered fallback —
     // still sourced from the REAL machinePoolRegistry capacities.

--- a/tests/unit/ws11-dispatch-to-owner-wiring.test.ts
+++ b/tests/unit/ws11-dispatch-to-owner-wiring.test.ts
@@ -1,0 +1,74 @@
+/**
+ * WS1.1 — dispatch-to-owner (MULTI-MACHINE-SEAMLESSNESS-SPEC): the pieces the
+ * queue merge (#1079) did NOT ship. (The receiver half — epoch fencing, durable
+ * remote receipts, sender re-validation — shipped with the queue and has its
+ * own suite; SessionRouter.test.ts covers the new skew gate's decision table.)
+ *
+ *  1. seamlessnessFlags roundtrip: heartbeat observation → getCapacity, with
+ *     ABSENT = non-participant (older peer) and live-only passthrough.
+ *  2. The drain spawn-boundary ownership re-check seam (TOCTOU double-spawn
+ *     guard) — source-level assertions on the server wiring, following the
+ *     established dashboard/ws3 at-rest pattern.
+ */
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { MachinePoolRegistry } from '../../src/core/MachinePoolRegistry.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const serverSrc = fs.readFileSync(path.join(__dirname, '..', '..', 'src', 'commands', 'server.ts'), 'utf-8');
+
+describe('WS1.1 — seamlessnessFlags heartbeat roundtrip', () => {
+  function makeRegistry() {
+    return new MachinePoolRegistry({
+      listMachines: () => [
+        { machineId: 'm_new', nickname: 'new' },
+        { machineId: 'm_old', nickname: 'old' },
+      ],
+    } as ConstructorParameters<typeof MachinePoolRegistry>[0]);
+  }
+
+  it('a heartbeat carrying ws11DeliverReceive surfaces on getCapacity; a peer without flags has the field ABSENT', () => {
+    const reg = makeRegistry();
+    reg.recordHeartbeat({ machineId: 'm_new', selfReportedLastSeen: new Date().toISOString(), seamlessnessFlags: { ws11DeliverReceive: true } });
+    reg.recordHeartbeat({ machineId: 'm_old', selfReportedLastSeen: new Date().toISOString() }); // pre-spec peer
+    expect(reg.getCapacity('m_new')?.seamlessnessFlags?.ws11DeliverReceive).toBe(true);
+    expect(reg.getCapacity('m_old')?.seamlessnessFlags).toBeUndefined(); // absent = non-participant
+  });
+
+  it('the advertisement is LIVE-only: withdrawing it on a later heartbeat withdraws the capability', () => {
+    const reg = makeRegistry();
+    reg.recordHeartbeat({ machineId: 'm_new', selfReportedLastSeen: new Date().toISOString(), seamlessnessFlags: { ws11DeliverReceive: true } });
+    reg.recordHeartbeat({ machineId: 'm_new', selfReportedLastSeen: new Date().toISOString() }); // queue went dark
+    expect(reg.getCapacity('m_new')?.seamlessnessFlags).toBeUndefined();
+  });
+});
+
+describe('WS1.1 — server wiring seams (at-rest)', () => {
+  it('the self-heartbeat advertises ws11DeliverReceive from the LIVE queue handle', () => {
+    expect(serverSrc).toMatch(/seamlessnessFlags: \{ ws11DeliverReceive: !!_inboundQueue \}/);
+  });
+
+  it('the drain spawn boundary re-checks ownership and bounces non-owner spawns to un-routable', () => {
+    const seam = serverSrc.match(/_ownershipReadForDrain && _meshSelfId[\s\S]{0,400}/);
+    expect(seam, 'drain spawn-boundary re-check missing').toBeTruthy();
+    expect(seam![0]).toContain("ownership-moved-before-spawn");
+    expect(seam![0]).toContain("'un-routable'");
+  });
+
+  it('the re-check guards the SPAWN path only (placed before the spawn-in-progress guard, after direct-inject)', () => {
+    const spawnGuardIdx = serverSrc.indexOf("reason: 'spawn-in-progress'");
+    const recheckIdx = serverSrc.indexOf("ownership-moved-before-spawn");
+    const directInjectIdx = serverSrc.indexOf('Direct inject: receipt FIRST');
+    expect(recheckIdx).toBeGreaterThan(directInjectIdx);
+    expect(recheckIdx).toBeLessThan(spawnGuardIdx);
+  });
+
+  it('the router wiring resolves ownerSupportsForward from the peer heartbeat flags (absent flags → false, unknown peer → null)', () => {
+    const wiring = serverSrc.match(/ownerSupportsForward: \(m\) => \{[\s\S]{0,400}/);
+    expect(wiring, 'ownerSupportsForward wiring missing').toBeTruthy();
+    expect(wiring![0]).toContain('seamlessnessFlags?.ws11DeliverReceive === true');
+    expect(wiring![0]).toContain('return null');
+  });
+});

--- a/upgrades/next/multi-machine-seamlessness-ws11.md
+++ b/upgrades/next/multi-machine-seamlessness-ws11.md
@@ -1,0 +1,50 @@
+# Upgrade Guide — Dispatch-to-owner hardening: no twins, no theft, capability-gated forwards
+
+<!-- bump: patch -->
+
+## What Changed
+
+WS1.1 of the converged multi-machine-seamlessness spec — the pieces the durable-queue
+merge (#1079, which already shipped the receiver half) did not cover:
+
+- **Drain spawn-boundary ownership re-check**: ownership moving between route()'s
+  verdict and the spawn produced the F20 double-spawn; a non-owner spawn now bounces
+  to `un-routable ('ownership-moved-before-spawn')` and re-queues for re-routing.
+- **`MachineCapacity.seamlessnessFlags`** (spec invariant 5): bounded fixed-size
+  capability advertisement (`ws11DeliverReceive`) on the authenticated heartbeat,
+  live-only (a dark queue withdraws it next heartbeat). Absent = non-participant.
+- **Sender-side skew gate** (`SessionRouter.ownerSupportsForward`): a live owner not
+  advertising durable receive is never forwarded to — the 501→retry→failover path
+  would STEAL the conversation from a healthy machine. Messages wait in the durable
+  queue, self-healing on the owner's upgrade. Unknown/absent → exactly today's
+  behavior.
+
+Inert without the pool/queue layer (ships dark). Phase-C clean: fixed-size
+advertisement, O(1) local reads, no LAN or interactive assumptions.
+
+## What to Tell Your User
+
+- "When my conversations move between machines, three new guards make the handoff
+  airtight: no duplicate sessions from mid-move races, machines only receive
+  forwarded messages they can durably accept, and a machine that's merely behind on
+  updates never gets its conversations taken away — messages just wait safely until
+  it catches up."
+
+## Summary of New Capabilities
+
+| Capability | How to Use |
+|-----------|-----------|
+| Capability-gated cross-machine delivery | Automatic within the multi-machine layer (dark until enabled) |
+
+## Evidence
+
+- `tests/unit/SessionRouter.test.ts` +4: the skew gate's full decision table (true →
+  forward; false → queue, NO deliver, NO cas-steal; null/absent → back-compat).
+- `tests/unit/ws11-dispatch-to-owner-wiring.test.ts` — 6: flags heartbeat roundtrip
+  incl. live-only withdrawal; the drain re-check seam + its exact placement (after
+  direct-inject, before spawn) pinned by source indices.
+- 163 tests green across the queue/router/handler suites; tsc clean; build green.
+- Independent second-pass audit (mandatory — dispatch + ownership surface): CONCUR,
+  6 verification notes, zero concerns — including proof the gate cannot lose a
+  message (refused-queue falls through to delivery, never a drop) and never marks a
+  flag-gated owner suspect. `upgrades/side-effects/multi-machine-seamlessness-ws11.md`.

--- a/upgrades/side-effects/multi-machine-seamlessness-ws11.md
+++ b/upgrades/side-effects/multi-machine-seamlessness-ws11.md
@@ -1,0 +1,105 @@
+# Side-Effects Review — WS1.1 dispatch-to-owner (the remaining pieces)
+
+**Spec:** docs/specs/MULTI-MACHINE-SEAMLESSNESS-SPEC.md §WS1.1 (converged + approved, on main)
+**Ground truth discovered during build:** the durable-queue merge (#1079) ALREADY
+shipped WS1.1's receiver half — `createDeliverMessageHandler` (epoch fencing, durable
+remote receipts via the queue store + message ledger, sender re-validation, the
+owner-side accept bridge with working-set + topic-profile pulls) — and the router's
+forward/queue verdicts. This change ships ONLY what was genuinely missing:
+
+1. **Drain spawn-boundary ownership re-check** (`_ownershipReadForDrain`): route()'s
+   verdict and the spawn are not atomic — ownership moving in that window produced
+   the F20 double-spawn. A non-owner spawn now bounces to `un-routable
+   ('ownership-moved-before-spawn')`; the entry re-queues and the next drain pass
+   re-routes against fresh ownership. Direct-inject into an EXISTING live local
+   session is deliberately not gated (a live local session is the strongest
+   local-serving signal; its lifecycle belongs to the reconciler/closeout).
+2. **`MachineCapacity.seamlessnessFlags` advertisement** (invariant 5): a bounded
+   fixed-size summary (`ws11DeliverReceive`) self-reported each heartbeat from the
+   LIVE queue handle; registry passthrough is live-observation-only (a peer going
+   dark withdraws the capability — the safe direction). Absent = pre-spec peer or
+   dark feature = non-participant.
+3. **Sender-side skew gate** (`SessionRouter.ownerSupportsForward`): a LIVE owner
+   that does not advertise durable receive is never forwarded to — the forward would
+   501 → retry → failover-STEAL from a live machine (the worst skew outcome). The
+   message waits in OUR durable queue (`'owner-lacks-ws11-receive'`), bounded by the
+   queue's own shelf life and self-healing on the owner's next heartbeat after
+   upgrade. Unknown (null) and absent-dep both preserve today's exact behavior.
+
+## 1. Over-block
+The skew gate can hold messages for a live-but-unflagged owner. Bounds: the queue's
+existing shelf-life/loss-reporting (never silent), the flags flipping true on the
+owner's next heartbeat after its queue enables, and ownership genuinely moving. The
+alternative (forward → 501 → failover steal) takes a conversation from a healthy
+machine — strictly worse. Unknown-capability peers are NOT held (null → forward),
+so the gate cannot over-trigger from a missing signal.
+
+## 2. Under-block
+The drain re-check is a point-read — ownership can still move between the re-check
+and the spawn completing (a narrower TOCTOU). The receipt + ledger dedup bound the
+damage to one extra session at worst, which the post-transfer closeout reaps; full
+elimination belongs to WS1.2's drain barrier. Named honestly, not silently claimed.
+
+## 3. Level-of-abstraction fit
+Each piece sits at its owning layer: the re-check at the spawn boundary (the only
+place the race exists), the flags on the existing heartbeat carrier (no new channel),
+the gate in the router's dispatch decision (beside isMachineAlive, the analogous
+check). No parallel mechanisms.
+
+## 4. Signal vs authority compliance
+The skew gate holds narrow custody authority (queue vs forward) over a deterministic
+signal (the peer's own self-advertisement on an authenticated heartbeat) and fails
+open to today's behavior on unknown. The drain re-check removes a wrong action
+(non-owner spawn) rather than adding authority. No message content, no user actions.
+
+## 5. Interactions
+- Composes with the queue's hold-for-stability: a gated message is an ordinary queued
+  entry (same caps, same loss reporting, same drain re-routing).
+- The existing receiver handler is untouched; the gate only prevents doomed sends.
+- The reconciler (WS1.3, in CI) shortens how long ownership stays pointed at a
+  machine that can't serve — the two compose toward faster convergence.
+- OwnerSuspectBreaker semantics preserved: the gate fires BEFORE forwarding, so a
+  flag-gated owner is never marked suspect for a 501 it never got to return.
+
+## 6. External surfaces
+A new optional heartbeat field (additive; older peers ignore it — the established
+quotaState/guardPosture precedent). No new mesh verbs, no new routes.
+
+## 7. Multi-machine posture (Cross-Machine Coherence)
+This IS the multi-machine correctness core. Flags: replicated via the authenticated
+heartbeat (named path), live-only by design. Gate + re-check: per-machine local
+reads only on hot paths (spec rule). Phase C: the advertisement is fixed-size
+regardless of pool size (never an inventory); the gate's per-owner read is O(1)
+against the local registry; nothing assumes 2 machines or a LAN; headless VMs
+advertise identically (no interactive step).
+
+## 8. Rollback cost
+All three pieces are inert without the pool/queue layer (which ships dark).
+Flag-flip rollback: disabling the queue withdraws the self-advertisement on the next
+heartbeat AND nulls `_inboundQueue` (the gate's information source degrades to
+null → today's behavior). The heartbeat field is additive data — no migration, no
+cleanup. Revert-and-release covers the code.
+
+## Second-pass review
+REQUIRED (inbound dispatch + ownership surface). Independent reviewer response
+appended below.
+
+<!-- second-pass reviewer response appended below by the independent reviewer -->
+
+### Independent second-pass review (2026-06-12)
+
+**Concur with the review.**
+
+1. **Skew gate never marks a flag-gated owner suspect — verified.** In `SessionRouter.dispatchOne` (SessionRouter.ts:241-245) the `supports === false` branch returns a `queued` outcome and early-exits BEFORE `forwardToOwner`. `markOwnerSuspect` is only reachable inside `forwardToOwner` (line 306) and the owner-dead branch (249); the queue path touches neither. `tests/unit/SessionRouter.test.ts:276` asserts both `deliver` and `cas` are NOT called on the false case, structurally proving the gate fires first and no steal/suspect occurs. The artifact's §5 claim is true.
+
+2. **Gate + queue cannot lose a message — verified safe.** When the gate fires and `queueMessage` returns `'refused'` (queue dark / storage fail), the router returns `acked: false`. At the ingress gate (server.ts:1970-1983) `isRemotelyHandled` is false and the custody short-circuit at 1978 requires `outcome.acked` true, so an un-acked `queued` falls through to local dispatch (line 2000+) — delivery, not a drop. This is exactly the spec's layered rule (invariant 5 line 96-97 "durable queue where available, else today's exact behavior"): the §3 queue path covers queue-available, the refused fall-through covers no-queue. The implementation satisfies BOTH the invariant-5 conservative-side clause and the §WS1.1 line-137 "local inject, never a drop" clause — no contradiction.
+
+3. **Drain re-check placement is correct — verified.** server.ts:2200-2205 runs AFTER `route()` (2142) and AFTER the direct-inject path (which returns at 2184/2186), only on the spawn path, guarded by `_ownershipReadForDrain && _meshSelfId` (null on a dark/single-machine agent → skipped, invariant 6). It cannot block direct-inject (that path already returned) and runs strictly after route()'s now-stale-able ownership consult — the only place the TOCTOU exists. `tests/unit/ws11-dispatch-to-owner-wiring.test.ts:60-66` pins this ordering via source indices.
+
+4. **`'un-routable'` re-queues, never drops — verified.** The new `ownership-moved-before-spawn` → `un-routable` disposition is handled in QueueDrainLoop.ts:731-736 via `releaseWithBackoff(row, attempts+1, …)` — release back to `queued` + backoff + attempts++, re-drained against fresh ownership next pass. The existing attempts-exhaustion path (648/661-663) reports loss loudly (`reportLoss`, terminal `attempts-exhausted`) rather than silently dropping — the bound is honest.
+
+5. **Live-only flags passthrough genuinely clears — verified at the registry.** `recordHeartbeat` REPLACES the whole `obs` (MachinePoolRegistry.ts:205), and `assemble` reads `seamlessnessFlags: live?.obs.seamlessnessFlags` (273) with NO `postureStore`-style durable fallback (unlike `guardPosture`, which deliberately carries forward at 200/277-285). A flags-less heartbeat therefore nulls the field — confirmed by the real-registry test at ws11-dispatch-to-owner-wiring.test.ts:40-45. Self-advertisement is `!!_inboundQueue` (server.ts:12656), so a dark queue withdraws the capability next beat — the safe direction.
+
+6. **"Receiver half already shipped" claim is true.** `createDeliverMessageHandler` (DeliverMessageHandler.ts:44-66) implements epoch fencing (50-53 → `stale-ownership`), sender re-validation BEFORE receipt (54-60 → `sender-rejected`), and idempotent durable receipt/dedupe (61-62 → `duplicate`). Wired at server.ts:12820-12844 with `ownerEpochOf`, `recordReceipt` (queue receipt + message ledger), and `validateSender` against THIS machine's UserManager. §2's residual-TOCTOU honesty holds — the point-read re-check narrows but does not eliminate the window; the receipt+ledger dedup bounds the damage to one extra session reaped by closeout, and full elimination is correctly deferred to WS1.2's drain barrier (not silently claimed as done).
+
+Both relevant unit files run green locally (33 tests passed). No claim in the artifact was found untrue in code.


### PR DESCRIPTION
## What

WS1.1 of the converged multi-machine-seamlessness spec. The durable-queue merge (#1079) already shipped the receiver half (epoch-fenced acceptance, durable remote receipts, sender re-validation) — this PR ships what was genuinely missing:

- **Drain spawn-boundary ownership re-check**: ownership moving between route()'s verdict and the spawn produced the F20 double-spawn (two machines, two sessions, one conversation). A non-owner spawn now bounces to `un-routable ('ownership-moved-before-spawn')` — the entry re-queues and re-routes against fresh ownership. Direct-inject into an existing live local session is deliberately ungated (strongest local-serving signal; the reconciler/closeout own its lifecycle).
- **`MachineCapacity.seamlessnessFlags`** (spec invariant 5): a bounded fixed-size capability advertisement (`ws11DeliverReceive`) self-reported on the authenticated heartbeat from the LIVE queue handle — a dark queue withdraws it next heartbeat. Absent = pre-spec peer or dark feature = non-participant.
- **Sender-side skew gate** (`SessionRouter.ownerSupportsForward`): a LIVE owner that does not advertise durable receive is never forwarded to — that forward would 501 → retry → failover-STEAL the conversation from a healthy machine. The message waits in OUR durable queue (`'owner-lacks-ws11-receive'`), bounded by the queue's shelf life and self-healing on the owner's next post-upgrade heartbeat. Unknown (null) and absent-dep both preserve today's exact behavior.

Inert without the pool/queue layer (ships dark). **Phase C**: the advertisement is fixed-size regardless of pool size; the gate's per-owner read is O(1) local; no LAN or interactive assumptions (headless-VM clean).

## ELI16 — no twins, no theft

When a conversation moves between the agent's machines, two ugly things could happen in the cracks: a message could spawn a duplicate session on a machine that JUST lost ownership (twins), and a message forwarded to a machine that can't safely receive it would fail in a way that made the system think that machine was dead — and take its conversations away (theft from the healthy). Now: spawns re-check ownership at the last moment, every machine's heartbeat carries a tiny 'I can safely receive' note, and senders check the note first — can't receive means the message waits safely in the queue until the machine catches up. All of it invisible until the multi-machine layer is switched on.

## Evidence

- `tests/unit/SessionRouter.test.ts` +4 — the skew gate's decision table: false → queued, deliver NOT called, cas NOT called (no steal); true/null/absent → forward (back-compat).
- `tests/unit/ws11-dispatch-to-owner-wiring.test.ts` — 6: heartbeat flags roundtrip incl. LIVE-ONLY withdrawal; the drain re-check seam with its exact placement (after direct-inject, before spawn) pinned by source indices.
- 163 tests green across queue/router/handler suites; `tsc --noEmit` clean; build + lints green.
- Mandatory independent second-pass (dispatch + ownership surface): **CONCUR, zero concerns**, 6 verification notes — including the no-message-loss proof (a refused queue falls through to delivery, never a drop) and the no-false-suspect proof (a flag-gated owner is never marked suspect). Full audit: `upgrades/side-effects/multi-machine-seamlessness-ws11.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)