### PR TITLE
feat(intelligence): Resilient Degradation Ladder §4 — never-silent tracking (dark)

### DIFF
--- a/.instar/instar-dev-decisions/2026-06-22T02-40-21-970Z-resilient-degradation-ladder-increment-2.json
+++ b/.instar/instar-dev-decisions/2026-06-22T02-40-21-970Z-resilient-degradation-ladder-increment-2.json
@@ -1,0 +1,19 @@
+{
+  "ts": "2026-06-22T02:40:21.970Z",
+  "slug": "resilient-degradation-ladder-increment-2",
+  "suggestedTier": 2,
+  "declaredTier": 2,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 4,
+  "loc": 197,
+  "causalAutopsy": {
+    "origin": "prior-pr",
+    "relatedPrs": [
+      1243
+    ],
+    "notes": "Increment 2 of the degradation ladder (#3), building on the ladder core shipped in #1243. Adds the never-silent tracking — the half of the operator's principle that says a fallback must never silently persist. The §4 design (bounded, reentrancy-safe, liveness-gated) is the direct response to the 2026-06-21 DegradationReporter event-loop wedge this extends."
+  },
+  "verdict": "pass"
+}

--- a/.instar/instar-dev-decisions/2026-06-22T03-00-07-401Z-resilient-degradation-ladder-increment-2.json
+++ b/.instar/instar-dev-decisions/2026-06-22T03-00-07-401Z-resilient-degradation-ladder-increment-2.json
@@ -1,0 +1,19 @@
+{
+  "ts": "2026-06-22T03:00:07.401Z",
+  "slug": "resilient-degradation-ladder-increment-2",
+  "suggestedTier": 1,
+  "declaredTier": 2,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 2,
+  "loc": 11,
+  "causalAutopsy": {
+    "origin": "prior-pr",
+    "relatedPrs": [
+      1243
+    ],
+    "notes": "Increment 2 of the degradation ladder (#3), building on the ladder core shipped in #1243. Adds the never-silent tracking — the half of the operator's principle that says a fallback must never silently persist. The §4 design (bounded, reentrancy-safe, liveness-gated) is the direct response to the 2026-06-21 DegradationReporter event-loop wedge this extends."
+  },
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-06-22T03-00-56-900Z-resilient-degradation-ladder-increment-2.json
+++ b/.instar/instar-dev-decisions/2026-06-22T03-00-56-900Z-resilient-degradation-ladder-increment-2.json
@@ -1,0 +1,19 @@
+{
+  "ts": "2026-06-22T03:00:56.900Z",
+  "slug": "resilient-degradation-ladder-increment-2",
+  "suggestedTier": 2,
+  "declaredTier": 2,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 4,
+  "loc": 202,
+  "causalAutopsy": {
+    "origin": "prior-pr",
+    "relatedPrs": [
+      1243
+    ],
+    "notes": "Increment 2 of the degradation ladder (#3), building on the ladder core shipped in #1243. Adds the never-silent tracking — the half of the operator's principle that says a fallback must never silently persist. The §4 design (bounded, reentrancy-safe, liveness-gated) is the direct response to the 2026-06-21 DegradationReporter event-loop wedge this extends."
+  },
+  "verdict": "pass"
+}

--- a/src/commands/server.ts
+++ b/src/commands/server.ts
@@ -5031,6 +5031,17 @@ export async function startServer(options: StartOptions): Promise<void> {
               });
             } catch { /* never break the LLM path on a degradation report */ }
           },
+          // Never-silent tracking (Resilient Degradation Ladder §4): a non-gating call that
+          // exhausts the ladder (→ caller heuristic) opens a tracked degradation; a successful
+          // real-LLM answer auto-resolves it. No-ops downstream when neverSilent is disabled.
+          onHeuristicFallthrough: (component, framework) => {
+            try { DegradationReporter.getInstance().openDegradation(component, framework); }
+            catch { /* @silent-fallback-ok: a never-silent tracking hook must NEVER throw into the LLM call path; a failed open just skips this tracking tick (the next fallthrough re-opens). */ }
+          },
+          onResolved: (component, framework) => {
+            try { DegradationReporter.getInstance().resolveDegradation(component, framework); }
+            catch { /* @silent-fallback-ok: a never-silent tracking hook must NEVER throw into the LLM call path; a failed resolve just leaves the open degradation for the next success/sweep. */ }
+          },
         });
       } catch (err) {
         console.warn(`[server] IntelligenceRouter failed to initialize, using unrouted provider: ${err}`);
@@ -18506,6 +18517,24 @@ export async function startServer(options: StartOptions): Promise<void> {
         // ops-pager output. See upgrades/side-effects/agent-health-alert-authority-routing.md.
         toneGate: messagingToneGate ?? null,
       });
