### PR TITLE
fix(session-reaper): make age-limit kill transcript-aware (close MCP/tool blind spot)

### DIFF
--- a/.instar/instar-dev-decisions/2026-06-14T05-04-15-109Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-06-14T05-04-15-109Z-unknown.json
@@ -1,0 +1,15 @@
+{
+  "ts": "2026-06-14T05:04:15.109Z",
+  "slug": "unknown",
+  "suggestedTier": 2,
+  "declaredTier": 2,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "new capability: new config key added"
+  ],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 81,
+  "causalAutopsy": null,
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-06-14T05-06-53-854Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-06-14T05-06-53-854Z-unknown.json
@@ -1,0 +1,15 @@
+{
+  "ts": "2026-06-14T05:06:53.854Z",
+  "slug": "unknown",
+  "suggestedTier": 2,
+  "declaredTier": 2,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "new capability: new config key added"
+  ],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 81,
+  "causalAutopsy": null,
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-06-14T05-09-39-714Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-06-14T05-09-39-714Z-unknown.json
@@ -1,0 +1,15 @@
+{
+  "ts": "2026-06-14T05:09:39.714Z",
+  "slug": "unknown",
+  "suggestedTier": 2,
+  "declaredTier": 2,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "new capability: new config key added"
+  ],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 81,
+  "causalAutopsy": null,
+  "verdict": "pass"
+}

--- a/docs/specs/age-kill-transcript-aware-resume.eli16.md
+++ b/docs/specs/age-kill-transcript-aware-resume.eli16.md
@@ -1,0 +1,32 @@
+# Age-Kill Transcript-Awareness — Plain-English Overview
+
+> The one-line version: the watchdog that retires very old sessions couldn't "see" work being done through the browser tool, so it killed a session that was busy — this teaches it to look at the session's live activity log before pulling the trigger.
+
+## The problem in one breath
+
+The agent runs each conversation as a long-lived background "session." A safety watchdog retires sessions that have been open a very long time (about 5 hours) — but only AFTER checking they're actually idle. The idle check looks at two things: is the terminal sitting quietly, and is anything running as a child program. Work done through the browser tool (and other plug-in "MCP" tools) shows up in NEITHER of those, so a session that was busy driving a browser looked idle and got killed mid-task — with no heads-up and no automatic resume.
+
+## What already exists
+
+- **The age watchdog** — retires sessions older than ~5 hours, but defers the kill if the session looks busy. The "looks busy" test is the weak part.
+- **A second, smarter reaper** — the one that retires *idle* sessions under memory/CPU pressure. It ALREADY cross-checks the session's live activity log (the transcript file that grows every time the agent does anything) and refuses to kill a session whose log is still growing. So that path would never have made this mistake.
+- **A mid-work resume queue** — brings interrupted work back. It only fires when a kill is tagged "was mid-work," which this kill was not.
+
+## What this adds
+
+One thing: the age watchdog now also checks the live activity log — the same signal the smarter reaper already trusts. If the session's log was written in the last 2 minutes, the session counts as busy and the kill is deferred (exactly like it already defers when a child program is running). Nothing else changes.
+
+## The new piece
+
+- **A tiny "was this session active recently?" probe** — it finds the session's activity-log file and checks when it was last written. Recent = busy = don't kill yet. It is deliberately cautious in the safe direction: if it can't find or read the log, it says "I don't know" and falls back to today's behavior — it never keeps a possibly-dead session alive forever.
+
+## The safeguards
+
+- It can only make the watchdog MORE cautious (kill fewer active sessions), never more aggressive.
+- Genuinely-finished sessions still get retired — once their log goes quiet, the existing idle check catches them within minutes. A just-finished session is at most deferred for one 2-minute window.
+- It's machine-local by design — each machine only ever looks at its own sessions and its own logs; nothing crosses between machines.
+- Fully covered by tests (busy → kept, quiet → reaped, unreadable → safe fallback), and it can be turned inert by setting the window to zero.
+
+## What you're deciding
+
+Whether to teach the age watchdog the same transcript check the other reaper already uses, so an actively-working session is never again retired as "idle." The blast radius is small (one defer condition added to one existing kill path), the rollback is a one-file revert, and it directly closes the exact failure that killed the EchoOfDawn session.

