### PR TITLE
feat(credential-repointing): WS5.2 Increment B / B3b — wire the balancer into the server (dry-run on dev)

### DIFF
--- a/.instar/instar-dev-decisions/2026-06-13T23-21-46-717Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-06-13T23-21-46-717Z-unknown.json
@@ -1,0 +1,13 @@
+{
+  "ts": "2026-06-13T23:21:46.717Z",
+  "slug": "unknown",
+  "suggestedTier": 2,
+  "declaredTier": 2,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 2,
+  "loc": 72,
+  "causalAutopsy": null,
+  "verdict": "pass"
+}

--- a/src/commands/server.ts
+++ b/src/commands/server.ts
@@ -9293,6 +9293,50 @@ export async function startServer(options: StartOptions): Promise<void> {
       maxForcedPerWindow: config.subscriptionPool?.credentialRepointing?.maxForcedManualSwapsPerWindow,
       forcedWindowMs: config.subscriptionPool?.credentialRepointing?.forcedManualSwapWindowMs,
     });
+    // B3b — the autonomous balancer (Increment B). Wraps the pure §2.4 decision core in a pass
+    // loop and actuates via the SAME gated swap executor. isEnabled mirrors the location gate
+    // (dev-gate-resolved AND the §2.10 env-token gate), and the executor's own dryRun keeps it a
+    // dry-run dogfood on a dev agent (full decision loop + audit, ZERO writes) until dryRun:false.
+    const { CredentialRebalancer } = await import('../core/CredentialRebalancer.js');
+    const { mapSlots: credMapSlots, mapAccounts: credMapAccounts, resolveRebalancerConfig: credResolveBalancerConfig } =
+      await import('../core/CredentialRebalancerSnapshot.js');
+    const CRED_DEFAULT_SLOT = '~/.claude';
+    const credentialRebalancer = new CredentialRebalancer({
+      // Same gate as the location gate: dev-gate-resolved AND not env-token-refused.
+      isEnabled: () =>
+        resolveDevAgentGate(config.subscriptionPool?.credentialRepointing?.enabled, config) &&
+        !credentialEnvTokenGate.evaluate().refused,
+      isDryRun: () => config.subscriptionPool?.credentialRepointing?.dryRun !== false,
+      listSlots: () => credMapSlots(credentialLocationLedger.getAssignments(), { defaultSlot: CRED_DEFAULT_SLOT }),
+      listAccounts: () => credMapAccounts(subscriptionPool.list(), Date.now()),
+      resolveConfig: () =>
+        credResolveBalancerConfig({
+          ...(config.subscriptionPool?.credentialRepointing?.balancer ?? {}),
+          slotCount: credentialLocationLedger.getAssignments().length,
+          // Dry-run dogfood defaults: keep the account currently in ~/.claude as the desired
+          // default (objective-0 keeps it alive). An explicit operator default-account config +
+          // tmux-activity busyness for the drain target are refinements <!-- tracked: 20905 -->.
+          desiredDefaultAccountId: credentialLocationLedger.tenantOf(CRED_DEFAULT_SLOT) ?? null,
+        }),
+      swap: async (a, b) => {
+        const r = await credentialSwapExecutor.swap(a, b);
+        return { ok: r.outcome === 'swapped' || r.outcome === 'dry-run', detail: r.reason };
+      },
+      emitDegraded: (m) => {
+        try {
+          DegradationReporter.getInstance().report({
+            feature: 'CredentialRebalancer', primary: 'autonomous balancer pass',
+            fallback: 'pass suspended (breaker / floor)', reason: m, impact: 'credential rebalancing degraded',
+          });
+        } catch { /* @silent-fallback-ok: degradation report is best-effort observability; a throwing reporter must never break the dark/dry-run pass */ }
+      },
+      emitAttention: (m) => {
+        void credentialAuditEmit.attention({
+          id: `credential-rebalancer-${credentialLocationLedger.version}`,
+          title: 'Credential rebalancer', summary: m, category: 'credential-repointing', priority: 'NORMAL',
+        });
+      },
+    });
     const credentialRepointing = {
       ledger: credentialLocationLedger,
       swapExecutor: credentialSwapExecutor,
@@ -9300,6 +9344,7 @@ export async function startServer(options: StartOptions): Promise<void> {
       audit: credentialAuditEmit,
       levers: credentialManualLevers,
       envTokenGate: credentialEnvTokenGate,
+      rebalancer: credentialRebalancer,
       readBlob: async (slot: string) => {
         const raw = await defaultKeychainExec.readService(credSwapService(slot));
         if (!raw) return null;
@@ -9312,6 +9357,25 @@ export async function startServer(options: StartOptions): Promise<void> {
         }
       },
     };
+
+    // B3b — the periodic balancer pass. tick() is a strict no-op while the feature resolves dark
+    // (so the timer can always run; the gate lives INSIDE tick()), and on a dev agent it runs the
+    // full decision loop in dry-run (zero writes). REENTRANCY-GUARDED: a slow tick never overlaps
+    // its successor. unref()'d so it never holds the process open. Interval clamped [1min, 60min].
+    let credRebalancerTickInFlight = false;
+    const credRebalancerPassMs = Math.min(
+      3_600_000,
+      Math.max(60_000, config.subscriptionPool?.credentialRepointing?.balancer?.passIntervalMs ?? 300_000),
+    );
+    const credRebalancerTimer = setInterval(() => {
+      if (credRebalancerTickInFlight) return; // reentrancy guard — skip if the prior tick is still running
+      credRebalancerTickInFlight = true;
+      void credentialRebalancer
+        .tick()
+        .catch((e) => console.warn(`[CredentialRebalancer] tick error: ${e instanceof Error ? e.message : String(e)}`))
+        .finally(() => { credRebalancerTickInFlight = false; });
+    }, credRebalancerPassMs);
+    credRebalancerTimer.unref?.();
 
     // QuotaPoller — per-account live quota reader (P1.2 of the Subscription &
     // Auth Standard). Reads each account's 5h/weekly utilization + reset dates

--- a/src/server/routes.ts
+++ b/src/server/routes.ts
@@ -676,6 +676,9 @@ export interface RouteContext {
     /** §2.10 env-token gate (Step 8) — refuses the feature (config field OR live env-token fleet)
      *  with a named reason surfaced on GET /credentials/rebalancer. */
     envTokenGate: import('../core/CredentialEnvTokenGate.js').CredentialEnvTokenGate;
+    /** B3b — the autonomous balancer (Increment B). Its `status()` is surfaced on
+     *  GET /credentials/rebalancer (last pass + breaker). Optional so tests can omit it. */
+    rebalancer?: import('../core/CredentialRebalancer.js').CredentialRebalancer;
     /** Raw-blob reader for a slot (restore-enrollment coherence probe). Injectable for tests. */
     readBlob?: (slot: string) => Promise<{ raw: string; oauth: import('../core/OAuthRefresher.js').ClaudeOauth | null } | null>;
   } | null;
@@ -19253,8 +19256,9 @@ export function createRoutes(ctx: RouteContext): Router {
     const verdict = cr.envTokenGate.evaluate();
     credSend(res, 200, {
       enabled: true,
-      // The balancer loop itself is Increment B — never running in Increment A regardless of the gate.
-      balancerWired: false,
+      // B3b: the balancer is now WIRED — surface its last-pass + breaker status.
+      balancerWired: !!cr.rebalancer,
+      rebalancer: cr.rebalancer ? cr.rebalancer.status() : null,
       envTokenGate: {
         refused: verdict.refused,
         // A named CATEGORY, not a credential; scrubbed regardless by credSend → audit.response.

--- a/tests/e2e/credential-repointing-routes-alive.test.ts
+++ b/tests/e2e/credential-repointing-routes-alive.test.ts
@@ -30,6 +30,8 @@ import { CredentialWriteFunnel } from '../../src/core/CredentialWriteFunnel.js';
 import { claudeCredentialService } from '../../src/core/OAuthRefresher.js';
 import type { InstarConfig } from '../../src/core/types.js';
 import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+import { CredentialRebalancer } from '../../src/core/CredentialRebalancer.js';
+import { mapSlots, mapAccounts, resolveRebalancerConfig } from '../../src/core/CredentialRebalancerSnapshot.js';
 
 const AUTH = 'test-e2e-cred-step7';
 const SLOT_A = '/h/.claude';
@@ -84,7 +86,17 @@ function buildRepointing(
     getAnthropicApiKey: () => envTokenOpts?.anthropicApiKey ?? '',
     listSessions: () => envTokenOpts?.fleet ?? [],
   });
-  return { ledger, swapExecutor, resolveIdentity: resolveAllow, audit, levers: new CredentialManualLevers(), envTokenGate };
+  // B3b — wire a real CredentialRebalancer just as the server composition root does, so the
+  // route's `balancerWired`/`rebalancer` surface is exercised on the production-shaped bundle.
+  const rebalancer = new CredentialRebalancer({
+    isEnabled: () => enabled && !envTokenGate.evaluate().refused,
+    isDryRun: () => true,
+    listSlots: () => mapSlots(ledger.getAssignments(), { defaultSlot: SLOT_A }),
+    listAccounts: () => mapAccounts([], Date.now()),
+    resolveConfig: () => resolveRebalancerConfig({ slotCount: 2, desiredDefaultAccountId: ledger.tenantOf(SLOT_A) ?? null }),
+    swap: async (a, b) => { const r = await swapExecutor.swap(a, b); return { ok: r.outcome === 'swapped' || r.outcome === 'dry-run', detail: r.reason }; },
+  });
+  return { ledger, swapExecutor, resolveIdentity: resolveAllow, audit, levers: new CredentialManualLevers(), envTokenGate, rebalancer };
 }
 
 describe('WS5.2 Step 7 /credentials/* E2E lifecycle (feature is alive)', () => {
@@ -182,7 +194,12 @@ describe('WS5.2 Step 7 /credentials/* E2E lifecycle (feature is alive)', () => {
     const r = await request(enabledApp).get('/credentials/rebalancer').set(auth());
     expect(r.status).toBe(200);
     expect(r.body.enabled).toBe(true);
-    expect(r.body.balancerWired).toBe(false); // the autonomous balancer is Increment B
+    // B3b: the balancer is now WIRED — its status surfaces (last pass + breaker).
+    expect(r.body.balancerWired).toBe(true);
+    expect(r.body.rebalancer).toBeTruthy();
+    expect(r.body.rebalancer.enabled).toBe(true);
+    expect(r.body.rebalancer.breaker.open).toBe(false);
+    expect(r.body.rebalancer.breaker.threshold).toBeGreaterThan(0);
     expect(r.body.envTokenGate.refused).toBe(false);
   });
 

--- a/upgrades/next/ws52-incb-b3b-wire.md
+++ b/upgrades/next/ws52-incb-b3b-wire.md
@@ -1,0 +1,32 @@
+# WS5.2 Increment B / B3b-wire — balancer wired into the server (dry-run on dev)
+
+<!-- bump: patch -->
+
+<!--
+  NOTE: wires the already-reviewed CredentialRebalancer orchestrator into the server
+  composition root + a reentrancy-guarded setInterval pass + the GET /credentials/rebalancer
+  status surface. Because the feature is re-gated live-on-dev-in-dry-run, the balancer now RUNS
+  on a dev agent every ~5min in dry-run (full decision loop + audit, ZERO credential writes);
+  the fleet is a strict no-op. No new write authority (the executor's dryRun is the write guard).
+  Second-pass reviewed (CONCUR).
+-->
+
+## What Changed
+
+Makes the autonomous balancer actually run — on a development agent, in dry-run — so it dogfoods its decisions instead of sitting as unwired code.
+
+- **Wired into the server** — the `CredentialRebalancer` is constructed in the credential-repointing bundle with the snapshot-mapper providers (ledger → slots, subscription pool → accounts, config resolver) and an `isEnabled` that mirrors the location gate exactly (dev-gate-resolved AND not env-token-refused). A reentrancy-guarded, interval-clamped (`[60s, 60min]`), `.unref()`'d `setInterval` runs the pass; tick errors are caught so a throw never crashes the loop.
+- **Live status surface** — `GET /credentials/rebalancer` now reports `balancerWired:true` + `rebalancer.status()` (enabled, the P19 breaker state, cooldown counts, and the last pass's decisions/degraded/attention) when the feature is live, scrubbed via the audit chokepoint; it stays a strict 503 no-op while dark.
+- **Dry-run dogfood, zero writes** — on a dev agent the loop runs the full decision loop and audits what it WOULD do, but the executor's `dryRun` default keeps every credential write off until a deliberate `dryRun:false`.
+
+## What to Tell Your User
+
+The automatic account-balancer is now actually running on me — but in dry-run, so it's all observation, no action. Every few minutes it looks at your quota picture, decides whether a login should move, and records what it WOULD do — moving zero real credentials. You can watch it at the rebalancer status endpoint (which account it would shuffle and why, plus its safety circuit-breaker). It only runs on a development agent like me (your wider fleet stays dark), and the step where it actually starts moving logins is still your deliberate switch, after the livetest. This is the dogfooding rung of the maturity path — it's live and watchable, with nothing irreversible happening.
+
+## Summary of New Capabilities
+
+The autonomous balancer (Increment B) is now wired + running in dry-run on a development agent. `GET /credentials/rebalancer` reports the live balancer status (last pass + P19 breaker). On a dev agent the balancer pass runs every ~5min (interval-clamped, reentrancy-guarded) computing + auditing its decisions; zero credential writes while `dryRun` holds (the default). The fleet stays dark (strict 503/no-op). No new write authority — the executor's dry-run gate is the load-bearing write guard.
+
+## Evidence
+
+- `tests/e2e/credential-repointing-routes-alive.test.ts` (6) — the rebalancer route now surfaces `balancerWired:true` + the live `rebalancer.status()` (enabled + breaker) on a production-shaped bundle with a real wired CredentialRebalancer; the dark path still 503s (strict no-op). tsc + full lint clean. Independent second-pass review CONCUR (gate mirrors the location gate; dry-run defaults true with the executor as the write guard; timer reentrancy-guarded/clamped/unref'd/error-caught; route is a leak-free 503-while-dark surface).

--- a/upgrades/side-effects/ws52-incb-b3b-wire.md
+++ b/upgrades/side-effects/ws52-incb-b3b-wire.md
@@ -1,0 +1,46 @@
+# Side-Effects Review — WS5.2 Increment B / B3b-wire: balancer wired into the server (dry-run on dev)
+
+**Version / slug:** `ws52-incb-b3b-wire`
+**Date:** 2026-06-13
+**Author:** echo
+**Second-pass reviewer:** independent reviewer subagent — CONCUR (wires autonomous-write actuation into the live server → Phase 5 required)
+
+## Summary of the change
+
+Wires the (already-reviewed) `CredentialRebalancer` orchestrator into the server composition root: constructs it in the `credentialRepointing` bundle (server.ts) with the snapshot-mapper providers + the re-gated `isEnabled`, schedules a reentrancy-guarded periodic `setInterval` pass, adds `rebalancer` to the bundle, and extends `GET /credentials/rebalancer` to report `rebalancer.status()` (last pass + breaker) alongside the env-token gate verdict. Because the feature is re-gated to live-on-dev-in-dry-run, on a DEV agent this loop now RUNS every ~5min in dry-run (full decision loop + audit, ZERO credential writes); on the fleet it is a strict no-op. This is the dogfooding the maturation path needs (CMT-1493). Real writes still require a deliberate `dryRun:false` (CMT-1494).
+
+## Decision-point inventory
+
+- `credentialRebalancer.tick()` (now scheduled) — the autonomous balancer pass, now LIVE-on-dev in dry-run. Its `isEnabled` mirrors the location gate exactly (dev-gate-resolved AND not env-token-refused); the destructive write is gated by the executor's own `dryRun` (default true). The orchestrator's decision/breaker logic was reviewed in B3a; this change is the WIRING.
+
+---
+
+## 1. Over-block
+No block/allow surface. Conservative direction preserved: the pass is a strict no-op whenever the feature is dark OR the env-token gate refuses; even when it runs (dev), the executor's dry-run gate blocks every write.
+
+## 2. Under-block
+The new exposure on a dev agent: the balancer loop now actuates decisions (in dry-run) every pass. The reviewer confirmed no path writes a credential without an explicit `dryRun:false`. The known operator-opt-in subtlety (an explicit `enabled:true` resolves the gate true even on a fleet agent) is the documented two-flag design and remains write-protected by the dry-run default.
+
+## 3. Level-of-abstraction fit
+Correct: the wiring layer holds ONLY the construction + scheduling; the decision is the pure policy's, the actuation is the gated executor's, the cross-pass state is the orchestrator's. The snapshot mappers (kept pure) translate live state. The setInterval is the thin "make it run" layer.
+
+## 4. Signal vs authority compliance
+- [x] Yes — the conservatively-bounded actuation authority the §2.4 Tier-0 justification sanctions: deterministic policy, oracle-verified reversible swaps, every pass audited, dark + dry-run-first. The wiring grants no NEW authority beyond scheduling the already-reviewed orchestrator under the unchanged gate. (Ref: docs/signal-vs-authority.md; §2.4.)
+
+## 5. Interactions
+- **Gate interaction:** `isEnabled` is byte-identical to the location gate, so the balancer and the QuotaPoller-attribution path agree on dark/live. The executor's own dark/dryRun gate is belt-and-suspenders.
+- **Timer:** reentrancy-guarded (a slow tick never overlaps), interval clamped [60s, 60min], `.unref()`'d (never holds the process open), tick errors caught (a throw never crashes the loop or sticks the in-flight flag).
+- **Route:** the dark path (`!credRepointEnabled()`) short-circuits to a 503 no-op BEFORE touching the rebalancer; the enabled path adds `balancerWired` + a leak-free `status()` (only enabled/breaker/cooldown counts + the last pass's slot/account/objective/reason — no token/blob material; scrubbed via `credSend → audit.response`).
+
+## 6. External surfaces
+- On a **dev agent**: `GET /credentials/rebalancer` now reports `balancerWired:true` + the live status, and the balancer runs its dry-run loop (visible in the audit + DegradationReporter/attention on a surfaced terminal state). Zero credential writes. On the **fleet**: byte-for-byte unchanged (dark 503; the unref'd timer's tick is a strict no-op).
+
+## 7. Multi-machine posture (Cross-Machine Coherence)
+- **Machine-local BY DESIGN.** Each machine schedules its own pass over its own ledger/pool/keychain snapshot; the in-memory cooldown/breaker state is per-process. No cross-machine input or coordination.
+
+## 8. Rollback cost
+Low. Revert the commit → the rebalancer is no longer constructed/scheduled and the route returns to `balancerWired:false`. No state, no migration, no credential touch (dry-run never wrote). Any swap the live balancer ever performs is the reversible, oracle-verified, dry-run-gated round-trip the executor owns.
+
+## Follow-ups (tracked, not orphaned)
+- An explicit operator default-account config + tmux-activity busyness for the drain target are dogfood refinements `<!-- tracked: 20905 -->` (B3b uses the current `~/.claude` tenant as the desired default and uniform busyness for now — safe in dry-run).
+- B4 (livetest tie-in) + the `dryRun:false` promotion decision are tracked as commitments CMT-1493 / CMT-1494.


### PR DESCRIPTION
## ELI16 — what this does in plain words

The automatic account-balancer now actually RUNS — on a development agent, in dry-run. Every ~5 minutes it looks at the quota picture, decides whether a login should move (to rescue a walling session or drain an expiring weekly allowance), and records what it WOULD do — moving **zero** real credentials. You can watch it at `GET /credentials/rebalancer` (which account it would shuffle and why, plus its circuit-breaker). The fleet stays dark; the step where it actually starts moving logins is still a deliberate `dryRun:false` switch, after the livetest. This is the dogfooding rung of the maturity path — live and watchable, nothing irreversible.

## What changed
- The `CredentialRebalancer` (reviewed in B3a) is constructed in the server's credential-repointing bundle with the snapshot-mapper providers + an `isEnabled` that mirrors the location gate exactly (dev-gate-resolved AND not env-token-refused).
- A reentrancy-guarded, interval-clamped `[60s, 60min]`, `.unref()`'d `setInterval` runs the pass; tick errors are caught so a throw never crashes the loop.
- `GET /credentials/rebalancer` reports `balancerWired:true` + `rebalancer.status()` (last pass + P19 breaker), scrubbed; strict 503 no-op while dark.

## Safety (independently second-pass reviewed — CONCUR)
- `isEnabled` is byte-identical to the location gate; the balancer never runs dark or env-token-refused.
- `isDryRun` defaults true; the executor's own `dryRun` is the load-bearing write guard — no path writes a credential without an explicit `dryRun:false`.
- Timer reentrancy-guarded / clamped / unref'd / error-caught; the route's status surface leaks no token material.

## Evidence
`credential-repointing-routes-alive` e2e (6) — the wired balancer status surfaces (`balancerWired:true` + breaker) on a production-shaped bundle; dark still 503s. tsc + full lint clean.

Spec: `docs/specs/live-credential-repointing-rebalancer.md` §2.4 (approved + converged).

Tracked follow-ups: explicit default-account config + tmux-activity busyness (dry-run refinements); B4 livetest + the `dryRun:false` promotion (CMT-1493 / CMT-1494).

🤖 Generated with [Claude Code](https://claude.com/claude-code)