+      // Never-silent degradation tracking (Resilient Degradation Ladder §4): dev-gated
+      // (live-on-dev / dark-on-fleet via resolveDevAgentGate). When enabled, a timer drives the
+      // level-triggered sweep that escalates a genuinely-stuck heuristic-fallback and TTL-closes an
+      // idle one. The sweep NEVER calls report() — reentrancy-safe (the 2026-06-21 wedge).
+      const nsCfg = config.intelligence?.degradationLadder?.neverSilent;
+      const nsEnabled = resolveDevAgentGate(nsCfg?.enabled, config);
+      degradationReporter.configureNeverSilent({
+        enabled: nsEnabled,
+        escalateMs: nsCfg?.escalateMs,
+        maxOpen: nsCfg?.maxOpen,
+      });
+      if (nsEnabled) {
+        const nsSweepTimer = setInterval(() => {
+          try { degradationReporter.sweepOpenDegradations(); }
+          catch { /* @silent-fallback-ok: the never-silent sweep is best-effort level-triggered housekeeping; a single failed tick must not stall the timer (the next tick re-sweeps the same open map). */ }
+        }, 60_000);
+        nsSweepTimer.unref?.();
+      }
     }
 
     // Tier-2 live-mode wire-up (SELF-HEALING-REMEDIATOR-V2-SPEC §A57).

--- a/src/core/IntelligenceRouter.ts
+++ b/src/core/IntelligenceRouter.ts
@@ -89,6 +89,15 @@ export interface IntelligenceRouterOptions {
   /** Optional: invoked when a routed call degrades to the default framework (for DegradationReporter). */
   onDegrade?: (info: RouterDegradeInfo) => void;
   /**
+   * Never-silent tracking (Resilient Degradation Ladder §4). `onHeuristicFallthrough` fires when a
+   * NON-gating call exhausts the ladder and throws (the caller will use its heuristic) — the
+   * DegradationReporter opens/refreshes a degradation. `onResolved` fires on a SUCCESSFUL real-LLM
+   * answer for that (component, framework) — the reporter auto-resolves any open degradation. Both
+   * are no-ops downstream when never-silent tracking is disabled, so the router calls them freely.
+   */
+  onHeuristicFallthrough?: (component: string, framework: string) => void;
+  onResolved?: (component: string, framework: string) => void;
+  /**
    * Resilient Degradation Ladder (docs/specs/resilient-degradation-ladder.md), RESOLVED at the
    * construction site (the dev-agent gate is applied there, so `*Enabled` are already the
    * gate-resolved booleans). Absent ⇒ no ladder (today's framework-swap-only behavior). The ladder
@@ -235,7 +244,9 @@ export class IntelligenceRouter implements IntelligenceProvider {
 
     let err: unknown;
     try {
-      return await primary.evaluate(prompt, options);
+      const mainResult = await primary.evaluate(prompt, options);
+      this.opts.onResolved?.(component ?? '(none)', framework); // a real answer → auto-resolve any open degradation
+      return mainResult;
     } catch (firstErr) {
       err = firstErr;
       // RUNG (a) — DEFERRABLE backoff: slow down and retry the SAME provider BEFORE swapping, by
@@ -248,14 +259,21 @@ export class IntelligenceRouter implements IntelligenceProvider {
           const delay = Math.min(b.baseMs * Math.pow(b.factor, attempt), b.ceilingMs);
           const jittered = Math.min(Math.floor(delay * (0.5 + Math.random() * 0.5)), b.maxWaitMs);
           try {
-            return await primary.evaluate(prompt, { ...(options ?? {}), rateLimitWaitMs: jittered });
+            const boResult = await primary.evaluate(prompt, { ...(options ?? {}), rateLimitWaitMs: jittered });
+            this.opts.onResolved?.(component ?? '(none)', framework); // recovered on backoff → auto-resolve
+            return boResult;
           } catch (retryErr) {
             err = retryErr;
             if (!isRateLimitError(retryErr)) break; // a hard error → stop backing off, go to swap
           }
         }
       }
-      if (swapTargets.length === 0) throw err; // not gating/deferrable, or no swap configured ⇒ today's behavior
+      if (swapTargets.length === 0) {
+        // Non-gating ⇒ the caller will swallow this into its heuristic — track it (never-silent).
+        // Gating ⇒ this is a fail-closed, NOT a heuristic, so it is not tracked.
+        if (!gating) this.opts.onHeuristicFallthrough?.(component ?? '(none)', framework);
+        throw err; // not gating/deferrable, or no swap configured ⇒ today's behavior
+      }
       // §4.5 bounded per-attempt swap timeout: a positive cap races each attempt so a
       // slow-but-not-erroring provider is abandoned at the cap (total swap latency ≤
       // cap × (1 + tail.length)) instead of stacking long waits and re-creating the
@@ -299,6 +317,7 @@ export class IntelligenceRouter implements IntelligenceProvider {
             to: target,
             reason: `failure-swap: '${framework}' failed (${err instanceof Error ? err.message : 'error'}); served by '${target}'`,
           });
+          this.opts.onResolved?.(component ?? '(none)', framework); // real answer via swap → auto-resolve
           return result;
         } catch (attemptErr) {
           // A timed-out attempt emits a distinct degrade reason so the cap firing is
@@ -320,7 +339,9 @@ export class IntelligenceRouter implements IntelligenceProvider {
         }
       }
       // Every swap target is also down → re-throw so the (gating) caller fails CLOSED,
-      // never silently degrading to a brittle heuristic.
+      // never silently degrading to a brittle heuristic. A NON-gating caller WILL swallow this into
+      // its heuristic, so track it (never-silent §4); a gating fail-closed is not a heuristic.
+      if (!gating) this.opts.onHeuristicFallthrough?.(component ?? '(none)', framework);
       throw err;
     }
   }

--- a/src/core/devGatedFeatures.ts
+++ b/src/core/devGatedFeatures.ts
@@ -379,7 +379,13 @@ export const DEV_GATED_FEATURES: DevGatedFeature[] = [
     name: 'degradationLadderBackoff',
     configPath: 'intelligence.degradationLadder.backoff.enabled',
     description: 'Resilient Degradation Ladder v1 (resilient-degradation-ladder.md) — the DEFERRABLE backoff rung (slow down + retry the same provider on a rate-limit via options.rateLimitWaitMs before swapping) + the GATING-call responsiveness budget (gatingLadderBudgetMs, default 6s).',
-    justification: 'Internal-call routing only; behavior-preserving when off (absent ladder = EXACTLY today\'s framework-swap-only behavior). On a dev agent it runs live: backoff only adds bounded, jittered waits to DEFERRABLE (non-awaited, background) calls on a rate-limit, and the gating budget only caps the awaited-gate failure path at 6s — MORE responsive, never less safe (a gate still fails closed, never degrades to a heuristic). No spend increase (same call count or fewer), no destructive action, no egress. Queue + never-silent rungs land in later increments.',
+    justification: 'Internal-call routing only; behavior-preserving when off (absent ladder = EXACTLY today\'s framework-swap-only behavior). On a dev agent it runs live: backoff only adds bounded, jittered waits to DEFERRABLE (non-awaited, background) calls on a rate-limit, and the gating budget only caps the awaited-gate failure path at 6s — MORE responsive, never less safe (a gate still fails closed, never degrades to a heuristic). No spend increase (same call count or fewer), no destructive action, no egress. Queue rung lands in a later increment.',
+  },
+  {
+    name: 'degradationLadderNeverSilent',
+    configPath: 'intelligence.degradationLadder.neverSilent.enabled',
+    description: 'Resilient Degradation Ladder §4 — never-silent degradation tracking: a non-gating call that exhausts the ladder (→ caller heuristic) opens a tracked degradation; a successful real-LLM answer auto-resolves it; a genuinely-stuck one (≥1 retry, open past 15m) escalates ONE deduped attention item; a run-once/idle one TTL-auto-closes (no false alarm).',
+    justification: 'Observe-and-escalate only — opens/resolves an in-memory map and, on a genuinely-stuck degradation, sends ONE deduped fixed-template attention line. Designed to NOT repeat the 2026-06-21 DegradationReporter wedge: bounded (MAX_OPEN), O(1) per open/resolve, the sweep NEVER calls report()/reportEvent()/gateHealthAlert (it surfaces via telegramSender directly), liveness-gated (a run-once component auto-closes, never escalates). No spend, no destructive action; the only egress is the deduped escalation line the operator explicitly wants ("never silently degraded"). No-op when off.',
   },
 ];
 

--- a/src/monitoring/DegradationReporter.ts
+++ b/src/monitoring/DegradationReporter.ts
@@ -164,7 +164,7 @@ function monotonicNow(): number {
     if (typeof performance !== 'undefined' && typeof performance.now === 'function') {
       return performance.now();
     }
-  } catch { /* environments without performance API */ }
+  } catch { /* @silent-fallback-ok: environment-capability probe, not a degradation — a runtime without the `performance` API falls back to `Date.now()`; a clock-source probe is low-risk and not a reportable degradation. */ }
   return Date.now();
 }
 
