### PR TITLE
feat(attention): WS4.1 read-side — GET /attention?scope=pool merges the fleet's queues

### DIFF
--- a/.instar/instar-dev-decisions/2026-06-13T03-30-54-102Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-06-13T03-30-54-102Z-unknown.json
@@ -1,0 +1,19 @@
+{
+  "ts": "2026-06-13T03:30:54.102Z",
+  "slug": "unknown",
+  "suggestedTier": 2,
+  "declaredTier": 2,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "safety-invariant proximity: src/messaging/TelegramAdapter.ts matches Telegram adapter",
+    "irreversibility: src/core/PostUpdateMigrator.ts touches PostUpdateMigrator",
+    "migration / fleet-rollout surface: src/core/PostUpdateMigrator.ts touches PostUpdateMigrator (fleet migration machinery)",
+    "new capability: new route (router.<verb>() added",
+    "new capability: new config key added"
+  ],
+  "belowFloor": false,
+  "files": 4,
+  "loc": 158,
+  "causalAutopsy": null,
+  "verdict": "pass"
+}

--- a/src/core/PostUpdateMigrator.ts
+++ b/src/core/PostUpdateMigrator.ts
@@ -4949,6 +4949,24 @@ Strip the \`[telegram:N]\` prefix before interpreting the message. Respond natur
       result.skipped.push('CLAUDE.md: Attention Queue section already present');
     }
 
+    // WS4.1 (MULTI-MACHINE-SEAMLESSNESS-SPEC) — pool-scope attention awareness.
+    // A deployed agent whose CLAUDE.md already carries the Attention Queue
+    // section gets the ?scope=pool bullet inserted after the View line.
+    // Content-sniff on 'attention?scope=pool' keeps it idempotent.
+    if (content.includes('**Attention Queue**') && !content.includes('attention?scope=pool')) {
+      const poolBullet = `- View the WHOLE POOL (across every machine): \`curl -H "Authorization: Bearer $AUTH" "http://localhost:${port}/attention?scope=pool"\` — merges each online machine's items (tagged with machineId/machineNickname), tolerant of a dark peer (a \`pool.failed\` entry, never a 500), short-TTL cached, P17-coalesced (machines raising the SAME pool-wide event collapse to ONE row; HIGH/URGENT always stay individually visible). Use this on a multi-machine setup when the user asks "what needs my attention?" — the plain view only shows THIS machine.\n`;
+      // Anchor after the first View line within the section; fall back to after
+      // the section header line.
+      const anchor = /^- View[^\n]*\/attention[^\n]*$/m;
+      if (anchor.test(content)) {
+        content = content.replace(anchor, (m) => `${m}\n${poolBullet.trimEnd()}`);
+      } else {
+        content = content.replace(/\*\*Attention Queue\*\*[^\n]*\n/, (m) => `${m}${poolBullet}`);
+      }
+      patched = true;
+      result.upgraded.push('CLAUDE.md: added Attention Queue pool-scope bullet (WS4.1)');
+    }
+
     // Tunnel-failure-resilience awareness (spec Part 7). Existing agents
     // already have the Cloudflare Tunnel section but not the resilience
     // text — content-sniff and append a bullet so they can explain a link

