### PR TITLE
feat(live-test): Slack live sender + placement responder reader (CMT-1568)

### DIFF
--- a/.instar/instar-dev-decisions/2026-06-16T10-05-44-797Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-06-16T10-05-44-797Z-unknown.json
@@ -1,0 +1,15 @@
+{
+  "ts": "2026-06-16T10:05:44.797Z",
+  "slug": "unknown",
+  "suggestedTier": 2,
+  "declaredTier": 2,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "new capability: new exported class / subsystem added"
+  ],
+  "belowFloor": false,
+  "files": 2,
+  "loc": 167,
+  "causalAutopsy": null,
+  "verdict": "pass"
+}

--- a/.instar/instar-dev-decisions/2026-06-16T10-06-36-926Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-06-16T10-06-36-926Z-unknown.json
@@ -1,0 +1,15 @@
+{
+  "ts": "2026-06-16T10:06:36.926Z",
+  "slug": "unknown",
+  "suggestedTier": 2,
+  "declaredTier": 2,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "new capability: new exported class / subsystem added"
+  ],
+  "belowFloor": false,
+  "files": 2,
+  "loc": 173,
+  "causalAutopsy": null,
+  "verdict": "pass"
+}

--- a/.instar/instar-dev-decisions/2026-06-16T10-10-30-690Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-06-16T10-10-30-690Z-unknown.json
@@ -1,0 +1,15 @@
+{
+  "ts": "2026-06-16T10:10:30.690Z",
+  "slug": "unknown",
+  "suggestedTier": 2,
+  "declaredTier": 2,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "new capability: new exported class / subsystem added"
+  ],
+  "belowFloor": false,
+  "files": 2,
+  "loc": 173,
+  "causalAutopsy": null,
+  "verdict": "pass"
+}

--- a/src/core/PlacementResponderReader.ts
+++ b/src/core/PlacementResponderReader.ts
@@ -1,0 +1,70 @@
+/**
+ * PlacementResponderReader — resolves WHICH machine served a reply, for the
+ * RealChannelDriver's injected `resolveResponderMachine` seam
+ * (docs/specs/live-user-channel-proof-standard.md §5.6 — the deterministic
+ * cross-machine proof). It maps a (surface, channelId) to the topic that
+ * `GET /pool/placement?topic=N` is keyed on, reads the authoritative owner, and
+ * returns that machine id.
+ *
+ * Why this is the right reader: `/pool/placement` is the authoritative placement
+ * surface (it proxies to the lease-holder, so any machine can answer), and its
+ * `owner` field is the machine currently serving the topic — exactly "who replied"
+ * after a transfer. We read `owner` (not `pinnedTo`): a pin is the INTENT to place;
+ * `owner` is who actually holds it. For the capstone that distinction is the whole
+ * point — a pin that didn't move the seat is the original bug.
+ *
+ * Parameterized for testability: the HTTP GET + the (surface, channelId)→topicId
+ * mapping are injected, so this is unit-testable with no live server. MUST NOT throw
+ * on a transient read error — it returns null so the RealChannelDriver degrades to an
+ * unattributed reply rather than failing the whole scenario.
+ */
+
+// RULE 3: EXEMPT — this reads instar's OWN authoritative `/pool/placement` JSON API
+// (a structured internal response with an explicit `owner` field), not fragile
+// provider/CLI stdout. There is no brittle output-parsing state-detection pattern to
+// harden: `owner` is read straight from the typed response, and any read error/absence
+// degrades to null. Not a provider-state detector.
+
+import type { Surface } from './LiveTestArtifactStore.js';
+
+export interface PlacementResult {
+  owner: string | null;
+  ownerNickname?: string | null;
+}
+
+export interface PlacementResponderReaderDeps {
+  /**
+   * Map (surface, channelId) → the topic id `/pool/placement` is keyed on. For
+   * telegram, channelId IS the topic. For slack, the caller injects the
+   * channel→topic resolution (the SlackAdapter's session keying). Return null when
+   * the channel doesn't map to a placement-tracked topic.
+   */
+  topicForChannel: (surface: Surface, channelId: string) => string | null;
+  /** GET /pool/placement?topic=<id> → the placement (owner). Throwing/transient errors are tolerated. */
+  fetchPlacement: (topicId: string) => Promise<PlacementResult | null>;
+  logger?: (m: string) => void;
+}
+
+export class PlacementResponderReader {
+  private readonly d: PlacementResponderReaderDeps;
+  constructor(deps: PlacementResponderReaderDeps) { this.d = deps; }
+
+  private log(m: string): void { this.d.logger?.(`[placement-responder-reader] ${m}`); }
+
+  /** The function shape RealChannelDriver injects: (surface, channelId) → machine id | null. */
+  resolve = async (surface: Surface, channelId: string): Promise<string | null> => {
+    const topicId = this.d.topicForChannel(surface, channelId);
+    if (!topicId) {
+      this.log(`no placement-tracked topic for ${surface}:${channelId}`);
+      return null;
+    }
+    try {
+      const p = await this.d.fetchPlacement(topicId);
+      return p?.owner ?? null;
+    } catch (err) {
+      // Tolerate: the driver degrades to an unattributed reply, never a thrown scenario.
+      this.log(`fetchPlacement failed for topic ${topicId}: ${err instanceof Error ? err.message : String(err)}`);
+      return null;
+    }
+  };
+}

