### PR TITLE
feat(ws52): Account Follow-Me enroll-drive START route (live-proof keystone)

### DIFF
--- a/.instar/instar-dev-decisions/2026-06-17T12-14-53-095Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-06-17T12-14-53-095Z-unknown.json
@@ -1,0 +1,16 @@
+{
+  "ts": "2026-06-17T12:14:53.095Z",
+  "slug": "unknown",
+  "suggestedTier": 2,
+  "declaredTier": 2,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "new capability: new route (router.<verb>() added",
+    "new capability: new config key added"
+  ],
+  "belowFloor": false,
+  "files": 2,
+  "loc": 188,
+  "causalAutopsy": null,
+  "verdict": "pass"
+}

--- a/src/core/resolveFollowMeEnrollTarget.ts
+++ b/src/core/resolveFollowMeEnrollTarget.ts
@@ -1,0 +1,95 @@
+/**
+ * WS5.2 §5.3 / S7 — resolve the OPERATOR-APPROVED enrollment target for an account, AUTHORITATIVELY,
+ * from real pool state — NEVER from the request body. This is the keystone of the email-safety gate:
+ * `expectedEmail` MUST be what the operator approved (the account's known email across the mesh), so
+ * `completeFollowMe` can later validate the freshly-minted login against it. A self-asserted email in
+ * the request body would defeat the gate entirely (S7), so this function only ever reads from the same
+ * authoritative source the scan uses: the local SubscriptionPool + the per-peer pool views (which
+ * carry each account's id + email from the replicated `subscription-account-meta` projection).
+ *
+ * FAIL-CLOSED by construction: if the account's email cannot be resolved from any holder, this returns
+ * `{ resolved: false }` and the caller MUST refuse (409) rather than starting an enrollment with a
+ * blank/wrong expectedEmail. Pure (no I/O) ⇒ unit-testable; the route supplies the fetched views.
+ */
+
+import type { MachinePoolView } from './accountFollowMeDepth.js';
+
+/** A local SubscriptionPool account row, as the resolver needs it. */
+export interface LocalAccountRow {
+  id: string;
+  email?: string;
+  nickname?: string;
+  provider?: string;
+  framework?: string;
+}
+
+export interface ResolveFollowMeEnrollTargetInput {
+  accountId: string;
+  /** This machine's local SubscriptionPool accounts (authoritative when the account is held here). */
+  localAccounts: LocalAccountRow[];
+  /** Cross-machine per-peer pool views (the same source the scan uses — carries id + email). */
+  peerViews: MachinePoolView[];
+  /** Fallbacks when the meta does not carry provider/framework (it usually does). */
+  defaultProvider?: string;
+  defaultFramework?: string;
+}
+
+export type ResolveFollowMeEnrollTargetResult =
+  | {
+      resolved: true;
+      /** The OPERATOR-APPROVED account email (authoritative; never from the request body). */
+      expectedEmail: string;
+      provider: string;
+      framework: string;
+      /** Operator-facing label for the new pending login. */
+      label: string;
+    }
+  | { resolved: false; reason: string };
+
+/**
+ * Resolve the approved email + provider/framework + label for `accountId`.
+ *
+ * Resolution order (authoritative-first):
+ *   1. the LOCAL SubscriptionPool (if this machine already holds/knows the account) — most trustworthy;
+ *   2. any PEER pool view that reports the account with a non-empty email (the replicated meta).
+ * The email MUST be a non-empty string for the result to be `resolved` — otherwise fail-closed.
+ */
+export function resolveFollowMeEnrollTarget(
+  input: ResolveFollowMeEnrollTargetInput,
+): ResolveFollowMeEnrollTargetResult {
+  const { accountId } = input;
+  const defaultProvider = input.defaultProvider ?? 'anthropic';
+  const defaultFramework = input.defaultFramework ?? 'claude-code';
+
+  // 1) Local pool — most authoritative when present.
+  const local = input.localAccounts.find((a) => a.id === accountId);
+  if (local && typeof local.email === 'string' && local.email.trim().length > 0) {
+    return {
+      resolved: true,
+      expectedEmail: local.email.trim(),
+      provider: (local.provider && local.provider.length > 0) ? local.provider : defaultProvider,
+      framework: (local.framework && local.framework.length > 0) ? local.framework : defaultFramework,
+      label: (local.nickname && local.nickname.trim().length > 0) ? local.nickname.trim() : accountId,
+    };
+  }
+
+  // 2) Peer views — the replicated meta projection (carries id + email).
+  for (const view of input.peerViews) {
+    for (const row of view.accounts) {
+      if (row.accountId !== accountId) continue;
+      if (typeof row.email === 'string' && row.email.trim().length > 0) {
+        return {
+          resolved: true,
+          expectedEmail: row.email.trim(),
+          // Peer view rows carry only id/email/status; provider/framework default for a re-mint
+          // (the target machine logs in with its own framework — claude-code/anthropic by default).
+          provider: defaultProvider,
+          framework: defaultFramework,
+          label: accountId,
+        };
+      }
+    }
+  }
+
+  return { resolved: false, reason: 'cannot resolve approved account email' };
+}

