### PR TITLE
feat(multi-machine): WS2-SEND-2b wire userRegistry send-side replication

### DIFF
--- a/.instar/instar-dev-decisions/2026-06-15T18-41-21-142Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-06-15T18-41-21-142Z-unknown.json
@@ -1,0 +1,13 @@
+{
+  "ts": "2026-06-15T18:41:21.142Z",
+  "slug": "unknown",
+  "suggestedTier": 2,
+  "declaredTier": 2,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 2,
+  "loc": 44,
+  "causalAutopsy": null,
+  "verdict": "pass"
+}

--- a/src/commands/server.ts
+++ b/src/commands/server.ts
@@ -3827,6 +3827,42 @@ export async function startServer(options: StartOptions): Promise<void> {
       });
     }
 
+    // WS2.6 SEND-SIDE: userRegistry (a PII kind). Unlike the seamed memory stores,
+    // there is NO single canonical UserManager — telegram (send-only + normal mode)
+    // and slack each construct their OWN long-lived instance against the same
+    // users.json. This shared attacher wires the journal-backed emitter to each so a
+    // user written on ANY in-process path replicates (upsertUser→persistUsers fires
+    // emitPut for every survivor; removeUser fires the channel-keyed emitDelete
+    // tombstone). Channel-keyed identity — the local userId NEVER crosses the wire.
+    // Dark by default ⇒ no-op. SECONDARY paths NOT covered by this in-process emitter
+    // (documented in the side-effects review): the Slack org-permission admin route
+    // (per-request UserManager in routes.ts, would need RouteContext plumbing) and
+    // the `instar user add` CLI (a separate process — the snapshot reads the journal,
+    // not users.json). REQ-M14: a replicated user record is NEVER authoritative for
+    // inbound-principal resolution — the local channel index always wins.
+    const _userReplStores = replicatedRecordEmitter
+      ? await import('../core/UserRegistryReplicatedStore.js')
+      : null;
+    const attachUserReplication = (um: UserManager): void => {
+      if (!replicatedRecordEmitter || !_userReplStores) return;
+      const emitter = replicatedRecordEmitter;
+      const { USER_STORE_KEY, deriveUserRecordKey, buildUserRecordData, buildUserTombstoneData } = _userReplStores;
+      um.setUserReplicationEmitter({
+        emitPut: (rec) =>
+          emitter.emit(
+            USER_STORE_KEY,
+            deriveUserRecordKey(rec.channels),
+            (hlc, origin, observed) => buildUserRecordData({ record: rec, hlc, origin, observed }),
+          ),
+        emitDelete: (channels, deletedAt) =>
+          emitter.emit(
+            USER_STORE_KEY,
+            deriveUserRecordKey(channels),
+            (hlc, origin, observed) => buildUserTombstoneData({ channels, hlc, origin, deletedAt, observed }),
+          ),
+      });
+    };
+
     const selfStateSyncReceive = (): Record<string, boolean> => {
       const out: Record<string, boolean> = {};
       const stores = _stateSyncStoresResolved;
@@ -5279,6 +5315,7 @@ export async function startServer(options: StartOptions): Promise<void> {
       // "--no-telegram (registry-only) injection" branch and slash-commands
       // reached the AI session as plain chat text.
       const userManagerSendOnly = new UserManager(config.stateDir, config.users);
+      attachUserReplication(userManagerSendOnly); // WS2.6 send-side (dark by default)
       _fixDeps = { state, liveConfig, sessionManager, telegram, config };
       wireTelegramRouting(telegram, sessionManager, quotaTracker, topicMemory, userManagerSendOnly,
         (topicId, text) => handleFixCommand(topicId, text, _fixDeps!),
@@ -5409,6 +5446,7 @@ export async function startServer(options: StartOptions): Promise<void> {
 
       // Initialize persistent UserManager for user identity resolution (Gap 8)
       const userManager = new UserManager(config.stateDir, config.users);
+      attachUserReplication(userManager); // WS2.6 send-side (dark by default)
 
       // Fix command dependencies — populated later when subsystems initialize.
       // Uses a mutable ref so wireTelegramRouting can capture it in a closure now.
@@ -5941,6 +5979,7 @@ export async function startServer(options: StartOptions): Promise<void> {
             // Own UserManager instance for verified-principal resolution (the
             // Telegram-block userManager is out of scope here). Reads users.json.
             const slackUserManager = new UserManager(config.stateDir, config.users);
+            attachUserReplication(slackUserManager); // WS2.6 send-side (dark by default)
             // ── Floor-action grants are read from the SIGNED Coordination Mandate ──
             // A MandateStore reader over the SAME file + SAME HMAC sign/verify deps as
             // the coordination engine in AgentServer (which is constructed later, so we

--- a/src/core/ws2SendWiring.ts
+++ b/src/core/ws2SendWiring.ts
@@ -24,19 +24,16 @@ export const WS2_SEND_WIRED_STORES: ReadonlyArray<string> = Object.freeze([
   'knowledge',
   'evolutionActions',
   'topicOperator',
+  'userRegistry',
 ]);
 
 /**
  * Stores registered for RECEIVE but whose SEND wiring is a KNOWN, enumerated
  * follow-up — NOT a silent omission. Each is here for a stated reason:
- *  - userRegistry: fully seamed manager (emitPut + emitDelete); its canonical write
- *    instance lives in the AgentServer, so it needs the emitter plumbed there before it
- *    can be wired (WS2-SEND-2b).
  *  - preferences: NO manager emit seam yet — it rode the deprecated `preferences-sync`
  *    verb; needs a manager emit hook before it can be wired (WS2-SEND-3).
  */
 export const WS2_SEND_PENDING_STORES: ReadonlyArray<string> = Object.freeze([
-  'userRegistry',
   'preferences',
 ]);
 

--- a/tests/e2e/ws2-userregistry-cross-instance.test.ts
+++ b/tests/e2e/ws2-userregistry-cross-instance.test.ts
@@ -1,0 +1,159 @@
+// safe-fs-allow: test fixture teardown uses SafeFsExecutor.safeRmSync on tmp dirs only.
+/**
+ * E2E — WS2 send-side: a registered USER known on instance A is READABLE on instance B
+ * (the proven round-trip shape applied to the `userRegistry` store — WS2-SEND-2b, the
+ * SECOND PII kind). Identity across machines = the CHANNEL SET, never the local userId.
+ *
+ * REQ-M14: a replicated user record is NEVER authoritative for inbound-principal
+ * resolution — this test only proves the CATALOG crosses (the local channel index stays
+ * the authority for "who is this sender?"). emitPut rides upsertUser→persistUsers;
+ * emitDelete rides removeUser. The local userId is NEVER emitted (channel-keyed identity).
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+
+import { CoherenceJournal } from '../../src/core/CoherenceJournal.js';
+import { JournalSyncApplier } from '../../src/core/JournalSyncApplier.js';
+import { ReplicatedPeerStreamReader } from '../../src/core/ReplicatedPeerStreamReader.js';
+import { ReplicatedRecordEmitter } from '../../src/core/ReplicatedRecordEmitter.js';
+import { ReplicatedStoreReader } from '../../src/core/ReplicatedStoreReader.js';
+import { ReplicatedKindRegistry } from '../../src/core/ReplicatedRecordEnvelope.js';
+import { ConflictStore } from '../../src/core/ConflictStore.js';
+import { DroppedOriginRegistry } from '../../src/core/RollbackUnmerge.js';
+import { UserManager } from '../../src/users/UserManager.js';
+import { HybridLogicalClock } from '../../src/core/HybridLogicalClock.js';
+import {
+  USER_KIND_REGISTRATION,
+  USER_RECORD_KIND,
+  USER_STORE_KEY,
+  userTierOf,
+  buildUserRecordData,
+  buildUserTombstoneData,
+  deriveUserRecordKey,
+} from '../../src/core/UserRegistryReplicatedStore.js';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+
+const A = 'm_laptop';
+const B = 'm_mac_mini';
+
+function reg(): ReplicatedKindRegistry {
+  const r = new ReplicatedKindRegistry();
+  r.register(USER_KIND_REGISTRATION);
+  return r;
+}
+
+interface Instance {
+  dir: string;
+  journal: CoherenceJournal;
+  applier: JournalSyncApplier;
+  reader: ReplicatedPeerStreamReader;
+  users: UserManager;
+  unionReader: ReplicatedStoreReader;
+}
+
+function makeInstance(machineId: string, label: string): Instance {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), `ws2e2e-user-${label}-`));
+  const registry = reg();
+  const journal = new CoherenceJournal({ stateDir: dir, machineId, flushIntervalMs: 1_000_000 });
+  journal.open();
+  journal.setReplicatedKindRegistry(registry);
+  const applier = new JournalSyncApplier({ stateDir: dir, replicatedRegistry: registry });
+  const reader = new ReplicatedPeerStreamReader({ stateDir: dir, registry, selfMachineId: machineId });
+  const users = new UserManager(dir, []);
+
+  const emitter = new ReplicatedRecordEmitter({
+    journal,
+    clock: new HybridLogicalClock({ node: machineId, now: () => Date.now() }),
+    registry,
+    origin: machineId,
+    stores: () => ({ userRegistry: { enabled: true } }),
+    loadWitness: (store, rk) => reader.loadWitness(store, rk),
+  });
+  users.setUserReplicationEmitter({
+    emitPut: (rec) => emitter.emit(USER_STORE_KEY, deriveUserRecordKey(rec.channels),
+      (hlc, o, observed) => buildUserRecordData({ record: rec, hlc, origin: o, observed })),
+    emitDelete: (channels, deletedAt) => emitter.emit(USER_STORE_KEY, deriveUserRecordKey(channels),
+      (hlc, o, observed) => buildUserTombstoneData({ channels, hlc, origin: o, deletedAt, observed })),
+  });
+
+  const unionReader = new ReplicatedStoreReader({
+    registry,
+    stores: { userRegistry: { enabled: true } },
+    tierOf: userTierOf,
+    loadOriginRecords: (store, rk) => reader.loadOriginRecords(store, rk),
+    listRecordKeys: (store) => reader.listRecordKeys(store),
+    droppedOrigins: new DroppedOriginRegistry({ stateDir: dir }),
+    conflictStore: new ConflictStore({ stateDir: dir, now: () => new Date() }),
+  });
+
+  return { dir, journal, applier, reader, users, unionReader };
+}
+
+function replicate(from: Instance, fromMachineId: string, to: Instance, fromSeq: number): number {
+  from.journal.flush();
+  const served = from.applier.buildServeBatch(USER_RECORD_KIND, fromSeq, fromMachineId);
+  if (served.entries.length === 0) return fromSeq;
+  to.applier.apply(fromMachineId, [served]);
+  return served.entries[served.entries.length - 1].seq;
+}
+
+describe('E2E — a registered user known on A is readable on B (WS2.6 send-side, userRegistry)', () => {
+  let a: Instance;
+  let b: Instance;
+
+  beforeEach(() => {
+    a = makeInstance(A, 'a');
+    b = makeInstance(B, 'b');
+  });
+  afterEach(() => {
+    for (const inst of [a, b]) {
+      try { inst.journal.close(); } catch { /* best-effort */ }
+      SafeFsExecutor.safeRmSync(inst.dir, { recursive: true, force: true, operation: 'tests/e2e/ws2-userregistry-cross-instance.test.ts' });
+    }
+  });
+
+  it('addUserInteractive on A becomes readable through B\'s union reader as a foreign-origin record (channel-keyed, no local userId)', () => {
+    a.users.addUserInteractive({ id: 'u1', name: 'Alice', channels: [{ type: 'telegram', identifier: '111' }], permissions: ['user'] });
+    const rk = deriveUserRecordKey([{ type: 'telegram', identifier: '111' }])!;
+
+    expect(b.unionReader.read(USER_STORE_KEY, rk).value).toBeNull();
+    replicate(a, A, b, 0);
+
+    const result = b.unionReader.read(USER_STORE_KEY, rk);
+    expect(result.value).not.toBeNull();
+    expect(result.value!.origin).toBe(A);
+    expect(result.value!.data.name).toBe('Alice');
+    // The local userId is NEVER among the projected fields (channel-keyed identity).
+    expect((result.value!.data as Record<string, unknown>).id).toBeUndefined();
+    expect(b.unionReader.readAll(USER_STORE_KEY).has(rk)).toBe(true);
+  });
+
+  it('the SAME user (same channel set) on BOTH machines collapses to ONE recordKey across origins', () => {
+    a.users.addUserInteractive({ id: 'u_a', name: 'Bob', channels: [{ type: 'telegram', identifier: '222' }] });
+    b.users.addUserInteractive({ id: 'u_b', name: 'Bob', channels: [{ type: 'telegram', identifier: '222' }] });
+
+    replicate(a, A, b, 0);
+    b.journal.flush();
+    const rk = deriveUserRecordKey([{ type: 'telegram', identifier: '222' }])!;
+    const origins = b.reader.loadOriginRecords(USER_STORE_KEY, rk);
+    expect(origins.map((o) => o.origin).sort()).toEqual([A, B].sort());
+    // ONE key, not two — the channel set collapsed the same person across machines.
+    expect(b.reader.listRecordKeys(USER_STORE_KEY)).toEqual([rk]);
+  });
+
+  it('a removeUser on A replicates as a channel-keyed tombstone and the union resolves the key to no-record', () => {
+    a.users.addUserInteractive({ id: 'doomed', name: 'Carol', channels: [{ type: 'telegram', identifier: '333' }] });
+    const rk = deriveUserRecordKey([{ type: 'telegram', identifier: '333' }])!;
+    let cursor = replicate(a, A, b, 0);
+    expect(b.unionReader.read(USER_STORE_KEY, rk).value).not.toBeNull();
+
+    expect(a.users.removeUser('doomed')).toBe(true);
+    cursor = replicate(a, A, b, cursor);
+    expect(cursor).toBeGreaterThan(0);
+
+    // The tombstone wins (no resurrection) — B resolves the key to "no record".
+    expect(b.unionReader.read(USER_STORE_KEY, rk).value).toBeNull();
+  });
+});