--- a/docs/specs/age-kill-transcript-aware-resume.md
+++ b/docs/specs/age-kill-transcript-aware-resume.md
@@ -1,0 +1,204 @@
+---
+title: "Age-Kill Transcript-Awareness — close the MCP/tool blind spot in the session age-limit reaper"
+slug: "age-kill-transcript-aware-resume"
+author: "echo"
+parent-principle: "Observation Needs Structure"
+eli16-overview: "age-kill-transcript-aware-resume.eli16.md"
+status: "converged"
+approved: true
+approved-by: "operator pre-approval — Justin, topic 25660, 2026-06-13: explicit pre-approval for this directive's decisions and any specs needing approval (exercised by Echo in the pre-approved 24h autonomous run; operator may revoke)"
+review-convergence: "2026-06-14T04:59:28.794Z"
+review-iterations: 2
+review-completed-at: "2026-06-14T04:59:28.794Z"
+review-report: "docs/specs/reports/age-kill-transcript-aware-resume-convergence.md"
+cross-model-review: "degraded-all-rounds"
+cross-model-review-reason: "codex not on session PATH; gemini API returned invalid content (retries exhausted)"
+single-run-completable: true
+frontloaded-decisions: 0
+cheap-to-change-tags: 0
+contested-then-cleared: 0
+---
+
+# Age-Kill Transcript-Awareness
+
+**Parent principle — "Observation Needs Structure"** (`docs/STANDARDS-REGISTRY.md`). Its corollary
+"your record schema is your perception — a missing category is a designed-in blindspot" is the
+indisputable fit: the age-gate's perception of "is this session working?" had a designed-in
+blindspot — it observed only the pane + child-procs and was structurally blind to the MCP/tool
+activity category. A guard whose perception silently omits a category cannot see the work it is
+killing; this change gives the age-gate the transcript-activity category its sibling guard (the
+SessionReaper) already perceives, so its self-model of session activity matches reality.
+
+## 1. Problem
+
+On 2026-06-13 an interactive session that was actively doing real work — driving the
+Playwright MCP server to provision the EchoOfDawn GitHub identity, interleaved with
+short `gh`/`curl` calls — was **terminal-killed by the session age-limit reaper** with no
+resume and a delayed notice. The operator saw silence, not a heads-up.
+
+Forensics (from `logs/reap-log.jsonl` + source):
+
+- The kill came from `SessionManager`'s wall-clock age enforcement (`terminateSession(id, 'age-limit', { disposition: 'terminal' })`), fired at the ~5h mark (`DEFAULT_MAX_DURATION_MINUTES = 240` + a 20%/max-60m buffer ≈ 300m). The session had been open since 15:30.
+- Reap-log recorded `midWork:false` → the session was NOT queued for mid-work resume.
+- The age-kill path's "is this session still working?" gate (the `ageGateTrulyIdle` check) consults only two signals: the tmux pane shows an idle prompt (`captureMeaningfulTail` + `IDLE_PROMPT_PATTERNS`) AND there is no non-baseline child process (`hasActiveProcesses`).
+- **Both signals are blind to MCP/tool work.** The Playwright MCP server runs OUT of the tmux session's process tree, and bash tool calls are short-lived. Between tool calls the pane shows an idle-looking prompt and there is no child process — so an actively-working session reads as "truly idle" and becomes age-kill-eligible.
+
+The root mechanism is a **parity gap between the two reap paths**:
+
+- The `SessionReaper` (the idle/pressure path) ALREADY layers transcript-growth awareness — it imports `probeTranscript` / `transcriptDelta` and requires `flat-transcript + positive-idle + confirmObservations` before a session is reap-eligible. A session whose JSONL is still growing is `'grew'` → KEEP. It would NOT have killed the EchoOfDawn session.
+- The `SessionManager` age-limit kill path does NOT layer transcript-growth. It is the lone blind spot.
+
+## 2. Goal / non-goals
+
+**Goal:** bring the age-limit kill path to parity with the SessionReaper's existing
+transcript-awareness, so a session that is actively producing output (its framework
+transcript is growing) is treated as working and the kill is HELD OFF — exactly as a
+session with a live child process already is. This both prevents the wrongful kill AND,
+because the only sessions age-killed are now genuinely quiet, makes the resume question
+moot for this path (we no longer terminal-kill active work).
+
+**Non-goals (deliberately out of scope, with reasons — not punted work):**
+
+- **No change to the WorkEvidence enum or the ReapGuard `evaluate()`/`workEvidence()` keep/resume logic.** That subsystem is fragile (documented kill/revive loops: 2026-06-13 13-session loop on stale `open-commitment`; 2026-06-05 flood). The lightest correct fix is to fix the blind path, not to re-architect evidence. The SessionReaper's existing transcript-awareness already covers the pressure/idle path; the age-path fix below covers the only remaining gap, so an active session is now protected on ALL paths without touching evidence. `<!-- tracked: topic-25660 -->` (a transcript-active WORK-EVIDENCE signal for the rare "active session hard-killed by a non-age path" case is a separate, evaluate()-coupled change requiring its own loop-safety analysis; recorded against topic 25660 for a future, independently-reviewable spec).
+- **No change to the reap-notify coalescing window.** The notice-delay symptom is a property of the genuine-idle reap notice path; with active sessions no longer age-killed, the active-session-silent-kill symptom is removed at the source. The notifier promptness question is a separate subsystem.
+
+## 3. Design
+
+### 3.1 New probe — `SessionManager.isTranscriptRecentlyActive(session, withinMs)`
+
+A small, public method on `SessionManager`:
+
+```
+isTranscriptRecentlyActive(session, withinMs):
+  sessionId = session.claudeSessionId
+  if !sessionId: return false
+  jsonlPath = resolveFrameworkTranscriptPath({
+    framework: session.framework ?? 'claude-code',
+    sessionId,
+    projectDir: session.cwd ?? this.config.projectDir,
+  })
+  if !jsonlPath: return false
+  return (Date.now() - statSync(jsonlPath).mtimeMs) < withinMs
+  // any throw (missing file, permission, stat error) ⇒ return false
+```
+
+- Reuses the same per-framework resolver the SessionReaper's `probeTranscript` uses (`resolveFrameworkTranscriptPath` from `core/FrameworkSessionStore`) — a CORE module, so no `core → monitoring` layering inversion. It deliberately does NOT depend on `monitoring/transcriptProber`.
+- Single-point mtime recency, NOT the SessionReaper's cross-tick `transcriptDelta` (grew/static across two snapshots). The two ask deliberately different questions: the SessionReaper asks "did it grow since my last tick?" (it owns multi-tick idle confirmation via `confirmObservations` + positive-idle); the age gate asks "was it touched in the last `withinMs`?" — the right shape for a single over-age check. The asymmetry is intentional and benign: a transcript last written 90s ago reads `static` to the SessionReaper's single-tick delta yet `recently-active` to the age gate. That cannot produce a contradictory kill — the SessionReaper never reaps on one `static` read (it requires repeated positive-idle confirmations), and the two paths are independent authorities; the age gate is simply the more conservative of the two within its 2-min window.
+- **Per-framework coverage + safe degradation.** `resolveFrameworkTranscriptPath` resolves claude-code (deterministic path), codex-cli (date-tree glob), and gemini-cli (session-file lookup). It has **no `pi-cli` case** — pi-cli falls through to the claude-code default and will not resolve a real pi transcript. This is a PRE-EXISTING gap in the shared resolver (it equally affects the SessionReaper's `probeTranscript`, `PreCompactionFlush`, and `ResumeValidator` — every transcript consumer, not just this change), surfaced by the convergence foundation-audit. For this change the consequence is **safe degradation, never regression**: a pi-cli (or any unresolvable) session gets `isTranscriptRecentlyActive === false` and the age gate falls back to EXACTLY today's pane/procs verdict — pi-cli is no worse than before this change, while claude/codex/gemini GAIN the transcript-deferral. Fixing pi-cli transcript resolution is a separate shared-foundation change (it needs pi's real transcript layout and re-tests all consumers) and is out of scope here. `<!-- tracked: topic-25660 -->`
+- **Fail direction:** an unprobeable transcript (no session id, unresolved path, missing file, stat error) returns `false` — NOT evidence of activity. This never *blocks* a kill on an unreadable transcript; it falls through to the existing pane/procs verdict. (Correct: a keep-true fail-safe here would pin a possibly-dead session alive forever — wrong direction for this method, which only ADDS a defer condition.)
+
+### 3.2 Wire it into the age gate
+
+In the wall-clock age block (`elapsed > limit`):
+
+```
+const ageGateTranscriptActive = this.isTranscriptRecentlyActive(session, AGE_GATE_TRANSCRIPT_ACTIVE_MS);
+const ageGateTrulyIdle = ageGateIsIdle && !ageGateHasProcs && !ageGateTranscriptActive;
+```
+
+The idle decision itself is extracted into a pure, exported
+`isAgeGateTrulyIdle(idleAtPrompt, hasActiveProcs, transcriptActive)` = `idleAtPrompt &&
+!hasActiveProcs && !transcriptActive`, called as
+`ageGateTrulyIdle = isAgeGateTrulyIdle(!!ageGateIsIdle, ageGateHasProcs, ageGateTranscriptActive)`.
+The extraction makes the exact incident reproducible at the decision boundary in a unit test
+(Bug-Fix Evidence Bar) without driving the whole `monitorTick` loop.
+
+A transcript-active session is therefore NOT "truly idle" → the existing `!ageGateTrulyIdle`
+branch defers the kill (logs the one-shot "actively working … Deferring kill" line, now also
+reporting `transcriptActive=…`), and falls through to idle-detection so a session that LATER
+goes quiet is still caught. No new kill path; one new defer condition.
+
+### 3.3 Constant
+
+`AGE_GATE_TRANSCRIPT_ACTIVE_MS = 120_000` (2 min). Comfortably covers the gap between tool
+calls during active MCP work. Over-deferring a just-finished session for at most one window is
+harmless: the idle-detection block below still reaps it once the transcript goes quiet.
+A code constant (not a config key) — it ships with the dist on update, so no Migration-Parity
+config work is required.
+
+## 4. Signal vs Authority
+
+The change is a SIGNAL that ADDS a defer (keep) condition to an existing authority; it grants
+NO new blocking authority and moves strictly in the safe direction (fewer kills of active
+sessions). It mirrors the SessionReaper's already-shipped transcript signal. Brittle-probe risk
+is bounded by the fail-to-`false` contract: a probe error never keeps a session alive, it only
+declines to add the new defer reason.
+
+## 4.1 The age cap is a zombie reaper, not a hard resource cap (denial-of-reaping)
+
+Convergence review (security) raised: with this change a session that keeps its transcript
+fresh is never age-killed — so a session could "stay alive forever." This is the INTENDED
+behavior, and it is not a new hole:
+
+- **Only real model activity keeps the transcript fresh.** A Claude Code session does not have
+  a tool to touch its own transcript mtime independent of producing turns; the runtime appends
+  to the JSONL when (and only when) the model actually does a turn / tool call. Keeping the
+  mtime <2-min fresh therefore REQUIRES continuous real work — which is precisely the state the
+  age gate should defer, not the gameable no-op the phrase "touch the file" implies.
+- **It matches the existing SessionReaper policy.** The pressure/idle reaper ALREADY refuses to
+  kill a session whose transcript is still growing (`'grew'` ⇒ KEEP). An actively-producing
+  session is already non-reapable system-wide; this change brings the age path into line, it
+  does not invent a new exemption.
+- **It is what the operator explicitly asked for** (topic 25660): "There's no reason the session
+  should be killed [while it has work in flight]." The age cap's job is to retire ZOMBIES (open
+  tmux, no model activity), not to wall-clock-evict live work.
+- **Runaway-but-active sessions are owned by other guards, not this one.** A session stuck in a
+  tight produce-garbage loop is the domain of the SessionWatchdog (stuck-process / escalating
+  kill), the context-wedge sentinel, and the CPU/memory-pressure reaper — all of which still
+  apply unchanged. The age gate deliberately does NOT try to be a hard resource ceiling; layering
+  one back on (e.g. "kill even an active session at 24h") would reintroduce the exact
+  kill-active-work bug this spec fixes and is explicitly rejected.
+
+## 5. Side effects (full review in the instar-dev artifact)
+
+- **Over-block (wrongly defers a kill):** a genuinely-finished session whose transcript was
+  touched <2m ago is held off for up to one window. Harmless — idle-detection reaps it next.
+- **Under-block (still kills something it shouldn't):** none new; the change only adds a defer
+  condition. A session with NO resolvable transcript (e.g. a framework whose transcript can't be
+  located) falls through to today's pane/procs verdict — identical to current behavior.
+- **Interactions:** consistent with the SessionReaper's existing transcript-growth gate (same
+  resolver, same intent); idle-detection block still owns genuinely-idle reaping; the
+  `overAgeButActiveLogged` once-per-session log set already prevents spam on the held-off path.
+- **Multi-machine posture:** machine-local BY DESIGN — each machine reaps only its own sessions
+  and reads only its own local transcripts. No replication/proxy surface; nothing crosses a
+  machine boundary.
+- **Rollback:** revert the PR (single-file behavior change + tests); no data migration, no agent
+  state repair. As an interim dial, setting the window to 0 makes the new condition inert.
+
+## 6. Testing (Testing Integrity)
+
+- **Unit (behavioral, `isTranscriptRecentlyActive`):** returns true for a transcript modified
+  within the window, false for stale, false for no-sessionId, false for a missing file, and
+  false (safe-degrade) for a non-claude framework whose transcript is unresolvable (codex-cli +
+  pi-cli) — both sides of every boundary, real fs fixtures written at the resolved path.
+- **Unit (decision boundary, `isAgeGateTrulyIdle`) — REPRODUCES the original failure
+  (Bug-Fix Evidence Bar):** the exact incident inputs (idle pane + no child proc + ACTIVE
+  transcript) resolve to `false` ⇒ held off, not killed; the genuine-zombie inputs (idle pane
+  + no proc + quiet transcript) resolve to `true` ⇒ still killed (no regression); a live child
+  process or a non-idle pane is never truly-idle. Exhaustive over all 8 combinations.
+- **Unit (source-assertion):** the age gate computes `ageGateTranscriptActive` via
+  `isTranscriptRecentlyActive` and feeds all three signals to `isAgeGateTrulyIdle`; the
+  constant + resolver import exist.
+- Typecheck (`tsc --noEmit`) clean; full unit suite green (Zero-Failure Standard).
+
+### 6.1 Test-tier applicability (Testing Integrity Standard)
+
+The three-tier mandate (unit / integration-HTTP / E2E-lifecycle) is calibrated for features
+with **API routes** — the "feature is alive, returns 200 not 503" E2E is its load-bearing case.
+This change introduces **no route, no DI component, no config/HTTP surface**: it is a pure
+decision method inside `SessionManager.monitorTick`. The substantive test surface is therefore
+the decision boundary itself, which the `isAgeGateTrulyIdle` extraction now covers directly
+(both sides, all combinations, the original-failure repro). A genuine E2E ("a real session is
+age-killed after >5h, then NOT killed when its transcript is live") is impractical — it would
+require a multi-hour wall-clock wait per run; the decision-boundary repro is the faithful,
+deterministic substitute. Integration/E2E tiers are recorded **N/A with this reason**, not
+skipped silently. (Conformance gate, round 1: Testing Integrity + Bug-Fix Evidence Bar
+findings — both addressed here.)
+
+## 7. Acceptance criteria
+
+1. An over-age session whose transcript was modified within `AGE_GATE_TRANSCRIPT_ACTIVE_MS` is
+   held off, not terminal-killed.
+2. An over-age, transcript-quiet, pane-idle, no-child-proc session is still killed (no
+   regression to the genuine-zombie reap).
+3. tsc clean; new unit tests pass; existing session-timeout tests still pass.

--- a/docs/specs/reports/age-kill-transcript-aware-resume-convergence.md
+++ b/docs/specs/reports/age-kill-transcript-aware-resume-convergence.md
@@ -1,0 +1,75 @@
+# Convergence Report — Age-Kill Transcript-Awareness
+
+## ⚠ Cross-model review: DEGRADED — ALL ROUNDS (degraded-all-rounds)
+
+The external (non-Claude) reviewer pass did NOT yield a successful opinion this convergence.
+`codex` was not on this session's PATH (recorded active in the 7-day history, but the CLI was
+not invocable here), and the `gemini` pass DEGRADED — the gemini CLI returned
+`API returned invalid content after all retries (retry attempts exhausted)`. Per the aggregation
+rule this is `degraded-all-rounds`: a non-Claude framework was present in the lookback but zero
+external rounds succeeded. **The spec converged on the SIX internal Claude reviewers + the
+code-backed Standards-Conformance gate only.** The reader should weigh this reduced external
+assurance before approving — though note the change is a ~60-LOC, dark-safe, single-decision-path
+fix with an extensive internal + constitutional review.
+
+## ELI10 Overview
+
+A watchdog retires very old agent sessions (~5h) but is supposed to spare ones still working.
+Its "still working?" test couldn't see work done through the browser/plug-in tools, so it killed
+a busy session by mistake. This change teaches that watchdog the same trick the system's *other*
+reaper already uses: check whether the session's live activity log was written in the last couple
+of minutes. If it was, the session is busy — don't kill it. Nothing else changes; the watchdog
+can now only be *more* careful, never less.
+
+## Original vs Converged
+
+The original spec already proposed the core fix (transcript-mtime check in the age gate) plus the
+`isTranscriptRecentlyActive` probe. Review changed it in four ways:
+
+1. **Reproduce-the-failure test (Bug-Fix Evidence Bar).** The idle decision was extracted into a
+   pure, exported `isAgeGateTrulyIdle(...)` so the EXACT incident inputs (idle pane + no child
+   proc + a growing transcript) are unit-tested to resolve to "deferred, not killed" — the
+   original plan tested the probe in isolation but never reproduced the actual failure.
+2. **Denial-of-reaping rationale (§4.1).** Security flagged that a session can stay alive by
+   keeping its transcript fresh. The spec now documents this is INTENDED and safe: only real
+   model activity refreshes the transcript, it matches the existing SessionReaper policy, the
+   operator explicitly asked for it, and runaway-but-active sessions are owned by other guards.
+3. **pi-cli safe-degradation (§3.1).** Two reviewers found `resolveFrameworkTranscriptPath` has
+   no pi-cli case (a pre-existing shared-foundation gap affecting all transcript consumers). The
+   spec now documents that pi-cli (and any unresolvable framework) safely degrades to today's
+   pane/procs behavior — no regression — and tracks the resolver gap as separate work.
+4. **Test-tier applicability (§6.1) + cross-framework coverage.** Integration/E2E tiers are
+   recorded N/A-with-reason (no route/DI/HTTP surface; a real >5h E2E is impractical), and a
+   cross-framework safe-degradation test (codex-cli + pi-cli) was added.
+
+## Iteration Summary
+
+| Iteration | Reviewers who flagged | Material findings | Spec changes |
+|-----------|-----------------------|-------------------|--------------|
+| 1 | conformance(Testing Integrity, Bug-Fix Evidence Bar), security, integration, lessons-aware | 6 | §6.1 tier-applicability; `isAgeGateTrulyIdle` extraction + repro test; §4.1 denial-of-reaping rationale; §3.1 pi-cli safe-degradation + mtime/delta asymmetry; cross-framework test; framework-parity wording fix |
+| 2 | (convergence check) | 0 new | none — conformance gate returns NO FINDINGS; checker verdict CONVERGED |
+
+Standards-Conformance Gate: round 1 — ran (2 flags: Testing Integrity, Bug-Fix Evidence Bar); round 2 — ran (0 flags).
+
+## Full Findings Catalog
+
+- **[HIGH] security — denial-of-reaping:** active session stays alive via fresh transcript →
+  RESOLVED as intended design (§4.1): real-activity-only refresh, matches SessionReaper, operator
+  intent, runaway owned by SessionWatchdog/pressure-reaper.
+- **[HIGH] integration + lessons-aware — pi-cli resolver fallthrough:** transcript-deferral inert
+  for pi-cli → RESOLVED via documented safe-degradation (no regression) + tracked foundation gap (§3.1).
+- **[MEDIUM] integration — cross-framework test gap:** RESOLVED, codex-cli + pi-cli safe-degrade
+  test added (§6).
+- **[LOW] integration — implied framework parity:** RESOLVED, §3.1 documents per-framework coverage.
+- **[conformance] Testing Integrity (missing tiers):** RESOLVED, §6.1 N/A-with-reason.
+- **[conformance] Bug-Fix Evidence Bar (reproduce failure):** RESOLVED, decision-boundary repro test.
+- **[lessons-aware] single-point mtime vs cross-tick delta asymmetry:** RESOLVED, §3.1 documents
+  the intentional, benign asymmetry.
+- **adversarial, scalability, decision-completeness:** NO MATERIAL FINDINGS (loop-safety confirmed;
+  negligible per-tick statSync cost; no parked user-decisions).
+
+## Convergence verdict
+
+Converged at iteration 2. No material findings in the verification round; the code-backed
+conformance gate returns NO FINDINGS on the converged spec. Spec is ready for user review and
+approval. External (non-Claude) assurance was degraded this run (see banner).

--- a/src/core/SessionManager.ts
+++ b/src/core/SessionManager.ts
@@ -18,6 +18,7 @@ import { SessionLivenessOracle, type SessionLivenessOracleConfig } from './Sessi
 import { resolveGhTokenFromVault } from './ghToken.js';
 import type { ReapGuard } from './ReapGuard.js';
 import { clampWorkEvidence, isMidWork } from './WorkEvidence.js';
+import { resolveFrameworkTranscriptPath } from './FrameworkSessionStore.js';
 import { paneShowsClaudeWorking } from './claudeActivityIndicators.js';
 import { extractGeminiFinalAssistantBlock, meaningfulTail } from './paneText.js';
 import { ensureInteractiveReady } from './ensureInteractiveReady.js';
@@ -80,6 +81,39 @@ import { AgeKillBackoff } from './AgeKillBackoff.js';
 
 /** Absolute maximum session duration (4 hours) — safety net for sessions without explicit timeout */
 const DEFAULT_MAX_DURATION_MINUTES = 240;
+
+/** Age-gate transcript-activity window (ms). A session whose framework transcript
+ *  (JSONL) was modified within this window is treated as actively producing work
+ *  — the same "defer the kill" treatment a live child process gets — even when
+ *  its tmux pane shows an idle-looking prompt and it has no non-baseline child
+ *  process. This closes the age-kill blind spot to MCP/tool work (Playwright and
+ *  other MCP servers run OUT of the pane's process tree; bash tool calls are
+ *  short-lived), which terminal-killed an actively-working session on 2026-06-13.
+ *  Claude Code appends to the JSONL on every turn/tool event, so a recent mtime
+ *  is ground-truth liveness independent of the pane. 2 min comfortably covers the
+ *  gap between tool calls; over-deferring a just-finished session for up to one
+ *  window is harmless (the idle-detection block below still reaps it later). */
+const AGE_GATE_TRANSCRIPT_ACTIVE_MS = 120_000;
+
+/**
+ * Pure age-gate idle decision — extracted so the exact 2026-06-13 incident can be
+ * reproduced at the decision boundary (Bug-Fix Evidence Bar). A session past its
+ * age limit is "truly idle" — and thus age-kill-eligible — ONLY when ALL THREE
+ * hold: its pane shows an idle prompt, it has no non-baseline child process, and
+ * its framework transcript is not recently active. Any ONE positive activity
+ * signal (a live child process OR a growing transcript) defers the kill. The
+ * transcript term is the fix: it closes the blind spot to MCP/tool work that runs
+ * OUT of the pane's process tree. The incident inputs
+ * (idleAtPrompt=true, hasActiveProcs=false, transcriptActive=true) return
+ * `false` ⇒ DEFERRED, not killed — which the pre-fix two-signal decision got wrong.
+ */
+export function isAgeGateTrulyIdle(
+  idleAtPrompt: boolean,
+  hasActiveProcs: boolean,
+  transcriptActive: boolean,
+): boolean {
+  return idleAtPrompt && !hasActiveProcs && !transcriptActive;
+}
 
 /** Minutes of idle-at-prompt before a non-protected session is killed */
 const IDLE_PROMPT_KILL_MINUTES = 15;
@@ -1247,7 +1281,17 @@ rm()  { "${shimRunner}" rm  "$@"; }
             const ageGateOutput = this.captureMeaningfulTail(session.tmuxSession, 5);
             const ageGateIsIdle = ageGateOutput && IDLE_PROMPT_PATTERNS.some(p => ageGateOutput.includes(p));
             const ageGateHasProcs = this.hasActiveProcesses(session.tmuxSession);
-            const ageGateTrulyIdle = ageGateIsIdle && !ageGateHasProcs;
+            // Transcript-activity backstop (2026-06-13 incident): the pane+procs
+            // check is BLIND to MCP/tool work. A session driving Playwright (or any
+            // MCP server) runs that work OUT of the tmux process tree, and between
+            // tool calls the pane shows an idle-looking prompt — so an actively
+            // working session reads as "idle, no procs" and was terminal-killed at
+            // the age limit. The framework transcript grows on every turn/tool
+            // event, so a recently-modified JSONL is ground-truth that the session
+            // is alive and producing. Treat it exactly like a live child process:
+            // defer the kill.
+            const ageGateTranscriptActive = this.isTranscriptRecentlyActive(session, AGE_GATE_TRANSCRIPT_ACTIVE_MS);
+            const ageGateTrulyIdle = isAgeGateTrulyIdle(!!ageGateIsIdle, ageGateHasProcs, ageGateTranscriptActive);
 
             if (!ageGateTrulyIdle) {
               // Over age limit but actively working. Log once per session to
@@ -1257,7 +1301,7 @@ rm()  { "${shimRunner}" rm  "$@"; }
                 this.overAgeButActiveLogged.add(session.id);
                 console.warn(
                   `[SessionManager] Session "${session.name}" is past the age limit (${Math.round(elapsed)}m > ${maxMinutes}m) ` +
-                  `but is actively working (procs=${ageGateHasProcs}, idleAtPrompt=${!!ageGateIsIdle}). Deferring kill; ` +
+                  `but is actively working (procs=${ageGateHasProcs}, idleAtPrompt=${!!ageGateIsIdle}, transcriptActive=${ageGateTranscriptActive}). Deferring kill; ` +
                   `the idle-detection block will catch it once it stops producing work.`
                 );
               }
@@ -2626,6 +2670,39 @@ rm()  { "${shimRunner}" rm  "$@"; }
     const raw = this.captureOutput(tmuxSession, Math.max(lines * 4, 50));
     if (raw === null) return null;
     return meaningfulTail(raw, lines);
+  }
+
+  /**
+   * Transcript-activity probe — ground-truth liveness independent of the tmux
+   * pane and process tree. A session doing MCP/tool work (e.g. driving Playwright)
+   * runs that work OUT of the pane's process tree and, between tool calls, shows an
+   * idle-looking prompt with no non-baseline child process — so the pane+procs
+   * activity check reads it as idle and the age-kill terminal-reaped it mid-work
+   * (2026-06-13 incident). The framework JSONL grows on every turn/tool event, so
+   * a transcript modified within `withinMs` proves the session is alive and
+   * producing. Returns true on a recent mtime; false on anything unprobeable
+   * (no session id, '' path, missing file, stat error) — never block a kill on a
+   * transcript we cannot read (the safe direction is to fall through to the
+   * pane/procs verdict, not to keep a possibly-dead session alive forever).
+   */
+  isTranscriptRecentlyActive(session: Session, withinMs: number): boolean {
+    try {
+      const sessionId = session.claudeSessionId;
+      if (!sessionId) return false;
+      const jsonlPath = resolveFrameworkTranscriptPath({
+        framework: session.framework ?? 'claude-code',
+        sessionId,
+        projectDir: session.cwd ?? this.config.projectDir,
+      });
+      if (!jsonlPath) return false;
+      const stat = fs.statSync(jsonlPath);
+      return Date.now() - stat.mtimeMs < withinMs;
+    } catch {
+      // @silent-fallback-ok — an unprobeable transcript is NOT evidence of
+      // activity; fall through to the pane/procs verdict rather than pinning a
+      // possibly-dead session alive on a read error.
+      return false;
+    }
   }
 
   private currentPaneCwd(tmuxSession: string): string | null {

--- a/tests/unit/session-manager-behavioral.test.ts
+++ b/tests/unit/session-manager-behavioral.test.ts
@@ -92,7 +92,8 @@ vi.mock('node:child_process', () => {
 import { execFileSync } from 'node:child_process';
 import { SessionManager } from '../../src/core/SessionManager.js';
 import { StateManager } from '../../src/core/StateManager.js';
-import type { SessionManagerConfig } from '../../src/core/types.js';
+import type { SessionManagerConfig, Session } from '../../src/core/types.js';
+import { resolveFrameworkTranscriptPath } from '../../src/core/FrameworkSessionStore.js';
 
 describe('SessionManager behavioral tests', () => {
   let tmpDir: string;
@@ -530,5 +531,113 @@ describe('SessionManager behavioral tests', () => {
     it('unknown instar session id is a safe no-op', () => {
       expect(() => manager.setClaudeSessionId('no-such-id', 'some-uuid')).not.toThrow();
     });
+  });
+});
+
+/**
+ * isTranscriptRecentlyActive — the age-kill transcript blind-spot fix (2026-06-13).
+ *
+ * A session doing MCP/tool work (e.g. driving Playwright) runs that work OUT of
+ * the tmux process tree and, between tool calls, shows an idle-looking prompt
+ * with no non-baseline child process — so the pane+procs activity check read it
+ * as idle and the age-kill terminal-reaped it mid-work. The framework JSONL grows
+ * on every turn/tool event, so a recently-modified transcript proves liveness.
+ *
+ * The method resolves the REAL per-framework transcript path (it does not take a
+ * home/root override — that override exists only for the resolver's own tests),
+ * so this test writes the fixture at the resolved path (a uniquely-named encoded
+ * subfolder keyed on a unique tmpDir + UUID — no collision) and removes it after.
+ */
+describe('SessionManager.isTranscriptRecentlyActive', () => {
+  const SESSION_UUID = 'eeeeeeee-1111-4000-8000-aaaaaaaaaaaa';
+  let tmpDir: string;
+  let sm: SessionManager;
+  let writtenPath: string | null;
+
+  const session = (over: Partial<Session> = {}): Session => ({
+    id: 'sess-1',
+    name: 'work',
+    tmuxSession: 'work',
+    claudeSessionId: SESSION_UUID,
+    framework: 'claude-code',
+    cwd: tmpDir,
+    status: 'running',
+    startedAt: new Date().toISOString(),
+    ...over,
+  } as Session);
+
+  const writeTranscript = (mtimeMsAgo: number): void => {
+    // Resolve exactly as the production method does (default home) so the file
+    // we write is the file it reads.
+    const p = resolveFrameworkTranscriptPath({
+      framework: 'claude-code',
+      sessionId: SESSION_UUID,
+      projectDir: tmpDir,
+    });
+    expect(p).not.toBe('');
+    fs.mkdirSync(path.dirname(p), { recursive: true });
+    fs.writeFileSync(p, '{"type":"assistant"}\n');
+    const whenSec = (Date.now() - mtimeMsAgo) / 1000;
+    fs.utimesSync(p, whenSec, whenSec);
+    writtenPath = p;
+  };
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'instar-transcript-active-'));
+    const stateDir = path.join(tmpDir, 'state');
+    fs.mkdirSync(stateDir, { recursive: true });
+    const config: SessionManagerConfig = {
+      tmuxPath: '/usr/bin/tmux',
+      claudePath: '/usr/local/bin/claude',
+      projectDir: tmpDir,
+      maxSessions: 3,
+      protectedSessions: [],
+      completionPatterns: [],
+      framework: 'claude-code',
+    };
+    sm = new SessionManager(config, new StateManager(stateDir));
+    writtenPath = null;
+    mockTmuxSessions.clear();
+  });
+
+  afterEach(() => {
+    // Remove the fixture transcript + its unique encoded parent dir.
+    const op = 'tests/unit/session-manager-behavioral.test.ts: isTranscriptRecentlyActive fixture cleanup';
+    try {
+      if (writtenPath) {
+        SafeFsExecutor.safeRmSync(writtenPath, { force: true, operation: op });
+        SafeFsExecutor.safeRmSync(path.dirname(writtenPath), { recursive: true, force: true, operation: op });
+      }
+    } catch { /* ignore */ }
+    try { SafeFsExecutor.safeRmSync(tmpDir, { recursive: true, force: true, operation: op }); } catch { /* ignore */ }
+  });
+
+  it('returns true when the transcript was modified within the window (MCP work is live)', () => {
+    writeTranscript(10_000); // 10s ago
+    expect(sm.isTranscriptRecentlyActive(session(), 120_000)).toBe(true);
+  });
+
+  it('returns false when the transcript is older than the window (genuinely idle)', () => {
+    writeTranscript(10 * 60_000); // 10 min ago
+    expect(sm.isTranscriptRecentlyActive(session(), 120_000)).toBe(false);
+  });
+
+  it('returns false with no claudeSessionId (unresolvable ⇒ not activity evidence)', () => {
+    writeTranscript(1_000);
+    expect(sm.isTranscriptRecentlyActive(session({ claudeSessionId: undefined }), 120_000)).toBe(false);
+  });
+
+  it('returns false when the transcript file is absent (no false-positive)', () => {
+    // No writeTranscript() — the resolved path has no file ⇒ stat throws ⇒ false.
+    expect(sm.isTranscriptRecentlyActive(session(), 120_000)).toBe(false);
+  });
+
+  it('safe-degrades for a non-claude framework whose transcript is unresolvable', () => {
+    // codex-cli globs ~/.codex/sessions/<date>/...-<uuid>.jsonl; a never-seen UUID
+    // resolves to '' (or no file) ⇒ false. The age gate then falls back to today's
+    // pane/procs verdict — no regression. (Integration-reviewer finding: cross-framework
+    // coverage; same safe-degradation path pi-cli takes via the resolver's default case.)
+    expect(sm.isTranscriptRecentlyActive(session({ framework: 'codex-cli' }), 120_000)).toBe(false);
+    expect(sm.isTranscriptRecentlyActive(session({ framework: 'pi-cli' }), 120_000)).toBe(false);
   });
 });

