### PR TITLE
feat(multi-machine): WS2-SEND-2 wire relationships send-side replication

### DIFF
--- a/.instar/instar-dev-decisions/2026-06-15T16-48-17-663Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-06-15T16-48-17-663Z-unknown.json
@@ -1,0 +1,13 @@
+{
+  "ts": "2026-06-15T16:48:17.663Z",
+  "slug": "unknown",
+  "suggestedTier": 1,
+  "declaredTier": 2,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 2,
+  "loc": 35,
+  "causalAutopsy": null,
+  "verdict": "pass"
+}

--- a/src/commands/server.ts
+++ b/src/commands/server.ts
@@ -3923,7 +3923,7 @@ export async function startServer(options: StartOptions): Promise<void> {
     // (= that one local record). tierOf returns HIGH (append-both-and-flag never
     // silently clobbers two divergent people). Consulted by the relationships peer-read
     // surface ONLY when stateSync.relationships.enabled is true.
-    const { relationshipTierOf, relationshipToOriginRecord, deriveRelationshipRecordKey, mergeUnionToRelationships, renderForeignRelationshipContext, RELATIONSHIP_STORE_KEY } = await import('../core/RelationshipsReplicatedStore.js');
+    const { relationshipTierOf, relationshipToOriginRecord, deriveRelationshipRecordKey, buildRelationshipRecordData, buildRelationshipTombstoneData, mergeUnionToRelationships, renderForeignRelationshipContext, RELATIONSHIP_STORE_KEY } = await import('../core/RelationshipsReplicatedStore.js');
     const relationshipsUnionReader = new ReplicatedStoreReader({
       registry: replicatedKindRegistry,
       stores: _stateSyncStoresResolved, // gate-resolved (dev-live / fleet-dark) per operator directive 2026-06-13
@@ -8536,6 +8536,35 @@ export async function startServer(options: StartOptions): Promise<void> {
             LEARNING_STORE_KEY,
             deriveLearningRecordKey(title, category, source),
             (hlc, origin, observed) => buildLearningTombstoneData({ title, category, source, hlc, origin, deletedAt, observed }),
+          ),
+      });
+    }
+
+    // WS2.3 SEND-SIDE: attach the journal-backed emitter to the RelationshipManager's
+    // replication hooks. The manager already fires emitPut on every saved person and
+    // emitDelete on erase/merge (RelationshipManager.setReplicationEmitter); the adapter
+    // maps the manager's emit signature to the relationship build*RecordData projection.
+    // The generic emitter owns the dark gate, HLC tick, `observed` witness, journal
+    // append, and ALL the safety guards (null recordKey ⇒ skip, null projection ⇒ skip,
+    // over-cap throw ⇒ counted no-op) — so the adapter mirrors learnings with no extra
+    // guarding. Attached only when the emitter exists (journal live) AND the manager is
+    // constructed; when stateSync.relationships is dark the hooks stay no-ops (byte-
+    // identical single-machine behavior — the local UUID id never crosses; only the
+    // disclosure-minimized, channel-keyed projection does — REQ-M4).
+    if (replicatedRecordEmitter && relationships) {
+      const emitter = replicatedRecordEmitter;
+      relationships.setReplicationEmitter({
+        emitPut: (rec) =>
+          emitter.emit(
+            RELATIONSHIP_STORE_KEY,
+            deriveRelationshipRecordKey(rec.channels),
+            (hlc, origin, observed) => buildRelationshipRecordData({ record: rec, hlc, origin, observed }),
+          ),
+        emitDelete: (channels, deletedAt) =>
+          emitter.emit(
+            RELATIONSHIP_STORE_KEY,
+            deriveRelationshipRecordKey(channels),
+            (hlc, origin, observed) => buildRelationshipTombstoneData({ channels, hlc, origin, deletedAt, observed }),
           ),
       });
     }