--- a/src/core/PlacementResponderReader.ts
+++ b/src/core/PlacementResponderReader.ts
@@ -62,7 +62,10 @@ export class PlacementResponderReader {
       const p = await this.d.fetchPlacement(topicId);
       return p?.owner ?? null;
     } catch (err) {
-      // Tolerate: the driver degrades to an unattributed reply, never a thrown scenario.
+      // @silent-fallback-ok: a transient /pool/placement read failure degrades this
+      // best-effort responder-machine lookup to null — the RealChannelDriver then
+      // proceeds with an unattributed reply rather than throwing the whole scenario.
+      // The failure is logged with topic context; it is not a gating/authority path.
       this.log(`fetchPlacement failed for topic ${topicId}: ${err instanceof Error ? err.message : String(err)}`);
       return null;
     }

--- a/src/core/SlackLiveSender.ts
+++ b/src/core/SlackLiveSender.ts
@@ -1,0 +1,103 @@
+/**
+ * SlackLiveSender — the real Slack `SurfaceSender` for the live-test harness
+ * (docs/specs/live-user-channel-proof-standard.md §5.4). It posts a message into a
+ * Slack channel AS A NON-AGENT IDENTITY (a user/second-bot token, NOT Echo's own bot
+ * — Echo never replies to itself) and then waits for the AGENT's reply by polling the
+ * channel history for a message from the agent's bot user id.
+ *
+ * Parameterization is deliberate: the sender takes an already-constructed
+ * `SlackApiClient` (carrying the non-Echo sender token) + the agent's bot user id. So
+ * the CODE is complete and unit-testable here; the only thing that has to be provided
+ * at wiring time is the sender CREDENTIAL (a user token / second-bot token in the
+ * demo workspace). That credential is the one piece that may need provisioning — the
+ * logic does not.
+ *
+ * `awaitReply` identifies the agent's reply DETERMINISTICALLY (a message strictly
+ * after the sent ts whose author is the agent's bot user id), never a fuzzy guess, and
+ * resolves null on timeout (the harness records that as a FAIL with reason). The
+ * responder-MACHINE attribution (the cross-machine proof) is NOT done here — that is
+ * the RealChannelDriver's injected placement reader; this sender only returns the
+ * reply text + id.
+ */
+
+import type { SurfaceSender } from './RealChannelDriver.js';
+import type { SendResult, ReplyResult } from './LiveTestHarness.js';
+
+/** Minimal Slack client surface this sender needs (matches SlackApiClient.call). */
+export interface SlackCaller {
+  call(method: string, params?: Record<string, unknown>): Promise<{
+    ok?: boolean;
+    ts?: string;
+    messages?: Array<{ ts: string; user?: string; bot_id?: string; text?: string; subtype?: string }>;
+    [k: string]: unknown;
+  }>;
+}
+
+export interface SlackLiveSenderDeps {
+  /** A SlackApiClient constructed with the NON-AGENT sender token (the user-role identity). */
+  api: SlackCaller;
+  /** The agent's (Echo's) Slack bot user id — awaitReply waits for a reply authored by THIS id. */
+  agentBotUserId: string;
+  /** Poll cadence while awaiting a reply. Default 2000ms. */
+  pollIntervalMs?: number;
+  /** Injected for tests; defaults to real timers / clock. */
+  sleep?: (ms: number) => Promise<void>;
+  now?: () => number;
+  logger?: (m: string) => void;
+}
+
+export class SlackLiveSender implements SurfaceSender {
+  private readonly d: SlackLiveSenderDeps;
+  constructor(deps: SlackLiveSenderDeps) { this.d = deps; }
+
+  private now(): number { return (this.d.now ?? Date.now)(); }
+  private async sleep(ms: number): Promise<void> {
+    return (this.d.sleep ?? ((m: number) => new Promise<void>((r) => setTimeout(r, m))))(ms);
+  }
+  private log(m: string): void { this.d.logger?.(`[slack-live-sender] ${m}`); }
+
+  async send(channelId: string, text: string): Promise<SendResult> {
+    const res = await this.d.api.call('chat.postMessage', { channel: channelId, text });
+    if (!res.ts) {
+      // A post with no ts is a real failure — surface it (the harness records a driver
+      // error FAIL), never fabricate a messageId.
+      throw new Error(`chat.postMessage returned no ts (ok=${res.ok}) — message not posted`);
+    }
+    return { messageId: res.ts };
+  }
+
+  async awaitReply(channelId: string, opts: { timeoutMs: number; afterMessageId?: string }): Promise<Omit<ReplyResult, 'responderMachineId'> | null> {
+    const deadline = this.now() + opts.timeoutMs;
+    const pollMs = this.d.pollIntervalMs ?? 2000;
+    const after = opts.afterMessageId; // a Slack ts string; lexicographic compare works for ts
+    // Poll at least once even if timeoutMs is ~0.
+    for (let first = true; first || this.now() < deadline; first = false) {
+      const reply = await this.findAgentReply(channelId, after);
+      if (reply) return reply;
+      if (this.now() >= deadline) break;
+      await this.sleep(pollMs);
+    }
+    this.log(`no agent reply in ${channelId} within ${opts.timeoutMs}ms`);
+    return null;
+  }
+
+  /** Find the FIRST agent-authored message strictly after `after` (oldest-first). */
+  private async findAgentReply(channelId: string, after?: string): Promise<{ text: string; messageId: string } | null> {
+    const res = await this.d.api.call('conversations.history', {
+      channel: channelId,
+      ...(after ? { oldest: after, inclusive: false } : {}),
+      limit: 100,
+    });
+    const messages = res.messages ?? [];
+    // conversations.history returns newest-first; scan oldest-first so we return the
+    // EARLIEST agent reply after the prompt (deterministic).
+    const oldestFirst = [...messages].sort((a, b) => (a.ts < b.ts ? -1 : a.ts > b.ts ? 1 : 0));
+    for (const m of oldestFirst) {
+      if (after && !(m.ts > after)) continue; // strictly-after guard (belt + suspenders vs `oldest`)
+      if (m.user !== this.d.agentBotUserId) continue; // only the AGENT's reply
+      const text = m.text ?? '';
+      return { text, messageId: m.ts };
+    }
+    return null;
+  }
+}

