### PR TITLE
feat(ws52): one-dashboard cross-machine mandate delivery

### DIFF
--- a/.instar/instar-dev-decisions/2026-06-17T15-37-08-657Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-06-17T15-37-08-657Z-unknown.json
@@ -1,0 +1,15 @@
+{
+  "ts": "2026-06-17T15:37:08.657Z",
+  "slug": "unknown",
+  "suggestedTier": 2,
+  "declaredTier": 2,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "new capability: new exported class / subsystem added"
+  ],
+  "belowFloor": false,
+  "files": 4,
+  "loc": 413,
+  "causalAutopsy": null,
+  "verdict": "pass"
+}

--- a/.instar/instar-dev-decisions/2026-06-17T16-41-08-055Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-06-17T16-41-08-055Z-unknown.json
@@ -1,0 +1,17 @@
+{
+  "ts": "2026-06-17T16:41:08.055Z",
+  "slug": "unknown",
+  "suggestedTier": 2,
+  "declaredTier": 2,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "new capability: new route (router.<verb>() added",
+    "new capability: new exported class / subsystem added",
+    "new capability: new config key added"
+  ],
+  "belowFloor": false,
+  "files": 6,
+  "loc": 568,
+  "causalAutopsy": null,
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-06-17T16-42-21-832Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-06-17T16-42-21-832Z-unknown.json
@@ -1,0 +1,17 @@
+{
+  "ts": "2026-06-17T16:42:21.832Z",
+  "slug": "unknown",
+  "suggestedTier": 2,
+  "declaredTier": 2,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "new capability: new route (router.<verb>() added",
+    "new capability: new exported class / subsystem added",
+    "new capability: new config key added"
+  ],
+  "belowFloor": false,
+  "files": 6,
+  "loc": 568,
+  "causalAutopsy": null,
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-06-17T16-43-10-336Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-06-17T16-43-10-336Z-unknown.json
@@ -1,0 +1,17 @@
+{
+  "ts": "2026-06-17T16:43:10.336Z",
+  "slug": "unknown",
+  "suggestedTier": 2,
+  "declaredTier": 2,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "new capability: new route (router.<verb>() added",
+    "new capability: new exported class / subsystem added",
+    "new capability: new config key added"
+  ],
+  "belowFloor": false,
+  "files": 6,
+  "loc": 568,
+  "causalAutopsy": null,
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-06-17T16-44-03-699Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-06-17T16-44-03-699Z-unknown.json
@@ -1,0 +1,17 @@
+{
+  "ts": "2026-06-17T16:44:03.699Z",
+  "slug": "unknown",
+  "suggestedTier": 2,
+  "declaredTier": 2,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "new capability: new route (router.<verb>() added",
+    "new capability: new exported class / subsystem added",
+    "new capability: new config key added"
+  ],
+  "belowFloor": false,
+  "files": 6,
+  "loc": 568,
+  "causalAutopsy": null,
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-06-17T16-45-01-633Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-06-17T16-45-01-633Z-unknown.json
@@ -1,0 +1,17 @@
+{
+  "ts": "2026-06-17T16:45:01.633Z",
+  "slug": "unknown",
+  "suggestedTier": 2,
+  "declaredTier": 2,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "new capability: new route (router.<verb>() added",
+    "new capability: new exported class / subsystem added",
+    "new capability: new config key added"
+  ],
+  "belowFloor": false,
+  "files": 6,
+  "loc": 568,
+  "causalAutopsy": null,
+  "verdict": "pass"
+}

--- a/dashboard/mandates.js
+++ b/dashboard/mandates.js
@@ -526,30 +526,51 @@ export function createController({ doc, els, fetchImpl }) {
     return { problems, authorities };
   }
 
