### PR TITLE
feat(ws52): Account Follow-Me §6.2 — locallyExecutable account-selection gate

### DIFF
--- a/.instar/instar-dev-decisions/2026-06-17T11-19-22-401Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-06-17T11-19-22-401Z-unknown.json
@@ -1,0 +1,13 @@
+{
+  "ts": "2026-06-17T11:19:22.401Z",
+  "slug": "unknown",
+  "suggestedTier": 2,
+  "declaredTier": 2,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 2,
+  "loc": 46,
+  "causalAutopsy": null,
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-06-17T11-21-50-298Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-06-17T11-21-50-298Z-unknown.json
@@ -1,0 +1,13 @@
+{
+  "ts": "2026-06-17T11:21:50.298Z",
+  "slug": "unknown",
+  "suggestedTier": 2,
+  "declaredTier": 2,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 2,
+  "loc": 46,
+  "causalAutopsy": null,
+  "verdict": "pass"
+}

--- a/src/core/QuotaAwareScheduler.ts
+++ b/src/core/QuotaAwareScheduler.ts
@@ -27,6 +27,7 @@ import type {
   SubscriptionAccount,
   AccountQuotaSnapshot,
 } from './SubscriptionPool.js';
+import { isLocallyExecutable } from './SubscriptionPool.js';
 
 /** The binding window for swap decisions: the 7-day window is the scarce one. */
 export interface SelectionOptions {
@@ -38,11 +39,6 @@ export interface SelectionOptions {
 }
 
 const DEFAULT_SOFT_THRESHOLD = 90;
-
-/** An account is selectable only in these statuses. */
-function isEligibleStatus(a: SubscriptionAccount): boolean {
-  return a.status === 'active' || a.status === 'warming';
-}
 
 /**
  * Most-constrained-window utilization: the MAX across the account's known
@@ -106,7 +102,7 @@ export function selectAccount(
   const nowMs = opts.nowMs ?? Date.parse('2026-01-01T00:00:00Z'); // tests pass nowMs; prod callers always set it
   const eligible = accounts.filter(
     (a) =>
-      isEligibleStatus(a) &&
+      isLocallyExecutable(a) &&
       a.id !== excludeId &&
       bindingUtilization(a.lastQuota) < soft,
   );
@@ -128,9 +124,11 @@ export function selectAccount(
  * "accepted as marginal" with real evidence that it materially under-delivered.)
  *
  * Crucially it shares the EXACT eligibility predicate `selectAccount` uses
- * (`isEligibleStatus` + binding utilization below the soft threshold), so
+ * (`isLocallyExecutable` + binding utilization below the soft threshold), so
  * `placeable` here ⟺ `selectAccount(...) !== null` — the never-loop invariant
- * holds (the throttle never allows when placement can place nothing). Percentages
+ * holds (the throttle never allows when placement can place nothing). A
+ * credential-less meta account (WS5.2 §6.2) is excluded from BOTH by the shared
+ * predicate, so the invariant is preserved. Percentages
  * are clamped to [0,100]; `degraded:true` when the best account has no trustworthy
  * live reading, so the throttle applies its bounded degraded cap instead of a
  * phantom "0% fresh".
@@ -141,7 +139,7 @@ export function poolHeadroom(
 ): { placeable: boolean; weeklyPercent: number | null; fiveHourPercent: number | null; degraded: boolean } {
   const soft = opts.softThresholdPct ?? DEFAULT_SOFT_THRESHOLD;
   const eligible = accounts.filter(
-    (a) => isEligibleStatus(a) && bindingUtilization(a.lastQuota) < soft,
+    (a) => isLocallyExecutable(a) && bindingUtilization(a.lastQuota) < soft,
   );
   if (eligible.length === 0) {
     return { placeable: false, weeklyPercent: null, fiveHourPercent: null, degraded: false };

--- a/src/core/SubscriptionPool.ts
+++ b/src/core/SubscriptionPool.ts
@@ -128,6 +128,27 @@ export interface SubscriptionAccount {
   version: number;
 }
 
+/**
+ * WS5.2 §6.2 — "locally executable" predicate. An account is executable on THIS
+ * machine iff this machine holds it with a real local `configHome` AND a valid
+ * login (status active/warming, never needs-reauth/disabled/rate-limited). A
+ * meta-only account replicated in from a peer (no local credential, empty
+ * `configHome`) is NOT locally executable and must be invisible to every
+ * account-selection / swap-target / placement path — closing the force-mode
+ * "use an account I have metadata for but no credential" hole at SELECTION time.
+ *
+ * This is a pure tightening: every real pool account today carries a non-empty
+ * `configHome` (required by `add()`), so this only ever excludes a credential-less
+ * meta projection — it never changes selection among genuinely-held accounts.
+ */
+export function isLocallyExecutable(a: SubscriptionAccount): boolean {
+  return (
+    typeof a.configHome === 'string' &&
+    a.configHome.trim().length > 0 &&
+    (a.status === 'active' || a.status === 'warming')
+  );
+}
+
 interface SubscriptionPoolStore {
   version: 1;
   accounts: SubscriptionAccount[];
@@ -241,6 +262,15 @@ export class SubscriptionPool {
   get(id: string): SubscriptionAccount | null {
     const found = this.store.accounts.find((a) => a.id === id);
     return found ? { ...found } : null;
+  }
+
+  /**
+   * WS5.2 §6.2 — accounts THIS machine can actually execute against (real local
+   * `configHome` + a valid login). The canonical selectable set for the router and
+   * every swap/placement path; a credential-less meta projection is excluded.
+   */
+  locallyExecutable(): SubscriptionAccount[] {
+    return this.store.accounts.filter(isLocallyExecutable).map((a) => ({ ...a }));
   }
 
   /** Count of accounts. A pool of 0 is the dark/no-op default. */

--- a/tests/unit/account-follow-me-locally-executable.test.ts
+++ b/tests/unit/account-follow-me-locally-executable.test.ts
@@ -1,0 +1,118 @@
+/**
+ * WS5.2 §6.2 — the `locallyExecutable` selection gate.
+ *
+ * An account is executable on THIS machine iff this machine holds it with a real
+ * local `configHome` AND a valid login (active/warming). A credential-less meta
+ * projection replicated in from a peer (empty `configHome`) must be invisible to
+ * every account-selection / swap-target / placement path — closing the force-mode
+ * "use an account I have metadata for but no credential" hole at SELECTION time.
+ *
+ * Wiring-integrity: a meta-only account is provably UNSELECTABLE by `selectAccount`
+ * and is excluded from `poolHeadroom`, preserving the never-loop invariant
+ * (`placeable ⟺ selectAccount(...) !== null`).
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import {
+  SubscriptionPool,
+  isLocallyExecutable,
+  type SubscriptionAccount,
+} from '../../src/core/SubscriptionPool.js';
+import { selectAccount, poolHeadroom } from '../../src/core/QuotaAwareScheduler.js';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+
+const NOW = Date.parse('2026-06-17T00:00:00Z');
+
+function acct(
+  id: string,
+  over: Partial<SubscriptionAccount> = {},
+): SubscriptionAccount {
+  return {
+    id,
+    nickname: id,
+    provider: 'anthropic',
+    framework: 'claude-code',
+    configHome: `/h/.claude-${id}`,
+    status: 'active',
+    lastQuota: null,
+    enrolledAt: '2026-06-01T00:00:00Z',
+    version: 1,
+    ...over,
+  };
+}
+
+describe('WS5.2 §6.2 isLocallyExecutable predicate', () => {
+  it('TRUE for a held account with a real configHome and a valid login', () => {
+    expect(isLocallyExecutable(acct('a', { status: 'active' }))).toBe(true);
+    expect(isLocallyExecutable(acct('b', { status: 'warming' }))).toBe(true);
+  });
+
+  it('FALSE for a meta-only account (empty / whitespace configHome) even when active', () => {
+    expect(isLocallyExecutable(acct('meta', { configHome: '', status: 'active' }))).toBe(false);
+    expect(isLocallyExecutable(acct('meta2', { configHome: '   ', status: 'active' }))).toBe(false);
+  });
+
+  it('FALSE for an invalid login even with a real configHome', () => {
+    expect(isLocallyExecutable(acct('r', { status: 'needs-reauth' }))).toBe(false);
+    expect(isLocallyExecutable(acct('d', { status: 'disabled' }))).toBe(false);
+    expect(isLocallyExecutable(acct('l', { status: 'rate-limited' }))).toBe(false);
+  });
+});
+
+describe('WS5.2 §6.2 selectAccount excludes meta-only accounts', () => {
+  it('never selects a credential-less meta account, even if it is the only "active" one', () => {
+    const metaOnly = acct('peer-meta', { configHome: '', status: 'active' });
+    expect(selectAccount([metaOnly], { nowMs: NOW })).toBeNull();
+  });
+
+  it('picks the real local account over a meta-only peer account', () => {
+    const metaOnly = acct('peer-meta', { configHome: '', status: 'active' });
+    const real = acct('local-real', { status: 'active' });
+    const picked = selectAccount([metaOnly, real], { nowMs: NOW });
+    expect(picked?.id).toBe('local-real');
+  });
+
+  it('genuinely-held accounts are unaffected (pure tightening — no regression)', () => {
+    const a = acct('a', { status: 'active' });
+    const b = acct('b', { status: 'warming' });
+    expect(selectAccount([a, b], { nowMs: NOW })).not.toBeNull();
+  });
+});
+
+describe('WS5.2 §6.2 poolHeadroom shares the predicate (never-loop invariant)', () => {
+  it('placeable:false when the only account is meta-only — matching selectAccount() === null', () => {
+    const metaOnly = acct('peer-meta', { configHome: '', status: 'active' });
+    expect(poolHeadroom([metaOnly], { nowMs: NOW }).placeable).toBe(false);
+    expect(selectAccount([metaOnly], { nowMs: NOW })).toBeNull();
+  });
+
+  it('placeable:true when a real account exists — matching selectAccount() !== null', () => {
+    const metaOnly = acct('peer-meta', { configHome: '', status: 'active' });
+    const real = acct('local-real', { status: 'active' });
+    expect(poolHeadroom([metaOnly, real], { nowMs: NOW }).placeable).toBe(true);
+    expect(selectAccount([metaOnly, real], { nowMs: NOW })).not.toBeNull();
+  });
+});
+
+describe('WS5.2 §6.2 SubscriptionPool.locallyExecutable()', () => {
+  let dir: string;
+  let pool: SubscriptionPool;
+
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'subpool-le-'));
+    pool = new SubscriptionPool({ stateDir: dir });
+  });
+  afterEach(() => {
+    try { SafeFsExecutor.safeRmSync(dir, { recursive: true, force: true, operation: 'tests/unit/account-follow-me-locally-executable.test.ts:cleanup' }); } catch { /* @silent-fallback-ok: best-effort temp-dir cleanup */ }
+  });
+
+  it('returns only accounts with a valid login (a real pool account always has a configHome)', () => {
+    pool.add({ id: 'a', nickname: 'a', provider: 'anthropic', framework: 'claude-code', configHome: '/h/.claude-a', status: 'active' });
+    pool.add({ id: 'b', nickname: 'b', provider: 'anthropic', framework: 'claude-code', configHome: '/h/.claude-b', status: 'needs-reauth' });
+    const ex = pool.locallyExecutable();
+    expect(ex.map((a) => a.id)).toEqual(['a']);
+  });
+});

