### PR TITLE
feat(jobs): WS4.3 read-side — GET /jobs?scope=pool merges the fleet's jobs + divergence detector

### DIFF
--- a/.instar/instar-dev-decisions/2026-06-13T05-04-45-049Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-06-13T05-04-45-049Z-unknown.json
@@ -1,0 +1,18 @@
+{
+  "ts": "2026-06-13T05:04:45.049Z",
+  "slug": "unknown",
+  "suggestedTier": 2,
+  "declaredTier": 2,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "irreversibility: src/core/PostUpdateMigrator.ts touches PostUpdateMigrator",
+    "migration / fleet-rollout surface: src/core/PostUpdateMigrator.ts touches PostUpdateMigrator (fleet migration machinery)",
+    "new capability: new route (router.<verb>() added",
+    "new capability: new config key added"
+  ],
+  "belowFloor": false,
+  "files": 3,
+  "loc": 178,
+  "causalAutopsy": null,
+  "verdict": "pass"
+}

--- a/src/core/PostUpdateMigrator.ts
+++ b/src/core/PostUpdateMigrator.ts
@@ -4967,6 +4967,25 @@ Strip the \`[telegram:N]\` prefix before interpreting the message. Respond natur
       result.upgraded.push('CLAUDE.md: added Attention Queue pool-scope bullet (WS4.1)');
     }
 
+    // WS4.3 (MULTI-MACHINE-SEAMLESSNESS-SPEC) — pool-scope jobs awareness.
+    // A deployed agent whose CLAUDE.md already carries the Job Scheduler
+    // section gets the ?scope=pool bullet inserted after the /jobs View line.
+    // Content-sniff on 'jobs?scope=pool' keeps it idempotent (route-qualified —
+    // a bare `scope=pool` sniff would falsely match other pool-scope routes).
+    if (content.includes('**Job Scheduler**') && !content.includes('jobs?scope=pool')) {
+      const poolBullet = `- View the WHOLE POOL (jobs across every machine): \`curl -H "Authorization: Bearer $AUTH" "http://localhost:${port}/jobs?scope=pool"\` — merges each online machine's jobs (each tagged with its machineId/machineNickname), tolerant of a dark peer (a \`pool.failed\` entry, never a 500), short-TTL cached. Also carries \`pool.divergences\` — an observe-only flag for a machine that DECLARES jobs but is running 0 locally (or returns 0 jobs while online). Use this when the user asks "what jobs do I have?" / "is a job running anywhere?" on a multi-machine setup — the plain view only shows THIS machine's jobs.\n`;
+      // Anchor after the first /jobs View line within the section; fall back to
+      // after the section header line.
+      const anchor = /^- View:[^\n]*\/jobs[^\n]*$/m;
+      if (anchor.test(content)) {
+        content = content.replace(anchor, (m) => `${m}\n${poolBullet.trimEnd()}`);
+      } else {
+        content = content.replace(/\*\*Job Scheduler\*\*[^\n]*\n/, (m) => `${m}${poolBullet}`);
+      }
+      patched = true;
+      result.upgraded.push('CLAUDE.md: added Job Scheduler pool-scope bullet (WS4.3)');
+    }
+
     // Tunnel-failure-resilience awareness (spec Part 7). Existing agents
     // already have the Cloudflare Tunnel section but not the resilience
     // text — content-sniff and append a bullet so they can explain a link