--- a/tests/unit/session-timeout-activity-aware.test.ts
+++ b/tests/unit/session-timeout-activity-aware.test.ts
@@ -20,6 +20,7 @@
 import { describe, it, expect } from 'vitest';
 import fs from 'node:fs';
 import path from 'node:path';
+import { isAgeGateTrulyIdle } from '../../src/core/SessionManager.js';
 
 const SM_SOURCE = fs.readFileSync(
   path.join(process.cwd(), 'src/core/SessionManager.ts'),
@@ -50,6 +51,25 @@ describe('Activity-aware session-timeout gate', () => {
     expect(SM_SOURCE).toMatch(/IDLE_PROMPT_PATTERNS\.some\(p\s*=>\s*ageGateOutput\.includes\(p\)\)/);
   });
 
+  it('gates the wall-clock kill on transcript activity (MCP/tool blind-spot fix)', () => {
+    // 2026-06-13 incident: a session driving the Playwright MCP server was
+    // age-killed because between tool calls the pane showed an idle prompt and
+    // there was no non-baseline child process (MCP runs out of the pane's
+    // process tree). The pane+procs check is blind to that work. The framework
+    // transcript (JSONL) grows on every turn/tool event, so a recently-modified
+    // transcript is ground-truth liveness. The true-idle determination must
+    // therefore ALSO require the transcript to be inactive.
+    expect(SM_SOURCE).toMatch(/ageGateTranscriptActive\s*=\s*this\.isTranscriptRecentlyActive/);
+    // The idle decision is the extracted pure function fed all three signals
+    // (the transcript term is the new one).
+    expect(SM_SOURCE).toMatch(/ageGateTrulyIdle\s*=\s*isAgeGateTrulyIdle\(\s*!!ageGateIsIdle,\s*ageGateHasProcs,\s*ageGateTranscriptActive\s*\)/);
+    // The probe + window constant must exist (the helper resolves the per-framework
+    // transcript and compares its mtime to the activity window).
+    expect(SM_SOURCE).toContain('AGE_GATE_TRANSCRIPT_ACTIVE_MS');
+    expect(SM_SOURCE).toMatch(/isTranscriptRecentlyActive\s*\(/);
+    expect(SM_SOURCE).toContain('resolveFrameworkTranscriptPath');
+  });
+
   it('defers the kill when the session is not truly idle', () => {
     // The deferred-kill branch must log "Deferring kill" (single source of
     // truth for the operator-visible signal) and must NOT enter the
@@ -78,5 +98,49 @@ describe('Activity-aware session-timeout gate', () => {
       // No `continue;` between the defer log and the closing brace.
       expect(block[0]).not.toMatch(/\bcontinue;\s*$/m);
     }
+  });
+});
+
+/**
+ * Decision-boundary tests for isAgeGateTrulyIdle — the pure idle decision the
+ * age gate uses. These REPRODUCE the 2026-06-13 failure at the decision level
+ * (Bug-Fix Evidence Bar): the inputs that wrongly killed an active session
+ * (idle pane + no child proc + a GROWING transcript) must now resolve to
+ * "not truly idle" ⇒ the kill is deferred. Covers both sides of all three
+ * boundaries (all 8 combinations).
+ */
+describe('isAgeGateTrulyIdle (age-kill decision boundary)', () => {
+  it('REPRODUCES the incident: idle pane + no child proc + ACTIVE transcript ⇒ NOT killed', () => {
+    // Pre-fix this exact combination returned true (killed). It must now be false.
+    expect(isAgeGateTrulyIdle(true, false, true)).toBe(false);
+  });
+
+  it('genuine zombie: idle pane + no child proc + quiet transcript ⇒ still killed (no regression)', () => {
+    expect(isAgeGateTrulyIdle(true, false, false)).toBe(true);
+  });
+
+  it('a live child process defers the kill regardless of transcript', () => {
+    expect(isAgeGateTrulyIdle(true, true, false)).toBe(false);
+    expect(isAgeGateTrulyIdle(true, true, true)).toBe(false);
+  });
+
+  it('a non-idle pane is never truly-idle regardless of the other signals', () => {
+    expect(isAgeGateTrulyIdle(false, false, false)).toBe(false);
+    expect(isAgeGateTrulyIdle(false, false, true)).toBe(false);
+    expect(isAgeGateTrulyIdle(false, true, false)).toBe(false);
+    expect(isAgeGateTrulyIdle(false, true, true)).toBe(false);
+  });
+
+  it('is true ONLY when all three say idle (idle pane, no proc, quiet transcript)', () => {
+    // Exhaustive: exactly one of the 8 combinations is true.
+    let trueCount = 0;
+    for (const idle of [true, false]) {
+      for (const procs of [true, false]) {
+        for (const transcript of [true, false]) {
+          if (isAgeGateTrulyIdle(idle, procs, transcript)) trueCount++;
+        }
+      }
+    }
+    expect(trueCount).toBe(1);
   });
 });

--- a/upgrades/next/age-kill-transcript-aware-resume.md
+++ b/upgrades/next/age-kill-transcript-aware-resume.md
@@ -1,0 +1,60 @@
+# Upgrade Guide — age-kill transcript-awareness
+
+<!-- bump: patch -->
+
+## What Changed
+
+The session age-limit reaper (`SessionManager`'s wall-clock timeout in `monitorTick`) now
+consults the session's live transcript before judging it idle enough to kill. Previously the
+age-gate's "truly idle?" check looked only at the tmux pane (idle prompt) and the process tree
+(no non-baseline child process) — both BLIND to MCP/tool work, which runs out of the pane's
+process tree (the Playwright MCP server) with only short-lived bash calls in between. A session
+actively driving a browser therefore looked idle between tool calls and was terminal-killed at
+the ~5h age cap with `midWork:false` (no resume).
+
+The other reap path — the `SessionReaper` (pressure/idle) — already cross-checks transcript
+growth and would not have killed it. This change brings the age-kill path to parity:
+`SessionManager.isTranscriptRecentlyActive(session, withinMs)` resolves the per-framework
+transcript via the core `resolveFrameworkTranscriptPath` and treats a session whose transcript
+was written within `AGE_GATE_TRANSCRIPT_ACTIVE_MS` (2 min) as actively working — the kill is held
+off, exactly as it already is for a session with a live child process. The idle decision is
+extracted into a pure, exported `isAgeGateTrulyIdle(idleAtPrompt, hasActiveProcs, transcriptActive)`.
+An unresolvable transcript (no session id, missing file, or a framework with no resolver case like
+pi-cli) returns false and the gate falls back to exactly today's pane/procs behavior — safe
+degradation, no regression. Machine-local; no config key, route, or migration.
+
+## What to Tell Your User
+
+- **Long-running sessions don't get killed while they're busy**: "If one of my longer sessions was
+  ever shut down while I was actually in the middle of real work — especially driving a browser or
+  an automation tool — that shouldn't happen anymore. I now tell whether I'm still working from my
+  live activity, not just whether the terminal looks quiet, so the watchdog leaves me alone until I
+  genuinely stop."
+
+## Summary of New Capabilities
+
+| Capability | How to Use |
+|-----------|-----------|
+| Age-reaper recognizes browser/tool work as "active" | automatic |
+
+## Evidence
+
+This fixes a real production incident, verified two ways:
+
+**Before (the actual failure, from `logs/reap-log.jsonl`):** the session
+`Self-Coherence — Knowing My Own Parallel Work` (topic 25660), which was actively driving the
+Playwright MCP server to provision a GitHub identity, was reaped at `2026-06-14T03:34:55Z` with
+`reason:"age-limit"`, `disposition:"terminal"`, `midWork:false` — killed mid-work, no resume, at
+the ~5h cap, because between tool calls the pane looked idle and no child process existed.
+
+**After (decision-boundary reproduction):** the extracted `isAgeGateTrulyIdle` is unit-tested over
+all 8 input combinations. The exact incident inputs — idle pane + no child process + a transcript
+written in the last 2 minutes — now resolve to `false` (held off, not killed), while the
+genuine-zombie inputs (idle pane + no process + a quiet transcript) still resolve to `true` (still
+reaped — no regression to the real zombie-cleanup). Behavioral tests also cover
+`isTranscriptRecentlyActive` for recent/stale/no-id/missing-file/cross-framework cases.
+
+**Why not a full live before/after:** reproducing the original end-to-end requires a >5h wall-clock
+wait plus a live MCP session, so it is not practical to exercise in dev; the decision-boundary
+repro over the captured incident inputs is the faithful, deterministic substitute, and the real
+reap-log entry above is the production "before."

--- a/upgrades/side-effects/age-kill-transcript-aware-resume.md
+++ b/upgrades/side-effects/age-kill-transcript-aware-resume.md
@@ -1,0 +1,115 @@
+# Side-Effects Review — Age-Kill Transcript-Awareness
+
+**Version / slug:** `age-kill-transcript-aware-resume`
+**Date:** `2026-06-14`
+**Author:** `echo`
+**Second-pass reviewer:** spec-convergence panel (6 internal reviewers + Standards-Conformance gate; external non-Claude pass degraded — see convergence report)
+
+## Summary of the change
+
+The session age-limit reaper (`SessionManager.monitorTick`, the `elapsed > limit` block) decides
+whether an over-age session is "truly idle" and therefore age-kill-eligible. Before this change
+that decision used only two signals — the tmux pane shows an idle prompt, and there is no
+non-baseline child process — both BLIND to MCP/tool work (the Playwright MCP server runs out of
+the pane's process tree; bash tool calls are short-lived). On 2026-06-13 an actively-working
+session was terminal-killed because, between tool calls, it looked idle. This change adds a third
+signal: `isTranscriptRecentlyActive(session, 120_000)` — true when the session's framework
+transcript (JSONL) was modified within the last 2 minutes. The idle decision is extracted into a
+pure, exported `isAgeGateTrulyIdle(idleAtPrompt, hasActiveProcs, transcriptActive)` so the exact
+incident is reproducible at the decision boundary in a unit test. Files: `src/core/SessionManager.ts`
+(constant `AGE_GATE_TRANSCRIPT_ACTIVE_MS`, the `isAgeGateTrulyIdle` function, the
+`isTranscriptRecentlyActive` method, the import of `resolveFrameworkTranscriptPath`, and the
+age-gate wiring); tests in `tests/unit/session-timeout-activity-aware.test.ts` and
+`tests/unit/session-manager-behavioral.test.ts`.
+
+## Decision-point inventory
+
+- `SessionManager.monitorTick age-gate (ageGateTrulyIdle)` — **modify** — adds a transcript-activity
+  defer condition; the kill now requires idle-pane AND no-child-proc AND transcript-not-recently-active.
+
+---
+
+## 1. Over-block
+
+**What legitimate inputs does this change reject that it shouldn't?**
+
+In reap terms, "over-block" = wrongly DEFERRING a kill. A genuinely-finished session whose
+transcript was touched <2 min before the check is held off for up to one 2-minute window. This is
+harmless: the idle-detection block immediately below the age gate still reaps it once its
+transcript goes quiet. No session is kept alive indefinitely on a stale signal — only real,
+ongoing transcript writes (which require real model activity) sustain the defer.
+
+## 2. Under-block
+
+**What failure modes does this still miss?**
+
+The change ONLY adds a defer condition; it removes no kill. A session with NO resolvable transcript
+(an unknown framework, or pi-cli which has no resolver case) gets `isTranscriptRecentlyActive ===
+false` and the age gate falls back to EXACTLY today's pane/procs verdict — so such a session is no
+better protected than before (safe degradation, no NEW under-block). The deliberate non-coverage:
+the age gate does not try to be a hard resource ceiling for runaway-but-active sessions — that is
+owned by SessionWatchdog (stuck-process), the context-wedge sentinel, and the CPU/memory-pressure
+reaper, all unchanged.
+
+## 3. Level-of-abstraction fit
+
+**Is this at the right layer?**
+
+Yes. The SessionReaper (the pressure/idle reap path) ALREADY layers transcript-growth awareness
+(`probeTranscript`/`transcriptDelta`). This change brings the parallel age-kill path to parity at
+the SAME layer using the SAME core resolver (`resolveFrameworkTranscriptPath` from
+`core/FrameworkSessionStore`). It is a cheap detector feeding an existing defer, not a new
+authority and not a re-implementation of an existing primitive. It deliberately does NOT depend on
+`monitoring/transcriptProber` (that would invert core→monitoring layering); it uses the core
+resolver directly.
+
+## 4. Signal vs authority compliance
+
+**Does this hold blocking authority with brittle logic, or produce a signal that feeds a smart gate?**
+
+It produces a SIGNAL that ADDS a defer (keep) condition to an existing authority. It grants no new
+blocking authority and moves strictly in the safe direction (fewer kills of active sessions). The
+probe is brittle (a single statSync) but its failure mode is bounded by the fail-to-`false`
+contract: a probe error never keeps a session alive — it only declines to add the new defer
+reason, falling through to the existing pane/procs verdict. (Ref: `docs/signal-vs-authority.md`.)
+
+## 5. Interactions
+
+**Does it shadow another check, get shadowed, double-fire, or race with adjacent cleanup?**
+
+Consistent with the SessionReaper's existing transcript gate (same resolver, same intent). The
+single-point mtime check vs the SessionReaper's cross-tick delta is an intentional, benign
+asymmetry (the SessionReaper requires repeated positive-idle confirmations before it reaps, so the
+two never produce a contradictory kill on the same tick). The idle-detection block below the age
+gate still owns genuinely-idle reaping (the held off path falls through, no `continue`). No new
+kill/revive loop: the change does NOT touch `WorkEvidence`/`ReapGuard.evaluate()`/`workEvidence()`,
+so the documented evaluate-vs-workEvidence disagreement class (2026-06-13 13-session loop) is
+untouched. Adversarial review confirmed loop-safety. The `overAgeButActiveLogged` set already
+prevents log spam on the held off path.
+
+## 6. External surfaces
+
+**Does it change anything visible to other agents/users/systems? Timing/state dependence?**
+
+No API route, no config key, no hook, no template, no dashboard surface. The only externally
+observable effect: a long-running, actively-working session is no longer terminal-killed at ~5h —
+which is the intended, operator-requested behavior. The new constant is code-level (not a config
+surface). The change reads only a local file's mtime; it depends on the framework runtime writing
+its transcript on activity (true for claude-code, codex-cli, gemini-cli; pi-cli safely degrades).
+
+## 7. Multi-machine posture (Cross-Machine Coherence)
+
+**Machine-local BY DESIGN.** Each machine's `SessionManager` reaps only its OWN sessions and reads
+only its OWN local transcripts. There is no shared/replicated/proxied state: the decision is a
+per-session, per-machine read of a local file. No cross-machine surface is introduced or needed —
+a reap decision is inherently local to the machine running the session. No user-facing notice is
+added (so no one-voice gating concern); no durable cross-machine state (so no topic-transfer
+strand); no generated URL.
+
+## 8. Rollback cost
+
+Revert the PR — a single-file behavior change plus its tests; no data migration, no agent-state
+repair, no config rollback. As an interim dial without a revert, setting
+`AGE_GATE_TRANSCRIPT_ACTIVE_MS` to 0 makes the new defer condition inert (reverts to the prior
+two-signal behavior). Ships with the dist on update (no PostUpdateMigrator entry needed — the
+change is internal runtime behavior, not an agent-installed file).


### PR DESCRIPTION
## ELI16 — Teach the "retire old sessions" watchdog to see browser/tool work so it stops killing busy sessions.

A watchdog retires agent sessions open ~5h, but only after checking they're idle. Its idle check looked at just the terminal screen and the process list — neither of which shows work done through the browser/automation (MCP) tools. So a session actively driving a browser looked idle and got killed mid-task, with no resume. This teaches the watchdog the same trick the system's *other* reaper already uses: if the session's live activity log was written in the last 2 minutes, it's still working — leave it alone. It can only make the watchdog more careful, never more aggressive; genuinely-finished sessions are still retired within minutes; and it's a one-file change that reverts cleanly.

## Problem

On 2026-06-13 an interactive session actively driving the Playwright MCP server (provisioning a GitHub identity, interleaved with short `gh`/`curl` calls) was **terminal-killed by the age-limit reaper** at the ~5h cap with `midWork:false` (no resume) and a delayed notice — the operator saw silence.

Root cause: `SessionManager`'s wall-clock age-gate decides "truly idle?" from only two signals — pane-idle + no child process — **both blind to MCP/tool work** (the MCP server runs out of the tmux process tree; bash calls are short-lived). Between tool calls an active session looks idle. The sibling reap path (`SessionReaper`, pressure/idle) **already** cross-checks transcript growth and would not have killed it — the age-kill path was the lone blind spot.

## Fix (brings the age-gate to parity)

- `SessionManager.isTranscriptRecentlyActive(session, withinMs)` — resolves the per-framework transcript via the core `resolveFrameworkTranscriptPath` and checks its mtime; **fail-to-false** on anything unprobeable (never pins a dead session alive).
- `AGE_GATE_TRANSCRIPT_ACTIVE_MS = 120_000` — a transcript written in the last 2 min => the session is producing => hold off the kill, exactly as a live child process already does.
- Idle decision extracted to pure exported `isAgeGateTrulyIdle(idle, procs, transcript)` so the **exact incident is reproduced at the decision boundary** in a unit test.

Scope is deliberately tight (challenge-the-mechanism): **no** change to the `WorkEvidence`/`ReapGuard` `evaluate()`/`workEvidence()` kill-revive-loop subsystem. `pi-cli` has no resolver case and **safely degrades** to today's pane/procs verdict (pre-existing shared-resolver gap, tracked). Machine-local by design.

## Process

- **Spec** `docs/specs/age-kill-transcript-aware-resume.md` — converged (2 rounds, /spec-converge), approved under operator pre-approval. Parent principle: *Observation Needs Structure*.
- **Convergence review** surfaced 6 findings (security denial-of-reaping [intended, documented], pi-cli [safe-degrade], testing tiers, bug-fix evidence, mtime/delta asymmetry, cross-framework test) — all addressed. External non-Claude pass degraded this run (codex not on PATH; gemini API error) — recorded in the report.
- **Tests**: behavioral `isTranscriptRecentlyActive` (recent/stale/no-id/missing/cross-framework) + exhaustive `isAgeGateTrulyIdle` decision boundary incl. the original-failure repro. `tsc --noEmit` clean.

## Rollback

Revert the PR (one source file + tests); or set the window to 0 to make the new condition inert. No migration, no state repair.

🤖 Generated with [Claude Code](https://claude.com/claude-code)