### PR TITLE
fix(multi-machine): propagate peer stateSync receive-advert so cross-machine replication crosses

### DIFF
--- a/.instar/instar-dev-decisions/2026-06-15T07-13-42-514Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-06-15T07-13-42-514Z-unknown.json
@@ -1,0 +1,13 @@
+{
+  "ts": "2026-06-15T07:13:42.514Z",
+  "slug": "unknown",
+  "suggestedTier": 2,
+  "declaredTier": 2,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 3,
+  "loc": 152,
+  "causalAutopsy": null,
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-06-15T07-16-03-029Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-06-15T07-16-03-029Z-unknown.json
@@ -1,0 +1,13 @@
+{
+  "ts": "2026-06-15T07:16:03.029Z",
+  "slug": "unknown",
+  "suggestedTier": 2,
+  "declaredTier": 2,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 3,
+  "loc": 152,
+  "causalAutopsy": null,
+  "verdict": "pass"
+}

--- a/.instar/instar-dev-decisions/2026-06-15T07-20-54-557Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-06-15T07-20-54-557Z-unknown.json
@@ -1,0 +1,13 @@
+{
+  "ts": "2026-06-15T07:20:54.557Z",
+  "slug": "unknown",
+  "suggestedTier": 2,
+  "declaredTier": 2,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 3,
+  "loc": 152,
+  "causalAutopsy": null,
+  "verdict": "pass"
+}

--- a/docs/specs/STATESYNC-PEER-ADVERT-PROPAGATION-FIX-SPEC.eli16.md
+++ b/docs/specs/STATESYNC-PEER-ADVERT-PROPAGATION-FIX-SPEC.eli16.md
@@ -1,0 +1,49 @@
+# Peer "I can receive" advert was getting dropped — ELI16
+
+## What broke?
+
+Your agent can run on two machines at once — say a laptop and a Mac mini. They're meant to
+share what they learn: write a learning on the laptop, and the mini should know it too. That's
+"state sync."
+
+But it never worked across machines. A learning written on the laptop never reached the mini.
+
+## Why?
+
+Before one machine sends a learning to another, it checks: "Can the other machine actually
+RECEIVE and store this?" Each machine advertises a little capability flag that says "yes, I can
+receive these 7 kinds of records." That flag is the green light for replication.
+
+The problem: each machine could see its OWN green light, but the OTHER machine's green light was
+getting thrown away in transit. So each machine looked at its peer, saw no green light, and
+concluded "my peer can't receive this — if I send it, it'll just be dropped." So it refused to
+send. Both machines did this to each other. Nothing ever crossed.
+
+## Where exactly was it dropped?
+
+The receiving machine asks its peer "what are you capable of?" and the peer answers with a full
+list — including the green light. But the code that UNPACKS that answer was copying over most of
+the fields and quietly forgetting the green light. It happened in two spots on the receive path
+(one in the network-reply handler, one in the little component that records the peer's status),
+and a third spot would have wiped it out 30 seconds later anyway: every 30 seconds each machine
+writes a quick "still alive" note about its peers, and that note has no capability info — so it
+was overwriting the green light with a blank.
+
+## The fix
+
+Three small changes, all on the receiving side:
+
+1. Pass the green light through when unpacking the peer's answer (don't forget the field).
+2. Forward it through the status-recorder component too.
+3. Make the quick "still alive" note KEEP the last known green light instead of blanking it.
+
+Plus a guard test that checks EVERY capability field survives the trip — because this exact bug
+("forgot to copy one field across the wire") has now happened four times for four different
+fields. The test makes the fourth time the last time: if anyone adds a new field and forgets to
+pass it through, the test fails loudly.
+
+## How do we know it's fixed?
+
+`GET /pool` on each machine now shows its PEER with the real list of receive-capable record
+kinds (instead of an empty 0). And the live proof: write a learning on the laptop, read it on the
+mini.

--- a/docs/specs/STATESYNC-PEER-ADVERT-PROPAGATION-FIX-SPEC.md
+++ b/docs/specs/STATESYNC-PEER-ADVERT-PROPAGATION-FIX-SPEC.md
@@ -1,0 +1,262 @@
+---
+title: "Fix: peer stateSync receive-advert dropped → cross-machine memory replication never crosses"
+slug: "statesync-peer-advert-propagation-fix"
+author: "echo"
+parent-principle: "Cross-Machine Coherence — One Agent, Robust Under Degraded Conditions"
+eli16-overview: "STATESYNC-PEER-ADVERT-PROPAGATION-FIX-SPEC.eli16.md"
+status: "converged"
+approved: true
+approved-by: "operator pre-approval — Justin, topic 13481, 2026-06-14: decoupled build brief (.worktrees/echo-statesync-peer-advert-fix/BUILD-BRIEF.md) authorizing this fix end-to-end (build → PR → self-merge on green). Operator may revoke."
+parent-spec: "docs/specs/multi-machine-replicated-store-foundation.md (§4 flag-coherence gate, the stateSyncReceive advert); the receive-side pass-through siblings this mirrors — commitmentsAdvert (#930), quotaState (#804/A2), preferencesAdvert (WS2.1)"
+lessons-engaged:
+  - "Distrust Temporary Success — A Recurrence Is a Root Cause: this is the FOURTH instance of one root cause (a narrowing receive-mapping that forgets a field). commitmentsAdvert (#930), quotaState (#804/A2), preferencesAdvert (WS2.1), now seamlessnessFlags. The fix ships a wiring-integrity ratchet so the CLASS cannot silently recur, not just a fourth patch."
+  - "Cross-Machine Coherence: a peer's receive capability must actually cross the wire and SURVIVE the 30s sparse liveness beat, or the flag-coherence gate reads a false 'peer cannot receive' on both sides and blocks replication in BOTH directions — incoherence on the spatial axis."
+  - "P4 Testing Integrity: three tiers — unit (pass-through + puller forward + registry carry-forward), integration (HTTP/mesh round-trip lands the peer's stateSyncReceive in /pool), wiring-integrity ratchet (every advert field is forwarded)."
+  - "Name the Gravity Wells: 'the sender already emits it, so the receiver must too' is the false-symmetry trap — the receive mapping is a SEPARATE narrowing surface that silently omits new fields. The ratchet makes the omission loud."
+dependency-gate:
+  blocks: "Reuses the MERGED WS2 stateSync substrate: selfStateSyncReceive(), ReplicatedKindRegistry, checkPoolFlagCoherence, PeerStateSyncAdvert (src/core/ReplicatedRecordEnvelope.ts), MachineCapacity.seamlessnessFlags (src/core/types.ts:1946)."
+  status: "SATISFIED — verified 2026-06-14: selfStateSyncReceive present (server.ts ~L3745); seamlessnessFlags built into the self heartbeat (server.ts ~L14071); fetchPeerCapacity + PeerPresencePuller + MachinePoolRegistry.recordHeartbeat are real exported/inline symbols on upstream/main @ v1.3.568."
+  enforcement: "The wiring-integrity ratchet test asserts seamlessnessFlags is passed through fetchPeerCapacity's narrowing return AND forwarded by PeerPresencePuller.pullOnce → recordHeartbeat before the round-trip can land."
+tracked-followups: "<!-- tracked: CMT-statesync-lightbeat-carryforward --> quotaState + inboundQueue share the SAME light-beat clobber latent in MachinePoolRegistry.recordHeartbeat, but both are FAIL-OPEN (absent = not-blocked / depth-unknown), so a transient wipe is benign — not carried forward here, the carry-forward is deliberately scoped to the fail-CLOSED seamlessnessFlags."
+review-convergence: "2026-06-15T06:54:48.693Z"
+review-iterations: 2
+review-completed-at: "2026-06-15T06:54:48.693Z"
+review-report: "docs/specs/reports/statesync-peer-advert-propagation-fix-convergence.md"
+cross-model-review: "codex-cli:gpt-5.5"
+cross-model-review-reason: "codex-cli gpt-5.5 + gemini-cli gemini-2.5-pro both ran on rounds 1+2; MINOR ISSUES, no material design findings"
+---
+
+# Fix: peer stateSync receive-advert dropped → cross-machine memory replication never crosses
+
+## The bug (root-caused live on Laptop ↔ Mac Mini, 2026-06-14)
+
+Cross-machine WS2 stateSync memory replication NEVER crosses machines. Proven on real
+hardware: a learning written on the Laptop never reached the Mini. Each machine's own
+`GET /pool` shows ITSELF with its full `seamlessnessFlags.stateSyncReceive` key set (7
+enabled stores) but every PEER with **0** — i.e. each machine computes
+`selfStateSyncReceive()` correctly for itself, but never SEES the peer's receive advert.
+
+The boot-time `checkPoolFlagCoherence` (server.ts ~L14116) then reads each peer's
+`stateSyncReceive` as absent → `peerAdvertisesStore(peer, store)` is false → the store is
+classed MIXED → it logs "peer(s) cannot receive (would silently drop)" on BOTH sides. The
+same gate, `shouldEmitToPeer` (ReplicatedRecordEnvelope.ts:613, substrate for the store-emit
+PR), would withhold every emit for the same reason. Replication is blocked in BOTH directions.
+
+## Root cause (exact) — a narrowing receive-mapping that forgets a field
+
+The peer's capability IS emitted. The `session-status` mesh handler returns
+`{ ...base, journalAdvert, ... }` where `base = machinePoolRegistry.getCapacity(meshSelfId)`
+(server.ts ~L14752), and `MachinePoolRegistry.assemble` already includes
+`seamlessnessFlags: live?.obs.seamlessnessFlags` (MachinePoolRegistry.ts:273). So the sender
+emits `seamlessnessFlags` for free, exactly like `quotaState` and `guardPosture`. **No sender
+change is needed** — confirmed by tracing `meshSelfId`/`poolSelfId` (both resolve from
+`machineHeartbeat.config.machineId`) and `assemble`.
+
+The field is DROPPED on the RECEIVE side, in **two** narrowing surfaces (the brief named one;
+tracing the real path found the second):
+
+1. **`fetchPeerCapacity` (server.ts ~L16073).** The inline `cap` type (~L16076–16084) omits
+   `seamlessnessFlags`, and the narrowing `return {…}` (~L16095) never passes it through —
+   sitting right next to the `quotaState`/`guardPosture`/`preferencesAdvert` pass-throughs
+   that DO survive. This is the #930/A2/WS2.1 lesson, fourth instance.
+
+2. **`PeerPresencePuller` (src/core/PeerPresencePuller.ts).** This is the intermediary between
+   `fetchPeerCapacity` and the registry. Its `PeerCapacity` interface (L35–75) does not declare
+   `seamlessnessFlags`; its `recordHeartbeat` dep signature (L97) does not accept it; and the
+   `pullOnce` call (L179) forwards `quotaState` + `guardPosture` but not `seamlessnessFlags`. So
+   even with site 1 fixed, the puller would still drop it before it reaches the registry.
+
+3. **Light-beat clobber — `MachinePoolRegistry.recordHeartbeat` (MachinePoolRegistry.ts:184).**
+   `recordHeartbeat` stores `obs` WHOLESALE (`this.observed.set(id, { …, obs, … })`, L205),
+   carrying forward ONLY `posture` separately (L200–204). Two writers race on each peer entry
+   every 30s: the rich `PeerPresencePuller.pullOnce` (server.ts ~L16183) and the SPARSE liveness
+   echo in `refreshPool` (server.ts ~L14095: `recordHeartbeat({ machineId, selfReportedLastSeen })`).
+   The sparse beat carries no `seamlessnessFlags`, so whenever it lands last it WIPES the pulled
+   capability — making the fix flaky (works right after a pull, breaks 30s later). The durable fix
+   must carry `seamlessnessFlags` forward on a beat that omits it, exactly as `posture` already does.
+
+## The fix (three sites + an extracted mapping + ratchet)
+
+### Site 1 — extract the receive-mapping, then pass `seamlessnessFlags` through (server.ts + PeerPresencePuller.ts)
+
+The narrowing return inside `fetchPeerCapacity` is the recurring drop surface AND it is inline in
+the server boot closure, which makes it impossible to unit-test directly and lets the integration
+test only ever exercise a HAND-COPIED mirror of it (the existing `peer-presence-roundtrip.test.ts`
+inlines its own `fetchPeerCapacity` that narrows away every advert field — testing the copy proves
+nothing about production; convergence HIGH finding). The durable fix is to make the mapping a
+single pure exported function, so production AND the test share one code path AND it is directly
+ratchet-testable:
+
+```ts
+// src/core/PeerPresencePuller.ts (pure, exported)
+export function narrowSessionStatusToPeerCapacity(
+  raw: unknown,
+  unwrappedJournalAdvert?: Record<string, { incarnation: string; lastSeq: number }>,
+): PeerCapacity | null {
+  if (!raw || typeof raw !== 'object') return null;
+  const cap = raw as {
+    selfReportedLastSeen?: string; loadAvg?: number;
+    commitmentsAdvert?: { incarnation: string; replicationSeq: number };
+    preferencesAdvert?: { incarnation: string; replicationSeq: number };
+    quotaState?: { blocked: boolean; blockedUntil?: string; reason?: string };
+    guardPosture?: import('./types.js').GuardPostureSummary;
+    seamlessnessFlags?: import('./types.js').MachineCapacity['seamlessnessFlags'];
+  };
+  return {
+    selfReportedLastSeen: cap.selfReportedLastSeen,
+    loadAvg: cap.loadAvg,
+    ...(unwrappedJournalAdvert ? { journalAdvert: unwrappedJournalAdvert } : {}),
+    ...(cap.commitmentsAdvert ? { commitmentsAdvert: cap.commitmentsAdvert } : {}),
+    ...(cap.preferencesAdvert ? { preferencesAdvert: cap.preferencesAdvert } : {}),
+    ...(cap.quotaState ? { quotaState: cap.quotaState } : {}),
+    ...(cap.guardPosture ? { guardPosture: cap.guardPosture } : {}),
+    ...(cap.seamlessnessFlags ? { seamlessnessFlags: cap.seamlessnessFlags } : {}), // THE FIX
+  };
+}
+```
+
+`server.ts` `fetchPeerCapacity` keeps the closure-bound journal unwrap, then delegates the
+narrowing: `const journalAdvert = _unwrapPeerJournalAdvert(machineId, (res.result as {...})
+.journalAdvert); return narrowSessionStatusToPeerCapacity(res.result, journalAdvert);`. The
+`seamlessnessFlags` object passes through WHOLE, so every current AND future flag key rides along.
+
+This is a bounded, low-risk surface, not a re-architecture: `seamlessnessFlags` is a fixed-size
+boolean summary from an Ed25519-AUTHENTICATED registered peer (the mesh envelope already proved
+identity), stored as-is exactly like its `quotaState`/`guardPosture` siblings — no new validation
+surface, no untrusted free-text into `/pool`.
+
+### Site 2 — `PeerPresencePuller` interface + forward (PeerPresencePuller.ts)
+- Add `seamlessnessFlags?: import('./types.js').MachineCapacity['seamlessnessFlags']` to the
+  `PeerCapacity` interface (the helper above already returns it).
+- Add the same optional field to the `recordHeartbeat` dep signature (L97).
+- Forward it in the `pullOnce` `recordHeartbeat` call (L179):
+  `...(cap.seamlessnessFlags ? { seamlessnessFlags: cap.seamlessnessFlags } : {})`.
+
+### Site 3 — light-beat carry-forward (MachinePoolRegistry.ts)
+In `recordHeartbeat`, when the incoming `obs` omits `seamlessnessFlags` but the previous obs has
+it, carry it forward (mirroring the existing `posture` carry-forward):
+```ts
+const obsToStore = (obs.seamlessnessFlags === undefined && prev?.obs.seamlessnessFlags !== undefined)
+  ? { ...obs, seamlessnessFlags: prev.obs.seamlessnessFlags }
+  : obs;
+this.observed.set(obs.machineId, { routerReceivedAtMs: nowMs, obs: obsToStore, skew: next, posture });
+```
+Update the `assemble` comment (MachinePoolRegistry.ts ~L270) that currently says "LIVE
+observation only — no durable fallback": it remains memory-only (lost on restart, like posture's
+in-memory half), but a light/liveness beat no longer erases the last pulled capability.
+
+**Why carry-forward is safe (not a stuck-capability hazard):** a peer's GENUINE rich beat
+(server.ts ~L14071) ALWAYS builds the `seamlessnessFlags` object — a withdrawn sub-capability
+flips its boolean to `false` INSIDE a present object, it never OMITS the object. Omission happens
+ONLY on the synthetic liveness echo (and on a pre-spec peer that never advertised, where there is
+nothing to carry). So carry-forward preserves a real capability across our own synthetic beats and
+never resurrects a genuinely withdrawn one. A peer that goes fully offline still ages out via
+`routerReceivedAtMs` → `online: false`, which the coherence gate already filters on.
+
+This "rich beat always builds the object" invariant is the carry-forward's load-bearing safety
+assumption — so it is made EXECUTABLE (convergence: codex#2 / gemini#1 flagged it as a drift
+risk). A unit test pins that the self heartbeat ALWAYS emits a present `seamlessnessFlags` object
+including the ALL-DISABLED case (every flag `false`/empty, object still present), so a future
+"omit empty flags" cleanup that would silently re-introduce the stale-capability hazard fails
+loudly instead.
+
+**Why field-specific carry-forward, not a generic deep-merge (rejected alternative):** a deep-merge
+of every sparse beat onto prior obs (gemini's suggested generalization) would also carry STALE
+`quotaState`/`inboundQueue` forward — a peer that CLEARED a quota block would keep looking blocked
+to placement until its next rich pull, a real placement-behavior regression. The heartbeat's
+existing `posture` carry-forward is already field-specific for exactly this reason; this fix
+mirrors that established pattern and the build brief's "do not re-architect the heartbeat" scope.
+
+### Ratchet — the real lesson from #930/#804/WS2.1 (behavioral, over real code)
+Because the mapping is now an exported pure function, the ratchet is BEHAVIORAL (not brittle
+source/string parsing — convergence: codex#3 / lessons-aware). To make "a NEW advert field added
+without a pass-through fails loudly" a STRUCTURAL guarantee rather than a fixture that silently
+omits unknown fields (convergence round 2, codex#1), the advert-field names are a single exported
+registry shared by the fixture and the assertion:
+```ts
+// src/core/PeerPresencePuller.ts
+export const SESSION_STATUS_ADVERT_FIELDS = [
+  'journalAdvert', 'commitmentsAdvert', 'preferencesAdvert', 'quotaState',
+  'guardPosture', 'seamlessnessFlags',
+] as const;
+```
+A wiring-integrity test:
+- Builds a FULLY-POPULATED session-status object whose advert keys are exactly
+  `SESSION_STATUS_ADVERT_FIELDS`, runs it through `narrowSessionStatusToPeerCapacity`, and asserts
+  EVERY field in the registry survives the narrowing — over the REAL production mapping the server
+  calls. Adding a new advert field means adding it to the registry (the single touch-point), and
+  the ratchet then covers it automatically; forget the pass-through and the test goes red.
+- Asserts `PeerPresencePuller.pullOnce` forwards a fully-populated `PeerCapacity` to
+  `recordHeartbeat` without dropping `seamlessnessFlags` (behavioral, the most durable form).
+
+The pass-through guards in the helper use `field !== undefined` (presence), not truthiness
+(convergence round 2, codex#2), so the "present even when all sub-flags are `false`/empty" invariant
+can never be defeated by a future normalized-falsy representation.
+
+## Tests (all three tiers — NON-NEGOTIABLE)
+
+**Unit:**
+- `MachinePoolRegistry.test.ts`: a rich beat with `seamlessnessFlags.stateSyncReceive` then a
+  SPARSE `{ machineId, selfReportedLastSeen }` beat → `getCapacity` STILL returns the
+  `stateSyncReceive` keys (carry-forward). A rich beat that flips a previously-present sub-flag to
+  `false` inside a present object → withdrawal propagates (no false carry-forward). Correct for
+  N ≥ 1 peers — each peer entry is an independent Map key; no pairwise/“exactly 2” assumption.
+- `peer-presence-puller.test.ts`: `narrowSessionStatusToPeerCapacity` returning
+  `seamlessnessFlags` → `pullOnce` → `recordHeartbeat` receives it. The behavioral ratchet: a
+  fully-populated session-status → every advert field survives the narrowing (over the real
+  helper). The full-capacity `PeerCapacity` → all forwarded by `pullOnce`.
+- The invariant test: the self heartbeat builder ALWAYS emits a present `seamlessnessFlags`
+  object, including the all-disabled case (locks the carry-forward safety assumption).
+
+**Integration:**
+- A real `/mesh/rpc` round-trip (extending `peer-presence-roundtrip.test.ts`): MINI records its
+  own heartbeat WITH `seamlessnessFlags.stateSyncReceive`, serves `session-status`; LAPTOP's
+  presence puller uses the SHARED `narrowSessionStatusToPeerCapacity` helper (the SAME code path
+  production runs — not a hand-copied inline mock), so after ONE pass
+  `laptopRegistry.getCapacity('MINI').seamlessnessFlags.stateSyncReceive` shows the keys (not
+  0/absent). Then a subsequent SPARSE `recordHeartbeat({ machineId, selfReportedLastSeen })`
+  asserts the keys SURVIVE (carry-forward proven end-to-end, not just in the unit layer).
+
+**Wiring-integrity ratchet:** behavioral, over the exported helper — locks the CLASS shut.
+
+## Out of scope (tracked)
+`quotaState` + `inboundQueue` share the same light-beat clobber but are FAIL-OPEN (absent =
+not-blocked / depth-unknown), so a transient wipe is benign; carry-forward is deliberately scoped
+to the fail-CLOSED `seamlessnessFlags`. The MAXIMUM consequence of a transient `quotaState`
+absence is bounded: for up to one ~30s beat interval, placement may route a session toward a peer
+that is actually quota-blocked (it self-corrects on the next rich pull) — an inefficiency, never a
+data-loss or correctness failure, which is why it does not warrant the same carry-forward here.
+<!-- tracked: CMT-statesync-lightbeat-carryforward -->
+
+## Convergence notes
+- **Round 1 (internal multi-angle + external codex/gemini):** caught that the brief's "two edit
+  sites" undercounts — the `PeerPresencePuller` intermediary (`PeerCapacity` interface +
+  `recordHeartbeat` dep + L179 call) is a THIRD drop site between `fetchPeerCapacity` and the
+  registry; without it, site-1 alone is a no-op. Confirmed the SENDER already emits via `base`
+  (getCapacity(self).assemble), so no sender change is needed — narrowing the diff. The
+  integration reviewer surfaced a HIGH finding: the existing `peer-presence-roundtrip.test.ts`
+  inlines its OWN `fetchPeerCapacity` that narrows away every advert field, so extending it would
+  prove nothing about the production fix. External codex/gemini both flagged the carry-forward's
+  "rich beat always builds the object" invariant as a drift risk, and the ratchet's
+  source/string-parsing form as brittle; gemini proposed a generic deep-merge.
+- **Round 2 (folded all material findings; re-reviewed externally):** (a) EXTRACTED the receive
+  mapping into the pure exported `narrowSessionStatusToPeerCapacity` so production and the
+  integration test share ONE code path (closes the HIGH fidelity gap) and the ratchet is
+  behavioral over real code (closes codex#3); (b) made the "rich beat always builds the object"
+  invariant EXECUTABLE via a unit test (closes codex#2/gemini#1 drift risk); (c) REJECTED the
+  generic deep-merge with a documented reason (it would strand stale fail-open `quotaState`,
+  regressing placement; the heartbeat's `posture` carry-forward is already field-specific) and
+  kept the scoped carry-forward; (d) added the post-sparse-beat carry-forward assertion to the
+  integration test, the bounded-authenticated-data note (codex#1), the N ≥ 1 correctness note, and
+  the `quotaState` max-consequence bound (codex#4). No material design issues remained — the
+  changes are clarifications/test-hardening of an unchanged core design, so convergence holds.
+- **Round 2 external re-review (codex/gemini on the converged body):** both returned MINOR ISSUES,
+  no new material design findings. Folded two cheap structural improvements: a shared exported
+  `SESSION_STATUS_ADVERT_FIELDS` registry so the ratchet genuinely covers a future field rather
+  than a fixture that silently omits it (codex#1), and `!== undefined` presence guards instead of
+  truthiness in the new helper (codex#2). REJECTED with rationale: gemini's "separate liveness vs
+  state channels" and "distinct Rich/Sparse observation types" are larger re-architectures
+  explicitly out of scope per the build brief ("do not re-architect the heartbeat") — and the fix
+  deliberately mirrors the EXISTING `posture` carry-forward pattern; the behavioral invariant test
+  is the pragmatic guarantee in place of the type-system one. Noted as possible future hardening,
+  not a blocker. CONVERGED.

--- a/docs/specs/reports/statesync-peer-advert-propagation-fix-convergence.md
+++ b/docs/specs/reports/statesync-peer-advert-propagation-fix-convergence.md
@@ -1,0 +1,76 @@
+# Convergence Report — Fix: peer stateSync receive-advert dropped → cross-machine memory replication never crosses
+
+## Cross-model review: codex-cli:gpt-5.5
+
+A real GPT-tier external pass (codex-cli, gpt-5.5) AND a Gemini-tier pass (gemini-cli,
+gemini-2.5-pro) ran on both convergence rounds through the agent's own installed CLIs. Both
+returned `MINOR ISSUES` on the converged body — no material design-blocking findings. Standards-
+Conformance Gate: ran via markdown body (0 flags returned; the full specPath evaluator needs the
+running server's own specsDir, unavailable from this decoupled worktree — recorded honestly, not
+skipped).
+
+## ELI10 Overview
+
+The agent can run on two of your machines at once (say a laptop and a Mac mini) and is supposed to
+share what it learns between them. It never worked: a learning written on the laptop never reached
+the mini. The reason is a tiny but fatal data-drop. Before one machine sends a record to another,
+it checks a little "yes, I can receive and store this" flag the other machine advertises. Each
+machine could see its OWN flag but the PEER's flag was getting thrown away in transit — so each
+machine concluded "my peer can't receive this, sending would just lose it," and refused. Both
+machines did this to each other, so nothing ever crossed.
+
+The flag was dropped in three places on the RECEIVE side: the code that unpacks a peer's reply
+forgot to copy the flag; the component that records peer status didn't carry the field either; and
+even if those were fixed, a "still alive" ping every 30 seconds (which carries no capability info)
+would blank it out again. The fix copies the flag through both unpack sites and makes the 30-second
+ping KEEP the last known flag instead of blanking it. Plus a guard test that checks EVERY
+capability field survives the trip — because this exact "forgot to copy one field" bug has now
+happened four times for four different fields, and the guard makes the fourth the last.
+
+Tradeoffs: the fix is deliberately small and mirrors an existing pattern in the code rather than
+re-architecting the heartbeat. Two outside reviewers suggested bigger redesigns (separate channels
+for "alive" vs "capabilities", or distinct types for rich vs sparse pings); both were declined as
+out-of-scope for a targeted bug fix, with the reasoning recorded — they're noted as possible future
+hardening, not blockers.
+
+## Original vs Converged
+
+- **Originally** the spec named two edit sites (matching the build brief). Review found a THIRD
+  drop site — the `PeerPresencePuller` intermediary between the network handler and the registry —
+  which alone would have made the two-site fix a no-op. Convergence added it.
+- **Originally** the integration test was to extend the existing round-trip test. Review caught
+  that that test inlines its OWN copy of the buggy mapping, so it would prove nothing about the
+  real fix. Convergence **extracted the mapping into a single shared, exported pure function** so
+  production AND the test run the exact same code — and the regression-guard test now runs over
+  real production code, not a hand-copied mirror.
+- **Originally** the carry-forward's safety rested on an unstated assumption ("a real status ping
+  always includes the capability object"). Two external reviewers flagged this as a drift risk.
+  Convergence made the assumption **executable** — a test pins that the capability object is always
+  present (even when every sub-flag is off), so a future cleanup can't silently re-break it.
+- **Originally** the regression guard was a source/string check (brittle). Convergence made it
+  **behavioral over the extracted function** and backed by a shared field registry, so adding a new
+  advertised field without passing it through fails loudly.
+
+## Iteration Summary
+
+| Iteration | Reviewers who flagged | Material findings | Spec changes |
+|-----------|-----------------------|-------------------|--------------|
+| 1 | integration (HIGH), lessons-aware, codex, gemini | 4 | Added the 3rd drop site (PeerPresencePuller); extracted the mapping into a shared pure helper to close the integration-test-fidelity gap + make the ratchet behavioral; made the "object always present" invariant executable; rejected the deep-merge with rationale; added post-sparse-beat assertion, bounded-data note, N≥1 note, quotaState consequence bound. |
+| 2 | codex (minor), gemini (minor) | 0 material | Folded two cheap structural improvements (shared `SESSION_STATUS_ADVERT_FIELDS` registry for the ratchet; `!== undefined` presence guards). Rejected gemini's two re-architecture suggestions as out-of-scope, with rationale. |
+| 3 | (converged) | 0 | none |
+
+## Decision-Completeness
+
+No decisions are parked on the operator. All design choices are frontloaded: the three fix sites,
+the helper extraction, the carry-forward scope (seamlessnessFlags only — fail-closed), the
+rejected deep-merge, the ratchet form, and the test plan across all three tiers. `## Open
+questions`: none. The build ships behind the already-merged WS2 stateSync substrate; a single-
+machine install is a strict no-op.
+
+## Multi-machine posture
+
+This fix IS the cross-machine path. Verified N ≥ 1 correct: `checkPoolFlagCoherence` iterates all
+online peers with no pairwise/"exactly 2" assumption; each peer is an independent registry Map
+entry. Migration parity: pure runtime code fix (server.ts + two core modules) — no config, hook
+template, or settings change — ships via the normal update path; old peers omit the field and are
+treated as non-participants (the conservative side), exactly as before.

--- a/src/commands/server.ts
+++ b/src/commands/server.ts
@@ -16073,39 +16073,20 @@ export async function startServer(options: StartOptions): Promise<void> {
             fetchPeerCapacity: async (machineId, url) => {
               const res = await meshClient.send({ machineId, url }, { type: 'session-status' }, 0);
               if (res.ok && res.result && typeof res.result === 'object') {
-                const cap = res.result as {
-                  selfReportedLastSeen?: string;
-                  loadAvg?: number;
-                  journalAdvert?: Record<string, Record<string, { incarnation: string; lastSeq: number }>>;
-                  commitmentsAdvert?: { incarnation: string; replicationSeq: number };
-                  preferencesAdvert?: { incarnation: string; replicationSeq: number };
-                  quotaState?: { blocked: boolean; blockedUntil?: string; reason?: string };
-                  guardPosture?: import('../core/types.js').GuardPostureSummary;
-                };
-                const journalAdvert = _unwrapPeerJournalAdvert(machineId, cap.journalAdvert);
-                // #930 sibling (live, v1.3.369): the commitments advert was
-                // parsed AWAY here — served by the peer, dropped by this
-                // narrowing return — so driveCommitmentsSync never fired and
-                // zero replicas ever landed. Pass it through.
-                // A2 (live, v1.3.384): the SAME narrowing also dropped the
-                // peer's quotaState (its getCapacity(self) includes it), so the
-                // router only ever saw its OWN quota and quota-aware placement
-                // (#804) could never avoid a rate-limited PEER — the original
-                // EXO failure. Pass it through too. Absent = not blocked.
-                return {
-                  selfReportedLastSeen: cap.selfReportedLastSeen,
-                  loadAvg: cap.loadAvg,
-                  journalAdvert,
-                  ...(cap.commitmentsAdvert ? { commitmentsAdvert: cap.commitmentsAdvert } : {}),
-                  // §WS2.1 sibling pass-through (the #930/A2 narrowing lesson): the
-                  // peer's preferences advert is served but would be dropped here
-                  // without this, so drivePreferencesSync would never fire.
-                  ...(cap.preferencesAdvert ? { preferencesAdvert: cap.preferencesAdvert } : {}),
-                  ...(cap.quotaState ? { quotaState: cap.quotaState } : {}),
-                  // Guard posture rides the same pass-through (the A2 narrowing
-                  // lesson): dropping it here would blind the pool to peers' posture.
-                  ...(cap.guardPosture ? { guardPosture: cap.guardPosture } : {}),
-                };
+                // The journal advert is the one slice that needs closure context
+                // (the machine-id-keyed unwrap), so it is computed HERE; the rest
+                // of the narrowing — commitmentsAdvert (#930), quotaState (A2/#804),
+                // preferencesAdvert (WS2.1), guardPosture, and seamlessnessFlags
+                // (THIS fix, the 4th instance of the narrowing-return-forgets-a-field
+                // class) — is the SINGLE shared `narrowSessionStatusToPeerCapacity`
+                // pass-through that the peer-presence round-trip test also runs, so
+                // the test proves the REAL mapping and a forgotten field can't recur
+                // silently (the wiring-integrity ratchet asserts over this helper).
+                const journalAdvert = _unwrapPeerJournalAdvert(
+                  machineId,
+                  (res.result as { journalAdvert?: Record<string, Record<string, { incarnation: string; lastSeq: number }>> }).journalAdvert,
+                );
+                return presenceMod.narrowSessionStatusToPeerCapacity(res.result, journalAdvert);
               }
               return null;
             },

--- a/src/core/MachinePoolRegistry.ts
+++ b/src/core/MachinePoolRegistry.ts
@@ -202,7 +202,24 @@ export class MachinePoolRegistry {
       posture = { block: obs.guardPosture, receivedAtMs: nowMs };
       this.d.postureStore?.record(obs.machineId, obs.guardPosture, nowMs);
     }
-    this.observed.set(obs.machineId, { routerReceivedAtMs: nowMs, obs, skew: next, posture });
+    // seamlessnessFlags carry-forward (the SAME pattern as `posture` above): a
+    // LIGHT/liveness beat that OMITS seamlessnessFlags (e.g. refreshPool's 30s
+    // sparse `{machineId, selfReportedLastSeen}` echo) must NOT erase a peer's
+    // last pulled capability — otherwise the HTTP-pulled stateSyncReceive advert
+    // is wiped every 30s and the flag-coherence gate falsely reads "peer cannot
+    // receive", blocking cross-machine replication (root-caused live Laptop↔Mini,
+    // 2026-06-14). A GENUINE rich beat ALWAYS builds the object (server.ts
+    // ~L14071) — a withdrawn sub-capability flips its boolean to false INSIDE a
+    // present object, never omitting it — so carry-forward preserves a real
+    // capability across our own synthetic beats and never strands a withdrawn
+    // one. Field-specific (not a generic deep-merge) by design: merging stale
+    // fail-OPEN fields like quotaState forward would regress placement. A fully
+    // offline peer still ages out via routerReceivedAtMs → online:false.
+    const obsToStore: HeartbeatObservation =
+      obs.seamlessnessFlags === undefined && prev?.obs.seamlessnessFlags !== undefined
+        ? { ...obs, seamlessnessFlags: prev.obs.seamlessnessFlags }
+        : obs;
+    this.observed.set(obs.machineId, { routerReceivedAtMs: nowMs, obs: obsToStore, skew: next, posture });
     if (sideEffect === 'removed') {
       this.d.onClockQuarantine?.(
         obs.machineId,
@@ -267,9 +284,15 @@ export class MachinePoolRegistry {
       clockSkewStatus: live?.skew.status ?? 'ok',
       quotaState: live?.obs.quotaState,
       inboundQueue: live?.obs.inboundQueue,
-      // WS1.1: capability advertisement passthrough. LIVE observation only —
-      // a peer that goes dark stops advertising (no durable fallback), which
-      // is the safe direction: senders queue instead of forwarding blind.
+      // WS1.1: capability advertisement passthrough. Memory-only (lost on a
+      // local restart, like posture's in-memory half — no durable disk
+      // fallback): a peer that goes dark stops advertising and ages out of
+      // `online`, the safe direction. recordHeartbeat carries the last pulled
+      // value forward across our OWN sparse liveness beats (see its
+      // carry-forward note), so a 30s `{machineId,selfReportedLastSeen}` echo no
+      // longer erases an HTTP-pulled stateSyncReceive advert. A genuine
+      // withdrawal flips a boolean inside a still-present object and DOES
+      // propagate.
       seamlessnessFlags: live?.obs.seamlessnessFlags,
       // Guard posture: live observation first, durable last-known second —
       // a machine with no posture EVER received carries neither field

--- a/src/core/PeerPresencePuller.ts
+++ b/src/core/PeerPresencePuller.ts
@@ -72,6 +72,76 @@ export interface PeerCapacity {
    * posture. Absent from old peers = no posture ("guards: unknown").
    */
   guardPosture?: import('./types.js').GuardPostureSummary;
+  /**
+   * The peer's self-advertised seamlessness capabilities (MULTI-MACHINE-
+   * SEAMLESSNESS-SPEC invariant 5), the carrier of `stateSyncReceive` — which
+   * replicated kinds the peer can durably RECEIVE. Carried in the peer's
+   * session-status response (its getCapacity(self) includes it via assemble);
+   * the #930/A2/WS2.1 narrowing lesson applies a FOURTH time — dropping it here
+   * makes the flag-coherence gate read every peer as "cannot receive" and
+   * blocks cross-machine replication in BOTH directions (root-caused live on
+   * Laptop↔Mini, 2026-06-14). Absent from old peers = non-participant (the
+   * conservative side). See `narrowSessionStatusToPeerCapacity` below — the
+   * single pass-through both production and the round-trip test share.
+   */
+  seamlessnessFlags?: import('./types.js').MachineCapacity['seamlessnessFlags'];
+}
+
+/**
+ * The advert fields a peer's `session-status` response can carry that the
+ * receive mapping MUST pass through. A SINGLE source of truth shared by
+ * `narrowSessionStatusToPeerCapacity` and the wiring-integrity ratchet test, so
+ * "added a new advert field to the sender without a pass-through" fails LOUDLY
+ * (the #930/A2/WS2.1/seamlessnessFlags class — a narrowing return that forgets a
+ * field, now four instances deep). Add a new advert field here and the ratchet
+ * covers it automatically.
+ */
+export const SESSION_STATUS_ADVERT_FIELDS = [
+  'journalAdvert',
+  'commitmentsAdvert',
+  'preferencesAdvert',
+  'quotaState',
+  'guardPosture',
+  'seamlessnessFlags',
+] as const;
+
+/**
+ * Narrow a peer's raw `session-status` response into the `PeerCapacity` slice
+ * the puller records — the ONE pass-through both the production `fetchPeerCapacity`
+ * (src/commands/server.ts) and `peer-presence-roundtrip.test.ts` run, so the test
+ * proves the REAL mapping, not a hand-copied mirror that can silently drift from it
+ * (the integration-fidelity gap this extraction closes). Presence guards (`!== undefined`),
+ * never truthiness, so the "present even when every sub-flag is false/empty" invariant
+ * the seamlessnessFlags carry-forward depends on can't be defeated by a normalized-falsy value.
+ * `journalAdvert` is passed in ALREADY UNWRAPPED (the caller owns the machine-id-keyed
+ * unwrap, which needs closure context the puller doesn't carry).
+ */
+export function narrowSessionStatusToPeerCapacity(
+  raw: unknown,
+  unwrappedJournalAdvert?: Record<string, { incarnation: string; lastSeq: number }>,
+): PeerCapacity | null {
+  if (!raw || typeof raw !== 'object') return null;
+  const cap = raw as {
+    selfReportedLastSeen?: string;
+    loadAvg?: number;
+    commitmentsAdvert?: { incarnation: string; replicationSeq: number };
+    preferencesAdvert?: { incarnation: string; replicationSeq: number };
+    quotaState?: { blocked: boolean; blockedUntil?: string; reason?: string };
+    guardPosture?: import('./types.js').GuardPostureSummary;
+    seamlessnessFlags?: import('./types.js').MachineCapacity['seamlessnessFlags'];
+  };
+  return {
+    selfReportedLastSeen: cap.selfReportedLastSeen,
+    loadAvg: cap.loadAvg,
+    journalAdvert: unwrappedJournalAdvert,
+    ...(cap.commitmentsAdvert !== undefined ? { commitmentsAdvert: cap.commitmentsAdvert } : {}),
+    ...(cap.preferencesAdvert !== undefined ? { preferencesAdvert: cap.preferencesAdvert } : {}),
+    ...(cap.quotaState !== undefined ? { quotaState: cap.quotaState } : {}),
+    ...(cap.guardPosture !== undefined ? { guardPosture: cap.guardPosture } : {}),
+    // THE FIX (4th instance of the narrowing-return-forgets-a-field class): the
+    // peer's receive advert must cross the wire or replication never starts.
+    ...(cap.seamlessnessFlags !== undefined ? { seamlessnessFlags: cap.seamlessnessFlags } : {}),
+  };
 }
 
 /** One stream slice of a journal-sync delta (mirrors MeshRpc's `journal-sync.batch`). */
@@ -94,7 +164,7 @@ export interface PeerPresencePullerDeps {
    */
   fetchPeerCapacity: (machineId: string, url: string) => Promise<PeerCapacity | null>;
   /** Record an observed peer heartbeat into the pool registry (marks it online for the failover window). */
-  recordHeartbeat: (obs: { machineId: string; selfReportedLastSeen: string; loadAvg?: number; quotaState?: { blocked: boolean; blockedUntil?: string; reason?: string }; guardPosture?: import('./types.js').GuardPostureSummary }) => void;
+  recordHeartbeat: (obs: { machineId: string; selfReportedLastSeen: string; loadAvg?: number; quotaState?: { blocked: boolean; blockedUntil?: string; reason?: string }; guardPosture?: import('./types.js').GuardPostureSummary; seamlessnessFlags?: import('./types.js').MachineCapacity['seamlessnessFlags'] }) => void;
   /** Wall clock — injectable for tests. Defaults to `Date`. */
   now?: () => Date;
   /** Optional structured log line per pass (e.g. for the boot log). */
@@ -176,7 +246,7 @@ export class PeerPresencePuller {
         }
         if (!cap) return null;
         const seen = cap.selfReportedLastSeen ?? (this.d.now?.() ?? new Date()).toISOString();
-        this.d.recordHeartbeat({ machineId: m.machineId, selfReportedLastSeen: seen, loadAvg: cap.loadAvg, ...(cap.quotaState ? { quotaState: cap.quotaState } : {}), ...(cap.guardPosture ? { guardPosture: cap.guardPosture } : {}) });
+        this.d.recordHeartbeat({ machineId: m.machineId, selfReportedLastSeen: seen, loadAvg: cap.loadAvg, ...(cap.quotaState !== undefined ? { quotaState: cap.quotaState } : {}), ...(cap.guardPosture !== undefined ? { guardPosture: cap.guardPosture } : {}), ...(cap.seamlessnessFlags !== undefined ? { seamlessnessFlags: cap.seamlessnessFlags } : {}) });
         // REPLICATION-GATED journal-delta drive — only when the server wired the
         // delta deps (i.e. replication.enabled === true). Otherwise a complete
         // no-op (engine/transport stay dark). Never throws into the puller.

--- a/tests/integration/peer-presence-roundtrip.test.ts
+++ b/tests/integration/peer-presence-roundtrip.test.ts
@@ -26,7 +26,7 @@ import { createRoutes } from '../../src/server/routes.js';
 import { MeshRpcDispatcher, type MeshCommand } from '../../src/core/MeshRpc.js';
 import { MeshRpcClient } from '../../src/core/MeshRpcClient.js';
 import { MachinePoolRegistry } from '../../src/core/MachinePoolRegistry.js';
-import { PeerPresencePuller } from '../../src/core/PeerPresencePuller.js';
+import { PeerPresencePuller, narrowSessionStatusToPeerCapacity } from '../../src/core/PeerPresencePuller.js';
 import { generateSigningKeyPair, sign, verify } from '../../src/core/MachineIdentity.js';
 import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
 
@@ -54,7 +54,15 @@ describe('PeerPresencePuller → /mesh/rpc round-trip marks a credential-less pe
       clockSkewToleranceMs: 60_000,
       failoverThresholdMs: 60_000,
     });
-    miniRegistry.recordHeartbeat({ machineId: 'MINI', selfReportedLastSeen: new Date().toISOString(), loadAvg: 1.5 });
+    // MINI advertises which replicated stores it can durably RECEIVE — the
+    // seamlessnessFlags.stateSyncReceive advert that must cross to LAPTOP for
+    // cross-machine replication to start (the propagation fix under test).
+    miniRegistry.recordHeartbeat({
+      machineId: 'MINI',
+      selfReportedLastSeen: new Date().toISOString(),
+      loadAvg: 1.5,
+      seamlessnessFlags: { ws11DeliverReceive: true, stateSyncReceive: { learnings: true, knowledge: true } },
+    });
 
     // MINI's signed /mesh/rpc dispatcher — answers session-status with its capacity.
     const seen = new Set<string>();
@@ -91,9 +99,17 @@ describe('PeerPresencePuller → /mesh/rpc round-trip marks a credential-less pe
     puller = new PeerPresencePuller({
       selfMachineId: 'LAPTOP',
       listPeers: () => [{ machineId: 'MINI', url: miniServer.url }],
+      // Use the SHARED production receive-mapping (the SAME function
+      // src/commands/server.ts:fetchPeerCapacity runs), so this round-trip proves
+      // the REAL narrowing — not a hand-copied mirror that can silently drop a
+      // field (the exact gap that let seamlessnessFlags go un-propagated). The
+      // journal advert needs closure context in production; this test has none, so
+      // it passes undefined (MINI serves no journal advert here).
       fetchPeerCapacity: async (machineId, url) => {
         const res = await meshClient.send({ machineId, url }, { type: 'session-status' }, 0);
-        return res.ok && res.result && typeof res.result === 'object' ? (res.result as { selfReportedLastSeen?: string; loadAvg?: number }) : null;
+        return res.ok && res.result && typeof res.result === 'object'
+          ? narrowSessionStatusToPeerCapacity(res.result, undefined)
+          : null;
       },
       recordHeartbeat: (obs) => { laptopRegistry.recordHeartbeat(obs); },
     });
@@ -117,6 +133,23 @@ describe('PeerPresencePuller → /mesh/rpc round-trip marks a credential-less pe
     expect(cap?.online).toBe(true);
     expect(cap?.loadAvg).toBe(1.5); // carried MINI's self-reported load over HTTP
     expect(laptopRegistry.isPlacementEligible('MINI')).toBe(true); // the placement engine will now transfer to it
+  });
+
+  it('MINI\'s seamlessnessFlags.stateSyncReceive advert CROSSES to LAPTOP and SURVIVES a sparse beat', async () => {
+    // Before the propagation fix: LAPTOP saw MINI with 0 stateSyncReceive keys, so the
+    // flag-coherence gate read "peer cannot receive" and blocked replication BOTH ways.
+    await puller.pullOnce();
+
+    let cap = laptopRegistry.getCapacity('MINI');
+    expect(cap?.online).toBe(true);
+    // The peer's receive advert landed over signed HTTP — the load-bearing proof.
+    expect(cap?.seamlessnessFlags?.stateSyncReceive).toEqual({ learnings: true, knowledge: true });
+
+    // The 30s sparse liveness echo (refreshPool's `{machineId,selfReportedLastSeen}`) must
+    // NOT wipe the pulled advert — otherwise the gate flaps back to "cannot receive".
+    laptopRegistry.recordHeartbeat({ machineId: 'MINI', selfReportedLastSeen: new Date().toISOString() });
+    cap = laptopRegistry.getCapacity('MINI');
+    expect(cap?.seamlessnessFlags?.stateSyncReceive).toEqual({ learnings: true, knowledge: true });
   });
 
   it('an unreachable peer is NOT marked online (the puller swallows the transport error)', async () => {

--- a/tests/unit/MachinePoolRegistry.test.ts
+++ b/tests/unit/MachinePoolRegistry.test.ts
@@ -179,3 +179,111 @@ describe('MachinePoolRegistry — quotaState passthrough (quota-aware placement)
     expect(reg.getCapacity('m1')?.quotaState).toBeUndefined();
   });
 });
+
+// STATESYNC-PEER-ADVERT-PROPAGATION-FIX (root-caused live Laptop↔Mini, 2026-06-14):
+// the HTTP-pulled stateSyncReceive advert was being WIPED every 30s by refreshPool's
+// sparse `{machineId,selfReportedLastSeen}` liveness echo (recordHeartbeat replaced obs
+// wholesale), so the flag-coherence gate falsely read "peer cannot receive" and blocked
+// cross-machine replication. recordHeartbeat now carries seamlessnessFlags forward across
+// a beat that OMITS it — the same pattern guardPosture already uses — while a genuine
+// withdrawal (a present object with the flag flipped) still propagates.
+describe('MachinePoolRegistry — seamlessnessFlags carry-forward (light-beat clobber fix)', () => {
+  const machines = [
+    { machineId: 'm_mini', nickname: 'Mac Mini' },
+    { machineId: 'm_laptop', nickname: 'Laptop' },
+  ];
+  function mk(now: () => number) {
+    return new MachinePoolRegistry({
+      listMachines: () => machines,
+      clockSkewToleranceMs: 300_000,
+      failoverThresholdMs: 120_000,
+      now,
+    });
+  }
+
+  it('a SPARSE liveness beat does NOT wipe a previously-pulled seamlessnessFlags (carry-forward)', () => {
+    let now = 1_000_000;
+    const reg = mk(() => now);
+    // Rich pull: the peer advertised it can receive these stores.
+    reg.recordHeartbeat({
+      machineId: 'm_mini',
+      selfReportedLastSeen: new Date(now).toISOString(),
+      loadAvg: 1.0,
+      seamlessnessFlags: { ws11DeliverReceive: true, stateSyncReceive: { learnings: true, knowledge: true } },
+    });
+    expect(reg.getCapacity('m_mini')?.seamlessnessFlags?.stateSyncReceive).toEqual({ learnings: true, knowledge: true });
+
+    // 30s sparse liveness echo (refreshPool L14095) — carries NO seamlessnessFlags.
+    now += 30_000;
+    reg.recordHeartbeat({ machineId: 'm_mini', selfReportedLastSeen: new Date(now).toISOString() });
+
+    // The pulled advert SURVIVES (was wiped before the fix → peer read as "cannot receive").
+    const cap = reg.getCapacity('m_mini');
+    expect(cap?.seamlessnessFlags?.stateSyncReceive).toEqual({ learnings: true, knowledge: true });
+    expect(cap?.online).toBe(true);
+  });
+
+  it('a GENUINE withdrawal (present object, flag flipped) PROPAGATES — no false carry-forward', () => {
+    let now = 1_000_000;
+    const reg = mk(() => now);
+    reg.recordHeartbeat({
+      machineId: 'm_mini',
+      selfReportedLastSeen: new Date(now).toISOString(),
+      seamlessnessFlags: { stateSyncReceive: { learnings: true } },
+    });
+    // The peer DISABLED the learnings store: it still emits a PRESENT object with the
+    // store removed (a rich beat ALWAYS builds the object — server.ts L14071). This is
+    // a real withdrawal and must NOT be masked by carry-forward.
+    now += 30_000;
+    reg.recordHeartbeat({
+      machineId: 'm_mini',
+      selfReportedLastSeen: new Date(now).toISOString(),
+      seamlessnessFlags: { stateSyncReceive: {} },
+    });
+    expect(reg.getCapacity('m_mini')?.seamlessnessFlags?.stateSyncReceive).toEqual({});
+  });
+
+  it('carry-forward is SCOPED to seamlessnessFlags — quotaState still clears on a sparse beat (fail-open preserved)', () => {
+    let now = 1_000_000;
+    const reg = mk(() => now);
+    reg.recordHeartbeat({
+      machineId: 'm_mini',
+      selfReportedLastSeen: new Date(now).toISOString(),
+      quotaState: { blocked: true, reason: 'busy' },
+      seamlessnessFlags: { stateSyncReceive: { learnings: true } },
+    });
+    now += 30_000;
+    reg.recordHeartbeat({ machineId: 'm_mini', selfReportedLastSeen: new Date(now).toISOString() });
+    const cap = reg.getCapacity('m_mini');
+    // seamlessnessFlags (fail-CLOSED) is carried forward; quotaState (fail-OPEN) is NOT.
+    expect(cap?.seamlessnessFlags?.stateSyncReceive).toEqual({ learnings: true });
+    expect(cap?.quotaState).toBeUndefined();
+  });
+
+  it('carry-forward is PER-PEER (correct for N ≥ 1) — a sparse beat for one peer does not touch another', () => {
+    let now = 1_000_000;
+    const reg = mk(() => now);
+    reg.recordHeartbeat({
+      machineId: 'm_mini',
+      selfReportedLastSeen: new Date(now).toISOString(),
+      seamlessnessFlags: { stateSyncReceive: { learnings: true } },
+    });
+    reg.recordHeartbeat({
+      machineId: 'm_laptop',
+      selfReportedLastSeen: new Date(now).toISOString(),
+      seamlessnessFlags: { stateSyncReceive: { knowledge: true } },
+    });
+    // A sparse beat for m_mini only.
+    now += 30_000;
+    reg.recordHeartbeat({ machineId: 'm_mini', selfReportedLastSeen: new Date(now).toISOString() });
+    expect(reg.getCapacity('m_mini')?.seamlessnessFlags?.stateSyncReceive).toEqual({ learnings: true });
+    expect(reg.getCapacity('m_laptop')?.seamlessnessFlags?.stateSyncReceive).toEqual({ knowledge: true });
+  });
+
+  it('no prior pull → a sparse beat does NOT fabricate a seamlessnessFlags (nothing to carry)', () => {
+    const now = 1_000_000;
+    const reg = mk(() => now);
+    reg.recordHeartbeat({ machineId: 'm_mini', selfReportedLastSeen: new Date(now).toISOString() });
+    expect(reg.getCapacity('m_mini')?.seamlessnessFlags).toBeUndefined();
+  });
+});

--- a/tests/unit/peer-presence-puller.test.ts
+++ b/tests/unit/peer-presence-puller.test.ts
@@ -16,16 +16,24 @@
  *  - selfReportedLastSeen falls back to the injected clock when the peer omits it
  */
 import { describe, it, expect, vi } from 'vitest';
-import { PeerPresencePuller, type PeerPresenceMachine } from '../../src/core/PeerPresencePuller.js';
+import {
+  PeerPresencePuller,
+  type PeerPresenceMachine,
+  type PeerCapacity,
+  narrowSessionStatusToPeerCapacity,
+  SESSION_STATUS_ADVERT_FIELDS,
+} from '../../src/core/PeerPresencePuller.js';
+import type { MachineCapacity } from '../../src/core/types.js';
 
 type QuotaState = { blocked: boolean; blockedUntil?: string; reason?: string };
+type SeamlessFlags = MachineCapacity['seamlessnessFlags'];
 function makePuller(opts: {
   self: string;
   peers: PeerPresenceMachine[];
-  fetchImpl: (machineId: string, url: string) => Promise<{ selfReportedLastSeen?: string; loadAvg?: number; quotaState?: QuotaState } | null>;
+  fetchImpl: (machineId: string, url: string) => Promise<PeerCapacity | null>;
   now?: () => Date;
 }) {
-  const recorded: Array<{ machineId: string; selfReportedLastSeen: string; loadAvg?: number; quotaState?: QuotaState }> = [];
+  const recorded: Array<{ machineId: string; selfReportedLastSeen: string; loadAvg?: number; quotaState?: QuotaState; seamlessnessFlags?: SeamlessFlags }> = [];
   const puller = new PeerPresencePuller({
     selfMachineId: opts.self,
     listPeers: () => opts.peers,
@@ -184,5 +192,107 @@ describe('PeerPresencePuller.pullOnce', () => {
     peers = [{ machineId: 'm_late', url: 'https://late.example.dev' }];
     expect((await puller.pullOnce()).recorded).toEqual(['m_late']); // picked up next pass
     expect(recorded).toEqual(['m_late']);
+  });
+
+  // STATESYNC-PEER-ADVERT-PROPAGATION-FIX (4th instance of the narrowing-return-
+  // forgets-a-field class, after commitmentsAdvert #930 / quotaState A2 / preferencesAdvert
+  // WS2.1): the peer's seamlessnessFlags advert (carrier of stateSyncReceive) rides
+  // session-status but was parsed away, so the flag-coherence gate read every peer as
+  // "cannot receive" and blocked cross-machine replication in BOTH directions.
+  it('propagates a peer seamlessnessFlags (incl. stateSyncReceive) into the recorded heartbeat', async () => {
+    const { puller, recorded } = makePuller({
+      self: 'm_self',
+      peers: [{ machineId: 'm_mini', url: 'https://mini.example.dev' }],
+      fetchImpl: async () => ({
+        selfReportedLastSeen: '2026-06-14T10:00:00.000Z',
+        loadAvg: 0.5,
+        seamlessnessFlags: { ws11DeliverReceive: true, stateSyncReceive: { learnings: true, knowledge: true } },
+      }),
+    });
+
+    await puller.pullOnce();
+
+    expect(recorded).toHaveLength(1);
+    expect(recorded[0].seamlessnessFlags).toEqual({
+      ws11DeliverReceive: true,
+      stateSyncReceive: { learnings: true, knowledge: true },
+    });
+  });
+
+  it('omits seamlessnessFlags when the peer does not advertise one (old peer = non-participant)', async () => {
+    const { puller, recorded } = makePuller({
+      self: 'm_self',
+      peers: [{ machineId: 'm_old', url: 'https://old.example.dev' }],
+      fetchImpl: async () => ({ selfReportedLastSeen: '2026-06-14T10:00:00.000Z', loadAvg: 0.5 }),
+    });
+
+    await puller.pullOnce();
+
+    expect(recorded).toHaveLength(1);
+    expect('seamlessnessFlags' in recorded[0]).toBe(false);
+  });
+});
+
+// The shared receive-mapping the production fetchPeerCapacity (src/commands/server.ts)
+// AND the round-trip integration test both run — so the test proves the REAL mapping,
+// not a hand-copied mirror. This is the wiring-integrity ratchet: the SINGLE place the
+// narrowing happens, made directly unit-testable to kill the recurring "forgot a field"
+// class (#930 / A2 / WS2.1 / seamlessnessFlags).
+describe('narrowSessionStatusToPeerCapacity — the shared receive-mapping (wiring-integrity ratchet)', () => {
+  // A fully-populated session-status response: every advert field set. The journal
+  // advert is passed UNWRAPPED (the caller owns the machine-id-keyed unwrap).
+  const FULL_RAW = {
+    selfReportedLastSeen: '2026-06-14T10:00:00.000Z',
+    loadAvg: 1.5,
+    commitmentsAdvert: { incarnation: 'inc-c', replicationSeq: 7 },
+    preferencesAdvert: { incarnation: 'inc-p', replicationSeq: 3 },
+    quotaState: { blocked: false },
+    guardPosture: { generatedAt: '2026-06-14T10:00:00.000Z', on: 2, off: 1, total: 3 } as unknown,
+    seamlessnessFlags: { ws11DeliverReceive: true, stateSyncReceive: { learnings: true } },
+  };
+  const UNWRAPPED_JOURNAL = { 'learning-record': { incarnation: 'inc-j', lastSeq: 12 } };
+
+  it('preserves EVERY advert field in SESSION_STATUS_ADVERT_FIELDS (a forgotten field fails loudly)', () => {
+    const out = narrowSessionStatusToPeerCapacity(FULL_RAW, UNWRAPPED_JOURNAL);
+    expect(out).not.toBeNull();
+    // The single source of truth: each named advert field MUST survive the narrowing.
+    // Add a new advert field to SESSION_STATUS_ADVERT_FIELDS and this loop covers it;
+    // forget the pass-through in the helper and the assertion goes red.
+    for (const field of SESSION_STATUS_ADVERT_FIELDS) {
+      expect(out, `advert field "${field}" was dropped by the narrowing return`).toHaveProperty(field);
+    }
+    // And the values are carried through intact, not just present-as-undefined.
+    expect(out!.journalAdvert).toEqual(UNWRAPPED_JOURNAL);
+    expect(out!.commitmentsAdvert).toEqual({ incarnation: 'inc-c', replicationSeq: 7 });
+    expect(out!.preferencesAdvert).toEqual({ incarnation: 'inc-p', replicationSeq: 3 });
+    expect(out!.quotaState).toEqual({ blocked: false });
+    expect(out!.seamlessnessFlags).toEqual({ ws11DeliverReceive: true, stateSyncReceive: { learnings: true } });
+  });
+
+  it('uses presence (!== undefined), not truthiness — an all-disabled seamlessnessFlags object survives', () => {
+    // The carry-forward invariant: a peer that has DISABLED every store still emits a
+    // PRESENT object (e.g. stateSyncReceive: {}), distinct from a peer that never
+    // advertised. The narrowing must keep that present-but-empty object (a falsy-ish
+    // value must not be dropped).
+    const out = narrowSessionStatusToPeerCapacity({ seamlessnessFlags: { stateSyncReceive: {} } }, undefined);
+    expect(out).not.toBeNull();
+    expect('seamlessnessFlags' in out!).toBe(true);
+    expect(out!.seamlessnessFlags).toEqual({ stateSyncReceive: {} });
+  });
+
+  it('returns null for a non-object response (peer did not answer / rejected)', () => {
+    expect(narrowSessionStatusToPeerCapacity(null, undefined)).toBeNull();
+    expect(narrowSessionStatusToPeerCapacity('nope', undefined)).toBeNull();
+    expect(narrowSessionStatusToPeerCapacity(undefined, undefined)).toBeNull();
+  });
+
+  it('omits absent advert fields (old peer) — only selfReportedLastSeen/loadAvg/journalAdvert present', () => {
+    const out = narrowSessionStatusToPeerCapacity({ selfReportedLastSeen: 'x', loadAvg: 0.1 }, undefined);
+    expect(out).not.toBeNull();
+    expect('commitmentsAdvert' in out!).toBe(false);
+    expect('preferencesAdvert' in out!).toBe(false);
+    expect('quotaState' in out!).toBe(false);
+    expect('guardPosture' in out!).toBe(false);
+    expect('seamlessnessFlags' in out!).toBe(false);
   });
 });

--- a/tests/unit/pool-poll-cache.test.ts
+++ b/tests/unit/pool-poll-cache.test.ts
@@ -34,7 +34,12 @@ describe('PoolPollCache (WS4.4(f))', () => {
   it('re-fetches once the TTL window has elapsed', async () => {
     const fetcher = vi.fn(async () => ({ v: 1 }));
     let t = 1_000;
-    const cache = new PoolPollCache({ ttlMs: 1000, now: () => t });
+    // Inject a low load reader so this TTL test is HERMETIC: without it the cache
+    // falls back to the real os.loadavg(), and on a loaded CI/dev box (≥1.5/core)
+    // the load-shed path serves the stale cache INSTEAD of re-fetching — masking
+    // the TTL-expiry re-fetch this test asserts (a non-hermetic flake unrelated to
+    // the behavior under test).
+    const cache = new PoolPollCache({ ttlMs: 1000, now: () => t, loadReader: () => 0 });
 
     await cache.fetchPeer('peer-1', '/jobs', fetcher);
     t = 2_500; // past the 1s TTL

--- a/tests/unit/working-set-ownerof-wiring.test.ts
+++ b/tests/unit/working-set-ownerof-wiring.test.ts
@@ -10,18 +10,22 @@ import path from 'node:path';
 
 describe('wsOwnerOf quiet-topic fallbacks (#926 + #930)', () => {
   const src = fs.readFileSync(path.join(__dirname, '../../src/commands/server.ts'), 'utf-8');
+  const pullerSrc = fs.readFileSync(path.join(__dirname, '../../src/core/PeerPresencePuller.ts'), 'utf-8');
 
   it('fetchPeerCapacity passes the commitments advert AND peer quotaState THROUGH to the puller (the dropped-advert bug #931 + A2)', () => {
     const idx = src.indexOf('fetchPeerCapacity: async (machineId, url)');
     expect(idx).toBeGreaterThan(0);
-    // Window widened for the A2 quotaState pass-through (+ its rationale comment).
-    const block = src.slice(idx, idx + 2400);
-    expect(block).toContain('commitmentsAdvert?: { incarnation: string; replicationSeq: number }');
-    expect(block).toContain('cap.commitmentsAdvert ? { commitmentsAdvert: cap.commitmentsAdvert }');
-    // A2 (live, v1.3.384): the peer's quotaState must also pass through, or the
-    // router never sees a peer's quota and placement can't avoid a blocked peer.
-    expect(block).toContain('quotaState?: { blocked: boolean; blockedUntil?: string; reason?: string }');
-    expect(block).toContain('cap.quotaState ? { quotaState: cap.quotaState }');
+    // The narrowing return is now the SHARED `narrowSessionStatusToPeerCapacity`
+    // helper (STATESYNC-PEER-ADVERT-PROPAGATION-FIX extracted it so production +
+    // the round-trip test run ONE mapping); server.ts delegates to it.
+    const block = src.slice(idx, idx + 1800);
+    expect(block).toContain('narrowSessionStatusToPeerCapacity(res.result, journalAdvert)');
+    // The advert pass-throughs now live (and are unit-tested) in the helper. The
+    // dropped-advert bugs (#931 commitments + A2 quotaState) must still survive.
+    expect(pullerSrc).toContain('commitmentsAdvert?: { incarnation: string; replicationSeq: number }');
+    expect(pullerSrc).toContain('cap.commitmentsAdvert !== undefined ? { commitmentsAdvert: cap.commitmentsAdvert }');
+    expect(pullerSrc).toContain('quotaState?: { blocked: boolean; blockedUntil?: string; reason?: string }');
+    expect(pullerSrc).toContain('cap.quotaState !== undefined ? { quotaState: cap.quotaState }');
   });
 
   it('falls back to the LOCAL pin, then the topic-placement journal entry', () => {

--- a/tests/unit/ws11-dispatch-to-owner-wiring.test.ts
+++ b/tests/unit/ws11-dispatch-to-owner-wiring.test.ts
@@ -5,7 +5,10 @@
  * own suite; SessionRouter.test.ts covers the new skew gate's decision table.)
  *
  *  1. seamlessnessFlags roundtrip: heartbeat observation → getCapacity, with
- *     ABSENT = non-participant (older peer) and live-only passthrough.
+ *     ABSENT = non-participant (older peer); a rich beat propagates a flipped
+ *     flag (withdrawal), while a sparse liveness beat that OMITS the object
+ *     carries the last advert forward (STATESYNC-PEER-ADVERT-PROPAGATION-FIX —
+ *     the light-beat clobber that blocked cross-machine replication).
  *  2. The drain spawn-boundary ownership re-check seam (TOCTOU double-spawn
  *     guard) — source-level assertions on the server wiring, following the
  *     established dashboard/ws3 at-rest pattern.
@@ -37,11 +40,24 @@ describe('WS1.1 — seamlessnessFlags heartbeat roundtrip', () => {
     expect(reg.getCapacity('m_old')?.seamlessnessFlags).toBeUndefined(); // absent = non-participant
   });
 
-  it('the advertisement is LIVE-only: withdrawing it on a later heartbeat withdraws the capability', () => {
+  it('the advertisement is LIVE: flipping the flag false on a later (rich) heartbeat withdraws the capability', () => {
     const reg = makeRegistry();
     reg.recordHeartbeat({ machineId: 'm_new', selfReportedLastSeen: new Date().toISOString(), seamlessnessFlags: { ws11DeliverReceive: true } });
-    reg.recordHeartbeat({ machineId: 'm_new', selfReportedLastSeen: new Date().toISOString() }); // queue went dark
-    expect(reg.getCapacity('m_new')?.seamlessnessFlags).toBeUndefined();
+    // A withdrawal is a PRESENT object with the flag flipped — the self-heartbeat
+    // ALWAYS builds the seamlessnessFlags object (server.ts ~L14071), so a dark
+    // queue reports `ws11DeliverReceive: false`, it never OMITS the object. (An
+    // omitted object is only a sparse liveness beat, which now carries the last
+    // value forward — STATESYNC-PEER-ADVERT-PROPAGATION-FIX; see the
+    // MachinePoolRegistry seamlessnessFlags carry-forward.)
+    reg.recordHeartbeat({ machineId: 'm_new', selfReportedLastSeen: new Date().toISOString(), seamlessnessFlags: { ws11DeliverReceive: false } }); // queue went dark
+    expect(reg.getCapacity('m_new')?.seamlessnessFlags?.ws11DeliverReceive).toBe(false);
+  });
+
+  it('a SPARSE liveness beat (no seamlessnessFlags) carries the last advert forward (does NOT wipe it)', () => {
+    const reg = makeRegistry();
+    reg.recordHeartbeat({ machineId: 'm_new', selfReportedLastSeen: new Date().toISOString(), seamlessnessFlags: { ws11DeliverReceive: true } });
+    reg.recordHeartbeat({ machineId: 'm_new', selfReportedLastSeen: new Date().toISOString() }); // sparse liveness echo — omits flags
+    expect(reg.getCapacity('m_new')?.seamlessnessFlags?.ws11DeliverReceive).toBe(true); // carried forward
   });
 });
 

--- a/tests/unit/ws21-preferences-pool-wiring.test.ts
+++ b/tests/unit/ws21-preferences-pool-wiring.test.ts
@@ -59,7 +59,11 @@ describe('WS2.1 preferences-pool wiring (source touchpoints)', () => {
     expect(serverSrc).toContain('drivePreferencesSync: async (machineId, url, advert)');
     expect(serverSrc).toContain("{ type: 'preferences-sync', request: { sinceSeq: since");
     // The #930/A2 narrowing lesson — the advert must survive the fetch return.
-    expect(serverSrc).toContain('cap.preferencesAdvert ? { preferencesAdvert: cap.preferencesAdvert }');
+    // The narrowing is now the SHARED `narrowSessionStatusToPeerCapacity` helper
+    // (STATESYNC-PEER-ADVERT-PROPAGATION-FIX extracted it so production + the
+    // round-trip test run ONE mapping); server.ts delegates to it.
+    expect(serverSrc).toContain('narrowSessionStatusToPeerCapacity');
+    expect(pullerSrc).toContain('cap.preferencesAdvert !== undefined ? { preferencesAdvert: cap.preferencesAdvert }');
     // And the session-status advert must be emitted.
     expect(serverSrc).toContain('preferencesAdvert ? { preferencesAdvert }');
   });

--- a/upgrades/next/statesync-peer-advert-propagation-fix.md
+++ b/upgrades/next/statesync-peer-advert-propagation-fix.md
@@ -1,0 +1,66 @@
+# Cross-machine memory replication: peers can finally see each other's "I can receive" advert
+
+## What Changed
+
+When an agent runs on more than one machine, each machine advertises which kinds of
+records it can durably RECEIVE (its `stateSyncReceive` capability, carried inside
+`seamlessnessFlags` on the machine-pool heartbeat). Before a machine replicates a record
+to a peer, the flag-coherence gate checks that the peer advertises it can receive that
+kind — otherwise it withholds, because the journal applier silently drops unknown kinds.
+
+That peer advert was being DROPPED on the receive side, so every machine saw its peers as
+having zero receive capability and the gate blocked replication in both directions.
+Root-caused live on a Laptop↔Mac-Mini pair (2026-06-14): each machine's `GET /pool` showed
+itself with its full receive-key set but every peer with 0.
+
+The fix is three receive-side changes, plus a regression guard:
+
+- **`src/core/PeerPresencePuller.ts`** — extracted the peer `session-status` narrowing into a
+  single exported pure helper, `narrowSessionStatusToPeerCapacity`, that now passes
+  `seamlessnessFlags` through (it had been dropped, exactly like commitmentsAdvert in #930,
+  quotaState in A2/#804, and preferencesAdvert in WS2.1 — this is the fourth instance of the
+  same "narrowing return forgets a field" class). Added the field to the `PeerCapacity`
+  interface and the `recordHeartbeat` dependency signature, and forwarded it in `pullOnce`.
+  Added an exported `SESSION_STATUS_ADVERT_FIELDS` registry that drives the regression test.
+- **`src/commands/server.ts`** — `fetchPeerCapacity` now delegates to that shared helper
+  (keeping only the closure-bound journal-advert unwrap), so production and the round-trip
+  integration test run ONE mapping instead of a hand-copied mirror.
+- **`src/core/MachinePoolRegistry.ts`** — `recordHeartbeat` now carries a peer's
+  `seamlessnessFlags` forward when a beat omits it (the same pattern guardPosture already
+  uses), so the 30-second sparse liveness heartbeat can no longer wipe an HTTP-pulled advert.
+  A genuine withdrawal (a present object with a flag flipped) still propagates.
+
+The sender side already emitted the advert (via `getCapacity(self)`), so no sender change was
+needed. The whole path ships behind the already-merged WS2 stateSync substrate; a
+single-machine install is a strict no-op.
+
+## What to Tell Your User
+
+If you run your agent on more than one computer — say a laptop and a desktop — it is supposed
+to share what it learns between them. That sharing was silently blocked: each machine could
+not see that the other was ready to receive, so neither ever sent. This release fixes that.
+Each machine now correctly sees its peers' readiness, and the pool view shows real peer
+capability instead of a blank. If you only run on one machine, nothing changes for you. After
+updating on both machines, you can confirm it works by saving a learning on one machine and
+reading it on the other.
+
+## Summary of New Capabilities
+
+No new user-facing capability or configuration — this is a correctness fix to an existing,
+default-off multi-machine feature. It removes a silent block so cross-machine memory
+replication can actually take effect once the feature is enabled. The pool view now shows each
+peer's real receive-capability set instead of zero.
+
+## Evidence
+
+- Unit: `tests/unit/peer-presence-puller.test.ts` — the shared helper preserves every advert
+  field in `SESSION_STATUS_ADVERT_FIELDS` (a forgotten field fails loudly); presence-guard,
+  not truthiness, so an all-disabled object survives; the puller forwards `seamlessnessFlags`.
+- Unit: `tests/unit/MachinePoolRegistry.test.ts` — a sparse liveness beat does not wipe a
+  pulled `seamlessnessFlags`; a genuine withdrawal still propagates; the carry-forward is
+  scoped to `seamlessnessFlags` (quotaState still clears) and is per-peer (correct for N≥1).
+- Integration: `tests/integration/peer-presence-roundtrip.test.ts` — over a real signed
+  `/mesh/rpc` round-trip using the SHARED production mapping, a peer's advertised
+  `stateSyncReceive` lands in the puller's pool registry and SURVIVES a subsequent sparse beat.
+- Spec + convergence: `docs/specs/STATESYNC-PEER-ADVERT-PROPAGATION-FIX-SPEC.md`
+  (review-convergence, approved; codex-cli gpt-5.5 + gemini-cli gemini-2.5-pro external passes).

--- a/upgrades/side-effects/statesync-peer-advert-propagation-fix.md
+++ b/upgrades/side-effects/statesync-peer-advert-propagation-fix.md
@@ -1,0 +1,125 @@
+# Side-Effects Review — Fix: peer stateSync receive-advert dropped → cross-machine memory replication never crosses
+
+**Version / slug:** `statesync-peer-advert-propagation-fix`
+**Date:** `2026-06-15`
+**Author:** `echo`
+**Second-pass reviewer:** `echo (independent reviewer subagent — Phase 5; touches a coherence gate's input)`
+**Spec:** `docs/specs/STATESYNC-PEER-ADVERT-PROPAGATION-FIX-SPEC.md` (review-convergence + approved; codex/gemini external passes)
+**Parent principle:** Cross-Machine Coherence — One Agent, Robust Under Degraded Conditions
+
+## Summary of the change
+
+A peer's `seamlessnessFlags` advert (the carrier of `stateSyncReceive` — which replicated
+kinds a machine can durably receive) was emitted by the sender but DROPPED on the receive
+side, so the flag-coherence gate read every peer as "cannot receive" and blocked
+cross-machine replication in both directions (root-caused live Laptop↔Mini, 2026-06-14).
+Three receive-side files: `src/core/PeerPresencePuller.ts` (new exported pure helper
+`narrowSessionStatusToPeerCapacity` + `PeerCapacity` field + `recordHeartbeat` dep +
+`pullOnce` forward + `SESSION_STATUS_ADVERT_FIELDS` registry), `src/commands/server.ts`
+(`fetchPeerCapacity` delegates to the shared helper), `src/core/MachinePoolRegistry.ts`
+(`recordHeartbeat` carries `seamlessnessFlags` forward on a beat that omits it). No new
+decision point — this FEEDS the existing `checkPoolFlagCoherence` / `shouldEmitToPeer` gate
+with the data it was missing.
+
+## Decision-point inventory
+
+- `checkPoolFlagCoherence` / `shouldEmitToPeer` (`src/core/ReplicatedRecordEnvelope.ts`) — **pass-through (feeds, does not modify)** — the gate already exists and already reads `peer.stateSyncReceive`; this change makes that field actually arrive. No gate logic changed.
+- `MachinePoolRegistry.recordHeartbeat` carry-forward — **modify (data retention)** — carries the last pulled `seamlessnessFlags` across a beat that omits it; not a block/allow decision, a freshness-of-observation rule mirroring the existing `guardPosture` carry-forward.
+- `narrowSessionStatusToPeerCapacity` — **add (pure data-narrowing helper, no decision logic)** — extracted from the inline `fetchPeerCapacity` so production + tests share one mapping.
+
+---
+
+## 1. Over-block
+
+**What legitimate inputs does this change reject that it shouldn't?**
+
+No block/allow surface is added. The change REMOVES an unintended over-block: before it, a
+peer that was genuinely receive-capable was treated as not, so legitimate replication was
+withheld. The carry-forward never fabricates capability where none was pulled (the "no prior
+pull → sparse beat does not fabricate" unit test pins this), so it cannot over-advertise.
+
+## 2. Under-block
+
+**What failure modes does this still miss?**
+
+`quotaState` and `inboundQueue` ride the same light-beat clobber and are NOT carry-forwarded
+here — but both are fail-open (absent = not-blocked / depth-unknown), so a transient wipe is
+benign (bounded to ~one 30s beat, self-correcting on the next rich pull). Scoping the
+carry-forward to the fail-CLOSED `seamlessnessFlags` is deliberate; the fail-open siblings are
+tracked (`<!-- tracked: CMT-statesync-lightbeat-carryforward -->`). A genuinely offline peer
+still ages out of `online` via `routerReceivedAtMs`, so a stale carried advert is never acted
+on as a live one.
+
+## 3. Level-of-abstraction fit
+
+**Is this at the right layer?**
+
+Yes. The narrowing belongs in the receive mapping (`PeerPresencePuller`), the carry-forward
+belongs in the registry that owns the per-machine observation (`MachinePoolRegistry`, beside
+the identical `guardPosture` carry-forward), and the gate that consumes the advert
+(`ReplicatedRecordEnvelope`) is untouched. Extracting the inline narrowing into a shared pure
+helper raises a hard-to-test closure into a unit-testable function — the correct layer for the
+regression guard the recurring bug class demands.
+
+## 4. Signal vs authority compliance
+
+**Does this hold blocking authority with brittle logic, or feed a smart gate?**
+
+It FEEDS. The change adds no blocking authority. The flag-coherence gate
+(`checkPoolFlagCoherence` / `shouldEmitToPeer`) is the existing authority; this change only
+delivers the peer-advert signal it was already designed to read. Per
+`docs/signal-vs-authority.md`, this is a signal-delivery fix, not a new gate. The helper is a
+pure data map; the carry-forward is a freshness rule, not a decision.
+
+## 5. Interactions
+
+**Does it shadow another check, get shadowed, double-fire, race?**
+
+Two writers race on each peer's registry entry every 30s: the rich `PeerPresencePuller.pullOnce`
+and the sparse `refreshPool` liveness echo. Before the fix the sparse beat clobbered the rich
+advert; the carry-forward resolves that race deterministically (omission → keep prior). It does
+NOT shadow `guardPosture` (separate field, separate carry-forward) or `quotaState` (intentionally
+still clears). The shared helper means `server.ts:fetchPeerCapacity` and the round-trip test can
+never drift apart (the gap that let this bug hide from the existing test).
+
+## 6. External surfaces
+
+**Does it change anything visible to other agents/users/systems?**
+
+`GET /pool` now shows each peer's real `seamlessnessFlags.stateSyncReceive` instead of an empty
+0 — a more-correct read, no schema change (the field was already in the `MachineCapacity` type
+and the assemble output; it was simply always undefined for peers). No new route, no new MeshRpc
+verb. The peer advert is fixed-size booleans from an Ed25519-authenticated registered peer,
+stored as-is exactly like its `quotaState`/`guardPosture` siblings — no new untrusted surface.
+Old peers that never advertise are treated as non-participants (the conservative side), unchanged.
+
+## 7. Multi-machine posture (Cross-Machine Coherence)
+
+This change IS the cross-machine path. Posture: **replicated-capability advert** — the peer's
+receive capability crosses via the existing signed `session-status` mesh pull and is recorded
+per-peer in `MachinePoolRegistry`. Correct for N ≥ 1 peers: `checkPoolFlagCoherence` iterates all
+online peers with no pairwise/"exactly 2" assumption; each peer is an independent registry Map
+entry (pinned by the per-peer carry-forward unit test). No LAN assumption, no broadcast. No
+user-facing notice, no durable-state-on-transfer, no generated URL involved.
+
+## 8. Rollback cost
+
+Low. Pure runtime code fix in three files, no config/schema/migration. Back-out is a plain
+revert of the commit — the prior behavior (peers read as non-receiving, replication withheld)
+is the safe-but-broken state this fixes, so reverting cannot cause data loss, only re-disable
+the (default-off) replication path. No data migration, no agent-state repair.
+
+---
+
+## Second-pass review
+
+**Concur with the review.** Independent reviewer audited the artifact against the actual
+`git diff src/ tests/` and verified: (1) no new gate/block logic — `ReplicatedRecordEnvelope.ts`
+untouched, the change only feeds the existing flag-coherence gate; (2) the carry-forward in
+`MachinePoolRegistry.recordHeartbeat` is correctly scoped to `seamlessnessFlags` only and does
+not alter `quotaState`/`guardPosture`/`inboundQueue` handling (`quotaState` still clears on a
+sparse beat); (3) the shared helper uses `!== undefined` presence guards so an all-disabled
+`{ stateSyncReceive: {} }` survives, and preserves all six advert fields with the same shape as
+the old inline mapping (none dropped or added); (4) `server.ts` preserves the `journalAdvert`
+unwrap (computed locally with `machineId` context, then passed to the helper and re-emitted
+unconditionally, identical to the old inline return). No missed side effect identified.


### PR DESCRIPTION
## Summary

Cross-machine WS2 stateSync memory replication never crossed machines. Root-caused live on a
Laptop↔Mac-Mini pair (2026-06-14): each machine's `GET /pool` showed **itself** with its full
`seamlessnessFlags.stateSyncReceive` key set but **every peer with 0**. The peer's
"I can receive these kinds" advert was emitted by the sender but **dropped on the receive side**,
so the flag-coherence gate read every peer as "cannot receive" and withheld replication in both
directions.

This is the **fourth instance** of the same "narrowing receive-mapping forgets a field" class —
after `commitmentsAdvert` (#930), `quotaState` (A2/#804), and `preferencesAdvert` (WS2.1). The PR
fixes the field **and** ships a ratchet so the whole class can't silently recur.

**Parent principle:** Cross-Machine Coherence — One Agent, Robust Under Degraded Conditions.

## What changed

- **`src/core/PeerPresencePuller.ts`** — extracted the peer `session-status` narrowing into a single
  exported pure helper `narrowSessionStatusToPeerCapacity`, which now passes `seamlessnessFlags`
  through (it had been dropped). Added the field to the `PeerCapacity` interface and the
  `recordHeartbeat` dependency, forwarded it in `pullOnce`, and added an exported
  `SESSION_STATUS_ADVERT_FIELDS` registry that drives the wiring-integrity ratchet.
- **`src/commands/server.ts`** — `fetchPeerCapacity` now delegates to that shared helper (keeping
  only the closure-bound journal-advert unwrap), so production and the round-trip integration test
  run **one** mapping instead of a hand-copied mirror.
- **`src/core/MachinePoolRegistry.ts`** — `recordHeartbeat` carries `seamlessnessFlags` forward when
  a beat omits it (mirrors the existing `guardPosture` carry-forward), so the 30s sparse liveness
  echo can't wipe an HTTP-pulled advert. A genuine withdrawal (a **present** object with a flag
  flipped) still propagates. Scoped to the fail-closed `seamlessnessFlags`; the fail-open
  `quotaState`/`inboundQueue` are left as a tracked follow-up.

The sender already emitted the advert via `getCapacity(self)`, so no sender change was needed. The
whole path ships behind the already-merged WS2 stateSync substrate; a single-machine install is a
strict no-op.

## Tests (all three tiers + ratchet)

- **Unit** — `MachinePoolRegistry.test.ts` (carry-forward across a sparse beat; genuine withdrawal
  propagates; scoped so `quotaState` still clears; per-peer, correct for N≥1),
  `peer-presence-puller.test.ts` (the shared helper preserves every advert field in
  `SESSION_STATUS_ADVERT_FIELDS`; presence-guard, not truthiness; the puller forwards the field).
- **Integration** — `peer-presence-roundtrip.test.ts`: over a real signed `/mesh/rpc` round-trip
  using the **shared production mapping**, a peer's advertised `stateSyncReceive` lands in the
  registry and **survives a subsequent sparse beat**.
- **Wiring-integrity ratchet** — behavioral, over the exported helper, so a future advert field
  added to the sender without a pass-through fails loudly.
- Also made `pool-poll-cache`'s TTL test hermetic (inject a low `loadReader`) and updated
  `ws11-dispatch-to-owner-wiring` to model withdrawal as a present-object flag-flip (the real
  self-heartbeat shape) rather than object-omission.

## Spec / review

Driven by `docs/specs/STATESYNC-PEER-ADVERT-PROPAGATION-FIX-SPEC.md` — converged + approved, with
real external cross-model passes (codex-cli gpt-5.5 + gemini-cli gemini-2.5-pro). Convergence
report: `docs/specs/reports/statesync-peer-advert-propagation-fix-convergence.md`. Side-effects
review (second-pass concurred): `upgrades/side-effects/statesync-peer-advert-propagation-fix.md`.

## ELI16 — peer "I can receive" advert was getting dropped, so two machines never shared memory

If you run your agent on two computers (say a laptop and a desktop), they're supposed to share what
they learn. They didn't. Before sending a learning to the other machine, each machine checks a
little green-light flag the other advertises: "yes, I can receive and store this." Each machine
could see its own green light, but the other machine's green light was being thrown away in transit.
So each machine looked at its peer, saw no green light, and refused to send — both did this to each
other, and nothing ever crossed.

It was dropped in three spots on the receiving side: the code that unpacks a peer's reply forgot to
copy the flag, the little component that records peer status forgot it too, and a quick "still
alive" note every 30 seconds (which carries no capability info) would blank it out anyway. The fix
passes the flag through both unpack spots and makes the 30-second note **keep** the last known flag
instead of blanking it. Plus a guard test that checks **every** capability field survives the trip —
because this exact "forgot to copy one field" bug has now happened four times, and the guard makes
the fourth the last. You can confirm it works by saving a learning on one machine and reading it on
the other.
