### PR TITLE
fix(reap-notifier): honest copy for an age-limit recycle of an active autonomous run

### DIFF
--- a/.instar/instar-dev-decisions/2026-06-14T07-30-16-333Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-06-14T07-30-16-333Z-unknown.json
@@ -1,0 +1,13 @@
+{
+  "ts": "2026-06-14T07:30:16.333Z",
+  "slug": "unknown",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 3,
+  "loc": 130,
+  "causalAutopsy": null,
+  "verdict": "pass"
+}

--- a/docs/specs/honest-session-recycle-spec.eli16.md
+++ b/docs/specs/honest-session-recycle-spec.eli16.md
@@ -1,0 +1,67 @@
+# Honest Session Recycle — plain-English overview
+
+## What this is, in one line
+
+When a long autonomous run's session hits its built-in "recycle" point and the
+system restarts it to keep going, the user should NOT get a scary tombstone
+message claiming the session "reached its maximum allowed runtime" — because the
+run isn't over, it's just being handed to a fresh process.
+
+## The problem we hit (real, 2026-06-14)
+
+An agent had an autonomous run going with about 11.5 hours left on its 24-hour
+clock. Each underlying terminal session, though, has its OWN much shorter
+lifetime cap (a few hours), after which the system kills the old process and
+spins up a fresh one that picks up exactly where it left off (a "recycle"). No
+work is lost — it's like swapping a tired runner for a fresh one mid-relay.
+
+But the message the user saw was: **"🪦 Your session was shut down — it reached
+its maximum allowed runtime."** At the very same moment, the run's own clock said
+"11h 42m remaining." Two messages, flatly contradicting each other. To the user
+it looked like their sessions keep dying for no reason — which is exactly the
+frustration that kicked this off.
+
+## What already exists
+
+The notifier that sends "your session was shut down" messages ALREADY knows how
+to stay quiet for a routine "kill-and-respawn" — it just wasn't told that an
+age-limit recycle of a still-active autonomous run is one of those. So the fix
+rides an existing seam rather than inventing a new system.
+
+## What's new
+
+1. When a session is recycled at its lifetime cap, we check: does this session's
+   topic have an autonomous run that is still inside its window? If yes, we stamp
+   the event as a recycle and how much time is left on the run.
+2. The notice then tells the truth: **"🔄 Your session was recycled at its
+   lifetime cap — your autonomous run has 11h 42m left, so I'll pick the work
+   back up where I left off. No work was lost."** No tombstone, no false
+   "maximum runtime" claim.
+
+## The safeguards, in plain terms
+
+- **We never go silent.** If anything goes wrong reading the run state, or the
+  run is genuinely over, the user still gets the normal loud "shut down" notice.
+  We only ever soften the wording when we are sure the run is still alive — we
+  never hide a real stop.
+- **Only the recycle case is touched.** A session that died because it got stuck
+  (not because of its age cap) still gets the honest "it was stuck" message, even
+  mid-run.
+- **No behavior change.** This changes words on a notice and adds one fact to an
+  event. It does NOT change when sessions get recycled, or whether they respawn.
+
+## What we deliberately did NOT do yet
+
+There's a stronger version where the system simply doesn't recycle a run at its
+midpoint at all (it respects the longer run clock). We held that back on purpose:
+it's only safe once we've proven the run is GUARANTEED to auto-respawn on its own,
+and today the respawn is triggered by the next message. That bigger change is
+tracked (commitment CMT-1520), not forgotten.
+
+## What you (the reader) actually need to decide
+
+Nothing is required to ship this — it's wording-only and can't hide a real
+failure. The one judgment call already made: ship the honest-wording fix now,
+and treat "stop recycling mid-run entirely" as a tracked follow-up gated on
+verifying guaranteed auto-respawn. If you'd rather hold even the wording change,
+say so; otherwise it's safe to land.

