### PR TITLE
feat(live-test): real-channel driver core — DemoChannelRegistry + RealChannelDriver (CMT-1568)

### DIFF
--- a/.instar/instar-dev-decisions/2026-06-16T09-48-04-578Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-06-16T09-48-04-578Z-unknown.json
@@ -1,0 +1,15 @@
+{
+  "ts": "2026-06-16T09:48:04.578Z",
+  "slug": "unknown",
+  "suggestedTier": 2,
+  "declaredTier": 2,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "new capability: new exported class / subsystem added"
+  ],
+  "belowFloor": false,
+  "files": 2,
+  "loc": 224,
+  "causalAutopsy": null,
+  "verdict": "pass"
+}

--- a/src/core/DemoChannelRegistry.ts
+++ b/src/core/DemoChannelRegistry.ts
@@ -1,0 +1,135 @@
+/**
+ * DemoChannelRegistry — the §5.3 isolation backbone of the live-user-channel-proof
+ * standard (docs/specs/live-user-channel-proof-standard.md §5.3 "Demo Channel
+ * Isolation").
+ *
+ * A volatile / permission / dangerous live-test scenario must NEVER touch the live
+ * operator channel — it runs only on a registered DEMO channel (a throwaway Slack
+ * workspace, a demo Telegram group). The LiveTestHarness enforces this structurally
+ * by calling `isDemoChannel(surface, channelId)` and refusing the whole run (a throw,
+ * not a convention) if a non-safe scenario points at a channel this registry does not
+ * vouch for.
+ *
+ * The bindings are SIGNED and read once. A binding set that fails signature
+ * verification (tampered, unsigned, wrong signer) is FAIL-CLOSED: every channel
+ * resolves to NOT-a-demo-channel, so the harness's §5.3 guard refuses every volatile
+ * scenario rather than trusting an unverified "this is a safe demo channel" claim.
+ * Fail-closed is the safe direction here — the cost of a false "not demo" is a refused
+ * test; the cost of a false "is demo" is a destructive scenario on the live channel.
+ *
+ * This module is pure/injectable: it takes the raw bindings document + a `verify`
+ * function (Ed25519, same signer surface the LiveTestArtifactStore uses) so it is
+ * unit-testable with no filesystem or crypto host.
+ */
+
+import type { Surface } from './LiveTestArtifactStore.js';
+
+/** One registered demo channel. `workspaceId` is Slack-only (the demo workspace). */
+export interface DemoChannelBinding {
+  surface: Surface;
+  /** Slack channel id, Telegram chat/topic id (as a string), or dashboard id. */
+  channelId: string;
+  /** Slack workspace / team id — REQUIRED for slack, ignored otherwise. */
+  workspaceId?: string;
+  /** Human label for audit (e.g. "SageMind Live Test"). */
+  label?: string;
+}
+
+/** The on-disk, signed bindings document. */
+export interface DemoChannelBindingsDoc {
+  version: 1;
+  /** The machine that authored these bindings (audit only). */
+  machineId: string;
+  bindings: DemoChannelBinding[];
+  signedAt: string;
+  /** Ed25519 signature over the canonical payload (see canonicalBindingsPayload). */
+  signature: string;
+}
+
+export interface DemoChannelRegistryDeps {
+  /** The raw bindings document (e.g. parsed from state/demo-channel-bindings.json), or null when none exist. */
+  doc: DemoChannelBindingsDoc | null;
+  /** Verify a signature over a canonical payload string. Returns true iff valid. */
+  verify: (payload: string, signature: string) => boolean;
+  logger?: (m: string) => void;
+}
+
+/**
+ * The exact bytes the signature covers. Stable, order-independent across the binding
+ * LIST (sorted) so a re-serialization can't change the signed payload, but the
+ * signature is otherwise over the full meaningful content (version + machineId +
+ * signedAt + every binding field). Any field change invalidates the signature.
+ */
+export function canonicalBindingsPayload(doc: Omit<DemoChannelBindingsDoc, 'signature'>): string {
+  // Each binding is encoded as an ORDERED JSON tuple, NOT a delimiter-free
+  // concatenation. A concatenation like `${surface}${channelId}${workspaceId}` is
+  // ambiguous at field boundaries ({channelId:'C1',workspaceId:'W2'} vs
+  // {channelId:'C1W2'} would serialize identically and share one signature — a
+  // real bypass that promotes an unvouched channelId to a demo channel). A JSON
+  // tuple makes every field boundary explicit and distinguishes an absent field
+  // (null) from a present empty string (''), so one signature covers exactly one
+  // binding set.
+  const norm = (b: DemoChannelBinding) =>
+    JSON.stringify([b.surface, b.channelId, b.workspaceId ?? null, b.label ?? null]);
+  const lines = [...doc.bindings].map(norm).sort();
+  return [
+    `v=${doc.version}`,
+    `machine=${doc.machineId}`,
+    `signedAt=${doc.signedAt}`,
+    ...lines.map((l) => `b=${l}`),
+  ].join('\n');
+}
+
+export class DemoChannelRegistry {
+  private readonly verified: boolean;
+  private readonly set: Set<string>;
+  private readonly d: DemoChannelRegistryDeps;
+
+  constructor(deps: DemoChannelRegistryDeps) {
+    this.d = deps;
+    const { doc } = deps;
+    if (!doc) {
+      // No bindings at all is a legitimate state (safe-only test runs). It is NOT an
+      // error — it simply means there are zero demo channels, so isDemoChannel is
+      // always false and only safe scenarios can run.
+      this.verified = false;
+      this.set = new Set();
+      return;
+    }
+    const { signature, ...unsigned } = doc;
+    let ok = false;
+    try {
+      ok = this.d.verify(canonicalBindingsPayload(unsigned), signature);
+    } catch (err) {
+      this.log(`verify threw (treating as unverified): ${err instanceof Error ? err.message : String(err)}`);
+      ok = false;
+    }
+    this.verified = ok;
+    if (!ok) {
+      // Fail-closed: a present-but-unverifiable bindings doc grants ZERO demo channels.
+      this.log(`bindings present but signature INVALID — fail-closed (0 demo channels; volatile scenarios will be refused)`);
+      this.set = new Set();
+      return;
+    }
+    this.set = new Set(doc.bindings.map((b) => this.key(b.surface, b.channelId)));
+  }
+
+  private key(surface: Surface, channelId: string): string {
+    // Unambiguous (JSON tuple) for the same reason canonicalBindingsPayload uses one —
+    // so a lookup key can never alias across the surface/channelId boundary. (Safe
+    // today since surface is a closed enum, but encoded explicitly for defense-in-depth.)
+    return JSON.stringify([surface, channelId]);
+  }
+  private log(m: string): void { this.d.logger?.(`[demo-channel-registry] ${m}`); }
+
+  /** True iff (surface, channelId) is a verified, registered demo channel. */
+  isDemoChannel(surface: Surface, channelId: string): boolean {
+    return this.set.has(this.key(surface, channelId));
+  }
+
+  /** Whether a present bindings doc verified (false when none exist OR signature failed). */
+  get isVerified(): boolean { return this.verified; }
+
+  /** Count of registered demo channels (0 when unverified/absent). */
+  get size(): number { return this.set.size; }
+}

