### PR TITLE
fix(multi-machine): wire the OwnershipApplier — boot-ordering left it never ticking (CMT-1569)

### DIFF
--- a/.instar/instar-dev-decisions/2026-06-16T06-37-44-080Z-ownership-applier-meshself-ordering-fix.json
+++ b/.instar/instar-dev-decisions/2026-06-16T06-37-44-080Z-ownership-applier-meshself-ordering-fix.json
@@ -1,0 +1,19 @@
+{
+  "ts": "2026-06-16T06:37:44.080Z",
+  "slug": "ownership-applier-meshself-ordering-fix",
+  "suggestedTier": 2,
+  "declaredTier": null,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 3,
+  "loc": 110,
+  "causalAutopsy": {
+    "origin": "latent",
+    "relatedPrs": [
+      1190
+    ],
+    "notes": "The transfer-fix §7.2 applier (introduced with the durable-ownership work, hardened in #1190) had a boot-ordering defect from inception: its server.ts guard read _meshSelfId ~650 lines before assignment, so it never ran. Latent until the gold-standard live re-run of the transfer exercised the real destination path."
+  },
+  "verdict": "pass"
+}

--- a/docs/specs/ownership-applier-meshself-ordering-fix.eli16.md
+++ b/docs/specs/ownership-applier-meshself-ordering-fix.eli16.md
@@ -1,0 +1,27 @@
+# ELI16 — OwnershipApplier mesh-self ordering fix
+
+**Parent principle:** Wiring Integrity — a dependency-injected component must actually run, not be a silently-skipped no-op (Testing Integrity Standard, wiring-integrity clause).
+
+## What's the problem, in plain words?
+
+When you move a conversation from one of my machines to another (say, Laptop → Mac Mini), the destination machine has to *learn* that it now owns that conversation, so the next message gets answered there. The piece of code that teaches it — the `OwnershipApplier` — reads a synced list of "who owns what" and writes down the ownership on the destination's own disk.
+
+It turns out that piece of code was **never actually turned on** at runtime. Not on either machine. The reason is a subtle ordering mistake in the server's startup file: the code that switches the applier on checks a variable (`_meshSelfId`, "which machine am I?") that doesn't get filled in until about 650 lines *later* in the startup sequence. So at the moment of the check, that variable is still empty, the check fails, and the applier is quietly skipped forever.
+
+You couldn't see this on the machine you move *from*, because that machine writes the ownership a different way. You could only see it on the machine you move *to* — and that's exactly the machine that needed the applier. So a moved conversation would say "moved!" but then go silent on the new machine, because the new machine never realized it was in charge. That's the precise bug the operator personally ran into.
+
+## How was it found?
+
+By the new gold-standard live test — the whole point of which is to drive a feature through the *real* path on *real* machines before a human ever has to. I moved a throwaway conversation to the Mini and then checked the Mini's *own disk and API* (not just the "ok" response from the move command). The move reported success, the "who owns what" list correctly synced to the Mini — but the Mini never wrote down the ownership. To be sure it wasn't a logic bug, I ran the applier by hand against the Mini's real data and it worked perfectly, materializing every moved conversation. That proved the code is correct and the problem is purely that the server never *runs* it.
+
+## What's the fix?
+
+Two small, careful changes that make the wiring impossible to break by reordering:
+
+1. **Make "which machine am I?" late-bound.** Instead of reading that variable once at startup (when it's still empty), the applier asks for it fresh each time it runs. The machine id is only used for a log label anyway — the actual ownership-writing doesn't need it — so even an early run before the id is known still does the right thing.
+
+2. **Turn the applier on based on the right condition.** The on-switch now checks only "is the durable ownership store active?" (which is the genuinely relevant thing) instead of also requiring the not-yet-filled machine-id variable. I pulled this on-switch out into its own tiny, testable function so a unit test can prove it switches on correctly — the inline version was untestable, which is how the bug slipped through in the first place.
+
+## How do we know it's really fixed?
+
+Tests prove the on-switch logic. But because the bug lived in the server's *startup ordering*, the real proof has to come from a real two-machine run — so the release gate is: deploy to both machines, move a throwaway conversation Laptop → Mini, and confirm the Mini writes the durable ownership record, its log shows its *own* applier ran, and a reply genuinely comes back *from the Mini* through Telegram and Slack. A "moved!" that isn't backed by the destination actually owning the conversation is the exact false success this whole effort exists to forbid.

--- a/docs/specs/ownership-applier-meshself-ordering-fix.md
+++ b/docs/specs/ownership-applier-meshself-ordering-fix.md
@@ -1,0 +1,231 @@
+---
+title: "OwnershipApplier mesh-self ordering fix — make the transfer-fix applier actually run"
+slug: "ownership-applier-meshself-ordering-fix"
+author: "echo"
+parent-principle: "Wiring Integrity — a dependency-injected component must actually run, not be a silently-skipped no-op (Testing Integrity Standard, wiring-integrity clause)."
+review-convergence: "2026-06-16T06:31:02.035Z"
+review-iterations: 3
+review-completed-at: "2026-06-16T06:31:02.035Z"
+review-report: "docs/specs/reports/ownership-applier-meshself-ordering-fix-convergence.md"
+cross-model-review: "codex-cli:gpt-5.5"
+approved: true
+approved-by: "echo (autonomous run, standing operator pre-approval for topic 13481 — design-fork/spec decisions are mine to approve and report in the ELI16)"
+---
+
+# OwnershipApplier mesh-self ordering fix
+
+## Problem statement
+
+The multi-machine transfer fix (transfer-fix §7.2) relies on the `OwnershipApplier` to
+materialize durable ownership on the machine a topic moved **to** — it reads the
+replicated placement journal (`peers/<machineId>.topic-placement.jsonl`) and writes a
+durable `LocalSessionOwnershipStore` record so the next message resolves the right owner.
+
+Applying the **Live-User-Channel Proof** gold standard to the transfer (the first feature
+held to that bar) caught a genuine ship-blocker: **the `OwnershipApplier` is never
+constructed or ticked at runtime — on either machine.**
+
+Root cause is a boot-ordering bug in `src/commands/server.ts`:
+
+- The applier wiring is guarded by `if (durableOwnershipStore && _meshSelfId)` at
+  ~line 14995.
+- `_meshSelfId` is not assigned (`_meshSelfId = meshSelfId`) until ~line 15648 — about
+  650 lines / a later `await` stage in the async boot sequence.
+
+So at the moment the guard is evaluated, `_meshSelfId` is still its initial `null`. The
+guard is `truthy && null` → **false**, and the applier block (construction + boot tick +
+the 15s interval) is skipped permanently.
+
+**Why it was invisible until the live test:** on the transfer **source** the durable
+ownership record is written directly (the `tclaim` path), so a source machine looks
+correct without the applier ever running. The applier is the **only** materialization
+path on the **destination**. So a transferred seat is recorded on the source, replicates
+to the destination's journal, and then **dies there** — the destination never materializes
+ownership, never knows it owns the session, and never serves the conversation. This is
+exactly the failure the operator personally hit, and exactly what the standard exists to
+catch: `/pool/transfer` returns `seatMoved:true` while, end-to-end, nothing landed on the
+destination.
+
+**Evidence the applier *logic* is correct (so this is purely a wiring/ordering bug):**
+constructing `CoherenceJournalReader` + `OwnershipApplier` + `LocalSessionOwnershipStore`
+by hand against the destination's *deployed* journal materialized every replicated
+placement correctly (`materialized 11/11`, including the live-test topic, tagged
+`SELF — this machine now serves it`). The activation fix (pool-consistent durable-store
+activation, v1.3.590) is necessary but not sufficient: the store is active, but the
+component that *uses* it never runs.
+
+## Proposed design
+
+Make the applier wiring **order-independent** (Structure > Willpower — a fix that depends on
+two code regions staying in a particular order is a wish; a fix that cannot break under
+reordering is a guarantee). Two surgical changes:
+
+### 1. `src/core/OwnershipApplier.ts` — late-bind `selfMachineId`
+
+`selfMachineId` is used **only** for the SELF-vs-peer log label (line ~122); it is NOT
+required to materialize a placement (every placement is materialized regardless of owner —
+fast-forward CAS on epoch). So accept it lazily:
+
+```ts
+selfMachineId: string | (() => string | null | undefined);
+```
+
+Resolve it at tick time via a private helper:
+
+```ts
+private resolveSelf(): string | null | undefined {
+  const s = this.d.selfMachineId;
+  return typeof s === 'function' ? s() : s;
+}
+```
+
+and use `this.resolveSelf()` where `this.d.selfMachineId` is read. A plain string still
+works (full backward compatibility — existing callers/tests are unaffected).
+
+### 2. Extract a testable wiring factory + construct on the durable-store condition alone
+
+The construction CONDITION is what the boot-ordering bug corrupted, so it is extracted into
+a small exported factory (`src/core/ownershipApplierWiring.ts`) — mirroring
+`durableOwnershipActivation` — so the invariant is unit-testable without booting the whole
+server (Structure > Willpower; the inline-in-`server.ts` condition was untestable, which is
+how the ordering bug shipped):
+
+```ts
+// ownershipApplierWiring.ts
+export function wireOwnershipApplier(deps: {
+  durableOwnershipStore: SessionOwnershipStore | null;
+  reader: PlacementReader;
+  getSelfMachineId: () => string | null | undefined;   // late-bound
+  logger?: (m: string) => void;
+}): OwnershipApplier | null {
+  if (!deps.durableOwnershipStore) return null;          // gate on the store ALONE — not on _meshSelfId
+  return new OwnershipApplier({
+    reader: deps.reader,
+    store: deps.durableOwnershipStore,
+    selfMachineId: deps.getSelfMachineId,                // getter, resolved per-tick
+    logger: deps.logger,
+  });
+}
+```
+
+`server.ts` calls `wireOwnershipApplier({ durableOwnershipStore, reader, getSelfMachineId: () => _meshSelfId, ... })`
+in place of the inline `if (durableOwnershipStore && _meshSelfId) { new OwnershipApplier(...) }`,
+then schedules the boot tick + 15s interval on the returned applier (when non-null).
+
+Construction now depends only on the durable store being active (the correct condition —
+applying replicated placements is a durable-store concern; InMemory has no replication to
+apply). The boot tick + 15s interval run from the start; an early tick that fires before
+`_meshSelfId` is assigned still materializes placements correctly (it only loses the
+SELF/peer log label on that one early tick), and every subsequent tick — milliseconds
+later, after the assignment — labels correctly.
+
+### Observability
+
+The applier's runtime activity is already observable and that surface becomes meaningful for
+the first time once it actually runs: each materializing tick logs
+`[ownership-applier] materialized topic <t> → owner <m> (SELF|peer …)` and the interval logs
+`[OwnershipApplier] materialized N/M topic(s) from replicated placements`; a tick error logs
+`[OwnershipApplier] tick failed`. These lines in `logs/server.log` are the read surface for
+"is the destination materializing transferred seats?" — their **presence** is itself the
+proof the wiring is alive (the bug's signature was their total absence). The applier is a
+deterministic file-scan component, not an LLM feature, so it carries no token/`/metrics`
+surface; the materialized/examined counts in the interval log are the equivalent rate signal.
+No new metric is introduced because the fix's success criterion is precisely the appearance
+of these existing-but-never-emitted lines.
+
+### Multi-machine posture
+
+This is the materialization half of the existing replicated transfer path; posture is
+unchanged (replicated placement journal → durable per-machine ownership store). Single
+machine: the durable store may be active but there are no peer placements to apply, so the
+applier is a harmless no-op tick. No new state, route, or URL is introduced.
+
+## Decision points touched
+
+No block/allow/route gate is introduced, removed, or modified. The change is internal
+wiring: it removes an over-restrictive construction guard (`&& _meshSelfId`) that was
+silently disabling a required component, and makes a dependency late-bound.
+
+## Frontloaded Decisions
+
+- **Lazy-bind vs relocate-the-block.** Both fix the ordering. Lazy-binding is chosen because
+  it is order-independent (cannot regress if either code region is later moved), it makes
+  the applier's construction condition *semantically correct* (gate on the durable store,
+  not on an unrelated mesh-id variable), and it keeps the diff local. Relocating the block
+  would leave a latent fragility (a future reorder reintroduces the bug). Reversible: behind
+  no flag, but it only activates the durable-ownership path that already ships dark for
+  single-machine and pool-consistent for replication-on pools.
+- **Construct even when self is momentarily null.** Accepted: materialization does not need
+  self; only the log label does. An early label-less tick is strictly better than never
+  materializing. Cheap-to-change: pure internal logging cosmetics.
+
+## Testing
+
+- **Tier 1 (`tests/unit/`):** OwnershipApplier resolves a **function** `selfMachineId` at tick
+  time — a getter returning `null` at construction then a value still materializes placements
+  on both ticks, and labels SELF/peer correctly once the getter returns a value; a plain
+  string still works (backward compat); a peer placement materializes even when self is
+  unresolved (proving construction-time self is not required — the regression guard for this
+  exact bug).
+- **Tier 2 / wiring-integrity (`tests/unit` + `tests/integration`):** test the EXTRACTED
+  `wireOwnershipApplier` factory directly — it returns a **live applier (non-null)** when a
+  durable store is present even though `getSelfMachineId()` returns `null` (the exact
+  condition the boot-ordering bug got wrong: store-present + self-unset must still construct),
+  and returns `null` when the store is absent (InMemory has nothing to apply). This proves the
+  construction CONDITION at the unit level — the regression surface codex flagged — without
+  booting the whole server. An integration test then exercises the
+  `CoherenceJournalReader` + (factory-built) applier + `LocalSessionOwnershipStore` triad over
+  a fixture peer placement journal and asserts a durable destination record is written — the
+  in-process analogue of the cross-machine path, runnable in CI without two machines.
+- **Tier 3 / E2E — the live bar (see Verification below).** A boot-ordering wiring bug only
+  fully manifests in a real two-machine deployment; the synthetic tiers above are necessary
+  but cannot exercise the actual server boot sequence that the bug lives in. The gold
+  standard's live-user-channel re-run **is** the E2E for this fix, and is a hard release gate
+  that runs in THIS effort as a required step (not optional, not postponed).
+
+**Named residual (explicit coverage map).** The factory unit test proves the construction
+*predicate* (store-present + self-unset ⇒ non-null applier); it deliberately does NOT prove
+that `server.ts` *invokes* `wireOwnershipApplier` at the right point in its boot sequence —
+that is the one surface a unit test cannot reach. That residual is owned, not waved away: it
+is closed by the Tier-3 live verification below (step 3b asserts the **server's own** applier
+emitted `[ownership-applier] materialized …`, and 3a/3c assert the durable destination state
+the boot wiring must produce). Factory unit test + live E2E together cover the predicate and
+the invocation; neither alone is sufficient, and the live E2E is a hard release gate so the
+invocation half can never be skipped.
+
+## Verification (the live bar — reproduces the original failure before claiming fixed)
+
+Per the **Bug-Fix Evidence Bar** (verify before you claim) and the **Live-User-Channel
+Proof** standard, the fix is not "done" until the *original* failure is reproduced against
+the deployed system and shown resolved end-to-end:
+
+1. Deploy the fixed version to **both** machines (Laptop + Mac Mini); restart both servers.
+2. `POST /pool/transfer` a throwaway topic Laptop→Mini.
+3. Assert the **destination** (Mini) materializes it — all THREE must hold (none was true
+   before the fix): (a) a durable record at `.instar/ownership/local/<topic>.json` on the
+   Mini owned by the Mini; (b) `[ownership-applier] materialized topic <topic> → owner
+   <mini>` in the Mini's `logs/server.log` (proving the **server's own** applier ran, not a
+   manual diagnostic — the `(SELF …)` label is best-effort and appears once `_meshSelfId`
+   resolves, so the gate keys on the materialized line and the durable record, NOT on the
+   SELF suffix, which an early pre-resolve tick legitimately omits); (c) the Mini's
+   `GET /pool/placement?topic=<topic>` reports `isThisMachine:true`.
+4. Drive a message through the real user channel (Telegram and Slack) and confirm the reply
+   is genuinely served **from the Mini**, then record the signed `LiveTestArtifact`.
+
+**The authoritative correctness gate is the durable STATE, not the log.** Steps 3(a) (the
+durable `.instar/ownership/local/<topic>.json` record on the Mini) and 3(c) (the Mini's
+`/pool/placement` reporting `isThisMachine:true`) are queried from durable state / a live
+API and are what PASS/FAIL keys on — immune to log-level changes, rotation, throttling, or
+async-flush loss. Step 3(b)'s log line is corroborating evidence that the **server's own**
+applier (not a manual diagnostic) produced the record; its absence with 3(a)+3(c) present is
+investigated (it would mean the record arrived by some other path) but does not by itself
+fail a run where durable state is correct, and its presence cannot substitute for a missing
+durable record. So log brittleness can neither cause a false PASS nor block a true one.
+
+A `seatMoved:true` from `/pool/transfer` that is NOT accompanied by destination
+materialization (step 3) is the exact false-OK this whole effort exists to forbid, and
+blocks the claim.
+
+## Open questions
+
+*(none)*

