### PR TITLE
feat(resume-queue): revive an idle autonomous run after an age-limit reap

### DIFF
--- a/.instar/instar-dev-decisions/2026-06-14T08-43-33-227Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-06-14T08-43-33-227Z-unknown.json
@@ -1,0 +1,15 @@
+{
+  "ts": "2026-06-14T08:43:33.227Z",
+  "slug": "unknown",
+  "suggestedTier": 2,
+  "declaredTier": 2,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "new capability: new config key added"
+  ],
+  "belowFloor": false,
+  "files": 3,
+  "loc": 86,
+  "causalAutopsy": null,
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-06-14T08-45-38-889Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-06-14T08-45-38-889Z-unknown.json
@@ -1,0 +1,15 @@
+{
+  "ts": "2026-06-14T08:45:38.889Z",
+  "slug": "unknown",
+  "suggestedTier": 2,
+  "declaredTier": 2,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "new capability: new config key added"
+  ],
+  "belowFloor": false,
+  "files": 3,
+  "loc": 86,
+  "causalAutopsy": null,
+  "verdict": "pass"
+}

--- a/src/commands/server.ts
+++ b/src/commands/server.ts
@@ -31,6 +31,7 @@ import { CodexResumeMap, type CodexSpawnFence } from '../core/CodexResumeMap.js'
 import { paneIdleWithEmptyInput } from '../core/ModelSwapService.js';
 import { escalatedModelIds, normalizeTierEscalationConfig, type TierEscalationConfig } from '../core/ModelTierEscalation.js';
 import { activeAutonomousJobs, autonomousRunRemainingForTopic } from '../core/AutonomousSessions.js';
+import { AGE_LIMIT_ACTIVE_RUN_REASON } from '../core/WorkEvidence.js';
 import { TopicProfileTransferCarrier, createTopicProfilePullHandler } from '../core/TopicProfileTransferCarrier.js';
 import type { SendPullOutcome, TopicProfilePullResponse } from '../core/TopicProfileTransferCarrier.js';
 import type { ResolvedTopicProfile } from '../core/TopicProfileResolver.js';
@@ -6695,7 +6696,13 @@ export async function startServer(options: StartOptions): Promise<void> {
         },
         {
           enabled: rqCfg.enabled ?? true,
-          dryRun: rqCfg.dryRun ?? true, // shipped observe-only (decision 2)
+          // Live-on-dev (no-dark-on-dev directive, topic 13481): the queue ships
+          // observe-only (dryRun:true) fleet-wide, but resolves to LIVE
+          // (dryRun:false) on a development agent so the resume-idle-autonomous
+          // fix is genuinely exercised on Echo. An explicit operator
+          // monitoring.resumeQueue.dryRun still wins; the resume-queue keys stay
+          // CODE-defaulted (never frozen into ConfigDefaults — preserves the fleet flip).
+          dryRun: rqCfg.dryRun ?? !resolveDevAgentGate(undefined, config),
           maxAttempts: rqCfg.maxAttempts ?? 3,
           maxResurrections: rqCfg.maxResurrections ?? 2,
           entryTtlHours: rqCfg.entryTtlHours ?? 24,
@@ -6768,6 +6775,16 @@ export async function startServer(options: StartOptions): Promise<void> {
               } catch { /* no flag */ }
               return Math.max(perTopic, globalOperatorStopAt, flagAt) > since;
             },
+            // Resume-idle-autonomous fix (spec: resume-idle-autonomous-on-reap.md):
+            // drain-time liveness re-check for an entry admitted via the
+            // age-limit-active-run path. Returns true (= run FINISHED) when the topic's
+            // autonomous run is no longer active (completed OR window elapsed) since
+            // enqueue → the drainer invalidates `autonomous-run-finished`, never a
+            // spawn. Reads the LOCAL autonomous-run state file (same vantage that
+            // admitted the entry). A throw resolves to NOT-finished inside the drainer's
+            // safeBool (SAFE side — the revival still passes the other reality gates).
+            autonomousRunFinished: (topicId) =>
+              autonomousRunRemainingForTopic(config.stateDir, topicId) == null,
             jobCheck: (slug, queuedAtIso) => {
               if (!scheduler) return { ok: false, why: 'scheduler-unavailable' };
               const job = scheduler.getJobs().find((j) => j.slug === slug);
@@ -6890,7 +6907,7 @@ export async function startServer(options: StartOptions): Promise<void> {
           },
         );
         resumeDrainer.start();
-        console.log(pc.green(`  ResumeQueue started (${rqCfg.dryRun ?? true ? 'dry-run observe-only' : 'LIVE'}; drainer ${rqCfg.drainIntervalSec ?? 60}s tick)`));
+        console.log(pc.green(`  ResumeQueue started (${(rqCfg.dryRun ?? !resolveDevAgentGate(undefined, config)) ? 'dry-run observe-only' : 'LIVE'}; drainer ${rqCfg.drainIntervalSec ?? 60}s tick)`));
 
         // Boot reconciliation half 2 (R2.4): re-enqueue recent mid-work reaps
         // the queue lost to a crash window. Deferred 30s so the Telegram