--- a/src/server/routes.ts
+++ b/src/server/routes.ts
@@ -1436,6 +1436,24 @@ export const PATCHABLE_CONFIG_KEYS: ReadonlySet<string> = new Set([
   'dispatches', 'feedback',
 ]);
 
+/**
+ * Resolve THIS agent's routing fingerprint — the named-party identity the mandate gate checks
+ * against the mandate's grantedTo. Mirrors the /passport route's best-effort source (the
+ * threadline agent-info.json fingerprint) and falls back to the project name when unavailable.
+ * Used by the account-follow-me enroll-start route's mandate evaluate (deny-by-default).
+ */
+function resolveAgentFingerprint(ctx: RouteContext): string {
+  try {
+    const infoPath = path.join(ctx.config.stateDir, '..', 'threadline', 'agent-info.json');
+    if (fs.existsSync(infoPath)) {
+      const info = JSON.parse(fs.readFileSync(infoPath, 'utf-8')) as { fingerprint?: string; publicKey?: string };
+      if (info.fingerprint) return info.fingerprint;
+      if (info.publicKey) return info.publicKey;
+    }
+  } catch { /* fall through to project name */ }
+  return ctx.config.projectName ?? 'self';
+}
+
 export function createRoutes(ctx: RouteContext): Router {
   const router = Router();
 
@@ -20850,6 +20868,81 @@ export function createRoutes(ctx: RouteContext): Router {
       res.json({ enabled: true, offered });
     } catch (err) {
       res.status(500).json({ error: err instanceof Error ? err.message : 'follow-me scan failed' });
+    }
+  });
+
+  // WS5.2 §5.3 (R6/R6a) — Account Follow-Me: DRIVE THE ENROLLMENT START on THIS target machine.
+  // After the operator issues the `account-follow-me` mandate (PIN-gated, on this machine's own
+  // dashboard — OQ6 option 2), this route is the keystone that re-mints the login (Mechanism B,
+  // ToS-safe — no token is ever copied). It is the START counterpart to /follow-me/enroll/:id/complete.
+  //
+  // Authorization is the operator MANDATE, deny-by-default (R1): the mandate gate is consulted for
+  // (accountId, this machine, mechanism=re-mint); a deny/absent mandate STOPS with 403. The
+  // operator-expected account email (S7) is resolved AUTHORITATIVELY from real pool state (the local
+  // pool + the same peer-views the scan uses — the replicated subscription-account-meta projection),
+  // NEVER from the request body — so `completeFollowMe` can later validate the minted account against
+  // what the operator actually approved. Unresolvable email ⇒ 409 fail-closed (never start blank).
+  // Dark behind multiMachine.accountFollowMe (503 when off). Mirrors the scan route's dark-gate exactly.
+  router.post('/subscription-pool/follow-me/enroll/start', async (req, res) => {
+    const afmCfg = (ctx.config as unknown as { multiMachine?: { accountFollowMe?: { enabled?: boolean } } }).multiMachine?.accountFollowMe;
+    if (!resolveDevAgentGate(afmCfg?.enabled, ctx.config)) {
+      res.status(503).json({ error: 'account follow-me not enabled' });
+      return;
+    }
+    if (!ctx.enrollmentWizard || !ctx.subscriptionPool || !ctx.coordination?.gate) {
+      res.status(503).json({ error: 'enrollment wizard, subscription pool, or mandate gate not configured' });
+      return;
+    }
+    const b = req.body ?? {};
+    if (typeof b.mandateId !== 'string' || !b.mandateId || typeof b.accountId !== 'string' || !b.accountId) {
+      res.status(400).json({ error: 'mandateId and accountId are required' });
+      return;
+    }
+    const { mandateId, accountId } = b as { mandateId: string; accountId: string };
+    const targetMachineId = ctx.meshSelfId ?? (ctx.config as { machineId?: string }).machineId ?? 'local';
+
+    // THE AUTHORIZATION (deny-by-default): consult the operator mandate for THIS exact
+    // (account, this machine, mechanism). A non-allow verdict STOPS — never work around it.
+    const verdict = ctx.coordination.gate.evaluate({
+      action: 'account-follow-me',
+      params: { accountId, targetMachineId, mechanism: 're-mint' },
+      agentFp: resolveAgentFingerprint(ctx),
+      mandateId,
+    });
+    if (verdict.decision !== 'allow') {
+      res.status(403).json({ error: 'account follow-me not authorized', reason: verdict.reason });
+      return;
+    }
+
+    // S7 — resolve the operator-APPROVED email authoritatively (local pool + peer views), NEVER
+    // from the request body. Unresolvable ⇒ fail-closed (never start with a blank/wrong email).
+    try {
+      const { resolveFollowMeEnrollTarget } = await import('../core/resolveFollowMeEnrollTarget.js');
+      const localAccounts = ctx.subscriptionPool.list().map((a) => ({
+        id: a.id, email: a.email, nickname: a.nickname, provider: a.provider, framework: a.framework,
+      }));
+      const peerViews = ctx.accountFollowMePeerViews ? await ctx.accountFollowMePeerViews() : [];
+      const target = resolveFollowMeEnrollTarget({ accountId, localAccounts, peerViews });
+      if (!target.resolved) {
+        res.status(409).json({ error: 'cannot resolve approved account email' });
+        return;
+      }
+
+      // Allocate this account's own config-home slot on THIS machine (one home per credential).
+      const safeAccountId = accountId.replace(/[^a-z0-9-]/gi, '-');
+      const configHome = path.join(os.homedir(), `.claude-followme-${safeAccountId}`);
+
+      const login = await ctx.enrollmentWizard.start({
+        id: accountId,
+        label: target.label,
+        provider: target.provider as import('../core/PendingLoginStore.js').LoginProvider,
+        framework: target.framework as import('../core/PendingLoginStore.js').PendingLogin['framework'],
+        configHome,
+        expectedEmail: target.expectedEmail,
+      });
+      res.status(201).json({ enabled: true, login });
+    } catch (err) {
+      res.status(500).json({ error: err instanceof Error ? err.message : 'follow-me enroll start failed' });
     }
   });
 

