### PR TITLE
fix(reaper): stop the stale-commitment kill→revive loop

### DIFF
--- a/.instar/instar-dev-decisions/2026-06-13T18-12-13-705Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-06-13T18-12-13-705Z-unknown.json
@@ -1,0 +1,13 @@
+{
+  "ts": "2026-06-13T18:12:13.705Z",
+  "slug": "unknown",
+  "suggestedTier": 1,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 19,
+  "causalAutopsy": null,
+  "verdict": "pass"
+}

--- a/src/core/ReapGuard.ts
+++ b/src/core/ReapGuard.ts
@@ -221,7 +221,24 @@ export class ReapGuard {
         () => this.deps.recentUserMessage(boundTopicId, this.opts.recentUserWindowMs),
         'recent-user-message',
       );
-      probe(() => this.deps.activeCommitmentForTopic(boundTopicId), 'open-commitment');
+      // Open commitment — gated by the SAME staleness horizon evaluate()'s KEEP
+      // check uses (guard J above). A commitment counts as in-flight-work evidence
+      // ONLY while the topic has had a user message within staleCommitmentWindowMs;
+      // past that, evaluate() treats the commitment as abandoned and lets the
+      // session die — so workEvidence() must NOT re-assert it as work. Without this
+      // gate the two methods disagree on the same commitment: an idle session is
+      // killed (evaluate: stale ⇒ reap) then immediately revived (workEvidence:
+      // open-commitment ⇒ resume-eligible), forever. They MUST agree on what an
+      // open commitment means. (2026-06-13: 13 idle sessions across 6 topics were
+      // age-killed + revived in a loop, every one tagged solely [open-commitment]
+      // on a commitment the KEEP-guard had already judged stale.)
+      probe(
+        () =>
+          this.opts.protectOpenCommitments &&
+          this.deps.activeCommitmentForTopic(boundTopicId) &&
+          this.deps.recentUserMessage(boundTopicId, this.opts.staleCommitmentWindowMs),
+        'open-commitment',
+      );
     }
     probe(() => this.deps.activeSubagentCount(session.claudeSessionId) > 0, 'active-subagent');
     probe(() => this.deps.buildOrAutonomousActive(topicId), 'structural-long-work');

--- a/tests/unit/work-evidence.test.ts
+++ b/tests/unit/work-evidence.test.ts
@@ -193,6 +193,62 @@ describe('ReapGuard.workEvidence — observe-only collection (R2.1)', () => {
   });
 });
 
