### PR TITLE
fix(monitoring): network-class uncaught exceptions degrade, not crash (CMT-1548)

### DIFF
--- a/.instar/instar-dev-decisions/2026-06-15T03-24-25-996Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-06-15T03-24-25-996Z-unknown.json
@@ -1,0 +1,13 @@
+{
+  "ts": "2026-06-15T03:24:25.996Z",
+  "slug": "unknown",
+  "suggestedTier": 1,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 18,
+  "causalAutopsy": null,
+  "verdict": "pass"
+}

--- a/docs/specs/cmt1548-uncaught-fetch-degrade.eli16.md
+++ b/docs/specs/cmt1548-uncaught-fetch-degrade.eli16.md
@@ -1,0 +1,35 @@
+# Network errors shouldn't crash the whole agent — Plain-English Overview
+
+> The one-line version: a failed network call during an outage was crashing the entire server instead of being shrugged off — this teaches the crash-handler to treat network failures as recoverable.
+
+## The problem in one breath
+
+When the internet (or a peer machine, or Anthropic's API) is briefly unreachable, some background network call fails. If nobody caught that failure, it bubbles all the way up as an "uncaught exception" — and the server's default reaction to an uncaught exception is to shut the whole agent down. On 2026-06-15, during an API/network rough patch, exactly this happened: a routine "fetch failed" took the server down (it restarted itself ~50 seconds later, but it shouldn't have gone down at all).
+
+## What already exists
+
+- **The crash handler** — at the very top of the server there's a catch-all for "uncaught exceptions." By default it does the safe thing for a truly-unknown error: close the databases cleanly and exit, so the next boot isn't corrupted.
+- **A recoverable-errors allowlist** — the handler already knows that a *small, specific* set of errors are harmless and should be logged-and-ignored instead of crashing: web-server double-reply hiccups, a Slack reconnect race, and a "this machine is on standby" stray write. These were added one at a time as each proved harmless.
+- **First-seen-stack logging** — when it suppresses one of those, it logs the full origin the first time so the real un-guarded spot is still findable and fixable, then stays quiet on repeats so the log doesn't flood.
+
+## What this adds
+
+Network failures join that allowlist. A failed outbound network call — talking to a peer machine, reconnecting to Slack, any HTTP request — is *isolated by nature*: that one call gave up, but the databases, the web server, and everything else are completely fine, and whatever made the call will simply try again. So crashing the entire agent over it is strictly worse than logging it and moving on. The specific signatures added are the ones Node and its HTTP library actually produce: `fetch failed`, `ECONNREFUSED`, `ECONNRESET`, `ETIMEDOUT`, `ENOTFOUND`, `EAI_AGAIN`, and `socket hang up`.
+
+## The new pieces
+
+- **Seven new allowlist entries (plus a comment explaining why).** No new code paths, no new module — just additions to the existing list the handler already consults. The handler's logic is untouched.
+
+## The safeguards
+
+**Keeps the safe default.** Anything the handler doesn't recognize still crashes, exactly as before. We only *added* recognized-as-harmless cases; we didn't change what happens to unknown errors.
+
+**Keeps the boundary tight.** The matching is on specific network tokens, not on a loose word like "failed." A unit test proves that ordinary failures such as "assertion failed" or "migration failed" still crash — they are not swept up by the network rule.
+
+**Doesn't hide the real bug.** The first-seen-stack logging still fires, so the actual un-guarded network call that threw is still recorded and can be properly wrapped later. This entry is the safety net, not an excuse to skip the proper fix.
+
+**Reversible instantly.** It's a pure code change with no saved data or migrations — if it ever proved wrong, removing the seven lines restores the old behavior on the next build.
+
+## What ships when
+
+One Tier-1 change: the allowlist additions plus the tests, in a single PR. The optional follow-up — wrapping the specific network calls (the peer broadcast and the Slack reconnect) so they never reach the catch-all in the first place — can land separately; this backstop is valuable on its own and protects every future un-guarded network call too.

--- a/src/core/uncaughtExceptionPolicy.ts
+++ b/src/core/uncaughtExceptionPolicy.ts
@@ -39,6 +39,24 @@ const NON_FATAL_UNCAUGHT_PATTERNS = [
   // This is a crash backstop ONLY — it does not change lease/standby behavior;
   // it stops a standby write from taking the process down.
   'StateManager is read-only',
+  // Network-class outbound failures (transient upstream/peer outage). A failed
+  // outbound fetch — the multi-machine lease-wire peer broadcast, a Slack
+  // connect/reconnect, any HTTP call — is ISOLATED by nature: the call has
+  // already unwound and SQLite, HTTP, and the other subsystems are intact. The
+  // owning subsystem retries/self-heals (lease-wire re-broadcasts; the socket
+  // reconnects with backoff). Crashing the whole agent on a transient network
+  // blip is strictly worse than logging + continuing — it was the cause of the
+  // 2026-06-15 crash-during-API-instability (an uncaught `fetch failed` took the
+  // server down mid-outage). The first-seen-stack logging below still surfaces
+  // the un-guarded callsite so the real missing `.catch` gets fixed; this is the
+  // crash backstop, NOT a license to skip the catch. (CMT-1548)
+  'fetch failed',          // undici / Node global fetch network failure
+  'ECONNREFUSED',
+  'ECONNRESET',
+  'ETIMEDOUT',
+  'ENOTFOUND',
+  'EAI_AGAIN',
+  'socket hang up',
 ];
 
 /**

--- a/tests/unit/uncaughtExceptionPolicy.test.ts
+++ b/tests/unit/uncaughtExceptionPolicy.test.ts
@@ -39,10 +39,29 @@ describe('isNonFatalUncaught', () => {
     ).toBe(true);
   });
 
+  it('treats network-class outbound failures as recoverable (CMT-1548 — a transient outage must not crash the agent)', () => {
+    // The exact crasher: an uncaught `fetch failed` during an upstream/peer
+    // outage (e.g. the multi-machine lease-wire broadcast to an offline peer)
+    // took the whole server down on 2026-06-15. A failed outbound call is
+    // isolated; the owning subsystem retries.
+    expect(isNonFatalUncaught(new Error('fetch failed'))).toBe(true);
+    expect(isNonFatalUncaught(new TypeError('fetch failed'))).toBe(true); // undici throws a TypeError
+    expect(isNonFatalUncaught(new Error('connect ECONNREFUSED 127.0.0.1:4042'))).toBe(true);
+    expect(isNonFatalUncaught(new Error('read ECONNRESET'))).toBe(true);
+    expect(isNonFatalUncaught(new Error('connect ETIMEDOUT'))).toBe(true);
+    expect(isNonFatalUncaught(new Error('getaddrinfo ENOTFOUND relay.example.com'))).toBe(true);
+    expect(isNonFatalUncaught(new Error('getaddrinfo EAI_AGAIN relay.example.com'))).toBe(true);
+    expect(isNonFatalUncaught(new Error('socket hang up'))).toBe(true);
+  });
+
   it('treats an UNKNOWN error as fatal (crash is the safe default)', () => {
     expect(isNonFatalUncaught(new Error('mutex lock failed'))).toBe(false);
     expect(isNonFatalUncaught(new Error('Cannot read properties of undefined'))).toBe(false);
     expect(isNonFatalUncaught(new Error('better-sqlite3 database is closed'))).toBe(false);
+    // A non-network "failed" message must NOT be caught by the network patterns
+    // (boundary stays tight — we match specific tokens, not a bare "failed").
+    expect(isNonFatalUncaught(new Error('assertion failed'))).toBe(false);
+    expect(isNonFatalUncaught(new Error('migration failed'))).toBe(false);
   });
 
   it('is robust to non-Error inputs', () => {

--- a/upgrades/next/cmt1548-uncaught-fetch-degrade.md
+++ b/upgrades/next/cmt1548-uncaught-fetch-degrade.md
@@ -1,0 +1,17 @@
+## What Changed
+
+Fixed a robustness gap where a transient network failure could crash the whole agent server. The top-level uncaught-exception handler crashes by default and only log-and-continues for a tight allowlist of known-isolated errors (HTTP double-response races, the Slack reconnect race, standby read-only writes). Network-class failures weren't on that list — so on 2026-06-15, during an API/network rough patch, an uncaught `fetch failed` (the multi-machine lease-wire broadcasting to an offline peer) took the server down (it auto-restarted ~50s later). Network-class tokens (`fetch failed`, `ECONNREFUSED`, `ECONNRESET`, `ETIMEDOUT`, `ENOTFOUND`, `EAI_AGAIN`, `socket hang up`) are now on the recoverable allowlist, so an isolated outbound-fetch failure degrades (log + continue) instead of crashing. The handler logic is untouched; any unrecognized error still crashes (the safe default), and the first-seen-stack logging still surfaces the un-guarded callsite so the real missing `.catch` gets fixed.
+
+## What to Tell Your User
+
+Nothing they need to do. The practical effect is fewer unexpected restarts: during a brief internet/API/peer-machine outage, the agent now rides it out and keeps serving instead of restarting itself over a failed background network call.
+
+## Summary of New Capabilities
+
+- The crash safety net treats transient network-class failures (`fetch failed` and common connection error codes) as recoverable — log-and-continue, not crash — while keeping the safe default (crash) for every unrecognized error.
+
+## Evidence
+
+- Unit tests: `tests/unit/uncaughtExceptionPolicy.test.ts` — 11/11 pass, including the new network-class positive cases (incl. undici `TypeError('fetch failed')`) and boundary cases proving `assertion failed` / `migration failed` / sqlite / undefined-property errors still crash.
+- Root cause in logs: `logs/server.log` 2026-06-15T01:50:28Z `[FATAL] Uncaught exception — closing databases before crash: fetch failed`, preceded by `[lease-wire] broadcast to m_4cbc… became unreachable: fetch failed`.
+- Side-effects review + independent adversarial second pass (concur): `upgrades/side-effects/cmt1548-uncaught-fetch-degrade.md`.

--- a/upgrades/side-effects/cmt1548-uncaught-fetch-degrade.md
+++ b/upgrades/side-effects/cmt1548-uncaught-fetch-degrade.md
@@ -1,0 +1,99 @@
+# Side-Effects Review — network-class uncaught exceptions degrade, not crash (CMT-1548)
+
+**Version / slug:** `cmt1548-uncaught-fetch-degrade`
+**Date:** `2026-06-15`
+**Author:** `Echo (instar-dev agent)`
+**Second-pass reviewer:** `adversarial reviewer subagent (see §Second-pass)`
+
+## Summary of the change
+
+The server's top-level `process.on('uncaughtException')` handler (`src/commands/server.ts`) crashes by default and only log-and-continues for errors whose message matches `NON_FATAL_UNCAUGHT_PATTERNS` in `src/core/uncaughtExceptionPolicy.ts`. That allowlist already covers HTTP double-response races, the Slack `Sent before connected` reconnect race, and standby read-only writes — but NOT network-class failures. On 2026-06-15 a transient `fetch failed` (the multi-machine lease-wire broadcasting to an offline peer, during an upstream/API outage) hit the handler as an uncaught exception and crashed the whole server (it auto-restarted ~50s later). This change adds network-class tokens (`fetch failed`, `ECONNREFUSED`, `ECONNRESET`, `ETIMEDOUT`, `ENOTFOUND`, `EAI_AGAIN`, `socket hang up`) to the allowlist, with a justification comment, plus unit tests on both sides of the boundary. Files: `src/core/uncaughtExceptionPolicy.ts` (+8 patterns +comment), `tests/unit/uncaughtExceptionPolicy.test.ts` (+1 positive block, +2 negative boundary cases). Handler logic untouched.
+
+## Decision-point inventory
+
+- `isNonFatalUncaught() recoverable-vs-fatal boundary` (`src/core/uncaughtExceptionPolicy.ts`) — **modify** — extends the existing recoverable allowlist with network-class tokens. Default for any unmatched error stays crash (the safe default).
+
+---
+
+## 1. Over-block
+
+In this context "over-block" = **suppressing an uncaught error that SHOULD have crashed** (false-recoverable). The risk: an error whose message merely *contains* a network token (e.g. a programming bug whose message happens to include "socket hang up") is now suppressed and the process keeps running in a possibly-degraded state instead of crashing clean.
+
+Concrete shapes considered: `'fetch failed'` and the `E*` codes are emitted by Node/undici for genuine network failures only — they are not substrings of common logic-bug messages. `'socket hang up'` and `'ECONNRESET'` are the broadest; both are still network-transport phrases, not general-purpose words. The boundary test asserts `'assertion failed'` / `'migration failed'` stay fatal (a bare "failed" is NOT matched — we match specific tokens). Residual risk is low and is the deliberate trade: a transient network blip must not crash the agent, and the first-seen-stack log surfaces any wrongly-suppressed origin for follow-up.
+
+---
+
+## 2. Under-block
+
+"Under-block" = **still crashing on something that was recoverable**. A network failure surfaced with a message outside this token set (e.g. a custom wrapper that rethrows "upstream unavailable" without the underlying code) would still crash. That is acceptable — the allowlist is intentionally tight; we add tokens as real crashes prove them recoverable rather than matching a broad "any network-ish word." The belt-and-suspenders follow-up (a `.catch` at the lease-wire broadcast + slack reconnect fetch paths) is the primary fix; this policy entry is the backstop.
+
+---
+
+## 3. Level-of-abstraction fit
+
+Correct layer. This is the process-level last-resort crash backstop — the established home for "this isolated error must not take the whole agent down." It is intentionally a low-level substring detector defaulting to the SAFE direction (crash on anything unrecognized). It does not replace the proper fix (guard the originating fetch with `.catch`); it prevents a missing-catch from escalating a transient outage into a crash-loop. A higher-level gate is not appropriate for a synchronous uncaught-exception handler.
+
+---
+
+## 4. Signal vs authority compliance
+
+**Required reference:** docs/signal-vs-authority.md
+
+- [x] Yes — but the logic is the EXISTING, blessed crash-backstop pattern, and it fails toward the safe default (crash) for anything unmatched.
+
+This entry extends an established allowlist whose whole design is: recognized-isolated → continue; everything else → crash. It holds "crash vs continue" authority, but with the conservative default (unknown ⇒ crash). It is not a new brittle detector owning block-authority over user input; it is the same precedent already shipping for HTTP races, Slack reconnects, and standby writes. The first-seen-stack diagnostic preserves the path to fixing the real missing-catch. No reshaping needed; the design matches the existing pattern exactly.
+
+---
+
+## 5. Interactions
+
+- **Shadowing:** runs only inside the top-level `uncaughtException` handler; no ordering against other checks. A matched error returns before `closeAllSqlite()` + `process.exit(1)`. No other check is shadowed.
+- **Double-fire:** none — a single uncaught exception is handled once.
+- **Races:** none — the policy is a pure substring function over the error message; no shared state. (`shouldLogStackForUncaught`'s dedup set is unchanged.)
+- **Feedback loops:** the change REDUCES a feedback loop — it stops the boot→transient-fetch-fail→FATAL→respawn→… crash-loop on a sustained outage.
+
+---
+
+## 6. External surfaces
+
+Fleet-wide runtime behavior change: every instar server will now log-and-continue (instead of crash+respawn) on an uncaught network-class error. User-visible effect is strictly positive (fewer unexpected restarts during upstream/network outages). No change to response formats, ledgers, databases, or any persistent state. No external system (Telegram/Slack/GitHub/Cloudflare) is called differently. No timing dependence. **Operator surface:** none — this change adds no operator-facing action.
+
+---
+
+## 6b. Operator-surface quality (Operator-Surface Quality standard)
+
+No operator surface — not applicable. This change touches no dashboard renderer, approval page, or grant/revoke/secret-drop form.
+
+---
+
+## 7. Multi-machine posture (Cross-Machine Coherence)
+
+**machine-local BY DESIGN** — the crash handler is per-process; each machine's server runs its own `uncaughtException` handler, and that is correct (a crash decision is inherently about the local process). There is no cross-machine state to replicate. Note the *motivating* failure was a multi-machine path (the lease-wire peer broadcast to an offline peer threw the uncaught `fetch failed`), so the benefit accrues most on multi-machine installs — but the fix itself is correctly per-process. Emits no user-facing notices (no one-voice gating needed). Holds no durable state (nothing strands on topic transfer). Generates no URLs.
+
+---
+
+## 8. Rollback cost
+
+Pure code change — revert the two files and ship as the next patch. No data migration, no persistent state, no agent-state repair, no user-visible regression during the rollback window. Reversible by removing the added patterns; the allowlist returns to its prior behavior immediately on the reverted build.
+
+---
+
+## Conclusion
+
+A tight, additive, well-precedented fix to the existing crash-backstop allowlist that resolves a real fleet-wide failure mode (a transient network error crashing the whole server during an outage). The review surfaced one genuine residual risk — over-suppression of a non-network error whose message coincidentally contains a network token — mitigated by keeping the token set specific (boundary test proves a bare "failed" is not matched) and by the first-seen-stack diagnostic that surfaces any wrongly-suppressed origin. Clear to ship as a Tier-1 change.
+
+---
+
+## Second-pass review (if required)
+
+**Reviewer:** adversarial reviewer subagent
+**Independent read of the artifact: concur**
+
+Independently verified the test green (11/11 via `vitest run`). Decisive adversarial check: every genuinely-fatal Node/TS error family — OOM (`JavaScript heap out of memory`), `SQLITE_CORRUPT` / `database is locked` / `database is closed`, `EMFILE` / `ENOSPC`, `EPIPE`, `Maximum call stack size exceeded`, and the classic `Cannot read properties of undefined` — all still CRASH, because the network-transport tokens are disjoint from those messages (confirmed by direct substring testing). The `E*` codes are SCREAMING_SNAKE and never appear inside ordinary logic-bug prose, so the `includes` matcher is safe. The only over-suppression constructible (`fetch failed` hiding a non-transient TLS/DNS `.cause`, or a contrived property literally named `'ECONNRESET'`) is either implausible or genuinely isolated-and-recoverable per the handler's contract, with the first-seen-stack diagnostic still surfacing the origin. The boundary tests (`assertion failed`/`migration failed` stay fatal) are load-bearing and correctly prove no bare-`failed` overreach. Clear to ship.
+
+---
+
+## Evidence pointers
+
+- Unit test: `tests/unit/uncaughtExceptionPolicy.test.ts` — 11/11 pass (verified locally via `vitest run`), incl. the new network-class positive block and the `assertion failed`/`migration failed` negative boundary cases.
+- Root-cause log evidence: `logs/server.log` 2026-06-15T01:50:28Z `[FATAL] Uncaught exception — closing databases before crash: fetch failed`, preceded by `[lease-wire] broadcast to m_4cbc... became unreachable: fetch failed`.


### PR DESCRIPTION
## ELI16 — Network errors shouldn't crash the whole agent

When the internet, a peer machine, or Anthropic's API is briefly unreachable, a background network call fails. If nobody caught that failure, it bubbles up as an "uncaught exception" — and the server's default reaction to an uncaught exception is to shut the whole agent down. On 2026-06-15, during an API/network rough patch, exactly this happened: a routine `fetch failed` (the multi-machine lease-wire broadcasting to an offline peer) took the server down. It restarted itself ~50 seconds later, but it shouldn't have gone down at all.

This change teaches the crash-handler to treat network failures as recoverable: a failed outbound call is isolated by nature — that one call gave up, but the databases, the web server, and everything else are fine, and whatever made the call will simply retry. So we add the specific signatures Node and its HTTP library actually produce (`fetch failed`, `ECONNREFUSED`, `ECONNRESET`, `ETIMEDOUT`, `ENOTFOUND`, `EAI_AGAIN`, `socket hang up`) to the existing recoverable-errors allowlist. The safe default is unchanged: any unrecognized error still crashes, the boundary stays tight (a unit test proves "assertion failed" / "migration failed" still crash), and first-seen-stack logging still records the un-guarded callsite so the proper `.catch` can land later. Pure code change, no migrations — instantly reversible.

## What

A transient network failure could crash the whole agent server. The top-level `process.on('uncaughtException')` handler crashes by default and only log-and-continues for a tight allowlist (`NON_FATAL_UNCAUGHT_PATTERNS` in `src/core/uncaughtExceptionPolicy.ts`) — HTTP double-response races, the Slack reconnect race, standby read-only writes. Network-class failures weren't on it.

On **2026-06-15**, during an Anthropic API / network rough patch, an uncaught `fetch failed` (the multi-machine lease-wire broadcasting to an offline peer) reached the handler and crashed the server (`logs/server.log` `[FATAL] Uncaught exception — closing databases before crash: fetch failed`, preceded by `[lease-wire] broadcast … became unreachable: fetch failed`). It auto-restarted ~50s later — but it shouldn't have gone down.

## The change (Tier 1, additive)

Add network-class tokens to the existing tested allowlist: `fetch failed`, `ECONNREFUSED`, `ECONNRESET`, `ETIMEDOUT`, `ENOTFOUND`, `EAI_AGAIN`, `socket hang up` — with a justification comment. A failed outbound fetch is isolated by nature (the call unwound; SQLite/HTTP/other subsystems intact; the owning subsystem retries).

- **Handler logic untouched.** Any unmatched error still crashes (the safe default).
- **First-seen-stack logging unchanged** — still surfaces the un-guarded callsite so the real missing `.catch` gets a proper follow-up fix. This is the backstop, not a license to skip the catch.
- **Tests both sides:** network tokens recoverable (incl. undici `TypeError('fetch failed')`); `assertion failed` / `migration failed` / sqlite / undefined-property stay fatal (boundary stays tight — matches specific tokens, not a bare "failed").

## Rigor

- Went through the `/instar-dev` gate: side-effects review artifact (`upgrades/side-effects/cmt1548-uncaught-fetch-degrade.md`) + ELI16 overview (`docs/specs/cmt1548-uncaught-fetch-degrade.eli16.md`) + an **independent adversarial second-pass review** which concurred — confirming every genuinely-fatal error family (OOM, `SQLITE_CORRUPT`, `EMFILE`/`ENOSPC`, stack overflow, undefined-property) is disjoint from the network tokens.
- Unit test green locally + on pre-push smoke tier (11/11).

Refs CMT-1548.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
