### PR TITLE
feat(ws52): Account Follow-Me §5.3/S7 — email-gate at enrollment completion

### DIFF
--- a/.instar/instar-dev-decisions/2026-06-17T11-27-23-163Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-06-17T11-27-23-163Z-unknown.json
@@ -1,0 +1,16 @@
+{
+  "ts": "2026-06-17T11:27:23.163Z",
+  "slug": "unknown",
+  "suggestedTier": 2,
+  "declaredTier": 2,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "new capability: new route (router.<verb>() added",
+    "new capability: new config key added"
+  ],
+  "belowFloor": false,
+  "files": 4,
+  "loc": 160,
+  "causalAutopsy": null,
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-06-17T11-28-55-561Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-06-17T11-28-55-561Z-unknown.json
@@ -1,0 +1,16 @@
+{
+  "ts": "2026-06-17T11:28:55.561Z",
+  "slug": "unknown",
+  "suggestedTier": 2,
+  "declaredTier": 2,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "new capability: new route (router.<verb>() added",
+    "new capability: new config key added"
+  ],
+  "belowFloor": false,
+  "files": 4,
+  "loc": 160,
+  "causalAutopsy": null,
+  "verdict": "pass"
+}

--- a/.instar/instar-dev-traces/2026-06-17T11-20-54-977Z-ws52-account-follow-me-email-gate-028e271a.json
+++ b/.instar/instar-dev-traces/2026-06-17T11-20-54-977Z-ws52-account-follow-me-email-gate-028e271a.json
@@ -1,0 +1,24 @@
+{
+  "version": 2,
+  "sessionId": "6ff0a0e8-d348-4f01-aa78-af08c7ea7ed5",
+  "timestamp": "2026-06-17T11:20:54.977Z",
+  "artifactPath": "upgrades/side-effects/ws52-account-follow-me-email-gate.md",
+  "artifactSha256": "7072e2cb5343c714b70085858946d4754cce27cb8038d601b3255e868787ad6d",
+  "specPath": "docs/specs/ws52-account-follow-me-security.md",
+  "coveredFiles": [
+    "src/commands/server.ts",
+    "src/core/EnrollmentWizard.ts",
+    "src/core/PendingLoginStore.ts",
+    "src/server/routes.ts",
+    "tests/integration/account-follow-me-complete-route.test.ts",
+    "tests/unit/enrollment-wizard.test.ts",
+    "tests/unit/pending-login-store.test.ts",
+    "upgrades/next/ws52-account-follow-me-email-gate.md",
+    "upgrades/side-effects/ws52-account-follow-me-email-gate.md"
+  ],
+  "phase": "complete",
+  "tier": 2,
+  "tierReasoning": "Credential-boundary email-identity gate at enrollment completion off an approved spec; high-risk, second-pass review required and concurred.",
+  "secondPass": "true",
+  "reviewerConcurred": true
+}

