### PR TITLE
feat(credential-repointing): boot-seed the location ledger — wire seedFromOracle (dark/dev)

### DIFF
--- a/.instar/instar-dev-decisions/2026-06-15T19-59-56-669Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-06-15T19-59-56-669Z-unknown.json
@@ -1,0 +1,13 @@
+{
+  "ts": "2026-06-15T19:59:56.669Z",
+  "slug": "unknown",
+  "suggestedTier": 1,
+  "declaredTier": 2,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 2,
+  "loc": 40,
+  "causalAutopsy": null,
+  "verdict": "pass"
+}

--- a/src/commands/server.ts
+++ b/src/commands/server.ts
@@ -9713,7 +9713,7 @@ export async function startServer(options: StartOptions): Promise<void> {
     // off (always, while dark) every gate read returns the enrollment-home fallback, so every
     // consumer is byte-for-byte today's behavior. A never-seeded ledger is the same fallback (back-
     // compat); only UNKNOWN mode (corrupt on-disk) raises a HIGH attention item, never throws.
-    const { CredentialLocationLedger } = await import('../core/CredentialLocationLedger.js');
+    const { CredentialLocationLedger, shouldBootSeedCredentialLedger } = await import('../core/CredentialLocationLedger.js');
     const { CredentialIdentityOracle } = await import('../core/CredentialIdentityOracle.js');
     const { CredentialLocationGate } = await import('../core/CredentialLocationGate.js');
     const credentialGateEmitAttention = telegram
@@ -9901,6 +9901,32 @@ export async function startServer(options: StartOptions): Promise<void> {
         }
       },
     };
+
+    // B3a — boot-seed the credential location ledger. This is the MISSING runtime trigger for
+    // seedFromOracle: without it the ledger stays NEVER-SEEDED forever, so getAssignments() returns
+    // [] and the rebalancer (B3b) only ever sees the default slot — it can decide but never actuate
+    // a use-it-or-lose-it drain (it has no other slots to move between). Gated on the SAME dev-gate
+    // as the rest of re-pointing (strict no-op / no probe on the fleet) and ONLY when the ledger is
+    // not already seeded — isSeeded() is false for both never-seeded AND UNKNOWN (corrupt) mode, so
+    // this also doubles as the named recovery path, and it's idempotent across restarts (a seeded
+    // ledger is skipped). Fire-and-forget: the oracle probes are per-slot network calls, so boot is
+    // never blocked on them; failures are loud at the slot level (quarantine + attention) INSIDE
+    // seedFromOracle. Seeding writes ONLY the local slot→account map — it moves ZERO credentials
+    // (the executor's dryRun gate + the one-home invariant still guard every real swap). <!-- tracked: 20905 -->
+    if (
+      shouldBootSeedCredentialLedger(
+        resolveDevAgentGate(config.subscriptionPool?.credentialRepointing?.enabled, config),
+        credentialLocationLedger.isSeeded(),
+      )
+    ) {
+      void credentialLocationLedger
+        .seedFromOracle()
+        .then((outcomes) => {
+          const assigned = outcomes.filter((o) => o.result === 'assigned').length;
+          console.log(pc.green(`  Credential location ledger seeded: ${assigned}/${outcomes.length} slot(s) mapped`));
+        })
+        .catch((e) => console.warn(`[CredentialLedger] boot seed failed: ${e instanceof Error ? e.message : String(e)}`));
+    }
 
     // B3b — the periodic balancer pass. tick() is a strict no-op while the feature resolves dark
     // (so the timer can always run; the gate lives INSIDE tick()), and on a dev agent it runs the

--- a/src/core/CredentialLocationLedger.ts
+++ b/src/core/CredentialLocationLedger.ts
@@ -482,3 +482,15 @@ export class CredentialLocationLedger {
     }
   }
 }
