### PR TITLE
feat(live-test): Telegram live sender (CMT-1568)

### DIFF
--- a/.instar/instar-dev-decisions/2026-06-16T10-15-58-661Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-06-16T10-15-58-661Z-unknown.json
@@ -1,0 +1,15 @@
+{
+  "ts": "2026-06-16T10:15:58.661Z",
+  "slug": "unknown",
+  "suggestedTier": 2,
+  "declaredTier": 2,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "new capability: new exported class / subsystem added"
+  ],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 91,
+  "causalAutopsy": null,
+  "verdict": "pass"
+}

--- a/src/core/TelegramLiveSender.ts
+++ b/src/core/TelegramLiveSender.ts
@@ -1,0 +1,91 @@
+/**
+ * TelegramLiveSender — the real Telegram `SurfaceSender` for the live-test harness
+ * (docs/specs/live-user-channel-proof-standard.md §5.4). It posts a message into a
+ * Telegram forum topic AS A NON-AGENT IDENTITY (a DEMO bot / second account in a demo
+ * group — NOT the agent's own bot, which the agent would not treat as inbound), then
+ * waits for the AGENT's reply by polling the topic history for the next agent-authored
+ * message.
+ *
+ * Same shape as SlackLiveSender: the send transport (the demo-bot post) and the
+ * history read are INJECTED, so the CODE is complete + unit-testable here and the only
+ * wiring-time dependency is the demo-bot CREDENTIAL + a demo group/topic (provisioning).
+ *
+ * The agent's reply is identified DETERMINISTICALLY: the earliest history entry with
+ * `fromUser === false` (an agent outbound) whose messageId is strictly after the one we
+ * sent. Null on timeout. The responder-MACHINE attribution (the cross-machine proof) is
+ * the RealChannelDriver's injected placement reader, not this sender.
+ */
+
+import type { SurfaceSender } from './RealChannelDriver.js';
+import type { SendResult, ReplyResult } from './LiveTestHarness.js';
+
+/** The subset of TelegramAdapter.getTopicHistory's LogEntry this sender reads. */
+export interface TelegramHistoryEntry {
+  messageId: number;
+  text: string;
+  /** true = inbound user message; false = an agent (bot) outbound — the reply we wait for. */
+  fromUser: boolean;
+}
+
+export interface TelegramLiveSenderDeps {
+  /** Post a message into the topic AS THE DEMO identity (demo-bot token). Returns the new message id. */
+  postAsDemoUser: (topicId: number, text: string) => Promise<{ messageId: number }>;
+  /** Read recent topic history (Echo's getTopicHistory), newest-or-oldest order tolerated. */
+  getHistory: (topicId: number, limit?: number) => TelegramHistoryEntry[] | Promise<TelegramHistoryEntry[]>;
+  pollIntervalMs?: number;
+  sleep?: (ms: number) => Promise<void>;
+  now?: () => number;
+  logger?: (m: string) => void;
+}
+
+export class TelegramLiveSender implements SurfaceSender {
+  private readonly d: TelegramLiveSenderDeps;
+  constructor(deps: TelegramLiveSenderDeps) { this.d = deps; }
+
+  private now(): number { return (this.d.now ?? Date.now)(); }
+  private async sleep(ms: number): Promise<void> {
+    return (this.d.sleep ?? ((m: number) => new Promise<void>((r) => setTimeout(r, m))))(ms);
+  }
+  private log(m: string): void { this.d.logger?.(`[telegram-live-sender] ${m}`); }
+
+  private topicNum(channelId: string): number {
+    const n = Number(channelId);
+    if (!Number.isFinite(n)) throw new Error(`telegram channelId "${channelId}" is not a numeric topic id`);
+    return n;
+  }
+
+  async send(channelId: string, text: string): Promise<SendResult> {
+    const res = await this.d.postAsDemoUser(this.topicNum(channelId), text);
+    if (!Number.isFinite(res?.messageId)) {
+      throw new Error(`postAsDemoUser returned no messageId — message not posted`);
+    }
+    return { messageId: String(res.messageId) };
+  }
+
+  async awaitReply(channelId: string, opts: { timeoutMs: number; afterMessageId?: string }): Promise<Omit<ReplyResult, 'responderMachineId'> | null> {
+    const topic = this.topicNum(channelId);
+    const afterId = opts.afterMessageId != null ? Number(opts.afterMessageId) : -Infinity;
+    const deadline = this.now() + opts.timeoutMs;
+    const pollMs = this.d.pollIntervalMs ?? 2000;
+    for (let first = true; first || this.now() < deadline; first = false) {
+      const reply = await this.findAgentReply(topic, afterId);
+      if (reply) return reply;
+      if (this.now() >= deadline) break;
+      await this.sleep(pollMs);
+    }
+    this.log(`no agent reply in topic ${topic} within ${opts.timeoutMs}ms`);
+    return null;
+  }
+
+  private async findAgentReply(topicId: number, afterId: number): Promise<{ text: string; messageId: string } | null> {
+    const entries = await this.d.getHistory(topicId, 100);
+    // Oldest-first by messageId so we return the EARLIEST agent reply after the prompt.
+    const oldestFirst = [...entries].sort((a, b) => a.messageId - b.messageId);
+    for (const e of oldestFirst) {
+      if (e.messageId <= afterId) continue;   // strictly after the prompt
+      if (e.fromUser) continue;               // skip inbound user messages (incl. our own demo post)
+      return { text: e.text ?? '', messageId: String(e.messageId) };
+    }
+    return null;
+  }
+}

