### PR TITLE
fix(multi-machine): inbound-queue engine never constructed — boot-order bug

### DIFF
--- a/.instar/instar-dev-decisions/2026-06-14T11-34-47-049Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-06-14T11-34-47-049Z-unknown.json
@@ -1,0 +1,13 @@
+{
+  "ts": "2026-06-14T11:34:47.049Z",
+  "slug": "unknown",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 2,
+  "loc": 50,
+  "causalAutopsy": null,
+  "verdict": "pass"
+}

--- a/docs/specs/inbound-queue-boot-order-fix.eli16.md
+++ b/docs/specs/inbound-queue-boot-order-fix.eli16.md
@@ -1,0 +1,85 @@
+# Inbound-Queue Boot-Order Fix — Plain-English Overview
+
+> The one-line version: a startup-ordering bug meant the durable inbound-message queue could never actually turn on, so this fixes the one line that always answered "stay off" when the queue should have started.
+
+## The problem in one breath
+
+The agent has a "durable inbound message queue" — a small crash-proof on-disk holding area for
+messages that can't be delivered the instant they arrive (because the conversation is mid-move
+between two of your machines, or the machine that owns it is briefly wobbly). It is supposed to
+catch those messages so none get dropped. The problem: it never actually started. Even with the
+right settings turned on, the part of startup that builds the queue's engine asked a question —
+"is the machine pool active?" — through a switch that hadn't been wired up yet at that exact moment,
+so the answer was always "no, it's off (dark)." The engine therefore never got built, and the page
+that reports on the queue (`/pool/queue`) returned "not available" forever.
+
+## What already exists
+
+- **The durable inbound queue** — the full engine, the crash-proof storage, the drain loop, the
+  loss-notices, and the `/pool/queue` status page were all built and shipped already. The feature
+  ships OFF by default (and in "dry-run" even when on), so nobody on the fleet ever hit this — it
+  only bites the first person who tries to turn it on for real.
+- **The session pool "stage" switch** — a small function (`_sessionPoolStage()`) that reports the
+  multi-machine pool's rollout stage: "dark" (off) or a named live stage. Lots of code consults it
+  to decide whether to do multi-machine things.
+
+## What this fixes
+
+During startup, the code that builds the queue engine runs *before* that stage switch gets wired
+to its real implementation. Until it's wired, the switch is a placeholder that always says "dark."
+So the build step read "dark," concluded the pool was off, and skipped building the queue — every
+single boot, no matter what the settings said. The fix: at the build step, don't ask the
+not-yet-wired switch. Instead read the same setting directly from config right there, inline, the
+exact same way the real switch reads it later. Now the build step gets the true answer and the
+engine constructs when it should.
+
+## The new piece
+
+- **`resolveSessionPoolStage(cfg)`** — a tiny shared helper that takes the pool's config block and
+  returns its stage ("dark" unless the pool is both enabled and carries a stage). Both the
+  early build-step (now) and the real switch (later) call this one helper, so they can never again
+  drift apart and disagree — which is the root cause class of this whole bug. It's pure logic with
+  no side effects, so it's directly and exhaustively unit-tested.
+
+## The safeguards
+
+**Fails toward OFF, never toward a half-on queue.** If reading the config ever throws, the inline
+resolution returns "dark" — the queue simply doesn't build this boot, which is byte-for-byte the
+shipped default. The safe direction is "no queue," and that's the direction every error path takes.
+
+**No new authority, no new config, no new route.** This only changes *when* an existing decision is
+read. It does not add a setting, change a default, add an endpoint, or grant any new capability.
+The queue still only runs where it was always meant to: enabled + a non-dark pool stage + not
+dry-run + the existing config invariants all satisfied.
+
+**The whole rest of the startup flow is untouched.** The placeholder switch is deliberately left in
+place — other code (the live message-routing handlers) legitimately closes over it and sees the
+real wired version when those handlers run later, after boot. Only the one synchronous build-time
+read was wrong, and only that read is changed.
+
+## Who is affected
+
+- **The fleet: no-op.** The inbound queue ships disabled by default, so nothing changes for any
+  agent that hasn't deliberately turned it on.
+- **An agent that enabled it (e.g. Echo, under the "no dark features on the dev agent" directive):**
+  the queue engine will now actually construct, and `/pool/queue` will answer 200 instead of 503.
+  This is the intended activation — the bug was hiding the feature from the very agent meant to
+  exercise it first.
+
+## How we proved it
+
+The bug was precisely "the engine is null when it should be live." So the proof is a test that
+checks the build-step no longer consults the not-yet-wired switch and instead resolves the stage
+inline — it fails against the old code and passes against the fix. A second focused test checks the
+new shared helper returns the right answer on both sides of the decision (enabled + stage → the
+stage; disabled or missing stage → dark). The existing route and lifecycle tests already prove that
+a constructed engine serves a real 200 on `/pool/queue`.
+
+## Open questions
+
+- **None blocking.** This is a behavior-correctness fix restoring intended behavior; there is no
+  design choice left open for the operator to make. The only judgment call was inline-read vs.
+  hoisting the wiring block — resolved in favor of the lower-risk inline read plus a shared helper
+  so the two readers can't drift again. If a future change wants the queue genuinely live (not
+  dry-run) on a real multi-machine setup, that is a separate, deliberate config flip, not part of
+  this fix.

