### PR TITLE
feat(slack): inbound dispatch follows pool placement (WS1.1 dispatch-to-owner, Slack arm)

### DIFF
--- a/.instar/instar-dev-decisions/2026-06-14T17-56-30-598Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-06-14T17-56-30-598Z-unknown.json
@@ -1,0 +1,13 @@
+{
+  "ts": "2026-06-14T17:56:30.598Z",
+  "slug": "unknown",
+  "suggestedTier": 2,
+  "declaredTier": 2,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 2,
+  "loc": 223,
+  "causalAutopsy": null,
+  "verdict": "pass"
+}

--- a/src/commands/server.ts
+++ b/src/commands/server.ts
@@ -96,6 +96,7 @@ import { SessionRecovery } from '../monitoring/SessionRecovery.js';
 import { MultiMachineCoordinator } from '../core/MultiMachineCoordinator.js';
 import { MachineIdentityManager } from '../core/MachineIdentity.js';
 import { isRemotelyHandled } from '../core/SessionRouter.js';
+import { isSlackSessionKey, reconstructSlackMessage } from '../core/SlackForwardBridge.js';
 import { formatForwardedTopicContext } from '../core/ForwardedTopicContext.js';
 import { resolveAdvertisedMeshUrl, advertiseSelfMeshUrl } from '../core/MeshUrlAdvertiser.js';
 import { relayOutbound } from '../core/TelegramRelay.js';
@@ -627,6 +628,13 @@ let _projectDir: string = process.cwd();
 let _sharedIntelligence: import('../core/types.js').IntelligenceProvider | null = null;
 let _selfKnowledgeTree: SelfKnowledgeTree | null = null;
 let _slackAdapter: import('../messaging/slack/SlackAdapter.js').SlackAdapter | null = null;
+// WS1.1 dispatch-to-owner (Slack arm): the owner-side bridge reconstructs a Slack
+// inbound Message from a forwarded mesh deliverMessage and replays it through the
+// SAME local dispatch the live inbound path uses. Set once in startServer's Slack
+// block; null when Slack is not configured (the owner-side Slack branch then
+// no-ops — a forwarded Slack key on a Slack-less owner is a misconfiguration the
+// router's placement should never produce, and falling through is harmless).
+let _slackInboundDispatch: ((message: import('../core/types.js').Message) => Promise<void>) | null = null;
 // SessionRefresh — agent-initiated respawn. Module-scope so onRestartSession
 // (defined outside startServer) can delegate to it once startServer wires it.
 // Null until startServer constructs it; the Telegram /restart handler falls
@@ -5998,7 +6006,14 @@ export async function startServer(options: StartOptions): Promise<void> {
         }
 
         // Wire message handler — inject Slack messages into sessions