--- a/src/core/RealChannelDriver.ts
+++ b/src/core/RealChannelDriver.ts
@@ -1,0 +1,89 @@
+/**
+ * RealChannelDriver — the production `ChannelDriver` for the LiveTestHarness
+ * (docs/specs/live-user-channel-proof-standard.md §5.4 "Platform-Sanctioned
+ * Automation"). It drives a feature end-to-end through the REAL user surfaces by
+ * composing one `SurfaceSender` per surface (Telegram, Slack, dashboard) plus:
+ *
+ *   - a DemoChannelRegistry → `isDemoChannel` (§5.3 isolation), and
+ *   - a `resolveResponderMachine` reader → the `responderMachineId` stamped on every
+ *     reply, which is the DETERMINISTIC cross-machine proof the harness asserts on
+ *     (e.g. "after the transfer, the reply was served FROM the Mini").
+ *
+ * The driver itself is pure transport composition: it knows nothing about HTTP,
+ * Telegram, or Slack — each surface sender + the placement reader are injected, so
+ * this module is fully unit-testable with fakes. The real senders (a demo-bot/user
+ * Telegram sender, a Slack user-token sender) and the real placement reader (a
+ * GET /pool/placement call) are wired at construction in server.ts.
+ *
+ * Safety: a surface with no registered sender is a hard error on use (never a silent
+ * skip that would fabricate a "no reply" FAIL), and `responderMachineId` resolution
+ * failures degrade to `undefined` (the harness then simply can't assert on responder)
+ * rather than throwing the whole scenario — the SEND/REPLY evidence is still recorded.
+ */
+
+import type { ChannelDriver, SendResult, ReplyResult } from './LiveTestHarness.js';
+import type { Surface } from './LiveTestArtifactStore.js';
+import type { DemoChannelRegistry } from './DemoChannelRegistry.js';
+
+/** One real surface transport. `channelId` is the surface-native id (topic id, Slack channel). */
+export interface SurfaceSender {
+  /** Send a USER-role message on the real surface. */
+  send(channelId: string, text: string): Promise<SendResult>;
+  /** Await the agent's reply after `afterMessageId` (null on timeout). No responder id — the driver stamps that. */
+  awaitReply(channelId: string, opts: { timeoutMs: number; afterMessageId?: string }): Promise<Omit<ReplyResult, 'responderMachineId'> | null>;
+}
+
+export interface RealChannelDriverDeps {
+  /** Per-surface real senders. A surface absent here throws if a scenario targets it. */
+  senders: Partial<Record<Surface, SurfaceSender>>;
+  /** §5.3 demo-channel isolation. */
+  demoRegistry: Pick<DemoChannelRegistry, 'isDemoChannel'>;
+  /**
+   * Resolve WHICH machine served (owns) the given channel at reply time — the
+   * cross-machine proof. Returns the machine id (or nickname-resolvable id), or null
+   * if it can't be determined. MUST NOT throw on a transient read error (return null).
+   */
+  resolveResponderMachine: (surface: Surface, channelId: string) => Promise<string | null>;
+  logger?: (m: string) => void;
+}
+
+export class RealChannelDriver implements ChannelDriver {
+  private readonly d: RealChannelDriverDeps;
+  constructor(deps: RealChannelDriverDeps) { this.d = deps; }
+
+  private log(m: string): void { this.d.logger?.(`[real-channel-driver] ${m}`); }
+
+  private senderFor(surface: Surface): SurfaceSender {
+    const s = this.d.senders[surface];
+    if (!s) {
+      // A missing sender is a CONFIGURATION error, surfaced loudly — never a silent
+      // skip that the harness would misread as a clean "no reply" FAIL.
+      throw new Error(`no real sender configured for surface "${surface}" — cannot drive it`);
+    }
+    return s;
+  }
+
+  isDemoChannel(surface: Surface, channelId: string): boolean {
+    return this.d.demoRegistry.isDemoChannel(surface, channelId);
+  }
+
+  async send(surface: Surface, channelId: string, text: string): Promise<SendResult> {
+    return this.senderFor(surface).send(channelId, text);
+  }
+
+  async awaitReply(surface: Surface, channelId: string, opts: { timeoutMs: number; afterMessageId?: string }): Promise<ReplyResult | null> {
+    const reply = await this.senderFor(surface).awaitReply(channelId, opts);
+    if (!reply) return null;
+    let responderMachineId: string | undefined;
+    try {
+      responderMachineId = (await this.d.resolveResponderMachine(surface, channelId)) ?? undefined;
+    } catch (err) {
+      // Degrade, never throw: we still have a real reply; we just can't attribute the
+      // responder machine this round. The harness records the reply evidence and
+      // (only) any responder-machine assertion can't be satisfied.
+      this.log(`responder-machine resolve failed for ${surface}:${channelId} (recording reply without it): ${err instanceof Error ? err.message : String(err)}`);
+      responderMachineId = undefined;
+    }
+    return { ...reply, responderMachineId };
+  }
+}

