### PR TITLE
fix(ws52): real login link (code=t de-wrap) + tap-simple Pending Logins card

### DIFF
--- a/.instar/instar-dev-decisions/2026-06-19T00-25-17-697Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-06-19T00-25-17-697Z-unknown.json
@@ -1,0 +1,13 @@
+{
+  "ts": "2026-06-19T00:25:17.697Z",
+  "slug": "unknown",
+  "suggestedTier": 2,
+  "declaredTier": 2,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 2,
+  "loc": 49,
+  "causalAutopsy": null,
+  "verdict": "pass"
+}

--- a/.instar/instar-dev-decisions/2026-06-19T00-28-03-196Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-06-19T00-28-03-196Z-unknown.json
@@ -1,0 +1,13 @@
+{
+  "ts": "2026-06-19T00:28:03.196Z",
+  "slug": "unknown",
+  "suggestedTier": 2,
+  "declaredTier": 2,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 2,
+  "loc": 49,
+  "causalAutopsy": null,
+  "verdict": "pass"
+}

--- a/dashboard/subscriptions.js
+++ b/dashboard/subscriptions.js
@@ -247,6 +247,21 @@ export function buildFollowMeIssuePayload(card, offers, pinValue) {
 }
 
 /** Pending Logins panel: device code / verification URL (as TEXT) + TTL + reissues. */
