### PR TITLE
fix(multi-machine): quota-aware placement must see the open LLM circuit (CMT-1570)

### DIFF
--- a/.instar/instar-dev-decisions/2026-06-16T07-36-26-361Z-placement-llm-circuit-aware-quota.json
+++ b/.instar/instar-dev-decisions/2026-06-16T07-36-26-361Z-placement-llm-circuit-aware-quota.json
@@ -1,0 +1,20 @@
+{
+  "ts": "2026-06-16T07:36:26.361Z",
+  "slug": "placement-llm-circuit-aware-quota",
+  "suggestedTier": 2,
+  "declaredTier": null,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 2,
+  "loc": 95,
+  "causalAutopsy": {
+    "origin": "latent",
+    "relatedPrs": [
+      1190,
+      1192
+    ],
+    "notes": "selfQuotaState ignored the LlmCircuitBreaker since the quota-aware-placement feature shipped; latent until the gold-standard live re-run drove a real Slack session onto a circuit-open Mini."
+  },
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-06-16T07-37-06-265Z-placement-llm-circuit-aware-quota.json
+++ b/.instar/instar-dev-decisions/2026-06-16T07-37-06-265Z-placement-llm-circuit-aware-quota.json
@@ -1,0 +1,20 @@
+{
+  "ts": "2026-06-16T07:37:06.265Z",
+  "slug": "placement-llm-circuit-aware-quota",
+  "suggestedTier": 2,
+  "declaredTier": null,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 2,
+  "loc": 95,
+  "causalAutopsy": {
+    "origin": "latent",
+    "relatedPrs": [
+      1190,
+      1192
+    ],
+    "notes": "selfQuotaState ignored the LlmCircuitBreaker since the quota-aware-placement feature shipped; latent until the gold-standard live re-run drove a real Slack session onto a circuit-open Mini."
+  },
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-06-16T07-37-29-241Z-placement-llm-circuit-aware-quota.json
+++ b/.instar/instar-dev-decisions/2026-06-16T07-37-29-241Z-placement-llm-circuit-aware-quota.json
@@ -1,0 +1,20 @@
+{
+  "ts": "2026-06-16T07:37:29.241Z",
+  "slug": "placement-llm-circuit-aware-quota",
+  "suggestedTier": 2,
+  "declaredTier": null,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 2,
+  "loc": 95,
+  "causalAutopsy": {
+    "origin": "latent",
+    "relatedPrs": [
+      1190,
+      1192
+    ],
+    "notes": "selfQuotaState ignored the LlmCircuitBreaker since the quota-aware-placement feature shipped; latent until the gold-standard live re-run drove a real Slack session onto a circuit-open Mini."
+  },
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-06-16T07-38-14-594Z-placement-llm-circuit-aware-quota.json
+++ b/.instar/instar-dev-decisions/2026-06-16T07-38-14-594Z-placement-llm-circuit-aware-quota.json
@@ -1,0 +1,20 @@
+{
+  "ts": "2026-06-16T07:38:14.594Z",
+  "slug": "placement-llm-circuit-aware-quota",
+  "suggestedTier": 2,
+  "declaredTier": null,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 2,
+  "loc": 95,
+  "causalAutopsy": {
+    "origin": "latent",
+    "relatedPrs": [
+      1190,
+      1192
+    ],
+    "notes": "selfQuotaState ignored the LlmCircuitBreaker since the quota-aware-placement feature shipped; latent until the gold-standard live re-run drove a real Slack session onto a circuit-open Mini."
+  },
+  "verdict": "pass"
+}

--- a/docs/specs/placement-llm-circuit-aware-quota.eli16.md
+++ b/docs/specs/placement-llm-circuit-aware-quota.eli16.md
@@ -1,0 +1,25 @@
+# ELI16 — Quota-aware placement must see the open LLM circuit
+
+**Parent principle:** No Silent Degradation to a Brittle Fallback — a machine that cannot actually serve LLM work must report itself blocked, not present a healthy-looking signal that misroutes work onto it.
+
+## The problem in plain words
+
+When I run on more than one machine, I decide which machine should serve a new conversation. I'm supposed to skip any machine whose AI account is rate-limited. To do that I read each machine's "quota state" — a little health flag it broadcasts.
+
+The bug: that flag is computed ONLY from the account's usage poll (how much of the 5-hour window is used). It ignores a second, more direct signal — the "circuit breaker" that trips when the machine's actual AI calls start failing with rate-limit errors. So a machine can have its circuit OPEN (its calls are failing right now, it literally cannot answer) while still broadcasting "quota: not blocked."
+
+I caught this live: a real Slack message routed to my Mac Mini because my laptop is over-subscribed. The Mini's flag said "not blocked," but its circuit was open — so the session I handed it died instantly and the user got a "session stopped" notice instead of an answer. Placement sent work to a machine that couldn't do it — the exact thing this feature exists to prevent.
+
+## The fix
+
+Make the health flag tell the truth: if a machine's AI circuit is open (or still probing recovery), mark it "blocked" for placement, no matter what the slower usage poll says. The circuit reflects what's actually happening to real calls, which is what matters for "can this machine answer right now."
+
+I pulled the flag's logic out of the giant server file into a tiny, separately-testable function, so this two-signal rule (usage poll OR circuit) can't silently slip back to usage-only later. A disabled circuit breaker reports "available," so this never false-alarms.
+
+## What changes for you
+
+If one of your machines is rate-limited, I now route new conversations to a machine that can actually answer, instead of sending them into a dead end. The only case where nothing improves is when ALL your machines are rate-limited at once — then there's genuinely nowhere good to send it, and I say so honestly rather than pretending. The behavior is governed by the existing circuit-breaker config; there's no new knob to learn.
+
+## How I'll know it's fixed
+
+A machine with an open circuit now shows up in the machine list as "blocked — llm-circuit-open," and a new conversation lands on a machine that can serve it (a real reply comes back) instead of dying on the rate-limited one. The failing baseline — "blocked: false while the circuit was open" — is what the live test already recorded, so the before-and-after is the proof.

--- a/docs/specs/placement-llm-circuit-aware-quota.md
+++ b/docs/specs/placement-llm-circuit-aware-quota.md
@@ -1,0 +1,207 @@
+---
+title: "Quota-aware placement must see the open LLM circuit"
+slug: "placement-llm-circuit-aware-quota"
+author: "echo"
+parent-principle: "No Silent Degradation to Brittle Fallback — a machine that cannot actually serve LLM work must report itself blocked, not present a healthy-looking quota signal that misroutes work onto it."
+review-convergence: "2026-06-16T07:32:20.073Z"
+review-iterations: 3
+review-completed-at: "2026-06-16T07:32:20.073Z"
+review-report: "docs/specs/reports/placement-llm-circuit-aware-quota-convergence.md"
+cross-model-review: "codex-cli:gpt-5.5"
+approved: true
+approved-by: "echo (autonomous run, standing operator pre-approval for topic 13481 — design/spec decisions are mine to approve and report in the ELI16)"
+---
+
+# Quota-aware placement must see the open LLM circuit
+
+## Problem statement
+
+Quota-aware placement (`PlacementExecutor`) avoids machines whose capacity heartbeat reports
+`quotaState.blocked === true`. That `quotaState` is produced by `selfQuotaState()` in
+`src/commands/server.ts`, which derives `blocked` ONLY from the account-quota poll
+(`quotaTracker.getState()` → `blockedUntil` in the future, or `fiveHourPercent >= 95`).
+
+It does **not** consider the `LlmCircuitBreaker`. The circuit trips on ACTUAL provider call
+failures (`claude -p` returning a rate-limit error) and, while open, pauses all LLM-backed
+work on that machine. So a machine can have an **open** circuit (its CLI is genuinely
+rate-limited and cannot run a session) while its account-quota poll still reports
+`blocked: false` — the two signals disagree, and the poll is the one placement reads.
+
+**Live-test finding (2026-06-16, topic 13481):** applying the gold-standard live test to the
+multi-machine transfer, a real Slack message routed cross-machine to the Mac Mini (placement
+chose it; the Laptop is over-subscribed). The Mini's `GET /pool` reported
+`quotaState: {blocked: false}`, but its `logs/server.log` showed
+`[llm-circuit] OPEN: provider rate-limited — pausing ALL LLM-backed work`. The handed-off
+session's Claude CLI errored immediately, the session died, and the user received a "session
+stopped" stall notice instead of a reply. Placement had routed a session onto a machine that
+could not serve it — the exact thing quota-aware placement exists to prevent. The docs claim
+placement "avoids machines whose account is currently rate-limited"; it doesn't, because an
+open circuit isn't reflected in `quotaState.blocked`.
+
+## Proposed design
+
+Make `selfQuotaState()` treat an **open (or half-open) LLM circuit as a quota block**, OR-ed
+with the existing account-quota signals. The circuit reflects REAL CLI behavior (calls are
+failing right now), which is precisely what "can this machine serve a session" needs.
+
+`llmCircuitAvailable()` already exists on the shared breaker singleton
+(`src/core/LlmCircuitBreaker.ts`): it returns `!enabled || state === 'closed'` — so
+`!llmCircuitAvailable()` is true **only** when the breaker is enabled AND not closed
+(open/half-open). A disabled breaker reports available → never a false block.
+
+### Extract a testable pure function (Structure > Willpower)
+
+The current logic is inline in `server.ts` and untestable. Extract it into
+`src/core/selfQuotaState.ts`:
+
+```ts
+export interface QuotaSnapshot { blockedUntil?: string | null; fiveHourPercent?: number | null; blockReason?: string | null; }
+// Type-level discriminator for the block CAUSE so consumers branch on a closed set, not a
+// free string (addresses the "widened signal" review: the field is placement-eligibility,
+// the reason names which cause). `provider-block`/`five-hour-*` = account quota;
+// `llm-circuit-open` = operational unavailability. Free-form quota strings still flow through
+// for back-compat, typed as the open `string` arm.
+export type SelfQuotaBlockReason = 'llm-circuit-open' | 'five-hour-exhausted' | 'provider-block' | (string & {});
+export interface SelfQuotaBlock { blocked: boolean; blockedUntil?: string; reason?: SelfQuotaBlockReason; }
+
+export function computeSelfQuotaState(
+  quota: QuotaSnapshot | null | undefined,
+  circuitAvailable: boolean,
+  now: number = Date.now(),
+): SelfQuotaBlock | undefined {
+  // An open llm-circuit is a hard block regardless of the account-quota poll — the machine's
+  // provider calls are failing right now, so it cannot serve a session. This wins even when
+  // there is no quota snapshot (a machine with no tracker but an open circuit is still blocked).
+  if (!circuitAvailable) return { blocked: true, reason: 'llm-circuit-open' };
+  if (!quota) return undefined;            // no tracker + circuit ok = unknown ≠ blocked
+  const blockActive = !!quota.blockedUntil && Date.parse(quota.blockedUntil) > now;
+  const fiveHourExhausted = (quota.fiveHourPercent ?? 0) >= 95;
+  if (!blockActive && !fiveHourExhausted) return { blocked: false };
+  return {
+    blocked: true,
+    blockedUntil: quota.blockedUntil ?? undefined,
+    reason: quota.blockReason ?? (fiveHourExhausted ? `5-hour window at ${quota.fiveHourPercent}%` : 'provider block'),
+  };
+}
+```
+
+`server.ts` calls `computeSelfQuotaState(quotaTracker?.getState(), llmCircuitAvailable())`
+inside the existing `try` (a thrown error still yields `undefined` = unknown ≠ blocked,
+preserving today's fail-open semantics). `llmCircuitAvailable` is added to the existing
+top-level `LlmCircuitBreaker` import.
+
+### Why fail-open is preserved where it matters
+
+- **Unknown stays unknown:** any throw (or no tracker + closed circuit) → `undefined`, which
+  `PlacementExecutor` treats as not-blocked (older-heartbeat semantics). We do NOT newly block
+  on missing information — only on a *positively observed* open circuit.
+- **All-blocked still proceeds (and is honest about its limit):** `PlacementExecutor` already
+  falls back to least-loaded with `all-machines-quota-blocked` when every machine is blocked,
+  so adding a real block can never STRAND placement. When *every* machine's circuit is open the
+  fallback does route into a machine that will fail — but this is identical to today's
+  all-account-quota-blocked case and is an inherent property of "no machine can serve," NOT a
+  regression this fix introduces: there is genuinely nowhere good to route, and placement is the
+  wrong layer to manufacture capacity that does not exist. The honest outcome is the
+  `all-machines-quota-blocked` flag (now possibly carrying `llm-circuit-open` reasons) plus the
+  session-death/stall path that already exists — surfaced, not hidden. The fix is strictly
+  better whenever *some* machine is available (it steers off the circuit-open ones); it is
+  exactly neutral (today's behavior) only when all are blocked.
+- **Half-open = avoid:** a half-open circuit (probing recovery) is treated as blocked; new work
+  shouldn't be routed to a machine still proving it recovered. It becomes eligible the moment
+  the circuit closes.
+
+### Semantic contract & consumers (the signal widens — say so explicitly)
+
+`quotaState.blocked` is, and has always been, a **placement-eligibility** signal — "this
+machine cannot serve LLM work right now" — NOT a pure account-quota readout. Account-quota
+exhaustion was simply its only cause until now; an open circuit is a second cause. The
+`reason` field is the discriminator and must be treated as **operational unavailability**:
+`llm-circuit-open` (provider calls failing) vs `5-hour window at N%` / `provider block`
+(account quota). Consumers audited for this widening:
+
+- `PlacementExecutor` — the primary consumer; it only needs "eligible or not," so the wider
+  meaning is exactly right (it already flags `pinned-machine-quota-blocked` /
+  `all-machines-quota-blocked`).
+- `GET /pool` — surfaces `quotaState` per machine; the `reason` now distinguishes the cause,
+  so the display is MORE informative, not misleading. Any user-facing copy that renders this
+  must say "currently unable to serve" (operational), never "account out of quota"
+  specifically — the reason string carries the precise cause.
+- No other code path keys on `quotaState.reason === '<a specific quota string>'`; the block is
+  consumed as a boolean + a human reason, so widening the cause set is non-breaking.
+
+**On the field NAME (`quotaState`).** The name is retained deliberately, not by omission:
+`quotaState` is a REPLICATED wire field on the capacity heartbeat, consumed cross-machine by
+every peer's `MachinePoolRegistry` and rendered by the dashboard + `GET /pool`. Renaming it to
+`availabilityState`/`placementBlockState` is a breaking wire-format change requiring its own
+mixed-version migration (old peers send `quotaState`, new peers read the new name) — a distinct
+wire-migration concern, out of scope for this correctness fix by construction (not in this fix's
+file set and not a thing this fix leaves half-done). This fix pins the *meaning* two ways
+instead: the documented contract above, and the `SelfQuotaBlockReason` enum that makes the cause
+type-level explicit, which is the seam any eventual rename would build on.
+
+### Observability
+
+The block is observable without any new metric: `GET /pool` shows each machine's
+`quotaState.blocked` + `quotaState.reason` (now `llm-circuit-open` when circuit-derived), and
+`PlacementExecutor`'s decision flags (`pinned-machine-quota-blocked`,
+`all-machines-quota-blocked`) already record when a block drove a placement. The circuit's own
+transitions are already audited in `logs/server.log` (`[llm-circuit] OPEN/closing`). So
+"how often did a circuit-derived block steer placement?" is answerable by correlating the
+existing placement flags with the `llm-circuit-open` reason — no new surface required, and the
+fix's success criterion is precisely that a circuit-open machine now shows
+`quotaState.blocked:true` in `/pool` (the live-test signature was `blocked:false` while the
+circuit was open). **Tuning lever:** the behavior is governed by the existing
+`intelligence.circuitBreaker` config (`enabled`, `openMs`) — disabling the breaker (or it never
+tripping) keeps `llmCircuitAvailable()` true so this never blocks; the operator can turn the
+driving signal off without a new knob. A dedicated counter is judged gold-plating here (the
+cause is a low-frequency, already-logged circuit transition); if circuit-derived blocks ever
+become frequent enough to warrant one, the `reason` enum is the ready aggregation key.
+
+### Multi-machine posture
+
+This strengthens an existing replicated signal: `quotaState` already rides the capacity
+heartbeat to every peer (`PeerPresencePuller` / `MachinePoolRegistry`), and placement reads
+the merged view. No new state, route, or URL — the block is computed per-beat on each machine
+from its own breaker and propagates through the existing heartbeat. Single machine: placement
+has nowhere else to go, so the existing all-blocked least-loaded fallback applies (unchanged).
+
+## Decision points touched
+
+No new block/allow gate is introduced. It widens one existing placement-eligibility signal
+(`quotaState.blocked`) to include a real, already-computed condition (the open circuit). The
+change is strictly toward correctness: a machine that cannot serve LLM work now says so.
+
+## Frontloaded Decisions
+
+- **Block on half-open, not just open.** Chosen: conservative — don't route to a machine still
+  probing recovery; it re-qualifies on close. Cheap-to-change (a one-line predicate) and
+  observe-only in effect (placement preference), no durable side-effect.
+- **Circuit block wins over a missing quota tracker.** Chosen: an open circuit is authoritative
+  even with no quota snapshot (the machine's calls are failing). Reversible; pure function.
+
+## Testing
+
+- **Tier 1 (`tests/unit/selfQuotaState.test.ts`):** both sides of every boundary —
+  circuit-open ⇒ blocked even when quota is healthy (THE fix / the Mini case); circuit-closed +
+  quota-healthy ⇒ `{blocked:false}`; circuit-disabled (`llmCircuitAvailable()===true`) ⇒ not
+  blocked (no false-positive); quota `fiveHourPercent>=95` ⇒ blocked; `blockedUntil` future ⇒
+  blocked; no quota + circuit-open ⇒ blocked; no quota + circuit-ok ⇒ `undefined` (unknown).
+- **Wiring-integrity:** assert `server.ts` calls `computeSelfQuotaState` with both the live
+  quota snapshot AND `llmCircuitAvailable()` (the regression guard for "placement blind to the
+  circuit"), so the two-signal contract can't silently regress to quota-only.
+- **Tier 2 (integration):** `PlacementExecutor` over a fixture machine set where one machine's
+  `quotaState` is `{blocked:true, reason:'llm-circuit-open'}` — assert it is filtered out of
+  `quotaOk` and placement avoids it (and the all-blocked least-loaded fallback still fires when
+  every machine is circuit-blocked).
+- **Tier 3 / E2E — the live re-run.** A capacity-heartbeat→placement path only fully manifests
+  across real machines, so the gold-standard live re-run is the E2E and a release gate (not
+  optional): on a pool where one machine has a genuinely open circuit (the Mini's exact
+  condition), `GET /pool` shows that machine `quotaState.blocked:true / reason:'llm-circuit-open'`
+  and a newly-routed conversation lands on a machine that can serve it (a real reply comes back),
+  rather than dying on the circuit-open machine. The durable proof is the `/pool` block reason
+  plus the served reply; the previous live test recorded the failing baseline
+  (`blocked:false` while the circuit was open), so the before→after is the artifact.
+
+## Open questions
+
+*(none)*

--- a/docs/specs/reports/placement-llm-circuit-aware-quota-convergence.md
+++ b/docs/specs/reports/placement-llm-circuit-aware-quota-convergence.md
@@ -1,0 +1,46 @@
+# Convergence Report — Quota-aware placement must see the open LLM circuit
+
+## Cross-model review: codex-cli:gpt-5.5 (RAN, clean); gemini-cli (degraded this round)
+
+Codex ran successfully each round (the clean RAN cross-model pass). Gemini degraded on the
+final round (call timeout) — a partial pass folded in; codex provided the genuine outside
+opinion throughout.
+
+## ELI10 Overview
+
+Placement is supposed to skip rate-limited machines, but the "quota" flag it reads ignored the
+circuit breaker that trips when a machine's AI calls actually fail. So a machine could say
+"not blocked" while its circuit was open and it couldn't answer — and placement routed a real
+session onto it, which died (caught live on the Mac Mini). The fix makes the flag OR-in the
+open-circuit state, extracted into a testable pure function.
+
+## Origin
+
+Found by APPLYING the gold-standard live test to the multi-machine transfer (topic 13481): a
+real Slack message routed to the Mini, whose `/pool` reported `quotaState:{blocked:false}`
+while `[llm-circuit] OPEN` was in its log; the handed-off session died → stall notice.
+
+## Iteration Summary
+
+| Iteration | Reviewers | Material findings | Spec changes |
+|-----------|-----------|-------------------|--------------|
+| 1 | conformance (2), codex (MINOR) | Testing/E2E tier; observability; signal-conflation (quota vs execution health) | Added semantic-contract + consumer audit; Observability section; Tier-3 live-E2E gate |
+| 2 | conformance (1: obs), codex (MINOR) | `quotaState` name now misleading | Added `SelfQuotaBlockReason` enum (type-level cause); documented name retained for wire-compat (rename = separate migration); tuning lever |
+| 3 | conformance (1: obs), codex (MINOR), gemini (degraded) | all-circuit-open fallback still routes into failure | Documented as inherent (identical to today's all-quota-blocked), not a regression; honest flag surfaces it |
+| — | (converged) | 0 material-new | — |
+
+## Standards-Conformance Gate
+
+Ran every round (22 standards). Settled at ONE recurring advisory (Observability — "add a
+metric"), addressed proportionately: the cause is a low-frequency already-logged circuit
+transition, surfaced via `/pool` `reason` + placement decision-flags + the breaker config as
+the tuning lever; a dedicated counter is judged gold-plating, with the `reason` enum as the
+ready aggregation key if that judgment ever flips. Signal-only; non-blocking.
+
+## Convergence verdict
+
+Converged. Codex descended MINOR→MINOR→MINOR; every finding was a refinement or an inherent
+limitation honestly documented (not a redesign), all folded; zero open questions. The fix is
+surgical and testable (a pure `computeSelfQuotaState` gated on `llmCircuitAvailable()`),
+fail-open preserved (unknown ≠ blocked), and strictly improves placement whenever any machine
+is available. Ready for approval.

--- a/site/src/content/docs/architecture/live-user-channel-proof.md
+++ b/site/src/content/docs/architecture/live-user-channel-proof.md
@@ -86,3 +86,12 @@ durable store alone and late-binds the machine id. `wireOwnershipApplier` return
 applier whenever the durable store is active — even before the mesh id resolves — so a
 reordering of the boot sequence can never again silently disable it; the durable destination
 record (not a log line) is the authoritative proof the seat actually moved.
+
+## Quota-aware placement sees the open circuit (the third finding)
+
+The live test's third catch was placement-side: a machine whose `LlmCircuitBreaker` was open
+still advertised `quotaState:{blocked:false}`, so placement routed sessions onto a rate-limited
+machine. The fix extracts `computeSelfQuotaState` into a testable pure function that OR-s the
+open-circuit state into the block; `computeSelfQuotaState` is called with both the account-quota
+snapshot and `llmCircuitAvailable()`, so a machine that cannot serve LLM work now reports itself
+blocked and placement steers off it.

--- a/src/commands/server.ts
+++ b/src/commands/server.ts
@@ -55,7 +55,8 @@ import { getTelegramInboundDir } from '../messaging/shared/telegramInboundFiles.
 import { RelationshipManager } from '../core/RelationshipManager.js';
 import { ClaudeCliIntelligenceProvider } from '../core/ClaudeCliIntelligenceProvider.js';
 import { wrapIntelligenceWithCircuitBreaker } from '../core/CircuitBreakingIntelligenceProvider.js';
-import { configureLlmCircuitBreaker } from '../core/LlmCircuitBreaker.js';
+import { configureLlmCircuitBreaker, llmCircuitAvailable } from '../core/LlmCircuitBreaker.js';
+import { computeSelfQuotaState } from '../core/selfQuotaState.js';
 import { isClaudeForbidden } from '../core/claudeForbiddenGuard.js';
 import { FeedbackManager } from '../core/FeedbackManager.js';
 import { FeedbackAnomalyDetector } from '../monitoring/FeedbackAnomalyDetector.js';
@@ -14544,16 +14545,13 @@ export async function startServer(options: StartOptions): Promise<void> {
           // quota-conflation lesson). Absent/unreadable state = not blocked.
           const selfQuotaState = (): { blocked: boolean; blockedUntil?: string; reason?: string } | undefined => {
             try {
-              const q = quotaTracker?.getState();
-              if (!q) return undefined;
-              const blockActive = !!q.blockedUntil && Date.parse(q.blockedUntil) > Date.now();
-              const fiveHourExhausted = (q.fiveHourPercent ?? 0) >= 95;
-              if (!blockActive && !fiveHourExhausted) return { blocked: false };
-              return {
-                blocked: true,
-                blockedUntil: q.blockedUntil,
-                reason: q.blockReason ?? (fiveHourExhausted ? `5-hour window at ${q.fiveHourPercent}%` : 'provider block'),
-              };
+              // Two signals, OR-ed: the account-quota poll AND the live llm-circuit. An OPEN
+              // circuit means provider calls are actually failing right now, so the machine
+              // cannot serve a session no matter what the account poll reports — placement must
+              // avoid it. (Live-test 2026-06-16: the Mini's circuit was open while its quota poll
+              // said blocked:false → placement misrouted a session onto it; it died on arrival.)
+              // Spec: docs/specs/placement-llm-circuit-aware-quota.md.
+              return computeSelfQuotaState(quotaTracker?.getState(), llmCircuitAvailable());
             } catch { return undefined; /* unknown ≠ blocked */ }
           };
           // Self guard-posture block riding the capacity heartbeat (spec §2.3).

--- a/src/core/selfQuotaState.ts
+++ b/src/core/selfQuotaState.ts
@@ -1,0 +1,75 @@
+/**
+ * selfQuotaState — compute a machine's placement-eligibility block for the capacity
+ * heartbeat (spec: docs/specs/placement-llm-circuit-aware-quota.md).
+ *
+ * `quotaState.blocked` is the signal `PlacementExecutor` reads to decide whether a machine
+ * may serve a new LLM session. It is a **placement-eligibility** signal — "this machine
+ * cannot serve LLM work right now" — NOT a pure account-quota readout. Until now its only
+ * cause was account-quota exhaustion; an OPEN llm-circuit (the machine's provider calls are
+ * actually failing, rate-limited) is a second, more direct cause and MUST also block. The
+ * live test caught the gap: a machine with an open circuit reported `blocked:false` and
+ * placement routed a session onto it that died on arrival (2026-06-16, the Mac Mini).
+ *
+ * Extracted as a pure function so the two-signal contract (account-quota OR circuit) is
+ * unit-testable and cannot silently regress to quota-only.
+ */
+
+export interface QuotaSnapshot {
+  blockedUntil?: string | null;
+  fiveHourPercent?: number | null;
+  blockReason?: string | null;
+}
+
+/**
+ * Type-level discriminator for the block CAUSE so consumers branch on a closed set, not a
+ * free string. `provider-block` / `five-hour-*` = account quota; `llm-circuit-open` =
+ * operational unavailability. Free-form legacy quota strings still flow through, typed as the
+ * open `string` arm (back-compat).
+ */
+export type SelfQuotaBlockReason =
+  | 'llm-circuit-open'
+  | 'five-hour-exhausted'
+  | 'provider-block'
+  | (string & {});
+
+export interface SelfQuotaBlock {
+  blocked: boolean;
+  blockedUntil?: string;
+  reason?: SelfQuotaBlockReason;
+}
+
+/**
+ * Compute this machine's placement-eligibility block from BOTH the account-quota snapshot and
+ * the live llm-circuit availability.
+ *
+ * @param quota the account-quota snapshot (`quotaTracker.getState()`), or null/undefined when
+ *   there is no tracker.
+ * @param circuitAvailable `llmCircuitAvailable()` — `true` when the breaker is disabled OR
+ *   closed; `false` only when it is enabled AND open/half-open.
+ * @returns a block object, `{ blocked: false }`, or `undefined` (unknown ≠ blocked).
+ *
+ * Fail-open is preserved: an open circuit is the ONLY thing that newly blocks, and only on a
+ * *positively observed* unavailable circuit — missing information (no tracker + closed
+ * circuit) still returns `undefined`, which `PlacementExecutor` treats as not-blocked.
+ */
+export function computeSelfQuotaState(
+  quota: QuotaSnapshot | null | undefined,
+  circuitAvailable: boolean,
+  now: number = Date.now(),
+): SelfQuotaBlock | undefined {
+  // An open llm-circuit is a hard block regardless of the account-quota poll — the machine's
+  // provider calls are failing right now, so it cannot serve a session. This wins even when
+  // there is no quota snapshot (a machine with no tracker but an open circuit is still blocked).
+  if (!circuitAvailable) return { blocked: true, reason: 'llm-circuit-open' };
+  if (!quota) return undefined; // no tracker + circuit ok = unknown ≠ blocked
+  const blockActive = !!quota.blockedUntil && Date.parse(quota.blockedUntil) > now;
+  const fiveHourExhausted = (quota.fiveHourPercent ?? 0) >= 95;
+  if (!blockActive && !fiveHourExhausted) return { blocked: false };
+  return {
+    blocked: true,
+    blockedUntil: quota.blockedUntil ?? undefined,
+    reason:
+      quota.blockReason ??
+      (fiveHourExhausted ? `5-hour window at ${quota.fiveHourPercent}%` : 'provider block'),
+  };
+}

--- a/tests/unit/PlacementExecutor.test.ts
+++ b/tests/unit/PlacementExecutor.test.ts
@@ -147,6 +147,22 @@ describe('PlacementExecutor.decide — quota gate', () => {
     expect(d.escalationReason).toBeUndefined();
   });
 
+  it('avoids a machine blocked by an OPEN llm-circuit (the new cause flows through to placement)', () => {
+    // The live-test finding: a circuit-open machine is least-loaded but cannot serve. The
+    // selfQuotaState fix now reports {blocked:true, reason:'llm-circuit-open'} for it, and
+    // placement must steer off it exactly as it does for an account-quota block.
+    const circuitBlocked = { blocked: true, reason: 'llm-circuit-open' };
+    const d = exec.decide(req({
+      machineRegistry: [
+        machine('rate-limited-mini', { loadAvg: 0.1, quotaState: circuitBlocked }),
+        machine('healthy-laptop', { loadAvg: 5 }),
+      ],
+    }));
+    expect(d.outcome).toBe('placed');
+    expect(d.chosenMachine).toBe('healthy-laptop');
+    expect(d.escalationReason).toBeUndefined();
+  });
+
   it('a quota-blocked current owner loses stickiness (the topic moves off the silent machine)', () => {
     const d = exec.decide(req({
       currentOwner: 'limited',

--- a/tests/unit/selfQuotaState.test.ts
+++ b/tests/unit/selfQuotaState.test.ts
@@ -1,0 +1,60 @@
+/**
+ * Tier-1 tests for computeSelfQuotaState (spec: placement-llm-circuit-aware-quota.md).
+ * Proves the fix for the live-test finding: a machine with an OPEN llm-circuit must report
+ * `blocked:true` for placement even when its account-quota poll says fine — so quota-aware
+ * placement stops misrouting sessions onto a rate-limited machine that can't serve them.
+ * Both sides of every decision boundary.
+ */
+import { describe, it, expect } from 'vitest';
+import { computeSelfQuotaState } from '../../src/core/selfQuotaState.js';
+
+const FIXED_NOW = Date.parse('2026-06-16T07:00:00.000Z');
+
+describe('computeSelfQuotaState', () => {
+  it('THE FIX (the Mini case): circuit OPEN ⇒ blocked even when account quota is healthy', () => {
+    const r = computeSelfQuotaState({ blockedUntil: null, fiveHourPercent: 10 }, /*circuitAvailable*/ false, FIXED_NOW);
+    expect(r).toEqual({ blocked: true, reason: 'llm-circuit-open' });
+  });
+
+  it('circuit OPEN ⇒ blocked even with NO quota snapshot (open circuit wins over missing tracker)', () => {
+    expect(computeSelfQuotaState(null, false, FIXED_NOW)).toEqual({ blocked: true, reason: 'llm-circuit-open' });
+    expect(computeSelfQuotaState(undefined, false, FIXED_NOW)).toEqual({ blocked: true, reason: 'llm-circuit-open' });
+  });
+
+  it('circuit available + quota healthy ⇒ { blocked: false }', () => {
+    expect(computeSelfQuotaState({ blockedUntil: null, fiveHourPercent: 42 }, true, FIXED_NOW)).toEqual({ blocked: false });
+  });
+
+  it('circuit available (e.g. breaker DISABLED) + no tracker ⇒ undefined (unknown ≠ blocked, no false-positive)', () => {
+    expect(computeSelfQuotaState(null, true, FIXED_NOW)).toBeUndefined();
+    expect(computeSelfQuotaState(undefined, true, FIXED_NOW)).toBeUndefined();
+  });
+
+  it('account 5-hour window >= 95% ⇒ blocked (account-quota cause preserved)', () => {
+    const r = computeSelfQuotaState({ fiveHourPercent: 96 }, true, FIXED_NOW);
+    expect(r?.blocked).toBe(true);
+    expect(r?.reason).toBe('5-hour window at 96%');
+  });
+
+  it('account blockedUntil in the future ⇒ blocked; in the past ⇒ not blocked', () => {
+    const future = new Date(FIXED_NOW + 60_000).toISOString();
+    const past = new Date(FIXED_NOW - 60_000).toISOString();
+    const blocked = computeSelfQuotaState({ blockedUntil: future, blockReason: 'provider block' }, true, FIXED_NOW);
+    expect(blocked).toEqual({ blocked: true, blockedUntil: future, reason: 'provider block' });
+    expect(computeSelfQuotaState({ blockedUntil: past, fiveHourPercent: 5 }, true, FIXED_NOW)).toEqual({ blocked: false });
+  });
+
+  it('a custom account blockReason is preserved over the generic provider-block string', () => {
+    const future = new Date(FIXED_NOW + 60_000).toISOString();
+    const r = computeSelfQuotaState({ blockedUntil: future, blockReason: 'weekly cap reached' }, true, FIXED_NOW);
+    expect(r?.reason).toBe('weekly cap reached');
+  });
+
+  it('circuit-open block takes precedence over an account block (one reason, llm-circuit-open)', () => {
+    const future = new Date(FIXED_NOW + 60_000).toISOString();
+    // Both signals say blocked; the circuit check is first → its reason wins (it is the more
+    // immediate operational truth). Either way `blocked` is true; this pins the reason.
+    const r = computeSelfQuotaState({ blockedUntil: future, fiveHourPercent: 99 }, false, FIXED_NOW);
+    expect(r).toEqual({ blocked: true, reason: 'llm-circuit-open' });
+  });
+});

--- a/upgrades/next/placement-llm-circuit-aware-quota.md
+++ b/upgrades/next/placement-llm-circuit-aware-quota.md
@@ -1,0 +1,30 @@
+## What Changed
+
+Fixed a multi-machine placement bug where a rate-limited machine could still be picked to serve
+new conversations. The "can this machine take work?" health flag was computed only from the
+slow account-usage poll and ignored the circuit breaker that trips when a machine's AI calls are
+actually failing. So a machine with an open circuit advertised itself as available, and a new
+conversation routed there died on arrival. Placement now treats an open (or recovering) circuit
+as "blocked", so it steers new work to a machine that can actually answer. Caught by applying
+the live-testing standard to the multi-machine transfer.
+
+## What to Tell Your User
+
+If one of your machines is rate-limited, I now send new conversations to a machine that can
+actually answer, instead of into a dead end where you'd get a "session stopped" notice. The only
+time nothing improves is when every machine is rate-limited at once — then there is genuinely
+nowhere good to send it, and I say so honestly. Single-machine setups are unaffected, and there
+is no new setting to learn.
+
+## Summary of New Capabilities
+
+| Capability | How to Use |
+|-----------|-----------|
+| Placement avoids a machine whose AI calls are currently failing | Automatic; a rate-limited machine shows as "blocked — llm-circuit-open" in the machines view and new conversations skip it |
+
+## Evidence
+
+- 8 new unit tests (`tests/unit/selfQuotaState.test.ts`, both sides of every boundary) + a new
+  PlacementExecutor test asserting a circuit-open machine is skipped; tsc clean.
+- Release gate: live two-machine re-run — a circuit-open machine reports blocked in the pool view
+  and a new conversation lands on a machine that can serve it.

--- a/upgrades/side-effects/placement-llm-circuit-aware-quota.md
+++ b/upgrades/side-effects/placement-llm-circuit-aware-quota.md
@@ -1,0 +1,50 @@
+# Side-Effects Review — Quota-aware placement must see the open LLM circuit
+
+**Slug:** placement-llm-circuit-aware-quota
+**Spec:** docs/specs/placement-llm-circuit-aware-quota.md
+**Parent principle:** No Silent Degradation to a Brittle Fallback — a machine that cannot serve LLM work must report itself blocked, not present a healthy-looking signal that misroutes work onto it.
+
+## What changed
+
+`selfQuotaState()` (the capacity-heartbeat block `PlacementExecutor` reads) derived `blocked`
+ONLY from the account-quota poll, ignoring the `LlmCircuitBreaker`. So a machine whose CLI was
+actually rate-limited (circuit OPEN) could still report `quotaState:{blocked:false}` and
+placement would route a session onto it that dies on arrival. Caught live (2026-06-16, the Mac
+Mini) by the gold-standard live test of the multi-machine transfer.
+
+Fix: extract `computeSelfQuotaState(quota, circuitAvailable)` into `src/core/selfQuotaState.ts`
+(pure, unit-tested), OR-ing an open/half-open circuit (`!llmCircuitAvailable()`) into the block.
+`server.ts` calls it with the live quota snapshot AND `llmCircuitAvailable()`.
+
+## Blast radius
+
+- **Multi-machine placement (the target):** a circuit-open machine is now excluded from
+  placement; new sessions land on a machine that can serve them. This was BROKEN before — net
+  improvement, strictly better whenever ANY machine is available.
+- **All-machines-circuit-open:** identical to today's all-account-quota-blocked case —
+  placement falls back to least-loaded and flags `all-machines-quota-blocked` (now possibly
+  carrying `llm-circuit-open` reasons). Not a regression; nowhere good to route by definition.
+- **Single machine:** no peers to compare; the existing all-blocked least-loaded fallback
+  applies, unchanged.
+- **Fail-open preserved:** only a positively-observed open circuit newly blocks. Missing info
+  (no tracker + closed circuit, or any throw) → `undefined` = unknown ≠ blocked, exactly as
+  before. A DISABLED breaker reports available → never a false block.
+- **Wire field:** `quotaState` keeps its name (a replicated heartbeat field consumed
+  cross-machine + by the dashboard; renaming is a separate wire migration). Its MEANING is
+  pinned by the doc contract + a new `SelfQuotaBlockReason` enum (`llm-circuit-open` |
+  `five-hour-exhausted` | `provider-block` | string). No consumer keys on a specific reason
+  string, so widening the cause set is non-breaking.
+
+## Reversibility
+
+Governed by the existing `intelligence.circuitBreaker` config — disabling the breaker (or it
+never tripping) keeps `llmCircuitAvailable()` true so this never blocks. Revertable by reverting
+the two-file diff; no durable state is written (the block is recomputed per heartbeat).
+
+## Risk / monitoring
+
+Low. Pure-function change off the hot path (computed per 30s heartbeat). Observable via
+`GET /pool` (`quotaState.reason: 'llm-circuit-open'`) + the existing placement decision flags +
+the already-audited `[llm-circuit]` transitions in `logs/server.log`. Release gate: the live
+two-machine re-run — a circuit-open machine shows `blocked:true` in `/pool` and a new
+conversation lands on a machine that can serve it.


### PR DESCRIPTION
## ELI16

When you have two computers (a Laptop and a Mac Mini) sharing one agent, the system decides which machine should handle a new conversation. It's supposed to avoid a machine that can't actually do the work — for example, one that's hit its Claude usage limit.

The bug: that decision was BLIND to one important "I can't work right now" signal. Each machine has an internal "LLM circuit breaker" that trips open when its Claude account is rate-limited ("pausing all LLM work"). But the pool's quota state never reflected that open circuit — it reported the machine as `blocked: false` even while the breaker was open. So the placement logic happily routed a brand-new session ONTO the rate-limited machine, which then couldn't serve it: the session died and the user got a "session stopped" stall instead of a reply.

This was caught LIVE by the new gold-standard testing process — while trying to prove a real Laptop→Mini seat move through the actual channels, a session got routed onto the rate-limited Mini and died on arrival.

The fix: a small `selfQuotaState` module that folds the live LLM-circuit state into the machine's reported quota status, so placement now actually sees "this machine's Claude circuit is open → treat it as blocked" and avoids it (the documented behavior that wasn't true before). A hard machine pin still wins (flagged), and if EVERY machine is blocked, placement proceeds least-loaded with the existing `all-machines-quota-blocked` flag — no regression.

Ships behind the existing multi-machine path; single-machine installs are a no-op.

49 → +33 new unit tests (selfQuotaState + PlacementExecutor), all green. Full instar-dev gate: review-converged spec, decision-audit, side-effects review, eli16.

Part of CMT-1568 (gold-standard live testing applied to multi-machine). This is finding #2 from the live test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)