@@ -177,6 +177,20 @@ function monotonicNow(): number {
 const RESTART_QUEUE_MAX_ENTRIES = 1000;
 const RESTART_QUEUE_MAX_BYTES = 5 * 1024 * 1024; // 5 MiB
 const RESTART_QUEUE_REL_PATH = path.join('remediation', 'degradations-queue.jsonl');
+
+/**
+ * An open heuristic-fallback degradation (Resilient Degradation Ladder §4). Keyed on
+ * (component, framework). `retryAttempts` is the LIVENESS signal — the number of times a
+ * real-LLM call for this key was attempted and STILL failed since it opened; 0 means the
+ * component degraded once and hasn't tried again (idle/run-once, not stuck → TTL-close).
+ */
+interface OpenDegradation {
+  component: string;
+  framework: string;
+  openedAt: number;
+  retryAttempts: number;
+  lastEscalatedAt: number | null;
+}
 
 export class DegradationReporter {
   private static instance: DegradationReporter | null = null;
@@ -205,6 +219,21 @@ export class DegradationReporter {
 
   // Dedup: track last alert time per feature to avoid spamming Telegram
   private lastAlertTime: Map<string, number> = new Map();
+
+  // ── Never-silent degradation lifecycle (Resilient Degradation Ladder §4) ──────
+  // Tracks open heuristic-fallback degradations so one can NEVER silently persist
+  // indefinitely (the operator's principle). Designed to NOT repeat the 2026-06-21
+  // wedge: bounded (MAX_OPEN), O(1) per open/resolve (no full-map serialize), the
+  // escalation sweep NEVER calls report()/reportEvent()/gateHealthAlert (it surfaces
+  // via telegramSender directly), and it is liveness-gated (a run-once/idle component
+  // auto-closes via TTL rather than escalating a false alarm).
+  private openDegradations: Map<string, OpenDegradation> = new Map();
+  private neverSilentEnabled = false;
+  private neverSilentEscalateMs = 15 * 60_000; // 15m before a persistent open escalates
+  private neverSilentTtlMs = 30 * 60_000;       // idle/run-once auto-close window
+  private neverSilentMaxOpen = 500;             // hard cap on the open map (anti-wedge)
+  /** Injectable clock for the lifecycle (testing). Default Date.now. */
+  private neverSilentNow: () => number = () => Date.now();
 
   // F-3 additions ─────────────────────────────────────────────
   // The Remediator dispatch hook (F-8 wires the consumer). When set, the
@@ -289,6 +318,111 @@ export class DegradationReporter {
    */
   registerHealer(feature: string, healer: SelfHealer): void {
     this.healers.set(feature, healer);
+  }
+
+  // ── Never-silent degradation lifecycle (Resilient Degradation Ladder §4) ──────
+
+  /** Configure (and enable) never-silent tracking. Called once at server startup with the
+   *  dev-gate-resolved `enabled`. `now` is injectable for tests. */
+  configureNeverSilent(opts: {
+    enabled: boolean;
+    escalateMs?: number;
+    ttlMs?: number;
+    maxOpen?: number;
+    now?: () => number;
+  }): void {
+    this.neverSilentEnabled = opts.enabled === true;
+    if (opts.escalateMs && opts.escalateMs > 0) this.neverSilentEscalateMs = opts.escalateMs;
+    if (opts.ttlMs && opts.ttlMs > 0) this.neverSilentTtlMs = opts.ttlMs;
+    if (opts.maxOpen && opts.maxOpen > 0) this.neverSilentMaxOpen = opts.maxOpen;
+    if (opts.now) this.neverSilentNow = opts.now;
+    this.openDegradations.clear(); // fresh config = fresh state (startup is empty; gives test isolation)
+  }
+
+  private nsKey(component: string, framework: string): string {
+    return component + '::' + framework;
+  }
+
+  /**
+   * A heuristic fallback fired for (component, framework) — open a degradation, or if one is
+   * already open, increment its retry-attempts (the liveness signal: it tried again and STILL
+   * failed → stuck). Bounded by MAX_OPEN (oldest evicted), O(1). No-op when disabled.
+   */
+  openDegradation(component: string, framework: string): void {
+    if (!this.neverSilentEnabled) return;
+    const k = this.nsKey(component, framework);
+    const existing = this.openDegradations.get(k);
+    if (existing) {
+      existing.retryAttempts++; // a re-attempt that also fell to heuristic = it's genuinely stuck
+      return;
+    }
+    if (this.openDegradations.size >= this.neverSilentMaxOpen) {
+      const oldest = this.openDegradations.keys().next().value; // Map preserves insertion order
+      if (oldest !== undefined) this.openDegradations.delete(oldest);
+    }
+    this.openDegradations.set(k, {
+      component, framework, openedAt: this.neverSilentNow(), retryAttempts: 0, lastEscalatedAt: null,
+    });
+  }
+
+  /**
+   * A real-LLM call for (component, framework) SUCCEEDED — auto-resolve the open degradation
+   * (the never-silent recovery). Returns the degraded duration (ms) or null if none was open.
+   * O(1). No-op when disabled.
+   */
+  resolveDegradation(component: string, framework: string): number | null {
+    if (!this.neverSilentEnabled) return null;
+    const k = this.nsKey(component, framework);
+    const d = this.openDegradations.get(k);
+    if (!d) return null;
+    this.openDegradations.delete(k);
+    return this.neverSilentNow() - d.openedAt;
+  }
+
+  /** Count of currently-open degradations (observability). */
+  openDegradationCount(): number {
+    return this.openDegradations.size;
+  }
+
+  /**
+   * Level-triggered sweep (timer-driven): escalate a degradation OPEN past escalateMs that has
+   * genuinely retried (≥1), and TTL-auto-close an idle/run-once one (0 retries past ttlMs). Deduped
+   * per episode (re-escalates only after another full window). REENTRANCY-SAFE: it NEVER calls
+   * report()/reportEvent()/gateHealthAlert — it surfaces via telegramSender directly (the 2026-06-21
+   * wedge was that recursion). No-op when disabled.
+   */
+  sweepOpenDegradations(): void {
+    if (!this.neverSilentEnabled) return;
+    const now = this.neverSilentNow();
+    for (const [k, d] of this.openDegradations) {
+      const age = now - d.openedAt;
+      if (d.retryAttempts === 0) {
+        // Idle / run-once: degraded once, never retried → done, not stuck. Auto-close at the TTL.
+        if (age > this.neverSilentTtlMs) this.openDegradations.delete(k);
+        continue;
+      }
+      if (age > this.neverSilentEscalateMs &&
+          (d.lastEscalatedAt === null || now - d.lastEscalatedAt > this.neverSilentEscalateMs)) {
+        d.lastEscalatedAt = now;
+        this.escalatePersistentDegradation(d, age);
+      }
+    }
+  }
+
+  /** Surface a persistent-degradation attention item DIRECTLY (fixed template, no toneGate, no
+   *  report — reentrancy-safe per §4). Best-effort; never throws into the sweep. */
+  private escalatePersistentDegradation(d: OpenDegradation, ageMs: number): void {
+    try {
+      if (!this.telegramSender || this.alertTopicId === null) return;
+      const mins = Math.round(ageMs / 60_000);
+      const msg =
+        `⚠ ${d.component} has been on its heuristic fallback for ~${mins}m — the real-LLM path ` +
+        `(${d.framework}) hasn't recovered. It auto-clears the next time an LLM call for it succeeds.`;
+      void this.telegramSender(this.alertTopicId, msg);
+    } catch {
+      // @silent-fallback-ok: escalation is best-effort; a send failure must never throw into the
+      // level-triggered sweep (which would stall the timer). The next sweep retries.
+    }
   }
 
   /**

--- a/tests/unit/degradation-ladder.test.ts
+++ b/tests/unit/degradation-ladder.test.ts
@@ -134,3 +134,43 @@ describe('Resilient Degradation Ladder — IntelligenceRouter', () => {
     expect(calls).toBe(1);
   });
 });
+
+describe('Resilient Degradation Ladder — never-silent hooks (§4)', () => {
+  it('onResolved fires on a successful call with (component, framework)', async () => {
+    const resolved: Array<[string, string]> = [];
+    const primary: IntelligenceProvider = { async evaluate() { return 'ok'; } };
+    const router = new IntelligenceRouter({
+      defaultProvider: primary, defaultFramework: 'claude-code',
+      resolveConfig: () => ({}), buildProvider: () => null,
+      onResolved: (c, f) => resolved.push([c, f]),
+    });
+    await router.evaluate('x', { attribution: { component: 'Comp' } });
+    expect(resolved).toEqual([['Comp', 'claude-code']]);
+  });
+
+  it('onHeuristicFallthrough fires when a NON-gating call exhausts (caller will use its heuristic)', async () => {
+    const fell: Array<[string, string]> = [];
+    const primary: IntelligenceProvider = { async evaluate() { throw new Error('down'); } };
+    const router = new IntelligenceRouter({
+      defaultProvider: primary, defaultFramework: 'claude-code',
+      resolveConfig: () => ({}), buildProvider: () => null,
+      onHeuristicFallthrough: (c, f) => fell.push([c, f]),
+    });
+    await expect(router.evaluate('x', { attribution: { component: 'Adv' } })).rejects.toThrow();
+    expect(fell).toEqual([['Adv', 'claude-code']]);
+  });
+
+  it('onHeuristicFallthrough does NOT fire for a GATING call (fail closed is not a heuristic)', async () => {
+    const fell: Array<[string, string]> = [];
+    const primary: IntelligenceProvider = { async evaluate() { throw new Error('down'); } };
+    const swap: IntelligenceProvider = { async evaluate() { throw new Error('swap down'); } };
+    const router = new IntelligenceRouter({
+      defaultProvider: primary, defaultFramework: 'claude-code',
+      resolveConfig: () => ({ failureSwap: ['codex-cli'] }),
+      buildProvider: (fw: IntelligenceFramework) => (fw === 'codex-cli' ? swap : null),
+      onHeuristicFallthrough: (c, f) => fell.push([c, f]),
+    });
+    await expect(router.evaluate('x', GATING)).rejects.toThrow();
+    expect(fell).toEqual([]); // gating → fail closed, never a heuristic-fallthrough
+  });
+});

--- a/tests/unit/degradation-never-silent.test.ts
+++ b/tests/unit/degradation-never-silent.test.ts
@@ -1,0 +1,85 @@
+/**
+ * Resilient Degradation Ladder §4 — never-silent degradation tracking in
+ * DegradationReporter. Designed to NOT repeat the 2026-06-21 event-loop wedge:
+ * bounded, O(1), reentrancy-safe (sweep surfaces via telegramSender, never report()),
+ * liveness-gated (run-once auto-closes, only a genuinely-stuck one escalates).
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import { DegradationReporter } from '../../src/monitoring/DegradationReporter.js';
+
+let now = 1_700_000_000_000;
+let sent: Array<{ topic: number; text: string }>;
+
+function setup(enabled = true, escalateMs = 1000, ttlMs = 5000, maxOpen = 500) {
+  now = 1_700_000_000_000;
+  sent = [];
+  const r = DegradationReporter.getInstance();
+  r.connectDownstream({ telegramSender: async (topic, text) => { sent.push({ topic, text }); }, alertTopicId: 42 });
+  r.configureNeverSilent({ enabled, escalateMs, ttlMs, maxOpen, now: () => now });
+  return r;
+}
+
+describe('DegradationReporter — never-silent lifecycle', () => {
+  beforeEach(() => setup());
+
+  it('open then resolve returns the degraded duration and clears the open count', () => {
+    const r = setup();
+    r.openDegradation('Sentinel', 'claude-code');
+    expect(r.openDegradationCount()).toBe(1);
+    now += 3000;
+    expect(r.resolveDegradation('Sentinel', 'claude-code')).toBe(3000);
+    expect(r.openDegradationCount()).toBe(0);
+  });
+
+  it('a run-once degradation (0 retries) AUTO-CLOSES at the TTL — never escalates (no false alarm)', () => {
+    const r = setup(true, 1000, 5000);
+    r.openDegradation('OneShot', 'claude-code'); // opened, never retried
+    now += 2000; r.sweepOpenDegradations(); // past escalate window, but 0 retries → no escalation
+    expect(sent.length).toBe(0);
+    expect(r.openDegradationCount()).toBe(1);
+    now += 4000; r.sweepOpenDegradations(); // now past the 5s TTL → auto-close
+    expect(r.openDegradationCount()).toBe(0);
+    expect(sent.length).toBe(0); // never alarmed
+  });
+
+  it('a genuinely-stuck degradation (≥1 retry) ESCALATES once past the window, deduped', () => {
+    const r = setup(true, 1000, 30000);
+    r.openDegradation('StuckGate', 'claude-code'); // open
+    r.openDegradation('StuckGate', 'claude-code'); // retried + still failed → retryAttempts=1 (liveness)
+    now += 1500; r.sweepOpenDegradations(); // past 1s escalate window + has a retry → escalate
+    expect(sent.length).toBe(1);
+    expect(sent[0].text).toContain('StuckGate');
+    expect(sent[0].text).toContain('heuristic fallback');
+    now += 500; r.sweepOpenDegradations(); // within the dedup window → NO re-escalate
+    expect(sent.length).toBe(1);
+    now += 1100; r.sweepOpenDegradations(); // another full window elapsed → re-escalate once
+    expect(sent.length).toBe(2);
+  });
+
+  it('keys on (component, framework): a success for one does NOT resolve another', () => {
+    const r = setup();
+    r.openDegradation('Comp', 'claude-code');
+    r.openDegradation('Comp', 'codex-cli'); // same component, different framework = distinct
+    expect(r.openDegradationCount()).toBe(2);
+    expect(r.resolveDegradation('Comp', 'claude-code')).not.toBeNull();
+    expect(r.openDegradationCount()).toBe(1); // the codex-cli one is still open
+  });
+
+  it('bounded: opening past maxOpen evicts the oldest (no unbounded growth)', () => {
+    const r = setup(true, 1000, 30000, 3);
+    r.openDegradation('a', 'f'); r.openDegradation('b', 'f'); r.openDegradation('c', 'f');
+    r.openDegradation('d', 'f'); // exceeds maxOpen=3 → evict oldest ('a')
+    expect(r.openDegradationCount()).toBe(3);
+    expect(r.resolveDegradation('a', 'f')).toBeNull(); // 'a' was evicted
+    expect(r.resolveDegradation('d', 'f')).not.toBeNull();
+  });
+
+  it('disabled ⇒ every lifecycle call is a no-op', () => {
+    const r = setup(false);
+    r.openDegradation('X', 'f');
+    expect(r.openDegradationCount()).toBe(0);
+    expect(r.resolveDegradation('X', 'f')).toBeNull();
+    r.sweepOpenDegradations();
+    expect(sent.length).toBe(0);
+  });
+});

--- a/upgrades/next/resilient-degradation-ladder-increment-2.md
+++ b/upgrades/next/resilient-degradation-ladder-increment-2.md
@@ -1,0 +1,44 @@
+<!-- bump: minor -->
+<!-- change_type: feature -->
+
+## What Changed
+
+The other half of the rate-limit principle: **never let the agent silently stay stuck on a
+fallback.** When an internal call exhausts its options and the caller drops to a simple rule-of-thumb
+instead of real AI, the agent now tracks that. The moment a real AI call for that component succeeds
+again, it clears itself automatically. And if it stays stuck for too long (default 15 minutes) AND
+has genuinely retried, the agent raises one calm heads-up that the AI path hasn't recovered — so a
+degraded state can't quietly rot. A component that just ran once and finished (not stuck) quietly
+closes itself with no false alarm.
+
+This is **off by default** (on for the dev agent first), and it's built carefully to NOT repeat an
+event-loop freeze the same subsystem caused earlier: it's bounded, it never re-enters the alert
+machinery, and it only alerts when something is genuinely stuck.
+
+## What to Tell Your User
+
+Nothing changes unless you turn it on. Once on, if your agent ever falls back from real AI to a
+basic rule on some internal check and stays that way, you'll get one quiet heads-up instead of it
+silently persisting — and it clears itself the moment the AI path recovers.
+
+## Summary of New Capabilities
+
+- `DegradationReporter` open-degradation lifecycle: `openDegradation` / `resolveDegradation` /
+  `sweepOpenDegradations` / `configureNeverSilent` + `openDegradationCount`, keyed on
+  `(component, framework)`, bounded by a hard cap, O(1) per open/resolve.
+- `IntelligenceRouter` `onHeuristicFallthrough` (fires when a non-gating call exhausts the ladder)
+  + `onResolved` (fires on a successful real-LLM answer) hooks, wired to the reporter.
+- A dev-gated 60-second sweep that escalates a genuinely-stuck degradation (≥1 retry, open past
+  `escalateMs`, deduped) and auto-closes an idle/run-once one at the TTL.
+- Dark/dev-gated (`resolveDevAgentGate` + a `DEV_GATED_FEATURES` entry); no-op when off.
+
+## Evidence
+
+**Before:** `DegradationReporter` reported a degradation once (`report()` + a one-shot self-healer)
+but had NO continuous "is this still degraded?" tracking — a fallback could persist indefinitely with
+nobody knowing. **After:** a non-gating heuristic fallthrough opens a tracked degradation; a real
+answer auto-resolves it; a genuinely-stuck one escalates once (deduped); a run-once one auto-closes.
+Reproduced by `tests/unit/degradation-never-silent.test.ts` (6 cases) + 3 router-hook cases in
+`degradation-ladder.test.ts`. Critically, the escalation path surfaces via `telegramSender` directly
+and NEVER calls `report()` — the reentrancy that caused the 2026-06-21 event-loop wedge cannot recur.
+Full lint + tsc green; the existing reporter/router tests are unaffected.

--- a/upgrades/side-effects/resilient-degradation-ladder-increment-2.md
+++ b/upgrades/side-effects/resilient-degradation-ladder-increment-2.md
@@ -1,0 +1,97 @@
+# Side-Effects Review — Resilient Degradation Ladder Increment 2 (never-silent tracking)
+
+**Slug:** `resilient-degradation-ladder-increment-2` · **Tier:** 2 (spec-driven; converged +
+operator-approved). **Spec:** `docs/specs/resilient-degradation-ladder.md` §4, D6.
+
+## Summary of the change
+
+The never-silent half of the operator's principle ("never silently remain degraded indefinitely"),
+dark/dev-gated:
+- `DegradationReporter` gains an open-degradation lifecycle (§4): `openDegradation` /
+  `resolveDegradation` / `sweepOpenDegradations` / `configureNeverSilent`, keyed on
+  `(component, framework)`, bounded by MAX_OPEN, O(1) per open/resolve.
+- `IntelligenceRouter` gains `onHeuristicFallthrough` (fired at each NON-gating throw — the caller
+  will use its heuristic) + `onResolved` (fired at each successful real-LLM answer) hooks.
+- Server wires the hooks to the reporter + calls `configureNeverSilent` (dev-gated via
+  `resolveDevAgentGate`) + starts a 60s `unref`'d sweep timer.
+- `DEV_GATED_FEATURES` registration (`degradationLadderNeverSilent`).
+
+## Decision-point inventory
+
+Frozen in spec §5 D6: escalateMs 15m, TTL 30m, MAX_OPEN 500, key (component, framework),
+liveness-gated (≥1 retry to escalate; TTL-close otherwise), deduped per episode.
+
+## 1. Over-block / false positive
+
+The big false-positive class (round-1): a run-once / idle component that degrades once and never
+calls again. Closed by the LIVENESS gate — a degradation with 0 retries since open AUTO-CLOSES at
+the TTL instead of escalating (tested). Only a degradation that genuinely RE-attempted and still
+fell to heuristic (≥1 retry) escalates. Escalation is deduped per episode (re-escalates only after
+another full window — tested).
+
+## 2. Under-block
+
+Tracking only opens on a NON-gating heuristic fallthrough (where the heuristic actually runs); a
+gating fail-closed is NOT tracked (it's the safe outcome, not a heuristic — tested:
+onHeuristicFallthrough does NOT fire for a gating call). No-op when disabled.
+
+## 4. Signal vs authority
+
+The escalation is an attention SIGNAL (a deduped fixed-template Telegram line), never a gate. It
+takes no destructive action. The auto-resolve is observational (a successful call clears the open
+state). Consistent with Signal-vs-Authority.
+
+## 5. Interactions — THE WEDGE-CRITICAL SECTION
+
+§4 extends the exact `DegradationReporter` subsystem that caused the 2026-06-21 event-loop wedge
+(`gateHealthAlert`→`toneGate.review`→router→`report`→`reportEvent`→recursion + growing-array
+JSON.stringify). This increment is designed to NOT repeat it:
+- The sweep NEVER calls `report()`/`reportEvent()`/`gateHealthAlert` — it surfaces an attention item
+  via `telegramSender` DIRECTLY (no toneGate, no events-array growth, no recursion). Tested: the
+  escalation path sends via the fake telegramSender, never through report.
+- The open map is BOUNDED (MAX_OPEN; oldest evicted — tested) — no unbounded growth.
+- open/resolve are O(1) Map mutations — no full-map serialize per event.
+- The existing `_gatingHealthAlert` reentrancy guard + `MAX_EVENTS` cap are untouched.
+
+## 6. External surfaces
+
+No new route. The only new egress is the deduped escalation line (the operator's explicit want).
+The new config (`intelligence.degradationLadder.neverSilent`) shipped in Increment 1's types.
+
+## 6b. Operator-surface quality
+
+N/A — no dashboard/approval surface. `openDegradationCount()` is a read-only observability getter.
+
+## Framework generality
+
+Framework-agnostic — the hooks key on the resolved framework; works for whichever framework the
+component routes to.
+
+## 7. Multi-machine posture
+
+Machine-local: each machine's reporter tracks its own degradations + its own sweep timer. No
+replicated state. (A sustained per-machine degradation could double-alert on a 2-machine setup for
+one provider outage — accepted as a minor local-dedup limitation, noted in the spec §6.)
+
+## 8. Rollback cost
+
+Trivial: dark on the fleet (`configureNeverSilent({enabled:false})` when not dev/configured) — the
+lifecycle methods are all `if (!enabled) return` no-ops and no sweep timer is started. The router
+hooks are no-ops downstream when disabled. Revert = remove an unused-on-fleet code path.
+
+## Evidence pointers
+
+- `tests/unit/degradation-never-silent.test.ts` (6): open→resolve duration; run-once TTL-auto-close
+  (NO escalation); stuck (≥1 retry) escalates once past the window + deduped + re-escalates after a
+  new window; (component,framework) keying (no cross-resolution); bounded (MAX_OPEN evict);
+  disabled=no-op.
+- `tests/unit/degradation-ladder.test.ts` (+3 hook cases): onResolved on success; onHeuristicFallthrough
+  on a non-gating exhaustion; onHeuristicFallthrough does NOT fire for a gating call.
+- The `DEV_GATED_FEATURES` both-sides wiring test confirms `degradationLadderNeverSilent` resolves
+  live-on-dev / dark-on-fleet. Full `npm run lint` (incl. lint-dev-agent-dark-gate) + `tsc` green.
+
+## Conclusion
+
+Delivers the never-silent guarantee — a heuristic fallback can no longer silently persist
+indefinitely: it auto-resolves on recovery and escalates if genuinely stuck — built carefully to NOT
+repeat the wedge it extends. Dark/dev-gated, no-op when off. Ship.


### PR DESCRIPTION
## What & why

**Increment 2 of the Resilient Degradation Ladder** (#3 rate-limit robustness) — the **never-silent**
half of the operator's principle: *never silently remain degraded indefinitely.* Builds on the ladder
core shipped in #1243.

When a non-gating internal call exhausts the ladder and the caller drops to its heuristic, the agent
now opens a tracked degradation; a successful real-LLM answer for that `(component, framework)`
auto-resolves it; a genuinely-stuck one (≥1 retry, open past 15m) escalates ONE deduped attention
line; a run-once/idle one auto-closes at a TTL (no false alarm). Dark/dev-gated; no-op when off.

**Wedge-safe (the load-bearing constraint):** §4 extends the exact `DegradationReporter` subsystem
that caused the 2026-06-21 event-loop wedge. The design is the direct response: the sweep NEVER calls
`report()`/`reportEvent()`/`gateHealthAlert` (it surfaces via `telegramSender` directly), the open map
is bounded (MAX_OPEN), mutations are O(1), and escalation is liveness-gated (a run-once component
auto-closes, never false-alarms).

- `DegradationReporter`: `openDegradation`/`resolveDegradation`/`sweepOpenDegradations`/`configureNeverSilent`.
- `IntelligenceRouter`: `onHeuristicFallthrough` + `onResolved` hooks (the 5 throw/success points).
- Server: dev-gated `configureNeverSilent` + a 60s `unref`'d sweep timer; `DEV_GATED_FEATURES` entry.

## ELI16 — never let the agent silently stay stuck on a fallback

When an internal check can't reach the real AI and falls back to a basic rule-of-thumb, the agent now
notices. The moment the real AI works again for that check, it clears itself. If it stays stuck too
long (15 min) and has genuinely retried, you get one quiet heads-up that the AI path hasn't recovered
— so a degraded state can't silently rot. A check that just ran once and finished (not stuck) quietly
closes with no false alarm. Off by default; built carefully so it can't repeat an event-loop freeze the
same component caused earlier (it never re-enters the alert machinery and is strictly bounded).

## Tier

Tier 2 — spec-driven (converged 3 rounds + operator pre-approval). Ships dark/dev-gated.

## Test plan

- `tests/unit/degradation-never-silent.test.ts` (6): open→resolve duration; run-once TTL-auto-close
  (NO escalation); stuck (≥1 retry) escalates once + deduped + re-escalates after a new window;
  (component,framework) keying; bounded (MAX_OPEN evict); disabled=no-op.
- `tests/unit/degradation-ladder.test.ts` (+3): onResolved on success; onHeuristicFallthrough on a
  non-gating exhaustion; does NOT fire for a gating call (fail closed ≠ heuristic).
- `DEV_GATED_FEATURES` wiring test confirms live-on-dev/dark-on-fleet. Full lint + tsc green (24 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
