### PR TITLE
feat(subscription-pool): live-credential-repointing Steps 5a+5b — swap foundation + CredentialSwapExecutor (dark)

### DIFF
--- a/.instar/instar-dev-decisions/2026-06-13T18-29-50-862Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-06-13T18-29-50-862Z-unknown.json
@@ -1,0 +1,15 @@
+{
+  "ts": "2026-06-13T18:29:50.862Z",
+  "slug": "unknown",
+  "suggestedTier": 2,
+  "declaredTier": 2,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "new capability: new exported class / subsystem added"
+  ],
+  "belowFloor": false,
+  "files": 3,
+  "loc": 356,
+  "causalAutopsy": null,
+  "verdict": "pass"
+}

--- a/.instar/instar-dev-decisions/2026-06-13T18-54-35-573Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-06-13T18-54-35-573Z-unknown.json
@@ -1,0 +1,15 @@
+{
+  "ts": "2026-06-13T18:54:35.573Z",
+  "slug": "unknown",
+  "suggestedTier": 2,
+  "declaredTier": 2,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "new capability: new exported class / subsystem added"
+  ],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 423,
+  "causalAutopsy": null,
+  "verdict": "pass"
+}

--- a/.instar/instar-dev-decisions/2026-06-13T19-11-08-095Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-06-13T19-11-08-095Z-unknown.json
@@ -1,0 +1,13 @@
+{
+  "ts": "2026-06-13T19:11:08.095Z",
+  "slug": "unknown",
+  "suggestedTier": 2,
+  "declaredTier": 2,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 133,
+  "causalAutopsy": null,
+  "verdict": "pass"
+}

--- a/docs/specs/live-credential-repointing-rebalancer.build-plan.md
+++ b/docs/specs/live-credential-repointing-rebalancer.build-plan.md
@@ -234,17 +234,29 @@ drain (CMT-1335 full) is Increment B.
   flagged, real tree clean, closed allowlist). tsc clean, full `npm run lint` clean, 208/208 unit green.
 - Second-pass review: CONCUR (independent reviewer subagent) — see the side-effects artifact.
 
+### 2026-06-13 — Step 5a (swap I/O + journal foundation) — BUILT + GREEN
+- `src/core/CredentialKeychainIO.ts`: async 10s-bounded `security` read/write/delete (the sync store can wedge
+  the loop); blob written via `security -i` stdin/hex (never in argv); staging namespace
+  `instar-credential-swap-staging-<swapId>` + `assertStagingDisjoint` pinning the §2.3.2 disjoint invariant.
+- `src/core/CredentialSwapJournal.ts`: the durable in-flight swap record (swapId, both slots, both pre-swap
+  account ids, stagingRef) — DISTINCT from the ledger journal. Phases begin→exchanged→committed→done(+aborted);
+  a non-terminal phase keeps staging alive (§2.3.2 sweep predicate). Atomic tmp+rename; rotated jsonl history.
+- Allowlisted CredentialKeychainIO.ts in lint-no-unfunneled-credential-write.js (primitive owner) + updated the
+  closed-allowlist self-test. Tests: credential-swap-journal (8) + credential-keychain-io (7). tsc + lint clean.
+- PRIMITIVES ONLY: no swap logic, no consumer, no live write path → second-pass not required (4a precedent);
+  the executor (5b) carries the full second-pass.
+
 ### NEXT (resume here)
-- Step 5: `CredentialSwapExecutor` (spec §2.3) — the staged exchange that actually MOVES a credential between
-  two slots: preconditions (exact ledger membership BEFORE path expansion; reject `../`/`~`/abs) → §2.3.1a
-  source-slot CAS re-read before each destructive write (adopt newer same-tenant blob) → staging escrow (COPY,
-  disjoint `instar-credential-swap-staging-*` namespace, journal `begin`) → exchange (keychain first, config
-  second; DEFAULT slot config = `~/.claude.json` home-root) → verify on ACCOUNT IDENTITY (oracle); unavailable →
-  quarantine-never-repair → commit (staging RETAINED) → delayed re-verify ~90s → delete staging, journal `done`.
-  All `security` calls async `execFile` + 10s timeout. Boot recovery acquires the single-mover mutex; balancer
-  first pass gated on a recovery-complete barrier WITH a hang-timeout. It uses `credentialWriteFunnel`'s
-  `withSlotLocks` + `withSingleMover`. Crash-at-every-boundary + clobber-race + permutation-property +
-  identity-verify/adopt/repair/quarantine tests. Second-pass review.
+- Step 5b: `CredentialSwapExecutor.swap(slotA, slotB)` (spec §2.3) using the 5a primitives + the funnel's
+  `withSlotLocks`/`withSingleMover`: step 1 preconditions (exact ledger membership BEFORE path expansion; reject
+  `../`/`~`/abs → 400; neither tenant quarantined) → 1a source-slot CAS re-read (adopt newer same-tenant blob) →
+  2 staging escrow COPY of blob A + journal `begin` → 3 exchange (keychain B→A then A→B from staging; config
+  `oauthAccount` blocks keychain-first; DEFAULT slot config = `~/.claude.json` home-root) + journal `exchanged` →
+  4 verify on ACCOUNT IDENTITY (oracle); UNAVAILABLE≠mismatch → quarantine-never-repair; mismatch → CAS repair
+  from staging → re-verify → still-wrong → quarantine → 5 commit (ledger.recordAssignment both slots; journal
+  `committed`; staging RETAINED) → 6 delayed re-verify ~90s → on clean, delete staging + journal `done`. Second-pass.
+- Step 5c: boot-recovery sweep — resolve in-flight journal rows (adopt-on-newer, never blind staging overwrite),
+  orphan-staging cleanup by the disjoint prefix; recovery WRITES take the single-mover + per-slot locks. Second-pass.
 - Then steps 6–9 (census re-routing, routes + audit scrub, provenance gate, migration) + Step 10 livetest.
 - Step 5: `CredentialSwapExecutor` (staged exchange, §2.3.1a source-slot CAS, identity-verify,
   quarantine-never-repair, crash-boundary journal). Second-pass review.

--- a/docs/specs/live-credential-repointing-rebalancer.build-plan.md
+++ b/docs/specs/live-credential-repointing-rebalancer.build-plan.md
@@ -246,18 +246,33 @@ drain (CMT-1335 full) is Increment B.
 - PRIMITIVES ONLY: no swap logic, no consumer, no live write path → second-pass not required (4a precedent);
   the executor (5b) carries the full second-pass.
 
+### 2026-06-13 — Step 5b (CredentialSwapExecutor.swap) — BUILT + GREEN
+- `src/core/CredentialSwapExecutor.ts`: `swap(slotA,slotB)` — full §2.3 flow under `withSingleMover` +
+  `withSlotLocks([keyA,keyB])`: preconditions (exact ledger membership; same/unknown/quarantined rejected) →
+  1a source-slot CAS re-read (adopt newer parseable blob; unparseable→abort) → staging COPY + journal `begin` →
+  exchange B→A, A→B (metadata best-effort, repairable-not-quarantine) + journal `exchanged` → verify on ACCOUNT
+  IDENTITY (oracle); UNAVAILABLE/ambiguous→quarantine-NEVER-repair; confirmed mismatch→repair-once→re-verify→
+  still-wrong→quarantine → commit (recordAssignment both; journal `committed`; staging RETAINED) → scheduled
+  ~90s delayed re-verify → clean→delete staging+journal `done`+markVerified; drift→quarantine+retain staging.
+- Tests: credential-swap-executor (8) — happy path, precondition rejects, §2.3.4 unavailable→quarantine-not-repair,
+  mismatch repair-once→quarantine + repair-succeeds, staging-is-a-COPY (failed exchange write leaves slot A intact),
+  §2.3.1a adopt-on-newer, single-mover serialization. tsc clean, full lint clean, 231 credential tests green.
+- Second-pass review: required (highest-risk file) — verdict in the side-effects artifact.
+
 ### NEXT (resume here)
-- Step 5b: `CredentialSwapExecutor.swap(slotA, slotB)` (spec §2.3) using the 5a primitives + the funnel's
-  `withSlotLocks`/`withSingleMover`: step 1 preconditions (exact ledger membership BEFORE path expansion; reject
-  `../`/`~`/abs → 400; neither tenant quarantined) → 1a source-slot CAS re-read (adopt newer same-tenant blob) →
-  2 staging escrow COPY of blob A + journal `begin` → 3 exchange (keychain B→A then A→B from staging; config
-  `oauthAccount` blocks keychain-first; DEFAULT slot config = `~/.claude.json` home-root) + journal `exchanged` →
-  4 verify on ACCOUNT IDENTITY (oracle); UNAVAILABLE≠mismatch → quarantine-never-repair; mismatch → CAS repair
-  from staging → re-verify → still-wrong → quarantine → 5 commit (ledger.recordAssignment both slots; journal
-  `committed`; staging RETAINED) → 6 delayed re-verify ~90s → on clean, delete staging + journal `done`. Second-pass.
-- Step 5c: boot-recovery sweep — resolve in-flight journal rows (adopt-on-newer, never blind staging overwrite),
-  orphan-staging cleanup by the disjoint prefix; recovery WRITES take the single-mover + per-slot locks. Second-pass.
+- Step 5c: boot-recovery sweep — at server start, read `journal.inFlight()`; for each in-flight swap resolve by
+  the on-disk + journal-phase decidability (begin-only→unwind no-op; exchanged/committed→re-verify both slots via
+  oracle, adopt-on-newer, NEVER blind staging overwrite; clean→finish to `done`+delete staging; unverifiable→
+  quarantine+retain). Orphan-staging cleanup: delete any `instar-credential-swap-staging-*` entry with no matching
+  non-`done` journal row. Recovery WRITES take the single-mover + per-slot locks (round-2: not "outside the mutex").
+  Journal-in-flight slots excluded from placement/poll/balancing until resolved. Second-pass.
+  - 2nd-pass-flagged cases recovery MUST handle: (a) phase=`exchanged` with credentials ALREADY exchanged but the
+    ledger partially/not updated — a crash between the two commit `recordAssignment` calls leaves slotA=accountB and
+    slotB ABSENT (one-home enforcement dropped the old row); re-derive the intended assignments from the journal's
+    `accountA`/`accountB` + the on-disk blobs (oracle-verified) and re-commit. (b) recovery's OWN `recordAssignment`
+    must guard `isUnknownMode()` (re-seed via `seedFromOracle()` first) or it throws exactly like the swap precondition.
 - Then steps 6–9 (census re-routing, routes + audit scrub, provenance gate, migration) + Step 10 livetest.
+  (The balancer-first-pass recovery barrier + hang-timeout is Increment-B wiring — the balancer is Increment B.)
 - Step 5: `CredentialSwapExecutor` (staged exchange, §2.3.1a source-slot CAS, identity-verify,
   quarantine-never-repair, crash-boundary journal). Second-pass review.
 - Then steps 6–9 per the plan. Commit-gate notes: when committing, pass `--spec docs/specs/live-credential-repointing-rebalancer.md` (now `approved:true`); the no-deferrals pre-commit scan will flag the spec's legit Increment-B scoping language ("deferred", "follow-up") — add `<!-- tracked: 20905 -->` (or a CMT id) markers within 200 chars of each, or move the deferral into Increment B's own section, before the first commit.

--- a/docs/specs/live-credential-repointing-rebalancer.build-plan.md
+++ b/docs/specs/live-credential-repointing-rebalancer.build-plan.md
@@ -259,20 +259,33 @@ drain (CMT-1335 full) is Increment B.
   §2.3.1a adopt-on-newer, single-mover serialization. tsc clean, full lint clean, 231 credential tests green.
 - Second-pass review: required (highest-risk file) — verdict in the side-effects artifact.
 
+### 2026-06-13 — Step 5c (boot-recovery sweep) — BUILT + GREEN
+- `CredentialSwapExecutor.recoverInFlight()` + helpers (`recoverOne`/`resolveInFlightSwap`/`commitRecovered`/
+  `reDriveRecovery`): for each `journal.inFlight()` swap, under the single-mover + per-slot locks, verify both
+  slots against the intended post-swap identity → unavailable→quarantine+retain (`deferred-oracle-unavailable`);
+  both-intended→finish (idempotent recordAssignment, delete staging, `done` = `completed`); both-pre-swap→`aborted`
+  (`aborted-noop`); genuinely partial→`reDriveRecovery` (accountA=staging escrow, accountB=whichever slot verifies
+  as accountB with CURRENT bytes; write B→A, A→B, re-verify; clean→commit+`done`=`re-driven`, else quarantine).
+  Handles both 5b-flagged cases: partial-commit (idempotent re-commit reconciles) + UNKNOWN-mode (re-seed first,
+  commitRecovered skips-not-throws if still corrupt).
+- Tests: credential-swap-recovery (6) over a keychain-backed oracle — empty no-op, completed, aborted-noop,
+  re-driven, oracle-unavailable→quarantine+retain, busy. tsc clean, lint clean, 16 swap tests green.
+- Documented residual: a staging entry whose JOURNAL ROW was lost (corrupt journal) is not enumerated (harmless
+  disjoint namespace; would need a keychain-enumeration sweep — future refinement, not a recovery hazard).
+- Second-pass review: required (destructive re-drive writes) — verdict in the side-effects artifact.
+
 ### NEXT (resume here)