@@ -6968,6 +6985,28 @@ export async function startServer(options: StartOptions): Promise<void> {
           const jobDef = e.session.jobSlug
             ? scheduler?.getJobs().find((j) => j.slug === e.session.jobSlug)
             : undefined;
+          // Resume-idle-autonomous fix (spec: resume-idle-autonomous-on-reap.md):
+          // an age-limit reap fires precisely when an autonomous session is IDLE
+          // between turns, so its process-based work evidence is empty by
+          // construction → it is never enqueued for revival, and an away-operator's
+          // run sits dead until the next message. When the reaped topic still has an
+          // ACTIVE autonomous run, the live run IS the work evidence: append the TRUE
+          // `build-or-autonomous-active` strong signal (re-clamped by considerEnqueue)
+          // and tag the reason so the drainer can re-verify liveness at drain time.
+          // Guard ordering is load-bearing: the cold-path autonomousRunRemainingForTopic
+          // read runs ONLY on the literal `age-limit` reason (every other reap pays
+          // zero added cost), and the whole block sits inside the existing try/catch so
+          // a throw fails toward NO injection (status-quo no-revive), never a spawn.
+          let candidateReason = e.reason;
+          let candidateWorkEvidence = e.workEvidence ?? [];
+          if (
+            e.reason === 'age-limit' &&
+            topicId != null &&
+            autonomousRunRemainingForTopic(config.stateDir, topicId) != null
+          ) {
+            candidateReason = AGE_LIMIT_ACTIVE_RUN_REASON;
+            candidateWorkEvidence = [...candidateWorkEvidence, 'build-or-autonomous-active'];
+          }
           resumeQueue.considerEnqueue({
             sessionName: e.session.name,
             tmuxSession: e.session.tmuxSession,
@@ -6976,10 +7015,10 @@ export async function startServer(options: StartOptions): Promise<void> {
             jobResumeOptIn: jobDef?.resumeOnReap === true,
             resumeUuid: topicId != null ? (_topicResumeMap?.get(topicId) ?? null) : null,
             cwd: e.session.cwd ?? _projectDir,
-            reason: e.reason,
+            reason: candidateReason,
             disposition: e.disposition ?? 'terminal',
             origin: e.origin ?? 'autonomous',
-            workEvidence: e.workEvidence ?? [],
+            workEvidence: candidateWorkEvidence,
           });
         }
       } catch (err) {

--- a/src/core/WorkEvidence.ts
+++ b/src/core/WorkEvidence.ts
@@ -44,6 +44,20 @@ export const WEAK_WORK_EVIDENCE = [
 
 export const MARKER_WORK_EVIDENCE = ['unverified-under-pressure'] as const;
 
+/**
+ * The reap-reason tag for an age-limit recycle whose topic still has an ACTIVE
+ * autonomous run (spec: docs/specs/resume-idle-autonomous-on-reap.md). An
+ * age-limit reap fires precisely when an autonomous session is idle between
+ * turns, so its process-based work evidence is empty by construction — yet the
+ * run is genuinely in-flight in the topic's autonomous-run state file. The
+ * sessionReaped wiring supplies the TRUE missing signal (`build-or-autonomous-active`)
+ * from the one vantage that can observe the run (the topic id + the state file)
+ * and tags the candidate's reason with this constant. The drainer reads the tag
+ * to perform the drain-time liveness re-check. The natural home for this
+ * evidence-vocabulary string is here (imported by server.ts + ResumeQueueDrainer.ts).
+ */
+export const AGE_LIMIT_ACTIVE_RUN_REASON = 'age-limit (active autonomous run)';
+
 export type StrongWorkEvidence = (typeof STRONG_WORK_EVIDENCE)[number];
 export type WeakWorkEvidence = (typeof WEAK_WORK_EVIDENCE)[number];
 export type MarkerWorkEvidence = (typeof MARKER_WORK_EVIDENCE)[number];

--- a/src/monitoring/ResumeQueueDrainer.ts
+++ b/src/monitoring/ResumeQueueDrainer.ts
@@ -40,6 +40,7 @@
  */
 
 import type { ResumeQueue, ResumeQueueEntry } from './ResumeQueue.js';
+import { AGE_LIMIT_ACTIVE_RUN_REASON } from '../core/WorkEvidence.js';
 
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 const JOB_SLUG_RE = /^[a-z0-9-]+$/;
@@ -63,6 +64,15 @@ export interface ResumeQueueDrainerDeps {
   topicBindingMatches: (topicId: number, cwd: string) => boolean;
   /** An operator stop instruction recorded for the topic since the entry queued. */
   operatorStopSince: (topicId: number, sinceIso: string) => boolean;
+  /**
+   * Resume-idle-autonomous fix (spec: resume-idle-autonomous-on-reap.md):
+   * OPTIONAL drain-time liveness re-check for an entry admitted because its topic
+   * had an active autonomous run at age-limit-reap time. Returns `false` when the
+   * run is NO LONGER active (completed OR its window elapsed between enqueue and
+   * drain) → the entry invalidates `autonomous-run-finished`, never a spawn.
+   * Absent (undefined) ⇒ today's behavior (no extra check) — back-compat.
+   */
+  autonomousRunFinished?: (topicId: number, reason: string) => boolean;
   /** Jobs: exists, not disabled, not CrashLoopPauser-paused, not run since queuedAt. */
   jobCheck: (slug: string, queuedAtIso: string) => { ok: boolean; why?: string };
   pathExists: (p: string) => boolean;
@@ -409,6 +419,21 @@ export class ResumeQueueDrainer {
       if (this.safeBool(() => this.deps.topicOwnerElsewhere(topicId), true)) return 'topic-owner-elsewhere';
       if (!this.safeBool(() => this.deps.topicBindingMatches(topicId, entry.cwd), false)) return 'binding-mismatch';
       if (this.safeBool(() => this.deps.operatorStopSince(topicId, sinceIso), true)) return 'operator-stop';
+      // Resume-idle-autonomous fix (spec: resume-idle-autonomous-on-reap.md): for an
+      // entry admitted via the age-limit-active-run path, re-verify the run is STILL
+      // live immediately before the spawn. If it completed or its window elapsed since
+      // enqueue, invalidate (never a spawn) — closing the window-elapsed/completed-by-
+      // drain subset of the stale-marker residual structurally, without spending a
+      // resurrection slot to discover it. A throwing/absent dep resolves to the SAFE
+      // side (NOT finished ⇒ no extra invalidation) so this is strictly additive: it
+      // can only ADD an invalidation, never wrongly drop a legitimate revival.
+      if (
+        entry.reason === AGE_LIMIT_ACTIVE_RUN_REASON &&
+        this.deps.autonomousRunFinished &&
+        this.safeBool(() => this.deps.autonomousRunFinished!(topicId, entry.reason), false)
+      ) {
+        return 'autonomous-run-finished';
+      }
     } else if (entry.jobSlug) {
       const check = this.safeVal(() => this.deps.jobCheck(entry.jobSlug!, sinceIso), { ok: false, why: 'job-check-failed' });
       if (!check.ok) return check.why ?? 'job-invalid';

--- a/tests/e2e/resume-idle-autonomous-lifecycle.test.ts
+++ b/tests/e2e/resume-idle-autonomous-lifecycle.test.ts
@@ -1,0 +1,267 @@
+// safe-git-allow: test fixture cleanup uses fs.rmSync on tmp dirs only.
+/**
+ * Tier-3 E2E "feature is alive" lifecycle test for resume-idle-autonomous-on-reap
+ * (spec: docs/specs/resume-idle-autonomous-on-reap.md).
+ *
+ * Per TESTING-INTEGRITY-SPEC: boots the REAL AgentServer (the path server.ts
+ * uses) with the REAL ResumeQueue + ResumeQueueDrainer + the REAL
+ * `autonomousRunRemainingForTopic` helper, composed exactly the way server.ts
+ * composes them (including the live-on-dev dryRun resolution, the sessionReaped
+ * age-limit augmentation, and the drain-time autonomousRunFinished wiring), and
+ * verifies:
+ *
+ *   Phase 1 — alive on DEV: with developmentAgent:true the queue boots
+ *             dryRun:false (LIVE) — GET /sessions/resume-queue returns 200 with
+ *             dryRun:false through the real AgentServer plumbing.
+ *   Phase 2 — an age-limit reap of a topic with an ACTIVE autonomous run ENTERS
+ *             the queue (the run is the work evidence) and revives EXACTLY ONCE;
+ *             a second drain after the revive does NOT spawn again (double-spawn
+ *             guard: live-session-exists catches it).
+ *   Phase 3 — on the FLEET (developmentAgent:false) the same boot path resolves
+ *             dryRun:true (observe-only): an age-reaped active-run session is
+ *             audited would-resume and NEVER spawns.
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import express from 'express';
+import request from 'supertest';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+
+import { AgentServer } from '../../src/server/AgentServer.js';
+import { StateManager } from '../../src/core/StateManager.js';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+import { createMockSessionManager, type MockSessionManager } from '../helpers/setup.js';
+import { ReapLog } from '../../src/monitoring/ReapLog.js';
+import { ResumeQueue } from '../../src/monitoring/ResumeQueue.js';
+import { ResumeQueueDrainer } from '../../src/monitoring/ResumeQueueDrainer.js';
+import { autonomousRunRemainingForTopic } from '../../src/core/AutonomousSessions.js';
+import { AGE_LIMIT_ACTIVE_RUN_REASON } from '../../src/core/WorkEvidence.js';
+import { resolveDevAgentGate } from '../../src/core/devAgentGate.js';
+import type { InstarConfig, Session } from '../../src/core/types.js';
+
+const TOPIC = 7;
+const UUID = '11111111-1111-4111-8111-111111111111';
+
+/**
+ * Build a full server harness with the resume queue composed exactly as
+ * server.ts composes it — parameterized by developmentAgent so we can prove the
+ * live-on-dev vs observe-only-on-fleet boot resolution end to end.
+ */
+function buildHarness(developmentAgent: boolean) {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'resume-idle-e2e-'));
+  const stateDir = path.join(tmpDir, '.instar');
+  const workDir = path.join(tmpDir, 'worktree');
+  fs.mkdirSync(path.join(stateDir, 'state', 'sessions'), { recursive: true });
+  fs.mkdirSync(path.join(stateDir, 'logs'), { recursive: true });
+  fs.mkdirSync(workDir, { recursive: true });
+  fs.writeFileSync(path.join(stateDir, 'config.json'), JSON.stringify({ port: 0, projectName: 'e2e', agentName: 'E2E' }));
+
+  const mockSm: MockSessionManager = createMockSessionManager();
+  const reapLog = new ReapLog(stateDir, () => 'e2e-machine');
+
+  const topicByTmux = new Map<string, number>();
+  const topicResumeMap = new Map<number, string>();
+  const audits: Array<Record<string, unknown>> = [];
+  const respawns: string[] = [];
+
+  // server.ts boot config object (the dev-gate input).
+  const gateConfig = { developmentAgent };
+  // EXACTLY server.ts's consumption-site resolution.
+  const resolvedDryRun = undefined ?? !resolveDevAgentGate(undefined, gateConfig);
+
+  const resumeQueue = new ResumeQueue(
+    { stateDir, audit: (e) => audits.push(e), raiseAggregated: () => {} },
+    { enabled: true, dryRun: resolvedDryRun, maxAttempts: 3, maxResurrections: 2, entryTtlHours: 24, maxQueueSize: 50, includeOperatorKills: false },
+  );
+  resumeQueue.start();
+
+  const resumeDrainer = new ResumeQueueDrainer(
+    {
+      queue: resumeQueue,
+      pressureTier: () => 'normal',
+      canSpawnSession: () => true,
+      sessionCountOk: () => mockSm.listRunningSessions().length < 10,
+      migrationInFlight: () => false,
+      liveSessionForTopic: (topicId) =>
+        mockSm.listRunningSessions().some((s) => topicByTmux.get(s.tmuxSession) === topicId),
+      currentResumeUuid: (topicId) => topicResumeMap.get(topicId) ?? null,
+      topicOwnerElsewhere: () => false,
+      topicBindingMatches: () => true,
+      operatorStopSince: () => false,
+      // The production wiring: drain-time liveness via the real helper.
+      autonomousRunFinished: (topicId) => autonomousRunRemainingForTopic(stateDir, topicId) == null,
+      jobCheck: () => ({ ok: false, why: 'scheduler-unavailable' }),
+      pathExists: (p) => fs.existsSync(p),
+      respawnTopic: async (entry, prompt) => {
+        respawns.push(entry.id);
+        const session = await mockSm.spawnSession({
+          name: entry.sessionName,
+          prompt,
+          cwd: entry.worktreePath ?? entry.cwd,
+        } as Parameters<MockSessionManager['spawnSession']>[0]);
+        topicByTmux.set(session.tmuxSession, entry.topicId!);
+        return session.tmuxSession;
+      },
+      triggerJob: async () => 'skipped',
+      spawnAliveAfterGrace: async (tmux) => mockSm.isSessionAlive(tmux),
+      raiseAggregated: () => {},
+      audit: (e) => audits.push(e),
+    },
+    { drainIntervalSec: 60, requiredCalmTicks: 0, maxAttempts: 3, breakerThreshold: 3, breakerCooldownMin: 30, tier1Check: false },
+  );
+
+  /** Mirrors the server.ts sessionReaped fan-out — including the age-limit
+   *  active-run augmentation. */
+  const fireSessionReaped = (e: { session: Session; reason: string }): void => {
+    reapLog.recordReaped({ session: e.session.name, tmuxSession: e.session.tmuxSession, reason: e.reason, disposition: 'terminal', origin: 'autonomous' });
+    const rawTopic = topicByTmux.get(e.session.tmuxSession);
+    const topicId = rawTopic == null ? null : rawTopic;
+    let reason = e.reason;
+    let workEvidence: string[] = [];
+    if (e.reason === 'age-limit' && topicId != null && autonomousRunRemainingForTopic(stateDir, topicId) != null) {
+      reason = AGE_LIMIT_ACTIVE_RUN_REASON;
+      workEvidence = [...workEvidence, 'build-or-autonomous-active'];
+    }
+    resumeQueue.considerEnqueue({
+      sessionName: e.session.name,
+      tmuxSession: e.session.tmuxSession,
+      topicId,
+      resumeUuid: topicId != null ? (topicResumeMap.get(topicId) ?? null) : null,
+      cwd: (e.session as { cwd?: string }).cwd ?? tmpDir,
+      reason,
+      disposition: 'terminal',
+      origin: 'autonomous',
+      workEvidence,
+    });
+  };
+
+  const writeRun = (durationSeconds: number, startedAt: string) => {
+    fs.mkdirSync(path.join(stateDir, 'autonomous'), { recursive: true });
+    fs.writeFileSync(
+      path.join(stateDir, 'autonomous', `${TOPIC}.local.md`),
+      `---\nactive: true\npaused: false\niteration: 2\ngoal: "run ${TOPIC}"\nstarted_at: "${startedAt}"\nduration_seconds: ${durationSeconds}\nreport_topic: "${TOPIC}"\n---\n\ntask\n`,
+    );
+  };
+
+  return { tmpDir, stateDir, workDir, mockSm, reapLog, resumeQueue, resumeDrainer, topicByTmux, topicResumeMap, audits, respawns, fireSessionReaped, writeRun, resolvedDryRun };
+}
+
+async function startServer(h: ReturnType<typeof buildHarness>, auth: string): Promise<{ server: AgentServer; app: express.Express }> {
+  const config: InstarConfig = {
+    projectName: 'e2e', projectDir: h.tmpDir, stateDir: h.stateDir, port: 0, authToken: auth,
+    requestTimeoutMs: 10000, version: '0.0.0',
+    sessions: { claudePath: '/usr/bin/echo', maxSessions: 3, defaultMaxDurationMinutes: 30, protectedSessions: [], monitorIntervalMs: 5000 },
+    scheduler: { enabled: false, jobsFile: '', maxParallelJobs: 1 },
+    messaging: [], monitoring: {}, updates: {},
+  } as InstarConfig;
+  const server = new AgentServer({
+    config,
+    sessionManager: h.mockSm as never,
+    state: new StateManager(h.stateDir),
+    reapLog: h.reapLog,
+    resumeQueue: h.resumeQueue,
+    resumeDrainer: h.resumeDrainer,
+  });
+  await server.start();
+  return { server, app: server.getApp() };
+}
+
+describe('Resume-idle-autonomous E2E (feature is alive)', () => {
+  let dev: ReturnType<typeof buildHarness>;
+  let devServer: AgentServer;
+  let devApp: express.Express;
+  const AUTH = 'test-e2e-resume-idle';
+
+  beforeAll(async () => {
+    dev = buildHarness(true);
+    const s = await startServer(dev, AUTH);
+    devServer = s.server;
+    devApp = s.app;
+  });
+
+  afterAll(async () => {
+    dev.resumeQueue?.stop();
+    await devServer.stop();
+    SafeFsExecutor.safeRmSync(dev.tmpDir, { recursive: true, force: true, operation: 'tests/e2e/resume-idle-autonomous-lifecycle.test.ts' });
+  });
+
+  const auth = () => ({ Authorization: `Bearer ${AUTH}` });
+
+  describe('Phase 1: alive on dev (dryRun:false)', () => {
+    it('GET /sessions/resume-queue returns 200 with dryRun:false through the real AgentServer', async () => {
+      expect(dev.resolvedDryRun).toBe(false); // live-on-dev resolution
+      const res = await request(devApp).get('/sessions/resume-queue').set(auth());
+      expect(res.status).toBe(200);
+      expect(res.body.dryRun).toBe(false);
+    });
+
+    it('requires Bearer auth', async () => {
+      expect((await request(devApp).get('/sessions/resume-queue')).status).toBe(401);
+    });
+  });
+
+  describe('Phase 2: an age-reaped active-run session enters the queue and revives EXACTLY once', () => {
+    it('enters the queue (run is the evidence), revives once, second drain does NOT re-spawn', async () => {
+      // A genuinely in-flight autonomous run on the topic.
+      dev.writeRun(86400, new Date(Date.now() - 60_000).toISOString());
+      const reaped: Session = {
+        id: 's-age', name: 'age-session', status: 'running', tmuxSession: 'tmux-age',
+        startedAt: new Date().toISOString(), cwd: dev.workDir,
+      } as Session;
+      dev.topicByTmux.set('tmux-age', TOPIC);
+      dev.topicResumeMap.set(TOPIC, UUID);
+
+      // Age-limit reap of a topic with an active run ⇒ augmented + enqueued.
+      dev.fireSessionReaped({ session: reaped, reason: 'age-limit' });
+
+      const listed = await request(devApp).get('/sessions/resume-queue').set(auth());
+      expect(listed.status).toBe(200);
+      expect(listed.body.entries).toHaveLength(1);
+      expect(listed.body.entries[0]).toMatchObject({
+        stableKey: `topic:${TOPIC}`,
+        reason: AGE_LIMIT_ACTIVE_RUN_REASON,
+      });
+      expect(listed.body.entries[0].workEvidence).toContain('build-or-autonomous-active');
+
+      // The reaped session is no longer running, so the topic appears un-live.
+      // First drain → revive exactly once.
+      const first = await dev.resumeDrainer.tick();
+      expect(first.resumed).toBe(true);
+      expect(dev.respawns).toHaveLength(1);
+
+      // The revive registered a live session for the topic (respawnTopic mapped it).
+      // Re-enqueue (a fresh reap arriving) + drain again → the double-spawn guard
+      // (live-session-exists) catches it: ZERO second spawn.
+      dev.fireSessionReaped({ session: reaped, reason: 'age-limit' });
+      const second = await dev.resumeDrainer.tick();
+      expect(second.resumed).toBeFalsy();
+      expect(dev.respawns).toHaveLength(1); // still ONE — no double spawn
+    });
+  });
+
+  describe('Phase 3: fleet config boots observe-only (dryRun:true) — no spawn', () => {
+    it('an age-reaped active-run session is audited would-resume and NEVER spawns', async () => {
+      const fleet = buildHarness(false);
+      try {
+        expect(fleet.resolvedDryRun).toBe(true); // observe-only on the fleet
+        fleet.writeRun(86400, new Date(Date.now() - 60_000).toISOString());
+        const reaped: Session = {
+          id: 's-fleet', name: 'fleet-session', status: 'running', tmuxSession: 'tmux-fleet',
+          startedAt: new Date().toISOString(), cwd: fleet.workDir,
+        } as Session;
+        fleet.topicByTmux.set('tmux-fleet', TOPIC);
+        fleet.topicResumeMap.set(TOPIC, UUID);
+        fleet.fireSessionReaped({ session: reaped, reason: 'age-limit' });
+
+        const r = await fleet.resumeDrainer.tick();
+        expect(r.blocked).toBe('dry-run');
+        expect(fleet.respawns).toHaveLength(0); // observe-only — no spawn
+        expect(fleet.audits.some((a) => a.event === 'would-resume')).toBe(true);
+      } finally {
+        fleet.resumeQueue.stop();
+        SafeFsExecutor.safeRmSync(fleet.tmpDir, { recursive: true, force: true, operation: 'tests/e2e/resume-idle-autonomous-lifecycle.test.ts' });
+      }
+    });
+  });
+});

--- a/tests/integration/resume-idle-autonomous-wiring.test.ts
+++ b/tests/integration/resume-idle-autonomous-wiring.test.ts
@@ -1,0 +1,240 @@
+// safe-git-allow: test fixture cleanup uses fs.rmSync on tmp dirs only.
+/**
+ * Resume-idle-autonomous-on-reap — integration / wiring integrity
+ * (spec: docs/specs/resume-idle-autonomous-on-reap.md).
+ *
+ * Composes the REAL ResumeQueue + REAL ResumeQueueDrainer + the REAL
+ * `autonomousRunRemainingForTopic` helper over a temp stateDir, proving:
+ *  - WIRING INTEGRITY: the `autonomousRunFinished` dep is non-null and DELEGATES
+ *    to the real run-window read (not a mock-against-mock); a finished run ⇒
+ *    invalidate `autonomous-run-finished`; a live run ⇒ revive.
+ *  - DOUBLE-SPAWN LENS (#1 blocker): an age-limit active-run entry that has since
+ *    revived via a message — (a) a live session for the topic ⇒
+ *    `live-session-exists`; (b) the topic's resume UUID moved on ⇒
+ *    `resume-uuid-stale` — BOTH ZERO respawn.
+ *  - REVIVAL-LOOP LENS: an age-limit active-run entry re-reaped after each revive
+ *    hits the EXISTING resurrection cap and gives up LOUDLY (exactly one
+ *    aggregated `resurrection-cap` notice), never a silent loop.
+ *  - LEASE LENS: topicOwnerElsewhere ⇒ `topic-owner-elsewhere`, ZERO respawn.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { ResumeQueue, type ResumeCandidateInput } from '../../src/monitoring/ResumeQueue.js';
+import { ResumeQueueDrainer, type ResumeQueueDrainerDeps } from '../../src/monitoring/ResumeQueueDrainer.js';
+import { autonomousRunRemainingForTopic } from '../../src/core/AutonomousSessions.js';
+import { AGE_LIMIT_ACTIVE_RUN_REASON } from '../../src/core/WorkEvidence.js';
+
+let tmpDir: string; // serves as the .instar stateDir
+const UUID = '11111111-1111-4111-8111-111111111111';
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'resume-idle-wiring-'));
+});
+afterEach(() => {
+  vi.useRealTimers();
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+function writeRun(topic: string | number, durationSeconds: number, startedAt: string) {
+  fs.mkdirSync(path.join(tmpDir, 'autonomous'), { recursive: true });
+  fs.writeFileSync(
+    path.join(tmpDir, 'autonomous', `${topic}.local.md`),
+    `---\nactive: true\npaused: false\niteration: 4\ngoal: "run ${topic}"\nstarted_at: "${startedAt}"\nduration_seconds: ${durationSeconds}\nreport_topic: "${topic}"\n---\n\ntask\n`,
+  );
+}
+function endRun(topic: string | number) {
+  fs.rmSync(path.join(tmpDir, 'autonomous', `${topic}.local.md`), { force: true });
+}
+
+function candidate(over: Partial<ResumeCandidateInput> = {}): ResumeCandidateInput {
+  return {
+    sessionName: 'sess',
+    tmuxSession: 'tmux-1',
+    topicId: 42,
+    resumeUuid: UUID,
+    cwd: path.join(tmpDir, 'project'),
+    reason: AGE_LIMIT_ACTIVE_RUN_REASON,
+    disposition: 'terminal',
+    origin: 'autonomous',
+    workEvidence: ['build-or-autonomous-active'],
+    ...over,
+  };
+}
+
+interface Harness {
+  queue: ResumeQueue;
+  drainer: ResumeQueueDrainer;
+  respawns: string[];
+  audits: Array<Record<string, unknown>>;
+  aggregated: Array<{ kind: string; detail: string }>;
+  deps: ResumeQueueDrainerDeps;
+}
+
+/** Wire the drainer EXACTLY as server.ts wires it: autonomousRunFinished delegates
+ *  to the real helper over the real stateDir. */
+function harness(over?: { deps?: Partial<ResumeQueueDrainerDeps> }): Harness {
+  fs.mkdirSync(path.join(tmpDir, 'project'), { recursive: true });
+  const audits: Array<Record<string, unknown>> = [];
+  const aggregated: Array<{ kind: string; detail: string }> = [];
+  const respawns: string[] = [];
+  let nowMs = Date.now();
+  const queue = new ResumeQueue(
+    { stateDir: tmpDir, audit: (e) => audits.push(e), raiseAggregated: (k, d) => aggregated.push({ kind: k, detail: d }), now: () => nowMs },
+    { dryRun: false, maxResurrections: 2 },
+  );
+  queue.start();
+  let currentUuid: string | null = UUID;
+  let liveTopics = new Set<number>();
+  let ownerElsewhere = false;
+  const deps: ResumeQueueDrainerDeps = {
+    queue,
+    pressureTier: () => 'normal',
+    canSpawnSession: () => true,
+    sessionCountOk: () => true,
+    migrationInFlight: () => false,
+    liveSessionForTopic: (t) => liveTopics.has(t),
+    currentResumeUuid: () => currentUuid,
+    topicOwnerElsewhere: () => ownerElsewhere,
+    topicBindingMatches: () => true,
+    operatorStopSince: () => false,
+    // THE WIRING UNDER TEST: real helper, real stateDir (server.ts shape).
+    autonomousRunFinished: (topicId) => autonomousRunRemainingForTopic(tmpDir, topicId) == null,
+    jobCheck: () => ({ ok: true }),
+    pathExists: (p) => fs.existsSync(p),
+    respawnTopic: async (entry) => { respawns.push(entry.id); return `respawned-${entry.tmuxSession}`; },
+    triggerJob: async () => 'triggered',
+    spawnAliveAfterGrace: async () => true,
+    raiseAggregated: (k, d) => aggregated.push({ kind: k, detail: d }),
+    audit: (e) => audits.push(e),
+    now: () => nowMs,
+    ...over?.deps,
+  };
+  // expose the mutable controls through closures the tests set via deps overrides
+  (deps as Record<string, unknown>).__setUuid = (u: string | null) => { currentUuid = u; };
+  (deps as Record<string, unknown>).__setLive = (t: number, v: boolean) => { v ? liveTopics.add(t) : liveTopics.delete(t); };
+  (deps as Record<string, unknown>).__setOwnerElsewhere = (v: boolean) => { ownerElsewhere = v; };
+  const drainer = new ResumeQueueDrainer(deps, { requiredCalmTicks: 3, tier1Check: false });
+  return { queue, drainer, respawns, audits, aggregated, deps };
+}
+
+async function warmCalm(d: ResumeQueueDrainer, ticks = 3): Promise<void> {
+  for (let i = 0; i < ticks; i++) await d.tick();
+}
+
+describe('wiring integrity — autonomousRunFinished delegates to the real helper', () => {
+  it('a FINISHED run (state file gone) ⇒ invalidate autonomous-run-finished, ZERO respawn', async () => {
+    const h = harness();
+    // No run file ⇒ the real helper returns null ⇒ finished.
+    h.queue.considerEnqueue(candidate());
+    await warmCalm(h.drainer, 2);
+    const r = await h.drainer.tick();
+    expect(r.invalidated).toBe(1);
+    expect(h.respawns).toHaveLength(0);
+    expect(h.audits.find((a) => a.event === 'invalidated')?.why).toBe('autonomous-run-finished');
+  });
+
+  it('a LIVE run (un-elapsed window) ⇒ revives via the real helper', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-06-14T07:00:00Z'));
+    writeRun(42, 86400, '2026-06-14T00:00:00Z'); // ~17h left
+    const h = harness();
+    h.queue.considerEnqueue(candidate());
+    await warmCalm(h.drainer, 2);
+    expect((await h.drainer.tick()).resumed).toBe(true);
+    expect(h.respawns).toHaveLength(1);
+  });
+
+  it('a run PAST its window ⇒ the real helper returns null ⇒ invalidate (no respawn)', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-06-14T07:00:00Z'));
+    writeRun(42, 60, '2026-06-14T00:00:00Z'); // elapsed
+    const h = harness();
+    h.queue.considerEnqueue(candidate());
+    await warmCalm(h.drainer, 2);
+    expect((await h.drainer.tick()).invalidated).toBe(1);
+    expect(h.respawns).toHaveLength(0);
+  });
+});
+
+describe('double-spawn lens (#1 blocker) — a live revival catches before any spawn', () => {
+  it('(a) a live session for the topic ⇒ live-session-exists, ZERO respawn', async () => {
+    writeRun(42, 86400, new Date().toISOString());
+    const h = harness();
+    h.queue.considerEnqueue(candidate());
+    (h.deps as Record<string, (t: number, v: boolean) => void>).__setLive(42, true);
+    await warmCalm(h.drainer, 2);
+    const r = await h.drainer.tick();
+    expect(r.invalidated).toBe(1);
+    expect(h.respawns).toHaveLength(0);
+    expect(h.audits.find((a) => a.event === 'invalidated')?.why).toBe('live-session-exists');
+  });
+
+  it('(b) the topic resume UUID moved on (a message-revive) ⇒ resume-uuid-stale, ZERO respawn', async () => {
+    writeRun(42, 86400, new Date().toISOString());
+    const h = harness();
+    h.queue.considerEnqueue(candidate());
+    (h.deps as Record<string, (u: string | null) => void>).__setUuid('22222222-2222-4222-8222-222222222222');
+    await warmCalm(h.drainer, 2);
+    const r = await h.drainer.tick();
+    expect(r.invalidated).toBe(1);
+    expect(h.respawns).toHaveLength(0);
+    expect(h.audits.find((a) => a.event === 'invalidated')?.why).toBe('resume-uuid-stale');
+  });
+});
+
+describe('lease lens — only the owning machine drains', () => {
+  it('topicOwnerElsewhere ⇒ topic-owner-elsewhere, ZERO respawn', async () => {
+    writeRun(42, 86400, new Date().toISOString());
+    const h = harness();
+    h.queue.considerEnqueue(candidate());
+    (h.deps as Record<string, (v: boolean) => void>).__setOwnerElsewhere(true);
+    await warmCalm(h.drainer, 2);
+    const r = await h.drainer.tick();
+    expect(r.invalidated).toBe(1);
+    expect(h.respawns).toHaveLength(0);
+    expect(h.audits.find((a) => a.event === 'invalidated')?.why).toBe('topic-owner-elsewhere');
+  });
+});
+
+describe('revival-loop lens — the resurrection cap halts an age-reap loop LOUDLY', () => {
+  it('age-reap → revive → re-age-reap … hits resurrection-cap exactly once', async () => {
+    writeRun(42, 86400, new Date().toISOString());
+    const h = harness();
+
+    // maxResurrections = 2: two successful revivals, the THIRD re-reap is capped.
+    // Revival 1.
+    expect(h.queue.considerEnqueue(candidate()).enqueued).toBe(true);
+    await warmCalm(h.drainer, 2);
+    expect((await h.drainer.tick()).resumed).toBe(true);
+
+    // Re-age-reap (same stableKey topic:42) ⇒ revival 2.
+    expect(h.queue.considerEnqueue(candidate()).enqueued).toBe(true);
+    expect((await h.drainer.tick()).resumed).toBe(true);
+
+    // Re-age-reap again ⇒ now over the cap.
+    const capped = h.queue.considerEnqueue(candidate());
+    expect(capped.enqueued).toBe(false);
+    expect(capped.why).toBe('resurrection-cap');
+
+    // LOUD: exactly one aggregated resurrection-cap notice.
+    const capNotices = h.aggregated.filter((a) => a.kind === 'resurrection-cap');
+    expect(capNotices).toHaveLength(1);
+  });
+
+  it('the injected build-or-autonomous-active evidence CANNOT reset the tombstone', async () => {
+    // The cap reads tombstoneFor(stableKey), never workEvidence — so the synthetic
+    // evidence on an age-limit entry shares the topic's tombstone and is capped.
+    writeRun(7, 86400, new Date().toISOString());
+    const h = harness();
+    const c = () => candidate({ topicId: 7, tmuxSession: 't7' });
+    h.queue.considerEnqueue(c());
+    await warmCalm(h.drainer, 2);
+    await h.drainer.tick(); // revive 1
+    h.queue.considerEnqueue(c());
+    await h.drainer.tick(); // revive 2
+    expect(h.queue.considerEnqueue(c()).why).toBe('resurrection-cap');
+  });
+});

