### PR TITLE
fix(lifeline): supervisor CPU-starvation guard judges sustained load, not an instant

### DIFF
--- a/.instar/instar-dev-decisions/2026-06-17T17-54-52-273Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-06-17T17-54-52-273Z-unknown.json
@@ -1,0 +1,13 @@
+{
+  "ts": "2026-06-17T17:54:52.273Z",
+  "slug": "unknown",
+  "suggestedTier": 1,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 40,
+  "causalAutopsy": null,
+  "verdict": "pass"
+}

--- a/docs/specs/supervisor-sustained-starvation-fix.eli16.md
+++ b/docs/specs/supervisor-sustained-starvation-fix.eli16.md
@@ -1,0 +1,32 @@
+# Supervisor restart loop fix — plain-English overview
+
+## What was going wrong
+
+Every instar agent has a small supervisor that watches its server and restarts it if it looks dead. The way it checks "is it dead?" is to ping the server's health endpoint every 10 seconds. If the ping keeps failing, the supervisor restarts the server.
+
+But there's a catch: when the computer is overloaded (way more work than CPU cores), a perfectly-alive server can be too slow to answer that ping in time. Restarting it doesn't help — the fresh server is just as starved — it only drops whatever the server was doing and starts a heavy boot sequence that makes the overload *worse*. So there's already a smart guard: "if the machine is CPU-starved, DON'T restart — wait for the load to ease."
+
+## The bug
+
+That guard checked the CPU load at a **single instant**. On a busy machine the 1-minute load average bounces around the cutoff line. Every so often it dips just below the line for one reading — and that single dip tricked the guard into thinking "not starved anymore → restart!", even though the machine had been starved the whole time. The restart spiked the load again, the next ping failed, and the cycle repeated roughly every 11–15 minutes (the 2026-06-17 incident: an agent's server restart-looping, causing message lag and queued replies).
+
+## What already existed
+
+- The CPU-starvation guard itself (it correctly defers restarts while starved).
+- A hard cap (~5 minutes) that force-restarts even while starved, as a backstop for a server that is genuinely frozen rather than merely slow.
+- Injectable load source + a dedicated unit-test file, so the fix is fully testable.
+
+## What's new
+
+The guard now judges **sustained** load, not a single instant. It records the load on each failing health check and keeps the last ~60 seconds of readings; it treats the box as starved if it was starved at **any** point in that window. A momentary dip can no longer authorize a restart while the machine has been busy the whole time. When the load genuinely stays down for the full window, the server restarts as before — so the guard is not permanent.
+
+## Safeguards (unchanged, verified)
+
+- A genuinely **dead** process still restarts instantly (the window logic never runs in that path).
+- A server truly stuck on an **idle** machine still restarts fast (low load → window stays low → restart).
+- The ~5-minute hard-cap backstop is preserved.
+- The recent-load window is dropped the moment the server recovers, so stale "busy" readings can't over-defer a later, unrelated problem.
+
+## What you need to decide
+
+Nothing structural — this is a conservative bug fix that only ever makes the supervisor *wait longer* before restarting under load (the safe direction). It ships to the whole fleet because every agent inherits the same supervisor. The review surface is this PR plus its tests.

--- a/src/lifeline/ServerSupervisor.ts
+++ b/src/lifeline/ServerSupervisor.ts
@@ -256,6 +256,19 @@ export class ServerSupervisor extends EventEmitter {
   private readonly maxLoadRatio = DEFAULT_MAX_LOAD_RATIO; // loadavg[0]/cpuCount above this = starved
   private readonly starvationRestartThreshold = 30; // ~5min at 10s checks — force a restart even if starved if unresponsiveness persists this long
   private readonly loadRatioProvider: () => number; // injectable for tests; default cpuLoadRatio
+  // Sustained-starvation window. The starvation guard must judge load over the
+  // unresponsive window, NOT a single instant: the 1-min loadavg oscillates
+  // around the threshold on an oversubscribed box, and a momentary dip below it
+  // must not authorize restarting a server that has been starved the whole time
+  // — that restart only deepens the starvation and loops (the 2026-06-17
+  // restart-loop incident: restarts fired at "10 checks", below the hard cap,
+  // because the instantaneous ratio dipped under the line for one sample). We
+  // sample the ratio on each unresponsive tick and treat the box as starved if
+  // it was starved at ANY point in the recent window.
+  private readonly loadSampleWindow = 6; // ~60s at 10s checks
+  private recentLoadRatios: number[] = [];
+  private lastStarvationCheckFailures = 0; // detect a failure-streak reset to drop stale samples
+  private lastSustainedLoadRatio = 0; // windowed max from the most recent defer check (for the log line)
   private stateDir: string | null;
 
   // Planned restart / maintenance wait — suppress alerts during expected downtime
@@ -1895,7 +1908,7 @@ export class ServerSupervisor extends EventEmitter {
       // Box is CPU-starved — bouncing the server won't help, it only drops the
       // in-flight message. Defer; the next healthy tick resets the counter.
       if (this.consecutiveFailures === effectiveThreshold) {
-        console.log(`[Supervisor] Server alive but unresponsive (${this.consecutiveFailures} checks) AND the box is CPU-starved (load ratio ${this.loadRatioProvider().toFixed(2)} > ${this.maxLoadRatio}) — DEFERRING restart; restarting a starved server only drops in-flight messages. Will force-restart at ${this.starvationRestartThreshold} checks (~${this.starvationRestartThreshold * 10}s) if it persists.`);
+        console.log(`[Supervisor] Server alive but unresponsive (${this.consecutiveFailures} checks) AND the box is CPU-starved (sustained load ratio ${this.lastSustainedLoadRatio.toFixed(2)} > ${this.maxLoadRatio} over the last ~${this.loadSampleWindow * 10}s) — DEFERRING restart; restarting a starved server only drops in-flight messages. Will force-restart at ${this.starvationRestartThreshold} checks (~${this.starvationRestartThreshold * 10}s) if it persists.`);
       }
     } else {
       console.log(`[Supervisor] Server process alive but unresponsive for ${this.consecutiveFailures} checks (~${this.consecutiveFailures * 10}s) — restarting`);
@@ -1911,10 +1924,33 @@ export class ServerSupervisor extends EventEmitter {
    * True when we should hold off restarting an alive-but-unresponsive server
    * because the machine is CPU-starved — but only up to the hard cap. Past the
    * cap we restart regardless (the server may be genuinely hung, not starved).
+   *
+   * The starvation signal is SUSTAINED, not instantaneous: we record the load
+   * ratio on each unresponsive tick and treat the box as starved if it exceeded
+   * the threshold at any point in the recent window. This prevents a momentary
+   * dip in the oscillating 1-min loadavg from triggering a pointless restart of
+   * a server that has been starved the whole time (the 2026-06-17 loop). The
+   * window is dropped when the failure streak resets (the server recovered), so
+   * stale high samples can't over-defer a later, unrelated unresponsive episode.
    */
   private deferRestartForCpuStarvation(): boolean {
+    // Within one unresponsive streak the failure counter strictly increases on
+    // each tick (++ before this runs); a new episode restarts at the threshold.
+    // So a non-increase means the prior streak ended (the server recovered) —
+    // drop the stale samples so they can't over-defer this fresh episode.
+    if (this.consecutiveFailures <= this.lastStarvationCheckFailures) {
+      this.recentLoadRatios = [];
+    }
+    this.lastStarvationCheckFailures = this.consecutiveFailures;
+
+    this.recentLoadRatios.push(this.loadRatioProvider());
+    if (this.recentLoadRatios.length > this.loadSampleWindow) {
+      this.recentLoadRatios.shift();
+    }
+    this.lastSustainedLoadRatio = Math.max(...this.recentLoadRatios);
+
     if (this.consecutiveFailures >= this.starvationRestartThreshold) return false; // hard cap — restart even if starved
-    return this.loadRatioProvider() > this.maxLoadRatio;
+    return this.lastSustainedLoadRatio > this.maxLoadRatio;
   }
 
   private handleUnhealthy(): void {

--- a/tests/unit/supervisor-cpu-starvation-defer.test.ts
+++ b/tests/unit/supervisor-cpu-starvation-defer.test.ts
@@ -76,17 +76,66 @@ describe('ServerSupervisor — CPU-starvation restart guard', () => {
     expect(sup.handleUnhealthy).not.toHaveBeenCalled();
   });
 
-  it('a starved-then-eased server restarts once load drops (defer is not permanent)', () => {
+  it('a starved-then-SUSTAINEDLY-eased server restarts once load stays down for the window (defer is not permanent)', () => {
+    // Sustained semantics: after load eases it takes a full window of low
+    // samples to flush the earlier high reading before a restart is authorized.
     const sup = makeSup(2.0); // starts starved
+    vi.spyOn(sup, 'isServerSessionAlive').mockReturnValue(true);
+    let cf = PROCESS_ALIVE_THRESHOLD;
+    sup.consecutiveFailures = cf;
+    sup.evaluateUnhealthyServer();
+    expect(sup.handleUnhealthy).not.toHaveBeenCalled(); // deferred while starved
+    // Load eases — but the window still holds the earlier high sample, so the
+    // FIRST eased tick must NOT restart (this is the 2026-06-17 dip-loop fix).
+    (sup as any).loadRatioProvider = () => 0.4;
+    cf += 1;
+    sup.consecutiveFailures = cf;
+    sup.evaluateUnhealthyServer();
+    expect(sup.handleUnhealthy).not.toHaveBeenCalled();
+    // Drive enough eased ticks to flush the window (loadSampleWindow = 6); once
+    // load has genuinely stayed down across the window it restarts — defer is
+    // not permanent.
+    for (let i = 0; i < 6; i++) {
+      cf += 1;
+      sup.consecutiveFailures = cf;
+      sup.evaluateUnhealthyServer();
+    }
+    expect(sup.handleUnhealthy).toHaveBeenCalled();
+  });
+
+  it('a momentary load DIP does NOT restart a sustainedly-starved server (the 2026-06-17 loop)', () => {
+    // The exact failure: load oscillates around the threshold; a single 1-min
+    // dip below the line must not authorize a restart while the box has been
+    // starved across the window.
+    const ratios = [2.0, 1.8, 2.1, 1.4 /* the dip, < 1.5 */, 1.9];
+    let idx = 0;
+    const sup = makeSup(2.0);
+    (sup as any).loadRatioProvider = () => ratios[Math.min(idx, ratios.length - 1)];
+    vi.spyOn(sup, 'isServerSessionAlive').mockReturnValue(true);
+    let cf = PROCESS_ALIVE_THRESHOLD;
+    for (idx = 0; idx < ratios.length; idx++) {
+      sup.consecutiveFailures = cf++;
+      sup.evaluateUnhealthyServer();
+    }
+    // Despite the dip at idx 3, the windowed max stayed > 1.5 the whole time.
+    expect(sup.handleUnhealthy).not.toHaveBeenCalled();
+  });
+
+  it('the sustained window is dropped when the failure streak resets (no stale over-defer)', () => {
+    // Episode 1: starved, defers and accumulates a high sample.
+    const sup = makeSup(2.0);
     vi.spyOn(sup, 'isServerSessionAlive').mockReturnValue(true);
     sup.consecutiveFailures = PROCESS_ALIVE_THRESHOLD;
     sup.evaluateUnhealthyServer();
-    expect(sup.handleUnhealthy).not.toHaveBeenCalled(); // deferred while starved
-    // Load eases — provider now reports a healthy ratio.
-    (sup as any).loadRatioProvider = () => 0.4;
-    sup.consecutiveFailures = PROCESS_ALIVE_THRESHOLD + 1;
+    expect(sup.handleUnhealthy).not.toHaveBeenCalled();
+    // Server recovers — the streak resets to 0 (done by the health loop).
+    sup.consecutiveFailures = 0;
+    // Episode 2: a genuinely-hung server on a now-IDLE box. The stale high
+    // sample from episode 1 must NOT keep deferring — load is low now.
+    (sup as any).loadRatioProvider = () => 0.3;
+    sup.consecutiveFailures = PROCESS_ALIVE_THRESHOLD;
     sup.evaluateUnhealthyServer();
-    expect(sup.handleUnhealthy).toHaveBeenCalledTimes(1);
+    expect(sup.handleUnhealthy).toHaveBeenCalledTimes(1); // restarts promptly
   });
 });
 

--- a/upgrades/next/supervisor-sustained-starvation-fix.md
+++ b/upgrades/next/supervisor-sustained-starvation-fix.md
@@ -1,0 +1,17 @@
+## What Changed
+
+Fixed a server restart loop that could hit an agent on an overloaded machine. The supervisor's CPU-starvation guard — which is supposed to NOT restart an alive-but-slow server while the box is oversubscribed — judged load at a single instant. On a machine whose 1-minute load average oscillates around the starvation threshold, a momentary dip below the line tricked the guard into restarting a server that had been starved the whole time; the restart's heavy boot deepened the overload and the cycle repeated every ~11–15 minutes (2026-06-17 incident, topic 12476). `ServerSupervisor.deferRestartForCpuStarvation()` now judges **sustained** load — it samples the load ratio on each unresponsive health-check tick, keeps the last ~60 seconds of readings, and treats the box as starved if it was starved at any point in that window. A single dip can no longer authorize a restart. The recent-load window is dropped the moment the server recovers, so stale readings can't over-defer a later, unrelated episode. The genuinely-dead-process path (instant restart), the idle-machine-hung path (fast restart), and the ~5-minute hard-cap backstop are all unchanged.
+
+## What to Tell Your User
+
+If your agent felt laggy or kept "auto-restarting" on a busy machine — replies arriving late, messages queueing, the dashboard briefly 502-ing every ~10–15 minutes — that was this loop. Your agent now rides out short load spikes instead of bouncing itself, so it stays responsive under load. Nothing for you to do; it applies automatically on update. (Separately: if a machine is *chronically* overloaded, the real cure is reducing how much is running on it — this fix stops the self-inflicted restart loop, not the underlying load.)
+
+## Summary of New Capabilities
+
+No new user-facing capability — this is a reliability fix to the existing server supervisor. The supervisor's CPU-starvation restart guard now uses a sustained (windowed) load signal instead of an instantaneous one.
+
+## Evidence
+
+- `src/lifeline/ServerSupervisor.ts` — `deferRestartForCpuStarvation()` rewritten to use a windowed-max load signal over `loadSampleWindow` (6 samples ≈ 60s); window cleared on failure-streak reset; deferral log line now reports the sustained ratio.
+- `tests/unit/supervisor-cpu-starvation-defer.test.ts` — updated the test that encoded the old instantaneous behavior (it expected a restart after a single dip — the bug); added cases: a momentary dip does NOT restart a sustainedly-starved server (the 2026-06-17 loop), sustained easing eventually restarts (defer is not permanent), and the window is dropped on streak reset (no stale over-defer).
+- All 4 supervisor-related unit suites green: 40 tests passed (10 in the starvation-defer file). `tsc --noEmit` clean.

--- a/upgrades/side-effects/supervisor-sustained-starvation-fix.md
+++ b/upgrades/side-effects/supervisor-sustained-starvation-fix.md
@@ -1,0 +1,81 @@
+# Side-Effects Review — Supervisor sustained-CPU-starvation restart guard
+
+**Version / slug:** `supervisor-sustained-starvation-fix`
+**Date:** `2026-06-17`
+**Author:** `Echo (instar-dev agent)`
+**Second-pass reviewer:** `(see Phase 5 section below — required: restart/recovery path)`
+
+## Summary of the change
+
+`ServerSupervisor.deferRestartForCpuStarvation()` decided whether to hold off restarting an alive-but-unresponsive server based on the **instantaneous** CPU load ratio (`loadRatioProvider() > maxLoadRatio`). On an oversubscribed box the 1-minute load average oscillates around the threshold, so a single sample dipping below it authorized a restart of a server that had been CPU-starved the whole time — and the restart's heavy boot deepened the starvation, producing a ~11–15-minute restart loop (2026-06-17 incident, topic 12476). The fix records the load ratio on each unresponsive tick into a small fixed window (`loadSampleWindow = 6`, ~60s) and treats the box as starved if the **windowed max** exceeds the threshold. The window is cleared when the failure streak resets (server recovered), so stale high readings can't over-defer a later episode. Files: `src/lifeline/ServerSupervisor.ts` (the guard + 4 new fields + the deferral log line now reports the sustained ratio), `tests/unit/supervisor-cpu-starvation-defer.test.ts` (updated the test that encoded the old instantaneous behavior; added dip-protection, sustained-easing, and window-reset cases).
+
+## Decision-point inventory
+
+- `ServerSupervisor.deferRestartForCpuStarvation()` — **modify** — the starvation SIGNAL feeding the restart authority is changed from instantaneous to a sustained windowed-max reading. No new authority added; the existing restart decision (and its hard cap) is unchanged in structure.
+
+---
+
+## 1. Over-block
+
+**What legitimate inputs does this change reject that it shouldn't?**
+
+Mapped to this domain, "over-block" = deferring a restart that genuinely should happen. The change makes deferral *more* likely (it holds off restarting while recent load was high). The bounded risk: a server that is genuinely hung (frozen event loop) AND happens to be on a box that was busy in the last ~60s will wait up to the full window (~60s) longer before the windowed max falls — and in the worst case waits for the ~5-minute hard cap, which is unchanged and still force-restarts. So the maximum added delay before a truly-hung server restarts is bounded by the existing hard cap; the change never *prevents* a restart, only delays it under recent-high-load — which is the intended, safe direction.
+
+## 2. Under-block
+
+**What failure modes does this still miss?**
+
+A box that is chronically starved for longer than the ~5-minute hard cap will still force-restart at the cap, which on a sustainedly-overloaded machine is itself unhelpful (restarting never cures starvation). This fix addresses the dominant observed failure (the sub-cap dip-triggered restarts at "10 checks") but does NOT change the hard-cap behavior. Making the hard cap escalate-instead-of-restart under sustained starvation is a genuine follow-up. <!-- tracked: topic-12476 --> The real cure for chronic starvation is reducing machine load (surfaced to the operator separately).
+
+## 3. Level-of-abstraction fit
+
+**Is this at the right layer?**
+
+Yes. The supervisor is the correct owner of the server-restart decision (process lifecycle). The starvation check is a *detector signal* feeding that authority; this change improves the signal's quality (smoothing out single-sample noise) rather than adding a new authority. It reuses the existing injectable `loadRatioProvider` / `cpuStarvation` primitive — no re-implementation of load reading.
+
+## 4. Signal vs authority compliance
+
+**Does this hold blocking authority with brittle logic, or produce a signal that feeds a smart gate?** (`docs/signal-vs-authority.md`)
+
+Compliant. The brittle part (reading load) is a detector; this change makes that detector *less* brittle by replacing an instantaneous reading with a sustained windowed one. The restart authority (the supervisor's deterministic lifecycle policy — appropriate for this tightly-constrained domain) is unchanged. No new brittle blocker is introduced; the existing one is smoothed.
+
+## 5. Interactions
+
+**Does it shadow another check, get shadowed, double-fire, race?**
+
+- It interacts only with `evaluateUnhealthyServer()`, which calls it once per unresponsive tick. No new timers, no concurrency. The window is single-threaded supervisor state.
+- The hard-cap early-return is preserved and runs *after* the sample is recorded, so the window stays accurate for logging.
+- The window-reset detection keys on `consecutiveFailures` not strictly increasing (it strictly increases within a streak; a new episode restarts at the threshold) — verified against all reset sites; deferral is only consulted at/above threshold, so the `<=` reset test is correct.
+- SleepWakeDetector uses the same `cpuStarvation` ratio but keeps its own state — no shared mutable state touched.
+
+## 6. External surfaces
+
+**Anything visible to other agents/users/systems? Timing/state dependencies?**
+
+Only the supervisor's own log line changes wording (now reports the sustained ratio + window). No API, no message, no cross-agent surface. Behavior is purely local process-lifecycle. The only timing dependency is the existing 10s health-check cadence, which the window is sized against (6 samples ≈ 60s).
+
+## 7. Multi-machine posture (Cross-Machine Coherence)
+
+**Machine-local BY DESIGN.** The supervisor watches the server on its OWN machine; CPU starvation and restart decisions are inherently per-machine. There is no cross-machine state to replicate and nothing to proxy on read — each machine's supervisor independently judges its own load. No one-voice/transfer/URL concerns (no user-facing notice, no durable shared state, no generated link).
+
+## 8. Rollback cost
+
+**If wrong in production, what's the back-out?**
+
+Low. Single-file logic change behind the existing injectable provider. Back-out = revert the commit (a hot-fix patch release). No data migration, no state repair — the supervisor holds only in-memory transient state (the load window), which resets on the next boot. Worst-case failure mode of the fix itself (over-deferral) is bounded by the unchanged ~5-minute hard cap.
+
+---
+
+## Phase 5 — Second-pass review (required: restart/recovery path)
+
+**Reviewer:** independent reviewer subagent (general-purpose), 2026-06-17.
+
+**Verdict: Concur with the review.**
+
+Independent audit findings:
+- **Windowing correctness:** the counter strictly increases within a streak because `consecutiveFailures++` precedes every `evaluateUnhealthyServer()` call (both failure callsites), so the `<=` reset-detection correctly distinguishes a continuing streak (no clear) from a new episode (clear); it cannot false-clear mid-streak.
+- **Empty-array / -Infinity:** safe — a sample is pushed unconditionally before every `Math.max(...)`, even right after a reset-to-`[]`.
+- **Safety valves all preserved:** dead process restarts instantly (early return before the guard); hung server on an idle box restarts promptly (window fills with low samples → max < threshold); the ~5-min hard cap still force-restarts.
+- **Signal vs authority:** compliant — improves a detector signal (instantaneous → sustained windowed-max), no new brittle authority.
+- **Direction:** only ever makes restart *less* aggressive; max added delay for a truly-hung-on-recently-busy box is bounded by the unchanged hard cap.
+- **Test quality:** the new tests genuinely fail against the old instantaneous code (the dip-sample and first-eased-tick cases).


### PR DESCRIPTION
## ELI16 — what this is in plain English

Every agent has a supervisor that restarts its server if health pings keep failing. There's a smart guard: *don't* restart when the machine is CPU-overloaded (a restart of a slow-because-busy server doesn't help — it just deepens the overload). But that guard checked load at a **single instant**. On a box whose 1-min load oscillates around the threshold, a momentary dip below the line tricked the guard into restarting a still-starved server → the heavy boot spiked load again → a ~11–15 min **restart loop** (2026-06-17 incident, topic 12476). This makes the guard judge **sustained** load (a ~60s window of samples; starved if the windowed max exceeds the threshold), so a single dip can't trigger a pointless restart. Full overview: `docs/specs/supervisor-sustained-starvation-fix.eli16.md`.

## What Changed

`ServerSupervisor.deferRestartForCpuStarvation()` now records the load ratio per unresponsive health-check tick into a fixed 6-sample (~60s) window and treats the box as CPU-starved if the **windowed max** exceeds `maxLoadRatio` — replacing the instantaneous `loadRatioProvider() > maxLoadRatio` read. The window is dropped when the failure streak resets (server recovered) so stale high readings can't over-defer a later episode. The deferral log line now reports the sustained ratio.

**Safety valves unchanged:** dead process restarts instantly; a hung server on an idle/low-load box restarts fast; the ~5-min hard-cap force-restart backstop is preserved.

## Evidence

- `tests/unit/supervisor-cpu-starvation-defer.test.ts`: updated the test that **encoded the old buggy instantaneous behavior** (it expected a restart after a single dip); added (a) a momentary dip does NOT restart a sustainedly-starved server, (b) sustained easing eventually restarts (defer not permanent), (c) window dropped on streak reset.
- 40 supervisor-related unit tests green; full pre-push smoke (209 tests) + path-scoped e2e gate green; `tsc` clean.
- Independent Phase-5 second-pass review concurred (restart/recovery path) — see the side-effects artifact.

## Tier

Tier 1 — bug fix to an already-converged guard (`supervisor-cpu-starvation-restart-guard`). Conservative: only ever defers restarts *longer* (the safe direction), never restarts more aggressively. Gate's own signal: suggestedTier=1, riskFloor=1.

## Rollback

Single-file logic change behind the existing injectable provider; revert the commit. No migration, no state repair (the load window is in-memory transient).

## Follow-up (tracked: topic-12476)

The ~5-min hard cap still force-restarts even under sustained starvation, which on a chronically-overloaded box is itself unhelpful — making it escalate-instead-of-restart is a genuine follow-up. The real cure for chronic overload is reducing machine load (surfaced to the operator separately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)