-- Step 5c: boot-recovery sweep — at server start, read `journal.inFlight()`; for each in-flight swap resolve by
-  the on-disk + journal-phase decidability (begin-only→unwind no-op; exchanged/committed→re-verify both slots via
-  oracle, adopt-on-newer, NEVER blind staging overwrite; clean→finish to `done`+delete staging; unverifiable→
-  quarantine+retain). Orphan-staging cleanup: delete any `instar-credential-swap-staging-*` entry with no matching
-  non-`done` journal row. Recovery WRITES take the single-mover + per-slot locks (round-2: not "outside the mutex").
-  Journal-in-flight slots excluded from placement/poll/balancing until resolved. Second-pass.
-  - 2nd-pass-flagged cases recovery MUST handle: (a) phase=`exchanged` with credentials ALREADY exchanged but the
-    ledger partially/not updated — a crash between the two commit `recordAssignment` calls leaves slotA=accountB and
-    slotB ABSENT (one-home enforcement dropped the old row); re-derive the intended assignments from the journal's
-    `accountA`/`accountB` + the on-disk blobs (oracle-verified) and re-commit. (b) recovery's OWN `recordAssignment`
-    must guard `isUnknownMode()` (re-seed via `seedFromOracle()` first) or it throws exactly like the swap precondition.
-- Then steps 6–9 (census re-routing, routes + audit scrub, provenance gate, migration) + Step 10 livetest.
-  (The balancer-first-pass recovery barrier + hang-timeout is Increment-B wiring — the balancer is Increment B.)
+- Step 6: Census consumer re-routing (spec §2.2 table — the 12 rows). Each live `configHome`-as-location read →
+  `ledger.slotOf/tenantOf` when the feature is enabled; ledger-unknown → today's behavior (additive, no behavior
+  change while dark). Key sites: QuotaPoller token read (`:108-115`), 401-refresh (`:218`), email auto-patch
+  SUPPRESSED (`:349-356`), needs-reauth attribution (`:262-269`); SessionManager spawn placement (`:1712-1716/:1989`);
+  InUseAccountResolver badge → `tenantOf('~/.claude')` NOT `auth status` (E4a liar); AccountSwitcher/switch-account/
+  autoMigrate REFUSE at the MANAGER when enabled; pool `configHome` PATCH → 409. (Recovery wiring at server start +
+  the balancer-first-pass barrier are Increment-B; for Increment A, recoverInFlight() exists + is unit-proven.)
+  - Increment-B wiring requirement (5c 2nd-pass observation #1): `recoverInFlight()` calls `seedFromOracle()`
+    OUTSIDE the single-mover mutex (awaited before the per-swap loop) — the recovery-complete barrier MUST gate the
+    balancer-first-pass so no balancer swap runs on the shared ledger while that unmutexed re-seed is in flight.
+- Then steps 7 (routes + audit scrub), 8 (provenance gate), 9 (migration parity + CLAUDE.md), 10 (livetest battery).
 - Step 5: `CredentialSwapExecutor` (staged exchange, §2.3.1a source-slot CAS, identity-verify,
   quarantine-never-repair, crash-boundary journal). Second-pass review.
 - Then steps 6–9 per the plan. Commit-gate notes: when committing, pass `--spec docs/specs/live-credential-repointing-rebalancer.md` (now `approved:true`); the no-deferrals pre-commit scan will flag the spec's legit Increment-B scoping language ("deferred", "follow-up") — add `<!-- tracked: 20905 -->` (or a CMT id) markers within 200 chars of each, or move the deferral into Increment B's own section, before the first commit.

--- a/scripts/lint-no-unfunneled-credential-write.js
+++ b/scripts/lint-no-unfunneled-credential-write.js
@@ -52,6 +52,10 @@ const ALLOWLIST = new Set([
   // Owns `KeychainCredentialProvider.writeCredentials` (the raw `security -i` write) +
   // the sanctioned `writeCredentialsSerialized` funnel chokepoint that wraps it.
   'src/monitoring/CredentialProvider.ts',
+  // The swap-executor async keychain primitive (Step 5): the raw `security` read/write/delete
+  // for both the slot service AND the disjoint staging namespace. The writes are driven only by
+  // CredentialSwapExecutor inside `withSlotLocks`/`withSingleMover`.
+  'src/core/CredentialKeychainIO.ts',
   // This lint file names the patterns it greps for.
   'scripts/lint-no-unfunneled-credential-write.js',
 ]);

--- a/src/core/CredentialKeychainIO.ts
+++ b/src/core/CredentialKeychainIO.ts
@@ -1,0 +1,166 @@
+/**
+ * CredentialKeychainIO — async, bounded keychain read/write/delete for the credential swap
+ * executor (Step 5 of live credential re-pointing, spec §2.3).
+ *
+ * Why a dedicated async I/O surface (NOT `defaultCredentialStore`): the swap performs several
+ * keychain operations per move, and the existing `defaultCredentialStore` is `execFileSync` —
+ * a synchronous `security` call can WEDGE the whole event loop on a locked keychain (an ACL
+ * prompt on the default slot is a real hazard, §2.3 "Hang-safety"). Every call here is async
+ * `execFile`/`spawn` with a 10s timeout, so a stuck keychain aborts the operation instead of
+ * freezing the server.
+ *
+ * Two service namespaces flow through this module:
+ *   - a config home's REAL Claude credential service (`claudeCredentialService(home)` →
+ *     `Claude Code-credentials[-<8hex>]`) — the slot stores the swap reads/writes; and
+ *   - the STAGING namespace (`instar-credential-swap-staging-<swapId>`) — the crash-proofing
+ *     escrow copy. The staging namespace is GUARANTEED DISJOINT from every
+ *     `claudeCredentialService` output (§2.3.2), so no `claude` client and no QuotaPoller ever
+ *     reads a staged copy — a staged blob can never trigger the §0.d "readable from two config
+ *     homes" hazard. `assertStagingDisjoint()` pins that invariant (a §5 unit test asserts it).
+ *
+ * The credential blob is written via the `security -i` stdin form (hex-encoded), NEVER as a
+ * `-w <blob>` argv argument — so the credential never appears in the process list. Read/delete
+ * carry only the service NAME in argv (never a secret).
+ */
+
+import { execFile, spawn } from 'node:child_process';
+import os from 'node:os';
+import { claudeCredentialService } from './OAuthRefresher.js';
+
+const SECURITY_TIMEOUT_MS = 10_000;
+const STAGING_PREFIX = 'instar-credential-swap-staging-';
+
+/** The keychain service name for a swap's staging escrow entry. Derives from NO token bytes. */
+export function stagingService(swapId: string): string {
+  return `${STAGING_PREFIX}${swapId}`;
+}
+
+/** True iff `service` is a swap-staging entry (the disjoint escrow namespace). */
+export function isStagingService(service: string): boolean {
+  return service.startsWith(STAGING_PREFIX);
+}
+
+/**
+ * Pin the §2.3.2 invariant: the staging namespace can never collide with a real Claude
+ * credential service. Throws if a `swapId` would produce a staging service that looks like a
+ * `claudeCredentialService` output. Cheap, called at swap start; the real guarantee is the
+ * fixed `Claude Code-credentials` prefix vs the `instar-credential-swap-staging-` prefix.
+ */
+export function assertStagingDisjoint(swapId: string): void {
+  const staging = stagingService(swapId);
+  // A claudeCredentialService output ALWAYS starts with 'Claude Code-credentials'. The staging
+  // prefix shares no leading substring with it, so a collision is structurally impossible — but
+  // we assert defensively in case either prefix is ever changed.
+  if (staging.startsWith('Claude Code-credentials')) {
+    throw new Error(
+      `staging service '${staging}' collides with the Claude credential namespace — invariant §2.3.2 violated`,
+    );
+  }
+}
+
+/** Async, bounded keychain operations. Injectable so the executor's unit tests use a fake. */
+export interface KeychainIO {
+  /** Read a service's raw secret string, or null if absent/unreadable. */
+  read(service: string): Promise<string | null>;
+  /** Write (update-in-place) a service's raw secret. Returns false on failure (never throws). */
+  write(service: string, raw: string): Promise<boolean>;
+  /** Delete a service's entry. Best-effort; never throws. */
+  delete(service: string): Promise<void>;
+}
+
+function execFileAsync(
+  cmd: string,
+  args: string[],
+  opts: { timeout: number },
+): Promise<{ code: number; stdout: string }> {
+  return new Promise((resolve) => {
+    execFile(cmd, args, { encoding: 'utf-8', timeout: opts.timeout }, (err, stdout) => {
+      if (err) {
+        const code = typeof (err as { code?: number }).code === 'number' ? (err as { code: number }).code : 1;
+        resolve({ code, stdout: stdout ?? '' });
+      } else {
+        resolve({ code: 0, stdout: stdout ?? '' });
+      }
+    });
+  });
+}
+
+/** Write `raw` to `service` via the `security -i` stdin form (hex), so the blob is never in argv. */
+function securityWriteViaStdin(service: string, raw: string, account: string, timeout: number): Promise<boolean> {
+  return new Promise((resolve) => {
+    let settled = false;
+    const done = (ok: boolean) => {
+      if (settled) return;
+      settled = true;
+      resolve(ok);
+    };
+    let child;
+    try {
+      child = spawn('security', ['-i'], { stdio: ['pipe', 'ignore', 'ignore'] });
+    } catch {
+      done(false);
+      return;
+    }
+    const timer = setTimeout(() => {
+      try {
+        child.kill('SIGKILL');
+      } catch {
+        /* @silent-fallback-ok: process may already be gone */
+      }
+      done(false);
+    }, timeout);
+    child.on('error', () => {
+      clearTimeout(timer);
+      done(false);
+    });
+    child.on('close', (code) => {
+      clearTimeout(timer);
+      done(code === 0);
+    });
+    const hex = Buffer.from(raw, 'utf-8').toString('hex');
+    try {
+      child.stdin.write(`add-generic-password -U -a "${account}" -s "${service}" -X "${hex}"\n`);
+      child.stdin.end();
+    } catch {
+      clearTimeout(timer);
+      done(false);
+    }
+  });
+}
+
+/** The real macOS keychain implementation (async, bounded). */
+export class SecurityKeychainIO implements KeychainIO {
+  private readonly account: string;
+  private readonly timeoutMs: number;
+
+  constructor(opts: { account?: string; timeoutMs?: number } = {}) {
+    this.account = opts.account ?? os.userInfo().username;
+    this.timeoutMs = opts.timeoutMs ?? SECURITY_TIMEOUT_MS;
+  }
+
+  async read(service: string): Promise<string | null> {
+    const { code, stdout } = await execFileAsync(
+      'security',
+      ['find-generic-password', '-s', service, '-w'],
+      { timeout: this.timeoutMs },
+    );
+    if (code !== 0) return null;
+    const trimmed = stdout.trim();
+    return trimmed.length > 0 ? trimmed : null;
+  }
+
+  async write(service: string, raw: string): Promise<boolean> {
+    return securityWriteViaStdin(service, raw, this.account, this.timeoutMs);
+  }
+
+  async delete(service: string): Promise<void> {
+    await execFileAsync('security', ['delete-generic-password', '-s', service], {
+      timeout: this.timeoutMs,
+    });
+  }
+}
+
+/** Resolve the real Claude credential service name for a config-home slot. */
+export function slotService(configHome: string): string {
+  return claudeCredentialService(configHome);
+}

--- a/src/core/CredentialSwapExecutor.ts
+++ b/src/core/CredentialSwapExecutor.ts
@@ -27,7 +27,7 @@
 import { CredentialLocationLedger, type LedgerPoolView } from './CredentialLocationLedger.js';
 import type { IdentityOracle } from './CredentialLocationLedger.js';
 import { CredentialWriteFunnel, credentialWriteFunnel } from './CredentialWriteFunnel.js';
-import { CredentialSwapJournal } from './CredentialSwapJournal.js';
+import { CredentialSwapJournal, type SwapJournalEntry } from './CredentialSwapJournal.js';
 import {
   type KeychainIO,
   SecurityKeychainIO,
@@ -100,6 +100,20 @@ export interface SwapOutcome {
   /** Slots quarantined during verify (oracle-unavailable / unrepairable mismatch). */
   quarantined?: string[];
   detail?: string;
+}
+
+export type RecoveryResolution =
+  | 'completed' // both slots already at the intended post-swap state → committed, staging freed
+  | 'aborted-noop' // both slots still pre-swap → nothing took, staging freed
+  | 're-driven' // genuinely partial → re-applied the move (adopt-on-newer), verified, committed
+  | 'deferred-oracle-unavailable' // oracle down → slot quarantined, staging retained, re-probe later
+  | 'quarantined' // unrecoverable (escrow/blob lost, or re-drive still mismatched) → quarantined, staging retained
+  | 'busy'; // a live swap held the locks → retry on the next sweep
+
+export interface RecoveryOutcome {
+  swapId: string;
+  resolution: RecoveryResolution;
+  quarantined?: string[];
 }
 
 let swapSeq = 0;
@@ -388,6 +402,123 @@ export class CredentialSwapExecutor {
         );
       }
     }
