### PR TITLE
feat(live-test): LiveTestRunner — multi-machine transfer capstone orchestrator (CMT-1568)

### DIFF
--- a/.instar/instar-dev-decisions/2026-06-16T10-29-59-085Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-06-16T10-29-59-085Z-unknown.json
@@ -1,0 +1,15 @@
+{
+  "ts": "2026-06-16T10:29:59.085Z",
+  "slug": "unknown",
+  "suggestedTier": 2,
+  "declaredTier": 2,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "new capability: new exported class / subsystem added"
+  ],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 114,
+  "causalAutopsy": null,
+  "verdict": "pass"
+}

--- a/src/core/LiveTestRunner.ts
+++ b/src/core/LiveTestRunner.ts
@@ -1,0 +1,114 @@
+/**
+ * LiveTestRunner — the orchestrator that APPLIES the live-user-channel-proof standard
+ * to the cross-machine transfer (docs/specs/live-user-channel-proof-standard.md §6 —
+ * the first feature held to the bar). It encodes the capstone flow that a user-role
+ * session runs:
+ *
+ *   1. MOVE THE SEAT FIRST — transfer the (throwaway) topic to the target machine.
+ *      If the transfer reports the seat did NOT move, the capstone premise is false and
+ *      we stop loudly (that "ok:true but moved nothing" lie is the original bug — we
+ *      refuse to paper over it).
+ *   2. Then run the LiveTestHarness over a scenario matrix that sends a real message
+ *      through each channel and asserts the reply was served FROM the target machine
+ *      (the `responderMachine` expectation — the deterministic cross-machine proof).
+ *
+ * This module is pure orchestration over the injected harness + an injected `transfer`
+ * action, so it is unit-testable with fakes. The server.ts route wires the real
+ * RealChannelDriver (real senders + placement reader) into the harness and the real
+ * `POST /pool/transfer` into `transfer`.
+ *
+ * Honesty contract: a non-moved seat THROWS (never records a misleading PASS); a moved
+ * seat that then fails to reply-from-target is a normal harness FAIL (recorded with the
+ * responder mismatch). The artifact only ever shows PASS when the seat moved AND the
+ * reply genuinely came from the target machine.
+ */
+
+import type { LiveTestHarness, HarnessMatrix, HarnessScenario } from './LiveTestHarness.js';
+import type { Surface } from './LiveTestArtifactStore.js';
+
+export interface TransferResult {
+  /** Did the seat genuinely move (the honest signal, NOT a bare ok:true)? */
+  seatMoved: boolean;
+  detail?: string;
+}
+
+export interface MultiMachineCapstoneOpts {
+  featureId?: string;
+  /** The machine the seat must move to (e.g. the Mini's machine id) — also the expected responder. */
+  targetMachine: string;
+  /** The throwaway Telegram topic id (also the placement key the responder reader uses). */
+  telegramTopicId: string;
+  /** Optional Slack channel id for the Slack half of the Telegram-AND-Slack bar. */
+  slackChannelId?: string;
+  /** The real transfer action (server.ts injects POST /pool/transfer). MUST report seatMoved honestly. */
+  transfer: (topicId: string, toMachine: string) => Promise<TransferResult>;
+  /** The user message to send (default a benign probe). */
+  message?: string;
+  timeoutMs?: number;
+  runId?: string;
+}
+
+export class LiveTestRunnerError extends Error {
+  constructor(message: string) { super(message); this.name = 'LiveTestRunnerError'; }
+}
+
+export class LiveTestRunner {
+  constructor(private readonly deps: { harness: LiveTestHarness; logger?: (m: string) => void }) {}
+
+  private log(m: string): void { this.deps.logger?.(`[live-test-runner] ${m}`); }
+
+  /**
+   * Run the multi-machine transfer capstone. Throws LiveTestRunnerError if the seat did
+   * not move (the capstone cannot meaningfully run). Otherwise returns the harness
+   * artifact (PASS only when the reply came FROM `targetMachine`).
+   */
+  async runMultiMachineTransferCapstone(opts: MultiMachineCapstoneOpts) {
+    // 1. Move the seat FIRST — and demand the honest seatMoved signal.
+    const t = await opts.transfer(opts.telegramTopicId, opts.targetMachine);
+    if (!t.seatMoved) {
+      throw new LiveTestRunnerError(
+        `transfer to ${opts.targetMachine} did not move the seat (${t.detail ?? 'seatMoved=false'}) — ` +
+        `capstone cannot run (refusing to record a misleading PASS over a non-move)`,
+      );
+    }
+    this.log(`seat moved to ${opts.targetMachine}; running channel scenarios`);
+
+    // 2. Build the matrix — each channel asserts the reply was served FROM targetMachine.
+    const message = (opts.message ?? `live-test probe ${opts.runId ?? ''}`).trim();
+    const surfaces: Surface[] = opts.slackChannelId ? ['telegram', 'slack'] : ['telegram'];
+    const scenarios: HarnessScenario[] = [
+      {
+        id: 'mm-transfer-telegram-reply-from-target',
+        description: `after transfer to ${opts.targetMachine}, the Telegram reply is served FROM it`,
+        surface: 'telegram',
+        riskCategory: 'happy-path',
+        volatility: 'safe',
+        channelId: opts.telegramTopicId,
+        input: message,
+        expect: { replyNotEmpty: true, responderMachine: opts.targetMachine },
+        ...(opts.timeoutMs ? { timeoutMs: opts.timeoutMs } : {}),
+      },
+    ];
+    if (opts.slackChannelId) {
+      scenarios.push({
+        id: 'mm-transfer-slack-reply-from-target',
+        description: `after transfer to ${opts.targetMachine}, the Slack reply is served FROM it (channel parity)`,
+        surface: 'slack',
+        riskCategory: 'channel-parity',
+        volatility: 'safe',
+        channelId: opts.slackChannelId,
+        input: message,
+        expect: { replyNotEmpty: true, responderMachine: opts.targetMachine },
+        ...(opts.timeoutMs ? { timeoutMs: opts.timeoutMs } : {}),
+      });
+    }
+
+    const matrix: HarnessMatrix = {
+      featureId: opts.featureId ?? 'multi-machine-transfer',
+      surfaces,
+      riskCategories: opts.slackChannelId ? ['happy-path', 'channel-parity'] : ['happy-path'],
+      scenarios,
+    };
+    return this.deps.harness.run(matrix, opts.runId ? { runId: opts.runId } : {});
+  }
+}

