### PR TITLE
feat(storage): Bounded Accumulation 2a — token-ledger SQLite retention (dark)

### DIFF
--- a/.instar/instar-dev-decisions/2026-06-22T00-35-56-869Z-bounded-accumulation-increment-2-token-ledger.json
+++ b/.instar/instar-dev-decisions/2026-06-22T00-35-56-869Z-bounded-accumulation-increment-2-token-ledger.json
@@ -1,0 +1,23 @@
+{
+  "ts": "2026-06-22T00:35:56.869Z",
+  "slug": "bounded-accumulation-increment-2-token-ledger",
+  "suggestedTier": 2,
+  "declaredTier": 2,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "safety-invariant proximity: src/monitoring/TokenLedger.ts matches token handling",
+    "safety-invariant proximity: src/monitoring/TokenLedgerPoller.ts matches token handling",
+    "new capability: new config key added"
+  ],
+  "belowFloor": false,
+  "files": 4,
+  "loc": 140,
+  "causalAutopsy": {
+    "origin": "prior-pr",
+    "relatedPrs": [
+      1241
+    ],
+    "notes": "Increment 2a of the Bounded Accumulation standard shipped in #1241 (the standard + Increment 1 substrate). This retrofits the first real store (token-ledger.db, 256MB — the lone unbounded SQLite store; ResourceLedger already pruned) onto the standard's SQLite retention class, behind a dark-by-default flag."
+  },
+  "verdict": "pass"
+}

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -3163,6 +3163,17 @@ export interface InstarConfig {
   };
   /** Update configuration */
   updates?: UpdateConfig;
+  /**
+   * Bounded Accumulation retention (Increment 2). Per-store retention enablement —
+   * ships DARK (each store defaults disabled); enabling a store opts it into the
+   * standard's bounded retention. Spec: docs/specs/bounded-accumulation-standard.md.
+   */
+  storage?: {
+    retention?: {
+      /** The 256MB token-ledger SQLite store. enabled:false (dark) by default. */
+      tokenLedger?: { enabled?: boolean; maxAgeMs?: number };
+    };
+  };
   /** Publishing (Telegraph) config */
   publishing?: PublishingConfig;
   /** Cloudflare Tunnel config */

