### PR TITLE
feat(ws52): Account Follow-Me R7a — lease-sliced per-account spend ceiling

### DIFF
--- a/.instar/instar-dev-decisions/2026-06-17T15-37-08-657Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-06-17T15-37-08-657Z-unknown.json
@@ -1,0 +1,15 @@
+{
+  "ts": "2026-06-17T15:37:08.657Z",
+  "slug": "unknown",
+  "suggestedTier": 2,
+  "declaredTier": 2,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "new capability: new exported class / subsystem added"
+  ],
+  "belowFloor": false,
+  "files": 4,
+  "loc": 413,
+  "causalAutopsy": null,
+  "verdict": "pass"
+}

--- a/src/config/ConfigDefaults.ts
+++ b/src/config/ConfigDefaults.ts
@@ -780,6 +780,29 @@ const SHARED_DEFAULTS: Record<string, unknown> = {
       // enrollment (/subscription-pool/enroll) is unchanged — it never reads this
       // and keeps the driver's 60s default.
       remoteScrapeTimeoutMs: 180000,
+      // WS5.2 R7a — per-account SPEND-SLICE control plane. The ceiling is denominated
+      // in provider quota-FRACTION (0..1); a borrowed account is sliced so the sum of
+      // OUTSTANDING slices across N machines can never exceed the ceiling (the
+      // sum-of-leases bound, owned by the FENCED lease holder). The renewal knobs below
+      // bound the requester-side control plane so N VMs on one hot account produce
+      // O(per-account-cap) renewal RPCs, never an O(N) herd:
+      //  - ceilingQuotaFraction: the account-wide spend ceiling (fraction of a provider
+      //    quota window) that the holder slices among machines (default 0.8 — leave the
+      //    holder's own headroom).
+      //  - minRenewIntervalMs: per-account renewal rate cap (the floor between RPCs).
+      //  - renewBackoffMultiplier / maxRenewIntervalMs: exponential backoff on refusal/
+      //    failure, ceilinged so the interval cannot grow unbounded.
+      //  - breakerThreshold / breakerCooldownMs: the P19 sustained-failure breaker — after
+      //    N consecutive transport FAILURES (slow/partitioned/unreachable holder) a VM
+      //    FAILS CLOSED TO ITS OWN ACCOUNT for the cooldown rather than retry-storming.
+      spendSlice: {
+        ceilingQuotaFraction: 0.8,
+        minRenewIntervalMs: 5000,
+        renewBackoffMultiplier: 2,
+        maxRenewIntervalMs: 300000,
+        breakerThreshold: 3,
+        breakerCooldownMs: 60000,
+      },
     },
     // WS3 one-voice gate (MULTI-MACHINE-SEAMLESSNESS-SPEC). Ships DARK: with
     // ws3OneVoice false the SpeakerElection returns "speak" unconditionally —

