### PR TITLE
feat(credential-repointing): balancer drain targets the busiest slot (real busyness signal)

### DIFF
--- a/.instar/instar-dev-decisions/2026-06-14T00-00-27-555Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-06-14T00-00-27-555Z-unknown.json
@@ -1,0 +1,13 @@
+{
+  "ts": "2026-06-14T00:00:27.555Z",
+  "slug": "unknown",
+  "suggestedTier": 2,
+  "declaredTier": 2,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 2,
+  "loc": 54,
+  "causalAutopsy": null,
+  "verdict": "pass"
+}

--- a/src/commands/server.ts
+++ b/src/commands/server.ts
@@ -9298,7 +9298,7 @@ export async function startServer(options: StartOptions): Promise<void> {
     // (dev-gate-resolved AND the §2.10 env-token gate), and the executor's own dryRun keeps it a
     // dry-run dogfood on a dev agent (full decision loop + audit, ZERO writes) until dryRun:false.
     const { CredentialRebalancer } = await import('../core/CredentialRebalancer.js');
-    const { mapSlots: credMapSlots, mapAccounts: credMapAccounts, resolveRebalancerConfig: credResolveBalancerConfig } =
+    const { mapSlots: credMapSlots, mapAccounts: credMapAccounts, resolveRebalancerConfig: credResolveBalancerConfig, computeBusynessBySlot: credComputeBusyness } =
       await import('../core/CredentialRebalancerSnapshot.js');
     const CRED_DEFAULT_SLOT = '~/.claude';
     const credentialRebalancer = new CredentialRebalancer({
@@ -9307,15 +9307,25 @@ export async function startServer(options: StartOptions): Promise<void> {
         resolveDevAgentGate(config.subscriptionPool?.credentialRepointing?.enabled, config) &&
         !credentialEnvTokenGate.evaluate().refused,
       isDryRun: () => config.subscriptionPool?.credentialRepointing?.dryRun !== false,
-      listSlots: () => credMapSlots(credentialLocationLedger.getAssignments(), { defaultSlot: CRED_DEFAULT_SLOT }),
+      // Busyness = count of RUNNING claude-code sessions per slot (the drain "busiest slot"
+      // signal), resolved from the live session list through the ledger's account→slot map.
+      listSlots: () =>
+        credMapSlots(credentialLocationLedger.getAssignments(), {
+          defaultSlot: CRED_DEFAULT_SLOT,
+          busynessBySlot: credComputeBusyness(
+            state.listSessions(),
+            (accountId) => credentialLocationLedger.slotOf(accountId),
+            CRED_DEFAULT_SLOT,
+          ),
+        }),
       listAccounts: () => credMapAccounts(subscriptionPool.list(), Date.now()),
       resolveConfig: () =>
         credResolveBalancerConfig({
           ...(config.subscriptionPool?.credentialRepointing?.balancer ?? {}),
           slotCount: credentialLocationLedger.getAssignments().length,
-          // Dry-run dogfood defaults: keep the account currently in ~/.claude as the desired
-          // default (objective-0 keeps it alive). An explicit operator default-account config +
-          // tmux-activity busyness for the drain target are refinements <!-- tracked: 20905 -->.
+          // Dry-run dogfood default: keep the account currently in ~/.claude as the desired
+          // default (objective-0 keeps it alive). An explicit operator default-account config
+          // is a refinement <!-- tracked: 20905 -->.
           desiredDefaultAccountId: credentialLocationLedger.tenantOf(CRED_DEFAULT_SLOT) ?? null,
         }),
       swap: async (a, b) => {

--- a/src/core/CredentialRebalancerSnapshot.ts
+++ b/src/core/CredentialRebalancerSnapshot.ts
@@ -99,6 +99,40 @@ export function mapSlots(assignments: readonly CredentialAssignment[], opts: Slo
   return assignments.map((a) => mapSlot(a, opts));
 }
 
+/** A session snapshot the busyness computation reads — only these three fields. */
+export interface BusynessSession {
+  status: string;
+  framework?: string;
+  /** The pool account this session launched under (→ its current slot via the ledger). */
+  subscriptionAccountId?: string;
+}
+
+/**
+ * Per-slot busyness = count of RUNNING claude-code sessions on each slot (the drain
+ * "busiest slot" signal, §2.4 — the balancer drains toward the busiest slot so an
+ * expiring weekly window is spent where the work actually is). A session's slot is its
+ * account's CURRENT slot (`slotOf(subscriptionAccountId)`); an UNTAGGED session (no pool
+ * account — the default interactive session) counts toward the default slot. Non-running
+ * or non-claude-code sessions don't count (only claude-code sessions read the credential
+ * store the balancer steers). Pure; the live wiring passes `state.listSessions()`.
+ */
+export function computeBusynessBySlot(
+  sessions: readonly BusynessSession[],
+  slotOf: (accountId: string) => string | null,
+  defaultSlot: string,
+): Record<string, number> {
+  const busy: Record<string, number> = {};
+  for (const s of sessions) {
+    if (s.status !== 'running') continue;
+    // Undefined framework = a legacy record (pre-framework-tag) — treat as claude-code (the
+    // default); only an EXPLICIT non-claude framework is excluded.
+    if (s.framework !== undefined && s.framework !== 'claude-code') continue;
+    const slot = s.subscriptionAccountId ? slotOf(s.subscriptionAccountId) : defaultSlot;
+    if (slot) busy[slot] = (busy[slot] ?? 0) + 1;
+  }
+  return busy;
+}
+
 function clamp(v: number | undefined, lo: number, hi: number, dflt: number): number {
   const n = typeof v === 'number' && Number.isFinite(v) ? v : dflt;
   return Math.min(hi, Math.max(lo, n));

--- a/tests/unit/credential-rebalancer-snapshot.test.ts
+++ b/tests/unit/credential-rebalancer-snapshot.test.ts
@@ -9,7 +9,7 @@
 
 import { describe, it, expect } from 'vitest';
 import {
-  mapAccountStatus, mapAccount, mapSlot, resolveRebalancerConfig,
+  mapAccountStatus, mapAccount, mapSlot, resolveRebalancerConfig, computeBusynessBySlot,
 } from '../../src/core/CredentialRebalancerSnapshot.js';
 import type { SubscriptionAccount } from '../../src/core/SubscriptionPool.js';
 import type { CredentialAssignment } from '../../src/core/CredentialLocationLedger.js';
@@ -116,5 +116,52 @@ describe('resolveRebalancerConfig', () => {
   it('passes through the desired default account id', () => {
     const c = resolveRebalancerConfig({ desiredDefaultAccountId: 'acct-D' });
     expect(c.desiredDefaultAccountId).toBe('acct-D');
+  });
+});
+
+describe('computeBusynessBySlot', () => {
+  // Account → slot map: A→slot-1, B→slot-2; an unknown account → null.
+  const slotOf = (a: string): string | null => (a === 'A' ? 'slot-1' : a === 'B' ? 'slot-2' : null);
+  const DEFAULT = '~/.claude';
+
+  it('counts RUNNING claude-code sessions per slot via the account→slot map', () => {
+    const busy = computeBusynessBySlot(
+      [
+        { status: 'running', framework: 'claude-code', subscriptionAccountId: 'A' },
+        { status: 'running', framework: 'claude-code', subscriptionAccountId: 'A' },
+        { status: 'running', framework: 'claude-code', subscriptionAccountId: 'B' },
+      ],
+      slotOf, DEFAULT,
+    );
+    expect(busy).toEqual({ 'slot-1': 2, 'slot-2': 1 });
+  });
+
+  it('attributes an UNTAGGED running session (no account) to the default slot', () => {
+    const busy = computeBusynessBySlot([{ status: 'running', framework: 'claude-code' }], slotOf, DEFAULT);
+    expect(busy).toEqual({ [DEFAULT]: 1 });
+  });
+
+  it('excludes non-running sessions', () => {
+    const busy = computeBusynessBySlot(
+      [{ status: 'stopped', framework: 'claude-code', subscriptionAccountId: 'A' }, { status: 'crashed', subscriptionAccountId: 'A' }],
+      slotOf, DEFAULT,
+    );
+    expect(busy).toEqual({});
+  });
+
+  it('excludes an EXPLICIT non-claude-code framework but counts an undefined (legacy) one', () => {
+    const busy = computeBusynessBySlot(
+      [
+        { status: 'running', framework: 'codex-cli', subscriptionAccountId: 'A' }, // excluded
+        { status: 'running', subscriptionAccountId: 'A' },                          // legacy → counted
+      ],
+      slotOf, DEFAULT,
+    );
+    expect(busy).toEqual({ 'slot-1': 1 });
+  });
+
+  it('drops a tagged session whose account has no current slot (slotOf null)', () => {
+    const busy = computeBusynessBySlot([{ status: 'running', framework: 'claude-code', subscriptionAccountId: 'GHOST' }], slotOf, DEFAULT);
+    expect(busy).toEqual({});
   });
 });

--- a/upgrades/next/ws52-busyness.md
+++ b/upgrades/next/ws52-busyness.md
@@ -1,0 +1,29 @@
+# WS5.2 balancer busyness signal — drain targets the busiest slot (dry-run refinement)
+
+<!-- bump: patch -->
+
+<!--
+  NOTE: resolves the tracked busyness follow-up for the Increment-B balancer. Pure
+  computeBusynessBySlot helper + a one-line server listSlots wiring change. Read-only signal;
+  affects only the §2.4 drain TARGET selection, dry-run on a dev agent (zero writes), dark on
+  the fleet. No new authority, no route, no config flag, no credential write path.
+-->
+
+## What Changed
+
+Makes the autonomous balancer's dry-run dogfooding produce meaningful drain decisions: the drain objective now targets the actually-busiest slot (real session-count signal) instead of an arbitrary one.
+
+- **`computeBusynessBySlot`** (src/core/CredentialRebalancerSnapshot.ts) — a pure helper: per-slot busyness = count of RUNNING claude-code sessions on each slot. A session's slot is its account's current slot (`ledger.slotOf`); an untagged session counts toward the default slot; non-running and explicit-non-claude sessions don't count.
+- **Wired into the balancer** — the server's `listSlots` provider now feeds this real busyness from the live session list, so the §2.4 drain objective deals an expiring weekly window to the slot where the work actually is. Read-only; dry-run on a dev agent (zero writes), dark on the fleet.
+
+## What to Tell Your User
+
+A small sharpening of the (still off-by-default, dry-run) account-balancer so what you watch is actually meaningful: when it considers draining an account whose weekly allowance is about to expire, it now sends that work to whichever of your config slots is genuinely busiest right now, instead of picking one arbitrarily. Nothing moves — it's still dry-run, still observation only — but the decisions you'd watch at the rebalancer status endpoint now reflect real activity, which is exactly the signal that builds confidence before you decide whether to turn on real moves.
+
+## Summary of New Capabilities
+
+No new runtime capability — a read-only refinement to the Increment-B balancer's dry-run decisions. New internal helper `computeBusynessBySlot` feeds real per-slot busyness (count of running claude-code sessions) into the balancer's drain-target selection. No route, no config flag, no credential write path; dry-run on dev, dark on fleet.
+
+## Evidence
+
+- `tests/unit/credential-rebalancer-snapshot.test.ts` (+5 = 15) — counts running claude-code sessions per slot via the account→slot map; untagged session → default slot; non-running excluded; explicit-non-claude excluded but legacy (undefined framework) counted; a tagged session whose account has no current slot is dropped. tsc + full lint clean.

--- a/upgrades/side-effects/ws52-busyness.md
+++ b/upgrades/side-effects/ws52-busyness.md
@@ -1,0 +1,38 @@
+# Side-Effects Review — WS5.2 balancer busyness signal (drain-target refinement)
+
+**Version / slug:** `ws52-busyness`
+**Date:** 2026-06-13
+**Author:** echo
+**Second-pass reviewer:** not required (a pure read-only data-signal helper + thin wiring; no gate/sentinel/lifecycle/write surface; the balancer it feeds is already dry-run-gated + B3a-reviewed)
+
+## Summary of the change
+
+Resolves the tracked busyness follow-up for the autonomous balancer (Increment B). Adds a pure `computeBusynessBySlot(sessions, slotOf, defaultSlot)` to `CredentialRebalancerSnapshot.ts` — per-slot busyness = count of RUNNING claude-code sessions on each slot (a session's slot is its account's current slot via `ledger.slotOf`; an untagged session counts toward the default slot; non-running / explicit-non-claude sessions don't count). Wires it into the server's `listSlots` provider so the balancer's drain objective targets the actually-busiest slot (real signal) instead of uniform-0. Read-only; affects only the §2.4 drain TARGET selection, and only in dry-run on a dev agent (zero credential writes).
+
+## Decision-point inventory
+
+- `CredentialRebalancerPolicy` drain-target selection (objective 2) — now fed a real busyness signal instead of uniform 0. No new decision point; it sharpens an existing one (which busy slot a drain deals to). No authority change; the balancer remains dry-run-gated.
+
+---
+
+## 1. Over-block / ## 2. Under-block
+No block/allow surface. The signal only orders drain TARGET candidates; a wrong count would at worst pick a sub-optimal busy slot to drain to (still a valid eligible slot), and only in dry-run.
+
+## 3. Level-of-abstraction fit
+Correct: the busyness computation is a pure mapper in the snapshot module (alongside mapSlot/mapAccount), kept out of server.ts so a counting bug is unit-testable. The server wiring is a one-line provider change passing `state.listSessions()` + the ledger's `slotOf`.
+
+## 4. Signal vs authority compliance
+- [x] No — a read-only data-signal helper; no block/allow surface, no authority. (Ref: docs/signal-vs-authority.md.)
+
+## 5. Interactions
+- Feeds only the policy's drain `busyness` field (already consumed; previously always 0). No shadowing/race — pure, computed fresh each pass from the live session list.
+- The untagged-session-→-default-slot attribution is a deliberate choice (the default interactive session runs on the default account); documented.
+
+## 6. External surfaces
+- None directly. The balancer's `GET /credentials/rebalancer` status (and its dry-run audit) will now reflect drain decisions that target the busiest slot — observably better dogfooding signal, still zero writes (dry-run on dev; dark on fleet).
+
+## 7. Multi-machine posture (Cross-Machine Coherence)
+- **Machine-local BY DESIGN.** Busyness is computed from THIS machine's live session list + THIS machine's ledger; per-machine. No cross-machine input.
+
+## 8. Rollback cost
+Trivial. Revert → the balancer falls back to uniform busyness (drain picks the first eligible busy slot). No state, no migration, no credential touch.


### PR DESCRIPTION
## ELI16 — what this does in plain words

A small sharpening of the (still off-by-default, dry-run) account-balancer so what you watch is actually meaningful: when it considers draining an account whose weekly allowance is about to expire, it now sends that work to whichever of your config slots is genuinely busiest right now, instead of picking one arbitrarily. Nothing moves — still dry-run, observation only — but the decisions at the rebalancer status endpoint now reflect real activity, the signal that builds confidence before you decide on real moves.

## What changed
- New pure `computeBusynessBySlot(sessions, slotOf, defaultSlot)` — per-slot busyness = count of RUNNING claude-code sessions on each slot (a session's slot = its account's current slot via `ledger.slotOf`; an untagged session → the default slot; non-running / explicit-non-claude excluded, legacy/undefined-framework counted).
- Wired into the server's `listSlots` provider from the live session list, so the §2.4 drain objective deals to the busiest slot. Read-only; dry-run on dev (zero writes), dark on fleet. No new authority, no route, no config flag, no write path.

## Evidence
`credential-rebalancer-snapshot` (+5 = 15): per-slot counts via the account→slot map; untagged → default; non-running excluded; explicit-non-claude excluded but legacy counted; no-slot dropped. tsc + full lint clean.

Resolves the tracked busyness follow-up; spec `docs/specs/live-credential-repointing-rebalancer.md` §2.4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)