--- a/docs/specs/reports/ownership-applier-meshself-ordering-fix-convergence.md
+++ b/docs/specs/reports/ownership-applier-meshself-ordering-fix-convergence.md
@@ -1,0 +1,47 @@
+# Convergence Report — OwnershipApplier mesh-self ordering fix
+
+## Cross-model review: codex-cli:gpt-5.5 + gemini-cli:gemini-2.5-pro (RAN, both families)
+
+Both supported non-Claude families were available and ran each round (codex gpt-5.5,
+gemini gemini-2.5-pro). The spec received genuine cross-model review across all rounds.
+
+## ELI10 Overview
+
+Moving a conversation between my machines was reported as succeeding while the destination
+machine never actually took ownership — so the conversation went silent on arrival. The
+cause: the code that hands ownership to the destination was never switched on, because its
+on-switch read a "which machine am I?" value that the startup sequence doesn't fill in until
+650 lines later. The fix makes that value late-bound and switches the component on based on
+the genuinely relevant condition (the durable store being active), pulled into a tiny
+testable function. The live two-machine re-run is the release gate.
+
+## Origin
+
+Found by APPLYING the Live-User-Channel Proof gold standard to the multi-machine transfer —
+the second, deeper bug the standard caught (the first, dev-gate-darkness, shipped in #1190 /
+v1.3.590). Activation alone was necessary but not sufficient: the durable store activates but
+the component that consumes it never ran.
+
+## Iteration Summary
+
+| Iteration | Reviewers | Material findings | Spec changes |
+|-----------|-----------|-------------------|--------------|
+| 1 | conformance (2 possible-violations), codex (MINOR/2pts) | Testing scope; Bug-Fix Evidence Bar; helper-not-server test surface; SELF-label over-requirement | Added Verification (reproduce-then-verify) section; relaxed SELF-label gate; committed integration tier |
+| 2 | conformance (1: Observability), codex (MINOR) | Observability surface; logs-as-correctness brittleness | Added Observability section; extracted testable `wireOwnershipApplier` factory; made durable state (not logs) the authoritative gate |
+| 3 | conformance (clean), codex (MINOR), gemini (CLEAN) | Residual: factory unit test ≠ proof server.ts invokes it under boot order | Named the residual explicitly + assigned it to the Tier-3 live-E2E release gate |
+| — | (converged) | 0 material-new | — |
+
+## Standards-Conformance Gate
+
+Ran every round (22 standards). Round 1: 2 possible-violations (Testing Integrity, Bug-Fix
+Evidence Bar). Round 2: 1 (Observability). Round 3: **0 possible-violations**.
+
+## Convergence verdict
+
+Converged. Gemini CLEAN; codex descended to a single MINOR residual that is structurally
+answered by the spec's existing Tier-3 live-verification release gate (a unit test cannot
+prove server.ts boot-invocation; the live E2E asserts the server's own applier ran). Zero
+open questions. The fix is surgical (lazy-bind `selfMachineId` + a testable
+`wireOwnershipApplier` factory gated on the durable store alone) and order-independent —
+robust against future reordering, which is what made the original bug possible. Ready for
+approval.