-        slackAdapter.onMessage(async (message) => {
+        // ── WS1.1 dispatch-to-owner (Slack arm) ──────────────────────────────
+        // The actual channel→session dispatch for a Slack inbound message. This is
+        // the body the live inbound `onMessage` handler runs AFTER pool routing has
+        // decided the message belongs to THIS machine — AND the body the owner-side
+        // mesh bridge replays when a Slack message was forwarded to this machine
+        // because it owns the conversation. Sharing one function is "Structure >
+        // Willpower": the forwarded path and the live path can never drift.
+        const slackInboundDispatch = async (message: Message): Promise<void> => {
           const channelId = message.channel.identifier;
           const isDM = message.metadata?.isDM as boolean;
           const senderName = message.metadata?.senderName as string || 'User';
@@ -6017,29 +6032,6 @@ export async function startServer(options: StartOptions): Promise<void> {
           const isThreadSession = slackAdapter!.isThreadRoutingKey(routingKey);
           // The thread_ts to thread replies under (only when this is a thread session).
           const replyThreadTs = isThreadSession ? threadTs : undefined;
-
-          // Sentinel intercept — classify message for emergency stop/pause
-          if (sentinel) {
-            try {
-              const classification = await sentinel.classify(message.content);
-              if (classification.category === 'emergency-stop') {
-                // Kill all sessions
-                const sessions = sessionManager.listRunningSessions();
-                for (const s of sessions) {
-                  try { sessionManager.killSession(s.id); } catch { /* ok */ }
-                }
-                slackAdapter!.sendToChannel(channelId, '🛑 Emergency stop — all sessions killed.').catch(() => {});
-                return;
-              } else if (classification.category === 'pause') {
-                const existingSession = slackAdapter!.getSessionForChannel(routingKey);
-                if (existingSession) {
-                  sessionManager.sendKey(existingSession, 'Escape');
-                  slackAdapter!.sendToChannel(channelId, '⏸️ Session paused.').catch(() => {});
-                }
-                return;
-              }
-            } catch { /* fail-open — if Sentinel errors, process message normally */ }
-          }
 
           // Build injection tag with sender info (matches Telegram's buildInjectionTag pattern)
           const slackUserId = message.metadata?.slackUserId as string;
@@ -6215,6 +6207,86 @@ export async function startServer(options: StartOptions): Promise<void> {
           } catch (err) {
             console.error(`[slack] Session spawn failed: ${err instanceof Error ? err.message : err}`);
           }
+        };
+        // Expose to the owner-side mesh bridge (a forwarded Slack message replays
+        // through the same dispatch on the machine that owns the conversation).
+        _slackInboundDispatch = slackInboundDispatch;
+
+        slackAdapter.onMessage(async (message) => {
+          const channelId = message.channel.identifier;
+          const messageTs = message.metadata?.ts as string | undefined;
+          const threadTs = message.metadata?.threadTs as string | undefined;
+          const routingKey = slackAdapter!.resolveRoutingKey(channelId, threadTs, messageTs);
+
+          // Sentinel intercept — classify message for emergency stop/pause. Runs on
+          // the machine the message arrived at (these are local-process actions);
+          // never forwarded.
+          if (sentinel) {
+            try {
+              const classification = await sentinel.classify(message.content);
+              if (classification.category === 'emergency-stop') {
+                // Kill all sessions
+                const sessions = sessionManager.listRunningSessions();
+                for (const s of sessions) {
+                  try { sessionManager.killSession(s.id); } catch { /* ok */ }
+                }
+                slackAdapter!.sendToChannel(channelId, '🛑 Emergency stop — all sessions killed.').catch(() => {});
+                return;
+              } else if (classification.category === 'pause') {
+                const existingSession = slackAdapter!.getSessionForChannel(routingKey);
+                if (existingSession) {
+                  sessionManager.sendKey(existingSession, 'Escape');
+                  slackAdapter!.sendToChannel(channelId, '⏸️ Session paused.').catch(() => {});
+                }
+                return;
+              }
+            } catch { /* fail-open — if Sentinel errors, process message normally */ }
+          }
+
+          // ── Multi-Machine Session Pool (§L4 / WS1.1): route through the pool ──
+          // Mirrors the Telegram inbound dispatch. When the rollout stage is past
+          // 'dark', consult the SessionRouter on the Slack routingKey: it may
+          // forward this conversation's message to the machine that OWNS the session
+          // (over the mesh) instead of binding it to whatever local session happens
+          // to be running. DARK (the default) skips this block entirely → the Slack
+          // inbound path is byte-identical to today's local-only dispatch. Any error
+          // falls back to the local dispatch below (fail-safe). This closes the bug
+          // where a Slack channel pinned/transferred to a peer machine still injected
+          // the next message into the already-running LOCAL session (Telegram's
+          // inbound path already followed the transfer; Slack's never did).
+          if (_sessionRouter && _sessionPoolStage() !== 'dark') {
+            try {
+              const outcome = await _sessionRouter.route({
+                sessionKey: routingKey,
+                messageId: String(message.id),
+                payload: message.content,
+                topicMetadata: _topicPinStore?.asTopicMetadata(routingKey),
+                senderEnvelope: {
+                  userId: (message.metadata?.slackUserId as string) || undefined,
+                  firstName: (message.metadata?.senderName as string) || undefined,
+                },
+              });
+              console.log(`[session-pool] slack route key=${routingKey} → action=${outcome.action} owner=${outcome.owner ?? '?'} self=${_meshSelfId ?? '?'} acked=${outcome.acked}`);
+              if (isRemotelyHandled(outcome, _meshSelfId)) {
+                console.log(`[session-pool] slack key ${routingKey} handled by owner ${outcome.owner ?? '?'} (${outcome.action}) — not dispatching locally`);
+                return;
+              }
+              // Custody-ack short-circuit (§2.2, mirrors the Telegram path): a
+              // queued/placement-blocked verdict whose enqueue COMMITTED (acked) is
+              // the durable queue's message now — no local fall-through (which would
+              // double-handle). Un-custodied (refused/off/dry-run) falls through.
+              if ((outcome.action === 'queued' || outcome.action === 'placement-blocked') && outcome.acked) {
+                console.log(`[session-pool] slack key ${routingKey} in durable custody (${outcome.detail ?? outcome.action}) — drain will deliver`);
+                return;
+              }
+              // 'handled-locally' / self 'spawned'/'owner-dead-replaced' / un-acked
+              // 'queued'/'placement-blocked' → fall through to local dispatch below.
+            } catch (err) {
+              console.warn(`[session-pool] slack route error for key ${routingKey} — falling back to local dispatch: ${err instanceof Error ? err.message : String(err)}`);
+            }
+          }
+
+          await slackInboundDispatch(message);
         });
 
         await slackAdapter.start();
@@ -14431,7 +14503,43 @@ export async function startServer(options: StartOptions): Promise<void> {
               // named here). Never blocks message delivery.
               if (Number.isFinite(wsTopic)) _topicProfileCarrier?.onTopicAcquired(wsTopic);
             }
-            if (_sessionPoolStage() === 'dark' || !telegram) return;
+            if (_sessionPoolStage() === 'dark') return;
+            // ── WS1.1 Slack arm (owner-side bridge) ──────────────────────────
+            // A Slack routing key is a non-numeric string (`C…` channel id, or
+            // `C…:<thread_ts>` for a thread session); a Telegram topic key is a
+            // pure number. When the forwarded session key isn't numeric, this is a
+            // Slack conversation that was forwarded here because THIS machine owns
+            // it: reconstruct the inbound Message and replay it through the SAME
+            // local Slack dispatch the live path uses (which itself handles
+            // inject-into-live-session vs spawn). Fire-and-forget: the durable
+            // receipt is already recorded + ACKed before this runs.
+            const slackKey = cmd.session;
+            if (isSlackSessionKey(slackKey)) {
+              if (!_slackInboundDispatch) return; // Slack not configured here
+              const sText = typeof cmd.payload === 'string'
+                ? cmd.payload
+                : (cmd.payload && typeof cmd.payload === 'object' && 'text' in (cmd.payload as object))
+                  ? String((cmd.payload as { text: unknown }).text)
+                  : '';
+              const envUid = (cmd as { senderEnvelope?: { userId?: string | number } }).senderEnvelope?.userId;
+              const sMessage = reconstructSlackMessage({
+                sessionKey: slackKey,
+                messageId: cmd.messageId,
+                text: sText,
+                senderUserId: envUid != null ? String(envUid) : undefined,
+              });
+              void _slackInboundDispatch(sMessage)
+                .then(() => {
+                  console.log(pc.green(`  [session-pool] owner-side Slack dispatch for forwarded key ${slackKey}`));
+                  _inboundQueue?.markRemoteInjected(cmd.session, cmd.messageId);
+                })
+                .catch((err) => {
+                  console.warn(`  [session-pool] owner-side Slack dispatch failed for key ${slackKey}: ${err instanceof Error ? err.message : String(err)}`);
+                  _inboundQueue?.reportPeerInjectError(cmd.session, cmd.messageId, err instanceof Error ? err.message : String(err));
+                });
+              return;
+            }
+            if (!telegram) return;
             const tg = telegram;
             const topicId = Number(cmd.session);
             if (!Number.isFinite(topicId)) return;

--- a/src/core/SlackForwardBridge.ts
+++ b/src/core/SlackForwardBridge.ts
@@ -1,0 +1,65 @@
+/**
+ * SlackForwardBridge — pure helpers for the WS1.1 Slack arm (owner-side bridge).
+ *
+ * When a Slack conversation is forwarded to the machine that OWNS it (via the
+ * §L4 deliverMessage mesh verb), the owner reconstructs the inbound Slack
+ * Message and replays it through the same local dispatch the live inbound path
+ * uses. These two pure functions are the testable core of that reconstruction:
+ *
+ *   - isSlackSessionKey: distinguishes a Slack routing key (a non-numeric string —
+ *     `C…` / `D…` / `G…` channel ids, optionally `:<thread_ts>`) from a Telegram
+ *     topic key (a pure number). The owner-side bridge dispatches a non-numeric
+ *     key to Slack and a numeric key to Telegram.
+ *   - reconstructSlackMessage: rebuilds the minimal inbound Message shape from a
+ *     forwarded session key + text + sender id, so slackInboundDispatch can
+ *     re-derive the routing key and resume/spawn the owned session.
+ *
+ * Kept pure (no I/O, no adapter handle) so the decision boundary is unit-testable
+ * without a live SlackAdapter — the wiring in server.ts is a thin call into these.
+ */
+
+import type { Message } from './types.js';
+
+/** A Telegram topic key is a pure number; everything else (Slack `C…:ts`) is not. */
+export function isSlackSessionKey(sessionKey: string): boolean {
+  return !/^\d+$/.test(sessionKey);
+}
+
+/**
+ * Split a Slack routing key back into channel id + optional thread_ts. The Slack
+ * channel id never contains ':' (always `C…`/`D…`/`G…`), so the first ':' is the
+ * boundary — mirrors SlackAdapter.parseRoutingKey but with no adapter dependency.
+ */
+export function parseSlackRoutingKey(routingKey: string): { channelId: string; threadTs?: string } {
+  const idx = routingKey.indexOf(':');
+  if (idx === -1) return { channelId: routingKey };
+  return { channelId: routingKey.slice(0, idx), threadTs: routingKey.slice(idx + 1) };
+}
+
+/**
+ * Reconstruct the minimal inbound Slack Message from a forwarded deliverMessage.
+ * `slackInboundDispatch` re-derives the routing key via
+ * resolveRoutingKey(channelId, threadTs), so passing channel + thread + sender is
+ * sufficient for the owner to resume/spawn the owned session.
+ */
+export function reconstructSlackMessage(opts: {
+  sessionKey: string;
+  messageId: string;
+  text: string;
+  senderUserId?: string;
+}): Message {
+  const { channelId, threadTs } = parseSlackRoutingKey(opts.sessionKey);
+  return {
+    id: opts.messageId,
+    userId: opts.senderUserId ?? channelId,
+    content: opts.text,
+    channel: { type: 'slack', identifier: channelId },
+    receivedAt: new Date().toISOString(),
+    metadata: {
+      channelId,
+      threadTs,
+      isDM: channelId.startsWith('D'),
+      slackUserId: opts.senderUserId,
+    },
+  };
+}

--- a/tests/e2e/session-pool-delivermessage-e2e.test.ts
+++ b/tests/e2e/session-pool-delivermessage-e2e.test.ts
@@ -120,3 +120,113 @@ describe('Session Pool deliverMessage — Tier-3 feature alive (§L4)', () => {
     expect(r.body.reason).toBe('not-router');
   });
 });
+
+/**
+ * Tier-3 E2E (WS1.1 Slack arm "feature alive"): the owner-side onAccepted bridge
+ * wired the PRODUCTION way — the shared createDeliverMessageHandler factory with an
+ * onAccepted that routes a forwarded SLACK-keyed deliverMessage to the Slack
+ * dispatch (via the same isSlackSessionKey + reconstructSlackMessage helpers
+ * server.ts boot uses), over a REAL MeshRpcDispatcher + /mesh/rpc route + SQLite
+ * ledger. Proves a forwarded Slack conversation actually reaches Slack dispatch on
+ * the owner — and that a numeric (Telegram) key is NOT routed to Slack.
+ */
+describe('WS1.1 Slack arm — owner-side onAccepted dispatches a forwarded Slack key (feature alive)', () => {
+  let dir: string;
+  let server: Server;
+  let ledger: MessageProcessingLedger;
+  let registry: SessionOwnershipRegistry;
+  const keys: Record<string, { priv: string; pub: string }> = {};
+  // What the owner-side bridge would dispatch into Slack vs Telegram.
+  let slackDispatched: Array<{ channelId: string; threadTs?: string; text: string; userId: string }>;
+  let telegramRouted: string[];
+
+  beforeEach(async () => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'dm-slack-e2e-'));
+    for (const id of ['ROUTER', 'OWNER']) {
+      const kp = generateSigningKeyPair();
+      keys[id] = { priv: kp.privateKey, pub: kp.publicKey };
+    }
+    ledger = MessageProcessingLedger.openMemory();
+    const seenOwn = new Set<string>();
+    registry = new SessionOwnershipRegistry({ store: new InMemorySessionOwnershipStore(), seenNonce: (k) => seenOwn.has(k), recordNonce: (k) => seenOwn.add(k) });
+    slackDispatched = [];
+    telegramRouted = [];
+
+    // Production-shaped onAccepted: the EXACT Slack-vs-Telegram branch from
+    // server.ts, using the same exported helpers. The Slack dispatch + Telegram
+    // path are captured here instead of touching tmux.
+    const { isSlackSessionKey, reconstructSlackMessage } = await import('../../src/core/SlackForwardBridge.js');
+    const deliverMessageHandler = createDeliverMessageHandler({
+      ownerEpochOf: (s) => registry.read(s)?.ownershipEpoch ?? null,
+      recordReceipt: (messageId, session) => ledger.record(messageId, { platform: 'mesh', topic: session }).firstSeen,
+      onAccepted: (cmd) => {
+        const text = typeof cmd.payload === 'string'
+          ? cmd.payload
+          : (cmd.payload && typeof cmd.payload === 'object' && 'text' in (cmd.payload as object))
+            ? String((cmd.payload as { text: unknown }).text)
+            : '';
+        if (isSlackSessionKey(cmd.session)) {
+          const envUid = (cmd as { senderEnvelope?: { userId?: string | number } }).senderEnvelope?.userId;
+          const m = reconstructSlackMessage({ sessionKey: cmd.session, messageId: cmd.messageId, text, senderUserId: envUid != null ? String(envUid) : undefined });
+          slackDispatched.push({ channelId: m.channel.identifier, threadTs: m.metadata?.threadTs as string | undefined, text: m.content, userId: m.userId });
+        } else {
+          telegramRouted.push(cmd.session);
+        }
+      },
+    });
+
+    const seenMesh = new Set<string>();
+    const dispatcher = new MeshRpcDispatcher({
+      verify: {
+        selfMachineId: 'OWNER',
+        verify: (c, s, sender) => !!keys[sender] && verify(c, s, keys[sender].pub),
+        isRegisteredPeer: (s) => !!keys[s],
+        seenNonce: (s, n) => seenMesh.has(`${s}:${n}`),
+        now: () => Date.now(),
+      },
+      rbac: { routerHolder: () => 'ROUTER', ownerOf: () => 'OWNER', placementTargetOf: () => 'OWNER' },
+      recordNonce: (s, n) => seenMesh.add(`${s}:${n}`),
+      handlers: { deliverMessage: deliverMessageHandler },
+    });
+    const ctx: any = { config: { authToken: 'test', stateDir: dir, port: 0 }, stateDir: dir, meshRpcDispatcher: dispatcher };
+    const app = express();
+    app.use(express.json());
+    app.use(createRoutes(ctx));
+    server = await listen(app);
+  });
+  afterEach(async () => {
+    await server.close();
+    ledger.close?.();
+    SafeFsExecutor.safeRmSync(dir, { recursive: true, force: true, operation: 'tests/e2e/session-pool-delivermessage-e2e.test.ts' });
+  });
+
+  let nonce = 0;
+  function forwardSlack(messageId: string, session: string, payload: unknown, senderUserId?: string) {
+    const cmd = { type: 'deliverMessage' as const, session, messageId, payload, ownershipEpoch: 1, ...(senderUserId ? { senderEnvelope: { userId: senderUserId } } : {}) };
+    const env = signEnvelope({ sender: 'ROUTER', recipient: 'OWNER', command: cmd as MeshCommand, epoch: 1, nonce: `s${++nonce}`, timestamp: Date.now() }, (c) => sign(c, keys.ROUTER.priv));
+    return fetch(server.url + '/mesh/rpc', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(env) })
+      .then(async (r) => ({ status: r.status, body: await r.json().catch(() => ({})) }));
+  }
+
+  it('ALIVE: a forwarded Slack thread key (200 + queued) dispatches to Slack with channel + thread + sender', async () => {
+    const r = await forwardSlack('slack-evt-1', 'C0123ABCD:1716200000.001500', 'hello from peer', 'U777USER');
+    expect(r.status).toBe(200);
+    expect(r.body.result).toEqual({ messageId: 'slack-evt-1', accepted: 'queued' });
+    expect(slackDispatched).toEqual([{ channelId: 'C0123ABCD', threadTs: '1716200000.001500', text: 'hello from peer', userId: 'U777USER' }]);
+    expect(telegramRouted).toEqual([]); // a Slack key is NEVER routed to Telegram
+  });
+
+  it('a numeric (Telegram topic) key is routed to the Telegram path, NOT Slack — both arms coexist', async () => {
+    const r = await forwardSlack('tg-evt-1', '13481', { text: 'telegram msg' });
+    expect(r.status).toBe(200);
+    expect(telegramRouted).toEqual(['13481']);
+    expect(slackDispatched).toEqual([]);
+  });
+
+  it('a redelivered Slack key is deduped (duplicate ACK) and NOT dispatched twice', async () => {
+    await forwardSlack('slack-evt-2', 'C0123ABCD', 'once', 'U1');
+    const again = await forwardSlack('slack-evt-2', 'C0123ABCD', 'once (retry)', 'U1');
+    expect(again.body.result.accepted).toBe('duplicate');
+    expect(slackDispatched).toHaveLength(1); // dispatched once — redelivery did not re-dispatch
+  });
+});

