### PR TITLE
fix(slack): slugify Updates/Attention channel names before createChannel

### DIFF
--- a/.instar/instar-dev-decisions/2026-06-14T10-50-32-333Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-06-14T10-50-32-333Z-unknown.json
@@ -1,0 +1,13 @@
+{
+  "ts": "2026-06-14T10:50:32.333Z",
+  "slug": "unknown",
+  "suggestedTier": 1,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 4,
+  "causalAutopsy": null,
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-06-14T10-51-21-964Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-06-14T10-51-21-964Z-unknown.json
@@ -1,0 +1,13 @@
+{
+  "ts": "2026-06-14T10:51:21.964Z",
+  "slug": "unknown",
+  "suggestedTier": 1,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 2,
+  "loc": 29,
+  "causalAutopsy": null,
+  "verdict": "pass"
+}

--- a/.instar/instar-dev-decisions/2026-06-14T10-52-04-251Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-06-14T10-52-04-251Z-unknown.json
@@ -1,0 +1,13 @@
+{
+  "ts": "2026-06-14T10:52:04.251Z",
+  "slug": "unknown",
+  "suggestedTier": 1,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 2,
+  "loc": 29,
+  "causalAutopsy": null,
+  "verdict": "pass"
+}

--- a/src/commands/server.ts
+++ b/src/commands/server.ts
@@ -20,6 +20,7 @@ import { loadConfig, ensureStateDir, detectTmuxPath, detectGeminiPath } from '..
 import { isNonFatalUncaught, shouldLogStackForUncaught } from '../core/uncaughtExceptionPolicy.js';
 import { resolveDevAgentGate, resolveStateSyncStores } from '../core/devAgentGate.js';
 import { parseProfileTrigger, platformMessageIdFrom } from '../core/topicProfileIngress.js';
+import { slugifyChannelName } from '../messaging/slack/sanitize.js';
 import {
   TopicProfileOrchestrator,
   resolvedToApplied,
@@ -2584,7 +2585,7 @@ async function ensureSlackAttentionChannel(
 
   try {
     const agentName = (slack as unknown as { config: { workspaceName?: string } }).config?.workspaceName?.replace(/-agent$/, '') || 'agent';
-    const channelId = await slack.createChannel(`${agentName}-sys-attention`);
+    const channelId = await slack.createChannel(slugifyChannelName(`${agentName}-sys-attention`));
     state.set('slack-attention-channel', channelId);
     await slack.sendToChannel(channelId,
       `Attention channel active. Blocked tasks, critical errors, quota alerts, and anything that needs your attention will appear here.`
@@ -2607,7 +2608,7 @@ async function ensureSlackUpdatesChannel(
 
   try {
     const agentName = (slack as unknown as { config: { workspaceName?: string } }).config?.workspaceName?.replace(/-agent$/, '') || 'agent';
-    const channelId = await slack.createChannel(`${agentName}-sys-updates`);
+    const channelId = await slack.createChannel(slugifyChannelName(`${agentName}-sys-updates`));
     state.set('slack-updates-channel', channelId);
     await slack.sendToChannel(channelId,
       `Updates channel active. Version updates, new features, and system announcements will appear here.`

--- a/src/messaging/slack/sanitize.ts
+++ b/src/messaging/slack/sanitize.ts
@@ -3,6 +3,10 @@
  *
  * Prevents prompt injection, path traversal, and SSRF attacks
  * by validating and cleaning user-controlled fields before use.
+ *
+ * CONTRACT-EVIDENCE: EXEMPT — pure string-validation/slug helpers; this module
+ * makes NO Slack API calls and touches no API-contract surface. The added
+ * slugifyChannelName is covered by tests/unit/slack-channel-slug.test.ts.
  */
 
 const CHANNEL_ID_PATTERN = /^[CDG][A-Z0-9]{8,12}$/;
@@ -39,6 +43,26 @@ export function validateChannelId(id: string): boolean {
  */
 export function validateChannelName(name: string): boolean {
   return CHANNEL_NAME_PATTERN.test(name);
+}
+
+/**
+ * Slugify an arbitrary string into a valid Slack channel name.
+ *
+ * Slack channel names must be lowercase and may only contain [a-z0-9-_]
+ * (see {@link validateChannelName}). A workspace-derived name like
+ * "SageMind Live Test" contains spaces and uppercase, which `createChannel`
+ * rejects via validate-and-throw. This produces a guaranteed-valid slug:
+ * lowercase, non-[a-z0-9] runs collapsed to a single hyphen, leading/trailing
+ * hyphens trimmed, and clamped to Slack's 80-char limit.
+ *
+ * Mirrors the session-channel slug logic in SlackAdapter.
+ */
+export function slugifyChannelName(name: string): string {
+  return name
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 80);
 }
 
 /**

--- a/tests/unit/slack-channel-slug.test.ts
+++ b/tests/unit/slack-channel-slug.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from 'vitest';
+import { slugifyChannelName, validateChannelName } from '../../src/messaging/slack/sanitize.js';
+
+// Regression: the Slack Updates/Attention channel callers passed an un-slugified
+// workspace-derived name (e.g. "SageMind Live Test-sys-updates") straight into
+// ChannelManager.createChannel, which validate-and-throws on names that aren't
+// lowercase [a-z0-9-_]. The fix slugifies caller-side, mirroring the session-channel
+// slug. These tests assert the slug is always a valid Slack channel name.
+
+describe('slugifyChannelName', () => {
+  describe('produces a valid Slack channel name', () => {
+    it('slugifies the exact failing Updates-channel name', () => {
+      // The live failure: "SageMind Live Test-sys-updates"
+      const slug = slugifyChannelName('SageMind Live Test-sys-updates');
+      expect(slug).toBe('sagemind-live-test-sys-updates');
+      // ...and crucially, createChannel would NOT throw on it:
+      expect(validateChannelName(slug)).toBe(true);
+    });
+
+    it('slugifies the Attention-channel variant', () => {
+      const slug = slugifyChannelName('SageMind Live Test-sys-attention');
+      expect(slug).toBe('sagemind-live-test-sys-attention');
+      expect(validateChannelName(slug)).toBe(true);
+    });
+
+    it('lowercases uppercase', () => {
+      expect(slugifyChannelName('AGENT-sys-updates')).toBe('agent-sys-updates');
+    });
+
+    it('collapses spaces to single hyphens', () => {
+      const slug = slugifyChannelName('my   agent   name');
+      expect(slug).toBe('my-agent-name');
+      expect(validateChannelName(slug)).toBe(true);
+    });
+
+    it('strips disallowed punctuation', () => {
+      const slug = slugifyChannelName("Justin's Agent! (prod)");
+      expect(validateChannelName(slug)).toBe(true);
+      expect(slug).toBe('justin-s-agent-prod');
+    });
+
+    it('trims leading/trailing hyphens', () => {
+      expect(slugifyChannelName('  spaced  ')).toBe('spaced');
+      expect(slugifyChannelName('!!!edge!!!')).toBe('edge');
+    });
+
+    it('preserves an already-valid name unchanged', () => {
+      const valid = 'agent-sys-updates';
+      expect(slugifyChannelName(valid)).toBe(valid);
+      expect(validateChannelName(valid)).toBe(true);
+    });
+
+    it('clamps to Slack 80-char limit', () => {
+      const long = 'a'.repeat(200);
+      const slug = slugifyChannelName(long);
+      expect(slug.length).toBeLessThanOrEqual(80);
+      expect(validateChannelName(slug)).toBe(true);
+    });
+  });
+
+  describe('demonstrates the bug it fixes', () => {
+    it('the raw un-slugified name is rejected by validateChannelName', () => {
+      // This is what the caller used to pass — it fails validation, which is
+      // why createChannel threw "Invalid channel name".
+      expect(validateChannelName('SageMind Live Test-sys-updates')).toBe(false);
+      // After slugifying, it passes.
+      expect(validateChannelName(slugifyChannelName('SageMind Live Test-sys-updates'))).toBe(true);
+    });
+  });
+});

--- a/upgrades/eli16/slack-updates-channel-slug.md
+++ b/upgrades/eli16/slack-updates-channel-slug.md
@@ -1,0 +1,16 @@
+# Why the Slack Updates channel failed to create (and now doesn't)
+
+## The one-sentence version
+When your Slack workspace had a space or a capital letter in its name (like "SageMind Live Test"), the agent tried to make a Slack channel literally named "SageMind Live Test-sys-updates" — but Slack only allows lowercase, no-spaces channel names, so the creation crashed every time. Now the name is cleaned up first.
+
+## Picture it
+Imagine a mailroom that will only accept package labels written in lowercase with dashes instead of spaces. The agent was handing it a label that said "SageMind Live Test-sys-updates" — capital letters, spaces and all — and the mailroom kept rejecting it. The fix is a tiny label-printer that rewrites the label as "sagemind-live-test-sys-updates" before handing it over.
+
+## What changed, precisely
+- The two callers that auto-create the Slack "Updates" and "Attention" channels were passing a raw, workspace-derived name straight into channel creation.
+- That raw name kept its spaces and capitals, which Slack rejects — so the channel never got made and you saw "Invalid channel name".
+- Now both callers run the name through a small slugifier first (lowercase it, turn anything that isn't a-z/0-9 into a single dash, trim stray dashes, cap at Slack's 80-char limit) — exactly the same cleanup the per-session Slack channels already used.
+
+## Why this is safe
+- It only changes how the name is *built* before creation; it does not touch the channel-creation rule that other code relies on (that rule still rejects bad names — it just never sees one now).
+- A name that was already valid passes through unchanged.

--- a/upgrades/next/slack-updates-channel-slug.md
+++ b/upgrades/next/slack-updates-channel-slug.md
@@ -1,0 +1,43 @@
+<!-- bump: patch -->
+
+## What Changed
+
+The boot helpers that auto-create the Slack "Updates" and "Attention" channels
+(`ensureSlackUpdatesChannel` / `ensureSlackAttentionChannel` in
+`src/commands/server.ts`) passed a raw, workspace-derived name straight into
+`SlackAdapter.createChannel`. When the workspace name contained spaces or
+uppercase (e.g. "SageMind Live Test"), that produced an invalid Slack channel
+name like `SageMind Live Test-sys-updates`, which `createChannel` rejects via
+`validateChannelName` — so the channel never got created and the boot logged
+`Failed to create Slack Updates channel: Invalid channel name`.
+
+Both callers now slugify the name first through a new shared
+`slugifyChannelName` helper in `src/messaging/slack/sanitize.ts` (lowercase,
+collapse non-`[a-z0-9]` runs to a single hyphen, trim edge hyphens, clamp to
+Slack's 80-char limit) — mirroring the per-session channel slug logic the
+adapter already used on its `-sess-` path. The `createChannel` /
+`validateChannelName` contract other callers rely on is untouched.
+
+## What to Tell Your User
+
+If your Slack workspace name has spaces or capital letters and your agent failed
+to create its Updates or Attention channel (an "Invalid channel name" error on
+startup), that's now fixed — the channel name is cleaned into a valid Slack
+slug before creation. Workspaces whose name was already lowercase-and-dashes see
+no change at all.
+
+## Summary of New Capabilities
+
+- New `slugifyChannelName(name)` helper in the Slack sanitize module — a single
+  source of truth for turning an arbitrary name into a valid Slack channel name.
+- The Slack Updates and Attention boot channels now create reliably regardless
+  of workspace-name casing or spaces.
+
+## Evidence
+
+- `tests/unit/slack-channel-slug.test.ts` — the exact failing name
+  ("SageMind Live Test-sys-updates") now slugifies to a name `validateChannelName`
+  accepts; covers lowercasing, space-collapse, punctuation stripping, edge-hyphen
+  trim, already-valid passthrough, 80-char clamp, and a regression assertion that
+  the raw un-slugified name is rejected.
+- `npx tsc --noEmit` clean; 9/9 new unit tests green.

--- a/upgrades/side-effects/slack-updates-channel-slug.md
+++ b/upgrades/side-effects/slack-updates-channel-slug.md
@@ -1,0 +1,46 @@
+# Side-Effects Review — Slack Updates/Attention channel name slugify
+
+## Change summary
+Caller-side fix in `src/commands/server.ts`: the `ensureSlackUpdatesChannel` and
+`ensureSlackAttentionChannel` boot helpers now slugify the workspace-derived
+channel name before calling `SlackAdapter.createChannel`, via a new shared
+`slugifyChannelName` helper in `src/messaging/slack/sanitize.ts`. Mirrors the
+existing per-session channel slug logic in `SlackAdapter` (`-sess-` path).
+
+## Tier
+Tier 1 — small, low-risk, single-machine Slack-adapter boot-path bugfix. No
+converged spec required.
+
+## Files touched
+- `src/messaging/slack/sanitize.ts` — adds exported `slugifyChannelName(name)`.
+- `src/commands/server.ts` — imports the helper; wraps both `-sys-updates` and
+  `-sys-attention` channel names with it before `createChannel`.
+- `tests/unit/slack-channel-slug.test.ts` — new focused unit test.
+
+## Behavioral side-effects
+- **Channel names on FRESH creation**: a workspace name containing spaces or
+  uppercase now yields a slugified channel (e.g. "SageMind Live Test" →
+  `sagemind-live-test-sys-updates`) instead of a hard failure. For workspaces
+  whose name was already slug-clean (lowercase, no spaces), the produced name is
+  byte-identical to before — no change.
+- **No change to `createChannel` / `validateChannelName`**: the validate-and-throw
+  behavior other callers depend on is untouched; the fix only ensures these two
+  callers never hand it an invalid name.
+- **Idempotent at the state layer**: both helpers early-return when their
+  `slack-*-channel` state key is already set, so this only affects the one-time
+  creation path; existing installs that already created a channel are unaffected.
+
+## Migration parity
+- No agent-installed file changed (no `.claude/settings.json` hooks, no
+  `.instar/config.json` defaults, no CLAUDE.md template, no hook scripts, no
+  built-in skills). This is server-side runtime code shipped in the normal
+  build — existing agents receive it on their next update with no migration.
+
+## Rollback
+- Revert the squash commit. The change is self-contained (one helper + two call
+  sites + one test); no data migration, no state schema change, nothing to undo.
+
+## Blast radius
+- Limited to the Slack adapter boot path. Telegram / WhatsApp / iMessage and all
+  non-Slack code paths are untouched. Dark-gate config line-map unchanged (no
+  ConfigDefaults edit).


### PR DESCRIPTION
## What this fixes

Slack "Updates" (and "Attention") channel auto-creation failed at server boot when the workspace name contained spaces or uppercase. The boot helpers `ensureSlackUpdatesChannel` / `ensureSlackAttentionChannel` (`src/commands/server.ts`) passed a raw workspace-derived name straight into `SlackAdapter.createChannel`, producing an invalid Slack channel name like `SageMind Live Test-sys-updates`, which `createChannel` rejects via `validateChannelName`:

```
Failed to create Slack Updates channel: Invalid channel name: "SageMind Live Test-sys-updates"
```

## The fix (minimal, caller-side)

Both callers now slugify the name first via a new shared `slugifyChannelName` helper in `src/messaging/slack/sanitize.ts` (lowercase → collapse non-`[a-z0-9]` runs to a single hyphen → trim edge hyphens → clamp to Slack's 80-char limit), mirroring the existing per-session channel slug logic in `SlackAdapter` (`-sess-` path). `createChannel` / `validateChannelName` behavior is **untouched** — other callers that rely on validate-and-throw are unaffected; these two callers simply never hand it an invalid name now.

## ELI16 — The Slack Updates and Attention channels failed to create whenever the agent's workspace name had spaces or capital letters

Slack only allows channel names that are lowercase with dashes instead of spaces. The agent was trying to create a channel literally named "SageMind Live Test-sys-updates" — capitals and spaces and all — so Slack rejected it every time and the channel was never made. Now the agent cleans the name into a valid Slack slug (lowercase letters, numbers, and dashes only) before creating the channel, so it works no matter what the workspace is called. A name that was already clean is left exactly as-is.

## Tier

Tier 1 — small, low-risk, single-machine Slack-adapter boot-path bugfix. No converged spec required.

## Tests

- `tests/unit/slack-channel-slug.test.ts` — the exact failing name slugifies to a name `validateChannelName` accepts; covers lowercasing, space-collapse, punctuation stripping, edge-hyphen trim, already-valid passthrough, 80-char clamp, plus a regression assertion that the raw un-slugified name is rejected (proves the bug). 9/9 green.
- `npx tsc --noEmit` clean. Related Slack/sanitize suites green (116 tests).
- Contract-evidence gate: `sanitize.ts` carries a `CONTRACT-EVIDENCE: EXEMPT` marker — pure string helpers, zero Slack API surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