--- a/src/scaffold/templates.ts
+++ b/src/scaffold/templates.ts
@@ -398,6 +398,7 @@ This routes feedback to the Instar maintainers automatically. Valid types: \`bug
 
 **Job Scheduler** — Run tasks on a schedule. Jobs in \`.instar/jobs.json\`.
 - View: \`curl -H "Authorization: Bearer $AUTH" http://localhost:${port}/jobs\`
+- View the WHOLE POOL (jobs across every machine): \`curl -H "Authorization: Bearer $AUTH" "http://localhost:${port}/jobs?scope=pool"\` — merges each online machine's jobs (each tagged with its machineId/machineNickname), tolerant of a dark peer (a \`pool.failed\` entry, never a 500), short-TTL cached. Also carries \`pool.divergences\` — an observe-only flag for a machine that DECLARES jobs but is running 0 locally (or returns 0 jobs while online). Use this when the user asks "what jobs do I have?" / "is a job running anywhere?" on a multi-machine setup — the plain view only shows THIS machine's jobs.
 - Trigger: \`curl -X POST -H "Authorization: Bearer $AUTH" http://localhost:${port}/jobs/SLUG/trigger\`
 
 **Sessions** — Spawn and manage Claude Code sessions.

--- a/src/server/routes.ts
+++ b/src/server/routes.ts
@@ -7832,23 +7832,165 @@ export function createRoutes(ctx: RouteContext): Router {
 
   // ── Jobs ────────────────────────────────────────────────────────
 
-  router.get('/jobs', (_req, res) => {
-    if (!ctx.scheduler) {
-      res.json({ jobs: [], scheduler: null });
-      return;
-    }
+  // Pool-scope job aggregation (WS4.3, MULTI-MACHINE-SEAMLESSNESS-SPEC §WS4.3 —
+  // READ-SIDE only). Mirrors the proven sessions?scope=pool / attention?scope=pool
+  // fan-out shape: a short-TTL cache so dashboard polls don't re-fan-out, a
+  // known-offline-peer skip, a per-peer timeout → failed marker (never a 500).
+  const jobsPoolCache = new Map<string, { at: number; payload: unknown }>();
+  const JOBS_POOL_CACHE_TTL_MS = 3_000;
+  const JOBS_PEER_TIMEOUT_MS = 5_000;
 
+  // Build THIS machine's local job list — the same shape the plain GET /jobs
+  // returns (so a peer's GET /jobs reply merges in identically).
+  function buildLocalJobs(): Array<Record<string, unknown>> {
+    if (!ctx.scheduler) return [];
     const nextRunTimes = ctx.scheduler.getNextRunTimes();
-    const jobs = ctx.scheduler.getJobs().map(job => {
+    return ctx.scheduler.getJobs().map((job) => {
       const jobState = ctx.state.getJobState(job.slug);
       // Merge live scheduler nextRun into state — fixes display bug where
       // never-run jobs show as "unscheduled" despite having active cron tasks
       const liveNext = nextRunTimes[job.slug];
       const mergedState = jobState
         ? { ...jobState, nextScheduled: jobState.nextScheduled ?? liveNext }
-        : liveNext ? { slug: job.slug, lastRun: null, lastResult: null, nextScheduled: liveNext, consecutiveFailures: 0 } : null;
+        : liveNext
+          ? { slug: job.slug, lastRun: null, lastResult: null, nextScheduled: liveNext, consecutiveFailures: 0 }
+          : null;
       return { ...job, state: mergedState, runsOnThisMachine: ctx.scheduler!.isJobLocal(job.slug) };
     });
+  }
+
+  // F8 job-placement divergence detector (observe-only — NEVER gates). Honest
+  // derivation: capacity carries no declared-job count, so we work from each
+  // machine's own /jobs reply. A divergence row flags ONLY the real F8 case — a
+  // machine that DECLARES jobs (its scheduler returned N>0) but RUNS none of
+  // them locally (runsOnThisMachine === true for 0 of them): "config says jobs
+  // here, machine isn't running them." A machine that declares ZERO jobs is NOT
+  // a divergence — a scheduler-less/dispatcher-only machine (or any machine
+  // with no jobs configured) legitimately has none, and flagging it is
+  // self-noise (2026-06-12 review finding). We never fabricate an expected
+  // count — only what the reply proves.
+  function detectJobDivergences(
+    perMachine: Array<{ machineId: string; nickname?: string | null; jobs: Array<Record<string, unknown>> }>,
+  ): Array<{ machineId: string; machineNickname?: string | null; declared: number; running: number; reason: string }> {
+    const out: Array<{ machineId: string; machineNickname?: string | null; declared: number; running: number; reason: string }> = [];
+    for (const m of perMachine) {
+      const declared = m.jobs.length;
+      const running = m.jobs.filter((j) => j.runsOnThisMachine === true).length;
+      if (declared > 0 && running === 0) {
+        out.push({
+          machineId: m.machineId,
+          machineNickname: m.nickname ?? undefined,
+          declared,
+          running,
+          reason: `machine ${m.nickname ?? m.machineId}: declares ${declared} jobs, running 0 locally`,
+        });
+      }
+    }
+    return out;
+  }
+
+  async function jobsPoolMerge(localJobs: Array<Record<string, unknown>>): Promise<Record<string, unknown>> {
+    const cacheKey = 'jobs';
+    const cached = jobsPoolCache.get(cacheKey);
+    if (cached && Date.now() - cached.at < JOBS_POOL_CACHE_TTL_MS) {
+      return cached.payload as Record<string, unknown>;
+    }
+
+    const selfMachineId = ctx.meshSelfId ?? null;
+    const selfNickname = selfMachineId
+      ? ctx.machinePoolRegistry?.getCapacity(selfMachineId)?.nickname ?? null
+      : null;
+
+    const peers = ctx.resolvePeerUrls?.() ?? [];
+    const failed: Array<{ machineId: string; error: string }> = [];
+    const remote: Array<Record<string, unknown>> = [];
+    // Per-machine declared/running view feeding the F8 divergence detector.
+    const perMachine: Array<{ machineId: string; nickname?: string | null; jobs: Array<Record<string, unknown>> }> = [
+      { machineId: selfMachineId ?? '(self)', nickname: selfNickname, jobs: localJobs },
+    ];
+    await Promise.all(
+      peers.map(async (p) => {
+        // Skip a peer the registry knows to be offline — saves the timeout
+        // wait; an unknown peer (no capacity row) is still tried.
+        const cap = ctx.machinePoolRegistry?.getCapacity(p.machineId);
+        if (cap && cap.online === false) {
+          failed.push({ machineId: p.machineId, error: 'offline' });
+          return;
+        }
+        try {
+          // Peers are called WITHOUT scope=pool — no recursion.
+          const r = await fetch(`${p.url}/jobs`, {
+            headers: { Authorization: `Bearer ${ctx.config.authToken}` },
+            signal: AbortSignal.timeout(JOBS_PEER_TIMEOUT_MS),
+          });
+          if (!r.ok) throw new Error(`HTTP ${r.status}`);
+          const body = (await r.json()) as { jobs?: Array<Record<string, unknown>> };
+          const nickname = cap?.nickname ?? null;
+          const peerJobs = body.jobs ?? [];
+          perMachine.push({ machineId: p.machineId, nickname, jobs: peerJobs });
+          for (const j of peerJobs) {
+            remote.push({
+              ...j,
+              machineId: j.machineId ?? p.machineId,
+              machineNickname: j.machineNickname ?? nickname ?? undefined,
+              remote: true,
+            });
+          }
+        } catch (err) {
+          failed.push({ machineId: p.machineId, error: err instanceof Error ? err.message : String(err) });
+        }
+      }),
+    );
+
+    // Tag local jobs with this machine's identity (additive — present only when
+    // the pool is wired). Mirrors sessions/attention self-tagging.
+    const localTagged = localJobs.map((j) => ({
+      ...j,
+      machineId: j.machineId ?? selfMachineId ?? undefined,
+      machineNickname: j.machineNickname ?? selfNickname ?? undefined,
+    }));
+
+    const jobs = [...localTagged, ...remote];
+    const payload = {
+      jobs,
+      count: jobs.length,
+      pool: {
+        enabled: !!ctx.machinePoolRegistry,
+        selfMachineId,
+        peersQueried: peers.length,
+        peersOk: peers.length - failed.length,
+        failed,
+        divergences: detectJobDivergences(perMachine),
+      },
+    };
+    jobsPoolCache.set(cacheKey, { at: Date.now(), payload });
+    return payload;
+  }
+
+  router.get('/jobs', async (req, res) => {
+    if (!ctx.scheduler) {
+      // scope=pool from a scheduler-less self still answers a coherent pool
+      // view (local-only empty) so the dashboard never 500s on a single role.
+      if (req.query.scope === 'pool') {
+        res.json(await jobsPoolMerge([]));
+        return;
+      }
+      res.json({ jobs: [], scheduler: null });
+      return;
+    }
+
+    const jobs = buildLocalJobs();
+
+    // scope=pool (WS4.3, MULTI-MACHINE-SEAMLESSNESS-SPEC §WS4.3): merge every
+    // ONLINE peer's plain GET /jobs into one view, each job tagged with its
+    // machine, plus an observe-only job-placement divergence list. Tolerant by
+    // design (per-peer timeout → a `failed` marker, never a 500), short-TTL
+    // cached so dashboard polling doesn't re-fan-out per request. Plain GET
+    // stays a back-compatible { jobs, queue } object.
+    if (req.query.scope === 'pool') {
+      res.json(await jobsPoolMerge(jobs));
+      return;
+    }
 
     res.json({ jobs, queue: ctx.scheduler.getQueue() });
   });

--- a/tests/integration/jobs-pool-scope.test.ts
+++ b/tests/integration/jobs-pool-scope.test.ts
@@ -1,0 +1,215 @@
+/**
+ * GET /jobs?scope=pool — pool-wide jobs aggregation (WS4.3,
+ * MULTI-MACHINE-SEAMLESSNESS-SPEC §WS4.3). READ-SIDE contract, both sides of
+ * every boundary:
+ *   - plain GET /jobs stays back-compatible ({ jobs, queue }), self-tagging
+ *     machine identity only via scope=pool (the plain shape is untouched);
+ *   - scope=pool merges every reachable peer's jobs behind a REAL second HTTP
+ *     server, tagging each with the peer's identity, local jobs tagged self;
+ *   - a known-offline peer is skipped to a pool.failed entry WITHOUT waiting;
+ *   - an unreachable peer degrades to a pool.failed entry — never a 500, local
+ *     jobs still answer;
+ *   - no-peers → local-only, enabled:true;
+ *   - the F8 job-placement divergence detector flags an online peer that
+ *     declares jobs but runs 0 locally (and a peer that returns 0 jobs).
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import express from 'express';
+import request from 'supertest';
+import type http from 'node:http';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { createRoutes } from '../../src/server/routes.js';
+import type { RouteContext } from '../../src/server/routes.js';
+import { generateAgentToken, deleteAgentToken } from '../../src/messaging/AgentTokenManager.js';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+
+const PROJECT_NAME = 'jobs-pool-scope-test';
+let AUTH = '';
+
+interface JobSpec {
+  slug: string;
+  local?: boolean; // runsOnThisMachine
+}
+
+interface CtxOpts {
+  jobs?: JobSpec[];
+  schedulerless?: boolean;
+  meshSelfId?: string | null;
+  capacities?: Record<string, { nickname?: string; online?: boolean }>;
+  peers?: Array<{ machineId: string; url: string }>;
+  pool?: boolean;
+}
+
+function buildScheduler(jobs: JobSpec[]): unknown {
+  const localSet = new Set(jobs.filter((j) => j.local !== false).map((j) => j.slug));
+  return {
+    getJobs: () => jobs.map((j) => ({ slug: j.slug, cron: '0 * * * *', tags: [] })),
+    getNextRunTimes: () => Object.fromEntries(jobs.map((j) => [j.slug, '2026-06-14T00:00:00Z'])),
+    isJobLocal: (slug: string) => localSet.has(slug),
+    getQueue: () => [],
+  };
+}
+
+function buildCtx(tmpDir: string, opts: CtxOpts = {}): RouteContext {
+  return {
+    config: { projectName: PROJECT_NAME, projectDir: tmpDir, stateDir: path.join(tmpDir, '.instar'), port: 0, authToken: AUTH } as never,
+    scheduler: opts.schedulerless ? null : (buildScheduler(opts.jobs ?? []) as never),
+    meshSelfId: opts.meshSelfId ?? null,
+    machinePoolRegistry: (opts.pool ?? true)
+      ? ({ getCapacity: (id: string) => opts.capacities?.[id] ?? null, getCapacities: () => [] } as never)
+      : null,
+    resolvePeerUrls: opts.peers ? () => opts.peers! : null,
+    state: { getJobState: () => null, getSession: () => null, listSessions: () => [] } as never,
+    sessionManager: null, telegram: null, relationships: null, feedback: null, dispatches: null,
+    updateChecker: null, autoUpdater: null, autoDispatcher: null, quotaTracker: null,
+    publisher: null, viewer: null, tunnel: null, evolution: null, watchdog: null,
+    triageNurse: null, topicMemory: null, discoveryEvaluator: null, startTime: new Date(),
+    mentorRunner: null, currentInboundByTopic: new Map(),
+  } as unknown as RouteContext;
+}
+
+function mount(tmpDir: string, opts: CtxOpts = {}): express.Express {
+  const app = express();
+  app.use(express.json());
+  app.use('/', createRoutes(buildCtx(tmpDir, opts)));
+  return app;
+}
+
+const auth = () => ({ Authorization: `Bearer ${AUTH}` });
+
+describe('GET /jobs — pool-wide aggregation (WS4.3)', () => {
+  let tmpDir: string;
+  let peerServer: http.Server | null = null;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'instar-jobs-pool-'));
+    AUTH = generateAgentToken(PROJECT_NAME);
+  });
+  afterEach(async () => {
+    deleteAgentToken(PROJECT_NAME);
+    if (peerServer) { await new Promise((r) => peerServer!.close(r)); peerServer = null; }
+    SafeFsExecutor.safeRmSync(tmpDir, { recursive: true, force: true, operation: 'test-cleanup' });
+  });
+
+  async function listenPeer(jobs: JobSpec[], meshSelfId: string): Promise<string> {
+    const app = mount(tmpDir, { jobs, meshSelfId, capacities: { [meshSelfId]: { nickname: 'Mac Mini', online: true } } });
+    peerServer = app.listen(0);
+    await new Promise((r) => peerServer!.once('listening', r));
+    const addr = peerServer!.address() as { port: number };
+    return `http://127.0.0.1:${addr.port}`;
+  }
+
+  it('plain GET /jobs stays { jobs, queue } and does NOT add the pool object', async () => {
+    const app = mount(tmpDir, { jobs: [{ slug: 'j1' }], meshSelfId: 'm_a', capacities: { m_a: { nickname: 'Laptop', online: true } } });
+    const res = await request(app).get('/jobs').set(auth());
+    expect(res.status).toBe(200);
+    expect(res.body.jobs).toHaveLength(1);
+    expect(res.body.jobs[0].slug).toBe('j1');
+    expect(res.body.jobs[0].runsOnThisMachine).toBe(true);
+    expect(res.body).toHaveProperty('queue');
+    expect(res.body).not.toHaveProperty('pool');
+  });
+
+  it('scope=pool self-tags local jobs with this machine identity when wired', async () => {
+    const app = mount(tmpDir, { jobs: [{ slug: 'j1' }], meshSelfId: 'm_a', capacities: { m_a: { nickname: 'Laptop', online: true } } });
+    const res = await request(app).get('/jobs').query({ scope: 'pool' }).set(auth());
+    expect(res.status).toBe(200);
+    expect(res.body.jobs[0].machineId).toBe('m_a');
+    expect(res.body.jobs[0].machineNickname).toBe('Laptop');
+    // Pre-change code had no scope=pool branch — plain GET ignored scope and
+    // returned { jobs, queue } with NO machine tags / NO pool object.
+    expect(res.body.pool).toMatchObject({ enabled: true, selfMachineId: 'm_a', peersQueried: 0, peersOk: 0 });
+  });
+
+  it('scope=pool merges a REAL peer\'s jobs, each tagged with the peer identity', async () => {
+    const peerUrl = await listenPeer([{ slug: 'peer-job' }], 'm_b');
+    const app = mount(tmpDir, {
+      jobs: [{ slug: 'local-job' }],
+      meshSelfId: 'm_a', capacities: { m_a: { nickname: 'Laptop', online: true }, m_b: { nickname: 'Mac Mini', online: true } },
+      peers: [{ machineId: 'm_b', url: peerUrl }],
+    });
+    const res = await request(app).get('/jobs').query({ scope: 'pool' }).set(auth());
+    expect(res.status).toBe(200);
+    expect(res.body.pool).toMatchObject({ enabled: true, selfMachineId: 'm_a', peersQueried: 1, peersOk: 1, failed: [] });
+    const slugs = res.body.jobs.map((j: { slug: string }) => j.slug).sort();
+    expect(slugs).toEqual(['local-job', 'peer-job']);
+    const remote = res.body.jobs.find((j: { slug: string }) => j.slug === 'peer-job');
+    expect(remote.machineId).toBe('m_b');
+    expect(remote.machineNickname).toBe('Mac Mini');
+    expect(remote.remote).toBe(true);
+    // Both machines run their jobs locally → no divergence.
+    expect(res.body.pool.divergences).toEqual([]);
+  });
+
+  it('an OFFLINE peer is skipped to a pool.failed entry without waiting (never a 500)', async () => {
+    const app = mount(tmpDir, {
+      jobs: [{ slug: 'l' }], meshSelfId: 'm_a',
+      capacities: { m_a: { online: true }, m_off: { online: false } },
+      peers: [{ machineId: 'm_off', url: 'http://127.0.0.1:1' }],
+    });
+    const res = await request(app).get('/jobs').query({ scope: 'pool' }).set(auth());
+    expect(res.status).toBe(200);
+    expect(res.body.jobs).toHaveLength(1);
+    expect(res.body.pool.peersOk).toBe(0);
+    expect(res.body.pool.failed[0]).toMatchObject({ machineId: 'm_off', error: 'offline' });
+  });
+
+  it('an unreachable (unknown-state) peer degrades to failed, local jobs still answer', async () => {
+    const app = mount(tmpDir, {
+      jobs: [{ slug: 'l' }], meshSelfId: 'm_a', capacities: { m_a: { online: true } },
+      peers: [{ machineId: 'm_dead', url: 'http://127.0.0.1:1' }],
+    });
+    const res = await request(app).get('/jobs').query({ scope: 'pool' }).set(auth());
+    expect(res.status).toBe(200);
+    expect(res.body.jobs).toHaveLength(1);
+    expect(res.body.pool.peersOk).toBe(0);
+    expect(res.body.pool.failed[0].machineId).toBe('m_dead');
+  });
+
+  it('scope=pool with no peers answers local-only, enabled true', async () => {
+    const app = mount(tmpDir, { jobs: [{ slug: 'l' }], meshSelfId: 'm_a', capacities: { m_a: { online: true } } });
+    const res = await request(app).get('/jobs').query({ scope: 'pool' }).set(auth());
+    expect(res.status).toBe(200);
+    expect(res.body.jobs).toHaveLength(1);
+    expect(res.body.pool).toMatchObject({ enabled: true, peersQueried: 0, peersOk: 0 });
+  });
+
+  it('F8: flags an online peer that DECLARES jobs but runs 0 locally', async () => {
+    // Peer returns jobs, but each has runsOnThisMachine:false (declared, not run here).
+    const peerUrl = await listenPeer([{ slug: 'd1', local: false }, { slug: 'd2', local: false }], 'm_b');
+    const app = mount(tmpDir, {
+      jobs: [{ slug: 'l' }], meshSelfId: 'm_a',
+      capacities: { m_a: { nickname: 'Laptop', online: true }, m_b: { nickname: 'Mac Mini', online: true } },
+      peers: [{ machineId: 'm_b', url: peerUrl }],
+    });
+    const res = await request(app).get('/jobs').query({ scope: 'pool' }).set(auth());
+    expect(res.status).toBe(200);
+    const div = res.body.pool.divergences.find((d: { machineId: string }) => d.machineId === 'm_b');
+    expect(div).toMatchObject({ machineId: 'm_b', machineNickname: 'Mac Mini', declared: 2, running: 0 });
+    expect(div.reason).toContain('declares 2 jobs, running 0');
+  });
+
+  it('F8: a peer that returns ZERO jobs is NOT a divergence (no scheduler / no jobs is legitimate, not self-noise)', async () => {
+    const peerUrl = await listenPeer([], 'm_b');
+    const app = mount(tmpDir, {
+      jobs: [{ slug: 'l' }], meshSelfId: 'm_a',
+      capacities: { m_a: { nickname: 'Laptop', online: true }, m_b: { nickname: 'Mac Mini', online: true } },
+      peers: [{ machineId: 'm_b', url: peerUrl }],
+    });
+    const res = await request(app).get('/jobs').query({ scope: 'pool' }).set(auth());
+    expect(res.status).toBe(200);
+    // m_b declares 0 jobs — legitimate (scheduler-less / none configured), NOT flagged.
+    const div = res.body.pool.divergences.find((d: { machineId: string }) => d.machineId === 'm_b');
+    expect(div).toBeUndefined();
+  });
+
+  it('scheduler-less self still answers a coherent scope=pool view (local empty)', async () => {
+    const app = mount(tmpDir, { schedulerless: true, meshSelfId: 'm_a', capacities: { m_a: { online: true } } });
+    const res = await request(app).get('/jobs').query({ scope: 'pool' }).set(auth());
+    expect(res.status).toBe(200);
+    expect(res.body.jobs).toEqual([]);
+    expect(res.body.pool).toMatchObject({ enabled: true, selfMachineId: 'm_a' });
+  });
+});

