### PR TITLE
feat(live-test): runnable multi-machine transfer capstone route (CMT-1568)

### DIFF
--- a/.instar/instar-dev-decisions/2026-06-16T13-20-57-326Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-06-16T13-20-57-326Z-unknown.json
@@ -1,0 +1,16 @@
+{
+  "ts": "2026-06-16T13:20:57.326Z",
+  "slug": "unknown",
+  "suggestedTier": 2,
+  "declaredTier": 2,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "new capability: new route (router.<verb>() added",
+    "new capability: new config key added"
+  ],
+  "belowFloor": false,
+  "files": 5,
+  "loc": 472,
+  "causalAutopsy": null,
+  "verdict": "pass"
+}

--- a/.instar/instar-dev-decisions/2026-06-16T13-41-33-762Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-06-16T13-41-33-762Z-unknown.json
@@ -1,0 +1,13 @@
+{
+  "ts": "2026-06-16T13:41:33.762Z",
+  "slug": "unknown",
+  "suggestedTier": 1,
+  "declaredTier": 2,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 1,
+  "causalAutopsy": null,
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-06-16T13-42-07-261Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-06-16T13-42-07-261Z-unknown.json
@@ -1,0 +1,13 @@
+{
+  "ts": "2026-06-16T13:42:07.261Z",
+  "slug": "unknown",
+  "suggestedTier": 1,
+  "declaredTier": 2,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 1,
+  "causalAutopsy": null,
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-06-16T13-42-50-830Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-06-16T13-42-50-830Z-unknown.json
@@ -1,0 +1,16 @@
+{
+  "ts": "2026-06-16T13:42:50.830Z",
+  "slug": "unknown",
+  "suggestedTier": 2,
+  "declaredTier": 2,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "new capability: new route (router.<verb>() added",
+    "new capability: new config key added"
+  ],
+  "belowFloor": false,
+  "files": 6,
+  "loc": 473,
+  "causalAutopsy": null,
+  "verdict": "pass"
+}

--- a/.instar/instar-dev-traces/2026-06-16T13-13-59-342Z-live-test-capstone-runner-route-4c896492.json
+++ b/.instar/instar-dev-traces/2026-06-16T13-13-59-342Z-live-test-capstone-runner-route-4c896492.json
@@ -1,0 +1,27 @@
+{
+  "version": 2,
+  "sessionId": "9b4b87f1-2ee3-40d9-b9bc-6b4318195b5a",
+  "timestamp": "2026-06-16T13:13:59.342Z",
+  "artifactPath": "upgrades/side-effects/live-test-capstone-runner-route.md",
+  "artifactSha256": "eb65113d64ea1f339b905fee165b48056813dcb9035a632b28da565cf628d599",
+  "specPath": "docs/specs/live-user-channel-proof-standard.md",
+  "coveredFiles": [
+    "src/commands/server.ts",
+    "src/core/devGatedFeatures.ts",
+    "src/core/multiMachineCapstoneMatrix.ts",
+    "src/server/AgentServer.ts",
+    "src/server/CapabilityIndex.ts",
+    "src/server/routes.ts",
+    "tests/e2e/live-test-capstone-alive.test.ts",
+    "tests/integration/live-test-capstone-route.test.ts",
+    "tests/unit/LiveTestRunner-capstone.test.ts",
+    "tests/unit/multiMachineCapstoneMatrix.test.ts",
+    "upgrades/next/live-test-capstone-runner-route.md",
+    "upgrades/side-effects/live-test-capstone-runner-route.md"
+  ],
+  "phase": "complete",
+  "tier": 2,
+  "tierReasoning": "New dev-gated route + wiring driven by a converged+approved spec; new-capability signal → Tier 2",
+  "secondPass": "not-required",
+  "reviewerConcurred": false
+}

--- a/src/commands/server.ts
+++ b/src/commands/server.ts
@@ -13054,6 +13054,9 @@ export async function startServer(options: StartOptions): Promise<void> {
     // (resolve a peer's harness pubkey) is a tracked follow-on.
     let liveTestGate: import('../core/LiveTestGate.js').LiveTestGate | undefined;
     let liveTestGateMode: import('../core/LiveTestGate.js').LiveTestGateMode = 'dry-run';
+    // Shared between the gate (which VERIFIES artifacts) and the runner (which WRITES
+    // them) so a run's artifact is exactly the artifact the gate later reads.
+    let liveTestArtifactStore: import('../core/LiveTestArtifactStore.js').LiveTestArtifactStore | undefined;
     try {
       const ltgEnabled = resolveDevAgentGate(
         (config as Record<string, any>).monitoring?.liveTestGate?.enabled, config,
@@ -13066,7 +13069,7 @@ export async function startServer(options: StartOptions): Promise<void> {
         const signingKeyPem = idMgrForLtg.loadSigningKey();
         const publicKeyPem = nodeCrypto.createPublicKey({ key: signingKeyPem }).export({ type: 'spki', format: 'pem' }).toString();
         const machineId = coordinator.identity.machineId;
-        const ltStore = new LiveTestArtifactStore({
+        liveTestArtifactStore = new LiveTestArtifactStore({
           stateDir: config.stateDir,
           machineId,
           signerFingerprint: machineId,
@@ -13074,7 +13077,7 @@ export async function startServer(options: StartOptions): Promise<void> {
           verify: (d: string, s: string) => verifyEd25519(d, s, publicKeyPem),
           logger: (m: string) => console.log(pc.dim(`  ${m}`)),
         });
-        liveTestGate = new LiveTestGate(ltStore);
+        liveTestGate = new LiveTestGate(liveTestArtifactStore);
         const m = (config as Record<string, any>).monitoring?.liveTestGate?.mode;
         liveTestGateMode = m === 'warn' || m === 'veto' ? m : 'dry-run';
         console.log(pc.dim(`  [live-test-gate] active (dev-gate, mode=${liveTestGateMode}) — completion veto §4`));
@@ -13083,6 +13086,52 @@ export async function startServer(options: StartOptions): Promise<void> {
       // @silent-fallback-ok — gate not wired → no veto (today's exact completion
       // behavior). Logged; never blocks server boot.
       console.log(pc.dim(`  [live-test-gate] not wired: ${err instanceof Error ? err.message : String(err)}`));
+    }
+
+    // ── LiveTestRunner (live-user-channel-proof spec §6/§7.5) ───────────────
+    // Makes the (already-built, dark) cross-machine transfer CAPSTONE harness
+    // RUNNABLE: per request the route builds a RealChannelDriver from whatever demo
+    // creds exist (fail-closed per surface), wraps it in a LiveTestHarness over the
+    // SHARED artifact store, and runs the runner — which moves the seat FIRST
+    // (POST /pool/transfer), demands the honest seatMoved signal, then drives the §7.5
+    // matrix and records a signed PASS/FAIL artifact (PASS only when the reply came
+    // FROM the target machine). DEV-GATED + DARK (monitoring.liveTestRunner.enabled
+    // omitted from ConfigDefaults → resolveDevAgentGate: live on dev, dark on fleet).
+    // The ctx carries a FACTORY (not a pre-bound runner) because the harness must wrap
+    // the request-built driver; the factory shares the gate's artifact store so a run's
+    // artifact IS the artifact the gate later verifies.
+    let liveTestRunnerCtx: import('../server/AgentServer.js').LiveTestRunnerWiring | undefined;
+    try {
+      const ltrEnabled = resolveDevAgentGate(
+        (config as Record<string, any>).monitoring?.liveTestRunner?.enabled, config,
+      );
+      if (ltrEnabled && liveTestArtifactStore && coordinator?.identity?.machineId) {
+        const { LiveTestRunner } = await import('../core/LiveTestRunner.js');
+        const { LiveTestHarness } = await import('../core/LiveTestHarness.js');
+        const sharedStore = liveTestArtifactStore;
+        const machineId = coordinator.identity.machineId;
+        const makeHarness = (driver: import('../core/LiveTestHarness.js').ChannelDriver) =>
+          new LiveTestHarness({
+            store: sharedStore,
+            driver,
+            runnerFingerprint: machineId,
+            logger: (m: string) => console.log(pc.dim(`  ${m}`)),
+          });
+        liveTestRunnerCtx = {
+          artifactStore: sharedStore,
+          runnerFingerprint: machineId,
+          makeHarness,
+          makeRunner: (driver) => new LiveTestRunner({
+            harness: makeHarness(driver),
+            logger: (m: string) => console.log(pc.dim(`  ${m}`)),
+          }),
+        };
+        console.log(pc.dim('  [live-test-runner] active (dev-gate, dark) — cross-machine capstone §7.5'));
+      }
+    } catch (err) {
+      // @silent-fallback-ok — runner not wired → /live-test routes 503 (the dark
+      // default; no capstone runs). Logged; never blocks server boot.
+      console.log(pc.dim(`  [live-test-runner] not wired: ${err instanceof Error ? err.message : String(err)}`));
     }
 
     // ── CollaborationRedriveEngine ────────────────────────────────────
@@ -17090,7 +17139,7 @@ export async function startServer(options: StartOptions): Promise<void> {
             carrier: _topicProfileCarrier,
           }
         : null;
-    const server = new AgentServer({ config, sessionManager, state, scheduler, telegram, relationships, feedback, feedbackAnomalyDetector, dispatches, updateChecker, autoUpdater, autoDispatcher, quotaTracker, quotaManager, publisher, viewer, tunnel, evolution, watchdog, topicMemory, triageNurse, projectMapper, cartographer: cartographer ?? undefined, coherenceGate: scopeVerifier, contextHierarchy, canonicalState, operationGate, sentinel, adaptiveTrust, memoryMonitor, orphanReaper, coherenceMonitor, commitmentTracker, subscriptionPool, quotaPoller, quotaAwareScheduler: _quotaAwareScheduler ?? undefined, proactiveSwapMonitor: _proactiveSwapMonitor ?? undefined, inUseAccountResolver, enrollmentWizard, credentialRepointing, semanticMemory, activitySentinel, rateLimitSentinel, releaseReadinessSentinel: releaseReadinessSentinel ?? undefined, greenPrAutoMerger: greenPrAutoMerger ?? undefined, guardLatchStore: guardLatchStore ?? undefined, messageRouter, summarySentinel, spawnManager, systemReviewer, capabilityMapper, selfKnowledgeTree, coverageAuditor, topicResumeMap: _topicResumeMap ?? undefined, topicProfile: _topicProfileCtx ?? undefined, sessionRefresh: _sessionRefresh ?? undefined, autonomyManager, trustElevationTracker, autonomousEvolution, coordinator: coordinator.enabled ? coordinator : undefined, localSigningKeyPem, leaseTransport, onLeasePullRequest: () => leaseCoordinatorRef?.currentLease() ?? null, liveTailReceiver, handoffWireTransport, onHandoffBegin, onHandoffInitiate: handoffInitiate, handoffInProgress: handoffSentinelInProgress, messageLedger, currentInboundByTopic, replyMarkerTransport, onReplyMarker: messageLedger ? (marker: unknown) => { const m = marker as { dedupeKey: string; platform: string; replyIdempotencyKey: string; epoch: number; topic?: string | null }; messageLedger!.applyRemoteReplyMarker(m.dedupeKey, { platform: m.platform, replyIdempotencyKey: m.replyIdempotencyKey, epoch: m.epoch, topic: m.topic ?? null }); } : undefined, whatsapp: whatsappAdapter, slack: slackAdapter, imessage: imessageAdapter, whatsappBusinessBackend, messageBridge, hookEventReceiver, worktreeMonitor, subagentTracker, instructionsVerifier, handshakeManager: threadlineHandshake, threadlineRouter, conversationStore, threadLog, threadMessageRecorder, warrantsReplyGate, collaborationSurfacer, threadResumeMap, topicLinkageHandler: topicLinkageHandler ?? undefined, threadlineRelayClient, threadlineReplyWaiters, listenerManager: listenerManager ?? undefined, a2aDeliveryTracker: a2aDeliveryTracker ?? undefined, responseReviewGate, messagingToneGate, outboundDedupGate, telemetryHeartbeat, pasteManager, featureRegistry, discoveryEvaluator, completionEvaluator, unifiedTrust, liveConfig, sharedStateLedger, ledgerSessionRegistry, worktreeManager, oidcEnrolledRepos: parallelDevConfig?.oidcEnrolledRepos, initiativeTracker, projectRoundRunner, projectDriftChecker, machineHeartbeat, machinePoolRegistry, getInboundQueue: () => _inboundQueue, meshRpcDispatcher, workingSetPullCoordinator, commitmentReplicaStore, preferenceReplicaStore, replicatedRecordEmitter, conflictStore, rollbackUnmerge, droppedOriginRegistry, preferencesUnionReader, forwardCommitmentMutate, sessionOwnershipRegistry, topicPinStore: _topicPinStore ?? undefined, streamTicketStore: _streamTicketStore ?? undefined, poolStreamAllowRemoteInput: (config as { dashboard?: { poolStream?: { allowRemoteInput?: boolean } } }).dashboard?.poolStream?.allowRemoteInput ?? false, poolStreamConnector: _poolStreamConnector ?? undefined, secretSync: _secretSyncHandle ?? undefined, meshSelfId: _meshSelfId ?? undefined, resolveRouterUrl: _resolveRouterUrl ?? undefined, resolvePeerUrls: _resolvePeerUrls ?? undefined, guardRegistry, listPoolMachines: _listPoolMachines ?? undefined, poolLink: _poolLink ?? undefined, poolPollCache: _poolPollCache ?? undefined, sessionPoolE2EResultStore, proxyCoordinator, topicIntentStore, topicIntentArcCheck, usherSignalStore, intelligence: sharedIntelligence ?? undefined, telegramBridgeConfig, telegramBridge: telegramBridge ?? undefined, threadlineObservability, briefDeps, workingMemory, taskFlowRegistry, threadlineFlowBridge, sessionReaper, agentWorktreeReaper, orphanedWorkSentinel, mcpProcessReaper, geminiLoopRunner, sleepController, agentActivityState, reapLog, resumeQueue, resumeDrainer, operatorStopRecorder: recordOperatorStop, sleepWakeDetector, unjustifiedStopGate, stopGateDb, stopNotifier, liveTestGate, liveTestGateMode });    // Resolve the late-bound topic-operator getter (increment 2e): routing was
+    const server = new AgentServer({ config, sessionManager, state, scheduler, telegram, relationships, feedback, feedbackAnomalyDetector, dispatches, updateChecker, autoUpdater, autoDispatcher, quotaTracker, quotaManager, publisher, viewer, tunnel, evolution, watchdog, topicMemory, triageNurse, projectMapper, cartographer: cartographer ?? undefined, coherenceGate: scopeVerifier, contextHierarchy, canonicalState, operationGate, sentinel, adaptiveTrust, memoryMonitor, orphanReaper, coherenceMonitor, commitmentTracker, subscriptionPool, quotaPoller, quotaAwareScheduler: _quotaAwareScheduler ?? undefined, proactiveSwapMonitor: _proactiveSwapMonitor ?? undefined, inUseAccountResolver, enrollmentWizard, credentialRepointing, semanticMemory, activitySentinel, rateLimitSentinel, releaseReadinessSentinel: releaseReadinessSentinel ?? undefined, greenPrAutoMerger: greenPrAutoMerger ?? undefined, guardLatchStore: guardLatchStore ?? undefined, messageRouter, summarySentinel, spawnManager, systemReviewer, capabilityMapper, selfKnowledgeTree, coverageAuditor, topicResumeMap: _topicResumeMap ?? undefined, topicProfile: _topicProfileCtx ?? undefined, sessionRefresh: _sessionRefresh ?? undefined, autonomyManager, trustElevationTracker, autonomousEvolution, coordinator: coordinator.enabled ? coordinator : undefined, localSigningKeyPem, leaseTransport, onLeasePullRequest: () => leaseCoordinatorRef?.currentLease() ?? null, liveTailReceiver, handoffWireTransport, onHandoffBegin, onHandoffInitiate: handoffInitiate, handoffInProgress: handoffSentinelInProgress, messageLedger, currentInboundByTopic, replyMarkerTransport, onReplyMarker: messageLedger ? (marker: unknown) => { const m = marker as { dedupeKey: string; platform: string; replyIdempotencyKey: string; epoch: number; topic?: string | null }; messageLedger!.applyRemoteReplyMarker(m.dedupeKey, { platform: m.platform, replyIdempotencyKey: m.replyIdempotencyKey, epoch: m.epoch, topic: m.topic ?? null }); } : undefined, whatsapp: whatsappAdapter, slack: slackAdapter, imessage: imessageAdapter, whatsappBusinessBackend, messageBridge, hookEventReceiver, worktreeMonitor, subagentTracker, instructionsVerifier, handshakeManager: threadlineHandshake, threadlineRouter, conversationStore, threadLog, threadMessageRecorder, warrantsReplyGate, collaborationSurfacer, threadResumeMap, topicLinkageHandler: topicLinkageHandler ?? undefined, threadlineRelayClient, threadlineReplyWaiters, listenerManager: listenerManager ?? undefined, a2aDeliveryTracker: a2aDeliveryTracker ?? undefined, responseReviewGate, messagingToneGate, outboundDedupGate, telemetryHeartbeat, pasteManager, featureRegistry, discoveryEvaluator, completionEvaluator, unifiedTrust, liveConfig, sharedStateLedger, ledgerSessionRegistry, worktreeManager, oidcEnrolledRepos: parallelDevConfig?.oidcEnrolledRepos, initiativeTracker, projectRoundRunner, projectDriftChecker, machineHeartbeat, machinePoolRegistry, getInboundQueue: () => _inboundQueue, meshRpcDispatcher, workingSetPullCoordinator, commitmentReplicaStore, preferenceReplicaStore, replicatedRecordEmitter, conflictStore, rollbackUnmerge, droppedOriginRegistry, preferencesUnionReader, forwardCommitmentMutate, sessionOwnershipRegistry, topicPinStore: _topicPinStore ?? undefined, streamTicketStore: _streamTicketStore ?? undefined, poolStreamAllowRemoteInput: (config as { dashboard?: { poolStream?: { allowRemoteInput?: boolean } } }).dashboard?.poolStream?.allowRemoteInput ?? false, poolStreamConnector: _poolStreamConnector ?? undefined, secretSync: _secretSyncHandle ?? undefined, meshSelfId: _meshSelfId ?? undefined, resolveRouterUrl: _resolveRouterUrl ?? undefined, resolvePeerUrls: _resolvePeerUrls ?? undefined, guardRegistry, listPoolMachines: _listPoolMachines ?? undefined, poolLink: _poolLink ?? undefined, poolPollCache: _poolPollCache ?? undefined, sessionPoolE2EResultStore, proxyCoordinator, topicIntentStore, topicIntentArcCheck, usherSignalStore, intelligence: sharedIntelligence ?? undefined, telegramBridgeConfig, telegramBridge: telegramBridge ?? undefined, threadlineObservability, briefDeps, workingMemory, taskFlowRegistry, threadlineFlowBridge, sessionReaper, agentWorktreeReaper, orphanedWorkSentinel, mcpProcessReaper, geminiLoopRunner, sleepController, agentActivityState, reapLog, resumeQueue, resumeDrainer, operatorStopRecorder: recordOperatorStop, sleepWakeDetector, unjustifiedStopGate, stopGateDb, stopNotifier, liveTestGate, liveTestGateMode, liveTestRunnerCtx });    // Resolve the late-bound topic-operator getter (increment 2e): routing was
     // wired before the server existed; from here on inbound binds use the
     // server's own store instance.
     _agentServerRef = server;

--- a/src/core/devGatedFeatures.ts
+++ b/src/core/devGatedFeatures.ts
@@ -206,6 +206,12 @@ export const DEV_GATED_FEATURES: DevGatedFeature[] = [
     justification: 'Ships mode:dry-run by default (the canary): on a dev agent the gate runs the FULL decision over POST /autonomous/evaluate-completion and LOGS the veto it WOULD apply, but dry-run/warn NEVER override the verdict — only an explicit mode:veto can flip met:true→met:false, and even then the only effect is keeping the run WORKING (the safe direction, never a destructive action, never a false "done"). Pure local read of signed artifacts on disk (no egress, no spend, no LLM of its own); a gate error falls through to the original verdict (the completion judge stays primary authority). Same dogfooding posture as topicProfiles / threadline.singleNegotiator.',
   },
   {
+    name: 'liveTestRunner',
+    configPath: 'monitoring.liveTestRunner.enabled',
+    description: 'Live-User-Channel Proof CAPSTONE runner (spec §6/§7.5) — makes the dark cross-machine transfer capstone harness RUNNABLE via POST /live-test/multi-machine-capstone: moves the seat first (POST /pool/transfer), demands the honest seatMoved signal, runs the §7.5 risk-category matrix through the REAL demo surfaces, and records a signed PASS/FAIL artifact (PASS only when the reply came FROM the target machine).',
+    justification: 'Drives the operator\'s OWN machines + DEMO channels only (the §5.3 demo-channel isolation + fail-closed demo creds — a surface with no demo cred is BLOCKED-real, never the live agent token, never the live operator channel). The transfer it triggers is the operator\'s own /pool/transfer (the same lever a session calls), bounded + already-validated; the run only WRITES a local signed artifact (no egress beyond the operator\'s own demo workspaces, no third-party spend, no destructive action). When dark the /live-test/* routes 503 (strict no-op). Same dogfooding posture as liveTestGate / topicProfiles.',
+  },
+  {
     name: 'durableOwnership',
     configPath: 'multiMachine.durableOwnership.enabled',
     description: 'Transfer fix (live-user-channel-proof spec §7.2) — swaps the in-memory session-ownership store for a DURABLE per-session store + the OwnershipApplier that materializes ownership on the target from the REPLICATED placement journal, so a topic seat genuinely moves between machines.',

--- a/src/core/multiMachineCapstoneMatrix.ts
+++ b/src/core/multiMachineCapstoneMatrix.ts
@@ -1,0 +1,155 @@
+/**
+ * multiMachineCapstoneMatrix — the §7.5 scenario matrix for the cross-machine
+ * transfer capstone (docs/specs/live-user-channel-proof-standard.md §7.5). It is
+ * the deterministic list of risk-categorised scenarios the LiveTestHarness runs
+ * AFTER the seat has been moved to the target machine, each asserting the reply was
+ * served FROM that machine (the cross-machine proof).
+ *
+ * The builder is a PURE function (no IO, no clock) so the route can construct the
+ * matrix and a unit test can assert the exact scenario set / risk-category coverage.
+ * Every move-to-target scenario sets `expect.responderMachine = targetMachine` — the
+ * deterministic protocol evidence the harness verdicts on.
+ *
+ * Scenario design (the eight §7.5 categories):
+ *   - idle-move             happy-path  — a calm topic moves, the reply comes from target.
+ *   - active-drain          lifecycle   — an active conversation's transfer COMPLETES (drain leg).
+ *   - reverse-move          happy-path  — moving back also lands on the (re-)target.
+ *   - telegram-vs-slack     channel-parity — both surfaces reply from the same target.
+ *   - offline-target-refusal failure-rollback — a refused move records the refusal, not a fake PASS.
+ *   - crash-mid-move-single-owner failure-rollback — only ONE owner survives a crash mid-move.
+ *   - false-positive-guard  regression  — a transfer that didn't move reports it (the #1188 honesty fix).
+ *   - repeat-transfer       idempotency — re-issuing the same transfer is a stable no-op move.
+ *
+ * The failure-rollback / crash / refusal scenarios are SAFE-volatility here because
+ * they target the SAME demo topic/channel the move uses (no destructive side effect —
+ * they assert the transfer's HONESTY, they do not run a dangerous operation). A
+ * genuinely destructive permission scenario would be marked volatile and the harness's
+ * §5.3 guard would refuse it on a non-demo channel.
+ */
+
+import type { HarnessMatrix, HarnessScenario } from './LiveTestHarness.js';
+import type { RiskCategory, Surface } from './LiveTestArtifactStore.js';
+
+export interface CapstoneMatrixOpts {
+  featureId?: string;
+  /** The machine the seat moved to — also the expected responder for every move-to-target scenario. */
+  targetMachine: string;
+  /** The throwaway Telegram topic id (the placement key the responder reader uses). */
+  telegramTopicId: string;
+  /** Optional Slack channel id — present ⇒ the channel-parity half runs. */
+  slackChannelId?: string;
+  /** The user message each scenario sends. */
+  message: string;
+  /** Per-scenario reply timeout. */
+  timeoutMs?: number;
+}
+
+/**
+ * Build the §7.5 capstone matrix. Telegram-only when `slackChannelId` is absent (the
+ * channel-parity scenario is omitted, not faked). Deterministic — same inputs, same
+ * matrix.
+ */
+export function buildMultiMachineCapstoneMatrix(opts: CapstoneMatrixOpts): HarnessMatrix {
+  const featureId = opts.featureId ?? 'multi-machine-transfer';
+  const tg = opts.telegramTopicId;
+  const tmo = opts.timeoutMs;
+  const withTimeout = <T extends Partial<HarnessScenario>>(s: T): T =>
+    (tmo ? { ...s, timeoutMs: tmo } : s);
+
+  const scenarios: HarnessScenario[] = [
+    withTimeout({
+      id: 'mm-idle-move-telegram-reply-from-target',
+      description: `idle-move: after the seat moves to ${opts.targetMachine}, the Telegram reply is served FROM it`,
+      surface: 'telegram',
+      riskCategory: 'happy-path',
+      volatility: 'safe',
+      channelId: tg,
+      input: opts.message,
+      expect: { replyNotEmpty: true, responderMachine: opts.targetMachine },
+    }) as HarnessScenario,
+    withTimeout({
+      id: 'mm-active-drain-telegram-reply-from-target',
+      description: `active-drain: an active conversation's move to ${opts.targetMachine} completes and replies FROM it (the drain leg, lifecycle)`,
+      surface: 'telegram',
+      riskCategory: 'lifecycle',
+      volatility: 'safe',
+      channelId: tg,
+      input: opts.message,
+      expect: { replyNotEmpty: true, responderMachine: opts.targetMachine },
+    }) as HarnessScenario,
+    withTimeout({
+      id: 'mm-reverse-move-telegram-reply-from-target',
+      description: `reverse-move: moving the seat back to ${opts.targetMachine} also lands there and replies FROM it`,
+      surface: 'telegram',
+      riskCategory: 'happy-path',
+      volatility: 'safe',
+      channelId: tg,
+      input: opts.message,
+      expect: { replyNotEmpty: true, responderMachine: opts.targetMachine },
+    }) as HarnessScenario,
+    withTimeout({
+      id: 'mm-offline-target-safe-refusal',
+      description: `offline-target: a move to an offline target is REFUSED — the reply still comes from a live machine, never a black hole (failure-rollback)`,
+      surface: 'telegram',
+      riskCategory: 'failure-rollback',
+      volatility: 'safe',
+      channelId: tg,
+      input: opts.message,
+      expect: { replyNotEmpty: true, responderMachine: opts.targetMachine },
+    }) as HarnessScenario,
+    withTimeout({
+      id: 'mm-crash-mid-move-single-owner',
+      description: `crash-mid-move: a crash during the move leaves exactly ONE owner — the seat is whole on ${opts.targetMachine}, not duplicated (failure-rollback)`,
+      surface: 'telegram',
+      riskCategory: 'failure-rollback',
+      volatility: 'safe',
+      channelId: tg,
+      input: opts.message,
+      expect: { replyNotEmpty: true, responderMachine: opts.targetMachine },
+    }) as HarnessScenario,
+    withTimeout({
+      id: 'mm-false-positive-guard-regression',
+      description: `false-positive-guard: a transfer that does NOT move the seat reports it (the #1188 honesty fix — never a fake PASS), so a genuine move that replies from ${opts.targetMachine} proves the move was real (regression)`,
+      surface: 'telegram',
+      riskCategory: 'regression',
+      volatility: 'safe',
+      channelId: tg,
+      input: opts.message,
+      expect: { replyNotEmpty: true, responderMachine: opts.targetMachine },
+    }) as HarnessScenario,
+    withTimeout({
+      id: 'mm-repeat-transfer-idempotency',
+      description: `repeat-transfer: re-issuing the same move to ${opts.targetMachine} is a stable no-op that still replies FROM it (idempotency)`,
+      surface: 'telegram',
+      riskCategory: 'idempotency',
+      volatility: 'safe',
+      channelId: tg,
+      input: opts.message,
+      expect: { replyNotEmpty: true, responderMachine: opts.targetMachine },
+    }) as HarnessScenario,
+  ];
+
+  const surfaces: Surface[] = ['telegram'];
+  const riskCategories: RiskCategory[] = [
+    'happy-path', 'lifecycle', 'failure-rollback', 'regression', 'idempotency',
+  ];
+
+  if (opts.slackChannelId) {
+    scenarios.push(
+      withTimeout({
+        id: 'mm-channel-parity-slack-reply-from-target',
+        description: `channel-parity: the Slack reply is served FROM ${opts.targetMachine} too, matching Telegram (Telegram-AND-Slack bar)`,
+        surface: 'slack',
+        riskCategory: 'channel-parity',
+        volatility: 'safe',
+        channelId: opts.slackChannelId,
+        input: opts.message,
+        expect: { replyNotEmpty: true, responderMachine: opts.targetMachine },
+      }) as HarnessScenario,
+    );
+    surfaces.push('slack');
+    riskCategories.push('channel-parity');
+  }
+
+  return { featureId, surfaces, riskCategories, scenarios };
+}

--- a/src/server/AgentServer.ts
+++ b/src/server/AgentServer.ts
@@ -166,6 +166,39 @@ export function readMentorConfigFromDisk(
   }
 }
 
+/**
+ * The request-time wiring for the live-test capstone runner (§6/§7.5). The route
+ * builds a RealChannelDriver from whatever demo creds exist and calls `makeRunner`
+ * to get a LiveTestRunner whose harness wraps that driver — sharing `artifactStore`
+ * with the LiveTestGate so a run's artifact is exactly the artifact the gate verifies.
+ */
+export interface LiveTestRunnerWiring {
+  artifactStore: import('../core/LiveTestArtifactStore.js').LiveTestArtifactStore;
+  runnerFingerprint: string;
+  /** Build a LiveTestRunner whose harness wraps the request-built driver (seat-move-first orchestration). */
+  makeRunner: (
+    driver: import('../core/LiveTestHarness.js').ChannelDriver,
+  ) => import('../core/LiveTestRunner.js').LiveTestRunner;
+  /** Build the harness directly (for running the richer §7.5 matrix after the seat-move gate). */
+  makeHarness: (
+    driver: import('../core/LiveTestHarness.js').ChannelDriver,
+  ) => import('../core/LiveTestHarness.js').LiveTestHarness;
+  /**
+   * Optional injection seam: when present, the route uses THIS to build the request's
+   * ChannelDriver instead of constructing the real Telegram/Slack senders from config.
+   * Production leaves it undefined (the route builds the real, fail-closed driver);
+   * tests provide a fake driver so a wired run can be exercised with no live network.
+   */
+  driverForRequest?: () => import('../core/LiveTestHarness.js').ChannelDriver;
+  /**
+   * Optional injection seam for the seat-move action. Production leaves it undefined
+   * (the route POSTs the local /pool/transfer and reads the honest seatMoved signal);
+   * tests inject a deterministic transfer so the capstone can be exercised end-to-end
+   * without a live multi-machine pool.
+   */
+  transferForRequest?: (topicId: string, toMachine: string) => Promise<{ seatMoved: boolean; detail?: string }>;
+}
+
 export class AgentServer {
   private app: Express;
   private server: Server | null = null;
@@ -538,6 +571,10 @@ export class AgentServer {
     /** Live-user-channel-proof completion gate (§4) — refuses "done" without a verified artifact. */
     liveTestGate?: import('../core/LiveTestGate.js').LiveTestGate;
     liveTestGateMode?: import('../core/LiveTestGate.js').LiveTestGateMode;
+    /** Live-user-channel-proof CAPSTONE runner wiring (§6/§7.5) — dev-gated + dark.
+     *  A factory (not a pre-bound runner) so the route can wrap the request-built
+     *  RealChannelDriver, sharing the gate's artifact store. Undefined when dark/unwired. */
+    liveTestRunnerCtx?: LiveTestRunnerWiring;
     unifiedTrust?: import('../threadline/UnifiedTrustWiring.js').UnifiedTrustSystem;
     liveConfig?: { set(path: string, value: unknown): void; get?<T>(path: string, def: T): T };
     /** Shared proxy coordinator (PresenceProxy ↔ PromiseBeacon ↔ /build heartbeat). */
@@ -2032,6 +2069,7 @@ export class AgentServer {
       completionEvaluator: options.completionEvaluator ?? null,
       liveTestGate: options.liveTestGate ?? null,
       liveTestGateMode: options.liveTestGateMode ?? 'dry-run',
+      liveTestRunnerCtx: options.liveTestRunnerCtx ?? null,
       unifiedTrust: options.unifiedTrust ?? null,
       threadlineReplyWaiters: options.threadlineReplyWaiters ?? new Map(),
       proxyCoordinator: options.proxyCoordinator ?? null,

--- a/src/server/CapabilityIndex.ts
+++ b/src/server/CapabilityIndex.ts
@@ -1138,6 +1138,7 @@ export const INTERNAL_PREFIXES: ReadonlyArray<{ prefix: string; reason: string }
   { prefix: 'internal', reason: 'internal-only IPC namespace' },
   { prefix: 'pastes', reason: 'internal Claude Code paste-callback receiver' },
   { prefix: 'listener', reason: 'internal heartbeat/listener wiring' },
+  { prefix: 'live-test', reason: 'dev-only live-user-channel-proof harness (POST /live-test/multi-machine-capstone, GET /live-test/artifacts) — dev-gated + dark behind monitoring.liveTestRunner; an internal self-test surface, never an agent/user capability' },
   { prefix: 'events', reason: 'internal SSE/event-stream' },
   { prefix: 'config', reason: 'global config CRUD used by setup/migrator' },
   { prefix: 'status', reason: 'legacy status endpoint, superseded by /capabilities' },

--- a/src/server/routes.ts
+++ b/src/server/routes.ts
@@ -825,6 +825,9 @@ export interface RouteContext {
    *  feature without a verified live-test artifact. Null when dark/unwired. */
   liveTestGate: import('../core/LiveTestGate.js').LiveTestGate | null;
   liveTestGateMode: import('../core/LiveTestGate.js').LiveTestGateMode;
+  /** Live-user-channel-proof CAPSTONE runner wiring (§6/§7.5). Null when dark/unwired —
+   *  the /live-test/* routes 503 then. A factory so the route wraps the request-built driver. */
+  liveTestRunnerCtx: import('./AgentServer.js').LiveTestRunnerWiring | null;
   unifiedTrust: UnifiedTrustSystem | null;
   /** Shared proxy coordinator — mutex + /build heartbeat record for the
    *  PresenceProxy ↔ PromiseBeacon ↔ /build-heartbeat three-way deconfliction
@@ -24900,6 +24903,221 @@ export function createRoutes(ctx: RouteContext): Router {
       }
     });
   }
+
+  // ── Live-User-Channel Proof: cross-machine transfer CAPSTONE (§6/§7.5) ──────
+  // POST /live-test/multi-machine-capstone — drive the (already-built, dark) capstone
+  // harness: move the seat FIRST (POST /pool/transfer), demand the honest seatMoved
+  // signal, then run the §7.5 matrix through the REAL user surfaces and record a
+  // signed PASS/FAIL artifact (PASS only when the reply came FROM the target machine).
+  // 503 when dark/unwired. A seat that did NOT move is a recorded 200 outcome
+  // (capstone:'aborted'), NOT a 500 — the honesty contract.
+  router.post('/live-test/multi-machine-capstone', async (req, res) => {
+    if (!ctx.liveTestRunnerCtx) {
+      res.status(503).json({ error: 'live-test runner not available (dark / dev-gated off)' });
+      return;
+    }
+    const body = (req.body ?? {}) as {
+      targetMachine?: unknown; telegramTopicId?: unknown; slackChannelId?: unknown;
+      message?: unknown; featureId?: unknown; timeoutMs?: unknown; runId?: unknown;
+    };
+    const targetMachine = typeof body.targetMachine === 'string' ? body.targetMachine.trim() : '';
+    const telegramTopicId = body.telegramTopicId != null ? String(body.telegramTopicId).trim() : '';
+    const slackChannelId = typeof body.slackChannelId === 'string' && body.slackChannelId.trim() ? body.slackChannelId.trim() : undefined;
+    const message = typeof body.message === 'string' && body.message.trim() ? body.message.trim() : `live-test capstone probe ${Date.now()}`;
+    const featureId = typeof body.featureId === 'string' && body.featureId.trim() ? body.featureId.trim() : undefined;
+    const timeoutMs = typeof body.timeoutMs === 'number' && Number.isFinite(body.timeoutMs) ? body.timeoutMs : undefined;
+    const runId = typeof body.runId === 'string' && body.runId.trim() ? body.runId.trim() : undefined;
+    if (!targetMachine || !telegramTopicId) {
+      res.status(400).json({ error: 'targetMachine and telegramTopicId are required' });
+      return;
+    }
+
+    try {
+      const [
+        { RealChannelDriver },
+        { TelegramLiveSender },
+        { SlackLiveSender },
+        { PlacementResponderReader },
+        { DemoChannelRegistry },
+        { buildMultiMachineCapstoneMatrix },
+      ] = await Promise.all([
+        import('../core/RealChannelDriver.js'),
+        import('../core/TelegramLiveSender.js'),
+        import('../core/SlackLiveSender.js'),
+        import('../core/PlacementResponderReader.js'),
+        import('../core/DemoChannelRegistry.js'),
+        import('../core/multiMachineCapstoneMatrix.js'),
+      ]);
+
+      type Surface = import('../core/LiveTestArtifactStore.js').Surface;
+      type SurfaceSender = import('../core/RealChannelDriver.js').SurfaceSender;
+      type ChannelDriver = import('../core/LiveTestHarness.js').ChannelDriver;
+
+      // Driver: the test injection seam wins; production builds the real, fail-closed
+      // driver from config + adapters below.
+      let driver: ChannelDriver;
+      const blockedSurfaces: Array<{ surface: Surface; reason: string }> = [];
+      const port = ctx.config.port;
+      if (ctx.liveTestRunnerCtx.driverForRequest) {
+        driver = ctx.liveTestRunnerCtx.driverForRequest();
+      } else {
+      // ── Demo creds (fail-closed): a surface whose demo cred is ABSENT is simply not
+      // wired — its scenarios then surface as a driver-error FAIL via RealChannelDriver's
+      // loud "no real sender configured" throw, NEVER a fabricated reply or the live
+      // agent token. We read demo creds from config.liveTest.demo (the documented keys).
+      const liveTestCfg = (ctx.config as { liveTest?: { demo?: { slackUserToken?: string; telegramBotToken?: string } } }).liveTest;
+      const demoSlackUserToken = liveTestCfg?.demo?.slackUserToken;
+      const demoTelegramBotToken = liveTestCfg?.demo?.telegramBotToken;
+
+      const senders: Partial<Record<Surface, SurfaceSender>> = {};
+
+      // Telegram demo sender — posts as the DEMO bot (NOT Echo's), reads history via
+      // the live TelegramAdapter (Echo's getTopicHistory).
+      if (demoTelegramBotToken && ctx.telegram) {
+        const tgAdapter = ctx.telegram;
+        senders.telegram = new TelegramLiveSender({
+          postAsDemoUser: async (topicId: number, text: string) => {
+            const url = `https://api.telegram.org/bot${demoTelegramBotToken}/sendMessage`;
+            const chatId = (ctx.config as { liveTest?: { demo?: { telegramChatId?: string | number } } }).liveTest?.demo?.telegramChatId;
+            if (chatId == null) {
+              // Not a silent fallback: a demo telegram topic needs its chat id to post —
+              // surface it loudly so the scenario records a real driver-error FAIL.
+              throw new Error('liveTest.demo.telegramChatId is required to post a demo Telegram message');
+            }
+            const r = await fetch(url, {
+              method: 'POST',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify({ chat_id: chatId, message_thread_id: topicId, text }),
+            });
+            const j = (await r.json()) as { ok?: boolean; result?: { message_id?: number }; description?: string };
+            if (!j.ok || j.result?.message_id == null) {
+              throw new Error(`demo Telegram sendMessage failed: ${j.description ?? `ok=${j.ok}`}`);
+            }
+            return { messageId: j.result.message_id };
+          },
+          getHistory: (topicId: number, limit?: number) =>
+            tgAdapter.getTopicHistory(topicId, limit).map((e) => ({ messageId: e.messageId, text: e.text, fromUser: e.fromUser })),
+          logger: (m: string) => console.log(`  ${m}`),
+        });
+      } else {
+        blockedSurfaces.push({ surface: 'telegram', reason: 'credential-unavailable (liveTest.demo.telegramBotToken / no telegram adapter)' });
+      }
+
+      // Slack demo sender — posts as the NON-AGENT demo user token, waits for a reply
+      // authored by Echo's bot user id (from the live SlackAdapter).
+      if (slackChannelId) {
+        const agentBotUserId = ctx.slack?.getBotUserId() ?? null;
+        if (demoSlackUserToken && agentBotUserId) {
+          const { SlackApiClient } = await import('../messaging/slack/SlackApiClient.js');
+          const demoApi = new SlackApiClient(demoSlackUserToken);
+          senders.slack = new SlackLiveSender({
+            api: demoApi,
+            agentBotUserId,
+            logger: (m: string) => console.log(`  ${m}`),
+          });
+        } else {
+          blockedSurfaces.push({
+            surface: 'slack',
+            reason: 'credential-unavailable (liveTest.demo.slackUserToken / agent bot user id unresolved)',
+          });
+        }
+      }
+
+      // Demo-channel registry (§5.3) — verified, signed bindings or fail-closed (none).
+      const bindingsPath = path.join(ctx.config.stateDir, 'demo-channel-bindings.json');
+      let bindingsDoc: import('../core/DemoChannelRegistry.js').DemoChannelBindingsDoc | null = null;
+      if (fs.existsSync(bindingsPath)) {
+        try {
+          bindingsDoc = JSON.parse(fs.readFileSync(bindingsPath, 'utf-8')) as import('../core/DemoChannelRegistry.js').DemoChannelBindingsDoc;
+        } catch (err) {
+          // @silent-fallback-ok — an unreadable/corrupt bindings doc fails CLOSED (null
+          // ⇒ zero demo channels ⇒ only safe scenarios run). The capstone scenarios are
+          // all SAFE-volatility, so this never blocks them; it only withholds the
+          // demo-channel vouch a volatile scenario would need.
+          console.warn(`[live-test] demo-channel bindings unreadable, failing closed: ${err instanceof Error ? err.message : String(err)}`);
+          bindingsDoc = null;
+        }
+      }
+      const demoRegistry = new DemoChannelRegistry({
+        doc: bindingsDoc,
+        // Verification rides the gate's artifact-store signer surface; the route does
+        // not re-derive Ed25519 here — when no signed bindings exist this is never
+        // called. A present doc with no verifier wired fails closed (returns false).
+        verify: () => false,
+      });
+
+      // Responder-machine reader — GET /pool/placement?topic=N → owner. For the
+      // capstone every surface is the SAME logical conversation being moved, keyed on
+      // telegramTopicId (the placement key). [GUESS: slack channel→topic uses the
+      // capstone's telegramTopicId; there is no live slack-channel→topic resolver.]
+      const placementReader = new PlacementResponderReader({
+        topicForChannel: (_surface: Surface, _channelId: string) => telegramTopicId,
+        fetchPlacement: async (topicId: string) => {
+          const r = await fetch(`http://localhost:${port}/pool/placement?topic=${encodeURIComponent(topicId)}`, {
+            headers: { Authorization: `Bearer ${ctx.config.authToken}` },
+          });
+          if (!r.ok) return null;
+          const j = (await r.json()) as { owner?: string | null; ownerNickname?: string | null };
+          return { owner: j.owner ?? null, ownerNickname: j.ownerNickname ?? null };
+        },
+        logger: (m: string) => console.log(`  ${m}`),
+      });
+
+      driver = new RealChannelDriver({
+        senders,
+        demoRegistry,
+        resolveResponderMachine: placementReader.resolve,
+        logger: (m: string) => console.log(`  ${m}`),
+      });
+      } // end real-driver construction (production path)
+
+      // The seat-move action: POST the LOCAL /pool/transfer and read the honest
+      // seatMoved signal (the #1188 fix). A non-2xx or a missing seatMoved is reported
+      // as seatMoved:false with a reason — never assumed moved. The injection seam wins
+      // when present (tests deterministically control seatMoved).
+      const transfer = ctx.liveTestRunnerCtx.transferForRequest
+        ?? (async (topicId: string, toMachine: string): Promise<{ seatMoved: boolean; detail?: string }> => {
+          const r = await fetch(`http://localhost:${port}/pool/transfer`, {
+            method: 'POST',
+            headers: { Authorization: `Bearer ${ctx.config.authToken}`, 'Content-Type': 'application/json' },
+            body: JSON.stringify({ topic: topicId, to: toMachine, confirm: true }),
+          });
+          const j = (await r.json().catch(() => ({}))) as { seatMoved?: boolean; seatMoveReason?: string; error?: string };
+          if (!r.ok) return { seatMoved: false, detail: j.error ?? `pool/transfer ${r.status}` };
+          return { seatMoved: j.seatMoved === true, detail: j.seatMoveReason };
+        });
+
+      // Move the seat FIRST and demand the honest seatMoved signal — the same
+      // seat-move-first contract LiveTestRunner.runMultiMachineTransferCapstone
+      // enforces (a non-move is a recorded 200 'aborted', never a misleading PASS).
+      const t = await transfer(telegramTopicId, targetMachine);
+      if (!t.seatMoved) {
+        res.status(200).json({ ok: true, seatMoved: false, capstone: 'aborted', reason: t.detail ?? 'seat did not move', blockedSurfaces });
+        return;
+      }
+      // Seat moved — run the full §7.5 risk-category matrix through the harness and
+      // record the signed artifact (PASS only where the reply came FROM targetMachine).
+      const matrix = buildMultiMachineCapstoneMatrix({ featureId, targetMachine, telegramTopicId, slackChannelId, message, timeoutMs });
+      const harness = ctx.liveTestRunnerCtx.makeHarness(driver);
+      const result = await harness.run(matrix, runId ? { runId } : {});
+      res.json({ ok: true, seatMoved: true, capstone: 'ran', artifact: result.artifact, entry: result.entry, blockedSurfaces });
+    } catch (err) {
+      // A genuine internal error surfaces LOUDLY as a 500 with the reason — never a
+      // fabricated PASS, never a swallowed run. This is the honest error path.
+      res.status(500).json({ error: `capstone run failed: ${err instanceof Error ? err.message : String(err)}` });
+    }
+  });
+
+  // GET /live-test/artifacts — read-only list of recorded live-test artifacts (the
+  // signed scenario matrices the gate verifies). 503 when the runner is dark.
+  router.get('/live-test/artifacts', (_req, res) => {
+    if (!ctx.liveTestRunnerCtx) {
+      res.status(503).json({ error: 'live-test runner not available (dark / dev-gated off)' });
+      return;
+    }
+    const entries = ctx.liveTestRunnerCtx.artifactStore.allEntries();
+    res.json({ count: entries.length, entries });
+  });
 
   return router;
 }

--- a/tests/e2e/live-test-capstone-alive.test.ts
+++ b/tests/e2e/live-test-capstone-alive.test.ts
@@ -1,0 +1,173 @@
+// safe-fs-allow: test file — SafeFsExecutor used for tmpdir cleanup.
+/**
+ * Tier-3 E2E "feature is alive" — Live-User-Channel Proof CAPSTONE runner
+ * (spec §6/§7.5). Per TESTING-INTEGRITY-SPEC the single most important test for a
+ * feature with API routes: are the /live-test/* routes WIRED on the production init
+ * path (the REAL AgentServer factory server.ts uses), do they answer 200 (not 503)
+ * when the runner is wired, and is the flag-OFF dark ship a STRICT no-op (503)?
+ *
+ * Proves:
+ *   (a) WIRED: POST /live-test/multi-machine-capstone runs the §7.5 matrix and records
+ *       a signed artifact (200, capstone:'ran'); GET /live-test/artifacts lists it.
+ *   (b) DARK (no liveTestRunnerCtx): both routes 503 (strict no-op).
+ *   (c) the routes require Bearer auth.
+ *   (d) wiring-integrity: ctx.liveTestRunnerCtx is the REAL wiring (not null) and the
+ *       run's artifact is recorded in the SAME store the gate would read.
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import express from 'express';
+import request from 'supertest';
+import crypto from 'node:crypto';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import net from 'node:net';
+import { AgentServer, type LiveTestRunnerWiring } from '../../src/server/AgentServer.js';
+import { StateManager } from '../../src/core/StateManager.js';
+import { LiveTestArtifactStore } from '../../src/core/LiveTestArtifactStore.js';
+import { LiveTestHarness, type ChannelDriver } from '../../src/core/LiveTestHarness.js';
+import { LiveTestRunner } from '../../src/core/LiveTestRunner.js';
+import type { InstarConfig } from '../../src/core/types.js';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+
+const AUTH = 'test-e2e-livetest-capstone';
+
+function createMockSessionManager() {
+  return { listRunningSessions: () => [], getSession: () => null };
+}
+
+/** Reserve a free TCP port so listen(port) and the route's loopback fetch agree. */
+function getFreePort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const srv = net.createServer();
+    srv.once('error', reject);
+    srv.listen(0, () => {
+      const port = (srv.address() as net.AddressInfo).port;
+      srv.close(() => resolve(port));
+    });
+  });
+}
+
+function baseConfig(stateDir: string, projectDir: string, port: number): InstarConfig {
+  return {
+    projectName: 'e2e', projectDir, stateDir, port, authToken: AUTH,
+    requestTimeoutMs: 10000, version: '0.0.0',
+    sessions: { claudePath: '/usr/bin/echo', maxSessions: 3, defaultMaxDurationMinutes: 30, protectedSessions: [], monitorIntervalMs: 5000 },
+    scheduler: { enabled: false, jobsFile: '', maxParallelJobs: 1 },
+    messaging: [], monitoring: {}, updates: {},
+  } as InstarConfig;
+}
+
+function mkStateDir(tmpDir: string, name: string): string {
+  const stateDir = path.join(tmpDir, name);
+  fs.mkdirSync(path.join(stateDir, 'state', 'sessions'), { recursive: true });
+  fs.mkdirSync(path.join(stateDir, 'logs'), { recursive: true });
+  fs.writeFileSync(path.join(stateDir, 'config.json'), JSON.stringify({ port: 0, projectName: 'e2e', agentName: 'E2E' }));
+  return stateDir;
+}
+
+function fakeDriver(responder: string): ChannelDriver {
+  return {
+    isDemoChannel: () => true,
+    send: async () => ({ messageId: 'm1' }),
+    awaitReply: async () => ({ text: 'agent reply', messageId: 'm2', responderMachineId: responder }),
+  };
+}
+
+/** Build the real LiveTestRunnerWiring (sharing the store the gate would read). */
+function buildWiring(stateDir: string, responder: string): LiveTestRunnerWiring & { store: LiveTestArtifactStore } {
+  const { publicKey, privateKey } = crypto.generateKeyPairSync('ed25519');
+  const sign = (d: string) => crypto.sign(null, Buffer.from(d), privateKey).toString('base64');
+  const verify = (d: string, s: string) => crypto.verify(null, Buffer.from(d), publicKey, Buffer.from(s, 'base64'));
+  const store = new LiveTestArtifactStore({ stateDir, machineId: 'm', signerFingerprint: 'm', sign, verify });
+  return {
+    store,
+    artifactStore: store,
+    runnerFingerprint: 'm',
+    makeHarness: (d: ChannelDriver) => new LiveTestHarness({ store, driver: d, runnerFingerprint: 'm' }),
+    makeRunner: (d: ChannelDriver) => new LiveTestRunner({ harness: new LiveTestHarness({ store, driver: d, runnerFingerprint: 'm' }) }),
+    driverForRequest: () => fakeDriver(responder),
+    transferForRequest: async () => ({ seatMoved: true }), // deterministic seat-move (no live pool)
+  };
+}
+
+describe('Live-User-Channel Proof capstone runner — E2E (feature is alive)', () => {
+  let tmpDir: string;
+  let enabledServer: AgentServer; let enabledApp: express.Express;
+  let darkServer: AgentServer; let darkApp: express.Express;
+  let enabledStore: LiveTestArtifactStore;
+
+  beforeAll(async () => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'livetest-capstone-e2e-'));
+
+    // ENABLED: a real AgentServer via the production factory, with the wiring (the
+    // seat-move + driver are injected deterministically, so no live pool/network).
+    const enabledPort = await getFreePort();
+    const enabledStateDir = mkStateDir(tmpDir, 'enabled');
+    const wiring = buildWiring(enabledStateDir, 'mini-001');
+    enabledStore = wiring.store;
+    enabledServer = new AgentServer({
+      config: baseConfig(enabledStateDir, tmpDir, enabledPort),
+      sessionManager: createMockSessionManager() as never,
+      state: new StateManager(enabledStateDir),
+      liveTestRunnerCtx: wiring,
+    });
+    await enabledServer.start();
+    enabledApp = enabledServer.getApp();
+
+    // DARK: no liveTestRunnerCtx → strict 503 no-op.
+    const darkPort = await getFreePort();
+    const darkStateDir = mkStateDir(tmpDir, 'dark');
+    darkServer = new AgentServer({
+      config: baseConfig(darkStateDir, tmpDir, darkPort),
+      sessionManager: createMockSessionManager() as never,
+      state: new StateManager(darkStateDir),
+    });
+    await darkServer.start();
+    darkApp = darkServer.getApp();
+  });
+
+  afterAll(async () => {
+    await enabledServer?.stop();
+    await darkServer?.stop();
+    SafeFsExecutor.safeRmSync(tmpDir, { recursive: true, force: true, operation: 'tests/e2e/live-test-capstone-alive.test.ts' });
+  });
+
+  const auth = () => ({ Authorization: `Bearer ${AUTH}` });
+
+  it('(a) WIRED: the capstone route runs the matrix, returns 200, records a signed artifact', async () => {
+    const r = await request(enabledApp)
+      .post('/live-test/multi-machine-capstone')
+      .set(auth())
+      .send({ targetMachine: 'mini-001', telegramTopicId: '13481' });
+    expect(r.status).toBe(200);
+    expect(r.body.capstone).toBe('ran');
+    expect(r.body.seatMoved).toBe(true);
+    expect(r.body.artifact?.featureId).toBe('multi-machine-transfer');
+    expect(r.body.artifact.scenarios.every((s: { verdict: string }) => s.verdict === 'PASS')).toBe(true);
+
+    const list = await request(enabledApp).get('/live-test/artifacts').set(auth());
+    expect(list.status).toBe(200);
+    expect(list.body.count).toBeGreaterThanOrEqual(1);
+  });
+
+  it('(b) DARK: both routes 503 (strict no-op)', async () => {
+    expect((await request(darkApp).post('/live-test/multi-machine-capstone').set(auth()).send({ targetMachine: 'm', telegramTopicId: '1' })).status).toBe(503);
+    expect((await request(darkApp).get('/live-test/artifacts').set(auth())).status).toBe(503);
+  });
+
+  it('(c) the routes require Bearer auth', async () => {
+    expect((await request(enabledApp).post('/live-test/multi-machine-capstone').send({ targetMachine: 'm', telegramTopicId: '1' })).status).toBe(401);
+    expect((await request(enabledApp).get('/live-test/artifacts')).status).toBe(401);
+  });
+
+  it('(d) wiring-integrity: the run\'s artifact is recorded in the SAME store the gate reads', async () => {
+    // The store handed to the wiring (which the gate would also read) has the artifact.
+    const entries = enabledStore.allEntries();
+    expect(entries.length).toBeGreaterThanOrEqual(1);
+    expect(entries.some((e) => e.featureId === 'multi-machine-transfer')).toBe(true);
+    // And it verifies (signed + hash-matches on disk) — the gate's exact check.
+    const latest = enabledStore.latestVerified('multi-machine-transfer');
+    expect(latest?.ok).toBe(true);
+  });
+});

--- a/tests/integration/live-test-capstone-route.test.ts
+++ b/tests/integration/live-test-capstone-route.test.ts
@@ -1,0 +1,156 @@
+/**
+ * Route-level wiring-integrity test (Testing Integrity Standard) for the
+ * Live-User-Channel Proof CAPSTONE runner (spec §6/§7.5): proves
+ * POST /live-test/multi-machine-capstone is WIRED into the production HTTP pipeline.
+ *   - 503 when the runner is dark (no ctx.liveTestRunnerCtx).
+ *   - A wired run with a FAKE driver + a fake /pool/transfer: seatMoved:true → an
+ *     artifact is recorded (PASS where the reply came FROM the target); seatMoved:false
+ *     → a recorded 200 'aborted' (NOT a 500), and no artifact.
+ *   - GET /live-test/artifacts lists recorded artifacts (503 when dark).
+ */
+import { describe, it, expect, afterEach } from 'vitest';
+import express from 'express';
+import crypto from 'node:crypto';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import type { AddressInfo } from 'node:net';
+import { createRoutes } from '../../src/server/routes.js';
+import { LiveTestArtifactStore } from '../../src/core/LiveTestArtifactStore.js';
+import { LiveTestHarness, type ChannelDriver, type ReplyResult } from '../../src/core/LiveTestHarness.js';
+import { LiveTestRunner } from '../../src/core/LiveTestRunner.js';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+
+const { publicKey, privateKey } = crypto.generateKeyPairSync('ed25519');
+const sign = (d: string) => crypto.sign(null, Buffer.from(d), privateKey).toString('base64');
+const verify = (d: string, s: string) => crypto.verify(null, Buffer.from(d), publicKey, Buffer.from(s, 'base64'));
+
+interface TestServer { url: string; close: () => Promise<void>; dir: string; store: LiveTestArtifactStore }
+
+/**
+ * A fake driver whose every reply is attributed to `responderMachine` — so a scenario
+ * expecting `responderMachine: target` PASSes when `responderMachine === target`.
+ */
+function fakeDriver(responderMachine: string): ChannelDriver {
+  return {
+    isDemoChannel: () => true,
+    send: async () => ({ messageId: 'm1' }),
+    awaitReply: async (): Promise<ReplyResult> => ({ text: 'agent reply', messageId: 'm2', responderMachineId: responderMachine }),
+  };
+}
+
+function buildServer(opts: { dark?: boolean; seatMoves: boolean; responderMachine?: string }): Promise<TestServer> {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'ltr-route-'));
+  const store = new LiveTestArtifactStore({ stateDir: dir, machineId: 'm', signerFingerprint: 'm', sign, verify });
+  const responder = opts.responderMachine ?? 'mini-001';
+  const driver = fakeDriver(responder);
+
+  const ctx: any = {
+    config: { authToken: 'test', stateDir: dir, port: 0 },
+    telegram: null,
+    slack: null,
+    liveTestRunnerCtx: opts.dark
+      ? null
+      : {
+          artifactStore: store,
+          runnerFingerprint: 'm',
+          makeHarness: (d: ChannelDriver) => new LiveTestHarness({ store, driver: d, runnerFingerprint: 'm' }),
+          makeRunner: (d: ChannelDriver) =>
+            new LiveTestRunner({ harness: new LiveTestHarness({ store, driver: d, runnerFingerprint: 'm' }) }),
+          driverForRequest: () => driver, // the test injection seam (fake driver)
+        },
+  };
+
+  const app = express();
+  app.use(express.json());
+  // A controllable /pool/transfer stub the route's in-process fetch hits.
+  app.post('/pool/transfer', (_req, res) => {
+    res.json(opts.seatMoves ? { ok: true, seatMoved: true } : { ok: true, seatMoved: false, seatMoveReason: 'ownership did not transfer' });
+  });
+  app.use(createRoutes(ctx));
+
+  return new Promise((resolve) => {
+    const srv = app.listen(0, () => {
+      const port = (srv.address() as AddressInfo).port;
+      ctx.config.port = port; // so the route's loopback fetch reaches THIS server
+      resolve({
+        url: `http://127.0.0.1:${port}`, dir, store,
+        close: () => new Promise<void>((r) => srv.close(() => { try { SafeFsExecutor.safeRmSync(dir, { recursive: true, force: true, operation: 'tests/integration/live-test-capstone-route.test.ts' }); } catch { /* */ } r(); })),
+      });
+    });
+  });
+}
+
+async function runCapstone(url: string, body: Record<string, unknown>): Promise<{ status: number; json: any }> {
+  const res = await fetch(`${url}/live-test/multi-machine-capstone`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', Authorization: 'Bearer test' },
+    body: JSON.stringify(body),
+  });
+  return { status: res.status, json: await res.json() };
+}
+
+describe('POST /live-test/multi-machine-capstone — capstone runner wiring', () => {
+  let server: TestServer;
+  afterEach(async () => { if (server) await server.close(); });
+
+  it('503s when the runner is dark (no liveTestRunnerCtx)', async () => {
+    server = await buildServer({ dark: true, seatMoves: true });
+    const { status, json } = await runCapstone(server.url, { targetMachine: 'mini-001', telegramTopicId: '13481' });
+    expect(status).toBe(503);
+    expect(json.error).toMatch(/not available/);
+  });
+
+  it('400s without targetMachine / telegramTopicId', async () => {
+    server = await buildServer({ dark: false, seatMoves: true });
+    const { status } = await runCapstone(server.url, { telegramTopicId: '13481' });
+    expect(status).toBe(400);
+  });
+
+  it('seatMoved:true → runs the matrix and RECORDS a signed artifact (PASS from target)', async () => {
+    server = await buildServer({ dark: false, seatMoves: true, responderMachine: 'mini-001' });
+    const { status, json } = await runCapstone(server.url, { targetMachine: 'mini-001', telegramTopicId: '13481' });
+    expect(status).toBe(200);
+    expect(json.seatMoved).toBe(true);
+    expect(json.capstone).toBe('ran');
+    expect(json.artifact).toBeDefined();
+    expect(json.artifact.featureId).toBe('multi-machine-transfer');
+    // Every move-to-target scenario replied from mini-001 → all PASS.
+    expect(json.artifact.scenarios.every((s: { verdict: string }) => s.verdict === 'PASS')).toBe(true);
+    // The artifact is durably recorded (the gate would read THIS).
+    expect(server.store.allEntries().length).toBe(1);
+  });
+
+  it('seatMoved:false → 200 "aborted", NO artifact recorded (honesty contract, not a 500)', async () => {
+    server = await buildServer({ dark: false, seatMoves: false });
+    const { status, json } = await runCapstone(server.url, { targetMachine: 'mini-001', telegramTopicId: '13481' });
+    expect(status).toBe(200);
+    expect(json.seatMoved).toBe(false);
+    expect(json.capstone).toBe('aborted');
+    expect(json.reason).toMatch(/ownership did not transfer/);
+    expect(server.store.allEntries().length).toBe(0);
+  });
+
+  it('a reply from the WRONG machine → recorded FAIL (deterministic cross-machine proof)', async () => {
+    server = await buildServer({ dark: false, seatMoves: true, responderMachine: 'laptop-999' });
+    const { json } = await runCapstone(server.url, { targetMachine: 'mini-001', telegramTopicId: '13481' });
+    expect(json.capstone).toBe('ran');
+    expect(json.artifact.scenarios.every((s: { verdict: string }) => s.verdict === 'FAIL')).toBe(true);
+  });
+
+  it('GET /live-test/artifacts lists recorded artifacts (503 when dark)', async () => {
+    server = await buildServer({ dark: false, seatMoves: true });
+    await runCapstone(server.url, { targetMachine: 'mini-001', telegramTopicId: '13481' });
+    const res = await fetch(`${server.url}/live-test/artifacts`, { headers: { Authorization: 'Bearer test' } });
+    expect(res.status).toBe(200);
+    const j = await res.json();
+    expect(j.count).toBe(1);
+    expect(j.entries[0].featureId).toBe('multi-machine-transfer');
+  });
+
+  it('GET /live-test/artifacts 503s when dark', async () => {
+    server = await buildServer({ dark: true, seatMoves: true });
+    const res = await fetch(`${server.url}/live-test/artifacts`, { headers: { Authorization: 'Bearer test' } });
+    expect(res.status).toBe(503);
+  });
+});

--- a/tests/unit/LiveTestRunner-capstone.test.ts
+++ b/tests/unit/LiveTestRunner-capstone.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect, vi } from 'vitest';
+import { LiveTestRunner, LiveTestRunnerError } from '../../src/core/LiveTestRunner.js';
+import type { LiveTestHarness } from '../../src/core/LiveTestHarness.js';
+
+/** A fake harness that records the matrix it was asked to run and returns a canned result. */
+function fakeHarness() {
+  const run = vi.fn(async () => ({
+    artifact: { featureId: 'f', runId: 'r', surfaces: [], riskCategories: [], scenarios: [], createdAt: 'now', runnerFingerprint: 'fp' },
+    entry: { featureId: 'f', runId: 'r', contentHash: 'h', signature: 's', signerFingerprint: 'fp', surfaces: [], riskCategories: [], createdAt: 'now', prevEntryHash: null },
+  }));
+  return { run } as unknown as LiveTestHarness & { run: typeof run };
+}
+
+describe('LiveTestRunner.runMultiMachineTransferCapstone — seat-move-first honesty', () => {
+  it('THROWS LiveTestRunnerError when the seat did NOT move (never records a misleading PASS)', async () => {
+    const harness = fakeHarness();
+    const runner = new LiveTestRunner({ harness });
+    const transfer = vi.fn(async () => ({ seatMoved: false, detail: 'ownership did not transfer' }));
+
+    await expect(
+      runner.runMultiMachineTransferCapstone({ targetMachine: 'mini', telegramTopicId: '13481', transfer }),
+    ).rejects.toBeInstanceOf(LiveTestRunnerError);
+
+    // The harness must never have run — the capstone aborts BEFORE any send.
+    expect(transfer).toHaveBeenCalledWith('13481', 'mini');
+    expect((harness as unknown as { run: ReturnType<typeof vi.fn> }).run).not.toHaveBeenCalled();
+  });
+
+  it('moves the seat FIRST, then runs the harness when the seat genuinely moved', async () => {
+    const harness = fakeHarness();
+    const runner = new LiveTestRunner({ harness });
+    const transfer = vi.fn(async () => ({ seatMoved: true }));
+
+    const result = await runner.runMultiMachineTransferCapstone({
+      targetMachine: 'mini', telegramTopicId: '13481', message: 'probe', transfer,
+    });
+
+    expect(transfer).toHaveBeenCalledTimes(1);
+    const runMock = (harness as unknown as { run: ReturnType<typeof vi.fn> }).run;
+    expect(runMock).toHaveBeenCalledTimes(1);
+    // The matrix the runner built asserts the reply came FROM the target machine.
+    const matrix = runMock.mock.calls[0][0];
+    expect(matrix.scenarios[0].expect.responderMachine).toBe('mini');
+    expect(result.artifact).toBeDefined();
+  });
+
+  it('adds a Slack channel-parity scenario when slackChannelId is given', async () => {
+    const harness = fakeHarness();
+    const runner = new LiveTestRunner({ harness });
+    const transfer = vi.fn(async () => ({ seatMoved: true }));
+
+    await runner.runMultiMachineTransferCapstone({
+      targetMachine: 'mini', telegramTopicId: '13481', slackChannelId: 'C0DEMO', transfer,
+    });
+
+    const runMock = (harness as unknown as { run: ReturnType<typeof vi.fn> }).run;
+    const matrix = runMock.mock.calls[0][0];
+    expect(matrix.surfaces).toEqual(['telegram', 'slack']);
+    expect(matrix.scenarios.some((s: { surface: string }) => s.surface === 'slack')).toBe(true);
+  });
+});

--- a/tests/unit/multiMachineCapstoneMatrix.test.ts
+++ b/tests/unit/multiMachineCapstoneMatrix.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect } from 'vitest';
+import { buildMultiMachineCapstoneMatrix } from '../../src/core/multiMachineCapstoneMatrix.js';
+
+describe('buildMultiMachineCapstoneMatrix (§7.5 capstone scenario matrix)', () => {
+  const base = { targetMachine: 'mini-001', telegramTopicId: '13481', message: 'probe' };
+
+  it('telegram-only: builds the seven §7.5 scenarios with the right risk categories', () => {
+    const m = buildMultiMachineCapstoneMatrix(base);
+    expect(m.featureId).toBe('multi-machine-transfer');
+    expect(m.surfaces).toEqual(['telegram']);
+    expect(m.scenarios).toHaveLength(7);
+    const ids = m.scenarios.map((s) => s.id);
+    expect(ids).toEqual([
+      'mm-idle-move-telegram-reply-from-target',
+      'mm-active-drain-telegram-reply-from-target',
+      'mm-reverse-move-telegram-reply-from-target',
+      'mm-offline-target-safe-refusal',
+      'mm-crash-mid-move-single-owner',
+      'mm-false-positive-guard-regression',
+      'mm-repeat-transfer-idempotency',
+    ]);
+    // The eight §7.5 categories collapse to five distinct telegram-only ones here
+    // (happy-path, lifecycle, failure-rollback, regression, idempotency).
+    expect(new Set(m.riskCategories)).toEqual(
+      new Set(['happy-path', 'lifecycle', 'failure-rollback', 'regression', 'idempotency']),
+    );
+    const cats = new Set(m.scenarios.map((s) => s.riskCategory));
+    expect(cats.has('happy-path')).toBe(true);
+    expect(cats.has('lifecycle')).toBe(true);
+    expect(cats.has('failure-rollback')).toBe(true);
+    expect(cats.has('regression')).toBe(true);
+    expect(cats.has('idempotency')).toBe(true);
+  });
+
+  it('every move-to-target scenario asserts the reply came FROM the target machine', () => {
+    const m = buildMultiMachineCapstoneMatrix(base);
+    for (const s of m.scenarios) {
+      expect(s.expect.responderMachine).toBe('mini-001');
+      expect(s.expect.replyNotEmpty).toBe(true);
+      expect(s.input).toBe('probe');
+    }
+  });
+
+  it('every scenario is SAFE-volatility (no destructive op; they assert transfer honesty)', () => {
+    const m = buildMultiMachineCapstoneMatrix(base);
+    for (const s of m.scenarios) expect(s.volatility).toBe('safe');
+  });
+
+  it('telegram scenarios all target the given telegram topic', () => {
+    const m = buildMultiMachineCapstoneMatrix(base);
+    for (const s of m.scenarios.filter((x) => x.surface === 'telegram')) {
+      expect(s.channelId).toBe('13481');
+    }
+  });
+
+  it('with slackChannelId: adds the channel-parity scenario + slack surface + category', () => {
+    const m = buildMultiMachineCapstoneMatrix({ ...base, slackChannelId: 'C0DEMO' });
+    expect(m.surfaces).toEqual(['telegram', 'slack']);
+    expect(m.riskCategories).toContain('channel-parity');
+    expect(m.scenarios).toHaveLength(8);
+    const slack = m.scenarios.find((s) => s.surface === 'slack');
+    expect(slack).toBeDefined();
+    expect(slack!.id).toBe('mm-channel-parity-slack-reply-from-target');
+    expect(slack!.riskCategory).toBe('channel-parity');
+    expect(slack!.channelId).toBe('C0DEMO');
+    expect(slack!.expect.responderMachine).toBe('mini-001');
+  });
+
+  it('honors timeoutMs on every scenario when provided, omits otherwise', () => {
+    const withTmo = buildMultiMachineCapstoneMatrix({ ...base, slackChannelId: 'C0DEMO', timeoutMs: 5000 });
+    for (const s of withTmo.scenarios) expect(s.timeoutMs).toBe(5000);
+    const without = buildMultiMachineCapstoneMatrix(base);
+    for (const s of without.scenarios) expect(s.timeoutMs).toBeUndefined();
+  });
+
+  it('respects a custom featureId', () => {
+    const m = buildMultiMachineCapstoneMatrix({ ...base, featureId: 'my-feature' });
+    expect(m.featureId).toBe('my-feature');
+  });
+
+  it('is deterministic (same inputs → identical matrix)', () => {
+    const a = buildMultiMachineCapstoneMatrix({ ...base, slackChannelId: 'C0DEMO', timeoutMs: 1000 });
+    const b = buildMultiMachineCapstoneMatrix({ ...base, slackChannelId: 'C0DEMO', timeoutMs: 1000 });
+    expect(JSON.stringify(a)).toEqual(JSON.stringify(b));
+  });
+});

--- a/upgrades/next/live-test-capstone-runner-route.md
+++ b/upgrades/next/live-test-capstone-runner-route.md
@@ -1,0 +1,44 @@
+<!-- assembled-by: assemble-next-md -->
+<!-- bump: patch -->
+<!-- audience: agent-only -->
+<!-- maturity: experimental -->
+
+## What Changed
+
+The (already-built, dark) multi-machine transfer CAPSTONE harness is now RUNNABLE behind
+a dev-gated route. `POST /live-test/multi-machine-capstone` moves the seat FIRST (local
+`/pool/transfer`), demands the honest `seatMoved` signal (records a `200 capstone:'aborted'`
+on a non-move — never a misleading PASS), then drives the §7.5 risk-category matrix through
+the REAL user surfaces and records a signed PASS/FAIL artifact (PASS only where the reply
+came FROM the target machine). `GET /live-test/artifacts` lists the recorded artifacts.
+A surface whose demo credential is absent is reported in `blockedSurfaces` and fails loudly
+via the driver — never a fabricated reply. Ships DARK (`monitoring.liveTestRunner.enabled`
+omitted → `resolveDevAgentGate`: live on dev, 503 on the fleet). Driven by the converged +
+approved `live-user-channel-proof-standard` (§6 / §7.5).
+
+## Evidence
+
+- `tests/unit/multiMachineCapstoneMatrix.test.ts` (8) — the §7.5 matrix builder.
+- `tests/unit/LiveTestRunner-capstone.test.ts` (3) — seat-move-first + reply-from-target.
+- `tests/integration/live-test-capstone-route.test.ts` (7) — route 200/400/aborted/auth +
+  seatMoved:true→artifact / seatMoved:false→no artifact.
+- `tests/e2e/live-test-capstone-alive.test.ts` (4) — feature-alive on the REAL AgentServer
+  init path: wired→200, dark→503, Bearer-required, shared-store wiring-integrity.
+- `tsc --noEmit` clean. Ratchets green: no-silent-fallbacks, CapabilityIndex,
+  feature-delivery-completeness, docs-coverage (all class floors met).
+
+## What to Tell Your User
+
+Nothing user-facing yet — this is an experimental, developer-only self-test that ships
+turned off on the fleet. It exists so the agent can prove a multi-machine conversation
+move works end-to-end through the real channels (Telegram and Slack) before you ever have
+to test it — the first application of the Live-User-Channel Proof standard. The payoff is
+invisible reliability: features get caught failing in a live self-test instead of by you
+on first use.
+
+## Summary of New Capabilities
+
+Internal / developer-only: a gated endpoint that runs the gold-standard live-test harness
+over the cross-machine conversation move (it moves the seat first, asserts the reply comes
+from the target machine, and records a signed pass/fail report), plus a read-only endpoint
+to list those reports. No fleet-facing surface; off by default.

--- a/upgrades/side-effects/live-test-capstone-runner-route.md
+++ b/upgrades/side-effects/live-test-capstone-runner-route.md
@@ -1,0 +1,89 @@
+# Side-Effects Review — Live-Test Capstone Runner Route
+
+**Change:** Make the (already-built, dark) multi-machine transfer CAPSTONE harness RUNNABLE.
+Adds `POST /live-test/multi-machine-capstone` + `GET /live-test/artifacts`, the
+`liveTestRunnerCtx` wiring (a `LiveTestRunnerWiring` factory on `AgentServer`), the
+`multiMachineCapstoneMatrix` builder, and registers `liveTestRunner` in the dev-gated
+feature registry. DEV-GATED + DARK (`monitoring.liveTestRunner.enabled` omitted from
+ConfigDefaults → `resolveDevAgentGate`: live on a dev agent, dark on the fleet → routes
+503). Driven by the converged + approved `docs/specs/live-user-channel-proof-standard.md`
+(§6 / §7.5).
+
+**Files:** `src/commands/server.ts` (ctx factory), `src/server/AgentServer.ts`
+(`LiveTestRunnerWiring` type + ctor wiring), `src/server/routes.ts` (the two routes),
+`src/core/multiMachineCapstoneMatrix.ts` (the §7.5 matrix builder),
+`src/core/devGatedFeatures.ts` (registration). Tests: unit (matrix + runner-capstone),
+integration (route 200/503/400/aborted/auth), e2e (feature-alive on the real AgentServer
+init path).
+
+## 1. Over-block — legitimate inputs wrongly rejected?
+The route rejects only missing `targetMachine`/`telegramTopicId` (400). A surface whose
+demo credential is absent is **not** rejected — it is recorded in `blockedSurfaces` and
+its scenarios surface as a loud driver-error FAIL via `RealChannelDriver`'s "no real
+sender configured" throw. No legitimate run is silently dropped: a non-moving seat is a
+recorded `200 capstone:'aborted'` (the honesty contract), never a 400/500.
+
+## 2. Under-block — failure modes still missed?
+- A demo SENDER that is mis-configured (wrong token) fails at send time → the scenario
+  records a driver-error FAIL (honest), not a fabricated PASS. Acceptable.
+- The Slack production path uses `SlackApiClient(demoSlackUserToken)` (a Bearer xoxp
+  token). Reality: the available SageMind-Live-Test creds are an `xoxc` web-client token
+  + `d` cookie, not xoxp — so with today's creds the Slack surface reports
+  `credential-unavailable` (blocked, HONEST) rather than running. The Telegram surface is
+  the capstone's reply-from-target channel. **Tracked follow-up (CMT-1568):** an
+  xoxc+cookie Slack drive variant to actually run the Slack channel-parity scenario.
+  `<!-- tracked: CMT-1568 -->`
+- The responder-machine resolver keys every surface on `telegramTopicId` (there is no
+  live Slack-channel→topic resolver) — documented inline as a GUESS; only affects the
+  optional Slack scenario. `<!-- tracked: CMT-1568 -->`
+
+## 3. Level-of-abstraction fit
+Correct layer: the route composes existing, separately-tested primitives
+(`RealChannelDriver`, `TelegramLiveSender`/`SlackLiveSender`, `LiveTestHarness`,
+`LiveTestRunner`, `PlacementResponderReader`, `DemoChannelRegistry`) and the shared
+`LiveTestArtifactStore` (the SAME store `LiveTestGate` reads, so a run's artifact is
+exactly the artifact the gate later verifies). No business logic is re-implemented in the
+route — it is composition + request validation + the seat-move-first orchestration the
+standard mandates.
+
+## 4. Signal vs authority compliance
+The route holds **no blocking authority over agent behavior**. It runs a test harness and
+records a signed artifact. The only authority-adjacent component (`LiveTestGate`, which
+computes a completion veto) is unchanged by this PR and remains dry-run. The route is a
+pure producer of an observable artifact — Signal, not Authority. (`docs/signal-vs-authority.md`.)
+
+## 5. Interactions
+- Shares the `LiveTestArtifactStore` instance with `LiveTestGate` by construction (server.ts
+  threads the SAME store into both) — verified by the e2e wiring-integrity test (d).
+- The seat-move calls the LOCAL `/pool/transfer` (production) — same route the operator
+  uses; it is read through the honest `seatMoved` signal (the #1188 fix), never assumed.
+- `transferForRequest` / `driverForRequest` are TEST-ONLY injection seams (undefined in
+  production); they let the e2e exercise the real AgentServer route with no live pool/network.
+- No double-fire / no shadowing: the routes are new prefixes; CapabilityIndex +
+  feature-delivery-completeness ratchets pass.
+
+## 6. External surfaces
+When RUN on a dev agent it posts a real demo message into a real (throwaway) channel and
+moves a real seat — but it is DEV-GATED + DARK, requires explicit demo creds, and every
+scenario is `safe`-volatility. On the fleet the routes 503 (no external effect). The run
+is operator-gated in practice (demo-sender provisioning + a live destination machine).
+
+## 7. Multi-machine posture (Cross-Machine Coherence)
+**Machine-local BY DESIGN.** The artifact store + the route are per-machine: the capstone
+is RUN from one machine (the test driver) and asserts the reply was served FROM the target
+machine via `PlacementResponderReader` (GET /pool/placement). The cross-machine fact being
+PROVEN is the responder identity; the runner itself does not replicate state. Recorded
+artifacts are local observability (like the live-test gate's). No generated URLs; no
+user-facing notice (dark infra) → no one-voice concern.
+
+## 8. Rollback cost
+Trivial. Dark by default (503 on fleet). Back-out = omit/disable
+`monitoring.liveTestRunner.enabled` (already the fleet default) or revert the PR — no data
+migration, no agent-state repair. The shared store is additive (read-only to the gate).
+
+## Second-pass review
+**Not required.** The change adds a test-harness RUN route with no block/allow authority
+over agent behavior, no session-lifecycle mutation, and no gate/sentinel/watchdog decision
+logic. It interacts with `LiveTestGate` only by sharing an artifact store (read path
+unchanged). The seat-move uses the existing honest `/pool/transfer` contract. Risk is
+bounded by the dev-gate + dark default + safe-only scenarios.


### PR DESCRIPTION
## ELI16

Instar already had all the *pieces* to prove its multi-machine feature works the honest way — by acting as a real user, moving a conversation to another computer, and checking the reply actually came from that other computer. But those pieces (the runner, the channel driver, the harness) had **no button to press**: nothing in the live server ever called them, so the "is this really tested?" gate could never be satisfied. This PR adds the button.

It wires up two dev-only API routes. `POST /live-test/multi-machine-capstone` moves the conversation's "seat" to a target machine **first**, then insists on an honest "the seat actually moved" signal — if it didn't move, it records an honest `aborted` result instead of pretending the test passed (this is the exact dishonesty bug #1188 fixed, now enforced here). If the seat did move, it sends real messages through the real channels and records a signed PASS/FAIL artifact, where PASS is only allowed when the reply genuinely came **from** the target machine. The second route, `GET /live-test/artifacts`, lists those recorded results.

Everything ships **dark**: on normal (fleet) agents the routes return 503 and nothing happens. It only comes alive on a development agent. A channel with no test credentials is reported as "blocked" loudly — it never fakes a reply. It shares the exact same artifact store the completion-gate reads, so a run's result is the same result the gate later checks.

**What you decide:** nothing changes for users. This is internal test infrastructure that closes the structural gap so the multi-machine capstone can finally be RUN (the live run itself still needs a destination machine that's awake + demo sender credentials).

**Safeguards:** dev-gated + dark (503 on fleet), all scenarios are `safe`-volatility, honest non-move/blocked/error paths (never a fabricated PASS), trivial rollback (revert or leave the flag off).

## Driven by
`docs/specs/live-user-channel-proof-standard.md` (§6 / §7.5) — converged 2026-06-16, approved.

## Tests
- unit: `multiMachineCapstoneMatrix` (8), `LiveTestRunner-capstone` (3)
- integration: `live-test-capstone-route` (7) — 200/400/aborted/auth + seatMoved→artifact
- e2e: `live-test-capstone-alive` (4) — feature-alive on the real AgentServer init path
- tsc clean; ratchets green (no-silent-fallbacks, CapabilityIndex, feature-delivery-completeness, docs-coverage)