### PR TITLE
feat(dev-gate): retire deliberate-fleet-default catch-all + action-bearing category (CMT-1438)

### DIFF
--- a/.instar/instar-dev-decisions/2026-06-13T20-14-53-367Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-06-13T20-14-53-367Z-unknown.json
@@ -1,0 +1,17 @@
+{
+  "ts": "2026-06-13T20:14:53.367Z",
+  "slug": "unknown",
+  "suggestedTier": 2,
+  "declaredTier": 2,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "irreversibility: src/core/PostUpdateMigrator.ts touches PostUpdateMigrator",
+    "migration / fleet-rollout surface: src/core/PostUpdateMigrator.ts touches PostUpdateMigrator (fleet migration machinery)",
+    "new capability: new config key added"
+  ],
+  "belowFloor": false,
+  "files": 9,
+  "loc": 322,
+  "causalAutopsy": null,
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-06-13T20-18-23-690Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-06-13T20-18-23-690Z-unknown.json
@@ -1,0 +1,17 @@
+{
+  "ts": "2026-06-13T20:18:23.690Z",
+  "slug": "unknown",
+  "suggestedTier": 2,
+  "declaredTier": 2,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "irreversibility: src/core/PostUpdateMigrator.ts touches PostUpdateMigrator",
+    "migration / fleet-rollout surface: src/core/PostUpdateMigrator.ts touches PostUpdateMigrator (fleet migration machinery)",
+    "new capability: new config key added"
+  ],
+  "belowFloor": false,
+  "files": 9,
+  "loc": 322,
+  "causalAutopsy": null,
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-06-13T20-19-24-302Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-06-13T20-19-24-302Z-unknown.json
@@ -1,0 +1,17 @@
+{
+  "ts": "2026-06-13T20:19:24.302Z",
+  "slug": "unknown",
+  "suggestedTier": 2,
+  "declaredTier": 2,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "irreversibility: src/core/PostUpdateMigrator.ts touches PostUpdateMigrator",
+    "migration / fleet-rollout surface: src/core/PostUpdateMigrator.ts touches PostUpdateMigrator (fleet migration machinery)",
+    "new capability: new config key added"
+  ],
+  "belowFloor": false,
+  "files": 9,
+  "loc": 322,
+  "causalAutopsy": null,
+  "verdict": "pass"
+}

