### PR TITLE
feat(multi-machine): dev-gate the 5 seamlessness coherence flags (live-on-dev, dark-fleet); hold sessionPool master (topic 13481)

### DIFF
--- a/.instar/instar-dev-decisions/2026-06-14T05-26-24-521Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-06-14T05-26-24-521Z-unknown.json
@@ -1,0 +1,17 @@
+{
+  "ts": "2026-06-14T05:26:24.521Z",
+  "slug": "unknown",
+  "suggestedTier": 2,
+  "declaredTier": 2,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "irreversibility: src/core/PostUpdateMigrator.ts touches PostUpdateMigrator",
+    "migration / fleet-rollout surface: src/core/PostUpdateMigrator.ts touches PostUpdateMigrator (fleet migration machinery)",
+    "new capability: new config key added"
+  ],
+  "belowFloor": false,
+  "files": 5,
+  "loc": 252,
+  "causalAutopsy": null,
+  "verdict": "pass"
+}

--- a/.instar/instar-dev-decisions/2026-06-14T05-27-02-030Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-06-14T05-27-02-030Z-unknown.json
@@ -1,0 +1,17 @@
+{
+  "ts": "2026-06-14T05:27:02.030Z",
+  "slug": "unknown",
+  "suggestedTier": 2,
+  "declaredTier": 2,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "irreversibility: src/core/PostUpdateMigrator.ts touches PostUpdateMigrator",
+    "migration / fleet-rollout surface: src/core/PostUpdateMigrator.ts touches PostUpdateMigrator (fleet migration machinery)",
+    "new capability: new config key added"
+  ],
+  "belowFloor": false,
+  "files": 5,
+  "loc": 252,
+  "causalAutopsy": null,
+  "verdict": "pass"
+}