+
+/**
+ * The boot-seed decision (B3a). Pure + isolated so the wiring decision is unit-testable without
+ * booting server.ts. Returns true ONLY when the re-pointing feature is enabled AND the ledger is
+ * not already seeded — `isSeeded()` is false for BOTH never-seeded and UNKNOWN (corrupt) mode, so
+ * a true result also covers the named recovery path, and a seeded ledger is always skipped (so the
+ * boot-seed is idempotent across restarts). The actual seed (`seedFromOracle()`) is non-destructive
+ * and already unit-tested; this guard is the new logic the wiring introduced.
+ */
+export function shouldBootSeedCredentialLedger(enabled: boolean, isSeeded: boolean): boolean {
+  return enabled && !isSeeded;
+}

--- a/tests/e2e/credential-ledger-boot-seed.test.ts
+++ b/tests/e2e/credential-ledger-boot-seed.test.ts
@@ -1,0 +1,110 @@
+/**
+ * E2E (Tier-3 "feature is alive" + data-flow) for the B3a boot-seed wiring.
+ *
+ * Spec: docs/specs/live-credential-repointing-rebalancer.md §52 (seeding/recovery via the oracle).
+ *
+ * Proves the loop the inline server.ts wiring closes: the boot-seed guard fires the (non-destructive)
+ * seedFromOracle() and the resulting slot↔account map FLOWS THROUGH to the real GET /credentials/locations
+ * route — i.e. the rebalancer would actually have slots to balance, instead of a permanently-empty ledger.
+ *
+ * Both sides of the boundary, end-to-end through the real route:
+ *  - dev-gate ON  → boot-seeds → /credentials/locations shows the mapped assignments (mode 'active')
+ *  - dev-gate OFF → guard skips the seed → ledger stays never-seeded → assignments: [] (mode 'dark')
+ */
+
+import { describe, it, expect, afterEach } from 'vitest';
+import express from 'express';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import type { AddressInfo } from 'node:net';
+import { createRoutes } from '../../src/server/routes.js';
+import { SubscriptionPool } from '../../src/core/SubscriptionPool.js';
+import {
+  CredentialLocationLedger,
+  shouldBootSeedCredentialLedger,
+  type IdentityOracle,
+  type LedgerPoolView,
+} from '../../src/core/CredentialLocationLedger.js';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+
+interface TestServer { url: string; close: () => Promise<void>; }
+function listen(app: express.Express): Promise<TestServer> {
+  return new Promise((resolve) => {
+    const srv = app.listen(0, () => {
+      const port = (srv.address() as AddressInfo).port;
+      resolve({ url: `http://127.0.0.1:${port}`, close: () => new Promise<void>((r) => srv.close(() => r())) });
+    });
+  });
+}
+
+describe('credential ledger boot-seed — E2E (seed flows to /credentials/locations)', () => {
+  let server: TestServer | undefined;
+  let dir: string | undefined;
+  afterEach(async () => {
+    await server?.close();
+    server = undefined;
+    if (dir) { try { SafeFsExecutor.safeRmSync(dir, { recursive: true, force: true, operation: 'credential-ledger-boot-seed.test cleanup' }); } catch { /* @silent-fallback-ok */ } dir = undefined; }
+  });
+
+  /** Mirror the server.ts boot-seed wiring chain (pool → oracle → ledger → guard → seed → route). */
+  async function bootSeeded(enabled: boolean): Promise<void> {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'cred-bootseed-e2e-'));
+    const pool = new SubscriptionPool({ stateDir: dir });
+    const homeA = path.join(dir, '.claude-a');
+    const homeB = path.join(dir, '.claude-b');
+    pool.add({ id: 'acct-a', nickname: 'A', provider: 'anthropic', framework: 'claude-code', configHome: homeA, email: 'a@x.com' });
+    pool.add({ id: 'acct-b', nickname: 'B', provider: 'anthropic', framework: 'claude-code', configHome: homeB, email: 'b@x.com' });
+
+    const poolView: LedgerPoolView = { list: () => pool.list().map((a) => ({ id: a.id, email: a.email, configHome: a.configHome, framework: a.framework })) };
+    // Oracle maps each slot (configHome) to its real tenant email — the happy path of seeding.
+    const emailByHome: Record<string, string> = { [homeA]: 'a@x.com', [homeB]: 'b@x.com' };
+    const oracle: IdentityOracle = { async resolveSlotTenant(slot: string) { const email = emailByHome[slot]; return email ? { email } : { unavailable: true }; } };
+
+    const ledger = new CredentialLocationLedger({ stateDir: dir, pool: poolView, oracle });
+
+    // THE WIRING UNDER TEST (identical guard the server.ts boot path uses, awaited here for determinism).
+    if (shouldBootSeedCredentialLedger(enabled, ledger.isSeeded())) {
+      await ledger.seedFromOracle();
+    }
+
+    const app = express();
+    app.use(express.json());
+    const ctx: any = {
+      config: { authToken: 't', stateDir: dir, port: 0, subscriptionPool: { credentialRepointing: { enabled } } },
+      startTime: new Date(),
+      subscriptionPool: pool,
+      credentialRepointing: {
+        ledger,
+        audit: { response: (b: unknown) => b },
+        levers: { forcedBudgetRemaining: () => 10 },
+      },
+    };
+    app.use(createRoutes(ctx));
+    server = await listen(app);
+  }
+
+  const api = (p: string) =>
+    fetch(server!.url + p, { headers: { 'Content-Type': 'application/json', Authorization: 'Bearer t' } }).then(async (r) => ({ status: r.status, body: await r.json().catch(() => ({})) as any }));
+
+  it('dev-gate ON: boot-seeds and the mapped slots flow to GET /credentials/locations', async () => {
+    await bootSeeded(true);
+    const r = await api('/credentials/locations');
+    expect(r.status).toBe(200);
+    expect(r.body.enabled).toBe(true);
+    expect(r.body.mode).toBe('active');
+    const byAccount = Object.fromEntries(r.body.assignments.map((a: any) => [a.accountId, a.slot]));
+    expect(byAccount['acct-a']).toMatch(/\.claude-a$/);
+    expect(byAccount['acct-b']).toMatch(/\.claude-b$/);
+    expect(r.body.assignments.filter((a: any) => a.accountId).length).toBe(2);
+  });
+
+  it('dev-gate OFF: the guard skips the seed — ledger stays never-seeded (assignments: [])', async () => {
+    await bootSeeded(false);
+    const r = await api('/credentials/locations');
+    expect(r.status).toBe(200);
+    expect(r.body.enabled).toBe(false);
+    expect(r.body.mode).toBe('dark');
+    expect(r.body.assignments).toEqual([]);
+  });
+});