--- a/tests/unit/LiveTestRunner.test.ts
+++ b/tests/unit/LiveTestRunner.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect, vi } from 'vitest';
+import { mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { LiveTestRunner, LiveTestRunnerError } from '../../src/core/LiveTestRunner.js';
+import { LiveTestHarness, type ChannelDriver } from '../../src/core/LiveTestHarness.js';
+import { LiveTestArtifactStore } from '../../src/core/LiveTestArtifactStore.js';
+
+const sign = (d: string) => `sig:${d}`;
+const verify = (d: string, s: string) => s === `sig:${d}`;
+
+function makeHarness(driver: ChannelDriver) {
+  const dir = mkdtempSync(join(tmpdir(), 'ltr-'));
+  const store = new LiveTestArtifactStore({ stateDir: dir, machineId: 'laptop', signerFingerprint: 'fp', sign, verify });
+  return new LiveTestHarness({ store, driver, runnerFingerprint: 'fp', now: () => 1000, maxReplyRetries: 0 });
+}
+
+/** A fake driver whose reply always reports it was served by `responder`. */
+function driverServedBy(responder: string, replyText = 'hello from the machine'): ChannelDriver {
+  return {
+    isDemoChannel: () => false,
+    send: vi.fn(async () => ({ messageId: 'sent-1' })),
+    awaitReply: vi.fn(async () => ({ text: replyText, messageId: 'r-1', responderMachineId: responder })),
+  };
+}
+
+describe('LiveTestRunner', () => {
+  it('throws (no harness run, no misleading PASS) when the seat did NOT move', async () => {
+    const driver = driverServedBy('m_mini');
+    const runner = new LiveTestRunner({ harness: makeHarness(driver) });
+    const transfer = vi.fn(async () => ({ seatMoved: false, detail: 'placedOwnership=false' }));
+    await expect(
+      runner.runMultiMachineTransferCapstone({ targetMachine: 'm_mini', telegramTopicId: '999', transfer, runId: 'r' }),
+    ).rejects.toBeInstanceOf(LiveTestRunnerError);
+    // The channel was never driven — we refuse to run the scenario over a non-move.
+    expect(driver.send).not.toHaveBeenCalled();
+  });
+
+  it('moves the seat then PASSES when the reply is served FROM the target machine', async () => {
+    const driver = driverServedBy('m_mini');
+    const runner = new LiveTestRunner({ harness: makeHarness(driver) });
+    const transfer = vi.fn(async () => ({ seatMoved: true }));
+    const { artifact } = await runner.runMultiMachineTransferCapstone({
+      targetMachine: 'm_mini', telegramTopicId: '960021', transfer, runId: 'run-1',
+    });
+    expect(transfer).toHaveBeenCalledWith('960021', 'm_mini');
+    expect(artifact.scenarios).toHaveLength(1);
+    expect(artifact.scenarios[0].verdict).toBe('PASS');
+    expect(artifact.scenarios[0].evidence?.responderMachineId).toBe('m_mini');
+  });
+
+  it('FAILS when the seat moved but the reply came from the WRONG machine (the bug this catches)', async () => {
+    const driver = driverServedBy('m_laptop'); // reply still served by the laptop — seat didn't really serve
+    const runner = new LiveTestRunner({ harness: makeHarness(driver) });
+    const transfer = vi.fn(async () => ({ seatMoved: true }));
+    const { artifact } = await runner.runMultiMachineTransferCapstone({
+      targetMachine: 'm_mini', telegramTopicId: '960021', transfer,
+    });
+    expect(artifact.scenarios[0].verdict).toBe('FAIL');
+    expect(artifact.scenarios[0].blockedReason).toMatch(/responder m_laptop ≠ expected m_mini/);
+  });
+
+  it('adds a Slack channel-parity scenario when slackChannelId is given', async () => {
+    const driver = driverServedBy('m_mini');
+    const runner = new LiveTestRunner({ harness: makeHarness(driver) });
+    const transfer = vi.fn(async () => ({ seatMoved: true }));
+    const { artifact } = await runner.runMultiMachineTransferCapstone({
+      targetMachine: 'm_mini', telegramTopicId: '960021', slackChannelId: 'C123', transfer,
+    });
+    expect(artifact.surfaces).toEqual(['telegram', 'slack']);
+    expect(artifact.scenarios.map(s => s.surface)).toEqual(['telegram', 'slack']);
+    expect(artifact.scenarios.every(s => s.verdict === 'PASS')).toBe(true);
+  });
+
+  it('FAILS (empty reply) when the reply is empty even if from the right machine', async () => {
+    const driver = driverServedBy('m_mini', '   ');
+    const runner = new LiveTestRunner({ harness: makeHarness(driver) });
+    const transfer = vi.fn(async () => ({ seatMoved: true }));
+    const { artifact } = await runner.runMultiMachineTransferCapstone({
+      targetMachine: 'm_mini', telegramTopicId: '1', transfer,
+    });
+    expect(artifact.scenarios[0].verdict).toBe('FAIL');
+    expect(artifact.scenarios[0].blockedReason).toMatch(/empty/);
+  });
+});

--- a/upgrades/next/live-test-runner.md
+++ b/upgrades/next/live-test-runner.md
@@ -1,0 +1,14 @@
+# LiveTestRunner — multi-machine transfer capstone orchestrator
+
+## What Changed
+`LiveTestRunner` (spec §6) — the orchestrator that applies the live-test standard to the cross-machine transfer, ships DARK (not wired). It transfers the throwaway topic to the target machine, demands the honest `seatMoved` signal (throws if the seat didn't move — no misleading PASS over the original "ok:true but moved nothing" bug), then runs the LiveTestHarness over a matrix asserting the reply was served FROM the target machine (the cross-machine proof). Pure orchestration over an injected harness + transfer action.
+
+## Evidence
+- `tests/unit/LiveTestRunner.test.ts` — 5 tests: non-move throws (no harness run), moved+reply-from-target→PASS, moved+wrong-machine→FAIL, slack channel-parity scenario added, empty-reply→FAIL.
+- `tsc --noEmit` clean. instar-dev gate green.
+
+## What to Tell Your User
+Nothing yet — internal harness infrastructure, ships dark (no runtime surface). The payoff is the capstone: proving a real Laptop↔Mini seat move with a reply served from the destination, through the real channels.
+
+## Summary of New Capabilities
+None user-facing. Internally: the orchestration that runs the multi-machine transfer capstone and records the signed PASS/FAIL artifact. No new routes, config, or flags (the route wrapper is the next increment).

--- a/upgrades/side-effects/live-test-runner.md
+++ b/upgrades/side-effects/live-test-runner.md
@@ -1,0 +1,28 @@
+# Side-Effects Review — LiveTestRunner (multi-machine transfer capstone orchestrator)
+
+**Slug:** live-test-runner
+**Spec:** docs/specs/live-user-channel-proof-standard.md §6 (apply the standard to multi-machine — the first feature)
+**Files:** src/core/LiveTestRunner.ts, tests/unit/LiveTestRunner.test.ts
+**Posture:** ships DARK — pure orchestration over an injected harness + transfer action. NOT wired into server.ts.
+
+## What it is
+LiveTestRunner encodes the capstone flow: (1) transfer the throwaway topic to the target machine and DEMAND the honest `seatMoved` signal (throw if it didn't move — refuse a misleading PASS over the original "ok:true but moved nothing" bug); (2) run the LiveTestHarness over a matrix that sends a real message per channel and asserts the reply was served FROM the target machine (the `responderMachine` expectation = the cross-machine proof).
+
+## Phase 1 — Principle check (signal vs authority)
+Not a decision gate over agent behavior — it's a test orchestrator. The one control-flow decision (throw on `seatMoved===false`) is a FAIL-LOUD on a test premise, not a runtime authority over messages/sessions. Compliant: it produces a PASS/FAIL artifact (a signal the completion gate already consumes), holds no blocking authority.
+
+## Phase 4 — Side-effects answers
+1. **Over-block** — n/a (no runtime block). Throwing on a non-moved seat is intended: it prevents recording a PASS when the premise failed. The alternative (running anyway) would manufacture a misleading verdict.
+2. **Under-block** — the runner trusts the injected `transfer`'s `seatMoved`. If a transfer LIES (reports seatMoved=true but didn't move), the harness still catches it downstream: the reply's `responderMachine` won't equal target → FAIL. So a lying transfer can't produce a false PASS — the responder assertion is the real backstop.
+3. **Level-of-abstraction fit** — correct: thin orchestration over the merged harness + an injected transfer. It does NOT reimplement transfer or the harness; it sequences them. The server.ts route injects the real `/pool/transfer` + RealChannelDriver.
+4. **Signal vs authority** — compliant (produces an artifact; no authority).
+5. **Interactions** — none yet (dark, unwired). When wired, it CALLS `/pool/transfer` (a real seat move on a THROWAWAY topic) then sends real messages — those surfaces are the server.ts route's review. The runner itself only sequences injected actions.
+6. **External surfaces** — none in this increment (unwired). When wired, the real transfer + sends are external — but scoped to a throwaway topic/demo channel by the caller (the §5.3 isolation in DemoChannelRegistry + the throwaway-topic choice).
+7. **Multi-machine posture** — this IS the multi-machine capstone: it proves a seat moves between machines and the reply is served from the destination. The `responderMachine` assertion (via the driver's placement reader, which reads the authoritative `/pool/placement`) is the cross-machine proof. No single-machine assumption — the whole point is cross-machine.
+8. **Rollback cost** — trivial: dark, unwired. Revert the commit.
+
+## No-deferrals
+The server.ts route (`POST /live-test/run`) that wires the real driver + transfer, and the demo-channel sender-credential provisioning, are the NEXT tracked steps (CMT-1568, `.instar/plans/live-test-harness-drivers-BUILD.md` GATE 1/2), not deferrals of this orchestrator. This module is complete + unit-tested (5 tests: non-move throws, moved+reply-from-target PASS, wrong-machine FAIL, slack-parity scenario, empty-reply FAIL).
+
+## Phase 5 — Second-pass review
+Borderline (it has a control-flow throw), but it adds no runtime authority over messages/sessions/lifecycle — it orchestrates a test and records an artifact. The genuine cross-machine safety (no false PASS) rests on the harness's responder assertion (reviewed in #1195/#1196), which this can't bypass. Not required; noted.


### PR DESCRIPTION
The orchestrator that applies the live-test standard to the cross-machine transfer (spec §6), ships dark.

**LiveTestRunner** runs the capstone flow a user-role session executes:
1. Transfer the throwaway topic to the target machine and DEMAND the honest `seatMoved` signal — throw if the seat didn't move (refuse a misleading PASS over the original "ok:true but moved nothing" bug).
2. Run the LiveTestHarness over a matrix that sends a real message per channel and asserts the reply was served FROM the target machine (the `responderMachine` expectation = the deterministic cross-machine proof).

A lying transfer (seatMoved=true but didn't move) still can't produce a false PASS — the reply's responderMachine won't match the target → FAIL. Pure orchestration over an injected harness + transfer action.

5 tests green, tsc clean. Independent off main. Next: the thin `POST /live-test/run` route (wires the real driver + /pool/transfer) + demo-channel sender provisioning. Part of CMT-1568. Dark.

🤖 Generated with [Claude Code](https://claude.com/claude-code)