### PR TITLE
feat(credential-repointing): WS5.2 Step 8 — provenance flag + env-token gate (dark)

### DIFF
--- a/.instar/instar-dev-decisions/2026-06-13T21-06-46-093Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-06-13T21-06-46-093Z-unknown.json
@@ -1,0 +1,17 @@
+{
+  "ts": "2026-06-13T21:06:46.093Z",
+  "slug": "unknown",
+  "suggestedTier": 2,
+  "declaredTier": 2,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "safety-invariant proximity: src/core/CredentialEnvTokenGate.ts matches token handling",
+    "new capability: new exported class / subsystem added",
+    "new capability: new config key added"
+  ],
+  "belowFloor": false,
+  "files": 5,
+  "loc": 262,
+  "causalAutopsy": null,
+  "verdict": "pass"
+}

--- a/src/commands/server.ts
+++ b/src/commands/server.ts
@@ -9200,9 +9200,31 @@ export async function startServer(options: StartOptions): Promise<void> {
       oracle: new CredentialIdentityOracle(),
       emitAttention: credentialGateEmitAttention,
     });
+    // The §2.10 env-token gate (Step 8): the §0.b applicability precondition, enforced. Evaluates
+    // BOTH `config.anthropicApiKey` (read LIVE per call — restartless) AND the live running fleet's
+    // durable per-session `credentialSource` flag, so a mid-run flip to an env token cannot silently
+    // un-steer the fleet. Pure evaluator (no IO). Constructed BEFORE the location gate so the
+    // location gate can AND-in its refusal — a §2.10 refusal suppresses ALL re-pointing attribution
+    // (requirement 3: an env-token session's usage is never mis-attributed to a slot tenant).
+    const { CredentialEnvTokenGate } = await import('../core/CredentialEnvTokenGate.js');
+    const credentialEnvTokenGate = new CredentialEnvTokenGate({
+      // SINGLE SOURCE OF TRUTH: the SessionManager spawn site reads `this.config.anthropicApiKey`,
+      // and `sessionManagerConfig` is `{ ...config.sessions }`, so the IDENTICAL value the env-block
+      // predicate sees is `config.sessions.anthropicApiKey`. Read it (not the legacy top-level field)
+      // so the gate's config predicate can never diverge from what actually launched the sessions.
+      getAnthropicApiKey: () => config.sessions?.anthropicApiKey,
+      listSessions: () => state.listSessions(),
+    });
     const credentialLocationGate = new CredentialLocationGate({
-      // Live flag read — a restartless config flip is honored on the next read.
-      isEnabled: () => config.subscriptionPool?.credentialRepointing?.enabled === true,
+      // Live flag read — a restartless config flip is honored on the next read. AND-ed with the
+      // §2.10 env-token gate: when the feature would refuse (config field set OR a live env-token
+      // session in the fleet), re-pointing attribution is suppressed wholesale, so the QuotaPoller
+      // stops routing reads/attribution through moved slots (an env fleet isn't store-steered, and
+      // attributing it would mis-credit usage to a slot tenant). Dark-default: when the feature flag
+      // is off this short-circuits before evaluating the gate, so it's byte-for-byte today's behavior.
+      isEnabled: () =>
+        config.subscriptionPool?.credentialRepointing?.enabled === true &&
+        !credentialEnvTokenGate.evaluate().refused,
       ledger: credentialLocationLedger,
       emitAttention: credentialGateEmitAttention,
     });
