### PR TITLE
feat(multi-machine): WS2-SEND-2 wire knowledge send-side replication

### DIFF
--- a/.instar/instar-dev-decisions/2026-06-15T17-07-23-439Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-06-15T17-07-23-439Z-unknown.json
@@ -1,0 +1,13 @@
+{
+  "ts": "2026-06-15T17:07:23.439Z",
+  "slug": "unknown",
+  "suggestedTier": 1,
+  "declaredTier": 2,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 2,
+  "loc": 35,
+  "causalAutopsy": null,
+  "verdict": "pass"
+}

--- a/src/commands/server.ts
+++ b/src/commands/server.ts
@@ -8590,6 +8590,8 @@ export async function startServer(options: StartOptions): Promise<void> {
       knowledgeTierOf,
       knowledgeToOriginRecord,
       deriveKnowledgeRecordKey,
+      buildKnowledgeRecordData,
+      buildKnowledgeTombstoneData,
       KNOWLEDGE_STORE_KEY,
     } = await import('../core/KnowledgeReplicatedStore.js');
     const knowledgeUnionReader = new ReplicatedStoreReader({
@@ -8619,7 +8621,34 @@ export async function startServer(options: StartOptions): Promise<void> {
       conflictStore,
     });
     void knowledgeUnionReader; // consumed by the knowledge peer-read surface + the journal-apply rollout stage (WS2.4+)
-    void knowledgeManager.setKnowledgeReplicationEmitter; // the emit seam exists (unit-tested + dark by default); the journal-backed emitter is attached in a later rollout stage, mirroring the WS2.2 learnings sibling
+
+    // WS2.4 SEND-SIDE: attach the journal-backed emitter to the KnowledgeManager's
+    // replication hooks. The manager already fires emitPut on every ingested source and
+    // emitDelete on remove() (KnowledgeManager.setKnowledgeReplicationEmitter); the adapter
+    // maps the manager's emit signature to the knowledge build*RecordData projection. The
+    // generic emitter owns the dark gate, HLC tick, `observed` witness, journal append, and
+    // ALL the safety guards (null recordKey ⇒ skip, null projection ⇒ skip, over-cap throw ⇒
+    // counted no-op) — so the adapter mirrors learnings/relationships with no extra guarding.
+    // Only the catalog METADATA crosses (title/url/type/tags/summary/wordCount) — NEVER the
+    // markdown file body, NEVER the local id/filePath (fork #2). Attached only when the
+    // emitter exists; dark by default ⇒ no-op (byte-identical single-machine behavior).
+    if (replicatedRecordEmitter) {
+      const emitter = replicatedRecordEmitter;
+      knowledgeManager.setKnowledgeReplicationEmitter({
+        emitPut: (rec) =>
+          emitter.emit(
+            KNOWLEDGE_STORE_KEY,
+            deriveKnowledgeRecordKey(rec.title, rec.url, rec.type),
+            (hlc, origin, observed) => buildKnowledgeRecordData({ record: rec, hlc, origin, observed }),
+          ),
+        emitDelete: (title, url, type, deletedAt) =>
+          emitter.emit(
+            KNOWLEDGE_STORE_KEY,
+            deriveKnowledgeRecordKey(title, url, type),
+            (hlc, origin, observed) => buildKnowledgeTombstoneData({ title, url, type, hlc, origin, deletedAt, observed }),
+          ),
+      });
+    }
 
     // WS2.5 — the bypass-proof union reader for the `evolutionActions` store. The single
     // funnel every replicated action read routes through, so no caller reads a raw replica

--- a/src/core/ws2SendWiring.ts
+++ b/src/core/ws2SendWiring.ts
@@ -21,19 +21,19 @@
 export const WS2_SEND_WIRED_STORES: ReadonlyArray<string> = Object.freeze([
   'learnings',
   'relationships',
+  'knowledge',
 ]);
 
 /**
  * Stores registered for RECEIVE but whose SEND wiring is a KNOWN, enumerated
  * follow-up — NOT a silent omission. Each is here for a stated reason:
- *  - knowledge / evolutionActions / userRegistry: fully seamed
+ *  - evolutionActions / userRegistry: fully seamed
  *    managers (emitPut + emitDelete); table-row wiring onto the same emitter (WS2-SEND-2).
  *  - topicOperator: seamed put-only (no emitDelete in its manager interface yet) (WS2-SEND-3).
  *  - preferences: NO manager emit seam yet — it rode the deprecated `preferences-sync`
  *    verb; needs a manager emit hook before it can be wired (WS2-SEND-3).
  */
 export const WS2_SEND_PENDING_STORES: ReadonlyArray<string> = Object.freeze([
-  'knowledge',
   'evolutionActions',
   'userRegistry',
   'topicOperator',

--- a/tests/e2e/ws2-knowledge-cross-instance.test.ts
+++ b/tests/e2e/ws2-knowledge-cross-instance.test.ts
@@ -1,0 +1,176 @@
+// safe-fs-allow: test fixture teardown uses SafeFsExecutor.safeRmSync on tmp dirs only.
+/**
+ * E2E — WS2 send-side: a knowledge SOURCE ingested on instance A is READABLE on
+ * instance B (the proven learnings/relationships round-trip shape applied to the
+ * `knowledge` store — WS2-SEND-2).
+ *
+ *   - A: KnowledgeManager + journal-backed emitter (emission enabled) + journal.
+ *   - B: JournalSyncApplier + ReplicatedPeerStreamReader + a ReplicatedStoreReader
+ *        (the bypass-proof no-clobber union — the SAME funnel the server uses).
+ * A.ingest → A's journal own-stream → serve → B.apply → B's `knowledge` union read
+ * returns A's source as a foreign-origin record. Also proves remove() replicates as a
+ * fingerprint-keyed TOMBSTONE (no resurrection) and the union resolves the key to "no
+ * record". Only catalog METADATA crosses — never the markdown body, never the local id
+ * or filePath (fork #2). Identity across machines = the content fingerprint (url||title
+ * + type), never the local id.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+
+import { CoherenceJournal } from '../../src/core/CoherenceJournal.js';
+import { JournalSyncApplier } from '../../src/core/JournalSyncApplier.js';
+import { ReplicatedPeerStreamReader } from '../../src/core/ReplicatedPeerStreamReader.js';
+import { ReplicatedRecordEmitter } from '../../src/core/ReplicatedRecordEmitter.js';
+import { ReplicatedStoreReader } from '../../src/core/ReplicatedStoreReader.js';
+import { ReplicatedKindRegistry } from '../../src/core/ReplicatedRecordEnvelope.js';
+import { ConflictStore } from '../../src/core/ConflictStore.js';
+import { DroppedOriginRegistry } from '../../src/core/RollbackUnmerge.js';
+import { KnowledgeManager } from '../../src/knowledge/KnowledgeManager.js';
+import { HybridLogicalClock } from '../../src/core/HybridLogicalClock.js';
+import {
+  KNOWLEDGE_KIND_REGISTRATION,
+  KNOWLEDGE_RECORD_KIND,
+  KNOWLEDGE_STORE_KEY,
+  knowledgeTierOf,
+  buildKnowledgeRecordData,
+  buildKnowledgeTombstoneData,
+  deriveKnowledgeRecordKey,
+} from '../../src/core/KnowledgeReplicatedStore.js';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+
+const A = 'm_laptop';
+const B = 'm_mac_mini';
+
+function reg(): ReplicatedKindRegistry {
+  const r = new ReplicatedKindRegistry();
+  r.register(KNOWLEDGE_KIND_REGISTRATION);
+  return r;
+}
+
+interface Instance {
+  dir: string;
+  registry: ReplicatedKindRegistry;
+  journal: CoherenceJournal;
+  applier: JournalSyncApplier;
+  reader: ReplicatedPeerStreamReader;
+  knowledge: KnowledgeManager;
+  unionReader: ReplicatedStoreReader;
+}
+
+function makeInstance(machineId: string, label: string): Instance {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), `ws2e2e-kb-${label}-`));
+  const registry = reg();
+  const journal = new CoherenceJournal({ stateDir: dir, machineId, flushIntervalMs: 1_000_000 });
+  journal.open();
+  journal.setReplicatedKindRegistry(registry);
+  const applier = new JournalSyncApplier({ stateDir: dir, replicatedRegistry: registry });
+  const reader = new ReplicatedPeerStreamReader({ stateDir: dir, registry, selfMachineId: machineId });
+  const knowledge = new KnowledgeManager(dir);
+
+  // Emitter (the SEND wiring) — emission ENABLED for knowledge.
+  const emitter = new ReplicatedRecordEmitter({
+    journal,
+    clock: new HybridLogicalClock({ node: machineId, now: () => Date.now() }),
+    registry,
+    origin: machineId,
+    stores: () => ({ knowledge: { enabled: true } }),
+    loadWitness: (store, rk) => reader.loadWitness(store, rk),
+  });
+  knowledge.setKnowledgeReplicationEmitter({
+    emitPut: (rec) => emitter.emit(KNOWLEDGE_STORE_KEY, deriveKnowledgeRecordKey(rec.title, rec.url, rec.type),
+      (hlc, o, observed) => buildKnowledgeRecordData({ record: rec, hlc, origin: o, observed })),
+    emitDelete: (title, url, type, deletedAt) => emitter.emit(KNOWLEDGE_STORE_KEY, deriveKnowledgeRecordKey(title, url, type),
+      (hlc, o, observed) => buildKnowledgeTombstoneData({ title, url, type, hlc, origin: o, deletedAt, observed })),
+  });
+
+  // The bypass-proof union reader (the SAME funnel + seams the server wires).
+  const unionReader = new ReplicatedStoreReader({
+    registry,
+    stores: { knowledge: { enabled: true } },
+    tierOf: knowledgeTierOf,
+    loadOriginRecords: (store, rk) => reader.loadOriginRecords(store, rk),
+    listRecordKeys: (store) => reader.listRecordKeys(store),
+    droppedOrigins: new DroppedOriginRegistry({ stateDir: dir }),
+    conflictStore: new ConflictStore({ stateDir: dir, now: () => new Date() }),
+  });
+
+  return { dir, registry, journal, applier, reader, knowledge, unionReader };
+}
+
+/** Ship every NEW own knowledge-record entry from `from` to `to` (the journal serve/apply
+ *  path, first-hop bound). Returns the cursor to resume from next time. */
+function replicate(from: Instance, fromMachineId: string, to: Instance, fromSeq: number): number {
+  from.journal.flush();
+  const served = from.applier.buildServeBatch(KNOWLEDGE_RECORD_KIND, fromSeq, fromMachineId);
+  if (served.entries.length === 0) return fromSeq;
+  to.applier.apply(fromMachineId, [served]);
+  return served.entries[served.entries.length - 1].seq;
+}
+
+describe('E2E — a knowledge source ingested on A is readable on B (WS2.4 send-side)', () => {
+  let a: Instance;
+  let b: Instance;
+
+  beforeEach(() => {
+    a = makeInstance(A, 'a');
+    b = makeInstance(B, 'b');
+  });
+  afterEach(() => {
+    for (const inst of [a, b]) {
+      try { inst.journal.close(); } catch { /* best-effort */ }
+      SafeFsExecutor.safeRmSync(inst.dir, { recursive: true, force: true, operation: 'tests/e2e/ws2-knowledge-cross-instance.test.ts' });
+    }
+  });
+
+  it('ingest on A becomes readable through B\'s union reader as a foreign-origin record (metadata only)', () => {
+    const url = 'https://example.com/exo-3-0';
+    a.knowledge.ingest('# EXO 3.0\n\nLong body text that must NOT cross the wire.', { title: 'EXO 3.0 Overview', url, type: 'article', tags: ['exo'] });
+    const rk = deriveKnowledgeRecordKey('EXO 3.0 Overview', url, 'article')!;
+
+    // B sees nothing yet.
+    expect(b.unionReader.read(KNOWLEDGE_STORE_KEY, rk).value).toBeNull();
+
+    replicate(a, A, b, 0);
+
+    const result = b.unionReader.read(KNOWLEDGE_STORE_KEY, rk);
+    expect(result.value).not.toBeNull();
+    expect(result.value!.origin).toBe(A);
+    expect(result.value!.data.title).toBe('EXO 3.0 Overview');
+    expect(result.value!.data.type).toBe('article');
+    // METADATA only — the markdown body + local filePath/id NEVER cross (fork #2).
+    expect((result.value!.data as Record<string, unknown>).filePath).toBeUndefined();
+    expect((result.value!.data as Record<string, unknown>).id).toBeUndefined();
+    expect(b.unionReader.readAll(KNOWLEDGE_STORE_KEY).has(rk)).toBe(true);
+  });
+
+  it('a remove on A replicates as a fingerprint-keyed tombstone and the union resolves the key to no-record', () => {
+    const url = 'https://example.com/doomed';
+    const res = a.knowledge.ingest('body', { title: 'Doomed Source', url, type: 'doc' });
+    const rk = deriveKnowledgeRecordKey('Doomed Source', url, 'doc')!;
+    let cursor = replicate(a, A, b, 0);
+    expect(b.unionReader.read(KNOWLEDGE_STORE_KEY, rk).value).not.toBeNull();
+
+    expect(a.knowledge.remove(res.sourceId)).toBe(true);
+    cursor = replicate(a, A, b, cursor);
+    expect(cursor).toBeGreaterThan(0);
+
+    // The tombstone wins (no resurrection) — B resolves the key to "no record".
+    expect(b.unionReader.read(KNOWLEDGE_STORE_KEY, rk).value).toBeNull();
+  });
+
+  it('the SAME source (same url+type) on BOTH machines collapses to ONE recordKey across origins', () => {
+    const url = 'https://example.com/shared';
+    a.knowledge.ingest('body A', { title: 'Shared Article', url, type: 'article' });
+    b.knowledge.ingest('body B', { title: 'Shared Article', url, type: 'article' });
+
+    replicate(a, A, b, 0);
+    b.journal.flush();
+    const rk = deriveKnowledgeRecordKey('Shared Article', url, 'article')!;
+    const origins = b.reader.loadOriginRecords(KNOWLEDGE_STORE_KEY, rk);
+    expect(origins.map((o) => o.origin).sort()).toEqual([A, B].sort());
+    // ONE key, not two — the content fingerprint collapsed the same source.
+    expect(b.reader.listRecordKeys(KNOWLEDGE_STORE_KEY)).toEqual([rk]);
+  });
+});

--- a/upgrades/next/ws2-send-2-knowledge.md
+++ b/upgrades/next/ws2-send-2-knowledge.md
@@ -1,0 +1,46 @@
+# Upgrade Guide — WS2-SEND-2: knowledge send-side replication
+
+<!-- bump: patch -->
+
+## What Changed
+
+The `knowledge` memory store is now wired into the WS2 send-side — the second of the
+WS2-SEND-2 table-row stores (after `relationships`). The generic emitter from #1168 is
+attached to `KnowledgeManager`'s existing ingest/remove hooks (the manager already fired
+`emitPut`/`emitDelete`; the emitter was a `void` placeholder), and `knowledge` flips
+PENDING→WIRED in the send-wiring ratchet. The knowledge union reader and the
+disclosure-minimized projection already shipped (WS2.4); this is the send attachment +
+its end-to-end proof. Dark by default (`multiMachine.stateSync.knowledge`). No new
+route/verb/config-default/migration. Only catalog METADATA crosses — never the markdown
+body, never the local id/filePath.
+
+## What to Tell Your User
+
+- **Cross-machine knowledge catalog now actually crosses**: "If you run me on more than
+  one machine, a source I ingest on one (an article, transcript, or doc) now shows up in
+  the catalog on the others — one shared knowledge index instead of one per machine. Only
+  the catalog entry crosses (title, link, type, tags, summary) — never the full document
+  text and never the local file path; the other machine learns the source exists and can
+  re-fetch it itself. It stays off until you ask me to turn on multi-machine knowledge
+  sync." ⚗️ Experimental — ships dark; metadata-only by design (full-content sync is a
+  separate tracked stage).
+
+## Summary of New Capabilities
+
+| Capability | How to Use |
+|-----------|-----------|
+| Cross-machine replication of the knowledge catalog (metadata only) | Automatic once `multiMachine.stateSync.knowledge` is enabled (off by default) |
+| Content-fingerprint identity — the same source on two machines collapses to one record | Automatic (read path) |
+| Removal propagates as a fingerprint-keyed tombstone (no resurrection of a removed source) | Automatic (remove path) |
+
+## Evidence
+
+Verified by a two-instance in-process E2E
+(`tests/e2e/ws2-knowledge-cross-instance.test.ts`): a source ingested on instance A is
+read back on B through the bypass-proof union reader as a foreign-origin record — and the
+markdown body, local `id`, and `filePath` are confirmed ABSENT from the projection
+(metadata only); a `remove` on A replicates as a fingerprint-keyed tombstone and B's
+union read resolves the key to "no record" (no resurrection); the same source (same
+url+type) ingested on both machines collapses to one record key across origins. `tsc
+--noEmit` clean; the new e2e (3) + relationships e2e (3) pass; the ws2-send-wiring
+integration ratchet (4) accepts the PENDING→WIRED move.

--- a/upgrades/side-effects/ws2-send-2-knowledge.md
+++ b/upgrades/side-effects/ws2-send-2-knowledge.md
@@ -1,0 +1,51 @@
+# Side-Effects Review — WS2-SEND-2: knowledge send-side replication
+
+**Version / slug:** `ws2-send-2-knowledge`
+**Date:** `2026-06-15`
+**Author:** `Instar Agent (echo)`
+**Second-pass reviewer:** `not required` (no block/allow/lifecycle authority — additive, dark-gated data-replication wiring; see §4)
+
+## Summary of the change
+
+Extends WS2 send-side emission to the `knowledge` store (the second WS2-SEND-2 table-row store after `relationships`). Mirrors the proven pattern: `src/commands/server.ts` imports `buildKnowledgeRecordData` + `buildKnowledgeTombstoneData` and attaches the generic `ReplicatedRecordEmitter` to `KnowledgeManager.setKnowledgeReplicationEmitter` (replacing the prior `void` placeholder), gated `if (replicatedRecordEmitter)`; `src/core/ws2SendWiring.ts` moves `knowledge` PENDING→WIRED; a new e2e round-trip `tests/e2e/ws2-knowledge-cross-instance.test.ts`. The knowledge union reader already existed (constructed @8566). No decision-point surface added beyond the pre-existing dark gate.
+
+## Decision-point inventory
+
+- `ReplicatedRecordEmitter.emit` dark gate (`stateSync.knowledge.enabled`) — **pass-through** — pre-existing; `knowledge` is now a registered emit target. Default false ⇒ no-op.
+- `KnowledgeManager.ingest`/`remove` emit funnel — **pass-through** — the manager already fires emitPut@165 / emitDelete@204; this attaches a real emitter where there was a no-op.
+- `ws2SendWiring` ratchet — **modify** — `knowledge` reclassified PENDING→WIRED.
+
+---
+
+## 1. Over-block
+
+No block/allow surface — over-block not applicable. The emitter never rejects an ingest/remove; a null recordKey / null projection / over-cap source is a counted no-op and the local catalog write always succeeds.
+
+## 2. Under-block
+
+Not applicable (no block surface). A source with an empty identity anchor (no url AND no title) has no cross-machine fingerprint and is intentionally not replicated (by design) — local-only.
+
+## 3. Level-of-abstraction fit
+
+Correct layer. Table-row registration onto the generic #1168 substrate, exactly as the spec's WS2-SEND-2 prescribes. The disclosure-minimized projection lives in `KnowledgeReplicatedStore` alongside the receive-side schema.
+
+## 4. Signal vs authority compliance
+
+Compliant. No blocking authority. The emitter is additive/best-effort: a builder/journal failure is swallowed + counted, never propagated, so a knowledge ingest can never fail because replication did. The union read is advisory (HIGH tier append-both-and-flag). Per `docs/signal-vs-authority.md`, a replicator with no gate authority.
+
+## 5. Interactions
+
+- Shares `server.ts`'s single `replicatedRecordEmitter` + the existing `knowledgeUnionReader`. No double-fire: emitPut rides the single `ingest()` path, emitDelete the single `remove()` path. Distinct store key/kind from learnings + relationships.
+- Touches the same `server.ts` + `ws2SendWiring.ts` as the other WS2-SEND stores → serialized (built on top of the merged #1169 relationships change; no parallel WS2-SEND PRs).
+
+## 6. External surfaces
+
+Dark by default (`multiMachine.stateSync.knowledge.enabled`). Off ⇒ byte-identical single-machine behavior. On (multi-machine, opt-in): only the catalog METADATA crosses (title, url, type, tags, summary, wordCount) — NEVER the markdown file BODY and NEVER the local id/filePath (fork #2). The peer LEARNS the source exists and may re-ingest locally; full-content sync is a separate tracked rollout stage. A received record is quoted `<replicated-untrusted-data>`, advisory reference only.
+
+## 7. Multi-machine posture (Cross-Machine Coherence)
+
+**Replicated.** Path: `KnowledgeManager.ingest/remove` → `ReplicatedRecordEmitter.emit` → `CoherenceJournal.emitReplicatedRecord` → peer serve/apply → `ReplicatedPeerStreamReader.loadOriginRecords` → `knowledgeUnionReader` (no-clobber union, conflict-flagged). Identity = content fingerprint (url||title + type), so the same source on two machines collapses to one recordKey. remove() propagates a fingerprint-keyed tombstone (a later `delete` hlc wins over an earlier `put` — no resurrection). No user-facing notice surface; no topic-transfer state; no generated URLs.
+
+## 8. Rollback cost
+
+Trivial. Dark by default; affects only agents that enable `stateSync.knowledge`. Back-out = revert the three-file change or set the flag false (instant, no migration). Receive-side + envelope schema already shipped, unaffected.


### PR DESCRIPTION
## ELI16

If you run this agent on more than one of your machines, it keeps a little catalog of things it has read — articles, transcripts, docs you've had it ingest. Until now that catalog lived separately on each machine. This change makes the *knowledge catalog* travel between your machines, so a source you add on your laptop shows up in the catalog on your Mac Mini too — one shared index instead of one per computer.

It reuses the exact pipe proven for lessons (#1168) and relationships (#1169); the knowledge store just hadn't been plugged in yet. Importantly, only the *catalog entry* crosses — the title, link, type, tags, and summary — never the full document text and never the local file path. The other machine simply learns the source exists and can re-fetch it itself if it wants the body. Removing a source sends a tombstone so it stays removed everywhere (it can't come back to life from a machine that still had it). The whole thing is OFF by default and only turns on if you ask for multi-machine knowledge sync; with it off, single-machine behavior is byte-for-byte unchanged.

Second of the four WS2-SEND-2 table-row stores; evolution-actions, user-registry, and topic-operator follow on the same wiring.

## What Changed

- `src/commands/server.ts`: attach the journal-backed `ReplicatedRecordEmitter` to `KnowledgeManager.setKnowledgeReplicationEmitter` (emitPut/emitDelete → `buildKnowledge{Record,Tombstone}Data`), replacing the prior `void` placeholder.
- `src/core/ws2SendWiring.ts`: move `knowledge` PENDING→WIRED.
- `tests/e2e/ws2-knowledge-cross-instance.test.ts`: new round-trip proof.

Dark by default (`multiMachine.stateSync.knowledge`). Metadata-only (fork #2). No new route/verb/config-default/migration.

## Evidence

`tsc --noEmit` clean. New e2e (3) + relationships e2e (3) pass; ws2-send-wiring ratchet (4) accepts PENDING→WIRED. Proves: source ingested on A readable on B as foreign-origin with body/id/filePath ABSENT from projection; remove → fingerprint-keyed tombstone resolves to no-record (no resurrection); same url+type source collapses to one recordKey across origins.

Spec: `docs/specs/WS2-SEND-SIDE-EMISSION-SPEC.md` (WS2-SEND-2). Side-effects: `upgrades/side-effects/ws2-send-2-knowledge.md`. Built on the merged #1169.