--- a/docs/specs/honest-session-recycle-spec.md
+++ b/docs/specs/honest-session-recycle-spec.md
@@ -1,0 +1,95 @@
+---
+title: Honest Session Recycle — stop dressing an autonomous-run recycle as a death
+status: draft
+parent-principle: "Honest progress messaging — a routine kill-to-respawn must not read to the user as a terminal failure (HONEST-PROGRESS-MESSAGING-SPEC lineage)."
+eli16-overview: docs/specs/honest-session-recycle-spec.eli16.md
+---
+
+# Honest Session Recycle
+
+## Problem (observed, topic 13481, 2026-06-14)
+
+A long autonomous run's tmux session is capped at `session.maxDurationMinutes`
+(default `DEFAULT_MAX_DURATION_MINUTES = 240`, +20%/max-60m buffer). The
+age-limit block in `SessionManager.runMaintenanceTick` defers the kill while the
+session shows active work (procs OR recently-grown transcript), but reaps it the
+moment it is **idle between turns** past the cap, via:
+
+```
+terminateSession(session.id, 'age-limit', { finalStatus: 'killed', disposition: 'terminal' })
+```
+
+`ReapNotifier` maps `age-limit → "it reached its maximum allowed runtime"` and,
+because `disposition: 'terminal'`, emits the user-facing
+`🪦 Your session … was shut down — it reached its maximum allowed runtime`.
+
+Meanwhile the **autonomous run** is a *separate* clock (`durationSeconds`, e.g.
+86400). `/session/clock` for the same topic reported **11h 42m remaining (51%)**
+at the exact moment the gravestone fired. Two clocks, contradictory user-facing
+claims. No work was lost (`midWork:false`, work on disk/merged, run record stays
+`active`, the session respawned ~31m later on the next inbound message). The
+harm is purely experiential: a routine recycle reads as repeated death, which is
+the operator's standing complaint ("sessions dying is getting REALLY bad").
+
+## Root cause
+
+The age-limit reaper consults **only** the per-session lifetime cap. It does not
+know that the session's TOPIC is mid-autonomous-run, so it (a) recycles at a
+point the run considers its midpoint and (b) classifies the recycle as a
+`terminal` disappearance rather than a continuation.
+
+## Design forks
+
+**F1 — Does an age-reaped autonomous session auto-respawn, or only on next message?**
+Today the respawn is message-triggered (the bridge's routing path detects the
+dead session). For an operator away from the keyboard, an autonomous run could
+sit stopped until they next message — so *silently* reclassifying the reap as a
+bounce would HIDE a real stop. **Lean:** do NOT silence unconditionally. Two
+sub-options, pick by F2.
+
+**F2 — Suppress the recycle, or just tell the truth about it?**
+- (a) *Respect the run window*: while a topic has an active autonomous run, the
+  per-session age cap does not terminally reap — it requests a **kill-to-respawn
+  bounce** (disposition `recovery-bounce`) routed through the guaranteed-respawn
+  path, so the run continues seamlessly and the notice stays silent (consistent
+  with "recovery-bounces stay silent"). Requires a real guaranteed-respawn seam.
+- (b) *Honest wording* (lower risk, no behavior change): keep the recycle, but
+  when the topic has an active autonomous run, replace the gravestone with an
+  honest continuation notice: "🔄 Session recycled at its lifetime cap — your
+  autonomous run (Xh left) continues; I'll resume on my own / on your next
+  message." Never claims "max runtime reached" while the run clock has hours left.
+
+**Lean:** ship (b) first (truthful, zero behavior change, removes the false
+death framing immediately and safely). F2a is tracked, not dropped <!-- tracked: CMT-1520 -->: pursue it only once a guaranteed auto-respawn seam for autonomous runs is verified to exist — because (a)'s correctness *depends* on that guarantee (F1).
+
+## Proposed change (increment 1 = F2b)
+
+1. `SessionManager` age-limit block: detect "topic has an active autonomous run"
+   via the existing autonomous-session source (the same state `/autonomous/sessions`
+   reads). Thread that fact onto the `sessionReaped` event (new optional field,
+   e.g. `autonomousRunActive: true` + `runRemainingSeconds`).
+2. `ReapNotifier`: when `reason === 'age-limit'` AND `autonomousRunActive`, emit
+   the honest continuation copy instead of the terminal-death template (and do
+   NOT contradict the live run clock). All other reaps unchanged.
+3. Never silence a reap whose run is NOT active — a genuine terminal stop still
+   surfaces loudly.
+
+## Testing (Testing Integrity Standard — all three tiers)
+
+- **Unit:** ReapNotifier emits continuation copy for `age-limit + autonomousRunActive`,
+  and the legacy gravestone for `age-limit` without an active run; the copy never
+  asserts "maximum runtime" when `runRemainingSeconds > 0`.
+- **Integration:** the `sessionReaped` → notify HTTP path carries `autonomousRunActive`
+  end-to-end and the rendered notice matches.
+- **E2E:** an autonomous-backed session crossing the age cap idle produces a
+  continuation notice (not a gravestone) AND the run record stays `active`.
+
+## Migration parity
+
+Notice-copy-only + an additive event field — no agent-installed-file change, so
+no `PostUpdateMigrator` entry required. Behavior for non-autonomous reaps is
+byte-identical.
+
+## Out of scope (tracked, not dropped)
+
+F2a (suppress-and-bounce respecting the run window) is tracked <!-- tracked: CMT-1520 --> pending verification of a guaranteed autonomous auto-respawn seam (F1). Increment 1 is complete on its own terms — it makes every age-limit recycle of an active run honest; it does not leave a half-fixed surface.