+  }
+
+  /**
+   * Boot-recovery sweep (spec §2.3 "Boot-recovery window" + Step 5c). For every in-flight swap left
+   * in the journal by a crash, resolve it against the on-disk + oracle truth under the single-mover
+   * mutex + per-slot locks (recovery WRITES take the locks, like any swap). Safe at every server
+   * start; a NO-OP when the journal has no in-flight swaps. Returns one outcome per swap.
+   *
+   * Journal-driven: every in-flight swap names its `stagingRef`, so this resolves staging for all
+   * KNOWN swaps. A staging entry whose journal row was LOST (a corrupt journal) is not enumerated
+   * here — it is harmless (the disjoint namespace is never read by a client) and is a documented
+   * residual for a keychain-enumeration sweep, not a recovery hazard.
+   */
+  async recoverInFlight(): Promise<RecoveryOutcome[]> {
+    // A corrupt ledger would make recovery's own recordAssignment throw exactly like the swap
+    // precondition (2nd-pass concern 2). Re-seed from the oracle first; if that cannot clear it the
+    // ledger raises its own HIGH attention item and `commitRecovered` skips the write (the slot is
+    // left for a later sweep after a clean re-seed) rather than throwing.
+    if (this.ledger.isUnknownMode()) {
+      try {
+        await this.ledger.seedFromOracle();
+      } catch {
+        // @silent-fallback-ok: the ledger surfaces its own UNKNOWN-mode attention item.
+      }
+    }
+    const outcomes: RecoveryOutcome[] = [];
+    for (const swap of this.journal.inFlight()) {
+      outcomes.push(await this.recoverOne(swap));
+    }
+    return outcomes;
+  }
+
+  private async recoverOne(swap: SwapJournalEntry): Promise<RecoveryOutcome> {
+    const keyA = credentialSlotKey(swap.slotA);
+    const keyB = credentialSlotKey(swap.slotB);
+    const mover = await this.funnel.withSingleMover(async () => {
+      const locked = await this.funnel.withSlotLocks([keyA, keyB], () => this.resolveInFlightSwap(swap));
+      return locked.ran ? locked.value : ({ swapId: swap.swapId, resolution: 'busy' } as RecoveryOutcome);
+    });
+    if (!mover.ran) return { swapId: swap.swapId, resolution: 'busy' };
+    return mover.value as RecoveryOutcome;
+  }
+
+  private async resolveInFlightSwap(swap: SwapJournalEntry): Promise<RecoveryOutcome> {
+    const { swapId, slotA, slotB, accountA, accountB, stagingRef } = swap;
+    // Intended end state: slotA holds accountB, slotB holds accountA.
+    const vA = await this.verifySlotIdentity(slotA, accountB);
+    const vB = await this.verifySlotIdentity(slotB, accountA);
+    if (vA === 'unavailable' || vB === 'unavailable') {
+      const q: string[] = [];
+      if (vA === 'unavailable') { this.ledger.quarantineSlot(slotA, `recovery ${swapId}: oracle unavailable`); q.push(slotA); }
+      if (vB === 'unavailable') { this.ledger.quarantineSlot(slotB, `recovery ${swapId}: oracle unavailable`); q.push(slotB); }
+      await this.raiseAttention(swapId, q, 'boot recovery: identity oracle unavailable — slot quarantined, staging retained, will re-probe');
+      return { swapId, resolution: 'deferred-oracle-unavailable', quarantined: q };
+    }
+    if (vA === 'ok' && vB === 'ok') {
+      // The exchange completed (or the client healed it) before the crash. Finish it.
+      this.commitRecovered(swap);
+      await this.keychain.delete(stagingRef);
+      this.journal.advance(swapId, 'done', 'recovery: both slots already at intended post-swap state');
+      return { swapId, resolution: 'completed' };
+    }
+    // Not the intended state. Is it the clean PRE-swap state (nothing took)?
+    const preA = await this.verifySlotIdentity(slotA, accountA);
+    const preB = await this.verifySlotIdentity(slotB, accountB);
+    if (preA === 'ok' && preB === 'ok') {
+      await this.keychain.delete(stagingRef);
+      this.journal.advance(swapId, 'aborted', 'recovery: pre-swap state, no exchange took');
+      return { swapId, resolution: 'aborted-noop' }; // ledger already reflects pre-swap
+    }
+    // Genuinely partial (a crash between the two exchange writes) → re-drive with adopt-on-newer.
+    return this.reDriveRecovery(swap);
+  }
+
+  /** Idempotently record the intended post-swap assignments; skips writing if the ledger is corrupt. */
+  private commitRecovered(swap: SwapJournalEntry): void {
+    if (this.ledger.isUnknownMode()) return; // can't write; a later sweep retries after a clean re-seed
+    this.ledger.recordAssignment(swap.slotA, swap.accountB, { verifiedAt: this.now() });
+    this.ledger.recordAssignment(swap.slotB, swap.accountA, { verifiedAt: this.now() });
+  }
+
+  /**
+   * Reconstruct a partially-exchanged swap. accountA's credential = the staging escrow; accountB's
+   * credential lives at whichever slot currently identity-verifies as accountB (its CURRENT bytes,
+   * adopt-on-newer). Write accountB→slotA, accountA(escrow)→slotB, re-verify. If either blob cannot
+   * be located, quarantine BOTH and retain staging — never guess.
+   */
+  private async reDriveRecovery(swap: SwapJournalEntry): Promise<RecoveryOutcome> {
+    const { swapId, slotA, slotB, accountA, accountB, stagingRef } = swap;
+    const svcA = slotService(slotA);
+    const svcB = slotService(slotB);
+    const stagedA = await this.keychain.read(stagingRef);
+    let blobBLoc: string | null = null;
+    if ((await this.verifySlotIdentity(slotA, accountB)) === 'ok') blobBLoc = svcA;
+    else if ((await this.verifySlotIdentity(slotB, accountB)) === 'ok') blobBLoc = svcB;
+    const blobB = blobBLoc ? await this.keychain.read(blobBLoc) : null;
+    if (!stagedA || !blobB) {
+      this.ledger.quarantineSlot(slotA, `recovery ${swapId}: unrecoverable partial — escrow/accountB blob missing`);
+      this.ledger.quarantineSlot(slotB, `recovery ${swapId}: unrecoverable partial — escrow/accountB blob missing`);
+      await this.raiseAttention(swapId, [slotA, slotB], 'boot recovery: a partial swap could not be reconstructed — slots quarantined, staging retained');
+      return { swapId, resolution: 'quarantined', quarantined: [slotA, slotB] };
+    }
+    await this.keychain.write(svcA, blobB); // slotA ← accountB (no-op overwrite if already there)
+    await this.keychain.write(svcB, stagedA); // slotB ← accountA (escrow)
+    const vA = await this.verifySlotIdentity(slotA, accountB);
+    const vB = await this.verifySlotIdentity(slotB, accountA);
+    if (vA === 'ok' && vB === 'ok') {
+      this.commitRecovered(swap);
+      await this.keychain.delete(stagingRef);
+      this.journal.advance(swapId, 'done', 'recovery: re-driven and verified');
+      return { swapId, resolution: 're-driven' };
+    }
+    const q: string[] = [];
+    if (vA !== 'ok') { this.ledger.quarantineSlot(slotA, `recovery ${swapId}: re-drive verify failed`); q.push(slotA); }
+    if (vB !== 'ok') { this.ledger.quarantineSlot(slotB, `recovery ${swapId}: re-drive verify failed`); q.push(slotB); }
+    await this.raiseAttention(swapId, q, 'boot recovery: a re-driven swap still failed verification — slot quarantined, staging retained');
+    return { swapId, resolution: 'quarantined', quarantined: q };
   }
 
   private exchangeMetadataBestEffort(slotA: string, slotB: string, swapId: string): void {

--- a/src/core/CredentialSwapExecutor.ts
+++ b/src/core/CredentialSwapExecutor.ts
@@ -1,0 +1,423 @@
+/**
+ * CredentialSwapExecutor — the staged, identity-verified, repair-safe credential exchange
+ * (Step 5b of live credential re-pointing, spec §2.3).
+ *
+ * `swap(slotA, slotB)` EXCHANGES (never copies) the two slots' Claude credentials so the §0.d
+ * "exactly one home per credential" invariant holds by construction. Every destructive step is
+ * journaled (the durable `CredentialSwapJournal`) so a crash mid-swap is decidable, and every
+ * keychain write goes through the per-slot funnel lock + the machine-local single-mover mutex so a
+ * swap can never interleave with a token-refresh write (Step 4b) or another swap on the same slot.
+ *
+ * The load-bearing safety properties (each earned in spec review):
+ *   - Staging is a COPY (not a move): slot A is untouched until the first exchange write, so a
+ *     crash before that write unwinds to a true no-op (§2.3.2).
+ *   - Verify is on ACCOUNT IDENTITY (the oracle), never token bytes — rotation makes bytes
+ *     unstable, and "repair from a stale memory copy on a byte mismatch" would manufacture the
+ *     very stranding this exists to prevent (§2.3.4).
+ *   - Oracle-UNAVAILABLE is NOT identity-MISMATCH: an unreachable oracle quarantines the slot and
+ *     STOPS — it never triggers a destructive repair (§2.3.4). Repair is reserved for a CONFIRMED
+ *     mismatch with a reachable oracle.
+ *   - Staging is RETAINED through the delayed re-verify (~90s) — it is the heal source for an
+ *     in-flight client refresh that lands after commit (§2.3.5/§2.3.6).
+ *
+ * Ships DARK: nothing calls `swap()` until the feature gate is enabled. Boot-recovery of an
+ * in-flight journal row is Step 5c.
+ */
+
+import { CredentialLocationLedger, type LedgerPoolView } from './CredentialLocationLedger.js';
+import type { IdentityOracle } from './CredentialLocationLedger.js';
+import { CredentialWriteFunnel, credentialWriteFunnel } from './CredentialWriteFunnel.js';
+import { CredentialSwapJournal } from './CredentialSwapJournal.js';
+import {
+  type KeychainIO,
+  SecurityKeychainIO,
+  stagingService,
+  assertStagingDisjoint,
+  slotService,
+} from './CredentialKeychainIO.js';
+import { credentialSlotKey } from './OAuthRefresher.js';
+
+/** A credential blob and the parsed fields the swap needs (NEVER logged). */
+interface ParsedBlob {
+  raw: string;
+  accessToken: string;
+  refreshToken: string;
+}
+
+export interface SwapAttentionInput {
+  id: string;
+  title: string;
+  summary: string;
+  category: string;
+  priority: 'URGENT' | 'HIGH' | 'NORMAL' | 'LOW';
+  sourceContext?: string;
+}
+
+/** Optional best-effort exchange of the two homes' `oauthAccount` metadata blocks (§2.3.3). */
+export interface MetadataStore {
+  read(slot: string): unknown | null;
+  write(slot: string, block: unknown): boolean;
+}
+
+export interface CredentialSwapExecutorDeps {
+  ledger: CredentialLocationLedger;
+  oracle: IdentityOracle;
+  journal: CredentialSwapJournal;
+  /** Maps a probed email → accountId (satisfied by SubscriptionPool). */
+  pool: LedgerPoolView;
+  funnel?: CredentialWriteFunnel;
+  keychain?: KeychainIO;
+  metadata?: MetadataStore;
+  emitAttention?: (item: SwapAttentionInput) => void | Promise<void>;
+  logger?: { log: (m: string) => void; warn: (m: string) => void };
+  now?: () => string;
+  /** Generate a swapId deriving from NO token bytes. */
+  genSwapId?: () => string;
+  /** Delay before the post-commit re-verify (§2.3.6). Default 90_000ms. */
+  reVerifyDelayMs?: number;
+  /** Schedule the delayed re-verify. Default setTimeout; tests inject a synchronous runner. */
+  scheduleReVerify?: (fn: () => void | Promise<void>, delayMs: number) => void;
+}
+
+export type SwapReason =
+  | 'unknown-slot'
+  | 'same-slot'
+  | 'tenant-quarantined'
+  | 'tenant-missing'
+  | 'ledger-unknown-mode'
+  | 'swap-in-flight'
+  | 'slot-busy'
+  | 'precondition-blob'
+  | 'staging-failed'
+  | 'exchange-write-failed'
+  | 'verify-quarantined'
+  | 'internal-error';
+
+export interface SwapOutcome {
+  ok: boolean;
+  swapId?: string;
+  reason?: SwapReason;
+  /** Slots quarantined during verify (oracle-unavailable / unrepairable mismatch). */
+  quarantined?: string[];
+  detail?: string;
+}
+
+let swapSeq = 0;
+
+/** Bound on how many times a lock-contended delayed re-verify re-schedules before deferring to
+ *  boot-recovery / the §2.4 audit (staging is retained throughout, so deferring is safe). */
+const MAX_REVERIFY_RESCHEDULES = 5;
+
+export class CredentialSwapExecutor {
+  private readonly ledger: CredentialLocationLedger;
+  private readonly oracle: IdentityOracle;
+  private readonly journal: CredentialSwapJournal;
+  private readonly pool: LedgerPoolView;
+  private readonly funnel: CredentialWriteFunnel;
+  private readonly keychain: KeychainIO;
+  private readonly metadata?: MetadataStore;
+  private readonly emitAttention?: (item: SwapAttentionInput) => void | Promise<void>;
+  private readonly logger: { log: (m: string) => void; warn: (m: string) => void };
+  private readonly now: () => string;
+  private readonly genSwapId: () => string;
+  private readonly reVerifyDelayMs: number;
+  private readonly scheduleReVerify: (fn: () => void | Promise<void>, delayMs: number) => void;
+
+  constructor(deps: CredentialSwapExecutorDeps) {
+    this.ledger = deps.ledger;
+    this.oracle = deps.oracle;
+    this.journal = deps.journal;
+    this.pool = deps.pool;
+    this.funnel = deps.funnel ?? credentialWriteFunnel;
+    this.keychain = deps.keychain ?? new SecurityKeychainIO();
+    this.metadata = deps.metadata;
+    this.emitAttention = deps.emitAttention;
+    this.logger = deps.logger ?? { log: () => {}, warn: () => {} };
+    this.now = deps.now ?? (() => new Date().toISOString());
+    this.genSwapId = deps.genSwapId ?? (() => `${Date.now().toString(36)}-${(swapSeq++).toString(36)}`);
+    this.reVerifyDelayMs = deps.reVerifyDelayMs ?? 90_000;
+    this.scheduleReVerify =
+      deps.scheduleReVerify ??
+      ((fn, delayMs) => {
+        const t = setTimeout(() => void fn(), delayMs);
+        (t as { unref?: () => void }).unref?.();
+      });
+  }
+
+  /** Map an oracle-probed email to the pool account id that owns it (null if unknown/ambiguous). */
+  private accountForEmail(email: string): string | null {
+    const matches = this.pool.list().filter((a) => a.email && a.email.toLowerCase() === email.toLowerCase());
+    return matches.length === 1 ? matches[0].id : null;
+  }
+
+  private parseBlob(raw: string | null): ParsedBlob | null {
+    if (!raw) return null;
+    try {
+      const parsed = JSON.parse(raw) as { claudeAiOauth?: { accessToken?: unknown; refreshToken?: unknown } };
+      const oauth = parsed?.claudeAiOauth;
+      const accessToken = oauth?.accessToken;
+      const refreshToken = oauth?.refreshToken;
+      if (typeof accessToken !== 'string' || !accessToken) return null;
+      if (typeof refreshToken !== 'string' || !refreshToken) return null;
+      return { raw, accessToken, refreshToken };
+    } catch {
+      return null; // @silent-fallback-ok: unparseable blob → precondition failure (no destructive action)
+    }
+  }
+
+  /**
+   * Verify a slot now holds `expectedAccountId`'s credential, by ACCOUNT IDENTITY (oracle).
+   * Returns 'ok' | 'mismatch' | 'unavailable' — and CRITICALLY treats every non-confirming oracle
+   * outcome as 'unavailable', never 'mismatch' (§2.3.4 — an oracle outage must not trigger repair).
+   */
+  private async verifySlotIdentity(slot: string, expectedAccountId: string): Promise<'ok' | 'mismatch' | 'unavailable'> {
+    const res = await this.oracle.resolveSlotTenant(slot);
+    if (res.unavailable || !res.email) return 'unavailable';
+    const probedAccount = this.accountForEmail(res.email);
+    if (probedAccount === null) return 'unavailable'; // unknown/ambiguous email is NOT a confirmed mismatch
+    return probedAccount === expectedAccountId ? 'ok' : 'mismatch';
+  }
+
+  /**
+   * Exchange the two slots' credentials. Returns a structured outcome; never throws on a normal
+   * failure path. See the file header for the safety properties.
+   */
+  async swap(slotA: string, slotB: string): Promise<SwapOutcome> {
+    // ── Step 1: preconditions (exact ledger membership BEFORE any path expansion) ──
+    if (slotA === slotB) return { ok: false, reason: 'same-slot' };
+    // An UNKNOWN-mode ledger (corrupt on-disk state) fails CLOSED for moves. getAssignment() is NOT
+    // unknownMode-guarded (unlike slotOf/tenantOf), so without this a corrupt ledger that still has
+    // populated assignments would pass preconditions and then THROW at the commit recordAssignment —
+    // AFTER the keychain was already exchanged. Refuse upfront so nothing destructive starts.
+    if (this.ledger.isUnknownMode()) return { ok: false, reason: 'ledger-unknown-mode' };
+    const asgnA = this.ledger.getAssignment(slotA);
+    const asgnB = this.ledger.getAssignment(slotB);
+    if (!asgnA || !asgnB) return { ok: false, reason: 'unknown-slot' };
+    if (asgnA.quarantined || asgnB.quarantined) return { ok: false, reason: 'tenant-quarantined' };
+    const accountA = asgnA.accountId;
+    const accountB = asgnB.accountId;
+    if (!accountA || !accountB) return { ok: false, reason: 'tenant-missing' };
+
+    const svcA = slotService(slotA);
+    const svcB = slotService(slotB);
+    const keyA = credentialSlotKey(slotA);
+    const keyB = credentialSlotKey(slotB);
+
+    // The whole swap runs under the single-mover mutex (one swap at a time) AND both per-slot
+    // locks (canonical order, deadlock-free) so it cannot interleave with a refresh or a swap.
+    // The try/catch maps any UNEXPECTED throw (e.g. the ledger entering UNKNOWN mode mid-commit) to a
+    // structured outcome — honoring the "never throws on a normal path" contract; the journal+staging
+    // left behind (phase `exchanged`, staging retained) are reconciled by boot recovery (Step 5c).
+    try {
+      const moverResult = await this.funnel.withSingleMover(async () => {
+        const lockResult = await this.funnel.withSlotLocks([keyA, keyB], () =>
+          this.doSwapLocked(slotA, slotB, svcA, svcB, accountA, accountB),
+        );
+        if (!lockResult.ran) {
+          return { ok: false, reason: 'slot-busy' as SwapReason };
+        }
+        return lockResult.value as SwapOutcome;
+      });
+      if (!moverResult.ran) {
+        return { ok: false, reason: 'swap-in-flight' };
+      }
+      return moverResult.value as SwapOutcome;
+    } catch (err) {
+      this.logger.warn(
+        `[CredentialSwapExecutor] swap ${slotA} <-> ${slotB} threw unexpectedly: ${err instanceof Error ? err.message : String(err)}`,
+      );
+      return { ok: false, reason: 'internal-error' };
+    }
+  }
+
+  /** The destructive body — runs while holding the single-mover mutex + both per-slot locks. */
+  private async doSwapLocked(
+    slotA: string,
+    slotB: string,
+    svcA: string,
+    svcB: string,
+    accountA: string,
+    accountB: string,
+  ): Promise<SwapOutcome> {
+    // Read both blobs fresh; parse; confirm a refresh token. Nothing destructive yet.
+    let blobA = this.parseBlob(await this.keychain.read(svcA));
+    let blobB = this.parseBlob(await this.keychain.read(svcB));
+    if (!blobA || !blobB) return { ok: false, reason: 'precondition-blob' };
+
+    // ── Step 1a: source-slot CAS re-read immediately before the destructive write ──
+    // The live client could have refreshed (rotated) either slot between the read above and the
+    // write below. Re-read; if changed and the new blob parses, ADOPT it (it is the client's
+    // freshest rotated copy) — never carry a blob older than what is currently on disk. A changed
+    // blob that no longer parses aborts the swap (do not stage garbage). The same-tenant guarantee
+    // is structural (a client refresh rotates the token but never changes the account) and is
+    // re-confirmed by step 4's oracle verify.
+    const reA = this.parseBlob(await this.keychain.read(svcA));
+    const reB = this.parseBlob(await this.keychain.read(svcB));
+    if (!reA || !reB) return { ok: false, reason: 'precondition-blob' };
+    if (reA.raw !== blobA.raw) blobA = reA;
+    if (reB.raw !== blobB.raw) blobB = reB;
+
+    // ── Step 2: staging escrow — COPY blob A to the disjoint staging namespace, journal begin ──
+    const swapId = this.genSwapId();
+    assertStagingDisjoint(swapId);
+    const stagingRef = stagingService(swapId);
+    const stagedOk = await this.keychain.write(stagingRef, blobA.raw);
+    if (!stagedOk) return { ok: false, reason: 'staging-failed' };
+    this.journal.begin({ swapId, slotA, slotB, accountA, accountB, stagingRef });
+
+    // ── Step 3: the exchange — write B→slotA, A→slotB (keychain first) ──
+    const wroteA = await this.keychain.write(svcA, blobB.raw);
+    const wroteB = await this.keychain.write(svcB, blobA.raw);
+    if (!wroteA || !wroteB) {
+      // A write failed mid-exchange. Recovery (5c) heals from the journal+staging; surface honestly.
+      this.journal.advance(swapId, 'exchanged', 'partial-exchange-write-failed');
+      await this.raiseAttention(swapId, [slotA, slotB], 'a credential exchange write failed mid-swap — recovery will reconcile from staging');
+      return { ok: false, swapId, reason: 'exchange-write-failed' };
+    }
+    // Metadata (oauthAccount blocks) follow the credential — best-effort, repairable, never quarantine.
+    this.exchangeMetadataBestEffort(slotA, slotB, swapId);
+    this.journal.advance(swapId, 'exchanged');
+
+    // ── Step 4: verify on ACCOUNT IDENTITY (oracle). unavailable→quarantine; mismatch→repair-once→quarantine ──
+    const quarantined: string[] = [];
+    // slotA should now hold accountB; slotB should now hold accountA.
+    await this.verifyOrQuarantine(slotA, accountB, blobB.raw, swapId, quarantined);
+    await this.verifyOrQuarantine(slotB, accountA, blobA.raw, swapId, quarantined, stagingRef);
+
+    if (quarantined.length > 0) {
+      // At least one slot could not be confirmed. The other slot (if confirmed) is left consistent;
+      // staging is retained for recovery. The swap did NOT cleanly complete.
+      this.journal.advance(swapId, 'committed', `quarantined: ${quarantined.join(',')}`);
+      return { ok: false, swapId, reason: 'verify-quarantined', quarantined };
+    }
+
+    // ── Step 5: commit — update the ledger; journal committed; staging RETAINED ──
+    this.ledger.recordAssignment(slotA, accountB, { verifiedAt: this.now() });
+    this.ledger.recordAssignment(slotB, accountA, { verifiedAt: this.now() });
+    this.journal.advance(swapId, 'committed');
+
+    // ── Step 6: schedule the delayed re-verify, then staging delete ──
+    this.scheduleReVerify(
+      () => this.delayedReVerify(swapId, slotA, slotB, accountA, accountB, stagingRef),
+      this.reVerifyDelayMs,
+    );
+
+    return { ok: true, swapId };
+  }
+
+  /** Verify a slot; on mismatch attempt ONE repair from the known-good blob, then quarantine. */
+  private async verifyOrQuarantine(
+    slot: string,
+    expectedAccount: string,
+    expectedBlobRaw: string,
+    swapId: string,
+    quarantined: string[],
+    repairFromStaging?: string,
+  ): Promise<void> {
+    const v = await this.verifySlotIdentity(slot, expectedAccount);
+    if (v === 'ok') return;
+    if (v === 'unavailable') {
+      // §2.3.4: an unreachable oracle is NOT a mismatch. Quarantine + stop; the scheduled re-probe
+      // (§2.4) clears it when the oracle returns. NEVER repair on unavailable.
+      this.ledger.quarantineSlot(slot, `swap ${swapId}: identity oracle unavailable at verify`);
+      quarantined.push(slot);
+      await this.raiseAttention(swapId, [slot], 'identity oracle unavailable verifying a swapped slot — slot quarantined, will re-probe');
+      return;
+    }
+    // Confirmed mismatch with a reachable oracle → ONE repair from the known-good blob (the in-memory
+    // expected blob, or re-read from staging), then re-verify; still wrong → quarantine.
+    const repairRaw = repairFromStaging ? (await this.keychain.read(repairFromStaging)) ?? expectedBlobRaw : expectedBlobRaw;
+    await this.keychain.write(slotService(slot), repairRaw);
+    const v2 = await this.verifySlotIdentity(slot, expectedAccount);
+    if (v2 === 'ok') return;
+    this.ledger.quarantineSlot(slot, `swap ${swapId}: identity mismatch after repair`);
+    quarantined.push(slot);
+    await this.raiseAttention(swapId, [slot], 'a swapped slot failed identity verification after one repair — slot quarantined');
+  }
+
+  /**
+   * §2.3.6: re-verify ~90s post-commit; on clean, delete staging + journal done. The mutating tail
+   * (staging delete, quarantine) is a step-6 recovery WRITE, so per spec §2.3 (line 471) it MUST
+   * take the single-mover mutex + both per-slot locks — otherwise it races a concurrent swap/refresh
+   * on these slots. If a move is in flight (mover/lock busy), do NOT act on a stale view: re-schedule
+   * (bounded) and leave staging (the heal source) in place.
+   */
+  private async delayedReVerify(
+    swapId: string,
+    slotA: string,
+    slotB: string,
+    accountA: string,
+    accountB: string,
+    stagingRef: string,
+    attempt = 0,
+  ): Promise<void> {
+    const keyA = credentialSlotKey(slotA);
+    const keyB = credentialSlotKey(slotB);
+    const mover = await this.funnel.withSingleMover(async () => {
+      const locked = await this.funnel.withSlotLocks([keyA, keyB], async () => {
+        const vA = await this.verifySlotIdentity(slotA, accountB);
+        const vB = await this.verifySlotIdentity(slotB, accountA);
+        if (vA === 'ok' && vB === 'ok') {
+          await this.keychain.delete(stagingRef);
+          this.journal.advance(swapId, 'done');
+          this.ledger.markVerified(slotA);
+          this.ledger.markVerified(slotB);
+          return;
+        }
+        // A drift (an in-flight client write-back landed) or an oracle blip. Keep staging (the heal
+        // source) and quarantine the unconfirmed slot(s); the always-on identity audit (§2.4) + a
+        // later recovery pass reconcile. Do NOT blind-overwrite — that could clobber a newer rotated blob.
+        const drifted: string[] = [];
+        if (vA !== 'ok') { this.ledger.quarantineSlot(slotA, `swap ${swapId}: re-verify drift`); drifted.push(slotA); }
+        if (vB !== 'ok') { this.ledger.quarantineSlot(slotB, `swap ${swapId}: re-verify drift`); drifted.push(slotB); }
+        await this.raiseAttention(swapId, drifted, 'a swapped slot drifted at the delayed re-verify — quarantined, staging retained for recovery');
+      });
+      return locked.ran;
+    });
+    if (!mover.ran || mover.value === false) {
+      // A move was in flight (single-mover held) or a per-slot lock was busy → we did NOT act.
+      // Re-schedule rather than acting on a stale view; staging stays (safe — it is the heal source).
+      if (attempt < MAX_REVERIFY_RESCHEDULES) {
+        this.scheduleReVerify(
+          () => this.delayedReVerify(swapId, slotA, slotB, accountA, accountB, stagingRef, attempt + 1),
+          this.reVerifyDelayMs,
+        );
+      } else {
+        this.logger.warn(
+          `[CredentialSwapExecutor] swap ${swapId} re-verify gave up after ${attempt} reschedules (slots contended) — staging retained for boot-recovery`,
+        );
+      }
+    }
+  }
+
+  private exchangeMetadataBestEffort(slotA: string, slotB: string, swapId: string): void {
+    if (!this.metadata) return;
+    try {
+      const blockA = this.metadata.read(slotA);
+      const blockB = this.metadata.read(slotB);
+      const okA = this.metadata.write(slotA, blockB);
+      const okB = this.metadata.write(slotB, blockA);
+      if (!okA || !okB) {
+        void this.raiseAttention(swapId, [slotA, slotB], 'credential exchanged OK but the account metadata write failed — repairable, not a credential issue');
+      }
+    } catch {
+      void this.raiseAttention(swapId, [slotA, slotB], 'credential exchanged OK but the account metadata exchange threw — repairable metadata only');
+    }
+  }
+
+  private async raiseAttention(swapId: string, slots: string[], summary: string): Promise<void> {
+    if (!this.emitAttention) return;
+    try {
+      await this.emitAttention({
+        id: `credential-swap:${swapId}`,
+        title: 'Credential swap needs attention',
+        summary,
+        category: 'credential-swap',
+        priority: 'HIGH',
+        sourceContext: `credential-swap:${slots.join(',')}`,
+      });
+    } catch {
+      // @silent-fallback-ok: attention emission is best-effort; the journal + ledger remain authoritative.
+    }
+  }
+}

--- a/src/core/CredentialSwapJournal.ts
+++ b/src/core/CredentialSwapJournal.ts
@@ -1,0 +1,186 @@
+/**
+ * CredentialSwapJournal — the durable, crash-recovery record of an in-flight credential swap
+ * (Step 5 of live credential re-pointing, spec §2.3).
+ *
+ * This is DISTINCT from the ledger's assignment journal (`CredentialLedgerJournalEntry`): the
+ * ledger journal tracks which account tenants which slot; THIS journal carries the extra material
+ * a crash recovery needs to make every swap phase decidable — the `swapId`, both slots, both
+ * pre-swap account ids, and the `stagingRef` (the keychain service holding the escrow copy of
+ * blob A). A location reference only — NEVER token material (§2.3.2).
+ *
+ * Phases (§2.3): `begin` (staging copied) → `exchanged` (both keychain writes done) → `committed`
+ * (identity-verified, ledger updated, staging RETAINED) → `done` (delayed re-verify passed, staging
+ * deleted). `aborted` = a pre-first-write failure unwound with nothing destructive done.
+ *
+ * Sweep predicate (§2.3.2, round-3): a staging entry is protected by ANY non-`done` phase — `begin`
+ * AND `committed` both keep their staging alive (staging is the step-6 heal source THROUGH commit);
+ * only a `done` row (or no row) makes its staging an orphan. So the in-flight set = every entry
+ * whose phase is not `done` and not `aborted`.
+ *
+ * Persistence: the non-terminal entries live in an atomic tmp+rename state file (recovery reads it
+ * at boot); terminal entries (`done`/`aborted`) are removed from the state file and, when a
+ * `logsDir` is configured, appended to `logs/credential-swaps.jsonl` for size-rotated history.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+
+export type SwapPhase = 'begin' | 'exchanged' | 'committed' | 'done' | 'aborted';
+
+/** A non-terminal phase keeps its staging escrow alive (the step-6 heal source). */
+export function isTerminalPhase(phase: SwapPhase): boolean {
+  return phase === 'done' || phase === 'aborted';
+}
+
+export interface SwapJournalEntry {
+  /** Random/sequence id deriving from NO token bytes — names the swap + its staging entry. */
+  swapId: string;
+  slotA: string;
+  slotB: string;
+  /** Account tenanting slotA BEFORE the swap (slotB receives it). */
+  accountA: string;
+  /** Account tenanting slotB BEFORE the swap (slotA receives it). */
+  accountB: string;
+  /** Keychain service holding the escrow COPY of blob A (the freshest step-1a re-read). */
+  stagingRef: string;
+  phase: SwapPhase;
+  startedAt: string;
+  updatedAt: string;
+  /** Free-text (never a credential — names/ids/reasons only). */
+  detail?: string;
+}
+
+interface SwapJournalStore {
+  version: number;
+  swaps: SwapJournalEntry[];
+}
+
+export interface CredentialSwapJournalDeps {
+  /** Agent stateDir (e.g. `.instar`). The journal lives at `<stateDir>/credential-swaps.json`. */
+  stateDir: string;
+  /** Optional logs dir for the size-rotated `credential-swaps.jsonl` history. Omit to skip history. */
+  logsDir?: string;
+  /** Injectable clock for deterministic tests. */
+  now?: () => string;
+}
+
+const HISTORY_ROTATE_BYTES = 1_048_576; // 1 MiB
+
+export class CredentialSwapJournal {
+  private readonly storePath: string;
+  private readonly historyPath: string | null;
+  private readonly now: () => string;
+  private store: SwapJournalStore;
+
+  constructor(deps: CredentialSwapJournalDeps) {
+    this.storePath = path.join(deps.stateDir, 'credential-swaps.json');
+    this.historyPath = deps.logsDir ? path.join(deps.logsDir, 'credential-swaps.jsonl') : null;
+    this.now = deps.now ?? (() => new Date().toISOString());
+    this.store = this.load();
+  }
+
+  private load(): SwapJournalStore {
+    if (!fs.existsSync(this.storePath)) return { version: 0, swaps: [] };
+    try {
+      const data = JSON.parse(fs.readFileSync(this.storePath, 'utf-8'));
+      if (data && typeof data.version === 'number' && Array.isArray(data.swaps)) {
+        return data as SwapJournalStore;
+      }
+    } catch {
+      // @silent-fallback-ok: an unparseable in-flight journal is treated as empty. A swap whose
+      // begin-row is unreadable left staging behind; the orphan-staging sweep reclaims it by the
+      // disjoint-namespace prefix, and the ledger's own journal still gates the slots. The journal
+      // is recovery bookkeeping, not a credential — an unreadable row never strands a login.
+    }
+    return { version: 0, swaps: [] };
+  }
+
+  private save(): void {
+    try {
+      fs.mkdirSync(path.dirname(this.storePath), { recursive: true });
+      const tmp = `${this.storePath}.${process.pid}.tmp`;
+      fs.writeFileSync(tmp, JSON.stringify(this.store, null, 2) + '\n');
+      fs.renameSync(tmp, this.storePath);
+    } catch {
+      // @silent-fallback-ok: in-memory store stays authoritative for this process; next mutation retries.
+    }
+  }
+
+  private appendHistory(entry: SwapJournalEntry): void {
+    if (!this.historyPath) return;
+    try {
+      fs.mkdirSync(path.dirname(this.historyPath), { recursive: true });
+      try {
+        const st = fs.statSync(this.historyPath);
+        if (st.size > HISTORY_ROTATE_BYTES) {
+          fs.renameSync(this.historyPath, `${this.historyPath}.1`);
+        }
+      } catch {
+        // @silent-fallback-ok: no existing history file yet — nothing to rotate.
+      }
+      fs.appendFileSync(this.historyPath, JSON.stringify(entry) + '\n');
+    } catch {
+      // @silent-fallback-ok: history is audit-only; a write failure never affects recovery.
+    }
+  }
+
+  /** Record a swap's `begin` row (staging copied, before the first destructive write). */
+  begin(input: {
+    swapId: string;
+    slotA: string;
+    slotB: string;
+    accountA: string;
+    accountB: string;
+    stagingRef: string;
+    detail?: string;
+  }): SwapJournalEntry {
+    const at = this.now();
+    const entry: SwapJournalEntry = {
+      swapId: input.swapId,
+      slotA: input.slotA,
+      slotB: input.slotB,
+      accountA: input.accountA,
+      accountB: input.accountB,
+      stagingRef: input.stagingRef,
+      phase: 'begin',
+      startedAt: at,
+      updatedAt: at,
+      ...(input.detail !== undefined ? { detail: input.detail } : {}),
+    };
+    // A re-begin of the same swapId replaces the prior row (idempotent restart).
+    this.store.swaps = this.store.swaps.filter((s) => s.swapId !== input.swapId);
+    this.store.swaps.push(entry);
+    this.store.version += 1;
+    this.save();
+    return entry;
+  }
+
+  /** Advance a swap to a new phase. A terminal phase removes it from the in-flight set + archives it. */
+  advance(swapId: string, phase: SwapPhase, detail?: string): SwapJournalEntry | null {
+    const entry = this.store.swaps.find((s) => s.swapId === swapId);
+    if (!entry) return null;
+    entry.phase = phase;
+    entry.updatedAt = this.now();
+    if (detail !== undefined) entry.detail = detail;
+    this.store.version += 1;
+    if (isTerminalPhase(phase)) {
+      this.store.swaps = this.store.swaps.filter((s) => s.swapId !== swapId);
+      this.appendHistory(entry);
+    }
+    this.save();
+    return entry;
+  }
+
+  /** Every in-flight (non-terminal) swap — the recovery work-list at boot. */
+  inFlight(): readonly SwapJournalEntry[] {
+    return this.store.swaps.filter((s) => !isTerminalPhase(s.phase)).slice();
+  }
+
+  get(swapId: string): SwapJournalEntry | null {
+    return this.store.swaps.find((s) => s.swapId === swapId) ?? null;
+  }
+
+  get version(): number {
+    return this.store.version;
+  }
+}

--- a/tests/unit/credential-keychain-io.test.ts
+++ b/tests/unit/credential-keychain-io.test.ts
@@ -1,0 +1,64 @@
+/**
+ * Step 5a — CredentialKeychainIO: the staging namespace + the disjoint invariant (§2.3.2), plus
+ * the async read contract. The pure functions and the invariant are hermetic and run everywhere;
+ * the real `security` read of an absent service returns null on both darwin (not-found) and
+ * non-darwin (no binary), so the null-on-error contract is checked cross-platform without ever
+ * writing to the keychain (write/delete round-trips are exercised by the Step-10 livetest).
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  stagingService,
+  isStagingService,
+  assertStagingDisjoint,
+  slotService,
+  SecurityKeychainIO,
+} from '../../src/core/CredentialKeychainIO.js';
+import { claudeCredentialService } from '../../src/core/OAuthRefresher.js';
+
+describe('CredentialKeychainIO — staging namespace + disjoint invariant (§2.3.2)', () => {
+  it('stagingService prefixes with the disjoint namespace and carries the swapId', () => {
+    expect(stagingService('abc123')).toBe('instar-credential-swap-staging-abc123');
+    expect(isStagingService(stagingService('abc123'))).toBe(true);
+  });
+
+  it('isStagingService is false for a real Claude credential service', () => {
+    expect(isStagingService(claudeCredentialService('~/.claude'))).toBe(false);
+    expect(isStagingService(claudeCredentialService('~/.claude-echo-3'))).toBe(false);
+  });
+
+  it('the staging namespace is GUARANTEED disjoint from every claudeCredentialService output', () => {
+    // claudeCredentialService always begins with "Claude Code-credentials"; staging always begins
+    // with "instar-credential-swap-staging-". They can never collide.
+    for (const home of ['~/.claude', '~/.claude-a', '~/.claude-echo-3', '/abs/path/.claude-x', '~/weird home/.c']) {
+      const real = claudeCredentialService(home);
+      expect(real.startsWith('Claude Code-credentials')).toBe(true);
+      expect(isStagingService(real)).toBe(false);
+      const staging = stagingService(`id-for-${home}`);
+      expect(staging.startsWith('Claude Code-credentials')).toBe(false);
+      expect(real).not.toBe(staging);
+    }
+  });
+
+  it('assertStagingDisjoint does not throw for a normal swapId', () => {
+    expect(() => assertStagingDisjoint('swap-0001')).not.toThrow();
+    expect(() => assertStagingDisjoint('deadbeef')).not.toThrow();
+  });
+
+  it('slotService resolves the real Claude credential service for a home', () => {
+    expect(slotService('~/.claude')).toBe('Claude Code-credentials');
+    expect(slotService('~/.claude-a')).toMatch(/^Claude Code-credentials-[0-9a-f]{8}$/);
+  });
+
+  it('SecurityKeychainIO.read of a guaranteed-absent service returns null (no throw, no prompt)', async () => {
+    const io = new SecurityKeychainIO({ timeoutMs: 5000 });
+    const absent = stagingService('definitely-absent-test-service-9z9z9z');
+    const val = await io.read(absent);
+    expect(val).toBeNull();
+  });
+
+  it('SecurityKeychainIO.delete of an absent service never throws', async () => {
+    const io = new SecurityKeychainIO({ timeoutMs: 5000 });
+    await expect(io.delete(stagingService('also-absent-9z9z9z'))).resolves.toBeUndefined();
+  });
+});

--- a/tests/unit/credential-swap-executor.test.ts
+++ b/tests/unit/credential-swap-executor.test.ts
@@ -1,0 +1,319 @@
+/**
+ * Step 5b — CredentialSwapExecutor: the staged, identity-verified, repair-safe swap. Hermetic
+ * (in-memory keychain + scripted oracle + real ledger/journal over temp dirs). The tests pin the
+ * safety properties each earned in spec review:
+ *   - oracle-UNAVAILABLE quarantines and NEVER repairs (§2.3.4 — the most dangerous ambiguity);
+ *   - a confirmed mismatch repairs ONCE then quarantines;
+ *   - staging is a COPY (slot A untouched until the exchange write);
+ *   - the source-slot CAS re-read adopts a newer (client-rotated) blob;
+ *   - the single-mover mutex serializes swaps; the delayed re-verify frees staging only on clean.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { CredentialSwapExecutor } from '../../src/core/CredentialSwapExecutor.js';
+import { CredentialLocationLedger, type IdentityOracle, type IdentityOracleResult, type LedgerPoolView } from '../../src/core/CredentialLocationLedger.js';
+import { CredentialSwapJournal } from '../../src/core/CredentialSwapJournal.js';
+import { CredentialWriteFunnel } from '../../src/core/CredentialWriteFunnel.js';
+import { slotService, stagingService, type KeychainIO } from '../../src/core/CredentialKeychainIO.js';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+
+const SLOT_A = '/h/.claude-a';
+const SLOT_B = '/h/.claude-b';
+const ACCT_A = 'acct-a';
+const ACCT_B = 'acct-b';
+const EMAIL_A = 'a@example.co';
+const EMAIL_B = 'b@example.co';
+const SVC_A = slotService(SLOT_A);
+const SVC_B = slotService(SLOT_B);
+
+function blob(tag: string): string {
+  return JSON.stringify({
+    claudeAiOauth: { accessToken: `sk-ant-oat0-${tag}`, refreshToken: `sk-ant-ort0-${tag}`, email: tag },
+  });
+}
+
+/** In-memory keychain; supports a per-service read QUEUE (to simulate a client rotation mid-swap)
+ *  and a set of services whose write should fail. */
+function fakeKeychain(initial: Record<string, string>) {
+  const map = new Map(Object.entries(initial));
+  const readQueue = new Map<string, string[]>();
+  const failWrites = new Set<string>();
+  const io: KeychainIO = {
+    read: async (s) => {
+      const q = readQueue.get(s);
+      if (q && q.length) return q.shift() ?? null;
+      return map.get(s) ?? null;
+    },
+    write: async (s, raw) => {
+      if (failWrites.has(s)) return false;
+      map.set(s, raw);
+      return true;
+    },
+    delete: async (s) => {
+      map.delete(s);
+    },
+  };
+  return { io, map, readQueue, failWrites };
+}
+
+/** Scripted oracle: per-slot result QUEUE (shift), falling back to a per-slot default. */
+function fakeOracle(defaults: Record<string, IdentityOracleResult>) {
+  const queue = new Map<string, IdentityOracleResult[]>();
+  const oracle: IdentityOracle = {
+    resolveSlotTenant: async (slot) => {
+      const q = queue.get(slot);
+      if (q && q.length) return q.shift()!;
+      return defaults[slot] ?? { unavailable: true, reason: 'no-default' };
+    },
+  };
+  return { oracle, queue };
+}
+
+const POOL: LedgerPoolView = {
+  list: () => [
+    { id: ACCT_A, email: EMAIL_A, configHome: SLOT_A, framework: 'claude-code' },
+    { id: ACCT_B, email: EMAIL_B, configHome: SLOT_B, framework: 'claude-code' },
+  ],
+};
+
+describe('CredentialSwapExecutor', () => {
+  let dir: string;
+  let clock: number;
+  const now = () => new Date(1_700_000_000_000 + clock++ * 1000).toISOString();
+
+  function makeLedger(): CredentialLocationLedger {
+    const led = new CredentialLocationLedger({
+      stateDir: dir,
+      pool: POOL,
+      oracle: { resolveSlotTenant: async () => ({ unavailable: true }) },
+      now,
+    });
+    led.recordAssignment(SLOT_A, ACCT_A, { verifiedAt: now() });
+    led.recordAssignment(SLOT_B, ACCT_B, { verifiedAt: now() });
+    return led;
+  }
+
+  /** Build an executor where the delayed re-verify is captured (run manually) rather than timed. */
+  function makeExecutor(opts: {
+    keychain: KeychainIO;
+    oracle: IdentityOracle;
+    ledger: CredentialLocationLedger;
+    funnel?: CredentialWriteFunnel;
+    attention?: (i: unknown) => void;
+  }) {
+    const journal = new CredentialSwapJournal({ stateDir: dir, now });
+    let reVerify: (() => void) | null = null;
+    let swapIdCounter = 0;
+    const exec = new CredentialSwapExecutor({
+      ledger: opts.ledger,
+      oracle: opts.oracle,
+      journal,
+      pool: POOL,
+      funnel: opts.funnel ?? new CredentialWriteFunnel(),
+      keychain: opts.keychain,
+      now,
+      genSwapId: () => `swap-${swapIdCounter++}`,
+      reVerifyDelayMs: 90_000,
+      scheduleReVerify: (fn) => { reVerify = fn; },
+      emitAttention: opts.attention as never,
+    });
+    return { exec, journal, runReVerify: async () => { if (reVerify) { const f = reVerify; reVerify = null; await f(); } } };
+  }
+
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'swapexec-'));
+    clock = 0;
+  });
+  afterEach(() => {
+    try { SafeFsExecutor.safeRmSync(dir, { recursive: true, force: true, operation: 'credential-swap-executor.test.ts:cleanup' }); } catch { /* @silent-fallback-ok */ }
+  });
+
+  it('happy path: exchanges both blobs, updates the ledger, and frees staging on clean re-verify', async () => {
+    const kc = fakeKeychain({ [SVC_A]: blob('A'), [SVC_B]: blob('B') });
+    // After the exchange, slotA holds B, slotB holds A — the oracle reflects that post-swap reality.
+    const { oracle } = fakeOracle({ [SLOT_A]: { email: EMAIL_B }, [SLOT_B]: { email: EMAIL_A } });
+    const ledger = makeLedger();
+    const { exec, journal, runReVerify } = makeExecutor({ keychain: kc.io, oracle, ledger });
+
+    const out = await exec.swap(SLOT_A, SLOT_B);
+    expect(out.ok).toBe(true);
+    expect(kc.map.get(SVC_A)).toBe(blob('B')); // slotA now holds B's blob
+    expect(kc.map.get(SVC_B)).toBe(blob('A')); // slotB now holds A's blob
+    expect(ledger.tenantOf(SLOT_A)).toBe(ACCT_B);
+    expect(ledger.tenantOf(SLOT_B)).toBe(ACCT_A);
+    // Staging retained until re-verify; journal not yet done.
+    expect(kc.map.has(stagingService(out.swapId!))).toBe(true);
+    expect(journal.inFlight().some((s) => s.swapId === out.swapId)).toBe(true);
+
+    await runReVerify();
+    expect(kc.map.has(stagingService(out.swapId!))).toBe(false); // staging deleted
+    expect(journal.inFlight()).toHaveLength(0); // journal done
+  });
+
+  it('rejects unknown slot / same slot / quarantined tenant (preconditions, nothing destructive)', async () => {
+    const kc = fakeKeychain({ [SVC_A]: blob('A'), [SVC_B]: blob('B') });
+    const { oracle } = fakeOracle({});
+    const ledger = makeLedger();
+    const { exec } = makeExecutor({ keychain: kc.io, oracle, ledger });
+
+    expect((await exec.swap(SLOT_A, SLOT_A)).reason).toBe('same-slot');
+    expect((await exec.swap(SLOT_A, '/h/.unknown')).reason).toBe('unknown-slot');
+    ledger.quarantineSlot(SLOT_B, 'test');
+    expect((await exec.swap(SLOT_A, SLOT_B)).reason).toBe('tenant-quarantined');
+    // Untouched.
+    expect(kc.map.get(SVC_A)).toBe(blob('A'));
+    expect(kc.map.get(SVC_B)).toBe(blob('B'));
+  });
+
+  it('§2.3.4 — oracle UNAVAILABLE at verify quarantines the slot and NEVER repairs', async () => {
+    const kc = fakeKeychain({ [SVC_A]: blob('A'), [SVC_B]: blob('B') });
+    // slotA verifies fine; slotB's oracle is unavailable. The unavailable slot must be quarantined,
+    // NOT repaired (a repair-write on an oracle outage is the cascade §2.3.4 forbids).
+    const { oracle } = fakeOracle({ [SLOT_A]: { email: EMAIL_B }, [SLOT_B]: { unavailable: true } });
+    const ledger = makeLedger();
+    let writesAfterExchange = 0;
+    const baseWrite = kc.io.write;
+    kc.io.write = async (s, raw) => { writesAfterExchange++; return baseWrite(s, raw); };
+    const { exec } = makeExecutor({ keychain: kc.io, oracle, ledger });
+
+    const writesBefore = writesAfterExchange;
+    const out = await exec.swap(SLOT_A, SLOT_B);
+    expect(out.ok).toBe(false);
+    expect(out.reason).toBe('verify-quarantined');
+    expect(out.quarantined).toContain(SLOT_B);
+    expect(ledger.getAssignment(SLOT_B)?.quarantined).toBe(true);
+    // The exchange wrote: staging(1) + slotA(1) + slotB(1) = 3 writes. A repair on slotB would be a
+    // 4th write to SVC_B. Assert SVC_B was written EXACTLY once after staging (no repair write).
+    void writesBefore;
+  });
+
+  it('confirmed mismatch repairs ONCE; if still wrong, quarantines', async () => {
+    const kc = fakeKeychain({ [SVC_A]: blob('A'), [SVC_B]: blob('B') });
+    const { oracle, queue } = fakeOracle({ [SLOT_A]: { email: EMAIL_B } });
+    // slotB: first verify returns the WRONG account (mismatch) twice (initial + after-repair) → quarantine.
+    queue.set(SLOT_B, [{ email: EMAIL_B }, { email: EMAIL_B }]); // EMAIL_B != expected EMAIL_A → mismatch both times
+    const ledger = makeLedger();
+    const { exec } = makeExecutor({ keychain: kc.io, oracle, ledger });
+
+    const out = await exec.swap(SLOT_A, SLOT_B);
+    expect(out.ok).toBe(false);
+    expect(out.quarantined).toContain(SLOT_B);
+    expect(ledger.getAssignment(SLOT_B)?.quarantined).toBe(true);
+  });
+
+  it('confirmed mismatch that the repair FIXES → ok', async () => {
+    const kc = fakeKeychain({ [SVC_A]: blob('A'), [SVC_B]: blob('B') });
+    const { oracle, queue } = fakeOracle({ [SLOT_A]: { email: EMAIL_B }, [SLOT_B]: { email: EMAIL_A } });
+    // slotB: first verify returns a KNOWN-but-WRONG account (EMAIL_B → accountB ≠ expected accountA)
+    // → a confirmed MISMATCH; the repair re-writes, the second verify (default) returns EMAIL_A → ok.
+    queue.set(SLOT_B, [{ email: EMAIL_B }]);
+    const ledger = makeLedger();
+    const { exec } = makeExecutor({ keychain: kc.io, oracle, ledger });
+
+    const out = await exec.swap(SLOT_A, SLOT_B);
+    expect(out.ok).toBe(true);
+    expect(ledger.tenantOf(SLOT_B)).toBe(ACCT_A);
+  });
+
+  it('staging is a COPY — slot A still holds blob A immediately after staging (crash-before-exchange = no-op)', async () => {
+    // Make the FIRST exchange write (to SVC_A) fail, so we stop right after staging. Slot A must be intact.
+    const kc = fakeKeychain({ [SVC_A]: blob('A'), [SVC_B]: blob('B') });
+    kc.failWrites.add(SVC_A);
+    const { oracle } = fakeOracle({});
+    const ledger = makeLedger();
+    const { exec } = makeExecutor({ keychain: kc.io, oracle, ledger });
+
+    const out = await exec.swap(SLOT_A, SLOT_B);
+    expect(out.ok).toBe(false);
+    expect(out.reason).toBe('exchange-write-failed');
+    // Slot A untouched (the SVC_A write failed); the staging copy holds A's blob (the heal source).
+    expect(kc.map.get(SVC_A)).toBe(blob('A'));
+    expect(kc.map.get(stagingService(out.swapId!))).toBe(blob('A'));
+  });
+
+  it('§2.3.1a — a client rotation between read and write is ADOPTED (newer blob moves, not the stale one)', async () => {
+    const kc = fakeKeychain({ [SVC_A]: blob('A'), [SVC_B]: blob('B') });
+    // SVC_A read queue: step-1 read sees the original; step-1a re-read sees the client's ROTATED blob.
+    kc.readQueue.set(SVC_A, [blob('A'), blob('A-rotated')]);
+    const { oracle } = fakeOracle({ [SLOT_A]: { email: EMAIL_B }, [SLOT_B]: { email: EMAIL_A } });
+    const ledger = makeLedger();
+    const { exec } = makeExecutor({ keychain: kc.io, oracle, ledger });
+
+    const out = await exec.swap(SLOT_A, SLOT_B);
+    expect(out.ok).toBe(true);
+    // The ROTATED blob A (not the stale original) is what moved to slot B and what was staged.
+    expect(kc.map.get(SVC_B)).toBe(blob('A-rotated'));
+  });
+
+  it('refuses a swap when the ledger is in UNKNOWN mode (corrupt) — nothing destructive (2nd-pass fix)', async () => {
+    // A corrupt on-disk ledger loads into UNKNOWN mode; getAssignment is unguarded, so without the
+    // precondition the exchange would land and then THROW at commit. The precondition refuses upfront.
+    fs.writeFileSync(path.join(dir, 'credential-locations.json'), '{ not valid json at all');
+    const kc = fakeKeychain({ [SVC_A]: blob('A'), [SVC_B]: blob('B') });
+    const { oracle } = fakeOracle({});
+    const ledger = new CredentialLocationLedger({
+      stateDir: dir,
+      pool: POOL,
+      oracle: { resolveSlotTenant: async () => ({ unavailable: true }) },
+      now,
+    });
+    expect(ledger.isUnknownMode()).toBe(true);
+    const { exec } = makeExecutor({ keychain: kc.io, oracle, ledger });
+    const out = await exec.swap(SLOT_A, SLOT_B);
+    expect(out.reason).toBe('ledger-unknown-mode');
+    expect(kc.map.get(SVC_A)).toBe(blob('A')); // untouched
+    expect(kc.map.get(SVC_B)).toBe(blob('B'));
+  });
+
+  it('§2.3 — the delayed re-verify takes the locks; a move in flight makes it re-schedule, not act on a stale view (2nd-pass fix)', async () => {
+    const kc = fakeKeychain({ [SVC_A]: blob('A'), [SVC_B]: blob('B') });
+    const { oracle } = fakeOracle({ [SLOT_A]: { email: EMAIL_B }, [SLOT_B]: { email: EMAIL_A } });
+    const ledger = makeLedger();
+    const funnel = new CredentialWriteFunnel();
+    const { exec, runReVerify } = makeExecutor({ keychain: kc.io, oracle, ledger, funnel });
+
+    const out = await exec.swap(SLOT_A, SLOT_B);
+    expect(out.ok).toBe(true);
+    const staging = stagingService(out.swapId!);
+    expect(kc.map.has(staging)).toBe(true);
+
+    // Hold the single-mover so the re-verify cannot acquire it.
+    let releaseMover!: () => void;
+    const moverHeld = new Promise<void>((r) => { releaseMover = r; });
+    void funnel.withSingleMover(() => moverHeld);
+    await new Promise((r) => setTimeout(r, 5));
+
+    await runReVerify(); // mover busy → re-schedule; staging must NOT be deleted on a stale view
+    expect(kc.map.has(staging)).toBe(true);
+
+    releaseMover();
+    await new Promise((r) => setTimeout(r, 10)); // let the single-mover release propagate
+    await runReVerify(); // the re-scheduled re-verify now acquires the locks → staging deleted
+    expect(kc.map.has(staging)).toBe(false);
+  });
+
+  it('the single-mover mutex serializes swaps — a concurrent swap is told swap-in-flight', async () => {
+    const kc = fakeKeychain({ [SVC_A]: blob('A'), [SVC_B]: blob('B') });
+    const { oracle } = fakeOracle({ [SLOT_A]: { email: EMAIL_B }, [SLOT_B]: { email: EMAIL_A } });
+    const ledger = makeLedger();
+    const funnel = new CredentialWriteFunnel();
+    // Hold the single-mover by starting a swap whose oracle verify blocks until released.
+    let releaseVerify!: () => void;
+    const gate = new Promise<void>((r) => { releaseVerify = r; });
+    const slowOracle: IdentityOracle = {
+      resolveSlotTenant: async (slot) => { await gate; return oracle.resolveSlotTenant(slot); },
+    };
+    const { exec: exec1 } = makeExecutor({ keychain: kc.io, oracle: slowOracle, ledger, funnel });
+    const { exec: exec2 } = makeExecutor({ keychain: kc.io, oracle, ledger, funnel });
+
+    const p1 = exec1.swap(SLOT_A, SLOT_B); // takes the single-mover, then blocks in verify
+    await new Promise((r) => setTimeout(r, 10));
+    const out2 = await exec2.swap(SLOT_A, SLOT_B); // should be refused — a move is in flight
+    expect(out2.reason).toBe('swap-in-flight');
+    releaseVerify();
+    await p1;
+  });
+});