--- a/site/src/content/docs/architecture/live-user-channel-proof.md
+++ b/site/src/content/docs/architecture/live-user-channel-proof.md
@@ -74,3 +74,15 @@ The durable store's activation is decided by `durableOwnershipActivation` — sp
 replication is explicitly on, not only on a dev-flagged machine. This closed a live-test
 finding where the Mini's store stayed dark and a transferred seat died on arrival;
 `durableOwnershipActivation` makes a replication-enabled pool activate consistently.
+
+## OwnershipApplier wiring (the second finding)
+
+The first live re-run of the transfer caught a deeper bug than the activation gap: the
+`OwnershipApplier` — the component that materializes durable ownership on the machine a topic
+moved *to* — was never wired at runtime, because its construction guard read a mesh-id
+variable hundreds of lines before the boot sequence assigned it. The fix extracts the
+construction condition into a testable `wireOwnershipApplier` factory that gates on the
+durable store alone and late-binds the machine id. `wireOwnershipApplier` returns a live
+applier whenever the durable store is active — even before the mesh id resolves — so a
+reordering of the boot sequence can never again silently disable it; the durable destination
+record (not a log line) is the authoritative proof the seat actually moved.

--- a/src/commands/server.ts
+++ b/src/commands/server.ts
@@ -14991,20 +14991,29 @@ export async function startServer(options: StartOptions): Promise<void> {
         // resolves the right owner on the next message — the step the in-memory store
         // never had. Off the hot path: ticked on an interval + once at boot (to adopt
         // a transfer that landed while we were down). Only when the durable store is
-        // active (dev-gate); InMemory has no cross-machine replication to apply.
-        if (durableOwnershipStore && _meshSelfId) {
-          const { OwnershipApplier } = await import('../core/OwnershipApplier.js');
-          const { CoherenceJournalReader } = await import('../core/CoherenceJournalReader.js');
-          const applier = new OwnershipApplier({
-            reader: new CoherenceJournalReader({ stateDir: config.stateDir }),
-            store: durableOwnershipStore,
-            selfMachineId: _meshSelfId,
-            logger: (m: string) => console.log(pc.dim(`  ${m}`)),
-          });
-          try { applier.tick(); } catch { /* @silent-fallback-ok — boot tick best-effort; the interval converges */ }
+        // active; InMemory has no cross-machine replication to apply.
+        //
+        // Construction is gated on the durable store ALONE — NOT on `_meshSelfId`. The
+        // old `&& _meshSelfId` guard ran here, ~650 lines before `_meshSelfId` is assigned
+        // in the boot sequence, so it was always null at this point and the applier was
+        // never wired (the boot-ordering bug the live test caught). `selfMachineId` is now
+        // a late-bound getter (label-only; materialization never needs it), so an early
+        // tick is correct and later ticks label SELF/peer once the id resolves. The wiring
+        // factory is extracted + unit-tested so this condition can never silently regress.
+        // Spec: docs/specs/ownership-applier-meshself-ordering-fix.md.
+        const { CoherenceJournalReader } = await import('../core/CoherenceJournalReader.js');
+        const { wireOwnershipApplier } = await import('../core/ownershipApplierWiring.js');
+        const ownershipApplier = wireOwnershipApplier({
+          durableOwnershipStore,
+          reader: new CoherenceJournalReader({ stateDir: config.stateDir }),
+          getSelfMachineId: () => _meshSelfId,
+          logger: (m: string) => console.log(pc.dim(`  ${m}`)),
+        });
+        if (ownershipApplier) {
+          try { ownershipApplier.tick(); } catch { /* @silent-fallback-ok — boot tick best-effort; the interval converges */ }
           const applierTimer = setInterval(() => {
             try {
-              const r = applier.tick();
+              const r = ownershipApplier.tick();
               if (r.materialized) console.log(pc.dim(`  [OwnershipApplier] materialized ${r.materialized}/${r.examined} topic(s) from replicated placements`));
             } catch (err) {
               console.error('[OwnershipApplier] tick failed:', err instanceof Error ? err.message : String(err));

--- a/src/core/OwnershipApplier.ts
+++ b/src/core/OwnershipApplier.ts
@@ -46,7 +46,14 @@ export interface OwnershipApplierDeps {
   /** The SAME durable store the SessionOwnershipRegistry reads — so a materialized
    *  record is immediately visible to owner-resolution / routing. */
   store: SessionOwnershipStore;
-  selfMachineId: string;
+  /**
+   * This machine's mesh id — used ONLY for the SELF-vs-peer log label, never for
+   * materialization (every placement is adopted regardless of owner). Accepts a
+   * **late-bound getter** so a caller can wire the applier before `_meshSelfId` is
+   * resolved without capturing a stale `null` (the boot-ordering hazard this fix closes);
+   * a plain string still works for callers/tests that already have the id.
+   */
+  selfMachineId: string | (() => string | null | undefined);
   /** Max placement entries to scan per tick (bounded cost). Default 1000. */
   scanLimit?: number;
   logger?: (msg: string) => void;
@@ -73,6 +80,12 @@ export class OwnershipApplier {
 
   private log(m: string): void {
     this.d.logger?.(`[ownership-applier] ${m}`);
+  }
+
+  /** Resolve the (possibly late-bound) self machine id at tick time, for the log label only. */
+  private resolveSelf(): string | null | undefined {
+    const s = this.d.selfMachineId;
+    return typeof s === 'function' ? s() : s;
   }
 
   /**
@@ -117,9 +130,14 @@ export class OwnershipApplier {
         const r = this.d.store.casWrite(rec);
         if (r.ok) {
           materialized++;
+          const self = this.resolveSelf();
           this.log(
             `materialized topic ${sessionKey} → owner ${best.owner} @epoch ${best.epoch}` +
-              (best.owner === this.d.selfMachineId ? ' (SELF — this machine now serves it)' : ' (peer — route forwards there)'),
+              (self && best.owner === self
+                ? ' (SELF — this machine now serves it)'
+                : self
+                  ? ' (peer — route forwards there)'
+                  : ''),
           );
         }
       }

--- a/src/core/ownershipApplierWiring.ts
+++ b/src/core/ownershipApplierWiring.ts
@@ -1,0 +1,55 @@
+/**
+ * ownershipApplierWiring — the testable construction factory for the transfer-fix §7.2
+ * OwnershipApplier (spec: docs/specs/ownership-applier-meshself-ordering-fix.md).
+ *
+ * Why this exists: the applier's construction CONDITION used to live inline in
+ * `server.ts` as `if (durableOwnershipStore && _meshSelfId)`. That guard read
+ * `_meshSelfId` ~650 lines BEFORE the boot sequence assigns it, so it was always
+ * `null` at the check → the applier was never constructed or ticked, on either machine,
+ * and a transferred seat never materialized on the destination. The inline condition was
+ * also untestable, which is precisely how the ordering bug shipped.
+ *
+ * The fix (Structure > Willpower): gate construction on the durable store ALONE — the
+ * genuinely relevant condition (applying replicated placements is a durable-store concern;
+ * the in-memory store has no cross-machine replication to apply) — and pass `selfMachineId`
+ * as a LATE-BOUND getter so the (label-only) self id resolves at tick time instead of being
+ * captured as a stale `null` at construction. This makes the wiring order-independent and
+ * unit-testable without booting the whole server.
+ */
+import type { PlacementReader } from './OwnershipApplier.js';
+import { OwnershipApplier } from './OwnershipApplier.js';
+import type { SessionOwnershipStore } from './SessionOwnershipRegistry.js';
+
+export interface OwnershipApplierWiringDeps {
+  /** The durable per-session store, or null when the in-memory store is in use. */
+  durableOwnershipStore: SessionOwnershipStore | null;
+  /** Reads replicated + own placement entries (CoherenceJournalReader). */
+  reader: PlacementReader;
+  /**
+   * Late-bound resolver for this machine's mesh id. May legitimately return null/undefined
+   * at construction time (before the boot sequence assigns it); it is used ONLY for the
+   * SELF-vs-peer log label, never for materialization.
+   */
+  getSelfMachineId: () => string | null | undefined;
+  scanLimit?: number;
+  logger?: (msg: string) => void;
+  now?: () => number;
+}
+
+/**
+ * Build the OwnershipApplier when (and only when) the durable ownership store is active.
+ * Returns `null` for the in-memory store (nothing to apply). NEVER gates on the self id —
+ * that was the boot-ordering bug. The caller schedules the boot tick + interval on a
+ * non-null result.
+ */
+export function wireOwnershipApplier(deps: OwnershipApplierWiringDeps): OwnershipApplier | null {
+  if (!deps.durableOwnershipStore) return null;
+  return new OwnershipApplier({
+    reader: deps.reader,
+    store: deps.durableOwnershipStore,
+    selfMachineId: deps.getSelfMachineId, // getter — resolved per-tick, never captured stale
+    scanLimit: deps.scanLimit,
+    logger: deps.logger,
+    now: deps.now,
+  });
+}

--- a/tests/unit/ownershipApplierWiring.test.ts
+++ b/tests/unit/ownershipApplierWiring.test.ts
@@ -1,0 +1,141 @@
+/**
+ * Tier-1 + wiring-integrity tests for the OwnershipApplier mesh-self ordering fix
+ * (spec: docs/specs/ownership-applier-meshself-ordering-fix.md).
+ *
+ * Proves the fix for the boot-ordering bug the GOLD-STANDARD live test caught: the applier
+ * was gated on `durableOwnershipStore && _meshSelfId`, but `_meshSelfId` is assigned ~650
+ * lines AFTER that guard in the server boot sequence, so it was always null at the check →
+ * the applier was never constructed/ticked → a transferred seat never materialized on the
+ * destination. The fix gates construction on the durable store ALONE and late-binds
+ * `selfMachineId` (label-only) so it can never capture a stale null.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+import { OwnershipApplier, type PlacementReader } from '../../src/core/OwnershipApplier.js';
+import { wireOwnershipApplier } from '../../src/core/ownershipApplierWiring.js';
+import { LocalSessionOwnershipStore } from '../../src/core/LocalSessionOwnershipStore.js';
+
+/** A fake reader returning fixed placement entries (mirrors CoherenceJournalReader.query). */
+function reader(entries: Array<{ topic: number; machine: string; owner: string; epoch: number; source?: 'own' | 'replica' }>): PlacementReader {
+  return {
+    query: () => ({
+      entries: entries.map((e) => ({ topic: e.topic, machine: e.machine, source: e.source ?? 'replica', data: { owner: e.owner, epoch: e.epoch, reason: 'user-move' } })),
+    }),
+  };
+}
+
+describe('wireOwnershipApplier factory (construction condition — the regression surface)', () => {
+  let dir: string;
+  let store: LocalSessionOwnershipStore;
+
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'applier-wiring-'));
+    store = new LocalSessionOwnershipStore({ dir });
+  });
+  afterEach(() => {
+    try { SafeFsExecutor.safeRmSync(dir, { recursive: true, force: true, operation: 'live-test-cleanup' }); } catch { /* best-effort */ }
+  });
+
+  it('THE REGRESSION GUARD: constructs a LIVE applier when the durable store is present even though getSelfMachineId() returns null', () => {
+    // This is the exact condition the boot-ordering bug got wrong: store present, self
+    // unresolved. The old guard returned no applier here. The fix MUST return one.
+    const applier = wireOwnershipApplier({
+      durableOwnershipStore: store,
+      reader: reader([{ topic: 970013, machine: 'laptop', owner: 'mini', epoch: 2 }]),
+      getSelfMachineId: () => null, // self not yet assigned (the boot-ordering hazard)
+    });
+    expect(applier).not.toBeNull();
+    // And it actually materializes — materialization never needed self.
+    const res = applier!.tick();
+    expect(res.materialized).toBe(1);
+    expect(store.read('970013')?.ownerMachineId).toBe('mini');
+  });
+
+  it('returns null when there is no durable store (InMemory has nothing to apply)', () => {
+    const applier = wireOwnershipApplier({
+      durableOwnershipStore: null,
+      reader: reader([{ topic: 970013, machine: 'laptop', owner: 'mini', epoch: 2 }]),
+      getSelfMachineId: () => 'mini',
+    });
+    expect(applier).toBeNull();
+  });
+
+  it('materializes a replicated placement end-to-end through the factory (in-process analogue of the cross-machine path)', () => {
+    const applier = wireOwnershipApplier({
+      durableOwnershipStore: store,
+      reader: reader([{ topic: 26406, machine: 'laptop', owner: 'mini', epoch: 3 }]),
+      getSelfMachineId: () => 'mini',
+    });
+    expect(store.read('26406')).toBeNull(); // the bug's starting state on the destination
+    expect(applier!.tick().materialized).toBe(1);
+    expect(store.read('26406')?.ownerMachineId).toBe('mini');
+    expect(store.read('26406')?.ownershipEpoch).toBe(3);
+  });
+});
+
+describe('OwnershipApplier late-bound selfMachineId', () => {
+  let dir: string;
+  let store: LocalSessionOwnershipStore;
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'applier-lazy-'));
+    store = new LocalSessionOwnershipStore({ dir });
+  });
+  afterEach(() => {
+    try { SafeFsExecutor.safeRmSync(dir, { recursive: true, force: true, operation: 'live-test-cleanup' }); } catch { /* best-effort */ }
+  });
+
+  it('a getter that is null at construction then resolves still materializes on both ticks and labels SELF once resolved', () => {
+    let self: string | null = null; // unresolved at construction (the boot ordering)
+    const logs: string[] = [];
+    const applier = new OwnershipApplier({
+      reader: reader([{ topic: 970013, machine: 'laptop', owner: 'mini', epoch: 1 }]),
+      store,
+      selfMachineId: () => self,
+      logger: (m) => logs.push(m),
+    });
+    // Tick #1: self still null → materializes (no SELF/peer suffix on the label).
+    expect(applier.tick().materialized).toBe(1);
+    expect(store.read('970013')?.ownerMachineId).toBe('mini');
+    expect(logs.some((l) => l.includes('materialized topic 970013'))).toBe(true);
+    expect(logs.some((l) => l.includes('(SELF') || l.includes('(peer'))).toBe(false);
+
+    // self resolves; a NEWER placement arrives → re-materialize, now labelled SELF.
+    self = 'mini';
+    logs.length = 0;
+    const applier2 = new OwnershipApplier({
+      reader: reader([{ topic: 970013, machine: 'laptop', owner: 'mini', epoch: 2 }]),
+      store,
+      selfMachineId: () => self,
+      logger: (m) => logs.push(m),
+    });
+    expect(applier2.tick().materialized).toBe(1);
+    expect(logs.some((l) => l.includes('(SELF — this machine now serves it)'))).toBe(true);
+  });
+
+  it('a peer-owned placement labels (peer …) once self is resolved', () => {
+    const logs: string[] = [];
+    const applier = new OwnershipApplier({
+      reader: reader([{ topic: 12476, machine: 'mini', owner: 'laptop', epoch: 4 }]),
+      store,
+      selfMachineId: () => 'mini', // I am mini; owner is laptop → peer
+      logger: (m) => logs.push(m),
+    });
+    expect(applier.tick().materialized).toBe(1);
+    expect(logs.some((l) => l.includes('(peer — route forwards there)'))).toBe(true);
+  });
+
+  it('still accepts a plain string selfMachineId (backward compatibility)', () => {
+    const logs: string[] = [];
+    const applier = new OwnershipApplier({
+      reader: reader([{ topic: 13481, machine: 'laptop', owner: 'mini', epoch: 5 }]),
+      store,
+      selfMachineId: 'mini', // legacy string form
+      logger: (m) => logs.push(m),
+    });
+    expect(applier.tick().materialized).toBe(1);
+    expect(logs.some((l) => l.includes('(SELF — this machine now serves it)'))).toBe(true);
+  });
+});

