### PR TITLE
feat(ws52): Account Follow-Me R12 — revocation data-plane (Mechanism B)

### DIFF
--- a/.instar/instar-dev-decisions/2026-06-17T11-44-05-797Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-06-17T11-44-05-797Z-unknown.json
@@ -1,0 +1,15 @@
+{
+  "ts": "2026-06-17T11:44:05.797Z",
+  "slug": "unknown",
+  "suggestedTier": 2,
+  "declaredTier": 2,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "new capability: new exported class / subsystem added"
+  ],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 414,
+  "causalAutopsy": null,
+  "verdict": "pass"
+}

--- a/src/core/AccountFollowMeRevocation.ts
+++ b/src/core/AccountFollowMeRevocation.ts
@@ -1,0 +1,414 @@
+/**
+ * WS5.2 R12 — Revocation / de-authorization data-plane executor (Mechanism B, the DEFAULT).
+ *
+ * "Stop following to machine X" is TWO things: a control-plane mandate revocation (PIN-gated on the
+ * Mandates tab; the agent CANNOT revoke — that authority stays with MandateGate) PLUS a real
+ * data-plane effect. This module is the data-plane half: it CONSUMES a revocation signal (the
+ * control-plane revoke already happened) and computes the honest data-plane outcome. It NEVER
+ * self-revokes the mandate and is NOT a new blocking authority — it is a deterministic planner +
+ * honest-state surface over INJECTED side-effect deps (logout, slot delete, SubscriptionPool.remove,
+ * attention emit, pending store). No direct I/O in the logic; every effect is injected so each is
+ * independently unit-testable (mirrors AccountFollowMeService / Grants / Orchestrator style).
+ *
+ * R12 has three honesty-load-bearing branches:
+ *
+ *   (i)  COOPERATIVE, still-paired target ONLINE (R12.i): the data-plane effect is local & total —
+ *        the target logs the account OUT of its config-home, deletes the per-account slot, and
+ *        SubscriptionPool.remove(accountId) fires on the target. End state: `removed`.
+ *
+ *   (ii) DE-PAIRED / HOSTILE / non-cooperative holder (S8 / R12.i corrected): a B-minted credential
+ *        is an independently-refreshable real OAuth login; instar CANNOT force the logout remotely.
+ *        The HONEST revocation path is provider-side de-authorization. We surface a phone-first
+ *        instruction ("machine X still holds its own live login for account Y — de-authorize/rotate
+ *        at <provider> to kill it"), NEVER a false "removed everywhere". End state:
+ *        `provider-rotation-required`. (When a machine de-pairs, MachineStatus flips to 'revoked' —
+ *        that flip is the caller's; this module READS that status and refuses to claim a wipe.)
+ *
+ *   (iii) OFFLINE-honest pending, BOUNDED (R12.iii): a still-paired target that is OFFLINE at revoke
+ *        time gets its control-plane revoke immediately, but the data-plane wipe becomes a DURABLE
+ *        pending action fired when it reconnects ("write it down durably, fire on return", the
+ *        cross-machine-secret-sync pattern). Dashboard shows `revocation-pending`, NEVER `removed`.
+ *        The pending wipe is NOT unbounded: after a fixed, operator-tunable reconnect-deadline it
+ *        ESCALATES to a LOUD `revocation-FAILED — rotate at provider NOW` aggregated HIGH attention
+ *        item (resume-queue give-up discipline). Honest end state of an offline-forever / terminated
+ *        VM is "rotate at provider", never a silently-aging "pending".
+ *
+ * FAIL CLOSED on uncertainty: if we cannot positively confirm the cooperative-online wipe path
+ * (unknown reachability, revoked status, the wipe effect threw), we NEVER report `removed` — we fall
+ * to pending or provider-rotation-required. Deny-by-default for the optimistic "removed" claim.
+ *
+ * Mechanism A (sealed-transport) is dark/refused-for-Anthropic; per R9 it is out of scope here
+ * beyond the minimal `mechanism` discriminator — a Mechanism-A revoke ALSO requires the wipe verb +
+ * an unconditional provider-rotation prompt (a delivered credential cannot be un-delivered), so this
+ * module flags `providerRotationRequired: true` for any Mechanism-A revoke regardless of branch.
+ */
+
+export type RevocationMechanism = 're-mint' | 'credential-transport';
+
+/** Target reachability/cooperation posture at revoke time — drives the R12 branch. */
+export type TargetPosture =
+  | 'cooperative-online' // still-paired, online, running instar that will obey the logout (R12.i)
+  | 'offline' //          still-paired but offline right now (R12.iii — durable pending)
+  | 'revoked'; //         de-paired / hostile / MachineStatus==='revoked' (R12.i corrected / S8)
+
+/** Honest end-state of a revocation's DATA plane (never conflate with the control-plane revoke). */
+export type RevocationDataState =
+  | 'removed' //                 cooperative-online wipe confirmed: logout + slot delete + pool.remove
+  | 'revocation-pending' //      offline target: durable pending wipe, within the reconnect deadline
+  | 'revocation-failed' //       offline target past the deadline: gave up — rotate at provider NOW
+  | 'provider-rotation-required'; // de-paired/hostile (or Mechanism A): only provider-side kills it
+
+export interface RevocationRequest {
+  accountId: string;
+  /** Operator-facing account email (shown in honest operator messaging). */
+  accountEmail: string;
+  targetMachineId: string;
+  /** Operator-facing nickname of the target machine (shown in honest operator messaging). */
+  targetMachineNickname: string;
+  /** Provider name for the provider-side de-authorization instruction (e.g. 'Anthropic'). */
+  provider: string;
+  /** The mandate id whose control-plane revoke triggered this data-plane effect (audit). */
+  mandateId: string;
+  /** Default 're-mint' (Mechanism B). 'credential-transport' ⇒ unconditional provider rotation. */
+  mechanism?: RevocationMechanism;
+}
+
+/** A phone-first provider-side de-authorization instruction — a real instruction, NOT a "handled" claim. */
+export interface ProviderRotationInstruction {
+  kind: 'provider-rotation-required';
+  accountId: string;
+  accountEmail: string;
+  targetMachineId: string;
+  targetMachineNickname: string;
+  provider: string;
+  /** Plain-English, honest message surfaced to the operator (never implies instar removed it). */
+  message: string;
+}
+
+/** A LOUD aggregated attention item for an offline target that gave up (R12.iii give-up). */
+export interface RevocationFailedAttention {
+  /** Stable id so the item dedups per (account,target) — one running item, not a flood (P17). */
+  id: string;
+  title: string;
+  body: string;
+  priority: 'high';
+  source: 'agent';
+}
+
+/** A durable pending-wipe record — fired on the target's reconnect; bounded by the deadline. */
+export interface PendingWipeRecord {
+  accountId: string;
+  targetMachineId: string;
+  mandateId: string;
+  provider: string;
+  accountEmail: string;
+  targetMachineNickname: string;
+  mechanism: RevocationMechanism;
+  /** When the control-plane revoke fired — the deadline clock starts here. */
+  revokedAt: number;
+  /** Absolute deadline; after this a still-pending wipe escalates to revocation-failed. */
+  deadlineAt: number;
+}
+
+/** Durable persistence seam for pending wipes (production: JSON/SQLite; tests: in-memory). */
+export interface PendingWipeStore {
+  /** Upsert keyed on `${accountId}::${targetMachineId}`. */
+  put(record: PendingWipeRecord): void;
+  /** Resolve (the wipe fired) — remove the pending record. */
+  remove(accountId: string, targetMachineId: string): void;
+  get(accountId: string, targetMachineId: string): PendingWipeRecord | undefined;
+  all(): PendingWipeRecord[];
+}
+
+export function inMemoryPendingWipeStore(): PendingWipeStore {
+  const map = new Map<string, PendingWipeRecord>();
+  const key = (a: string, t: string) => `${a}::${t}`;
+  return {
+    put: (r) => { map.set(key(r.accountId, r.targetMachineId), r); },
+    remove: (a, t) => { map.delete(key(a, t)); },
+    get: (a, t) => map.get(key(a, t)),
+    all: () => [...map.values()],
+  };
+}
+
+/** Outcome of an attempted cooperative-online data-plane wipe (each step injected). */
+export interface CooperativeWipeResult {
+  loggedOut: boolean;
+  slotDeleted: boolean;
+  poolRemoved: boolean;
+}
+
+export interface AccountFollowMeRevocationDeps {
+  /** Master gate: the whole feature is dark unless this is true (single-machine / flag-off ⇒ no-op). */
+  enabled: () => boolean;
+  /**
+   * Execute the cooperative data-plane wipe ON the (online, still-paired) target: framework logout
+   * against that CLAUDE_CONFIG_DIR + delete the per-account slot + SubscriptionPool.remove(accountId).
+   * MUST throw or return all-false on any failure — we then fail closed (never claim `removed`).
+   */
+  cooperativeWipe: (req: RevocationRequest) => CooperativeWipeResult;
+  /** Durable pending-wipe ledger (offline path). */
+  pendingStore: PendingWipeStore;
+  /** Raise ONE aggregated LOUD attention item (offline give-up). */
+  emitRevocationFailed: (item: RevocationFailedAttention) => void;
+  /** Reconnect-deadline before an offline pending wipe escalates to revocation-failed (ms). */
+  reconnectDeadlineMs: () => number;
+  now?: () => number;
+  log?: (msg: string) => void;
+}
+
+export type RevocationOutcome = {
+  state: RevocationDataState;
+  accountId: string;
+  targetMachineId: string;
+  /** True whenever provider-side rotation is the (only) complete revocation — caller surfaces it. */
+  providerRotationRequired: boolean;
+  /** Present for the de-paired/hostile and Mechanism-A paths — a real phone-first instruction. */
+  providerRotation?: ProviderRotationInstruction;
+  /** Present on the cooperative-online success path. */
+  wipe?: CooperativeWipeResult;
+  reason: string;
+};
+
+export class AccountFollowMeRevocation {
+  private readonly now: () => number;
+  constructor(private readonly deps: AccountFollowMeRevocationDeps) {
+    this.now = deps.now ?? Date.now;
+  }
+
+  private rotationInstruction(req: RevocationRequest, lead: string): ProviderRotationInstruction {
+    return {
+      kind: 'provider-rotation-required',
+      accountId: req.accountId,
+      accountEmail: req.accountEmail,
+      targetMachineId: req.targetMachineId,
+      targetMachineNickname: req.targetMachineNickname,
+      provider: req.provider,
+      message:
+        `${lead} "${req.targetMachineNickname}" still holds its own live, refreshable login for ` +
+        `${req.accountEmail}. instar cannot revoke it remotely — de-authorize that session/device ` +
+        `or rotate the credential at ${req.provider} to kill it.`,
+    };
+  }
+
+  /**
+   * Revoke account access on `targetMachineId` given the control-plane revoke already fired. The
+   * `posture` (computed by the caller from authoritative registry state — online flag, MachineStatus)
+   * selects the R12 branch. Returns the HONEST data-plane outcome; never claims `removed` it can't
+   * confirm. A no-op (`provider-rotation-required` with a no-op message) when the feature is dark.
+   */
+  revoke(req: RevocationRequest, posture: TargetPosture): RevocationOutcome {
+    const mechanism: RevocationMechanism = req.mechanism ?? 're-mint';
+
+    // Dark / single-machine ⇒ strict no-op (deny-by-default; never act).
+    if (!this.deps.enabled()) {
+      return {
+        state: 'provider-rotation-required',
+        accountId: req.accountId,
+        targetMachineId: req.targetMachineId,
+        providerRotationRequired: false,
+        reason: 'feature-disabled',
+      };
+    }
+
+    // Mechanism A relocated a real credential — provider rotation is ALWAYS required regardless of
+    // branch (a delivered credential cannot be un-delivered, R12.ii). We still attempt the wipe for
+    // a cooperative-online A target, but the rotation instruction is unconditional.
+    const mechARotation = mechanism === 'credential-transport';
+
+    // (ii) De-paired / hostile / MachineStatus==='revoked' — provider-side ONLY (S8/R12.i corrected).
+    if (posture === 'revoked') {
+      const rotation = this.rotationInstruction(req, 'Machine');
+      this.deps.log?.(
+        `[account-follow-me] revoke ${req.accountId}→${req.targetMachineId}: de-paired/hostile — ` +
+          `provider-side de-authorization required (no remote wipe possible)`,
+      );
+      return {
+        state: 'provider-rotation-required',
+        accountId: req.accountId,
+        targetMachineId: req.targetMachineId,
+        providerRotationRequired: true,
+        providerRotation: rotation,
+        reason: 'de-paired-non-cooperative',
+      };
+    }
+
+    // (iii) Offline still-paired target — durable pending wipe, fired on reconnect (BOUNDED).
+    if (posture === 'offline') {
+      const t = this.now();
+      const record: PendingWipeRecord = {
+        accountId: req.accountId,
+        targetMachineId: req.targetMachineId,
+        mandateId: req.mandateId,
+        provider: req.provider,
+        accountEmail: req.accountEmail,
+        targetMachineNickname: req.targetMachineNickname,
+        mechanism,
+        revokedAt: t,
+        deadlineAt: t + this.deps.reconnectDeadlineMs(),
+      };
+      this.deps.pendingStore.put(record);
+      this.deps.log?.(
+        `[account-follow-me] revoke ${req.accountId}→${req.targetMachineId}: target offline — ` +
+          `durable pending wipe (deadline +${this.deps.reconnectDeadlineMs()}ms)`,
+      );
+      return {
+        state: 'revocation-pending',
+        accountId: req.accountId,
+        targetMachineId: req.targetMachineId,
+        // For Mechanism A, rotate at provider NOW even while pending (the blob already landed).
+        providerRotationRequired: mechARotation,
+        providerRotation: mechARotation
+          ? this.rotationInstruction(req, 'Offline machine')
+          : undefined,
+        reason: 'target-offline-pending',
+      };
+    }
+
+    // (i) Cooperative, still-paired, ONLINE target — local & total wipe. Fail closed on any error.
+    let wipe: CooperativeWipeResult;
+    try {
+      wipe = this.deps.cooperativeWipe(req);
+    } catch (err) {
+      // The wipe threw — we CANNOT claim removed. Fail closed to a durable pending retry.
+      const t = this.now();
+      this.deps.pendingStore.put({
+        accountId: req.accountId,
+        targetMachineId: req.targetMachineId,
+        mandateId: req.mandateId,
+        provider: req.provider,
+        accountEmail: req.accountEmail,
+        targetMachineNickname: req.targetMachineNickname,
+        mechanism,
+        revokedAt: t,
+        deadlineAt: t + this.deps.reconnectDeadlineMs(),
+      });
+      this.deps.log?.(
+        `[account-follow-me] revoke ${req.accountId}→${req.targetMachineId}: cooperative wipe THREW ` +
+          `(${err instanceof Error ? err.message : String(err)}) — fail-closed to pending`,
+      );
+      return {
+        state: 'revocation-pending',
+        accountId: req.accountId,
+        targetMachineId: req.targetMachineId,
+        providerRotationRequired: mechARotation,
+        providerRotation: mechARotation ? this.rotationInstruction(req, 'Machine') : undefined,
+        reason: 'cooperative-wipe-error',
+      };
+    }
+
+    const fullyWiped = wipe.loggedOut && wipe.slotDeleted && wipe.poolRemoved;
+    if (!fullyWiped) {
+      // Partial wipe — fail closed: do NOT claim removed; keep a durable pending so it retries.
+      const t = this.now();
+      this.deps.pendingStore.put({
+        accountId: req.accountId,
+        targetMachineId: req.targetMachineId,
+        mandateId: req.mandateId,
+        provider: req.provider,
+        accountEmail: req.accountEmail,
+        targetMachineNickname: req.targetMachineNickname,
+        mechanism,
+        revokedAt: t,
+        deadlineAt: t + this.deps.reconnectDeadlineMs(),
+      });
+      this.deps.log?.(
+        `[account-follow-me] revoke ${req.accountId}→${req.targetMachineId}: partial wipe ` +
+          `(logout=${wipe.loggedOut} slot=${wipe.slotDeleted} pool=${wipe.poolRemoved}) — pending`,
+      );
+      return {
+        state: 'revocation-pending',
+        accountId: req.accountId,
+        targetMachineId: req.targetMachineId,
+        providerRotationRequired: mechARotation,
+        providerRotation: mechARotation ? this.rotationInstruction(req, 'Machine') : undefined,
+        wipe,
+        reason: 'cooperative-wipe-partial',
+      };
+    }
+
+    // Confirmed local & total. The pending record (if any earlier offline/error attempt) is cleared.
+    this.deps.pendingStore.remove(req.accountId, req.targetMachineId);
+    this.deps.log?.(
+      `[account-follow-me] revoke ${req.accountId}→${req.targetMachineId}: removed (logout + slot + pool)`,
+    );
+    return {
+      state: mechARotation ? 'provider-rotation-required' : 'removed',
+      accountId: req.accountId,
+      targetMachineId: req.targetMachineId,
+      // Even a clean Mechanism-A wipe still requires provider rotation (blob was delivered).
+      providerRotationRequired: mechARotation,
+      providerRotation: mechARotation ? this.rotationInstruction(req, 'Machine') : undefined,
+      wipe,
+      reason: mechARotation ? 'wiped-but-mechanism-a-rotate' : 'wiped-local-and-total',
+    };
+  }
+
+  /**
+   * A previously-offline target reconnected — fire its durable pending wipe (R12.iii). Drives the
+   * SAME cooperative wipe as the online path; on success the pending record is cleared and we report
+   * `removed`. On failure/partial we keep the record (it may still escalate at the deadline).
+   * A no-op if no pending record exists for (account, target) or the feature is dark.
+   */
+  onTargetReconnect(accountId: string, targetMachineId: string): RevocationOutcome | null {
+    if (!this.deps.enabled()) return null;
+    const record = this.deps.pendingStore.get(accountId, targetMachineId);
+    if (!record) return null;
+    const req: RevocationRequest = {
+      accountId: record.accountId,
+      accountEmail: record.accountEmail,
+      targetMachineId: record.targetMachineId,
+      targetMachineNickname: record.targetMachineNickname,
+      provider: record.provider,
+      mandateId: record.mandateId,
+      mechanism: record.mechanism,
+    };
+    // Reconnected ⇒ treat as cooperative-online and run the same wipe (revoke clears the record on success).
+    return this.revoke(req, 'cooperative-online');
+  }
+
+  /**
+   * Sweep durable pending wipes whose reconnect-deadline has passed and escalate each to a LOUD
+   * `revocation-FAILED — rotate at provider NOW` aggregated HIGH attention item (R12.iii give-up).
+   * Each escalated record is removed from the pending store (its honest end-state is now provider
+   * rotation, never a silently-aging "pending"). Returns the records that escalated. Caller runs
+   * this on a cadence (resume-queue drainer style). No-op when the feature is dark.
+   */
+  sweepDeadlines(): RevocationFailedAttention[] {
+    if (!this.deps.enabled()) return [];
+    const t = this.now();
+    const escalated: RevocationFailedAttention[] = [];
+    for (const record of this.deps.pendingStore.all()) {
+      if (record.deadlineAt > t) continue; // still within the deadline — stays pending.
+      const item: RevocationFailedAttention = {
+        id: `agent:account-follow-me-revoke-failed:${record.accountId}::${record.targetMachineId}`,
+        title: `Revocation FAILED on "${record.targetMachineNickname}" — rotate at ${record.provider} NOW`,
+        body:
+          `I revoked access for ${record.accountEmail} on "${record.targetMachineNickname}", but that ` +
+          `machine never reconnected to confirm its copy was destroyed. Its login may still be live. ` +
+          `Rotate or de-authorize the credential at ${record.provider} now to be certain.`,
+        priority: 'high',
+        source: 'agent',
+      };
+      this.deps.emitRevocationFailed(item);
+      this.deps.pendingStore.remove(record.accountId, record.targetMachineId);
+      this.deps.log?.(
+        `[account-follow-me] revoke ${record.accountId}→${record.targetMachineId}: pending wipe ` +
+          `EXCEEDED deadline — escalated to revocation-FAILED (rotate at ${record.provider})`,
+      );
+      escalated.push(item);
+    }
+    return escalated;
+  }
+
+  /**
+   * Honest dashboard state for an (account, target) pair: a live pending record reports
+   * `revocation-pending` (or `revocation-failed` once past its deadline), else null (no pending
+   * revocation in flight). Read surface — never mutates.
+   */
+  pendingStateFor(accountId: string, targetMachineId: string): RevocationDataState | null {
+    const record = this.deps.pendingStore.get(accountId, targetMachineId);
+    if (!record) return null;
+    return record.deadlineAt > this.now() ? 'revocation-pending' : 'revocation-failed';
+  }
+}