--- a/src/commands/server.ts
+++ b/src/commands/server.ts
@@ -30,7 +30,7 @@ import {
 import { CodexResumeMap, type CodexSpawnFence } from '../core/CodexResumeMap.js';
 import { paneIdleWithEmptyInput } from '../core/ModelSwapService.js';
 import { escalatedModelIds, normalizeTierEscalationConfig, type TierEscalationConfig } from '../core/ModelTierEscalation.js';
-import { activeAutonomousJobs } from '../core/AutonomousSessions.js';
+import { activeAutonomousJobs, autonomousRunRemainingForTopic } from '../core/AutonomousSessions.js';
 import { TopicProfileTransferCarrier, createTopicProfilePullHandler } from '../core/TopicProfileTransferCarrier.js';
 import type { SendPullOutcome, TopicProfilePullResponse } from '../core/TopicProfileTransferCarrier.js';
 import type { ResolvedTopicProfile } from '../core/TopicProfileResolver.js';
@@ -6551,6 +6551,22 @@ export async function startServer(options: StartOptions): Promise<void> {
         quietHoursEndAt: (now) => notificationBatcher.quietHoursEndAt(now),
         summaryReleaseAt: (now) => notificationBatcher.nextSummaryReleaseAt(now),
         resumeQueuedFor: (tmuxSession) => resumeQueuedForSession(tmuxSession),
+        // Honest-recycle (honest-session-recycle-spec): tell ReapNotifier whether
+        // this session's topic has an ACTIVE autonomous run (and how long is left),
+        // so an age-limit RECYCLE of a still-active run reads as a continuation
+        // instead of a "reached its maximum allowed runtime" death. Read here at
+        // the wiring layer (which has the autonomous state) — SessionManager's kill
+        // chokepoint is untouched. Returns null ⇒ legacy death copy (safe default).
+        autonomousRunActiveFor: (tmuxSession) => {
+          try {
+            const t = telegram?.getTopicForSession(tmuxSession);
+            if (t == null) return null;
+            return autonomousRunRemainingForTopic(config.stateDir, t);
+          } catch {
+            // Fail toward the legacy death copy — never silence the notice.
+            return null;
+          }
+        },
         reportDegradation: (reason, impact) => {
           try {
             DegradationReporter.getInstance().report({

--- a/src/core/AutonomousSessions.ts
+++ b/src/core/AutonomousSessions.ts
@@ -95,6 +95,36 @@ export function activeAutonomousJobs(stateDir: string): AutonomousJobSummary[] {
   return listAutonomousJobs(stateDir).filter((j) => j.active && !j.paused);
 }
 
+/**
+ * Honest-recycle helper (honest-session-recycle-spec): the ACTIVE autonomous run
+ * for `topic` with the seconds remaining on its window — or null when there is no
+ * active run for the topic, or its window is already over. This is the single
+ * place the run-window remaining is computed, so the recycle copy (and any future
+ * caller) agree on "is this an in-flight run, and how long is left?". The reaper's
+ * per-session age cap is a SEPARATE, shorter clock; this answers the run clock.
+ */
+export function autonomousRunRemainingForTopic(
+  stateDir: string,
+  topic: string | number,
+  nowMs: number = Date.now(),
+): { active: true; remainingSeconds: number } | null {
+  const topicStr = String(topic);
+  const job = activeAutonomousJobs(stateDir).find(
+    (j) => j.topic != null && String(j.topic) === topicStr,
+  );
+  if (!job || !job.active || !job.startedAt || !job.durationSeconds) return null;
+  const startedMs = new Date(job.startedAt).getTime();
+  if (!Number.isFinite(startedMs)) return null;
+  const remainingSeconds = Math.max(
+    0,
+    Math.round(job.durationSeconds - (nowMs - startedMs) / 1000),
+  );
+  // A run already past its own window is NOT a continuation — the terminal death
+  // copy should stand for it.
+  if (remainingSeconds <= 0) return null;
+  return { active: true, remainingSeconds };
+}
+
 export interface CanStartDeps {
   stateDir: string;
   maxConcurrent: number;

--- a/src/monitoring/ReapNotifier.ts
+++ b/src/monitoring/ReapNotifier.ts
@@ -53,6 +53,14 @@ export interface ReapEvent {
   midWork?: boolean;
   /** Clamped work-evidence names behind midWork. */
   workEvidence?: string[];
+  /** Notifier-stamped (NOT emitter-supplied): set at ingest when an `age-limit`
+   *  reap targets a session whose topic has an ACTIVE autonomous run — the recycle
+   *  is a continuation (the run respawns on its next turn), not a death. The
+   *  honest-recycle copy (honest-session-recycle-spec) keys on this instead of
+   *  the "reached its maximum allowed runtime" death template. */
+  autonomousRunActive?: boolean;
+  /** Notifier-stamped: seconds left on that autonomous run, read at reap time. */
+  runRemainingSeconds?: number;
 }
 
 export interface ReapNotifierDeps {
@@ -83,6 +91,11 @@ export interface ReapNotifierDeps {
   /** True when a resume-queue entry is QUEUED for this session AND the queue is
    *  LIVE (not dry-run) — gates the "resume queued" line (R1.2). */
   resumeQueuedFor?: (tmuxSession: string) => boolean;
+  /** Resolve whether `tmuxSession`'s topic has an ACTIVE autonomous run, and how
+   *  many seconds remain on it, read at reap time. Returns null when there is no
+   *  active run (or on any error — the safe direction is the legacy death copy,
+   *  never silence). Honest-recycle (honest-session-recycle-spec). */
+  autonomousRunActiveFor?: (tmuxSession: string) => { active: boolean; remainingSeconds?: number } | null;
   /** Loud degradation surface for enqueue failures (aggregated upstream). */
   reportDegradation?: (reason: string, impact: string) => void;
   now?: () => number;
@@ -142,6 +155,29 @@ function literal(value: string): string {
   return '`' + String(value).replace(/`/g, "'") + '`';
 }
 
+/** Humanize a remaining-seconds count as "11h 42m" / "42m" / "" (when absent). */
+export function formatRunRemaining(seconds: number | undefined): string {
+  if (seconds == null || !Number.isFinite(seconds) || seconds <= 0) return '';
+  const total = Math.round(seconds);
+  const h = Math.floor(total / 3600);
+  const m = Math.floor((total % 3600) / 60);
+  if (h > 0) return m > 0 ? `${h}h ${m}m` : `${h}h`;
+  if (m > 0) return `${m}m`;
+  return 'under a minute';
+}
+
+/** Per-session detail clause — honest about an autonomous-run recycle (a
+ *  continuation) vs a terminal reap. Used in the aggregate bullet lists. */
+function reapDetailClause(ev: ReapEvent): string {
+  if (ev.autonomousRunActive) {
+    const left = formatRunRemaining(ev.runRemainingSeconds);
+    return left
+      ? `recycled at its lifetime cap — its autonomous run has ${left} left`
+      : `recycled at its lifetime cap — its autonomous run is still active`;
+  }
+  return plainEnglishReason(ev.reason);
+}
+
 interface TopicAggregate {
   count: number;
   midWorkCount: number;
@@ -176,6 +212,20 @@ export class ReapNotifier {
     // the user already knows about their own operator kill.
     if ((event.disposition ?? 'terminal') !== 'terminal') return;
     if (event.origin === 'operator') return;
+
+    // Honest-recycle stamp (honest-session-recycle-spec): an age-limit reap of a
+    // session whose topic has an ACTIVE autonomous run is a RECYCLE (the run
+    // respawns on its next turn), not a death. Read the run state NOW — it is
+    // accurate at reap time, whereas the SUMMARY release can be up to ~30 min
+    // later. We never SILENCE the notice (a genuinely-stopped run still surfaces
+    // loudly) — only tell the truth in its wording. Fail toward the legacy death
+    // copy (safe direction).
+    if (event.reason === 'age-limit') {
+      const recycle = this.safeAutonomousRunActive(event.session.tmuxSession);
+      if (recycle?.active) {
+        event = { ...event, autonomousRunActive: true, runRemainingSeconds: recycle.remainingSeconds };
+      }
+    }
 
     this.windowCount++;
     this.buffer.push(event);
@@ -236,6 +286,17 @@ export class ReapNotifier {
     } catch {
       // @silent-fallback-ok — null = "unbound": the session is routed to the
       // lifeline index line instead; a notice is never dropped on this path.
+      return null;
+    }
+  }
+
+  private safeAutonomousRunActive(tmuxSession: string): { active: boolean; remainingSeconds?: number } | null {
+    try {
+      return this.deps.autonomousRunActiveFor?.(tmuxSession) ?? null;
+    } catch {
+      // @silent-fallback-ok — fail toward the legacy "shut down" copy: a read
+      // error must never silence the notice, only forgo the gentler recycle
+      // wording. The session still gets its (terminal-worded) notice.
       return null;
     }
   }
@@ -428,7 +489,16 @@ export class ReapNotifier {
     const lines: string[] = [];
     if (agg.count === 1 && agg.detail.length === 1) {
       const ev = agg.detail[0];
-      lines.push(`🪦 Your session ${literal(ev.session.name)} was shut down — ${plainEnglishReason(ev.reason)}.`);
+      if (ev.autonomousRunActive) {
+        const left = formatRunRemaining(ev.runRemainingSeconds);
+        lines.push(
+          `🔄 Your session ${literal(ev.session.name)} was recycled at its per-session lifetime cap` +
+            (left ? ` — your autonomous run has ${left} left` : ` — your autonomous run is still active`) +
+            `, so no work was lost. I'll pick it back up on my next turn — send a message if I stay quiet.`,
+        );
+      } else {
+        lines.push(`🪦 Your session ${literal(ev.session.name)} was shut down — ${plainEnglishReason(ev.reason)}.`);
+      }
       if (ev.midWork) {
         lines.push(`It was in the middle of work when it was stopped.`);
       }
@@ -443,7 +513,7 @@ export class ReapNotifier {
       : `🪦 ${agg.count} of this topic's sessions were shut down (details were trimmed in a busy window — every shutdown is still recorded).`;
     lines.push(header);
     for (const ev of agg.detail.slice(-5)) {
-      lines.push(`• ${literal(ev.session.name)} — ${plainEnglishReason(ev.reason)}${ev.midWork ? ' (mid-work)' : ''}`);
+      lines.push(`• ${literal(ev.session.name)} — ${reapDetailClause(ev)}${ev.midWork ? ' (mid-work)' : ''}`);
     }
     if (agg.detail.length > 5) {
       lines.push(`(showing the latest 5 of ${agg.detail.length})`);
@@ -460,7 +530,7 @@ export class ReapNotifier {
   private formatUnboundNotice(unbound: TopicAggregate): string {
     const lines = [`🪦 ${unbound.count} background session${unbound.count === 1 ? ' was' : 's were'} shut down:`];
     for (const ev of unbound.detail.slice(-5)) {
-      lines.push(`• ${literal(ev.session.name)} — ${plainEnglishReason(ev.reason)}${ev.midWork ? ' (mid-work)' : ''}`);
+      lines.push(`• ${literal(ev.session.name)} — ${reapDetailClause(ev)}${ev.midWork ? ' (mid-work)' : ''}`);
     }
     if (unbound.count > unbound.detail.length) {
       lines.push(`(showing ${Math.min(5, unbound.detail.length)} of ${unbound.count})`);
@@ -479,6 +549,12 @@ export class ReapNotifier {
   // ── Legacy formatting (byte-compatible) ──────────────────────────────
 
   private formatSingleLegacy(ev: ReapEvent): string {
+    if (ev.autonomousRunActive) {
+      const left = formatRunRemaining(ev.runRemainingSeconds);
+      return `🔄 Session ${literal(ev.session.name)} was recycled at its lifetime cap`
+        + (left ? ` — its autonomous run has ${left} left` : ` — its autonomous run is still active`)
+        + `; no work was lost — it resumes on its next turn.`;
+    }
     return `🪦 Session ${literal(ev.session.name)} was shut down — ${literal(ev.reason)}. `
       + `See the reap-log (\`GET /sessions/reap-log\`) for the full record.`;
   }

--- a/tests/integration/honest-session-recycle-wiring.test.ts
+++ b/tests/integration/honest-session-recycle-wiring.test.ts
@@ -1,0 +1,89 @@
+// safe-git-allow: test-tmpdir-cleanup — afterEach removes per-test mkdtempSync tmpdir.
+/**
+ * Honest Session Recycle — wiring/integration (honest-session-recycle-spec).
+ *
+ * Composes the REAL `autonomousRunRemainingForTopic` helper with the REAL
+ * ReapNotifier over a temp stateDir — proving the two production pieces wire
+ * together (the dep is non-null and delegates to the real run-window read), not
+ * a mock-against-mock. This is the wiring-integrity tier for the additive
+ * `autonomousRunActiveFor` dep the server provides in `commands/server.ts`.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { ReapNotifier } from '../../src/monitoring/ReapNotifier.js';
+import { autonomousRunRemainingForTopic } from '../../src/core/AutonomousSessions.js';
+
+let stateDir: string;
+
+function writeRun(topic: string, durationSeconds: number, startedAt: string) {
+  fs.mkdirSync(path.join(stateDir, 'autonomous'), { recursive: true });
+  fs.writeFileSync(
+    path.join(stateDir, 'autonomous', `${topic}.local.md`),
+    `---\nactive: true\npaused: false\niteration: 5\ngoal: "run ${topic}"\nstarted_at: "${startedAt}"\nduration_seconds: ${durationSeconds}\nreport_topic: "${topic}"\n---\n\ntask\n`,
+  );
+}
+
+/** Build a notifier wired EXACTLY as server.ts wires it: the autonomousRunActiveFor
+ *  dep delegates to the real helper via a topic resolver. */
+function makeWiredNotifier(topicForSession: Record<string, number>) {
+  const rows: Array<{ topic_id: number; text: string }> = [];
+  const n = new ReapNotifier(
+    {
+      resolveTopic: (tmux) => topicForSession[tmux] ?? null,
+      lifelineTopic: () => 999,
+      send: () => {},
+      enqueueNotice: (input) => { rows.push({ topic_id: input.topic_id, text: input.text }); return true; },
+      recordNotify: () => {},
+      summaryReleaseAt: (now) => now + 10 * 60_000,
+      // The production wiring (server.ts): topic → real run-window read.
+      autonomousRunActiveFor: (tmux) => {
+        const topic = topicForSession[tmux];
+        if (topic == null) return null;
+        return autonomousRunRemainingForTopic(stateDir, topic);
+      },
+      now: () => new Date('2026-06-14T06:57:00Z').getTime(),
+    },
+    { enabled: true, coalesceWindowMs: 60_000, maxBuffer: 100, perTopic: true, maxImmediatePerFlush: 5, drainEnabled: true },
+  );
+  return { n, rows };
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  // Pin the system clock so BOTH the notifier's now() AND the real helper's
+  // internal Date.now() (the production wiring passes no nowMs) agree.
+  vi.setSystemTime(new Date('2026-06-14T06:57:00Z'));
+  stateDir = fs.mkdtempSync(path.join(os.tmpdir(), 'instar-recycle-'));
+});
+afterEach(() => {
+  vi.useRealTimers();
+  fs.rmSync(stateDir, { recursive: true, force: true });
+});
+
+describe('Honest Session Recycle — real helper composed with real notifier', () => {
+  it('age-limit reap of a topic with a real in-flight run renders the honest recycle copy', async () => {
+    writeRun('13481', 86400, '2026-06-13T18:40:00Z'); // ~11h43m left at the frozen now
+    const { n, rows } = makeWiredNotifier({ 'echo-instar-exo': 13481 });
+    n.onReaped({ session: { name: 'instar-exo', tmuxSession: 'echo-instar-exo' }, reason: 'age-limit', disposition: 'terminal' });
+    await n.flush();
+    expect(rows).toHaveLength(1);
+    expect(rows[0].topic_id).toBe(13481);
+    expect(rows[0].text).toContain('🔄');
+    expect(rows[0].text).toContain('recycled');
+    expect(rows[0].text).toMatch(/11h 4\dm left/); // real computed remaining
+    expect(rows[0].text).not.toContain('maximum allowed runtime');
+  });
+
+  it('age-limit reap of a topic with NO autonomous run file gets the terminal death copy', async () => {
+    // No run written for topic 555.
+    const { n, rows } = makeWiredNotifier({ 'echo-bg': 555 });
+    n.onReaped({ session: { name: 'bg', tmuxSession: 'echo-bg' }, reason: 'age-limit', disposition: 'terminal' });
+    await n.flush();
+    expect(rows).toHaveLength(1);
+    expect(rows[0].text).toContain('🪦');
+    expect(rows[0].text).toContain('maximum allowed runtime');
+  });
+});

--- a/tests/unit/AutonomousSessions.test.ts
+++ b/tests/unit/AutonomousSessions.test.ts
@@ -11,6 +11,7 @@ import {
   suspendAutonomousTopicForMove,
   listAutonomousJobs,
   activeAutonomousJobs,
+  autonomousRunRemainingForTopic,
   canStartAutonomousJob,
   stopAutonomousTopic,
   stopAllAutonomousJobs,
@@ -219,5 +220,61 @@ describe('WS1.4 — suspendAutonomousTopicForMove (MULTI-MACHINE-SEAMLESSNESS-SP
     expect(emitted[0].topic).toBe(42);
     expect(emitted[0].data.action).toBe('stopped');
     expect(String((emitted[0].data.artifactPaths as string[])[0])).toContain('42.local.md');
+  });
+});
+
+describe('autonomousRunRemainingForTopic (honest-recycle helper)', () => {
+  function writeRun(
+    topic: string,
+    opts: { active?: boolean; paused?: boolean; startedAt?: string; durationSeconds?: number | null } = {},
+  ) {
+    const {
+      active = true,
+      paused = false,
+      startedAt = '2026-06-13T18:40:00Z',
+      durationSeconds = 86400,
+    } = opts;
+    fs.mkdirSync(path.join(stateDir, 'autonomous'), { recursive: true });
+    const dur = durationSeconds == null ? '' : `\nduration_seconds: ${durationSeconds}`;
+    fs.writeFileSync(
+      path.join(stateDir, 'autonomous', `${topic}.local.md`),
+      `---\nactive: ${active}\npaused: ${paused}\niteration: 3\ngoal: "run ${topic}"\nstarted_at: "${startedAt}"${dur}\nreport_topic: "${topic}"\n---\n\ntask\n`,
+    );
+  }
+
+  it('returns active + remaining for an in-flight run (the topic-13481 case)', () => {
+    writeRun('13481', { startedAt: '2026-06-13T18:40:00Z', durationSeconds: 86400 });
+    // 12h17m after start → ~11h43m remaining.
+    const now = new Date('2026-06-14T06:57:00Z').getTime();
+    const r = autonomousRunRemainingForTopic(stateDir, 13481, now);
+    expect(r).not.toBeNull();
+    expect(r!.active).toBe(true);
+    // ~42180s remaining; allow a small rounding window.
+    expect(r!.remainingSeconds).toBeGreaterThan(42000);
+    expect(r!.remainingSeconds).toBeLessThan(42300);
+  });
+
+  it('accepts a numeric OR string topic', () => {
+    writeRun('77');
+    const now = new Date('2026-06-13T19:00:00Z').getTime();
+    expect(autonomousRunRemainingForTopic(stateDir, 77, now)).not.toBeNull();
+    expect(autonomousRunRemainingForTopic(stateDir, '77', now)).not.toBeNull();
+  });
+
+  it('returns null when the run window is already OVER (not a continuation)', () => {
+    writeRun('5', { startedAt: '2026-06-13T18:40:00Z', durationSeconds: 3600 });
+    const now = new Date('2026-06-13T20:00:00Z').getTime(); // 80m later, cap 60m
+    expect(autonomousRunRemainingForTopic(stateDir, 5, now)).toBeNull();
+  });
+
+  it('returns null for a topic with no active run, a paused run, or a missing duration', () => {
+    const now = new Date('2026-06-13T19:00:00Z').getTime();
+    expect(autonomousRunRemainingForTopic(stateDir, 999, now)).toBeNull(); // no file
+    writeRun('inactive', { active: false });
+    expect(autonomousRunRemainingForTopic(stateDir, 'inactive', now)).toBeNull();
+    writeRun('paused', { paused: true });
+    expect(autonomousRunRemainingForTopic(stateDir, 'paused', now)).toBeNull();
+    writeRun('nodur', { durationSeconds: null });
+    expect(autonomousRunRemainingForTopic(stateDir, 'nodur', now)).toBeNull();
   });
 });

--- a/tests/unit/reap-notifier.test.ts
+++ b/tests/unit/reap-notifier.test.ts
@@ -145,6 +145,7 @@ function makeV2(over?: {
   quietHoursEndAt?: (now: number) => number | null;
   summaryReleaseAt?: (now: number) => number;
   resumeQueuedFor?: (t: string) => boolean;
+  autonomousRunActiveFor?: (t: string) => { active: boolean; remainingSeconds?: number } | null;
   now?: () => number;
 }) {
   const sends: Array<{ topicId: number; text: string }> = [];
@@ -168,6 +169,7 @@ function makeV2(over?: {
       quietHoursEndAt: over?.quietHoursEndAt ?? (() => null),
       summaryReleaseAt: over?.summaryReleaseAt ?? ((now) => now + 10 * 60_000),
       resumeQueuedFor: over?.resumeQueuedFor,
+      autonomousRunActiveFor: over?.autonomousRunActiveFor,
       reportDegradation: (reason) => { degradations.push(reason); },
       now: over?.now ?? (() => NOW),
     },
@@ -348,5 +350,87 @@ describe('ReapNotifier v2 — outcome records + degraded paths (R1.3)', () => {
     await n.flush();
     expect(rows).toHaveLength(0);
     expect(records.map((r) => r.outcome)).toEqual(['no-topic']);
+  });
+});
+
+describe('ReapNotifier — honest recycle (honest-session-recycle-spec)', () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
+  it('an age-limit reap of a topic with an ACTIVE autonomous run reads as a RECYCLE, not a death', async () => {
+    const { n, rows } = makeV2({
+      resolveTopic: () => 42,
+      autonomousRunActiveFor: () => ({ active: true, remainingSeconds: 11 * 3600 + 42 * 60 }),
+    });
+    n.onReaped({ session: sess('instar-exo'), reason: 'age-limit', disposition: 'terminal' });
+    await n.flush();
+    expect(rows).toHaveLength(1);
+    const text = rows[0].text;
+    // Honest continuation copy — NOT the false "maximum allowed runtime" death.
+    expect(text).toContain('🔄');
+    expect(text).toContain('recycled');
+    expect(text).toContain('11h 42m left');
+    expect(text).toContain('no work was lost');
+    expect(text).not.toContain('🪦');
+    expect(text).not.toContain('maximum allowed runtime');
+    expect(text).not.toContain('was shut down');
+  });
+
+  it('NEVER contradicts the run clock: a still-active run is never told "max runtime reached"', async () => {
+    const { n, rows } = makeV2({
+      resolveTopic: () => 7,
+      autonomousRunActiveFor: () => ({ active: true, remainingSeconds: 30 * 60 }),
+    });
+    n.onReaped({ session: sess('s'), reason: 'age-limit', disposition: 'terminal' });
+    await n.flush();
+    expect(rows[0].text).toContain('30m left');
+    expect(rows[0].text).not.toContain('maximum');
+  });
+
+  it('an age-limit reap with NO active run still gets the terminal death copy (loud, not silenced)', async () => {
+    const { n, rows } = makeV2({
+      resolveTopic: () => 42,
+      autonomousRunActiveFor: () => null,
+    });
+    n.onReaped({ session: sess('beta'), reason: 'age-limit', disposition: 'terminal' });
+    await n.flush();
+    expect(rows).toHaveLength(1);
+    expect(rows[0].text).toContain('🪦');
+    expect(rows[0].text).toContain('maximum allowed runtime');
+    expect(rows[0].text).not.toContain('🔄');
+  });
+
+  it('only age-limit recycles: a different reason on an active-run topic is NOT softened', async () => {
+    const { n, rows } = makeV2({
+      resolveTopic: () => 42,
+      autonomousRunActiveFor: () => ({ active: true, remainingSeconds: 3600 }),
+    });
+    n.onReaped({ session: sess('z'), reason: 'idle-zombie', disposition: 'terminal' });
+    await n.flush();
+    // idle-zombie is a genuine stuck-session death even mid-run → stays terminal.
+    expect(rows[0].text).toContain('🪦');
+    expect(rows[0].text).not.toContain('🔄');
+  });
+
+  it('a resolver that THROWS fails toward the death copy — never silences the notice', async () => {
+    const { n, rows } = makeV2({
+      resolveTopic: () => 42,
+      autonomousRunActiveFor: () => { throw new Error('autonomous read failed'); },
+    });
+    n.onReaped({ session: sess('gamma'), reason: 'age-limit', disposition: 'terminal' });
+    await n.flush();
+    expect(rows).toHaveLength(1);
+    expect(rows[0].text).toContain('🪦');
+  });
+
+  it('a run already PAST its window (remaining 0) is NOT a recycle — death copy stands', async () => {
+    const { n, rows } = makeV2({
+      resolveTopic: () => 42,
+      // The wiring returns null for remaining<=0; simulate that contract here.
+      autonomousRunActiveFor: () => null,
+    });
+    n.onReaped({ session: sess('over'), reason: 'age-limit', disposition: 'terminal' });
+    await n.flush();
+    expect(rows[0].text).toContain('🪦');
   });
 });

--- a/upgrades/next/honest-session-recycle.md
+++ b/upgrades/next/honest-session-recycle.md
@@ -1,0 +1,43 @@
+## What Changed
+
+Reap notices no longer dress a routine **session recycle** up as a death. A long
+autonomous run periodically hits its per-session lifetime cap, at which point the
+old terminal process is replaced by a fresh one that continues the run — but the
+user used to see `🪦 Your session was shut down — it reached its maximum allowed
+runtime`, even while the run's own clock still showed many hours remaining. Now,
+when an `age-limit` reap targets a session whose topic has an ACTIVE autonomous
+run, ReapNotifier emits honest continuation copy instead:
+`🔄 Your session was recycled at its per-session lifetime cap — your autonomous
+run has 11h 42m left, so no work was lost. I'll pick it back up on my next turn —
+send a message if I stay quiet.`
+
+It never goes silent: any read error, or a run that is genuinely over, falls back
+to the normal loud "shut down" notice. Only the age-limit-recycle-of-an-active-run
+case is reworded; a stuck-session death is still surfaced loudly even mid-run.
+
+## What to Tell Your User
+
+If you run long autonomous sessions and were alarmed by repeated "your session was
+shut down — reached its maximum allowed runtime" messages: those were usually a
+routine recycle, not a failure — your work was never lost and the run kept going.
+You'll now see an honest "🔄 recycled, your run has Xh left, no work lost" notice
+for that case instead of the tombstone. A genuine stop still shows the loud notice.
+
+## Summary of New Capabilities
+
+- Honest reap-notice wording for an age-limit recycle of a still-active autonomous
+  run (continuation, not death), with the run's real remaining time.
+- New shared helper `autonomousRunRemainingForTopic` (one source of truth for "is
+  this topic's run in-flight, and how long is left?").
+
+## Evidence
+
+- `tests/unit/reap-notifier.test.ts` — honest-recycle block: recycle copy,
+  never-contradicts-clock, no-run→death, only-age-limit, throws→fail-loud,
+  over-window→death.
+- `tests/unit/AutonomousSessions.test.ts` — `autonomousRunRemainingForTopic`:
+  in-flight remaining, numeric/string topic, over-window null, no-run/paused/
+  missing-duration null.
+- `tests/integration/honest-session-recycle-wiring.test.ts` — real helper composed
+  with real notifier (dep non-null, real computed remaining).
+- `npx tsc --noEmit` clean; 51/51 unit + 2/2 integration green.

--- a/upgrades/side-effects/honest-session-recycle.md
+++ b/upgrades/side-effects/honest-session-recycle.md
@@ -1,0 +1,140 @@
+# Side-Effects Review — Honest Session Recycle
+
+**Version / slug:** `honest-session-recycle`
+**Date:** `2026-06-14`
+**Author:** `Instar Agent (echo)`
+**Second-pass reviewer:** `independent reviewer subagent — CONCUR (2 non-blocking concerns, both resolved)`
+
+## Summary of the change
+
+When a session is reaped at its per-session lifetime cap (`reason: 'age-limit'`)
+but its Telegram topic still has an ACTIVE autonomous run, the recycle is a
+continuation (the run respawns), not a death. ReapNotifier now stamps that fact
+at ingest and emits honest "🔄 recycled at its lifetime cap — your autonomous run
+has Xh left, resuming; no work was lost" copy instead of the false "🪦 reached its
+maximum allowed runtime" gravestone. Files: `src/monitoring/ReapNotifier.ts`
+(new optional dep `autonomousRunActiveFor`, ingest stamp, four render branches,
+two pure helpers), `src/commands/server.ts` (wires the dep via a new
+`autonomousRunRemainingForTopic`), `src/core/AutonomousSessions.ts` (the extracted
+run-remaining helper). No SessionManager / kill-chokepoint change.
+
+## Decision-point inventory
+
+- `ReapNotifier.onReaped` ingest — **modify** — stamps `autonomousRunActive` when
+  an `age-limit` reap has an active run; affects only NOTICE WORDING, never
+  whether a notice is sent.
+- `ReapNotifier` render (single/aggregate/unbound/legacy) — **modify** — branch the
+  per-event copy on the stamp.
+- The reap/respawn behavior itself — **pass-through** — unchanged.
+
+---
+
+## 1. Over-block
+
+No block/allow surface — this change only chooses notice WORDING. It can never
+suppress a notice: the only effect of the recycle branch is gentler copy; the
+notice is always still sent. Over-block not applicable.
+
+## 2. Under-block
+
+No block/allow surface. The nearest analogue is "could a real death be softened
+into a recycle?" — covered: the stamp requires `reason === 'age-limit'` AND an
+active run with remaining > 0. A stuck-session death (`idle-zombie`,
+`watchdog-stuck`, etc.) is never softened even mid-run (unit-tested). A run past
+its window returns null → death copy stands.
+
+## 3. Level-of-abstraction fit
+
+Correct layer. The wording decision lives in ReapNotifier (the existing single
+listener that already owns "is this a disappearance worth a notice?"). The
+autonomous-state lookup lives at the server wiring layer (which has the state) and
+is computed by one shared helper `autonomousRunRemainingForTopic` in
+AutonomousSessions.ts — the same module that owns the run-window data — so the
+recycle copy and any future caller agree on "is this run in-flight, how long
+left?". SessionManager's kill chokepoint is deliberately NOT touched (lowest blast
+radius).
+
+## 4. Signal vs authority compliance
+
+**Reference:** docs/signal-vs-authority.md
+
+- [x] No — this change has no block/allow surface. It is pure presentation: a
+  signal (the autonomous-run fact) consumed to choose honest wording. It holds no
+  authority over reaping, respawning, or whether a notice fires. Fails toward the
+  loud legacy copy on any error.
+
+## 5. Interactions
+
+- **Shadowing:** none — the branch is inside the existing notice formatter; it
+  does not run before/after any other check.
+- **Double-fire:** none — still exactly one `sessionReaped` → one notice per the
+  existing coalescing; this only changes the text.
+- **Races:** the autonomous-run state is read at INGEST (synchronously when the
+  event arrives), not at the SUMMARY release (which can be ~30 min later), so the
+  "X left" figure reflects reap time and can't drift to a stale/negative value at
+  render. The reported `remainingSeconds` is a point-in-time snapshot, by design.
+- **Feedback loops:** none — reads autonomous state, writes only notice text.
+
+## 6. External surfaces
+
+- Telegram: the user-visible reap notice text changes for the active-run recycle
+  case (🔄 + "no work was lost") — this is the intended fix. All other reap
+  notices are byte-identical.
+- No other-agent, GitHub, Cloudflare, or persistent-state surface. No new route.
+- **Operator surface (Mobile-Complete):** no operator-facing actions added — this
+  is an outbound notice wording change only. Not applicable.
+
+## 6b. Operator-surface quality
+
+No operator surface — not applicable. No `dashboard/*` or approval/grant/secret
+form is touched.
+
+## 7. Multi-machine posture (Cross-Machine Coherence)
+
+**machine-local BY DESIGN.** Reap notices are emitted by the machine that owns
+and reaps the session; the autonomous run state read (`config.stateDir`) is that
+same machine's. A recycle on machine A is narrated by machine A in the topic — the
+correct single voice for that event (the reaping machine is authoritative about
+its own reap). No durable state is created (notice text only), so nothing strands
+on topic transfer. No URLs generated. One-voice: the notice rides the existing
+ReapNotifier coalescing + reap-notice drain, which already own single-emission.
+
+## 8. Rollback cost
+
+Pure code change — revert the three files and ship a patch. No persistent state,
+no migration, no agent-state repair. During any rollback window the only
+regression is the notice reverting to the old (alarming-but-not-harmful) wording.
+No user data affected. The feature is also inert by construction when no
+autonomous run is active (the common case) — it only ever activates on an
+age-limit recycle of a live run.
+
+## Conclusion
+
+The review produced one design refinement during the build: the run-remaining
+computation was extracted from an inline server.ts block into a single tested
+helper (`autonomousRunRemainingForTopic`) so the run clock has one source of
+truth. The change is wording-only with a fail-loud default and full both-sides
+test coverage (recycle vs death; active / over-window / paused / no-run / missing
+duration / throws). Clear to ship pending the high-risk second-pass concurrence.
+
+## Second-pass review (if required)
+
+**Reviewer:** independent reviewer subagent (high-risk: reap-notifier / session-lifecycle)
+**Independent read of the artifact: CONCUR** (verified: fail-open is airtight across three layers; cannot silence a notice; terminal-death mislabeling is prevented by the `age-limit` + `remaining>0` guard; run-state read at ingest not render; pure presentation, no blocking authority).
+
+Two non-blocking concerns raised — **both resolved before commit:**
+
+- **Test-tier coverage.** Resolved: added `tests/integration/honest-session-recycle-wiring.test.ts`, which composes the REAL `autonomousRunRemainingForTopic` helper with the REAL ReapNotifier over a temp stateDir (the dep is non-null and delegates to the real run-window read) — the wiring-integrity tier. Tier-3 HTTP E2E is N/A by design: this change adds NO API route or feature-alive surface (it is outbound notice WORDING), so the canonical "feature returns 200" E2E does not apply; the integration composition is the appropriate top tier here.
+- **Copy over-promised self-resume.** Resolved: respawn is message-triggered today (spec F1), so the copy was corrected to "no work was lost. I'll pick it back up on my next turn — send a message if I stay quiet" (single) / "it resumes on its next turn" (legacy) — no "resumes automatically" claim.
+
+## Evidence pointers
+
+- `tests/unit/reap-notifier.test.ts` — honest-recycle describe block (6 tests):
+  recycle copy, never-contradicts-clock, no-run-death, only-age-limit, throws-fails-safe, over-window-death.
+- `tests/unit/AutonomousSessions.test.ts` — `autonomousRunRemainingForTopic`
+  describe block (4 tests): in-flight remaining, numeric/string topic, over-window
+  null, no-run/paused/missing-duration null.
+- `tests/integration/honest-session-recycle-wiring.test.ts` — real helper composed
+  with real notifier (2 tests): in-flight run → honest recycle copy with real
+  computed remaining; no run file → terminal death copy.
+- `npx tsc --noEmit` clean; 51/51 unit + 2/2 integration tests green.


### PR DESCRIPTION
## ELI16 — Stop telling you a session "died" when it's just being recycled to keep going

When a long autonomous run's session hits its per-session lifetime cap, the old terminal process is recycled and replaced by a fresh one that continues the run — but the user used to see `🪦 Your session was shut down — it reached its maximum allowed runtime`, even while the run's own clock still showed many hours left. (Real incident: topic 13481, 2026-06-14 — the gravestone fired with 11h 42m still on the run clock.) Two messages, flatly contradicting each other; to the operator it looks like sessions keep dying for no reason.

This makes the notice honest: an `age-limit` reap whose topic has an ACTIVE autonomous run now renders `🔄 Your session was recycled at its per-session lifetime cap — your autonomous run has 11h 42m left, so no work was lost. I'll pick it back up on my next turn — send a message if I stay quiet.` Nothing about WHEN sessions recycle or whether they respawn changes — only the wording, plus one added fact on the event and a small read helper.

## Safeguards (plain terms)

- **Never goes silent.** Any read error, or a run that is genuinely over, falls back to the normal loud "shut down" notice. We only soften wording when we're sure the run is still alive — we never hide a real stop (fail-loud verified across three layers + a `throws -> gravestone` test).
- **Only the recycle case is touched.** A stuck-session death (`idle-zombie`, `watchdog-stuck`) is still surfaced loudly even mid-run.
- **No behavior change.** SessionManager's kill chokepoint is untouched.

## Honest scope (tracked, not deferred)

The stronger fix — don't recycle a run at its midpoint at all (respect the longer run clock) — is held back on purpose: it is only safe once a GUARANTEED auto-respawn seam is verified (today respawn is message-triggered). Tracked as commitment CMT-1520, not forgotten.

## Tier & review

Tier 1 (wording + additive fact + pure helper). Phase-5 second-pass reviewer (high-risk reap-notifier/session-lifecycle) **CONCURRED**; both non-blocking concerns (test-tier coverage; copy over-promising self-resume) resolved before commit.

## Tests

- `tests/unit/reap-notifier.test.ts` — recycle copy, never-contradicts-clock, no-run to death, only-age-limit, throws to fail-loud, over-window to death.
- `tests/unit/AutonomousSessions.test.ts` — `autonomousRunRemainingForTopic`: in-flight remaining, numeric/string topic, over-window null, no-run/paused/missing-duration null.
- `tests/integration/honest-session-recycle-wiring.test.ts` — real helper composed with real notifier (dep non-null, real computed remaining).
- `tsc --noEmit` clean; 51/51 unit + 2/2 integration green; full lint clean.

Parent principle: Honest progress messaging (HONEST-PROGRESS-MESSAGING-SPEC lineage). Topic 13481.

Generated with Claude Code