--- a/tests/integration/session-router-dispatch.test.ts
+++ b/tests/integration/session-router-dispatch.test.ts
@@ -125,6 +125,34 @@ describe('SessionRouter dispatch over MeshRpc (§L4)', () => {
     expect(processed).toEqual(['evt-100']);
   });
 
+  it('WS1.1 Slack arm: a Slack-shaped routing key forwards to the remote owner just like a Telegram topic key', async () => {
+    // The SessionRouter is sessionKey-agnostic: the Slack inbound path consults it
+    // on a routing key like `C0123ABCD:1716200000.001500`. This proves a Slack key
+    // forwards to the owner over the real transport (the bug was the Slack inbound
+    // path NEVER consulting the router at all — it injected locally regardless).
+    const deps: SessionRouterDeps = {
+      selfMachineId: 'ROUTER',
+      placement: new PlacementExecutor(),
+      machineRegistry: () => [cap('ROUTER'), cap('OWNER')],
+      resolveOwnership: () => ({ owner: 'OWNER', epoch: 5, status: 'active' }) as OwnershipView,
+      isMachineAlive: () => true,
+      casClaimOwnership: (_s, _m, e) => ({ ok: true, epoch: e + 1 }),
+      deliverMessage: makeDeliverDep(owner.url),
+      handleLocally: async () => {},
+      spawnOnMachine: async () => {},
+      queueMessage: () => 'refused' as const,
+      raiseAttention: () => {},
+      sleep: async () => {},
+    };
+    const router = new SessionRouter(deps);
+    const slackKey = 'C0123ABCD:1716200000.001500';
+    const out = await router.route({ sessionKey: slackKey, messageId: 'slack-evt-1', payload: 'hi from slack' });
+
+    expect(out).toMatchObject({ action: 'forwarded', owner: 'OWNER', acked: true });
+    expect(ledger).toEqual(['slack-evt-1']);
+    expect(processed).toEqual(['slack-evt-1']);
+  });
+
   it('redelivering the SAME messageId is ACKed as duplicate and NOT re-processed (ledger dedupe)', async () => {
     const deps: SessionRouterDeps = {
       selfMachineId: 'ROUTER',

--- a/tests/unit/SlackForwardBridge.test.ts
+++ b/tests/unit/SlackForwardBridge.test.ts
@@ -1,0 +1,83 @@
+/**
+ * Unit tests for the WS1.1 Slack arm owner-side bridge helpers
+ * (SlackForwardBridge). These cover BOTH sides of the decision boundary the
+ * owner-side onAccepted bridge keys on: numeric (Telegram) vs non-numeric
+ * (Slack) session keys, and the routing-key → Message reconstruction.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  isSlackSessionKey,
+  parseSlackRoutingKey,
+  reconstructSlackMessage,
+} from '../../src/core/SlackForwardBridge.js';
+
+describe('SlackForwardBridge.isSlackSessionKey — Slack vs Telegram key discrimination', () => {
+  it('a pure-numeric key (Telegram topic) is NOT a Slack key', () => {
+    expect(isSlackSessionKey('13481')).toBe(false);
+    expect(isSlackSessionKey('0')).toBe(false);
+    expect(isSlackSessionKey('999999999')).toBe(false);
+  });
+
+  it('a Slack channel id is a Slack key', () => {
+    expect(isSlackSessionKey('C0123ABCD')).toBe(true);
+    expect(isSlackSessionKey('D0456EFGH')).toBe(true); // DM
+    expect(isSlackSessionKey('G0789IJKL')).toBe(true); // private group
+  });
+
+  it('a Slack thread routing key (channel:thread_ts) is a Slack key', () => {
+    expect(isSlackSessionKey('C0123ABCD:1716200000.001500')).toBe(true);
+  });
+});
+
+describe('SlackForwardBridge.parseSlackRoutingKey — split channel + thread', () => {
+  it('a bare channel id has no thread_ts', () => {
+    expect(parseSlackRoutingKey('C0123ABCD')).toEqual({ channelId: 'C0123ABCD' });
+  });
+
+  it('a thread key splits on the first colon (ts contains a dot, never a colon)', () => {
+    expect(parseSlackRoutingKey('C0123ABCD:1716200000.001500')).toEqual({
+      channelId: 'C0123ABCD',
+      threadTs: '1716200000.001500',
+    });
+  });
+});
+
+describe('SlackForwardBridge.reconstructSlackMessage — forwarded → inbound Message', () => {
+  it('reconstructs a channel message with sender id carried through', () => {
+    const m = reconstructSlackMessage({
+      sessionKey: 'C0123ABCD',
+      messageId: 'slack-1716200000.001500',
+      text: 'hello from the peer',
+      senderUserId: 'U999USER',
+    });
+    expect(m.channel).toEqual({ type: 'slack', identifier: 'C0123ABCD' });
+    expect(m.content).toBe('hello from the peer');
+    expect(m.id).toBe('slack-1716200000.001500');
+    expect(m.userId).toBe('U999USER');
+    expect(m.metadata?.channelId).toBe('C0123ABCD');
+    expect(m.metadata?.threadTs).toBeUndefined();
+    expect(m.metadata?.isDM).toBe(false);
+    expect(m.metadata?.slackUserId).toBe('U999USER');
+  });
+
+  it('reconstructs a thread message carrying the thread_ts (so the owner resumes the thread session)', () => {
+    const m = reconstructSlackMessage({
+      sessionKey: 'C0123ABCD:1716200000.001500',
+      messageId: 'slack-1716200099.002000',
+      text: 'reply in thread',
+    });
+    expect(m.channel.identifier).toBe('C0123ABCD');
+    expect(m.metadata?.threadTs).toBe('1716200000.001500');
+  });
+
+  it('marks a DM channel (D-prefixed) so it routes to the lifeline session, and falls back userId→channelId when no sender carried', () => {
+    const m = reconstructSlackMessage({
+      sessionKey: 'D0456EFGH',
+      messageId: 'slack-1',
+      text: 'dm',
+    });
+    expect(m.metadata?.isDM).toBe(true);
+    expect(m.userId).toBe('D0456EFGH'); // no senderUserId → channelId fallback
+    expect(m.metadata?.slackUserId).toBeUndefined();
+  });
+});

--- a/tests/unit/session-pool-activation-wiring.test.ts
+++ b/tests/unit/session-pool-activation-wiring.test.ts
@@ -74,8 +74,12 @@ describe('Session Pool activation wiring (§L4)', () => {
     // Window widened 4200→5000: the working-set move trigger (WORKING-SET-HANDOFF §3.3)
     // now prefixes the onAccepted body before the stage gate.
     const block = src.slice(idx, idx + 7500);
-    // Gated on a non-dark stage + only with Telegram present.
-    expect(block).toContain("_sessionPoolStage() === 'dark' || !telegram");
+    // Gated on a non-dark stage (early return), then the Telegram arm requires
+    // Telegram present. (WS1.1 split the combined gate so a Slack routing key
+    // branches between the two: dark-gate stays shared, the !telegram gate now
+    // applies only to the numeric/Telegram arm.)
+    expect(block).toContain("_sessionPoolStage() === 'dark'");
+    expect(block).toContain('if (!telegram) return;');
     // Bridges to the existing local spawn/resume path for the topic (now wrapped in an
     // async IIFE that first fetches the moved topic's history from the router — bug #2).
     // The spawn name is a clean topic-derived name, NOT the prefixed getSessionForTopic

--- a/tests/unit/slack-thread-session-wiring.test.ts
+++ b/tests/unit/slack-thread-session-wiring.test.ts
@@ -39,13 +39,14 @@ describe('thread→session: adapter API surface exists', () => {
 });
 
 describe('thread→session: the live message path consults the routing key', () => {
-  // Anchor on the onMessage handler region (the handler runs ~200 lines, so the
-  // window must reach past the spawn/register block at the end of it).
-  const handlerStart = SERVER_TS.indexOf('slackAdapter.onMessage(async (message)');
-  const handlerEnd = SERVER_TS.indexOf('await slackAdapter.start();', handlerStart);
+  // Anchor on the shared slackInboundDispatch function — the actual channel→session
+  // dispatch body (WS1.1 split it out of the onMessage closure so the owner-side
+  // mesh bridge can replay it). The window reaches past the spawn/register block.
+  const handlerStart = SERVER_TS.indexOf('const slackInboundDispatch = async (message');
+  const handlerEnd = SERVER_TS.indexOf('_slackInboundDispatch = slackInboundDispatch;', handlerStart);
   const handlerBlock = SERVER_TS.slice(handlerStart, handlerEnd > handlerStart ? handlerEnd : handlerStart + 14000);
 
-  it('the handler computes a routingKey from resolveRoutingKey', () => {
+  it('the dispatch computes a routingKey from resolveRoutingKey', () => {
     expect(handlerStart).toBeGreaterThan(-1);
     expect(handlerBlock).toContain('slackAdapter!.resolveRoutingKey(channelId, threadTs, messageTs)');
   });
@@ -70,6 +71,46 @@ describe('thread→session: the live message path consults the routing key', () 
 
   it('the channel id (raw) is still used for the Slack reply target + spawn channel binding', () => {
     expect(handlerBlock).toContain('slackChannelId: channelId');
+  });
+});
+
+describe('WS1.1 Slack dispatch-to-owner: inbound consults pool placement', () => {
+  // The onMessage handler (distinct from slackInboundDispatch) must route the
+  // inbound message through the SessionRouter BEFORE local dispatch — the exact
+  // fix for "a Slack channel pinned to a peer machine still injected locally".
+  const onMsgStart = SERVER_TS.indexOf('slackAdapter.onMessage(async (message)');
+  const onMsgEnd = SERVER_TS.indexOf('await slackAdapter.start();', onMsgStart);
+  const onMsgBlock = SERVER_TS.slice(onMsgStart, onMsgEnd > onMsgStart ? onMsgEnd : onMsgStart + 6000);
+
+  it('the onMessage handler exists and reaches slackInboundDispatch only after routing', () => {
+    expect(onMsgStart).toBeGreaterThan(-1);
+    expect(onMsgBlock).toContain('await slackInboundDispatch(message)');
+  });
+
+  it('the handler consults the SessionRouter on the routing key (not bare channelId)', () => {
+    expect(onMsgBlock).toContain('_sessionRouter');
+    expect(onMsgBlock).toContain('_sessionRouter.route(');
+    expect(onMsgBlock).toContain('sessionKey: routingKey');
+  });
+
+  it('the handler short-circuits local dispatch when the owner is a remote machine', () => {
+    expect(onMsgBlock).toContain('isRemotelyHandled(outcome, _meshSelfId)');
+  });
+
+  it('routing is gated behind the pool stage so dark = byte-identical local dispatch', () => {
+    expect(onMsgBlock).toContain("_sessionPoolStage() !== 'dark'");
+  });
+
+  it('the owner-side mesh bridge replays a forwarded Slack key through the shared dispatch', () => {
+    // onAccepted: a non-numeric forwarded session key is a Slack conversation
+    // owned by THIS machine → reconstruct the Message and replay it.
+    const acceptStart = SERVER_TS.indexOf('onAccepted: (cmd) => {');
+    expect(acceptStart).toBeGreaterThan(-1);
+    const acceptBlock = SERVER_TS.slice(acceptStart, acceptStart + 4000);
+    expect(acceptBlock).toContain('_slackInboundDispatch');
+    // Slack keys are non-numeric; Telegram topic keys are pure numbers.
+    expect(acceptBlock).toContain('isSlackSessionKey(slackKey)');
+    expect(acceptBlock).toContain('reconstructSlackMessage(');
   });
 });
 

--- a/upgrades/next/slack-pool-dispatch-to-owner.md
+++ b/upgrades/next/slack-pool-dispatch-to-owner.md
@@ -1,0 +1,24 @@
+## What Changed
+
+Extended the **WS1.1 dispatch-to-owner** machinery (Multi-Machine Session Pool) from Telegram to **Slack**, so a Slack conversation follows the user across machines. Previously the Slack adapter's inbound channel→session dispatch was LOCAL-ONLY: a Slack message bound a channel to whatever local session was already running and reused it, IGNORING pool ownership. A live multi-machine test surfaced the bug — a Slack channel's topic was transferred to a peer machine (`POST /pool/transfer` 200, ownership converged `reason:pinned`), but the NEXT Slack message in that channel was still injected into the already-running LOCAL session instead of being routed to the owner machine. Telegram's inbound path already followed a transfer; Slack's never did.
+
+The fix routes Slack inbound through the SAME §L4 `SessionRouter` authority Telegram uses. The Slack `onMessage` handler now consults `_sessionRouter.route()` on the Slack routing key BEFORE local dispatch and short-circuits when `isRemotelyHandled` says the owner is a remote peer (it also honors the custody-ACK short-circuit so a durably-queued message isn't double-handled). The existing Slack dispatch body was extracted into a shared `slackInboundDispatch(message)` function so the live inbound path AND the owner-side mesh bridge replay through one code path (Structure > Willpower — they can't drift). A new pure module `src/core/SlackForwardBridge.ts` (`isSlackSessionKey` / `parseSlackRoutingKey` / `reconstructSlackMessage`) lets the owner-side `onAccepted` bridge distinguish a Slack routing key (non-numeric string `C…`/`C…:thread_ts`) from a Telegram topic key (pure number) and reconstruct the forwarded inbound Message. The whole feature is gated on the existing `_sessionPoolStage() !== 'dark'` — no new config key, route, or authority.
+
+audience: agent-only
+maturity: stable
+
+## What to Tell Your User
+
+Nothing to announce proactively — the multi-machine session pool ships dark by default, so for any single-machine agent (and any agent that hasn't enabled the pool) nothing changes; the Slack inbound path is byte-identical to before. If asked: when you run the agent on more than one machine with the session pool enabled and you move a Slack conversation to another machine, the next Slack message in that channel now correctly goes to the machine that owns the conversation, instead of being answered by the stale session on the old machine. This is the same "follow the user across machines" behavior Telegram already had, now working for Slack.
+
+## Summary of New Capabilities
+
+No standalone new capability and no new config key — this completes the existing dispatch-to-owner capability for a second platform (Slack), behind the already-shipped `multiMachine.sessionPool` dark gate.
+
+## Evidence
+
+Observed before/after for the live multi-machine repro that surfaced the bug:
+
+- **Before:** A Slack channel's topic was transferred/pinned to a peer machine (Mac Mini): `POST /pool/transfer` returned 200 and ownership converged (`reason:pinned`, `pendingReplacement:false`). The NEXT Slack message in that channel was STILL injected into the already-running LOCAL (Laptop) session — never routed to the owner machine. Laptop `logs/server.log` showed the message dispatched locally with no `[session-pool] slack route` line, because the Slack `onMessage` handler never consulted the SessionRouter at all. Telegram's inbound path under the identical scenario correctly forwarded to the owner.
+- **After:** The Slack `onMessage` handler logs `[session-pool] slack route key=<C…> → action=forwarded owner=<peer> … acked=true` and short-circuits local dispatch (`… handled by owner … — not dispatching locally`); the owner machine's `onAccepted` bridge logs `[session-pool] owner-side Slack dispatch for forwarded key <C…>` and resumes/spawns the conversation there. The forwarded message is deduped on the owner's ledger (a redelivery ACKs `duplicate` and is not re-dispatched).
+- **Reproduced in test, not just unit-passing:** `tests/integration/session-router-dispatch.test.ts` drives a Slack-shaped routing key (`C0123ABCD:1716200000.001500`) through the real MeshRpc transport and asserts `action: 'forwarded', owner: 'OWNER'` with the owner's ledger recording it exactly once. `tests/e2e/session-pool-delivermessage-e2e.test.ts` posts a signed forwarded Slack-keyed `deliverMessage` to a real `/mesh/rpc` route and asserts the owner-side bridge dispatches it to Slack with the right channel + thread + sender, while a numeric Telegram key routes to the Telegram path and a redelivery is deduped (`slackDispatched` length stays 1).

--- a/upgrades/side-effects/slack-pool-dispatch-to-owner.md
+++ b/upgrades/side-effects/slack-pool-dispatch-to-owner.md
@@ -1,0 +1,127 @@
+# Side-Effects Review — Slack inbound dispatch consults pool placement (WS1.1 Slack arm)
+
+**Version / slug:** `slack-pool-dispatch-to-owner`
+**Date:** `2026-06-14`
+**Author:** `Instar Agent (echo)`
+**Second-pass reviewer:** `dispatch-reviewer subagent (Phase 5 — touches inbound dispatch)`
+
+## Summary of the change
+
+The Slack adapter's inbound channel→session dispatch was LOCAL-ONLY: a Slack message bound a channel to whatever local session was already running and reused it, IGNORING pool ownership. So when a Slack channel's topic was transferred/pinned to a peer machine (ownership converged, `reason:pinned`), the NEXT Slack message in that channel was still injected into the already-running LOCAL session instead of being routed to the owner machine. Telegram's inbound path already followed a transfer (WS1.1 dispatch-to-owner: SessionRouter consultation + the owner-side `deliverMessage` bridge). This change extends that SAME machinery to Slack: (1) the Slack `onMessage` handler now consults `_sessionRouter.route()` on the Slack routing key BEFORE local dispatch and short-circuits when `isRemotelyHandled` says the owner is a remote peer; (2) the existing Slack dispatch body was extracted into a shared `slackInboundDispatch(message)` function so the live inbound path AND the owner-side bridge replay through one code path; (3) a new pure module `src/core/SlackForwardBridge.ts` (`isSlackSessionKey` / `parseSlackRoutingKey` / `reconstructSlackMessage`) lets the owner-side `onAccepted` bridge distinguish a Slack key (non-numeric string `C…`/`C…:ts`) from a Telegram topic key (pure number) and reconstruct the inbound Message. Files: `src/commands/server.ts` (Slack `onMessage` + owner-side `onAccepted` branch), `src/core/SlackForwardBridge.ts` (new). The whole feature is gated on the existing `_sessionPoolStage() !== 'dark'` — when dark (the fleet default and any single-machine install) the Slack path is byte-identical to today.
+
+## Decision-point inventory
+
+- `Slack onMessage → SessionRouter.route()` (src/commands/server.ts) — **modify** — Slack inbound now consults the §L4 SessionRouter (the existing dispatch authority) before local dispatch, mirroring Telegram. New consultation, not a new authority.
+- `Owner-side onAccepted bridge` (src/commands/server.ts) — **modify** — the forwarded-deliverMessage handler gained a Slack arm: a non-numeric session key reconstructs a Slack Message and replays it through `slackInboundDispatch`; a numeric key keeps the unchanged Telegram path.
+- `isSlackSessionKey` (src/core/SlackForwardBridge.ts) — **add** — a structural validator (numeric vs non-numeric key) selecting WHICH dispatch arm to use. Holds no block/allow authority.
+- `Slack emergency-stop / pause sentinel intercept` — **pass-through** — moved verbatim from the old `onMessage` closure into the new `onMessage` handler; runs on the receiving machine (local-process actions), never forwarded. Unchanged behavior.
+
+---
+
+## 1. Over-block
+
+**What legitimate inputs does this change reject that it shouldn't?**
+
+No block/allow surface — over-block not applicable. The change only ROUTES an inbound message (local dispatch vs forward-to-owner vs durable-queue custody). No Slack message is ever rejected by this change. When the SessionRouter consultation throws, the code falls through to today's local dispatch (fail-safe); when the pool is dark the consultation is skipped entirely.
+
+---
+
+## 2. Under-block
+
+**What failure modes does this still miss?**
+
+No block/allow surface — under-block not applicable. As a routing concern, the residual gaps are: (a) if the owner machine advertises but cannot durably receive (`ownerSupportsForward` false / version skew), the SessionRouter's existing conservative path keeps the message in OUR durable queue rather than forwarding — same as Telegram, by design. (b) The Telegram path also has an inbound-queue ORDERING gate (`_inboundQueue.hasQueued`) that enqueues a live message behind existing queued entries; I mirrored the custody-ACK short-circuit but NOT that ordering pre-gate. Impact is bounded: the inbound queue ships dark, and without the pre-gate a live Slack message for an in-custody session would fall through to the router (which itself custody-checks) rather than strictly ordering behind the queue — a parity refinement, not a correctness break for the primary follow-the-transfer fix. Tracked as a follow-up below, not deferred silently.
+
+---
+
+## 3. Level-of-abstraction fit
+
+**Is this at the right layer?**
+
+Yes. The dispatch authority (SessionRouter, §L4) already exists and is platform-agnostic — it keys on a `string` `sessionKey` and makes the place/forward/queue decision. The right fix is to FEED the Slack inbound path INTO that existing authority, exactly as Telegram does — not to build a parallel Slack-specific ownership resolver. The new `SlackForwardBridge` helpers are low-level structural primitives (key discrimination + Message reconstruction) with no decision authority — the correct layer for them. `parseSlackRoutingKey` deliberately mirrors `SlackAdapter.parseRoutingKey` so the owner-side reconstruction matches the live path's key derivation.
+
+---
+
+## 4. Signal vs authority compliance
+
+**Required reference:** [docs/signal-vs-authority.md](../../docs/signal-vs-authority.md)
+
+**Does this change hold blocking authority with brittle logic?**
+
+- [x] No — this change produces a signal consumed by an existing smart gate.
+- [ ] No — this change has no block/allow surface.
+- [ ] Yes — but the logic is a smart gate with full conversational context.
+- [ ] ⚠️ Yes, with brittle logic — STOP.
+
+The change consults the existing SessionRouter authority (the single owner of the §L4 dispatch decision) and acts on its `RouteOutcome`. `isSlackSessionKey` is a structural validator (numeric vs non-numeric) used only to select the dispatch arm in the owner-side bridge — it never blocks a message; both arms dispatch. No new brittle blocker with authority was introduced.
+
+---
+
+## 5. Interactions
+
+**Does this interact with existing checks, recovery paths, or infrastructure?**
+
+- **Shadowing:** The SessionRouter consultation runs AFTER the sentinel emergency-stop/pause intercept (preserved at the top of `onMessage`) and BEFORE local dispatch. Emergency-stop/pause still short-circuit first (correct — they're local actions). When the pool is dark the consultation block is skipped so the sentinel + local path run exactly as before.
+- **Double-fire:** The exact bug this fixes is double-dispatch (spawn-on-owner AND inject-locally). `isRemotelyHandled(outcome, _meshSelfId)` short-circuits local dispatch whenever the session ended up on another machine, and the custody-ACK short-circuit prevents local fall-through when the durable queue took custody. The owner-side bridge dedupes via the existing `recordReceipt`/ledger (a redelivered messageId ACKs `duplicate` and is NOT re-dispatched — proven in the e2e test).
+- **Races:** The SessionRouter serializes per `sessionKey` (its `chains` map), so two Slack messages for the same routing key dispatch in order, one in-flight — same guarantee Telegram gets. The shared `slackInboundDispatch` reads `getSessionForChannel(routingKey)` the same way the old closure did; no new shared mutable state was introduced.
+- **Feedback loops:** None. The owner-side bridge calls `markRemoteInjected`/`reportPeerInjectError` on the inbound queue (best-effort, gated on `_inboundQueue` which is dark by default) exactly as the Telegram bridge does.
+
+---
+
+## 6. External surfaces
+
+**Does this change anything visible outside the immediate code path?**
+
+- **Other agents on the same machine:** none.
+- **Other users of the install base:** none while dark (fleet default). When the session pool is enabled on a multi-machine Slack-using agent, a Slack conversation now correctly follows a topic transfer between machines — the intended, user-positive behavior.
+- **External systems (Slack):** the owner-side bridge fetches channel history via the Slack API on the OWNER machine (Slack history is server-side, reachable from any machine), and replies via the same `slack-reply.sh` relay path. No new Slack API surface; reuses existing adapter methods.
+- **Persistent state:** none new. Reuses the existing MessageProcessingLedger (receipt dedupe) and the dark-by-default inbound queue. No new config keys, so no migration parity work needed.
+- **Timing/runtime:** the forward is async/bounded by the SessionRouter's existing deliver retry/timeout config — unchanged.
+- **Operator surface (Mobile-Complete):** No operator-facing actions added — this is internal dispatch routing.
+
+---
+
+## 6b. Operator-surface quality
+
+No operator surface — not applicable. The change touches no `dashboard/*` file, approval page, or grant/revoke/secret-drop form.
+
+---
+
+## 7. Multi-machine posture (Cross-Machine Coherence)
+
+**Posture: replicated (dispatch-to-owner).** This feature IS a multi-machine coherence feature — it makes a Slack conversation follow the user across machines. The replication path is the §L4 SessionRouter + the `deliverMessage` mesh verb + the journal-backed `SessionOwnershipRegistry` (the exact path Telegram already uses, WS1.1). Ownership is a LOCAL read of the placement view; a remote-owned conversation forwards over the mesh to the owner, which spawns/injects with CONTINUATION context.
+
+- **User-facing notices / one-voice:** The dispatch itself produces no user-facing notice; the conversation's replies come from exactly one session (the owner's), which is the one-voice property this fix RESTORES (before it, both the stale local session and the new owner could answer).
+- **Durable state on topic transfer:** No new durable state strands — the owner-side bridge reconstructs the Message from the forwarded payload and the session registry is per-machine, resolved fresh on each side.
+- **URLs across machine boundaries:** none generated.
+- **Single-machine / dark:** strict no-op — gated on `_sessionPoolStage() !== 'dark'`; a single-machine or dark-pool agent runs the byte-identical local dispatch.
+
+---
+
+## 8. Rollback cost
+
+Pure code change — revert the commit and ship as the next patch. No persistent state is created (reuses existing ledger + dark inbound queue), no new config key, no migration. While dark (fleet default) the change is inert, so a rollback has zero user-visible effect on the install base. On a multi-machine Slack agent with the pool enabled, rollback simply restores the prior local-only Slack dispatch (the pre-fix behavior).
+
+---
+
+## Conclusion
+
+The review produced no design changes — the implementation already feeds the existing SessionRouter authority rather than adding a parallel brittle blocker, and is gated dark/additive. One parity refinement (the inbound-queue ORDERING pre-gate that the Telegram path has) is surfaced as a tracked follow-up rather than silently deferred; it does not affect the correctness of the primary follow-the-transfer fix because the SessionRouter custody-checks regardless. The change is clear to ship behind the existing dark pool gate. (Separately surfaced as a tracked follow-up, NOT fixed here to avoid scope-creep: ~33 `[mesh-rpc] rejected session-status: stale-timestamp` rejections observed in a live multi-machine log despite `/pool` reporting `clockSkew:ok` — needs live cross-machine timestamp-vs-receipt diagnosis; widening the 30s tolerance blindly would weaken the replay-window guard.)
+
+---
+
+## Second-pass review (if required)
+
+**Reviewer:** dispatch-reviewer subagent
+**Independent read of the artifact: concur**
+
+Concur with the review. The change feeds the existing §L4 SessionRouter authority rather than adding a new blocker — `isSlackSessionKey` is a pure numeric-vs-string validator selecting a dispatch arm (both arms dispatch; no block authority), so it is signal-vs-authority compliant. Double-dispatch is closed on both ends: the inbound path short-circuits via `isRemotelyHandled` + the custody-ACK check (identical arms to Telegram's), and the owner-side Slack branch sits inside `DeliverMessageHandler`'s `recordReceipt`-gated `onAccepted`, so a redelivered forward ACKs `duplicate` and never re-dispatches (proven by the e2e test). On a `route()` throw the path falls through to local dispatch (fail-safe, never drops), and the whole block is dark-gated so single-machine/dark agents are byte-identical. The admitted Telegram-parity divergence (the inbound-queue ordering pre-gate) is correctness-neutral for the primary fix because the inbound queue ships dark and the SessionRouter custody-checks regardless — acceptable as a tracked follow-up.
+
+---
+
+## Evidence pointers
+
+- Unit: `tests/unit/SlackForwardBridge.test.ts` (8 tests — both sides of the Slack-vs-Telegram key boundary + reconstruction), `tests/unit/slack-thread-session-wiring.test.ts` (21 tests — re-anchored on `slackInboundDispatch` + new WS1.1 pool-routing wiring assertions).
+- Integration: `tests/integration/session-router-dispatch.test.ts` (Slack-shaped routing key forwards to the remote owner over real MeshRpc).
+- E2E "feature alive": `tests/e2e/session-pool-delivermessage-e2e.test.ts` (owner-side `onAccepted` dispatches a forwarded Slack key to Slack with channel+thread+sender; a numeric Telegram key routes to the Telegram path; redelivery deduped).
+- Wiring ratchet preserved: `tests/unit/session-pool-activation-wiring.test.ts` updated for the split dark-gate / `!telegram` gate.


### PR DESCRIPTION
## What Changed

The Slack adapter's inbound channel→session dispatch was **LOCAL-ONLY**: a Slack message bound a channel to whatever local session was already running and reused it, **ignoring pool ownership**. So when a Slack channel's topic was transferred/pinned to a peer machine (ownership converged, `reason:pinned`), the NEXT Slack message in that channel was still injected into the already-running LOCAL session instead of being routed to the owner machine. Telegram's inbound path already followed a transfer (WS1.1 dispatch-to-owner: `SessionRouter` consultation + the owner-side `deliverMessage` bridge); Slack's never did. This was surfaced by a live 3-machine "Luna on Slack" test.

**Fix — extend the SAME WS1.1 machinery to Slack:**
- The Slack `onMessage` handler now consults the existing §L4 `SessionRouter` on the Slack routing key **before** local dispatch and short-circuits when `isRemotelyHandled` says the owner is a remote peer (plus the custody-ACK short-circuit so a durably-queued message isn't double-handled). Mirrors the Telegram inbound block.
- The existing Slack dispatch body is extracted into a shared `slackInboundDispatch()` so the live inbound path **and** the owner-side mesh bridge replay through ONE path (Structure > Willpower — they can't drift). The sentinel emergency-stop/pause intercept moves to the new `onMessage` handler (it runs on the receiving machine — local-process actions, never forwarded).
- New pure module `src/core/SlackForwardBridge.ts` (`isSlackSessionKey` / `parseSlackRoutingKey` / `reconstructSlackMessage`): the owner-side `onAccepted` bridge branches a Slack key (non-numeric string `C…`/`C…:thread_ts`) vs a Telegram topic key (pure number) and reconstructs the forwarded inbound `Message`.

**Signal vs authority:** no new brittle blocker — the change *feeds* the existing `SessionRouter` authority (the single owner of the §L4 dispatch decision). `isSlackSessionKey` is a structural validator selecting which dispatch arm to use; both arms dispatch, it holds no block authority.

**Phase-C ready:** the `SessionRouter` is N-machine / no-LAN / headless-agnostic (keys on a `string` `sessionKey`); no 2-peer hardcoding.

**Additive + dark-gated:** gated on the existing `_sessionPoolStage() !== 'dark'` — **no new config key, route, or authority**; byte-identical when dark (fleet default / any single-machine install). Pure code change; rollback = revert + patch.

## Tests (3 tiers + wiring)

- **Unit:** `tests/unit/SlackForwardBridge.test.ts` (both sides of the Slack-vs-Telegram key boundary + Message reconstruction); `tests/unit/slack-thread-session-wiring.test.ts` re-anchored on `slackInboundDispatch` + new pool-routing wiring assertions.
- **Integration:** `tests/integration/session-router-dispatch.test.ts` — a Slack-shaped routing key forwards to the remote owner over real MeshRpc.
- **E2E (feature alive):** `tests/e2e/session-pool-delivermessage-e2e.test.ts` — owner-side `onAccepted` dispatches a forwarded Slack key to Slack with channel+thread+sender; a numeric Telegram key routes to the Telegram path; a redelivery is deduped.
- **Wiring ratchet preserved:** `tests/unit/session-pool-activation-wiring.test.ts` updated for the split dark-gate / `!telegram` gate.

Tier 2 (dispatch surface) — driven by the approved `MULTI-MACHINE-SEAMLESSNESS-SPEC.md` (WS1.1); side-effects artifact + second-pass dispatch review (concur) staged at `upgrades/side-effects/slack-pool-dispatch-to-owner.md`.

## ELI16 — Slack conversations now follow you between your machines

When you run your agent on more than one computer, it can move a conversation from one machine to another (the "session pool"). Telegram already handled this: after a move, your next Telegram message went to the machine now in charge of that chat. Slack did **not** — a live test caught it. You'd move a Slack channel to your Mac Mini, the move would succeed, but your next Slack message in that channel would still be answered by the old session on your laptop, as if the move never happened. The laptop "owned" the channel by accident, just because it was the machine where a session happened to already be running.

This change makes Slack behave exactly like Telegram. When a Slack message comes in, the agent first asks the shared "who owns this conversation?" router — the same one Telegram already uses — and if another machine owns it, the message is handed to that machine instead of being answered locally. The machine that owns the conversation picks it up (resuming or starting a session there), so you keep talking to one agent, not two copies. A small helper tells Slack channel ids (like `C0123`) apart from Telegram topic numbers so the moved-to machine knows how to rebuild and handle a forwarded Slack message.

It's all off unless you've turned on the multi-machine session pool, which ships disabled by default — so for a single-machine agent, or any agent that hasn't enabled the pool, **nothing changes**; the Slack path runs exactly as before. There's no new setting, no new command, and if anything goes wrong while deciding ownership it safely falls back to answering locally (it never drops your message). The thing to know: this completes "your agent follows you across machines" for Slack, matching what Telegram already did.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