--- a/tests/unit/credential-ledger-boot-seed-guard.test.ts
+++ b/tests/unit/credential-ledger-boot-seed-guard.test.ts
@@ -1,0 +1,37 @@
+/**
+ * Unit test for the B3a boot-seed guard (`shouldBootSeedCredentialLedger`).
+ *
+ * This is the NEW decision the boot-seed wiring introduced (server.ts, just before the B3b
+ * rebalancer timer). Without a runtime trigger the CredentialLocationLedger stays NEVER-SEEDED
+ * forever — getAssignments() returns [] and the rebalancer only ever sees the default slot, so it
+ * can decide but never actuate a use-it-or-lose-it drain. The guard decides WHEN to fire the
+ * (non-destructive, already-unit-tested) seedFromOracle() at boot.
+ *
+ * Both sides of every boundary (Testing Integrity — semantic correctness):
+ *  - enabled + not-seeded            → seed   (the populate path AND the unknown-mode recovery path,
+ *                                              since isSeeded() is false for both)
+ *  - disabled (dark fleet)           → no-op  (byte-for-byte today's behavior; no probe)
+ *  - enabled + already seeded        → no-op  (idempotent across restarts — never re-probes)
+ *  - disabled + already seeded       → no-op
+ */
+
+import { describe, it, expect } from 'vitest';
+import { shouldBootSeedCredentialLedger } from '../../src/core/CredentialLocationLedger.js';
+
+describe('shouldBootSeedCredentialLedger — boot-seed guard (B3a)', () => {
+  it('seeds when enabled AND the ledger is not yet seeded (never-seeded / unknown-mode recovery)', () => {
+    expect(shouldBootSeedCredentialLedger(true, false)).toBe(true);
+  });
+
+  it('does NOT seed when the feature is disabled (dark fleet) — no probe, today’s behavior', () => {
+    expect(shouldBootSeedCredentialLedger(false, false)).toBe(false);
+  });
+
+  it('does NOT re-seed when the ledger is already seeded — idempotent across restarts', () => {
+    expect(shouldBootSeedCredentialLedger(true, true)).toBe(false);
+  });
+
+  it('does NOT seed when disabled even if somehow already seeded', () => {
+    expect(shouldBootSeedCredentialLedger(false, true)).toBe(false);
+  });
+});