--- a/src/commands/server.ts
+++ b/src/commands/server.ts
@@ -10656,6 +10656,26 @@ export async function startServer(options: StartOptions): Promise<void> {
     const enrollmentWizard = new EnrollmentWizard({
       store: pendingLoginStore,
       logger: { log: (m) => console.log(m), warn: (m) => console.warn(m) },
+      // WS5.2 §5.3/S7 — the follow-me completion gate reads the minted login's account email
+      // from its config-home slot (the Anthropic OAuth profile endpoint) and validates it against
+      // operator expectation before the account is selectable. Same oracle the credential-location
+      // ledger uses; constructed fresh here (the ledger's instance is not in scope at this point).
+      oracle: new CredentialIdentityOracle(),
+      // A HELD follow-me completion (surprise/mismatched/unverifiable email) raises a HIGH
+      // attention item for the operator. Map the email-gate's {id,title,body,priority,source}
+      // shape onto the telegram attention-queue createAttentionItem shape.
+      emitAttention: telegram
+        ? (item) =>
+            void telegram!.createAttentionItem({
+              id: item.id,
+              title: item.title,
+              summary: item.body,
+              description: item.body,
+              category: 'account-follow-me',
+              priority: 'HIGH',
+              sourceContext: 'account-follow-me-email-gate',
+            })
+        : undefined,
       driveLogin: new FrameworkLoginDriver({
         capture: async (session) => sessionManager.captureOutput(session, 120) || '',
         spawn: async ({ framework, configHome }) => {

--- a/src/core/EnrollmentWizard.ts
+++ b/src/core/EnrollmentWizard.ts
@@ -30,6 +30,8 @@ import {
   ensureInteractiveReady,
   type EnsureInteractiveReadyResult,
 } from './ensureInteractiveReady.js';
+import type { IdentityOracle } from './CredentialLocationLedger.js';
+import { validateEnrolledAccountEmail } from './AccountFollowMeEmailGate.js';
 
 /** The public artifact a framework login yields (no secret). */
 export interface LoginArtifact {
@@ -61,6 +63,20 @@ export interface EnrollmentWizardConfig {
    * Injectable for hermetic tests; production uses the real util.
    */
   ensureReady?: (configHome: string) => EnsureInteractiveReadyResult;
+  /**
+   * WS5.2 §5.3/S7 — identity oracle used by `completeFollowMe` to read the freshly-minted
+   * login's account email from its config-home slot, for validation against operator
+   * expectation. Absent ⇒ the follow-me gate fails CLOSED (the account is HELD, never
+   * auto-selected). The plain `complete()` path never touches it.
+   */
+  oracle?: IdentityOracle;
+  /**
+   * WS5.2 §5.3/S7 — emit a HIGH attention item when a follow-me completion is HELD
+   * (surprise/mismatched/unverifiable email). Best-effort; absence does not change the
+   * fail-closed verdict (the account is still NOT selected), only whether the operator
+   * is paged.
+   */
+  emitAttention?: (item: { id: string; title: string; body: string; priority: 'high'; source: 'agent' }) => void;
 }
 
 export interface StartEnrollmentInput {
@@ -72,6 +88,9 @@ export interface StartEnrollmentInput {
   kind?: LoginFlowKind;
   /** The new account's CLAUDE_CONFIG_DIR — isolates the login to its own slot. */
   configHome?: string;
+  /** WS5.2 §5.3/S7 — the operator-expected account email (follow-me path only). Carried
+   *  onto the pending login so `completeFollowMe` can validate the minted account. */
+  expectedEmail?: string;
 }
 
 export class EnrollmentWizard {
@@ -79,12 +98,16 @@ export class EnrollmentWizard {
   private readonly driveLogin: LoginDriver;
   private readonly logger: { log: (m: string) => void; warn: (m: string) => void };
   private readonly ensureReady: (configHome: string) => EnsureInteractiveReadyResult;
+  private readonly oracle?: IdentityOracle;
+  private readonly emitAttention?: (item: { id: string; title: string; body: string; priority: 'high'; source: 'agent' }) => void;
 
   constructor(cfg: EnrollmentWizardConfig) {
     this.store = cfg.store;
     this.driveLogin = cfg.driveLogin;
     this.logger = cfg.logger ?? { log: () => {}, warn: () => {} };
     this.ensureReady = cfg.ensureReady ?? ensureInteractiveReady;
+    this.oracle = cfg.oracle;
+    this.emitAttention = cfg.emitAttention;
   }
 
   /** Default flow kind per provider: Codex/OpenAI = device-code (its endorsed
@@ -137,6 +160,7 @@ export class EnrollmentWizard {
       verificationUrl: artifact.verificationUrl,
       userCode: artifact.userCode,
       notice: EnrollmentWizard.flowNotice(kind),
+      expectedEmail: input.expectedEmail,
       ttlMs: artifact.ttlMs,
     });
     this.logger.log(`[EnrollmentWizard] started ${kind} login for ${input.label} (${input.provider})`);
@@ -197,6 +221,62 @@ export class EnrollmentWizard {
       }
     }
     return login;
+  }
+
+  /**
+   * WS5.2 §5.3 step 3 / S7 — the FOLLOW-ME completion path. Completes the pending login
+   * (reusing the sync `complete()` so claude-code interactive-readiness still runs), then
+   * validates the freshly-minted account's email against the operator's expectation BEFORE
+   * the account is allowed to become selectable. Only a verified match returns 'validated'
+   * (the caller — the route — then adds it to the SubscriptionPool); everything else FAILS
+   * CLOSED to 'held' (a HIGH attention item is emitted, the account is NOT added to the pool).
+   *
+   * Fail-closed by construction: a missing oracle, an unreadable/missing config-home, an
+   * unavailable identity probe, or a missing operator-expected email all resolve to 'held'
+   * — an account is NEVER auto-selected unless its email provably matches what the operator
+   * approved (this is the FOLLOW-ME path, so the email gate ALWAYS runs).
+   */
+  async completeFollowMe(
+    id: string,
+    targetMachineNickname: string,
+  ): Promise<
+    | { outcome: 'validated'; login: PendingLogin; email: string }
+    | { outcome: 'held'; login: PendingLogin; reason: string }
+    | { outcome: 'not-found' }
+  > {
+    const login = this.complete(id);
+    if (!login) return { outcome: 'not-found' };
+
+    // Read the email the COMPLETED login actually authenticated as. No oracle / no config-home
+    // / a probe failure are all treated as "unavailable" → the gate fails closed below.
+    let completedEmail: string | null = null;
+    if (this.oracle) {
+      let probe;
+      try {
+        probe = await this.oracle.resolveSlotTenant(login.configHome ?? '');
+      } catch (err) {
+        probe = { unavailable: true, reason: `oracle threw: ${err instanceof Error ? err.message : String(err)}` };
+      }
+      completedEmail = 'email' in probe && probe.email ? probe.email : null;
+    }
+
+    // The follow-me gate ALWAYS runs (this IS the follow-me path); a missing expectedEmail
+    // is caller misuse and the gate fails it closed with reason 'missing-expected-email'.
+    const verdict = validateEnrolledAccountEmail({
+      completedEmail,
+      expectedEmail: login.expectedEmail,
+      accountId: login.id,
+      targetMachineNickname,
+    });
+
+    if (verdict.selectable) {
+      this.logger.log(`[EnrollmentWizard] follow-me completion ${login.id} validated as ${verdict.email}`);
+      return { outcome: 'validated', login, email: verdict.email };
+    }
+
+    this.emitAttention?.(verdict.attentionItem);
+    this.logger.warn(`[EnrollmentWizard] follow-me completion ${login.id} HELD (${verdict.reason}) — account NOT selected`);
+    return { outcome: 'held', login, reason: verdict.reason };
   }
 
   /** The phone surface: still-valid logins awaiting approval. */

--- a/src/core/PendingLoginStore.ts
+++ b/src/core/PendingLoginStore.ts
@@ -57,6 +57,11 @@ export interface PendingLogin {
    *  Claude two-code sequence (email-verification code first, then the sign-in code).
    *  Surfaced on the pending-login so the operator knows what to expect. */
   notice?: string;
+  /** WS5.2 §5.3/S7 — the account email the operator EXPECTED to enroll (the mandate's
+   *  account). On a follow-me completion the freshly-minted login's email is validated
+   *  against this before the account becomes selectable; a surprise email is held, not
+   *  auto-used. Absent for a plain (non-follow-me) enrollment. Never a secret. */
+  expectedEmail?: string;
   /** ISO timestamp the code/URL expires. */
   ttlExpiresAt: string;
   status: PendingLoginStatus;
@@ -91,6 +96,9 @@ export interface IssueLoginInput {
   userCode?: string;
   /** Operator-facing flow heads-up (e.g. the Claude two-code sequence). */
   notice?: string;
+  /** WS5.2 §5.3/S7 — the operator-expected account email (a follow-me login carries it
+   *  so completion can validate the minted account against operator expectation). */
+  expectedEmail?: string;
   /** TTL in ms from now (default 15 min — the observed Codex device-code TTL). */
   ttlMs?: number;
 }
@@ -172,6 +180,7 @@ export class PendingLoginStore {
       verificationUrl: input.verificationUrl.trim(),
       ...(input.userCode ? { userCode: input.userCode.trim() } : {}),
       ...(input.notice?.trim() ? { notice: input.notice.trim() } : {}),
+      ...(input.expectedEmail?.trim() ? { expectedEmail: input.expectedEmail.trim() } : {}),
       ttlExpiresAt: new Date(this.now() + (input.ttlMs ?? DEFAULT_TTL_MS)).toISOString(),
       status: 'pending',
       reissueCount: 0,

--- a/src/server/routes.ts
+++ b/src/server/routes.ts
@@ -20880,6 +20880,57 @@ export function createRoutes(ctx: RouteContext): Router {
     res.json({ enabled: true, login });
   });
 
+  // WS5.2 §5.3 step 3 / S7 — Account Follow-Me completion with the email-validation gate.
+  // When an operator-authorized follow-me enrollment COMPLETES on this target machine, the
+  // freshly-minted login's account email is validated against the operator's expectation BEFORE
+  // the account becomes a selectable pool account. A surprise/mismatched/unverifiable email is
+  // HELD (NOT added to the pool) and raises a HIGH attention item. Only a verified match adds
+  // the account to the SubscriptionPool. Dark behind multiMachine.accountFollowMe (503 when off).
+  router.post('/subscription-pool/follow-me/enroll/:id/complete', async (req, res) => {
+    const afmCfg = (ctx.config as unknown as { multiMachine?: { accountFollowMe?: { enabled?: boolean } } }).multiMachine?.accountFollowMe;
+    if (!resolveDevAgentGate(afmCfg?.enabled, ctx.config)) {
+      res.status(503).json({ error: 'account follow-me not enabled' });
+      return;
+    }
+    if (!ctx.enrollmentWizard || !ctx.subscriptionPool) {
+      res.status(503).json({ error: 'enrollment wizard or subscription pool not configured' });
+      return;
+    }
+    const nickname = (req.body?.nickname && typeof req.body.nickname === 'string' && req.body.nickname.trim())
+      ? req.body.nickname.trim()
+      : 'this machine';
+    try {
+      const result = await ctx.enrollmentWizard.completeFollowMe(req.params.id, nickname);
+      if (result.outcome === 'not-found') {
+        res.status(404).json({ error: `pending login ${req.params.id} not found` });
+        return;
+      }
+      if (result.outcome === 'held') {
+        // Fail-closed: the account is NOT added to the pool; the gate already raised the
+        // HIGH attention item for the operator.
+        res.json({ enabled: true, outcome: 'held', reason: result.reason, login: result.login });
+        return;
+      }
+      // outcome === 'validated' — the email matched operator expectation; make it selectable.
+      const { login, email } = result;
+      const account = ctx.subscriptionPool.add({
+        id: login.id,
+        nickname: login.label,
+        provider: login.provider,
+        framework: login.framework,
+        configHome: login.configHome ?? '',
+        status: 'active',
+        email,
+      });
+      res.status(201).json({ enabled: true, outcome: 'validated', account });
+    } catch (err) {
+      const isValidation = err instanceof Error && err.name === 'ValidationError';
+      res.status(isValidation ? 400 : 500).json({
+        error: err instanceof Error ? err.message : 'follow-me completion failed',
+      });
+    }
+  });
+
   // ── Live credential re-pointing — levers + ledger census + audit-scrub (WS5.2 Step 7) ──
   //
   // POST /credentials/swap|set-default|restore-enrollment (DETECTIVE controls: operator

--- a/tests/integration/account-follow-me-complete-route.test.ts
+++ b/tests/integration/account-follow-me-complete-route.test.ts
@@ -1,0 +1,137 @@
+/**
+ * Integration test — WS5.2 §5.3 step 3 / S7 follow-me completion route over the full HTTP
+ * pipeline (createRoutes + a real SubscriptionPool + a real EnrollmentWizard with a fake
+ * driveLogin + a fake identity oracle). Verifies: dark → 503; enabled + matching email → 201
+ * validated + the account is added to the pool; enabled + mismatched email → 200 held + the
+ * pool is unchanged + a HIGH attention item is emitted.
+ */
+
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import express from 'express';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import type { AddressInfo } from 'node:net';
+import { createRoutes } from '../../src/server/routes.js';
+import { SubscriptionPool } from '../../src/core/SubscriptionPool.js';
+import { EnrollmentWizard } from '../../src/core/EnrollmentWizard.js';
+import { PendingLoginStore } from '../../src/core/PendingLoginStore.js';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+
+interface TestServer { url: string; close: () => Promise<void>; }
+async function listen(app: express.Express): Promise<TestServer> {
+  return new Promise((resolve) => {
+    const srv = app.listen(0, () => {
+      const port = (srv.address() as AddressInfo).port;
+      resolve({ url: `http://127.0.0.1:${port}`, close: () => new Promise<void>((r) => srv.close(() => r())) });
+    });
+  });
+}
+
+function buildCtx(dir: string, opts: {
+  dev: boolean;
+  oracleEmail: string;
+  emit: ReturnType<typeof vi.fn>;
+}) {
+  const pool = new SubscriptionPool({ stateDir: dir });
+  const store = new PendingLoginStore({ stateDir: dir });
+  // Pre-issue a follow-me pending login carrying the operator-expected email.
+  store.issue({
+    id: 'fm-1',
+    label: 'main',
+    provider: 'anthropic',
+    framework: 'claude-code',
+    kind: 'url-code-paste',
+    configHome: path.join(dir, '.claude-fm'),
+    verificationUrl: 'https://claude.com/oauth',
+    expectedEmail: 'approved@x.com',
+  });
+  const enrollmentWizard = new EnrollmentWizard({
+    store,
+    driveLogin: async () => ({ verificationUrl: 'https://claude.com/oauth', ttlMs: 15 * 60_000 }),
+    // ensureReady stub so completing a claude-code login doesn't touch a real config home.
+    ensureReady: () => ({ patched: false, reason: 'already interactive-ready' }),
+    oracle: { resolveSlotTenant: async () => ({ email: opts.oracleEmail }) },
+    emitAttention: (item) => opts.emit(item),
+  });
+  return {
+    config: {
+      authToken: 'test', stateDir: dir, port: 0, projectName: 'echo',
+      developmentAgent: opts.dev,
+      multiMachine: { accountFollowMe: {} },
+    },
+    startTime: new Date(),
+    subscriptionPool: pool,
+    enrollmentWizard,
+  } as unknown as Parameters<typeof createRoutes>[0];
+}
+
+describe('/subscription-pool/follow-me/enroll/:id/complete (integration)', () => {
+  let server: TestServer;
+  let dir: string;
+  const post = (p: string, body?: unknown) =>
+    fetch(server.url + p, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      ...(body !== undefined ? { body: JSON.stringify(body) } : {}),
+    }).then(async (r) => ({ status: r.status, body: await r.json().catch(() => ({})) }));
+
+  afterEach(async () => {
+    await server?.close();
+    try { SafeFsExecutor.safeRmSync(dir, { recursive: true, force: true, operation: 'tests/integration/account-follow-me-complete-route.test.ts:cleanup' }); } catch { /* @silent-fallback-ok */ }
+  });
+
+  it('dark (non-dev, flag enabled omitted) → 503', async () => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'afm-complete-'));
+    const app = express(); app.use(express.json());
+    app.use(createRoutes(buildCtx(dir, { dev: false, oracleEmail: 'approved@x.com', emit: vi.fn() })));
+    server = await listen(app);
+    const r = await post('/subscription-pool/follow-me/enroll/fm-1/complete', { nickname: 'the Mini' });
+    expect(r.status).toBe(503);
+  });
+
+  it('enabled + matching email → 201 validated + account added to the pool', async () => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'afm-complete-'));
+    const emit = vi.fn();
+    const ctx = buildCtx(dir, { dev: true, oracleEmail: 'approved@x.com', emit });
+    const app = express(); app.use(express.json());
+    app.use(createRoutes(ctx));
+    server = await listen(app);
+    const r = await post('/subscription-pool/follow-me/enroll/fm-1/complete', { nickname: 'the Mini' });
+    expect(r.status).toBe(201);
+    expect(r.body.outcome).toBe('validated');
+    expect(r.body.account).toMatchObject({ id: 'fm-1', email: 'approved@x.com', status: 'active' });
+    // The account is now a selectable pool account.
+    const pool = (ctx as unknown as { subscriptionPool: SubscriptionPool }).subscriptionPool;
+    expect(pool.get('fm-1')).toBeTruthy();
+    expect(emit).not.toHaveBeenCalled();
+  });
+
+  it('enabled + mismatched email → 200 held + pool unchanged + HIGH attention emitted', async () => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'afm-complete-'));
+    const emit = vi.fn();
+    const ctx = buildCtx(dir, { dev: true, oracleEmail: 'attacker@evil.com', emit });
+    const app = express(); app.use(express.json());
+    app.use(createRoutes(ctx));
+    server = await listen(app);
+    const r = await post('/subscription-pool/follow-me/enroll/fm-1/complete', { nickname: 'the Mini' });
+    expect(r.status).toBe(200);
+    expect(r.body.outcome).toBe('held');
+    expect(r.body.reason).toBe('email-mismatch');
+    // The account was NOT added to the pool (fail-closed).
+    const pool = (ctx as unknown as { subscriptionPool: SubscriptionPool }).subscriptionPool;
+    expect(pool.get('fm-1')).toBeNull();
+    // A HIGH attention item was raised for the operator.
+    expect(emit).toHaveBeenCalledTimes(1);
+    expect(emit.mock.calls[0][0]).toMatchObject({ priority: 'high', source: 'agent' });
+  });
+
+  it('enabled + unknown id → 404', async () => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'afm-complete-'));
+    const app = express(); app.use(express.json());
+    app.use(createRoutes(buildCtx(dir, { dev: true, oracleEmail: 'approved@x.com', emit: vi.fn() })));
+    server = await listen(app);
+    const r = await post('/subscription-pool/follow-me/enroll/nope/complete', { nickname: 'the Mini' });
+    expect(r.status).toBe(404);
+  });
+});