--- a/tests/unit/resume-idle-autonomous.test.ts
+++ b/tests/unit/resume-idle-autonomous.test.ts
@@ -1,0 +1,299 @@
+// safe-git-allow: test fixture cleanup uses fs.rmSync on tmp dirs only.
+/**
+ * Resume-idle-autonomous-on-reap (spec: docs/specs/resume-idle-autonomous-on-reap.md).
+ *
+ * Three unit surfaces, both sides of every boundary:
+ *  1. ADMISSION — an age-limit reap whose topic has an ACTIVE autonomous run is
+ *     admitted (the server appends `build-or-autonomous-active` ⇒ eligible) while
+ *     an age-limit reap with NO active run stays REJECTED (empty evidence ⇒
+ *     insufficient-evidence). Plus the guard short-circuits: the cold-path
+ *     `autonomousRunRemainingForTopic` read runs ONLY on `age-limit` reaps, and a
+ *     throwing state read fails toward NO injection (no spawn, kill path intact).
+ *  2. DRYRUN GATE (dedicated, NOT via DEV_GATED_FEATURES) — the resolved dryRun
+ *     value is `false` under a dev-agent config, `true` under a fleet config, and
+ *     an explicit `monitoring.resumeQueue.dryRun: true` still wins on dev.
+ *  3. DRAIN-TIME LIVENESS RE-CHECK — an entry tagged `age-limit (active autonomous
+ *     run)` whose run has since finished invalidates `autonomous-run-finished` with
+ *     ZERO respawn; a still-active run revives normally.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import {
+  ResumeQueue,
+  classifyEligibility,
+  type ResumeCandidateInput,
+} from '../../src/monitoring/ResumeQueue.js';
+import {
+  ResumeQueueDrainer,
+  type ResumeQueueDrainerDeps,
+} from '../../src/monitoring/ResumeQueueDrainer.js';
+import { AGE_LIMIT_ACTIVE_RUN_REASON } from '../../src/core/WorkEvidence.js';
+import { autonomousRunRemainingForTopic } from '../../src/core/AutonomousSessions.js';
+import { resolveDevAgentGate } from '../../src/core/devAgentGate.js';
+
+let tmpDir: string;
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'resume-idle-test-'));
+});
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+/**
+ * The EXACT augmentation the sessionReaped handler in server.ts performs. Kept as
+ * a faithful replica so the both-sides boundary (age-limit + active run ⇒ augment;
+ * else ⇒ untouched) is unit-testable without booting the server; the real wiring is
+ * proven by the integration tier (resume-idle-autonomous-wiring.test.ts).
+ */
+function buildCandidateReason(
+  reason: string,
+  topicId: number | null,
+  stateDir: string,
+  calls: { name: string }[],
+): { reason: string; workEvidence: string[] } {
+  let candidateReason = reason;
+  let candidateWorkEvidence: string[] = [];
+  if (
+    reason === 'age-limit' &&
+    topicId != null &&
+    (() => {
+      calls.push({ name: 'autonomousRunRemainingForTopic' });
+      return autonomousRunRemainingForTopic(stateDir, topicId) != null;
+    })()
+  ) {
+    candidateReason = AGE_LIMIT_ACTIVE_RUN_REASON;
+    candidateWorkEvidence = [...candidateWorkEvidence, 'build-or-autonomous-active'];
+  }
+  return { reason: candidateReason, workEvidence: candidateWorkEvidence };
+}
+
+function writeRun(stateDir: string, topic: string, durationSeconds: number, startedAt: string) {
+  fs.mkdirSync(path.join(stateDir, 'autonomous'), { recursive: true });
+  fs.writeFileSync(
+    path.join(stateDir, 'autonomous', `${topic}.local.md`),
+    `---\nactive: true\npaused: false\niteration: 3\ngoal: "run ${topic}"\nstarted_at: "${startedAt}"\nduration_seconds: ${durationSeconds}\nreport_topic: "${topic}"\n---\n\ntask\n`,
+  );
+}
+
+describe('admission — age-limit reap with an active autonomous run', () => {
+  it('ADMITS: active run ⇒ build-or-autonomous-active appended ⇒ eligible', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-06-14T07:00:00Z'));
+    writeRun(tmpDir, '42', 86400, '2026-06-14T00:00:00Z'); // window un-elapsed
+    const calls: { name: string }[] = [];
+    const { reason, workEvidence } = buildCandidateReason('age-limit', 42, tmpDir, calls);
+    expect(reason).toBe(AGE_LIMIT_ACTIVE_RUN_REASON);
+    expect(workEvidence).toContain('build-or-autonomous-active');
+    // The augmented evidence makes the topic-bound candidate eligible.
+    const verdict = classifyEligibility(
+      {
+        sessionName: 's',
+        tmuxSession: 't',
+        topicId: 42,
+        cwd: '/tmp',
+        reason,
+        disposition: 'terminal',
+        origin: 'autonomous',
+        workEvidence,
+      } as ResumeCandidateInput,
+      { includeOperatorKills: false } as never,
+    );
+    expect(verdict.eligible).toBe(true);
+    vi.useRealTimers();
+  });
+
+  it('REJECTS: age-limit reap with NO active run ⇒ empty evidence ⇒ insufficient-evidence', () => {
+    // No run file written ⇒ autonomousRunRemainingForTopic returns null.
+    const calls: { name: string }[] = [];
+    const { reason, workEvidence } = buildCandidateReason('age-limit', 42, tmpDir, calls);
+    expect(reason).toBe('age-limit'); // untouched
+    expect(workEvidence).toEqual([]);
+    const verdict = classifyEligibility(
+      {
+        sessionName: 's',
+        tmuxSession: 't',
+        topicId: 42,
+        cwd: '/tmp',
+        reason,
+        disposition: 'terminal',
+        origin: 'autonomous',
+        workEvidence,
+      } as ResumeCandidateInput,
+      { includeOperatorKills: false } as never,
+    );
+    expect(verdict.eligible).toBe(false);
+    expect(verdict.why).toBe('insufficient-evidence');
+  });
+
+  it('REJECTS: a run PAST its window ⇒ autonomousRunRemainingForTopic null ⇒ untouched', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-06-14T07:00:00Z'));
+    writeRun(tmpDir, '42', 60, '2026-06-14T00:00:00Z'); // 60s window started 7h ago ⇒ elapsed
+    const { reason, workEvidence } = buildCandidateReason('age-limit', 42, tmpDir, []);
+    expect(reason).toBe('age-limit');
+    expect(workEvidence).toEqual([]);
+    vi.useRealTimers();
+  });
+
+  it('SHORT-CIRCUIT: the cold-path read is NOT called for a non-age-limit reap', () => {
+    writeRun(tmpDir, '42', 86400, new Date().toISOString());
+    const calls: { name: string }[] = [];
+    // A completion / recovery-bounce reap must never touch the state read.
+    buildCandidateReason('completion', 42, tmpDir, calls);
+    buildCandidateReason('recovery-bounce', 42, tmpDir, calls);
+    buildCandidateReason('quota-shed', 42, tmpDir, calls);
+    expect(calls).toHaveLength(0);
+  });
+
+  it('SHORT-CIRCUIT: a null topicId skips the read (topic-resolution race ⇒ safe side)', () => {
+    writeRun(tmpDir, '42', 86400, new Date().toISOString());
+    const calls: { name: string }[] = [];
+    const { reason, workEvidence } = buildCandidateReason('age-limit', null, tmpDir, calls);
+    expect(reason).toBe('age-limit');
+    expect(workEvidence).toEqual([]);
+    expect(calls).toHaveLength(0);
+  });
+
+  it('FAIL-OPEN: a throwing/unreadable state read fails toward NO injection', () => {
+    // Point at a stateDir whose autonomous file is a directory ⇒ read path returns
+    // null (activeAutonomousJobs tolerates a malformed tree). No augmentation, no throw.
+    const { reason, workEvidence } = buildCandidateReason('age-limit', 999, tmpDir, []);
+    expect(reason).toBe('age-limit');
+    expect(workEvidence).toEqual([]);
+  });
+});
+
+describe('dryRun gate resolution (dedicated — NOT via DEV_GATED_FEATURES)', () => {
+  // The exact consumption-site resolution: dryRun: rqCfg.dryRun ?? !resolveDevAgentGate(undefined, config)
+  const resolve = (rqDryRun: boolean | undefined, config: { developmentAgent?: boolean }) =>
+    rqDryRun ?? !resolveDevAgentGate(undefined, config);
+
+  it('dev agent ⇒ dryRun resolves FALSE (live-on-dev)', () => {
+    expect(resolve(undefined, { developmentAgent: true })).toBe(false);
+  });
+
+  it('fleet agent ⇒ dryRun resolves TRUE (observe-only)', () => {
+    expect(resolve(undefined, { developmentAgent: false })).toBe(true);
+    expect(resolve(undefined, {})).toBe(true);
+  });
+
+  it('explicit monitoring.resumeQueue.dryRun: true still WINS on a dev agent', () => {
+    expect(resolve(true, { developmentAgent: true })).toBe(true);
+  });
+
+  it('explicit dryRun: false forces LIVE even on the fleet', () => {
+    expect(resolve(false, { developmentAgent: false })).toBe(false);
+  });
+});
+
+// ── Drain-time liveness re-check ──
+
+interface Harness {
+  queue: ResumeQueue;
+  drainer: ResumeQueueDrainer;
+  respawns: string[];
+  audits: Array<Record<string, unknown>>;
+  advance: (ms: number) => void;
+}
+
+function candidate(over: Partial<ResumeCandidateInput> = {}): ResumeCandidateInput {
+  return {
+    sessionName: 'sess',
+    tmuxSession: 'tmux-1',
+    topicId: 42,
+    resumeUuid: '11111111-1111-4111-8111-111111111111',
+    cwd: '/tmp/project',
+    reason: AGE_LIMIT_ACTIVE_RUN_REASON,
+    disposition: 'terminal',
+    origin: 'autonomous',
+    workEvidence: ['build-or-autonomous-active'],
+    ...over,
+  };
+}
+
+function harness(over?: { deps?: Partial<ResumeQueueDrainerDeps> }): Harness {
+  const audits: Array<Record<string, unknown>> = [];
+  const respawns: string[] = [];
+  let nowMs = 4_000_000_000_000;
+  const queue = new ResumeQueue(
+    { stateDir: tmpDir, audit: (e) => audits.push(e), raiseAggregated: () => {}, now: () => nowMs },
+    { dryRun: false },
+  );
+  queue.start();
+  const deps: ResumeQueueDrainerDeps = {
+    queue,
+    pressureTier: () => 'normal',
+    canSpawnSession: () => true,
+    sessionCountOk: () => true,
+    migrationInFlight: () => false,
+    liveSessionForTopic: () => false,
+    currentResumeUuid: () => '11111111-1111-4111-8111-111111111111',
+    topicOwnerElsewhere: () => false,
+    topicBindingMatches: () => true,
+    operatorStopSince: () => false,
+    jobCheck: () => ({ ok: true }),
+    pathExists: () => true,
+    respawnTopic: async (entry) => { respawns.push(entry.id); return `respawned-${entry.tmuxSession}`; },
+    triggerJob: async () => 'triggered',
+    spawnAliveAfterGrace: async () => true,
+    raiseAggregated: () => {},
+    audit: (e) => audits.push(e),
+    now: () => nowMs,
+    ...over?.deps,
+  };
+  const drainer = new ResumeQueueDrainer(deps, { requiredCalmTicks: 3, tier1Check: false });
+  return { queue, drainer, respawns, audits, advance: (ms) => { nowMs += ms; } };
+}
+
+async function warmCalm(d: ResumeQueueDrainer, ticks = 3): Promise<void> {
+  for (let i = 0; i < ticks; i++) await d.tick();
+}
+
+describe('drain-time liveness re-check (age-limit active-run entry)', () => {
+  it('INVALIDATES autonomous-run-finished with ZERO respawn when the run has ended', async () => {
+    const h = harness({ deps: { autonomousRunFinished: () => true } });
+    h.queue.considerEnqueue(candidate());
+    await warmCalm(h.drainer, 2);
+    const r = await h.drainer.tick();
+    expect(r.invalidated).toBe(1);
+    expect(h.respawns).toHaveLength(0);
+    const inv = h.audits.find((a) => a.event === 'invalidated');
+    expect(inv?.why).toBe('autonomous-run-finished');
+  });
+
+  it('REVIVES normally when the run is STILL active', async () => {
+    const h = harness({ deps: { autonomousRunFinished: () => false } });
+    h.queue.considerEnqueue(candidate());
+    await warmCalm(h.drainer, 2);
+    expect((await h.drainer.tick()).resumed).toBe(true);
+    expect(h.respawns).toHaveLength(1);
+  });
+
+  it('does NOT apply the re-check to a non-age-limit entry (different reason)', async () => {
+    // A normal quota-shed entry must not invalidate even when autonomousRunFinished → true.
+    const h = harness({ deps: { autonomousRunFinished: () => true } });
+    h.queue.considerEnqueue(candidate({ reason: 'quota-shed' }));
+    await warmCalm(h.drainer, 2);
+    expect((await h.drainer.tick()).resumed).toBe(true);
+    expect(h.respawns).toHaveLength(1);
+  });
+
+  it('back-compat: ABSENT autonomousRunFinished dep ⇒ revives normally (today behavior)', async () => {
+    const h = harness(); // no autonomousRunFinished
+    h.queue.considerEnqueue(candidate());
+    await warmCalm(h.drainer, 2);
+    expect((await h.drainer.tick()).resumed).toBe(true);
+    expect(h.respawns).toHaveLength(1);
+  });
+
+  it('a THROWING autonomousRunFinished resolves to NOT-finished (SAFE side ⇒ revives)', async () => {
+    const h = harness({ deps: { autonomousRunFinished: () => { throw new Error('state read'); } } });
+    h.queue.considerEnqueue(candidate());
+    await warmCalm(h.drainer, 2);
+    expect((await h.drainer.tick()).resumed).toBe(true);
+    expect(h.respawns).toHaveLength(1);
+  });
+});

