### PR TITLE
feat(multi-machine): wire WS2 send-side emission — memory records now cross machines (learnings E2E)

### DIFF
--- a/.instar/instar-dev-decisions/2026-06-15T09-08-29-072Z-ws2-send-side-emission.json
+++ b/.instar/instar-dev-decisions/2026-06-15T09-08-29-072Z-ws2-send-side-emission.json
@@ -1,0 +1,15 @@
+{
+  "ts": "2026-06-15T09:08:29.072Z",
+  "slug": "ws2-send-side-emission",
+  "suggestedTier": 2,
+  "declaredTier": 2,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "new capability: new exported class / subsystem added"
+  ],
+  "belowFloor": false,
+  "files": 6,
+  "loc": 885,
+  "causalAutopsy": null,
+  "verdict": "pass"
+}

--- a/.instar/instar-dev-decisions/2026-06-15T09-11-48-119Z-ws2-send-side-emission.json
+++ b/.instar/instar-dev-decisions/2026-06-15T09-11-48-119Z-ws2-send-side-emission.json
@@ -1,0 +1,15 @@
+{
+  "ts": "2026-06-15T09:11:48.119Z",
+  "slug": "ws2-send-side-emission",
+  "suggestedTier": 2,
+  "declaredTier": 2,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "new capability: new exported class / subsystem added"
+  ],
+  "belowFloor": false,
+  "files": 6,
+  "loc": 885,
+  "causalAutopsy": null,
+  "verdict": "pass"
+}

--- a/.instar/instar-dev-decisions/2026-06-15T09-12-34-865Z-ws2-send-side-emission.json
+++ b/.instar/instar-dev-decisions/2026-06-15T09-12-34-865Z-ws2-send-side-emission.json
@@ -1,0 +1,15 @@
+{
+  "ts": "2026-06-15T09:12:34.865Z",
+  "slug": "ws2-send-side-emission",
+  "suggestedTier": 2,
+  "declaredTier": 2,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "new capability: new exported class / subsystem added"
+  ],
+  "belowFloor": false,
+  "files": 6,
+  "loc": 893,
+  "causalAutopsy": null,
+  "verdict": "pass"
+}

--- a/docs/specs/WS2-SEND-SIDE-EMISSION-SPEC.eli16.md
+++ b/docs/specs/WS2-SEND-SIDE-EMISSION-SPEC.eli16.md
@@ -1,0 +1,53 @@
+# WS2 Send-Side Emission — ELI16
+
+## What is this?
+
+Your agent can run on more than one machine — say a laptop and a Mac mini. The goal of
+the multi-machine memory work is simple: a memory the agent forms on the laptop (a lesson
+it learned, a person it remembers) should also be known on the mini. An earlier fix made
+the two machines correctly *announce* to each other "yes, I can receive these memories."
+But when we actually tested it live, a lesson written on the laptop never showed up on the
+mini, even after waiting.
+
+## What was broken?
+
+Think of it like two offices that agreed to share their filing cabinets. The announcement
+fix was both offices saying "send me copies of your files." But it turned out the laptop
+was never actually *putting its files in the outbox*. Each part of the agent's memory
+(lessons, people, knowledge, users) already had a little "drop a copy in the outbox" button
+wired up — but the button wasn't connected to anything. The code literally said "we'll
+connect the real outbox later," and "later" never came. So every memory write pressed a
+button that did nothing, and the outbox stayed empty forever. Nothing to copy → nothing
+crosses.
+
+## What does this change do?
+
+It connects the outbox — and three smaller things needed for a copy to make it all the way
+across:
+
+1. **The outbox itself** — one small, shared piece that, whenever a memory is written,
+   stamps it with a precise timestamp and drops a copy into the cross-machine log.
+2. **The log accepts the new memory types** — the shared log knew about 5 older record
+   types but would reject the 7 memory types. Now it accepts them.
+3. **The receiving machine accepts them too** — same fix on the other end, so an incoming
+   memory isn't bounced.
+4. **Reading looks at the other machine's copies** — before, when the agent read its
+   memory it only ever looked at its own machine's drawer. Now it also looks at the copies
+   it received from peers.
+
+## How do we know it actually works this time?
+
+The most important test starts up TWO agents in one test (machine A and machine B), writes
+a lesson on A, ships it across exactly the way the real machines do, and then checks that B
+can read A's lesson. That's the live bug, reproduced in a test — so it can never silently
+break again. There's also a guard test that fails the build if someone ever adds a new
+memory type that can be received but not sent (the exact mistake that caused this).
+
+## Is it safe? Will it change anything for me right now?
+
+It's off by default — nothing replicates unless the multi-machine memory sync is explicitly
+turned on for that memory type. A memory copied from another machine is treated as a
+*hint*, never as the boss: it never silently overwrites what your machine already believes.
+If two machines disagree, the agent shows both versions and flags it for you, rather than
+picking a winner behind your back. This change makes the first memory type (lessons)
+actually cross between machines end-to-end; the rest follow on the same machinery.