--- a/upgrades/next/credential-ledger-boot-seed.md
+++ b/upgrades/next/credential-ledger-boot-seed.md
@@ -1,0 +1,20 @@
+## What Changed
+
+Wired the missing runtime trigger for the live-credential-repointing **location ledger**. The build (spec §52) shipped the ability to seed the ledger from the identity oracle but never called it at boot, so on every agent the ledger stayed permanently NEVER-SEEDED: `GET /credentials/locations` returned `assignments: []` and the autonomous use-it-or-lose-it `CredentialRebalancer` could *decide* but never *actuate* a drain (it only ever saw the single default slot). This change adds a boot-seed in `src/commands/server.ts` (just before the B3b rebalancer timer), guarded by a new pure `shouldBootSeedCredentialLedger(enabled, isSeeded)` helper in `CredentialLocationLedger.ts`: it seeds once at startup when re-pointing is dev-gated-on AND the ledger is not already seeded (`isSeeded()` is false for both never-seeded and corrupt/unknown mode, so it doubles as the spec's named recovery path), idempotent across restarts. Fire-and-forget so boot is never blocked on the per-slot oracle probes. **Non-destructive**: it writes only the local slot→account map; moving a credential still requires the executor's `dryRun:false` gate + the write funnel + the one-home invariant — none of which this change touches.
+
+## What to Tell Your User
+
+Nothing changes for regular agents — this ships switched off for them and does nothing there. For the developer agent, the account optimizer that spreads work across your subscriptions can now actually see your accounts at startup instead of starting blank, so its practice runs reflect your real accounts. Nothing is moved by this change — the separate step that lets it actually shift logins between accounts still needs your explicit go-ahead.
+
+## Summary of New Capabilities
+
+- The credential location ledger now self-seeds at server boot on a dev agent (dev-gated; dark/no-op on the fleet) — `GET /credentials/locations` shows real slot↔account assignments (`mode: 'active'`) instead of `assignments: []`.
+- The autonomous credential rebalancer (use-it-or-lose-it drainer) now has real slots to operate over in its dry-run dogfooding, instead of only ever seeing the default slot.
+- Doubles as the ledger's boot-recovery path (a corrupt/unknown-mode ledger is re-seeded from the identity oracle on the next restart).
+
+## Evidence
+
+- Unit (new): `tests/unit/credential-ledger-boot-seed-guard.test.ts` — 4 tests, both sides of every boundary (enabled+unseeded→seed incl. unknown-mode recovery / disabled→no-op / already-seeded→no-op idempotent).
+- Unit (existing, unchanged): `tests/unit/credential-location-ledger.test.ts` — 17 tests for `seedFromOracle` itself (oracle-unavailable→quarantine, ambiguous/unknown-email→refuse+attention, one-home invariant, unknown-mode recovery).
+- E2E (new): `tests/e2e/credential-ledger-boot-seed.test.ts` — 2 tests booting the real `GET /credentials/locations` route over the server.ts wiring chain (pool → oracle → ledger → guard → seed): dev-gate ON boot-seeds and the mapped slots flow to the route (`mode: 'active'`, 2 assignments); dev-gate OFF the guard skips the seed so the ledger stays never-seeded (`assignments: []`, `mode: 'dark'`).
+- `tsc --noEmit` clean. Side-effects review: `upgrades/side-effects/credential-ledger-boot-seed.md`.

--- a/upgrades/side-effects/credential-ledger-boot-seed.md
+++ b/upgrades/side-effects/credential-ledger-boot-seed.md
@@ -1,0 +1,95 @@
+# Side-Effects Review — Credential location ledger boot-seed (B3a)
+
+**Version / slug:** `credential-ledger-boot-seed`
+**Date:** `2026-06-15`
+**Author:** `Echo (instar-dev agent)`
+**Second-pass reviewer:** `(see Phase 5 below)`
+
+## Summary of the change
+
+Wires the missing runtime trigger for `CredentialLocationLedger.seedFromOracle()`. The live-credential-repointing build (spec §52) shipped the seeding *capability* but never called it at runtime, so on every agent the ledger stayed permanently NEVER-SEEDED: `getAssignments()` returns `[]`, `GET /credentials/locations` shows `assignments: []`, and the use-it-or-lose-it `CredentialRebalancer` (B3b) sees only the default slot — it can *decide* but can never *actuate* a drain (no other slots to move between). This change adds a boot-seed in `src/commands/server.ts` immediately before the B3b rebalancer timer, guarded by a new pure helper `shouldBootSeedCredentialLedger(enabled, isSeeded)` in `src/core/CredentialLocationLedger.ts`. Files: `src/commands/server.ts` (the boot-seed callsite + import), `src/core/CredentialLocationLedger.ts` (the exported guard), `tests/unit/credential-ledger-boot-seed-guard.test.ts` (guard truth-table), `tests/e2e/credential-ledger-boot-seed.test.ts` (boot-seed → `/credentials/locations` data-flow).
+
+## Decision-point inventory
+
+- `shouldBootSeedCredentialLedger(enabled, isSeeded)` (src/core/CredentialLocationLedger.ts) — **add** — pure boolean: seed only when the re-pointing dev-gate is on AND the ledger is not already seeded. This is NOT a runtime authority over agent behavior; it only decides whether to run a one-time, non-destructive data-population at boot.
+- The boot-seed callsite (src/commands/server.ts, before the B3b timer) — **add** — fire-and-forget `seedFromOracle()` when the guard returns true. Reuses the existing `resolveDevAgentGate(...credentialRepointing.enabled)` gate that the location gate, executor, and rebalancer already share.
+- `seedFromOracle()` itself — **pass-through** — unchanged; already converged + unit-tested (oracle-unavailable→quarantine, ambiguous/unknown-email→refuse+attention, one-home invariant).
+
+---
+
+## 1. Over-block
+
+**What legitimate inputs does this change reject that it shouldn't?**
+
+No block/allow surface — over-block not applicable. The change populates a ledger; it rejects no input and gates no message or action. The seed never *moves* a credential (that authority stays behind the executor's `dryRun` gate + the write funnel + the one-home invariant), so there is no "blocked legitimate swap" failure mode introduced here.
+
+---
+
+## 2. Under-block
+
+**What failure modes does this still miss?**
+
+No block/allow surface — under-block not applicable. Adjacent residuals worth naming honestly: (a) the boot-seed is a *one-shot* at startup — if accounts are enrolled/removed mid-run the ledger is not re-seeded until the next restart (acceptable: the rebalancer reads `getAssignments()` live, and a never-seeded→seeded transition is the load-bearing fix; periodic re-seed is a tracked follow-up `<!-- tracked: CMT-1564 -->`, not part of this change). (b) A slot whose oracle probe is unavailable/ambiguous is recorded quarantined (excluded from balancing) with a HIGH attention item — surfaced, never silently dropped.
+
+---
+
+## 3. Level-of-abstraction fit
+
+**Is this at the right layer?**
+
+Yes. The seed lives at server boot (`commands/server.ts`), the same layer that already constructs the ledger, gate, executor, and rebalancer timer — it sits directly beside the B3b timer it feeds. The decision logic is extracted into a pure helper on the ledger module (the owner of seed state) rather than left inline, so it is unit-testable without booting the server. It does NOT re-implement seeding — it *uses* the existing `seedFromOracle()` primitive. No higher-level gate exists that should own "populate the ledger at boot"; boot wiring is the correct home (the spec's named "boot recovery" path).
+
+---
+
+## 4. Signal vs authority compliance
+
+**Does this hold blocking authority with brittle logic, or produce a signal that feeds a smart gate?**
+
+Compliant (`docs/signal-vs-authority.md`). The change adds NO blocking authority. `shouldBootSeedCredentialLedger` is a pure idempotency/enablement predicate, not a runtime gate over agent behavior. The actual authority — moving a credential between slots — remains entirely with the existing `CredentialSwapExecutor` (its own `enabled`/`dryRun` gate) and the `credentialWriteFunnel`. Seeding only writes the local slot→account *map* (an observation of which account already tenants which home), derived from the identity oracle — it asserts nothing it cannot verify and moves nothing.
+
+---
+
+## 5. Interactions
+
+**Does it shadow another check, get shadowed, double-fire, or race?**
+
+- Shares the exact `resolveDevAgentGate(...credentialRepointing.enabled)` gate as the location gate, executor, and rebalancer — so it is on/off in lockstep with them (no divergent gating).
+- Idempotent across restarts: `isSeeded()` is false only for never-seeded OR unknown(corrupt) mode, so a re-run skips an already-seeded ledger and the same call doubles as the spec's named recovery path. No double-fire.
+- Runs once before the B3b timer is created; the timer's first tick fires `passIntervalMs` (≥60s) later, so the fire-and-forget seed's oracle probes have time to complete before the rebalancer reads assignments. A still-in-flight seed at first tick simply means the rebalancer sees the default slot for that one tick (its prior behavior) — never a crash or a wrong move.
+- The seed write goes through the ledger's own `save()`; it does not race the swap executor (no swaps occur while dark/dry-run, and a real swap is serialized through the funnel).
+
+---
+
+## 6. External surfaces
+
+**Does it change anything visible to other agents, users, or systems?**
+
+On a dev agent (gate on): `GET /credentials/locations` now returns populated `assignments` + `mode: 'active'` instead of `[]`/`mode: 'dark'`, and the dashboard/rebalancer surfaces reflect real slots. It performs per-slot identity-oracle probes (network calls to the OAuth profile endpoint) once at boot — transient, no token persisted. On the fleet (gate off / dark): strict no-op, no probe, byte-for-byte today's behavior. No agent-to-agent surface. Depends on the subscription pool being populated (it derives slots from `pool.list().filter(isClaudeCodeAccount)`); an empty pool seeds zero slots (harmless).
+
+---
+
+## 7. Multi-machine posture (Cross-Machine Coherence)
+
+**Machine-local BY DESIGN.** The credential location ledger is the machine-local source of truth for "which account's credential sits in which config-home on THIS machine" — config homes and keychain blobs are inherently per-machine, so the seed (and the ledger it populates) is correctly machine-local and must NOT replicate. Each machine boot-seeds its own ledger from its own pool + its own oracle probes. There is no cross-machine read to merge and no durable state that should survive a topic transfer (a credential's physical location does not move with a conversation). This matches the rest of the credential-repointing feature's machine-local posture. No one-voice/notice surface is added (the only user-facing emissions are the existing seed-refusal attention items, which are per-machine and already deduped by id).
+
+---
+
+## 8. Rollback cost
+
+**If this turns out wrong in production, what's the back-out?**
+
+Cheap and safe. (1) The feature is dev-gated + dark on the fleet, so a fleet agent is unaffected regardless. (2) On a dev agent, set `subscriptionPool.credentialRepointing.enabled` off (or revert this commit) — the guard returns false and no seed runs; the ledger falls back to never-seeded and consumers fall back to enrollment-home behavior (today's behavior). (3) The seed writes only the local `credential-locations` ledger file; deleting it returns to never-seeded. No credential is moved by this change, so there is no credential state to repair and no data migration. No hot-fix release is forced — the dev-gate + config flip is the immediate back-out.
+
+---
+
+## Phase 5 — Second-pass review
+
+**Reviewer:** independent reviewer subagent (read the artifact + the diff + the seed implementation + the boot callsite independently).
+
+**Verdict: CONCUR.** Evidence checked:
+- **(a) Dev-gated, dark-on-fleet** — callsite passes `resolveDevAgentGate(config.subscriptionPool?.credentialRepointing?.enabled, config)`; `credentialRepointing` is a DARK_GATE_EXCLUSIONS entry with `enabled` omitted, so the gate resolves `false` on the fleet → no seed, no oracle probe. E2E dev-gate-OFF confirms `assignments: []`, `mode: 'dark'`.
+- **(b) Non-destructive** — `seedFromOracle` only mutates `this.store` + `save()` + raises attention; never references the swap executor, keychain `writeService`, or the credential write funnel. Moves zero credentials.
+- **(c) First-tick safety (two layers)** — the timer fires ≥60s after boot; `listSlots()` reads `getAssignments()` live each tick, so a momentarily-empty `[]` yields only the synthesized default slot → `decidePass` cannot form a swap (no source+target). Backstop: the executor's own `enabled:false`+`dryRun:true` gate suppresses every real write regardless. No wrong move is reachable from a partial seed.
+- **(d) No race/crash** — fire-and-forget with `.catch`; a throwing/unavailable oracle is caught per-slot and quarantined (+ HIGH attention), never thrown out of boot.
+- **(e) Guard logic matches the artifact** — `shouldBootSeedCredentialLedger = enabled && !isSeeded`; `isSeeded()` false for never-seeded AND unknown/corrupt mode, matching the "doubles as recovery path" + "idempotent" claims. Unit truth-table + e2e data-flow pass; tsc clean.
+- **Disclosed limitation (not a defect):** one-shot at boot; a transiently-down slot stays quarantined until next restart / manual re-probe. Named in §2 as tracked follow-up CMT-1564; the rebalancer reads assignments live so a later re-seed flows through.


### PR DESCRIPTION
## ELI16

The use-it-or-lose-it credential optimizer (the autonomous balancer that drains accounts about to waste their weekly quota) was built and running on the dev agent in dry-run — but it could never actually move anything, because its account-map (the credential **location ledger**) was permanently empty. The build shipped the ability to fill that map (`seedFromOracle()`) but nothing ever *called* it at runtime, so `GET /credentials/locations` always returned `assignments: []` and the balancer only ever saw the single default slot.

This PR wires the missing trigger: at server boot, if credential re-pointing is enabled (dev agent) and the ledger hasn't been seeded yet, it seeds once from the identity oracle. It's guarded by a tiny pure helper `shouldBootSeedCredentialLedger(enabled, isSeeded)`, fire-and-forget so boot is never blocked on the oracle probes, idempotent across restarts, and it doubles as the ledger's boot-recovery path for a corrupt ledger.

**Safety:** non-destructive — seeding writes only the local slot→account *map*; it moves ZERO credentials. Actually moving a login between accounts still requires the executor's separate `dryRun:false` gate + the write funnel + the one-home invariant, none of which this touches. Dev-gated, so it's a strict no-op (no probe, byte-for-byte today's behavior) on the fleet. Independent second-pass review: CONCUR.

## What Changed
- `src/commands/server.ts` — boot-seed callsite (before the B3b rebalancer timer) + import.
- `src/core/CredentialLocationLedger.ts` — new pure `shouldBootSeedCredentialLedger(enabled, isSeeded)` guard.
- Tests: unit guard truth-table (4) + Tier-3 e2e proving the seed flows to `GET /credentials/locations` (2); existing `seedFromOracle` unit tests (17) unchanged.

Spec: §52 of `docs/specs/live-credential-repointing-rebalancer.md` (approved). Side-effects review: `upgrades/side-effects/credential-ledger-boot-seed.md`. Tracked: CMT-1564.

🤖 Generated with [Claude Code](https://claude.com/claude-code)