### PR TITLE
feat(multi-machine): WS2-SEND-2b wire topicOperator send-side replication

### DIFF
--- a/.instar/instar-dev-decisions/2026-06-15T18-19-05-910Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-06-15T18-19-05-910Z-unknown.json
@@ -1,0 +1,13 @@
+{
+  "ts": "2026-06-15T18:19:05.910Z",
+  "slug": "unknown",
+  "suggestedTier": 1,
+  "declaredTier": 2,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 2,
+  "loc": 31,
+  "causalAutopsy": null,
+  "verdict": "pass"
+}

--- a/src/commands/server.ts
+++ b/src/commands/server.ts
@@ -16637,6 +16637,32 @@ export async function startServer(options: StartOptions): Promise<void> {
     // server's own store instance.
     _agentServerRef = server;
 
+    // ── WS2.6 SEND-SIDE: topicOperator (the THIRD PII kind) ──────────────
+    // The AUTHORITATIVE topic-operator writer is the AgentServer's OWN
+    // TopicOperatorStore (it constructs `this.topicOperatorStore` internally and
+    // binds it from the authenticated sender via setOperator). server.ts has no
+    // canonical instance of its own, so we attach the journal-backed emitter to the
+    // server's store here, right after the AgentServer exists. setOperator already
+    // fires emitPut on every real bind/rebind. PUT-ONLY BY CONSTRUCTION — a topic
+    // rebinds, never unbinds, so there is NO emitDelete path (the receive side
+    // resolves the latest binding by HLC). Dark by default
+    // (multiMachine.stateSync.topicOperator); off ⇒ no-op. A content name can never
+    // become an operator — only the platform-verified uid is emitted (Know Your
+    // Principal); a replicated record is NEVER authoritative for inbound resolution.
+    if (replicatedRecordEmitter) {
+      const _topicOpEmitter = replicatedRecordEmitter;
+      const { TOPIC_OPERATOR_STORE_KEY, deriveTopicOperatorRecordKey, buildTopicOperatorRecordData } =
+        await import('../core/TopicOperatorReplicatedStore.js');
+      server.getTopicOperatorStore()?.setOperatorReplicationEmitter({
+        emitPut: (topicId, record) =>
+          _topicOpEmitter.emit(
+            TOPIC_OPERATOR_STORE_KEY,
+            deriveTopicOperatorRecordKey(topicId, record.uid),
+            (hlc, origin, observed) => buildTopicOperatorRecordData({ topicId, record, hlc, origin, observed }),
+          ),
+      });
+    }
+
     // ── WS5.3 (escalation-rides-topic) destination re-admit driver ──
     // Bound here (after the AgentServer exists) so it can reach the SAME
     // ModelSwapService the /sessions/:name/model-swap route uses. Re-admission

--- a/src/core/ws2SendWiring.ts
+++ b/src/core/ws2SendWiring.ts
@@ -23,6 +23,7 @@ export const WS2_SEND_WIRED_STORES: ReadonlyArray<string> = Object.freeze([
   'relationships',
   'knowledge',
   'evolutionActions',
+  'topicOperator',
 ]);
 
 /**
@@ -31,15 +32,11 @@ export const WS2_SEND_WIRED_STORES: ReadonlyArray<string> = Object.freeze([
  *  - userRegistry: fully seamed manager (emitPut + emitDelete); its canonical write
  *    instance lives in the AgentServer, so it needs the emitter plumbed there before it
  *    can be wired (WS2-SEND-2b).
- *  - topicOperator: seamed put-only (a topic rebinds, never unbinds — no emitDelete by
- *    construction); its authoritative writer is the AgentServer's TopicOperatorStore, so it
- *    needs the emitter plumbed there before it can be wired (WS2-SEND-2b).
  *  - preferences: NO manager emit seam yet — it rode the deprecated `preferences-sync`
  *    verb; needs a manager emit hook before it can be wired (WS2-SEND-3).
  */
 export const WS2_SEND_PENDING_STORES: ReadonlyArray<string> = Object.freeze([
   'userRegistry',
-  'topicOperator',
   'preferences',
 ]);
 

--- a/tests/e2e/ws2-topicoperator-cross-instance.test.ts
+++ b/tests/e2e/ws2-topicoperator-cross-instance.test.ts
@@ -1,0 +1,147 @@
+// safe-fs-allow: test fixture teardown uses SafeFsExecutor.safeRmSync on tmp dirs only.
+/**
+ * E2E — WS2 send-side: a verified TOPIC OPERATOR bound on instance A is READABLE on
+ * instance B (the proven round-trip shape applied to the `topicOperator` store —
+ * WS2-SEND-2b, the THIRD PII kind). PUT-ONLY by construction: a topic rebinds, never
+ * unbinds, so there is no emitDelete path (the manager has no delete event).
+ *
+ * THE LOAD-BEARING SAFETY RULE (Know Your Principal): a replicated topic-operator record
+ * is UNTRUSTED peer data — NEVER the authoritative answer to "who is my verified operator
+ * of this topic?". Only the LOCAL bind from an authenticated sender is authoritative. This
+ * test only proves the binding CATALOG crosses. Identity = sha-keyed (topicId + verified
+ * uid); a content name can never become the operator.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+
+import { CoherenceJournal } from '../../src/core/CoherenceJournal.js';
+import { JournalSyncApplier } from '../../src/core/JournalSyncApplier.js';
+import { ReplicatedPeerStreamReader } from '../../src/core/ReplicatedPeerStreamReader.js';
+import { ReplicatedRecordEmitter } from '../../src/core/ReplicatedRecordEmitter.js';
+import { ReplicatedStoreReader } from '../../src/core/ReplicatedStoreReader.js';
+import { ReplicatedKindRegistry } from '../../src/core/ReplicatedRecordEnvelope.js';
+import { ConflictStore } from '../../src/core/ConflictStore.js';
+import { DroppedOriginRegistry } from '../../src/core/RollbackUnmerge.js';
+import { TopicOperatorStore } from '../../src/users/TopicOperatorStore.js';
+import { HybridLogicalClock } from '../../src/core/HybridLogicalClock.js';
+import {
+  TOPIC_OPERATOR_KIND_REGISTRATION,
+  TOPIC_OPERATOR_RECORD_KIND,
+  TOPIC_OPERATOR_STORE_KEY,
+  topicOperatorTierOf,
+  buildTopicOperatorRecordData,
+  deriveTopicOperatorRecordKey,
+} from '../../src/core/TopicOperatorReplicatedStore.js';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+
+const A = 'm_laptop';
+const B = 'm_mac_mini';
+
+function reg(): ReplicatedKindRegistry {
+  const r = new ReplicatedKindRegistry();
+  r.register(TOPIC_OPERATOR_KIND_REGISTRATION);
+  return r;
+}
+
+interface Instance {
+  dir: string;
+  journal: CoherenceJournal;
+  applier: JournalSyncApplier;
+  reader: ReplicatedPeerStreamReader;
+  ops: TopicOperatorStore;
+  unionReader: ReplicatedStoreReader;
+}
+
+function makeInstance(machineId: string, label: string): Instance {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), `ws2e2e-topicop-${label}-`));
+  const registry = reg();
+  const journal = new CoherenceJournal({ stateDir: dir, machineId, flushIntervalMs: 1_000_000 });
+  journal.open();
+  journal.setReplicatedKindRegistry(registry);
+  const applier = new JournalSyncApplier({ stateDir: dir, replicatedRegistry: registry });
+  const reader = new ReplicatedPeerStreamReader({ stateDir: dir, registry, selfMachineId: machineId });
+  const ops = new TopicOperatorStore(path.join(dir, 'state'));
+
+  const emitter = new ReplicatedRecordEmitter({
+    journal,
+    clock: new HybridLogicalClock({ node: machineId, now: () => Date.now() }),
+    registry,
+    origin: machineId,
+    stores: () => ({ topicOperator: { enabled: true } }),
+    loadWitness: (store, rk) => reader.loadWitness(store, rk),
+  });
+  ops.setOperatorReplicationEmitter({
+    emitPut: (topicId, record) => emitter.emit(TOPIC_OPERATOR_STORE_KEY, deriveTopicOperatorRecordKey(topicId, record.uid),
+      (hlc, o, observed) => buildTopicOperatorRecordData({ topicId, record, hlc, origin: o, observed })),
+  });
+
+  const unionReader = new ReplicatedStoreReader({
+    registry,
+    stores: { topicOperator: { enabled: true } },
+    tierOf: topicOperatorTierOf,
+    loadOriginRecords: (store, rk) => reader.loadOriginRecords(store, rk),
+    listRecordKeys: (store) => reader.listRecordKeys(store),
+    droppedOrigins: new DroppedOriginRegistry({ stateDir: dir }),
+    conflictStore: new ConflictStore({ stateDir: dir, now: () => new Date() }),
+  });
+
+  return { dir, journal, applier, reader, ops, unionReader };
+}
+
+function replicate(from: Instance, fromMachineId: string, to: Instance, fromSeq: number): number {
+  from.journal.flush();
+  const served = from.applier.buildServeBatch(TOPIC_OPERATOR_RECORD_KIND, fromSeq, fromMachineId);
+  if (served.entries.length === 0) return fromSeq;
+  to.applier.apply(fromMachineId, [served]);
+  return served.entries[served.entries.length - 1].seq;
+}
+
+describe('E2E — a topic-operator binding on A is readable on B (WS2.6 send-side, topicOperator, put-only)', () => {
+  let a: Instance;
+  let b: Instance;
+
+  beforeEach(() => {
+    a = makeInstance(A, 'a');
+    b = makeInstance(B, 'b');
+  });
+  afterEach(() => {
+    for (const inst of [a, b]) {
+      try { inst.journal.close(); } catch { /* best-effort */ }
+      SafeFsExecutor.safeRmSync(inst.dir, { recursive: true, force: true, operation: 'tests/e2e/ws2-topicoperator-cross-instance.test.ts' });
+    }
+  });
+
+  it('setOperator on A becomes readable through B\'s union reader as a foreign-origin record (topicId+uid keyed)', () => {
+    a.ops.setOperator(13481, { platform: 'telegram', uid: '999', displayName: 'Justin', boundAt: '2026-06-15T00:00:00.000Z' });
+    const rk = deriveTopicOperatorRecordKey(13481, '999')!;
+
+    expect(b.unionReader.read(TOPIC_OPERATOR_STORE_KEY, rk).value).toBeNull();
+    replicate(a, A, b, 0);
+
+    const result = b.unionReader.read(TOPIC_OPERATOR_STORE_KEY, rk);
+    expect(result.value).not.toBeNull();
+    expect(result.value!.origin).toBe(A);
+    expect(result.value!.data.uid).toBe('999');
+    expect(result.value!.data.platform).toBe('telegram');
+    // The verified uid is the authority; the projected names are lowercased display names.
+    expect(result.value!.data.names).toContain('justin');
+    expect(b.unionReader.readAll(TOPIC_OPERATOR_STORE_KEY).has(rk)).toBe(true);
+  });
+
+  it('a re-bind of the same operator (idempotent setOperator) replicates the latest record without a delete path', () => {
+    a.ops.setOperator(20905, { platform: 'telegram', uid: '777', displayName: 'Justin', boundAt: '2026-06-15T00:00:00.000Z' });
+    const rk = deriveTopicOperatorRecordKey(20905, '777')!;
+    let cursor = replicate(a, A, b, 0);
+    expect(b.unionReader.read(TOPIC_OPERATOR_STORE_KEY, rk).value).not.toBeNull();
+
+    // Re-bind with a later boundAt — a new put re-emits (put-only store; no tombstone exists).
+    a.ops.setOperator(20905, { platform: 'telegram', uid: '777', displayName: 'Justin', boundAt: '2026-06-15T12:00:00.000Z' });
+    cursor = replicate(a, A, b, cursor);
+
+    const result = b.unionReader.read(TOPIC_OPERATOR_STORE_KEY, rk);
+    expect(result.value).not.toBeNull();
+    expect(result.value!.data.boundAt).toBe('2026-06-15T12:00:00.000Z');
+  });
+});