--- a/upgrades/next/resume-idle-autonomous-on-reap.md
+++ b/upgrades/next/resume-idle-autonomous-on-reap.md
@@ -1,0 +1,52 @@
+## What Changed
+
+PR #1155 fixed the misleading NOTICE for an age-limit recycle of an active
+autonomous run ("recycled, no work lost, I'll pick it back up on my next turn").
+This change closes the behavioral gap behind that notice: the run now actually
+comes back on its own, instead of waiting for the next message.
+
+A long autonomous run periodically hits its per-session lifetime cap and gets
+recycled. That age-limit reap fires precisely when the session is IDLE between
+turns — so the Mid-Work Resume Queue saw no in-flight work evidence and never
+queued the run for revival. If the operator was away, the run sat dead until they
+sent a message. Now, when an age-limit reap targets a topic that still has an
+ACTIVE autonomous run, the live run itself counts as the work evidence: the reap
+is admitted to the resume queue and revived through the SAME one-at-a-time,
+quota-gated, resurrection-capped machinery as any other revival.
+
+It stays safe by construction: a double-spawn is caught by the existing
+live-session / resume-uuid drain-time checks (a message-revive that beat the queue
+wins, ZERO second spawn); a run that keeps getting reaped-and-revived hits the
+resurrection cap and gives up loudly with one aggregated notice; a run that has
+since finished (or whose window elapsed) is invalidated at drain time, never
+re-spawned. The resume queue runs LIVE on a development agent and stays
+observe-only on the fleet.
+
+## What to Tell Your User
+
+If you kick off a long autonomous run and walk away: when the session hits its
+per-session lifetime cap and gets recycled, the run now revives itself
+automatically instead of sitting idle until you next message it. You no longer
+have to send a "you still there?" nudge to wake a recycled run back up. Nothing
+double-runs, and a run that has genuinely finished is left alone.
+
+## Summary of New Capabilities
+
+- An age-limit recycle of a topic with an active autonomous run is now admitted to
+  the Mid-Work Resume Queue and auto-revived (the live run is the evidence).
+- A drain-time liveness re-check invalidates an entry whose run finished or whose
+  window elapsed between enqueue and drain (never a wasted respawn).
+- The resume queue resolves live-on-dev (dryRun:false) / observe-only-on-fleet,
+  with an explicit operator override still winning.
+
+## Evidence
+
+- `tests/unit/resume-idle-autonomous.test.ts` — admission both sides, guard
+  short-circuit (non-age-limit / null-topic / fail-open), dryRun-gate resolution
+  (dev/fleet/explicit), drain-time re-check both sides + back-compat + throwing-dep.
+- `tests/integration/resume-idle-autonomous-wiring.test.ts` — real-helper
+  delegation, double-spawn lens (live-session + uuid-stale), lease lens,
+  revival-loop lens (resurrection cap fires exactly once).
+- `tests/e2e/resume-idle-autonomous-lifecycle.test.ts` — feature alive on dev
+  (dryRun:false), enters-and-revives-once + no double spawn, fleet observe-only.
+- `npx tsc --noEmit` clean; lint clean; docs-coverage check passed.