--- a/upgrades/next/ws52-account-follow-me-locally-executable.md
+++ b/upgrades/next/ws52-account-follow-me-locally-executable.md
@@ -1,0 +1,19 @@
+## What Changed
+
+WS5.2 Account Follow-Me, §6.2 — the `locallyExecutable` account-selection gate. A new shared predicate `isLocallyExecutable(account)` (an account is executable on THIS machine iff it holds a real local `configHome` AND a valid login — active/warming) now gates account selection at its chokepoint: both `QuotaAwareScheduler.selectAccount()` (placement + swap-target selection) and `poolHeadroom()` (the quota throttle) filter on it, preserving the documented never-loop invariant `placeable ⟺ selectAccount(...) !== null`. A credential-less meta-only account replicated in from a peer (empty `configHome`) is now structurally unselectable — closing the force-mode "use an account I have metadata for but no credential" hole at SELECTION time. Adds `SubscriptionPool.locallyExecutable()` as the canonical machine-executable account set.
+
+This is a pure tightening: every real pool account already carries a non-empty `configHome` (required by `add()`), so among genuinely-held accounts the predicate is a no-op — it only ever excludes a credential-less peer projection. The structural guard that lets the later enrollment-execution PRs add accounts without any path ever selecting a peer's credential-less account.
+
+## Evidence
+
+- 9 unit tests (`tests/unit/account-follow-me-locally-executable.test.ts`): both boundary sides (executable active/warming + real configHome; non-executable empty/whitespace configHome, needs-reauth/disabled/rate-limited), selectAccount exclusion of a meta-only account, real-over-meta preference, no-regression for held accounts, and explicit never-loop-invariant agreement (`poolHeadroom.placeable ⟺ selectAccount !== null`) for meta-only and real cases. `tsc --noEmit` clean.
+- Side-effects review + mandatory independent second-pass security review (concurred): verified the never-loop invariant is preserved by the shared predicate, the change is a true no-op for current accounts, zero dangling references, no missed selection path, fail-closed (no fail-open). Artifact: `upgrades/side-effects/ws52-account-follow-me-locally-executable.md`.
+- Spec: `docs/specs/ws52-account-follow-me-security.md` §6.2 + §6.3a (converged, approved).
+
+## What to Tell Your User
+
+Nothing to do — this is an internal selection-safety guard, shipped off by default as part of the multi-machine account-sharing groundwork. It guarantees this machine can only ever pick an account it actually holds a login for, never a peer's account it merely knows about. No user-facing surface in this release.
+
+## Summary of New Capabilities
+
+Internal: a `locallyExecutable` account-selection gate so a credential-less peer account projection can never be selected for execution, placement, or swap on this machine. Defense-in-depth groundwork for the WS5.2 enrollment-execution path. No user-facing surface.