--- a/tests/unit/DemoChannelRegistry.test.ts
+++ b/tests/unit/DemoChannelRegistry.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect } from 'vitest';
+import {
+  DemoChannelRegistry,
+  canonicalBindingsPayload,
+  type DemoChannelBindingsDoc,
+} from '../../src/core/DemoChannelRegistry.js';
+
+// A trivial deterministic "signature" = the payload itself; verify checks equality.
+// This exercises the verification PATH (right payload → valid; any mutation → invalid)
+// without needing a real crypto host.
+const sign = (payload: string): string => `sig:${payload}`;
+const verify = (payload: string, signature: string): boolean => signature === `sig:${payload}`;
+
+function signedDoc(bindings: DemoChannelBindingsDoc['bindings']): DemoChannelBindingsDoc {
+  const unsigned = { version: 1 as const, machineId: 'laptop', bindings, signedAt: '2026-06-16T00:00:00Z' };
+  return { ...unsigned, signature: sign(canonicalBindingsPayload(unsigned)) };
+}
+
+describe('DemoChannelRegistry', () => {
+  it('absent bindings → zero demo channels, unverified, not an error', () => {
+    const r = new DemoChannelRegistry({ doc: null, verify });
+    expect(r.isVerified).toBe(false);
+    expect(r.size).toBe(0);
+    expect(r.isDemoChannel('slack', 'C123')).toBe(false);
+    expect(r.isDemoChannel('telegram', '999')).toBe(false);
+  });
+
+  it('valid signed bindings → registered channels resolve true, others false', () => {
+    const doc = signedDoc([
+      { surface: 'slack', channelId: 'C123', workspaceId: 'W1', label: 'SageMind Live Test' },
+      { surface: 'telegram', channelId: '555', label: 'demo group' },
+    ]);
+    const r = new DemoChannelRegistry({ doc, verify });
+    expect(r.isVerified).toBe(true);
+    expect(r.size).toBe(2);
+    expect(r.isDemoChannel('slack', 'C123')).toBe(true);
+    expect(r.isDemoChannel('telegram', '555')).toBe(true);
+    // not registered
+    expect(r.isDemoChannel('slack', 'C999')).toBe(false);
+    // surface must match — same id on a different surface is NOT a demo channel
+    expect(r.isDemoChannel('telegram', 'C123')).toBe(false);
+  });
+
+  it('FAIL-CLOSED: a tampered binding (added channel) invalidates the signature → 0 demo channels', () => {
+    const doc = signedDoc([{ surface: 'slack', channelId: 'C123' }]);
+    // Attacker appends a live operator channel after signing.
+    doc.bindings.push({ surface: 'slack', channelId: 'C-OPERATOR-LIVE' });
+    const r = new DemoChannelRegistry({ doc, verify });
+    expect(r.isVerified).toBe(false);
+    expect(r.size).toBe(0);
+    // The smuggled channel does NOT become a demo channel.
+    expect(r.isDemoChannel('slack', 'C-OPERATOR-LIVE')).toBe(false);
+    // Neither does the originally-signed one — fail-closed grants nothing.
+    expect(r.isDemoChannel('slack', 'C123')).toBe(false);
+  });
+
+  it('FAIL-CLOSED: a forged/empty signature grants nothing', () => {
+    const doc = signedDoc([{ surface: 'slack', channelId: 'C123' }]);
+    doc.signature = 'sig:not-the-real-payload';
+    const r = new DemoChannelRegistry({ doc, verify });
+    expect(r.isVerified).toBe(false);
+    expect(r.isDemoChannel('slack', 'C123')).toBe(false);
+  });
+
+  it('FAIL-CLOSED: a verify() that throws is treated as unverified, never as valid', () => {
+    const doc = signedDoc([{ surface: 'slack', channelId: 'C123' }]);
+    const throwingVerify = () => { throw new Error('crypto host down'); };
+    const r = new DemoChannelRegistry({ doc, verify: throwingVerify });
+    expect(r.isVerified).toBe(false);
+    expect(r.isDemoChannel('slack', 'C123')).toBe(false);
+  });
+
+  it('canonical payload is order-independent across the binding list (re-sort cannot change the signed bytes)', () => {
+    const a = canonicalBindingsPayload({
+      version: 1, machineId: 'm', signedAt: 't',
+      bindings: [{ surface: 'slack', channelId: 'C1' }, { surface: 'telegram', channelId: '2' }],
+    });
+    const b = canonicalBindingsPayload({
+      version: 1, machineId: 'm', signedAt: 't',
+      bindings: [{ surface: 'telegram', channelId: '2' }, { surface: 'slack', channelId: 'C1' }],
+    });
+    expect(a).toBe(b);
+  });
+
+  it('SECURITY: no canonical collision across the channelId/workspaceId boundary (signature cannot be reused on a different binding)', () => {
+    // The signer vouches for channel 'C1' in workspace 'W2'. An attacker tries to
+    // reuse that signature to vouch for a DIFFERENT channelId 'C1W2' by sliding the
+    // workspaceId into the channelId. With a delimiter-free encoding these would
+    // collide; with the JSON-tuple encoding they must NOT.
+    const signed = canonicalBindingsPayload({
+      version: 1, machineId: 'm', signedAt: 't',
+      bindings: [{ surface: 'slack', channelId: 'C1', workspaceId: 'W2' }],
+    });
+    const tampered = canonicalBindingsPayload({
+      version: 1, machineId: 'm', signedAt: 't',
+      bindings: [{ surface: 'slack', channelId: 'C1W2' }],
+    });
+    expect(signed).not.toBe(tampered);
+
+    // End-to-end: the tampered doc (carrying the signature minted for the ORIGINAL)
+    // must fail verification → the smuggled channel 'C1W2' is NOT a demo channel.
+    const original = { version: 1 as const, machineId: 'm', signedAt: 't', bindings: [{ surface: 'slack' as const, channelId: 'C1', workspaceId: 'W2' }] };
+    const sig = sign(canonicalBindingsPayload(original));
+    const attackDoc = { version: 1 as const, machineId: 'm', signedAt: 't', bindings: [{ surface: 'slack' as const, channelId: 'C1W2' }], signature: sig };
+    const r = new DemoChannelRegistry({ doc: attackDoc, verify });
+    expect(r.isVerified).toBe(false);
+    expect(r.isDemoChannel('slack', 'C1W2')).toBe(false);
+  });
+
+  it('SECURITY: absent vs present-empty workspaceId are distinguishable (no null/"" aliasing)', () => {
+    const absent = canonicalBindingsPayload({
+      version: 1, machineId: 'm', signedAt: 't',
+      bindings: [{ surface: 'slack', channelId: 'C1' }],
+    });
+    const emptyWs = canonicalBindingsPayload({
+      version: 1, machineId: 'm', signedAt: 't',
+      bindings: [{ surface: 'slack', channelId: 'C1', workspaceId: '' }],
+    });
+    expect(absent).not.toBe(emptyWs);
+  });
+
+  it('canonical payload changes when any meaningful field changes (so the signature breaks)', () => {
+    const base = { version: 1 as const, machineId: 'm', signedAt: 't', bindings: [{ surface: 'slack' as const, channelId: 'C1' }] };
+    const p0 = canonicalBindingsPayload(base);
+    expect(canonicalBindingsPayload({ ...base, machineId: 'other' })).not.toBe(p0);
+    expect(canonicalBindingsPayload({ ...base, signedAt: 'later' })).not.toBe(p0);
+    expect(canonicalBindingsPayload({ ...base, bindings: [{ surface: 'slack', channelId: 'C2' }] })).not.toBe(p0);
+    expect(canonicalBindingsPayload({ ...base, bindings: [{ surface: 'slack', channelId: 'C1', workspaceId: 'W' }] })).not.toBe(p0);
+  });
+});