+  // WS5.2 R4a — an account-follow-me authority targets a SPECIFIC machine. From the operator's ONE
+  // dashboard, such a mandate is issued AND delivered to that target via /mandate/issue-for-machine
+  // (which issues locally then dispatches the R4a-signed bundle over the mesh) — the operator NEVER
+  // opens the target's own dashboard. A non-follow-me mandate uses the ordinary /mandate/issue path.
+  function followMeTarget(authorities) {
+    if (!Array.isArray(authorities)) return null;
+    const a = authorities.find((x) => x && x.action === 'account-follow-me'
+      && x.bounds && typeof x.bounds.accountId === 'string' && typeof x.bounds.targetMachineId === 'string');
+    return a ? { accountId: a.bounds.accountId, targetMachineId: a.bounds.targetMachineId } : null;
+  }
+
   async function issue() {
     const { problems, authorities } = validateIssueForm();
     if (problems.length > 0) {
       note('Not issued — fix the following first:\n' + problems.join('\n'), 'error');
       return;
     }
-    const payload = {
-      pin: els.issuePin.value,
-      scope: els.issueScope?.value?.trim(),
-      agents: [els.issueAgentA?.value?.trim(), els.issueAgentB?.value?.trim()],
-      authorities,
-      expiresAt: new Date(els.issueExpires.value).toISOString(),
-    };
+    const expiresAt = new Date(els.issueExpires.value).toISOString();
+    const pin = els.issuePin.value;
+    const agents = [els.issueAgentA?.value?.trim(), els.issueAgentB?.value?.trim()];
+    const fm = followMeTarget(authorities);
+    // Route an account-follow-me mandate through the one-dashboard issue+deliver path; everything
+    // else through the ordinary issue path.
+    const endpoint = fm ? '/mandate/issue-for-machine' : '/mandate/issue';
+    const payload = fm
+      ? { pin, scope: els.issueScope?.value?.trim(), agents, expiresAt, accountId: fm.accountId, targetMachineId: fm.targetMachineId }
+      : { pin, scope: els.issueScope?.value?.trim(), agents, authorities, expiresAt };
     els.issueBtn.disabled = true;
     try {
-      const { status, body } = await fetchJson('/mandate/issue', {
+      const { status, body } = await fetchJson(endpoint, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(payload),
       });
       if (els.issuePin) els.issuePin.value = ''; // never retain the PIN
       if (status === 201) {
-        note(`✓ Mandate ${body?.mandate?.id ?? ''} issued — it is active and listed above. The agents can now act within its bounds.`, 'success');
+        const deliveredNote = fm
+          ? (body?.delivered ? ' and delivered to the target machine' : (body?.local ? ' (target is this machine)' : ''))
+          : '';
+        note(`✓ Mandate ${body?.mandate?.id ?? ''} issued${deliveredNote} — it is active and listed above. The agents can now act within its bounds.`, 'success');
         if (els.issueDetails) els.issueDetails.open = false;
+        await refresh();
+      } else if (fm && status === 502) {
+        // Issued locally but cross-machine DELIVERY failed — honest, retry-able.
+        note(`Mandate ${body?.mandate?.id ?? ''} issued, but delivery to the target failed: ${body?.reason ?? body?.error ?? `HTTP ${status}`}. Retry to re-deliver (issuance is idempotent on the target).`, 'error');
         await refresh();
       } else {
         note(`Not issued — the server refused: ${body?.error ?? `HTTP ${status}`}`, 'error');

--- a/src/commands/server.ts
+++ b/src/commands/server.ts
@@ -489,6 +489,15 @@ let _sendDrain:
     >)
   | null = null;
 let _listPoolMachines: (() => Array<{ machineId: string; nickname?: string; lastKnownUrl?: string | null }>) | null = null;
+/** WS5.2 R4a — operator/issuer leg: deliver an R4a-signed account-follow-me mandate to a REMOTE
+ *  target over the signed mesh (the new verb). Set in the mesh-client block; null = no mesh client
+ *  (single-machine) → the issue-for-machine route 503s on a remote target. */
+let _deliverMandateToMachine:
+  | ((args: {
+      targetMachineId: string;
+      portable: import('../coordination/AccountFollowMeMandateBridge.js').PortableMandate;
+    }) => Promise<{ ok: boolean; status: number; reason?: string }>)
+  | null = null;
 /** Multi-Machine Session Pool §L4: per-topic placement pin store ("move this to <nickname>"). */
 let _topicPinStore: import('../core/TopicPlacementPinStore.js').TopicPlacementPinStore | null = null;
 /** Cross-machine secret-sync (spec Phase 4): route-facing handle (push lever + read-only status). */
@@ -16110,6 +16119,18 @@ export async function startServer(options: StartOptions): Promise<void> {
             routerHolder: () => coordinator?.getSyncStatus().leaseHolder ?? null,
             ownerOf: (s) => ownReg.ownerOf(s),
             placementTargetOf: (s) => ownReg.placementTargetOf(s),
+            // WS5.2 R4a — the COARSE gate for account-follow-me-mandate-deliver: follow-me must be
+            // enabled on THIS machine AND the sender a registered ACTIVE peer (verifyEnvelope already
+            // proved the Ed25519/recipient/nonce). DENY-BY-DEFAULT (dark agent → refused here). The
+            // LOAD-BEARING authority is the R4a signature re-verification in the handler below.
+            authorizeMandateDeliver: ({ sender }) => {
+              const afmEnabled = resolveDevAgentGate(
+                (config as { multiMachine?: { accountFollowMe?: { enabled?: boolean } } })
+                  .multiMachine?.accountFollowMe?.enabled,
+                config,
+              );
+              return afmEnabled && meshIdMgr.isMachineActive(sender);
+            },
           },
           recordNonce: (s, n) => {
             const t = Date.now();
@@ -16338,6 +16359,21 @@ export async function startServer(options: StartOptions): Promise<void> {
               _secretShareHandler
                 ? _secretShareHandler.handle(cmd as { type: 'secret-share'; encrypted: string }, sender)
                 : { ok: false, reason: 'secret-sync disabled' },
+            // WS5.2 R4a — ONE-DASHBOARD cross-machine mandate DELIVERY (target side). The operator
+            // issued the account-follow-me mandate (PIN-gated) on their single dashboard and
+            // delivered it here. verifyEnvelope already authenticated `sender` (Ed25519, recipient,
+            // nonce, registered-peer); the LOAD-BEARING authority is the R4a issuance-signature
+            // re-verification, done by AgentServer.acceptDeliveredMandateCommand against the SAME
+            // registered operator key verifyEnvelope used (resolved here, NEVER from the payload).
+            // FAIL CLOSED on every uncertainty; an unverified mandate is never persisted.
+            'account-follow-me-mandate-deliver': (cmd, sender) => {
+              const c = cmd as import('../core/MeshRpc.js').MeshCommand & { type: 'account-follow-me-mandate-deliver' };
+              // Resolve the AUTHENTICATED sender's REGISTERED Ed25519 public key — the trust anchor.
+              const operatorPem = meshIdMgr.getSigningPublicKeyPem(sender);
+              const r = _agentServerRef?.acceptDeliveredMandateCommand(sender, c.portable, operatorPem)
+                ?? { accepted: false, reason: 'agent-server-not-ready' };
+              return r;
+            },
             // WS4.4 holder side (MULTI-MACHINE-SEAMLESSNESS-SPEC §WS4.4). The
             // verifyEnvelope gate already proved WHICH fronting machine is asking
             // (`sender` = the authenticated, registered peer — used as the
@@ -16421,6 +16457,33 @@ export async function startServer(options: StartOptions): Promise<void> {
           const peerUrl = (machineId: string): string | null =>
             meshIdMgr.getActiveMachines().find((m) => m.machineId === machineId)?.entry.lastKnownUrl ?? null;
           _meshSelfId = meshSelfId;
+          // WS5.2 R4a — operator/issuer leg: deliver an R4a-signed account-follow-me mandate to a
+          // REMOTE target over the signed mesh `account-follow-me-mandate-deliver` verb. Every
+          // failure shape maps to an explicit outcome the issue-for-machine route surfaces honestly
+          // (the mandate is already issued+persisted locally; only delivery may fail → retry-able).
+          _deliverMandateToMachine = async ({ targetMachineId, portable }) => {
+            const url = peerUrl(targetMachineId);
+            if (!url) return { ok: false, status: 0, reason: 'no-peer-url' };
+            try {
+              const res = await meshClient.send(
+                { machineId: targetMachineId, url },
+                { type: 'account-follow-me-mandate-deliver', portable },
+                0,
+                { timeoutMs: 15_000 },
+              );
+              if (res.ok) {
+                const r = (res.result ?? {}) as { accepted?: boolean; reason?: string };
+                return r.accepted === true
+                  ? { ok: true, status: 200 }
+                  : { ok: false, status: 200, reason: typeof r.reason === 'string' ? r.reason : 'target-refused' };
+              }
+              return { ok: false, status: res.status, reason: res.reason ?? `status-${res.status}` };
+            } catch (err) {
+              // @silent-fallback-ok — a failed delivery RPC returns ok:false to the route, which
+              // surfaces a retry-able 502 (the mandate is safe locally); never a stuck/half delivery.
+              return { ok: false, status: 0, reason: err instanceof Error ? err.message : String(err) };
+            }
+          };
           // WS1.2 sender leg: signed drain order to a remote owner. Bounded by
           // the drain bound + slack so a clean drain (≤30s wait + close) can
           // complete within one call; every failure shape maps to an explicit
@@ -17805,7 +17868,7 @@ export async function startServer(options: StartOptions): Promise<void> {
             carrier: _topicProfileCarrier,
           }
         : null;
-    const server = new AgentServer({ config, sessionManager, state, scheduler, telegram, relationships, feedback, feedbackAnomalyDetector, dispatches, updateChecker, autoUpdater, autoDispatcher, quotaTracker, quotaManager, publisher, viewer, tunnel, evolution, watchdog, topicMemory, triageNurse, projectMapper, cartographer: cartographer ?? undefined, coherenceGate: scopeVerifier, contextHierarchy, canonicalState, operationGate, sentinel, adaptiveTrust, memoryMonitor, orphanReaper, coherenceMonitor, commitmentTracker, subscriptionPool, accountFollowMePeerViews: async () => { const machines = (_listPoolMachines?.() ?? []).filter((m) => m.machineId !== _meshSelfId && !!m.lastKnownUrl); if (machines.length === 0) return []; const { fetchPeerSubscriptionViews } = await import('../core/fetchPeerSubscriptionViews.js'); return fetchPeerSubscriptionViews({ peers: () => machines.map((m) => ({ machineId: m.machineId, nickname: m.nickname ?? m.machineId, url: m.lastKnownUrl as string })), fetchImpl: fetch as unknown as Parameters<typeof fetchPeerSubscriptionViews>[0]['fetchImpl'], authToken: config.authToken ?? '' }); }, quotaPoller, quotaAwareScheduler: _quotaAwareScheduler ?? undefined, proactiveSwapMonitor: _proactiveSwapMonitor ?? undefined, inUseAccountResolver, enrollmentWizard, accountFollowMeRevocation, credentialRepointing, semanticMemory, activitySentinel, rateLimitSentinel, releaseReadinessSentinel: releaseReadinessSentinel ?? undefined, greenPrAutoMerger: greenPrAutoMerger ?? undefined, guardLatchStore: guardLatchStore ?? undefined, messageRouter, summarySentinel, spawnManager, systemReviewer, capabilityMapper, selfKnowledgeTree, coverageAuditor, topicResumeMap: _topicResumeMap ?? undefined, topicProfile: _topicProfileCtx ?? undefined, sessionRefresh: _sessionRefresh ?? undefined, autonomyManager, trustElevationTracker, autonomousEvolution, coordinator: coordinator.enabled ? coordinator : undefined, localSigningKeyPem, leaseTransport, onLeasePullRequest: () => leaseCoordinatorRef?.currentLease() ?? null, liveTailReceiver, handoffWireTransport, onHandoffBegin, onHandoffInitiate: handoffInitiate, handoffInProgress: handoffSentinelInProgress, messageLedger, currentInboundByTopic, replyMarkerTransport, onReplyMarker: messageLedger ? (marker: unknown) => { const m = marker as { dedupeKey: string; platform: string; replyIdempotencyKey: string; epoch: number; topic?: string | null }; messageLedger!.applyRemoteReplyMarker(m.dedupeKey, { platform: m.platform, replyIdempotencyKey: m.replyIdempotencyKey, epoch: m.epoch, topic: m.topic ?? null }); } : undefined, whatsapp: whatsappAdapter, slack: slackAdapter, imessage: imessageAdapter, whatsappBusinessBackend, messageBridge, hookEventReceiver, worktreeMonitor, subagentTracker, instructionsVerifier, handshakeManager: threadlineHandshake, threadlineRouter, conversationStore, threadLog, threadMessageRecorder, warrantsReplyGate, collaborationSurfacer, threadResumeMap, topicLinkageHandler: topicLinkageHandler ?? undefined, threadlineRelayClient, threadlineReplyWaiters, listenerManager: listenerManager ?? undefined, a2aDeliveryTracker: a2aDeliveryTracker ?? undefined, responseReviewGate, messagingToneGate, outboundDedupGate, telemetryHeartbeat, pasteManager, featureRegistry, discoveryEvaluator, completionEvaluator, unifiedTrust, liveConfig, sharedStateLedger, ledgerSessionRegistry, worktreeManager, oidcEnrolledRepos: parallelDevConfig?.oidcEnrolledRepos, initiativeTracker, projectRoundRunner, projectDriftChecker, machineHeartbeat, machinePoolRegistry, getInboundQueue: () => _inboundQueue, meshRpcDispatcher, workingSetPullCoordinator, commitmentReplicaStore, preferenceReplicaStore, replicatedRecordEmitter, conflictStore, rollbackUnmerge, droppedOriginRegistry, preferencesUnionReader, forwardCommitmentMutate, sessionOwnershipRegistry, topicPinStore: _topicPinStore ?? undefined, streamTicketStore: _streamTicketStore ?? undefined, poolStreamAllowRemoteInput: (config as { dashboard?: { poolStream?: { allowRemoteInput?: boolean } } }).dashboard?.poolStream?.allowRemoteInput ?? false, poolStreamConnector: _poolStreamConnector ?? undefined, secretSync: _secretSyncHandle ?? undefined, meshSelfId: _meshSelfId ?? undefined, resolveRouterUrl: _resolveRouterUrl ?? undefined, resolvePeerUrls: _resolvePeerUrls ?? undefined, guardRegistry, listPoolMachines: _listPoolMachines ?? undefined, poolLink: _poolLink ?? undefined, poolPollCache: _poolPollCache ?? undefined, sessionPoolE2EResultStore, proxyCoordinator, topicIntentStore, topicIntentArcCheck, usherSignalStore, intelligence: sharedIntelligence ?? undefined, telegramBridgeConfig, telegramBridge: telegramBridge ?? undefined, threadlineObservability, briefDeps, workingMemory, taskFlowRegistry, threadlineFlowBridge, sessionReaper, agentWorktreeReaper, orphanedWorkSentinel, mcpProcessReaper, geminiLoopRunner, sleepController, agentActivityState, reapLog, resumeQueue, resumeDrainer, autonomousLivenessReconciler, prHandLease: prHandLease ?? undefined, operatorStopRecorder: recordOperatorStop, sleepWakeDetector, unjustifiedStopGate, stopGateDb, stopNotifier, liveTestGate, liveTestGateMode, liveTestRunnerCtx });    // Resolve the late-bound topic-operator getter (increment 2e): routing was
+    const server = new AgentServer({ config, sessionManager, state, scheduler, telegram, relationships, feedback, feedbackAnomalyDetector, dispatches, updateChecker, autoUpdater, autoDispatcher, quotaTracker, quotaManager, publisher, viewer, tunnel, evolution, watchdog, topicMemory, triageNurse, projectMapper, cartographer: cartographer ?? undefined, coherenceGate: scopeVerifier, contextHierarchy, canonicalState, operationGate, sentinel, adaptiveTrust, memoryMonitor, orphanReaper, coherenceMonitor, commitmentTracker, subscriptionPool, accountFollowMePeerViews: async () => { const machines = (_listPoolMachines?.() ?? []).filter((m) => m.machineId !== _meshSelfId && !!m.lastKnownUrl); if (machines.length === 0) return []; const { fetchPeerSubscriptionViews } = await import('../core/fetchPeerSubscriptionViews.js'); return fetchPeerSubscriptionViews({ peers: () => machines.map((m) => ({ machineId: m.machineId, nickname: m.nickname ?? m.machineId, url: m.lastKnownUrl as string })), fetchImpl: fetch as unknown as Parameters<typeof fetchPeerSubscriptionViews>[0]['fetchImpl'], authToken: config.authToken ?? '' }); }, quotaPoller, quotaAwareScheduler: _quotaAwareScheduler ?? undefined, proactiveSwapMonitor: _proactiveSwapMonitor ?? undefined, inUseAccountResolver, enrollmentWizard, accountFollowMeRevocation, credentialRepointing, semanticMemory, activitySentinel, rateLimitSentinel, releaseReadinessSentinel: releaseReadinessSentinel ?? undefined, greenPrAutoMerger: greenPrAutoMerger ?? undefined, guardLatchStore: guardLatchStore ?? undefined, messageRouter, summarySentinel, spawnManager, systemReviewer, capabilityMapper, selfKnowledgeTree, coverageAuditor, topicResumeMap: _topicResumeMap ?? undefined, topicProfile: _topicProfileCtx ?? undefined, sessionRefresh: _sessionRefresh ?? undefined, autonomyManager, trustElevationTracker, autonomousEvolution, coordinator: coordinator.enabled ? coordinator : undefined, localSigningKeyPem, leaseTransport, onLeasePullRequest: () => leaseCoordinatorRef?.currentLease() ?? null, liveTailReceiver, handoffWireTransport, onHandoffBegin, onHandoffInitiate: handoffInitiate, handoffInProgress: handoffSentinelInProgress, messageLedger, currentInboundByTopic, replyMarkerTransport, onReplyMarker: messageLedger ? (marker: unknown) => { const m = marker as { dedupeKey: string; platform: string; replyIdempotencyKey: string; epoch: number; topic?: string | null }; messageLedger!.applyRemoteReplyMarker(m.dedupeKey, { platform: m.platform, replyIdempotencyKey: m.replyIdempotencyKey, epoch: m.epoch, topic: m.topic ?? null }); } : undefined, whatsapp: whatsappAdapter, slack: slackAdapter, imessage: imessageAdapter, whatsappBusinessBackend, messageBridge, hookEventReceiver, worktreeMonitor, subagentTracker, instructionsVerifier, handshakeManager: threadlineHandshake, threadlineRouter, conversationStore, threadLog, threadMessageRecorder, warrantsReplyGate, collaborationSurfacer, threadResumeMap, topicLinkageHandler: topicLinkageHandler ?? undefined, threadlineRelayClient, threadlineReplyWaiters, listenerManager: listenerManager ?? undefined, a2aDeliveryTracker: a2aDeliveryTracker ?? undefined, responseReviewGate, messagingToneGate, outboundDedupGate, telemetryHeartbeat, pasteManager, featureRegistry, discoveryEvaluator, completionEvaluator, unifiedTrust, liveConfig, sharedStateLedger, ledgerSessionRegistry, worktreeManager, oidcEnrolledRepos: parallelDevConfig?.oidcEnrolledRepos, initiativeTracker, projectRoundRunner, projectDriftChecker, machineHeartbeat, machinePoolRegistry, getInboundQueue: () => _inboundQueue, meshRpcDispatcher, workingSetPullCoordinator, commitmentReplicaStore, preferenceReplicaStore, replicatedRecordEmitter, conflictStore, rollbackUnmerge, droppedOriginRegistry, preferencesUnionReader, forwardCommitmentMutate, sessionOwnershipRegistry, topicPinStore: _topicPinStore ?? undefined, streamTicketStore: _streamTicketStore ?? undefined, poolStreamAllowRemoteInput: (config as { dashboard?: { poolStream?: { allowRemoteInput?: boolean } } }).dashboard?.poolStream?.allowRemoteInput ?? false, poolStreamConnector: _poolStreamConnector ?? undefined, secretSync: _secretSyncHandle ?? undefined, meshSelfId: _meshSelfId ?? undefined, resolveRouterUrl: _resolveRouterUrl ?? undefined, resolvePeerUrls: _resolvePeerUrls ?? undefined, guardRegistry, listPoolMachines: _listPoolMachines ?? undefined, deliverMandateToMachine: _deliverMandateToMachine ?? undefined, poolLink: _poolLink ?? undefined, poolPollCache: _poolPollCache ?? undefined, sessionPoolE2EResultStore, proxyCoordinator, topicIntentStore, topicIntentArcCheck, usherSignalStore, intelligence: sharedIntelligence ?? undefined, telegramBridgeConfig, telegramBridge: telegramBridge ?? undefined, threadlineObservability, briefDeps, workingMemory, taskFlowRegistry, threadlineFlowBridge, sessionReaper, agentWorktreeReaper, orphanedWorkSentinel, mcpProcessReaper, geminiLoopRunner, sleepController, agentActivityState, reapLog, resumeQueue, resumeDrainer, autonomousLivenessReconciler, prHandLease: prHandLease ?? undefined, operatorStopRecorder: recordOperatorStop, sleepWakeDetector, unjustifiedStopGate, stopGateDb, stopNotifier, liveTestGate, liveTestGateMode, liveTestRunnerCtx });    // Resolve the late-bound topic-operator getter (increment 2e): routing was
     // wired before the server existed; from here on inbound binds use the
     // server's own store instance.
     _agentServerRef = server;

--- a/src/config/ConfigDefaults.ts
+++ b/src/config/ConfigDefaults.ts
@@ -780,6 +780,29 @@ const SHARED_DEFAULTS: Record<string, unknown> = {
       // enrollment (/subscription-pool/enroll) is unchanged — it never reads this
       // and keeps the driver's 60s default.
       remoteScrapeTimeoutMs: 180000,
+      // WS5.2 R7a — per-account SPEND-SLICE control plane. The ceiling is denominated
+      // in provider quota-FRACTION (0..1); a borrowed account is sliced so the sum of
+      // OUTSTANDING slices across N machines can never exceed the ceiling (the
+      // sum-of-leases bound, owned by the FENCED lease holder). The renewal knobs below
+      // bound the requester-side control plane so N VMs on one hot account produce
+      // O(per-account-cap) renewal RPCs, never an O(N) herd:
+      //  - ceilingQuotaFraction: the account-wide spend ceiling (fraction of a provider
+      //    quota window) that the holder slices among machines (default 0.8 — leave the
+      //    holder's own headroom).
+      //  - minRenewIntervalMs: per-account renewal rate cap (the floor between RPCs).
+      //  - renewBackoffMultiplier / maxRenewIntervalMs: exponential backoff on refusal/
+      //    failure, ceilinged so the interval cannot grow unbounded.
+      //  - breakerThreshold / breakerCooldownMs: the P19 sustained-failure breaker — after
+      //    N consecutive transport FAILURES (slow/partitioned/unreachable holder) a VM
+      //    FAILS CLOSED TO ITS OWN ACCOUNT for the cooldown rather than retry-storming.
+      spendSlice: {
+        ceilingQuotaFraction: 0.8,
+        minRenewIntervalMs: 5000,
+        renewBackoffMultiplier: 2,
+        maxRenewIntervalMs: 300000,
+        breakerThreshold: 3,
+        breakerCooldownMs: 60000,
+      },
     },
     // WS3 one-voice gate (MULTI-MACHINE-SEAMLESSNESS-SPEC). Ships DARK: with
     // ws3OneVoice false the SpeakerElection returns "speak" unconditionally —

--- a/src/coordination/AccountFollowMeMandateDelivery.ts
+++ b/src/coordination/AccountFollowMeMandateDelivery.ts
@@ -1,0 +1,125 @@
+/**
+ * WS5.2 R4a — the TARGET-side acceptance of a cross-machine-delivered account-follow-me mandate.
+ *
+ * Pure logic over INJECTED seams (the operator-machine key resolver, the bounds expectation, the
+ * delivered-mandate store) so the dangerous authority decision is unit-testable without a server.
+ * This is the brains behind the `account-follow-me-mandate-deliver` mesh handler.
+ *
+ * THE TRUST MODEL (Know Your Principal — load-bearing):
+ *   - `sender` is the MESH-AUTHENTICATED operator machine (verifyEnvelope already proved the
+ *     Ed25519 signature, recipient-binding, freshness, and registered-peer status before this runs).
+ *     A name inside the payload is NEVER trusted; `sender` is the only fingerprint we anchor to.
+ *   - We resolve the operator machine's REGISTERED Ed25519 public key for `sender` (the SAME key
+ *     verifyEnvelope used), then `acceptDeliveredMandate` re-verifies the PortableMandate's OWN
+ *     asymmetric issuance signature against that key + `sender` as the expected operator fingerprint.
+ *     This proves the operator machine signed THIS mandate's canonical bytes (defense beyond the
+ *     envelope), and that the mandate's embedded issuerFingerprint === the authenticated sender.
+ *   - FAIL CLOSED on every uncertainty: feature dark, no operator key registered, signature fails,
+ *     wrong issuer, or the delivered bounds are not an exact account-follow-me/re-mint shape → REFUSE
+ *     and persist NOTHING. An unverified mandate never lands in the store.
+ *
+ * The accepted mandate's exact (accountId, targetMachineId, mechanism) bounds are validated to be a
+ * re-mint account-follow-me grant for THIS machine here too (so a malformed delivery is rejected at
+ * accept time); the enroll-start route re-verifies again at point-of-use (never trust a stored flag).
+ */
+
+import { acceptDeliveredMandate, type PortableMandate } from './AccountFollowMeMandateBridge.js';
+import type { DeliveredMandateStore } from './DeliveredMandateStore.js';
+
+export type MandateDeliveryResult =
+  | { accepted: true; mandateId: string }
+  | { accepted: false; reason: string };
+
+export interface AccountFollowMeMandateDeliveryDeps {
+  /** Is account follow-me enabled (resolved dev-gate) on THIS machine? Dark ⇒ refuse everything. */
+  enabled: () => boolean;
+  /** This machine's id — the delivered mandate's targetMachineId MUST equal it (exact-bounds, R1). */
+  selfMachineId: () => string;
+  /**
+   * The REGISTERED Ed25519 public key (PEM) for the AUTHENTICATED sender (the operator machine), or
+   * null if unknown. SAME source verifyEnvelope used (the registered machine-identity store) — NEVER
+   * a key from the payload. PEM (not a KeyObject) so the verified key is persisted for the
+   * point-of-use re-verify without a later peer-key lookup.
+   */
+  operatorMachinePublicKey: (sender: string) => string | null;
+  /** Durable store of accepted+verified delivered mandates. */
+  store: DeliveredMandateStore;
+  log?: (msg: string) => void;
+}
+
+/**
+ * Read the account-follow-me bounds off a (already-R4a-verified) mandate. Returns null when the
+ * mandate carries no account-follow-me authority (so a foreign mandate delivered here is refused).
+ */
+export function readFollowMeBounds(
+  mandate: PortableMandate['mandate'],
+): { accountId: string; targetMachineId: string; mechanism: string } | null {
+  const authority = (mandate.authorities ?? []).find((a) => a.action === 'account-follow-me');
+  if (!authority) return null;
+  const b = (authority.bounds ?? {}) as Record<string, unknown>;
+  const accountId = typeof b.accountId === 'string' ? b.accountId : '';
+  const targetMachineId = typeof b.targetMachineId === 'string' ? b.targetMachineId : '';
+  const mechanism = typeof b.mechanism === 'string' ? b.mechanism : '';
+  if (!accountId || !targetMachineId || !mechanism) return null;
+  return { accountId, targetMachineId, mechanism };
+}
+
+/**
+ * Accept (or refuse) a delivered account-follow-me mandate on the target. FAIL CLOSED.
+ * `sender` MUST be the mesh-authenticated envelope sender.
+ */
+export function acceptMandateDelivery(
+  deps: AccountFollowMeMandateDeliveryDeps,
+  sender: string,
+  portable: PortableMandate | undefined | null,
+): MandateDeliveryResult {
+  if (!deps.enabled()) return { accepted: false, reason: 'feature-disabled' };
+  if (!portable || !portable.mandate || !portable.issuanceSignature) {
+    return { accepted: false, reason: 'malformed-portable-mandate' };
+  }
+  if (!sender) return { accepted: false, reason: 'no-authenticated-sender' };
+
+  // Know Your Principal: resolve the operator machine's REGISTERED key for the AUTHENTICATED sender.
+  // No registered key ⇒ we cannot ground the trust anchor ⇒ refuse (deny-by-default).
+  const operatorKey = deps.operatorMachinePublicKey(sender);
+  if (!operatorKey) {
+    deps.log?.(`[account-follow-me] mandate-deliver refused: no registered operator key for ${sender}`);
+    return { accepted: false, reason: 'no-operator-key-registered' };
+  }
+
+  // R4a — the LOAD-BEARING authority: verify the asymmetric issuance signature against the
+  // registered operator key, binding the expected issuer to the authenticated sender (a payload
+  // name can never become the operator by construction).
+  const accept = acceptDeliveredMandate({
+    portable,
+    operatorEd25519PublicKey: operatorKey,
+    expectedOperatorMachineFingerprint: sender,
+  });
+  if (!accept.accepted) {
+    deps.log?.(`[account-follow-me] mandate-deliver refused: ${accept.reason}`);
+    return { accepted: false, reason: accept.reason };
+  }
+
+  // Exact-bounds (R1): the mandate MUST be a re-mint account-follow-me grant for THIS machine.
+  // A foreign or mis-targeted mandate is refused — it can never be replayed for another machine.
+  const bounds = readFollowMeBounds(accept.mandate);
+  if (!bounds) return { accepted: false, reason: 'not-an-account-follow-me-mandate' };
+  if (bounds.targetMachineId !== deps.selfMachineId()) {
+    deps.log?.(
+      `[account-follow-me] mandate-deliver refused: target ${bounds.targetMachineId} !== this machine`,
+    );
+    return { accepted: false, reason: 'target-not-this-machine' };
+  }
+  if (bounds.mechanism !== 're-mint') {
+    return { accepted: false, reason: `unsupported-mechanism:${bounds.mechanism}` };
+  }
+
+  // Verified — persist the FULL portable bundle (so enroll-start can re-verify at point-of-use) +
+  // the authenticated delivering operator machine AND the registered operator key the R4a signature
+  // verified against (the trust anchor for that re-verify, re-bound without a later peer-key lookup).
+  deps.store.put(portable, sender, operatorKey);
+  deps.log?.(
+    `[account-follow-me] accepted delivered mandate ${accept.mandate.id} (account=${bounds.accountId}) from ${sender}`,
+  );
+  return { accepted: true, mandateId: accept.mandate.id };
+}

--- a/src/coordination/DeliveredMandateStore.ts
+++ b/src/coordination/DeliveredMandateStore.ts
@@ -1,0 +1,111 @@
+/**
+ * WS5.2 R4a — durable store of cross-machine-DELIVERED account-follow-me mandates.
+ *
+ * THE ONE-DASHBOARD PROBLEM (operator feedback, load-bearing): the operator has ONE dashboard.
+ * An account-follow-me enrollment is acted on by the TARGET machine, but a mandate is issued
+ * (PIN-gated) on the operator's machine. A mandate issued on the laptop has LAPTOP authorship
+ * (a symmetric HMAC over the laptop's per-machine authToken, §3.1a) and will NOT pass the target's
+ * `MandateStore.verifyAuthorship` — by design. So the operator dashboard issues the mandate and
+ * DELIVERS it (the R4a-signed `PortableMandate`) to the target over the mesh, where it is verified
+ * via the asymmetric issuance signature against the target's REGISTERED operator-machine key.
+ *
+ * This store is where a target persists a delivered+verified mandate. It retains the FULL
+ * `PortableMandate` (the mandate AND its asymmetric issuance signature), keyed by mandate id, so
+ * the enroll-start route can RE-VERIFY at point-of-use (defense-in-depth — never trust a stored
+ * flag blindly; the §3.1a HMAC proof is local-only and cannot ground a delivered mandate, so the
+ * R4a signature is the standing proof of authority). It also records the authenticated operator
+ * machine that delivered it (the mesh-authenticated `env.sender`) so the re-verify at use time
+ * binds to the SAME trust anchor.
+ *
+ * Trust boundary (same root as MandateStore): integrity of the on-disk file against a LOCAL-write
+ * attacker is the baseline (T12, out of scope). The R4a signature stops a forged/edited delivered
+ * mandate from a hostile peer — local-file tamper of server-managed state is the baseline boundary.
+ *
+ * Pure file-state, no DB (file-based-state design decision). Mirrors MandateStore's read/write
+ * shape. WS5.2 one-dashboard cross-machine mandate delivery.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import type { PortableMandate } from './AccountFollowMeMandateBridge.js';
+
+/** A delivered mandate as persisted on the target: the portable bundle + its delivery provenance. */
+export interface DeliveredMandateRecord {
+  /** The mandate id (the store key). */
+  id: string;
+  /** The full R4a-signed bundle — retained so the bounds + provenance + signature survive for
+   *  point-of-use re-verification. */
+  portable: PortableMandate;
+  /** The mesh-AUTHENTICATED operator machine that delivered it (env.sender) — the trust anchor
+   *  the enroll-start re-verify must bind to. NEVER a name from the payload. */
+  deliveredBy: string;
+  /** The REGISTERED operator-machine Ed25519 public key (PEM) the R4a signature verified against at
+   *  delivery — recorded so the point-of-use re-verify re-binds to the SAME anchor WITHOUT needing a
+   *  peer-key lookup. This is a PUBLIC key (never a secret); persisting it is safe. */
+  operatorPublicKeyPem: string;
+  /** When the target accepted+persisted it (ISO). */
+  deliveredAt: string;
+}
+
+export interface DeliveredMandateStoreDeps {
+  /** Absolute path to the delivered-mandates JSON file. */
+  filePath: string;
+  now?: () => number;
+}
+
+export class DeliveredMandateStore {
+  private readonly d: DeliveredMandateStoreDeps;
+  constructor(deps: DeliveredMandateStoreDeps) {
+    this.d = deps;
+  }
+
+  private nowIso(): string {
+    return new Date(this.d.now ? this.d.now() : Date.now()).toISOString();
+  }
+
+  private readAll(): DeliveredMandateRecord[] {
+    try {
+      const raw = JSON.parse(fs.readFileSync(this.d.filePath, 'utf8'));
+      return Array.isArray(raw) ? (raw as DeliveredMandateRecord[]) : [];
+    } catch {
+      // @silent-fallback-ok — file may not exist yet; an empty store is DENY-BY-DEFAULT (the safe state).
+      return [];
+    }
+  }
+
+  private writeAll(records: DeliveredMandateRecord[]): void {
+    fs.mkdirSync(path.dirname(this.d.filePath), { recursive: true });
+    fs.writeFileSync(this.d.filePath, JSON.stringify(records, null, 2));
+  }
+
+  /**
+   * Persist a delivered+verified mandate (called by the mesh handler ONLY after `acceptDeliveredMandate`
+   * verified the R4a signature). `deliveredBy` is the mesh-AUTHENTICATED sender, NOT a payload name.
+   * Idempotent by mandate id (a redelivery overwrites with the latest provenance).
+   */
+  put(portable: PortableMandate, deliveredBy: string, operatorPublicKeyPem: string): DeliveredMandateRecord {
+    const id = portable.mandate.id;
+    const record: DeliveredMandateRecord = {
+      id, portable, deliveredBy, operatorPublicKeyPem, deliveredAt: this.nowIso(),
+    };
+    const all = this.readAll().filter((r) => r.id !== id);
+    all.push(record);
+    this.writeAll(all);
+    return record;
+  }
+
+  get(id: string): DeliveredMandateRecord | undefined {
+    return this.readAll().find((r) => r.id === id);
+  }
+
+  list(): DeliveredMandateRecord[] {
+    return this.readAll();
+  }
+
+  /** Remove a delivered mandate (e.g. on revocation). Idempotent. */
+  remove(id: string): void {
+    const all = this.readAll();
+    const next = all.filter((r) => r.id !== id);
+    if (next.length !== all.length) this.writeAll(next);
+  }
+}

--- a/src/core/AccountFollowMeSpendSlice.ts
+++ b/src/core/AccountFollowMeSpendSlice.ts
@@ -1,0 +1,303 @@
+/**
+ * WS5.2 R7a — per-account spend-slice ORCHESTRATION (the LEASE-SLICED ceiling, owned by the
+ * fenced single-writer). This is the cohesive control-plane unit on top of the durable
+ * `AccountFollowMeGrantLedger` (AccountFollowMeGrants.ts), kept PURE + injectable so the
+ * distributed math is unit-testable without a live mesh.
+ *
+ * Spec bounds enforced here (docs/specs/ws52-account-follow-me-security.md §R7a, §S5, §I5):
+ *
+ *  (a) FENCED single-writer issuance. Slices are issued ONLY by the current `FencedLease` holder;
+ *      a non-holder issuing is refused (`not-lease-holder`). Issuance is epoch-fenced: a renew
+ *      stamped with a stale lease epoch is void (`stale-lease-epoch`). On a holder FAILOVER the new
+ *      holder constructs `SliceIssuer` over the SAME durable ledger and re-derives outstanding
+ *      slices BEFORE issuing — the ledger's sum-of-leases bound holds across the handoff with no
+ *      double-allocation (proven in AccountFollowMeGrants).
+ *
+ *  (b) `maxSpend` is denominated in provider quota-FRACTION (0..1), reusing AccountQuotaSnapshot.
+ *      The issuer takes the ceiling as a fraction; per-slice consumption is the durable grant amount.
+ *
+ *  (c) The requester-side renewal CONTROL PLANE is rate-capped + coalesced + P19-breaker-protected,
+ *      so N VMs on one hot account produce O(per-account-cap) renewal RPCs — never an O(N) herd:
+ *        - per-(account,machine) in-flight COALESCING: a VM with an outstanding renewal does not
+ *          start a second (`coalesced-in-flight`);
+ *        - per-account renewal RATE CAP with EXPONENTIAL backoff after each refusal/failure;
+ *        - a P19 sustained-FAILURE breaker: after `breakerThreshold` consecutive failures the VM
+ *          FAILS CLOSED TO ITS OWN ACCOUNT (`breaker-open`) instead of retry-storming a slow/
+ *          partitioned/unreachable holder. The breaker re-closes after `breakerCooldownMs`.
+ *
+ *  (d) FIRST-SLICE-under-partition: a VM that never received a slice is treated identically to a
+ *      VM whose slice is exhausted — it FAILS CLOSED TO ITS OWN ACCOUNT until it obtains its first
+ *      slice (the `decideAccountUse` consultation below).
+ *
+ * INVARIANT (load-bearing): fail-closed-to-OWN-account on EVERY uncertainty — no slice, exhausted,
+ * partition, breaker open, no mandate, ledger error. A borrowed account is NEVER overspent past its
+ * grant. Everything stays dark behind `multiMachine.accountFollowMe` at the wiring layer.
+ */
+
+import {
+  AccountFollowMeGrantLedger,
+  type GrantStore,
+  type IssueResult,
+} from './AccountFollowMeGrants.js';
+
+// ───────────────────────────── Issuer side (the fenced holder) ─────────────────────────────
+
+export interface SliceIssuerConfig {
+  /** This machine's id — must equal the lease holder for issuance to be authorized. */
+  selfMachineId: string;
+  /**
+   * The current effective lease epoch + whether THIS machine holds the lease at it. Read live so a
+   * mid-flight failover (we lost the lease) refuses issuance rather than double-allocating.
+   */
+  holdsLease: () => boolean;
+  currentLeaseEpoch: () => number;
+  now?: () => number;
+}
+
+/** The renewal request a requesting VM sends to the holder (the `slice-renew` verb payload, decoded). */
+export interface SliceRenewRequest {
+  grantId: string;
+  mandateId: string;
+  accountId: string;
+  /** Requesting machine's routing fingerprint (carried in the verb; bound into the grant). */
+  requestingMachineFp: string;
+  /** Slice size requested (provider quota-fraction). */
+  amount: number;
+  /** Absolute expiry of the slice (ms since epoch). */
+  expiresAt: number;
+}
+
+export interface SliceIssuanceContext {
+  /** The account's spend ceiling (provider quota-fraction, 0..1) — from the live grant/quota policy. */
+  ceiling: number;
+}
+
+export type SliceIssueOutcome =
+  | { ok: true; grantId: string; amount: number; leaseEpoch: number; expiresAt: number }
+  | { ok: false; reason: string };
+
+/**
+ * The HOLDER-side issuer. Runs ON the fenced lease holder (the `slice-renew` handler wires this).
+ * Refuses unless this machine genuinely holds the lease right now, then delegates the sum-of-leases
+ * accounting to the durable ledger (single source of truth, re-derived on every call → failover-safe).
+ */
+export class SliceIssuer {
+  private readonly ledger: AccountFollowMeGrantLedger;
+  private readonly now: () => number;
+
+  constructor(
+    store: GrantStore,
+    private readonly cfg: SliceIssuerConfig,
+  ) {
+    this.now = cfg.now ?? Date.now;
+    this.ledger = new AccountFollowMeGrantLedger(store, this.now);
+  }
+
+  /** Outstanding committed slices for an account (re-derived from the durable ledger). */
+  outstandingFor(accountId: string): number {
+    return this.ledger.outstandingFor(accountId);
+  }
+
+  /**
+   * Issue (or re-issue) a slice in response to a renew request. FENCED: refuses unless this machine
+   * holds the lease at the current epoch. The slice is stamped with the CURRENT lease epoch, so it is
+   * void at a later epoch (consume/renew checks via the ledger). The ledger enforces the sum-of-leases
+   * ceiling and single-use grant ids.
+   */
+  issueForRenew(req: SliceRenewRequest, ctx: SliceIssuanceContext): SliceIssueOutcome {
+    // (a) FENCED single-writer: only the live lease holder may issue. A non-holder (e.g. a stale
+    //     ex-holder mid-failover) refuses — the safe direction (no double-allocation).
+    if (!this.cfg.holdsLease()) {
+      return { ok: false, reason: 'not-lease-holder' };
+    }
+    const leaseEpoch = this.cfg.currentLeaseEpoch();
+    const result: IssueResult = this.ledger.issue({
+      grantId: req.grantId,
+      mandateId: req.mandateId,
+      accountId: req.accountId,
+      targetFingerprint: req.requestingMachineFp,
+      amount: req.amount,
+      ceiling: ctx.ceiling,
+      leaseEpoch,
+      expiresAt: req.expiresAt,
+    });
+    if (!result.ok) return { ok: false, reason: result.reason };
+    return {
+      ok: true,
+      grantId: result.grant.grantId,
+      amount: result.grant.amount,
+      leaseEpoch: result.grant.leaseEpoch,
+      expiresAt: result.grant.expiresAt,
+    };
+  }
+}
+
+// ───────────────────────── Requester side (renewal control plane) ─────────────────────────
+
+export interface SliceLeaseState {
+  /** The grant id of the slice this VM currently holds for the account, if any. */
+  grantId?: string;
+  /** Remaining unspent budget on the held slice (provider quota-fraction). */
+  remaining: number;
+  /** Lease epoch the held slice was issued under — void if the holder advanced past it. */
+  leaseEpoch: number;
+  /** Absolute expiry of the held slice (ms since epoch). */
+  expiresAt: number;
+}
+
+export interface RenewControlConfig {
+  /**
+   * Minimum interval between renewal RPCs for ONE account on this machine (ms). The per-account
+   * rate cap — combined with coalescing + the holder's own ceiling, the worst-case fleet renewal
+   * rate is O(per-account-cap), independent of N. Default 5000.
+   */
+  minRenewIntervalMs?: number;
+  /** Exponential-backoff multiplier applied to the interval after each refusal/failure. Default 2. */
+  backoffMultiplier?: number;
+  /** Backoff ceiling (ms) so the interval cannot grow unbounded. Default 300000 (5m). */
+  maxRenewIntervalMs?: number;
+  /** Consecutive failures before the P19 breaker opens (fail closed to own account). Default 3. */
+  breakerThreshold?: number;
+  /** How long the breaker stays open before a probe is allowed again (ms). Default 60000. */
+  breakerCooldownMs?: number;
+  now?: () => number;
+}
+
+export type RenewAttemptDecision =
+  | { proceed: true }
+  | { proceed: false; reason: 'coalesced-in-flight' | 'rate-capped' | 'breaker-open' };
+
+export type RenewOutcomeKind = 'issued' | 'refused' | 'failed';
+
+/**
+ * The per-machine requester-side renewal control plane for ONE account. Pure state-machine: a caller
+ * asks `shouldAttempt()` before sending a `slice-renew` RPC, marks `beginAttempt()` when it sends,
+ * and reports `recordOutcome()` with the result. It enforces coalescing, the rate cap with
+ * exponential backoff, and the P19 breaker — so the transport above it can be a thin RPC.
+ */
+export class SliceRenewalControl {
+  private readonly minInterval: number;
+  private readonly backoffMul: number;
+  private readonly maxInterval: number;
+  private readonly breakerThreshold: number;
+  private readonly breakerCooldownMs: number;
+  private readonly now: () => number;
+
+  private inFlight = false;
+  private lastAttemptAt = -Infinity;
+  /** Current backoff interval (grows on refusal/failure, resets on success). */
+  private currentInterval: number;
+  private consecutiveFailures = 0;
+  private breakerOpenedAt: number | null = null;
+
+  constructor(cfg: RenewControlConfig = {}) {
+    this.minInterval = cfg.minRenewIntervalMs ?? 5000;
+    this.backoffMul = cfg.backoffMultiplier ?? 2;
+    this.maxInterval = cfg.maxRenewIntervalMs ?? 300000;
+    this.breakerThreshold = cfg.breakerThreshold ?? 3;
+    this.breakerCooldownMs = cfg.breakerCooldownMs ?? 60000;
+    this.now = cfg.now ?? Date.now;
+    this.currentInterval = this.minInterval;
+  }
+
+  /** Is the P19 breaker currently open (a probe not yet allowed)? */
+  breakerOpen(): boolean {
+    if (this.breakerOpenedAt === null) return false;
+    return this.now() - this.breakerOpenedAt < this.breakerCooldownMs;
+  }
+
+  /**
+   * May this VM send a renewal RPC for the account right now? Refuses (fail-closed at the call site)
+   * when a renewal is already in flight (coalescing), the rate cap has not elapsed, or the breaker is
+   * open. The caller treats any `proceed:false` as "use my OWN account this turn."
+   */
+  shouldAttempt(): RenewAttemptDecision {
+    if (this.inFlight) return { proceed: false, reason: 'coalesced-in-flight' };
+    if (this.breakerOpen()) return { proceed: false, reason: 'breaker-open' };
+    if (this.now() - this.lastAttemptAt < this.currentInterval) {
+      return { proceed: false, reason: 'rate-capped' };
+    }
+    return { proceed: true };
+  }
+
+  /** Mark a renewal RPC as started (coalescing latch). Must be paired with recordOutcome(). */
+  beginAttempt(): void {
+    this.inFlight = true;
+    this.lastAttemptAt = this.now();
+  }
+
+  /**
+   * Report the RPC result, advancing the control state:
+   *  - issued  → reset backoff + breaker (the channel is healthy again);
+   *  - refused → grant-level refusal (e.g. would-exceed-ceiling); back off, but NOT a transport
+   *              failure, so it does not advance the breaker (the holder answered);
+   *  - failed  → transport failure (timeout/partition/unreachable); back off AND advance the breaker.
+   */
+  recordOutcome(kind: RenewOutcomeKind): void {
+    this.inFlight = false;
+    if (kind === 'issued') {
+      this.currentInterval = this.minInterval;
+      this.consecutiveFailures = 0;
+      this.breakerOpenedAt = null;
+      return;
+    }
+    // Back off on any non-success.
+    this.currentInterval = Math.min(this.currentInterval * this.backoffMul, this.maxInterval);
+    if (kind === 'failed') {
+      this.consecutiveFailures += 1;
+      if (this.consecutiveFailures >= this.breakerThreshold && this.breakerOpenedAt === null) {
+        this.breakerOpenedAt = this.now();
+      }
+    }
+  }
+}
+
+// ───────────────────────── Router consultation (selection time) ─────────────────────────
+
+export type AccountUseDecision =
+  | { use: 'borrowed'; remaining: number; reason: 'live-slice' }
+  | {
+      use: 'own';
+      reason:
+        | 'follow-me-disabled'
+        | 'not-a-borrowed-account'
+        | 'no-slice'
+        | 'slice-exhausted'
+        | 'slice-expired'
+        | 'stale-lease-epoch';
+    };
+
+export interface AccountUseQuery {
+  /** Master dark gate (`multiMachine.accountFollowMe`). When false → ALWAYS own account. */
+  followMeEnabled: boolean;
+  /** Is the candidate account a BORROWED (follow-me / metadata-only-credentialed) account? */
+  isBorrowedAccount: boolean;
+  /** The slice this VM currently holds for the candidate account (undefined ⇒ never received one). */
+  slice: SliceLeaseState | undefined;
+  /** The current effective lease epoch (a slice from an older epoch is void). */
+  currentLeaseEpoch: number;
+  now: number;
+}
+
+/**
+ * The SELECTION-TIME consultation (R7a(b)/(d), S5, §6.2). Returns whether a candidate BORROWED
+ * account may be used this turn, or whether the call must FALL BACK to this machine's OWN account.
+ *
+ * Fail-closed-to-own-account on EVERY uncertainty: flag off, not a borrowed account, no slice ever
+ * received (first-slice-under-partition), exhausted slice, expired slice, or a stale-epoch slice all
+ * resolve to `own`. ONLY a live, unexpired, current-epoch slice with remaining budget yields
+ * `borrowed`. This is pure — the router/pool wiring calls it and routes accordingly; when off it can
+ * never be reached so default behavior is byte-identical.
+ */
+export function decideAccountUse(q: AccountUseQuery): AccountUseDecision {
+  if (!q.followMeEnabled) return { use: 'own', reason: 'follow-me-disabled' };
+  if (!q.isBorrowedAccount) return { use: 'own', reason: 'not-a-borrowed-account' };
+  const s = q.slice;
+  // (d) first-slice-under-partition: never received a slice → own account.
+  if (!s || !s.grantId) return { use: 'own', reason: 'no-slice' };
+  // A slice from a superseded lease epoch is void (the holder failed over).
+  if (s.leaseEpoch < q.currentLeaseEpoch) return { use: 'own', reason: 'stale-lease-epoch' };
+  if (s.expiresAt <= q.now) return { use: 'own', reason: 'slice-expired' };
+  if (!(s.remaining > 0)) return { use: 'own', reason: 'slice-exhausted' };
+  return { use: 'borrowed', remaining: s.remaining, reason: 'live-slice' };
+}

--- a/src/core/AnthropicSubscriptionRouter.ts
+++ b/src/core/AnthropicSubscriptionRouter.ts
@@ -31,6 +31,7 @@
 import type { IntelligenceProvider, IntelligenceOptions } from './types.js';
 import { decideSdkVsSubscription } from '../providers/costAwareRouting.js';
 import type { AgentSdkCreditSnapshot } from '../providers/primitives/observability/usageMeterProvider.js';
+import type { AccountUseDecision } from './AccountFollowMeSpendSlice.js';
 
 export type SubscriptionPathMode = 'auto' | 'force';
 
@@ -64,6 +65,23 @@ export interface AnthropicSubscriptionRouterOptions {
   onRoute?: (info: SubscriptionRouteInfo) => void;
   /** Observability tap — auto-mode fallback after a primary failure. */
   onDegrade?: (info: SubscriptionDegradeInfo) => void;
+  /**
+   * WS5.2 R7a (S5, §6.2) — OPTIONAL slice consultation. When account follow-me is enabled and
+   * wired, the routing layer injects this to decide, AT SELECTION TIME, whether the subscription
+   * path may use a BORROWED (follow-me) account this call or must fall back to this machine's OWN
+   * account. It returns the same `AccountUseDecision` as `decideAccountUse` — `use:'own'` on EVERY
+   * uncertainty (no slice / exhausted / expired / stale epoch / first-slice-under-partition / flag
+   * off), `use:'borrowed'` only on a live current-epoch slice with remaining budget.
+   *
+   * ABSENT (the default, and ALWAYS when `multiMachine.accountFollowMe` is off) ⇒ this hook is
+   * never invoked, so routing is BYTE-IDENTICAL to today. The router NEVER overspends a borrowed
+   * account: it never reaches for one unless this consultation says `borrowed`, and a borrowed
+   * selection here only ever scopes the subscription-pool path the pool provider already uses
+   * (the pool's own account selection honors the decision via `onSliceConsult`).
+   */
+  consultSlice?: (options?: IntelligenceOptions) => AccountUseDecision;
+  /** Observability tap — the slice consultation result for a subscription-path call. */
+  onSliceConsult?: (info: { decision: AccountUseDecision; component?: string }) => void;
 }
 
 const DEFAULT_SAFETY_MARGIN_FRACTION = 0.1;
@@ -83,11 +101,24 @@ export class AnthropicSubscriptionRouter implements IntelligenceProvider {
     }
   }
 
+  /**
+   * WS5.2 R7a — run the (optional) slice consultation before a subscription-pool call. NO-OP when
+   * `consultSlice` is unwired (the default / flag-off), so today's behavior is byte-identical. When
+   * wired it surfaces the decision (own vs borrowed) to observability + the pool's account selection;
+   * the router never overspends — a `use:'own'` keeps the pool on this machine's own account.
+   */
+  private consultSliceForSubscription(options?: IntelligenceOptions, component?: string): void {
+    if (!this.opts.consultSlice) return;
+    const decision = this.opts.consultSlice(options);
+    this.opts.onSliceConsult?.({ decision, component });
+  }
+
   async evaluate(prompt: string, options?: IntelligenceOptions): Promise<string> {
     const component = options?.attribution?.component;
 
     if (this.opts.mode === 'force') {
       this.opts.onRoute?.({ path: 'subscription-pool', reason: 'forced-subscription-mode', component });
+      this.consultSliceForSubscription(options, component);
       // No fallback by design — force mode guarantees zero `claude -p`
       // traffic; a pool failure must surface, not silently re-route.
       return this.opts.pool.evaluate(prompt, options);
@@ -107,6 +138,7 @@ export class AnthropicSubscriptionRouter implements IntelligenceProvider {
       : 'sdk-credit';
 
     this.opts.onRoute?.({ path: primaryLabel, reason: decision.reason, component });
+    if (primaryLabel === 'subscription-pool') this.consultSliceForSubscription(options, component);
     try {
       return await primary.evaluate(prompt, options);
     } catch (err) {
@@ -120,6 +152,7 @@ export class AnthropicSubscriptionRouter implements IntelligenceProvider {
         reason: `fallback-after-primary-failure: ${reason.slice(0, 200)}`,
         component,
       });
+      if (fallbackLabel === 'subscription-pool') this.consultSliceForSubscription(options, component);
       return fallback.evaluate(prompt, options);
     }
   }

--- a/src/core/MeshRpc.ts
+++ b/src/core/MeshRpc.ts
@@ -70,6 +70,25 @@ export type MeshCommand =
       amount: number;
       expiresAt: number;
     }
+  | {
+      // WS5.2 R4a / R1 — ONE-DASHBOARD cross-machine account-follow-me mandate DELIVERY.
+      // The operator issues the account-follow-me mandate (PIN-gated) on their SINGLE dashboard,
+      // then delivers it to the TARGET machine via this verb so the target's enroll-start route
+      // can honor it — WITHOUT the operator ever opening the target's own dashboard.
+      //
+      // NOT the "any registered peer" read class — it carries a credential-adjacent authorization.
+      // But the REAL gate is NOT a role check at the RBAC layer: a delivered mandate is trusted
+      // ONLY when the R4a asymmetric issuance signature in the carried PortableMandate verifies, IN
+      // THE HANDLER, against THIS machine's REGISTERED operator-machine Ed25519 key + the
+      // AUTHENTICATED sender fingerprint (Know Your Principal — a name in the payload is never
+      // trusted; the §3.1a local HMAC proof is local-only and cannot ground a peer's mandate).
+      // The RBAC case therefore proves only that the sender is a registered ACTIVE peer
+      // (verifyEnvelope already did the Ed25519 + recipient-binding + nonce checks); the handler
+      // fails CLOSED on any verification failure and NEVER persists an unverified mandate.
+      type: 'account-follow-me-mandate-deliver';
+      /** The R4a-signed bundle: the mandate + its asymmetric issuance signature. */
+      portable: import('../coordination/AccountFollowMeMandateBridge.js').PortableMandate;
+    }
   // Pool Dashboard Streaming (POOL-DASHBOARD-STREAM-SPEC §2.3): a peer asks this
   // machine to mint a single-use bearer ticket so it may open a /pool-stream WS
   // and watch `session`. Read/observe class — minting a ticket discloses
@@ -269,7 +288,8 @@ export type RbacReason =
   | 'claim-unauthorized'
   | 'release-unauthorized'
   | 'drain-unauthorized'
-  | 'slice-renew-unauthorized';
+  | 'slice-renew-unauthorized'
+  | 'mandate-deliver-unauthorized';
 
 export interface RbacDeps {
   /** The machine currently holding the router lease (verify-on-read, §L1), or null. */
@@ -291,6 +311,16 @@ export interface RbacDeps {
     accountId: string;
     requestingMachineFp: string;
   }) => boolean;
+  /**
+   * WS5.2 R4a — the gate for `account-follow-me-mandate-deliver`. Returns true ONLY when account
+   * follow-me is ENABLED on this machine AND the sender is THIS machine's trusted operator machine
+   * (the verified-operator binding). Deny-by-default: ABSENT ⇒ the verb is refused (fail-closed) —
+   * on a build without the seam wired, or on a non-dev/dark agent, a delivered mandate can never be
+   * accepted at the gate. This is ONLY the coarse "should I even look at it" gate; the LOAD-BEARING
+   * authority is the R4a asymmetric signature verification in the handler, which re-binds to the
+   * authenticated sender + registered operator key. Mirrors the deny-by-default discipline of R3a.
+   */
+  authorizeMandateDeliver?: (args: { sender: MachineId }) => boolean;
 }
 
 /**
@@ -340,6 +370,17 @@ export function checkCommandRBAC(command: MeshCommand, sender: MachineId, deps: 
         requestingMachineFp: command.requestingMachineFp,
       }) ?? false;
       return authd ? { ok: true, reason: 'ok' } : { ok: false, reason: 'slice-renew-unauthorized' };
+    }
+    case 'account-follow-me-mandate-deliver': {
+      // WS5.2 R4a — deliberately its OWN case (NOT the "any registered peer" read class). The
+      // RBAC gate proves the sender is a registered ACTIVE peer (verifyEnvelope already did the
+      // crypto) AND that follow-me is enabled with this sender bound as the operator machine.
+      // DENY-BY-DEFAULT: with no `authorizeMandateDeliver` seam wired, or when the sender is not
+      // the trusted operator machine / the feature is dark, the verb is refused HERE — before the
+      // handler runs. The LOAD-BEARING authority is still the R4a signature re-verification in the
+      // handler (this gate is the coarse, fail-closed pre-filter).
+      const authd = deps.authorizeMandateDeliver?.({ sender }) ?? false;
+      return authd ? { ok: true, reason: 'ok' } : { ok: false, reason: 'mandate-deliver-unauthorized' };
     }
     case 'commitment-mutate':
       // MUTATING verb, deliberately its OWN case (COMMITMENTS-COHERENCE-SPEC
@@ -444,6 +485,7 @@ function statusForReason(reason: string): number {
     case 'release-unauthorized':
     case 'drain-unauthorized':
     case 'slice-renew-unauthorized':
+    case 'mandate-deliver-unauthorized':
       return 403;
     case 'replayed-nonce':
     case 'stale-timestamp':

--- a/src/core/MeshRpc.ts
+++ b/src/core/MeshRpc.ts
@@ -50,6 +50,26 @@ export type MeshCommand =
   | { type: 'capacity-report' }
   | { type: 'session-status'; session?: string }
   | { type: 'secret-share'; encrypted: string }
+  | {
+      // WS5.2 R7a/R7(c) — per-account SPEND-SLICE renewal (account follow-me).
+      // OPERATOR-MANDATE-GATED with its OWN `checkCommandRBAC` case — deliberately
+      // NOT the "any registered peer" read/observe class (R3a/R6a discipline): a
+      // borrowed account is a money/quota credential, so a slice may be issued ONLY
+      // to a machine the operator's mandate names. A requesting VM asks the FENCED
+      // lease holder to renew its slice; the holder (via SliceIssuer) verifies the
+      // grant is live + a slice remains within `maxSpend` before issuing. A
+      // non-holder receiving it MUST NOT issue (only the fenced single-writer
+      // issues) — that refusal lives in the handler/SliceIssuer, the RBAC gate here
+      // only proves the requester is mandate-authorized. The verb is rate-capped +
+      // coalesced + P19-breaker-protected on the REQUESTER side (SliceRenewalControl)
+      // so worst-case RPC rate is O(per-account-cap), not O(N).
+      type: 'slice-renew';
+      mandateId: string;
+      accountId: string;
+      requestingMachineFp: string;
+      amount: number;
+      expiresAt: number;
+    }
   // Pool Dashboard Streaming (POOL-DASHBOARD-STREAM-SPEC §2.3): a peer asks this
   // machine to mint a single-use bearer ticket so it may open a /pool-stream WS
   // and watch `session`. Read/observe class — minting a ticket discloses
@@ -248,7 +268,8 @@ export type RbacReason =
   | 'not-router'
   | 'claim-unauthorized'
   | 'release-unauthorized'
-  | 'drain-unauthorized';
+  | 'drain-unauthorized'
+  | 'slice-renew-unauthorized';
 
 export interface RbacDeps {
   /** The machine currently holding the router lease (verify-on-read, §L1), or null. */
@@ -257,6 +278,19 @@ export interface RbacDeps {
   ownerOf: (session: string) => MachineId | null;
   /** The machine the router last assigned (via place/transfer) for a session, or null. */
   placementTargetOf: (session: string) => MachineId | null;
+  /**
+   * WS5.2 R7a — the operator-mandate gate for the `slice-renew` verb. Returns true ONLY when the
+   * authorizing mandate authorizes (sender, accountId, requesting fingerprint) for account follow-me
+   * — deny-by-default. INJECTED so the dangerous authority decision is a real check, never an
+   * inherit. ABSENT ⇒ the verb is refused (fail-closed): on a build without the seam wired, a
+   * slice-renew can never be authorized. Mirrors the deny-by-default discipline of R3a/R4a.
+   */
+  authorizeSliceRenew?: (args: {
+    sender: MachineId;
+    mandateId: string;
+    accountId: string;
+    requestingMachineFp: string;
+  }) => boolean;
 }
 
 /**
@@ -289,6 +323,23 @@ export function checkCommandRBAC(command: MeshCommand, sender: MachineId, deps: 
       if (deps.ownerOf(command.session) === sender) return { ok: true, reason: 'ok' };
       if (isRouter && command.failover === true) return { ok: true, reason: 'ok' };
       return { ok: false, reason: 'release-unauthorized' };
+    }
+    case 'slice-renew': {
+      // WS5.2 R7a — OPERATOR-MANDATE-GATED, deliberately its OWN case (NOT the
+      // "any registered peer" read class). verifyEnvelope already proved WHO; this
+      // proves the operator's mandate AUTHORIZES this requester to borrow this
+      // account's spend. DENY-BY-DEFAULT: with no `authorizeSliceRenew` seam wired,
+      // or when the mandate does not authorize (sender, account, requesting fp), the
+      // verb is refused. The FENCED-single-writer "only the lease holder issues"
+      // check lives in the handler/SliceIssuer (a non-holder still refuses there);
+      // the gate's job is the mandate authorization, before any issuance work.
+      const authd = deps.authorizeSliceRenew?.({
+        sender,
+        mandateId: command.mandateId,
+        accountId: command.accountId,
+        requestingMachineFp: command.requestingMachineFp,
+      }) ?? false;
+      return authd ? { ok: true, reason: 'ok' } : { ok: false, reason: 'slice-renew-unauthorized' };
     }
     case 'commitment-mutate':
       // MUTATING verb, deliberately its OWN case (COMMITMENTS-COHERENCE-SPEC
@@ -392,6 +443,7 @@ function statusForReason(reason: string): number {
     case 'claim-unauthorized':
     case 'release-unauthorized':
     case 'drain-unauthorized':
+    case 'slice-renew-unauthorized':
       return 403;
     case 'replayed-nonce':
     case 'stale-timestamp':

--- a/src/server/AgentServer.ts
+++ b/src/server/AgentServer.ts
@@ -12,7 +12,7 @@ import express, { type Express, type Request, type Response } from 'express';
 import type { Server } from 'node:http';
 import fs from 'node:fs';
 import path from 'node:path';
-import { createHash, createHmac, timingSafeEqual } from 'node:crypto';
+import { createHash, createHmac, timingSafeEqual, createPrivateKey } from 'node:crypto';
 import { ApprovalLedger } from '../core/ApprovalLedger.js';
 import { resolveDevAgentGate } from '../core/devAgentGate.js';
 import { TopicOperatorStore } from '../users/TopicOperatorStore.js';
@@ -23,6 +23,9 @@ import { MandateGate } from '../coordination/MandateGate.js';
 import { MandateAudit } from '../coordination/MandateAudit.js';
 import { ConditionsRegistry } from '../coordination/conditions.js';
 import { ReviewExchangeEngine } from '../coordination/ReviewExchange.js';
+import { DeliveredMandateStore } from '../coordination/DeliveredMandateStore.js';
+import { packageMandateForDelivery, acceptDeliveredMandate } from '../coordination/AccountFollowMeMandateBridge.js';
+import { readFollowMeBounds, acceptMandateDelivery } from '../coordination/AccountFollowMeMandateDelivery.js';
 import { CutoverReadiness } from '../feedback-factory/cutoverReadiness.js';
 import { InboxDrainer } from '../feedback-factory/inbox/InboxDrainer.js';
 import { BlobInboxClient } from '../feedback-factory/inbox/BlobInboxClient.js';
@@ -242,6 +245,9 @@ export class AgentServer {
   /** Coordination Mandate enforcement (spec §4): deny-by-default gate + signed
    *  store + hash-chained audit. Null when stateDir is unavailable. */
   private coordination: { store: MandateStore; gate: MandateGate; audit: MandateAudit; conditions: ConditionsRegistry; reviews: ReviewExchangeEngine } | null = null;
+  /** WS5.2 R4a — durable store of cross-machine-DELIVERED account-follow-me mandates (target side).
+   *  Null when coordination/stateDir is unavailable. */
+  private deliveredMandateStore: import('../coordination/DeliveredMandateStore.js').DeliveredMandateStore | null = null;
   /** Operator Authorization Request (agent proposes → operator approves one-tap). Null
    *  when coordination/stateDir is unavailable. `enabled` is the resolved dev-gate. */
   private authorizationRequests: {
@@ -483,6 +489,13 @@ export class AgentServer {
     /** Signed rollout-stage E2E result store (§Rollout). */
     sessionPoolE2EResultStore?: import('../core/SessionPoolE2EResultStore.js').SessionPoolE2EResultStore;
     localSigningKeyPem?: string;
+    /** WS5.2 R4a — operator/issuer side: deliver an R4a-signed account-follow-me mandate to a REMOTE
+     *  target over the signed mesh. Injected from server.ts (where the mesh client + peer-URL
+     *  resolution live). Absent ⇒ this machine cannot deliver (single-machine / no mesh). */
+    deliverMandateToMachine?: (args: {
+      targetMachineId: string;
+      portable: import('../coordination/AccountFollowMeMandateBridge.js').PortableMandate;
+    }) => Promise<{ ok: boolean; status: number; reason?: string }>;
     /** Lease wire transport — receives peer lease broadcasts at /api/lease (spec §6). */
     leaseTransport?: { recordObserved: (lease: any) => void };
     /**
@@ -1316,6 +1329,22 @@ export class AgentServer {
         });
         this.coordination = { store, gate, audit, conditions, reviews };
 
+        // WS5.2 R4a — ONE-DASHBOARD cross-machine mandate delivery: the durable store of mandates
+        // delivered+verified to THIS machine from the operator machine. Built on the SAME stateDir
+        // as the mandate store; it retains the full R4a-signed PortableMandate so the enroll-start
+        // route re-verifies at point-of-use. No new authority path — a delivered mandate is trusted
+        // ONLY via the R4a asymmetric signature (verified by the mesh handler), never local authorship.
+        try {
+          this.deliveredMandateStore = new DeliveredMandateStore({
+            filePath: path.join(options.config.stateDir, 'state', 'delivered-mandates.json'),
+          });
+        } catch (dmErr) {
+          // @silent-fallback-ok — null leaves the delivered-mandate path inert (enroll-start falls
+          // back to deny-by-default), never blocks boot.
+          console.warn('[instar] delivered-mandate store init failed (non-fatal):', dmErr);
+          this.deliveredMandateStore = null;
+        }
+
         // Operator Authorization Request — agent proposes → operator approves one-tap.
         // Built on the SAME stateDir; the approve route issues grants via `store` above
         // (the existing signed MandateStore), so no new authority path is introduced.
@@ -2132,6 +2161,36 @@ export class AgentServer {
       approvalLedger: this.approvalLedger,
       topicOperatorStore: this.topicOperatorStore,
       coordination: this.coordination,
+      deliveredMandateStore: this.deliveredMandateStore,
+      // WS5.2 R4a — operator side: package an issued mandate with the asymmetric issuance signature
+      // using THIS machine's Ed25519 identity key + fingerprint (meshSelfId). Null when no mesh
+      // identity (single-machine) — the issue-for-machine route then 503s on a remote target.
+      packageMandateForDelivery: (() => {
+        const pem = options.localSigningKeyPem;
+        const selfId = options.meshSelfId;
+        if (!pem || !selfId) return null;
+        return (mandate: import('../coordination/types.js').CoordinationMandate) => {
+          const priv = createPrivateKey(pem);
+          return packageMandateForDelivery(mandate, selfId, priv);
+        };
+      })(),
+      deliverMandateToMachine: options.deliverMandateToMachine ?? null,
+      // WS5.2 R4a — target side: re-verify a DELIVERED mandate AT POINT OF USE against the operator
+      // key recorded at delivery (defense-in-depth; never trust a stored flag). Returns the verified
+      // account-follow-me bounds, or null on any failure (fail-closed).
+      verifyDeliveredMandate: this.deliveredMandateStore
+        ? (mandateId: string) => {
+            const record = this.deliveredMandateStore!.get(mandateId);
+            if (!record) return null;
+            const accept = acceptDeliveredMandate({
+              portable: record.portable,
+              operatorEd25519PublicKey: record.operatorPublicKeyPem,
+              expectedOperatorMachineFingerprint: record.deliveredBy,
+            });
+            if (!accept.accepted) return null;
+            return readFollowMeBounds(accept.mandate);
+          }
+        : null,
       authorizationRequests: this.authorizationRequests,
       cutoverReadiness: this.cutoverReadiness,
       inboxDrainer: this.inboxDrainer,
@@ -3790,6 +3849,41 @@ export class AgentServer {
    */
   getApp(): Express {
     return this.app;
+  }
+
+  /**
+   * WS5.2 R4a — TARGET-side acceptance of a cross-machine-delivered account-follow-me mandate (the
+   * brains behind the `account-follow-me-mandate-deliver` mesh handler, which is wired in server.ts
+   * where the peer-key resolver lives). `sender` MUST be the mesh-AUTHENTICATED envelope sender;
+   * `operatorPublicKeyPem` is that sender's REGISTERED Ed25519 key (resolved by the caller from the
+   * same registered-identity store verifyEnvelope used) — never a key from the payload. FAIL CLOSED:
+   * feature dark / no store / signature-or-bounds failure → refuse + persist nothing.
+   */
+  acceptDeliveredMandateCommand(
+    sender: string,
+    portable: import('../coordination/AccountFollowMeMandateBridge.js').PortableMandate | undefined | null,
+    operatorPublicKeyPem: string | null,
+  ): { accepted: boolean; reason?: string; mandateId?: string } {
+    if (!this.deliveredMandateStore) return { accepted: false, reason: 'delivered-mandate-store-unavailable' };
+    const enabled = resolveDevAgentGate(
+      (this.config as unknown as { multiMachine?: { accountFollowMe?: { enabled?: boolean } } })
+        .multiMachine?.accountFollowMe?.enabled,
+      this.config,
+    );
+    const result = acceptMandateDelivery(
+      {
+        enabled: () => enabled,
+        selfMachineId: () => this.meshSelfId ?? (this.config as { machineId?: string }).machineId ?? 'local',
+        operatorMachinePublicKey: () => operatorPublicKeyPem,
+        store: this.deliveredMandateStore,
+        log: (m) => console.log(m),
+      },
+      sender,
+      portable,
+    );
+    return result.accepted
+      ? { accepted: true, mandateId: result.mandateId }
+      : { accepted: false, reason: result.reason };
   }
 
   /** Wiring-integrity accessor: the ParallelWorkSentinel when constructed (enabled), else null. */

--- a/src/server/routes.ts
+++ b/src/server/routes.ts
@@ -925,6 +925,34 @@ export interface RouteContext {
     /** ReviewExchange engine (spec §7 G2.3) — mandate-gated mutual code-review sign-offs. */
     reviews: import('../coordination/ReviewExchange.js').ReviewExchangeEngine;
   } | null;
+  /** WS5.2 R4a — ONE-DASHBOARD cross-machine account-follow-me mandate delivery.
+   *  Durable store of mandates DELIVERED+VERIFIED to THIS machine from the operator machine; the
+   *  enroll-start route consults it (re-verifying at point-of-use) when no LOCAL mandate authorizes.
+   *  Null/absent when account follow-me is dark on this agent. */
+  deliveredMandateStore?: import('../coordination/DeliveredMandateStore.js').DeliveredMandateStore | null;
+  /** WS5.2 R4a — re-verify a delivered mandate AT POINT OF USE (defense-in-depth — never trust a
+   *  stored flag). Returns the verified bounds when the persisted PortableMandate's asymmetric
+   *  issuance signature STILL verifies against the registered operator-machine key recorded at
+   *  delivery; null on any failure (fail-closed). Injected so the dangerous re-check is a real check.
+   *  Absent ⇒ the delivered-mandate path is inert (the route falls back to deny-by-default). */
+  verifyDeliveredMandate?: ((mandateId: string) => {
+    accountId: string;
+    targetMachineId: string;
+    mechanism: string;
+  } | null) | null;
+  /** WS5.2 R4a — operator/issuer side: deliver an issued account-follow-me mandate to a REMOTE
+   *  target machine over the signed mesh (the new verb). Resolves the target's mesh address +
+   *  signs the envelope with THIS machine's Ed25519 identity key. Returns the per-target outcome.
+   *  Absent/null when this machine cannot deliver (no mesh identity / single-machine). */
+  deliverMandateToMachine?: ((args: {
+    targetMachineId: string;
+    portable: import('../coordination/AccountFollowMeMandateBridge.js').PortableMandate;
+  }) => Promise<{ ok: boolean; status: number; reason?: string }>) | null;
+  /** WS5.2 R4a — sign an issued mandate for cross-machine delivery (operator side): produce the
+   *  R4a PortableMandate (mandate + asymmetric issuance signature) with THIS machine's Ed25519
+   *  identity key + fingerprint. Absent/null when this machine has no mesh identity. */
+  packageMandateForDelivery?: ((mandate: import('../coordination/types.js').CoordinationMandate) =>
+    import('../coordination/AccountFollowMeMandateBridge.js').PortableMandate) | null;
   /** Operator Authorization Request (agent proposes → operator approves one-tap).
    *  Spec: docs/specs/OPERATOR-AUTHORIZATION-REQUEST-SPEC.md. Null when stateDir is
    *  unavailable. `enabled` is the resolved dev-gate (enabled-on-dev / dark-on-fleet);
@@ -7533,6 +7561,84 @@ export function createRoutes(ctx: RouteContext): Router {
       expiresAt: b.expiresAt,
     });
     res.status(201).json({ issued: true, mandate });
+  });
+
+  // WS5.2 R4a / R1 — ONE-DASHBOARD cross-machine mandate issuance + delivery. Issue an
+  // account-follow-me mandate (PIN-gated, EXACTLY like /mandate/issue) for a REMOTE target machine,
+  // then DELIVER it to that target over the signed mesh so the target's enroll-start route honors it
+  // — WITHOUT the operator ever opening the target's own dashboard. The mandate is signed locally
+  // (its LOCAL authProof is meaningless on the target) AND packaged with the R4a asymmetric issuance
+  // signature (the ONLY thing the target can verify). A LOCAL target (targetMachineId === this
+  // machine) is the unchanged /mandate/issue path and is NOT delivered (the local gate sees it).
+  router.post('/mandate/issue-for-machine', async (req, res) => {
+    if (!ctx.coordination) {
+      res.status(503).json({ error: 'coordination mandate engine unavailable (no stateDir or init failed)' });
+      return;
+    }
+    const afmCfg = (ctx.config as unknown as { multiMachine?: { accountFollowMe?: { enabled?: boolean } } })
+      .multiMachine?.accountFollowMe;
+    if (!resolveDevAgentGate(afmCfg?.enabled, ctx.config)) {
+      res.status(503).json({ error: 'account follow-me not enabled' });
+      return;
+    }
+    if (!checkMandatePin(req, res)) return;
+    const b = req.body ?? {};
+    // The mandate is ALWAYS an account-follow-me grant pinned to ONE account + ONE target machine +
+    // re-mint (R1 exact-bounds): the body carries the bounds, never an arbitrary authority list.
+    if (typeof b.accountId !== 'string' || !b.accountId.trim()) {
+      res.status(400).json({ error: 'accountId is required' });
+      return;
+    }
+    if (typeof b.targetMachineId !== 'string' || !b.targetMachineId.trim()) {
+      res.status(400).json({ error: 'targetMachineId is required' });
+      return;
+    }
+    if (!Array.isArray(b.agents) || b.agents.length !== 2 || b.agents.some((a: unknown) => typeof a !== 'string' || !a)) {
+      res.status(400).json({ error: 'agents must be a pair of two agent fingerprints' });
+      return;
+    }
+    if (typeof b.expiresAt !== 'string' || isNaN(Date.parse(b.expiresAt)) || Date.parse(b.expiresAt) <= Date.now()) {
+      res.status(400).json({ error: 'expiresAt must be a future ISO timestamp (mandates always expire)' });
+      return;
+    }
+    const { accountId, targetMachineId } = b as { accountId: string; targetMachineId: string };
+    const selfMachineId = ctx.meshSelfId ?? (ctx.config as { machineId?: string }).machineId ?? 'local';
+
+    // Issue locally (PIN-gated above) — exact-bounds account-follow-me / re-mint (R1).
+    const mandate = ctx.coordination.store.issue({
+      scope: typeof b.scope === 'string' && b.scope.trim() ? b.scope : 'account-follow-me',
+      agents: [b.agents[0], b.agents[1]],
+      authorities: [
+        { action: 'account-follow-me', bounds: { accountId, targetMachineId, mechanism: 're-mint' } },
+      ],
+      author: typeof b.author === 'string' && b.author ? b.author : 'justin',
+      expiresAt: b.expiresAt,
+    });
+
+    // A LOCAL target is the ordinary path — the local gate already sees this mandate; no delivery.
+    if (targetMachineId === selfMachineId) {
+      res.status(201).json({ issued: true, mandate, delivered: false, local: true });
+      return;
+    }
+
+    // REMOTE target — package with the R4a issuance signature and deliver over the mesh.
+    if (!ctx.packageMandateForDelivery || !ctx.deliverMandateToMachine) {
+      res.status(503).json({ error: 'cross-machine mandate delivery unavailable (no mesh identity)' });
+      return;
+    }
+    try {
+      const portable = ctx.packageMandateForDelivery(mandate);
+      const outcome = await ctx.deliverMandateToMachine({ targetMachineId, portable });
+      if (!outcome.ok) {
+        // The mandate is issued + persisted locally; only the DELIVERY failed. Honest 502 so the
+        // operator can retry delivery without re-issuing (idempotent put on the target by id).
+        res.status(502).json({ issued: true, mandate, delivered: false, deliveryStatus: outcome.status, reason: outcome.reason });
+        return;
+      }
+      res.status(201).json({ issued: true, mandate, delivered: true, deliveryStatus: outcome.status });
+    } catch (err) {
+      res.status(502).json({ issued: true, mandate, delivered: false, error: err instanceof Error ? err.message : 'delivery failed' });
+    }
   });
 
   // Revoke a mandate — PIN-GATED (the operator kill switch; checked on every action).
@@ -20964,7 +21070,8 @@ export function createRoutes(ctx: RouteContext): Router {
     const targetMachineId = ctx.meshSelfId ?? (ctx.config as { machineId?: string }).machineId ?? 'local';
 
     // THE AUTHORIZATION (deny-by-default): consult the operator mandate for THIS exact
-    // (account, this machine, mechanism). A non-allow verdict STOPS — never work around it.
+    // (account, this machine, mechanism). A non-allow verdict STOPS — UNLESS a cross-machine
+    // DELIVERED mandate authorizes it (the one-dashboard path, R4a). Never work around a deny.
     const verdict = ctx.coordination.gate.evaluate({
       action: 'account-follow-me',
       params: { accountId, targetMachineId, mechanism: 're-mint' },
@@ -20972,8 +21079,22 @@ export function createRoutes(ctx: RouteContext): Router {
       mandateId,
     });
     if (verdict.decision !== 'allow') {
-      res.status(403).json({ error: 'account follow-me not authorized', reason: verdict.reason });
-      return;
+      // WS5.2 R4a — ADDITIONAL accepted source (the LOCAL-mandate path above is unchanged; this
+      // never weakens it). The operator issued + delivered the mandate from their SINGLE dashboard,
+      // so it has no LOCAL authorship here and the local gate correctly denies. Consult the
+      // delivered-mandate store, RE-VERIFYING the R4a signature at point-of-use (never a stored
+      // flag), then check the EXACT bounds match this (account, this machine, re-mint). Both paths
+      // are fail-closed: no verified delivered mandate with matching bounds → 403.
+      const deliveredBounds = ctx.verifyDeliveredMandate ? ctx.verifyDeliveredMandate(mandateId) : null;
+      const deliveredOk =
+        !!deliveredBounds &&
+        deliveredBounds.accountId === accountId &&
+        deliveredBounds.targetMachineId === targetMachineId &&
+        deliveredBounds.mechanism === 're-mint';
+      if (!deliveredOk) {
+        res.status(403).json({ error: 'account follow-me not authorized', reason: verdict.reason });
+        return;
+      }
     }
 
     // S7 — resolve the operator-APPROVED email authoritatively (local pool + peer views), NEVER

--- a/tests/integration/account-follow-me-delivered-mandate-enroll.test.ts
+++ b/tests/integration/account-follow-me-delivered-mandate-enroll.test.ts
@@ -1,0 +1,135 @@
+/**
+ * Integration test — WS5.2 R4a: the enroll-start route honors a cross-machine-DELIVERED+verified
+ * mandate (the one-dashboard path) when the LOCAL gate denies, and still 403s without one.
+ *
+ * This is the keystone of "one dashboard": the operator issued the mandate on their OWN machine, so
+ * it has NO local authorship here and `coordination.gate.evaluate` correctly DENIES. The route must
+ * fall back to the delivered-mandate store, re-verifying at point-of-use (`verifyDeliveredMandate`),
+ * and proceed ONLY when the verified bounds exactly match (account, this machine, re-mint).
+ *
+ * Proves:
+ *   (a) gate DENY + a verified delivered mandate with matching bounds → 201 (proceeds to enroll);
+ *   (b) gate DENY + NO delivered mandate → 403 (deny-by-default);
+ *   (c) gate DENY + a delivered mandate whose bounds MISMATCH (wrong account) → 403 (fail-closed);
+ *   (d) the LOCAL-gate path is unchanged: gate ALLOW still proceeds with no delivered mandate.
+ */
+
+import { describe, it, expect, afterEach } from 'vitest';
+import express from 'express';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import type { AddressInfo } from 'node:net';
+import { createRoutes } from '../../src/server/routes.js';
+import { SubscriptionPool } from '../../src/core/SubscriptionPool.js';
+import { EnrollmentWizard } from '../../src/core/EnrollmentWizard.js';
+import { PendingLoginStore } from '../../src/core/PendingLoginStore.js';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+
+interface TestServer { url: string; close: () => Promise<void>; }
+async function listen(app: express.Express): Promise<TestServer> {
+  return new Promise((resolve) => {
+    const srv = app.listen(0, () => {
+      const port = (srv.address() as AddressInfo).port;
+      resolve({ url: `http://127.0.0.1:${port}`, close: () => new Promise<void>((r) => srv.close(() => r())) });
+    });
+  });
+}
+
+const THIS_MACHINE = 'm_this_machine';
+
+function buildCtx(dir: string, opts: {
+  decision: 'allow' | 'deny';
+  /** What `verifyDeliveredMandate` returns for mandateId 'm-delivered' (null = none verified). */
+  deliveredBounds: { accountId: string; targetMachineId: string; mechanism: string } | null;
+}) {
+  const pool = new SubscriptionPool({ stateDir: dir });
+  pool.add({ id: 'a1', nickname: 'main', provider: 'anthropic', framework: 'claude-code', configHome: '/x/a1', email: 'approved@x.com' });
+  const enrollmentWizard = new EnrollmentWizard({
+    store: new PendingLoginStore({ stateDir: dir }),
+    driveLogin: async () => ({ verificationUrl: 'https://claude.com/oauth', userCode: 'WXYZ-1234', ttlMs: 15 * 60_000 }),
+    ensureReady: () => ({ patched: false, reason: 'already interactive-ready' }),
+  });
+  return {
+    config: {
+      authToken: 'test', stateDir: dir, port: 0, projectName: 'echo',
+      developmentAgent: true,
+      multiMachine: { accountFollowMe: {} },
+    },
+    startTime: new Date(),
+    meshSelfId: THIS_MACHINE,
+    subscriptionPool: pool,
+    enrollmentWizard,
+    coordination: { gate: { evaluate: () => ({ decision: opts.decision, reason: opts.decision === 'allow' ? 'mandate ok' : 'no local mandate' }) } },
+    accountFollowMePeerViews: async () => ([]),
+    // The delivered-mandate point-of-use re-verify seam — keyed on the route's mandateId.
+    verifyDeliveredMandate: (mandateId: string) => (mandateId === 'm-delivered' ? opts.deliveredBounds : null),
+  } as unknown as Parameters<typeof createRoutes>[0];
+}
+
+describe('enroll-start honors a delivered mandate (WS5.2 R4a one-dashboard)', () => {
+  let server: TestServer;
+  let dir: string;
+  const post = (p: string, body?: unknown) =>
+    fetch(server.url + p, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      ...(body !== undefined ? { body: JSON.stringify(body) } : {}),
+    }).then(async (r) => ({ status: r.status, body: await r.json().catch(() => ({})) as Record<string, unknown> }));
+
+  afterEach(async () => {
+    await server?.close();
+    try { SafeFsExecutor.safeRmSync(dir, { recursive: true, force: true, operation: 'tests/integration/account-follow-me-delivered-mandate-enroll.test.ts:cleanup' }); } catch { /* @silent-fallback-ok */ }
+  });
+
+  it('(a) gate DENY + verified delivered mandate with matching bounds → 201 (proceeds)', async () => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'afm-dm-'));
+    const ctx = buildCtx(dir, { decision: 'deny', deliveredBounds: { accountId: 'a1', targetMachineId: THIS_MACHINE, mechanism: 're-mint' } });
+    const app = express(); app.use(express.json());
+    app.use(createRoutes(ctx));
+    server = await listen(app);
+    const r = await post('/subscription-pool/follow-me/enroll/start', { mandateId: 'm-delivered', accountId: 'a1' });
+    expect(r.status).toBe(201);
+    expect(r.body.enabled).toBe(true);
+  });
+
+  it('(b) gate DENY + NO delivered mandate → 403 (deny-by-default)', async () => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'afm-dm-'));
+    const ctx = buildCtx(dir, { decision: 'deny', deliveredBounds: null });
+    const app = express(); app.use(express.json());
+    app.use(createRoutes(ctx));
+    server = await listen(app);
+    const r = await post('/subscription-pool/follow-me/enroll/start', { mandateId: 'm-delivered', accountId: 'a1' });
+    expect(r.status).toBe(403);
+  });
+
+  it('(c) gate DENY + delivered mandate with MISMATCHED bounds (wrong account) → 403 (fail-closed)', async () => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'afm-dm-'));
+    const ctx = buildCtx(dir, { decision: 'deny', deliveredBounds: { accountId: 'a-OTHER', targetMachineId: THIS_MACHINE, mechanism: 're-mint' } });
+    const app = express(); app.use(express.json());
+    app.use(createRoutes(ctx));
+    server = await listen(app);
+    const r = await post('/subscription-pool/follow-me/enroll/start', { mandateId: 'm-delivered', accountId: 'a1' });
+    expect(r.status).toBe(403);
+  });
+
+  it('(c2) gate DENY + delivered mandate targeting ANOTHER machine → 403 (cannot be replayed here)', async () => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'afm-dm-'));
+    const ctx = buildCtx(dir, { decision: 'deny', deliveredBounds: { accountId: 'a1', targetMachineId: 'm_some_other', mechanism: 're-mint' } });
+    const app = express(); app.use(express.json());
+    app.use(createRoutes(ctx));
+    server = await listen(app);
+    const r = await post('/subscription-pool/follow-me/enroll/start', { mandateId: 'm-delivered', accountId: 'a1' });
+    expect(r.status).toBe(403);
+  });
+
+  it('(d) the LOCAL-gate path is unchanged: gate ALLOW → 201 with no delivered mandate', async () => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'afm-dm-'));
+    const ctx = buildCtx(dir, { decision: 'allow', deliveredBounds: null });
+    const app = express(); app.use(express.json());
+    app.use(createRoutes(ctx));
+    server = await listen(app);
+    const r = await post('/subscription-pool/follow-me/enroll/start', { mandateId: 'm-local', accountId: 'a1' });
+    expect(r.status).toBe(201);
+  });
+});