--- a/upgrades/side-effects/ws52-account-follow-me-locally-executable.md
+++ b/upgrades/side-effects/ws52-account-follow-me-locally-executable.md
@@ -1,0 +1,69 @@
+# Side-Effects Review — WS5.2 §6.2 `locallyExecutable` selection gate
+
+**Version / slug:** `ws52-account-follow-me-locally-executable`
+**Date:** `2026-06-17`
+**Author:** `Echo (instar-dev agent)`
+**Second-pass reviewer:** `pending (high-risk: account selection / credential boundary)`
+
+## Summary of the change
+
+WS5.2 §6.2. Adds a single shared predicate `isLocallyExecutable(account)` (exported from `src/core/SubscriptionPool.ts`) — an account is executable on THIS machine iff it carries a real local `configHome` AND a valid login (status `active`/`warming`). A meta-only account replicated in from a peer (credential-less, empty `configHome`) is NOT locally executable. The predicate is applied at the account-selection chokepoint in `src/core/QuotaAwareScheduler.ts` — in BOTH `selectAccount()` (the placement/swap selector, used by `ProactiveSwapMonitor` + `onQuotaPressure`/`SessionMigrator`) AND `poolHeadroom()` (the quota-throttle), which MUST share the exact eligibility predicate to preserve the documented never-loop invariant `placeable ⟺ selectAccount(...) !== null`. A `SubscriptionPool.locallyExecutable()` convenience method returns the filtered selectable set. Files: `SubscriptionPool.ts`, `QuotaAwareScheduler.ts`, plus `tests/unit/account-follow-me-locally-executable.test.ts`.
+
+## Decision-point inventory
+
+- `QuotaAwareScheduler.selectAccount()` eligibility filter — **modify** — tightened from status-only (`isEligibleStatus`) to `isLocallyExecutable` (status + non-empty configHome). A credential-less account is now unselectable.
+- `QuotaAwareScheduler.poolHeadroom()` eligibility filter — **modify** — tightened identically, preserving `placeable ⟺ selectAccount !== null`.
+- `SubscriptionPool.locallyExecutable()` — **add** — canonical read of the machine-executable account set.
+
+---
+
+## 1. Over-block
+
+**What legitimate inputs does this change reject that it shouldn't?**
+
+None. Every genuinely-held pool account carries a non-empty `configHome` (required by `SubscriptionPool.add()`, which trims and validates it), so among real accounts this predicate is a pure no-op — it returns exactly what `isEligibleStatus` returned before. It only ever excludes an account with an empty/whitespace `configHome`, which by construction has no local credential and therefore cannot spawn a session. There is no legitimate "selectable account with no configHome" today.
+
+## 2. Under-block
+
+**What failure modes does this still miss?**
+
+It gates SELECTION, not execution-time credential validity. An account that has a `configHome` and `active` status but whose on-disk token is stale/revoked still passes the predicate (the swap/refresh machinery + provider-side 401 handling owns that case — out of scope for §6.2). It also does not inspect token contents; a corrupted credential file at a valid `configHome` is caught downstream, not here. This is intentional: §6.2's job is "never select an account we hold no credential for," not "verify the credential works."
+
+## 3. Level-of-abstraction fit
+
+Correct layer. Account selection is exactly where "can this machine run this account?" must be decided — the predicate lives next to the `SubscriptionAccount` type (its canonical home) and is applied at the two selectors that gate placement. A higher layer (the router) does not select accounts (it routes SDK-vs-pool *path*, then the interactive pool runs whatever account the session was placed under); a lower layer (the credential store) does not know about selection. The shared-predicate design avoids the classic split-brain where two selectors drift.
+
+## 4. Signal vs authority compliance
+
+This is a **filter on a selection set**, not a brittle check with blocking authority over messages/actions. It is deterministic (a field-presence + status check), not heuristic — so it does not fall under the signal-vs-authority concern about brittle blocking logic. It cannot mis-fire on ambiguous input: `configHome` is either a non-empty string or not. It never blocks a user message or an outbound action; it only narrows which accounts a placement/swap may pick. Reference: `docs/signal-vs-authority.md` — a deterministic capability gate (can this machine physically execute this account) is authority appropriately exercised, not a brittle heuristic.
+
+## 5. Interactions
+
+The one real interaction is the **never-loop invariant** between `selectAccount` and `poolHeadroom`: the throttle's comment guarantees `placeable ⟺ selectAccount(...) !== null`. Tightening only one selector would break it (throttle says "go" while placement returns null → spin). Both are tightened with the SAME predicate, and a unit test asserts the two agree on a meta-only account. No other selector consumes these. `ProactiveSwapMonitor`/`SessionMigrator`/`onQuotaPressure` reach selection THROUGH `selectAccount`, so they inherit the gate for free. `PlacementExecutor` (cross-machine placement) does not select an account, so it is unaffected.
+
+## 6. External surfaces
+
+No new route, no new config, no user-facing surface. `SubscriptionPool.locallyExecutable()` is a new read method but no route exposes it in this change. Behavior visible to other agents/users is unchanged because the predicate is a no-op for all real accounts today (all have configHomes). It does not depend on timing or runtime conditions.
+
+## 7. Multi-machine posture (Cross-Machine Coherence)
+
+**Machine-local BY DESIGN.** This is the precise point of the change: a `configHome` is a per-machine credential location, so "locally executable" is inherently a per-machine question. The predicate deliberately treats a peer's account (which would arrive as a credential-less meta projection if/when a future scope=pool selection merges peer accounts into a local selection list) as NON-executable here. There is no replication or proxy-on-read surface — by design, each machine answers "which accounts can I run?" from its OWN configHome-bearing accounts. This is the structural guard that lets the later enrollment-execution PRs safely add accounts without any path ever selecting a peer's credential-less account.
+
+## 8. Rollback cost
+
+Trivial. Pure code change, no migration, no persisted state, no config. Revert is a single-commit back-out; because the predicate is a no-op for all current accounts, reverting changes nothing observable today. No agent state repair, no data migration.
+
+---
+
+## Second-pass review
+
+**Concur with the review.** Verified independently against the actual code, spec §6.2/§6.3a, build, and tests:
+
+1. **Never-loop invariant preserved** — `selectAccount` (`QuotaAwareScheduler.ts:103-108`) and `poolHeadroom` (`:141-143`) use the byte-identical eligibility predicate `isLocallyExecutable(a) && bindingUtilization(a.lastQuota) < soft`. `selectAccount`'s extra `a.id !== excludeId` is a pure narrowing on the swap path; the throttle calls `poolHeadroom` without an exclude, so `placeable ⟺ selectAccount(...) !== null` holds.
+2. **True no-op for current accounts** — `add()` (`SubscriptionPool.ts:308-309`) and `update()` (`:356-359`) both trim and reject empty `configHome`; no real account can have one. For real accounts `isLocallyExecutable` reduces to the old `active/warming` status check — exact behavioral parity.
+3. **Zero dangling `isEligibleStatus`** — grep across `src/` + `tests/` returns nothing; `tsc --noEmit` EXIT=0.
+4. **No missed selection path** — all `selectAccount`/`poolHeadroom` callers (`ProactiveSwapMonitor:226` swap-target, `server.ts:14343` spawn-resolver, `onQuotaPressure`, QuotaTracker throttle) route through the gated selectors. `AnthropicSubscriptionRouter` routes SDK-vs-pool *paths*, not accounts; `InteractivePoolIntelligenceProvider` runs sessions already spawned under a gated account; `mapCandidates` only enumerates running-session SOURCES; no `.list()[0]`-style ungated picks exist; `PlacementExecutor` doesn't select accounts.
+5. **Tests cover both boundary sides + invariant agreement** — 9/9 pass; explicit `poolHeadroom.placeable ⟺ selectAccount !== null` assertions for meta-only and real cases.
+6. **No fail-OPEN** — predicate is fail-closed (missing/non-string/empty `configHome` → false).
+
+Sound, well-tested pure tightening with the never-loop invariant correctly preserved.