--- a/upgrades/next/ownership-applier-meshself-ordering-fix.md
+++ b/upgrades/next/ownership-applier-meshself-ordering-fix.md
@@ -1,0 +1,29 @@
+## What Changed
+
+Fixed a boot-ordering bug that left the cross-machine `OwnershipApplier` permanently
+un-wired: a topic moved between machines was reported moved but the destination never took
+ownership, so the conversation went silent on arrival. The applier's on-switch now depends on
+the durable ownership store alone (extracted into a testable `wireOwnershipApplier` factory),
+and the machine id it uses for logging is late-bound, so the wiring can't be broken by code
+reordering. Caught by applying the Live-User-Channel Proof gold standard to a real
+Laptop→Mini transfer (the second, deeper bug after the dev-gate-darkness fix in v1.3.590).
+
+## What to Tell Your User
+
+If you move a conversation between your machines, the destination now genuinely takes over and
+answers there. Before this, a moved conversation could report success but then go quiet on the
+new machine, because the new machine never realized it owned the conversation. Single-machine
+setups are unaffected.
+
+## Summary of New Capabilities
+
+| Capability | How to Use |
+|-----------|-----------|
+| Moving a conversation between machines actually lands it on the destination | Move a topic to another machine as usual; the destination now takes ownership and serves it |
+
+## Evidence
+
+- 6 new unit/wiring tests (`tests/unit/ownershipApplierWiring.test.ts`) + 7 existing applier
+  tests stay green; tsc clean.
+- Release gate: a live two-machine re-run asserts the destination materializes the seat and a
+  reply serves from it (Telegram + Slack).