--- a/tests/integration/account-follow-me-issue-for-machine-route.test.ts
+++ b/tests/integration/account-follow-me-issue-for-machine-route.test.ts
@@ -1,0 +1,173 @@
+/**
+ * Integration test — WS5.2 R4a ONE-DASHBOARD cross-machine mandate issuance + delivery, over the
+ * full HTTP pipeline (createRoutes). Proves:
+ *   (a) dark (non-dev, flag omitted) → 503;
+ *   (b) enabled but NO PIN → 403 (issuance stays PIN-gated; the agent can never self-issue);
+ *   (c) enabled + correct PIN + REMOTE target → issues locally, packages the R4a bundle, dispatches
+ *       it over the injected delivery seam, and returns delivered:true;
+ *   (d) a delivery failure (seam ok:false) → 502 honest, mandate still issued locally (retry-able);
+ *   (e) a LOCAL target (== this machine) → issued, delivered:false (the local gate already sees it).
+ *
+ * The delivery seam + the package helper are injected (the real ones live in AgentServer/server.ts);
+ * the test asserts the route's authorization + dispatch contract, not the mesh transport itself.
+ */
+
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import express from 'express';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import crypto from 'node:crypto';
+import type { AddressInfo } from 'node:net';
+import { createRoutes } from '../../src/server/routes.js';
+import { MandateStore } from '../../src/coordination/MandateStore.js';
+import { packageMandateForDelivery } from '../../src/coordination/AccountFollowMeMandateBridge.js';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+
+interface TestServer { url: string; close: () => Promise<void>; }
+async function listen(app: express.Express): Promise<TestServer> {
+  return new Promise((resolve) => {
+    const srv = app.listen(0, () => {
+      const port = (srv.address() as AddressInfo).port;
+      resolve({ url: `http://127.0.0.1:${port}`, close: () => new Promise<void>((r) => srv.close(() => r())) });
+    });
+  });
+}
+
+const PIN = '123456';
+
+function buildCtx(dir: string, opts: {
+  dev: boolean;
+  deliver?: (args: { targetMachineId: string; portable: unknown }) => Promise<{ ok: boolean; status: number; reason?: string }>;
+  deliverCapture?: Array<{ targetMachineId: string; portable: unknown }>;
+}) {
+  const op = crypto.generateKeyPairSync('ed25519');
+  // A real signed MandateStore so issue() produces a real mandate; an audit-free gate.
+  const store = new MandateStore({
+    filePath: path.join(dir, 'mandates.json'),
+    sign: (c) => crypto.createHmac('sha256', 'k').update(c).digest('hex'),
+    verifySig: (c, p) => crypto.createHmac('sha256', 'k').update(c).digest('hex') === p,
+  });
+  // The issue-for-machine route only calls store.issue (PIN-gated) + the delivery seam — never the
+  // gate — so a stub gate is sufficient here.
+  const gate = { evaluate: () => ({ decision: 'deny' as const, reason: 'unused' }) };
+  return {
+    config: {
+      authToken: 'test', stateDir: dir, port: 0, projectName: 'echo', dashboardPin: PIN,
+      developmentAgent: opts.dev,
+      multiMachine: { accountFollowMe: {} },
+    },
+    startTime: new Date(),
+    meshSelfId: 'm_this_machine',
+    coordination: { store, gate },
+    packageMandateForDelivery: (m: import('../../src/coordination/types.js').CoordinationMandate) =>
+      packageMandateForDelivery(m, 'm_this_machine', op.privateKey),
+    deliverMandateToMachine: async (args: { targetMachineId: string; portable: unknown }) => {
+      opts.deliverCapture?.push(args);
+      return opts.deliver ? opts.deliver(args) : { ok: true, status: 200 };
+    },
+  } as unknown as Parameters<typeof createRoutes>[0];
+}
+
+const futureExpiry = new Date(Date.now() + 3_600_000).toISOString();
+const baseBody = {
+  accountId: 'acct-1',
+  agents: ['fp-op-agent', 'fp-target-agent'],
+  expiresAt: futureExpiry,
+};
+
+describe('/mandate/issue-for-machine (integration)', () => {
+  let server: TestServer;
+  let dir: string;
+  const post = (p: string, body?: unknown) =>
+    fetch(server.url + p, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      ...(body !== undefined ? { body: JSON.stringify(body) } : {}),
+    }).then(async (r) => ({ status: r.status, body: await r.json().catch(() => ({})) as Record<string, unknown> }));
+
+  afterEach(async () => {
+    await server?.close();
+    try { SafeFsExecutor.safeRmSync(dir, { recursive: true, force: true, operation: 'tests/integration/account-follow-me-issue-for-machine-route.test.ts:cleanup' }); } catch { /* @silent-fallback-ok */ }
+  });
+
+  it('(a) dark (non-dev, flag enabled omitted) → 503', async () => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'afm-ifm-'));
+    const app = express(); app.use(express.json());
+    app.use(createRoutes(buildCtx(dir, { dev: false })));
+    server = await listen(app);
+    const r = await post('/mandate/issue-for-machine', { ...baseBody, targetMachineId: 'm_mini', pin: PIN });
+    expect(r.status).toBe(503);
+  });
+
+  it('(b) enabled but NO/incorrect PIN → 403 (issuance stays PIN-gated)', async () => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'afm-ifm-'));
+    const app = express(); app.use(express.json());
+    app.use(createRoutes(buildCtx(dir, { dev: true })));
+    server = await listen(app);
+    const noPin = await post('/mandate/issue-for-machine', { ...baseBody, targetMachineId: 'm_mini' });
+    expect(noPin.status).toBe(403);
+    const wrongPin = await post('/mandate/issue-for-machine', { ...baseBody, targetMachineId: 'm_mini', pin: '999999' });
+    expect(wrongPin.status).toBe(403);
+  });
+
+  it('(c) enabled + correct PIN + REMOTE target → issues + packages + delivers', async () => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'afm-ifm-'));
+    const deliverCapture: Array<{ targetMachineId: string; portable: unknown }> = [];
+    const ctx = buildCtx(dir, { dev: true, deliverCapture });
+    const app = express(); app.use(express.json());
+    app.use(createRoutes(ctx));
+    server = await listen(app);
+    const r = await post('/mandate/issue-for-machine', { ...baseBody, targetMachineId: 'm_mini', pin: PIN });
+    expect(r.status).toBe(201);
+    expect(r.body.issued).toBe(true);
+    expect(r.body.delivered).toBe(true);
+    // The mandate carries the exact account-follow-me / re-mint bounds pinned to the target.
+    const mandate = r.body.mandate as { authorities: Array<{ action: string; bounds: Record<string, unknown> }> };
+    expect(mandate.authorities[0]).toMatchObject({
+      action: 'account-follow-me',
+      bounds: { accountId: 'acct-1', targetMachineId: 'm_mini', mechanism: 're-mint' },
+    });
+    // The delivery seam received the target + a packaged (signed) portable bundle.
+    expect(deliverCapture).toHaveLength(1);
+    expect(deliverCapture[0].targetMachineId).toBe('m_mini');
+    expect((deliverCapture[0].portable as { issuanceSignature?: unknown }).issuanceSignature).toBeDefined();
+  });
+
+  it('(d) a delivery failure → 502 honest, mandate still issued locally (retry-able)', async () => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'afm-ifm-'));
+    const ctx = buildCtx(dir, { dev: true, deliver: async () => ({ ok: false, status: 0, reason: 'no-peer-url' }) });
+    const app = express(); app.use(express.json());
+    app.use(createRoutes(ctx));
+    server = await listen(app);
+    const r = await post('/mandate/issue-for-machine', { ...baseBody, targetMachineId: 'm_mini', pin: PIN });
+    expect(r.status).toBe(502);
+    expect(r.body.issued).toBe(true);
+    expect(r.body.delivered).toBe(false);
+    expect(r.body.reason).toBe('no-peer-url');
+  });
+
+  it('(e) LOCAL target (== this machine) → issued, delivered:false (local gate sees it)', async () => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'afm-ifm-'));
+    const deliverCapture: Array<{ targetMachineId: string; portable: unknown }> = [];
+    const ctx = buildCtx(dir, { dev: true, deliverCapture });
+    const app = express(); app.use(express.json());
+    app.use(createRoutes(ctx));
+    server = await listen(app);
+    const r = await post('/mandate/issue-for-machine', { ...baseBody, targetMachineId: 'm_this_machine', pin: PIN });
+    expect(r.status).toBe(201);
+    expect(r.body.delivered).toBe(false);
+    expect(r.body.local).toBe(true);
+    // A local target is NEVER dispatched over the mesh.
+    expect(deliverCapture).toHaveLength(0);
+  });
+
+  it('missing targetMachineId → 400 (after PIN)', async () => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'afm-ifm-'));
+    const app = express(); app.use(express.json());
+    app.use(createRoutes(buildCtx(dir, { dev: true })));
+    server = await listen(app);
+    const r = await post('/mandate/issue-for-machine', { ...baseBody, pin: PIN });
+    expect(r.status).toBe(400);
+  });
+});