--- a/src/core/ws2SendWiring.ts
+++ b/src/core/ws2SendWiring.ts
@@ -20,19 +20,19 @@
  *  follow on the SAME emitter (WS2-SEND-2). */
 export const WS2_SEND_WIRED_STORES: ReadonlyArray<string> = Object.freeze([
   'learnings',
+  'relationships',
 ]);
 
 /**
  * Stores registered for RECEIVE but whose SEND wiring is a KNOWN, enumerated
  * follow-up — NOT a silent omission. Each is here for a stated reason:
- *  - relationships / knowledge / evolutionActions / userRegistry: fully seamed
+ *  - knowledge / evolutionActions / userRegistry: fully seamed
  *    managers (emitPut + emitDelete); table-row wiring onto the same emitter (WS2-SEND-2).
  *  - topicOperator: seamed put-only (no emitDelete in its manager interface yet) (WS2-SEND-3).
  *  - preferences: NO manager emit seam yet — it rode the deprecated `preferences-sync`
  *    verb; needs a manager emit hook before it can be wired (WS2-SEND-3).
  */
 export const WS2_SEND_PENDING_STORES: ReadonlyArray<string> = Object.freeze([
-  'relationships',
   'knowledge',
   'evolutionActions',
   'userRegistry',

--- a/tests/e2e/ws2-relationships-cross-instance.test.ts
+++ b/tests/e2e/ws2-relationships-cross-instance.test.ts
@@ -1,0 +1,180 @@
+// safe-fs-allow: test fixture teardown uses SafeFsExecutor.safeRmSync on tmp dirs only.
+/**
+ * E2E — WS2 send-side: a relationship (person) recorded on instance A is READABLE on
+ * instance B (the SAME proof shape that closed the learnings gap, applied to the
+ * `relationships` store — WS2-SEND-2).
+ *
+ * Two in-process instances with separate stateDirs, each wired exactly as server.ts
+ * wires them:
+ *   - A: RelationshipManager + journal-backed emitter (emission enabled) + journal.
+ *   - B: JournalSyncApplier + ReplicatedPeerStreamReader + a ReplicatedStoreReader
+ *        (the bypass-proof no-clobber union — the SAME funnel the server uses).
+ * A.findOrCreate → A's journal own-stream → serve → B.apply → B's `relationships`
+ * union read returns A's person as a foreign-origin record. Also proves a delete
+ * replicates as a channel-keyed TOMBSTONE (REQ-D4) and the union resolves the key to
+ * "no record". Identity across machines is the CHANNEL SET, never the local UUID.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+
+import { CoherenceJournal } from '../../src/core/CoherenceJournal.js';
+import { JournalSyncApplier } from '../../src/core/JournalSyncApplier.js';
+import { ReplicatedPeerStreamReader } from '../../src/core/ReplicatedPeerStreamReader.js';
+import { ReplicatedRecordEmitter } from '../../src/core/ReplicatedRecordEmitter.js';
+import { ReplicatedStoreReader } from '../../src/core/ReplicatedStoreReader.js';
+import { ReplicatedKindRegistry } from '../../src/core/ReplicatedRecordEnvelope.js';
+import { ConflictStore } from '../../src/core/ConflictStore.js';
+import { DroppedOriginRegistry } from '../../src/core/RollbackUnmerge.js';
+import { RelationshipManager } from '../../src/core/RelationshipManager.js';
+import { HybridLogicalClock } from '../../src/core/HybridLogicalClock.js';
+import {
+  RELATIONSHIP_KIND_REGISTRATION,
+  RELATIONSHIP_RECORD_KIND,
+  RELATIONSHIP_STORE_KEY,
+  relationshipTierOf,
+  buildRelationshipRecordData,
+  buildRelationshipTombstoneData,
+  deriveRelationshipRecordKey,
+} from '../../src/core/RelationshipsReplicatedStore.js';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+import type { UserChannel } from '../../src/core/types.js';
+
+const A = 'm_laptop';
+const B = 'm_mac_mini';
+
+function reg(): ReplicatedKindRegistry {
+  const r = new ReplicatedKindRegistry();
+  r.register(RELATIONSHIP_KIND_REGISTRATION);
+  return r;
+}
+
+interface Instance {
+  dir: string;
+  registry: ReplicatedKindRegistry;
+  journal: CoherenceJournal;
+  applier: JournalSyncApplier;
+  reader: ReplicatedPeerStreamReader;
+  relationships: RelationshipManager;
+  unionReader: ReplicatedStoreReader;
+}
+
+function makeInstance(machineId: string, label: string): Instance {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), `ws2e2e-rel-${label}-`));
+  const registry = reg();
+  const journal = new CoherenceJournal({ stateDir: dir, machineId, flushIntervalMs: 1_000_000 });
+  journal.open();
+  journal.setReplicatedKindRegistry(registry);
+  const applier = new JournalSyncApplier({ stateDir: dir, replicatedRegistry: registry });
+  const reader = new ReplicatedPeerStreamReader({ stateDir: dir, registry, selfMachineId: machineId });
+  const relationships = new RelationshipManager({ relationshipsDir: path.join(dir, 'relationships'), maxRecentInteractions: 10 });
+
+  // Emitter (the SEND wiring) — emission ENABLED for relationships.
+  const emitter = new ReplicatedRecordEmitter({
+    journal,
+    clock: new HybridLogicalClock({ node: machineId, now: () => Date.now() }),
+    registry,
+    origin: machineId,
+    stores: () => ({ relationships: { enabled: true } }),
+    loadWitness: (store, rk) => reader.loadWitness(store, rk),
+  });
+  relationships.setReplicationEmitter({
+    emitPut: (rec) => emitter.emit(RELATIONSHIP_STORE_KEY, deriveRelationshipRecordKey(rec.channels),
+      (hlc, o, observed) => buildRelationshipRecordData({ record: rec, hlc, origin: o, observed })),
+    emitDelete: (channels, deletedAt) => emitter.emit(RELATIONSHIP_STORE_KEY, deriveRelationshipRecordKey(channels),
+      (hlc, o, observed) => buildRelationshipTombstoneData({ channels, hlc, origin: o, deletedAt, observed })),
+  });
+
+  // The bypass-proof union reader (the SAME funnel + seams the server wires).
+  const unionReader = new ReplicatedStoreReader({
+    registry,
+    stores: { relationships: { enabled: true } },
+    tierOf: relationshipTierOf,
+    loadOriginRecords: (store, rk) => reader.loadOriginRecords(store, rk),
+    listRecordKeys: (store) => reader.listRecordKeys(store),
+    droppedOrigins: new DroppedOriginRegistry({ stateDir: dir }),
+    conflictStore: new ConflictStore({ stateDir: dir, now: () => new Date() }),
+  });
+
+  return { dir, registry, journal, applier, reader, relationships, unionReader };
+}
+
+/** Ship every NEW own relationship-record entry from `from` to `to` (the journal
+ *  serve/apply path, first-hop bound). Returns the cursor to resume from next time. */
+function replicate(from: Instance, fromMachineId: string, to: Instance, fromSeq: number): number {
+  from.journal.flush();
+  const served = from.applier.buildServeBatch(RELATIONSHIP_RECORD_KIND, fromSeq, fromMachineId);
+  if (served.entries.length === 0) return fromSeq;
+  to.applier.apply(fromMachineId, [served]);
+  return served.entries[served.entries.length - 1].seq;
+}
+
+const tg = (id: string): UserChannel => ({ type: 'telegram', identifier: id });
+
+describe('E2E — a person recorded on A is readable on B (WS2.3 send-side)', () => {
+  let a: Instance;
+  let b: Instance;
+
+  beforeEach(() => {
+    a = makeInstance(A, 'a');
+    b = makeInstance(B, 'b');
+  });
+  afterEach(() => {
+    for (const inst of [a, b]) {
+      try { inst.journal.close(); } catch { /* best-effort */ }
+      SafeFsExecutor.safeRmSync(inst.dir, { recursive: true, force: true, operation: 'tests/e2e/ws2-relationships-cross-instance.test.ts' });
+    }
+  });
+
+  it('findOrCreate on A becomes readable through B\'s union reader as a foreign-origin record', () => {
+    const rec = a.relationships.findOrCreate('Alice', tg('12345'));
+    const rk = deriveRelationshipRecordKey(rec.channels)!;
+
+    // B sees nothing yet (no replication has happened).
+    expect(b.unionReader.read(RELATIONSHIP_STORE_KEY, rk).value).toBeNull();
+
+    // Replicate A → B over the real serve/apply path.
+    replicate(a, A, b, 0);
+
+    // B's union read now returns A's person — a foreign-origin record, channel-keyed.
+    const result = b.unionReader.read(RELATIONSHIP_STORE_KEY, rk);
+    expect(result.value).not.toBeNull();
+    expect(result.value!.origin).toBe(A);
+    expect(result.value!.data.name).toBe('Alice');
+    expect((result.value!.data.channels as UserChannel[]).some((c) => c.identifier === '12345')).toBe(true);
+    // The local UUID is NEVER replicated (identity is the channel set, REQ-M4/D17).
+    expect((result.value!.data as Record<string, unknown>).id).toBeUndefined();
+    // And it appears in B's full key listing.
+    expect(b.unionReader.readAll(RELATIONSHIP_STORE_KEY).has(rk)).toBe(true);
+  });
+
+  it('a delete on A replicates as a channel-keyed tombstone and the union resolves the key to no-record', () => {
+    const rec = a.relationships.findOrCreate('Bob', tg('67890'));
+    const rk = deriveRelationshipRecordKey(rec.channels)!;
+    let cursor = replicate(a, A, b, 0);
+    expect(b.unionReader.read(RELATIONSHIP_STORE_KEY, rk).value).not.toBeNull();
+
+    // Erase Bob on A, replicate the tombstone.
+    expect(a.relationships.delete(rec.id)).toBe(true);
+    cursor = replicate(a, A, b, cursor);
+    expect(cursor).toBeGreaterThan(0);
+
+    // B resolves the key to "no record" (an explicit tombstone, not a record absence).
+    expect(b.unionReader.read(RELATIONSHIP_STORE_KEY, rk).value).toBeNull();
+  });
+
+  it('the SAME person (same channel set) on BOTH machines collapses to ONE recordKey across origins', () => {
+    const recA = a.relationships.findOrCreate('Carol', tg('55555'));
+    b.relationships.findOrCreate('Carol', tg('55555'));
+
+    // A replicates to B; flush B so its OWN emitted record is durable on disk too.
+    replicate(a, A, b, 0);
+    b.journal.flush();
+    const rk = deriveRelationshipRecordKey(recA.channels)!;
+    const origins = b.reader.loadOriginRecords(RELATIONSHIP_STORE_KEY, rk);
+    expect(origins.map((o) => o.origin).sort()).toEqual([A, B].sort());
+    // ONE key, not two — the channel-set identity surface collapsed the same person.
+    expect(b.reader.listRecordKeys(RELATIONSHIP_STORE_KEY)).toEqual([rk]);
+  });
+});

--- a/upgrades/next/ws2-send-2-relationships.md
+++ b/upgrades/next/ws2-send-2-relationships.md
@@ -1,0 +1,54 @@
+# Upgrade Guide — WS2-SEND-2: relationships send-side replication
+
+<!-- bump: patch -->
+
+## What Changed
+
+The `relationships` memory store is now wired into the WS2 send-side, the first of the
+four "table-row" stores the WS2-SEND-SIDE-EMISSION-SPEC enumerated as the WS2-SEND-2
+follow-on. #1168 proved the generic `ReplicatedRecordEmitter` machinery end-to-end for
+`learnings`; this change attaches that same emitter to the `RelationshipManager`'s
+existing write hooks (the manager already fired `emitPut` on every saved person and
+`emitDelete` on erase/merge — the emitter was simply never attached), and flips
+`relationships` from PENDING to WIRED in the send-wiring ratchet (`ws2SendWiring.ts`).
+
+No new design: the disclosure-minimized projection (`buildRelationshipRecordData` /
+`buildRelationshipTombstoneData`), the channel-set identity surface, the receive-side
+schema, and the no-clobber union read all already shipped with the WS2.3 relationships
+work. This is the send attachment + its end-to-end proof. Everything stays behind the
+per-store dark gate (`multiMachine.stateSync.relationships`, off by default — the
+development-agent gate flips it live on a dev agent only). Records ride the existing
+journal-sync tail and pull — no new HTTP route or mesh verb.
+
+## What to Tell Your User
+
+- **Cross-machine relationships now actually cross**: "If you run me on more than one
+  machine, a person I know on one is now known on the others — one shared relationship
+  graph instead of one per machine. Only a disclosure-minimized, channel-keyed
+  projection crosses (never the raw record or the local id), a copy from another machine
+  is always a hint and never the authority on who is messaging you, and an erased person
+  stays erased everywhere via a tombstone. It stays off until you ask me to turn on
+  multi-machine relationship sync." ⚗️ Experimental — ships dark; the learnings slice is
+  the proven path and the remaining stores follow on the same wiring.
+
+## Summary of New Capabilities
+
+| Capability | How to Use |
+|-----------|-----------|
+| Cross-machine replication of known people (relationships) | Automatic once `multiMachine.stateSync.relationships` is enabled (off by default) |
+| Channel-keyed identity — same person on two machines collapses to one record | Automatic (read path) |
+| Erasure propagates as a channel-keyed tombstone (stays erased on offline-then-rejoining peers) | Automatic (delete path) |
+
+## Evidence
+
+Verified by a two-instance in-process E2E
+(`tests/e2e/ws2-relationships-cross-instance.test.ts`): a person recorded on instance A
+(`findOrCreate`), shipped over the real journal serve/apply path, is read back on
+instance B through the bypass-proof union reader as a foreign-origin record — and the
+local UUID is confirmed absent from the projection; a `delete` on A replicates as a
+channel-keyed tombstone and B's union read resolves the key to "no record"; the same
+person (same channel set) recorded on both machines collapses to one record key across
+origins. Before the attachment B's union read returned null; after, it returns A's
+record. `tsc --noEmit` clean; the new e2e (3) + the learnings e2e (3) pass; the
+ws2-send-wiring integration ratchet (4) accepts the PENDING→WIRED move; the existing
+`relationship-replication-emit` seam unit tests (6) stay green.

--- a/upgrades/side-effects/ws2-send-2-relationships.md
+++ b/upgrades/side-effects/ws2-send-2-relationships.md
@@ -1,0 +1,52 @@
+# Side-Effects Review — WS2-SEND-2: relationships send-side replication
+
+**Version / slug:** `ws2-send-2-relationships`
+**Date:** `2026-06-15`
+**Author:** `Instar Agent (echo)`
+**Second-pass reviewer:** `not required` (no block/allow/lifecycle authority — pure additive, dark-gated data-replication wiring; see §4)
+
+## Summary of the change
+
+Extends the WS2 send-side emission (proven end-to-end for `learnings` in #1168) to the `relationships` store — the first of the four "table-row" stores the WS2-SEND-SIDE-EMISSION-SPEC enumerates as WS2-SEND-2. Three edits, all mirroring the learnings slice: (1) `src/commands/server.ts` imports `buildRelationshipRecordData` + `buildRelationshipTombstoneData` and attaches the journal-backed `ReplicatedRecordEmitter` to `RelationshipManager.setReplicationEmitter` (emitPut/emitDelete → build\*RecordData), gated `if (replicatedRecordEmitter && relationships)`; (2) `src/core/ws2SendWiring.ts` moves `relationships` from `WS2_SEND_PENDING_STORES` to `WS2_SEND_WIRED_STORES`; (3) a new e2e round-trip test `tests/e2e/ws2-relationships-cross-instance.test.ts`. No decision-point surface is added — the only "decision" is the pre-existing dark gate (`isStoreEmissionEnabled`) inside the generic emitter.
+
+## Decision-point inventory
+
+- `ReplicatedRecordEmitter.emit` dark gate (`stateSync.relationships.enabled`) — **pass-through** — already exists; this change merely makes `relationships` a registered emit target. Default `false` ⇒ strict no-op.
+- `RelationshipManager.save`/`delete` emit funnel — **pass-through** — the manager already fires emitPut@904 / emitDelete@695,734; this change attaches a real emitter where there was `undefined` (no-op).
+- `ws2SendWiring` ratchet classification — **modify** — `relationships` reclassified PENDING→WIRED (it is now genuinely send-wired).
+
+---
+
+## 1. Over-block
+
+No block/allow surface — over-block not applicable. The emitter never rejects a manager write; a null recordKey / null projection / over-cap record is a counted no-op inside `emit()` and the local write always succeeds.
+
+## 2. Under-block
+
+Not applicable (no block surface). The one "miss" worth naming: a relationship with NO channels has no cross-machine identity surface (`deriveRelationshipRecordKey` → null) and is intentionally not replicated — by design (REQ-D17), not a gap; such a record is local-only and surfaces nowhere on the peer.
+
+## 3. Level-of-abstraction fit
+
+Correct layer. The generic `ReplicatedRecordEmitter` + `ReplicatedStoreReader` substrate (built in #1168) is the right home; this change is a table-row registration onto it, exactly as the spec's `tracked-next-work` (WS2-SEND-2) prescribes. No new parallel mechanism; the disclosure-minimized projection lives in `RelationshipsReplicatedStore` where the receive-side schema already lives.
+
+## 4. Signal vs authority compliance
+
+Compliant. This adds NO blocking authority. The emitter is an additive, best-effort signal-producer: a failure (builder throw, journal fault) is swallowed + counted, never propagated, so the manager's local write can never fail because replication did (`@silent-fallback-ok` documented at both call sites). The union read is advisory (HIGH tier = append-both-and-flag; it injects both variants as hints, never blocks). Per `docs/signal-vs-authority.md`, this is a detector/replicator with no gate authority.
+
+## 5. Interactions
+
+- Shares `server.ts`'s single `replicatedRecordEmitter` + the existing `relationshipsUnionReader` (already constructed @3927, previously unconsumed for send). No double-fire: emitPut rides the single `save()` persistence funnel; emitDelete rides the single `delete()` path.
+- Does not shadow or race learnings — distinct store key (`relationships` vs `learnings`), distinct journal kind (`relationship-record`).
+- Touches the same `server.ts` + `ws2SendWiring.ts` as the other five WS2-SEND stores → those PRs must SERIALIZE (stated in the run plan); no parallel WS2-SEND PRs.
+
+## 6. External surfaces
+
+Dark by default (`multiMachine.stateSync.relationships.enabled` defaults false). With the flag off: byte-identical single-machine behavior — nothing crosses the wire, no external surface changes. With the flag on (multi-machine, opt-in): the disclosure-minimized, channel-keyed projection of a relationship crosses to paired machines — NEVER the local UUID `id`, NEVER the raw on-disk blob (REQ-M4). A received record is rendered as quoted `<replicated-untrusted-data>`, never authoritative for inbound-principal identity resolution (which stays local-only, REQ-M14). At-rest honesty already documented in the WS2.3 spec + CLAUDE.md relationships section.
+
+## 7. Multi-machine posture (Cross-Machine Coherence)
+
+**Replicated** — this IS a cross-machine replication path. Replication path: `RelationshipManager.save/delete` → `ReplicatedRecordEmitter.emit` → `CoherenceJournal.emitReplicatedRecord` (own-stream) → peer serve/apply → `ReplicatedPeerStreamReader.loadOriginRecords` → `relationshipsUnionReader` (no-clobber union, conflict-flagged). Identity across machines = the CHANNEL SET (not the per-machine UUID), so the same person on two machines collapses to one recordKey. Deletes propagate as channel-keyed tombstones so an erased person stays erased even on an offline-then-rejoining peer (REQ-D4). No user-facing notice surface (no one-voice gating needed). No topic-transfer state to strand. No generated URLs.
+
+## 8. Rollback cost
+
+Trivial. The feature is dark by default; if wrong in production it affects only agents that explicitly enabled `stateSync.relationships`. Back-out = revert the three-file commit (or set the flag false — instant, no restart-coupled data migration). The receive-side + envelope schema already shipped and are unaffected. No data migration, no agent-state repair.


### PR DESCRIPTION
## ELI16

If you run this agent on more than one of your machines, it keeps a little address book of the people it talks to. Until now, that address book lived separately on each machine — a person it met on your laptop was a stranger on your Mac Mini. This change makes the *relationships* part of its memory actually travel between your machines, so it's one shared address book instead of one per computer.

It does this by reusing the exact pipe that was already proven for *lessons* in #1168 — the machinery existed, the relationships store just hadn't been plugged into it yet. Only a stripped-down, privacy-minimized version of each person crosses the wire (never the raw record, never the internal id), a copy from another machine is always treated as a hint and never as the authority on "who is messaging me," and deleting someone sends a tombstone so they stay deleted everywhere — even on a machine that was asleep when you deleted them. The whole thing is OFF by default and only turns on if you ask for multi-machine relationship sync. With it off, behavior on a single machine is byte-for-byte unchanged.

This is the first of four "table-row" stores in the WS2-SEND-2 follow-on enumerated by the send-side spec; the others (knowledge, evolution-actions, user-registry) follow on the same wiring.

## What Changed

- `src/commands/server.ts`: attach the journal-backed `ReplicatedRecordEmitter` to `RelationshipManager.setReplicationEmitter` (emitPut/emitDelete → `buildRelationship{Record,Tombstone}Data`), gated `if (replicatedRecordEmitter && relationships)`, mirroring the learnings attachment.
- `src/core/ws2SendWiring.ts`: move `relationships` from `WS2_SEND_PENDING_STORES` → `WS2_SEND_WIRED_STORES`.
- `tests/e2e/ws2-relationships-cross-instance.test.ts`: new two-instance round-trip proof.

Dark by default (`multiMachine.stateSync.relationships`). No new route/verb/config-default/migration — the receive-side + envelope schema already shipped (WS2.3).

## Evidence

`tsc --noEmit` clean. New e2e (3) + learnings e2e (3) pass; ws2-send-wiring ratchet (4) accepts PENDING→WIRED; relationship-replication-emit seam unit tests (6) green. Proves: person recorded on A is readable on B as foreign-origin (local UUID absent from projection); delete → channel-keyed tombstone resolves to no-record; same channel-set person collapses to one recordKey across origins.

Spec: `docs/specs/WS2-SEND-SIDE-EMISSION-SPEC.md` (WS2-SEND-2). Side-effects: `upgrades/side-effects/ws2-send-2-relationships.md`.