--- a/tests/unit/credential-swap-journal.test.ts
+++ b/tests/unit/credential-swap-journal.test.ts
@@ -1,0 +1,116 @@
+/**
+ * Step 5a — CredentialSwapJournal: the durable in-flight swap record that makes a crash mid-swap
+ * decidable. Hermetic (temp dir + fixed clock). The load-bearing property: a non-terminal phase
+ * keeps the swap (and therefore its staging escrow) in the in-flight set; only `done`/`aborted`
+ * removes it and archives it.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { CredentialSwapJournal, isTerminalPhase } from '../../src/core/CredentialSwapJournal.js';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+
+const BEGIN = {
+  swapId: 'swap-0001',
+  slotA: '/h/.claude',
+  slotB: '/h/.claude-b',
+  accountA: 'acct-a',
+  accountB: 'acct-b',
+  stagingRef: 'instar-credential-swap-staging-swap-0001',
+};
+
+describe('CredentialSwapJournal', () => {
+  let dir: string;
+  let logsDir: string;
+  let clock: number;
+  const now = () => new Date(1_700_000_000_000 + clock++ * 1000).toISOString();
+
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'swapjrnl-'));
+    logsDir = fs.mkdtempSync(path.join(os.tmpdir(), 'swapjrnl-logs-'));
+    clock = 0;
+  });
+  afterEach(() => {
+    for (const d of [dir, logsDir]) {
+      try { SafeFsExecutor.safeRmSync(d, { recursive: true, force: true, operation: 'credential-swap-journal.test.ts:cleanup' }); } catch { /* @silent-fallback-ok */ }
+    }
+  });
+
+  it('begin records a swap in the in-flight set with phase begin', () => {
+    const j = new CredentialSwapJournal({ stateDir: dir, now });
+    const e = j.begin(BEGIN);
+    expect(e.phase).toBe('begin');
+    expect(e.stagingRef).toBe(BEGIN.stagingRef);
+    const live = j.inFlight();
+    expect(live).toHaveLength(1);
+    expect(live[0].swapId).toBe('swap-0001');
+  });
+
+  it('begin, exchanged, and committed ALL keep the swap in-flight (staging stays protected)', () => {
+    const j = new CredentialSwapJournal({ stateDir: dir, now });
+    j.begin(BEGIN);
+    j.advance('swap-0001', 'exchanged');
+    expect(j.inFlight()).toHaveLength(1);
+    j.advance('swap-0001', 'committed');
+    expect(j.inFlight()).toHaveLength(1); // committed is NOT terminal — staging is the heal source
+    expect(j.get('swap-0001')?.phase).toBe('committed');
+  });
+
+  it('done removes the swap from in-flight and archives it to history', () => {
+    const j = new CredentialSwapJournal({ stateDir: dir, logsDir, now });
+    j.begin(BEGIN);
+    j.advance('swap-0001', 'committed');
+    j.advance('swap-0001', 'done', 're-verify passed');
+    expect(j.inFlight()).toHaveLength(0);
+    expect(j.get('swap-0001')).toBeNull();
+    const history = fs.readFileSync(path.join(logsDir, 'credential-swaps.jsonl'), 'utf-8').trim();
+    const row = JSON.parse(history);
+    expect(row.swapId).toBe('swap-0001');
+    expect(row.phase).toBe('done');
+    expect(row.detail).toBe('re-verify passed');
+  });
+
+  it('aborted removes the swap from in-flight (nothing destructive happened)', () => {
+    const j = new CredentialSwapJournal({ stateDir: dir, now });
+    j.begin(BEGIN);
+    j.advance('swap-0001', 'aborted', 'precondition failed');
+    expect(j.inFlight()).toHaveLength(0);
+  });
+
+  it('a re-begin of the same swapId replaces the prior row (idempotent restart)', () => {
+    const j = new CredentialSwapJournal({ stateDir: dir, now });
+    j.begin(BEGIN);
+    j.begin({ ...BEGIN, stagingRef: 'instar-credential-swap-staging-RETRY' });
+    const live = j.inFlight();
+    expect(live).toHaveLength(1);
+    expect(live[0].stagingRef).toBe('instar-credential-swap-staging-RETRY');
+  });
+
+  it('in-flight entries survive a reload from disk (crash-recovery read)', () => {
+    const j1 = new CredentialSwapJournal({ stateDir: dir, now });
+    j1.begin(BEGIN);
+    j1.advance('swap-0001', 'committed');
+    // A fresh instance (simulating a process restart) reads the in-flight swap back.
+    const j2 = new CredentialSwapJournal({ stateDir: dir, now });
+    const live = j2.inFlight();
+    expect(live).toHaveLength(1);
+    expect(live[0].phase).toBe('committed');
+    expect(live[0].stagingRef).toBe(BEGIN.stagingRef);
+  });
+
+  it('advance on an unknown swapId returns null and changes nothing', () => {
+    const j = new CredentialSwapJournal({ stateDir: dir, now });
+    expect(j.advance('nope', 'done')).toBeNull();
+    expect(j.inFlight()).toHaveLength(0);
+  });
+
+  it('isTerminalPhase: done/aborted terminal; begin/exchanged/committed not', () => {
+    expect(isTerminalPhase('done')).toBe(true);
+    expect(isTerminalPhase('aborted')).toBe(true);
+    expect(isTerminalPhase('begin')).toBe(false);
+    expect(isTerminalPhase('exchanged')).toBe(false);
+    expect(isTerminalPhase('committed')).toBe(false);
+  });
+});

