### PR TITLE
feat(ws52): Account Follow-Me R6b — headless-enrollment reliability

### DIFF
--- a/.instar/instar-dev-decisions/2026-06-17T12-44-00-403Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-06-17T12-44-00-403Z-unknown.json
@@ -1,0 +1,16 @@
+{
+  "ts": "2026-06-17T12:44:00.403Z",
+  "slug": "unknown",
+  "suggestedTier": 2,
+  "declaredTier": 2,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "new capability: new exported class / subsystem added",
+    "new capability: new config key added"
+  ],
+  "belowFloor": false,
+  "files": 4,
+  "loc": 149,
+  "causalAutopsy": null,
+  "verdict": "pass"
+}

--- a/src/config/ConfigDefaults.ts
+++ b/src/config/ConfigDefaults.ts
@@ -773,6 +773,13 @@ const SHARED_DEFAULTS: Record<string, unknown> = {
     accountFollowMe: {
       credentialTransport: {},
       maxFollowMachines: 5,
+      // WS5.2 R6b — the scrape-timeout budget (ms) for a REMOTE/cloud follow-me
+      // enrollment drive. Cloud→provider latency + the two-code Claude window do
+      // NOT fit the local-LAN 60s assumption, so the follow-me start path threads
+      // this LARGER budget to FrameworkLoginDriver (3min default). Normal LOCAL
+      // enrollment (/subscription-pool/enroll) is unchanged — it never reads this
+      // and keeps the driver's 60s default.
+      remoteScrapeTimeoutMs: 180000,
     },
     // WS3 one-voice gate (MULTI-MACHINE-SEAMLESSNESS-SPEC). Ships DARK: with
     // ws3OneVoice false the SpeakerElection returns "speak" unconditionally —

--- a/src/core/EnrollmentWizard.ts
+++ b/src/core/EnrollmentWizard.ts
@@ -48,7 +48,34 @@ export type LoginDriver = (req: {
   /** The new account's CLAUDE_CONFIG_DIR — isolates this login to its own slot
    *  so enrolling a 2nd account never clobbers the 1st. */
   configHome?: string;
+  /** WS5.2 R6b — per-call scrape-timeout budget (ms). The follow-me/remote path
+   *  passes a larger value (cloud→provider latency + the two-code Claude window);
+   *  omitted ⇒ the driver's own default (the local-LAN budget). */
+  scrapeTimeoutMs?: number;
 }) => Promise<LoginArtifact>;
+
+/**
+ * WS5.2 R6b — the honest-failure surface for a DRIVE failure during `start()`.
+ * Thrown (NOT swallowed) when `driveLogin` fails, so a remote/cloud enrollment
+ * surfaces an operator-facing "couldn't start the login on <nickname> — retry?"
+ * instead of either an opaque 500 OR a silently-stuck pending-login. The key
+ * invariant it guarantees: a drive failure NEVER leaves a pending-login issued
+ * with no artifact (the store is only written AFTER the drive succeeds), so the
+ * caller can render this as a retry-able failure with no dangling state.
+ */
+export class EnrollmentDriveError extends Error {
+  readonly code = 'enrollment-drive-failed' as const;
+  /** A short, operator-facing message (machine nickname interpolated by the caller). */
+  readonly operatorMessage: string;
+  /** The underlying driver error, for logs/audit (never shown to the operator raw). */
+  readonly cause?: unknown;
+  constructor(opts: { operatorMessage: string; cause?: unknown }) {
+    super(opts.operatorMessage);
+    this.name = 'EnrollmentDriveError';
+    this.operatorMessage = opts.operatorMessage;
+    this.cause = opts.cause;
+  }
+}
 
 export interface EnrollmentWizardConfig {
   store: PendingLoginStore;
@@ -91,6 +118,18 @@ export interface StartEnrollmentInput {
   /** WS5.2 §5.3/S7 — the operator-expected account email (follow-me path only). Carried
    *  onto the pending login so `completeFollowMe` can validate the minted account. */
   expectedEmail?: string;
+  /**
+   * WS5.2 R6b — this is a remote/cloud (follow-me) enrollment, not a local-LAN one.
+   * When set: (a) the per-provider flow-kind selection prefers the device-code
+   *   single-code flow where the provider supports it (Phase-C default — sidesteps
+   *   the two-code Claude problem entirely), and (b) `remoteScrapeTimeoutMs` (if
+   *   provided) is threaded to the driver as a larger scrape budget. Defaulted-off,
+   *   so normal local enrollment is byte-for-byte unchanged.
+   */
+  remote?: boolean;
+  /** WS5.2 R6b — larger scrape-timeout budget (ms) used only when `remote` is true.
+   *  Omitted ⇒ the driver's own default (the local-LAN budget). */
+  remoteScrapeTimeoutMs?: number;
 }
 
 export class EnrollmentWizard {
@@ -114,6 +153,21 @@ export class EnrollmentWizard {
    *  flow); everyone else = url-code-paste (the phone-friendly Claude path). */
   static defaultKind(provider: LoginProvider): LoginFlowKind {
     return provider === 'openai' ? 'device-code' : 'url-code-paste';
+  }
+
+  /**
+   * WS5.2 R6b — flow kind for a REMOTE/cloud (follow-me) enrollment. Prefers the
+   * device-code single-code flow wherever the provider supports it (the Phase-C
+   * default per R6b), because a single code sidesteps the two-code Claude window
+   * entirely on a headless VM. Providers that have a device-code endpoint
+   * (OpenAI/Codex) get `device-code`; a provider with no single-code flow
+   * (Anthropic/Claude → url-code-paste) keeps its two-code flow, and the caller
+   * MUST give it the larger scrape budget so the full two-code interaction fits
+   * inside one poll window (the URL appears late on cloud→provider latency). This
+   * is a SUPERSET of defaultKind — anything device-code-capable locally is also
+   * device-code-capable remotely. */
+  static remoteKind(provider: LoginProvider): LoginFlowKind {
+    return provider === 'openai' ? 'device-code' : EnrollmentWizard.defaultKind(provider);
   }
 
   /**
@@ -143,13 +197,36 @@ export class EnrollmentWizard {
    * surface the operator's phone shows.
    */
   async start(input: StartEnrollmentInput): Promise<PendingLogin> {
-    const kind = input.kind ?? EnrollmentWizard.defaultKind(input.provider);
-    const artifact = await this.driveLogin({
-      provider: input.provider,
-      framework: input.framework,
-      kind,
-      configHome: input.configHome,
-    });
+    // WS5.2 R6b — a remote/cloud (follow-me) enrollment prefers the device-code
+    // single-code flow where the provider supports it; an explicit `kind` always
+    // wins. Local enrollment is unchanged (uses defaultKind).
+    const kind =
+      input.kind ??
+      (input.remote ? EnrollmentWizard.remoteKind(input.provider) : EnrollmentWizard.defaultKind(input.provider));
+    // WS5.2 R6b — the honest-failure surface. The store is written ONLY AFTER the
+    // drive succeeds, so a drive throw leaves NO pending-login behind; we re-raise
+    // it as a typed EnrollmentDriveError the caller renders as "couldn't start the
+    // login on <nickname> — retry?", never an opaque 500 / silently-stuck pending.
+    let artifact: LoginArtifact;
+    try {
+      artifact = await this.driveLogin({
+        provider: input.provider,
+        framework: input.framework,
+        kind,
+        configHome: input.configHome,
+        // Threaded only for remote drives; omitted ⇒ the driver's local-LAN default.
+        ...(input.remote && typeof input.remoteScrapeTimeoutMs === 'number'
+          ? { scrapeTimeoutMs: input.remoteScrapeTimeoutMs }
+          : {}),
+      });
+    } catch (err) {
+      const detail = err instanceof Error ? err.message : String(err);
+      this.logger.warn(`[EnrollmentWizard] start drive failed for ${input.label} (${input.provider}): ${detail}`);
+      throw new EnrollmentDriveError({
+        operatorMessage: 'the provider login didn’t start in time — retry?',
+        cause: err,
+      });
+    }
     const login = this.store.issue({
       id: input.id,
       label: input.label,

--- a/src/core/FrameworkLoginDriver.ts
+++ b/src/core/FrameworkLoginDriver.ts
@@ -103,12 +103,19 @@ export class FrameworkLoginDriver {
    * Drive a framework login: spawn it under the target config home, poll the
    * pane until the public artifact appears (or timeout), and return it. Throws
    * on timeout so the wizard logs + leaves the login for the next sweep.
+   *
+   * `scrapeTimeoutMs` (per-call) overrides the constructor default for THIS
+   * drive only — WS5.2 R6b uses it to give a remote/cloud enrollment a larger
+   * budget (cloud→provider latency + the two-code Claude window) without
+   * rebuilding the shared production driver. Omitted ⇒ the constructor default
+   * (the local-LAN budget) is unchanged. A non-finite/≤0 value is ignored.
    */
   async drive(req: {
     provider: LoginProvider;
     framework: FrameworkLoginRequest['framework'];
     kind: LoginFlowKind;
     configHome?: string;
+    scrapeTimeoutMs?: number;
   }): Promise<LoginArtifact> {
     const { session } = await this.deps.spawn({
       provider: req.provider,
@@ -116,7 +123,11 @@ export class FrameworkLoginDriver {
       kind: req.kind,
       configHome: req.configHome,
     });
-    const deadline = this.now() + this.scrapeTimeoutMs;
+    const budgetMs =
+      typeof req.scrapeTimeoutMs === 'number' && Number.isFinite(req.scrapeTimeoutMs) && req.scrapeTimeoutMs > 0
+        ? req.scrapeTimeoutMs
+        : this.scrapeTimeoutMs;
+    const deadline = this.now() + budgetMs;
     let lastText = '';
     while (this.now() < deadline) {
       lastText = await this.deps.capture(session);
@@ -130,10 +141,10 @@ export class FrameworkLoginDriver {
       await this.sleep(this.pollIntervalMs);
     }
     this.logger.warn(
-      `[FrameworkLoginDriver] timed out scraping ${req.kind} login for ${req.provider}/${req.framework}`,
+      `[FrameworkLoginDriver] timed out scraping ${req.kind} login for ${req.provider}/${req.framework} (budget ${budgetMs}ms)`,
     );
     throw new Error(
-      `login artifact not found for ${req.provider}/${req.framework} within ${this.scrapeTimeoutMs}ms`,
+      `login artifact not found for ${req.provider}/${req.framework} within ${budgetMs}ms`,
     );
   }
 

--- a/src/server/routes.ts
+++ b/src/server/routes.ts
@@ -20818,6 +20818,14 @@ export function createRoutes(ctx: RouteContext): Router {
       const login = await ctx.enrollmentWizard.start({ id, label, provider, framework, kind, configHome });
       res.status(201).json({ enabled: true, login });
     } catch (err) {
+      // WS5.2 R6b — a DRIVE failure is honest + retry-able (502), NOT an opaque 500.
+      // No pending-login was issued (the store is written only after the drive
+      // succeeds), so the caller can simply retry.
+      const { EnrollmentDriveError } = await import('../core/EnrollmentWizard.js');
+      if (err instanceof EnrollmentDriveError) {
+        res.status(502).json({ error: 'login-did-not-start', retryable: true, message: err.operatorMessage });
+        return;
+      }
       res.status(500).json({ error: err instanceof Error ? err.message : 'failed to start enrollment' });
     }
   });
@@ -20884,7 +20892,7 @@ export function createRoutes(ctx: RouteContext): Router {
   // what the operator actually approved. Unresolvable email ⇒ 409 fail-closed (never start blank).
   // Dark behind multiMachine.accountFollowMe (503 when off). Mirrors the scan route's dark-gate exactly.
   router.post('/subscription-pool/follow-me/enroll/start', async (req, res) => {
-    const afmCfg = (ctx.config as unknown as { multiMachine?: { accountFollowMe?: { enabled?: boolean } } }).multiMachine?.accountFollowMe;
+    const afmCfg = (ctx.config as unknown as { multiMachine?: { accountFollowMe?: { enabled?: boolean; remoteScrapeTimeoutMs?: number } } }).multiMachine?.accountFollowMe;
     if (!resolveDevAgentGate(afmCfg?.enabled, ctx.config)) {
       res.status(503).json({ error: 'account follow-me not enabled' });
       return;
@@ -20932,6 +20940,16 @@ export function createRoutes(ctx: RouteContext): Router {
       const safeAccountId = accountId.replace(/[^a-z0-9-]/gi, '-');
       const configHome = path.join(os.homedir(), `.claude-followme-${safeAccountId}`);
 
+      // WS5.2 R6b — this IS the remote/cloud (follow-me) enrollment path, so use the
+      // remote-aware kind selection (device-code single-code flow where supported) and
+      // thread the LARGER scrape-timeout budget (cloud→provider latency + the two-code
+      // window). The budget comes from the config knob (default 180000); omitted ⇒ the
+      // driver's local-LAN default.
+      const remoteScrapeTimeoutMs =
+        typeof afmCfg?.remoteScrapeTimeoutMs === 'number' && Number.isFinite(afmCfg.remoteScrapeTimeoutMs)
+          ? afmCfg.remoteScrapeTimeoutMs
+          : undefined;
+
       const login = await ctx.enrollmentWizard.start({
         id: accountId,
         label: target.label,
@@ -20939,9 +20957,23 @@ export function createRoutes(ctx: RouteContext): Router {
         framework: target.framework as import('../core/PendingLoginStore.js').PendingLogin['framework'],
         configHome,
         expectedEmail: target.expectedEmail,
+        remote: true,
+        remoteScrapeTimeoutMs,
       });
       res.status(201).json({ enabled: true, login });
     } catch (err) {
+      // WS5.2 R6b — a DRIVE failure is honest + retry-able (502), NOT an opaque 500.
+      // The store is written ONLY after the drive succeeds, so a drive throw leaves NO
+      // stuck pending-login behind — the caller can simply retry the enrollment.
+      const { EnrollmentDriveError } = await import('../core/EnrollmentWizard.js');
+      if (err instanceof EnrollmentDriveError) {
+        res.status(502).json({
+          error: 'login-did-not-start',
+          retryable: true,
+          message: `couldn’t start the login on the target — ${err.operatorMessage}`,
+        });
+        return;
+      }
       res.status(500).json({ error: err instanceof Error ? err.message : 'follow-me enroll start failed' });
     }
   });

--- a/tests/integration/account-follow-me-enroll-start-route.test.ts
+++ b/tests/integration/account-follow-me-enroll-start-route.test.ts
@@ -7,6 +7,10 @@
  *   (c) enabled + valid mandate + resolvable email → 201, the login carries the device-code AND a
  *       pending login now exists with expectedEmail set to the OPERATOR-APPROVED email (S7);
  *   (d) enabled + valid mandate but email unresolvable → 409 fail-closed (never start blank).
+ *
+ * Plus the R6b reliability enhancements layered onto the SAME secure route:
+ *   (e) a driveLogin throw → 502 honest/retry-able response AND no stuck pending login;
+ *   (f) the drive call receives the LARGER remote scrape budget + the device-code (remote) kind.
  */
 
 import { describe, it, expect, afterEach, vi } from 'vitest';
@@ -37,6 +41,12 @@ function buildCtx(dir: string, opts: {
   decision: 'allow' | 'deny';
   /** When true, the account a1 is known LOCALLY with its email; when false, no email is resolvable. */
   knowAccountEmail: boolean;
+  /** R6b — when true, driveLogin THROWS (simulates a provider login that didn't start). */
+  driveFails?: boolean;
+  /** R6b — captures the drive request so the test can assert kind + scrapeTimeoutMs threading. */
+  driveCapture?: Array<Record<string, unknown>>;
+  /** R6b — the configured remote scrape-timeout budget (ms) the route should thread. */
+  remoteScrapeTimeoutMs?: number;
 }) {
   const pool = new SubscriptionPool({ stateDir: dir });
   if (opts.knowAccountEmail) {
@@ -46,15 +56,20 @@ function buildCtx(dir: string, opts: {
   const store = new PendingLoginStore({ stateDir: dir });
   const enrollmentWizard = new EnrollmentWizard({
     store,
-    // Fake driveLogin returns a public device-code/URL — never a credential.
-    driveLogin: async () => ({ verificationUrl: 'https://claude.com/oauth', userCode: 'WXYZ-1234', ttlMs: 15 * 60_000 }),
+    // Fake driveLogin returns a public device-code/URL — never a credential. Captures its
+    // request (R6b) so the test can assert the remote budget + kind, and can be made to THROW.
+    driveLogin: async (req) => {
+      opts.driveCapture?.push({ ...req });
+      if (opts.driveFails) throw new Error('provider login did not start in time');
+      return { verificationUrl: 'https://claude.com/oauth', userCode: 'WXYZ-1234', ttlMs: 15 * 60_000 };
+    },
     ensureReady: () => ({ patched: false, reason: 'already interactive-ready' }),
   });
   return {
     config: {
       authToken: 'test', stateDir: dir, port: 0, projectName: 'echo',
       developmentAgent: opts.dev,
-      multiMachine: { accountFollowMe: {} },
+      multiMachine: { accountFollowMe: typeof opts.remoteScrapeTimeoutMs === 'number' ? { remoteScrapeTimeoutMs: opts.remoteScrapeTimeoutMs } : {} },
     },
     startTime: new Date(),
     meshSelfId: 'this-machine',
@@ -145,5 +160,43 @@ describe('/subscription-pool/follow-me/enroll/start (integration)', () => {
     server = await listen(app);
     const r = await post('/subscription-pool/follow-me/enroll/start', { accountId: 'a1' });
     expect(r.status).toBe(400);
+  });
+
+  it('(e) R6b — a driveLogin throw → 502 honest/retry-able response, NO stuck pending login', async () => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'afm-start-'));
+    // Authorized + email resolvable, but the provider login fails to start (the drive throws).
+    const ctx = buildCtx(dir, { dev: true, decision: 'allow', knowAccountEmail: true, driveFails: true });
+    const app = express(); app.use(express.json());
+    app.use(createRoutes(ctx));
+    server = await listen(app);
+    const r = await post('/subscription-pool/follow-me/enroll/start', { mandateId: 'm1', accountId: 'a1' });
+    // Honest, retry-able 502 — never an opaque 500.
+    expect(r.status).toBe(502);
+    expect(r.body.error).toBe('login-did-not-start');
+    expect(r.body.retryable).toBe(true);
+    expect(typeof r.body.message).toBe('string');
+    // The store is written only AFTER the drive succeeds → a drive throw leaves NO stuck pending login.
+    const wizard = (ctx as unknown as { enrollmentWizard: EnrollmentWizard }).enrollmentWizard;
+    expect(wizard.pending()).toHaveLength(0);
+  });
+
+  it('(f) R6b — the drive receives the larger remote scrape budget + the remote (device-code-preferring) kind', async () => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'afm-start-'));
+    const driveCapture: Array<Record<string, unknown>> = [];
+    // The account is openai so the remote kind selection prefers the single-code device-code flow.
+    const ctx = buildCtx(dir, { dev: true, decision: 'allow', knowAccountEmail: false, driveCapture, remoteScrapeTimeoutMs: 180000 });
+    // Inject an openai account locally so the email + provider resolve to the remote-aware kind.
+    const pool = (ctx as unknown as { subscriptionPool: SubscriptionPool }).subscriptionPool;
+    pool.add({ id: 'a1', nickname: 'main', provider: 'openai', framework: 'codex-cli', configHome: '/x/a1', email: 'approved@x.com' });
+    const app = express(); app.use(express.json());
+    app.use(createRoutes(ctx));
+    server = await listen(app);
+    const r = await post('/subscription-pool/follow-me/enroll/start', { mandateId: 'm1', accountId: 'a1' });
+    expect(r.status).toBe(201);
+    // The drive call was threaded the LARGER remote budget (config knob, not the local-LAN default).
+    expect(driveCapture).toHaveLength(1);
+    expect(driveCapture[0].scrapeTimeoutMs).toBe(180000);
+    // An openai (device-code-capable) provider on the remote path uses the device-code single-code flow.
+    expect(driveCapture[0].kind).toBe('device-code');
   });
 });

--- a/tests/unit/enrollment-wizard.test.ts
+++ b/tests/unit/enrollment-wizard.test.ts
@@ -10,7 +10,7 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { PendingLoginStore } from '../../src/core/PendingLoginStore.js';
-import { EnrollmentWizard, type LoginArtifact } from '../../src/core/EnrollmentWizard.js';
+import { EnrollmentWizard, EnrollmentDriveError, type LoginArtifact, type LoginDriver } from '../../src/core/EnrollmentWizard.js';
 import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
 
 const T0 = Date.parse('2026-06-07T00:00:00Z');
@@ -276,6 +276,117 @@ describe('EnrollmentWizard', () => {
       const w = build({ oracle: { resolveSlotTenant: async () => ({ email: 'j@x.com' }) } });
       const r = await w.completeFollowMe('nope', 'the Mini');
       expect(r.outcome).toBe('not-found');
+    });
+  });
+
+  // ── WS5.2 R6b — Phase-C headless-enrollment reliability contract ───────────
+  describe('R6b: honest failure surface + remote timeout/device-code preference', () => {
+    // ── Part 2: honest failure surface (the load-bearing fix) ──
+    it('a driveLogin throw during start() raises a typed EnrollmentDriveError (not opaque)', async () => {
+      const drive: LoginDriver = async () => { throw new Error('login flow timed out'); };
+      const w = new EnrollmentWizard({ store, driveLogin: drive, now: () => clock });
+      await expect(
+        w.start({ id: 'fm-1', label: 'main', provider: 'anthropic', framework: 'claude-code', remote: true }),
+      ).rejects.toBeInstanceOf(EnrollmentDriveError);
+    });
+
+    it('the EnrollmentDriveError carries a code + operator-facing message', async () => {
+      const drive: LoginDriver = async () => { throw new Error('underlying detail'); };
+      const w = new EnrollmentWizard({ store, driveLogin: drive, now: () => clock });
+      const err = await w.start({ id: 'fm-1', label: 'main', provider: 'anthropic', framework: 'claude-code', remote: true })
+        .then(() => null, (e) => e);
+      expect(err).toBeInstanceOf(EnrollmentDriveError);
+      expect(err.code).toBe('enrollment-drive-failed');
+      expect(typeof err.operatorMessage).toBe('string');
+      expect(err.operatorMessage.length).toBeGreaterThan(0);
+      // the underlying cause is preserved for logs/audit (never the raw operator message)
+      expect(err.cause).toBeInstanceOf(Error);
+    });
+
+    it('a drive failure NEVER leaves a dangling/stuck pending-login (store stays empty)', async () => {
+      const drive: LoginDriver = async () => { throw new Error('network stalled'); };
+      const w = new EnrollmentWizard({ store, driveLogin: drive, now: () => clock });
+      await expect(
+        w.start({ id: 'fm-1', label: 'main', provider: 'anthropic', framework: 'claude-code', remote: true }),
+      ).rejects.toBeInstanceOf(EnrollmentDriveError);
+      // The invariant: store is written ONLY after a successful drive → nothing dangling.
+      expect(store.size()).toBe(0);
+      expect(store.get('fm-1')).toBeNull();
+      expect(w.pending()).toEqual([]);
+    });
+
+    it('the honest-failure surface applies to LOCAL (non-remote) starts too', async () => {
+      const drive: LoginDriver = async () => { throw new Error('boom'); };
+      const w = new EnrollmentWizard({ store, driveLogin: drive, now: () => clock });
+      await expect(
+        w.start({ id: 'codex-1', label: 'codex', provider: 'openai', framework: 'codex-cli' }),
+      ).rejects.toBeInstanceOf(EnrollmentDriveError);
+      expect(store.size()).toBe(0);
+    });
+
+    // ── Part 3: device-code preference for remote ──
+    it('remoteKind prefers device-code for OpenAI; keeps url-code-paste for Claude', () => {
+      expect(EnrollmentWizard.remoteKind('openai')).toBe('device-code');
+      expect(EnrollmentWizard.remoteKind('anthropic')).toBe('url-code-paste');
+    });
+
+    it('a remote OpenAI start uses device-code (single-code Phase-C default)', async () => {
+      let seenKind: string | undefined;
+      const drive: LoginDriver = async (req) => {
+        seenKind = req.kind;
+        return { verificationUrl: 'https://auth.openai.com/codex/device', userCode: '7DAU-W4XJA', ttlMs: 15 * 60_000 };
+      };
+      const w = new EnrollmentWizard({ store, driveLogin: drive, now: () => clock });
+      const l = await w.start({ id: 'codex-r', label: 'codex', provider: 'openai', framework: 'codex-cli', remote: true });
+      expect(seenKind).toBe('device-code');
+      expect(l.kind).toBe('device-code');
+    });
+
+    it('a remote Claude start stays url-code-paste (no single-code flow) + keeps the two-code notice', async () => {
+      let seenKind: string | undefined;
+      const drive: LoginDriver = async (req) => {
+        seenKind = req.kind;
+        return { verificationUrl: 'https://claude.ai/oauth/authorize?code=true', ttlMs: 15 * 60_000 };
+      };
+      const w = new EnrollmentWizard({ store, driveLogin: drive, now: () => clock });
+      const l = await w.start({ id: 'claude-r', label: 'main', provider: 'anthropic', framework: 'claude-code', remote: true });
+      expect(seenKind).toBe('url-code-paste');
+      expect(l.notice).toMatch(/two codes/i);
+    });
+
+    it('an explicit kind always wins over the remote preference', async () => {
+      let seenKind: string | undefined;
+      const drive: LoginDriver = async (req) => {
+        seenKind = req.kind;
+        return { verificationUrl: 'https://auth.openai.com/codex/device', userCode: '7DAU-W4XJA', ttlMs: 15 * 60_000 };
+      };
+      const w = new EnrollmentWizard({ store, driveLogin: drive, now: () => clock });
+      await w.start({ id: 'x', label: 'x', provider: 'openai', framework: 'codex-cli', remote: true, kind: 'url-code-paste' });
+      expect(seenKind).toBe('url-code-paste');
+    });
+
+    // ── Part 1: timeout-config resolution (remote = larger budget; local unchanged) ──
+    it('a remote start threads the larger scrapeTimeoutMs to the driver', async () => {
+      let seenTimeout: number | undefined;
+      const drive: LoginDriver = async (req) => {
+        seenTimeout = req.scrapeTimeoutMs;
+        return { verificationUrl: 'https://auth.openai.com/codex/device', userCode: 'AAAA-BBBB', ttlMs: 15 * 60_000 };
+      };
+      const w = new EnrollmentWizard({ store, driveLogin: drive, now: () => clock });
+      await w.start({ id: 'r1', label: 'r', provider: 'openai', framework: 'codex-cli', remote: true, remoteScrapeTimeoutMs: 180_000 });
+      expect(seenTimeout).toBe(180_000);
+    });
+
+    it('a LOCAL start does NOT thread a scrapeTimeoutMs (driver default unchanged)', async () => {
+      let seenTimeout: number | undefined = -1;
+      const drive: LoginDriver = async (req) => {
+        seenTimeout = req.scrapeTimeoutMs;
+        return { verificationUrl: 'https://auth.openai.com/codex/device', userCode: 'AAAA-BBBB', ttlMs: 15 * 60_000 };
+      };
+      const w = new EnrollmentWizard({ store, driveLogin: drive, now: () => clock });
+      // remoteScrapeTimeoutMs is supplied but remote is false → it must be ignored.
+      await w.start({ id: 'l1', label: 'l', provider: 'openai', framework: 'codex-cli', remoteScrapeTimeoutMs: 180_000 });
+      expect(seenTimeout).toBeUndefined();
     });
   });
 });

--- a/tests/unit/framework-login-driver.test.ts
+++ b/tests/unit/framework-login-driver.test.ts
@@ -111,4 +111,48 @@ describe('FrameworkLoginDriver.drive', () => {
     const a = await fn({ provider: 'anthropic', framework: 'claude-code', kind: 'url-code-paste' });
     expect(a.verificationUrl).toContain('claude.ai/oauth');
   });
+
+  // ── WS5.2 R6b — per-call scrape-timeout override (larger budget for remote drives) ──
+  it('a per-call scrapeTimeoutMs OVERRIDES the constructor default (larger remote budget)', async () => {
+    // Constructor default 60s would give up at clock=60_000 (one poll/sec). The URL
+    // appears late (at the 100th capture ≈ 100s) — only a larger per-call budget reaches it.
+    let i = 0;
+    let clock = 0;
+    const captures = (n: number) => (n >= 100 ? CLAUDE_PANE : 'still booting...');
+    const driver = new FrameworkLoginDriver({
+      spawn: async () => ({ session: 's' }),
+      capture: async () => captures(i++),
+      sleep: async (ms: number) => { clock += ms; },
+      now: () => clock,
+      pollIntervalMs: 1_000,
+      scrapeTimeoutMs: 60_000, // local default — would time out before 100s
+    });
+    const a = await driver.drive({ provider: 'anthropic', framework: 'claude-code', kind: 'url-code-paste', scrapeTimeoutMs: 180_000 });
+    expect(a.verificationUrl).toContain('claude.ai/oauth');
+  });
+
+  it('without a per-call override, the constructor default still applies (local unchanged)', async () => {
+    let i = 0;
+    let clock = 0;
+    const captures = (n: number) => (n >= 100 ? CLAUDE_PANE : 'still booting...');
+    const driver = new FrameworkLoginDriver({
+      spawn: async () => ({ session: 's' }),
+      capture: async () => captures(i++),
+      sleep: async (ms: number) => { clock += ms; },
+      now: () => clock,
+      pollIntervalMs: 1_000,
+      scrapeTimeoutMs: 60_000,
+    });
+    // URL only appears at ~100s but the local 60s default times out first.
+    await expect(
+      driver.drive({ provider: 'anthropic', framework: 'claude-code', kind: 'url-code-paste' }),
+    ).rejects.toThrow(/not found/);
+  });
+
+  it('an invalid per-call scrapeTimeoutMs (0 / non-finite) falls back to the constructor default', async () => {
+    const { deps } = fakeDeps([CODEX_PANE]);
+    const driver = new FrameworkLoginDriver(deps);
+    const a = await driver.drive({ provider: 'openai', framework: 'codex-cli', kind: 'device-code', scrapeTimeoutMs: 0 });
+    expect(a.userCode).toBe('7DAU-W4XJA');
+  });
 });

--- a/tests/unit/lint-dev-agent-dark-gate.test.ts
+++ b/tests/unit/lint-dev-agent-dark-gate.test.ts
@@ -400,9 +400,11 @@ describe('lint-dev-agent-dark-gate', () => {
       // DEV_GATED_FEATURES) so it introduces no new attributed path. After merging JKHeadley/main
       // (which added its own config above), the sessionPool keys resolve to 872/897/926.
       // RE-VERIFIED by hand via the attributor on the MERGED ConfigDefaults.
-      '894': 'multiMachine.sessionPool.enabled',
-      '919': 'multiMachine.sessionPool.inboundQueue.enabled',
-      '948': 'multiMachine.sessionPool.holdForStability.enabled',
+      // R6b: the accountFollowMe block gained `remoteScrapeTimeoutMs` (+ comment, ~7 lines)
+      // ABOVE these keys, shifting each DOWN by +7. RE-VERIFIED via the attributor.
+      '901': 'multiMachine.sessionPool.enabled',
+      '926': 'multiMachine.sessionPool.inboundQueue.enabled',
+      '955': 'multiMachine.sessionPool.holdForStability.enabled',
       // mm-stores-devgate (operator directive 2026-06-13, topic 13481): the 7
       // multiMachine.stateSync.* memory stores MOVED from DARK_GATE_EXCLUSIONS to
       // DEV_GATED_FEATURES and their `enabled: false` literals were REMOVED from
@@ -436,10 +438,10 @@ describe('lint-dev-agent-dark-gate', () => {
       // attributor on the edited ConfigDefaults.
       // After merging JKHeadley/main + my accountFollowMe block, these resolve as below.
       // RE-VERIFIED by hand via the attributor on the MERGED ConfigDefaults.
-      '1117': 'multiMachine.stateSync.threadlinePairing.enabled',
-      '1239': 'cartographer.freshnessSweep.enabled',
-      '1284': 'cartographer.conformanceAudit.llmEnrichment.enabled',
-      '1309': 'cartographer.subtreeNav.llmRerank.enabled',
+      '1124': 'multiMachine.stateSync.threadlinePairing.enabled',
+      '1246': 'cartographer.freshnessSweep.enabled',
+      '1291': 'cartographer.conformanceAudit.llmEnrichment.enabled',
+      '1316': 'cartographer.subtreeNav.llmRerank.enabled',
     };
     const actual = attributeRealConfigDefaults();
     expect(actual).toEqual(EXPECTED);

--- a/tests/unit/ws52-account-follow-me-wiring.test.ts
+++ b/tests/unit/ws52-account-follow-me-wiring.test.ts
@@ -71,6 +71,8 @@ describe('WS5.2 ConfigDefaults + dev-gate', () => {
     expect(defaultsSrc).toMatch(/accountFollowMe:\s*\{/);
     expect(defaultsSrc).toContain('credentialTransport: {}');
     expect(defaultsSrc).toContain('maxFollowMachines: 5');
+    // WS5.2 R6b — the remote/cloud scrape-timeout budget knob (3min default).
+    expect(defaultsSrc).toContain('remoteScrapeTimeoutMs: 180000');
     // The enabled literal must NOT be hardcoded under accountFollowMe (dev-gate decides).
     expect(defaultsSrc).not.toMatch(/accountFollowMe:\s*\{[^}]*enabled:\s*false/s);
   });

--- a/upgrades/next/ws52-account-follow-me-r6b-reliability.md
+++ b/upgrades/next/ws52-account-follow-me-r6b-reliability.md
@@ -1,0 +1,17 @@
+## What Changed
+
+WS5.2 R6b — the Phase-C headless-enrollment reliability contract, layered onto the existing secure enroll-start route without weakening its mandate-gate/authoritative-email guarantees. Three parts: (1) a configurable, larger scrape-timeout budget for remote/cloud enrollments — new config knob `multiMachine.accountFollowMe.remoteScrapeTimeoutMs` (default 180000ms / 3min), threaded into the follow-me enroll path ONLY (normal local enrollment keeps the 60s default); `FrameworkLoginDriver.drive()` gained an optional per-call timeout override (invalid values fall back safely). (2) The honest failure surface: `EnrollmentWizard.start()` now catches a login-drive failure and re-raises a typed `EnrollmentDriveError` — and because the drive runs BEFORE the pending-login is persisted, a failure never leaves a silently-stuck pending-login; both enroll routes map it to an honest, retryable 502 instead of an opaque 500. (3) The two-code Claude case: the remote path prefers the device-code single-code flow where the provider supports it (OpenAI/Codex), and for Claude (no device-code endpoint) the larger budget covers a late-arriving verification URL.
+
+## Evidence
+
+- 60 tests across 4 files: `enrollment-wizard` (honest-failure + no-dangling-pending for local & remote, remoteKind, device-code preference, explicit-kind-wins, timeout threading), `framework-login-driver` (per-call override reaches a late artifact; default still times out; invalid override falls back), `ws52-account-follow-me-wiring` (the new defaults knob), and the enroll-start integration test (kept all of #1214's security cases: dark→503, denied→403, valid→201 w/ S7 email, unresolvable→409, 400; added: drive-throw→502 honest + no stuck pending, and the drive receives the larger remote timeout + device-code). `tsc --noEmit` clean.
+- Side-effects review + mandatory independent second-pass security review (concurred): CRITICALLY verified the reconciliation kept #1214's mandate gate + authoritative-email resolution intact (this change was reconciled after a parallel-timing collision); confirmed no stuck pending-login, local enrollment unchanged, both callers handle the typed error, and no fail-open.
+- Spec: `docs/specs/ws52-account-follow-me-security.md` R6/R6b (converged, approved).
+
+## What to Tell Your User
+
+Still nothing to do — this hardens the multi-machine enrollment (off by default). When a machine enrolls one of your accounts, it now gets a realistic login window (cloud/remote logins are slower than local), prefers the simplest one-code login where possible, and if the login can't start it tells you honestly with a retry instead of leaving a stuck half-started enrollment.
+
+## Summary of New Capabilities
+
+Enrollment reliability (dark): a configurable larger remote scrape-timeout, an honest typed drive-failure surface (no silently-stuck pending logins; retryable 502), and a device-code preference for remote enrollments. No user-facing surface is live in this release.

--- a/upgrades/side-effects/ws52-account-follow-me-r6b-reliability.md
+++ b/upgrades/side-effects/ws52-account-follow-me-r6b-reliability.md
@@ -1,0 +1,66 @@
+# Side-Effects Review — WS5.2 R6b: Phase-C headless-enrollment reliability
+
+**Version / slug:** `ws52-account-follow-me-r6b-reliability`
+**Date:** `2026-06-17`
+**Author:** `Echo (instar-dev agent)`
+**Second-pass reviewer:** `pending (high-risk: enrollment/credential path — EnrollmentWizard.start failure handling + the follow-me enroll-start route)`
+
+## Summary of the change
+
+WS5.2 R6b — the Phase-C headless-enrollment reliability contract, layered onto the existing (#1214) secure enroll-start route WITHOUT weakening its mandate-gate/authoritative-email guarantees. Three parts: (1) `FrameworkLoginDriver.drive()` accepts an optional per-call `scrapeTimeoutMs` override (non-finite/≤0 ignored → falls back to the constructor default); a new config knob `multiMachine.accountFollowMe.remoteScrapeTimeoutMs` (default 180000ms / 3min) is threaded into the FOLLOW-ME enroll path only — normal local enrollment keeps the 60s default. (2) The HONEST FAILURE SURFACE: `EnrollmentWizard.start()` now wraps `driveLogin` in try/catch and re-raises a drive failure as a typed `EnrollmentDriveError` (with `code`/`operatorMessage`/`cause`); because `start()` calls `driveLogin` BEFORE `store.issue()`, a drive failure never leaves a stuck pending-login. Both `start()` callers map `EnrollmentDriveError` → an honest, retryable 502 (the generic `/subscription-pool/enroll` route and the follow-me enroll-start route) instead of a bare 500. (3) The two-code Claude case: the follow-me/remote path prefers the device-code single-code flow where the provider supports it (`remoteKind()` → device-code for OpenAI/Codex; Anthropic has no device-code endpoint so it stays `url-code-paste`), and for the no-single-code provider the larger remote timeout covers a late-arriving verification URL (instar only scrapes the URL; the second code is operator→CLI, never scraped). Files: `FrameworkLoginDriver.ts`, `EnrollmentWizard.ts`, `ConfigDefaults.ts`, `routes.ts` (502 mapping + enhancements on #1214's route — the duplicate insecure route an earlier stale-base build added was removed; #1214's secure route is authoritative), + 4 test files.
+
+## Decision-point inventory
+
+- `EnrollmentWizard.start()` drive-failure handling — **modify** — a drive failure becomes a typed error a caller can render honestly, never a silent stuck pending-login.
+- Follow-me enroll-start route 502 mapping + remote timeout/device-code — **modify** (on #1214's route) — enrollment reliability; the mandate gate + authoritative email (the authorization decisions) are UNCHANGED.
+- `remoteScrapeTimeoutMs` config knob — **add** — larger cloud scrape budget, follow-me path only.
+
+---
+
+## 1. Over-block
+
+None. The larger timeout only ever makes the remote path WAIT LONGER before failing — it never rejects a legitimate enrollment that the old 60s would have accepted. The honest-failure path turns a previously-opaque drive throw into a clear 502 retry signal; it does not reject anything that previously succeeded. Local enrollment is byte-for-byte unchanged (the knob is read only on the follow-me path).
+
+## 2. Under-block
+
+The reliability layer does not add authorization — that remains #1214's mandate gate (unchanged). A drive that SUCCEEDS but mints the wrong account is still caught downstream by S7 at `/complete` (email validation) — R6b does not touch that. The honest-failure surface reports a START failure; it does not itself verify the eventual login outcome (by design — the completion gate owns that).
+
+## 3. Level-of-abstraction fit
+
+Correct layers: the timeout knob lives on the driver (which owns the scrape), the failure-typing lives on `EnrollmentWizard.start` (which owns the drive call), and the HTTP mapping lives on the routes (which own the operator-facing surface). The kind-preference (device-code) extends the existing `defaultKind` logic rather than re-implementing flow selection. No logic was duplicated; the earlier stale-base duplicate route was removed in favor of #1214's secure one.
+
+## 4. Signal vs authority compliance
+
+R6b adds NO new authority — it is purely reliability + honest reporting. The only authority on this path (the mandate gate) is #1214's and is untouched. `EnrollmentDriveError` is a signal (a typed failure the caller renders); it never blocks an authorized action — it reports that a drive could not START, with a retry hint. Deterministic (a timeout or a thrown driver error), not heuristic.
+
+## 5. Interactions
+
+The change composes with #1214's enroll-start route (enhances it) and the S7 `/complete` gate (unchanged downstream). The `start()`-before-`issue()` ordering is the load-bearing invariant for "no stuck pending-login on drive failure" — preserved. Both `start()` callers were updated to map the typed error (no caller left throwing an opaque 500). The background `reissueExpired` sweep already swallowed driver errors by design and was deliberately NOT changed (it is not the start path). No double-fire, no shadowing.
+
+## 6. External surfaces
+
+One new config knob (`remoteScrapeTimeoutMs`, additive, defaulted). The enroll-start + generic enroll routes now return 502 (retryable) on a drive failure instead of 500 — a more honest status for the same failure class; both remain dark behind `multiMachine.accountFollowMe` (the follow-me route) / unchanged-gating (the generic route). No new route. No cross-machine surface.
+
+## 7. Multi-machine posture (Cross-Machine Coherence)
+
+The reliability layer is per-machine by nature: the larger timeout + device-code preference apply to the enrollment running ON the target machine (the one minting its own login). The config knob is read locally. Nothing replicates. This directly serves the multi-machine case (a remote/slower target gets a realistic login budget + an honest failure message instead of a silent 60s timeout), which is exactly the Phase-C scenario R6b targets.
+
+## 8. Rollback cost
+
+Low. Dark behind `multiMachine.accountFollowMe` for the follow-me path; the generic-route 502 mapping is a status-code refinement (revert is trivial). The config knob is additive (absence → the driver's existing 60s default). No migration, no persisted state. Single-commit back-out.
+
+---
+
+## Second-pass review
+
+**Concur with the review.** Independent audit (the reconciliation was verified to NOT weaken #1214):
+
+1. **(CRITICAL) Mandate authorization intact** — exactly one `/subscription-pool/follow-me/enroll/start` route; the mandate gate (`ctx.coordination.gate.evaluate({action:'account-follow-me',...})` → 403 on `decision !== 'allow'`) and `resolveFollowMeEnrollTarget` (409 fail-closed, body email never used) are fully preserved. R6b only inserted `remote:true` + `remoteScrapeTimeoutMs` INSIDE the already-gated block.
+2. **No stuck pending-login** — `driveLogin` runs before `store.issue()`; a throw is caught + re-raised as `EnrollmentDriveError` before any persistence; tests assert `pending()` empty after a drive throw.
+3. **Local enrollment unchanged** — the larger budget + `remoteKind` apply only when `remote:true`; the generic route keeps the 60s default.
+4. **Both start() callers handle EnrollmentDriveError** → 502 retryable; none unhandled.
+5. **Config knob** — `remoteScrapeTimeoutMs` default 180000, read on the follow-me path with a `Number.isFinite` guard.
+6. **Device-code preference** — `remoteKind` returns device-code only for openai; Claude stays `url-code-paste` (no unsupported flow forced).
+7. **No fail-open** — invalid timeout falls back to the safe default (tested); deny-by-default gate unchanged.
+
+`tsc --noEmit` EXIT=0; 60/60 tests pass.


### PR DESCRIPTION
## ELI16

This makes the "let a machine enroll its own login for your account" step reliable when the machine is remote or slow — and honest when it fails. It builds on the secure enroll-start route (which already checks your approval and the right account); this PR only adds reliability, and a second-pass security review confirmed it did NOT weaken any of that security.

Three things. First: remote logins are slower than local ones (a cloud machine talking to the login provider has more latency than your laptop). The old code gave every login 60 seconds to produce its code; that's fine locally but too short remotely. So this adds a bigger time budget (3 minutes) used ONLY for the cross-machine enrollment path — your normal local logins are completely unchanged.

Second, and most important: if the login can't even START (the provider didn't hand back a code in time), the old code threw a confusing error and could leave a half-started enrollment stuck with nothing to show you. Now it fails honestly — you get a clear "couldn't start the login on that machine — retry?" message (a retryable 502), and crucially nothing half-started is left lying around (the code checks the login started BEFORE recording anything, so a failure records nothing).

Third: where the provider offers a simple one-code login (like OpenAI's device code), the remote path now prefers it; for Claude (which uses a two-step code flow) the bigger time budget covers the slower case.

It's off by default behind the `multiMachine.accountFollowMe` flag.

## What this PR does
- New config knob `multiMachine.accountFollowMe.remoteScrapeTimeoutMs` (default 180000ms), threaded into the follow-me enroll path only; `FrameworkLoginDriver.drive()` gets an optional per-call timeout (invalid → safe fallback).
- `EnrollmentWizard.start()` catches a drive failure → typed `EnrollmentDriveError` raised BEFORE persisting (no stuck pending-login); both enroll routes map it → honest retryable 502.
- Remote path prefers device-code where supported (openai); Claude stays url-code-paste covered by the larger budget.
- 60 tests (unit + Tier-2 integration); `tsc` clean; side-effects + independent second-pass review (concurred — critically verified #1214's mandate gate + authoritative-email resolution remained intact through the reconciliation, no stuck pending-login, no fail-open).

Spec: `docs/specs/ws52-account-follow-me-security.md` R6/R6b (converged, approved).