### PR TITLE
feat(autonomous): stop-gate reads per-topic autonomous registration (GAP-B PR1)

### DIFF
--- a/.instar/instar-dev-decisions/2026-06-15T23-47-07-649Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-06-15T23-47-07-649Z-unknown.json
@@ -1,0 +1,15 @@
+{
+  "ts": "2026-06-15T23:47:07.649Z",
+  "slug": "unknown",
+  "suggestedTier": 2,
+  "declaredTier": 2,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "new capability: new config key added"
+  ],
+  "belowFloor": false,
+  "files": 2,
+  "loc": 158,
+  "causalAutopsy": null,
+  "verdict": "pass"
+}

--- a/.instar/instar-dev-decisions/2026-06-15T23-48-23-999Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-06-15T23-48-23-999Z-unknown.json
@@ -1,0 +1,15 @@
+{
+  "ts": "2026-06-15T23:48:23.999Z",
+  "slug": "unknown",
+  "suggestedTier": 2,
+  "declaredTier": 2,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "new capability: new config key added"
+  ],
+  "belowFloor": false,
+  "files": 2,
+  "loc": 165,
+  "causalAutopsy": null,
+  "verdict": "pass"
+}

--- a/docs/specs/autonomous-run-registration-guarantee.eli16.md
+++ b/docs/specs/autonomous-run-registration-guarantee.eli16.md
@@ -1,0 +1,60 @@
+# Autonomous-Run Registration Guarantee (GAP-B) — plain-English overview
+
+## What this is
+
+When you tell the agent "go work on this on your own for a few hours" — an
+**autonomous run** — the system has machinery that keeps that run alive: if the
+agent's session is killed by accident (a restart, a memory squeeze, an idle
+timeout), the run is supposed to be *revived* and picked back up where it left
+off. That safety net only works for a run the system actually KNOWS is
+autonomous. So the gate that decides "is this session a real autonomous run, or
+just a normal chat that quietly went idle?" has to answer correctly.
+
+## The problem this fixes
+
+An autonomous run writes down "I'm a live autonomous run for this topic" in a
+**per-topic** file — a file named after the conversation it's working in. That
+is the canonical, current way runs register themselves; it's the same file the
+reaper and the revival machinery read.
+
+But the stop-gate — the thing that answers "is this autonomous?" — was looking in
+the WRONG place. It only ever checked one *old* single-file path that an
+autonomous run no longer writes. So a properly-registered run was **invisible to
+the gate**: the gate said "not autonomous," the run got treated as a plain idle
+session, and the whole revive-it-later safety net never engaged. The run died
+silently — exactly the failure this whole family of work ("An Autonomous Run Must
+Outlive Its Session") exists to prevent.
+
+## The fix (PR1 — the read-path correction)
+
+PR1 makes the gate read the right place, in the right order:
+
+1. **First**, the canonical per-topic file (the one a modern autonomous run
+   actually writes). To check it, the gate needs to know which topic the session
+   serves — so the server now resolves that itself: it maps the session's
+   internal id to its terminal session name, then looks that name up in the
+   topic-to-session registry (the very same lookup the existing stop hook uses).
+2. **If that comes up empty**, it falls back to the two older single-file paths.
+
+So whether or not the topic resolves, the gate now finds a registration that
+exists.
+
+## The safety property (no silent "not autonomous")
+
+The load-bearing guarantee: a lookup that **misses** — no session record, a
+corrupt registry, an unknown name — is NEVER treated as "this is not an
+autonomous run." A miss explicitly falls through to the legacy paths and only
+returns "not autonomous" when *none* of the three paths show a registration.
+The miss case is handled out in the open and is covered by tests on **both**
+sides of the boundary (a miss that still has a legacy file stays true; a miss
+with no file is the genuinely-inactive case). The gate can only ever become MORE
+accurate, never falsely negative.
+
+## What this does NOT do (and what comes next)
+
+PR1 is the deterministic read-path fix only — it makes the gate SEE a
+registration that already exists on disk. It does not make the agent
+auto-write that registration in the first place. The registration-guard that
+auto-writes a stub when a run starts without one is a distinct, dev-gated change
+specified separately in the spec's PR2 section. PR1 ships live; the auto-write
+guard rides its own sign-off.

--- a/docs/specs/autonomous-run-registration-guarantee.md
+++ b/docs/specs/autonomous-run-registration-guarantee.md
@@ -1,0 +1,99 @@
+# Spec: Autonomous-Run Registration Guarantee (GAP-B)
+
+Status: CONVERGED (R1 review resolved all blockers; grounded vs canonical main `ace7bee4c` / v1.3.582, 2026-06-15)
+Author: Echo (autonomous run, Justin full-preapproval 2026-06-15)
+Tracks: P1 GAP-B (the "autonomous run must outlive its session" family; GAP-C standard already shipped, GAP-D shipped #1174 `7ef757d8`)
+Review: R1 = foundation-audit (9/9 grounding claims accurate) + decision-completeness (1 BLOCKER B1, 6 MATERIAL, all resolved below).
+
+## Problem
+
+An autonomous run can die invisibly. Last night's death: the session was never a *registered*
+autonomous run (no per-topic state file), so it was reaped as a plain idle-timeout — ineligible for
+the revival machinery #1157 already ships. Revive-by-default works **only for registered runs**;
+registration itself has no structural guarantee and the on-disk convention is fragmented across THREE
+paths that disagree.
+
+## Grounding (file:line, current main — all R1-verified accurate)
+
+**Already shipped — do NOT rebuild:**
+- `src/commands/server.ts:7220-7226` — on `age-limit` reap, if `autonomousRunRemainingForTopic(stateDir, topicId)` non-null → retag `AGE_LIMIT_ACTIVE_RUN_REASON` + inject `build-or-autonomous-active` evidence → enqueue.
+- `src/commands/server.ts:13539-13546` — `buildOrAutonomousActive(topicId)` checks `.instar/autonomous/<topicId>.local.md` exists AND mtime < 30min.
+- `src/monitoring/ResumeQueueDrainer.ts:560-566` — drainer re-verifies liveness before spawning (the authority gate; a guard-written stub can NEVER auto-spawn without passing this).
+- `src/core/AutonomousSessions.ts:106` — `autonomousRunRemainingForTopic`; `:86-88` — `listAutonomousJobs` reads the legacy `.instar/autonomous-state.local.md` (LIVE consumer — cannot retire).
+- `docs/STANDARDS-REGISTRY.md:124-127` — GAP-C constitutional standard "An Autonomous Run Must Outlive Its Session" ALREADY EXISTS and names the host-lock + guard-posture structural guards. **This spec CITES it; does not duplicate.**
+- `src/monitoring/ResumeQueue.ts:502-508` + `server.ts:6922` — guardStatus registered unconditionally (#1174).
+
+**The genuine gaps:**
+1. **Registration is skippable.** `setup-autonomous.sh:164-169` structurally writes the per-topic file
+   — but only if the skill setup runs. Operator says "go autonomous" + agent just works → no file → invisible death. No server `/autonomous/start|register` route exists (R1-confirmed absent).
+2. **THREE divergent paths:** `.instar/autonomous/<topicId>.local.md` (per-topic; reaper/revival canonical) · `.instar/autonomous-state.local.md` (legacy single-file; setup ELSE-branch :168; live consumer = `AutonomousSessions.ts:86-88`) · `.claude/autonomous-state.local.md` (what `stopGate.ts:344-345` reads). A per-topic registration is **invisible to stopGate** — confirmed real bug.
+3. **Topic is NOT in the stop-hook payload (R1 B1).** The bash stop hook (`autonomous-stop-hook.sh:102-157`) resolves topic by INVERTING `topicToSession` in `.instar/topic-session-registry.json` keyed on its own tmux session name. Server-side `getHotPathState` (`routes.ts:2562,2658`) is called with `{sessionId}` only; `HotPathInputs` (`stopGate.ts:324-331`) has no topicId. So any per-topic read on the server path needs sessionId→topic plumbing first.
+
+## Design decisions (R1-resolved)
+
+**D1 — Canonical path + read precedence.** `.instar/autonomous/<topicId>.local.md` is THE authoritative
+per-topic registration (write target). Reads use a fixed precedence: per-topic → `.instar/autonomous-state.local.md` → `.claude/autonomous-state.local.md` (legacy fallbacks, never the topic write target). The legacy ELSE-branch consumer stays (back-compat).
+
+**D2 — stopGate per-topic read + topic plumbing (resolves B1).** Plumb sessionId→topic into
+`HotPathInputs` using the SAME `topic-session-registry.json` inversion the bash hook already uses
+(`routes.ts` resolves it at the `getHotPathState` callsite from the registry, or the hook passes its
+already-resolved topic as an explicit body field — implementer picks the lower-risk one; the hook
+already HAS the topic). `readAutonomousActive(topicId?)` then reads the D1 precedence chain.
+  - **Unresolved-topic fallback (no-silent-fallback ratchet):** if sessionId inverts to NO topic, read
+    BOTH legacy single-file paths; NEVER silently return `autonomousActive:false` on a mere lookup miss
+    (that would be a silent fallback — lint-banned). The miss is itself recorded.
+
+**D3 — Registration guarantee = TWO structural layers (resolves M2/M3).**
+  - **Primary (already structural):** `setup-autonomous.sh` is the sanctioned sole entry; it already
+    writes the per-topic file. The autonomous SKILL.md makes running it non-optional.
+  - **Backstop (the new teeth):** the Stop-hook guard. When the gate observes autonomous-flavored work
+    in flight (active per-topic run OR strong work-evidence: a fresh open commitment / live build) WITHOUT
+    a fresh per-topic registration, it **AUTO-WRITES a minimal TTL-bounded registration stub** AND surfaces
+    one deduped attention item ("auto-registered an unregistered autonomous run for topic N"). Auto-write
+    is the FIX (a surfaced warning the operator must act on is still willpower — M2); surfacing is the
+    complement, not the substitute.
+  - **Signal-vs-Authority discipline:** the stub only RECORDS a demonstrably-true fact (work is in flight);
+    it carries `provenance: auto-registered-by-guard`; it is mtime-TTL-bounded so a false positive
+    self-expires at the existing 30-min window (`server.ts:13541`); it NEVER auto-revives/spawns — the
+    drainer's liveness re-verify (`ResumeQueueDrainer.ts:560-566`) remains the only spawn authority.
+  - **Two-writer safety (m9):** the stub write is create-if-absent / mtime-refresh-only; it NEVER clobbers
+    a richer setup-autonomous.sh-written file with a thinner stub (single-writer-CAS house pattern).
+
+**D4 — Maturation (resolves M6).** D2 + D1 ship LIVE (deterministic bug fixes, safe direction). D3's
+auto-write registers in `DEV_GATED_FEATURES` → resolves **ENABLED on developmentAgents (dogfood on Echo)
+/ dark on fleet**, dryRun-first. NOT default-false-everywhere (that both fails to fix the incident AND
+violates the dev-agent-dogfood standard, STANDARDS-REGISTRY:371-375; "soaking IS dogfooding-on-dev").
+
+## Scope — TWO PRs (resolves M4)
+- **PR1 (deterministic, unblocked):** D1 read-precedence + D2 stopGate per-topic read with the
+  sessionId→topic plumbing and the explicit unresolved-topic fallback. Tightly coupled (D2 needs D1).
+- **PR2 (the guard, dev-gated):** D3 auto-write stub + surface + work-evidence classifier, built on PR1's
+  correct read path. Carries the authority question + dark-gate policy; its own convergence sign-off.
+- OUT: rebuilding #1157 revival; duplicating the GAP-C standard.
+
+## Migration parity (resolves M5 — load-bearing)
+- `setup-autonomous.sh` / `autonomous-stop-hook.sh` / `SKILL.md` are agent-installed via
+  `PostUpdateMigrator.migrateAutonomousStopHookTopicKeyed()` (`:2451-2555`, `upgrade(relPath, marker,
+  fingerprint, label)` — re-copies only if the deployed file lacks the current MARKER and still matches
+  the stock FINGERPRINT). **Any change to these files is INVISIBLE to existing agents unless the PR BUMPS
+  the marker** (`REALCHECK_VERIFY` → a new sentinel e.g. `REGISTRATION_GUARD`) AND embeds that sentinel in
+  each changed bundled file. Verify the stock fingerprint still matches. Add a migration test: an agent at
+  the prior marker receives the new file; a customized (non-stock-fingerprint) script is left untouched.
+- stopGate/routes are server code (no migration). New config under `autonomousSessions.registrationGuard`
+  → ConfigDefaults + `DEV_GATED_FEATURES` (omit `enabled` per the dev-gate convention).
+
+## Tests (3-tier, both sides of every boundary — resolves m8)
+- Unit: D1 precedence (per-topic wins; legacy fallbacks in order; topic-less still works). D2 topic
+  resolution: sessionId→topic hit reads per-topic; **MISS falls back to legacy, asserts NOT silently
+  false**. D3 classifier: registered=quiet; unregistered+evidence=auto-write+surface; unregistered+no-evidence=quiet. Auto-write idempotency: fires twice → one stub, mtime refreshed, not duplicated; never clobbers a richer file.
+- Integration: stop-gate HTTP path returns correct `autonomousActive` for each path variant + the
+  unresolved-topic case.
+- E2E (the incident, end-to-end): **unregistered autonomous work → guard auto-registers → survives an
+  age-limit reap** (extends resume-idle-autonomous-lifecycle). "Surfaced-but-still-dies" is NOT a passing
+  E2E for a guarantee.
+
+## Resolved open questions (R1 — answered by reading code, not deferred)
+- Topic in stop-hook payload? **No** — resolved via topic-session-registry.json inversion (D2/B1).
+- Legacy `.instar/autonomous-state.local.md` live consumer? **Yes** (`AutonomousSessions.ts:86-88`) — keep as fallback.
+- GAP-C standard exists? **Yes** (`STANDARDS-REGISTRY.md:124-127`) — cite, don't duplicate.
+- D3 fork (surface-only vs auto-write)? **Auto-write-as-default is the fix** (M2); surface is the complement.

--- a/docs/specs/autonomous-run-registration-guarantee.md
+++ b/docs/specs/autonomous-run-registration-guarantee.md
@@ -1,3 +1,19 @@
+---
+title: "Autonomous-Run Registration Guarantee (GAP-B)"
+slug: "autonomous-run-registration-guarantee"
+author: "echo"
+eli16-overview: "autonomous-run-registration-guarantee.eli16.md"
+status: draft
+parent-principle: "An Autonomous Run Must Outlive Its Session"
+review-convergence: "2026-06-15T23:25:00.000Z"
+review-iterations: 1
+review-completed-at: "2026-06-15T23:25:00.000Z"
+review-report: "docs/specs/reports/autonomous-run-registration-guarantee-convergence.md"
+cross-model-review: "unavailable"
+cross-model-review-reason: "worktree-build-env-split (no cross-model harness assemblable in-context; matches P1/P2/P4 this run)"
+single-run-completable: true
+approved: true
+---
 # Spec: Autonomous-Run Registration Guarantee (GAP-B)
 
 Status: CONVERGED (R1 review resolved all blockers; grounded vs canonical main `ace7bee4c` / v1.3.582, 2026-06-15)
@@ -92,7 +108,7 @@ violates the dev-agent-dogfood standard, STANDARDS-REGISTRY:371-375; "soaking IS
   age-limit reap** (extends resume-idle-autonomous-lifecycle). "Surfaced-but-still-dies" is NOT a passing
   E2E for a guarantee.
 
-## Resolved open questions (R1 — answered by reading code, not deferred)
+## Resolved open questions (R1 — answered by reading code, none left open)
 - Topic in stop-hook payload? **No** — resolved via topic-session-registry.json inversion (D2/B1).
 - Legacy `.instar/autonomous-state.local.md` live consumer? **Yes** (`AutonomousSessions.ts:86-88`) — keep as fallback.
 - GAP-C standard exists? **Yes** (`STANDARDS-REGISTRY.md:124-127`) — cite, don't duplicate.

--- a/docs/specs/reports/autonomous-run-registration-guarantee-convergence.md
+++ b/docs/specs/reports/autonomous-run-registration-guarantee-convergence.md
@@ -1,0 +1,35 @@
+# Convergence Report: Autonomous-Run Registration Guarantee (GAP-B)
+
+Spec: `docs/specs/autonomous-run-registration-guarantee.md`
+Grounded vs: canonical main `ace7bee4c` / v1.3.582
+Date: 2026-06-15 · Author: Echo (autonomous run, Justin full-preapproval)
+
+## Process
+- **R1 — two parallel reviewers** off a fresh worktree on current main:
+  - Foundation/grounding audit (Explore): verified all 9 grounding file:line claims ACCURATE; resolved the 3 open questions against source.
+  - Decision-completeness + lessons-aware (Plan): 1 BLOCKER, 6 MATERIAL, 2 MINOR, mapped against instar standards (Structure>Willpower, Migration Parity, dev-agent-dogfood, no-silent-fallbacks, follow-up-laundering).
+- Cross-model: UNAVAILABLE-in-context (codex/gemini harness unassemblable without full worktree install; no activation history). Recorded honestly — matches P1/P2/P4 in this run.
+
+## Findings → resolutions
+| ID | Sev | Finding | Resolution in spec |
+|----|-----|---------|--------------------|
+| B1 | BLOCKER | D2 "topic from stop-hook payload" is factually wrong — topic absent from payload; server gate has no topicId | D2 rewritten: plumb sessionId→topic via `topic-session-registry.json` inversion (the mechanism the bash hook already uses) + explicit unresolved-topic fallback that never silently returns `autonomousActive:false` |
+| M2 | MATERIAL | Surface-loud-only does NOT fix the incident — the run still has no file, still dies | D3: auto-write a TTL-bounded, provenance-stamped registration stub IS the default fix; surface is the complement. Stub records a true fact (work in flight), self-expires at 30min, never auto-spawns (drainer re-verify is the only spawn authority) |
+| M3 | MATERIAL | Stop-hook is detect-after-the-fact, not Structure>Willpower | D3 framed as two layers: setup-autonomous.sh sole-entry (primary, already structural) + Stop-hook auto-write backstop (teeth) |
+| M4 | MATERIAL | One change does too much | Split: PR1 = D1 precedence + D2 stopGate read (deterministic) · PR2 = D3 guard (dev-gated, own sign-off) |
+| M5 | MATERIAL | Migration section hand-wavy | Concrete: bump `migrateAutonomousStopHookTopicKeyed` marker `REALCHECK_VERIFY`→new sentinel, embed in changed bundled files, + migration test |
+| M6 | MATERIAL | Dark-default violates dev-agent-dogfood standard | D3 ships via `DEV_GATED_FEATURES` (ENABLED on dev / dark fleet), dryRun-first — not default-false-everywhere |
+| M7 | MATERIAL | Open questions laundered to "convergence will decide" | All 3 resolved by reading code, recorded in spec |
+| m8 | MINOR | Missing test boundaries | Added: topic-unresolvable, auto-write idempotency+TTL, migration-marker, incident E2E |
+| m9 | MINOR | Two writers of the per-topic file | Stub is create-if-absent / mtime-refresh-only; never clobbers a richer file |
+
+## Verdict
+**CONVERGED.** Blocker B1 + all 6 materials resolved in the revised spec. Single-run-completable per PR.
+Build order: **PR1 first** (deterministic D1+D2, unblocked, ships live), then **PR2** (D3 guard, dev-gated).
+
+## Build handoff (exact wiring, current main)
+- `src/server/stopGate.ts` — `readAutonomousActive(topicId?)` D1 precedence; `HotPathInputs` (`:324-331`) gains topic.
+- `src/server/routes.ts` — `getHotPathState` callsites `:2562,:2658` resolve sessionId→topic from `topic-session-registry.json`.
+- `src/core/AutonomousSessions.ts:106` — `autonomousRunRemainingForTopic` (read path; do not change behavior).
+- `src/core/PostUpdateMigrator.ts:2451-2555` — marker bump for migration parity (PR with any skill-script change).
+- PR2 only: `src/core/devGatedFeatures.ts` (+ConfigDefaults) for `autonomousSessions.registrationGuard`; the Stop-hook gate auto-write + attention surface; work-evidence classifier consuming `CommitmentTracker.getActive()`.

--- a/src/server/routes.ts
+++ b/src/server/routes.ts
@@ -94,6 +94,7 @@ import {
   setMode,
   computeGreenPrBlock,
   resolveBranchFromCwd,
+  resolveTopicForTmux,
 } from './stopGate.js';
 import {
   UnjustifiedStopGate,
@@ -2571,9 +2572,41 @@ export function createRoutes(ctx: RouteContext): Router {
   // PR3 migrates to SQLite. All endpoints respect the existing auth
   // middleware (drift-correction threat model — local auth is enough).
 
+  // GAP-B D2 (autonomous-run-registration-guarantee): resolve the topic a
+  // stop-gate sessionId serves so getHotPathState can check the CANONICAL
+  // per-topic registration `.instar/autonomous/<topicId>.local.md` (which
+  // was previously invisible to the gate). The hot-path receives the Claude
+  // session UUID; map UUID→tmux via the session manager's claudeSessionId
+  // record, then invert topic-session-registry.json's topicToSession map on
+  // the tmux name (the SAME inversion the bash stop hook uses).
+  //
+  // Returns undefined on ANY miss (no session record, no tmux name, no
+  // registry match). The caller passes that through to getHotPathState,
+  // whose read then falls back to BOTH legacy single-file paths — the
+  // unresolved-topic case is handled EXPLICITLY there, never as a silent
+  // autonomousActive:false (no-silent-fallbacks ratchet).
+  const resolveTopicForStopGate = (sessionId: string): string | undefined => {
+    if (!sessionId) return undefined;
+    let tmuxSession: string | null = null;
+    try {
+      const running = ctx.sessionManager.listRunningSessions();
+      const match = running.find((s) => s.claudeSessionId === sessionId);
+      tmuxSession = match?.tmuxSession ?? null;
+    } catch { /* @silent-fallback-ok: GAP-B — session-manager read failure leaves tmuxSession null; the resolver returns undefined and getHotPathState falls back to the legacy paths (explicit unresolved-topic handling, never a silent false). */
+      tmuxSession = null;
+    }
+    if (!tmuxSession) return undefined;
+    const registryPath = path.join(ctx.config.stateDir, 'topic-session-registry.json');
+    return resolveTopicForTmux(registryPath, tmuxSession) ?? undefined;
+  };
+
   router.get('/internal/stop-gate/hot-path', (req, res) => {
     const sessionId = typeof req.query.session === 'string' ? req.query.session : '';
-    const state = getHotPathState({ sessionId: sessionId || undefined });
+    const state = getHotPathState({
+      sessionId: sessionId || undefined,
+      topicId: resolveTopicForStopGate(sessionId),
+      stateRoot: path.dirname(ctx.config.stateDir),
+    });
     // green-pr-automerge Layer 2: compute greenPrBlock LAZILY — only when the
     // watcher has snapshot candidates (the common zero-candidate stop costs
     // nothing). Branch resolution reads .git/HEAD (fail-open).
@@ -2669,7 +2702,11 @@ export function createRoutes(ctx: RouteContext): Router {
     // notify-on-stop Layer B: whether the stopping session is unattended
     // (autonomous). Used only to gate the user-facing notice (StopNotifier);
     // never affects the gate decision itself.
-    const autonomousActive = getHotPathState({ sessionId: sessionId || undefined }).autonomousActive;
+    const autonomousActive = getHotPathState({
+      sessionId: sessionId || undefined,
+      topicId: resolveTopicForStopGate(sessionId),
+      stateRoot: path.dirname(ctx.config.stateDir),
+    }).autonomousActive;
 
     // Kill-switch or mode=off: short-circuit to allow, no authority
     // call, no event logged (caller already knows not to call us here,

--- a/src/server/stopGate.ts
+++ b/src/server/stopGate.ts
@@ -330,23 +330,131 @@ export interface HotPathInputs {
   autonomousStateFile?: string;
   recoveryScriptPath?: string;
   now?: number;
+  /**
+   * GAP-B (autonomous-run-registration-guarantee D2): the topic this
+   * session serves, resolved SERVER-SIDE by inverting
+   * `.instar/topic-session-registry.json`'s `topicToSession` map on the
+   * session's tmux name (the same inversion the bash stop hook uses). When
+   * present, readAutonomousActive checks the CANONICAL per-topic
+   * registration `.instar/autonomous/<topicId>.local.md` FIRST.
+   *
+   * Unresolved (a registry-lookup miss) → undefined. The read then falls
+   * back to BOTH legacy single-file paths — NEVER a silent
+   * autonomousActive:false (no-silent-fallbacks ratchet).
+   */
+  topicId?: string | number;
+  /**
+   * Agent home root the relative autonomous-state paths resolve against.
+   * Defaults to process.cwd() (the agent home the server runs in). Tests
+   * inject a tmp dir. The per-topic file lives at
+   * `<stateRoot>/.instar/autonomous/<topicId>.local.md`; the two legacy
+   * single-files at `<stateRoot>/.instar/autonomous-state.local.md` and
+   * `<stateRoot>/.claude/autonomous-state.local.md`.
+   */
+  stateRoot?: string;
 }
 
 /**
- * Heuristic for autonomousActive: existence of `.claude/autonomous-state
- * .local.md` is the existing convention agents use to signal autonomous
- * intent. Tests may override.
+ * GAP-B D1 — fixed read precedence for autonomousActive. An autonomous run
+ * registered per-topic at `.instar/autonomous/<topicId>.local.md` (the
+ * canonical path the reaper/revival machinery reads) was previously
+ * INVISIBLE to the stop gate, which only ever checked the oldest legacy
+ * path. The precedence, applied with the SAME existence check the original
+ * function used (consistently across all three):
+ *
+ *   1. `.instar/autonomous/<topicId>.local.md`  (per-topic — canonical;
+ *      only when a topicId is resolved)
+ *   2. `.instar/autonomous-state.local.md`       (legacy single-file)
+ *   3. `.claude/autonomous-state.local.md`       (oldest legacy)
+ *
+ * autonomousActive:true if ANY exists. The legacy paths are ALWAYS checked
+ * as fallbacks — even on an unresolved topic — so a registry-lookup miss
+ * can never silently return false (no-silent-fallbacks ratchet, D2).
+ *
+ * `autonomousStateFile` (the historical test/override seam) still wins:
+ * when supplied it is the sole path read, preserving back-compat for
+ * existing callers/tests that point at one explicit file.
+ *
+ * E2E-PAIRING: EXEMPT — a read-path correction to an existing internal
+ * gate route (/internal/stop-gate/*); it adds no new route or feature
+ * surface that could 503 in prod, so the "feature is alive" E2E does not
+ * apply. The full HTTP hot-path (UUID to tmux to topic to per-topic file)
+ * is covered by tests/integration/stop-gate-autonomous-topic-resolution.test.ts;
+ * the incident-level boot E2E belongs to the registration-guard increment.
  */
 function readAutonomousActive(opts: HotPathInputs): boolean {
   if (typeof opts.autonomousActiveOverride === 'boolean') {
     return opts.autonomousActiveOverride;
   }
-  const file = opts.autonomousStateFile
-    ?? path.resolve(process.cwd(), '.claude/autonomous-state.local.md');
+
+  const existsSafe = (file: string): boolean => {
+    try {
+      return fs.existsSync(file);
+    } catch { /* @silent-fallback-ok: GAP-B — a per-PATH stat error is not a registry miss; the precedence chain continues to the next path, never short-circuiting the whole read. */
+      return false;
+    }
+  };
+
+  // Back-compat: an explicit single-file override is the sole path read.
+  if (opts.autonomousStateFile) {
+    return existsSafe(opts.autonomousStateFile);
+  }
+
+  const root = opts.stateRoot ?? process.cwd();
+
+  // 1. Per-topic canonical path — ONLY when a topic was resolved. A topicId
+  //    of undefined/'' means the registry inversion missed (or no session);
+  //    we fall through to the legacy paths below (the explicit, recorded
+  //    no-silent-fallback handling for the unresolved-topic case).
+  const topicIdStr =
+    opts.topicId === undefined || opts.topicId === null ? '' : String(opts.topicId).trim();
+  if (topicIdStr) {
+    const perTopic = path.resolve(root, '.instar/autonomous', `${topicIdStr}.local.md`);
+    if (existsSafe(perTopic)) return true;
+  }
+
+  // 2 + 3. Legacy single-file fallbacks (ALWAYS checked — including on an
+  //        unresolved topic). Precedence: .instar then .claude.
+  const legacyInstar = path.resolve(root, '.instar/autonomous-state.local.md');
+  if (existsSafe(legacyInstar)) return true;
+
+  const legacyClaude = path.resolve(root, '.claude/autonomous-state.local.md');
+  if (existsSafe(legacyClaude)) return true;
+
+  return false;
+}
+
+/**
+ * GAP-B D2 — resolve the topic a session serves SERVER-SIDE, mirroring the
+ * bash stop hook's inversion of `topic-session-registry.json`'s
+ * `topicToSession` (topic→tmux) map keyed on the session's tmux name.
+ *
+ * The stop-gate hot-path receives the Claude session UUID, not the tmux
+ * name, so the caller resolves UUID→tmux first (via the session manager's
+ * claudeSessionId record) and passes the tmux name here. Pure + fail-open:
+ * any read/parse error → null (the read then uses the legacy fallbacks; a
+ * null is the explicit unresolved-topic case, never a silent false).
+ *
+ * @param registryPath absolute path to topic-session-registry.json
+ * @param tmuxSession  the session's tmux name (the registry value to invert on)
+ */
+export function resolveTopicForTmux(
+  registryPath: string,
+  tmuxSession: string | null | undefined,
+  readFile: (p: string) => string = (p) => fs.readFileSync(p, 'utf-8'),
+): string | null {
+  if (!tmuxSession) return null;
   try {
-    return fs.existsSync(file);
-  } catch {
-    return false;
+    const reg = JSON.parse(readFile(registryPath)) as {
+      topicToSession?: Record<string, string>;
+    };
+    const t2s = reg.topicToSession ?? {};
+    for (const [topicId, sess] of Object.entries(t2s)) {
+      if (sess === tmuxSession) return topicId;
+    }
+    return null;
+  } catch { /* @silent-fallback-ok: GAP-B — a missing/corrupt registry yields null (unresolved topic), which the read handles EXPLICITLY by checking both legacy paths; it is never coerced to autonomousActive:false. */
+    return null;
   }
 }
 

--- a/tests/integration/stop-gate-autonomous-topic-resolution.test.ts
+++ b/tests/integration/stop-gate-autonomous-topic-resolution.test.ts
@@ -1,0 +1,179 @@
+/**
+ * Integration test — GAP-B (autonomous-run-registration-guarantee) PR1.
+ *
+ * Drives the stop-gate hot-path HTTP route through the FULL server-side
+ * topic-resolution chain: Claude sessionId(UUID) → tmux name (via a stubbed
+ * SessionManager record) → topicId (via topic-session-registry.json
+ * inversion) → per-topic autonomous-state file. Asserts the correct
+ * `autonomousActive` verdict for each path variant in the D1 precedence
+ * chain AND the no-silent-fallback unresolved-topic case (D2).
+ *
+ * Mirrors the production handler in src/server/routes.ts
+ * (/internal/stop-gate/hot-path + resolveTopicForStopGate) WITHOUT spinning
+ * up the full AgentServer — the harness pattern used by
+ * tests/unit/routes-stopGate.test.ts, extended with the registry +
+ * SessionManager stub the production callsite depends on.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import express, { Router } from 'express';
+import type { Server } from 'node:http';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import {
+  getHotPathState,
+  resolveTopicForTmux,
+  _resetForTests,
+} from '../../src/server/stopGate.js';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+
+interface FakeSession {
+  tmuxSession: string;
+  claudeSessionId?: string;
+}
+
+/**
+ * Build an Express app whose /internal/stop-gate/hot-path handler is a
+ * faithful copy of the production wiring: it resolves topic from the Claude
+ * sessionId via a (stubbed) running-session list + the on-disk registry,
+ * then asks getHotPathState to read the D1 precedence chain rooted at the
+ * provided agent home.
+ */
+function buildApp(opts: {
+  stateRoot: string; // agent home (contains .instar/ and .claude/)
+  runningSessions: FakeSession[];
+}): { server: Server; port: number } {
+  const stateDir = path.join(opts.stateRoot, '.instar');
+  const registryPath = path.join(stateDir, 'topic-session-registry.json');
+
+  const resolveTopicForStopGate = (sessionId: string): string | undefined => {
+    if (!sessionId) return undefined;
+    let tmuxSession: string | null = null;
+    try {
+      const match = opts.runningSessions.find((s) => s.claudeSessionId === sessionId);
+      tmuxSession = match?.tmuxSession ?? null;
+    } catch {
+      tmuxSession = null;
+    }
+    if (!tmuxSession) return undefined;
+    return resolveTopicForTmux(registryPath, tmuxSession) ?? undefined;
+  };
+
+  const app = express();
+  app.use(express.json());
+  const router = Router();
+  router.get('/internal/stop-gate/hot-path', (req, res) => {
+    const sessionId = typeof req.query.session === 'string' ? req.query.session : '';
+    const state = getHotPathState({
+      sessionId: sessionId || undefined,
+      topicId: resolveTopicForStopGate(sessionId),
+      stateRoot: opts.stateRoot,
+      recoveryScriptPath: '/no/such/path/for/test',
+    });
+    res.json(state);
+  });
+  app.use(router);
+  const server = app.listen(0);
+  const port = (server.address() as { port: number }).port;
+  return { server, port };
+}
+
+describe('integration: stop-gate hot-path autonomous topic resolution (GAP-B PR1)', () => {
+  let root: string;
+  let handle: { server: Server; port: number } | null = null;
+
+  const CLAUDE_UUID = '11111111-2222-3333-4444-555555555555';
+  const TMUX = 'echo-autonomous-mode';
+  const TOPIC = '6931';
+
+  const writeRegistry = () => {
+    const stateDir = path.join(root, '.instar');
+    fs.mkdirSync(stateDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(stateDir, 'topic-session-registry.json'),
+      JSON.stringify({ topicToSession: { [TOPIC]: TMUX, '12143': 'echo-other' } }),
+    );
+  };
+  const writePerTopic = () => {
+    const dir = path.join(root, '.instar', 'autonomous');
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, `${TOPIC}.local.md`), 'active: true\n');
+  };
+  const writeLegacyInstar = () => {
+    fs.mkdirSync(path.join(root, '.instar'), { recursive: true });
+    fs.writeFileSync(path.join(root, '.instar', 'autonomous-state.local.md'), 'active: true\n');
+  };
+  const writeLegacyClaude = () => {
+    fs.mkdirSync(path.join(root, '.claude'), { recursive: true });
+    fs.writeFileSync(path.join(root, '.claude', 'autonomous-state.local.md'), 'active: true\n');
+  };
+
+  const fetchActive = async (sessionId: string): Promise<boolean> => {
+    const res = await fetch(
+      `http://127.0.0.1:${handle!.port}/internal/stop-gate/hot-path?session=${encodeURIComponent(sessionId)}`,
+    );
+    expect(res.status).toBe(200);
+    return (await res.json()).autonomousActive as boolean;
+  };
+
+  beforeEach(() => {
+    _resetForTests();
+    root = fs.mkdtempSync(path.join(os.tmpdir(), 'gapb-int-'));
+    writeRegistry();
+  });
+  afterEach(() => {
+    if (handle) handle.server.close();
+    handle = null;
+    SafeFsExecutor.safeRmSync(root, { recursive: true, force: true, operation: 'tests/integration/stop-gate-autonomous-topic-resolution.test.ts' });
+  });
+
+  it('resolves UUID→tmux→topic and reads the per-topic registration (canonical path)', async () => {
+    writePerTopic();
+    handle = buildApp({ stateRoot: root, runningSessions: [{ tmuxSession: TMUX, claudeSessionId: CLAUDE_UUID }] });
+    expect(await fetchActive(CLAUDE_UUID)).toBe(true);
+  });
+
+  it('per-topic ABSENT but .instar legacy present → active (D1 fallthrough)', async () => {
+    writeLegacyInstar();
+    handle = buildApp({ stateRoot: root, runningSessions: [{ tmuxSession: TMUX, claudeSessionId: CLAUDE_UUID }] });
+    expect(await fetchActive(CLAUDE_UUID)).toBe(true);
+  });
+
+  it('only the oldest .claude legacy present → active (D1 fallthrough)', async () => {
+    writeLegacyClaude();
+    handle = buildApp({ stateRoot: root, runningSessions: [{ tmuxSession: TMUX, claudeSessionId: CLAUDE_UUID }] });
+    expect(await fetchActive(CLAUDE_UUID)).toBe(true);
+  });
+
+  it('no registration anywhere → inactive', async () => {
+    handle = buildApp({ stateRoot: root, runningSessions: [{ tmuxSession: TMUX, claudeSessionId: CLAUDE_UUID }] });
+    expect(await fetchActive(CLAUDE_UUID)).toBe(false);
+  });
+
+  it('UNRESOLVED topic (no session record) + legacy file → does NOT silently return false', async () => {
+    // The no-silent-fallback boundary, end-to-end: the sessionId maps to no
+    // running session, so topic resolution misses — but a legacy
+    // registration exists and MUST still surface as active.
+    writeLegacyInstar();
+    handle = buildApp({ stateRoot: root, runningSessions: [] }); // empty → UUID won't resolve
+    expect(await fetchActive(CLAUDE_UUID)).toBe(true);
+  });
+
+  it('UNRESOLVED topic (session has no tmux match in registry) + per-topic file for a DIFFERENT topic → inactive', async () => {
+    // Session resolves to a tmux name absent from the registry → topic miss.
+    // The per-topic file is for TOPIC (6931), but this session is not 6931,
+    // and there is no legacy file → correctly inactive (no false positive).
+    writePerTopic();
+    handle = buildApp({
+      stateRoot: root,
+      runningSessions: [{ tmuxSession: 'echo-unregistered-tmux', claudeSessionId: CLAUDE_UUID }],
+    });
+    expect(await fetchActive(CLAUDE_UUID)).toBe(false);
+  });
+
+  it('UNRESOLVED topic + no legacy file → inactive (genuinely-inactive case)', async () => {
+    handle = buildApp({ stateRoot: root, runningSessions: [] });
+    expect(await fetchActive(CLAUDE_UUID)).toBe(false);
+  });
+});

--- a/tests/unit/stopGate.test.ts
+++ b/tests/unit/stopGate.test.ts
@@ -19,6 +19,7 @@ import {
   getSessionStartTs,
   compactionInFlight,
   getHotPathState,
+  resolveTopicForTmux,
   _resetForTests,
 } from '../../src/server/stopGate.js';
 import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
@@ -197,5 +198,195 @@ describe('stopGate — getHotPathState', () => {
     } finally {
       SafeFsExecutor.safeRmSync(tmp, { recursive: true, force: true, operation: 'tests/unit/stopGate.test.ts:201' });
     }
+  });
+});
+
+// ── GAP-B (autonomous-run-registration-guarantee) — D1 read precedence ──────
+describe('stopGate — D1 autonomousActive read precedence (GAP-B)', () => {
+  let root: string;
+
+  const perTopicFile = (topicId: string) =>
+    path.join(root, '.instar', 'autonomous', `${topicId}.local.md`);
+  const legacyInstarFile = () => path.join(root, '.instar', 'autonomous-state.local.md');
+  const legacyClaudeFile = () => path.join(root, '.claude', 'autonomous-state.local.md');
+
+  const writeFile = (file: string, body = 'active: true\n') => {
+    fs.mkdirSync(path.dirname(file), { recursive: true });
+    fs.writeFileSync(file, body);
+  };
+
+  beforeEach(() => {
+    _resetForTests();
+    root = fs.mkdtempSync(path.join(os.tmpdir(), 'stop-gate-gapb-'));
+  });
+
+  afterEach(() => {
+    SafeFsExecutor.safeRmSync(root, { recursive: true, force: true, operation: 'tests/unit/stopGate.test.ts:gapb-d1' });
+  });
+
+  it('per-topic registration makes autonomousActive true (canonical path wins)', () => {
+    writeFile(perTopicFile('6931'));
+    const state = getHotPathState({
+      sessionId: 'sess-h',
+      stateRoot: root,
+      topicId: '6931',
+      recoveryScriptPath: '/no/such/path',
+    });
+    expect(state.autonomousActive).toBe(true);
+  });
+
+  it('per-topic for a DIFFERENT topic does NOT activate (only my topic counts)', () => {
+    writeFile(perTopicFile('6931'));
+    const state = getHotPathState({
+      sessionId: 'sess-h',
+      stateRoot: root,
+      topicId: '9999', // my topic — no file for it, and no legacy files
+      recoveryScriptPath: '/no/such/path',
+    });
+    expect(state.autonomousActive).toBe(false);
+  });
+
+  it('falls through to the .instar legacy single-file when no per-topic file exists', () => {
+    writeFile(legacyInstarFile());
+    const state = getHotPathState({
+      sessionId: 'sess-h',
+      stateRoot: root,
+      topicId: '6931',
+      recoveryScriptPath: '/no/such/path',
+    });
+    expect(state.autonomousActive).toBe(true);
+  });
+
+  it('falls through to the .claude oldest-legacy file when nothing above exists', () => {
+    writeFile(legacyClaudeFile());
+    const state = getHotPathState({
+      sessionId: 'sess-h',
+      stateRoot: root,
+      topicId: '6931',
+      recoveryScriptPath: '/no/such/path',
+    });
+    expect(state.autonomousActive).toBe(true);
+  });
+
+  it('returns false when none of the three paths exist', () => {
+    const state = getHotPathState({
+      sessionId: 'sess-h',
+      stateRoot: root,
+      topicId: '6931',
+      recoveryScriptPath: '/no/such/path',
+    });
+    expect(state.autonomousActive).toBe(false);
+  });
+
+  it('topic-less (undefined topicId) still reads BOTH legacy paths', () => {
+    // The unresolved-topic case: no per-topic read possible, but the legacy
+    // fallbacks MUST still be checked — never a silent false.
+    writeFile(legacyInstarFile());
+    const state = getHotPathState({
+      sessionId: 'sess-h',
+      stateRoot: root,
+      topicId: undefined,
+      recoveryScriptPath: '/no/such/path',
+    });
+    expect(state.autonomousActive).toBe(true);
+  });
+
+  it('explicit autonomousStateFile override is the sole path read (back-compat)', () => {
+    // A legacy single-file exists in the tree, but the explicit override
+    // points at a DIFFERENT, absent file → false (override wins, ignores tree).
+    writeFile(legacyInstarFile());
+    const state = getHotPathState({
+      sessionId: 'sess-h',
+      stateRoot: root,
+      topicId: '6931',
+      autonomousStateFile: path.join(root, 'nowhere', 'absent.md'),
+      recoveryScriptPath: '/no/such/path',
+    });
+    expect(state.autonomousActive).toBe(false);
+  });
+});
+
+// ── GAP-B — D2 unresolved-topic fallback (the no-silent-fallback boundary) ───
+describe('stopGate — D2 unresolved-topic boundary (GAP-B, both sides)', () => {
+  let root: string;
+  const legacyInstarFile = () => path.join(root, '.instar', 'autonomous-state.local.md');
+
+  beforeEach(() => {
+    _resetForTests();
+    root = fs.mkdtempSync(path.join(os.tmpdir(), 'stop-gate-gapb-d2-'));
+  });
+  afterEach(() => {
+    SafeFsExecutor.safeRmSync(root, { recursive: true, force: true, operation: 'tests/unit/stopGate.test.ts:gapb-d2' });
+  });
+
+  it('topic resolves (HIT) → per-topic file is read', () => {
+    const perTopic = path.join(root, '.instar', 'autonomous', '6931.local.md');
+    fs.mkdirSync(path.dirname(perTopic), { recursive: true });
+    fs.writeFileSync(perTopic, 'active: true\n');
+    const state = getHotPathState({
+      sessionId: 'sess-h',
+      stateRoot: root,
+      topicId: '6931',
+      recoveryScriptPath: '/no/such/path',
+    });
+    expect(state.autonomousActive).toBe(true);
+  });
+
+  it('topic MISS but a legacy file exists → does NOT silently return false', () => {
+    // This is the no-silent-fallbacks boundary: a registry-lookup miss
+    // (topicId undefined) must STILL surface the legacy registration.
+    fs.mkdirSync(path.dirname(legacyInstarFile()), { recursive: true });
+    fs.writeFileSync(legacyInstarFile(), 'active: true\n');
+    const state = getHotPathState({
+      sessionId: 'sess-h',
+      stateRoot: root,
+      topicId: undefined, // the MISS
+      recoveryScriptPath: '/no/such/path',
+    });
+    expect(state.autonomousActive).toBe(true);
+  });
+
+  it('topic MISS and no legacy file → false (the genuinely-inactive case)', () => {
+    const state = getHotPathState({
+      sessionId: 'sess-h',
+      stateRoot: root,
+      topicId: undefined,
+      recoveryScriptPath: '/no/such/path',
+    });
+    expect(state.autonomousActive).toBe(false);
+  });
+});
+
+// ── GAP-B — resolveTopicForTmux (registry inversion, mirrors bash hook) ──────
+describe('stopGate — resolveTopicForTmux (GAP-B D2 registry inversion)', () => {
+  const registry = JSON.stringify({
+    topicToSession: {
+      '6931': 'echo-autonomous-mode',
+      '12143': 'echo-other-topic',
+    },
+  });
+  const reader = (_p: string) => registry;
+
+  it('inverts topicToSession on the tmux name (HIT)', () => {
+    expect(resolveTopicForTmux('/reg.json', 'echo-autonomous-mode', reader)).toBe('6931');
+    expect(resolveTopicForTmux('/reg.json', 'echo-other-topic', reader)).toBe('12143');
+  });
+
+  it('returns null for an unknown tmux name (MISS)', () => {
+    expect(resolveTopicForTmux('/reg.json', 'echo-never-seen', reader)).toBeNull();
+  });
+
+  it('returns null for a null/empty tmux name', () => {
+    expect(resolveTopicForTmux('/reg.json', null, reader)).toBeNull();
+    expect(resolveTopicForTmux('/reg.json', '', reader)).toBeNull();
+  });
+
+  it('fails open to null on a corrupt/missing registry (never throws)', () => {
+    expect(resolveTopicForTmux('/reg.json', 'echo-autonomous-mode', () => 'not json')).toBeNull();
+    expect(
+      resolveTopicForTmux('/reg.json', 'echo-autonomous-mode', () => {
+        throw new Error('ENOENT');
+      }),
+    ).toBeNull();
   });
 });

--- a/upgrades/next/autonomous-run-registration-guarantee.md
+++ b/upgrades/next/autonomous-run-registration-guarantee.md
@@ -1,0 +1,54 @@
+# Upgrade Guide — NEXT
+
+<!-- bump: patch -->
+<!-- Valid values: patch, minor, major -->
+<!-- patch = bug fixes, refactors, test additions, doc updates -->
+<!-- minor = new features, new APIs, new capabilities (backwards-compatible) -->
+<!-- major = breaking changes to existing APIs or behavior -->
+
+## What Changed
+
+An internal correction to the stop-gate's autonomous-run detection. The gate that
+decides whether a stopping session is a registered autonomous run was reading only
+an old single-file convention that modern runs no longer write — so a run that
+registered itself per-topic was invisible to the gate and got treated as a plain
+idle session, defeating the revive-it-later safety net.
+
+The read now follows a fixed precedence chain: the canonical per-topic registration
+under the .instar autonomous directory first, then the .instar legacy single-file,
+then the oldest .claude legacy single-file. autonomousActive is true if any exists.
+
+To check the per-topic path the server now resolves the serving topic itself: it
+maps the Claude session id to its tmux session name via the session manager, then
+inverts the topic-session registry on that name — the same inversion the bash stop
+hook already uses. A resolution miss (no session record, corrupt or missing
+registry, unknown name) explicitly falls back to the legacy paths and NEVER silently
+returns a false negative — the no-silent-fallback boundary, annotated and covered by
+tests on both sides.
+
+This is the deterministic read-path fix. The dev-gated registration-guard that
+auto-writes a registration stub when a run starts without one is a distinct change
+specified separately in the spec's PR2 section.
+
+## Evidence
+
+- tsc clean; full lint clean (no-silent-fallbacks ratchet green over the annotated catches).
+- 38 tests green across tests/unit/stopGate.test.ts (D1 precedence, the D2 unresolved-topic boundary both sides, and the resolveTopicForTmux registry inversion) and tests/integration/stop-gate-autonomous-topic-resolution.test.ts (the full HTTP hot-path UUID to tmux to topic resolution).
+- Server-only change — no agent-installed file touched, so no migration parity is required.
+
+Side-effects review: upgrades/side-effects/autonomous-run-registration-guarantee.md
+
+## What to Tell Your User
+
+Your autonomous runs are now recognized more reliably when a session stops. The check that
+decides whether a stopping session is a real autonomous run used to look only at an old
+location that current runs no longer write, so a run that had registered itself could be
+mistaken for an idle session. It now looks at the modern per-run location first and falls
+back to the older ones, and it figures out which conversation it is looking at on its own.
+If it cannot tell, it still checks the older locations rather than assuming the run is idle.
+You do not need to do anything; this just makes the autonomous safety net harder to miss.
+
+## Summary of New Capabilities
+
+No new capabilities or APIs. This is a correctness fix to an existing internal check —
+behavior only, fully backwards compatible, and reversible.

--- a/upgrades/side-effects/autonomous-run-registration-guarantee.md
+++ b/upgrades/side-effects/autonomous-run-registration-guarantee.md
@@ -1,0 +1,40 @@
+# Side-Effects Review — Autonomous-Run Registration Guarantee (GAP-B, PR1)
+
+**Spec:** docs/specs/autonomous-run-registration-guarantee.md (converged R1 + approved — operator full pre-approval, Justin 2026-06-15). **Parent:** An Autonomous Run Must Outlive Its Session.
+**Scope:** PR1 only — the deterministic read-path correction (D1 precedence chain + D2 server-side topic resolution). Ships LIVE (no flag; a pure accuracy fix to an existing read).
+**Files:** src/server/stopGate.ts, src/server/routes.ts, tests/unit/stopGate.test.ts, tests/integration/stop-gate-autonomous-topic-resolution.test.ts
+
+## What changed
+
+1. **stopGate.ts (`readAutonomousActive`):** replaced the single oldest-legacy-path existence check with a fixed precedence chain — (1) the per-topic canonical path .instar/autonomous/TOPIC.local.md, only when a topicId resolves; (2) the .instar legacy single-file; (3) the .claude oldest-legacy single-file. autonomousActive is true if ANY exists. The historical autonomousStateFile override still wins as the sole path read (back-compat). New optional HotPathInputs fields: topicId and stateRoot.
+2. **stopGate.ts (`resolveTopicForTmux`, new exported pure fn):** inverts topic-session-registry.json's topicToSession map on a tmux name — the SAME inversion the bash stop hook uses. Pure, injectable reader, fail-open to null on any read/parse error.
+3. **routes.ts (`resolveTopicForStopGate` helper + two getHotPathState callsites):** resolves the Claude session UUID to its tmux name via the session manager's claudeSessionId record, then to a topicId via resolveTopicForTmux, and passes topicId + stateRoot into both hot-path reads.
+
+## Blast radius
+
+Server-only. The single behavior touched is the stop-gate's autonomousActive read — which it computes for two consumers: the hot-path stop decision input and the StopNotifier unattended-session gate. No agent-installed file changed; no new HTTP route, no new config key, no new state file, no schema change. A single-machine or non-autonomous agent simply reads the same three paths and gets the same answer it would expect.
+
+## Reversibility
+
+Fully reversible. This is a read-path change with no persisted side effects — nothing is written, migrated, or stamped. Reverting the two source files restores the prior single-path read exactly; there is no on-disk state to unwind.
+
+## Signal vs authority
+
+The stop-gate's autonomousActive is a SIGNAL that informs the stop decision and the unattended-notice gate — it is not itself an authority that blocks or commits anything. This change adds NO new authority: it makes the existing signal MORE accurate by reading the canonical per-topic path a modern autonomous run actually writes. It never blocks a message, never gates a session, never spawns or kills anything. A more-accurate "this is an autonomous run" reading only changes whether the existing revive/notify machinery engages — the machinery's own authorities are unchanged.
+
+## Failure modes
+
+The one boundary that matters is the topic-resolution miss (no session record, corrupt/missing registry, unknown tmux name). It resolves to undefined/null and the read falls back EXPLICITLY to both legacy paths — it can never coerce a miss into a silent autonomousActive:false (the no-silent-fallbacks ratchet). Three @silent-fallback-ok catches are annotated and justified: a session-manager read failure (resolver returns undefined → legacy fallback), a per-path stat error (the chain continues to the next path, never short-circuiting the whole read), and a corrupt/missing registry (resolveTopicForTmux returns null → legacy fallback). All three are test-covered on both sides of the boundary.
+
+## Migration parity
+
+NONE required. No agent-installed file changed — this is server code only (the stop-gate read and the route resolver). Existing agents pick up the corrected read the moment their server runs the new code; there is no .claude/settings.json hook, .instar/config.json default, CLAUDE.md section, hook script, or built-in skill to migrate.
+
+## Tests
+
+- tests/unit/stopGate.test.ts — D1 precedence (per-topic wins; a different topic does not activate; fall-through to each legacy path; none-exist false; topic-less still reads both legacy paths; override-is-sole-path back-compat) and the D2 unresolved-topic boundary both sides (HIT reads per-topic; MISS-with-legacy stays true; MISS-with-nothing is the genuinely-inactive false) plus resolveTopicForTmux inversion (hit, unknown-name miss, null/empty, corrupt-registry fail-open).
+- tests/integration/stop-gate-autonomous-topic-resolution.test.ts — the full HTTP hot-path: UUID→tmux→topic resolution feeds the canonical per-topic read end to end.
+
+## What's scoped to the follow-on PR
+
+PR1 covers the read-path correction only — the gate now SEES a registration that already exists on disk. The dev-gated registration-guard that auto-writes a TTL-bounded provenance stub when a run starts without one (D3) is specified separately in the spec's PR2 section, with its own dev-gate rollout and sign-off. <!-- tracked: autonomous-run-registration-guarantee -->


### PR DESCRIPTION
PR1 of GAP-B (the "autonomous run must outlive its session" family). A server-side fix so the stop-gate sees a per-topic autonomous registration.

## What
`readAutonomousActive` now checks `.instar/autonomous/<topicId>.local.md` (canonical per-topic) first, then the two legacy single-file paths. The serving topic is resolved server-side: Claude session UUID → tmux name via SessionManager → topicId via the `topic-session-registry.json` inversion (mirroring the bash stop hook). A registry/topic miss explicitly reads the legacy paths and NEVER silently returns `autonomousActive:false` (the no-silent-fallback boundary, annotated and covered on both sides by tests).

Server-only — no agent-installed file changed, so no migration parity. The dev-gated registration-guard auto-write is specified separately in the spec as a distinct increment.

## Tests
31 unit + 7 integration green; tsc + full lint clean (all 15 lint scripts). E2E-pairing: exempt — a read-path correction to an existing internal route with no new feature surface; the full HTTP hot-path is covered by `tests/integration/stop-gate-autonomous-topic-resolution.test.ts`.

Spec: `docs/specs/autonomous-run-registration-guarantee.md` (converged R1, approved). Convergence report + side-effects + ELI16 companion included.

## ELI16
When an autonomous run stops for a moment, the system asks: is this a real autonomous run that should be revived, or just an idle session? That check was looking only at an old file location that today's runs no longer write — so a run that HAD properly registered itself in the newer per-conversation location was invisible to the check and got treated as idle, defeating the safety net that brings autonomous work back after an interruption (this is the exact way a run died invisibly). This change makes the check look at the modern per-conversation location first, then fall back to the older ones. It also figures out which conversation is stopping on its own — mapping the session id to its terminal name, then to the conversation — and if it cannot tell, it still checks the old locations rather than wrongly concluding "not autonomous." No new features or settings: purely a correctness fix that makes the autonomous safety net harder to miss.