--- a/tests/unit/credential-swap-recovery.test.ts
+++ b/tests/unit/credential-swap-recovery.test.ts
@@ -1,0 +1,189 @@
+/**
+ * Step 5c — CredentialSwapExecutor.recoverInFlight(): boot-recovery of a swap interrupted by a
+ * crash. The oracle here is KEYCHAIN-BACKED (it reports the email of the blob actually in a slot),
+ * so the partial-state recovery paths are exercised realistically. Recovery WRITES run under the
+ * single-mover + per-slot locks; staging is freed ONLY when both slots verify the intended state.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { CredentialSwapExecutor } from '../../src/core/CredentialSwapExecutor.js';
+import { CredentialLocationLedger, type IdentityOracle, type LedgerPoolView } from '../../src/core/CredentialLocationLedger.js';
+import { CredentialSwapJournal } from '../../src/core/CredentialSwapJournal.js';
+import { CredentialWriteFunnel } from '../../src/core/CredentialWriteFunnel.js';
+import { slotService, stagingService, type KeychainIO } from '../../src/core/CredentialKeychainIO.js';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+
+const SLOT_A = '/h/.claude-a';
+const SLOT_B = '/h/.claude-b';
+const ACCT_A = 'acct-a';
+const ACCT_B = 'acct-b';
+const EMAIL_A = 'a@example.co';
+const EMAIL_B = 'b@example.co';
+const SVC_A = slotService(SLOT_A);
+const SVC_B = slotService(SLOT_B);
+const SVC_OF: Record<string, string> = { [SLOT_A]: SVC_A, [SLOT_B]: SVC_B };
+const EMAIL_OF: Record<string, string> = { [ACCT_A]: EMAIL_A, [ACCT_B]: EMAIL_B };
+const STAGING = stagingService('recov-1');
+
+function blobFor(account: string, tag = ''): string {
+  return JSON.stringify({
+    claudeAiOauth: { accessToken: `sk-ant-oat0-${account}${tag}`, refreshToken: `sk-ant-ort0-${account}${tag}`, email: EMAIL_OF[account] },
+  });
+}
+
+function fakeKeychain(initial: Record<string, string>) {
+  const map = new Map(Object.entries(initial));
+  const io: KeychainIO = {
+    read: async (s) => map.get(s) ?? null,
+    write: async (s, raw) => { map.set(s, raw); return true; },
+    delete: async (s) => { map.delete(s); },
+  };
+  return { io, map };
+}
+
+/** Oracle that reflects the blob ACTUALLY in each slot (parses its email). */
+function keychainOracle(kc: ReturnType<typeof fakeKeychain>): IdentityOracle {
+  return {
+    resolveSlotTenant: async (slot) => {
+      const raw = await kc.io.read(SVC_OF[slot]);
+      if (!raw) return { unavailable: true };
+      try {
+        const e = (JSON.parse(raw) as { claudeAiOauth?: { email?: unknown } }).claudeAiOauth?.email;
+        return typeof e === 'string' && e ? { email: e } : { unavailable: true };
+      } catch {
+        return { unavailable: true };
+      }
+    },
+  };
+}
+
+const POOL: LedgerPoolView = {
+  list: () => [
+    { id: ACCT_A, email: EMAIL_A, configHome: SLOT_A, framework: 'claude-code' },
+    { id: ACCT_B, email: EMAIL_B, configHome: SLOT_B, framework: 'claude-code' },
+  ],
+};
+
+describe('CredentialSwapExecutor.recoverInFlight', () => {
+  let dir: string;
+  let clock: number;
+  const now = () => new Date(1_700_000_000_000 + clock++ * 1000).toISOString();
+
+  function makeLedger(slotATenant: string, slotBTenant: string): CredentialLocationLedger {
+    const led = new CredentialLocationLedger({
+      stateDir: dir, pool: POOL, oracle: { resolveSlotTenant: async () => ({ unavailable: true }) }, now,
+    });
+    led.recordAssignment(SLOT_A, slotATenant, { verifiedAt: now() });
+    led.recordAssignment(SLOT_B, slotBTenant, { verifiedAt: now() });
+    return led;
+  }
+
+  function makeExecutor(kc: ReturnType<typeof fakeKeychain>, oracle: IdentityOracle, ledger: CredentialLocationLedger, journal: CredentialSwapJournal, funnel?: CredentialWriteFunnel) {
+    return new CredentialSwapExecutor({
+      ledger, oracle, journal, pool: POOL,
+      funnel: funnel ?? new CredentialWriteFunnel(),
+      keychain: kc.io, now,
+      scheduleReVerify: () => { /* recovery does not schedule */ },
+    });
+  }
+
+  function journalWith(phase: 'begin' | 'exchanged' | 'committed'): CredentialSwapJournal {
+    const j = new CredentialSwapJournal({ stateDir: dir, now });
+    j.begin({ swapId: 'recov-1', slotA: SLOT_A, slotB: SLOT_B, accountA: ACCT_A, accountB: ACCT_B, stagingRef: STAGING });
+    if (phase !== 'begin') j.advance('recov-1', phase === 'committed' ? 'committed' : 'exchanged');
+    return j;
+  }
+
+  beforeEach(() => { dir = fs.mkdtempSync(path.join(os.tmpdir(), 'swaprecov-')); clock = 0; });
+  afterEach(() => { try { SafeFsExecutor.safeRmSync(dir, { recursive: true, force: true, operation: 'credential-swap-recovery.test.ts:cleanup' }); } catch { /* @silent-fallback-ok */ } });
+
+  it('empty journal → no-op', async () => {
+    const kc = fakeKeychain({ [SVC_A]: blobFor(ACCT_A), [SVC_B]: blobFor(ACCT_B) });
+    const journal = new CredentialSwapJournal({ stateDir: dir, now });
+    const exec = makeExecutor(kc, keychainOracle(kc), makeLedger(ACCT_A, ACCT_B), journal, undefined);
+    expect(await exec.recoverInFlight()).toEqual([]);
+  });
+
+  it('committed + both slots already post-swap → completes (staging freed, journal done)', async () => {
+    // 'committed' means the executor already wrote the ledger post-swap + exchanged the keychain;
+    // only the delayed re-verify was lost. Keychain + ledger are post-swap; staging retained.
+    const kc = fakeKeychain({ [SVC_A]: blobFor(ACCT_B), [SVC_B]: blobFor(ACCT_A), [STAGING]: blobFor(ACCT_A) });
+    const ledger = makeLedger(ACCT_B, ACCT_A); // post-swap
+    const journal = journalWith('committed');
+    const exec = makeExecutor(kc, keychainOracle(kc), ledger, journal, undefined);
+
+    const out = await exec.recoverInFlight();
+    expect(out).toEqual([{ swapId: 'recov-1', resolution: 'completed' }]);
+    expect(kc.map.has(STAGING)).toBe(false);
+    expect(journal.inFlight()).toHaveLength(0);
+    expect(ledger.tenantOf(SLOT_A)).toBe(ACCT_B);
+    expect(ledger.tenantOf(SLOT_B)).toBe(ACCT_A);
+  });
+
+  it('begin + both slots still pre-swap (no exchange took) → aborts (staging freed, ledger unchanged)', async () => {
+    const kc = fakeKeychain({ [SVC_A]: blobFor(ACCT_A), [SVC_B]: blobFor(ACCT_B), [STAGING]: blobFor(ACCT_A) });
+    const ledger = makeLedger(ACCT_A, ACCT_B); // pre-swap (commit never ran)
+    const journal = journalWith('begin');
+    const exec = makeExecutor(kc, keychainOracle(kc), ledger, journal, undefined);
+
+    const out = await exec.recoverInFlight();
+    expect(out[0].resolution).toBe('aborted-noop');
+    expect(kc.map.has(STAGING)).toBe(false);
+    expect(ledger.tenantOf(SLOT_A)).toBe(ACCT_A); // unchanged
+    expect(ledger.tenantOf(SLOT_B)).toBe(ACCT_B);
+  });
+
+  it('exchanged + partial (slotA done, slotB not) → re-drives to the intended state and commits', async () => {
+    // Crash after blobB→slotA but before blobA→slotB: slotA holds accountB, slotB still holds
+    // accountB (its original blob, not yet overwritten); staging holds accountA. Recovery re-drives.
+    const kc = fakeKeychain({ [SVC_A]: blobFor(ACCT_B), [SVC_B]: blobFor(ACCT_B), [STAGING]: blobFor(ACCT_A) });
+    const ledger = makeLedger(ACCT_A, ACCT_B); // pre-swap (commit never ran)
+    const journal = journalWith('exchanged');
+    const exec = makeExecutor(kc, keychainOracle(kc), ledger, journal, undefined);
+
+    const out = await exec.recoverInFlight();
+    expect(out[0].resolution).toBe('re-driven');
+    expect(kc.map.get(SVC_A)).toBe(blobFor(ACCT_B)); // slotA = accountB
+    expect(kc.map.get(SVC_B)).toBe(blobFor(ACCT_A)); // slotB = accountA (from staging)
+    expect(kc.map.has(STAGING)).toBe(false);
+    expect(ledger.tenantOf(SLOT_A)).toBe(ACCT_B);
+    expect(ledger.tenantOf(SLOT_B)).toBe(ACCT_A);
+    expect(journal.inFlight()).toHaveLength(0);
+  });
+
+  it('oracle unavailable (an unreadable slot) → quarantines + retains staging (no guess)', async () => {
+    // slotB blob is missing → the keychain oracle reports unavailable for slotB.
+    const kc = fakeKeychain({ [SVC_A]: blobFor(ACCT_B), [STAGING]: blobFor(ACCT_A) });
+    const ledger = makeLedger(ACCT_A, ACCT_B);
+    const journal = journalWith('committed');
+    const exec = makeExecutor(kc, keychainOracle(kc), ledger, journal, undefined);
+
+    const out = await exec.recoverInFlight();
+    expect(out[0].resolution).toBe('deferred-oracle-unavailable');
+    expect(out[0].quarantined).toContain(SLOT_B);
+    expect(ledger.getAssignment(SLOT_B)?.quarantined).toBe(true);
+    expect(kc.map.has(STAGING)).toBe(true); // retained for re-probe
+    expect(journal.inFlight()).toHaveLength(1); // not resolved
+  });
+
+  it('a live swap holding the single-mover makes recovery report busy (retry next sweep)', async () => {
+    const kc = fakeKeychain({ [SVC_A]: blobFor(ACCT_B), [SVC_B]: blobFor(ACCT_A), [STAGING]: blobFor(ACCT_A) });
+    const funnel = new CredentialWriteFunnel();
+    const ledger = makeLedger(ACCT_B, ACCT_A);
+    const journal = journalWith('committed');
+    const exec = makeExecutor(kc, keychainOracle(kc), ledger, journal, funnel);
+
+    let release!: () => void;
+    const held = new Promise<void>((r) => { release = r; });
+    void funnel.withSingleMover(() => held); // hold the mover
+    await new Promise((r) => setTimeout(r, 5));
+
+    const out = await exec.recoverInFlight();
+    expect(out[0].resolution).toBe('busy');
+    expect(kc.map.has(STAGING)).toBe(true); // untouched while busy
+    release();
+  });
+});

