### PR TITLE
fix(dashboard): make the account-matrix "Needs sign-in" cell actionable

### DIFF
--- a/dashboard/subscriptions.js
+++ b/dashboard/subscriptions.js
@@ -457,13 +457,18 @@ export function renderAccountMatrix(doc, target, poolScope, pendingScope, transi
     tr.appendChild(el(doc, 'th', 'sub-matrix-acct', sanitizeForDisplay(row.account.email, 'label')));
     for (const c of row.cells) {
       const td = el(doc, 'td', `sub-matrix-cell sub-matrix-${c.state}`);
-      if (c.state === 'empty' || c.state === 'held' || c.state === 'cant-resolve') {
-        // An actionable cell → a "Set up" button (held/cant-resolve let the operator retry).
-        const btn = el(doc, 'button', 'sub-matrix-setup', c.state === 'empty' ? 'Set up' : 'Retry');
+      if (c.state === 'empty' || c.state === 'needs-reauth' || c.state === 'held' || c.state === 'cant-resolve') {
+        // An actionable cell → a button that runs the SAME in-dashboard sign-in flow (PIN → link →
+        // paste code). empty → "Set up"; needs-reauth (an existing account whose login expired) →
+        // "Sign in"; held/cant-resolve → "Retry". A needs-reauth account already resolves to its
+        // email, so the start-cell orchestrator drives a real re-auth — never a cosmetic button.
+        const label = c.state === 'empty' ? 'Set up' : (c.state === 'needs-reauth' ? 'Sign in' : 'Retry');
+        const btn = el(doc, 'button', 'sub-matrix-setup', label);
         btn.setAttribute('data-matrix-setup', '1');
         btn.setAttribute('data-account-id', sanitizeForDisplay(c.accountId, 'label'));
         btn.setAttribute('data-machine-id', sanitizeForDisplay(c.machineId, 'label'));
         if (c.state !== 'empty') {
+          // Show the status word ("⟳ Needs sign-in" / "⚠ Didn't match…") ABOVE the button.
           td.appendChild(el(doc, 'div', 'sub-matrix-glyph', `${MATRIX_CELL_GLYPH[c.state]} ${MATRIX_CELL_WORD[c.state]}`));
         }
         td.appendChild(btn);

--- a/docs/specs/matrix-needs-signin-button.eli16.md
+++ b/docs/specs/matrix-needs-signin-button.eli16.md
@@ -1,0 +1,29 @@
+# Account Matrix "Needs sign-in" → actionable Sign-in button — Plain-English Overview
+
+> The one-line version: a matrix cell that said "Needs sign-in" was a dead-end with no button to act on — this gives it a working "Sign in" button right below the words, exactly like the empty cells already have.
+
+## The problem in one breath
+
+The Subscriptions dashboard shows a grid of "which account is signed in on which machine." Empty cells get a "Set up" button you can tap; a cell whose login expired showed only the grey text "⟳ Needs sign-in" — with nothing to tap. So the user could SEE that an account needed re-authentication but had no way to do anything about it from the dashboard. The operator's exact words: "Everything should be actionable from the dashboard itself."
+
+## What already exists
+
+- **The account × machine matrix** — a table in the Subscriptions tab. Rows are accounts (by email), columns are machines (Laptop, Mac Mini). Each cell shows a state: ✓ Active, an empty "Set up" button, "Needs sign-in", "Signing in…", "Machine offline", etc.
+- **The in-dashboard sign-in flow** — tapping "Set up" expands an inline PIN box → on confirm it calls the PIN-gated `start-cell` endpoint → that returns a real provider sign-in link + a code-paste box. The whole login happens inside the dashboard, no terminal. This already works for empty cells.
+- **`start-cell`** — the server orchestrator behind that flow. It resolves the account's email from the account id, issues the follow-me mandate, and drives the login (on this machine or, over the mesh, on a peer machine).
+
+## What this adds
+
+The "Needs sign-in" state was simply left out of the list of cell-states that render a button — it fell into the "just draw text" branch. This change moves `needs-reauth` into the actionable branch alongside the empty/retry states, and gives it the label **"Sign in"**. The status word "⟳ Needs sign-in" still shows, with the button directly below it — precisely the layout the operator asked for. The button carries the same `(account id, machine id)` data and triggers the exact same existing flow, so a tap drives a genuine re-authentication. An account in the needs-sign-in state already resolves to its email, so `start-cell` works for it unchanged — the button is real, not cosmetic.
+
+## The new pieces
+
+- **No new module, no new endpoint, no new authority.** This is a pure front-end rendering change in `dashboard/subscriptions.js`. The PIN gate, the mandate issuance, and the sign-in orchestration all already exist and are untouched. The button simply re-uses them.
+
+## The safeguards
+
+The action behind the button is still gated by the operator's dashboard PIN (the `start-cell` endpoint refuses without it) — adding the button changes nothing about who is allowed to start a login. The change is one branch condition plus a button label; a new unit test asserts the needs-sign-in cell now renders a "Sign in" button wired to the existing flow, so the dead-end can't silently come back. Other cell states (active, offline, in-progress) are unchanged.
+
+## What the reader needs to decide
+
+Nothing risky — this is a small UX fix that makes a visible dead-end actionable using machinery that already ships. The only judgement call was the button label ("Sign in" vs "Re-authenticate"); "Sign in" matches the rest of the flow's vocabulary.

--- a/tests/unit/subscriptions-render.test.ts
+++ b/tests/unit/subscriptions-render.test.ts
@@ -324,6 +324,32 @@ describe('renderAccountMatrix', () => {
     expect(cell!.querySelector('.sub-matrix-setup')).toBeNull();
   });
 
+  it('renders a "Sign in" button (with the "Needs sign-in" word above it) for a needs-reauth cell', () => {
+    // a3 exists on a reachable machine but its login expired (status needs-reauth) → the cell must
+    // be ACTIONABLE: the status word AND a "Sign in" button carrying the (account, machine) ids.
+    const t = el();
+    const pool = {
+      enabled: true,
+      accounts: [
+        { id: 'a3', email: 'a3@x.com', status: 'needs-reauth', machineId: 'm1', machineNickname: 'Laptop' },
+      ],
+      pool: { selfMachineId: 'm1', failed: [] },
+      scope: 'pool',
+    };
+    renderAccountMatrix(doc, t, pool, { enabled: true, logins: [] }, {});
+    const cell = t.querySelector('.sub-matrix-needs-reauth');
+    expect(cell).toBeTruthy();
+    // The status word still shows…
+    expect(cell!.textContent).toContain('Needs sign-in');
+    // …AND there is a real, actionable button wired to the same start-cell flow as "Set up".
+    const btn = cell!.querySelector('.sub-matrix-setup');
+    expect(btn).toBeTruthy();
+    expect(btn!.textContent).toBe('Sign in');
+    expect(btn!.getAttribute('data-matrix-setup')).toBe('1');
+    expect(btn!.getAttribute('data-account-id')).toBe('a3');
+    expect(btn!.getAttribute('data-machine-id')).toBe('m1');
+  });
+
   it('buildMatrixModel pivots on (accountId, machineId) and marks offline machines', () => {
     const model = buildMatrixModel(poolScope, pendingScope, {});
     expect(model.machines.find((m: any) => m.machineId === 'm2')!.offline).toBe(true);

--- a/upgrades/next/matrix-needs-signin-button.md
+++ b/upgrades/next/matrix-needs-signin-button.md
@@ -1,0 +1,26 @@
+## What Changed
+
+The Subscriptions dashboard's account × machine matrix had a dead-end. A cell whose login had expired showed only the grey text "⟳ Needs sign-in" with **no button to act on** — so you could see an account needed re-authentication but had no way to do anything about it from the dashboard. Every other cell-state was already actionable: an empty cell gets a "Set up" button, a failed cell gets a "Retry" button. The `needs-reauth` state was simply left out of the branch that renders a button and fell through to the "just draw text" path.
+
+This fix moves `needs-reauth` into the actionable branch in `dashboard/subscriptions.js`. The cell now shows the status word "⟳ Needs sign-in" **and** a "Sign in" button directly below it. The button carries the same `(account, machine)` ids as the "Set up" button and runs the exact same in-dashboard flow (PIN → provider sign-in link → paste code). Because a needs-sign-in account already resolves to its email, the `start-cell` orchestrator drives a genuine re-authentication — the button is real, not cosmetic. No server route, authority, or data model changed; the PIN gate on starting a login is untouched.
+
+## What to Tell Your User
+
+If you saw an account in your Subscriptions grid marked "Needs sign-in" with no way to fix it, that's now a one-tap action. The cell shows "Needs sign-in" with a **Sign in** button right below — tap it, enter your PIN, open the sign-in link, and paste the code back, exactly like setting up a new account. Everything stays inside the dashboard; nothing changed about who's allowed to start a login.
+
+## Summary of New Capabilities
+
+- The account × machine matrix's "Needs sign-in" cell is now actionable: it renders the status word **plus a "Sign in" button** that runs the existing in-dashboard re-authentication flow (PIN → link → paste code).
+- The button works for an account whose login expired on this machine OR on a peer machine — it rides the same PIN-gated, mesh-delivered `start-cell` path the "Set up" button already uses.
+- No change to authorization: starting a login still requires the operator's dashboard PIN.
+
+## Evidence
+
+- New regression unit test in `tests/unit/subscriptions-render.test.ts`: asserts a `needs-reauth` cell renders the "Needs sign-in" word AND a `.sub-matrix-setup` "Sign in" button wired to the start-cell flow (`data-matrix-setup`, correct account/machine ids). 34/34 in that file pass.
+- Related front-end tests green: `follow-me-controller-wiring.test.ts` (8) and `account-follow-me-locally-executable.test.ts` (9) — confirms the existing tap-handler/flow this button re-uses is unchanged.
+- Traced root cause directly in `renderAccountMatrix`: `needs-reauth` was absent from the actionable-cell branch condition; the server `start-cell` route resolves an existing account's email and drives a real re-auth, so the new button is functional.
+- Side-effects review: `upgrades/side-effects/matrix-needs-signin-button.md` (no block/allow surface; no new authority; machine-local render of an existing pool-scope flow). Tier 1.
+
+## ELI16
+
+The Subscriptions screen has a grid showing which account is signed in on which machine. Empty squares had a "Set up" button you could tap. But a square for an account whose login had run out just said "Needs sign-in" in grey — with no button. So you could see the problem but couldn't fix it from the screen. Turns out the code that decides "should this square have a button?" simply forgot to include the "needs sign-in" case, so it drew plain text instead. This fix adds the button: the square now says "Needs sign-in" with a "Sign in" button right under it, and tapping it runs the same sign-in steps as setting up a new account (enter your PIN, open the link, paste the code). It actually signs the account back in — it's not a fake button — and it works whether the account expired on this machine or another one.

--- a/upgrades/side-effects/matrix-needs-signin-button.md
+++ b/upgrades/side-effects/matrix-needs-signin-button.md
@@ -1,0 +1,70 @@
+# Side-Effects Review — Account matrix "Needs sign-in" → actionable Sign-in button
+
+**Version / slug:** `matrix-needs-signin-button`
+**Date:** `2026-06-20`
+**Author:** `Instar Agent (echo)`
+**Second-pass reviewer:** `not required (no block/allow surface, no lifecycle/gate/sentinel)`
+
+## Summary of the change
+
+The account × machine matrix in the Subscriptions dashboard had a cell-state, `needs-reauth` ("Needs sign-in"), that rendered as static text with no actionable control — a dead-end. This change (one branch condition + a button label in `dashboard/subscriptions.js`, plus one unit test in `tests/unit/subscriptions-render.test.ts`) moves `needs-reauth` into the actionable rendering branch so it draws the status word "⟳ Needs sign-in" AND a "Sign in" button directly below it. The button carries the same `data-matrix-setup` / `data-account-id` / `data-machine-id` attributes the empty-cell "Set up" button does, so it routes through the EXISTING, unchanged PIN-gated `start-cell` → sign-in-link → code-paste flow. No server route, authority, or data model is touched.
+
+## Decision-point inventory
+
+This change touches NO decision point. It is presentation logic only: it decides which DOM (a button vs plain text) to render for an already-computed cell state. The authority that gates starting a login (the dashboard-PIN check on `POST /subscription-pool/matrix/start-cell`) is unchanged and continues to be the sole gate.
+
+- `renderAccountMatrix` cell rendering (`dashboard/subscriptions.js`) — modify — adds `needs-reauth` to the set of cell-states that render an actionable button; pure view logic, no gating.
+
+---
+
+## 1. Over-block
+
+No block/allow surface — over-block not applicable. The change ADDS an affordance; it rejects nothing.
+
+---
+
+## 2. Under-block
+
+No block/allow surface — under-block not applicable. The PIN gate on `start-cell` is unchanged, so this adds no new path that bypasses authorization: tapping "Sign in" still requires the operator's PIN to actually start a login, exactly as "Set up" does.
+
+---
+
+## 3. Level-of-abstraction fit
+
+Correct layer. This is a view-rendering concern living in the dashboard front-end, exactly where the sibling "Set up"/"Retry" button logic already lives. It re-uses the existing `start-cell` orchestrator rather than re-implementing any email-resolution / mandate / login logic — it feeds the smart gate that already exists instead of running parallel to it.
+
+---
+
+## 4. Signal vs authority compliance
+
+Compliant. The change adds NO blocking authority and NO brittle decision logic. It renders a button that, when tapped, calls an existing PIN-gated authority (`start-cell`). The button itself holds no authority; the server endpoint remains the single authority and is untouched.
+
+---
+
+## 5. Interactions
+
+- The new button uses the SAME delegated tap handler (`wireMatrixSetup` → `onSetupTap` → `onConfirmTap` → `start-cell`) as the empty-cell "Set up" button, so it cannot double-fire or shadow another handler — it is the same code path keyed on `data-matrix-setup`.
+- `start-cell` already handles an existing account: it resolves the account email from the accountId (`resolveFollowMeEnrollTarget`) and has self-target idempotency that reuses an in-flight pending login. A needs-reauth account resolves to its email, so the flow drives a real re-auth and does not mint a duplicate when one is already pending.
+- No race with adjacent cleanup: the cell re-renders from durable state each poll; an in-progress login transitions the cell to the in-progress (◷) state with its Cancel button, exactly as a "Set up"-initiated login does.
+
+---
+
+## 6. External surfaces
+
+The only external surface is the dashboard UI: a `needs-reauth` cell now shows a "Sign in" button. No change to any API response, agent-to-agent surface, or other system. No new timing/conversation-state dependency — rendering is a pure function of the already-fetched pool/pending state.
+
+### 6b. Operator-surface quality
+
+This change EXISTS to improve operator-surface quality: it converts a non-actionable status into a one-tap action, matching the operator's directive that everything be actionable from the dashboard. The button label ("Sign in") matches the flow's existing vocabulary; the status word remains visible so the operator still understands WHY the action is offered.
+
+---
+
+## 7. Multi-machine posture (Cross-Machine Coherence)
+
+Machine-local rendering of a pool-scope read, BY DESIGN. The matrix already reads `scope=pool` (peers merged) and the `start-cell` flow already delivers the mandate over the mesh for a peer-target cell. A needs-reauth cell on a PEER machine (e.g. the account expired on the Laptop while the Mini fronts the dashboard) routes its "Sign in" through the same proven cross-machine `start-cell` → peer enroll/start path the "Set up" button uses. No new replication or per-machine state is introduced; the change rides the existing cross-machine plumbing.
+
+---
+
+## 8. Rollback cost
+
+Trivial. Revert the single commit (one branch condition + label + one test) — the cell returns to showing static "Needs sign-in" text. No data migration, no agent-state repair, no release coordination. Dashboard files ship static (no compiled artifact), so a revert is immediately effective on next deploy.


### PR DESCRIPTION
## What & why

The Subscriptions dashboard's **account × machine matrix** had a dead-end. A cell whose login had expired (`needs-reauth`) rendered only the static text "⟳ Needs sign-in" with **no button** — the operator could see an account needed re-authentication but had no way to act from the dashboard. Every other cell-state was already actionable (empty → "Set up", held/cant-resolve → "Retry"); `needs-reauth` was simply absent from the actionable rendering branch and fell through to the "just draw text" path.

## The fix

One branch condition + a label in `dashboard/subscriptions.js` (`renderAccountMatrix`): `needs-reauth` now renders the status word "⟳ Needs sign-in" **and** a **"Sign in"** button directly below it. The button carries the same `data-matrix-setup` / account / machine attributes the "Set up" button does, so it runs the **existing, unchanged** PIN-gated `start-cell` flow (PIN → provider link → paste code). A needs-sign-in account already resolves to its email, so `start-cell` drives a genuine re-auth — the button is functional, not cosmetic. Works for an account expired on this machine or a peer (rides the same mesh-delivered path).

No server route, authority, or data model changed.

## Tier

**Tier 1** — front-end render only, no new decision authority (re-uses the existing PIN-gated endpoint). Artifacts shipped: ELI16 (`docs/specs/matrix-needs-signin-button.eli16.md`), side-effects review (`upgrades/side-effects/matrix-needs-signin-button.md`), release fragment (`upgrades/next/matrix-needs-signin-button.md`).

## Evidence

- New regression test in `tests/unit/subscriptions-render.test.ts`: a `needs-reauth` cell renders the word AND a `.sub-matrix-setup` "Sign in" button wired to the start-cell flow with the correct account/machine ids. **34/34** pass.
- `follow-me-controller-wiring` (8) + `account-follow-me-locally-executable` (9) green — the tap-handler/flow the button re-uses is unchanged.
- `tsc --noEmit` + full lint suite exit 0.

## ELI16 — explain like I'm 16

The Subscriptions screen has a grid showing which account is signed in on which machine. Empty squares had a "Set up" button you could tap. But a square for an account whose login had run out just said "Needs sign-in" in grey — with **no button**, so you could see the problem but couldn't fix it from the screen. The code that decides "should this square have a button?" simply forgot to include the "needs sign in" case, so it drew plain text. This adds the button: the square now says "Needs sign-in" with a **Sign in** button under it, and tapping it runs the same sign-in steps as setting up a new account (enter your PIN, open the link, paste the code). It actually signs the account back in — not a fake button — and works whether the account expired on this machine or another one.