### PR TITLE
feat(multi-machine): dev-gate the 7 stateSync memory stores (live-on-dev, dark-fleet) (topic 13481)

### DIFF
--- a/.instar/instar-dev-decisions/2026-06-14T04-38-35-625Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-06-14T04-38-35-625Z-unknown.json
@@ -1,0 +1,17 @@
+{
+  "ts": "2026-06-14T04:38:35.625Z",
+  "slug": "unknown",
+  "suggestedTier": 2,
+  "declaredTier": 2,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "irreversibility: src/core/PostUpdateMigrator.ts touches PostUpdateMigrator",
+    "migration / fleet-rollout surface: src/core/PostUpdateMigrator.ts touches PostUpdateMigrator (fleet migration machinery)",
+    "new capability: new config key added"
+  ],
+  "belowFloor": false,
+  "files": 6,
+  "loc": 391,
+  "causalAutopsy": null,
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-06-14T04-39-05-448Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-06-14T04-39-05-448Z-unknown.json
@@ -1,0 +1,17 @@
+{
+  "ts": "2026-06-14T04:39:05.448Z",
+  "slug": "unknown",
+  "suggestedTier": 2,
+  "declaredTier": 2,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "irreversibility: src/core/PostUpdateMigrator.ts touches PostUpdateMigrator",
+    "migration / fleet-rollout surface: src/core/PostUpdateMigrator.ts touches PostUpdateMigrator (fleet migration machinery)",
+    "new capability: new config key added"
+  ],
+  "belowFloor": false,
+  "files": 6,
+  "loc": 391,
+  "causalAutopsy": null,
+  "verdict": "pass"
+}

--- a/.instar/instar-dev-decisions/2026-06-14T04-39-48-498Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-06-14T04-39-48-498Z-unknown.json
@@ -1,0 +1,17 @@
+{
+  "ts": "2026-06-14T04:39:48.498Z",
+  "slug": "unknown",
+  "suggestedTier": 2,
+  "declaredTier": 2,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "irreversibility: src/core/PostUpdateMigrator.ts touches PostUpdateMigrator",
+    "migration / fleet-rollout surface: src/core/PostUpdateMigrator.ts touches PostUpdateMigrator (fleet migration machinery)",
+    "new capability: new config key added"
+  ],
+  "belowFloor": false,
+  "files": 6,
+  "loc": 394,
+  "causalAutopsy": null,
+  "verdict": "pass"
+}

--- a/.instar/instar-dev-decisions/2026-06-14T04-40-58-478Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-06-14T04-40-58-478Z-unknown.json
@@ -1,0 +1,17 @@
+{
+  "ts": "2026-06-14T04:40:58.478Z",
+  "slug": "unknown",
+  "suggestedTier": 2,
+  "declaredTier": 2,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "irreversibility: src/core/PostUpdateMigrator.ts touches PostUpdateMigrator",
+    "migration / fleet-rollout surface: src/core/PostUpdateMigrator.ts touches PostUpdateMigrator (fleet migration machinery)",
+    "new capability: new config key added"
+  ],
+  "belowFloor": false,
+  "files": 6,
+  "loc": 394,
+  "causalAutopsy": null,
+  "verdict": "pass"
+}

--- a/src/commands/server.ts
+++ b/src/commands/server.ts
@@ -18,7 +18,7 @@ import pc from 'picocolors';
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 import { loadConfig, ensureStateDir, detectTmuxPath, detectGeminiPath } from '../core/Config.js';
 import { isNonFatalUncaught, shouldLogStackForUncaught } from '../core/uncaughtExceptionPolicy.js';
-import { resolveDevAgentGate } from '../core/devAgentGate.js';
+import { resolveDevAgentGate, resolveStateSyncStores } from '../core/devAgentGate.js';
 import { parseProfileTrigger, platformMessageIdFrom } from '../core/topicProfileIngress.js';
 import {
   TopicProfileOrchestrator,
@@ -3720,9 +3720,21 @@ export async function startServer(options: StartOptions): Promise<void> {
     });
     void storeSnapshotEngine; // consumed by the state-snapshot mesh handler below + the store PRs (WS2.1+)
 