--- a/tests/unit/enrollment-wizard.test.ts
+++ b/tests/unit/enrollment-wizard.test.ts
@@ -5,7 +5,7 @@
  * driver-failure resilience, default flow kind per provider, and complete.
  */
 
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
@@ -187,5 +187,95 @@ describe('EnrollmentWizard', () => {
     expect(cfg.bypassPermissionsModeAccepted).toBe(true);
     expect(cfg.hasTrustDialogAccepted).toBe(true);
     expect(cfg.oauthAccount).toEqual({ accountUuid: 'u-1' }); // untouched
+  });
+
+  // ── WS5.2 §5.3 step 3 / S7 — completeFollowMe (email-validation gate) ───────────────
+  describe('completeFollowMe (email-validation-before-selectable)', () => {
+    // Pre-issue a follow-me pending login carrying the operator-expected email.
+    function issueFollowMe(expectedEmail: string | undefined, configHome = '/x/.claude-fm') {
+      store.issue({
+        id: 'fm-1',
+        label: 'main',
+        provider: 'anthropic',
+        framework: 'claude-code',
+        kind: 'url-code-paste',
+        configHome,
+        verificationUrl: 'https://claude.com/oauth',
+        ...(expectedEmail !== undefined ? { expectedEmail } : {}),
+      });
+    }
+    function build(opts: {
+      oracle?: { resolveSlotTenant: (slot: string) => Promise<{ email?: string; unavailable?: boolean; reason?: string }> };
+      emitAttention?: (item: { id: string; title: string; body: string; priority: 'high'; source: 'agent' }) => void;
+    }) {
+      return new EnrollmentWizard({
+        store,
+        driveLogin: async () => ({ verificationUrl: 'https://claude.com/oauth', ttlMs: 15 * 60_000 }),
+        now: () => clock,
+        oracle: opts.oracle,
+        emitAttention: opts.emitAttention,
+      });
+    }
+
+    it('(a) matching email → validated, returns the email, no attention', async () => {
+      issueFollowMe('j@x.com');
+      const emit = vi.fn();
+      const w = build({ oracle: { resolveSlotTenant: async () => ({ email: 'j@x.com' }) }, emitAttention: emit });
+      const r = await w.completeFollowMe('fm-1', 'the Mini');
+      expect(r.outcome).toBe('validated');
+      if (r.outcome === 'validated') expect(r.email).toBe('j@x.com');
+      expect(emit).not.toHaveBeenCalled();
+      // the login was still completed (sync complete() ran)
+      expect(store.get('fm-1')?.status).toBe('completed');
+    });
+
+    it('(b) mismatched email → held + HIGH attention emitted + not validated', async () => {
+      issueFollowMe('approved@x.com');
+      const emit = vi.fn();
+      const w = build({ oracle: { resolveSlotTenant: async () => ({ email: 'attacker@evil.com' }) }, emitAttention: emit });
+      const r = await w.completeFollowMe('fm-1', 'the Mini');
+      expect(r.outcome).toBe('held');
+      if (r.outcome === 'held') expect(r.reason).toBe('email-mismatch');
+      expect(emit).toHaveBeenCalledTimes(1);
+      expect(emit.mock.calls[0][0]).toMatchObject({ priority: 'high', source: 'agent' });
+    });
+
+    it('(c) oracle unavailable → held (fail-closed)', async () => {
+      issueFollowMe('j@x.com');
+      const emit = vi.fn();
+      const w = build({ oracle: { resolveSlotTenant: async () => ({ unavailable: true, reason: '401' }) }, emitAttention: emit });
+      const r = await w.completeFollowMe('fm-1', 'the Mini');
+      expect(r.outcome).toBe('held');
+      if (r.outcome === 'held') expect(r.reason).toBe('missing-completed-email');
+      expect(emit).toHaveBeenCalledTimes(1);
+    });
+
+    it('(c2) no oracle configured → held (fail-closed)', async () => {
+      issueFollowMe('j@x.com');
+      const w = build({});
+      const r = await w.completeFollowMe('fm-1', 'the Mini');
+      expect(r.outcome).toBe('held');
+    });
+
+    it('(c3) oracle throws → held (fail-closed, never crashes)', async () => {
+      issueFollowMe('j@x.com');
+      const w = build({ oracle: { resolveSlotTenant: async () => { throw new Error('boom'); } } });
+      const r = await w.completeFollowMe('fm-1', 'the Mini');
+      expect(r.outcome).toBe('held');
+    });
+
+    it('(c4) missing operator-expected email → held (fail-closed even on a real probe)', async () => {
+      issueFollowMe(undefined);
+      const w = build({ oracle: { resolveSlotTenant: async () => ({ email: 'j@x.com' }) } });
+      const r = await w.completeFollowMe('fm-1', 'the Mini');
+      expect(r.outcome).toBe('held');
+      if (r.outcome === 'held') expect(r.reason).toBe('missing-expected-email');
+    });
+
+    it('(d) unknown id → not-found', async () => {
+      const w = build({ oracle: { resolveSlotTenant: async () => ({ email: 'j@x.com' }) } });
+      const r = await w.completeFollowMe('nope', 'the Mini');
+      expect(r.outcome).toBe('not-found');
+    });
   });
 });

