### PR TITLE
fix(slack): contain Slack subsystem errors so a socket send can't crash the process (net #1)

### DIFF
--- a/.instar/instar-dev-decisions/2026-06-15T04-10-55-458Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-06-15T04-10-55-458Z-unknown.json
@@ -1,0 +1,13 @@
+{
+  "ts": "2026-06-15T04:10:55.458Z",
+  "slug": "unknown",
+  "suggestedTier": 2,
+  "declaredTier": 2,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 3,
+  "loc": 210,
+  "causalAutopsy": null,
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-06-15T04-12-18-712Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-06-15T04-12-18-712Z-unknown.json
@@ -1,0 +1,13 @@
+{
+  "ts": "2026-06-15T04:12:18.712Z",
+  "slug": "unknown",
+  "suggestedTier": 2,
+  "declaredTier": 2,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 3,
+  "loc": 210,
+  "causalAutopsy": null,
+  "verdict": "pass"
+}

--- a/.instar/instar-dev-decisions/2026-06-15T04-18-59-768Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-06-15T04-18-59-768Z-unknown.json
@@ -1,0 +1,13 @@
+{
+  "ts": "2026-06-15T04:18:59.768Z",
+  "slug": "unknown",
+  "suggestedTier": 1,
+  "declaredTier": 2,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 8,
+  "causalAutopsy": null,
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-06-15T04-19-31-238Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-06-15T04-19-31-238Z-unknown.json
@@ -1,0 +1,13 @@
+{
+  "ts": "2026-06-15T04:19:31.238Z",
+  "slug": "unknown",
+  "suggestedTier": 2,
+  "declaredTier": 2,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 3,
+  "loc": 218,
+  "causalAutopsy": null,
+  "verdict": "pass"
+}

--- a/docs/specs/SLACK-SUBSYSTEM-ERROR-CONTAINMENT-SPEC.eli16.md
+++ b/docs/specs/SLACK-SUBSYSTEM-ERROR-CONTAINMENT-SPEC.eli16.md
@@ -1,0 +1,88 @@
+# Slack Subsystem Error Containment (Net #1) — Plain-English Overview
+
+> The one-line version: make a Slack network hiccup unable to crash the whole
+> agent, by funneling every "send to Slack" through one careful helper and adding a
+> second process-level safety catch that still crashes on anything genuinely unknown.
+
+## The problem in one breath
+
+The agent talks to Slack over an always-on network pipe (a WebSocket). If the code
+tries to push a message into that pipe at the exact moment it's closing or
+reconnecting, the send throws an error. On 2026-06-14 one of those errors wasn't
+caught, and instead of just dropping a Slack message, it took the **entire agent
+process** down for about two hours (the recovery nets were also down that day).
+
+## What already exists
+
+- **Two crash-recovery nets** — net #2 (the agent notices its own server died and
+  respawns it in ~10 seconds) and net #3 (the operating system relaunches it if it
+  vanishes entirely). Both are live now, so a crash today is a ~10-second blip, not a
+  long outage. They restart a *dead* process; they don't stop one from dying.
+- **A Slack reconnect engine** — already hardened: exponential backoff, a 30-second
+  heartbeat that notices a dead socket, and a careful "epoch" model that stops a
+  stale, torn-down socket from interfering with a fresh one.
+- **A narrow, audited crash policy** — a short, deliberately tight list of
+  "known-harmless" errors the process is allowed to log-and-continue on instead of
+  crashing. Anything not on the list still crashes (the safe default). It already
+  covers one Slack send-race message, but only the wording from an older network
+  library — not the wording today's Node.js uses.
+
+## What this adds
+
+The core change is one small private helper, `_safeSend`, that **every** Slack
+socket send now goes through. It checks the pipe is actually open, wraps the send so
+an error can never escape and crash the process, returns a simple success/failure,
+and — only for the heartbeat "are you alive?" probe — quietly triggers a reconnect
+when the pipe itself is dead. Four scattered send calls become one funnel with one
+policy, plus a test that fails if anyone ever adds a send that skips the funnel.
+
+Secondary changes: a second process-level safety catch for "unhandled promise
+rejections" (the error category the existing catch doesn't cover, and the one the
+real crash actually fell into), wired through the **exact same** narrow allowlist; and
+one new, tightly-anchored entry in that allowlist for today's Node.js wording.
+
+## The new pieces
+
+- **`_safeSend`** — the single, careful send funnel. It is allowed to: check the
+  socket, swallow a send error, and (for the liveness probe only) ask the existing
+  reconnect engine to reconnect. It is **not** allowed to: hold any blocking power
+  over the rest of the agent, resurrect a socket that was deliberately torn down, or
+  reconnect a fresh healthy socket by mistake. It is a self-healing helper, not a
+  decision-maker.
+- **`handleProcessLevelError`** — one shared function both process-level catches call,
+  so the "crash vs. continue" decision is identical for both and can never drift
+  apart. It crashes on anything not on the tiny allowlist.
+
+## The safeguards
+
+**Prevents a Slack glitch from crashing the agent.** Every send is wrapped; an error
+on a closing/closed socket is dropped and (where appropriate) reconnected, never
+escalated to a process crash. Your other chats, scheduled jobs, and memory keep
+running through a Slack hiccup.
+
+**Prevents the safety catch from hiding a real bug.** The allowlist stays tiny and
+the default stays *crash* — because a crash now costs ~10 seconds (net #2), while
+wrongly limping along on corrupted state could cost much more. The one new allowlist
+entry is anchored to the exact "WebSocket is not open" wording so it can't
+accidentally swallow unrelated "registration is not open" or "database is not open"
+errors. A negative test guards that.
+
+**Prevents silent message loss and reconnect storms.** A failed message-queue drain
+keeps the unsent messages for the next reconnect instead of discarding them. A failed
+acknowledgement does *not* trigger a reconnect (a single failed ack doesn't prove the
+socket is dead, and reconnecting on every one would thrash) — the 30-second heartbeat
+remains the recovery path.
+
+## What ships when
+
+One PR, shipped live (not behind a flag — it only changes behavior on the unhappy
+path, and there's nothing to toggle on a good day). It reaches existing agents
+through the normal `instar update`. A broader "single-writer" socket redesign that
+would prevent these races by construction is recorded as separate future hardening —
+it solves message-ordering, not the crash, and isn't bundled here.
+
+## What you actually need to decide
+
+Do you approve shipping net #1 as scoped — contain Slack socket errors at the
+subsystem boundary, add the matching `unhandledRejection` catch through the same
+narrow allowlist, and keep the global default as fail-toward-crash — yes or no?

--- a/docs/specs/SLACK-SUBSYSTEM-ERROR-CONTAINMENT-SPEC.md
+++ b/docs/specs/SLACK-SUBSYSTEM-ERROR-CONTAINMENT-SPEC.md
@@ -1,0 +1,351 @@
+---
+status: draft
+parent-principle: "Structure beats Willpower — a single subsystem error must never be able to crash the whole server process. Contain failures at the subsystem boundary; never rely on every callsite remembering to guard a socket send."
+tracked_deferrals:
+  - "A serialized outbound socket writer (single-writer transport) is recorded as future hardening, tracked separately under dev topic 13481. It is NOT part of the uncaught-throw incident class this spec closes; see Non-goals."
+eli16-overview: "SLACK-SUBSYSTEM-ERROR-CONTAINMENT-SPEC.eli16.md"
+review-convergence: "2026-06-15T03:47:27.471Z"
+review-iterations: 3
+review-completed-at: "2026-06-15T03:47:27.471Z"
+review-report: "docs/specs/reports/slack-subsystem-error-containment-convergence.md"
+cross-model-review: "codex-cli:gpt-5.5"
+single-run-completable: true
+frontloaded-decisions: 8
+cheap-to-change-tags: 0
+contested-then-cleared: 0
+approved: true
+approved-by: "operator (delegated) — decoupled instar-dev build brief / commitment CMT-1351, which pre-authorized Robustness Net #1 and pre-resolved the Goal 3 direction. Applied autonomously in the decoupled run and reported to Telegram topic 13481; not an interactive click."
+approved-at: "2026-06-15T03:47:27.471Z"
+---
+
+# Slack Subsystem Error Containment (Robustness Net #1)
+
+## Problem (root cause, grounded in code 2026-06-14)
+
+On 2026-06-14 the server process crashed and the recovery nets were also down,
+producing a ~2h outage. Robustness nets #2 (in-process ~10s respawn, PR #1164 /
+v1.3.567) and #3 (OS launchd watchdog) are now live, so a crash now self-recovers
+in seconds. Net #1 closes the remaining hole: **stop a Slack subsystem error from
+crashing the whole process in the first place** (defense-in-depth, no longer
+load-bearing, but real).
+
+### Concrete failure mechanism (corrected against current code)
+
+`src/messaging/slack/SocketModeClient.ts` calls `WebSocket.send()` from contexts
+that are NOT exception-guarded. A `send()` on a socket that is not `OPEN`
+(CONNECTING / CLOSING / CLOSED) throws **synchronously** (`InvalidStateError` /
+`"WebSocket is not open: readyState N"` for the Node 22+ built-in, or
+`"Sent before connected"` for the `ws` polyfill). These callsites run inside
+WebSocket *event-listener* callbacks (`'open'`, `'message'`), which are not
+awaited — a throw becomes an `uncaughtException` (sync path) **or an
+`unhandledRejection`** (the `'message'` listener calls the `async`
+`_handleRawMessage`, so an escaping throw there is a *rejection*, not a sync
+exception). Either can take the whole process down.
+
+**Current state of the four `.send(` callsites (read 2026-06-14, v1.3.567 — this
+supersedes the seed analysis's stale line numbers):**
+
+1. **`queueOutbound` (L113)** — `this.ws.send(data)`. Guarded by an
+   `this.isConnected && this.ws` check, but **NO try/catch** → TOCTOU race: the
+   socket can transition between the readyState check and the send. **Genuinely
+   unguarded today.**
+2. **ACK send (L236)** — `this.ws.send(JSON.stringify({ envelope_id }))`. **ALREADY
+   guarded** (`readyState === OPEN` + `try/catch` logging `Ack send failed`). Fires
+   on every inbound envelope.
+3. **Heartbeat liveness probe (L321)** — `this.ws?.send('{"type":"ping"}')`.
+   **ALREADY guarded** by `try/catch` → `_forceReconnect()` on throw.
+4. **`_drainQueue` (L352)** — `this.ws.send(item.data)` in a `for` loop invoked
+   from the `'open'` listener. Guarded by a readyState check at entry but **NO
+   try/catch** → a throw mid-loop escapes the un-awaited `'open'` listener.
+   **Genuinely unguarded today.**
+
+So the genuinely-unguarded sends today are **`queueOutbound` and `_drainQueue`**.
+Goal 1's `_safeSend` centralization is therefore primarily a **consistency +
+regression-prevention** measure (one funnel, one policy, one wiring-integrity
+ratchet), not an ACK rescue. Folding ALL FOUR through one funnel buys: (a) a single
+reconnect-on-failure policy, (b) a grep/lint ratchet so a future callsite can't
+regress, (c) one place that respects the epoch/teardown model.
+
+### The surrounding concurrency model (#1076) — must not be disturbed
+
+Every deliberate teardown bumps `this.epoch` and nulls `this.ws` *before* close;
+stale socket events are identity-guarded (`this.ws !== sock`). `_safeSend` must
+**read `this.ws` at call time** (never a captured/parameter socket), and never
+resurrect a torn-down socket. Its reconnect trigger must reuse the existing
+`_forceReconnect()` / `_backoffReconnect()` guards (`if (this.started &&
+!this.reconnecting)`), not bypass them.
+
+## Frontloaded Decisions
+
+Every decision the build needs is resolved here (Autonomy Principle 2 — a single
+autonomous run). The operator's build brief (commitment CMT-1351) carries the
+authority; convergence *verifies* these, it does not re-decide them.
+
+**FD-1 — Goal 3 shape: option (b), per-subsystem boundaries + the existing narrow
+audited allowlist. No blanket uncaught-swallow.** `src/core/uncaughtExceptionPolicy.ts`
+already implements exactly this; net #2 already restarts a truly-dead process in
+~10s, so the global default stays **fail-toward-crash** (unknown error → crash).
+
+**FD-2 — Add `process.on('unhandledRejection')`.** server.ts has none today, yet
+the primary failure mode (`async _handleRawMessage` escaping a throw) surfaces as a
+*rejection*, not a sync exception — the existing `uncaughtException` handler does
+not catch it. The new handler routes through the **same** `isNonFatalUncaught`
+predicate, the **same** `closeAllSqlite()` + `process.exit(1)` on anything
+unrecognized, and the **same** first-seen-stack dedup. No second, looser allowlist;
+no rejection-specific patterns. To keep the two handlers byte-identical in policy,
+the shared decision is extracted into one function in `uncaughtExceptionPolicy.ts`
+that both handlers call:
+
+```ts
+handleProcessLevelError(
+  err: unknown,
+  label: 'uncaughtException' | 'unhandledRejection',
+  opts: { onFatalCleanup: () => void; exit?: (code: number) => never },
+): 'recovered' | 'fatal'
+```
+
+The function **owns the entire sequence** so the two callsites cannot drift: on a
+non-fatal match it logs `console.warn` (with the first-seen-stack dedup) and returns
+`'recovered'`; otherwise it logs `console.error`, calls `opts.onFatalCleanup()`, then
+`(opts.exit ?? process.exit)(1)` and returns `'fatal'`. Cleanup + exit are **injected
+callbacks** (server.ts passes `() => { try { closeAllSqlite(); } catch {} }` and the
+real `process.exit`) so `uncaughtExceptionPolicy.ts` stays pure decision-logic — it
+does NOT statically import `SqliteRegistry` or call `process.exit` directly, which
+also lets the unit test inject fakes and assert the fatal path triggers cleanup+exit
+under BOTH labels. server.ts's existing `uncaughtException` handler is rewritten to
+delegate to this same function (its current inline body becomes the function body),
+so adding `unhandledRejection` cannot introduce a divergent policy.
+
+**FD-3 — Backstop matching: add ONE anchored substring `'WebSocket is not open'`
+to the allowlist; do NOT use a re-thrown custom-error marker.** Rationale (answers
+the cross-model + internal marker advocates): `_safeSend` *swallows* contained
+errors at the source — they never reach any process-level handler — so a structured
+marker set inside `_safeSend` cannot help the backstop. The backstop allowlist only
+ever sees errors that **escaped the funnel** (a future un-funneled `.send()`
+regression, or a non-Slack caller); those did not pass through `_safeSend` and so
+carry no marker. For *those*, an anchored message substring is the only available
+primitive. The Node 22+ built-in `WebSocket` (the default runtime path; the `ws`
+polyfill only loads on Node <22) throws `"WebSocket is not open: readyState N"`,
+which the current `'Sent before connected'` entry does not match — so the deployed
+case is uncovered. Adding the anchored `'WebSocket is not open'` closes it. The
+match is **anchored, not the bare `'is not open'`** — that bare form collides with
+live user-facing strings (`"<name> is not open for public registration"` in
+TelegramAdapter/AuthGate, plus DB-closed messages) and would risk swallowing a
+genuinely-fatal error. A negative unit test pins this. The real guarantee against
+un-funneled regressions remains the `_safeSend` funnel + the grep ratchet, not the
+substring.
+
+**Scope of the allowlist entry (honest residual risk).** `'WebSocket is not open'`
+is NOT Slack-scoped — it is a **transport-level** non-fatal class. The tree has
+several WebSocket users besides Slack Socket Mode (Threadline relay/client,
+`src/server/WebSocketManager.ts`, `SlackLifeline`), and a `send()` on a non-OPEN
+socket is an isolated, self-healing transport condition for *every* one of them
+(each owns its own reconnect; the dropped frame is best-effort). So swallowing this
+class process-wide is correct, not a Slack-specific leak — continuing is safe for
+all current WebSocket users. The residual risk is the generic brittle-substring one:
+a future Node/`ws` version could change the message and silently disable the
+backstop. Mitigations: (a) the funnel + ratchet, not the substring, is the primary
+guarantee; (b) the allowlist entry carries a source comment citing the Node origin
+of the message string as a maintainer breadcrumb; (c) the negative test guards the
+anchor. If a new WebSocket subsystem ever needs a non-OPEN send to be *fatal*, that
+is a new decision for that subsystem — not silently granted here.
+
+**FD-4 — `_safeSend` per-callsite reconnect/failure policy (signature
+`_safeSend(data: string, context: string, reconnectOnFailure = false): boolean`;
+no per-call object allocation on the hot path):**
+
+| Callsite | `reconnectOnFailure` | Behavior on `_safeSend` → false |
+|----------|----------------------|---------------------------------|
+| `queueOutbound` | `false` | **Enqueue** the item (fall through to the bounded queue) — closes the TOCTOU instead of dropping. |
+| ACK send | `false` | Log + move on. Slack redelivers the unacked envelope. **No reconnect** (a failed ACK does not by itself prove the socket is dead, and the 30s heartbeat is the recovery bound; reconnecting per-ACK risks an epoch-churn storm). |
+| Heartbeat liveness probe | `true` | The probe IS the liveness signal — a throw means the socket is dead → `_forceReconnect()`. On success, reset `lastEventAt`. |
+| `_drainQueue` | `false` | **Break** the loop on first false, **retain** the failed item + remainder in `outboundQueue` for the next `'open'` drain. No reconnect from drain. **Mechanics (avoid mutate-during-iterate):** iterate by index `k` over a captured snapshot; on the first `_safeSend → false`, set `this.outboundQueue = snapshot.slice(k)` once (the unsent tail) and break; if the loop completes, `this.outboundQueue = []`. Remove-only, so length stays ≤ `MAX_OUTBOUND_QUEUE`. |
+
+**FD-5 — `_safeSend` logging is flood-safe by construction.** The `readyState !==
+OPEN` precheck branch (the *expected* transient state during reconnect) logs
+**nothing** and never reconnects — it just returns false. Only the genuine
+`catch` branch (check passed, `send()` threw — a rare race) logs `[slack-socket]
+<context> send failed (readyState=N): <msg>`, message-only, never the payload.
+Because a non-OPEN socket short-circuits at the no-log precheck, repeated sends
+against a dead socket cannot flood; only the single OPEN→threw transition logs.
+
+**FD-6 — Goal 2 is verify-and-test-only.** The synchronous boot boundary already
+exists for Slack (server.ts try/catch around the Slack init incl
+`await slackAdapter.start()`, sets `slackAdapter = undefined` on failure), and
+likewise for WhatsApp and iMessage; `_openConnection` already routes dial errors to
+`handlers.onError` without rejecting out. No new shared-boundary refactor ships in
+this PR. We add an integration test asserting a Slack connect failure surfaces via
+`onError` and server bootstrap continues / `/health` stays 200. The *async*
+residual (throws in un-awaited post-boot listeners) is closed by Goal 1, not Goal 2.
+
+**FD-7 — No new config flag; ships live (not dark).** The change has no happy-path
+behavior surface to gate, and a flag would incur `migrateConfig` / template-awareness
+obligations for negligible benefit. Reversibility is via release rollback (reaches
+agents through `instar update`; nets #2/#3 keep them alive meanwhile). This keeps
+the Migration Parity claim intact (pure `src/*.ts` + tests).
+
+**FD-8 — E2E "feature is alive" seam (named so it cannot false-green).** A naive
+boot-time test is a false-green: server.ts's existing boot try/catch already
+contains a `start()` failure, so the regression under test (a throw from an
+un-awaited *post-boot* listener) never fires during boot. The E2E instead proves
+**process survival of a contained Slack error through the real process-level
+guards**: a child process registers the real `uncaughtException` +
+`unhandledRejection` handlers (via the shared `handleProcessLevelError` wiring),
+emits both a contained error (`"WebSocket is not open: readyState 2"`) AND a
+non-allowlisted control error, and asserts the process stays alive for the
+contained one and exits 1 for the control. This exercises the genuine
+escaped-to-process path, not the boot path.
+
+## Goals
+
+1. **No Slack socket send can throw uncaught.** Route every `.send()` in
+   `SocketModeClient` through a single private
+   `_safeSend(data, context, reconnectOnFailure = false)`. **Exact sequence (pins the
+   identity re-check both reviewers flagged):**
+   ```
+   const sock = this.ws;                                   // read this.ws ONCE
+   if (!sock || sock.readyState !== WebSocket.OPEN) return false;  // no log, no reconnect (FD-5)
+   try {
+     sock.send(data);                                      // send on the SAME captured local
+     return true;
+   } catch (err) {
+     console.warn(`[slack-socket] ${context} send failed (readyState=${sock.readyState}): ${err.message}`);
+     if (reconnectOnFailure && this.started && !this.reconnecting && this.ws === sock) {
+       this._forceReconnect();                             // identity re-check: only reconnect the socket we sent on
+     }
+     return false;
+   }
+   ```
+   `_safeSend` reads `this.ws` exactly once, sends on that captured `sock`, and in the
+   catch reconnects **only if `this.ws === sock`** (the socket we sent on is still
+   current) — so a throw after a teardown-and-replace cannot force-reconnect a fresh
+   healthy socket. It never resurrects a torn-down socket (respects the epoch model).
+   Replace the two unguarded callsites (`queueOutbound`, `_drainQueue`) AND fold in
+   the two already-guarded ones (ACK, heartbeat probe) so all four share the funnel.
+2. **Subsystem boundary at the adapter (verify-and-test-only — FD-6).** Confirm the
+   existing adapter connect/reconnect boundary catches a throw during connection
+   setup and surfaces it via `onError(err, permanent)` — never rejecting out of
+   server bootstrap. Add an integration test; no refactor.
+3. **Last-resort process guard (FD-1/FD-2/FD-3).** Keep option (b): per-subsystem
+   boundaries + the existing narrow audited allowlist, fail-toward-crash by default.
+   Add a `process.on('unhandledRejection')` handler that shares the exact same
+   `isNonFatalUncaught` decision (via the extracted `handleProcessLevelError`).
+   Broaden the allowlist by one anchored entry (`'WebSocket is not open'`) with a
+   negative test guarding against over-broad matching.
+
+## Non-goals
+
+- Reworking Slack reconnect/backoff strategy (already hardened).
+- **A single-writer socket-actor abstraction.** Routing all outbound frames through
+  one serialized transport writer is the textbook way to eliminate socket-send
+  TOCTOU by design (raised by both cross-model reviewers). **Scoping the claim
+  precisely:** `_safeSend` + the wiring ratchet **fully closes the incident class
+  this spec targets — "an uncaught/un-rejected socket send throw crashes the whole
+  process."** It does NOT claim to eliminate the broader socket-concurrency space
+  (frame ordering, ACK/send interleaving, lifecycle coupling); a serialized writer
+  would address those, but they are a different, larger concern and are not what
+  took the process down on 2026-06-14. The serialized-writer redesign is recorded as
+  future hardening, tracked separately (see `tracked_deferrals`), and nothing in the
+  *uncaught-throw* class is left unaddressed by building `_safeSend` now.
+- Touching Telegram/WhatsApp adapters beyond the (already-present) boot boundary.
+- Replacing nets #2/#3.
+
+## Signal vs Authority compliance
+
+`_safeSend` is a **pure signal-producer / self-heal at the subsystem boundary**: it
+returns a boolean and (on the liveness path) triggers reconnect; it holds **no
+cross-subsystem blocking authority**. It is a structural validator at a hard
+invariant (a socket must be OPEN to send) — not a judgment call — so it does not
+need to route to an LLM authority. The canonical fail-toward-crash **authority**
+stays `uncaughtExceptionPolicy`, kept narrow and default-crash (FD-1). The
+`unhandledRejection` handler reuses that same authority verbatim (FD-2) — it does
+not introduce a second, divergent policy.
+
+## Cross-Machine Coherence (multi-machine posture)
+
+All three artifacts are **machine-local-by-design** — process-level / per-socket
+resources with nothing to replicate or proxy:
+
+- **`_safeSend` + reconnect** — the Slack WebSocket is a per-process resource; only
+  the machine holding the live socket sends. A standby machine has `this.ws === null`
+  and `_safeSend` correctly no-ops. (Which machine owns the socket is governed by the
+  existing lease/standby model; `_safeSend` does not change it.)
+- **`uncaughtException` / `unhandledRejection` handlers** — crash containment is
+  inherently per-process. The allowlist already encodes the standby case
+  (`'StateManager is read-only'`), and the new rejection handler consults the *same*
+  authority, so lease/standby semantics stay identical across both handlers.
+
+## Observability (no new masking surface)
+
+Contained failures must leave an artifact, never silently mask a persistent fault
+(Distrust Temporary Success). `_safeSend`'s `catch` branch logs `[slack-socket]`
+with the readyState (FD-5). A *persistent* fault manifests through the existing,
+already-visible machinery: `consecutiveErrors` grows on each `_backoffReconnect`,
+the heartbeat logs `readyState != OPEN` every 30s and forces reconnect, and a
+permanent dial failure routes to `onError`. No new always-on swallow is introduced
+that could hide a real corruption — the global default remains crash (FD-1).
+
+## Testing (all three tiers — Testing Integrity Standard)
+
+- **Unit (`_safeSend`):**
+  - OPEN → sends, returns true; CONNECTING / CLOSING / CLOSED → no-op, returns
+    false, **no throw, no log**.
+  - A `send()` that throws on an OPEN socket → swallowed + logged; with
+    `reconnectOnFailure` → forces reconnect; without → does not.
+  - Reproduce the L236 ACK race: ack while `readyState=CLOSING` → must not throw,
+    must not reconnect (ACK path), event still processed.
+  - Stale-socket: `this.ws` nulled between check and send → no send, no resurrection,
+    no spurious reconnect.
+  - N rapid non-OPEN sends → **at most one** in-flight `_forceReconnect` / epoch bump
+    (storm guard).
+  - `queueOutbound` while CONNECTING → **enqueues** (does not drop, does not
+    reconnect).
+  - `_drainQueue` where item k of n fails → items `1..k-1` sent, items `k..n`
+    **retained** in `outboundQueue`, loop stops at k, no reconnect, queue length
+    stays ≤ `MAX_OUTBOUND_QUEUE`.
+- **Unit (process guard):** `handleProcessLevelError` log-and-continues for every
+  allowlist member (including the new anchored `'WebSocket is not open'`) under both
+  `uncaughtException` and `unhandledRejection` labels; crashes (cleanup + exit 1) for
+  an unrecognized error; **negative** test: `"Foo is not open for public
+  registration"` and a synthetic `"database is not open"` do **NOT** match
+  `isNonFatalUncaught`.
+- **Integration:** SlackAdapter connect failure surfaces via `onError`, server
+  bootstrap continues, `/health` stays 200 (FD-6).
+- **E2E (the "feature is alive" test):** the child-process survival test of FD-8 —
+  contained `uncaughtException` + `unhandledRejection` keep the process alive; a
+  non-allowlisted error exits 1.
+- **Wiring-integrity ratchet (supplemental to the behavioral tests above, not the
+  primary guarantee):** a unit test that reads `SocketModeClient.ts`, finds every raw
+  socket send (`this.ws.send(`, `this.ws?.send(`, and any `<sock>.send(`), and asserts
+  they appear **only inside the `_safeSend` method body** — so a future un-funneled
+  callsite (in either `.send(` or `?.send(` form) fails the test. Also assert each of
+  the four logical callsites references `_safeSend`, and that server.ts registers BOTH
+  `uncaughtException` and `unhandledRejection` through the shared
+  `handleProcessLevelError`. The real protection is behavioral (the `_safeSend` unit
+  tests drive a fake WebSocket whose `send` throws and assert no throw escapes); the
+  source-grep ratchet is a cheap regression tripwire layered on top, not a substitute.
+
+## Migration parity
+
+Pure source/runtime fix in shipped code — reaches existing agents via the normal
+release/update path. No `.claude`/config/template migration needed (no config flag —
+FD-7). If a future change adds a config flag, `migrateConfig()` must seed it for
+existing agents.
+
+## Rollback
+
+Back-out = revert the commit + patch release (reaches agents via `instar update`;
+nets #2/#3 keep them alive meanwhile). No config kill-switch — the change has no
+happy-path surface to disable. The riskiest individual knob is the allowlist
+broadening, which is independently revertable.
+
+## Rollout
+
+Ships live (not dark — FD-7) — containment hardening with no behavior change on the
+happy path. The one failure-path behavior change (queueOutbound enqueues instead of
+dropping on a lost TOCTOU; drain retains instead of discarding) is strictly more
+correct. Verify on this agent post-release.
+
+## Open questions
+
+*(none)*

--- a/docs/specs/reports/slack-subsystem-containment-codegrounding.md
+++ b/docs/specs/reports/slack-subsystem-containment-codegrounding.md
@@ -1,0 +1,87 @@
+# Code-grounding context for reviewers — Slack Subsystem Error Containment (Net #1)
+
+This note captures the ACTUAL current state of the code (read 2026-06-14, base
+`upstream/main` v1.3.567) so reviewers ground their review in reality, not the
+seed spec's stale line numbers. The seed spec's root-cause analysis predates two
+hardening commits already on main.
+
+## Current state of `src/messaging/slack/SocketModeClient.ts` (357 lines)
+
+Four `.send(` callsites exist today:
+
+1. **`queueOutbound` (L113)** — `this.ws.send(data)`. Guarded by an
+   `this.isConnected && this.ws` check, but **NO try/catch** → TOCTOU race: the
+   socket can transition between the readyState check and the send.
+2. **ACK send (L236)** — `this.ws.send(JSON.stringify({ envelope_id }))`. ALREADY
+   guarded: `if (envelope.envelope_id && this.ws && this.ws.readyState === OPEN)`
+   + `try/catch` that logs `[slack-socket] Ack send failed`. (Added by a prior
+   fix referencing the "Sent before connected" FATAL.)
+3. **Heartbeat liveness probe (L321)** — `this.ws?.send('{"type":"ping"}')`.
+   ALREADY guarded by `try/catch` → `_forceReconnect()` on throw.
+4. **`_drainQueue` (L352)** — `this.ws.send(item.data)` in a `for` loop, invoked
+   from the `'open'` event listener. Guarded by a readyState check at L350 but
+   **NO try/catch** → a throw mid-loop escapes the un-awaited `'open'` listener.
+
+So vs. the seed spec: the ACK (seed "L193") and heartbeat are ALREADY guarded.
+The genuinely-unguarded sends today are **`queueOutbound` and `_drainQueue`**.
+Goal 1's `_safeSend` centralization remains fully valid — fold ALL FOUR through
+one funnel for (a) consistency, (b) a wiring-integrity grep ratchet so a future
+callsite can't regress, (c) a single reconnect-on-failure policy.
+
+`epoch`-based teardown (#1076) is the surrounding concurrency model: every
+deliberate teardown bumps `this.epoch` and nulls `this.ws` before close; stale
+socket events are identity-guarded (`this.ws !== sock`). `_safeSend` must not
+disturb this — it operates on `this.ws` at call time and never resurrects a
+torn-down socket.
+
+## Current state of the adapter boundary (Goal 2)
+
+- `src/messaging/slack/SlackAdapter.ts` `start()` (L192) builds `SocketModeHandlers`
+  with an `onError(err, permanent)` that logs (does not rethrow), then
+  `await this.socketClient.connect()` under a 15s `Promise.race` timeout.
+- `SocketModeClient._openConnection()` already catches its own dial errors and
+  routes them to `handlers.onError(err, permanent)` — it does not reject out.
+- In `src/commands/server.ts` the ENTIRE Slack init block — including
+  `await slackAdapter.start()` (L6292) — is already wrapped in a `try/catch`
+  (L5789–6427) that reports degradation (`degradationReporter.report`) and sets
+  `slackAdapter = undefined`. WhatsApp (L5676) and iMessage (L6446) starts are
+  likewise inside try/catch. So the **synchronous boot boundary already exists**.
+- The real residual risk is the **async** path: throws inside un-awaited
+  WebSocket event listeners AFTER boot — those bypass the boot try/catch. That is
+  exactly what Goal 1's `_safeSend` funnel closes at the source.
+
+## Current state of the process guard (Goal 3) — ALREADY EXISTS
+
+`src/core/uncaughtExceptionPolicy.ts` already implements **option (b) + a narrow
+audited allowlist** — the shape the seed spec leans toward:
+
+- `NON_FATAL_UNCAUGHT_PATTERNS` is a tight substring allowlist; unknown errors
+  crash (the safe default). It already includes `'Sent before connected'` for the
+  Slack WS reconnect race, plus HTTP double-response races and the standby
+  read-only-write case.
+- `isNonFatalUncaught(err)` + `shouldLogStackForUncaught(err)` (first-seen-stack
+  dedup, bounded to 200) are unit-testable on both sides.
+- `src/commands/server.ts` L17204 `process.on('uncaughtException')` consults
+  `isNonFatalUncaught`: log-and-continue for the allowlist, else
+  `closeAllSqlite()` + `process.exit(1)`.
+
+**Gaps to weigh in convergence:**
+- There is **no `process.on('unhandledRejection')`** handler in server.ts (only
+  `TelegramLifeline.ts` has one). An async throw in a `.then` chain (vs a sync
+  listener) would currently be an unhandled rejection with no containment.
+- The allowlist pattern `'Sent before connected'` is the **`ws` package**'s
+  message. Node 22+ built-in `WebSocket` throws `DOMException`/`InvalidStateError`
+  with a DIFFERENT message (e.g. `"WebSocket is not open: readyState N"`). A
+  non-OPEN send under the built-in WebSocket would NOT match the allowlist.
+  Because Goal 1's funnel catches these at the source, the backstop matters only
+  for a future un-funneled regression — but broadening the allowlist (or, better,
+  tagging contained errors with a structured marker the policy matches on instead
+  of brittle message substrings) is a candidate, narrow, audited improvement.
+
+## Signal-vs-authority note
+
+`uncaughtExceptionPolicy` is the canonical "narrow allowlist, fail-toward-crash"
+authority. `_safeSend` is a pure signal-producer/​self-heal at the subsystem
+boundary (returns boolean, triggers reconnect) — it holds no cross-subsystem
+blocking authority. The design must keep the global handler's default-crash
+posture (do not broaden into a blanket swallow).

--- a/docs/specs/reports/slack-subsystem-error-containment-convergence.md
+++ b/docs/specs/reports/slack-subsystem-error-containment-convergence.md
@@ -1,0 +1,189 @@
+# Convergence Report — Slack Subsystem Error Containment (Robustness Net #1)
+
+## Cross-model review: codex-cli:gpt-5.5
+
+A real GPT-tier external pass ran through the agent's `codex` CLI in **both**
+review rounds (gpt-5.5), and a Gemini-tier pass ran through the `gemini` CLI
+(gemini-2.5-pro) in both rounds. Every external pass returned `status: ok`
+(MINOR ISSUES — no blockers). This is the clean RAN state. The aggregate is the
+freshest successful flag: `codex-cli:gpt-5.5`.
+
+## ELI10 Overview
+
+The agent talks to Slack over a always-on network pipe (a WebSocket). On
+2026-06-14 that pipe hiccuped at a bad moment, the code tried to send a message
+down a pipe that wasn't fully open, and the resulting error wasn't caught — so the
+*whole* agent process crashed. Two newer safety nets (an in-process auto-respawn
+and an OS-level watchdog) already bring a crashed agent back in about ten seconds,
+so this was a short outage, not a long one. But the cleanest fix is to stop the
+Slack pipe from being able to crash the whole agent in the first place. That's what
+this change does.
+
+The fix funnels every "send something to Slack" call through one small, careful
+helper (`_safeSend`) that checks the pipe is open, wraps the send so an error can
+never escape, and quietly reconnects when the pipe is the thing that's dead. A
+companion change adds a second process-level safety catch for a category of error
+(an "unhandled promise rejection") that the existing catch didn't cover — using the
+*exact same* tight, audited list of "known-harmless" errors, so the agent still
+crashes-and-restarts on anything genuinely unknown (a corrupted state should reset,
+not limp along).
+
+For users, nothing changes on a good day — there's no new button, no new setting,
+no behavior difference when Slack is healthy. The only visible difference is on a
+bad day: a transient Slack glitch that used to take the whole agent down now just
+reconnects Slack and leaves everything else (your other chats, scheduled jobs,
+memory) running. The main tradeoff the review debated was "how much should the
+agent swallow vs. crash-and-restart?" — and the answer landed firmly on *swallow
+only a tiny, named set of known-benign network errors; crash on everything else*,
+because a crash now costs ~10 seconds and a wrongly-swallowed corruption could cost
+much more.
+
+## Original vs Converged
+
+**Originally**, the spec described the fix as primarily rescuing the Slack
+*acknowledgement* send (its "most likely trigger") and left the process-level guard
+as an open "decide between a global swallow vs. per-subsystem boundaries" question.
+It also left several mechanical decisions implicit.
+
+**After review**, three things changed materially:
+
+1. **The framing was corrected against the real code.** The acknowledgement send and
+   the heartbeat probe are *already* guarded; the genuinely-unguarded sends today are
+   `queueOutbound` and `_drainQueue`. So `_safeSend` is now framed as a *consistency +
+   regression-prevention* funnel (one policy, one wiring ratchet), not an ACK rescue.
+
+2. **Every open decision was frontloaded.** The decision-completeness reviewer found
+   7+ decisions still parked on a human (whether to add an `unhandledRejection`
+   handler, how the message queue behaves on a failed drain, the test seam, a config
+   flag, etc.). All are now resolved in a `## Frontloaded Decisions` section
+   (FD-1..FD-8) so the build is a single autonomous run with zero "stop and ask"
+   points. `## Open questions` is empty.
+
+3. **The riskiest details were pinned so they can't be implemented wrong.** The ACK
+   path must NOT trigger a reconnect (a failed ack ≠ a dead socket; reconnecting
+   per-message risks a storm). The queue drain must *retain* unsent messages on
+   failure instead of silently dropping them. `_safeSend` must capture the socket
+   once and re-check identity before reconnecting (so it never tears down a freshly
+   replaced healthy socket). The process-guard backstop adds exactly one *anchored*
+   error string (`'WebSocket is not open'`, never the bare `'is not open'`, which
+   collides with live "registration is not open" / "database is not open" messages),
+   and the new `unhandledRejection` handler shares the *identical* narrow allowlist
+   via one extracted function so the two handlers can never drift.
+
+The review also debated, and ultimately *kept narrow*, a tempting broader rewrite
+(a single-writer socket "actor" that eliminates these races by construction). That
+is recorded as future hardening — it solves a *different*, larger problem (message
+ordering, send interleaving) than the one that crashed the agent, and bolting it on
+here would widen the blast radius of an incident fix.
+
+## Iteration Summary
+
+| Iteration | Reviewers who flagged | Material findings | Spec changes |
+|-----------|-----------------------|-------------------|--------------|
+| 1 | security, scalability, adversarial, integration, decision-completeness, lessons-aware, codex-cli, gemini-cli | 14 distinct (high consensus) | Full rewrite: corrected framing; added `## Frontloaded Decisions` (FD-1..FD-8); per-callsite `_safeSend` policy table; `unhandledRejection` handler decision; anchored allowlist entry; Signal-vs-Authority + Cross-Machine + Observability sections; named E2E seam; dual-form wiring ratchet |
+| 2 | decision-completeness (0 parked), lessons-aware (0; reversed its marker stance after grounding), adversarial (F2 material + 2 precision), codex-cli (minor), gemini-cli (minor) | 1 material (F2: shared-handler cleanup/exit ownership) + several precision/refinement | Pinned `handleProcessLevelError` location + injected cleanup/exit callbacks; exact `_safeSend` sequence with `this.ws === sock` identity re-check; drain index-snapshot-slice mechanics; transport-level allowlist scope + residual risk; scoped the non-goal claim + recorded tracked deferral; ratchet reframed as supplemental to behavioral tests |
+| 3 | final adversarial confirm | 0 | none — converged |
+
+## Full Findings Catalog
+
+### Round 1
+
+**Security (3 material).**
+- *Anchor the allowlist, don't use bare `'is not open'`* — collides with live
+  `"<name> is not open for public registration"` (TelegramAdapter/AuthGate) + DB
+  strings → could swallow a fatal error. **Resolved:** FD-3 uses anchored
+  `'WebSocket is not open'` + a negative unit test.
+- *Prefer a structured marker over message-substring* — **Resolved with grounded
+  counter** (FD-3): `_safeSend` swallows at source, so a marker can't reach the
+  backstop; the backstop only sees un-funneled escapes that carry no marker → an
+  anchored substring is the correct primitive. (Both round-2 lessons-aware and the
+  externals concurred after grounding.)
+- *`unhandledRejection` handler must reuse the same narrow predicate + default-crash*
+  — **Resolved:** FD-2 shares one `isNonFatalUncaught` decision via
+  `handleProcessLevelError`.
+- (minor) reconnect-storm guard; no payload in logs — **Resolved:** FD-4 storm
+  guard + FD-5 message-only logging.
+
+**Scalability (3 material).**
+- *`_safeSend` reconnect-on-failure must collapse to one reconnect/epoch-bump per
+  tick* — **Resolved:** FD-4 ACK path does not reconnect; reconnect path is guarded
+  by `!this.reconnecting` + identity re-check.
+- *`_drainQueue` break-and-retain semantics + cap* — **Resolved:** FD-4 drain breaks
+  on first failure, retains the tail (remove-only, ≤ MAX).
+- *Log-flood: skip the expected not-OPEN branch + dedup* — **Resolved:** FD-5 logs
+  nothing on the not-OPEN precheck (the flood source); only the rare OPEN→threw race
+  logs.
+- (minor) ACK hot-path overhead is provably nil (same guard relocated); no per-call
+  object allocation — **Resolved:** signature uses positional args, not an opts
+  object.
+
+**Adversarial (4 material).**
+- *ACK path must NOT reconnect-on-failure* — **Resolved:** FD-4.
+- *`_drainQueue` must retain unsent items* — **Resolved:** FD-4.
+- *Backstop must match the Node built-in WebSocket message* — **Resolved:** FD-3
+  anchored entry.
+- *`unhandledRejection` must reuse the tight allowlist, never swallow DB/state
+  rejections* — **Resolved:** FD-2 (crash-by-default on anything unrecognized).
+- (minor) stale-socket no-op correctness; spec line-number drift — **Resolved:**
+  Goal 1 reads `this.ws` at call time + identity re-check; framing corrected.
+
+**Integration (4 material).**
+- *Name the E2E seam so it can't false-green* — **Resolved:** FD-8 child-process
+  survival test of the real escaped-to-process path (not boot path).
+- *Declare multi-machine posture* — **Resolved:** Cross-Machine Coherence section
+  (all three artifacts machine-local-by-design).
+- *`unhandledRejection` is the more-important half + must route through the same
+  authority* — **Resolved:** FD-2.
+- *Net #2/#3 interaction — containment removes the crash-and-reset; state it + test
+  reconnect IS triggered* — **Resolved:** Observability section + heartbeat as the
+  Slack-liveness guard; FD-8/integration tests assert survival.
+- (minor) migration parity; rollback posture; wiring ratchet must match `?.send(` —
+  **Resolved:** Migration/Rollback sections + dual-form ratchet.
+
+**Decision-Completeness (7+ parked).** All frontloaded into FD-1..FD-8; `## Open
+questions` emptied.
+
+**Lessons-aware (3 material).** Fail-toward-crash default preserved (FD-1);
+brittle-substring foundation smell addressed (FD-3 + funnel/ratchet as the real
+guarantee); observability / no-new-masking-surface (Observability section).
+
+**codex-cli:gpt-5.5 (MINOR).** Spec/code drift; Goal 3 "decide" → "verify/extend";
+substring is weak; single-writer alternative; ratchet brittleness. All folded in.
+
+**gemini-cli:gemini-2.5-pro (MINOR).** Obsolete framing; `unhandledRejection` gap;
+custom-error-type pattern; authority interprets structured signal. Folded in (with
+the grounded counter on the marker for *escaped* errors).
+
+### Round 2
+
+- **F2 (material):** the extracted `handleProcessLevelError` must own the
+  cleanup+exit or the two handlers can drift. **Resolved:** function owns the full
+  sequence; cleanup+exit are injected callbacks (keeps `uncaughtExceptionPolicy.ts`
+  pure + unit-testable); the existing inline body becomes the function body.
+- **codex#1 / adversarial F3 (precision):** identity re-check `this.ws === sock`
+  before reconnect. **Resolved:** exact `_safeSend` sequence in Goal 1.
+- **F1 (precision):** drain mutate-during-iterate. **Resolved:** index-over-snapshot
+  + single `slice` assignment.
+- **codex#2 (refinement):** allowlist entry is transport-level, not Slack-scoped.
+  **Resolved:** FD-3 scope + residual-risk paragraph.
+- **codex#3 / gemini#1 (refinement):** scope the single-writer non-goal claim + track
+  it. **Resolved:** Non-goals rewritten + `tracked_deferrals` entry.
+- **gemini#2 (refinement):** cite the Node origin of the error message. **Resolved:**
+  noted as an implementation comment requirement in FD-3.
+
+### Round 3
+Final adversarial confirm: 0 material findings.
+
+## Convergence verdict
+
+Converged at iteration 3. No material findings in the final round. All round-1/2
+findings are addressed; the decision-completeness gate is clean (0 decisions parked
+on the user; `## Open questions` empty); both external families ran successfully in
+both rounds. Spec is ready for build.
+
+**Approval note (decoupled autonomous build).** This convergence runs inside a
+decoupled instar-dev session launched by the operator's build brief (commitment
+CMT-1351), which pre-authorized net #1 and pre-resolved the Goal 3 direction. The
+`approved: true` tag is applied under that delegated authority and recorded
+transparently here and in the Telegram milestone, rather than waiting on an
+interactive click the decoupled run cannot receive.

--- a/src/commands/server.ts
+++ b/src/commands/server.ts
@@ -17,7 +17,7 @@ import pc from 'picocolors';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 import { loadConfig, ensureStateDir, detectTmuxPath, detectGeminiPath } from '../core/Config.js';
-import { isNonFatalUncaught, shouldLogStackForUncaught } from '../core/uncaughtExceptionPolicy.js';
+import { handleProcessLevelError } from '../core/uncaughtExceptionPolicy.js';
 import { resolveDevAgentGate, resolveStateSyncStores } from '../core/devAgentGate.js';
 import { parseProfileTrigger, platformMessageIdFrom } from '../core/topicProfileIngress.js';
 import { slugifyChannelName } from '../messaging/slack/sanitize.js';
@@ -17201,30 +17201,25 @@ export async function startServer(options: StartOptions): Promise<void> {
     // (e.g., cloudflared crash cascade during sleep/wake), close databases to prevent
     // the "mutex lock failed" error on next start. This doesn't prevent the crash,
     // but ensures the next boot is clean.
+    // Route BOTH process-level error events through one shared decision
+    // (uncaughtExceptionPolicy.handleProcessLevelError) so they cannot drift to
+    // divergent policies: one narrow allowlist (HTTP double-response races, the
+    // Slack Socket Mode reconnect race, standby read-only writes), one
+    // fail-toward-crash default, one dedup'd log path. Isolated/recoverable
+    // errors log-and-continue; anything unknown closes ALL registered SQLite
+    // handles (so the crash exit doesn't compound into a "mutex lock failed"
+    // SIGABRT) and exits — net #2 respawns a clean process in ~10s.
+    //
+    // The unhandledRejection handler is essential, not optional: the Slack
+    // 'message' listener calls the async _handleRawMessage, so an escaping throw
+    // there surfaces as a REJECTION, not a sync exception (net #1). Cleanup is
+    // injected so the policy module stays pure decision-logic.
+    const onFatalCleanup = (): void => { closeAllSqlite(); };
     process.on('uncaughtException', (err) => {
-      // Isolated, recoverable uncaught exceptions — log and continue, don't
-      // crash the server (which would close its databases + drop in-flight
-      // work). See isNonFatalUncaught for the allowlist + rationale (HTTP
-      // double-response races, Slack Socket Mode reconnect races).
-      if (isNonFatalUncaught(err)) {
-        // Attach the stack the first time a given origin is seen so the offending
-        // call site (e.g. a route that double-responds → "Cannot set headers")
-        // is diagnosable; repeats log message-only to avoid flooding the log
-        // (these isolated races recur ~10-20x/hour).
-        const stackSuffix =
-          shouldLogStackForUncaught(err) && err.stack
-            ? `\n  first-seen stack (for diagnosis):\n${err.stack}`
-            : '';
-        console.warn(`[WARN] Non-fatal uncaught exception (suppressed): ${err.message}${stackSuffix}`);
-        return; // Don't crash — the server is fine
-      }
-
-      console.error('[FATAL] Uncaught exception — closing databases before crash:', err.message);
-      // Close ALL registered SQLite handles (not just topic/semantic memory) so
-      // the crash exit doesn't compound into a "mutex lock failed" SIGABRT on top
-      // of the original error. closeAllSqlite() is best-effort + idempotent.
-      try { closeAllSqlite(); } catch { /* best effort */ }
-      process.exit(1);
+      handleProcessLevelError(err, 'uncaughtException', { onFatalCleanup });
+    });
+    process.on('unhandledRejection', (reason) => {
+      handleProcessLevelError(reason, 'unhandledRejection', { onFatalCleanup });
     });
 
     // Wire the ForegroundRestartWatcher to the graceful shutdown function.

--- a/src/core/uncaughtExceptionPolicy.ts
+++ b/src/core/uncaughtExceptionPolicy.ts
@@ -28,6 +28,21 @@ const NON_FATAL_UNCAUGHT_PATTERNS = [
   // that sleeps/wakes often, where reconnects are frequent). The root cause is
   // also guarded at the ack send site; this is the defense-in-depth backstop.
   'Sent before connected',
+  // The SAME non-OPEN-WebSocket-send race as 'Sent before connected', but the
+  // message form thrown by Node's BUILT-IN WebSocket (Node 22+, the default
+  // runtime path — the 'ws' polyfill only loads on Node <22). Built-in throws
+  // a DOMException `"WebSocket is not open: readyState N"` (see Node's
+  // lib/internal/deps/undici/undici.js — sendMessage's not-OPEN guard), which
+  // 'Sent before connected' does not match. This is a TRANSPORT-level non-fatal
+  // class, correct for EVERY WebSocket user in the tree (Slack Socket Mode,
+  // Threadline relay/client, server WebSocketManager, SlackLifeline) — each owns
+  // its own reconnect and a dropped frame is best-effort. ANCHORED to
+  // "WebSocket is not open" (NOT the bare "is not open", which collides with
+  // live "<name> is not open for public registration" and "database connection
+  // is not open" messages and would swallow a genuinely-fatal error — guarded by
+  // a negative test). Net #1's _safeSend funnel + grep ratchet is the PRIMARY
+  // guarantee; this only ever catches an un-funneled future regression.
+  'WebSocket is not open',
   // Standby read-only write: when this machine is on standby (a peer holds the
   // multi-machine lease), StateManager.guardWrite() throws on any stray
   // write ("StateManager is read-only (this machine is on standby)"). That is a
@@ -89,4 +104,55 @@ export function shouldLogStackForUncaught(err: unknown): boolean {
 /** Test-only: reset the dedup memory so each test starts from a clean slate. */
 export function __resetUncaughtStackDedupeForTests(): void {
   seenUncaughtStacks.clear();
+}
+
+/**
+ * The single crash-vs-continue decision shared by BOTH process-level handlers
+ * (`uncaughtException` and `unhandledRejection`). Extracting it into one function
+ * is what guarantees the two handlers cannot drift to divergent policies — there
+ * is exactly one allowlist, one default-crash posture, one dedup'd log path.
+ *
+ * Behavior:
+ * - A non-fatal match (`isNonFatalUncaught`) → `console.warn` (with the first-seen
+ *   stack attached once per distinct origin) and returns `'recovered'`. The server
+ *   stays up.
+ * - Anything else → `console.error`, run `opts.onFatalCleanup()` (best-effort —
+ *   wrapped so a cleanup failure can't mask the original error), then exit(1) and
+ *   return `'fatal'`. This is the fail-toward-crash default: an unknown error
+ *   crashes, and net #2 respawns a clean process in ~10s.
+ *
+ * Cleanup and exit are INJECTED callbacks (server.ts passes `closeAllSqlite` and
+ * the real `process.exit`) so this module stays pure decision-logic — it does NOT
+ * import the SQLite registry, and the unit test injects fakes to assert the fatal
+ * path triggers cleanup + exit under BOTH labels without actually exiting.
+ *
+ * The `exit` callback is typed `(code) => never`, but the function still has a
+ * trailing `return 'fatal'`: with the real `process.exit` that line is
+ * unreachable; with an injected test fake that returns, the assertion can observe
+ * the verdict. This is the standard injectable-exit test pattern.
+ */
+export function handleProcessLevelError(
+  err: unknown,
+  label: 'uncaughtException' | 'unhandledRejection',
+  opts: { onFatalCleanup: () => void; exit?: (code: number) => never },
+): 'recovered' | 'fatal' {
+  const message = err instanceof Error ? err.message : typeof err === 'string' ? err : String(err);
+  if (isNonFatalUncaught(err)) {
+    // Attach the stack the first time a given origin is seen so the offending
+    // call site is diagnosable; repeats log message-only to avoid flooding the
+    // log (these isolated races recur).
+    const stackSuffix =
+      shouldLogStackForUncaught(err) && err instanceof Error && err.stack
+        ? `\n  first-seen stack (for diagnosis):\n${err.stack}`
+        : '';
+    console.warn(`[WARN] Non-fatal ${label} (suppressed): ${message}${stackSuffix}`);
+    return 'recovered';
+  }
+
+  console.error(`[FATAL] Uncaught ${label} — closing databases before crash: ${message}`);
+  // Close ALL registered SQLite handles before the crash exit so it doesn't
+  // compound into a "mutex lock failed" SIGABRT. onFatalCleanup is best-effort.
+  try { opts.onFatalCleanup(); } catch { /* best effort */ }
+  (opts.exit ?? process.exit)(1);
+  return 'fatal';
 }

--- a/src/messaging/slack/SocketModeClient.ts
+++ b/src/messaging/slack/SocketModeClient.ts
@@ -6,6 +6,14 @@
  * too_many_websockets handling, proactive rotation).
  *
  * Uses Node's built-in WebSocket (Node 22+) or falls back to 'ws' package.
+ *
+ * CONTRACT-EVIDENCE: EXEMPT — net #1 (_safeSend containment) touches NO Slack
+ * Socket Mode API-contract surface. The bytes sent to Slack are byte-identical
+ * (the same ack `{ envelope_id }`, the same `{"type":"ping"}`, the same queued
+ * payloads); only the local non-OPEN-send guarding (readyState check + try/catch)
+ * and the reconnect policy changed. No wire-protocol / envelope shape change, so
+ * live-API contract evidence does not apply. Remove this marker when the file's
+ * actual API surface next changes.
  */
 
 import { SlackApiClient, SlackApiError } from './SlackApiClient.js';
@@ -107,15 +115,54 @@ export class SocketModeClient {
     }
   }
 
+  /**
+   * The single funnel for EVERY WebSocket send in this client (net #1). A
+   * `send()` on a socket that is not OPEN (CONNECTING / CLOSING / CLOSED) throws
+   * synchronously — `"WebSocket is not open: readyState N"` on the Node 22+
+   * built-in, `"Sent before connected"` on the `ws` polyfill — and these sends
+   * run inside un-awaited event-listener callbacks, where an escaping throw
+   * becomes an uncaughtException / unhandledRejection that can crash the whole
+   * process. `_safeSend` contains that at the source.
+   *
+   * Reads `this.ws` ONCE into a local and sends on THAT local, so the readyState
+   * check and the send target the same socket (no internal TOCTOU). Returns true
+   * iff the frame was handed to the socket.
+   *
+   * - Not-OPEN precheck (the EXPECTED transient state during reconnect): returns
+   *   false silently — no log, no reconnect. A non-OPEN socket short-circuits
+   *   here, so repeated sends against a dead socket can never flood the log.
+   * - A genuine throw on an OPEN socket (a rare race): logged message-only (never
+   *   the payload). Only the liveness path (`reconnectOnFailure`) reconnects, and
+   *   only if the socket we sent on is still current (`this.ws === sock`) — so a
+   *   throw after a teardown-and-replace can never tear down a fresh healthy
+   *   socket. Reuses the existing `_forceReconnect` guard (epoch model, #1076);
+   *   never resurrects a torn-down socket.
+   */
+  private _safeSend(data: string, context: string, reconnectOnFailure = false): boolean {
+    const sock = this.ws;
+    if (!sock || sock.readyState !== WebSocket.OPEN) return false;
+    try {
+      sock.send(data);
+      return true;
+    } catch (err) {
+      console.warn(
+        `[slack-socket] ${context} send failed (readyState=${sock.readyState}): ${(err as Error).message}`,
+      );
+      if (reconnectOnFailure && this.started && !this.reconnecting && this.ws === sock) {
+        this._forceReconnect();
+      }
+      return false;
+    }
+  }
+
   /** Queue an outbound message for sending (or send immediately if connected). */
   queueOutbound(data: string): void {
-    if (this.isConnected && this.ws) {
-      this.ws.send(data);
-    } else {
-      this.outboundQueue.push({ data, enqueuedAt: Date.now() });
-      if (this.outboundQueue.length > MAX_OUTBOUND_QUEUE) {
-        this.outboundQueue.shift(); // Drop oldest
-      }
+    // Send immediately if the socket is OPEN; otherwise (or on a lost TOCTOU
+    // race) enqueue for the next drain instead of dropping the message.
+    if (this._safeSend(data, 'outbound')) return;
+    this.outboundQueue.push({ data, enqueuedAt: Date.now() });
+    if (this.outboundQueue.length > MAX_OUTBOUND_QUEUE) {
+      this.outboundQueue.shift(); // Drop oldest
     }
   }
 
@@ -225,22 +272,17 @@ export class SocketModeClient {
       return;
     }
 
-    // Acknowledge immediately (must be within 3 seconds). Guard the send:
-    // during a reconnect race the socket can be mid-transition (CONNECTING /
-    // CLOSING), and an unguarded ws.send() on a non-OPEN socket throws — which,
-    // uncaught in this async message handler, crashed the whole server (the
-    // observed "Sent before connected" FATAL after a sleep/wake reconnect).
-    // Mirror queueOutbound's readyState guard + the liveness-probe try/catch.
-    if (envelope.envelope_id && this.ws && this.ws.readyState === WebSocket.OPEN) {
-      try {
-        this.ws.send(JSON.stringify({ envelope_id: envelope.envelope_id }));
-      } catch (err) {
-        // Socket changed state between the check and the send (rare race) —
-        // log and move on; Slack will redeliver the unacked event.
-        console.warn(
-          `[slack-socket] Ack send failed (socket mid-transition): ${(err as Error).message}`,
-        );
-      }
+    // Acknowledge immediately (must be within 3 seconds). Route through the
+    // _safeSend funnel: during a reconnect race the socket can be mid-transition
+    // (CONNECTING / CLOSING), and an unguarded send on a non-OPEN socket throws —
+    // which, uncaught in this async message handler, crashed the whole server
+    // (the observed "Sent before connected" FATAL after a sleep/wake reconnect).
+    // No reconnect on a failed ack: a single failed ack does not prove the socket
+    // is dead, and reconnecting per-envelope would risk an epoch-churn storm —
+    // Slack redelivers the unacked event, and the 30s heartbeat is the recovery
+    // bound for a genuinely-dead socket.
+    if (envelope.envelope_id) {
+      this._safeSend(JSON.stringify({ envelope_id: envelope.envelope_id }), 'ack');
     }
 
     // Process event with exception guard (post-ack — Slack won't redeliver)
@@ -317,14 +359,12 @@ export class SocketModeClient {
       const sinceLastEvent = Date.now() - this.lastEventAt;
       if (sinceLastEvent > DEAD_SILENCE_MS) {
         console.log(`[slack-socket] No events for ${Math.round(sinceLastEvent / 60000)}m — sending liveness probe`);
-        try {
-          this.ws?.send('{"type":"ping"}');
+        // Route through the funnel with reconnectOnFailure: a probe that throws
+        // means the socket is dead at the OS level → _safeSend forces a reconnect.
+        if (this._safeSend('{"type":"ping"}', 'liveness-probe', true)) {
           // send() succeeded → TCP connection is alive. Reset silence timer
           // so we don't immediately re-probe on the next tick.
           this.lastEventAt = Date.now();
-        } catch {
-          console.warn('[slack-socket] Liveness probe send failed, forcing reconnect');
-          this._forceReconnect();
         }
       }
     }, HEARTBEAT_INTERVAL_MS);
@@ -348,8 +388,17 @@ export class SocketModeClient {
 
   private _drainQueue(): void {
     if (!this.ws || this.ws.readyState !== WebSocket.OPEN) return;
-    for (const item of this.outboundQueue) {
-      this.ws.send(item.data);
+    // Iterate a snapshot by index. If a send fails mid-drain (socket went down),
+    // retain the unsent tail (this item + the rest) for the next 'open' drain
+    // rather than silently dropping it. Remove-only — never grows the queue, so
+    // length stays <= MAX_OUTBOUND_QUEUE. Single-threaded synchronous loop, so
+    // no concurrent queueOutbound can interleave with the reassignment.
+    const pending = this.outboundQueue;
+    for (let k = 0; k < pending.length; k++) {
+      if (!this._safeSend(pending[k].data, 'drain')) {
+        this.outboundQueue = pending.slice(k);
+        return;
+      }
     }
     this.outboundQueue = [];
   }

--- a/tests/e2e/slack-containment-process-survival.test.ts
+++ b/tests/e2e/slack-containment-process-survival.test.ts
@@ -1,0 +1,85 @@
+/**
+ * E2E "feature is alive" test (Robustness Net #1, FD-8).
+ *
+ * The single most important test for this feature: prove that the REAL
+ * process-level guards keep a process ALIVE through a contained Slack error, and
+ * still CRASH (exit 1) on a genuinely-unknown one. A naive boot-time test would
+ * false-green — server.ts's existing boot try/catch already contains a start()
+ * failure, so the regression under test (a throw from an un-awaited POST-boot
+ * listener, surfacing as uncaughtException OR unhandledRejection) never fires
+ * during boot. Instead we spawn a real child process that registers the real
+ * handlers via the built dist `handleProcessLevelError`, emits the error from an
+ * un-awaited context, and we assert the OS-level process outcome.
+ */
+
+import { describe, it, expect, beforeAll } from 'vitest';
+import { spawn, execFileSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import path from 'node:path';
+
+const POLICY_PATH = path.resolve(__dirname, '../../dist/core/uncaughtExceptionPolicy.js');
+const REPO_ROOT = path.resolve(__dirname, '../..');
+
+// The child registers the REAL handlers (real process.on, real process.exit)
+// delegating to the built handleProcessLevelError — the production wiring.
+const CHILD_SCRIPT = `
+const { handleProcessLevelError } = await import(process.env.POLICY_PATH);
+const onFatalCleanup = () => {};
+process.on('uncaughtException', (e) => handleProcessLevelError(e, 'uncaughtException', { onFatalCleanup }));
+process.on('unhandledRejection', (r) => handleProcessLevelError(r, 'unhandledRejection', { onFatalCleanup }));
+const scenario = process.env.SCENARIO;
+if (scenario === 'contained-uncaught') {
+  setTimeout(() => { throw new Error('WebSocket is not open: readyState 2'); }, 10);
+} else if (scenario === 'contained-rejection') {
+  Promise.reject(new Error('WebSocket is not open: readyState 2'));
+} else if (scenario === 'control-uncaught') {
+  setTimeout(() => { throw new Error('genuine unknown corruption — must crash'); }, 10);
+}
+// If the process is still alive after the error would have fired, declare it.
+setTimeout(() => { process.stdout.write('STILL-ALIVE\\n'); process.exit(0); }, 300);
+`;
+
+interface ChildResult { code: number | null; stdout: string; stderr: string; }
+
+function runChild(scenario: string): Promise<ChildResult> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, ['--input-type=module', '-e', CHILD_SCRIPT], {
+      env: { ...process.env, POLICY_PATH, SCENARIO: scenario },
+    });
+    let stdout = '';
+    let stderr = '';
+    child.stdout.on('data', (d) => { stdout += String(d); });
+    child.stderr.on('data', (d) => { stderr += String(d); });
+    child.on('error', reject);
+    child.on('close', (code) => resolve({ code, stdout, stderr }));
+  });
+}
+
+describe('Slack containment — process survives a contained error, crashes on an unknown one', () => {
+  beforeAll(() => {
+    // The E2E exercises the BUILT artifact (closest to production). CI builds
+    // before tests; build here if the dist is missing so the test is self-contained.
+    if (!existsSync(POLICY_PATH)) {
+      execFileSync('npm', ['run', 'build'], { cwd: REPO_ROOT, stdio: 'ignore' });
+    }
+    expect(existsSync(POLICY_PATH)).toBe(true);
+  }, 300_000);
+
+  it('survives a contained Slack WebSocket error thrown as an uncaughtException', async () => {
+    const { code, stdout } = await runChild('contained-uncaught');
+    expect(stdout).toContain('STILL-ALIVE');
+    expect(code).toBe(0);
+  }, 30_000);
+
+  it('survives a contained Slack WebSocket error surfacing as an unhandledRejection', async () => {
+    const { code, stdout } = await runChild('contained-rejection');
+    expect(stdout).toContain('STILL-ALIVE');
+    expect(code).toBe(0);
+  }, 30_000);
+
+  it('STILL crashes (exit 1) on a genuinely-unknown error — fail-toward-crash preserved', async () => {
+    const { code, stdout } = await runChild('control-uncaught');
+    expect(stdout).not.toContain('STILL-ALIVE');
+    expect(code).toBe(1);
+  }, 30_000);
+});

--- a/tests/e2e/slack-containment-process-survival.test.ts
+++ b/tests/e2e/slack-containment-process-survival.test.ts
@@ -12,13 +12,23 @@
  * un-awaited context, and we assert the OS-level process outcome.
  */
 
-import { describe, it, expect, beforeAll } from 'vitest';
-import { spawn, execFileSync } from 'node:child_process';
+import { describe, it, expect } from 'vitest';
+import { spawn } from 'node:child_process';
 import { existsSync } from 'node:fs';
 import path from 'node:path';
 
 const POLICY_PATH = path.resolve(__dirname, '../../dist/core/uncaughtExceptionPolicy.js');
-const REPO_ROOT = path.resolve(__dirname, '../..');
+
+// This E2E exercises the BUILT artifact (closest to production), so it needs a
+// fresh dist. Mirror the repo convention (tests/e2e/dev-preflight-cli.test.ts):
+// SKIP when dist is absent rather than building it — a test must never run
+// `npm run build` as a side-effect. The unit-test CI shards do NOT build dist
+// (only `npm ci` + `test:push`), and a build here would materialize dist for
+// every OTHER dist-gated test sharing the shard (e.g. dev-preflight, which then
+// runs `pnpm` and fails on runners without it). The build happens before push
+// locally, so this runs there; CI coverage of the policy is the in-process
+// process-level-error-handler unit tests.
+const DIST_BUILT = existsSync(POLICY_PATH);
 
 // The child registers the REAL handlers (real process.on, real process.exit)
 // delegating to the built handleProcessLevelError — the production wiring.
@@ -55,16 +65,7 @@ function runChild(scenario: string): Promise<ChildResult> {
   });
 }
 
-describe('Slack containment — process survives a contained error, crashes on an unknown one', () => {
-  beforeAll(() => {
-    // The E2E exercises the BUILT artifact (closest to production). CI builds
-    // before tests; build here if the dist is missing so the test is self-contained.
-    if (!existsSync(POLICY_PATH)) {
-      execFileSync('npm', ['run', 'build'], { cwd: REPO_ROOT, stdio: 'ignore' });
-    }
-    expect(existsSync(POLICY_PATH)).toBe(true);
-  }, 300_000);
-
+describe.skipIf(!DIST_BUILT)('Slack containment — process survives a contained error, crashes on an unknown one', () => {
   it('survives a contained Slack WebSocket error thrown as an uncaughtException', async () => {
     const { code, stdout } = await runChild('contained-uncaught');
     expect(stdout).toContain('STILL-ALIVE');

--- a/tests/integration/slack-adapter-boundary.test.ts
+++ b/tests/integration/slack-adapter-boundary.test.ts
@@ -1,0 +1,69 @@
+/**
+ * Slack adapter boundary (Robustness Net #1, Goal 2 — verify-and-test-only).
+ *
+ * A throw during Slack connection setup must surface via the adapter's onError
+ * path, NEVER reject out of server bootstrap. This is "verify-and-test-only": the
+ * synchronous boot boundary already exists in server.ts (the Slack init block —
+ * including `await slackAdapter.start()` — is wrapped in try/catch that sets
+ * `slackAdapter = undefined` and reports degradation, so /health keeps serving).
+ * These tests pin (1) the async dial-failure boundary behaviorally and (2) the
+ * synchronous boot boundary structurally.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { readFileSync } from 'fs';
+import path from 'path';
+import { SocketModeClient, type SocketModeHandlers } from '../../src/messaging/slack/SocketModeClient.js';
+import { SlackApiError } from '../../src/messaging/slack/SlackApiClient.js';
+
+function makeHandlers(): SocketModeHandlers {
+  return {
+    onEvent: vi.fn(async () => {}),
+    onInteraction: vi.fn(async () => {}),
+    onConnected: vi.fn(),
+    onDisconnected: vi.fn(),
+    onError: vi.fn(),
+  };
+}
+
+describe('SocketModeClient dial failure surfaces via onError (does not reject out of bootstrap)', () => {
+  it('a permanent dial error calls onError(err, true) and connect() resolves without throwing', async () => {
+    const handlers = makeHandlers();
+    const permanentErr = new SlackApiError('invalid auth', 'apps.connections.open', 'invalid_auth', true);
+    const apiClient = { call: vi.fn(() => Promise.reject(permanentErr)) };
+    const client = new SocketModeClient(apiClient as any, handlers);
+
+    // connect() must RESOLVE (not reject) — a caller awaiting it in server
+    // bootstrap is not torn down by the dial failure.
+    await expect(client.connect()).resolves.toBeUndefined();
+
+    expect(handlers.onError).toHaveBeenCalledWith(permanentErr, true);
+    expect(client.isConnected).toBe(false);
+  });
+
+  it('a permanent dial error stops retrying (started=false), so bootstrap is not blocked by backoff', async () => {
+    const handlers = makeHandlers();
+    const apiClient = {
+      call: vi.fn(() => Promise.reject(new SlackApiError('invalid auth', 'apps.connections.open', 'invalid_auth', true))),
+    };
+    const client = new SocketModeClient(apiClient as any, handlers);
+
+    await client.connect();
+
+    // A permanent failure must not arm an endless backoff loop — exactly one
+    // dial attempt, and the client is no longer "started".
+    expect(apiClient.call).toHaveBeenCalledTimes(1);
+    expect((client as unknown as { started: boolean }).started).toBe(false);
+  });
+});
+
+describe('server.ts boot boundary contains a Slack init failure (keeps /health serving)', () => {
+  const serverSource = readFileSync(path.resolve(__dirname, '../../src/commands/server.ts'), 'utf-8');
+
+  it('wraps the Slack init (incl. slackAdapter.start) and degrades instead of crashing boot', () => {
+    // The catch sets slackAdapter = undefined and reports a 'Slack' degradation —
+    // bootstrap continues, so the HTTP server (and /health) stays up.
+    expect(serverSource).toMatch(/await slackAdapter\.start\(\)/);
+    expect(serverSource).toMatch(/catch \(err\)[\s\S]*?slackAdapter = undefined;[\s\S]*?degradationReporter\.report\(\{[\s\S]*?feature: 'Slack'/);
+  });
+});

--- a/tests/integration/sqlite-close-on-exit.test.ts
+++ b/tests/integration/sqlite-close-on-exit.test.ts
@@ -92,14 +92,19 @@ describe('SQLite close-on-exit — server.ts wiring (ordering)', () => {
     expect(closeAfterStop).toBeGreaterThan(stopIdx); // close LAST, after the server stops
   });
 
-  it('the uncaughtException handler closes ALL sqlite (not just topic/semantic memory)', () => {
+  it('the uncaughtException handler closes ALL sqlite via the shared fatal-path cleanup', () => {
+    // The handler now delegates to handleProcessLevelError (net #1 — so the
+    // uncaughtException + unhandledRejection handlers share ONE policy), passing
+    // an onFatalCleanup that closes ALL registered sqlite handles (not just
+    // topic/semantic memory) before the FATAL exit. Assert that wiring.
+    const onFatalIdx = serverSrc.indexOf('const onFatalCleanup');
+    expect(onFatalIdx).toBeGreaterThan(0);
+    expect(serverSrc.slice(onFatalIdx, onFatalIdx + 200)).toMatch(/closeAllSqlite\(\)/);
+
     const uncaughtStart = serverSrc.indexOf("process.on('uncaughtException'");
     expect(uncaughtStart).toBeGreaterThan(0);
-    // Window generous enough to span the whole handler (the suppressed-error
-    // branch now logs a first-seen stack before the FATAL branch's
-    // closeAllSqlite() call — so a tight window would miss it).
-    const body = serverSrc.slice(uncaughtStart, uncaughtStart + 2000);
-    expect(body).toMatch(/closeAllSqlite\(\)/);
+    const body = serverSrc.slice(uncaughtStart, uncaughtStart + 300);
+    expect(body).toMatch(/handleProcessLevelError\([\s\S]*?onFatalCleanup/);
   });
 
   it('the old hand-maintained 2-store close-list is gone from the exit paths', () => {

--- a/tests/unit/process-level-error-handler.test.ts
+++ b/tests/unit/process-level-error-handler.test.ts
@@ -1,0 +1,112 @@
+/**
+ * handleProcessLevelError + the anchored 'WebSocket is not open' allowlist entry
+ * (Robustness Net #1, Goal 3).
+ *
+ * Both process-level handlers (uncaughtException AND unhandledRejection) delegate
+ * to one shared handleProcessLevelError so they cannot drift: one narrow allowlist,
+ * one fail-toward-crash default, one dedup'd log. These tests exercise BOTH sides of
+ * the boundary under BOTH labels with injected cleanup/exit fakes (so the fatal path
+ * is observable without actually exiting), and pin the anchored allowlist entry —
+ * including the NEGATIVE cases that the bare 'is not open' substring would wrongly
+ * swallow.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  handleProcessLevelError,
+  isNonFatalUncaught,
+  __resetUncaughtStackDedupeForTests,
+} from '../../src/core/uncaughtExceptionPolicy.js';
+
+type Label = 'uncaughtException' | 'unhandledRejection';
+const LABELS: Label[] = ['uncaughtException', 'unhandledRejection'];
+
+function makeOpts() {
+  const onFatalCleanup = vi.fn();
+  const exit = vi.fn() as unknown as (code: number) => never;
+  return { onFatalCleanup, exit, opts: { onFatalCleanup, exit } };
+}
+
+beforeEach(() => {
+  __resetUncaughtStackDedupeForTests();
+  vi.spyOn(console, 'warn').mockImplementation(() => {});
+  vi.spyOn(console, 'error').mockImplementation(() => {});
+});
+
+describe('handleProcessLevelError — recoverable (allowlisted) errors', () => {
+  it.each(LABELS)('%s: the Node built-in WebSocket non-OPEN message is recovered (no cleanup, no exit)', (label) => {
+    const { onFatalCleanup, exit, opts } = makeOpts();
+    const verdict = handleProcessLevelError(
+      new Error('WebSocket is not open: readyState 2 (CLOSING)'),
+      label,
+      opts,
+    );
+    expect(verdict).toBe('recovered');
+    expect(onFatalCleanup).not.toHaveBeenCalled();
+    expect(exit).not.toHaveBeenCalled();
+  });
+
+  it.each(LABELS)('%s: the ws-polyfill "Sent before connected" message is recovered', (label) => {
+    const { onFatalCleanup, exit, opts } = makeOpts();
+    expect(handleProcessLevelError(new Error('Sent before connected.'), label, opts)).toBe('recovered');
+    expect(onFatalCleanup).not.toHaveBeenCalled();
+    expect(exit).not.toHaveBeenCalled();
+  });
+
+  it('recovers a non-Error string rejection that matches the allowlist (unhandledRejection)', () => {
+    const { exit, opts } = makeOpts();
+    expect(handleProcessLevelError('WebSocket is not open: readyState 3', 'unhandledRejection', opts)).toBe('recovered');
+    expect(exit).not.toHaveBeenCalled();
+  });
+});
+
+describe('handleProcessLevelError — fatal (unknown) errors crash by default', () => {
+  it.each(LABELS)('%s: an unrecognized error runs cleanup then exits(1)', (label) => {
+    const { onFatalCleanup, exit, opts } = makeOpts();
+    const verdict = handleProcessLevelError(new Error('genuine unknown corruption'), label, opts);
+    expect(verdict).toBe('fatal');
+    expect(onFatalCleanup).toHaveBeenCalledTimes(1);
+    expect(exit).toHaveBeenCalledWith(1);
+  });
+
+  it('a cleanup that throws does not stop the exit (best-effort cleanup)', () => {
+    const exit = vi.fn() as unknown as (code: number) => never;
+    const onFatalCleanup = vi.fn(() => { throw new Error('cleanup blew up'); });
+    const verdict = handleProcessLevelError(new Error('unknown'), 'uncaughtException', { onFatalCleanup, exit });
+    expect(verdict).toBe('fatal');
+    expect(exit).toHaveBeenCalledWith(1);
+  });
+
+  it('a non-Error, non-allowlisted rejection reason is fatal', () => {
+    const { exit, opts } = makeOpts();
+    expect(handleProcessLevelError({ weird: 'object' }, 'unhandledRejection', opts)).toBe('fatal');
+    expect(exit).toHaveBeenCalledWith(1);
+  });
+});
+
+describe('anchored allowlist — must NOT swallow look-alike fatal errors', () => {
+  it('the registration "is not open" message does NOT match (would be a fatal swallow)', () => {
+    // TelegramAdapter / AuthGate emit "<name> is not open for public registration".
+    expect(isNonFatalUncaught(new Error('Workspace is not open for public registration'))).toBe(false);
+  });
+
+  it('a "database connection is not open" message does NOT match', () => {
+    // SqliteRegistry's already-closed-handle throw — a genuine DB-layer error.
+    expect(isNonFatalUncaught(new Error('database connection is not open'))).toBe(false);
+  });
+
+  it('the bare phrase "is not open" alone does NOT match (anchor requires "WebSocket")', () => {
+    expect(isNonFatalUncaught(new Error('the door is not open'))).toBe(false);
+  });
+
+  it('still matches the real Node built-in WebSocket message form', () => {
+    expect(isNonFatalUncaught(new Error('WebSocket is not open: readyState 2'))).toBe(true);
+  });
+
+  it('routes the registration look-alike to the fatal path end-to-end', () => {
+    const { onFatalCleanup, exit, opts } = makeOpts();
+    expect(handleProcessLevelError(new Error('Acme is not open for public registration'), 'uncaughtException', opts)).toBe('fatal');
+    expect(onFatalCleanup).toHaveBeenCalledTimes(1);
+    expect(exit).toHaveBeenCalledWith(1);
+  });
+});

--- a/tests/unit/slack-safesend.test.ts
+++ b/tests/unit/slack-safesend.test.ts
@@ -1,0 +1,273 @@
+/**
+ * _safeSend funnel tests (Robustness Net #1 — Slack subsystem error containment).
+ *
+ * Every WebSocket send in SocketModeClient routes through one private _safeSend
+ * funnel: it checks the socket is OPEN, swallows a send throw so it can never
+ * escape an un-awaited event listener (→ uncaughtException/unhandledRejection →
+ * process crash), returns a boolean, and (liveness path only) self-heals via the
+ * existing _forceReconnect. These tests pin the behavior on every readyState, the
+ * per-callsite policy (queueOutbound enqueues, ack does NOT reconnect, drain
+ * breaks-and-retains, liveness reconnects), the storm guard, the stale-socket
+ * identity guard, and the wiring-integrity ratchet.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { readFileSync } from 'fs';
+import path from 'path';
+import { SocketModeClient, type SocketModeHandlers } from '../../src/messaging/slack/SocketModeClient.js';
+
+const socketClientPath = path.resolve(__dirname, '../../src/messaging/slack/SocketModeClient.ts');
+const socketClientSource = readFileSync(socketClientPath, 'utf-8');
+
+function makeHandlers(): SocketModeHandlers {
+  return {
+    onEvent: vi.fn(async () => {}),
+    onInteraction: vi.fn(async () => {}),
+    onConnected: vi.fn(),
+    onDisconnected: vi.fn(),
+    onError: vi.fn(),
+  };
+}
+
+function makeClient(): SocketModeClient {
+  return new SocketModeClient({} as any, makeHandlers());
+}
+
+/** Invoke the private _safeSend with whatever this.ws currently is. */
+function safeSend(client: SocketModeClient, data: string, context: string, reconnect = false): boolean {
+  return (client as unknown as {
+    _safeSend(d: string, c: string, r?: boolean): boolean;
+  })._safeSend(data, context, reconnect);
+}
+
+describe('_safeSend on each readyState', () => {
+  it('OPEN → sends and returns true', () => {
+    const client = makeClient();
+    const send = vi.fn();
+    (client as any).ws = { readyState: WebSocket.OPEN, send };
+    expect(safeSend(client, 'hi', 'test')).toBe(true);
+    expect(send).toHaveBeenCalledWith('hi');
+  });
+
+  it.each([
+    ['CONNECTING', WebSocket.CONNECTING],
+    ['CLOSING', WebSocket.CLOSING],
+    ['CLOSED', WebSocket.CLOSED],
+  ])('%s → no-op, returns false, never calls send, never throws, never logs', (_name, state) => {
+    const client = makeClient();
+    const send = vi.fn();
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    (client as any).ws = { readyState: state, send };
+    expect(() => safeSend(client, 'hi', 'test')).not.toThrow();
+    expect(safeSend(client, 'hi', 'test')).toBe(false);
+    expect(send).not.toHaveBeenCalled();
+    // The not-OPEN precheck is the EXPECTED transient state — it must not log
+    // (otherwise a dead socket floods the log at message rate).
+    expect(warn).not.toHaveBeenCalled();
+    warn.mockRestore();
+  });
+
+  it('this.ws null → no-op, returns false, no throw', () => {
+    const client = makeClient();
+    (client as any).ws = null;
+    expect(() => safeSend(client, 'hi', 'test')).not.toThrow();
+    expect(safeSend(client, 'hi', 'test')).toBe(false);
+  });
+});
+
+describe('_safeSend swallows a send throw on an OPEN socket', () => {
+  it('catches the throw, logs message-only, returns false', () => {
+    const client = makeClient();
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const send = vi.fn(() => { throw new Error('WebSocket is not open: readyState 2'); });
+    (client as any).ws = { readyState: WebSocket.OPEN, send };
+    expect(safeSend(client, 'hi', 'ack')).toBe(false);
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('ack send failed'));
+    // Never logs the payload itself.
+    expect(warn).not.toHaveBeenCalledWith(expect.stringContaining('hi'));
+    warn.mockRestore();
+  });
+
+  it('does NOT reconnect when reconnectOnFailure is false (default — e.g. ack path)', () => {
+    const client = makeClient();
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const force = vi.spyOn(client as any, '_forceReconnect').mockImplementation(() => {});
+    const send = vi.fn(() => { throw new Error('WebSocket is not open: readyState 2'); });
+    (client as any).ws = { readyState: WebSocket.OPEN, send };
+    (client as any).started = true;
+    safeSend(client, 'hi', 'ack', false);
+    expect(force).not.toHaveBeenCalled();
+    vi.restoreAllMocks();
+  });
+
+  it('reconnects when reconnectOnFailure is true (liveness path)', () => {
+    const client = makeClient();
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const force = vi.spyOn(client as any, '_forceReconnect').mockImplementation(() => {});
+    const send = vi.fn(() => { throw new Error('WebSocket is not open: readyState 2'); });
+    (client as any).ws = { readyState: WebSocket.OPEN, send };
+    (client as any).started = true;
+    (client as any).reconnecting = false;
+    safeSend(client, '{"type":"ping"}', 'liveness-probe', true);
+    expect(force).toHaveBeenCalledTimes(1);
+    vi.restoreAllMocks();
+  });
+
+  it('storm guard: does NOT reconnect if already reconnecting', () => {
+    const client = makeClient();
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const force = vi.spyOn(client as any, '_forceReconnect').mockImplementation(() => {});
+    const send = vi.fn(() => { throw new Error('WebSocket is not open: readyState 2'); });
+    (client as any).ws = { readyState: WebSocket.OPEN, send };
+    (client as any).started = true;
+    (client as any).reconnecting = true; // a reconnect is already in flight
+    safeSend(client, '{"type":"ping"}', 'liveness-probe', true);
+    expect(force).not.toHaveBeenCalled();
+    vi.restoreAllMocks();
+  });
+
+  it('stale-socket identity guard: does NOT reconnect if this.ws was replaced before the throw', () => {
+    const client = makeClient();
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const force = vi.spyOn(client as any, '_forceReconnect').mockImplementation(() => {});
+    const freshSocket = { readyState: WebSocket.OPEN, send: vi.fn() };
+    const dyingSocket = {
+      readyState: WebSocket.OPEN,
+      send: vi.fn(() => {
+        // Simulate a teardown-and-replace happening between capture and throw.
+        (client as any).ws = freshSocket;
+        throw new Error('WebSocket is not open: readyState 2');
+      }),
+    };
+    (client as any).ws = dyingSocket;
+    (client as any).started = true;
+    (client as any).reconnecting = false;
+    safeSend(client, '{"type":"ping"}', 'liveness-probe', true);
+    // this.ws !== sock (the socket we sent on) → must NOT tear down the fresh one.
+    expect(force).not.toHaveBeenCalled();
+    vi.restoreAllMocks();
+  });
+});
+
+describe('queueOutbound through _safeSend', () => {
+  it('OPEN → sends immediately, queue stays empty', () => {
+    const client = makeClient();
+    const send = vi.fn();
+    (client as any).ws = { readyState: WebSocket.OPEN, send };
+    client.queueOutbound('msg-1');
+    expect(send).toHaveBeenCalledWith('msg-1');
+    expect((client as any).outboundQueue).toHaveLength(0);
+  });
+
+  it('CONNECTING → enqueues (does not drop), does not reconnect', () => {
+    const client = makeClient();
+    const send = vi.fn();
+    const force = vi.spyOn(client as any, '_forceReconnect').mockImplementation(() => {});
+    (client as any).ws = { readyState: WebSocket.CONNECTING, send };
+    client.queueOutbound('msg-1');
+    expect(send).not.toHaveBeenCalled();
+    expect((client as any).outboundQueue.map((i: any) => i.data)).toEqual(['msg-1']);
+    expect(force).not.toHaveBeenCalled();
+    vi.restoreAllMocks();
+  });
+
+  it('OPEN-but-throws → enqueues for the next drain instead of dropping', () => {
+    const client = makeClient();
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const send = vi.fn(() => { throw new Error('WebSocket is not open: readyState 2'); });
+    (client as any).ws = { readyState: WebSocket.OPEN, send };
+    client.queueOutbound('msg-1');
+    expect((client as any).outboundQueue.map((i: any) => i.data)).toEqual(['msg-1']);
+    vi.restoreAllMocks();
+  });
+});
+
+describe('_drainQueue through _safeSend (break-and-retain)', () => {
+  function drain(client: SocketModeClient): void {
+    (client as unknown as { _drainQueue(): void })._drainQueue();
+  }
+
+  it('all OPEN → drains everything, queue empties', () => {
+    const client = makeClient();
+    const send = vi.fn();
+    (client as any).ws = { readyState: WebSocket.OPEN, send };
+    (client as any).outboundQueue = ['a', 'b', 'c'].map((data) => ({ data, enqueuedAt: 0 }));
+    drain(client);
+    expect(send).toHaveBeenCalledTimes(3);
+    expect((client as any).outboundQueue).toHaveLength(0);
+  });
+
+  it('fails at item k → items before k sent, item k + remainder retained, loop stops, no reconnect', () => {
+    const client = makeClient();
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const force = vi.spyOn(client as any, '_forceReconnect').mockImplementation(() => {});
+    let calls = 0;
+    const send = vi.fn(() => {
+      calls++;
+      if (calls === 3) throw new Error('WebSocket is not open: readyState 2'); // item index 2 fails
+    });
+    (client as any).ws = { readyState: WebSocket.OPEN, send };
+    (client as any).started = true;
+    (client as any).outboundQueue = ['a', 'b', 'c', 'd', 'e'].map((data) => ({ data, enqueuedAt: 0 }));
+    drain(client);
+    // items a,b sent (2 successful) + c attempted-and-threw = 3 send() calls; d,e never attempted.
+    expect(send).toHaveBeenCalledTimes(3);
+    // c,d,e retained for the next 'open' drain (remove-only — never dropped).
+    expect((client as any).outboundQueue.map((i: any) => i.data)).toEqual(['c', 'd', 'e']);
+    // Drain never triggers reconnect.
+    expect(force).not.toHaveBeenCalled();
+    vi.restoreAllMocks();
+  });
+
+  it('retained queue length never exceeds the original (remove-only)', () => {
+    const client = makeClient();
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const send = vi.fn(() => { throw new Error('WebSocket is not open: readyState 2'); }); // first item fails
+    (client as any).ws = { readyState: WebSocket.OPEN, send };
+    const original = ['a', 'b', 'c'].map((data) => ({ data, enqueuedAt: 0 }));
+    (client as any).outboundQueue = original;
+    drain(client);
+    expect((client as any).outboundQueue.length).toBeLessThanOrEqual(original.length);
+    expect((client as any).outboundQueue.map((i: any) => i.data)).toEqual(['a', 'b', 'c']);
+    vi.restoreAllMocks();
+  });
+});
+
+describe('Wiring-integrity ratchet — every raw socket send funnels through _safeSend', () => {
+  /** Brace-match a method body starting at `signaturePrefix`. */
+  function methodBody(source: string, signaturePrefix: string): { body: string; start: number; end: number } {
+    const sigIdx = source.indexOf(signaturePrefix);
+    expect(sigIdx, `expected to find ${signaturePrefix}`).toBeGreaterThan(-1);
+    const open = source.indexOf('{', sigIdx);
+    let depth = 0;
+    let j = open;
+    for (; j < source.length; j++) {
+      if (source[j] === '{') depth++;
+      else if (source[j] === '}') { depth--; if (depth === 0) break; }
+    }
+    return { body: source.slice(open, j + 1), start: open, end: j + 1 };
+  }
+
+  it('the ONLY raw socket send (sock.send / this.ws(?.)send) lives inside _safeSend', () => {
+    const span = methodBody(socketClientSource, 'private _safeSend(');
+    // Match every raw socket-send form, optional-chained or not.
+    const re = /\b(?:this\.ws\??|sock)\.send\(/g;
+    const offenders: number[] = [];
+    let m: RegExpExecArray | null;
+    while ((m = re.exec(socketClientSource)) !== null) {
+      if (m.index < span.start || m.index >= span.end) offenders.push(m.index);
+    }
+    expect(
+      offenders,
+      `raw socket .send( found OUTSIDE _safeSend at offsets ${offenders.join(', ')} — route it through _safeSend`,
+    ).toEqual([]);
+  });
+
+  it('all four logical callsites reference _safeSend', () => {
+    // queueOutbound, the ack, the liveness probe, and the drain.
+    expect(socketClientSource).toMatch(/queueOutbound\(data: string\): void \{[\s\S]*?this\._safeSend\(data, 'outbound'\)/);
+    expect(socketClientSource).toMatch(/this\._safeSend\(JSON\.stringify\(\{ envelope_id: envelope\.envelope_id \}\), 'ack'\)/);
+    expect(socketClientSource).toMatch(/this\._safeSend\('\{"type":"ping"\}', 'liveness-probe', true\)/);
+    expect(socketClientSource).toMatch(/_drainQueue\(\): void \{[\s\S]*?this\._safeSend\(pending\[k\]\.data, 'drain'\)/);
+  });
+});

--- a/tests/unit/slack-socket-heartbeat.test.ts
+++ b/tests/unit/slack-socket-heartbeat.test.ts
@@ -39,19 +39,28 @@ describe('Heartbeat timing constants', () => {
 });
 
 describe('Active liveness probe', () => {
-  it('sends a ping probe when no events for DEAD_SILENCE_MS', () => {
-    // After DEAD_SILENCE_MS of silence, sends a JSON ping
-    expect(socketClientSource).toMatch(/sinceLastEvent > DEAD_SILENCE_MS[\s\S]*?ws\?\.send\(.*ping/);
+  it('sends a ping probe through the _safeSend funnel when no events for DEAD_SILENCE_MS', () => {
+    // After DEAD_SILENCE_MS of silence, sends a JSON ping via _safeSend (net #1)
+    expect(socketClientSource).toMatch(
+      /sinceLastEvent > DEAD_SILENCE_MS[\s\S]*?_safeSend\('\{"type":"ping"\}', 'liveness-probe', true\)/,
+    );
   });
 
-  it('resets silence timer after successful send (TCP alive)', () => {
-    // Successful send() means TCP connection is alive — reset lastEventAt
-    // so we don't immediately re-probe on the next tick
-    expect(socketClientSource).toMatch(/ws\?\.send\(.*ping[\s\S]*?lastEventAt = Date\.now\(\)/);
+  it('resets silence timer after a successful probe send (TCP alive)', () => {
+    // _safeSend returning true means the send succeeded → reset lastEventAt so we
+    // don't immediately re-probe on the next tick.
+    expect(socketClientSource).toMatch(
+      /_safeSend\('\{"type":"ping"\}', 'liveness-probe', true\)\) \{[\s\S]*?lastEventAt = Date\.now\(\)/,
+    );
   });
 
-  it('forces reconnect if send() throws (socket already dead)', () => {
-    expect(socketClientSource).toMatch(/catch[\s\S]*?Liveness probe send failed[\s\S]*?_forceReconnect/);
+  it('forces reconnect via _safeSend reconnectOnFailure when the probe send throws', () => {
+    // The probe passes reconnectOnFailure=true; the funnel force-reconnects on a
+    // caught throw (socket dead at the OS level), guarded by the identity check.
+    expect(socketClientSource).toMatch(/_safeSend\('\{"type":"ping"\}', 'liveness-probe', true\)/);
+    expect(socketClientSource).toMatch(
+      /reconnectOnFailure && this\.started && !this\.reconnecting && this\.ws === sock\) \{[\s\S]*?this\._forceReconnect\(\)/,
+    );
   });
 });
 

--- a/tests/unit/slack-socket-reconnect.test.ts
+++ b/tests/unit/slack-socket-reconnect.test.ts
@@ -145,35 +145,39 @@ describe('Ack send guard against a mid-reconnect socket (#43 — no whole-agent 
     await expect(handleRaw(client, JSON.stringify(payload))).resolves.toBeUndefined();
 
     expect(send).toHaveBeenCalledWith(JSON.stringify({ envelope_id: 'E-send-race' }));
-    expect(warn).toHaveBeenCalledWith(expect.stringContaining('Ack send failed'));
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('ack send failed'));
     expect(handlers.onEvent).toHaveBeenCalledWith('message', payload.payload);
     warn.mockRestore();
   });
 
-  it('guards the event ack on socket readyState === OPEN', () => {
-    // The "must ack within 3s" send previously called this.ws?.send() with only
-    // a null check — during a reconnect race the socket can be CONNECTING/CLOSING,
-    // and the unguarded send threw "Sent before connected" → uncaught → FATAL.
+  it('routes the event ack through the _safeSend funnel (net #1)', () => {
+    // The "must ack within 3s" send now goes through _safeSend, which owns the
+    // readyState guard + try/catch — during a reconnect race the socket can be
+    // CONNECTING/CLOSING, and an unguarded send threw "Sent before connected" →
+    // uncaught → FATAL. The ack path passes no reconnectOnFailure (a failed ack
+    // does not by itself prove the socket is dead).
     expect(socketClientSource).toMatch(
-      /envelope\.envelope_id[\s\S]*?this\.ws\.readyState === WebSocket\.OPEN[\s\S]*?this\.ws\.send\(/,
+      /envelope\.envelope_id\)\s*\{[\s\S]*?this\._safeSend\(JSON\.stringify\(\{ envelope_id: envelope\.envelope_id \}\), 'ack'\)/,
     );
   });
 
-  it('wraps the ack send in try/catch (state can change between check and send)', () => {
+  it('_safeSend guards the send on readyState === OPEN and wraps it in try/catch', () => {
+    // The funnel reads this.ws once into a local, returns false on a non-OPEN
+    // precheck (no throw), and wraps the OPEN-socket send in try/catch so a
+    // state flip between check and send cannot escape.
     expect(socketClientSource).toMatch(
-      /this\.ws\.readyState === WebSocket\.OPEN\) \{[\s\S]*?try \{[\s\S]*?this\.ws\.send\([\s\S]*?\} catch/,
+      /_safeSend\([^)]*\): boolean \{[\s\S]*?readyState !== WebSocket\.OPEN\) return false;[\s\S]*?try \{[\s\S]*?sock\.send\([\s\S]*?\} catch/,
     );
   });
 
-  it('server routes uncaught exceptions through the isNonFatalUncaught policy (defense-in-depth)', () => {
-    // The recoverable-error allowlist (HTTP races + the Slack WS race) is now a
-    // testable module, used by the process-level handler instead of an inline list.
-    // Tolerate additional named imports from the policy module (e.g.
-    // shouldLogStackForUncaught) — the intent is "server imports the
-    // isNonFatalUncaught policy", not a byte-exact import line.
+  it('server routes BOTH process-level error events through the shared policy (defense-in-depth)', () => {
+    // The recoverable-error allowlist is a testable module; both the
+    // uncaughtException AND unhandledRejection handlers delegate to the one
+    // shared handleProcessLevelError so they cannot drift to divergent policies.
     expect(serverSource).toMatch(
-      /import \{[^}]*\bisNonFatalUncaught\b[^}]*\} from '\.\.\/core\/uncaughtExceptionPolicy\.js'/,
+      /import \{[^}]*\bhandleProcessLevelError\b[^}]*\} from '\.\.\/core\/uncaughtExceptionPolicy\.js'/,
     );
-    expect(serverSource).toMatch(/if \(isNonFatalUncaught\(err\)\) \{[\s\S]*?return;/);
+    expect(serverSource).toMatch(/process\.on\('uncaughtException'[\s\S]*?handleProcessLevelError\(/);
+    expect(serverSource).toMatch(/process\.on\('unhandledRejection'[\s\S]*?handleProcessLevelError\(/);
   });
 });

--- a/upgrades/next/slack-subsystem-error-containment.md
+++ b/upgrades/next/slack-subsystem-error-containment.md
@@ -1,0 +1,65 @@
+<!-- bump: patch -->
+
+## What Changed
+
+Robustness Net #1: a Slack subsystem error can no longer crash the whole agent
+process. Previously, a Slack WebSocket send that happened during a reconnect (the
+socket not fully OPEN) threw synchronously inside an un-awaited event listener,
+which escaped as an uncaughtException or unhandledRejection and could take the
+entire server down — the root cause of the 2026-06-14 outage.
+
+- Every Slack socket send now goes through one funnel (`_safeSend`) that checks the
+  socket is OPEN, wraps the send so a throw can never escape, and (for the liveness
+  probe only) reconnects on failure — guarded so it can never tear down a freshly
+  replaced socket.
+- The four send sites are unified: `queueOutbound` now enqueues instead of dropping
+  on a lost race, the acknowledgement send no longer reconnects per-message, the
+  queue drain retains unsent messages on failure, and the heartbeat probe self-heals.
+- A process-level `unhandledRejection` handler is added (the async Slack message
+  path surfaces failures as rejections, which the existing handler did not catch),
+  sharing the exact same narrow, audited allowlist and fail-toward-crash default as
+  the existing uncaughtException handler via one shared decision function.
+- The allowlist gains one tightly-anchored "WebSocket is not open" entry so the
+  Node 22+ built-in WebSocket message form is recognized — anchored so it cannot
+  swallow look-alike fatal errors.
+
+This is defense-in-depth behind the existing in-process respawn (net #2) and the OS
+watchdog (net #3). No behavior change on the happy path.
+
+## What to Tell Your User
+
+A short Slack network hiccup can no longer crash your agent. Before this, if Slack's
+connection dropped at exactly the wrong moment, the whole agent could go down for a
+moment and restart. Now the agent quietly reconnects to Slack and keeps everything
+else running — your other chats, scheduled jobs, and memory are unaffected. There is
+nothing to turn on and nothing to configure; on a normal day you will not notice any
+difference. You only benefit on a bad day, when a transient Slack glitch that used to
+ripple outward now stays contained to Slack and heals itself.
+
+## Summary of New Capabilities
+
+- Slack socket errors are contained at the subsystem boundary and can no longer take
+  the whole agent process down.
+- The agent now also recovers from a wider class of unexpected internal errors
+  (unhandled promise rejections) the same careful way it already handled others —
+  logging and continuing for a tiny set of known-harmless cases, and restarting
+  cleanly for anything genuinely unknown.
+
+## Evidence
+
+- Root cause grounded in code (read 2026-06-14): the unguarded sends were
+  `queueOutbound` and the queue drain; the acknowledgement and heartbeat sends were
+  already guarded. All four are now funneled.
+- Tests across all three tiers, all green: unit (`tests/unit/slack-safesend.test.ts`,
+  `tests/unit/process-level-error-handler.test.ts`, plus updated socket reconnect /
+  heartbeat / sqlite-close tests), integration
+  (`tests/integration/slack-adapter-boundary.test.ts`), and an E2E "feature is alive"
+  process-survival test (`tests/e2e/slack-containment-process-survival.test.ts`) that
+  spawns a real child process, emits a contained error (both uncaughtException and
+  unhandledRejection forms) and asserts the process stays alive, then emits an unknown
+  error and asserts it still exits 1.
+- A wiring-integrity ratchet asserts every raw socket send lives only inside
+  `_safeSend`, so a future un-funneled callsite fails the test.
+- Converged spec + report: `docs/specs/SLACK-SUBSYSTEM-ERROR-CONTAINMENT-SPEC.md`,
+  `docs/specs/reports/slack-subsystem-error-containment-convergence.md`.
+- Side-effects review (second-pass concur): `upgrades/side-effects/slack-subsystem-error-containment.md`.

--- a/upgrades/side-effects/slack-subsystem-error-containment.md
+++ b/upgrades/side-effects/slack-subsystem-error-containment.md
@@ -1,0 +1,225 @@
+# Side-Effects Review — Slack Subsystem Error Containment (Robustness Net #1)
+
+**Version / slug:** `slack-subsystem-error-containment`
+**Date:** `2026-06-15`
+**Author:** `Echo (instar-dev agent)`
+**Second-pass reviewer:** `required (touches the uncaughtException recovery path + a self-heal "reconnect" trigger)`
+
+## Summary of the change
+
+Contains Slack WebSocket subsystem errors so a non-OPEN socket send can never crash
+the whole agent process (Robustness Net #1; defense-in-depth behind nets #2/#3).
+Three source files:
+
+- `src/messaging/slack/SocketModeClient.ts` — adds one private funnel
+  `_safeSend(data, context, reconnectOnFailure = false)` and routes all four socket
+  sends through it (`queueOutbound`, the ACK send, the heartbeat liveness probe,
+  `_drainQueue`). The funnel reads `this.ws` once, sends only on an OPEN socket inside
+  a `try/catch`, returns a boolean, and (liveness path only) triggers the existing
+  `_forceReconnect()` — guarded by `this.started && !this.reconnecting && this.ws === sock`.
+- `src/core/uncaughtExceptionPolicy.ts` — extracts `handleProcessLevelError(err, label,
+  opts)` (the crash-vs-continue decision both process handlers share) and adds ONE
+  anchored allowlist entry `'WebSocket is not open'` (the Node 22+ built-in message
+  form of the already-allowlisted non-OPEN-send race).
+- `src/commands/server.ts` — rewrites the existing `uncaughtException` handler to
+  delegate to `handleProcessLevelError`, and adds a `process.on('unhandledRejection')`
+  handler delegating to the same function (closes the async `.then`-chain gap — the
+  `'message'` listener's escaping throw is a *rejection*, not a sync exception).
+
+Decision points: the process-level crash-vs-continue authority (modified — extracted +
+one narrow allowlist addition + a second event type) and a per-socket self-heal signal
+(added — `_safeSend`'s liveness-path reconnect, no blocking authority).
+
+## Decision-point inventory
+
+- `uncaughtExceptionPolicy.isNonFatalUncaught` (the fail-toward-crash allowlist) —
+  **modify** — adds one anchored substring `'WebSocket is not open'`; default stays
+  crash-on-unknown.
+- `process.on('uncaughtException')` handler (server.ts) — **modify** — body extracted
+  into `handleProcessLevelError`; behavior preserved byte-for-byte in policy.
+- `process.on('unhandledRejection')` handler (server.ts) — **add** — same authority,
+  same default-crash, via the same shared function.
+- `SocketModeClient._safeSend` liveness-path `_forceReconnect()` — **add** — a
+  self-heal signal at the subsystem boundary; no cross-subsystem blocking authority.
+- The four `.send()` callsites — **modify (pass-through)** — routed through `_safeSend`;
+  no new decision logic.
+
+---
+
+## 1. Over-block
+
+**What legitimate inputs does this reject that it shouldn't?**
+
+`_safeSend` only changes behavior on the *unhappy* path. On an OPEN socket it sends
+exactly as before; the only "rejection" is a send on a non-OPEN socket, which today
+either throws (the bug) or is already guarded. No legitimate Slack message is dropped
+on a healthy socket. The one nuance: `queueOutbound` on a non-OPEN socket now *enqueues*
+the message (previously it also enqueued, but an OPEN-but-racing send could throw) — so
+this is strictly fewer drops, not more.
+
+The allowlist addition is the one over-broadening risk: `'WebSocket is not open'` is
+anchored precisely so it does NOT match the live user-facing strings `"<name> is not
+open for public registration"` (TelegramAdapter/AuthGate) or `"database connection is
+not open"` (SqliteRegistry's already-closed-handle message). A negative unit test pins
+that those do NOT match `isNonFatalUncaught`.
+
+---
+
+## 2. Under-block
+
+**What failure modes does this still miss?**
+
+- The process-level backstop is brittle-substring by nature: a future Node/`ws` version
+  could change `"WebSocket is not open: readyState N"` and silently disable the
+  allowlist match. Mitigated by the `_safeSend` funnel + grep ratchet being the PRIMARY
+  guarantee (the backstop only ever sees *un-funneled* escapes), plus a source comment
+  citing the Node origin of the string.
+- A genuinely-wedged reconnect (e.g. `reconnecting` stuck true) would leave the process
+  alive but Slack-silent — neither net #2 nor #3 observes subsystem-level degradation
+  (both are process-existence triggers). The 30s heartbeat's `readyState != OPEN →
+  _forceReconnect` is the recovery bound; `consecutiveErrors` + `onError` are the
+  visible signal. This is an accepted, documented trade (Slack is non-load-bearing).
+
+---
+
+## 3. Level-of-abstraction fit
+
+`_safeSend` is a **low-level structural validator** at a hard invariant (a socket must
+be OPEN to send) — not a judgment call — so it correctly does not route to an LLM
+authority. It produces a boolean signal and self-heals via the *existing*
+`_forceReconnect`/`_backoffReconnect` path; it does not re-implement reconnect logic.
+The crash-vs-continue **authority** stays exactly where it belongs:
+`uncaughtExceptionPolicy`. The change does not add a parallel authority — it extends the
+one that exists (one new event type, one narrow allowlist entry) and funnels the new
+`unhandledRejection` handler into it so the two can't diverge.
+
+---
+
+## 4. Signal vs authority compliance
+
+**Required reference:** [docs/signal-vs-authority.md](../../docs/signal-vs-authority.md)
+
+- [x] No — `_safeSend` produces a signal (boolean + self-heal) consumed by the existing
+  reconnect machinery; it holds no cross-subsystem blocking authority.
+- [x] Yes, smart-gate-equivalent — the process-level allowlist is the canonical,
+  deliberately-narrow, audited authority and stays default-crash. The new
+  `unhandledRejection` handler reuses the *identical* `isNonFatalUncaught` predicate; it
+  does NOT introduce a second, looser policy.
+
+`_safeSend`'s readyState check is a deterministic hard-invariant validator (OPEN or not),
+the documented exception class for structural validators — not a brittle content
+heuristic holding block authority. No brittle-detector-with-authority is introduced.
+
+---
+
+## 5. Interactions
+
+- **Shadowing:** `_safeSend` replaces the inline ACK guard and the heartbeat try/catch —
+  same behavior, relocated. The heartbeat's pre-probe `readyState != OPEN` check still
+  runs first and force-reconnects before the probe ever reaches `_safeSend`.
+- **Double-fire:** the liveness-path reconnect is guarded by `!this.reconnecting` + the
+  `this.ws === sock` identity check, so a burst of failures collapses to at most one
+  `_forceReconnect`/epoch-bump (storm guard, unit-tested). The ACK path does NOT
+  reconnect (a failed ack ≠ a dead socket), removing a reconnect-churn source.
+- **Races:** `_safeSend` reads `this.ws` once into `sock` and reconnects only if
+  `this.ws === sock` — so a teardown-and-replace between capture and throw cannot tear
+  down a fresh healthy socket. Respects the #1076 epoch model (never resurrects a
+  torn-down socket). `_drainQueue` iterates a snapshot and reassigns `outboundQueue`
+  once (no mutate-during-iterate; single-threaded so no interleave).
+- **Feedback loops:** none. `handleProcessLevelError`'s non-fatal branch logs-and-returns;
+  it does not re-throw or re-enter.
+
+---
+
+## 6. External surfaces
+
+- **Other agents (same machine):** none — per-process socket + per-process crash guard.
+- **Install base:** ships to all agents via the normal release path (pure `src/*.ts`).
+- **External systems (Slack):** strictly more robust — a transient socket glitch now
+  reconnects instead of crashing; unacked envelopes are redelivered by Slack as today.
+- **Persistent state:** none added. The fatal path still calls `closeAllSqlite()` before
+  exit (now via the injected cleanup callback) — unchanged behavior.
+- **Operator surface (Mobile-Complete):** no operator-facing action added — no route, no
+  form, no PIN/approval surface. Not applicable.
+
+## 6b. Operator-surface quality
+
+No operator surface — no dashboard renderer, approval page, or grant/secret form touched.
+Not applicable.
+
+---
+
+## 7. Multi-machine posture (Cross-Machine Coherence)
+
+**Machine-local BY DESIGN** — all three artifacts are per-process / per-socket:
+
+- `_safeSend` + reconnect: the Slack WebSocket is a per-process resource; only the
+  machine holding the live socket sends. A standby machine has `this.ws === null`, so
+  `_safeSend` no-ops. Which machine owns the socket is the existing lease/standby model's
+  job; this change does not touch it.
+- `uncaughtException` / `unhandledRejection` handlers: process-level crash containment is
+  inherently per-process. The allowlist already encodes the standby case
+  (`'StateManager is read-only'`); the new rejection handler consults the same authority,
+  so lease/standby semantics stay identical across both handlers.
+
+No user-facing notices (no one-voice concern). No durable state (nothing strands on topic
+transfer). No generated URLs.
+
+---
+
+## 8. Rollback cost
+
+Pure code change — revert the commit, ship as the next patch (reaches agents via `instar
+update`; nets #2/#3 keep them alive during the rollback window). No persistent state, no
+data migration, no config flag (so no `migrateConfig` obligation), no user-visible
+regression. The single riskiest knob — the allowlist broadening — is independently
+revertable (delete the one entry) without touching `_safeSend`.
+
+---
+
+## Conclusion
+
+The review produced the converged design directly (the spec's `## Frontloaded Decisions`
+captured every choice). Key review-driven shapes baked in: the ACK path does not reconnect
+(storm-avoidance), `_drainQueue` retains unsent messages on failure, `_safeSend` re-checks
+socket identity before reconnecting, the allowlist entry is anchored + transport-scoped
+with a negative test, and the new `unhandledRejection` handler shares one authority with
+`uncaughtException` so they cannot drift. No brittle-detector-with-authority is introduced;
+the global default stays fail-toward-crash. Clear to ship pending the required second-pass
+read.
+
+---
+
+## Second-pass review (if required)
+
+**Reviewer:** independent reviewer subagent (instar-dev Phase 5 — change touches the
+process-level recovery path + a self-heal reconnect trigger)
+**Independent read of the artifact: concur**
+
+Read all three implementation files line-by-line plus tree-wide greps, and verified
+the six load-bearing points against the ACTUAL code (not the artifact's claims):
+(1) `_safeSend` reads `this.ws` once into `sock`, sends on `sock`, and reconnects only
+when `reconnectOnFailure && this.started && !this.reconnecting && this.ws === sock` —
+identity guard present, no resurrection; (2) ACK passes no reconnect, liveness passes
+`true`, `queueOutbound` enqueues on false, `_drainQueue` breaks + `pending.slice(k)`
+retains the unsent tail (remove-only, ≤ MAX), no reconnect from drain; (3) the not-OPEN
+precheck logs nothing, the catch never logs the payload; (4) `handleProcessLevelError`
+has zero static `SqliteRegistry` import, takes injected `onFatalCleanup`/`exit`, owns the
+full log/cleanup/exit sequence, and BOTH server.ts handlers delegate to it with one
+shared `onFatalCleanup`; (5) the allowlist entry is the anchored `'WebSocket is not open'`
+and a tree-wide grep confirms the live "...is not open for public registration" /
+"database connection is not open" strings do NOT contain it; (6) exactly one raw
+`sock.send(` exists (inside `_safeSend`), no shadow process handlers, no mutate-during-
+iterate. Concur with the review — clear to ship.
+
+---
+
+## Evidence pointers
+
+- Converged spec: `docs/specs/SLACK-SUBSYSTEM-ERROR-CONTAINMENT-SPEC.md`
+- Convergence report: `docs/specs/reports/slack-subsystem-error-containment-convergence.md`
+- ELI16 overview: `docs/specs/SLACK-SUBSYSTEM-ERROR-CONTAINMENT-SPEC.eli16.md`
+- Tests (added): `tests/unit/slack-safesend.test.ts`,
+  `tests/unit/process-level-error-handler.test.ts`,
+  `tests/integration/slack-adapter-boundary.test.ts`,
+  `tests/e2e/slack-containment-process-survival.test.ts`


### PR DESCRIPTION
## Robustness Net #1 — Slack subsystem error containment (CMT-1351)

A Slack WebSocket send on a not-OPEN socket throws **synchronously** inside un-awaited Slack event-listener callbacks. The escaping throw becomes an `uncaughtException` (sync path) or an `unhandledRejection` (the `'message'` listener calls the async `_handleRawMessage`) and could take the **whole process** down — the root cause of the 2026-06-14 outage. Nets #2 (in-process ~10s respawn) and #3 (launchd watchdog) already restart a dead process; this net stops a Slack error from crashing it in the first place.

**parent-principle:** *Structure beats Willpower* — contain failures at the subsystem boundary; never rely on every callsite remembering to guard a socket send (funnel + grep ratchet, not willpower).

### What changed

- **`_safeSend` funnel** — every WebSocket send in `SocketModeClient` now goes through one private `_safeSend(data, context, reconnectOnFailure = false)`: reads `this.ws` once into a local, sends only on an OPEN socket inside `try/catch`, returns a boolean, and (liveness path only) self-heals via `_forceReconnect`, **identity-guarded** (`this.ws === sock`) so it never tears down a freshly replaced socket. Per-callsite policy: `queueOutbound` **enqueues** on failure (closes the TOCTOU instead of dropping), the ACK send does **not** reconnect (a failed ack ≠ a dead socket; avoids an epoch-churn storm), the heartbeat probe reconnects, and `_drainQueue` **retains** unsent messages on a mid-drain failure (remove-only, ≤ MAX).
- **`unhandledRejection` handler** — added (server.ts had none; the async Slack path surfaces failures as rejections the existing handler never caught), sharing the **exact same** narrow, fail-toward-crash allowlist as `uncaughtException` via one extracted `handleProcessLevelError` (cleanup + exit are injected callbacks, so `uncaughtExceptionPolicy.ts` stays pure decision-logic and the two handlers cannot drift).
- **Anchored allowlist entry** — `'WebSocket is not open'` (the Node 22+ built-in message form; the existing `'Sent before connected'` was only the `ws`-polyfill form). Anchored, NOT the bare `'is not open'`, which collides with live `"<name> is not open for public registration"` / `"database connection is not open"` strings — a negative test pins this.

### Goal 2 (verify-and-test-only)

The synchronous boot boundary already exists (server.ts wraps the Slack init incl `await slackAdapter.start()` in try/catch → `slackAdapter = undefined` + degradation report, so `/health` keeps serving). No refactor; an integration test pins it.

## ELI16 — A Slack network hiccup can no longer crash the whole agent

The agent talks to Slack over an always-on network pipe (a WebSocket). If the code tried to push a message into that pipe at the exact moment it was closing or reconnecting, the send threw an error — and on 2026-06-14 that error wasn't caught and took the **entire agent** down for ~2 hours.

This change funnels every "send to Slack" through one careful helper that checks the pipe is open, wraps the send so an error can never escape, and quietly reconnects when the pipe itself is dead. It also adds a second process-level safety catch for the error category the real crash fell into (an unhandled promise rejection) — using the **exact same** tiny, audited list of "known-harmless" errors, so the agent still crashes-and-restarts on anything genuinely unknown (a crash now costs ~10 seconds; wrongly limping along on corrupted state could cost much more).

For users: nothing changes on a good day — no new button, no new setting, no behavior difference when Slack is healthy. You only benefit on a bad day, when a transient Slack glitch that used to take the whole agent down now stays contained to Slack and heals itself; your other chats, scheduled jobs, and memory keep running.

## Testing (all three tiers — green)

- **Unit:** `tests/unit/slack-safesend.test.ts` (every readyState; throw-swallow; reconnect only on the liveness path; storm guard; stale-socket identity guard; `queueOutbound` enqueue; `_drainQueue` break-and-retain; **wiring-integrity ratchet** asserting every raw socket send lives only inside `_safeSend`). `tests/unit/process-level-error-handler.test.ts` (both branches × both labels; anchored allowlist + negative tests that the registration / DB look-alikes do NOT match). Updated `slack-socket-reconnect`, `slack-socket-heartbeat`, `sqlite-close-on-exit`.
- **Integration:** `tests/integration/slack-adapter-boundary.test.ts` — a dial failure surfaces via `onError` without rejecting out of bootstrap; the boot boundary keeps `/health` serving.
- **E2E "feature is alive":** `tests/e2e/slack-containment-process-survival.test.ts` — spawns a real child process registering the real handlers via the built dist, emits a contained error (both `uncaughtException` and `unhandledRejection` forms) and asserts the process **stays alive**, then emits an unknown error and asserts it **still exits 1** (fail-toward-crash preserved).

## Process

- Spec converged through `/spec-converge` (3 rounds, 6 internal reviewers + real codex-gpt-5.5 + gemini-2.5-pro external passes → 0 material findings): `docs/specs/SLACK-SUBSYSTEM-ERROR-CONTAINMENT-SPEC.md` + report `docs/specs/reports/slack-subsystem-error-containment-convergence.md`. Side-effects review with independent second-pass concur: `upgrades/side-effects/slack-subsystem-error-containment.md`.
- **Approval:** applied under the operator's delegated authority — the decoupled instar-dev build brief (commitment CMT-1351) pre-authorized Net #1 and pre-resolved the Goal 3 direction; recorded in the convergence report and reported to the dev topic, not an interactive click.

## Tracked deferral

A serialized outbound socket-writer (single-writer transport) — the textbook way to eliminate socket-send TOCTOU by design — is recorded as **future hardening, tracked separately** (`tracked_deferrals` in the spec frontmatter; dev topic 13481). It addresses a *different, broader* concern (frame ordering / send interleaving), not the uncaught-throw incident class this PR closes; nothing in *this* class is left unaddressed.

## Migration parity / rollout

Pure `src/*.ts` + tests — reaches existing agents via the normal release/update path. No config flag, no `.claude`/template migration. Ships live (no happy-path behavior change); back-out is a revert + patch release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
