### PR TITLE
feat(topic-profile): per-topic Claude Code effort pin (--effort at spawn)

### DIFF
--- a/.instar/instar-dev-decisions/2026-06-13T04-40-53-785Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-06-13T04-40-53-785Z-unknown.json
@@ -1,0 +1,13 @@
+{
+  "ts": "2026-06-13T04:40:53.785Z",
+  "slug": "unknown",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 12,
+  "loc": 250,
+  "causalAutopsy": null,
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-06-13T04-41-13-759Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-06-13T04-41-13-759Z-unknown.json
@@ -1,0 +1,13 @@
+{
+  "ts": "2026-06-13T04:41:13.759Z",
+  "slug": "unknown",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 12,
+  "loc": 250,
+  "causalAutopsy": null,
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-06-13T04-41-32-844Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-06-13T04-41-32-844Z-unknown.json
@@ -1,0 +1,13 @@
+{
+  "ts": "2026-06-13T04:41:32.844Z",
+  "slug": "unknown",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 12,
+  "loc": 250,
+  "causalAutopsy": null,
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-06-13T04-42-16-812Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-06-13T04-42-16-812Z-unknown.json
@@ -1,0 +1,13 @@
+{
+  "ts": "2026-06-13T04:42:16.812Z",
+  "slug": "unknown",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 12,
+  "loc": 250,
+  "causalAutopsy": null,
+  "verdict": "pass"
+}

--- a/docs/specs/topic-effort-pin.eli16.md
+++ b/docs/specs/topic-effort-pin.eli16.md
@@ -1,0 +1,49 @@
+# Per-topic effort pin — plain-English overview
+
+## What this is
+
+Claude Code has an "effort" setting (low / medium / high / xhigh / max) that
+trades speed for thinking depth. instar's topic profiles already let you pin a
+model, a thinking mode, and a framework to a conversation topic so the choice
+survives session restarts. This adds **effort** as a fourth pinnable field: a
+topic can be pinned to, say, `max` effort, and every session instar spawns for
+that topic passes `--effort max` to Claude Code — so the choice sticks across
+respawns instead of resetting to the account default each time.
+
+It was prompted by the operator asking to set "ultracode" for a topic. ultracode
+is a Claude Code *session mode* (max effort + dynamic workflows) that the CLI
+does **not** expose as a flag — `--effort` only accepts low/medium/high/xhigh/max
+(verified by probe). So this pin reaches the real ceiling the CLI allows (`max`);
+the workflow-orchestration half of ultracode has no command-line surface and is
+filed as a separate harness gap.
+
+## What already existed vs what's new
+
+Existed: the whole topic-profile machinery (store, resolver, validation,
+conversational "set X on this topic" grammar, the change-classifier that decides
+whether a pin change needs a respawn, and the per-topic `--model` pass-through at
+spawn). New: an `effort` field threaded through every one of those pieces, plus
+the `--effort` argv injection in the Claude Code launch builders (interactive and
+headless), plus a `/topic effort <level>` command and the conversational grammar
+("set max effort here").
+
+## Safeguards in plain terms
+
+- **Closed enum, fail-open everywhere.** Only the five real CLI values are
+  accepted. An invalid stored value resolves to "no effort flag" rather than
+  passing garbage to the CLI — checked at the resolver, again at the launch
+  builder, and rejected at the write API. `ultracode` is refused at every layer.
+- **No behavior change unless set.** The field is unset by default; nothing about
+  existing spawns changes until a topic is pinned.
+- **Right respawn reason.** An effort-only change triggers a clean kill +
+  `claude --resume` (effort is a launch-time flag, benign across resume) with its
+  own honest reason — not mislabeled as a thinking change.
+- **Non-Claude frameworks ignore it.** Codex/Gemini/Pi spawns are untouched.
+
+## What the operator needs to decide
+
+Nothing to configure — it's additive and off until used. Once merged, you (or I,
+conversationally) can pin a topic's effort, e.g. "set max effort on this topic,"
+and it survives restarts. The only standing caveat: full UI-"ultracode"
+(workflow-default-on) still isn't pinnable from instar because the harness has no
+CLI/spawn surface for it (tracked as a separate gap).

--- a/src/commands/server.ts
+++ b/src/commands/server.ts
@@ -906,6 +906,9 @@ async function spawnSessionForTopic(
     ? resolvedProfile.model
     : undefined;
   const profileThinkingMode = resolvedProfile?.thinkingMode;
+  // Topic Profile — per-topic Claude `--effort` pin (already enum-clamped /
+  // fail-open in the resolver; undefined = no --effort, today's behavior).
+  const profileEffort = resolvedProfile?.effort;
 
   const newSessionName = await sessionManager.spawnInteractiveSession(bootstrapMessage, sessionName, {
     telegramTopicId: topicId,
@@ -915,6 +918,7 @@ async function spawnSessionForTopic(
     ...(codexLocalModelOverride ? { defaultModel: codexLocalModelOverride } : {}),
     ...(profileModel ? { defaultModel: profileModel } : {}),
     ...(profileThinkingMode ? { thinkingMode: profileThinkingMode } : {}),
+    ...(profileEffort ? { effort: profileEffort } : {}),
     // Subscription & Auth Standard P1.3 (additive): account-swap — launch under
     // this account's config home + record its id. Unset = unchanged.
     ...(accountSwap?.configHome ? { configHome: accountSwap.configHome } : {}),
@@ -1422,13 +1426,15 @@ function wireTelegramCallbacks(
       patch = { modelTier: parts[1].toLowerCase(), model: null };
     } else if (head === 'thinking' && parts.length === 2) {
       patch = { thinkingMode: parts[1].toLowerCase() };
+    } else if (head === 'effort' && parts.length === 2) {
+      patch = { effort: parts[1].toLowerCase() };
     } else if (head === 'escalation' && parts.length === 2) {
       patch = { escalationOverride: parts[1].toLowerCase() };
     }
     if (!patch) {
       return {
         ok: false,
-        message: 'Usage: /topic [status] · /topic <framework> · /topic model <id> · /topic tier <default|escalated> · /topic thinking <off|low|medium|high|max> · /topic escalation <inherit|suppress> · /topic clear · /topic undo · /topic re-apply — or just tell me in plain words.',
+        message: 'Usage: /topic [status] · /topic <framework> · /topic model <id> · /topic tier <default|escalated> · /topic thinking <off|low|medium|high|max> · /topic effort <low|medium|high|xhigh|max> · /topic escalation <inherit|suppress> · /topic clear · /topic undo · /topic re-apply — or just tell me in plain words.',
       };
     }
     const result = await surface.applyWrite({
@@ -4025,7 +4031,7 @@ export async function startServer(options: StartOptions): Promise<void> {
             enabled?: boolean;
             dryRun?: boolean;
             switchNowConfirmTtlMs?: number;
-            defaults?: Record<string, { model?: string; thinkingMode?: string }>;
+            defaults?: Record<string, { model?: string; thinkingMode?: string; effort?: string }>;
           };
         }).topicProfiles;
         _topicProfileStore = new TopicProfileStore({

--- a/src/core/SessionManager.ts
+++ b/src/core/SessionManager.ts
@@ -3072,6 +3072,10 @@ rm()  { "${shimRunner}" rm  "$@"; }
      *  builder (claude `--effort` / codex `model_reasoning_effort`; no-op on
      *  frameworks without a reasoning knob). */
     thinkingMode?: import('./topicProfileValidation.js').ThinkingMode;
+    /** Topic Profile — per-topic Claude Code `--effort` level pin, threaded to
+     *  the launch builder as `--effort <level>` (claude-code only; strict no-op
+     *  on other frameworks). A DIRECT CLI-flag pin, distinct from thinkingMode. */
+    effort?: import('./topicProfileValidation.js').EffortLevel;
     /** Explicit per-spawn working directory (reap-notify spec R2.8 / L13 —
      *  a NAMED extension: no spawn path accepted a per-spawn cwd before).
      *  The resume-queue drainer threads a queue entry's recorded cwd /
@@ -3218,6 +3222,9 @@ rm()  { "${shimRunner}" rm  "$@"; }
       // Topic Profile §6: per-topic thinking mode (claude --effort / codex
       // model_reasoning_effort; strict no-op on gemini/pi).
       ...(options?.thinkingMode ? { thinkingMode: options.thinkingMode } : {}),
+      // Topic Profile: direct per-topic Claude `--effort` pin (claude-code
+      // only; the builder validates the enum + drops an unknown value).
+      ...(options?.effort ? { effort: options.effort } : {}),
     });
 
     // Spawn the framework CLI in tmux — no bash -c shell intermediary.

--- a/src/core/TopicProfileOrchestrator.ts
+++ b/src/core/TopicProfileOrchestrator.ts
@@ -97,6 +97,7 @@ import {
 } from './TopicProfileStore.js';
 import type { ResolvedTopicProfile } from './TopicProfileResolver.js';
 import type {
+  EffortLevel,
   ProfileModelTier,
   ThinkingMode,
   ValidatedProfilePatch,
@@ -147,6 +148,8 @@ export interface AppliedProfile {
   /** Tier shape of the pin that produced the model, when tier-shaped. */
   modelTier: ProfileModelTier | null;
   thinkingMode: ThinkingMode | null;
+  /** Claude `--effort` level applied at spawn, or null. */
+  effort: EffortLevel | null;
 }
 
 export interface OrchTopicSession {
@@ -350,7 +353,7 @@ const REAPPLY_COOLDOWN_MS = 10 * 60_000;
 const CONFIRM_ARM_RATE_CAP = 5;
 const CONFIRM_ARM_RATE_WINDOW_MS = 60_000;
 
-const PROFILE_AXES = ['framework', 'model', 'modelTier', 'escalationOverride', 'thinkingMode'] as const;
+const PROFILE_AXES = ['framework', 'model', 'modelTier', 'escalationOverride', 'thinkingMode', 'effort'] as const;
 
 export class TopicProfileOrchestrator {
   private readonly deps: TopicProfileOrchestratorDeps;
@@ -513,7 +516,7 @@ export class TopicProfileOrchestrator {
     if (action === 'clear') {
       const live = await this.applyLiveWrite(
         key,
-        { framework: null, model: null, modelTier: null, thinkingMode: null, escalationOverride: null },
+        { framework: null, model: null, modelTier: null, thinkingMode: null, effort: null, escalationOverride: null },
         attribution,
         { recovery: true },
       );
@@ -550,6 +553,7 @@ export class TopicProfileOrchestrator {
       model: parked.profile.model ?? null,
       modelTier: parked.profile.modelTier ?? null,
       thinkingMode: parked.profile.thinkingMode ?? null,
+      effort: parked.profile.effort ?? null,
       escalationOverride: parked.profile.escalationOverride ?? null,
     };
     const live = await this.applyLiveWrite(key, patch, attribution, {
@@ -1779,6 +1783,7 @@ function appliedToPseudo(applied: AppliedProfile | null): TopicProfile | null {
     model: applied.modelTier ? null : applied.model,
     modelTier: applied.modelTier,
     thinkingMode: applied.thinkingMode,
+    effort: applied.effort,
     updatedAt: '',
     updatedBy: '',
   };
@@ -1790,6 +1795,7 @@ function resolvedToPseudo(resolved: ResolvedTopicProfile): TopicProfile {
     model: resolved.modelTier ? null : (resolved.model ?? null),
     modelTier: resolved.modelTier ?? null,
     thinkingMode: resolved.thinkingMode ?? null,
+    effort: resolved.effort ?? null,
     updatedAt: '',
     updatedBy: '',
   };
@@ -1802,6 +1808,7 @@ export function resolvedToApplied(resolved: ResolvedTopicProfile): AppliedProfil
     model: resolved.modelTier ? null : (resolved.model ?? null),
     modelTier: resolved.modelTier ?? null,
     thinkingMode: resolved.thinkingMode ?? null,
+    effort: resolved.effort ?? null,
   };
 }
 
@@ -1810,7 +1817,8 @@ function appliedEquals(a: AppliedProfile, b: AppliedProfile): boolean {
     a.framework === b.framework &&
     (a.model ?? null) === (b.model ?? null) &&
     (a.modelTier ?? null) === (b.modelTier ?? null) &&
-    (a.thinkingMode ?? null) === (b.thinkingMode ?? null)
+    (a.thinkingMode ?? null) === (b.thinkingMode ?? null) &&
+    (a.effort ?? null) === (b.effort ?? null)
   );
 }
 

--- a/src/core/TopicProfileResolver.ts
+++ b/src/core/TopicProfileResolver.ts
@@ -36,6 +36,8 @@ import type { IntelligenceFramework } from './intelligenceProviderFactory.js';
 import type { TopicProfileStore, TopicProfile } from './TopicProfileStore.js';
 import {
   validateModelId,
+  EFFORT_LEVELS,
+  type EffortLevel,
   type EscalationOverride,
   type ProfileModelTier,
   type ThinkingMode,
@@ -53,10 +55,16 @@ export interface ResolvedTopicProfile {
   /** The baseline tier pin, when the pin is tier-shaped (§7 in-flight row eligibility). */
   modelTier: ProfileModelTier | null;
   thinkingMode: ThinkingMode | undefined;
+  /**
+   * The Claude Code `--effort` level to pass at spawn, or undefined for none.
+   * An invalid stored value FAILS OPEN to undefined (no `--effort` passed) —
+   * resolution never throws and never hands the CLI a bad value.
+   */
+  effort: EffortLevel | undefined;
   /** §9 — default 'inherit' (the heavy-work ultra mandate stays in force). */
   escalationOverride: EscalationOverride;
   /** Which layer supplied each arm (audit/readout). */
-  sources: { framework: string; model: string; thinkingMode: string };
+  sources: { framework: string; model: string; thinkingMode: string; effort: string };
   /**
    * Once-per-transition fallback notices to surface (empty in the common
    * case). Already deduped — the caller may send them verbatim.
@@ -71,7 +79,7 @@ export interface TopicProfileResolverOptions {
   /** Legacy config-level framework defaults (`config.topicFrameworks`). */
   configTopicFrameworks: () => Record<string, string>;
   /** `topicProfiles.defaults` — per-topic config-default profiles (§12.5). */
-  configProfileDefaults: () => Record<string, { model?: string; thinkingMode?: string }>;
+  configProfileDefaults: () => Record<string, { model?: string; thinkingMode?: string; effort?: string }>;
   /** `frameworkDefaultModels` config layer. */
   frameworkDefaultModels: () => Partial<Record<IntelligenceFramework, string>>;
   /** Live tier-escalation config — resolves a modelTier pin to a concrete id. */
@@ -226,15 +234,55 @@ export class TopicProfileResolver {
       }
     }
 
+    // ── effort arm (claude `--effort` direct pin) ────────────────────────
+    // FAIL-OPEN: any stored/config value not in the closed enum resolves to
+    // undefined (no `--effort` passed). Resolution never throws and never
+    // hands the CLI a value it would reject (e.g. a legacy 'ultracode' pin).
+    let effort: EffortLevel | undefined;
+    let effortSource = 'unset';
+    if (pin?.effort != null) {
+      if ((EFFORT_LEVELS as readonly string[]).includes(pin.effort)) {
+        effort = pin.effort;
+        effortSource = 'profile-pin';
+        this.clearTransition(key, 'effort-pin-invalid');
+      } else {
+        const notice = this.onceNotice(
+          key,
+          'effort-pin-invalid',
+          `this topic's pinned effort level is no longer valid — ignoring it`,
+        );
+        if (notice) notices.push(notice);
+        this.opts.audit?.({ type: 'fallback', reason: 'effort-pin-invalid', topic: key });
+      }
+    } else {
+      const configDefaults = this.opts.configProfileDefaults()[key];
+      const configEffort = configDefaults?.effort;
+      if (configEffort) {
+        if ((EFFORT_LEVELS as readonly string[]).includes(configEffort)) {
+          effort = configEffort as EffortLevel;
+          effortSource = 'topicProfiles-config-default';
+        } else {
+          const notice = this.onceNotice(
+            key,
+            'config-effort-invalid',
+            `the configured default effort level for this topic isn't valid — ignoring it`,
+          );
+          if (notice) notices.push(notice);
+          this.opts.audit?.({ type: 'fallback', reason: 'config-effort-invalid', topic: key });
+        }
+      }
+    }
+
     return {
       framework,
       model,
       modelTier,
       thinkingMode,
+      effort,
       // §9 — honor-on-read covers the escalation arm even when the feature
       // flag is off; absent = 'inherit' (the mandate stays in force).
       escalationOverride: pin?.escalationOverride ?? 'inherit',
-      sources: { framework: frameworkSource, model: modelSource, thinkingMode: thinkingSource },
+      sources: { framework: frameworkSource, model: modelSource, thinkingMode: thinkingSource, effort: effortSource },
       notices,
     };
   }

--- a/src/core/TopicProfileStore.ts
+++ b/src/core/TopicProfileStore.ts
@@ -44,6 +44,7 @@ import { DegradationReporter } from '../monitoring/DegradationReporter.js';
 import {
   modelTierMutualExclusionError,
   validateProfileFields,
+  type EffortLevel,
   type EscalationOverride,
   type ProfileModelTier,
   type ProfileValidationError,
@@ -60,6 +61,13 @@ export interface TopicProfile {
   /** §9 — does the heavy-work ultra mandate still apply? Default 'inherit'. */
   escalationOverride?: EscalationOverride | null;
   thinkingMode?: ThinkingMode | null;
+  /**
+   * Claude Code `--effort` launch level (low|medium|high|xhigh|max), passed
+   * verbatim as `--effort <level>` at spawn — a DIRECT CLI-flag pin, distinct
+   * from the cross-framework `thinkingMode` abstraction. No-op on non-claude
+   * frameworks.
+   */
+  effort?: EffortLevel | null;
   /** ISO timestamp, stamped server-side. */
   updatedAt: string;
   /** VERIFIED operator principal (or 'api-token' / 'system:*'), stamped server-side. */
@@ -194,7 +202,7 @@ export interface TopicProfileStoreOptions {
 
 const WRITE_LOCK_TIMEOUT_MS = 5_000;
 
-const PROFILE_FIELDS = ['framework', 'model', 'modelTier', 'escalationOverride', 'thinkingMode'] as const;
+const PROFILE_FIELDS = ['framework', 'model', 'modelTier', 'escalationOverride', 'thinkingMode', 'effort'] as const;
 type ProfileField = (typeof PROFILE_FIELDS)[number];
 
 export class TopicProfileStore {
@@ -937,7 +945,7 @@ function clampArrivingFields(
     }
   }
 
-  for (const field of ['model', 'modelTier', 'thinkingMode', 'escalationOverride'] as const) {
+  for (const field of ['model', 'modelTier', 'thinkingMode', 'effort', 'escalationOverride'] as const) {
     const raw = source[field];
     if (raw == null) continue;
     const v = validateProfileFields({ [field]: String(raw) }, effectiveFramework);

--- a/src/core/classifyProfileChange.ts
+++ b/src/core/classifyProfileChange.ts
@@ -83,7 +83,7 @@ export interface ProfileChangeClassification {
   changedFields: string[];
 }
 
-const AXES = ['framework', 'model', 'modelTier', 'thinkingMode', 'escalationOverride'] as const;
+const AXES = ['framework', 'model', 'modelTier', 'thinkingMode', 'effort', 'escalationOverride'] as const;
 
 function isOffOnToggle(a: TopicProfile | null, b: TopicProfile | null): boolean {
   const oldMode = a?.thinkingMode ?? null;
@@ -190,6 +190,7 @@ export function classifyProfileChange(
   const modelChanged = changedFields.includes('model');
   const tierChanged = changedFields.includes('modelTier');
   const thinkingChanged = changedFields.includes('thinkingMode');
+  const effortChanged = changedFields.includes('effort');
 
   if (newFramework === 'codex-cli') {
     // §7 Codex rows: none-loss IFF the fence-validated rollout-id is
@@ -323,6 +324,37 @@ export function classifyProfileChange(
       swapMethod: 'resume',
       expectedLoss: 'none',
       reason: 'model change — kill + claude --resume (full transcript)',
+      refuseOrConfirm: false,
+      freshRespawn: false,
+    });
+  }
+
+  // effort-only change (claude). --effort is a pure LAUNCH-TIME flag: it does
+  // not touch the thinking-block transcript shape, so a kill + claude --resume
+  // is benign (none-loss when a resume UUID was hook-captured; else a disclosed
+  // fresh spawn with recent-only history). Its OWN row — without this, an
+  // effort-only change falls through to the thinkingMode block and reports a
+  // wrong reason gated on the wrong (thinking) verification flag (second-pass
+  // review finding, 2026-06-12). Combined effort+model/tier/thinking changes are
+  // already handled by those rows above (their respawn carries the new --effort).
+  if (effortChanged && !modelChanged && !tierChanged && !thinkingChanged) {
+    if (!session.claudeResumeReady) {
+      return killGuards({
+        ...base,
+        requiresRespawn: true,
+        swapMethod: 'continuation',
+        expectedLoss: 'recent-only',
+        reason: 'effort change with no hook-captured resume UUID — fresh spawn, recent history only (disclosed)',
+        refuseOrConfirm: false,
+        freshRespawn: true,
+      });
+    }
+    return killGuards({
+      ...base,
+      requiresRespawn: true,
+      swapMethod: 'resume',
+      expectedLoss: 'none',
+      reason: 'effort change — kill + claude --resume (--effort is a launch-time flag; benign across resume)',
       refuseOrConfirm: false,
       freshRespawn: false,
     });

--- a/src/core/frameworkSessionLaunch.ts
+++ b/src/core/frameworkSessionLaunch.ts
@@ -15,7 +15,7 @@
 
 import type { IntelligenceFramework } from './intelligenceProviderFactory.js';
 import { codexSupportsHookTrustBypass } from './codexCapabilities.js';
-import type { ThinkingMode } from './topicProfileValidation.js';
+import { EFFORT_LEVELS, type EffortLevel, type ThinkingMode } from './topicProfileValidation.js';
 
 /**
  * Cross-framework generic model tiers. Higher-level code (UpgradeNotify,
@@ -187,6 +187,16 @@ export interface InteractiveLaunchOptions {
    *  - gemini-cli / pi-cli: strict no-op (no reasoning knob shipped).
    */
   thinkingMode?: ThinkingMode;
+  /**
+   * Topic Profile — per-topic Claude Code `--effort` level pin (a DIRECT pin
+   * of the CLI flag value: low|medium|high|xhigh|max). When set, the
+   * claude-code builder pushes `--effort <level>` at spawn. Validated against
+   * the closed enum INSIDE the builder (defense in depth) — an unknown value
+   * is dropped, never passed to the CLI. Strict no-op on non-claude
+   * frameworks. Distinct from `thinkingMode` (which the builders MAP onto the
+   * reasoning knob); `effort` is the launch flag verbatim.
+   */
+  effort?: EffortLevel;
 }
 
 export interface InteractiveLaunchSpec {
@@ -204,6 +214,16 @@ type Builder = (options: InteractiveLaunchOptions) => InteractiveLaunchSpec;
 
 const claudeCodeBuilder: Builder = (options) => {
   const argv: string[] = [options.binaryPath, '--dangerously-skip-permissions'];
+  // Topic Profile — direct `--effort` pin, emitted right after
+  // --dangerously-skip-permissions. Validated against the closed enum INSIDE
+  // the builder (defense in depth): an unknown value is dropped, never passed
+  // to the CLI. A direct pin WINS over the thinkingMode→effort mapping below
+  // (the thinkingMode branch is skipped when a direct effort is present so
+  // `--effort` is never emitted twice).
+  const directEffort = validateEffortLevel(options.effort);
+  if (directEffort) {
+    argv.push('--effort', directEffort);
+  }
   if (options.resumeSessionId) {
     argv.push('--resume', options.resumeSessionId);
   } else if (options.sessionId) {
@@ -234,11 +254,12 @@ const claudeCodeBuilder: Builder = (options) => {
   };
   // Topic Profile §6 — thinking mode. The live CLI's `--effort` flag carries
   // low/medium/high/max; `off` has no flag level, so it rides the
-  // MAX_THINKING_TOKENS=0 env channel (thinking disabled).
-  const claudeEffort = claudeEffortForThinkingMode(options.thinkingMode);
+  // MAX_THINKING_TOKENS=0 env channel (thinking disabled). Skipped when a
+  // direct effort pin already emitted `--effort` (the pin wins; no duplicate).
+  const claudeEffort = directEffort ? null : claudeEffortForThinkingMode(options.thinkingMode);
   if (claudeEffort) {
     argv.push('--effort', claudeEffort);
-  } else if (options.thinkingMode === 'off') {
+  } else if (!directEffort && options.thinkingMode === 'off') {
     envOverrides.MAX_THINKING_TOKENS = '0';
   }
   // Subscription & Auth Standard P1.3: when a per-account config home is given,
@@ -507,6 +528,15 @@ export interface HeadlessLaunchOptions {
    * don't use MCP). No effect on non-codex frameworks.
    */
   codexAllowMcpTools?: boolean;
+  /**
+   * Topic Profile — per-topic Claude Code `--effort` level pin (a DIRECT pin
+   * of the CLI flag value: low|medium|high|xhigh|max). When set, the
+   * claude-code headless builder pushes `--effort <level>` right after the
+   * `--model` block and before the `-p` prompt. Validated against the closed
+   * enum INSIDE the builder — an unknown value is dropped. No-op on non-claude
+   * frameworks.
+   */
+  effort?: EffortLevel;
 }
 
 export interface HeadlessLaunchSpec {
@@ -527,6 +557,13 @@ const claudeCodeHeadlessBuilder: HeadlessBuilder = (options) => {
   const resolved = resolveModelForFramework('claude-code', options.model);
   if (resolved) {
     argv.push('--model', resolved);
+  }
+  // Topic Profile — direct `--effort` pin, emitted right after the --model
+  // block and before the `-p` prompt positional. Validated against the closed
+  // enum INSIDE the builder (defense in depth): an unknown value is dropped.
+  const headlessEffort = validateEffortLevel(options.effort);
+  if (headlessEffort) {
+    argv.push('--effort', headlessEffort);
   }
   argv.push('-p', options.prompt);
   return {
@@ -705,6 +742,20 @@ export function buildHeadlessLaunch(
  * Returns `[]` for non-claude frameworks or when neither option is requested, so
  * the caller can splice unconditionally. Pure + order-stable for testing.
  */
+/**
+ * Defense-in-depth clamp for the direct `--effort` pin: returns the value
+ * verbatim when it is a member of the closed enum, else null (the builder
+ * drops it). The resolver already fails-open, but the builder is a second
+ * untrusted entry point — an unknown value must never reach the CLI. Exported
+ * for unit tests.
+ */
+export function validateEffortLevel(value: string | undefined | null): EffortLevel | null {
+  if (value != null && (EFFORT_LEVELS as readonly string[]).includes(value)) {
+    return value as EffortLevel;
+  }
+  return null;
+}
+
 /**
  * Topic Profile §6 — map the generic thinking-mode enum to the Claude CLI's
  * `--effort` levels. `off` returns null (it rides the MAX_THINKING_TOKENS=0

--- a/src/core/topicProfileIngress.ts
+++ b/src/core/topicProfileIngress.ts
@@ -30,7 +30,7 @@
  *        metadata never matches ANY ingress recognition, round-5).
  */
 
-import type { ProfilePatchInput, ThinkingMode } from './topicProfileValidation.js';
+import type { EffortLevel, ProfilePatchInput, ThinkingMode } from './topicProfileValidation.js';
 
 // ── trigger grammar ─────────────────────────────────────────────────────────
 
@@ -55,6 +55,7 @@ const FRAMEWORK_WORDS: Record<string, string> = {
 };
 
 const THINKING_WORDS = ['off', 'low', 'medium', 'high', 'max'];
+const EFFORT_WORDS = ['low', 'medium', 'high', 'xhigh', 'max'];
 
 /**
  * Parse a first-party operator turn against the closed trigger set.
@@ -95,6 +96,18 @@ export function parseProfileTrigger(text: string): ProfileTrigger | null {
   if (!m) m = t.match(/^use (off|low|medium|high|max) thinking (?:here|on this topic)$/);
   if (m && THINKING_WORDS.includes(m[1])) {
     return { kind: 'write', patch: { thinkingMode: m[1] as ThinkingMode } };
+  }
+
+  // effort level: "set high effort on this topic" / "set effort to xhigh on
+  // this topic" / "use max effort here". A DIRECT Claude `--effort` pin (the
+  // CLI's launch flag), distinct from thinking mode. Closed-enum only —
+  // 'ultracode'/'ultra' and any other non-CLI word are out-of-grammar and ride
+  // the propose-confirm lane rather than mis-firing a write.
+  m = t.match(/^set (low|medium|high|xhigh|max) effort (?:on this topic|here)$/);
+  if (!m) m = t.match(/^set effort to (low|medium|high|xhigh|max)(?: on this topic| here)?$/);
+  if (!m) m = t.match(/^use (low|medium|high|xhigh|max) effort (?:here|on this topic)$/);
+  if (m && EFFORT_WORDS.includes(m[1])) {
+    return { kind: 'write', patch: { effort: m[1] as EffortLevel } };
   }
 
   // escalation override — `suppress` requires an UNAMBIGUOUS explicit

--- a/src/core/topicProfileValidation.ts
+++ b/src/core/topicProfileValidation.ts
@@ -20,6 +20,17 @@ import { SUPPORTED_FRAMEWORKS } from './TopicFrameworksStore.js';
 export const THINKING_MODES = ['off', 'low', 'medium', 'high', 'max'] as const;
 export type ThinkingMode = (typeof THINKING_MODES)[number];
 
+/**
+ * Claude Code's `--effort` launch flag levels (the live CLI's verified set).
+ * A DIRECT pin of the CLI flag value — distinct from `thinkingMode` (which is
+ * a cross-framework reasoning-budget abstraction the launch builders MAP onto
+ * `--effort`/`model_reasoning_effort`). `effort` passes through verbatim as
+ * `--effort <level>` on claude-code spawns and is a strict no-op elsewhere.
+ * NOTE: 'ultracode' / 'ultra' are NOT CLI values and are deliberately absent.
+ */
+export const EFFORT_LEVELS = ['low', 'medium', 'high', 'xhigh', 'max'] as const;
+export type EffortLevel = (typeof EFFORT_LEVELS)[number];
+
 export const ESCALATION_OVERRIDES = ['inherit', 'suppress'] as const;
 export type EscalationOverride = (typeof ESCALATION_OVERRIDES)[number];
 
@@ -104,6 +115,7 @@ export interface ProfilePatchInput {
   modelTier?: string | null;
   escalationOverride?: string | null;
   thinkingMode?: string | null;
+  effort?: string | null;
 }
 
 export interface ValidatedProfilePatch {
@@ -112,6 +124,7 @@ export interface ValidatedProfilePatch {
   modelTier?: ProfileModelTier | null;
   escalationOverride?: EscalationOverride | null;
   thinkingMode?: ThinkingMode | null;
+  effort?: EffortLevel | null;
 }
 
 /** §10.3 — a rejected value is arbitrary text; store only a clamped prefix. */
@@ -202,6 +215,26 @@ export function validateProfileFields(
           field: 'thinkingMode',
           failure: 'off-enum',
           reason: `thinkingMode must be one of: ${THINKING_MODES.join(', ')}`,
+          rejectedPrefix: prefix,
+          rejectedLength: length,
+        },
+      };
+    }
+  }
+
+  if (patch.effort !== undefined) {
+    if (patch.effort === null) {
+      out.effort = null;
+    } else if ((EFFORT_LEVELS as readonly string[]).includes(patch.effort)) {
+      out.effort = patch.effort as EffortLevel;
+    } else {
+      const { prefix, length } = clampRejectedValue(patch.effort);
+      return {
+        ok: false,
+        error: {
+          field: 'effort',
+          failure: 'off-enum',
+          reason: `effort must be one of: ${EFFORT_LEVELS.join(', ')}`,
           rejectedPrefix: prefix,
           rejectedLength: length,
         },

--- a/src/core/topicProfileWriteSurface.ts
+++ b/src/core/topicProfileWriteSurface.ts
@@ -156,7 +156,7 @@ export interface TopicProfileWriteSurfaceDeps {
   now?: () => number;
 }
 
-const NEW_AXES = ['model', 'modelTier', 'thinkingMode', 'escalationOverride'] as const;
+const NEW_AXES = ['model', 'modelTier', 'thinkingMode', 'effort', 'escalationOverride'] as const;
 const ALL_FIELDS = ['framework', ...NEW_AXES] as const;
 const DEFAULT_REAPPLY_COOLDOWN_MS = 600_000;
 
@@ -499,7 +499,7 @@ export class TopicProfileWriteSurface {
     try {
       const result = await this.deps.store.mutate(
         topicKey,
-        { framework: null, model: null, modelTier: null, thinkingMode: null, escalationOverride: null, updatedBy },
+        { framework: null, model: null, modelTier: null, thinkingMode: null, effort: null, escalationOverride: null, updatedBy },
         { shiftPrevious: true },
       );
       changed = result.changed;
@@ -669,6 +669,7 @@ export class TopicProfileWriteSurface {
       `This topic runs on ${resolved.framework}`
       + (resolved.model ? ` with model ${resolved.model}` : ' with the account-default model')
       + (resolved.thinkingMode ? ` and ${resolved.thinkingMode} thinking` : '')
+      + (resolved.effort ? ` at ${resolved.effort} effort` : '')
       + ` (framework: ${resolved.sources.framework}, model: ${resolved.sources.model}).`,
     );
     // §9 framework-aware escalation disclosure.

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -2505,7 +2505,7 @@ export interface InstarConfig {
      * Optional per-topic config-default profiles (§5.2); keys use the §10.5
      * conversation-key scheme (numeric topic id, or `slack:<channel>[:<thread>]`).
      */
-    defaults?: Record<string, { model?: string; thinkingMode?: string }>;
+    defaults?: Record<string, { model?: string; thinkingMode?: string; effort?: string }>;
   };
   /**
    * Topic-intent auto-capture loop config (rung 0 of continuous-working-awareness).

--- a/src/server/routes.ts
+++ b/src/server/routes.ts
@@ -5761,6 +5761,7 @@ export function createRoutes(ctx: RouteContext): Router {
         model: resolved.model ?? null,
         modelTier: resolved.modelTier,
         thinkingMode: resolved.thinkingMode ?? null,
+        effort: resolved.effort ?? null,
         escalationOverride: resolved.escalationOverride,
         sources: resolved.sources,
       },
@@ -5805,7 +5806,7 @@ export function createRoutes(ctx: RouteContext): Router {
     if (!gate) return;
     const body = (req.body ?? {}) as Record<string, unknown>;
     const patch: Record<string, string | null> = {};
-    for (const field of ['framework', 'model', 'modelTier', 'thinkingMode', 'escalationOverride'] as const) {
+    for (const field of ['framework', 'model', 'modelTier', 'thinkingMode', 'effort', 'escalationOverride'] as const) {
       if (!(field in body)) continue;
       const value = body[field];
       if (value !== null && typeof value !== 'string') {
@@ -5862,7 +5863,7 @@ export function createRoutes(ctx: RouteContext): Router {
     }
     const body = (req.body ?? {}) as Record<string, unknown>;
     const patch: Record<string, string | null> = {};
-    for (const field of ['framework', 'model', 'modelTier', 'thinkingMode', 'escalationOverride'] as const) {
+    for (const field of ['framework', 'model', 'modelTier', 'thinkingMode', 'effort', 'escalationOverride'] as const) {
       if (!(field in body)) continue;
       const value = body[field];
       if (value !== null && typeof value !== 'string') {

--- a/tests/integration/topic-profile-routes.test.ts
+++ b/tests/integration/topic-profile-routes.test.ts
@@ -315,3 +315,54 @@ describe('recovery surfaces (§10.3 / §5.2(b))', () => {
     expect(bundle.store.parkedFor(23)).toBeNull();
   });
 });
+
+// ── effort pin: full POST→store→GET data-flow over the HTTP pipeline ─────────
+// Wiring/data-flow coverage that the resolved `effort` makes it all the way
+// from a write, through the store + resolver, back out the GET read surface
+// (the same `resolved.effort` the spawn path threads into the launch builder).
+describe('effort pin (POST→store→GET data-flow)', () => {
+  it('lands a valid effort LIVE under the fully-live regime and reads it back', async () => {
+    const bundle = buildBundle({ enabled: true, dryRun: false });
+    const app = buildApp(bundle);
+    const write = await request(app)
+      .post('/topic-profile/13481')
+      .set('X-Instar-Request', '1')
+      .send({ effort: 'max' });
+    expect(write.status).toBe(200);
+    expect(write.body.appliedLive).toContain('effort');
+    expect(bundle.store.resolve(13481)?.effort).toBe('max');
+
+    // The resolver surfaces it on the GET read — the same value the spawn path
+    // threads into the launch builder as `--effort`.
+    const read = await request(app).get('/topic-profile/13481');
+    expect(read.status).toBe(200);
+    expect(read.body.resolved.effort).toBe('max');
+    expect(read.body.resolved.sources.effort).toBe('profile-pin');
+
+    // Persistence survives a store reload (a second instance reads the pin).
+    const reloaded = new TopicProfileStore({
+      stateFilePath: path.join(stateDir, 'state', 'topic-profiles.json'),
+    });
+    expect(reloaded.resolve(13481)?.effort).toBe('max');
+  });
+
+  it('rejects an off-enum effort (400, profile unchanged) — ultracode is not a CLI value', async () => {
+    const bundle = buildBundle({ enabled: true, dryRun: false });
+    const app = buildApp(bundle);
+    const res = await request(app)
+      .post('/topic-profile/13481')
+      .set('X-Instar-Request', '1')
+      .send({ effort: 'ultracode' });
+    expect(res.status).toBe(400);
+    expect(res.body.validation.field).toBe('effort');
+    expect(res.body.validation.failure).toBe('off-enum');
+    expect(bundle.store.resolve(13481)).toBeNull();
+  });
+
+  it('GET exposes resolved.effort:null when no pin is set', async () => {
+    const app = buildApp(buildBundle(FLEET_REGIME));
+    const res = await request(app).get('/topic-profile/55');
+    expect(res.status).toBe(200);
+    expect(res.body.resolved.effort).toBeNull();
+  });
+});

--- a/tests/unit/classifyProfileChange.test.ts
+++ b/tests/unit/classifyProfileChange.test.ts
@@ -179,6 +179,44 @@ describe('classifyProfileChange — Claude thinking rows', () => {
   });
 });
 
+describe('classifyProfileChange — Claude effort rows', () => {
+  it('effort-only change, resume-ready → resume, none-loss, effort-specific reason (NOT thinking)', () => {
+    const c = classifyProfileChange(p({ effort: 'high' }), p({ effort: 'max' }), idleSession());
+    expect(c.swapMethod).toBe('resume');
+    expect(c.expectedLoss).toBe('none');
+    expect(c.requiresRespawn).toBe(true);
+    expect(c.reason).toContain('effort change');
+    expect(c.reason).not.toContain('thinking');
+  });
+
+  it('effort-only change, no resume UUID → fresh, recent-only', () => {
+    const c = classifyProfileChange(
+      p({ effort: 'low' }),
+      p({ effort: 'max' }),
+      idleSession({ claudeResumeReady: false }),
+    );
+    expect(c.swapMethod).toBe('continuation');
+    expect(c.expectedLoss).toBe('recent-only');
+    expect(c.reason).toContain('effort change');
+  });
+
+  it('effort-only change is NOT gated on the thinking verification flags (the bug this row fixes)', () => {
+    const c = classifyProfileChange(
+      p({ effort: 'high' }),
+      p({ effort: 'max' }),
+      idleSession({ thinkingLevelResumeVerified: false, thinkingOffOnResumeVerified: false }),
+    );
+    expect(c.swapMethod).toBe('resume');
+    expect(c.expectedLoss).toBe('none');
+  });
+
+  it('setting effort from unset → resume (none-loss), effort reason', () => {
+    const c = classifyProfileChange(p(), p({ effort: 'max' }), idleSession());
+    expect(c.requiresRespawn).toBe(true);
+    expect(c.reason).toContain('effort change');
+  });
+});
+
 describe('classifyProfileChange — Codex rows', () => {
   it('codex change with fence-captured rollout-id → resume, none-loss', () => {
     const c = classifyProfileChange(

--- a/tests/unit/frameworkSessionLaunch-effort.test.ts
+++ b/tests/unit/frameworkSessionLaunch-effort.test.ts
@@ -1,0 +1,164 @@
+/**
+ * Unit tests — the Topic Profile direct `--effort` launch pin in the
+ * claude-code interactive + headless builders.
+ *
+ * `effort` is a DIRECT pin of Claude Code's `--effort` CLI flag
+ * (low|medium|high|xhigh|max), distinct from `thinkingMode` (which the
+ * builders MAP onto --effort). Contract under test:
+ *   - present  → argv contains `--effort <level>` in the right position;
+ *   - absent   → no `--effort`;
+ *   - invalid  → dropped (defense-in-depth enum check inside the builder);
+ *   - a direct pin WINS over the thinkingMode→effort mapping (no duplicate);
+ *   - non-claude frameworks ignore it entirely.
+ *
+ * These assertions FAIL against the pre-change builders, which had no `effort`
+ * option at all.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  buildInteractiveLaunch,
+  buildHeadlessLaunch,
+  validateEffortLevel,
+} from '../../src/core/frameworkSessionLaunch.js';
+import type { EffortLevel } from '../../src/core/topicProfileValidation.js';
+
+const LEVELS: EffortLevel[] = ['low', 'medium', 'high', 'xhigh', 'max'];
+
+function effortIdx(argv: string[]): number {
+  return argv.indexOf('--effort');
+}
+function countEffort(argv: string[]): number {
+  return argv.filter((a) => a === '--effort').length;
+}
+
+describe('validateEffortLevel (defense-in-depth clamp)', () => {
+  it('accepts every closed-enum level', () => {
+    for (const l of LEVELS) expect(validateEffortLevel(l)).toBe(l);
+  });
+  it('drops anything off-enum (incl. ultracode/ultra), undefined, null', () => {
+    for (const bad of ['ultracode', 'ultra', 'xxhigh', 'HIGH', '', 'minimal', undefined, null]) {
+      expect(validateEffortLevel(bad)).toBeNull();
+    }
+  });
+});
+
+describe('claude-code interactive builder — direct --effort pin', () => {
+  it('emits --effort <level> right after --dangerously-skip-permissions', () => {
+    for (const level of LEVELS) {
+      const spec = buildInteractiveLaunch('claude-code', {
+        binaryPath: '/usr/local/bin/claude',
+        effort: level,
+      });
+      const idx = effortIdx(spec.argv);
+      expect(idx).toBeGreaterThan(-1);
+      expect(spec.argv[idx + 1]).toBe(level);
+      // Position: immediately after the skip-permissions flag (argv[1]).
+      expect(spec.argv[0]).toBe('/usr/local/bin/claude');
+      expect(spec.argv[1]).toBe('--dangerously-skip-permissions');
+      expect(idx).toBe(2);
+    }
+  });
+
+  it('absent → no --effort', () => {
+    const spec = buildInteractiveLaunch('claude-code', { binaryPath: '/usr/local/bin/claude' });
+    expect(spec.argv).not.toContain('--effort');
+  });
+
+  it('invalid value is dropped (no --effort reaches the CLI)', () => {
+    const spec = buildInteractiveLaunch('claude-code', {
+      binaryPath: '/usr/local/bin/claude',
+      // Force an unknown value past the type system (the resolver fails open,
+      // but the builder is a second untrusted entry point).
+      effort: 'ultracode' as unknown as EffortLevel,
+    });
+    expect(spec.argv).not.toContain('--effort');
+  });
+
+  it('a direct effort pin WINS over thinkingMode and emits --effort exactly once', () => {
+    const spec = buildInteractiveLaunch('claude-code', {
+      binaryPath: '/usr/local/bin/claude',
+      effort: 'xhigh',
+      thinkingMode: 'low', // would otherwise map to --effort low
+    });
+    expect(countEffort(spec.argv)).toBe(1);
+    const idx = effortIdx(spec.argv);
+    expect(spec.argv[idx + 1]).toBe('xhigh');
+  });
+
+  it('a direct effort pin overrides thinkingMode:off (no MAX_THINKING_TOKENS=0 suppression)', () => {
+    const spec = buildInteractiveLaunch('claude-code', {
+      binaryPath: '/usr/local/bin/claude',
+      effort: 'high',
+      thinkingMode: 'off',
+    });
+    const idx = effortIdx(spec.argv);
+    expect(spec.argv[idx + 1]).toBe('high');
+    expect(spec.envOverrides.MAX_THINKING_TOKENS).toBeUndefined();
+  });
+
+  it('coexists with --model (both flags present)', () => {
+    const spec = buildInteractiveLaunch('claude-code', {
+      binaryPath: '/usr/local/bin/claude',
+      defaultModel: 'opus',
+      effort: 'max',
+    });
+    expect(spec.argv).toContain('--model');
+    const idx = effortIdx(spec.argv);
+    expect(spec.argv[idx + 1]).toBe('max');
+  });
+});
+
+describe('claude-code headless builder — direct --effort pin', () => {
+  it('emits --effort <level> after the --model block and before -p', () => {
+    const spec = buildHeadlessLaunch('claude-code', {
+      binaryPath: '/usr/local/bin/claude',
+      prompt: 'do the thing',
+      model: 'opus',
+      effort: 'high',
+    });
+    const idx = effortIdx(spec.argv);
+    const modelIdx = spec.argv.indexOf('--model');
+    const pIdx = spec.argv.indexOf('-p');
+    expect(idx).toBeGreaterThan(-1);
+    expect(spec.argv[idx + 1]).toBe('high');
+    expect(idx).toBeGreaterThan(modelIdx); // after --model block
+    expect(idx).toBeLessThan(pIdx); // before the prompt positional
+  });
+
+  it('absent → no --effort; prompt is still the final positional', () => {
+    const spec = buildHeadlessLaunch('claude-code', {
+      binaryPath: '/usr/local/bin/claude',
+      prompt: 'hello',
+    });
+    expect(spec.argv).not.toContain('--effort');
+    expect(spec.argv[spec.argv.length - 1]).toBe('hello');
+  });
+
+  it('invalid value is dropped', () => {
+    const spec = buildHeadlessLaunch('claude-code', {
+      binaryPath: '/usr/local/bin/claude',
+      prompt: 'hi',
+      effort: 'ultracode' as unknown as EffortLevel,
+    });
+    expect(spec.argv).not.toContain('--effort');
+  });
+});
+
+describe('non-claude frameworks ignore effort', () => {
+  it('codex interactive does not emit --effort for a direct effort pin', () => {
+    const spec = buildInteractiveLaunch('codex-cli', {
+      binaryPath: '/usr/local/bin/codex',
+      effort: 'max',
+    });
+    expect(spec.argv).not.toContain('--effort');
+  });
+  it('gemini headless does not emit --effort', () => {
+    const spec = buildHeadlessLaunch('gemini-cli', {
+      binaryPath: '/usr/local/bin/gemini',
+      prompt: 'hi',
+      effort: 'high',
+    });
+    expect(spec.argv).not.toContain('--effort');
+  });
+});

--- a/tests/unit/topic-profile-server-wiring.test.ts
+++ b/tests/unit/topic-profile-server-wiring.test.ts
@@ -143,6 +143,20 @@ describe('server-boot wiring: Topic Profile orchestrator + carrier (TOPIC-PROFIL
       expect(src).toContain('_topicProfileOrchestrator?.onProfileWrite(topicKey, info)');
     });
 
+    it('resolves the per-topic effort from the profile and threads it into the spawn options (data-flow)', () => {
+      // The resolved profile's `effort` must reach spawnInteractiveSession as
+      // options.effort — otherwise the pin resolves but never becomes a
+      // `--effort` launch arg (the "resolved but inert" failure). Pin both the
+      // resolve read and the conditional spawn-option spread.
+      expect(src).toContain('const profileEffort = resolvedProfile?.effort;');
+      expect(src).toContain('...(profileEffort ? { effort: profileEffort } : {}),');
+      // The spawn-option spread must live inside the spawnInteractiveSession call.
+      const spawnIdx = src.indexOf('sessionManager.spawnInteractiveSession(bootstrapMessage, sessionName, {');
+      expect(spawnIdx).toBeGreaterThan(0);
+      const block = src.slice(spawnIdx, spawnIdx + 1200);
+      expect(block).toContain('...(profileEffort ? { effort: profileEffort } : {}),');
+    });
+
     it('§8 ingress "switch now" bridges to the orchestrator confirm surface (the disclosed instruction is not a dead end)', () => {
       // The orchestrator discloses "say 'switch now' to interrupt" and arms its
       // OWN switch-now slot; the ingress must route the operator's reply to

--- a/tests/unit/topicProfileResolver-effort.test.ts
+++ b/tests/unit/topicProfileResolver-effort.test.ts
@@ -1,0 +1,133 @@
+/**
+ * Unit tests — the Topic Profile `effort` resolution arm in
+ * TopicProfileResolver.resolve(): a valid pin resolves; an INVALID stored
+ * value FAILS OPEN to undefined (no --effort) without throwing; an absent pin
+ * resolves to undefined; and the config-default layer is honored / clamped.
+ *
+ * `effort` is a DIRECT Claude `--effort` pin (low|medium|high|xhigh|max),
+ * distinct from the cross-framework `thinkingMode` abstraction. The fail-open
+ * guarantee is the safety property under test: a poisoned on-disk value (e.g.
+ * a legacy 'ultracode' pin) must never reach the CLI as a launch arg.
+ *
+ * These assertions FAIL against the pre-change resolver, which had no `effort`
+ * field on ResolvedTopicProfile at all.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { TopicProfileStore } from '../../src/core/TopicProfileStore.js';
+import { TopicProfileResolver } from '../../src/core/TopicProfileResolver.js';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+
+let tmpDir: string;
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'effort-resolver-'));
+});
+afterEach(() => {
+  SafeFsExecutor.safeRmSync(tmpDir, { recursive: true, force: true, operation: 'tests/unit/topicProfileResolver-effort.test.ts cleanup' });
+});
+
+/**
+ * Seed topic-profiles.json directly (bypassing the enum-clamping write
+ * surface) so a deliberately-INVALID `effort` value can be persisted, then
+ * build a store that loads it. This is how a poisoned on-disk value reaches
+ * the resolver in production (a legacy pin, a hand-edited file, an enum that
+ * shrank after the write).
+ */
+function storeWithRawEffort(rawEffort: unknown): TopicProfileStore {
+  const stateFilePath = path.join(tmpDir, 'state', 'topic-profiles.json');
+  fs.mkdirSync(path.dirname(stateFilePath), { recursive: true });
+  fs.writeFileSync(
+    stateFilePath,
+    JSON.stringify({
+      updatedAt: new Date().toISOString(),
+      topics: {
+        '13481': {
+          current: {
+            effort: rawEffort,
+            updatedAt: new Date().toISOString(),
+            updatedBy: 'telegram:777',
+          },
+          previous: null,
+          intendedProfile: null,
+          parked: null,
+          breakerCount: 0,
+        },
+      },
+    }),
+    'utf-8',
+  );
+  return new TopicProfileStore({ stateFilePath });
+}
+
+function resolverFor(
+  store: TopicProfileStore,
+  configDefaults: Record<string, { effort?: string }> = {},
+): TopicProfileResolver {
+  return new TopicProfileResolver({
+    store,
+    defaultFramework: () => 'claude-code',
+    configTopicFrameworks: () => ({}),
+    configProfileDefaults: () => configDefaults,
+    frameworkDefaultModels: () => ({}),
+    tierEscalationConfig: () => undefined,
+    localModelBinding: () => null,
+    frameworkBinaryPath: () => null,
+  });
+}
+
+describe('TopicProfileResolver — effort arm', () => {
+  it('resolves a valid stored effort pin', () => {
+    for (const level of ['low', 'medium', 'high', 'xhigh', 'max'] as const) {
+      const store = storeWithRawEffort(level);
+      const resolved = resolverFor(store).resolve('13481');
+      expect(resolved.effort).toBe(level);
+      expect(resolved.sources.effort).toBe('profile-pin');
+    }
+  });
+
+  it('FAILS OPEN to undefined on an invalid stored value — never throws, no --effort', () => {
+    for (const bad of ['ultracode', 'ultra', 'xxhigh', 'HIGH', '', 'minimal']) {
+      const store = storeWithRawEffort(bad);
+      const resolver = resolverFor(store);
+      // Must not throw on a poisoned value.
+      const resolved = resolver.resolve('13481');
+      expect(resolved.effort).toBeUndefined();
+      expect(resolved.sources.effort).toBe('unset');
+    }
+  });
+
+  it('resolves to undefined when no pin and no config default', () => {
+    const stateFilePath = path.join(tmpDir, 'state', 'topic-profiles.json');
+    const store = new TopicProfileStore({ stateFilePath });
+    const resolved = resolverFor(store).resolve('99999');
+    expect(resolved.effort).toBeUndefined();
+    expect(resolved.sources.effort).toBe('unset');
+  });
+
+  it('honors a valid topicProfiles config default when no pin is set', () => {
+    const stateFilePath = path.join(tmpDir, 'state', 'topic-profiles.json');
+    const store = new TopicProfileStore({ stateFilePath });
+    const resolved = resolverFor(store, { '13481': { effort: 'high' } }).resolve('13481');
+    expect(resolved.effort).toBe('high');
+    expect(resolved.sources.effort).toBe('topicProfiles-config-default');
+  });
+
+  it('a pin WINS over the config default', () => {
+    const store = storeWithRawEffort('max');
+    const resolved = resolverFor(store, { '13481': { effort: 'low' } }).resolve('13481');
+    expect(resolved.effort).toBe('max');
+    expect(resolved.sources.effort).toBe('profile-pin');
+  });
+
+  it('an invalid config default is ignored (fail open to undefined)', () => {
+    const stateFilePath = path.join(tmpDir, 'state', 'topic-profiles.json');
+    const store = new TopicProfileStore({ stateFilePath });
+    const resolved = resolverFor(store, { '13481': { effort: 'ultracode' } }).resolve('13481');
+    expect(resolved.effort).toBeUndefined();
+    expect(resolved.sources.effort).toBe('unset');
+  });
+});

--- a/upgrades/next/topic-effort-pin.md
+++ b/upgrades/next/topic-effort-pin.md
@@ -1,0 +1,51 @@
+# Topic profiles — pin the Claude Code effort level per topic
+
+## What Changed
+
+- Topic profiles gain an optional **`effort`** field (`low|medium|high|xhigh|max`),
+  mirroring the existing `model`/`thinkingMode`/`framework` pins. When set, instar
+  passes `--effort <level>` to Claude Code at session spawn, so the choice survives
+  respawns. Settable conversationally ("set max effort on this topic") and via
+  `/topic effort <level>`; exposed on `GET /topic-profile/:id` as
+  `resolved.effort` + `sources.effort`.
+- Argv injection in both Claude Code launch builders (`frameworkSessionLaunch.ts`):
+  interactive (after `--dangerously-skip-permissions`) and headless (after
+  `--model`, before `-p`). A direct effort pin wins over the `thinkingMode`→effort
+  mapping (exactly one `--effort` emitted). Non-Claude frameworks ignore it.
+- Closed enum, **fail-open at three layers** (resolver, launch builder, write API):
+  an off-enum / `ultracode` value never reaches the CLI. `ultracode` is not a CLI
+  `--effort` value (the harness exposes it only via the UI `/effort` picker — filed
+  as framework-issue a06fb2aa); this pin reaches the CLI ceiling `max`.
+- `classifyProfileChange` gets a dedicated effort-only row: an effort change is a
+  launch-time flag → clean kill + `claude --resume` (none-loss when resume-ready),
+  with its own honest reason (not mislabeled as a thinking change).
+
+## Evidence
+
+- `tests/unit/topicProfileResolver-effort.test.ts` (6): valid pin resolves;
+  invalid/`ultracode` → fail-open undefined (never throws); absent → undefined;
+  config-default honored/clamped; pin wins over config.
+- `tests/unit/frameworkSessionLaunch-effort.test.ts` (13): `validateEffortLevel`
+  both sides; interactive `--effort` position; headless position; absent → none;
+  invalid → dropped; direct-pin-wins-over-thinkingMode (one `--effort`); non-claude
+  no-op.
+- `tests/unit/classifyProfileChange.test.ts` (+4): effort-only → resume/none-loss,
+  not gated on thinking flags, effort-specific reason.
+- `tests/integration/topic-profile-routes.test.ts` (+3): POST→store→GET data-flow,
+  off-enum 400, `effort:null` when unset. `tests/unit/topic-profile-server-wiring.test.ts`
+  (+1): the spawn handoff. `tsc --noEmit` clean; topic-profile suite green.
+
+## What to Tell Your User
+
+You can now pin how hard Claude thinks on a specific topic — say "set max effort
+on this topic" and every session I start for it runs at that effort level, and it
+sticks across restarts (the same way pinning a model or thinking depth already
+does). The five levels are low, medium, high, xhigh, and max. (The "ultracode"
+mode you pick in the Claude Code UI is a session-only setting the command line
+can't pin yet — this gives you the max effort level it can; I've filed the rest
+as a gap.)
+
+## Summary of New Capabilities
+
+- Per-topic `--effort` pin (`/topic effort <level>` or conversationally), durable
+  across respawns, exposed on `GET /topic-profile/:id`.

--- a/upgrades/side-effects/topic-effort-pin.md
+++ b/upgrades/side-effects/topic-effort-pin.md
@@ -1,0 +1,117 @@
+# Side-Effects Review — per-topic effort pin (--effort at spawn)
+
+**Version / slug:** `topic-effort-pin`
+**Date:** `2026-06-12`
+**Author:** `Instar Agent (echo)`
+**Second-pass reviewer:** `workflow adversarial reviewer (CONCUR — 1 MEDIUM fixed, see below)`
+
+## Summary of the change
+
+Adds an optional `effort` field (enum `low|medium|high|xhigh|max`) to the
+topic-profile system, threaded through validation, store, resolver, write
+surface, change-classifier, orchestrator, conversational ingress, types, and the
+two routes; and injects `--effort <level>` into the Claude Code launch argv
+(interactive + headless builders in `frameworkSessionLaunch.ts`), resolved from
+the topic profile at spawn in `SessionManager`/`server.ts`. Mirrors `thinkingMode`'s
+plumbing. Operator request: Justin, topic 13481, "set ultracode for this topic"
+(ultracode is not a CLI value; this pins the CLI ceiling `max`).
+
+## Decision-point inventory
+
+- Topic-profile resolution — **modify** — adds an `effort` resolution arm
+  (pin > config-default > unset); off-enum value → fail-open `undefined`.
+- Launch argv builders — **modify** — push `--effort` for claude-code only when
+  set + enum-valid; non-claude untouched.
+- `classifyProfileChange` — **modify** — adds a dedicated effort-only row
+  (kill+resume, none-loss when resume-ready) so it is not misclassified as a
+  thinking change (the second-pass MEDIUM finding, now fixed).
+- Write surface / routes / ingress — **modify** — accept + validate `effort`.
+
+---
+
+## 1. Over-block
+Off-enum values are rejected at the write API (HTTP 400, profile unchanged) — that
+is the intended block. No legitimate input is rejected; the five CLI-valid levels
+all pass. `ultracode` is deliberately refused (not a CLI value).
+
+## 2. Under-block
+A value that is enum-valid but unsupported by the *running model* (e.g. `xhigh`
+on a model that floors to `high`) is passed through — the CLI itself floors it
+(documented behavior), so no instar-side block is needed. Headless one-shot/job
+spawns do NOT thread effort (interactive-only); acceptable — per-topic effort is
+a per-conversation pin, and the headless builder support is forward-looking
+defense-in-depth (flagged by the reviewer as a deliberate choice, not a bug).
+
+## 3. Level-of-abstraction fit
+Right layer: mirrors `thinkingMode` exactly across the same files; the resolver
+owns precedence, the launch builder owns argv, the classifier owns respawn
+semantics. No parallel machinery invented.
+
+## 4. Signal vs authority compliance
+N/A as a gate — this is a config field, not a decision point. The one authority-
+adjacent concern (a bad value reaching the CLI) is defended by three independent
+fail-open/validate layers.
+
+## 5. Interactions
+- Interacts with the `thinkingMode`→`--effort` mapping in the interactive builder:
+  a direct effort pin WINS and suppresses the thinkingMode-derived mapping, so
+  `--effort` is emitted exactly once (unit-tested).
+- The change-classifier effort row composes with model/tier/thinking rows: a
+  combined change is handled by those rows (their respawn carries the new flag);
+  only effort-only needed the new row.
+
+## 6. External surfaces
+- `GET /topic-profile/:id` gains `resolved.effort` + `sources.effort` (additive).
+- POST profile/propose accept `effort` (additive; off-enum → 400).
+- A spawned Claude session's argv gains `--effort <level>` when the topic pins it.
+  Old behavior (no pin) is byte-identical.
+
+## Framework generality
+
+The change DOES route through the framework abstraction (`frameworkSessionLaunch.ts`
+builders), and is **deliberately Claude-optimizing, not Claude-leaking**:
+
+- `--effort <low|medium|high|xhigh|max>` is a **Claude Code CLI flag**. Only the
+  `claudeCodeBuilder` (interactive) and `claudeCodeHeadlessBuilder` (headless) push
+  it. `InteractiveLaunchOptions.effort` / `HeadlessLaunchOptions.effort` are optional
+  inputs the non-Claude builders simply **ignore** — `codexCliBuilder`,
+  `geminiCliBuilder`, and `piCliBuilder` are untouched and emit no effort flag.
+- This is the "Framework-Agnostic — and Framework-Optimizing" standard satisfied:
+  the abstraction stays framework-agnostic (every builder receives the same options
+  object; none is forced to honor a flag it doesn't have), while Claude gets its
+  native knob. Codex/Gemini have their own reasoning/effort controls
+  (e.g. codex `-c model_reasoning_effort`); wiring those is explicitly OUT OF SCOPE
+  here and would be a separate per-framework mapping (a future `resolveEffortForFramework`
+  analogous to `resolveModelForFramework`), not a generalization of this Claude flag.
+- The topic-profile `effort` field itself is framework-agnostic (it's a profile
+  value); only its TRANSLATION to a launch flag is Claude-specific, which is the
+  correct layer for framework specificity (mirrors how `model` resolves per-framework
+  via `resolveModelForFramework`).
+
+## 7. Multi-machine posture (Cross-Machine Coherence)
+**proxied-on-read / machine-local-by-design.** The topic profile already resolves
+per-machine at spawn; effort rides the same path. When a topic transfers machines,
+its profile carrier (the existing topic-profile pull-at-acquire seam) carries
+`effort` along with the other fields (it's in `PROFILE_FIELDS`), so the pin
+follows the conversation. No new replication surface; no new URL/notice.
+
+## 8. Rollback cost
+Trivial: additive field, unset by default. Reverting the PR removes the field and
+the argv injection; no durable migration (the field simply stops being read). A
+stored `effort` on a profile file is ignored by older code (additive JSON).
+
+---
+
+## Second-pass review
+
+Workflow adversarial reviewer: **CONCUR** (tscClean, testsPass). Two findings:
+- **MEDIUM — effort half-wired in `classifyProfileChange`** (in AXES but no
+  branch → effort-only change fell through to the thinkingMode row, wrong reason
+  + wrong verification gate). **FIXED**: added a dedicated effort-only row
+  (kill+resume, none-loss when resume-ready; fresh recent-only otherwise) with an
+  effort-specific reason; +4 classifier unit tests asserting it resolves as
+  `resume`/none-loss, is NOT gated on the thinking flags, and the reason says
+  "effort change" not "thinking".
+- **LOW — headless builder has no live caller** (interactive-only data flow).
+  Acknowledged as a deliberate, documented forward-looking choice (per-topic
+  effort is a per-conversation interactive pin), not a bug (§2 above).


### PR DESCRIPTION
## ELI16

Claude Code has an effort setting (low/medium/high/xhigh/max) trading speed for thinking depth. instar's topic profiles already pin a model, thinking mode, and framework per conversation topic so the choice survives restarts. This adds **effort** as a fourth pinnable field: pin a topic to (say) `max` and every session instar spawns for it passes `--effort max`, surviving respawns. Prompted by the operator asking to set "ultracode" on a topic — ultracode is a Claude Code *UI session mode* the CLI can't pin (`--effort` only takes the five levels; probed + confirmed), so this reaches the CLI ceiling `max`; the workflow-orchestration half of ultracode is filed as a separate harness gap (framework-issue a06fb2aa). Additive, off by default, fail-open at three layers so a bad value never reaches the CLI.

## What's in it

- `effort` field on the topic profile (enum low|medium|high|xhigh|max), threaded through validation, store, resolver, write surface, change-classifier, orchestrator, conversational ingress, types, and the two routes — mirroring `thinkingMode` exactly.
- `--effort` argv injection in BOTH Claude Code launch builders (interactive after `--dangerously-skip-permissions`; headless after `--model`, before `-p`). A direct pin wins over the thinkingMode→effort mapping (exactly one `--effort`). **Non-Claude builders ignore it** (framework-optimizing, not Claude-leaking — see the side-effects artifact's Framework-generality section).
- `/topic effort <level>` + conversational "set max effort here"; `GET /topic-profile/:id` exposes `resolved.effort` + `sources.effort`.
- `classifyProfileChange` gets a dedicated effort-only row: a launch-flag change → kill + `claude --resume` (none-loss when resume-ready), not mislabeled as a thinking change.

## Review discipline

Built by a fresh-context implementer + adversarial reviewer (ultracode workflow). Reviewer **CONCUR** (tsc clean, tests pass) with one MEDIUM: effort was half-wired in `classifyProfileChange` (in AXES but no branch → fell through to the thinking row, wrong reason + wrong verification gate). **Fixed** with the dedicated row + 4 classifier tests asserting it resolves `resume`/none-loss, is NOT gated on the thinking flags, and reads "effort change". A LOW (headless builder has no live caller — interactive-only) is documented as a deliberate forward-looking choice.

## Evidence

- `topicProfileResolver-effort` (6), `frameworkSessionLaunch-effort` (13), `classifyProfileChange` (+4), `topic-profile-routes` integration (+3), `topic-profile-server-wiring` (+1). All fail against pre-change code. `tsc --noEmit` clean; topic-profile suite green; no-silent-fallbacks ratchet satisfied.
- Multi-machine posture (§7): the pin rides the existing topic-profile carrier (in PROFILE_FIELDS), so it follows a topic across machines; no new replication surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)