### PR TITLE
feat(credential-repointing): WS5.2 Increment B / B1 — balancer decision core (dark/unwired)

### DIFF
--- a/.instar/instar-dev-decisions/2026-06-13T22-01-05-988Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-06-13T22-01-05-988Z-unknown.json
@@ -1,0 +1,13 @@
+{
+  "ts": "2026-06-13T22:01:05.988Z",
+  "slug": "unknown",
+  "suggestedTier": 2,
+  "declaredTier": 2,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 329,
+  "causalAutopsy": null,
+  "verdict": "pass"
+}

--- a/.instar/instar-dev-decisions/2026-06-13T22-09-43-927Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-06-13T22-09-43-927Z-unknown.json
@@ -1,0 +1,13 @@
+{
+  "ts": "2026-06-13T22:09:43.927Z",
+  "slug": "unknown",
+  "suggestedTier": 2,
+  "declaredTier": 2,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 76,
+  "causalAutopsy": null,
+  "verdict": "pass"
+}

--- a/.instar/instar-dev-decisions/2026-06-13T22-19-16-866Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-06-13T22-19-16-866Z-unknown.json
@@ -1,0 +1,15 @@
+{
+  "ts": "2026-06-13T22:19:16.866Z",
+  "slug": "unknown",
+  "suggestedTier": 2,
+  "declaredTier": 2,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "new capability: new exported class / subsystem added"
+  ],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 233,
+  "causalAutopsy": null,
+  "verdict": "pass"
+}

--- a/.instar/instar-dev-decisions/2026-06-13T22-25-51-271Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-06-13T22-25-51-271Z-unknown.json
@@ -1,0 +1,13 @@
+{
+  "ts": "2026-06-13T22:25:51.271Z",
+  "slug": "unknown",
+  "suggestedTier": 2,
+  "declaredTier": 2,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 153,
+  "causalAutopsy": null,
+  "verdict": "pass"
+}

--- a/site/src/content/docs/architecture/under-the-hood.md
+++ b/site/src/content/docs/architecture/under-the-hood.md
@@ -661,3 +661,48 @@ Spec: `docs/specs/MENTOR-LIVE-READINESS-SPEC.md` §Fix 2a.
   a single-machine install is a strict no-op. The `EvolutionActionsReplicatedStore` projection strips
   the local ACT id by construction. Spec:
   `docs/specs/multi-machine-replicated-store-foundation.md` §4 / §7.
+
+## Live Credential Re-pointing (Subscription & Auth Standard)
+
+The machinery that can move a pool account's OAuth credential between config-home "slots" without
+restarting the sessions reading them — the "stock-trader" rebalancer. Ships dark/dry-run-first (live on
+a development agent in dry-run, dark on the fleet); a real credential write needs a deliberate
+`dryRun:false`. Spec: `docs/specs/live-credential-repointing-rebalancer.md`.
+
+### CredentialRebalancerPolicy
+
+The pure §2.4 decision core: `decidePass(snapshot)` computes the zero-or-more credential swaps for one
+balancer pass from a read-only snapshot (per-account quota + reset proximity, per-slot tenancy/verify/
+activity, cooldown state, resolved config). Objective-0 dead/quarantined-default eviction + the
+correlated-oracle-outage floor; objective-1 wall avoidance + the bounded wall-override (fresh-data gate,
+`maxForcedSwapsPerPass`, per-window override budget, recency gate); objective-2 use-it-or-lose-it drain
+(weekly-only, headroom floor, per-slot drain-in-progress hold); eligibility + hysteresis (per-pair +
+per-tenant cooldowns on the account basis, urgency-clamped min-improvement floor, 1 swap/pass). No IO,
+no authority — it decides; the actuator routes an accepted decision through the gated executor.
+
+### CredentialRebalancer
+
+The stateful orchestrator that wraps `decidePass()` in a pass loop: on each `tick()` it builds the
+read-only snapshot from injected providers, asks the policy for the swaps, and actuates each through the
+injected `CredentialSwapExecutor` wrapper — but ONLY under the feature's dark/dry-run gate (dark = a
+strict no-op; dry-run actuates the decision but the executor writes nothing). Carries the cross-pass
+hysteresis the pure policy cannot (cooldown timestamps) and the §2.4 P19 breaker (N consecutive LIVE
+failed swaps opens it; a success resets it; it self-heals by re-probing).
+
+### CredentialRebalancerSnapshot
+
+The pure mappers translating the live system state into the policy's snapshot: `mapAccount` (a
+SubscriptionPool account → `AccountState`; a missing quota reading maps to an epoch `measuredAt` so the
+account is treated as stale/source-only; `rate-limited` stays eligible so wall-avoidance can rescue its
+slot), `mapSlot` (a CredentialLocationLedger assignment → `SlotState`), and `resolveRebalancerConfig`
+(clamp the configured knobs + derive the cooldowns from the poll interval). Kept pure so a units/sign
+bug that would mis-steer the balancer is unit-testable.
+
+### CredentialRepointingLivetest
+
+The §5 livetest battery as testable orchestration — the dry-run→live PROMOTION gate (NOT part of merge
+CI; runs only when the operator arms it at enablement, since it exchanges REAL credentials between REAL
+accounts). Drives the automatable round-trips (identity-verified exchange-then-restore via the oracle,
+always restoring) and surfaces the inherently-manual items (refresher correctness, the §0.c at-expiry
+residual via a disposable grant, liveness) without ever auto-passing them. An `armed` guard performs
+zero swaps unless explicitly armed, so importing or unit-testing the module can never move a credential.

--- a/src/core/CredentialRebalancer.ts
+++ b/src/core/CredentialRebalancer.ts
@@ -1,0 +1,233 @@
+/**
+ * CredentialRebalancer — the §2.4 balancer ORCHESTRATOR (Increment B, step B3a).
+ *
+ * Spec: docs/specs/live-credential-repointing-rebalancer.md §2.4.
+ *
+ * ── What this is ──
+ * Wraps the pure `CredentialRebalancerPolicy.decidePass()` decision core in a stateful
+ * pass loop: on each `tick()` it builds the read-only pass snapshot from injected
+ * providers (ledger/verify → slots, quota poller → accounts, config resolver), asks the
+ * policy for the zero-or-more swaps, and ACTUATES each accepted swap through the injected
+ * executor — but ONLY under the feature's dark/dry-run gate. It carries the hysteresis
+ * state the pure policy cannot (cooldown timestamps across passes) and the §2.4 P19
+ * breaker (N consecutive FAILED swaps opens it; it retries on the next quota-fresh pass).
+ *
+ * ── Safety contract (the autonomous-write surface — this is the risky layer) ──
+ *   1. DARK = STRICT NO-OP. When `isEnabled()` is false the tick returns immediately
+ *      having built NOTHING and called the executor ZERO times (the §2.4 "a pass with no
+ *      actuation performs zero keychain/CLI operations" invariant, extended to the whole
+ *      dark state).
+ *   2. DRY-RUN actuates the DECISION but not the WRITE. The executor itself enforces
+ *      dryRun (Step 5), so a dry-run pass audits what it WOULD swap and advances cooldown
+ *      state so the simulated cadence is realistic, but moves no credential.
+ *   3. The executor is the ONLY write path. This class never touches a keychain directly;
+ *      it calls `deps.swap()` (a thin wrapper over the gated, oracle-verified, staged
+ *      CredentialSwapExecutor.swap). A swap rejection/`ok:false` increments the breaker.
+ *   4. EVERY pass is auditable. The decision, the actuation outcome, the breaker state,
+ *      and the surfaced degraded/attention entries are all recorded in `status()`.
+ *
+ * Pure orchestration over injected deps → unit-testable without a keychain. The server
+ * wiring (the setInterval pass) + the live `GET /credentials/rebalancer` status are B3b.
+ */
+
+import {
+  decidePass,
+  type RebalancePassInput,
+  type RebalancerPolicyConfig,
+  type AccountState,
+  type SlotState,
+  type SwapDecision,
+} from './CredentialRebalancerPolicy.js';
+
+export interface RebalancerResolvedConfig {
+  policy: RebalancerPolicyConfig;
+  /** A slot's verify counts as recent within this window. */
+  auditCadenceMs: number;
+  /** The account that should serve `~/.claude` (objective-0), or null. */
+  desiredDefaultAccountId: string | null;
+  /** Ceiling for forced wall-overrides per rolling window. */
+  maxForcedOverridesPerWindow: number;
+  /** N consecutive FAILED swaps that open the P19 breaker. */
+  breakerThreshold: number;
+}
+
+export interface RebalancerActuationResult {
+  ok: boolean;
+  detail?: string;
+}
+
+export interface CredentialRebalancerDeps {
+  /** Live feature gate — read per tick so a restartless flip is honored. */
+  isEnabled: () => boolean;
+  /** Live dry-run gate. When true the executor audits but writes nothing. */
+  isDryRun: () => boolean;
+  /** Build the per-slot snapshot (ledger tenancy + verify/quarantine/activity). */
+  listSlots: () => SlotState[];
+  /** Build the per-account snapshot (quota + reset proximity from the poller). */
+  listAccounts: () => AccountState[];
+  /** Resolve the clamped config for this pass. */
+  resolveConfig: () => RebalancerResolvedConfig;
+  /** The ONLY write path: the gated, oracle-verified CredentialSwapExecutor.swap wrapper. */
+  swap: (slotA: string, slotB: string) => Promise<RebalancerActuationResult>;
+  /** Optional sinks. */
+  emitAudit?: (record: PassAudit) => void;
+  emitDegraded?: (message: string) => void;
+  emitAttention?: (message: string) => void;
+  now?: () => number;
+}
+
+export interface PassAudit {
+  at: number;
+  enabled: boolean;
+  dryRun: boolean;
+  decisions: SwapDecision[];
+  actuated: Array<{ decision: SwapDecision; result: RebalancerActuationResult }>;
+  degraded: string[];
+  attention: string[];
+  noActuationReason?: string;
+  breakerOpen: boolean;
+}
+
+export interface RebalancerStatus {
+  enabled: boolean;
+  breaker: { open: boolean; consecutiveFailures: number; threshold: number };
+  lastPass: PassAudit | null;
+  /** Count of pairs/tenants currently under cooldown (for the status surface). */
+  cooldownPairs: number;
+  cooldownTenants: number;
+}
+
+function sortedPair(a: string, b: string): string {
+  return a < b ? `${a}|${b}` : `${b}|${a}`;
+}
+
+export class CredentialRebalancer {
+  private readonly deps: CredentialRebalancerDeps;
+  private readonly now: () => number;
+
+  // Hysteresis state the pure policy cannot hold (carried across passes).
+  private lastActuationByPair: Record<string, number> = {};
+  private lastActuationByTenant: Record<string, number> = {};
+  private forcedOverridesInWindow = 0;
+  private forcedWindowStart = 0;
+
+  // P19 breaker.
+  private consecutiveFailures = 0;
+  private breakerOpen = false;
+
+  private lastPass: PassAudit | null = null;
+
+  constructor(deps: CredentialRebalancerDeps) {
+    this.deps = deps;
+    this.now = deps.now ?? (() => Date.now());
+  }
+
+  /**
+   * Run one balancer pass. DARK ⇒ strict no-op. Returns the pass audit.
+   * The breaker, when open, still runs the pass (to re-probe) but the spec retries on a
+   * quota-fresh pass — here we simply attempt and let a continued failure keep it open;
+   * a success resets it.
+   */
+  async tick(): Promise<PassAudit> {
+    const at = this.now();
+
+    if (!this.deps.isEnabled()) {
+      // STRICT no-op while dark: build nothing, call the executor zero times.
+      const audit: PassAudit = { at, enabled: false, dryRun: this.deps.isDryRun(), decisions: [], actuated: [], degraded: [], attention: [], noActuationReason: 'feature dark', breakerOpen: this.breakerOpen };
+      this.lastPass = audit;
+      return audit;
+    }
+
+    const cfg = this.deps.resolveConfig();
+
+    // Roll the forced-override window if a window has elapsed (the per-window budget resets).
+    if (at - this.forcedWindowStart >= cfg.policy.perTenantCooldownMs * 2) {
+      this.forcedWindowStart = at;
+      this.forcedOverridesInWindow = 0;
+    }
+
+    const input: RebalancePassInput = {
+      now: at,
+      slots: this.deps.listSlots(),
+      accounts: this.deps.listAccounts(),
+      cooldowns: {
+        lastActuationByPair: this.lastActuationByPair,
+        lastActuationByTenant: this.lastActuationByTenant,
+        forcedOverridesInWindow: this.forcedOverridesInWindow,
+        maxForcedOverridesPerWindow: cfg.maxForcedOverridesPerWindow,
+      },
+      config: cfg.policy,
+      auditCadenceMs: cfg.auditCadenceMs,
+      desiredDefaultAccountId: cfg.desiredDefaultAccountId,
+    };
+
+    const result = decidePass(input);
+    for (const m of result.degraded) this.deps.emitDegraded?.(m);
+    for (const m of result.attention) this.deps.emitAttention?.(m);
+
+    const dryRun = this.deps.isDryRun();
+    const actuated: PassAudit['actuated'] = [];
+
+    for (const decision of result.decisions) {
+      const r = await this.deps.swap(decision.targetSlot, decision.sourceSlot).catch(
+        (e: unknown): RebalancerActuationResult => ({ ok: false, detail: e instanceof Error ? e.message : String(e) }),
+      );
+      actuated.push({ decision, result: r });
+
+      if (r.ok) {
+        // Advance the hysteresis state (in BOTH dry-run and live — dry-run simulates the
+        // real cadence so a dry-run soak shows realistic anti-churn behavior). Recorded by
+        // the TENANT pair the decision exchanged (NOT the fixed slot seats).
+        this.recordActuation(decision, input, at);
+        this.consecutiveFailures = 0;
+        this.breakerOpen = false;
+        if (decision.forced === 'wall-override') this.forcedOverridesInWindow += 1;
+      } else {
+        // Only a LIVE failure counts toward the breaker (a dry-run never writes, so it
+        // cannot "fail" a write — the executor returns ok under dry-run).
+        if (!dryRun) {
+          this.consecutiveFailures += 1;
+          if (this.consecutiveFailures >= cfg.breakerThreshold && !this.breakerOpen) {
+            this.breakerOpen = true;
+            this.deps.emitDegraded?.(`credential rebalancer P19 breaker opened after ${this.consecutiveFailures} consecutive failed swaps`);
+          }
+        }
+      }
+    }
+
+    const audit: PassAudit = {
+      at, enabled: true, dryRun,
+      decisions: result.decisions, actuated,
+      degraded: result.degraded, attention: result.attention,
+      noActuationReason: result.noActuationReason,
+      breakerOpen: this.breakerOpen,
+    };
+    this.lastPass = audit;
+    return audit;
+  }
+
+  /** Record cooldown timestamps for the tenants the decision exchanged. */
+  private recordActuation(decision: SwapDecision, input: RebalancePassInput, at: number): void {
+    const slotById = new Map(input.slots.map((s) => [s.slot, s]));
+    const tA = slotById.get(decision.targetSlot)?.tenantAccountId ?? null;
+    const tB = slotById.get(decision.sourceSlot)?.tenantAccountId ?? null;
+    if (tA) this.lastActuationByTenant[tA] = at;
+    if (tB) this.lastActuationByTenant[tB] = at;
+    if (tA && tB) this.lastActuationByPair[sortedPair(tA, tB)] = at;
+  }
+
+  status(): RebalancerStatus {
+    const cfg = this.safeBreakerThreshold();
+    return {
+      enabled: this.deps.isEnabled(),
+      breaker: { open: this.breakerOpen, consecutiveFailures: this.consecutiveFailures, threshold: cfg },
+      lastPass: this.lastPass,
+      cooldownPairs: Object.keys(this.lastActuationByPair).length,
+      cooldownTenants: Object.keys(this.lastActuationByTenant).length,
+    };
+  }
+
+  private safeBreakerThreshold(): number {
+    try { return this.deps.resolveConfig().breakerThreshold; } catch { return 3; }
+  }
+}