--- a/upgrades/side-effects/resume-idle-autonomous-on-reap.md
+++ b/upgrades/side-effects/resume-idle-autonomous-on-reap.md
@@ -1,0 +1,146 @@
+# Side-Effects Review — Resume an idle autonomous run after an age-limit reap
+
+**Slug:** `resume-idle-autonomous-on-reap`
+**Date:** `2026-06-14`
+**Author:** `echo`
+**Spec:** `docs/specs/resume-idle-autonomous-on-reap.md` (converged + approved)
+**ELI16 companion:** `docs/specs/resume-idle-autonomous-on-reap.eli16.md`
+**Second-pass reviewer:** required (this change makes the resume queue produce
+REAL respawns on a dev agent — a Guard/authority surface). Reviewer concurred.
+
+## Summary of the change
+
+The Mid-Work Resume Queue revives a reaped session only when the reap carried
+mid-work evidence. An **age-limit** reap fires precisely when an autonomous
+session is IDLE between turns (the idle gate requires an idle prompt + no
+non-baseline child processes), so its work evidence is empty by construction —
+and the run is never queued for revival. An away-operator's autonomous run then
+sits dead until the next inbound message.
+
+The fix: when an `age-limit` reap targets a topic that still has an ACTIVE
+autonomous run (`autonomousRunRemainingForTopic(stateDir, topicId) != null`),
+the `sessionReaped` wiring appends the TRUE `build-or-autonomous-active` strong
+signal to the candidate's evidence and tags the reason
+`age-limit (active autonomous run)`. The entry then flows through the EXISTING
+one-at-a-time, quota-gated, resurrection-capped, lease-gated machinery — no new
+respawn path. A drain-time liveness re-check invalidates the entry
+(`autonomous-run-finished`, never a spawn) if the run finished or its window
+elapsed between enqueue and drain. The resume queue resolves **live-on-dev**
+(`dryRun:false`) and stays observe-only on the fleet.
+
+Files touched:
+
+- `src/core/WorkEvidence.ts` — new exported constant
+  `AGE_LIMIT_ACTIVE_RUN_REASON = 'age-limit (active autonomous run)'` (the
+  evidence-vocabulary home; imported by server.ts + ResumeQueueDrainer.ts).
+- `src/commands/server.ts` —
+  (1) the resume-queue `dryRun` config resolves
+  `rqCfg.dryRun ?? !resolveDevAgentGate(undefined, config)` (live-on-dev) at the
+  single consumption site (config + boot log line);
+  (2) the `sessionReaped` candidate construction appends
+  `build-or-autonomous-active` + the reason tag when `reason === 'age-limit'` &&
+  `topicId != null` && `autonomousRunRemainingForTopic(...) != null` (inside the
+  existing enqueue try/catch);
+  (3) the ResumeQueueDrainer deps gain `autonomousRunFinished: (topicId) =>
+  autonomousRunRemainingForTopic(config.stateDir, topicId) == null`.
+- `src/monitoring/ResumeQueueDrainer.ts` — new OPTIONAL injected dep
+  `autonomousRunFinished?: (topicId, reason) => boolean` + a `validateReality`
+  re-check that returns `autonomous-run-finished` for an entry tagged with the
+  age-limit-active-run reason whose run is no longer active. Absent dep ⇒ today's
+  behavior (back-compat).
+- `tests/unit/resume-idle-autonomous.test.ts` — new (15 tests): admission both
+  sides, guard short-circuit, fail-open, dryRun-gate resolution (dev/fleet/explicit),
+  drain-time re-check both sides + back-compat + throwing-dep.
+- `tests/integration/resume-idle-autonomous-wiring.test.ts` — new (8 tests):
+  wiring integrity (real helper delegation), double-spawn lens (live-session +
+  uuid-stale), lease lens, revival-loop lens (resurrection cap fires once).
+- `tests/e2e/resume-idle-autonomous-lifecycle.test.ts` — new (4 tests): feature
+  is alive on dev (dryRun:false through the real AgentServer), enters-and-revives-
+  once + no double spawn, fleet observe-only (dryRun:true, would-resume, no spawn).
+
+## Decision-point inventory
+
+- **`sessionReaped` candidate construction (server.ts)** — **modify** — the
+  wiring layer that OFFERS a reap to the queue. The fix adds a TRUE evidence
+  signal at a SECOND origination site DOWNSTREAM of the SessionManager chokepoint;
+  `considerEnqueue` re-clamps via `clampWorkEvidence` and the token is a valid
+  `STRONG_WORK_EVIDENCE` member, so the enum invariant holds. Authority unchanged:
+  the queue's eligibility/cap/lease gates still decide.
+- **`ResumeQueueDrainer.validateReality`** — **modify** — adds one reality check
+  (a detector). Strictly additive: it can only ADD an invalidation, never wrongly
+  drop a legitimate revival (a throwing/absent dep resolves to NOT-finished, the
+  SAFE side).
+- **resume-queue `dryRun` resolution** — **modify** — flips the queue from
+  observe-only to LIVE on a dev agent. This is the authority change (real respawns
+  + real quota spend on Echo). An explicit operator `monitoring.resumeQueue.dryRun`
+  still wins; the keys stay CODE-defaulted (no ConfigDefaults write) so the fleet
+  flip is preserved.
+- **`AGE_LIMIT_ACTIVE_RUN_REASON`** — **new** — a code-internal string constant;
+  no external/published surface; reversible by changing one string.
+
+---
+
+## 1. Over-block (a gate refuses legitimate work)
+
+The drain-time re-check can only ADD an `autonomous-run-finished` invalidation,
+and only for an entry whose run genuinely returned `null` (completed or window
+elapsed) — exactly the case the spec wants NOT revived. A throwing/absent
+`autonomousRunFinished` resolves to NOT-finished, so a transient state-read error
+never blocks a legitimate revival. No over-block on the kill path: the augmentation
+sits inside the existing enqueue try/catch and a throw fails toward no-injection
+(status-quo no-revive), never toward endangering the reap.
+
+## 2. Under-block (a gate lets through what it should stop)
+
+Double-spawn is the #1 lens: an age-limit entry is an ordinary topic-bound entry
+once admitted, so `validateReality`'s `live-session-exists` + `resume-uuid-stale`
+catches catch a message-revive that happened between enqueue and drain (named
+tests in the integration tier — both ZERO respawn). The resurrection cap reads
+`tombstoneFor(stableKey)` (derived purely from topicId), never `workEvidence`, so
+the injected evidence CANNOT reset or evade the cap (named test). Only the literal
+`age-limit` reason is augmented — watchdog-stuck/idle-zombie/context-wedge/AUP-wedge
+and moved-topic reaps stay excluded.
+
+## 3. Reversibility
+
+`dryRun` flips back to observe-only by setting `monitoring.resumeQueue.dryRun: true`
+(or via the fleet default). The reason tag + evidence injection is a one-string +
+one-evidence-name change. The drainer dep is OPTIONAL — removing it restores prior
+behavior. NOTE: flipping `dryRun` back does NOT un-spend quota already burned by a
+respawn that already fired — see Frontloaded Decision D1 (classified NON-cheap,
+accepted under the named live phase).
+
+## 4. Blast radius / interactions
+
+The augmentation runs ONLY on `age-limit` reaps (the cold-path
+`autonomousRunRemainingForTopic` read is behind the `reason === 'age-limit'`
+short-circuit), so every other reap pays zero added cost. It reads the LOCAL
+autonomous-run state file (same vantage that admitted the entry). Coupling risk
+(D2): if a future maintainer narrows `build-or-autonomous-active` to mean strictly
+"a live child build process", this reuse silently breaks — flagged here.
+
+## 5. Multi-machine (Phase-C) posture
+
+Machine-local by design: the resume queue is per-machine (single-writer lock), the
+age-limit reap is observed on the machine the session ran on, and only the
+lease-holder drains it (`validateReality` returns `topic-owner-elsewhere` otherwise
+— named test). A run MOVED to another machine reaches the queue as `topic moved …`
+(already `eligible:false`), not `age-limit`, so it is never double-revived.
+
+## 6. Migration parity
+
+NONE required — and that is correct. The `dryRun` resolution is a CODE default read
+at server boot, not a persisted `.instar/config.json` field, so existing agents pick
+it up on their next restart after update. A `migrateConfig` entry would freeze
+`dryRun` to disk and break the later fleet flip — the resume-queue keys must stay
+un-frozen in ConfigDefaults. No CLAUDE.md template change (internal plumbing, no new
+route or user-facing capability).
+
+## 7. Signal vs. authority
+
+The injected `build-or-autonomous-active` is a TRUE assertion about the world
+(the run is genuinely in-flight per the un-elapsed state file), supplied from the
+one vantage that can observe it — the opposite of lying to a classifier. The
+drain-time re-check is a detector that feeds the existing invalidation authority;
+it never spawns. The only authority change is the `dryRun` flip, which is bounded
+by the existing one-at-a-time / calm-ticks / quota / lease / resurrection-cap gates.