--- a/tests/unit/pending-login-store.test.ts
+++ b/tests/unit/pending-login-store.test.ts
@@ -101,4 +101,17 @@ describe('PendingLoginStore', () => {
     expect(fresh.size()).toBe(0);
     expect(fresh.issue(deviceCode()).id).toBe('codex-1');
   });
+
+  // ── WS5.2 §5.3/S7 — expectedEmail (follow-me email-validation gate) ────────────────
+  it('issue() carries expectedEmail when provided (trimmed)', () => {
+    const login = store.issue({ ...deviceCode(), expectedEmail: '  J@X.com  ' });
+    expect(login.expectedEmail).toBe('J@X.com');
+    // round-trips through get()/list() (persisted onto the record)
+    expect(store.get('codex-1')?.expectedEmail).toBe('J@X.com');
+  });
+
+  it('issue() omits expectedEmail when absent or blank', () => {
+    expect(store.issue(deviceCode()).expectedEmail).toBeUndefined();
+    expect(store.issue({ ...deviceCode('codex-2'), expectedEmail: '   ' }).expectedEmail).toBeUndefined();
+  });
 });

--- a/upgrades/next/ws52-account-follow-me-email-gate.md
+++ b/upgrades/next/ws52-account-follow-me-email-gate.md
@@ -1,0 +1,17 @@
+## What Changed
+
+WS5.2 Account Follow-Me, §5.3/S7 — the **email-safety gate at enrollment completion**. When a follow-me enrollment completes on a machine, the freshly-minted account's real email (read from its config-home via the provider profile endpoint) is now validated against the email the operator approved BEFORE the account can be selected for any work. A surprise or mismatched email is HELD — the account is NOT added to the pool — and a HIGH attention item is raised for the operator. Threads `expectedEmail` from `EnrollmentWizard.start()` through `PendingLoginStore` to the new `EnrollmentWizard.completeFollowMe()`, and exposes it via a dark route `POST /subscription-pool/follow-me/enroll/:id/complete` that calls `SubscriptionPool.add()` only on a verified match. Fail-closed on every uncertainty (no oracle, unreadable email, missing expected email → held). Dark behind `multiMachine.accountFollowMe`; normal (non-follow-me) enrollment is completely untouched.
+
+## Evidence
+
+- 33 tests: 29 unit (`pending-login-store` expectedEmail threading; `enrollment-wizard` `completeFollowMe` — validated match, mismatch→held+attention, oracle-unavailable→held, oracle-throws→held, no-oracle→held, missing-expected-email→held, unknown→not-found) + 4 Tier-2 integration over the REAL HTTP pipeline (`account-follow-me-complete-route`: dark→503, validated→201+account added, mismatch→200 held+pool unchanged+HIGH attention, unknown→404). `tsc --noEmit` clean.
+- Side-effects review + mandatory independent second-pass security review (concurred): traced every fail-closed path, confirmed `SubscriptionPool.add()` is reached ONLY on a verified email match, no regression to normal enrollment, deterministic attention-id de-dup, and the dark gate.
+- Spec: `docs/specs/ws52-account-follow-me-security.md` §5.3/S7 (converged, approved).
+
+## What to Tell Your User
+
+Still nothing to do — this ships off by default as part of the multi-machine account-sharing groundwork. With it, when a machine enrolls one of your accounts, I verify the login that actually completed matches the account you approved BEFORE using it — if it doesn't (a typo, the wrong account, an unverifiable login), I hold it and flag you rather than ever using a surprise account. The one-tap enrollment surface that drives this end-to-end is the next step.
+
+## Summary of New Capabilities
+
+Email-identity safety gate at follow-me enrollment completion (dark): a freshly-enrolled account is validated against the operator-approved email before it becomes selectable; a mismatch is held (never auto-used) and raises a HIGH attention item. New dark route `POST /subscription-pool/follow-me/enroll/:id/complete`. No user-facing surface is live in this release.