--- a/tests/unit/PlacementResponderReader.test.ts
+++ b/tests/unit/PlacementResponderReader.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect, vi } from 'vitest';
+import { PlacementResponderReader } from '../../src/core/PlacementResponderReader.js';
+
+describe('PlacementResponderReader', () => {
+  it('telegram: channelId is the topic; returns the placement owner', async () => {
+    const fetchPlacement = vi.fn(async (t: string) => ({ owner: 'm_mini', ownerNickname: 'Mac Mini' }));
+    const r = new PlacementResponderReader({
+      topicForChannel: (_s, c) => c, // telegram: channel == topic
+      fetchPlacement,
+    });
+    expect(await r.resolve('telegram', '960021')).toBe('m_mini');
+    expect(fetchPlacement).toHaveBeenCalledWith('960021');
+  });
+
+  it('returns owner (who holds it), reflecting a real seat move', async () => {
+    const r = new PlacementResponderReader({
+      topicForChannel: (_s, c) => c,
+      fetchPlacement: async () => ({ owner: 'm_laptop' }),
+    });
+    expect(await r.resolve('telegram', '13481')).toBe('m_laptop');
+  });
+
+  it('slack: uses the injected channel→topic mapping', async () => {
+    const fetchPlacement = vi.fn(async (_t: string) => ({ owner: 'm_mini' }));
+    const r = new PlacementResponderReader({
+      topicForChannel: (s, c) => (s === 'slack' && c === 'C123' ? 'topic-77' : null),
+      fetchPlacement,
+    });
+    expect(await r.resolve('slack', 'C123')).toBe('m_mini');
+    expect(fetchPlacement).toHaveBeenCalledWith('topic-77');
+  });
+
+  it('no placement-tracked topic → null (and never calls fetch)', async () => {
+    const fetchPlacement = vi.fn(async () => ({ owner: 'x' }));
+    const r = new PlacementResponderReader({
+      topicForChannel: () => null,
+      fetchPlacement,
+    });
+    expect(await r.resolve('slack', 'C-unknown')).toBeNull();
+    expect(fetchPlacement).not.toHaveBeenCalled();
+  });
+
+  it('owner null → null', async () => {
+    const r = new PlacementResponderReader({
+      topicForChannel: (_s, c) => c,
+      fetchPlacement: async () => ({ owner: null }),
+    });
+    expect(await r.resolve('telegram', '1')).toBeNull();
+  });
+
+  it('a fetch error degrades to null (never throws — driver keeps the reply)', async () => {
+    const r = new PlacementResponderReader({
+      topicForChannel: (_s, c) => c,
+      fetchPlacement: async () => { throw new Error('placement 503'); },
+    });
+    await expect(r.resolve('telegram', '1')).resolves.toBeNull();
+  });
+
+  it('the resolve field is bound (usable directly as RealChannelDriver.resolveResponderMachine)', async () => {
+    const r = new PlacementResponderReader({
+      topicForChannel: (_s, c) => c,
+      fetchPlacement: async () => ({ owner: 'm_mini' }),
+    });
+    const fn = r.resolve; // detached reference — must still work (arrow-bound)
+    expect(await fn('telegram', '5')).toBe('m_mini');
+  });
+});