--- a/upgrades/next/ws2-send-2b-userregistry.md
+++ b/upgrades/next/ws2-send-2b-userregistry.md
@@ -1,0 +1,51 @@
+# Upgrade Guide — WS2-SEND-2b: userRegistry send-side replication
+
+<!-- bump: patch -->
+
+## What Changed
+
+The `userRegistry` store (a PII kind) is now wired into the WS2 send-side. Unlike the
+seamed memory stores, there is no single canonical `UserManager` — telegram (send-only +
+normal mode) and slack each construct their own long-lived instance. A shared
+`attachUserReplication` helper in `server.ts` wires the generic emitter (#1168) to each at
+its construction site, and `userRegistry` flips PENDING→WIRED in the ratchet (leaving only
+`preferences`). Channel-keyed identity — the local userId never crosses. Dark by default
+(`multiMachine.stateSync.userRegistry`). No new route/verb/config-default/migration.
+
+## What to Tell Your User
+
+- **The people I know now travel across machines**: "If you run me on more than one
+  machine, a user I learn about on one (from telegram or slack) now shows up in my user
+  registry on the others — one shared set of people instead of one per machine. Only the
+  profile crosses (name, channels, permissions) — never the local id I use internally, and
+  identity is matched by a person's channel set so the same person collapses to one record
+  across machines. Importantly, a user record that arrives from another machine is a HINT
+  only — it is NEVER how I decide who an incoming message is actually from (that stays a
+  local, verified decision). It stays off until you ask me to turn on multi-machine sync."
+  ⚗️ Experimental — ships dark.
+
+## Summary of New Capabilities
+
+| Capability | How to Use |
+|-----------|-----------|
+| Cross-machine replication of the user registry (profile metadata, channel-keyed) | Automatic once `multiMachine.stateSync.userRegistry` is enabled (off by default) |
+| Same person (same channel set) on two machines collapses to one record | Automatic (read path) |
+| Removing a user propagates a channel-keyed tombstone (no resurrection) | Automatic (removeUser path) |
+
+## Known capture-scope (honest)
+
+The in-process emitter captures the dominant server-process user-creation paths (telegram
+both modes + slack inbound). Two secondary paths are NOT captured by design and are
+documented in the side-effects review: the Slack org-permission admin route (a per-request
+UserManager) and the `instar user add` CLI (a separate process). A single canonical-instance
+funnel would close both and is a reasonable future refactor.
+
+## Evidence
+
+Verified by a two-instance in-process E2E
+(`tests/e2e/ws2-userregistry-cross-instance.test.ts`): a user added on instance A is read
+back on B through the bypass-proof union reader as a foreign-origin record (channel-keyed,
+local userId confirmed ABSENT); the same user (same channel set) on both machines collapses
+to one record key across origins; and a removeUser on A replicates as a channel-keyed
+tombstone so B resolves the key to "no record". `tsc --noEmit` clean; the new e2e (3) passes;
+the ws2-send-wiring integration ratchet (4) accepts the PENDING→WIRED move.

--- a/upgrades/side-effects/ws2-send-2b-userregistry.md
+++ b/upgrades/side-effects/ws2-send-2b-userregistry.md
@@ -1,0 +1,48 @@
+# Side-Effects Review — WS2-SEND-2b: userRegistry send-side replication
+
+**Version / slug:** `ws2-send-2b-userregistry`
+**Date:** `2026-06-15`
+**Author:** `Instar Agent (echo)`
+**Second-pass reviewer:** `not required` (no block/allow/lifecycle authority — additive, dark-gated data-replication wiring; see §4)
+
+## Summary of the change
+
+Extends WS2 send-side emission to the `userRegistry` store (the SECOND PII kind; WS2-SEND-2b). Unlike the seamed memory stores, `userRegistry` has NO single canonical UserManager — telegram (send-only mode + normal mode) and slack each construct their OWN long-lived `UserManager` against the same `users.json`. So a single shared attacher (`attachUserReplication`, defined in `src/commands/server.ts` right after the emitter is constructed) wires the journal-backed emitter to each long-lived instance at its construction site (`userManagerSendOnly`, `userManager`, `slackUserManager`). `ws2SendWiring.ts` moves `userRegistry` PENDING→WIRED (leaving only `preferences`). The union reader + projection already shipped (WS2.6). New e2e round-trip.
+
+Channel-keyed identity — the local `userId` NEVER crosses. `upsertUser→persistUsers` fires emitPut for every surviving user; `removeUser` fires the channel-keyed emitDelete tombstone.
+
+## Decision-point inventory
+
+- `ReplicatedRecordEmitter.emit` dark gate (`stateSync.userRegistry.enabled`) — **pass-through** — pre-existing; `userRegistry` becomes a registered emit target. Default false ⇒ no-op.
+- `UserManager.persistUsers` / `removeUser` emit funnels — **pass-through** — already fire; this attaches a real emitter at each long-lived instance.
+- `ws2SendWiring` ratchet — **modify** — `userRegistry` reclassified PENDING→WIRED.
+
+---
+
+## 1. Over-block
+No block/allow surface. The emitter never rejects a user write; null recordKey / null projection / over-cap is a counted no-op and the local write always succeeds.
+
+## 2. Under-block
+Not applicable (no block surface). **Honest capture-scope note** (the load-bearing caveat): the in-process emitter fires on the SERVER-PROCESS user-write paths — telegram (both modes) + slack inbound registration, which are the dominant user-creation paths. TWO secondary paths are NOT covered, by design, and are stated rather than silently dropped:
+  1. The Slack org-permission **admin** route (`buildSlackRegistry` in routes.ts) constructs a per-request UserManager; reaching the emitter there needs RouteContext plumbing disproportionate to a secondary admin flow.
+  2. The `instar user add` **CLI** runs in a SEPARATE PROCESS, so it can never fire the server's in-process emitter; the send-side snapshot reads the journal's own entries, not `users.json`, so a CLI-only user is a known gap.
+This matches the accepted in-process capture scope of relationships/knowledge. A single write funnel (one canonical UserManager) would close both gaps and is a reasonable future refactor; it is out of scope for "identical wiring."
+
+## 3. Level-of-abstraction fit
+Correct layer. A shared attacher at the construction sites is the minimal change that captures the multiple long-lived instances without a refactor. The projection lives in `UserRegistryReplicatedStore` beside the receive-side schema.
+
+## 4. Signal vs authority compliance
+Compliant. No blocking authority. The emitter is additive/best-effort (the funnel swallows + counts faults; a user write can never fail because replication did). **REQ-M14 (Know Your Principal):** a replicated user record is UNTRUSTED peer data and is NEVER the authoritative answer to "who is this inbound sender?" — inbound-principal resolution stays LOCAL-ONLY (the local channel index always wins). The union read is advisory HIGH-tier. Per `docs/signal-vs-authority.md`.
+
+## 5. Interactions
+- Uses server.ts's single `replicatedRecordEmitter` via the shared `attachUserReplication` helper. Distinct store key/kind from the other WS2 stores. No double-fire (each instance rides its own persistUsers funnel; the same person on two instances collapses to one channel-keyed recordKey).
+- Touches `server.ts` + `ws2SendWiring.ts` (the shared WS2-SEND files) → serialized on top of merged topicOperator; no parallel WS2-SEND PRs.
+
+## 6. External surfaces
+Dark by default (`multiMachine.stateSync.userRegistry`). Off ⇒ byte-identical single-machine behavior. On (multi-machine, opt-in): crosses the channel-keyed profile projection (name, channels, permissions) — never the local userId. Same at-rest honesty as relationships (transit encrypted; at-rest plaintext per machine). A received record is quoted `<replicated-untrusted-data>`, advisory only.
+
+## 7. Multi-machine posture (Cross-Machine Coherence)
+**Replicated.** Path: `upsertUser/removeUser → persistUsers → emit → CoherenceJournal.emitReplicatedRecord → peer serve/apply → ReplicatedPeerStreamReader → userRegistryUnionReader`. Identity = channel set (the same person on two machines collapses to one recordKey). removeUser propagates a channel-keyed tombstone (no resurrection). Verified end-to-end by the new e2e (put round-trip + channel-set collapse + removeUser tombstone resolves to no-record).
+
+## 8. Rollback cost
+Trivial. Dark by default. Back-out = revert the server.ts + ws2SendWiring.ts change or set the flag false (instant, no migration). Receive-side + envelope schema already shipped, unaffected.


### PR DESCRIPTION
## What

Wires the `userRegistry` store (a PII kind) into the WS2 send-side. Unlike the seamed memory stores, there is no single canonical `UserManager` — telegram (send-only + normal mode) and slack each construct their own long-lived instance against the same `users.json`. A shared `attachUserReplication` helper (defined in `server.ts` right after the emitter is built) wires the generic `ReplicatedRecordEmitter` (#1168) to each at its construction site. `ws2SendWiring.ts` moves `userRegistry` PENDING→WIRED (leaving only `preferences`).

Channel-keyed identity — the local `userId` NEVER crosses. `upsertUser→persistUsers` fires emitPut per surviving user; `removeUser` fires the channel-keyed emitDelete tombstone. Dark by default (`multiMachine.stateSync.userRegistry`).

**Honest capture-scope** (side-effects §2): the in-process emitter covers the dominant server-process user-creation paths (telegram both modes + slack inbound). Two secondary paths are NOT covered, by design and documented: the Slack org-permission admin route (per-request UserManager) and the `instar user add` CLI (separate process). A single-funnel refactor would close both; out of scope for "identical wiring."

## ELI16

I keep a little address book of the people who talk to me. When you run me on two computers, until now each computer kept its OWN separate address book. This change lets a person I meet on one computer show up in the address book on the other — matched by their chat handles, so the same person doesn't get listed twice. I only send the public profile bits (name, which chats they're on, what they're allowed to do) and never the private internal id number I use for them. The most important safety rule: an address-book entry that arrives from the other computer is only ever a *hint* — it is NEVER how I decide who an incoming message is really from. That decision always stays local and verified, so a synced entry can't impersonate anyone. It's off unless you turn on multi-machine sync. A two-machine test proves a user added on machine A shows up on B, the same person collapses to one entry, and removing them sends a "tombstone" so they don't come back.

## Testing

- `tsc --noEmit` clean.
- New e2e `ws2-userregistry-cross-instance.test.ts` (3) — put round-trip (channel-keyed, local userId confirmed absent) + same-channel-set collapse across origins + removeUser tombstone resolves to no-record, over the real journal serve/apply path.
- `ws2-send-wiring` integration ratchet (4) accepts the PENDING→WIRED move.

🤖 Generated with [Claude Code](https://claude.com/claude-code)