--- a/upgrades/side-effects/ws52-account-follow-me-email-gate.md
+++ b/upgrades/side-effects/ws52-account-follow-me-email-gate.md
@@ -1,0 +1,70 @@
+# Side-Effects Review — WS5.2 §5.3/S7 email-gate at follow-me enrollment completion
+
+**Version / slug:** `ws52-account-follow-me-email-gate`
+**Date:** `2026-06-17`
+**Author:** `Echo (instar-dev agent)`
+**Second-pass reviewer:** `pending (high-risk: credential boundary / email-identity gate / account selection)`
+
+## Summary of the change
+
+WS5.2 §5.3/S7. Wires the (PR2) `validateEnrolledAccountEmail` gate into the follow-me enrollment-completion path so a freshly-minted account's email is validated against operator expectation BEFORE the account becomes a selectable pool member. Threads `expectedEmail` from `EnrollmentWizard.start()` → `PendingLoginStore.issue()` → the `PendingLogin` record. Adds `EnrollmentWizard.completeFollowMe(id, nickname)`: completes the login (reusing sync `complete()` so interactive-readiness still runs), reads the COMPLETED account's email via an injected `IdentityOracle` (`CredentialIdentityOracle.resolveSlotTenant(configHome)` → the provider profile endpoint), runs the gate, and returns `validated` (verified match) | `held` (mismatch/missing/unverifiable → emits a HIGH attention item, account NOT selectable) | `not-found`. Adds a dark route `POST /subscription-pool/follow-me/enroll/:id/complete` that calls `SubscriptionPool.add()` ONLY on `validated`. Wires the oracle + attention emitter into the wizard in `server.ts`. Files: `PendingLoginStore.ts`, `EnrollmentWizard.ts`, `routes.ts`, `server.ts` + 3 test files. Dark behind `multiMachine.accountFollowMe`.
+
+## Decision-point inventory
+
+- `EnrollmentWizard.completeFollowMe()` — **add** — the S7 decision: a completed follow-me login becomes selectable IFF its real email matches the operator-approved email.
+- `POST /subscription-pool/follow-me/enroll/:id/complete` — **add** — dark route; the only path that calls `add()` for a follow-me account, gated on `validated`.
+- `PendingLoginStore` / `StartEnrollmentInput` `expectedEmail` — **add** — data carried from issuance to completion (the operator-approved email travels with the pending login).
+
+---
+
+## 1. Over-block
+
+**What legitimate inputs does this change reject that it shouldn't?**
+
+A legitimate enrollment whose account genuinely matches the operator's expectation but whose email the oracle cannot read (profile endpoint down, transient network failure) is HELD, not added — the operator sees a HIGH attention item rather than the account silently appearing. This is deliberate fail-closed behavior (S7: never auto-select an unverified account). The cost is a retry/attention rather than a silent success; this is the correct trade for a credential gate. It does NOT affect normal (non-follow-me) enrollment at all — `complete()` is unchanged and the generic `/enroll/:id/complete` route is untouched; only the new follow-me route runs the gate.
+
+## 2. Under-block
+
+**What failure modes does this still miss?**
+
+The gate validates EMAIL identity, not token validity or scope — a matching-email account whose token is later revoked is caught downstream (provider 401 + §6.2 selection gate excludes a needs-reauth account), not here. It also trusts the oracle's profile read: if the provider profile endpoint itself returned a wrong email (provider-side compromise), the gate would accept it — but that is outside instar's trust boundary (the same endpoint authenticates the account). The host-allowlist validation of a target-supplied verificationUrl (the other half of S7/R6) is a separate concern owned by the enroll-drive path, not this completion gate.
+
+## 3. Level-of-abstraction fit
+
+Correct layer. The email-identity decision belongs at enrollment completion — the single moment the minted account first exists and before any selection can reach it. The gate LOGIC lives in the already-shipped `AccountFollowMeEmailGate` (PR2); this change only WIRES it at the completion chokepoint + adds the data (`expectedEmail`) it needs. The wizard reads identity via the existing `IdentityOracle` abstraction rather than re-implementing a profile fetch. `SubscriptionPool.add()` stays the single pool-mutation point; the route gates it. No lower/higher layer is a better fit.
+
+## 4. Signal vs authority compliance
+
+This gate holds genuine authority (it decides whether an account becomes selectable), and that is appropriate: the decision is DETERMINISTIC (a normalized string-equality of two emails), not a brittle heuristic. It fails CLOSED on every uncertainty (no oracle, unreadable email, missing expected email, mismatch → held). It does not block any user message or outbound action — it only withholds a credential-bearing account from the selectable set and surfaces a HIGH attention item for the operator to resolve. Reference `docs/signal-vs-authority.md`: a deterministic, fail-closed credential-admission gate is authority correctly exercised, not a brittle blocker.
+
+## 5. Interactions
+
+`completeFollowMe` reuses the existing sync `complete()` (so `ensureInteractiveReady` still runs for claude-code homes) and then layers the gate — no double-completion (the pending login transitions to `completed` exactly once). It does NOT touch the generic `complete()` path, so normal enrollment is byte-for-byte unchanged. The validated account enters the pool via the SAME `SubscriptionPool.add()` validation as a manual add (configHome non-empty, no-credential guard) — and §6.2's `isLocallyExecutable` then governs its selection. The attention item id is deterministic (`account-follow-me-email:<accountId>:<nickname-slug>`) so repeated held completions de-duplicate rather than flooding (P17). No race with adjacent cleanup.
+
+## 6. External surfaces
+
+One new HTTP route, dark behind `multiMachine.accountFollowMe` (503 when off — proven by the integration test). A HELD completion raises ONE HIGH attention item (operator-visible, deduped by deterministic id). No change visible to other agents/machines. The route is the per-server completion path (R6a option-2: the operator drives the target machine's own enroll route); it does not reach across the mesh.
+
+## 7. Multi-machine posture (Cross-Machine Coherence)
+
+**Machine-local BY DESIGN** (per the chosen R6a option-2 / OQ6 resolution). The enrollment completes ON the target machine, against the credential that machine just minted into its OWN config-home, validated by THAT machine's oracle against the operator-approved email carried on the local pending login. Nothing replicates: the account becomes selectable only on the machine that holds its login. This is the intended posture — a per-machine login is the ToS-safe Mechanism-B model; "the account works on every machine" is achieved by each machine running this completion for its own enrollment, never by moving a credential. The attention item on a held completion surfaces on the target machine's operator surface.
+
+## 8. Rollback cost
+
+Low. The route is dark by default (no agent runs it until `multiMachine.accountFollowMe` is enabled). `expectedEmail` is an optional additive field on `PendingLogin` (no migration — old records simply lack it; the gate fails them closed, which is safe). Revert is a single-commit back-out; no persisted-state repair (a pending login is ephemeral, TTL-bounded). No data migration.
+
+---
+
+## Second-pass review
+
+**Concur with the review.** Verified by reading source (not author framing):
+
+1. **Fail-closed completeness** — traced every path in `completeFollowMe`: no oracle → `completedEmail=null`; `{unavailable}` → null; oracle throws → caught → null; empty `configHome` → no token → unavailable → null; missing `expectedEmail` → gate `missing-expected-email`; mismatch → `email-mismatch`. Every non-match path returns `held`; `validated` requires real normalized email equality. No credential-less/unverified account can reach `validated`.
+2. **Route only adds on validated** — `subscriptionPool.add()` is reached only after `not-found`(404) and `held`(200) are exhaustively returned; the gate runs before any pool mutation. Dark gate matches the PR2 scan-route pattern exactly; no path collision with the generic route.
+3. **No regression** — generic `complete()` and `POST /subscription-pool/enroll/:id/complete` are byte-unchanged (pure addition); `completeFollowMe` REUSES `complete()` (ensureInteractiveReady still runs); no double-transition.
+4. **expectedEmail threading** — flows start()→issue()→record (trimmed, omitted-when-blank) and is read from `login.expectedEmail`. An old pending login without it fails closed (`missing-expected-email`).
+5. **server.ts wiring** — `CredentialIdentityOracle` + `telegram` in scope; emitAttention maps to a valid `priority:'HIGH'` createAttentionItem. `tsc --noEmit` EXIT=0.
+6. **Attention flooding** — deterministic attention id de-dupes repeated held completions.
+7. **Test adequacy** — both boundary sides covered via the REAL route pipeline (dark→503, validated→201+pool added, held→200+pool NOT mutated+HIGH attention, 404); units assert fail-closed on oracle-unavailable/no-oracle/throws/missing-email. 33/33 green.
+
+Minor non-blocking note: gate normalizes case for comparison while the store preserves case on `expectedEmail` — correct (no false mismatch on case).


### PR DESCRIPTION
## ELI16

This is the next piece of "Account Follow-Me" — the feature that lets you log in once and have your subscription work across all your machines. This piece is the safety check that runs the moment a machine finishes logging in to one of your accounts.

Here's the situation it protects. When you authorize a machine to enroll one of your accounts, that machine drives a normal login (you approve it from your phone). But what login actually *completes* on that machine isn't guaranteed to be the account you meant — a typo, the wrong account picked at the provider's page, or (in a bad case) a tampered login could finish as a *different* account than the one you approved.

This change adds a gate at the exact moment the login completes: before the freshly-enrolled account is allowed to be used for any work, the machine reads the email the login *actually* authenticated as (from the account's own profile, via its config-home) and compares it to the email you approved. If they match, the account becomes usable. If they DON'T match — or the email can't be read at all — the account is HELD: it is NOT added to the usable pool, and you get a HIGH-priority alert to check it. It never silently uses a surprise account.

It's fail-closed everywhere: no way to read the email, no expected email on record, the reader throws an error — every uncertain case results in "held," never "used." Normal (non-follow-me) logins are completely untouched — this only runs on the follow-me completion path.

The account is added to the pool ONLY on a verified email match, through a new route that's off by default (dark) behind the `multiMachine.accountFollowMe` flag.

## What this PR does
- Threads `expectedEmail` (the operator-approved account email) `EnrollmentWizard.start()` → `PendingLoginStore` → the pending-login record.
- Adds `EnrollmentWizard.completeFollowMe(id, nickname)`: completes the login, reads the real email via the `CredentialIdentityOracle`, runs `validateEnrolledAccountEmail` (PR2), returns `validated` | `held` (+HIGH attention) | `not-found`.
- Adds dark route `POST /subscription-pool/follow-me/enroll/:id/complete` that calls `SubscriptionPool.add()` ONLY on a verified match.
- Wires the oracle + attention emitter into the wizard in `server.ts`.
- 33 tests (29 unit + 4 Tier-2 integration over the real route pipeline); `tsc` clean; side-effects + independent second-pass security review (concurred).

Spec: `docs/specs/ws52-account-follow-me-security.md` §5.3/S7 (converged, approved).