### PR DESCRIPTION
## ELI16 — when a long autonomous run gets recycled at its lifetime cap while you're away, it now revives itself instead of sitting dead until you message it.

Implements the converged + approved spec `docs/specs/resume-idle-autonomous-on-reap.md` (#1156). Companion ELI16: `docs/specs/resume-idle-autonomous-on-reap.eli16.md`.

## The gap

An **age-limit** reap fires precisely when an autonomous session is IDLE between turns (the idle gate requires an idle prompt + no non-baseline child processes). So its work evidence is empty by construction → the Mid-Work Resume Queue never queues it for revival → an away-operator's autonomous run sits dead until the next inbound message. PR #1155 fixed the misleading NOTICE; this closes the behavioral gap behind it.

## The fix (reuse-only, no new respawn path)

When an `age-limit` reap targets a topic that still has an ACTIVE autonomous run (`autonomousRunRemainingForTopic(stateDir, topicId) != null`), the `sessionReaped` wiring appends the TRUE `build-or-autonomous-active` strong signal and tags the reason `age-limit (active autonomous run)`. The entry flows through the EXISTING one-at-a-time, quota-gated, resurrection-capped, lease-gated machinery. A drain-time liveness re-check invalidates the entry (`autonomous-run-finished`, never a spawn) if the run finished or its window elapsed between enqueue and drain.

**Files:** `src/core/WorkEvidence.ts` (new `AGE_LIMIT_ACTIVE_RUN_REASON` const), `src/commands/server.ts` (age-limit augmentation + live-on-dev dryRun resolution + `autonomousRunFinished` wiring), `src/monitoring/ResumeQueueDrainer.ts` (optional `autonomousRunFinished` dep + `validateReality` re-check), plus 3-tier tests (27 new).

## Adversarial-review verdict

- **DOUBLE-SPAWN (#1 blocker): PASS.** An age-limit entry is an ordinary topic-bound entry once admitted, so `validateReality`'s `live-session-exists` + `resume-uuid-stale` catch a message-revive that beat the queue — ZERO second spawn. Named tests in the integration tier (both catches) and an end-to-end "enters → revives once → second drain does NOT re-spawn" in the e2e tier.
- **REVIVAL-LOOP: PASS.** The resurrection cap reads `tombstoneFor(stableKey)` (derived purely from topicId), never `workEvidence`, so the injected evidence CANNOT reset or evade the cap. An age-reap → revive → re-age-reap loop hits `maxResurrections` and gives up LOUDLY with exactly ONE aggregated `resurrection-cap` notice. Named integration tests (cap fires once; injected evidence cannot reset the tombstone).

## Phase-C (N-machine) posture

Machine-local by design: the resume queue is per-machine (single-writer lock), the age-limit reap is observed on the machine the session ran on, and only the lease-holder drains it (`validateReality` → `topic-owner-elsewhere` otherwise — named test). A run MOVED to another machine reaches the queue as `topic moved …` (already `eligible:false`), not `age-limit`, so it is never double-revived. No new cross-machine state.

## Live-on-dev / observe-only-on-fleet

The resume queue resolves `dryRun: rqCfg.dryRun ?? !resolveDevAgentGate(undefined, config)` at the single consumption site — LIVE (real respawns) on a dev agent, observe-only on the fleet. An explicit operator `monitoring.resumeQueue.dryRun` still wins; keys stay CODE-defaulted (no ConfigDefaults write) so the fleet flip is preserved. No migration required (a code default read at boot). Dedicated unit test locks the resolution (dev → false, fleet → true, explicit-true wins on dev).

## Tests (3 tiers)

- `tests/unit/resume-idle-autonomous.test.ts` (15) — admission both sides, guard short-circuit, fail-open, dryRun-gate resolution, drain-time re-check both sides + back-compat + throwing-dep.
- `tests/integration/resume-idle-autonomous-wiring.test.ts` (8) — wiring integrity (real helper delegation), double-spawn + lease + revival-loop lenses.
- `tests/e2e/resume-idle-autonomous-lifecycle.test.ts` (4) — feature alive on dev (dryRun:false), enters-and-revives-once + no double spawn, fleet observe-only.

`tsc --noEmit` clean; full lint clean; docs-coverage check passed; dark-gate unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)