--- a/src/core/AccountFollowMeSpendSlice.ts
+++ b/src/core/AccountFollowMeSpendSlice.ts
@@ -1,0 +1,303 @@
+/**
+ * WS5.2 R7a — per-account spend-slice ORCHESTRATION (the LEASE-SLICED ceiling, owned by the
+ * fenced single-writer). This is the cohesive control-plane unit on top of the durable
+ * `AccountFollowMeGrantLedger` (AccountFollowMeGrants.ts), kept PURE + injectable so the
+ * distributed math is unit-testable without a live mesh.
+ *
+ * Spec bounds enforced here (docs/specs/ws52-account-follow-me-security.md §R7a, §S5, §I5):
+ *
+ *  (a) FENCED single-writer issuance. Slices are issued ONLY by the current `FencedLease` holder;
+ *      a non-holder issuing is refused (`not-lease-holder`). Issuance is epoch-fenced: a renew
+ *      stamped with a stale lease epoch is void (`stale-lease-epoch`). On a holder FAILOVER the new
+ *      holder constructs `SliceIssuer` over the SAME durable ledger and re-derives outstanding
+ *      slices BEFORE issuing — the ledger's sum-of-leases bound holds across the handoff with no
+ *      double-allocation (proven in AccountFollowMeGrants).
+ *
+ *  (b) `maxSpend` is denominated in provider quota-FRACTION (0..1), reusing AccountQuotaSnapshot.
+ *      The issuer takes the ceiling as a fraction; per-slice consumption is the durable grant amount.
+ *
+ *  (c) The requester-side renewal CONTROL PLANE is rate-capped + coalesced + P19-breaker-protected,
+ *      so N VMs on one hot account produce O(per-account-cap) renewal RPCs — never an O(N) herd:
+ *        - per-(account,machine) in-flight COALESCING: a VM with an outstanding renewal does not
+ *          start a second (`coalesced-in-flight`);
+ *        - per-account renewal RATE CAP with EXPONENTIAL backoff after each refusal/failure;
+ *        - a P19 sustained-FAILURE breaker: after `breakerThreshold` consecutive failures the VM
+ *          FAILS CLOSED TO ITS OWN ACCOUNT (`breaker-open`) instead of retry-storming a slow/
+ *          partitioned/unreachable holder. The breaker re-closes after `breakerCooldownMs`.
+ *
+ *  (d) FIRST-SLICE-under-partition: a VM that never received a slice is treated identically to a
+ *      VM whose slice is exhausted — it FAILS CLOSED TO ITS OWN ACCOUNT until it obtains its first
+ *      slice (the `decideAccountUse` consultation below).
+ *
+ * INVARIANT (load-bearing): fail-closed-to-OWN-account on EVERY uncertainty — no slice, exhausted,
+ * partition, breaker open, no mandate, ledger error. A borrowed account is NEVER overspent past its
+ * grant. Everything stays dark behind `multiMachine.accountFollowMe` at the wiring layer.
+ */
+
+import {
+  AccountFollowMeGrantLedger,
+  type GrantStore,
+  type IssueResult,
+} from './AccountFollowMeGrants.js';
+
+// ───────────────────────────── Issuer side (the fenced holder) ─────────────────────────────
+
+export interface SliceIssuerConfig {
+  /** This machine's id — must equal the lease holder for issuance to be authorized. */
+  selfMachineId: string;
+  /**
+   * The current effective lease epoch + whether THIS machine holds the lease at it. Read live so a
+   * mid-flight failover (we lost the lease) refuses issuance rather than double-allocating.
+   */
+  holdsLease: () => boolean;
+  currentLeaseEpoch: () => number;
+  now?: () => number;
+}
+
+/** The renewal request a requesting VM sends to the holder (the `slice-renew` verb payload, decoded). */
+export interface SliceRenewRequest {
+  grantId: string;
+  mandateId: string;
+  accountId: string;
+  /** Requesting machine's routing fingerprint (carried in the verb; bound into the grant). */
+  requestingMachineFp: string;
+  /** Slice size requested (provider quota-fraction). */
+  amount: number;
+  /** Absolute expiry of the slice (ms since epoch). */
+  expiresAt: number;
+}
+
+export interface SliceIssuanceContext {
+  /** The account's spend ceiling (provider quota-fraction, 0..1) — from the live grant/quota policy. */
+  ceiling: number;
+}
+
+export type SliceIssueOutcome =
+  | { ok: true; grantId: string; amount: number; leaseEpoch: number; expiresAt: number }
+  | { ok: false; reason: string };
+
+/**
+ * The HOLDER-side issuer. Runs ON the fenced lease holder (the `slice-renew` handler wires this).
+ * Refuses unless this machine genuinely holds the lease right now, then delegates the sum-of-leases
+ * accounting to the durable ledger (single source of truth, re-derived on every call → failover-safe).
+ */
+export class SliceIssuer {
+  private readonly ledger: AccountFollowMeGrantLedger;
+  private readonly now: () => number;
+
+  constructor(
+    store: GrantStore,
+    private readonly cfg: SliceIssuerConfig,
+  ) {
+    this.now = cfg.now ?? Date.now;
+    this.ledger = new AccountFollowMeGrantLedger(store, this.now);
+  }
+
+  /** Outstanding committed slices for an account (re-derived from the durable ledger). */
+  outstandingFor(accountId: string): number {
+    return this.ledger.outstandingFor(accountId);
+  }
+
+  /**
+   * Issue (or re-issue) a slice in response to a renew request. FENCED: refuses unless this machine
+   * holds the lease at the current epoch. The slice is stamped with the CURRENT lease epoch, so it is
+   * void at a later epoch (consume/renew checks via the ledger). The ledger enforces the sum-of-leases
+   * ceiling and single-use grant ids.
+   */
+  issueForRenew(req: SliceRenewRequest, ctx: SliceIssuanceContext): SliceIssueOutcome {
+    // (a) FENCED single-writer: only the live lease holder may issue. A non-holder (e.g. a stale
+    //     ex-holder mid-failover) refuses — the safe direction (no double-allocation).
+    if (!this.cfg.holdsLease()) {
+      return { ok: false, reason: 'not-lease-holder' };
+    }
+    const leaseEpoch = this.cfg.currentLeaseEpoch();
+    const result: IssueResult = this.ledger.issue({
+      grantId: req.grantId,
+      mandateId: req.mandateId,
+      accountId: req.accountId,
+      targetFingerprint: req.requestingMachineFp,
+      amount: req.amount,
+      ceiling: ctx.ceiling,
+      leaseEpoch,
+      expiresAt: req.expiresAt,
+    });
+    if (!result.ok) return { ok: false, reason: result.reason };
+    return {
+      ok: true,
+      grantId: result.grant.grantId,
+      amount: result.grant.amount,
+      leaseEpoch: result.grant.leaseEpoch,
+      expiresAt: result.grant.expiresAt,
+    };
+  }
+}
+
+// ───────────────────────── Requester side (renewal control plane) ─────────────────────────
+
+export interface SliceLeaseState {
+  /** The grant id of the slice this VM currently holds for the account, if any. */
+  grantId?: string;
+  /** Remaining unspent budget on the held slice (provider quota-fraction). */
+  remaining: number;
+  /** Lease epoch the held slice was issued under — void if the holder advanced past it. */
+  leaseEpoch: number;
+  /** Absolute expiry of the held slice (ms since epoch). */
+  expiresAt: number;
+}
+
+export interface RenewControlConfig {
+  /**
+   * Minimum interval between renewal RPCs for ONE account on this machine (ms). The per-account
+   * rate cap — combined with coalescing + the holder's own ceiling, the worst-case fleet renewal
+   * rate is O(per-account-cap), independent of N. Default 5000.
+   */
+  minRenewIntervalMs?: number;
+  /** Exponential-backoff multiplier applied to the interval after each refusal/failure. Default 2. */
+  backoffMultiplier?: number;
+  /** Backoff ceiling (ms) so the interval cannot grow unbounded. Default 300000 (5m). */
+  maxRenewIntervalMs?: number;
+  /** Consecutive failures before the P19 breaker opens (fail closed to own account). Default 3. */
+  breakerThreshold?: number;
+  /** How long the breaker stays open before a probe is allowed again (ms). Default 60000. */
+  breakerCooldownMs?: number;
+  now?: () => number;
+}
+
+export type RenewAttemptDecision =
+  | { proceed: true }
+  | { proceed: false; reason: 'coalesced-in-flight' | 'rate-capped' | 'breaker-open' };
+
+export type RenewOutcomeKind = 'issued' | 'refused' | 'failed';
+
+/**
+ * The per-machine requester-side renewal control plane for ONE account. Pure state-machine: a caller
+ * asks `shouldAttempt()` before sending a `slice-renew` RPC, marks `beginAttempt()` when it sends,
+ * and reports `recordOutcome()` with the result. It enforces coalescing, the rate cap with
+ * exponential backoff, and the P19 breaker — so the transport above it can be a thin RPC.
+ */
+export class SliceRenewalControl {
+  private readonly minInterval: number;
+  private readonly backoffMul: number;
+  private readonly maxInterval: number;
+  private readonly breakerThreshold: number;
+  private readonly breakerCooldownMs: number;
+  private readonly now: () => number;
+
+  private inFlight = false;
+  private lastAttemptAt = -Infinity;
+  /** Current backoff interval (grows on refusal/failure, resets on success). */
+  private currentInterval: number;
+  private consecutiveFailures = 0;
+  private breakerOpenedAt: number | null = null;
+
+  constructor(cfg: RenewControlConfig = {}) {
+    this.minInterval = cfg.minRenewIntervalMs ?? 5000;
+    this.backoffMul = cfg.backoffMultiplier ?? 2;
+    this.maxInterval = cfg.maxRenewIntervalMs ?? 300000;
+    this.breakerThreshold = cfg.breakerThreshold ?? 3;
+    this.breakerCooldownMs = cfg.breakerCooldownMs ?? 60000;
+    this.now = cfg.now ?? Date.now;
+    this.currentInterval = this.minInterval;
+  }
+
+  /** Is the P19 breaker currently open (a probe not yet allowed)? */
+  breakerOpen(): boolean {
+    if (this.breakerOpenedAt === null) return false;
+    return this.now() - this.breakerOpenedAt < this.breakerCooldownMs;
+  }
+
+  /**
+   * May this VM send a renewal RPC for the account right now? Refuses (fail-closed at the call site)
+   * when a renewal is already in flight (coalescing), the rate cap has not elapsed, or the breaker is
+   * open. The caller treats any `proceed:false` as "use my OWN account this turn."
+   */
+  shouldAttempt(): RenewAttemptDecision {
+    if (this.inFlight) return { proceed: false, reason: 'coalesced-in-flight' };
+    if (this.breakerOpen()) return { proceed: false, reason: 'breaker-open' };
+    if (this.now() - this.lastAttemptAt < this.currentInterval) {
+      return { proceed: false, reason: 'rate-capped' };
+    }
+    return { proceed: true };
+  }
+
+  /** Mark a renewal RPC as started (coalescing latch). Must be paired with recordOutcome(). */
+  beginAttempt(): void {
+    this.inFlight = true;
+    this.lastAttemptAt = this.now();
+  }
+
+  /**
+   * Report the RPC result, advancing the control state:
+   *  - issued  → reset backoff + breaker (the channel is healthy again);
+   *  - refused → grant-level refusal (e.g. would-exceed-ceiling); back off, but NOT a transport
+   *              failure, so it does not advance the breaker (the holder answered);
+   *  - failed  → transport failure (timeout/partition/unreachable); back off AND advance the breaker.
+   */
+  recordOutcome(kind: RenewOutcomeKind): void {
+    this.inFlight = false;
+    if (kind === 'issued') {
+      this.currentInterval = this.minInterval;
+      this.consecutiveFailures = 0;
+      this.breakerOpenedAt = null;
+      return;
+    }
+    // Back off on any non-success.
+    this.currentInterval = Math.min(this.currentInterval * this.backoffMul, this.maxInterval);
+    if (kind === 'failed') {
+      this.consecutiveFailures += 1;
+      if (this.consecutiveFailures >= this.breakerThreshold && this.breakerOpenedAt === null) {
+        this.breakerOpenedAt = this.now();
+      }
+    }
+  }
+}
+
+// ───────────────────────── Router consultation (selection time) ─────────────────────────
+
+export type AccountUseDecision =
+  | { use: 'borrowed'; remaining: number; reason: 'live-slice' }
+  | {
+      use: 'own';
+      reason:
+        | 'follow-me-disabled'
+        | 'not-a-borrowed-account'
+        | 'no-slice'
+        | 'slice-exhausted'
+        | 'slice-expired'
+        | 'stale-lease-epoch';
+    };
+
+export interface AccountUseQuery {
+  /** Master dark gate (`multiMachine.accountFollowMe`). When false → ALWAYS own account. */
+  followMeEnabled: boolean;
+  /** Is the candidate account a BORROWED (follow-me / metadata-only-credentialed) account? */
+  isBorrowedAccount: boolean;
+  /** The slice this VM currently holds for the candidate account (undefined ⇒ never received one). */
+  slice: SliceLeaseState | undefined;
+  /** The current effective lease epoch (a slice from an older epoch is void). */
+  currentLeaseEpoch: number;
+  now: number;
+}
+
+/**
+ * The SELECTION-TIME consultation (R7a(b)/(d), S5, §6.2). Returns whether a candidate BORROWED
+ * account may be used this turn, or whether the call must FALL BACK to this machine's OWN account.
+ *
+ * Fail-closed-to-own-account on EVERY uncertainty: flag off, not a borrowed account, no slice ever
+ * received (first-slice-under-partition), exhausted slice, expired slice, or a stale-epoch slice all
+ * resolve to `own`. ONLY a live, unexpired, current-epoch slice with remaining budget yields
+ * `borrowed`. This is pure — the router/pool wiring calls it and routes accordingly; when off it can
+ * never be reached so default behavior is byte-identical.
+ */
+export function decideAccountUse(q: AccountUseQuery): AccountUseDecision {
+  if (!q.followMeEnabled) return { use: 'own', reason: 'follow-me-disabled' };
+  if (!q.isBorrowedAccount) return { use: 'own', reason: 'not-a-borrowed-account' };
+  const s = q.slice;
+  // (d) first-slice-under-partition: never received a slice → own account.
+  if (!s || !s.grantId) return { use: 'own', reason: 'no-slice' };
+  // A slice from a superseded lease epoch is void (the holder failed over).
+  if (s.leaseEpoch < q.currentLeaseEpoch) return { use: 'own', reason: 'stale-lease-epoch' };
+  if (s.expiresAt <= q.now) return { use: 'own', reason: 'slice-expired' };
+  if (!(s.remaining > 0)) return { use: 'own', reason: 'slice-exhausted' };
+  return { use: 'borrowed', remaining: s.remaining, reason: 'live-slice' };
+}