--- a/tests/unit/SlackLiveSender.test.ts
+++ b/tests/unit/SlackLiveSender.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect, vi } from 'vitest';
+import { SlackLiveSender, type SlackCaller } from '../../src/core/SlackLiveSender.js';
+
+const AGENT = 'UECHOBOT';
+const noSleep = async () => {};
+
+function caller(handlers: Partial<Record<string, (params: any) => any>>): SlackCaller {
+  return {
+    call: vi.fn(async (method: string, params: any = {}) => {
+      const h = handlers[method];
+      if (!h) throw new Error(`unexpected call ${method}`);
+      return h(params);
+    }),
+  };
+}
+
+describe('SlackLiveSender', () => {
+  it('send posts via chat.postMessage and returns the ts as messageId', async () => {
+    const api = caller({ 'chat.postMessage': () => ({ ok: true, ts: '111.222' }) });
+    const s = new SlackLiveSender({ api, agentBotUserId: AGENT, sleep: noSleep });
+    const res = await s.send('C1', 'hello');
+    expect(res.messageId).toBe('111.222');
+    expect(api.call).toHaveBeenCalledWith('chat.postMessage', { channel: 'C1', text: 'hello' });
+  });
+
+  it('send throws (never fabricates a messageId) when no ts is returned', async () => {
+    const api = caller({ 'chat.postMessage': () => ({ ok: false }) });
+    const s = new SlackLiveSender({ api, agentBotUserId: AGENT, sleep: noSleep });
+    await expect(s.send('C1', 'x')).rejects.toThrow(/no ts/);
+  });
+
+  it('awaitReply returns the AGENT reply after the sent ts (ignores the sender own message + earlier msgs)', async () => {
+    const api = caller({
+      'conversations.history': () => ({
+        ok: true,
+        messages: [
+          { ts: '300.0', user: AGENT, text: 'the agent reply' },   // newest-first ordering from Slack
+          { ts: '200.0', user: 'UMIA', text: 'the prompt' },        // the sender's own message
+          { ts: '100.0', user: AGENT, text: 'an OLD agent message' },
+        ],
+      }),
+    });
+    const s = new SlackLiveSender({ api, agentBotUserId: AGENT, sleep: noSleep });
+    const reply = await s.awaitReply('C1', { timeoutMs: 1000, afterMessageId: '200.0' });
+    expect(reply).not.toBeNull();
+    expect(reply!.text).toBe('the agent reply');
+    expect(reply!.messageId).toBe('300.0');
+  });
+
+  it('awaitReply ignores a non-agent message even if it is after the prompt', async () => {
+    const api = caller({
+      'conversations.history': () => ({
+        messages: [{ ts: '250.0', user: 'USOMEONE', text: 'not the agent' }],
+      }),
+    });
+    let nowVal = 0;
+    const s = new SlackLiveSender({ api, agentBotUserId: AGENT, sleep: noSleep, pollIntervalMs: 1, now: () => (nowVal += 600) });
+    const reply = await s.awaitReply('C1', { timeoutMs: 1000, afterMessageId: '200.0' });
+    expect(reply).toBeNull();
+  });
+
+  it('awaitReply polls until the reply appears, then returns it', async () => {
+    let calls = 0;
+    const api = caller({
+      'conversations.history': () => {
+        calls++;
+        if (calls < 3) return { messages: [{ ts: '200.0', user: 'UMIA', text: 'prompt' }] };
+        return { messages: [{ ts: '400.0', user: AGENT, text: 'finally' }, { ts: '200.0', user: 'UMIA', text: 'prompt' }] };
+      },
+    });
+    let nowVal = 0;
+    const s = new SlackLiveSender({ api, agentBotUserId: AGENT, sleep: noSleep, pollIntervalMs: 1, now: () => (nowVal += 100) });
+    const reply = await s.awaitReply('C1', { timeoutMs: 100000, afterMessageId: '200.0' });
+    expect(reply!.text).toBe('finally');
+    expect(calls).toBeGreaterThanOrEqual(3);
+  });
+
+  it('awaitReply returns null on timeout (no agent reply ever)', async () => {
+    const api = caller({ 'conversations.history': () => ({ messages: [] }) });
+    let nowVal = 0;
+    const s = new SlackLiveSender({ api, agentBotUserId: AGENT, sleep: noSleep, pollIntervalMs: 1, now: () => (nowVal += 600) });
+    const reply = await s.awaitReply('C1', { timeoutMs: 1000, afterMessageId: '200.0' });
+    expect(reply).toBeNull();
+  });
+
+  it('awaitReply with no afterMessageId still returns the agent message', async () => {
+    const api = caller({ 'conversations.history': () => ({ messages: [{ ts: '10.0', user: AGENT, text: 'hi' }] }) });
+    const s = new SlackLiveSender({ api, agentBotUserId: AGENT, sleep: noSleep });
+    const reply = await s.awaitReply('C1', { timeoutMs: 1000 });
+    expect(reply!.text).toBe('hi');
+  });
+});