--- a/tests/unit/RealChannelDriver.test.ts
+++ b/tests/unit/RealChannelDriver.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect, vi } from 'vitest';
+import { RealChannelDriver, type SurfaceSender } from '../../src/core/RealChannelDriver.js';
+import type { Surface } from '../../src/core/LiveTestArtifactStore.js';
+
+function fakeSender(reply: { text: string; messageId: string } | null): SurfaceSender {
+  return {
+    send: vi.fn(async (_c: string, _t: string) => ({ messageId: 'sent-1' })),
+    awaitReply: vi.fn(async () => reply),
+  };
+}
+
+const demoYes = { isDemoChannel: () => true };
+const demoNo = { isDemoChannel: () => false };
+
+describe('RealChannelDriver', () => {
+  it('dispatches send to the surface sender', async () => {
+    const tg = fakeSender({ text: 'hi', messageId: 'r1' });
+    const driver = new RealChannelDriver({
+      senders: { telegram: tg },
+      demoRegistry: demoNo,
+      resolveResponderMachine: async () => 'mini',
+    });
+    const res = await driver.send('telegram', '13481', 'hello');
+    expect(res.messageId).toBe('sent-1');
+    expect(tg.send).toHaveBeenCalledWith('13481', 'hello');
+  });
+
+  it('awaitReply stamps responderMachineId from the placement reader (the cross-machine proof)', async () => {
+    const tg = fakeSender({ text: 'served from mini', messageId: 'r9' });
+    const resolve = vi.fn(async (_s: Surface, _c: string) => 'm_mini');
+    const driver = new RealChannelDriver({
+      senders: { telegram: tg },
+      demoRegistry: demoNo,
+      resolveResponderMachine: resolve,
+    });
+    const reply = await driver.awaitReply('telegram', '960021', { timeoutMs: 5000, afterMessageId: 'sent-1' });
+    expect(reply).not.toBeNull();
+    expect(reply!.text).toBe('served from mini');
+    expect(reply!.responderMachineId).toBe('m_mini');
+    expect(resolve).toHaveBeenCalledWith('telegram', '960021');
+  });
+
+  it('null reply (timeout) returns null without calling the placement reader', async () => {
+    const tg = fakeSender(null);
+    const resolve = vi.fn(async () => 'm_mini');
+    const driver = new RealChannelDriver({
+      senders: { telegram: tg },
+      demoRegistry: demoNo,
+      resolveResponderMachine: resolve,
+    });
+    const reply = await driver.awaitReply('telegram', '1', { timeoutMs: 10, afterMessageId: 'x' });
+    expect(reply).toBeNull();
+    expect(resolve).not.toHaveBeenCalled();
+  });
+
+  it('a placement-reader error degrades to undefined responder, never throws away the real reply', async () => {
+    const sl = fakeSender({ text: 'real reply', messageId: 'r2' });
+    const driver = new RealChannelDriver({
+      senders: { slack: sl },
+      demoRegistry: demoYes,
+      resolveResponderMachine: async () => { throw new Error('placement read 503'); },
+    });
+    const reply = await driver.awaitReply('slack', 'C1', { timeoutMs: 100 });
+    expect(reply).not.toBeNull();
+    expect(reply!.text).toBe('real reply');
+    expect(reply!.responderMachineId).toBeUndefined();
+  });
+
+  it('a missing sender for a surface throws loudly (never a silent skip)', async () => {
+    const driver = new RealChannelDriver({
+      senders: { telegram: fakeSender(null) }, // no slack sender
+      demoRegistry: demoNo,
+      resolveResponderMachine: async () => null,
+    });
+    await expect(driver.send('slack', 'C1', 'x')).rejects.toThrow(/no real sender configured for surface "slack"/);
+  });
+
+  it('isDemoChannel delegates to the registry', () => {
+    const driver = new RealChannelDriver({
+      senders: {},
+      demoRegistry: { isDemoChannel: (s, c) => s === 'slack' && c === 'C-demo' },
+      resolveResponderMachine: async () => null,
+    });
+    expect(driver.isDemoChannel('slack', 'C-demo')).toBe(true);
+    expect(driver.isDemoChannel('slack', 'C-other')).toBe(false);
+    expect(driver.isDemoChannel('telegram', 'C-demo')).toBe(false);
+  });
+
+  it('resolveResponderMachine returning null → responderMachineId undefined', async () => {
+    const tg = fakeSender({ text: 'x', messageId: 'r' });
+    const driver = new RealChannelDriver({
+      senders: { telegram: tg },
+      demoRegistry: demoNo,
+      resolveResponderMachine: async () => null,
+    });
+    const reply = await driver.awaitReply('telegram', '1', { timeoutMs: 10 });
+    expect(reply!.responderMachineId).toBeUndefined();
+  });
+});

