### PR TITLE
feat(credential-repointing): WS5.2 Increment B / B4 — livetest battery entrypoint (promotion gate)

### DIFF
--- a/.instar/instar-dev-decisions/2026-06-13T23-35-26-787Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-06-13T23-35-26-787Z-unknown.json
@@ -1,0 +1,15 @@
+{
+  "ts": "2026-06-13T23:35:26.787Z",
+  "slug": "unknown",
+  "suggestedTier": 2,
+  "declaredTier": 2,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "new capability: new route (router.<verb>() added"
+  ],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 47,
+  "causalAutopsy": null,
+  "verdict": "pass"
+}

--- a/site/src/content/docs/architecture/under-the-hood.md
+++ b/site/src/content/docs/architecture/under-the-hood.md
@@ -706,3 +706,14 @@ accounts). Drives the automatable round-trips (identity-verified exchange-then-r
 always restoring) and surfaces the inherently-manual items (refresher correctness, the §0.c at-expiry
 residual via a disposable grant, liveness) without ever auto-passing them. An `armed` guard performs
 zero swaps unless explicitly armed, so importing or unit-testing the module can never move a credential.
+
+### POST /credentials/livetest (the promotion gate)
+
+`POST /credentials/livetest` is the reachable entrypoint for the §5 livetest battery (the
+`CredentialRepointingLivetest` harness) — the dry-run→live PROMOTION gate. It wires the harness to
+the real swap executor + identity oracle and runs the automatable round-trips. Two independent
+gates protect it: the harness performs ZERO swaps unless `armed:true` is in the request body (the
+operator explicitly arms the battery), and even armed the executor's own `dryRun` keeps writes off
+until a deliberate `dryRun:false`. Dark → 503; every named slot is validated against the enumerated
+ledger set (→ 400) before the harness runs. The report is scrubbed and carries no token material.
+

--- a/src/server/routes.ts
+++ b/src/server/routes.ts
@@ -19434,6 +19434,53 @@ export function createRoutes(ctx: RouteContext): Router {
     });
   });
 