--- a/upgrades/next/live-test-slack-sender.md
+++ b/upgrades/next/live-test-slack-sender.md
@@ -1,0 +1,17 @@
+# Live-test Slack sender + placement responder reader
+
+## What Changed
+Two more pure building blocks for the live-test harness (spec live-user-channel-proof-standard §5.4/§5.6), ships DARK (not wired):
+- `SlackLiveSender` — a real Slack `SurfaceSender`: posts as a non-agent identity via `chat.postMessage`, awaits the agent's reply by polling `conversations.history` (deterministic: a message strictly after the prompt, authored by the agent's bot user id). Parameterized on the sender token so only the credential needs provisioning.
+- `PlacementResponderReader` — the injectable `resolveResponderMachine` for RealChannelDriver: maps (surface, channelId)→topic, reads `/pool/placement` `owner` (the machine that actually holds the seat — the cross-machine proof), tolerates read errors (returns null).
+
+## Evidence
+- `tests/unit/SlackLiveSender.test.ts` — 7 tests: post→ts, no-ts throw, agent-reply-after-prompt, ignores non-agent + stale messages, poll-until-appears, timeout→null, no-afterId.
+- `tests/unit/PlacementResponderReader.test.ts` — 7 tests: telegram channel==topic, owner reflects seat move, slack channel→topic mapping, no-topic→null (no fetch), owner-null→null, fetch-error→null, arrow-bound detached reference.
+- `tsc --noEmit` clean. instar-dev gate green.
+
+## What to Tell Your User
+Nothing yet — internal infrastructure for the gold-standard live-testing harness, ships dark (no runtime surface, no behavior change). The payoff is when the harness drives the real Slack channel and proves which machine served the reply.
+
+## Summary of New Capabilities
+None user-facing. Internally: the real Slack drive + the cross-machine "which machine answered" reader that the live-test harness needs. No new routes, no config, no flags.

