### PR TITLE
feat(live-test): xoxc web-client Slack sender (LiveTestSlackCaller) for the capstone harness

### DIFF
--- a/.instar/instar-dev-decisions/2026-06-16T15-07-56-867Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-06-16T15-07-56-867Z-unknown.json
@@ -1,0 +1,16 @@
+{
+  "ts": "2026-06-16T15:07:56.867Z",
+  "slug": "unknown",
+  "suggestedTier": 2,
+  "declaredTier": 2,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "new capability: new exported class / subsystem added",
+    "new capability: new config key added"
+  ],
+  "belowFloor": false,
+  "files": 2,
+  "loc": 187,
+  "causalAutopsy": null,
+  "verdict": "pass"
+}

--- a/.instar/instar-dev-decisions/2026-06-16T15-08-47-139Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-06-16T15-08-47-139Z-unknown.json
@@ -1,0 +1,16 @@
+{
+  "ts": "2026-06-16T15:08:47.139Z",
+  "slug": "unknown",
+  "suggestedTier": 2,
+  "declaredTier": 2,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "new capability: new exported class / subsystem added",
+    "new capability: new config key added"
+  ],
+  "belowFloor": false,
+  "files": 2,
+  "loc": 194,
+  "causalAutopsy": null,
+  "verdict": "pass"
+}

--- a/.instar/instar-dev-decisions/2026-06-16T15-10-24-090Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-06-16T15-10-24-090Z-unknown.json
@@ -1,0 +1,16 @@
+{
+  "ts": "2026-06-16T15:10:24.090Z",
+  "slug": "unknown",
+  "suggestedTier": 2,
+  "declaredTier": 2,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "new capability: new exported class / subsystem added",
+    "new capability: new config key added"
+  ],
+  "belowFloor": false,
+  "files": 2,
+  "loc": 194,
+  "causalAutopsy": null,
+  "verdict": "pass"
+}

--- a/site/src/content/docs/architecture/live-user-channel-proof.md
+++ b/site/src/content/docs/architecture/live-user-channel-proof.md
@@ -36,6 +36,22 @@ reply text and the machine that actually answered. `LiveTestHarness` refuses to 
 volatile or permission-changing scenario on anything but an isolated demo channel, so a
 dangerous test can never touch the live operator channel.
 
+### Driving Slack as a real member
+
+The Slack arm of the harness posts as a *non-agent* identity so the agent never replies to
+itself. `SlackLiveSender` consumes a small `SlackCaller` seam, and the multi-machine capstone
+route picks the credential transport for that seam at wiring time. A plain Bearer (xoxp/xoxb)
+sender token uses the standard `SlackApiClient`. But the only distinct non-Echo senders we can
+capture for a demo workspace are real test *users*, authenticated the browser way — an `xoxc`
+web-client token plus the user's `d` session cookie — which are not Bearer tokens. For those,
+`LiveTestSlackCaller` is the adapter: it posts `chat.postMessage` *as the member* via the
+`xoxc` token in the form body and the `d` cookie in a `Cookie` header against the workspace
+host, while reading history (`conversations.history`) over the agent's own Bearer bot token at
+`slack.com`. The route detects an `xoxc-` sender by prefix and wires `LiveTestSlackCaller`
+behind `SlackLiveSender`; a missing cookie, workspace host, or bot token fails closed as a
+recorded blocked-surface, never a fabricated reply. That is what lets the harness drive a real
+Slack channel end-to-end as a genuine member.
+
 ## First feature held to the bar: durable multi-machine ownership
 
 The standard's first application was the cross-machine transfer fix. The bug: moving a

