### PR TITLE
fix(monitoring): SleepWakeDetector — separate event-loop block from sleep via per-process CPU

### DIFF
--- a/.instar/instar-dev-decisions/2026-06-21T20-57-13-308Z-sleepwake-stall-not-sleep.json
+++ b/.instar/instar-dev-decisions/2026-06-21T20-57-13-308Z-sleepwake-stall-not-sleep.json
@@ -1,0 +1,16 @@
+{
+  "ts": "2026-06-21T20:57:13.308Z",
+  "slug": "sleepwake-stall-not-sleep",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 86,
+  "causalAutopsy": {
+    "origin": "latent",
+    "notes": "The detector classified drift using system loadavg only; that signal is structurally blind to a single-process event-loop block on a many-core host (one pinned Node thread doesn't move a 16-core loadavg above maxLoadRatio). The misclassification was always present but only surfaced as a visible bug now, when event-loop wedges on a caffeinated host were logged as 'wake after ~Ns sleep'. Fixed by adding the per-process CPU-burn discriminator."
+  },
+  "verdict": "pass"
+}

--- a/.instar/instar-dev-decisions/2026-06-21T20-58-29-663Z-sleepwake-stall-not-sleep.json
+++ b/.instar/instar-dev-decisions/2026-06-21T20-58-29-663Z-sleepwake-stall-not-sleep.json
@@ -1,0 +1,16 @@
+{
+  "ts": "2026-06-21T20:58:29.663Z",
+  "slug": "sleepwake-stall-not-sleep",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 86,
+  "causalAutopsy": {
+    "origin": "latent",
+    "notes": "The detector classified drift using system loadavg only; that signal is structurally blind to a single-process event-loop block on a many-core host (one pinned Node thread doesn't move a 16-core loadavg above maxLoadRatio). The misclassification was always present but only surfaced as a visible bug now, when event-loop wedges on a caffeinated host were logged as 'wake after ~Ns sleep'. Fixed by adding the per-process CPU-burn discriminator."
+  },
+  "verdict": "pass"
+}