@@ -9277,6 +9299,7 @@ export async function startServer(options: StartOptions): Promise<void> {
       resolveIdentity: credResolveIdentity,
       audit: credentialAuditEmit,
       levers: credentialManualLevers,
+      envTokenGate: credentialEnvTokenGate,
       readBlob: async (slot: string) => {
         const raw = await defaultKeychainExec.readService(credSwapService(slot));
         if (!raw) return null;

--- a/src/core/CredentialEnvTokenGate.ts
+++ b/src/core/CredentialEnvTokenGate.ts
@@ -1,0 +1,152 @@
+/**
+ * CredentialEnvTokenGate — the §0.b applicability precondition, enforced structurally
+ * (Step 8 of live credential re-pointing).
+ *
+ * Spec: docs/specs/live-credential-repointing-rebalancer.md §2.10 (the env-token gate — verbatim
+ * contract), §0.b (applicability gate), §2.4 (the status route the named reason surfaces on).
+ *
+ * ── What this is ──
+ * The live credential re-pointing mechanism only works for sessions whose credential comes from
+ * the per-`CLAUDE_CONFIG_DIR` STORE (a swap re-points the store; claude-code re-reads it on the
+ * next 401). A session launched with an env token (`CLAUDE_CODE_OAUTH_TOKEN` / `ANTHROPIC_API_KEY`
+ * set from a non-empty `config.anthropicApiKey`) NEVER reads the store, ignores any swap, and is
+ * INVISIBLE to the mechanism. If such a launch were the norm the entire feature would be inert
+ * (§0.b). This gate REFUSES to run the feature — with a NAMED reason on the status route — whenever
+ * an env-token condition is present, so the mechanism can never silently mis-steer a fleet it does
+ * not actually control.
+ *
+ * ── The load-bearing safety contract (spec §2.10; build-prompt invariants 1, 2) ──
+ *   1. EVALUATES BOTH the config field AND the live running fleet. A config-only check would miss
+ *      the mid-life flip: an operator setting `config.anthropicApiKey` to an OAuth token mid-run
+ *      leaves already-running STORE sessions steerable while new ENV spawns are silently un-steered
+ *      — a genuinely mixed fleet a config-only check freezes incoherently. The fleet scan reads the
+ *      durable per-session `credentialSource` flag (recorded at spawn from the IDENTICAL expression
+ *      that selected the env block — single source of truth) so it can detect that mixed state.
+ *   2. THE CONFIG PREDICATE IS "ANY NON-EMPTY anthropicApiKey" (round-3) — NOT only an
+ *      `sk-ant-oat` OAuth token. The code's launch predicate is binary: `sk-ant-oat…` sets
+ *      `CLAUDE_CODE_OAUTH_TOKEN`, ANY OTHER non-empty value sets `ANTHROPIC_API_KEY`, and BOTH make
+ *      claude-code ignore the store. So the gate predicate is `(anthropicApiKey ?? '') !== ''`,
+ *      matching the SessionManager `?? ''`-then-non-empty branch exactly.
+ *   3. NAMED, CATEGORICAL REASON. The refusal reason is a category string (never a credential), but
+ *      the host still routes it through `CredentialAuditEmit.scrub` (Step 7) before any surface,
+ *      consistent with the §2.9 chokepoint.
+ *
+ * This module performs NO IO and NO credential reads. It is a pure evaluator over an injected
+ * config-key getter + an injected session lister, so it is fully unit-testable.
+ */
+
+import type { Session } from './types.js';
+
+/** A session lister snapshot input — the gate only reads `framework`, `status`, `credentialSource`. */
+export type EnvTokenFleetSession = Pick<Session, 'framework' | 'status' | 'credentialSource'>;
+
+export interface CredentialEnvTokenGateDeps {
+  /**
+   * Reads the live `config.anthropicApiKey` value EACH call (not cached) so a restartless config
+   * flip is honored on the next evaluation — the same restartless posture the rest of the feature
+   * uses. May return undefined/empty when no key is configured (the §0.b alive case).
+   */
+  getAnthropicApiKey: () => string | undefined;
+  /**
+   * Lists the CURRENT sessions (the live fleet). The gate filters to running claude-code sessions
+   * and reads their durable `credentialSource` flag. Injected so the gate stays IO-free.
+   */
+  listSessions: () => EnvTokenFleetSession[];
+}
+
+/** The named refusal reason categories (a category, never a credential). */
+export type EnvTokenRefusalReason =
+  | 'config-anthropic-api-key-set'
+  | 'env-token-session-in-fleet';
+
+export interface EnvTokenGateVerdict {
+  /** True when the feature MUST refuse to run (an env-token condition is present). */
+  refused: boolean;
+  /** The named, scrub-safe reason category when refused; undefined when permitted. */
+  reason?: EnvTokenRefusalReason;
+  /** A human-readable one-line explanation (category-level, no credential material). */
+  detail?: string;
+  /**
+   * The names/ids absent here on purpose: the verdict carries NO session identifiers and NO key
+   * material, so it is safe to surface as-is (and is scrubbed regardless by the host).
+   */
+  /** How many running claude-code sessions in the fleet are env-token (0 when none / config-only refusal). */
+  envSessionCount: number;
+}
+
+/**
+ * Evaluates the §2.10 env-token precondition over BOTH the config field AND the live fleet.
+ *
+ * Construct ONE per process and call `evaluate()` at enable-time AND per-pass. The CONFIG check is
+ * evaluated FIRST (cheapest + the dominant case); the FLEET scan closes the mid-life-flip hole.
+ */
+export class CredentialEnvTokenGate {
+  private readonly getAnthropicApiKey: () => string | undefined;
+  private readonly listSessions: () => EnvTokenFleetSession[];
+
+  constructor(deps: CredentialEnvTokenGateDeps) {
+    this.getAnthropicApiKey = deps.getAnthropicApiKey;
+    this.listSessions = deps.listSessions;
+  }
+
+  /**
+   * The §2.10 verdict. Refuses when:
+   *   (a) `config.anthropicApiKey` is non-empty (ANY value — OAuth or API key); OR
+   *   (b) any RUNNING claude-code session's `credentialSource` is `'env'` (the live-fleet path that
+   *       closes the mid-life flip). `credentialSource` undefined on a legacy/non-claude record is
+   *       treated as `'store'` (the safe, non-refusing direction — only an explicit `'env'` refuses).
+   * Permits (refused:false) only when the config field is empty AND every running claude-code
+   * session reads the store.
+   */
+  evaluate(): EnvTokenGateVerdict {
+    // (a) Config field — the dominant case, checked first. `?? ''`-then-non-empty mirrors the
+    // SessionManager launch predicate exactly: any non-empty value (OAuth OR API key) bypasses
+    // the store.
+    const key = this.getAnthropicApiKey() ?? '';
+    if (key !== '') {
+      return {
+        refused: true,
+        reason: 'config-anthropic-api-key-set',
+        detail:
+          'credential re-pointing refused: config.anthropicApiKey is set, so sessions launch with ' +
+          'an env token and bypass the per-CLAUDE_CONFIG_DIR store the mechanism steers (§0.b).',
+        envSessionCount: 0,
+      };
+    }
+
+    // (b) Live fleet — closes the mid-life flip. Count RUNNING claude-code sessions whose durable
+    // provenance flag is explicitly 'env'. Undefined ⇒ 'store' (safe direction).
+    const envSessions = this.listSessions().filter(
+      (s) =>
+        s.status === 'running' &&
+        s.framework === 'claude-code' &&
+        s.credentialSource === 'env',
+    );
+    if (envSessions.length > 0) {
+      return {
+        refused: true,
+        reason: 'env-token-session-in-fleet',
+        detail:
+          `credential re-pointing refused: ${envSessions.length} running claude-code session(s) ` +
+          'launched with an env token (store-bypassing) per the durable per-session provenance ' +
+          'flag — a config field flipped mid-run would otherwise leave a mixed fleet steered ' +
+          'incoherently (§2.10).',
+        envSessionCount: envSessions.length,
+      };
+    }
+
+    // Permitted: config empty + all-store fleet (the §0.b "alive" case for THIS deployment).
+    return { refused: false, envSessionCount: 0 };
+  }
+
+  /**
+   * True iff a given session should still feed `tenantOf(slot)` slot-attribution into usage records.
+   * On a §2.10 refusal the balancer STOPS feeding attribution for env-token sessions so an env
+   * session's usage is never mis-attributed to a slot tenant (spec §2.10 requirement 3). A session
+   * with `credentialSource: 'env'` never reads the store, so its usage does not belong to any slot
+   * tenant — it is attributed to its own account directly (enrollment-home behavior).
+   */
+  static shouldAttributeSlotTenant(session: Pick<Session, 'credentialSource'>): boolean {
+    return session.credentialSource !== 'env';
+  }
+}

--- a/src/core/SessionManager.ts
+++ b/src/core/SessionManager.ts
@@ -1837,6 +1837,14 @@ rm()  { "${shimRunner}" rm  "$@"; }
           '-e', `ANTHROPIC_BASE_URL=${this.config.anthropicBaseUrl ?? ''}`,
         ]
       : [];
+    // §2.10 provenance — SINGLE SOURCE OF TRUTH: the SAME `(anthropicApiKey ?? '') !== ''`
+    // predicate that selects the Anthropic env block above. Non-empty ⇒ this session launches
+    // with an env token (store-bypassing) ⇒ 'env'; empty ⇒ it reads the per-CLAUDE_CONFIG_DIR
+    // store ⇒ 'store'. Only meaningful for the claude-code env-block lane (undefined otherwise).
+    const headlessCredentialSource: 'store' | 'env' | undefined =
+      headlessFramework === 'claude-code'
+        ? ((this.config.anthropicApiKey ?? '') !== '' ? 'env' : 'store')
+        : undefined;
 
     try {
       execFileSync(this.config.tmuxPath, [
@@ -1913,6 +1921,8 @@ rm()  { "${shimRunner}" rm  "$@"; }
       // Subscription-pool pinning: tag the session with the account it launched
       // under, so auto-swap can move it when that account hits a quota wall.
       ...(pinnedAccount ? { subscriptionAccountId: pinnedAccount.accountId } : {}),
+      // §2.10 credential provenance — derived from the SAME predicate as the env block.
+      ...(headlessCredentialSource ? { credentialSource: headlessCredentialSource } : {}),
       // Positive-lane observability (june15-headless-spawn-reroute O4): always
       // populated now, so the soak's "zero headless under force" criterion is
       // machine-checkable from GET /sessions. completionMode stays 'exit' (the
@@ -2111,6 +2121,10 @@ rm()  { "${shimRunner}" rm  "$@"; }
         ? ['-e', `CLAUDE_CODE_OAUTH_TOKEN=${this.config.anthropicApiKey}`, '-e', 'ANTHROPIC_API_KEY=']
         : ['-e', `ANTHROPIC_API_KEY=${this.config.anthropicApiKey ?? ''}`, '-e', 'CLAUDE_CODE_OAUTH_TOKEN='];
     anthropicEnvFlags.push('-e', `ANTHROPIC_BASE_URL=${this.config.anthropicBaseUrl ?? ''}`);
+    // §2.10 provenance — SINGLE SOURCE OF TRUTH: the SAME `(anthropicApiKey ?? '') !== ''`
+    // predicate as the env block above (this lane is always claude-code → always set).
+    const reroutedCredentialSource: 'store' | 'env' =
+      (this.config.anthropicApiKey ?? '') !== '' ? 'env' : 'store';
 
     try {
       execFileSync(this.config.tmuxPath, [
@@ -2181,6 +2195,8 @@ rm()  { "${shimRunner}" rm  "$@"; }
       // Subscription-pool pinning: tag with the account this launched under, so
       // auto-swap can move it when that account hits a quota wall.
       ...(pinnedAccount ? { subscriptionAccountId: pinnedAccount.accountId } : {}),
+      // §2.10 credential provenance — derived from the SAME predicate as the env block.
+      credentialSource: reroutedCredentialSource,
       // The reroute's completion contract (spec O1 + O4):
       launchLane: 'rerouted-interactive',
       completionMode: 'pattern',
@@ -3224,6 +3240,13 @@ rm()  { "${shimRunner}" rm  "$@"; }
     const effectiveConfigHome =
       explicitConfigHome ?? (pinnedAccount ? this.resolvePinnedSpawnHome(pinnedAccount) : undefined);
     const effectiveAccountId = options?.subscriptionAccountId ?? pinnedAccount?.accountId;
+    // §2.10 provenance — SINGLE SOURCE OF TRUTH: the SAME `(anthropicApiKey ?? '') !== ''`
+    // predicate that selects the Anthropic env block in the execFileSync below. Only meaningful
+    // for the claude-code lane (the only one whose env block claude-code actually reads).
+    const interactiveCredentialSource: 'store' | 'env' | undefined =
+      framework === 'claude-code'
+        ? ((this.config.anthropicApiKey ?? '') !== '' ? 'env' : 'store')
+        : undefined;
     // This interactive session is about to launch under a pool account's config
     // home — seed the onboarding flags first or a headless-enrolled home wedges
     // it on the first-launch onboarding wizard (2026-06-09 incident). Applies to
@@ -3361,6 +3384,8 @@ rm()  { "${shimRunner}" rm  "$@"; }
       // user-facing interactive lane is now tagged just like the headless lane).
       // Undefined for single-account agents (resolver unwired → no pin).
       ...(effectiveAccountId ? { subscriptionAccountId: effectiveAccountId } : {}),
+      // §2.10 credential provenance — derived from the SAME predicate as the env block.
+      ...(interactiveCredentialSource ? { credentialSource: interactiveCredentialSource } : {}),
       prompt: effectiveInitialMessage,
       maxDurationMinutes: this.effectiveMaxDurationMinutes,
       // R2.8/L13: record the spawn cwd so a resume-queue entry can revive
@@ -3646,6 +3671,11 @@ rm()  { "${shimRunner}" rm  "$@"; }
       tmuxSession,
       startedAt: new Date().toISOString(),
       maxDurationMinutes: 10,
+      // §2.10 provenance — the triage lane hardcodes an EMPTY `ANTHROPIC_API_KEY=` above
+      // (it always reads the per-CLAUDE_CONFIG_DIR store, never an env token), so 'store' is
+      // the deterministic provenance here. Set explicitly so no claude-code spawn record is
+      // provenance-blind (an env-token lane that forgot the flag would be a lint-caught bug).
+      credentialSource: 'store',
     };
     this.state.saveSession(session);
 

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -124,6 +124,24 @@ export interface Session {
    * soak's success criterion (zero 'headless' under force) is machine-checkable. */
   launchLane?: 'headless' | 'rerouted-interactive';
   /**
+   * Credential provenance (live-credential-repointing-rebalancer §2.10). Records,
+   * at spawn, WHERE this session's Anthropic credential comes from:
+   * - 'store' — the per-`CLAUDE_CONFIG_DIR` credential store (steerable by the
+   *   live re-pointing mechanism; the swap takes effect on its next API call).
+   * - 'env'   — an env-token launch (`CLAUDE_CODE_OAUTH_TOKEN` / `ANTHROPIC_API_KEY`
+   *   set from a non-empty `config.anthropicApiKey`); the session ignores the store
+   *   and is INVISIBLE to re-pointing (the §0.b applicability precondition).
+   *
+   * SINGLE SOURCE OF TRUTH: derived at the spawn site from the IDENTICAL expression
+   * that selects the session's Anthropic env block —
+   * `(config.anthropicApiKey ?? '') !== '' ? 'env' : 'store'` — NEVER an independent
+   * recomputation (a later recompute re-creates the spawn-time staleness class this
+   * spec exists to kill). Default 'store'; only set on claude-code launch lanes
+   * (the only lanes that build an Anthropic env block). Undefined on legacy records
+   * and non-claude-code sessions; the env-token gate's fleet scan treats undefined
+   * as 'store' (the safe, non-refusing direction). */
+  credentialSource?: 'store' | 'env';
+  /**
    * Hard lifetime ceiling in minutes for a rerouted-interactive session
    * (june15-headless-spawn-reroute, PR2 finding O1 belt-and-suspenders). An
    * interactive REPL never exits, so if the model phrases its finish differently

--- a/src/server/routes.ts
+++ b/src/server/routes.ts
@@ -673,6 +673,9 @@ export interface RouteContext {
     audit: import('../core/CredentialAuditEmit.js').CredentialAuditEmit;
     /** Per-pair cooldown + §0.g force budget. */
     levers: import('../core/CredentialManualLevers.js').CredentialManualLevers;
+    /** §2.10 env-token gate (Step 8) — refuses the feature (config field OR live env-token fleet)
+     *  with a named reason surfaced on GET /credentials/rebalancer. */
+    envTokenGate: import('../core/CredentialEnvTokenGate.js').CredentialEnvTokenGate;
     /** Raw-blob reader for a slot (restore-enrollment coherence probe). Injectable for tests. */
     readBlob?: (slot: string) => Promise<{ raw: string; oauth: import('../core/OAuthRefresher.js').ClaudeOauth | null } | null>;
   } | null;
@@ -19230,10 +19233,36 @@ export function createRoutes(ctx: RouteContext): Router {
     });
   });
 
-  // GET /credentials/rebalancer — the autonomous balancer's last-pass surface. 503 in Increment A
-  // (the CredentialRebalancer is Increment B). Named so the route exists + is discoverable now.
+  // GET /credentials/rebalancer — the autonomous balancer's last-pass surface. The CredentialRebalancer
+  // (Increment B) is not wired in Increment A, so the balancer ITSELF still reports 503/not-wired. But
+  // Step 8 (§2.10) surfaces the ENV-TOKEN GATE verdict here: WHY the feature would refuse to run even
+  // once the balancer lands. SHIPS DARK: with the flag off (always, while dark) the route is a strict
+  // no-op 503, byte-for-byte its prior behavior. With the flag ON it ALSO carries the env-token gate's
+  // named refusal reason (config field OR live-fleet env-token sessions), scrubbed via the audit
+  // chokepoint — the §2.10 applicability precondition made visible.
   router.get('/credentials/rebalancer', (_req, res) => {
-    res.status(503).json({ enabled: false, reason: 'the autonomous balancer is Increment B — not wired in Increment A' });
+    const cr = ctx.credentialRepointing;
+    // Dark / unwired → strict no-op 503 (unchanged): the surface stays exactly as it shipped at Step 7.
+    if (!cr || !credRepointEnabled()) {
+      const body = { enabled: false, reason: 'the autonomous balancer is Increment B — not wired in Increment A' };
+      // Route through the scrub chokepoint when the bundle is wired; else send the static body.
+      res.status(503).json(cr ? cr.audit.response(body) : body);
+      return;
+    }
+    // Flag ON: evaluate the §2.10 env-token gate (config field + live fleet) and surface its verdict.
+    const verdict = cr.envTokenGate.evaluate();
+    credSend(res, 200, {
+      enabled: true,
+      // The balancer loop itself is Increment B — never running in Increment A regardless of the gate.
+      balancerWired: false,
+      envTokenGate: {
+        refused: verdict.refused,
+        // A named CATEGORY, not a credential; scrubbed regardless by credSend → audit.response.
+        reason: verdict.reason,
+        detail: verdict.detail,
+        envSessionCount: verdict.envSessionCount,
+      },
+    });
   });
 
   // Shared lever guard: dark → 503; levers disabled → 403. Returns the wired bundle or null.

--- a/tests/e2e/credential-repointing-routes-alive.test.ts
+++ b/tests/e2e/credential-repointing-routes-alive.test.ts
@@ -25,6 +25,7 @@ import { CredentialLocationLedger, type IdentityOracle } from '../../src/core/Cr
 import { CredentialSwapExecutor, type KeychainCredentialExec, type ResolveSlotIdentity } from '../../src/core/CredentialSwapExecutor.js';
 import { CredentialAuditEmit } from '../../src/core/CredentialAuditEmit.js';
 import { CredentialManualLevers } from '../../src/core/CredentialManualLevers.js';
+import { CredentialEnvTokenGate, type EnvTokenFleetSession } from '../../src/core/CredentialEnvTokenGate.js';
 import { CredentialWriteFunnel } from '../../src/core/CredentialWriteFunnel.js';
 import { claudeCredentialService } from '../../src/core/OAuthRefresher.js';
 import type { InstarConfig } from '../../src/core/types.js';
@@ -66,7 +67,11 @@ function memKeychain(): KeychainCredentialExec {
 }
 const resolveAllow: ResolveSlotIdentity = async (slot) => ({ accountId: slot === SLOT_A ? ACC_B : ACC_A });
 
-function buildRepointing(stateDir: string, enabled: boolean) {
+function buildRepointing(
+  stateDir: string,
+  enabled: boolean,
+  envTokenOpts?: { anthropicApiKey?: string; fleet?: EnvTokenFleetSession[] },
+) {
   const ledger = new CredentialLocationLedger({ stateDir, pool: { list: () => [] }, oracle: noopOracle });
   ledger.recordAssignment(SLOT_A, ACC_A, { op: 'seed' });
   ledger.recordAssignment(SLOT_B, ACC_B, { op: 'seed' });
@@ -75,13 +80,18 @@ function buildRepointing(stateDir: string, enabled: boolean) {
     funnel: new CredentialWriteFunnel(), ledger, keychain: memKeychain(),
     resolveIdentity: resolveAllow, config: { enabled, dryRun: true }, reverifyDelayMs: 5,
   });
-  return { ledger, swapExecutor, resolveIdentity: resolveAllow, audit, levers: new CredentialManualLevers() };
+  const envTokenGate = new CredentialEnvTokenGate({
+    getAnthropicApiKey: () => envTokenOpts?.anthropicApiKey ?? '',
+    listSessions: () => envTokenOpts?.fleet ?? [],
+  });
+  return { ledger, swapExecutor, resolveIdentity: resolveAllow, audit, levers: new CredentialManualLevers(), envTokenGate };
 }
 
 describe('WS5.2 Step 7 /credentials/* E2E lifecycle (feature is alive)', () => {
   let tmpDir: string;
   let enabledServer: AgentServer; let enabledApp: express.Express;
   let darkServer: AgentServer; let darkApp: express.Express;
+  let envGateServer: AgentServer; let envGateApp: express.Express;
 
   beforeAll(async () => {
     tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cred-step7-e2e-'));
@@ -105,11 +115,28 @@ describe('WS5.2 Step 7 /credentials/* E2E lifecycle (feature is alive)', () => {
     });
     await darkServer.start();
     darkApp = darkServer.getApp();
+
+    // Step 8 §2.10 — enabled feature with a LIVE env-token condition (a running claude-code session
+    // tagged credentialSource:'env'), config field empty. The env-token gate must REFUSE on the
+    // live-fleet path even though the config field is clean (the mid-life flip).
+    const envGateStateDir = mkStateDir(tmpDir, 'env-gate');
+    envGateServer = new AgentServer({
+      config: baseConfig(envGateStateDir, tmpDir, true),
+      sessionManager: createMockSessionManager() as never,
+      state: new StateManager(envGateStateDir),
+      credentialRepointing: buildRepointing(envGateStateDir, true, {
+        anthropicApiKey: '',
+        fleet: [{ framework: 'claude-code', status: 'running', credentialSource: 'env' }],
+      }),
+    });
+    await envGateServer.start();
+    envGateApp = envGateServer.getApp();
   });
 
   afterAll(async () => {
     await enabledServer?.stop();
     await darkServer?.stop();
+    await envGateServer?.stop();
     SafeFsExecutor.safeRmSync(tmpDir, { recursive: true, force: true, operation: 'tests/e2e/credential-repointing-routes-alive.test.ts' });
   });
 
@@ -145,7 +172,25 @@ describe('WS5.2 Step 7 /credentials/* E2E lifecycle (feature is alive)', () => {
     expect((await request(enabledApp).get('/credentials/rebalancer')).status).toBe(401);
   });
 
-  it('rebalancer is 503 in Increment A even when the feature is enabled', async () => {
-    expect((await request(enabledApp).get('/credentials/rebalancer').set(auth())).status).toBe(503);
+  it('(d) Step 8 §2.10: rebalancer DARK is a strict 503 no-op (unchanged surface)', async () => {
+    // The dark case keeps the byte-for-byte prior surface: 503, balancer-not-wired, no gate eval.
+    const r = await request(darkApp).get('/credentials/rebalancer').set(auth());
+    expect(r.status).toBe(503);
+  });
+
+  it('(e) Step 8 §2.10: rebalancer ENABLED + clean config + all-store fleet PERMITS (refused:false)', async () => {
+    const r = await request(enabledApp).get('/credentials/rebalancer').set(auth());
+    expect(r.status).toBe(200);
+    expect(r.body.enabled).toBe(true);
+    expect(r.body.balancerWired).toBe(false); // the autonomous balancer is Increment B
+    expect(r.body.envTokenGate.refused).toBe(false);
+  });
+
+  it('(f) Step 8 §2.10: rebalancer ENABLED + a live env-token session REFUSES with named reason', async () => {
+    const r = await request(envGateApp).get('/credentials/rebalancer').set(auth());
+    expect(r.status).toBe(200);
+    expect(r.body.envTokenGate.refused).toBe(true);
+    expect(r.body.envTokenGate.reason).toBe('env-token-session-in-fleet');
+    expect(r.body.envTokenGate.envSessionCount).toBe(1);
   });
 });

--- a/tests/integration/credential-routes.test.ts
+++ b/tests/integration/credential-routes.test.ts
@@ -25,6 +25,7 @@ import {
 } from '../../src/core/CredentialSwapExecutor.js';
 import { CredentialAuditEmit } from '../../src/core/CredentialAuditEmit.js';
 import { CredentialManualLevers } from '../../src/core/CredentialManualLevers.js';
+import { CredentialEnvTokenGate, type EnvTokenFleetSession } from '../../src/core/CredentialEnvTokenGate.js';
 import { claudeCredentialService } from '../../src/core/OAuthRefresher.js';
 import { CredentialWriteFunnel } from '../../src/core/CredentialWriteFunnel.js';
 import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
@@ -71,7 +72,12 @@ function buildLedger(stateDir: string): CredentialLocationLedger {
 /** Identity resolver mapping the in-memory blob's token → its account (commit-side ALLOW). */
 const resolveAllow: ResolveSlotIdentity = async (slot) => ({ accountId: slot === SLOT_A ? ACC_B : ACC_A });
 
-function makeApp(opts: { enabled: boolean; manualLeversEnabled?: boolean }): { app: express.Express; stateDir: string; auditLines: string[] } {
+function makeApp(opts: {
+  enabled: boolean;
+  manualLeversEnabled?: boolean;
+  anthropicApiKey?: string;
+  fleet?: EnvTokenFleetSession[];
+}): { app: express.Express; stateDir: string; auditLines: string[] } {
   const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cred-routes-'));
   fs.mkdirSync(path.join(stateDir, 'logs'), { recursive: true });
   const ledger = buildLedger(stateDir);
@@ -92,6 +98,10 @@ function makeApp(opts: { enabled: boolean; manualLeversEnabled?: boolean }): { a
     resolveIdentity: resolveAllow,
     audit,
     levers: new CredentialManualLevers(),
+    envTokenGate: new CredentialEnvTokenGate({
+      getAnthropicApiKey: () => opts.anthropicApiKey ?? '',
+      listSessions: () => opts.fleet ?? [],
+    }),
     readBlob: async (slot: string) => {
       const raw = km.map.get(claudeCredentialService(slot)) ?? null;
       if (!raw) return null;
@@ -134,6 +144,53 @@ describe('/credentials/* routes (integration)', () => {
     const loc = await api('/credentials/locations');
     expect(loc.status).toBe(200);
     expect(loc.body.enabled).toBe(false);
+  });
+
+  it('Step 8 §2.10: rebalancer surfaces the env-token gate refusal (config field set), scrubbed', async () => {
+    const built = makeApp({ enabled: true, anthropicApiKey: 'sk-ant-oat01-LeAkMe1234567890_secret' });
+    stateDir = built.stateDir; cleanup.push(stateDir);
+    server = await listen(built.app);
+    const r = await api('/credentials/rebalancer');
+    expect(r.status).toBe(200);
+    expect(r.body.enabled).toBe(true);
+    expect(r.body.envTokenGate.refused).toBe(true);
+    expect(r.body.envTokenGate.reason).toBe('config-anthropic-api-key-set');
+    // The reason is a CATEGORY, not a credential — and the response routes through the scrub
+    // chokepoint regardless, so no token byte leaks even though the config key carries one.
+    expect(JSON.stringify(r.body)).not.toContain('LeAkMe1234567890');
+  });
+
+  it('Step 8 §2.10: rebalancer surfaces the live-fleet refusal (mid-life flip), config empty', async () => {
+    const built = makeApp({
+      enabled: true,
+      anthropicApiKey: '',
+      fleet: [
+        { framework: 'claude-code', status: 'running', credentialSource: 'store' },
+        { framework: 'claude-code', status: 'running', credentialSource: 'env' },
+      ],
+    });
+    stateDir = built.stateDir; cleanup.push(stateDir);
+    server = await listen(built.app);
+    const r = await api('/credentials/rebalancer');
+    expect(r.status).toBe(200);
+    expect(r.body.envTokenGate.refused).toBe(true);
+    expect(r.body.envTokenGate.reason).toBe('env-token-session-in-fleet');
+    expect(r.body.envTokenGate.envSessionCount).toBe(1);
+  });
+
+  it('Step 8 §2.10: rebalancer PERMITS (refused:false) when config empty + all-store fleet', async () => {
+    const built = makeApp({
+      enabled: true,
+      anthropicApiKey: '',
+      fleet: [{ framework: 'claude-code', status: 'running', credentialSource: 'store' }],
+    });
+    stateDir = built.stateDir; cleanup.push(stateDir);
+    server = await listen(built.app);
+    const r = await api('/credentials/rebalancer');
+    expect(r.status).toBe(200);
+    expect(r.body.enabled).toBe(true);
+    expect(r.body.balancerWired).toBe(false);
+    expect(r.body.envTokenGate.refused).toBe(false);
   });
 
   it('LIVE (flag on): POST /credentials/swap executes the executor; response carries NO token', async () => {

--- a/tests/unit/codex-model-swap-wiring.test.ts
+++ b/tests/unit/codex-model-swap-wiring.test.ts
@@ -106,9 +106,11 @@ describe('codex model-swap wiring — both spawn paths consume the helper', () =
     // Same rationale as the headless case above: legitimate code can sit between
     // resolution and the build — e.g. the subscription account-swap lane seeds a
     // pool home's onboarding flags here (ensurePinnedHomeInteractiveReady) before
-    // launch. The invariant is "resolved before, passed as launchModel", not
-    // literal proximity, so use the same widened look-back window.
-    const before = src.slice(Math.max(0, idx - 2500), idx);
+    // launch, and (WS5.2 Step 8) the §2.10 credentialSource provenance derivation
+    // sits between effectiveAccountId and the build. The invariant is "resolved
+    // before, passed as launchModel", not literal proximity, so use a widened
+    // look-back window (3000 chars — bumped from 2500 for the Step 8 derivation).
+    const before = src.slice(Math.max(0, idx - 3000), idx);
     expect(before).toContain('this.resolveCodexLaunchModel(framework');
     expect(src.slice(idx, idx + 250)).toContain('launchDefaultModel');
   });

--- a/tests/unit/credential-env-token-gate.test.ts
+++ b/tests/unit/credential-env-token-gate.test.ts
@@ -1,0 +1,194 @@
+/**
+ * Unit tests for WS5.2 Step 8 — the §2.10 env-token gate + the per-session `credentialSource`
+ * provenance flag.
+ *
+ * Spec: docs/specs/live-credential-repointing-rebalancer.md §2.10 (the env-token gate — verbatim
+ * contract), §0.b (applicability gate).
+ *
+ * The load-bearing adversarial lenses, each a named test:
+ *   1. SINGLE SOURCE OF TRUTH — the `credentialSource` flag is the IDENTICAL boolean expression
+ *      that selects the env block at each of the three SessionManager spawn lanes. Proven against
+ *      the real source: a static grep-assert that the derivation reads `this.config.anthropicApiKey`
+ *      adjacent to each env-block predicate (a divergence is the bug to prevent).
+ *   2. MID-LIFE FLIP / LIVE FLEET — the gate refuses on a running `env` session even when the
+ *      config field is currently empty (a config-only gate would miss it).
+ *   3. CONFIG PREDICATE — refuses on ANY non-empty `anthropicApiKey` (OAuth OR API key), not only
+ *      `sk-ant-oat`.
+ *   4. ATTRIBUTION-SUPPRESSION — `shouldAttributeSlotTenant` is false for an env session (its usage
+ *      is never mis-attributed to a slot tenant).
+ *   5. ALLOW — empty config + all-store fleet permits (refused:false).
+ */
+
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+  CredentialEnvTokenGate,
+  type EnvTokenFleetSession,
+} from '../../src/core/CredentialEnvTokenGate.js';
+import type { Session } from '../../src/core/types.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const SESSION_MANAGER_SRC = path.resolve(__dirname, '../../src/core/SessionManager.ts');
+
+function gate(opts: {
+  key?: string | undefined;
+  sessions?: EnvTokenFleetSession[];
+}): CredentialEnvTokenGate {
+  return new CredentialEnvTokenGate({
+    getAnthropicApiKey: () => opts.key,
+    listSessions: () => opts.sessions ?? [],
+  });
+}
+
+const running = (over: Partial<EnvTokenFleetSession> = {}): EnvTokenFleetSession => ({
+  framework: 'claude-code',
+  status: 'running',
+  credentialSource: 'store',
+  ...over,
+});
+
+describe('CredentialEnvTokenGate — §2.10 config predicate', () => {
+  it('PERMITS when config empty + all-store fleet (the §0.b alive case)', () => {
+    const v = gate({ key: '', sessions: [running(), running()] }).evaluate();
+    expect(v.refused).toBe(false);
+    expect(v.reason).toBeUndefined();
+    expect(v.envSessionCount).toBe(0);
+  });
+
+  it('PERMITS when config is undefined (no key configured)', () => {
+    const v = gate({ key: undefined, sessions: [running()] }).evaluate();
+    expect(v.refused).toBe(false);
+  });
+
+  it('REFUSES on an sk-ant-oat OAuth token in config (named reason)', () => {
+    const v = gate({ key: 'sk-ant-oat01-abcdef', sessions: [] }).evaluate();
+    expect(v.refused).toBe(true);
+    expect(v.reason).toBe('config-anthropic-api-key-set');
+    expect(v.detail).toMatch(/anthropicApiKey is set/i);
+  });
+
+  it('REFUSES on ANY non-empty key — a direct sk-ant-api03 API key (round-3, NOT only OAuth)', () => {
+    const v = gate({ key: 'sk-ant-api03-direct-billing-key', sessions: [] }).evaluate();
+    expect(v.refused).toBe(true);
+    expect(v.reason).toBe('config-anthropic-api-key-set');
+  });
+
+  it('REFUSES on a non-empty key that is neither oat nor api03 (binary: any value bypasses store)', () => {
+    const v = gate({ key: 'literally-anything', sessions: [] }).evaluate();
+    expect(v.refused).toBe(true);
+    expect(v.reason).toBe('config-anthropic-api-key-set');
+  });
+});
+
+describe('CredentialEnvTokenGate — §2.10 live-fleet path (the mid-life flip)', () => {
+  it('REFUSES when config empty but ONE running claude-code session is credentialSource:env', () => {
+    const v = gate({
+      key: '',
+      sessions: [running(), running({ credentialSource: 'env' }), running()],
+    }).evaluate();
+    expect(v.refused).toBe(true);
+    expect(v.reason).toBe('env-token-session-in-fleet');
+    expect(v.envSessionCount).toBe(1);
+    expect(v.detail).toMatch(/env token/i);
+  });
+
+  it('counts MULTIPLE env sessions in the fleet', () => {
+    const v = gate({
+      key: '',
+      sessions: [running({ credentialSource: 'env' }), running({ credentialSource: 'env' })],
+    }).evaluate();
+    expect(v.refused).toBe(true);
+    expect(v.envSessionCount).toBe(2);
+  });
+
+  it('does NOT refuse on a NON-running env session (only the live fleet counts)', () => {
+    const v = gate({
+      key: '',
+      sessions: [running({ status: 'completed', credentialSource: 'env' })],
+    }).evaluate();
+    expect(v.refused).toBe(false);
+  });
+
+  it('does NOT refuse on a non-claude-code env-tagged session (the flag is claude-code-only)', () => {
+    const v = gate({
+      key: '',
+      sessions: [running({ framework: 'codex-cli', credentialSource: 'env' })],
+    }).evaluate();
+    expect(v.refused).toBe(false);
+  });
+
+  it('treats undefined credentialSource as store (legacy record, safe direction)', () => {
+    const v = gate({
+      key: '',
+      sessions: [running({ credentialSource: undefined })],
+    }).evaluate();
+    expect(v.refused).toBe(false);
+  });
+
+  it('config-field refusal SHORT-CIRCUITS before the fleet scan (envSessionCount 0)', () => {
+    // When the config field already refuses, the fleet scan is not consulted — its count stays 0.
+    const v = gate({
+      key: 'sk-ant-oat01-x',
+      sessions: [running({ credentialSource: 'env' }), running({ credentialSource: 'env' })],
+    }).evaluate();
+    expect(v.refused).toBe(true);
+    expect(v.reason).toBe('config-anthropic-api-key-set');
+    expect(v.envSessionCount).toBe(0);
+  });
+});
+
+describe('CredentialEnvTokenGate — §2.10 attribution-suppression (requirement 3)', () => {
+  it('an env session must NOT feed slot-tenant attribution', () => {
+    const env: Pick<Session, 'credentialSource'> = { credentialSource: 'env' };
+    expect(CredentialEnvTokenGate.shouldAttributeSlotTenant(env)).toBe(false);
+  });
+
+  it('a store session DOES feed slot-tenant attribution', () => {
+    expect(CredentialEnvTokenGate.shouldAttributeSlotTenant({ credentialSource: 'store' })).toBe(true);
+  });
+
+  it('an undefined-provenance (legacy) session feeds attribution (store-default)', () => {
+    expect(CredentialEnvTokenGate.shouldAttributeSlotTenant({ credentialSource: undefined })).toBe(true);
+  });
+});
+
+describe('Step 8 — SINGLE SOURCE OF TRUTH (the blocker lens, against real source)', () => {
+  // The flag MUST be the IDENTICAL expression as the env-block selection at each spawn lane —
+  // proven structurally: the SessionManager source contains, at each of the three claude-code
+  // launch lanes, BOTH the env-block predicate `(this.config.anthropicApiKey ?? '').startsWith(
+  // 'sk-ant-oat')` AND the provenance derivation `(this.config.anthropicApiKey ?? '') !== '' ?
+  // 'env' : 'store'` reading the SAME `this.config.anthropicApiKey`. An independent recomputation
+  // (a different source expression) would fail this assertion.
+  const src = fs.readFileSync(SESSION_MANAGER_SRC, 'utf-8');
+
+  it('has exactly three env-block predicates over this.config.anthropicApiKey (the 3 lanes)', () => {
+    const matches = src.match(
+      /\(this\.config\.anthropicApiKey \?\? ''\)\.startsWith\('sk-ant-oat'\)/g,
+    );
+    expect(matches?.length).toBe(3);
+  });
+
+  it('has three credentialSource derivations using the IDENTICAL anthropicApiKey expression', () => {
+    const matches = src.match(
+      /\(this\.config\.anthropicApiKey \?\? ''\) !== '' \? 'env' : 'store'/g,
+    );
+    expect(matches?.length).toBe(3);
+  });
+
+  it('writes credentialSource onto a session record at every spawn lane (3 derived + triage)', () => {
+    const writes = src.match(/credentialSource:/g);
+    // 3 derived lane writes + 1 explicit triage 'store' write = 4 record-write occurrences.
+    expect(writes?.length).toBe(4);
+  });
+
+  it('the derivation predicate matches the env-block predicate (no divergence)', () => {
+    // Both predicates key on `(this.config.anthropicApiKey ?? '')`. A divergence (e.g. one reading
+    // a cached/recomputed value) is exactly the staleness class this spec exists to kill.
+    const envBlockKeyReads = (src.match(/\(this\.config\.anthropicApiKey \?\? ''\)\.startsWith/g) ?? []).length;
+    const provenanceKeyReads = (src.match(/\(this\.config\.anthropicApiKey \?\? ''\) !== ''/g) ?? []).length;
+    expect(envBlockKeyReads).toBe(3);
+    expect(provenanceKeyReads).toBe(3);
+  });
+});

--- a/upgrades/next/ws52-step8-provenance-gate.md
+++ b/upgrades/next/ws52-step8-provenance-gate.md
@@ -1,0 +1,39 @@
+# WS5.2 Step 8 — credential provenance flag + env-token gate (dark)
+
+<!-- bump: patch -->
+
+<!--
+  NOTE: dark/additive + internal. One new exported class (CredentialEnvTokenGate) + a new
+  additive optional Session.credentialSource field + one rebalancer route that now surfaces
+  the gate verdict. ALL gated by the EXISTING subscriptionPool.credentialRepointing flag
+  (enabled:false + dryRun:true, already a DARK_GATE_EXCLUSIONS destructive entry) — NO new
+  config flag, so the dark-gate line-map is UNCHANGED (no recompute; lint clean, dark-gate
+  test green as-is). No new unfunneled credential write path — the gate is a pure read-time
+  evaluator and the provenance field is free session-record metadata. CLAUDE.md awareness +
+  migrateConfig are Step 9 (Migration parity).
+-->
+
+## What Changed
+
+Enforces the spec's applicability precondition: live credential re-pointing only works for sessions that read their credential from the per-config-home store. A session launched with an env token bypasses that store and is invisible to the mechanism — so this step records, at spawn, WHERE each session's Anthropic credential comes from, and refuses to run the feature whenever an env-token session is present.
+
+- **Durable per-session provenance flag** — a new `credentialSource: 'store' | 'env'` field on the session record, set at every claude-code spawn lane. It is derived from the IDENTICAL expression that selects the session's Anthropic env block — `(config.anthropicApiKey ?? '') !== '' ? 'env' : 'store'`, computed at the spawn site — so the flag can never drift from what actually launched the session (single source of truth; an independent recomputation would re-create the staleness class this spec exists to kill).
+- **The env-token gate** — a new `CredentialEnvTokenGate` (src/core/CredentialEnvTokenGate.ts), a pure evaluator. It REFUSES the feature, with a NAMED category reason, when either the config field `anthropicApiKey` is any non-empty value (an OAuth token OR a direct API key — both bypass the store) OR any running claude-code session's provenance flag is `env`. Checking the LIVE fleet — not just the config field — closes the mid-life-flip hole: an operator setting an env token mid-run would otherwise leave already-running store sessions steerable while new env spawns are silently un-steered.
+- **Named reason on the status route** — `GET /credentials/rebalancer`, when the feature flag is ON, now surfaces the gate verdict (refused, the reason category, and the count of env sessions), scrubbed through the existing secret-scrub chokepoint. Dark (flag off) it stays a strict 503 no-op.
+- **Attribution-suppression** — on a gate refusal the location gate behaves as dark, so the quota poller stops routing reads/attribution through moved slots: an env session's usage is never mis-attributed to a slot tenant.
+- **Dark** — gated by the existing `subscriptionPool.credentialRepointing` flag. With the feature off (the fleet + dev default) the gate is never consulted and the only delta is the additive provenance field on new session records (free metadata, never read) — byte-for-byte today's behavior.
+
+## What to Tell Your User
+
+This is internal plumbing that ships turned off, so nothing changes for you day to day. What it builds toward, with a safety guarantee baked in: the under-the-hood feature that moves a credential between your subscription accounts only works for sessions that read their login from the on-disk store I manage. If a session was instead launched with a login token handed straight to it in its environment, that session ignores the store entirely and the moving trick would be a no-op for it. So this step teaches me to record, the moment each session starts, which of those two kinds it is — and to refuse to run the whole moving feature at all whenever any running session is the kind I cannot steer. That refusal is deliberate and visible, with a plain reason, rather than the feature quietly mis-handling a session it does not actually control. It is off by default and does nothing until the feature is turned on after a review window.
+
+## Summary of New Capabilities
+
+One new exported class — `CredentialEnvTokenGate` (the env-token applicability gate: refuses on the config field OR a live env-token session in the fleet, with a named reason) — plus a new additive optional `Session.credentialSource` provenance field set at every claude-code spawn lane, and the `GET /credentials/rebalancer` route surfacing the gate verdict. All gated by the existing `subscriptionPool.credentialRepointing` flag. No new gate flag, no new unfunneled credential write path.
+
+## Evidence
+
+- `tests/unit/credential-env-token-gate.test.ts` (18) — config predicate (permits empty/undefined; refuses on sk-ant-oat, on a direct sk-ant-api03 key, and on any non-empty value); live-fleet path (refuses on one running env session with config empty, counts multiple, ignores a non-running env session and a non-claude env session, treats undefined as store, config-field refusal short-circuits before the fleet scan); attribution-suppression (`shouldAttributeSlotTenant` false for env, true for store/undefined); and the single-source-of-truth blocker proven by a static grep-assert against the real SessionManager source (exactly 3 env-block predicates + 3 identical provenance derivations + 4 record writes).
+- `tests/integration/credential-routes.test.ts` (+3) — the rebalancer route surfaces the config-field refusal (scrubbed, no token leak), the live-fleet refusal (mid-life flip, config empty), and permits when config empty + all-store fleet.
+- `tests/e2e/credential-repointing-routes-alive.test.ts` (+3) — feature-alive on the real AgentServer factory: rebalancer DARK is a strict 503 no-op, ENABLED + clean config + all-store fleet permits, ENABLED + a live env-token session refuses with the named reason.
+- tsc clean; full `npm run lint` clean (dark-gate 16/16 unchanged — no ConfigDefaults touched); no-silent-fallbacks + no-empty-catch-blocks + feature-delivery-completeness + docs-coverage green.

--- a/upgrades/side-effects/ws52-step8-provenance-gate.md
+++ b/upgrades/side-effects/ws52-step8-provenance-gate.md
@@ -1,0 +1,78 @@
+# Side-effects review — WS5.2 Step 8 (credential provenance flag + env-token gate)
+
+**Spec:** `docs/specs/live-credential-repointing-rebalancer.md` (approved:true, converged) §2.10/§0.b/§2.4, build-plan §8.
+**Tier:** 2 (src code + a read-time gate + a session-record metadata field; ships DARK behind the EXISTING `subscriptionPool.credentialRepointing` flag — NO new gate flag).
+**Parent principle:** Cross-Machine Coherence — One Agent, Robust Under Degraded Conditions.
+**Second-pass reviewer:** independent reviewer subagent (this change touches a "gate" → Phase 5 required).
+
+## What changed
+
+- **NEW `src/core/CredentialEnvTokenGate.ts`** — the §2.10 env-token gate (the §0.b applicability precondition, enforced). Pure evaluator (no IO): `evaluate()` REFUSES the feature, with a NAMED CATEGORY reason, when (a) `config.anthropicApiKey` is ANY non-empty value (OAuth OR API key — round-3) OR (b) any RUNNING claude-code session's durable `credentialSource` flag is `'env'` (the live-fleet path that closes the mid-life flip). The static helper `shouldAttributeSlotTenant(session)` is `false` for an env session (its usage is never mis-attributed to a slot tenant — §2.10 requirement 3).
+- **`src/core/types.ts`** — adds `Session.credentialSource?: 'store' | 'env'` (additive optional metadata field; no `enabled:` literal → dark-gate UNCHANGED).
+- **`src/core/SessionManager.ts`** — sets `credentialSource` on the session record at all four claude-code spawn record-writes. At the three env-block lanes (headless `~:1846`, rerouted-interactive `~:2127`, interactive `~:3248`) it is derived from the **IDENTICAL** expression that selects the Anthropic env block — `(this.config.anthropicApiKey ?? '') !== '' ? 'env' : 'store'`, computed at the spawn site, NEVER a recomputation. The triage lane hardcodes `'store'` (it always empties `ANTHROPIC_API_KEY=`, so it deterministically reads the store).
+- **`src/commands/server.ts`** — constructs the `CredentialEnvTokenGate` (reading `config.sessions.anthropicApiKey` — the SAME source `sessionManagerConfig` spreads into SessionManager — and `state.listSessions()`); AND-s its refusal into the `CredentialLocationGate.isEnabled` (so a §2.10 refusal suppresses ALL re-pointing attribution: requirement 3 enforced structurally through the one gate the QuotaPoller already consults); adds the gate to the `credentialRepointing` bundle.
+- **`src/server/routes.ts`** — adds `envTokenGate` to the `credentialRepointing` RouteContext type; `GET /credentials/rebalancer` now surfaces the gate verdict (refused + named reason + envSessionCount) when the flag is ON, scrubbed via `audit.response`. DARK → strict 503 no-op (unchanged).
+- **Tests:** NEW `tests/unit/credential-env-token-gate.test.ts` (18); extended `tests/integration/credential-routes.test.ts` (+3 rebalancer cases) and `tests/e2e/credential-repointing-routes-alive.test.ts` (+3 cases, incl. live env-token fleet); widened the look-back window in `tests/unit/codex-model-swap-wiring.test.ts` (the §2.10 derivation sits between `effectiveAccountId` and `buildInteractiveLaunch` — the WS5.3 source-string-ratchet lesson).
+
+## Decision-point inventory
+
+- `CredentialEnvTokenGate.evaluate()` — **add** — the §2.10 refusal decision (config field OR live fleet). It is a SIGNAL feeding the rebalancer status surface + the location-gate enablement; it never blocks a session spawn, a message, or a swap directly.
+- `CredentialLocationGate.isEnabled` AND-in — **modify** — a §2.10 refusal makes the location gate behave as dark (attribution off) so the QuotaPoller stops re-routing reads/attribution through moved slots for an env fleet.
+- `Session.credentialSource` derivation — **add** — additive provenance metadata, not a decision (it is the durable INPUT the gate's fleet scan reads).
+
+## State files / migrations
+
+- **No new state file.** `credentialSource` rides the existing session record (`state/sessions/*.json`); additive optional field, absent on legacy records (treated as `'store'` — the safe, non-refusing direction).
+- **No migration in Step 8.** The CLAUDE.md awareness template + `migrateConfig`/`migrateClaudeMd` + CapabilityIndex are explicitly scoped to **build-plan §9 (Step 9 — Migration parity)** — tracked there, not deferred silently. No new config flag means nothing to migrate for the gate itself.
+
+## Blast radius / reversibility
+
+- **Ships DARK.** The gate is only consulted behind `subscriptionPool.credentialRepointing.enabled` (the location-gate AND-in short-circuits on the flag BEFORE evaluating the gate, and the rebalancer route 503s while dark). With the flag off (always, fleet-wide) the only runtime delta is the additive `credentialSource` field on new session records — free metadata, never read. E2E proves the dark surface is a byte-for-byte 503 no-op.
+- Reversibility: revert the commit. The `credentialSource` field is inert metadata; no credential write, no schema migration, no durable state to repair. A swap is still the reversible oracle-verified permutation from Step 5.
+
+## Per-Phase-C (multi-machine posture)
+
+- **Machine-local BY DESIGN.** The gate is per-machine: each machine evaluates ITS OWN `config.sessions.anthropicApiKey` + ITS OWN `state.listSessions()`. An N-machine pool is N independent gates; a machine running an env-token fleet refuses LOCALLY without reading or affecting a peer's store-reading fleet. No cross-machine credential read, no LAN/broadcast assumption. The `credentialSource` flag is per-session-per-machine durable metadata and never crosses machines (it would be meaningless on another machine, whose config/fleet differ). This is the correct posture: env-vs-store is a function of the LOCAL config field + the LOCAL fleet, so a remote read would be both unnecessary and a coherence hazard.
+
+## Adversarial review (4 lenses, folded as named tests)
+
+1. **Single-source-of-truth provenance (THE blocker)** — the flag is the IDENTICAL `(this.config.anthropicApiKey ?? '')` expression as the env-block selection at each of the three lanes, computed at the spawn site. Proven by a static grep-assert against the real SessionManager source (exactly 3 env-block predicates + 3 identical provenance derivations + 4 record writes) — an independent recomputation would fail it. A divergence test guards the staleness class this whole spec exists to kill.
+2. **Mid-life-flip / live-fleet** — the gate refuses on a running `env` session even when the config field is empty (named unit + integration + e2e tests). A config-only gate would miss it; the fleet scan reads the durable flag.
+3. **Attribution-suppression** — `shouldAttributeSlotTenant` is false for an env session (named test); structurally, the location-gate AND-in suppresses re-pointing attribution wholesale on refusal so the QuotaPoller never mis-attributes an env session's usage to a slot tenant.
+4. **Dark-ship inertness** — flag OFF → rebalancer 503 strict no-op; record-write shape unchanged except the additive field (e2e "feature is alive" — the single most important test).
+
+## Silent-fallback tags
+
+`CredentialEnvTokenGate` is pure logic with NO catch blocks. The route/server edits add no new catch. no-silent-fallbacks (5/5) + no-empty-catch-blocks (4/4) pass with NO baseline bump.
+
+## Second-pass review (Phase 5 — independent reviewer subagent)
+
+**Concur with the review.** All seven load-bearing invariants verified against the actual code:
+1. Single-source-of-truth — the `credentialSource` derivation is the IDENTICAL `(this.config.anthropicApiKey ?? '') !== ''` expression adjacent to each lane's `.startsWith('sk-ant-oat')` env-block predicate over the SAME `this.config.anthropicApiKey` field (SessionManager lanes 1/2/3); triage hardcodes `'store'` and demonstrably empties `ANTHROPIC_API_KEY=`. Not a recomputation.
+2. Config predicate is "any non-empty value" (`key !== ''`), correctly broader than the launch's sk-ant-oat branch (both branches set a store-bypassing env var).
+3. Gate ANDs the live-fleet scan (running + claude-code + `credentialSource === 'env'`, undefined→store safe default) onto the config check, closing the mid-life-flip hole.
+4. The location-gate `isEnabled` AND-in is sound: `&&` short-circuits on the dark flag BEFORE `evaluate()` is ever called (true no-op while dark); on refusal it suppresses re-pointing attribution wholesale (the conservatively-correct direction); `shouldAttributeSlotTenant` false for env.
+5. Gate-level single-source-of-truth holds — `config.sessions?.anthropicApiKey` is the same value `sessionManagerConfig = { ...config.sessions }` feeds SessionManager (anthropicApiKey not overridden).
+6. Dark surface is a strict 503 no-op through the scrub chokepoint; the only record-shape delta is the additive optional field.
+7. Signal-vs-authority: advisory except the attribution-suppression AND-in, which is appropriate and non-brittle (a boolean over a durable flag with a safe default).
+
+No concern raised.
+
+## Gate-ratchet results (run locally before push)
+
+- `tsc --noEmit` clean; full `npm run lint` clean (includes dark-gate 16/16 — **UNCHANGED**, no ConfigDefaults touch).
+- no-silent-fallbacks 5/5, no-empty-catch-blocks 4/4, feature-delivery-completeness 97/97, docs-coverage --check pass (floor-based; internal-plumbing symbol, no floor breach).
+- credential-env-token-gate 18/18; credential-routes (integration) all pass incl. 3 new rebalancer cases; credential-repointing-routes-alive (e2e) 6/6 incl. live env-token fleet; codex-model-swap-wiring 7/7 (window widened); all SessionManager wiring/activation tests green.
+
+## Second-pass review verdict (Phase 5 — required: change touches a "gate")
+
+Independent reviewer subagent audited the gate + the 4 spawn-site provenance derivations + the dark-ship short-circuit against the real code (not the artifact's claims), and against `docs/signal-vs-authority.md`. All six verification points held:
+
+1. **Single-source-of-truth** — all 3 env-block lanes (`SessionManager.ts:1844/2126/3246`) derive `credentialSource` from the identical `(this.config.anthropicApiKey ?? '') !== ''` predicate adjacent to their own env-block write; the triage lane hardcodes `'store'` and provably empties `ANTHROPIC_API_KEY=`. The gate reads `config.sessions?.anthropicApiKey` (`server.ts:9213`), which is the SAME value `sessionManagerConfig = {...config.sessions}` feeds SessionManager (not overridden). Not a recompute.
+2. **Fail-safe direction** — `credentialSource==='env'` is the only fleet-path refusal; `undefined`→`'store'` (non-refusing). A refusal disables the FEATURE (re-pointing attribution), never messaging/sessions/swaps.
+3. **Dark-ship inertness** — `enabled === true && !gate.evaluate().refused` short-circuits on the flag BEFORE `evaluate()`; the route 503s before evaluating. Byte-for-byte prior behavior when dark.
+4. **Config predicate** — refuses on ANY non-empty `anthropicApiKey` (OAuth `sk-ant-oat` OR api key), matching both SessionManager launch branches.
+5. **Signal-vs-authority** — a deterministic policy evaluator over a structured durable flag, not a brittle detector; the only authority it holds is suppressing the feature itself (the conservatively-correct fail-safe), which the principle doc explicitly permits for a domain this constrained.
+6. **Over/under-refuse** — the mixed-fleet whole-feature refusal is conservatively-correct (refuse rather than mis-steer); machine-local posture is correct. No hole found.
+
+**Verdict: CONCUR.** The side-effects artifact's claims all hold against the actual code.


### PR DESCRIPTION
## ELI16 — Each session now records whether its Claude login comes from the on-disk store (steerable) or an env token (not), and the credential-moving feature refuses to run whenever any session is the kind it can't steer.

The live credential re-pointing feature (WS5.2) only works for sessions that read their Claude login from the per-config-home **store** I manage — moving a credential there takes effect on the session's next API call. A session launched with a login token handed straight to it in its **environment** ignores that store entirely, so the moving trick is a silent no-op for it. This step (§2.10) makes that applicability precondition structural:

- **Provenance flag.** Every claude-code session records, at spawn, a durable `credentialSource: 'store' | 'env'` on its session record. It's derived from the **identical** expression that picks the session's Anthropic env block — `(config.anthropicApiKey ?? '') !== '' ? 'env' : 'store'`, computed right there at the spawn site — so the flag can never drift from what actually launched the session.
- **Env-token gate.** A new `CredentialEnvTokenGate` refuses the feature (with a named, scrubbed reason on `GET /credentials/rebalancer`) when either the config field `anthropicApiKey` is **any** non-empty value (OAuth token OR direct API key — both bypass the store) **OR** any running claude-code session's flag is `env`. Checking the **live fleet** — not just the config field — closes the mid-life-flip hole (an operator setting an env token mid-run would otherwise leave old store sessions steerable while new env spawns go silently un-steered).
- **Attribution-suppression.** On a refusal the location gate behaves as dark, so the quota poller stops routing reads/attribution through moved slots — an env session's usage is never mis-attributed to a slot tenant.

Ships **DARK** on the **existing** `subscriptionPool.credentialRepointing` flag — no new config flag, dark-gate line-map unchanged (16/16).

## Phase C — multi-machine posture

**Machine-local BY DESIGN.** The gate is per-machine: each machine evaluates its OWN `config.sessions.anthropicApiKey` + its OWN `state.listSessions()`. An N-machine pool is **N independent gates**; a machine running an env-token fleet refuses **locally** without reading or affecting a peer's store-reading fleet. **No cross-machine credential read**, no LAN/broadcast assumption. The `credentialSource` flag is per-session-per-machine durable metadata and never crosses machines (it would be meaningless on a peer whose config/fleet differ). This is correct: env-vs-store is a pure function of the LOCAL config field + the LOCAL fleet, so a remote read would be both unnecessary and a coherence hazard.

## What changed

- **NEW `src/core/CredentialEnvTokenGate.ts`** — pure evaluator; `evaluate()` (config-field + live-fleet refusal with a named category reason) and the `shouldAttributeSlotTenant` helper.
- **`src/core/types.ts`** — additive optional `Session.credentialSource?: 'store' | 'env'`.
- **`src/core/SessionManager.ts`** — sets the flag at all four claude-code spawn record-writes (3 lanes from the identical env-block expression + triage hardcoded `'store'`).
- **`src/commands/server.ts`** — constructs the gate (reading `config.sessions.anthropicApiKey` — the same source SessionManager reads — + `state.listSessions()`); AND-s its refusal into `CredentialLocationGate.isEnabled` (attribution suppression, short-circuited while dark).
- **`src/server/routes.ts`** — `GET /credentials/rebalancer` surfaces the gate verdict (scrubbed) when enabled; strict 503 no-op while dark.

## Tests (three tiers)

- **Unit** `tests/unit/credential-env-token-gate.test.ts` (18) — config predicate (any non-empty, not just sk-ant-oat), live-fleet path (mid-life flip, counts, non-running/non-claude ignored, undefined→store, short-circuit), attribution-suppression, and the **single-source-of-truth blocker** proven by a static grep-assert against the real SessionManager source (3 env-block predicates + 3 identical derivations + 4 record writes).
- **Integration** `tests/integration/credential-routes.test.ts` (+3) — rebalancer surfaces config-field refusal (no token leak), live-fleet refusal (config empty), and permits when all-store.
- **E2E** `tests/e2e/credential-repointing-routes-alive.test.ts` (+3) — on the real AgentServer factory: rebalancer DARK strict 503 no-op; ENABLED + clean config + all-store permits; ENABLED + a live env-token session refuses with the named reason.

## Gate results

tsc clean; full `npm run lint` clean (**dark-gate 16/16 UNCHANGED** — no ConfigDefaults touched); no-silent-fallbacks 5/5, no-empty-catch-blocks 4/4, feature-delivery-completeness 97/97, docs-coverage `--check` green. Single clean feat commit through the full instar-dev gate (approved+converged spec, side-effects artifact, second-pass reviewer concur). Migration parity (§4) + CapabilityIndex are scoped to **Step 9**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)