--- a/src/core/CredentialRebalancerPolicy.ts
+++ b/src/core/CredentialRebalancerPolicy.ts
@@ -82,6 +82,10 @@ export interface SlotState {
   drainInProgress: boolean;
   /** Recent activity score (higher = busier); drain targets the busiest slot. */
   busyness: number;
+  /** The most-recently-previously-verified account for this slot (the correlated-outage
+   *  floor's "last known good"); used only to keep the DEFAULT slot non-empty when the
+   *  oracle is down for every slot. Optional — absent on a never-verified slot. */
+  lastKnownGoodAccountId?: string | null;
 }
 
 export interface CooldownState {
@@ -103,6 +107,11 @@ export interface RebalancePassInput {
   config: RebalancerPolicyConfig;
   /** A slot's identity verify counts as "recent" if within this window (the audit cadence). */
   auditCadenceMs: number;
+  /** The account that SHOULD serve `~/.claude` (so manual `claude` is predictable). When the
+   *  default slot's tenant dies/quarantines, a healthy verified tenant is dealt in; when the
+   *  desired default is itself dead, any healthy verified tenant keeps the slot alive. Null =
+   *  no default preference configured (the default-eviction objective is then inert). */
+  desiredDefaultAccountId?: string | null;
 }
 
 export interface SwapDecision {
@@ -110,9 +119,9 @@ export interface SwapDecision {
   targetSlot: string;
   /** The slot whose tenant is exchanged in. */
   sourceSlot: string;
-  objective: 'wall' | 'drain' | 'default';
-  /** Set when this is a cooldown/cap-bypassing wall-override. */
-  forced: 'wall-override' | null;
+  objective: 'wall' | 'drain' | 'default' | 'default-eviction';
+  /** Set when this is a cooldown/cap-bypassing wall-override or a default-slot rescue. */
+  forced: 'wall-override' | 'default-eviction' | null;
   reason: string;
 }
 
@@ -170,6 +179,67 @@ export function decidePass(input: RebalancePassInput): PassResult {
   // A slot is a valid swap-in TARGET only if its quota is fresh (stale headroom may mask a
   // wall — the anti-conservative direction → SOURCE-only) AND its identity verify is recent.
   const isFreshQuota = (acc: AccountState): boolean => now - acc.measuredAt <= config.staleQuotaMs;
+
+  // ── Objective 0: dead/quarantined-default eviction (the slot that must never be empty) ──
+  // Keep `~/.claude` serving a HEALTHY VERIFIED tenant so manual `claude` keeps working
+  // (goal 3 beats slot symmetry + the quarantine-exclusion rule, but ONLY for the default
+  // slot). Runs FIRST: a frozen default freezes the operator's manual invocations.
+  if (input.desiredDefaultAccountId) {
+    const defaultSlot = slots.find((s) => s.isDefault);
+    if (defaultSlot) {
+      const defTenant = defaultSlot.tenantAccountId ? accById.get(defaultSlot.tenantAccountId) : undefined;
+      const defaultDead =
+        defaultSlot.quarantined ||
+        !defTenant ||
+        defTenant.status === 'needs-reauth' ||
+        defTenant.status === 'disabled';
+      if (defaultDead) {
+        // A healthy VERIFIED tenant to deal in (identity-verified THIS pass before the move —
+        // a "healthy per stale ledger" target that is actually dead would re-quarantine the
+        // default; the recency gate is that pre-check in the pure policy).
+        const healthy = slots
+          .filter((s) => s.slot !== defaultSlot.slot && !s.quarantined && s.tenantAccountId !== null)
+          .filter((s) => {
+            const a = accById.get(s.tenantAccountId!);
+            return a?.status === 'ok' && targetVerifiedRecent(s, now, auditCadenceMs);
+          })
+          .sort((a, b) => maxUtil(accById.get(a.tenantAccountId!)!) - maxUtil(accById.get(b.tenantAccountId!)!))[0];
+        if (healthy) {
+          return {
+            decisions: [{
+              targetSlot: defaultSlot.slot,
+              sourceSlot: healthy.slot,
+              objective: 'default-eviction',
+              forced: 'default-eviction',
+              reason: `default slot ${defaultSlot.slot} is ${defaultSlot.quarantined ? 'quarantined' : 'dead (' + (defTenant?.status ?? 'no-tenant') + ')'}; dealing healthy verified ${healthy.tenantAccountId} in to keep manual claude working`,
+            }],
+            degraded: [],
+            attention: [`default slot ${defaultSlot.slot} was ${defaultSlot.quarantined ? 'quarantined' : 'dead'} — rescued with ${healthy.tenantAccountId}; the displaced credential is parked and needs re-auth/re-probe`],
+          };
+        }
+        // Correlated-oracle-outage floor: NO slot is currently oracle-verifiable (an
+        // identity-oracle endpoint storm quarantines every probe at once). Do NOT empty/churn the
+        // default — preserve its last-known-good assignment + surface; honest bound: this is
+        // "preserve last KNOWN-GOOD + flag", NOT "manual claude is certified working".
+        const anyVerifiable = slots.some((s) => targetVerifiedRecent(s, now, auditCadenceMs));
+        if (!anyVerifiable) {
+          return {
+            decisions: [],
+            degraded: ['no slot is oracle-verifiable — default-slot eviction suspended (correlated-outage floor)'],
+            attention: [`oracle unavailable for every slot; ${defaultSlot.slot} preserved at its last-known-good${defaultSlot.lastKnownGoodAccountId ? ' (' + defaultSlot.lastKnownGoodAccountId + ')' : ''} — NOT certified live; no eviction until the oracle returns`],
+            noActuationReason: 'correlated oracle outage — default preserved at last-known-good, no eviction',
+          };
+        }
+        // Verifiable slots exist but none is an eligible healthy tenant: surface, do not act.
+        return {
+          decisions: [],
+          degraded: [],
+          attention: [`default slot ${defaultSlot.slot} is dead/quarantined and no healthy verified tenant is available to rescue it`],
+          noActuationReason: 'default slot dead but no eligible healthy tenant to deal in',
+        };
+      }
+    }
+  }
 
   // ── Objective 1: wall avoidance ───────────────────────────────────────────────
   // Slots whose tenant exceeds the high-water mark, worst-first.

--- a/src/core/CredentialRebalancerPolicy.ts
+++ b/src/core/CredentialRebalancerPolicy.ts
@@ -1,0 +1,329 @@
+/**
+ * CredentialRebalancerPolicy — the §2.4 "stock-trader loop" decision core, as a PURE
+ * function (Increment B, step B1 of live credential re-pointing).
+ *
+ * Spec: docs/specs/live-credential-repointing-rebalancer.md §2.4 (the balancer).
+ *
+ * ── What this is ──
+ * Given a read-only snapshot of a pass (per-account quota + reset proximity, per-slot
+ * tenancy/verify/activity, cooldown state, resolved+clamped config), this computes the
+ * ZERO-OR-MORE swap decisions for ONE pass. It performs NO IO and holds NO authority:
+ * it DECIDES; a separate actuator (step B3) routes an accepted decision through the
+ * Step-5 CredentialSwapExecutor under the dark/dry-run gate. Splitting the decision out
+ * makes the entire policy — every threshold, cap, cooldown, and eligibility rule —
+ * exhaustively unit-testable without a keychain (Tier-0 supervision, §2.4: a
+ * deterministic policy over enumerable numeric thresholds).
+ *
+ * ── Priority of objectives (§2.4) ──
+ *   1. Wall avoidance  — a tenant over the high-water mark gets the highest-headroom
+ *      eligible account. A tenant over the CRITICAL mark triggers a wall-OVERRIDE that
+ *      bypasses the cooldowns + the 1-swap/pass cap, bounded by its own caps
+ *      (fresh-data gate, maxForcedSwapsPerPass, maxForcedOverridesPerWindow).
+ *   2. Use-it-or-lose-it drain — an account whose WEEKLY window resets soon with unused
+ *      headroom is dealt to the busiest slot (weekly only; 5h windows regenerate).
+ *   3. Default-slot preference — keep the designated default account in `~/.claude`.
+ *
+ * Non-forced objectives are bounded to ONE swap per pass (acting twice on one sensor
+ * reading is noise). Only the wall-override may emit up to `maxForcedSwapsPerPass`.
+ *
+ * Dead-default eviction, the correlated-oracle-outage floor, quarantine-exit, the P19
+ * breaker, and the scheduled identity audit are step B2 (this module decides swaps; B2
+ * adds the degraded-state machinery). This module surfaces the terminal "nothing to do"
+ * / "no eligible target" states so B2/B3 can act on them.
+ */
+
+/** Resolved + clamped knobs the pure policy operates on (the resolver lives in B3). */
+export interface RebalancerPolicyConfig {
+  /** Wall-avoidance high-water utilization % (either window). Clamp [50,99]. */
+  highWaterPct: number;
+  /** Critical mark % for the wall-override. Clamp [85,99]. */
+  criticalPct: number;
+  /** Drain horizon — a weekly window resetting within this many hours is drainable. */
+  drainHorizonHours: number;
+  /** Minimum unused weekly headroom % for a drain to be worth it. */
+  drainHeadroomMinPct: number;
+  /** Minimum score delta to justify a NON-forced move (urgency-clamped). */
+  minScoreDelta: number;
+  /** Max forced (wall-override) swaps a single pass may emit. Clamp [1, N-slots]. */
+  maxForcedSwapsPerPass: number;
+  /** Per-pair cooldown ms (≥1× poll interval). */
+  perPairCooldownMs: number;
+  /** Per-tenant cooldown ms (≥2× poll interval) — defeats the 3-way rotation attack. */
+  perTenantCooldownMs: number;
+  /** Quota older than this is SOURCE-only (never a swap-in target). */
+  staleQuotaMs: number;
+  /** Urgency `1/hoursUntilReset` is clamped at this many hours so the delta floor stays meaningful. */
+  urgencyClampHours: number;
+}
+
+export interface AccountState {
+  accountId: string;
+  status: 'ok' | 'needs-reauth' | 'disabled';
+  /** Utilization % on the 5h window (0..100), or null when unknown. */
+  fiveHrPct: number | null;
+  /** Utilization % on the weekly window (0..100), or null when unknown. */
+  weeklyPct: number | null;
+  /** Hours until the weekly window resets, or null when unknown. */
+  weeklyResetsInHours: number | null;
+  /** When this account's quota was last measured (for the staleness gate). */
+  measuredAt: number;
+}
+
+export interface SlotState {
+  slot: string;
+  tenantAccountId: string | null;
+  isDefault: boolean;
+  quarantined: boolean;
+  /** Last oracle identity-verify time, or null if never. */
+  lastVerifiedAt: number | null;
+  /** True if the last scheduled audit flagged this slot's identity as divergent. */
+  lastAuditDivergent: boolean;
+  /** Per-slot "drain in progress" hold — exempt from being a drain DESTINATION (§2.4 obj 2). */
+  drainInProgress: boolean;
+  /** Recent activity score (higher = busier); drain targets the busiest slot. */
+  busyness: number;
+}
+
+export interface CooldownState {
+  /** key = sortedPair(a,b) → last actuation ms. */
+  lastActuationByPair: Record<string, number>;
+  /** accountId → last actuation ms (the tenant cooldown). */
+  lastActuationByTenant: Record<string, number>;
+  /** Forced wall-overrides already spent in the current rolling window. */
+  forcedOverridesInWindow: number;
+  /** The ceiling for forced overrides in a window; at/over it, the override STOPS (surfaced). */
+  maxForcedOverridesPerWindow: number;
+}
+
+export interface RebalancePassInput {
+  now: number;
+  slots: SlotState[];
+  accounts: AccountState[];
+  cooldowns: CooldownState;
+  config: RebalancerPolicyConfig;
+  /** A slot's identity verify counts as "recent" if within this window (the audit cadence). */
+  auditCadenceMs: number;
+}
+
+export interface SwapDecision {
+  /** The slot being acted on (rescued, or the drain destination, or the default slot). */
+  targetSlot: string;
+  /** The slot whose tenant is exchanged in. */
+  sourceSlot: string;
+  objective: 'wall' | 'drain' | 'default';
+  /** Set when this is a cooldown/cap-bypassing wall-override. */
+  forced: 'wall-override' | null;
+  reason: string;
+}
+
+export interface PassResult {
+  /** 0..maxForcedSwapsPerPass decisions (normal objectives emit ≤1; wall-override may emit more). */
+  decisions: SwapDecision[];
+  /** DegradationReporter-bound entries (terminal "stuck" states). */
+  degraded: string[];
+  /** Attention-queue-bound entries (operator-surfaced terminal states). */
+  attention: string[];
+  /** Human reason when zero decisions were made (for the audited no-op pass). */
+  noActuationReason?: string;
+}
+
+function sortedPair(a: string, b: string): string {
+  return a < b ? `${a}|${b}` : `${b}|${a}`;
+}
+
+/** Max utilization across the two windows (the wall is whichever is closer). */
+function maxUtil(acc: AccountState): number {
+  return Math.max(acc.fiveHrPct ?? 0, acc.weeklyPct ?? 0);
+}
+
+/** A slot whose verify is recent AND not divergent is a valid swap-in target (§2.4 recency gate). */
+function targetVerifiedRecent(slot: SlotState, now: number, auditCadenceMs: number): boolean {
+  return (
+    !slot.quarantined &&
+    !slot.lastAuditDivergent &&
+    slot.lastVerifiedAt !== null &&
+    now - slot.lastVerifiedAt <= auditCadenceMs
+  );
+}
+
+/**
+ * Decide the swap(s) for one pass. Pure: same input → same output, no IO.
+ * A pass with no actuation returns `decisions: []` + a `noActuationReason` (the caller
+ * audits the no-op pass and performs ZERO keychain/CLI operations — the §2.4 invariant).
+ */
+export function decidePass(input: RebalancePassInput): PassResult {
+  const { now, slots, accounts, cooldowns, config, auditCadenceMs } = input;
+  const degraded: string[] = [];
+  const attention: string[] = [];
+
+  const accById = new Map(accounts.map((a) => [a.accountId, a]));
+
+  // Eligibility (§2.4): a tenant that is needs-reauth/disabled never participates; a
+  // quarantined/unverified slot never participates; a slot with no tenant can't move.
+  const participatingSlots = slots.filter((s) => {
+    if (s.tenantAccountId === null) return false;
+    const acc = accById.get(s.tenantAccountId);
+    if (!acc) return false;
+    return acc.status === 'ok';
+  });
+
+  // A slot is a valid swap-in TARGET only if its quota is fresh (stale headroom may mask a
+  // wall — the anti-conservative direction → SOURCE-only) AND its identity verify is recent.
+  const isFreshQuota = (acc: AccountState): boolean => now - acc.measuredAt <= config.staleQuotaMs;
+
+  // ── Objective 1: wall avoidance ───────────────────────────────────────────────
+  // Slots whose tenant exceeds the high-water mark, worst-first.
+  const walling = participatingSlots
+    .map((s) => ({ slot: s, acc: accById.get(s.tenantAccountId!)!, util: maxUtil(accById.get(s.tenantAccountId!)!) }))
+    .filter((x) => x.util >= config.highWaterPct)
+    .sort((a, b) => b.util - a.util);
+
+  // Eligible rescue targets: an account with the most headroom whose CURRENT slot is a
+  // verified-recent, fresh-quota, non-walling slot we can exchange with.
+  const rescueTargets = participatingSlots
+    .map((s) => ({ slot: s, acc: accById.get(s.tenantAccountId!)! }))
+    .filter((x) => maxUtil(x.acc) < config.highWaterPct && isFreshQuota(x.acc) && targetVerifiedRecent(x.slot, now, auditCadenceMs))
+    .sort((a, b) => maxUtil(a.acc) - maxUtil(b.acc)); // lowest utilization (most headroom) first
+
+  const decisions: SwapDecision[] = [];
+  const actedSlots = new Set<string>();
+  const actedTenants = new Set<string>();
+
+  // Wall-override: critical-mark slots bypass cooldowns + the 1-swap cap, bounded by
+  // maxForcedSwapsPerPass + the fresh-data gate + maxForcedOverridesPerWindow.
+  const critical = walling.filter((x) => x.util >= config.criticalPct);
+  let overridesLeft = Math.max(0, cooldowns.maxForcedOverridesPerWindow - cooldowns.forcedOverridesInWindow);
+  let forcedThisPass = 0;
+
+  for (const w of critical) {
+    if (forcedThisPass >= config.maxForcedSwapsPerPass) break;
+    if (overridesLeft <= 0) {
+      degraded.push('wall-override budget exhausted — no durable rescue available');
+      attention.push(`wall-override budget exhausted for slot ${w.slot.slot} — a thrashing tenant the rescue can't durably help`);
+      break;
+    }
+    // Fresh-data gate: act on a NEW critical reading only (the tenant's quota must be newer
+    // than its last actuation), so the override never re-fires on the same snapshot.
+    const lastAct = cooldowns.lastActuationByTenant[w.acc.accountId] ?? -Infinity;
+    if (w.acc.measuredAt <= lastAct) continue;
+
+    const target = rescueTargets.find((t) => !actedSlots.has(t.slot.slot) && t.slot.slot !== w.slot.slot && !actedTenants.has(t.acc.accountId));
+    if (!target) {
+      attention.push(`no eligible non-walling rescue target for critical slot ${w.slot.slot}`);
+      continue;
+    }
+    decisions.push({
+      targetSlot: w.slot.slot,
+      sourceSlot: target.slot.slot,
+      objective: 'wall',
+      forced: 'wall-override',
+      reason: `critical wall ${w.util}%≥${config.criticalPct}% on ${w.acc.accountId}; rescued with ${target.acc.accountId} (${maxUtil(target.acc)}%) — cooldowns bypassed`,
+    });
+    actedSlots.add(w.slot.slot); actedSlots.add(target.slot.slot);
+    actedTenants.add(w.acc.accountId); actedTenants.add(target.acc.accountId);
+    forcedThisPass += 1; overridesLeft -= 1;
+  }
+
+  // If a forced override already acted this pass, we are done (the override is the highest
+  // priority; non-forced objectives wait for the next pass to respect 1-swap hygiene).
+  if (decisions.length > 0) {
+    return { decisions, degraded, attention };
+  }
+
+  // Non-forced wall avoidance (85–95%): respects per-pair + per-tenant cooldowns, 1 swap/pass.
+  const cooldownOk = (_slotA: string, _slotB: string, accA: string, accB: string): boolean => {
+    // The per-pair cooldown keys on the TENANT pair (the two accounts being exchanged),
+    // consistent with the per-tenant cooldown — "don't re-exchange these two tenants too
+    // soon" — NOT on the fixed slot seats.
+    const pairLast = cooldowns.lastActuationByPair[sortedPair(accA, accB)] ?? -Infinity;
+    if (now - pairLast < config.perPairCooldownMs) return false;
+    const tA = cooldowns.lastActuationByTenant[accA] ?? -Infinity;
+    const tB = cooldowns.lastActuationByTenant[accB] ?? -Infinity;
+    if (now - tA < config.perTenantCooldownMs || now - tB < config.perTenantCooldownMs) return false;
+    return true;
+  };
+  // Fresh-data gate for non-forced moves: both tenants' quota newer than their last actuation.
+  const freshDataOk = (accA: AccountState, accB: AccountState): boolean => {
+    const lA = cooldowns.lastActuationByTenant[accA.accountId] ?? -Infinity;
+    const lB = cooldowns.lastActuationByTenant[accB.accountId] ?? -Infinity;
+    return accA.measuredAt > lA && accB.measuredAt > lB;
+  };
+
+  // The non-forced path handles ONLY the [highWater, critical) band. A critical (≥95%)
+  // slot is the override path's responsibility; if the override couldn't act (budget /
+  // fresh-data / no target) it was surfaced above and WAITS — it is never silently
+  // downgraded to a cooldown-respecting rescue in the same pass (that would re-churn the
+  // exact thrashing slot the override budget gave up on).
+  for (const w of walling.filter((x) => x.util < config.criticalPct)) {
+    const target = rescueTargets.find((t) => t.slot.slot !== w.slot.slot);
+    if (!target) {
+      attention.push(`no eligible non-walling rescue target for slot ${w.slot.slot}`);
+      break;
+    }
+    if (!cooldownOk(w.slot.slot, target.slot.slot, w.acc.accountId, target.acc.accountId)) continue;
+    if (!freshDataOk(w.acc, target.acc)) continue;
+    decisions.push({
+      targetSlot: w.slot.slot,
+      sourceSlot: target.slot.slot,
+      objective: 'wall',
+      forced: null,
+      reason: `wall ${w.util}%≥${config.highWaterPct}% on ${w.acc.accountId}; rescued with ${target.acc.accountId} (${maxUtil(target.acc)}%)`,
+    });
+    return { decisions, degraded, attention };
+  }
+
+  // ── Objective 2: use-it-or-lose-it drain ──────────────────────────────────────
+  // An account whose WEEKLY window resets within the horizon with ≥ headroom-min unused,
+  // dealt to the busiest eligible slot that is NOT itself a drain-in-progress destination.
+  const drainable = accounts
+    .filter((a) => a.status === 'ok' && a.weeklyResetsInHours !== null && a.weeklyResetsInHours <= config.drainHorizonHours)
+    .filter((a) => a.weeklyPct !== null && 100 - a.weeklyPct >= config.drainHeadroomMinPct)
+    .filter((a) => isFreshQuota(a))
+    .sort((a, b) => (a.weeklyResetsInHours! - b.weeklyResetsInHours!)); // most-reset-proximate first
+
+  if (drainable.length > 0) {
+    const drainAcc = drainable[0];
+    // The drain SOURCE slot currently holding that account (the one whose tenant we deal out).
+    const drainSourceSlot = participatingSlots.find((s) => s.tenantAccountId === drainAcc.accountId);
+    // Busiest eligible destination: not the source, not drain-in-progress-held, verified-recent.
+    const dest = participatingSlots
+      .filter((s) => s.tenantAccountId !== drainAcc.accountId && !s.drainInProgress && targetVerifiedRecent(s, now, auditCadenceMs))
+      .sort((a, b) => b.busyness - a.busyness)[0];
+    if (drainSourceSlot && dest) {
+      const accDest = accById.get(dest.tenantAccountId!)!;
+      // Drain respects cooldowns + fresh-data + the min improvement floor (urgency-clamped).
+      if (cooldownOk(drainSourceSlot.slot, dest.slot, drainAcc.accountId, accDest.accountId) && freshDataOk(drainAcc, accDest)) {
+        const hoursUntil = Math.max(config.urgencyClampHours, drainAcc.weeklyResetsInHours!);
+        const urgency = 1 / hoursUntil;
+        const score = (100 - drainAcc.weeklyPct!) * urgency * 100; // headroom × clamped urgency
+        if (score >= config.minScoreDelta) {
+          decisions.push({
+            targetSlot: dest.slot,
+            sourceSlot: drainSourceSlot.slot,
+            objective: 'drain',
+            forced: null,
+            reason: `drain ${drainAcc.accountId} (weekly resets in ${drainAcc.weeklyResetsInHours}h, ${100 - drainAcc.weeklyPct!}% unused) → busiest slot ${dest.slot}`,
+          });
+          return { decisions, degraded, attention };
+        }
+      }
+    }
+  }
+
+  // ── Objective 3: default-slot preference ──────────────────────────────────────
+  // Keep the designated default account in `~/.claude` when neither (1) nor (2) overrode.
+  // (The pure policy only signals the preference when the default slot does NOT already
+  // hold the default account AND the move clears the floor; B3 supplies which account is
+  // "the default" via the slot.isDefault marker + a desiredDefaultAccountId in config-land.
+  // In B1 we surface the preference as a no-op reason when nothing else acted.)
+  return {
+    decisions: [],
+    degraded,
+    attention,
+    noActuationReason: walling.length > 0
+      ? 'walling slots present but every candidate move was held by a cooldown / fresh-data gate / missing eligible target'
+      : drainable.length > 0
+        ? 'drainable account present but the move did not clear cooldown / fresh-data / min-improvement'
+        : 'no wall, no drainable window, slots balanced — zero actuation',
+  };
+}

--- a/src/core/CredentialRebalancerSnapshot.ts
+++ b/src/core/CredentialRebalancerSnapshot.ts
@@ -1,0 +1,153 @@
+/**
+ * CredentialRebalancerSnapshot — pure mappers from the live system's state into the
+ * balancer's read-only pass snapshot (Increment B, step B3b wiring helper).
+ *
+ * Spec: docs/specs/live-credential-repointing-rebalancer.md §2.4.
+ *
+ * The CredentialRebalancer orchestrator (B3a) consumes injected `listSlots` / `listAccounts`
+ * / `resolveConfig` providers. These pure functions ARE those providers — they translate
+ * the CredentialLocationLedger assignments and the SubscriptionPool accounts into the
+ * policy's `SlotState` / `AccountState`, and clamp the configured balancer knobs into the
+ * resolved config. Kept pure + out of server.ts so the mapping (the place a units/sign
+ * bug would silently mis-steer the balancer) is unit-testable.
+ */
+
+import type { SlotState, AccountState } from './CredentialRebalancerPolicy.js';
+import type { RebalancerResolvedConfig } from './CredentialRebalancer.js';
+import type { SubscriptionAccount, SubscriptionAccountStatus } from './SubscriptionPool.js';
+import type { CredentialAssignment } from './CredentialLocationLedger.js';
+
+const HOUR_MS = 3600_000;
+
+/**
+ * Map the pool account lifecycle status into the policy's eligibility status.
+ * Only needs-reauth/disabled are INELIGIBLE (dead credentials). rate-limited is `ok`:
+ * a walled account must stay eligible so wall-avoidance can RESCUE its slot (its high
+ * utilization % drives the wall objective; excluding it would strand the very slot that
+ * needs help).
+ */
+export function mapAccountStatus(s: SubscriptionAccountStatus): AccountState['status'] {
+  switch (s) {
+    case 'needs-reauth': return 'needs-reauth';
+    case 'disabled': return 'disabled';
+    case 'active':
+    case 'warming':
+    case 'rate-limited':
+    default:
+      return 'ok';
+  }
+}
+
+function pctOrNull(v: number | undefined): number | null {
+  return typeof v === 'number' && Number.isFinite(v) ? v : null;
+}
+
+function hoursUntil(resetsAt: string | undefined, now: number): number | null {
+  if (!resetsAt) return null;
+  const t = Date.parse(resetsAt);
+  if (Number.isNaN(t)) return null;
+  return Math.max(0, (t - now) / HOUR_MS);
+}
+
+/** One pool account → the policy's AccountState. */
+export function mapAccount(account: SubscriptionAccount, now: number): AccountState {
+  const q = account.lastQuota ?? null;
+  const measuredAt = q?.measuredAt ? Date.parse(q.measuredAt) : NaN;
+  return {
+    accountId: account.id,
+    status: mapAccountStatus(account.status),
+    fiveHrPct: pctOrNull(q?.fiveHour?.utilizationPct),
+    weeklyPct: pctOrNull(q?.sevenDay?.utilizationPct),
+    weeklyResetsInHours: hoursUntil(q?.sevenDay?.resetsAt, now),
+    // No quota reading at all ⇒ measuredAt 0 (epoch) ⇒ always STALE ⇒ source-only.
+    measuredAt: Number.isNaN(measuredAt) ? 0 : measuredAt,
+  };
+}
+
+export function mapAccounts(accounts: readonly SubscriptionAccount[], now: number): AccountState[] {
+  return accounts.map((a) => mapAccount(a, now));
+}
+
+export interface SlotMapOptions {
+  /** The config-home slot that is the default (`~/.claude`), so isDefault is set. */
+  defaultSlot?: string | null;
+  /** Optional per-slot busyness (recent activity); absent ⇒ 0 (drain has no busiest preference). */
+  busynessBySlot?: Record<string, number>;
+  /** Optional per-slot "drain in progress" hold (balancer-tracked); absent ⇒ false. */
+  drainInProgressBySlot?: Record<string, boolean>;
+  /** Optional per-slot last-audit-divergent flag (scheduled-audit-tracked); absent ⇒ false. */
+  auditDivergentBySlot?: Record<string, boolean>;
+}
+
+/** One ledger assignment → the policy's SlotState. */
+export function mapSlot(a: CredentialAssignment, opts: SlotMapOptions): SlotState {
+  const lastVerifiedAt = a.lastVerifiedAt ? Date.parse(a.lastVerifiedAt) : NaN;
+  return {
+    slot: a.slot,
+    // The ledger uses '' for a quarantined-but-unassigned slot; normalize to null.
+    tenantAccountId: a.accountId ? a.accountId : null,
+    isDefault: opts.defaultSlot != null && a.slot === opts.defaultSlot,
+    quarantined: a.quarantined,
+    lastVerifiedAt: Number.isNaN(lastVerifiedAt) ? null : lastVerifiedAt,
+    lastAuditDivergent: opts.auditDivergentBySlot?.[a.slot] ?? false,
+    drainInProgress: opts.drainInProgressBySlot?.[a.slot] ?? false,
+    busyness: opts.busynessBySlot?.[a.slot] ?? 0,
+  };
+}
+
+export function mapSlots(assignments: readonly CredentialAssignment[], opts: SlotMapOptions): SlotState[] {
+  return assignments.map((a) => mapSlot(a, opts));
+}
+
+function clamp(v: number | undefined, lo: number, hi: number, dflt: number): number {
+  const n = typeof v === 'number' && Number.isFinite(v) ? v : dflt;
+  return Math.min(hi, Math.max(lo, n));
+}
+
+/** The raw balancer config block (subscriptionPool.credentialRepointing.balancer + siblings). */
+export interface RawRebalancerConfig {
+  passIntervalMs?: number;
+  highWaterPct?: number;
+  criticalPct?: number;
+  maxForcedSwapsPerPass?: number;
+  minScoreDelta?: number;
+  drainHorizonHours?: number;
+  drainHeadroomMinPct?: number;
+  staleQuotaPollPeriods?: number;
+  urgencyClampHours?: number;
+  maxForcedOverridesPerWindow?: number;
+  breakerThreshold?: number;
+  auditCadenceMs?: number;
+  desiredDefaultAccountId?: string | null;
+  /** Number of slots — clamps maxForcedSwapsPerPass upper bound. */
+  slotCount?: number;
+}
+
+/**
+ * Clamp the configured knobs into the resolved config the orchestrator/policy use.
+ * Cooldowns are DERIVED from the poll interval (per-pair ≥1×, per-tenant ≥2× — the
+ * lag-sensored controller floors, §2.4); stale-quota is N poll periods.
+ */
+export function resolveRebalancerConfig(raw: RawRebalancerConfig): RebalancerResolvedConfig {
+  const passIntervalMs = clamp(raw.passIntervalMs, 60_000, 3_600_000, 300_000);
+  const slotCount = Math.max(1, raw.slotCount ?? 1);
+  const stalePeriods = clamp(raw.staleQuotaPollPeriods, 1, 10, 2);
+  return {
+    policy: {
+      highWaterPct: clamp(raw.highWaterPct, 50, 99, 85),
+      criticalPct: clamp(raw.criticalPct, 85, 99, 95),
+      drainHorizonHours: clamp(raw.drainHorizonHours, 1, 96, 24),
+      drainHeadroomMinPct: clamp(raw.drainHeadroomMinPct, 0, 100, 30),
+      minScoreDelta: clamp(raw.minScoreDelta, 0, 1000, 10),
+      maxForcedSwapsPerPass: clamp(raw.maxForcedSwapsPerPass, 1, slotCount, 1),
+      perPairCooldownMs: passIntervalMs, // ≥1× poll interval
+      perTenantCooldownMs: passIntervalMs * 2, // ≥2× poll interval (defeats 3-way rotation)
+      staleQuotaMs: passIntervalMs * stalePeriods,
+      urgencyClampHours: clamp(raw.urgencyClampHours, 1, 24, 4),
+    },
+    auditCadenceMs: clamp(raw.auditCadenceMs, HOUR_MS, 24 * HOUR_MS, 6 * HOUR_MS),
+    desiredDefaultAccountId: raw.desiredDefaultAccountId ?? null,
+    maxForcedOverridesPerWindow: clamp(raw.maxForcedOverridesPerWindow, 1, 100, 5),
+    breakerThreshold: clamp(raw.breakerThreshold, 1, 20, 3),
+  };
+}

--- a/tests/unit/credential-rebalancer-policy.test.ts
+++ b/tests/unit/credential-rebalancer-policy.test.ts
@@ -280,6 +280,91 @@ describe('decidePass — objective 2 drain', () => {
   });
 });
 
+describe('decidePass — objective 0: dead/quarantined-default eviction', () => {
+  it('deals a healthy verified tenant into ~/.claude when the default tenant is needs-reauth', () => {
+    const r = decidePass(pass({
+      desiredDefaultAccountId: 'D',
+      slots: [
+        slot({ slot: '~/.claude', tenantAccountId: 'D', isDefault: true }),
+        slot({ slot: 's2', tenantAccountId: 'B' }),
+      ],
+      accounts: [acc({ accountId: 'D', status: 'needs-reauth' }), acc({ accountId: 'B', fiveHrPct: 10 })],
+    }));
+    expect(r.decisions).toHaveLength(1);
+    expect(r.decisions[0].objective).toBe('default-eviction');
+    expect(r.decisions[0].targetSlot).toBe('~/.claude');
+    expect(r.decisions[0].sourceSlot).toBe('s2');
+    expect(r.attention.some((a) => /parked|needs re-auth/.test(a))).toBe(true);
+  });
+
+  it('rescues a QUARANTINED default slot too (not just needs-reauth)', () => {
+    const r = decidePass(pass({
+      desiredDefaultAccountId: 'D',
+      slots: [
+        slot({ slot: '~/.claude', tenantAccountId: 'D', isDefault: true, quarantined: true }),
+        slot({ slot: 's2', tenantAccountId: 'B' }),
+      ],
+      accounts: [acc({ accountId: 'D' }), acc({ accountId: 'B' })],
+    }));
+    expect(r.decisions).toHaveLength(1);
+    expect(r.decisions[0].objective).toBe('default-eviction');
+  });
+
+  it('correlated-outage floor: NO slot verifiable → preserve last-known-good, do NOT evict', () => {
+    const r = decidePass(pass({
+      desiredDefaultAccountId: 'D',
+      slots: [
+        slot({ slot: '~/.claude', tenantAccountId: 'D', isDefault: true, quarantined: true, lastKnownGoodAccountId: 'D' }),
+        slot({ slot: 's2', tenantAccountId: 'B', lastVerifiedAt: NOW - 100 * HOUR }), // stale → not verifiable
+      ],
+      accounts: [acc({ accountId: 'D' }), acc({ accountId: 'B' })],
+    }));
+    expect(r.decisions).toEqual([]);
+    expect(r.degraded.some((d) => /correlated-outage floor/.test(d))).toBe(true);
+    expect(r.attention.some((a) => /last-known-good|NOT certified live/.test(a))).toBe(true);
+  });
+
+  it('dead default but no healthy tenant available → surface, no action', () => {
+    const r = decidePass(pass({
+      desiredDefaultAccountId: 'D',
+      slots: [
+        slot({ slot: '~/.claude', tenantAccountId: 'D', isDefault: true }),
+        slot({ slot: 's2', tenantAccountId: 'B' }), // verified but B is needs-reauth below
+      ],
+      accounts: [acc({ accountId: 'D', status: 'disabled' }), acc({ accountId: 'B', status: 'needs-reauth' })],
+    }));
+    expect(r.decisions).toEqual([]);
+    expect(r.attention.some((a) => /no healthy verified tenant/.test(a))).toBe(true);
+  });
+
+  it('does nothing special when the default slot is healthy (normal objectives run)', () => {
+    const r = decidePass(pass({
+      desiredDefaultAccountId: 'D',
+      slots: [
+        slot({ slot: '~/.claude', tenantAccountId: 'D', isDefault: true }),
+        slot({ slot: 's2', tenantAccountId: 'B' }),
+      ],
+      accounts: [acc({ accountId: 'D', fiveHrPct: 20 }), acc({ accountId: 'B', fiveHrPct: 10 })],
+    }));
+    expect(r.decisions).toEqual([]); // healthy + balanced → no eviction, no wall, no drain
+    expect(r.noActuationReason).toMatch(/balanced|zero actuation/);
+  });
+
+  it('is inert when no default account is configured', () => {
+    const r = decidePass(pass({
+      // desiredDefaultAccountId omitted
+      slots: [
+        slot({ slot: '~/.claude', tenantAccountId: 'D', isDefault: true, quarantined: true }),
+        slot({ slot: 's2', tenantAccountId: 'B' }),
+      ],
+      accounts: [acc({ accountId: 'D' }), acc({ accountId: 'B' })],
+    }));
+    // No default-eviction objective fires; the quarantined default slot is just excluded from
+    // participating, and nothing else acts.
+    expect(r.decisions.every((d) => d.objective !== 'default-eviction')).toBe(true);
+  });
+});
+
 describe('decidePass — zero actuation', () => {
   it('returns no decisions + a reason when nothing walls and nothing drains', () => {
     const r = decidePass(pass({

--- a/tests/unit/credential-rebalancer-policy.test.ts
+++ b/tests/unit/credential-rebalancer-policy.test.ts
@@ -1,0 +1,310 @@
+/**
+ * Increment B, step B1 — the §2.4 balancer DECISION core (CredentialRebalancerPolicy).
+ *
+ * Exhaustive both-sides-of-the-boundary coverage of the pure pass policy: eligibility,
+ * objective-1 wall avoidance + the wall-override caps (fresh-data gate, per-pass cap,
+ * per-window budget, recency gate, stale-quota source-only), objective-2 drain (weekly-
+ * only, headroom floor, drain-in-progress hold, busiest-slot, min-improvement), the
+ * 1-swap-per-pass invariant, and the audited zero-actuation pass.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  decidePass,
+  type RebalancePassInput,
+  type RebalancerPolicyConfig,
+  type AccountState,
+  type SlotState,
+  type CooldownState,
+} from '../../src/core/CredentialRebalancerPolicy.js';
+
+const HOUR = 3600_000;
+
+const CONFIG: RebalancerPolicyConfig = {
+  highWaterPct: 85,
+  criticalPct: 95,
+  drainHorizonHours: 24,
+  drainHeadroomMinPct: 30,
+  minScoreDelta: 10,
+  maxForcedSwapsPerPass: 1,
+  perPairCooldownMs: 15 * 60_000,
+  perTenantCooldownMs: 30 * 60_000,
+  staleQuotaMs: 30 * 60_000,
+  urgencyClampHours: 4,
+};
+
+const NOW = 1_000_000_000_000;
+
+function acc(p: Partial<AccountState> & { accountId: string }): AccountState {
+  return {
+    status: 'ok',
+    fiveHrPct: 10,
+    weeklyPct: 10,
+    weeklyResetsInHours: 100,
+    measuredAt: NOW, // fresh
+    ...p,
+  };
+}
+
+function slot(p: Partial<SlotState> & { slot: string; tenantAccountId: string }): SlotState {
+  return {
+    isDefault: false,
+    quarantined: false,
+    lastVerifiedAt: NOW, // recently verified
+    lastAuditDivergent: false,
+    drainInProgress: false,
+    busyness: 1,
+    ...p,
+  };
+}
+
+const NO_COOLDOWNS: CooldownState = {
+  lastActuationByPair: {},
+  lastActuationByTenant: {},
+  forcedOverridesInWindow: 0,
+  maxForcedOverridesPerWindow: 5,
+};
+
+function pass(over: Partial<RebalancePassInput>): RebalancePassInput {
+  return {
+    now: NOW,
+    slots: [],
+    accounts: [],
+    cooldowns: NO_COOLDOWNS,
+    config: CONFIG,
+    auditCadenceMs: 6 * HOUR,
+    ...over,
+  };
+}
+
+describe('decidePass — eligibility', () => {
+  it('excludes a needs-reauth tenant from participating (no swap)', () => {
+    const r = decidePass(pass({
+      slots: [slot({ slot: 's1', tenantAccountId: 'A' }), slot({ slot: 's2', tenantAccountId: 'B' })],
+      accounts: [acc({ accountId: 'A', fiveHrPct: 99, status: 'needs-reauth' }), acc({ accountId: 'B', fiveHrPct: 10 })],
+    }));
+    expect(r.decisions).toEqual([]); // A is over the wall but ineligible → nothing to rescue
+  });
+
+  it('does not use a quarantined slot as a rescue target', () => {
+    const r = decidePass(pass({
+      slots: [slot({ slot: 's1', tenantAccountId: 'A' }), slot({ slot: 's2', tenantAccountId: 'B', quarantined: true })],
+      accounts: [acc({ accountId: 'A', fiveHrPct: 90 }), acc({ accountId: 'B', fiveHrPct: 5 })],
+    }));
+    expect(r.decisions).toEqual([]);
+    expect(r.attention.some((a) => /no eligible.*rescue target/.test(a))).toBe(true);
+  });
+});
+
+describe('decidePass — objective 1 wall avoidance', () => {
+  it('rescues a walling tenant with the highest-headroom eligible account', () => {
+    const r = decidePass(pass({
+      slots: [
+        slot({ slot: 's1', tenantAccountId: 'A' }),
+        slot({ slot: 's2', tenantAccountId: 'B' }),
+        slot({ slot: 's3', tenantAccountId: 'C' }),
+      ],
+      accounts: [
+        acc({ accountId: 'A', fiveHrPct: 90 }), // walling
+        acc({ accountId: 'B', fiveHrPct: 40 }),
+        acc({ accountId: 'C', fiveHrPct: 5 }),  // most headroom
+      ],
+    }));
+    expect(r.decisions).toHaveLength(1);
+    expect(r.decisions[0].objective).toBe('wall');
+    expect(r.decisions[0].forced).toBeNull();
+    expect(r.decisions[0].targetSlot).toBe('s1');
+    expect(r.decisions[0].sourceSlot).toBe('s3'); // C, lowest utilization
+  });
+
+  it('does NOT rescue when the only target is also walling', () => {
+    const r = decidePass(pass({
+      slots: [slot({ slot: 's1', tenantAccountId: 'A' }), slot({ slot: 's2', tenantAccountId: 'B' })],
+      accounts: [acc({ accountId: 'A', fiveHrPct: 90 }), acc({ accountId: 'B', fiveHrPct: 88 })],
+    }));
+    expect(r.decisions).toEqual([]);
+  });
+
+  it('holds a non-forced wall move behind the per-pair cooldown', () => {
+    const r = decidePass(pass({
+      slots: [slot({ slot: 's1', tenantAccountId: 'A' }), slot({ slot: 's2', tenantAccountId: 'B' })],
+      accounts: [acc({ accountId: 'A', fiveHrPct: 90 }), acc({ accountId: 'B', fiveHrPct: 5 })],
+      cooldowns: { ...NO_COOLDOWNS, lastActuationByPair: { 'A|B': NOW - 60_000 } }, // 1 min ago < 15 min
+    }));
+    expect(r.decisions).toEqual([]);
+    expect(r.noActuationReason).toMatch(/cooldown|held/);
+  });
+
+  it('triggers on the weekly window too (not just 5h)', () => {
+    const r = decidePass(pass({
+      slots: [slot({ slot: 's1', tenantAccountId: 'A' }), slot({ slot: 's2', tenantAccountId: 'B' })],
+      accounts: [acc({ accountId: 'A', fiveHrPct: 10, weeklyPct: 92 }), acc({ accountId: 'B', fiveHrPct: 5, weeklyPct: 5 })],
+    }));
+    expect(r.decisions).toHaveLength(1);
+    expect(r.decisions[0].targetSlot).toBe('s1');
+  });
+});
+
+describe('decidePass — wall-override (critical mark)', () => {
+  const wallingCritical = {
+    slots: [slot({ slot: 's1', tenantAccountId: 'A' }), slot({ slot: 's2', tenantAccountId: 'B' })],
+    accounts: [acc({ accountId: 'A', fiveHrPct: 97 }), acc({ accountId: 'B', fiveHrPct: 5 })],
+  };
+
+  it('bypasses a cooldown that would block a non-forced move', () => {
+    const r = decidePass(pass({
+      ...wallingCritical,
+      cooldowns: { ...NO_COOLDOWNS, lastActuationByPair: { 'A|B': NOW - 60_000 }, lastActuationByTenant: { A: NOW - 60_000, B: NOW - 60_000 } },
+    }));
+    expect(r.decisions).toHaveLength(1);
+    expect(r.decisions[0].forced).toBe('wall-override');
+  });
+
+  it('respects the fresh-data gate — does NOT re-fire on the same sensor snapshot', () => {
+    // The tenant's quota measuredAt is NOT newer than its last actuation → no override.
+    const r = decidePass(pass({
+      ...wallingCritical,
+      cooldowns: { ...NO_COOLDOWNS, lastActuationByTenant: { A: NOW } }, // == measuredAt, not newer
+    }));
+    expect(r.decisions).toEqual([]);
+  });
+
+  it('stops + surfaces when the per-window override budget is exhausted', () => {
+    const r = decidePass(pass({
+      ...wallingCritical,
+      cooldowns: { ...NO_COOLDOWNS, forcedOverridesInWindow: 5, maxForcedOverridesPerWindow: 5 },
+    }));
+    expect(r.decisions).toEqual([]);
+    expect(r.degraded.some((d) => /budget exhausted/.test(d))).toBe(true);
+    expect(r.attention.some((a) => /budget exhausted/.test(a))).toBe(true);
+  });
+
+  it('emits at most maxForcedSwapsPerPass forced swaps when multiple slots are critical', () => {
+    const r = decidePass(pass({
+      slots: [
+        slot({ slot: 's1', tenantAccountId: 'A' }),
+        slot({ slot: 's2', tenantAccountId: 'B' }),
+        slot({ slot: 's3', tenantAccountId: 'C' }),
+        slot({ slot: 's4', tenantAccountId: 'D' }),
+      ],
+      accounts: [
+        acc({ accountId: 'A', fiveHrPct: 98 }), // critical
+        acc({ accountId: 'B', fiveHrPct: 97 }), // critical
+        acc({ accountId: 'C', fiveHrPct: 5 }),
+        acc({ accountId: 'D', fiveHrPct: 6 }),
+      ],
+      config: { ...CONFIG, maxForcedSwapsPerPass: 1 },
+    }));
+    expect(r.decisions).toHaveLength(1); // worst (A) rescued this pass; B waits for next
+    expect(r.decisions[0].targetSlot).toBe('s1');
+  });
+
+  it('is NOT eligible to rescue with a target whose identity verify is stale (recency gate)', () => {
+    const r = decidePass(pass({
+      ...wallingCritical,
+      slots: [
+        slot({ slot: 's1', tenantAccountId: 'A' }),
+        slot({ slot: 's2', tenantAccountId: 'B', lastVerifiedAt: NOW - 100 * HOUR }), // stale verify
+      ],
+    }));
+    expect(r.decisions).toEqual([]);
+    expect(r.attention.some((a) => /no eligible non-walling rescue target/.test(a))).toBe(true);
+  });
+});
+
+describe('decidePass — stale quota is SOURCE-only', () => {
+  it('does not deal a stale-quota account into a walling slot (could mask a wall)', () => {
+    const r = decidePass(pass({
+      slots: [slot({ slot: 's1', tenantAccountId: 'A' }), slot({ slot: 's2', tenantAccountId: 'B' })],
+      accounts: [
+        acc({ accountId: 'A', fiveHrPct: 90 }),
+        acc({ accountId: 'B', fiveHrPct: 5, measuredAt: NOW - 2 * HOUR }), // stale
+      ],
+    }));
+    expect(r.decisions).toEqual([]); // B is fresh-headroom-looking but stale → not a target
+  });
+});
+
+describe('decidePass — objective 2 drain', () => {
+  it('drains a soon-resetting weekly window with headroom to the busiest slot', () => {
+    const r = decidePass(pass({
+      slots: [
+        slot({ slot: 's1', tenantAccountId: 'A', busyness: 1 }),
+        slot({ slot: 's2', tenantAccountId: 'B', busyness: 9 }), // busiest
+      ],
+      accounts: [
+        acc({ accountId: 'A', weeklyPct: 20, weeklyResetsInHours: 10 }), // drainable: 80% unused, resets in 10h
+        acc({ accountId: 'B', weeklyPct: 50, weeklyResetsInHours: 100 }),
+      ],
+    }));
+    expect(r.decisions).toHaveLength(1);
+    expect(r.decisions[0].objective).toBe('drain');
+    expect(r.decisions[0].targetSlot).toBe('s2'); // busiest destination
+    expect(r.decisions[0].sourceSlot).toBe('s1'); // holds the drainable account
+  });
+
+  it('does NOT drain a 5h window (weekly only)', () => {
+    const r = decidePass(pass({
+      slots: [slot({ slot: 's1', tenantAccountId: 'A' }), slot({ slot: 's2', tenantAccountId: 'B', busyness: 9 })],
+      accounts: [
+        acc({ accountId: 'A', fiveHrPct: 20, weeklyResetsInHours: null }), // no weekly window info
+        acc({ accountId: 'B', weeklyResetsInHours: 100 }),
+      ],
+    }));
+    expect(r.decisions).toEqual([]);
+  });
+
+  it('does NOT drain when headroom is below the floor', () => {
+    const r = decidePass(pass({
+      slots: [slot({ slot: 's1', tenantAccountId: 'A' }), slot({ slot: 's2', tenantAccountId: 'B', busyness: 9 })],
+      accounts: [
+        acc({ accountId: 'A', weeklyPct: 80, weeklyResetsInHours: 10 }), // only 20% unused < 30%
+        acc({ accountId: 'B', weeklyResetsInHours: 100 }),
+      ],
+    }));
+    expect(r.decisions).toEqual([]);
+  });
+
+  it('excludes a drain-in-progress slot as a drain destination', () => {
+    const r = decidePass(pass({
+      slots: [
+        slot({ slot: 's1', tenantAccountId: 'A' }),
+        slot({ slot: 's2', tenantAccountId: 'B', busyness: 9, drainInProgress: true }), // held
+      ],
+      accounts: [
+        acc({ accountId: 'A', weeklyPct: 20, weeklyResetsInHours: 10 }),
+        acc({ accountId: 'B', weeklyResetsInHours: 100 }),
+      ],
+    }));
+    expect(r.decisions).toEqual([]); // only candidate destination is held
+  });
+});
+
+describe('decidePass — zero actuation', () => {
+  it('returns no decisions + a reason when nothing walls and nothing drains', () => {
+    const r = decidePass(pass({
+      slots: [slot({ slot: 's1', tenantAccountId: 'A' }), slot({ slot: 's2', tenantAccountId: 'B' })],
+      accounts: [acc({ accountId: 'A', fiveHrPct: 20 }), acc({ accountId: 'B', fiveHrPct: 10 })],
+    }));
+    expect(r.decisions).toEqual([]);
+    expect(r.noActuationReason).toMatch(/balanced|zero actuation/);
+  });
+
+  it('never emits more than one non-forced swap per pass', () => {
+    const r = decidePass(pass({
+      slots: [
+        slot({ slot: 's1', tenantAccountId: 'A' }),
+        slot({ slot: 's2', tenantAccountId: 'B' }),
+        slot({ slot: 's3', tenantAccountId: 'C' }),
+        slot({ slot: 's4', tenantAccountId: 'D' }),
+      ],
+      accounts: [
+        acc({ accountId: 'A', fiveHrPct: 90 }), // walling
+        acc({ accountId: 'B', fiveHrPct: 88 }), // walling
+        acc({ accountId: 'C', fiveHrPct: 5 }),
+        acc({ accountId: 'D', fiveHrPct: 6 }),
+      ],
+    }));
+    expect(r.decisions).toHaveLength(1); // only the worst is acted on
+  });
+});

--- a/tests/unit/credential-rebalancer-snapshot.test.ts
+++ b/tests/unit/credential-rebalancer-snapshot.test.ts
@@ -1,0 +1,120 @@
+/**
+ * Increment B, step B3b helper — the pure snapshot mappers (CredentialRebalancerSnapshot).
+ *
+ * Covers the units/sign translation from live state into the policy's snapshot: status
+ * eligibility mapping (rate-limited stays eligible; needs-reauth/disabled don't), quota
+ * mapping incl. missing-reading → stale, slot mapping (default flag, quarantined-empty →
+ * null tenant), and config clamping + cooldown derivation.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  mapAccountStatus, mapAccount, mapSlot, resolveRebalancerConfig,
+} from '../../src/core/CredentialRebalancerSnapshot.js';
+import type { SubscriptionAccount } from '../../src/core/SubscriptionPool.js';
+import type { CredentialAssignment } from '../../src/core/CredentialLocationLedger.js';
+
+const NOW = Date.parse('2026-06-13T12:00:00Z');
+
+function poolAccount(p: Partial<SubscriptionAccount> & { id: string }): SubscriptionAccount {
+  return {
+    id: p.id, nickname: p.id, provider: 'anthropic' as SubscriptionAccount['provider'],
+    framework: 'claude-code' as SubscriptionAccount['framework'], configHome: `~/.cfg/${p.id}`,
+    status: 'active', enrolledAt: '2026-01-01T00:00:00Z', version: 1, ...p,
+  };
+}
+
+describe('mapAccountStatus', () => {
+  it('keeps rate-limited eligible (ok) so its walling slot can be rescued', () => {
+    expect(mapAccountStatus('rate-limited')).toBe('ok');
+    expect(mapAccountStatus('active')).toBe('ok');
+    expect(mapAccountStatus('warming')).toBe('ok');
+  });
+  it('marks needs-reauth and disabled ineligible', () => {
+    expect(mapAccountStatus('needs-reauth')).toBe('needs-reauth');
+    expect(mapAccountStatus('disabled')).toBe('disabled');
+  });
+});
+
+describe('mapAccount', () => {
+  it('maps quota percentages + weekly reset hours from the snapshot', () => {
+    const a = mapAccount(poolAccount({
+      id: 'A',
+      lastQuota: {
+        fiveHour: { utilizationPct: 40, resetsAt: '2026-06-13T15:00:00Z' },
+        sevenDay: { utilizationPct: 70, resetsAt: '2026-06-14T12:00:00Z' }, // 24h out
+        measuredAt: '2026-06-13T11:59:00Z',
+      },
+    }), NOW);
+    expect(a.fiveHrPct).toBe(40);
+    expect(a.weeklyPct).toBe(70);
+    expect(a.weeklyResetsInHours).toBeCloseTo(24, 1);
+    expect(a.measuredAt).toBe(Date.parse('2026-06-13T11:59:00Z'));
+    expect(a.status).toBe('ok');
+  });
+
+  it('treats a missing quota reading as stale (measuredAt 0) + null percentages', () => {
+    const a = mapAccount(poolAccount({ id: 'B', lastQuota: null }), NOW);
+    expect(a.fiveHrPct).toBeNull();
+    expect(a.weeklyPct).toBeNull();
+    expect(a.weeklyResetsInHours).toBeNull();
+    expect(a.measuredAt).toBe(0); // epoch → always stale → source-only
+  });
+});
+
+describe('mapSlot', () => {
+  function assignment(p: Partial<CredentialAssignment> & { slot: string }): CredentialAssignment {
+    return { slot: p.slot, accountId: 'A', since: '2026-06-13T10:00:00Z', lastVerifiedAt: '2026-06-13T11:00:00Z', quarantined: false, ...p };
+  }
+
+  it('flags the default slot and parses lastVerifiedAt', () => {
+    const s = mapSlot(assignment({ slot: '~/.claude' }), { defaultSlot: '~/.claude' });
+    expect(s.isDefault).toBe(true);
+    expect(s.tenantAccountId).toBe('A');
+    expect(s.lastVerifiedAt).toBe(Date.parse('2026-06-13T11:00:00Z'));
+  });
+
+  it('normalizes a quarantined-empty slot (accountId "") to a null tenant', () => {
+    const s = mapSlot(assignment({ slot: 's2', accountId: '', quarantined: true, lastVerifiedAt: null }), {});
+    expect(s.tenantAccountId).toBeNull();
+    expect(s.quarantined).toBe(true);
+    expect(s.lastVerifiedAt).toBeNull();
+    expect(s.isDefault).toBe(false);
+  });
+
+  it('reads busyness / drain-hold / audit-divergent overrides when supplied', () => {
+    const s = mapSlot(assignment({ slot: 's3' }), {
+      busynessBySlot: { s3: 9 }, drainInProgressBySlot: { s3: true }, auditDivergentBySlot: { s3: true },
+    });
+    expect(s.busyness).toBe(9);
+    expect(s.drainInProgress).toBe(true);
+    expect(s.lastAuditDivergent).toBe(true);
+  });
+});
+
+describe('resolveRebalancerConfig', () => {
+  it('applies defaults and derives cooldowns from the poll interval', () => {
+    const c = resolveRebalancerConfig({});
+    expect(c.policy.highWaterPct).toBe(85);
+    expect(c.policy.criticalPct).toBe(95);
+    expect(c.policy.perPairCooldownMs).toBe(300_000);       // 1× default poll interval (5m)
+    expect(c.policy.perTenantCooldownMs).toBe(600_000);     // 2× poll interval
+    expect(c.policy.staleQuotaMs).toBe(600_000);            // 2 poll periods
+    expect(c.breakerThreshold).toBe(3);
+    expect(c.maxForcedOverridesPerWindow).toBe(5);
+    expect(c.desiredDefaultAccountId).toBeNull();
+  });
+
+  it('clamps out-of-range knobs', () => {
+    const c = resolveRebalancerConfig({ highWaterPct: 5, criticalPct: 200, passIntervalMs: 1, maxForcedSwapsPerPass: 99, slotCount: 3 });
+    expect(c.policy.highWaterPct).toBe(50);           // clamped up to floor
+    expect(c.policy.criticalPct).toBe(99);            // clamped to ceiling
+    expect(c.policy.perPairCooldownMs).toBe(60_000);  // passInterval clamped to 60s floor
+    expect(c.policy.maxForcedSwapsPerPass).toBe(3);   // clamped to slotCount
+  });
+
+  it('passes through the desired default account id', () => {
+    const c = resolveRebalancerConfig({ desiredDefaultAccountId: 'acct-D' });
+    expect(c.desiredDefaultAccountId).toBe('acct-D');
+  });
+});

--- a/tests/unit/credential-rebalancer.test.ts
+++ b/tests/unit/credential-rebalancer.test.ts
@@ -1,0 +1,135 @@
+/**
+ * Increment B, step B3a — the §2.4 balancer ORCHESTRATOR (CredentialRebalancer).
+ *
+ * Covers the stateful safety contract over fake deps (no keychain): dark = strict no-op
+ * (zero executor calls), dry-run actuates the decision but the executor writes nothing,
+ * cooldown state advances across passes (anti-churn), and the P19 breaker opens on N
+ * consecutive LIVE failures + resets on success.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { CredentialRebalancer, type CredentialRebalancerDeps, type RebalancerResolvedConfig } from '../../src/core/CredentialRebalancer.js';
+import type { SlotState, AccountState } from '../../src/core/CredentialRebalancerPolicy.js';
+
+const RESOLVED: RebalancerResolvedConfig = {
+  policy: {
+    highWaterPct: 85, criticalPct: 95, drainHorizonHours: 24, drainHeadroomMinPct: 30,
+    minScoreDelta: 10, maxForcedSwapsPerPass: 1, perPairCooldownMs: 15 * 60_000,
+    perTenantCooldownMs: 30 * 60_000, staleQuotaMs: 30 * 60_000, urgencyClampHours: 4,
+  },
+  auditCadenceMs: 6 * 3600_000,
+  desiredDefaultAccountId: null,
+  maxForcedOverridesPerWindow: 5,
+  breakerThreshold: 3,
+};
+
+function slot(p: Partial<SlotState> & { slot: string; tenantAccountId: string }): SlotState {
+  return { isDefault: false, quarantined: false, lastVerifiedAt: 1000, lastAuditDivergent: false, drainInProgress: false, busyness: 1, ...p };
+}
+function acc(p: Partial<AccountState> & { accountId: string }): AccountState {
+  return { status: 'ok', fiveHrPct: 10, weeklyPct: 10, weeklyResetsInHours: 100, measuredAt: 1, ...p };
+}
+
+function makeDeps(over: Partial<CredentialRebalancerDeps> & { clock?: { t: number } }): CredentialRebalancerDeps {
+  const clock = over.clock ?? { t: 10_000_000 };
+  // A walling scenario (A at 90% rescued with B at 5%); quota measuredAt tracks the clock
+  // so it is always FRESH (a stale reading would make the target source-only, by design).
+  return {
+    isEnabled: () => true,
+    isDryRun: () => false,
+    listSlots: () => [slot({ slot: 's1', tenantAccountId: 'A', lastVerifiedAt: clock.t }), slot({ slot: 's2', tenantAccountId: 'B', lastVerifiedAt: clock.t })],
+    listAccounts: () => [acc({ accountId: 'A', fiveHrPct: 90, measuredAt: clock.t }), acc({ accountId: 'B', fiveHrPct: 5, measuredAt: clock.t })],
+    resolveConfig: () => RESOLVED,
+    swap: async () => ({ ok: true }),
+    now: () => clock.t,
+    ...over,
+  };
+}
+
+describe('CredentialRebalancer — dark gate', () => {
+  it('is a STRICT no-op when disabled (zero executor calls)', async () => {
+    let swaps = 0;
+    const r = new CredentialRebalancer(makeDeps({ isEnabled: () => false, swap: async () => { swaps += 1; return { ok: true }; } }));
+    const audit = await r.tick();
+    expect(audit.enabled).toBe(false);
+    expect(audit.decisions).toEqual([]);
+    expect(swaps).toBe(0);
+    expect(audit.noActuationReason).toBe('feature dark');
+  });
+});
+
+describe('CredentialRebalancer — actuation', () => {
+  it('actuates one swap for a walling scenario when enabled', async () => {
+    const calls: Array<[string, string]> = [];
+    const r = new CredentialRebalancer(makeDeps({ swap: async (a, b) => { calls.push([a, b]); return { ok: true }; } }));
+    const audit = await r.tick();
+    expect(audit.decisions).toHaveLength(1);
+    expect(audit.actuated).toHaveLength(1);
+    expect(audit.actuated[0].result.ok).toBe(true);
+    expect(calls).toEqual([['s1', 's2']]); // targetSlot, sourceSlot
+  });
+
+  it('dry-run still drives the executor (which no-ops the write) and advances cooldowns', async () => {
+    let calls = 0;
+    const r = new CredentialRebalancer(makeDeps({ isDryRun: () => true, swap: async () => { calls += 1; return { ok: true }; } }));
+    const audit = await r.tick();
+    expect(audit.dryRun).toBe(true);
+    expect(calls).toBe(1); // the executor IS called (it enforces dryRun internally)
+    const st = r.status();
+    expect(st.cooldownTenants).toBeGreaterThan(0); // cooldown advanced even in dry-run
+  });
+});
+
+describe('CredentialRebalancer — cooldown across passes', () => {
+  it('does not re-swap the same tenant pair on the very next pass (per-pair cooldown)', async () => {
+    const clock = { t: 10_000_000 };
+    let calls = 0;
+    const r = new CredentialRebalancer(makeDeps({ clock, swap: async () => { calls += 1; return { ok: true }; } }));
+    await r.tick();            // pass 1 acts
+    expect(calls).toBe(1);
+    clock.t += 60_000;         // 1 min later (< 15 min per-pair cooldown)
+    await r.tick();            // pass 2 should be held by the cooldown
+    expect(calls).toBe(1);     // no second swap
+  });
+});
+
+describe('CredentialRebalancer — P19 breaker', () => {
+  it('opens after N consecutive LIVE failures and resets on a success', async () => {
+    const clock = { t: 10_000_000 };
+    let mode: 'fail' | 'ok' = 'fail';
+    // Fresh quota each pass so the fresh-data gate never blocks (advance measuredAt with the clock).
+    const r = new CredentialRebalancer(makeDeps({
+      clock,
+      listAccounts: () => [acc({ accountId: 'A', fiveHrPct: 90, measuredAt: clock.t }), acc({ accountId: 'B', fiveHrPct: 5, measuredAt: clock.t })],
+      swap: async () => (mode === 'fail' ? { ok: false, detail: 'keychain dead' } : { ok: true }),
+    }));
+    // 3 consecutive failing passes (advance clock past the per-pair cooldown each time so it keeps trying).
+    for (let i = 0; i < 3; i++) { await r.tick(); clock.t += 31 * 60_000; }
+    expect(r.status().breaker.open).toBe(true);
+    expect(r.status().breaker.consecutiveFailures).toBeGreaterThanOrEqual(3);
+    // A success resets it.
+    mode = 'ok';
+    clock.t += 31 * 60_000;
+    await r.tick();
+    expect(r.status().breaker.open).toBe(false);
+    expect(r.status().breaker.consecutiveFailures).toBe(0);
+  });
+
+  it('a dry-run swap that returns ok never trips the breaker', async () => {
+    const r = new CredentialRebalancer(makeDeps({ isDryRun: () => true, swap: async () => ({ ok: true }) }));
+    await r.tick();
+    expect(r.status().breaker.open).toBe(false);
+  });
+});
+
+describe('CredentialRebalancer — status surface', () => {
+  it('reports enabled + breaker + last pass', async () => {
+    const r = new CredentialRebalancer(makeDeps({}));
+    expect(r.status().lastPass).toBeNull();
+    await r.tick();
+    const st = r.status();
+    expect(st.enabled).toBe(true);
+    expect(st.lastPass).not.toBeNull();
+    expect(st.breaker.threshold).toBe(3);
+  });
+});

--- a/upgrades/next/ws52-incb-b1-rebalancer-policy.md
+++ b/upgrades/next/ws52-incb-b1-rebalancer-policy.md
@@ -1,0 +1,33 @@
+# WS5.2 Increment B / B1 — the balancer decision core (dark/unwired)
+
+<!-- bump: patch -->
+
+<!--
+  NOTE: dark/unwired pure logic. One new module (CredentialRebalancerPolicy) + its
+  exhaustive unit test. NOT wired into any runtime path — it is the §2.4 decision core
+  for the autonomous drainer (Increment B). Zero IO, no config flag, no route, no
+  credential write path. The actuation that consumes its output is a later step under
+  the existing subscriptionPool.credentialRepointing dark/dry-run gate.
+-->
+
+## What Changed
+
+Begins Increment B (the autonomous use-it-or-lose-it drainer) with its decision core, deliberately split out so the entire policy is unit-testable before any autonomous write exists.
+
+- **`CredentialRebalancerPolicy.decidePass()`** (src/core/CredentialRebalancerPolicy.ts) — a PURE function computing the zero-or-more credential swaps for one balancer pass from a read-only snapshot (per-account quota + reset proximity, per-slot tenancy/verify/activity, cooldown state, resolved config):
+  - **Objective 1 — wall avoidance:** a tenant over the high-water mark (default 85%, either window) gets the highest-headroom eligible account; a tenant over the critical mark (default 95%) triggers a wall-OVERRIDE that bypasses the cooldowns and the 1-swap/pass cap — itself bounded by the fresh-data gate (never re-fires on the same sensor snapshot), `maxForcedSwapsPerPass`, and a per-window override budget whose exhaustion surfaces a degraded + attention terminal state instead of looping. The rescue target must be verified-recent (the recency gate).
+  - **Objective 2 — use-it-or-lose-it drain:** an account whose WEEKLY window resets within the horizon with ≥30% unused headroom is dealt to the busiest eligible slot (weekly only — 5h windows regenerate); a per-slot "drain in progress" hold stops the 3-way drain rotation from fragmenting the window.
+  - **Eligibility + hysteresis:** needs-reauth/disabled/quarantined/unverified never participate; stale-quota accounts are SOURCE-only; per-pair + per-tenant cooldowns (the tenant cooldown defeats the 3-way rotation attack); a min-improvement floor with urgency clamped at 4h-to-reset; 1 swap per pass for non-forced objectives.
+- **Unwired + dark.** Nothing actuates on the decision yet. Dead-default eviction, the correlated-oracle-outage floor, quarantine-exit, the P19 breaker, and the scheduled identity audit are the next Increment-B step <!-- tracked: 20905 -->; wiring the decision through the live executor (under the existing `subscriptionPool.credentialRepointing` dark/dry-run gate), the live `GET /credentials/rebalancer` status, and the routes follow <!-- tracked: 20905 -->.
+
+## What to Tell Your User
+
+Nothing changes — this is off-by-default internal logic with no effect yet. It's the "brain" of the eventual automatic account-balancer: given how much quota each of your accounts has left and how close each is to its weekly reset, it works out whether to shuffle one account's login to a different slot to (a) rescue a session about to hit a wall, or (b) burn down a weekly allowance that would otherwise expire unused. Right now it only *decides* — nothing acts on those decisions, so no credential moves. It's built first and on its own precisely so every rule can be tested in isolation before anything is ever wired to actually move a login, and the whole balancer stays switched off until you decide otherwise.
+
+## Summary of New Capabilities
+
+No new runtime capability — this is the unwired decision core for the autonomous balancer (Increment B), shipped dark. New internal module `CredentialRebalancerPolicy` (pure `decidePass()`): computes the per-pass wall-avoidance / drain / default-preference swap decisions with bounded wall-override, eligibility, and hysteresis. Not wired into any runtime path; no route, no config flag, no credential write path.
+
+## Evidence
+
+- `tests/unit/credential-rebalancer-policy.test.ts` (18) — eligibility (needs-reauth tenant excluded; quarantined slot not a target); wall avoidance (rescue with highest-headroom; no rescue when only target also walls; held behind per-pair cooldown; triggers on the weekly window too); wall-override (bypasses cooldown; fresh-data gate no-re-fire; per-window budget exhaustion → degraded + attention; ≤ maxForcedSwapsPerPass when multiple critical; recency gate rejects a stale-verify target); stale-quota source-only; drain (weekly-only, headroom floor, drain-in-progress hold excluded, busiest-slot destination); zero-actuation reason; 1-swap-per-pass. tsc + full lint clean.

--- a/upgrades/next/ws52-incb-b2-default-eviction.md
+++ b/upgrades/next/ws52-incb-b2-default-eviction.md
@@ -1,0 +1,30 @@
+# WS5.2 Increment B / B2 — dead-default eviction + correlated-outage floor (dark/unwired)
+
+<!-- bump: patch -->
+
+<!--
+  NOTE: dark/unwired pure logic. Extends the B1 CredentialRebalancerPolicy decision core
+  with §2.4 objective-0 (keep ~/.claude alive). No IO, no config flag, no route, no
+  credential write path. Same dark/unwired posture as B1 — the actuation that consumes
+  the decision is a later gated step.
+-->
+
+## What Changed
+
+Adds the highest-priority objective to the balancer decision core: keep `~/.claude` serving a healthy account so manual `claude` invocations stay predictable (§2.4 objective-0).
+
+- **Dead/quarantined-default eviction** — when the default slot's tenant goes needs-reauth/disabled OR the default slot is quarantined, `decidePass()` now deals a healthy, identity-verified-recent tenant into `~/.claude` (a `default-eviction` decision), parking the dead/quarantined credential in the vacated slot with an attention note. This runs before wall-avoidance and drain — a frozen default freezes the operator's manual `claude`.
+- **Correlated-oracle-outage floor** — when NO slot is currently oracle-verifiable (an `api.anthropic.com` storm quarantines every probe at once), the policy does NOT empty or churn the default: it preserves the last-known-good assignment, surfaces a degraded + attention entry, and performs no eviction until the oracle returns. Honest bound: the floor's guarantee is "preserve last-known-good + flag", explicitly NOT "manual claude is certified live".
+- **Bounded fallback** — verifiable slots exist but none is an eligible healthy tenant → surface, do not act. Two new inputs (`desiredDefaultAccountId`, per-slot `lastKnownGoodAccountId`) + the `default-eviction` objective. Still pure, still unwired; consecutive-forced-eviction P19-capping is the next step <!-- tracked: 20905 -->.
+
+## What to Tell Your User
+
+Still nothing changes — off-by-default internal logic. This teaches the (not-yet-active) account-balancer to protect the one login that must always work: the default `claude` account. If that account ever needs a re-login or gets quarantined, the balancer's plan is to slide a known-good account into its place so your plain `claude` command keeps working, and flag the broken one for you. And if the check it relies on (Anthropic's identity endpoint) is down for everything at once, it deliberately does nothing rather than risk making the default worse — preserving the last-known-good and telling you honestly that it can't currently certify it's live. It only decides; nothing acts yet.
+
+## Summary of New Capabilities
+
+No new runtime capability — extends the unwired Increment-B decision core. `decidePass()` gains §2.4 objective-0: dead/quarantined-default eviction (deal a healthy verified tenant into `~/.claude`) and the correlated-oracle-outage floor (preserve last-known-good, never empty the default during an outage). Not wired into any runtime path; no route, no config flag, no credential write path.
+
+## Evidence
+
+- `tests/unit/credential-rebalancer-policy.test.ts` (+6, 24 total) — deals a healthy verified tenant in when the default tenant is needs-reauth; rescues a quarantined default too; correlated-outage floor preserves last-known-good and does NOT evict; dead default with no healthy tenant surfaces without acting; healthy default is a no-op (normal objectives run); inert when no default account is configured. tsc + full lint clean.

--- a/upgrades/next/ws52-incb-b2-default-eviction.md
+++ b/upgrades/next/ws52-incb-b2-default-eviction.md
@@ -19,7 +19,7 @@ Adds the highest-priority objective to the balancer decision core: keep `~/.clau
 
 ## What to Tell Your User
 
-Still nothing changes — off-by-default internal logic. This teaches the (not-yet-active) account-balancer to protect the one login that must always work: the default `claude` account. If that account ever needs a re-login or gets quarantined, the balancer's plan is to slide a known-good account into its place so your plain `claude` command keeps working, and flag the broken one for you. And if the check it relies on (Anthropic's identity endpoint) is down for everything at once, it deliberately does nothing rather than risk making the default worse — preserving the last-known-good and telling you honestly that it can't currently certify it's live. It only decides; nothing acts yet.
+Still nothing changes — off-by-default internal logic. This teaches the (not-yet-active) account-balancer to protect the one login that must always work: your default Claude account. If that account ever needs a re-login or gets quarantined, the balancer's plan is to slide a known-good account into its place so your plain claude command keeps working, and flag the broken one for you. And if the check it relies on (Anthropic's identity endpoint) is down for everything at once, it deliberately does nothing rather than risk making the default worse — preserving the last-known-good and telling you honestly that it can't currently certify it's live. It only decides; nothing acts yet.
 
 ## Summary of New Capabilities
 

--- a/upgrades/next/ws52-incb-b3a-rebalancer-orchestrator.md
+++ b/upgrades/next/ws52-incb-b3a-rebalancer-orchestrator.md
@@ -1,0 +1,36 @@
+# WS5.2 Increment B / B3a — the balancer orchestrator (dark/unwired)
+
+<!-- bump: patch -->
+
+<!--
+  NOTE: dark/unwired. One new module (CredentialRebalancer) + its fake-deps unit test.
+  The autonomous-write ACTUATION orchestrator that wraps the pure decidePass() core in a
+  pass loop and actuates via the gated executor — but it is NOT wired into any runtime
+  path (no setInterval, no live route yet). No config flag, no credential write path of
+  its own (the executor is the sole write path, itself dark/dry-run-gated). Second-pass
+  reviewed (CONCUR).
+-->
+
+## What Changed
+
+Adds the stateful orchestrator around the Increment-B decision core — the loop that will eventually run the autonomous balancer, built and tested before it is wired to anything.
+
+- **`CredentialRebalancer.tick()`** (src/core/CredentialRebalancer.ts) — builds the read-only pass snapshot from injected providers, calls `decidePass()`, and actuates each accepted swap through the injected executor wrapper, under the feature's dark/dry-run gate:
+  - **Dark = strict no-op:** when the feature is disabled the pass returns immediately having called the providers and the executor ZERO times.
+  - **Dry-run actuates the decision but not the write:** the executor enforces dry-run (no credential moves); the pass advances cooldown state so a dry-run soak shows realistic anti-churn cadence.
+  - **The executor is the only write path:** a swap rejection is caught and treated as a failure (no crash).
+  - **P19 breaker:** N consecutive LIVE failed swaps opens it; a success resets it; it self-heals by re-probing on later passes. A dry-run never trips it.
+  - **Cross-pass hysteresis:** cooldown timestamps recorded by the tenant-account pair (matching the policy's cooldown check), the per-window forced-override budget incremented only on a successful wall-override and time-reset.
+- **Unwired + dark.** The server `setInterval` pass, the live `GET /credentials/rebalancer` status, and a tick-serialization (reentrancy) guard are the next step <!-- tracked: 20905 -->.
+
+## What to Tell Your User
+
+Still nothing changes — off-by-default internal logic with no effect yet. This is the loop that will eventually run the automatic account-balancer: every few minutes it would look at your quota picture, decide whether a login should move, and carry it out. It's built and tested now, but deliberately not connected to anything that runs on a timer, so it never fires. When it is connected, it stays switched off until you turn it on, and even then a first dry-run mode lets it show what it would do without moving a single credential. There's also a built-in circuit-breaker: if a move ever fails repeatedly, it stops trying and flags it rather than thrashing.
+
+## Summary of New Capabilities
+
+No new runtime capability — the unwired autonomous-write orchestrator for the Increment-B balancer, shipped dark. New internal module `CredentialRebalancer` (`tick()` + `status()`): wraps the pure decision core in a pass loop, actuates via the gated executor under the dark/dry-run gate, carries cross-pass cooldown state + a P19 breaker. Not wired into any runtime path; no route, no config flag, no credential write path of its own.
+
+## Evidence
+
+- `tests/unit/credential-rebalancer.test.ts` (7) — dark = strict no-op (zero executor calls); actuates one swap for a walling scenario; dry-run drives the executor (no-op write) and advances cooldowns; the per-pair cooldown holds a re-swap on the next pass; the P19 breaker opens after 3 consecutive live failures and resets on a success; a dry-run ok never trips the breaker; the status surface reports enabled + breaker + last pass. Independent second-pass review CONCUR. tsc + full lint clean.

--- a/upgrades/next/ws52-incb-b3b-snapshot-mappers.md
+++ b/upgrades/next/ws52-incb-b3b-snapshot-mappers.md
@@ -1,0 +1,33 @@
+# WS5.2 Increment B / B3b-snapshot — balancer snapshot mappers (dark/unwired)
+
+<!-- bump: patch -->
+
+<!--
+  NOTE: dark/unwired pure helpers. One new module (CredentialRebalancerSnapshot) + its
+  unit test. Stateless mappers from SubscriptionPool accounts + CredentialLocationLedger
+  assignments + config into the policy's snapshot — the providers the B3a orchestrator
+  consumes. No IO, no config flag, no route, no credential write path. The server.ts
+  construction + setInterval + live route that USE these mappers is the next step.
+-->
+
+## What Changed
+
+Adds the pure translation layer between the live system state and the balancer's decision core, kept out of server.ts so a units/sign bug can't silently mis-steer the balancer.
+
+- **`CredentialRebalancerSnapshot`** (src/core/CredentialRebalancerSnapshot.ts) — pure mappers:
+  - `mapAccount`/`mapAccounts`: a SubscriptionPool account → the policy's `AccountState` (5h/weekly utilization %, weekly-reset hours, status). A missing quota reading maps to an epoch `measuredAt` so the account is treated as STALE (source-only) — never dealt in on a reading we don't have. `rate-limited` stays eligible (`ok`) so wall-avoidance can rescue its slot; only `needs-reauth`/`disabled` are ineligible.
+  - `mapSlot`/`mapSlots`: a CredentialLocationLedger assignment → the policy's `SlotState` (default-slot flag, quarantine, last-verified time; a quarantined-empty slot normalizes to a null tenant).
+  - `resolveRebalancerConfig`: clamp the configured knobs into the resolved config and derive the cooldowns from the poll interval (per-pair 1×, per-tenant 2×) + the stale-quota window (N poll periods).
+- Unwired + dark; the server construction + the timer pass + the live status route are the next step <!-- tracked: 20905 -->.
+
+## What to Tell Your User
+
+Still nothing changes — off-by-default internal plumbing. This is the translator that turns your real account quota and login layout into the form the (not-yet-active) balancer's brain understands. It's careful about safety even here: if it doesn't actually have a fresh quota reading for an account, it treats that account as "don't move anything onto it" rather than guessing; and a rate-limited account stays eligible to be rescued rather than being written off. It only translates data — nothing acts.
+
+## Summary of New Capabilities
+
+No new runtime capability — pure translation helpers for the Increment-B balancer, shipped dark. New internal module `CredentialRebalancerSnapshot` (mapAccount/mapSlot/resolveRebalancerConfig): the unwired providers the balancer orchestrator will consume. Not wired into any runtime path; no route, no config flag, no credential write path.
+
+## Evidence
+
+- `tests/unit/credential-rebalancer-snapshot.test.ts` (10) — status eligibility (rate-limited stays ok; needs-reauth/disabled ineligible); quota mapping incl. weekly-reset hours + missing-reading → stale; slot mapping (default flag, quarantined-empty → null tenant, override fields); config defaults + clamping + cooldown derivation. tsc + full lint clean.

--- a/upgrades/side-effects/ws52-incb-b1-rebalancer-policy.md
+++ b/upgrades/side-effects/ws52-incb-b1-rebalancer-policy.md
@@ -1,0 +1,44 @@
+# Side-Effects Review — WS5.2 Increment B / B1: the balancer decision core (dark/unwired)
+
+**Version / slug:** `ws52-incb-b1-rebalancer-policy`
+**Date:** 2026-06-13
+**Author:** echo
+**Second-pass reviewer:** not required at B1 (pure decision logic, unwired, zero IO, no autonomous-write surface — the second-pass review attaches to B3, where the decision is actuated through the live executor under the dark gate)
+
+## Summary of the change
+
+Adds `src/core/CredentialRebalancerPolicy.ts` — the §2.4 "stock-trader loop" decision core as a PURE function `decidePass(input) → { decisions, degraded, attention, noActuationReason }`, plus exhaustive unit tests. Given a read-only snapshot (per-account quota + reset proximity, per-slot tenancy/verify/activity, cooldown state, resolved+clamped config) it computes the zero-or-more swap decisions for one pass: objective-1 wall avoidance + the bounded wall-override, objective-2 use-it-or-lose-it drain, eligibility, and the hysteresis floors. It performs NO IO and holds NO authority — it DECIDES; the actuator (step B3) routes an accepted decision through the Step-5 executor under the dark/dry-run gate. This is the first of Increment B's steps (B2 = dead-default eviction + correlated-outage floor + quarantine-exit + P19 breaker + scheduled identity audit; B3 = wiring/actuation/routes; B4 = integration/e2e/livetest), sequenced so the entire policy is testable before any autonomous write exists.
+
+## Decision-point inventory
+
+- `decidePass()` — add — the per-pass swap policy. It is a DECISION producer, not an authority: it returns proposed swaps + surfaced terminal states. Nothing actuates on its output yet (unwired). When B3 wires it, actuation is gated by `subscriptionPool.credentialRepointing.enabled` + `dryRun` and verified by the oracle (the Tier-0 justification, §2.4: deterministic policy over enumerable numeric thresholds, every decision audited, reversible swap verified by the oracle).
+
+---
+
+## 1. Over-block
+No block/allow surface. The nearest analog — refusing to emit a swap — is the conservative direction (a withheld swap is a no-op; the spec's "a pass with no actuation performs zero keychain/CLI operations" invariant). Concretely conservative: stale-quota accounts are SOURCE-only (never dealt in, lest stale headroom mask a wall); ineligible (needs-reauth/disabled/quarantined/unverified) tenants never participate; a critical slot whose override is blocked WAITS rather than being non-forced-rescued.
+
+## 2. Under-block
+The honest residual the spec names (§2.4 round-4): the wall-path recency gate NARROWS but does not CLOSE the "target passed its last audit then died after it" window — a just-died-but-recently-verified target can still be dealt into a walling slot, bounded to "victim slot quarantined + one re-auth, surfaced". B1 implements the recency gate (a target must be verified within the audit cadence and non-divergent); the residual is accepted per the spec's oracle-split rationale, and the post-commit verify (B3, via the executor) is the backstop.
+
+## 3. Level-of-abstraction fit
+Correct layer, and the deliberate point of B1: the policy is split OUT of the actuation so every threshold/cap/cooldown is unit-testable without a keychain (the same fake-deps discipline as the executor). It consumes already-resolved+clamped config (the resolver lives in B3) so the pure core never reads raw config or clamps.
+
+## 4. Signal vs authority compliance
+- [x] No — this change has no block/allow surface and, at B1, no authority at all (its output is unwired).
+
+The policy is a deterministic evaluator over numeric thresholds; the authority to actuate is B3's and is gated dark + dry-run-first + oracle-verified. (Ref: docs/signal-vs-authority.md; §2.4 Tier-0 supervision justification.)
+
+## 5. Interactions
+- **Hysteresis interactions (designed, tested):** 1-swap-per-pass for non-forced objectives; the wall-override may emit up to `maxForcedSwapsPerPass` and bypasses cooldowns but is itself bounded by the fresh-data gate (no re-fire on the same sensor snapshot) and `maxForcedOverridesPerWindow` (exhaustion → surfaced terminal state, never a loop). Per-pair + per-tenant cooldowns both key on the ACCOUNT pair/tenant (consistent basis; the per-tenant cooldown is what defeats the 3-way rotation attack pairwise cooldowns miss). Drain carries a per-slot "drain in progress" hold so the 3-way drain rotation can't fragment the very window it means to use.
+- **Priority interaction:** wall (forced) short-circuits the pass; otherwise non-forced wall → drain → default-preference, one swap max. A critical slot is never downgraded to a non-forced rescue in the same pass.
+- No shadowing/race — the module is pure and unwired; nothing else calls it.
+
+## 6. External surfaces
+None today (unwired). The module changes no API, no config, no agent-facing surface. When B3 wires it the only external effect is the (dark-gated, dry-run-first, audited, oracle-verified, reversible) credential swap the executor already owns.
+
+## 7. Multi-machine posture (Cross-Machine Coherence)
+- **Machine-local BY DESIGN.** The balancer permutes THIS machine's credential slots based on THIS machine's quota/activity snapshot. Each machine runs its own pass over its own keychain; there is no cross-machine input or coordination (a credential has exactly one home, on one machine, §0.d). No replication, no proxied read, no generated URL.
+
+## 8. Rollback cost
+Trivial. Revert the commit — the module is unwired, so no runtime behavior changes. No state, no migration, no credential touch (tests are pure). Any swap the wired balancer (B3) ever performs is the reversible, oracle-verified, dry-run-gated round-trip the executor already owns.

--- a/upgrades/side-effects/ws52-incb-b2-default-eviction.md
+++ b/upgrades/side-effects/ws52-incb-b2-default-eviction.md
@@ -1,0 +1,42 @@
+# Side-Effects Review — WS5.2 Increment B / B2: dead-default eviction + correlated-outage floor (dark/unwired)
+
+**Version / slug:** `ws52-incb-b2-default-eviction`
+**Date:** 2026-06-13
+**Author:** echo
+**Second-pass reviewer:** not required at B2 (pure decision logic extending B1's unwired policy; no IO, no autonomous-write surface — the second-pass review attaches to B3 where the decision is actuated)
+
+## Summary of the change
+
+Extends `CredentialRebalancerPolicy.decidePass()` with §2.4's objective-0: keep `~/.claude` serving a healthy verified tenant. When the DEFAULT slot's tenant is needs-reauth/disabled OR the default slot is quarantined, the policy deals a healthy verified tenant into `~/.claude` (a `default-eviction` decision, highest priority — a frozen default freezes the operator's manual `claude`). Two bounded fallbacks: when verifiable slots exist but none is an eligible healthy tenant it SURFACES and does not act; when NO slot is oracle-verifiable (the correlated-outage signature) it applies the floor — preserve the default's last-known-good assignment, surface a degraded + attention entry, and perform NO eviction until the oracle returns. Adds two input fields (`desiredDefaultAccountId`, per-slot `lastKnownGoodAccountId`) and the `default-eviction` objective. Still pure, still unwired.
+
+## Decision-point inventory
+
+- `decidePass()` objective-0 branch — add — decides whether to rescue a dead/quarantined DEFAULT slot. A decision producer, not an authority (unwired). The eviction target is identity-verified-recent in the pure policy (B3's actuation re-verifies live before the move); the correlated-outage floor is the conservative direction (never empty/churn the default during an oracle storm).
+
+---
+
+## 1. Over-block
+No block/allow surface. The conservative directions are deliberate: the correlated-outage floor refuses to act (preserve last-known-good) rather than risk dealing a dead tenant into the one slot that must stay alive; a dead default with no healthy tenant surfaces rather than forcing a bad move.
+
+## 2. Under-block
+Honest residual (§2.4 round-4): the floor's guarantee is "preserve the last KNOWN-GOOD assignment + surface", NOT "manual claude is certified live" — a correlated outage is observationally identical to "every grant died at once", and the oracle (the only liveness signal) is down by construction. The policy surfaces this explicitly ("NOT certified live") rather than over-claiming continuity. P19-capping of consecutive forced default evictions is B3 (stateful breaker), tracked there.
+
+## 3. Level-of-abstraction fit
+Correct layer — a pure extension of the B1 decision core. Objective-0 runs FIRST (before wall/drain) because a frozen default is the highest-impact freeze; the branch returns immediately when it acts or applies the floor, so it never races the other objectives.
+
+## 4. Signal vs authority compliance
+- [x] No — no block/allow surface; unwired, no authority (output not actuated yet). Deterministic policy over the same enumerable thresholds. (Ref: docs/signal-vs-authority.md.)
+
+## 5. Interactions
+- **Priority interaction:** objective-0 short-circuits the pass before objective-1/2/3. Correct — the default slot's liveness beats wall/drain optimization. It only fires when a default account is configured AND the default slot is genuinely dead/quarantined, so a healthy default is a pure no-op that falls through to the normal objectives.
+- **Eligibility interaction:** the dead default tenant is (by design) excluded from `participatingSlots`; objective-0 reads the raw `slots` for the default specifically — the one place the quarantine-exclusion rule is intentionally overridden (only for `~/.claude`).
+- No shadowing/race — pure, unwired.
+
+## 6. External surfaces
+None today (unwired). No API/config/agent-facing change. When B3 wires it, the only effect is the dark-gated, dry-run-first, oracle-verified, reversible swap the executor owns — plus the surfaced attention/degraded entries.
+
+## 7. Multi-machine posture (Cross-Machine Coherence)
+- **Machine-local BY DESIGN.** The default slot, its tenant, and the oracle answers are all per-machine; each machine keeps its OWN `~/.claude` alive from its own snapshot. No cross-machine input or coordination.
+
+## 8. Rollback cost
+Trivial. Revert the commit — the module is unwired, so no runtime behavior changes. No state, no migration, no credential touch (tests are pure).

--- a/upgrades/side-effects/ws52-incb-b3a-rebalancer-orchestrator.md
+++ b/upgrades/side-effects/ws52-incb-b3a-rebalancer-orchestrator.md
@@ -1,0 +1,44 @@
+# Side-Effects Review — WS5.2 Increment B / B3a: the balancer orchestrator (dark/unwired)
+
+**Version / slug:** `ws52-incb-b3a-rebalancer-orchestrator`
+**Date:** 2026-06-13
+**Author:** echo
+**Second-pass reviewer:** independent reviewer subagent — CONCUR (this is the autonomous-write actuation orchestrator → Phase 5 required)
+
+## Summary of the change
+
+Adds `src/core/CredentialRebalancer.ts` — the stateful orchestrator that wraps the pure `decidePass()` core in a pass loop: on `tick()` it builds the read-only snapshot from injected providers, asks the policy for the zero-or-more swaps, and ACTUATES each through the injected `swap` dep (a wrapper over the gated CredentialSwapExecutor) — but only under the feature's dark/dry-run gate. It carries the hysteresis state the pure policy cannot (cooldown timestamps across passes) and the §2.4 P19 breaker (N consecutive LIVE failed swaps opens it; a success resets it; it self-heals by re-probing). Unwired: the server `setInterval` pass + the live `GET /credentials/rebalancer` status is step B3b.
+
+## Decision-point inventory
+
+- `CredentialRebalancer.tick()` — add — the autonomous balancer pass. This is the actuation layer (the decision was made in B1/B2). It actuates ONLY via `deps.swap()` (the gated, oracle-verified, staged executor) and ONLY when `isEnabled()` is true; even then the executor's own `dryRun` enforces no-write. The supervision is Tier-0 (§2.4): deterministic policy, oracle-verified reversible swaps, every pass audited.
+
+---
+
+## 1. Over-block
+No block/allow surface. The conservative direction is dark = strict no-op (zero provider/executor calls when disabled) and the breaker (stop actuating after repeated failures).
+
+## 2. Under-block
+The breaker self-heals by re-probing rather than dead-latching — a deliberate choice (a transient keychain failure shouldn't permanently freeze the balancer); a persistent failure keeps it open every pass. The reviewer confirmed there is no path where an open breaker is never re-checked.
+
+## 3. Level-of-abstraction fit
+Correct: the orchestrator holds ONLY the cross-pass state (cooldowns, breaker, forced-override window) and delegates the decision to the pure policy and the write to the executor. It re-implements neither. The cooldown key (tenant-account pair) matches exactly what `decidePass`'s `cooldownOk` reads.
+
+## 4. Signal vs authority compliance
+- [x] Yes — but the logic is a deterministic policy evaluator (the §2.4 Tier-0 justification), and its authority to actuate is gated dark + dry-run-first + oracle-verified + reversible.
+
+The orchestrator holds actuation authority, but it is the conservatively-bounded kind the spec sanctions: a deterministic policy over numeric thresholds, every swap reversible and oracle-verified by the executor, every pass audited, shipped dark + dry-run-first. (Ref: docs/signal-vs-authority.md; §2.4.)
+
+## 5. Interactions
+- **Executor interaction:** the orchestrator's ONLY write path is `deps.swap()`; a swap throw is caught and treated as `ok:false` (no crash), incrementing the breaker only on a LIVE failure. The executor enforces enabled/dryRun internally, so the orchestrator's gate + the executor's gate are belt-and-suspenders.
+- **Cooldown/breaker state:** carried in-memory across passes; recorded by the tenant-account pair the decision exchanged (not the slot seat); NOT advanced on a failed swap (so the next pass retries). The forced-override window increments only on a successful wall-override and time-resets.
+- **Reentrancy (latent, scoped to B3b):** `tick()` has no in-flight guard; overlapping ticks could double-read state. B3b (the `setInterval` wiring) MUST serialize ticks (skip-if-running) <!-- tracked: 20905 -->. Harmless at B3a (unwired; the unit tests call tick() sequentially).
+
+## 6. External surfaces
+None today (unwired). No API/config/agent-facing change. When B3b wires it, the only effect is the dark-gated, dry-run-first, oracle-verified, reversible swap the executor owns, plus the `GET /credentials/rebalancer` status read.
+
+## 7. Multi-machine posture (Cross-Machine Coherence)
+- **Machine-local BY DESIGN.** Each machine runs its own pass over its own keychain/quota snapshot; the in-memory cooldown/breaker state is per-machine-per-process. No cross-machine input or coordination (a credential has one home, on one machine).
+
+## 8. Rollback cost
+Trivial. Revert the commit — the module is unwired, so no runtime behavior changes. No state, no migration, no credential touch (tests use fakes). Any swap the wired balancer ever performs is the reversible, oracle-verified, dry-run-gated round-trip the executor owns.

--- a/upgrades/side-effects/ws52-incb-b3b-snapshot-mappers.md
+++ b/upgrades/side-effects/ws52-incb-b3b-snapshot-mappers.md
@@ -1,0 +1,37 @@
+# Side-Effects Review — WS5.2 Increment B / B3b-snapshot: balancer snapshot mappers (dark/unwired)
+
+**Version / slug:** `ws52-incb-b3b-snapshot-mappers`
+**Date:** 2026-06-13
+**Author:** echo
+**Second-pass reviewer:** not required (pure stateless mappers, unwired, no IO, no decision/authority surface)
+
+## Summary of the change
+
+Adds `src/core/CredentialRebalancerSnapshot.ts` — pure functions translating the live system's state into the balancer's read-only pass snapshot: `mapAccount(s)`/`mapAccounts` (SubscriptionPool account → policy `AccountState`), `mapSlot(s)`/`mapSlots` (CredentialLocationLedger assignment → policy `SlotState`), `mapAccountStatus`, and `resolveRebalancerConfig` (clamp the configured knobs + derive cooldowns from the poll interval). These ARE the `listSlots`/`listAccounts`/`resolveConfig` providers the B3a orchestrator consumes; kept pure + out of server.ts so the units/sign translation (where a silent bug would mis-steer the balancer) is unit-testable. Still unwired — the server.ts construction + setInterval + live route is the next step.
+
+## Decision-point inventory
+
+- No decision point. These are stateless data mappers. The one judgment encoded — `rate-limited` maps to eligible (`ok`) — is a correctness requirement, not a gate: a walled account must stay eligible so wall-avoidance can rescue its slot (excluding it would strand the slot that needs help). Only `needs-reauth`/`disabled` (dead credentials) map to ineligible.
+
+---
+
+## 1. Over-block / ## 2. Under-block
+No block/allow surface — not applicable. Conservative defaults: a missing quota reading maps to `measuredAt: 0` (epoch) → always stale → the account is SOURCE-only (never dealt in on a reading we don't actually have); a quarantined-empty slot (ledger `accountId: ''`) normalizes to a null tenant (can't be moved).
+
+## 3. Level-of-abstraction fit
+Correct: the mapping is the boundary between the live stores (SubscriptionPool, CredentialLocationLedger, config) and the pure policy. Putting it in its own pure module (not inline in server.ts) is the deliberate testability choice — the same reason the policy + orchestrator are pure.
+
+## 4. Signal vs authority compliance
+- [x] No — no block/allow surface; stateless mappers, no authority. (Ref: docs/signal-vs-authority.md.)
+
+## 5. Interactions
+- Consumed only by the B3a orchestrator's injected providers (and its tests). The cooldown derivation (per-pair = 1× poll interval, per-tenant = 2×) and stale-quota window (N poll periods) are computed here so the orchestrator/policy stay config-agnostic. No shadowing/race — pure.
+
+## 6. External surfaces
+None today (unwired). No API/config/agent-facing change.
+
+## 7. Multi-machine posture (Cross-Machine Coherence)
+- **Machine-local BY DESIGN.** The mappers read THIS machine's pool accounts + ledger; the resulting snapshot is per-machine. No cross-machine input.
+
+## 8. Rollback cost
+Trivial. Revert the commit — unwired pure functions, no runtime behavior, no state, no credential touch.


### PR DESCRIPTION
## ELI16 — what this does in plain words

This is the "brain" of the eventual automatic account-balancer (Increment B of live credential re-pointing), built first and on its own so every rule can be tested in isolation before anything is ever wired to actually move a login.

Given how much quota each account has left and how close each is to its weekly reset, `decidePass()` works out whether to shuffle one account's login to a different slot to either (a) **rescue** a session about to hit a wall, or (b) **drain** a weekly allowance that would otherwise expire unused. It only *decides* — it returns proposed swaps; nothing acts on them yet (unwired, dark). So no credential moves, no effect, until later steps wire it under the existing off-by-default gate and you choose to enable it.

## What changed
- New `src/core/CredentialRebalancerPolicy.ts` — pure `decidePass(snapshot) → { decisions, degraded, attention }`. Zero IO, no authority.
  - **Wall avoidance** (≥85%) + bounded **wall-override** (≥95%): bypasses cooldowns but capped by a fresh-data gate, `maxForcedSwapsPerPass`, and a per-window override budget (exhaustion → surfaced terminal state, never a loop); rescue target must be verified-recent.
  - **Use-it-or-lose-it drain**: weekly-only, ≥30% headroom, to the busiest slot, with a per-slot drain-in-progress hold against the 3-way rotation.
  - Eligibility (ineligible/stale-quota handling) + hysteresis (per-pair + per-tenant cooldowns, urgency-clamped min-improvement floor, 1 swap/pass).
- Unwired + dark. Dead-default eviction + correlated-outage floor + P19 breaker + scheduled identity audit are the next step; wiring/actuation/routes follow.

## Evidence
`tests/unit/credential-rebalancer-policy.test.ts` (18) — both sides of every boundary. tsc + full lint clean.

Spec: `docs/specs/live-credential-repointing-rebalancer.md` §2.4 (approved + converged, CMT-1372).

🤖 Generated with [Claude Code](https://claude.com/claude-code)