### PR TITLE
feat(credential-repointing): scheduled identity audit — un-inerts the use-it-or-lose-it optimizer (B3c)

### DIFF
--- a/.instar/instar-dev-decisions/2026-06-17T00-02-12-403Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-06-17T00-02-12-403Z-unknown.json
@@ -1,0 +1,13 @@
+{
+  "ts": "2026-06-17T00:02:12.403Z",
+  "slug": "unknown",
+  "suggestedTier": 2,
+  "declaredTier": 2,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 3,
+  "loc": 236,
+  "causalAutopsy": null,
+  "verdict": "pass"
+}

--- a/docs/specs/live-credential-repointing-rebalancer.eli16.md
+++ b/docs/specs/live-credential-repointing-rebalancer.eli16.md
@@ -90,3 +90,17 @@ from actually moving any credential. The wider fleet stays fully dark. Actually 
 between accounts still needs a deliberate, operator-controlled flip (`dryRun:false`), gated behind
 running the livetest battery first. So: alive and observable for dogfooding on a dev agent, with
 **zero real credential moves** until you say go.
+
+## Amendment (2026-06-16) — the scheduled identity audit is now BUILT (§2.4.1)
+
+The design always called for an "always-on scheduled identity audit," but it was never actually
+implemented — and that turned out to be the reason the optimizer never did anything. In plain terms:
+before the balancer will move work onto an account, it insists that account was **identity-checked
+recently** (within 6 hours). Nothing re-checked them after the first setup, so a few hours later every
+account read as "not recently checked," the balancer found nothing it was allowed to touch, and it sat
+idle forever — even with an account about to reset and waste its quota. This change adds the missing
+background re-check: every so often it re-confirms each account's slot and stamps it fresh, and it
+auto-clears an account that was set aside once its identity re-confirms. It is deliberately careful —
+a momentary check failure **holds** a healthy account in place rather than knocking it offline — and
+it moves **zero** credentials; it only keeps the balancer's view fresh so it CAN act. Still dark on
+the fleet, still dry-run on a dev agent.