--- a/upgrades/side-effects/live-test-slack-sender.md
+++ b/upgrades/side-effects/live-test-slack-sender.md
@@ -1,0 +1,29 @@
+# Side-Effects Review — Live-test Slack sender + placement responder reader
+
+**Slug:** live-test-slack-sender
+**Spec:** docs/specs/live-user-channel-proof-standard.md §5.4 (Platform-Sanctioned Automation) + §5.6 (deterministic cross-machine proof)
+**Files:** src/core/SlackLiveSender.ts, src/core/PlacementResponderReader.ts, tests/unit/SlackLiveSender.test.ts, tests/unit/PlacementResponderReader.test.ts
+**Posture:** ships DARK — two pure/injectable building blocks, NOT wired into server.ts. No route, no runtime construction. Stacked on the driver core (PR #1195).
+
+## What it is
+- **SlackLiveSender** — a real Slack `SurfaceSender`: posts a message AS A NON-AGENT identity (a user/second-bot token, injected) via `chat.postMessage`, and `awaitReply` polls `conversations.history` for the AGENT's reply (a message strictly after the sent ts authored by the agent's bot user id). Deterministic match; null on timeout; throws (never fabricates an id) if a post returns no ts.
+- **PlacementResponderReader** — the injectable `resolveResponderMachine` for RealChannelDriver: maps (surface, channelId)→topic, reads `GET /pool/placement` `owner`, returns the serving machine id. Tolerates read errors (returns null). Reads `owner` (who holds the seat), NOT `pinnedTo` (the intent) — the distinction IS the capstone.
+
+## Phase 1 — Principle check (signal vs authority)
+Neither module is a decision point. SlackLiveSender is transport (post + poll); PlacementResponderReader is a read that returns a machine id. Neither blocks, filters, or gates anything — they produce data the harness asserts on. No brittle blocking authority added. Compliant.
+
+## Phase 4 — Side-effects answers
+1. **Over-block** — n/a (no block surface). Worst case: SlackLiveSender's reply-match is too strict and misses a genuine agent reply → the scenario records a FAIL/no-reply. Mitigation: it matches on the agent's bot user id (the deterministic author), and polls the full window.
+2. **Under-block** — n/a. A risk: matching a STALE agent message as the reply. Mitigated by the strictly-after-ts guard (both via `oldest`+`inclusive:false` AND an explicit `m.ts > after` belt-and-suspenders) and oldest-first scan returning the EARLIEST post-prompt agent message.
+3. **Level-of-abstraction fit** — correct: both are the concrete adapters the harness's injected seams (`SurfaceSender`, `resolveResponderMachine`) were designed for. They wrap existing surfaces (`SlackApiClient`, `/pool/placement`) rather than reinventing them.
+4. **Signal vs authority** — compliant (transport + read, no authority). See Phase 1.
+5. **Interactions** — none yet (dark, unwired). SlackLiveSender uses a SEPARATE sender token from Echo's bot, so it can't be confused with Echo's own outbound; it reads history read-only. PlacementResponderReader only GETs placement. No shadowing/double-fire.
+6. **External surfaces** — when wired, SlackLiveSender WILL post a real message into a Slack channel (the demo workspace) and PlacementResponderReader WILL GET the local placement route. In THIS increment: no wiring, so no external surface. The sender token/identity is the one piece that needs provisioning (a user/second-bot token in the demo workspace) — the code is parameterized on it.
+7. **Multi-machine posture** — PlacementResponderReader IS the multi-machine attribution: it reads the authoritative `/pool/placement` (proxied to the lease-holder), so it answers "which machine served this" correctly regardless of which machine runs the harness. SlackLiveSender is machine-agnostic (talks to Slack's API). No single-machine assumption.
+8. **Rollback cost** — trivial: dark, unwired. Revert the commit.
+
+## No-deferrals
+The Telegram live sender + the runner route are the NEXT tracked increment (CMT-1568, `.instar/plans/live-test-harness-drivers-BUILD.md`), not a deferral of this one. This increment is complete + fully unit-tested (14 tests). The Slack/Telegram SENDER-IDENTITY provisioning (a user token / demo bot) is an external-credential dependency tracked in the plan, explicitly NOT a code deferral — the code is parameterized so only the credential is missing.
+
+## Phase 5 — Second-pass review
+Not required: neither module adds a block/allow decision, a session-lifecycle action, a sentinel/guard/gate/watchdog, or a coherence/trust surface (the Phase-5 triggers). Both are transport/read adapters. The driver core that DOES touch the §5.3 block (DemoChannelRegistry) had its second-pass in PR #1195.


### PR DESCRIPTION
## ELI16 — Two new tools so the agent can test itself over real Slack, across machines

Before we tell the operator a Slack feature "works," the agent should prove it by actually using Slack the way a person would. This PR adds two small building blocks for that self-test harness (both ship dark — nothing is wired up yet):

- **SlackLiveSender** posts a message into Slack as a *different* identity (not the agent), then watches the channel for the agent's reply — so we confirm a real round-trip happened, not just that code ran.
- **PlacementResponderReader** answers "which of my machines is actually holding this conversation?" by reading the live placement map — the proof that the right machine responded when work is spread across several.

Both are fully unit-tested (14 green) and type-clean.

---

Two dark building blocks for the live-test harness (spec §5.4/§5.6), stacked on #1195.

- **SlackLiveSender** — real Slack SurfaceSender: posts as a non-Echo identity via chat.postMessage, awaits the agent's reply by polling conversations.history (deterministic: strictly-after-ts + agent bot user id). Parameterized on the sender token so only the credential needs provisioning.
- **PlacementResponderReader** — the injectable resolveResponderMachine for RealChannelDriver: maps (surface,channelId)->topic, reads /pool/placement owner (the machine that actually holds the seat — the cross-machine proof), degrades to null on error.

14 tests green, tsc clean. Ships dark (not wired). Part of CMT-1568.

NOTE: stacked on #1195 — until #1195 merges this diff also shows the driver-core commit; rebase onto main after #1195 lands for a clean single-commit diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