--- a/upgrades/side-effects/ownership-applier-meshself-ordering-fix.md
+++ b/upgrades/side-effects/ownership-applier-meshself-ordering-fix.md
@@ -1,0 +1,52 @@
+# Side-Effects Review — OwnershipApplier mesh-self ordering fix
+
+**Slug:** ownership-applier-meshself-ordering-fix
+**Spec:** docs/specs/ownership-applier-meshself-ordering-fix.md
+**Parent principle:** Wiring Integrity — a dependency-injected component must actually run, not be a silently-skipped no-op.
+
+## What changed
+
+A boot-ordering bug in `src/commands/server.ts` meant the transfer-fix §7.2 `OwnershipApplier`
+was never constructed or ticked at runtime (its guard read `_meshSelfId` ~650 lines before
+the boot sequence assigns it, so the guard was always false). Result: a topic transferred
+between machines was recorded on the SOURCE and replicated to the DESTINATION's journal, but
+the destination never materialized ownership → it never knew it owned the session → the seat
+died on arrival. Caught by applying the Live-User-Channel Proof gold standard to a real
+Laptop→Mini transfer.
+
+Fix (order-independent — Structure > Willpower):
+- `src/core/OwnershipApplier.ts` — `selfMachineId` accepts a late-bound getter (label-only;
+  materialization never needs it); resolved per-tick instead of captured stale at construction.
+- `src/core/ownershipApplierWiring.ts` (new) — `wireOwnershipApplier()` factory gates
+  construction on the durable store ALONE (the correct condition), extracted so the invariant
+  is unit-testable (the inline condition was untestable, which is how the bug shipped).
+- `src/commands/server.ts` — calls the factory in place of the inline guard.
+
+## Blast radius
+
+- **Multi-machine destinations (the target):** a transferred seat now materializes durable
+  ownership on the destination and is served there. This was BROKEN before — net improvement.
+- **Single machine:** the durable store may be active but there are no peer placements; the
+  applier ticks and finds nothing — a harmless no-op. No behavior change.
+- **Transfer SOURCE:** unchanged (it writes ownership directly via the tclaim path).
+- **No new route, config flag, state schema, URL, or migration.** Pure internal wiring +
+  one new internal module (no agent-facing surface → no CLAUDE.md template change required).
+- **Backward compatibility:** `OwnershipApplier`'s `selfMachineId` still accepts a plain
+  string; all existing callers/tests are unaffected (7 existing applier tests stay green).
+
+## Reversibility
+
+No flag (it only activates the durable-ownership path that already ships pool-consistent for
+replication-on pools / dark for single-machine). Revertable by reverting the three-file diff;
+no durable state is written that would outlive a revert (ownership records are re-derived from
+the replicated journal on the next tick).
+
+## Risk / monitoring
+
+Low. The applier is off the hot path (boot tick + 15s interval), never throws (degrades to
+"materialized fewer this tick"), and fast-forward-CAS guards against clobbering a fresher
+local decision. Observable via `[ownership-applier] materialized …` / `[OwnershipApplier]
+materialized N/M …` in `logs/server.log` — their appearance is itself the proof the wiring is
+now alive (the bug's signature was their total absence). Release gate: the live two-machine
+re-run (deploy both → transfer → assert destination materializes + a reply serves from the
+destination).


### PR DESCRIPTION
## What this is

The **second, deeper bug** the gold-standard live test caught while proving the multi-machine transfer (the first — dev-gate darkness — shipped in #1190 / v1.3.590). Activation alone was necessary but not sufficient.

**Root cause (a real ship-blocker):** in `src/commands/server.ts` the transfer-fix §7.2 `OwnershipApplier` is guarded by `if (durableOwnershipStore && _meshSelfId)` at ~line 14995, but `_meshSelfId` isn't assigned until ~line 15648 — ~650 lines later in the async boot. So `_meshSelfId` is always `null` at the guard → the applier is **never constructed or ticked, on either machine.** On the transfer SOURCE this is invisible (ownership is written directly via tclaim); on the DESTINATION the applier is the *only* materialization path → a transferred seat replicates to the destination's journal and then dies there, never materialized. This is exactly the failure the operator personally hit: `/pool/transfer` returns `seatMoved:true` while nothing landed on the destination.

**Proven by the live test:** a real Laptop→Mini transfer of a throwaway topic — `seatMoved:true` on the Laptop, the placement replicated to the Mini's `peers/…topic-placement.jsonl`, but **zero** durable ownership on the Mini and **zero** applier log lines. Running the applier by hand against the Mini's deployed journal materialized 11/11 topics perfectly — proving the logic is correct and it's purely never wired in.

## The fix (order-independent — Structure > Willpower)

- `src/core/OwnershipApplier.ts` — `selfMachineId` accepts a **late-bound getter** (it's label-only; materialization never needs it), resolved per-tick instead of captured stale.
- `src/core/ownershipApplierWiring.ts` (new) — `wireOwnershipApplier()` factory gates construction on the **durable store alone** (the correct condition), extracted so the invariant is unit-testable (the inline condition was untestable — how the bug shipped).
- `src/commands/server.ts` — calls the factory in place of the inline guard.

6 new unit/wiring tests + 7 existing applier tests stay green; tsc clean.

## ELI16

The "prove it live" standard caught a real bug in my own multi-machine code: when you move a conversation to another machine, the destination has to *learn* it now owns that conversation. The code that teaches it was never switched on — its on-switch checked a "which machine am I?" value that the startup sequence doesn't fill in until ~650 lines later, so the check always failed silently. A moved conversation said "moved!" then went quiet on the new machine. The fix gates that on-switch on the genuinely relevant thing (is the durable store active?), pulled into a tiny tested function, and makes the machine-id late-bound so reordering the startup can't break it again. The release gate is the real two-machine re-run: deploy both, move a throwaway topic Laptop→Mini, and only call it fixed when the Mini writes the ownership record and a reply genuinely comes back from the Mini.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