+  // POST /credentials/livetest {armed, enrolledPair?, defaultSlotPair?} — B4: the §5 livetest
+  // battery as a REACHABLE entrypoint (the dry-run→live PROMOTION gate). Wires the
+  // CredentialRepointingLivetest harness to the REAL executor + identity oracle and runs the
+  // automatable round-trips. SAFETY: the harness performs ZERO swaps unless `armed:true` is in
+  // the body (the operator explicitly arms the battery), and even armed, the executor's own
+  // dryRun keeps writes off until a deliberate dryRun:false — so this is meaningful ONLY at the
+  // operator's enablement moment (it exchanges REAL credentials between REAL accounts). Dark →
+  // 503 (credLeverGuard); levers disabled → 403.
+  router.post('/credentials/livetest', async (req, res) => {
+    const cr = credLeverGuard(res);
+    if (!cr) return;
+    const body = (req.body ?? {}) as {
+      armed?: boolean;
+      enrolledPair?: { slotA: string; slotB: string };
+      defaultSlotPair?: { defaultSlot: string; enrolledSlot: string };
+    };
+    const { CredentialRepointingLivetest } = await import('../core/CredentialRepointingLivetest.js');
+    const members = new Set(cr.ledger.getAssignments().map((a) => a.slot));
+    const DEFAULT_SLOT = '~/.claude';
+    const enrolled = [...members].filter((s) => s !== DEFAULT_SLOT);
+    const enrolledPair = body.enrolledPair ?? { slotA: enrolled[0], slotB: enrolled[1] };
+    const defaultSlotPair = body.defaultSlotPair ?? { defaultSlot: DEFAULT_SLOT, enrolledSlot: enrolled[0] };
+    // Validate every named slot is a known ledger member (a value not in the enumerated set never
+    // reaches a keychain/path write — defence-in-depth; the executor also re-checks).
+    const named = [enrolledPair.slotA, enrolledPair.slotB, defaultSlotPair.defaultSlot, defaultSlotPair.enrolledSlot];
+    if (named.some((s) => typeof s !== 'string' || !members.has(s))) {
+      credSend(res, 400, { error: 'enrolledPair/defaultSlotPair must name known ledger slots', knownSlots: [...members] });
+      return;
+    }
+    const harness = new CredentialRepointingLivetest(
+      {
+        swap: async (a, b) => {
+          const r = await cr.swapExecutor.swap(a, b);
+          return { ok: r.outcome === 'swapped' || r.outcome === 'dry-run', detail: r.reason };
+        },
+        resolveIdentity: async (slot) => {
+          const probe = await cr.resolveIdentity(slot);
+          return { accountId: 'accountId' in probe ? probe.accountId : null };
+        },
+      },
+      { armed: body.armed === true },
+    );
+    cr.audit.audit({ event: 'credential-livetest-invoked', armed: body.armed === true });
+    const report = await harness.run(enrolledPair, defaultSlotPair);
+    credSend(res, 200, report);
+  });
+
   // ── Episodic Memory (Activity Sentinel) ──────────────────────────
 
   router.get('/episodes/stats', (req, res) => {

--- a/tests/integration/credential-routes.test.ts
+++ b/tests/integration/credential-routes.test.ts
@@ -240,4 +240,50 @@ describe('/credentials/* routes (integration)', () => {
     expect(await noauth('/credentials/restore-enrollment', { method: 'POST', body: '{}' })).toBe(401);
     expect(await noauth('/credentials/locations')).toBe(401);
   });
+
+  // ── B4 — the §5 livetest battery entrypoint (the dry-run→live promotion gate) ──
+  it('B4 livetest: DARK → POST /credentials/livetest 503 (no-op)', async () => {
+    const built = makeApp({ enabled: false }); stateDir = built.stateDir; cleanup.push(stateDir);
+    server = await listen(built.app);
+    expect((await api('/credentials/livetest', { method: 'POST', body: '{}' })).status).toBe(503);
+  });
+
+  it('B4 livetest: ENABLED + NOT armed → refused report, ZERO swaps', async () => {
+    const built = makeApp({ enabled: true }); stateDir = built.stateDir; cleanup.push(stateDir);
+    server = await listen(built.app);
+    const r = await api('/credentials/livetest', {
+      method: 'POST',
+      body: JSON.stringify({ enrolledPair: { slotA: SLOT_A, slotB: SLOT_B }, defaultSlotPair: { defaultSlot: SLOT_A, enrolledSlot: SLOT_B } }),
+    });
+    expect(r.status).toBe(200);
+    expect(r.body.armed).toBe(false);
+    expect(r.body.refusedReason).toMatch(/PROMOTION gate/);
+    expect(r.body.steps).toEqual([]);
+    expect(Array.isArray(r.body.manualSteps)).toBe(true);
+    expect(r.body.manualSteps.length).toBeGreaterThan(0);
+  });
+
+  it('B4 livetest: ENABLED + armed → runs the battery (armed report, steps present)', async () => {
+    const built = makeApp({ enabled: true }); stateDir = built.stateDir; cleanup.push(stateDir);
+    server = await listen(built.app);
+    const r = await api('/credentials/livetest', {
+      method: 'POST',
+      body: JSON.stringify({ armed: true, enrolledPair: { slotA: SLOT_A, slotB: SLOT_B }, defaultSlotPair: { defaultSlot: SLOT_A, enrolledSlot: SLOT_B } }),
+    });
+    expect(r.status).toBe(200);
+    expect(r.body.armed).toBe(true);
+    expect(Array.isArray(r.body.steps)).toBe(true);
+    expect(r.body.steps.length).toBe(2); // (a) enrolled + (b) default round-trips
+    expect(r.body.promotable).toBe(false); // manual items remain outstanding
+  });
+
+  it('B4 livetest: unknown slot → 400 (no harness run)', async () => {
+    const built = makeApp({ enabled: true }); stateDir = built.stateDir; cleanup.push(stateDir);
+    server = await listen(built.app);
+    const r = await api('/credentials/livetest', {
+      method: 'POST',
+      body: JSON.stringify({ enrolledPair: { slotA: '~/.does-not-exist', slotB: SLOT_B }, defaultSlotPair: { defaultSlot: SLOT_A, enrolledSlot: SLOT_B } }),
+    });
+    expect(r.status).toBe(400);
+  });
 });