--- a/src/core/AnthropicSubscriptionRouter.ts
+++ b/src/core/AnthropicSubscriptionRouter.ts
@@ -31,6 +31,7 @@
 import type { IntelligenceProvider, IntelligenceOptions } from './types.js';
 import { decideSdkVsSubscription } from '../providers/costAwareRouting.js';
 import type { AgentSdkCreditSnapshot } from '../providers/primitives/observability/usageMeterProvider.js';
+import type { AccountUseDecision } from './AccountFollowMeSpendSlice.js';
 
 export type SubscriptionPathMode = 'auto' | 'force';
 
@@ -64,6 +65,23 @@ export interface AnthropicSubscriptionRouterOptions {
   onRoute?: (info: SubscriptionRouteInfo) => void;
   /** Observability tap — auto-mode fallback after a primary failure. */
   onDegrade?: (info: SubscriptionDegradeInfo) => void;
+  /**
+   * WS5.2 R7a (S5, §6.2) — OPTIONAL slice consultation. When account follow-me is enabled and
+   * wired, the routing layer injects this to decide, AT SELECTION TIME, whether the subscription
+   * path may use a BORROWED (follow-me) account this call or must fall back to this machine's OWN
+   * account. It returns the same `AccountUseDecision` as `decideAccountUse` — `use:'own'` on EVERY
+   * uncertainty (no slice / exhausted / expired / stale epoch / first-slice-under-partition / flag
+   * off), `use:'borrowed'` only on a live current-epoch slice with remaining budget.
+   *
+   * ABSENT (the default, and ALWAYS when `multiMachine.accountFollowMe` is off) ⇒ this hook is
+   * never invoked, so routing is BYTE-IDENTICAL to today. The router NEVER overspends a borrowed
+   * account: it never reaches for one unless this consultation says `borrowed`, and a borrowed
+   * selection here only ever scopes the subscription-pool path the pool provider already uses
+   * (the pool's own account selection honors the decision via `onSliceConsult`).
+   */
+  consultSlice?: (options?: IntelligenceOptions) => AccountUseDecision;
+  /** Observability tap — the slice consultation result for a subscription-path call. */
+  onSliceConsult?: (info: { decision: AccountUseDecision; component?: string }) => void;
 }
 
 const DEFAULT_SAFETY_MARGIN_FRACTION = 0.1;
@@ -83,11 +101,24 @@ export class AnthropicSubscriptionRouter implements IntelligenceProvider {
     }
   }
 