+// ── open-commitment staleness gate: workEvidence MUST agree with evaluate ──
+// Regression for the 2026-06-13 kill→revive loop. evaluate() (the KEEP guard)
+// only protects a session on an open commitment while a user message is within
+// staleCommitmentWindowMs; past that the commitment is "abandoned" and the
+// session is reaped. Before this fix workEvidence() emitted 'open-commitment'
+// for ANY active commitment (no staleness gate) — so an idle session was killed
+// (stale ⇒ reap) AND tagged resume-eligible (open-commitment ⇒ revive), looping
+// forever. Both methods must now read a STALE commitment the same way: not a
+// keep, not work evidence.
+describe('ReapGuard — open-commitment evidence honors the staleness gate (2026-06-13 loop fix)', () => {
+  // A commitment that is open but whose topic has had NO user message within ANY
+  // window — i.e. exactly the state of the 13 looped sessions.
+  const staleCommitmentDeps = (over: Partial<ReapGuardDeps> = {}): ReapGuardDeps =>
+    guardDeps({
+      topicBinding: () => 18423,
+      activeCommitmentForTopic: () => true,
+      recentUserMessage: () => false, // no message in any window ⇒ stale
+      ...over,
+    });
+
+  it('does NOT emit open-commitment evidence for a STALE commitment', () => {
+    const guard = new ReapGuard(staleCommitmentDeps(), { minAgeMs: 0 });
+    const evidence = guard.workEvidence(fakeSession());
+    expect(evidence).not.toContain('open-commitment');
+    expect(isMidWork(evidence)).toBe(false); // ⇒ not resume-eligible ⇒ no revive loop
+  });
+
+  it('STILL emits open-commitment evidence for a FRESH commitment (message within stale window)', () => {
+    const guard = new ReapGuard(
+      staleCommitmentDeps({
+        // active within the 8h stale window but not the 30min recent-user window
+        recentUserMessage: (_t, withinMs) => withinMs > 60 * 60_000,
+      }),
+      { minAgeMs: 0 },
+    );
+    expect(guard.workEvidence(fakeSession())).toContain('open-commitment');
+  });
+
+  it('consistency: evaluate() and workEvidence() agree on the same stale commitment', () => {
+    const guard = new ReapGuard(staleCommitmentDeps(), { minAgeMs: 0 });
+    const session = fakeSession();
+    // evaluate(): stale commitment does NOT keep (the session is reapable)…
+    expect(guard.blockedReason(session)).toBeNull();
+    // …and workEvidence() agrees it is not in-flight work (so it is not revived).
+    expect(guard.workEvidence(session)).not.toContain('open-commitment');
+  });
+
+  it('respects protectOpenCommitments:false — no open-commitment evidence even if fresh', () => {
+    const guard = new ReapGuard(
+      staleCommitmentDeps({ recentUserMessage: () => true }),
+      { minAgeMs: 0, protectOpenCommitments: false },
+    );
+    expect(guard.workEvidence(fakeSession())).not.toContain('open-commitment');
+  });
+});
+
 // ── terminateSession threading (the chokepoint) ───────────────────────
 
 describe('terminateSession — evidence threading (R2.1)', () => {

--- a/upgrades/eli16/reapguard-stale-commitment-revival-loop.md
+++ b/upgrades/eli16/reapguard-stale-commitment-revival-loop.md
@@ -1,0 +1,28 @@
+# Stale-commitment kill→revive loop — Plain-English Overview
+
+> The one-line version: a session that finished its work but had an old, untouched promise still on the books was being killed (correctly) and then revived (incorrectly) over and over, forever. This stops the revival half from firing on a stale promise.
+
+## The problem in one breath
+
+Today 13 idle sessions across 6 different topics were age-killed and then brought back to life, again and again, in a loop. Every single one was idle — its turn was finished, nothing was running — and the *only* reason the system revived it was that a commitment ("I'll keep you posted") was still registered on that topic. Many of those commitments were long-since done; they just were never marked delivered.
+
+## What already exists
+
+The reaper has one shared "is it safe to end this session?" guard with two halves:
+
+- **The kill half** (`evaluate()`) already knows a commitment goes *stale*. If the topic has had no user message for 8 hours, the commitment is treated as abandoned and no longer keeps the session alive — so an idle session with only a stale promise is correctly reaped. (This staleness rule was added back on 2026-06-06.)
+- **The revive half** (`workEvidence()`) decides whether a killed session had real interrupted *work* worth bringing back. It tags the session with evidence like "a build was running" or "a sub-agent was live" — and, until now, "an open commitment exists."
+
+## What this changes
+
+One line. The revive half now applies the **same 8-hour staleness gate** the kill half already uses. So an open commitment only counts as "interrupted work worth reviving" while the topic has had a user message within 8 hours.
+
+The result: the two halves finally agree. A stale commitment neither keeps a session alive *nor* revives it. A *fresh* commitment keeps the session alive in the first place, so it never needs reviving. The loop's engine — kill (stale) then revive (commitment) — is gone.
+
+## Why this is safe
+
+It can only ever revive **less**, never more. A session that was genuinely doing work when it died still carries its real work signals (a live build, an active sub-agent, a pending message, a running process) — those are untouched, and a busy session is never age-killed in the first place. The only revivals removed are exactly the harmful ones: an idle session resurrected to "finish" a promise that was already done. Promises still get their own follow-through from the commitment system (the beacon and the overdue-commitment job) — that's the right owner for a promise, not a respawned session burning a fresh turn each time.
+
+## What you'll notice
+
+Fewer "🪦 your session was shut down — a restart is queued" messages on topics where nothing was actually unfinished. The looping topics (this one included) settle down. Nothing else changes.

--- a/upgrades/next/reapguard-stale-commitment-revival-loop.md
+++ b/upgrades/next/reapguard-stale-commitment-revival-loop.md
@@ -1,0 +1,22 @@
+# Fix: stale-commitment kill→revive loop
+
+## What Changed
+
+The session reaper's shared guard (`ReapGuard`) had two halves that disagreed about a *stale* open commitment. The KILL decision (`evaluate()`) already treats a commitment as abandoned after 8h of topic silence and lets the idle session be reaped. But the RESUME-eligibility decision (`workEvidence()`) counted **any** open commitment as proof of interrupted work — with no staleness gate. So an idle session was killed (commitment stale ⇒ reap) and immediately revived (commitment exists ⇒ resume-eligible), in an endless loop.
+
+This patch applies the **same 8h staleness gate** to the resume-eligibility probe that the kill decision already uses, so the two halves agree: a stale commitment neither keeps a session alive nor revives it, and a fresh one keeps the session alive so it never needs reviving. Strictly safer — it can only ever revive *less*, never more. Genuine interrupted work (a live build, an active sub-agent, a pending injection, a running process) is untouched.
+
+## Evidence
+
+- Live `logs/reap-log.jsonl` (2026-06-13): **13** age-limit reaps with `midWork=true`, every one carrying solely `workEvidence=[open-commitment]`, across 6 topics — and corresponding repeated `reason=age-limit` respawn entries in the resume queue (several doubled per topic). The loop, captured.
+- Root cause confirmed in source: `ReapGuard.evaluate()` gates the open-commitment KEEP on `recentUserMessage(topicId, staleCommitmentWindowMs)`; `ReapGuard.workEvidence()` did not.
+- New regression tests in `tests/unit/work-evidence.test.ts`: a stale commitment emits no `open-commitment` evidence (and `isMidWork`→false); a fresh one still does; an explicit `evaluate()`/`workEvidence()` consistency assertion; and the `protectOpenCommitments:false` boundary. All 22 work-evidence + 19 reap-guard unit tests green; 164 related reap/resume tests green; `tsc --noEmit` clean.
+- Independent second-pass review (lifecycle change): **Concur** — confirmed the age-limit path uses the patched fallback, no legitimate revival is lost, downstream ResumeQueue / live-enqueue / boot-reconciliation re-enqueue (all `midWork`/`evidenceEligible`-gated) all behave correctly.
+
+## What to Tell Your User
+
+Sessions that finished their work but still had an old, untouched promise on the books were being killed and revived over and over. That loop is fixed. You'll see fewer "🪦 your session was shut down — a restart is queued" notices on topics where nothing was actually unfinished. Promises still get followed up on by the commitment system — that part is unchanged.
+
+## Summary of New Capabilities
+
+No new capability — this is a bugfix. It removes a spurious session kill→revive loop driven by stale (long-untouched) open commitments by aligning the reaper guard's resume-eligibility decision with its existing kill-decision staleness rule.

--- a/upgrades/side-effects/reapguard-stale-commitment-revival-loop.md
+++ b/upgrades/side-effects/reapguard-stale-commitment-revival-loop.md
@@ -1,0 +1,82 @@
+# Side-Effects Review — ReapGuard stale-commitment revival loop
+
+**Version / slug:** `reapguard-stale-commitment-revival-loop`
+**Date:** `2026-06-13`
+**Author:** `echo`
+**Second-pass reviewer:** `general-purpose reviewer subagent (lifecycle change — required)`
+
+## Summary of the change
+
+`ReapGuard` (the shared, stateless "is it safe to reap this session?" guard) has two methods that read an open commitment differently. `evaluate()` (the KILL decision) only keeps a session alive on an open commitment while the topic has had a user message within `staleCommitmentWindowMs` (default 8h); past that the commitment is "abandoned" and the idle session is reaped (staleness gate added 2026-06-06). `workEvidence()` (the RESUME-eligibility decision) emitted `open-commitment` evidence for **any** active commitment, with **no** staleness gate. So the same guard killed an idle session (commitment stale ⇒ reap) and immediately tagged it resume-eligible (commitment exists ⇒ revive), looping forever.
+
+Evidence (live `logs/reap-log.jsonl`, 2026-06-13): 13 age-limit reaps with `midWork=true`, **all** carrying solely `workEvidence=[open-commitment]`, across 6 topics (multi-channel-support, Resource Limitation Mitigation, instar evolution, Subscription & Auth, instar-exo, Topic UX). The resume queue showed repeated `reason=age-limit` respawn entries, several doubled per topic.
+
+The fix: one line in `ReapGuard.workEvidence()` — the `open-commitment` probe now applies the identical predicate `evaluate()` uses (`protectOpenCommitments && activeCommitmentForTopic && recentUserMessage(staleCommitmentWindowMs)`). Files touched: `src/core/ReapGuard.ts` (the probe + a comment), `tests/unit/work-evidence.test.ts` (a new regression `describe` block).
+
+## Decision-point inventory
+
+- `ReapGuard.workEvidence()` open-commitment probe (`src/core/ReapGuard.ts`) — **modify** — narrows when `open-commitment` is emitted as work evidence to match the KEEP guard's staleness horizon. This is a SIGNAL producer (work evidence consumed by the resume queue / reap-notify), not a blocking authority.
+
+---
+
+## 1. Over-block
+
+**What legitimate inputs does this change reject that it shouldn't?**
+
+This change narrows a SIGNAL (work evidence), not a block/allow gate. The "over-block" analogue is: does it now suppress `open-commitment` evidence for a session that genuinely had interrupted work? No. To be age-killed at all, a session must be idle-at-prompt with no live processes (the age-gate's `ageGateTrulyIdle` check) — a genuinely-busy session is deferred, never killed. And by the time `workEvidence()` runs as the fallback, `blockedReason()` has already returned null, meaning the commitment was already judged stale (no user message in 8h). A session with real interrupted work carries OTHER evidence (`structural-long-work`, `active-subagent`, `pending-injection`, `active-process`, `main-process-active`) which are untouched. A commitment touched within 8h still emits `open-commitment` (covered by the "FRESH commitment" test). No legitimate revival is lost.
+
+## 2. Under-block
+
+**What failure modes does this still miss?**
+
+The change does not, by itself, drain the 279 already-`pending` commitments that fuel the loop — but it makes them HARMLESS for revival (a stale one no longer revives). A separate, careful runtime hygiene pass to mark genuinely-delivered commitments is tracked: <!-- tracked: topic-18423 --> (operator-visible follow-up on the live machine; not a code deferral). It also does not change the age-limit reaper killing idle sessions — that is correct behavior and out of this fix's scope by design (the loop was the *revival* half, not the kill).
+
+## 3. Level-of-abstraction fit
+
+**Is this at the right layer?**
+
+Yes. `ReapGuard` is the single shared guard both the reaper and the terminate authority consult; aligning its two methods at that one place fixes every killer that uses the `workEvidence()` fallback (the age-limit path does). Putting the staleness logic anywhere downstream (resume queue, reap-notify) would patch one consumer and leave the evidence itself wrong for the others. The correct owner of *promise* follow-through (the commitment beacon / overdue-commitment job) is a different subsystem and is intentionally left to do its job — this fix stops the resume queue from double-covering it on a stale signal.
+
+## 4. Signal vs authority compliance
+
+**Does this hold blocking authority with brittle logic, or produce a signal that feeds a smart gate?** (ref: `docs/signal-vs-authority.md`)
+
+Compliant. `workEvidence()` is a pure SIGNAL producer — observe-only evidence collection. It holds no blocking authority (the KILL authority is `evaluate()`/`blockedReason()`, unchanged). This change makes the existing signal MORE accurate by removing a false-positive; it adds no new brittle check and no new authority.
+
+## 5. Interactions
+
+**Does it shadow another check, get shadowed, double-fire, race with cleanup?**
+
+The two `ReapGuard` methods now use one identical predicate, removing the contradiction that WAS the bug. No race: `workEvidence()` is only collected after `blockedReason()` returned null (a non-null keep returns early at terminateSession before evidence is gathered), so the two never disagree on the same live state. Downstream consumers behave correctly: dropping the sole `open-commitment` signal flips `isMidWork`→false and `evidenceEligible`→false, which correctly prevents (a) `ResumeQueue` enqueue (gated on `evidenceEligible`), (b) the server's live enqueue (gated on `midWork===true`), and (c) boot-reconciliation re-enqueue from the reap-log (also `midWork===true`). The reaper's own idle path supplies authoritative `workEvidence:[]` and is unaffected (it was never the loop's source).
+
+## 6. External surfaces
+
+**Does it change anything visible to other agents/users/systems?**
+
+User-visible: fewer "your session was shut down — a restart is queued" notices on topics with no genuinely-unfinished work; the looping topics settle. Reap-log entries for these reaps now record `midWork:false` (honest — they were idle reaps, not interrupted work). No agent-to-agent or cross-system surface. No new timing/runtime dependency — it reuses the same in-memory `recentUserMessage` dep `evaluate()` already calls.
+
+## 7. Multi-machine posture (Cross-Machine Coherence)
+
+**Machine-local BY DESIGN.** `ReapGuard` evaluates the LOCAL machine's sessions against that machine's local topic-state deps (topic binding, recent-message, active-commitment). Session reaping is inherently a per-machine operation — a machine reaps its own sessions — so there is no replication path to add and none is wanted. The commitment registry that backs `activeCommitmentForTopic` follows its own (separate) cross-machine story; this change reads it identically to how `evaluate()` already does, so it introduces no new multi-machine assumption. No user-facing notice voice, durable-state-on-transfer, or generated-URL concern applies.
+
+## 8. Rollback cost
+
+Cheap. Pure code change, no migration, no persisted-state shape change. Back-out = revert the one-line probe to its prior form (`upgrades/eli16/...` + git revert) and ship a patch. The reap-log entries already written are inert historical records. Config knob `staleCommitmentWindowMs: Infinity` independently restores the always-protect behavior for BOTH methods consistently (now that they share the predicate) without a code change, if a site wants the old revival behavior back immediately.
+
+---
+
+## Second-pass review
+
+**Reviewer:** independent general-purpose reviewer subagent (required: change touches session lifecycle kill/recovery + a "guard").
+
+**VERDICT: Concur with the review.**
+
+The reviewer independently audited `ReapGuard.evaluate()`/`workEvidence()`, the `SessionManager.terminateSession` evidence path (lines 825–925), and the new tests, pressure-testing all five risk dimensions:
+
+- **A (over-block):** could not construct a genuinely-interrupted session left un-revived; busy sessions never reach the age-kill, and real work carries other evidence.
+- **B (race/consistency):** the two methods now use the identical predicate triple; the benign `recent-user-message`/`open-commitment` independence in `workEvidence()` cannot resurrect the loop (for a stale session both windows are false; workEvidence is recomputed from the same live deps regardless of WHY evaluate cleared).
+- **C (killer-supplied evidence):** grepped every killer supplying explicit `opts.workEvidence` — only the idle-reaper (authoritative `[]`), the operator force-resume (`['active-build-or-autonomous-run']`), and tests. The age-limit path supplies none → uses the patched fallback. The fix reaches the path that actually fired.
+- **D (config edges):** `protectOpenCommitments:false` and `staleCommitmentWindowMs:Infinity` now behave consistently across both methods.
+- **E (downstream):** correctly prevents ResumeQueue enqueue, server live enqueue, AND boot-reconciliation re-enqueue (all `midWork===true`/`evidenceEligible` gated); ReapNotifier reports the idle reap honestly.
+
+No concern raised; no design iteration required.


### PR DESCRIPTION
## ELI16 — the reaper was killing idle sessions then reviving them in a loop, just because an old promise was still on the books

When a session finishes its turn and goes idle, the reaper is allowed to clean it up. A guard decides two separate things: (1) should we KILL this idle session? and (2) if a session got killed, did it have real interrupted WORK worth reviving? The bug: those two halves disagreed about an old, untouched "I'll keep you posted"-type commitment. The kill half already knew a commitment goes stale after 8 hours of silence and stops protecting the session — so the idle session was correctly reaped. But the revive half saw *any* open commitment and said "this had work in flight, bring it back." So the same guard killed the session (stale) and instantly revived it (open commitment), over and over — 13 times across 6 topics today. This change makes the revive half use the exact same 8-hour staleness check the kill half already uses, so the two finally agree. A stale commitment now neither keeps a session alive nor revives it; a fresh one keeps it alive so it never needs reviving. It can only ever revive *less*, never more — promises themselves still get followed up by the commitment system, their proper owner.

## What

`ReapGuard` had two methods that disagreed about a **stale** open commitment:

- **`evaluate()`** (the KILL decision) treats a commitment as abandoned after `staleCommitmentWindowMs` (8h) of topic silence → lets the idle session be reaped. (Staleness gate added 2026-06-06.)
- **`workEvidence()`** (the RESUME-eligibility decision) emitted `open-commitment` for **any** active commitment, with **no** staleness gate → tagged `midWork` → strong evidence → resume-eligible → revived.

So the same guard killed an idle session (stale ⇒ reap) and immediately revived it (open-commitment ⇒ resume-eligible) — forever.

## Evidence

Live `logs/reap-log.jsonl` (2026-06-13): **13** age-limit reaps with `midWork=true`, **every one** carrying solely `workEvidence=[open-commitment]`, across 6 topics — with repeated `reason=age-limit` respawn entries in the resume queue (several doubled per topic).

## Fix

One line: `workEvidence()`'s `open-commitment` probe now applies the identical predicate `evaluate()` uses — `protectOpenCommitments && activeCommitmentForTopic && recentUserMessage(staleCommitmentWindowMs)`. **Strictly safer — it can only ever revive *less*.**

## Tests

New `describe` block in `tests/unit/work-evidence.test.ts`: stale ⇒ no `open-commitment` evidence (+ `isMidWork`→false); fresh ⇒ still emitted; explicit `evaluate()`/`workEvidence()` consistency assertion; `protectOpenCommitments:false` boundary. 22 work-evidence + 19 reap-guard + 164 related reap/resume unit tests green; `tsc --noEmit` clean.

## Process

Tier 1 (instar-dev). ELI16 + side-effects artifacts staged. Independent second-pass review (required — lifecycle): **Concur** — confirmed the age-limit path uses the patched fallback, no legitimate revival lost, and downstream ResumeQueue / live-enqueue / boot-reconciliation re-enqueue (all `midWork`/`evidenceEligible`-gated) all behave correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