+    // The 7 stateSync memory stores follow the developmentAgent dark-feature gate
+    // (operator directive 2026-06-13, topic 13481): their ConfigDefaults OMIT
+    // `enabled` so the gate decides — LIVE on a dev agent, DARK on the fleet. Resolve
+    // the gate ONCE here so every consumer funnel below (selfStateSyncReceive, the 7
+    // union readers, checkPoolFlagCoherence) receives a stores map whose per-store
+    // `enabled` is already the resolved boolean — the funnels keep their unchanged
+    // `enabled === true` semantics but now see a live flag on a dev agent. An explicit
+    // operator `enabled` in config still wins (force-dark false / fleet-flip true).
+    const _stateSyncStoresResolved = resolveStateSyncStores(
+      config as { developmentAgent?: boolean; multiMachine?: { stateSync?: Record<string, { enabled?: boolean } & Record<string, unknown>> } },
+    ) as import('../core/ReplicatedRecordEnvelope.js').StateSyncStores | undefined;
+
     const selfStateSyncReceive = (): Record<string, boolean> => {
       const out: Record<string, boolean> = {};
-      const stores = (config.multiMachine as unknown as { stateSync?: Record<string, { enabled?: boolean }> } | undefined)?.stateSync;
+      const stores = _stateSyncStoresResolved;
       for (const store of replicatedKindRegistry.stores()) {
         // Advertise the receive capability iff the machinery exists (kind
         // registered) AND the store is enabled here — so a peer never forwards a
@@ -3780,7 +3792,7 @@ export async function startServer(options: StartOptions): Promise<void> {
     const { prefEntryToOriginRecord, prefTierOf, PREF_STORE_KEY } = await import('../core/PreferencesReplicatedStore.js');
     const preferencesUnionReader = new ReplicatedStoreReader({
       registry: replicatedKindRegistry,
-      stores: (config.multiMachine as unknown as { stateSync?: import('../core/ReplicatedRecordEnvelope.js').StateSyncStores } | undefined)?.stateSync,
+      stores: _stateSyncStoresResolved, // gate-resolved (dev-live / fleet-dark) per operator directive 2026-06-13
       tierOf: prefTierOf,
       loadOriginRecords: (store, recordKey) => {
         if (store !== PREF_STORE_KEY || _meshSelfId === null) return [];
@@ -3819,7 +3831,7 @@ export async function startServer(options: StartOptions): Promise<void> {
     const { relationshipTierOf, relationshipToOriginRecord, deriveRelationshipRecordKey, mergeUnionToRelationships, renderForeignRelationshipContext, RELATIONSHIP_STORE_KEY } = await import('../core/RelationshipsReplicatedStore.js');
     const relationshipsUnionReader = new ReplicatedStoreReader({
       registry: replicatedKindRegistry,
-      stores: (config.multiMachine as unknown as { stateSync?: import('../core/ReplicatedRecordEnvelope.js').StateSyncStores } | undefined)?.stateSync,
+      stores: _stateSyncStoresResolved, // gate-resolved (dev-live / fleet-dark) per operator directive 2026-06-13
       tierOf: relationshipTierOf,
       loadOriginRecords: (store, recordKey) => {
         if (store !== RELATIONSHIP_STORE_KEY || _meshSelfId === null || !relationships) return [];
@@ -8252,7 +8264,7 @@ export async function startServer(options: StartOptions): Promise<void> {
     const { learningTierOf, learningToOriginRecord, deriveLearningRecordKey, LEARNING_STORE_KEY } = await import('../core/LearningsReplicatedStore.js');
     const learningsUnionReader = new ReplicatedStoreReader({
       registry: replicatedKindRegistry,
-      stores: (config.multiMachine as unknown as { stateSync?: import('../core/ReplicatedRecordEnvelope.js').StateSyncStores } | undefined)?.stateSync,
+      stores: _stateSyncStoresResolved, // gate-resolved (dev-live / fleet-dark) per operator directive 2026-06-13
       tierOf: learningTierOf,
       loadOriginRecords: (store, recordKey) => {
         if (store !== LEARNING_STORE_KEY || _meshSelfId === null) return [];
@@ -8303,7 +8315,7 @@ export async function startServer(options: StartOptions): Promise<void> {
     } = await import('../core/KnowledgeReplicatedStore.js');
     const knowledgeUnionReader = new ReplicatedStoreReader({
       registry: replicatedKindRegistry,
-      stores: (config.multiMachine as unknown as { stateSync?: import('../core/ReplicatedRecordEnvelope.js').StateSyncStores } | undefined)?.stateSync,
+      stores: _stateSyncStoresResolved, // gate-resolved (dev-live / fleet-dark) per operator directive 2026-06-13
       tierOf: knowledgeTierOf,
       loadOriginRecords: (store, recordKey) => {
         if (store !== KNOWLEDGE_STORE_KEY || _meshSelfId === null) return [];
@@ -8352,7 +8364,7 @@ export async function startServer(options: StartOptions): Promise<void> {
     } = await import('../core/EvolutionActionsReplicatedStore.js');
     const evolutionActionsUnionReader = new ReplicatedStoreReader({
       registry: replicatedKindRegistry,
-      stores: (config.multiMachine as unknown as { stateSync?: import('../core/ReplicatedRecordEnvelope.js').StateSyncStores } | undefined)?.stateSync,
+      stores: _stateSyncStoresResolved, // gate-resolved (dev-live / fleet-dark) per operator directive 2026-06-13
       tierOf: evolutionActionTierOf,
       loadOriginRecords: (store, recordKey) => {
         if (store !== EVOLUTION_ACTION_STORE_KEY || _meshSelfId === null) return [];
@@ -8394,7 +8406,7 @@ export async function startServer(options: StartOptions): Promise<void> {
     const { userTierOf, userToOriginRecord, deriveUserRecordKey, USER_STORE_KEY } = await import('../core/UserRegistryReplicatedStore.js');
     const userRegistryUnionReader = new ReplicatedStoreReader({
       registry: replicatedKindRegistry,
-      stores: (config.multiMachine as unknown as { stateSync?: import('../core/ReplicatedRecordEnvelope.js').StateSyncStores } | undefined)?.stateSync,
+      stores: _stateSyncStoresResolved, // gate-resolved (dev-live / fleet-dark) per operator directive 2026-06-13
       tierOf: userTierOf,
       loadOriginRecords: (store, recordKey) => {
         if (store !== USER_STORE_KEY || _meshSelfId === null) return [];
@@ -8436,7 +8448,7 @@ export async function startServer(options: StartOptions): Promise<void> {
     const { topicOperatorTierOf, topicOperatorToOriginRecord, deriveTopicOperatorRecordKey, TOPIC_OPERATOR_STORE_KEY } = await import('../core/TopicOperatorReplicatedStore.js');
     const topicOperatorUnionReader = new ReplicatedStoreReader({
       registry: replicatedKindRegistry,
-      stores: (config.multiMachine as unknown as { stateSync?: import('../core/ReplicatedRecordEnvelope.js').StateSyncStores } | undefined)?.stateSync,
+      stores: _stateSyncStoresResolved, // gate-resolved (dev-live / fleet-dark) per operator directive 2026-06-13
       tierOf: topicOperatorTierOf,
       loadOriginRecords: (store, recordKey) => {
         if (store !== TOPIC_OPERATOR_STORE_KEY || _meshSelfId === null) return [];
@@ -13957,7 +13969,7 @@ export async function startServer(options: StartOptions): Promise<void> {
                 online: c.online,
                 stateSyncReceive: c.seamlessnessFlags?.stateSyncReceive,
               }));
-            const stores = (config.multiMachine as unknown as { stateSync?: import('../core/ReplicatedRecordEnvelope.js').StateSyncStores } | undefined)?.stateSync;
+            const stores = _stateSyncStoresResolved; // gate-resolved (dev-live / fleet-dark) per operator directive 2026-06-13
             const verdict = checkPoolFlagCoherence(replicatedKindRegistry, stores, peers);
             if (verdict.mixedStores.length > 0) {
               // Surface ONCE (coalesced): one log line listing every mixed store.

--- a/src/config/ConfigDefaults.ts
+++ b/src/config/ConfigDefaults.ts
@@ -918,104 +918,79 @@ const SHARED_DEFAULTS: Record<string, unknown> = {
       maxDriftMs: 300000, // 5 min — the §3.4 default, within the [60s,15min] clamp
       maxCachedSnapshots: 16, // §8.2 snapshot-cache count ceiling
       maxCacheBytes: 67108864, // 64 MiB — §8.2 snapshot-cache byte ceiling (reconciled to spec §8.2 from the 32 MiB Step-2 literal)
-      // WS2.1 (multi-machine-replicated-store-foundation §4/§10.1) — the FIRST
-      // concrete replicated-store consumer: `pref-record` on the HLC foundation.
-      // Per-store on-switch ships the graduated-rollout ladder dark:
-      // `enabled:false` (the foundation primitives stay inert) + `dryRun:true` (on
-      // first enable, log intended merges WITHOUT mutating store state). A literal
-      // `enabled:false` (NOT dev-gate-omit) per the spec ladder dark→dryRun→live —
-      // classified in DARK_GATE_EXCLUSIONS (optional-integration, staged rollout),
-      // mirroring multiMachine.sessionPool.inboundQueue. SUPERSEDES the legacy
-      // seamlessness path (CMT-1416), both dark ⇒ zero runtime duplication.
+      // ── The 7 stateSync memory stores follow the developmentAgent dark-feature
+      //    gate (standard_development_agent_dark_feature_gate), MOVED from
+      //    DARK_GATE_EXCLUSIONS on 2026-06-13 per operator directive topic 13481:
+      //    "NOTHING should ship dark on development agents — every multi-machine
+      //    feature must be live on dev agents so it actually gets tested, not rot."
+      //    Each store OMITS `enabled` so resolveDevAgentGate decides at runtime —
+      //    LIVE on a dev agent (Echo/the Mini, the dogfooding ground), DARK on the
+      //    fleet. A literal `enabled: false` would force-dark dev agents too (the
+      //    #1001 shape the §12.5 dark-gate lint forbids for a dev-gated block) — so
+      //    it is OMITTED, NOT baked false. The four consumer funnels
+      //    (selfStateSyncReceive, ReplicatedStoreReader.isLive, isStoreEmissionEnabled,
+      //    and the /preferences/session-context route) read the gate-RESOLVED stores
+      //    map built at the construction boundary in server.ts (resolveStateSyncStores),
+      //    so the gate genuinely flips them live — not just registry array-shuffling.
+      //    UNLIKE credentialRepointing (whose keychain WRITE is destructive, so it keeps
+      //    dryRun:true as the write-safety canary), these stores replicate between the
+      //    operator's OWN machines with NO external egress and NO destructive/irreversible
+      //    write — fully reversible via the foundation's rollback-unmerge (disabling a
+      //    store atomically drops that origin's contribution). A dry-run would defeat
+      //    "actually gets tested", so `dryRun: false` (genuinely live). An operator's
+      //    EXPLICIT `enabled` in .instar/config.json remains the documented force-dark /
+      //    fleet-flip override. applyDefaults is add-missing-only deep-merge, so existing
+      //    agents backfill these on update (Migration Parity) and an operator's existing
+      //    values are NEVER overwritten.
+      // WS2.1 (multi-machine-replicated-store-foundation §4/§10.1) — `pref-record`.
+      // SUPERSEDES the legacy seamlessness path (CMT-1416).
       preferences: {
-        enabled: false,
-        dryRun: true,
+        dryRun: false,
       },
-      // WS2.3 (ws23-relationships-userregistry-security) — the SECOND replicated-
-      // store consumer and the FIRST PII kind: `relationship-record` on the HLC
-      // foundation. Per-store on-switch ships the graduated-rollout ladder dark:
-      // `enabled:false` (the foundation primitives stay inert, NO PII ever crosses
-      // a machine boundary) + `dryRun:true` (on first enable, log intended merges
-      // WITHOUT mutating store state). A literal `enabled:false` (NOT dev-gate-omit)
-      // per the spec ladder dark→dryRun→live — classified in DARK_GATE_EXCLUSIONS
-      // (optional-integration, staged rollout), mirroring the preferences sibling.
-      // user-registry + topic-operator (the spec's other two PII kinds) are a
-      // tracked follow-up (CMT-1416) on the proven relationship-record machinery.
+      // WS2.3 (ws23-relationships-userregistry-security) — `relationship-record`, the
+      // FIRST PII kind. Every replicated field is type-clamped on receive; a peer
+      // record is quoted UNTRUSTED data, never the authoritative "who is messaging me";
+      // a delete propagates a tombstone. PII crosses ONLY between the operator's own
+      // machines (transit-encrypted).
       relationships: {
-        enabled: false,
-        dryRun: true,
+        dryRun: false,
       },
-      // WS2.2 (multi-machine-replicated-store-foundation) — the THIRD replicated-store
-      // consumer and the SECOND memory-family kind: `learning-record` on the HLC
-      // foundation. Per-store on-switch ships the graduated-rollout ladder dark:
-      // `enabled:false` (the foundation primitives stay inert, NO learning ever crosses
-      // a machine boundary; the local LRN-NNN id is NEVER replicated) + `dryRun:true`
-      // (on first enable, log intended merges WITHOUT mutating store state). A literal
-      // `enabled:false` (NOT dev-gate-omit) per the spec ladder dark→dryRun→live —
-      // classified in DARK_GATE_EXCLUSIONS (optional-integration, staged rollout),
-      // mirroring the relationships sibling. WS2.4 (KB) / WS2.5 (evolution) / WS2.6
-      // (playbook) reduce to schema+projection+flag on this same machinery (CMT-1416).
+      // WS2.2 (multi-machine-replicated-store-foundation) — `learning-record`, the SECOND
+      // memory-family kind. The local LRN-NNN id is NEVER replicated (the recordKey is a
+      // content fingerprint).
       learnings: {
-        enabled: false,
-        dryRun: true,
+        dryRun: false,
       },
-      // WS2.4 (multi-machine-replicated-store-foundation) — the FOURTH replicated-store
-      // consumer and the THIRD memory-family kind: `knowledge-record` on the HLC
-      // foundation. Per-store on-switch ships the graduated-rollout ladder dark:
-      // `enabled:false` (the foundation primitives stay inert, NO knowledge source ever
-      // crosses a machine boundary; the local generated id + filePath are NEVER replicated
-      // — only the catalog metadata, never the file body) + `dryRun:true` (on first enable,
-      // log intended merges WITHOUT mutating store state). A literal `enabled:false` (NOT
-      // dev-gate-omit) per the spec ladder dark→dryRun→live — classified in
-      // DARK_GATE_EXCLUSIONS (optional-integration, staged rollout), mirroring the
-      // learnings sibling. Full-content-body sync (beyond catalog metadata) is a tracked
-      // follow-up (CMT-1416).
+      // WS2.4 (multi-machine-replicated-store-foundation) — `knowledge-record`, the THIRD
+      // memory-family kind. Only catalog METADATA crosses (NEVER the file body or the
+      // local path); the local generated id is never replicated.
       knowledge: {
-        enabled: false,
-        dryRun: true,
+        dryRun: false,
       },
-      // WS2.5 (multi-machine-replicated-store-foundation) — the FIFTH replicated-store
-      // consumer and the FOURTH memory-family kind: `evolution-action-record` on the HLC
-      // foundation (the agent's self-improvement action queue). Per-store on-switch ships the
-      // graduated-rollout ladder dark: `enabled:false` (the foundation primitives stay inert,
-      // NO action ever crosses a machine boundary; the local ACT-NNN id is NEVER replicated) +
-      // `dryRun:true` (on first enable, log intended merges WITHOUT mutating store state). A
-      // literal `enabled:false` (NOT dev-gate-omit) per the spec ladder dark→dryRun→live —
-      // classified in DARK_GATE_EXCLUSIONS (optional-integration, staged rollout), mirroring
-      // the knowledge sibling. The load-bearing cross-machine field is `status` — a peer must
-      // SEE an action was already completed/in_progress elsewhere so it does not redo it.
+      // WS2.5 (multi-machine-replicated-store-foundation) — `evolution-action-record`, the
+      // FOURTH memory-family kind (the agent's self-improvement action queue). The local
+      // ACT-NNN id is NEVER replicated; the load-bearing cross-machine field is `status` —
+      // a peer must SEE an action was already completed/in_progress elsewhere so it does
+      // not redo it.
       evolutionActions: {
-        enabled: false,
-        dryRun: true,
+        dryRun: false,
       },
-      // WS2.6 (multi-machine-replicated-store-foundation) — the SIXTH replicated-store
-      // consumer and the SECOND PII kind: `user-record` on the HLC foundation (the multi-user
-      // registry the UserManager resolves an inbound message to). Per-store on-switch ships the
-      // graduated-rollout ladder dark: `enabled:false` (the foundation primitives stay inert, NO
-      // user PII ever crosses a machine boundary; the local userId is NEVER replicated — the
-      // recordKey is the channel-set identity surface) + `dryRun:true` (on first enable, log
-      // intended merges WITHOUT mutating store state). A literal `enabled:false` (NOT dev-gate-
-      // omit) per the spec ladder dark→dryRun→live — classified in DARK_GATE_EXCLUSIONS
-      // (optional-integration, staged rollout), mirroring the relationships sibling. Completes the
-      // WS2 memory family alongside topicOperator (CMT-1416).
+      // WS2.6 (multi-machine-replicated-store-foundation) — `user-record`, the SECOND PII
+      // kind (the multi-user registry). The local userId is NEVER replicated — the recordKey
+      // is the channel-set identity surface; inbound-principal RESOLUTION stays LOCAL-ONLY
+      // (the local channel index is always authoritative). User PII crosses ONLY between the
+      // operator's own machines (transit-encrypted).
       userRegistry: {
-        enabled: false,
-        dryRun: true,
+        dryRun: false,
       },
-      // WS2.6 (multi-machine-replicated-store-foundation) — the SEVENTH replicated-store consumer
-      // and the THIRD PII kind: `topic-operator-record` on the HLC foundation (which VERIFIED
-      // operator a topic was bound to). Per-store on-switch ships the graduated-rollout ladder
-      // dark: `enabled:false` (the foundation primitives stay inert, NO operator binding ever
-      // crosses a machine boundary; the recordKey is sha256(topicId + ":" + verified-uid), NEVER a
-      // content-name) + `dryRun:true`. A literal `enabled:false` (NOT dev-gate-omit) per the spec
-      // ladder dark→dryRun→live — classified in DARK_GATE_EXCLUSIONS (optional-integration, staged
-      // rollout), mirroring the userRegistry sibling. THE LOAD-BEARING SAFETY INVARIANT: a
-      // replicated topic-operator record is UNTRUSTED peer data — NEVER this machine's
-      // authoritative answer to "who is my verified operator?" (only the local authenticated
-      // setOperator binds the principal; Know-Your-Principal).
+      // WS2.6 (multi-machine-replicated-store-foundation) — `topic-operator-record`, the
+      // THIRD PII kind (which VERIFIED operator a topic was bound to). The recordKey is
+      // sha256(topicId + ":" + verified-uid), NEVER a content-name. THE LOAD-BEARING SAFETY
+      // INVARIANT: a replicated topic-operator record is UNTRUSTED peer data — NEVER this
+      // machine's authoritative answer to "who is my verified operator?" (only the local
+      // authenticated setOperator binds the principal; Know-Your-Principal).
       topicOperator: {
-        enabled: false,
-        dryRun: true,
+        dryRun: false,
       },
     },
   },

--- a/src/core/PostUpdateMigrator.ts
+++ b/src/core/PostUpdateMigrator.ts
@@ -179,6 +179,63 @@ export function migrateConfigCredentialRepointingDevGate(config: Record<string, 
   return true;
 }
 
+/** The 7 stateSync memory stores re-gated to the developmentAgent gate on 2026-06-13. */
+const STATE_SYNC_DEV_GATED_STORES = [
+  'preferences',
+  'relationships',
+  'learnings',
+  'knowledge',
+  'evolutionActions',
+  'userRegistry',
+  'topicOperator',
+] as const;
+
+/**
+ * The 7 multiMachine.stateSync.* memory stores (preferences, relationships, learnings,
+ * knowledge, evolutionActions, userRegistry, topicOperator) were re-gated from
+ * DARK_GATE_EXCLUSIONS (off for everyone) to the developmentAgent gate (live-on-dev,
+ * dark fleet) per the 2026-06-13 operator directive (topic 13481: "NOTHING should ship
+ * dark on development agents"). Existing agents that ran the old ConfigDefaults carry an
+ * explicit `enabled: false` per store, which (being explicit) would keep
+ * resolveDevAgentGate DARK even on a dev agent. Strip that default-shaped `false` so the
+ * gate resolves (live on dev, dark on fleet) — mirroring the credentialRepointing strip.
+ *
+ * UNLIKE credentialRepointing (which keeps `dryRun:true` as the write-safety canary for a
+ * destructive keychain write), these stores have NO destructive write and the operator's
+ * decision is GENUINELY LIVE — so the new ConfigDefaults set `dryRun:false`. Existing
+ * agents carry the old default-shaped `dryRun:true`; applyDefaults (add-missing-only)
+ * would NOT overwrite it, leaving the agent on a stale dryRun:true. To land the operator's
+ * not-dry-run intent, the OLD-DEFAULT SIGNATURE is treated as one unit: a store whose
+ * block is exactly `{ enabled:false, dryRun:true }` (the ConfigDefaults-backfilled shape,
+ * never an operator's hand edit) has BOTH stripped, so applyDefaults backfills the new
+ * `{ dryRun:false }`. A store with any divergence (explicit `enabled:true`, a different
+ * dryRun, extra keys) is treated as operator-touched and left ENTIRELY alone — reach is
+ * not authority. Idempotent (a second run finds nothing default-shaped to strip).
+ */
+export function migrateConfigStateSyncStoresDevGate(config: Record<string, unknown>): boolean {
+  const mm = config.multiMachine as Record<string, unknown> | undefined;
+  if (!mm || typeof mm !== 'object') return false;
+  const ss = mm.stateSync as Record<string, unknown> | undefined;
+  if (!ss || typeof ss !== 'object') return false;
+  let changed = false;
+  for (const store of STATE_SYNC_DEV_GATED_STORES) {
+    const block = ss[store] as Record<string, unknown> | undefined;
+    if (!block || typeof block !== 'object') continue;
+    const keys = Object.keys(block);
+    // ONLY the exact old-default signature `{ enabled:false, dryRun:true }` is migrated —
+    // anything else is operator-touched and left entirely alone.
+    const isOldDefaultSignature =
+      keys.length === 2 &&
+      block.enabled === false &&
+      block.dryRun === true;
+    if (!isOldDefaultSignature) continue;
+    delete block.enabled; // gate resolves it (live-on-dev / dark-fleet)
+    delete block.dryRun;  // applyDefaults backfills the new dryRun:false (genuinely live)
+    changed = true;
+  }
+  return changed;
+}
+
 export class PostUpdateMigrator {
   private config: MigratorConfig;
   /**
@@ -7261,6 +7318,17 @@ Create worktrees for collaborator repos with \`instar worktree create <branch>\`
       result.upgraded.push('config.json: stripped default-shaped subscriptionPool.credentialRepointing.enabled=false so the developmentAgent gate resolves it (live-on-dev dry-run, dark fleet)');
     } else {
       result.skipped.push('config.json: subscriptionPool.credentialRepointing.enabled dev-gate already correct (omitted or operator-set)');
+    }
+
+    // The 7 multiMachine.stateSync.* memory stores re-gated to the developmentAgent gate
+    // (2026-06-13 operator directive topic 13481): strip a default-shaped
+    // { enabled:false, dryRun:true } so the gate resolves them live-on-dev / dark-fleet and
+    // applyDefaults backfills the new dryRun:false (genuinely live — no destructive write).
+    if (migrateConfigStateSyncStoresDevGate(config)) {
+      patched = true;
+      result.upgraded.push('config.json: stripped default-shaped multiMachine.stateSync.* memory-store {enabled:false,dryRun:true} blocks so the developmentAgent gate resolves them (live-on-dev, dark fleet, dryRun:false)');
+    } else {
+      result.skipped.push('config.json: multiMachine.stateSync.* memory-store dev-gates already correct (omitted or operator-set)');
     }
 
     if (patched) {

--- a/src/core/devAgentGate.ts
+++ b/src/core/devAgentGate.ts
@@ -43,3 +43,37 @@ export function resolveDevAgentGate(
 ): boolean {
   return explicitEnabled ?? !!config?.developmentAgent;
 }
+
+/**
+ * Resolve the developmentAgent dark-feature gate across the multiMachine.stateSync
+ * per-store map, returning a NEW stores map where each store's `enabled` is the
+ * gate-RESOLVED boolean (the raw `enabled` ?? `!!developmentAgent`), preserving
+ * every other per-store field (e.g. `dryRun`).
+ *
+ * WHY (operator directive 2026-06-13, topic 13481): the 7 stateSync memory stores
+ * were moved from DARK_GATE_EXCLUSIONS to DEV_GATED_FEATURES so they run LIVE on a
+ * dev agent and DARK on the fleet. Their ConfigDefaults OMIT `enabled` so the gate
+ * decides — but the four consumer funnels (selfStateSyncReceive,
+ * ReplicatedStoreReader.isLive, isStoreEmissionEnabled, checkPoolFlagCoherence) read
+ * `stores[store].enabled === true` DIRECTLY off config, which would see `undefined`
+ * and stay dark even on a dev agent. Routing the config through this helper ONCE at
+ * the construction boundary makes the gate genuinely flip them live without changing
+ * any funnel's `enabled === true` semantics (they receive a pre-resolved map). An
+ * explicit `enabled` in config still wins (force-dark false / fleet-flip true).
+ */
+export function resolveStateSyncStores(
+  config: { developmentAgent?: boolean; multiMachine?: { stateSync?: Record<string, { enabled?: boolean } & Record<string, unknown>> } } | undefined,
+): Record<string, { enabled?: boolean } & Record<string, unknown>> | undefined {
+  const stores = config?.multiMachine?.stateSync;
+  if (!stores) return undefined;
+  const out: Record<string, { enabled?: boolean } & Record<string, unknown>> = {};
+  for (const [store, flags] of Object.entries(stores)) {
+    if (flags == null || typeof flags !== 'object') {
+      // Preserve non-store foundation knobs (numbers like maxDriftMs) untouched.
+      out[store] = flags as { enabled?: boolean } & Record<string, unknown>;
+      continue;
+    }
+    out[store] = { ...flags, enabled: resolveDevAgentGate(flags.enabled, config) };
+  }
+  return out;
+}

--- a/src/core/devGatedFeatures.ts
+++ b/src/core/devGatedFeatures.ts
@@ -203,6 +203,64 @@ export const DEV_GATED_FEATURES: DevGatedFeature[] = [
     description: 'Boot health beacon — a minimal /health responder during the heavy boot phase.',
     justification: 'D4-verified read-only: binds a localhost-only inbound /health socket during boot and cleanly releases it before the real server binds; zero outbound (no fetch/Telegram), no spend, no destructive action.',
   },
+  // ── multi-machine replicated-store memory family (WS2.1–WS2.6) — the 7 stateSync
+  //    stores, MOVED from DARK_GATE_EXCLUSIONS on 2026-06-13 per operator directive
+  //    topic 13481 ("NOTHING should ship dark on development agents — every
+  //    multi-machine feature must be live on dev agents so it actually gets tested").
+  //    UNLIKE credentialRepointing (which keeps dryRun:true because its keychain WRITE
+  //    is destructive), these replicate between the operator's OWN two machines with NO
+  //    external egress and NO destructive/irreversible write — the foundation's
+  //    rollback-unmerge drops a peer's namespace on disable, so they are fully
+  //    reversible. A dry-run would defeat "actually gets tested", so the ConfigDefaults
+  //    OMIT `enabled` (resolveDevAgentGate flips them LIVE on dev / DARK on fleet) AND
+  //    set `dryRun:false` (genuinely live). Spec: docs/specs/multi-machine-replicated-
+  //    store-foundation.md (these are its consumers). The `enabled` reads at the four
+  //    funnels (selfStateSyncReceive, ReplicatedStoreReader.isLive,
+  //    isStoreEmissionEnabled, the /preferences/session-context route) are routed
+  //    through resolveDevAgentGate at the construction boundary so the gate actually
+  //    flips them live — not just array-shuffling. ──
+  {
+    name: 'stateSyncPreferences',
+    configPath: 'multiMachine.stateSync.preferences.enabled',
+    description: 'WS2.1 cross-machine preference replication (multi-machine-replicated-store-foundation).',
+    justification: 'Replicates between the operator\'s OWN machines only — no external egress; advisory-only on read (never authority); fully reversible (rollback-unmerge drops a peer namespace on disable); no destructive/irreversible write, no third-party spend. Runs live AND dryRun:false on dev (no destructive write warrants a dry-run). Operator directive 2026-06-13 topic 13481.',
+  },
+  {
+    name: 'stateSyncRelationships',
+    configPath: 'multiMachine.stateSync.relationships.enabled',
+    description: 'WS2.3 cross-machine relationship replication — the FIRST PII kind (ws23-relationships-userregistry-security).',
+    justification: 'PII crosses only between the operator\'s OWN machines (transit-encrypted); every replicated field is type-clamped on receive; a peer record is quoted UNTRUSTED data, never the authoritative answer to "who is messaging me"; a delete propagates a tombstone; fully reversible (rollback-unmerge). No external egress, no destructive write, no spend. Runs live AND dryRun:false on dev. Operator directive 2026-06-13 topic 13481.',
+  },
+  {
+    name: 'stateSyncLearnings',
+    configPath: 'multiMachine.stateSync.learnings.enabled',
+    description: 'WS2.2 cross-machine learning replication — the SECOND memory-family kind (multi-machine-replicated-store-foundation).',
+    justification: 'Replicates between the operator\'s OWN machines only — no external egress; advisory-only on read; type-clamped on receive; tombstoned deletes; the local LRN-NNN id is never replicated; fully reversible (rollback-unmerge); no destructive write, no spend. Runs live AND dryRun:false on dev. Operator directive 2026-06-13 topic 13481.',
+  },
+  {
+    name: 'stateSyncKnowledge',
+    configPath: 'multiMachine.stateSync.knowledge.enabled',
+    description: 'WS2.4 cross-machine knowledge-base replication — the THIRD memory-family kind (multi-machine-replicated-store-foundation).',
+    justification: 'Only catalog METADATA crosses (never the file body or local path), between the operator\'s OWN machines; advisory-only on read; type-clamped on receive; tombstoned deletes; fully reversible (rollback-unmerge); no external egress, no destructive write, no spend. Runs live AND dryRun:false on dev. Operator directive 2026-06-13 topic 13481.',
+  },
+  {
+    name: 'stateSyncEvolutionActions',
+    configPath: 'multiMachine.stateSync.evolutionActions.enabled',
+    description: 'WS2.5 cross-machine evolution-action-queue replication — the FOURTH memory-family kind (multi-machine-replicated-store-foundation).',
+    justification: 'Replicates the self-improvement action queue between the operator\'s OWN machines only; advisory work-items on read (load-bearing field is status so a peer does not redo completed work); type-clamped on receive; tombstoned removals; the local ACT-NNN id is never replicated; fully reversible (rollback-unmerge); no external egress, no destructive write, no spend. Runs live AND dryRun:false on dev. Operator directive 2026-06-13 topic 13481.',
+  },
+  {
+    name: 'stateSyncUserRegistry',
+    configPath: 'multiMachine.stateSync.userRegistry.enabled',
+    description: 'WS2.6 cross-machine user-registry replication — the SECOND PII kind (multi-machine-replicated-store-foundation).',
+    justification: 'User PII crosses only between the operator\'s OWN machines (transit-encrypted); type-clamped on receive; a peer record is quoted UNTRUSTED data and inbound-principal RESOLUTION stays LOCAL-ONLY (the local channel index is authoritative); tombstoned deletes; fully reversible (rollback-unmerge); no external egress, no destructive write, no spend. Runs live AND dryRun:false on dev. Operator directive 2026-06-13 topic 13481.',
+  },
+  {
+    name: 'stateSyncTopicOperator',
+    configPath: 'multiMachine.stateSync.topicOperator.enabled',
+    description: 'WS2.6 cross-machine topic-operator replication — the THIRD PII kind (multi-machine-replicated-store-foundation).',
+    justification: 'Replicates the verified-operator binding between the operator\'s OWN machines only; THE LOAD-BEARING SAFETY INVARIANT (Know Your Principal): a replicated record is UNTRUSTED peer data and is NEVER the authoritative answer to "who is my verified operator?" — only the LOCAL authenticated setOperator binds it; recordKey is sha256(topicId+verified-uid), never a content-name; tombstoned unbinds; fully reversible (rollback-unmerge); no external egress, no destructive write, no spend. Runs live AND dryRun:false on dev. Operator directive 2026-06-13 topic 13481.',
+  },
 ];
 
 /**
@@ -314,41 +372,14 @@ export const DARK_GATE_EXCLUSIONS: DarkGateExclusion[] = [
     category: 'optional-integration',
     reason: 'hold-for-stability policy; trails inboundQueue one rollout stage behind (operator discipline)',
   },
-  {
-    configPath: 'multiMachine.stateSync.preferences.enabled',
-    category: 'optional-integration',
-    reason: 'WS2.1 cross-machine preference replication on the HLC foundation; graduated rollout dark→dryRun→live per spec §10.1, opt-in per deployment (mirrors sessionPool.inboundQueue staging)',
-  },
-  {
-    configPath: 'multiMachine.stateSync.relationships.enabled',
-    category: 'optional-integration',
-    reason: 'WS2.3 cross-machine relationship replication — the FIRST PII kind on the HLC foundation; graduated rollout dark→dryRun→live per ws23-relationships-userregistry-security §INV-iii, opt-in per deployment (PII never crosses a machine boundary while dark; mirrors the preferences sibling)',
-  },
-  {
-    configPath: 'multiMachine.stateSync.learnings.enabled',
-    category: 'optional-integration',
-    reason: 'WS2.2 cross-machine learning replication — the SECOND memory-family kind on the HLC foundation; graduated rollout dark→dryRun→live per multi-machine-replicated-store-foundation, opt-in per deployment (no learning crosses a machine boundary while dark; the local LRN-NNN id is never replicated; mirrors the relationships sibling)',
-  },
-  {
-    configPath: 'multiMachine.stateSync.knowledge.enabled',
-    category: 'optional-integration',
-    reason: 'WS2.4 cross-machine knowledge-base replication — the THIRD memory-family kind on the HLC foundation; graduated rollout dark→dryRun→live per multi-machine-replicated-store-foundation, opt-in per deployment (no knowledge source crosses a machine boundary while dark; the local generated id + filePath are never replicated, only catalog metadata; mirrors the learnings sibling)',
-  },
-  {
-    configPath: 'multiMachine.stateSync.evolutionActions.enabled',
-    category: 'optional-integration',
-    reason: 'WS2.5 cross-machine evolution-action-queue replication — the FOURTH memory-family kind on the HLC foundation; graduated rollout dark→dryRun→live per multi-machine-replicated-store-foundation, opt-in per deployment (no action crosses a machine boundary while dark; the local ACT-NNN id is never replicated; the load-bearing field is status so a peer sees an action was already completed elsewhere; mirrors the knowledge sibling)',
-  },
-  {
-    configPath: 'multiMachine.stateSync.userRegistry.enabled',
-    category: 'optional-integration',
-    reason: 'WS2.6 cross-machine user-registry replication — the SECOND PII kind on the HLC foundation; graduated rollout dark→dryRun→live per multi-machine-replicated-store-foundation, opt-in per deployment (no user PII crosses a machine boundary while dark; the local userId is never replicated, the recordKey is the channel-set identity surface; mirrors the relationships sibling)',
-  },
-  {
-    configPath: 'multiMachine.stateSync.topicOperator.enabled',
-    category: 'optional-integration',
-    reason: 'WS2.6 cross-machine topic-operator replication — the THIRD PII kind on the HLC foundation; graduated rollout dark to dryRun to live per multi-machine-replicated-store-foundation, opt-in per deployment (no operator binding crosses a machine boundary while dark; recordKey is sha256 of topicId plus the verified uid, never a content-name; THE LOAD-BEARING INVARIANT: a replicated topic-operator record is NEVER the authoritative principal — only the local authenticated setOperator binds it; mirrors the userRegistry sibling)',
-  },
+  // (the 7 multiMachine.stateSync.* memory stores — preferences, relationships,
+  //  learnings, knowledge, evolutionActions, userRegistry, topicOperator — MOVED to
+  //  DEV_GATED_FEATURES on 2026-06-13 per operator directive topic 13481: "NOTHING
+  //  should ship dark on development agents — every multi-machine feature must be
+  //  live on dev agents so it actually gets tested, not rot." They replicate between
+  //  the operator's OWN machines (no external egress, fully reversible via the
+  //  foundation's rollback-unmerge), so unlike credentialRepointing they run live AND
+  //  dryRun:false on a dev agent — see the DEV_GATED_FEATURES entries' justifications.)
   // ── action-bearing — when merely enabled, automatically produces an outbound
   //    side-effect that reaches an external system or the operator (a send, a PR
   //    merge, a remote mutation). De-dup/rate-limiting reduces severity but an

--- a/src/server/routes.ts
+++ b/src/server/routes.ts
@@ -16282,9 +16282,19 @@ export function createRoutes(ctx: RouteContext): Router {
       // seamlessness flag (the two are mutually exclusive in practice, CMT-1416). A
       // single-machine / pre-apply agent's union is just its own local store, so the
       // block is byte-identical to the legacy own-only read.
-      const stateSyncPrefEnabled =
+      // The `preferences` store follows the developmentAgent dark-feature gate
+      // (operator directive 2026-06-13, topic 13481): its ConfigDefaults OMIT `enabled`
+      // so the gate decides — LIVE on a dev agent, DARK on the fleet. Resolve it the
+      // same way the union reader's construction boundary did (resolveStateSyncStores),
+      // so the route's own gate and ctx.preferencesUnionReader.isLive() agree.
+      // E2E-PAIRING: EXEMPT — no new route/feature-alive surface; this only re-resolves
+      // the EXISTING /preferences/session-context gating through resolveDevAgentGate so it
+      // agrees with the union reader (a gating-consistency change, not a new endpoint).
+      const stateSyncPrefEnabled = resolveDevAgentGate(
         (ctx.config.multiMachine as { stateSync?: { preferences?: { enabled?: boolean } } } | undefined)
-          ?.stateSync?.preferences?.enabled === true;
+          ?.stateSync?.preferences?.enabled,
+        ctx.config as { developmentAgent?: boolean },
+      );
       if (stateSyncPrefEnabled && ctx.preferencesUnionReader) {
         const { buildUnionSessionContext, PREF_STORE_KEY } = await import('../core/PreferencesReplicatedStore.js');
         const union = ctx.preferencesUnionReader.readAll(PREF_STORE_KEY);

--- a/tests/unit/PostUpdateMigrator-stateSyncStoresDevGate.test.ts
+++ b/tests/unit/PostUpdateMigrator-stateSyncStoresDevGate.test.ts
@@ -1,0 +1,118 @@
+/**
+ * Migration parity for the 7 multiMachine.stateSync.* memory stores re-gated to the
+ * developmentAgent gate on 2026-06-13 (operator directive topic 13481: "NOTHING should
+ * ship dark on development agents").
+ *
+ * Existing agents carry the OLD ConfigDefaults-backfilled signature per store —
+ * `{ enabled:false, dryRun:true }`. The explicit `enabled:false` would keep
+ * resolveDevAgentGate DARK even on a dev agent, and `applyDefaults` (add-missing-only)
+ * would not overwrite the stale `dryRun:true`. migrateConfigStateSyncStoresDevGate strips
+ * that exact signature (BOTH keys) so the gate resolves (live-on-dev / dark-fleet) and the
+ * new `dryRun:false` default backfills — UNLESS the block is operator-touched (any
+ * divergence), in which case it is left entirely alone (reach is not authority).
+ */
+import { describe, it, expect } from 'vitest';
+import { migrateConfigStateSyncStoresDevGate } from '../../src/core/PostUpdateMigrator.js';
+import { applyDefaults, getMigrationDefaults } from '../../src/config/ConfigDefaults.js';
+import { resolveDevAgentGate } from '../../src/core/devAgentGate.js';
+
+const STORES = [
+  'preferences',
+  'relationships',
+  'learnings',
+  'knowledge',
+  'evolutionActions',
+  'userRegistry',
+  'topicOperator',
+] as const;
+
+function oldDefaultConfig(): Record<string, any> {
+  return {
+    multiMachine: {
+      stateSync: Object.fromEntries(STORES.map((s) => [s, { enabled: false, dryRun: true }])),
+    },
+  };
+}
+
+describe('migrateConfigStateSyncStoresDevGate', () => {
+  it('strips the exact old-default signature {enabled:false,dryRun:true} from all 7 stores', () => {
+    const cfg = oldDefaultConfig();
+    expect(migrateConfigStateSyncStoresDevGate(cfg)).toBe(true);
+    for (const store of STORES) {
+      const block = cfg.multiMachine.stateSync[store];
+      expect(Object.prototype.hasOwnProperty.call(block, 'enabled'), `${store}.enabled stripped`).toBe(false);
+      expect(Object.prototype.hasOwnProperty.call(block, 'dryRun'), `${store}.dryRun stripped`).toBe(false);
+    }
+  });
+
+  it('after the strip + applyDefaults, the stores resolve LIVE on a dev agent and DARK on the fleet, dryRun:false', () => {
+    // Dev agent: strip, then apply the (new) defaults exactly as the migrator runner does.
+    const dev: Record<string, any> = { developmentAgent: true, ...oldDefaultConfig() };
+    migrateConfigStateSyncStoresDevGate(dev);
+    applyDefaults(dev, getMigrationDefaults('standalone'));
+    for (const store of STORES) {
+      const block = dev.multiMachine.stateSync[store];
+      expect(resolveDevAgentGate(block.enabled, dev), `${store} live on dev`).toBe(true);
+      expect(block.dryRun, `${store} dryRun:false on dev`).toBe(false);
+    }
+    // Fleet agent: same migration, dark resolution.
+    const fleet: Record<string, any> = { developmentAgent: false, ...oldDefaultConfig() };
+    migrateConfigStateSyncStoresDevGate(fleet);
+    applyDefaults(fleet, getMigrationDefaults('standalone'));
+    for (const store of STORES) {
+      const block = fleet.multiMachine.stateSync[store];
+      expect(resolveDevAgentGate(block.enabled, fleet), `${store} dark on fleet`).toBe(false);
+    }
+  });
+
+  it('is idempotent (a second run finds nothing default-shaped to strip)', () => {
+    const cfg = oldDefaultConfig();
+    expect(migrateConfigStateSyncStoresDevGate(cfg)).toBe(true);
+    expect(migrateConfigStateSyncStoresDevGate(cfg)).toBe(false);
+  });
+
+  it('leaves an operator-set explicit enabled:true entirely alone (reach is not authority)', () => {
+    const cfg: Record<string, any> = {
+      multiMachine: { stateSync: { preferences: { enabled: true, dryRun: true } } },
+    };
+    expect(migrateConfigStateSyncStoresDevGate(cfg)).toBe(false);
+    expect(cfg.multiMachine.stateSync.preferences.enabled).toBe(true);
+    expect(cfg.multiMachine.stateSync.preferences.dryRun).toBe(true);
+  });
+
+  it('leaves a divergent block (extra keys, or a non-default dryRun) untouched', () => {
+    const cfg: Record<string, any> = {
+      multiMachine: {
+        stateSync: {
+          // enabled:false but dryRun:false → not the old signature, operator-touched
+          preferences: { enabled: false, dryRun: false },
+          // old signature + an extra key → not exactly 2 keys, operator-touched
+          relationships: { enabled: false, dryRun: true, somethingElse: 1 },
+        },
+      },
+    };
+    expect(migrateConfigStateSyncStoresDevGate(cfg)).toBe(false);
+    expect(cfg.multiMachine.stateSync.preferences).toEqual({ enabled: false, dryRun: false });
+    expect(cfg.multiMachine.stateSync.relationships).toEqual({ enabled: false, dryRun: true, somethingElse: 1 });
+  });
+
+  it('only migrates the stores present (a partial config strips just what is default-shaped)', () => {
+    const cfg: Record<string, any> = {
+      multiMachine: {
+        stateSync: {
+          preferences: { enabled: false, dryRun: true }, // strip
+          learnings: { enabled: true }, // operator-on, leave
+        },
+      },
+    };
+    expect(migrateConfigStateSyncStoresDevGate(cfg)).toBe(true);
+    expect(cfg.multiMachine.stateSync.preferences).toEqual({});
+    expect(cfg.multiMachine.stateSync.learnings).toEqual({ enabled: true });
+  });
+
+  it('returns false (no-op) on a config with no stateSync block (single-machine / fresh)', () => {
+    expect(migrateConfigStateSyncStoresDevGate({})).toBe(false);
+    expect(migrateConfigStateSyncStoresDevGate({ multiMachine: {} })).toBe(false);
+    expect(migrateConfigStateSyncStoresDevGate({ multiMachine: { stateSync: {} } })).toBe(false);
+  });
+});

--- a/tests/unit/lint-dev-agent-dark-gate.test.ts
+++ b/tests/unit/lint-dev-agent-dark-gate.test.ts
@@ -351,16 +351,18 @@ describe('lint-dev-agent-dark-gate', () => {
       '786': 'multiMachine.sessionPool.enabled',
       '811': 'multiMachine.sessionPool.inboundQueue.enabled',
       '840': 'multiMachine.sessionPool.holdForStability.enabled',
-      '931': 'multiMachine.stateSync.preferences.enabled',
-      '945': 'multiMachine.stateSync.relationships.enabled',
-      '959': 'multiMachine.stateSync.learnings.enabled',
-      '974': 'multiMachine.stateSync.knowledge.enabled',
-      '988': 'multiMachine.stateSync.evolutionActions.enabled',
-      '1002': 'multiMachine.stateSync.userRegistry.enabled',
-      '1017': 'multiMachine.stateSync.topicOperator.enabled',
-      '1125': 'cartographer.freshnessSweep.enabled',
-      '1170': 'cartographer.conformanceAudit.llmEnrichment.enabled',
-      '1195': 'cartographer.subtreeNav.llmRerank.enabled',
+      // mm-stores-devgate (operator directive 2026-06-13, topic 13481): the 7
+      // multiMachine.stateSync.* memory stores MOVED from DARK_GATE_EXCLUSIONS to
+      // DEV_GATED_FEATURES and their `enabled: false` literals were REMOVED from
+      // ConfigDefaults (the stores now OMIT `enabled` so the dev-gate resolves them
+      // live on a dev agent, dark on the fleet) — so they have NO attributed path
+      // here anymore (exactly like credentialRepointing/authorizationRequests). Their
+      // removal shrank the stateSync block, shifting cartographer up: 1125→1100,
+      // 1170→1145, 1195→1170. RE-VERIFIED by hand via the attributor on the edited
+      // ConfigDefaults (each maps to a real `enabled: false,` line).
+      '1100': 'cartographer.freshnessSweep.enabled',
+      '1145': 'cartographer.conformanceAudit.llmEnrichment.enabled',
+      '1170': 'cartographer.subtreeNav.llmRerank.enabled',
     };
     const actual = attributeRealConfigDefaults();
     expect(actual).toEqual(EXPECTED);

--- a/tests/unit/state-sync-stores-dark-gate.test.ts
+++ b/tests/unit/state-sync-stores-dark-gate.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect } from 'vitest';
+import { applyDefaults, getMigrationDefaults } from '../../src/config/ConfigDefaults.js';
+import { DARK_GATE_EXCLUSIONS, DEV_GATED_FEATURES, getConfigByPath } from '../../src/core/devGatedFeatures.js';
+import { resolveDevAgentGate, resolveStateSyncStores } from '../../src/core/devAgentGate.js';
+
+/**
+ * The 7 multiMachine.stateSync.* memory stores were RE-GATED on 2026-06-13
+ * (operator directive, topic 13481: "NOTHING should ship dark on development
+ * agents — every multi-machine feature must be live on dev agents so it actually
+ * gets tested, not rot") from DARK_GATE_EXCLUSIONS (off for everyone) to the
+ * developmentAgent gate: they resolve LIVE on a dev agent and DARK on the fleet.
+ *
+ * UNLIKE credentialRepointing (whose keychain WRITE is destructive, so it keeps
+ * dryRun:true as the write-safety canary), these stores replicate between the
+ * operator's OWN machines with NO external egress and NO destructive/irreversible
+ * write — fully reversible via the foundation's rollback-unmerge. A dry-run would
+ * defeat "actually gets tested", so on a dev agent they run ENABLED + dryRun:false
+ * (genuinely live).
+ *
+ * Builds the config a real agent would run with (explicit developmentAgent flag +
+ * the REAL ConfigDefaults applied, exactly as PostUpdateMigrator does).
+ */
+function buildConfig(developmentAgent: boolean): Record<string, unknown> {
+  const cfg: Record<string, unknown> = { developmentAgent };
+  applyDefaults(cfg, getMigrationDefaults('standalone'));
+  return cfg;
+}
+
+const STORES = [
+  'preferences',
+  'relationships',
+  'learnings',
+  'knowledge',
+  'evolutionActions',
+  'userRegistry',
+  'topicOperator',
+] as const;
+
+const ENABLED_PATH = (store: string) => `multiMachine.stateSync.${store}.enabled`;
+const DRYRUN_PATH = (store: string) => `multiMachine.stateSync.${store}.dryRun`;
+
+describe('stateSync memory stores — developmentAgent gate (re-gated 2026-06-13, topic 13481)', () => {
+  for (const store of STORES) {
+    const ep = ENABLED_PATH(store);
+
+    it(`${store} is registered in DEV_GATED_FEATURES (not DARK_GATE_EXCLUSIONS)`, () => {
+      expect(
+        DEV_GATED_FEATURES.some((e) => e.configPath === ep),
+        `${ep} must be a DEV_GATED_FEATURES entry`,
+      ).toBe(true);
+      expect(
+        DARK_GATE_EXCLUSIONS.some((e) => e.configPath === ep),
+        `${ep} must NOT remain a DARK_GATE_EXCLUSIONS entry`,
+      ).toBe(false);
+    });
+
+    it(`${store} OMITS enabled in ConfigDefaults so the gate decides (no baked-in false)`, () => {
+      const cfg = buildConfig(true);
+      expect(getConfigByPath(cfg, ep)).toBeUndefined();
+      // dryRun is present + FALSE (genuinely live — no destructive write warrants dry-run).
+      expect(getConfigByPath(cfg, DRYRUN_PATH(store))).toBe(false);
+    });
+
+    it(`${store} resolves LIVE on a dev agent and DARK on the fleet`, () => {
+      const dev = buildConfig(true);
+      const fleet = buildConfig(false);
+      expect(resolveDevAgentGate(getConfigByPath(dev, ep) as boolean | undefined, dev)).toBe(true);
+      expect(resolveDevAgentGate(getConfigByPath(fleet, ep) as boolean | undefined, fleet)).toBe(false);
+    });
+
+    it(`${store} resolves NOT-dry-run on BOTH dev and fleet (genuinely live, the operator's key decision)`, () => {
+      // dryRun:false regardless of agent kind — it is the gate (enabled) that darks
+      // the fleet, not dryRun. The point is that when LIVE (dev), it is NOT dry-run.
+      expect(getConfigByPath(buildConfig(true), DRYRUN_PATH(store))).toBe(false);
+      expect(getConfigByPath(buildConfig(false), DRYRUN_PATH(store))).toBe(false);
+    });
+
+    it(`${store} honors an explicit operator override of enabled (explicit wins over the gate)`, () => {
+      const fleetForcedOn: Record<string, unknown> = { developmentAgent: false };
+      applyDefaults(fleetForcedOn, getMigrationDefaults('standalone'));
+      (((((fleetForcedOn.multiMachine as Record<string, unknown>).stateSync) as Record<string, unknown>)[store]) as Record<string, unknown>).enabled = true;
+      expect(resolveDevAgentGate(getConfigByPath(fleetForcedOn, ep) as boolean | undefined, fleetForcedOn)).toBe(true);
+    });
+  }
+
+  it('resolveStateSyncStores flips all 7 stores LIVE on a dev agent (the construction-boundary funnel)', () => {
+    const dev = buildConfig(true) as { developmentAgent?: boolean; multiMachine?: { stateSync?: Record<string, { enabled?: boolean; dryRun?: boolean }> } };
+    const resolved = resolveStateSyncStores(dev);
+    expect(resolved).toBeDefined();
+    for (const store of STORES) {
+      expect(resolved![store]?.enabled, `${store} should be live on dev`).toBe(true);
+      // dryRun preserved (false) — the funnel only resolves enabled, never touches dryRun.
+      expect(resolved![store]?.dryRun, `${store} dryRun preserved`).toBe(false);
+    }
+  });
+
+  it('resolveStateSyncStores keeps all 7 stores DARK on the fleet', () => {
+    const fleet = buildConfig(false) as { developmentAgent?: boolean; multiMachine?: { stateSync?: Record<string, { enabled?: boolean }> } };
+    const resolved = resolveStateSyncStores(fleet);
+    expect(resolved).toBeDefined();
+    for (const store of STORES) {
+      expect(resolved![store]?.enabled, `${store} should be dark on fleet`).toBe(false);
+    }
+  });
+
+  it('resolveStateSyncStores preserves the foundation-level numeric knobs untouched', () => {
+    const dev = buildConfig(true) as { developmentAgent?: boolean; multiMachine?: { stateSync?: Record<string, unknown> } };
+    const resolved = resolveStateSyncStores(dev) as Record<string, unknown>;
+    // maxDriftMs / maxCachedSnapshots / etc are numbers, not per-store objects — they
+    // must pass through unchanged (the funnel never coerces a knob into a store).
+    expect(resolved['maxDriftMs']).toBe((dev.multiMachine!.stateSync as Record<string, unknown>)['maxDriftMs']);
+    expect(resolved['maxCachedSnapshots']).toBe((dev.multiMachine!.stateSync as Record<string, unknown>)['maxCachedSnapshots']);
+    expect(typeof resolved['maxDriftMs']).toBe('number');
+  });
+
+  it('resolveStateSyncStores honors an explicit operator force-dark on a dev agent (explicit false wins)', () => {
+    const dev = buildConfig(true) as { developmentAgent?: boolean; multiMachine?: { stateSync?: Record<string, { enabled?: boolean }> } };
+    dev.multiMachine!.stateSync!.preferences.enabled = false; // operator force-dark
+    const resolved = resolveStateSyncStores(dev);
+    expect(resolved!.preferences?.enabled).toBe(false);
+    // the other stores stay live (only the explicitly-overridden one darks)
+    expect(resolved!.relationships?.enabled).toBe(true);
+  });
+
+  it('resolveStateSyncStores returns undefined when there is no stateSync block (single-machine no-op)', () => {
+    expect(resolveStateSyncStores({ developmentAgent: true })).toBeUndefined();
+    expect(resolveStateSyncStores(undefined)).toBeUndefined();
+  });
+});

--- a/tests/unit/ws22-learnings-wiring.test.ts
+++ b/tests/unit/ws22-learnings-wiring.test.ts
@@ -94,12 +94,17 @@ describe('WS2.2 EvolutionManager emit seam (source touchpoints)', () => {
 });
 
 describe('WS2.2 ConfigDefaults + awareness', () => {
-  it('ConfigDefaults ships the learnings stateSync dark default (enabled:false, dryRun:true)', () => {
+  it('ConfigDefaults ships the learnings stateSync dev-gated posture (OMITS enabled, dryRun:false — operator directive 2026-06-13)', () => {
     const defaultsSrc = read('src/config/ConfigDefaults.ts');
-    expect(defaultsSrc).toMatch(/learnings:\s*\{\s*\n\s*enabled:\s*false,\s*\n\s*dryRun:\s*true,/);
+    // Re-gated to the developmentAgent dark-feature gate: `enabled` is OMITTED so the
+    // gate resolves it live-on-dev / dark-fleet; dryRun:false (genuinely live — no
+    // destructive write warrants a dry-run, unlike credentialRepointing).
+    expect(defaultsSrc).toMatch(/learnings:\s*\{\s*\n\s*dryRun:\s*false,\s*\n\s*\},/);
+    // explicitly NOT a baked-in enabled:false in the learnings block
+    expect(defaultsSrc).not.toMatch(/learnings:\s*\{\s*\n\s*enabled:\s*false/);
   });
 
-  it('the dev-gate dark exclusion classifies the learnings path', () => {
+  it('the dev-gate classifies the learnings path as DEV_GATED (live-on-dev), not a dark exclusion', () => {
     const devGated = read('src/core/devGatedFeatures.ts');
     expect(devGated).toContain("configPath: 'multiMachine.stateSync.learnings.enabled'");
   });

--- a/tests/unit/ws23-relationships-wiring.test.ts
+++ b/tests/unit/ws23-relationships-wiring.test.ts
@@ -67,13 +67,16 @@ describe('WS2.3 server.ts wiring (source touchpoints)', () => {
 });
 
 describe('WS2.3 ConfigDefaults + awareness', () => {
-  it('ConfigDefaults ships the relationships stateSync dark default (enabled:false, dryRun:true)', () => {
+  it('ConfigDefaults ships the relationships stateSync dev-gated posture (OMITS enabled, dryRun:false — operator directive 2026-06-13)', () => {
     const defaultsSrc = read('src/config/ConfigDefaults.ts');
-    // The relationships sub-block follows the preferences sibling under stateSync.
-    expect(defaultsSrc).toMatch(/relationships:\s*\{\s*\n\s*enabled:\s*false,\s*\n\s*dryRun:\s*true,/);
+    // Re-gated to the developmentAgent gate: `enabled` OMITTED (gate resolves it
+    // live-on-dev / dark-fleet); dryRun:false (genuinely live). The relationships
+    // sub-block follows the preferences sibling under stateSync.
+    expect(defaultsSrc).toMatch(/relationships:\s*\{\s*\n\s*dryRun:\s*false,\s*\n\s*\},/);
+    expect(defaultsSrc).not.toMatch(/relationships:\s*\{\s*\n\s*enabled:\s*false/);
   });
 
-  it('the dev-gate dark exclusion classifies the relationships path', () => {
+  it('the dev-gate classifies the relationships path as DEV_GATED (live-on-dev), not a dark exclusion', () => {
     const devGated = read('src/core/devGatedFeatures.ts');
     expect(devGated).toContain("configPath: 'multiMachine.stateSync.relationships.enabled'");
   });

--- a/tests/unit/ws24-knowledge-wiring.test.ts
+++ b/tests/unit/ws24-knowledge-wiring.test.ts
@@ -92,12 +92,13 @@ describe('WS2.4 KnowledgeManager emit seam (source touchpoints)', () => {
 });
 
 describe('WS2.4 ConfigDefaults + awareness', () => {
-  it('ConfigDefaults ships the knowledge stateSync dark default (enabled:false, dryRun:true)', () => {
+  it('ConfigDefaults ships the knowledge stateSync dev-gated posture (OMITS enabled, dryRun:false — operator directive 2026-06-13)', () => {
     const defaultsSrc = read('src/config/ConfigDefaults.ts');
-    expect(defaultsSrc).toMatch(/knowledge:\s*\{\s*\n\s*enabled:\s*false,\s*\n\s*dryRun:\s*true,/);
+    expect(defaultsSrc).toMatch(/knowledge:\s*\{\s*\n\s*dryRun:\s*false,\s*\n\s*\},/);
+    expect(defaultsSrc).not.toMatch(/knowledge:\s*\{\s*\n\s*enabled:\s*false/);
   });
 
-  it('the dev-gate dark exclusion classifies the knowledge path', () => {
+  it('the dev-gate classifies the knowledge path as DEV_GATED (live-on-dev), not a dark exclusion', () => {
     const devGated = read('src/core/devGatedFeatures.ts');
     expect(devGated).toContain("configPath: 'multiMachine.stateSync.knowledge.enabled'");
   });

--- a/tests/unit/ws25-evolution-actions-wiring.test.ts
+++ b/tests/unit/ws25-evolution-actions-wiring.test.ts
@@ -92,12 +92,13 @@ describe('WS2.5 EvolutionManager emit seam (source touchpoints)', () => {
 });
 
 describe('WS2.5 ConfigDefaults + awareness', () => {
-  it('ConfigDefaults ships the evolutionActions stateSync dark default (enabled:false, dryRun:true)', () => {
+  it('ConfigDefaults ships the evolutionActions stateSync dev-gated posture (OMITS enabled, dryRun:false — operator directive 2026-06-13)', () => {
     const defaultsSrc = read('src/config/ConfigDefaults.ts');
-    expect(defaultsSrc).toMatch(/evolutionActions:\s*\{\s*\n\s*enabled:\s*false,\s*\n\s*dryRun:\s*true,/);
+    expect(defaultsSrc).toMatch(/evolutionActions:\s*\{\s*\n\s*dryRun:\s*false,\s*\n\s*\},/);
+    expect(defaultsSrc).not.toMatch(/evolutionActions:\s*\{\s*\n\s*enabled:\s*false/);
   });
 
-  it('the dev-gate dark exclusion classifies the evolutionActions path', () => {
+  it('the dev-gate classifies the evolutionActions path as DEV_GATED (live-on-dev), not a dark exclusion', () => {
     const devGated = read('src/core/devGatedFeatures.ts');
     expect(devGated).toContain("configPath: 'multiMachine.stateSync.evolutionActions.enabled'");
   });

--- a/tests/unit/ws26-user-topicop-wiring.test.ts
+++ b/tests/unit/ws26-user-topicop-wiring.test.ts
@@ -108,12 +108,14 @@ describe('WS2.6 manager emit seams (source touchpoints)', () => {
 });
 
 describe('WS2.6 ConfigDefaults + dev-gate + awareness', () => {
-  it('ConfigDefaults ships BOTH stateSync dark defaults (enabled:false, dryRun:true)', () => {
+  it('ConfigDefaults ships BOTH stateSync dev-gated postures (OMIT enabled, dryRun:false — operator directive 2026-06-13)', () => {
     const defaultsSrc = read('src/config/ConfigDefaults.ts');
-    expect(defaultsSrc).toMatch(/userRegistry:\s*\{\s*\n\s*enabled:\s*false,\s*\n\s*dryRun:\s*true,/);
-    expect(defaultsSrc).toMatch(/topicOperator:\s*\{\s*\n\s*enabled:\s*false,\s*\n\s*dryRun:\s*true,/);
+    expect(defaultsSrc).toMatch(/userRegistry:\s*\{\s*\n\s*dryRun:\s*false,\s*\n\s*\},/);
+    expect(defaultsSrc).toMatch(/topicOperator:\s*\{\s*\n\s*dryRun:\s*false,\s*\n\s*\},/);
+    expect(defaultsSrc).not.toMatch(/userRegistry:\s*\{\s*\n\s*enabled:\s*false/);
+    expect(defaultsSrc).not.toMatch(/topicOperator:\s*\{\s*\n\s*enabled:\s*false/);
   });
-  it('the dev-gate dark exclusions classify BOTH paths', () => {
+  it('the dev-gate classifies BOTH paths as DEV_GATED (live-on-dev), not dark exclusions', () => {
     const devGated = read('src/core/devGatedFeatures.ts');
     expect(devGated).toContain("configPath: 'multiMachine.stateSync.userRegistry.enabled'");
     expect(devGated).toContain("configPath: 'multiMachine.stateSync.topicOperator.enabled'");

--- a/upgrades/next/mm-stores-devgate.md
+++ b/upgrades/next/mm-stores-devgate.md
@@ -1,0 +1,68 @@
+# Multi-machine memory stores — dev-gated (live-on-dev, dark-fleet)
+
+## What Changed
+
+- **The 7 `multiMachine.stateSync.*` cross-machine memory stores** (preferences,
+  relationships, learnings, knowledge, evolutionActions, userRegistry, topicOperator)
+  **moved from `DARK_GATE_EXCLUSIONS` (off for EVERYONE, including dev agents) to
+  `DEV_GATED_FEATURES` (live-on-dev / dark-fleet, `dryRun:false`)**, mirroring the
+  `subscriptionPool.credentialRepointing` precedent.
+- **Driver — operator directive (topic 13481, 2026-06-13):** "NOTHING should ship dark
+  on development agents — every multi-machine feature must be live on dev agents so it
+  actually gets tested, not rot." A literal `enabled: false` in `ConfigDefaults` had
+  force-darked the stores everywhere, so the WS2 replicated-store family never got
+  dogfooded on a dev agent and never graduated.
+- **How it resolves now:** each store's `ConfigDefaults` block OMITS `enabled` so the
+  developmentAgent gate decides — LIVE on a dev agent, DARK on the fleet. A new helper
+  `resolveStateSyncStores(config)` resolves the gate ONCE at the server construction
+  boundary; the resolved stores map is fed into `selfStateSyncReceive`, all 7
+  `ReplicatedStoreReader` instances, and `checkPoolFlagCoherence`, so every consumer
+  funnel keeps its unchanged `enabled === true` semantics but now sees a live flag on a
+  dev agent. The `/preferences/session-context` route resolves the same gate so it
+  agrees with the union reader's `isLive()`.
+- **`dryRun:false` (genuinely live):** unlike `credentialRepointing` (whose keychain
+  write is destructive, so it keeps `dryRun:true` as a write-safety canary), these stores
+  replicate between the operator's OWN machines with NO external egress and NO
+  destructive/irreversible write — fully reversible via the foundation's rollback-unmerge.
+  A dry-run would defeat "actually gets tested".
+- **Fleet + single-machine agents are an unchanged no-op** — the stores resolve dark
+  exactly as before. An operator's explicit `multiMachine.stateSync.<store>.enabled` in
+  config remains the documented force-dark (false) / fleet-flip (true) override.
+
+## Migration
+
+- `PostUpdateMigrator.migrateConfigStateSyncStoresDevGate` strips ONLY the exact
+  old-default signature `{ enabled:false, dryRun:true }` per store (the
+  ConfigDefaults-backfilled shape, never an operator hand-edit) so `applyDefaults`
+  backfills the new `dryRun:false` and the gate resolves `enabled`. Any divergent
+  (operator-touched) block is left entirely alone — reach is not authority. Idempotent.
+
+## Evidence
+
+- `tests/unit/state-sync-stores-dark-gate.test.ts` (40): each of the 7 stores resolves
+  live-on-dev / dark-on-fleet through the gate; an explicit `enabled` (true/false) wins;
+  per-store `dryRun` + non-store foundation knobs are preserved by `resolveStateSyncStores`.
+- `tests/unit/PostUpdateMigrator-stateSyncStoresDevGate.test.ts` (7): the migrator strips
+  the exact old-default signature, leaves operator-touched blocks alone, and is idempotent.
+- `tests/unit/lint-dev-agent-dark-gate.test.ts`: the EXPECTED attribution map no longer
+  carries the 7 stateSync `enabled:false` paths (the literals were removed); the dark-gate
+  lint confirms the stores are dev-gated, not force-darked.
+- `tests/unit/ws22..ws26-*-wiring.test.ts`: the existing wiring tests stay green against
+  the gate-resolved stores map.
+
+## Summary of New Capabilities
+
+- The 7 cross-machine memory stores (preferences, relationships, learnings, knowledge,
+  evolution-actions, user-registry, topic-operator) now run LIVE on development agents
+  (dark on the fleet) so the WS2 replicated-store family is actually exercised instead of
+  shipping dark everywhere.
+
+## What to Tell Your User
+
+Nothing changes for fleet agents — these cross-machine memory-sync features stay off for
+everyone except development agents, where they now run live so they finally get tested.
+There is no user-facing action and no behavior change on a normal install (or any
+single-machine agent). An operator can still force-dark or fleet-flip any individual store
+explicitly through the multi-machine state-sync settings in config.
+
+<!-- tracked: CMT-1416 -->

--- a/upgrades/side-effects/mm-stores-devgate.md
+++ b/upgrades/side-effects/mm-stores-devgate.md
@@ -1,0 +1,92 @@
+# Side-Effects — multiMachine.stateSync memory stores → dev-gated (topic 13481)
+
+**Change:** Re-gate the 7 `multiMachine.stateSync.*` cross-machine memory stores
+(preferences, relationships, learnings, knowledge, evolutionActions, userRegistry,
+topicOperator) from `DARK_GATE_EXCLUSIONS` (off for EVERYONE, including dev agents) to
+`DEV_GATED_FEATURES` (live-on-dev / dark-fleet, `dryRun:false`), mirroring the
+`subscriptionPool.credentialRepointing` precedent.
+
+**Driver:** Operator directive (Justin, topic 13481, 2026-06-13): "NOTHING should ship dark
+on development agents — every multi-machine feature must be live on dev agents so it
+actually gets tested, not rot." A feature shipped dark everywhere never gets exercised; the
+WS2 replicated-store family was in exactly that state.
+
+**Spec:** `docs/specs/multi-machine-replicated-store-foundation.md` (the converged + approved
+spec the 7 stores were built against). This is a follow-up gating fix to the merged WS2
+stores, not a new feature.
+
+## What was wrong
+
+The 7 stores shipped with a literal `enabled: false` in `ConfigDefaults.ts` and were
+classified in `DARK_GATE_EXCLUSIONS` ("deliberate-fleet-default" — off for everyone,
+including dev). That is the #1001 anti-pattern the §12.5 dark-gate lint forbids for a
+dev-gated block: a written `enabled: false` literal force-darks even a development agent,
+so the stores never ran ANYWHERE — they could never be dogfooded on Echo/the Mini and never
+graduated.
+
+## What changed
+
+- `src/core/devGatedFeatures.ts` — moved all 7 entries from `DARK_GATE_EXCLUSIONS` to
+  `DEV_GATED_FEATURES`, each keyed on `multiMachine.stateSync.<store>.enabled` (the wiring
+  tests now prove each resolves live-on-dev / dark-on-fleet).
+- `src/config/ConfigDefaults.ts` — OMIT `enabled` from all 7 store blocks so the
+  developmentAgent gate decides; set `dryRun: false` (these stores replicate between the
+  operator's OWN machines with no destructive write, so unlike credentialRepointing they
+  need no write-safety dry-run canary — a dry-run would defeat "actually gets tested").
+- `src/core/devAgentGate.ts` — NEW `resolveStateSyncStores(config)` helper: returns a new
+  stores map where each store's `enabled` is the gate-resolved boolean (raw `enabled` ??
+  `!!developmentAgent`), preserving every other per-store field (e.g. `dryRun`). Non-store
+  foundation knobs (numbers like `maxDriftMs`) pass through untouched.
+- `src/commands/server.ts` — resolve the gate ONCE at the construction boundary
+  (`_stateSyncStoresResolved = resolveStateSyncStores(config)`) and feed that resolved map
+  into `selfStateSyncReceive`, all 7 `new ReplicatedStoreReader({ stores })` instances, and
+  `checkPoolFlagCoherence`. The funnels keep their unchanged `enabled === true` semantics —
+  they now read an already-resolved boolean, so a dev agent sees a LIVE flag. This is why
+  `ReplicatedStoreReader.ts`'s raw `.enabled === true` read is correct and was NOT touched.
+- `src/server/routes.ts` — the `/preferences/session-context` route resolves the
+  `preferences` store's `enabled` via `resolveDevAgentGate(..., ctx.config)` so the route's
+  own gate and `ctx.preferencesUnionReader.isLive()` agree.
+- `src/core/PostUpdateMigrator.ts` — NEW `migrateConfigStateSyncStoresDevGate(config)`:
+  strips ONLY the exact old-default signature `{ enabled:false, dryRun:true }` (2 keys, that
+  exact shape) per store, so `applyDefaults` backfills the new `{ dryRun:false }` and the
+  gate resolves `enabled`. Any divergence (operator-set `enabled:true`, a different dryRun,
+  extra keys) is treated as operator-touched and left ENTIRELY alone. Idempotent. Wired into
+  the migrate path (`upgraded`/`skipped` reporting), mirroring the credentialRepointing strip.
+- `tests/unit/lint-dev-agent-dark-gate.test.ts` — the 7 stateSync `enabled:`-line entries
+  are GONE from the EXPECTED attribution map (the literals were removed from ConfigDefaults,
+  so they have no attributed enabled:false path — exactly like credentialRepointing); the
+  three cartographer entries below them shift up (1125→1100, 1170→1145, 1195→1170). Verified
+  via the attributor against the edited ConfigDefaults.
+
+## Behavioral impact
+
+- **Dev agents (`developmentAgent: true`):** all 7 stores now resolve LIVE and `dryRun:false`
+  — replication genuinely runs so the family is dogfooded. Replication is between the
+  operator's OWN machines only: NO external egress, NO third-party spend. The PII stores
+  (relationships, userRegistry, topicOperator) carry the same at-rest honesty already
+  documented — at-rest plaintext per machine, transit-encrypted; an inbound-principal
+  RESOLUTION and "who is my verified operator?" stay LOCAL-authoritative (a replicated record
+  is untrusted advisory data). Fully reversible: the foundation's rollback-unmerge atomically
+  drops a peer's contribution on disable.
+- **Fleet (`developmentAgent` unset/false):** UNCHANGED — all 7 stores resolve dark, a
+  strict no-op, exactly as before. A single-machine agent is a no-op regardless.
+- **Reversibility:** set an explicit `multiMachine.stateSync.<store>.enabled: false` in
+  config to force-dark even a dev agent; an explicit `true` is the documented fleet-flip.
+
+## Migration parity
+
+`applyDefaults` is add-missing-only deep-merge, so a new agent gets the omitted-`enabled` /
+`dryRun:false` shape via `init`. Existing agents that already received the old
+`{ enabled:false, dryRun:true }` per store would, under add-missing-only, keep that stale
+shape (explicit values are not overwritten) and stay dark even on a dev agent — so
+`migrateConfigStateSyncStoresDevGate` strips the exact old-default signature on update,
+letting the gate resolve and `applyDefaults` backfill `dryRun:false`. An operator's
+hand-edited block (any divergence from the exact signature) is never touched — reach is not
+authority. The migration is idempotent (a second run finds nothing default-shaped to strip).
+
+## Tests
+
+Unit: `state-sync-stores-dark-gate` (40), `PostUpdateMigrator-stateSyncStoresDevGate` (7),
+the 5 ws2x wiring tests (ws22/23/24/25/26), `lint-dev-agent-dark-gate` (line-map recomputed),
+`no-silent-fallbacks`, `feature-delivery-completeness` — all green locally. Typecheck clean
+(`tsc --noEmit` exit 0). The full unit suite is left to CI (it is the authority).


### PR DESCRIPTION
---
parent-principle: "Cross-Machine Coherence — One Agent, Robust Under Degraded Conditions"
---

## Summary

Re-gate the 7 `multiMachine.stateSync.*` cross-machine memory stores (preferences, relationships, learnings, knowledge, evolutionActions, userRegistry, topicOperator) from `DARK_GATE_EXCLUSIONS` (off for everyone, including dev agents) to `DEV_GATED_FEATURES` (live-on-dev / dark-fleet, `dryRun:false`), mirroring the `subscriptionPool.credentialRepointing` precedent.

**Operator directive (Justin, topic 13481, 2026-06-13):** "NOTHING should ship dark on development agents — every multi-machine feature must be live on dev agents so it actually gets tested, not rot." A literal `enabled: false` in `ConfigDefaults` had force-darked the WS2 replicated-store family everywhere, so it never got dogfooded and never graduated.

## What changed

- `src/core/devGatedFeatures.ts` — 7 entries moved to `DEV_GATED_FEATURES` (keyed on `multiMachine.stateSync.<store>.enabled`).
- `src/config/ConfigDefaults.ts` — OMIT `enabled` per store (gate decides); `dryRun:false` (replication is between the operator's OWN machines, no destructive write → no dry-run canary needed; a dry-run would defeat "actually gets tested").
- `src/core/devAgentGate.ts` — new `resolveStateSyncStores(config)` resolves the gate across the store map at the construction boundary, preserving per-store fields (`dryRun`) and non-store foundation knobs.
- `src/commands/server.ts` — resolve ONCE (`_stateSyncStoresResolved`) → fed into `selfStateSyncReceive`, all 7 `ReplicatedStoreReader` instances, and `checkPoolFlagCoherence`. The funnels keep their unchanged `enabled === true` semantics but now read an already-resolved boolean → live on a dev agent.
- `src/server/routes.ts` — `/preferences/session-context` resolves the gate so its check agrees with the union reader's `isLive()` (a gating-consistency change to an existing route — no new endpoint; E2E-pairing exempt).
- `src/core/PostUpdateMigrator.ts` — `migrateConfigStateSyncStoresDevGate` strips ONLY the exact old-default signature `{ enabled:false, dryRun:true }` per store so `applyDefaults` backfills `dryRun:false`; any operator-touched block is left alone. Idempotent (Migration Parity).

## Behavioral impact

- **Dev agents:** all 7 stores resolve LIVE + `dryRun:false` — the family is finally dogfooded. Replication is between the operator's own machines only (no external egress, no spend); PII stores keep their existing at-rest honesty and local-authoritative principal resolution. Fully reversible (rollback-unmerge).
- **Fleet + single-machine agents:** unchanged no-op (stores resolve dark exactly as before). An explicit config `enabled` still wins (force-dark false / fleet-flip true).

## Tests

`state-sync-stores-dark-gate` (40), `PostUpdateMigrator-stateSyncStoresDevGate` (7), the 5 ws2x wiring tests, `lint-dev-agent-dark-gate` (line-map recomputed — 7 stateSync entries removed), `no-silent-fallbacks`, `feature-delivery-completeness` — all green locally. `tsc --noEmit` exit 0.

Spec: `docs/specs/multi-machine-replicated-store-foundation.md` (converged + approved). Side-effects: `upgrades/side-effects/mm-stores-devgate.md`.

## ELI16 — turning on the cross-machine memory features for my own dev agent so they actually get tested

The 7 cross-machine memory-sync features (my preferences, who I know, what I've learned, my knowledge base, my action queue, the user list, and which operator owns each topic) were shipped switched-off even on my own development agent — so they never actually got exercised and just sat there rotting. This turns them on for development agents (still completely off for everyone else, and a no-op on any single-machine setup) so they finally get tested instead of being dead code. Nothing changes for normal users.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
