### PR TITLE
docs(spec): converged spec — resume an idle autonomous run after an age-limit reap

### DIFF
--- a/docs/specs/reports/resume-idle-autonomous-on-reap-convergence.md
+++ b/docs/specs/reports/resume-idle-autonomous-on-reap-convergence.md
@@ -1,0 +1,126 @@
+# Convergence Report — Resume an idle autonomous run after an age-limit reap
+
+## Cross-model review: codex-cli:gpt-5.5
+
+A real GPT-tier external pass (codex CLI, gpt-5.5) AND a Gemini-tier pass
+(gemini-cli, gemini-2.5-pro) ran on BOTH rounds. Both returned MINOR ISSUES
+on both rounds; no material new issues in round 2. This is the clean RAN state.
+
+## ELI10 Overview
+
+The agent has a safety net — the "resume queue" — that quietly restarts a
+session if it got shut down while doing real work. But it judged "real work" by
+looking for something running at the exact moment of shutdown (a build, a queued
+message, a sub-task). There's one shutdown that always looks idle: the
+**age-limit recycle**. Sessions aren't allowed to run forever, so a long-running
+autonomous job that's sitting idle between steps gets recycled — and at that
+instant nothing is "running," so the queue saw no evidence and never brought it
+back. If that happened while the operator was away, the job sat dead until the
+next message woke it.
+
+This change tells the queue: when a recycle hits a topic whose autonomous job is
+**still genuinely live** (its run state file shows an un-elapsed window), treat
+that live run as the proof of work and bring it back. It reuses ALL the existing
+safety rails — one restart at a time, only when the machine is calm and has
+spare quota, only on the machine that owns the topic, and a hard cap that gives
+up loudly if a job keeps dying. No new restart path was built. The change also
+turns the queue from "watch only" to actually-live on the dev agent (Echo), so
+it gets exercised on a real two-machine setup, while the rest of the fleet stays
+in watch-only mode until a deliberate later switch.
+
+The main tradeoff: on the dev machine this now performs REAL restarts that spend
+REAL quota — that's a deliberate, operator-approved choice, classified honestly
+as a non-cheap (irreversible-once-done) decision rather than hidden behind a
+"it's off everywhere else" label.
+
+## Original vs Converged
+
+Originally the spec described the fix and asserted the four safety invariants
+were covered, with the live-on-dev decision tucked into "Residual risks" as
+something "mitigated by" the existing gates — i.e. effectively treated as cheap.
+After review:
+
+- A **`## Frontloaded Decisions` table** was added (D1–D6), and the live-on-dev
+  decision was **reclassified as NON-CHEAP, accepted under a named live phase**,
+  with its irreversibility (quota already spent can't be un-spent) stated
+  honestly. This was the one MATERIAL finding (decision-completeness reviewer).
+- A **drain-time liveness re-check** was added: right before a restart, the
+  drainer re-reads the run state; if the run finished in the meantime, it
+  invalidates (`autonomous-run-finished`) instead of wasting a restart. This
+  structurally closes the "completed-but-state-says-remaining, window already
+  elapsed" subset of the stale-marker residual — a consensus point raised by the
+  adversarial, lessons-aware, codex, AND gemini reviewers.
+- The **`autonomousRunRemainingForTopic` contract** was documented precisely
+  (codex finding): "remaining" = last-known-incomplete within an un-elapsed
+  duration window; a run past its window returns null and is never revived.
+- It was clarified that this gate is **deliberately NOT in `DEV_GATED_FEATURES`**
+  (integration finding): it rides `dryRun` (where `true` = observe-only), so
+  registering it would make the wiring test assert the inverse of every other
+  entry. A dedicated dryRun-resolution test locks it instead.
+- The **evidence injection was reframed as a TRUE assertion**, not gate-gaming
+  (lessons-aware foundation audit): the run genuinely IS live; the idle-gate
+  just can't see it as a process. The reuse-vs-new-signal coupling risk was
+  documented and routed to the side-effects Interactions review.
+- A **3-tier test plan** was added (unit both-sides + dryRun-gate + drain
+  re-check; integration real-composition for all four invariants;
+  E2E "feature is alive" on both sides of the dev gate), plus the **fail-open
+  guard-ordering invariant**, the **topic-resolution-race residual**, and the
+  **poisoned-state-file bounded-residual** were made explicit.
+
+## Iteration Summary
+
+| Iteration | Reviewers who flagged | Material findings | Spec changes |
+|-----------|-----------------------|-------------------|--------------|
+| 1 | decision-completeness (D1 reclassify), integration (DEV_GATED inverted semantics), lessons-aware (E2E + P3 + truth-assertion), adversarial (drain re-check rec), security (bounded residuals), scalability (guard-ordering/fail-open), codex (contract + stale), gemini (stale residual) | 1 material (D1) + several MEDIUM hardening | Added Frontloaded Decisions table; reclassified D1; added drain-time liveness re-check; documented contract; NOT-in-DEV_GATED rationale + dedicated test; truth-assertion framing; 3-tier test plan; fail-open/guard-ordering invariant; topic-race + poisoned-file residuals |
+| 2 | codex (token-coupling note, non-material — already documented), gemini (glossary/terminology, non-material) | 0 material | none |
+| 2 | (converged) | 0 | none |
+
+Standards-Conformance Gate: ran round 1 (22 standards checked, 0 findings,
+registry canary ok, semantic layer degraded:error — advisory only). Round 2:
+unavailable (local vault auth flaked on the loaded dev box; signal-only, never
+blocks). The body change between rounds was additive hardening; the registry
+canary was already green.
+
+Cross-model: ran (codex-cli:gpt-5.5 + gemini-cli:gemini-2.5-pro), both rounds,
+MINOR ISSUES, zero material new findings in round 2.
+
+## Full Findings Catalog
+
+**Round 1 — material:**
+- **[MATERIAL] Decision-completeness:** D1 (live-on-dev) mislabeled as
+  cheap-equivalent. → RESOLVED: added Frontloaded Decisions table, reclassified
+  D1 as non-cheap/accepted/irreversible.
+
+**Round 1 — MEDIUM (folded):**
+- **Integration:** dryRun gate must NOT go in `DEV_GATED_FEATURES` (inverted
+  semantics). → RESOLVED: documented + dedicated dryRun-resolution test.
+- **Lessons-aware:** missing Tier-3 E2E dev-gate test + explicit P3 (no
+  migration) statement. → RESOLVED: both added.
+- **Adversarial:** recommend drain-time liveness re-check (closes window-elapsed
+  stale-marker subset). → RESOLVED: added as `invalidate:autonomous-run-finished`.
+- **Adversarial:** requeue-override is the only path past the cap (undocumented).
+  → RESOLVED: documented in No-revival-loop invariant.
+
+**Round 1 — LOW/INFO (folded):**
+- Security: poisoned state file (bounded, in-trust-boundary). → documented residual.
+- Scalability: name the fail-open try/catch + age-limit short-circuit invariant.
+  → RESOLVED: documented in Mechanism.
+- Lessons-aware: evidence injection is a true assertion, not gaming; second
+  origination site justified by re-clamp. → RESOLVED: documented.
+- Adversarial: topic-resolution race fails to safe side. → documented residual.
+- Codex: define `autonomousRunRemainingForTopic` contract. → RESOLVED: added.
+
+**Round 2 — non-material (no change required):**
+- Codex: prefer a dedicated `autonomous-run-remaining` signal OR a comment near
+  the enum. The spec adopts the documented-coupling path and routes it to the
+  side-effects Interactions review — codex's own stated acceptable alternative.
+- Gemini: terminology density / add a glossary. Non-material clarity preference;
+  the spec links concepts to the foundation code and STANDARDS-REGISTRY.
+
+## Convergence verdict
+
+Converged at iteration 2. Zero material findings in the final round. Both
+mandatory blocker lenses (NO double-spawn, NO revival loop) verified FULLY
+COVERED by existing guards across both rounds — the convergence gate's stop
+condition (an unresolved blocking finding on either lens) was never triggered.
+Zero unresolved open questions. The spec is ready for user review and approval.

--- a/docs/specs/resume-idle-autonomous-on-reap.eli16.md
+++ b/docs/specs/resume-idle-autonomous-on-reap.eli16.md
@@ -1,0 +1,87 @@
+---
+status: draft-for-convergence
+approved: false
+parent-principle: "Cross-Machine Coherence — One Agent, Robust Under Degraded Conditions"
+---
+
+# ELI16 — Bring an idle autonomous run back after it gets recycled
+
+## The one-line version
+
+If a long-running autonomous job's session gets shut down just for being old
+(not for being broken), and the job isn't actually finished, automatically
+bring it back — instead of letting it sit dead until someone sends a message.
+
+## What's going on today
+
+The agent has a safety net called the **resume queue**. When a session gets
+killed *in the middle of real work*, the queue notices and quietly restarts it
+later, one at a time, only when the machine is calm and has spare capacity. If
+the same thing keeps dying over and over, the queue gives up loudly so it
+doesn't spin forever.
+
+But there's a catch in HOW the queue decides a session was "doing real work."
+It looks for live evidence at the exact moment of the kill — a running build, a
+sub-task in flight, a queued message. There's one kind of shutdown where none
+of that is visible: the **age-limit recycle**. Sessions aren't allowed to run
+forever, so when an autonomous session has been alive too long AND is sitting
+idle between turns (waiting for its next step), it gets recycled. At that exact
+instant nothing is "running" — so the queue sees no evidence and concludes
+"nothing to bring back," even though the autonomous job itself is still very
+much alive and unfinished.
+
+Result: if this happens while you're away, the job is just... dead. It comes
+back only when you next message that topic. A recent fix (PR #1155) made the
+*notice* you'd see honest about this; this change fixes the actual behavior.
+
+## The fix
+
+When an age-limit recycle hits a topic that still has a **live autonomous run**,
+we treat the live run itself as the proof of work. We tell the queue "yes, this
+one counts," and from there it flows through all the existing safety rails — no
+new restart path, no shortcuts.
+
+We're careful to only do this for the *recycle* case. A session that was killed
+because it was genuinely stuck or genuinely dead does NOT get auto-revived —
+restarting those just recreates the problem.
+
+We also flip this on **live for the dev agent (Echo)** so it actually gets
+exercised on a real two-machine setup, while the rest of the fleet stays in
+"watch only" mode until a deliberate later switch.
+
+## Why it's safe (the four things that could go wrong)
+
+1. **It won't start two copies.** If you message the topic and it wakes up
+   before the queue gets to it, the queue checks "is a session already live
+   here?" right before restarting — and if so, it backs off. Covered by an
+   existing guard.
+2. **It won't loop forever.** If a job keeps getting recycled-and-revived, it
+   hits the existing "give up after N times in 24h" cap and raises one clear
+   alert instead of spinning.
+3. **Only the right machine revives it.** On a multi-machine setup, only the
+   machine that "owns" the topic restarts it — never two machines at once.
+4. **It won't pile onto a stressed machine.** Restarts still wait for the
+   machine to be calm and for spare quota.
+
+All four are handled by machinery that already exists — this change just lets
+the age-limit-recycle case INTO that machinery, and adds tests proving each
+guard still holds for it.
+
+## What review tightened
+
+The adversarial, security, and two outside-model (GPT + Gemini) reviews all
+confirmed the two scariest failure modes — starting two copies, and an
+endless restart loop — are already blocked by existing guards. Review then
+added one structural improvement: right before a restart, the agent now
+re-checks whether the job is STILL live; if it finished in the meantime, it
+quietly skips the restart instead of wasting one. Review also pinned down the
+honest classification of the live-on-dev decision: it spends real resources on
+the dev machine, so it's treated as a deliberate, accepted, operator-approved
+choice — not hand-waved as "safe because it's off everywhere else."
+
+## Open questions for the operator
+
+*(none)* — The forks (only age-limit qualifies; reuse the existing
+`build-or-autonomous-active` evidence signal; live-on-dev / dark-on-fleet) were
+pre-resolved by the operator under the topic-13481 autonomous-session
+pre-approval and are recorded in the spec's Frontloaded Decisions table.

--- a/docs/specs/resume-idle-autonomous-on-reap.md
+++ b/docs/specs/resume-idle-autonomous-on-reap.md
@@ -1,0 +1,367 @@
+---
+status: approved
+approved: true
+approval-provenance: "Justin session pre-approval, topic 13481 (autonomous instar-dev session)"
+parent-principle: "Cross-Machine Coherence — One Agent, Robust Under Degraded Conditions"
+review-convergence: "2026-06-14T08:09:22.451Z"
+review-iterations: 2
+review-completed-at: "2026-06-14T08:09:22.451Z"
+review-report: "docs/specs/reports/resume-idle-autonomous-on-reap-convergence.md"
+cross-model-review: "codex-cli:gpt-5.5"
+single-run-completable: true
+frontloaded-decisions: 6
+cheap-to-change-tags: 4
+contested-then-cleared: 1
+---
+
+# Resume an idle autonomous run after an age-limit reap
+
+## The gap
+
+The Mid-Work Resume Queue (`ResumeQueue` + `ResumeQueueDrainer`) is the durable
+session-revival mechanism: a reaped session is queued, and the drainer brings
+reaped sessions back ONE AT A TIME, quota-gated, with a loud resurrection cap
+(`maxResurrections`, default 2) that gives up after N revivals in a 24h window.
+
+Admission is decided by `ResumeQueue.considerEnqueue` →
+`classifyEligibility` → `evidenceEligible(workEvidence, topicBound)`
+(`src/core/WorkEvidence.ts`). A reap is resume-eligible only when it carries
+≥1 STRONG work-evidence signal (or, for a topic-bound session, ≥2 distinct
+WEAK signals). `midWork` is just `isMidWork(workEvidence)` — any non-marker
+evidence.
+
+The **age-limit** reap path (`SessionManager`, `terminateSession(id,
+'age-limit', …)`, line ~1336) fires precisely when an autonomous session is
+**truly IDLE between turns** past its per-session lifetime cap. The idle gate
+(`SessionManager` §"truly idle") requires the terminal to show an idle prompt
+AND no non-baseline child processes — i.e. at the reap moment there is NO
+running build process, NO pending injection, NO active subagent. So the
+collected `workEvidence` is empty (or only weak/marker), `evidenceEligible`
+returns false, and the session is **NEVER enqueued for revival**.
+
+Consequence: an autonomous run whose session is age-reaped while the operator
+is AWAY sits dead until the next inbound message wakes it. The age-limit reap
+is a **recycle** of a long-lived session (hygiene — keep sessions from running
+unbounded), not a signal that the *work* is finished. The work — the
+autonomous run — is still live in `.instar/autonomous/<topicId>.local.md`.
+PR #1155 (merged) fixed the misleading user-facing NOTICE for this case; THIS
+spec closes the behavioral gap behind it: the run should actually come back.
+
+## The fix
+
+When an `age-limit` reap targets a topic that has an **ACTIVE autonomous run**,
+admit it to the resume queue REGARDLESS of `midWork`/evidence — **the live run
+IS the work evidence.**
+
+### The `autonomousRunRemainingForTopic` contract (the predicate)
+
+The fix's trigger is `autonomousRunRemainingForTopic(stateDir, topicId)`
+(`src/core/AutonomousSessions.ts`, added by PR #1155) returning **non-null**.
+Its exact contract — verified against the code, so the predicate's meaning is
+unambiguous (codex finding 1):
+
+- Returns `{ active: true, remainingSeconds }` ONLY when the topic's autonomous
+  job file (`<stateDir>/autonomous/<topicId>.local.md`) reports `active: true`,
+  has a parseable `started_at`, has a `duration_seconds`, AND
+  `remainingSeconds > 0` (`duration_seconds − elapsed`).
+- Returns `null` — i.e. NOT a continuation, NO synthetic evidence — when: the
+  job is absent/`active:false`; `started_at` is unparseable (`NaN`); fields are
+  missing; OR **the run is already past its own window** (`remainingSeconds <=
+  0`). A run past its window is deliberately NOT revived — the terminal death
+  copy stands for it. This is the structural self-expiry that bounds the
+  stale-marker residual (below): a genuinely-finished run whose duration window
+  has elapsed gets `null` and is never re-admitted, even before the cap.
+
+"Remaining" therefore means **last-known-incomplete within an un-elapsed
+duration window** — not "actively producing output this second" (the session is
+idle between turns by construction at the age-limit reap). The freshness bound
+is the duration window itself.
+
+### Mechanism (minimal, reuse-only)
+
+1. The `sessionReaped` handler in `src/commands/server.ts` already computes the
+   topic id and offers every terminal autonomous reap to
+   `resumeQueue.considerEnqueue(...)`. We extend ONLY the candidate
+   construction there: when `reason === 'age-limit'` AND
+   `autonomousRunRemainingForTopic(config.stateDir, topicId)` returns non-null,
+   we append a NEW strong-evidence signal — `build-or-autonomous-active` is
+   reused (it already exists in `STRONG_WORK_EVIDENCE` and exactly names this
+   condition) — to the candidate's `workEvidence`, and tag the reason
+   `age-limit (active autonomous run)`.
+
+   **This is a TRUE assertion about the world, not synthetic evidence to game a
+   gate.** At the age-limit reap moment the run is genuinely in-flight (the
+   state file reports an un-elapsed window); the idle-gate simply cannot observe
+   it as a child process — it kills *precisely* when process-based evidence is
+   absent by construction. The reaper supplies the missing TRUE signal from the
+   one vantage that can observe the run state (the topic id + the state file).
+   This is the sanctioned response to an evidence-collection blindspot
+   (parent-principle's "record schema is your perception" corollary), the
+   opposite of lying to the classifier.
+
+   **Guard ordering + fail-open (load-bearing).** The `autonomousRunRemainingForTopic`
+   call sits BEHIND the `reason === 'age-limit'` short-circuit (`&&`), so it
+   runs ONLY on age-limit reaps — every other reap (completion,
+   recovery-bounce, operator close, watchdog, idle-zombie) pays ZERO added
+   cost. The call sits INSIDE the existing enqueue-hook `try/catch` (which
+   already wraps `considerEnqueue`): a throw fails toward NOT injecting evidence
+   (status-quo no-revive), NEVER toward a spawn and NEVER toward endangering the
+   kill path. This mirrors the existing ReapNotifier `autonomousRunActiveFor`
+   gate (`server.ts`, `event.reason === 'age-limit'`), which already makes this
+   exact call once per age-limit reap — so the cost is an already-paid cold-path
+   read on a non-hot event handler.
+
+   **Second evidence-origination site (clarity).** `WorkEvidence.ts` advertises
+   a single chokepoint (`SessionManager.terminateSession`) that clamps evidence
+   to the enum. This injection adds evidence at the WIRING layer (the
+   `sessionReaped` handler) DOWNSTREAM of that chokepoint. The invariant still
+   holds: `considerEnqueue` re-clamps via `clampWorkEvidence`, and
+   `build-or-autonomous-active` is a valid `STRONG_WORK_EVIDENCE` member, so it
+   passes through cleanly with no drift. This is a deliberate SECOND
+   origination site, justified by the re-clamp gate — documented here so a
+   future reader does not assume the chokepoint is the sole source.
+
+   This makes `evidenceEligible` admit the candidate through the EXISTING
+   eligibility path. No new admission branch, no new respawn path: the entry
+   flows through the same one-at-a-time, quota-gated, resurrection-capped,
+   lease-gated machinery as any other resume-queue entry.
+
+   **Drain-time liveness re-check (structural close of the stale-marker
+   window).** Inside `ResumeQueueDrainer.validateReality`, for a topic-bound
+   entry tagged with the `age-limit (active autonomous run)` reason, re-read
+   `autonomousRunRemainingForTopic(stateDir, topicId)`; if it now returns
+   `null` (the run completed OR its window elapsed between enqueue and drain),
+   invalidate the entry (`invalidated:autonomous-run-finished`) — never a
+   spawn. This is strictly additive (one file read, the same fail-to-safe-side
+   pattern as the other `validateReality` checks) and closes the
+   window-elapsed/completed subset of the stale-marker residual structurally,
+   rather than spending a resurrection slot to discover it (P14 spirit:
+   re-verify the cause, don't trust the symptom-reset). It does NOT subsume the
+   resurrection cap (a still-open-window stale marker returns the same "active"
+   answer) — the cap remains the hard ceiling for that subset.
+
+2. ONLY `age-limit` qualifies (the recycle case). The genuine-death /
+   genuine-wedge reaps are explicitly EXCLUDED and stay excluded:
+   - `watchdog-stuck` → already `eligible:false` (`watchdog-kill`); resuming
+     recreates the wedge.
+   - `idle-zombie` → a session proven dead; not a recycle of live work.
+   - context-wedge / AUP-wedge respawns → owned by the ContextWedgeSentinel's
+     fresh-respawn path, not the resume queue.
+   The new evidence is injected ONLY on the literal `age-limit` reason, so no
+   other reap reason is affected.
+
+3. **Live-on-dev (no-dark-on-dev directive, topic 13481).** The resume queue
+   ships `dryRun: true` (observe-only) fleet-wide so the drainer audits
+   `would-resume` and never spawns. To actually EXERCISE this on Echo (a real
+   2-machine dev setup), the `dryRun` default resolves to `false` on a
+   development agent and stays `true` on the fleet — mirroring the dev-gating
+   pattern used for the stateSync stores (#1151/#1153, `resolveDevAgentGate`).
+   The resolution happens at the single consumption site
+   (`server.ts`, `dryRun: rqCfg.dryRun ?? !resolveDevAgentGate(undefined, config)`),
+   so an explicit operator `monitoring.resumeQueue.dryRun` still wins and the
+   resume-queue keys stay CODE-defaulted (never frozen into ConfigDefaults,
+   preserving the later fleet flip).
+
+   **NOT registered in `DEV_GATED_FEATURES`** (integration finding). That
+   registry's both-sides wiring test asserts the gated flag resolves to
+   *feature-is-LIVE = true* on dev. This gate is INVERTED — it rides `dryRun`,
+   where `true` means observe-only (NOT live). Registering it would make the
+   wiring test assert the semantic opposite of every other entry (`true` =
+   "dry-run on" rather than "feature live"), poisoning the registry's
+   reviewer-checkable contract. Unlike `topicProfiles`/`credentialRepointing`
+   (which carry a separate `enabled`-via-gate flag and a SECOND `dryRun` field
+   the gate doesn't touch), the resume queue's `enabled` defaults `true` for
+   everyone and the gate rides `dryRun` directly. Instead, a **dedicated
+   purpose-named unit test** locks the resolved `dryRun` VALUE directly: dev
+   config → `dryRun === false`; fleet config → `dryRun === true`; explicit
+   `monitoring.resumeQueue.dryRun: true` still wins on dev. This tests the
+   actual field semantics, not an inverted proxy.
+
+   **Migration: NONE — and that is correct (Migration Parity).** The resolution
+   is a CODE default read at server boot, not a persisted `.instar/config.json`
+   field, so existing agents pick it up on their next server restart after
+   update. A `PostUpdateMigrator`/`migrateConfig` entry would be actively WRONG:
+   it would freeze `dryRun` to disk and break the later fleet flip the
+   ConfigDefaults comment protects. The resume-queue keys must stay un-frozen
+   in ConfigDefaults.
+
+   **Observe live-on-dev** via `logs/resume-queue.jsonl` (`would-resume` →
+   `respawned` / `invalidated:*` events) and `GET /sessions/resume-queue`; the
+   `age-limit (active autonomous run)` reason tag distinguishes these entries
+   from any other resume-queue entry.
+
+## Frontloaded Decisions
+
+Every fork the building agent would otherwise stop to ask about, resolved here
+(operator pre-approval, topic 13481 autonomous session) with its
+cheap/non-cheap classification under the closed taxonomy (durable external
+side-effects / money / identity / published interface → NEVER cheap).
+
+| # | Decision | Resolution | Class |
+|---|----------|------------|-------|
+| D1 | Make the resume queue **live-on-dev** (`dryRun:false`) | Yes — operator no-dark-on-dev directive | **NON-CHEAP, accepted under a named live phase.** It produces REAL respawns on Echo (durable side-effects) + REAL quota spend (money). The fleet dark-gate gives ZERO protection on the dev machine — that is exactly where it runs. The mitigations (one-at-a-time, calm-ticks, quota gate, resurrection cap) BOUND the blast radius but do NOT make a respawn-already-fired reversible. Flipping `dryRun` back does not un-spend the quota already burned. Accepted because the operator explicitly authorized live exercise on the dev agent; NOT labeled "cheap because ships dark." |
+| D2 | Reuse `build-or-autonomous-active` vs. mint a new evidence signal | Reuse | **Cheap.** Internal code-only label feeding an internal predicate; no external/published surface; reversible by changing one string. (Coupling risk noted: if a future maintainer narrows the token's meaning to "a live child build process," this reuse silently breaks — flagged in the side-effects review's Interactions dimension.) |
+| D3 | ONLY `age-limit` qualifies (exclude idle-zombie / watchdog-stuck / context-wedge / AUP-wedge) | age-limit only | **Cheap.** A `reason === 'age-limit'` guard; excluding more is always the safe direction. |
+| D4 | A run MOVED to another machine reaches the queue as `topic moved …` (already ineligible), not `age-limit` | Derived (no fork) | n/a — consequence, documented in Phase-C posture. |
+| D5 | Accept reviving a logically-finished-but-state-says-"remaining" run | Accept (revive-once) | **Cheap (accepted residual).** Bounded by the drain-time liveness re-check (window-elapsed/completed subset) + the resurrection cap (still-open-window subset); revived session can self-terminate; cost of a wrong call is one capped, quota-gated respawn. |
+| D6 | Single consumption-site `dryRun` resolution + keep resume-queue keys CODE-defaulted (out of ConfigDefaults) | As designed | **Cheap.** Code-internal; reversible; preserves the fleet flip (a ConfigDefaults write would freeze it). Same decision as D1 viewed from the config layer. |
+
+## Load-bearing safety invariants
+
+All four are satisfied by EXISTING machinery; this section is the audit that
+proves each is covered (and names the test that locks it).
+
+### 1. No double-spawn (THE #1 blocker lens)
+
+If the session already revived via an inbound message before the queue drains
+it, the queue must NOT spawn a second one.
+
+- **Enqueue dedup**: `considerEnqueue` refuses a second open entry for the same
+  `stableKey` (`duplicate-open-entry`) — one open entry per topic.
+- **Drain-time reality validation (R2.6)**: `ResumeQueueDrainer.validateReality`
+  runs IMMEDIATELY before any spawn and returns `live-session-exists` (→
+  `invalidated`, never a spawn) when `liveSessionForTopic(topicId)` is true.
+  A session revived by a message between enqueue and drain is caught here.
+- **resume-uuid-stale**: if the topic's resume UUID has moved on since enqueue,
+  the entry invalidates rather than spawning onto a stale conversation.
+
+These already cover an age-limit-admitted entry identically to any other entry
+(the entry is an ordinary topic-bound entry once admitted). Validation is
+co-located with the spawn inside a single serialized drainer tick (the
+`ticking` guard), so there is no enqueue→drain→spawn window where a live
+session is invisible. **Tests** (two, to lock BOTH catches): (a) admit an
+age-limit active-run entry, mark the topic's session live (`liveSessionForTopic
+→ true`), drain, assert `invalidated:live-session-exists` with ZERO respawn;
+(b) mark the topic's resume UUID moved on (a message-revive saved a new UUID),
+drain, assert `invalidated:resume-uuid-stale` with ZERO respawn.
+
+### 2. No revival loop
+
+A run that keeps getting age-reaped-and-revived must hit the EXISTING
+resurrection cap and give up LOUDLY.
+
+- `considerEnqueue` consults `tombstoneFor(stableKey)`; a re-reap after a
+  successful resume within the 24h `RESURRECTION_WINDOW_MS` increments
+  `resurrections`, and at `maxResurrections` returns `resurrection-cap`,
+  raising ONE aggregated attention item via `raiseAggregated`.
+- An age-limit active-run entry carries the same `stableKey` (`topic:N`,
+  derived purely from topicId — independent of evidence/reason), so it shares
+  the same tombstone and is capped identically. The synthetic
+  `build-or-autonomous-active` evidence touches ONLY `workEvidence`; the cap
+  check reads `tombstoneFor(stableKey)`, never evidence — so the injected
+  evidence CANNOT reset or evade the tombstone.
+- **The manual `requeue` override is the ONLY path past the cap** and remains
+  operator-gated: it grants exactly ONE additional revival per invocation and
+  is audited, after which the next re-reap re-caps. The cap bounds every
+  *automatic* loop; a re-armed loop requires a deliberate, audited,
+  one-at-a-time operator action.
+- **Test**: drive the same topic through resume → re-age-reap →
+  resume → re-age-reap until the cap; assert the final enqueue returns
+  `resurrection-cap` and `raiseAggregated('resurrection-cap', …)` fired exactly
+  once at the cap.
+
+### 3. Lease-holder-only (Phase-C, N-machine)
+
+Revival happens only on the machine that holds the lease for the topic — never
+double-revive across machines.
+
+- `validateReality` returns `topic-owner-elsewhere` (→ `invalidated`, no spawn)
+  when `topicOwnerElsewhere(topicId)` is true. Revival therefore proceeds only
+  on the owning/lease-holder machine; a standby that enqueued the same reap
+  invalidates at drain.
+- This is unchanged by the fix (an age-limit entry is an ordinary topic-bound
+  entry) and is asserted in the existing drainer suite; the integration test
+  adds a `topicOwnerElsewhere → true` case for an age-limit active-run entry.
+
+### 4. Resource pressure
+
+Revival stays gated on the existing quota / calm-machine checks (don't revive
+into a starved box).
+
+- `ResumeQueueDrainer.gateBlock` requires `requiredCalmTicks` consecutive calm
+  ticks AND a non-critical pressure tier before any spawn; the drainer reads
+  pressure and treats an unreadable tier as `critical` (no spawn). An age-limit
+  active-run entry is subject to the identical gate. Unchanged by the fix.
+
+## Phase-C (N-machine) posture
+
+**Multi-machine posture: machine-local by design, lease-gated.** The resume
+queue is per-machine (single-writer lock on `<stateDir>/state/resume-queue.lock`).
+The age-limit reap is observed on the machine the session ran on, and only the
+lease-holder for the topic actually drains it (invariant 3). No new
+cross-machine state is introduced; `autonomousRunRemainingForTopic` reads the
+LOCAL autonomous-run state file (the run lives on the same machine as the
+session). A topic whose run was MOVED to another machine reaches the resume
+queue as `topic moved …` (already `eligible:false`, `topic-moved`) — not
+`age-limit` — so a moved run is never double-revived here.
+
+## Test plan (3 tiers — Testing Integrity Standard)
+
+- **Unit (admission, both sides):** `classifyEligibility` / the candidate-build
+  path admits an `age-limit` reap with an active run (synthetic
+  `build-or-autonomous-active` ⇒ `eligible:true`) AND refuses an `age-limit`
+  reap with NO active run (`autonomousRunRemainingForTopic → null` ⇒ empty
+  evidence ⇒ `insufficient-evidence`). Plus: the guard short-circuits — assert
+  `listAutonomousJobs`/`autonomousRunRemainingForTopic` is NOT called for a
+  non-`age-limit` reap (completion / recovery-bounce), and a throwing state
+  read fails toward no-injection (no spawn, kill path intact).
+- **Unit (dryRun gate, dedicated — NOT via `DEV_GATED_FEATURES`):** the
+  resolved `dryRun` value at the consumption site is `false` under a dev-agent
+  config, `true` under a fleet config, and an explicit
+  `monitoring.resumeQueue.dryRun: true` still wins on a dev agent.
+- **Unit (drain-time liveness re-check):** an entry tagged `age-limit (active
+  autonomous run)` whose `autonomousRunRemainingForTopic` now returns `null`
+  invalidates `autonomous-run-finished` with ZERO respawn.
+- **Integration (real composition):** a real `ReapNotifier` + `ResumeQueue` +
+  `ResumeQueueDrainer` + autonomous-run state file. (1) double-spawn lens (a)
+  `live-session-exists` and (b) `resume-uuid-stale` — both ZERO respawn;
+  (2) revival-loop lens — drive to the resurrection cap, assert
+  `resurrection-cap` + exactly one aggregated attention item; (3) lease lens —
+  `topicOwnerElsewhere → true` ⇒ `topic-owner-elsewhere`, ZERO respawn;
+  (4) operator-stop-after-enqueue ⇒ `operator-stop`, ZERO respawn.
+- **E2E (the "feature is alive" test):** the production init path (mirroring
+  `server.ts`) with `developmentAgent: true` ⇒ the resume queue boots
+  `dryRun:false`; an age-reaped active-run session ENTERS the queue and revives
+  exactly ONCE (a second drain after the revive does NOT spawn again). A fleet
+  config boots `dryRun:true` (observe-only, `would-resume` audited, no spawn).
+
+## Residual risks (accepted)
+
+- **Idle vs. genuinely-finished autonomous run.** An autonomous run that has
+  *logically* completed but whose state file still reads "remaining" would be
+  revived at most once. Bounded on BOTH sides now: (a) the **window-elapsed /
+  completed-by-drain** subset is closed STRUCTURALLY by the drain-time
+  `autonomousRunRemainingForTopic == null → invalidate:autonomous-run-finished`
+  re-check — no spawn, no resurrection slot spent; (b) the **still-open-window**
+  subset (the state file says "remaining" but the run has logically finished
+  while its duration window is genuinely un-elapsed) revives once, the revived
+  session resumes via continuation prompt and can observe its own completion
+  and stop, and the resurrection cap halts any loop. NOTE for the cap message:
+  if the cap fires on an `age-limit (active autonomous run)` entry, the likely
+  root is a stale `remaining` marker, not "something keeps killing it" — the
+  aggregated attention item's generic copy may mislead; a follow-up could
+  special-case it. The safe direction is to revive (the run can self-terminate)
+  rather than to silently abandon live work — consistent with the parent
+  principle.
+- **Topic-resolution race.** If `getTopicForSession` returns null at reap time
+  (the session de-registered from the topic map before the `sessionReaped`
+  event fired), `topicId` is null → the active-run check is skipped → the run
+  is NOT revived. This fails to the SAFE side: it is the pre-fix behavior (the
+  run waits for the next inbound message), NEVER a double-spawn. Accepted.
+- **Dev-live blast radius.** Live-on-dev means real respawns on Echo (durable
+  side-effects + real quota — see Frontloaded Decision D1, classified NON-cheap
+  and accepted). Mitigated by: one-at-a-time, calm-ticks + quota gate,
+  resurrection cap, the drain-time liveness re-check, and the dry-run-on-fleet
+  default (the fleet remains observe-only until a deliberate flip). Observe via
+  `logs/resume-queue.jsonl` + `GET /sessions/resume-queue`.
+- **Poisoned autonomous-run state file (in-trust-boundary, bounded).** A party
+  who can write `<stateDir>/autonomous/<topicId>.local.md` can forge an "active
+  run" — but that is the same trust boundary as the entire state dir (an
+  attacker there already owns the agent), the forged file can only revive the
+  topic that was ACTUALLY reaped (topicId comes from the session map, not the
+  file — no cross-topic pivot), and the revival still passes `validateReality`
+  + the quota/lease/cap gates. Worst forgeable outcome: one capped respawn of
+  the legitimately-reaped topic. `summarize()` already clamps
+  `duration_seconds`/`iteration` to `^\d+$`; defense-in-depth clamp of an
+  absurd `duration_seconds` is optional (the cap already halts any loop).
+  Accepted, consistent with the file-based-state trust model.


### PR DESCRIPTION
Converged spec (docs-only) for the behavioral fix behind PR #1155.

## The gap
An `age-limit` reap fires when a long-running autonomous session is IDLE between turns past its lifetime cap. The idle gate guarantees no running build / no pending injection / no active subagent at that moment, so the reap is tagged `midWork:false` and the Mid-Work Resume Queue (whose admission needs strong work-evidence) NEVER revives it. The autonomous run is still live on disk, but the session sits dead until the next inbound message. PR #1155 fixed the misleading NOTICE; this closes the behavior.

## The fix (spec only — build PR follows)
When an `age-limit` reap targets a topic with an ACTIVE autonomous run (`autonomousRunRemainingForTopic` non-null), the live run IS the work evidence: inject the existing `build-or-autonomous-active` strong signal so the queue admits it through the EXISTING one-at-a-time / quota-gated / resurrection-capped / lease-gated machinery. No new respawn path. Only `age-limit` qualifies. The queue is made live-on-dev (dryRun:false) on the dev agent, dark on the fleet.

## Convergence
Converged at iteration 2 (`review-convergence` stamped, `approved: true` under topic-13481 session pre-approval). Cross-model: codex gpt-5.5 + gemini-2.5-pro, both rounds, MINOR ISSUES only. Both blocker lenses verified FULLY COVERED by existing guards across both rounds:
- **No double-spawn**: `validateReality` → `live-session-exists` + `resume-uuid-stale` (co-located with spawn in a serialized tick) + enqueue dedup.
- **No revival loop**: topic-keyed tombstone resurrection cap (independent of the injected evidence), gives up loudly.

Review added a drain-time liveness re-check (`invalidate:autonomous-run-finished`) that structurally closes the window-elapsed stale-marker subset, plus a Frontloaded Decisions table reclassifying live-on-dev honestly as non-cheap/accepted.

Report: `docs/specs/reports/resume-idle-autonomous-on-reap-convergence.md`

## ELI16 — When a long autonomous job's session gets recycled just for being old (not broken) and the job isn't finished, automatically bring it back instead of letting it sit dead until someone messages — reusing the existing one-at-a-time, quota-gated, capped, lease-gated restart machinery.

🤖 Generated with [Claude Code](https://claude.com/claude-code)