--- a/tests/unit/PostUpdateMigrator-jobsPoolScope.test.ts
+++ b/tests/unit/PostUpdateMigrator-jobsPoolScope.test.ts
@@ -1,0 +1,113 @@
+/**
+ * Verifies PostUpdateMigrator adds the GET /jobs?scope=pool awareness bullet to
+ * an existing agent's CLAUDE.md Job Scheduler section on update (WS4.3,
+ * MULTI-MACHINE-SEAMLESSNESS-SPEC §WS4.3 — read-side). Migration Parity Standard:
+ * a deployed agent only learns about pool-wide jobs visibility through this path.
+ *
+ * Content-sniff on 'jobs?scope=pool' keeps it idempotent and route-qualified (a
+ * bare `scope=pool` sniff would falsely match other pool-scope routes).
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { PostUpdateMigrator } from '../../src/core/PostUpdateMigrator.js';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+
+type MigrationResult = { upgraded: string[]; skipped: string[]; errors: string[] };
+
+function newMigrator(projectDir: string): PostUpdateMigrator {
+  return new PostUpdateMigrator({
+    projectDir,
+    stateDir: path.join(projectDir, '.instar'),
+    port: 4042,
+    hasTelegram: false,
+    projectName: 'test',
+  });
+}
+
+function runClaudeMdMigration(migrator: PostUpdateMigrator): MigrationResult {
+  const result: MigrationResult = { upgraded: [], skipped: [], errors: [] };
+  (migrator as unknown as { migrateClaudeMd(r: MigrationResult): void }).migrateClaudeMd(result);
+  return result;
+}
+
+// A minimal CLAUDE.md carrying the Job Scheduler section as a deployed agent
+// (predating WS4.3) would have it.
+const LEGACY_JOBS_SECTION =
+  '# CLAUDE.md\n\n' +
+  '**Job Scheduler** — Run tasks on a schedule. Jobs in `.instar/jobs.json`.\n' +
+  '- View: `curl -H "Authorization: Bearer $AUTH" http://localhost:4042/jobs`\n' +
+  '- Trigger: `curl -X POST -H "Authorization: Bearer $AUTH" http://localhost:4042/jobs/SLUG/trigger`\n';
+
+describe('PostUpdateMigrator — Job Scheduler pool-scope bullet (WS4.3)', () => {
+  let projectDir: string;
+  let claudeMdPath: string;
+
+  beforeEach(() => {
+    projectDir = fs.mkdtempSync(path.join(os.tmpdir(), 'instar-jobs-pool-mig-'));
+    fs.mkdirSync(path.join(projectDir, '.instar'), { recursive: true });
+    claudeMdPath = path.join(projectDir, 'CLAUDE.md');
+  });
+
+  afterEach(() => {
+    SafeFsExecutor.safeRmSync(projectDir, {
+      recursive: true,
+      force: true,
+      operation: 'tests/unit/PostUpdateMigrator-jobsPoolScope.test.ts:cleanup',
+    });
+  });
+
+  it('adds the jobs?scope=pool bullet to an existing Job Scheduler section', () => {
+    fs.writeFileSync(claudeMdPath, LEGACY_JOBS_SECTION);
+
+    const result = runClaudeMdMigration(newMigrator(projectDir));
+
+    expect(result.errors).toEqual([]);
+    expect(result.upgraded.some((u) => u.includes('Job Scheduler pool-scope'))).toBe(true);
+
+    const after = fs.readFileSync(claudeMdPath, 'utf-8');
+    expect(after).toContain('jobs?scope=pool');
+    expect(after).toContain('pool.divergences');
+    // The bullet is inserted right after the /jobs View line, not at EOF.
+    const viewIdx = after.indexOf('- View: `curl');
+    const poolIdx = after.indexOf('jobs?scope=pool');
+    const triggerIdx = after.indexOf('- Trigger:');
+    expect(viewIdx).toBeLessThan(poolIdx);
+    expect(poolIdx).toBeLessThan(triggerIdx);
+  });
+
+  it('is idempotent — re-running does not add a duplicate bullet', () => {
+    fs.writeFileSync(claudeMdPath, LEGACY_JOBS_SECTION);
+
+    runClaudeMdMigration(newMigrator(projectDir));
+    const afterFirst = fs.readFileSync(claudeMdPath, 'utf-8');
+
+    const result2 = runClaudeMdMigration(newMigrator(projectDir));
+    const afterSecond = fs.readFileSync(claudeMdPath, 'utf-8');
+
+    expect(result2.upgraded.some((u) => u.includes('Job Scheduler pool-scope'))).toBe(false);
+    expect(afterSecond).toBe(afterFirst);
+    expect((afterSecond.match(/jobs\?scope=pool/g) ?? []).length).toBe(1);
+  });
+
+  it('does NOT patch a CLAUDE.md with no Job Scheduler section', () => {
+    fs.writeFileSync(claudeMdPath, '# CLAUDE.md\n\nNothing job-related here.\n');
+
+    runClaudeMdMigration(newMigrator(projectDir));
+    const after = fs.readFileSync(claudeMdPath, 'utf-8');
+
+    expect(after).not.toContain('jobs?scope=pool');
+  });
+});
+
+describe('Job Scheduler pool-scope is in the agent template (fresh installs get it)', () => {
+  it('the template emits the jobs?scope=pool bullet', () => {
+    const templateSource = fs.readFileSync(
+      path.join(process.cwd(), 'src/scaffold/templates.ts'),
+      'utf-8',
+    );
+    expect(templateSource).toContain('jobs?scope=pool');
+    expect(templateSource).toContain('pool.divergences');
+  });
+});

--- a/upgrades/next/multi-machine-seamlessness-ws43-jobs-pool-read.md
+++ b/upgrades/next/multi-machine-seamlessness-ws43-jobs-pool-read.md
@@ -1,0 +1,43 @@
+# Multi-machine seamlessness — jobs, pooled (WS4.3 read-side)
+
+## What Changed
+
+- **`GET /jobs?scope=pool`** merges every online machine's scheduled jobs into one
+  view, each tagged with the machine that runs it — mirroring the proven
+  `sessions?scope=pool` / `attention?scope=pool` family: per-peer 5s timeout with a
+  `pool.failed[]` marker on a dark/offline peer (never a 500), a 3s short-TTL cache,
+  non-recursive peer calls. Plain `GET /jobs` is byte-for-byte unchanged.
+- **F8 placement-divergence detector** (observe-only, `pool.divergences[]`): flags a
+  machine that DECLARES jobs (N>0) but RUNS none of them locally — "config says jobs
+  here, this machine isn't running them." Derived honestly from each machine's own
+  `/jobs` reply; no fabricated counts; never gates. A machine with zero jobs is NOT
+  flagged (legitimate scheduler-less/dispatcher machine).
+- CLAUDE.md template + idempotent PostUpdateMigrator bullet (Agent Awareness +
+  Migration Parity).
+
+This is the READ half of WS4.3. The role-guard-at-spawn (refuse state-writing jobs on
+a read-only standby → re-route or attention) and the journal-lease claim cutover are
+SEPARATE follow-up slices. <!-- tracked: CMT-1416 -->
+
+## Evidence
+
+- `tests/integration/jobs-pool-scope.test.ts` (9, new): plain GET self-tags identity;
+  scope=pool merges a REAL peer server's jobs; offline peer → failed without waiting;
+  unreachable peer → failed, local still answers; no-peers → local-only; divergence
+  flags declares-N-runs-0; a zero-jobs peer is NOT flagged; scheduler-less shape.
+- `tests/unit/PostUpdateMigrator-jobsPoolScope.test.ts` (4, new): migration + template
+  parity, idempotent. `tsc --noEmit` clean. Existing jobs-endpoints-auth (15) +
+  guardian-jobs (11) + attention-pool-scope (7) all still green.
+
+## What to Tell Your User
+
+On a multi-machine setup, "what jobs are running where?" now answers across all your
+machines at once — each scheduled job tagged with the machine running it, a machine
+that's offline noted rather than dropped, and a heads-up if a machine is configured to
+run jobs but isn't actually running any.
+
+## Summary of New Capabilities
+
+- One pooled view of scheduled jobs across the fleet (`GET /jobs?scope=pool`),
+  machine-tagged, dark peers surfaced as `failed`, plus an observe-only placement-
+  divergence signal.

--- a/upgrades/side-effects/multi-machine-seamlessness-ws43-jobs-pool-read.md
+++ b/upgrades/side-effects/multi-machine-seamlessness-ws43-jobs-pool-read.md
@@ -1,0 +1,88 @@
+# Side-Effects Review — WS4.3 read-side: GET /jobs?scope=pool + divergence detector
+
+**Version / slug:** `multi-machine-seamlessness-ws43-jobs-pool-read`
+**Date:** `2026-06-12`
+**Author:** `Instar Agent (echo)`
+**Second-pass reviewer:** `workflow adversarial reviewer (CONCUR — 1 LOW fixed)`
+
+## Summary of the change
+
+The read-side of WS4.3 (MULTI-MACHINE-SEAMLESSNESS-SPEC §WS4.3): `GET /jobs?scope=pool`
+merges every online peer's jobs into one view (which machine runs each job),
+mirroring the proven `sessions?scope=pool` / WS4.1 `attention?scope=pool` family —
+per-peer 5s timeout, `pool.failed[]` markers (never a 500), offline-peer skip, 3s
+short-TTL cache, machine tagging. Plus an observe-only F8 placement-divergence
+detector. Files: `src/server/routes.ts` (route + `jobsPoolMerge` + `detectJobDivergences`),
+`src/scaffold/templates.ts` + `src/core/PostUpdateMigrator.ts` (Agent Awareness +
+Migration Parity). The role-guard-at-spawn and journal-lease cutover are SEPARATE
+follow-up slices (not in this PR). <!-- tracked: CMT-1416 -->
+
+## Decision-point inventory
+
+- `GET /jobs?scope=pool` merge — **add** — read-only aggregation; never mutates a
+  job, never gates; tolerant fan-out.
+- `detectJobDivergences` — **add** — observe-only signal in `pool.divergences[]`;
+  flags ONLY `declared>0 && running===0` (a machine that should run jobs but isn't).
+
+---
+
+## 1. Over-block
+No block/allow surface — read-only. The divergence detector after the LOW fix flags
+ONLY the real case (declares N>0, runs 0). A machine declaring 0 jobs is NOT flagged
+(was self-noise — fixed: a scheduler-less/dispatcher-only machine legitimately has none).
+
+## 2. Under-block
+Capacity carries no declared-job count, so divergence is derived from each machine's
+own `/jobs` reply (declared = jobs returned, running = `runsOnThisMachine===true`
+count). A machine that is DOWN (no reply) is in `pool.failed[]`, not `divergences` —
+so a fully-dark machine's jobs aren't flagged as "running 0" (correct; it's a
+reachability failure, surfaced separately). No fabricated counts.
+
+## 3. Level-of-abstraction fit
+Right layer — mirrors the sessions/attention pool-scope route code exactly (same
+fan-out/timeout/failed/cache/tag shape); the divergence helper is a pure function
+over the merged replies.
+
+## 4. Signal vs authority compliance
+Compliant — pure read + an observe-only signal. Gates nothing.
+
+## 5. Interactions
+- Plain `GET /jobs` is byte-for-byte unchanged (`{jobs,queue}`; no `pool` object, no
+  machine tags) — only `?scope=pool` adds them.
+- The cache key is fixed (`'jobs'`) and read/written only inside `jobsPoolMerge`;
+  there are no status/scope variants to cross-contaminate (stronger isolation than
+  attention's status-keyed cache).
+- Peers are called WITHOUT `scope` → no recursive fan-out storm.
+
+## 6. External surfaces
+- New query mode on an existing route; old callers (no `?scope=pool`) unaffected.
+- Calls each peer's `GET /jobs` with the agent bearer (same pattern as
+  sessions/attention pool scope). An old peer returns its local jobs → merges fine.
+
+## Framework generality
+No framework-launch abstraction touched (this is a read/merge route only; no change
+to `frameworkSessionLaunch.ts`). The job model is framework-agnostic; the merge tags
+machines, not frameworks. N/A beyond that.
+
+## 7. Multi-machine posture (Cross-Machine Coherence)
+**proxied-on-read** — fans out to peers per request (cached 3s), each job tagged with
+its owning machine; consults the pool registry's online flag to skip dark peers
+cheaply. No replication, no durable cross-machine state in this slice. Phase-C clean:
+per-online-peer fan-out, O(jobs) divergence, no 2-peer assumption.
+
+## 8. Rollback cost
+Trivial: additive scope branch; reverting restores today's local-only `GET /jobs`.
+No durable state; the CLAUDE.md migrator bullet is idempotent (content-sniffed).
+
+---
+
+## Second-pass review
+
+Workflow adversarial reviewer: **CONCUR** (tscClean, testsPass; all 7 audit points
+verified incl. tolerant fan-out, back-compat, cache isolation, observe-only +
+no-fabricated-count divergence, non-recursive peers, awareness+migration parity,
+tests proven failing pre-change). One **LOW**: a scheduler-less/no-jobs machine
+self-flagged a "declares 0 jobs while online" divergence (self-noise). **FIXED**:
+the detector now flags ONLY `declared>0 && running===0`; the 0-jobs case is dropped
+(legitimate, not a divergence), and its test now asserts NO divergence for a
+zero-jobs peer.


### PR DESCRIPTION
## ELI16

On a multi-machine setup, "what jobs are running where?" used to answer only for the machine you asked. This adds `GET /jobs?scope=pool`, merging every online machine's scheduled jobs into one view, each tagged with the machine that runs it — mirroring the proven `sessions?scope=pool` / `attention?scope=pool` family (per-peer 5s timeout, `pool.failed[]` on a dark/offline peer instead of a 500, 3s cache, non-recursive peer calls). Plain `GET /jobs` is byte-for-byte unchanged. It also adds an observe-only F8 placement-divergence detector: a heads-up when a machine is configured to run jobs (declares N>0) but is running none of them locally. This is the READ half of WS4.3; the role-guard-at-spawn and journal-lease cutover are separate follow-up slices.

## What's in it

- `GET /jobs?scope=pool` merge (`jobsPoolMerge`) in `routes.ts` + `detectJobDivergences`. Tolerant fan-out, offline-skip, short-TTL cache, machine tagging. Response `{ jobs, count, pool:{enabled, selfMachineId, peersQueried, peersOk, failed[], divergences[]} }`.
- Divergence is honest-derived from each machine's own `/jobs` reply (declared = jobs returned, running = `runsOnThisMachine===true`); no fabricated counts; never gates. A zero-jobs machine is NOT flagged (legitimate scheduler-less/dispatcher machine — the LOW the review caught, fixed).
- CLAUDE.md template + idempotent PostUpdateMigrator bullet (Agent Awareness + Migration Parity).

## Review discipline

Built by a fresh-context implementer + adversarial reviewer (ultracode workflow). Reviewer **CONCUR** (tsc clean, 13 tests pass, all 7 audit points verified by reading code: tolerant fan-out, back-compat plain GET, cache-key isolation, observe-only + no-fabricated-count divergence, non-recursive peers, awareness+migration parity, tests proven failing pre-change). One **LOW** (a scheduler-less machine self-flagged a "declares 0 jobs" divergence — self-noise) **fixed**: the detector now flags only `declared>0 && running===0`; its test now asserts a zero-jobs peer is NOT flagged.

## Evidence

- `tests/integration/jobs-pool-scope.test.ts` (9, REAL second peer server) + `tests/unit/PostUpdateMigrator-jobsPoolScope.test.ts` (4). `tsc --noEmit` clean; existing jobs-auth (15), guardian-jobs (11), attention-pool-scope (7) all still green.
- Multi-machine posture (§7): proxied-on-read; no replication in this slice; Phase-C clean (per-online-peer fan-out, O(jobs) divergence, no 2-peer assumption).
- Spec: MULTI-MACHINE-SEAMLESSNESS-SPEC §WS4.3 (read-side). Follow-ups (role-guard, journal-lease) tracked CMT-1416.

🤖 Generated with [Claude Code](https://claude.com/claude-code)