### PR TITLE
feat(credential-repointing): WS5.2 Step 10 — livetest battery orchestration (dark/unwired)

### DIFF
--- a/.instar/instar-dev-decisions/2026-06-13T21-46-43-448Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-06-13T21-46-43-448Z-unknown.json
@@ -1,0 +1,15 @@
+{
+  "ts": "2026-06-13T21:46:43.448Z",
+  "slug": "unknown",
+  "suggestedTier": 2,
+  "declaredTier": 2,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "new capability: new exported class / subsystem added"
+  ],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 201,
+  "causalAutopsy": null,
+  "verdict": "pass"
+}

--- a/src/core/CredentialRepointingLivetest.ts
+++ b/src/core/CredentialRepointingLivetest.ts
@@ -1,0 +1,201 @@
+/**
+ * CredentialRepointingLivetest — the §5 livetest battery as testable orchestration
+ * (Step 10 of live credential re-pointing).
+ *
+ * Spec: docs/specs/live-credential-repointing-rebalancer.md §5 (livetest battery),
+ * §0.c (E3/E4 live experiments), §2.8 (dogfood (d) — the §0.c residual).
+ *
+ * ── What this is ──
+ * The livetest battery is the GATE for the dry-run → live promotion decision. It is
+ * NOT part of the merge CI and it NEVER runs autonomously: it exchanges REAL OAuth
+ * credentials between the operator's REAL subscription accounts, so executing it is an
+ * enablement-time action the OPERATOR takes (with the agent), never a dark-build step.
+ *
+ * This module is the ORCHESTRATION + VERDICT logic for battery items (a) and (b) —
+ * the automatable round-trip swaps — expressed over INJECTED dependencies so it is
+ * fully unit-testable WITHOUT touching a keychain (the same fake-deps discipline the
+ * CredentialSwapExecutor itself uses). Items (c) post-swap refresher correctness and
+ * (d) the §0.c at-expiry residual (a deliberately-minted disposable grant) are
+ * inherently manual/destructive and are surfaced as REQUIRED operator steps in the
+ * report rather than auto-run — the harness reports them as pending, it does not fake
+ * a pass.
+ *
+ * ── The load-bearing safety contract ──
+ *   1. ARMED GUARD. `run()` REFUSES unless explicitly armed (the live entrypoint sets
+ *      `armed` only behind an operator flag + the feature's own enable check). An
+ *      unarmed run returns a `refused` report and performs ZERO swaps — so importing
+ *      or unit-testing this module can never move a real credential.
+ *   2. IDENTITY-VERIFIED ROUND TRIP. Every swap is verified by the identity oracle
+ *      (NOT by `claude auth status`, disqualified in E4a as a lying oracle): after a
+ *      swap the two slots' oracle identities must have EXCHANGED; after the swap-back
+ *      they must be RESTORED to the originals. Any deviation fails the step.
+ *   3. ALWAYS SWAP BACK. A round-trip leaves the world as it found it. If the forward
+ *      swap's verification fails the harness still attempts the restoring swap and
+ *      reports the residual state honestly (never silently leaves slots exchanged).
+ *
+ * This module performs NO IO of its own: it calls injected `swap` + `resolveIdentity`
+ * functions. The live entrypoint wires those to the real CredentialSwapExecutor +
+ * CredentialIdentityOracle; a unit test wires fakes.
+ */
+
+/** Identity of the account whose credential currently sits in a slot (oracle answer). */
+export interface SlotIdentity {
+  /** The owning account id/email per the identity oracle, or null when unresolvable. */
+  accountId: string | null;
+}
+
+export interface CredentialRepointingLivetestDeps {
+  /**
+   * Executes a REAL staged swap of the credentials in slotA and slotB (the shipped
+   * CredentialSwapExecutor.swap in live mode). Resolves on success; rejects on a
+   * refusal/error (the harness records the rejection as a step failure).
+   */
+  swap: (slotA: string, slotB: string) => Promise<{ ok: boolean; detail?: string }>;
+  /**
+   * Resolves which account a slot's credential belongs to via the identity oracle
+   * (GET /api/oauth/profile over the slot's blob — E4b). Returns `{ accountId: null }`
+   * when the oracle is unavailable/uncertain (the harness treats null as a verify
+   * failure, never a guess).
+   */
+  resolveIdentity: (slot: string) => Promise<SlotIdentity>;
+}
+
+/** A single battery step's verdict. */
+export interface LivetestStepResult {
+  step: string;
+  passed: boolean;
+  detail: string;
+  /** Ordered observations (identities seen, swaps performed) for the operator report. */
+  observations: string[];
+}
+
+/** The full battery report. */
+export interface LivetestReport {
+  armed: boolean;
+  /** True only when armed AND every automated step passed AND no manual step is outstanding. */
+  promotable: boolean;
+  refusedReason?: string;
+  steps: LivetestStepResult[];
+  /** Items (c)/(d): inherently manual/destructive — listed, never auto-passed. */
+  manualSteps: string[];
+}
+
+export interface CredentialRepointingLivetestOptions {
+  /**
+   * MUST be true to run any swap. The live entrypoint sets this only behind the
+   * operator flag + the feature enable check. Default false ⇒ a strict no-op refusal.
+   */
+  armed?: boolean;
+}
+
+export class CredentialRepointingLivetest {
+  private readonly swap: CredentialRepointingLivetestDeps['swap'];
+  private readonly resolveIdentity: CredentialRepointingLivetestDeps['resolveIdentity'];
+  private readonly armed: boolean;
+
+  constructor(deps: CredentialRepointingLivetestDeps, opts?: CredentialRepointingLivetestOptions) {
+    this.swap = deps.swap;
+    this.resolveIdentity = deps.resolveIdentity;
+    this.armed = opts?.armed === true;
+  }
+
+  /** The §2.8 manual/destructive items — surfaced for the operator, never auto-run. */
+  static readonly MANUAL_STEPS: readonly string[] = [
+    '(c) Post-swap hourly-refresher correctness on BOTH slots — observe one QuotaPoller ' +
+      '401-refresh cycle per slot after a swap and confirm the refreshed token stays on the ' +
+      'right account (requires waiting out an access-token expiry; operator-observed).',
+    '(d) §0.c at-expiry write-back residual — mint a DISPOSABLE second grant, swap it under a ' +
+      'live session, drive it past access-token expiry, and confirm the scheduled identity ' +
+      'audit detects-or-clears any old-lineage write-back. Destructive to a real lineage by ' +
+      'design ⇒ operator-run with a throwaway grant only.',
+    'Liveness (E4): run the round-trip while a real interactive session is pinned to one slot ' +
+      'and confirm zero interruption (the harness cannot observe the operator\'s session; ' +
+      'operator-observed).',
+  ];
+
+  /**
+   * Battery items (a)/(b): an identity-verified swap round-trip between two slots.
+   * Used for both an enrolled-home pair (a) and the default-home slot (b).
+   * ALWAYS attempts to restore the original layout, even when the forward verify fails.
+   */
+  private async roundTrip(slotA: string, slotB: string, label: string): Promise<LivetestStepResult> {
+    const observations: string[] = [];
+
+    const beforeA = await this.resolveIdentity(slotA);
+    const beforeB = await this.resolveIdentity(slotB);
+    observations.push(`before: ${slotA}=${beforeA.accountId ?? 'UNRESOLVED'}, ${slotB}=${beforeB.accountId ?? 'UNRESOLVED'}`);
+    if (beforeA.accountId === null || beforeB.accountId === null) {
+      return { step: label, passed: false, detail: 'oracle could not resolve a slot identity before the swap (fail-closed — never guess)', observations };
+    }
+    if (beforeA.accountId === beforeB.accountId) {
+      return { step: label, passed: false, detail: 'both slots already report the same account — cannot prove an exchange', observations };
+    }
+
+    // Forward swap.
+    const fwd = await this.swap(slotA, slotB).catch((e: unknown) => ({ ok: false, detail: e instanceof Error ? e.message : String(e) }));
+    observations.push(`forward swap: ${fwd.ok ? 'ok' : 'FAILED — ' + (fwd.detail ?? 'unknown')}`);
+    if (!fwd.ok) {
+      return { step: label, passed: false, detail: `forward swap did not complete: ${fwd.detail ?? 'unknown'}`, observations };
+    }
+
+    const afterA = await this.resolveIdentity(slotA);
+    const afterB = await this.resolveIdentity(slotB);
+    observations.push(`after swap: ${slotA}=${afterA.accountId ?? 'UNRESOLVED'}, ${slotB}=${afterB.accountId ?? 'UNRESOLVED'}`);
+    const exchanged = afterA.accountId === beforeB.accountId && afterB.accountId === beforeA.accountId;
+
+    // ALWAYS restore — even if the verify above failed, leave the world as we found it.
+    const back = await this.swap(slotA, slotB).catch((e: unknown) => ({ ok: false, detail: e instanceof Error ? e.message : String(e) }));
+    observations.push(`restoring swap: ${back.ok ? 'ok' : 'FAILED — ' + (back.detail ?? 'unknown')}`);
+
+    const restoredA = await this.resolveIdentity(slotA);
+    const restoredB = await this.resolveIdentity(slotB);
+    observations.push(`after restore: ${slotA}=${restoredA.accountId ?? 'UNRESOLVED'}, ${slotB}=${restoredB.accountId ?? 'UNRESOLVED'}`);
+    const restored = restoredA.accountId === beforeA.accountId && restoredB.accountId === beforeB.accountId;
+
+    if (!exchanged) {
+      return { step: label, passed: false, detail: 'oracle identities did NOT exchange after the forward swap — actuation unproven', observations };
+    }
+    if (!back.ok || !restored) {
+      return { step: label, passed: false, detail: 'forward swap verified, but the layout was NOT cleanly restored — left in a residual state, investigate before promotion', observations };
+    }
+    return { step: label, passed: true, detail: 'identity-verified round trip: slots exchanged then restored cleanly', observations };
+  }
+
+  /**
+   * Runs the automatable battery (items a + b). REFUSES (zero swaps) unless armed.
+   * @param enrolledPair two enrolled-home slots for item (a).
+   * @param defaultSlotPair the default-home slot paired with an enrolled slot for item (b).
+   */
+  async run(
+    enrolledPair: { slotA: string; slotB: string },
+    defaultSlotPair: { defaultSlot: string; enrolledSlot: string },
+  ): Promise<LivetestReport> {
+    const manualSteps = [...CredentialRepointingLivetest.MANUAL_STEPS];
+    if (!this.armed) {
+      return {
+        armed: false,
+        promotable: false,
+        refusedReason:
+          'livetest is the dry-run→live PROMOTION gate — it swaps REAL credentials between REAL ' +
+          'accounts and only runs when explicitly armed by the operator at enablement (never in CI, ' +
+          'never as a dark-build step). No swaps performed.',
+        steps: [],
+        manualSteps,
+      };
+    }
+
+    const steps: LivetestStepResult[] = [];
+    steps.push(await this.roundTrip(enrolledPair.slotA, enrolledPair.slotB, '(a) enrolled-home swap round-trip (E3/E4 vs the shipped executor)'));
+    steps.push(await this.roundTrip(defaultSlotPair.defaultSlot, defaultSlotPair.enrolledSlot, '(b) default-home slot swap + swap-back (CMT-1337 payoff; the claude-created ACL)'));
+
+    const allAutomatedPassed = steps.every((s) => s.passed);
+    return {
+      armed: true,
+      // Promotion still requires the operator to complete the manual items — the harness
+      // never declares promotable while manual steps remain outstanding.
+      promotable: allAutomatedPassed && manualSteps.length === 0,
+      steps,
+      manualSteps,
+    };
+  }
+}