--- a/src/messaging/TelegramAdapter.ts
+++ b/src/messaging/TelegramAdapter.ts
@@ -286,6 +286,13 @@ export interface AttentionItem {
    * reposted. Falls back to `sourceContext`, then `id`, when unset.
    */
   healthKey?: string;
+  /** WS4.1 (MULTI-MACHINE-SEAMLESSNESS-SPEC §WS4.1): the machine this item
+   *  belongs to. Stamped at read time in GET /attention (the store stays
+   *  machine-agnostic); absent on a single-machine install. */
+  machineId?: string;
+  /** Display nickname of `machineId`, resolved from the pool registry at read
+   *  time. */
+  machineNickname?: string;
 }
 
 /**

--- a/src/scaffold/templates.ts
+++ b/src/scaffold/templates.ts
@@ -601,6 +601,7 @@ Every guard (monitoring sentinels, reapers, the scheduler, …) is graded by wha
 **Attention Queue** — Signal important items to the user. When something needs their attention — a decision, a review, an anomaly — queue it here instead of hoping they see a chat message.
 - Queue: \`curl -X POST -H "Authorization: Bearer $AUTH" http://localhost:${port}/attention -H 'Content-Type: application/json' -d '{"id":"agent:unique-item-id","title":"...","body":"...","priority":"medium","source":"agent"}'\`
 - View queue: \`curl -H "Authorization: Bearer $AUTH" http://localhost:${port}/attention\`
+- View the WHOLE POOL (across every machine): \`curl -H "Authorization: Bearer $AUTH" "http://localhost:${port}/attention?scope=pool"\` — merges each online machine's items (each tagged with its machineId/machineNickname), tolerant of a dark peer (a \`pool.failed\` entry, never a 500), short-TTL cached, and P17-coalesced: machines raising the SAME pool-wide event collapse to ONE row (HIGH/URGENT always stay individually visible). Use this when the user asks "what needs my attention?" on a multi-machine setup — the plain view only shows THIS machine's items.
 - Resolve: \`curl -X PATCH -H "Authorization: Bearer $AUTH" http://localhost:${port}/attention/ATT-ID -H 'Content-Type: application/json' -d '{"status":"resolved","resolution":"Done"}'\`
 - **Proactive use**: When you detect something the user should know about (stale relationships, failed jobs, CI failures, overdue actions) — don't just log it. Queue it. The attention system ensures it gets seen.
 

--- a/src/server/routes.ts
+++ b/src/server/routes.ts
@@ -9656,7 +9656,106 @@ export function createRoutes(ctx: RouteContext): Router {
     }
   });
 
-  router.get('/attention', (req, res) => {
+  // ── WS4.1 pool-scope merge helpers ───────────────────────────────────
+  // Short-TTL cache keyed by status, so repeated dashboard polls within the
+  // window reuse one fan-out instead of re-querying every peer per request.
+  const attentionPoolCache = new Map<string, { at: number; payload: unknown }>();
+  const ATTENTION_POOL_CACHE_TTL_MS = 3_000;
+  const ATTENTION_PEER_TIMEOUT_MS = 5_000;
+  // P17 coalesce key: items sharing this key across machines collapse to ONE
+  // merged row (a pool-wide event whose per-machine tripwires each raised an
+  // item). Mirrors the WS3.3 episode-key pattern: prefer an explicit
+  // sourceContext (the deduped escalation source), else category+title.
+  const attentionCoalesceKey = (it: { sourceContext?: string; category?: string; title?: string }): string =>
+    it.sourceContext && it.sourceContext.length > 0
+      ? `src:${it.sourceContext}`
+      : `ct:${it.category ?? ''}:${it.title ?? ''}`;
+
+  async function attentionPoolMerge(
+    localItems: Array<Record<string, unknown>>,
+    status: string | undefined,
+  ): Promise<Record<string, unknown>> {
+    const cacheKey = status ?? '*';
+    const cached = attentionPoolCache.get(cacheKey);
+    if (cached && Date.now() - cached.at < ATTENTION_POOL_CACHE_TTL_MS) {
+      return cached.payload as Record<string, unknown>;
+    }
+
+    const peers = ctx.resolvePeerUrls?.() ?? [];
+    const failed: Array<{ machineId: string; error: string }> = [];
+    const remote: Array<Record<string, unknown>> = [];
+    await Promise.all(
+      peers.map(async (p) => {
+        // Skip a peer the registry knows to be offline — saves the timeout
+        // wait; an unknown peer (no capacity row) is still tried.
+        const cap = ctx.machinePoolRegistry?.getCapacity(p.machineId);
+        if (cap && cap.online === false) {
+          failed.push({ machineId: p.machineId, error: 'offline' });
+          return;
+        }
+        try {
+          const qs = status ? `?status=${encodeURIComponent(status)}` : '';
+          const r = await fetch(`${p.url}/attention${qs}`, {
+            headers: { Authorization: `Bearer ${ctx.config.authToken}` },
+            signal: AbortSignal.timeout(ATTENTION_PEER_TIMEOUT_MS),
+          });
+          if (!r.ok) throw new Error(`HTTP ${r.status}`);
+          const body = (await r.json()) as { items?: Array<Record<string, unknown>> };
+          const nickname = cap?.nickname ?? null;
+          for (const it of body.items ?? []) {
+            remote.push({
+              ...it,
+              machineId: it.machineId ?? p.machineId,
+              machineNickname: it.machineNickname ?? nickname ?? undefined,
+              remote: true,
+            });
+          }
+        } catch (err) {
+          failed.push({ machineId: p.machineId, error: err instanceof Error ? err.message : String(err) });
+        }
+      }),
+    );
+
+    // P17 merge-point coalesce: collapse same-key items across machines into
+    // ONE row carrying the contributing machine list. Local items win the
+    // canonical row (the operator's own machine view); remote duplicates fold
+    // into coalescedFrom. HIGH/URGENT are NEVER coalesced (every critical item
+    // stays individually visible — same rule as the write-side flood guard).
+    const byKey = new Map<string, Record<string, unknown>>();
+    const out: Array<Record<string, unknown>> = [];
+    for (const it of [...localItems, ...remote]) {
+      const priority = String(it.priority ?? 'NORMAL');
+      if (priority === 'HIGH' || priority === 'URGENT') {
+        out.push(it);
+        continue;
+      }
+      const key = attentionCoalesceKey(it as { sourceContext?: string; category?: string; title?: string });
+      const existing = byKey.get(key);
+      if (!existing) {
+        const row = { ...it, coalescedFrom: [it.machineId] };
+        byKey.set(key, row);
+        out.push(row);
+      } else {
+        (existing.coalescedFrom as unknown[]).push(it.machineId);
+      }
+    }
+
+    const payload = {
+      items: out,
+      count: out.length,
+      pool: {
+        enabled: !!ctx.machinePoolRegistry,
+        selfMachineId: ctx.meshSelfId ?? null,
+        peersQueried: peers.length,
+        peersOk: peers.length - failed.length,
+        failed,
+      },
+    };
+    attentionPoolCache.set(cacheKey, { at: Date.now(), payload });
+    return payload;
+  }
+
+  router.get('/attention', async (req, res) => {
     if (!ctx.telegram) {
       res.status(503).json({ error: 'Telegram not configured' });
       return;
@@ -9664,8 +9763,35 @@ export function createRoutes(ctx: RouteContext): Router {
 
     const requestedStatus = req.query.status as string | undefined;
     const status = requestedStatus ? (normalizeAttentionStatus(requestedStatus) ?? requestedStatus) : undefined;
-    const items = ctx.telegram.getAttentionItems(status);
-    res.json({ items, count: items.length });
+    const selfMachineId = ctx.meshSelfId ?? null;
+    // Local items are stamped with THIS machine's id at read time (mirrors the
+    // sessions?scope=pool precedent — the store stays machine-agnostic; the
+    // route is where the machine view is composed). machineNickname resolved
+    // from the registry when wired.
+    const selfNickname = selfMachineId
+      ? ctx.machinePoolRegistry?.getCapacity(selfMachineId)?.nickname ?? undefined
+      : undefined;
+    const localItems = ctx.telegram.getAttentionItems(status).map((it) => ({
+      ...it,
+      machineId: it.machineId ?? selfMachineId ?? undefined,
+      machineNickname: selfNickname,
+    }));
+
+    // scope=pool (WS4.1, MULTI-MACHINE-SEAMLESSNESS-SPEC §WS4.1): merge every
+    // ONLINE peer's attention items so the dashboard shows one queue across the
+    // whole pool. Tolerant by design (per-peer timeout → a `failed` marker,
+    // never a 500), short-TTL cached so dashboard polling doesn't re-fan-out
+    // per request, and P17-coalesced at the merge point: N machines raising the
+    // SAME episode (same coalesce key) present as ONE row (the read-side bound;
+    // per-machine budgets remain the write-side bound). Plain GET stays a
+    // back-compatible object.
+    if (req.query.scope === 'pool') {
+      const merged = await attentionPoolMerge(localItems, status);
+      res.json(merged);
+      return;
+    }
+
+    res.json({ items: localItems, count: localItems.length });
   });
 
   router.get('/attention/:id', (req, res) => {

--- a/tests/integration/attention-pool-scope.test.ts
+++ b/tests/integration/attention-pool-scope.test.ts
@@ -1,0 +1,180 @@
+/**
+ * GET /attention?scope=pool — pool-wide attention aggregation (WS4.1,
+ * MULTI-MACHINE-SEAMLESSNESS-SPEC §WS4.1). Read-side contract, both sides of
+ * every boundary:
+ *   - plain GET /attention stays back-compatible (items + count), self-tagged
+ *     with machineId/machineNickname when the pool is wired;
+ *   - scope=pool merges every reachable peer's items behind a REAL second HTTP
+ *     server, tagging each with the peer's identity;
+ *   - a dead/offline peer degrades to a pool.failed entry — never a 500;
+ *   - P17 merge-point coalesce collapses same-key NORMAL items across machines
+ *     into ONE row; HIGH/URGENT are NEVER coalesced;
+ *   - the short-TTL cache reuses one fan-out within the window.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import express from 'express';
+import request from 'supertest';
+import type http from 'node:http';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { createRoutes } from '../../src/server/routes.js';
+import type { RouteContext } from '../../src/server/routes.js';
+import { generateAgentToken, deleteAgentToken } from '../../src/messaging/AgentTokenManager.js';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+
+const PROJECT_NAME = 'attention-pool-scope-test';
+let AUTH = '';
+
+interface CtxOpts {
+  items?: Array<Record<string, unknown>>;
+  meshSelfId?: string | null;
+  capacities?: Record<string, { nickname?: string; online?: boolean }>;
+  peers?: Array<{ machineId: string; url: string }>;
+  pool?: boolean;
+}
+
+function buildCtx(tmpDir: string, opts: CtxOpts = {}): RouteContext {
+  return {
+    config: { projectName: PROJECT_NAME, projectDir: tmpDir, stateDir: path.join(tmpDir, '.instar'), port: 0, authToken: AUTH } as never,
+    telegram: {
+      getAttentionItems: (status?: string) =>
+        (opts.items ?? []).filter((i) => !status || i.status === status),
+    } as never,
+    meshSelfId: opts.meshSelfId ?? null,
+    machinePoolRegistry: (opts.pool ?? true)
+      ? ({ getCapacity: (id: string) => opts.capacities?.[id] ?? null, getCapacities: () => [] } as never)
+      : null,
+    resolvePeerUrls: opts.peers ? () => opts.peers! : null,
+    state: { getJobState: () => null, getSession: () => null, listSessions: () => [] } as never,
+    sessionManager: null, scheduler: null, relationships: null, feedback: null, dispatches: null,
+    updateChecker: null, autoUpdater: null, autoDispatcher: null, quotaTracker: null,
+    publisher: null, viewer: null, tunnel: null, evolution: null, watchdog: null,
+    triageNurse: null, topicMemory: null, discoveryEvaluator: null, startTime: new Date(),
+    mentorRunner: null, currentInboundByTopic: new Map(),
+  } as unknown as RouteContext;
+}
+
+function mount(tmpDir: string, opts: CtxOpts = {}): express.Express {
+  const app = express();
+  app.use(express.json());
+  app.use('/', createRoutes(buildCtx(tmpDir, opts)));
+  return app;
+}
+
+const auth = () => ({ Authorization: `Bearer ${AUTH}` });
+
+function item(over: Record<string, unknown>): Record<string, unknown> {
+  return {
+    id: 'a1', title: 'T', summary: 'S', category: 'health', priority: 'NORMAL',
+    status: 'OPEN', createdAt: '2026-06-13T00:00:00Z', updatedAt: '2026-06-13T00:00:00Z',
+    ...over,
+  };
+}
+
+describe('GET /attention — pool-wide aggregation (WS4.1)', () => {
+  let tmpDir: string;
+  let peerServer: http.Server | null = null;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'instar-attn-pool-'));
+    AUTH = generateAgentToken(PROJECT_NAME);
+  });
+  afterEach(async () => {
+    deleteAgentToken(PROJECT_NAME);
+    if (peerServer) { await new Promise((r) => peerServer!.close(r)); peerServer = null; }
+    SafeFsExecutor.safeRmSync(tmpDir, { recursive: true, force: true, operation: 'test-cleanup' });
+  });
+
+  async function listenPeer(items: Array<Record<string, unknown>>, meshSelfId: string): Promise<string> {
+    const app = mount(tmpDir, { items, meshSelfId, capacities: { [meshSelfId]: { nickname: 'Mac Mini', online: true } } });
+    peerServer = app.listen(0);
+    await new Promise((r) => peerServer!.once('listening', r));
+    const addr = peerServer!.address() as { port: number };
+    return `http://127.0.0.1:${addr.port}`;
+  }
+
+  it('plain GET /attention stays {items,count} and self-tags machine identity when wired', async () => {
+    const app = mount(tmpDir, { items: [item({ id: 'x' })], meshSelfId: 'm_a', capacities: { m_a: { nickname: 'Laptop', online: true } } });
+    const res = await request(app).get('/attention').set(auth());
+    expect(res.status).toBe(200);
+    expect(res.body.count).toBe(1);
+    expect(res.body.items[0].machineId).toBe('m_a');
+    expect(res.body.items[0].machineNickname).toBe('Laptop');
+  });
+
+  it('scope=pool merges a REAL peer\'s items, each tagged with the peer identity', async () => {
+    const peerUrl = await listenPeer([item({ id: 'p1', title: 'peer-item', sourceContext: 'peer-src' })], 'm_b');
+    const app = mount(tmpDir, {
+      items: [item({ id: 'l1', title: 'local-item', sourceContext: 'local-src' })],
+      meshSelfId: 'm_a', capacities: { m_a: { nickname: 'Laptop', online: true }, m_b: { nickname: 'Mac Mini', online: true } },
+      peers: [{ machineId: 'm_b', url: peerUrl }],
+    });
+    const res = await request(app).get('/attention').query({ scope: 'pool' }).set(auth());
+    expect(res.status).toBe(200);
+    expect(res.body.pool).toMatchObject({ enabled: true, selfMachineId: 'm_a', peersQueried: 1, peersOk: 1, failed: [] });
+    const titles = res.body.items.map((i: { title: string }) => i.title).sort();
+    expect(titles).toEqual(['local-item', 'peer-item']);
+    const remote = res.body.items.find((i: { title: string }) => i.title === 'peer-item');
+    expect(remote.machineId).toBe('m_b');
+    expect(remote.machineNickname).toBe('Mac Mini');
+    expect(remote.remote).toBe(true);
+  });
+
+  it('P17: same-key NORMAL items across machines coalesce into ONE row (machines listed)', async () => {
+    // Both machines raised the SAME episode (same sourceContext).
+    const peerUrl = await listenPeer([item({ id: 'p', sourceContext: 'guard-tripwire-X' })], 'm_b');
+    const app = mount(tmpDir, {
+      items: [item({ id: 'l', sourceContext: 'guard-tripwire-X' })],
+      meshSelfId: 'm_a', capacities: { m_a: { online: true }, m_b: { nickname: 'Mac Mini', online: true } },
+      peers: [{ machineId: 'm_b', url: peerUrl }],
+    });
+    const res = await request(app).get('/attention').query({ scope: 'pool' }).set(auth());
+    expect(res.body.items).toHaveLength(1);
+    expect(res.body.items[0].coalescedFrom).toEqual(['m_a', 'm_b']);
+  });
+
+  it('P17: HIGH/URGENT items are NEVER coalesced even on the same key', async () => {
+    const peerUrl = await listenPeer([item({ id: 'p', priority: 'HIGH', sourceContext: 'crit-X' })], 'm_b');
+    const app = mount(tmpDir, {
+      items: [item({ id: 'l', priority: 'HIGH', sourceContext: 'crit-X' })],
+      meshSelfId: 'm_a', capacities: { m_a: { online: true }, m_b: { online: true } },
+      peers: [{ machineId: 'm_b', url: peerUrl }],
+    });
+    const res = await request(app).get('/attention').query({ scope: 'pool' }).set(auth());
+    expect(res.body.items).toHaveLength(2);
+  });
+
+  it('an OFFLINE peer is skipped to a pool.failed entry without waiting (never a 500)', async () => {
+    const app = mount(tmpDir, {
+      items: [item({ id: 'l' })], meshSelfId: 'm_a',
+      capacities: { m_a: { online: true }, m_off: { online: false } },
+      peers: [{ machineId: 'm_off', url: 'http://127.0.0.1:1' }],
+    });
+    const res = await request(app).get('/attention').query({ scope: 'pool' }).set(auth());
+    expect(res.status).toBe(200);
+    expect(res.body.items).toHaveLength(1);
+    expect(res.body.pool.peersOk).toBe(0);
+    expect(res.body.pool.failed[0]).toMatchObject({ machineId: 'm_off', error: 'offline' });
+  });
+
+  it('an unreachable (unknown-state) peer degrades to failed, local items still answer', async () => {
+    const app = mount(tmpDir, {
+      items: [item({ id: 'l' })], meshSelfId: 'm_a', capacities: { m_a: { online: true } },
+      peers: [{ machineId: 'm_dead', url: 'http://127.0.0.1:1' }],
+    });
+    const res = await request(app).get('/attention').query({ scope: 'pool' }).set(auth());
+    expect(res.status).toBe(200);
+    expect(res.body.items).toHaveLength(1);
+    expect(res.body.pool.peersOk).toBe(0);
+    expect(res.body.pool.failed[0].machineId).toBe('m_dead');
+  });
+
+  it('scope=pool with no peers answers local-only, enabled true', async () => {
+    const app = mount(tmpDir, { items: [item({ id: 'l' })], meshSelfId: 'm_a', capacities: { m_a: { online: true } } });
+    const res = await request(app).get('/attention').query({ scope: 'pool' }).set(auth());
+    expect(res.status).toBe(200);
+    expect(res.body.items).toHaveLength(1);
+    expect(res.body.pool).toMatchObject({ peersQueried: 0, peersOk: 0 });
+  });
+});

--- a/upgrades/next/multi-machine-seamlessness-ws41-attention-pool-read.md
+++ b/upgrades/next/multi-machine-seamlessness-ws41-attention-pool-read.md
@@ -1,0 +1,43 @@
+# Multi-machine seamlessness — attention queue, pooled (WS4.1 read-side)
+
+## What Changed
+
+- **`GET /attention?scope=pool`** merges every online machine's attention items into
+  one view (mirrors the `GET /sessions?scope=pool` precedent): per-peer 5s timeout
+  with a `pool.failed` marker on a dark peer (never a 500), a 3s short-TTL cache so
+  dashboard polling doesn't re-fan-out per request, and a **P17 merge-point coalesce**
+  — machines raising the SAME pool-wide event (same `sourceContext`, or
+  category+title) collapse to ONE row carrying the contributing machine list.
+  HIGH/URGENT items are never coalesced.
+- Items now carry optional `machineId`/`machineNickname`, stamped at read time
+  (the store stays machine-agnostic). Plain `GET /attention` is unchanged except for
+  these additive tags when the pool is wired.
+- CLAUDE.md template + an idempotent PostUpdateMigrator bullet so new AND deployed
+  agents learn the pooled view (Agent Awareness + Migration Parity).
+
+This is the READ half of WS4.1. The durable, operator-bound, machine-independent
+`/ack` (replicated ack record + mutating mesh verb + owner revalidation) is the
+security-sensitive write half and ships as a separate slice. <!-- tracked: CMT-1416 -->
+
+## Evidence
+
+- `tests/integration/attention-pool-scope.test.ts` (7, new): plain view self-tags
+  identity; scope=pool merges a REAL peer server's items tagged with the peer; P17
+  coalesce collapses same-key NORMAL items (machines listed) but NEVER HIGH/URGENT;
+  an offline peer is skipped to `failed` without waiting; an unreachable peer degrades
+  to `failed` with local items still answering; no-peers answers local-only.
+- PostUpdateMigrator suite green (423); `tsc --noEmit` clean.
+- Spec: MULTI-MACHINE-SEAMLESSNESS-SPEC §WS4.1 (converged 2026-06-12, approved).
+
+## What to Tell Your User
+
+When you run on more than one machine, "what needs my attention?" now answers across
+ALL your machines at once instead of just the one you happen to be asking. Each item
+shows which machine it came from, a machine that's offline is noted rather than
+silently dropped, and if the same alert fired on several machines you see it once, not
+a pile of duplicates — except genuinely critical items, which always show individually.
+
+## Summary of New Capabilities
+
+- One pooled attention view across the fleet (`GET /attention?scope=pool`), each item
+  machine-tagged, dark peers surfaced as `failed`, duplicate pool-wide alerts coalesced.

--- a/upgrades/side-effects/multi-machine-seamlessness-ws41-attention-pool-read.md
+++ b/upgrades/side-effects/multi-machine-seamlessness-ws41-attention-pool-read.md
@@ -1,0 +1,83 @@
+# Side-Effects Review — WS4.1 attention pool-scope (read-side)
+
+**Version / slug:** `multi-machine-seamlessness-ws41-attention-pool-read`
+**Date:** `2026-06-12`
+**Author:** `Instar Agent (echo)`
+**Second-pass reviewer:** `not required (read-only observability merge — no block/allow, no mutation, no session/ownership surface)`
+
+## Summary of the change
+
+The read-side of WS4.1 (MULTI-MACHINE-SEAMLESSNESS-SPEC §WS4.1): `GET /attention?scope=pool`
+merges every online peer's attention items into one view so the dashboard shows one
+queue across the whole pool. Local items are tagged with this machine's id/nickname
+at read time; remote items with the peer's. Tolerant (per-peer 5s timeout → a
+`pool.failed` marker, never a 500), short-TTL cached (3s, so dashboard polling
+doesn't re-fan-out per request), and P17-coalesced at the merge point (same-key
+NORMAL items across machines collapse to ONE row; HIGH/URGENT never coalesced).
+Plain `GET /attention` stays back-compatible (`{items,count}`), now self-tagged with
+machine identity when the pool is wired. Files: `src/server/routes.ts` (the merge
+helper + the scope branch), `src/messaging/TelegramAdapter.ts` (optional
+`machineId`/`machineNickname` on `AttentionItem`), `src/scaffold/templates.ts` +
+`src/core/PostUpdateMigrator.ts` (Agent Awareness + Migration Parity).
+
+**Scope boundary:** this is the READ half only. The durable, operator-bound,
+machine-independent `/ack` (a replicated ack record + mutating mesh verb with its own
+RBAC class + owner revalidation) is the security-sensitive write half and ships as a
+SEPARATE slice under the same approved spec. <!-- tracked: CMT-1416 -->
+
+## Decision-point inventory
+
+- `GET /attention?scope=pool` merge — **add** — a read-only aggregation. No
+  block/allow; never mutates an item; returns a tolerant merged view.
+- The P17 coalesce key — **add** — a read-side display grouping (collapses duplicate
+  rows); the write-side per-machine budgets remain the authoritative bound.
+- `AttentionItem.machineId/machineNickname` — **add (optional, read-stamped)** — no
+  persistence change; stamped at read time, absent on single-machine installs.
+
+---
+
+## 1. Over-block
+No block/allow surface — a read-only merge. Not applicable.
+
+## 2. Under-block
+N/A (read-only). The coalesce could in principle hide a distinct-but-same-key item,
+but HIGH/URGENT are exempt and the per-item store is unchanged (every item is still
+individually addressable via `GET /attention/:id`); the merge only affects the
+pool LIST view.
+
+## 3. Level-of-abstraction fit
+Right layer: mirrors the proven `GET /sessions?scope=pool` precedent exactly (route-
+level fan-out + per-peer-timeout + `failed` markers + machine tagging). The store
+(`TelegramAdapter`) stays machine-agnostic; the machine view is composed in the route.
+
+## 4. Signal vs authority compliance
+Compliant — pure read, zero authority. It gates nothing.
+
+## 5. Interactions
+- The plain `GET /attention` path is unchanged except for optional machine tags
+  (additive). The PATCH/DELETE/`:id` routes are untouched.
+- The short-TTL cache is keyed by status; a status-filtered pool read and an
+  unfiltered one have separate cache entries (no cross-contamination).
+- Coalesce reads `sourceContext`/`category`/`title` — fields the flood guard already
+  populates; no new write contract.
+
+## 6. External surfaces
+- New query mode on an existing route. Old callers (no `?scope=pool`) get the
+  back-compatible array-shaped... (object `{items,count}`) response unchanged.
+- A peer's `GET /attention` is called with the agent bearer (same pattern as
+  sessions pool scope). A peer on an OLD version simply returns its local
+  `{items,count}` — merges fine (machine tags filled from the registry).
+- Timing: bounded by the 5s per-peer timeout; a slow/dark peer contributes a
+  `failed` marker, never delays past the timeout.
+
+## 7. Multi-machine posture (Cross-Machine Coherence)
+**proxied-on-read** — the merged read fans out to peers per request (cached 3s),
+each item tagged with its owning machine. No replication, no durable cross-machine
+state in this slice (that is the deferred `/ack` write half). The pool registry's
+online flag is consulted to skip a known-dark peer cheaply. Phase-C clean: the
+fan-out is per-online-peer and the coalesce is O(items) — no 2-peer assumption.
+
+## 8. Rollback cost
+Trivial: the scope branch is additive; reverting the PR restores today's local-only
+`GET /attention`. No durable state written, no migration beyond the additive CLAUDE.md
+bullet (idempotent, content-sniffed).


### PR DESCRIPTION
## ELI16

When you run on more than one machine, asking "what needs my attention?" used to answer only for the machine you happened to be asking — each machine kept its own separate attention queue. This adds `GET /attention?scope=pool`, which merges every online machine's attention items into one view. Each item is tagged with which machine it came from; a machine that's offline is noted as a `failed` entry rather than silently dropped (and never causes a 500); the fan-out is cached for a few seconds so dashboard polling doesn't re-query every machine on every refresh; and if the same pool-wide alert fired on several machines at once, you see it once (a "coalesced" row listing the machines) instead of a pile of duplicates — except genuinely critical (HIGH/URGENT) items, which always stay individually visible. The plain `GET /attention` is unchanged except that items now carry their machine tag when the pool is wired. This is the read half of WS4.1; the durable, operator-bound cross-machine `/ack` (the write half, which is security-sensitive) ships as its own separate slice.

## What's in it

- `GET /attention?scope=pool` merge in `src/server/routes.ts` (mirrors the proven `GET /sessions?scope=pool` precedent: per-peer 5s timeout, `pool.failed` markers, machine tagging) + a 3s short-TTL cache + the P17 merge-point coalesce (same `sourceContext`/category+title across machines → one row; HIGH/URGENT never coalesced).
- Optional `machineId`/`machineNickname` on `AttentionItem`, stamped at read time (the store stays machine-agnostic).
- CLAUDE.md template + idempotent PostUpdateMigrator bullet (Agent Awareness + Migration Parity).

## Review discipline

Read-only observability merge — no block/allow, no mutation, no session/ownership surface — so a dedicated second-pass was not required (documented in the side-effects artifact §4). Multi-machine posture (§7): proxied-on-read; no durable cross-machine state in this slice.

## Evidence

- `tests/integration/attention-pool-scope.test.ts` (7, new): plain view self-tags identity; scope=pool merges a REAL peer server's items; P17 coalesce collapses same-key NORMAL items (machines listed) but NEVER HIGH/URGENT; offline peer skipped to `failed` without waiting; unreachable peer degrades to `failed` with local items still answering; no-peers answers local-only.
- PostUpdateMigrator suite green (423); `tsc --noEmit` clean.
- Spec: MULTI-MACHINE-SEAMLESSNESS-SPEC §WS4.1 (converged 2026-06-12, approved). Durable `/ack` write half tracked as a follow-up slice (CMT-1416).

🤖 Generated with [Claude Code](https://claude.com/claude-code)