### PR TITLE
feat(subscription-pool): live-credential-repointing Step 6 — census consumer re-routing (dark)

### DIFF
--- a/.instar/instar-dev-decisions/2026-06-13T19-47-00-948Z-ws52-step6-census-rerouting.json
+++ b/.instar/instar-dev-decisions/2026-06-13T19-47-00-948Z-ws52-step6-census-rerouting.json
@@ -1,0 +1,16 @@
+{
+  "ts": "2026-06-13T19:47:00.948Z",
+  "slug": "ws52-step6-census-rerouting",
+  "suggestedTier": 2,
+  "declaredTier": null,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "new capability: new exported class / subsystem added",
+    "new capability: new config key added"
+  ],
+  "belowFloor": false,
+  "files": 9,
+  "loc": 468,
+  "causalAutopsy": null,
+  "verdict": "pass"
+}

--- a/src/commands/server.ts
+++ b/src/commands/server.ts
@@ -9145,6 +9145,61 @@ export async function startServer(options: StartOptions): Promise<void> {
       console.log(pc.green(`  Subscription pool: ${subscriptionPool.size()} account(s) registered`));
     }
 
+    // ── Live credential re-pointing — census consumer re-routing (WS5.2 Step 6) ──
+    // The CredentialLocationLedger is the machine-local source of truth for "which account is in
+    // which config-home slot" once re-pointing is enabled. The CredentialLocationGate re-routes
+    // the §2.2 census consumers (quota poll, spawn placement, in-use badge) through it. Ships DARK:
+    // the gate reads `subscriptionPool.credentialRepointing.enabled` LIVE per call — with the flag
+    // off (always, while dark) every gate read returns the enrollment-home fallback, so every
+    // consumer is byte-for-byte today's behavior. A never-seeded ledger is the same fallback (back-
+    // compat); only UNKNOWN mode (corrupt on-disk) raises a HIGH attention item, never throws.
+    const { CredentialLocationLedger } = await import('../core/CredentialLocationLedger.js');
+    const { CredentialIdentityOracle } = await import('../core/CredentialIdentityOracle.js');
+    const { CredentialLocationGate } = await import('../core/CredentialLocationGate.js');
+    const credentialGateEmitAttention = telegram
+      ? (item: import('../core/CredentialLocationGate.js').CredentialGateAttentionInput) =>
+          void telegram!.createAttentionItem({
+            id: item.id,
+            title: item.title,
+            summary: item.summary,
+            description: item.description,
+            category: item.category,
+            priority: item.priority,
+            sourceContext: item.sourceContext,
+          })
+      : undefined;
+    const credentialLocationLedger = new CredentialLocationLedger({
+      stateDir: config.stateDir,
+      pool: subscriptionPool,
+      oracle: new CredentialIdentityOracle(),
+      emitAttention: credentialGateEmitAttention,
+    });
+    const credentialLocationGate = new CredentialLocationGate({
+      // Live flag read — a restartless config flip is honored on the next read.
+      isEnabled: () => config.subscriptionPool?.credentialRepointing?.enabled === true,
+      ledger: credentialLocationLedger,
+      emitAttention: credentialGateEmitAttention,
+    });
+    // Census #9: the manager-level competing-writer refusal gate. Installed process-wide so
+    // AccountSwitcher / `/switch-account` / autoMigrate refuse a write to a repointing-owned slot
+    // at the funnel chokepoint, not just on a route. Refuses ONLY when re-pointing is enabled AND
+    // the ledger holds a tenant for the (canonicalized) slot.
+    const { setCredentialWriteRefusalGate } = await import('../monitoring/CredentialProvider.js');
+    const { credentialSlotKey: canonicalizeSlot } = await import('../core/OAuthRefresher.js');
+    setCredentialWriteRefusalGate({
+      shouldRefuse: (canonicalSlot: string) => {
+        if (config.subscriptionPool?.credentialRepointing?.enabled !== true) return false;
+        // The funnel passes a canonicalized slot key, but the ledger stores raw enrollment-home
+        // spellings (`~/.claude`, an enrollment path). Compare canonical-to-canonical so a
+        // repointing-owned slot is recognized regardless of spelling.
+        return credentialLocationLedger
+          .getAssignments()
+          .some((a) => !!a.accountId && canonicalizeSlot(a.slot) === canonicalSlot);
+      },
+    });
+    // Census #5/#6: spawn placement resolves a pinned account's home through the gate (no-op dark).
+    sessionManager.setCredentialLocationGate(credentialLocationGate);
+
     // QuotaPoller — per-account live quota reader (P1.2 of the Subscription &
     // Auth Standard). Reads each account's 5h/weekly utilization + reset dates
     // via the OAuth usage endpoint (transient per-account token, never persisted)
