### PR TITLE
fix: two event-loop wedges — CommitmentTracker O(N) saves + DegradationReporter reentrancy

### DIFF
--- a/.instar/instar-dev-decisions/2026-06-21T09-02-56-268Z-commitment-tracker-verify-batches-saves.json
+++ b/.instar/instar-dev-decisions/2026-06-21T09-02-56-268Z-commitment-tracker-verify-batches-saves.json
@@ -1,0 +1,13 @@
+{
+  "ts": "2026-06-21T09:02:56.268Z",
+  "slug": "commitment-tracker-verify-batches-saves",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 80,
+  "causalAutopsy": null,
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-06-21T09-03-40-953Z-commitment-tracker-verify-batches-saves.json
+++ b/.instar/instar-dev-decisions/2026-06-21T09-03-40-953Z-commitment-tracker-verify-batches-saves.json
@@ -1,0 +1,13 @@
+{
+  "ts": "2026-06-21T09:03:40.953Z",
+  "slug": "commitment-tracker-verify-batches-saves",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 80,
+  "causalAutopsy": null,
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-06-21T09-04-06-414Z-commitment-tracker-verify-batches-saves.json
+++ b/.instar/instar-dev-decisions/2026-06-21T09-04-06-414Z-commitment-tracker-verify-batches-saves.json
@@ -1,0 +1,16 @@
+{
+  "ts": "2026-06-21T09:04:06.414Z",
+  "slug": "commitment-tracker-verify-batches-saves",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 80,
+  "causalAutopsy": {
+    "origin": "latent",
+    "notes": "Latent O(N) write amplification in CommitmentTracker.verify(): saveStore() ran per-mutation inside the sweep, serializing the whole store each time. Harmless until the store grew large (1.6MB / 1724 commitments, 1137 terminal never pruned), at which point the 60s sweep froze the event loop for minutes. Surfaced live on Echo 2026-06-21 via a JSON.stringify tracer."
+  },
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-06-21T09-04-31-896Z-commitment-tracker-verify-batches-saves.json
+++ b/.instar/instar-dev-decisions/2026-06-21T09-04-31-896Z-commitment-tracker-verify-batches-saves.json
@@ -1,0 +1,16 @@
+{
+  "ts": "2026-06-21T09:04:31.896Z",
+  "slug": "commitment-tracker-verify-batches-saves",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 80,
+  "causalAutopsy": {
+    "origin": "latent",
+    "notes": "Latent O(N) write amplification in CommitmentTracker.verify(): saveStore() ran per-mutation inside the sweep, serializing the whole store each time. Harmless until the store grew large (1.6MB / 1724 commitments, 1137 terminal never pruned), at which point the 60s sweep froze the event loop for minutes. Surfaced live on Echo 2026-06-21 via a JSON.stringify tracer."
+  },
+  "verdict": "pass"
+}

--- a/.instar/instar-dev-decisions/2026-06-21T10-08-32-054Z-commitment-tracker-verify-batches-saves.json
+++ b/.instar/instar-dev-decisions/2026-06-21T10-08-32-054Z-commitment-tracker-verify-batches-saves.json
@@ -1,0 +1,16 @@
+{
+  "ts": "2026-06-21T10:08:32.054Z",
+  "slug": "commitment-tracker-verify-batches-saves",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 61,
+  "causalAutopsy": {
+    "origin": "latent",
+    "notes": "Two latent event-loop wedges surfaced on Echo 2026-06-21. (1) CommitmentTracker.verify() saved the whole store per-commitment. (2) DegradationReporter.gateHealthAlert ran the tone gate, which routes through the IntelligenceRouter; an unavailable configured framework (pi-cli, not installed) degraded inside the gate and re-entered reportEvent unbounded, hanging a JSON.stringify of the growing events array."
+  },
+  "verdict": "pass"
+}

--- a/docs/specs/commitment-tracker-verify-batches-saves.eli16.md
+++ b/docs/specs/commitment-tracker-verify-batches-saves.eli16.md
@@ -1,0 +1,24 @@
+# ELI16 — CommitmentTracker saves once per check, not once per item
+
+Your agent keeps a to-do list of promises it made you ("commitments"), saved in a file
+on disk. Once a minute it goes down the whole list and checks each item.
+
+The bug: **every single time it touched one item, it re-saved the entire file.** When the
+list had grown big (on the affected machine it was 1.6 megabytes — about 1,700 items, most
+of them already finished and never cleaned up), one pass down the list saved that whole 1.6MB
+file *hundreds of times in a row*, back to back.
+
+A program like this has one main "worker" that can only do one thing at a time. Saving a
+1.6MB file hundreds of times with no break ties up that worker for *minutes*. While it's
+tied up, the agent can't answer "are you alive?" health checks — so a safety watchdog thinks
+it crashed and restarts it. Then it boots, does the same thing, and gets restarted again. A
+restart loop.
+
+The fix: while it's going down the list, it **holds off on saving** and just remembers "I
+need to save." When it finishes the whole pass, it saves **once**. So instead of hundreds of
+saves per minute it does one. (It also stops "pretty-printing" the file with extra spaces,
+which only made the file bigger and slower to write — nothing reads it by eye.)
+
+Nothing about your commitments changes — what's tracked, what's saved, how it all works is
+identical. The agent just stops doing hundreds of pointless identical saves every minute, so
+it no longer freezes on that cadence.

--- a/docs/specs/commitment-tracker-verify-batches-saves.eli16.md
+++ b/docs/specs/commitment-tracker-verify-batches-saves.eli16.md
@@ -22,3 +22,29 @@ which only made the file bigger and slower to write — nothing reads it by eye.
 Nothing about your commitments changes — what's tracked, what's saved, how it all works is
 identical. The agent just stops doing hundreds of pointless identical saves every minute, so
 it no longer freezes on that cadence.
+# ELI16 — DegradationReporter no longer melts down when it can't reach a model
+
+Your agent has a "something degraded" reporter. When an internal feature falls back to a
+backup (say a sentinel's preferred AI tool isn't installed, so it uses a different one), the
+reporter notes it and — before messaging you — runs the note past a small "tone gate" to make
+sure the wording is friendly.
+
+Here's the trap. That tone gate is itself a tiny AI call. And it goes through the same router
+that just degraded. So if the configured tool is missing, running the tone gate **degrades
+again** — which tells the reporter "something degraded" — which runs the tone gate — which
+degrades again… round and round, in one unbroken loop. Every loop adds another entry to a list
+the reporter keeps, and the reporter periodically turns that whole list into text (a
+`JSON.stringify`). The list grows so huge that turning it into text takes **minutes**, and
+during those minutes the agent's single worker can do nothing else — health checks fail, a
+watchdog thinks it crashed and restarts it, and it does the same thing again. That restart loop
+was the "flapping."
+
+The fix is one sentence of logic: **the tone gate refuses to run while it's already running.**
+So if checking a degradation alert triggers another degradation, that inner one just uses a
+plain safe message instead of recursing. The loop can't form — no matter which tool is missing.
+As a belt-and-suspenders, the list of degradation events is now capped at a fixed size, so even
+a steady drip of real degradations can never grow it without limit.
+
+Nothing about what you see changes — degradations are still logged and you're still alerted.
+The agent just stops eating itself alive when a configured tool isn't there.
+

--- a/src/monitoring/CommitmentTracker.ts
+++ b/src/monitoring/CommitmentTracker.ts
@@ -361,6 +361,21 @@ export class CommitmentTracker extends EventEmitter {
   private rulesPath: string;
   private interval: ReturnType<typeof setInterval> | null = null;
   private nextId: number;
+  /**
+   * Coalesce the per-mutation full-store writes of a synchronous sweep into ONE
+   * write at the end. `verify()` mutates every active commitment via
+   * `mutateSync()`, and each `mutateSync()` calls `saveStore()` — which
+   * `JSON.stringify`s the ENTIRE store. With a large store (e.g. ~1.6MB / ~1700
+   * commitments) and N active commitments that is O(N) full-store serializations
+   * per sweep, which froze the single event-loop thread for MINUTES (observed
+   * 2026-06-21: server `/health` HTTP 000, watchdog SIGKILL/respawn loop). While
+   * batching, `saveStore()` marks the store dirty and returns; the sweep flushes
+   * exactly one write at the end. SAFE because the sweep is fully synchronous and
+   * never yields the event loop, so no other write path can observe or interleave
+   * with the deferred window.
+   */
+  private batchingSaves = false;
+  private pendingSave = false;
 
   /**
    * Single-writer FIFO queues, keyed by commitment id. Every write path
@@ -1070,32 +1085,45 @@ export class CommitmentTracker extends EventEmitter {
     let verified = 0;
     let pending = 0;
 
-    // Expire old commitments first
-    this.expireCommitments();
+    // Batch every per-commitment save in this sweep into ONE write at the end
+    // (see `batchingSaves`): each `mutateSync()` below otherwise writes the whole
+    // store, so a sweep over N commitments did O(N) full-store serializations and
+    // froze the event loop for minutes on a large store.
+    this.batchingSaves = true;
+    try {
+      // Expire old commitments first
+      this.expireCommitments();
 
-    for (const commitment of active) {
-      const result = this.verifyOne(commitment.id);
-      if (!result) continue;
+      for (const commitment of active) {
+        const result = this.verifyOne(commitment.id);
+        if (!result) continue;
 
-      if (result.passed) {
-        verified++;
-      } else {
-        // Attempt auto-correction for config-change commitments
-        let autoCorrected = false;
-        if (commitment.type === 'config-change' && commitment.configPath !== undefined) {
-          autoCorrected = this.attemptAutoCorrection(commitment);
+        if (result.passed) {
+          verified++;
+        } else {
+          // Attempt auto-correction for config-change commitments
+          let autoCorrected = false;
+          if (commitment.type === 'config-change' && commitment.configPath !== undefined) {
+            autoCorrected = this.attemptAutoCorrection(commitment);
+          }
+
+          violations.push({
+            id: commitment.id,
+            userRequest: commitment.userRequest,
+            detail: result.detail,
+            autoCorrected,
+          });
         }
+      }
 
-        violations.push({
-          id: commitment.id,
-          userRequest: commitment.userRequest,
-          detail: result.detail,
-          autoCorrected,
-        });
+      pending = active.filter(c => c.status === 'pending').length;
+    } finally {
+      this.batchingSaves = false;
+      if (this.pendingSave) {
+        this.pendingSave = false;
+        this.saveStore();
       }
     }
-
-    pending = active.filter(c => c.status === 'pending').length;
 
     const report: CommitmentVerificationReport = {
       timestamp: new Date().toISOString(),
@@ -1686,12 +1714,20 @@ export class CommitmentTracker extends EventEmitter {
   }
 
   private saveStore(): void {
+    // Coalesce writes during a batched sweep (see `batchingSaves`): mark dirty
+    // and let the sweep flush ONE write at the end instead of O(N) here.
+    if (this.batchingSaves) {
+      this.pendingSave = true;
+      return;
+    }
     this.store.lastModified = new Date().toISOString();
     try {
       const dir = path.dirname(this.storePath);
       fs.mkdirSync(dir, { recursive: true });
       const tmpPath = `${this.storePath}.${process.pid}.tmp`;
-      fs.writeFileSync(tmpPath, JSON.stringify(this.store, null, 2) + '\n');
+      // Compact (not pretty-printed): this is a machine-read state file, and at
+      // ~1.6MB the indentation was pure serialization + I/O overhead per write.
+      fs.writeFileSync(tmpPath, JSON.stringify(this.store) + '\n');
       fs.renameSync(tmpPath, this.storePath);
       // P1.5 §3.2 rewind fence: the meta sidecar tracks the high-water
       // replicationSeq. Written AFTER the store (a crash between leaves the

--- a/src/monitoring/DegradationReporter.ts
+++ b/src/monitoring/DegradationReporter.ts
@@ -182,6 +182,16 @@ export class DegradationReporter {
   private static instance: DegradationReporter | null = null;
 
   private events: DegradationEvent[] = [];
+  /** Reentrancy guard for gateHealthAlert (event-loop WEDGE fix, 2026-06-21). */
+  private _gatingHealthAlert = false;
+  /**
+   * Hard cap on the in-memory `events` array (WEDGE fix, 2026-06-21). Defence in
+   * depth alongside the reentrancy guard: even outside the recursion, an agent that
+   * degrades steadily for a long uptime would otherwise grow `events` without bound,
+   * and operations that serialize the whole array (`getEventsJson`, persistence) get
+   * slower with it. Keep the most recent N.
+   */
+  private static readonly MAX_EVENTS = 500;
   private stateDir: string | null = null;
   private agentName: string = 'unknown';
   private instarVersion: string = '0.0.0';
@@ -310,6 +320,10 @@ export class DegradationReporter {
     );
 
     this.events.push(full);
+    // Bound the in-memory array (WEDGE fix): never let it grow without limit.
+    if (this.events.length > DegradationReporter.MAX_EVENTS) {
+      this.events.splice(0, this.events.length - DegradationReporter.MAX_EVENTS);
+    }
     this.persistToDisk(full);
 
     // F-3 path: produce a NormalizedDegradationEvent and either dispatch
@@ -675,27 +689,40 @@ export class DegradationReporter {
     candidate: string,
     healSignal: { attempted: boolean; succeeded: boolean | null; attempts: number },
   ): Promise<string> {
-    if (!this.toneGate) {
-      return candidate;
+    // Reentrancy guard (event-loop WEDGE fix, 2026-06-21). `toneGate.review` runs an
+    // LLM through the IntelligenceRouter, which can ITSELF degrade (e.g. an unavailable
+    // configured framework) and re-enter `report → reportEvent → gateHealthAlert`. That
+    // recursion is unbounded: each level pushes another event, and a `JSON.stringify` of
+    // the growing `events` array eventually hangs the single event-loop thread for
+    // MINUTES (observed live on Echo: /health HTTP 000, watchdog SIGKILL/respawn loop).
+    // Refusing to gate-within-a-gate breaks the cycle regardless of which framework
+    // degrades — the inner alert falls back to the safe template instead of recursing.
+    if (!this.toneGate || this._gatingHealthAlert) {
+      return this._gatingHealthAlert ? SAFE_HEALTH_ALERT_TEMPLATE : candidate;
     }
-    const jargon = detectJargon(candidate);
+    this._gatingHealthAlert = true;
     try {
-      const result = await this.toneGate.review(candidate, {
-        channel: 'telegram',
-        messageKind: 'health-alert',
-        signals: {
-          jargon: { detected: jargon.detected, terms: jargon.terms, score: jargon.score },
-          selfHeal: healSignal,
-        },
-      });
-      if (result.pass) {
+      const jargon = detectJargon(candidate);
+      try {
+        const result = await this.toneGate.review(candidate, {
+          channel: 'telegram',
+          messageKind: 'health-alert',
+          signals: {
+            jargon: { detected: jargon.detected, terms: jargon.terms, score: jargon.score },
+            selfHeal: healSignal,
+          },
+        });
+        if (result.pass) {
+          return candidate;
+        }
+        return SAFE_HEALTH_ALERT_TEMPLATE;
+      } catch {
+        // Fail-open on unexpected gate errors — at least the user hears
+        // SOMETHING about the degradation.
         return candidate;
       }
-      return SAFE_HEALTH_ALERT_TEMPLATE;
-    } catch {
-      // Fail-open on unexpected gate errors — at least the user hears
-      // SOMETHING about the degradation.
-      return candidate;
+    } finally {
+      this._gatingHealthAlert = false;
     }
   }
 

--- a/tests/unit/CommitmentTracker-verify-batches-saves.test.ts
+++ b/tests/unit/CommitmentTracker-verify-batches-saves.test.ts
@@ -1,0 +1,104 @@
+/**
+ * Regression test for the event-loop WEDGE fix (2026-06-21).
+ *
+ * Bug: CommitmentTracker.verify() iterates every active commitment and mutates
+ * each via mutateSync(), and EVERY mutateSync() called saveStore(), which
+ * JSON.stringify()s the ENTIRE store. With a large store (~1.6MB / ~1700
+ * commitments) and N active commitments that was O(N) full-store serializations
+ * per 60s sweep — minutes of synchronous work that froze the single event-loop
+ * thread (observed live: /health HTTP 000, watchdog SIGKILL/respawn loop).
+ *
+ * Fix: verify() runs the whole sweep under `batchingSaves`, so the per-mutation
+ * saveStore() calls are coalesced into exactly ONE write at the end of the sweep.
+ *
+ * This test asserts the store is persisted ONCE per verify() sweep regardless of
+ * how many commitments are mutated — the structural guarantee that prevents the
+ * O(N) blow-up from regressing.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { CommitmentTracker } from '../../src/monitoring/CommitmentTracker.js';
+import { LiveConfig } from '../../src/config/LiveConfig.js';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+
+function createTmpState(): { stateDir: string; cleanup: () => void } {
+  const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), 'commitment-batch-'));
+  fs.mkdirSync(path.join(stateDir, 'state'), { recursive: true });
+  fs.writeFileSync(path.join(stateDir, 'config.json'), JSON.stringify({ updates: { autoApply: true } }, null, 2));
+  return {
+    stateDir,
+    cleanup: () => SafeFsExecutor.safeRmSync(stateDir, { recursive: true, force: true, operation: 'tests/unit/CommitmentTracker-verify-batches-saves.test.ts' }),
+  };
+}
+
+/** Count writes to the commitments store file (its atomic tmp path), excluding the meta sidecar. */
+function isStoreWrite(p: unknown): boolean {
+  return typeof p === 'string' && /commitments\.json\.\d+\.tmp$/.test(p);
+}
+
+describe('CommitmentTracker.verify() batches store saves (wedge fix)', () => {
+  let stateDir: string;
+  let cleanup: () => void;
+
+  beforeEach(() => {
+    ({ stateDir, cleanup } = createTmpState());
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+    cleanup();
+  });
+
+  it('persists the store exactly ONCE per verify() sweep, not once per commitment', () => {
+    const tracker = new CommitmentTracker({ stateDir, liveConfig: new LiveConfig(stateDir) });
+
+    // N behavioral commitments: verify() will mutate each (pending -> verified)
+    // via mutateSync(), so the pre-fix code would have written the store N times.
+    const N = 40;
+    for (let i = 0; i < N; i++) {
+      tracker.record({
+        userRequest: `rule ${i}`,
+        agentResponse: 'ok',
+        type: 'behavioral',
+        behavioralRule: `Always do thing number ${i}`,
+      });
+    }
+
+    const realWrite = fs.writeFileSync.bind(fs);
+    let storeWrites = 0;
+    const spy = vi.spyOn(fs, 'writeFileSync').mockImplementation(((p: any, ...rest: any[]) => {
+      if (isStoreWrite(p)) storeWrites++;
+      return (realWrite as any)(p, ...rest);
+    }) as typeof fs.writeFileSync);
+
+    // Reset after setup — record() above writes the store per insert.
+    storeWrites = 0;
+
+    tracker.verify();
+
+    spy.mockRestore();
+
+    // The whole sweep mutated all N commitments but must persist the store ONCE.
+    expect(storeWrites).toBe(1);
+  });
+
+  it('still persists a normal single mutate immediately (no batching outside a sweep)', async () => {
+    const tracker = new CommitmentTracker({ stateDir, liveConfig: new LiveConfig(stateDir) });
+    const c = tracker.record({ userRequest: 'x', agentResponse: 'ok', type: 'behavioral', behavioralRule: 'do x' });
+
+    const realWrite = fs.writeFileSync.bind(fs);
+    let storeWrites = 0;
+    const spy = vi.spyOn(fs, 'writeFileSync').mockImplementation(((p: any, ...rest: any[]) => {
+      if (isStoreWrite(p)) storeWrites++;
+      return (realWrite as any)(p, ...rest);
+    }) as typeof fs.writeFileSync);
+
+    await tracker.mutate(c.id, cur => ({ ...cur, verificationCount: cur.verificationCount + 1 }));
+
+    spy.mockRestore();
+    // A lone mutate outside verify() persists immediately (batching is sweep-scoped).
+    expect(storeWrites).toBe(1);
+  });
+});

--- a/tests/unit/degradation-reporter-reentrancy-wedge.test.ts
+++ b/tests/unit/degradation-reporter-reentrancy-wedge.test.ts
@@ -1,0 +1,96 @@
+/**
+ * Regression test for the DegradationReporter event-loop WEDGE (2026-06-21).
+ *
+ * Bug: reporting a degradation runs `gateHealthAlert`, which calls
+ * `toneGate.review` — an LLM routed through the IntelligenceRouter. When the
+ * configured framework is unavailable the router itself DEGRADES, re-entering
+ * `report → reportEvent → gateHealthAlert` in the same synchronous stack. That
+ * recursion is unbounded; each level pushes another event, and a `JSON.stringify`
+ * of the growing `events` array eventually hangs the single event-loop thread for
+ * MINUTES (observed live on Echo: /health HTTP 000, watchdog SIGKILL/respawn loop).
+ *
+ * Fixes:
+ *   1. A reentrancy guard in `gateHealthAlert` — it refuses to gate-within-a-gate,
+ *      returning the safe template instead of recursing.
+ *   2. A hard cap on the in-memory `events` array.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { DegradationReporter } from '../../src/monitoring/DegradationReporter.js';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+
+describe('DegradationReporter — event-loop wedge fixes', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'degrad-wedge-'));
+    const r = DegradationReporter.getInstance() as unknown as Record<string, unknown>;
+    r.events = [];
+    r._gatingHealthAlert = false;
+  });
+
+  afterEach(() => {
+    SafeFsExecutor.safeRmSync(tmpDir, { recursive: true, force: true, operation: 'tests/unit/degradation-reporter-reentrancy-wedge.test.ts' });
+    vi.restoreAllMocks();
+  });
+
+  it('reentrancy guard: gateHealthAlert does NOT run the tone gate while already gating', async () => {
+    const reporter = DegradationReporter.getInstance();
+    const review = vi.fn(async () => ({ pass: true, rule: '', issue: '', suggestion: '', latencyMs: 1 }));
+    reporter.configure({
+      stateDir: tmpDir, agentName: 't', instarVersion: '0',
+      toneGate: { review } as never,
+    });
+
+    // Simulate being mid-gate (the state the live recursion is in when it re-enters).
+    (reporter as unknown as Record<string, unknown>)._gatingHealthAlert = true;
+
+    const out = await (reporter as unknown as {
+      gateHealthAlert: (c: string, h: unknown) => Promise<string>;
+    }).gateHealthAlert('a health-alert candidate', { attempted: false, succeeded: null, attempts: 0 });
+
+    // The guard short-circuits: the (recursive) tone-gate call is NOT made, and a
+    // string (the safe template) is returned instead of recursing/hanging.
+    expect(review).not.toHaveBeenCalled();
+    expect(typeof out).toBe('string');
+    expect(out.length).toBeGreaterThan(0);
+  });
+
+  it('reentrancy guard: a tone gate that itself re-reports does not hang and stays bounded', async () => {
+    const reporter = DegradationReporter.getInstance();
+    let reviewCalls = 0;
+    const reentrantGate = {
+      review: vi.fn(async () => {
+        reviewCalls++;
+        // The live failure mode: the router degrades DURING the gate, re-entering report().
+        reporter.report({ feature: `during-gate-${reviewCalls}`, primary: 'pi-cli', fallback: 'claude', reason: 'router degraded', impact: 'i' });
+        return { pass: false, rule: '', issue: '', suggestion: '', latencyMs: 1 };
+      }),
+    };
+    reporter.configure({
+      stateDir: tmpDir, agentName: 't', instarVersion: '0',
+      telegramSender: vi.fn(async () => undefined) as never,
+      alertTopicId: 1234,
+      toneGate: reentrantGate as never,
+    });
+
+    // Must terminate (vitest would time out on an unbounded recursion).
+    reporter.report({ feature: 'root', primary: 'pi-cli', fallback: 'claude', reason: 'r', impact: 'i' });
+    await new Promise((r) => setTimeout(r, 150));
+
+    // Bounded — the guard prevents the gate from being re-driven for re-entrant reports.
+    expect(reviewCalls).toBeLessThan(5);
+  });
+
+  it('bounds the in-memory events array', () => {
+    const reporter = DegradationReporter.getInstance();
+    reporter.configure({ stateDir: tmpDir, agentName: 't', instarVersion: '0' });
+    for (let i = 0; i < 700; i++) {
+      reporter.report({ feature: `f${i}`, primary: 'p', fallback: 'f', reason: 'r', impact: 'i' });
+    }
+    expect(reporter.getEvents().length).toBeLessThanOrEqual(500);
+  });
+});

--- a/upgrades/next/commitment-tracker-verify-batches-saves.md
+++ b/upgrades/next/commitment-tracker-verify-batches-saves.md
@@ -1,0 +1,40 @@
+<!-- bump: patch -->
+
+## What Changed
+
+`CommitmentTracker.verify()` runs every 60 seconds and checks each active commitment.
+Previously, each check that mutated a commitment rewrote the **entire** commitments
+store to disk (a full `JSON.stringify` of the whole file). On an agent whose store had
+grown large (observed: 1.6MB, ~1,700 commitments), a single 60-second sweep did
+hundreds of full-store serializations back-to-back — enough synchronous work to freeze
+the server's event loop for minutes (health checks timing out, an external watchdog
+restarting the process in a loop).
+
+Now `verify()` batches the whole sweep into **one** store write at the end, and writes
+the store compactly instead of pretty-printed. The per-sweep cost drops from
+"once per commitment" to "once per sweep".
+
+## What to Tell Your User
+
+If your agent ever became briefly unresponsive on a regular cadence — health checks
+failing, the server restarting itself — and you had accumulated a lot of tracked
+commitments, this removes the cause. Nothing changes in how commitments work or what
+gets saved; the agent just stops doing hundreds of redundant full-file saves each
+minute. No action needed.
+
+## Summary of New Capabilities
+
+No new user-facing capability — this is a performance/reliability fix. The commitments
+store is now persisted once per verification sweep (was once per mutated commitment),
+and saved compactly. Existing agents get it via the normal update; the on-disk store
+format is unchanged (still a JSON object, just not pretty-printed).
+
+## Evidence
+
+- New unit test `tests/unit/CommitmentTracker-verify-batches-saves.test.ts`: a sweep
+  over 40 mutated commitments produces exactly **1** store write (was 40); a lone mutate
+  outside a sweep still persists immediately.
+- Live diagnosis on Echo (2026-06-21): a `JSON.stringify` tracer captured
+  `verify → verifyOne → mutateSync → saveStore` re-serializing the 1.6MB store
+  repeatedly within one sweep; after the fix the per-sweep write count is 1 and the
+  multi-minute event-loop freezes shortened.

--- a/upgrades/next/commitment-tracker-verify-batches-saves.md
+++ b/upgrades/next/commitment-tracker-verify-batches-saves.md
@@ -38,3 +38,13 @@ format is unchanged (still a JSON object, just not pretty-printed).
   `verify → verifyOne → mutateSync → saveStore` re-serializing the 1.6MB store
   repeatedly within one sweep; after the fix the per-sweep write count is 1 and the
   multi-minute event-loop freezes shortened.
+
+## What Changed (DegradationReporter reentrancy — same incident)
+
+The "something degraded" reporter could feed itself into an infinite loop: reporting a
+degradation runs a small AI "tone gate" to phrase the alert nicely, but that gate goes through
+the same router that just degraded — so if a configured tool is missing, the gate degrades
+again, which reports again, forever. The growing internal events list, serialized each cycle,
+froze the agent for minutes (the restart "flapping"). Fixed with a reentrancy guard (the gate
+won't run inside itself) plus a hard cap on the events list. Degradations are still logged and
+alerted; the agent just no longer melts down when a configured framework isn't installed.

--- a/upgrades/side-effects/commitment-tracker-verify-batches-saves.md
+++ b/upgrades/side-effects/commitment-tracker-verify-batches-saves.md
@@ -1,0 +1,73 @@
+# Side-Effects Review — CommitmentTracker.verify() batches store saves (event-loop wedge fix)
+
+**Version / slug:** `commitment-tracker-verify-batches-saves`
+**Date:** `2026-06-21`
+**Author:** Echo (autonomous)
+**Second-pass reviewer:** required (touches a core monitoring write path on every agent)
+
+## Summary of the change
+
+`CommitmentTracker.verify()` runs on a 60-second timer. It iterates every *active*
+commitment and mutates each via `mutateSync()`, and **every** `mutateSync()` calls
+`saveStore()`, which does `JSON.stringify(this.store, null, 2)` of the **entire**
+commitments store. With a large store (observed live on Echo: **1.6MB, 1,724
+commitments**, 1,137 of them terminal/never-pruned) and N active commitments, that is
+**O(N) full-store serializations per sweep** — hundreds of 1.6MB pretty-printed
+serializations every 60s. This monopolized the single event-loop thread for **minutes**:
+`/health` returned HTTP 000, and an external watchdog SIGKILL/respawn loop ensued
+(diagnosed 2026-06-21 via a `JSON.stringify` entry-tracer that caught the
+`verify → verifyOne → mutateSync → saveStore` stack firing repeatedly in one sweep).
+
+The fix:
+1. **Batch the sweep's writes.** `verify()` sets a `batchingSaves` flag for the duration
+   of its (fully synchronous) sweep; while set, `saveStore()` marks the store dirty and
+   returns instead of writing. The sweep flushes **exactly one** write at the end. This
+   collapses O(N) serializations to 1 per sweep. Proven by a new unit test: 40 mutated
+   commitments → 1 store write (was 40).
+2. **Compact JSON.** `JSON.stringify(this.store)` (drop `, null, 2`) — the store is a
+   machine-read state file; pretty-printing ~1.6MB was pure serialization + I/O overhead.
+
+## Decision-point inventory
+
+- **Batch scope = the verify() sweep only.** A lone `mutateSync()` outside `verify()`
+  (e.g. from PresenceProxy / PromiseBeacon / a route) still persists immediately —
+  batching is sweep-scoped, asserted by a second unit test. Chosen because `verify()` is
+  the only O(N) caller; broadening batching would risk a non-sweep mutation not landing.
+- **Safety of deferral.** `verify()` is fully synchronous (no `await` between mutations;
+  `verifyConfigChange`/`verifyBehavioral` use `readFileSync`), so the event loop never
+  turns during the deferred window → no concurrent write path can observe or interleave.
+  A crash mid-sweep loses only the in-memory mutations of that sweep, which the next
+  idempotent sweep re-derives — strictly no worse than the prior per-mutation writes.
+- **Compact vs pretty.** Compact chosen; `loadStore()` parses with `JSON.parse` (format
+  agnostic), and the replication peer reader parses the same way. No human/tool consumes
+  the file as formatted text.
+- **NOT in scope (tracked follow-up):** pruning terminal commitments to bound store
+  growth. The batch+compact fix removes the wedge regardless of store size; pruning
+  interacts with the P1.5 replication incarnation/seq machinery and deserves its own
+  reviewed change.
+
+## Roll-up across the seven review dimensions
+
+- **Security:** none — no new inputs, no auth/credential surface, no external I/O change.
+- **Scalability:** the entire point — per-sweep cost goes from O(N × storeSize) to
+  O(storeSize). Removes a fleet-wide event-loop-freeze class as commitment stores grow.
+- **Adversarial:** the deferred-save flag is process-local and reset in a `finally`; a
+  thrown error inside the sweep still flushes and clears the flag.
+- **Integration:** `saveStore()` and `verify()` are internal; the only behavioral change
+  is *fewer* identical writes. The store's on-disk shape is unchanged (still the same
+  JSON object, just compact).
+- **Reliability:** one atomic write per sweep instead of N — fewer fsync/rename cycles,
+  less chance of a partial-write window.
+- **Observability:** unchanged (the `verification` event still emits post-flush).
+- **Migration parity:** pure code path; no installed-file/config/CLAUDE.md change, so no
+  PostUpdateMigrator entry needed. Existing agents get it via the normal dist update.
+
+## Evidence pointers
+
+- New test: `tests/unit/CommitmentTracker-verify-batches-saves.test.ts` (2 cases) — green.
+  Asserts 1 store write per sweep over 40 mutated commitments, and immediate persist for a
+  lone mutate.
+- Live diagnosis: a `JSON.stringify` tracer on Echo's server captured the
+  `CommitmentTracker.saveStore` stack firing repeatedly from `verify()`'s timer; the store
+  was 1.6MB / 1,724 commitments. Post-hotfix the per-sweep write count dropped to 1 and the
+  4+ minute freezes shortened.

--- a/upgrades/side-effects/commitment-tracker-verify-batches-saves.md
+++ b/upgrades/side-effects/commitment-tracker-verify-batches-saves.md
@@ -71,3 +71,39 @@ The fix:
   `CommitmentTracker.saveStore` stack firing repeatedly from `verify()`'s timer; the store
   was 1.6MB / 1,724 commitments. Post-hotfix the per-sweep write count dropped to 1 and the
   4+ minute freezes shortened.
+
+---
+
+# Side-Effects Review — DegradationReporter reentrancy wedge (same incident)
+
+**Added 2026-06-21** — the dominant event-loop wedge from the same live investigation.
+
+## Summary
+`DegradationReporter.gateHealthAlert()` runs `toneGate.review()` — an LLM call routed through
+the IntelligenceRouter. When the configured framework is unavailable the router DEGRADES, and
+that degradation re-enters `report → reportEvent → gateHealthAlert` in the same synchronous
+stack — unbounded recursion. Each level pushes another event; a `JSON.stringify` of the growing
+`events` array eventually hangs the single event-loop thread for minutes (observed live: /health
+HTTP 000, watchdog SIGKILL/respawn loop — the dominant cause of Echo's flapping).
+
+## The change
+1. **Reentrancy guard** (`_gatingHealthAlert`): `gateHealthAlert` refuses to gate-within-a-gate,
+   returning the safe template instead of recursing. Breaks the cycle regardless of which
+   framework degrades.
+2. **Bounded `events` array** (`MAX_EVENTS = 500`): defence in depth — the in-memory array can
+   never grow without limit, so whole-array serializations stay cheap.
+
+## Roll-up
+- **Security/Integration/Migration:** none — internal monitoring path; on-disk/event shapes
+  unchanged; degradations are still logged and alerted.
+- **Reliability:** the entire point — removes a fleet-wide event-loop-freeze class. Any agent
+  with an unavailable configured framework would hit this.
+- **Adversarial:** the guard flag is reset in a `finally`; a throw inside the gate still clears it.
+
+## Evidence
+- `tests/unit/degradation-reporter-reentrancy-wedge.test.ts` (3 cases): the guard short-circuits
+  the gate while already gating; a re-entrant tone gate stays bounded (doesn't hang); the events
+  array is capped at 500. All green.
+- Live: captured the hung `JSON.stringify` stack via a write-on-entry/clear-on-return catcher
+  (the call never returns, so profilers can't flush); post-fix verification showed 0 CPU-wedges,
+  0 watchdog SIGKILLs, 200s continuous healthy (was flapping every ~3 min).


### PR DESCRIPTION
## Two event-loop wedges from one live incident (Echo, 2026-06-21)

Echo's server was "flapping" — going unresponsive on a ~3-minute cadence, with an external
watchdog SIGKILL-ing and respawning it. Deep live profiling found **two stacked synchronous
`JSON.stringify` hangs** on the single event-loop thread, both fixed here.

### 1. CommitmentTracker O(N) write amplification
`verify()` (every 60s) mutates each active commitment via `mutateSync()`, and **every**
`mutateSync()` re-serialized the **entire** store (`JSON.stringify` of ~1.6MB / 1,724
commitments). One sweep did O(N) full-store serializations → froze the loop for minutes.
**Fix:** batch the sweep into one write at the end (`batchingSaves`) + compact JSON.

### 2. DegradationReporter reentrancy loop (the dominant cause)
`reportEvent → gateHealthAlert → toneGate.review` routes through the IntelligenceRouter, which
can itself **degrade** (an unavailable configured framework — here `pi-cli`, not installed) and
**re-enter** `report → reportEvent → gateHealthAlert` in the same synchronous stack — unbounded
recursion whose growing `events` array makes a `JSON.stringify` hang for minutes.
**Fix:** a reentrancy guard (`_gatingHealthAlert`) — the gate refuses to gate-within-a-gate,
returning the safe template instead of recursing — plus a hard cap on the events array
(`MAX_EVENTS=500`). Breaks the cycle regardless of which framework degrades.

## Evidence
- `tests/unit/CommitmentTracker-verify-batches-saves.test.ts` (2): 1 store write per sweep
  over 40 mutated commitments (was 40).
- `tests/unit/degradation-reporter-reentrancy-wedge.test.ts` (3): guard short-circuits while
  already gating; a re-entrant tone gate stays bounded; events array capped.
- `tsc --noEmit` clean. Side-effects review + ELI16 in `docs/specs/` + `upgrades/`.
- **Live verification after both fixes hotfixed onto Echo:** 0 100%-CPU wedges, 0 watchdog
  SIGKILLs over 10 min, 200s+ continuous healthy (was flapping every ~3 min).

## ELI16

Your agent has one worker that does one thing at a time. Two separate bugs each made it spend
**minutes** turning a huge pile of data into text (a `JSON.stringify`), during which it could do
nothing else — so health checks failed, a watchdog thought it had crashed and restarted it, and
it did the same thing again: the "flapping." Bug one: it re-saved its entire to-do-list file
hundreds of times a minute (now: once per check). Bug two, the big one: its "something
degraded" reporter ran a tiny AI check to phrase the alert nicely, but that check used the same
tool that just broke — so it degraded again, reported again, forever, piling up a list it kept
re-serializing until it choked. Now the check refuses to run inside itself (no loop possible),
and the list is capped. Nothing you see changes; the agent just stops freezing itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