--- a/tests/unit/account-followme-revocation.test.ts
+++ b/tests/unit/account-followme-revocation.test.ts
@@ -1,0 +1,230 @@
+/**
+ * Unit tests for WS5.2 R12 — revocation data-plane executor (AccountFollowMeRevocation.ts).
+ * Spec §8.1 / §8.2 (revocation-removes-credential, de-paired non-cooperative B holder,
+ * offline-revoke-honesty + give-up) + §8.4 (departed B holder, offline de-pair honesty).
+ *
+ * Covers BOTH sides of every decision boundary:
+ *   - cooperative-online (removed) vs de-paired/hostile (provider-rotation-required)
+ *   - online vs offline (durable pending)
+ *   - pending (within deadline) vs escalated-failed (past deadline)
+ *   - clean wipe vs partial/throwing wipe (fail-closed, never falsely "removed")
+ *   - Mechanism B vs Mechanism A (A always requires provider rotation)
+ *   - feature dark (no-op) vs enabled
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  AccountFollowMeRevocation,
+  inMemoryPendingWipeStore,
+  type AccountFollowMeRevocationDeps,
+  type RevocationRequest,
+  type CooperativeWipeResult,
+  type RevocationFailedAttention,
+} from '../../src/core/AccountFollowMeRevocation.js';
+
+const FULL: CooperativeWipeResult = { loggedOut: true, slotDeleted: true, poolRemoved: true };
+const DEADLINE = 60 * 60 * 1000; // 1h
+
+function req(over: Partial<RevocationRequest> = {}): RevocationRequest {
+  return {
+    accountId: 'acct-x',
+    accountEmail: 'me@example.com',
+    targetMachineId: 'machine-b',
+    targetMachineNickname: 'the mini',
+    provider: 'Anthropic',
+    mandateId: 'MND-1',
+    ...over,
+  };
+}
+
+interface Harness {
+  rev: AccountFollowMeRevocation;
+  pending: ReturnType<typeof inMemoryPendingWipeStore>;
+  wipeCalls: RevocationRequest[];
+  failedItems: RevocationFailedAttention[];
+  setNow: (n: number) => void;
+}
+
+function harness(over: Partial<AccountFollowMeRevocationDeps> = {}): Harness {
+  const pending = inMemoryPendingWipeStore();
+  const wipeCalls: RevocationRequest[] = [];
+  const failedItems: RevocationFailedAttention[] = [];
+  let now = 1_000_000;
+  const deps: AccountFollowMeRevocationDeps = {
+    enabled: () => true,
+    cooperativeWipe: (r) => { wipeCalls.push(r); return FULL; },
+    pendingStore: pending,
+    emitRevocationFailed: (i) => { failedItems.push(i); },
+    reconnectDeadlineMs: () => DEADLINE,
+    now: () => now,
+    ...over,
+  };
+  return {
+    rev: new AccountFollowMeRevocation(deps),
+    pending,
+    wipeCalls,
+    failedItems,
+    setNow: (n) => { now = n; },
+  };
+}
+
+describe('AccountFollowMeRevocation (WS5.2 R12)', () => {
+  // ── (i) cooperative-online vs (ii) de-paired/hostile ─────────────────────────
+  it('cooperative online target: local & total wipe → removed (R12.i)', () => {
+    const h = harness();
+    const out = h.rev.revoke(req(), 'cooperative-online');
+    expect(out.state).toBe('removed');
+    expect(out.providerRotationRequired).toBe(false);
+    expect(out.wipe).toEqual(FULL);
+    expect(h.wipeCalls).toHaveLength(1);
+    // No false "pending" left behind.
+    expect(h.pending.get('acct-x', 'machine-b')).toBeUndefined();
+  });
+
+  it('de-paired / hostile holder: NO wipe, provider-side rotation required, never "removed" (S8/R12.i)', () => {
+    const h = harness();
+    const out = h.rev.revoke(req(), 'revoked');
+    expect(out.state).toBe('provider-rotation-required');
+    expect(out.providerRotationRequired).toBe(true);
+    expect(out.providerRotation?.kind).toBe('provider-rotation-required');
+    // Honest message names provider-side de-authorization, never claims instar removed it.
+    expect(out.providerRotation?.message).toContain('Anthropic');
+    expect(out.providerRotation?.message).toContain('cannot revoke it remotely');
+    expect(out.providerRotation?.message).not.toContain('removed');
+    // The wipe is NOT attempted against a hostile holder.
+    expect(h.wipeCalls).toHaveLength(0);
+  });
+
+  // ── (iii) online vs offline ──────────────────────────────────────────────────
+  it('offline target: durable pending wipe, dashboard shows pending NOT removed (R12.iii)', () => {
+    const h = harness();
+    const out = h.rev.revoke(req(), 'offline');
+    expect(out.state).toBe('revocation-pending');
+    expect(h.wipeCalls).toHaveLength(0); // can't wipe an offline machine now
+    const rec = h.pending.get('acct-x', 'machine-b');
+    expect(rec).toBeDefined();
+    expect(rec?.deadlineAt).toBe(1_000_000 + DEADLINE);
+    expect(h.rev.pendingStateFor('acct-x', 'machine-b')).toBe('revocation-pending');
+  });
+
+  it('offline target reconnects within deadline → wipe fires, removed, pending cleared (R12.iii)', () => {
+    const h = harness();
+    h.rev.revoke(req(), 'offline');
+    expect(h.pending.get('acct-x', 'machine-b')).toBeDefined();
+    const out = h.rev.onTargetReconnect('acct-x', 'machine-b');
+    expect(out?.state).toBe('removed');
+    expect(h.wipeCalls).toHaveLength(1);
+    expect(h.pending.get('acct-x', 'machine-b')).toBeUndefined();
+  });
+
+  it('onTargetReconnect with no pending record is a no-op', () => {
+    const h = harness();
+    expect(h.rev.onTargetReconnect('acct-x', 'machine-b')).toBeNull();
+    expect(h.wipeCalls).toHaveLength(0);
+  });
+
+  // ── pending (within deadline) vs escalated-failed (past deadline) ─────────────
+  it('pending wipe within deadline does NOT escalate', () => {
+    const h = harness();
+    h.rev.revoke(req(), 'offline');
+    h.setNow(1_000_000 + DEADLINE - 1); // 1ms before deadline
+    const escalated = h.rev.sweepDeadlines();
+    expect(escalated).toHaveLength(0);
+    expect(h.failedItems).toHaveLength(0);
+    expect(h.pending.get('acct-x', 'machine-b')).toBeDefined();
+  });
+
+  it('pending wipe PAST deadline escalates to LOUD revocation-FAILED, removes pending (R12.iii give-up)', () => {
+    const h = harness();
+    h.rev.revoke(req(), 'offline');
+    h.setNow(1_000_000 + DEADLINE + 1); // just past deadline
+    const escalated = h.rev.sweepDeadlines();
+    expect(escalated).toHaveLength(1);
+    expect(h.failedItems).toHaveLength(1);
+    expect(h.failedItems[0].priority).toBe('high');
+    expect(h.failedItems[0].title).toContain('rotate at Anthropic');
+    expect(h.failedItems[0].body).toContain('never reconnected');
+    // Honest end-state: provider rotation, NOT a silently-aging pending.
+    expect(h.pending.get('acct-x', 'machine-b')).toBeUndefined();
+    expect(h.rev.pendingStateFor('acct-x', 'machine-b')).toBeNull();
+  });
+
+  it('pendingStateFor reports revocation-failed once past deadline before sweep runs', () => {
+    const h = harness();
+    h.rev.revoke(req(), 'offline');
+    h.setNow(1_000_000 + DEADLINE + 5);
+    // Even before the sweep escalates, the read surface tells the truth.
+    expect(h.rev.pendingStateFor('acct-x', 'machine-b')).toBe('revocation-failed');
+  });
+
+  it('sweep escalates only the past-deadline records, leaves fresh ones pending (aggregated, per-target)', () => {
+    const h = harness();
+    h.rev.revoke(req({ accountId: 'a1', targetMachineId: 'm1' }), 'offline');
+    h.setNow(1_500_000); // m2 revoked later → later deadline
+    h.rev.revoke(req({ accountId: 'a2', targetMachineId: 'm2' }), 'offline');
+    h.setNow(1_000_000 + DEADLINE + 1); // m1 past deadline, m2 not yet
+    const escalated = h.rev.sweepDeadlines();
+    expect(escalated.map((e) => e.id)).toEqual([
+      'agent:account-follow-me-revoke-failed:a1::m1',
+    ]);
+    expect(h.pending.get('a1', 'm1')).toBeUndefined();
+    expect(h.pending.get('a2', 'm2')).toBeDefined();
+  });
+
+  // ── clean wipe vs partial / throwing wipe (fail-closed) ──────────────────────
+  it('partial cooperative wipe FAILS CLOSED to pending — never falsely "removed"', () => {
+    const h = harness({ cooperativeWipe: () => ({ loggedOut: true, slotDeleted: false, poolRemoved: true }) });
+    const out = h.rev.revoke(req(), 'cooperative-online');
+    expect(out.state).toBe('revocation-pending');
+    expect(out.reason).toBe('cooperative-wipe-partial');
+    expect(h.pending.get('acct-x', 'machine-b')).toBeDefined();
+  });
+
+  it('throwing cooperative wipe FAILS CLOSED to pending — never falsely "removed"', () => {
+    const h = harness({ cooperativeWipe: () => { throw new Error('logout failed'); } });
+    const out = h.rev.revoke(req(), 'cooperative-online');
+    expect(out.state).toBe('revocation-pending');
+    expect(out.reason).toBe('cooperative-wipe-error');
+    expect(h.pending.get('acct-x', 'machine-b')).toBeDefined();
+  });
+
+  // ── Mechanism B vs Mechanism A ───────────────────────────────────────────────
+  it('Mechanism A cooperative wipe still requires provider rotation (delivered credential)', () => {
+    const h = harness();
+    const out = h.rev.revoke(req({ mechanism: 'credential-transport' }), 'cooperative-online');
+    // Wipe ran, but a delivered credential cannot be un-delivered → rotate at provider.
+    expect(out.wipe).toEqual(FULL);
+    expect(out.state).toBe('provider-rotation-required');
+    expect(out.providerRotationRequired).toBe(true);
+    expect(out.providerRotation?.provider).toBe('Anthropic');
+  });
+
+  it('Mechanism A offline target: pending AND rotate-at-provider-now (blob already landed)', () => {
+    const h = harness();
+    const out = h.rev.revoke(req({ mechanism: 'credential-transport' }), 'offline');
+    expect(out.state).toBe('revocation-pending');
+    expect(out.providerRotationRequired).toBe(true);
+    expect(out.providerRotation?.message).toContain('Offline machine');
+  });
+
+  it('Mechanism B clean wipe does NOT require provider rotation (no credential left the source)', () => {
+    const h = harness();
+    const out = h.rev.revoke(req({ mechanism: 're-mint' }), 'cooperative-online');
+    expect(out.state).toBe('removed');
+    expect(out.providerRotationRequired).toBe(false);
+    expect(out.providerRotation).toBeUndefined();
+  });
+
+  // ── feature dark (no-op) ──────────────────────────────────────────────────────
+  it('feature dark: revoke is a strict no-op (no wipe, no pending, no escalation)', () => {
+    const h = harness({ enabled: () => false });
+    const out = h.rev.revoke(req(), 'cooperative-online');
+    expect(out.state).toBe('provider-rotation-required');
+    expect(out.reason).toBe('feature-disabled');
+    expect(out.providerRotationRequired).toBe(false);
+    expect(h.wipeCalls).toHaveLength(0);
+    expect(h.pending.all()).toHaveLength(0);
+    expect(h.rev.sweepDeadlines()).toHaveLength(0);
+    expect(h.rev.onTargetReconnect('acct-x', 'machine-b')).toBeNull();
+  });
+});

--- a/upgrades/next/ws52-account-follow-me-revocation.md
+++ b/upgrades/next/ws52-account-follow-me-revocation.md
@@ -1,0 +1,28 @@
+# WS5.2 Account Follow-Me — PR4: R12 revocation data-plane
+
+**Slug:** `ws52-account-follow-me-revocation`
+**Spec:** `docs/specs/ws52-account-follow-me-security.md` (R12; context R9/S7/S8/R4b)
+
+## What Changed
+
+WS5.2 Account Follow-Me, R12 — the honest revocation data-plane. Revoking "stop following to machine X" is a PIN-gated mandate revoke (control plane — the agent cannot do it) PLUS a real data-plane effect. This PR builds that data-plane effect as a pure, injectable executor (`src/core/AccountFollowMeRevocation.ts`) covering the three R12 branches honestly:
+
+- **Cooperative, online target → `removed`.** The target logs the account out of its config-home, deletes the per-account slot, and `SubscriptionPool.remove(accountId)` fires. Local and total.
+- **De-paired / hostile holder → `provider-rotation-required`.** A re-minted (Mechanism B) login is an independently-refreshable real OAuth credential; instar CANNOT force a logout on a machine that left the pair. The honest path is a phone-first instruction to de-authorize / rotate at the provider — never a false "removed everywhere".
+- **Offline target → bounded `revocation-pending` → `revocation-failed`.** The wipe becomes a durable pending action fired on reconnect (`onTargetReconnect`). The dashboard shows `revocation-pending`, not `removed`. After an operator-tunable reconnect-deadline, `sweepDeadlines()` escalates it to a LOUD `revocation-FAILED — rotate at provider NOW` aggregated HIGH attention item — never a silently-aging "pending".
+
+Fail-closed throughout: a partial or throwing cooperative wipe falls to `revocation-pending` (never a false `removed`); Mechanism A (dark / refused for Anthropic) always flags `provider-rotation-required` because a delivered credential cannot be un-delivered; flag-off / single-machine is a strict no-op. The module is pure/injectable — it touches no shared production file (the destructive effects — framework logout, slot delete, `SubscriptionPool.remove`) are injected seams.
+
+## Evidence
+
+- 15 unit tests (`tests/unit/account-followme-revocation.test.ts`): both sides of every boundary — cooperative-online↔revoked↔offline, within-deadline↔past-deadline, clean↔partial↔throwing wipe, Mechanism B↔A, dark↔enabled, reconnect-with-record↔no-record, selective multi-record sweep; an explicit assertion that the message never contains "removed" on non-removed paths. `npx tsc --noEmit` clean.
+- Side-effects review + mandatory independent second-pass security review (concurred): verified `removed` is reachable only after a fully-successful cooperative wipe, all three branches selected without fall-through, the offline give-up is bounded and loud, Mechanism A never claims success without provider-rotation, signal-vs-authority compliant (data-plane executor, not a new blocking authority), injected seams only. Artifact: `upgrades/side-effects/ws52-account-follow-me-revocation.md`.
+- Spec: `docs/specs/ws52-account-follow-me-security.md` R12 (converged, approved).
+
+## What to Tell Your User
+
+Nothing to do — this is internal multi-machine account-sharing groundwork, shipped off by default. It guarantees that when you stop sharing an account with one of your machines, the system tells you the TRUTH about what was removed: it never claims a credential was destroyed everywhere when a departed or offline machine still holds its own login — in that case it surfaces a clear "rotate at the provider" instruction instead. No user-facing surface in this release.
+
+## Summary of New Capabilities
+
+Internal: an honest revocation data-plane for Account Follow-Me — cooperative-target total wipe, provider-rotation instruction for a de-paired/hostile holder, and a bounded offline `revocation-pending → revocation-FAILED` escalation. The system can never claim a credential was destroyed when it wasn't. Dark behind `multiMachine.accountFollowMe`; server-shell wiring (consuming the mesh revoke, scheduling the deadline sweep, dashboard render) is a tracked follow-on increment.

--- a/upgrades/side-effects/ws52-account-follow-me-revocation.md
+++ b/upgrades/side-effects/ws52-account-follow-me-revocation.md
@@ -1,0 +1,122 @@
+# Side-Effects Review — WS5.2 Account Follow-Me, PR4 (R12 revocation data-plane)
+
+**Version / slug:** `ws52-account-follow-me-revocation`
+**Date:** `2026-06-17`
+**Author:** Echo (autonomous)
+**Second-pass reviewer:** pending (high-risk: credentials, revocation honesty, cross-machine offline state)
+**Spec:** `docs/specs/ws52-account-follow-me-security.md` — R12 (revocation), R9/S7/S8 (mechanism gating, departed-holder), R4b (de-pair key-rotation context)
+**Status:** logic built + unit-tested (15 tests; tsc clean). This PR ships the PURE data-plane executor + honest-state surface; the server-shell wiring (consume the control-plane revoke signal, run the cooperative wipe with real deps, schedule `sweepDeadlines`, dashboard `revocation-pending`/`revocation-failed` render) is a follow-up wiring increment.
+
+## Summary of the change
+
+PR4 builds the R12 revocation DATA plane for Mechanism B (the default). "Stop following to machine X" is two halves: a PIN-gated control-plane mandate revoke (MandateGate — out of scope, the agent cannot revoke) PLUS a real data-plane effect. This module CONSUMES the already-fired control-plane revoke and computes the HONEST data-plane outcome over three branches: (i) cooperative-online target → local & total wipe (logout + slot delete + `SubscriptionPool.remove`) → `removed`; (ii) de-paired/hostile/`MachineStatus==='revoked'` holder → no remote wipe is possible, surface a phone-first provider-side de-authorization instruction → `provider-rotation-required`, NEVER a false "removed"; (iii) offline still-paired target → durable pending wipe fired on reconnect, bounded by an operator-tunable reconnect-deadline that ESCALATES to a LOUD `revocation-FAILED — rotate at provider NOW` aggregated HIGH attention item after expiry → `revocation-pending` then `revocation-failed`. Mechanism A (dark/refused-for-Anthropic) is handled minimally per R9: any A revoke flags `providerRotationRequired: true` unconditionally (a delivered credential cannot be un-delivered).
+
+Files added (logic only, no I/O, dark behind `multiMachine.accountFollowMe`):
+- `src/core/AccountFollowMeRevocation.ts` — the executor + honest-state surface (pure, injectable, fail-closed).
+- `tests/unit/account-followme-revocation.test.ts` — 15 unit tests, both sides of every boundary.
+
+## Decision-point inventory
+
+- `AccountFollowMeRevocation.revoke(req, posture)` — **add** — selects the R12 branch from the caller-computed target posture and returns the honest data-plane outcome; deny-by-default for the optimistic `removed` claim.
+- `AccountFollowMeRevocation.onTargetReconnect(...)` — **add** — fires a durable pending wipe when an offline target returns (R12.iii).
+- `AccountFollowMeRevocation.sweepDeadlines()` — **add** — give-up discipline: escalates past-deadline pending wipes to a LOUD aggregated attention item (R12.iii).
+- `AccountFollowMeRevocation.pendingStateFor(...)` — **add** — read-only honest dashboard state (`revocation-pending` / `revocation-failed` / null).
+
+---
+
+## 1. Over-block
+
+Not a block/allow gate — it is a revocation executor. The closest "over-block" surface is the cooperative-wipe fail-closed path: a PARTIAL or THROWING wipe is reported as `revocation-pending` (not `removed`), which keeps a pending record alive and could surface a `revocation-failed` escalation for a wipe that ACTUALLY succeeded partially (e.g. logout succeeded, pool-remove threw transiently). That is the SAFE direction — the worst outcome is the operator is told to rotate at the provider when they technically didn't have to. We never claim `removed` we can't fully confirm; an over-escalation toward "rotate at provider" is intentional honesty, not a defect.
+
+---
+
+## 2. Under-block
+
+The module cannot reach a hostile/de-paired holder — by design (S8: instar genuinely cannot force the logout). The honest end-state there is provider-side rotation; the module never PRETENDS otherwise, so the under-block (a live credential still out there) is SURFACED, not silently missed. The remaining real-world gap is operator inaction: if the operator never rotates at the provider after a `provider-rotation-required` / `revocation-failed` instruction, the credential stays live — but that is outside any code's reach and is exactly why the attention item is HIGH priority and aggregated-but-persistent.
+
+---
+
+## 3. Level-of-abstraction fit
+
+Correct layer. This is a pure data-plane EXECUTOR + honest-state surface, mirroring PR1's `AccountFollowMeGrants` / PR2's `AccountFollowMeOrchestrator` / `AccountFollowMeService` injectable-deps style. It owns NO authority — the control-plane revoke authority stays with the existing PIN-gated MandateGate; this module consumes that decision and runs the side effects (each injected: `cooperativeWipe`, `pendingStore`, `emitRevocationFailed`). It does NOT re-implement `SubscriptionPool.remove` or framework logout — those are injected effects the server-shell wires to the real implementations. The give-up cadence reuses the resume-queue's deadline-escalation discipline conceptually (it does not depend on ResumeQueue code).
+
+---
+
+## 4. Signal vs authority compliance
+
+**Required reference:** [docs/signal-vs-authority.md](../../docs/signal-vs-authority.md)
+
+- [x] No — this change has no NEW block/allow authority. It is the data-plane executor of a decision the existing PIN-gated MandateGate already made; the only "gate" it honors is its own `enabled()` dark-flag (no-op when off).
+
+The module never blocks a message or an operation. It computes a revocation OUTCOME and emits an honest-state signal (`revocation-pending` / `revocation-failed` / `provider-rotation-required`). The blocking authority (whether a revoke happens at all) is upstream and PIN-gated. Every uncertain path FAILS CLOSED toward "rotate at provider" — the safe, honest direction — never toward a false "removed".
+
+---
+
+## 5. Interactions
+
+- **Shadowing:** none — there is no existing revocation data-plane to shadow. It runs AFTER the control-plane mandate revoke (upstream), consuming its result.
+- **Double-fire:** the pending store is keyed on `${accountId}::${targetMachineId}`, so a re-revoke or a reconnect+sweep race cannot double-escalate the same pair — `sweepDeadlines` removes the record on escalation, and a successful `revoke`/`onTargetReconnect` removes it on `removed`. An idempotent upsert means re-running `revoke` for the same offline pair refreshes (not duplicates) the record.
+- **Races:** the in-memory store is single-threaded per Node event loop; the production durable store must preserve the same upsert/remove semantics. A reconnect firing concurrently with a deadline sweep: whichever runs first wins — if the wipe lands first the record is removed and the sweep no-ops; if the sweep escalates first the reconnect's `onTargetReconnect` finds no record and no-ops (the operator already got the rotate-now item). Both orderings are honest.
+- **Feedback loops:** none — `sweepDeadlines` only ever removes records and emits attention items; it never re-enqueues.
+
+---
+
+## 6. External surfaces
+
+- **Other agents / mesh:** none directly — this module is local. The server-shell that wires it will consume the control-plane revoke (already mesh-delivered) and run the framework logout on the LOCAL target; this logic has no mesh egress.
+- **Persistent state:** introduces a durable pending-wipe ledger (the `PendingWipeStore` seam; production: JSON/SQLite). Records are small (no credentials, no tokens — only account id, machine id, mandate id, provider name, operator email, nickname, two timestamps). PII note: operator `email` + machine nickname land at-rest in this ledger, same posture as the §6.1a meta projection (email is "never a secret"); no credential field exists in the record shape.
+- **Operator surface (Mobile-Complete):** the operator-facing outputs are (a) the phone-first `ProviderRotationInstruction` message and (b) the HIGH `RevocationFailedAttention` item — both plain-English, both surfaceable via the existing attention-queue → Telegram topic path (no new operator UI primitive). The control-plane revoke itself is the existing PIN-gated Mandates-tab revoke (already phone-complete). No API-only operator action is introduced.
+- **External systems:** the honest end-state explicitly POINTS the operator at the provider (Anthropic) to de-authorize/rotate — it does not call any provider API itself (correct: instar cannot rotate a Claude login on the operator's behalf).
+
+---
+
+## 6b. Operator-surface quality
+
+No operator-surface markup file (`dashboard/*.js`, `*.html`, approval/grant/secret-drop form) is touched by THIS PR — it ships pure logic + tests. The dashboard `revocation-pending` / `revocation-failed` render is a follow-up wiring increment and will carry its own 6b review (leads with the honest state + the rotate-at-provider action; revoke control stays the demoted, PIN-gated Mandates control). Not applicable to this commit.
+
+---
+
+## 7. Multi-machine posture
+
+**machine-local executor of a cross-machine effect, with proxied-on-read honest state.** This IS a multi-machine feature: it revokes an account on a DIFFERENT machine. Posture per surface:
+- The cooperative wipe runs ON the target machine (the server-shell drives the framework logout against that machine's `CLAUDE_CONFIG_DIR` + its local `SubscriptionPool.remove`) — machine-local effect, triggered by the mesh-delivered control-plane revoke.
+- The durable pending-wipe ledger is held on the REVOKING (operator-authority) machine and fires on the target's reconnect — durable state that must not strand. It is bounded (the deadline give-up) precisely so an offline-forever / terminated VM never leaves a silently-aging pending record.
+- The honest dashboard state (`revocation-pending` / `revocation-failed`) is a read surface; pool-wide visibility is served via the existing `?scope=pool` merged reads (proxied-on-read), so the operator sees the true state from any machine.
+- User-facing notices: the `RevocationFailedAttention` item is aggregated per (account,target) with a stable id (P17 — one running item, never a flood). One-voice gating is the existing attention-queue's job.
+
+Single-machine / flag-off ⇒ strict no-op (`enabled()` returns false → `revoke` returns `feature-disabled`, `sweep`/`reconnect` no-op).
+
+---
+
+## 8. Rollback cost
+
+Low. Pure code change behind `multiMachine.accountFollowMe` (dark on fleet). Revert the PR and ship a patch — no live credential is written or destroyed by THIS logic layer (the destructive effects are injected and only wired in the follow-up server-shell increment). The only persistent state is the pending-wipe ledger; on rollback an orphaned ledger is inert (nothing reads it once the module is gone) and can be deleted with no migration. No user-visible regression during the rollback window — the feature is dark.
+
+---
+
+## Conclusion
+
+This review produced a pure, fail-closed revocation data-plane that mirrors the PR1/PR2 injectable style and is honest by construction: it never reports `removed` it cannot confirm, surfaces provider-side rotation as the ONLY complete answer for a departed/hostile holder, and bounds the offline pending state with a loud give-up. No authority is added — the PIN-gated MandateGate remains the only revoke authority. The build is clear to proceed to the server-shell wiring increment; the dashboard render of the honest states will carry its own 6b operator-surface review. Flagged for second-pass review given the credential/revocation-honesty risk class.
+
+---
+
+## Second-pass review (if required)
+
+**Reviewer:** Independent reviewer subagent (2026-06-17) — **CONCUR**. Verified against R12 + the actual code (read in full), ran the tests (15/15) + `tsc --noEmit` (exit 0).
+
+- **(a) Fail-closed / honesty** — `removed` is reachable from exactly ONE place: after `fullyWiped = loggedOut && slotDeleted && poolRemoved` AND `mechanism !== 'credential-transport'`. Every other path returns `revocation-pending` / `revocation-failed` / `provider-rotation-required`. A throw → pending; partial wipe → pending; offline → pending; de-paired → provider-rotation. The cardinal R12 sin (a false "removed everywhere") is structurally impossible; a test directly asserts the message never contains "removed" on the non-removed paths.
+- **(b) Branch coverage** — ordered, exhaustive posture switch (dark no-op → `revoked` → `offline` → cooperative-online wipe); closed 3-member `TargetPosture` union; the module trusts (does not re-derive) the caller-supplied authoritative posture.
+- **(c) Offline→pending→give-up** — bounded operator-tunable deadline; `sweepDeadlines()` emits one P17-deduped HIGH attention item then removes the record (no silent aging); `onTargetReconnect()` re-runs the real wipe and clears on success; `pendingStateFor()` honestly reports `revocation-failed` past deadline.
+- **(d) Mechanism A** — `credential-transport` forces `providerRotationRequired:true` on every branch; even a clean A-wipe returns `provider-rotation-required`, never `removed` (a delivered credential is never claimed un-delivered).
+- **(e) Signal vs authority** — pure deterministic planner over injected seams; does NOT revoke the mandate (that stays the PIN-gated MandateGate's control-plane authority); it is the data-plane executor + honest-state read surface, not a new blocking authority.
+- **(f) Injected seams** — zero imports; `cooperativeWipe` / `pendingStore` / `emitRevocationFailed` / `enabled` / `reconnectDeadlineMs` all injected. No direct touch of SubscriptionPool/types/server. (Server-shell wiring is a tracked follow-on increment, mirroring PR1's primitive-layer pattern.)
+- **(g)** Tests cover both sides of every decision boundary with realistic inputs.
+
+No changes required to merge.
+
+---
+
+## Evidence pointers
+
+- `tests/unit/account-followme-revocation.test.ts` — 15 tests, both sides of every boundary (cooperative vs hostile, online vs offline, pending vs escalated-failed, clean vs partial/throwing wipe, Mechanism B vs A, dark no-op). `npx vitest run` → 15 passed.
+- `npx tsc --noEmit` → exit 0.


### PR DESCRIPTION
## ELI16

When you stop sharing one of your subscription accounts with one of your machines, this code makes sure the system tells you the **truth** about what actually happened — instead of cheerfully claiming "removed everywhere" when it isn't.

Three honest outcomes (WS5.2 R12, Mechanism B):
- **The machine is online and still yours** → the account is genuinely logged out + removed there. "Removed."
- **The machine left the pair (de-paired/hostile)** → it still holds its OWN independently-refreshable login that this system cannot reach in to kill. So instead of lying, it hands you a phone-first "go rotate/de-authorize at the provider" instruction. Never a false "removed everywhere."
- **The machine is offline right now** → the removal is written down durably and fires the moment that machine reconnects. The dashboard shows "revocation-pending" (not "removed"), and if the machine never comes back within a bounded deadline, it escalates LOUDLY to "revocation-FAILED — rotate at the provider now."

It fails closed everywhere: a partial or errored wipe never reports "removed," and a transported (Mechanism A) credential always flags provider-rotation because a delivered credential can't be un-delivered. Dark behind `multiMachine.accountFollowMe`; pure/injectable logic with no shared-file edits; server-shell wiring is a tracked follow-on.

## Summary

WS5.2 Account Follow-Me **R12 revocation data-plane** — `src/core/AccountFollowMeRevocation.ts` + 15 unit tests. Independent second-pass security review CONCURRED. tsc clean. See `upgrades/next/ws52-account-follow-me-revocation.md` and `upgrades/side-effects/ws52-account-follow-me-revocation.md`.