--- a/src/monitoring/TokenLedger.ts
+++ b/src/monitoring/TokenLedger.ts
@@ -256,6 +256,16 @@ export interface TokenLedgerOptions {
    */
   maxFilesPerScan?: number;
   /**
+   * Bounded Accumulation retention (Increment 2). When `enabled`, token_events older
+   * than `maxAgeMs` are pruned in bounded batches off the hot path (driven by the
+   * poller via {@link TokenLedger.pruneToRetention}). Ships dark (default disabled):
+   * the 256MB ledger is read-only observability, so retention is opt-in. On a FRESH
+   * DB `auto_vacuum=INCREMENTAL` lets the prune reclaim disk; the existing un-converted
+   * file only reclaims after the Increment-3 one-time VACUUM (prune still bounds the
+   * row count going forward).
+   */
+  retention?: { enabled?: boolean; maxAgeMs?: number };
+  /**
    * Yield to the event loop every N files within a scan. Default 25.
    * Even with maxFilesPerScan, a 500-file batch on slow disks can block for
    * seconds without yielding.
@@ -313,6 +323,8 @@ export class TokenLedger {
   private claudeProjectsDir: string;
   private maxFileAgeMs: number;
   private maxFilesPerScan: number;
+  private retentionEnabled: boolean;
+  private retentionMaxAgeMs: number;
   private yieldEveryNFiles: number;
   private asyncYieldFn: () => Promise<void>;
   /** Background attribution-backfill timer (async strategy); cleared on close(). */
@@ -335,6 +347,11 @@ export class TokenLedger {
     this.claudeProjectsDir = opts.claudeProjectsDir;
     this.maxFileAgeMs = opts.maxFileAgeMs && opts.maxFileAgeMs > 0 ? opts.maxFileAgeMs : 0;
     this.maxFilesPerScan = opts.maxFilesPerScan && opts.maxFilesPerScan > 0 ? opts.maxFilesPerScan : 500;
+    this.retentionEnabled = opts.retention?.enabled === true;
+    this.retentionMaxAgeMs =
+      opts.retention?.maxAgeMs && opts.retention.maxAgeMs > 0
+        ? opts.retention.maxAgeMs
+        : 30 * 24 * 60 * 60 * 1000; // 30d default (registry derived-token-ledger maxAgeMs)
     this.yieldEveryNFiles = opts.yieldEveryNFiles && opts.yieldEveryNFiles > 0 ? opts.yieldEveryNFiles : 25;
     this.asyncYieldFn = opts.asyncYieldFn ?? (() => new Promise<void>(resolve => setImmediate(resolve)));
     if (opts.dbPath !== ':memory:') {
@@ -355,6 +372,14 @@ export class TokenLedger {
     );
     this.db.pragma('journal_mode = WAL');
     this.db.pragma('synchronous = NORMAL');
+    // Bounded Accumulation (Increment 2): enable INCREMENTAL auto-vacuum so a
+    // retention prune can reclaim disk via incremental_vacuum without a full
+    // (locking, whole-file-rewriting) VACUUM. This takes effect ONLY on a FRESH DB
+    // (set before any table is created, below); on an existing file it is a safe
+    // no-op (auto_vacuum is fixed until a one-time VACUUM converts it — that
+    // conversion is the operator-gated Increment-3 cleanup). The prune still bounds
+    // the row count on the existing file; only disk reclaim waits for the VACUUM.
+    try { this.db.pragma('auto_vacuum = INCREMENTAL'); } catch { /* @silent-fallback-ok: a pragma failure must never break ledger init (observability path); retention just won't auto-reclaim. */ }
     // Close-on-exit registry (SqliteRegistry.ts) — closed once at shutdown via
     // closeAllSqlite(). The registry's at-most-once closed-set + this idempotent
     // closeFn make an explicit unregister unnecessary for this lifetime singleton.
@@ -1355,6 +1380,60 @@ export class TokenLedger {
       firstTs: Number(r.firstTs) || 0,
       lastTs: Number(r.lastTs) || 0,
     }));
+  }
+
+  /**
+   * Bounded Accumulation §4 — prune token_events older than `cutoffMs` in BOUNDED
+   * batches, so a large backlog is spread across calls instead of blocking the event
+   * loop in one synchronous DELETE. Returns { deleted, more } — `more` is true if the
+   * per-call batch cap was hit and another call would prune further. Fail-open
+   * (housekeeping must never throw into the poller).
+   */
+  pruneOlderThan(cutoffMs: number, opts?: { batchSize?: number; maxBatches?: number }): { deleted: number; more: boolean } {
+    if (this.closed) return { deleted: 0, more: false };
+    const batchSize = opts?.batchSize && opts.batchSize > 0 ? opts.batchSize : 5000;
+    const maxBatches = opts?.maxBatches && opts.maxBatches > 0 ? opts.maxBatches : 20;
+    let deleted = 0;
+    let more = false;
+    try {
+      const del = this.db.prepare(
+        `DELETE FROM token_events WHERE request_id IN (SELECT request_id FROM token_events WHERE ts < ? LIMIT ?)`,
+      );
+      for (let b = 0; b < maxBatches; b++) {
+        const n = Number(del.run(cutoffMs, batchSize).changes ?? 0);
+        deleted += n;
+        if (n < batchSize) { more = false; break; }
+        more = true; // hit a full batch — more may remain for the next call
+      }
+      return { deleted, more };
+    } catch {
+      // @silent-fallback-ok: retention prune is best-effort. A failed prune leaves
+      // older rows for the next tick; it must never throw into the poller's cadence.
+      return { deleted, more };
+    }
+  }
+
+  /** Reclaim up to `pages` freed pages (no-op unless auto_vacuum=INCREMENTAL is active). Fail-open. */
+  incrementalVacuum(pages = 1000): void {
+    if (this.closed) return;
+    try {
+      this.db.pragma(`incremental_vacuum(${Math.max(1, Math.floor(pages))})`);
+    } catch {
+      // @silent-fallback-ok: disk reclaim is best-effort; a no-op on a non-auto_vacuum DB is expected.
+    }
+  }
+
+  /**
+   * Driven by the poller each tick when retention is enabled: prune events older than
+   * the configured maxAgeMs (bounded per call) and, if anything was deleted, reclaim a
+   * bounded number of pages. No-op when retention is disabled (ships dark). `nowMs` is
+   * injectable for tests.
+   */
+  pruneToRetention(nowMs: number, opts?: { batchSize?: number; maxBatches?: number }): { deleted: number; more: boolean } {
+    if (!this.retentionEnabled) return { deleted: 0, more: false };
+    const res = this.pruneOlderThan(nowMs - this.retentionMaxAgeMs, opts);
+    if (res.deleted > 0) this.incrementalVacuum();
+    return res;
   }
 
   close(): void {

--- a/src/monitoring/TokenLedgerPoller.ts
+++ b/src/monitoring/TokenLedgerPoller.ts
@@ -32,6 +32,16 @@ export interface TokenLedgerPollerOptions {
   codexProjectDir?: string;
   /** Skip Codex rollouts older than this when scanning. Mirrors the Claude window. */
   codexMaxFileAgeMs?: number;
+  /**
+   * Bounded Accumulation (Increment 2): how often to drive the ledger's retention
+   * prune (TokenLedger.pruneToRetention). Default 6h (matches the feature-metrics
+   * prune cadence). The prune itself is a no-op when retention is disabled on the
+   * ledger, so this always-runs hook is cheap when off. When a prune reports a
+   * remaining backlog (`more`), the next tick prunes again to drain it without one
+   * giant blocking DELETE. */
+  retentionPruneIntervalMs?: number;
+  /** Injectable clock for cadence testing. Default Date.now. */
+  now?: () => number;
 }
 
 export class TokenLedgerPoller {
@@ -46,6 +56,12 @@ export class TokenLedgerPoller {
   private afterTick: (() => void | Promise<void>) | null;
   private codexProjectDir: string | null;
   private codexMaxFileAgeMs: number;
+  private retentionPruneIntervalMs: number;
+  private now: () => number;
+  /** Wall-clock of the last retention prune; 0 = never. */
+  private lastRetentionPruneAtMs = 0;
+  /** True while a backlog prune is draining — forces the next tick to prune again. */
+  private retentionDraining = false;
 
   constructor(opts: TokenLedgerPollerOptions) {
     this.ledger = opts.ledger;
@@ -60,6 +76,34 @@ export class TokenLedgerPoller {
       console.warn('[token-ledger] scan error:', err);
     });
     this.afterTick = opts.afterTick ?? null;
+    this.retentionPruneIntervalMs =
+      opts.retentionPruneIntervalMs && opts.retentionPruneIntervalMs > 0
+        ? opts.retentionPruneIntervalMs
+        : 6 * 60 * 60 * 1000;
+    this.now = opts.now ?? (() => Date.now());
+  }
+
+  /**
+   * Drive the ledger's retention prune on a sub-cadence (the scan runs every
+   * intervalMs; the prune only every retentionPruneIntervalMs). A no-op when
+   * retention is disabled on the ledger. If a prune leaves a backlog (`more`), the
+   * next tick prunes again to drain it gradually rather than in one blocking DELETE.
+   * Fail-open: a prune error is reported and resets the cadence, never throws.
+   */
+  private maybePruneRetention(): void {
+    const now = this.now();
+    if (!this.retentionDraining && now - this.lastRetentionPruneAtMs < this.retentionPruneIntervalMs) {
+      return;
+    }
+    try {
+      const res = this.ledger.pruneToRetention(now);
+      this.lastRetentionPruneAtMs = now;
+      this.retentionDraining = res.more === true;
+    } catch (err) {
+      this.onError(err);
+      this.lastRetentionPruneAtMs = now;
+      this.retentionDraining = false;
+    }
   }
 
   start(): void {
@@ -112,6 +156,9 @@ export class TokenLedgerPoller {
       })
       .finally(() => {
         this.running = false;
+        // Retention prune rides the existing cadence, off the scan path (no-op when
+        // retention is disabled on the ledger). Synchronous + fail-open inside.
+        this.maybePruneRetention();
         if (this.afterTick) {
           Promise.resolve()
             .then(() => this.afterTick!())

--- a/src/server/AgentServer.ts
+++ b/src/server/AgentServer.ts
@@ -920,6 +920,9 @@ export class AgentServer {
           maxFileAgeMs: 30 * 24 * 60 * 60 * 1000, // 30 days
           maxFilesPerScan: 500,
           yieldEveryNFiles: 25,
+          // Bounded Accumulation (Increment 2): per-store retention, dark by default.
+          // The poller drives pruneToRetention on a sub-cadence; a no-op while disabled.
+          retention: options.config.storage?.retention?.tokenLedger,
         });
       }
     } catch (err) {

--- a/tests/unit/token-ledger-poller-retention.test.ts
+++ b/tests/unit/token-ledger-poller-retention.test.ts
@@ -1,0 +1,70 @@
+/**
+ * Bounded Accumulation §4 — the poller drives TokenLedger.pruneToRetention on a
+ * SUB-cadence (the scan runs every intervalMs; the prune only every
+ * retentionPruneIntervalMs), and drains a backlog (more=true) across ticks.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { TokenLedgerPoller } from '../../src/monitoring/TokenLedgerPoller.js';
+
+function fakeLedger(pruneReturn: { deleted: number; more: boolean } = { deleted: 0, more: false }) {
+  return {
+    scanAllAsync: vi.fn(() => Promise.resolve(0)),
+    pruneToRetention: vi.fn(() => pruneReturn),
+  } as unknown as import('../../src/monitoring/TokenLedger.js').TokenLedger;
+}
+
+describe('TokenLedgerPoller — retention prune sub-cadence', () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => { vi.clearAllTimers(); vi.useRealTimers(); });
+
+  it('prunes once initially, then only after the sub-cadence elapses (not every scan tick)', async () => {
+    let now = 1_700_000_000_000;
+    const ledger = fakeLedger();
+    const p = new TokenLedgerPoller({ ledger, intervalMs: 1_000, retentionPruneIntervalMs: 10_000, now: () => now });
+    p.start();
+    await vi.advanceTimersByTimeAsync(0); // immediate first tick @ now0
+    expect(ledger.pruneToRetention).toHaveBeenCalledTimes(1);
+    // 8 scan ticks within the 10s prune window → no extra prune
+    for (let i = 0; i < 8; i++) { now += 1_000; await vi.advanceTimersByTimeAsync(1_000); }
+    expect(ledger.pruneToRetention).toHaveBeenCalledTimes(1);
+    // cross the prune interval (now0 + 10_000) → prune again
+    now += 2_000; await vi.advanceTimersByTimeAsync(1_000);
+    expect(ledger.pruneToRetention).toHaveBeenCalledTimes(2);
+    p.stop();
+  });
+
+  it('drains a backlog: while prune reports more=true, every tick prunes again', async () => {
+    let now = 1_700_000_000_000;
+    const ledger = fakeLedger({ deleted: 5000, more: true });
+    const p = new TokenLedgerPoller({ ledger, intervalMs: 1_000, retentionPruneIntervalMs: 10_000, now: () => now });
+    p.start();
+    await vi.advanceTimersByTimeAsync(0); // tick 1 → prune (more:true → draining)
+    expect(ledger.pruneToRetention).toHaveBeenCalledTimes(1);
+    now += 1_000; await vi.advanceTimersByTimeAsync(1_000); // tick 2, within interval but draining → prune
+    expect(ledger.pruneToRetention).toHaveBeenCalledTimes(2);
+    now += 1_000; await vi.advanceTimersByTimeAsync(1_000); // tick 3, still draining → prune
+    expect(ledger.pruneToRetention).toHaveBeenCalledTimes(3);
+    p.stop();
+  });
+
+  it('a prune error is reported and never throws out of the tick (fail-open)', async () => {
+    let now = 1_700_000_000_000;
+    const errors: unknown[] = [];
+    const ledger = {
+      scanAllAsync: vi.fn(() => Promise.resolve(0)),
+      pruneToRetention: vi.fn(() => { throw new Error('boom'); }),
+    } as unknown as import('../../src/monitoring/TokenLedger.js').TokenLedger;
+    const p = new TokenLedgerPoller({
+      ledger, intervalMs: 1_000, retentionPruneIntervalMs: 10_000, now: () => now,
+      onError: (e) => errors.push(e),
+    });
+    p.start();
+    await vi.advanceTimersByTimeAsync(0);
+    expect(errors.length).toBe(1);
+    // and the poller keeps ticking (scan still runs next interval)
+    (ledger.scanAllAsync as ReturnType<typeof vi.fn>).mockClear();
+    now += 1_000; await vi.advanceTimersByTimeAsync(1_000);
+    expect(ledger.scanAllAsync).toHaveBeenCalledTimes(1);
+    p.stop();
+  });
+});

--- a/tests/unit/token-ledger-retention.test.ts
+++ b/tests/unit/token-ledger-retention.test.ts
@@ -1,0 +1,71 @@
+/**
+ * Bounded Accumulation §4 — TokenLedger SQLite retention (Increment 2).
+ * The 256MB token-ledger was the lone unbounded SQLite store; this proves the
+ * batched, dark-by-default prune deletes old events and keeps recent ones.
+ */
+import { describe, it, expect, afterEach } from 'vitest';
+import Database from 'better-sqlite3';
+import { TokenLedger } from '../../src/monitoring/TokenLedger.js';
+
+const ledgers: TokenLedger[] = [];
+afterEach(() => { for (const l of ledgers.splice(0)) { try { l.close(); } catch { /* ignore */ } } });
+
+function makeLedger(retention?: { enabled?: boolean; maxAgeMs?: number }) {
+  // Create the db INSIDE the factory so TokenLedger's NativeModuleHealer wrapper
+  // (openWithHealSync) covers it — a raw `new Database()` outside the factory would
+  // hit a better-sqlite3 ABI mismatch before any heal could run.
+  let db: any;
+  const ledger = new TokenLedger({
+    dbPath: ':memory:',
+    claudeProjectsDir: '/tmp/does-not-exist-token-retention-test',
+    databaseFactory: () => { db = new Database(':memory:'); return db; },
+    retention,
+  });
+  ledgers.push(ledger);
+  return { ledger, db };
+}
+
+function insert(db: any, requestId: string, ts: number) {
+  db.prepare(
+    `INSERT OR IGNORE INTO token_events (request_id, session_id, ts, input_tokens, output_tokens) VALUES (?, 'sess', ?, 0, 0)`,
+  ).run(requestId, ts);
+}
+function ids(db: any): string[] {
+  return db.prepare('SELECT request_id FROM token_events ORDER BY ts').all().map((r: any) => r.request_id);
+}
+
+const NOW = 1_700_000_000_000;
+
+describe('TokenLedger retention', () => {
+  it('pruneToRetention deletes events older than maxAgeMs, keeps newer', () => {
+    const { ledger, db } = makeLedger({ enabled: true, maxAgeMs: 1000 });
+    insert(db, 'old', NOW - 5000); // older than the 1s window → pruned
+    insert(db, 'fresh', NOW - 200); // within the window → kept
+    const res = ledger.pruneToRetention(NOW);
+    expect(res.deleted).toBe(1);
+    expect(ids(db)).toEqual(['fresh']);
+  });
+
+  it('is a NO-OP when retention is disabled (ships dark)', () => {
+    const { ledger, db } = makeLedger({ enabled: false });
+    insert(db, 'ancient', NOW - 10 ** 11);
+    expect(ledger.pruneToRetention(NOW).deleted).toBe(0);
+    expect(ids(db)).toEqual(['ancient']);
+  });
+
+  it('pruneOlderThan batches and reports more=true when the per-call cap is hit', () => {
+    const { ledger, db } = makeLedger({ enabled: true, maxAgeMs: 0 });
+    const ins = db.prepare(
+      `INSERT OR IGNORE INTO token_events (request_id, session_id, ts, input_tokens, output_tokens) VALUES (?, 'sess', ?, 0, 0)`,
+    );
+    db.transaction(() => { for (let i = 0; i < 25; i++) ins.run('e' + i, NOW - 1); })();
+    const res = ledger.pruneOlderThan(NOW, { batchSize: 10, maxBatches: 2 });
+    expect(res.deleted).toBe(20); // 2 batches × 10
+    expect(res.more).toBe(true); // cap hit → more remain
+    // a follow-up call drains the rest
+    const rest = ledger.pruneOlderThan(NOW, { batchSize: 10, maxBatches: 5 });
+    expect(rest.deleted).toBe(5);
+    expect(rest.more).toBe(false);
+    expect(ids(db)).toEqual([]);
+  });
+});

--- a/upgrades/next/bounded-accumulation-increment-2-token-ledger.md
+++ b/upgrades/next/bounded-accumulation-increment-2-token-ledger.md
@@ -1,0 +1,46 @@
+<!-- bump: minor -->
+<!-- change_type: feature -->
+
+## What Changed
+
+The token-usage ledger (`token-ledger.db`) was the single biggest unbounded store on disk —
+observed at 256 MB — because it kept every token-usage event forever with no trimming. This adds
+the Bounded Accumulation standard's retention to it: events older than a configurable window
+(default 30 days) are deleted in small batches off the busy path, and freed space is reclaimed
+incrementally (no slow, locking full-database rewrite). It ships **off by default** — the ledger
+is read-only observability that can be re-derived from the underlying transcripts, so trimming is
+opt-in per agent.
+
+## What to Tell Your User
+
+If your agent's token-usage database has grown large, you can now cap it: turn on retention and it
+keeps the last 30 days (configurable) of token-usage history instead of everything, forever.
+Nothing changes unless you enable it. The historical token totals you see in the dashboard stay
+accurate within the retention window; older raw events are dropped (they can be re-scanned from
+the Claude Code transcripts if needed).
+
+## Summary of New Capabilities
+
+- `storage.retention.tokenLedger` config: `{ enabled?: boolean (default false), maxAgeMs?: number
+  (default 30d) }`.
+- `TokenLedger` gains a batched, bounded-per-call `pruneOlderThan` + `incrementalVacuum` +
+  `pruneToRetention`, and sets `auto_vacuum=INCREMENTAL` on fresh databases so retention can
+  reclaim disk without a full VACUUM (the existing oversized file reclaims after the one-time
+  Increment-3 cleanup; until then retention still bounds its row count).
+- `TokenLedgerPoller` drives the prune on a 6-hour sub-cadence (the transcript scan stays at its
+  normal cadence), draining a large first-time backlog gradually so it never blocks the loop in
+  one statement.
+
+## Evidence
+
+**Before:** `token-ledger.db` had no DELETE/VACUUM anywhere (confirmed in `TokenLedger.ts`); it
+only ever grew (256 MB observed on Echo, 2026-06-21). `ResourceLedger` already had
+`pruneOlderThan`, proving token-ledger was the lone unbounded SQLite store.
+
+**After:** with retention enabled, `pruneToRetention(now)` deletes `token_events` where
+`ts < now − maxAgeMs` in bounded batches and reclaims pages; with it disabled (the default) it is
+a no-op. Reproduced by unit tests: `token-ledger-retention.test.ts` (prunes old / keeps fresh;
+no-op when disabled; batches and reports a remaining backlog) and `token-ledger-poller-retention.test.ts`
+(prunes on the 6h sub-cadence not every scan; drains a backlog across ticks; a prune error is
+reported and never throws out of the tick). No regression to the existing poller cadence
+(`token-ledger-poller-idle.test.ts` green).

--- a/upgrades/side-effects/bounded-accumulation-increment-2-token-ledger.md
+++ b/upgrades/side-effects/bounded-accumulation-increment-2-token-ledger.md
@@ -1,0 +1,97 @@
+# Side-Effects Review — Bounded Accumulation Increment 2a: token-ledger SQLite retention
+
+**Slug:** `bounded-accumulation-increment-2-token-ledger` · **Tier:** 2 (spec-driven; the
+Bounded Accumulation spec converged + operator-approved, merged in #1241)
+**Spec:** `docs/specs/bounded-accumulation-standard.md` §4 (SQLite class) + §6 D1.
+
+## Summary of the change
+
+Retrofits the single largest unbounded store — `token-ledger.db` (256MB, the lone SQLite
+store with no retention; ResourceLedger already prunes) — with the standard's bounded
+retention, behind a dark-by-default config flag:
+- `TokenLedger`: `auto_vacuum=INCREMENTAL` pragma (set before table creation, so it takes
+  effect on FRESH DBs and is a safe no-op on the existing un-converted file); `pruneOlderThan`
+  (BATCHED, bounded-per-call DELETE so a huge backlog never blocks the loop in one statement);
+  `incrementalVacuum` (reclaim freed pages); `pruneToRetention` (no-op when disabled).
+- `TokenLedgerPoller`: drives `pruneToRetention` on a 6h SUB-cadence (the scan stays 60s),
+  off the scan path; a reported backlog (`more`) drains across subsequent ticks.
+- `InstarConfig.storage.retention.tokenLedger` (`enabled` default false, `maxAgeMs` default 30d).
+- `AgentServer` wires the config to the ledger.
+
+## Decision-point inventory
+
+Frozen in spec §6: D1 token-ledger window = 30 days (default), SQLite mechanics =
+`auto_vacuum=INCREMENTAL` + batched delete + incremental_vacuum off the request path on a 6h
+timer (mirrors the real feature-metrics prune). No decision is introduced at the callsite.
+
+## 1. Over-block / data loss
+
+The prune deletes token_events older than `maxAgeMs` (default 30d). token-ledger is read-only
+observability, re-derivable from Claude Code transcripts (the §5 re-derivability caveat). Ships
+DARK (`enabled` defaults false) — zero deletion until an operator opts in, so there is no
+surprise data loss. Batched + bounded so it never blocks the event loop.
+
+## 2. Under-block
+
+Disabled by default → no enforcement until opted in (intentional dark rollout, spec §6). The
+existing 256MB file's DISK is not reclaimed until the one-time Increment-3 VACUUM converts it to
+auto_vacuum; until then the prune still bounds the ROW COUNT (stops further growth). Stated, not
+hidden.
+
+## 4. Signal vs authority
+
+No gate/block. The retention is housekeeping driven by the existing poller cadence; it takes no
+destructive action beyond deleting aged observability rows it owns. Fail-open throughout
+(`@silent-fallback-ok` on every prune/vacuum catch — a failed prune leaves rows for the next
+tick, never throws into the poller).
+
+## 5. Interactions
+
+`pruneToRetention` is a no-op when disabled, so the poller's new sub-cadence call is inert on
+every current agent (flag defaults false). The auto_vacuum pragma is a no-op on the existing
+256MB file (only fresh DBs convert). No existing TokenLedger query/insert path is changed. The
+poller's scan cadence is unchanged (prune rides a separate 6h sub-cadence).
+
+## 6. External surfaces
+
+No new route. One new config field (`storage.retention.tokenLedger`), additive + optional. The
+`/tokens/*` routes are unaffected (same data, just aged-out beyond the window when enabled).
+
+## 6b. Operator-surface quality
+
+N/A — no operator/dashboard/approval surface. Enabling is a config edit (a future increment may
+add a dashboard toggle).
+
+## Framework generality
+
+N/A — TokenLedger is framework-agnostic observability (scans Claude Code + Codex transcripts);
+not part of the session launch/inject abstraction.
+
+## 7. Multi-machine posture
+
+token-ledger.db is `derived-cache` / machine-local by design (each machine scans its own
+transcripts). Retention is per-machine; no replicated state. Safe on single- and multi-machine.
+
+## 8. Rollback cost
+
+Trivial: the feature is dark (default false), so reverting is removing an unused code path. An
+operator who enabled it sets `enabled:false` to stop pruning (already-deleted rows are
+re-derivable from transcripts within their own retention). The auto_vacuum pragma is harmless
+(no-op on existing files).
+
+## Evidence pointers
+
+- `tests/unit/token-ledger-retention.test.ts` (3): prunes-old/keeps-new; no-op-when-disabled;
+  batched prune reports `more` + a follow-up call drains the rest. (CI-run: better-sqlite3 ABI
+  is rebuilt for CI's Node; these can't execute in a dev worktree on a mismatched Node — the
+  existing token-ledger.test.ts has the same constraint.)
+- `tests/unit/token-ledger-poller-retention.test.ts` (3, run locally with a fake ledger): prunes
+  on the sub-cadence not every scan; drains a backlog while `more`; a prune error is reported and
+  never throws out of the tick (fail-open).
+- Existing `token-ledger-poller-idle.test.ts` (3) still green → no regression to the cadence.
+
+## Conclusion
+
+Caps the biggest disk hog (256MB token-ledger) with a dark-by-default, batched, non-blocking,
+fail-open retention prune driven off the existing poller cadence. Zero behavior change until an
+operator opts in. Ship.


### PR DESCRIPTION
## What & why

**Bounded Accumulation Increment 2a** — retrofits real retention onto the single biggest
unbounded store: `token-ledger.db` (observed at **256 MB** on Echo; the lone SQLite store with no
retention — `ResourceLedger` already pruned). Follows the standard + Increment-1 substrate merged
in #1241.

Ships **dark by default** (`storage.retention.tokenLedger.enabled` defaults false): the ledger is
read-only observability re-derivable from transcripts, so trimming is opt-in per agent.

- `TokenLedger`: `auto_vacuum=INCREMENTAL` (effective on fresh DBs; safe no-op on the existing
  un-converted file until the Increment-3 VACUUM) + batched, bounded-per-call `pruneOlderThan`
  (never one blocking DELETE) + `incrementalVacuum` + `pruneToRetention` (no-op when disabled).
- `TokenLedgerPoller`: drives the prune on a 6-hour sub-cadence off the scan path; drains a
  first-time backlog gradually via the `more` signal.
- `config.storage.retention.tokenLedger` `{ enabled=false, maxAgeMs=30d }`; `AgentServer` wires it.

## ELI16 — capping the token-usage database

Your agent keeps a little database of every token-usage event (to show you cost/usage). The
problem: it never deleted anything, so it grew to 256 MB. This adds an off-by-default switch:
turn it on and the database keeps the last 30 days (you choose) and deletes older events in small
batches, in the background, so it never freezes the agent — and reclaims the freed space bit by
bit instead of one slow full rewrite. Off by default, because the data can be rebuilt from the
underlying transcripts if you ever need the old events back. Nothing changes until you flip the
switch.

## Tier

Tier 2 — spec-driven (the Bounded Accumulation standard converged + operator-approved, #1241).

## Test plan

- `tests/unit/token-ledger-retention.test.ts` (3): prunes-old/keeps-fresh; no-op-when-disabled;
  batched prune reports a remaining backlog + a follow-up call drains it. **(CI-run** — real
  better-sqlite3; a dev worktree on a mismatched Node ABI can't execute it, same constraint as the
  existing `token-ledger.test.ts`.)
- `tests/unit/token-ledger-poller-retention.test.ts` (3, runs locally with a fake ledger): prunes
  on the 6h sub-cadence not every scan; drains a backlog across ticks; a prune error is reported and
  never throws out of the tick (fail-open).
- Existing `token-ledger-poller-idle.test.ts` (3) green → no regression to the cadence.
- Local `npm run lint` + `tsc` green (including the new retention lints, now live from #1241).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