+// Only render a verification URL as a TAPPABLE link when it is https AND points at a
+// known provider sign-in host. Anything else falls back to plain text (preserves the
+// "never make an arbitrary href clickable" intent while giving a real one-tap sign-in
+// for the legitimate provider OAuth URLs).
+const PROVIDER_LOGIN_HOSTS = ['claude.com', 'claude.ai', 'anthropic.com', 'openai.com', 'auth.openai.com', 'accounts.google.com', 'google.com'];
+function trustedLoginUrl(raw) {
+  if (typeof raw !== 'string' || !raw) return null;
+  try {
+    const u = new URL(raw);
+    if (u.protocol !== 'https:') return null;
+    const host = u.hostname.toLowerCase();
+    return PROVIDER_LOGIN_HOSTS.some((h) => host === h || host.endsWith('.' + h)) ? u.href : null;
+  } catch { return null; }
+}
+
 export function renderPendingLogins(doc, target, logins, now = Date.now()) {
   if (!target) return;
   target.replaceChildren();
@@ -256,25 +271,42 @@ export function renderPendingLogins(doc, target, logins, now = Date.now()) {
   }
   for (const l of logins) {
     const row = el(doc, 'div', 'sub-pending');
-    const head = el(doc, 'div', 'sub-pending-head');
-    head.appendChild(el(doc, 'span', 'sub-pending-label', sanitizeForDisplay(l && l.label, 'label')));
-    const ttl = l && l.ttlExpiresAt ? countdown(l.ttlExpiresAt, now) : '';
-    head.appendChild(el(doc, 'span', 'sub-pending-ttl', ttl ? `expires in ${ttl}` : 'expired'));
-    row.appendChild(head);
-    // Flow heads-up (e.g. the Claude two-code sequence) — shown before the code so
-    // the operator knows what to expect. Plain text, sanitized; never a live href.
-    if (l && l.notice) {
-      row.appendChild(el(doc, 'div', 'sub-pending-notice', sanitizeForDisplay(l.notice, 'summary')));
+
+    // Lead with a plain-language headline naming what to do + where (machine).
+    const machine = sanitizeForDisplay(l && (l.machineNickname || l.machineId), 'label');
+    const who = sanitizeForDisplay(l && l.label, 'label');
+    const headline = machine
+      ? `Sign in to finish setting up ${who} on ${machine}`
+      : `Sign in to finish setting up ${who}`;
+    row.appendChild(el(doc, 'div', 'sub-pending-headline', headline));
+
+    // The PRIMARY action: one tappable "Sign in" link to the provider's own OAuth URL.
+    // Falls back to copy-text only if the URL isn't a trusted provider sign-in host.
+    const href = trustedLoginUrl(l && l.verificationUrl);
+    if (href) {
+      const a = doc.createElement('a');
+      a.setAttribute('href', href);
+      a.setAttribute('target', '_blank');
+      a.setAttribute('rel', 'noopener noreferrer');
+      a.setAttribute('class', 'sub-pending-signin');
+      a.textContent = 'Sign in';
+      row.appendChild(a);
+    } else if (l && l.verificationUrl) {
+      row.appendChild(el(doc, 'div', 'sub-pending-url', sanitizeForDisplay(l.verificationUrl, 'url')));
     }
+
+    // A device code (only some flows) — shown compactly under the button.
     if (l && l.userCode) {
       row.appendChild(el(doc, 'div', 'sub-pending-code', `Code: ${sanitizeForDisplay(l.userCode, 'code')}`));
     }
-    // Verification URL shown as TEXT for the operator to copy — never a live href.
-    row.appendChild(el(doc, 'div', 'sub-pending-url', sanitizeForDisplay(l && l.verificationUrl, 'url')));
-    const rc = l && Number(l.reissueCount);
-    if (Number.isFinite(rc) && rc > 0) {
-      row.appendChild(el(doc, 'div', 'sub-pending-reissue', `Re-issued ${rc} time${rc === 1 ? '' : 's'}`));
+
+    // One short secondary line: the TTL, and the flow notice only if present (trimmed).
+    const ttl = l && l.ttlExpiresAt ? countdown(l.ttlExpiresAt, now) : '';
+    if (ttl) row.appendChild(el(doc, 'div', 'sub-pending-ttl', `Link expires in ${ttl}`));
+    if (l && l.notice) {
+      row.appendChild(el(doc, 'div', 'sub-pending-notice', sanitizeForDisplay(l.notice, 'summary')));
     }
+    // (No "re-issued N times" noise — it confused more than it informed.)
     target.appendChild(row);
   }
 }

--- a/src/commands/server.ts
+++ b/src/commands/server.ts
@@ -10686,7 +10686,19 @@ export async function startServer(options: StartOptions): Promise<void> {
             })
         : undefined,
       driveLogin: new FrameworkLoginDriver({
-        capture: async (session) => sessionManager.captureOutput(session, 120) || '',
+        // Capture with `tmux capture-pane -J` so a hard-WRAPPED verification URL is
+        // joined back into one line (the 2026-06-18 "code=t" truncation bug). Falls
+        // back to the generic capture if tmux/the -J capture is unavailable;
+        // parseArtifact ALSO de-wraps defensively.
+        capture: async (session) => {
+          const tmuxPath = detectTmuxPath();
+          if (tmuxPath) {
+            try {
+              return execFileSync(tmuxPath, ['capture-pane', '-p', '-J', '-S', '-300', '-t', `=${session}:`], { encoding: 'utf-8', timeout: 5000 }) || '';
+            } catch { /* @silent-fallback-ok — fall through to the generic capture */ }
+          }
+          return sessionManager.captureOutput(session, 120) || '';
+        },
         spawn: async ({ framework, configHome }) => {
           const tmuxPath = detectTmuxPath();
           if (!tmuxPath) throw new Error('tmux not available for enrollment login');

--- a/src/core/FrameworkLoginDriver.ts
+++ b/src/core/FrameworkLoginDriver.ts
@@ -84,7 +84,14 @@ export class FrameworkLoginDriver {
    */
   static parseArtifact(paneText: string, kind: LoginFlowKind): LoginArtifact | null {
     if (!paneText) return null;
-    const urlMatch = paneText.match(URL_RE);
+    // A long verification URL HARD-WRAPS across tmux pane lines with no inserted
+    // space (e.g. "...authorize?code=t\nrue&client_id=...\nri=https%3A..."). A naive
+    // single-line URL_RE truncates at the first wrap (the 2026-06-18 "code=t" bug:
+    // the real URL was "...?code=true&client_id=..."). De-wrap first so the FULL URL
+    // is matched. (The capture is ALSO switched to `tmux capture-pane -J`; this is the
+    // pure, unit-tested defense so a wrapped capture still parses correctly.)
+    const dewrapped = dewrapWrappedUrls(paneText);
+    const urlMatch = dewrapped.match(URL_RE);
     if (!urlMatch) return null;
     const verificationUrl = stripTrailingPunctuation(urlMatch[1]);
 
@@ -156,6 +163,32 @@ export class FrameworkLoginDriver {
 
 function stripTrailingPunctuation(url: string): string {
   return url.replace(/[.,;:'")\]]+$/, '');
+}
+
+/**
+ * Re-join a verification URL that a terminal HARD-WRAPPED across pane lines. tmux
+ * wraps a long line at the pane width by inserting a newline with NO space — so a
+ * URL becomes "...?code=t\nrue&client_id=...\nri=...". We reassemble it: find the
+ * line bearing the first http(s) URL, then append each following line that is a pure
+ * URL-continuation fragment (non-empty and containing NO whitespace), stopping at the
+ * first blank line or a line with internal whitespace (real output, e.g. a prompt).
+ * Only that one URL region is joined; the rest of the text is left untouched so the
+ * code/TTL parses stay line-accurate. Idempotent on already-unwrapped text.
+ */
+function dewrapWrappedUrls(text: string): string {
+  const lines = text.split('\n');
+  const i = lines.findIndex((l) => /https?:\/\//i.test(l));
+  if (i === -1) return text;
+  let joined = lines[i].replace(/\s+$/, '');
+  let j = i + 1;
+  for (; j < lines.length; j++) {
+    const ln = lines[j];
+    if (ln.trim() === '') break;          // blank line ends the URL
+    if (/\s/.test(ln.trim())) break;       // internal whitespace ⇒ real output, not a wrap fragment
+    joined += ln.replace(/\s+$/, '');
+  }
+  // Rebuild: lines before the URL, the rejoined URL line, then the remaining lines.
+  return [...lines.slice(0, i), joined, ...lines.slice(j)].join('\n');
 }
 
 function parseTtlMs(text: string): number | undefined {

--- a/tests/e2e/subscriptions-tab-lifecycle.test.ts
+++ b/tests/e2e/subscriptions-tab-lifecycle.test.ts
@@ -85,8 +85,13 @@ describe('/subscription-pool — Subscriptions tab E2E feature-alive', () => {
     expect(els.accounts.querySelector('.sub-account-nick')!.textContent).toBe('personal');
     expect(els.accounts.querySelectorAll('.sub-quota').length).toBe(2);
     expect(els.pending.querySelector('.sub-pending-code')!.textContent).toContain('7DAU-W4XJA');
-    // safety: no live link / injected element survived the round-trip
-    expect(els.pending.querySelector('a')).toBeNull();
+    // The pending login now offers a tappable "Sign in" link to the trusted provider URL
+    // (auth.openai.com) — the UX fix. The href is the provider's own OAuth URL, no token.
+    const signin = els.pending.querySelector('a.sub-pending-signin') as HTMLAnchorElement | null;
+    expect(signin).not.toBeNull();
+    expect(signin!.getAttribute('href')).toBe('https://auth.openai.com/codex/device');
+    expect(JSON.stringify(els.pending.innerHTML).toLowerCase()).not.toMatch(/token|secret|refresh|api_key/);
+    // safety: no injected <script> survived the round-trip
     expect(els.accounts.querySelector('script')).toBeNull();
   });
 

--- a/tests/unit/framework-login-driver.test.ts
+++ b/tests/unit/framework-login-driver.test.ts
@@ -46,6 +46,32 @@ describe('FrameworkLoginDriver.parseArtifact', () => {
     expect(a!.userCode).toBeUndefined(); // paste-back code flows user→CLI, not scraped
   });
 
+  it('re-joins a verification URL HARD-WRAPPED across tmux pane lines (the code=t bug)', () => {
+    // Real captured pane from `claude auth login` on the Mac Mini (2026-06-18): the long
+    // OAuth URL wrapped at the pane width with NO inserted space, so a naive scrape
+    // truncated it to "...authorize?code=t". parseArtifact must de-wrap and return the FULL url.
+    const WRAPPED = [
+      'Opening browser to sign in…',
+      'If the browser didn’t open, visit: https://claude.com/cai/oauth/authorize?code=t',
+      'rue&client_id=9d1c250a-e61b-44d9-88ed-5944d1962f5e&response_type=code&redirect_u',
+      'ri=https%3A%2F%2Fplatform.claude.com%2Foauth%2Fcode%2Fcallback&scope=user%3Aprofile',
+      '&state=K9pItOrURdZZjsD2XdIssdaVUOr7tT-oCJ1s1LnYadY',
+      'Paste code here if prompted >',
+    ].join('\n');
+    const a = FrameworkLoginDriver.parseArtifact(WRAPPED, 'url-code-paste');
+    expect(a).not.toBeNull();
+    expect(a!.verificationUrl).toBe(
+      'https://claude.com/cai/oauth/authorize?code=true&client_id=9d1c250a-e61b-44d9-88ed-5944d1962f5e&response_type=code&redirect_uri=https%3A%2F%2Fplatform.claude.com%2Foauth%2Fcode%2Fcallback&scope=user%3Aprofile&state=K9pItOrURdZZjsD2XdIssdaVUOr7tT-oCJ1s1LnYadY',
+    );
+    // NOT the truncated value
+    expect(a!.verificationUrl).not.toBe('https://claude.com/cai/oauth/authorize?code=t');
+  });
+
+  it('leaves an already-unwrapped URL unchanged (idempotent de-wrap)', () => {
+    const a = FrameworkLoginDriver.parseArtifact('visit: https://claude.ai/oauth/authorize?code=xyz123\nPaste code >', 'url-code-paste');
+    expect(a!.verificationUrl).toBe('https://claude.ai/oauth/authorize?code=xyz123');
+  });
+
   it('returns null for a device-code flow until the code has printed', () => {
     const partial = 'To authenticate, visit: https://auth.openai.com/codex/device\nWaiting...';
     expect(FrameworkLoginDriver.parseArtifact(partial, 'device-code')).toBeNull();

--- a/tests/unit/subscriptions-render.test.ts
+++ b/tests/unit/subscriptions-render.test.ts
@@ -171,17 +171,23 @@ describe('renderPendingLogins', () => {
     renderPendingLogins(doc, t, [], NOW);
     expect(t.querySelector('.sub-empty')).toBeTruthy();
   });
-  it('renders code + url-as-text + TTL + reissue count; never a live href', () => {
+  it('renders a tap-simple card: headline + a "Sign in" link to the trusted provider URL + code + TTL (no reissue noise)', () => {
     const t = el();
     renderPendingLogins(doc, t, [{
       id: 'codex-1', label: 'codex', kind: 'device-code', userCode: '7DAU-W4XJA',
       verificationUrl: 'https://auth.openai.com/codex/device', ttlExpiresAt: '2026-06-07T00:12:00Z', reissueCount: 2,
     }], NOW);
+    expect(t.querySelector('.sub-pending-headline')!.textContent).toContain('Sign in to finish setting up');
+    // A trusted provider host (auth.openai.com) → a real tappable "Sign in" link.
+    const a = t.querySelector('a.sub-pending-signin');
+    expect(a).toBeTruthy();
+    expect(a!.getAttribute('href')).toBe('https://auth.openai.com/codex/device');
+    expect(a!.getAttribute('rel')).toContain('noopener');
+    expect(a!.textContent).toBe('Sign in');
     expect(t.querySelector('.sub-pending-code')!.textContent).toContain('7DAU-W4XJA');
-    expect(t.querySelector('.sub-pending-url')!.textContent).toContain('auth.openai.com');
-    expect(t.querySelector('a')).toBeNull(); // URL is TEXT, never a live link
-    expect(t.querySelector('.sub-pending-ttl')!.textContent).toBe('expires in 12m');
-    expect(t.querySelector('.sub-pending-reissue')!.textContent).toContain('2 times');
+    expect(t.querySelector('.sub-pending-ttl')!.textContent).toBe('Link expires in 12m');
+    // The confusing "re-issued N times" noise is gone.
+    expect(t.querySelector('.sub-pending-reissue')).toBeNull();
   });
   it('a javascript: URL renders as inert text, not an anchor', () => {
     const t = el();

--- a/upgrades/next/ws52-code-t-fix.md
+++ b/upgrades/next/ws52-code-t-fix.md
@@ -1,0 +1,19 @@
+<!-- slug: ws52-code-t-fix -->
+<!-- bump: patch -->
+
+## What Changed
+
+Fixes the account-follow-me login link showing a placeholder (a URL ending in `code=t`) instead of a working Claude sign-in link. The long verification URL from `claude auth login` hard-wraps across tmux pane lines with no inserted space; the scrape that reads it stopped at the first wrap and kept only the head fragment. The login was always real — the scrape cut it short. Now `FrameworkLoginDriver.parseArtifact` re-joins wrapped URL fragments before matching, and the capture uses `tmux capture-pane -J` to join wraps at the source.
+
+## What to Tell Your User
+
+The "let another machine use this subscription" login link now comes through complete and usable, instead of a broken placeholder.
+
+## Summary of New Capabilities
+
+- No new capability — a correctness fix so the follow-me device-code login link is the full, usable URL.
+
+## Evidence
+
+- `tests/unit/framework-login-driver.test.ts` — NEW test re-joins the REAL captured (wrapped) Mac Mini login pane into the full URL and asserts it is NOT the `code=t` head fragment; 14 driver tests green.
+- `tsc --noEmit` clean.

--- a/upgrades/side-effects/ws52-code-t-fix.md
+++ b/upgrades/side-effects/ws52-code-t-fix.md
@@ -1,0 +1,33 @@
+# Side-Effects Review — WS5.2: re-join line-wrapped verification URL (code=t fix)
+
+**Version / slug:** `ws52-code-t-fix`
+**Date:** `2026-06-18`
+**Author:** `Echo (instar-dev agent)`
+**Second-pass reviewer:** `not required (pure scrape-parse fix + a source-side capture flag; no decision/auth surface)`
+
+## Summary
+The follow-me device-code login link surfaced as a placeholder ending in `code=t`. Root cause: the long Claude OAuth URL from `claude auth login` hard-wraps across tmux pane lines with no inserted space (`...?code=t` then `rue&client_id=...`); `FrameworkLoginDriver`'s `URL_RE` stopped at the first wrap. Fix: `parseArtifact` re-joins wrapped URL fragments before matching (pure, unit-tested against the real captured pane); the injected `capture` now uses `tmux capture-pane -J` to join wraps at the source. Files: `src/core/FrameworkLoginDriver.ts`, `src/commands/server.ts`, `tests/unit/framework-login-driver.test.ts`.
+
+## 1. Over-block / 2. Under-block
+No block/allow surface. The de-wrap only affects which characters of a verification URL are captured. Under-block: a URL containing internal whitespace would not be a single wrapped token, but real URLs have none; the join stops at the first whitespace/blank line, so non-URL output is never absorbed.
+
+## 3. Level-of-abstraction fit
+Correct — the fix is in the pure scrape parser (where the bug is) + the source capture flag. No higher layer involved.
+
+## 4. Signal vs authority compliance
+No authority. Pure text parsing; reads only the PUBLIC verification URL (never a token). Strictly a correctness improvement.
+
+## 5. Interactions
+`parseArtifact` is also used for Codex device-code + already-unwrapped URLs — covered by existing + new idempotency tests (an unwrapped URL is unchanged). The `-J` capture is scoped to the enrollment login driver only; generic captures are untouched.
+
+## 6. External surfaces
+The operator now receives the full, usable login URL instead of a placeholder. No token exposure (unchanged). No new endpoint.
+
+## 7. Multi-machine posture
+Machine-local: each target machine scrapes its own login pane. No cross-machine state. Both machines get the fix via the normal deploy.
+
+## 8. Rollback cost
+Revert; ship a patch. Pure code, no persistent state.
+
+## Conclusion
+Small, pure, well-tested fix to the actual blocker that made the surfaced login link unusable. 14 driver tests green incl. the real wrapped-pane fixture; tsc clean.

--- a/upgrades/side-effects/ws52-code-t-fix.md
+++ b/upgrades/side-effects/ws52-code-t-fix.md
@@ -31,3 +31,7 @@ Revert; ship a patch. Pure code, no persistent state.
 
 ## Conclusion
 Small, pure, well-tested fix to the actual blocker that made the surfaced login link unusable. 14 driver tests green incl. the real wrapped-pane fixture; tsc clean.
+
+## Follow-up — Pending-logins card UX redesign (operator feedback, 2026-06-18)
+
+Justin: the Pending Logins card was "extremely hard to understand." Redesigned `renderPendingLogins` to be tap-simple: (1) a plain-language headline ("Sign in to finish setting up <account> on <machine>"); (2) the PRIMARY action is a single tappable "Sign in" link — but ONLY when the URL is https AND on a trusted provider host (claude.com/anthropic/openai/google); an untrusted or `javascript:` URL still renders as inert text with NO anchor (safety invariant preserved + unit-tested); (3) removed the confusing "re-issued N times" noise; (4) TTL shown as one short line. Tests updated: subscriptions-render (26), subscriptions-tab (5), subscriptions-tab-lifecycle e2e (2), pending-logins-pool-merge (3) — all green; the javascript:-URL-stays-inert safety test retained.

--- a/upgrades/side-effects/ws52-enroll-seams.md
+++ b/upgrades/side-effects/ws52-enroll-seams.md
@@ -69,3 +69,7 @@ CI surfaced two real issues from seam #3, both fixed: (1) the `?scope=pool` bran
 ## Follow-up (CI hang fix, 2026-06-18)
 
 CI shard 4/4 hung ~1h46m — root cause in this change: the seam #1 consumer's `setTimeout` (boot-sweep) + `setInterval` (60s tick) in AgentServer were NOT `.unref()`'d, so a test that boots AgentServer kept the event loop alive (vitest hangs on the open handle). Fixed: `.unref()` both timers (matches the sibling pollers), and added `AbortSignal.timeout` to the consumer's self-fetches (5s on the idempotency reads, 200s on the enroll-start drive) so a wedged fetch can't hold the loop either. tsc clean.
+
+## Follow-up (the real "code=t" login bug, 2026-06-18)
+
+Driving the proof to completion (Justin tapped Approve) exposed the actual remaining bug: the device-code login link surfaced as a placeholder ending in code=t. Root cause: the verification URL from `claude auth login` is long and HARD-WRAPS across tmux pane lines with no inserted space (`...?code=t` then `rue&client_id=...` on the next line); FrameworkLoginDriver's URL scrape stopped at the first wrap and kept only the head fragment. The login was always real; the SCRAPE cut it short. Fix: (1) `parseArtifact` now re-joins wrapped URL fragments before matching (pure + unit-tested against the REAL captured Mini pane); (2) the capture switched to `tmux capture-pane -J` (joins wraps at the source). 14 FrameworkLoginDriver tests green incl. the wrapped-URL fixture. This makes the surfaced login link actually usable.


### PR DESCRIPTION
## What this fixes

Two issues found by driving the follow-me proof to completion (Justin tapped Approve, the login surfaced — but was unusable + confusing):

**1. The login link was a placeholder (`code=t`).** The long Claude OAuth URL from `claude auth login` hard-wraps across tmux pane lines with no inserted space (`...?code=t` then `rue&client_id=...`); the URL scrape stopped at the first wrap. The login was always real — the scrape cut it short. Fix: `parseArtifact` re-joins wrapped URL fragments before matching (pure, unit-tested against the REAL captured Mac Mini pane), and the capture uses `tmux capture-pane -J`.

**2. The Pending Logins card was hard to understand.** Redesigned to be tap-simple: a plain headline ("Sign in to finish setting up X on Y"), a single tappable "Sign in" link (only for https URLs on trusted provider hosts — untrusted/`javascript:` stays inert text, safety preserved + tested), removed the confusing "re-issued N times" noise, TTL as one short line.

## ELI16

When you tapped Approve, a login card appeared — but the link was broken (it ended in "code=t") and the card was cluttered and confusing. The broken link wasn't a broken login; the long sign-in web address was wrapping onto the next line in the terminal and getting cut off when the system read it. Now it's stitched back together into the full, working address. And the card itself is rebuilt: instead of a wall of text and a raw web address, it's a clear line ("Sign in to finish setting up adriana on Mac Mini") with a single "Sign in" button to tap. Junk like "re-issued 172 times" is gone. Safety is kept: only real provider sign-in links (Claude/OpenAI/Google) become tappable; anything else stays plain text.

## Verification
- `tests/unit/framework-login-driver.test.ts` (14) — re-joins the real wrapped Mini pane to the full URL, asserts it's NOT `code=t`.
- `tests/unit/subscriptions-render.test.ts` (26) + subscriptions-tab (5) + subscriptions-tab-lifecycle e2e (2) + pending-logins-pool-merge (3) — green; the `javascript:`-stays-inert safety test retained.
- `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)