--- a/upgrades/next/live-test-channel-drivers.md
+++ b/upgrades/next/live-test-channel-drivers.md
@@ -1,0 +1,19 @@
+# Live-test real-channel driver core (DemoChannelRegistry + RealChannelDriver)
+
+## What Changed
+Added the two pure core modules behind the `LiveTestHarness`'s `ChannelDriver` seam (spec: live-user-channel-proof-standard §5.3/§5.4):
+- `DemoChannelRegistry` — verifies a signed demo-channel bindings doc; fail-closed `isDemoChannel(surface, channelId)` (absent or signature-invalid → zero demo channels). Canonical payload is an ordered JSON tuple so a signature can never be reused on a different binding set (closes a delimiter-collision bypass caught in second-pass review).
+- `RealChannelDriver` — the production `ChannelDriver`: composes per-surface `SurfaceSender`s, dispatches send/awaitReply, and stamps `responderMachineId` on each reply via an injected placement reader (the deterministic cross-machine proof). Degrades-not-throws on a placement-read error; throws loudly on a missing surface sender (never a silent skip).
+
+Ships DARK — not wired into server.ts. The real Telegram/Slack surface senders + the runner route are the next increment.
+
+## Evidence
+- `tests/unit/DemoChannelRegistry.test.ts` — 9 tests: valid signed bindings resolve, absent → 0, tampered/forged/throwing-verify all fail-closed, cross-boundary signature-collision rejection, absent-vs-empty distinguishability, canonical order-independence + field-sensitivity.
+- `tests/unit/RealChannelDriver.test.ts` — 7 tests: send dispatch, responderMachineId stamping, null-reply short-circuit, placement-error degrade, missing-sender loud throw, isDemoChannel delegation, null-responder.
+- `tsc --noEmit` clean. instar-dev gate green (converged+approved spec, side-effects + second-pass review).
+
+## What to Tell Your User
+Nothing yet — this is internal infrastructure for the gold-standard live-testing harness and ships dark (no runtime surface, no behavior change). The user-visible payoff lands when the harness runs end-to-end and proves a feature through the real Telegram/Slack channels before they ever test it.
+
+## Summary of New Capabilities
+None user-facing in this increment. Internally: the building blocks that let the live-test harness drive real user channels and assert WHICH machine served a reply (the cross-machine seat-move proof). No new routes, no config, no flags flipped.