--- a/src/core/LiveTestSlackCaller.ts
+++ b/src/core/LiveTestSlackCaller.ts
@@ -1,0 +1,149 @@
+/**
+ * LiveTestSlackCaller — a credential adapter implementing the `SlackCaller` seam that
+ * `SlackLiveSender` consumes (see src/core/SlackLiveSender.ts), built for the
+ * live-test harness (docs/specs/live-user-channel-proof-standard.md §5.4).
+ *
+ * THE PROBLEM IT SOLVES: the only DISTINCT non-Echo Slack senders we have captured in
+ * the demo workspace are real test-USER identities authenticated the way a browser is —
+ * an `xoxc-…` web-client token PLUS the user's `d` session cookie. Those are NOT Bearer
+ * (xoxp/xoxb) tokens, so `SlackApiClient` (which only knows `Authorization: Bearer`)
+ * cannot post AS one of those users. Without this adapter the harness's Slack arm could
+ * never drive a REAL channel as a REAL member — defeating the whole point of the
+ * gold-standard live-test (drive real channels as a real user).
+ *
+ * THE MECHANISM (mirrors .instar/slack-live-test/post-as.mjs):
+ *  - `chat.postMessage` (POST AS THE MEMBER) → Slack web-client auth: the `xoxc` token
+ *    goes in the x-www-form-urlencoded BODY (`token=<xoxc>`), and the member's `d`
+ *    session cookie goes in a `Cookie: d=<value>` header, against the workspace host
+ *    `https://<workspaceHost>/api/chat.postMessage`. This is exactly how the real Slack
+ *    web client authenticates a message send, so the bot sees a genuine distinct-principal
+ *    message over the live adapter.
+ *  - every OTHER method (e.g. `conversations.history`) → the normal bot-token path:
+ *    `Authorization: Bearer <botToken>` against `https://slack.com/api/<method>`. Reading
+ *    history does not need to be done AS the member, and the bot token is a clean Bearer.
+ *
+ * Pure transport over an injected `fetch` (defaults to the global) so it is fully
+ * unit-testable with a fake fetch. No silent fallbacks: a missing credential for the
+ * path a call needs throws loudly (the harness records a real driver-error FAIL), never
+ * a fabricated reply.
+ */
+
+import type { SlackCaller } from './SlackLiveSender.js';
+
+/** The subset of `fetch` this adapter uses (so tests can inject a fake). */
+export type FetchLike = (
+  url: string,
+  init: {
+    method: string;
+    headers: Record<string, string>;
+    body: string;
+  },
+) => Promise<{ json(): Promise<unknown> }>;
+
+export interface LiveTestSlackCallerDeps {
+  /** Workspace host for web-client posts, e.g. `sagemindlivetest.slack.com` (no scheme). */
+  workspaceHost: string;
+  /** The member's `xoxc-…` web-client token (goes in the form body for chat.postMessage). */
+  xoxcToken: string;
+  /** The member's `d` session cookie VALUE (goes in the `Cookie: d=…` header). */
+  dCookie: string;
+  /** A clean Bearer bot token used for every non-postMessage method (e.g. history reads). */
+  botToken: string;
+  /** Injected for tests; defaults to global fetch. */
+  fetchImpl?: FetchLike;
+  logger?: (m: string) => void;
+}
+
+/** The shape SlackCaller.call resolves to. */
+type SlackCallResult = Awaited<ReturnType<SlackCaller['call']>>;
+
+export class LiveTestSlackCaller implements SlackCaller {
+  private readonly d: LiveTestSlackCallerDeps;
+
+  constructor(deps: LiveTestSlackCallerDeps) {
+    // Inline, loud validation (no silent fallbacks). Each credential is required for the
+    // path it serves; an empty one is a wiring error, not something to paper over.
+    if (!deps.workspaceHost) {
+      throw new Error('LiveTestSlackCaller: workspaceHost is required (the demo workspace host for web-client posts)');
+    }
+    if (!deps.xoxcToken) {
+      throw new Error('LiveTestSlackCaller: xoxcToken is required (the member web-client token for chat.postMessage)');
+    }
+    if (!deps.dCookie) {
+      throw new Error('LiveTestSlackCaller: dCookie is required (the member `d` session cookie for chat.postMessage)');
+    }
+    if (!deps.botToken) {
+      throw new Error('LiveTestSlackCaller: botToken is required (the Bearer token for history/other reads)');
+    }
+    this.d = deps;
+  }
+
+  private log(m: string): void {
+    this.d.logger?.(`[live-test-slack-caller] ${m}`);
+  }
+
+  private fetch(): FetchLike {
+    return this.d.fetchImpl ?? ((url, init) => fetch(url, init) as unknown as Promise<{ json(): Promise<unknown> }>);
+  }
+
+  async call(method: string, params: Record<string, unknown> = {}): Promise<SlackCallResult> {
+    if (method === 'chat.postMessage') {
+      return this.postAsMember(params);
+    }
+    return this.callAsBot(method, params);
+  }
+
+  /**
+   * POST AS THE MEMBER — Slack web-client auth: xoxc token in the form body + `d` cookie
+   * in the Cookie header, against the workspace host.
+   */
+  private async postAsMember(params: Record<string, unknown>): Promise<SlackCallResult> {
+    const form = new URLSearchParams();
+    form.set('token', this.d.xoxcToken);
+    // Slack web-client send envelope (matches post-as.mjs).
+    form.set('_x_reason', 'webapp_message_send');
+    form.set('_x_mode', 'online');
+    for (const [k, v] of Object.entries(params)) {
+      if (v === undefined) continue; // skip undefined params (never serialize "undefined")
+      form.set(k, typeof v === 'string' ? v : String(v));
+    }
+
+    const url = `https://${this.d.workspaceHost}/api/chat.postMessage`;
+    const res = await this.fetch()(url, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded',
+        Cookie: `d=${this.d.dCookie}`,
+      },
+      body: form.toString(),
+    });
+    const json = (await res.json()) as SlackCallResult;
+    this.log(`chat.postMessage AS member → ok=${json.ok} ts=${json.ts ?? ''}`);
+    return json;
+  }
+
+  /**
+   * Every other method goes over the clean Bearer bot-token path at slack.com — a JSON
+   * body, `Authorization: Bearer <botToken>`.
+   */
+  private async callAsBot(method: string, params: Record<string, unknown>): Promise<SlackCallResult> {
+    const body: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(params)) {
+      if (v === undefined) continue; // skip undefined params
+      body[k] = v;
+    }
+
+    const url = `https://slack.com/api/${method}`;
+    const res = await this.fetch()(url, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${this.d.botToken}`,
+        'Content-Type': 'application/json; charset=utf-8',
+      },
+      body: JSON.stringify(body),
+    });
+    const json = (await res.json()) as SlackCallResult;
+    this.log(`${method} (bot) → ok=${json.ok}`);
+    return json;
+  }
+}

--- a/src/server/routes.ts
+++ b/src/server/routes.ts
@@ -24965,8 +24965,10 @@ export function createRoutes(ctx: RouteContext): Router {
       // wired — its scenarios then surface as a driver-error FAIL via RealChannelDriver's
       // loud "no real sender configured" throw, NEVER a fabricated reply or the live
       // agent token. We read demo creds from config.liveTest.demo (the documented keys).
-      const liveTestCfg = (ctx.config as { liveTest?: { demo?: { slackUserToken?: string; telegramBotToken?: string } } }).liveTest;
+      const liveTestCfg = (ctx.config as { liveTest?: { demo?: { slackUserToken?: string; slackUserCookie?: string; slackWorkspaceHost?: string; telegramBotToken?: string } } }).liveTest;
       const demoSlackUserToken = liveTestCfg?.demo?.slackUserToken;
+      const demoSlackUserCookie = liveTestCfg?.demo?.slackUserCookie;
+      const demoSlackWorkspaceHost = liveTestCfg?.demo?.slackWorkspaceHost;
       const demoTelegramBotToken = liveTestCfg?.demo?.telegramBotToken;
 
       const senders: Partial<Record<Surface, SurfaceSender>> = {};
@@ -25006,8 +25008,47 @@ export function createRoutes(ctx: RouteContext): Router {
       // Slack demo sender — posts as the NON-AGENT demo user token, waits for a reply
       // authored by Echo's bot user id (from the live SlackAdapter).
       if (slackChannelId) {
+        // E2E-PAIRING: EXEMPT — no new route and no liveness/503 change. This only
+        // swaps the Slack demo SENDER's credential transport inside the existing,
+        // already-E2E-covered /live-test/multi-machine-capstone route (Bearer
+        // SlackApiClient → xoxc web-client LiveTestSlackCaller when the sender token is
+        // xoxc). The transport selection is fully covered by the LiveTestSlackCaller
+        // unit tests (tests/unit/LiveTestSlackCaller.test.ts); the route's liveness is
+        // unchanged.
         const agentBotUserId = ctx.slack?.getBotUserId() ?? null;
-        if (demoSlackUserToken && agentBotUserId) {
+        // An xoxc web-client token (member browser auth) needs a DIFFERENT transport
+        // than a Bearer token: the member posts via xoxc-in-body + the `d` cookie, while
+        // history reads still go over Echo's own Bearer bot token. Detect xoxc by its
+        // `xoxc-` prefix; anything else is treated as a normal Bearer sender token.
+        const isXoxcSender = typeof demoSlackUserToken === 'string' && demoSlackUserToken.startsWith('xoxc-');
+        const slackBotToken = (ctx.config.messaging?.find((m) => m.type === 'slack')?.config as { botToken?: string } | undefined)?.botToken;
+        if (isXoxcSender && agentBotUserId) {
+          // Member-as-real-user path: require the `d` cookie + a workspace host + a
+          // Bearer bot token for the history reads. A missing one is a wiring error, not
+          // a silent fallback — record it loudly as a blocked surface so the scenario is
+          // a real driver-error FAIL rather than a fabricated reply.
+          if (demoSlackUserCookie && demoSlackWorkspaceHost && slackBotToken) {
+            const { LiveTestSlackCaller } = await import('../core/LiveTestSlackCaller.js');
+            const demoApi = new LiveTestSlackCaller({
+              workspaceHost: demoSlackWorkspaceHost,
+              xoxcToken: demoSlackUserToken as string,
+              dCookie: demoSlackUserCookie,
+              botToken: slackBotToken,
+              logger: (m: string) => console.log(`  ${m}`),
+            });
+            senders.slack = new SlackLiveSender({
+              api: demoApi,
+              agentBotUserId,
+              logger: (m: string) => console.log(`  ${m}`),
+            });
+          } else {
+            blockedSurfaces.push({
+              surface: 'slack',
+              reason: 'credential-unavailable (xoxc sender needs liveTest.demo.slackUserCookie + slackWorkspaceHost + a slack bot token for history reads)',
+            });
+          }
+        } else if (demoSlackUserToken && agentBotUserId) {
+          // Bearer (xoxp/xoxb) sender path — the original SlackApiClient transport.
           const { SlackApiClient } = await import('../messaging/slack/SlackApiClient.js');
           const demoApi = new SlackApiClient(demoSlackUserToken);
           senders.slack = new SlackLiveSender({

--- a/tests/unit/LiveTestSlackCaller.test.ts
+++ b/tests/unit/LiveTestSlackCaller.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect } from 'vitest';
+import { LiveTestSlackCaller, type FetchLike } from '../../src/core/LiveTestSlackCaller.js';
+
+const BASE = {
+  workspaceHost: 'sagemindlivetest.slack.com',
+  xoxcToken: 'xoxc-test-member-token',
+  dCookie: 'xoxd-the-d-cookie-value',
+  botToken: 'xoxb-echo-bot-token',
+};
+
+type Captured = { url: string; method: string; headers: Record<string, string>; body: string };
+
+/** A fake fetch that records the request and returns a canned JSON body. */
+function fakeFetch(response: unknown): { fetchImpl: FetchLike; calls: Captured[] } {
+  const calls: Captured[] = [];
+  const fetchImpl: FetchLike = async (url, init) => {
+    calls.push({ url, method: init.method, headers: init.headers, body: init.body });
+    return { json: async () => response };
+  };
+  return { fetchImpl, calls };
+}
+
+describe('LiveTestSlackCaller', () => {
+  it('chat.postMessage posts AS THE MEMBER: xoxc token in the form body + d cookie header, NOT Bearer, at the workspace host', async () => {
+    const { fetchImpl, calls } = fakeFetch({ ok: true, ts: '171.222' });
+    const caller = new LiveTestSlackCaller({ ...BASE, fetchImpl });
+
+    const res = await caller.call('chat.postMessage', { channel: 'C123', text: 'hi from member' });
+
+    expect(res.ok).toBe(true);
+    expect(res.ts).toBe('171.222');
+    expect(calls).toHaveLength(1);
+    const c = calls[0];
+    // Web-client host, not slack.com.
+    expect(c.url).toBe('https://sagemindlivetest.slack.com/api/chat.postMessage');
+    // The xoxc token rides the x-www-form-urlencoded BODY, never a header.
+    expect(c.headers['Content-Type']).toBe('application/x-www-form-urlencoded');
+    const form = new URLSearchParams(c.body);
+    expect(form.get('token')).toBe('xoxc-test-member-token');
+    expect(form.get('channel')).toBe('C123');
+    expect(form.get('text')).toBe('hi from member');
+    expect(form.get('_x_reason')).toBe('webapp_message_send');
+    expect(form.get('_x_mode')).toBe('online');
+    // The `d` session cookie is in the Cookie header.
+    expect(c.headers['Cookie']).toBe('d=xoxd-the-d-cookie-value');
+    // And it is NOT a Bearer call.
+    expect(c.headers['Authorization']).toBeUndefined();
+    expect(c.body).not.toContain('Bearer');
+  });
+
+  it('conversations.history uses the Bearer bot token at slack.com, JSON body, NOT xoxc / cookie', async () => {
+    const { fetchImpl, calls } = fakeFetch({ ok: true, messages: [{ ts: '9.9', user: 'UECHOBOT', text: 'reply' }] });
+    const caller = new LiveTestSlackCaller({ ...BASE, fetchImpl });
+
+    const res = await caller.call('conversations.history', { channel: 'C123', limit: 100 });
+
+    expect(res.ok).toBe(true);
+    expect(res.messages?.[0]?.user).toBe('UECHOBOT');
+    expect(calls).toHaveLength(1);
+    const c = calls[0];
+    expect(c.url).toBe('https://slack.com/api/conversations.history');
+    // Bearer bot token, JSON body — the clean read path.
+    expect(c.headers['Authorization']).toBe('Bearer xoxb-echo-bot-token');
+    expect(c.headers['Content-Type']).toBe('application/json; charset=utf-8');
+    expect(c.headers['Cookie']).toBeUndefined();
+    const parsed = JSON.parse(c.body) as Record<string, unknown>;
+    expect(parsed.channel).toBe('C123');
+    expect(parsed.limit).toBe(100);
+    // The xoxc token must never leak into a bot-path body.
+    expect(c.body).not.toContain('xoxc-');
+  });
+
+  it('skips undefined params on both transports (never serializes "undefined")', async () => {
+    const post = fakeFetch({ ok: true, ts: '1.1' });
+    const caller1 = new LiveTestSlackCaller({ ...BASE, fetchImpl: post.fetchImpl });
+    await caller1.call('chat.postMessage', { channel: 'C1', text: 't', thread_ts: undefined });
+    const form = new URLSearchParams(post.calls[0].body);
+    expect(form.has('thread_ts')).toBe(false);
+    expect(post.calls[0].body).not.toContain('undefined');
+
+    const hist = fakeFetch({ ok: true, messages: [] });
+    const caller2 = new LiveTestSlackCaller({ ...BASE, fetchImpl: hist.fetchImpl });
+    await caller2.call('conversations.history', { channel: 'C1', oldest: undefined, limit: 50 });
+    const parsed = JSON.parse(hist.calls[0].body) as Record<string, unknown>;
+    expect('oldest' in parsed).toBe(false);
+    expect(parsed.limit).toBe(50);
+  });
+
+  it('throws loudly (no silent fallback) when a required credential is missing', () => {
+    expect(() => new LiveTestSlackCaller({ ...BASE, workspaceHost: '' })).toThrow(/workspaceHost/);
+    expect(() => new LiveTestSlackCaller({ ...BASE, xoxcToken: '' })).toThrow(/xoxcToken/);
+    expect(() => new LiveTestSlackCaller({ ...BASE, dCookie: '' })).toThrow(/dCookie/);
+    expect(() => new LiveTestSlackCaller({ ...BASE, botToken: '' })).toThrow(/botToken/);
+  });
+});

--- a/upgrades/next/xoxc-slack-caller.md
+++ b/upgrades/next/xoxc-slack-caller.md
@@ -1,0 +1,56 @@
+<!-- bump: patch -->
+
+## What Changed
+
+The gold-standard live-test harness can now drive a REAL Slack channel as a REAL
+workspace member. Previously the harness's multi-machine capstone route
+(`POST /live-test/multi-machine-capstone`) built its Slack sender with
+`new SlackApiClient(demoSlackUserToken)`, which only knows how to authenticate
+with a Bearer token (`xoxp`/`xoxb`). But the only DISTINCT non-Echo Slack
+senders captured in the demo workspace are real test-USER identities
+authenticated the browser way — an `xoxc-…` web-client token plus the user's
+`d` session cookie. Those are not Bearer tokens, so the harness could never post
+AS a real member, which defeats the whole point of the standard (drive real
+channels as a real user).
+
+A new `LiveTestSlackCaller` credential adapter (implementing the same
+`SlackCaller` seam `SlackLiveSender` already consumes) closes the gap. It routes
+per method: `chat.postMessage` posts AS THE MEMBER via Slack web-client auth
+(`xoxc` token in the form body + the `d` cookie in a `Cookie: d=…` header,
+against the workspace host), while every other method (e.g.
+`conversations.history`) reads over Echo's own clean Bearer bot token at
+`slack.com`. The capstone route detects an `xoxc-` sender by prefix and wires
+the new adapter; a plain Bearer sender keeps the original `SlackApiClient` path.
+Two new config keys — `liveTest.demo.slackUserCookie` and
+`liveTest.demo.slackWorkspaceHost` — supply the cookie + host alongside the
+existing `slackUserToken`. The fail-closed `blockedSurfaces` behavior is intact:
+a missing cookie/host/bot-token records a loud blocked-surface (a real
+driver-error FAIL), never a fabricated reply.
+
+This is dark harness/developer infrastructure — it only runs inside the
+dev-gated live-test runner, never on the fleet runtime path, and changes no
+user-facing behavior.
+
+## What to Tell Your User
+
+Nothing user-facing changes. This is internal developer test-harness plumbing:
+it lets the live-test runner post into a Slack channel as a genuine distinct
+member (via captured web-client credentials) instead of being limited to Bearer
+tokens, so the harness can actually exercise the real Slack surface end-to-end
+before any user does. If your agent isn't a development/instar-dev agent running
+the live-test capstone, you will never see this code execute.
+
+## Summary of New Capabilities
+
+- `LiveTestSlackCaller` (`src/core/LiveTestSlackCaller.ts`) — a `SlackCaller`
+  adapter that posts `chat.postMessage` AS a real workspace member using an
+  `xoxc` web-client token + the member's `d` session cookie, and reads all other
+  methods over a Bearer bot token. Pure transport over an injectable `fetch`
+  (unit-testable).
+- The multi-machine capstone route (`POST /live-test/multi-machine-capstone`)
+  now wires `LiveTestSlackCaller` when the demo Slack sender is an `xoxc` token
+  (detected by prefix) and the `d` cookie + workspace host + bot token are
+  configured; otherwise it keeps the original Bearer `SlackApiClient` path.
+- New config keys `liveTest.demo.slackUserCookie` and
+  `liveTest.demo.slackWorkspaceHost` (read alongside the existing
+  `liveTest.demo.slackUserToken`).

--- a/upgrades/side-effects/xoxc-slack-caller.md
+++ b/upgrades/side-effects/xoxc-slack-caller.md
@@ -1,0 +1,99 @@
+# Side-Effects Review — LiveTestSlackCaller (xoxc web-client Slack sender for the live-test harness)
+
+**Version / slug:** `xoxc-slack-caller`
+**Date:** `2026-06-16`
+**Author:** Echo (autonomous)
+**Second-pass reviewer:** not-required (Tier 2; dev-gated test-harness-only surface, no fleet runtime path)
+
+## Summary of the change
+
+The gold-standard live-test harness's multi-machine capstone route
+(`POST /live-test/multi-machine-capstone`) constructs its Slack demo sender with
+`new SlackApiClient(demoSlackUserToken)` — a Bearer-only transport. The only
+DISTINCT non-Echo Slack senders we have captured for the demo workspace are real
+test-USER identities authenticated as a browser is: an `xoxc-…` web-client token
++ the user's `d` session cookie. These are valid (verified via `auth.test`) but
+are NOT Bearer tokens, so the route's Slack arm could not actually post AS a real
+member — defeating the standard's purpose (drive REAL channels as a real user).
+
+Files added:
+- `src/core/LiveTestSlackCaller.ts` — a `SlackCaller` adapter (the seam
+  `SlackLiveSender` already consumes). `chat.postMessage` → posts AS the member
+  via xoxc-in-body + `d` cookie header against the workspace host; every other
+  method → Bearer bot token at `slack.com`. Pure transport over an injectable
+  `fetch`.
+- `tests/unit/LiveTestSlackCaller.test.ts` — fake-fetch unit tests asserting the
+  two transports, undefined-param skipping, and loud constructor validation.
+- `upgrades/next/xoxc-slack-caller.md` — release fragment.
+
+Files modified:
+- `src/server/routes.ts` — the capstone route's Slack branch: detect an `xoxc-`
+  sender by prefix; when so (and the `d` cookie + workspace host + a Slack bot
+  token are configured) wire `SlackLiveSender({ api: new LiveTestSlackCaller(...) })`;
+  otherwise keep the existing Bearer `SlackApiClient` path. Adds config keys
+  `liveTest.demo.slackUserCookie` + `liveTest.demo.slackWorkspaceHost` to the
+  read-type and reads Echo's own bot token from `ctx.config.messaging` (slack)
+  for the history reads.
+
+## Decision-point inventory
+
+- **Added**: `src/core/LiveTestSlackCaller.ts` `call()` method-routing branch —
+  routes `chat.postMessage` to the member (web-client) transport vs everything
+  else to the Bearer bot transport. A *transport-selection* decision, not a
+  message-flow gate.
+- **Modified**: `src/server/routes.ts` capstone Slack branch — a new
+  `isXoxcSender` discriminator selects which sender to build. Fail-closed:
+  missing cookie/host/bot-token records a loud `blockedSurfaces` entry (a real
+  driver-error FAIL), never a fabricated reply or a silent fallback.
+
+No agent-to-user message-flow decision points are added. This is developer
+test-harness infrastructure behind the dev-gated live-test runner.
+
+## Roll-up across the seven review dimensions
+
+1. **Over-block**: none. The change only adds a new credential path; the
+   pre-existing Bearer path is preserved verbatim for non-xoxc tokens. A missing
+   credential records the same kind of loud blocked-surface the route already
+   used.
+2. **Under-block**: none. No gate was loosened. The xoxc path still requires the
+   `d` cookie + workspace host + a bot token; absence is recorded as a FAIL, not
+   waved through.
+3. **Level-of-abstraction fit**: correct. The credential mechanics live in a
+   dedicated adapter implementing the existing `SlackCaller` seam — the same
+   seam `SlackLiveSender` already depends on — so `SlackLiveSender` is unchanged
+   and the transport detail is isolated and unit-testable.
+4. **Signal-vs-authority compliance**: N/A to message flow. The only decision is
+   transport selection + a fail-closed blocked-surface record; no message is
+   blocked, delayed, or rewritten. No silent try/catch (inline guards throw
+   loudly) — complies with the no-silent-fallbacks ratchet.
+5. **Interactions**: the route now reads Echo's own Slack bot token from
+   `ctx.config.messaging` for history reads. This is read-only config access
+   already used elsewhere in the same file (precedent at the channel-invite
+   path). No new mutation, no shared state.
+6. **External surfaces**: a new outbound HTTP path to `https://<workspaceHost>/api/chat.postMessage`
+   carrying an `xoxc` token + a `d` cookie — but ONLY when an operator has
+   configured those demo creds and the dev-gated live-test runner is invoked.
+   The xoxc token + cookie are credentials of a throwaway demo test user, never
+   the operator's, and never logged (the adapter logs only `ok`/`ts`). No change
+   to any fleet runtime path.
+7. **Rollback cost**: low. Single revertable commit; the new file is additive;
+   the route change is a guarded branch that falls back to the prior Bearer path
+   when the xoxc discriminator is false. No persistent state.
+
+## Credential-handling note
+
+The adapter handles two secrets: the member `xoxc` token (form body) and the
+`d` session cookie (Cookie header). Both belong to a throwaway demo workspace
+test user, are supplied via `liveTest.demo.*` config, and are never written to
+logs — the adapter's logger emits only `ok` and `ts`. The Bearer history-read
+token is Echo's own bot token, already present in `ctx.config.messaging`.
+
+## Evidence pointers
+
+- `npx tsc --noEmit` — clean.
+- `npx vitest run tests/unit/LiveTestSlackCaller.test.ts` — 4/4 pass (asserts
+  xoxc-in-body + cookie + NOT-Bearer for postMessage; Bearer-bot for history;
+  undefined-param skip; loud constructor validation).
+- Ratchets green: `tests/unit/no-silent-fallbacks.test.ts`,
+  `tests/unit/CapabilityIndex.test.ts`,
+  `tests/unit/feature-delivery-completeness.test.ts`.


### PR DESCRIPTION
## What & why

The gold-standard live-test multi-machine capstone route (`POST /live-test/multi-machine-capstone`) built its Slack demo sender with `new SlackApiClient(demoSlackUserToken)` — a **Bearer-only** transport. But the only DISTINCT non-Echo Slack senders captured for the demo workspace are real test-USER identities authenticated the browser way: an `xoxc-…` web-client token + the user's `d` session cookie. Those are valid (verified via `auth.test`) but are NOT Bearer tokens, so the route could never post AS a real member — defeating the standard's purpose (drive REAL channels as a real user).

## What changed

- **New `src/core/LiveTestSlackCaller.ts`** — a `SlackCaller` adapter (the seam `SlackLiveSender` already consumes). `chat.postMessage` posts AS the member via Slack web-client auth (`xoxc` token in the form body + the `d` cookie in a `Cookie: d=…` header, at `https://<workspaceHost>/api/chat.postMessage`); every other method (e.g. `conversations.history`) reads over Echo's clean Bearer bot token at `slack.com`. Pure transport over an injectable `fetch` (unit-testable).
- **`src/server/routes.ts`** — the capstone Slack branch detects an `xoxc-` sender by prefix and wires `SlackLiveSender({ api: new LiveTestSlackCaller(...) })`; otherwise it keeps the original Bearer `SlackApiClient` path. Fail-closed `blockedSurfaces` intact (missing cookie/host/bot-token → loud blocked surface, never a fabricated reply). New config keys `liveTest.demo.slackUserCookie` + `liveTest.demo.slackWorkspaceHost`.
- **`tests/unit/LiveTestSlackCaller.test.ts`** — fake-fetch unit tests over both transports + undefined-param skip + loud constructor validation. 4/4 pass.

Rides the already-converged+approved spec `docs/specs/live-user-channel-proof-standard.md` (Tier 2). Dev-gated test-harness infra only — no fleet runtime path, no new route, no liveness/503 change.

## ELI16

Imagine a robot (Echo) that helps you in a Slack chat. To make sure the robot really works, we test it by sending it a message and checking it replies. The catch: the test message has to come from a DIFFERENT person, not the robot itself — otherwise the robot would just be talking to itself. We had logged-in "fake test users" we could borrow, but they were logged in the way a person logs in through a web browser (a special browser token plus a login cookie), not the way an app logs in (a simpler "Bearer" key). Our test code only knew how to use the app-style key, so it literally couldn't send a message as one of those fake people. This change teaches the test code the browser way: when it sees a browser-style token it sends the message using that token plus the login cookie, exactly like a real person clicking "send". When it just needs to READ the chat to see the robot's reply, it goes back to the simple app key. Now the test can actually drive a real Slack channel as a real member from start to finish — which is the whole point of the gold-standard live test. None of this touches anything real users see; it only runs inside the developer test harness.

## Testing

- `npx tsc --noEmit` — clean.
- `npx vitest run tests/unit/LiveTestSlackCaller.test.ts` — 4/4 pass.
- Ratchets green: `no-silent-fallbacks`, `CapabilityIndex`, `feature-delivery-completeness`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)