--- a/docs/specs/WS2-SEND-SIDE-EMISSION-SPEC.md
+++ b/docs/specs/WS2-SEND-SIDE-EMISSION-SPEC.md
@@ -1,0 +1,239 @@
+---
+title: "WS2 Send-Side Emission — wire the journal-backed replicated-record emitter (close the receive-only gap)"
+slug: "ws2-send-side-emission"
+author: "echo"
+parent-principle: "Cross-Machine Coherence — One Agent, Robust Under Degraded Conditions"
+eli16-overview: "WS2-SEND-SIDE-EMISSION-SPEC.eli16.md"
+status: "converged"
+review-convergence: "2026-06-15T09:00:00.000Z"
+review-iterations: 1
+review-completed-at: "2026-06-15T09:00:00.000Z"
+approved: true
+approved-by: "operator pre-approval — Justin, topic 13481: multi-machine memory-replication headline; #1167 fixed the advert, this makes records cross. Decoupled build brief: .worktrees/echo-ws2-emission/BUILD-BRIEF.md"
+parent-spec: "docs/specs/multi-machine-replicated-store-foundation.md (the WS2 substrate — this implements the step-3 SEND consumer left unbuilt there); docs/specs/ws22-learnings-replication.md (the learnings kind this wires end-to-end)"
+lessons-engaged:
+  - "Structure > Willpower: emission is a journal-backed EMITTER attached at one wiring chokepoint, not a per-store willpower hook; the wiring-integrity ratchet makes a future receive-only kind a CI failure, not a memory item."
+  - "L15 Authorization: reach ≠ authority — a received peer record is read through the no-clobber union (append-both-and-flag for high-impact); a replicated record never clobbers a divergent local one. The emitter only emits THIS machine's own records (single-origin)."
+  - "P4 Testing Integrity: three tiers + the E2E two-instance round-trip (a learning written on A is readable on B) + the wiring-integrity ratchet (every registered kind that is send-enabled has an emit path)."
+  - "Distrust Temporary Success: the live gap shipped GREEN as substrate (registry + receive machinery + advert) with the SEND half a no-op stub — wiring-only/passing-unit-tests is not proof; only the cross-instance E2E is."
+  - "Phase C: design holds for N machines — single-origin emission, content-fingerprint recordKeys, per-store bounds independent of pool size."
+dependency-gate:
+  blocks: "Reuses the MERGED WS2 generic substrate (HLC, CoherenceJournal kinds, ReplicatedRecordEnvelope, JournalSyncApplier tail transport, StoreSnapshot engine, UnionReader, ReplicatedStoreReader, ConflictStore, RollbackUnmerge) AND #1167 (the receive-advert fix)."
+  status: "SATISFIED — verified 2026-06-15: all 7 *-record kinds present in CoherenceJournal.JOURNAL_KINDS and registered in replicatedKindRegistry (server.ts); #1167 merged @ 40f484a31 (v1.3.570)."
+  enforcement: "The wiring-integrity ratchet asserts every send-enabled registered kind has a constructed emitter; the dual-registry coupling test (pre-existing) asserts each kind in BOTH registries."
+cross-model-review: "internal multi-angle (the 5 adversarial lenses exercised in tests); external codex/gemini passes not run in the decoupled headless loop — the design is inherited from the already-converged foundation spec (this implements its step-3 consumer), and every decision below is grounded line-by-line in the merged substrate."
+tracked-next-work: "WS2-SEND-2 wires the remaining seamed stores (relationships, knowledge, userRegistry, evolutionActions) onto the SAME emitter table; WS2-SEND-3 adds the preferences manager emit seam (it currently has none) + topicOperator delete-emission; WS2-SEND-4 wires the snapshot-pull bootstrap caller (state-snapshot client + applySnapshotCutover) so a long-dark machine bootstraps without a from-genesis tail. Each is enumerated in src/core/ws2SendWiring.ts (the wiring-integrity ratchet)."
+---
+
+# WS2 Send-Side Emission
+
+## 1. The gap (root-caused LIVE on Laptop↔Mac-Mini, 2026-06-15)
+
+After #1167 the receive-advert is correct (each machine reports the peer's
+`stateSyncReceive` = 7). But a learning written on the Laptop never appears on the
+Mini. The Laptop's coherence-journal META lists only the 5 pre-existing lifecycle
+kinds — **none of the 7 WS2 `*-record` kinds**. WS2 records are never written to the
+journal own-streams, so a peer has nothing to pull.
+
+WS2 shipped as SUBSTRATE (kind registry + receive/apply machinery + advert) with the
+SEND half unimplemented. The precise stub: in `src/commands/server.ts` the
+`StoreSnapshotEngine` is constructed with `loadOwnEntries: () => ({})`, and — the
+deeper cause — the per-store managers ALREADY call an internal `emitPut`/`emitDelete`
+replication hook on every write (`EvolutionManager.saveLearnings`,
+`RelationshipManager.save`, `KnowledgeManager.ingest`, `UserManager.persistUsers`, …),
+but server.ts never constructs the concrete journal-backed emitter those hooks call —
+two sites explicitly defer it ("the journal-backed emitter is attached in a later
+rollout stage", server.ts:8483, 8532). The hooks fire into a `null` emitter (no-op),
+so nothing is ever appended to a `*-record` stream.
+
+## 2. What already exists (do NOT reinvent)
+
+- **The per-store emit call sites** — every memory manager already invokes
+  `emitter.emitPut(record)` / `emitter.emitDelete(...)` at its real write/delete
+  funnel, behind a `*ReplicationEmitter | null` seam (a setter or constructor arg).
+  The call sites are DONE; the emitter implementation and its injection are missing.
+- **The per-store record builders** — `buildLearningRecordData` /
+  `buildLearningTombstoneData` / `deriveLearningRecordKey` (LearningsReplicatedStore),
+  and the exact analogs for the other six stores. They produce the disclosure-minimized,
+  byte-capped, type-clamped envelope `data`. DONE.
+- **The generic envelope + validator** — `validateReplicatedEnvelope` +
+  `ReplicatedKindRegistry` (ReplicatedRecordEnvelope.ts). DONE.
+- **The journal tail transport** — `CoherenceJournal` (per-kind append-only streams,
+  own-advert over `JOURNAL_KINDS`), `JournalSyncApplier` (first-hop-bound receive →
+  `peers/<M>.<kind>.jsonl`, seq-contiguous, incarnation-fenced), and the
+  receiver-driven `PeerPresencePuller.driveJournalDelta` which ALREADY pulls EVERY
+  kind in a peer's advert (no kind allowlist) — so it will pull the new `*-record`
+  streams the instant they exist. DONE.
+- **The no-clobber read** — `UnionReader.readUnion` (HLC-max + last-writer-witness
+  concurrency detector → append-both-and-flag), `ReplicatedStoreReader` (the
+  bypass-proof funnel). DONE; its `loadOriginRecords` seam currently returns only the
+  OWN origin.
+
+## 3. The four generic gaps (what this PR builds)
+
+All four are KIND-AGNOSTIC — built once, they serve every registered replicated kind;
+the only per-store work is one small adapter that maps the manager's emit signature to
+the store's `build*RecordData` (a table row).
+
+### 3.1 The journal cannot append/validate a `*-record` kind
+`CoherenceJournal.validate()` is a hardcoded switch over the 5 lifecycle kinds; any
+`*-record` kind falls through to `return null` (schema-reject). And there is no public
+method to append a replicated record.
+
+**Fix.** Inject the `ReplicatedKindRegistry` into the journal (a setter, optional —
+absent ⇒ unchanged behavior). Add `emitReplicatedRecord(kind, data)`: a public,
+non-blocking emit that (a) requires a registered replicated kind, (b) validates via
+`validateReplicatedEnvelope(data, schema, counters)`, (c) derives the op-key from
+`recordKey + ':' + serializeHlcKey(hlc)` (idempotent on the exact logical event — a
+retry of the same put/delete dedupes; a new HLC is a new event), and (d) enqueues like
+any other emit. `validate()` gains ONE branch: a registered replicated kind delegates
+to `validateReplicatedEnvelope`; everything else is unchanged. The per-entry byte cap
+becomes per-kind (`*-record` → 64 KB, the `LEARNING_MAX_ENTRY_BYTES` class; lifecycle
+kinds → the unchanged 8 KB) so a fat-but-legal learning is not dropped as oversize.
+
+### 3.2 The applier rejects a `*-record` kind on receive
+`JournalSyncApplier.validateData()` mirrors the same hardcoded switch → a peer's
+`learning-record` entry is marked `invalid`, suspect-flags the stream, stops the batch.
+
+**Fix.** Inject the SAME registry (optional). `validateData(kind, data)` delegates a
+registered replicated kind to `validateReplicatedEnvelope`; the per-entry size cap is
+per-kind (matching §3.1). Everything else (first-hop binding, seq-contiguity,
+incarnation fencing, durable-before-ack) is unchanged — the record kinds ride the
+existing tail transport verbatim.
+
+### 3.3 The union read sees only the OWN origin
+`ReplicatedStoreReader.loadOriginRecords` returns one OWN record; a peer's replica in
+`peers/<M>.<kind>.jsonl` is never materialized, so even a correctly-received record is
+invisible to a read.
+
+**Fix.** A new pure-ish reader, `ReplicatedPeerStreamReader`, materializes the union's
+per-origin records from the journal streams on disk: it reads the OWN stream
+(`<self>.<kind>.jsonl` + archives) AND every peer stream (`peers/<M>.<kind>.jsonl` +
+archives), validates each line via `validateReplicatedEnvelope` + the store schema,
+and folds to the LATEST record per `(origin, recordKey)` by HLC-max (a delete is a
+tombstone, kept). It exposes `loadOriginRecords(store, recordKey)` and
+`listRecordKeys(store)` — exactly the `ReplicatedStoreReader` seams. The own origin is
+now journal-sourced (its authoritative emit-time HLC), so own + peer share one merge
+order. A `learnings` union reader is wired through this for the slice.
+
+### 3.4 `loadOwnEntries` is a no-op stub
+The snapshot-serve path returns no entries, so a recovering peer that pulls a snapshot
+gets nothing (it still falls back to the from-genesis tail — correctness-safe, just not
+the bootstrap optimization).
+
+**Fix.** Replace the stub with a loader that reads the OWN journal streams for every
+registered kind that maps to the requested store, returning `entriesByKind`. This makes
+`serveSnapshot` return real entries. (The snapshot-PULL caller — `applySnapshotCutover`
+— remains tracked as WS2-SEND-4 <!-- tracked: WS2-SEND-4 -->; the ongoing tail already
+replicates without it.)
+
+## 4. The emitter (the new load-bearing piece)
+
+`src/core/ReplicatedRecordEmitter.ts` — a generic, store-agnostic, journal-backed
+emitter. Seams (DI'd, unit-testable): the journal's `emitReplicatedRecord`, a
+`HybridLogicalClock`, the resolved `StateSyncStores` flags, this machine's `origin`
+id, and `loadWitness(store, recordKey) => HlcTimestamp | undefined`.
+
+On `put(store, recordKey, buildData)` / `delete(store, recordKey, buildTombstone)`:
+1. **Dark gate** — `isStoreEmissionEnabled(stores, store)` false ⇒ strict no-op (the
+   default; a single-machine or fleet agent emits nothing).
+2. **Degenerate guard** — a null `recordKey` (no stable identity surface) ⇒ skip.
+3. **Witness (the `observed` field, §7.2 of the foundation)** —
+   `observed = loadWitness(store, recordKey)` = the MAX HLC over every origin record
+   THIS machine currently holds on disk for that key (own prior + applied peers). This
+   is SOUND by construction: it claims "sequential-after" only a version provably on
+   disk; a not-yet-pulled peer version is simply absent ⇒ the pair flags concurrent
+   (err-toward-flag, never a silent clobber). Absent (first write) ⇒ omitted.
+4. **Tick** — `hlc = clock.tick()`. HLC monotonicity guarantees `hlc > observed`, so a
+   reader sees this write as the later one in a clean sequential chain.
+5. **Build + append** — `buildData(hlc, origin, observed)` (the store's
+   `build*RecordData`); on null skip; else `journal.emitReplicatedRecord(kind, data)`.
+
+Per-store glue (server.ts) is one adapter object per manager, e.g.:
+```
+evolution.setLearningReplicationEmitter({
+  emitPut: (rec) => emitter.put('learnings',
+     deriveLearningRecordKey(rec.title, rec.category, rec.source),
+     (hlc, origin, observed) => buildLearningRecordData({ record: rec, hlc, origin, observed })),
+  emitDelete: (title, category, source, deletedAt) => emitter.delete('learnings',
+     deriveLearningRecordKey(title, category, source),
+     (hlc, origin, observed) => buildLearningTombstoneData({ title, category, source, hlc, origin, deletedAt, observed })),
+});
+```
+The emitter never throws into the manager (the manager's hooks are already try/wrapped);
+a disabled store, a degenerate key, or a build-rejection is a counted no-op.
+
+## 5. Decisions resolved (the brief's convergence questions)
+
+- **emit-on-write vs periodic-scan → emit-on-write.** The manager call sites already
+  exist and fire at the exact mutation funnel; a scan would duplicate the prune/upsert
+  logic and lag. Coalescing of churn is the journal's per-kind rate cap, not a scan.
+- **per-kind sync driver vs generic engine → generic.** `PeerPresencePuller.
+  driveJournalDelta` already pulls every advertised kind, and `JournalSyncApplier`
+  already applies any kind it can validate. Once §3.1–3.3 land, the existing tail
+  transport replicates all 7 kinds with NO per-kind driver. `drivePreferencesSync`
+  (the deprecated `preferences-sync` verb) is NOT extended — it is superseded by this
+  foundation path.
+- **ordering / incarnation → orthogonal.** Merge order is the record-level HLC (in
+  `data`); stream fencing is the journal incarnation (in meta). An incarnation flip
+  re-mints the stream but never resets HLC order (HLC is monotone across incarnations).
+- **idempotency on recordKey → op-key = `recordKey:serializeHlcKey(hlc)`.** A retry of
+  the identical logical event dedupes (the journal's restart-proof op-key index); a new
+  HLC is a distinct event. On receive, seq-contiguity + the HLC-identity dedup net make
+  re-apply idempotent.
+
+## 6. Scope — the vertical slice (brief's SCOPE HONESTY clause)
+
+This PR ships the COMPLETE generic machinery (§3, §4) and wires **learnings**
+end-to-end with a passing two-instance E2E (a learning written on instance A is
+readable on instance B). The other seamed stores (relationships, knowledge,
+userRegistry, evolutionActions) are table rows on the SAME emitter and are wired in
+WS2-SEND-2; preferences (no manager emit seam yet) + topicOperator (put-only) are
+WS2-SEND-3. The wiring-integrity ratchet (§7) enumerates exactly which registered kinds
+are send-wired vs send-pending, so a future kind cannot be silently added receive-only
+again (the exact gap this fixes). Everything ships DARK behind
+`multiMachine.stateSync.<store>.enabled` (default false; dev-agent gate live).
+
+## 7. Test plan (three tiers + named invariants — NON-NEGOTIABLE)
+
+- **Unit** (`tests/unit/ReplicatedRecordEmitter.test.ts`,
+  `tests/unit/CoherenceJournal-record-emit.test.ts`,
+  `tests/unit/ReplicatedPeerStreamReader.test.ts`):
+  - emitter is a strict no-op when the store is disabled; emits the built record when
+    enabled; omits `observed` on first write and supplies the prior HLC on a sequential
+    re-write; skips a degenerate (null) recordKey.
+  - `CoherenceJournal.emitReplicatedRecord` appends a `learning-record` line (validated,
+    op-key deduped, 64 KB cap honored) and rejects an unregistered kind / a malformed
+    envelope.
+  - `ReplicatedPeerStreamReader` materializes own + peer streams to per-origin
+    `OriginRecord`s, folds by HLC-max, keeps a tombstone, and lists record keys.
+  - `loadOwnEntries` returns the own entries for a registered kind.
+- **Integration** (`tests/integration/ws2-send-journal-roundtrip.test.ts`): a real
+  `CoherenceJournal` + `JournalSyncApplier` — emit a learning on the writer →
+  `buildServeBatch('learning-record', …)` returns it → `applier.apply(sender, batch)`
+  durably writes the peer replica → `ReplicatedPeerStreamReader` on the receiver reads
+  it back. Also: `StoreSnapshotEngine.serveSnapshot('learnings')` returns real entries.
+- **E2E (the real proof)** (`tests/e2e/ws2-learnings-cross-instance.test.ts`): two
+  in-process instances A and B with separate stateDirs. A's `EvolutionManager.addLearning`
+  (emission enabled) → A's journal stream has the record → transfer A's own stream to B
+  via the buildServeBatch→apply path (mirroring journal-sync-roundtrip) → B's `learnings`
+  union read returns A's learning as a foreign origin record. This reproduces and closes
+  the live gap.
+- **Wiring-integrity ratchet** (`tests/integration/ws2-send-wiring.test.ts`): for every
+  store registered in `replicatedKindRegistry`, assert it is either in the
+  send-WIRED set (has a constructed emitter adapter) or the explicit send-PENDING
+  allowlist — and assert `learnings` is WIRED. A new kind added with neither fails CI.
+
+## 8. Safety, rollout, migration & awareness
+
+- **Dark by default.** Emission is gated on `multiMachine.stateSync.<store>.enabled`
+  (default false; the dev-agent gate flips it live on a dev agent only). No gate blocks
+  a user action; the only refusals are at the receive door (validator) and the emit door
+  (dark store) — both protect data.
+- **Migration parity.** No new agent-installed files; the feature is server-internal and
+  activates on the next restart of an agent whose stateSync stores are enabled. The
+  CLAUDE.md template already documents stateSync; no template change required for the
+  dark slice (awareness lands when a kind is flipped on for the fleet).
+- **Bounds.** Per-kind retention + rate caps already exist in the journal's
+  `DEFAULT_RETENTION`; the 64 KB per-entry cap for `*-record` kinds matches the store
+  builders' `assertProjectionUnderCap`.

--- a/src/commands/server.ts
+++ b/src/commands/server.ts
@@ -3700,6 +3700,67 @@ export async function startServer(options: StartOptions): Promise<void> {
     const { TOPIC_OPERATOR_KIND_REGISTRATION } = await import('../core/TopicOperatorReplicatedStore.js');
     replicatedKindRegistry.register(TOPIC_OPERATOR_KIND_REGISTRATION);
 
+    // ── WS2 SEND-SIDE wiring (docs/specs/WS2-SEND-SIDE-EMISSION-SPEC.md). The
+    //    substrate above ships the registry + receive/serve machinery + advert; THIS
+    //    wires the SEND half that was deferred ("the journal-backed emitter is attached
+    //    in a later rollout stage"). Three pieces, all KIND-AGNOSTIC: (1) inject the
+    //    now-populated registry into the journal writer + the applier so a registered
+    //    `*-record` kind validates/accepts on BOTH ends (without it a peer's record
+    //    suspect-flags the stream — the receive-only gap); (2) the peer-stream reader
+    //    that materializes own + peer journal streams into the union's per-origin
+    //    records (makes a received record READABLE) + the snapshot loadOwnEntries
+    //    source + the emitter's `observed`-witness source; (3) the author-side HLC
+    //    clock. All require the coherence journal (the emit sink + the streams to read);
+    //    when it is dark these stay undefined and every consumer degrades to its
+    //    existing single-machine no-op. The generic record emitter is constructed below
+    //    (it also needs the resolved stateSync flags).
+    let replicatedPeerStreamReader: import('../core/ReplicatedPeerStreamReader.js').ReplicatedPeerStreamReader | undefined;
+    let replicatedRecordEmitter: import('../core/ReplicatedRecordEmitter.js').ReplicatedRecordEmitter | undefined;
+    let replicatedHlcClock: import('../core/HybridLogicalClock.js').HybridLogicalClock | undefined;
+    if (coherenceJournal && cjOwnMachineId) {
+      try {
+        coherenceJournal.setReplicatedKindRegistry(replicatedKindRegistry);
+        journalSyncApplier?.setReplicatedKindRegistry(replicatedKindRegistry);
+
+        const { ReplicatedPeerStreamReader } = await import('../core/ReplicatedPeerStreamReader.js');
+        replicatedPeerStreamReader = new ReplicatedPeerStreamReader({
+          stateDir: config.stateDir,
+          registry: replicatedKindRegistry,
+          selfMachineId: cjOwnMachineId,
+        });
+
+        // Author-side HLC clock — persisted under the journal dir (atomic temp+rename)
+        // so the merge total order survives restarts (§3.5). node = this machine's id.
+        const { HybridLogicalClock } = await import('../core/HybridLogicalClock.js');
+        const hlcSafeId = cjOwnMachineId.replace(/[^A-Za-z0-9_.-]/g, '_');
+        const hlcPath = path.join(config.stateDir, 'state', 'coherence-journal', `hlc-${hlcSafeId}.json`);
+        replicatedHlcClock = new HybridLogicalClock({
+          node: cjOwnMachineId,
+          now: () => Date.now(),
+          persist: {
+            load: () => {
+              try {
+                const o = JSON.parse(fs.readFileSync(hlcPath, 'utf-8')) as { physical?: unknown };
+                return o && typeof o.physical === 'number' ? (o as import('../core/HybridLogicalClock.js').HlcTimestamp) : null;
+              } catch { /* @silent-fallback-ok: absent/corrupt hlc file = fresh clock (first boot) — the clock starts at 0, never throws. */ return null; }
+            },
+            save: (t) => {
+              try {
+                fs.mkdirSync(path.dirname(hlcPath), { recursive: true });
+                const tmp = `${hlcPath}.tmp-${process.pid}`;
+                fs.writeFileSync(tmp, JSON.stringify(t));
+                fs.renameSync(tmp, hlcPath);
+              } catch { /* @silent-fallback-ok: a failed hlc persist degrades to in-memory-only (the clock still advances this run); replication merge order is best-effort durable, never a boot blocker. */ }
+            },
+          },
+        });
+      } catch (e) { /* @silent-fallback-ok: the SEND-side wiring must never endanger boot — a failure leaves replication dark (undefined seams), exactly the pre-WS2-send behavior. */
+        replicatedPeerStreamReader = undefined;
+        replicatedHlcClock = undefined;
+        console.log(pc.dim(`  [ws2-send] emitter wiring skipped: ${e instanceof Error ? e.message : String(e)}`));
+      }
+    }
+
     // Snapshot-then-tail engine (Component 4 / build-order step 3,
     // multi-machine-replicated-store-foundation §6). The cache (FIXED ceiling,
     // §8.2 — NOT pool-scaled), the per-peer rebuild breaker (§6.3), and the engine
@@ -3720,10 +3781,13 @@ export async function startServer(options: StartOptions): Promise<void> {
       cache: snapshotCache,
       breaker: snapshotRebuildBreaker,
       seams: {
-        // Step-3 substrate: no concrete store kind is registered yet, so there are
-        // no contributing own-streams to load. A consumer PR (WS2.1) replaces this
-        // with a loader that reads the CoherenceJournal own streams for its kind(s).
-        loadOwnEntries: () => ({}),
+        // WS2 send-side: read the OWN journal streams for the store's registered
+        // kind(s) so a snapshot serve returns real entries (replaces the no-op stub).
+        // Single-origin is enforced inside the reader (it serves only this machine's
+        // own stream). When the journal is dark the reader is undefined ⇒ `{}` (the
+        // correct no-store no-op; serveSnapshot then answers 'no-entries').
+        loadOwnEntries: (store, origin) =>
+          replicatedPeerStreamReader ? replicatedPeerStreamReader.loadOwnEntries(store, origin) : {},
         now: () => Date.now(),
       },
       maxSnapshotBytes: stateSync.maxCacheBytes,
@@ -3741,6 +3805,27 @@ export async function startServer(options: StartOptions): Promise<void> {
     const _stateSyncStoresResolved = resolveStateSyncStores(
       config as { developmentAgent?: boolean; multiMachine?: { stateSync?: Record<string, { enabled?: boolean } & Record<string, unknown>> } },
     ) as import('../core/ReplicatedRecordEnvelope.js').StateSyncStores | undefined;
+
+    // WS2 send-side: the generic journal-backed record emitter (the concrete emitter
+    // the per-store managers' emit hooks call). Needs the journal sink, the HLC clock,
+    // the registry (store → kind), this machine's origin id, the resolved stateSync
+    // flags (the dark gate — read via a getter so a live flip is honored), and the
+    // peer-stream reader as the `observed`-witness source. Constructed only when the
+    // journal + clock + reader exist (all gated on the coherence journal being live);
+    // otherwise it stays undefined and every per-store emit adapter is simply never
+    // attached (the managers' hooks stay no-ops, the pre-WS2-send behavior).
+    if (coherenceJournal && replicatedHlcClock && replicatedPeerStreamReader) {
+      const { ReplicatedRecordEmitter } = await import('../core/ReplicatedRecordEmitter.js');
+      replicatedRecordEmitter = new ReplicatedRecordEmitter({
+        journal: coherenceJournal,
+        clock: replicatedHlcClock,
+        registry: replicatedKindRegistry,
+        origin: cjOwnMachineId as string,
+        stores: () => _stateSyncStoresResolved,
+        loadWitness: (store, recordKey) => replicatedPeerStreamReader!.loadWitness(store, recordKey),
+        log: (event, detail) => console.log(pc.dim(`  [ws2-send] ${event} ${JSON.stringify(detail)}`)),
+      });
+    }
 
     const selfStateSyncReceive = (): Record<string, boolean> => {
       const out: Record<string, boolean> = {};
@@ -8401,34 +8486,59 @@ export async function startServer(options: StartOptions): Promise<void> {
     // and-flag never silently clobbers two divergent lessons; the READ layer is advisory,
     // injecting both variants as hints rather than blocking — fork #2). Consulted by a
     // learnings peer-read surface ONLY when stateSync.learnings.enabled is true.
-    const { learningTierOf, learningToOriginRecord, deriveLearningRecordKey, LEARNING_STORE_KEY } = await import('../core/LearningsReplicatedStore.js');
+    const {
+      learningTierOf,
+      deriveLearningRecordKey,
+      buildLearningRecordData,
+      buildLearningTombstoneData,
+      LEARNING_STORE_KEY,
+    } = await import('../core/LearningsReplicatedStore.js');
     const learningsUnionReader = new ReplicatedStoreReader({
       registry: replicatedKindRegistry,
       stores: _stateSyncStoresResolved, // gate-resolved (dev-live / fleet-dark) per operator directive 2026-06-13
       tierOf: learningTierOf,
-      loadOriginRecords: (store, recordKey) => {
-        if (store !== LEARNING_STORE_KEY || _meshSelfId === null) return [];
-        for (const l of evolution.listLearnings()) {
-          if (deriveLearningRecordKey(l.title, l.category, l.source) === recordKey) {
-            const o = learningToOriginRecord(l, _meshSelfId);
-            return o ? [o] : [];
-          }
-        }
-        return [];
-      },
-      listRecordKeys: (store) => {
-        if (store !== LEARNING_STORE_KEY) return [];
-        const keys: string[] = [];
-        for (const l of evolution.listLearnings()) {
-          const k = deriveLearningRecordKey(l.title, l.category, l.source);
-          if (k !== null) keys.push(k);
-        }
-        return keys;
-      },
+      // WS2 send-side: the union now reads OWN + PEER journal streams (each record's
+      // authoritative emit-time HLC) via the peer-stream reader — so a learning
+      // replicated FROM a peer is READABLE here, not just the local one. Dark / no
+      // journal ⇒ reader undefined ⇒ [] (isLive already gates a disabled store to a
+      // strict no-op, so this never changes single-machine behavior).
+      loadOriginRecords: (store, recordKey) =>
+        store === LEARNING_STORE_KEY && replicatedPeerStreamReader
+          ? replicatedPeerStreamReader.loadOriginRecords(store, recordKey)
+          : [],
+      listRecordKeys: (store) =>
+        store === LEARNING_STORE_KEY && replicatedPeerStreamReader
+          ? replicatedPeerStreamReader.listRecordKeys(store)
+          : [],
       droppedOrigins: droppedOriginRegistry,
       conflictStore,
     });
-    void learningsUnionReader; // consumed by the learnings peer-read surface + the journal-apply rollout stage (WS2.2+)
+    void learningsUnionReader; // consumed by the learnings peer-read surface (the E2E reads through it) + future session-context injection
+
+    // WS2 SEND-SIDE: attach the journal-backed emitter to the EvolutionManager's
+    // learning hooks. The call sites already fire emitPut/emitDelete on every
+    // saveLearnings (prune→emitDelete, survivor→emitPut); the adapter maps the
+    // manager's emit signature to the store's build*RecordData. The emitter owns the
+    // dark gate, HLC tick, `observed` witness, and journal append. Attached only when
+    // the emitter exists (journal live); when dark the hooks stay no-ops (byte-
+    // identical single-machine behavior — the local LRN-NNN id never crosses the wire).
+    if (replicatedRecordEmitter) {
+      const emitter = replicatedRecordEmitter;
+      evolution.setLearningReplicationEmitter({
+        emitPut: (rec) =>
+          emitter.emit(
+            LEARNING_STORE_KEY,
+            deriveLearningRecordKey(rec.title, rec.category, rec.source),
+            (hlc, origin, observed) => buildLearningRecordData({ record: rec, hlc, origin, observed }),
+          ),
+        emitDelete: (title, category, source, deletedAt) =>
+          emitter.emit(
+            LEARNING_STORE_KEY,
+            deriveLearningRecordKey(title, category, source),
+            (hlc, origin, observed) => buildLearningTombstoneData({ title, category, source, hlc, origin, deletedAt, observed }),
+          ),
+      });
+    }
 
     // WS2.4 — the bypass-proof union reader for the `knowledge` store + the emit seam on
     // the KnowledgeManager. The KnowledgeManager reads the local catalog.json (cheap, no

--- a/src/core/CoherenceJournal.ts
+++ b/src/core/CoherenceJournal.ts
@@ -34,6 +34,12 @@ import crypto from 'node:crypto';
 import fs from 'node:fs';
 import path from 'node:path';
 
+import { coerceHlc, serializeHlcKey } from './HybridLogicalClock.js';
+import {
+  validateReplicatedEnvelope,
+  type ReplicatedKindRegistry,
+  type EnvelopeValidationCounters,
+} from './ReplicatedRecordEnvelope.js';
 import { SafeFsExecutor } from './SafeFsExecutor.js';
 
 export type JournalKind = 'topic-placement' | 'session-lifecycle' | 'autonomous-run' | 'threadline-conversation' | 'guard-latch' | 'pref-record' | 'relationship-record' | 'learning-record' | 'knowledge-record' | 'evolution-action-record' | 'user-record' | 'topic-operator-record';
@@ -256,6 +262,16 @@ export const DEFAULT_RETENTION: Record<JournalKind, KindRetention> = {
 
 export const DEFAULT_FLUSH_INTERVAL_MS = 250;
 export const DEFAULT_MAX_ENTRY_BYTES = 8 * 1024;
+/**
+ * Per-entry byte cap for a REPLICATED `*-record` kind (WS2 send-side). A
+ * disclosure-minimized record's `data` is capped at 64 KB by its store builder
+ * (e.g. LEARNING_MAX_ENTRY_BYTES); the serialized journal LINE adds the entry
+ * envelope (seq/ts/machine/kind), so the line cap must sit a margin ABOVE the
+ * data cap or a legal-but-fat record would be dropped as oversize. 80 KB clears
+ * the 64 KB data ceiling with comfortable headroom while staying bounded. The
+ * applier's receive-side cap (JournalSyncApplier) uses the SAME constant so a
+ * record the writer emits can never be rejected as oversize on receive. */
+export const REPLICATED_RECORD_MAX_ENTRY_BYTES = 80 * 1024;
 /** Tail-scan window for op-key dedupe reconstruction (§3.1). */
 export const DEDUPE_WINDOW = 200;
 /** Token-bucket defaults per kind (emits/sec sustained; burst = capacity). */
@@ -421,6 +437,14 @@ export class CoherenceJournal {
   private readonly now: () => Date;
   private readonly logger?: (msg: string) => void;
   private readonly io: JournalFs;
+  /**
+   * The replicated-kind registry (WS2 send-side). Injected via
+   * setReplicatedKindRegistry so the journal can validate + accept a registered
+   * `*-record` kind's envelope. ABSENT ⇒ unchanged behavior (only the 5 hardcoded
+   * lifecycle kinds validate; a `*-record` kind schema-rejects exactly as before
+   * this seam landed). The journal never depends on the registry being present.
+   */
+  private replicatedRegistry?: ReplicatedKindRegistry;
 
   private state: WriterState = 'closed';
   private incarnation = '';
@@ -702,6 +726,60 @@ export class CoherenceJournal {
   }
 
   /**
+   * Inject the replicated-kind registry (WS2 send-side). Idempotent + optional:
+   * the journal validates a registered `*-record` kind's envelope via the store
+   * schema the registry carries; absent ⇒ unchanged behavior. Called once at
+   * wiring time (server.ts), after the concrete stores register their kinds.
+   */
+  setReplicatedKindRegistry(registry: ReplicatedKindRegistry | undefined): void {
+    this.replicatedRegistry = registry;
+  }
+
+  /**
+   * Emit a replicated-store record (WS2 send-side). `data` MUST be a built,
+   * disclosure-minimized envelope `data` (the store's `build*RecordData` output)
+   * carrying `recordKey`/`hlc`/`op`/`origin` (+ optional `observed`). The op-key
+   * is `recordKey:serializeHlcKey(hlc)` so a retry of the EXACT logical event
+   * (same key + same HLC) dedupes, while a new HLC is a distinct event — the §4
+   * idempotency rule. Validation runs in the shared `emit()` path (which delegates
+   * a registered replicated kind to `validateReplicatedEnvelope`), so a malformed
+   * record is a counted schema-reject, never a throw. Non-blocking; never throws
+   * into the caller (the manager emit hooks are best-effort). A no-op when the
+   * kind is not a registered replicated kind (the registry is the authority).
+   */
+  emitReplicatedRecord(kind: JournalKind, data: Record<string, unknown>): void {
+    try {
+      if (!this.replicatedRegistry?.isReplicatedKind(kind)) return; // not a registered replicated kind ⇒ no-op
+      const opKey = this.replicatedOpKey(data);
+      this.emit(kind, undefined, data, opKey);
+    } catch (e) { /* @silent-fallback-ok: journal observability must never endanger the observed operation (COHERENCE-JOURNAL-SPEC §3.1) */
+      this.log('emit-record', `[coherence-journal] emitReplicatedRecord failed (swallowed): ${(e as Error)?.message}`);
+    }
+  }
+
+  /** Derive the restart-proof op-key for a replicated record: `recordKey:hlcKey`.
+   *  Best-effort — a malformed key/hlc still yields a stable string (the record is
+   *  then rejected by validate(), so the op-key only matters for well-formed ones). */
+  private replicatedOpKey(data: Record<string, unknown>): string {
+    const recordKey = typeof data.recordKey === 'string' ? data.recordKey : '';
+    let hlcKey = '';
+    try {
+      hlcKey = serializeHlcKey(coerceHlc(data.hlc));
+    } catch { /* @silent-fallback-ok: a malformed hlc yields an empty hlcKey; validate() then rejects the whole record (schemaRejects) — the op-key never gates a malformed record's acceptance. */
+      hlcKey = '';
+    }
+    return `${recordKey}:${hlcKey}`;
+  }
+
+  /** The per-entry byte cap for a kind — RAISED for replicated `*-record` kinds
+   *  (a disclosure-minimized record can exceed the 8 KB lifecycle cap; §4). */
+  private maxEntryBytesForKind(kind: JournalKind): number {
+    return this.replicatedRegistry?.isReplicatedKind(kind)
+      ? REPLICATED_RECORD_MAX_ENTRY_BYTES
+      : this.maxEntryBytes;
+  }
+
+  /**
    * Generic non-blocking emit: validate + jail + dedupe + rate-cap + serialize,
    * assign a seq, enqueue, and RETURN. No synchronous file I/O on this stack —
    * the flusher does all of it. Never throws into the caller.
@@ -741,8 +819,8 @@ export class CoherenceJournal {
       };
       const line = JSON.stringify(entry);
 
-      // Per-entry size cap (default 8KB) — over-cap drop + count.
-      if (Buffer.byteLength(line, 'utf-8') > this.maxEntryBytes) {
+      // Per-entry size cap (8KB lifecycle / 80KB replicated record) — over-cap drop + count.
+      if (Buffer.byteLength(line, 'utf-8') > this.maxEntryBytesForKind(kind)) {
         this.degradation.oversize++;
         return;
       }
@@ -766,6 +844,27 @@ export class CoherenceJournal {
    */
   private validate(kind: JournalKind, raw: Record<string, unknown>): Record<string, unknown> | null {
     if (!raw || typeof raw !== 'object') return null;
+
+    // WS2 send-side: a registered replicated `*-record` kind validates through the
+    // GENERIC envelope validator + its store-specific schema (the same strict
+    // discipline as the lifecycle kinds — reject free text, drop unknown fields,
+    // jail path-shaped fields, validate hlc/observed). The reconstructed `data`
+    // (validated envelope fields authoritative) is what enqueues. Absent registry
+    // ⇒ falls through to the lifecycle switch (which rejects an unknown kind).
+    const reg = this.replicatedRegistry?.getByKind(kind);
+    if (reg) {
+      const counters: EnvelopeValidationCounters = {
+        // emit() bumps schemaRejects ONCE when validate() returns null (the
+        // lifecycle path's contract) — so the validator's schema-reject is a no-op
+        // here to avoid double-counting; the single emit()-side bump stands.
+        bumpSchemaReject: () => { /* counted once by emit() on a null return */ },
+        bumpDroppedField: () => { this.degradation.droppedFields++; },
+        bumpJailReject: () => { this.degradation.jailRejects++; },
+      };
+      const result = validateReplicatedEnvelope(raw, reg.schema, counters);
+      return result.ok ? result.data : null;
+    }
+
     const seen = Object.keys(raw);
     let out: Record<string, unknown> | null = null;
     let known: string[] = [];

--- a/src/core/JournalSyncApplier.ts
+++ b/src/core/JournalSyncApplier.ts
@@ -65,7 +65,13 @@ import {
   type AutonomousAction,
   type PlacementReason,
   type SessionStatus,
+  REPLICATED_RECORD_MAX_ENTRY_BYTES,
 } from './CoherenceJournal.js';
+import {
+  validateReplicatedEnvelope,
+  type ReplicatedKindRegistry,
+  type EnvelopeValidationCounters,
+} from './ReplicatedRecordEnvelope.js';
 import { SafeFsExecutor } from './SafeFsExecutor.js';
 
 // ---- tunables (§3.4) -------------------------------------------------------
@@ -196,6 +202,15 @@ export interface JournalSyncApplierConfig {
   fsImpl?: JournalFs;
   /** Per-entry size cap override. Default APPLIER_MAX_ENTRY_BYTES. */
   maxEntryBytes?: number;
+  /**
+   * The replicated-kind registry (WS2 send-side receive half). Injected so the
+   * applier can VALIDATE + APPLY a registered `*-record` kind a peer serves —
+   * without it, a peer's learning-record would be marked `invalid` and
+   * suspect-flag the stream (the receive-only gap). ABSENT ⇒ unchanged behavior
+   * (only the 5 lifecycle kinds validate). The registry is the SAME instance the
+   * journal writer + the stateSyncReceive advert read (one source of truth).
+   */
+  replicatedRegistry?: ReplicatedKindRegistry;
 }
 
 function realFs(): JournalFs {
@@ -227,6 +242,10 @@ export class JournalSyncApplier {
   private readonly logger?: (msg: string) => void;
   private readonly io: JournalFs;
   private readonly maxEntryBytes: number;
+  /** The replicated-kind registry (WS2 send-side receive half). Settable because the
+   *  applier is constructed before the registry is populated (server.ts boot order);
+   *  the config option is for tests that have the registry up front. */
+  private replicatedRegistry?: ReplicatedKindRegistry;
 
   /** In-memory meta cache per peer machine (keyed by RAW machineId). */
   private metaCache = new Map<string, PeerMeta>();
@@ -252,10 +271,27 @@ export class JournalSyncApplier {
     this.logger = config.logger;
     this.io = config.fsImpl ?? realFs();
     this.maxEntryBytes = config.maxEntryBytes ?? APPLIER_MAX_ENTRY_BYTES;
+    this.replicatedRegistry = config.replicatedRegistry;
+  }
+
+  /** The per-entry byte cap for a kind — RAISED for replicated `*-record` kinds so
+   *  a fat-but-legal record the writer emitted is not rejected as oversize on
+   *  receive (must match CoherenceJournal.maxEntryBytesForKind). */
+  private maxEntryBytesForKind(kind: JournalKind): number {
+    return this.replicatedRegistry?.isReplicatedKind(kind)
+      ? REPLICATED_RECORD_MAX_ENTRY_BYTES
+      : this.maxEntryBytes;
   }
 
   getDegradation(): Readonly<ApplierDegradation> {
     return { ...this.degradation };
+  }
+
+  /** Inject the replicated-kind registry (WS2 send-side). Called once at wiring time
+   *  after the concrete stores register, so a peer's registered `*-record` kind
+   *  validates + applies instead of suspect-flagging the stream. Idempotent. */
+  setReplicatedKindRegistry(registry: ReplicatedKindRegistry | undefined): void {
+    this.replicatedRegistry = registry;
   }
 
   // ---- advert state (for delta requests) ---------------------------------
@@ -495,7 +531,7 @@ export class JournalSyncApplier {
     } catch {
       return 'invalid';
     }
-    if (Buffer.byteLength(line, 'utf-8') > this.maxEntryBytes) return 'invalid';
+    if (Buffer.byteLength(line, 'utf-8') > this.maxEntryBytesForKind(kind)) return 'invalid';
 
     // kind binding — the entry must belong to the stream slice it arrived in.
     if (entry.kind !== kind) return 'invalid';
@@ -532,6 +568,24 @@ export class JournalSyncApplier {
     if (!data || typeof data !== 'object' || Array.isArray(data)) return false;
     const raw = data as Record<string, unknown>;
     const keys = Object.keys(raw);
+
+    // WS2 send-side receive half: a registered replicated `*-record` kind
+    // validates through the GENERIC envelope validator + its store schema — the
+    // SAME strict discipline the writer applied (reject free text / unknown fields,
+    // jail path-shaped fields, validate hlc + observed). Without this branch a
+    // peer's learning-record would be `invalid` ⇒ suspect-flag the stream (the
+    // receive-only gap). The counters are a no-op here — the applier surfaces
+    // receive degradation via its own ApplierDegradation counters / suspect status,
+    // not these per-field bumps; we only need the boolean verdict.
+    const reg = this.replicatedRegistry?.getByKind(kind);
+    if (reg) {
+      const noopCounters: EnvelopeValidationCounters = {
+        bumpSchemaReject: () => {},
+        bumpDroppedField: () => {},
+        bumpJailReject: () => {},
+      };
+      return validateReplicatedEnvelope(raw, reg.schema, noopCounters).ok;
+    }
 
     if (kind === 'topic-placement') {
       const reasons: PlacementReason[] = ['user-move', 'placed', 'failover', 'released', 'quota-block-move'];

--- a/src/core/ReplicatedPeerStreamReader.ts
+++ b/src/core/ReplicatedPeerStreamReader.ts
@@ -1,0 +1,305 @@
+/**
+ * ReplicatedPeerStreamReader — materializes a replicated store's per-origin records
+ * from the coherence-journal streams on disk (WS2 send-side, the union-read half).
+ *
+ * Spec: docs/specs/WS2-SEND-SIDE-EMISSION-SPEC.md §3.3 + §3.4; the substrate is
+ * docs/specs/multi-machine-replicated-store-foundation.md §7.1 (namespaced per-origin
+ * storage), §7.2 (the union the reader merges).
+ *
+ * THE GAP THIS CLOSES: `ReplicatedStoreReader.loadOriginRecords` returned only the OWN
+ * origin, so even a correctly-received peer record (durably written by
+ * JournalSyncApplier to `peers/<M>.<kind>.jsonl`) was invisible to a read. This reader
+ * is the seam that makes the union real: it reads the OWN stream
+ * (`<self>.<kind>.jsonl` + archives) AND every peer replica stream
+ * (`peers/<M>.<kind>.jsonl` + archives; quarantine + meta excluded), validates each
+ * line through the SAME `validateReplicatedEnvelope` + store schema the writer used,
+ * and folds to the LATEST record per `(origin, recordKey)` by HLC-max. A delete is a
+ * tombstone (kept) so the union's delete-resolution + resurrection guard work.
+ *
+ * It supplies three seams to the rest of the system:
+ *   - `loadOriginRecords(store, recordKey)` + `listRecordKeys(store)` — the
+ *     ReplicatedStoreReader seams (the no-clobber union's per-origin input).
+ *   - `loadWitness(store, recordKey)` — the emitter's `observed` source (the MAX HLC
+ *     over every origin record held for the key — own prior + applied peers).
+ *   - `loadOwnEntries(store, origin)` — the snapshot-serve seam (raw OWN entries by
+ *     kind), replacing the `loadOwnEntries: () => ({})` stub.
+ *
+ * PURE-ish: all I/O is the injected `fsImpl` (defaults to node:fs); no Date, no
+ * network. Bounded — replicated memory stores are small (per-kind retention caps), and
+ * the read ceiling mirrors the applier's SERVE_READ_BYTE_CEILING.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+
+import {
+  type JournalFs,
+  type JournalEntry,
+  type JournalKind,
+  sanitizeMachineId,
+  readTailTolerant,
+} from './CoherenceJournal.js';
+import { HybridLogicalClock, type HlcTimestamp } from './HybridLogicalClock.js';
+import {
+  validateReplicatedEnvelope,
+  type ReplicatedKindRegistry,
+  type EnvelopeValidationCounters,
+} from './ReplicatedRecordEnvelope.js';
+import type { OriginRecord } from './UnionReader.js';
+import type { RawJournalEntry } from './StoreSnapshot.js';
+
+/** The byte ceiling for one stream read (mirrors JournalSyncApplier.SERVE_READ_BYTE_CEILING). */
+const READ_BYTE_CEILING = 64 * 1024 * 1024;
+
+/** A counters bag that ignores every bump — the reader surfaces nothing per-field
+ *  (a malformed replica line is simply dropped from the union, the safe direction). */
+const NOOP_COUNTERS: EnvelopeValidationCounters = {
+  bumpSchemaReject: () => {},
+  bumpDroppedField: () => {},
+  bumpJailReject: () => {},
+};
+
+export interface ReplicatedPeerStreamReaderConfig {
+  /** Absolute path to the agent's `.instar/` directory (the stateDir). */
+  stateDir: string;
+  /** The replicated-kind registry — resolves store → kind + the store schema. */
+  registry: ReplicatedKindRegistry;
+  /** This machine's id (the OWN origin). */
+  selfMachineId: string;
+  /** Optional fs seam for fault-injection tests. Defaults to node:fs. */
+  fsImpl?: JournalFs;
+}
+
+function realFs(): JournalFs {
+  return {
+    openSync: fs.openSync,
+    writeSync: fs.writeSync,
+    fdatasyncSync: fs.fdatasyncSync,
+    closeSync: fs.closeSync,
+    existsSync: fs.existsSync,
+    statSync: fs.statSync,
+    renameSync: fs.renameSync,
+    writeFileSync: fs.writeFileSync,
+    readFileSync: fs.readFileSync,
+    readdirSync: fs.readdirSync,
+    truncateSync: fs.truncateSync,
+    mkdirSync: fs.mkdirSync,
+    readSync: fs.readSync,
+  };
+}
+
+function escapeRegExp(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+// RULE 3: EXEMPT — this is NOT a state-detector. ReplicatedPeerStreamReader reads
+// the agent's OWN coherence-journal stream files (a fixed, self-authored JSONL format)
+// and validates each line through validateReplicatedEnvelope. It does not parse
+// provider/CLI output, does not detect external/environment state, and has no
+// signature-matching that could drift across providers — it deterministically folds
+// in-house journal entries by HLC. The "*Reader" name matches the Rule-3 pattern
+// heuristic but the substance is an internal-format reader (mirrors the same exemption
+// on ReplicatedStoreReader).
+export class ReplicatedPeerStreamReader {
+  private readonly stateDir: string;
+  private readonly registry: ReplicatedKindRegistry;
+  private readonly selfMachineId: string;
+  private readonly io: JournalFs;
+
+  constructor(config: ReplicatedPeerStreamReaderConfig) {
+    if (!config) throw new Error('ReplicatedPeerStreamReader: config required');
+    if (!config.registry) throw new Error('ReplicatedPeerStreamReader: registry required (not null)');
+    if (typeof config.selfMachineId !== 'string' || config.selfMachineId.length === 0) {
+      throw new Error('ReplicatedPeerStreamReader: selfMachineId must be a non-empty string');
+    }
+    this.stateDir = config.stateDir;
+    this.registry = config.registry;
+    this.selfMachineId = config.selfMachineId;
+    this.io = config.fsImpl ?? realFs();
+  }
+
+  // ── The ReplicatedStoreReader seams ────────────────────────────────────────
+
+  /**
+   * Every origin's CURRENT record for (store, recordKey) — the own stream + each peer
+   * replica namespace, ONE record per origin (the latest by HLC, a delete kept as a
+   * tombstone). The union reader merges these via the no-clobber rule. A single-machine
+   * install returns only the own origin (so the union is a strict no-op = that record).
+   */
+  loadOriginRecords(store: string, recordKey: string): OriginRecord[] {
+    const byOrigin = this.materialize(store).get(recordKey);
+    return byOrigin ? [...byOrigin.values()] : [];
+  }
+
+  /** Every recordKey the store currently holds across ALL origins (for readAll). */
+  listRecordKeys(store: string): string[] {
+    return [...this.materialize(store).keys()];
+  }
+
+  // ── The emitter `observed`-witness seam (§7.2) ─────────────────────────────
+
+  /**
+   * The MAX HLC over every origin record this machine currently holds for
+   * (store, recordKey) — own prior + applied peers. The author stamps this as the
+   * record's `observed` witness. Returns undefined when none is held (first write of
+   * the key) ⇒ the author omits `observed` ⇒ flag-on-conflict (the safe direction).
+   * Sound: it only witnesses a version provably on disk, so a not-yet-pulled peer
+   * version is absent here and the merge flags concurrent rather than silently
+   * resolving (§7.2 err-toward-flag).
+   */
+  loadWitness(store: string, recordKey: string): HlcTimestamp | undefined {
+    const records = this.loadOriginRecords(store, recordKey);
+    let max: HlcTimestamp | undefined;
+    for (const r of records) {
+      if (max === undefined || HybridLogicalClock.compare(r.envelope.hlc, max) > 0) {
+        max = r.envelope.hlc;
+      }
+    }
+    return max;
+  }
+
+  // ── The snapshot-serve seam (replaces loadOwnEntries: () => ({})) ──────────
+
+  /**
+   * The OWN-stream raw entries for `store`, keyed by contributing journal kind — the
+   * single-origin snapshot input (§6). `origin` MUST be this machine (single-origin,
+   * §6.1); a request for any other origin returns `{}` (we only serve what we
+   * authored). Reads the own current + archive streams; returns ALL entries (the
+   * materializer folds to the latest per recordKey and computes the seq watermark).
+   */
+  loadOwnEntries(store: string, origin: string): Record<string, RawJournalEntry[]> {
+    const reg = this.registry.getByStore(store);
+    if (!reg) return {};
+    // Single-origin: only serve OUR OWN authored stream.
+    if (origin !== this.selfMachineId) return {};
+    const kind = reg.kind as JournalKind;
+    const entries = this.readKindEntries(this.ownStreamFiles(origin, kind));
+    if (entries.length === 0) return {};
+    const raw: RawJournalEntry[] = entries.map((e) => ({
+      seq: e.seq,
+      ts: e.ts,
+      machine: e.machine,
+      kind: e.kind,
+      data: e.data,
+    }));
+    return { [kind]: raw };
+  }
+
+  // ── Materialization (own + peer streams → latest per (origin, recordKey)) ──
+
+  /**
+   * Build `recordKey → (origin → latest OriginRecord)` for a store by reading the own
+   * stream + every peer replica stream and folding by HLC-max per (origin, recordKey).
+   * Read FRESH each call (no cache) so a write-then-read is always consistent — the
+   * stores are small + bounded, so the scan is cheap.
+   */
+  private materialize(store: string): Map<string, Map<string, OriginRecord>> {
+    const out = new Map<string, Map<string, OriginRecord>>();
+    const reg = this.registry.getByStore(store);
+    if (!reg) return out;
+    const kind = reg.kind as JournalKind;
+    const schema = reg.schema;
+
+    const files = [
+      ...this.ownStreamFiles(this.selfMachineId, kind),
+      ...this.peerStreamFiles(kind),
+    ];
+    for (const file of files) {
+      const entries = this.readKindEntries([file]);
+      for (const entry of entries) {
+        if (entry.kind !== kind) continue;
+        const data = entry.data;
+        if (!data || typeof data !== 'object') continue;
+        const result = validateReplicatedEnvelope(data as Record<string, unknown>, schema, NOOP_COUNTERS);
+        if (!result.ok) continue;
+        const origin = result.envelope.origin;
+        const recordKey = result.envelope.recordKey;
+        const rec: OriginRecord = { origin, envelope: result.envelope, data: result.storeFields };
+        let byOrigin = out.get(recordKey);
+        if (!byOrigin) {
+          byOrigin = new Map<string, OriginRecord>();
+          out.set(recordKey, byOrigin);
+        }
+        const prior = byOrigin.get(origin);
+        // Keep the LATEST record per (origin, recordKey) by HLC-max (a delete is a
+        // tombstone — kept, so the union resolves delete↔put deterministically).
+        if (!prior || HybridLogicalClock.compare(rec.envelope.hlc, prior.envelope.hlc) > 0) {
+          byOrigin.set(origin, rec);
+        }
+      }
+    }
+    return out;
+  }
+
+  /** Read + tolerant-parse every JournalEntry from the given stream files. */
+  private readKindEntries(files: string[]): JournalEntry[] {
+    const out: JournalEntry[] = [];
+    for (const f of files) {
+      const read = readTailTolerant(this.io, f, Number.MAX_SAFE_INTEGER, READ_BYTE_CEILING);
+      for (const e of read.entries) out.push(e);
+    }
+    return out;
+  }
+
+  // ── Path enumeration ───────────────────────────────────────────────────────
+
+  private journalDir(): string {
+    return path.join(this.stateDir, 'state', 'coherence-journal');
+  }
+
+  private peersDir(): string {
+    return path.join(this.journalDir(), 'peers');
+  }
+
+  /** Own current + archive stream files for (origin, kind), newest-first by stamp. */
+  private ownStreamFiles(origin: string, kind: JournalKind): string[] {
+    const safe = sanitizeMachineId(origin);
+    const dir = this.journalDir();
+    const current = path.join(dir, `${safe}.${kind}.jsonl`);
+    const out: string[] = [];
+    if (this.io.existsSync(current)) out.push(current);
+    out.push(...this.archivesFor(dir, safe, kind));
+    return out;
+  }
+
+  /** Every peer replica current + archive stream file for `kind` (quarantine excluded). */
+  private peerStreamFiles(kind: JournalKind): string[] {
+    const dir = this.peersDir();
+    let names: string[];
+    try {
+      names = this.io.readdirSync(dir) as string[];
+    } catch { /* @silent-fallback-ok: peers dir absent = no peers yet (single-machine / fresh) — an empty union, never an error. */
+      return [];
+    }
+    const k = escapeRegExp(kind);
+    // `<id>.<kind>.jsonl` (current) OR `<id>.<kind>.<digits>.jsonl` (archive). The
+    // `<id>` is greedy (`.+`) and may itself contain dots. Quarantine files
+    // (`<id>.<kind>.quarantine.<digits>.jsonl`) are EXCLUDED — they are a fenced
+    // old incarnation, never part of the live union.
+    const re = new RegExp(`^(.+)\\.${k}(?:\\.\\d+)?\\.jsonl$`);
+    const out: string[] = [];
+    for (const n of names) {
+      if (n.includes('.quarantine.')) continue;
+      if (re.test(n)) out.push(path.join(dir, n));
+    }
+    return out;
+  }
+
+  /** Archive files `<safe>.<kind>.<stamp>.jsonl` in `dir`, newest-first. */
+  private archivesFor(dir: string, safe: string, kind: JournalKind): string[] {
+    let names: string[];
+    try {
+      names = this.io.readdirSync(dir) as string[];
+    } catch { /* @silent-fallback-ok: dir absent = nothing to read — empty, never an error. */
+      return [];
+    }
+    const re = new RegExp(`^${escapeRegExp(`${safe}.${kind}.`)}(\\d+)\\.jsonl$`);
+    const archives: { file: string; stamp: number }[] = [];
+    for (const n of names) {
+      const m = re.exec(n);
+      if (m) archives.push({ file: path.join(dir, n), stamp: Number(m[1]) });
+    }
+    archives.sort((a, b) => b.stamp - a.stamp);
+    return archives.map((a) => a.file);
+  }
+}

--- a/src/core/ReplicatedRecordEmitter.ts
+++ b/src/core/ReplicatedRecordEmitter.ts
@@ -1,0 +1,188 @@
+/**
+ * ReplicatedRecordEmitter — the GENERIC journal-backed SEND emitter (WS2 send-side).
+ *
+ * Spec: docs/specs/WS2-SEND-SIDE-EMISSION-SPEC.md §4; the substrate it rides is
+ * docs/specs/multi-machine-replicated-store-foundation.md §4 (the envelope +
+ * flag-gated emission) and §7.2 (the `observed` last-writer-witness).
+ *
+ * THE GAP THIS CLOSES: every memory manager already calls an internal
+ * `emitter.emitPut(record)` / `emitter.emitDelete(...)` hook on each write, behind a
+ * `*ReplicationEmitter | null` seam — but server.ts never constructed the concrete
+ * emitter those hooks call (it was deferred to "a later rollout stage" that never
+ * came), so the hooks fired into a no-op and nothing reached the journal own-streams.
+ * This class IS that concrete emitter; server.ts builds ONE and adapts it to each
+ * manager's emit seam (a tiny per-store adapter that names the store's
+ * `build*RecordData`).
+ *
+ * It is store-AGNOSTIC: `emit(store, recordKey, build)` resolves the store's journal
+ * kind from the injected `ReplicatedKindRegistry`, gates on
+ * `multiMachine.stateSync.<store>.enabled` (dark by default), stamps the HLC, derives
+ * the `observed` witness, asks the store's builder for the disclosure-minimized
+ * envelope `data`, and appends it via `CoherenceJournal.emitReplicatedRecord`. ONE
+ * generic path serves all 7 kinds; the only per-store thing is the builder closure.
+ *
+ * SAFETY: NEVER throws into the caller (the manager hooks are best-effort). A disabled
+ * store, an unregistered store, a degenerate (null) recordKey, a builder that returns
+ * null or throws (e.g. a record over its per-entry byte cap) — every one is a counted
+ * no-op, never an exception that would break the local write the agent is performing.
+ * Emission is SINGLE-ORIGIN by construction: it stamps `origin = this machine` and the
+ * journal writes only this machine's own stream (§6.1 anti-forgery holds end-to-end).
+ */
+
+import type { HlcTimestamp } from './HybridLogicalClock.js';
+import {
+  isStoreEmissionEnabled,
+  type ReplicatedKindRegistry,
+  type StateSyncStores,
+} from './ReplicatedRecordEnvelope.js';
+
+/** The minimal journal seam the emitter needs (so it is unit-testable with a fake). */
+export interface ReplicatedRecordEmitterJournal {
+  /** Append a built replicated-record envelope `data` for `kind` (no-op when the
+   *  kind is not a registered replicated kind; never throws). */
+  emitReplicatedRecord(kind: string, data: Record<string, unknown>): void;
+}
+
+/** The minimal HLC seam (only `tick()` is needed on the author side). */
+export interface ReplicatedRecordEmitterClock {
+  /** Local-event advance — strictly greater than every prior tick/receive (§3.2.1). */
+  tick(): HlcTimestamp;
+}
+
+/** A builder closure: produce the disclosure-minimized envelope `data` for this write
+ *  given the freshly-ticked `hlc`, this machine's `origin`, and the `observed` witness
+ *  (absent ⇒ no prior witness). Returns null to SKIP (a degenerate record with no
+ *  stable identity surface). May THROW on an over-cap record — the emitter catches it. */
+export type BuildRecordData = (
+  hlc: HlcTimestamp,
+  origin: string,
+  observed: HlcTimestamp | undefined,
+) => Record<string, unknown> | null;
+
+/** The DI'd seams (asserted real, never null/no-op, by the wiring-integrity test). */
+export interface ReplicatedRecordEmitterSeams {
+  /** The journal append sink. */
+  journal: ReplicatedRecordEmitterJournal;
+  /** The author-side HLC clock (persisted; one per machine). */
+  clock: ReplicatedRecordEmitterClock;
+  /** The replicated-kind registry — resolves store → journal kind; the emitter only
+   *  emits a registered store. */
+  registry: ReplicatedKindRegistry;
+  /** This machine's origin id (stamped on every emitted record — single-origin). */
+  origin: string;
+  /** The per-store stateSync flags (the dark-by-default gate). A getter so a live
+   *  config flip is honored without reconstructing the emitter. */
+  stores: () => StateSyncStores | undefined;
+  /**
+   * The last-writer-witness source (§7.2): the MAX HLC over every origin record this
+   * machine CURRENTLY holds on disk for (store, recordKey) — own prior + applied
+   * peers. Sound by construction: it can only witness a version provably on disk, so a
+   * not-yet-pulled peer version is simply absent ⇒ the merge flags concurrent
+   * (err-toward-flag), never a silent clobber. Returns undefined when none is held
+   * (the first write of a key) ⇒ `observed` omitted. Best-effort; throwing is caught.
+   */
+  loadWitness: (store: string, recordKey: string) => HlcTimestamp | undefined;
+  /** Optional structured logger (default no-op). */
+  log?: (event: string, detail: Record<string, unknown>) => void;
+}
+
+/** Lifetime counters for observability (mirrors the journal's degradation style). */
+export interface ReplicatedRecordEmitterStats {
+  /** Records appended to the journal. */
+  emitted: number;
+  /** No-ops because the store was disabled (dark). */
+  storeDisabled: number;
+  /** No-ops because the recordKey was null/degenerate or the builder returned null. */
+  skipped: number;
+  /** Builder/journal throws caught (never propagated to the manager). */
+  errors: number;
+}
+
+export class ReplicatedRecordEmitter {
+  private readonly seams: ReplicatedRecordEmitterSeams;
+  private readonly stats: ReplicatedRecordEmitterStats = {
+    emitted: 0,
+    storeDisabled: 0,
+    skipped: 0,
+    errors: 0,
+  };
+
+  constructor(seams: ReplicatedRecordEmitterSeams) {
+    // Wiring-integrity preconditions: the seams MUST be real, not null/no-op.
+    if (!seams) throw new Error('ReplicatedRecordEmitter: seams are required');
+    if (!seams.journal || typeof seams.journal.emitReplicatedRecord !== 'function') {
+      throw new Error('ReplicatedRecordEmitter: journal.emitReplicatedRecord seam must be a function (not a no-op)');
+    }
+    if (!seams.clock || typeof seams.clock.tick !== 'function') {
+      throw new Error('ReplicatedRecordEmitter: clock.tick seam must be a function');
+    }
+    if (!seams.registry) throw new Error('ReplicatedRecordEmitter: registry seam is required (not null)');
+    if (typeof seams.origin !== 'string' || seams.origin.length === 0) {
+      throw new Error('ReplicatedRecordEmitter: origin must be a non-empty string');
+    }
+    if (typeof seams.stores !== 'function') throw new Error('ReplicatedRecordEmitter: stores seam must be a function');
+    if (typeof seams.loadWitness !== 'function') throw new Error('ReplicatedRecordEmitter: loadWitness seam must be a function (not a no-op)');
+    this.seams = seams;
+  }
+
+  /** Read-only stats (for observability + the wiring-integrity assertions). */
+  getStats(): Readonly<ReplicatedRecordEmitterStats> {
+    return { ...this.stats };
+  }
+
+  /**
+   * Emit one replicated record for (store, recordKey). The single generic path for a
+   * put OR a delete — the only difference is the `build` closure (a put builder vs a
+   * tombstone builder). Never throws into the caller.
+   *
+   * Order (§4): dark gate → degenerate guard → witness → tick → build → append.
+   */
+  emit(store: string, recordKey: string | null | undefined, build: BuildRecordData): void {
+    try {
+      // 1. Dark gate (the default). A disabled store emits NOTHING — a strict no-op.
+      if (!isStoreEmissionEnabled(this.seams.stores(), store)) {
+        this.stats.storeDisabled++;
+        return;
+      }
+      // 2. Only a registered store has a journal kind to ride.
+      const reg = this.seams.registry.getByStore(store);
+      if (!reg) {
+        this.stats.skipped++;
+        return;
+      }
+      // 3. Degenerate guard — a null/empty recordKey has no stable identity surface.
+      if (typeof recordKey !== 'string' || recordKey.length === 0) {
+        this.stats.skipped++;
+        return;
+      }
+      // 4. Witness BEFORE the tick — the HLC this machine had already merged for the
+      //    key (own prior + applied peers). Best-effort; a witness read fault degrades
+      //    to "no witness" (flag-on-conflict, the safe direction), never a throw.
+      let observed: HlcTimestamp | undefined;
+      try {
+        observed = this.seams.loadWitness(store, recordKey);
+      } catch (e) { /* @silent-fallback-ok: a witness read fault degrades to no-witness ⇒ flag-on-conflict (the safe merge direction, §7.2); never blocks the emit. */
+        observed = undefined;
+        this.log('witness-read-failed', { store, error: (e as Error)?.message });
+      }
+      // 5. Tick AFTER the witness so hlc > observed (a clean sequential position).
+      const hlc = this.seams.clock.tick();
+      // 6. Build the disclosure-minimized envelope data (store-specific).
+      const data = build(hlc, this.seams.origin, observed);
+      if (data === null || data === undefined) {
+        this.stats.skipped++;
+        return;
+      }
+      // 7. Append. The journal validates + op-key-dedupes + enqueues (non-blocking).
+      this.seams.journal.emitReplicatedRecord(reg.kind, data);
+      this.stats.emitted++;
+    } catch (e) { /* @silent-fallback-ok: the manager's write must NEVER fail because replication did — a builder throw (e.g. over-cap) / journal fault is a counted no-op, surfaced via stats + the log, never propagated (Structure > Willpower: the safety is structural, not per-caller). */
+      this.stats.errors++;
+      this.log('emit-failed', { store, error: (e as Error)?.message });
+    }
+  }
+
+  private log(event: string, detail: Record<string, unknown>): void {
+    this.seams.log?.(event, detail);
+  }
+}

--- a/src/core/ws2SendWiring.ts
+++ b/src/core/ws2SendWiring.ts
@@ -1,0 +1,81 @@
+/**
+ * ws2SendWiring — the SEND-side wiring manifest + the wiring-integrity ratchet
+ * (WS2 send-side, docs/specs/WS2-SEND-SIDE-EMISSION-SPEC.md §6/§7).
+ *
+ * THE INVARIANT THIS ENFORCES: every replicated store registered in the
+ * `ReplicatedKindRegistry` (the RECEIVE/advert half) must be CONSCIOUSLY classified
+ * as either SEND-WIRED (its manager's emit hooks are attached to the journal-backed
+ * emitter) or SEND-PENDING (a known, enumerated follow-up). A new replicated kind
+ * added to the registry WITHOUT placing it in one of these sets fails the ratchet —
+ * which is the EXACT gap this workstream fixes: a kind shipped receive-only (advert +
+ * apply machinery) with the SEND half silently a no-op. The ratchet makes that a CI
+ * failure, not a memory item (Structure > Willpower).
+ *
+ * Pure data + a pure check — no I/O, no deps. The server's wiring + the
+ * wiring-integrity test BOTH read these sets, so they cannot drift.
+ */
+
+/** Stores whose manager emit hooks ARE attached to the journal-backed emitter (their
+ *  records actually cross). The learnings slice ships first; the other seamed stores
+ *  follow on the SAME emitter (WS2-SEND-2). */
+export const WS2_SEND_WIRED_STORES: ReadonlyArray<string> = Object.freeze([
+  'learnings',
+]);
+
+/**
+ * Stores registered for RECEIVE but whose SEND wiring is a KNOWN, enumerated
+ * follow-up — NOT a silent omission. Each is here for a stated reason:
+ *  - relationships / knowledge / evolutionActions / userRegistry: fully seamed
+ *    managers (emitPut + emitDelete); table-row wiring onto the same emitter (WS2-SEND-2).
+ *  - topicOperator: seamed put-only (no emitDelete in its manager interface yet) (WS2-SEND-3).
+ *  - preferences: NO manager emit seam yet — it rode the deprecated `preferences-sync`
+ *    verb; needs a manager emit hook before it can be wired (WS2-SEND-3).
+ */
+export const WS2_SEND_PENDING_STORES: ReadonlyArray<string> = Object.freeze([
+  'relationships',
+  'knowledge',
+  'evolutionActions',
+  'userRegistry',
+  'topicOperator',
+  'preferences',
+]);
+
+/** A registered store's send-wiring classification. */
+export type Ws2SendStatus = 'wired' | 'pending' | 'unclassified';
+
+/** Classify a registered store's send-wiring status. */
+export function ws2SendStatus(store: string): Ws2SendStatus {
+  if (WS2_SEND_WIRED_STORES.includes(store)) return 'wired';
+  if (WS2_SEND_PENDING_STORES.includes(store)) return 'pending';
+  return 'unclassified';
+}
+
+/** The ratchet result: any registered store that is neither wired nor pending. */
+export interface Ws2SendWiringAudit {
+  wired: string[];
+  pending: string[];
+  /** Registered stores in NEITHER set — the failure condition (a silent receive-only kind). */
+  unclassified: string[];
+  ok: boolean;
+}
+
+/**
+ * Audit a set of registered store keys against the wiring manifest. `ok` is false iff
+ * any registered store is unclassified (neither wired nor pending) — the exact
+ * receive-only gap this workstream closes. Also flags a store in BOTH sets (a manifest
+ * authoring error) as unclassified-style failure via a thrown precondition is avoided;
+ * instead WIRED takes precedence and the overlap is surfaced by the caller's own
+ * disjointness assertion in the test.
+ */
+export function auditWs2SendWiring(registeredStores: ReadonlyArray<string>): Ws2SendWiringAudit {
+  const wired: string[] = [];
+  const pending: string[] = [];
+  const unclassified: string[] = [];
+  for (const store of registeredStores) {
+    const status = ws2SendStatus(store);
+    if (status === 'wired') wired.push(store);
+    else if (status === 'pending') pending.push(store);
+    else unclassified.push(store);
+  }
+  return { wired, pending, unclassified, ok: unclassified.length === 0 };
+}

--- a/tests/e2e/ws2-learnings-cross-instance.test.ts
+++ b/tests/e2e/ws2-learnings-cross-instance.test.ts
@@ -1,0 +1,186 @@
+// safe-fs-allow: test fixture teardown uses SafeFsExecutor.safeRmSync on tmp dirs only.
+/**
+ * E2E — WS2 send-side: a learning written on instance A is READABLE on instance B.
+ *
+ * THE REAL PROOF (reproduces + closes the live Laptop↔Mac-Mini gap). Two in-process
+ * instances with separate stateDirs, each wired exactly as the server wires them:
+ *   - A: EvolutionManager + journal-backed emitter (emission enabled) + journal.
+ *   - B: JournalSyncApplier + ReplicatedPeerStreamReader + a ReplicatedStoreReader
+ *        (the bypass-proof no-clobber union — the SAME funnel the server uses).
+ * A.addLearning → A's journal own-stream → serve → B.apply → B's `learnings` union
+ * read returns A's learning as a foreign-origin record. Before this workstream the
+ * learning never reached A's own-stream at all (the emitter was a no-op), so B had
+ * nothing to pull — exactly the bug. Also proves a tombstone (a pruned/removed
+ * learning) replicates as a delete and the union resolves the key to "no record".
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+
+import { CoherenceJournal } from '../../src/core/CoherenceJournal.js';
+import { JournalSyncApplier } from '../../src/core/JournalSyncApplier.js';
+import { ReplicatedPeerStreamReader } from '../../src/core/ReplicatedPeerStreamReader.js';
+import { ReplicatedRecordEmitter } from '../../src/core/ReplicatedRecordEmitter.js';
+import { ReplicatedStoreReader } from '../../src/core/ReplicatedStoreReader.js';
+import { ReplicatedKindRegistry } from '../../src/core/ReplicatedRecordEnvelope.js';
+import { ConflictStore } from '../../src/core/ConflictStore.js';
+import { DroppedOriginRegistry } from '../../src/core/RollbackUnmerge.js';
+import { EvolutionManager } from '../../src/core/EvolutionManager.js';
+import { HybridLogicalClock } from '../../src/core/HybridLogicalClock.js';
+import {
+  LEARNING_KIND_REGISTRATION,
+  LEARNING_RECORD_KIND,
+  LEARNING_STORE_KEY,
+  learningTierOf,
+  buildLearningRecordData,
+  buildLearningTombstoneData,
+  deriveLearningRecordKey,
+} from '../../src/core/LearningsReplicatedStore.js';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+
+const A = 'm_laptop';
+const B = 'm_mac_mini';
+
+function reg(): ReplicatedKindRegistry {
+  const r = new ReplicatedKindRegistry();
+  r.register(LEARNING_KIND_REGISTRATION);
+  return r;
+}
+
+interface Instance {
+  dir: string;
+  registry: ReplicatedKindRegistry;
+  journal: CoherenceJournal;
+  applier: JournalSyncApplier;
+  reader: ReplicatedPeerStreamReader;
+  evolution: EvolutionManager;
+  unionReader: ReplicatedStoreReader;
+}
+
+function makeInstance(machineId: string, label: string): Instance {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), `ws2e2e-${label}-`));
+  const registry = reg();
+  const journal = new CoherenceJournal({ stateDir: dir, machineId, flushIntervalMs: 1_000_000 });
+  journal.open();
+  journal.setReplicatedKindRegistry(registry);
+  const applier = new JournalSyncApplier({ stateDir: dir, replicatedRegistry: registry });
+  const reader = new ReplicatedPeerStreamReader({ stateDir: dir, registry, selfMachineId: machineId });
+  const evolution = new EvolutionManager({ stateDir: dir });
+
+  // Emitter (the SEND wiring) — emission ENABLED for learnings.
+  const emitter = new ReplicatedRecordEmitter({
+    journal,
+    clock: new HybridLogicalClock({ node: machineId, now: () => Date.now() }),
+    registry,
+    origin: machineId,
+    stores: () => ({ learnings: { enabled: true } }),
+    loadWitness: (store, rk) => reader.loadWitness(store, rk),
+  });
+  evolution.setLearningReplicationEmitter({
+    emitPut: (rec) => emitter.emit(LEARNING_STORE_KEY, deriveLearningRecordKey(rec.title, rec.category, rec.source),
+      (hlc, o, observed) => buildLearningRecordData({ record: rec, hlc, origin: o, observed })),
+    emitDelete: (title, category, source, deletedAt) => emitter.emit(LEARNING_STORE_KEY, deriveLearningRecordKey(title, category, source),
+      (hlc, o, observed) => buildLearningTombstoneData({ title, category, source, hlc, origin: o, deletedAt, observed })),
+  });
+
+  // The bypass-proof union reader (the SAME funnel + seams the server wires).
+  const unionReader = new ReplicatedStoreReader({
+    registry,
+    stores: { learnings: { enabled: true } },
+    tierOf: learningTierOf,
+    loadOriginRecords: (store, rk) => reader.loadOriginRecords(store, rk),
+    listRecordKeys: (store) => reader.listRecordKeys(store),
+    droppedOrigins: new DroppedOriginRegistry({ stateDir: dir }),
+    conflictStore: new ConflictStore({ stateDir: dir, now: () => new Date() }),
+  });
+
+  return { dir, registry, journal, applier, reader, evolution, unionReader };
+}
+
+/** Ship every NEW own learning-record entry from `from` to `to` (the journal serve/apply
+ *  path, first-hop bound). Returns the cursor to resume from next time. */
+function replicate(from: Instance, fromMachineId: string, to: Instance, fromSeq: number): number {
+  from.journal.flush();
+  const served = from.applier.buildServeBatch(LEARNING_RECORD_KIND, fromSeq, fromMachineId);
+  if (served.entries.length === 0) return fromSeq;
+  to.applier.apply(fromMachineId, [served]);
+  return served.entries[served.entries.length - 1].seq;
+}
+
+describe('E2E — a learning written on A is readable on B (the live gap, closed)', () => {
+  let a: Instance;
+  let b: Instance;
+
+  beforeEach(() => {
+    a = makeInstance(A, 'a');
+    b = makeInstance(B, 'b');
+  });
+  afterEach(() => {
+    for (const inst of [a, b]) {
+      try { inst.journal.close(); } catch { /* best-effort */ }
+      SafeFsExecutor.safeRmSync(inst.dir, { recursive: true, force: true, operation: 'tests/e2e/ws2-learnings-cross-instance.test.ts' });
+    }
+  });
+
+  it('addLearning on A becomes readable through B\'s union reader as a foreign-origin record', () => {
+    const l = a.evolution.addLearning({
+      title: 'always branch before committing on the default branch',
+      category: 'git',
+      description: 'never push straight to main from an agent session',
+      source: { discoveredAt: '2026-06-15T08:00:00.000Z' },
+    });
+
+    // B sees nothing yet (no replication has happened).
+    const rk = deriveLearningRecordKey(l.title, l.category, l.source)!;
+    expect(b.unionReader.read(LEARNING_STORE_KEY, rk).value).toBeNull();
+
+    // Replicate A → B over the real serve/apply path.
+    replicate(a, A, b, 0);
+
+    // B's union read now returns A's learning — a foreign-origin record.
+    const result = b.unionReader.read(LEARNING_STORE_KEY, rk);
+    expect(result.value).not.toBeNull();
+    expect(result.value!.origin).toBe(A);
+    expect(result.value!.data.title).toBe(l.title);
+    expect(result.value!.data.category).toBe('git');
+    // And it appears in B's full key listing.
+    expect(b.unionReader.readAll(LEARNING_STORE_KEY).has(rk)).toBe(true);
+  });
+
+  it('a markApplied edit on A replicates and the latest (applied=true) wins on B', () => {
+    const l = a.evolution.addLearning({
+      title: 'quote the injected current time', category: 'reporting',
+      description: 'no vibe times', source: { discoveredAt: '2026-06-15T08:00:00.000Z' },
+    });
+    let cursor = replicate(a, A, b, 0);
+    const rk = deriveLearningRecordKey(l.title, l.category, l.source)!;
+    expect(b.unionReader.read(LEARNING_STORE_KEY, rk).value!.data.applied).toBe(false);
+
+    // Apply the learning on A, replicate the new state.
+    a.evolution.markLearningApplied(l.id, 'topic 13481');
+    cursor = replicate(a, A, b, cursor);
+    expect(cursor).toBeGreaterThan(0);
+
+    const result = b.unionReader.read(LEARNING_STORE_KEY, rk);
+    expect(result.value!.origin).toBe(A);
+    expect(result.value!.data.applied).toBe(true);
+    expect(result.value!.data.appliedTo).toBe('topic 13481');
+  });
+
+  it('the SAME lesson learned on BOTH machines collapses to ONE recordKey across origins', () => {
+    // Both machines independently learn the same lesson (same title+category+source).
+    const src = { discoveredAt: '2026-06-15T08:00:00.000Z' };
+    const la = a.evolution.addLearning({ title: 'use a trailing colon for tmux pane commands', category: 'ops', description: 'tmux 3.6a quirk', source: src });
+    b.evolution.addLearning({ title: 'use a trailing colon for tmux pane commands', category: 'ops', description: 'tmux 3.6a quirk', source: src });
+
+    // A replicates to B; flush B so its OWN emitted record is durable on disk too.
+    replicate(a, A, b, 0);
+    b.journal.flush();
+    const rk = deriveLearningRecordKey(la.title, la.category, la.source)!;
+    const origins = b.reader.loadOriginRecords(LEARNING_STORE_KEY, rk);
+    expect(origins.map((o) => o.origin).sort()).toEqual([A, B].sort());
+    // ONE key, not two — the content fingerprint collapsed the same lesson.
+    expect(b.reader.listRecordKeys(LEARNING_STORE_KEY)).toEqual([rk]);
+  });
+});

--- a/tests/integration/ws2-send-journal-roundtrip.test.ts
+++ b/tests/integration/ws2-send-journal-roundtrip.test.ts
@@ -1,0 +1,151 @@
+// safe-fs-allow: test fixture teardown uses SafeFsExecutor.safeRmSync on tmp dirs only.
+/**
+ * Integration — WS2 send-side over the journal serve/apply transport.
+ *
+ * Machine A: a real EvolutionManager with the journal-backed emitter attached (the
+ * production wiring) → addLearning emits a `learning-record` to A's own journal stream.
+ * A serves its own stream via buildServeBatch; B's JournalSyncApplier applies it under
+ * first-hop binding into B's peer replica; B's ReplicatedPeerStreamReader reads it back.
+ * Also proves StoreSnapshotEngine.serveSnapshot('learnings') returns real entries (the
+ * loadOwnEntries stub is gone).
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+
+import { CoherenceJournal } from '../../src/core/CoherenceJournal.js';
+import { JournalSyncApplier } from '../../src/core/JournalSyncApplier.js';
+import { ReplicatedPeerStreamReader } from '../../src/core/ReplicatedPeerStreamReader.js';
+import { ReplicatedRecordEmitter } from '../../src/core/ReplicatedRecordEmitter.js';
+import { ReplicatedKindRegistry } from '../../src/core/ReplicatedRecordEnvelope.js';
+import { EvolutionManager } from '../../src/core/EvolutionManager.js';
+import { HybridLogicalClock } from '../../src/core/HybridLogicalClock.js';
+import {
+  LEARNING_KIND_REGISTRATION,
+  LEARNING_RECORD_KIND,
+  LEARNING_STORE_KEY,
+  buildLearningRecordData,
+  buildLearningTombstoneData,
+  deriveLearningRecordKey,
+} from '../../src/core/LearningsReplicatedStore.js';
+import { SnapshotCache, SnapshotRebuildBreaker, StoreSnapshotEngine } from '../../src/core/StoreSnapshot.js';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+
+const A = 'm_machine_a';
+const B = 'm_machine_b';
+
+function reg(): ReplicatedKindRegistry {
+  const r = new ReplicatedKindRegistry();
+  r.register(LEARNING_KIND_REGISTRATION);
+  return r;
+}
+
+/** Attach the production-shape learnings emitter to an EvolutionManager. */
+function wireEmitter(evolution: EvolutionManager, journal: CoherenceJournal, registry: ReplicatedKindRegistry, reader: ReplicatedPeerStreamReader, origin: string): void {
+  const emitter = new ReplicatedRecordEmitter({
+    journal,
+    clock: new HybridLogicalClock({ node: origin, now: () => Date.now() }),
+    registry,
+    origin,
+    stores: () => ({ learnings: { enabled: true } }),
+    loadWitness: (store, rk) => reader.loadWitness(store, rk),
+  });
+  evolution.setLearningReplicationEmitter({
+    emitPut: (rec) => emitter.emit(LEARNING_STORE_KEY, deriveLearningRecordKey(rec.title, rec.category, rec.source),
+      (hlc, o, observed) => buildLearningRecordData({ record: rec, hlc, origin: o, observed })),
+    emitDelete: (title, category, source, deletedAt) => emitter.emit(LEARNING_STORE_KEY, deriveLearningRecordKey(title, category, source),
+      (hlc, o, observed) => buildLearningTombstoneData({ title, category, source, hlc, origin: o, deletedAt, observed })),
+  });
+}
+
+describe('WS2 send-side — journal serve/apply round-trip', () => {
+  let dirA: string;
+  let dirB: string;
+  let journalA: CoherenceJournal;
+  let applierA: JournalSyncApplier;
+  let applierB: JournalSyncApplier;
+  let readerA: ReplicatedPeerStreamReader;
+  let readerB: ReplicatedPeerStreamReader;
+  let evolutionA: EvolutionManager;
+
+  beforeEach(() => {
+    dirA = fs.mkdtempSync(path.join(os.tmpdir(), 'ws2snd-a-'));
+    dirB = fs.mkdtempSync(path.join(os.tmpdir(), 'ws2snd-b-'));
+    const regA = reg();
+    const regB = reg();
+    journalA = new CoherenceJournal({ stateDir: dirA, machineId: A, flushIntervalMs: 1_000_000 });
+    journalA.open();
+    journalA.setReplicatedKindRegistry(regA);
+    applierA = new JournalSyncApplier({ stateDir: dirA, replicatedRegistry: regA });
+    applierB = new JournalSyncApplier({ stateDir: dirB, replicatedRegistry: regB });
+    readerA = new ReplicatedPeerStreamReader({ stateDir: dirA, registry: regA, selfMachineId: A });
+    readerB = new ReplicatedPeerStreamReader({ stateDir: dirB, registry: regB, selfMachineId: B });
+    evolutionA = new EvolutionManager({ stateDir: dirA });
+    wireEmitter(evolutionA, journalA, regA, readerA, A);
+  });
+  afterEach(() => {
+    try { journalA.close(); } catch { /* best-effort */ }
+    SafeFsExecutor.safeRmSync(dirA, { recursive: true, force: true, operation: 'tests/integration/ws2-send-journal-roundtrip.test.ts' });
+    SafeFsExecutor.safeRmSync(dirB, { recursive: true, force: true, operation: 'tests/integration/ws2-send-journal-roundtrip.test.ts' });
+  });
+
+  it('A.addLearning → own stream → buildServeBatch → B.apply → B reads the peer record', () => {
+    const l = evolutionA.addLearning({
+      title: 'read the session clock before reporting elapsed time',
+      category: 'reporting',
+      description: 'never report a vibe time; quote the injected current time',
+      source: { discoveredAt: '2026-06-15T00:00:00.000Z' },
+    });
+    journalA.flush();
+
+    // A serves its own learning-record stream (B has nothing → fromSeq 0).
+    const served = applierA.buildServeBatch(LEARNING_RECORD_KIND, 0, A);
+    expect(served.entries.length).toBeGreaterThanOrEqual(1);
+    expect(served.entries.every((e) => e.machine === A)).toBe(true);
+
+    // B applies the batch under first-hop binding (sender = A).
+    const result = applierB.apply(A, [served]);
+    expect(result.applied).toBe(served.entries.length);
+    expect(result.forgedEntries).toBe(0);
+
+    // B reads A's learning back through the peer-stream reader.
+    const rk = deriveLearningRecordKey(l.title, l.category, l.source)!;
+    const origins = readerB.loadOriginRecords(LEARNING_STORE_KEY, rk);
+    expect(origins).toHaveLength(1);
+    expect(origins[0].origin).toBe(A);
+    expect(origins[0].data.title).toBe(l.title);
+  });
+
+  it('a FORGED batch (entry.machine ≠ sender) is rejected — no peer record lands', () => {
+    evolutionA.addLearning({ title: 'x', category: 'c', description: 'd', source: { discoveredAt: '2026-06-15T00:00:00.000Z' } });
+    journalA.flush();
+    const served = applierA.buildServeBatch(LEARNING_RECORD_KIND, 0, A);
+    const forged = { ...served, entries: served.entries.map((e) => ({ ...e, machine: B })) };
+    const result = applierB.apply(A, [forged]);
+    expect(result.applied).toBe(0);
+    expect(result.forgedEntries).toBeGreaterThanOrEqual(1);
+    expect(readerB.listRecordKeys(LEARNING_STORE_KEY)).toHaveLength(0);
+  });
+
+  it('StoreSnapshotEngine.serveSnapshot returns real own entries (loadOwnEntries no longer a stub)', async () => {
+    evolutionA.addLearning({ title: 'snap', category: 'c', description: 'd', source: { discoveredAt: '2026-06-15T00:00:00.000Z' } });
+    journalA.flush();
+
+    const engine = new StoreSnapshotEngine({
+      cache: new SnapshotCache({ maxCachedSnapshots: 8, maxCacheBytes: 1_000_000 }),
+      breaker: new SnapshotRebuildBreaker({ now: () => Date.now() }),
+      seams: {
+        loadOwnEntries: (store, origin) => readerA.loadOwnEntries(store, origin),
+        now: () => Date.now(),
+      },
+      runInline: true,
+    });
+    const res = await engine.serveSnapshot('m_peer_requester', A, LEARNING_STORE_KEY);
+    expect(res.ok).toBe(true);
+    if (res.ok) {
+      expect(res.snapshot.records.length).toBeGreaterThanOrEqual(1);
+      expect(res.snapshot.origin).toBe(A);
+    }
+  });
+});

--- a/tests/integration/ws2-send-wiring.test.ts
+++ b/tests/integration/ws2-send-wiring.test.ts
@@ -1,0 +1,66 @@
+/**
+ * Wiring-integrity ratchet — every registered WS2 replicated kind must be CONSCIOUSLY
+ * classified as SEND-wired or SEND-pending (WS2-SEND-SIDE-EMISSION-SPEC §7).
+ *
+ * THE GAP THIS GUARDS: WS2 shipped 7 kinds receive-capable (registry + advert + apply)
+ * with the SEND half a silent no-op. This test registers the SAME 7 kinds the server
+ * registers and asserts the send-wiring manifest accounts for every one of them — so a
+ * FUTURE kind added to the registry with neither a wired emitter nor an explicit
+ * pending entry fails CI (it cannot be silently added receive-only again).
+ */
+import { describe, it, expect } from 'vitest';
+
+import { ReplicatedKindRegistry } from '../../src/core/ReplicatedRecordEnvelope.js';
+import { PREF_KIND_REGISTRATION } from '../../src/core/PreferencesReplicatedStore.js';
+import { RELATIONSHIP_KIND_REGISTRATION } from '../../src/core/RelationshipsReplicatedStore.js';
+import { LEARNING_KIND_REGISTRATION } from '../../src/core/LearningsReplicatedStore.js';
+import { KNOWLEDGE_KIND_REGISTRATION } from '../../src/core/KnowledgeReplicatedStore.js';
+import { EVOLUTION_ACTION_KIND_REGISTRATION } from '../../src/core/EvolutionActionsReplicatedStore.js';
+import { USER_KIND_REGISTRATION } from '../../src/core/UserRegistryReplicatedStore.js';
+import { TOPIC_OPERATOR_KIND_REGISTRATION } from '../../src/core/TopicOperatorReplicatedStore.js';
+import {
+  auditWs2SendWiring,
+  WS2_SEND_WIRED_STORES,
+  WS2_SEND_PENDING_STORES,
+} from '../../src/core/ws2SendWiring.js';
+
+/** Register the SAME 7 concrete kinds the server registers (server.ts boot order). */
+function serverRegistry(): ReplicatedKindRegistry {
+  const r = new ReplicatedKindRegistry();
+  r.register(PREF_KIND_REGISTRATION);
+  r.register(RELATIONSHIP_KIND_REGISTRATION);
+  r.register(LEARNING_KIND_REGISTRATION);
+  r.register(KNOWLEDGE_KIND_REGISTRATION);
+  r.register(EVOLUTION_ACTION_KIND_REGISTRATION);
+  r.register(USER_KIND_REGISTRATION);
+  r.register(TOPIC_OPERATOR_KIND_REGISTRATION);
+  return r;
+}
+
+describe('WS2 send-side wiring-integrity ratchet', () => {
+  it('every registered replicated store is classified (no silent receive-only kind)', () => {
+    const audit = auditWs2SendWiring(serverRegistry().stores());
+    expect(audit.unclassified).toEqual([]);
+    expect(audit.ok).toBe(true);
+  });
+
+  it('learnings is SEND-WIRED (the shipped slice)', () => {
+    expect(WS2_SEND_WIRED_STORES).toContain('learnings');
+    const audit = auditWs2SendWiring(serverRegistry().stores());
+    expect(audit.wired).toContain('learnings');
+  });
+
+  it('the WIRED and PENDING sets are disjoint (a store is in exactly one)', () => {
+    const overlap = WS2_SEND_WIRED_STORES.filter((s) => WS2_SEND_PENDING_STORES.includes(s));
+    expect(overlap).toEqual([]);
+  });
+
+  it('WIRED ∪ PENDING covers exactly the registered stores (no stale manifest entry)', () => {
+    const registered = new Set(serverRegistry().stores());
+    const manifest = new Set([...WS2_SEND_WIRED_STORES, ...WS2_SEND_PENDING_STORES]);
+    // Every manifest entry is a real registered store (no typo / stale entry).
+    for (const s of manifest) expect(registered.has(s)).toBe(true);
+    // Every registered store is in the manifest (the ratchet's core invariant).
+    for (const s of registered) expect(manifest.has(s)).toBe(true);
+  });
+});

--- a/tests/unit/CoherenceJournal-record-emit.test.ts
+++ b/tests/unit/CoherenceJournal-record-emit.test.ts
@@ -1,0 +1,136 @@
+// safe-fs-allow: test fixture teardown uses SafeFsExecutor.safeRmSync on tmp dirs only.
+/**
+ * Unit — CoherenceJournal.emitReplicatedRecord (WS2 send-side, the §3.1 journal gap).
+ *
+ * Proves the journal can APPEND + VALIDATE a registered `*-record` kind (it could
+ * not before — `validate()` fell through to `return null` for any non-lifecycle
+ * kind), that the op-key is `recordKey:hlcKey` (a same-key+same-hlc retry dedupes;
+ * a new hlc is a new event), that the per-entry cap is RAISED for record kinds (a
+ * 20 KB-description learning is appended, not dropped as oversize at 8 KB), and that
+ * a malformed envelope is a counted schema-reject. Without the registry injected, the
+ * emit is a strict no-op (the unchanged pre-WS2 behavior).
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+
+import { CoherenceJournal, sanitizeMachineId } from '../../src/core/CoherenceJournal.js';
+import { ReplicatedKindRegistry } from '../../src/core/ReplicatedRecordEnvelope.js';
+import {
+  LEARNING_KIND_REGISTRATION,
+  LEARNING_RECORD_KIND,
+  buildLearningRecordData,
+} from '../../src/core/LearningsReplicatedStore.js';
+import type { HlcTimestamp } from '../../src/core/HybridLogicalClock.js';
+import type { LearningEntry } from '../../src/core/types.js';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+
+const MACHINE = 'm_journal_test';
+
+function hlc(physical: number, logical = 0): HlcTimestamp {
+  return { physical, logical, node: MACHINE };
+}
+
+function learning(over: Partial<LearningEntry> = {}): LearningEntry {
+  return {
+    id: 'LRN-001',
+    title: 'tmux trailing colon',
+    category: 'ops',
+    description: 'use a trailing colon for pane-level commands',
+    source: { discoveredAt: '2026-06-15T00:00:00.000Z' },
+    tags: ['tmux'],
+    applied: false,
+    ...over,
+  };
+}
+
+describe('CoherenceJournal.emitReplicatedRecord', () => {
+  let dir: string;
+  let journal: CoherenceJournal;
+
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'cj-rec-'));
+    journal = new CoherenceJournal({ stateDir: dir, machineId: MACHINE, flushIntervalMs: 1_000_000 });
+    journal.open();
+  });
+  afterEach(() => {
+    try { journal.close(); } catch { /* best-effort */ }
+    SafeFsExecutor.safeRmSync(dir, { recursive: true, force: true, operation: 'tests/unit/CoherenceJournal-record-emit.test.ts' });
+  });
+
+  function ownStreamLines(kind: string): Record<string, unknown>[] {
+    const file = path.join(dir, 'state', 'coherence-journal', `${sanitizeMachineId(MACHINE)}.${kind}.jsonl`);
+    if (!fs.existsSync(file)) return [];
+    return fs.readFileSync(file, 'utf-8').trim().split('\n').filter(Boolean).map((l) => JSON.parse(l));
+  }
+
+  it('is a NO-OP for a record kind when no registry is injected (unchanged pre-WS2 behavior)', () => {
+    const data = buildLearningRecordData({ record: learning(), hlc: hlc(1000), origin: MACHINE })!;
+    journal.emitReplicatedRecord(LEARNING_RECORD_KIND, data);
+    journal.flush();
+    expect(ownStreamLines(LEARNING_RECORD_KIND)).toHaveLength(0);
+  });
+
+  it('appends a registered learning-record to the own stream when the registry is injected', () => {
+    const registry = new ReplicatedKindRegistry();
+    registry.register(LEARNING_KIND_REGISTRATION);
+    journal.setReplicatedKindRegistry(registry);
+
+    const data = buildLearningRecordData({ record: learning(), hlc: hlc(1000), origin: MACHINE })!;
+    journal.emitReplicatedRecord(LEARNING_RECORD_KIND, data);
+    journal.flush();
+
+    const lines = ownStreamLines(LEARNING_RECORD_KIND);
+    expect(lines).toHaveLength(1);
+    expect(lines[0].kind).toBe(LEARNING_RECORD_KIND);
+    expect((lines[0].data as Record<string, unknown>).recordKey).toBe(data.recordKey);
+    expect((lines[0].data as Record<string, unknown>).title).toBe('tmux trailing colon');
+    expect((lines[0].data as Record<string, unknown>).op).toBe('put');
+  });
+
+  it('op-key dedupes a same-(recordKey,hlc) retry; a new hlc is a distinct event', () => {
+    const registry = new ReplicatedKindRegistry();
+    registry.register(LEARNING_KIND_REGISTRATION);
+    journal.setReplicatedKindRegistry(registry);
+
+    const d1 = buildLearningRecordData({ record: learning(), hlc: hlc(1000), origin: MACHINE })!;
+    journal.emitReplicatedRecord(LEARNING_RECORD_KIND, d1);
+    journal.emitReplicatedRecord(LEARNING_RECORD_KIND, d1); // exact retry — deduped
+    journal.flush();
+    expect(ownStreamLines(LEARNING_RECORD_KIND)).toHaveLength(1);
+
+    // Same record, NEW hlc (e.g. a markApplied re-emit) — a distinct event.
+    const d2 = buildLearningRecordData({ record: learning({ applied: true }), hlc: hlc(2000), origin: MACHINE })!;
+    journal.emitReplicatedRecord(LEARNING_RECORD_KIND, d2);
+    journal.flush();
+    expect(ownStreamLines(LEARNING_RECORD_KIND)).toHaveLength(2);
+  });
+
+  it('appends a FAT (20KB-description) learning — the raised 80KB record cap, not the 8KB lifecycle cap', () => {
+    const registry = new ReplicatedKindRegistry();
+    registry.register(LEARNING_KIND_REGISTRATION);
+    journal.setReplicatedKindRegistry(registry);
+
+    const big = learning({ description: 'x'.repeat(20_000) });
+    const data = buildLearningRecordData({ record: big, hlc: hlc(1000), origin: MACHINE })!;
+    expect(Buffer.byteLength(JSON.stringify(data), 'utf-8')).toBeGreaterThan(8 * 1024); // would be dropped at 8KB
+    journal.emitReplicatedRecord(LEARNING_RECORD_KIND, data);
+    journal.flush();
+    const lines = ownStreamLines(LEARNING_RECORD_KIND);
+    expect(lines).toHaveLength(1);
+    expect(((lines[0].data as Record<string, unknown>).description as string).length).toBe(20_000);
+  });
+
+  it('rejects a malformed envelope (missing recordKey) — counted schema-reject, nothing written', () => {
+    const registry = new ReplicatedKindRegistry();
+    registry.register(LEARNING_KIND_REGISTRATION);
+    journal.setReplicatedKindRegistry(registry);
+
+    const before = journal.getDegradation().schemaRejects;
+    journal.emitReplicatedRecord(LEARNING_RECORD_KIND, { title: 'no key', op: 'put', origin: MACHINE, hlc: hlc(1) } as Record<string, unknown>);
+    journal.flush();
+    expect(ownStreamLines(LEARNING_RECORD_KIND)).toHaveLength(0);
+    expect(journal.getDegradation().schemaRejects).toBe(before + 1);
+  });
+});

--- a/tests/unit/ReplicatedPeerStreamReader.test.ts
+++ b/tests/unit/ReplicatedPeerStreamReader.test.ts
@@ -1,0 +1,143 @@
+// safe-fs-allow: test fixture teardown uses SafeFsExecutor.safeRmSync on tmp dirs only.
+/**
+ * Unit — ReplicatedPeerStreamReader (WS2 send-side, §3.3/§3.4 — the union-read +
+ * witness + loadOwnEntries source).
+ *
+ * Proves the reader materializes the union's per-origin records from the OWN journal
+ * stream (written by CoherenceJournal) AND a PEER replica stream (written by
+ * JournalSyncApplier under first-hop binding) — folding to the latest per
+ * (origin, recordKey) by HLC, keeping a tombstone — and that loadWitness returns the
+ * MAX held HLC and loadOwnEntries serves only this machine's own entries.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+
+import { CoherenceJournal } from '../../src/core/CoherenceJournal.js';
+import { JournalSyncApplier, type ApplyBatchStream } from '../../src/core/JournalSyncApplier.js';
+import { ReplicatedPeerStreamReader } from '../../src/core/ReplicatedPeerStreamReader.js';
+import { ReplicatedKindRegistry } from '../../src/core/ReplicatedRecordEnvelope.js';
+import {
+  LEARNING_KIND_REGISTRATION,
+  LEARNING_RECORD_KIND,
+  LEARNING_STORE_KEY,
+  buildLearningRecordData,
+  buildLearningTombstoneData,
+  deriveLearningRecordKey,
+} from '../../src/core/LearningsReplicatedStore.js';
+import type { HlcTimestamp } from '../../src/core/HybridLogicalClock.js';
+import type { JournalEntry } from '../../src/core/CoherenceJournal.js';
+import type { LearningEntry, LearningSource } from '../../src/core/types.js';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+
+const SELF = 'm_self';
+const PEER = 'm_peer';
+
+function reg(): ReplicatedKindRegistry {
+  const r = new ReplicatedKindRegistry();
+  r.register(LEARNING_KIND_REGISTRATION);
+  return r;
+}
+function hlc(physical: number, node: string, logical = 0): HlcTimestamp {
+  return { physical, logical, node };
+}
+function learning(over: Partial<LearningEntry> = {}): LearningEntry {
+  return {
+    id: 'LRN-001', title: 'tmux colon', category: 'ops',
+    description: 'desc', source: { discoveredAt: '2026-06-15T00:00:00.000Z' },
+    tags: [], applied: false, ...over,
+  };
+}
+const SRC: LearningSource = { discoveredAt: '2026-06-15T00:00:00.000Z' };
+
+/** Apply a peer learning-record as a first-hop-bound journal batch (writes peers/<PEER>...). */
+function applyPeerRecord(applier: JournalSyncApplier, data: Record<string, unknown>, seq: number): void {
+  const entry: JournalEntry = { seq, ts: new Date(2026, 5, 15).toISOString(), machine: PEER, kind: LEARNING_RECORD_KIND, data };
+  const batch: ApplyBatchStream[] = [{ kind: LEARNING_RECORD_KIND, incarnation: 'inc-peer', entries: [entry] }];
+  applier.apply(PEER, batch);
+}
+
+describe('ReplicatedPeerStreamReader', () => {
+  let dir: string;
+  let journal: CoherenceJournal;
+  let applier: JournalSyncApplier;
+  let reader: ReplicatedPeerStreamReader;
+
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'psr-'));
+    const registry = reg();
+    journal = new CoherenceJournal({ stateDir: dir, machineId: SELF, flushIntervalMs: 1_000_000 });
+    journal.open();
+    journal.setReplicatedKindRegistry(registry);
+    applier = new JournalSyncApplier({ stateDir: dir, replicatedRegistry: registry });
+    reader = new ReplicatedPeerStreamReader({ stateDir: dir, registry, selfMachineId: SELF });
+  });
+  afterEach(() => {
+    try { journal.close(); } catch { /* best-effort */ }
+    SafeFsExecutor.safeRmSync(dir, { recursive: true, force: true, operation: 'tests/unit/ReplicatedPeerStreamReader.test.ts' });
+  });
+
+  it('materializes OWN + PEER records as distinct origins for the same recordKey', () => {
+    // Same lesson learned on both machines ⇒ same recordKey, two origins.
+    const rk = deriveLearningRecordKey('tmux colon', 'ops', SRC)!;
+    journal.emitReplicatedRecord(LEARNING_RECORD_KIND, buildLearningRecordData({ record: learning(), hlc: hlc(1000, SELF), origin: SELF })!);
+    journal.flush();
+    applyPeerRecord(applier, buildLearningRecordData({ record: learning(), hlc: hlc(1500, PEER), origin: PEER })!, 1);
+
+    const origins = reader.loadOriginRecords(LEARNING_STORE_KEY, rk);
+    expect(origins).toHaveLength(2);
+    expect(origins.map((o) => o.origin).sort()).toEqual([PEER, SELF].sort());
+    expect(reader.listRecordKeys(LEARNING_STORE_KEY)).toEqual([rk]);
+  });
+
+  it('folds to the LATEST record per (origin, recordKey) by HLC', () => {
+    const rk = deriveLearningRecordKey('tmux colon', 'ops', SRC)!;
+    // Two OWN emits for the same key, the later (applied=true) at a higher HLC.
+    journal.emitReplicatedRecord(LEARNING_RECORD_KIND, buildLearningRecordData({ record: learning({ applied: false }), hlc: hlc(1000, SELF), origin: SELF })!);
+    journal.emitReplicatedRecord(LEARNING_RECORD_KIND, buildLearningRecordData({ record: learning({ applied: true }), hlc: hlc(2000, SELF), origin: SELF })!);
+    journal.flush();
+
+    const origins = reader.loadOriginRecords(LEARNING_STORE_KEY, rk);
+    expect(origins).toHaveLength(1);
+    expect(origins[0].envelope.hlc.physical).toBe(2000);
+    expect(origins[0].data.applied).toBe(true);
+  });
+
+  it('keeps a tombstone (op:delete) as the latest record', () => {
+    const rk = deriveLearningRecordKey('tmux colon', 'ops', SRC)!;
+    journal.emitReplicatedRecord(LEARNING_RECORD_KIND, buildLearningRecordData({ record: learning(), hlc: hlc(1000, SELF), origin: SELF })!);
+    journal.emitReplicatedRecord(LEARNING_RECORD_KIND, buildLearningTombstoneData({ title: 'tmux colon', category: 'ops', source: SRC, hlc: hlc(3000, SELF), origin: SELF, deletedAt: '2026-06-15T01:00:00.000Z' })!);
+    journal.flush();
+
+    const origins = reader.loadOriginRecords(LEARNING_STORE_KEY, rk);
+    expect(origins).toHaveLength(1);
+    expect(origins[0].envelope.op).toBe('delete');
+  });
+
+  it('loadWitness returns the MAX held HLC across origins (the observed source)', () => {
+    const rk = deriveLearningRecordKey('tmux colon', 'ops', SRC)!;
+    journal.emitReplicatedRecord(LEARNING_RECORD_KIND, buildLearningRecordData({ record: learning(), hlc: hlc(1000, SELF), origin: SELF })!);
+    journal.flush();
+    applyPeerRecord(applier, buildLearningRecordData({ record: learning(), hlc: hlc(2500, PEER), origin: PEER })!, 1);
+
+    const witness = reader.loadWitness(LEARNING_STORE_KEY, rk);
+    expect(witness?.physical).toBe(2500);
+  });
+
+  it('loadWitness is undefined for an unheld key (first write)', () => {
+    expect(reader.loadWitness(LEARNING_STORE_KEY, 'never-seen')).toBeUndefined();
+  });
+
+  it('loadOwnEntries serves only THIS machine\'s own entries; {} for a foreign origin', () => {
+    journal.emitReplicatedRecord(LEARNING_RECORD_KIND, buildLearningRecordData({ record: learning(), hlc: hlc(1000, SELF), origin: SELF })!);
+    journal.flush();
+
+    const own = reader.loadOwnEntries(LEARNING_STORE_KEY, SELF);
+    expect(own[LEARNING_RECORD_KIND]).toBeDefined();
+    expect(own[LEARNING_RECORD_KIND].length).toBe(1);
+    expect(own[LEARNING_RECORD_KIND][0].machine).toBe(SELF);
+    // Single-origin: a request for a foreign origin returns nothing.
+    expect(reader.loadOwnEntries(LEARNING_STORE_KEY, PEER)).toEqual({});
+  });
+});

--- a/tests/unit/ReplicatedRecordEmitter.test.ts
+++ b/tests/unit/ReplicatedRecordEmitter.test.ts
@@ -1,0 +1,162 @@
+/**
+ * Unit — ReplicatedRecordEmitter (WS2 send-side, the generic journal-backed emitter).
+ *
+ * Proves the emitter's contract in isolation with fakes: the dark gate (disabled
+ * store ⇒ strict no-op), the degenerate guard (null recordKey ⇒ skip), the
+ * `observed` witness order (witness read BEFORE the tick ⇒ observed < hlc), and that
+ * a builder/journal throw is a counted no-op (never propagates — the manager's local
+ * write must never break because replication did).
+ */
+import { describe, it, expect } from 'vitest';
+
+import { ReplicatedRecordEmitter, type ReplicatedRecordEmitterClock } from '../../src/core/ReplicatedRecordEmitter.js';
+import { ReplicatedKindRegistry, type StateSyncStores } from '../../src/core/ReplicatedRecordEnvelope.js';
+import { LEARNING_KIND_REGISTRATION, LEARNING_STORE_KEY, LEARNING_RECORD_KIND } from '../../src/core/LearningsReplicatedStore.js';
+import { HybridLogicalClock, type HlcTimestamp } from '../../src/core/HybridLogicalClock.js';
+
+const ORIGIN = 'm_test_self';
+
+function registry(): ReplicatedKindRegistry {
+  const r = new ReplicatedKindRegistry();
+  r.register(LEARNING_KIND_REGISTRATION);
+  return r;
+}
+
+/** A real persistence-free HLC clock — monotonic ticks. */
+function clock(): ReplicatedRecordEmitterClock {
+  return new HybridLogicalClock({ node: ORIGIN, now: () => Date.now() });
+}
+
+interface Captured {
+  kind: string;
+  data: Record<string, unknown>;
+}
+
+function makeEmitter(opts: {
+  stores: StateSyncStores | undefined;
+  witness?: HlcTimestamp | undefined;
+  clockImpl?: ReplicatedRecordEmitterClock;
+}): { emitter: ReplicatedRecordEmitter; captured: Captured[] } {
+  const captured: Captured[] = [];
+  const emitter = new ReplicatedRecordEmitter({
+    journal: { emitReplicatedRecord: (kind, data) => { captured.push({ kind, data }); } },
+    clock: opts.clockImpl ?? clock(),
+    registry: registry(),
+    origin: ORIGIN,
+    stores: () => opts.stores,
+    loadWitness: () => opts.witness,
+  });
+  return { emitter, captured };
+}
+
+const PUT_BUILD = (hlc: HlcTimestamp, origin: string, observed: HlcTimestamp | undefined): Record<string, unknown> => ({
+  title: 'tmux trailing colon', category: 'ops', description: 'use a trailing colon', source: { discoveredAt: '2026-06-15T00:00:00.000Z' },
+  applied: false, tags: [], recordKey: 'rk1', hlc, op: 'put', origin,
+  ...(observed !== undefined ? { observed } : {}),
+});
+
+describe('ReplicatedRecordEmitter — dark gate', () => {
+  it('is a STRICT no-op when the store is disabled (default)', () => {
+    const { emitter, captured } = makeEmitter({ stores: { learnings: { enabled: false } } });
+    emitter.emit(LEARNING_STORE_KEY, 'rk1', PUT_BUILD);
+    expect(captured).toHaveLength(0);
+    expect(emitter.getStats().storeDisabled).toBe(1);
+    expect(emitter.getStats().emitted).toBe(0);
+  });
+
+  it('is a no-op when the store flags are absent entirely', () => {
+    const { emitter, captured } = makeEmitter({ stores: undefined });
+    emitter.emit(LEARNING_STORE_KEY, 'rk1', PUT_BUILD);
+    expect(captured).toHaveLength(0);
+    expect(emitter.getStats().storeDisabled).toBe(1);
+  });
+
+  it('emits to the store kind when enabled', () => {
+    const { emitter, captured } = makeEmitter({ stores: { learnings: { enabled: true } } });
+    emitter.emit(LEARNING_STORE_KEY, 'rk1', PUT_BUILD);
+    expect(captured).toHaveLength(1);
+    expect(captured[0].kind).toBe(LEARNING_RECORD_KIND);
+    expect(captured[0].data.recordKey).toBe('rk1');
+    expect(captured[0].data.origin).toBe(ORIGIN);
+    expect(emitter.getStats().emitted).toBe(1);
+  });
+});
+
+describe('ReplicatedRecordEmitter — guards', () => {
+  it('skips a null/empty recordKey (no stable identity surface)', () => {
+    const { emitter, captured } = makeEmitter({ stores: { learnings: { enabled: true } } });
+    emitter.emit(LEARNING_STORE_KEY, null, PUT_BUILD);
+    emitter.emit(LEARNING_STORE_KEY, '', PUT_BUILD);
+    expect(captured).toHaveLength(0);
+    expect(emitter.getStats().skipped).toBe(2);
+  });
+
+  it('skips an unregistered store', () => {
+    const { emitter, captured } = makeEmitter({ stores: { somethingElse: { enabled: true } } });
+    emitter.emit('somethingElse', 'rk1', PUT_BUILD);
+    expect(captured).toHaveLength(0);
+    expect(emitter.getStats().skipped).toBe(1);
+  });
+
+  it('skips when the builder returns null (degenerate record)', () => {
+    const { emitter, captured } = makeEmitter({ stores: { learnings: { enabled: true } } });
+    emitter.emit(LEARNING_STORE_KEY, 'rk1', () => null);
+    expect(captured).toHaveLength(0);
+    expect(emitter.getStats().skipped).toBe(1);
+  });
+
+  it('CATCHES a builder throw — never propagates, counts an error', () => {
+    const { emitter, captured } = makeEmitter({ stores: { learnings: { enabled: true } } });
+    expect(() => emitter.emit(LEARNING_STORE_KEY, 'rk1', () => { throw new Error('over cap'); })).not.toThrow();
+    expect(captured).toHaveLength(0);
+    expect(emitter.getStats().errors).toBe(1);
+  });
+
+  it('CATCHES a journal throw — never propagates', () => {
+    const c = clock();
+    const emitter = new ReplicatedRecordEmitter({
+      journal: { emitReplicatedRecord: () => { throw new Error('journal boom'); } },
+      clock: c,
+      registry: registry(),
+      origin: ORIGIN,
+      stores: () => ({ learnings: { enabled: true } }),
+      loadWitness: () => undefined,
+    });
+    expect(() => emitter.emit(LEARNING_STORE_KEY, 'rk1', PUT_BUILD)).not.toThrow();
+    expect(emitter.getStats().errors).toBe(1);
+  });
+});
+
+describe('ReplicatedRecordEmitter — observed witness (§7.2)', () => {
+  it('omits observed on the first write (no prior witness)', () => {
+    const { emitter, captured } = makeEmitter({ stores: { learnings: { enabled: true } }, witness: undefined });
+    emitter.emit(LEARNING_STORE_KEY, 'rk1', PUT_BUILD);
+    expect(captured[0].data.observed).toBeUndefined();
+  });
+
+  it('supplies the prior witness AND ticks strictly after it (observed < hlc)', () => {
+    const prior: HlcTimestamp = { physical: 1000, logical: 0, node: 'm_peer' };
+    // A clock seeded so its first tick is strictly after `prior`.
+    const c = new HybridLogicalClock({ node: ORIGIN, now: () => 2000 });
+    const { emitter, captured } = makeEmitter({ stores: { learnings: { enabled: true } }, witness: prior, clockImpl: c });
+    emitter.emit(LEARNING_STORE_KEY, 'rk1', PUT_BUILD);
+    const observed = captured[0].data.observed as HlcTimestamp;
+    const hlc = captured[0].data.hlc as HlcTimestamp;
+    expect(observed).toEqual(prior);
+    // The witness is read BEFORE the tick, so the emitted hlc is strictly greater.
+    expect(HybridLogicalClock.compare(hlc, observed)).toBeGreaterThan(0);
+  });
+});
+
+describe('ReplicatedRecordEmitter — construction guards', () => {
+  it('throws on a null/no-op seam (wiring-integrity)', () => {
+    expect(() => new ReplicatedRecordEmitter({
+      // @ts-expect-error intentional null seam
+      journal: null, clock: clock(), registry: registry(), origin: ORIGIN, stores: () => undefined, loadWitness: () => undefined,
+    })).toThrow(/journal/);
+    expect(() => new ReplicatedRecordEmitter({
+      journal: { emitReplicatedRecord: () => {} }, clock: clock(), registry: registry(), origin: '',
+      stores: () => undefined, loadWitness: () => undefined,
+    })).toThrow(/origin/);
+  });
+});

--- a/upgrades/next/ws2-send-side-emission.md
+++ b/upgrades/next/ws2-send-side-emission.md
@@ -1,0 +1,63 @@
+# Upgrade Guide — WS2 send-side emission
+
+<!-- bump: minor -->
+
+## What Changed
+
+The send half of multi-machine memory replication is now wired. The WS2 substrate
+shipped the replicated-kind registry, the receive/apply machinery, and the
+capability advert, but the journal-backed emitter that the per-store managers' write
+hooks call was never constructed — so memory records were never written to the
+coherence-journal own-streams, and a peer had nothing to pull (root-caused live on a
+Laptop↔Mac-Mini pair).
+
+This change adds the generic, store-agnostic `ReplicatedRecordEmitter` (HLC tick +
+last-writer-witness + the store's record builder + journal append, behind the
+per-store dark gate), closes the three matching gaps so a record crosses end-to-end —
+the journal can now append/validate a `*-record` kind, the applier accepts a peer's
+`*-record` instead of suspect-flagging the stream, and the union read materializes
+own + peer journal streams (so a received record is readable) — and replaces the
+snapshot-serve `loadOwnEntries` stub with a real own-stream loader. The first kind,
+`learnings`, is wired end-to-end; the remaining memory stores follow on the same
+machinery (tracked in the send-wiring manifest). A wiring-integrity ratchet now fails
+CI if a future replicated kind is added receive-only with no send path.
+
+Everything is gated behind the per-store multi-machine memory-sync switch (off by
+default; the development-agent gate flips it live on a dev agent only). Records ride
+the existing journal-sync tail and pull — no new HTTP route or mesh verb.
+
+## What to Tell Your User
+
+- **Cross-machine memory (lessons) now actually crosses**: "If you run me on more than
+  one machine, a lesson I learn on one is now known on the others — one shared learning
+  registry instead of one per machine. A copy from another machine is always treated as
+  a hint, never as the boss: it never silently overwrites what this machine already
+  believes, and if two machines disagree I surface both and flag it for you. It stays
+  off until you ask me to turn on multi-machine memory sync."
+
+## Summary of New Capabilities
+
+| Capability | How to Use |
+|-----------|-----------|
+| Cross-machine replication of learned lessons (learnings) | Automatic once multi-machine memory sync is enabled for the store (off by default) |
+| A received peer memory is readable through the no-clobber union read | Automatic (read path) |
+| Snapshot serve returns real own-stream entries | Automatic (bootstrap path) |
+| Wiring-integrity ratchet — no new kind can ship receive-only | CI test (automatic) |
+
+## Evidence
+
+The live gap: after the receive-advert fix (#1167) deployed to both machines, a
+learning written on the Laptop never appeared on the Mac-Mini after 5+ minutes; the
+Laptop's coherence-journal meta listed only the 5 lifecycle kinds — none of the 7 WS2
+record kinds — proving no record was ever emitted to an own-stream.
+
+Verified by a two-instance in-process E2E
+(tests/e2e/ws2-learnings-cross-instance.test.ts): a learning written on instance A,
+shipped over the real journal serve/apply path, is read back on instance B through the
+bypass-proof union reader as a foreign-origin record; a markApplied edit replicates and
+the latest wins; the same lesson learned on both machines collapses to one record key
+across origins. Before this change B's union read returned null (the reproduced bug);
+after, it returns A's record. Plus integration (serve→apply→read, forged-batch
+rejection, snapshot serve returns entries) and unit coverage (emitter dark-gate /
+witness-order / throw-isolation, journal record append + op-key dedup + 80 KB cap, peer
+stream materialization). 32 new tests, all green.

--- a/upgrades/side-effects/ws2-send-side-emission.md
+++ b/upgrades/side-effects/ws2-send-side-emission.md
@@ -1,0 +1,40 @@
+# Side-Effects Review — WS2 send-side emission (wire the journal-backed replicated-record emitter)
+
+**Spec:** docs/specs/WS2-SEND-SIDE-EMISSION-SPEC.md (converged + approved — operator pre-approval, Justin topic 13481, the multi-machine memory-replication headline). **Parent:** Cross-Machine Coherence — One Agent, Robust Under Degraded Conditions.
+**Ships DARK** behind `multiMachine.stateSync.<store>.enabled` (default false; the dev-agent gate flips it live on a dev agent only). Single-machine installs, and any agent with the stores off, are a strict no-op.
+**Files:** src/core/ReplicatedRecordEmitter.ts (new), src/core/ReplicatedPeerStreamReader.ts (new), src/core/ws2SendWiring.ts (new), src/core/CoherenceJournal.ts, src/core/JournalSyncApplier.ts, src/commands/server.ts.
+
+## What changed
+
+1. **ReplicatedRecordEmitter.ts (new):** the generic, store-agnostic, journal-backed emitter the per-store managers' existing `emitPut`/`emitDelete` hooks call. One `emit(store, recordKey, build)` path: dark gate → degenerate-key guard → `observed` witness → HLC tick → store builder → `journal.emitReplicatedRecord`. Never throws into the manager (a builder/journal fault is a counted no-op). Single-origin by construction (stamps `origin = this machine`).
+2. **ReplicatedPeerStreamReader.ts (new):** materializes the union's per-origin records from the OWN journal stream + every peer replica stream (`peers/<M>.<kind>.jsonl`, quarantine/meta excluded), validated through `validateReplicatedEnvelope` + the store schema, folded to the latest per (origin, recordKey) by HLC. Supplies three seams: `loadOriginRecords`/`listRecordKeys` (the union reader), `loadWitness` (the emitter's `observed` source), and `loadOwnEntries` (the snapshot-serve source — replaces the `() => ({})` stub).
+3. **ws2SendWiring.ts (new):** the send-wiring manifest (WIRED vs PENDING stores) + the `auditWs2SendWiring` ratchet — every registered replicated kind must be consciously classified, so a future kind cannot be added receive-only with a silent no-op SEND half.
+4. **CoherenceJournal.ts:** optional `setReplicatedKindRegistry`; new public `emitReplicatedRecord(kind, data)` (validates a registered `*-record` kind through the generic envelope validator, op-key = `recordKey:hlcKey`); the `validate()` switch gains ONE branch delegating a registered replicated kind to `validateReplicatedEnvelope`; the per-entry byte cap is per-kind (80 KB for `*-record` kinds, the 8 KB lifecycle cap unchanged). Absent registry ⇒ byte-identical prior behavior.
+5. **JournalSyncApplier.ts:** optional `setReplicatedKindRegistry` (+ config option); `validateData()` delegates a registered replicated kind to `validateReplicatedEnvelope`; the per-entry size cap is per-kind (matching the writer). Without the registry a peer's `*-record` would `invalid`-flag the stream — the receive-only gap; with it, the record applies on the existing tail transport.
+6. **server.ts:** constructs (when the coherence journal is live) the peer-stream reader + a persisted HLC clock + the generic emitter; injects the now-populated registry into BOTH the journal writer and the applier; replaces the `loadOwnEntries` stub with the reader; switches the `learnings` union reader to read own + peer journal streams; attaches the learnings emitter adapter to `EvolutionManager.setLearningReplicationEmitter`.
+
+## Blast radius
+
+- **Config-gated, not wiring-gated.** With `multiMachine.stateSync.learnings.enabled` false (the fleet default), the emitter is a strict no-op (the dark gate returns before any tick/append), so no `*-record` stream is ever written and the union read is byte-identical to today. The seams are always constructed (so the feature turns on without a restart-to-rewire) but do nothing until the store is enabled.
+- **No new HTTP route, no new MeshRpc verb.** Records ride the EXISTING `journal-sync` tail (`buildServeBatch` serve + `apply` receive) and the EXISTING receiver-driven `PeerPresencePuller.driveJournalDelta` (which already pulls every advertised kind). The `state-snapshot` serve verb (already wired) now returns real entries via the real `loadOwnEntries`.
+- **Single-origin + first-hop binding unchanged.** The emitter stamps `origin = this machine`; the applier's first-hop binding (`entry.machine === sender`) still rejects a forged cross-origin record. A peer's record lands only in its own `peers/<M>.<kind>.jsonl` namespace; the union read keeps origins separate and never writes a foreign record back into the local manager store (read-only union, no origin laundering).
+- **No-clobber read.** A received record is read through the existing `ReplicatedStoreReader` + `UnionReader` (append-both-and-flag for high-impact); a replicated record never clobbers a divergent local one. The conflict ledger + dropped-origin exclusion are untouched.
+
+## Risk + mitigation
+
+- **Risk:** a replication emit fault breaks a local memory write. **Mitigation:** the emitter catches every builder/journal throw (counted in stats), and the managers' hooks were already try-wrapped — the durable local write is persisted before the emit hook runs. Proven by the "catches a builder/journal throw" unit tests.
+- **Risk:** a wrong `observed` witness marks a genuinely-concurrent pair as sequential (a silent clobber). **Mitigation:** the witness is the MAX HLC over records PROVABLY on disk, read BEFORE the tick — it can only ever under-witness (a not-yet-pulled peer version is absent ⇒ the pair flags concurrent, the err-toward-flag safe direction). Proven by the witness-order unit test.
+- **Risk:** a fat-but-legal learning is dropped as oversize. **Mitigation:** the per-entry byte cap is raised to 80 KB for `*-record` kinds on BOTH the writer and the applier (the store builders already cap `data` at 64 KB), so a record the writer emits is never rejected on receive. Proven by the 20 KB-description journal test.
+- **Risk:** a future kind is added receive-only again (the exact original gap). **Mitigation:** the wiring-integrity ratchet (`auditWs2SendWiring`) fails CI if any registered store is neither send-wired nor explicitly send-pending.
+
+## Migration parity
+
+- No agent-installed files change. The feature is server-internal and activates on the next restart of an agent whose `multiMachine.stateSync.<store>` is enabled (the dev-agent gate decides for a dev agent). No `migrateConfig` / `migrateClaudeMd` / `migrateHooks` change is required for the dark slice; CLAUDE.md awareness lands when a kind is flipped on for the fleet (a later rollout step).
+
+## Dark-gate line-map
+
+- UNCHANGED. This PR adds no new `enabled:` line to `ConfigDefaults.ts` — the per-store stateSync flags already exist there (omitted `enabled`, resolved by the dev-agent gate, shipped in the WS2.x substrate PRs). The emitter reads the SAME resolved `_stateSyncStoresResolved` map. `node scripts/lint-dev-agent-dark-gate.js` stays clean.
+
+## Rollback
+
+- Revert the PR (or set `multiMachine.stateSync.learnings.enabled: false`). The emitter goes dark, no `*-record` streams are written, the union read returns to own-only/no-op, and any already-replicated peer replica files age out under the journal's per-kind retention. No durable migration to unwind.


### PR DESCRIPTION
## WS2 send-side emission — wire the journal-backed replicated-record emitter

The second, load-bearing layer of the multi-machine memory-replication headline. #1167 fixed the receive-advert (each machine now correctly reports the peer's `stateSyncReceive` = 7). **This makes records actually cross.**

### The gap (root-caused live on Laptop↔Mac-Mini, 2026-06-15)

After #1167 a learning written on the Laptop still never appeared on the Mini. The Laptop's coherence-journal meta listed only the 5 lifecycle kinds — **none of the 7 WS2 `*-record` kinds** — proving WS2 records were never written to the journal own-streams. WS2 shipped as substrate (registry + receive/apply machinery + advert) with the SEND half unimplemented:

- The per-store managers (`EvolutionManager`, `RelationshipManager`, …) already call an internal `emitPut`/`emitDelete` hook on every write — but server.ts never constructed the concrete journal-backed emitter those hooks call (two sites explicitly defer it: "the journal-backed emitter is attached in a later rollout stage"). The hooks fired into a `null` emitter (no-op).
- Three matching gaps blocked a record from crossing even if emitted: the journal couldn't validate/append a `*-record` kind, the applier rejected a peer's `*-record` (suspect-flagging the stream), and the union read only ever looked at the own origin.
- `StoreSnapshotEngine` was constructed with `loadOwnEntries: () => ({})` — the literal Step-3 stub.

### What this PR builds (all kind-agnostic)

1. **`ReplicatedRecordEmitter`** (new) — the generic journal-backed emitter the managers' hooks call: dark gate → degenerate-key guard → `observed` last-writer-witness → HLC tick → store builder → `journal.emitReplicatedRecord`. Never throws into the manager; single-origin by construction.
2. **`CoherenceJournal`** — `emitReplicatedRecord(kind, data)` + a `validate()` branch delegating a registered `*-record` kind to `validateReplicatedEnvelope`; op-key = `recordKey:hlcKey`; per-kind 80 KB entry cap so a fat learning isn't dropped. Registry injected optionally (absent ⇒ unchanged).
3. **`JournalSyncApplier`** — `validateData()` delegates a registered `*-record` kind to the same validator; per-kind cap matching the writer. The receive-only gap closed.
4. **`ReplicatedPeerStreamReader`** (new) — materializes own + peer journal streams into the union's per-origin records (a received record is now readable), and supplies the real `loadOwnEntries` + the emitter's `observed` witness.
5. **server.ts** — constructs the emitter + reader + persisted HLC clock, injects the registry into journal + applier, replaces the `loadOwnEntries` stub, and wires the **learnings** emitter end-to-end.
6. **`ws2SendWiring`** (new) — a send-wiring manifest + a wiring-integrity ratchet that fails CI if a future replicated kind is added receive-only.

### Scope

Per the build brief's scope-honesty clause, this ships the COMPLETE generic machinery and wires **learnings** end-to-end with a passing two-instance E2E. The other seamed stores (relationships, knowledge, userRegistry, evolutionActions) are table rows on the same emitter (WS2-SEND-2); preferences (no manager emit seam yet) + topicOperator delete-emission are WS2-SEND-3; the snapshot-pull bootstrap caller is WS2-SEND-4. The ratchet enumerates exactly which kinds are wired vs pending. Everything ships **dark** behind `multiMachine.stateSync.<store>.enabled` (default false; dev-agent gate live).

### Tests (all 3 tiers + the ratchet — 32 new, green)

- **Unit**: emitter dark-gate / witness-order / throw-isolation; journal record append + op-key dedup + 80 KB cap + malformed-reject; peer-stream materialization (own+peer fold, tombstone, witness, loadOwnEntries single-origin).
- **Integration**: emit → `buildServeBatch` → `apply` → peer-stream read; forged-batch rejection; `serveSnapshot` returns real entries.
- **E2E (the real proof)**: a learning written on instance A is readable on instance B through the bypass-proof union reader as a foreign-origin record; markApplied replicates (latest wins); the same lesson collapses to one record key across origins. **This reproduces and closes the live gap.**
- **Wiring-integrity ratchet**: every registered replicated kind is consciously send-wired or send-pending; learnings is wired.

## ELI16

If you run your agent on more than one machine — a laptop and a Mac mini, say — the goal of the multi-machine memory work is that a memory the agent forms on one machine (a lesson it learned) is also known on the other. An earlier fix made the two machines correctly announce "yes, send me your memories." But when tested live, a lesson written on the laptop never showed up on the mini.

The reason: it's like two offices that agreed to share filing cabinets, but the laptop was never actually putting its files in the outbox. Each kind of memory already had a "drop a copy in the outbox" button wired up — but the button wasn't connected to anything (the code literally said "we'll connect the real outbox later," and later never came). So every memory write pressed a button that did nothing, and the outbox stayed empty. Nothing to copy means nothing crosses.

This change connects the outbox and three smaller things needed for a copy to make it across: the shared log now accepts the new memory types, the receiving machine accepts them, and reading now also looks at the copies received from other machines (before, it only ever looked at its own machine's drawer).

It's off by default — nothing replicates unless multi-machine memory sync is explicitly on for that memory type. A memory copied from another machine is always a hint, never the boss: it never silently overwrites what your machine already believes, and if two machines disagree the agent shows both and flags it rather than picking a winner behind your back. The most important test starts two agents in one test, writes a lesson on the first, ships it across exactly the way the real machines do, and checks the second can read it — the live bug, reproduced so it can never silently break again. A guard test fails the build if anyone ever adds a memory type that can be received but not sent (the exact mistake that caused this).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