--- a/upgrades/side-effects/live-test-channel-drivers.md
+++ b/upgrades/side-effects/live-test-channel-drivers.md
@@ -1,0 +1,41 @@
+# Side-Effects Review — Live-Test Real Channel Driver core (DemoChannelRegistry + RealChannelDriver)
+
+**Slug:** live-test-channel-drivers
+**Spec:** docs/specs/live-user-channel-proof-standard.md §5.3 (Demo Channel Isolation) + §5.4 (Platform-Sanctioned Automation)
+**Files:** src/core/DemoChannelRegistry.ts, src/core/RealChannelDriver.ts, tests/unit/DemoChannelRegistry.test.ts, tests/unit/RealChannelDriver.test.ts
+**Posture:** ships DARK — two pure/injectable core modules, NOT yet wired into server.ts. No route, no runtime construction. The surface senders + runner route are the next increment (`.instar/plans/live-test-harness-drivers-BUILD.md`).
+
+## What it is
+The production-side building blocks for the `LiveTestHarness`'s `ChannelDriver`:
+- **DemoChannelRegistry** — verifies a SIGNED demo-channel bindings doc and answers `isDemoChannel(surface, channelId)`. Fail-closed: an absent OR signature-invalid doc grants ZERO demo channels.
+- **RealChannelDriver** — composes one `SurfaceSender` per surface, dispatches `send`/`awaitReply`, and stamps `responderMachineId` on every reply via an injected `resolveResponderMachine` reader (the cross-machine proof the harness asserts on).
+
+## Phase 1 — Principle check (signal vs authority)
+This increment touches a decision point — `isDemoChannel` gates whether a volatile/permission scenario may run on a given channel (§5.3). Analysis per `docs/signal-vs-authority.md`:
+- **DemoChannelRegistry is a SIGNAL, not the authority.** It returns a boolean; the *authority* that refuses a run is the already-merged `LiveTestHarness.run` (it throws `HarnessVolatileChannelError`). The registry never blocks anything itself.
+- The registry's logic is **fail-closed**, which is the safe direction for a §5.3 isolation check: a false "not a demo channel" only refuses a test; a false "is a demo channel" would let a destructive scenario touch the live operator channel. Verification failures (tampered/absent/throwing verify) all collapse to "no demo channels."
+- **RealChannelDriver holds no decision authority** — pure transport composition. The one place it could mask a failure (a missing surface sender) throws LOUDLY rather than silently returning "no reply" (which the harness would misread as a clean FAIL).
+
+Verdict: compliant. No brittle check with blocking authority added.
+
+## Phase 4 — Side-effects answers
+1. **Over-block** — `isDemoChannel` could return false for a channel that IS legitimately a demo channel if its signed bindings are absent/stale. Effect: a volatile scenario is refused (the harness throws) rather than running. That is the intended fail-closed direction — it never lets the scenario through, only ever refuses. Safe scenarios (the headline transfer-capstone) don't consult demo status, so they're unaffected.
+2. **Under-block** — the registry only vouches for channels in the signed list; it can't detect that a *non-demo* channel is secretly safe. By design — the harness simply requires volatile scenarios to be on a registered demo channel. No false "allow."
+3. **Level-of-abstraction fit** — correct layer: the registry is a pure data/verification helper feeding the harness gate (which already owns the §5.3 throw). The driver is the transport adapter the harness's injected-`ChannelDriver` seam was explicitly designed for (`LiveTestHarness.ts:8-11`). Neither reinvents a higher-layer gate.
+4. **Signal vs authority** — see Phase 1. Compliant (registry = fail-closed signal; harness = authority; driver = transport).
+5. **Interactions** — none yet: nothing constructs either class at runtime (dark). When wired, the driver composes existing senders + the `/pool/placement` reader; it does not shadow or double-fire any existing check. The registry reads a NEW state file (`state/demo-channel-bindings.json`) that no other component touches.
+6. **External surfaces** — none in this increment. No route, no message send, no other-agent-visible change. (The eventual senders WILL drive real Telegram/Slack — that surface lands in the next, separately-reviewed increment.)
+7. **Multi-machine posture** — `responderMachineId` is the feature's whole multi-machine point: the driver resolves WHICH machine served a reply (via the injected placement reader, which reads the authoritative `/pool/placement`, proxied to the lease-holder). The DemoChannelRegistry is **machine-local BY DESIGN** — demo-channel bindings are an operational/test-fixture fact of the machine running the harness; the harness runs on one machine at a time and asserts cross-machine behavior THROUGH the channel, not by replicating bindings. No silent single-machine assumption: the cross-machine dimension is carried explicitly by `responderMachineId`.
+8. **Rollback cost** — trivial: dark, unwired code. Back-out = revert the commit (or simply never wire it). No data migration, no live state, no fleet behavior change.
+
+## No-deferrals
+The surface senders + runner are NOT a deferral of THIS increment — they are the next tracked increment (CMT-1568, `.instar/plans/live-test-harness-drivers-BUILD.md`). This increment is complete and self-contained: both modules are fully implemented (no stubs/TODOs) and fully unit-tested (16 tests, both sides of every boundary — valid/tampered/absent/throwing/collision/empty-vs-absent for the registry; dispatch/stamp/degrade/missing-sender for the driver).
+
+## Phase 5 — Second-pass review
+An independent reviewer subagent audited the modules + this artifact adversarially.
+
+**Concern raised (and RESOLVED):** `canonicalBindingsPayload`'s per-binding encoding was a delimiter-free concatenation (`${surface}${channelId}${workspaceId}${label}`), an ambiguous field boundary that lets a tampered binding collide to the same signed bytes — e.g. `{channelId:'C1', workspaceId:'W2'}` and `{channelId:'C1W2'}` serialize identically and share one valid signature, promoting an unvouched channelId to a demo channel. That is exactly the dangerous false "is demo" the module guards against.
+
+**Fix applied:** the per-binding encoding is now an ordered JSON tuple (`JSON.stringify([surface, channelId, workspaceId ?? null, label ?? null])`), which makes every field boundary explicit and distinguishes an absent field (`null`) from a present empty string (`''`). The lookup `key()` was hardened the same way (defense-in-depth). Two regression tests added: a cross-boundary collision test (the tampered doc fails verification → the smuggled channel is NOT a demo channel) and an absent-vs-empty distinguishability test. (Also stripped stray `\x01` control bytes that had crept into the source — invisible and git-binary-fragile.)
+
+Re-review verdict after fix: the collision is closed; the surface↔channelId boundary was already safe (surface is a closed enum, none a prefix of another); fail-closed paths and the driver's degrade-not-throw / loud-missing-sender behavior are correct. **Concur with the review (post-fix).**