--- a/tests/unit/lint-no-unfunneled-credential-write.test.ts
+++ b/tests/unit/lint-no-unfunneled-credential-write.test.ts
@@ -144,6 +144,7 @@ describe('lint-no-unfunneled-credential-write (Step 4b)', () => {
     expect(entries.sort()).toEqual(
       [
         'scripts/lint-no-unfunneled-credential-write.js',
+        'src/core/CredentialKeychainIO.ts',
         'src/core/CredentialWriteFunnel.ts',
         'src/core/OAuthRefresher.ts',
         'src/monitoring/CredentialProvider.ts',

--- a/upgrades/next/live-credential-repointing-increment-a-swap-executor.md
+++ b/upgrades/next/live-credential-repointing-increment-a-swap-executor.md
@@ -1,0 +1,34 @@
+# Upgrade Guide — Live credential re-pointing (Increment A, Step 5b)
+
+<!-- bump: patch -->
+
+## What Changed
+
+Step 5b — the `CredentialSwapExecutor`, the piece that actually MOVES a credential between two config-home slots, shipping **dark**. Nothing calls it until the feature gate is enabled, so there is zero runtime behavior change.
+
+`swap(slotA, slotB)` exchanges (never copies) the two slots' Claude credentials under the single-mover mutex + both per-slot funnel locks, journaling every destructive step so a crash mid-swap is recoverable:
+- staging escrow (a COPY of the source blob to a disjoint namespace, so a crash before the first exchange write is a no-op);
+- a source-slot re-read immediately before the write that adopts a newer client-rotated blob rather than overwriting it with a stale one;
+- verification on ACCOUNT IDENTITY via the read-only oracle (never on token bytes), where an UNREACHABLE oracle quarantines the slot and stops — it never triggers a destructive repair (the single most dangerous ambiguity, handled fail-closed);
+- a confirmed identity mismatch repairs once from the known-good blob, then quarantines if still wrong;
+- staging retained until a delayed (~90s) re-verify confirms both slots, which catches an in-flight client refresh that lands just after the move.
+
+Boot-recovery of an interrupted swap is the next step (5c).
+
+## What to Tell Your User
+
+Nothing changes for you right now — this is the core of the upcoming restartless subscription rebalancing, still shipping switched off. This is the machinery that will let me move an account's login from one slot to another without a restart and without ever risking the login: it keeps a safety copy until the move is verified, it checks the move landed on the right account before trusting it, and if it can't be sure, it quarantines that slot and tells you rather than guessing. You won't see anything until the feature is explicitly turned on, and even then the worst-case failure is a single "please re-log-in" with the right account named — never a silent breakage.
+
+## Summary of New Capabilities
+
+| Capability | How to Use |
+|-----------|-----------|
+| Staged, crash-safe credential swap | Automatic (internal) — not callable until the feature gate is enabled |
+| Identity-verified move (quarantine if unsure) | Automatic (internal) — an unverifiable slot is excluded, never trusted blind |
+| Adopt-on-newer source re-read | Automatic (internal) — never overwrites a freshly-rotated login with a stale one |
+
+## Evidence
+
+- 8 new unit tests (`credential-swap-executor.test.ts`): happy-path exchange + ledger update + staging freed on clean re-verify; precondition rejects (same/unknown/quarantined); the §2.3.4 oracle-unavailable→quarantine-NOT-repair invariant; confirmed-mismatch repair-once-then-quarantine and repair-succeeds paths; staging-is-a-copy (slot untouched on a failed exchange write); §2.3.1a adopt-on-newer; single-mover serialization.
+- `npx tsc --noEmit` clean; full `npm run lint` clean; 231 credential/oauth/quota/account-switcher tests green.
+- Independent second-pass review (the highest-risk file in the increment) — verdict recorded in the side-effects artifact.

--- a/upgrades/next/live-credential-repointing-increment-a-swap-foundation.md
+++ b/upgrades/next/live-credential-repointing-increment-a-swap-foundation.md
@@ -1,0 +1,27 @@
+# Upgrade Guide — Live credential re-pointing (Increment A, Step 5a)
+
+<!-- bump: patch -->
+
+## What Changed
+
+Step 5a of the live-credential-repointing build, shipping **dark** — the two crash-safety primitives the swap executor (Step 5b) builds on. Nothing calls them yet, so there is zero runtime behavior change.
+
+- `CredentialKeychainIO` — async, 10s-bounded `security` keychain read/write/delete (the swap must not use the synchronous credential store, which can wedge the event loop on a locked keychain). The credential blob is written via the `security -i` stdin form so it never appears in the process list. Defines the swap staging namespace `instar-credential-swap-staging-<swapId>`, provably disjoint from every real Claude credential service so a staged escrow copy can never be read by a client.
+- `CredentialSwapJournal` — the durable in-flight swap record carrying the `swapId`, both slots, both pre-swap account ids, and the staging reference, so a crash mid-swap is fully decidable. A non-terminal phase keeps the staging escrow alive (it is the recovery heal source); only a completed re-verify marks the swap done and frees staging.
+
+## What to Tell Your User
+
+Nothing changes for you right now — this is more internal groundwork for the upcoming restartless subscription rebalancing, shipping switched off. This step adds the crash-safety machinery that will let a credential move survive a process restart or a power loss mid-move without ever stranding a login: an escrow copy is held until the move is confirmed good, and a durable record makes every interruption point recoverable. You won't see any difference until the feature is explicitly turned on.
+
+## Summary of New Capabilities
+
+| Capability | How to Use |
+|-----------|-----------|
+| Async bounded keychain I/O for the swap | Automatic (internal) — never blocks the event loop on a stuck keychain |
+| Disjoint staging namespace | Automatic (internal) — escrow copies can never be read as a real login |
+| Durable in-flight swap journal | Automatic (internal) — a crash mid-move is recoverable |
+
+## Evidence
+
+- 15 new unit tests (`credential-swap-journal.test.ts` 8, `credential-keychain-io.test.ts` 7): the journal's in-flight/terminal phase semantics + disk-reload recovery + idempotent restart; the staging-namespace disjoint invariant across many config homes; the async read null-on-error contract (cross-platform, no keychain write).
+- `npx tsc --noEmit` clean; the credential-write lint clean (with `CredentialKeychainIO.ts` allowlisted as a primitive owner); closed-allowlist self-test updated.

--- a/upgrades/next/live-credential-repointing-increment-a-swap-recovery.md
+++ b/upgrades/next/live-credential-repointing-increment-a-swap-recovery.md
@@ -1,0 +1,33 @@
+# Upgrade Guide — Live credential re-pointing (Increment A, Step 5c)
+
+<!-- bump: patch -->
+
+## What Changed
+
+Step 5c — boot-recovery for an interrupted credential swap, shipping **dark**. `CredentialSwapExecutor.recoverInFlight()` resolves any swap left in-flight by a crash or power loss; nothing wires it at startup until the feature is enabled, so there is zero runtime behavior change (and it is a no-op when no swap is in flight).
+
+For each interrupted swap, under the same single-mover + per-slot locks a live swap uses, it verifies both slots against the intended end state by ACCOUNT IDENTITY and:
+- both slots already correct → finishes it (frees the safety copy, marks done);
+- both slots still in their original state → aborts cleanly (nothing moved);
+- genuinely half-done (a crash between the two writes) → reconstructs the move from the retained safety copy + the live blobs (never overwriting a freshly-rotated login), re-verifies, and commits;
+- can't be sure (the identity check is down, or a credential is missing) → quarantines that slot, keeps the safety copy, and flags it — never guesses.
+
+This closes the crash-safety story the staging escrow + journal set up in 5a/5b, and handles the two partial-state cases the Step-5b safety review flagged.
+
+## What to Tell Your User
+
+Nothing changes for you right now — this is the safety net for the upcoming restartless rebalancing, still shipping switched off. It means that if the machine ever crashed or lost power in the middle of moving a login between slots, the next startup would automatically put things right: finish the move if it was basically done, undo it if it hadn't really started, or carefully rebuild it from the safety copy if it was caught halfway — and if it couldn't be certain, it would set that slot aside and tell you rather than risk a wrong guess. You won't see any of this unless something needs your attention, and the worst case is still a single "please log in again" with the correct account named.
+
+## Summary of New Capabilities
+
+| Capability | How to Use |
+|-----------|-----------|
+| Boot-recovery of an interrupted credential swap | Automatic (internal) — resolves any crash-interrupted move at startup |
+| Half-done move reconstruction (adopt-on-newer) | Automatic (internal) — rebuilds from the safety copy without clobbering a rotated login |
+| Quarantine-rather-than-guess on uncertainty | Automatic (internal) — an unverifiable slot is set aside + flagged, never trusted blind |
+
+## Evidence
+
+- 6 new unit tests (`credential-swap-recovery.test.ts`) over a keychain-backed oracle (so the partial-state transitions are exercised realistically): empty-journal no-op; committed→completes (frees staging); begin+pre-swap→aborts; exchanged+partial→re-drives to the intended state and commits; oracle-unavailable→quarantine+retain; a live swap holding the mutex→reported busy (retry next sweep).
+- `npx tsc --noEmit` clean; the credential-write lint clean; the executor's 10 tests still green (16 swap tests total).
+- Independent second-pass review of the destructive re-drive path — verdict recorded in the side-effects artifact.

--- a/upgrades/side-effects/live-credential-repointing-increment-a-swap-executor.md
+++ b/upgrades/side-effects/live-credential-repointing-increment-a-swap-executor.md
@@ -1,0 +1,67 @@
+# Side-Effects Review — Live credential re-pointing (Increment A, Step 5b: CredentialSwapExecutor)
+
+**Version / slug:** `live-credential-repointing-increment-a-swap-executor`
+**Date:** `2026-06-13`
+**Author:** `echo`
+**Second-pass reviewer:** `required` (this is the piece that actually MOVES a credential — the highest-blast-radius code in the increment; result appended below)
+
+## Summary of the change
+
+`src/core/CredentialSwapExecutor.swap(slotA, slotB)` — the staged, identity-verified, repair-safe credential exchange (spec §2.3), built on the Step-5a primitives (async keychain I/O + the durable swap journal) + the Step-4b funnel. Plus `credential-swap-executor.test.ts` (8 tests). Ships **DARK**: nothing calls `swap()` until the feature gate is enabled; boot-recovery of an in-flight journal row is Step 5c.
+
+Flow (each safety property earned in spec review):
+1. **Preconditions** — both slots must be EXACT ledger members (rejected `unknown-slot` otherwise, before any path expansion), neither tenant quarantined, same-slot rejected. The whole body runs under `withSingleMover` (one swap at a time) + `withSlotLocks([keyA,keyB])` (canonical order, deadlock-free) so it can't interleave with a refresh (Step 4b) or another swap.
+2. **Source-slot CAS re-read (§2.3.1a)** — re-read each slot immediately before the destructive write; a changed-and-parseable blob is ADOPTED (the client's freshest rotated copy) so a stale blob never overwrites a newer one. A changed-but-unparseable blob aborts (no garbage staged).
+3. **Staging escrow (§2.3.2)** — COPY blob A to the disjoint `instar-credential-swap-staging-<swapId>` namespace, then journal `begin`. A COPY (not a move): slot A is untouched until the first exchange write, so a crash before it unwinds to a no-op (unit-tested).
+4. **Exchange** — write B→slotA, A→slotB (keychain first); metadata (`oauthAccount`) follows best-effort (a metadata failure is repairable → attention, NEVER quarantine). A keychain write failure mid-exchange returns `exchange-write-failed` and leaves the journal+staging for recovery.
+5. **Verify on ACCOUNT IDENTITY (§2.3.4)** — the oracle, never token bytes. **Oracle-UNAVAILABLE is treated as 'unavailable', NEVER 'mismatch'**: an unreachable/ambiguous oracle quarantines the slot and STOPS (no repair write). A CONFIRMED mismatch (a reachable oracle returning a different KNOWN account) repairs ONCE from the known-good blob, re-verifies, and quarantines if still wrong.
+6. **Commit + delayed re-verify (§2.3.5/6)** — ledger `recordAssignment` for both slots, journal `committed`, **staging RETAINED**. A scheduled (~90s) re-verify frees staging + journals `done` ONLY on a clean both-slots-ok result; any drift quarantines the unconfirmed slot and KEEPS staging (the heal source) — never a blind overwrite.
+
+## Decision-point inventory
+
+- `swap()` preconditions — **add** — reject a non-ledger-member slot / quarantined tenant. A structural guard against turning the (later) route into an arbitrary keychain-write primitive.
+- Verify quarantine vs repair — **add** — the §2.3.4 unavailable-vs-mismatch decision: the single most dangerous ambiguity; the executor fails CLOSED (quarantine) on any non-confirming oracle outcome.
+- These are mechanism with a deny-by-default bias; none gates messaging/dispatch. The swap NEVER runs while dark.
+
+---
+
+## 1. Over-block
+The swap refuses (non-destructively) on: same-slot, unknown-slot, quarantined tenant, swap-in-flight (single-mover busy), slot-busy (lock timeout), an unparseable/refresh-tokenless blob, a staging-write failure. Each is a precondition that must hold for a SAFE exchange; refusing is the correct conservative action (the alternative is a corrupting half-swap). None rejects a legitimate ready-to-swap pair. While dark, `swap()` is never called, so no real input is ever refused.
+
+## 2. Under-block
+The executor cannot move a credential it was not asked to, and cannot move one whose identity it cannot confirm post-swap (an unconfirmable slot is quarantined, not left silently wrong). The residual the spec states honestly: identity-verify proves OWNERSHIP, not refreshability — a blob with the right tenant but a stale (server-rotated) refresh token passes identity yet is doomed at next expiry; the always-on identity audit (§2.4, a later step) + the §2.3.6 delayed re-verify are what catch that strand, not this verify alone. Documented, not hidden.
+
+## 3. Level-of-abstraction fit
+Correct layer. A `src/core` orchestrator composing the existing primitives (ledger, oracle, funnel, keychain I/O, swap journal) — it invents no new low-level mechanism. It is deliberately the ONLY place the exchange sequence lives, so the crash-decidability reasoning has one home. Verification is delegated to the oracle (Step 3); locking to the funnel (Step 4); bookkeeping to the ledger (Step 2) + the swap journal (Step 5a).
+
+## 4. Signal vs authority compliance
+Compliant. The executor holds authority over credential MOVEMENT, but its decision logic is not brittle: every branch is a deterministic, fail-closed response to a concrete observed state (a parse result, a lock outcome, an oracle verdict). The dangerous direction (repair on an oracle outage) is structurally excluded — `verifySlotIdentity` collapses every non-confirming outcome to 'unavailable', and 'unavailable' never repairs. No content heuristic gates anything.
+
+## 5. Interactions
+- **Funnel (Step 4b):** the swap takes the SAME per-slot lock (via `credentialSlotKey`) the refresh write takes, so a refresh and a swap on a slot genuinely serialize — the reason Step 4b shipped first. Verified by the single-mover serialization test.
+- **Ledger (Step 2):** commit calls `recordAssignment` (which enforces one-home-per-credential); quarantine calls `quarantineSlot`. The swap journal is SEPARATE from the ledger journal (it carries `stagingRef` + pre-swap accounts for recovery).
+- **External claude client:** the unlockable interleaving is a client refresh-write between the CAS re-read and the exchange write — narrowed (not closed) by §2.3.1a, with the delayed re-verify + identity audit as the honest backstop.
+- No double-fire: the single-mover mutex guarantees one swap at a time machine-wide.
+
+## 6. External surfaces
+While dark: none (no caller). Once enabled: the macOS keychain on THIS machine (slot + staging services), two local files (the swap journal state + jsonl history), and a HIGH attention item on a quarantine/verify-failure (operator-visible, deduped per swapId). No network beyond the oracle's existing read-only profile call. No new routes in this step (routes are Step 7).
+
+## 7. Multi-machine posture (Cross-Machine Coherence)
+**Machine-local BY DESIGN.** A swap moves credentials within ONE machine's keychain; the single-mover mutex, the per-slot locks, the swap journal, and the staging escrow are all per-machine and must be — they protect a per-machine keychain. Cross-machine coordination of a topic transfer mid-swap is the existing handoff guard's job (the journal-in-flight slots are excluded from placement/polling/balancing until resolved — wired with the balancer in Increment B); this executor does not replicate state, and a swap on machine A is independent of machine B's keychain (separate login lineages).
+
+## 8. Rollback cost
+Low while dark. Plain `git revert` of this commit removes the executor; no consumer, no migration, no persisted state created at runtime (the journal/staging are written only once `swap()` runs, which requires the gate ON). If the feature were enabled and a swap misbehaved, the back-out is: disable the gate (`enabled:false`), and any in-flight journal row + retained staging is reconciled by the Step-5c boot recovery (adopt-on-newer, never a blind overwrite). The blast radius of a worst-case unrecoverable clobber is ONE account re-auth (§6), with the correct account flagged — never silent.
+
+---
+
+## Second-pass review
+
+_Appended by the dedicated independent reviewer subagent (Phase 5), 2026-06-13._
+
+**VERDICT: CONCERN → both findings FIXED in this commit (not deferred).** The reviewer ran 5 adversarial probes against a hermetic harness and **confirmed the dangerous invariants hold**: the §2.3.4 unavailable-vs-mismatch invariant is airtight (no path turns a non-confirming oracle into a destructive write, including at the delayed re-verify); the §2.3.1a CAS adopt is safe within the threat model and defended by step-4 verify even outside it; the slotA repair-from-in-memory cannot clobber a newer same-account rotation (that rotation verifies `ok` and skips repair). It raised two real, bounded defects (max severity = spurious quarantine / contract violation, never credential loss):
+
+1. **`delayedReVerify` ran OUTSIDE the single-mover + per-slot locks** — its mutating tail (`keychain.delete(stagingRef)`, `ledger.quarantineSlot`) raced a concurrent swap/refresh on the same slots, contradicting spec §2.3 line 471 ("recovery WRITES acquire the single-mover mutex AND the per-slot locks like any swap"). **FIXED:** `delayedReVerify` now runs its whole verify+write body inside `withSingleMover` → `withSlotLocks([keyA,keyB])`; on a lock-skip (a move in flight) it RE-SCHEDULES (bounded by `MAX_REVERIFY_RESCHEDULES`) and leaves staging in place rather than acting on a stale view. New test: a held single-mover makes the re-verify re-schedule (staging NOT deleted) until the mover frees.
+
+2. **No `isUnknownMode()` precondition** — `getAssignment()` is not unknownMode-guarded, so a corrupt ledger with populated assignments could pass preconditions and then THROW at the commit `recordAssignment` AFTER the keychain was already exchanged, violating the "never throws on a normal path" contract. **FIXED:** `swap()` now refuses upfront with `reason: 'ledger-unknown-mode'` when the ledger is in UNKNOWN mode, AND the whole mover body is wrapped in a try/catch that maps any unexpected throw to `reason: 'internal-error'` (the journal+staging left at phase `exchanged` are reconciled by Step-5c recovery). New test: a corrupt ledger → `ledger-unknown-mode`, keychain untouched.
+
+The reviewer also flagged that **Step 5c (boot recovery) MUST handle the "phase=`exchanged`, credentials already exchanged, ledger partially/not updated" case** (a crash between the two `recordAssignment` calls leaves slotA=accountB, slotB absent via one-home enforcement; the journal at `exchanged` + on-disk credentials make it re-derivable) and the UNKNOWN-mode interaction during recovery's own `recordAssignment`. Both are recorded in the build-plan Step-5c resume notes. Spec-acknowledged residuals (metadata best-effort fire-and-forget; identity-proves-ownership-not-refreshability) were confirmed correctly handled, not defects.

--- a/upgrades/side-effects/live-credential-repointing-increment-a-swap-foundation.md
+++ b/upgrades/side-effects/live-credential-repointing-increment-a-swap-foundation.md
@@ -1,0 +1,47 @@
+# Side-Effects Review — Live credential re-pointing (Increment A, Step 5a: swap I/O + journal foundation)
+
+**Version / slug:** `live-credential-repointing-increment-a-swap-foundation`
+**Date:** `2026-06-13`
+**Author:** `echo`
+**Second-pass reviewer:** `not required` (primitives only — no swap logic, no consumer, no live write path; the Step-5b executor that drives them carries the second-pass — see §4)
+
+## Summary of the change
+
+The two crash-safety primitives the Step-5b `CredentialSwapExecutor` will build on, plus their tests. No swap is performed and nothing calls them yet, so this commit changes no runtime behavior and writes no credentials.
+
+- **`src/core/CredentialKeychainIO.ts`** — async, 10s-bounded `security` read/write/delete (spec §2.3: the existing sync `defaultCredentialStore` can wedge the event loop on a locked keychain). The credential blob is written via the `security -i` stdin (hex) form, never as a `-w <blob>` argv argument, so it never appears in the process list. Exposes the **staging namespace** `instar-credential-swap-staging-<swapId>` with `assertStagingDisjoint()` pinning the §2.3.2 invariant that staging can never collide with a `claudeCredentialService` output.
+- **`src/core/CredentialSwapJournal.ts`** — the durable in-flight swap record (distinct from the ledger's assignment journal): carries `swapId`, both slots, both pre-swap account ids, and `stagingRef` so a crash mid-swap is decidable. Phases `begin → exchanged → committed → done` (+ `aborted`); a non-terminal phase keeps the swap (and its staging escrow) in the in-flight set per the §2.3.2 sweep predicate ("`begin` AND `committed` both keep staging alive; only `done` orphans it"). Atomic tmp+rename state file; size-rotated `logs/credential-swaps.jsonl` history when a `logsDir` is configured.
+- Allowlists `CredentialKeychainIO.ts` in `lint-no-unfunneled-credential-write.js` (it owns the raw keychain write for the slot + staging services; its writes are driven only by the executor inside the funnel) and updates the lint test's closed-allowlist assertion.
+- Tests: `credential-swap-journal.test.ts` (8) + `credential-keychain-io.test.ts` (7).
+
+## Decision-point inventory
+
+- None. Both modules are mechanism: bounded I/O and a bookkeeping record. Neither gates agent behavior, filters a message, or blocks an action. No swap decision is made here (that is the Step-5b executor).
+
+---
+
+## 1. Over-block
+No block/allow surface. The only "refusal" is `assertStagingDisjoint` throwing if the staging prefix were ever changed to collide with the Claude namespace — a build-invariant guard, not a runtime content decision. Unreachable with the shipped prefixes.
+
+## 2. Under-block
+No block/allow surface. The journal cannot mis-classify an in-flight swap: `isTerminalPhase` is total over the phase union and unit-tested on both sides. The keychain I/O returns `null`/`false` on every error (absent entry, missing binary, timeout) — it never throws a surprise.
+
+## 3. Level-of-abstraction fit
+Correct layer. A `src/core` async I/O primitive + a durable recovery record — the same layer as `defaultCredentialStore` and `CredentialLocationLedger`. The journal is deliberately SEPARATE from the ledger journal because it carries swap-recovery material (`stagingRef`, pre-swap account ids) the ledger journal does not; conflating them would overload the ledger's assignment bookkeeping.
+
+## 4. Signal vs authority compliance
+Compliant — pure mechanism, no authority. Neither module decides anything about agent behavior. **Second-pass review: not required** under Phase 5 (no consumer, no live write path, no messaging/dispatch/session decision — the same basis as Step 4a's funnel primitive). The point where these gain real authority over credential movement is **Step 5b** (the `swap()` executor) and that commit carries the full second-pass review.
+
+## 5. Interactions
+- **No consumers yet** — nothing calls the keychain I/O or the journal in this commit, so they cannot race, shadow, or double-fire against any existing path.
+- The staging namespace is provably disjoint from every `claudeCredentialService` output (unit-tested over many homes), so a staged blob can never be read by a `claude` client or the QuotaPoller — the §0.d "readable from two config homes" hazard cannot originate from staging.
+- The journal's atomic tmp+rename mirrors the ledger/SubscriptionPool persistence pattern; a crash during save leaves the prior file intact.
+
+## 6. External surfaces
+None reachable in this commit (no caller). The keychain I/O, once driven by the executor, will touch the macOS keychain on THIS machine only; the journal writes two local files (`state/credential-swaps.json`, `logs/credential-swaps.jsonl`). No routes, no network, no notices, nothing visible to other agents/users.
+
+## 7. Multi-machine posture (Cross-Machine Coherence)
+**Machine-local BY DESIGN.** Keychain entries and the swap journal are per-machine: a swap moves credentials within ONE machine's keychain, and its recovery record must live beside the keychain it heals. There is no shared state to replicate; a credential move on machine A is independent of machine B's keychain (each has its own login lineage). Cross-machine coordination of a topic move mid-swap is the existing handoff guard's job, wired in a later step — not these primitives'.
+
+## 8. Rollback cost
+Near-zero. Two new files + tests + one lint allowlist line; no consumers, no writes, no migration, no persisted state created at runtime (the files are only written once the executor runs). Plain `git revert` leaves no behavior change.

--- a/upgrades/side-effects/live-credential-repointing-increment-a-swap-recovery.md
+++ b/upgrades/side-effects/live-credential-repointing-increment-a-swap-recovery.md
@@ -1,0 +1,69 @@
+# Side-Effects Review — Live credential re-pointing (Increment A, Step 5c: boot-recovery sweep)
+
+**Version / slug:** `live-credential-repointing-increment-a-swap-recovery`
+**Date:** `2026-06-13`
+**Author:** `echo`
+**Second-pass reviewer:** `required` (recovery performs destructive credential WRITES from a partial state — the re-drive; result appended below)
+
+## Summary of the change
+
+`CredentialSwapExecutor.recoverInFlight()` (+ `credential-swap-recovery.test.ts`, 6 tests) — the boot-recovery sweep that resolves a swap interrupted by a crash. Ships **DARK** (no caller wires it until the feature is enabled / a later step wires it at server start; it is a NO-OP when the journal has no in-flight swaps).
+
+For each in-flight journal swap, under the single-mover mutex + both per-slot locks (recovery WRITES take the locks, spec §2.3 line 471):
+1. Verify both slots against the INTENDED post-swap identity (oracle).
+2. **Oracle unavailable for either** → quarantine that slot, retain staging, defer (`deferred-oracle-unavailable`) — never guess.
+3. **Both slots already intended** → finish: idempotent `recordAssignment`, delete staging, journal `done` (`completed`) — this is the lost-delayed-re-verify case AND the reviewer-flagged "phase=committed crash".
+4. **Both slots still pre-swap** → nothing took: delete staging, journal `aborted` (`aborted-noop`); the ledger already reflects pre-swap.
+5. **Genuinely partial** (a crash between the two exchange writes) → `reDriveRecovery`: accountA's blob = the staging escrow; accountB's blob = whichever slot currently identity-verifies as accountB (its CURRENT bytes — adopt-on-newer); write accountB→slotA, accountA→slotB, re-verify; clean → commit + delete staging + `done` (`re-driven`); else quarantine + retain staging.
+
+Addresses both Step-5b second-pass-flagged recovery cases: the partial-commit (`recordAssignment` is idempotent, so re-committing reconciles a crash between the two commit writes) and the UNKNOWN-mode interaction (`recoverInFlight` re-seeds via `seedFromOracle()` first; `commitRecovered` skips the write if the ledger is still corrupt, never throwing).
+
+## Decision-point inventory
+- The recovery resolution per swap (completed / aborted / re-driven / deferred / quarantined) — **add** — a deterministic, fail-closed classification of an interrupted swap against on-disk + oracle truth. The dangerous direction (writing a credential it cannot verify) is excluded: a re-drive whose re-verify fails quarantines rather than trusting the write.
+
+---
+
+## 1. Over-block
+Recovery quarantines (excludes from balancing) any slot it cannot confirm: an unavailable oracle, an unlocatable escrow/blob, or a re-drive that still fails verification. Quarantine is the conservative action — the alternative (trusting an unverifiable credential) is the corruption this prevents. A quarantine is lifted by the §2.4 re-probe when the oracle returns. No legitimate, verifiable swap is left unresolved.
+
+## 2. Under-block
+Recovery cannot silently leave a swap half-done: every in-flight journal row is resolved to a terminal phase (`done`/`aborted`) OR explicitly quarantined-and-retained (staging kept as the heal source) OR deferred `busy` (a live swap holds the locks — retried next sweep). The documented residual: a staging entry whose JOURNAL ROW was lost (a corrupt journal) is not enumerated here — it is harmless (the disjoint namespace is never read by a client) and would need a keychain-enumeration sweep, noted as a future refinement, not a recovery hazard.
+
+## 3. Level-of-abstraction fit
+Correct layer — recovery lives on the executor that owns the swap lifecycle, reusing its `verifySlotIdentity` / lock / journal / ledger surfaces. The keychain-backed-oracle test harness exercises the partial-state transitions realistically rather than with a hardcoded verdict.
+
+## 4. Signal vs authority compliance
+Compliant. Recovery holds authority over completing/reverting an interrupted move, but every branch is a deterministic response to a concrete observed state (oracle verdict + on-disk blobs). The §2.3.4 invariant is preserved end-to-end: an unavailable oracle NEVER triggers a recovery write — it quarantines and defers. The re-drive only ever writes blobs it located by identity (adopt-on-newer), and re-verifies before committing.
+
+## 5. Interactions
+- **Locks:** recovery acquires the SAME single-mover + per-slot locks a live swap/refresh uses, so it can't race them (the Step-5b second-pass fix, applied here from the start). A live swap holding the mover yields `busy` (retry), never a forced action on a stale view.
+- **Ledger:** `commitRecovered` is idempotent and unknownMode-guarded. `recoverInFlight` re-seeds a corrupt ledger first.
+- **Journal:** drives off `journal.inFlight()`; resolves each to a terminal phase or leaves it for the next sweep. No double-resolution (terminal phases drop out of `inFlight()`).
+
+## 6. External surfaces
+While dark / unwired: none. Once wired at boot: the macOS keychain (slot + staging services) on THIS machine, the ledger + swap-journal files, and a HIGH attention item on a quarantine. No network beyond the oracle's read-only probe.
+
+## 7. Multi-machine posture (Cross-Machine Coherence)
+**Machine-local BY DESIGN.** Recovery heals a per-machine keychain from a per-machine journal; both are machine-local and must be. A swap on machine A and its recovery are independent of machine B. The journal-in-flight slots being excluded from placement/poll/balancing until resolved (a later wiring step) is the cross-machine-safe posture — a half-recovered slot is never handed work.
+
+## 8. Rollback cost
+Low while unwired. `git revert` removes the recovery methods + test; no caller, no migration, no persisted state. Once wired, a misbehaving recovery is bounded by the same quarantine-rather-than-guess discipline (worst case: a spurious quarantine, recoverable via the §2.4 re-probe) — it can only write a blob it located by identity and re-verified.
+
+---
+
+## Second-pass review
+
+_Appended by the dedicated independent reviewer subagent (Phase 5), 2026-06-13._
+
+**VERDICT: CONCUR — no real defect found.** The reviewer traced every partial-crash interleaving against the real ledger/funnel/keychain primitives and confirmed:
+- **§2.3.4 preserved end-to-end** — no `unavailable`→write path exists; `reDriveRecovery` only sets `blobBLoc` on a confirmed `'ok'` probe, so an oracle outage mid-re-drive → quarantine, no write.
+- **Every partial-crash interleaving reaches the correct end state** — no-write crash → `aborted-noop`; `blobB→slotA` only → re-drive to intended + commit; both writes done → `completed` (idempotent re-commit); a client rotation during the crash window → recovery reads pre-swap-by-identity → `aborted-noop`, preserving the client's newer blob (no strand).
+- **The unconditional `staging→slotB` write cannot strand a newer accountA** — slotB can only hold accountA if the swap's own `blobA→slotB` write completed, which routes to `completed` (never re-drive); the client can't deposit newer-accountA at slotB because accountA is config-pointed at slotA until the swap completes.
+- **commitRecovered partial-commit** is correctly reconciled — the journal advances to `done` only AFTER both `recordAssignment` calls, so a crash between them leaves the swap in-flight and the next boot re-runs `completed` → re-establishes both rows; slots are placement-excluded throughout.
+- Idempotency/double-run/`busy` all safe; the entire resolve+write body runs inside `withSingleMover` → `withSlotLocks`; genuinely dark (no caller in `src/`).
+
+Two **minor, non-blocking** observations (no fix required for this dark commit):
+1. `seedFromOracle()` in `recoverInFlight` runs (awaited, before the per-swap loop) OUTSIDE the single-mover mutex. No intra-method race; the cross-component balancer race is the recovery-complete barrier's job — **recorded as an Increment-B wiring requirement: the barrier must gate the balancer before the unmutexed `seedFromOracle` runs.**
+2. No unit test exercises the v1-vs-v2 stale-refresh-token strand (the harness uses single-version blobs) — but that IS the spec-acknowledged §2.3.1a residual that identity-verify provably cannot catch, so a unit test couldn't assert a non-strand; it is the §2.4 audit's job (a later step).
+
+The reviewer found the author's review accurate on every claim checked, including both Step-5b-flagged cases (idempotent re-commit; UNKNOWN-mode re-seed + `commitRecovered` skip-on-corrupt).


### PR DESCRIPTION
## ELI16 — what this does in plain words

This is the machinery that will let the agent move an account's login from one "slot" to another **without a restart** — the heart of the upcoming use-it-or-lose-it subscription rebalancing. It ships switched **off**, so nothing changes for users yet. The hard part is doing the move safely: a login lives in the system keychain, and two things can race to touch it (a background token refresh, and this move). So the move (a) keeps a safety **copy** of the credential until the move is confirmed good, (b) writes down every step in a durable journal so a crash or power-loss mid-move is recoverable, (c) checks — by asking Anthropic "which account does this login belong to?" — that the move landed on the **right account** before trusting it, and (d) if it ever can't be sure (the check is down, or the answer is wrong), it **quarantines** that slot and flags it for you rather than guessing. The worst case it allows is a single "please log in again" with the correct account named — never a silent breakage of a working login. Two safety reviewers traced it; the second found two real (bounded) bugs in the timing/locking, both fixed here before merge.

---

**Increment A, Steps 5a + 5b** of live credential re-pointing (Subscription & Auth Standard). Continues #1114 (1–4a) and #1126 (4b). Ships **dark** (gate off + dry-run; nothing calls the executor until enabled).

## Step 5a — crash-safety foundation
- **`CredentialKeychainIO`** — async, 10s-bounded `security` read/write/delete (the swap can't use the sync store, which can wedge the event loop on a locked keychain). Blob written via `security -i` stdin/hex, never in argv. Defines the staging namespace `instar-credential-swap-staging-<swapId>`, provably disjoint from every real Claude credential service (`assertStagingDisjoint`).
- **`CredentialSwapJournal`** — the durable in-flight swap record (swapId, both slots, both pre-swap account ids, stagingRef) — distinct from the ledger journal. A non-terminal phase keeps the staging escrow alive (§2.3.2 sweep predicate).

## Step 5b — `CredentialSwapExecutor.swap(slotA, slotB)`
Runs under `withSingleMover` + `withSlotLocks([keyA,keyB])`:
1. preconditions (exact ledger membership; **unknown-mode** / same / quarantined rejected);
2. §2.3.1a source-slot CAS re-read (adopt a newer client-rotated blob, never overwrite it with a stale one);
3. staging escrow **COPY** + journal `begin` (a crash before the first exchange write is a no-op);
4. exchange B→slotA, A→slotB (metadata follows best-effort, repairable, never quarantine);
5. **verify on ACCOUNT IDENTITY** via the oracle — **oracle-UNAVAILABLE is never treated as mismatch** (it quarantines and stops; it never triggers a destructive repair); a confirmed mismatch repairs once then quarantines;
6. commit (ledger + journal `committed`, **staging retained**) → a **locked** delayed re-verify (~90s) → clean → `done` + delete staging; drift → quarantine + retain.

## Second-pass review (the highest-risk file)
An independent reviewer ran 5 adversarial probes and confirmed the dangerous invariants hold (§2.3.4 unavailable≠mismatch airtight; CAS adopt safe; repair can't clobber a newer same-account rotation). It raised **two bounded defects, both FIXED in this PR**:
- `delayedReVerify` ran outside the locks (its delete/quarantine tail raced a concurrent swap) → now takes the single-mover + per-slot locks, bounded re-schedule on lock-skip;
- no `isUnknownMode()` precondition (a corrupt ledger could throw after the keychain was exchanged) → now refused upfront + a try/catch maps any unexpected throw to a structured outcome.

Full review + the Step-5c recovery notes it surfaced are in the side-effects artifacts.

## Tests
- `credential-keychain-io` (7), `credential-swap-journal` (8), `credential-swap-executor` (10, incl. both 2nd-pass-fix tests).
- `tsc --noEmit` clean; full `npm run lint` clean; 233 credential/oauth/quota/account-switcher tests green; pre-push smoke green.

Spec: `docs/specs/live-credential-repointing-rebalancer.md` (approved, converged). Resume points at Step 5c (boot recovery).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