--- a/tests/integration/account-follow-me-enroll-start-route.test.ts
+++ b/tests/integration/account-follow-me-enroll-start-route.test.ts
@@ -1,0 +1,149 @@
+/**
+ * Integration test — WS5.2 §5.3 (R6/R6a) follow-me enroll-START route over the full HTTP pipeline
+ * (createRoutes + a real SubscriptionPool + a real EnrollmentWizard with a fake driveLogin + a
+ * stub MandateGate). Verifies the keystone of the live cross-machine proof:
+ *   (a) dark (non-dev, flag omitted) → 503;
+ *   (b) enabled + NO/denied mandate → 403 (deny-by-default — the gate is THE authorization);
+ *   (c) enabled + valid mandate + resolvable email → 201, the login carries the device-code AND a
+ *       pending login now exists with expectedEmail set to the OPERATOR-APPROVED email (S7);
+ *   (d) enabled + valid mandate but email unresolvable → 409 fail-closed (never start blank).
+ */
+
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import express from 'express';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import type { AddressInfo } from 'node:net';
+import { createRoutes } from '../../src/server/routes.js';
+import { SubscriptionPool } from '../../src/core/SubscriptionPool.js';
+import { EnrollmentWizard } from '../../src/core/EnrollmentWizard.js';
+import { PendingLoginStore } from '../../src/core/PendingLoginStore.js';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+
+interface TestServer { url: string; close: () => Promise<void>; }
+async function listen(app: express.Express): Promise<TestServer> {
+  return new Promise((resolve) => {
+    const srv = app.listen(0, () => {
+      const port = (srv.address() as AddressInfo).port;
+      resolve({ url: `http://127.0.0.1:${port}`, close: () => new Promise<void>((r) => srv.close(() => r())) });
+    });
+  });
+}
+
+function buildCtx(dir: string, opts: {
+  dev: boolean;
+  /** Gate verdict — 'allow' to authorize, 'deny' for deny-by-default. */
+  decision: 'allow' | 'deny';
+  /** When true, the account a1 is known LOCALLY with its email; when false, no email is resolvable. */
+  knowAccountEmail: boolean;
+}) {
+  const pool = new SubscriptionPool({ stateDir: dir });
+  if (opts.knowAccountEmail) {
+    // The operator-approved account is known locally with its email (authoritative S7 source).
+    pool.add({ id: 'a1', nickname: 'main', provider: 'anthropic', framework: 'claude-code', configHome: '/x/a1', email: 'approved@x.com' });
+  }
+  const store = new PendingLoginStore({ stateDir: dir });
+  const enrollmentWizard = new EnrollmentWizard({
+    store,
+    // Fake driveLogin returns a public device-code/URL — never a credential.
+    driveLogin: async () => ({ verificationUrl: 'https://claude.com/oauth', userCode: 'WXYZ-1234', ttlMs: 15 * 60_000 }),
+    ensureReady: () => ({ patched: false, reason: 'already interactive-ready' }),
+  });
+  return {
+    config: {
+      authToken: 'test', stateDir: dir, port: 0, projectName: 'echo',
+      developmentAgent: opts.dev,
+      multiMachine: { accountFollowMe: {} },
+    },
+    startTime: new Date(),
+    meshSelfId: 'this-machine',
+    subscriptionPool: pool,
+    enrollmentWizard,
+    coordination: { gate: { evaluate: () => ({ decision: opts.decision, reason: opts.decision === 'allow' ? 'mandate ok' : 'no mandate' }) } },
+    // No peer views in this harness; email resolution leans on the local pool (or fails closed).
+    accountFollowMePeerViews: async () => ([]),
+  } as unknown as Parameters<typeof createRoutes>[0];
+}
+
+describe('/subscription-pool/follow-me/enroll/start (integration)', () => {
+  let server: TestServer;
+  let dir: string;
+  const post = (p: string, body?: unknown) =>
+    fetch(server.url + p, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      ...(body !== undefined ? { body: JSON.stringify(body) } : {}),
+    }).then(async (r) => ({ status: r.status, body: await r.json().catch(() => ({})) }));
+
+  afterEach(async () => {
+    await server?.close();
+    try { SafeFsExecutor.safeRmSync(dir, { recursive: true, force: true, operation: 'tests/integration/account-follow-me-enroll-start-route.test.ts:cleanup' }); } catch { /* @silent-fallback-ok */ }
+  });
+
+  it('(a) dark (non-dev, flag enabled omitted) → 503', async () => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'afm-start-'));
+    const app = express(); app.use(express.json());
+    app.use(createRoutes(buildCtx(dir, { dev: false, decision: 'allow', knowAccountEmail: true })));
+    server = await listen(app);
+    const r = await post('/subscription-pool/follow-me/enroll/start', { mandateId: 'm1', accountId: 'a1' });
+    expect(r.status).toBe(503);
+  });
+
+  it('(b) enabled + denied mandate → 403 (deny-by-default)', async () => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'afm-start-'));
+    const ctx = buildCtx(dir, { dev: true, decision: 'deny', knowAccountEmail: true });
+    const app = express(); app.use(express.json());
+    app.use(createRoutes(ctx));
+    server = await listen(app);
+    const r = await post('/subscription-pool/follow-me/enroll/start', { mandateId: 'm1', accountId: 'a1' });
+    expect(r.status).toBe(403);
+    expect(r.body.reason).toBe('no mandate');
+    // Fail-closed: NO pending login was started.
+    const wizard = (ctx as unknown as { enrollmentWizard: EnrollmentWizard }).enrollmentWizard;
+    expect(wizard.pending()).toHaveLength(0);
+  });
+
+  it('(c) enabled + valid mandate + resolvable email → 201 + pending login with expectedEmail set', async () => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'afm-start-'));
+    const ctx = buildCtx(dir, { dev: true, decision: 'allow', knowAccountEmail: true });
+    const app = express(); app.use(express.json());
+    app.use(createRoutes(ctx));
+    server = await listen(app);
+    const r = await post('/subscription-pool/follow-me/enroll/start', { mandateId: 'm1', accountId: 'a1' });
+    expect(r.status).toBe(201);
+    expect(r.body.enabled).toBe(true);
+    // The returned login carries the public device-code/URL for the operator to approve.
+    expect(r.body.login).toMatchObject({ id: 'a1', userCode: 'WXYZ-1234', verificationUrl: 'https://claude.com/oauth' });
+    // A pending login now exists carrying the OPERATOR-APPROVED email (not from the request body).
+    const wizard = (ctx as unknown as { enrollmentWizard: EnrollmentWizard }).enrollmentWizard;
+    const pending = wizard.pending();
+    expect(pending).toHaveLength(1);
+    expect(pending[0]).toMatchObject({ id: 'a1', expectedEmail: 'approved@x.com' });
+    // The slot is this account's own config-home (one home per credential).
+    expect(pending[0].configHome).toContain('.claude-followme-a1');
+  });
+
+  it('(d) enabled + valid mandate but email unresolvable → 409 fail-closed', async () => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'afm-start-'));
+    const ctx = buildCtx(dir, { dev: true, decision: 'allow', knowAccountEmail: false });
+    const app = express(); app.use(express.json());
+    app.use(createRoutes(ctx));
+    server = await listen(app);
+    const r = await post('/subscription-pool/follow-me/enroll/start', { mandateId: 'm1', accountId: 'a1' });
+    expect(r.status).toBe(409);
+    expect(r.body.error).toBe('cannot resolve approved account email');
+    // Fail-closed: NO pending login was started with a blank/wrong email.
+    const wizard = (ctx as unknown as { enrollmentWizard: EnrollmentWizard }).enrollmentWizard;
+    expect(wizard.pending()).toHaveLength(0);
+  });
+
+  it('missing mandateId/accountId → 400', async () => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'afm-start-'));
+    const app = express(); app.use(express.json());
+    app.use(createRoutes(buildCtx(dir, { dev: true, decision: 'allow', knowAccountEmail: true })));
+    server = await listen(app);
+    const r = await post('/subscription-pool/follow-me/enroll/start', { accountId: 'a1' });
+    expect(r.status).toBe(400);
+  });
+});

