### PR TITLE
fix(feedback): back off on webhook 429/503 instead of re-POSTing the whole backlog

### DIFF
--- a/.instar/instar-dev-decisions/2026-06-20T21-59-40-766Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-06-20T21-59-40-766Z-unknown.json
@@ -1,0 +1,15 @@
+{
+  "ts": "2026-06-20T21:59:40.766Z",
+  "slug": "unknown",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "new capability: new config key added"
+  ],
+  "belowFloor": true,
+  "files": 2,
+  "loc": 169,
+  "causalAutopsy": null,
+  "verdict": "pass"
+}

--- a/.instar/instar-dev-decisions/2026-06-20T22-07-18-957Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-06-20T22-07-18-957Z-unknown.json
@@ -1,0 +1,13 @@
+{
+  "ts": "2026-06-20T22:07:18.957Z",
+  "slug": "unknown",
+  "suggestedTier": 1,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 2,
+  "loc": 23,
+  "causalAutopsy": null,
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-06-20T22-07-52-380Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-06-20T22-07-52-380Z-unknown.json
@@ -1,0 +1,13 @@
+{
+  "ts": "2026-06-20T22:07:52.380Z",
+  "slug": "unknown",
+  "suggestedTier": 1,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 2,
+  "loc": 23,
+  "causalAutopsy": null,
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-06-20T22-08-22-369Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-06-20T22-08-22-369Z-unknown.json
@@ -1,0 +1,15 @@
+{
+  "ts": "2026-06-20T22:08:22.369Z",
+  "slug": "unknown",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "new capability: new config key added"
+  ],
+  "belowFloor": true,
+  "files": 2,
+  "loc": 176,
+  "causalAutopsy": null,
+  "verdict": "pass"
+}

--- a/src/core/FeedbackManager.ts
+++ b/src/core/FeedbackManager.ts
@@ -17,6 +17,7 @@ import path from 'node:path';
 import { randomUUID, createHmac, createHash } from 'node:crypto';
 import type { FeedbackItem, FeedbackConfig } from './types.js';
 import { SafeFsExecutor } from './SafeFsExecutor.js';
+import { decideFeedbackRetry, parseRetryAfterSeconds } from './feedbackBackoff.js';
 
 /** Maximum number of feedback items stored locally. */
 const MAX_FEEDBACK_ITEMS = 1000;
@@ -35,6 +36,15 @@ export class FeedbackManager {
   private version: string;
   /** Cache of agentName -> pseudonym for resolvePseudonym reverse lookups */
   private pseudonymMap: Map<string, string> = new Map();
+  /**
+   * Webhook backoff state (L364). When the canonical feedback endpoint rate-limits
+   * us (429/503), we stop POSTing until `webhookNextRetryAtMs` and grow the wait
+   * with `webhookConsecutive429s`. In-memory by design: a restart re-probes once
+   * (one cycle) then re-backs-off — back-compatible and self-correcting. This is
+   * what stops `retryUnforwarded()` from re-POSTing the whole backlog every cycle.
+   */
+  private webhookNextRetryAtMs = 0;
+  private webhookConsecutive429s = 0;
 
   constructor(config: FeedbackConfig) {
     if (config.webhookUrl) {
@@ -163,8 +173,11 @@ export class FeedbackManager {
       forwarded: false,
     };
 
-    // Forward to webhook if enabled (before persisting, so we know result)
-    if (this.config.enabled && this.config.webhookUrl) {
+    // Forward to webhook if enabled (before persisting, so we know result).
+    // Skip the POST entirely while we're in a rate-limit backoff window (L364):
+    // hammering a 429-ing endpoint only makes it worse. The local record is still
+    // written below, so retryUnforwarded() will pick it up once the window passes.
+    if (this.config.enabled && this.config.webhookUrl && Date.now() >= this.webhookNextRetryAtMs) {
       try {
         const payload = {
           feedbackId: feedback.id,
@@ -187,11 +200,20 @@ export class FeedbackManager {
           signal: AbortSignal.timeout(10000), // 10s timeout
         });
 
-        if (response.ok) {
+        const decision = decideFeedbackRetry({
+          ok: response.ok,
+          status: typeof response.status === 'number' ? response.status : null,
+          retryAfterSec: parseRetryAfterSeconds(response.headers?.get?.('retry-after')),
+          nowMs: Date.now(),
+          consecutive429s: this.webhookConsecutive429s,
+        });
+        this.webhookNextRetryAtMs = decision.nextRetryAtMs;
+        this.webhookConsecutive429s = decision.consecutive429s;
+        if (decision.markForwarded) {
           feedback.forwarded = true;
           console.log(`[feedback] Forwarded to webhook`);
         } else {
-          console.error(`[feedback] Webhook returned ${response.status}: ${response.statusText}`);
+          console.error(`[feedback] Webhook returned ${response.status}: ${response.statusText} — ${decision.reason}`);
         }
       } catch (err) {
         // Don't fail on webhook errors — the local record is the receipt
@@ -231,8 +253,18 @@ export class FeedbackManager {
       return { retried: 0, succeeded: 0 };
     }
 
+    // Respect an active rate-limit backoff window (L364): if the endpoint just
+    // 429'd us, do NOT re-POST the whole backlog this cycle — that is exactly the
+    // self-reinforcing storm this fixes (661 items × every cycle = thousands of 429s).
+    if (Date.now() < this.webhookNextRetryAtMs) {
+      return { retried: 0, succeeded: 0 };
+    }
+
     let succeeded = 0;
+    let attempted = 0;
     for (const item of unforwarded) {
+      attempted++;
+      let decisionBreak = false;
       try {
         const payload = {
           feedbackId: item.id,
@@ -254,20 +286,35 @@ export class FeedbackManager {
           signal: AbortSignal.timeout(10000),
         });
 
-        if (response.ok) {
+        const decision = decideFeedbackRetry({
+          ok: response.ok,
+          status: typeof response.status === 'number' ? response.status : null,
+          retryAfterSec: parseRetryAfterSeconds(response.headers?.get?.('retry-after')),
+          nowMs: Date.now(),
+          consecutive429s: this.webhookConsecutive429s,
+        });
+        this.webhookNextRetryAtMs = decision.nextRetryAtMs;
+        this.webhookConsecutive429s = decision.consecutive429s;
+        if (decision.markForwarded) {
           item.forwarded = true;
           succeeded++;
         }
+        // Rate-limited → stop the batch NOW; the rest retry after the backoff window.
+        if (decision.breakBatch) {
+          console.error(`[feedback] retry batch halted after ${attempted}/${unforwarded.length}: ${decision.reason}`);
+          decisionBreak = true;
+        }
       } catch {
-        // @silent-fallback-ok — retry on next attempt
+        // @silent-fallback-ok — network/timeout: retry on next cycle
       }
+      if (decisionBreak) break;
     }
 
     if (succeeded > 0) {
       this.saveFeedback(items);
     }
 
-    return { retried: unforwarded.length, succeeded };
+    return { retried: attempted, succeeded };
   }
 
   // ── Private helpers ──────────────────────────────────────────────

--- a/src/core/feedbackBackoff.ts
+++ b/src/core/feedbackBackoff.ts
@@ -1,0 +1,115 @@
+/**
+ * Feedback webhook retry/backoff decision (L364 — No Unbounded Self-Reinforcing
+ * Loops; Responsible Resource).
+ *
+ * THE BUG THIS FIXES (observed live 2026-06-20, topic 13481): the agent had a
+ * backlog of 661 un-forwarded feedback items and a canonical feedback endpoint
+ * that was returning 429 (Too Many Requests). `retryUnforwarded()` looped the
+ * ENTIRE backlog every scheduled cycle, POSTing all 661, getting 429 on each,
+ * marking none forwarded — so the next cycle re-POSTed all 661 again, forever
+ * (2,384 429s and climbing). A loop hammering a rate-limited external endpoint
+ * with no backoff: bad-citizenship to the external service AND wasted local work
+ * that contributed to event-loop pressure.
+ *
+ * This pure decider answers, per webhook response, three questions:
+ *   - markForwarded — did this item land (2xx)?
+ *   - breakBatch    — are we rate-limited (429/503)? Then STOP the rest of this
+ *                     batch immediately; sending more only makes the 429 worse.
+ *   - nextRetryAtMs — don't touch the webhook again until this wall-clock ms
+ *                     (honors a Retry-After header, else exponential backoff,
+ *                     capped). The caller gates BOTH submit() and the next
+ *                     retry cycle on this.
+ *
+ * Pure + deterministic → fully unit-testable. SIGNAL-style: it decides cadence,
+ * it never blocks the local record (the local feedback store is always written).
+ */
+
+export interface FeedbackRetryInputs {
+  /** `response.ok` — the success signal. Robust: every real fetch Response has it,
+   *  and we never depend on a numeric status being present to decide "forwarded". */
+  ok: boolean;
+  /** HTTP status of the webhook POST, or null on a network/timeout error / absent.
+   *  Used ONLY to classify a rate-limit (429/503) for backoff — never for success. */
+  status: number | null;
+  /** Parsed Retry-After header in seconds, if the server sent one (429/503). */
+  retryAfterSec?: number;
+  /** Wall clock now (ms). */
+  nowMs: number;
+  /** Consecutive rate-limit (429/503) responses seen so far (for the exp curve). */
+  consecutive429s: number;
+  /** Base backoff (ms) for the exponential schedule. Default caller: 60_000. */
+  baseBackoffMs?: number;
+  /** Cap on the backoff (ms). Default caller: 3_600_000 (1h). */
+  maxBackoffMs?: number;
+}
+
+export interface FeedbackRetryDecision {
+  /** The item forwarded successfully (2xx) → mark it forwarded. */
+  markForwarded: boolean;
+  /** Rate-limited → STOP this retry batch (do not hammer the remaining items). */
+  breakBatch: boolean;
+  /** Do not POST the webhook again until this wall-clock ms. 0 = no hold. */
+  nextRetryAtMs: number;
+  /** New consecutive-429 count for the caller to persist. */
+  consecutive429s: number;
+  reason: string;
+}
+
+const RATE_LIMIT_STATUSES = new Set([429, 503]);
+
+export function decideFeedbackRetry(i: FeedbackRetryInputs): FeedbackRetryDecision {
+  const base = i.baseBackoffMs ?? 60_000;
+  const cap = i.maxBackoffMs ?? 3_600_000;
+
+  // Success → forwarded, clear any backoff. Driven by response.ok (always present),
+  // NOT by a numeric status, so it is robust to any response shape.
+  if (i.ok) {
+    return {
+      markForwarded: true,
+      breakBatch: false,
+      nextRetryAtMs: 0,
+      consecutive429s: 0,
+      reason: `forwarded${i.status !== null ? ` (${i.status})` : ''}`,
+    };
+  }
+
+  // Rate-limited (429) or service-unavailable (503) → back off AND halt the batch.
+  if (i.status !== null && RATE_LIMIT_STATUSES.has(i.status)) {
+    const n = i.consecutive429s + 1;
+    let waitMs: number;
+    if (i.retryAfterSec !== undefined && Number.isFinite(i.retryAfterSec) && i.retryAfterSec > 0) {
+      waitMs = Math.min(i.retryAfterSec * 1000, cap);
+    } else {
+      // Exponential from base: base, 2×base, 4×base, … capped.
+      waitMs = Math.min(base * 2 ** (n - 1), cap);
+    }
+    return {
+      markForwarded: false,
+      breakBatch: true,
+      nextRetryAtMs: i.nowMs + waitMs,
+      consecutive429s: n,
+      reason: `rate-limited (${i.status}) — backing off ${Math.round(waitMs / 1000)}s, batch halted`,
+    };
+  }
+
+  // Any other non-2xx, or a network/timeout error: leave the item un-forwarded so
+  // it retries on the next cycle (today's behavior), but do NOT halt the batch —
+  // a per-item error is not a pool-wide rate-limit. PRESERVE the 429 streak (do not
+  // reset it): an endpoint flapping between 429 and 500 must keep climbing the
+  // exponential curve, not restart it at base on every interleaved 500. Only a
+  // genuine 2xx success (above) clears the streak.
+  return {
+    markForwarded: false,
+    breakBatch: false,
+    nextRetryAtMs: 0,
+    consecutive429s: i.consecutive429s,
+    reason: i.status === null ? 'network/timeout error — retry next cycle' : `error ${i.status} — retry next cycle`,
+  };
+}
+
+/** Parse a Retry-After header value (delta-seconds form only) → seconds | undefined. */
+export function parseRetryAfterSeconds(headerValue: string | null | undefined): number | undefined {
+  if (!headerValue) return undefined;
+  const n = Number(headerValue.trim());
+  return Number.isFinite(n) && n >= 0 ? n : undefined;
+}

--- a/tests/unit/FeedbackManager.test.ts
+++ b/tests/unit/FeedbackManager.test.ts
@@ -59,7 +59,7 @@ describe('FeedbackManager', () => {
 
     it('marks as forwarded when webhook succeeds', async () => {
       const originalFetch = global.fetch;
-      global.fetch = vi.fn().mockResolvedValue({ ok: true });
+      global.fetch = vi.fn().mockResolvedValue({ ok: true, status: 200, headers: { get: () => null } });
 
       const item = await manager.submit({
         type: 'feature',
@@ -185,12 +185,61 @@ describe('FeedbackManager', () => {
       expect(manager.list()[0].forwarded).toBe(false);
 
       // Retry succeeds
-      global.fetch = vi.fn().mockResolvedValue({ ok: true });
+      global.fetch = vi.fn().mockResolvedValue({ ok: true, status: 200, headers: { get: () => null } });
       const result = await manager.retryUnforwarded();
 
       expect(result.retried).toBe(1);
       expect(result.succeeded).toBe(1);
       expect(manager.list()[0].forwarded).toBe(true);
+
+      global.fetch = originalFetch;
+    });
+
+    // The 2026-06-20 storm fix (L364): a 429 must HALT the batch — not re-POST the
+    // whole backlog — and back off so the very next cycle does not POST at all.
+    it('a 429 halts the batch after one POST and backs off the next cycle', async () => {
+      const originalFetch = global.fetch;
+
+      // Seed a backlog of 3 unforwarded items (submit offline so none forward).
+      global.fetch = vi.fn().mockRejectedValue(new Error('offline'));
+      for (let i = 0; i < 3; i++) {
+        await manager.submit({
+          type: 'bug', title: `b${i}`, description: 'd', agentName: 't',
+          instarVersion: '0.1.0', nodeVersion: 'v20.0.0', os: 'darwin arm64',
+        });
+      }
+      expect(manager.list().filter(f => !f.forwarded).length).toBe(3);
+
+      // Endpoint is rate-limiting. The batch must stop after the FIRST POST.
+      const fetchMock = vi.fn().mockResolvedValue({ ok: false, status: 429, statusText: 'Too Many Requests', headers: { get: () => null } });
+      global.fetch = fetchMock;
+      const r1 = await manager.retryUnforwarded();
+      expect(fetchMock).toHaveBeenCalledTimes(1);      // halted after one, NOT 3
+      expect(r1.succeeded).toBe(0);
+      expect(manager.list().filter(f => !f.forwarded).length).toBe(3); // none lost
+
+      // Next cycle is inside the backoff window → zero POSTs (the storm is dead).
+      const fetchMock2 = vi.fn().mockResolvedValue({ ok: false, status: 429, headers: { get: () => null } });
+      global.fetch = fetchMock2;
+      const r2 = await manager.retryUnforwarded();
+      expect(fetchMock2).not.toHaveBeenCalled();
+      expect(r2).toEqual({ retried: 0, succeeded: 0 });
+
+      global.fetch = originalFetch;
+    });
+
+    it('honors a Retry-After header on a 429 (backoff window)', async () => {
+      const originalFetch = global.fetch;
+      global.fetch = vi.fn().mockRejectedValue(new Error('offline'));
+      await manager.submit({ type: 'bug', title: 'b', description: 'd', agentName: 't', instarVersion: '0.1.0', nodeVersion: 'v20.0.0', os: 'darwin arm64' });
+
+      global.fetch = vi.fn().mockResolvedValue({ ok: false, status: 429, headers: { get: (h: string) => (h.toLowerCase() === 'retry-after' ? '120' : null) } });
+      await manager.retryUnforwarded();
+      // Inside the 120s window the next cycle must not POST.
+      const fm = vi.fn().mockResolvedValue({ ok: true, status: 200, headers: { get: () => null } });
+      global.fetch = fm;
+      await manager.retryUnforwarded();
+      expect(fm).not.toHaveBeenCalled();
 
       global.fetch = originalFetch;
     });

--- a/tests/unit/feedbackBackoff.test.ts
+++ b/tests/unit/feedbackBackoff.test.ts
@@ -1,0 +1,102 @@
+/**
+ * Feedback webhook 429-backoff decider (L364). Proves: success clears backoff;
+ * 429/503 halts the batch + sets exponential backoff; Retry-After is honored and
+ * capped; other errors retry-next-cycle without halting; Retry-After parsing.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { decideFeedbackRetry, parseRetryAfterSeconds, type FeedbackRetryInputs } from '../../src/core/feedbackBackoff.js';
+
+const base: FeedbackRetryInputs = { ok: true, status: 200, nowMs: 1_000_000, consecutive429s: 0 };
+// Derive `ok` from the status under test unless a case sets it explicitly — mirrors a
+// real fetch Response where response.ok === (status in 200..299).
+const d = (o: Partial<FeedbackRetryInputs>) => {
+  const status = o.status !== undefined ? o.status : base.status;
+  const ok = o.ok !== undefined ? o.ok : status !== null && status >= 200 && status < 300;
+  return decideFeedbackRetry({ ...base, ...o, ok });
+};
+
+describe('decideFeedbackRetry', () => {
+  it('2xx → forwarded, backoff cleared', () => {
+    const v = d({ status: 204, consecutive429s: 5 });
+    expect(v.markForwarded).toBe(true);
+    expect(v.breakBatch).toBe(false);
+    expect(v.nextRetryAtMs).toBe(0);
+    expect(v.consecutive429s).toBe(0); // streak reset
+  });
+
+  it('429 → NOT forwarded, batch HALTED, backoff set, streak incremented', () => {
+    const v = d({ status: 429, consecutive429s: 0 });
+    expect(v.markForwarded).toBe(false);
+    expect(v.breakBatch).toBe(true);
+    expect(v.consecutive429s).toBe(1);
+    expect(v.nextRetryAtMs).toBe(1_000_000 + 60_000); // base 60s on first 429
+  });
+
+  it('503 is treated as rate-limit too (halt + backoff)', () => {
+    const v = d({ status: 503 });
+    expect(v.breakBatch).toBe(true);
+    expect(v.nextRetryAtMs).toBeGreaterThan(1_000_000);
+  });
+
+  it('exponential backoff grows with the 429 streak, capped at maxBackoffMs', () => {
+    expect(d({ status: 429, consecutive429s: 0 }).nextRetryAtMs).toBe(1_000_000 + 60_000);   // 60s
+    expect(d({ status: 429, consecutive429s: 1 }).nextRetryAtMs).toBe(1_000_000 + 120_000);  // 120s
+    expect(d({ status: 429, consecutive429s: 2 }).nextRetryAtMs).toBe(1_000_000 + 240_000);  // 240s
+    // huge streak → capped at 1h default, not unbounded
+    expect(d({ status: 429, consecutive429s: 50 }).nextRetryAtMs).toBe(1_000_000 + 3_600_000);
+  });
+
+  it('Retry-After header is honored (and capped) over the exponential schedule', () => {
+    const v = d({ status: 429, retryAfterSec: 30, consecutive429s: 3 });
+    expect(v.nextRetryAtMs).toBe(1_000_000 + 30_000); // 30s from header, not 480s from streak
+    // an absurd Retry-After is still capped
+    const capped = d({ status: 429, retryAfterSec: 999_999, maxBackoffMs: 600_000 });
+    expect(capped.nextRetryAtMs).toBe(1_000_000 + 600_000);
+  });
+
+  it('other 4xx/5xx → retry next cycle, batch NOT halted, no backoff, streak PRESERVED', () => {
+    const v = d({ status: 500, consecutive429s: 2 });
+    expect(v.markForwarded).toBe(false);
+    expect(v.breakBatch).toBe(false);
+    expect(v.nextRetryAtMs).toBe(0);
+    expect(v.consecutive429s).toBe(2); // preserved — a flapping 429/500 endpoint keeps climbing the curve
+  });
+
+  it('only a genuine 2xx clears the 429 streak (flap protection)', () => {
+    // 429 streak of 3 → a 500 preserves it → the next 429 backs off from streak 4, not 1.
+    const afterErr = d({ status: 500, consecutive429s: 3 });
+    expect(afterErr.consecutive429s).toBe(3);
+    const next429 = d({ status: 429, consecutive429s: afterErr.consecutive429s });
+    expect(next429.nextRetryAtMs).toBe(1_000_000 + Math.min(60_000 * 2 ** 3, 3_600_000)); // 480s, not 60s
+    // a real success resets it
+    expect(d({ status: 200, consecutive429s: 9 }).consecutive429s).toBe(0);
+  });
+
+  it('network/timeout error (status null) → retry next cycle, no halt', () => {
+    const v = d({ status: null });
+    expect(v.markForwarded).toBe(false);
+    expect(v.breakBatch).toBe(false);
+    expect(v.reason).toMatch(/network\/timeout/i);
+  });
+
+  it('a zero/negative Retry-After is ignored (falls back to exponential)', () => {
+    expect(d({ status: 429, retryAfterSec: 0 }).nextRetryAtMs).toBe(1_000_000 + 60_000);
+    expect(d({ status: 429, retryAfterSec: -5 }).nextRetryAtMs).toBe(1_000_000 + 60_000);
+  });
+});
+
+describe('parseRetryAfterSeconds', () => {
+  it('parses delta-seconds', () => {
+    expect(parseRetryAfterSeconds('120')).toBe(120);
+    expect(parseRetryAfterSeconds(' 45 ')).toBe(45);
+    expect(parseRetryAfterSeconds('0')).toBe(0);
+  });
+  it('rejects junk / absent / negative', () => {
+    expect(parseRetryAfterSeconds(null)).toBeUndefined();
+    expect(parseRetryAfterSeconds(undefined)).toBeUndefined();
+    expect(parseRetryAfterSeconds('')).toBeUndefined();
+    expect(parseRetryAfterSeconds('Wed, 21 Oct 2026 07:28:00 GMT')).toBeUndefined(); // HTTP-date form unsupported → undefined (safe)
+    expect(parseRetryAfterSeconds('-3')).toBeUndefined();
+  });
+});

--- a/upgrades/eli16/feedback-429-backoff.eli16.md
+++ b/upgrades/eli16/feedback-429-backoff.eli16.md
@@ -1,0 +1,47 @@
+# Feedback retry storm fix — in plain terms
+
+## What this is
+
+Your agent has a little "phone home" feature: when something noteworthy happens, it
+saves a feedback note locally and tries to send a copy to a central feedback inbox
+over the internet. A background job periodically retries any notes that haven't been
+sent yet.
+
+## What was broken
+
+The central inbox started replying "429 — too many requests" (it was rate-limiting
+us). The retry job didn't understand "429" as "slow down." It just kept re-sending
+the **entire** backlog of unsent notes — 661 of them — every single cycle. Each one
+got a 429, none were marked as sent, so the next cycle tried all 661 again. Over time
+that piled up to **2,384+ failed sends**, and the repeated bursts of work were one of
+the things briefly freezing the agent's main loop (which, knock-on, made the two
+machines' clocks look out of sync and broke their handshake — the very problem the
+larger project is fixing).
+
+## What's new
+
+The retry now reads the inbox's reply and reacts like a polite client:
+- If a note sends fine, it's marked done.
+- If the inbox says "429 / try later," the agent **stops the batch immediately**
+  (no point hammering a server that's asking us to back off) and **waits** before
+  trying again. If the server says exactly how long to wait, it obeys that; otherwise
+  it waits a minute, then two, then four… up to an hour, then settles there.
+- New notes submitted during a backoff are still saved locally and just wait their
+  turn — nothing is lost.
+
+## The safeguards
+
+- **Nothing is dropped.** Every note is still stored locally; backoff only delays
+  *sending*, never *recording*.
+- **Self-correcting.** The backoff lives in memory; after a restart it tries once and
+  re-learns the backoff — no stuck state.
+- **Back-compatible.** When the inbox is healthy, behavior is identical to before
+  (send immediately, never wait).
+- **Reversible.** It's two files; reverting restores the old behavior exactly.
+
+## What you need to decide
+
+Nothing — it's a contained, reversible fix that only makes the agent a better
+internet citizen and stops wasted work. The only judgment call baked in: we treat the
+two standard "slow down" replies (429 and 503) as stop-signals, and treat other
+errors as one-off retries — matching how the wider web expects clients to behave.

--- a/upgrades/next/feedback-429-backoff.md
+++ b/upgrades/next/feedback-429-backoff.md
@@ -1,0 +1,34 @@
+# Feedback webhook: back off on rate-limit (429) instead of re-sending the whole backlog
+
+## What Changed
+
+`FeedbackManager` now treats a `429`/`503` from the canonical feedback endpoint as a
+stop-signal: it HALTS the current retry batch and waits (honoring `Retry-After`, else
+exponential 60s→1h) before POSTing again. Previously `retryUnforwarded()` re-POSTed the
+ENTIRE un-forwarded backlog every scheduled cycle regardless of rate-limiting — against
+a 429-ing endpoint that re-sent the whole backlog forever (observed live: 661 backlog
+items → 2,384+ failed POSTs). A pure `decideFeedbackRetry()` helper makes the cadence
+decision; the local feedback record is always written (nothing is lost or dropped).
+
+## Evidence
+
+- New `tests/unit/feedbackBackoff.test.ts` (11 cases): 2xx clears backoff; 429/503 halt
+  + exponential backoff capped at 1h; `Retry-After` honored + capped; non-429 errors
+  retry-next-cycle and PRESERVE the 429 streak (flap protection); junk/negative
+  `Retry-After` rejected.
+- `tests/unit/FeedbackManager.test.ts` (+2 cases): a 429 halts the batch after ONE POST
+  (not the whole backlog) and the next cycle POSTs zero times while backed off; no item
+  lost. Independent second-pass review concurred.
+
+## What to Tell Your User
+
+If your agent had been quietly retrying feedback against a busy endpoint, it now backs
+off politely instead of hammering it — fewer wasted network calls and less background
+churn. Nothing you do changes; no feedback is lost (notes are still saved locally and
+sent once the endpoint is ready).
+
+## Summary of New Capabilities
+
+- Rate-limit-aware feedback forwarding: halts on 429/503, honors `Retry-After`, backs
+  off exponentially (capped), and never re-sends the whole backlog against a limited
+  endpoint. Back-compatible on a healthy endpoint (forwards immediately as before).

--- a/upgrades/side-effects/feedback-429-backoff.md
+++ b/upgrades/side-effects/feedback-429-backoff.md
@@ -1,0 +1,71 @@
+# Side-Effects Review — Feedback webhook 429 backoff (stop the retry storm)
+
+**Tier:** 1 (contained fix to one manager + a pure helper).
+**Files:** `src/core/feedbackBackoff.ts` (new pure helper), `src/core/FeedbackManager.ts` (wiring), `tests/unit/feedbackBackoff.test.ts`, `tests/unit/FeedbackManager.test.ts`.
+
+## What changed
+
+`FeedbackManager.retryUnforwarded()` previously looped the ENTIRE un-forwarded
+backlog every scheduled cycle, POSTing each item; on a non-2xx it simply left the
+item un-forwarded — so against a 429-ing endpoint it re-POSTed the whole backlog
+forever (observed live 2026-06-20, topic 13481: 661 un-forwarded items, 2,384+ 429s).
+
+Now a pure `decideFeedbackRetry()` classifies each webhook response:
+- 2xx → mark forwarded, clear backoff.
+- **429/503 → HALT the batch immediately** and set a backoff window (`Retry-After`
+  if present, else exponential from 60s, capped at 1h).
+- other non-2xx / network error → leave un-forwarded, retry next cycle (unchanged),
+  no batch halt.
+
+`submit()` and `retryUnforwarded()` both skip the webhook entirely while inside the
+backoff window. State (`webhookNextRetryAtMs`, `webhookConsecutive429s`) is in-memory.
+
+## The 8 questions
+
+1. **Over-block.** While backed off, `submit()` skips the live POST and the item is
+   stored locally un-forwarded (picked up by the next allowed retry cycle). No
+   feedback is lost — only deferred. The local store is always written, exactly as
+   before. Worst case: a feedback item is forwarded minutes later instead of
+   instantly, during an active rate-limit — acceptable and correct.
+2. **Under-block.** A non-429/503 error (e.g. a one-off 500) does NOT halt the batch
+   — by design, since it is a per-item issue, not a pool-wide rate-limit. If an
+   endpoint signalled overload with a bare 500 (not 503/429) the storm guard would
+   not engage; this is the documented trade (we only treat the standard rate-limit
+   statuses as "stop"). The exponential cap still bounds total backoff growth.
+3. **Level-of-abstraction fit.** Correct layer: the decision is a pure helper; the
+   FeedbackManager owns the I/O and the (in-memory) backoff state. No new subsystem.
+4. **Signal vs authority.** It governs the webhook POST cadence only. It NEVER blocks
+   the local feedback record (always written) and never gates anything else. It is
+   the "Responsible Resource" / L364 (No Unbounded Self-Reinforcing Loops) standard
+   made real for this loop.
+5. **Interactions.** No shadowing. The scheduled `feedback-retry` job still drives
+   `retryUnforwarded()`; this only changes what one cycle does (halt-on-429 instead
+   of POST-all). The `feedback-factory` receiver/processor are unaffected (different
+   path). In-memory state means a server restart re-probes once then re-backs-off —
+   self-correcting, no persistence coupling.
+6. **External surfaces.** This DECREASES external load (fewer POSTs to the canonical
+   feedback endpoint) — strictly better citizenship. No new external call. Honors the
+   server's `Retry-After` when provided.
+7. **Multi-machine posture.** Machine-local BY DESIGN: each machine forwards its own
+   local feedback store and keeps its own in-memory backoff. There is no shared state
+   to replicate (the backoff is about THIS machine's POST cadence to the endpoint).
+   No topic-transfer or URL-survival concern (no user-facing surface).
+8. **Rollback cost.** Trivial: revert the two files. No migration, no persisted state,
+   no config. Back-compatible — on a healthy (2xx) endpoint behavior is identical to
+   before (forward immediately, no backoff ever set).
+
+## Second-pass
+
+Requested (retry/recovery loop with external side-effects).
+
+**Reviewer verdict (independent): Concur with the review.** Confirmed: (1) stop-after-
+first-429 is correct (`breakBatch`→`break` before any further POST); (2) next-cycle
+gating is symmetric (submit `>= nextRetryAtMs`, retry early-returns on `<`); (3) no
+item loss (un-forwarded items stay persisted+retryable, success-only save is safe);
+(4) no stuck-forever (a 2xx always returns `nextRetryAtMs:0`+`consecutive429s:0`).
+Two non-blocking notes: (a) the load→fetch→full-overwrite race in `retryUnforwarded()`
+is **pre-existing** (`appendFeedback` already read-modify-writes) and untouched here —
+not a regression; (b) a non-429 error mid-recovery reset the 429 streak, softening the
+curve on a flapping endpoint. **Note (b) addressed in code**: the helper now PRESERVES
+`consecutive429s` on a non-429 error and clears it only on a genuine 2xx, with a
+flap-protection test. Note (a) is logged as a separate pre-existing item, out of scope.


### PR DESCRIPTION
## What & why

`FeedbackManager.retryUnforwarded()` re-POSTed the **entire** un-forwarded backlog every scheduled cycle; on a non-2xx it left items un-forwarded, so against a `429`-ing endpoint it re-sent the whole backlog forever. Observed live 2026-06-20 (agent Echo): **661 backlog items → 2,384+ failed POSTs**, an L364 "unbounded self-reinforcing loop" hammering an external service and contributing to event-loop pressure.

## Fix

A pure `decideFeedbackRetry()`:
- 2xx (`response.ok`) → mark forwarded, clear backoff.
- **429/503 → HALT the batch** + set a backoff window (`Retry-After` if present, else exponential 60s→1h cap).
- other non-2xx / network error → retry next cycle (unchanged), no halt, **preserve** the 429 streak (flap protection).

`submit()` and `retryUnforwarded()` both skip the POST while inside the backoff window. The local feedback record is **always written** — nothing is lost. Back-compatible on a healthy endpoint (forwards immediately as before).

## Tests

23 unit (11 helper + 12 manager): a 429 halts the batch after ONE POST (not the whole backlog), the next cycle POSTs zero while backed off, `Retry-After` honored + capped, flap-protection, junk/negative `Retry-After` rejected. Full pre-push smoke (163 tests) green. Independent 2nd-pass review concurred (its note — preserve streak on non-429 — is in code).

## ELI16 Overview

See `upgrades/eli16/feedback-429-backoff.eli16.md`. Plain version: the agent's "phone home" feature kept re-sending a 661-item backlog to a busy inbox that said "too many requests," forever. Now it backs off politely (obeys the server's wait time, or waits 1→2→4 min up to an hour), stops the batch on the first "slow down," and never loses a note. Reversible, back-compatible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