--- a/tests/unit/credential-repointing-livetest.test.ts
+++ b/tests/unit/credential-repointing-livetest.test.ts
@@ -1,0 +1,157 @@
+/**
+ * Step 10 — the §5 livetest battery orchestration (CredentialRepointingLivetest).
+ *
+ * Verifies the harness's safety contract + verdict logic against FAKE deps (no real
+ * keychain, no real oracle): the armed guard (zero swaps unless armed), the
+ * identity-verified round trip (exchange-then-restore via the oracle, NOT auth status),
+ * always-restore-on-failure, fail-closed on an unresolvable oracle, and that the
+ * inherently-manual items (c)/(d) are surfaced — never auto-passed.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { CredentialRepointingLivetest } from '../../src/core/CredentialRepointingLivetest.js';
+
+/**
+ * A fake keychain world: a map of slot → accountId. `swap` exchanges the two slots'
+ * accounts; `resolveIdentity` reads the current owner. Mirrors the real executor's
+ * observable effect (identity follows the credential) without any IO.
+ */
+function fakeWorld(initial: Record<string, string | null>) {
+  const slots: Record<string, string | null> = { ...initial };
+  const calls: Array<[string, string]> = [];
+  return {
+    slots,
+    calls,
+    deps: {
+      swap: async (a: string, b: string) => {
+        calls.push([a, b]);
+        const tmp = slots[a];
+        slots[a] = slots[b];
+        slots[b] = tmp;
+        return { ok: true };
+      },
+      resolveIdentity: async (slot: string) => ({ accountId: slots[slot] ?? null }),
+    },
+  };
+}
+
+const ENROLLED = { slotA: '~/.config/a', slotB: '~/.config/b' };
+const DEFAULT_PAIR = { defaultSlot: '~/.claude', enrolledSlot: '~/.config/a' };
+
+describe('CredentialRepointingLivetest — armed guard', () => {
+  it('REFUSES and performs ZERO swaps when not armed', async () => {
+    const world = fakeWorld({ '~/.config/a': 'acct-A', '~/.config/b': 'acct-B', '~/.claude': 'acct-D' });
+    const lt = new CredentialRepointingLivetest(world.deps); // armed defaults to false
+
+    const report = await lt.run(ENROLLED, DEFAULT_PAIR);
+
+    expect(report.armed).toBe(false);
+    expect(report.promotable).toBe(false);
+    expect(report.refusedReason).toMatch(/PROMOTION gate/);
+    expect(report.steps).toEqual([]);
+    expect(world.calls).toEqual([]); // not a single real swap was attempted
+    // Manual items are still surfaced even on a refusal.
+    expect(report.manualSteps.length).toBe(CredentialRepointingLivetest.MANUAL_STEPS.length);
+  });
+});
+
+describe('CredentialRepointingLivetest — armed round trips', () => {
+  it('passes both automated steps when identities exchange and restore cleanly', async () => {
+    const world = fakeWorld({ '~/.config/a': 'acct-A', '~/.config/b': 'acct-B', '~/.claude': 'acct-D' });
+    const lt = new CredentialRepointingLivetest(world.deps, { armed: true });
+
+    const report = await lt.run(ENROLLED, DEFAULT_PAIR);
+
+    expect(report.armed).toBe(true);
+    expect(report.steps).toHaveLength(2);
+    expect(report.steps.every((s) => s.passed)).toBe(true);
+    // Each round trip is a forward + a restoring swap = 2 swaps per step, 4 total.
+    expect(world.calls).toHaveLength(4);
+    // World is left exactly as found.
+    expect(world.slots).toEqual({ '~/.config/a': 'acct-A', '~/.config/b': 'acct-B', '~/.claude': 'acct-D' });
+  });
+
+  it('is NOT promotable while manual items (c)/(d) remain outstanding', async () => {
+    const world = fakeWorld({ '~/.config/a': 'acct-A', '~/.config/b': 'acct-B', '~/.claude': 'acct-D' });
+    const lt = new CredentialRepointingLivetest(world.deps, { armed: true });
+
+    const report = await lt.run(ENROLLED, DEFAULT_PAIR);
+
+    expect(report.steps.every((s) => s.passed)).toBe(true);
+    expect(report.manualSteps.length).toBeGreaterThan(0);
+    // Automated all-green is necessary but NOT sufficient — the operator must still
+    // complete (c)/(d) before promotion.
+    expect(report.promotable).toBe(false);
+  });
+
+  it('fails the step (fail-closed) when the oracle cannot resolve a slot identity', async () => {
+    const world = fakeWorld({ '~/.config/a': null, '~/.config/b': 'acct-B', '~/.claude': 'acct-D' });
+    const lt = new CredentialRepointingLivetest(world.deps, { armed: true });
+
+    const report = await lt.run(ENROLLED, DEFAULT_PAIR);
+
+    expect(report.steps[0].passed).toBe(false);
+    expect(report.steps[0].detail).toMatch(/oracle could not resolve/);
+    // No swap attempted when the pre-state is unverifiable.
+    expect(world.calls).toHaveLength(0);
+  });
+
+  it('fails when the two slots already report the same account (cannot prove an exchange)', async () => {
+    const world = fakeWorld({ '~/.config/a': 'same', '~/.config/b': 'same', '~/.claude': 'acct-D' });
+    const lt = new CredentialRepointingLivetest(world.deps, { armed: true });
+
+    const report = await lt.run(ENROLLED, DEFAULT_PAIR);
+    expect(report.steps[0].passed).toBe(false);
+    expect(report.steps[0].detail).toMatch(/same account/);
+  });
+
+  it('fails AND still restores when the forward swap does not actuate (identities do not exchange)', async () => {
+    // A swap that records the call but does NOT change identities (a no-op executor).
+    const slots: Record<string, string | null> = { '~/.config/a': 'acct-A', '~/.config/b': 'acct-B', '~/.claude': 'acct-D' };
+    const calls: Array<[string, string]> = [];
+    const lt = new CredentialRepointingLivetest(
+      {
+        swap: async (a, b) => { calls.push([a, b]); return { ok: true }; }, // no state change
+        resolveIdentity: async (slot) => ({ accountId: slots[slot] ?? null }),
+      },
+      { armed: true },
+    );
+
+    const report = await lt.run(ENROLLED, DEFAULT_PAIR);
+    expect(report.steps[0].passed).toBe(false);
+    expect(report.steps[0].detail).toMatch(/did NOT exchange/);
+    // Restore was still attempted (forward + restore) even though verify failed.
+    expect(calls.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('reports a residual state when the restoring swap fails', async () => {
+    let n = 0;
+    const slots: Record<string, string | null> = { '~/.config/a': 'acct-A', '~/.config/b': 'acct-B' };
+    const lt = new CredentialRepointingLivetest(
+      {
+        swap: async (a, b) => {
+          n += 1;
+          if (n === 1) { const t = slots[a]; slots[a] = slots[b]; slots[b] = t; return { ok: true }; } // forward ok
+          return { ok: false, detail: 'restore failed' }; // restoring swap fails
+        },
+        resolveIdentity: async (slot) => ({ accountId: slots[slot] ?? null }),
+      },
+      { armed: true },
+    );
+
+    const report = await lt.run({ slotA: '~/.config/a', slotB: '~/.config/b' }, DEFAULT_PAIR);
+    expect(report.steps[0].passed).toBe(false);
+    expect(report.steps[0].detail).toMatch(/NOT cleanly restored|residual/);
+  });
+});
+
+describe('CredentialRepointingLivetest — manual battery items', () => {
+  it('surfaces the §2.8 manual items (c) refresher, (d) §0.c residual, and E4 liveness', () => {
+    const joined = CredentialRepointingLivetest.MANUAL_STEPS.join('\n');
+    expect(joined).toMatch(/\(c\)/);
+    expect(joined).toMatch(/refresher/i);
+    expect(joined).toMatch(/\(d\)/);
+    expect(joined).toMatch(/disposable/i);
+    expect(joined).toMatch(/E4|liveness/i);
+  });
+});

--- a/upgrades/next/ws52-step10-livetest.md
+++ b/upgrades/next/ws52-step10-livetest.md
@@ -1,0 +1,34 @@
+# WS5.2 Step 10 — livetest battery orchestration (dry-run→live promotion gate)
+
+<!-- bump: patch -->
+
+<!--
+  NOTE: dark/unwired tooling. One new exported class (CredentialRepointingLivetest) +
+  its fake-deps unit test. NOT wired into any runtime path — it is the §5 livetest
+  battery (the dry-run→live PROMOTION gate), which by the spec is NOT part of merge CI
+  and runs ONLY when the operator arms it at enablement. No route, no config flag, no
+  credential write path. The module performs zero IO (pure orchestration over injected
+  swap + resolveIdentity deps); the unit test uses fakes only. The live battery touches
+  REAL credentials and is the operator's enablement-time action, not a dark-build step.
+-->
+
+## What Changed
+
+Delivers the §5 livetest battery as testable orchestration — the structural gate for the dry-run→live promotion decision, so "is this safe to turn on?" is a runnable, verified procedure rather than a memory.
+
+- **`CredentialRepointingLivetest`** (src/core/CredentialRepointingLivetest.ts) — drives the automatable battery items against injected deps (wired to the real CredentialSwapExecutor + identity oracle only at enablement):
+  - **(a)** enrolled-home swap round-trip and **(b)** default-home slot round-trip — each verified by the identity oracle (NOT `claude auth status`, disqualified in E4a): after the swap the two slots' identities must have EXCHANGED; after the swap-back they must be RESTORED. The harness ALWAYS attempts the restoring swap, even when the forward verify fails, and reports any residual state honestly.
+  - **Manual items surfaced, never auto-passed** — (c) post-swap refresher correctness, (d) the §0.c at-expiry residual (a deliberately-minted disposable grant), and the E4 liveness observation are listed as required operator steps; `promotable` stays `false` while any remain outstanding.
+- **Armed guard** — `run()` performs ZERO swaps unless explicitly armed. The arm is set only at enablement, behind an operator flag + the feature's own enable check — never in CI, never as a dark-build step. So importing or testing the module can never move a real credential.
+
+## What to Tell Your User
+
+Nothing changes for you yet — this is off-by-default validation tooling. What it adds: before the credential-moving feature is ever turned on, there's now a runnable, verified "is this actually safe to switch on?" check. It performs a real account-swap and swap-back and confirms — using the trustworthy identity check, not the misleading one — that the move landed on the right account and then cleanly undid itself, always leaving things exactly as they were. Two parts of that check are inherently hands-on (they involve waiting out a token refresh and deliberately stressing a throwaway login), so the tool lists those as steps you and I do together. Crucially, the whole battery refuses to run unless explicitly armed at turn-on time — it can never move a real credential just by existing or being tested. Turning the feature on, and running this gate, stays your decision.
+
+## Summary of New Capabilities
+
+No new runtime capability — this is the dry-run→live promotion gate for live credential re-pointing, shipped unwired (it runs only when the operator arms it at enablement). New internal class `CredentialRepointingLivetest`: drives the automatable swap round-trip battery (identity-verified exchange-then-restore, always restoring), surfaces the manual items (refresher correctness, the at-expiry residual via a disposable grant, liveness) without ever auto-passing them, and refuses every swap unless explicitly armed. Not wired into any runtime path; no route, no config flag, no credential write path.
+
+## Evidence
+
+- `tests/unit/credential-repointing-livetest.test.ts` (8) — armed guard (refuses + zero swaps when unarmed); armed happy path (both round-trips exchange-then-restore, world left exactly as found, 4 swaps); not-promotable while manual items remain; fail-closed when the oracle can't resolve a slot; refusal when both slots already report one account; fail-AND-still-restore when the forward swap doesn't actuate; residual-state report when the restoring swap fails; the manual items (c)/(d)/E4 are surfaced. tsc + full lint clean; feature-delivery-completeness 97/97.

--- a/upgrades/side-effects/ws52-step10-livetest.md
+++ b/upgrades/side-effects/ws52-step10-livetest.md
@@ -1,0 +1,43 @@
+# Side-Effects Review — WS5.2 Step 10: livetest battery orchestration (dry-run→live promotion gate)
+
+**Version / slug:** `ws52-step10-livetest`
+**Date:** 2026-06-13
+**Author:** echo
+**Second-pass reviewer:** not required (no runtime gate/sentinel/session-lifecycle/messaging-block surface; the module is unwired-by-design tooling, run only at enablement)
+
+## Summary of the change
+
+Adds `src/core/CredentialRepointingLivetest.ts` — the §5 livetest battery expressed as testable orchestration — plus its fake-deps unit test. The harness drives the automatable battery items (a) enrolled-home swap round-trip and (b) default-home slot round-trip against INJECTED `swap` + `resolveIdentity` deps (wired to the real CredentialSwapExecutor + identity oracle only at enablement), verifying each swap by oracle identity (exchange-then-restore) and ALWAYS restoring the original layout. The inherently manual/destructive items — (c) post-swap refresher correctness and (d) the §0.c at-expiry residual via a disposable grant — are surfaced as required operator steps, never auto-passed. The module is **not wired into any runtime path**: it is the dry-run→live PROMOTION gate, which by the spec is NOT part of merge CI and runs only when the operator arms it at enablement.
+
+## Decision-point inventory
+
+- `CredentialRepointingLivetest.run()` — add — a guard (`armed`) and a verdict computation. It is NOT a runtime decision point in any live path: nothing in `server.ts` constructs or calls it. It only ever runs from a unit test (fakes) or, at enablement, an operator-armed entrypoint. The only authority it holds is over its own report (`promotable`), which is advisory input to the operator's enable decision — never an automated action.
+
+---
+
+## 1. Over-block
+No block/allow surface — over-block not applicable. (The `armed` guard refuses to RUN the test battery when unarmed; it gates a test harness, not any user/agent action.)
+
+## 2. Under-block
+No block/allow surface — under-block not applicable. Worth noting the deliberate under-claim: `promotable` is `false` while any manual step remains outstanding, so the harness can never green-light promotion on automated checks alone.
+
+## 3. Level-of-abstraction fit
+Correct layer. This is test/validation tooling at the same abstraction as the executor it exercises, expressed over injected deps so the orchestration is unit-testable without IO (the established CredentialSwapExecutor fake-deps pattern). The real keychain/oracle wiring is deferred to the enablement entrypoint, keeping this module pure and verifiable.
+
+## 4. Signal vs authority compliance
+- [x] No — this change has no block/allow surface in any live path.
+
+The `promotable` verdict is a signal to the operator's enable decision, not an authority that performs any action. (Ref: docs/signal-vs-authority.md.)
+
+## 5. Interactions
+- **Shadowing / double-fire / race:** none — the module is unwired; nothing else constructs or calls it. The `armed` default (`false`) guarantees that importing it (e.g. a future index re-export, or a test) performs zero swaps.
+- **Executor interaction (at enablement only):** the harness calls the real `swap` exactly twice per round-trip (forward + restore) and verifies via the oracle between/after; it relies on the executor's own §2.3 safety (staging, verify, quarantine) — it does not re-implement any of it.
+
+## 6. External surfaces
+- No runtime/API/agent-facing surface today (unwired). At enablement the armed entrypoint performs REAL credential swaps on the operator's REAL accounts — which is exactly why it is gated behind an explicit operator arm + the feature's own enable check, runs WITH the operator, and always restores. This module itself ships inert.
+
+## 7. Multi-machine posture (Cross-Machine Coherence)
+- **Machine-local BY DESIGN.** The battery validates THIS machine's keychain + slots before promoting THIS machine's feature to live. Credentials and the identity oracle answers are per-machine; there is no cross-machine surface. Running it on one machine makes no claim about another (each machine is promoted on its own battery).
+
+## 8. Rollback cost
+Trivial. Revert the commit — the module is unwired, so removing it changes no runtime behavior. No state, no migration, no credential touch (the unit test uses fakes only). Any real swap the armed harness ever performs is itself the reversible, oracle-verified, always-restored round-trip from Step 5.


### PR DESCRIPTION
## ELI16 — what this does in plain words

Before the credential-moving feature is ever switched on, you want to *prove* it's safe on this machine. This adds that proof as a runnable, verified procedure: it swaps a real account's login between two slots and swaps it back, and confirms — using the trustworthy identity check (the profile endpoint), not the misleading `claude auth status` — that the move actually landed on the right account and then cleanly undid itself, always leaving things exactly as they were.

Two parts of the full battery are inherently hands-on — waiting out a token refresh, and deliberately stressing a *throwaway* login past expiry — so the harness lists those as steps you and I do together rather than faking a pass. And the whole thing **refuses to run unless explicitly armed** at turn-on time, so it can never move a real credential just by existing or being unit-tested.

**Nothing is wired into any runtime path.** This is the dry-run→live *promotion gate*; it runs only when you arm it at enablement. Turning the feature on stays your decision.

## What changed
- New `src/core/CredentialRepointingLivetest.ts` — drives battery items (a) enrolled-home and (b) default-home swap round-trips against injected `swap` + `resolveIdentity` deps (wired to the real executor + oracle only at enablement). Identity-verified exchange-then-restore; always restores; `promotable` stays false while the manual items (c)/(d)/liveness remain.
- Pure orchestration, zero IO. Armed guard defaults off → importing/testing performs zero swaps. Not wired into any runtime path; no route, no config flag, no credential write path.

## Evidence
`tests/unit/credential-repointing-livetest.test.ts` (8): armed guard (zero swaps unarmed), happy round-trip (world restored, 4 swaps), not-promotable-while-manual, fail-closed oracle, no-actuation-still-restores, residual-on-restore-fail, manual items surfaced. tsc + full lint clean; feature-delivery-completeness 97/97.

Spec: `docs/specs/live-credential-repointing-rebalancer.md` §5 (approved + converged, CMT-1372).

🤖 Generated with [Claude Code](https://claude.com/claude-code)