--- a/upgrades/next/ws52-incb-b4-livetest-route.md
+++ b/upgrades/next/ws52-incb-b4-livetest-route.md
@@ -1,0 +1,31 @@
+# WS5.2 Increment B / B4 — the livetest battery entrypoint (promotion gate)
+
+<!-- bump: patch -->
+
+<!--
+  NOTE: adds POST /credentials/livetest — the reachable entrypoint for the §5 livetest battery
+  (the Step-10 CredentialRepointingLivetest harness), the dry-run→live promotion gate. A
+  credential-action route, but double-gated: ZERO swaps unless armed:true (harness), and even
+  armed ZERO writes unless dryRun:false (executor). Dark → 503; slots validated → 400. Second-pass
+  reviewed (CONCUR). Running it live is the operator's enablement moment (CMT-1494).
+-->
+
+## What Changed
+
+Completes Increment B's tooling with the promotion gate made reachable: `POST /credentials/livetest` runs the §5 livetest battery (the harness built in Step 10) against the real swap executor + identity oracle.
+
+- **Double-gated credential-action route.** A real credential move needs BOTH `armed:true` in the request body (the harness performs zero swaps otherwise) AND a deliberate `dryRun:false` (the executor writes nothing otherwise). Either gate alone keeps every credential untouched.
+- **Defence-in-depth.** Dark → 503 (the lever guard); every named slot is validated against the enumerated ledger set → 400 before the harness runs (a `../`/`~`/absolute path can't reach a write); the report is scrubbed and carries no token material.
+- **The report.** Surfaces the automatable round-trip verdicts (identity-verified exchange-then-restore, always restoring) and the inherently-manual items (refresher correctness, the §0.c residual via a disposable grant, liveness) — `promotable` stays false while any manual item remains.
+
+## What to Tell Your User
+
+The "is this safe to turn on?" check is now a button you can press when you're ready. It runs the real safety battery — a live account-swap and swap-back, verified with the trustworthy identity check, always restoring — and tells you whether the automatic moves landed correctly. Two separate safety catches protect it: it does nothing unless you explicitly arm it, and even armed it won't move a real credential until you've also flipped off dry-run. Two parts of the full battery are hands-on (waiting out a token refresh, stressing a throwaway login), which it lists for you. This is the last rung before the go/no-go: when you want to actually turn on real credential moves, you run this first, watch it pass, then decide.
+
+## Summary of New Capabilities
+
+`POST /credentials/livetest` — the reachable promotion gate for live credential re-pointing. Runs the §5 livetest battery against the real executor + oracle; double-gated (armed:true AND dryRun:false both required to move a real credential), dark → 503, slots validated → 400, report scrubbed. The operator-run last rung before the dry-run→live go/no-go.
+
+## Evidence
+
+- `tests/integration/credential-routes.test.ts` (+4 = 13) — DARK → 503; ENABLED + NOT armed → refused report with zero swaps + the manual items surfaced; ENABLED + armed → the battery runs (armed report, both round-trip steps present, promotable false); unknown slot → 400 (no harness run). tsc + full lint clean; docs-coverage route floor preserved. Independent second-pass review CONCUR (two independent gates intact — armed AND dryRun:false; dark 503s before construction; path-traversal slots rejected; report scrubbed; harness always-restores).

--- a/upgrades/side-effects/ws52-incb-b4-livetest-route.md
+++ b/upgrades/side-effects/ws52-incb-b4-livetest-route.md
@@ -1,0 +1,42 @@
+# Side-Effects Review — WS5.2 Increment B / B4: the livetest battery entrypoint (promotion gate)
+
+**Version / slug:** `ws52-incb-b4-livetest-route`
+**Date:** 2026-06-13
+**Author:** echo
+**Second-pass reviewer:** independent reviewer subagent — CONCUR (a credential-action route that can trigger real swaps → Phase 5 required)
+
+## Summary of the change
+
+Adds `POST /credentials/livetest` (src/server/routes.ts) — the reachable entrypoint for the §5 livetest battery (the Step-10 `CredentialRepointingLivetest` harness). It wires the harness to the REAL swap executor + identity oracle and runs the automatable round-trips (the dry-run→live PROMOTION gate). The destructive surface is protected by TWO independent gates: the harness performs ZERO swaps unless `armed:true` is in the body (the operator explicitly arms the battery), AND even armed, the executor's own `dryRun` keeps writes off until a deliberate `dryRun:false`. Dark → 503 (credLeverGuard); every named slot is validated against the enumerated ledger set (→ 400) before the harness runs. This completes Increment B's tooling — running the battery live is the operator's enablement moment (CMT-1494).
+
+## Decision-point inventory
+
+- `POST /credentials/livetest` — add — a credential-action entrypoint. It can trigger credential swaps, but ONLY when BOTH (a) `armed:true` (harness gate) AND (b) `dryRun:false` (executor gate, set only at construction, never touched by the route) hold. Both gates are independently reviewed (Step 10 harness armed-guard; Step 5 executor dryRun). The route adds only slot-validation + the dark gate.
+
+---
+
+## 1. Over-block
+No legitimate input is wrongly rejected: the slot validation rejects only values not in the enumerated ledger set (path-traversal `../`/`~`/absolute can't reach a write — the executor re-validates too). The dark 503 and the not-armed refusal are the conservative directions.
+
+## 2. Under-block
+The honest exposure: an operator with the Bearer token who arms the battery AND has flipped `dryRun:false` can move real credentials via this route — which is the INTENT (the promotion gate is the operator's enablement action). The reviewer confirmed no path moves a real credential without BOTH gates; the harness's always-restore leaves no residual exchange even on a forward-verify failure.
+
+## 3. Level-of-abstraction fit
+Correct: the route is a thin wrapper that wires the already-reviewed harness to the real executor + oracle. It holds no battery logic of its own (that's the harness) and no swap mechanics (that's the executor).
+
+## 4. Signal vs authority compliance
+- [x] Yes — but the authority is the operator's, exercised through two independent explicit gates (armed + dryRun:false). The route grants no autonomous authority; it is a manual, operator-armed entrypoint. (Ref: docs/signal-vs-authority.md.)
+
+## 5. Interactions
+- **Double-gate independence:** `armed` (request body) and `dryRun` (executor construction config) are independent; the route passes `armed` through and never overrides `dryRun`. Verified by integration tests (not-armed → refused/zero-swaps; the executor's dry-run path returns 'dry-run' with zero writes).
+- **Validation before run:** slot validation + the dark gate run BEFORE harness construction/run.
+- No shadowing/race — a manual, synchronous request.
+
+## 6. External surfaces
+- A new authenticated route. Dark → 503 (unchanged for a fleet/disabled agent). On a live (dev) agent, NOT armed → a refused report (zero swaps); armed → the battery runs (in dry-run, the round-trips report honestly that identities didn't exchange — real verification needs `dryRun:false`). The report is scrubbed via credSend and carries no token/blob material.
+
+## 7. Multi-machine posture (Cross-Machine Coherence)
+- **Machine-local BY DESIGN.** The battery validates THIS machine's keychain/slots before promoting THIS machine's feature; the route operates on the local ledger + executor + oracle. No cross-machine surface.
+
+## 8. Rollback cost
+Trivial. Revert the commit → the route is gone; no state, no migration. Any swap the armed+live battery ever performs is the reversible, oracle-verified, always-restored round-trip the executor + harness own.


### PR DESCRIPTION
## ELI16 — what this does in plain words

The "is this safe to turn on?" check is now a button you can press when you're ready. `POST /credentials/livetest` runs the real safety battery — a live account-swap and swap-back, verified with the trustworthy identity check, always restoring — and tells you whether the automatic moves land correctly. **Two separate safety catches** protect it: it does nothing unless you explicitly `armed:true` it, and even armed it won't move a real credential until you've also flipped `dryRun:false`. This is the last rung before the go/no-go on real credential moves.

## What changed
- New `POST /credentials/livetest` wires the Step-10 `CredentialRepointingLivetest` harness to the real swap executor + identity oracle.
- **Double-gated:** a real move needs BOTH `armed:true` (harness — zero swaps otherwise) AND `dryRun:false` (executor — zero writes otherwise). Either gate alone keeps every credential untouched.
- Defence-in-depth: dark → 503; every named slot validated against the enumerated ledger set → 400 (path-traversal can't reach a write); report scrubbed (no token material).

## Safety (independently second-pass reviewed — CONCUR)
- The two gates are independent and intact; no path moves a real credential without both `armed:true` and an explicit `dryRun:false`.
- credLeverGuard 503s before any harness construction; slots validated before the run; the harness always-restores (no residual exchange).

## Evidence
`credential-routes` integration (+4 = 13): dark→503, not-armed→refused/zero-swaps, armed→runs battery, unknown-slot→400. tsc + full lint clean; docs-coverage route floor preserved.

Spec: `docs/specs/live-credential-repointing-rebalancer.md` §5 (approved + converged). Running the battery live is the operator's enablement moment (CMT-1494).

🤖 Generated with [Claude Code](https://claude.com/claude-code)