### PR TITLE
fix(slack): slugify workspace name before creating system channels

### DIFF
--- a/.instar/instar-dev-decisions/2026-06-14T10-49-01-327Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-06-14T10-49-01-327Z-unknown.json
@@ -1,0 +1,13 @@
+{
+  "ts": "2026-06-14T10:49:01.327Z",
+  "slug": "unknown",
+  "suggestedTier": 1,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 2,
+  "loc": 30,
+  "causalAutopsy": null,
+  "verdict": "pass"
+}

--- a/.instar/instar-dev-decisions/2026-06-14T10-49-59-199Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-06-14T10-49-59-199Z-unknown.json
@@ -1,0 +1,13 @@
+{
+  "ts": "2026-06-14T10:49:59.199Z",
+  "slug": "unknown",
+  "suggestedTier": 1,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 5,
+  "causalAutopsy": null,
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-06-14T10-50-32-164Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-06-14T10-50-32-164Z-unknown.json
@@ -1,0 +1,13 @@
+{
+  "ts": "2026-06-14T10:50:32.164Z",
+  "slug": "unknown",
+  "suggestedTier": 1,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 5,
+  "causalAutopsy": null,
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-06-14T10-51-07-199Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-06-14T10-51-07-199Z-unknown.json
@@ -1,0 +1,13 @@
+{
+  "ts": "2026-06-14T10:51:07.199Z",
+  "slug": "unknown",
+  "suggestedTier": 1,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 2,
+  "loc": 35,
+  "causalAutopsy": null,
+  "verdict": "pass"
+}

--- a/docs/specs/slack-system-channel-slugify.eli16.md
+++ b/docs/specs/slack-system-channel-slugify.eli16.md
@@ -1,0 +1,33 @@
+# Slack System-Channel Name Slugify — Plain-English Overview
+
+> The one-line version: when an agent's Slack workspace name has spaces or capitals (like "SageMind Live Test"), the agent could no longer create its Slack Updates and Attention channels — this fixes the name it asks Slack for so those channels actually get created.
+
+## The problem in one breath
+
+When an instar agent connects to Slack, it tries to create two housekeeping channels at startup: an "Updates" channel (for version/feature announcements) and an "Attention" channel (for alerts that need you). It builds the channel name from the workspace name — but it forgot to clean that name up first. Slack only accepts channel names that are lowercase letters, digits, and hyphens, so a workspace called "SageMind Live Test" produced the name "SageMind Live Test-sys-updates", which Slack rejected outright. The result: the Updates channel was never created, and every server boot logged `Failed to create Slack Updates channel: Invalid channel name`.
+
+## What already exists
+
+- **The Slack adapter's session channels** — when the agent spins up a per-conversation Slack channel, it already cleans the name correctly: it lowercases the workspace name and replaces anything that isn't a letter or digit with a hyphen (the `<workspace>-sess-...` pattern in `SlackAdapter`). That path has always worked.
+- **The channel-name validator** — `ChannelManager.createChannel` runs every requested name through `validateChannelName` (in `src/messaging/slack/sanitize.ts`) and throws if the name isn't lowercase-alphanumeric-with-hyphens. This is the gate that was correctly rejecting the bad names.
+- **The two system-channel creators** — `ensureSlackUpdatesChannel` and `ensureSlackAttentionChannel` in `src/commands/server.ts` build their names directly from the workspace name. These are the two callers that skipped the cleanup step.
+
+## What this adds
+
+One small shared helper, `slugifyChannelName`, placed right next to the validator it has to satisfy (in `sanitize.ts`), and used by both system-channel creators. It does exactly what the session-channel path already did — lowercase, turn every non-`[a-z0-9]` character into a hyphen, collapse repeated hyphens, trim the ends, and fall back to `"agent"` if the name empties out entirely. Both `ensureSlackUpdatesChannel` and `ensureSlackAttentionChannel` now run the workspace-derived name through it before appending `-sys-updates` / `-sys-attention`.
+
+## The new pieces
+
+- **`slugifyChannelName(raw)`** — a pure, no-side-effect string helper. It takes a raw name segment and returns a Slack-channel-safe slug. It is deliberately co-located with `validateChannelName` so the cleanup rule and the validation rule can't drift apart over time. It is NOT a gate, a sentinel, or anything that makes a decision about agent behavior — it just produces a valid name.
+
+## The safeguards
+
+**No behavior change for already-valid names.** A workspace name that was already lowercase-and-hyphenated (like `echo` or `ai-guy`) passes through untouched, so existing agents whose channels already work see zero change.
+
+**The fix is proven, not asserted.** The unit test includes the exact failing case ("SageMind Live Test") and checks both that the slug is correct AND that the full `<slug>-sys-updates` name now passes the real `validateChannelName` gate — plus a test that confirms the OLD un-slugified name would have failed, so the regression can't silently come back.
+
+**It can never produce an empty or invalid name.** If a workspace name is all symbols (or blank), the helper falls back to `"agent"`, which is itself valid — so the channel creation can't fail a different way.
+
+## What ships when
+
+This is a single Tier-1 fix: one helper, two one-line caller changes, one unit test. It ships in one PR. It is single-machine behavior with no multi-machine, replication, or cross-agent surface — the Slack channel set is created locally on whichever machine fronts the Slack connection.

--- a/src/commands/server.ts
+++ b/src/commands/server.ts
@@ -20,6 +20,7 @@ import { loadConfig, ensureStateDir, detectTmuxPath, detectGeminiPath } from '..
 import { isNonFatalUncaught, shouldLogStackForUncaught } from '../core/uncaughtExceptionPolicy.js';
 import { resolveDevAgentGate, resolveStateSyncStores } from '../core/devAgentGate.js';
 import { parseProfileTrigger, platformMessageIdFrom } from '../core/topicProfileIngress.js';
+import { slugifyChannelName } from '../messaging/slack/sanitize.js';
 import {
   TopicProfileOrchestrator,
   resolvedToApplied,
@@ -2583,7 +2584,7 @@ async function ensureSlackAttentionChannel(
   }
 
   try {
-    const agentName = (slack as unknown as { config: { workspaceName?: string } }).config?.workspaceName?.replace(/-agent$/, '') || 'agent';
+    const agentName = slugifyChannelName((slack as unknown as { config: { workspaceName?: string } }).config?.workspaceName?.replace(/-agent$/, '') || 'agent');
     const channelId = await slack.createChannel(`${agentName}-sys-attention`);
     state.set('slack-attention-channel', channelId);
     await slack.sendToChannel(channelId,
@@ -2606,7 +2607,7 @@ async function ensureSlackUpdatesChannel(
   if (existingChannelId) return;
 
   try {
-    const agentName = (slack as unknown as { config: { workspaceName?: string } }).config?.workspaceName?.replace(/-agent$/, '') || 'agent';
+    const agentName = slugifyChannelName((slack as unknown as { config: { workspaceName?: string } }).config?.workspaceName?.replace(/-agent$/, '') || 'agent');
     const channelId = await slack.createChannel(`${agentName}-sys-updates`);
     state.set('slack-updates-channel', channelId);
     await slack.sendToChannel(channelId,

--- a/src/messaging/slack/sanitize.ts
+++ b/src/messaging/slack/sanitize.ts
@@ -3,6 +3,11 @@
  *
  * Prevents prompt injection, path traversal, and SSRF attacks
  * by validating and cleaning user-controlled fields before use.
+ *
+ * CONTRACT-EVIDENCE: EXEMPT — this module is pure local string
+ * validation/transformation; it makes no Slack API calls and touches no
+ * API-contract surface. The change here adds `slugifyChannelName`, a pure
+ * helper covered by unit tests; live-API contract tests are not applicable.
  */
 
 const CHANNEL_ID_PATTERN = /^[CDG][A-Z0-9]{8,12}$/;
@@ -39,6 +44,31 @@ export function validateChannelId(id: string): boolean {
  */
 export function validateChannelName(name: string): boolean {
   return CHANNEL_NAME_PATTERN.test(name);
+}
+
+/**
+ * Slugify an agent/workspace-derived segment into a Slack-channel-safe form.
+ *
+ * Slack channel names must be lowercase alphanumeric with hyphens/underscores
+ * (see {@link validateChannelName}). A raw workspaceName such as
+ * "SageMind Live Test" otherwise produces an invalid name like
+ * "SageMind Live Test-sys-updates" that `ChannelManager.createChannel`
+ * rejects. This mirrors the session-channel slugify in `SlackAdapter`
+ * (`<workspace>-sess-...`): lowercase, replace every non-`[a-z0-9]` char with
+ * a hyphen, collapse runs, trim leading/trailing hyphens. Falls back to
+ * "agent" when the input slugs away to empty.
+ *
+ * The result is a single name SEGMENT (callers append suffixes like
+ * `-sys-updates`); it is intentionally not length-clamped here so a short
+ * suffix still fits inside Slack's 80-char limit.
+ */
+export function slugifyChannelName(raw: string): string {
+  const slug = raw
+    .toLowerCase()
+    .replace(/[^a-z0-9]/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^-|-$/g, '');
+  return slug || 'agent';
 }
 
 /**

--- a/tests/unit/slack-channel-slugify.test.ts
+++ b/tests/unit/slack-channel-slugify.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest';
+import { slugifyChannelName, validateChannelName } from '../../src/messaging/slack/sanitize.js';
+
+/**
+ * Regression coverage for the Slack system-channel name bug:
+ * `ensureSlackUpdatesChannel` / `ensureSlackAttentionChannel` in
+ * src/commands/server.ts built `${agentName}-sys-updates` from an
+ * un-slugified workspaceName, so a name like "SageMind Live Test"
+ * produced "SageMind Live Test-sys-updates" which `validateChannelName`
+ * (and therefore `ChannelManager.createChannel`) rejected with
+ * "Invalid channel name". The fix slugifies the segment first.
+ */
+describe('slugifyChannelName', () => {
+  it('slugifies a workspace name with spaces and uppercase (the bug case)', () => {
+    expect(slugifyChannelName('SageMind Live Test')).toBe('sagemind-live-test');
+  });
+
+  it('produces a name that passes validateChannelName when suffixed (the actual failure path)', () => {
+    const seg = slugifyChannelName('SageMind Live Test');
+    // The exact call shape the server makes for the two system channels.
+    expect(validateChannelName(`${seg}-sys-updates`)).toBe(true);
+    expect(validateChannelName(`${seg}-sys-attention`)).toBe(true);
+  });
+
+  it('demonstrates the un-slugified name would have FAILED validation (proves the bug was real)', () => {
+    expect(validateChannelName('SageMind Live Test-sys-updates')).toBe(false);
+  });
+
+  it('leaves an already-valid lowercase-hyphenated name unchanged', () => {
+    expect(slugifyChannelName('echo')).toBe('echo');
+    expect(slugifyChannelName('ai-guy')).toBe('ai-guy');
+  });
+
+  it('collapses runs of separators and trims leading/trailing hyphens', () => {
+    expect(slugifyChannelName('  Dawn   //  Portal!! ')).toBe('dawn-portal');
+    expect(slugifyChannelName('---Hello---')).toBe('hello');
+  });
+
+  it('strips symbols, underscores-from-non-alnum, and unicode to hyphens', () => {
+    expect(slugifyChannelName('Acme™ Corp (Prod)')).toBe('acme-corp-prod');
+  });
+
+  it('falls back to "agent" when the input slugs away to empty', () => {
+    expect(slugifyChannelName('!!!')).toBe('agent');
+    expect(slugifyChannelName('   ')).toBe('agent');
+    expect(slugifyChannelName('')).toBe('agent');
+  });
+
+  it('preserves digits', () => {
+    expect(slugifyChannelName('Team 42 Alpha')).toBe('team-42-alpha');
+  });
+});

--- a/upgrades/next/slack-system-channel-slugify.md
+++ b/upgrades/next/slack-system-channel-slugify.md
@@ -1,0 +1,17 @@
+## What Changed
+
+Fixed a bug where an agent could not create its Slack **Updates** and **Attention** channels when its Slack workspace name contained spaces or uppercase letters. At startup the server built the channel name (`<workspace>-sys-updates` / `-sys-attention`) directly from the workspace name without normalizing it, so a workspace like "SageMind Live Test" produced "SageMind Live Test-sys-updates" — which Slack rejects as an invalid channel name, logging `Failed to create Slack Updates channel: Invalid channel name` on every boot. A new shared `slugifyChannelName` helper (in `src/messaging/slack/sanitize.ts`, next to the validator it must satisfy) now normalizes the name — lowercase, non-alphanumeric → hyphens, collapse/trim — exactly like the per-session Slack channel path already did. Both `ensureSlackUpdatesChannel` and `ensureSlackAttentionChannel` use it.
+
+## What to Tell Your User
+
+If your Slack workspace name has spaces or capital letters, your agent's Updates and Attention channels will now be created correctly (they may have been silently failing before). Nothing to do on your end — it takes effect on the next server start. Agents whose workspace name was already all-lowercase-with-hyphens see no change.
+
+## Summary of New Capabilities
+
+None — this is a bug fix. No new API routes, config, or user-facing capability; it restores Slack system-channel creation for workspaces with non-slug-safe names.
+
+## Evidence
+
+- New unit test `tests/unit/slack-channel-slugify.test.ts` (8 cases) — covers the exact failing input ("SageMind Live Test"), asserts the slug + the full `<slug>-sys-updates` name passes the real `validateChannelName` gate, and includes a test proving the OLD un-slugified name would have failed (regression lock).
+- Live reproduction observed at authoring: `logs/server.log` on the SageMind Live Test workspace showed `Failed to create Slack Updates channel: Error: Invalid channel name: "SageMind Live Test-sys-updates"` on every boot.
+- Full lint (`pnpm lint`: tsc --noEmit + 15 custom lints incl. dev-agent-dark-gate) clean; `pnpm build` clean.

--- a/upgrades/side-effects/slack-system-channel-slugify.md
+++ b/upgrades/side-effects/slack-system-channel-slugify.md
@@ -1,0 +1,68 @@
+# Side-Effects Review — Slack system-channel name slugify
+
+**Version / slug:** `slack-system-channel-slugify`
+**Date:** 2026-06-14
+**Author:** Echo (Instar Agent)
+**Second-pass reviewer:** not required (no block/allow/dispatch/session-lifecycle/gate/sentinel surface — see §4)
+
+## Summary of the change
+
+At server startup, `ensureSlackUpdatesChannel` and `ensureSlackAttentionChannel` (`src/commands/server.ts`) build a Slack channel name as `${workspaceName-stripped}-sys-updates` / `-sys-attention`, but passed the workspace-derived segment to `slack.createChannel` WITHOUT slugifying it. `ChannelManager.createChannel` validates the name via `validateChannelName` (`src/messaging/slack/sanitize.ts`) and throws on any non-`[a-z0-9-_]` content, so a workspace name with spaces/uppercase (e.g. "SageMind Live Test") yielded "SageMind Live Test-sys-updates" → rejected, and the Updates channel was never created (observed live: `Failed to create Slack Updates channel: Invalid channel name`). The session-channel path (`SlackAdapter.ts:1707`) already slugifies. This change adds a shared `slugifyChannelName` helper in `sanitize.ts` (co-located with the validator) and applies it in both system-channel creators. Files touched: `src/messaging/slack/sanitize.ts` (new exported helper), `src/commands/server.ts` (import + 2 caller swaps), `tests/unit/slack-channel-slugify.test.ts` (new).
+
+## Decision-point inventory
+
+This change touches NO decision point. It produces a valid string; it does not gate information flow, block actions, filter messages, or constrain agent behavior.
+
+- `slugifyChannelName` — add — pure string transform (name → Slack-safe name); no decision logic, no authority.
+
+---
+
+## 1. Over-block
+
+**No block/allow surface — over-block not applicable.** The helper never rejects input; for any string it returns a valid channel-name segment (falling back to `"agent"` when the input slugs to empty).
+
+---
+
+## 2. Under-block
+
+**No block/allow surface — under-block not applicable.** The downstream `validateChannelName` gate is unchanged and still rejects anything invalid; this change only ensures the names we generate are valid before they reach that gate.
+
+---
+
+## 3. Level-of-abstraction fit
+
+Correct layer. The slugifier lives in `sanitize.ts` directly beside `validateChannelName` (the rule it must satisfy), so the cleanup rule and the validation rule are co-located and can't drift. It is a low-level pure primitive (a detector-class string helper, no reasoning, no authority). It does NOT re-implement a higher gate — it FEEDS the existing `validateChannelName`/`createChannel` path with a conformant name. The session-channel path duplicated the same `toLowerCase().replace(/[^a-z0-9]/g,'-')` inline; this change makes the canonical version shared and exported (a small consolidation; the inline session-channel copy is left untouched to keep the diff minimal and avoid touching the working hot path — behaviorally identical, no functional drift).
+
+---
+
+## 4. Signal vs authority compliance
+
+Compliant. The change adds NO blocking authority. `slugifyChannelName` is a pure value-producer with no decision power (per `docs/signal-vs-authority.md`, it is neither a detector-with-authority nor a brittle gate). No second-pass review required: the change has no block/allow on messaging or dispatch, no session lifecycle, no compaction/recovery, no coherence/idempotency/trust surface, and no "sentinel/guard/gate/watchdog" component.
+
+---
+
+## 5. Interactions
+
+- Does NOT shadow or get shadowed by another check: the only adjacent check is `validateChannelName`, which this FEEDS (produces a name that passes it) rather than duplicating or bypassing.
+- No double-fire: the two callers are idempotent already (each returns early if the channel id is already in state); the slug is deterministic, so a re-run produces the identical name.
+- No race with cleanup: the session-channel archiver (`SlackAdapter` periodic, archives only `-sess-` channels) does not touch `-sys-updates`/`-sys-attention` channels — different name family, unaffected.
+
+---
+
+## 6. External surfaces
+
+- Visible change: agents whose workspace name contains spaces/uppercase will now successfully create their `-sys-updates` and `-sys-attention` Slack channels (previously failed). The channel NAME for such agents changes from "never created" to a slugified name (e.g. `sagemind-live-test-sys-updates`).
+- For agents whose workspace name was already slug-valid (lowercase/hyphenated), the produced name is byte-identical to before — zero observable change.
+- No dependency on timing, conversation state, or runtime conditions. The transform is pure and deterministic.
+
+---
+
+## 7. Multi-machine posture (Cross-Machine Coherence)
+
+**Machine-local BY DESIGN.** Slack system-channel creation runs at server startup on whichever machine fronts the Slack Socket-Mode connection; the channel ids are persisted to that machine's local `StateManager` (`slack-updates-channel` / `slack-attention-channel`). There is no cross-machine replication concern: the slug is a deterministic function of the (shared) workspace name, so every machine that runs this path computes the IDENTICAL name and Slack's own create-or-find semantics converge on one channel. No durable state to strand on topic transfer; no generated URL; no user-facing notice. The change neither adds nor removes any multi-machine surface.
+
+---
+
+## 8. Rollback cost
+
+Trivial. Pure additive helper + two one-line caller swaps. Back-out is a one-commit revert (no data migration, no agent state repair, no fleet coordination). The worst-case if the fix were wrong is the pre-existing behavior (channel fails to create and logs an error) — strictly no worse than today.


### PR DESCRIPTION
## What this fixes

Agents whose Slack workspace name contains spaces or uppercase letters (e.g. "SageMind Live Test") could not create their Slack **Updates** and **Attention** system channels. `ensureSlackUpdatesChannel` / `ensureSlackAttentionChannel` in `src/commands/server.ts` built the channel name from an un-slugified workspace name, which `ChannelManager.createChannel` rejects via `validateChannelName`. Observed live on every boot: `Failed to create Slack Updates channel: Error: Invalid channel name: "SageMind Live Test-sys-updates"`.

The session-channel path (`SlackAdapter.ts:1707`) already slugifies. This adds a shared `slugifyChannelName` helper in `src/messaging/slack/sanitize.ts` (co-located with the validator it must satisfy) and applies it in both system-channel creators.

## Tier

**Tier 1.** Pure string helper + 2 one-line caller swaps + 1 unit test. No decision point, no API-contract surface. `sanitize.ts` carries `CONTRACT-EVIDENCE: EXEMPT` (pure local string validation, no Slack API calls).

## Tests

- `tests/unit/slack-channel-slugify.test.ts` (8 cases): the exact failing input, the slug + `validateChannelName` round-trip for both `-sys-updates`/`-sys-attention`, a regression-lock proving the OLD un-slugified name would fail, plus edge cases (empty→"agent" fallback, symbol/unicode stripping, digit preservation).
- Full `pnpm lint` (tsc --noEmit + 15 custom lints incl. dev-agent-dark-gate) clean; `pnpm build` clean; pre-push suite 139/139 green.

Side-effects artifact: `upgrades/side-effects/slack-system-channel-slugify.md`. Durable ELI16 companion: `docs/specs/slack-system-channel-slugify.eli16.md`.

---

# ELI16 — Slack System-Channel Name Slugify (Plain-English Overview)

When an instar agent connects to Slack, it creates two housekeeping channels at startup: an "Updates" channel (version/feature announcements) and an "Attention" channel (alerts that need you). It builds each channel's name from the workspace name — but it forgot to clean that name up first. Slack only accepts channel names that are lowercase letters, digits, and hyphens, so a workspace called "SageMind Live Test" produced the name "SageMind Live Test-sys-updates", which Slack rejected outright. The result: the Updates channel was never created, and every server boot logged "Failed to create Slack Updates channel: Invalid channel name". This change adds one small shared helper, `slugifyChannelName`, placed right next to the validator it has to satisfy, and used by both system-channel creators. It does exactly what the existing per-session Slack channel path already did: lowercase the name, turn every non-alphanumeric character into a hyphen, collapse repeated hyphens, trim the ends, and fall back to "agent" if the name empties out entirely.

## What's safe about it

**No behavior change for already-valid names.** A workspace name that was already lowercase-and-hyphenated (like `echo` or `ai-guy`) passes through untouched, so existing agents whose channels already work see zero change. **The fix is proven, not asserted:** the unit test includes the exact failing case ("SageMind Live Test") and checks both that the slug is correct AND that the full `<slug>-sys-updates` name now passes the real `validateChannelName` gate — plus a test that confirms the OLD un-slugified name would have failed, so the regression can't silently come back. **It can never produce an empty or invalid name:** an all-symbols or blank workspace name falls back to "agent", which is itself valid.

## Multi-machine posture

Machine-local by design. Slack system-channel creation runs at server startup on whichever machine fronts the Slack connection; the channel ids are persisted to that machine's local state. The slug is a deterministic function of the (shared) workspace name, so every machine computes the identical name and Slack's create-or-find semantics converge on one channel. No replication, no generated URL, no durable state to strand on a topic move.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- re-trigger eli16 gate with corrected ELI16 heading -->