--- a/tests/unit/TelegramLiveSender.test.ts
+++ b/tests/unit/TelegramLiveSender.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect, vi } from 'vitest';
+import { TelegramLiveSender, type TelegramHistoryEntry } from '../../src/core/TelegramLiveSender.js';
+
+const noSleep = async () => {};
+
+describe('TelegramLiveSender', () => {
+  it('send posts as the demo identity and returns the messageId as a string', async () => {
+    const postAsDemoUser = vi.fn(async (_t: number, _x: string) => ({ messageId: 5001 }));
+    const s = new TelegramLiveSender({ postAsDemoUser, getHistory: () => [], sleep: noSleep });
+    const res = await s.send('13481', 'hello');
+    expect(res.messageId).toBe('5001');
+    expect(postAsDemoUser).toHaveBeenCalledWith(13481, 'hello');
+  });
+
+  it('send throws on a non-numeric topic id (never silently mis-routes)', async () => {
+    const s = new TelegramLiveSender({ postAsDemoUser: async () => ({ messageId: 1 }), getHistory: () => [], sleep: noSleep });
+    await expect(s.send('not-a-topic', 'x')).rejects.toThrow(/not a numeric topic id/);
+  });
+
+  it('send throws (never fabricates) when no messageId is returned', async () => {
+    const s = new TelegramLiveSender({ postAsDemoUser: async () => ({ messageId: NaN }), getHistory: () => [], sleep: noSleep });
+    await expect(s.send('1', 'x')).rejects.toThrow(/no messageId/);
+  });
+
+  it('awaitReply returns the earliest AGENT reply after the prompt (skips inbound + earlier)', async () => {
+    const history: TelegramHistoryEntry[] = [
+      { messageId: 100, text: 'old agent msg', fromUser: false },
+      { messageId: 200, text: 'the demo prompt', fromUser: true },
+      { messageId: 201, text: 'AGENT REPLY', fromUser: false },
+      { messageId: 202, text: 'later agent', fromUser: false },
+    ];
+    const s = new TelegramLiveSender({ postAsDemoUser: async () => ({ messageId: 200 }), getHistory: () => history, sleep: noSleep });
+    const reply = await s.awaitReply('13481', { timeoutMs: 1000, afterMessageId: '200' });
+    expect(reply!.text).toBe('AGENT REPLY');
+    expect(reply!.messageId).toBe('201');
+  });
+
+  it('awaitReply ignores an inbound user message after the prompt', async () => {
+    const history: TelegramHistoryEntry[] = [{ messageId: 250, text: 'another user', fromUser: true }];
+    let nowVal = 0;
+    const s = new TelegramLiveSender({ postAsDemoUser: async () => ({ messageId: 200 }), getHistory: () => history, sleep: noSleep, pollIntervalMs: 1, now: () => (nowVal += 600) });
+    const reply = await s.awaitReply('1', { timeoutMs: 1000, afterMessageId: '200' });
+    expect(reply).toBeNull();
+  });
+
+  it('awaitReply polls until the agent reply lands', async () => {
+    let calls = 0;
+    const getHistory = () => {
+      calls++;
+      return calls < 3
+        ? [{ messageId: 200, text: 'prompt', fromUser: true }]
+        : [{ messageId: 200, text: 'prompt', fromUser: true }, { messageId: 300, text: 'finally', fromUser: false }];
+    };
+    let nowVal = 0;
+    const s = new TelegramLiveSender({ postAsDemoUser: async () => ({ messageId: 200 }), getHistory, sleep: noSleep, pollIntervalMs: 1, now: () => (nowVal += 100) });
+    const reply = await s.awaitReply('1', { timeoutMs: 100000, afterMessageId: '200' });
+    expect(reply!.text).toBe('finally');
+    expect(calls).toBeGreaterThanOrEqual(3);
+  });
+
+  it('awaitReply returns null on timeout', async () => {
+    let nowVal = 0;
+    const s = new TelegramLiveSender({ postAsDemoUser: async () => ({ messageId: 1 }), getHistory: () => [], sleep: noSleep, pollIntervalMs: 1, now: () => (nowVal += 600) });
+    const reply = await s.awaitReply('1', { timeoutMs: 1000, afterMessageId: '1' });
+    expect(reply).toBeNull();
+  });
+
+  it('supports an async getHistory', async () => {
+    const s = new TelegramLiveSender({
+      postAsDemoUser: async () => ({ messageId: 1 }),
+      getHistory: async () => [{ messageId: 2, text: 'reply', fromUser: false }],
+      sleep: noSleep,
+    });
+    const reply = await s.awaitReply('1', { timeoutMs: 1000, afterMessageId: '1' });
+    expect(reply!.text).toBe('reply');
+  });
+});