--- a/src/commands/server.ts
+++ b/src/commands/server.ts
@@ -5414,7 +5414,12 @@ export async function startServer(options: StartOptions): Promise<void> {
         const telegramForRoleGuard = telegram; // const-narrow for the closure
         scheduler.setRoleGuard(
           () => ({
-            enabled: config.multiMachine?.seamlessness?.ws43RoleGuard === true,
+            // DEV-AGENT DARK GATE (operator directive 2026-06-13, topic 13481):
+            // read ws43RoleGuard through resolveDevAgentGate so it resolves LIVE on
+            // a dev agent / DARK on the fleet. The guard can only ever REFUSE a
+            // spawn (never wrongly spawn — the safe direction); single-machine
+            // agents always hold the lease, so it never fires there even live.
+            enabled: resolveDevAgentGate(config.multiMachine?.seamlessness?.ws43RoleGuard, config),
             holdsLease: coordinator.holdsLease(),
           }),
           (slug, machineId) => {
@@ -9750,7 +9755,12 @@ export async function startServer(options: StartOptions): Promise<void> {
     const { SpeakerElection } = await import('../monitoring/SpeakerElection.js');
     const ws3Cfg = () => ((config as Record<string, any>).multiMachine?.seamlessness ?? {}) as { ws3OneVoice?: boolean; ws3DwellMs?: number };
     const speakerElection = new SpeakerElection({
-      enabled: () => ws3Cfg().ws3OneVoice === true,
+      // DEV-AGENT DARK GATE (operator directive 2026-06-13, topic 13481): read
+      // ws3OneVoice through resolveDevAgentGate so it resolves LIVE on a dev agent
+      // (config OMITS it → undefined → !!developmentAgent) and DARK on the fleet.
+      // An explicit config value still wins. Single-machine is a no-op regardless
+      // (the election never engages below 2 online machines).
+      enabled: () => resolveDevAgentGate(ws3Cfg().ws3OneVoice, config),
       currentMachineId: (() => {
         // @silent-fallback-ok — no machine identity = the election's legacy-no-machine-id
         // verdict (always speak): the designed single-machine degradation, not a loss.
@@ -13821,8 +13831,18 @@ export async function startServer(options: StartOptions): Promise<void> {
           scheduler.setJournalLeaseCutover(
             leaseStore,
             () => ({
-              enabled: config.multiMachine?.seamlessness?.ws43JournalLease === true,
-              dryRun: config.multiMachine?.seamlessness?.ws43JournalLeaseDryRun !== false,
+              // DEV-AGENT DARK GATE (operator directive 2026-06-13, topic 13481):
+              // read ws43JournalLease through resolveDevAgentGate → LIVE on a dev
+              // agent / DARK on the fleet (config OMITS both flags). ws43JournalLease
+              // DryRun resolves COHERENTLY: on a dev agent the cutover goes genuinely
+              // live (dryRun → false) so the journal-lease path is actually exercised,
+              // not just logged; on the fleet it resolves to the safe dry-run default
+              // (true). An explicit config value still wins on either flag. A genuine
+              // live cutover only engages when the flag resolves live AND the pool is
+              // flag-coherent (≥2 machines all advertising not-dry-run), so a
+              // single-machine dev agent never half-migrates.
+              enabled: resolveDevAgentGate(config.multiMachine?.seamlessness?.ws43JournalLease, config),
+              dryRun: config.multiMachine?.seamlessness?.ws43JournalLeaseDryRun ?? !resolveDevAgentGate(undefined, config),
               epoch: coordinator.getLeaseEpoch(),
               peers: registryForCutover
                 .getCapacities()
@@ -13913,7 +13933,7 @@ export async function startServer(options: StartOptions): Promise<void> {
                 // WS1.1 capability advertisement (spec invariant 5): a bounded
                 // fixed-size summary, never an inventory. Reported live each
                 // heartbeat so a queue going dark withdraws the capability.
-                seamlessnessFlags: { ws11DeliverReceive: !!_inboundQueue, ws12DrainReceive: !!_drainRunner, ws44PoolLinks: !!_poolLink, ws44PoolCache: !!_poolPollCache, ws43JournalLease: config.multiMachine?.seamlessness?.ws43JournalLease === true && config.multiMachine?.seamlessness?.ws43JournalLeaseDryRun !== true, stateSyncReceive: selfStateSyncReceive() },
+                seamlessnessFlags: { ws11DeliverReceive: !!_inboundQueue, ws12DrainReceive: !!_drainRunner, ws44PoolLinks: !!_poolLink, ws44PoolCache: !!_poolPollCache, ws43JournalLease: resolveDevAgentGate(config.multiMachine?.seamlessness?.ws43JournalLease, config) && (config.multiMachine?.seamlessness?.ws43JournalLeaseDryRun ?? !resolveDevAgentGate(undefined, config)) !== true, stateSyncReceive: selfStateSyncReceive() },
                 // Durable Inbound Message Queue §5.1: depth + oldest + tenure +
                 // bounded top-K — the survivor's loss-SUSPECTED item, capped
                 // re-placement arm, and supersede-dedupe key all read these.
@@ -14204,7 +14224,14 @@ export async function startServer(options: StartOptions): Promise<void> {
           const ws13Cfg = () => ((config as Record<string, any>).multiMachine?.seamlessness ?? {}) as { ws13Reconcile?: boolean; ws13DryRun?: boolean; ws13TickMs?: number };
           const { OwnershipReconciler } = await import('../core/OwnershipReconciler.js');
           const reconciler = new OwnershipReconciler({
-            enabled: () => ws13Cfg().ws13Reconcile === true,
+            // DEV-AGENT DARK GATE (operator directive 2026-06-13, topic 13481):
+            // read ws13Reconcile through resolveDevAgentGate so the reconcile loop
+            // resolves LIVE on a dev agent / DARK on the fleet. ws13DryRun STAYS a
+            // plain config read (the in-component "log intended CAS without
+            // performing it" rung — NOT the dev-gate); so on a dev agent the loop
+            // runs live but in dry-run (no destructive CAS), exactly as the rollout
+            // ladder intends. Strict single-machine no-op inside the module.
+            enabled: () => resolveDevAgentGate(ws13Cfg().ws13Reconcile, config),
             dryRun: () => ws13Cfg().ws13DryRun !== false,
             selfMachineId: _meshSelfId,
             pinStore: _topicPinStore,

--- a/src/config/ConfigDefaults.ts
+++ b/src/config/ConfigDefaults.ts
@@ -694,13 +694,27 @@ const SHARED_DEFAULTS: Record<string, unknown> = {
     // byte-for-byte today's behavior. Single-machine pools are a strict no-op
     // even when enabled (the election never engages below 2 online machines).
     seamlessness: {
-      ws3OneVoice: false,
+      // WS3 one-voice gate. DEV-AGENT DARK GATE (operator directive 2026-06-13,
+      // topic 13481 — "NOTHING should ship dark on development agents"):
+      // `ws3OneVoice` is DELIBERATELY OMITTED here (not hardcoded false) so
+      // resolveDevAgentGate decides at runtime — LIVE on a development agent
+      // (dogfooding across the operator's own machines), DARK on the fleet until
+      // explicitly flipped on. Hardcoding `false` would force-dark even a dev
+      // agent (the PR #1001 bug). Registered in DEV_GATED_FEATURES
+      // (src/core/devGatedFeatures.ts). When dark/single-machine the
+      // SpeakerElection returns "speak" unconditionally (byte-for-byte today's
+      // behavior); the election never engages below 2 online machines, so a
+      // single-machine dev agent is a strict no-op even when resolved live.
       ws3DwellMs: 60000,
       // WS1.3 ownership reconcile: bounded pin/owner convergence (cooperative
       // transfer→claim while the owner lives; force only with owner-death
-      // evidence + quorum). DARK + dry-run default — dryRun logs intended CAS
-      // actions without performing them.
-      ws13Reconcile: false,
+      // evidence + quorum). DEV-AGENT DARK GATE: `ws13Reconcile` is DELIBERATELY
+      // OMITTED here (not hardcoded false) so resolveDevAgentGate decides at
+      // runtime — LIVE on a development agent, DARK on the fleet. Its dry-run
+      // sub-knob (ws13DryRun, default true) STAYS a plain hardcoded default — it
+      // is the in-component "log intended CAS actions without performing them"
+      // rung, NOT the dev-gate, so the reconcile loop runs live on dev but in
+      // dry-run (no destructive CAS) exactly as the rollout ladder intends.
       ws13DryRun: true,
       ws13TickMs: 30000,
       // WS2.1 preferences pool: cross-machine read-replication of the
@@ -715,26 +729,27 @@ const SHARED_DEFAULTS: Record<string, unknown> = {
       // operator acks a pooled attention item whose OWNER is briefly offline,
       // the ack intent is persisted (with the authenticated operator principal)
       // and re-delivered when the owner returns — so the intent survives a dark
-      // owner instead of evaporating. DARK default; a plain seamlessness boolean
-      // (read live at the route + drain sites), mirroring the ws21PreferencesPool
-      // sibling — NOT named `enabled`, so it is outside the dev-agent dark-gate
-      // lint. When off, POST /attention/:id/remote-ack 503s and the receiver's
+      // owner instead of evaporating. DEV-AGENT DARK GATE (operator directive
+      // 2026-06-13, topic 13481): `ws41DurableAck` is DELIBERATELY OMITTED here
+      // (not hardcoded false) so resolveDevAgentGate decides at runtime — LIVE on
+      // a development agent, DARK on the fleet. Registered in DEV_GATED_FEATURES.
+      // When dark, POST /attention/:id/remote-ack 503s and the receiver's
       // remote-ack precedence guard is a no-op; single-machine agents are a
-      // strict no-op even when on (no peers to route to).
-      ws41DurableAck: false,
+      // strict no-op even when resolved live (no peers to route to).
       // WS4.3 role-guard-at-spawn (CMT-1416 follow-up to the merged WS4.3 jobs
       // read-side, PR #1104). When on, the scheduler refuses to spawn a
       // STATE-WRITING job (JobDefinition.writesState) on a machine that does NOT
       // hold the lease — the spawn-boundary re-check that closes the TOCTOU hole
       // where a machine awake at boot demotes to read-only standby mid-run while
       // its cron tasks keep firing (the scheduler is constructed only when awake
-      // but is never torn down on demotion). DARK default; a plain seamlessness
-      // boolean (read live at the triggerJob spawn boundary), mirroring the
-      // ws41DurableAck sibling — NOT named `enabled`, so it is outside the
-      // dev-agent dark-gate lint. When off, the guard is a strict no-op
-      // (byte-for-byte today's behavior). Single-machine agents always hold the
-      // lease, so the guard never fires there even when on.
-      ws43RoleGuard: false,
+      // but is never torn down on demotion). DEV-AGENT DARK GATE (operator
+      // directive 2026-06-13, topic 13481): `ws43RoleGuard` is DELIBERATELY
+      // OMITTED here (not hardcoded false) so resolveDevAgentGate decides at
+      // runtime — LIVE on a development agent, DARK on the fleet. Registered in
+      // DEV_GATED_FEATURES. When dark, the guard is a strict no-op (byte-for-byte
+      // today's behavior). Single-machine agents always hold the lease, so the
+      // guard never fires there even when resolved live (it can only ever refuse,
+      // never wrongly spawn — the safe direction).
       // WS4.3 journal-lease cutover (MULTI-MACHINE-SEAMLESSNESS-SPEC §WS4.3,
       // "Cutover discipline"). When on AND the pool is flag-coherent (every
       // online peer advertises ws43JournalLease), job claims upgrade from the
@@ -742,17 +757,25 @@ const SHARED_DEFAULTS: Record<string, unknown> = {
       // replicated journal. The cutover gate (JobLeaseCutoverGate) guarantees the
       // two mechanisms are NEVER both live for a job set (the named migration
       // hazard: one machine leasing via journal while a peer broadcasts via bus).
-      // DARK default; a plain seamlessness boolean (read live at the claim
-      // boundary), mirroring the ws43RoleGuard sibling — NOT named `enabled`, so
-      // outside the dev-agent dark-gate lint. When off, or in a mixed/older pool,
-      // or single-machine, the scheduler stays on the legacy bus path
-      // (byte-for-byte today's behavior).
-      ws43JournalLease: false,
+      // DEV-AGENT DARK GATE (operator directive 2026-06-13, topic 13481):
+      // `ws43JournalLease` is DELIBERATELY OMITTED here (not hardcoded false) so
+      // resolveDevAgentGate decides at runtime — LIVE on a development agent,
+      // DARK on the fleet. Registered in DEV_GATED_FEATURES. When dark, or in a
+      // mixed/older pool, or single-machine, the scheduler stays on the legacy
+      // bus path (byte-for-byte today's behavior); the JobLeaseCutoverGate's
+      // flag-coherence requirement means a single-machine dev agent (no peers)
+      // is a strict no-op even when the flag resolves live.
+      //
       // WS4.3 journal-lease DRY-RUN (the WS-wide "log intended claims" posture).
-      // When the gate is coherent-but-dry-run, the intended journal claim is
-      // LOGGED but the legacy bus path still runs — so a dry-run pool never
-      // half-migrates. Default true: the first rung of the rollout ladder.
-      ws43JournalLeaseDryRun: true,
+      // `ws43JournalLeaseDryRun` is ALSO DELIBERATELY OMITTED so the dev-gate
+      // resolves it COHERENTLY with ws43JournalLease: on a dev agent the cutover
+      // goes LIVE (dryRun → false) so the journal-lease path is actually
+      // exercised (not just logged); on the fleet it resolves to the safe dry-run
+      // default (true). The consumer computes `dryRun: cfg?.ws43JournalLeaseDryRun
+      // ?? !resolveDevAgentGate(undefined, config)` — an explicit config value
+      // still wins. A genuine live cutover only engages when the flag resolves
+      // live AND the pool is flag-coherent (≥2 machines all advertising the
+      // capability not-dry-run), so a single-machine dev agent never half-migrates.
       // WS4.4 "links that survive machine boundaries". DEV-AGENT DARK GATE:
       // `ws44PoolLinks` is DELIBERATELY OMITTED here (not hardcoded false) so
       // resolveDevAgentGate decides at runtime — LIVE on a development agent

--- a/src/core/PostUpdateMigrator.ts
+++ b/src/core/PostUpdateMigrator.ts
@@ -236,6 +236,67 @@ export function migrateConfigStateSyncStoresDevGate(config: Record<string, unkno
   return changed;
 }
 
+/**
+ * The 5 multiMachine.seamlessness coherence flags (WS3 / WS1.3 / WS4.1 / WS4.3)
+ * re-gated to the developmentAgent gate on 2026-06-13 (operator directive topic
+ * 13481). Each was a hardcoded `false` in ConfigDefaults; now OMITTED so
+ * resolveDevAgentGate decides (live-on-dev / dark-fleet) — mirroring ws44PoolLinks.
+ */
+const SEAMLESSNESS_DEV_GATED_FLAGS = [
+  'ws3OneVoice',
+  'ws13Reconcile',
+  'ws41DurableAck',
+  'ws43RoleGuard',
+  'ws43JournalLease',
+] as const;
+
+/**
+ * Strip default-shaped literal `false` for the 5 seamlessness coherence flags so
+ * the developmentAgent gate resolves them (live on dev, dark on fleet) — exactly the
+ * ws44PoolLinks / ws44PoolCache invariant, applied to ws3OneVoice / ws13Reconcile /
+ * ws41DurableAck / ws43RoleGuard / ws43JournalLease (operator directive 2026-06-13,
+ * topic 13481). An existing agent that ran the old ConfigDefaults carries an explicit
+ * `false` per flag, which (being explicit) would keep resolveDevAgentGate DARK even on
+ * a dev agent. Rules per flag:
+ *   - absent          → no-op. The gate already decides correctly.
+ *   - === false       → STRIP it. It was a default-shaped force-dark.
+ *   - === true        → leave it. An operator's explicit fleet-flip wins.
+ *
+ * SPECIAL CASE ws43JournalLeaseDryRun: the OLD default carried the PAIR
+ * `{ ws43JournalLease:false, ws43JournalLeaseDryRun:true }`. The new ConfigDefaults
+ * OMIT BOTH so the consumer computes dryRun COHERENTLY with the gate (dev→false/live,
+ * fleet→true/dry-run). So when ws43JournalLease is a default-shaped `false` AND
+ * ws43JournalLeaseDryRun is a default-shaped `true`, strip the dryRun key too (so the
+ * consumer's coherent default applies). An operator-set ws43JournalLeaseDryRun (any
+ * other value, or present without the paired false) is left untouched — reach is not
+ * authority. A stripped seamlessness block left empty is removed. Idempotent.
+ */
+export function migrateConfigSeamlessnessDevGate(config: Record<string, unknown>): boolean {
+  const mm = config.multiMachine as Record<string, unknown> | undefined;
+  if (!mm || typeof mm !== 'object') return false;
+  const seam = mm.seamlessness as Record<string, unknown> | undefined;
+  if (!seam || typeof seam !== 'object') return false;
+  let changed = false;
+  for (const flag of SEAMLESSNESS_DEV_GATED_FLAGS) {
+    if (!Object.prototype.hasOwnProperty.call(seam, flag)) continue;
+    // Only a default-shaped `false` is stripped; an explicit `true` is preserved.
+    if (seam[flag] !== false) continue;
+    delete seam[flag];
+    changed = true;
+    // Coherent dryRun strip — only alongside a default-shaped ws43JournalLease:false.
+    if (
+      flag === 'ws43JournalLease' &&
+      Object.prototype.hasOwnProperty.call(seam, 'ws43JournalLeaseDryRun') &&
+      seam.ws43JournalLeaseDryRun === true
+    ) {
+      delete seam.ws43JournalLeaseDryRun;
+    }
+  }
+  // Tidy: drop an emptied seamlessness block so the migration leaves no cruft.
+  if (changed && Object.keys(seam).length === 0) delete mm.seamlessness;
+  return changed;
+}
+
 export class PostUpdateMigrator {
   private config: MigratorConfig;
   /**
@@ -7329,6 +7390,19 @@ Create worktrees for collaborator repos with \`instar worktree create <branch>\`
       result.upgraded.push('config.json: stripped default-shaped multiMachine.stateSync.* memory-store {enabled:false,dryRun:true} blocks so the developmentAgent gate resolves them (live-on-dev, dark fleet, dryRun:false)');
     } else {
       result.skipped.push('config.json: multiMachine.stateSync.* memory-store dev-gates already correct (omitted or operator-set)');
+    }
+
+    // The 5 multiMachine.seamlessness coherence flags (WS3 / WS1.3 / WS4.1 / WS4.3)
+    // re-gated to the developmentAgent gate (2026-06-13 operator directive topic
+    // 13481): strip a default-shaped literal `false` per flag so the gate resolves
+    // them live-on-dev / dark-fleet — same omitted-gate invariant as ws44PoolLinks.
+    // ws43JournalLeaseDryRun:true is stripped alongside a default-shaped
+    // ws43JournalLease:false so the consumer's coherent dryRun default applies.
+    if (migrateConfigSeamlessnessDevGate(config)) {
+      patched = true;
+      result.upgraded.push('config.json: stripped default-shaped multiMachine.seamlessness.{ws3OneVoice,ws13Reconcile,ws41DurableAck,ws43RoleGuard,ws43JournalLease}=false (and paired ws43JournalLeaseDryRun:true) so the developmentAgent gate resolves them (live-on-dev, dark fleet)');
+    } else {
+      result.skipped.push('config.json: multiMachine.seamlessness coherence-flag dev-gates already correct (omitted or operator-set)');
     }
 
     if (patched) {

--- a/src/core/devGatedFeatures.ts
+++ b/src/core/devGatedFeatures.ts
@@ -115,6 +115,54 @@ export const DEV_GATED_FEATURES: DevGatedFeature[] = [
     description: 'Live credential re-pointing (WS5.2) — the /credentials/* levers + the autonomous balancer that MOVES a pool account\'s OAuth credential between config-home slots without restarting.',
     justification: 'Ships dryRun:true (the dry-run canary): on a dev agent the levers + the balancer run the FULL decision loop and AUDIT every swap they WOULD make, but the CredentialSwapExecutor returns BEFORE the keychain/config write step while dryRun holds (verified at CredentialSwapExecutor §2.3 — outcome `dry-run`, ZERO writes). So live-on-dev is alive + observable but performs NO destructive credential write; real writes need a deliberate dryRun:false (gated behind the §5 livetest promotion). Same dogfooding posture as topicProfiles / threadline.singleNegotiator. (Operator directive 2026-06-13, topic 20905: NONE of this should be dark for development agents — replaces the rev-2 dark-for-everyone DARK_GATE_EXCLUSIONS choice.)',
   },
+  // ── multi-machine seamlessness coherence layers (WS3 / WS1.3 / WS4.1 / WS4.3),
+  //    MOVED from hardcoded `false` in ConfigDefaults on 2026-06-13 per operator
+  //    directive topic 13481 ("NOTHING should ship dark on development agents —
+  //    every multi-machine feature must be live on dev agents so it actually gets
+  //    tested, not rot"). Each ConfigDefaults entry now OMITS the flag (NOT
+  //    hardcoded false), so resolveDevAgentGate flips it LIVE on a dev agent / DARK
+  //    on the fleet — mirroring the ws44PoolLinks/ws44PoolCache siblings below. They
+  //    coordinate across the operator's OWN machines (active-active) with NO external
+  //    egress; each is reversible (a config flip OR single-machine no-op) and runs in
+  //    the SAFE direction on dev. Spec: docs/specs/MULTI-MACHINE-SEAMLESSNESS-SPEC.md.
+  //    NOTE: the multiMachine.sessionPool.* master switch + its inboundQueue /
+  //    holdForStability sub-flags are DELIBERATELY NOT moved here — they share a
+  //    SECOND structural gate (`sessionPool.stage`, StageAdvancer-write-only, E2E-
+  //    gated rollout ladder dark→shadow→live-transfer→rebalance). The activation
+  //    expression everywhere is `enabled && stage !== 'dark'`, so dev-gating
+  //    `enabled` alone leaves them inert (still-dark-on-dev), and forcing `stage`
+  //    past dark in ConfigDefaults would bypass the deliberate cutover discipline.
+  //    They stay in DARK_GATE_EXCLUSIONS for an operator decision (held PR2). ──
+  {
+    name: 'ws3OneVoice',
+    configPath: 'multiMachine.seamlessness.ws3OneVoice',
+    description: 'WS3 one-voice gate — the SpeakerElection that gives a multi-machine conversation a single outbound voice (no double-replies across machines).',
+    justification: 'Coordinates between the operator\'s OWN machines only — no external egress; when dark/single-machine the election returns "speak" unconditionally (byte-for-byte today\'s behavior) and never engages below 2 online machines; a verdict only WITHHOLDS a duplicate send (the safe direction), never fabricates one. No destructive action, no third-party spend. Operator directive 2026-06-13 topic 13481.',
+  },
+  {
+    name: 'ws13Reconcile',
+    configPath: 'multiMachine.seamlessness.ws13Reconcile',
+    description: 'WS1.3 ownership reconcile — bounded pin/owner convergence (cooperative transfer→claim while the owner lives; force only with owner-death evidence + quorum).',
+    justification: 'Coordinates between the operator\'s OWN machines only — no external egress; its in-component dryRun sub-knob (ws13DryRun) stays a plain hardcoded default true, so live-on-dev runs the reconcile loop but LOGS intended CAS actions without performing them (no destructive CAS) exactly as the rollout ladder intends; strict single-machine no-op inside the module. No third-party spend. Operator directive 2026-06-13 topic 13481.',
+  },
+  {
+    name: 'ws41DurableAck',
+    configPath: 'multiMachine.seamlessness.ws41DurableAck',
+    description: 'WS4.1 durable operator-bound /ack across machines — a pooled-attention ack whose owner is briefly offline is persisted with the authenticated operator principal and re-delivered when the owner returns.',
+    justification: 'Coordinates between the operator\'s OWN machines only — no external egress; the persisted intent is bound to the AUTHENTICATED operator and the owner REVALIDATES at apply time (a stale resolve against a since-escalated item is rejected — current state wins); when dark the routes 503 and the precedence guard is inert; strict single-machine no-op (no peers). No destructive action, no third-party spend. Operator directive 2026-06-13 topic 13481.',
+  },
+  {
+    name: 'ws43RoleGuard',
+    configPath: 'multiMachine.seamlessness.ws43RoleGuard',
+    description: 'WS4.3 role-guard-at-spawn — the scheduler refuses to spawn a STATE-WRITING job on a machine that does NOT hold the lease (closes the TOCTOU hole where a machine demotes to read-only standby mid-run while its cron tasks keep firing).',
+    justification: 'Coordinates between the operator\'s OWN machines only — no external egress; the guard can ONLY ever REFUSE a spawn (never wrongly spawn — the safe direction); when dark it is a strict no-op (byte-for-byte today\'s behavior); single-machine agents always hold the lease so it never fires there even live. The refusal raises ONE deduped attention item (no flood). No destructive action, no third-party spend. Operator directive 2026-06-13 topic 13481.',
+  },
+  {
+    name: 'ws43JournalLease',
+    configPath: 'multiMachine.seamlessness.ws43JournalLease',
+    description: 'WS4.3 journal-lease cutover — job claims upgrade from the best-effort AgentBus broadcast to a durable, epoch-fenced lease over the replicated journal (the JobLeaseCutoverGate guarantees the two mechanisms are NEVER both live for a job set).',
+    justification: 'Coordinates between the operator\'s OWN machines only — no external egress. The dryRun sub-flag (ws43JournalLeaseDryRun) is ALSO omitted from ConfigDefaults and resolves COHERENTLY with this flag at the consumer (dev → live, fleet → dry-run) so live-on-dev actually exercises the lease path. A genuine live cutover engages ONLY when the flag resolves live AND the pool is flag-coherent (≥2 machines all advertising not-dry-run), so a single-machine dev agent never half-migrates (strict no-op). Job-claim coordination on durable local/replicated state — no destructive/irreversible write, no third-party spend. Operator directive 2026-06-13 topic 13481.',
+  },
   {
     name: 'ws44PoolLinks',
     configPath: 'multiMachine.seamlessness.ws44PoolLinks',

--- a/src/server/routes.ts
+++ b/src/server/routes.ts
@@ -10399,11 +10399,17 @@ export function createRoutes(ctx: RouteContext): Router {
   const ATTENTION_PEER_TIMEOUT_MS = 5_000;
 
   // WS4.1 follow-up (CMT-1416): durable operator-bound /ack across machines.
-  // Plain seamlessness boolean read LIVE (mirrors ws21PreferencesPool) — off ⇒
-  // POST /attention/:id/remote-ack 503s, the PATCH precedence guard is inert,
-  // and the store is never touched (strict no-op on a flag-off agent).
+  // DEV-AGENT DARK GATE (operator directive 2026-06-13, topic 13481): read
+  // ws41DurableAck through resolveDevAgentGate so it resolves LIVE on a dev agent
+  // (config OMITS it → undefined → !!developmentAgent) / DARK on the fleet. An
+  // explicit config value still wins. Off ⇒ POST /attention/:id/remote-ack 503s,
+  // the PATCH precedence guard is inert, and the store is never touched (strict
+  // no-op); single-machine agents are a no-op even live (no peers to route to).
   const ws41DurableAckEnabled = (): boolean =>
-    ((ctx.config as Record<string, any>).multiMachine?.seamlessness ?? {}).ws41DurableAck === true;
+    resolveDevAgentGate(
+      ((ctx.config as Record<string, any>).multiMachine?.seamlessness ?? {}).ws41DurableAck,
+      ctx.config,
+    );
   const remoteAckStore = new RemoteAckStore(ctx.config.stateDir);
   const remoteAckLimiter = rateLimiter(60_000, 30);
   const REMOTE_ACK_GIVE_UP_ATTEMPTS = 50;

--- a/tests/e2e/attention-remote-ack-alive.test.ts
+++ b/tests/e2e/attention-remote-ack-alive.test.ts
@@ -41,7 +41,16 @@ function createAttentionAdapter() {
   };
 }
 
-async function startServer(enabled: boolean, tmpDir: string, auth: string): Promise<AgentServer> {
+// `enabled`: when a boolean, set the explicit flag value. When 'dev-gated', OMIT the
+// flag entirely and rely on the developmentAgent gate (resolveDevAgentGate) to resolve it
+// — the heart of mm-pool-seamlessness-devgate: a dev agent runs it live, the fleet stays
+// dark, with NO explicit config value present.
+async function startServer(
+  enabled: boolean | 'dev-gated',
+  tmpDir: string,
+  auth: string,
+  opts: { developmentAgent?: boolean } = {},
+): Promise<AgentServer> {
   const stateDir = path.join(tmpDir, '.instar');
   fs.mkdirSync(stateDir, { recursive: true });
   const config: InstarConfig = {
@@ -52,12 +61,14 @@ async function startServer(enabled: boolean, tmpDir: string, auth: string): Prom
     authToken: auth,
     requestTimeoutMs: 10000,
     version: '0.0.0',
+    developmentAgent: opts.developmentAgent,
     sessions: { claudePath: '/usr/bin/echo', maxSessions: 3, defaultMaxDurationMinutes: 30, protectedSessions: [], monitorIntervalMs: 5000 },
     scheduler: { enabled: false, jobsFile: '', maxParallelJobs: 1 },
     messaging: [],
     monitoring: {},
     updates: {},
-    multiMachine: { seamlessness: { ws41DurableAck: enabled } },
+    // 'dev-gated' → OMIT the flag so the dev-gate decides; otherwise set it explicitly.
+    multiMachine: { seamlessness: enabled === 'dev-gated' ? {} : { ws41DurableAck: enabled } },
   } as unknown as InstarConfig;
 
   const server = new AgentServer({
@@ -124,6 +135,42 @@ describe('E2E: WS4.1 durable remote-ack routes are ALIVE through the real AgentS
     } finally {
       await offServer.stop();
       SafeFsExecutor.safeRmSync(offDir, { recursive: true, force: true, operation: 'tests/e2e/attention-remote-ack-alive.test.ts' });
+    }
+  });
+
+  // mm-pool-seamlessness-devgate (operator directive topic 13481): with the flag OMITTED
+  // (no explicit config value), the developmentAgent gate must flip the route ALIVE on a
+  // dev agent and keep it 503 on the fleet — proving the dev-gate actually flips the route,
+  // not just shuffles a registry. This is the load-bearing PR2 behavior for ws41DurableAck.
+  it('dev-gate: flag OMITTED + developmentAgent:true → route ALIVE (not the dark-fleet 503)', async () => {
+    const devDir = fs.mkdtempSync(path.join(os.tmpdir(), 'remote-ack-dev-'));
+    const devServer = await startServer('dev-gated', devDir, AUTH, { developmentAgent: true });
+    try {
+      const res = await request(devServer.getApp())
+        .post('/attention/att-dev/remote-ack')
+        .set(auth())
+        .send({ machineId: 'm_owner', status: 'DONE' });
+      expect(res.status).toBe(200);
+      expect(res.body).toMatchObject({ ok: true, queued: true });
+    } finally {
+      await devServer.stop();
+      SafeFsExecutor.safeRmSync(devDir, { recursive: true, force: true, operation: 'tests/e2e/attention-remote-ack-alive.test.ts' });
+    }
+  });
+
+  it('dev-gate: flag OMITTED + developmentAgent:false (fleet) → 503 (dark by default)', async () => {
+    const fleetDir = fs.mkdtempSync(path.join(os.tmpdir(), 'remote-ack-fleet-'));
+    const fleetServer = await startServer('dev-gated', fleetDir, AUTH, { developmentAgent: false });
+    try {
+      const res = await request(fleetServer.getApp())
+        .post('/attention/x/remote-ack')
+        .set(auth())
+        .send({ machineId: 'm_owner', status: 'DONE' });
+      expect(res.status).toBe(503);
+      expect(res.body.error).toMatch(/ws41DurableAck/);
+    } finally {
+      await fleetServer.stop();
+      SafeFsExecutor.safeRmSync(fleetDir, { recursive: true, force: true, operation: 'tests/e2e/attention-remote-ack-alive.test.ts' });
     }
   });
 });

--- a/tests/unit/PostUpdateMigrator-seamlessnessDevGate.test.ts
+++ b/tests/unit/PostUpdateMigrator-seamlessnessDevGate.test.ts
@@ -1,0 +1,140 @@
+/**
+ * Migration parity for the 5 multiMachine.seamlessness coherence flags (WS3 / WS1.3 /
+ * WS4.1 / WS4.3) re-gated to the developmentAgent gate on 2026-06-13 (operator directive
+ * topic 13481: "NOTHING should ship dark on development agents").
+ *
+ * Existing agents carry the OLD ConfigDefaults-backfilled signature — an explicit
+ * `false` per flag (and for ws43, the pair `{ ws43JournalLease:false,
+ * ws43JournalLeaseDryRun:true }`). The explicit `false` would keep resolveDevAgentGate
+ * DARK even on a dev agent. migrateConfigSeamlessnessDevGate strips a default-shaped
+ * `false` per flag so the gate resolves (live-on-dev / dark-fleet) — and strips the paired
+ * ws43JournalLeaseDryRun:true so the consumer's coherent dryRun default applies. An
+ * operator-set explicit `true` (or any non-default value) is left entirely alone (reach is
+ * not authority). Mirrors the ws44PoolLinks / stateSync strips.
+ */
+import { describe, it, expect } from 'vitest';
+import { migrateConfigSeamlessnessDevGate } from '../../src/core/PostUpdateMigrator.js';
+import { applyDefaults, getMigrationDefaults } from '../../src/config/ConfigDefaults.js';
+import { resolveDevAgentGate } from '../../src/core/devAgentGate.js';
+
+const FLAGS = [
+  'ws3OneVoice',
+  'ws13Reconcile',
+  'ws41DurableAck',
+  'ws43RoleGuard',
+  'ws43JournalLease',
+] as const;
+
+function oldDefaultConfig(): Record<string, any> {
+  return {
+    multiMachine: {
+      seamlessness: {
+        ...Object.fromEntries(FLAGS.map((f) => [f, false])),
+        ws43JournalLeaseDryRun: true,
+      },
+    },
+  };
+}
+
+describe('migrateConfigSeamlessnessDevGate', () => {
+  it('strips the default-shaped false from all 5 coherence flags + paired ws43JournalLeaseDryRun', () => {
+    const cfg = oldDefaultConfig();
+    expect(migrateConfigSeamlessnessDevGate(cfg)).toBe(true);
+    // All 5 flags + dryRun stripped → seamlessness block was emptied & removed.
+    expect(cfg.multiMachine.seamlessness).toBeUndefined();
+  });
+
+  it('keeps non-default tunables when stripping only the flags (block not emptied)', () => {
+    const cfg: Record<string, any> = {
+      multiMachine: {
+        seamlessness: {
+          ...Object.fromEntries(FLAGS.map((f) => [f, false])),
+          ws43JournalLeaseDryRun: true,
+          ws3DwellMs: 60000, // a tunable, not a gate — left alone
+        },
+      },
+    };
+    expect(migrateConfigSeamlessnessDevGate(cfg)).toBe(true);
+    for (const f of FLAGS) {
+      expect(Object.prototype.hasOwnProperty.call(cfg.multiMachine.seamlessness, f), `${f} stripped`).toBe(false);
+    }
+    expect(Object.prototype.hasOwnProperty.call(cfg.multiMachine.seamlessness, 'ws43JournalLeaseDryRun')).toBe(false);
+    expect(cfg.multiMachine.seamlessness.ws3DwellMs).toBe(60000);
+  });
+
+  it('after strip + applyDefaults, the flags resolve LIVE on a dev agent and DARK on the fleet', () => {
+    const dev: Record<string, any> = { developmentAgent: true, ...oldDefaultConfig() };
+    migrateConfigSeamlessnessDevGate(dev);
+    applyDefaults(dev, getMigrationDefaults('standalone'));
+    const devSeam = dev.multiMachine?.seamlessness ?? {};
+    for (const f of FLAGS) {
+      expect(resolveDevAgentGate(devSeam[f], dev), `${f} live on dev`).toBe(true);
+    }
+    // ws43JournalLeaseDryRun resolves COHERENTLY false on dev (genuinely live cutover).
+    expect(devSeam.ws43JournalLeaseDryRun ?? !resolveDevAgentGate(undefined, dev), 'ws43 dryRun false on dev').toBe(false);
+
+    const fleet: Record<string, any> = { developmentAgent: false, ...oldDefaultConfig() };
+    migrateConfigSeamlessnessDevGate(fleet);
+    applyDefaults(fleet, getMigrationDefaults('standalone'));
+    const fleetSeam = fleet.multiMachine?.seamlessness ?? {};
+    for (const f of FLAGS) {
+      expect(resolveDevAgentGate(fleetSeam[f], fleet), `${f} dark on fleet`).toBe(false);
+    }
+    // Fleet stays in the safe dry-run posture.
+    expect(fleetSeam.ws43JournalLeaseDryRun ?? !resolveDevAgentGate(undefined, fleet), 'ws43 dryRun true on fleet').toBe(true);
+  });
+
+  it('is idempotent (a second run finds nothing default-shaped to strip)', () => {
+    const cfg = oldDefaultConfig();
+    expect(migrateConfigSeamlessnessDevGate(cfg)).toBe(true);
+    expect(migrateConfigSeamlessnessDevGate(cfg)).toBe(false);
+  });
+
+  it('leaves an operator-set explicit true entirely alone (reach is not authority)', () => {
+    const cfg: Record<string, any> = {
+      multiMachine: { seamlessness: { ws3OneVoice: true, ws43JournalLease: true } },
+    };
+    expect(migrateConfigSeamlessnessDevGate(cfg)).toBe(false);
+    expect(cfg.multiMachine.seamlessness.ws3OneVoice).toBe(true);
+    expect(cfg.multiMachine.seamlessness.ws43JournalLease).toBe(true);
+  });
+
+  it('leaves an operator-set ws43JournalLeaseDryRun untouched when not paired with a default-shaped false', () => {
+    // ws43JournalLease operator-on (true) → not stripped; the paired dryRun strip never fires.
+    const cfg: Record<string, any> = {
+      multiMachine: { seamlessness: { ws43JournalLease: true, ws43JournalLeaseDryRun: true } },
+    };
+    expect(migrateConfigSeamlessnessDevGate(cfg)).toBe(false);
+    expect(cfg.multiMachine.seamlessness.ws43JournalLeaseDryRun).toBe(true);
+  });
+
+  it('does NOT strip ws43JournalLeaseDryRun:false even alongside a default-shaped ws43JournalLease:false (operator-touched dryRun)', () => {
+    const cfg: Record<string, any> = {
+      multiMachine: { seamlessness: { ws43JournalLease: false, ws43JournalLeaseDryRun: false } },
+    };
+    expect(migrateConfigSeamlessnessDevGate(cfg)).toBe(true);
+    // ws43JournalLease (default-shaped false) stripped; the operator dryRun:false preserved.
+    expect(Object.prototype.hasOwnProperty.call(cfg.multiMachine.seamlessness, 'ws43JournalLease')).toBe(false);
+    expect(cfg.multiMachine.seamlessness.ws43JournalLeaseDryRun).toBe(false);
+  });
+
+  it('migrates only the flags present (a partial config strips just what is default-shaped)', () => {
+    const cfg: Record<string, any> = {
+      multiMachine: {
+        seamlessness: {
+          ws3OneVoice: false, // strip
+          ws43RoleGuard: true, // operator-on, leave
+        },
+      },
+    };
+    expect(migrateConfigSeamlessnessDevGate(cfg)).toBe(true);
+    expect(Object.prototype.hasOwnProperty.call(cfg.multiMachine.seamlessness, 'ws3OneVoice')).toBe(false);
+    expect(cfg.multiMachine.seamlessness.ws43RoleGuard).toBe(true);
+  });
+
+  it('returns false (no-op) on a config with no seamlessness block (single-machine / fresh)', () => {
+    expect(migrateConfigSeamlessnessDevGate({})).toBe(false);
+    expect(migrateConfigSeamlessnessDevGate({ multiMachine: {} })).toBe(false);
+    expect(migrateConfigSeamlessnessDevGate({ multiMachine: { seamlessness: {} } })).toBe(false);
+  });
+});

--- a/tests/unit/lint-dev-agent-dark-gate.test.ts
+++ b/tests/unit/lint-dev-agent-dark-gate.test.ts
@@ -348,9 +348,19 @@ describe('lint-dev-agent-dark-gate', () => {
       // lease cutover inserts another 18-line plain-boolean seamlessness block
       // (ws43JournalLease + ws43JournalLeaseDryRun, NOT `enabled:` paths) above
       // sessionPool, a further +18 shift. RE-VERIFIED by hand via the attributor on the merged ConfigDefaults.
-      '786': 'multiMachine.sessionPool.enabled',
-      '811': 'multiMachine.sessionPool.inboundQueue.enabled',
-      '840': 'multiMachine.sessionPool.holdForStability.enabled',
+      // mm-pool-seamlessness-devgate (operator directive 2026-06-13, topic 13481):
+      // the 5 multiMachine.seamlessness coherence flags (ws3OneVoice, ws13Reconcile,
+      // ws41DurableAck, ws43RoleGuard, ws43JournalLease) had their hardcoded `false`
+      // literals REMOVED (now OMITTED so the dev-gate resolves them live-on-dev / dark-
+      // fleet). They were never `enabled:` paths so the attributor never tracked them, but
+      // removing the literals + their comment reflow shifted the sessionPool block DOWN by
+      // +23 (786→809) and cartographer DOWN by +23 (1100→1123). The 3 sessionPool flags
+      // stay HARDCODED false (held — they share the StageAdvancer `stage !== 'dark'` gate,
+      // not cleanly dev-gatable), so they remain attributed here. RE-VERIFIED by hand via
+      // the attributor on the edited ConfigDefaults (each maps to a real `enabled: false,` line).
+      '809': 'multiMachine.sessionPool.enabled',
+      '834': 'multiMachine.sessionPool.inboundQueue.enabled',
+      '863': 'multiMachine.sessionPool.holdForStability.enabled',
       // mm-stores-devgate (operator directive 2026-06-13, topic 13481): the 7
       // multiMachine.stateSync.* memory stores MOVED from DARK_GATE_EXCLUSIONS to
       // DEV_GATED_FEATURES and their `enabled: false` literals were REMOVED from
@@ -360,9 +370,9 @@ describe('lint-dev-agent-dark-gate', () => {
       // removal shrank the stateSync block, shifting cartographer up: 1125→1100,
       // 1170→1145, 1195→1170. RE-VERIFIED by hand via the attributor on the edited
       // ConfigDefaults (each maps to a real `enabled: false,` line).
-      '1100': 'cartographer.freshnessSweep.enabled',
-      '1145': 'cartographer.conformanceAudit.llmEnrichment.enabled',
-      '1170': 'cartographer.subtreeNav.llmRerank.enabled',
+      '1123': 'cartographer.freshnessSweep.enabled',
+      '1168': 'cartographer.conformanceAudit.llmEnrichment.enabled',
+      '1193': 'cartographer.subtreeNav.llmRerank.enabled',
     };
     const actual = attributeRealConfigDefaults();
     expect(actual).toEqual(EXPECTED);

--- a/tests/unit/seamlessness-dev-gate-wiring.test.ts
+++ b/tests/unit/seamlessness-dev-gate-wiring.test.ts
@@ -1,0 +1,153 @@
+/**
+ * mm-pool-seamlessness-devgate (operator directive 2026-06-13, topic 13481): the 5
+ * multiMachine.seamlessness coherence flags (ws3OneVoice, ws13Reconcile, ws41DurableAck,
+ * ws43RoleGuard, ws43JournalLease) moved from hardcoded `false` in ConfigDefaults to the
+ * developmentAgent gate — config OMITS them, the runtime resolves via resolveDevAgentGate
+ * (live-on-dev / dark-fleet), mirroring the ws44PoolLinks/ws44PoolCache precedent.
+ *
+ * This test enforces the TWO halves the PR1 lesson taught us NOT to skip:
+ *   A. RESOLUTION — each flag resolves true on a dev agent, false on the fleet (and the
+ *      ws43JournalLeaseDryRun coherence: dev → live/false, fleet → dry-run/true).
+ *   B. NO-MISSED-CONSUMER — every production read-site routes the raw config value through
+ *      resolveDevAgentGate. A consumer left on the old raw `=== true` read would keep the
+ *      feature DARK on a dev agent even though ConfigDefaults omits it (the exact "still-
+ *      dark-on-dev = incomplete" failure mode). Asserted at the source-string seam so a
+ *      regression that reverts a consumer to the raw read fails CI.
+ */
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { resolveDevAgentGate } from '../../src/core/devAgentGate.js';
+import { applyDefaults, getMigrationDefaults } from '../../src/config/ConfigDefaults.js';
+import { DEV_GATED_FEATURES, DARK_GATE_EXCLUSIONS } from '../../src/core/devGatedFeatures.js';
+
+const FLAGS = [
+  'ws3OneVoice',
+  'ws13Reconcile',
+  'ws41DurableAck',
+  'ws43RoleGuard',
+  'ws43JournalLease',
+] as const;
+
+const srcDir = path.join(process.cwd(), 'src');
+const serverSrc = fs.readFileSync(path.join(srcDir, 'commands', 'server.ts'), 'utf-8');
+const routesSrc = fs.readFileSync(path.join(srcDir, 'server', 'routes.ts'), 'utf-8');
+const configDefaultsSrc = fs.readFileSync(path.join(srcDir, 'config', 'ConfigDefaults.ts'), 'utf-8');
+
+describe('seamlessness dev-gate — A. resolution (live-on-dev / dark-fleet)', () => {
+  it('ConfigDefaults OMITS each flag (no hardcoded `false` injected)', () => {
+    // A fresh standalone config gets the migration defaults applied — the flags must NOT
+    // be present (omitted), so resolveDevAgentGate decides per-agent.
+    const dev: Record<string, any> = { developmentAgent: true };
+    applyDefaults(dev, getMigrationDefaults('standalone'));
+    const seam = dev.multiMachine?.seamlessness ?? {};
+    for (const f of FLAGS) {
+      expect(seam[f], `${f} omitted from ConfigDefaults`).toBeUndefined();
+    }
+    // ws43JournalLeaseDryRun is ALSO omitted (computed coherently at the consumer).
+    expect(seam.ws43JournalLeaseDryRun, 'ws43JournalLeaseDryRun omitted').toBeUndefined();
+  });
+
+  it('each flag resolves LIVE on a dev agent and DARK on the fleet', () => {
+    const dev: Record<string, any> = { developmentAgent: true };
+    applyDefaults(dev, getMigrationDefaults('standalone'));
+    const fleet: Record<string, any> = { developmentAgent: false };
+    applyDefaults(fleet, getMigrationDefaults('standalone'));
+    for (const f of FLAGS) {
+      const devSeam = dev.multiMachine?.seamlessness ?? {};
+      const fleetSeam = fleet.multiMachine?.seamlessness ?? {};
+      expect(resolveDevAgentGate(devSeam[f], dev), `${f} live on dev`).toBe(true);
+      expect(resolveDevAgentGate(fleetSeam[f], fleet), `${f} dark on fleet`).toBe(false);
+    }
+  });
+
+  it('ws43JournalLeaseDryRun resolves COHERENTLY: false (live) on dev, true (dry-run) on fleet', () => {
+    const dev: Record<string, any> = { developmentAgent: true };
+    applyDefaults(dev, getMigrationDefaults('standalone'));
+    const fleet: Record<string, any> = { developmentAgent: false };
+    applyDefaults(fleet, getMigrationDefaults('standalone'));
+    // The consumer formula: cfg?.ws43JournalLeaseDryRun ?? !resolveDevAgentGate(undefined, config)
+    const devDry = (dev.multiMachine?.seamlessness?.ws43JournalLeaseDryRun) ?? !resolveDevAgentGate(undefined, dev);
+    const fleetDry = (fleet.multiMachine?.seamlessness?.ws43JournalLeaseDryRun) ?? !resolveDevAgentGate(undefined, fleet);
+    expect(devDry, 'dev → live cutover (dryRun false)').toBe(false);
+    expect(fleetDry, 'fleet → dry-run (dryRun true)').toBe(true);
+  });
+
+  it('an explicit operator config value still wins (force-dark false / fleet-flip true)', () => {
+    const devForceDark: Record<string, any> = { developmentAgent: true };
+    expect(resolveDevAgentGate(false, devForceDark)).toBe(false);
+    const fleetFlip: Record<string, any> = { developmentAgent: false };
+    expect(resolveDevAgentGate(true, fleetFlip)).toBe(true);
+  });
+});
+
+describe('seamlessness dev-gate — B. no-missed-consumer (every read routes through resolveDevAgentGate)', () => {
+  it('ws3OneVoice — SpeakerElection.enabled reads through resolveDevAgentGate(ws3Cfg().ws3OneVoice, config)', () => {
+    expect(serverSrc).toMatch(/resolveDevAgentGate\(ws3Cfg\(\)\.ws3OneVoice,\s*config\)/);
+    // The old raw read must be GONE (a revert would re-dark dev).
+    expect(serverSrc).not.toMatch(/enabled:\s*\(\)\s*=>\s*ws3Cfg\(\)\.ws3OneVoice === true/);
+  });
+
+  it('ws13Reconcile — OwnershipReconciler.enabled reads through resolveDevAgentGate; ws13DryRun stays a plain read', () => {
+    expect(serverSrc).toMatch(/resolveDevAgentGate\(ws13Cfg\(\)\.ws13Reconcile,\s*config\)/);
+    expect(serverSrc).not.toMatch(/enabled:\s*\(\)\s*=>\s*ws13Cfg\(\)\.ws13Reconcile === true/);
+    // ws13DryRun is the in-component rung, NOT the dev-gate — it stays a plain config read.
+    expect(serverSrc).toMatch(/dryRun:\s*\(\)\s*=>\s*ws13Cfg\(\)\.ws13DryRun !== false/);
+  });
+
+  it('ws41DurableAck — routes.ts ws41DurableAckEnabled reads through resolveDevAgentGate(..., ctx.config)', () => {
+    expect(routesSrc).toMatch(/resolveDevAgentGate\(\s*\(\(ctx\.config[\s\S]{0,160}?\)\.ws41DurableAck,\s*ctx\.config/);
+    expect(routesSrc).not.toMatch(/\.ws41DurableAck === true;/);
+  });
+
+  it('ws43RoleGuard — scheduler.setRoleGuard enabled reads through resolveDevAgentGate', () => {
+    expect(serverSrc).toMatch(/resolveDevAgentGate\(config\.multiMachine\?\.seamlessness\?\.ws43RoleGuard,\s*config\)/);
+    expect(serverSrc).not.toMatch(/enabled:\s*config\.multiMachine\?\.seamlessness\?\.ws43RoleGuard === true/);
+  });
+
+  it('ws43JournalLease — setJournalLeaseCutover enabled reads through resolveDevAgentGate; dryRun is coherent', () => {
+    expect(serverSrc).toMatch(/resolveDevAgentGate\(config\.multiMachine\?\.seamlessness\?\.ws43JournalLease,\s*config\)/);
+    // The dryRun consumer formula (cfg ?? !resolveDevAgentGate(undefined, config)).
+    expect(serverSrc).toMatch(/ws43JournalLeaseDryRun \?\? !resolveDevAgentGate\(undefined,\s*config\)/);
+    // The old raw cutover-input read must be GONE.
+    expect(serverSrc).not.toMatch(/enabled:\s*config\.multiMachine\?\.seamlessness\?\.ws43JournalLease === true,/);
+  });
+
+  it('ws43JournalLease — the heartbeat capability advert resolves through the gate (not the raw read)', () => {
+    // The seamlessnessFlags advert advertises journal-lease only when the gate resolves
+    // it live AND it is not dry-run — both via resolveDevAgentGate, never the raw === true.
+    const advert = serverSrc.match(/seamlessnessFlags:\s*\{[\s\S]{0,400}?ws43JournalLease:[\s\S]{0,260}?stateSyncReceive/)![0];
+    expect(advert).toMatch(/resolveDevAgentGate\(config\.multiMachine\?\.seamlessness\?\.ws43JournalLease,\s*config\)/);
+    expect(advert).not.toMatch(/ws43JournalLease:\s*config\.multiMachine\?\.seamlessness\?\.ws43JournalLease === true/);
+  });
+});
+
+describe('seamlessness dev-gate — registry coherence', () => {
+  it('all 5 flags are registered in DEV_GATED_FEATURES by configPath', () => {
+    for (const f of FLAGS) {
+      const entry = DEV_GATED_FEATURES.find((e) => e.configPath === `multiMachine.seamlessness.${f}`);
+      expect(entry, `${f} registered in DEV_GATED_FEATURES`).toBeDefined();
+      expect(entry!.justification.length, `${f} has a real justification`).toBeGreaterThan(40);
+    }
+  });
+
+  it('none of the 5 flags are in DARK_GATE_EXCLUSIONS (they are dev-gated, not dark-for-everyone)', () => {
+    for (const f of FLAGS) {
+      const excl = DARK_GATE_EXCLUSIONS.find((e) => e.configPath === `multiMachine.seamlessness.${f}`);
+      expect(excl, `${f} NOT in DARK_GATE_EXCLUSIONS`).toBeUndefined();
+    }
+  });
+
+  it('the 3 sessionPool flags stay HELD in DARK_GATE_EXCLUSIONS (shared StageAdvancer stage-gate, not cleanly dev-gatable)', () => {
+    for (const cp of [
+      'multiMachine.sessionPool.enabled',
+      'multiMachine.sessionPool.inboundQueue.enabled',
+      'multiMachine.sessionPool.holdForStability.enabled',
+    ]) {
+      expect(DARK_GATE_EXCLUSIONS.find((e) => e.configPath === cp), `${cp} held in exclusions`).toBeDefined();
+      expect(DEV_GATED_FEATURES.find((e) => e.configPath === cp), `${cp} NOT dev-gated`).toBeUndefined();
+    }
+    // And they remain hardcoded `enabled: false` in ConfigDefaults (held, not omitted).
+    expect(configDefaultsSrc).toMatch(/sessionPool:\s*\{\s*\n\s*enabled:\s*false/);
+  });
+});

--- a/upgrades/next/mm-pool-seamlessness-devgate.md
+++ b/upgrades/next/mm-pool-seamlessness-devgate.md
@@ -1,0 +1,72 @@
+# Multi-machine seamlessness coherence layers — dev-gated (live-on-dev, dark-fleet)
+
+## What Changed
+
+- **The 5 `multiMachine.seamlessness` coherence flags** — `ws3OneVoice` (one-voice
+  election), `ws13Reconcile` (ownership reconcile), `ws41DurableAck` (durable cross-machine
+  acknowledgement), `ws43RoleGuard` (role-guard-at-spawn), `ws43JournalLease` (journal-lease
+  cutover) — **moved from a hardcoded `false` in `ConfigDefaults` to the developmentAgent
+  gate (live-on-dev / dark-fleet)**, mirroring the already-merged `ws44PoolLinks` /
+  `ws44PoolCache` precedent.
+- **Driver — operator directive (topic 13481, 2026-06-13):** "Nothing should ship dark for
+  development agents. Everything fully functional so it actually gets tested and doesn't
+  just rot." This is PR2 of that directive; PR1 (#1151) moved the 7 cross-machine memory
+  stores.
+- **How it resolves now:** each flag's `ConfigDefaults` block OMITS the literal so
+  `resolveDevAgentGate` decides — LIVE on a development agent, DARK on the fleet. Every
+  consumer read-site (the SpeakerElection, the OwnershipReconciler, the durable remote-ack
+  routes, the scheduler role-guard, the journal-lease cutover gate, and the heartbeat
+  capability advert) was routed through that one gate, and `ws43JournalLeaseDryRun` is
+  computed COHERENTLY with its gate (a dev agent runs the cutover genuinely live, the fleet
+  stays in the safe dry-run posture).
+- **The session-pool master switch is deliberately HELD.** `multiMachine.sessionPool`
+  (the active-active master plus its inbound-queue and hold-for-stability sub-flags) was NOT
+  moved. It carries a second, structurally-enforced rollout gate (`sessionPool.stage`,
+  advanced only through an end-to-end-test-gated ladder); flipping only the dev gate would
+  leave the pool inert, and forcing the stage would bypass that deliberate cutover
+  discipline. It is surfaced for an operator decision instead (advance the stage on the dev
+  mesh if active-active pooling should be dogfooded live).
+- **Fleet + single-machine agents are an unchanged no-op** — every layer resolves dark
+  exactly as before, and each is a strict no-op without a second online machine. An
+  operator's explicit per-flag setting remains the documented force-dark (false) /
+  fleet-flip (true) override.
+
+## Migration
+
+- `PostUpdateMigrator.migrateConfigSeamlessnessDevGate` strips a default-shaped `false` per
+  flag on update (and the paired `ws43JournalLeaseDryRun:true` only alongside a
+  default-shaped `ws43JournalLease:false`) so the gate resolves on already-deployed dev
+  agents. An operator-set value is left entirely alone — reach is not authority. Idempotent.
+
+## Evidence
+
+- `tests/unit/seamlessness-dev-gate-wiring.test.ts` (13): each flag resolves live-on-dev /
+  dark-on-fleet through the gate; the dryRun coherence holds; a no-missed-consumer
+  source-string check fails CI if any consumer reverts to the raw read; the registry
+  coherence check confirms the 5 flags are dev-gated and the 3 session-pool flags stay held.
+- `tests/unit/PostUpdateMigrator-seamlessnessDevGate.test.ts` (9): the migrator strips the
+  default-shaped values, leaves operator-touched config alone, and is idempotent.
+- `tests/e2e/attention-remote-ack-alive.test.ts`: two new dev-gate cases prove the durable
+  remote-ack route goes ALIVE on a dev agent with the flag omitted and stays a 503 on the
+  fleet — the gate flips the real route, not just a registry entry.
+- `tests/unit/lint-dev-agent-dark-gate.test.ts`: the EXPECTED attribution map line numbers
+  were recomputed; the 3 session-pool flags remain as held hardcoded defaults.
+
+## Summary of New Capabilities
+
+- The five cross-machine coherence layers — single outbound voice, ownership reconcile,
+  durable cross-machine acknowledgement, the spawn-time role-guard, and the job journal-lease
+  cutover — now run LIVE on development agents (dark on the fleet) so they are actually
+  exercised across the operator's two machines instead of shipping dark everywhere.
+
+## What to Tell Your User
+
+Nothing changes for fleet agents — these multi-machine coherence features stay off for
+everyone except development agents. On a development agent that runs across two of your
+machines, the coordination layers that keep the two machines behaving as one agent (one
+voice per conversation, no double-replies, durable acknowledgements that survive a briefly
+offline machine, and a guard that keeps state-writing jobs on the right machine) now run
+live, so they finally get real-world testing before reaching everyone. There is no
+user-facing action and no behavior change on a normal install or any single-machine agent.
+The active-active session pool itself stays off pending a separate operator decision, because
+it has its own staged rollout that should advance deliberately.

--- a/upgrades/side-effects/mm-pool-seamlessness-devgate.md
+++ b/upgrades/side-effects/mm-pool-seamlessness-devgate.md
@@ -1,0 +1,149 @@
+# Side-Effects — multiMachine.seamlessness coherence flags → dev-gated (topic 13481), sessionPool master HELD
+
+**Change (PR2 of the no-dark-on-dev multi-machine directive):** Re-gate the 5
+`multiMachine.seamlessness` coherence flags — `ws3OneVoice` (one-voice election),
+`ws13Reconcile` (ownership reconcile), `ws41DurableAck` (durable cross-machine /ack),
+`ws43RoleGuard` (role-guard-at-spawn), `ws43JournalLease` (journal-lease cutover) — from
+hardcoded `false` in `ConfigDefaults.ts` to the developmentAgent gate (live-on-dev /
+dark-fleet), mirroring the merged `ws44PoolLinks` / `ws44PoolCache` precedent. The
+`ws43JournalLeaseDryRun` sub-knob is computed COHERENTLY with its gate (dev → live/false,
+fleet → dry-run/true). **The `multiMachine.sessionPool.*` master switch and its
+`inboundQueue` / `holdForStability` sub-flags are deliberately HELD** (see #7).
+
+**Driver:** Operator directive (Justin, topic 13481, 2026-06-13): "NOTHING should ship
+dark on development agents. Everything fully functional so it actually gets tested and
+doesn't just rot." PR1 (#1151) moved the 7 stateSync memory stores; PR2 is the remaining
+dark-on-dev multi-machine seamlessness layers.
+
+**Spec:** `docs/specs/MULTI-MACHINE-SEAMLESSNESS-SPEC.md` (the converged + approved spec the
+seamlessness flags were built against) + `docs/specs/multi-machine-replicated-store-
+foundation.md` (sessionPool context). This is a follow-up gating fix to already-merged
+features, not a new feature.
+
+## What was wrong
+
+The 5 seamlessness flags shipped with a literal `false` in `ConfigDefaults.ts` (e.g.
+`ws3OneVoice: false`). A written literal force-darks even a development agent (the #1001
+anti-pattern), so the coherence layers never ran ANYWHERE — they could never be dogfooded
+on Echo / the Mini and never graduated toward the fleet. ws44PoolLinks/ws44PoolCache had
+already been corrected to the omitted-gate pattern; these five lagged behind.
+
+## What changed
+
+- `src/config/ConfigDefaults.ts` — OMIT the hardcoded `false` for all 5 flags (each carries
+  a ws44-style "DELIBERATELY OMITTED" comment) so `resolveDevAgentGate` decides at runtime.
+  `ws43JournalLeaseDryRun` is ALSO omitted (computed coherently at the consumer). `ws13DryRun`
+  stays a plain hardcoded default `true` (it is the in-component "log intended CAS without
+  performing it" rung, NOT the dev-gate). The sessionPool block is UNTOUCHED.
+- `src/commands/server.ts` — route each consumer read through `resolveDevAgentGate(...)`:
+  - `ws3OneVoice`: `SpeakerElection.enabled` → `resolveDevAgentGate(ws3Cfg().ws3OneVoice, config)`.
+  - `ws13Reconcile`: `OwnershipReconciler.enabled` → gated; `dryRun` stays the plain `ws13DryRun !== false` read.
+  - `ws43RoleGuard`: `scheduler.setRoleGuard().enabled` → gated.
+  - `ws43JournalLease`: `setJournalLeaseCutover().enabled` → gated; `dryRun` →
+    `cfg?.ws43JournalLeaseDryRun ?? !resolveDevAgentGate(undefined, config)` (coherent).
+  - the heartbeat `seamlessnessFlags` advert resolves journal-lease via the gate, not the raw read.
+- `src/server/routes.ts` — `ws41DurableAckEnabled()` reads through
+  `resolveDevAgentGate(..., ctx.config)`, so the route + precedence guard agree.
+- `src/core/devGatedFeatures.ts` — ADD all 5 flags as `DEV_GATED_FEATURES` entries
+  (by-name, each with a non-destructive/no-egress justification). A header comment records
+  WHY the sessionPool master + sub-flags are NOT moved here (the StageAdvancer stage-gate).
+- `src/core/PostUpdateMigrator.ts` — NEW `migrateConfigSeamlessnessDevGate(config)`: strips
+  a default-shaped `false` per flag (and the paired `ws43JournalLeaseDryRun:true` only
+  alongside a default-shaped `ws43JournalLease:false`) so the gate resolves on update. An
+  operator-set value (explicit `true`, a divergent dryRun) is left ENTIRELY alone. Idempotent.
+  Wired into the migrate path with `upgraded`/`skipped` reporting.
+- `tests/unit/lint-dev-agent-dark-gate.test.ts` — EXPECTED attribution map line numbers
+  recomputed via the attributor (the 5 removed literals + comment reflow shift sessionPool
+  786→809 and cartographer 1100→1123). The 3 sessionPool flags STAY in the map (held,
+  hardcoded false). No paths added/removed (the seamlessness flags were never `enabled:`-named).
+
+## Decision-point inventory (Phase-4)
+
+### 1. Over-block
+A gate that resolved live when it shouldn't. Not possible: `resolveDevAgentGate` resolves
+true ONLY when `developmentAgent: true` (or an explicit `true`), so the fleet is byte-for-byte
+unchanged. Each layer is additionally a strict single-machine no-op (the election never
+engages below 2 online machines; the role-guard never fires when this machine holds the lease;
+the journal-lease cutover requires ≥2 flag-coherent peers).
+
+### 2. Under-block
+A consumer left on the raw `=== true` read would keep the feature DARK on a dev agent even
+though ConfigDefaults omits it (the PR1 "still-dark-on-dev = incomplete" failure). Closed by
+grepping ALL consumer sites (5 flags + the heartbeat advert + the dryRun coherence formula)
+and routing every one through the gate, then pinning it with a source-string no-missed-consumer
+wiring test (`tests/unit/seamlessness-dev-gate-wiring.test.ts`, section B) that fails CI if a
+consumer reverts to the raw read.
+
+### 3. Level-of-abstraction fit
+The gate is resolved at the SAME construction/route boundary as the ws44 precedent — one
+funnel (`resolveDevAgentGate`) reads the raw config value and the agent's `developmentAgent`
+flag. No new abstraction; the consumers' downstream `enabled`-true semantics are unchanged.
+
+### 4. Signal vs authority compliance
+Each layer runs in the SAFE direction and none gains authority from going live-on-dev:
+ws3OneVoice only WITHHOLDS a duplicate send (never fabricates one); ws13Reconcile runs in its
+own dry-run (logs intended CAS, performs none); ws43RoleGuard can only REFUSE a spawn (never
+wrongly spawn); ws41DurableAck persists an intent bound to the AUTHENTICATED operator and the
+owner REVALIDATES at apply time; ws43JournalLease coordinates job claims over durable state
+and the cutover gate guarantees the two mechanisms are never both live for a job set.
+
+### 5. Interactions
+- ws43JournalLease ↔ ws43JournalLeaseDryRun: the two MUST resolve coherently or a dev agent
+  would run live-but-dry-run (logged, never exercised) — handled by the `?? !resolveDevAgentGate`
+  formula at the consumer AND the migration's paired strip.
+- The heartbeat `seamlessnessFlags.ws43JournalLease` advert (what peers read to decide
+  coherence) now mirrors the resolved enabled+not-dry-run, so a dev agent honestly advertises
+  the capability to a peer.
+- sessionPool HELD: because the seamlessness flags have NO stage-gate, they are independent of
+  the sessionPool master — flipping them live-on-dev does not activate the (held) session pool.
+
+### 6. External surfaces
+None new. The five features' routes/behaviors already existed; this only changes WHICH agents
+resolve them live. Replication/coordination is between the operator's OWN machines — no
+external egress, no third-party spend, no new API.
+
+### 7. Rollback cost & multi-machine posture (the heart)
+- **Rollback:** trivial and per-flag — set an explicit `multiMachine.seamlessness.<flag>: false`
+  in `.instar/config.json` to force-dark even a dev agent; an explicit `true` is the fleet-flip.
+  No data migration to undo (these are coordination layers, not stores). The 3 sessionPool flags
+  need no rollback — they were never flipped.
+- **Multi-machine posture:** these layers EXIST to make the operator's two machines behave as
+  one agent. Live-on-dev means Echo (laptop) + the Mac Mini now genuinely exercise one-voice
+  election, ownership reconcile, durable cross-machine acks, the spawn-time role-guard, and the
+  journal-lease cutover across the real two-machine mesh — the only way they get tested before
+  fleet. A single-machine dev agent is a strict no-op for all five (no peers).
+- **sessionPool HELD — the deliberate exception:** `multiMachine.sessionPool.{enabled,
+  inboundQueue.enabled, holdForStability.enabled}` were NOT moved to dev-gated. They share a
+  SECOND, structurally-enforced gate: `sessionPool.stage` is **StageAdvancer-write-only** (a
+  module-private `STAGE_WRITE_TOKEN`, rejected by `stageWriteGuard.ts` for any other writer),
+  defaults to `'dark'`, and advances only through an E2E-gated rollout ladder
+  (`dark → shadow → live-transfer → rebalance`). The activation expression EVERYWHERE is
+  `enabled && stage !== 'dark'` (server.ts:1990, 1998, 14351, 15611; boot-sweep gate 7019-7024).
+  So: (a) dev-gating `enabled` alone leaves the pool INERT on a dev agent (`stage` is still
+  dark) — a hollow move that fails the directive's "actually gets tested"; and (b) forcing
+  `stage` past dark in ConfigDefaults would BYPASS the deliberate cutover discipline the
+  StageAdvancer exists to enforce — not a clean, safe-by-default, reversible change. This is a
+  genuine collision between the "nothing dark on dev" directive and an explicit structural
+  safety invariant, so it is surfaced to the operator rather than forced. **Operator decision
+  needed:** advance `sessionPool.stage` on the dev mesh via the StageAdvancer ladder (gated on
+  green E2E) if active-active pooling should be dogfooded live; until then it stays dark.
+
+## Migration parity
+
+`applyDefaults` is add-missing-only deep-merge, so a new agent gets the omitted-flag shape via
+`init`. Existing agents that received the old `false` literals would keep them (explicit values
+are not overwritten) and stay dark even on a dev agent — so `migrateConfigSeamlessnessDevGate`
+strips the exact default-shaped `false` (and paired dryRun) on update. An operator's hand-edited
+value is never touched (reach is not authority). Idempotent (a second run strips nothing).
+
+## Tests
+
+Unit: `seamlessness-dev-gate-wiring` (13 — resolution + no-missed-consumer source-seam +
+registry coherence), `PostUpdateMigrator-seamlessnessDevGate` (9), `lint-dev-agent-dark-gate`
+(line-map recomputed), `devGatedFeatures-wiring` (74), `feature-delivery-completeness` (99),
+`SpeakerElection` / `OwnershipReconciler` / `ws3-one-voice-wiring`. Integration/E2E: the
+existing `scheduler-role-guard`, `scheduler-journal-lease-cutover`, `attention-remote-ack`
+suites stay green; `attention-remote-ack-alive` E2E gains two dev-gate cases (flag OMITTED +
+developmentAgent:true → route ALIVE; fleet → 503) proving the gate flips the route, not just
+the registry. Typecheck clean (`tsc --noEmit` exit 0); full lint suite clean. The full suite is
+left to CI (the authority).


### PR DESCRIPTION
## ELI16 — multi-machine session-pooling's coherence layers now run LIVE on development agents

The five multi-machine coherence layers — one voice per conversation (no double-replies across machines), ownership reconcile, durable cross-machine acks (an ack survives a briefly-offline machine), the spawn-time role-guard (state-writing jobs only run on the lease-holder), and the job journal-lease cutover — used to ship hardcoded dark for EVERYONE, including development agents, so they sat untested and rotted. This flips all five to the developmentAgent gate: they run LIVE across the operator's own two machines (dark on the fleet, a strict no-op single-machine) so they actually get exercised, mirroring the already-merged ws44PoolLinks/ws44PoolCache precedent. The active-active session pool master switch itself is deliberately HELD because it has a second, structurally-enforced staged-rollout gate that should advance deliberately, not be forced.

## What this PR does (PR2 of the no-dark-on-dev directive, operator topic 13481)

Re-gates the 5 `multiMachine.seamlessness` coherence flags — `ws3OneVoice`, `ws13Reconcile`, `ws41DurableAck`, `ws43RoleGuard`, `ws43JournalLease` — from a hardcoded `false` in `ConfigDefaults` to the developmentAgent gate (live-on-dev / dark-fleet). PR1 (#1151) did the same for the 7 stateSync memory stores.

- **ConfigDefaults**: OMIT the 5 literals (+ `ws43JournalLeaseDryRun`) so `resolveDevAgentGate` decides; `ws13DryRun` stays the plain in-component rung; sessionPool block untouched.
- **server.ts / routes.ts**: every consumer read (SpeakerElection, OwnershipReconciler, the durable remote-ack routes, the scheduler role-guard, the journal-lease cutover gate, and the heartbeat capability advert) now routes through `resolveDevAgentGate`. `ws43JournalLeaseDryRun` resolves coherently (dev → live/false, fleet → dry-run/true).
- **devGatedFeatures.ts**: add 5 `DEV_GATED_FEATURES` entries; a header comment records why sessionPool stays held.
- **PostUpdateMigrator.ts**: `migrateConfigSeamlessnessDevGate` strips a default-shaped `false` per flag on update (operator values left alone; idempotent).

## sessionPool master HELD (STOP-and-report)

`multiMachine.sessionPool.{enabled, inboundQueue.enabled, holdForStability.enabled}` were NOT moved. They share a SECOND structural gate: `sessionPool.stage` is StageAdvancer-write-only (token-guarded), defaults to `'dark'`, and advances only through an E2E-gated ladder (`dark → shadow → live-transfer → rebalance`). The activation expression everywhere is `enabled && stage !== 'dark'`. Dev-gating `enabled` alone would leave the pool inert (hollow), and forcing `stage` past dark in ConfigDefaults would bypass the deliberate cutover discipline — neither is cleanly safe+reversible. **Operator decision:** advance `sessionPool.stage` on the dev mesh via the StageAdvancer ladder if active-active pooling should be dogfooded live.

## Tests

- `tests/unit/seamlessness-dev-gate-wiring.test.ts` (13): resolution (live-on-dev / dark-fleet, dryRun coherence) + no-missed-consumer source-string seam + registry coherence (5 flags dev-gated, 3 sessionPool flags held).
- `tests/unit/PostUpdateMigrator-seamlessnessDevGate.test.ts` (9): strip + idempotency + operator-value preservation.
- `tests/e2e/attention-remote-ack-alive.test.ts`: two new dev-gate cases (flag OMITTED + developmentAgent:true → route ALIVE; fleet → 503) proving the gate flips the real route.
- `lint-dev-agent-dark-gate` line-map recomputed; full lint suite clean; `tsc --noEmit` exit 0.

Artifacts: `upgrades/side-effects/mm-pool-seamlessness-devgate.md`, `upgrades/next/mm-pool-seamlessness-devgate.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)