--- a/docs/specs/DEV-AGENT-DARK-GATE-TEETH-SPEC.md
+++ b/docs/specs/DEV-AGENT-DARK-GATE-TEETH-SPEC.md
@@ -1,0 +1,446 @@
+---
+title: Dev-Agent Dark-Gate Teeth — retire the deliberate-fleet-default catch-all
+status: draft
+parent-principle: "Structure beats Willpower"
+tags: [side-effects]
+author: echo
+created: 2026-06-13
+eli16-overview: dev-agent-dark-gate-teeth.eli16.md
+lessons-engaged:
+  - "P2 Signal vs. Authority: the lint is a signal-emitter (closes the invalid/unclassified-category hole); D4 code-grounding + GrowthMilestoneAnalyst R6 are the authority-tier backstop against MIScategorization — the spec does not over-claim the lint prevents that."
+  - "P3 Migration Parity: a reclassification that only works for new agents is broken — D5 adds a dev-agent-only one-shot PostUpdateMigrator strip of stale persisted enabled:false for the 4 newly-DEV_GATED paths (mirrors migrateCartographerDevGate), with a test tier."
+  - "P4 Testing Integrity: the migration is the most load-bearing change and gets its own unit test (stale-false stripped on dev / untouched on fleet / operator-true preserved / idempotent)."
+  - "P7 LLM-Supervised Execution: correctionLearning's per-message Tier-1 distill is exactly why it is classified cost-bearing (held off-on-dev), not observe-only."
+  - "P14 Distrust Temporary Success / P16: the deliberate-fleet-default bucket was a temporary success (each mis-park fixed one-off, PR #1105) hiding the root cause — retiring the catch-all is the root-cause fix."
+  - "P17 Bounded Notification Surface: releaseReadiness's attention path routes through the budgeted createForumTopic funnel; the two high-volume Telegram senders are held as action-bearing exclusions precisely to avoid an unbounded-on-dev flood."
+  - "L6 Side-effects (7 dimensions): the side-effects artifact dimensions over/under-block, abstraction, external surfaces, interactions (esp. shared _instar_migrations namespace with migrateCartographerDevGate), and rollback."
+relates_to:
+  - DEV-AGENT-DARK-GATE-ENFORCEMENT-SPEC.md
+  - DEV-AGENT-DARK-GATE-CONFORMANCE-SPEC.md
+  - STANDARDS-REGISTRY.md (standard_development_agent_dark_feature_gate)
+approved: true
+approval:
+  by: Justin
+  channel: telegram:12476
+  at: 2026-06-13T11:52:34-07:00
+  decision: "Build the TEETH guard; move all 7 safe features (parallel-work sentinel, failure-learning, correction/preference sentinel, apprenticeship-SLA, gemini-capacity, release-readiness, read-only boot /health responder) LIVE on Echo."
+review-convergence: "2026-06-13T19:44:59.569Z"
+review-iterations: 6
+review-completed-at: "2026-06-13T19:44:59.569Z"
+review-report: "docs/specs/reports/dev-agent-dark-gate-teeth-convergence.md"
+cross-model-review: "codex-cli:gpt-5.5"
+single-run-completable: true
+frontloaded-decisions: 8
+cheap-to-change-tags: 0
+contested-then-cleared: 3
+---
+
+# Dev-Agent Dark-Gate Teeth
+
+## ELI16 — A feature can only be parked "off even on dev agents" if it proves it would be genuinely unsafe to run there (it kills things, spends money, takes a real external action, or needs config it doesn't have). The vague "off for everyone by policy" bucket is retired, because that's exactly where safe features got hidden by accident.
+
+## Why this exists (grounded requirement)
+
+Justin, 2026-06-12, topic 12476 — immediately after approving Threadline Phase 2:
+
+> "And please make sure we enforce that all features get enabled for dev agents"
+
+My reply (22:40) set the enforceable shape, which he did not push back on:
+
+> "the enforceable rule isn't 'literally everything on,' it's: dev-gated is the
+> DEFAULT, and the only way to opt a feature OUT of dev (the 'off even on dev'
+> bucket) is to justify why dev-live is genuinely unsafe — destructive,
+> action-bearing, or cost-bearing — and have it reviewed."
+
+### What already exists (do not rebuild)
+
+PR #1056 (merged to canonical main 2026-06-10) shipped the machinery:
+- `src/core/devAgentGate.ts` — `resolveDevAgentGate(explicit, config)`: omit `enabled`
+  from defaults → the flag resolves `true` on a `developmentAgent` agent, `false`
+  on the fleet. The single funnel.
+- `src/core/devGatedFeatures.ts` — two registries: `DEV_GATED_FEATURES`
+  (live-on-dev, dark-on-fleet) and `DARK_GATE_EXCLUSIONS` (off-even-on-dev, each
+  tagged with a `DarkGateCategory` + a `reason`).
+- `scripts/lint-dev-agent-dark-gate.js` — Assertion C: every literal
+  `enabled: false` in `ConfigDefaults.ts` MUST be registered in one bucket or the
+  other; an exclusion needs a valid category + a ≥12-char reason. Runs in CI.
+
+So the "unclassified dark default" hole is already closed. **This spec does not
+re-open it.**
+
+### The remaining hole (the precise CMT-1438 gap)
+
+The `DarkGateCategory` enum contains a catch-all member:
+
+```
+'destructive' | 'optional-integration' | 'cost-bearing' | 'structural-stub'
+| 'deliberate-fleet-default'   ← the catch-all with no teeth
+```
+
+The lint accepts `deliberate-fleet-default` as a fully-valid category. So a feature
+that is perfectly safe to dogfood on a dev agent can be parked off-even-on-dev
+with nothing more than a 12-character sentence — no obligation to prove it is
+actually unsafe there. The category *is* the escape hatch.
+
+This is not hypothetical. The single-negotiator lease (Phase 1) was mis-parked in
+`deliberate-fleet-default` at ship, which starved its FD-7 dry-run telemetry and
+would have blocked the feature from ever graduating — caught by Justin, fixed in
+PR #1105. The fix was one-off; the bucket that *allowed* it is still open.
+
+**Live evidence in the registry today** — of the 11 current
+`deliberate-fleet-default` entries, **6 confess the loophole in their own reason
+strings** (each calls itself observe-only and flags itself as a dev-gating candidate
+for a later audit): `parallelWorkSentinel`, `failureLearning`, `correctionLearning`,
+`apprenticeshipCycleSla`, `geminiCapacityEscalation`, `releaseReadiness`. These
+are safe-on-dev features sitting in the off-on-dev bucket because the bucket let
+them. **This spec IS that audit; retiring the catch-all closes the
+*unclassified/non-reason* hole structurally so it can't recur** — the
+*miscategorization* hole (a safe feature parked under a dishonest-but-valid
+category) is closed by D4 + the R6 runtime cross-check, not by the lint alone
+(Signal vs. Authority — see Security). The audit itself also flagged that 3 of
+those 6 "confessed safe" features are NOT actually safe-on-dev once you read their
+code (D4) — proof the reason strings are a hypothesis, not the verdict.
+
+## The standard being sharpened
+
+`standard_development_agent_dark_feature_gate` (STANDARDS-REGISTRY.md) already says
+dev-gated is the default and a dark default must be a deliberate, classified
+choice. This spec gives the "off even on dev" half of that classification **teeth**:
+the classification must name a *concrete reason the feature is unsafe on dev*, not
+merely assert "policy." A bucket whose only meaning is "off because we said so" is
+willpower wearing a category label.
+
+## The design — retire the catch-all, force a concrete unsafe-on-dev reason
+
+### D1. Drop `deliberate-fleet-default` from `DarkGateCategory`.
+
+Every surviving category must name a **concrete reason dev-live is the wrong place
+to run the feature** — and that reason is one of two honest kinds: the feature is
+*unsafe* on dev (it does something it shouldn't), or it is *not runnable* on dev
+(there is nothing to dogfood). What is retired is the *third* kind — "off because we
+said so," a non-reason. The valid set:
+
+| category | kind | meaning |
+|---|---|---|
+| `destructive` | unsafe | kills/deletes/mutates on a heuristic (reapers) |
+| `cost-bearing` | unsafe | spends real third-party / LLM money when live |
+| `action-bearing` | unsafe | **(new)** when merely *enabled*, automatically produces an outbound side-effect that reaches an external system or the operator — merges a PR, sends a user-facing message/escalation (incl. a Telegram attention topic), mutates a remote. Distinct from a *local* signal/record (an in-process event, a JSONL line, a queried-only attention item). De-dup / rate-limiting reduces severity but does NOT reclassify it — an auto-send is an auto-send. An `action-bearing` **reason should name the action type and whether it is bounded/deduped** (so a reviewer can weigh severity; a future split into `external-mutation` vs `operator-notification` is a possible refinement, not done here). A feature here is held off-on-dev but stays opt-in per agent (an explicit `enabled: true` is always allowed). |
+| `optional-integration` | not-runnable | cannot function without per-deployment config/credential/allowlist — live-on-dev would be inert or error, not unsafe. The reason **must name the gating config/credential/allowlist** (so "needs config" can't become the new soft parking spot). |
+| `structural-stub` | not-runnable | no runtime consumer wired yet (dead flag) |
+
+There is no "off by policy" member. If a feature is safe AND runnable on a dev
+agent, the only correct home is `DEV_GATED_FEATURES`.
+
+**Classification rule (the decision a reviewer applies):** classify by **what is
+reachable under normal configured dev operation**, not by the worst thing the code
+could do under some other config. A feature whose unsafe path is gated behind a
+*second* switch that ships dark (e.g. `releaseReadiness`'s send, behind the
+off-by-default `release-readiness-check` job) is classified by its reachable
+behavior with that second switch at its default (read-only) — and the dependency is
+named explicitly (D4) + pinned by a test (Testing), never left implicit.
+
+**Honest scope (Signal vs. Authority, P2).** Retiring one catch-all does not make
+abuse impossible — it relocates the soft surface to the gentlest *valid* category
+(`optional-integration` / `structural-stub`), which describe "not runnable," not
+"unsafe." The lint adjudicates category *spelling + reason length*, never category
+*honesty*; a dishonest-but-valid label still passes CI. The real backstops against
+mis-parking a safe feature are **D4 code-grounding** (build-time) and the
+**GrowthMilestoneAnalyst R6 runtime cross-check** (flags a registered dev-gated
+feature observed dark on a live dev agent) — not this lint. The `optional-integration`
+"must name the gating config" rule above is a **review/D4 convention + reason-quality
+bar on a CODEOWNERS-reviewed path** (the human-gate model the registry already runs
+under, per `devGatedFeatures.ts`'s docstring) — honestly NOT lint-enforced (the lint
+validates only category membership + reason length ≥12). Naming it raises the bar a
+reviewer checks; it does not pretend the lint adjudicates it.
+
+`action-bearing` is added because four occupants are genuinely unsafe-on-dev for a
+reason none of the existing categories captured: `greenPrAutoMerge` (merges PRs),
+`threadline.a2aCheckIn` (sends user-facing summaries — floods the operator), and
+(found by D4) `apprenticeshipCycleSla` + `geminiCapacityEscalation` (auto-post a
+Telegram attention topic on enable). Folding these into `destructive` would be
+dishonest; they deserve their own concrete reason.
+
+### D2. Lint teeth (Assertion D, in `lint-dev-agent-dark-gate.js` + `lib/dark-gate-attribution.js`).
+
+- Remove `deliberate-fleet-default` from `VALID_CATEGORIES` **(in
+  `scripts/lib/dark-gate-attribution.js`, where the set lives)** AND from the
+  `DarkGateCategory` TS union **(in `src/core/devGatedFeatures.ts`)**, adding
+  `action-bearing` to both — the two must move together or the lint and the type
+  drift. Any `DARK_GATE_EXCLUSIONS` entry still using the retired category fails CI
+  with a fix message naming the concrete categories and pointing the author to
+  `DEV_GATED_FEATURES` if the feature is actually safe-on-dev.
+- **Close the silent-skip gap (round-1 adversarial finding).** `extractRegistry`'s
+  `entryRe` only matches exclusion entries whose `reason` is a quote-delimited
+  string; an entry written with a **backtick/template-literal reason** is counted
+  by the path regex (`configPathOf`) but invisible to the entry regex, so its
+  category + reason validation is **silently skipped** — an author could ship a
+  bogus category past CI. The lint must assert `exclusionEntries.length ===
+  exclusionPaths.length` and fail loudly on mismatch (a parsed-path-without-a-parsed-
+  entry means a malformed/unparseable entry that escaped validation). This is the
+  honest "the validator must see every entry" guard.
+- Otherwise a pure tightening of the existing closed-enum check (Assertion C) — no
+  new scan surface, no new line-number map.
+
+### D3. Reclassify the 11 current occupants (the audited one-time pass).
+
+The table below is the **final classification after D4 grounding** (see "D4
+grounding result" below). The hypothesis (operator-approved O1) was to move all 7
+candidates to DEV_GATED; the per-feature code check held 4 live and kept 3 as
+exclusions with honest categories — exactly the D4 override the approved spec
+prescribes.
+
+| configPath | new home | category / reason |
+|---|---|---|
+| `monitoring.parallelWorkSentinel.enabled` | **DEV_GATED** | observe-only overlap councilor; emits an in-process event with no listener wired; local audit log only — no egress/spend |
+| `monitoring.failureLearning.enabled` | **DEV_GATED** | observe-only loop; append-only ledger; Telegram escalation unimplemented; all ingestion sources off by default — no egress/spend |
+| `monitoring.releaseReadiness.enabled` | **DEV_GATED** | observe-only; constructed but NOT auto-started (a separate off-by-default job drives ticks), so enable alone is inert; repo-gated |
+| `monitoring.bootHealthBeacon.enabled` | **DEV_GATED** | minimal read-only /health responder; localhost-only inbound socket, zero outbound |
+| `monitoring.correctionLearning.enabled` | EXCLUSION | `cost-bearing` — per-message Tier-1 LLM distill (model 'fast', ≤25¢/day) on every preference/frustration message; ongoing spend (D4 disproved "no spend") |
+| `monitoring.apprenticeshipCycleSla.enabled` | EXCLUSION | `action-bearing` — auto-ticks on the always-running token-ledger poller and posts a user-facing Telegram attention topic on each overdue cycle (D4 disproved "no egress") |
+| `monitoring.geminiCapacityEscalation.enabled` | EXCLUSION | `action-bearing` — auto-ticks the same cadence and posts a user-facing Telegram escalation when Gemini is capacity-blocked >60min (D4 disproved "no egress") |
+| `monitoring.greenPrAutoMerge.enabled` | EXCLUSION | `action-bearing` — merges PRs |
+| `threadline.a2aCheckIn.enabled` | EXCLUSION | `action-bearing` — sends user-facing summaries; live-on-dev floods operator |
+| `mentor.enabled` | EXCLUSION | `optional-integration` — inert until rollout/allowlist configured |
+| `mentee.enabled` | EXCLUSION | `optional-integration` — inert until an allowlisted mentor configured |
+
+**Open decision O1 (operator) — RESOLVED (Justin, telegram:12476, 2026-06-13):**
+approved moving all 7 read/observe-only candidates LIVE on Echo. The build then
+ran the mandatory D4 code-grounding on each (below); 4 verified clean and moved
+live, 3 (`correctionLearning`, `apprenticeshipCycleSla`, `geminiCapacityEscalation`)
+proved NOT observe-only and were held as exclusions with honest categories per the
+spec's own D4 clause, and the deviation was reported to the operator (topic 12476,
+2026-06-13). Holding the 3 does not forbid them — the operator can still flip any
+on per-agent with an explicit `enabled: true`.
+
+### D4. Every DEV_GATED move re-grounds against the code, not the reason string.
+
+The reclassification is verified per-feature: the build confirms each moved
+feature truly has no egress / no spend / no destructive or external action path
+before moving it (the reason strings are the hypothesis, the code is the proof).
+A feature whose code contradicts "observe-only" stays an exclusion with the honest
+category. This is `verify-claim` discipline applied to the audit.
+
+#### D4 grounding result (build-time, 2026-06-13)
+
+Each of the 7 candidates was traced to its runtime construction + tick/seam:
+
+- **`parallelWorkSentinel`** — VERIFIED clean. `ParallelWorkSentinel.tick()` emits
+  an `'overlap'` event with **no listener wired** and appends a local
+  `sentinel-events.jsonl` line. No fetch/telegram/LLM. → **DEV_GATED**.
+- **`failureLearning`** — VERIFIED clean at default sub-flags. Append-only ledger;
+  `insightTelegramEscalation` only flips a reported stage string (send path
+  unimplemented); ingestion sources (`ci/revert/regression/…`) all off by default;
+  loop creates only draft items needing approval. → **DEV_GATED**.
+- **`releaseReadiness`** — VERIFIED inert-on-enable (two-switch dependency, made
+  explicit per round-2 codex finding). `server.ts` constructs the sentinel but does
+  **not** `.start()` it; ticks are driven by the SEPARATE `release-readiness-check`
+  cron job, which ships `enabled: false` and is verified `enabled: false` on Echo
+  today. So the dev-gate (switch 1) makes only the READ surface live (routes stop
+  503-ing); the SEND capability is reachable only if the operator ALSO enables the
+  job (switch 2), and that send is itself P17-bounded (the `createForumTopic` budget
+  funnel). We classify by what's reachable under *normal configured dev operation*
+  (job off ⇒ no send), and name the dependency openly rather than hide it: if the
+  job is later dev-enabled, releaseReadiness's bounded attention path becomes a
+  separate, explicit decision. → **DEV_GATED** (read-surface live, send dormant
+  behind the dark job).
+- **`bootHealthBeacon`** — VERIFIED read-only. Binds a localhost-only inbound
+  `/health` socket during boot; zero outbound; cleanly released before the real
+  server binds. → **DEV_GATED**.
+- **`correctionLearning`** — CONTRADICTED. When enabled, the capture seam runs a
+  per-message Tier-1 LLM distill (`sharedIntelligence.evaluate(..., {model:'fast',
+  maxTokens:400})` via a dedicated `LlmQueue`, `≤25¢/day`) on every
+  preference/frustration-classified inbound message — ongoing LLM spend, gated by
+  the base loop, not a sub-flag. The reason string's "no spend" is false. →
+  **EXCLUSION `cost-bearing`**.
+- **`apprenticeshipCycleSla`** — CONTRADICTED. Constructed on `enabled===true` with
+  `raiseAttention` bound to `telegram.createAttentionItem`, auto-ticked by the
+  always-started `TokenLedgerPoller.afterTick`; on an overdue cycle it calls
+  `createForumTopic` + `sendMessage` (a real user-facing Telegram escalation). →
+  **EXCLUSION `action-bearing`**.
+- **`geminiCapacityEscalation`** — CONTRADICTED. Same construction + auto-tick +
+  Telegram-send pattern when Gemini stays capacity-blocked past the threshold. → **EXCLUSION
+  `action-bearing`**.
+
+The deviation (3 of 7 held back) was reported to the operator (topic 12476,
+2026-06-13) before building, per the brief. The mechanism that produced it — D4 —
+is the operator-approved part of this spec; the override is the spec working as
+designed, not a departure from it.
+
+### D5. One-shot strip of stale persisted `enabled: false` on dev agents (the migration the audit forces).
+
+Removing the `enabled: false` literal from defaults only lets the resolver govern
+when the key is **absent** from the agent's persisted config. Round-1 grounding
+found that is NOT true on Echo: `.instar/config.json` already persists
+`monitoring.parallelWorkSentinel.enabled: false` and
+`monitoring.releaseReadiness.enabled: false` (baked in by a prior `applyDefaults`
+run from the old hardcoded default). `applyDefaults` is add-missing-only, so those
+stale `false`s survive and `resolveDevAgentGate(false, …)` short-circuits to dark —
+the two flags would **stay dark on the very dev agent meant to dogfood them**. This
+is the exact cartographer trap (P3 Migration Parity): a reclassification that only
+works for new agents is broken.
+
+The fix is a one-shot, idempotent, **dev-agent-only** `PostUpdateMigrator` step,
+mirroring the proven `migrateCartographerDevGate` (`src/core/PostUpdateMigrator.ts`):
+
+- **Marker:** `dev-gate-teeth-strip` in `_instar_migrations` makes the strip
+  **run-once**. Be precise about what that buys: the marker does NOT distinguish a
+  stale-default `false` from a deliberate pre-migration operator `false` (they are
+  byte-identical — this is a deliberately **lossy** migration, see the tradeoff
+  decision below). What it guarantees is idempotency — after the one-time strip, a
+  *later* operator-set `false` is never touched again.
+- **Dev-agent guard:** runs only when `config.developmentAgent === true`. A fleet
+  agent is never touched, so fleet behavior stays byte-for-byte (this is *why*
+  Finding "fleet unchanged" holds).
+- **Allowlist — exactly the 4 newly-DEV_GATED paths, hardcoded** (never "the
+  dev-gated ones" dynamically): `monitoring.parallelWorkSentinel.enabled`,
+  `monitoring.failureLearning.enabled`, `monitoring.releaseReadiness.enabled`,
+  `monitoring.bootHealthBeacon.enabled`. For each, guard the parent object exists
+  (`if (obj && typeof obj === 'object' && !Array.isArray(obj) && obj.enabled ===
+  false) delete obj.enabled`) — an absent/non-object parent is a safe no-op, never a
+  throw (mirroring `migrateCartographerDevGate`). Delete only the literal `false`; an
+  operator's `true` survives untouched; `failureLearning`/`bootHealthBeacon` already
+  persist `true` on Echo so they are no-ops there, but a different dev agent with a
+  persisted `false` is correctly freed. The 3 D4-held exclusion paths are NOT in the
+  allowlist — they keep their persisted `false`.
+
+**Frontloaded decision — accept the cartographer-parity tradeoff (round-2 codex
+finding).** A persisted `false` and a deliberate operator `false` are byte-identical,
+so this one-shot strip *can* delete a dev-agent operator's deliberate pre-migration
+`false` for one of the 4 paths. This is the **same tradeoff `migrateCartographerDevGate`
+already made and the operator already approved (PR #1056)**: on a dev agent, a
+persisted `false` for a now-dev-gated feature is treated as the stale old default and
+freed ONCE; if the operator genuinely wants it off, they re-set `false` *after* the
+migration and the run-once marker makes that choice stick permanently. We deliberately
+do NOT add a dry-run/ack/provenance flow — it would diverge from the established
+precedent and add exactly the machinery complexity round-2 review flagged. For Echo
+specifically the risk is empirically nil: the 4 paths are verifiably stale-default
+`false` (parallelWorkSentinel, releaseReadiness) or already `true`
+(failureLearning, bootHealthBeacon) — none is a deliberate `false` — and the operator
+was told these go live (topic 12476, 2026-06-13). **Visibility mitigation (round-3
+codex finding):** the migration **logs one line per path it actually strips** and
+includes the stripped set in the `PostUpdateMigrator` result summary (the existing
+post-update migration report), so a *non-Echo* dev-agent operator can see exactly
+which flags were freed and deliberately re-disable any they want off — turning the
+silent strip into a reported one.
+
+## Migration Parity (P3/P10)
+
+- **D5 is the migration** (above). Without it, `migrateConfig()`'s add-missing-only
+  semantics leave the stale persisted `enabled: false` in place and the 4 flags
+  never go live on an existing dev agent. D5's allowlisted, dev-agent-only,
+  run-once strip is what makes "become LIVE on Echo at next session start" actually
+  true. An operator who deliberately set one of these `true` keeps it (delete fires
+  only on literal `false`); a *later* deliberate `false` is preserved by the
+  run-once marker.
+- Fleet behavior is **unchanged**: D5 is dev-agent-only, and every reclassified flag
+  still resolves `false` on a non-development agent. Only development agents gain
+  the 4 live observers.
+- The 3 D4-held features keep their `enabled: false` literal in defaults (now
+  classified under concrete `cost-bearing`/`action-bearing` exclusions) — byte-for-
+  byte unchanged for every agent, dev included; and they are excluded from the D5
+  allowlist.
+- **Shared-namespace note (L6 interactions):** D5's marker lives in the same
+  `_instar_migrations` ledger as `migrateCartographerDevGate`; the new marker key is
+  distinct, so the two run independently and idempotently.
+- No flag-day, no Dawn-side change.
+
+## Testing (three tiers)
+
+- **Unit:** (1) `DarkGateCategory` no longer includes `deliberate-fleet-default`
+  (type + the `VALID_CATEGORIES` set); (2) the lint fails a fixture exclusion that
+  uses the retired category, with the fix message; (3) the lint passes the 4 new
+  concrete categories; (4) the `action-bearing` category is accepted; (5) wiring
+  test — each of the 4 newly-DEV_GATED flags resolves live-on-dev / dark-on-fleet
+  through `resolveDevAgentGate` (both sides); (6) **count-match guard** — a fixture
+  registry with one exclusion entry written with a backtick/template-literal reason
+  trips the `exclusionEntries.length === exclusionPaths.length` assertion (the
+  silent-skip gap is closed); (7) **D5 migration** (mirrors
+  `PostUpdateMigrator-cartographerDevGate.test.ts`): given a `developmentAgent: true`
+  config with the 4 allowlisted paths persisted `enabled: false`, after the migrator
+  the keys are deleted (resolver then yields live); a fleet config (`developmentAgent`
+  absent/false) is left untouched; an operator-set `enabled: true` is preserved; a
+  second run is a no-op (marker idempotency); the 3 D4-held paths are never touched.
+- **Integration:** the lint script run over the real `ConfigDefaults.ts` +
+  `devGatedFeatures.ts` exits 0 after the reclassification (no occupant left in
+  the retired bucket) and the count-match assertion holds on the real registry.
+- **Two-switch guard (round-3/5 codex finding):** an assertion that with
+  `monitoring.releaseReadiness.enabled` resolving live-on-dev BUT the
+  `release-readiness-check` job disabled, the sentinel is constructed (read surface
+  alive) and **does NOT `.start()` / tick / send** — proving the DEV_GATED move
+  leaves the send capability dormant behind the dark job (its classification's
+  load-bearing invariant). The test ALSO asserts the shipped `release-readiness-check`
+  job default is `enabled: false` — so if a future change flips that default (or
+  dev-gates the job), this test fails loudly and forces the releaseReadiness
+  classification to be re-reviewed (drift guard, not just a point-in-time check).
+- **E2E:** a `developmentAgent: true` boot **whose persisted config still carries
+  the stale `enabled: false`** resolves the 4 reclassified features `enabled` (alive)
+  *after migration* — this is the single most important test (it proves D5 actually
+  changed dev behavior, not just that new agents work), and a fleet
+  (`developmentAgent: false`) boot resolves them `false` — proving the fleet stays
+  dark.
+
+## Security / adversarial
+
+- **Can a feature dodge the teeth by inventing a fake concrete category?** No — the
+  enum is closed and the lint validates membership; a novel string fails CI. (And
+  the D2 count-match guard closes the one way an entry could *evade* validation
+  entirely — a backtick-reason entry that the entry-regex didn't parse.)
+- **Can a feature dodge the teeth with a dishonest-but-VALID category?** Partly —
+  this is the honest residual. Retiring `deliberate-fleet-default` relocates the
+  soft surface to `optional-integration` / `structural-stub` ("not runnable"). The
+  lint cannot adjudicate honesty. The backstops are: D4 code-grounding at build
+  time, the `optional-integration`-must-name-its-gating-config rule (D1), and the
+  **GrowthMilestoneAnalyst R6** runtime cross-check that flags a registered
+  dev-gated feature observed dark on a live dev agent. The lint closes the
+  *invalid/unclassified-category* hole; D4 + R6 close the *miscategorization* hole.
+  This is why the spec says the lint makes the *unclassified* hole un-recurrable —
+  NOT that it makes all mis-parking impossible (Signal vs. Authority, P2).
+- **Could retiring the bucket force a genuinely-unsafe feature into a wrong
+  concrete category?** D4's code-grounded verification is the guard: the category
+  must match what the code actually does. `action-bearing` was added precisely so
+  the four real "unsafe but not destructive/cost" features have an honest home.
+- **Residual risk — D4 is point-in-time.** A feature verified observe-only today
+  could later grow an egress/spend/action seam (e.g. `failureLearning`'s currently
+  unimplemented Telegram path being wired) without anything re-running D4; it is
+  already live-on-dev, so the gate re-checks nothing. The R6 runtime cross-check is
+  the partial backstop (it flags a dev-gated feature observed *dark*, not one that
+  grew a *new send*). A durable per-feature capability-seam lint (a DEV_GATED entry
+  may not construct a known send/LLM/action client without an explicit override) is
+  the right structural answer but is **out of scope here and named as a follow-up** <!-- tracked: dev-gate-teeth-residuals --> —
+  this spec retires the catch-all and adds the migration; it does not claim to close
+  the capability-drift hole.
+- **Residual risk — the registry parser is hand-rolled regex (round-2 codex finding).**
+  `extractRegistry` parses the registry source with regexes, not the TS compiler. The
+  D2 count-match guard closes the specific *parsed-path-without-a-parsed-entry* class
+  (backtick reasons and several reorderings — round-2 adversarial verified it
+  fail-safe, never fail-open), but other source-shape shifts (object spread, imported
+  constants, `as const`) remain a theoretical blind spot in pre-existing machinery.
+  The structural fix — validate the loaded/exported registry objects (TS compiler API
+  or a built-module import in the test harness), or move the registry to a pure-data
+  (JSON/YAML) source, instead of parsing TS source text — is a **tracked follow-up
+  (owner: echo)** <!-- tracked: dev-gate-teeth-residuals -->, alongside the
+  capability-seam lint. This spec adds the cheap high-value guard; it does not rewrite
+  the parser. A runtime "your dependent job just made this feature a sender" warning
+  (round-3 gemini suggestion) is likewise a named follow-up <!-- tracked: dev-gate-teeth-residuals --> — out of scope here
+  because this spec touches gating only, never a feature's internal runtime behavior.
+- **Why a bespoke gate rather than an off-the-shelf flag service (round-2 gemini
+  finding)?** Instar is file-based with no external-service dependency by core design
+  (CLAUDE.md Key Design Decision #1) and the gate must be greppable + CI-lintable in
+  the source tree; a LaunchDarkly-style service is the wrong shape here. The registry
+  in `devGatedFeatures.ts` IS the add-a-flag checklist (a new dev-gated feature is one
+  entry + omit `enabled`); the machinery complexity the reviewer notes is inherent to
+  enforcing the convention structurally rather than by memory (Structure > Willpower).
+- **Does moving features live-on-dev create risk?** Each candidate is verified
+  observe/read/signal-only before the move (D4) — and the check did its job: 3 of 7
+  were held back when their code disproved the claim. Dry-run-style features keep
+  their own `dryRun` default; this spec only touches `enabled` gating, never a
+  feature's internal safety posture.
+
+## Open decisions for the operator — RESOLVED
+
+- **O1** — RESOLVED (Justin, telegram:12476, 2026-06-13): approved moving all 7
+  read/observe-only candidates live on Echo. Build-time D4 grounding then held 3
+  back as honest exclusions (see "D4 grounding result"); final = 4 live. Reported.
+- **O2** — RESOLVED (Justin, telegram:12476, 2026-06-13): `bootHealthBeacon` is
+  DEV_GATED (minimal read-only /health responder). D4 confirmed it is localhost-only
+  inbound with zero outbound — it moved live.

--- a/docs/specs/dev-agent-dark-gate-teeth.eli16.md
+++ b/docs/specs/dev-agent-dark-gate-teeth.eli16.md
@@ -1,0 +1,77 @@
+# Dev-Agent Dark-Gate Teeth — Plain-English Overview
+
+## The one-sentence version
+
+Make it impossible to quietly park a *safe* feature in the "off even for the
+people building Instar" pile — a feature can only go there if it proves it would
+actually be dangerous to run on a dev agent.
+
+## Why we need this
+
+Instar ships new features **dark** (off) for everyone, but **live** for
+"development agents" (like Echo) so they get dogfooded before the fleet gets them.
+A few weeks ago we built the machinery that enforces this: every off-by-default
+feature has to be filed into one of two drawers —
+
+- **"dogfood on dev"** (safe — runs live on Echo, dark on the fleet), or
+- **"off even on dev"** (each tagged with a reason: it deletes things, it spends
+  money, etc.).
+
+The problem: the "off even on dev" drawer had a junk slot called
+**`deliberate-fleet-default`** — basically "off because we said so," with no
+requirement to prove the feature is actually unsafe. So safe features kept landing
+in it by accident. The single-negotiator lease (Phase 1) got mis-filed there and
+it silently starved the feature's own roll-out telemetry — Justin caught that one
+by hand. The bucket that *let* it happen is still open.
+
+Right now, **6 of the 11** features in that drawer literally admit it in their own
+notes: *"observe-only … candidate for dev-gating in a follow-up audit."* They're
+safe; they're just hidden. This is that follow-up audit — done structurally so it
+can't happen again.
+
+## What this changes
+
+1. **Delete the junk slot.** `deliberate-fleet-default` is removed. To be "off even
+   on dev," a feature must name a *concrete* reason it's unsafe there: it
+   **kills/deletes** things, it **spends money**, it **takes a real action**
+   (merges a PR, sends the operator a message), or it **needs setup it doesn't have**
+   yet. No "because we said so."
+
+2. **A new honest label: `action-bearing.`** Two real features (the green-PR
+   auto-merger, and the agent-to-agent check-in summarizer that messages you) are
+   genuinely unsafe to run live on dev — not because they're destructive, but
+   because they *do something out in the world*. They get this label instead of
+   being forced into a wrong one.
+
+3. **Move the *verified* safe ones to "dogfood on dev."** Each candidate is checked
+   against its actual code first — "observe-only" has to be true in the code, not
+   just in the note. That check did its job: of the 7 candidates, **4 passed and go
+   live** (parallel-work sentinel, failure-learning loop, release-readiness watcher,
+   boot health responder), and **3 were caught and held back** because their code
+   disproved the "harmless" label:
+   - *correction-learning* secretly **spends money** (a small AI summary on every
+     preference message you send, ~25¢/day cap) → filed as "spends money."
+   - *apprenticeship-cycle SLA* and *gemini-capacity escalation* both **auto-post a
+     Telegram alert** → filed as "takes a real action."
+   You can still flip any of the 3 on for Echo yourself later — they're opt-in, not
+   banned.
+
+4. **The lint grows teeth.** CI now fails if anyone ever tries to use the deleted
+   junk slot again. Structure, not a reminder.
+
+The whole fleet's behavior is **unchanged** — every one of these features is still
+off for everyone except development agents. No change on Dawn's side.
+
+## The decisions that were yours (both resolved)
+
+- **O1 — Move the safe features live on Echo? RESOLVED: yes.** You approved moving
+  all 7 candidates. The build's code-check then held 3 back (the two Telegram-alert
+  ones and the money-spending one, above) because their code disproved "harmless" —
+  exactly what the check is for. Final result: **4 go live, 3 stay off** with honest
+  reasons. You were told which 3 and why, and you can still switch any on yourself.
+
+- **O2 — Is it OK for Echo to answer the minimal boot /health probe live? RESOLVED:
+  yes.** The code-check confirmed it only answers a local "are you alive?" probe and
+  never reaches outward, so it moved live.
+
+This was built under the same approve-first gate as the Threadline phases.

--- a/docs/specs/reports/dev-agent-dark-gate-teeth-convergence.md
+++ b/docs/specs/reports/dev-agent-dark-gate-teeth-convergence.md
@@ -1,0 +1,143 @@
+# Convergence Report — Dev-Agent Dark-Gate Teeth (CMT-1438)
+
+## Cross-model review: codex-cli:gpt-5.5
+
+A real GPT-tier external pass (codex CLI, gpt-5.5) ran in **every** round and
+succeeded in rounds 1–6; the Gemini-tier pass (gemini-2.5-pro) degraded on a
+timeout in round 1 and then ran successfully rounds 2–5. The spec received genuine
+non-Claude review on its final content. No ⚠ — this is the clean RAN state.
+
+## ELI10 Overview
+
+Instar ships new features "dark" (off) for everyone but "live" for development
+agents like Echo, so they get dogfooded before the whole fleet gets them. There's a
+registry that files every off-by-default feature into one of two drawers: "dogfood
+on dev" (safe to run live on Echo) or "off even on dev" (with a reason — it deletes
+things, spends money, etc.). The problem this spec fixes: the "off even on dev"
+drawer had a junk slot literally meaning "off because we said so," with no
+requirement to prove the feature is actually unsafe there — so safe features kept
+getting hidden in it by accident.
+
+This spec deletes that junk slot, adds an honest new reason ("action-bearing" — it
+sends a message or merges a PR when live), and re-files the 11 features that were in
+the junk drawer. Crucially, before moving any feature to "dogfood on dev," the build
+*reads its actual code* to confirm it really is harmless — and that check caught 3
+of the 7 candidates that turned out NOT to be harmless (one quietly spends money on
+AI summaries; two auto-send Telegram alerts). Those 3 stay off with an honest label.
+The 4 verified-safe ones go live. A migration is added so the change actually takes
+effect on Echo (whose config had stale "off" values baked in), and the CI lint grows
+teeth so the junk slot can never be used again.
+
+## Original vs Converged
+
+The original spec was sound on its core idea (retire the catch-all, add
+`action-bearing`, reclassify) but had three gaps the review process closed:
+
+1. **It said no migration was needed — that was wrong.** Echo's on-disk config
+   already persists `enabled: false` for two of the four "go-live" features
+   (a stale artifact of the old default). Because config-merge only *adds* missing
+   keys, removing the default would have left those two **dark on the very agent
+   meant to dogfood them**. The converged spec adds **D5**: a dev-agent-only,
+   run-once, allowlisted migration that strips the stale `false` (mirroring the
+   proven `migrateCartographerDevGate`), plus its test tier — so the change actually
+   lands. This was the single most important finding.
+
+2. **The "observe-only" labels were hypotheses, not proof.** The converged spec
+   makes **D4 code-grounding** explicit and records its result: 3 of 7 candidates
+   (`correctionLearning` — per-message LLM spend; `apprenticeshipCycleSla` and
+   `geminiCapacityEscalation` — auto-send Telegram topics) were held back as honest
+   `cost-bearing` / `action-bearing` exclusions, and the deviation from the
+   operator's "move all 7" approval was reported to topic 12476 before building.
+
+3. **It over-claimed and under-disclosed.** The converged spec is honest about
+   scope: the lint closes the *unclassified-category* hole (Signal vs. Authority —
+   it adjudicates spelling, not honesty); the *miscategorization* and
+   *capability-drift* holes are closed by D4 + the GrowthMilestoneAnalyst R6 runtime
+   cross-check, with a durable capability-seam lint named as a follow-up. It also
+   fixed a real CI bug found in review (a backtick-reason exclusion entry silently
+   skipped category validation → a count-match guard now fails loud), sharpened the
+   `action-bearing` definition, made the `releaseReadiness` two-switch dependency
+   explicit + test-pinned, and added a `lessons-engaged` frontmatter block.
+
+## Iteration Summary
+
+| Iteration | Reviewers who flagged | Material findings | Spec changes |
+|-----------|-----------------------|-------------------|--------------|
+| 1 | adversarial (minor), integration (**SERIOUS**), decision-completeness (minor), lessons-aware (2 crit/4 high), codex (minor, 5), gemini (degraded/timeout); security + scalability CLEAN | migration gap (P3/P4), backtick-reason lint skip, D1 framing, signal-vs-authority over-claim, missing lessons-engaged, action-bearing under-defined | Added D5 migration + test tier; D2 count-match guard; D1 unsafe-vs-not-runnable framing + sharpened action-bearing; softened "can't recur"; residual-risk disclosure; `lessons-engaged` block |
+| 2 | integration (RESOLVED), adversarial (converged), lessons-aware (0 blocking), decision-completeness (clean), codex (**SERIOUS**, 4), gemini (minor) | D5 lossy-tradeoff not stated; releaseReadiness composed-activation (two-switch); optional-integration teeth not enforced; parser brittleness | D5 cartographer-parity tradeoff paragraph + parent-object guard; releaseReadiness two-switch entry; optional-integration = review convention (not lint-enforced); parser-brittleness residual + why-custom-not-LaunchDarkly |
+| 3 | security CLEAN, scalability CLEAN, codex (minor, 5), gemini (minor) | migration should report stripped paths; two-switch deserves a test; action-bearing reason-quality; parser follow-up ownership | D5 logs/reports stripped paths; two-switch test added to Testing; action-bearing reasons name type + bounded/deduped; parser follow-up given an owner; runtime-warning named as follow-up |
+| 4 | codex (minor, 5), gemini (minor) | marker-wording precision; promote classification rule to general | Reworded marker bullet as explicitly lossy; added general "classify by reachable-under-normal-config" rule to D1 |
+| 5 | codex (minor — residuals + drift-guard), gemini (minor — "acknowledged residuals") | two-switch test should also assert job-default-off (drift guard) | Hardened two-switch test to assert the job's shipped default is `enabled: false` |
+| 6 | codex (minor, 4 — all non-material) | 0 material | none (converged) |
+
+## Full Findings Catalog
+
+### Round 1
+- **Integration — SERIOUS (migration gap).** Spec claimed no migration needed, but
+  Echo persists `enabled:false` for `parallelWorkSentinel` + `releaseReadiness` →
+  they'd stay dark. Resolution: D5 migration (mirrors `migrateCartographerDevGate`,
+  `src/core/PostUpdateMigrator.ts:512-579`) + test tier. **Resolved (round 2).**
+- **Lessons-aware — CRITICAL P3 / P4.** Same migration gap + no test for it.
+  Resolution: D5 + Testing item 7. **Resolved (round 2).**
+- **Lessons-aware — HIGH P2 (Signal vs. Authority).** "Can't recur" over-claimed the
+  lint's authority. Resolution: scoped to the unclassified-category hole; D4 + R6
+  named as the miscategorization backstop. **Resolved (round 2).**
+- **Lessons-aware — HIGH P17 / P7 / P14-16 / L6.** Missing `lessons-engaged`
+  engagement. Resolution: `lessons-engaged` frontmatter block. **Resolved (round 2).**
+- **Adversarial — MINOR (backtick-reason silent skip).** A template-literal `reason`
+  bypasses `entryRe` so category validation is skipped. Resolution: D2 count-match
+  assertion (`exclusionEntries.length === exclusionPaths.length`), fail-loud.
+  **Resolved (round 2); round-2 adversarial verified the invariant is fail-safe.**
+- **Codex — MINOR (5).** D1 framing (unsafe vs inert); D4 durable-enforcement gap;
+  migration for persisted false; action-bearing boundaries; partial-context caveat.
+  **All resolved/disclosed (round 2).**
+- **Security + Scalability — CLEAN** (re-confirmed CLEAN in final pass).
+
+### Round 2
+- **Codex — SERIOUS (4).** (1) D5 can erase a deliberate pre-migration `false` →
+  documented as the accepted cartographer-parity lossy tradeoff + Echo-specific
+  nil-risk + logged. (2) Parser still hand-rolled regex → disclosed residual +
+  follow-up. (3) `action-bearing` "when merely enabled" misses composed activation
+  (two-switch) → releaseReadiness two-switch dependency made explicit + later
+  test-pinned. (4) optional-integration teeth not enforced → clarified as a
+  review/D4 convention, not lint-enforced. **All resolved/disclosed (rounds 2–3).**
+- **Gemini — MINOR.** Architectural complexity / jargon / manual D4 → why-custom
+  justification added; ELI16 is the plain-language entry; D4 residual disclosed.
+
+### Rounds 3–5
+- Findings converged to recurring **disclosed residuals** (regex-parser brittleness;
+  point-in-time D4 / capability drift) plus incremental hardening requests, each
+  addressed: D5 now reports stripped paths; the two-switch invariant is test-pinned
+  AND drift-guarded (asserts job default stays off); action-bearing reasons must name
+  action-type + bounded/deduped; the parser + capability-seam fixes are named
+  follow-ups with an owner. Gemini round 5 explicitly characterized its remaining
+  findings as "acknowledging and managing residual risks that the spec itself
+  astutely identifies" — i.e. non-material.
+
+### Round 6 (final confirmation)
+Codex returned 4 MINOR findings, **all non-material** (none require a spec change):
+(1) state the dev-agent-accepts-dev-gated-defaults premise — already the documented
+contract of `resolveDevAgentGate` (`devAgentGate.ts`); (2) split `action-bearing`
+now — a design preference contrary to the spec's deliberate, documented decision to
+defer the split; (3) name the dependent job in the `releaseReadiness` *registry
+justification string* — a build-time wording note (D4 + the drift-guard test already
+cover it; honored when writing the `DEV_GATED_FEATURES` entry); (4) regex-parser
+brittleness — a re-statement of the already-disclosed residual + follow-up. The
+finding set has been stable and disclosed since round 2; nothing new is material.
+
+### Residual risks (disclosed, non-blocking, named follow-ups)
+- **Hand-rolled regex registry parser.** The D2 count-match guard closes the
+  parsed-path-without-a-parsed-entry class (fail-safe), but a structural fix
+  (TS-compiler / built-module / pure-data registry) is a tracked follow-up.
+- **Capability drift after D4.** D4 is point-in-time; R6 is the partial runtime
+  backstop; a durable per-feature capability-seam lint is a named follow-up.
+
+## Convergence verdict
+
+Converged at iteration 6. The design has been stable since round 2; rounds 3–6 were
+honesty/clarity/test-hardening refinements with monotonically decreasing severity
+(SERIOUS → SERIOUS → MINOR → MINOR → MINOR-residuals → none). The final round
+produced no material findings — both external reviewers' remaining notes are
+disclosed residuals the spec openly carries as named follow-ups, not changes the
+spec requires. Zero unresolved user-decisions remain (O1 + O2 RESOLVED). The spec is
+ready for build.

--- a/scripts/lib/dark-gate-attribution.js
+++ b/scripts/lib/dark-gate-attribution.js
@@ -103,12 +103,17 @@ export function attributeEnabledFalsePaths(absPath) {
   return { paths: results, error: null };
 }
 
+// CMT-1438 (DEV-AGENT-DARK-GATE-TEETH): the catch-all `deliberate-fleet-default`
+// was RETIRED. Every off-even-on-dev category now names a CONCRETE reason dev-live
+// is wrong — unsafe (destructive/cost-bearing/action-bearing) or not-runnable
+// (optional-integration/structural-stub). Keep this set in lockstep with the
+// `DarkGateCategory` TS union in src/core/devGatedFeatures.ts.
 const VALID_CATEGORIES = new Set([
   'destructive',
-  'optional-integration',
   'cost-bearing',
+  'action-bearing',
+  'optional-integration',
   'structural-stub',
-  'deliberate-fleet-default',
 ]);
 
 export { VALID_CATEGORIES };

--- a/scripts/lint-dev-agent-dark-gate.js
+++ b/scripts/lint-dev-agent-dark-gate.js
@@ -272,13 +272,31 @@ for (const file of resolveTargets()) {
   const gatedSet = new Set(gatedPaths);
   const exclusionSet = new Set(exclusionPaths);
 
+  // ── Count-match guard (CMT-1438, DEV-AGENT-DARK-GATE-TEETH) ──
+  // `extractRegistry` parses an exclusion's configPath (via configPathOf's path
+  // regex) and its category+reason (via the stricter entryRe) with two different
+  // patterns. An entry whose `reason` is written as a backtick/template literal (or
+  // otherwise reordered) matches the path regex but NOT entryRe — so its category +
+  // reason validation below is SILENTLY SKIPPED, letting a bogus category slip past
+  // CI. entryRe always requires a quoted configPath that configPathOf also matches,
+  // so exclusionEntries.length <= exclusionPaths.length always holds; any shortfall
+  // means an entry escaped validation. Fail LOUD on the mismatch (fail-safe — it can
+  // only over-trip on a malformed entry, never fail-open on one).
+  if (exclusionEntries.length !== exclusionPaths.length) {
+    violations.push({
+      file: DEV_GATED_FEATURES_REL, line: 0, kind: 'C: exclusion entry escaped validation',
+      text: `parsed ${exclusionPaths.length} DARK_GATE_EXCLUSIONS configPath(s) but only ${exclusionEntries.length} full {configPath,category,reason} entr(y/ies) — ${exclusionPaths.length - exclusionEntries.length} entr(y/ies) did not parse for category+reason validation`,
+      fix: 'an exclusion entry must be a literal `{ configPath: "...", category: "...", reason: "..." }` with a STRING (quote-delimited, not backtick/template-literal) reason, fields in that order, so the validator can read its category — rewrite the offending entry so all three fields parse',
+    });
+  }
+
   // Validate exclusion-entry quality (closed enum + reason length).
   for (const e of exclusionEntries) {
     if (!VALID_CATEGORIES.has(e.category)) {
       violations.push({
         file: DEV_GATED_FEATURES_REL, line: 0, kind: 'C: invalid exclusion category',
         text: `${e.configPath} → category '${e.category}'`,
-        fix: `category must be one of: ${[...VALID_CATEGORIES].join(', ')}`,
+        fix: `category must name a CONCRETE reason dev-live is wrong — one of: ${[...VALID_CATEGORIES].join(', ')}. The catch-all 'deliberate-fleet-default' was retired (CMT-1438): if the feature is actually SAFE + runnable on a dev agent, it does NOT belong here — move it to DEV_GATED_FEATURES (omit \`enabled\` from its ConfigDefaults block so the gate resolves it live-on-dev).`,
       });
     }
     const reasonLen = (e.reason || '').replace(/\s/g, '').length;

--- a/src/commands/server.ts
+++ b/src/commands/server.ts
@@ -3032,11 +3032,13 @@ export async function startServer(options: StartOptions): Promise<void> {
     // runs BEFORE AgentServer binds its port, so for minutes nothing answers
     // /health and the supervisor can mistake a slow boot for a dead process →
     // the restart loop. This minimal beacon answers /health from the very start
-    // of boot; it is closed at the handoff just before server.start(). Dark by
-    // default (monitoring.bootHealthBeacon.enabled); the grace bump (#979) covers
-    // the window until this is enabled. Belt-and-suspenders, not a boot reorder.
+    // of boot; it is closed at the handoff just before server.start().
+    // DEV-GATED (CMT-1438): `enabled` OMITTED from defaults so the developmentAgent
+    // gate decides — LIVE on a dev agent, DARK on the fleet; the grace bump (#979)
+    // covers the window on the fleet. D4-verified read-only (localhost-only inbound
+    // socket, zero outbound). Belt-and-suspenders, not a boot reorder.
     let bootBeacon: BootHealthBeacon | undefined;
-    if (config.monitoring?.bootHealthBeacon?.enabled) {
+    if (resolveDevAgentGate(config.monitoring?.bootHealthBeacon?.enabled, config)) {
       try {
         bootBeacon = new BootHealthBeacon(config.port);
         await bootBeacon.start();
@@ -13416,7 +13418,13 @@ export async function startServer(options: StartOptions): Promise<void> {
     {
       const rrCfg = config.monitoring?.releaseReadiness;
       const repoPath = rrCfg?.repoPath ?? process.cwd();
-      if (rrCfg?.enabled) {
+      // DEV-GATED (CMT-1438): `enabled` OMITTED from defaults so the developmentAgent
+      // gate decides — LIVE on a dev agent, DARK on the fleet. D4-verified
+      // inert-on-enable: this only constructs the READ surface; ticks/sends require
+      // the SEPARATE off-by-default release-readiness-check job (two-switch). The
+      // `rrCfg &&` guard preserves the original "block must exist" semantics
+      // (applyDefaults always injects it) and narrows the type for the field reads.
+      if (rrCfg && resolveDevAgentGate(rrCfg.enabled, config)) {
         const { isAnalyzableRepo, buildReleaseReadinessDeps } = await import('../monitoring/releaseReadinessWiring.js');
         if (isAnalyzableRepo(repoPath)) {
           const { ReleaseReadinessSentinel } = await import('../monitoring/ReleaseReadinessSentinel.js');

--- a/src/config/ConfigDefaults.ts
+++ b/src/config/ConfigDefaults.ts
@@ -32,12 +32,12 @@ const SHARED_DEFAULTS: Record<string, unknown> = {
   monitoring: {
     memoryMonitoring: true,
     healthCheckIntervalMs: 30000,
-    // Boot health beacon — ships OFF (dark). When enabled, a minimal /health
-    // responder answers from the start of boot so the supervisor can't mistake a
-    // slow boot for a dead process (topic 21816 root cause #1). Absent ⇒ off.
-    bootHealthBeacon: {
-      enabled: false,
-    },
+    // Boot health beacon — a minimal /health responder that answers from the start
+    // of boot so the supervisor can't mistake a slow boot for a dead process (topic
+    // 21816 root cause #1). DEV-GATED (CMT-1438): `enabled` is deliberately OMITTED
+    // so resolveDevAgentGate decides — LIVE on a developmentAgent, DARK on the
+    // fleet. NEVER hardcode `enabled: false` here (it would dark dev agents too).
+    bootHealthBeacon: {},
     // Default-on so SessionWatchdog runs everywhere — required for the
     // compaction-idle polling fallback to actually fire.
     watchdog: {
@@ -50,13 +50,13 @@ const SHARED_DEFAULTS: Record<string, unknown> = {
       enabled: true,
     },
     // Parallel-Work Awareness sentinel (Phase B) — the proactive overlap councilor.
-    // Ships DARK (enabled:false): a false-positive nudge is worse than silence, so it
-    // graduates only after it's proven quiet. When enabled it ticks on a cadence
-    // (lease-holder only), detects cross-topic work overlap, and emits ONE deduped
-    // councilor nudge. Signal-only; never gates. docs/specs/parallel-activity-coherence.md.
-    parallelWorkSentinel: {
-      enabled: false,
-    },
+    // DEV-GATED (CMT-1438): `enabled` is OMITTED so resolveDevAgentGate decides —
+    // LIVE on a developmentAgent (dogfood), DARK on the fleet. A false-positive nudge
+    // is worse than silence on the fleet, so it graduates there only after the dev
+    // dogfooding proves it quiet. When live it ticks on a cadence (lease-holder only),
+    // detects cross-topic work overlap, and emits ONE deduped in-process councilor
+    // nudge (signal-only; never gates). docs/specs/parallel-activity-coherence.md.
+    parallelWorkSentinel: {},
     // ResourceLedger — default-on so every agent durably records its rate-limit
     // events (breaker trips + sentinel detections) instead of losing them on
     // restart. Read-only observability; never gates. Event-driven, negligible
@@ -268,11 +268,12 @@ const SHARED_DEFAULTS: Record<string, unknown> = {
       indeterminateEscalateCount: 15,
       progressFloorBytes: 512,
     },
-    // Failure-Learning Loop (docs/specs/FAILURE-LEARNING-LOOP-SPEC.md). Ships
-    // OFF — when disabled, the /failures routes 503-stub (surface still exists
-    // for capability probing). Registers itself on the rollout board.
+    // Failure-Learning Loop (docs/specs/FAILURE-LEARNING-LOOP-SPEC.md). DEV-GATED
+    // (CMT-1438): `enabled` is OMITTED so resolveDevAgentGate decides — LIVE on a
+    // developmentAgent, DARK on the fleet (when off, /failures routes 503-stub; the
+    // surface still exists for capability probing). The ingestion sources below
+    // default off, so live-on-dev is observe-only. Registers on the rollout board.
     failureLearning: {
-      enabled: false,
       minSupport: 4,
       minDistinctSessions: 3,
       minDistinctCauseCommits: 3,
@@ -410,11 +411,12 @@ const SHARED_DEFAULTS: Record<string, unknown> = {
       escalateAfterMinutes: 60,
     },
     // ReleaseReadinessSentinel (docs/specs/RELEASE-READINESS-VISIBILITY-SPEC.md
-    // §4.2). Ships OFF — Echo dogfoods first. Repo-gated: inert unless the
-    // install has an analyzable instar git repo. Thresholds default to
-    // silent <2d, LOW ≥2d, MEDIUM ≥4d, HIGH ≥7d.
+    // §4.2). DEV-GATED (CMT-1438): `enabled` is OMITTED so resolveDevAgentGate
+    // decides — LIVE on a developmentAgent, DARK on the fleet. Repo-gated: inert
+    // unless the install has an analyzable instar git repo. Inert-on-enable for
+    // SENDS: ticks are driven by the SEPARATE off-by-default release-readiness-check
+    // job (two-switch). Thresholds default silent <2d, LOW ≥2d, MEDIUM ≥4d, HIGH ≥7d.
     releaseReadiness: {
-      enabled: false,
       tickIntervalMs: 21_600_000,
       backlogAgeDaysSilent: 2,
       backlogAgeDaysLow: 2,

--- a/src/core/PostUpdateMigrator.ts
+++ b/src/core/PostUpdateMigrator.ts
@@ -304,6 +304,7 @@ export class PostUpdateMigrator {
     this.migrateWorktreeMisplacedFloodItems(result);
     this.migrateSubscriptionPoolInteractiveReady(result);
     this.migrateCartographerDevGate(result);
+    this.migrateDevGateTeethStrip(result);
     this.migrateCommitmentOwnerBackfill(result);
     this.migrateMultiMachinePostureReviewDimension(result);
     this.migrateConformanceGateAutoInvoke(result);
@@ -575,6 +576,92 @@ export class PostUpdateMigrator {
       result.upgraded.push(`cartographer-dev-gate: stripped default-shaped \`enabled: false\` at ${stripped.join(', ')} so the developmentAgent gate resolves them live`);
     } else {
       result.skipped.push('cartographer-dev-gate: no default-shaped false to strip (marker set)');
+    }
+  }
+
+  // ── DEV-AGENT-DARK-GATE-TEETH (CMT-1438): strip stale persisted `enabled: false`
+  // for the 4 features moved out of the retired `deliberate-fleet-default` bucket
+  // into DEV_GATED_FEATURES. Same mechanism + rationale as migrateCartographerDevGate:
+  // removing the ConfigDefaults literal only lets the gate decide when `enabled` is
+  // ABSENT, but applyDefaults is add-missing-only — so an agent (e.g. Echo) that
+  // already persisted the old default `false` keeps it and the feature stays DARK on
+  // the very dev agent meant to dogfood it. This one-shot, dev-agent-only strip frees
+  // a DEFAULT-SHAPED `false` at exactly the 4 allowlisted, D4-code-grounded-safe paths.
+  //
+  // Lossy-but-precedented (D5): the `false` value alone can't distinguish a stale
+  // default from a deliberate pre-migration operator choice; the run-once marker means
+  // each path's `false` is touched at most ONCE — a LATER operator-set `false` is never
+  // re-stripped (re-add it to deliberately keep a flag off). Same accepted tradeoff as
+  // the cartographer strip. Allowlist is HARDCODED (never "the dev-gated ones"
+  // dynamically) and deliberately EXCLUDES the 3 D4-held exclusions
+  // (correctionLearning / apprenticeshipCycleSla / geminiCapacityEscalation), which
+  // keep their persisted `false`. Idempotent, existence-checked, dev-agent-only.
+  private migrateDevGateTeethStrip(result: MigrationResult): void {
+    const configPath = path.join(this.config.stateDir, 'config.json');
+    if (!fs.existsSync(configPath)) {
+      result.skipped.push('dev-gate-teeth: config.json not found');
+      return;
+    }
+
+    let config: Record<string, unknown>;
+    try {
+      config = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+    } catch (err) {
+      result.errors.push(`dev-gate-teeth: config.json read failed: ${err instanceof Error ? err.message : String(err)}`);
+      return;
+    }
+
+    const migrations = (config._instar_migrations ?? []) as string[];
+    const marker = 'dev-gate-teeth-strip';
+    if (migrations.some(m => m.startsWith(marker))) {
+      result.skipped.push('dev-gate-teeth: already migrated');
+      return;
+    }
+
+    // Dev-agent-only: a fleet agent's `false` is the correct dark default and is left
+    // untouched (marker NOT set here, so a later promotion can still run once).
+    if (config.developmentAgent !== true) {
+      result.skipped.push('dev-gate-teeth: not a development agent');
+      return;
+    }
+
+    // The 4 newly-DEV_GATED leaf flags, all under config.monitoring. HARDCODED — the
+    // 3 D4-held exclusion paths are deliberately NOT in this list.
+    const monitoring = config.monitoring;
+    const stripped: string[] = [];
+    if (monitoring && typeof monitoring === 'object' && !Array.isArray(monitoring)) {
+      const mon = monitoring as Record<string, unknown>;
+      const allowlist = ['parallelWorkSentinel', 'failureLearning', 'releaseReadiness', 'bootHealthBeacon'] as const;
+      for (const key of allowlist) {
+        const sub = mon[key];
+        if (sub && typeof sub === 'object' && !Array.isArray(sub)) {
+          const subObj = sub as Record<string, unknown>;
+          if (subObj.enabled === false) {
+            delete subObj.enabled;
+            stripped.push(`monitoring.${key}.enabled`);
+          }
+        }
+      }
+    }
+
+    // Record the marker even when nothing was stripped, so it runs exactly once
+    // (value-already-absent / operator-set-true cases are terminal too).
+    const now = new Date().toISOString();
+    migrations.push(`${marker}-${now}`);
+    config._instar_migrations = migrations;
+    try {
+      fs.writeFileSync(configPath, JSON.stringify(config, null, 2));
+    } catch (err) {
+      result.errors.push(`dev-gate-teeth: config.json write failed: ${err instanceof Error ? err.message : String(err)}`);
+      return;
+    }
+
+    if (stripped.length > 0) {
+      // Report each stripped path (CMT-1438 round-3 finding): a non-Echo dev operator
+      // sees exactly which flags were freed and can deliberately re-disable any.
+      result.upgraded.push(`dev-gate-teeth: stripped default-shaped \`enabled: false\` at ${stripped.join(', ')} so the developmentAgent gate resolves them live (CMT-1438; re-add \`enabled: false\` to deliberately keep one off — it will not be re-stripped)`);
+    } else {
+      result.skipped.push('dev-gate-teeth: no default-shaped false to strip (marker set)');
     }
   }
 

--- a/src/core/devGatedFeatures.ts
+++ b/src/core/devGatedFeatures.ts
@@ -155,6 +155,34 @@ export const DEV_GATED_FEATURES: DevGatedFeature[] = [
     justification:
       'Dev-enabled per the Maturation Path standard (the dev agent is the controlled blast radius where a lifecycle-touching feature matures before fleet). Loss-reducing only: R1 is a read-only pre-kill dirty-check (no egress, no spend); R2 is a SIGNAL + a tracked beacon (never a blocking gate) plus a NON-destructive preservation patch (git diff → a state-dir file, secret-scrubbed, size-capped; never mutates index/ref/history). The operator origin-veto is preserved — an explicit operator/user/emergency kill is never auto-revived. Fail-open everywhere.',
   },
+  // ── CMT-1438 (DEV-AGENT-DARK-GATE-TEETH): the 4 audited-safe migrants from the
+  //    retired deliberate-fleet-default bucket. Each was code-grounded (D4) before
+  //    the move; 3 candidates (correctionLearning, apprenticeshipCycleSla,
+  //    geminiCapacityEscalation) FAILED grounding and stayed exclusions below. ──
+  {
+    name: 'parallelWorkSentinel',
+    configPath: 'monitoring.parallelWorkSentinel.enabled',
+    description: 'Proactive cross-topic work-overlap councilor (parallel-activity-coherence Phase B).',
+    justification: 'D4-verified observe-only: ticks on a cadence, emits an in-process `overlap` event with NO listener wired, and appends to a local sentinel-events.jsonl audit. No fetch/Telegram/relay, no LLM, no destructive or external action.',
+  },
+  {
+    name: 'failureLearning',
+    configPath: 'monitoring.failureLearning.enabled',
+    description: 'Failure-Learning Loop — append-only failure ledger + pattern surface (/failures).',
+    justification: 'D4-verified observe-only at default sub-flags: append-only ledger; the Telegram insight-push path is unimplemented (insightTelegramEscalation only flips a reported stage string); all ingestion sources (ci/revert/regression/degradation) default off; the loop creates only draft items needing human approval — never auto-implements. No egress/spend on enable.',
+  },
+  {
+    name: 'releaseReadiness',
+    configPath: 'monitoring.releaseReadiness.enabled',
+    description: 'Release-Readiness Sentinel — release-hygiene read surface (repo-gated).',
+    justification: 'D4-verified inert-on-enable: server constructs the sentinel but does NOT start it — ticks are driven by the SEPARATE `release-readiness-check` cron job which ships (and is) enabled:false. So dev-gating makes only the READ surface live (routes stop 503-ing); the send capability is reachable only if the operator ALSO enables that dark job (a P17-budgeted createForumTopic), a separate explicit decision pinned by a drift-guard test. No egress/spend on enable.',
+  },
+  {
+    name: 'bootHealthBeacon',
+    configPath: 'monitoring.bootHealthBeacon.enabled',
+    description: 'Boot health beacon — a minimal /health responder during the heavy boot phase.',
+    justification: 'D4-verified read-only: binds a localhost-only inbound /health socket during boot and cleanly releases it before the real server binds; zero outbound (no fetch/Telegram), no spend, no destructive action.',
+  },
 ];
 
 /**
@@ -169,13 +197,24 @@ export const DEV_GATED_FEATURES: DevGatedFeature[] = [
  * prevention. It is a CODEOWNERS-reviewed path; the human gate is the real
  * backstop. The lint REJECTS an entry with an unknown category or a reason
  * shorter than 12 non-whitespace chars.
+ *
+ * CMT-1438 (DEV-AGENT-DARK-GATE-TEETH): the catch-all `deliberate-fleet-default`
+ * category was RETIRED. Every off-even-on-dev category now names a CONCRETE reason
+ * dev-live is the wrong place to run the feature — either *unsafe*
+ * (`destructive` / `cost-bearing` / `action-bearing`) or *not-runnable*
+ * (`optional-integration` / `structural-stub`). There is no "off by policy" home;
+ * a feature that is safe AND runnable on a dev agent belongs in DEV_GATED_FEATURES.
+ * Honest scope (Signal vs. Authority): the lint adjudicates category spelling +
+ * reason length, never category *honesty* — the backstops against mis-parking a
+ * safe feature are D4 code-grounding (build-time, per spec) and the
+ * GrowthMilestoneAnalyst R6 runtime cross-check.
  */
 export type DarkGateCategory =
   | 'destructive'
-  | 'optional-integration'
   | 'cost-bearing'
-  | 'structural-stub'
-  | 'deliberate-fleet-default';
+  | 'action-bearing'
+  | 'optional-integration'
+  | 'structural-stub';
 
 export interface DarkGateExclusion {
   /** Dotted path to the feature's `enabled` flag in the agent config. */
@@ -281,61 +320,47 @@ export const DARK_GATE_EXCLUSIONS: DarkGateExclusion[] = [
     category: 'optional-integration',
     reason: 'WS2.5 cross-machine evolution-action-queue replication — the FOURTH memory-family kind on the HLC foundation; graduated rollout dark→dryRun→live per multi-machine-replicated-store-foundation, opt-in per deployment (no action crosses a machine boundary while dark; the local ACT-NNN id is never replicated; the load-bearing field is status so a peer sees an action was already completed elsewhere; mirrors the knowledge sibling)',
   },
-  // ── deliberate-fleet-default — off for everyone by design (incl. dev) ──
+  // ── action-bearing — when merely enabled, automatically produces an outbound
+  //    side-effect that reaches an external system or the operator (a send, a PR
+  //    merge, a remote mutation). De-dup/rate-limiting reduces severity but an
+  //    auto-send is an auto-send. Held off-on-dev; opt-in per agent. (CMT-1438) ──
   {
     configPath: 'monitoring.greenPrAutoMerge.enabled',
-    category: 'deliberate-fleet-default',
-    reason: 'green-PR auto-merge watcher — action-bearing (merges PRs), so NOT dev-gated (the dev-gate registry bars action-bearing features, devGatedFeatures.ts contract). Off fleet-wide; flipped on per dev agent with expectedGhLogin. safe-merge re-verifies + lease-gated + runtime rollback + breaker; GitHub App is a binding precondition before any fleet promotion.',
-  },
-  {
-    configPath: 'monitoring.bootHealthBeacon.enabled',
-    category: 'deliberate-fleet-default',
-    reason: 'minimal boot /health responder; deliberate fleet default, off until a supervisor needs it',
-  },
-  {
-    configPath: 'monitoring.parallelWorkSentinel.enabled',
-    category: 'deliberate-fleet-default',
-    reason: 'observe-only overlap councilor; candidate for dev-gating in a follow-up audit',
-  },
-  {
-    configPath: 'monitoring.failureLearning.enabled',
-    category: 'deliberate-fleet-default',
-    reason: 'observe-only failure-learning loop; candidate for dev-gating in a follow-up audit',
-  },
-  {
-    configPath: 'monitoring.correctionLearning.enabled',
-    category: 'deliberate-fleet-default',
-    reason: 'observe-only correction/preference sentinel; candidate for dev-gating in a follow-up audit',
-  },
-  {
-    configPath: 'monitoring.apprenticeshipCycleSla.enabled',
-    category: 'deliberate-fleet-default',
-    reason: 'observe-only overdue-cycle signal; candidate for dev-gating in a follow-up audit',
-  },
-  {
-    configPath: 'monitoring.geminiCapacityEscalation.enabled',
-    category: 'deliberate-fleet-default',
-    reason: 'observe-only capacity-block escalation; candidate for dev-gating in a follow-up audit',
-  },
-  {
-    configPath: 'monitoring.releaseReadiness.enabled',
-    category: 'deliberate-fleet-default',
-    reason: 'observe-only release-readiness sentinel; repo-gated; candidate for dev-gating in a follow-up audit',
+    category: 'action-bearing',
+    reason: 'green-PR auto-merge watcher — merges PRs (an irreversible external mutation) when live. Off fleet-wide; flipped on per dev agent with expectedGhLogin. safe-merge re-verifies + lease-gated + runtime rollback + breaker; GitHub App is a binding precondition before any fleet promotion.',
   },
   {
     configPath: 'threadline.a2aCheckIn.enabled',
-    category: 'deliberate-fleet-default',
-    reason: 'A2A check-in summarizer; deliberate fleet default, opt-in to keep the operator un-flooded',
+    category: 'action-bearing',
+    reason: 'A2A check-in summarizer — sends UNBOUNDED user-facing Telegram summaries on a heartbeat while a conversation is active; live-on-dev would flood the operator. Opt-in to keep the operator un-flooded.',
   },
   {
+    configPath: 'monitoring.apprenticeshipCycleSla.enabled',
+    category: 'action-bearing',
+    reason: 'D4-grounded action-bearing: auto-ticks on the always-running TokenLedgerPoller cadence and, on each overdue cycle, calls telegram.createAttentionItem → createForumTopic + sendMessage (a user-facing Telegram escalation, flood-guard/dedup bounded). Read-only on the cycle store, but the auto-send contradicts the observe-only claim — held off-on-dev, opt-in per agent.',
+  },
+  {
+    configPath: 'monitoring.geminiCapacityEscalation.enabled',
+    category: 'action-bearing',
+    reason: 'D4-grounded action-bearing: same pattern as apprenticeshipCycleSla — auto-ticks the TokenLedgerPoller cadence and, on a capacity-block deferral episode (>escalateAfterMinutes), auto-posts a user-facing Telegram attention topic (dedup-bounded per episode). The auto-send contradicts the observe-only claim — held off-on-dev, opt-in per agent.',
+  },
+  // ── cost-bearing addition (CMT-1438 D4 grounding) ──
+  {
+    configPath: 'monitoring.correctionLearning.enabled',
+    category: 'cost-bearing',
+    reason: 'D4-grounded cost-bearing: enabling the capture loop runs a per-message Tier-1 LLM distill (sharedIntelligence.evaluate model:fast via a dedicated LlmQueue, <=25c/day cap) on every preference/frustration-classified inbound message — ongoing LLM spend gated by the base loop, not a sub-flag. The earlier no-spend reason-string was disproved; held off-on-dev, opt-in per agent.',
+  },
+  // ── optional-integration — inert until per-deployment config/credential exists
+  //    (must name the gating config); not unsafe, just nothing to dogfood. (CMT-1438) ──
+  {
     configPath: 'mentor.enabled',
-    category: 'deliberate-fleet-default',
-    reason: 'framework-onboarding mentor system; deliberate fleet default, off until the human advances rollout',
+    category: 'optional-integration',
+    reason: 'framework-onboarding mentor system — inert until the operator advances the graduated rollout (mode off→dry-run→live) and configures menteeFramework; nothing to dogfood live-on-dev until that per-deployment config exists.',
   },
   {
     configPath: 'mentee.enabled',
-    category: 'deliberate-fleet-default',
-    reason: 'mentee receiver wiring; deliberate fleet default, off until an allowlisted mentor is configured',
+    category: 'optional-integration',
+    reason: 'mentee receiver wiring — inert until localAgentName + knownMentors (an allowlisted mentor) + replyChatId/replyTopicId are configured; any missing piece logs a skip and stays dark, so there is nothing to dogfood until that per-deployment allowlist exists.',
   },
 ];
 

--- a/src/monitoring/guardManifest.ts
+++ b/src/monitoring/guardManifest.ts
@@ -239,7 +239,7 @@ export const GUARD_MANIFEST: readonly GuardManifestEntry[] = [
     process: 'server',
     expectRuntime: false,
     component: 'BootHealthBeacon',
-    description: 'Boot-time health beacon endpoint.',
+    description: 'Boot-time health beacon endpoint (dev-gated, CMT-1438).',
   },
   {
     key: 'monitoring.rateLimitSentinel.enabled',
@@ -259,7 +259,7 @@ export const GUARD_MANIFEST: readonly GuardManifestEntry[] = [
     process: 'server',
     expectRuntime: false,
     component: 'ParallelWorkSentinel',
-    description: 'Cross-topic overlap councilor (ships dark, Phase B).',
+    description: 'Cross-topic overlap councilor (dev-gated, Phase B).',
   },
   {
     key: 'monitoring.resourceLedger.enabled',
@@ -352,7 +352,7 @@ export const GUARD_MANIFEST: readonly GuardManifestEntry[] = [
     process: 'server',
     expectRuntime: false,
     component: 'FailureLearningLoop',
-    description: 'Failure-Learning Loop capture + pattern surfacing.',
+    description: 'Failure-Learning Loop capture + pattern surfacing (dev-gated, CMT-1438).',
   },
   {
     key: 'monitoring.correctionLearning.enabled',
@@ -405,7 +405,7 @@ export const GUARD_MANIFEST: readonly GuardManifestEntry[] = [
     process: 'server',
     expectRuntime: false,
     component: 'ReleaseReadinessSentinel',
-    description: 'Stalled-release watchdog (maintainer environments).',
+    description: 'Stalled-release watchdog (dev-gated; maintainer environments).',
   },
   {
     key: 'monitoring.promptGate.enabled',

--- a/src/server/AgentServer.ts
+++ b/src/server/AgentServer.ts
@@ -851,12 +851,13 @@ export class AgentServer {
     }
 
     // Parallel-Work Awareness, Phase B — the proactive overlap councilor sentinel.
-    // Ships DARK (monitoring.parallelWorkSentinel.enabled defaults false). When on, it
-    // ticks on a cadence over the index, detects cross-topic overlap, and emits ONE
-    // deduped nudge. Signal-only. Own try/catch (cascade isolation). Every transition is
-    // audited to logs/sentinel-events.jsonl (house pattern); a nudge additionally surfaces
-    // to the user via the post-update channel if Telegram is wired.
-    const pwsEnabled = options.config.monitoring?.parallelWorkSentinel?.enabled === true;
+    // DEV-GATED (CMT-1438): `enabled` is OMITTED from the ConfigDefaults block so the
+    // developmentAgent gate decides — LIVE on a dev agent (the dogfooding ground),
+    // DARK on the fleet. When on, it ticks on a cadence over the index, detects
+    // cross-topic overlap, and emits ONE in-process nudge event (no listener wired).
+    // Signal-only. Own try/catch (cascade isolation). Every transition is audited to
+    // logs/sentinel-events.jsonl (house pattern). D4-verified observe-only.
+    const pwsEnabled = resolveDevAgentGate(options.config.monitoring?.parallelWorkSentinel?.enabled, options.config);
     if (pwsEnabled && this.parallelActivityIndex && options.config.stateDir) {
       try {
         const index = this.parallelActivityIndex;
@@ -1227,12 +1228,15 @@ export class AgentServer {
     }
 
     // Failure-Learning Loop (docs/specs/FAILURE-LEARNING-LOOP-SPEC.md) — instar
-    // self-hosting dev-process forensics. Ships OFF; constructed only when
-    // enabled (else the inline /failures routes 503-stub via the null ledger).
-    // Toolchain attribution is instar-repo-local (§3 scope). Own try/catch so a
-    // failure here can never cascade into the other ledgers' init.
+    // self-hosting dev-process forensics. DEV-GATED (CMT-1438): `enabled` is OMITTED
+    // from the ConfigDefaults block so the developmentAgent gate decides — LIVE on a
+    // dev agent, DARK on the fleet (the inline /failures routes 503-stub via the null
+    // ledger when off). D4-verified observe-only at default sub-flags: append-only
+    // ledger, ingestion sources all off by default, no auto-send. Toolchain
+    // attribution is instar-repo-local (§3 scope). Own try/catch so a failure here
+    // can never cascade into the other ledgers' init.
     try {
-      if (options.config.monitoring?.failureLearning?.enabled === true && options.config.stateDir) {
+      if (resolveDevAgentGate(options.config.monitoring?.failureLearning?.enabled, options.config) && options.config.stateDir) {
         this.failureLedger = new FailureLedger({
           dbPath: path.join(options.config.stateDir, 'failure-ledger.db'),
         });

--- a/src/server/CapabilityIndex.ts
+++ b/src/server/CapabilityIndex.ts
@@ -27,6 +27,7 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { SafeGitExecutor } from '../core/SafeGitExecutor.js';
+import { resolveDevAgentGate } from '../core/devAgentGate.js';
 import { activeAutonomousJobs, DEFAULT_MAX_CONCURRENT_AUTONOMOUS } from '../core/AutonomousSessions.js';
 import type { SecretDrop } from './SecretDrop.js';
 import type { RouteContext } from './routes.js';
@@ -806,7 +807,9 @@ export const CAPABILITY_INDEX: readonly CapabilityEntry[] = [
     prefixes: ['/failures'],
     description: 'Failure-Learning Loop — instar dev-process failure forensics (which spec/tool produced a failure; what process gaps recur)',
     build: ({ ctx }) => ({
-      enabled: ctx.config.monitoring?.failureLearning?.enabled === true,
+      // DEV-GATED (CMT-1438): resolve through the funnel so the capability report
+      // matches the construction gate — LIVE on a dev agent, DARK on the fleet.
+      enabled: resolveDevAgentGate(ctx.config.monitoring?.failureLearning?.enabled, ctx.config),
       endpoints: [
         'GET /failures — list failure records (filter by source/category/initiative/attribution)',
         'GET /failures/:id — one record',

--- a/tests/integration/dev-gate-teeth-rollout.test.ts
+++ b/tests/integration/dev-gate-teeth-rollout.test.ts
@@ -1,0 +1,135 @@
+/**
+ * DEV-AGENT-DARK-GATE-TEETH (CMT-1438) — full rollout pipeline integration test.
+ *
+ * Proves the reclassification ACTUALLY changes dev behavior end-to-end, exercising
+ * the real update path a deployed agent runs: PostUpdateMigrator.migrateDevGateTeethStrip
+ * → applyDefaults (add-missing) → resolveDevAgentGate. The single most important
+ * assertion (spec §Testing E2E): an EXISTING dev agent whose persisted config still
+ * carries the stale `enabled: false` resolves the 4 reclassified features LIVE *after
+ * migration* — proving the change works for deployed agents, not just new ones (the
+ * cartographer trap). Plus the fleet-stays-dark side, the fresh-agent path, and the
+ * releaseReadiness two-switch drift guard.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { PostUpdateMigrator } from '../../src/core/PostUpdateMigrator.js';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+import { applyDefaults, getMigrationDefaults } from '../../src/config/ConfigDefaults.js';
+import { resolveDevAgentGate } from '../../src/core/devAgentGate.js';
+import { getConfigByPath } from '../../src/core/devGatedFeatures.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.resolve(__dirname, '../..');
+
+const GATED_PATHS = [
+  'monitoring.parallelWorkSentinel.enabled',
+  'monitoring.failureLearning.enabled',
+  'monitoring.releaseReadiness.enabled',
+  'monitoring.bootHealthBeacon.enabled',
+];
+
+type MigrationResult = { upgraded: string[]; skipped: string[]; errors: string[] };
+
+describe('dev-gate teeth — full rollout pipeline (migration → defaults → resolver)', () => {
+  let stateDir: string;
+
+  function writeConfig(cfg: Record<string, unknown>): void {
+    fs.writeFileSync(path.join(stateDir, 'config.json'), JSON.stringify(cfg, null, 2));
+  }
+  function readConfig(): Record<string, unknown> {
+    return JSON.parse(fs.readFileSync(path.join(stateDir, 'config.json'), 'utf-8'));
+  }
+  function migrateThenApplyDefaults(): Record<string, unknown> {
+    const result: MigrationResult = { upgraded: [], skipped: [], errors: [] };
+    const migrator = new PostUpdateMigrator({
+      projectDir: stateDir, stateDir, port: 4042, hasTelegram: false, projectName: 'test',
+    });
+    (migrator as unknown as { migrateDevGateTeethStrip(r: MigrationResult): void })
+      .migrateDevGateTeethStrip(result);
+    // The deployed update path then runs applyDefaults (add-missing) over the config.
+    const cfg = readConfig();
+    applyDefaults(cfg, getMigrationDefaults('standalone'));
+    return cfg;
+  }
+  function resolves(cfg: Record<string, unknown>, p: string): boolean {
+    return resolveDevAgentGate(
+      getConfigByPath(cfg, p) as boolean | undefined,
+      cfg as { developmentAgent?: boolean },
+    );
+  }
+
+  beforeEach(() => {
+    stateDir = fs.mkdtempSync(path.join(os.tmpdir(), 'devgate-teeth-rollout-'));
+  });
+  afterEach(() => {
+    SafeFsExecutor.safeRmSync(stateDir, { recursive: true, force: true, operation: 'tests/integration/dev-gate-teeth-rollout.test.ts' });
+  });
+
+  it('THE MOST IMPORTANT TEST — an existing dev agent with stale persisted `enabled: false` resolves all 4 LIVE after the migration runs', () => {
+    // The cartographer trap: applyDefaults is add-missing-only, so without the
+    // migration the stale `false` survives and the feature stays dark on the very
+    // agent meant to dogfood it. This asserts the migration actually frees them.
+    writeConfig({
+      developmentAgent: true,
+      monitoring: {
+        parallelWorkSentinel: { enabled: false },
+        failureLearning: { enabled: false },
+        releaseReadiness: { enabled: false },
+        bootHealthBeacon: { enabled: false },
+      },
+    });
+    const cfg = migrateThenApplyDefaults();
+    for (const p of GATED_PATHS) {
+      expect(resolves(cfg, p), `${p} must be LIVE on the dev agent after migration`).toBe(true);
+    }
+  });
+
+  it('a fleet agent with the same stale `false` stays DARK (migration is a no-op off-dev)', () => {
+    writeConfig({
+      developmentAgent: false,
+      monitoring: {
+        parallelWorkSentinel: { enabled: false },
+        failureLearning: { enabled: false },
+        releaseReadiness: { enabled: false },
+        bootHealthBeacon: { enabled: false },
+      },
+    });
+    const cfg = migrateThenApplyDefaults();
+    for (const p of GATED_PATHS) {
+      expect(resolves(cfg, p), `${p} must stay DARK on the fleet`).toBe(false);
+    }
+  });
+
+  it('a fresh dev agent (no persisted block) resolves all 4 LIVE via the omitted-default path', () => {
+    writeConfig({ developmentAgent: true });
+    const cfg = migrateThenApplyDefaults();
+    // applyDefaults injects the default blocks with `enabled` OMITTED → gate yields live.
+    for (const p of GATED_PATHS) {
+      expect(getConfigByPath(cfg, p), `${p} default must omit enabled`).toBeUndefined();
+      expect(resolves(cfg, p), `${p} must be LIVE on a fresh dev agent`).toBe(true);
+    }
+  });
+
+  it('a fresh fleet agent resolves all 4 DARK', () => {
+    writeConfig({ developmentAgent: false });
+    const cfg = migrateThenApplyDefaults();
+    for (const p of GATED_PATHS) {
+      expect(resolves(cfg, p), `${p} must be DARK on a fresh fleet agent`).toBe(false);
+    }
+  });
+
+  it('two-switch drift guard: the shipped release-readiness-check job default is `enabled: false`', () => {
+    // releaseReadiness is classified DEV_GATED only because its SEND capability is
+    // gated behind this SEPARATE job, which must ship dark. If a future change flips
+    // this default on, dev-gating releaseReadiness would silently make it a sender —
+    // this assertion fails loudly and forces the classification to be re-reviewed.
+    const tmpl = fs.readFileSync(
+      path.join(ROOT, 'src/scaffold/templates/jobs/instar/release-readiness-check.md'),
+      'utf-8',
+    );
+    expect(/^enabled:\s*false\s*$/m.test(tmpl)).toBe(true);
+  });
+});

--- a/tests/unit/PostUpdateMigrator-devGateTeethStrip.test.ts
+++ b/tests/unit/PostUpdateMigrator-devGateTeethStrip.test.ts
@@ -1,0 +1,173 @@
+/**
+ * Verifies PostUpdateMigrator.migrateDevGateTeethStrip — the one-shot, dev-agent-only
+ * migration that strips a DEFAULT-SHAPED `enabled: false` from an EXISTING dev agent's
+ * config for the 4 features moved out of the retired `deliberate-fleet-default` bucket
+ * into DEV_GATED_FEATURES (CMT-1438, DEV-AGENT-DARK-GATE-TEETH §D5). Without it,
+ * applyDefaults's add-missing-only semantics leave a stale persisted `false` in place
+ * and the feature stays DARK on the very dev agent meant to dogfood it (the cartographer
+ * trap; Migration Parity).
+ *
+ * Covers both sides of every boundary: dev-agent strip (resolver then yields live),
+ * fleet-agent no-op (the dark default is correct), an operator `true` preserved, the 3
+ * D4-held exclusion paths NEVER touched, idempotency via the _instar_migrations
+ * run-once marker (a re-added operator `false` is never re-stripped), the stripped set
+ * reported in result.upgraded, no-config skip, and corrupt-config error with bytes
+ * preserved.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { PostUpdateMigrator } from '../../src/core/PostUpdateMigrator.js';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+import { resolveDevAgentGate } from '../../src/core/devAgentGate.js';
+import { getConfigByPath } from '../../src/core/devGatedFeatures.js';
+
+type MigrationResult = { upgraded: string[]; skipped: string[]; errors: string[] };
+
+const GATED_PATHS = [
+  'monitoring.parallelWorkSentinel.enabled',
+  'monitoring.failureLearning.enabled',
+  'monitoring.releaseReadiness.enabled',
+  'monitoring.bootHealthBeacon.enabled',
+];
+
+describe('PostUpdateMigrator — dev-gate teeth strip (CMT-1438 §D5)', () => {
+  let projectDir: string;
+  let stateDir: string;
+
+  function configPath(): string {
+    return path.join(stateDir, 'config.json');
+  }
+  function writeConfig(cfg: Record<string, unknown>): void {
+    fs.writeFileSync(configPath(), JSON.stringify(cfg, null, 2));
+  }
+  function readConfig(): Record<string, unknown> {
+    return JSON.parse(fs.readFileSync(configPath(), 'utf-8'));
+  }
+  function runMigration(): MigrationResult {
+    const result: MigrationResult = { upgraded: [], skipped: [], errors: [] };
+    const migrator = new PostUpdateMigrator({
+      projectDir, stateDir, port: 4042, hasTelegram: false, projectName: 'test',
+    });
+    (migrator as unknown as { migrateDevGateTeethStrip(r: MigrationResult): void })
+      .migrateDevGateTeethStrip(result);
+    return result;
+  }
+  /** A monitoring block with all 4 gated paths + the 3 D4-held paths persisted false. */
+  function fullStaleMonitoring(): Record<string, unknown> {
+    return {
+      parallelWorkSentinel: { enabled: false },
+      failureLearning: { enabled: false, minSupport: 4 },
+      releaseReadiness: { enabled: false, tickIntervalMs: 1 },
+      bootHealthBeacon: { enabled: false },
+      // The 3 D4-held exclusions — must be left UNTOUCHED.
+      correctionLearning: { enabled: false },
+      apprenticeshipCycleSla: { enabled: false },
+      geminiCapacityEscalation: { enabled: false },
+    };
+  }
+
+  beforeEach(() => {
+    projectDir = fs.mkdtempSync(path.join(os.tmpdir(), 'devgate-teeth-mig-'));
+    stateDir = projectDir;
+  });
+  afterEach(() => {
+    SafeFsExecutor.safeRmSync(projectDir, { recursive: true, force: true, operation: 'tests/unit/PostUpdateMigrator-devGateTeethStrip.test.ts' });
+  });
+
+  it('dev agent: strips the 4 default-shaped `false`s so the resolver yields LIVE, and leaves the 3 D4-held exclusions DARK', () => {
+    writeConfig({ developmentAgent: true, monitoring: fullStaleMonitoring() });
+    const result = runMigration();
+    const cfg = readConfig();
+
+    // The 4 dev-gated paths: `enabled` deleted → resolveDevAgentGate yields LIVE on dev.
+    for (const p of GATED_PATHS) {
+      expect(getConfigByPath(cfg, p), `${p} should be stripped`).toBeUndefined();
+      expect(
+        resolveDevAgentGate(getConfigByPath(cfg, p) as boolean | undefined, cfg as { developmentAgent?: boolean }),
+        `${p} should now resolve live on the dev agent`,
+      ).toBe(true);
+    }
+
+    // The 3 D4-held exclusions: NEVER touched → still persisted false → still DARK.
+    for (const p of [
+      'monitoring.correctionLearning.enabled',
+      'monitoring.apprenticeshipCycleSla.enabled',
+      'monitoring.geminiCapacityEscalation.enabled',
+    ]) {
+      expect(getConfigByPath(cfg, p), `${p} must be left untouched`).toBe(false);
+    }
+
+    // The stripped set is reported (round-3 visibility finding), naming all 4 paths.
+    const line = result.upgraded.find((u) => u.includes('dev-gate-teeth'));
+    expect(line).toBeTruthy();
+    for (const p of GATED_PATHS) expect(line!).toContain(p);
+  });
+
+  it('fleet agent: no-op (the dark default is correct for the fleet); marker NOT set so a later promotion can still run once', () => {
+    writeConfig({ monitoring: fullStaleMonitoring() }); // developmentAgent absent
+    const result = runMigration();
+    const cfg = readConfig();
+    for (const p of GATED_PATHS) {
+      expect(getConfigByPath(cfg, p), `${p} must stay false on the fleet`).toBe(false);
+    }
+    expect(result.upgraded.length).toBe(0);
+    expect(result.skipped.some((s) => s.includes('not a development agent'))).toBe(true);
+    expect((cfg._instar_migrations as string[] | undefined) ?? []).not.toContainEqual(
+      expect.stringContaining('dev-gate-teeth-strip'),
+    );
+  });
+
+  it('dev agent: NEVER strips an EXPLICIT operator `true` (only literal `false` is stripped)', () => {
+    writeConfig({
+      developmentAgent: true,
+      monitoring: {
+        parallelWorkSentinel: { enabled: true },
+        failureLearning: { enabled: true },
+        releaseReadiness: { enabled: false }, // a stale false — this one IS stripped
+        bootHealthBeacon: { enabled: true },
+      },
+    });
+    runMigration();
+    const cfg = readConfig();
+    expect(getConfigByPath(cfg, 'monitoring.parallelWorkSentinel.enabled')).toBe(true);
+    expect(getConfigByPath(cfg, 'monitoring.failureLearning.enabled')).toBe(true);
+    expect(getConfigByPath(cfg, 'monitoring.bootHealthBeacon.enabled')).toBe(true);
+    expect(getConfigByPath(cfg, 'monitoring.releaseReadiness.enabled')).toBeUndefined();
+  });
+
+  it('idempotent: a re-added operator `false` is NOT re-stripped after the marker is set', () => {
+    writeConfig({ developmentAgent: true, monitoring: { parallelWorkSentinel: { enabled: false } } });
+    runMigration(); // strips + sets marker
+    expect(getConfigByPath(readConfig(), 'monitoring.parallelWorkSentinel.enabled')).toBeUndefined();
+    // Operator deliberately re-adds false later.
+    const cfg = readConfig();
+    (cfg.monitoring as Record<string, any>).parallelWorkSentinel.enabled = false;
+    writeConfig(cfg);
+    const result2 = runMigration();
+    expect(getConfigByPath(readConfig(), 'monitoring.parallelWorkSentinel.enabled')).toBe(false);
+    expect(result2.skipped.some((s) => s.includes('already migrated'))).toBe(true);
+  });
+
+  it('dev agent with absent/partial monitoring block: safe no-op (no throw)', () => {
+    writeConfig({ developmentAgent: true }); // no monitoring block at all
+    const result = runMigration();
+    expect(result.errors.length).toBe(0);
+    // Marker still set (runs once); nothing to strip.
+    expect(result.skipped.some((s) => s.includes('no default-shaped false to strip'))).toBe(true);
+  });
+
+  it('no config.json: skips cleanly without error', () => {
+    const result = runMigration();
+    expect(result.errors.length).toBe(0);
+    expect(result.skipped.some((s) => s.includes('config.json not found'))).toBe(true);
+  });
+
+  it('corrupt config.json: reports an error and preserves bytes', () => {
+    fs.writeFileSync(configPath(), '{ not valid json');
+    const result = runMigration();
+    expect(result.errors.length).toBeGreaterThanOrEqual(1);
+    expect(fs.readFileSync(configPath(), 'utf-8')).toBe('{ not valid json');
+  });
+});

--- a/tests/unit/lint-dev-agent-dark-gate.test.ts
+++ b/tests/unit/lint-dev-agent-dark-gate.test.ts
@@ -7,7 +7,7 @@ import { fileURLToPath } from 'node:url';
 import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
 // The SAME attributor the lint's assertion C uses — the golden-path test asserts
 // THIS resolver reproduces a hand-authored map (never the resolver's own output).
-import { attributeEnabledFalsePaths } from '../../scripts/lib/dark-gate-attribution.js';
+import { attributeEnabledFalsePaths, VALID_CATEGORIES } from '../../scripts/lib/dark-gate-attribution.js';
 import { DEV_GATED_FEATURES, DARK_GATE_EXCLUSIONS } from '../../src/core/devGatedFeatures.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -305,110 +305,44 @@ describe('lint-dev-agent-dark-gate', () => {
     // ws13Reconcile/ws13DryRun/ws13TickMs sub-block, shifting every entry at or
     // after multiMachine.sessionPool by +7. Verified by hand against
     // ConfigDefaults.ts after the post-#1079 merge.
+    // CMT-1438 (DEV-AGENT-DARK-GATE-TEETH): 4 paths LEFT this map because their
+    // `enabled: false` literal was REMOVED from ConfigDefaults so the dev-gate
+    // resolves them live (they moved to DEV_GATED_FEATURES): bootHealthBeacon,
+    // parallelWorkSentinel, failureLearning, releaseReadiness — they have NO
+    // attributed path now (dev-gated). The 3 D4-held additions
+    // (correctionLearning=cost-bearing, apprenticeshipCycleSla/geminiCapacityEscalation
+    // =action-bearing) KEEP their `enabled: false` and stay in this map.
+    // REBASE onto upstream/main @ v1.3.538 (credential-repointing Step 5/6 #1128/#1130
+    // + build-session-yield-safety #1129): those PRs added ConfigDefaults blocks above
+    // mcpProcessReaper (yieldSafety is dev-gated → NO new attributed path), shifting
+    // every entry from mcpProcessReaper down by +13; sessionReaper/agentWorktreeReaper
+    // unchanged. Every line below RE-VERIFIED by hand via the attributor against the
+    // MERGED ConfigDefaults.ts (each maps to a real `enabled: false,` line).
     const EXPECTED: Record<string, string> = {
-      '39': 'monitoring.bootHealthBeacon.enabled',
-      '58': 'monitoring.parallelWorkSentinel.enabled',
       '138': 'monitoring.sessionReaper.enabled',
       '196': 'monitoring.agentWorktreeReaper.enabled',
-      // ORPHANED-WORK-SENTINEL: the monitoring.orphanedWorkSentinel default block
-      // (15 lines incl. comment, `enabled` deliberately OMITTED so it is dev-gated
-      // — hence NO new entry here) was inserted right after the agentWorktreeReaper
-      // block, shifting EVERY entry below by +15. Verified by hand (attributor)
-      // against ConfigDefaults.ts.
-      // BUILD-SESSION-YIELD-SAFETY (ACT-839, THIS PR): a dev-gated
-      // monitoring.yieldSafety default block (13 lines incl. comment, `enabled`
-      // deliberately OMITTED so it is dev-gated — hence NO new entry here) was
-      // inserted right after the orphanedWorkSentinel block, shifting EVERY entry
-      // from mcpProcessReaper onward by +13. Verified by hand (attributor) against
-      // ConfigDefaults.ts — all paths unchanged, only line numbers shifted.
       '238': 'monitoring.mcpProcessReaper.enabled',
       '252': 'monitoring.agentSleep.enabled',
-      '275': 'monitoring.failureLearning.enabled',
-      '307': 'monitoring.correctionLearning.enabled',
-      // PROMISE-BEACON-ESCALATION-SPEC: the monitoring.promiseBeacon.escalation
-      // default block (22 lines, `enabled` deliberately OMITTED so it is dev-
-      // gated — hence NO new entry here) was inserted right after the
-      // correctionLearning block, shifting EVERY entry below by +22. Verified by
-      // hand (attributor) against the MERGED ConfigDefaults.ts.
-      // OrphanedWorkSentinel (THIS PR): adds a dev-gated monitoring.orphanedWorkSentinel
-      // config block (no attributed path — dev-gated) after correctionLearning, shifting
-      // every entry from apprenticeshipCycleSla onward +15. Recomputed via the attributor
-      // against the rebased ConfigDefaults.ts.
-      '401': 'monitoring.apprenticeshipCycleSla.enabled',
-      '409': 'monitoring.geminiCapacityEscalation.enabled',
-      '417': 'monitoring.releaseReadiness.enabled',
-      '432': 'monitoring.greenPrAutoMerge.enabled',
-      '482': 'threadline.a2aCheckIn.enabled',
-      '574': 'mentor.enabled',
-      '585': 'mentor.autonomousFix.enabled',
-      '600': 'mentee.enabled',
-      '719': 'multiMachine.sessionPool.enabled',
-      '744': 'multiMachine.sessionPool.inboundQueue.enabled',
-      '773': 'multiMachine.sessionPool.holdForStability.enabled',
-      // multi-machine-replicated-store-foundation Step 2: the multiMachine block
-      // gained a `stateSync` sub-block (foundation knobs only; NO `enabled` key →
-      // NO new attributed path) after coherenceJournal (which sits after sessionPool
-      // but before cartographer). sessionPool entries unshifted; every cartographer
-      // entry shifted +17 (the stateSync block's line count). Verified by hand
-      // (attributor) against the MERGED ConfigDefaults.ts.
-      // WS2.1 (multi-machine-replicated-store-foundation §4): the stateSync block
-      // gained a `preferences: { enabled:false, dryRun:true }` per-store sub-block —
-      // the FIRST concrete replicated-store consumer. It ADDS this literal
-      // `enabled:false` path (842, classified in DARK_GATE_EXCLUSIONS as
-      // optional-integration) and shifts every cartographer + credentialRepointing
-      // entry below it by +13 (the new sub-block's line count). RECOMPUTED via the
-      // attributor against the MERGED ConfigDefaults.ts.
-      '864': 'multiMachine.stateSync.preferences.enabled',
-      // WS2.3 (ws23-relationships-userregistry-security): the stateSync block gained
-      // a `relationships: { enabled:false, dryRun:true }` per-store sub-block — the
-      // SECOND replicated-store consumer + the FIRST PII kind. It ADDS this literal
-      // `enabled:false` path (865, classified in DARK_GATE_EXCLUSIONS as
-      // optional-integration) right after the preferences sub-block and shifts every
-      // cartographer + credentialRepointing entry below it by +14 (the new sub-block's
-      // line count). RECOMPUTED via the attributor against the MERGED ConfigDefaults.ts.
-      '878': 'multiMachine.stateSync.relationships.enabled',
-      // WS2.2 (multi-machine-replicated-store-foundation): the stateSync block gained a
-      // `learnings: { enabled:false, dryRun:true }` per-store sub-block — the THIRD
-      // replicated-store consumer + the SECOND memory-family kind. It ADDS this literal
-      // `enabled:false` path (879, classified in DARK_GATE_EXCLUSIONS as
-      // optional-integration) right after the relationships sub-block and shifts every
-      // cartographer + credentialRepointing entry below it by +14 (the new sub-block's
-      // line count). RECOMPUTED via the attributor against the MERGED ConfigDefaults.ts.
-      '892': 'multiMachine.stateSync.learnings.enabled',
-      // WS2.4 (multi-machine-replicated-store-foundation): the stateSync block gained a
-      // `knowledge: { enabled:false, dryRun:true }` per-store sub-block — the FOURTH
-      // replicated-store consumer + the THIRD memory-family kind. It ADDS this literal
-      // `enabled:false` path (894, classified in DARK_GATE_EXCLUSIONS as
-      // optional-integration) right after the learnings sub-block and shifts every
-      // cartographer + credentialRepointing entry below it by +15 (the new sub-block's
-      // line count incl. its 12-line comment). RECOMPUTED via the attributor against the
-      // MERGED ConfigDefaults.ts.
-      '907': 'multiMachine.stateSync.knowledge.enabled',
-      // WS2.5 (multi-machine-replicated-store-foundation): the stateSync block gained an
-      // `evolutionActions: { enabled:false, dryRun:true }` per-store sub-block — the FIFTH
-      // replicated-store consumer + the FOURTH memory-family kind. It ADDS this literal
-      // `enabled:false` path (908, classified in DARK_GATE_EXCLUSIONS as optional-integration)
-      // right after the knowledge sub-block and shifts every cartographer + credentialRepointing
-      // entry below it by +14 (the new sub-block's line count incl. its comment). RECOMPUTED via
-      // the attributor against the MERGED ConfigDefaults.ts.
-      '921': 'multiMachine.stateSync.evolutionActions.enabled',
-      '1029': 'cartographer.freshnessSweep.enabled',
-      '1074': 'cartographer.conformanceAudit.llmEnrichment.enabled',
-      '1099': 'cartographer.subtreeNav.llmRerank.enabled',
-      // Threadline Robustness Phase 2 (CMT-1362): the threadline.canonicalHistory
-      // block (no `enabled` literal — conversationDiscipline is dev-gated) is inserted
-      // AFTER the threadline section; entries at/after mentor.enabled shift again.
-      // RECOMPUTED via the attributor against the MERGED ConfigDefaults.ts.
-      // live-credential-repointing Increment A: subscriptionPool.credentialRepointing
-      // is appended at the END of SHARED_DEFAULTS (after topicProfiles), so it shifts
-      // no prior entry — it only ADDS this literal `enabled: false` path. category
-      // 'destructive' in DARK_GATE_EXCLUSIONS (writes OAuth credentials).
-      // multi-machine-replicated-store-foundation Step 3 (snapshot-then-tail, #1115)
-      // added stateSync cache config (NO new attributed `enabled` path) below the
-      // cartographer block but above credentialRepointing → this END entry shifted
-      // +15 (1015 → 1030); cartographer/sessionPool entries unchanged. RECOMPUTED via
-      // the attributor against the MERGED ConfigDefaults.ts.
-      '1136': 'subscriptionPool.credentialRepointing.enabled',
+      '308': 'monitoring.correctionLearning.enabled',
+      '402': 'monitoring.apprenticeshipCycleSla.enabled',
+      '410': 'monitoring.geminiCapacityEscalation.enabled',
+      '434': 'monitoring.greenPrAutoMerge.enabled',
+      '484': 'threadline.a2aCheckIn.enabled',
+      '576': 'mentor.enabled',
+      '587': 'mentor.autonomousFix.enabled',
+      '602': 'mentee.enabled',
+      '721': 'multiMachine.sessionPool.enabled',
+      '746': 'multiMachine.sessionPool.inboundQueue.enabled',
+      '775': 'multiMachine.sessionPool.holdForStability.enabled',
+      '866': 'multiMachine.stateSync.preferences.enabled',
+      '880': 'multiMachine.stateSync.relationships.enabled',
+      '894': 'multiMachine.stateSync.learnings.enabled',
+      '909': 'multiMachine.stateSync.knowledge.enabled',
+      '923': 'multiMachine.stateSync.evolutionActions.enabled',
+      '1031': 'cartographer.freshnessSweep.enabled',
+      '1076': 'cartographer.conformanceAudit.llmEnrichment.enabled',
+      '1101': 'cartographer.subtreeNav.llmRerank.enabled',
+      '1138': 'subscriptionPool.credentialRepointing.enabled',
     };
     const actual = attributeRealConfigDefaults();
     expect(actual).toEqual(EXPECTED);
@@ -440,6 +374,119 @@ describe('lint-dev-agent-dark-gate', () => {
     for (const f of DEV_GATED_FEATURES) {
       expect(typeof f.justification, `${f.name} justification`).toBe('string');
       expect(f.justification.replace(/\s/g, '').length, `${f.name} justification length`).toBeGreaterThanOrEqual(12);
+    }
+  });
+
+  // ── CMT-1438 (DEV-AGENT-DARK-GATE-TEETH): the retired catch-all + new category ──
+
+  it('VALID_CATEGORIES retires `deliberate-fleet-default` and adds `action-bearing` (the closed concrete-reason set)', () => {
+    expect(VALID_CATEGORIES.has('deliberate-fleet-default')).toBe(false);
+    expect(VALID_CATEGORIES.has('action-bearing')).toBe(true);
+    // The full valid set is exactly the 5 concrete reasons.
+    expect([...VALID_CATEGORIES].sort()).toEqual(
+      ['action-bearing', 'cost-bearing', 'destructive', 'optional-integration', 'structural-stub'],
+    );
+  });
+
+  it('Assertion C: the retired `deliberate-fleet-default` category now FAILS, and the fix points to DEV_GATED_FEATURES', () => {
+    const { dir, env } = writeCFixture({
+      defaultsBody: '  myFeature: {\n    enabled: false,\n  },',
+      exclusionEntries:
+        "  { configPath: 'myFeature.enabled', category: 'deliberate-fleet-default', reason: 'off because we said so, no concrete reason' },",
+    });
+    try {
+      const { code, out } = runLint([path.join(dir, 'ConfigDefaults.ts')], env);
+      expect(code).toBe(1);
+      expect(out).toContain('C: invalid exclusion category');
+      // The fix message names the concrete categories AND points safe-on-dev
+      // features to DEV_GATED_FEATURES (spec D2).
+      expect(out).toContain('DEV_GATED_FEATURES');
+      expect(out).toContain('action-bearing');
+    } finally {
+      cleanup(dir);
+    }
+  });
+
+  it('Assertion C: the new `action-bearing` category is ACCEPTED', () => {
+    const { dir, env } = writeCFixture({
+      defaultsBody: '  myFeature: {\n    enabled: false,\n  },',
+      exclusionEntries:
+        "  { configPath: 'myFeature.enabled', category: 'action-bearing', reason: 'auto-sends a user-facing Telegram escalation when live' },",
+    });
+    try {
+      const { code } = runLint([path.join(dir, 'ConfigDefaults.ts')], env);
+      expect(code).toBe(0);
+    } finally {
+      cleanup(dir);
+    }
+  });
+
+  it('Assertion C count-match guard: a backtick/template-literal reason TRIPS the escaped-validation assertion (fail-loud, not silent skip)', () => {
+    // The exact silent-skip hole the guard closes: the path regex parses the
+    // configPath (so the entry is COUNTED), but the entry regex requires a
+    // quote-delimited reason, so a backtick reason is invisible to category+reason
+    // validation. Without the guard, a bogus category here would pass CI unseen.
+    const { dir, env } = writeCFixture({
+      defaultsBody: '  myFeature: {\n    enabled: false,\n  },',
+      exclusionEntries:
+        '  { configPath: \'myFeature.enabled\', category: \'not-a-real-category\', reason: `a backtick reason that the entry regex cannot parse` },',
+    });
+    try {
+      const { code, out } = runLint([path.join(dir, 'ConfigDefaults.ts')], env);
+      expect(code).toBe(1);
+      expect(out).toContain('C: exclusion entry escaped validation');
+    } finally {
+      cleanup(dir);
+    }
+  });
+
+  it('Assertion C count-match guard: a well-formed (quote-delimited) exclusion does NOT trip the guard', () => {
+    const { dir, env } = writeCFixture({
+      defaultsBody: '  myFeature: {\n    enabled: false,\n  },',
+      exclusionEntries:
+        "  { configPath: 'myFeature.enabled', category: 'action-bearing', reason: 'auto-sends a user-facing escalation when live' },",
+    });
+    try {
+      const { code, out } = runLint([path.join(dir, 'ConfigDefaults.ts')], env);
+      expect(code).toBe(0);
+      expect(out).not.toContain('escaped validation');
+    } finally {
+      cleanup(dir);
+    }
+  });
+
+  it('the 3 D4-held features are EXCLUSIONS with concrete categories (cost-bearing / action-bearing), NOT dev-gated', () => {
+    const gatedPaths = new Set(DEV_GATED_FEATURES.map((f) => f.configPath));
+    const excl = new Map(DARK_GATE_EXCLUSIONS.map((e) => [e.configPath, e.category]));
+    expect(excl.get('monitoring.correctionLearning.enabled')).toBe('cost-bearing');
+    expect(excl.get('monitoring.apprenticeshipCycleSla.enabled')).toBe('action-bearing');
+    expect(excl.get('monitoring.geminiCapacityEscalation.enabled')).toBe('action-bearing');
+    for (const p of [
+      'monitoring.correctionLearning.enabled',
+      'monitoring.apprenticeshipCycleSla.enabled',
+      'monitoring.geminiCapacityEscalation.enabled',
+    ]) {
+      expect(gatedPaths.has(p), `${p} must NOT be dev-gated`).toBe(false);
+    }
+  });
+
+  it('the 4 audited-safe migrants ARE in DEV_GATED_FEATURES and NOT in DARK_GATE_EXCLUSIONS', () => {
+    const gatedPaths = new Set(DEV_GATED_FEATURES.map((f) => f.configPath));
+    const excludedPaths = new Set(DARK_GATE_EXCLUSIONS.map((e) => e.configPath));
+    for (const p of [
+      'monitoring.parallelWorkSentinel.enabled',
+      'monitoring.failureLearning.enabled',
+      'monitoring.releaseReadiness.enabled',
+      'monitoring.bootHealthBeacon.enabled',
+    ]) {
+      expect(gatedPaths.has(p), `${p} must be dev-gated`).toBe(true);
+      expect(excludedPaths.has(p), `${p} must NOT be an exclusion`).toBe(false);
+    }
+  });
+
+  it('no DARK_GATE_EXCLUSIONS entry uses the retired `deliberate-fleet-default` category', () => {
+    for (const e of DARK_GATE_EXCLUSIONS) {
+      expect(e.category, `${e.configPath}`).not.toBe('deliberate-fleet-default');
     }
   });
 });

--- a/upgrades/next/dev-agent-dark-gate-teeth.md
+++ b/upgrades/next/dev-agent-dark-gate-teeth.md
@@ -1,0 +1,67 @@
+# Dev-Agent Dark-Gate Teeth (CMT-1438)
+
+## What Changed
+
+Retired the catch-all `deliberate-fleet-default` category from the dev-feature
+dark-gate classification and added a concrete `action-bearing` category. Every
+"off even on a development agent" feature must now name a real reason it would be
+unsafe or non-runnable there — it kills/deletes, spends money, takes an external
+action, or needs per-deployment config — and the vague "off by policy" bucket is
+gone. The CI lint (`scripts/lint-dev-agent-dark-gate.js`) rejects the retired
+category and now fails loud if an exclusion entry escapes category validation (the
+backtick-reason silent-skip hole), via a count-match guard in
+`scripts/lib/dark-gate-attribution.js`.
+
+Reclassified the 11 features that were in the retired bucket. Each candidate for
+going live on a development agent was re-grounded against its actual code (D4): 4
+verified safe and moved to `DEV_GATED_FEATURES` (`parallelWorkSentinel`,
+`failureLearning`, `releaseReadiness`, `bootHealthBeacon`) — their `enabled` flag
+is now omitted from `ConfigDefaults` so the developmentAgent gate resolves them
+live-on-dev / dark-on-fleet, and their construction sites route through
+`resolveDevAgentGate`. The other 3 candidates were held back as honest exclusions
+because their code contradicted "observe-only": `correctionLearning` (cost-bearing
+— per-message LLM spend), `apprenticeshipCycleSla` and `geminiCapacityEscalation`
+(action-bearing — auto-post Telegram alerts). `greenPrAutoMerge` + `a2aCheckIn` are
+recategorized action-bearing; `mentor` + `mentee` optional-integration.
+
+Added a one-shot, dev-agent-only `PostUpdateMigrator.migrateDevGateTeethStrip` that
+strips a stale persisted `enabled: false` for the 4 newly-dev-gated flags so an
+existing development agent actually picks up the change (without it the add-missing
+config merge would leave the stale value and the features would stay dark — the
+cartographer trap).
+
+## What to Tell Your User
+
+Nothing changes for you on a normal install — every one of these features stays off
+until you turn it on, exactly as before. On a development agent (the dogfooding
+machine), four watch-only helpers now switch on automatically after the update: a
+parallel-work overlap watcher, a failure-learning recorder, a release-readiness
+watcher, and a boot health responder. They only observe and record — none of them
+sends you a message, spends money, or changes anything. Three other helpers that
+were candidates to turn on were deliberately kept off because they would have spent
+money or sent you alerts; you can still switch any of those on yourself if you want
+them.
+
+## Summary of New Capabilities
+
+- A development agent now runs four verified watch-only observers live (parallel-work
+  overlap, failure-learning, release-readiness, boot health) so they get dogfooded
+  before the fleet ever sees them.
+- The dark-feature classification now requires a concrete, honest reason for any
+  feature parked "off even on dev" — enforced in CI — so a safe feature can no longer
+  be hidden behind a vague "off by policy" label.
+
+## Evidence
+
+- Spec + 6-round convergence report with a real cross-model (GPT-tier) external pass:
+  `docs/specs/DEV-AGENT-DARK-GATE-TEETH-SPEC.md`,
+  `docs/specs/reports/dev-agent-dark-gate-teeth-convergence.md`.
+- Tests (all green): `tests/unit/lint-dev-agent-dark-gate.test.ts` (retired category
+  rejected, `action-bearing` accepted, count-match guard, hand-verified drift canary),
+  `tests/unit/devGatedFeatures-wiring.test.ts` (the 4 new entries resolve live-on-dev /
+  dark-on-fleet through the real `ConfigDefaults`),
+  `tests/unit/PostUpdateMigrator-devGateTeethStrip.test.ts` (migration both sides +
+  idempotency + the 3 held untouched), `tests/integration/dev-gate-teeth-rollout.test.ts`
+  (full migration → defaults → resolver pipeline + the two-switch drift guard).
+- D4 code-grounding evidence (file:line per feature) is recorded in the spec's
+  "D4 grounding result" section.

--- a/upgrades/side-effects/dev-agent-dark-gate-teeth.md
+++ b/upgrades/side-effects/dev-agent-dark-gate-teeth.md
@@ -1,0 +1,201 @@
+# Side-Effects Review — Dev-Agent Dark-Gate Teeth (CMT-1438)
+
+**Version / slug:** `dev-agent-dark-gate-teeth`
+**Date:** `2026-06-13`
+**Author:** `echo`
+**Second-pass reviewer:** `required (touches gate/sentinel/migration) — see below`
+
+## Summary of the change
+
+Retires the catch-all `deliberate-fleet-default` category from the `DarkGateCategory`
+enum and adds a concrete `action-bearing` category, so every "off even on dev"
+classification must name a real reason dev-live is wrong (unsafe: destructive /
+cost-bearing / action-bearing; or not-runnable: optional-integration /
+structural-stub). Tightens the CI lint (`scripts/lint-dev-agent-dark-gate.js` +
+`scripts/lib/dark-gate-attribution.js`) to reject the retired category and adds a
+count-match guard that fails loud when an exclusion entry escapes category validation
+(the backtick-reason silent-skip hole). Reclassifies the 11 occupants: after per-feature
+D4 code-grounding, 4 move to `DEV_GATED_FEATURES` (parallelWorkSentinel, failureLearning,
+releaseReadiness, bootHealthBeacon) — their construction sites now route through
+`resolveDevAgentGate` and their `enabled: false` literal is removed from ConfigDefaults;
+7 stay exclusions with concrete categories (correctionLearning=cost-bearing,
+apprenticeshipCycleSla/geminiCapacityEscalation/greenPrAutoMerge/a2aCheckIn=action-bearing,
+mentor/mentee=optional-integration). Adds `PostUpdateMigrator.migrateDevGateTeethStrip` —
+a one-shot, dev-agent-only strip of stale persisted `enabled: false` for the 4 paths so
+the move actually lands on existing dev agents.
+Files: `src/core/devGatedFeatures.ts`, `scripts/lib/dark-gate-attribution.js`,
+`scripts/lint-dev-agent-dark-gate.js`, `src/config/ConfigDefaults.ts`,
+`src/server/AgentServer.ts` (parallelWorkSentinel + failureLearning gates),
+`src/commands/server.ts` (releaseReadiness + bootHealthBeacon gates),
+`src/server/CapabilityIndex.ts` (failureLearning capability report),
+`src/core/PostUpdateMigrator.ts` (D5 migration) + 3 test files.
+
+## Decision-point inventory
+
+- `DarkGateCategory` enum (classification taxonomy) — **modify** — drop the catch-all, add `action-bearing`; closes the willpower escape hatch.
+- `lint-dev-agent-dark-gate.js` Assertion C (CI gate) — **modify** — the closed-enum membership check tightens (one fewer valid category) + a count-match guard added.
+- `resolveDevAgentGate` at 4 construction sites — **modify (pass-through to the funnel)** — the 4 features' enable check now goes through the existing dev-gate funnel instead of a hand-rolled `=== true`. No new decision logic; it reuses the established resolver.
+- `migrateDevGateTeethStrip` — **add** — a config-mutation migration (deletes a stale `enabled: false`), dev-agent-only, run-once. Not an information-flow gate.
+
+---
+
+## 1. Over-block
+
+No outbound/inbound message block surface. The only "block"-shaped surface is the CI
+lint, which now *rejects* (a) an exclusion using the retired `deliberate-fleet-default`
+category and (b) an exclusion entry that doesn't fully parse (count-mismatch). The
+count-match guard can *over-trip* on a legitimate-but-unparseable entry — specifically
+an exclusion `reason` written with embedded quotes or a backtick/template literal. This
+is intentional fail-safe behavior (it forces a parseable, single-line, quote-delimited
+reason); it never lets a bad entry through. It surfaced exactly once during this build
+(my own reasons contained embedded `"`), was loud, and was fixed by rewording — proving
+the guard works. Authoring constraint, not a runtime over-block.
+
+---
+
+## 2. Under-block
+
+The lint still matches the literal `enabled: false` spelling only (a pre-existing,
+documented limitation — a non-literal `enabled: someFlag ?? false` evades attribution).
+The count-match guard closes the parsed-path-without-a-parsed-entry class (backtick
+reasons, reordered fields) but the registry parser remains regex-based, so other
+source-shape shifts (object spread, imported constants, `as const`) are still a
+theoretical blind spot — disclosed in the spec and tracked as a follow-up (AST /
+pure-data registry). The category honesty itself is never machine-checked (the lint
+validates spelling + reason length, not truthfulness); D4 code-grounding + the
+GrowthMilestoneAnalyst R6 runtime cross-check are the backstops, also disclosed.
+
+---
+
+## 3. Level-of-abstraction fit
+
+Right layer. The change does NOT add a new detector or authority — it (a) edits a
+classification enum + its CI lint (build-time signal), and (b) routes 4 features through
+the EXISTING `resolveDevAgentGate` funnel rather than re-implementing the gate inline
+(it removes 4 hand-rolled `=== true` checks). The migration reuses the EXISTING
+`migrateCartographerDevGate` pattern (same `_instar_migrations` marker machinery, same
+dev-agent guard). Nothing is re-implemented; everything feeds or reuses an existing
+primitive.
+
+---
+
+## 4. Signal vs authority compliance
+
+**Required reference:** [docs/signal-vs-authority.md](../../docs/signal-vs-authority.md)
+
+- [x] No — this change produces a signal consumed by an existing smart gate / has no
+  runtime block-allow surface.
+
+The CI lint is a deterministic build-time *signal-emitter* (it fails CI on an invalid
+classification); it is not a runtime authority over agent behavior. The spec is explicit
+that the lint closes only the *unclassified/invalid-category* hole — it does NOT
+adjudicate category *honesty* (that is D4 + R6). `resolveDevAgentGate` is the established
+funnel, not a new brittle authority. No brittle blocking authority is added.
+
+---
+
+## 5. Interactions
+
+- **Shadowing:** the 4 construction-site gate calls replace `=== true` with
+  `resolveDevAgentGate(...)`. For 3 of the 4, routes/consumers already gate on the
+  *constructed instance* (null → 503), so they follow the gate result with no shadowing.
+  For `failureLearning`, `CapabilityIndex` also reads the flag — updated to the SAME
+  funnel so the capability report matches the construction gate (no skew).
+- **Double-fire:** `migrateDevGateTeethStrip` shares the `_instar_migrations` ledger
+  with `migrateCartographerDevGate`; the new marker key (`dev-gate-teeth-strip`) is
+  distinct (not a prefix of, nor prefixed by, `cartographer-dev-gate-strip`), so the two
+  run independently and each exactly once. Verified by the round-2 integration review.
+- **Races:** the migration runs in the single-threaded PostUpdateMigrator pass at update
+  time; no concurrent writer to config.json during it.
+- **Feedback loops:** none. The lint is one-way (CI fails or passes).
+
+---
+
+## 6. External surfaces
+
+- **Other agents on the machine:** none — the change is per-agent config + a CI lint.
+- **Install base:** fleet behavior is byte-for-byte unchanged (every reclassified flag
+  still resolves `false` on a non-development agent; the migration is dev-agent-only).
+  Only development agents gain the 4 live observers.
+- **External systems (Telegram/GitHub/etc.):** the 4 features moved live are
+  D4-verified to make NO automatic outbound send on enable (parallelWorkSentinel: local
+  event/JSONL; failureLearning: append-only ledger, send path unimplemented;
+  releaseReadiness: read surface only, sends gated behind the separate dark job;
+  bootHealthBeacon: localhost-only inbound socket). The 3 features that DO auto-send
+  (correctionLearning spend; apprenticeshipCycleSla/geminiCapacityEscalation Telegram)
+  were deliberately HELD as exclusions precisely to avoid that surface on dev.
+- **Persistent state:** the migration deletes a stale `enabled: false` key from the dev
+  agent's own `config.json` (and records a run-once marker). Reported in the migration
+  result summary so a non-Echo operator sees which flags were freed.
+- **Operator surface (Mobile-Complete):** no operator-facing actions added — no route, no
+  form, no PIN-gated action. Not applicable.
+
+---
+
+## 6b. Operator-surface quality (Operator-Surface Quality standard)
+
+No operator surface — this change touches no dashboard renderer/markup, approval page, or
+grant/revoke/secret-drop form. Not applicable.
+
+---
+
+## 7. Multi-machine posture (Cross-Machine Coherence)
+
+**machine-local BY DESIGN.** The dev-feature classification is a code-shipped TypeScript
+enum + `ConfigDefaults` + each agent's per-machine `.instar/config.json`; `developmentAgent`
+is intrinsically a per-machine identity. None of the `multiMachine.stateSync.*` replicated
+kinds cover config flags or dev-gate state, and nothing here should follow the agent across
+machines — a machine either is or isn't a development agent. The D5 migration is
+dev-agent-only and mutates only the local config.json. No user-facing notice is emitted by
+this change (the 4 live features that COULD notify are either send-inert on enable or held
+as exclusions). No durable cross-machine state, no generated URLs. Confirmed by the
+round-1 integration reviewer (no journal kind needed).
+
+---
+
+## 8. Rollback cost
+
+Pure code + config-default change. Back-out = revert the commit (re-adds the
+`deliberate-fleet-default` enum member, the 4 `enabled: false` literals, the 4
+construction-site `=== true` checks, and removes the migration) and ship a patch. The D5
+migration is idempotent and run-once; a rolled-back agent that already ran it keeps its
+stripped config (the 4 flags then resolve via the reverted hardcoded `false` again — back
+to dark — with no error). No data migration, no agent state repair, no user-visible
+regression during the rollback window (fleet was never changed). An operator who wants a
+freed flag off again simply re-adds `enabled: false` (the run-once marker preserves it).
+
+---
+
+## Conclusion
+
+This review (plus the 6-round spec convergence that preceded it) reshaped the change in
+three material ways: (1) the migration was added after convergence found the 4 flags
+would otherwise stay dark on Echo (the cartographer trap); (2) D4 code-grounding held 3
+of 7 candidates back as honest exclusions when their code contradicted "observe-only";
+(3) the count-match lint guard was added after the adversarial reviewer found the
+backtick-reason silent-skip. The change adds no runtime blocking authority, makes no
+automatic external send on the dev agent (the senders are held off), leaves the fleet
+byte-for-byte unchanged, and is cleanly reversible. Clear to ship.
+
+---
+
+## Second-pass review (if required)
+
+**Reviewer:** independent reviewer subagent
+**Independent read of the artifact: concur**
+
+Concur with the review. The reviewer grounded every claim against the actual diff and confirmed: (1) all 4 construction sites route through `resolveDevAgentGate` with no hand-rolled `?? !!developmentAgent` (AgentServer.ts:858/1238, server.ts:3041/13258, CapabilityIndex.ts:794); (2) the migration allowlist is EXACTLY the 4 dev-gated paths, dev-agent-guarded, with a run-once marker distinct from cartographer's; (3) the signal-vs-authority answer holds (build-time signal + reused funnel + fail-safe count-match guard, no new blocking authority); (4) the highest-risk check — a missed read site — was investigated: the 4 flags also feed `src/monitoring/guardManifest.ts` → the `/guards` posture endpoint, but `guardPosture.ts:resolveGuardConfigSnapshot` already iterates `DEV_GATED_FEATURES` and injects the gate-resolved value, so moving the 4 into the registry makes `/guards` resolve them live on a dev agent automatically — NO "live-but-reported-disabled" skew, and the now-absent default raises no spurious boot tripwire. The reviewer's one non-blocking nit (stale "ships dark" prose in 4 `guardManifest.ts` descriptions) was fixed in this commit (descriptions now say "(dev-gated)"). Clear to ship.
+
+---
+
+## Evidence pointers
+
+- Spec + convergence report: `docs/specs/DEV-AGENT-DARK-GATE-TEETH-SPEC.md`,
+  `docs/specs/reports/dev-agent-dark-gate-teeth-convergence.md` (6 rounds, real
+  cross-model pass codex-cli:gpt-5.5).
+- Tests: `tests/unit/lint-dev-agent-dark-gate.test.ts` (enum/category/count-match +
+  drift canary), `tests/unit/devGatedFeatures-wiring.test.ts` (42 tests — 4 new entries
+  resolve live-on-dev/dark-on-fleet), `tests/unit/PostUpdateMigrator-devGateTeethStrip.test.ts`
+  (7 tests — migration both sides + idempotency + the 3 held), `tests/integration/dev-gate-teeth-rollout.test.ts`
+  (5 tests — full migration→defaults→resolver pipeline + two-switch drift guard).
+- D4 grounding evidence (file:line) is in the spec's "D4 grounding result" section.


### PR DESCRIPTION
## ELI16 — A feature can only be parked "off even on our own dev agents" if it proves running there would be genuinely unsafe (it kills things, spends money, takes a real external action, or needs config it doesn't have). The vague "off for everyone by policy" bucket is retired — that's exactly where safe features got hidden by accident. The audit that retires it also re-checked each feature's actual code, caught 3 that weren't as harmless as labeled, and added the migration that makes the change actually take effect on existing dev agents.

## What this is

CMT-1438 (DEV-AGENT-DARK-GATE-TEETH). Instar ships features dark for the fleet but live for development agents (the dogfooding ground). PR #1056 built the registry + lint that files every off-by-default `enabled: false` into one of two buckets: `DEV_GATED_FEATURES` (live-on-dev) or `DARK_GATE_EXCLUSIONS` (off-even-on-dev, with a category + reason). This PR gives the "off even on dev" half **teeth**.

Driven by the converged + approved spec `docs/specs/DEV-AGENT-DARK-GATE-TEETH-SPEC.md` (6 review rounds, real cross-model external pass `codex-cli:gpt-5.5`; report: `docs/specs/reports/dev-agent-dark-gate-teeth-convergence.md`).

## What changed

- **D1 — retire the catch-all.** Drops `deliberate-fleet-default` from `DarkGateCategory` and adds `action-bearing`. Every off-even-on-dev category now names a concrete reason dev-live is wrong — unsafe (`destructive` / `cost-bearing` / `action-bearing`) or not-runnable (`optional-integration` / `structural-stub`). No "off by policy" home remains.
- **D2 — lint teeth.** `VALID_CATEGORIES` (`scripts/lib/dark-gate-attribution.js`) drops the retired category and adds `action-bearing`; the fix message points safe-on-dev features to `DEV_GATED_FEATURES`. A **count-match guard** (`exclusionEntries.length === exclusionPaths.length`) fails loud when an exclusion entry escapes category validation (the backtick-reason silent-skip hole found in review).
- **D3 — reclassify the 11 occupants.** After D4 grounding: **4 → DEV_GATED** (`parallelWorkSentinel`, `failureLearning`, `releaseReadiness`, `bootHealthBeacon`) — `enabled` literal removed from `ConfigDefaults`, construction sites routed through `resolveDevAgentGate`. **7 → exclusions** with concrete categories: `correctionLearning` (cost-bearing), `apprenticeshipCycleSla` / `geminiCapacityEscalation` / `greenPrAutoMerge` / `a2aCheckIn` (action-bearing), `mentor` / `mentee` (optional-integration).
- **D4 — code-grounding caught 3 deviations.** The operator approved moving all 7 candidates, but re-grounding each against its code held 3 back as honest exclusions: `correctionLearning` runs a per-message Tier-1 LLM distill (≤25¢/day) — cost-bearing; `apprenticeshipCycleSla` + `geminiCapacityEscalation` auto-post Telegram attention topics on enable — action-bearing. The deviation was reported to the operator before building. (D4 grounding result with file:line is in the spec.)
- **D5 — the migration the audit forced.** `PostUpdateMigrator.migrateDevGateTeethStrip`: a one-shot, dev-agent-only, allowlisted strip of stale persisted `enabled: false` for the 4 newly-dev-gated paths (mirrors `migrateCartographerDevGate`). Convergence found that without it, the add-missing config merge leaves the stale value and the features stay dark on the very dev agent meant to dogfood them (the cartographer trap).

## Migration parity

Fleet behavior is byte-for-byte unchanged (every reclassified flag still resolves `false` off-dev; D5 is dev-agent-only and runs once). The 3 held features keep their persisted `false` and are excluded from the migration allowlist. An operator who deliberately re-sets a flag off keeps it (the run-once marker preserves it).

## Tests (3 tiers, green)

- **Unit** — `tests/unit/lint-dev-agent-dark-gate.test.ts`: retired category rejected (fix points to `DEV_GATED_FEATURES`), `action-bearing` accepted, count-match guard trips on a backtick reason, `VALID_CATEGORIES` membership, hand-verified drift canary updated. `tests/unit/devGatedFeatures-wiring.test.ts`: the 4 new entries resolve live-on-dev / dark-on-fleet through the real `ConfigDefaults` (42 tests). `tests/unit/PostUpdateMigrator-devGateTeethStrip.test.ts`: migration both sides + operator-`true` preserved + idempotency + the 3 held untouched.
- **Integration** — `tests/integration/dev-gate-teeth-rollout.test.ts`: full migration → applyDefaults → resolver pipeline (existing dev agent with stale `false` goes live; fleet stays dark; fresh agent both ways) + the releaseReadiness two-switch drift guard.
- Lint clean on the real tree; second-pass review concurred (verified all 4 construction sites route through the funnel and the `/guards` posture endpoint stays consistent).

## Side-effects review

`upgrades/side-effects/dev-agent-dark-gate-teeth.md` (8 dimensions; multi-machine = machine-local by design; no new blocking authority; second-pass concur).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
