### PR TITLE
fix(monitoring): CompactionSentinel stands down instead of trampling a working session

### DIFF
--- a/.instar/instar-dev-decisions/2026-06-18T05-44-34-766Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-06-18T05-44-34-766Z-unknown.json
@@ -1,0 +1,13 @@
+{
+  "ts": "2026-06-18T05:44:34.766Z",
+  "slug": "unknown",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 41,
+  "causalAutopsy": null,
+  "verdict": "pass"
+}

--- a/docs/specs/compaction-sentinel-no-trample.eli16.md
+++ b/docs/specs/compaction-sentinel-no-trample.eli16.md
@@ -1,0 +1,25 @@
+# Plain-English overview — Stop the watchdog from interrupting a session that's actively working
+
+## What this is
+
+There's an internal safety watchdog (the "Compaction Sentinel"). Its job: when a long agent session hits its context limit and auto-compacts, that can occasionally leave the session stuck, so the watchdog gives it a little "nudge" to wake back up.
+
+## The bug
+
+When my session compacts (normal on a long run), the watchdog goes to nudge it. It already checks "is this session actively working right now?" and politely waits if so — **but only for about 4 minutes.** After that, it forced the nudge in **even if I was still actively working.** That forced nudge lands as an interruption of whatever I was in the middle of — the recurring "Claude was interrupted" the operator kept seeing. On a 23-hour session that compacts repeatedly, it fired several times.
+
+## What this change does
+
+The watchdog now **stands down** instead of forcing the nudge: if the defer budget runs out but the session is *still actively working*, it concludes the session is alive and already recovered on its own, and does **nothing** — it never interrupts a live, working turn. The time limit now caps how long it *waits*, not a license to barge in.
+
+The one case the old "force after 4 minutes" was trying to catch — a session whose footer falsely says "working" while it's truly frozen — is already handled by the *other* watchdogs (the silence and context-wedge sentinels), which detect a genuinely frozen screen. So nothing is lost by this watchdog standing down.
+
+The explicit opt-out is preserved: setting the defer budget to 0 still means "inject immediately even while working," for anyone who wants the old aggressive behavior.
+
+## Safeguards / rollback
+
+Pure logic change in one guard method, behind no flag (it's a strict de-escalation — the watchdog becomes *less* likely to act, never more). 24 unit tests pass, including a new regression test that fails if a still-working session is ever force-injected again. Rollback is a one-line revert. No data, no migration.
+
+## What you need to decide
+
+Nothing — it's a safety de-escalation that removes a known cause of interruptions. The only judgment call (made here) is that a still-working session should be trusted as alive rather than nudged, with the frozen-frame sentinels as the backstop for genuinely-hung sessions.

--- a/src/monitoring/CompactionSentinel.ts
+++ b/src/monitoring/CompactionSentinel.ts
@@ -325,20 +325,47 @@ export class CompactionSentinel extends EventEmitter {
   }
 
   /**
-   * If the session is actively working (mid-turn) and we haven't exhausted the
-   * defer budget, record a defer, schedule another verify window WITHOUT
-   * injecting, and return true (the caller must return). Otherwise return false
-   * and let the caller proceed with its normal inject/retry/fail path.
+   * If the session is actively working (mid-turn): if we haven't exhausted the
+   * defer budget, record a defer, schedule another verify window WITHOUT injecting,
+   * and return true (the caller must return). If we HAVE exhausted the budget but
+   * the session is STILL working, STAND DOWN (finalize self-recovered, no inject)
+   * and return true — never force a resume nudge into a live, working session.
+   * Only when the session is NOT actively working do we return false and let the
+   * caller proceed with its normal inject/retry/fail path.
    *
    * This is the heart of the busy-session guard: a long extended-think on a
    * large context emits nothing to the JSONL until the turn lands, so the
    * no-growth check would otherwise read it as "stuck" and re-inject — burying
-   * the user's real message. Deferring waits it out instead, and the cap means
-   * a genuinely-hung "working" footer still gets a forced inject eventually.
+   * the user's real message. Deferring waits it out; and crucially, exhausting the
+   * defer budget on a session that is STILL working is NOT a license to interrupt
+   * it — we stand down. (A footer that FALSELY shows "working" while truly hung is
+   * the frozen-frame silence/wedge sentinels' job, not this recovery path's.)
    */
   private deferForActiveWork(state: RecoveryState): boolean {
     if (!this.deps.isActivelyWorking?.(state.sessionName)) return false;
-    if (state.workingDefers >= this.cfg.maxWorkingDefers) return false;
+    // maxWorkingDefers === 0 is the explicit opt-out: "disable the working-guard,
+    // inject immediately even while working." Preserve it — proceed to inject.
+    if (this.cfg.maxWorkingDefers === 0) return false;
+    if (state.workingDefers >= this.cfg.maxWorkingDefers) {
+      // Defer budget exhausted, but the live frame STILL shows active work. Do NOT
+      // force-inject: that would trample a genuinely-working session, which is the
+      // recurring mid-turn "[Request interrupted by user]" on long autonomous
+      // sessions that compact periodically (2026-06-18, topic 13481). A session that
+      // is demonstrably alive AND working has already recovered from the compaction
+      // on its own — a resume nudge here only interrupts its live turn. So STAND
+      // DOWN. (The opposite case — a session whose footer FALSELY shows "working"
+      // while actually hung — is the job of the frozen-frame silence/wedge sentinels,
+      // not this compaction-recovery path; this path's only safe action on a working
+      // session is to wait, never to interrupt.)
+      console.log(
+        `[Sentinel] "${state.sessionName}" still actively working after ` +
+        `${state.workingDefers} defers — standing down, NOT forcing an inject ` +
+        `(session is alive + working; no resume nudge needed)`,
+      );
+      this.emit('compaction:recovered', { ...state });
+      this.finalize(state, 'recovered');
+      return true;
+    }
 
     state.workingDefers += 1;
     state.status = 'deferring';

--- a/tests/unit/CompactionSentinel.test.ts
+++ b/tests/unit/CompactionSentinel.test.ts
@@ -123,6 +123,36 @@ describe('CompactionSentinel', () => {
     expect(failed!.payload.attempts).toBe(3);
   });
 
+  // ─── Stand-down on a still-working session (no-trample fix, 2026-06-18) ───
+
+  it('STANDS DOWN (never force-injects) when the defer budget is exhausted but the session is STILL actively working', async () => {
+    // Regression guard: a session whose live frame still shows active work must
+    // NEVER be force-injected after the defer budget runs out — that interrupts a
+    // genuinely-working session (the recurring mid-turn "[Request interrupted by
+    // user]" on long autonomous runs that compact periodically). It must stand down.
+    const recover = vi.fn().mockResolvedValue(true);
+    const ev: string[] = [];
+    const s = new CompactionSentinel(
+      { recoverFn: recover as any, projectDir: '/fake/project', jsonlRoot: jsonl.root, isActivelyWorking: () => true },
+      { dedupeWindowMs: 60_000, verifyWindowMs: 25_000, maxInjectAttempts: 3, recoveryGuardMs: 600_000, maxWorkingDefers: 2 },
+    );
+    for (const e of ['compaction:recovered', 'compaction:failed', 'compaction:inject-attempted']) {
+      s.on(e as any, () => ev.push(e));
+    }
+    jsonl.write('foo.jsonl', 100);
+    s.report('s1', 'watchdog-poll');
+    await vi.advanceTimersByTimeAsync(0);
+    // Advance well past every defer/verify window (maxWorkingDefers=2).
+    await vi.advanceTimersByTimeAsync(25_000 * 6);
+    // The session was working throughout → it was NEVER injected (no trample):
+    expect(recover).not.toHaveBeenCalled();
+    expect(ev).not.toContain('compaction:inject-attempted');
+    // And it stood down as self-recovered (alive + working), not failed:
+    expect(ev).toContain('compaction:recovered');
+    expect(ev).not.toContain('compaction:failed');
+    s.stop();
+  });
+
   it('stops retrying as soon as jsonl grows (recovers on attempt 2)', async () => {
     jsonl.write('foo.jsonl', 100);
     sentinel.report('s1', 'watchdog-poll');
@@ -406,17 +436,22 @@ describe('CompactionSentinel', () => {
       expect(evs.some(e => e.type === 'compaction:recovered')).toBe(true);
     });
 
-    it('caps consecutive defers at maxWorkingDefers then forces an inject', async () => {
+    it('caps consecutive defers at maxWorkingDefers then STANDS DOWN (never force-injects a still-working session)', async () => {
+      // Fixed 2026-06-18 (topic 13481): the old behavior force-injected after the cap,
+      // which interrupted genuinely-working long sessions. A session still showing
+      // active work after the budget is alive + self-recovered — stand down, never inject.
       build({ maxWorkingDefers: 4 });
       j.write('foo.jsonl', 100);
-      working = true; // hung "working" footer — never clears
+      working = true; // still actively working — footer never clears
       s.report('s1', 'watchdog-poll');
       await vi.advanceTimersByTimeAsync(0);
       // defer #1 at report; defers #2/#3/#4 at the next three verify windows;
-      // the window after that forces an inject.
-      for (let i = 0; i < 4; i++) await vi.advanceTimersByTimeAsync(25_500);
+      // the window after that STANDS DOWN (no inject) instead of forcing one.
+      for (let i = 0; i < 5; i++) await vi.advanceTimersByTimeAsync(25_500);
       expect(evs.filter(e => e.type === 'compaction:deferred')).toHaveLength(4);
-      expect(rec).toHaveBeenCalledTimes(1);
+      expect(rec).not.toHaveBeenCalled(); // NEVER force-injected the working session
+      expect(evs.some(e => e.type === 'compaction:inject-attempted')).toBe(false);
+      expect(evs.some(e => e.type === 'compaction:recovered')).toBe(true); // stood down as self-recovered
     });
 
     it('maxWorkingDefers=0 disables deferral (injects immediately even while working)', async () => {

--- a/upgrades/next/compaction-sentinel-no-trample.md
+++ b/upgrades/next/compaction-sentinel-no-trample.md
@@ -1,0 +1,20 @@
+<!-- slug: compaction-sentinel-no-trample -->
+<!-- bump: patch -->
+
+## What Changed
+
+Fixes the recurring mid-turn interrupt of long sessions (the "Claude was interrupted" / "[Request interrupted by user]" you'd see on a long autonomous run). Root cause: the CompactionSentinel's recovery guard deferred a resume-nudge while a session was actively working, but only for ~4 minutes (`maxWorkingDefers`); after that it force-injected the nudge **even if the session was still actively working**, interrupting the live turn. On a long session that compacts periodically, it fired repeatedly. Now, when the defer budget is exhausted but the session is still actively working, the sentinel **stands down** (the session is alive and self-recovered — no nudge needed) instead of force-injecting. The genuinely-frozen-footer case is already owned by the silence/context-wedge sentinels. The `maxWorkingDefers: 0` opt-out (inject-immediately) is preserved.
+
+## What to Tell Your User
+
+If you ever saw your long-running session get "interrupted" out of nowhere, that's fixed. An internal recovery watchdog was occasionally nudging sessions that were actually still working, which interrupted them. It now leaves a working session alone.
+
+## Summary of New Capabilities
+
+- No new capability — a reliability fix. The compaction-recovery watchdog no longer interrupts a session that is still actively working; it stands down instead of forcing a resume nudge.
+
+## Evidence
+
+- `tests/unit/CompactionSentinel.test.ts` — 24/24 pass. Updated the old "caps defers then forces an inject" test to assert STAND-DOWN, and added a dedicated regression test that fails if a still-working session is ever force-injected again.
+- `npx tsc --noEmit` clean.
+- Root cause evidenced in `logs/sentinel-events.jsonl`: `"resume nudge injected via internal recovery channel"` + `"no jsonl growth after 6 attempts"`.

--- a/upgrades/side-effects/compaction-sentinel-no-trample.md
+++ b/upgrades/side-effects/compaction-sentinel-no-trample.md
@@ -1,0 +1,52 @@
+# Side-Effects Review — CompactionSentinel: stand down instead of trampling a working session
+
+**Version / slug:** `compaction-sentinel-no-trample`
+**Date:** `2026-06-18`
+**Author:** `Echo (instar-dev agent)`
+**Second-pass reviewer:** `required (sentinel/recovery change) — appended below`
+
+## Summary of the change
+
+Fixes the recurring mid-turn interrupt of long autonomous sessions ("[Request interrupted by user]"). Root cause: `CompactionSentinel.deferForActiveWork` deferred a recovery resume-nudge while the session was actively working, but only up to `maxWorkingDefers` (~4min); once exhausted it returned `false`, and the caller **force-injected the resume nudge even though the session was still actively working** — interrupting the live turn. On a 23h session that compacts periodically, this fired repeatedly. The fix: when the defer budget is exhausted but `isActivelyWorking` is STILL true, the sentinel **stands down** (emits `compaction:recovered`, finalizes — a session demonstrably alive + working has already self-recovered and needs no nudge) instead of force-injecting. The explicit `maxWorkingDefers === 0` opt-out (inject-immediately-even-while-working) is preserved. File: `src/monitoring/CompactionSentinel.ts` (one guard method). Test: `tests/unit/CompactionSentinel.test.ts` (updated the old "force inject after cap" test to assert stand-down; added a dedicated stand-down regression test; 24 tests pass).
+
+## Decision-point inventory
+- `CompactionSentinel.deferForActiveWork` — **modify** — when budget exhausted AND still actively working: stand down (no inject) instead of returning false (which force-injected). The `not actively working` path and the `maxWorkingDefers === 0` opt-out are unchanged.
+
+## 1. Over-block
+Not a block/allow surface. The change makes the sentinel inject LESS (a de-escalation). The only "rejection" added: it now declines to inject a recovery nudge into a still-working session — which is the entire point (that inject was the defect).
+
+## 2. Under-block
+The one scenario the old force-inject targeted — a session whose tmux footer FALSELY shows "working" while truly hung — is no longer force-recovered by THIS sentinel. That case is covered by the frozen-frame detectors (ActiveWorkSilenceSentinel, ContextWedgeSentinel, SessionWatchdog), which use frame-change/socket signals rather than the footer boolean. So the genuinely-hung case still has recovery owners; this sentinel simply stops trampling genuinely-working sessions.
+
+## 3. Level-of-abstraction fit
+Correct layer — the fix is in the guard that already exists for exactly this purpose (`deferForActiveWork`). It uses the same `isActivelyWorking` (live-tmux-frame) signal already wired; no new detection added.
+
+## 4. Signal vs authority compliance
+**Required reference:** docs/signal-vs-authority.md
+- [x] Yes, with appropriate de-escalation: the sentinel holds runtime authority (it injects into sessions). This change REDUCES that authority (it stops acting on working sessions). Strictly safer direction — never adds a brittle block; it removes a brittle action.
+
+## 5. Interactions
+- **Shadowing:** none changed. The other recovery sentinels are unaffected and now solely own the falsely-working-footer case (no double-recovery with this one).
+- **Double-fire:** reduced (this sentinel no longer fires into working sessions that the autonomous stop-hook is already re-driving).
+- **Races:** the stand-down calls `finalize(state,'recovered')` which keeps state briefly for the recovery-guard window (existing behavior), so the zombie-killer veto timing is unchanged.
+
+## 6. External surfaces
+No operator surface, no API, no message shape change. The only external-visible effect: long sessions stop being interrupted mid-turn. A `compaction:recovered` event now fires for the stand-down case (audited in `sentinel-events.jsonl`) — additive, no consumer breaks.
+
+## 7. Multi-machine posture (Cross-Machine Coherence)
+Machine-local BY DESIGN — the CompactionSentinel runs per-machine over that machine's own sessions (recovery is a local-process concern). No cross-machine state; the fix changes only local decision logic. Both machines get the fix via the normal deploy/update path.
+
+## 8. Rollback cost
+One-method revert, ship a patch. No persistent state, no migration, no operator action. Because the change is a pure de-escalation, even an un-noticed regression fails safe (worst case: a falsely-working-footer hung session waits for the other sentinels instead of this one).
+
+## Conclusion
+Small, well-scoped fix to the exact guard responsible for the recurring interrupt. De-escalation only; 24 unit tests pass incl. a new regression test that fails if a still-working session is ever force-injected again. Clear to ship pending the appended second-pass.
+
+## Second-pass review (if required)
+**Reviewer:** independent general-purpose reviewer subagent (read-only), 2026-06-18 — **CONCUR**
+
+Verified against the actual code (cited file:line): (1) stand-down replaces force-inject — when `isActivelyWorking` && `workingDefers >= maxWorkingDefers`, emits `compaction:recovered` + `finalize('recovered')` + returns true; both callers (`attemptInjection:297`, `verifyRecovery:420`) bail before `recoverFn` — no inject. (2) `maxWorkingDefers === 0` opt-out preserved (early `return false` at :348 → inject). (3) not-working path unchanged (:345 → normal inject/retry/fail; genuinely-stuck still recovered). (4) no timer/state leak — stand-down routes through the same `finalize` terminal path; at every call site the per-session timer was already deleted; `isRecoveryActive` returns false in `recovered` so the zombie-veto releases. (5) strict de-escalation — `recoverFn` called strictly less; no new block/interrupt path. (6) coverage gap closed — the falsely-working-footer hung case is owned by ActiveWorkSilenceSentinel (frame-HASH change + frozen-indicator backstop) and ContextWedgeSentinel (transcript fast-fail signatures), which use orthogonal signals, so standing down here strands nothing. **No concerns.**
+
+## Evidence pointers
+- `tests/unit/CompactionSentinel.test.ts` — 24/24 pass; new "STANDS DOWN" test + updated cap test.
+- `npx tsc --noEmit` clean.


### PR DESCRIPTION
## What this fixes

The recurring mid-turn interrupt of long autonomous sessions ("[Request interrupted by user]" / "Claude was interrupted"). Root cause: `CompactionSentinel.deferForActiveWork` deferred a recovery resume-nudge while a session was actively working, but only up to `maxWorkingDefers` (~4min); once exhausted it **force-injected the nudge even while the session was still actively working**, interrupting the live turn. On a 23h session that compacts periodically, it fired repeatedly.

## Fix

When the defer budget is exhausted but `isActivelyWorking` is STILL true → **stand down** (emit `compaction:recovered` + finalize; the session is alive and self-recovered, no nudge needed) instead of force-injecting. Preserved: the `maxWorkingDefers === 0` opt-out (inject-immediately) and the not-working path (genuinely-stuck sessions still recovered). The falsely-working-footer hung case is owned by the frame-hash silence/wedge sentinels (orthogonal signals), so standing down here strands nothing.

## ELI16

An internal safety watchdog tries to "nudge" a session awake if it gets stuck after hitting its context limit. It checks "is this session still working?" and waits if so — but only ~4 minutes, then it forced the nudge in anyway, which interrupted sessions that were actually still working. Now it stands down instead: if the session is clearly still working, it's alive and doesn't need a nudge, so the watchdog leaves it alone. The genuinely-frozen case is already handled by other watchdogs. One-line-class logic change; strict de-escalation (the watchdog acts less, never more).

## Verification
- 24/24 `CompactionSentinel.test.ts` pass — updated the old "force inject after cap" test to assert stand-down + added a regression test that fails if a still-working session is ever force-injected again.
- `tsc --noEmit` clean. Independent second-pass review: concur (strict de-escalation, opt-out preserved, no state leak, hung-case still covered).

🤖 Generated with [Claude Code](https://claude.com/claude-code)