--- a/tests/unit/resolve-follow-me-enroll-target.test.ts
+++ b/tests/unit/resolve-follow-me-enroll-target.test.ts
@@ -1,0 +1,62 @@
+/**
+ * Unit test — WS5.2 §5.3/S7 resolveFollowMeEnrollTarget: the operator-approved enrollment target
+ * is resolved AUTHORITATIVELY from real pool state (local pool first, then peer views), and FAILS
+ * CLOSED when no holder reports a usable email. The email must NEVER come from a request body.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { resolveFollowMeEnrollTarget } from '../../src/core/resolveFollowMeEnrollTarget.js';
+import type { MachinePoolView } from '../../src/core/accountFollowMeDepth.js';
+
+describe('resolveFollowMeEnrollTarget', () => {
+  it('resolves from the LOCAL pool (most authoritative), carrying provider/framework/label', () => {
+    const r = resolveFollowMeEnrollTarget({
+      accountId: 'a1',
+      localAccounts: [{ id: 'a1', email: 'approved@x.com', nickname: 'main', provider: 'anthropic', framework: 'claude-code' }],
+      peerViews: [],
+    });
+    expect(r).toEqual({ resolved: true, expectedEmail: 'approved@x.com', provider: 'anthropic', framework: 'claude-code', label: 'main' });
+  });
+
+  it('resolves from a PEER view when the account is not held locally (replicated meta projection)', () => {
+    const peerViews: MachinePoolView[] = [
+      { machineId: 'mini', nickname: 'the Mini', accounts: [{ accountId: 'a1', email: 'approved@x.com', status: 'active', locallyHeld: false }] },
+    ];
+    const r = resolveFollowMeEnrollTarget({ accountId: 'a1', localAccounts: [], peerViews });
+    expect(r).toMatchObject({ resolved: true, expectedEmail: 'approved@x.com', provider: 'anthropic', framework: 'claude-code', label: 'a1' });
+  });
+
+  it('prefers the local pool over a peer view (no override from a peer)', () => {
+    const peerViews: MachinePoolView[] = [
+      { machineId: 'mini', nickname: 'the Mini', accounts: [{ accountId: 'a1', email: 'peer@x.com', status: 'active', locallyHeld: false }] },
+    ];
+    const r = resolveFollowMeEnrollTarget({
+      accountId: 'a1',
+      localAccounts: [{ id: 'a1', email: 'local@x.com', nickname: 'main', provider: 'anthropic', framework: 'claude-code' }],
+      peerViews,
+    });
+    expect(r).toMatchObject({ resolved: true, expectedEmail: 'local@x.com' });
+  });
+
+  it('FAILS CLOSED when no holder reports an email', () => {
+    const peerViews: MachinePoolView[] = [
+      { machineId: 'mini', nickname: 'the Mini', accounts: [{ accountId: 'a1', status: 'active', locallyHeld: false }] },
+    ];
+    const r = resolveFollowMeEnrollTarget({ accountId: 'a1', localAccounts: [{ id: 'a1' }], peerViews });
+    expect(r).toEqual({ resolved: false, reason: 'cannot resolve approved account email' });
+  });
+
+  it('FAILS CLOSED for an unknown account', () => {
+    const r = resolveFollowMeEnrollTarget({
+      accountId: 'nope',
+      localAccounts: [{ id: 'a1', email: 'approved@x.com' }],
+      peerViews: [{ machineId: 'mini', nickname: 'm', accounts: [{ accountId: 'a1', email: 'approved@x.com', status: 'active', locallyHeld: false }] }],
+    });
+    expect(r.resolved).toBe(false);
+  });
+
+  it('treats a blank/whitespace email as unresolvable (fail-closed)', () => {
+    const r = resolveFollowMeEnrollTarget({ accountId: 'a1', localAccounts: [{ id: 'a1', email: '   ' }], peerViews: [] });
+    expect(r.resolved).toBe(false);
+  });
+});

--- a/upgrades/next/ws52-account-follow-me-enroll-start.md
+++ b/upgrades/next/ws52-account-follow-me-enroll-start.md
@@ -1,0 +1,17 @@
+## What Changed
+
+WS5.2 Account Follow-Me, R6/R6a(option 2)/S7 — the enroll-drive **START** route, the keystone that makes a cross-machine enrollment actually run after the operator approves it. New dark route `POST /subscription-pool/follow-me/enroll/start`: given an operator-issued `account-follow-me` mandate, it verifies the mandate (deny-by-default — non-allow → 403, the agent can never self-authorize), resolves the operator-APPROVED account email AUTHORITATIVELY from real pool state (local SubscriptionPool + the replicated `subscription-account-meta` peer views — NEVER the request body, per S7; unresolvable → 409 fail-closed), allocates a per-account config-home slot on this machine, and drives the local `EnrollmentWizard.start({…, expectedEmail})` to mint the device-code login. The existing `/complete` route then validates the minted login's email against `expectedEmail` before the account is added. This closes the gap between consent (the scan) and completion (the S7 gate) — the full Mechanism-B flow now runs end-to-end (per-server: the operator drives the target machine's own enroll route; nothing but read-only email metadata crosses machines).
+
+## Evidence
+
+- 11 tests: 6 unit (`resolveFollowMeEnrollTarget` — local-pool resolve, peer-view resolve, local-preferred, and all three fail-closed branches: unknown account, no email, blank email) + 5 Tier-2 integration over the REAL route pipeline (dark→503, denied/no-mandate→403 with zero pending logins, valid+resolvable→201 with a pending login carrying `expectedEmail` and the correct per-account slot, unresolvable email→409 fail-closed, missing fields→400). `tsc --noEmit` clean.
+- Side-effects review + mandatory independent second-pass security review (concurred): verified deny-by-default authorization, `expectedEmail` is authoritative (never from the body), agentFp fails closed (a wrong fp denies, never accidentally allows), config-home path-traversal-safe, fail-closed exhaustiveness, and no regression to normal enrollment.
+- Spec: `docs/specs/ws52-account-follow-me-security.md` R1/R6/R6a/S7 (converged, approved).
+
+## What to Tell Your User
+
+This is the piece that makes "log in once, it works on every machine" actually run end-to-end (still off by default). When you approve a machine to use one of your accounts (a one-tap dashboard approval), that machine now starts its OWN login for it, and I verify the login that completes is really the account you approved before it's used — no token is ever copied between machines. With this in, the cross-machine enrollment works start-to-finish behind the flag.
+
+## Summary of New Capabilities
+
+The enroll-drive START route (dark): an operator-mandate-gated, per-server route that drives a target machine's own `EnrollmentWizard` with the authoritatively-resolved approved email, completing the WS5.2 Mechanism-B flow (consent → start → email-validated completion → selectable). No user-facing surface is live in this release.

--- a/upgrades/side-effects/ws52-account-follow-me-enroll-start.md
+++ b/upgrades/side-effects/ws52-account-follow-me-enroll-start.md
@@ -1,0 +1,65 @@
+# Side-Effects Review — WS5.2 Account Follow-Me enroll-drive START route
+
+**Version / slug:** `ws52-account-follow-me-enroll-start`
+**Date:** `2026-06-17`
+**Author:** `Echo (instar-dev agent)`
+**Second-pass reviewer:** `pending (high-risk: mandate authorization + credential enrollment + the live-proof keystone)`
+
+## Summary of the change
+
+WS5.2 R6/R6a(option 2)/S7. The keystone that makes the cross-machine enrollment actually run: a new dark route `POST /subscription-pool/follow-me/enroll/start` (per-server — the operator drives the TARGET machine's own enroll route). Given an operator-issued `account-follow-me` mandate, it (1) verifies the mandate via `ctx.coordination.gate.evaluate({action:'account-follow-me', params:{accountId, targetMachineId, mechanism:'re-mint'}, agentFp, mandateId})` — deny-by-default, non-allow → 403; (2) resolves the operator-APPROVED account email AUTHORITATIVELY (local SubscriptionPool then the replicated `subscription-account-meta` peer views — NEVER the request body, per S7) via the new pure helper `resolveFollowMeEnrollTarget`, unresolvable → 409 fail-closed; (3) allocates a per-account configHome slot on this machine; (4) calls `EnrollmentWizard.start({..., expectedEmail})` returning the device-code/URL. The EXISTING `/complete` route then finishes via `completeFollowMe` (validates the minted login's email == expectedEmail before adding). Files: `src/server/routes.ts` (route + a `resolveAgentFingerprint` helper), `src/core/resolveFollowMeEnrollTarget.ts` (new pure helper), + 2 test files. Dark behind `multiMachine.accountFollowMe`.
+
+## Decision-point inventory
+
+- `POST /subscription-pool/follow-me/enroll/start` mandate check — **add** — the authorization decision: a follow-me enrollment STARTS only under a valid operator `account-follow-me` mandate for this exact (account, this machine, mechanism). Deny-by-default.
+- `resolveFollowMeEnrollTarget` — **add** — the S7 decision input: `expectedEmail` is the authoritatively-resolved approved email, never self-asserted; unresolvable → refuse.
+
+---
+
+## 1. Over-block
+
+A legitimate enrollment whose account email is not yet known on this machine (the replicated `subscription-account-meta` hasn't arrived, or the peer holding it is offline) is refused with 409. This is deliberate fail-closed (S7: never start an enrollment without the approved email to validate against). The operator retries once the account metadata has replicated (the scan that produced the consent already proves the email is known mesh-wide, so in the real flow the email is present). No legitimate "start without a known approved email" case exists.
+
+## 2. Under-block
+
+The route authorizes the START; the actual credential admission is gated downstream by S7 at `/complete` (the minted email must match expectedEmail) and by §6.2 (`isLocallyExecutable`) at selection. This route does not itself verify the device-code login outcome — by design, the completion gate owns that. It also trusts the mandate gate's verdict (the mandate is the authorizer); a mis-issued mandate is the operator's PIN-gated responsibility, not this route's. agentFp resolution that fails (returns a fallback) makes the mandate evaluate DENY (the mandate is party-bound) — safe direction, never an accidental allow.
+
+## 3. Level-of-abstraction fit
+
+Correct layer (R6a option 2): the START runs ON the target machine's own server, driven by the operator from that machine's dashboard after they issue the mandate locally — so the device-code is minted on the machine that will hold the credential and never transits. The mandate check reuses the existing `ctx.coordination.gate` (no new authorization primitive). The email resolution reuses the same authoritative source the scan uses (local pool + replicated meta peer views), extracted into a pure, testable helper rather than re-implemented inline.
+
+## 4. Signal vs authority compliance
+
+This route holds genuine authority (it starts a credential enrollment), exercised through the EXISTING deny-by-default MandateGate — not a new brittle check. The authorization is the mandate (PIN-gated, operator-issued); the route is a consumer of that authority, never a self-grant (requester≠authorizer preserved — the agent cannot issue the mandate). Every uncertain path fails closed (no/denied mandate → 403; unresolvable email → 409). Reference `docs/signal-vs-authority.md`: authority delegated from the operator mandate, deny-by-default, is correctly-placed authority.
+
+## 5. Interactions
+
+Pairs with the existing scan (detection→consent), the S7 `/complete` gate, and §6.2 selection — this route is the missing START link between consent and completion. It does NOT touch the generic `/subscription-pool/enroll` route (normal enrollment unchanged). The configHome slot is per-account (`.claude-followme-<accountId>`), isolated from other accounts. The pending login it issues carries `expectedEmail`, which `completeFollowMe` reads — the two routes compose without shared mutable state beyond the PendingLoginStore (single-flow-per-id discipline). No double-fire (one pending login per start; the wizard's id discipline applies).
+
+## 6. External surfaces
+
+One new HTTP route, dark behind `multiMachine.accountFollowMe` (503 when off — proven by the integration test). It returns a device-code/verificationUrl (already public per the EnrollmentWizard contract). No new config. It is the per-server enroll path (R6a option 2) and does not reach across the mesh itself (the operator drives it on the target's own dashboard).
+
+## 7. Multi-machine posture (Cross-Machine Coherence)
+
+**Machine-local execution BY DESIGN, fed by replicated read-only metadata.** The enrollment runs on the TARGET machine (the one gaining the login); `targetMachineId` is this machine (`ctx.meshSelfId`). The only cross-machine input is the READ-ONLY `subscription-account-meta` projection (the approved email), consumed via the existing peer-views fetch — no credential or configHome crosses. The mandate is verified locally against `ctx.coordination.gate`. This is the intended Mechanism-B posture: each machine mints its own login locally; nothing is replicated except the email metadata used to validate identity.
+
+## 8. Rollback cost
+
+Low. The route is dark by default (no agent runs it until `multiMachine.accountFollowMe` is enabled). No persisted schema change (the configHome slot is created only on a real enrollment; PendingLogin already carries `expectedEmail` from S7). Revert is a single-commit back-out of the route + helper; no migration, no state repair.
+
+---
+
+## Second-pass review
+
+**Concur with the review.** Independent audit of the full route (`routes.ts:20886-20947`), `resolveAgentFingerprint`, the pure resolver, `MandateGate.evaluate` (`:85-135`), `EnrollmentWizard.start`/`completeFollowMe`, and both test files. tsc EXIT=0; 11/11 pass.
+
+1. **Deny-by-default** — missing ids → 400; gate called with the exact action/params/mandateId; `verdict.decision !== 'allow'` → 403 (correctly not `=== 'deny'`). No path starts without allow. Route never issues/widens a mandate (requester≠authorizer).
+2. **expectedEmail authoritative (S7)** — resolver reads only `localAccounts` + `peerViews`, never `req.body` (route destructures only `mandateId`/`accountId`); blank/missing → 409 fail-closed, `start` not called. Chain holds: `start` persists expectedEmail, `completeFollowMe` validates it.
+3. **agentFp (critical)** — fails closed: a wrong/fallback fp is not a named mandate party → MandateGate step 5 denies. A wrong fp can never produce allow.
+4. **configHome isolation** — `accountId.replace(/[^a-z0-9-]/gi,'-')`; `../../etc` → `------etc`, no traversal; per-account slot.
+5. **No regression** — routes.ts diff +93/-0 purely additive; generic `/enroll` + `/complete` untouched.
+6. **Fail-closed exhaustiveness** — dark→503, missing deps→503, bad body→400, non-allow→403, unresolvable email→409, start throws→500. None start a bogus enrollment.
+7. **Test adequacy** — dark→503, denied/no-mandate→403 (zero pending logins), valid→201 (pending carries expectedEmail + correct slot), unresolvable→409, 400; unit covers resolved + all fail-closed branches.
+
+Minor note (not a defect): the integration test stubs `gate.evaluate` (exercises route branching, not real party-binding — that guarantee rests on MandateGate, verified directly).


### PR DESCRIPTION
## ELI16

This is the keystone that makes "log in once, it works on every machine" actually run from start to finish. The earlier pieces built the safety rails; this one connects them so the flow works end-to-end.

Picture the full journey of letting your laptop's subscription work on your Mac Mini: (1) the Mini notices it has no login for your account and asks you to approve enrolling it; (2) you approve on the dashboard (a PIN-gated mandate); (3) the Mini starts its OWN fresh login for that account and shows you a one-tap login code; (4) you approve the login; (5) the Mini checks the login that completed is really the account you approved, and only then starts using it. No password or token is ever copied between machines — the Mini logs in itself, exactly like you logging the same account into a second laptop.

Steps 1, 2, and 5 already existed. This PR builds step 3 — the missing trigger that, after you approve the mandate, actually makes the Mini start its own login with the right "expected account" attached (so step 5 can verify it). Without this, approving the mandate did nothing; with it, the whole chain runs.

The security is strict and fail-closed: the route refuses unless there's a valid operator mandate for this exact account+machine (the agent can never approve this itself); it figures out which account-email to expect from trusted shared metadata, NOT from whatever the request says (so a forged request can't make it accept the wrong account); and if it can't determine the expected email, it refuses rather than guessing. It's off by default behind the `multiMachine.accountFollowMe` flag.

## What this PR does
- New dark route `POST /subscription-pool/follow-me/enroll/start`: verifies the `account-follow-me` mandate (deny-by-default → 403), resolves the operator-approved email authoritatively (local pool + replicated `subscription-account-meta` peer views, never the request body), allocates a per-account config-home slot, and drives the local `EnrollmentWizard.start({…, expectedEmail})` → device-code login. The existing `/complete` route validates the minted email before adding.
- New pure helper `resolveFollowMeEnrollTarget` (authoritative email/provider/framework resolution, fail-closed).
- 11 tests (6 unit + 5 Tier-2 integration over the real route pipeline); `tsc` clean; side-effects + independent second-pass security review (concurred — verified deny-by-default, authoritative email, agentFp fails-closed, path-traversal-safe).

Spec: `docs/specs/ws52-account-follow-me-security.md` R1/R6/R6a/S7 (converged, approved). Completes the WS5.2 Mechanism-B flow end-to-end.