+  /**
+   * WS5.2 R7a — run the (optional) slice consultation before a subscription-pool call. NO-OP when
+   * `consultSlice` is unwired (the default / flag-off), so today's behavior is byte-identical. When
+   * wired it surfaces the decision (own vs borrowed) to observability + the pool's account selection;
+   * the router never overspends — a `use:'own'` keeps the pool on this machine's own account.
+   */
+  private consultSliceForSubscription(options?: IntelligenceOptions, component?: string): void {
+    if (!this.opts.consultSlice) return;
+    const decision = this.opts.consultSlice(options);
+    this.opts.onSliceConsult?.({ decision, component });
+  }
+
   async evaluate(prompt: string, options?: IntelligenceOptions): Promise<string> {
     const component = options?.attribution?.component;
 
     if (this.opts.mode === 'force') {
       this.opts.onRoute?.({ path: 'subscription-pool', reason: 'forced-subscription-mode', component });
+      this.consultSliceForSubscription(options, component);
       // No fallback by design — force mode guarantees zero `claude -p`
       // traffic; a pool failure must surface, not silently re-route.
       return this.opts.pool.evaluate(prompt, options);
@@ -107,6 +138,7 @@ export class AnthropicSubscriptionRouter implements IntelligenceProvider {
       : 'sdk-credit';
 
     this.opts.onRoute?.({ path: primaryLabel, reason: decision.reason, component });
+    if (primaryLabel === 'subscription-pool') this.consultSliceForSubscription(options, component);
     try {
       return await primary.evaluate(prompt, options);
     } catch (err) {
@@ -120,6 +152,7 @@ export class AnthropicSubscriptionRouter implements IntelligenceProvider {
         reason: `fallback-after-primary-failure: ${reason.slice(0, 200)}`,
         component,
       });
+      if (fallbackLabel === 'subscription-pool') this.consultSliceForSubscription(options, component);
       return fallback.evaluate(prompt, options);
     }
   }

--- a/src/core/MeshRpc.ts
+++ b/src/core/MeshRpc.ts
@@ -50,6 +50,26 @@ export type MeshCommand =
   | { type: 'capacity-report' }
   | { type: 'session-status'; session?: string }
   | { type: 'secret-share'; encrypted: string }
+  | {
+      // WS5.2 R7a/R7(c) — per-account SPEND-SLICE renewal (account follow-me).
+      // OPERATOR-MANDATE-GATED with its OWN `checkCommandRBAC` case — deliberately
+      // NOT the "any registered peer" read/observe class (R3a/R6a discipline): a
+      // borrowed account is a money/quota credential, so a slice may be issued ONLY
+      // to a machine the operator's mandate names. A requesting VM asks the FENCED
+      // lease holder to renew its slice; the holder (via SliceIssuer) verifies the
+      // grant is live + a slice remains within `maxSpend` before issuing. A
+      // non-holder receiving it MUST NOT issue (only the fenced single-writer
+      // issues) — that refusal lives in the handler/SliceIssuer, the RBAC gate here
+      // only proves the requester is mandate-authorized. The verb is rate-capped +
+      // coalesced + P19-breaker-protected on the REQUESTER side (SliceRenewalControl)
+      // so worst-case RPC rate is O(per-account-cap), not O(N).
+      type: 'slice-renew';
+      mandateId: string;
+      accountId: string;
+      requestingMachineFp: string;
+      amount: number;
+      expiresAt: number;
+    }
   // Pool Dashboard Streaming (POOL-DASHBOARD-STREAM-SPEC §2.3): a peer asks this
   // machine to mint a single-use bearer ticket so it may open a /pool-stream WS
   // and watch `session`. Read/observe class — minting a ticket discloses
@@ -248,7 +268,8 @@ export type RbacReason =
   | 'not-router'
   | 'claim-unauthorized'
   | 'release-unauthorized'
-  | 'drain-unauthorized';
+  | 'drain-unauthorized'
+  | 'slice-renew-unauthorized';
 
 export interface RbacDeps {
   /** The machine currently holding the router lease (verify-on-read, §L1), or null. */
@@ -257,6 +278,19 @@ export interface RbacDeps {
   ownerOf: (session: string) => MachineId | null;
   /** The machine the router last assigned (via place/transfer) for a session, or null. */
   placementTargetOf: (session: string) => MachineId | null;
+  /**
+   * WS5.2 R7a — the operator-mandate gate for the `slice-renew` verb. Returns true ONLY when the
+   * authorizing mandate authorizes (sender, accountId, requesting fingerprint) for account follow-me
+   * — deny-by-default. INJECTED so the dangerous authority decision is a real check, never an
+   * inherit. ABSENT ⇒ the verb is refused (fail-closed): on a build without the seam wired, a
+   * slice-renew can never be authorized. Mirrors the deny-by-default discipline of R3a/R4a.
+   */
+  authorizeSliceRenew?: (args: {
+    sender: MachineId;
+    mandateId: string;
+    accountId: string;
+    requestingMachineFp: string;
+  }) => boolean;
 }
 
 /**
@@ -289,6 +323,23 @@ export function checkCommandRBAC(command: MeshCommand, sender: MachineId, deps: 
       if (deps.ownerOf(command.session) === sender) return { ok: true, reason: 'ok' };
       if (isRouter && command.failover === true) return { ok: true, reason: 'ok' };
       return { ok: false, reason: 'release-unauthorized' };
+    }
+    case 'slice-renew': {
+      // WS5.2 R7a — OPERATOR-MANDATE-GATED, deliberately its OWN case (NOT the
+      // "any registered peer" read class). verifyEnvelope already proved WHO; this
+      // proves the operator's mandate AUTHORIZES this requester to borrow this
+      // account's spend. DENY-BY-DEFAULT: with no `authorizeSliceRenew` seam wired,
+      // or when the mandate does not authorize (sender, account, requesting fp), the
+      // verb is refused. The FENCED-single-writer "only the lease holder issues"
+      // check lives in the handler/SliceIssuer (a non-holder still refuses there);
+      // the gate's job is the mandate authorization, before any issuance work.
+      const authd = deps.authorizeSliceRenew?.({
+        sender,
+        mandateId: command.mandateId,
+        accountId: command.accountId,
+        requestingMachineFp: command.requestingMachineFp,
+      }) ?? false;
+      return authd ? { ok: true, reason: 'ok' } : { ok: false, reason: 'slice-renew-unauthorized' };
     }
     case 'commitment-mutate':
       // MUTATING verb, deliberately its OWN case (COMMITMENTS-COHERENCE-SPEC
@@ -392,6 +443,7 @@ function statusForReason(reason: string): number {
     case 'claim-unauthorized':
     case 'release-unauthorized':
     case 'drain-unauthorized':
+    case 'slice-renew-unauthorized':
       return 403;
     case 'replayed-nonce':
     case 'stale-timestamp':

--- a/tests/unit/MeshRpc.test.ts
+++ b/tests/unit/MeshRpc.test.ts
@@ -138,6 +138,21 @@ describe('MeshRpc — per-command RBAC (§L0)', () => {
     }
   });
 
+  it('slice-renew (WS5.2 R7a): operator-mandate-gated with its OWN refusal — NOT the any-peer class', () => {
+    const cmd: MeshCommand = {
+      type: 'slice-renew', mandateId: 'M1', accountId: 'acct', requestingMachineFp: 'fp-mini', amount: 0.3, expiresAt: 9_000_000_000_000,
+    };
+    // No `authorizeSliceRenew` seam wired ⇒ deny-by-default (fail closed).
+    expect(checkCommandRBAC(cmd, 'ANY_PEER', rbac())).toEqual({ ok: false, reason: 'slice-renew-unauthorized' });
+    // Seam says the mandate does NOT authorize this requester ⇒ refused.
+    expect(checkCommandRBAC(cmd, 'ROGUE', rbac({ authorizeSliceRenew: () => false })).reason).toBe('slice-renew-unauthorized');
+    // Seam authorizes the mandated requester ⇒ ok; the args are threaded to the gate.
+    const seen: unknown[] = [];
+    const ok = checkCommandRBAC(cmd, 'MANDATED', rbac({ authorizeSliceRenew: (a) => { seen.push(a); return true; } }));
+    expect(ok).toEqual({ ok: true, reason: 'ok' });
+    expect(seen[0]).toEqual({ sender: 'MANDATED', mandateId: 'M1', accountId: 'acct', requestingMachineFp: 'fp-mini' });
+  });
+
   it('state-snapshot is read/observe class — any registered peer → ok (no router/owner role)', () => {
     // The single-origin snapshot pull is self-binding (origin === serving machine);
     // RBAC adds NO authorization beyond verifyEnvelope, exactly like the other

--- a/tests/unit/account-followme-spend-slice.test.ts
+++ b/tests/unit/account-followme-spend-slice.test.ts
@@ -1,0 +1,164 @@
+/**
+ * Unit tests for WS5.2 R7a — per-account spend-slice ORCHESTRATION (AccountFollowMeSpendSlice.ts).
+ * Covers the distributed edge cases the spec names (§R7a, §S5, §I5, §8.4):
+ *   - SliceIssuer: fenced single-writer; sum-of-leases bound; lease-holder failover re-derivation.
+ *   - SliceRenewalControl: per-(account,machine) coalescing; rate-cap + exponential backoff; P19
+ *     breaker → fail closed to own account; O(per-account-cap) renewal rate (not O(N)).
+ *   - decideAccountUse: live slice → borrowed; exhausted / expired / stale-epoch / no-slice
+ *     (first-slice-under-partition) / flag-off → own account (fail-closed on EVERY uncertainty).
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  SliceIssuer,
+  SliceRenewalControl,
+  decideAccountUse,
+  type SliceRenewRequest,
+} from '../../src/core/AccountFollowMeSpendSlice.js';
+import { inMemoryGrantStore, type GrantStore } from '../../src/core/AccountFollowMeGrants.js';
+
+const FUTURE = 9_000_000_000_000;
+function req(over: Partial<SliceRenewRequest> = {}): SliceRenewRequest {
+  return {
+    grantId: 'g1', mandateId: 'M1', accountId: 'acct', requestingMachineFp: 'fp-mini',
+    amount: 0.3, expiresAt: FUTURE, ...over,
+  };
+}
+
+describe('SliceIssuer — fenced single-writer (R7a(a))', () => {
+  it('a NON-holder cannot issue a slice (only the fenced single-writer issues)', () => {
+    const issuer = new SliceIssuer(inMemoryGrantStore(), {
+      selfMachineId: 'B', holdsLease: () => false, currentLeaseEpoch: () => 5, now: () => 1000,
+    });
+    expect(issuer.issueForRenew(req(), { ceiling: 1.0 })).toEqual({ ok: false, reason: 'not-lease-holder' });
+  });
+
+  it('the holder issues a slice stamped with the current lease epoch', () => {
+    const issuer = new SliceIssuer(inMemoryGrantStore(), {
+      selfMachineId: 'A', holdsLease: () => true, currentLeaseEpoch: () => 7, now: () => 1000,
+    });
+    const r = issuer.issueForRenew(req({ amount: 0.4 }), { ceiling: 1.0 });
+    expect(r).toMatchObject({ ok: true, amount: 0.4, leaseEpoch: 7 });
+  });
+
+  it('enforces the sum-of-leases ceiling across machines (a 6th VM does not raise it)', () => {
+    const store = inMemoryGrantStore();
+    const issuer = new SliceIssuer(store, {
+      selfMachineId: 'A', holdsLease: () => true, currentLeaseEpoch: () => 1, now: () => 1000,
+    });
+    for (let i = 0; i < 5; i++) {
+      expect(issuer.issueForRenew(req({ grantId: `g${i}`, requestingMachineFp: `fp${i}`, amount: 0.2 }), { ceiling: 1.0 }).ok).toBe(true);
+    }
+    // The aggregate is at the ceiling; the next slice is refused — bound is sum-of-leases, not N×ceiling.
+    expect(issuer.issueForRenew(req({ grantId: 'g6', requestingMachineFp: 'fp6', amount: 0.2 }), { ceiling: 1.0 }))
+      .toEqual({ ok: false, reason: 'would-exceed-ceiling' });
+    expect(issuer.outstandingFor('acct')).toBeCloseTo(1.0);
+  });
+
+  it('lease-holder FAILOVER re-derives outstanding from the durable ledger → no double-allocation', () => {
+    const store: GrantStore = inMemoryGrantStore();
+    // Holder A issues 0.7 of the ceiling under epoch 5.
+    const holderA = new SliceIssuer(store, {
+      selfMachineId: 'A', holdsLease: () => true, currentLeaseEpoch: () => 5, now: () => 1000,
+    });
+    expect(holderA.issueForRenew(req({ grantId: 'gA', requestingMachineFp: 'fpA', amount: 0.7 }), { ceiling: 1.0 }).ok).toBe(true);
+    // A dies; B wins the fenced lease at epoch 6 and rebuilds from the SAME store BEFORE issuing.
+    const holderB = new SliceIssuer(store, {
+      selfMachineId: 'B', holdsLease: () => true, currentLeaseEpoch: () => 6, now: () => 1000,
+    });
+    expect(holderB.outstandingFor('acct')).toBeCloseTo(0.7);
+    // B cannot over-allocate beyond the already-committed 0.7 — the bound holds across the handoff.
+    expect(holderB.issueForRenew(req({ grantId: 'gB', requestingMachineFp: 'fpB', amount: 0.4 }), { ceiling: 1.0 }))
+      .toEqual({ ok: false, reason: 'would-exceed-ceiling' });
+    expect(holderB.issueForRenew(req({ grantId: 'gB', requestingMachineFp: 'fpB', amount: 0.3 }), { ceiling: 1.0 }).ok).toBe(true);
+  });
+});
+
+describe('SliceRenewalControl — control plane (R7a(c), O(per-account-cap) not O(N))', () => {
+  it('coalesces: a VM with an in-flight renewal does not start a second', () => {
+    let t = 100000;
+    const ctl = new SliceRenewalControl({ now: () => t });
+    expect(ctl.shouldAttempt().proceed).toBe(true);
+    ctl.beginAttempt();
+    // Even after the rate window, a second attempt is refused while one is in flight.
+    t += 1_000_000;
+    expect(ctl.shouldAttempt()).toEqual({ proceed: false, reason: 'coalesced-in-flight' });
+  });
+
+  it('rate-caps with exponential backoff after a refusal/failure', () => {
+    let t = 0;
+    const ctl = new SliceRenewalControl({ now: () => t, minRenewIntervalMs: 1000, backoffMultiplier: 2 });
+    ctl.beginAttempt();
+    ctl.recordOutcome('refused');
+    // Inside the (backed-off) window → rate-capped.
+    t = 1500;
+    expect(ctl.shouldAttempt()).toEqual({ proceed: false, reason: 'rate-capped' });
+    // After the backed-off interval (2000ms) → allowed again.
+    t = 2001;
+    expect(ctl.shouldAttempt().proceed).toBe(true);
+  });
+
+  it('a refusal (grant-level) does NOT advance the breaker — only transport failures do', () => {
+    let t = 0;
+    const ctl = new SliceRenewalControl({ now: () => t, minRenewIntervalMs: 1, breakerThreshold: 2 });
+    for (let i = 0; i < 5; i++) { ctl.beginAttempt(); ctl.recordOutcome('refused'); t += 1000; }
+    expect(ctl.breakerOpen()).toBe(false);
+  });
+
+  it('P19 breaker opens after N consecutive transport FAILURES → fail closed to own account', () => {
+    let t = 0;
+    const ctl = new SliceRenewalControl({ now: () => t, minRenewIntervalMs: 1, breakerThreshold: 3, breakerCooldownMs: 60000 });
+    for (let i = 0; i < 3; i++) { ctl.beginAttempt(); ctl.recordOutcome('failed'); t += 1000; }
+    expect(ctl.breakerOpen()).toBe(true);
+    expect(ctl.shouldAttempt()).toEqual({ proceed: false, reason: 'breaker-open' });
+    // After the cooldown a probe is allowed again.
+    t += 60000;
+    expect(ctl.breakerOpen()).toBe(false);
+  });
+
+  it('a successful issue resets backoff AND the breaker', () => {
+    let t = 0;
+    const ctl = new SliceRenewalControl({ now: () => t, minRenewIntervalMs: 1000, breakerThreshold: 2 });
+    ctl.beginAttempt(); ctl.recordOutcome('failed'); t += 5000;
+    ctl.beginAttempt(); ctl.recordOutcome('issued');
+    // Interval is back to the floor (1000) and the breaker is closed.
+    t += 1001;
+    expect(ctl.breakerOpen()).toBe(false);
+    expect(ctl.shouldAttempt().proceed).toBe(true);
+  });
+});
+
+describe('decideAccountUse — selection-time consultation (R7a(b)/(d), S5)', () => {
+  const base = { followMeEnabled: true, isBorrowedAccount: true, currentLeaseEpoch: 5, now: 1000 };
+
+  it('a live, current-epoch slice with remaining budget → BORROWED', () => {
+    const d = decideAccountUse({ ...base, slice: { grantId: 'g1', remaining: 0.2, leaseEpoch: 5, expiresAt: FUTURE } });
+    expect(d).toEqual({ use: 'borrowed', remaining: 0.2, reason: 'live-slice' });
+  });
+
+  it('flag off → OWN account (byte-identical default behavior)', () => {
+    const d = decideAccountUse({ ...base, followMeEnabled: false, slice: { grantId: 'g1', remaining: 0.2, leaseEpoch: 5, expiresAt: FUTURE } });
+    expect(d).toEqual({ use: 'own', reason: 'follow-me-disabled' });
+  });
+
+  it('not a borrowed account → OWN account', () => {
+    expect(decideAccountUse({ ...base, isBorrowedAccount: false, slice: undefined }).reason).toBe('not-a-borrowed-account');
+  });
+
+  it('first-slice-under-partition (never received a slice) → OWN account', () => {
+    expect(decideAccountUse({ ...base, slice: undefined }).reason).toBe('no-slice');
+    expect(decideAccountUse({ ...base, slice: { remaining: 0.5, leaseEpoch: 5, expiresAt: FUTURE } }).reason).toBe('no-slice');
+  });
+
+  it('exhausted slice → OWN account', () => {
+    expect(decideAccountUse({ ...base, slice: { grantId: 'g1', remaining: 0, leaseEpoch: 5, expiresAt: FUTURE } }).reason).toBe('slice-exhausted');
+  });
+
+  it('expired slice → OWN account', () => {
+    expect(decideAccountUse({ ...base, now: 5000, slice: { grantId: 'g1', remaining: 0.5, leaseEpoch: 5, expiresAt: 2000 } }).reason).toBe('slice-expired');
+  });
+
+  it('a slice from a SUPERSEDED lease epoch (holder failed over) is void → OWN account', () => {
+    expect(decideAccountUse({ ...base, currentLeaseEpoch: 6, slice: { grantId: 'g1', remaining: 0.5, leaseEpoch: 5, expiresAt: FUTURE } }).reason).toBe('stale-lease-epoch');
+  });
+});

--- a/tests/unit/anthropic-subscription-router.test.ts
+++ b/tests/unit/anthropic-subscription-router.test.ts
@@ -234,3 +234,59 @@ describe('InteractivePoolIntelligenceProvider', () => {
     );
   });
 });
+
+describe('AnthropicSubscriptionRouter — WS5.2 R7a slice consultation (S5, §6.2)', () => {
+  it('unwired consultSlice → byte-identical: pool is called, no consultation surfaced', async () => {
+    const pool = provider('pool');
+    const onSliceConsult = vi.fn();
+    const router = new AnthropicSubscriptionRouter({
+      headless: provider('hl'), pool, mode: 'force',
+      readSdkCredit: async () => null, onSliceConsult,
+    });
+    expect(await router.evaluate('x')).toBe('pool:ok');
+    expect(pool.calls.length).toBe(1);
+    expect(onSliceConsult).not.toHaveBeenCalled();
+  });
+
+  it('force mode → consults the slice before the subscription-pool call', async () => {
+    const consultSlice = vi.fn(() => ({ use: 'own' as const, reason: 'no-slice' as const }));
+    const onSliceConsult = vi.fn();
+    const router = new AnthropicSubscriptionRouter({
+      headless: provider('hl'), pool: provider('pool'), mode: 'force',
+      readSdkCredit: async () => null, consultSlice, onSliceConsult,
+    });
+    await router.evaluate('x', { attribution: { component: 'C' } });
+    expect(consultSlice).toHaveBeenCalledTimes(1);
+    expect(onSliceConsult).toHaveBeenCalledWith({ decision: { use: 'own', reason: 'no-slice' }, component: 'C' });
+  });
+
+  it('auto mode → consults ONLY when the subscription-pool path is selected (not on sdk-credit)', async () => {
+    const consultSlice = vi.fn(() => ({ use: 'borrowed' as const, remaining: 0.3, reason: 'live-slice' as const }));
+    // Above margin → sdk-credit primary → NO slice consultation.
+    const sdk = new AnthropicSubscriptionRouter({
+      headless: provider('hl'), pool: provider('pool'), mode: 'auto',
+      readSdkCredit: async () => snapshot(200, 200), consultSlice,
+    });
+    await sdk.evaluate('x');
+    expect(consultSlice).not.toHaveBeenCalled();
+    // Null credit → subscription floor primary → slice IS consulted.
+    consultSlice.mockClear();
+    const sub = new AnthropicSubscriptionRouter({
+      headless: provider('hl'), pool: provider('pool'), mode: 'auto',
+      readSdkCredit: async () => null, consultSlice,
+    });
+    await sub.evaluate('x');
+    expect(consultSlice).toHaveBeenCalledTimes(1);
+  });
+
+  it('auto mode fallback to subscription after sdk failure → consults the slice on the fallback', async () => {
+    const consultSlice = vi.fn(() => ({ use: 'own' as const, reason: 'slice-exhausted' as const }));
+    const router = new AnthropicSubscriptionRouter({
+      headless: provider('hl', async () => { throw new Error('sdk down'); }),
+      pool: provider('pool'), mode: 'auto',
+      readSdkCredit: async () => snapshot(200, 200), consultSlice,
+    });
+    expect(await router.evaluate('x')).toBe('pool:ok');
+    expect(consultSlice).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/unit/lint-dev-agent-dark-gate.test.ts
+++ b/tests/unit/lint-dev-agent-dark-gate.test.ts
@@ -400,11 +400,11 @@ describe('lint-dev-agent-dark-gate', () => {
       // DEV_GATED_FEATURES) so it introduces no new attributed path. After merging JKHeadley/main
       // (which added its own config above), the sessionPool keys resolve to 872/897/926.
       // RE-VERIFIED by hand via the attributor on the MERGED ConfigDefaults.
-      // R6b: the accountFollowMe block gained `remoteScrapeTimeoutMs` (+ comment, ~7 lines)
-      // ABOVE these keys, shifting each DOWN by +7. RE-VERIFIED via the attributor.
-      '901': 'multiMachine.sessionPool.enabled',
-      '926': 'multiMachine.sessionPool.inboundQueue.enabled',
-      '955': 'multiMachine.sessionPool.holdForStability.enabled',
+      // R6b: the accountFollowMe block gained `remoteScrapeTimeoutMs` (+7); R7a added the
+      // `spendSlice` block (+23 more) ABOVE these keys → +23 vs R6b. RE-VERIFIED via the attributor.
+      '924': 'multiMachine.sessionPool.enabled',
+      '949': 'multiMachine.sessionPool.inboundQueue.enabled',
+      '978': 'multiMachine.sessionPool.holdForStability.enabled',
       // mm-stores-devgate (operator directive 2026-06-13, topic 13481): the 7
       // multiMachine.stateSync.* memory stores MOVED from DARK_GATE_EXCLUSIONS to
       // DEV_GATED_FEATURES and their `enabled: false` literals were REMOVED from
@@ -438,10 +438,10 @@ describe('lint-dev-agent-dark-gate', () => {
       // attributor on the edited ConfigDefaults.
       // After merging JKHeadley/main + my accountFollowMe block, these resolve as below.
       // RE-VERIFIED by hand via the attributor on the MERGED ConfigDefaults.
-      '1124': 'multiMachine.stateSync.threadlinePairing.enabled',
-      '1246': 'cartographer.freshnessSweep.enabled',
-      '1291': 'cartographer.conformanceAudit.llmEnrichment.enabled',
-      '1316': 'cartographer.subtreeNav.llmRerank.enabled',
+      '1147': 'multiMachine.stateSync.threadlinePairing.enabled',
+      '1269': 'cartographer.freshnessSweep.enabled',
+      '1314': 'cartographer.conformanceAudit.llmEnrichment.enabled',
+      '1339': 'cartographer.subtreeNav.llmRerank.enabled',
     };
     const actual = attributeRealConfigDefaults();
     expect(actual).toEqual(EXPECTED);

--- a/upgrades/next/ws52-account-follow-me-r7a-spend-slice.md
+++ b/upgrades/next/ws52-account-follow-me-r7a-spend-slice.md
@@ -1,0 +1,19 @@
+## What Changed
+
+WS5.2 R7a — the per-account spend ceiling, lease-sliced and owned by the fenced single-writer, so multiple machines sharing one operator account can never collectively over-spend its quota (bounded by sum-of-leases, never N×ceiling — even under partition and across a lease-holder failover). New module `src/core/AccountFollowMeSpendSlice.ts` (pure/injectable): `SliceIssuer` (holder-side; refuses unless it holds the live fenced lease; delegates the sum-of-leases ceiling to the durable PR1 grant-ledger; epoch-stamps every slice), `SliceRenewalControl` (requester-side rate-cap + exponential backoff + per-(account,machine) coalescing + a P19 breaker that fails a machine closed to its OWN account when the holder is slow/partitioned — so the renewal RPC rate is O(per-account-cap), not O(N)), and `decideAccountUse` (the pure selection-time check — a borrowed account is used ONLY for a live, current-epoch, unexpired, positive-remaining slice; every uncertainty falls back to the machine's own account). A new operator-mandate-gated `slice-renew` mesh verb (its own deny-by-default RBAC case). The `AnthropicSubscriptionRouter` gains an optional consult hook (subscription-path only). Config knobs under `multiMachine.accountFollowMe.spendSlice`. Dark behind `multiMachine.accountFollowMe`.
+
+**Scope (honest):** this delivers the spend-ceiling MECHANISM + the consultation; the router currently surfaces the decision to observability. The pool's account selection actually choosing own-vs-borrowed based on it is the enforcement integration that requires the (not-yet-live) borrowed-account-in-pool concept — so the consultation is inert today by construction (nothing is borrowed yet), leaving no reachable over-spend path unguarded. The enforcement wiring lands with that selection layer.
+
+## Evidence
+
+- 59+ tests across `account-followme-spend-slice` (fenced issuance, non-holder refusal, sum-of-leases/Nth-VM refusal, failover re-derivation with no double-allocation, coalescing, rate-cap+backoff, refusal-vs-failure breaker distinction, breaker open/cooldown/reset, all `decideAccountUse` branches), `MeshRpc` (slice-renew deny-by-default RBAC: unwired/rogue/mandated), and `anthropic-subscription-router` (unwired byte-identical, consult on subscription paths only). `tsc --noEmit` clean. Dark-gate lint golden-map updated for the new config block (24/24).
+- Side-effects review + mandatory independent second-pass security review (concurred on all 7 audit points: sum-of-leases bound, failover no-double-allocation, fail-closed-to-own everywhere, deny-by-default RBAC, O(per-account-cap) control plane, dark-by-default, no fail-open).
+- Spec: `docs/specs/ws52-account-follow-me-security.md` R7a/R7/S5 (converged, approved).
+
+## What to Tell Your User
+
+Nothing to do — this ships off by default. It's the safety cap that lets several of your machines share one subscription account without them collectively blowing past that account's quota: each machine gets a metered slice of the account's allowance from one coordinating machine, and if it can't reach that coordinator it quietly uses its own account instead of overspending the shared one.
+
+## Summary of New Capabilities
+
+Cross-machine per-account spend ceiling (dark): lease-sliced sub-budgets issued by the fenced single-writer, bounded by sum-of-leases under partition + failover, with an operator-mandate-gated renewal mesh verb and fail-closed-to-own-account on every uncertainty. No user-facing surface is live in this release.

--- a/upgrades/side-effects/ws52-account-follow-me-r7a-spend-slice.md
+++ b/upgrades/side-effects/ws52-account-follow-me-r7a-spend-slice.md
@@ -1,0 +1,70 @@
+# Side-Effects Review — WS5.2 R7a: lease-sliced per-account spend ceiling
+
+**Version / slug:** `ws52-account-follow-me-r7a-spend-slice`
+**Date:** `2026-06-17`
+**Author:** `Echo (instar-dev agent)`
+**Second-pass reviewer:** `pending (HIGHEST-risk: cross-machine money/quota ceiling under partition + a new operator-mandate-gated mesh verb)`
+
+## Summary of the change
+
+WS5.2 R7a. A per-account spend ceiling, lease-sliced, owned by the fenced single-writer (the `FencedLease` holder), so N machines sharing one operator account can never collectively over-spend its quota — bounded by sum-of-leases, never N×ceiling, even under partition and across lease-holder failover. New module `src/core/AccountFollowMeSpendSlice.ts` (pure/injectable): `SliceIssuer` (holder-side — refuses `not-lease-holder`, stamps the current lease epoch, delegates the sum-of-leases ceiling to the existing durable `AccountFollowMeGrantLedger`); `SliceRenewalControl` (requester-side rate-cap + exponential backoff + per-(account,machine) coalescing + P19 breaker → fail-closed-to-own-account on a slow/partitioned holder); `decideAccountUse` (pure selection-time consultation — borrowed account used ONLY for a live, current-epoch, unexpired, remaining>0 slice; every uncertainty → own account). A new operator-mandate-gated `slice-renew` mesh verb in `MeshRpc.ts` (its own deny-by-default `checkCommandRBAC` case via an injected `authorizeSliceRenew` seam). `AnthropicSubscriptionRouter` gains optional `consultSlice`/`onSliceConsult` hooks invoked only on the subscription-pool selection path (no-op when unwired). Config knobs under `multiMachine.accountFollowMe.spendSlice`. Dark behind `multiMachine.accountFollowMe`; default behavior byte-identical when the hook is unwired/off.
+
+## Decision-point inventory
+
+- `slice-renew` mesh verb RBAC — **add** — deny-by-default; only the operator-mandate-authorized requester (via `authorizeSliceRenew`) may request a slice; absent seam → deny.
+- `SliceIssuer.issueForRenew` — **add** — only the live `FencedLease` holder issues; ceiling enforced by the durable ledger; epoch-stamped.
+- `decideAccountUse` — **add** — selection-time: borrowed vs own account; fail-closed-to-own on every uncertainty.
+- `SliceRenewalControl` — **add** — the control-plane bound (rate-cap/coalesce/breaker) → O(per-account-cap) renewal RPCs.
+
+---
+
+## 1. Over-block
+
+The conservative direction is intentional: when a slice is unknown/stale/expired/exhausted, or the holder is slow/partitioned, a machine "over-blocks" by falling back to its OWN account rather than using the borrowed one. This is the REQUIRED safe direction (never overspend a borrowed money/quota credential). It cannot wrongly deny the machine's own account (fallback is always available). No legitimate over-block of a healthy borrowed slice (a live current-epoch slice with budget is used).
+
+## 2. Under-block
+
+The ceiling is enforced at slice ISSUANCE (the ledger refuses `outstanding + amount > ceiling`) and at selection (a machine without budget falls back). It does NOT meter per-call token spend WITHIN a slice — a slice is a pre-allocated sub-budget; intra-slice accounting is the slice's granularity (by design — the spec's lease-slice model). A compromised holder could in principle over-issue, but the holder is the fenced single-writer (the same trust root as who-is-awake) and the ledger still caps the durable sum; a non-holder cannot issue at all.
+
+## 3. Level-of-abstraction fit
+
+Correct layers: issuance authority on the FencedLease holder (the existing single-writer), durable accounting in the existing GrantLedger (reused, not rebuilt), the renewal control-plane as a pure injectable state machine, the consultation as a pure function the router calls. The mesh verb sits in MeshRpc with the other commands. No logic duplicated; the ledger's sum-of-leases + epoch-fencing is reused as-is.
+
+## 4. Signal vs authority compliance
+
+The authority here (issue a spend slice) is held by the fenced single-writer + gated by the operator mandate (deny-by-default) — appropriate, not a brittle heuristic. The consultation (`decideAccountUse`) is a deterministic pure function (field checks on a slice), fail-closed. The breaker is a signal (consecutive transport failures → open) that only ever makes a machine MORE conservative (fall back to own account). No brittle blocking authority over user actions. Reference `docs/signal-vs-authority.md`: operator-mandate + fenced-single-writer authority, deny-by-default, is correctly-placed.
+
+## 5. Interactions
+
+Reuses `AccountFollowMeGrantLedger` (PR1) for the durable sum-of-leases bound + epoch-fenced consume — failover re-derivation is "for free" because `SliceIssuer` holds no in-memory slice state (reads the durable store live; a new holder over the same store sees the committed set). The `not-lease-holder` guard prevents a stale ex-holder from issuing during a handoff. The breaker distinguishes grant REFUSALS (`would-exceed-ceiling` — the holder answered; back off but don't trip) from transport FAILURES (trip the breaker) — so a healthy-but-full account doesn't open the breaker. The router hook runs only on the subscription path (never sdk-credit), so it can't perturb SDK routing.
+
+## 6. External surfaces
+
+One new mesh verb (`slice-renew`), deny-by-default, dark behind the flag. New config block (`spendSlice`, additive, defaulted). No new HTTP route. When `multiMachine.accountFollowMe` is off (or the router hook unwired — the default), behavior is byte-identical: the consult hook is never invoked. Other agents see the new verb only if they're mandated peers in a follow-me pool.
+
+## 7. Multi-machine posture (Cross-Machine Coherence)
+
+This IS a multi-machine coherence mechanism by construction. The single source of truth is the fenced-lease holder + the durable grant-ledger; slices are epoch-stamped so a failover voids stale-epoch slices and the new holder re-derives the outstanding set from the durable store before issuing — the sum-of-leases bound holds across the handoff with no double-allocation. Under partition, a VM that can't reach the holder fails closed to its own account (bounded, never unbounded overshoot). The renewal control plane is O(per-account-cap), not O(N), so it can't storm the holder. A single-machine agent is a no-op (no peers, the flag is off).
+
+## 8. Rollback cost
+
+Low. Entirely dark behind `multiMachine.accountFollowMe` + the unwired router hook → no live effect by default. New module + additive config + one mesh verb. Revert is a single-commit back-out; no migration, no persisted-schema change (the slice records live in the existing grant-ledger store, which already shipped in PR1).
+
+---
+
+## Scope note (honest, not a hidden deferral)
+
+R7a delivers the spend-ceiling MECHANISM end-to-end: the fenced-single-writer slice issuer (ledger-backed sum-of-leases ceiling + epoch-fenced failover re-derivation), the requester-side renewal control plane (rate-cap + coalescing + P19 breaker → O(per-account-cap)), the operator-mandate-gated `slice-renew` mesh verb, the pure `decideAccountUse` consultation (fail-closed-to-own on every uncertainty), AND the router hook that invokes it. The router currently SURFACES the decision to observability (`onSliceConsult`); the pool's account-selection actually CHOOSING own-vs-borrowed based on that decision is the enforcement integration that belongs to — and requires — the borrowed-account-in-pool concept, which is not yet live (enrollment adds accounts as normal local accounts; nothing is marked `isBorrowedAccount` yet). So the consultation is inert today by construction (every account → `own`), meaning there is NO reachable over-spend path that this layer leaves unguarded. This is the correct decomposition for a dark mechanism, not a deferral of reachable behavior; the enforcement wiring lands with the borrowed-account selection layer.
+
+## Second-pass review
+
+**Concur with the review** (security substance) — the independent reviewer verified all 7 points directly:
+1. **Sum-of-leases bound holds** — `SliceIssuer.issueForRenew` delegates to the ledger's `issue()` (re-reads outstanding from the durable store, refuses `outstanding + amount > ceiling`); `SliceIssuer` holds ZERO in-memory accounting state; the `GrantStore` is synchronous so no interleave past the ceiling (structural invariant: keep the store synchronous). `outstandingFor` conservatively over-counts (safe direction).
+2. **Failover / no double-allocation** — `holdsLease()` blocks a stale ex-holder; the new holder re-derives from the same durable store; epoch-stamped slices are void on stale epoch. Tested.
+3. **Fail-closed-to-own on every uncertainty** — `decideAccountUse` returns `own` for flag-off / not-borrowed / no-slice / stale-epoch / expired / `!(remaining>0)` (0, negative, NaN). `borrowed` only via a live current-epoch unexpired positive-remaining slice.
+4. **slice-renew RBAC deny-by-default** — own `checkCommandRBAC` case; `authorizeSliceRenew?.(...) ?? false` → absent seam OR false → 403; not the any-peer read class.
+5. **Control plane O(per-account-cap)** — coalescing + rate-cap + exponential backoff + P19 breaker on transport `failed` only; grant `refused` (would-exceed-ceiling) backs off but does NOT trip the breaker.
+6. **Dark by default / byte-identical when off** — `consultSlice` no-ops when unwired; subscription-path only, never sdk-credit. (Observe-only in this layer — see Scope note above.)
+7. **No fail-open** — no catch/`||true`/default-allow; every positive outcome follows explicit guards.
+
+The reviewer's one CONCERN was the dark-gate lint golden-map line shift from the new `spendSlice` config block — **FIXED**: the 7 shifted entries updated to the attributor's values (924/949/978/1147/1269/1314/1339); `lint-dev-agent-dark-gate.test.ts` now 24/24 green. tsc EXIT=0; the 3 R7a suites 59 passed.


### PR DESCRIPTION
## ELI16

This is the last WS5.2 piece: a spending cap that lets several of your machines share ONE subscription account without them collectively blowing past that account's quota. It ships OFF by default.

The problem: if three machines all use the same account, nothing stops them from together burning way more than the account allows. The fix: one machine (the "coordinator", chosen by an existing fenced-lease mechanism) hands out metered SLICES of the account's allowance to each machine. A machine spends only within its slice; the coordinator never hands out more slices than the account's total cap — so the sum of everyone's slices can never exceed the ceiling. This holds even if the network splits or the coordinator role moves to another machine (slices are stamped with the coordinator's "term number" and go void when the term changes; the new coordinator re-derives what's outstanding from durable storage before issuing more — no double-handing-out).

Safety is fail-closed everywhere: if a machine can't reach the coordinator, or its slice is expired/used-up/from an old term, it quietly uses its OWN account instead of overspending the shared one — never the reverse. Renewing a slice goes through a new operator-mandate-gated mesh command (deny-by-default), and the renewal traffic is rate-capped + coalesced + circuit-broken so it can't storm the coordinator regardless of how many machines there are.

Scope note (honest): this PR delivers the full mechanism + the consultation logic; the router currently surfaces the decision for observability. The pool actually picking own-vs-borrowed based on it is the enforcement step that needs the "borrowed account in the pool" concept, which isn't live yet — so the consultation is inert today (nothing is borrowed), leaving no over-spend path unguarded. That enforcement wiring lands with the borrowed-account selection layer.

## What this PR does
- New `AccountFollowMeSpendSlice.ts`: `SliceIssuer` (fenced-holder-only, ledger-backed sum-of-leases ceiling, epoch-stamped, failover re-derivation), `SliceRenewalControl` (rate-cap + backoff + coalescing + P19 breaker → O(per-account-cap), fail-closed-to-own), `decideAccountUse` (borrowed only for a live slice; every uncertainty → own).
- Operator-mandate-gated `slice-renew` mesh verb (deny-by-default RBAC).
- `AnthropicSubscriptionRouter` consult hook (subscription-path only; observe-only this layer).
- Config under `multiMachine.accountFollowMe.spendSlice`. Dark behind `multiMachine.accountFollowMe`.
- 59+ tests; `tsc` clean; side-effects + independent second-pass security review concurred on all 7 audit points (sum-of-leases bound, failover no-double-allocation, fail-closed-to-own, deny-by-default RBAC, O(per-account-cap), dark-default, no fail-open).

Spec: `docs/specs/ws52-account-follow-me-security.md` R7a/R7/S5 (converged, approved). This completes the WS5.2 build.