### PR DESCRIPTION
## ELI16

The "gold-standard live testing" idea is: a feature isn't done until a session acting AS THE USER drives it through the real Telegram/Slack channels and proves it works — before the operator ever has to test it. The harness CORE that runs that scenario matrix already merged (#1188). It drives an injected `ChannelDriver` (send a message / wait for the reply / is-this-a-demo-channel), so the real platform drivers plug into one seam.

This PR adds the two pure building blocks behind that seam — DARK (not wired into the server yet; no behavior change):

1. **DemoChannelRegistry** — answers "is (surface, channelId) a registered DEMO channel?" from a SIGNED bindings file. This is the §5.3 safety backbone: a volatile/dangerous test scenario is only ever allowed to run on a demo channel, never the live operator channel. It's **fail-closed** — if the bindings are absent, tampered, or the signature can't be verified, it grants ZERO demo channels (a false "not demo" only refuses a test; a false "is demo" could let a destructive scenario hit the live channel, so we fail toward refusing).

2. **RealChannelDriver** — the production `ChannelDriver`: it composes one real sender per surface and, crucially, stamps every reply with `responderMachineId` — WHICH machine actually served the reply. That's the deterministic proof for the multi-machine capstone ("after the transfer, the reply genuinely came FROM the Mini"). It degrades gracefully (keeps the real reply, drops only the machine attribution) if the placement read fails, and throws loudly rather than silently skipping if a surface has no sender configured.

**Safeguard caught in review:** the second-pass reviewer found a real signature-bypass — the original canonical encoding concatenated binding fields with no delimiter, so a tampered binding could collide to the same signed bytes and smuggle an unvouched channel in as "demo." Fixed by encoding each binding as an ordered JSON tuple (explicit field boundaries; absent ≠ empty-string), with two regression tests. (Also stripped stray invisible control bytes from the source.)

**What you need to decide:** nothing — it's dark infrastructure. The next increment wires the real Telegram/Slack senders + a runner and actually runs the matrix over the multi-machine transfer.

## What's in it
- `src/core/DemoChannelRegistry.ts` + `tests/unit/DemoChannelRegistry.test.ts` (9 tests)
- `src/core/RealChannelDriver.ts` + `tests/unit/RealChannelDriver.test.ts` (7 tests)
- Side-effects review + second-pass review (concern raised → resolved): `upgrades/side-effects/live-test-channel-drivers.md`
- 16 tests green, tsc clean. Spec: docs/specs/live-user-channel-proof-standard.md §5.3/§5.4 (converged + approved, #1188).

Part of CMT-1568. Ships dark — no runtime wiring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)