### PR TITLE
feat(multi-machine): WS2-SEND-2 wire evolutionActions send-side replication

### DIFF
--- a/.instar/instar-dev-decisions/2026-06-15T17-57-32-879Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-06-15T17-57-32-879Z-unknown.json
@@ -1,0 +1,13 @@
+{
+  "ts": "2026-06-15T17:57:32.879Z",
+  "slug": "unknown",
+  "suggestedTier": 2,
+  "declaredTier": 2,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 2,
+  "loc": 44,
+  "causalAutopsy": null,
+  "verdict": "pass"
+}

--- a/src/commands/server.ts
+++ b/src/commands/server.ts
@@ -8668,6 +8668,8 @@ export async function startServer(options: StartOptions): Promise<void> {
       evolutionActionTierOf,
       evolutionActionToOriginRecord,
       deriveEvolutionActionRecordKey,
+      buildEvolutionActionRecordData,
+      buildEvolutionActionTombstoneData,
       EVOLUTION_ACTION_STORE_KEY,
     } = await import('../core/EvolutionActionsReplicatedStore.js');
     const evolutionActionsUnionReader = new ReplicatedStoreReader({
@@ -8697,7 +8699,36 @@ export async function startServer(options: StartOptions): Promise<void> {
       conflictStore,
     });
     void evolutionActionsUnionReader; // consumed by the evolution-actions peer-read surface + the journal-apply rollout stage (WS2.5+)
-    void evolution.setEvolutionActionReplicationEmitter; // the emit seam exists (unit-tested + dark by default); the journal-backed emitter is attached in a later rollout stage, mirroring the WS2.2 learnings sibling
+
+    // WS2.5 SEND-SIDE: attach the journal-backed emitter to the EvolutionManager's
+    // action-queue hooks. saveActions already fires emitPut on every surviving action
+    // (so a STATUS CHANGE re-emits — a peer SEES completed/in_progress and won't redo it)
+    // and emitDelete on every action actually pruned out of the queue (a RETAINED terminal
+    // action is never tombstoned — only a real queue-removal is). The adapter maps the
+    // manager's emit signature to the action build*RecordData projection; the generic emitter
+    // owns the dark gate, HLC tick, `observed` witness, journal append, and ALL the safety
+    // guards (null recordKey ⇒ skip, null projection ⇒ skip, over-cap throw ⇒ counted no-op).
+    // `evolution` is the canonical instance handed to the AgentServer, so the action routes'
+    // real writes flow through these hooks. Attached only when the emitter exists; dark by
+    // default ⇒ no-op (byte-identical single-machine behavior; the local ACT-NNN id never
+    // crosses the wire — fork #1, only the enumerated content projection does).
+    if (replicatedRecordEmitter) {
+      const emitter = replicatedRecordEmitter;
+      evolution.setEvolutionActionReplicationEmitter({
+        emitPut: (rec) =>
+          emitter.emit(
+            EVOLUTION_ACTION_STORE_KEY,
+            deriveEvolutionActionRecordKey(rec.title, rec.commitTo, rec.createdAt),
+            (hlc, origin, observed) => buildEvolutionActionRecordData({ record: rec, hlc, origin, observed }),
+          ),
+        emitDelete: (title, commitTo, createdAt, deletedAt) =>
+          emitter.emit(
+            EVOLUTION_ACTION_STORE_KEY,
+            deriveEvolutionActionRecordKey(title, commitTo, createdAt),
+            (hlc, origin, observed) => buildEvolutionActionTombstoneData({ title, commitTo, createdAt, hlc, origin, deletedAt, observed }),
+          ),
+      });
+    }
 
     // WS2.6 — the bypass-proof union reader for the `userRegistry` store (the SECOND PII kind). The
     // single funnel every replicated user read routes through, so no caller reads a raw replica

--- a/src/core/ws2SendWiring.ts
+++ b/src/core/ws2SendWiring.ts
@@ -22,19 +22,22 @@ export const WS2_SEND_WIRED_STORES: ReadonlyArray<string> = Object.freeze([
   'learnings',
   'relationships',
   'knowledge',
+  'evolutionActions',
 ]);
 
 /**
  * Stores registered for RECEIVE but whose SEND wiring is a KNOWN, enumerated
  * follow-up — NOT a silent omission. Each is here for a stated reason:
- *  - evolutionActions / userRegistry: fully seamed
- *    managers (emitPut + emitDelete); table-row wiring onto the same emitter (WS2-SEND-2).
- *  - topicOperator: seamed put-only (no emitDelete in its manager interface yet) (WS2-SEND-3).
+ *  - userRegistry: fully seamed manager (emitPut + emitDelete); its canonical write
+ *    instance lives in the AgentServer, so it needs the emitter plumbed there before it
+ *    can be wired (WS2-SEND-2b).
+ *  - topicOperator: seamed put-only (a topic rebinds, never unbinds — no emitDelete by
+ *    construction); its authoritative writer is the AgentServer's TopicOperatorStore, so it
+ *    needs the emitter plumbed there before it can be wired (WS2-SEND-2b).
  *  - preferences: NO manager emit seam yet — it rode the deprecated `preferences-sync`
  *    verb; needs a manager emit hook before it can be wired (WS2-SEND-3).
  */
 export const WS2_SEND_PENDING_STORES: ReadonlyArray<string> = Object.freeze([
-  'evolutionActions',
   'userRegistry',
   'topicOperator',
   'preferences',

--- a/tests/e2e/ws2-evolution-actions-cross-instance.test.ts
+++ b/tests/e2e/ws2-evolution-actions-cross-instance.test.ts
@@ -1,0 +1,160 @@
+// safe-fs-allow: test fixture teardown uses SafeFsExecutor.safeRmSync on tmp dirs only.
+/**
+ * E2E — WS2 send-side: an evolution ACTION raised on instance A is READABLE on
+ * instance B, and a STATUS CHANGE on A re-replicates so B SEES the action is already
+ * completed/in_progress and won't redo it (the proven learnings/relationships/knowledge
+ * round-trip shape applied to the `evolutionActions` store — WS2-SEND-2).
+ *
+ *   - A: EvolutionManager + journal-backed emitter (emission enabled) + journal.
+ *   - B: JournalSyncApplier + ReplicatedPeerStreamReader + a ReplicatedStoreReader
+ *        (the bypass-proof no-clobber union — the SAME funnel the server uses).
+ * A.addAction → A's journal own-stream → serve → B.apply → B's `evolutionActions` union
+ * read returns A's action as a foreign-origin record. A.updateAction(completed) re-emits
+ * (saveActions re-emits every survivor) → B's latest read shows status:'completed'. Only
+ * the enumerated content projection crosses — never the local ACT-NNN id (fork #1).
+ * Identity across machines = the content fingerprint (title + commitTo + createdAt).
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+
+import { CoherenceJournal } from '../../src/core/CoherenceJournal.js';
+import { JournalSyncApplier } from '../../src/core/JournalSyncApplier.js';
+import { ReplicatedPeerStreamReader } from '../../src/core/ReplicatedPeerStreamReader.js';
+import { ReplicatedRecordEmitter } from '../../src/core/ReplicatedRecordEmitter.js';
+import { ReplicatedStoreReader } from '../../src/core/ReplicatedStoreReader.js';
+import { ReplicatedKindRegistry } from '../../src/core/ReplicatedRecordEnvelope.js';
+import { ConflictStore } from '../../src/core/ConflictStore.js';
+import { DroppedOriginRegistry } from '../../src/core/RollbackUnmerge.js';
+import { EvolutionManager } from '../../src/core/EvolutionManager.js';
+import { HybridLogicalClock } from '../../src/core/HybridLogicalClock.js';
+import {
+  EVOLUTION_ACTION_KIND_REGISTRATION,
+  EVOLUTION_ACTION_RECORD_KIND,
+  EVOLUTION_ACTION_STORE_KEY,
+  evolutionActionTierOf,
+  buildEvolutionActionRecordData,
+  buildEvolutionActionTombstoneData,
+  deriveEvolutionActionRecordKey,
+} from '../../src/core/EvolutionActionsReplicatedStore.js';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+
+const A = 'm_laptop';
+const B = 'm_mac_mini';
+
+function reg(): ReplicatedKindRegistry {
+  const r = new ReplicatedKindRegistry();
+  r.register(EVOLUTION_ACTION_KIND_REGISTRATION);
+  return r;
+}
+
+interface Instance {
+  dir: string;
+  registry: ReplicatedKindRegistry;
+  journal: CoherenceJournal;
+  applier: JournalSyncApplier;
+  reader: ReplicatedPeerStreamReader;
+  evolution: EvolutionManager;
+  unionReader: ReplicatedStoreReader;
+}
+
+function makeInstance(machineId: string, label: string): Instance {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), `ws2e2e-evo-${label}-`));
+  const registry = reg();
+  const journal = new CoherenceJournal({ stateDir: dir, machineId, flushIntervalMs: 1_000_000 });
+  journal.open();
+  journal.setReplicatedKindRegistry(registry);
+  const applier = new JournalSyncApplier({ stateDir: dir, replicatedRegistry: registry });
+  const reader = new ReplicatedPeerStreamReader({ stateDir: dir, registry, selfMachineId: machineId });
+  const evolution = new EvolutionManager({ stateDir: dir });
+
+  // Emitter (the SEND wiring) — emission ENABLED for evolutionActions.
+  const emitter = new ReplicatedRecordEmitter({
+    journal,
+    clock: new HybridLogicalClock({ node: machineId, now: () => Date.now() }),
+    registry,
+    origin: machineId,
+    stores: () => ({ evolutionActions: { enabled: true } }),
+    loadWitness: (store, rk) => reader.loadWitness(store, rk),
+  });
+  evolution.setEvolutionActionReplicationEmitter({
+    emitPut: (rec) => emitter.emit(EVOLUTION_ACTION_STORE_KEY, deriveEvolutionActionRecordKey(rec.title, rec.commitTo, rec.createdAt),
+      (hlc, o, observed) => buildEvolutionActionRecordData({ record: rec, hlc, origin: o, observed })),
+    emitDelete: (title, commitTo, createdAt, deletedAt) => emitter.emit(EVOLUTION_ACTION_STORE_KEY, deriveEvolutionActionRecordKey(title, commitTo, createdAt),
+      (hlc, o, observed) => buildEvolutionActionTombstoneData({ title, commitTo, createdAt, hlc, origin: o, deletedAt, observed })),
+  });
+
+  // The bypass-proof union reader (the SAME funnel + seams the server wires).
+  const unionReader = new ReplicatedStoreReader({
+    registry,
+    stores: { evolutionActions: { enabled: true } },
+    tierOf: evolutionActionTierOf,
+    loadOriginRecords: (store, rk) => reader.loadOriginRecords(store, rk),
+    listRecordKeys: (store) => reader.listRecordKeys(store),
+    droppedOrigins: new DroppedOriginRegistry({ stateDir: dir }),
+    conflictStore: new ConflictStore({ stateDir: dir, now: () => new Date() }),
+  });
+
+  return { dir, registry, journal, applier, reader, evolution, unionReader };
+}
+
+/** Ship every NEW own evolution-action-record entry from `from` to `to` (the journal
+ *  serve/apply path, first-hop bound). Returns the cursor to resume from next time. */
+function replicate(from: Instance, fromMachineId: string, to: Instance, fromSeq: number): number {
+  from.journal.flush();
+  const served = from.applier.buildServeBatch(EVOLUTION_ACTION_RECORD_KIND, fromSeq, fromMachineId);
+  if (served.entries.length === 0) return fromSeq;
+  to.applier.apply(fromMachineId, [served]);
+  return served.entries[served.entries.length - 1].seq;
+}
+
+describe('E2E — an evolution action raised on A is readable on B (WS2.5 send-side)', () => {
+  let a: Instance;
+  let b: Instance;
+
+  beforeEach(() => {
+    a = makeInstance(A, 'a');
+    b = makeInstance(B, 'b');
+  });
+  afterEach(() => {
+    for (const inst of [a, b]) {
+      try { inst.journal.close(); } catch { /* best-effort */ }
+      SafeFsExecutor.safeRmSync(inst.dir, { recursive: true, force: true, operation: 'tests/e2e/ws2-evolution-actions-cross-instance.test.ts' });
+    }
+  });
+
+  it('addAction on A becomes readable through B\'s union reader as a foreign-origin record (metadata only, no ACT id)', () => {
+    const action = a.evolution.addAction({ title: 'Wire WS2 send-side', description: 'Attach the emitter', priority: 'high', commitTo: 'multi-machine' });
+    const rk = deriveEvolutionActionRecordKey(action.title, action.commitTo, action.createdAt)!;
+
+    // B sees nothing yet.
+    expect(b.unionReader.read(EVOLUTION_ACTION_STORE_KEY, rk).value).toBeNull();
+
+    replicate(a, A, b, 0);
+
+    const result = b.unionReader.read(EVOLUTION_ACTION_STORE_KEY, rk);
+    expect(result.value).not.toBeNull();
+    expect(result.value!.origin).toBe(A);
+    expect(result.value!.data.title).toBe('Wire WS2 send-side');
+    expect(result.value!.data.status).toBe('pending');
+    // The local ACT-NNN id NEVER crosses (fork #1).
+    expect((result.value!.data as Record<string, unknown>).id).toBeUndefined();
+    expect(b.unionReader.readAll(EVOLUTION_ACTION_STORE_KEY).has(rk)).toBe(true);
+  });
+
+  it('a STATUS CHANGE (completed) on A re-replicates and the latest status wins on B (peer won\'t redo it)', () => {
+    const action = a.evolution.addAction({ title: 'Ship the batch', description: 'do it', priority: 'medium' });
+    const rk = deriveEvolutionActionRecordKey(action.title, action.commitTo, action.createdAt)!;
+    let cursor = replicate(a, A, b, 0);
+    expect(b.unionReader.read(EVOLUTION_ACTION_STORE_KEY, rk).value!.data.status).toBe('pending');
+
+    // Complete the action on A — saveActions re-emits the survivor with the new status.
+    expect(a.evolution.updateAction(action.id, { status: 'completed' })).toBe(true);
+    cursor = replicate(a, A, b, cursor);
+    expect(cursor).toBeGreaterThan(0);
+
+    // B now SEES the action is completed elsewhere — so it will not redo it.
+    expect(b.unionReader.read(EVOLUTION_ACTION_STORE_KEY, rk).value!.data.status).toBe('completed');
+  });
+});

--- a/tests/integration/unified-trust-system.test.ts
+++ b/tests/integration/unified-trust-system.test.ts
@@ -378,7 +378,12 @@ describe('5. Sybil Protection', () => {
   });
 
   it('rejects PoW for wrong IP', () => {
-    const challenge = generateChallenge('127.0.0.1', 8);
+    // The IP is hashed into the PoW (SHA-256(epoch || clientIP || nonce)), so a
+    // nonce solved for 127.0.0.1 only validates for 10.0.0.1 if its hash happens
+    // to clear the difficulty bar there too — probability 2^-difficulty per run.
+    // At difficulty 8 that is 1/256, which flakes CI (~0.4% of runs). Use 16 so
+    // the false-accept probability is ~1.5e-5 (negligible) while solve stays fast.
+    const challenge = generateChallenge('127.0.0.1', 16);
     const solution = solveChallenge(challenge, '127.0.0.1');
     expect(verifySolution(solution, '10.0.0.1').valid).toBe(false);
   });

--- a/upgrades/next/ws2-send-2-evolution-actions.md
+++ b/upgrades/next/ws2-send-2-evolution-actions.md
@@ -1,0 +1,50 @@
+# Upgrade Guide — WS2-SEND-2: evolutionActions send-side replication
+
+<!-- bump: patch -->
+
+## What Changed
+
+The `evolutionActions` memory store is now wired into the WS2 send-side — the next of the
+WS2-SEND-2 table-row stores (after `relationships` + `knowledge`). The generic emitter
+from #1168 is attached to `EvolutionManager`'s existing action-queue hooks (the manager
+already fired `emitPut` per surviving action + `emitDelete` per pruned action in
+`saveActions`; the emitter was a `void` placeholder), and `evolutionActions` flips
+PENDING→WIRED in the send-wiring ratchet. The evolution-actions union reader and the
+disclosure-minimized projection already shipped (WS2.5); this is the send attachment +
+its end-to-end proof. Dark by default (`multiMachine.stateSync.evolutionActions`). No new
+route/verb/config-default/migration. Only the enumerated action projection crosses — never
+the local `ACT-NNN` id.
+
+This PR also fixes a probabilistic CI flake in the Sybil-protection integration test (a
+PoW wrong-IP assertion that false-accepted ~0.4% of runs at difficulty 8; raised to 16 so
+it's negligible). Pure test hygiene, no production behavior change.
+
+## What to Tell Your User
+
+- **Cross-machine self-improvement queue now actually crosses**: "If you run me on more
+  than one machine, a self-improvement action I raise on one now shows up on the others —
+  one shared action queue instead of one per machine. The load-bearing part: a peer SEES
+  when an action was already completed or is in progress elsewhere, so I don't redo work
+  another of my machines already did. Only the action's content crosses (title,
+  description, priority, status, tags) — never the local `ACT-NNN` id. It stays off until
+  you ask me to turn on multi-machine sync." ⚗️ Experimental — ships dark.
+
+## Summary of New Capabilities
+
+| Capability | How to Use |
+|-----------|-----------|
+| Cross-machine replication of the evolution action queue | Automatic once `multiMachine.stateSync.evolutionActions` is enabled (off by default) |
+| Status visibility — a peer sees completed/in_progress and won't redo a finished action | Automatic (a status change re-emits) |
+| Removal (prune-over-maxActions) propagates as a fingerprint-keyed tombstone (no resurrection) | Automatic (save path); a RETAINED terminal action is never tombstoned |
+
+## Evidence
+
+Verified by a two-instance in-process E2E
+(`tests/e2e/ws2-evolution-actions-cross-instance.test.ts`): an action raised on instance A
+is read back on B through the bypass-proof union reader as a foreign-origin record — with
+the local `ACT-NNN` id confirmed ABSENT from the projection — and a status change
+(updateAction → completed) on A re-replicates so B's latest read shows `status:'completed'`
+(the peer-won't-redo-it behavior), all over the real journal serve/apply path. `tsc
+--noEmit` clean; the new e2e (2) passes; the ws2-send-wiring integration ratchet (4)
+accepts the PENDING→WIRED move; the unified-trust-system integration suite is green with
+the de-flaked PoW test.

--- a/upgrades/next/ws2-send-2-evolution-actions.md
+++ b/upgrades/next/ws2-send-2-evolution-actions.md
@@ -13,11 +13,7 @@ PENDING→WIRED in the send-wiring ratchet. The evolution-actions union reader a
 disclosure-minimized projection already shipped (WS2.5); this is the send attachment +
 its end-to-end proof. Dark by default (`multiMachine.stateSync.evolutionActions`). No new
 route/verb/config-default/migration. Only the enumerated action projection crosses — never
-the local `ACT-NNN` id.
-
-This PR also fixes a probabilistic CI flake in the Sybil-protection integration test (a
-PoW wrong-IP assertion that false-accepted ~0.4% of runs at difficulty 8; raised to 16 so
-it's negligible). Pure test hygiene, no production behavior change.
+the local internal id.
 
 ## What to Tell Your User
 
@@ -26,7 +22,7 @@ it's negligible). Pure test hygiene, no production behavior change.
   one shared action queue instead of one per machine. The load-bearing part: a peer SEES
   when an action was already completed or is in progress elsewhere, so I don't redo work
   another of my machines already did. Only the action's content crosses (title,
-  description, priority, status, tags) — never the local `ACT-NNN` id. It stays off until
+  description, priority, status, tags) — never the local internal id. It stays off until
   you ask me to turn on multi-machine sync." ⚗️ Experimental — ships dark.
 
 ## Summary of New Capabilities

--- a/upgrades/side-effects/ws2-send-2-evolution-actions.md
+++ b/upgrades/side-effects/ws2-send-2-evolution-actions.md
@@ -1,0 +1,57 @@
+# Side-Effects Review — WS2-SEND-2: evolutionActions send-side replication (+ PoW test flake fix)
+
+**Version / slug:** `ws2-send-2-evolution-actions`
+**Date:** `2026-06-15`
+**Author:** `Instar Agent (echo)`
+**Second-pass reviewer:** `not required` (no block/allow/lifecycle authority — additive, dark-gated data-replication wiring; see §4)
+
+## Summary of the change
+
+Extends WS2 send-side emission to the `evolutionActions` store (the next WS2-SEND-2 table-row store after `relationships` + `knowledge`). Mirrors the proven pattern: `src/commands/server.ts` adds `buildEvolutionActionRecordData` + `buildEvolutionActionTombstoneData` to the existing `EvolutionActionsReplicatedStore` destructure and attaches the generic `ReplicatedRecordEmitter` to `evolution.setEvolutionActionReplicationEmitter` (replacing the prior `void` placeholder), gated `if (replicatedRecordEmitter)`; `src/core/ws2SendWiring.ts` moves `evolutionActions` PENDING→WIRED; a new e2e round-trip `tests/e2e/ws2-evolution-actions-cross-instance.test.ts`. The evolution-actions union reader already existed (@8673). `evolution` is the canonical EvolutionManager handed to the AgentServer, so the action-queue routes' real writes flow through the attached hooks (verified: the emit funnel lives in `EvolutionManager.saveActions`, which both addAction and updateAction route through).
+
+**Re-scoping note (honest):** the prior plan batched evolutionActions + userRegistry + topicOperator as one PR on the assumption all three were "just replace the void line." Grounding disproved that for the other two: `userRegistry`'s writes go through ad-hoc UserManager instances + the CLI, and `topicOperator`'s authoritative writer is the AgentServer's own `TopicOperatorStore` — both need the emitter plumbed INTO the AgentServer, not the server.ts mirror. Only `evolutionActions` is a clean canonical-instance attachment. So this PR ships `evolutionActions` alone (high-confidence, the emit genuinely fires on real writes); userRegistry + topicOperator follow in WS2-SEND-2b with the AgentServer plumbing. This is correctness-driven granularity, not deferral — both remain in `WS2_SEND_PENDING_STORES` with their real blocker stated.
+
+**Bundled fix (suite integrity):** `tests/integration/unified-trust-system.test.ts` "rejects PoW for wrong IP" was probabilistically flaky — it solved a PoW at difficulty 8 for one IP and asserted the same nonce is invalid for another IP, but a random hash clears 8 leading-zero bits with probability 1/256, so ~0.4% of CI runs false-accepted and the assertion flipped (observed blocking this very PR train). Raised that one test's difficulty to 16 (false-accept ≈ 1.5e-5, negligible; solve stays <60ms). Zero-Failure-Standard fix encountered while merging — included here rather than left to flake the train again.
+
+## Decision-point inventory
+
+- `ReplicatedRecordEmitter.emit` dark gate (`stateSync.evolutionActions.enabled`) — **pass-through** — pre-existing; `evolutionActions` is now a registered emit target. Default false ⇒ no-op.
+- `EvolutionManager.saveActions` emit funnel — **pass-through** — the manager already fires emitPut per survivor + emitDelete per pruned action (@1212); this attaches a real emitter where there was a no-op.
+- `ws2SendWiring` ratchet — **modify** — `evolutionActions` reclassified PENDING→WIRED.
+- PoW wrong-IP test difficulty 8→16 — **modify (test only)** — no production behavior; removes a probabilistic CI flake.
+
+---
+
+## 1. Over-block
+
+No block/allow surface — over-block not applicable. The emitter never rejects an action write; a null recordKey / null projection / over-cap action is a counted no-op and the local action-queue write always succeeds.
+
+## 2. Under-block
+
+Not applicable (no block surface). An action with an empty identity anchor (no title/createdAt ⇒ `deriveEvolutionActionRecordKey` null) has no cross-machine fingerprint and is intentionally not replicated — local-only. A terminal completed/cancelled action that is RETAINED is NOT tombstoned; only a real queue-removal (prune-over-maxActions) emits a delete — the resurrection guard is preserved.
+
+## 3. Level-of-abstraction fit
+
+Correct layer. Table-row registration onto the generic #1168 substrate, exactly as the spec's WS2-SEND-2 prescribes. The disclosure-minimized projection lives in `EvolutionActionsReplicatedStore` alongside the receive-side schema.
+
+## 4. Signal vs authority compliance
+
+Compliant. No blocking authority. The emitter is additive/best-effort: a builder/journal failure is swallowed + counted (the `saveActions` try/catch guards each emit), never propagated, so an action write can never fail because replication did. The union read is advisory (HIGH tier append-both-and-flag — two divergent states, e.g. completed vs in_progress, inject BOTH as hints rather than silently clobbering). Per `docs/signal-vs-authority.md`, a replicator with no gate authority.
+
+## 5. Interactions
+
+- Shares `server.ts`'s single `replicatedRecordEmitter` + the existing `evolutionActionsUnionReader`. No double-fire: emitPut/emitDelete ride the single `saveActions` path. Distinct store key/kind from learnings + relationships + knowledge.
+- `evolution` (EvolutionManager) is the SAME instance that owns learnings replication (already WIRED) — the two seams are independent (`setLearningReplicationEmitter` vs `setEvolutionActionReplicationEmitter`), distinct store keys, no cross-talk.
+- Touches the same `server.ts` + `ws2SendWiring.ts` as the other WS2-SEND stores → serialized (built on top of merged #1170 knowledge; no parallel WS2-SEND PRs).
+
+## 6. External surfaces
+
+Dark by default (`multiMachine.stateSync.evolutionActions.enabled`). Off ⇒ byte-identical single-machine behavior. On (multi-machine, opt-in): only the enumerated action projection crosses (title, description, priority, status, createdAt, tags, optional commitTo/resolution/dueBy/completedAt/source) — NEVER the local `ACT-NNN` id (fork #1). The load-bearing field is `status`: a peer SEES an action was already completed/in_progress elsewhere so it does not redo it. A received record is quoted `<replicated-untrusted-data>`, advisory work-item only.
+
+## 7. Multi-machine posture (Cross-Machine Coherence)
+
+**Replicated.** Path: `EvolutionManager.addAction/updateAction → saveActions` → `ReplicatedRecordEmitter.emit` → `CoherenceJournal.emitReplicatedRecord` → peer serve/apply → `ReplicatedPeerStreamReader.loadOriginRecords` → `evolutionActionsUnionReader` (no-clobber union, conflict-flagged). Identity = content fingerprint (title + commitTo + createdAt). A STATUS CHANGE re-emits (saveActions re-emits every survivor), so a peer sees the latest status. An actual queue-removal propagates a fingerprint-keyed tombstone (a later `delete` hlc wins — no resurrection). No user-facing notice surface; no topic-transfer state; no generated URLs. Verified end-to-end by the new e2e (put round-trip + status-change re-replication on real journal serve/apply).
+
+## 8. Rollback cost
+
+Trivial. Dark by default; affects only agents that enable `stateSync.evolutionActions`. Back-out = revert the three-file change or set the flag false (instant, no migration). Receive-side + envelope schema already shipped, unaffected. The test-difficulty bump is pure test hygiene, independently revertible.


### PR DESCRIPTION
## What

Wires the `evolutionActions` memory store into the WS2 send-side (the next WS2-SEND-2 table-row store after `relationships` #1169 + `knowledge` #1170). Attaches the generic `ReplicatedRecordEmitter` (#1168 substrate) to the canonical `EvolutionManager`'s action-queue hooks — replacing the prior `void` placeholder — and flips `evolutionActions` PENDING→WIRED in the `ws2SendWiring` ratchet.

- `src/commands/server.ts`: import `buildEvolutionActionRecordData` + `buildEvolutionActionTombstoneData`; attach the emitter via `evolution.setEvolutionActionReplicationEmitter` (gated `if (replicatedRecordEmitter)`).
- `src/core/ws2SendWiring.ts`: `evolutionActions` PENDING→WIRED; the remaining-store comments updated to name the real blocker for userRegistry/topicOperator (their canonical write instances live in AgentServer → WS2-SEND-2b).
- `tests/e2e/ws2-evolution-actions-cross-instance.test.ts`: new round-trip proof.

`evolution` is the SAME instance handed to the AgentServer, and `saveActions` already fires `emitPut` per surviving action + `emitDelete` per pruned action, so real action-queue writes now journal and cross. Dark by default (`multiMachine.stateSync.evolutionActions`); the local `ACT-NNN` id never crosses — only the enumerated content projection. The load-bearing field is `status`: a peer SEES an action completed/in_progress elsewhere and won't redo it.

Also de-flakes the Sybil PoW "rejects PoW for wrong IP" integration test (probabilistic 1/256 false-accept at difficulty 8 → difficulty 16) which was intermittently blocking this PR train.

## ELI16

Imagine you keep a to-do list of ways to improve yourself, and you run on two computers — your laptop and a Mac mini. Until now each computer kept its OWN separate to-do list, so the mini had no idea the laptop already finished a task, and might redo it. This change makes that list shared: when the laptop adds, finishes, or drops a self-improvement task, the mini finds out. The clever bit is it only sends the *contents* of each task (its title, what it's about, whether it's done) and never the laptop's private internal ID number for it — so the two computers recognize "this is the same task" by its fingerprint, not by a secret number. It stays completely turned off unless you ask for multi-machine sync, so nothing changes for a single-computer setup. We proved it really works with a two-machine test: a task added on machine A shows up on machine B, and when A marks it done, B sees "done" too. We also fixed a flaky test that was randomly failing about 1 in 250 times because of a coincidence in a security puzzle — now it basically never does.

## Testing

- `tsc --noEmit` clean.
- New e2e `ws2-evolution-actions-cross-instance.test.ts` (2) — put round-trip + status-change re-replication over the real journal serve/apply path.
- `ws2-send-wiring` integration ratchet (4) accepts the PENDING→WIRED move.
- `unified-trust-system` integration suite green with the de-flaked PoW test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)