--- a/upgrades/next/live-test-telegram-sender.md
+++ b/upgrades/next/live-test-telegram-sender.md
@@ -1,0 +1,14 @@
+# Live-test Telegram sender
+
+## What Changed
+`TelegramLiveSender` — a real Telegram `SurfaceSender` for the live-test harness (spec §5.4), ships DARK (not wired). Posts into a forum topic as a non-agent demo identity (injected post fn), awaits the agent's reply by polling topic history for the earliest `fromUser===false` entry strictly after the sent messageId. Parameterized on the demo-bot post fn + history reader, so only the demo-bot credential + demo group need provisioning.
+
+## Evidence
+- `tests/unit/TelegramLiveSender.test.ts` — 8 tests: post→id, non-numeric-topic throw, no-id throw, earliest-agent-reply-after-prompt, ignores inbound, poll-until-lands, timeout→null, async getHistory.
+- `tsc --noEmit` clean. instar-dev gate green.
+
+## What to Tell Your User
+Nothing yet — internal harness infrastructure, ships dark (no runtime surface, no behavior change).
+
+## Summary of New Capabilities
+None user-facing. Internally: the real Telegram drive for the live-test harness (Telegram half of the Telegram-AND-Slack bar). No new routes, config, or flags.

--- a/upgrades/side-effects/live-test-telegram-sender.md
+++ b/upgrades/side-effects/live-test-telegram-sender.md
@@ -1,0 +1,28 @@
+# Side-Effects Review — Live-test Telegram sender
+
+**Slug:** live-test-telegram-sender
+**Spec:** docs/specs/live-user-channel-proof-standard.md §5.4 (Platform-Sanctioned Automation)
+**Files:** src/core/TelegramLiveSender.ts, tests/unit/TelegramLiveSender.test.ts
+**Posture:** ships DARK — one pure/injectable SurfaceSender, NOT wired into server.ts.
+
+## What it is
+TelegramLiveSender — the real Telegram `SurfaceSender`: posts into a forum topic AS A NON-AGENT identity (an injected demo-bot post fn), then `awaitReply` polls the topic history for the AGENT's reply (the earliest entry with `fromUser === false` strictly after the sent messageId). Same proven shape as SlackLiveSender; parameterized on the demo-bot post fn + the history reader, so only the demo-bot CREDENTIAL + a demo group/topic need provisioning.
+
+## Phase 1 — Principle check (signal vs authority)
+Not a decision point — transport (post + poll). No block/filter/gate. Compliant.
+
+## Phase 4 — Side-effects answers
+1. **Over-block** — n/a. Worst case: the reply match misses a genuine agent reply → scenario records no-reply FAIL. Mitigated by the deterministic `fromUser===false` + strictly-after-messageId match over the full poll window.
+2. **Under-block** — n/a. Risk of matching a STALE agent message mitigated by the `messageId > afterId` strictly-after guard + oldest-first scan (earliest reply after the prompt).
+3. **Level-of-abstraction fit** — correct: the concrete Telegram adapter for the harness's `SurfaceSender` seam. Wraps the demo-bot post + getTopicHistory rather than reinventing them.
+4. **Signal vs authority** — compliant (transport, no authority).
+5. **Interactions** — none yet (dark, unwired). The demo-bot identity is SEPARATE from Echo's own bot, so a demo post can't be confused with Echo's outbound; history read is read-only.
+6. **External surfaces** — when wired, it WILL post a real message into a demo Telegram group via the demo-bot token. THIS increment: no wiring, no external surface. The demo-bot token + demo group is the provisioning dependency; the code is parameterized on it.
+7. **Multi-machine posture** — machine-agnostic (talks to the Telegram Bot API + reads topic history). The cross-machine attribution is the RealChannelDriver's PlacementResponderReader, not this sender. No single-machine assumption.
+8. **Rollback cost** — trivial: dark, unwired. Revert the commit.
+
+## No-deferrals
+The runner route (wires both senders + RealChannelDriver + harness + the multi-machine matrix) is the NEXT tracked increment (CMT-1568, `.instar/plans/live-test-harness-drivers-BUILD.md`), not a deferral. This sender is complete + fully unit-tested (8 tests). The demo-bot/group provisioning is an external-credential dependency tracked in the plan, not a code deferral — the code is parameterized so only the credential is missing.
+
+## Phase 5 — Second-pass review
+Not required: transport adapter, no block/allow/lifecycle/sentinel/gate surface (the Phase-5 triggers).


### PR DESCRIPTION
The Telegram half of the live-test harness's real-channel drive (spec §5.4), ships dark.

**TelegramLiveSender** — a real Telegram `SurfaceSender`: posts into a forum topic as a NON-Echo demo identity (injected post fn so Echo treats it as inbound), then awaits the agent's reply by polling topic history for the earliest `fromUser===false` entry strictly after the sent messageId. Deterministic match; null on timeout; throws (never fabricates) on a non-numeric topic or a missing messageId. Parameterized on the demo-bot post fn + history reader, so only the demo-bot credential + a demo group need provisioning.

This completes the harness's per-surface senders (Slack #1196 + this). Next: the runner route that wires both senders + RealChannelDriver + the harness over the multi-machine matrix.

8 tests green, tsc clean. Independent off main (depends only on SurfaceSender from #1195, merged). Part of CMT-1568. Dark.

🤖 Generated with [Claude Code](https://claude.com/claude-code)