--- a/upgrades/next/ws2-send-2b-topicoperator.md
+++ b/upgrades/next/ws2-send-2b-topicoperator.md
@@ -1,0 +1,43 @@
+# Upgrade Guide — WS2-SEND-2b: topicOperator send-side replication
+
+<!-- bump: patch -->
+
+## What Changed
+
+The `topicOperator` store is now wired into the WS2 send-side (a PII kind; WS2-SEND-2b).
+Its authoritative writer is the AgentServer's own `TopicOperatorStore`, so the generic
+emitter (#1168) is attached to `server.getTopicOperatorStore()` right after the AgentServer
+is constructed, and `topicOperator` flips PENDING→WIRED in the send-wiring ratchet. The
+union reader + disclosure-minimized projection already shipped (WS2.6). PUT-ONLY by
+construction — a topic rebinds, never unbinds. Dark by default
+(`multiMachine.stateSync.topicOperator`). No new route/verb/config-default/migration.
+
+## What to Tell Your User
+
+- **Who-runs-which-topic now travels across machines**: "If you run me on more than one
+  machine, the verified operator I bound for a topic on one machine is visible as advisory
+  context on the others — so a topic's operator isn't re-learned from scratch per machine.
+  Only the platform-verified identity crosses (the verified user id + display name) — a name
+  that merely appears in a message can never become an operator. Crucially, a binding that
+  arrives from another machine is treated as a HINT, never as the final word on 'who is my
+  operator here' — only a binding I make locally from an authenticated sender is
+  authoritative. It stays off until you ask me to turn on multi-machine sync." ⚗️
+  Experimental — ships dark.
+
+## Summary of New Capabilities
+
+| Capability | How to Use |
+|-----------|-----------|
+| Cross-machine visibility of verified topic-operator bindings (advisory) | Automatic once `multiMachine.stateSync.topicOperator` is enabled (off by default) |
+| Put-only by construction — a rebind supersedes by HLC; a topic never unbinds | Automatic |
+| Know-Your-Principal preserved — a replicated record is never authoritative for inbound resolution | Automatic (local authenticated bind always wins) |
+
+## Evidence
+
+Verified by a two-instance in-process E2E
+(`tests/e2e/ws2-topicoperator-cross-instance.test.ts`): a `setOperator` bind on instance A
+is read back on B through the bypass-proof union reader as a foreign-origin record keyed on
+(topicId + verified uid), carrying only the verified uid + lowercased names + platform; and
+an idempotent re-bind with a later `boundAt` re-replicates the latest record (put-only —
+there is no delete path). `tsc --noEmit` clean; the new e2e (2) passes; the ws2-send-wiring
+integration ratchet (4) accepts the PENDING→WIRED move.

--- a/upgrades/side-effects/ws2-send-2b-topicoperator.md
+++ b/upgrades/side-effects/ws2-send-2b-topicoperator.md
@@ -1,0 +1,45 @@
+# Side-Effects Review — WS2-SEND-2b: topicOperator send-side replication
+
+**Version / slug:** `ws2-send-2b-topicoperator`
+**Date:** `2026-06-15`
+**Author:** `Instar Agent (echo)`
+**Second-pass reviewer:** `not required` (no block/allow/lifecycle authority — additive, dark-gated data-replication wiring; see §4)
+
+## Summary of the change
+
+Extends WS2 send-side emission to the `topicOperator` store (a PII kind; WS2-SEND-2b). Unlike the seamed memory stores, topicOperator's authoritative writer is the AgentServer's OWN `TopicOperatorStore` (constructed internally at `AgentServer.ts:1092`, bound from the authenticated sender via `setOperator`). server.ts has no canonical instance of its own, so the emitter is attached AFTER the AgentServer exists, in server.ts right after `_agentServerRef = server`, via `server.getTopicOperatorStore()?.setOperatorReplicationEmitter(...)`. `ws2SendWiring.ts` moves `topicOperator` PENDING→WIRED. The union reader + projection already shipped (WS2.6). New e2e round-trip.
+
+**PUT-ONLY by construction** — a topic-operator binding is rebound, never erased (the manager has no emitDelete path; the receive side resolves the latest binding by HLC). Wiring put-only is the COMPLETE correct behavior, not a deferred gap.
+
+## Decision-point inventory
+
+- `ReplicatedRecordEmitter.emit` dark gate (`stateSync.topicOperator.enabled`) — **pass-through** — pre-existing; `topicOperator` becomes a registered emit target. Default false ⇒ no-op.
+- `TopicOperatorStore.setOperator` emit funnel — **pass-through** — already fires emitPut on a real bind/rebind; this attaches a real emitter.
+- `ws2SendWiring` ratchet — **modify** — `topicOperator` reclassified PENDING→WIRED.
+
+---
+
+## 1. Over-block
+No block/allow surface. The emitter never rejects a bind; null recordKey / null projection / over-cap is a counted no-op and the local bind always succeeds.
+
+## 2. Under-block
+Not applicable (no block surface). PUT-ONLY is the correct, complete design: a topic rebinds (a new put supersedes by HLC), never unbinds, so there is no emitDelete to wire. A `buildTopicOperatorTombstoneData` helper exists for symmetry but no manager event fires it — by construction, not omission.
+
+## 3. Level-of-abstraction fit
+Correct layer. The attach point is at the server-composition layer (where the AgentServer and its store exist), which is the only place the authoritative TopicOperatorStore is reachable. The projection lives in `TopicOperatorReplicatedStore` beside the receive-side schema.
+
+## 4. Signal vs authority compliance
+Compliant. No blocking authority. The emitter is additive/best-effort (the funnel swallows + counts faults; a bind can never fail because replication did). **Know Your Principal (REQ-M14):** only the platform-verified `uid` + lowercased display names are emitted — a content name can NEVER become an operator. A replicated topic-operator record is UNTRUSTED peer data and is NEVER the authoritative answer to "who is my verified operator of this topic?" — only the LOCAL bind from an authenticated sender is authoritative. The union read is advisory HIGH-tier. Per `docs/signal-vs-authority.md`.
+
+## 5. Interactions
+- Uses server.ts's single `replicatedRecordEmitter` (in scope at the attach point, constructed earlier). Distinct store key/kind from the other WS2 stores. No double-fire (rides the single setOperator funnel).
+- Touches `server.ts` + `ws2SendWiring.ts` (the shared WS2-SEND files) → serialized on top of merged evolutionActions; no parallel WS2-SEND PRs.
+
+## 6. External surfaces
+Dark by default (`multiMachine.stateSync.topicOperator`). Off ⇒ byte-identical single-machine behavior. On (multi-machine, opt-in): crosses the sha-keyed (topicId + verified uid) projection — platform, uid, lowercased names, boundAt. Same at-rest honesty as relationships (transit encrypted; at-rest plaintext per machine). A received record is quoted `<replicated-untrusted-data>`, advisory only — never adopted as the operator.
+
+## 7. Multi-machine posture (Cross-Machine Coherence)
+**Replicated (put-only).** Path: `TopicOperatorStore.setOperator → emit → CoherenceJournal.emitReplicatedRecord → peer serve/apply → ReplicatedPeerStreamReader → topicOperatorUnionReader`. Identity = sha(topicId + verified uid). A rebind re-emits the latest record (HLC-ordered); there is no delete (a topic never unbinds). Verified end-to-end by the new e2e (put round-trip + idempotent rebind replicates the latest boundAt).
+
+## 8. Rollback cost
+Trivial. Dark by default. Back-out = revert the server.ts + ws2SendWiring.ts change or set the flag false (instant, no migration). Receive-side + envelope schema already shipped, unaffected.


### PR DESCRIPTION
## What

Wires the `topicOperator` store (a PII kind) into the WS2 send-side. Unlike the seamed memory stores, topicOperator's authoritative writer is the AgentServer's own `TopicOperatorStore` (constructed internally; bound from the authenticated sender via `setOperator`). So the generic `ReplicatedRecordEmitter` (#1168) is attached to `server.getTopicOperatorStore()` right after the AgentServer is constructed, and `topicOperator` flips PENDING→WIRED in the ratchet. Union reader + projection already shipped (WS2.6).

**PUT-ONLY by construction** — a topic-operator binding is rebound, never erased (no emitDelete path; the receive side resolves the latest binding by HLC). Dark by default (`multiMachine.stateSync.topicOperator`).

## ELI16

Think of a "topic" as a chat room, and each room has one verified person in charge — its operator. When you run me on two computers, until now each computer figured out the operator separately. This change lets the operator I verified on one computer show up on the other as a helpful hint. The safety bit is the important part: I only ever send the *verified* id of that person (the one the chat platform itself confirmed), never a name that just happened to appear in a message — so nobody can become the operator by typing a name. And a hint that arrives from the other computer is never treated as the final word on "who's in charge here"; only a fresh, locally-verified sign-in counts as authority. It's put-only because a room's operator gets *replaced*, never deleted — so there's no "remove" to send, just the latest one. It's off unless you turn on multi-machine sync, and a two-machine test proves a binding made on machine A is readable on machine B, and that re-binding sends the newest record.

## Testing

- `tsc --noEmit` clean.
- New e2e `ws2-topicoperator-cross-instance.test.ts` (2) — put round-trip (topicId+verified-uid keyed, verified-uid + lowercased names only) + idempotent re-bind replicates the latest record, over the real journal serve/apply path.
- `ws2-send-wiring` integration ratchet (4) accepts the PENDING→WIRED move.

🤖 Generated with [Claude Code](https://claude.com/claude-code)