--- a/docs/specs/sleepwake-stall-not-sleep.eli16.md
+++ b/docs/specs/sleepwake-stall-not-sleep.eli16.md
@@ -1,0 +1,57 @@
+# ELI16 — Stop misreading a frozen event loop as "the machine slept"
+
+## What this is, in plain English
+
+Echo's server has a little watcher called `SleepWakeDetector`. Every couple of
+seconds it checks the clock. If a lot more time passed than expected between two
+checks, *something* made the program stop running for a while — and the watcher
+has to guess **what**. There are two very different causes, and they need
+opposite responses:
+
+1. **The computer actually went to sleep** (lid closed, OS suspend). That's
+   normal. On wake-up, recovery steps run (reset timers, re-check the network).
+2. **The program froze its own event loop** — one Node.js thread got stuck doing
+   a huge chunk of work and couldn't answer anything for 10–60 seconds. That's a
+   *bug* (a "wedge"), not sleep, and it should be flagged for the wedge watchers,
+   never celebrated as a clean wake.
+
+## What already exists
+
+The detector already tries to tell these apart, but only with **system load**
+(`loadavg ÷ cores`). The idea was: if the whole machine is overloaded, a late
+check is starvation, not sleep — so suppress the false "wake."
+
+## What was broken
+
+System load is the **wrong yardstick for a single stuck process**. On Echo's
+16-core box, one Node thread can pin itself solid for 14 seconds and the 16-core
+load average barely moves — it stays *well* under the "overloaded" line. So the
+load guard never trips, and the detector announces **"Wake detected after ~14s
+sleep"** — on a machine that is plugged in, lid open, with `caffeinate` running,
+where sleep is *physically impossible*. Justin caught exactly this: he didn't
+trust the sleep measurement, and he was right. Worse, those false "sleep" reports
+hid the real problem — the event-loop wedges that were actually causing the
+restarts.
+
+## What's new
+
+A second, **decisive** check: how much CPU **this exact process** burned during
+the gap. A sleeping process is frozen — it burns ~0 CPU. A wedged event loop
+burns CPU for almost the whole gap. So:
+
+- Burned a lot of CPU through the gap → it was a **block/wedge**, not sleep. Emit
+  a new `stall` signal for the wedge watchers; **suppress** the false "wake."
+- Burned ~0 CPU → it really was idle/asleep → emit "wake" as before.
+
+This new check runs **first**, beats the old load guesswork, and applies even to
+**long** gaps (the old code blindly called any multi-minute gap "sleep" — but a
+multi-minute CPU-busy gap is the worst kind of wedge). It defaults on, needs no
+config, and fails safe: if the CPU reading can't be taken, it quietly falls back
+to the old load-based behavior instead of crashing the watcher.
+
+## What the reader needs to decide
+
+Nothing to configure. This is a correctness fix: the detector now tells the truth
+about *why* time jumped, so wedges stop being laundered into "sleep." The knob
+`cpuBlockBusyRatio` (default 0.5 = "burned ≥50% of the gap on CPU → it's a
+block") exists only if you ever want to tune or disable it (set 0).

--- a/src/core/SleepWakeDetector.ts
+++ b/src/core/SleepWakeDetector.ts
@@ -107,6 +107,24 @@ export interface SleepWakeDetectorConfig {
   cpuCountProvider?: () => number;
   /** Injectable wall-clock source (testing). Default: Date.now. */
   nowProvider?: () => number;
+  /**
+   * Fraction of a drift gap during which THIS process must have consumed CPU for the
+   * drift to be classified as an event-loop BLOCK (a wedge/stall) rather than sleep.
+   *
+   * This is the per-PROCESS signal the load heuristics can't provide: a suspended
+   * (sleeping) process burns ~0 CPU during the gap, while a blocked event loop burns
+   * CPU for most of it. One Node thread blocking for 14s doesn't move a 16-core
+   * `loadavg` above `maxLoadRatio`, so the load guards emit a FALSE "sleep" — but the
+   * process's own CPU usage exposes it definitively. Applies to LONG drifts too: a
+   * multi-minute CPU-busy drift is the event-loop wedge, never sleep. Default: 0.5.
+   * Set 0 to disable.
+   */
+  cpuBlockBusyRatio?: number;
+  /**
+   * Injectable cumulative-process-CPU source in MICROSECONDS (testing). Default sums
+   * `process.cpuUsage()` user + system. Used to compute CPU burned across a drift gap.
+   */
+  cpuUsageProvider?: () => number;
 }
 
 export interface WakeEvent {
@@ -114,7 +132,20 @@ export interface WakeEvent {
   timestamp: string;
 }
 
-export type WakeSuppressionReason = 'cpu-starvation' | 'cooldown';
+export type WakeSuppressionReason = 'cpu-starvation' | 'cooldown' | 'event-loop-block';
+
+/**
+ * Emitted when a drift is PROVEN to be an event-loop block (this process burned CPU
+ * through the gap), not sleep. Signal-only so wedge watchers can see a real stall that
+ * the detector would otherwise have mislabeled as a wake. No consumer = harmless.
+ */
+export interface StallEvent {
+  /** Drift duration in seconds (how long the loop was blocked). */
+  stallSeconds: number;
+  /** Fraction of the gap this process spent on CPU (≈1 = fully CPU-bound block). */
+  cpuBusyRatio: number;
+  timestamp: string;
+}
 
 export interface SuppressedWakeEvent {
   reason: WakeSuppressionReason;
@@ -160,6 +191,11 @@ export class SleepWakeDetector extends EventEmitter {
   private loadAvgProvider: () => number[];
   private cpuCountProvider: () => number;
   private now: () => number;
+  private cpuBlockBusyRatio: number;
+  private cpuUsageProvider: () => number;
+  /** Cumulative process CPU (µs) sampled at the previous tick — drives the per-process
+   *  CPU-busy-through-the-gap discriminator that separates a real sleep from a block. */
+  private lastCpuMicros = 0;
   private wakeHistory: WakeEvent[] = [];
   private suppressionHistory: SuppressedWakeEvent[] = [];
 
@@ -176,17 +212,26 @@ export class SleepWakeDetector extends EventEmitter {
     this.loadAvgProvider = config.loadAvgProvider ?? (() => os.loadavg());
     this.cpuCountProvider = config.cpuCountProvider ?? (() => os.cpus().length);
     this.now = config.nowProvider ?? (() => Date.now());
+    this.cpuBlockBusyRatio = config.cpuBlockBusyRatio ?? 0.5;
+    this.cpuUsageProvider =
+      config.cpuUsageProvider ?? (() => { const c = process.cpuUsage(); return c.user + c.system; });
     this.lastTick = this.now();
+    this.lastCpuMicros = this.readCpuMicros();
   }
 
   start(): void {
     if (this.interval) return;
     this.lastTick = this.now();
+    this.lastCpuMicros = this.readCpuMicros();
 
     this.interval = setInterval(() => {
       const now = this.now();
       const elapsed = now - this.lastTick;
       this.lastTick = now;
+      // CPU burned by THIS process across the gap — the per-process sleep-vs-block signal.
+      const cpuNowMicros = this.readCpuMicros();
+      const cpuBusyRatio = elapsed > 0 ? ((cpuNowMicros - this.lastCpuMicros) / 1000) / elapsed : 0;
+      this.lastCpuMicros = cpuNowMicros;
 
       if (elapsed <= this.driftThresholdMs) { this.consecutiveDrifts = 0; return; } // on-time tick → not starving
 
@@ -198,6 +243,30 @@ export class SleepWakeDetector extends EventEmitter {
       // guard below can measure recurrence; capture the prior value first for the check.
       const prevShortDriftAtMs = this.lastShortDriftAtMs;
       if (!isLongSleep) this.lastShortDriftAtMs = now;
+
+      // Per-process CPU check — the DEFINITIVE sleep-vs-block discriminator, ahead of the
+      // load heuristics. A suspended (sleeping) process burns ~0 CPU during the gap; a
+      // blocked event loop burns CPU through most of it. So a high busy ratio means the
+      // loop was BLOCKED and the machine did NOT sleep — regardless of duration (a
+      // multi-minute CPU-busy drift is the event-loop WEDGE, not sleep) and regardless of
+      // the system loadavg (one blocked Node thread doesn't move a 16-core average). Emit a
+      // `stall` signal for the wedge watchers; never a `wake`. (2026-06-21: fixes the
+      // misdiagnosis where 11-18s event-loop blocks on a caffeinated host — where sleep is
+      // physically impossible — were logged as "Wake detected after ~Ns sleep".)
+      if (this.cpuBlockBusyRatio > 0 && cpuBusyRatio >= this.cpuBlockBusyRatio) {
+        this.recordSuppression('event-loop-block', sleepDuration, loadRatio, now);
+        console.warn(
+          `[SleepWakeDetector] Drift ~${sleepDuration}s but this process burned ` +
+            `${Math.round(cpuBusyRatio * 100)}% CPU through the gap — event-loop BLOCK, not ` +
+            `sleep (the machine did not sleep). Emitting stall, suppressing wake.`,
+        );
+        this.emit('stall', {
+          stallSeconds: sleepDuration,
+          cpuBusyRatio,
+          timestamp: new Date(now).toISOString(),
+        } as StallEvent);
+        return;
+      }
 
       // Consecutive-drift burst = sustained CPU starvation, not sleep. A genuine sleep
       // is ONE isolated drift (the next on-time tick resets the counter); the 2nd+
@@ -283,6 +352,20 @@ export class SleepWakeDetector extends EventEmitter {
     }
   }
 
+  /** Read cumulative process CPU (µs) defensively. A provider error (or a non-finite
+   *  reading) yields the prior value, so the gap delta becomes 0 → no block signal →
+   *  the tick falls through to the load guards. That is the safe direction: a CPU-read
+   *  failure can never crash the tick (it runs inside setInterval) nor force a false
+   *  block classification — it just disables this one discriminator for that tick. */
+  private readCpuMicros(): number {
+    try {
+      const v = this.cpuUsageProvider();
+      return Number.isFinite(v) ? v : this.lastCpuMicros;
+    } catch {
+      return this.lastCpuMicros;
+    }
+  }
+
   /** Current `loadavg[0] / cpuCount` ratio. Returns 0 when load is unavailable
    *  (e.g. Windows reports [0,0,0]), which disables the starvation guard there. */
   private currentLoadRatio(): number {
@@ -353,6 +436,7 @@ export class SleepWakeDetector extends EventEmitter {
     const suppressedByReason: Record<WakeSuppressionReason, number> = {
       'cpu-starvation': 0,
       cooldown: 0,
+      'event-loop-block': 0,
     };
     for (const e of suppressed) suppressedByReason[e.reason]++;
     return {

--- a/tests/unit/SleepWakeDetector-cpu-block.test.ts
+++ b/tests/unit/SleepWakeDetector-cpu-block.test.ts
@@ -1,0 +1,99 @@
+/**
+ * Regression test for the sleep-vs-event-loop-block MISDIAGNOSIS (2026-06-21).
+ *
+ * Bug: the detector inferred "sleep" from timer drift + system loadavg. But one Node
+ * thread can block its event loop for tens of seconds without moving a 16-core loadavg
+ * above maxLoadRatio, so an isolated block under normal load emitted a FALSE
+ * "Wake detected after ~Ns sleep" — even on a caffeinated host where sleep is
+ * physically impossible. That laundered real event-loop wedges into "sleep".
+ *
+ * Fix: a per-PROCESS check. A suspended (sleeping) process burns ~0 CPU during the gap;
+ * a blocked event loop burns CPU through most of it. So `process.cpuUsage()` across the
+ * gap definitively separates block from sleep — independent of system load and duration.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { SleepWakeDetector, type WakeEvent, type StallEvent } from '../../src/core/SleepWakeDetector.js';
+
+describe('SleepWakeDetector — CPU-busy drift is an event-loop block, not sleep', () => {
+  beforeEach(() => vi.useFakeTimers({ now: new Date('2026-01-01T00:00:00Z') }));
+  afterEach(() => { vi.clearAllTimers(); vi.useRealTimers(); });
+
+  function make() {
+    let cpuMicros = 0;
+    const wakes: WakeEvent[] = [];
+    const stalls: StallEvent[] = [];
+    const detector = new SleepWakeDetector({
+      checkIntervalMs: 1000,
+      driftThresholdMs: 5000,
+      minWakeIntervalMs: 0,
+      loadAvgProvider: () => [0, 0, 0], // normal load — the load guards would emit a false "sleep"
+      cpuUsageProvider: () => cpuMicros,
+    });
+    detector.on('wake', (e) => wakes.push(e));
+    detector.on('stall', (e) => stalls.push(e));
+    detector.start();
+    /** Simulate a drift of ~gapMs during which the process burned `cpuBurnedMs` of CPU. */
+    const simulateGap = (gapMs: number, cpuBurnedMs: number) => {
+      vi.setSystemTime(new Date(Date.now() + gapMs)); // OS froze/blocked the process
+      cpuMicros += cpuBurnedMs * 1000;                // CPU consumed during the gap (µs)
+      vi.advanceTimersByTime(1000);                   // fire one tick that sees the jump
+    };
+    return { detector, wakes, stalls, simulateGap };
+  }
+
+  it('a ~14s drift where the process burned CPU through the gap → STALL, not wake', () => {
+    const { wakes, stalls, simulateGap } = make();
+    simulateGap(14_000, 14_000); // CPU-bound the whole gap
+
+    expect(stalls.length).toBe(1);
+    expect(wakes.length).toBe(0);
+    expect(stalls[0].cpuBusyRatio).toBeGreaterThanOrEqual(0.5);
+    expect(stalls[0].stallSeconds).toBeGreaterThan(0);
+  });
+
+  it('a genuine sleep (process idle through the gap) still emits a WAKE', () => {
+    const { wakes, stalls, simulateGap } = make();
+    simulateGap(14_000, 0); // suspended process — no CPU burned
+
+    expect(wakes.length).toBe(1);
+    expect(stalls.length).toBe(0);
+  });
+
+  it('a LONG CPU-busy drift is a BLOCK, not a long sleep (old code always emitted wake)', () => {
+    const { wakes, stalls, simulateGap } = make();
+    simulateGap(400_000, 400_000); // > longSleepFloorSeconds (300) but CPU-bound = the wedge
+
+    expect(stalls.length).toBe(1);
+    expect(wakes.length).toBe(0);
+  });
+
+  it('records the suppression under the event-loop-block reason', () => {
+    const { detector, simulateGap } = make();
+    simulateGap(14_000, 14_000);
+    const stats = detector.getStats();
+    expect(stats.suppressedByReason['event-loop-block']).toBe(1);
+    expect(stats.wakeCount).toBe(0);
+  });
+
+  it('a throwing cpuUsageProvider never crashes the tick — it degrades to a wake (real sleep)', () => {
+    // The CPU read runs inside setInterval; a throw there would crash the process. The
+    // defensive read must swallow it and fall through to the load guards (here: idle, so
+    // a genuine wake still emits).
+    const wakes: WakeEvent[] = [];
+    const detector = new SleepWakeDetector({
+      checkIntervalMs: 1000,
+      driftThresholdMs: 5000,
+      minWakeIntervalMs: 0,
+      loadAvgProvider: () => [0, 0, 0],
+      cpuUsageProvider: () => { throw new Error('cpuUsage unavailable'); },
+    });
+    detector.on('wake', (e) => wakes.push(e));
+    expect(() => {
+      detector.start();
+      vi.setSystemTime(new Date(Date.now() + 14_000));
+      vi.advanceTimersByTime(1000);
+    }).not.toThrow();
+    expect(wakes.length).toBe(1); // degraded safely to the load-guard path
+  });
+});

--- a/upgrades/next/sleepwake-stall-not-sleep.md
+++ b/upgrades/next/sleepwake-stall-not-sleep.md
@@ -1,0 +1,57 @@
+<!-- bump: patch -->
+<!-- change_type: fix -->
+
+## What Changed
+
+The sleep/wake watcher (`SleepWakeDetector`) used to decide "did the machine sleep?"
+purely from a timer-drift jump plus **system load**. On a multi-core machine, one
+internal thread can freeze for 10–60 seconds without moving the system load average — so
+the watcher would announce a "wake after ~Ns sleep" when the machine never slept at all
+(it was plugged in, lid open, with `caffeinate` running — sleep was impossible). Those
+false "sleep" reports hid the real cause: short event-loop freezes.
+
+Now the watcher also measures how much CPU **its own process** burned during the gap. A
+truly sleeping process burns almost no CPU; a frozen-but-busy one burns CPU the whole
+time. So a busy gap is correctly reported as a `stall` (a freeze the wedge watchers can
+act on) instead of a phantom "sleep." The new check runs first, applies even to
+multi-minute gaps, defaults on with no configuration, and fails safe (if the CPU reading
+can't be taken it quietly falls back to the old behavior).
+
+## What to Tell Your User
+
+If you ever saw your agent claim it "woke from sleep" on a machine that was plugged in
+and awake — that was a misread. The watcher now tells the difference between a real sleep
+and an internal freeze by checking its own CPU use, so those phantom "sleep" messages stop
+and genuine freezes get flagged honestly. Nothing to configure.
+
+## Summary of New Capabilities
+
+No new user-facing capability — a correctness fix. `SleepWakeDetector` gains a per-process
+CPU-burn discriminator that separates an event-loop block from real sleep: it emits a
+signal-only `stall` event (and suppresses the false `wake`) when this process burned CPU
+through the drift gap. Tunable via the optional `cpuBlockBusyRatio` (default 0.5; set 0 to
+disable). `getStats().suppressedByReason` gains an `event-loop-block` count. Existing
+agents get it via the normal update; on-disk formats and API shapes are unchanged.
+
+## Evidence
+
+**Reproduction (live, 2026-06-21):** Echo's server was flapping (watchdog SIGKILL+respawn
+on a cadence) from event-loop wedges. Throughout, `logs/server.log` carried
+`[SleepWakeDetector] Wake detected after ~Ns sleep` lines — on a host that was plugged in,
+lid open, with `caffeinate` running, where OS sleep is physically impossible. `pmset -g`
+confirmed no sleep occurred. The drifts were single-process event-loop blocks (one Node
+thread pinned), and the 16-core `loadavg` stayed well under `maxLoadRatio` (1.5), so the
+existing load guard never tripped and each block printed a phantom "sleep."
+
+**Before:** a 14s CPU-bound event-loop block under normal system load → `wake` emitted
+(`sleepDurationSeconds ≈ 14`), credited as real sleep in `wakeHistory`; the wedge was
+invisible (laundered into "sleep").
+
+**After:** the same 14s CPU-bound drift → the per-process CPU check measures ~100% busy
+across the gap → a `stall` event is emitted and the `wake` is suppressed (recorded under
+`suppressedByReason['event-loop-block']`), so it is never credited as sleep. A genuine
+idle/suspend gap (~0% CPU) still emits `wake` unchanged.
+
+**Automated:** `tests/unit/SleepWakeDetector-cpu-block.test.ts` reproduces both directions
+with injected clock + CPU providers (CPU-busy short drift → stall; idle drift → wake; long
+CPU-busy drift → stall; throwing provider → no crash). 15/15 unit tests green; `tsc` clean.

--- a/upgrades/side-effects/sleepwake-stall-not-sleep.md
+++ b/upgrades/side-effects/sleepwake-stall-not-sleep.md
@@ -1,0 +1,102 @@
+# Side-Effects Review — SleepWakeDetector: per-process CPU check separates event-loop block from sleep
+
+**Version / slug:** `sleepwake-stall-not-sleep`
+**Tier:** 1 (surgical bug-fix, one core file + tests; no new route, config contract, or persistence schema)
+
+## Summary of the change
+
+`SleepWakeDetector` inferred "sleep" from timer drift + **system loadavg**. A single
+Node thread blocking its own event loop for tens of seconds does NOT move a 16-core
+`loadavg` above `maxLoadRatio` (1.5), so an isolated event-loop block under normal
+system load emitted a FALSE `wake` ("Wake detected after ~14s sleep") — even on a
+caffeinated host where sleep is physically impossible. That laundered real wedges into
+"sleep" and masked the actual fault.
+
+The fix adds a per-PROCESS discriminator: `process.cpuUsage()` sampled across the drift
+gap. A suspended (sleeping) process burns ~0 CPU; a blocked event loop burns CPU through
+most of the gap. When `cpuBusyRatio >= cpuBlockBusyRatio` (default 0.5) the drift is a
+BLOCK — emit a new signal-only `stall` event and SUPPRESS the false `wake`. The check
+runs ahead of the existing load/burst/cooldown guards and, unlike the old `isLongSleep`
+exemption, applies to LONG drifts too (a multi-minute CPU-busy drift is the wedge, never
+sleep).
+
+## Decision-point inventory
+
+- **Threshold `cpuBlockBusyRatio` = 0.5.** A real wake burns ~0 CPU over the gap (ratio
+  ~0); a CPU-bound block burns ~1 core (ratio ~1.0). 0.5 is the safe midpoint; set 0 to
+  disable. Tunable, defaults on.
+- **Ordering:** the CPU check is FIRST (most authoritative). A real long sleep (≈0 CPU)
+  falls through it and still emits a wake via the existing `isLongSleep` exemption.
+- **New `stall` event:** signal-only. No consumer = harmless (the value is the suppressed
+  false wake). Wedge watchers MAY consume it later.
+
+## 1. Over-block (false positive — suppressing a REAL wake)
+
+Could a genuine wake be misread as a block? On real OS suspend the process is frozen →
+~0 CPU over the gap → ratio ~0 → NOT suppressed → wake emits correctly. A wake immediately
+followed by heavy CPU still reads low, because the drift tick fires once at wake and the
+gap's CPU (the frozen span) is ~0. Verified by the `genuine sleep → WAKE` test.
+
+## 2. Under-block (missing a block)
+
+A low-CPU stall (IO-wait, not CPU-bound) reads ratio ~0 and is NOT flagged by this check —
+by design; it falls through to the existing load/burst/recurring guards exactly as before.
+This change only ADDS detection for the CPU-bound case the load heuristics were blind to;
+it removes no existing suppression path.
+
+## 4. Signal vs authority compliance
+
+The detector only decides whether to emit `wake` vs `stall` — both are signals to other
+watchers; it gates nothing and takes no destructive action. Recovery authority stays with
+the consumers (ServerSupervisor / wedge watchers), unchanged.
+
+## 5. Interactions
+
+`getCumulativeSleepMsBetween` (the wake-reaper's sleep-credit source) reads only EMITTED
+wakes; a suppressed block is never credited as sleep — so a wedge can no longer inflate a
+job's sleep credit and cause an early reap. `getStats().suppressedByReason` gains an
+`event-loop-block` counter (additive; existing keys unchanged).
+
+## 6. External surfaces
+
+None. No new route, no config-file contract change (the two new config fields are optional
+with safe defaults), no persistence, no messaging. `GET /sleep/stats` (routes.ts) returns
+the same `SleepWakeStats` shape plus the additive reason key.
+
+## 6b. Operator-surface quality
+
+N/A — no operator/dashboard/approval surface is touched. Change is internal to a core
+detector.
+
+## Framework generality
+
+N/A — `SleepWakeDetector` is a framework-agnostic core monitor (not part of the session
+launch/inject abstraction). It runs per-process regardless of which agentic framework the
+session uses.
+
+## 7. Multi-machine posture
+
+Per-process and per-machine by nature; each machine's detector watches its own loop. No
+replicated state, no cross-machine contract. Safe on single- and multi-machine installs.
+
+## 8. Rollback cost
+
+Trivial and safe: set `cpuBlockBusyRatio: 0` to disable the new branch (reverts to the
+prior load-only behavior), or revert the commit. The defensive CPU read fails toward the
+old behavior, so even a provider error degrades to pre-change semantics rather than
+breaking.
+
+## Evidence pointers
+
+- New tests: `tests/unit/SleepWakeDetector-cpu-block.test.ts` (5 tests — CPU-busy short
+  drift → stall; genuine sleep → wake; long CPU-busy drift → stall; stats record; throwing
+  provider never crashes the tick). Existing `SleepWakeDetector.test.ts` (10 tests) still
+  green — 15/15. `tsc --noEmit` clean.
+- Live root cause (2026-06-21): a caffeinated, lid-open, plugged-in host logged "Wake
+  detected after ~Ns sleep" for what were event-loop blocks — the misdiagnosis this fixes.
+
+## Conclusion
+
+A correctness fix that makes drift classification honest: CPU-bound event-loop blocks are
+flagged as `stall`, not laundered into a false `wake`. Defaults on, fails safe, trivially
+reversible. Ship.


### PR DESCRIPTION
## What & why

`SleepWakeDetector` classified timer drift as "sleep" using **system loadavg**
only. That signal is structurally blind to a single-process event-loop block on a
many-core host: one pinned Node thread doesn't move a 16-core loadavg above
`maxLoadRatio`, so an isolated 10–60s block under normal system load emitted a
**false** `wake` ("Wake detected after ~Ns sleep") — even on a caffeinated,
lid-open, plugged-in host where sleep is physically impossible. That laundered
real event-loop wedges into "sleep" and masked the actual fault (the operator
explicitly distrusted the sleep measurement — correctly).

This adds a per-**process** discriminator: `process.cpuUsage()` sampled across the
drift gap. A suspended (sleeping) process burns ~0 CPU; a blocked event loop burns
CPU through most of the gap. When `cpuBusyRatio >= cpuBlockBusyRatio` (default
0.5), the drift is a **block** — emit a new signal-only `stall` event and suppress
the false `wake`. The check runs **ahead** of the existing load/burst/cooldown
guards and (unlike the old `isLongSleep` exemption) applies to **long** drifts too
— a multi-minute CPU-busy drift is the wedge, not sleep. Defaults on, no config;
fails safe (a CPU-read error degrades to the prior load-only behavior, never
crashes the `setInterval` tick).

## ELI16 — telling a real sleep apart from a frozen program

Echo has a watcher that notices when time suddenly jumps and tries to say *why*:
either the machine **went to sleep** (normal) or the program **froze its own work
loop** for a few seconds (a bug). It used to guess from how busy the *whole
machine* was — but on a 16-core box, one stuck thread doesn't make the machine
look busy, so the watcher kept announcing "woke from sleep" on a machine that was
plugged in and wide awake, hiding the real freezes. Now it also checks how much
CPU *its own process* used during the gap: a sleeping program uses almost none, a
frozen-but-busy one uses a lot. So a busy gap is correctly reported as a freeze
(`stall`) the wedge-watchers can act on, instead of a fake "sleep." It turns on by
itself, needs no settings, works even for long freezes, and if it can't read CPU
it quietly falls back to the old behavior. One optional knob (`cpuBlockBusyRatio`,
default 0.5) tunes or disables it.

## Tier

Tier-1 (instar-dev lite lane): one core file + tests, two optional safe-defaulted
config fields, no new route/config-contract/persistence/operator surface.

## Test plan

- New `tests/unit/SleepWakeDetector-cpu-block.test.ts` (5 tests): CPU-busy short
  drift → `stall` (no wake); genuine sleep (idle gap) → `wake`; long CPU-busy
  drift → `stall`; suppression recorded under `event-loop-block`; a **throwing**
  `cpuUsageProvider` never crashes the tick (degrades to the load-guard path).
- Existing `tests/unit/SleepWakeDetector.test.ts` (10 tests) unchanged & green —
  **15/15**. `tsc --noEmit` clean. Full lint suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