--- a/src/commands/server.ts
+++ b/src/commands/server.ts
@@ -15691,7 +15691,33 @@ export async function startServer(options: StartOptions): Promise<void> {
             // wouldEnqueue/wouldHold/wouldRefuse counters ARE the promotion
             // evidence and /pool/queue must serve them. The boot sweep already
             // gate-expired any live→dry-run residual rows.
-            if (qcfg.enabled && _sessionPoolStage() !== 'dark') {
+            //
+            // BOOT-ORDER FIX: do NOT consult `_sessionPoolStage()` here — at this
+            // point in the synchronous boot flow it is still the line-~443 stub
+            // (`() => 'dark'`); the real impl is only assigned ~350 lines BELOW
+            // (the `_sessionPoolStage = () => { ... }` reassignment after the
+            // peer-presence puller is wired). Reading the stub made the gate
+            // ALWAYS false, so the inbound-queue engine never constructed even
+            // when correctly configured, and `/pool/queue` 503'd forever. Resolve
+            // the stage INLINE from config here — mirroring the line-~16045 impl
+            // exactly (liveConfig override with the static config block as the
+            // fallback) — instead of depending on the not-yet-wired ref.
+            const _sessionPoolStageNow = ((): string => {
+              try {
+                const fallback = (config.multiMachine?.sessionPool ?? {}) as { enabled?: boolean; stage?: string };
+                const live = liveConfig.get('multiMachine.sessionPool', fallback) as { enabled?: boolean; stage?: string };
+                return iqcMod.resolveSessionPoolStage(live);
+              } catch {
+                // @silent-fallback-ok: a config-read failure resolves the stage
+                // to 'dark' (the inert default) → the queue simply does not
+                // construct this boot, byte-identical to the ships-dark default.
+                // This is the SAFE direction (fail-closed: no queue), not a
+                // degraded capability worth a DegradationReporter event. Mirrors
+                // the live _sessionPoolStage getter's identical guard below.
+                return 'dark';
+              }
+            })();
+            if (qcfg.enabled && _sessionPoolStageNow !== 'dark') {
               const inv = iqcMod.validateInboundQueueInvariants(qcfg, hcfg);
               if (!inv.ok) {
                 for (const v of inv.violations) {
@@ -16042,11 +16068,12 @@ export async function startServer(options: StartOptions): Promise<void> {
           const peerPresenceTimer = setInterval(() => { void peerPresencePuller.pullOnce(); }, 30_000);
           if (typeof peerPresenceTimer.unref === 'function') peerPresenceTimer.unref();
 
+          const { resolveSessionPoolStage: _resolveSessionPoolStage } = await import('../core/inboundQueueConfig.js');
           _sessionPoolStage = () => {
             try {
               const fallback = (config.multiMachine?.sessionPool ?? {}) as { enabled?: boolean; stage?: string };
               const live = liveConfig.get('multiMachine.sessionPool', fallback) as { enabled?: boolean; stage?: string };
-              return live?.enabled && live?.stage ? String(live.stage) : 'dark';
+              return _resolveSessionPoolStage(live);
             } catch { return 'dark'; }
           };
           console.log(pc.green('  SessionRouter wired (L4) — inert until rollout stage advances past dark'));

--- a/src/core/inboundQueueConfig.ts
+++ b/src/core/inboundQueueConfig.ts
@@ -95,6 +95,25 @@ export const PROTOCOL_REDISPATCH_HORIZON_MAX_MS = 12 * 60 * 60 * 1000; // 12h
  */
 export const BOOT_SWEEP_WINDOW_MS = 5 * 60 * 1000; // 5 min
 
+/**
+ * Resolve the Multi-Machine Session Pool rollout STAGE from a config block.
+ * Returns the configured `stage` string only when the pool is BOTH enabled AND
+ * carries a `stage`; otherwise 'dark' (the inert default). This is the single
+ * source of truth for "is the session pool active, and at what stage?" — both
+ * the boot-time inbound-queue construction gate AND the live `_sessionPoolStage`
+ * getter in server.ts resolve through this one pure function, so the two can
+ * never drift (the original divergence is exactly what let the construction gate
+ * read a stale stub and keep the inbound queue dark forever — boot-order bug).
+ *
+ * @param cfg the resolved `multiMachine.sessionPool` block (liveConfig override
+ *   merged over the static config block, or just the static block at boot).
+ */
+export function resolveSessionPoolStage(
+  cfg: { enabled?: boolean; stage?: string } | null | undefined,
+): string {
+  return cfg?.enabled && cfg?.stage ? String(cfg.stage) : 'dark';
+}
+
 /** Σbackoff: total worst-case backoff across maxAttempts (capped curve). */
 export function sumBackoffMs(cfg: Pick<InboundQueueConfig, 'baseBackoffMs' | 'maxBackoffMs' | 'maxAttempts'>): number {
   let sum = 0;

--- a/tests/unit/inbound-queue-boot-order.test.ts
+++ b/tests/unit/inbound-queue-boot-order.test.ts
@@ -1,0 +1,93 @@
+/**
+ * Regression guard for the inbound-queue BOOT-ORDER bug (boot-order-fix).
+ *
+ * THE BUG: in startServer()'s mesh block the inbound-queue engine is constructed
+ * SYNCHRONOUSLY, but the gate guarding that construction read the module-level
+ * `_sessionPoolStage()` getter — which at that point in the boot flow is still
+ * the line-~443 stub `() => 'dark'`. The real getter is only assigned ~350 lines
+ * BELOW the construction site. So `_sessionPoolStage() !== 'dark'` was ALWAYS
+ * false at construction time → the engine never constructed → `/pool/queue`
+ * 503'd forever, even with `inboundQueue.enabled=true` + a non-dark stage. The
+ * feature had been inert since it shipped.
+ *
+ * THE FIX: the construction gate resolves the stage INLINE from config (via the
+ * shared `resolveSessionPoolStage` helper) instead of calling the not-yet-wired
+ * `_sessionPoolStage()` ref. These assertions pin that structurally — they FAIL
+ * against the pre-fix source (gate calls `_sessionPoolStage()`) and PASS after.
+ *
+ * Source-text assertions are the right tier here: standing up the full
+ * startServer mesh boot path in a test is heavyweight, and the bug is purely an
+ * ordering relationship between two lines in that one file. The companion
+ * `tests/unit/resolve-session-pool-stage.test.ts` proves the resolution LOGIC,
+ * and `tests/integration/inbound-queue-route.test.ts` proves a constructed
+ * engine actually serves 200 on /pool/queue (feature-alive).
+ */
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const SERVER = path.join(process.cwd(), 'src/commands/server.ts');
+
+describe('Inbound-queue boot-order fix (engine constructs when configured)', () => {
+  const src = fs.readFileSync(SERVER, 'utf-8');
+
+  // Anchor on the construction gate region: from the engine-construction comment
+  // to the QueueDrainLoop instantiation.
+  function constructionRegion(): string {
+    const start = src.indexOf('Durable Inbound Message Queue: engine construction');
+    expect(start).toBeGreaterThan(0);
+    const end = src.indexOf('new qdlMod.QueueDrainLoop(', start);
+    expect(end).toBeGreaterThan(start);
+    return src.slice(start, end);
+  }
+
+  it('the construction gate does NOT call the not-yet-wired _sessionPoolStage() getter', () => {
+    const region = constructionRegion();
+    // The bug was precisely `if (qcfg.enabled && _sessionPoolStage() !== 'dark')`.
+    // After the fix the gate must NOT invoke the getter to decide construction.
+    // (Strip the explanatory FIX comment, which legitimately names the old call
+    // form in prose, before asserting on executable code.)
+    const code = region
+      .split('\n')
+      .filter((l) => !l.trimStart().startsWith('//'))
+      .join('\n');
+    expect(code).not.toContain('_sessionPoolStage()');
+  });
+
+  it('the construction gate resolves the stage INLINE before gating', () => {
+    const region = constructionRegion();
+    // Inline resolution computed at construction time (not the stale ref).
+    expect(region).toContain('_sessionPoolStageNow');
+    expect(region).toContain('resolveSessionPoolStage(');
+    expect(region).toContain("liveConfig.get('multiMachine.sessionPool'");
+    // The gate now reads the inline value.
+    expect(region).toContain("_sessionPoolStageNow !== 'dark'");
+  });
+
+  it('the inline resolution sits BEFORE the gate it feeds (ordering correctness)', () => {
+    const region = constructionRegion();
+    const resolveAt = region.indexOf('const _sessionPoolStageNow');
+    const gateAt = region.indexOf("if (qcfg.enabled && _sessionPoolStageNow !== 'dark')");
+    expect(resolveAt).toBeGreaterThan(-1);
+    expect(gateAt).toBeGreaterThan(resolveAt);
+  });
+
+  it('BOTH stage resolvers (boot gate + live getter) route through the shared helper (no drift)', () => {
+    // The construction gate and the live _sessionPoolStage getter must both use
+    // resolveSessionPoolStage — that single source of truth is what prevents the
+    // original hand-duplicated divergence from recurring.
+    const helperUses = src.split('resolveSessionPoolStage(').length - 1;
+    // ≥2 callsites in server.ts (the boot-gate inline + the live getter); the
+    // import line carries the symbol name but not the `(` call form.
+    expect(helperUses).toBeGreaterThanOrEqual(2);
+    // The live getter is still wired (the original assignment survives the fix).
+    expect(src).toContain('_sessionPoolStage = () => {');
+  });
+
+  it('the stub default is unchanged (the getter still defaults dark until wired)', () => {
+    // The fix does NOT remove the stub — runtime handlers (wireTelegramRouting,
+    // onAccepted) legitimately close over the ref and see the wired impl when
+    // they run AFTER boot. Only the SYNCHRONOUS boot-time read was buggy.
+    expect(src).toContain("let _sessionPoolStage: () => string = () => 'dark'");
+  });
+});

--- a/tests/unit/resolve-session-pool-stage.test.ts
+++ b/tests/unit/resolve-session-pool-stage.test.ts
@@ -1,0 +1,43 @@
+/**
+ * Unit tests for resolveSessionPoolStage — the single source of truth for the
+ * Multi-Machine Session Pool rollout stage, shared by BOTH the boot-time
+ * inbound-queue construction gate AND the live `_sessionPoolStage` getter in
+ * server.ts (boot-order-fix: the two used to be hand-duplicated, and the
+ * construction gate read a not-yet-wired stub that always returned 'dark',
+ * keeping the inbound queue engine null forever even when correctly configured).
+ *
+ * Decision boundary: a stage is returned ONLY when the pool is BOTH enabled AND
+ * carries a stage; every other shape → 'dark' (inert default).
+ */
+import { describe, it, expect } from 'vitest';
+import { resolveSessionPoolStage } from '../../src/core/inboundQueueConfig.js';
+
+describe('resolveSessionPoolStage', () => {
+  it('enabled + stage → returns the configured stage', () => {
+    expect(resolveSessionPoolStage({ enabled: true, stage: 'live-transfer' })).toBe('live-transfer');
+    expect(resolveSessionPoolStage({ enabled: true, stage: 'shadow' })).toBe('shadow');
+  });
+
+  it('enabled but MISSING stage → dark (a half-configured pool is inert, never a crash)', () => {
+    expect(resolveSessionPoolStage({ enabled: true })).toBe('dark');
+    expect(resolveSessionPoolStage({ enabled: true, stage: undefined })).toBe('dark');
+    expect(resolveSessionPoolStage({ enabled: true, stage: '' })).toBe('dark');
+  });
+
+  it('disabled (regardless of stage) → dark', () => {
+    expect(resolveSessionPoolStage({ enabled: false, stage: 'live-transfer' })).toBe('dark');
+    expect(resolveSessionPoolStage({ stage: 'live-transfer' })).toBe('dark'); // enabled absent
+    expect(resolveSessionPoolStage({ enabled: false })).toBe('dark');
+  });
+
+  it('empty / null / undefined config → dark (the production default state)', () => {
+    expect(resolveSessionPoolStage({})).toBe('dark');
+    expect(resolveSessionPoolStage(null)).toBe('dark');
+    expect(resolveSessionPoolStage(undefined)).toBe('dark');
+  });
+
+  it('coerces a non-string stage to a string (defensive — config is untrusted)', () => {
+    // A numeric/odd stage value never crashes the gate; it stringifies.
+    expect(resolveSessionPoolStage({ enabled: true, stage: 42 as unknown as string })).toBe('42');
+  });
+});

--- a/upgrades/next/inbound-queue-boot-order-fix.md
+++ b/upgrades/next/inbound-queue-boot-order-fix.md
@@ -1,0 +1,27 @@
+## What Changed
+
+Fixed a boot-ordering bug that meant the **Durable Inbound Message Queue** (`multiMachine.sessionPool.inboundQueue`) could NEVER construct its engine, regardless of config. In `startServer()`, the queue-engine construction gate read the module-level `_sessionPoolStage()` getter while it was still its initial stub (`() => 'dark'`) — the real liveConfig-reading implementation is only assigned ~350 lines further down the same synchronous boot flow. So the gate's `_sessionPoolStage() !== 'dark'` test was always false at construction time, the engine never built, and `GET /pool/queue` answered 503 forever even with the feature enabled and a non-dark session-pool stage. The feature ships dark/dry-run by default, so the fleet never hit this; it only bites the first agent to enable it for real.
+
+The fix resolves the stage INLINE at the construction site, reading the same `multiMachine.sessionPool` config (liveConfig override over the static block) via a new shared pure helper `resolveSessionPoolStage(cfg)` in `src/core/inboundQueueConfig.ts`, instead of consulting the not-yet-wired ref. The live `_sessionPoolStage` getter is refactored to call the same helper, so the two stage readers can never drift apart again (that drift was the root cause). No new capability, config key, HTTP route, or authority — purely a correction to WHEN an existing decision is read.
+
+audience: agent-only
+maturity: stable
+
+A no-deferrals audit of all five `_sessionPoolStage()` call sites confirmed exactly one genuinely-premature boot-time read (the construction gate). The three runtime-handler reads (`wireTelegramRouting` x2, the `onAccepted` forwarded-message callback) are correct as-is: they execute per-message AFTER boot and close over the ref, so they see the wired implementation when invoked.
+
+## What to Tell Your User
+
+Nothing to announce proactively — the inbound queue ships disabled by default, so for any agent that hasn't deliberately turned it on, nothing changes. If asked: the crash-proof holding area for messages that arrive while a conversation is mid-move between machines had a startup bug that kept it from ever turning on; it now starts correctly when enabled. For a developer agent running it live, the queue's status page now returns real data instead of "not available." Every error path still fails toward off (no queue), which is identical to the shipped default.
+
+## Summary of New Capabilities
+
+No new capability — a latent behavior-correctness fix restoring intended behavior.
+
+| Change | Effect |
+|--------|--------|
+| Inbound-queue construction gate reads stage inline | The queue engine constructs when `inboundQueue.enabled=true` + a non-dark `sessionPool` stage (was: never) |
+| `resolveSessionPoolStage(cfg)` shared helper | Single source of truth for the pool stage; boot gate + live getter can no longer drift |
+
+## Evidence
+
+Behavior-correctness fix; reproduced by code-read on `JKHeadley/main` and pinned by a fails-before/passes-after structural regression guard. `tests/unit/inbound-queue-boot-order.test.ts` (5) asserts the construction gate no longer calls the stub getter, resolves inline before gating, routes both readers through the shared helper, and leaves the stub declaration intact (4 of 5 assertions fail against pre-fix `server.ts`; all 5 pass against the fix). `tests/unit/resolve-session-pool-stage.test.ts` (5) covers both sides of the stage-resolution boundary (enabled+stage→stage; disabled/missing→dark). The existing `tests/integration/inbound-queue-route.test.ts` and `tests/e2e/inbound-queue-lifecycle.test.ts` already prove a constructed engine serves a real 200 on `/pool/queue`. `npx tsc --noEmit` clean; full lint + dark-gate (24/24, line-map unchanged) + no-silent-fallbacks (baseline 474 unchanged) + feature-delivery-completeness + route-completeness green.

--- a/upgrades/side-effects/inbound-queue-boot-order-fix.md
+++ b/upgrades/side-effects/inbound-queue-boot-order-fix.md
@@ -1,0 +1,72 @@
+# Side-Effects Review — Inbound-Queue Boot-Order Fix
+
+**Tier:** 1 (latent behavior-correctness fix restoring intended behavior — no new capability, no new config key, no new route, no new authority). **Parent principle:** Structure > Willpower / feature-is-alive — a feature that can never construct is a broken feature; this restores the intended construction path and pins it with a regression guard.
+**Files:** src/commands/server.ts, src/core/inboundQueueConfig.ts, tests/unit/resolve-session-pool-stage.test.ts (new), tests/unit/inbound-queue-boot-order.test.ts (new)
+
+## The bug
+
+The Durable Inbound Message Queue (`multiMachine.sessionPool.inboundQueue`, spec `docs/specs/durable-inbound-message-queue.md`) NEVER constructed its engine, regardless of correct config, because of a boot-ordering bug in `src/commands/server.ts`:
+
+- `let _sessionPoolStage: () => string = () => 'dark';` — a module-level stub initialized to always return `'dark'`.
+- The inbound-queue engine construction is gated `if (qcfg.enabled && _sessionPoolStage() !== 'dark') { … _inboundQueue = new QueueDrainLoop(…) … }`, running SYNCHRONOUSLY in the mesh boot block (`if (meshIdMgr && meshSelfId)`) inside `startServer()`.
+- The ONLY reassignment of `_sessionPoolStage` to the real (liveConfig-reading) impl executes ~350 lines BELOW that construction site, also synchronously, in the same block.
+
+At construction time the stub is still in force → `_sessionPoolStage()` returns `'dark'` → `'dark' !== 'dark'` is false → the engine never constructs. The same gate guards the `else if (_sweptInboundStore)` cleanup branch. Net: the feature has been inert since it shipped (it ships dark/dry-run by default, so nobody on the fleet hit it). `/pool/queue` returns 503 forever even with `inboundQueue.enabled=true` + a non-dark stage.
+
+## The no-deferrals audit — every `_sessionPoolStage()` call site
+
+Grepped ALL uses of `_sessionPoolStage` in `src/commands/server.ts`. Verdict for each:
+
+| Line (main) | Context | Runs synchronously at boot before the ~16045 reassignment? | Verdict |
+|---|---|---|---|
+| ~443 | `let _sessionPoolStage = () => 'dark'` | n/a (the stub declaration) | the bug SOURCE — left in place by design (runtime handlers legitimately close over it) |
+| ~1992 | inside `wireTelegramRouting` (the per-message inbound dispatch handler) | NO — invoked per-message at runtime, after boot; closes over the ref and sees the wired impl | FINE — not fixed |
+| ~2000 | inside `wireTelegramRouting` (same handler) | NO — same as above | FINE — not fixed |
+| ~14434 | inside the `onAccepted` callback (fires when a forwarded mesh message arrives) | NO — runtime mesh-message handler; closes over the ref | FINE — not fixed |
+| ~15694 | the inbound-queue engine CONSTRUCTION gate | **YES** — synchronous boot read, BEFORE the ~16045 reassignment | **BUGGY — FIXED** |
+| ~16045 | the `_sessionPoolStage = () => {…}` reassignment to the real impl | n/a (the assignment itself; everything after it sees the wired impl) | FINE — refactored to use the shared helper |
+
+Exactly ONE genuinely-premature boot-time read (15694). No sibling premature read left unfixed. The three runtime-handler reads (1992/2000/14434) are correct as-is — they execute only after boot, by which time the ref is wired; the `session-pool-activation-wiring.test.ts` structural test continues to assert those handlers use `_sessionPoolStage()`, and it stays green.
+
+## What changed
+
+1. **`src/core/inboundQueueConfig.ts`** — added a pure helper `resolveSessionPoolStage(cfg)` that returns the configured `stage` only when the pool is BOTH `enabled` AND carries a `stage`, else `'dark'`. This becomes the single source of truth for the stage decision, eliminating the hand-duplicated logic that let the two readers drift. No config types, defaults, or invariants changed.
+2. **`src/commands/server.ts` (construction site, ~15694):** the gate now computes the stage INLINE — `const _sessionPoolStageNow = (() => { try { const live = liveConfig.get('multiMachine.sessionPool', fallback); return iqcMod.resolveSessionPoolStage(live); } catch { return 'dark'; } })();` — mirroring the ~16045 impl exactly (liveConfig override over the static config block), then gates on `qcfg.enabled && _sessionPoolStageNow !== 'dark'`. It no longer consults the not-yet-wired `_sessionPoolStage()` ref.
+3. **`src/commands/server.ts` (the real getter, ~16045):** refactored to call the same `resolveSessionPoolStage` helper (dynamic-imported at that site, matching the file's existing dynamic-import pattern) instead of its own inline copy of the logic. Behavior identical; now DRY with the boot gate.
+4. **Tests (new):** `tests/unit/resolve-session-pool-stage.test.ts` (5) proves the resolution logic on both sides of the decision boundary; `tests/unit/inbound-queue-boot-order.test.ts` (5) is the structural regression guard — it asserts the construction gate no longer reads the stub, resolves inline before gating, routes both readers through the shared helper, and leaves the stub declaration intact.
+
+## Blast radius (activation, explicit)
+
+- **Fleet = no-op.** The inbound queue ships `enabled: false` (and `dryRun: true` even when enabled) by default. No fleet agent's behavior changes: with the queue disabled, `qcfg.enabled` is false and the gate short-circuits before the stage is even consulted.
+- **Any agent with `inboundQueue.enabled=true` AND `sessionPool` stage `!== 'dark'`** will now CONSTRUCT the queue engine where before it silently did not. `/pool/queue` flips from 503 to 200. For **Echo** this is the intended **no-dark-on-dev activation** — the dev agent enabling the feature live is the first real exercise of the construction path, which is exactly the path this fixes.
+- **Multi-machine posture:** machine-local construction only. This is a behavior-correctness fix — it changes WHEN an existing local decision is read, not any cross-machine protocol, route, or mesh verb. A single-machine agent that hasn't enabled the queue is wholly unaffected.
+- **No new authority surface.** The construction still requires the full existing gate chain (enabled + non-dark stage + the six config-seam invariants validated by `validateInboundQueueInvariants` + dry-run handling). Nothing about WHAT the queue is allowed to do changed.
+
+## Risk + mitigation
+
+- **Risk:** the inline read disagrees with the live getter (the same drift class that caused the bug). **Mitigation:** both now call the single `resolveSessionPoolStage` helper — there is no second copy of the logic to drift. Pinned by `inbound-queue-boot-order.test.ts` (asserts ≥2 helper callsites) + `resolve-session-pool-stage.test.ts`.
+- **Risk:** a config-read throw at the inline site crashes boot or builds a half-configured queue. **Mitigation:** the inline resolution is try/caught and fails to `'dark'` (the safe, queue-OFF direction = the shipped default), carrying an in-brace `@silent-fallback-ok` justification. Verified against `tests/unit/no-silent-fallbacks.test.ts` (baseline unchanged at 474).
+- **Risk:** the fix accidentally activates the queue on the fleet. **Mitigation:** the `qcfg.enabled` half of the gate is untouched and still defaults false; the fix only corrects the stage half. Fleet default behavior is byte-identical.
+
+## Migration parity
+
+- No agent-installed files changed: no `.claude/settings.json` hooks, no `.instar/config.json` defaults, no CLAUDE.md template section, no hook scripts, no built-in skills. `resolveSessionPoolStage` is a pure code helper consumed only by `server.ts`. No `PostUpdateMigrator` change is needed — existing agents pick up the corrected construction path the moment their server runs the new code.
+
+## Dark-gate line-map
+
+- UNCHANGED. The change touches `src/core/inboundQueueConfig.ts` (a new pure function, no `enabled:` literal) and `src/commands/server.ts` (no `ConfigDefaults.ts` edit). The dark-gate attributor reads `src/core/ConfigDefaults.ts` only and matches `enabled:` lines; no such line shifted. Verified: `tests/unit/lint-dev-agent-dark-gate.test.ts` → 24/24 green, unchanged.
+
+## Rollback
+
+- Revert the two source edits (the inline resolution at the construction site + the helper call at the getter) and delete the helper + the two new test files. The queue reverts to never-constructing (the prior broken-but-inert state). Because the feature ships dark, the revert is a strict no-op on the fleet. No data migration, no durable-state change.
+
+## Tests
+
+- `tests/unit/resolve-session-pool-stage.test.ts` (5) — the stage-resolution logic: enabled+stage→stage; enabled+missing-stage→dark; disabled→dark; empty/null/undefined→dark; non-string stage coerced.
+- `tests/unit/inbound-queue-boot-order.test.ts` (5) — the structural regression guard: the construction gate does not call the stub getter; resolves inline; resolution precedes the gate; both readers use the shared helper; the stub declaration is intact. Fails-before/passes-after verified (4 of 5 assertions fail against pre-fix `server.ts`; all 5 pass against the fix).
+- Existing coverage already proves feature-alive: `tests/integration/inbound-queue-route.test.ts` (engine present → 200, absent → 503) and `tests/e2e/inbound-queue-lifecycle.test.ts` (boot-sweep → construct → drain → /pool/queue 200).
+- Green locally: `npx tsc --noEmit` clean; the two new suites + `session-pool-activation-wiring` + `inbound-queue-route` + `inbound-queue-config` + `no-silent-fallbacks` + `feature-delivery-completeness` + `route-completeness` + `lint-dev-agent-dark-gate` (159 tests) all pass.
+
+## Agent awareness
+
+- No CLAUDE.md change. The inbound queue is already documented in the agent template ("Durable Inbound Message Queue + Hold-for-Stability"); this fix restores the documented behavior rather than adding a capability, so no `generateClaudeMd`/`migrateClaudeMd` change is required (feature-delivery-completeness green — no new tracked section). <!-- tracked: inbound-queue-boot-order-fix -->


### PR DESCRIPTION
## ELI16 — the inbound message queue had a startup bug that kept it from ever turning on; this fixes the one line that always answered "off"

The agent has a durable inbound message queue: a small crash-proof on-disk holding area for messages that can't be delivered the instant they arrive (a conversation mid-move between two of your machines, or a machine that's briefly wobbly). It's supposed to catch those messages so none get dropped. The bug: it never actually started. During startup, the step that builds the queue's engine asked "is the multi-machine pool active?" through a switch that hadn't been wired up yet at that exact moment, so the answer was always "no, it's off." The engine therefore never got built, and the status page (`/pool/queue`) returned "not available" forever — even with the feature correctly enabled. The fix: at the build step, don't ask the not-yet-wired switch — read the same setting directly from config right there, the exact same way the real switch reads it later. A new shared helper makes both readers use one piece of logic so they can never disagree again. No new capability, config key, route, or authority.

## The bug (confirmed by code-read on `JKHeadley/main`)

`startServer()` constructs the inbound-queue engine SYNCHRONOUSLY inside the mesh boot block, gated on `if (qcfg.enabled && _sessionPoolStage() !== 'dark')`. But `_sessionPoolStage` is still its initial stub (`() => 'dark'`) at that point — the real liveConfig-reading implementation is only assigned ~350 lines further down the same synchronous flow. So `_sessionPoolStage() !== 'dark'` was always false at construction time → the engine never built → `GET /pool/queue` 503'd forever even with `inboundQueue.enabled=true` + a non-dark stage. The feature ships dark/dry-run by default, so the fleet never hit it.

## The fix

- **`src/core/inboundQueueConfig.ts`** — new pure helper `resolveSessionPoolStage(cfg)` (the single source of truth for the pool stage; returns the stage only when enabled AND a stage is set, else `'dark'`).
- **`src/commands/server.ts` (construction site)** — resolves the stage INLINE from config (liveConfig override over the static block) via the helper, instead of the not-yet-wired ref, then gates on that.
- **`src/commands/server.ts` (the real getter)** — refactored to call the same helper, so the boot gate and the live getter can never drift again (that drift was the root cause).
- Fails toward OFF on any config-read error (the safe, queue-off direction = the shipped default), with an in-brace `@silent-fallback-ok` justification.

## No-deferrals audit (every `_sessionPoolStage()` call site)

| Site | Context | Premature boot read? | Verdict |
|---|---|---|---|
| stub decl (~443) | the `() => 'dark'` stub | n/a | left intact (runtime handlers close over it) |
| ~1992 | `wireTelegramRouting` (per-message dispatch) | NO — runtime, post-boot | FINE |
| ~2000 | `wireTelegramRouting` | NO — runtime, post-boot | FINE |
| ~14434 | `onAccepted` forwarded-message callback | NO — runtime mesh handler | FINE |
| ~15694 | inbound-queue CONSTRUCTION gate | **YES** — sync boot, before the reassignment | **FIXED** |
| ~16045 | the `_sessionPoolStage = …` reassignment | n/a | refactored to the shared helper |

Exactly one premature boot-time read; no sibling left unfixed.

## Activation blast radius

- **Fleet = no-op.** The inbound queue ships disabled by default; with it off the gate short-circuits before the stage is even consulted.
- **Any agent with `inboundQueue.enabled=true` AND a non-dark `sessionPool` stage** now constructs the queue engine where it previously did not — `/pool/queue` flips 503 → 200. For Echo this is the intended no-dark-on-dev activation: the dev agent enabling the feature live is the first real exercise of the construction path this fixes.
- Machine-local construction; behavior-correctness fix, no cross-machine protocol/route/verb change.

## Tests (fails-before / passes-after)

- `tests/unit/inbound-queue-boot-order.test.ts` (5) — structural regression guard: the construction gate no longer calls the stub getter, resolves inline before gating, both readers use the shared helper, the stub declaration is intact. **4 of 5 assertions fail against pre-fix `server.ts`; all 5 pass against the fix** (verified by running the suite against the original `main` source).
- `tests/unit/resolve-session-pool-stage.test.ts` (5) — the resolution logic on both sides of the boundary (enabled+stage→stage; disabled/missing→dark; null/undefined→dark; non-string coerced).
- Existing `tests/integration/inbound-queue-route.test.ts` (engine present → 200, absent → 503) and `tests/e2e/inbound-queue-lifecycle.test.ts` (boot-sweep → construct → drain → 200) already prove feature-alive.
- `npx tsc --noEmit` clean; lint + dark-gate (24/24, line-map unchanged) + no-silent-fallbacks (baseline 474 unchanged) + feature-delivery-completeness + route-completeness green.

**Tier 1** — latent behavior-correctness fix restoring intended behavior (no new capability/config/route/authority). Staged ELI16 + side-effects artifact + release-note fragment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