--- a/tests/unit/MeshRpc.test.ts
+++ b/tests/unit/MeshRpc.test.ts
@@ -138,6 +138,21 @@ describe('MeshRpc — per-command RBAC (§L0)', () => {
     }
   });
 
+  it('slice-renew (WS5.2 R7a): operator-mandate-gated with its OWN refusal — NOT the any-peer class', () => {
+    const cmd: MeshCommand = {
+      type: 'slice-renew', mandateId: 'M1', accountId: 'acct', requestingMachineFp: 'fp-mini', amount: 0.3, expiresAt: 9_000_000_000_000,
+    };
+    // No `authorizeSliceRenew` seam wired ⇒ deny-by-default (fail closed).
+    expect(checkCommandRBAC(cmd, 'ANY_PEER', rbac())).toEqual({ ok: false, reason: 'slice-renew-unauthorized' });
+    // Seam says the mandate does NOT authorize this requester ⇒ refused.
+    expect(checkCommandRBAC(cmd, 'ROGUE', rbac({ authorizeSliceRenew: () => false })).reason).toBe('slice-renew-unauthorized');
+    // Seam authorizes the mandated requester ⇒ ok; the args are threaded to the gate.
+    const seen: unknown[] = [];
+    const ok = checkCommandRBAC(cmd, 'MANDATED', rbac({ authorizeSliceRenew: (a) => { seen.push(a); return true; } }));
+    expect(ok).toEqual({ ok: true, reason: 'ok' });
+    expect(seen[0]).toEqual({ sender: 'MANDATED', mandateId: 'M1', accountId: 'acct', requestingMachineFp: 'fp-mini' });
+  });
+
   it('state-snapshot is read/observe class — any registered peer → ok (no router/owner role)', () => {
     // The single-origin snapshot pull is self-binding (origin === serving machine);
     // RBAC adds NO authorization beyond verifyEnvelope, exactly like the other

--- a/tests/unit/MeshRpc.test.ts
+++ b/tests/unit/MeshRpc.test.ts
@@ -153,6 +153,23 @@ describe('MeshRpc — per-command RBAC (§L0)', () => {
     expect(seen[0]).toEqual({ sender: 'MANDATED', mandateId: 'M1', accountId: 'acct', requestingMachineFp: 'fp-mini' });
   });
 
+  it('account-follow-me-mandate-deliver (WS5.2 R4a): gated with its OWN refusal — NOT the any-peer class', () => {
+    const cmd = {
+      type: 'account-follow-me-mandate-deliver',
+      portable: { mandate: { id: 'MND-1' }, issuanceSignature: { alg: 'ed25519', issuerFingerprint: 'm_op', sig: 'x' } },
+    } as unknown as MeshCommand;
+    // No `authorizeMandateDeliver` seam wired ⇒ deny-by-default (fail closed) — proves it is NOT
+    // in the any-registered-peer read class.
+    expect(checkCommandRBAC(cmd, 'ANY_PEER', rbac())).toEqual({ ok: false, reason: 'mandate-deliver-unauthorized' });
+    // Seam refuses (feature dark / sender not the operator machine) ⇒ refused.
+    expect(checkCommandRBAC(cmd, 'ROGUE', rbac({ authorizeMandateDeliver: () => false })).reason).toBe('mandate-deliver-unauthorized');
+    // Seam authorizes ⇒ ok; the sender is threaded to the gate.
+    const seen: unknown[] = [];
+    const ok = checkCommandRBAC(cmd, 'OPERATOR', rbac({ authorizeMandateDeliver: (a) => { seen.push(a); return true; } }));
+    expect(ok).toEqual({ ok: true, reason: 'ok' });
+    expect(seen[0]).toEqual({ sender: 'OPERATOR' });
+  });
+
   it('state-snapshot is read/observe class — any registered peer → ok (no router/owner role)', () => {
     // The single-origin snapshot pull is self-binding (origin === serving machine);
     // RBAC adds NO authorization beyond verifyEnvelope, exactly like the other

--- a/tests/unit/account-follow-me-mandate-delivery.test.ts
+++ b/tests/unit/account-follow-me-mandate-delivery.test.ts
@@ -1,0 +1,180 @@
+/**
+ * Unit tests — WS5.2 R4a ONE-DASHBOARD cross-machine mandate delivery (target side):
+ *   - DeliveredMandateStore persistence (put/get/remove, idempotent by id, retains the portable
+ *     bundle + the operator key + the authenticated deliverer).
+ *   - acceptMandateDelivery: a valid R4a-signed mandate from the trusted operator key is accepted
+ *     + persisted; a bad signature, a wrong operator key, a target-machine mismatch, a non-follow-me
+ *     mandate, a feature-dark agent, and a missing operator key are all REFUSED (fail-closed) and
+ *     NEVER persist.
+ */
+
+import { describe, it, expect, afterEach } from 'vitest';
+import crypto from 'node:crypto';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { packageMandateForDelivery } from '../../src/coordination/AccountFollowMeMandateBridge.js';
+import { DeliveredMandateStore } from '../../src/coordination/DeliveredMandateStore.js';
+import { acceptMandateDelivery } from '../../src/coordination/AccountFollowMeMandateDelivery.js';
+import type { CoordinationMandate } from '../../src/coordination/types.js';
+
+const OP_FP = 'm_operator_machine';
+const THIS_MACHINE = 'm_target_machine';
+
+function mandate(over: Partial<CoordinationMandate> = {}): CoordinationMandate {
+  return {
+    id: 'MND-deliver-1',
+    scope: 'account-follow-me',
+    agents: ['fp-op-agent', 'fp-target-agent'],
+    authorities: [{ action: 'account-follow-me', bounds: { accountId: 'acct-1', targetMachineId: THIS_MACHINE, mechanism: 're-mint' } }],
+    author: 'justin',
+    createdAt: '2026-06-17T00:00:00Z',
+    expiresAt: '2099-01-01T00:00:00Z',
+    revoked: null,
+    authProof: 'local-hmac-irrelevant-cross-machine',
+    ...over,
+  };
+}
+
+function pemOf(key: crypto.KeyObject): string {
+  return key.export({ type: 'spki', format: 'pem' }).toString();
+}
+
+let dirs: string[] = [];
+function freshStore(): DeliveredMandateStore {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'afm-deliver-'));
+  dirs.push(dir);
+  return new DeliveredMandateStore({ filePath: path.join(dir, 'delivered-mandates.json') });
+}
+
+afterEach(() => {
+  for (const d of dirs) { try { SafeFsExecutor.safeRmSync(d, { recursive: true, force: true, operation: 'tests/unit/account-follow-me-mandate-delivery.test.ts:cleanup' }); } catch { /* @silent-fallback-ok: best-effort temp-dir cleanup */ } }
+  dirs = [];
+});
+
+describe('DeliveredMandateStore', () => {
+  it('persists + reads back a delivered mandate by id (idempotent put)', () => {
+    const op = crypto.generateKeyPairSync('ed25519');
+    const store = freshStore();
+    const portable = packageMandateForDelivery(mandate(), OP_FP, op.privateKey);
+    store.put(portable, OP_FP, pemOf(op.publicKey));
+    const rec = store.get('MND-deliver-1');
+    expect(rec).toBeDefined();
+    expect(rec!.deliveredBy).toBe(OP_FP);
+    expect(rec!.operatorPublicKeyPem).toContain('BEGIN PUBLIC KEY');
+    expect(rec!.portable.mandate.id).toBe('MND-deliver-1');
+    // Re-put overwrites (idempotent by id) — never duplicates.
+    store.put(portable, OP_FP, pemOf(op.publicKey));
+    expect(store.list()).toHaveLength(1);
+  });
+
+  it('remove() drops a delivered mandate (idempotent)', () => {
+    const op = crypto.generateKeyPairSync('ed25519');
+    const store = freshStore();
+    store.put(packageMandateForDelivery(mandate(), OP_FP, op.privateKey), OP_FP, pemOf(op.publicKey));
+    store.remove('MND-deliver-1');
+    expect(store.get('MND-deliver-1')).toBeUndefined();
+    store.remove('MND-deliver-1'); // no throw
+  });
+
+  it('missing file → empty list (deny-by-default safe state)', () => {
+    const store = new DeliveredMandateStore({ filePath: path.join(os.tmpdir(), 'does-not-exist-xyz', 'd.json') });
+    expect(store.list()).toEqual([]);
+    expect(store.get('any')).toBeUndefined();
+  });
+});
+
+describe('acceptMandateDelivery (WS5.2 R4a target-side gate)', () => {
+  function deps(store: DeliveredMandateStore, over: Partial<Parameters<typeof acceptMandateDelivery>[0]> = {}) {
+    return {
+      enabled: () => true,
+      selfMachineId: () => THIS_MACHINE,
+      operatorMachinePublicKey: (_s: string) => pemOf(crypto.generateKeyPairSync('ed25519').publicKey),
+      store,
+      ...over,
+    };
+  }
+
+  it('ACCEPTS a valid R4a-signed mandate from the trusted operator key → persists it', () => {
+    const op = crypto.generateKeyPairSync('ed25519');
+    const store = freshStore();
+    const portable = packageMandateForDelivery(mandate(), OP_FP, op.privateKey);
+    const r = acceptMandateDelivery(deps(store, { operatorMachinePublicKey: () => pemOf(op.publicKey) }), OP_FP, portable);
+    expect(r.accepted).toBe(true);
+    if (r.accepted) expect(r.mandateId).toBe('MND-deliver-1');
+    expect(store.get('MND-deliver-1')).toBeDefined();
+  });
+
+  it('REFUSES (fail-closed) when the feature is dark → persists nothing', () => {
+    const op = crypto.generateKeyPairSync('ed25519');
+    const store = freshStore();
+    const portable = packageMandateForDelivery(mandate(), OP_FP, op.privateKey);
+    const r = acceptMandateDelivery(deps(store, { enabled: () => false, operatorMachinePublicKey: () => pemOf(op.publicKey) }), OP_FP, portable);
+    expect(r.accepted).toBe(false);
+    if (!r.accepted) expect(r.reason).toBe('feature-disabled');
+    expect(store.list()).toHaveLength(0);
+  });
+
+  it('REFUSES when no operator key is registered (cannot ground the trust anchor)', () => {
+    const op = crypto.generateKeyPairSync('ed25519');
+    const store = freshStore();
+    const portable = packageMandateForDelivery(mandate(), OP_FP, op.privateKey);
+    const r = acceptMandateDelivery(deps(store, { operatorMachinePublicKey: () => null }), OP_FP, portable);
+    expect(r.accepted).toBe(false);
+    if (!r.accepted) expect(r.reason).toBe('no-operator-key-registered');
+    expect(store.list()).toHaveLength(0);
+  });
+
+  it('REFUSES a mandate signed by an UNTRUSTED key (bad signature against the registered key)', () => {
+    const op = crypto.generateKeyPairSync('ed25519');
+    const attacker = crypto.generateKeyPairSync('ed25519');
+    const store = freshStore();
+    // Signed by the attacker, but the registered operator key is op → signature verify fails.
+    const portable = packageMandateForDelivery(mandate(), OP_FP, attacker.privateKey);
+    const r = acceptMandateDelivery(deps(store, { operatorMachinePublicKey: () => pemOf(op.publicKey) }), OP_FP, portable);
+    expect(r.accepted).toBe(false);
+    if (!r.accepted) expect(r.reason).toMatch(/issuance-verify-failed/);
+    expect(store.list()).toHaveLength(0);
+  });
+
+  it('REFUSES when the authenticated sender ≠ the signed issuer fingerprint (issuer-not-trusted)', () => {
+    const op = crypto.generateKeyPairSync('ed25519');
+    const store = freshStore();
+    // Mandate signed binding issuer fingerprint OP_FP, but it is delivered by a DIFFERENT sender.
+    const portable = packageMandateForDelivery(mandate(), OP_FP, op.privateKey);
+    const r = acceptMandateDelivery(deps(store, { operatorMachinePublicKey: () => pemOf(op.publicKey) }), 'm_other_machine', portable);
+    expect(r.accepted).toBe(false);
+    if (!r.accepted) expect(r.reason).toMatch(/issuer-not-trusted/);
+    expect(store.list()).toHaveLength(0);
+  });
+
+  it('REFUSES a mandate targeting a DIFFERENT machine (exact-bounds, cannot be replayed)', () => {
+    const op = crypto.generateKeyPairSync('ed25519');
+    const store = freshStore();
+    const m = mandate({ authorities: [{ action: 'account-follow-me', bounds: { accountId: 'acct-1', targetMachineId: 'm_some_other_target', mechanism: 're-mint' } }] });
+    const portable = packageMandateForDelivery(m, OP_FP, op.privateKey);
+    const r = acceptMandateDelivery(deps(store, { operatorMachinePublicKey: () => pemOf(op.publicKey) }), OP_FP, portable);
+    expect(r.accepted).toBe(false);
+    if (!r.accepted) expect(r.reason).toBe('target-not-this-machine');
+    expect(store.list()).toHaveLength(0);
+  });
+
+  it('REFUSES a non-account-follow-me mandate', () => {
+    const op = crypto.generateKeyPairSync('ed25519');
+    const store = freshStore();
+    const m = mandate({ authorities: [{ action: 'sign-code-review', bounds: { artifact: 'x' } }] });
+    const portable = packageMandateForDelivery(m, OP_FP, op.privateKey);
+    const r = acceptMandateDelivery(deps(store, { operatorMachinePublicKey: () => pemOf(op.publicKey) }), OP_FP, portable);
+    expect(r.accepted).toBe(false);
+    if (!r.accepted) expect(r.reason).toBe('not-an-account-follow-me-mandate');
+    expect(store.list()).toHaveLength(0);
+  });
+
+  it('REFUSES a malformed portable mandate (fail-closed)', () => {
+    const store = freshStore();
+    const r = acceptMandateDelivery(deps(store), OP_FP, null);
+    expect(r.accepted).toBe(false);
+    if (!r.accepted) expect(r.reason).toBe('malformed-portable-mandate');
+  });
+});

--- a/tests/unit/account-followme-spend-slice.test.ts
+++ b/tests/unit/account-followme-spend-slice.test.ts
@@ -1,0 +1,164 @@
+/**
+ * Unit tests for WS5.2 R7a — per-account spend-slice ORCHESTRATION (AccountFollowMeSpendSlice.ts).
+ * Covers the distributed edge cases the spec names (§R7a, §S5, §I5, §8.4):
+ *   - SliceIssuer: fenced single-writer; sum-of-leases bound; lease-holder failover re-derivation.
+ *   - SliceRenewalControl: per-(account,machine) coalescing; rate-cap + exponential backoff; P19
+ *     breaker → fail closed to own account; O(per-account-cap) renewal rate (not O(N)).
+ *   - decideAccountUse: live slice → borrowed; exhausted / expired / stale-epoch / no-slice
+ *     (first-slice-under-partition) / flag-off → own account (fail-closed on EVERY uncertainty).
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  SliceIssuer,
+  SliceRenewalControl,
+  decideAccountUse,
+  type SliceRenewRequest,
+} from '../../src/core/AccountFollowMeSpendSlice.js';
+import { inMemoryGrantStore, type GrantStore } from '../../src/core/AccountFollowMeGrants.js';
+
+const FUTURE = 9_000_000_000_000;
+function req(over: Partial<SliceRenewRequest> = {}): SliceRenewRequest {
+  return {
+    grantId: 'g1', mandateId: 'M1', accountId: 'acct', requestingMachineFp: 'fp-mini',
+    amount: 0.3, expiresAt: FUTURE, ...over,
+  };
+}
+
+describe('SliceIssuer — fenced single-writer (R7a(a))', () => {
+  it('a NON-holder cannot issue a slice (only the fenced single-writer issues)', () => {
+    const issuer = new SliceIssuer(inMemoryGrantStore(), {
+      selfMachineId: 'B', holdsLease: () => false, currentLeaseEpoch: () => 5, now: () => 1000,
+    });
+    expect(issuer.issueForRenew(req(), { ceiling: 1.0 })).toEqual({ ok: false, reason: 'not-lease-holder' });
+  });
+
+  it('the holder issues a slice stamped with the current lease epoch', () => {
+    const issuer = new SliceIssuer(inMemoryGrantStore(), {
+      selfMachineId: 'A', holdsLease: () => true, currentLeaseEpoch: () => 7, now: () => 1000,
+    });
+    const r = issuer.issueForRenew(req({ amount: 0.4 }), { ceiling: 1.0 });
+    expect(r).toMatchObject({ ok: true, amount: 0.4, leaseEpoch: 7 });
+  });
+
+  it('enforces the sum-of-leases ceiling across machines (a 6th VM does not raise it)', () => {
+    const store = inMemoryGrantStore();
+    const issuer = new SliceIssuer(store, {
+      selfMachineId: 'A', holdsLease: () => true, currentLeaseEpoch: () => 1, now: () => 1000,
+    });
+    for (let i = 0; i < 5; i++) {
+      expect(issuer.issueForRenew(req({ grantId: `g${i}`, requestingMachineFp: `fp${i}`, amount: 0.2 }), { ceiling: 1.0 }).ok).toBe(true);
+    }
+    // The aggregate is at the ceiling; the next slice is refused — bound is sum-of-leases, not N×ceiling.
+    expect(issuer.issueForRenew(req({ grantId: 'g6', requestingMachineFp: 'fp6', amount: 0.2 }), { ceiling: 1.0 }))
+      .toEqual({ ok: false, reason: 'would-exceed-ceiling' });
+    expect(issuer.outstandingFor('acct')).toBeCloseTo(1.0);
+  });
+
+  it('lease-holder FAILOVER re-derives outstanding from the durable ledger → no double-allocation', () => {
+    const store: GrantStore = inMemoryGrantStore();
+    // Holder A issues 0.7 of the ceiling under epoch 5.
+    const holderA = new SliceIssuer(store, {
+      selfMachineId: 'A', holdsLease: () => true, currentLeaseEpoch: () => 5, now: () => 1000,
+    });
+    expect(holderA.issueForRenew(req({ grantId: 'gA', requestingMachineFp: 'fpA', amount: 0.7 }), { ceiling: 1.0 }).ok).toBe(true);
+    // A dies; B wins the fenced lease at epoch 6 and rebuilds from the SAME store BEFORE issuing.
+    const holderB = new SliceIssuer(store, {
+      selfMachineId: 'B', holdsLease: () => true, currentLeaseEpoch: () => 6, now: () => 1000,
+    });
+    expect(holderB.outstandingFor('acct')).toBeCloseTo(0.7);
+    // B cannot over-allocate beyond the already-committed 0.7 — the bound holds across the handoff.
+    expect(holderB.issueForRenew(req({ grantId: 'gB', requestingMachineFp: 'fpB', amount: 0.4 }), { ceiling: 1.0 }))
+      .toEqual({ ok: false, reason: 'would-exceed-ceiling' });
+    expect(holderB.issueForRenew(req({ grantId: 'gB', requestingMachineFp: 'fpB', amount: 0.3 }), { ceiling: 1.0 }).ok).toBe(true);
+  });
+});
+
+describe('SliceRenewalControl — control plane (R7a(c), O(per-account-cap) not O(N))', () => {
+  it('coalesces: a VM with an in-flight renewal does not start a second', () => {
+    let t = 100000;
+    const ctl = new SliceRenewalControl({ now: () => t });
+    expect(ctl.shouldAttempt().proceed).toBe(true);
+    ctl.beginAttempt();
+    // Even after the rate window, a second attempt is refused while one is in flight.
+    t += 1_000_000;
+    expect(ctl.shouldAttempt()).toEqual({ proceed: false, reason: 'coalesced-in-flight' });
+  });
+
+  it('rate-caps with exponential backoff after a refusal/failure', () => {
+    let t = 0;
+    const ctl = new SliceRenewalControl({ now: () => t, minRenewIntervalMs: 1000, backoffMultiplier: 2 });
+    ctl.beginAttempt();
+    ctl.recordOutcome('refused');
+    // Inside the (backed-off) window → rate-capped.
+    t = 1500;
+    expect(ctl.shouldAttempt()).toEqual({ proceed: false, reason: 'rate-capped' });
+    // After the backed-off interval (2000ms) → allowed again.
+    t = 2001;
+    expect(ctl.shouldAttempt().proceed).toBe(true);
+  });
+
+  it('a refusal (grant-level) does NOT advance the breaker — only transport failures do', () => {
+    let t = 0;
+    const ctl = new SliceRenewalControl({ now: () => t, minRenewIntervalMs: 1, breakerThreshold: 2 });
+    for (let i = 0; i < 5; i++) { ctl.beginAttempt(); ctl.recordOutcome('refused'); t += 1000; }
+    expect(ctl.breakerOpen()).toBe(false);
+  });
+
+  it('P19 breaker opens after N consecutive transport FAILURES → fail closed to own account', () => {
+    let t = 0;
+    const ctl = new SliceRenewalControl({ now: () => t, minRenewIntervalMs: 1, breakerThreshold: 3, breakerCooldownMs: 60000 });
+    for (let i = 0; i < 3; i++) { ctl.beginAttempt(); ctl.recordOutcome('failed'); t += 1000; }
+    expect(ctl.breakerOpen()).toBe(true);
+    expect(ctl.shouldAttempt()).toEqual({ proceed: false, reason: 'breaker-open' });
+    // After the cooldown a probe is allowed again.
+    t += 60000;
+    expect(ctl.breakerOpen()).toBe(false);
+  });
+
+  it('a successful issue resets backoff AND the breaker', () => {
+    let t = 0;
+    const ctl = new SliceRenewalControl({ now: () => t, minRenewIntervalMs: 1000, breakerThreshold: 2 });
+    ctl.beginAttempt(); ctl.recordOutcome('failed'); t += 5000;
+    ctl.beginAttempt(); ctl.recordOutcome('issued');
+    // Interval is back to the floor (1000) and the breaker is closed.
+    t += 1001;
+    expect(ctl.breakerOpen()).toBe(false);
+    expect(ctl.shouldAttempt().proceed).toBe(true);
+  });
+});
+
+describe('decideAccountUse — selection-time consultation (R7a(b)/(d), S5)', () => {
+  const base = { followMeEnabled: true, isBorrowedAccount: true, currentLeaseEpoch: 5, now: 1000 };
+
+  it('a live, current-epoch slice with remaining budget → BORROWED', () => {
+    const d = decideAccountUse({ ...base, slice: { grantId: 'g1', remaining: 0.2, leaseEpoch: 5, expiresAt: FUTURE } });
+    expect(d).toEqual({ use: 'borrowed', remaining: 0.2, reason: 'live-slice' });
+  });
+
+  it('flag off → OWN account (byte-identical default behavior)', () => {
+    const d = decideAccountUse({ ...base, followMeEnabled: false, slice: { grantId: 'g1', remaining: 0.2, leaseEpoch: 5, expiresAt: FUTURE } });
+    expect(d).toEqual({ use: 'own', reason: 'follow-me-disabled' });
+  });
+
+  it('not a borrowed account → OWN account', () => {
+    expect(decideAccountUse({ ...base, isBorrowedAccount: false, slice: undefined }).reason).toBe('not-a-borrowed-account');
+  });
+
+  it('first-slice-under-partition (never received a slice) → OWN account', () => {
+    expect(decideAccountUse({ ...base, slice: undefined }).reason).toBe('no-slice');
+    expect(decideAccountUse({ ...base, slice: { remaining: 0.5, leaseEpoch: 5, expiresAt: FUTURE } }).reason).toBe('no-slice');
+  });
+
+  it('exhausted slice → OWN account', () => {
+    expect(decideAccountUse({ ...base, slice: { grantId: 'g1', remaining: 0, leaseEpoch: 5, expiresAt: FUTURE } }).reason).toBe('slice-exhausted');
+  });
+
+  it('expired slice → OWN account', () => {
+    expect(decideAccountUse({ ...base, now: 5000, slice: { grantId: 'g1', remaining: 0.5, leaseEpoch: 5, expiresAt: 2000 } }).reason).toBe('slice-expired');
+  });
+
+  it('a slice from a SUPERSEDED lease epoch (holder failed over) is void → OWN account', () => {
+    expect(decideAccountUse({ ...base, currentLeaseEpoch: 6, slice: { grantId: 'g1', remaining: 0.5, leaseEpoch: 5, expiresAt: FUTURE } }).reason).toBe('stale-lease-epoch');
+  });
+});

--- a/tests/unit/anthropic-subscription-router.test.ts
+++ b/tests/unit/anthropic-subscription-router.test.ts
@@ -234,3 +234,59 @@ describe('InteractivePoolIntelligenceProvider', () => {
     );
   });
 });
+
+describe('AnthropicSubscriptionRouter — WS5.2 R7a slice consultation (S5, §6.2)', () => {
+  it('unwired consultSlice → byte-identical: pool is called, no consultation surfaced', async () => {
+    const pool = provider('pool');
+    const onSliceConsult = vi.fn();
+    const router = new AnthropicSubscriptionRouter({
+      headless: provider('hl'), pool, mode: 'force',
+      readSdkCredit: async () => null, onSliceConsult,
+    });
+    expect(await router.evaluate('x')).toBe('pool:ok');
+    expect(pool.calls.length).toBe(1);
+    expect(onSliceConsult).not.toHaveBeenCalled();
+  });
+
+  it('force mode → consults the slice before the subscription-pool call', async () => {
+    const consultSlice = vi.fn(() => ({ use: 'own' as const, reason: 'no-slice' as const }));
+    const onSliceConsult = vi.fn();
+    const router = new AnthropicSubscriptionRouter({
+      headless: provider('hl'), pool: provider('pool'), mode: 'force',
+      readSdkCredit: async () => null, consultSlice, onSliceConsult,
+    });
+    await router.evaluate('x', { attribution: { component: 'C' } });
+    expect(consultSlice).toHaveBeenCalledTimes(1);
+    expect(onSliceConsult).toHaveBeenCalledWith({ decision: { use: 'own', reason: 'no-slice' }, component: 'C' });
+  });
+
+  it('auto mode → consults ONLY when the subscription-pool path is selected (not on sdk-credit)', async () => {
+    const consultSlice = vi.fn(() => ({ use: 'borrowed' as const, remaining: 0.3, reason: 'live-slice' as const }));
+    // Above margin → sdk-credit primary → NO slice consultation.
+    const sdk = new AnthropicSubscriptionRouter({
+      headless: provider('hl'), pool: provider('pool'), mode: 'auto',
+      readSdkCredit: async () => snapshot(200, 200), consultSlice,
+    });
+    await sdk.evaluate('x');
+    expect(consultSlice).not.toHaveBeenCalled();
+    // Null credit → subscription floor primary → slice IS consulted.
+    consultSlice.mockClear();
+    const sub = new AnthropicSubscriptionRouter({
+      headless: provider('hl'), pool: provider('pool'), mode: 'auto',
+      readSdkCredit: async () => null, consultSlice,
+    });
+    await sub.evaluate('x');
+    expect(consultSlice).toHaveBeenCalledTimes(1);
+  });
+
+  it('auto mode fallback to subscription after sdk failure → consults the slice on the fallback', async () => {
+    const consultSlice = vi.fn(() => ({ use: 'own' as const, reason: 'slice-exhausted' as const }));
+    const router = new AnthropicSubscriptionRouter({
+      headless: provider('hl', async () => { throw new Error('sdk down'); }),
+      pool: provider('pool'), mode: 'auto',
+      readSdkCredit: async () => snapshot(200, 200), consultSlice,
+    });
+    expect(await router.evaluate('x')).toBe('pool:ok');
+    expect(consultSlice).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/unit/dashboard-mandatesTab.test.ts
+++ b/tests/unit/dashboard-mandatesTab.test.ts
@@ -171,6 +171,39 @@ describe('mandates.js controller — the PIN discipline', () => {
     controller.stop();
   });
 
+  it('WS5.2 R4a — an account-follow-me authority routes issuance through /mandate/issue-for-machine', async () => {
+    const { controller, els, calls } = controllerWith({
+      '/mandate/issue-for-machine': { status: 201, body: { issued: true, delivered: true, mandate: { id: 'm-fm' } } },
+    });
+    controller.start();
+    // The operator authorizes account acct-1 to follow onto machine m_mini (one dashboard).
+    els.issueAuthorities.value = '[{"action":"account-follow-me","bounds":{"accountId":"acct-1","targetMachineId":"m_mini","mechanism":"re-mint"}}]';
+    els.issuePin.value = '424242';
+    await (els.issueBtn.onclick as any)();
+    // It went to the issue-for-machine route, NOT plain /mandate/issue, carrying the bounds + PIN.
+    const ifm = calls.find((c) => c.url === '/mandate/issue-for-machine');
+    expect(ifm).toBeTruthy();
+    const body = JSON.parse(ifm!.opts.body);
+    expect(body).toMatchObject({ pin: '424242', accountId: 'acct-1', targetMachineId: 'm_mini' });
+    expect(calls.some((c) => c.url === '/mandate/issue')).toBe(false);
+    expect(els.notice.textContent).toMatch(/delivered to the target/);
+    expect(els.issuePin.value).toBe(''); // PIN never retained
+    controller.stop();
+  });
+
+  it('WS5.2 R4a — a follow-me delivery failure (502) is surfaced honestly as retry-able', async () => {
+    const { controller, els } = controllerWith({
+      '/mandate/issue-for-machine': { status: 502, body: { issued: true, delivered: false, mandate: { id: 'm-fm' }, reason: 'no-peer-url' } },
+    });
+    controller.start();
+    els.issueAuthorities.value = '[{"action":"account-follow-me","bounds":{"accountId":"acct-1","targetMachineId":"m_mini","mechanism":"re-mint"}}]';
+    els.issuePin.value = '424242';
+    await (els.issueBtn.onclick as any)();
+    expect(els.notice.textContent).toMatch(/delivery to the target failed/);
+    expect(els.notice.textContent).toMatch(/no-peer-url/);
+    controller.stop();
+  });
+
   it('start() prefills the A/A/B authorities template only when empty', () => {
     const { controller, els } = controllerWith({});
     els.issueAuthorities.value = '';

--- a/tests/unit/lint-dev-agent-dark-gate.test.ts
+++ b/tests/unit/lint-dev-agent-dark-gate.test.ts
@@ -400,11 +400,11 @@ describe('lint-dev-agent-dark-gate', () => {
       // DEV_GATED_FEATURES) so it introduces no new attributed path. After merging JKHeadley/main
       // (which added its own config above), the sessionPool keys resolve to 872/897/926.
       // RE-VERIFIED by hand via the attributor on the MERGED ConfigDefaults.
-      // R6b: the accountFollowMe block gained `remoteScrapeTimeoutMs` (+ comment, ~7 lines)
-      // ABOVE these keys, shifting each DOWN by +7. RE-VERIFIED via the attributor.
-      '901': 'multiMachine.sessionPool.enabled',
-      '926': 'multiMachine.sessionPool.inboundQueue.enabled',
-      '955': 'multiMachine.sessionPool.holdForStability.enabled',
+      // R6b: the accountFollowMe block gained `remoteScrapeTimeoutMs` (+7); R7a added the
+      // `spendSlice` block (+23 more) ABOVE these keys → +23 vs R6b. RE-VERIFIED via the attributor.
+      '924': 'multiMachine.sessionPool.enabled',
+      '949': 'multiMachine.sessionPool.inboundQueue.enabled',
+      '978': 'multiMachine.sessionPool.holdForStability.enabled',
       // mm-stores-devgate (operator directive 2026-06-13, topic 13481): the 7
       // multiMachine.stateSync.* memory stores MOVED from DARK_GATE_EXCLUSIONS to
       // DEV_GATED_FEATURES and their `enabled: false` literals were REMOVED from
@@ -438,10 +438,10 @@ describe('lint-dev-agent-dark-gate', () => {
       // attributor on the edited ConfigDefaults.
       // After merging JKHeadley/main + my accountFollowMe block, these resolve as below.
       // RE-VERIFIED by hand via the attributor on the MERGED ConfigDefaults.
-      '1124': 'multiMachine.stateSync.threadlinePairing.enabled',
-      '1246': 'cartographer.freshnessSweep.enabled',
-      '1291': 'cartographer.conformanceAudit.llmEnrichment.enabled',
-      '1316': 'cartographer.subtreeNav.llmRerank.enabled',
+      '1147': 'multiMachine.stateSync.threadlinePairing.enabled',
+      '1269': 'cartographer.freshnessSweep.enabled',
+      '1314': 'cartographer.conformanceAudit.llmEnrichment.enabled',
+      '1339': 'cartographer.subtreeNav.llmRerank.enabled',
     };
     const actual = attributeRealConfigDefaults();
     expect(actual).toEqual(EXPECTED);

--- a/upgrades/next/ws52-account-follow-me-r7a-spend-slice.md
+++ b/upgrades/next/ws52-account-follow-me-r7a-spend-slice.md
@@ -1,0 +1,19 @@
+## What Changed
+
+WS5.2 R7a — the per-account spend ceiling, lease-sliced and owned by the fenced single-writer, so multiple machines sharing one operator account can never collectively over-spend its quota (bounded by sum-of-leases, never N×ceiling — even under partition and across a lease-holder failover). New module `src/core/AccountFollowMeSpendSlice.ts` (pure/injectable): `SliceIssuer` (holder-side; refuses unless it holds the live fenced lease; delegates the sum-of-leases ceiling to the durable PR1 grant-ledger; epoch-stamps every slice), `SliceRenewalControl` (requester-side rate-cap + exponential backoff + per-(account,machine) coalescing + a P19 breaker that fails a machine closed to its OWN account when the holder is slow/partitioned — so the renewal RPC rate is O(per-account-cap), not O(N)), and `decideAccountUse` (the pure selection-time check — a borrowed account is used ONLY for a live, current-epoch, unexpired, positive-remaining slice; every uncertainty falls back to the machine's own account). A new operator-mandate-gated `slice-renew` mesh verb (its own deny-by-default RBAC case). The `AnthropicSubscriptionRouter` gains an optional consult hook (subscription-path only). Config knobs under `multiMachine.accountFollowMe.spendSlice`. Dark behind `multiMachine.accountFollowMe`.
+
+**Scope (honest):** this delivers the spend-ceiling MECHANISM + the consultation; the router currently surfaces the decision to observability. The pool's account selection actually choosing own-vs-borrowed based on it is the enforcement integration that requires the (not-yet-live) borrowed-account-in-pool concept — so the consultation is inert today by construction (nothing is borrowed yet), leaving no reachable over-spend path unguarded. The enforcement wiring lands with that selection layer.
+
+## Evidence
+
+- 59+ tests across `account-followme-spend-slice` (fenced issuance, non-holder refusal, sum-of-leases/Nth-VM refusal, failover re-derivation with no double-allocation, coalescing, rate-cap+backoff, refusal-vs-failure breaker distinction, breaker open/cooldown/reset, all `decideAccountUse` branches), `MeshRpc` (slice-renew deny-by-default RBAC: unwired/rogue/mandated), and `anthropic-subscription-router` (unwired byte-identical, consult on subscription paths only). `tsc --noEmit` clean. Dark-gate lint golden-map updated for the new config block (24/24).
+- Side-effects review + mandatory independent second-pass security review (concurred on all 7 audit points: sum-of-leases bound, failover no-double-allocation, fail-closed-to-own everywhere, deny-by-default RBAC, O(per-account-cap) control plane, dark-by-default, no fail-open).
+- Spec: `docs/specs/ws52-account-follow-me-security.md` R7a/R7/S5 (converged, approved).
+
+## What to Tell Your User
+
+Nothing to do — this ships off by default. It's the safety cap that lets several of your machines share one subscription account without them collectively blowing past that account's quota: each machine gets a metered slice of the account's allowance from one coordinating machine, and if it can't reach that coordinator it quietly uses its own account instead of overspending the shared one.
+
+## Summary of New Capabilities
+
+Cross-machine per-account spend ceiling (dark): lease-sliced sub-budgets issued by the fenced single-writer, bounded by sum-of-leases under partition + failover, with an operator-mandate-gated renewal mesh verb and fail-closed-to-own-account on every uncertainty. No user-facing surface is live in this release.

--- a/upgrades/next/ws52-one-dashboard-mandate-delivery.md
+++ b/upgrades/next/ws52-one-dashboard-mandate-delivery.md
@@ -1,0 +1,17 @@
+## What Changed
+
+WS5.2 — one-dashboard cross-machine mandate delivery. Closes a real UX gap: authorizing an account-follow-me enrollment on another machine used to require a PIN-gated mandate issued on THAT machine's own dashboard (per-machine friction). Now the operator's SINGLE dashboard does it: a new PIN-gated `POST /mandate/issue-for-machine` issues the mandate locally and, for a remote target, packages it with the operator machine's Ed25519 signature (the already-approved ws52 R4a bridge) and delivers it over a new `account-follow-me-mandate-deliver` mesh verb. The target authenticates the mesh sender (existing Ed25519 envelope verification → the registered operator-machine identity), R4a-verifies the mandate's issuance signature against that registered key (a name in the payload is never trusted — Know Your Principal), checks the exact bounds (account-follow-me / this machine / re-mint), and persists it to a new `DeliveredMandateStore`. The enroll-start route then consults the delivered mandate (re-verifying the signature at point-of-use) when the local gate has none — both paths fail-closed. The core MandateGate authorship model is untouched. Dark behind `multiMachine.accountFollowMe`.
+
+## Evidence
+
+- 122 tests across 11 files (delivery store + accept/trust path: valid R4a → stored+honored; bad signature / untrusted key / issuer≠sender / wrong-target / wrong-mechanism / non-follow-me → refused & nothing persisted; mesh-verb RBAC deny-by-default; issue-for-machine PIN-gated + dark→503 + honest 502 on delivery failure + local-target unchanged; enroll-start honoring a delivered+verified mandate vs 403 without one; dashboard routing). `tsc --noEmit` clean.
+- Side-effects review + mandatory independent second-pass security review (concurred on all 8 points: trust anchor = authenticated sender never payload, R4a load-bearing fail-closed, exact-bounds double-gated no-replay, enroll-start additive fail-closed with point-of-use re-verify, PIN-gated issuance / no self-issue, deny-by-default mesh RBAC, dark-by-default, no fail-open).
+- Spec: `docs/specs/ws52-account-follow-me-security.md` R4a/R1/R6a (converged, approved) — wires the spec's R4a cross-machine mandate bridge.
+
+## What to Tell Your User
+
+You now manage everything from your ONE dashboard — no more "open the other machine's dashboard." When you approve a machine to use one of your accounts, you do it once on your single dashboard with your PIN; your approval is cryptographically signed and delivered to that machine, which verifies it really came from you before acting. You never touch the other machine. (Off by default while the broader account-sharing feature is dark.)
+
+## Summary of New Capabilities
+
+One-dashboard cross-machine mandate authorization (dark): issue + deliver an account-follow-me mandate to any of your machines from your single dashboard; the target verifies it via the R4a operator signature and honors it only for its exact bounds. New PIN-gated `POST /mandate/issue-for-machine` + the `account-follow-me-mandate-deliver` mesh verb. No user-facing surface is live until `multiMachine.accountFollowMe` is enabled.

--- a/upgrades/side-effects/ws52-account-follow-me-r7a-spend-slice.md
+++ b/upgrades/side-effects/ws52-account-follow-me-r7a-spend-slice.md
@@ -1,0 +1,70 @@
+# Side-Effects Review — WS5.2 R7a: lease-sliced per-account spend ceiling
+
+**Version / slug:** `ws52-account-follow-me-r7a-spend-slice`
+**Date:** `2026-06-17`
+**Author:** `Echo (instar-dev agent)`
+**Second-pass reviewer:** `pending (HIGHEST-risk: cross-machine money/quota ceiling under partition + a new operator-mandate-gated mesh verb)`
+
+## Summary of the change
+
+WS5.2 R7a. A per-account spend ceiling, lease-sliced, owned by the fenced single-writer (the `FencedLease` holder), so N machines sharing one operator account can never collectively over-spend its quota — bounded by sum-of-leases, never N×ceiling, even under partition and across lease-holder failover. New module `src/core/AccountFollowMeSpendSlice.ts` (pure/injectable): `SliceIssuer` (holder-side — refuses `not-lease-holder`, stamps the current lease epoch, delegates the sum-of-leases ceiling to the existing durable `AccountFollowMeGrantLedger`); `SliceRenewalControl` (requester-side rate-cap + exponential backoff + per-(account,machine) coalescing + P19 breaker → fail-closed-to-own-account on a slow/partitioned holder); `decideAccountUse` (pure selection-time consultation — borrowed account used ONLY for a live, current-epoch, unexpired, remaining>0 slice; every uncertainty → own account). A new operator-mandate-gated `slice-renew` mesh verb in `MeshRpc.ts` (its own deny-by-default `checkCommandRBAC` case via an injected `authorizeSliceRenew` seam). `AnthropicSubscriptionRouter` gains optional `consultSlice`/`onSliceConsult` hooks invoked only on the subscription-pool selection path (no-op when unwired). Config knobs under `multiMachine.accountFollowMe.spendSlice`. Dark behind `multiMachine.accountFollowMe`; default behavior byte-identical when the hook is unwired/off.
+
+## Decision-point inventory
+
+- `slice-renew` mesh verb RBAC — **add** — deny-by-default; only the operator-mandate-authorized requester (via `authorizeSliceRenew`) may request a slice; absent seam → deny.
+- `SliceIssuer.issueForRenew` — **add** — only the live `FencedLease` holder issues; ceiling enforced by the durable ledger; epoch-stamped.
+- `decideAccountUse` — **add** — selection-time: borrowed vs own account; fail-closed-to-own on every uncertainty.
+- `SliceRenewalControl` — **add** — the control-plane bound (rate-cap/coalesce/breaker) → O(per-account-cap) renewal RPCs.
+
+---
+
+## 1. Over-block
+
+The conservative direction is intentional: when a slice is unknown/stale/expired/exhausted, or the holder is slow/partitioned, a machine "over-blocks" by falling back to its OWN account rather than using the borrowed one. This is the REQUIRED safe direction (never overspend a borrowed money/quota credential). It cannot wrongly deny the machine's own account (fallback is always available). No legitimate over-block of a healthy borrowed slice (a live current-epoch slice with budget is used).
+
+## 2. Under-block
+
+The ceiling is enforced at slice ISSUANCE (the ledger refuses `outstanding + amount > ceiling`) and at selection (a machine without budget falls back). It does NOT meter per-call token spend WITHIN a slice — a slice is a pre-allocated sub-budget; intra-slice accounting is the slice's granularity (by design — the spec's lease-slice model). A compromised holder could in principle over-issue, but the holder is the fenced single-writer (the same trust root as who-is-awake) and the ledger still caps the durable sum; a non-holder cannot issue at all.
+
+## 3. Level-of-abstraction fit
+
+Correct layers: issuance authority on the FencedLease holder (the existing single-writer), durable accounting in the existing GrantLedger (reused, not rebuilt), the renewal control-plane as a pure injectable state machine, the consultation as a pure function the router calls. The mesh verb sits in MeshRpc with the other commands. No logic duplicated; the ledger's sum-of-leases + epoch-fencing is reused as-is.
+
+## 4. Signal vs authority compliance
+
+The authority here (issue a spend slice) is held by the fenced single-writer + gated by the operator mandate (deny-by-default) — appropriate, not a brittle heuristic. The consultation (`decideAccountUse`) is a deterministic pure function (field checks on a slice), fail-closed. The breaker is a signal (consecutive transport failures → open) that only ever makes a machine MORE conservative (fall back to own account). No brittle blocking authority over user actions. Reference `docs/signal-vs-authority.md`: operator-mandate + fenced-single-writer authority, deny-by-default, is correctly-placed.
+
+## 5. Interactions
+
+Reuses `AccountFollowMeGrantLedger` (PR1) for the durable sum-of-leases bound + epoch-fenced consume — failover re-derivation is "for free" because `SliceIssuer` holds no in-memory slice state (reads the durable store live; a new holder over the same store sees the committed set). The `not-lease-holder` guard prevents a stale ex-holder from issuing during a handoff. The breaker distinguishes grant REFUSALS (`would-exceed-ceiling` — the holder answered; back off but don't trip) from transport FAILURES (trip the breaker) — so a healthy-but-full account doesn't open the breaker. The router hook runs only on the subscription path (never sdk-credit), so it can't perturb SDK routing.
+
+## 6. External surfaces
+
+One new mesh verb (`slice-renew`), deny-by-default, dark behind the flag. New config block (`spendSlice`, additive, defaulted). No new HTTP route. When `multiMachine.accountFollowMe` is off (or the router hook unwired — the default), behavior is byte-identical: the consult hook is never invoked. Other agents see the new verb only if they're mandated peers in a follow-me pool.
+
+## 7. Multi-machine posture (Cross-Machine Coherence)
+
+This IS a multi-machine coherence mechanism by construction. The single source of truth is the fenced-lease holder + the durable grant-ledger; slices are epoch-stamped so a failover voids stale-epoch slices and the new holder re-derives the outstanding set from the durable store before issuing — the sum-of-leases bound holds across the handoff with no double-allocation. Under partition, a VM that can't reach the holder fails closed to its own account (bounded, never unbounded overshoot). The renewal control plane is O(per-account-cap), not O(N), so it can't storm the holder. A single-machine agent is a no-op (no peers, the flag is off).
+
+## 8. Rollback cost
+
+Low. Entirely dark behind `multiMachine.accountFollowMe` + the unwired router hook → no live effect by default. New module + additive config + one mesh verb. Revert is a single-commit back-out; no migration, no persisted-schema change (the slice records live in the existing grant-ledger store, which already shipped in PR1).
+
+---
+
+## Scope note (honest, not a hidden deferral)
+
+R7a delivers the spend-ceiling MECHANISM end-to-end: the fenced-single-writer slice issuer (ledger-backed sum-of-leases ceiling + epoch-fenced failover re-derivation), the requester-side renewal control plane (rate-cap + coalescing + P19 breaker → O(per-account-cap)), the operator-mandate-gated `slice-renew` mesh verb, the pure `decideAccountUse` consultation (fail-closed-to-own on every uncertainty), AND the router hook that invokes it. The router currently SURFACES the decision to observability (`onSliceConsult`); the pool's account-selection actually CHOOSING own-vs-borrowed based on that decision is the enforcement integration that belongs to — and requires — the borrowed-account-in-pool concept, which is not yet live (enrollment adds accounts as normal local accounts; nothing is marked `isBorrowedAccount` yet). So the consultation is inert today by construction (every account → `own`), meaning there is NO reachable over-spend path that this layer leaves unguarded. This is the correct decomposition for a dark mechanism, not a deferral of reachable behavior; the enforcement wiring lands with the borrowed-account selection layer.
+
+## Second-pass review
+
+**Concur with the review** (security substance) — the independent reviewer verified all 7 points directly:
+1. **Sum-of-leases bound holds** — `SliceIssuer.issueForRenew` delegates to the ledger's `issue()` (re-reads outstanding from the durable store, refuses `outstanding + amount > ceiling`); `SliceIssuer` holds ZERO in-memory accounting state; the `GrantStore` is synchronous so no interleave past the ceiling (structural invariant: keep the store synchronous). `outstandingFor` conservatively over-counts (safe direction).
+2. **Failover / no double-allocation** — `holdsLease()` blocks a stale ex-holder; the new holder re-derives from the same durable store; epoch-stamped slices are void on stale epoch. Tested.
+3. **Fail-closed-to-own on every uncertainty** — `decideAccountUse` returns `own` for flag-off / not-borrowed / no-slice / stale-epoch / expired / `!(remaining>0)` (0, negative, NaN). `borrowed` only via a live current-epoch unexpired positive-remaining slice.
+4. **slice-renew RBAC deny-by-default** — own `checkCommandRBAC` case; `authorizeSliceRenew?.(...) ?? false` → absent seam OR false → 403; not the any-peer read class.
+5. **Control plane O(per-account-cap)** — coalescing + rate-cap + exponential backoff + P19 breaker on transport `failed` only; grant `refused` (would-exceed-ceiling) backs off but does NOT trip the breaker.
+6. **Dark by default / byte-identical when off** — `consultSlice` no-ops when unwired; subscription-path only, never sdk-credit. (Observe-only in this layer — see Scope note above.)
+7. **No fail-open** — no catch/`||true`/default-allow; every positive outcome follows explicit guards.
+
+The reviewer's one CONCERN was the dark-gate lint golden-map line shift from the new `spendSlice` config block — **FIXED**: the 7 shifted entries updated to the attributor's values (924/949/978/1147/1269/1314/1339); `lint-dev-agent-dark-gate.test.ts` now 24/24 green. tsc EXIT=0; the 3 R7a suites 59 passed.

--- a/upgrades/side-effects/ws52-one-dashboard-mandate-delivery.md
+++ b/upgrades/side-effects/ws52-one-dashboard-mandate-delivery.md
@@ -1,0 +1,74 @@
+# Side-Effects Review — WS5.2 one-dashboard cross-machine mandate delivery
+
+**Version / slug:** `ws52-one-dashboard-mandate-delivery`
+**Date:** `2026-06-17`
+**Author:** `Echo (instar-dev agent)`
+**Second-pass reviewer:** `concurred (HIGH-stakes: cross-machine authorization delivery)`
+
+## Summary of the change
+
+Operator feedback (topic 13481): "there should only be ONE dashboard for the agent, not one per machine." Today an account-follow-me enrollment on a TARGET machine needs a PIN-gated mandate ISSUED on that target's OWN dashboard — the per-machine friction the operator rejects. This change lets the operator's SINGLE dashboard issue + deliver the mandate to the target, verified there via the already-approved ws52 R4a bridge. New `POST /mandate/issue-for-machine` (PIN-gated, same auth as `/mandate/issue`): issues the mandate locally, then for a REMOTE target packages it (`packageMandateForDelivery`, signed with this operator machine's Ed25519 identity key) and dispatches it over a new `account-follow-me-mandate-deliver` mesh verb. The target's handler authenticates the mesh `sender` (existing Ed25519 envelope verification → the registered operator-machine identity), resolves that sender's REGISTERED key, R4a-verifies the mandate's issuance signature against it (`acceptMandateDelivery` → `acceptDeliveredMandate`, with `expectedIssuer === authenticated sender`), checks exact bounds (account-follow-me / this machine / re-mint), and only then persists it to a new `DeliveredMandateStore`. The enroll-start route (`POST /subscription-pool/follow-me/enroll/start`) now, when the LOCAL gate denies, ALSO consults the delivered mandate — re-verifying the R4a signature at point-of-use and re-checking bounds — both paths fail-closed (403). Files: `AccountFollowMeMandateDelivery.ts` + `DeliveredMandateStore.ts` (new), `MeshRpc.ts`, `routes.ts`, `AgentServer.ts`, `commands/server.ts`, `dashboard/mandates.js`. Dark behind `multiMachine.accountFollowMe`.
+
+## Decision-point inventory
+
+- `account-follow-me-mandate-deliver` mesh verb handler / `acceptMandateDelivery` — **add** — the cross-machine authorization-acceptance decision: a delivered mandate is trusted ONLY via R4a verification against the authenticated sender's registered key + exact bounds. Deny-by-default.
+- `POST /mandate/issue-for-machine` — **add** — PIN-gated issuance + remote delivery (agent cannot self-issue).
+- enroll-start delivered-mandate consultation — **modify** — an ADDITIONAL fail-closed authorization source alongside the unchanged local gate.
+
+---
+
+## 1. Over-block
+Conservative by design: any uncertainty (no registered operator key for the sender, signature fails, bounds mismatch, target≠this machine, feature off) denies. The operator's own PIN-gated issuance is unchanged, so the operator is never wrongly blocked from authorizing; a delivery that can't be verified simply isn't honored (the operator retries / the honest 502 surfaces). No legitimate authorized enrollment is rejected.
+
+## 2. Under-block
+The delivered mandate authorizes ONLY its exact bounds (account-follow-me, specific accountId, this targetMachineId, re-mint). It cannot be replayed for another account/machine. It does not expand what a mandate authorizes — it only changes WHERE the operator can issue it from (one dashboard) and HOW it reaches the target (signed mesh delivery). The downstream S7 email-gate + the enrollment flow are unchanged.
+
+## 3. Level-of-abstraction fit
+Correct: issuance stays in the PIN-gated mandate route; delivery rides the existing authenticated `meshRpcDispatcher` (same pipe as remote-close); acceptance uses the already-approved ws52 R4a bridge (`acceptDeliveredMandate`); the core `MandateGate` authorship model is UNTOUCHED (delivered mandates use the R4a path, scoped to the account-follow-me enroll-start consumer — not a change to how every mandate is trusted). This is the minimal-blast-radius placement.
+
+## 4. Signal vs authority compliance
+The authority is the operator's PIN-gated mandate (unchanged) + the R4a cryptographic binding to the registered operator machine. The agent cannot self-issue (bearer token insufficient — PIN required). The mesh verb's real gate is the signature re-verification, not a coarse role check. Deterministic + fail-closed; reference `docs/signal-vs-authority.md`.
+
+## 5. Interactions
+The enroll-start consultation is ADDITIVE — the existing local-mandate path is byte-unchanged; the delivered path is reached only when the local gate denies, and both deny-by-default. `verifyDeliveredMandate` re-verifies at point-of-use (never trusts a stored flag). No change to the core MandateGate, so no other mandate consumer is affected. The delivery RPC failure surfaces as an honest 502 (retryable), never a silent stuck issuance.
+
+## 6. External surfaces
+One new PIN-gated route + one new mesh verb (deny-by-default, signature-gated) + a dashboard change routing account-follow-me issuance through the new route. All dark behind `multiMachine.accountFollowMe` (503/refuse when off). The mesh verb is only honored from an authenticated registered peer whose R4a signature verifies — no new attack surface for an unauthenticated party.
+
+## 7. Multi-machine posture (Cross-Machine Coherence)
+This change EXISTS to fix a cross-machine coherence defect: the per-machine dashboard/mandate seam. It is replicated-by-delivery: the operator's single machine is the issuance authority; the signed mandate is delivered to + verified on the target; the target holds it locally (in DeliveredMandateStore) for its own enroll-start. Trust is grounded in the registered MachineIdentity store (Know Your Principal — the authenticated mesh sender, never a payload name). Single-machine agents never deliver (local target path unchanged) — no-op.
+
+## 8. Rollback cost
+Low. Dark by default; new files + additive route/verb; the core MandateGate is untouched so reverting cannot destabilize existing mandate behavior. Single-commit back-out; no migration (DeliveredMandateStore is new + only populated when the feature is live).
+
+---
+
+## 6b. Operator-Surface Quality (dashboard change)
+
+The change touches `dashboard/mandates.js` (an operator surface), so per the Operator-Surface Quality standard:
+
+1. **Right action surfaced prominently / clear next step:** The change makes the EXISTING mandate issue form work for a remote target — when the operator approves an `account-follow-me` authority, it routes through `/mandate/issue-for-machine` and shows a plain-language outcome ("delivered to <machine>" / "issued locally" / a retryable "couldn't reach <machine>" on a 502). The operator's action (approve with PIN) is unchanged and primary; the delivery is automatic. This REMOVES a confusing dead-end (the old "open that machine's dashboard to approve" note) — the exact operator-surface defect this change fixes.
+2. **No internals as primary content:** The operator sees machine NICKNAMES and a plain outcome sentence, not fingerprints/mesh internals (those remain in the support/reference line only). The cross-machine delivery + R4a verification happen invisibly.
+3. **Destructive actions de-emphasized:** This surface issues an authorization (not a destructive action); revoke remains the separate, clearly-labeled control. Nothing destructive is added or made prominent.
+4. **Plain language at phone width:** The new notices are short plain sentences ("Approved — delivered to Mac Mini"), not JSON or jargon, and reuse the existing mobile-responsive mandate-card layout. No new wide/desktop-only element.
+
+(Note: a dedicated pre-filled follow-me picker reading the deep-link `?account=&target=&mechanism=` params is a nice-to-have not built here; the functional path works via the existing form. Tracked as a polish follow-up <!-- tracked: topic-13481 -->.)
+
+## Agent Proposes, Operator Approves
+
+The operator approves a SERVER-AUTHORED request built from STRUCTURED DATA — never agent-supplied free-text:
+- The mandate's authority is a structured `CoordinationMandate` (bounds: `accountId`, `targetMachineId`, `mechanism:'re-mint'`, `action:'account-follow-me'`, `expiresAt`) constructed server-side by `MandateStore.issue()` from typed fields. The operator approves it with their dashboard PIN (`checkMandatePin`) — the agent's bearer token cannot issue/widen it (requester ≠ authorizer preserved).
+- The cross-machine delivery carries that SAME canonical structured mandate; the R4a signature is over the server-canonicalized bytes (`canonicalMandate`), and the target re-derives the bounds from the structured mandate (`readFollowMeBounds`) — it never parses or trusts agent/operator free-text. A name in the payload is never authority (Know Your Principal); only the structured bounds + the R4a signature against the registered operator key are.
+- The dashboard surfaces the structured authority (account + target machine nickname + the fixed action slug) for approval; it does not let the agent inject free-text that becomes the approved authority. The operator approves a typed, server-authored grant, full stop.
+
+## Second-pass review
+
+**Concur with the review.** Independent audit verified all 8 points against the actual source (tsc EXIT=0; 47/47 tests):
+1. **Trust anchor = authenticated sender, never payload** — handler resolves `operatorPem = meshIdMgr.getSigningPublicKeyPem(sender)` (same registered-identity source `verifyEnvelope` uses); `acceptMandateDelivery` passes `expectedOperatorMachineFingerprint: sender`; `CrossMachineMandate` rejects `issuerFingerprint !== expectedIssuer`. No payload field is ever the anchor.
+2. **R4a load-bearing + fail-closed** — no operator key → refuse; sig fail → refuse; issuer≠sender → refuse; `store.put` strictly after all checks. Unverified mandate never persisted/honored.
+3. **Exact-bounds, no replay** — double-gated (accept-time + enroll-start point-of-use): accountId + targetMachineId===this-machine + mechanism=re-mint. A/X cannot be replayed for B/Y.
+4. **enroll-start additive + fail-closed** — local path unchanged; delivered path reached only on local-deny; `verifyDeliveredMandate` re-verifies R4a (not a stored flag); no match → 403.
+5. **issue-for-machine PIN-gated** — `checkMandatePin` same as `/mandate/issue`; bearer alone insufficient; local-target unchanged.
+6. **Mesh RBAC deny-by-default** — own case; `authorizeMandateDeliver ?? false`; real authority = signature re-verify (rogue registered peer still can't deliver an unsigned mandate).
+7. **Dark by default** — route 503, verb refused, accept `feature-disabled` when off; single-machine no-op.
+8. **No fail-open** — terminal `accepted:true` only after all refusals; the only `@silent-fallback-ok` catches fail toward denial (`ok:false` / `[]`).


### PR DESCRIPTION
## ELI16

This fixes a real UX complaint: "there should be ONE dashboard for the agent, not one per machine." Today, to let your Mac Mini use one of your accounts, you'd have to approve a mandate on the *Mini's own* dashboard — but you only have one dashboard, and the Mini's mandate doesn't show up there. The dashboard even fell back to telling you "open that machine's dashboard to approve." That's the bug.

Now you do it all from your ONE dashboard. When you approve "enroll adriana on the Mac Mini" with your PIN, your machine cryptographically signs that approval (the R4a Ed25519 signature built earlier) and sends it to the Mini over the already-authenticated agent-to-agent link. The Mini checks the message genuinely came from your trusted operator machine (using that machine's registered key — never a name written in the message), confirms the approval is *exactly* "enroll adriana, on me, via re-mint," and only then honors it. You never touch the Mini.

Security is strict and fail-closed: the trust anchor is the authenticated sender + its registered key (Know Your Principal), not anything in the payload; an approval for account A / machine X can't be replayed to enroll account B or machine Y; the agent still can't self-approve (your PIN is the authority); and every uncertainty (no registered key, bad signature, wrong target, feature off) refuses. The core mandate engine is untouched — this is scoped to the account-follow-me path. Off by default behind `multiMachine.accountFollowMe`.

## What this PR does
- New PIN-gated `POST /mandate/issue-for-machine`: issues locally, then for a remote target packages the mandate (R4a) and delivers it via the new `account-follow-me-mandate-deliver` mesh verb.
- Target side (`AccountFollowMeMandateDelivery` + `DeliveredMandateStore`): authenticate sender → R4a-verify vs the registered operator key (expectedIssuer === authenticated sender) → exact-bounds check → persist. Deny-by-default.
- `enroll-start` consults the delivered mandate (re-verifying the signature at point-of-use) when the local gate has none — both fail-closed (403).
- Dashboard routes account-follow-me issuance through the one-dashboard flow.
- 122 tests; `tsc` clean; side-effects review (incl. operator-surface §6b + agent-proposes-operator-approves) + independent second-pass security review concurred on all 8 points.

NOTE: this branch is based on the R7a branch (#1217); once that merges, this PR's diff is just the one-dashboard delta. Spec: `docs/specs/ws52-account-follow-me-security.md` R4a/R1/R6a.