### PR DESCRIPTION
## ELI16

This is the third piece of "Account Follow-Me" — the feature that lets you log in to your subscription once and have it work across all your machines. This piece is a small, internal safety guard with no user-facing change.

Here's the problem it prevents. When you run on more than one machine, each machine learns a little bit of *metadata* about the accounts the other machines hold — things like the account's email and how much quota is left — so it can answer "how much quota do I have across everything?". But that metadata is NOT a login: knowing an account exists on another machine doesn't mean THIS machine can actually use it (the real credential lives only on the machine you logged in on).

The danger: somewhere down the line, the code that picks "which account should I run this work on?" could accidentally pick one of those metadata-only accounts — an account this machine knows about but holds no login for. That would fail (or worse, behave unpredictably) at the moment of use.

This change adds one rule, enforced in code, at the exact spot where an account gets chosen: an account is only selectable on this machine if this machine actually holds its login (a real local config home) AND that login is healthy. A metadata-only account from a peer is now structurally impossible to select.

It's a "pure tightening" — every real account you've logged in already has a config home, so this changes nothing for accounts you actually hold. It only ever rules out the credential-less peer projections. It also carefully keeps a pre-existing invariant intact: the quota throttle and the account picker share the exact same rule, so they can never disagree (which would cause a spin loop).

Ships dark as groundwork for the later step where machines actually enroll their own logins.

## What this PR does
- Adds `isLocallyExecutable(account)` (exported from `SubscriptionPool.ts`) + `SubscriptionPool.locallyExecutable()`.
- Applies it in BOTH `QuotaAwareScheduler.selectAccount()` and `poolHeadroom()`, preserving `placeable ⟺ selectAccount(...) !== null`.
- 9 unit tests; `tsc` clean; side-effects + independent second-pass security review (concurred).

Spec: `docs/specs/ws52-account-follow-me-security.md` §6.2/§6.3a (converged, approved).