@@ -9156,6 +9211,8 @@ export async function startServer(options: StartOptions): Promise<void> {
     const quotaPoller = new QuotaPoller({
       pool: subscriptionPool,
       logger: { log: (m) => console.log(m), warn: (m) => console.warn(m) },
+      // Census #1–#4: resolve each account's LIVE slot through the ledger (no-op while dark).
+      locationGate: credentialLocationGate,
     });
     if (subscriptionPool.size() > 0) {
       quotaPoller.start();
@@ -9166,7 +9223,9 @@ export async function startServer(options: StartOptions): Promise<void> {
     // right now" for the dashboard "in use" badge (read-only; cached probe of
     // `claude auth status`). One shared instance so the TTL cache is honored.
     const { InUseAccountResolver } = await import('../core/InUseAccountResolver.js');
-    const inUseAccountResolver = new InUseAccountResolver({});
+    // Census #8 (the E4a liar): when re-pointing is enabled and the ledger knows the `~/.claude`
+    // tenant, the badge resolves from the ledger — NOT a stale `claude auth status` re-probe.
+    const inUseAccountResolver = new InUseAccountResolver({ locationGate: credentialLocationGate });
 
     // EnrollmentWizard — mobile-first new-account login (P2.1 of the Subscription
     // & Auth Standard). Dark with the pool: the /subscription-pool/enroll routes

--- a/src/core/CredentialLocationGate.ts
+++ b/src/core/CredentialLocationGate.ts
@@ -1,0 +1,152 @@
+/**
+ * CredentialLocationGate — the SINGLE re-routing chokepoint for the §2.2 consumer census
+ * (Step 6 of live credential re-pointing).
+ *
+ * Spec: docs/specs/live-credential-repointing-rebalancer.md §2.2 (the consumer census table).
+ *
+ * ── What this is ──
+ * Every place in the live code that today treats a pool account's enrollment `configHome` as the
+ * LIVE location of its credential (the QuotaPoller token read / 401-refresh / email auto-patch /
+ * needs-reauth attribution; spawn placement + session attribution; the InUseAccountResolver
+ * default badge) is re-routed through ONE gate object instead of reaching into the ledger
+ * directly. Centralizing the gate keeps the load-bearing safety contract in a single auditable
+ * place — every consumer inherits the same flag-gating, back-compat-on-unknown, and
+ * fail-open-loud posture by construction (Structure > Willpower).
+ *
+ * ── The load-bearing safety contract (spec §2.2; build-prompt invariants 1, 5) ──
+ *   1. FLAG-GATED. With `enabled:false` (always, while the feature ships dark) every read returns
+ *      the caller's `enrollmentHome` (or null for tenant reads) — byte-for-byte today's behavior.
+ *   2. BACK-COMPAT ON UNKNOWN. With the flag ON but the ledger holding no record for that
+ *      account/slot (never-seeded), the gate ALSO falls back to today's behavior. The ledger only
+ *      ever ADDS truth, never removes the working path.
+ *   3. SYNC + FAIL-OPEN-LOUD. `ledger.slotOf/tenantOf` are in-memory sync reads that return null in
+ *      UNKNOWN mode (corrupt on-disk state). This gate NEVER throws into a hot path (QuotaPoller /
+ *      spawn): on UNKNOWN mode it returns the enrollment fallback AND raises ONE deduped HIGH
+ *      attention item naming the degradation, then the caller continues on today's behavior.
+ *
+ * The gate performs NO credential writes. It is a pure read-router over the ledger + flag.
+ */
+
+import type { CredentialLocationLedger } from './CredentialLocationLedger.js';
+import { credentialSlotKey } from './OAuthRefresher.js';
+
+/** Attention-item shape (mirrors CredentialLocationLedger.CredentialLedgerAttentionInput). */
+export interface CredentialGateAttentionInput {
+  id: string;
+  title: string;
+  summary: string;
+  description?: string;
+  category: string;
+  priority: 'URGENT' | 'HIGH' | 'NORMAL' | 'LOW';
+  sourceContext?: string;
+}
+
+export interface CredentialLocationGateDeps {
+  /**
+   * Reads the live `subscriptionPool.credentialRepointing.enabled` flag. Read EACH call (not
+   * cached) so a restartless config flip is honored on the next read — the same restartless
+   * posture the rest of the feature uses.
+   */
+  isEnabled: () => boolean;
+  /** The machine-local ledger (the single source of truth for "which account is in which slot"). */
+  ledger: CredentialLocationLedger;
+  /** Emit a deduped HIGH attention item on UNKNOWN-mode degradation (best-effort). */
+  emitAttention?: (item: CredentialGateAttentionInput) => void | Promise<void>;
+}
+
+/**
+ * Re-routes the §2.2 census consumers' `configHome`-as-location reads through the ledger.
+ *
+ * Construct ONE per process and hand it to each consumer (QuotaPoller, SessionManager spawn,
+ * InUseAccountResolver). The consumers stay dumb — they ask the gate "where does account X live
+ * now?" and "who tenants slot Y now?" and otherwise behave exactly as today.
+ */
+export class CredentialLocationGate {
+  private readonly isEnabledFn: () => boolean;
+  private readonly ledger: CredentialLocationLedger;
+  private readonly emitAttention?: (item: CredentialGateAttentionInput) => void | Promise<void>;
+  /** Dedupe the UNKNOWN-mode attention item so a read storm raises it once per process. */
+  private unknownAttentionRaised = false;
+
+  constructor(deps: CredentialLocationGateDeps) {
+    this.isEnabledFn = deps.isEnabled;
+    this.ledger = deps.ledger;
+    this.emitAttention = deps.emitAttention;
+  }
+
+  /** Live flag read — true only when re-pointing is enabled. */
+  isEnabled(): boolean {
+    return this.isEnabledFn();
+  }
+
+  /**
+   * The config-home SLOT where `accountId`'s credential CURRENTLY lives.
+   *
+   * - flag OFF                       → `enrollmentHome` (today's behavior, byte-identical).
+   * - flag ON + ledger has a record  → the ledger's current slot for the account.
+   * - flag ON + ledger UNKNOWN/empty → `enrollmentHome` (back-compat) AND, if UNKNOWN mode,
+   *   one deduped HIGH attention item (fail-open-LOUD). NEVER throws.
+   *
+   * The returned slot is in the SAME shape the caller passed (a config-home path); it is NOT
+   * canonicalized here so a caller that does its own `expandHome` keeps working unchanged.
+   */
+  slotForAccount(accountId: string, enrollmentHome: string): string {
+    if (!this.isEnabledFn()) return enrollmentHome;
+    // ledger.slotOf is a sync in-memory read; null in UNKNOWN mode or when never-seeded.
+    const slot = this.ledger.slotOf(accountId);
+    if (slot) return slot;
+    if (this.ledger.isUnknownMode()) this.raiseUnknownModeAttention();
+    return enrollmentHome;
+  }
+
+  /**
+   * The pool account id CURRENTLY tenanting `slot` per the ledger, or null.
+   *
+   * - flag OFF                       → null (caller keeps its existing attribution path).
+   * - flag ON + ledger has a record  → the ledger's tenant account id.
+   * - flag ON + ledger UNKNOWN/empty → null (back-compat) AND, if UNKNOWN mode, one deduped HIGH
+   *   attention item (fail-open-LOUD). NEVER throws.
+   *
+   * `slot` is matched against the ledger as-passed; pass the same shape the ledger stores (the
+   * consumers use `~/.claude` for the default badge, matching seedFromOracle's slot keys).
+   */
+  tenantForSlot(slot: string): string | null {
+    if (!this.isEnabledFn()) return null;
+    const tenant = this.ledger.tenantOf(slot);
+    if (tenant) return tenant;
+    if (this.ledger.isUnknownMode()) this.raiseUnknownModeAttention();
+    return null;
+  }
+
+  /**
+   * True iff `slot` (any spelling) canonicalizes to the DEFAULT `~/.claude` home. Used by the
+   * swap-commit cache-bust: only a swap touching the default slot need bust the in-use badge.
+   */
+  static touchesDefaultHome(slot: string): boolean {
+    return credentialSlotKey(slot) === credentialSlotKey('~/.claude');
+  }
+
+  private raiseUnknownModeAttention(): void {
+    if (this.unknownAttentionRaised || !this.emitAttention) return;
+    this.unknownAttentionRaised = true;
+    try {
+      void this.emitAttention({
+        id: 'credential-location-gate-unknown-mode',
+        title: 'Credential location ledger UNKNOWN — consumers fell back to enrollment homes',
+        summary:
+          'A census consumer (quota poll / spawn placement / in-use badge) read the credential ' +
+          'location ledger while it was in UNKNOWN mode (corrupt on-disk state). The read fell ' +
+          'back to enrollment-home behavior (no path broke), but credential re-pointing is not ' +
+          'authoritative until the ledger is re-seeded via the identity oracle.',
+        category: 'credential-repointing',
+        priority: 'HIGH',
+        sourceContext: 'credential-location-gate',
+      });
+    } catch {
+      // @silent-fallback-ok — the attention emitter is best-effort; a delivery failure must never
+      // throw into the QuotaPoller / spawn hot path. The actual safety behavior (the enrollment-
+      // home fallback) is already in force regardless of whether the notice was delivered, so the
+      // path's correctness does not depend on this emit.
+    }
+  }
+}

--- a/src/core/CredentialSwapExecutor.ts
+++ b/src/core/CredentialSwapExecutor.ts
@@ -228,6 +228,13 @@ export interface CredentialSwapExecutorDeps {
   emitAudit?: (record: SwapAuditRecord) => void;
   /** HIGH attention on a quarantine (the blast-radius surface). */
   emitAttention?: (item: { id: string; title: string; summary: string; category: string; priority: 'URGENT' | 'HIGH' | 'NORMAL' | 'LOW'; sourceContext?: string }) => void | Promise<void>;
+  /**
+   * Census #8 cache-bust hook. Invoked at commit with the slots whose tenant just changed. The
+   * server wires this to `InUseAccountResolver.bustCache()` so a default-slot (`~/.claude`) swap
+   * invalidates the stale in-use badge immediately — the keychain-first/config-second window is
+   * exactly when a re-probe would re-cache the wrong tenant. Best-effort; never throws into commit.
+   */
+  onSlotsChanged?: (slots: string[]) => void;
   now?: () => number;
   nowIso?: () => string;
   /** Delay before the step-6 re-verify (ms; default 90_000). Tests inject a small value. */
@@ -253,6 +260,7 @@ export class CredentialSwapExecutor {
   private readonly config: { enabled: boolean; dryRun: boolean };
   private readonly emitAudit?: (record: SwapAuditRecord) => void;
   private readonly emitAttention?: CredentialSwapExecutorDeps['emitAttention'];
+  private readonly onSlotsChanged?: (slots: string[]) => void;
   private readonly now: () => number;
   private readonly nowIso: () => string;
   private readonly reverifyDelayMs: number;
@@ -274,6 +282,7 @@ export class CredentialSwapExecutor {
     this.config = { enabled: deps.config?.enabled ?? false, dryRun: deps.config?.dryRun ?? true };
     this.emitAudit = deps.emitAudit;
     this.emitAttention = deps.emitAttention;
+    this.onSlotsChanged = deps.onSlotsChanged;
     this.now = deps.now ?? (() => Date.now());
     this.nowIso = deps.nowIso ?? (() => new Date(this.now()).toISOString());
     this.reverifyDelayMs = deps.reverifyDelayMs ?? DEFAULT_REVERIFY_DELAY_MS;
@@ -303,6 +312,19 @@ export class CredentialSwapExecutor {
   private audit(swapId: string, step: string, slotA: string, slotB: string, detail?: string): void {
     if (!this.emitAudit) return;
     this.emitAudit({ swapId, step, slotA, slotB, detail: detail ? scrub(detail) : undefined, at: this.nowIso() });
+  }
+
+  /** Census #8: fire the cache-bust hook (best-effort — a consumer error never breaks commit). */
+  private notifySlotsChanged(slots: string[]): void {
+    if (!this.onSlotsChanged) return;
+    try {
+      this.onSlotsChanged(slots);
+    } catch {
+      // @silent-fallback-ok — the cache-bust is an observability nicety (a stale in-use badge
+      // self-corrects at TTL expiry). A throwing consumer must never roll back or break the
+      // already-committed swap, which is the load-bearing operation; the slots are exchanged
+      // whether or not the badge was busted.
+    }
   }
 
   private stagingService(swapId: string): string {
@@ -419,6 +441,9 @@ export class CredentialSwapExecutor {
     this.ledger.recordAssignment(slotA, expectB, { verifiedAt: this.nowIso(), op: 'swap' });
     this.ledger.recordAssignment(slotB, expectA, { verifiedAt: this.nowIso(), op: 'swap' });
     this.audit(swapId, 'committed', slotA, slotB, `tenants exchanged (staging retained)`);
+    // Census #8: the slot tenants just changed — bust any in-use badge cache so a default-slot
+    // (`~/.claude`) swap doesn't leave the dashboard showing the pre-swap tenant for a full TTL.
+    this.notifySlotsChanged([slotA, slotB]);
 
     // Step 6: delayed re-verify, then staging delete. Scheduled (does NOT block the swap return);
     // a client whose refresh exchange was in flight DURING the swap lands its write after step 4.

--- a/src/core/InUseAccountResolver.ts
+++ b/src/core/InUseAccountResolver.ts
@@ -25,6 +25,7 @@
 
 import { execFile } from 'node:child_process';
 
+import type { CredentialLocationGate } from './CredentialLocationGate.js';
 import type { SubscriptionAccount } from './SubscriptionPool.js';
 
 /** Probe the DEFAULT claude config's authenticated account email (or null). */
@@ -37,6 +38,15 @@ export interface InUseAccountResolverConfig {
   ttlMs?: number;
   /** Injected for tests. */
   now?: () => number;
+  /**
+   * Census #8 (the E4a liar). When present AND enabled, the default-tenant badge resolves from
+   * `ledger.tenantOf('~/.claude')` instead of re-probing `claude auth status` — `auth status`
+   * reads `.claude.json` `oauthAccount`, which is STALE during the keychain-first/config-second
+   * window after a swap, so re-probing would re-cache the WRONG tenant for the full TTL. The
+   * swap-commit cache-bust (`bustCache`) keeps the badge honest across a `~/.claude` swap.
+   * Absent (or flag-off / ledger-unknown) → byte-for-byte today's re-probe behavior.
+   */
+  locationGate?: CredentialLocationGate;
 }
 
 export interface InUseResult {
@@ -115,6 +125,7 @@ export class InUseAccountResolver {
   private readonly probe: AuthStatusProbe;
   private readonly ttlMs: number;
   private readonly now: () => number;
+  private readonly locationGate?: CredentialLocationGate;
   private cached: { email: string | null; at: number } | null = null;
   private inFlight: Promise<string | null> | null = null;
 
@@ -122,6 +133,17 @@ export class InUseAccountResolver {
     this.probe = config.probe ?? defaultAuthStatusProbe;
     this.ttlMs = config.ttlMs ?? 60_000;
     this.now = config.now ?? (() => Date.now());
+    this.locationGate = config.locationGate;
+  }
+
+  /**
+   * Census #8: invalidate the cached probe result so the next badge read re-resolves. The swap
+   * executor calls this immediately on a commit touching `~/.claude` (the keychain-first/
+   * config-second window is exactly when a re-probe would re-cache the wrong tenant). Cheap +
+   * idempotent — a no-op when nothing is cached.
+   */
+  bustCache(): void {
+    this.cached = null;
   }
 
   /** The active default-config email, cached for ttlMs. Coalesces concurrent probes. */
@@ -144,8 +166,30 @@ export class InUseAccountResolver {
     return this.inFlight;
   }
 
-  /** Resolve which pool account the agent is currently running on. */
+  /**
+   * Resolve which pool account the agent is currently running on.
+   *
+   * Census #8 (the E4a liar stays dead): when the location gate is enabled AND the ledger knows
+   * the `~/.claude` tenant, the badge is resolved DIRECTLY from `ledger.tenantOf('~/.claude')` —
+   * the `claude auth status` re-probe is NOT run at all. That probe reads `.claude.json`
+   * `oauthAccount`, which lags during the metadata-repair window after a swap, so trusting it
+   * would re-cache the wrong tenant for the full TTL. With the gate off / absent / ledger-unknown
+   * the resolver falls through to its original probe-and-match path (byte-for-byte today).
+   */
   async resolve(accounts: SubscriptionAccount[]): Promise<InUseResult> {
+    if (this.locationGate?.isEnabled()) {
+      const tenantAccountId = this.locationGate.tenantForSlot('~/.claude');
+      if (tenantAccountId) {
+        // Ledger is authoritative for the slot — report its tenant WITHOUT re-probing auth status.
+        const acct = accounts.find((a) => a.id === tenantAccountId);
+        return {
+          activeAccountId: tenantAccountId,
+          activeEmail: acct?.email ?? null,
+        };
+      }
+      // Gate enabled but the ledger has no `~/.claude` record (never-seeded / UNKNOWN) → fall
+      // through to today's re-probe behavior (back-compat — never break the badge).
+    }
     const activeEmail = await this.activeEmail();
     return {
       activeEmail,

--- a/src/core/QuotaPoller.ts
+++ b/src/core/QuotaPoller.ts
@@ -45,6 +45,7 @@ import {
   expandHome,
   type RefreshResult,
 } from './OAuthRefresher.js';
+import type { CredentialLocationGate } from './CredentialLocationGate.js';
 
 /** Injectable token resolver — returns an account's OAuth access token or null. */
 export type TokenResolver = (account: SubscriptionAccount) => string | null;
@@ -78,6 +79,14 @@ export interface QuotaPollerConfig {
   refresher?: AccountRefresher;
   /** Logger (defaults to console). */
   logger?: { log: (m: string) => void; warn: (m: string) => void };
+  /**
+   * Census re-routing gate (§2.2 rows #1–#4). When present AND enabled, the poller resolves
+   * each account's LIVE slot via the ledger instead of reading its enrollment `configHome` —
+   * so a swap mid-poll can't make the poller read the wrong tenant's token, refresh the wrong
+   * slot, cross-contaminate pool emails, or attribute needs-reauth to the wrong account. Absent
+   * (or flag-off / ledger-unknown) → byte-for-byte today's enrollment-home behavior.
+   */
+  locationGate?: CredentialLocationGate;
 }
 
 /** Outcome of a single usage read (internal). */
@@ -201,6 +210,7 @@ export class QuotaPoller {
   private readonly tokenResolver: TokenResolver;
   private readonly refresher: AccountRefresher;
   private readonly logger: { log: (m: string) => void; warn: (m: string) => void };
+  private readonly locationGate?: CredentialLocationGate;
   private interval: ReturnType<typeof setInterval> | null = null;
   /** Most-recent snapshot per account id. */
   private readonly lastByAccount = new Map<string, AccountQuotaSnapshot>();
@@ -217,6 +227,25 @@ export class QuotaPoller {
     this.refresher =
       config.refresher ?? ((account) => refreshClaudeToken(expandHome(account.configHome)));
     this.logger = config.logger ?? { log: () => {}, warn: () => {} };
+    this.locationGate = config.locationGate;
+  }
+
+  /**
+   * Census re-routing (§2.2 rows #1–#4): resolve the account's LIVE slot home through the ledger
+   * gate when enabled, else its enrollment `configHome` (today's behavior). The result is the
+   * config home every per-account credential read in this poller targets — so a swap mid-poll
+   * reads/refreshes/attributes against the slot the credential ACTUALLY lives in now. Sync,
+   * fail-open-loud (the gate never throws), back-compat when the ledger is unknown/never-seeded.
+   *
+   * Returns the account UNCHANGED when no re-route is needed, so the byte-identical flag-off path
+   * does not allocate a clone (and the default token resolver / refresher see the exact same
+   * object they do today).
+   */
+  private accountForReads(account: SubscriptionAccount): SubscriptionAccount {
+    if (!this.locationGate) return account;
+    const slot = this.locationGate.slotForAccount(account.id, account.configHome);
+    if (slot === account.configHome) return account;
+    return { ...account, configHome: slot };
   }
 
   start(): void {
@@ -278,7 +307,13 @@ export class QuotaPoller {
    * unresolvable or the read fails. NEVER logs or returns the token.
    */
   async pollAccount(account: SubscriptionAccount): Promise<AccountQuotaSnapshot | null> {
-    const token = this.tokenResolver(account);
+    // Census #1/#2/#4: every per-account credential read (token resolve, 401-refresh, needs-reauth
+    // attribution) targets the account's LIVE slot per the ledger gate — NOT its enrollment home —
+    // so a swap mid-poll can't read/refresh/flag the wrong tenant. account.id is preserved (only
+    // the slot home moves), so pool.update + logging still name the right account.
+    const slotAccount = this.accountForReads(account);
+
+    const token = this.tokenResolver(slotAccount);
     if (!token) {
       this.logger.warn(`[QuotaPoller] no resolvable token for account ${account.id} — skipping`);
       return null;
@@ -289,7 +324,7 @@ export class QuotaPoller {
 
     let body: Record<string, unknown> | null;
     if (read.authFailed) {
-      const refreshed = await this.refresher(account);
+      const refreshed = await this.refresher(slotAccount);
       if (!refreshed.ok) {
         if (refreshed.reason === 'write-skipped') {
           // The refresh exchange SUCCEEDED but the per-slot credential funnel lock was busy
@@ -355,11 +390,19 @@ export class QuotaPoller {
       const patch: Parameters<SubscriptionPool['update']>[1] = { lastQuota: snap };
       // A clean read on an account previously flagged needs-reauth restores it.
       if (account.status === 'needs-reauth') patch.status = 'active';
-      // Auto-populate the account email from the config home's own login record,
-      // so the stored email always reflects which account actually authenticated
-      // (a login into the wrong account surfaces here instead of hiding).
-      const email = readAccountEmail(account.configHome);
-      if (email && email !== account.email) patch.email = email;
+      // Census #3: email auto-patch. When credential re-pointing is enabled the enrollment home
+      // no longer maps 1:1 to a tenant (a swap moves the credential), so reading the slot's
+      // `.claude.json` email and writing it onto this pool account would CROSS-CONTAMINATE pool
+      // emails and poison the recovery probe's email→account map. So while the gate is enabled the
+      // auto-patch is SUPPRESSED (the ledger + identity oracle own divergence detection now). With
+      // the gate absent/off this is byte-for-byte today's behavior.
+      if (!this.locationGate?.isEnabled()) {
+        // Auto-populate the account email from the config home's own login record,
+        // so the stored email always reflects which account actually authenticated
+        // (a login into the wrong account surfaces here instead of hiding).
+        const email = readAccountEmail(account.configHome);
+        if (email && email !== account.email) patch.email = email;
+      }
       try {
         this.pool.update(account.id, patch);
       } catch {

--- a/src/core/SessionManager.ts
+++ b/src/core/SessionManager.ts
@@ -277,6 +277,15 @@ export class SessionManager extends EventEmitter {
    * no eligible account exists. */
   private spawnAccountResolver?: () => { configHome: string; accountId: string } | null;
 
+  /**
+   * Census #5/#6: live credential re-pointing gate. When set AND enabled, a pinned account's
+   * spawn home is resolved through the ledger (the account's CURRENT slot) instead of the
+   * enrollment `configHome` the resolver returns — so after a swap a session lands on the slot
+   * the credential ACTUALLY lives in now, not the stale enrollment home. Unset / flag-off /
+   * ledger-unknown → the enrollment home is used exactly as today (strict no-op while dark).
+   */
+  private credentialLocationGate?: import('./CredentialLocationGate.js').CredentialLocationGate;
+
   /** Prompt Gate InputDetector — monitors terminal output for interactive prompts */
   private promptDetector?: InputDetector;
 
@@ -549,6 +558,24 @@ rm()  { "${shimRunner}" rm  "$@"; }
    */
   setSpawnAccountResolver(resolver: () => { configHome: string; accountId: string } | null): void {
     this.spawnAccountResolver = resolver;
+  }
+
+  /**
+   * Wire the credential re-pointing gate (census #5/#6). Called from server startup; absent /
+   * flag-off keeps spawn placement on the enrollment home exactly as today.
+   */
+  setCredentialLocationGate(gate: import('./CredentialLocationGate.js').CredentialLocationGate): void {
+    this.credentialLocationGate = gate;
+  }
+
+  /**
+   * Census #5/#6: resolve a pinned account's LIVE spawn home through the ledger gate. Returns the
+   * account's current slot when re-pointing is enabled AND the ledger knows it; otherwise the
+   * enrollment `configHome` unchanged (today's behavior). Sync + fail-open (the gate never throws).
+   */
+  private resolvePinnedSpawnHome(pinned: { configHome: string; accountId: string }): string {
+    if (!this.credentialLocationGate) return pinned.configHome;
+    return this.credentialLocationGate.slotForAccount(pinned.accountId, pinned.configHome);
   }
 
   /**
@@ -1793,8 +1820,10 @@ rm()  { "${shimRunner}" rm  "$@"; }
       ? (this.spawnAccountResolver?.() ?? null)
       : null;
     if (pinnedAccount) {
-      headlessSpec.envOverrides.CLAUDE_CONFIG_DIR = pinnedAccount.configHome;
-      this.ensurePinnedHomeInteractiveReady(pinnedAccount.configHome, 'headless pin');
+      // Census #6: pin to the account's CURRENT slot per the ledger gate, not its enrollment home.
+      const pinnedHome = this.resolvePinnedSpawnHome(pinnedAccount);
+      headlessSpec.envOverrides.CLAUDE_CONFIG_DIR = pinnedHome;
+      this.ensurePinnedHomeInteractiveReady(pinnedHome, 'headless pin');
     }
     const frameworkEnvFlags: string[] = [];
     for (const [k, v] of Object.entries(headlessSpec.envOverrides)) {
@@ -2067,8 +2096,10 @@ rm()  { "${shimRunner}" rm  "$@"; }
     // and tag the session. No-op unless the resolver is wired + returns an account.
     const pinnedAccount = this.spawnAccountResolver?.() ?? null;
     if (pinnedAccount) {
-      launchSpec.envOverrides.CLAUDE_CONFIG_DIR = pinnedAccount.configHome;
-      this.ensurePinnedHomeInteractiveReady(pinnedAccount.configHome, 'interactive-reroute pin');
+      // Census #6: pin to the account's CURRENT slot per the ledger gate, not its enrollment home.
+      const pinnedHome = this.resolvePinnedSpawnHome(pinnedAccount);
+      launchSpec.envOverrides.CLAUDE_CONFIG_DIR = pinnedHome;
+      this.ensurePinnedHomeInteractiveReady(pinnedHome, 'interactive-reroute pin');
     }
     const frameworkEnvFlags: string[] = [];
     for (const [k, v] of Object.entries(launchSpec.envOverrides)) {
@@ -3187,7 +3218,11 @@ rm()  { "${shimRunner}" rm  "$@"; }
     const pinnedAccount = (!explicitConfigHome && framework === 'claude-code')
       ? (this.spawnAccountResolver?.() ?? null)
       : null;
-    const effectiveConfigHome = explicitConfigHome ?? pinnedAccount?.configHome;
+    // Census #6: when the home comes from a pinned pool account, resolve its LIVE slot through the
+    // ledger gate (an explicit caller-supplied home — the account-swap / SessionRefresh path — is a
+    // deliberate pin and always wins, unchanged).
+    const effectiveConfigHome =
+      explicitConfigHome ?? (pinnedAccount ? this.resolvePinnedSpawnHome(pinnedAccount) : undefined);
     const effectiveAccountId = options?.subscriptionAccountId ?? pinnedAccount?.accountId;
     // This interactive session is about to launch under a pool account's config
     // home — seed the onboarding flags first or a headless-enrolled home wedges

--- a/src/monitoring/AccountSwitcher.ts
+++ b/src/monitoring/AccountSwitcher.ts
@@ -17,6 +17,7 @@ import {
   redactToken,
   writeCredentialsSerialized,
   DEFAULT_CREDENTIAL_SLOT,
+  CredentialWriteRepointingOwnedError,
 } from './CredentialProvider.js';
 
 interface AccountEntry {
@@ -161,6 +162,17 @@ export class AccountSwitcher {
         };
       }
     } catch (err) {
+      // Census #9: the slot is owned by live credential re-pointing — refuse cleanly (the manager
+      // chokepoint already refused; surface it as a named, non-destructive switch failure rather
+      // than a generic write error).
+      if (err instanceof CredentialWriteRepointingOwnedError) {
+        return {
+          success: false,
+          message: err.message,
+          previousAccount,
+          newAccount: null,
+        };
+      }
       return {
         success: false,
         message: `Failed to write credentials via ${this.provider.platform} provider: ${err instanceof Error ? err.message : String(err)}`,

--- a/src/monitoring/CredentialProvider.ts
+++ b/src/monitoring/CredentialProvider.ts
@@ -276,6 +276,42 @@ export function createDefaultProvider(): CredentialProvider {
 export const DEFAULT_CREDENTIAL_SLOT = credentialSlotKey('~/.claude');
 
 /**
+ * Thrown by `writeCredentialsSerialized` when the target slot is owned by the credential
+ * re-pointing ledger (census #9). A competing writer (AccountSwitcher / `/switch-account` /
+ * `autoMigrate`) writing that slot would graft a Frankenstein blob over the ledger's tenant and
+ * silently resurrect a stranded account (spec §2.7). This is a NAMED, NON-DESTRUCTIVE refusal —
+ * nothing was written — pointing the caller at the sanctioned replacement.
+ */
+export class CredentialWriteRepointingOwnedError extends Error {
+  constructor(reason: string) {
+    super(reason);
+    this.name = 'CredentialWriteRepointingOwnedError';
+  }
+}
+
+/**
+ * Manager-level refusal gate for the competing-writer census row (#9). Injected at the funnel
+ * chokepoint so a refusal lives at the MANAGER, not only on the two known routes — any future
+ * caller of `writeCredentialsSerialized` inherits it (the "every item a unique source" dodge the
+ * flood-ceiling lesson warns against, applied to credential writes).
+ *
+ *   `shouldRefuse(slot)` → true ⇒ the write is refused (the slot is repointing-owned). It receives
+ *   the canonicalized slot key so the gate matches the ledger's spelling regardless of caller
+ *   input. Returns false (or the gate being absent) ⇒ the write proceeds exactly as today.
+ */
+export interface CredentialWriteRefusalGate {
+  shouldRefuse(canonicalSlot: string): boolean;
+}
+
+/** Process-shared refusal gate; wired at server startup when re-pointing is enabled. */
+let sharedWriteRefusalGate: CredentialWriteRefusalGate | undefined;
+
+/** Install (or clear, with `undefined`) the process-shared competing-writer refusal gate. */
+export function setCredentialWriteRefusalGate(gate: CredentialWriteRefusalGate | undefined): void {
+  sharedWriteRefusalGate = gate;
+}
+
+/**
  * Serialize a `provider.writeCredentials` through the per-slot credential funnel (Step 4b).
  *
  * This is the ONLY sanctioned path for an external caller (e.g. AccountSwitcher) to write the
@@ -283,6 +319,12 @@ export const DEFAULT_CREDENTIAL_SLOT = credentialSlotKey('~/.claude');
  * the swap executor (Step 5), so a switch can never interleave with a refresh on the same slot.
  * The companion lint (`lint-no-unfunneled-credential-write.js`) forbids calling
  * `provider.writeCredentials(...)` directly outside this funnel-owning module.
+ *
+ * Census #9 (manager-level competing-writer refusal): when the process-shared refusal gate (or an
+ * explicitly-passed `refusalGate`) reports the target slot is repointing-owned, the write is
+ * REFUSED here at the manager — BEFORE the funnel lock — with a `CredentialWriteRepointingOwnedError`.
+ * This is the funnel: a non-route caller can't dodge it. Refusal is non-destructive (nothing was
+ * written) and names the sanctioned replacement (`POST /credentials/set-default`).
  *
  * Returns the funnel result. `ran:false` means the lock was busy and the write was SKIPPED (the
  * caller decides whether to surface "busy, try again"); it is never a credential corruption.
@@ -292,8 +334,16 @@ export async function writeCredentialsSerialized(
   slot: string,
   creds: ClaudeCredentials,
   funnel: CredentialWriteFunnel = credentialWriteFunnel,
+  refusalGate: CredentialWriteRefusalGate | undefined = sharedWriteRefusalGate,
 ): Promise<FunnelResult<void>> {
   // Canonicalize the slot so a switch and a refresh on the SAME home share one lock regardless
   // of spelling (second-pass review hardening, 2026-06-13).
-  return funnel.withSlotLock(credentialSlotKey(slot), () => provider.writeCredentials(creds));
+  const canonicalSlot = credentialSlotKey(slot);
+  if (refusalGate?.shouldRefuse(canonicalSlot)) {
+    throw new CredentialWriteRepointingOwnedError(
+      `credential slot '${slot}' is owned by live credential re-pointing — a direct switch/migrate ` +
+        `write would clobber the ledger's tenant. Use POST /credentials/set-default instead.`,
+    );
+  }
+  return funnel.withSlotLock(canonicalSlot, () => provider.writeCredentials(creds));
 }

--- a/src/server/routes.ts
+++ b/src/server/routes.ts
@@ -19003,6 +19003,24 @@ export function createRoutes(ctx: RouteContext): Router {
       return;
     }
     const { nickname, framework, configHome, status, lastQuota, lastUsedAt, email } = req.body ?? {};
+    // Census #10/#11: while live credential re-pointing is enabled the account `configHome` is
+    // enrollment metadata, NOT the credential's live location (the ledger owns location). A hand
+    // edit here would silently desync the ledger and re-point sessions to the wrong slot, so the
+    // field is refused with 409 — the operator changes location via POST /credentials/set-default,
+    // never by editing this field. With the flag off (always, while dark) this is a no-op and the
+    // PATCH behaves exactly as today.
+    if (
+      configHome !== undefined &&
+      ctx.config.subscriptionPool?.credentialRepointing?.enabled === true
+    ) {
+      res.status(409).json({
+        error:
+          'configHome cannot be edited while live credential re-pointing is enabled — it is ' +
+          'enrollment metadata, not the credential location. Use POST /credentials/set-default ' +
+          'to change which account a slot serves.',
+      });
+      return;
+    }
     try {
       const updated = ctx.subscriptionPool.update(
         req.params.id,

--- a/tests/e2e/credential-repointing-census-lifecycle.test.ts
+++ b/tests/e2e/credential-repointing-census-lifecycle.test.ts
@@ -1,0 +1,139 @@
+/**
+ * E2E (Tier-3 "feature is alive") for WS5.2 Step 6 — census consumer re-routing.
+ *
+ * Spec: docs/specs/live-credential-repointing-rebalancer.md §2.2.
+ *
+ * The single most important Step-6 assertion: with the feature flag OFF (always, while it ships
+ * dark) EVERY census consumer behaves EXACTLY as today — the re-routing is wired but strictly
+ * inert. This boots a real Express server with the SAME wiring chain server.ts builds (the ledger
+ * + the CredentialLocationGate + the consumers reading through it) and proves:
+ *   - the wiring constructs end-to-end without error (feature is alive, not 503 / crash);
+ *   - flag OFF → the in-use badge re-probes auth status exactly as today (no ledger short-circuit);
+ *   - flag OFF → the quota poll reads the enrollment home exactly as today;
+ *   - flag OFF → PATCH configHome is allowed (today's behavior), not 409.
+ */
+
+import { describe, it, expect, afterEach } from 'vitest';
+import express from 'express';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import type { AddressInfo } from 'node:net';
+import { createRoutes } from '../../src/server/routes.js';
+import { SubscriptionPool } from '../../src/core/SubscriptionPool.js';
+import { QuotaPoller, type FetchImpl } from '../../src/core/QuotaPoller.js';
+import { InUseAccountResolver } from '../../src/core/InUseAccountResolver.js';
+import {
+  CredentialLocationLedger,
+  type IdentityOracle,
+  type LedgerPoolView,
+} from '../../src/core/CredentialLocationLedger.js';
+import { CredentialLocationGate } from '../../src/core/CredentialLocationGate.js';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+
+interface TestServer { url: string; close: () => Promise<void>; }
+function listen(app: express.Express): Promise<TestServer> {
+  return new Promise((resolve) => {
+    const srv = app.listen(0, () => {
+      const port = (srv.address() as AddressInfo).port;
+      resolve({ url: `http://127.0.0.1:${port}`, close: () => new Promise<void>((r) => srv.close(() => r())) });
+    });
+  });
+}
+
+const noopOracle: IdentityOracle = { async resolveSlotTenant() { return { unavailable: true }; } };
+const USAGE = { five_hour: { utilization: 5, resets_at: '2026-06-07T00:00:00Z' }, seven_day: { utilization: 40, resets_at: '2026-06-12T00:00:00Z' } };
+const okFetch: FetchImpl = async () => ({ ok: true, status: 200, json: async () => USAGE });
+
+describe('credential re-pointing census re-routing — E2E feature-alive (dark = strict no-op)', () => {
+  let server: TestServer | undefined;
+  let dir: string | undefined;
+  afterEach(async () => {
+    await server?.close();
+    server = undefined;
+    if (dir) { try { SafeFsExecutor.safeRmSync(dir, { recursive: true, force: true, operation: 'credential-repointing-census-lifecycle.test cleanup' }); } catch { /* @silent-fallback-ok */ } dir = undefined; }
+  });
+
+  /** Build the server.ts wiring chain (ledger → gate → consumers) with the flag set as given. */
+  async function bootWired(enabled: boolean): Promise<{ pool: SubscriptionPool; seenHomes: string[]; probeCalls: () => number }> {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'cred-census-e2e-'));
+    const pool = new SubscriptionPool({ stateDir: dir });
+    pool.add({ id: 'claude-1', nickname: 'primary', provider: 'anthropic', framework: 'claude-code', configHome: path.join(dir, '.claude-enroll'), email: 'a@x.com' });
+    const poolView: LedgerPoolView = { list: () => pool.list().map((a) => ({ id: a.id, email: a.email, configHome: a.configHome, framework: a.framework })) };
+
+    const ledger = new CredentialLocationLedger({ stateDir: dir, pool: poolView, oracle: noopOracle });
+    // Seed the live slot for claude-1 at the default `~/.claude` home. This is DIFFERENT from its
+    // enrollment home (`.claude-enroll`), so: (a) a flag-off quota read that leaked through would
+    // visibly target `~/.claude` instead of the enrollment home, and (b) the in-use census #8 can
+    // resolve the badge from `ledger.tenantOf('~/.claude')` when the flag is on.
+    ledger.recordAssignment('~/.claude', 'claude-1');
+
+    const gate = new CredentialLocationGate({
+      isEnabled: () => enabled,
+      ledger,
+    });
+
+    const seenHomes: string[] = [];
+    const quotaPoller = new QuotaPoller({
+      pool,
+      fetchImpl: okFetch,
+      tokenResolver: (a) => { seenHomes.push(a.configHome); return 'sk-ant-oat-x'; },
+      locationGate: gate,
+    });
+
+    let probes = 0;
+    const inUseAccountResolver = new InUseAccountResolver({
+      probe: async () => { probes++; return 'a@x.com'; },
+      locationGate: gate,
+    });
+
+    const app = express();
+    app.use(express.json());
+    const ctx: any = {
+      config: { authToken: 't', stateDir: dir, port: 0, subscriptionPool: { credentialRepointing: { enabled } } },
+      startTime: new Date(),
+      subscriptionPool: pool,
+      quotaPoller,
+      inUseAccountResolver,
+    };
+    app.use(createRoutes(ctx));
+    server = await listen(app);
+    return { pool, seenHomes, probeCalls: () => probes };
+  }
+
+  const api = (p: string, init?: RequestInit) =>
+    fetch(server!.url + p, { headers: { 'Content-Type': 'application/json' }, ...init }).then(async (r) => ({ status: r.status, body: await r.json().catch(() => ({})) }));
+
+  it('FLAG OFF: the full wiring is alive AND strictly inert (every consumer = today)', async () => {
+    const { seenHomes, probeCalls } = await bootWired(false);
+
+    // in-use badge: re-probes auth status (NOT the ledger short-circuit).
+    const inUse = await api('/subscription-pool/in-use');
+    expect(inUse.status).toBe(200);
+    expect(inUse.body).toEqual({ enabled: true, activeAccountId: 'claude-1', activeEmail: 'a@x.com' });
+    expect(probeCalls()).toBe(1); // it DID re-probe — flag-off behavior
+
+    // quota poll: reads the ENROLLMENT home, not the ledger's live slot.
+    const poll = await api('/subscription-pool/poll', { method: 'POST' });
+    expect(poll.status).toBe(200);
+    expect(poll.body).toMatchObject({ enabled: true, polled: 1 });
+    expect(seenHomes.every((h) => h.endsWith('.claude-enroll'))).toBe(true);
+    expect(seenHomes.some((h) => h === '~/.claude')).toBe(false); // ledger slot NOT consulted
+
+    // PATCH configHome: allowed (today's behavior), not 409.
+    const patch = await api('/subscription-pool/claude-1', { method: 'PATCH', body: JSON.stringify({ configHome: '/edited' }) });
+    expect(patch.status).toBe(200);
+  });
+
+  it('FLAG ON: the same wiring now routes the in-use badge through the ledger (no re-probe)', async () => {
+    const { probeCalls } = await bootWired(true);
+    const inUse = await api('/subscription-pool/in-use');
+    expect(inUse.status).toBe(200);
+    expect(inUse.body).toEqual({ enabled: true, activeAccountId: 'claude-1', activeEmail: 'a@x.com' });
+    expect(probeCalls()).toBe(0); // E4a liar stays dead — resolved from the ledger, no re-probe
+
+    // PATCH configHome now refused (409).
+    const patch = await api('/subscription-pool/claude-1', { method: 'PATCH', body: JSON.stringify({ configHome: '/edited' }) });
+    expect(patch.status).toBe(409);
+  });
+});

--- a/tests/integration/credential-repointing-census-routes.test.ts
+++ b/tests/integration/credential-repointing-census-routes.test.ts
@@ -1,0 +1,98 @@
+/**
+ * Integration test — WS5.2 Step 6 census re-routing, the route surfaces (full HTTP pipeline).
+ *
+ * Spec: docs/specs/live-credential-repointing-rebalancer.md §2.2 rows #10/#11.
+ *
+ * Boots a real Express app with createRoutes() + a real SubscriptionPool and proves:
+ *   - PATCH /subscription-pool/:id editing `configHome` → 409 while re-pointing is ENABLED;
+ *   - the same PATCH → 200 (today's behavior) while the flag is OFF;
+ *   - a non-configHome field still PATCHes fine even while enabled (only `configHome` is refused).
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import express from 'express';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import type { AddressInfo } from 'node:net';
+import { createRoutes } from '../../src/server/routes.js';
+import { SubscriptionPool } from '../../src/core/SubscriptionPool.js';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+
+interface TestServer { url: string; close: () => Promise<void>; }
+async function listen(app: express.Express): Promise<TestServer> {
+  return new Promise((resolve) => {
+    const srv = app.listen(0, () => {
+      const port = (srv.address() as AddressInfo).port;
+      resolve({ url: `http://127.0.0.1:${port}`, close: () => new Promise<void>((r) => srv.close(() => r())) });
+    });
+  });
+}
+
+/** Boot the app with the credentialRepointing.enabled flag set as given. */
+async function boot(enabled: boolean): Promise<{ server: TestServer; dir: string; pool: SubscriptionPool }> {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'cred-census-int-'));
+  const pool = new SubscriptionPool({ stateDir: dir });
+  pool.add({ id: 'claude-1', nickname: 'primary', provider: 'anthropic', framework: 'claude-code', configHome: '/h/.claude-1' });
+  const app = express();
+  app.use(express.json());
+  const ctx: any = {
+    config: {
+      authToken: 't',
+      stateDir: dir,
+      port: 0,
+      subscriptionPool: { credentialRepointing: { enabled } },
+    },
+    startTime: new Date(),
+    subscriptionPool: pool,
+  };
+  app.use(createRoutes(ctx));
+  const server = await listen(app);
+  return { server, dir, pool };
+}
+
+describe('/subscription-pool PATCH configHome — census #10/#11 (integration)', () => {
+  let ctx: { server: TestServer; dir: string; pool: SubscriptionPool } | undefined;
+  afterEach(async () => {
+    await ctx?.server.close();
+    if (ctx) { try { SafeFsExecutor.safeRmSync(ctx.dir, { recursive: true, force: true, operation: 'credential-repointing-census-routes.test cleanup' }); } catch { /* @silent-fallback-ok */ } }
+    ctx = undefined;
+  });
+
+  const api = (server: TestServer, p: string, init?: RequestInit) =>
+    fetch(server.url + p, { headers: { 'Content-Type': 'application/json' }, ...init })
+      .then(async (r) => ({ status: r.status, body: await r.json().catch(() => ({})) }));
+
+  it('flag ON → editing configHome is refused with 409 (pointing at /credentials/set-default)', async () => {
+    ctx = await boot(true);
+    const r = await api(ctx.server, '/subscription-pool/claude-1', {
+      method: 'PATCH',
+      body: JSON.stringify({ configHome: '/h/.claude-edited' }),
+    });
+    expect(r.status).toBe(409);
+    expect(r.body.error).toContain('set-default');
+    // The field was NOT changed.
+    const acct = await api(ctx.server, '/subscription-pool/claude-1');
+    expect(acct.body.configHome).toBe('/h/.claude-1');
+  });
+
+  it('flag OFF → editing configHome behaves exactly as today (200)', async () => {
+    ctx = await boot(false);
+    const r = await api(ctx.server, '/subscription-pool/claude-1', {
+      method: 'PATCH',
+      body: JSON.stringify({ configHome: '/h/.claude-edited' }),
+    });
+    expect(r.status).toBe(200);
+    expect(r.body.configHome).toBe('/h/.claude-edited');
+  });
+
+  it('flag ON → a non-configHome field still PATCHes fine (only configHome is refused)', async () => {
+    ctx = await boot(true);
+    const r = await api(ctx.server, '/subscription-pool/claude-1', {
+      method: 'PATCH',
+      body: JSON.stringify({ nickname: 'renamed' }),
+    });
+    expect(r.status).toBe(200);
+    expect(r.body.nickname).toBe('renamed');
+  });
+});

--- a/tests/unit/account-switcher-provider.test.ts
+++ b/tests/unit/account-switcher-provider.test.ts
@@ -8,7 +8,11 @@
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { AccountSwitcher } from '../../src/monitoring/AccountSwitcher.js';
-import { ClaudeConfigCredentialProvider } from '../../src/monitoring/CredentialProvider.js';
+import {
+  ClaudeConfigCredentialProvider,
+  setCredentialWriteRefusalGate,
+  DEFAULT_CREDENTIAL_SLOT,
+} from '../../src/monitoring/CredentialProvider.js';
 import type { CredentialProvider, ClaudeCredentials } from '../../src/monitoring/CredentialProvider.js';
 import fs from 'node:fs';
 import path from 'node:path';
@@ -74,7 +78,42 @@ describe('AccountSwitcher with CredentialProvider', () => {
   });
 
   afterEach(() => {
+    setCredentialWriteRefusalGate(undefined);
     SafeFsExecutor.safeRmSync(tmpDir, { recursive: true, force: true, operation: 'tests/unit/account-switcher-provider.test.ts:77' });
+  });
+
+  // ── WS5.2 Step 6 census #9: competing-writer refusal at the MANAGER ──
+
+  it('census #9: REFUSES the switch (no write) when the default slot is repointing-owned', async () => {
+    const registry = createRegistry({
+      'dawn@sagemindai.io': { name: 'Dawn', token: 'dawn-token-123' },
+      'justin@sagemindai.io': { name: 'Justin', token: 'justin-token-456' },
+    }, 'dawn@sagemindai.io');
+    fs.writeFileSync(registryPath, JSON.stringify(registry, null, 2));
+    // Re-pointing owns the default slot — a direct switch would clobber the ledger's tenant.
+    setCredentialWriteRefusalGate({ shouldRefuse: (slot) => slot === DEFAULT_CREDENTIAL_SLOT });
+
+    const result = await switcher.switchAccount('justin');
+    expect(result.success).toBe(false);
+    expect(result.message).toContain('set-default'); // points at the sanctioned replacement
+    expect(result.newAccount).toBeNull();
+    // NON-DESTRUCTIVE: the credential was never written, the active account is unchanged.
+    expect(await provider.readCredentials()).toBeNull();
+    const reg = JSON.parse(fs.readFileSync(registryPath, 'utf-8'));
+    expect(reg.activeAccountEmail).toBe('dawn@sagemindai.io');
+  });
+
+  it('census #9: with NO refusal gate installed → the switch proceeds (today\'s behavior)', async () => {
+    const registry = createRegistry({
+      'dawn@sagemindai.io': { name: 'Dawn', token: 'dawn-token-123' },
+      'justin@sagemindai.io': { name: 'Justin', token: 'justin-token-456' },
+    }, 'dawn@sagemindai.io');
+    fs.writeFileSync(registryPath, JSON.stringify(registry, null, 2));
+    setCredentialWriteRefusalGate(undefined);
+
+    const result = await switcher.switchAccount('justin');
+    expect(result.success).toBe(true);
+    expect((await provider.readCredentials())!.accessToken).toBe('justin-token-456');
   });
 
   it('exposes the provider via getProvider()', () => {

--- a/tests/unit/credential-location-gate.test.ts
+++ b/tests/unit/credential-location-gate.test.ts
@@ -1,0 +1,314 @@
+/**
+ * Unit tests for WS5.2 Step 6 — census consumer re-routing through the CredentialLocationGate.
+ *
+ * Spec: docs/specs/live-credential-repointing-rebalancer.md §2.2 (the consumer census table).
+ *
+ * Every re-routed consumer is proven on THREE axes (the load-bearing safety contract):
+ *   (a) flag OFF                      → today's enrollment-home behavior (byte-identical);
+ *   (b) flag ON + ledger KNOWN        → resolves through the ledger;
+ *   (c) flag ON + ledger UNKNOWN/EMPTY → falls back to today's behavior (back-compat).
+ * Plus the four adversarial-lens regressions:
+ *   - E4a-liar: InUseAccountResolver does NOT re-probe `auth status` when enabled + busts cache;
+ *   - competing-writer: writeCredentialsSerialized REFUSES at the manager when slot is owned;
+ *   - hot-path safety: an UNKNOWN-mode read returns the fallback + attention, never throws;
+ *   - dark-ship inertness: the gate-absent path allocates nothing / behaves exactly as today.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+import {
+  CredentialLocationLedger,
+  type IdentityOracle,
+  type LedgerPoolView,
+  type LedgerPoolAccount,
+  type CredentialLedgerAttentionInput,
+} from '../../src/core/CredentialLocationLedger.js';
+import {
+  CredentialLocationGate,
+  type CredentialGateAttentionInput,
+} from '../../src/core/CredentialLocationGate.js';
+import { credentialSlotKey } from '../../src/core/OAuthRefresher.js';
+import { QuotaPoller, type FetchImpl } from '../../src/core/QuotaPoller.js';
+import { InUseAccountResolver } from '../../src/core/InUseAccountResolver.js';
+import { SubscriptionPool, type SubscriptionAccount } from '../../src/core/SubscriptionPool.js';
+import {
+  writeCredentialsSerialized,
+  setCredentialWriteRefusalGate,
+  CredentialWriteRepointingOwnedError,
+} from '../../src/monitoring/CredentialProvider.js';
+import { CredentialWriteFunnel } from '../../src/core/CredentialWriteFunnel.js';
+
+const noopOracle: IdentityOracle = { async resolveSlotTenant() { return { unavailable: true }; } };
+function poolView(accounts: LedgerPoolAccount[]): LedgerPoolView {
+  return { list: () => accounts.slice() };
+}
+
+let tmp: string;
+beforeEach(() => {
+  tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'credgate-'));
+});
+afterEach(() => {
+  setCredentialWriteRefusalGate(undefined);
+  SafeFsExecutor.safeRmSync(tmp, { recursive: true, force: true, operation: 'credential-location-gate.test cleanup' });
+});
+
+/** A ledger with one assignment recorded for `slot → accountId` (seeded, known). */
+function ledgerWith(slot: string, accountId: string): CredentialLocationLedger {
+  const ledger = new CredentialLocationLedger({ stateDir: tmp, pool: poolView([]), oracle: noopOracle });
+  ledger.recordAssignment(slot, accountId);
+  return ledger;
+}
+
+/** A never-seeded ledger (empty assignments) — the back-compat case. */
+function emptyLedger(): CredentialLocationLedger {
+  return new CredentialLocationLedger({ stateDir: tmp, pool: poolView([]), oracle: noopOracle });
+}
+
+/** A ledger forced into UNKNOWN mode via a corrupt on-disk file. */
+function unknownLedger(): CredentialLocationLedger {
+  fs.writeFileSync(path.join(tmp, 'credential-locations.json'), '{ this is not json');
+  return new CredentialLocationLedger({ stateDir: tmp, pool: poolView([]), oracle: noopOracle });
+}
+
+// ── The gate itself ────────────────────────────────────────────────────────────────────────
+
+describe('CredentialLocationGate — slotForAccount / tenantForSlot', () => {
+  it('(a) flag OFF → returns the enrollment home / null (byte-identical to today)', () => {
+    const gate = new CredentialLocationGate({ isEnabled: () => false, ledger: ledgerWith('/home/acct-b', 'acct-a') });
+    expect(gate.slotForAccount('acct-a', '/enroll/acct-a')).toBe('/enroll/acct-a');
+    expect(gate.tenantForSlot('/home/acct-b')).toBeNull();
+  });
+
+  it('(b) flag ON + ledger KNOWN → resolves through the ledger', () => {
+    const gate = new CredentialLocationGate({ isEnabled: () => true, ledger: ledgerWith('/slot/now', 'acct-a') });
+    expect(gate.slotForAccount('acct-a', '/enroll/acct-a')).toBe('/slot/now');
+    expect(gate.tenantForSlot('/slot/now')).toBe('acct-a');
+  });
+
+  it('(c) flag ON + ledger never-seeded → falls back to today (back-compat), no attention', () => {
+    const seen: CredentialGateAttentionInput[] = [];
+    const gate = new CredentialLocationGate({ isEnabled: () => true, ledger: emptyLedger(), emitAttention: (i) => void seen.push(i) });
+    expect(gate.slotForAccount('acct-a', '/enroll/acct-a')).toBe('/enroll/acct-a');
+    expect(gate.tenantForSlot('/slot/x')).toBeNull();
+    expect(seen).toHaveLength(0); // never-seeded is NORMAL, not a degradation
+  });
+
+  it('hot-path safety: UNKNOWN mode → fallback + ONE deduped HIGH attention, never throws', () => {
+    const seen: CredentialGateAttentionInput[] = [];
+    const gate = new CredentialLocationGate({ isEnabled: () => true, ledger: unknownLedger(), emitAttention: (i) => void seen.push(i) });
+    expect(() => gate.slotForAccount('acct-a', '/enroll/acct-a')).not.toThrow();
+    expect(gate.slotForAccount('acct-a', '/enroll/acct-a')).toBe('/enroll/acct-a');
+    expect(gate.tenantForSlot('/slot/x')).toBeNull();
+    // Many reads → ONE attention item (deduped per process).
+    gate.slotForAccount('acct-a', '/enroll/acct-a');
+    gate.tenantForSlot('/slot/x');
+    expect(seen).toHaveLength(1);
+    expect(seen[0].priority).toBe('HIGH');
+  });
+
+  it('hot-path safety: a THROWING attention emitter never escapes the read', () => {
+    const gate = new CredentialLocationGate({
+      isEnabled: () => true,
+      ledger: unknownLedger(),
+      emitAttention: () => { throw new Error('telegram down'); },
+    });
+    expect(() => gate.slotForAccount('acct-a', '/enroll/acct-a')).not.toThrow();
+  });
+
+  it('touchesDefaultHome canonicalizes spellings of ~/.claude', () => {
+    expect(CredentialLocationGate.touchesDefaultHome('~/.claude')).toBe(true);
+    expect(CredentialLocationGate.touchesDefaultHome(credentialSlotKey('~/.claude'))).toBe(true);
+    expect(CredentialLocationGate.touchesDefaultHome('/some/other/home')).toBe(false);
+  });
+});
+
+// ── Census #1–#4: QuotaPoller ────────────────────────────────────────────────────────────────
+
+function acct(over: Partial<SubscriptionAccount> = {}): SubscriptionAccount {
+  return {
+    id: 'acct-a',
+    nickname: 'A',
+    provider: 'anthropic',
+    framework: 'claude-code',
+    configHome: '/enroll/acct-a',
+    status: 'active',
+    ...over,
+  } as SubscriptionAccount;
+}
+const OK_BODY = {
+  five_hour: { utilization: 10, resets_at: '2026-06-07T00:20:00Z' },
+  seven_day: { utilization: 71, resets_at: '2026-06-12T18:59:59Z' },
+};
+const okFetch: FetchImpl = async () => ({ ok: true, status: 200, json: async () => OK_BODY });
+
+describe('QuotaPoller census #1 (token read) — slot re-routing', () => {
+  it('(a) flag OFF → token resolver sees the enrollment home unchanged', async () => {
+    const gate = new CredentialLocationGate({ isEnabled: () => false, ledger: ledgerWith('/slot/now', 'acct-a') });
+    const seenHomes: string[] = [];
+    const poller = new QuotaPoller({
+      pool: new SubscriptionPool({ stateDir: tmp }),
+      fetchImpl: okFetch,
+      tokenResolver: (a) => { seenHomes.push(a.configHome); return 'sk-ant-oat-x'; },
+      locationGate: gate,
+    });
+    await poller.pollAccount(acct());
+    expect(seenHomes).toEqual(['/enroll/acct-a']);
+  });
+
+  it('(b) flag ON + ledger KNOWN → token resolver sees the LIVE slot, account.id preserved', async () => {
+    const gate = new CredentialLocationGate({ isEnabled: () => true, ledger: ledgerWith('/slot/now', 'acct-a') });
+    const seenHomes: string[] = [];
+    const poller = new QuotaPoller({
+      pool: new SubscriptionPool({ stateDir: tmp }),
+      fetchImpl: okFetch,
+      tokenResolver: (a) => { seenHomes.push(a.configHome); expect(a.id).toBe('acct-a'); return 'sk-ant-oat-x'; },
+      locationGate: gate,
+    });
+    await poller.pollAccount(acct());
+    expect(seenHomes).toEqual(['/slot/now']);
+  });
+
+  it('(c) flag ON + ledger never-seeded → enrollment home (back-compat)', async () => {
+    const gate = new CredentialLocationGate({ isEnabled: () => true, ledger: emptyLedger() });
+    const seenHomes: string[] = [];
+    const poller = new QuotaPoller({
+      pool: new SubscriptionPool({ stateDir: tmp }),
+      fetchImpl: okFetch,
+      tokenResolver: (a) => { seenHomes.push(a.configHome); return 'sk-ant-oat-x'; },
+      locationGate: gate,
+    });
+    await poller.pollAccount(acct());
+    expect(seenHomes).toEqual(['/enroll/acct-a']);
+  });
+});
+
+describe('QuotaPoller census #2 (401-refresh) — slot re-routing', () => {
+  it('flag ON + ledger KNOWN → refresher sees the LIVE slot', async () => {
+    const gate = new CredentialLocationGate({ isEnabled: () => true, ledger: ledgerWith('/slot/now', 'acct-a') });
+    const seenHomes: string[] = [];
+    let call = 0;
+    const fetchImpl: FetchImpl = async () => (call++ === 0
+      ? { ok: false, status: 401, json: async () => ({}) }
+      : { ok: true, status: 200, json: async () => OK_BODY });
+    const poller = new QuotaPoller({
+      pool: new SubscriptionPool({ stateDir: tmp }),
+      fetchImpl,
+      tokenResolver: () => 'sk-ant-oat-x',
+      refresher: async (a) => { seenHomes.push(a.configHome); return { ok: true, accessToken: 'sk-ant-oat-fresh' }; },
+      locationGate: gate,
+    });
+    await poller.pollAccount(acct());
+    expect(seenHomes).toEqual(['/slot/now']);
+  });
+});
+
+describe('QuotaPoller census #3 (email auto-patch) — SUPPRESSED while enabled', () => {
+  it('flag ON → no email auto-patch (suppressed)', async () => {
+    const pool = new SubscriptionPool({ stateDir: tmp });
+    pool.add({ id: 'acct-a', nickname: 'A', provider: 'anthropic', framework: 'claude-code', configHome: tmp, email: 'old@x.com' } as never);
+    const gate = new CredentialLocationGate({ isEnabled: () => true, ledger: ledgerWith(tmp, 'acct-a') });
+    // .claude.json in tmp records a DIFFERENT email — today this would be auto-patched.
+    fs.writeFileSync(path.join(tmp, '.claude.json'), JSON.stringify({ oauthAccount: { emailAddress: 'observed@y.com' } }));
+    const updateSpy = vi.spyOn(pool, 'update');
+    const poller = new QuotaPoller({ pool, fetchImpl: okFetch, tokenResolver: () => 'sk-ant-oat-x', locationGate: gate });
+    await poller.pollAll();
+    const patchedEmail = updateSpy.mock.calls.some((c) => (c[1] as Record<string, unknown>).email !== undefined);
+    expect(patchedEmail).toBe(false); // suppressed — no cross-contamination
+  });
+
+  it('flag OFF → email auto-patch happens (today\'s behavior preserved)', async () => {
+    const pool = new SubscriptionPool({ stateDir: tmp });
+    pool.add({ id: 'acct-a', nickname: 'A', provider: 'anthropic', framework: 'claude-code', configHome: tmp, email: 'old@x.com' } as never);
+    const gate = new CredentialLocationGate({ isEnabled: () => false, ledger: ledgerWith(tmp, 'acct-a') });
+    fs.writeFileSync(path.join(tmp, '.claude.json'), JSON.stringify({ oauthAccount: { emailAddress: 'observed@y.com' } }));
+    const updateSpy = vi.spyOn(pool, 'update');
+    const poller = new QuotaPoller({ pool, fetchImpl: okFetch, tokenResolver: () => 'sk-ant-oat-x', locationGate: gate });
+    await poller.pollAll();
+    const patchedEmail = updateSpy.mock.calls.some((c) => (c[1] as Record<string, unknown>).email === 'observed@y.com');
+    expect(patchedEmail).toBe(true);
+  });
+});
+
+// ── Census #8: InUseAccountResolver (the E4a liar) ──────────────────────────────────────────
+
+describe('InUseAccountResolver census #8 — E4a-liar resurrection BLOCKER', () => {
+  const accounts: SubscriptionAccount[] = [
+    { id: 'acct-a', email: 'a@x.com', provider: 'anthropic', framework: 'claude-code' } as SubscriptionAccount,
+    { id: 'acct-b', email: 'b@x.com', provider: 'anthropic', framework: 'claude-code' } as SubscriptionAccount,
+  ];
+
+  it('flag ON + ledger KNOWN → resolves from the ledger, NEVER re-probes auth status', async () => {
+    const probe = vi.fn(async () => 'a@x.com'); // the LYING oracle, would say acct-a
+    const gate = new CredentialLocationGate({ isEnabled: () => true, ledger: ledgerWith('~/.claude', 'acct-b') });
+    const resolver = new InUseAccountResolver({ probe, locationGate: gate });
+    const res = await resolver.resolve(accounts);
+    expect(res.activeAccountId).toBe('acct-b'); // the LEDGER's tenant, not the liar's acct-a
+    expect(res.activeEmail).toBe('b@x.com');
+    expect(probe).not.toHaveBeenCalled(); // THE blocker: no re-probe at all
+  });
+
+  it('flag OFF → re-probes auth status exactly as today', async () => {
+    const probe = vi.fn(async () => 'a@x.com');
+    const gate = new CredentialLocationGate({ isEnabled: () => false, ledger: ledgerWith('~/.claude', 'acct-b') });
+    const resolver = new InUseAccountResolver({ probe, locationGate: gate });
+    const res = await resolver.resolve(accounts);
+    expect(res.activeAccountId).toBe('acct-a');
+    expect(probe).toHaveBeenCalledTimes(1);
+  });
+
+  it('flag ON + ledger never-seeded → falls through to the probe (back-compat)', async () => {
+    const probe = vi.fn(async () => 'a@x.com');
+    const gate = new CredentialLocationGate({ isEnabled: () => true, ledger: emptyLedger() });
+    const resolver = new InUseAccountResolver({ probe, locationGate: gate });
+    const res = await resolver.resolve(accounts);
+    expect(res.activeAccountId).toBe('acct-a');
+    expect(probe).toHaveBeenCalledTimes(1);
+  });
+
+  it('bustCache clears a cached probe result so the next read re-resolves', async () => {
+    let n = 0;
+    const probe = vi.fn(async () => (n++ === 0 ? 'a@x.com' : 'b@x.com'));
+    const resolver = new InUseAccountResolver({ probe, ttlMs: 60_000 });
+    expect((await resolver.resolve(accounts)).activeAccountId).toBe('acct-a');
+    expect((await resolver.resolve(accounts)).activeAccountId).toBe('acct-a'); // cached
+    resolver.bustCache();
+    expect((await resolver.resolve(accounts)).activeAccountId).toBe('acct-b'); // re-probed
+    expect(probe).toHaveBeenCalledTimes(2);
+  });
+});
+
+// ── Census #9: competing-writer refusal at the MANAGER ──────────────────────────────────────
+
+describe('writeCredentialsSerialized census #9 — competing-writer clobber BLOCKER', () => {
+  const fakeProvider = { writeCredentials: vi.fn(async () => {}) };
+
+  it('REFUSES at the manager when the slot is repointing-owned (no write occurs)', async () => {
+    setCredentialWriteRefusalGate({ shouldRefuse: (slot) => slot === credentialSlotKey('~/.claude') });
+    const funnel = new CredentialWriteFunnel();
+    await expect(
+      writeCredentialsSerialized(fakeProvider, '~/.claude', { accessToken: 'x', expiresAt: 0 }, funnel),
+    ).rejects.toBeInstanceOf(CredentialWriteRepointingOwnedError);
+    expect(fakeProvider.writeCredentials).not.toHaveBeenCalled();
+  });
+
+  it('a non-owned slot writes through normally', async () => {
+    fakeProvider.writeCredentials.mockClear();
+    setCredentialWriteRefusalGate({ shouldRefuse: (slot) => slot === credentialSlotKey('~/.claude') });
+    const funnel = new CredentialWriteFunnel();
+    const out = await writeCredentialsSerialized(fakeProvider, '/other/home', { accessToken: 'x', expiresAt: 0 }, funnel);
+    expect(out.ran).toBe(true);
+    expect(fakeProvider.writeCredentials).toHaveBeenCalledTimes(1);
+  });
+
+  it('dark-ship inertness: NO refusal gate installed → write proceeds (today\'s behavior)', async () => {
+    fakeProvider.writeCredentials.mockClear();
+    setCredentialWriteRefusalGate(undefined);
+    const funnel = new CredentialWriteFunnel();
+    const out = await writeCredentialsSerialized(fakeProvider, '~/.claude', { accessToken: 'x', expiresAt: 0 }, funnel);
+    expect(out.ran).toBe(true);
+    expect(fakeProvider.writeCredentials).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/unit/credential-swap-executor.test.ts
+++ b/tests/unit/credential-swap-executor.test.ts
@@ -124,6 +124,7 @@ function makeExecutor(opts: {
   funnel?: CredentialWriteFunnel;
   reverifyDelayMs?: number;
   emitAttention?: (i: { id: string }) => void;
+  onSlotsChanged?: (slots: string[]) => void;
 }) {
   return new CredentialSwapExecutor({
     funnel: opts.funnel ?? new CredentialWriteFunnel(),
@@ -134,6 +135,7 @@ function makeExecutor(opts: {
     reverifyDelayMs: opts.reverifyDelayMs ?? 50,
     swapIdFactory: (() => { let n = 0; return () => `swap${n++}`; })(),
     emitAttention: opts.emitAttention as never,
+    onSlotsChanged: opts.onSlotsChanged,
   });
 }
 
@@ -231,6 +233,28 @@ describe('CredentialSwapExecutor — the happy exchange (keychain-first, identit
     expect(km.map[stagingSvc!]).toBeUndefined();
     const journal = led.getJournal().filter((e) => e.op === 'swap');
     expect(journal.some((e) => e.phase === 'done')).toBe(true);
+  });
+
+  it('census #8: fires onSlotsChanged at commit with both swapped slots (in-use badge cache-bust)', async () => {
+    const km = memKeychain({ [claudeCredentialService(SLOT_A)]: blob(ACC_A), [claudeCredentialService(SLOT_B)]: blob(ACC_B) });
+    const led = makeLedger(stateDir);
+    const changed: string[][] = [];
+    const ex = makeExecutor({ km, ledger: led, resolveIdentity: identityFromMap(km), onSlotsChanged: (s) => changed.push(s) });
+    const res = await ex.swap(SLOT_A, SLOT_B);
+    expect(res.outcome).toBe('swapped');
+    expect(changed).toHaveLength(1);
+    expect(changed[0].sort()).toEqual([SLOT_A, SLOT_B].sort());
+    // SLOT_A is the default `~/.claude` home → the badge cache-bust is warranted.
+    expect(changed[0].some((s) => s === SLOT_A)).toBe(true);
+  });
+
+  it('census #8: a THROWING onSlotsChanged never rolls back the committed swap', async () => {
+    const km = memKeychain({ [claudeCredentialService(SLOT_A)]: blob(ACC_A), [claudeCredentialService(SLOT_B)]: blob(ACC_B) });
+    const led = makeLedger(stateDir);
+    const ex = makeExecutor({ km, ledger: led, resolveIdentity: identityFromMap(km), onSlotsChanged: () => { throw new Error('bust failed'); } });
+    const res = await ex.swap(SLOT_A, SLOT_B);
+    expect(res.outcome).toBe('swapped'); // commit survived a throwing cache-bust
+    expect(led.tenantOf(SLOT_A)).toBe(ACC_B);
   });
 
   it('exactly ONE lineage per readable config home after the exchange (§0.d — no duplicate)', async () => {

--- a/tests/unit/interactive-session-pin.test.ts
+++ b/tests/unit/interactive-session-pin.test.ts
@@ -44,6 +44,11 @@ import { execFileSync } from 'node:child_process';
 import { SessionManager } from '../../src/core/SessionManager.js';
 import { StateManager } from '../../src/core/StateManager.js';
 import type { SessionManagerConfig } from '../../src/core/types.js';
+import { CredentialLocationLedger, type IdentityOracle, type LedgerPoolView } from '../../src/core/CredentialLocationLedger.js';
+import { CredentialLocationGate } from '../../src/core/CredentialLocationGate.js';
+
+const noopOracleForPin: IdentityOracle = { async resolveSlotTenant() { return { unavailable: true }; } };
+const emptyPoolView: LedgerPoolView = { list: () => [] };
 
 describe('interactive session pinning (B1) — unit', () => {
   let dir: string;
@@ -117,6 +122,40 @@ describe('interactive session pinning (B1) — unit', () => {
 
     expect(recordFor(tmux)?.subscriptionAccountId).toBeUndefined();
     expect(hasConfigDir()).toBe(false);
+  });
+
+  // ── WS5.2 Step 6 census #5/#6: pinned spawn home re-routes through the ledger gate ──
+
+  const gateWith = (stateDir: string, enabled: boolean, slot?: string, accountId?: string): CredentialLocationGate => {
+    const ledger = new CredentialLocationLedger({ stateDir, pool: emptyPoolView, oracle: noopOracleForPin });
+    if (slot && accountId) ledger.recordAssignment(slot, accountId);
+    return new CredentialLocationGate({ isEnabled: () => enabled, ledger });
+  };
+
+  it('census #6: flag ON + ledger KNOWN → pins to the account\'s LIVE slot, not its enrollment home', async () => {
+    manager.setSpawnAccountResolver(() => ({ configHome: '/h/.claude-enroll-a', accountId: 'acct-a' }));
+    manager.setCredentialLocationGate(gateWith(path.join(dir, 'state'), true, '/h/.claude-LIVE', 'acct-a'));
+    const tmux = await manager.spawnInteractiveSession(undefined, 'pin-rerouted');
+
+    expect(recordFor(tmux)?.subscriptionAccountId).toBe('acct-a');
+    expect(newSessionArgs()).toContain('CLAUDE_CONFIG_DIR=/h/.claude-LIVE');
+    expect(newSessionArgs()).not.toContain('CLAUDE_CONFIG_DIR=/h/.claude-enroll-a');
+  });
+
+  it('census #6: flag OFF → pins to the enrollment home (byte-identical to today)', async () => {
+    manager.setSpawnAccountResolver(() => ({ configHome: '/h/.claude-enroll-a', accountId: 'acct-a' }));
+    manager.setCredentialLocationGate(gateWith(path.join(dir, 'state'), false, '/h/.claude-LIVE', 'acct-a'));
+    const tmux = await manager.spawnInteractiveSession(undefined, 'pin-flag-off');
+
+    expect(newSessionArgs()).toContain('CLAUDE_CONFIG_DIR=/h/.claude-enroll-a');
+  });
+
+  it('census #6: flag ON + ledger never-seeded → enrollment home (back-compat)', async () => {
+    manager.setSpawnAccountResolver(() => ({ configHome: '/h/.claude-enroll-a', accountId: 'acct-a' }));
+    manager.setCredentialLocationGate(gateWith(path.join(dir, 'state'), true)); // no assignment
+    const tmux = await manager.spawnInteractiveSession(undefined, 'pin-unseeded');
+
+    expect(newSessionArgs()).toContain('CLAUDE_CONFIG_DIR=/h/.claude-enroll-a');
   });
 
   it('seeds onboarding flags on a resolver-pinned headless home, never touching tokens', async () => {

--- a/upgrades/next/ws52-step6-census-rerouting.md
+++ b/upgrades/next/ws52-step6-census-rerouting.md
@@ -1,0 +1,45 @@
+# WS5.2 Step 6 — census consumer re-routing (the live ledger read-path wiring for credential re-pointing)
+
+<!-- bump: patch -->
+
+<!--
+  NOTE: dark/additive + internal. A new exported class src/core/CredentialLocationGate.ts
+  re-routes the spec §2.2 consumer census through the merged CredentialLocationLedger,
+  gated by the EXISTING subscriptionPool.credentialRepointing flag (enabled:false +
+  dryRun:true, already a DARK_GATE_EXCLUSIONS destructive entry) — NO new config flag, so
+  the dark-gate line-map is UNCHANGED (no recompute; lint clean, dark-gate test green
+  as-is). No new credential write path (Step 6 is read re-routing + two ownership-refusal
+  surfaces); lint-no-unfunneled-credential-write clean. Routes/audit-scrub are Step 7.
+-->
+
+## What Changed
+
+Wires the merged credential-location ledger into the live read paths (spec §2.2 — the 12-row consumer census). Every place that today treats a subscription account's enrollment config home as the live LOCATION of its credential now resolves through one chokepoint, the new `CredentialLocationGate`, when the feature is enabled — so once a credential is moved between homes, a poll/spawn/badge reads the home the credential ACTUALLY lives in now, instead of being silently invalidated.
+
+- **One re-route chokepoint** — `CredentialLocationGate` (src/core/CredentialLocationGate.ts) reads the ledger via sync in-memory `slotForAccount`/`tenantForSlot`. Flag-gated: with the feature OFF (the only shipped state) every read returns today's enrollment-home value. Back-compat: a never-seeded ledger ALSO returns today's value. Fail-open-loud: an UNKNOWN-mode (corrupt) ledger returns the fallback AND raises ONE HIGH attention item — it never throws into a poll or spawn.
+- **QuotaPoller (census #1–#4)** — the per-account token read, the 401-refresh exchange, and the needs-reauth attribution all target the account's LIVE slot; the email auto-patch is SUPPRESSED while enabled (it would otherwise cross-contaminate pool emails after a move).
+- **Spawn placement (census #5/#6)** — a pinned pool account's session launches under its CURRENT slot, not its stale enrollment home. An explicit caller-supplied home (the account-swap path) still wins unchanged.
+- **In-use badge (census #8, the lying-oracle fix)** — the dashboard "which account am I on" badge reads the ledger's default-home tenant instead of re-probing the client status command, which lags during the post-move window and would re-cache the wrong account. The badge cache is busted the moment a default-home move commits.
+- **Competing-writer refusal (census #9)** — a manual account switch / auto-migrate that would write a moved home is refused at the MANAGER (the single credential-write funnel), not just on a route, with a plain-English message pointing at the correct replacement. The refusal is non-destructive — nothing is written.
+- **Config-home edit lock (census #10/#11)** — editing an account's config-home field via the pool API is refused (409) while enabled — that field is enrollment metadata, not the live location.
+- **Dark** — gated by the existing `subscriptionPool.credentialRepointing` flag (`enabled:false`). With the feature off (the fleet + dev default) every consumer is byte-for-byte today's behavior; the refusal surfaces refuse nothing; the config-home lock never fires.
+
+The HTTP routes and the audit-scrub chokepoint that expose this to the operator are Step 7 (a later increment).
+
+## What to Tell Your User
+
+This is internal plumbing that ships turned off, so day to day nothing changes for you. What it builds toward: when I hold more than one of your subscription accounts and move a credential between them under the hood, all the parts of me that read your accounts now agree on where each one actually lives — the quota poller checks the right account, a new session launches on the right account, the dashboard badge shows the right account, and a stale background process can no longer silently overwrite a moved account and resurrect an old one. Before this, those readers each trusted a separate, easily-outdated note about where an account lived, so a move could quietly make them disagree. It is off by default and does nothing until it is deliberately turned on after a review window. If something does go wrong while it is on, it fails toward today's behavior and tells me loudly, rather than guessing.
+
+## Summary of New Capabilities
+
+New exported `CredentialLocationGate` (src/core/CredentialLocationGate.ts) — the spec §2.2 census re-routing chokepoint of live credential re-pointing. Gated by the existing `subscriptionPool.credentialRepointing` flag; no new config flag, no new HTTP route (routes are Step 7). Re-routes QuotaPoller, SessionManager spawn placement, InUseAccountResolver, the credential-write funnel (manager-level competing-writer refusal), and the pool config-home PATCH through the merged Step 2 location ledger.
+
+## Evidence
+
+- `tests/unit/credential-location-gate.test.ts` (19) — the gate (flag-off/on-known/on-unknown, fail-open-loud, dedup attention, throwing-emitter safety); QuotaPoller census #1/#2 slot re-route + #3 email-suppress (both sides); InUseAccountResolver census #8 (E4a-liar: never re-probes when enabled, ledger-known short-circuit, never-seeded fall-through, bustCache); competing-writer refusal #9 (manager refuse + non-owned write-through + no-gate inertness).
+- `tests/unit/credential-swap-executor.test.ts` (+2) — census #8 `onSlotsChanged` fires at commit with both swapped slots; a throwing cache-bust never rolls back the committed swap.
+- `tests/unit/interactive-session-pin.test.ts` (+3) — census #6 spawn re-route (flag-on-known → live slot; flag-off → enrollment home; never-seeded → enrollment home).
+- `tests/unit/account-switcher-provider.test.ts` (+2) — census #9 AccountSwitcher manager-refusal (refused switch, no write, active account unchanged) + no-gate proceeds.
+- `tests/integration/credential-repointing-census-routes.test.ts` (3) — PATCH config-home → 409 when enabled, 200 when off, non-config-home field still PATCHes when enabled.
+- `tests/e2e/credential-repointing-census-lifecycle.test.ts` (2) — feature-alive: flag-OFF strict no-op end-to-end (badge re-probes, poll reads enrollment home, PATCH allowed) + flag-ON ledger short-circuit (badge no re-probe, PATCH 409).
+- tsc clean; full `npm run lint` clean; dark-gate unchanged (no ConfigDefaults touched); docs-coverage green.

--- a/upgrades/side-effects/ws52-step6-census-rerouting.md
+++ b/upgrades/side-effects/ws52-step6-census-rerouting.md
@@ -1,0 +1,143 @@
+# Side-Effects Review — WS5.2 Step 6: census consumer re-routing (live credential re-pointing, dark)
+
+**Version / slug:** `ws52-step6-census-rerouting`
+**Date:** `2026-06-13`
+**Author:** `Echo`
+**Second-pass reviewer:** `4-adversarial-lens self-review (folded as named tests)`
+
+## Summary of the change
+
+Step 6 of live credential re-pointing (spec §2.2). Every place in the live code that today treats a
+pool account's enrollment `configHome` as the LIVE location of its credential is re-routed through a
+single new chokepoint, `CredentialLocationGate`, which reads the `CredentialLocationLedger` (Steps
+1–5, merged). The gate is FLAG-GATED on the EXISTING `subscriptionPool.credentialRepointing.enabled`
+(no new config flag → the dark-gate line-map is UNCHANGED), back-compat-on-unknown (a never-seeded /
+UNKNOWN ledger falls back to today's enrollment-home behavior), and fail-open-loud (an UNKNOWN-mode
+read returns the fallback + ONE HIGH attention, never throws into a hot path). Files touched:
+`src/core/CredentialLocationGate.ts` (new), `src/core/QuotaPoller.ts` (census #1–#4),
+`src/core/InUseAccountResolver.ts` (census #8, the E4a liar), `src/core/SessionManager.ts` (census
+#5/#6 spawn placement), `src/monitoring/CredentialProvider.ts` (census #9 manager-level refusal gate),
+`src/monitoring/AccountSwitcher.ts` (surfaces the #9 refusal cleanly),
+`src/core/CredentialSwapExecutor.ts` (an `onSlotsChanged` commit hook for the #8 cache-bust),
+`src/server/routes.ts` (census #10/#11 PATCH configHome → 409), `src/commands/server.ts` (the wiring
+chain: ledger + gate + consumers + the process-shared refusal gate).
+
+## Decision-point inventory
+
+- `CredentialLocationGate.slotForAccount/tenantForSlot` — add — the single re-route chokepoint; flag-gated, back-compat-on-unknown, fail-open-loud.
+- `QuotaPoller.accountForReads` — add — resolves each account's live slot for token read / 401-refresh / needs-reauth; email auto-patch SUPPRESSED while enabled.
+- `InUseAccountResolver.resolve` — modify — when enabled + ledger-known, resolves the default badge from the ledger instead of a `claude auth status` re-probe; `bustCache()` added.
+- `SessionManager.resolvePinnedSpawnHome` — add — a pinned account's spawn home resolves through the ledger; an explicit caller home (account-swap path) still wins.
+- `writeCredentialsSerialized` refusal gate — add — a manager-level competing-writer refusal at the funnel chokepoint (not only the route).
+- `PATCH /subscription-pool/:id` configHome — modify — refused 409 while enabled.
+- `CredentialSwapExecutor.onSlotsChanged` — add — a best-effort commit hook that busts the in-use badge on a default-slot swap.
+
+---
+
+## 1. Over-block
+
+The only block surfaces are: (a) the PATCH-409 on `configHome` — refuses ONLY when the flag is
+enabled (always off while dark), and ONLY the `configHome` field (every other field still PATCHes);
+(b) the manager-level competing-writer refusal — refuses ONLY when the flag is enabled AND the ledger
+holds a tenant for the (canonicalized) slot. A legitimate switch to a slot the ledger does NOT own is
+not refused. With the flag off (the shipped dark state) neither block fires: no over-block surface
+exists in the shipped configuration.
+
+---
+
+## 2. Under-block
+
+The competing-writer refusal keys on "the ledger holds a tenant for this canonical slot." If a writer
+targets a slot the ledger has never recorded (a brand-new enrollment home not yet seeded), it is NOT
+refused — but that slot is not repointing-owned, so writing it cannot clobber a ledger tenant; this is
+correct back-compat, not an under-block. The refusal is at the SOLE manager funnel
+(`writeCredentialsSerialized`), so a non-route caller cannot dodge it — the spec §2.7 "every item a
+unique source dodge" is closed by construction.
+
+---
+
+## 3. Level-of-abstraction fit
+
+`CredentialLocationGate` is a thin DETECTOR/router (sync in-memory ledger read + a flag check), not an
+authority — it never decides policy, it answers "where does account X live now?" The single authority
+in the change is the manager-level refusal, which is a deterministic ownership check (does the ledger
+own this slot?) — the correct altitude per spec §2.7 (manager chokepoint, not a brittle route guard).
+The gate FEEDS the existing consumers; it does not run parallel to them. The ledger (Step 2) is the
+lower-level primitive the gate USES; nothing is re-implemented.
+
+---
+
+## 4. Signal vs authority compliance
+
+**Reference:** docs/signal-vs-authority.md
+
+- [x] No — the re-routing reads are SIGNAL (advisory location resolution feeding existing consumers);
+      the two block surfaces (PATCH-409, competing-writer refusal) are deterministic OWNERSHIP checks
+      over durable ledger state, not brittle heuristics — they have full structural context (the
+      ledger is the single source of truth), so they are smart-gate-equivalent, not brittle detectors.
+
+The gate reads never own block authority: an UNKNOWN-mode read fails OPEN (returns the enrollment
+fallback + an attention item), so a corrupt ledger degrades to today's behavior, never blocks a poll
+or a spawn.
+
+---
+
+## 5. Interactions
+
+- **Shadowing:** the PATCH-409 runs BEFORE `subscriptionPool.update` in `/subscription-pool/:id` — when it fires the update never runs (intended; the field-edit must not land). Other fields are unaffected. The competing-writer refusal runs BEFORE the funnel lock in `writeCredentialsSerialized` — when it fires no lock is taken and no write occurs (intended, non-destructive).
+- **Double-fire:** the swap-commit `onSlotsChanged` fires exactly once per committed swap; it is best-effort and a throwing consumer is swallowed (the commit is the load-bearing op and is never rolled back by a cache-bust failure — proven by a named test).
+- **Races:** the gate reads are sync in-memory (no shared mutable state); the refusal gate reads the ledger's in-memory assignments (single-writer process). The InUseAccountResolver cache-bust is idempotent.
+- **Feedback loops:** the email auto-patch SUPPRESSION removes a feedback loop that previously cross-contaminated pool emails after a swap (spec §2.2 #3) — a net REDUCTION in a feedback path.
+
+---
+
+## 6. External surfaces
+
+- **Other agents on the same machine:** none — the ledger/gate are per-machine and read-only over the local ledger.
+- **Install base:** none while dark (flag off → byte-identical behavior; proven by the E2E strict-no-op test + per-consumer flag-off unit tests).
+- **External systems:** none — no new network calls; the gate is a pure in-memory read-router.
+- **Persistent state:** reads the existing `state/credential-locations.json` (Step 2); writes nothing new (Step 6 is read re-routing + two refusal surfaces — neither adds a credential write; the `lint-no-unfunneled-credential-write` lint is clean).
+- **Operator surface:** the PATCH-409 changes a `/subscription-pool/:id` response (409 with a plain-English message pointing at `POST /credentials/set-default`) ONLY when the flag is enabled. The AccountSwitcher refusal returns a `SwitchResult` with a plain-English message — phone-surfaced via the existing `/switch-account` Telegram command path. No new operator-only API action is introduced.
+
+## 6b. Operator-surface quality
+
+No operator surface (no dashboard renderer / approval page / grant form) is added or touched — the
+dashboard Subscriptions-tab `/credentials/locations` fetch is census #11, which Step 7 owns per the
+build plan §6/§7 sequencing. Not applicable to this step.
+
+---
+
+## 7. Multi-machine posture (Cross-Machine Coherence)
+
+**machine-local BY DESIGN.** The reason it SHOULD differ per machine: each machine's
+`CredentialLocationLedger` is the truth for ITS OWN slots (`SubscriptionPool` decision 1A —
+per-machine enrollment = independent grant lineages). An N-machine pool has N independent ledgers and
+this step adds NO cross-machine read. A swap on machine A never needs to bust machine B's in-use cache
+(B's `~/.claude` is a different physical slot with a different credential). Degrades safely:
+ledger-unknown on any machine → that machine shows today's (re-probed) badge / enrollment-home reads.
+No user-facing notice is emitted by the re-routing (the only notice is the UNKNOWN-mode HIGH attention,
+which is a per-machine local degradation surface — correct as machine-local). No durable cross-machine
+state is created; no URLs are generated. (Phase C of the build prompt, answered explicitly.)
+
+---
+
+## Rollback
+
+Pure dark-ship: the feature is gated on `subscriptionPool.credentialRepointing.enabled` (default
+false). With the flag off — the only shipped state — every census consumer is byte-for-byte today's
+behavior, the refusal gate refuses nothing, the PATCH-409 never fires. To roll back the code entirely,
+revert this commit; nothing persists (no migration, no new state file — the ledger file predates this
+step). No two-flag flip is part of this step.
+
+## 4-adversarial-lens verdict
+
+1. **E4a-liar resurrection (THE blocker) — PASS.** `InUseAccountResolver` does NOT re-probe `claude auth status` for the default badge when enabled + ledger-known; it reads `ledger.tenantOf('~/.claude')`. `bustCache()` clears the cache, fired at swap-commit by `onSlotsChanged` for any `~/.claude` swap. Named tests: "resolves from the ledger, NEVER re-probes auth status" (`probe` spy asserted `.not.toHaveBeenCalled()`) + "bustCache clears a cached probe result" + the E2E flag-on `probeCalls() === 0`.
+2. **Competing-writer clobber — PASS.** The refusal lives at the MANAGER (`writeCredentialsSerialized`), before the funnel lock; a non-route caller inherits it. Named tests: "REFUSES at the manager when the slot is repointing-owned (no write occurs)" + AccountSwitcher "REFUSES the switch (no write) … active account unchanged."
+3. **Hot-path safety — PASS.** A ledger UNKNOWN-mode read returns the enrollment fallback + ONE deduped HIGH attention, never throws. Named tests: "UNKNOWN mode → fallback + ONE deduped HIGH attention, never throws" + "a THROWING attention emitter never escapes the read."
+4. **Dark-ship inertness — PASS.** Flag off → every consumer byte-for-byte today. Named tests: the per-consumer flag-OFF unit tests (every census row) + the E2E "FLAG OFF: the full wiring is alive AND strictly inert" (in-use re-probes, quota reads enrollment home, PATCH allowed).
+
+## Test tiers
+
+- Unit: `tests/unit/credential-location-gate.test.ts` (19), additions to `credential-swap-executor.test.ts` (#8 cache-bust + throw-safety), `interactive-session-pin.test.ts` (#6 spawn re-route ×3), `account-switcher-provider.test.ts` (#9 refusal ×2).
+- Integration: `tests/integration/credential-repointing-census-routes.test.ts` (PATCH-409 live, flag-off 200, non-configHome field still PATCHes).
+- E2E: `tests/e2e/credential-repointing-census-lifecycle.test.ts` (feature-alive: flag-off strict no-op end-to-end + flag-on ledger short-circuit).


### PR DESCRIPTION
## ELI16 — When I move a credential between accounts, every part of me now agrees on where each account actually lives, instead of trusting a stale note that a move silently invalidates.

WS5.2 Step 6 of live credential re-pointing (spec §2.2 — the 12-row consumer census). Wires the merged `CredentialLocationLedger` (Steps 1–5) into the live read paths through ONE new chokepoint, `CredentialLocationGate`. Every place that today treats a pool account's enrollment `configHome` as the LIVE location of its credential now resolves through the ledger when the feature is enabled — so a swap can't be silently invalidated. **Ships DARK** on the EXISTING `subscriptionPool.credentialRepointing` flag (no new config flag → dark-gate line-map UNCHANGED).

### Census rows wired
- **#1–#4 QuotaPoller** — token read / 401-refresh / needs-reauth resolve the account's live slot; email auto-patch SUPPRESSED while enabled (no pool-email cross-contamination after a move).
- **#5/#6 SessionManager spawn placement** — a pinned account's session launches under its CURRENT slot, not the stale enrollment home (an explicit caller home still wins).
- **#8 InUseAccountResolver (the E4a liar)** — the default badge reads `ledger.tenantOf('~/.claude')` instead of re-probing `claude auth status` (which lags during the post-swap metadata-repair window and would re-cache the wrong tenant for 60s); `bustCache()` fires at swap-commit via the new `CredentialSwapExecutor.onSlotsChanged` hook for any `~/.claude` swap.
- **#9 AccountSwitcher / autoMigrate** — REFUSE at the MANAGER (`writeCredentialsSerialized` funnel chokepoint, not only the route) when the slot is repointing-owned — non-destructive, points at `POST /credentials/set-default`.
- **#10/#11 pool configHome PATCH → 409** while enabled.

### Safety contract (all proven by tests)
1. **Flag-gated + back-compat.** Flag off → byte-for-byte today; flag on + ledger never-seeded/UNKNOWN → also today's behavior.
2. **Sync + fail-open-loud.** Ledger reads are sync in-memory; UNKNOWN mode returns the enrollment fallback + ONE HIGH attention, NEVER throws into the QuotaPoller/spawn hot path.
3. **No new unfunneled write** — Step 6 is read re-routing + two ownership-refusal surfaces; `lint-no-unfunneled-credential-write` clean.

### Phase C — multi-machine posture
**Machine-local BY DESIGN.** Each machine's `CredentialLocationLedger` is the truth for ITS OWN slots (`SubscriptionPool` decision 1A — per-machine enrollment = independent grant lineages). An N-machine pool has N independent ledgers; this step adds NO cross-machine read. A swap on machine A never needs to bust machine B's in-use cache (B's `~/.claude` is a different physical slot). Degrades safely: ledger-unknown on any machine → that machine shows today's (re-probed) badge / enrollment-home reads. No user-facing notice from the re-routing (only the UNKNOWN-mode HIGH attention, a correct per-machine local degradation surface); no durable cross-machine state created; no URLs generated.

### 4-adversarial-lens verdict
1. **E4a-liar resurrection (THE blocker) — PASS.** InUseAccountResolver does NOT re-probe `auth status` when enabled + ledger-known; reads `ledger.tenantOf('~/.claude')`; cache busted at swap-commit. Named tests: "resolves from the ledger, NEVER re-probes auth status" (probe spy asserted `.not.toHaveBeenCalled()`), "bustCache clears a cached probe result", and the E2E flag-on `probeCalls() === 0`.
2. **Competing-writer clobber — PASS.** Refusal lives at the MANAGER (`writeCredentialsSerialized`), before the funnel lock; a non-route caller inherits it. Named tests: "REFUSES at the manager … (no write occurs)" + AccountSwitcher "REFUSES the switch … active account unchanged".
3. **Hot-path safety — PASS.** UNKNOWN-mode read returns the fallback + ONE deduped HIGH attention, never throws. Named tests: "UNKNOWN mode → fallback + ONE deduped HIGH attention, never throws" + "a THROWING attention emitter never escapes the read".
4. **Dark-ship inertness — PASS.** Flag off → every consumer byte-for-byte today. Named tests: per-consumer flag-OFF units + the E2E "FLAG OFF: the full wiring is alive AND strictly inert".

### Tests (3 tiers)
- **Unit** — `credential-location-gate.test.ts` (19) + additions to `credential-swap-executor.test.ts`, `interactive-session-pin.test.ts`, `account-switcher-provider.test.ts`.
- **Integration** — `credential-repointing-census-routes.test.ts` (PATCH-409 live / flag-off 200 / non-configHome still PATCHes).
- **E2E** — `credential-repointing-census-lifecycle.test.ts` (server-wired flag-off strict no-op + flag-on ledger short-circuit).

tsc clean; full `npm run lint` clean; dark-gate 16/16 unchanged (no ConfigDefaults touched); docs-coverage green. Single clean feat commit through the /instar-dev gate. Routes + audit-scrub chokepoint are Step 7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)