--- a/docs/specs/live-credential-repointing-rebalancer.md
+++ b/docs/specs/live-credential-repointing-rebalancer.md
@@ -665,6 +665,42 @@ A periodic pass (default every 5 min, clamp [1 min, 60 min]) in `CredentialRebal
   accepted residual of the autonomy posture; it is named here rather than left implicit, and
   it is the concrete reason PIN-gating returns on the multi-operator-fleet review.
 
+#### 2.4.1 Scheduled identity audit — IMPLEMENTED (B3c, 2026-06-16)
+
+The "always-on scheduled identity audit" this section, §2.3, §6, and §0.c repeatedly name as the
+long-tail detector is now BUILT and wired (it was specified but never implemented in Increment B's
+first landing — the canary cross-check existed only inside `seedFromOracle()`/the executor's
+post-swap re-verify, never on a standing cadence). `CredentialLocationLedger.auditIdentities()` is a
+NON-DESTRUCTIVE periodic re-verification: it re-probes each EXISTING tracked slot via the oracle and
+updates ONLY its verification/quarantine state (it WIPES nothing — distinct from `seedFromOracle`).
+
+**Why it is load-bearing, not cosmetic (the bug it closes):** the balancer's every objective
+(wall-rescue AND the §2.4-obj-2 use-it-or-lose-it drain) only acts on a DESTINATION slot that passes
+`targetVerifiedRecent` = `lastVerifiedAt` within `auditCadenceMs` (default 6h, §resolver). Nothing
+re-stamped `lastVerifiedAt` after the boot seed — `markVerified` had ZERO callers and the periodic
+`rebalancer.tick()` never re-verified — so every slot decayed to "not recently verified" ~6h after
+seed, leaving every objective with zero eligible targets: a permanently-INERT optimizer that decided
+nothing (the observed live symptom: `decisions: []`, `noActuationReason: "… missing eligible
+target"`, on a pool with an idle soon-resetting account begging to be drained). The audit keeps the
+target set live.
+
+**Safe direction (§2.11 never-guess / quarantine-never-repair):** oracle unavailable/throws → HOLD a
+currently-healthy slot (NEVER quarantine on a transient probe failure — that would re-create the very
+inert-optimizer stall this method prevents); a confirmed `email` for a DIFFERENT account than the
+recorded tenant → quarantine (the oracle never guesses a mismatch, so a differing confirmed email is a
+real login divergence); ambiguous/unknown email on a healthy slot → quarantine; a quarantined slot
+that now resolves cleanly → RECOVER (un-quarantine + record). It moves ZERO credentials and never
+triggers a swap — it only refreshes the ledger state the rebalancer reads next pass. Gated on the SAME
+dev-gate as the rebalancer (strict no-op / no probe on the dark fleet); reentrancy-guarded; cadence =
+`auditCadenceMs/2` capped at 30 min, floored at 1 min, plus a one-shot boot pass (~90 s after start,
+after the seed) so a long-running agent's verification refreshes immediately on restart. Wiring gate:
+the pure `shouldRunIdentityAudit(enabled, seeded, unknownMode, inFlight)` predicate. Surfaced on
+`GET /credentials/rebalancer` as `identityAudit` (last-pass counts: refreshed/recovered/quarantined/
+unresolved; null until the first pass). Tests: `tests/unit/credential-identity-audit.test.ts` (both
+sides of every branch), the predicate in `tests/unit/credential-ledger-boot-seed-guard.test.ts`,
+integration in `tests/integration/credential-routes.test.ts`, e2e-alive in
+`tests/e2e/credential-repointing-routes-alive.test.ts`.
+
 ### 2.5 Robustness comparison — one-account-for-all vs spread (the delegated decision)
 
 - **(i) Single-account convergence** — impossible under §0.d (one lineage can't occupy

--- a/src/commands/server.ts
+++ b/src/commands/server.ts
@@ -9987,7 +9987,7 @@ export async function startServer(options: StartOptions): Promise<void> {
     // off (always, while dark) every gate read returns the enrollment-home fallback, so every
     // consumer is byte-for-byte today's behavior. A never-seeded ledger is the same fallback (back-
     // compat); only UNKNOWN mode (corrupt on-disk) raises a HIGH attention item, never throws.
-    const { CredentialLocationLedger, shouldBootSeedCredentialLedger } = await import('../core/CredentialLocationLedger.js');
+    const { CredentialLocationLedger, shouldBootSeedCredentialLedger, shouldRunIdentityAudit } = await import('../core/CredentialLocationLedger.js');
     const { CredentialIdentityOracle } = await import('../core/CredentialIdentityOracle.js');
     const { CredentialLocationGate } = await import('../core/CredentialLocationGate.js');
     const credentialGateEmitAttention = telegram
@@ -10187,19 +10187,27 @@ export async function startServer(options: StartOptions): Promise<void> {
     // never blocked on them; failures are loud at the slot level (quarantine + attention) INSIDE
     // seedFromOracle. Seeding writes ONLY the local slot→account map — it moves ZERO credentials
     // (the executor's dryRun gate + the one-home invariant still guard every real swap). <!-- tracked: 20905 -->
+    // `credSeedInFlight` closes the fresh-agent seed↔audit interleave: a never-seeded boot fires
+    // seedFromOracle() fire-and-forget at t=0, and the boot identity audit fires at t≈90s. If the
+    // oracle hangs past 90s the two passes could otherwise touch the in-memory assignments view at
+    // their respective awaits. isSeeded() does NOT protect this (seedFromOracle bumps version at
+    // 'begin', so isSeeded() flips true mid-seed), so the audit gate also checks this flag.
+    let credSeedInFlight = false;
     if (
       shouldBootSeedCredentialLedger(
         resolveDevAgentGate(config.subscriptionPool?.credentialRepointing?.enabled, config),
         credentialLocationLedger.isSeeded(),
       )
     ) {
+      credSeedInFlight = true;
       void credentialLocationLedger
         .seedFromOracle()
         .then((outcomes) => {
           const assigned = outcomes.filter((o) => o.result === 'assigned').length;
           console.log(pc.green(`  Credential location ledger seeded: ${assigned}/${outcomes.length} slot(s) mapped`));
         })
-        .catch((e) => console.warn(`[CredentialLedger] boot seed failed: ${e instanceof Error ? e.message : String(e)}`));
+        .catch((e) => console.warn(`[CredentialLedger] boot seed failed: ${e instanceof Error ? e.message : String(e)}`))
+        .finally(() => { credSeedInFlight = false; });
     }
 
     // B3b — the periodic balancer pass. tick() is a strict no-op while the feature resolves dark
@@ -10220,6 +10228,60 @@ export async function startServer(options: StartOptions): Promise<void> {
         .finally(() => { credRebalancerTickInFlight = false; });
     }, credRebalancerPassMs);
     credRebalancerTimer.unref?.();
+
+    // B3c — the periodic NON-DESTRUCTIVE identity audit. THE FIX for the inert-optimizer bug:
+    // the rebalancer's every objective (wall-rescue AND the use-it-or-lose-it drain) only acts on
+    // a DESTINATION slot whose identity was verified within `auditCadenceMs` (default 6h). Nothing
+    // re-stamped verification after the boot seed (markVerified had zero callers), so every slot
+    // decayed to "not recently verified" and the rebalancer went permanently inert — it decided
+    // nothing because it had no eligible targets. auditIdentities() re-probes each slot and refreshes
+    // its verification (and lets a since-resolvable slot EXIT quarantine), keeping the optimizer's
+    // target set live. It moves ZERO credentials (ledger verification state only); never triggers a
+    // swap; HOLDS a healthy slot on a transient oracle blip (never re-creates the stall). Same
+    // dev-gate as the rebalancer (strict no-op / no probe on the dark fleet); reentrancy-guarded;
+    // unref'd. Audit cadence = half of auditCadenceMs, capped at 30min, floored at 1min, so a
+    // healthy slot is always re-confirmed well inside the verified-recent window. <!-- tracked: 20905 -->
+    const credAuditCadenceMs = credResolveBalancerConfig({
+      ...(config.subscriptionPool?.credentialRepointing?.balancer ?? {}),
+      slotCount: credentialLocationLedger.getAssignments().length,
+    }).auditCadenceMs;
+    const credAuditIntervalMs = Math.max(60_000, Math.min(Math.floor(credAuditCadenceMs / 2), 30 * 60_000));
+    let credAuditInFlight = false;
+    const runCredentialIdentityAudit = async (trigger: 'boot' | 'periodic'): Promise<void> => {
+      // Pure, unit-tested gate (shouldRunIdentityAudit): enabled (no-op/no-probe on the dark fleet)
+      // AND seeded AND not UNKNOWN-mode AND not already in flight (reentrancy guard).
+      // `credSeedInFlight` is the runtime seed↔audit interleave guard (a boot seed can be mid-probe
+      // when the boot audit fires); the pure predicate covers the persistent-state gates.
+      if (
+        credSeedInFlight ||
+        !shouldRunIdentityAudit(
+          resolveDevAgentGate(config.subscriptionPool?.credentialRepointing?.enabled, config),
+          credentialLocationLedger.isSeeded(),
+          credentialLocationLedger.isUnknownMode(),
+          credAuditInFlight,
+        )
+      ) {
+        return;
+      }
+      credAuditInFlight = true;
+      try {
+        const r = await credentialLocationLedger.auditIdentities();
+        if (r.refreshed || r.recovered || r.quarantined) {
+          console.log(pc.dim(`  Credential identity audit (${trigger}): ${r.refreshed} refreshed, ${r.recovered} recovered, ${r.quarantined} quarantined, ${r.unresolved} unresolved`));
+        }
+      } catch (e) {
+        console.warn(`[CredentialIdentityAudit] ${trigger} error: ${e instanceof Error ? e.message : String(e)}`);
+      } finally {
+        credAuditInFlight = false;
+      }
+    };
+    // Boot one-shot (delayed so it never races the boot seed) — refreshes stale verification
+    // immediately on restart so a long-running agent's rebalancer has fresh targets without
+    // waiting a full cadence.
+    const credAuditBootTimer = setTimeout(() => void runCredentialIdentityAudit('boot'), 90_000);
+    credAuditBootTimer.unref?.();
+    const credAuditTimer = setInterval(() => void runCredentialIdentityAudit('periodic'), credAuditIntervalMs);
+    credAuditTimer.unref?.();
 
     // QuotaPoller — per-account live quota reader (P1.2 of the Subscription &
     // Auth Standard). Reads each account's 5h/weekly utilization + reset dates

--- a/src/core/CredentialLocationLedger.ts
+++ b/src/core/CredentialLocationLedger.ts
@@ -140,6 +140,40 @@ export interface SeedSlotOutcome {
   reason?: string;
 }
 
+/** Outcome of a periodic NON-DESTRUCTIVE identity re-verification (auditIdentities) for one slot. */
+export interface IdentityAuditOutcome {
+  slot: string;
+  /**
+   * - `refreshed` — healthy slot re-confirmed; lastVerifiedAt stamped fresh (the core fix).
+   * - `recovered` — a quarantined/tenant-less slot now resolves cleanly; assignment restored + unquarantined.
+   * - `diverged-quarantined` — a healthy slot's credential now belongs to a DIFFERENT account (confirmed login change) → quarantined.
+   * - `unverifiable-quarantined` — a healthy slot's email became ambiguous/unknown → quarantined.
+   * - `unavailable-held` — oracle unavailable/threw; a healthy slot is HELD (never quarantined on a transient probe failure).
+   * - `still-quarantined` — an already-quarantined slot still can't be cleanly resolved.
+   */
+  result:
+    | 'refreshed'
+    | 'recovered'
+    | 'diverged-quarantined'
+    | 'unverifiable-quarantined'
+    | 'unavailable-held'
+    | 'still-quarantined';
+  accountId?: string;
+  email?: string;
+  reason?: string;
+}
+
+/** Aggregate report of one auditIdentities pass (returned + retained for the status surface). */
+export interface IdentityAuditReport {
+  at: string;
+  outcomes: IdentityAuditOutcome[];
+  refreshed: number;
+  recovered: number;
+  quarantined: number;
+  /** Held (transient) + still-quarantined — slots the pass could not freshly confirm. */
+  unresolved: number;
+}
+
 const MAX_COMPLETED_JOURNAL = 50;
 const NON_CLAUDE_FRAMEWORKS = new Set(['codex-cli', 'gemini-cli', 'pi-cli']);
 
@@ -160,6 +194,8 @@ export class CredentialLocationLedger {
   private unknownMode = false;
   /** Dedupe the UNKNOWN-mode attention item so a re-read storm raises it once. */
   private unknownAttentionRaised = false;
+  /** Last NON-DESTRUCTIVE identity audit pass (auditIdentities) — surfaced in status. */
+  private lastAuditReport: IdentityAuditReport | null = null;
   /** In-memory index: accountId → slot (rebuilt on every mutation/load). */
   private slotByAccount = new Map<string, string>();
   /** In-memory index: slot → accountId. */
@@ -440,6 +476,117 @@ export class CredentialLocationLedger {
     return outcomes;
   }
 
+  /**
+   * Periodic, NON-DESTRUCTIVE identity re-verification (the §2.4 scheduled identity audit).
+   *
+   * Unlike `seedFromOracle()` — which WIPES + rebuilds the whole ledger — this re-probes each
+   * EXISTING tracked slot and updates ONLY its verification/quarantine state. It is the missing
+   * piece that keeps a healthy slot's `lastVerifiedAt` FRESH: without a periodic re-stamp the
+   * rebalancer's `targetVerifiedRecent` gate (default 6h) decays every slot to "not recently
+   * verified", leaving every objective (wall-rescue AND use-it-or-lose-it drain) with zero
+   * eligible targets — a permanently-inert optimizer. It ALSO lets a slot that has since become
+   * resolvable EXIT quarantine.
+   *
+   * Safety direction (§2.11 never-guess / quarantine-never-repair):
+   *   - oracle unavailable/throws → HOLD: NEVER quarantine a currently-healthy slot on a
+   *     transient probe failure (that would itself induce the inert-rebalancer failure this
+   *     method exists to prevent). An already-quarantined slot stays quarantined.
+   *   - email → exactly one pool account:
+   *       · matches the slot's current healthy tenant → markVerified (refresh — the core fix).
+   *       · slot is quarantined / tenant-less → RECOVER: record the assignment verified-now and
+   *         lift the quarantine.
+   *       · matches a DIFFERENT account than the recorded healthy tenant → a CONFIRMED login
+   *         divergence (the oracle never guesses a mismatch — an `email` is identity-confirmed)
+   *         → quarantine (safe direction).
+   *   - ambiguous / unknown-email on a currently-healthy slot → quarantine (its login became
+   *     unrecognizable); an already-quarantined slot stays quarantined.
+   *
+   * This NEVER triggers a credential swap — it only refreshes the ledger verification state the
+   * rebalancer reads on its next pass. No-op in UNKNOWN mode (recovery is seedFromOracle's job).
+   */
+  async auditIdentities(): Promise<IdentityAuditReport> {
+    const at = this.now();
+    const outcomes: IdentityAuditOutcome[] = [];
+    if (this.unknownMode) {
+      const empty: IdentityAuditReport = { at, outcomes, refreshed: 0, recovered: 0, quarantined: 0, unresolved: 0 };
+      this.lastAuditReport = empty;
+      return empty;
+    }
+
+    const claudeAccounts = this.pool.list().filter(isClaudeCodeAccount);
+    // Snapshot the slot list up-front: the mutators below rewrite `assignments`.
+    const slots = this.getAssignments().map((a) => a.slot);
+
+    for (const slot of slots) {
+      const existing = this.store.assignments.find((x) => x.slot === slot);
+      if (!existing) continue; // disappeared mid-pass (defensive) — nothing to re-verify.
+
+      let result: IdentityOracleResult;
+      try {
+        result = await this.oracle.resolveSlotTenant(slot);
+      } catch (err) {
+        result = { unavailable: true, reason: `oracle threw: ${(err as Error)?.message ?? 'unknown'}` };
+      }
+
+      if (result.unavailable || !result.email) {
+        // HOLD — a transient probe failure must never demote a healthy slot.
+        outcomes.push({
+          slot,
+          result: existing.quarantined ? 'still-quarantined' : 'unavailable-held',
+          reason: result.reason ?? 'oracle unavailable',
+        });
+        continue;
+      }
+
+      const matches = claudeAccounts.filter((a) => a.email && a.email === result.email);
+      if (matches.length === 1) {
+        const matchId = matches[0].id;
+        if (!existing.quarantined && existing.accountId === matchId) {
+          this.markVerified(slot, at);
+          outcomes.push({ slot, result: 'refreshed', accountId: matchId, email: result.email });
+        } else if (existing.quarantined || existing.accountId === '') {
+          // A quarantined / tenant-less slot now resolves cleanly → recover + un-quarantine.
+          this.recordAssignment(slot, matchId, { verifiedAt: at, op: 'restore' });
+          outcomes.push({ slot, result: 'recovered', accountId: matchId, email: result.email });
+        } else {
+          // Healthy slot, but the confirmed email belongs to a DIFFERENT account → divergence.
+          this.quarantineSlot(slot, `audit: slot diverged — now ${result.email} (${matchId}), recorded tenant ${existing.accountId}`);
+          outcomes.push({ slot, result: 'diverged-quarantined', accountId: matchId, email: result.email, reason: `diverged from ${existing.accountId}` });
+        }
+      } else if (matches.length > 1) {
+        if (existing.quarantined) {
+          outcomes.push({ slot, result: 'still-quarantined', email: result.email, reason: `ambiguous (${matches.length})` });
+        } else {
+          this.quarantineSlot(slot, `audit: ambiguous — ${matches.length} accounts share ${result.email}`);
+          outcomes.push({ slot, result: 'unverifiable-quarantined', email: result.email, reason: `ambiguous (${matches.length})` });
+        }
+      } else {
+        if (existing.quarantined) {
+          outcomes.push({ slot, result: 'still-quarantined', email: result.email, reason: 'unknown-email' });
+        } else {
+          this.quarantineSlot(slot, `audit: unknown email ${result.email} — no pool account`);
+          outcomes.push({ slot, result: 'unverifiable-quarantined', email: result.email, reason: 'unknown-email' });
+        }
+      }
+    }
+
+    const report: IdentityAuditReport = {
+      at,
+      outcomes,
+      refreshed: outcomes.filter((o) => o.result === 'refreshed').length,
+      recovered: outcomes.filter((o) => o.result === 'recovered').length,
+      quarantined: outcomes.filter((o) => o.result === 'diverged-quarantined' || o.result === 'unverifiable-quarantined').length,
+      unresolved: outcomes.filter((o) => o.result === 'unavailable-held' || o.result === 'still-quarantined').length,
+    };
+    this.lastAuditReport = report;
+    return report;
+  }
+
+  /** The last NON-DESTRUCTIVE identity audit pass, or null if none has run. */
+  getLastAuditReport(): IdentityAuditReport | null {
+    return this.lastAuditReport;
+  }
+
   // ─── Attention (LOUD degradation surfaces) ───────────────────────────────────────
 
   private async raiseUnknownModeAttention(): Promise<void> {
@@ -493,4 +640,23 @@ export class CredentialLocationLedger {
  */
 export function shouldBootSeedCredentialLedger(enabled: boolean, isSeeded: boolean): boolean {
   return enabled && !isSeeded;
+}
+
+/**
+ * The periodic identity-audit gating decision (B3c). Pure + isolated so the scheduled-audit wiring
+ * is unit-testable without booting server.ts. Returns true ONLY when ALL hold:
+ *   - `enabled` — the re-pointing dev-gate is on (strict no-op / no oracle probe on the dark fleet);
+ *   - `isSeeded` — there is a ledger to re-verify (boot-seed + recovery is seedFromOracle's job);
+ *   - NOT `unknownMode` — a corrupt ledger refuses mutations (auditIdentities is a no-op there anyway);
+ *   - NOT `inFlight` — the prior pass has not finished (reentrancy guard; a slow oracle never overlaps).
+ * The audit (`auditIdentities()`) is non-destructive (verification state only; zero credential moves)
+ * and unit-tested; this guard is the new logic the scheduled wiring introduced.
+ */
+export function shouldRunIdentityAudit(
+  enabled: boolean,
+  isSeeded: boolean,
+  unknownMode: boolean,
+  inFlight: boolean,
+): boolean {
+  return enabled && isSeeded && !unknownMode && !inFlight;
 }

--- a/src/server/routes.ts
+++ b/src/server/routes.ts
@@ -20808,6 +20808,10 @@ export function createRoutes(ctx: RouteContext): Router {
       // B3b: the balancer is now WIRED — surface its last-pass + breaker status.
       balancerWired: !!cr.rebalancer,
       rebalancer: cr.rebalancer ? cr.rebalancer.status() : null,
+      // B3c: the NON-DESTRUCTIVE identity audit's last pass — the freshness-keeper that prevents
+      // the rebalancer from decaying to inert (every objective needs verified-recent targets).
+      // null until the first audit runs (~90s after boot). Counts only; no credential material.
+      identityAudit: cr.ledger.getLastAuditReport(),
       envTokenGate: {
         refused: verdict.refused,
         // A named CATEGORY, not a credential; scrubbed regardless by credSend → audit.response.

--- a/tests/e2e/credential-repointing-routes-alive.test.ts
+++ b/tests/e2e/credential-repointing-routes-alive.test.ts
@@ -164,6 +164,12 @@ describe('WS5.2 Step 7 /credentials/* E2E lifecycle (feature is alive)', () => {
     expect(loc.status).toBe(200);
     expect(loc.body.enabled).toBe(true);
     expect(loc.body.mode).toBe('active');
+
+    // B3c: the identity-audit surface is ALIVE on the production-shaped bundle (the freshness-keeper
+    // that prevents the rebalancer decaying to inert). The field is present (null until a pass runs).
+    const reb = await request(enabledApp).get('/credentials/rebalancer').set(auth());
+    expect(reb.status).toBe(200);
+    expect(reb.body).toHaveProperty('identityAudit');
   });
 
   it('(b) DARK: every POST lever 503s; rebalancer 503; locations reports dark (strict no-op)', async () => {

--- a/tests/integration/credential-routes.test.ts
+++ b/tests/integration/credential-routes.test.ts
@@ -77,7 +77,7 @@ function makeApp(opts: {
   manualLeversEnabled?: boolean;
   anthropicApiKey?: string;
   fleet?: EnvTokenFleetSession[];
-}): { app: express.Express; stateDir: string; auditLines: string[] } {
+}): { app: express.Express; stateDir: string; auditLines: string[]; ledger: CredentialLocationLedger } {
   const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cred-routes-'));
   fs.mkdirSync(path.join(stateDir, 'logs'), { recursive: true });
   const ledger = buildLedger(stateDir);
@@ -118,7 +118,7 @@ function makeApp(opts: {
     credentialRepointing,
   } as never;
   app.use(createRoutes(ctx));
-  return { app, stateDir, auditLines };
+  return { app, stateDir, auditLines, ledger };
 }
 
 describe('/credentials/* routes (integration)', () => {
@@ -191,6 +191,27 @@ describe('/credentials/* routes (integration)', () => {
     expect(r.body.enabled).toBe(true);
     expect(r.body.balancerWired).toBe(false);
     expect(r.body.envTokenGate.refused).toBe(false);
+  });
+
+  it('B3c: rebalancer surfaces the identity-audit last pass (null before a run, real counts after)', async () => {
+    const built = makeApp({ enabled: true }); stateDir = built.stateDir; cleanup.push(stateDir);
+    server = await listen(built.app);
+    // Before any audit pass: the field is present and null (route reads getLastAuditReport live).
+    const before = await api('/credentials/rebalancer');
+    expect(before.status).toBe(200);
+    expect(before.body).toHaveProperty('identityAudit');
+    expect(before.body.identityAudit).toBeNull();
+    // Run one audit. The test ledger has 2 healthy slots + a noop oracle (always unavailable), so the
+    // safe direction must HOLD both (never quarantine on a transient probe failure) — proven end-to-end.
+    const report = await built.ledger.auditIdentities();
+    expect(report.outcomes.length).toBe(2);
+    expect(report.refreshed).toBe(0);
+    expect(report.quarantined).toBe(0); // a healthy slot is NEVER demoted by an unavailable probe
+    const after = await api('/credentials/rebalancer');
+    expect(after.status).toBe(200);
+    expect(after.body.identityAudit).not.toBeNull();
+    expect(after.body.identityAudit.unresolved).toBe(2);
+    expect(after.body.identityAudit.refreshed).toBe(0);
   });
 
   it('LIVE (flag on): POST /credentials/swap executes the executor; response carries NO token', async () => {

--- a/tests/unit/credential-identity-audit.test.ts
+++ b/tests/unit/credential-identity-audit.test.ts
@@ -1,0 +1,250 @@
+/**
+ * Unit test for the NON-DESTRUCTIVE periodic identity audit (`CredentialLocationLedger.auditIdentities`).
+ *
+ * WHY THIS EXISTS (the bug it closes): the credential rebalancer's every objective (wall-rescue
+ * AND the use-it-or-lose-it drain) only acts on a DESTINATION slot that passes `targetVerifiedRecent`
+ * = lastVerifiedAt within `auditCadenceMs` (default 6h). Nothing refreshed lastVerifiedAt after seed
+ * (`markVerified` had zero callers; the only periodic loop never re-verified), so every slot decayed
+ * to "not recently verified" and the optimizer went permanently inert. `auditIdentities()` is the
+ * missing scheduled re-verification.
+ *
+ * Both sides of every decision boundary (Testing Integrity — semantic correctness):
+ *  - healthy + oracle re-confirms same tenant   → refreshed (lastVerifiedAt advances)
+ *  - quarantined + now resolves cleanly         → recovered (assignment restored, un-quarantined)
+ *  - healthy + oracle confirms a DIFFERENT acct → diverged-quarantined (safe direction)
+ *  - healthy + oracle unavailable (transient)   → unavailable-held (NEVER quarantine a healthy slot)
+ *  - healthy + ambiguous email                  → unverifiable-quarantined
+ *  - healthy + unknown email                    → unverifiable-quarantined
+ *  - already-quarantined + still unavailable    → still-quarantined (no spurious recovery)
+ *  - UNKNOWN mode                               → no-op empty report
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+import {
+  CredentialLocationLedger,
+  type IdentityOracle,
+  type IdentityOracleResult,
+  type LedgerPoolView,
+  type LedgerPoolAccount,
+} from '../../src/core/CredentialLocationLedger.js';
+
+/** A mutable, scriptable oracle — its response map can be swapped between seed and audit. */
+function mutableOracle(initial: Record<string, IdentityOracleResult>, opts?: { throwOn?: () => string | null }) {
+  let map = initial;
+  const oracle: IdentityOracle = {
+    async resolveSlotTenant(slot: string): Promise<IdentityOracleResult> {
+      if (opts?.throwOn?.() === slot) throw new Error('oracle boom');
+      return map[slot] ?? { unavailable: true, reason: 'no script' };
+    },
+  };
+  return { oracle, set: (next: Record<string, IdentityOracleResult>) => { map = next; } };
+}
+
+function poolFrom(accounts: LedgerPoolAccount[]): LedgerPoolView {
+  return { list: () => accounts.slice() };
+}
+
+let tmp: string;
+let counter: number;
+const seq = () => `2026-06-16T00:00:${String(counter++).padStart(2, '0')}.000Z`;
+
+beforeEach(() => {
+  tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'credaudit-'));
+  counter = 0;
+});
+afterEach(() => {
+  SafeFsExecutor.safeRmSync(tmp, { recursive: true, force: true, operation: 'tests/unit/credential-identity-audit.test.ts cleanup' });
+});
+
+function makeLedger(pool: LedgerPoolView, oracle: IdentityOracle): CredentialLocationLedger {
+  return new CredentialLocationLedger({ stateDir: tmp, pool, oracle, now: seq });
+}
+
+const POOL = poolFrom([
+  { id: 'justin-gmail', email: 'justin@gmail.com', configHome: '/h/justin' },
+  { id: 'adriana', email: 'adriana@x.com', configHome: '/h/adriana' },
+]);
+
+describe('CredentialLocationLedger.auditIdentities — refresh (the core fix)', () => {
+  it('re-stamps lastVerifiedAt on a healthy slot the oracle re-confirms', async () => {
+    const { oracle } = mutableOracle({
+      '/h/justin': { email: 'justin@gmail.com' },
+      '/h/adriana': { email: 'adriana@x.com' },
+    });
+    const led = makeLedger(POOL, oracle);
+    await led.seedFromOracle();
+    const seededAt = led.getAssignment('/h/justin')!.lastVerifiedAt;
+    expect(seededAt).not.toBeNull();
+
+    const report = await led.auditIdentities();
+
+    const out = report.outcomes.find((o) => o.slot === '/h/justin')!;
+    expect(out.result).toBe('refreshed');
+    expect(report.refreshed).toBe(2);
+    const refreshedAt = led.getAssignment('/h/justin')!.lastVerifiedAt;
+    expect(refreshedAt).not.toBeNull();
+    // The audit advanced the freshness stamp (later than seed) — the whole point.
+    expect(Date.parse(refreshedAt!)).toBeGreaterThan(Date.parse(seededAt!));
+    expect(led.getAssignment('/h/justin')!.quarantined).toBe(false);
+  });
+});
+
+describe('CredentialLocationLedger.auditIdentities — quarantine exit (recovery)', () => {
+  it('recovers a slot that was seed-quarantined once it resolves cleanly', async () => {
+    // Seed with the oracle unavailable for adriana → that slot quarantines.
+    const m = mutableOracle({
+      '/h/justin': { email: 'justin@gmail.com' },
+      '/h/adriana': { unavailable: true, reason: 'down at seed' },
+    });
+    const led = makeLedger(POOL, m.oracle);
+    await led.seedFromOracle();
+    expect(led.getAssignment('/h/adriana')!.quarantined).toBe(true);
+    expect(led.getAssignment('/h/adriana')!.accountId).toBe('');
+
+    // Oracle recovers → audit should restore + un-quarantine.
+    m.set({ '/h/justin': { email: 'justin@gmail.com' }, '/h/adriana': { email: 'adriana@x.com' } });
+    const report = await led.auditIdentities();
+
+    const out = report.outcomes.find((o) => o.slot === '/h/adriana')!;
+    expect(out.result).toBe('recovered');
+    expect(report.recovered).toBe(1);
+    expect(led.getAssignment('/h/adriana')!.quarantined).toBe(false);
+    expect(led.getAssignment('/h/adriana')!.accountId).toBe('adriana');
+    expect(led.getAssignment('/h/adriana')!.lastVerifiedAt).not.toBeNull();
+  });
+});
+
+describe('CredentialLocationLedger.auditIdentities — divergence (safe direction)', () => {
+  it('quarantines a healthy slot whose credential now belongs to a DIFFERENT account', async () => {
+    const m = mutableOracle({
+      '/h/justin': { email: 'justin@gmail.com' },
+      '/h/adriana': { email: 'adriana@x.com' },
+    });
+    const led = makeLedger(POOL, m.oracle);
+    await led.seedFromOracle();
+
+    // /h/justin's blob now resolves to adriana's email (a client write-back swapped the login).
+    m.set({ '/h/justin': { email: 'adriana@x.com' }, '/h/adriana': { email: 'adriana@x.com' } });
+    const report = await led.auditIdentities();
+
+    const out = report.outcomes.find((o) => o.slot === '/h/justin')!;
+    expect(out.result).toBe('diverged-quarantined');
+    expect(led.getAssignment('/h/justin')!.quarantined).toBe(true);
+    expect(report.quarantined).toBeGreaterThanOrEqual(1);
+  });
+});
+
+describe('CredentialLocationLedger.auditIdentities — transient unavailability is HELD, never quarantined', () => {
+  it('holds a healthy slot when the oracle is unavailable (does NOT demote it)', async () => {
+    const m = mutableOracle({
+      '/h/justin': { email: 'justin@gmail.com' },
+      '/h/adriana': { email: 'adriana@x.com' },
+    });
+    const led = makeLedger(POOL, m.oracle);
+    await led.seedFromOracle();
+    const beforeAt = led.getAssignment('/h/justin')!.lastVerifiedAt;
+
+    // Oracle goes down for justin on the audit pass.
+    m.set({ '/h/justin': { unavailable: true, reason: 'timeout' }, '/h/adriana': { email: 'adriana@x.com' } });
+    const report = await led.auditIdentities();
+
+    const out = report.outcomes.find((o) => o.slot === '/h/justin')!;
+    expect(out.result).toBe('unavailable-held');
+    // Critically: still healthy, NOT quarantined — a transient blip must not break balancing.
+    expect(led.getAssignment('/h/justin')!.quarantined).toBe(false);
+    expect(led.getAssignment('/h/justin')!.lastVerifiedAt).toBe(beforeAt); // unchanged (not re-stamped)
+  });
+
+  it('treats an oracle that THROWS identically to unavailable (held, not quarantined)', async () => {
+    let throwSlot: string | null = null;
+    const m = mutableOracle(
+      { '/h/justin': { email: 'justin@gmail.com' }, '/h/adriana': { email: 'adriana@x.com' } },
+      { throwOn: () => throwSlot },
+    );
+    const led = makeLedger(POOL, m.oracle);
+    await led.seedFromOracle();
+    throwSlot = '/h/justin';
+    const report = await led.auditIdentities();
+    expect(report.outcomes.find((o) => o.slot === '/h/justin')!.result).toBe('unavailable-held');
+    expect(led.getAssignment('/h/justin')!.quarantined).toBe(false);
+  });
+});
+
+describe('CredentialLocationLedger.auditIdentities — unverifiable email quarantines', () => {
+  it('quarantines a healthy slot whose email became AMBIGUOUS (≥2 pool accounts)', async () => {
+    const dupPool = poolFrom([
+      { id: 'justin-gmail', email: 'shared@x.com', configHome: '/h/justin' },
+      { id: 'justin-2', email: 'shared@x.com', configHome: '/h/justin2' },
+      { id: 'adriana', email: 'adriana@x.com', configHome: '/h/adriana' },
+    ]);
+    // Seed cleanly first (distinct emails), then make justin's email collide.
+    const m = mutableOracle({ '/h/justin': { email: 'uniq@x.com' }, '/h/justin2': { email: 'other@x.com' }, '/h/adriana': { email: 'adriana@x.com' } });
+    const seedPool = poolFrom([
+      { id: 'justin-gmail', email: 'uniq@x.com', configHome: '/h/justin' },
+      { id: 'justin-2', email: 'other@x.com', configHome: '/h/justin2' },
+      { id: 'adriana', email: 'adriana@x.com', configHome: '/h/adriana' },
+    ]);
+    const led = new CredentialLocationLedger({ stateDir: tmp, pool: seedPool, oracle: m.oracle, now: seq });
+    await led.seedFromOracle();
+    expect(led.getAssignment('/h/justin')!.quarantined).toBe(false);
+    // Re-point the SAME ledger's pool view by rebuilding with the dup pool would change identity;
+    // instead simulate the audit pool returning shared emails via a fresh ledger over the same dir.
+    const led2 = new CredentialLocationLedger({ stateDir: tmp, pool: dupPool, oracle: mutableOracle({ '/h/justin': { email: 'shared@x.com' }, '/h/justin2': { email: 'shared@x.com' }, '/h/adriana': { email: 'adriana@x.com' } }).oracle, now: seq });
+    const report = await led2.auditIdentities();
+    expect(report.outcomes.find((o) => o.slot === '/h/justin')!.result).toBe('unverifiable-quarantined');
+    expect(led2.getAssignment('/h/justin')!.quarantined).toBe(true);
+  });
+
+  it('quarantines a healthy slot whose email matches NO pool account (unknown-email)', async () => {
+    const m = mutableOracle({ '/h/justin': { email: 'justin@gmail.com' }, '/h/adriana': { email: 'adriana@x.com' } });
+    const led = makeLedger(POOL, m.oracle);
+    await led.seedFromOracle();
+    m.set({ '/h/justin': { email: 'stranger@nowhere.com' }, '/h/adriana': { email: 'adriana@x.com' } });
+    const report = await led.auditIdentities();
+    expect(report.outcomes.find((o) => o.slot === '/h/justin')!.result).toBe('unverifiable-quarantined');
+    expect(led.getAssignment('/h/justin')!.quarantined).toBe(true);
+  });
+});
+
+describe('CredentialLocationLedger.auditIdentities — already-quarantined stays quarantined', () => {
+  it('does not spuriously recover a quarantined slot the oracle still cannot resolve', async () => {
+    const m = mutableOracle({ '/h/justin': { email: 'justin@gmail.com' }, '/h/adriana': { unavailable: true } });
+    const led = makeLedger(POOL, m.oracle);
+    await led.seedFromOracle();
+    expect(led.getAssignment('/h/adriana')!.quarantined).toBe(true);
+    const report = await led.auditIdentities();
+    expect(report.outcomes.find((o) => o.slot === '/h/adriana')!.result).toBe('still-quarantined');
+    expect(led.getAssignment('/h/adriana')!.quarantined).toBe(true);
+  });
+});
+
+describe('CredentialLocationLedger.auditIdentities — report aggregate + getter', () => {
+  it('counts a mixed pass and retains the last report', async () => {
+    const m = mutableOracle({ '/h/justin': { email: 'justin@gmail.com' }, '/h/adriana': { unavailable: true } });
+    const led = makeLedger(POOL, m.oracle);
+    await led.seedFromOracle(); // justin healthy, adriana quarantined
+    m.set({ '/h/justin': { email: 'justin@gmail.com' }, '/h/adriana': { email: 'adriana@x.com' } });
+    const report = await led.auditIdentities(); // justin refreshed, adriana recovered
+    expect(report.refreshed).toBe(1);
+    expect(report.recovered).toBe(1);
+    expect(report.quarantined).toBe(0);
+    expect(led.getLastAuditReport()).toEqual(report);
+  });
+
+  it('is a no-op (empty report) in UNKNOWN mode', async () => {
+    // Corrupt the on-disk store to force UNKNOWN mode.
+    const m = mutableOracle({ '/h/justin': { email: 'justin@gmail.com' } });
+    const led = makeLedger(poolFrom([{ id: 'justin-gmail', email: 'justin@gmail.com', configHome: '/h/justin' }]), m.oracle);
+    await led.seedFromOracle();
+    fs.writeFileSync(path.join(tmp, 'credential-locations.json'), '{ not valid json');
+    const led2 = makeLedger(poolFrom([{ id: 'justin-gmail', email: 'justin@gmail.com', configHome: '/h/justin' }]), m.oracle);
+    expect(led2.isUnknownMode()).toBe(true);
+    const report = await led2.auditIdentities();
+    expect(report.outcomes).toEqual([]);
+    expect(report.refreshed).toBe(0);
+  });
+});

--- a/tests/unit/credential-ledger-boot-seed-guard.test.ts
+++ b/tests/unit/credential-ledger-boot-seed-guard.test.ts
@@ -16,7 +16,7 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import { shouldBootSeedCredentialLedger } from '../../src/core/CredentialLocationLedger.js';
+import { shouldBootSeedCredentialLedger, shouldRunIdentityAudit } from '../../src/core/CredentialLocationLedger.js';
 
 describe('shouldBootSeedCredentialLedger — boot-seed guard (B3a)', () => {
   it('seeds when enabled AND the ledger is not yet seeded (never-seeded / unknown-mode recovery)', () => {
@@ -33,5 +33,28 @@ describe('shouldBootSeedCredentialLedger — boot-seed guard (B3a)', () => {
 
   it('does NOT seed when disabled even if somehow already seeded', () => {
     expect(shouldBootSeedCredentialLedger(false, true)).toBe(false);
+  });
+});
+
+describe('shouldRunIdentityAudit — periodic audit gate (B3c)', () => {
+  // Runs ONLY on the all-true path; every other combination is a no-op. Args: (enabled, seeded, unknown, inFlight).
+  it('runs when enabled AND seeded AND not-unknown AND not-in-flight', () => {
+    expect(shouldRunIdentityAudit(true, true, false, false)).toBe(true);
+  });
+
+  it('does NOT run when the feature is disabled (dark fleet — no oracle probe)', () => {
+    expect(shouldRunIdentityAudit(false, true, false, false)).toBe(false);
+  });
+
+  it('does NOT run before the ledger is seeded (nothing to re-verify)', () => {
+    expect(shouldRunIdentityAudit(true, false, false, false)).toBe(false);
+  });
+
+  it('does NOT run in UNKNOWN (corrupt) mode — recovery is seedFromOracle’s job', () => {
+    expect(shouldRunIdentityAudit(true, true, true, false)).toBe(false);
+  });
+
+  it('does NOT run while a prior pass is in flight (reentrancy guard — no overlap)', () => {
+    expect(shouldRunIdentityAudit(true, true, false, true)).toBe(false);
   });
 });

--- a/upgrades/next/credential-identity-audit.md
+++ b/upgrades/next/credential-identity-audit.md
@@ -1,0 +1,54 @@
+<!-- bump: patch -->
+
+## What Changed
+
+Implements the **always-on scheduled identity audit** the live-credential-repointing design already
+specified (§2.4 / §0.c) but never actually built — the missing piece that lets the account
+"use-it-or-lose-it" optimizer actually act.
+
+Background: the credential rebalancer can only move an account's work onto a slot whose identity was
+**verified recently** (within `auditCadenceMs`, default 6h). But nothing re-verified after the initial
+boot seed — `markVerified` had **zero callers** and the periodic balancer loop never re-checked — so
+~6h after seeding, every slot decayed to "not recently verified", the rebalancer found zero eligible
+targets, and the optimizer went **permanently inert** (it decided nothing even with an idle account
+whose quota was about to reset and go to waste).
+
+- **`CredentialLocationLedger.auditIdentities()`** — a NON-DESTRUCTIVE periodic re-verification (wipes
+  nothing, unlike `seedFromOracle`): re-probes each tracked slot via the identity oracle and refreshes
+  ONLY its verification/quarantine state. A re-confirmed healthy slot is re-stamped fresh; a slot that
+  has since become resolvable EXITS quarantine; a slot whose credential now belongs to a different
+  account (a confirmed login divergence) is quarantined.
+- **Safe direction (never re-creates the stall):** a transient oracle failure/timeout **HOLDS** a
+  healthy slot — it is never knocked offline on a momentary probe failure. It moves **zero**
+  credentials and never triggers a swap; it only refreshes the ledger state the rebalancer reads.
+- **Wiring:** a boot one-shot (~90s after start, guarded against the in-flight boot seed) plus a
+  periodic pass at `auditCadenceMs/2` (capped 30 min), behind the pure `shouldRunIdentityAudit` gate
+  and the SAME dev-gate as the rebalancer. Surfaced read-only on `GET /credentials/rebalancer` as
+  `identityAudit` (last-pass counts).
+
+Ships **dark on the fleet** (rides `subscriptionPool.credentialRepointing.enabled`; strict no-op / no
+oracle probe when off) and runs **live in dry-run on a development agent** (refreshes verification,
+moves zero credentials). Flag-off = byte-identical to today.
+
+## What to Tell Your User
+
+- "The account load-balancer that drains a soon-to-reset account before its quota is wasted now stays
+  alive — previously it quietly stopped finding anything to do after a few hours and sat idle."
+- "It changes nothing on a normal install (off by default) and still moves zero real logins on its own
+  — it just keeps the optimizer's view of your accounts fresh so it can act when you turn it loose."
+
+## Summary of New Capabilities
+
+| Capability | How to Use |
+|-----------|-----------|
+| Scheduled credential identity audit (keeps the rebalancer's targets fresh) | Automatic when credential re-pointing is enabled; no action needed |
+| Audit status | `GET /credentials/rebalancer` → `identityAudit` (last-pass refreshed/recovered/quarantined/unresolved counts) |
+
+## Evidence
+
+- 16 new/extended tests across all three tiers + a pure wiring predicate (`auditIdentities` both sides
+  of every branch, `shouldRunIdentityAudit` all 5 combos, integration route surfacing a real pass,
+  e2e "feature alive") — all green; broader credential sweep 88 green; `tsc` clean.
+- Spec implementation note: `docs/specs/live-credential-repointing-rebalancer.md` §2.4.1.
+- Side-effects review with an independent Phase-5 second-pass concurrence:
+  `upgrades/side-effects/credential-identity-audit.md`.

--- a/upgrades/side-effects/credential-identity-audit.md
+++ b/upgrades/side-effects/credential-identity-audit.md
@@ -1,0 +1,183 @@
+# Side-Effects Review — Scheduled credential identity audit (B3c)
+
+**Version / slug:** `credential-identity-audit`
+**Date:** `2026-06-16`
+**Author:** `Echo (instar-dev agent)`
+**Second-pass reviewer:** `subagent (Phase 5 — credential subsystem is high-risk-adjacent)`
+
+## Summary of the change
+
+Implements the "always-on scheduled identity audit" the live-credential-repointing spec already
+specified (§2.4 / §0.c / §6) but never built. `CredentialLocationLedger.auditIdentities()` is a
+NON-DESTRUCTIVE periodic re-verification: it re-probes each EXISTING tracked slot via the identity
+oracle and refreshes ONLY that slot's verification/quarantine state (it wipes nothing — distinct from
+`seedFromOracle`, which rebuilds). It is wired in `server.ts` as a boot one-shot (~90 s after start,
+after the seed) plus a periodic interval (`auditCadenceMs/2`, capped 30 min, floored 1 min), gated by
+the pure `shouldRunIdentityAudit(enabled, seeded, unknownMode, inFlight)` predicate and the SAME
+dev-gate as the rebalancer. The last pass is surfaced read-only on `GET /credentials/rebalancer` as
+`identityAudit`. Files: `src/core/CredentialLocationLedger.ts`, `src/commands/server.ts`,
+`src/server/routes.ts`, `docs/specs/live-credential-repointing-rebalancer.md` (§2.4.1), + 4 test files.
+
+**Why it matters:** the credential rebalancer's every objective (wall-rescue AND the use-it-or-lose-it
+drain) only acts on a DESTINATION slot that passed `targetVerifiedRecent` = verified within
+`auditCadenceMs` (default 6h). Nothing re-stamped `lastVerifiedAt` after the boot seed (`markVerified`
+had zero callers; the periodic `rebalancer.tick()` never re-verified), so ~6h after seed every slot
+decayed to "not recently verified" and the optimizer went permanently inert (`decisions: []`,
+`noActuationReason: "… missing eligible target"`) even with an idle soon-resetting account begging to
+be drained. This is the robustness fix that makes the existing optimizer able to act.
+
+## Decision-point inventory
+
+- `CredentialLocationLedger.auditIdentities()` — **add** — per-slot: refresh verified-recent on a
+  re-confirmed healthy slot; recover (un-quarantine) a now-resolvable slot; quarantine a confirmed
+  divergence / unverifiable email; HOLD a healthy slot on a transient oracle failure.
+- `shouldRunIdentityAudit(enabled, seeded, unknownMode, inFlight)` — **add** — pure gate deciding
+  whether a scheduled pass runs.
+- `GET /credentials/rebalancer` response — **modify (pass-through, additive)** — adds a read-only
+  `identityAudit` field (last-pass counts; null until first pass). No behavior change to existing fields.
+
+---
+
+## 1. Over-block
+
+No outbound/inbound message or dispatch block surface. The nearest "block-like" action is quarantining
+a slot (excluding it from balancing). Over-quarantine risk: a healthy slot quarantined when it
+shouldn't be. The safe direction explicitly prevents the dangerous over-block: a transient oracle
+failure/throw → **HOLD** (the slot is left exactly as-is, never quarantined). A slot is only
+quarantined on a CONFIRMED `email` (the oracle contract §2.11: `email` set === identity-confirmed, it
+never guesses a mismatch) that belongs to a different account / no account / an ambiguous account — a
+genuine login divergence, the same condition `seedFromOracle` already quarantines on.
+
+## 2. Under-block
+
+The audit will NOT catch a divergence during the window between two passes (≤ `auditCadenceMs/2`,
+≤30 min) — a login that changes and changes back within one interval is missed, as is any divergence
+in the seconds before a rebalancer pass reads the slot. This is acceptable: the §2.3.6 delayed
+re-verify still covers in-flight-swap divergence, and the audit narrows (not closes) the long-tail
+client-write-back window exactly as §6 already states. It also does not re-probe a pool `configHome`
+that was never seeded into the ledger (a brand-new enrollment) — that is `seedFromOracle`'s job at boot;
+the audit is scoped to existing tracked slots by design.
+
+## 3. Level-of-abstraction fit
+
+Right layer. The audit lives ON the ledger (`CredentialLocationLedger`) — the single write funnel that
+already owns the oracle, the pool view, and every verification/quarantine mutator (`markVerified`,
+`quarantineSlot`, `unquarantineSlot`, `recordAssignment`). It REUSES those primitives rather than
+re-implementing identity resolution, and mirrors `seedFromOracle`'s probe/classify logic on a
+per-slot, non-destructive basis. The scheduling is a thin `setInterval` in `server.ts` (the same
+pattern as the existing rebalancer tick), and the run/skip decision is extracted to a pure predicate
+(`shouldRunIdentityAudit`) exactly like the existing `shouldBootSeedCredentialLedger`.
+
+## 4. Signal vs authority compliance
+
+**Required reference:** [docs/signal-vs-authority.md](../../docs/signal-vs-authority.md)
+
+- [x] No — this change produces a SIGNAL (refreshed ledger verification state) consumed by the
+  existing rebalancer; it has no outbound/dispatch block authority.
+
+The audit moves ZERO credentials and NEVER triggers a swap — the executor (gated by dry-run) remains
+the only write path for credential material. The one authority-shaped action, quarantining a slot, is
+a DETECTIVE, reversible exclusion that follows the spec's already-converged quarantine-never-repair
+rule, fires only on the oracle's non-brittle CONFIRMED-email contract, and is biased to the safe
+direction (transient failure → HOLD, never quarantine). It adds no brittle blocking logic.
+
+## 5. Interactions
+
+- **Shadowing:** none. The audit refreshes state the rebalancer reads on its NEXT tick; it runs on its
+  own timer (different cadence) and does not pre-empt or wrap the rebalancer tick.
+- **Double-fire:** the periodic timer + the boot one-shot can never overlap — both go through the
+  single `credAuditInFlight` reentrancy guard (and the pure predicate gates on it). A slow oracle pass
+  cannot stack a successor.
+- **Seed↔audit interleave (hardened after second-pass):** on a FRESH never-seeded agent the boot
+  `seedFromOracle()` is fire-and-forget at t=0 and the boot audit fires at t≈90 s; `isSeeded()` does
+  NOT protect this (seed bumps version at 'begin', flipping `isSeeded()` true mid-seed). Closed
+  structurally with a `credSeedInFlight` flag (set around the boot seed, cleared in its `.finally`)
+  that `runCredentialIdentityAudit` checks before running — so the audit cannot interleave with an
+  in-flight boot seed, rather than relying on the 90 s timing assumption.
+- **Races:** the audit and the rebalancer both touch the ledger, but the ledger is a single-writer
+  in-process store (version-bumped, `save()` after each mutation); they run on the same Node event
+  loop (no true concurrency), and the audit only writes verification/quarantine fields the rebalancer
+  reads, never the cooldown/hysteresis state the rebalancer owns. The `seedFromOracle` boot path and
+  the audit are sequenced (the boot audit is delayed 90 s and the predicate skips while unseeded).
+- **Feedback loops:** none. The audit's output (fresh verification) feeds the rebalancer, but the
+  rebalancer does not feed back into the oracle's identity answers.
+
+## 6. External surfaces
+
+- **Identity oracle (Anthropic OAuth profile endpoint):** the audit issues per-slot oracle probes on
+  its cadence — the same probe `seedFromOracle` already makes, now also on a ≤30 min schedule. Bounded
+  (≤ slot count per pass; reentrancy-guarded; dark-fleet no-op so single-account/plain installs never
+  probe). No new external system, no new credential surface — the oracle dependency already exists.
+- **`GET /credentials/rebalancer`:** adds a read-only `identityAudit` field (counts only — never any
+  token material; the route's existing scrub chokepoint is unchanged). Additive; existing fields
+  untouched.
+- **Persistent state:** writes the SAME ledger file (`credential-locations.json`) the seed/swap paths
+  already write (verification timestamps + quarantine flags + journal entries). No new file, no schema
+  change to the assignment shape.
+- **No operator-facing actions** added — the audit is autonomous background housekeeping; the only
+  surface is the read-only status field. Not applicable to Mobile-Complete.
+
+## 6b. Operator-surface quality
+
+No operator surface — not applicable. This change touches no `dashboard/*` renderer, approval page, or
+grant/revoke/secret form; the only surface is a read-only JSON field on an existing API route.
+
+## 7. Multi-machine posture (Cross-Machine Coherence)
+
+**machine-local BY DESIGN.** A credential's login physically lives in a config-home on ONE machine's
+disk/keychain; the `CredentialLocationLedger` is inherently per-machine (it maps THIS machine's slots
+to accounts), as is the rebalancer it feeds. The identity audit re-verifies THIS machine's slots — it
+must differ per machine because the credential blobs differ per machine. It emits NO user-facing
+notices (one-voice gating not needed — background housekeeping, counts only in a status field), holds
+no topic-bound durable state (so nothing strands on topic transfer), and generates no URLs. The
+cross-machine credential story (sharing logins across machines) is the separate, in-flight
+`cross-machine-account-sharing` workstream (instar-exo) and is explicitly out of this change's scope;
+confirmed zero source-file overlap with that branch.
+
+## 8. Rollback cost
+
+Pure code change — revert the commit, ship as the next patch. No data migration: the audit writes only
+the existing ledger fields (`lastVerifiedAt`, `quarantined`, journal) that seed/swap already write, so
+a rollback leaves the ledger in a valid state (just no longer auto-refreshed). No agent-state repair,
+no user-visible regression during the rollback window (the feature is dev-gated and dark on the fleet;
+on a dev agent a rollback simply returns to the prior inert-after-6h behavior). The new `identityAudit`
+status field disappearing is inert (read-only, additive).
+
+## Conclusion
+
+The review produced no design changes — the implementation already follows the safe-direction and
+single-write-funnel patterns the converged spec established. The change closes a specified-but-unbuilt
+gap (the scheduled identity audit) that was the root cause of the optimizer never acting; it adds a
+signal-refresher with no brittle blocking authority, reuses existing ledger primitives, is
+reentrancy-guarded and dark-gated, and is covered across all three test tiers plus a pure wiring
+predicate. Clear to ship pending Phase 5 second-pass concurrence.
+
+## Second-pass review (if required)
+
+**Reviewer:** subagent (credential-subsystem reviewer)
+**Independent read of the artifact: CONCUR**
+
+The reviewer independently traced the code and confirmed: the safe direction is correct (an
+`unavailable`/throwing oracle lands `unavailable-held` via `continue`, never reaching `quarantineSlot`;
+a confirmed-different email correctly `diverged-quarantined`; a recovered slot correctly
+un-quarantines); signal-vs-authority compliant (zero credential moves; quarantine fires only on the
+oracle's non-brittle CONFIRMED-`email` contract); iteration safety correct (slot names snapshotted
+up-front, `existing` re-fetched per iteration, `continue` on mid-pass disappearance — no
+mutate-while-iterating bug); no token leak (status routes through the scrub chokepoint; carries
+non-secret email/accountId identifiers only); all three test tiers genuinely cover both sides of every
+boundary (no hollow assertions). One LOW finding raised and RESOLVED in this artifact: the fresh-agent
+seed↔audit interleave now has an explicit `credSeedInFlight` guard (see §5) rather than relying on the
+90 s timing assumption. Concur to ship.
+
+## Evidence pointers
+
+- `tests/unit/credential-identity-audit.test.ts` — 10 tests, both sides of every branch (refresh,
+  recover, divergence-quarantine, transient-held, ambiguous/unknown quarantine, still-quarantined,
+  UNKNOWN-mode no-op, aggregate report).
+- `tests/unit/credential-ledger-boot-seed-guard.test.ts` — `shouldRunIdentityAudit` predicate, all 5
+  boundary combinations.
+- `tests/integration/credential-routes.test.ts` — route surfaces a real audit pass live (wiring
+  integrity + safe-direction end-to-end).
+- `tests/e2e/credential-repointing-routes-alive.test.ts` — `identityAudit` alive on the
+  production-shaped bundle.
+- Broader sweep: 88 green across the credential subsystem; `tsc --noEmit` clean.


### PR DESCRIPTION
## ELI16 — in plain English

Before my account load-balancer will move work onto one of your Claude accounts, it insists that account was identity-checked recently (within 6 hours). The problem: nothing ever re-checked them. Each account got checked once when it was first set up, and there was no background job to re-check on a schedule — so a few hours later every account read as "not recently checked," the balancer found nothing it was allowed to touch, and it sat completely idle. That's why an account like Adriana could be about to reset with most of its weekly quota unused and the balancer would do nothing about it. This change adds the missing background re-check: it periodically re-confirms each account's identity and stamps it fresh, and auto-clears an account that was set aside once it re-confirms. It's deliberately careful — a momentary check failure *holds* a healthy account in place rather than knocking it offline — and it moves zero real logins; it only keeps the balancer's view fresh so it can act. Off by default on normal installs; runs in safe "decide-only" mode on a development agent.

## What & why

Implements the **always-on scheduled identity audit** the live-credential-repointing spec already specified (§2.4 / §0.c) but never built — the missing piece that makes the account "use-it-or-lose-it" optimizer able to act.

**Root cause (live-observed):** the rebalancer's every objective (wall-rescue AND the use-it-or-lose-it drain) only acts on a slot that passed `targetVerifiedRecent` = verified within `auditCadenceMs` (default 6h). But `markVerified` had **zero callers** and the periodic `rebalancer.tick()` never re-verified — so ~6h after the boot seed every slot decayed to "not recently verified", the rebalancer found zero eligible targets, and the optimizer went **permanently inert** even with an idle account whose weekly quota was about to reset and go to waste.

## The fix

- **`CredentialLocationLedger.auditIdentities()`** — NON-DESTRUCTIVE periodic re-verification (wipes nothing, unlike `seedFromOracle`): re-probes each tracked slot via the oracle and refreshes only its verification/quarantine state. Refresh re-confirmed-healthy / recover now-resolvable-quarantined / quarantine a confirmed login divergence / **HOLD** a healthy slot on a transient oracle failure (never demote it). Moves **zero** credentials; never triggers a swap.
- **`shouldRunIdentityAudit()`** pure gate + **B3c server wiring** (boot one-shot guarded against the in-flight boot seed via `credSeedInFlight`, + periodic at `auditCadenceMs/2` capped 30m), same dev-gate as the rebalancer; reentrancy-guarded.
- **`identityAudit`** surfaced read-only on `GET /credentials/rebalancer` (last-pass counts).
- Spec implementation note §2.4.1; ELI16 file amended.

## Safety

Dark on the fleet (rides `subscriptionPool.credentialRepointing.enabled`; strict no-op when off); live-in-dry-run on a dev agent. Signal-only — refreshes ledger state, holds no brittle blocking authority; quarantine fires only on the oracle's CONFIRMED-`email` contract. Independent Phase-5 second-pass **concur**; the one finding (fresh-agent seed-audit interleave) hardened with `credSeedInFlight`.

## Tests

39 across all 3 tiers + a pure wiring predicate; broader credential sweep 88 green; `tsc` clean. Side-effects artifact: `upgrades/side-effects/credential-identity-audit.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
