### PR TITLE
feat(intelligence): Resilient Degradation Ladder §3b.3 — deferrable queue rung (#3 increment 3, dark)

### DIFF
--- a/.instar/instar-dev-decisions/2026-06-22T03-38-37-940Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-06-22T03-38-37-940Z-unknown.json
@@ -1,0 +1,13 @@
+{
+  "ts": "2026-06-22T03:38:37.940Z",
+  "slug": "unknown",
+  "suggestedTier": 2,
+  "declaredTier": 2,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 5,
+  "loc": 212,
+  "causalAutopsy": null,
+  "verdict": "pass"
+}

--- a/src/commands/server.ts
+++ b/src/commands/server.ts
@@ -4970,6 +4970,27 @@ export async function startServer(options: StartOptions): Promise<void> {
 
         const computedDefault = resolveInternalFrameworkDefault(activeFrameworkSet);
 
+        // Resilient Degradation Ladder rung gates, resolved ONCE here (dev-gated: `enabled` OMITTED in
+        // config ⇒ resolveDevAgentGate ⇒ live-on-dev / dark-on-fleet). The ladder object is present
+        // when ANY rung is active; absent (fleet, unconfigured) ⇒ undefined ⇒ EXACTLY today's behavior.
+        const dlCfg = config.intelligence?.degradationLadder;
+        const ladderBackoffEnabled = resolveDevAgentGate(dlCfg?.backoff?.enabled, config);
+        const ladderQueueEnabled = resolveDevAgentGate(dlCfg?.queue?.enabled, config);
+        // Dedicated LlmQueue for the queue rung (§3b.3) — built ONLY when the rung is active so the
+        // fleet default allocates nothing. A deferrable internal call that exhausted framework-swap
+        // WAITS here for capacity (background lane, its own small daily cap so it can't starve
+        // interactive callers; maxConcurrent:1 serializes retries → naturally herd-safe) instead of
+        // dropping to its heuristic. `drainMinGapMs` is the opt-in §3c pacing gap (0/off by default).
+        let degradationLadderQueue: import('../core/IntelligenceRouter.js').DeferrableQueue | undefined;
+        if (ladderQueueEnabled) {
+          const { LlmQueue: DegradationLadderQueueCls } = await import('../monitoring/LlmQueue.js');
+          degradationLadderQueue = new DegradationLadderQueueCls({
+            maxConcurrent: 1,
+            maxDailyCents: 25,
+            backgroundDispatchMinGapMs: dlCfg?.queue?.drainMinGapMs ?? 0,
+          });
+        }
+
         sharedIntelligence = new IntelligenceRouter({
           defaultProvider: rawDefault,
           defaultFramework: defaultFw,
@@ -4997,26 +5018,28 @@ export async function startServer(options: StartOptions): Promise<void> {
           // §4.5: per-attempt swap timeout, inline-defaulted to 5s (no ConfigDefaults
           // entry — codexExecJson precedent; absent ⇒ 5s, present ⇒ operator's value).
           swapAttemptTimeoutMs: config.intelligence?.swapAttemptTimeoutMs ?? 5000,
-          // Resilient Degradation Ladder (docs/specs/resilient-degradation-ladder.md), v1.
-          // Dev-gated: the backoff rung's `enabled` is OMITTED in config so resolveDevAgentGate
-          // resolves it (live-on-dev / dark-on-fleet); the gating budget rides the ladder's
-          // activation. Absent (fleet, unconfigured) ⇒ undefined ⇒ EXACTLY today's behavior.
-          ladder: (() => {
-            const dl = config.intelligence?.degradationLadder;
-            const backoffEnabled = resolveDevAgentGate(dl?.backoff?.enabled, config);
-            if (!backoffEnabled) return undefined;
-            return {
-              gatingLadderBudgetMs: dl?.gatingLadderBudgetMs ?? 6000,
-              backoffEnabled,
-              backoff: {
-                baseMs: dl?.backoff?.baseMs ?? 500,
-                factor: dl?.backoff?.factor ?? 2,
-                maxAttempts: dl?.backoff?.maxAttempts ?? 3,
-                ceilingMs: dl?.backoff?.ceilingMs ?? 8000,
-                maxWaitMs: dl?.backoff?.maxWaitMs ?? 60000,
-              },
-            };
-          })(),
+          // The dedicated queue for the DEFERRABLE queue rung (§3b.3); undefined when the rung is
+          // dark ⇒ the rung is a no-op (a deferrable call falls straight to its heuristic, as before).
+          llmQueue: degradationLadderQueue,
+          // Resilient Degradation Ladder (docs/specs/resilient-degradation-ladder.md). Dev-gated: each
+          // rung's `enabled` is OMITTED in config so resolveDevAgentGate resolves it (live-on-dev /
+          // dark-on-fleet); the gating budget rides the ladder's activation. The ladder object is
+          // present when ANY rung (backoff OR queue) is active; absent ⇒ EXACTLY today's behavior.
+          ladder: (ladderBackoffEnabled || ladderQueueEnabled)
+            ? {
+                gatingLadderBudgetMs: dlCfg?.gatingLadderBudgetMs ?? 6000,
+                backoffEnabled: ladderBackoffEnabled,
+                backoff: {
+                  baseMs: dlCfg?.backoff?.baseMs ?? 500,
+                  factor: dlCfg?.backoff?.factor ?? 2,
+                  maxAttempts: dlCfg?.backoff?.maxAttempts ?? 3,
+                  ceilingMs: dlCfg?.backoff?.ceilingMs ?? 8000,
+                  maxWaitMs: dlCfg?.backoff?.maxWaitMs ?? 60000,
+                },
+                queueEnabled: ladderQueueEnabled,
+                queueAttemptTimeoutMs: dlCfg?.queue?.attemptTimeoutMs ?? 60000,
+              }
+            : undefined,
           // Each non-default framework gets its OWN breaker (built once, from the
           // shared probe-cache so the active-set probe doesn't double-build).
           buildProvider: (fw) => cachedBuild(fw),

--- a/src/core/IntelligenceRouter.ts
+++ b/src/core/IntelligenceRouter.ts
@@ -63,6 +63,19 @@ export interface RouterDegradeInfo {
   reason: string;
 }
 
+/**
+ * Minimal structural view of `LlmQueue` (src/monitoring/LlmQueue.ts) used by the deferrable queue
+ * rung. Declared here so `core` does NOT import `monitoring` (avoids a layering cycle); the real
+ * LlmQueue satisfies this shape structurally.
+ */
+export interface DeferrableQueue {
+  enqueue(
+    lane: 'interactive' | 'background',
+    fn: (signal: AbortSignal) => Promise<string>,
+    costCents?: number,
+  ): Promise<string>;
+}
+
 export interface IntelligenceRouterOptions {
   /** The existing shared provider for the default framework (global breaker). Used unconfigured + for default-routed calls. */
   defaultProvider: IntelligenceProvider;
@@ -98,11 +111,16 @@ export interface IntelligenceRouterOptions {
   onHeuristicFallthrough?: (component: string, framework: string) => void;
   onResolved?: (component: string, framework: string) => void;
   /**
+   * The shared LLM call queue (LlmQueue) for the DEFERRABLE queue rung (§3b.3). Absent ⇒ no queue
+   * rung (a deferrable call falls straight through to its heuristic after framework-swap, as before).
+   */
+  llmQueue?: DeferrableQueue;
+  /**
    * Resilient Degradation Ladder (docs/specs/resilient-degradation-ladder.md), RESOLVED at the
    * construction site (the dev-agent gate is applied there, so `*Enabled` are already the
    * gate-resolved booleans). Absent ⇒ no ladder (today's framework-swap-only behavior). The ladder
    * is path-dependent: a GATING call stays fast under `gatingLadderBudgetMs`; only a DEFERRABLE call
-   * gets the backoff rung. (Queue + never-silent rungs land in later increments.)
+   * gets the backoff + queue rungs.
    */
   ladder?: {
     /** Hard total wall-clock budget (ms) for the whole GATING failure path; exceeded ⇒ fail closed. */
@@ -110,6 +128,10 @@ export interface IntelligenceRouterOptions {
     /** Whether the DEFERRABLE backoff rung is enabled (gate-resolved). */
     backoffEnabled: boolean;
     backoff: { baseMs: number; factor: number; maxAttempts: number; ceilingMs: number; maxWaitMs: number };
+    /** Whether the DEFERRABLE queue rung is enabled (gate-resolved). Absent/false ⇒ no queue rung. */
+    queueEnabled?: boolean;
+    /** Bound (ms) for a single enqueued deferrable call so a stuck/abandoned one self-terminates. */
+    queueAttemptTimeoutMs?: number;
   };
 }
 
@@ -269,6 +291,13 @@ export class IntelligenceRouter implements IntelligenceProvider {
         }
       }
       if (swapTargets.length === 0) {
+        // RUNG (c) — DEFERRABLE queue: no swap configured, but a deferrable call can WAIT for capacity
+        // in the LlmQueue before dropping to its heuristic. gating can never reach here (deferrable =
+        // !gating && …) — the D5 queue-skip invariant is structural.
+        if (deferrable) {
+          const q = await this.tryDeferrableQueue(primary, prompt, options, component ?? '(none)', framework, category);
+          if (q.ok) return q.result;
+        }
         // Non-gating ⇒ the caller will swallow this into its heuristic — track it (never-silent).
         // Gating ⇒ this is a fail-closed, NOT a heuristic, so it is not tracked.
         if (!gating) this.opts.onHeuristicFallthrough?.(component ?? '(none)', framework);
@@ -338,11 +367,66 @@ export class IntelligenceRouter implements IntelligenceProvider {
           continue; // target also down (timeout / circuit-open / error) → try the next one
         }
       }
+      // RUNG (c) — DEFERRABLE queue: every swap target is also down, but a deferrable call can WAIT
+      // for capacity in the LlmQueue before dropping to its heuristic (the gentle order, §3b.3). A
+      // gating call NEVER reaches here (deferrable = !gating && …) — D5 queue-skip is structural.
+      if (deferrable) {
+        const q = await this.tryDeferrableQueue(primary, prompt, options, component ?? '(none)', framework, category);
+        if (q.ok) return q.result;
+      }
       // Every swap target is also down → re-throw so the (gating) caller fails CLOSED,
       // never silently degrading to a brittle heuristic. A NON-gating caller WILL swallow this into
       // its heuristic, so track it (never-silent §4); a gating fail-closed is not a heuristic.
       if (!gating) this.opts.onHeuristicFallthrough?.(component ?? '(none)', framework);
       throw err;
+    }
+  }
+
+  /**
+   * Queue rung (Resilient Degradation Ladder §3b.3) — DEFERRABLE calls only. Enqueue the SAME
+   * provider.evaluate so the call WAITS for capacity (the enqueued evaluate honors the account-global
+   * breaker's retryAfterMs via acquireOrWait — the §3b.3 rate-awareness) instead of dropping to the
+   * caller's heuristic. The AbortSignal cannot reach the subprocess (no IntelligenceOptions.signal —
+   * same as the swap loop), so we bound the enqueued call with `timeoutMs` and rely on the queue to
+   * free its slot on preemption; a preempted/abandoned call self-terminates at the bound. An enqueue
+   * REJECTION (daily-cap / interactive-reserve) OR a failed queued call returns `{ ok: false }` so the
+   * caller falls through to its heuristic — NEVER silently dropped (the callsite's onHeuristicFallthrough
+   * tracks it, §4). Both outcomes emit a distinct onDegrade reason for /metrics/features (D7).
+   */
+  private async tryDeferrableQueue(
+    primary: IntelligenceProvider,
+    prompt: string,
+    options: IntelligenceOptions | undefined,
+    component: string,
+    framework: IntelligenceFramework,
+    category: ComponentCategory,
+  ): Promise<{ ok: true; result: string } | { ok: false }> {
+    const q = this.opts.llmQueue;
+    const ladder = this.opts.ladder;
+    if (!q || !ladder?.queueEnabled) return { ok: false };
+    const bound = ladder.queueAttemptTimeoutMs ?? 0;
+    const enqueueOptions: IntelligenceOptions | undefined =
+      bound > 0 ? { ...(options ?? {}), timeoutMs: bound } : options;
+    try {
+      const result = await q.enqueue('background', () => primary.evaluate(prompt, enqueueOptions));
+      this.opts.onDegrade?.({
+        component,
+        category,
+        from: framework,
+        to: framework,
+        reason: 'queued: deferrable call waited for capacity in the LLM queue and was served',
+      });
+      this.opts.onResolved?.(component, framework); // a real answer via the queue → auto-resolve
+      return { ok: true, result };
+    } catch {
+      this.opts.onDegrade?.({
+        component,
+        category,
+        from: framework,
+        to: framework,
+        reason: 'queue-rejected: enqueue refused (daily-cap/reserve) or queued call failed — falling through to heuristic',
+      });
+      return { ok: false };
     }
   }
 }

--- a/src/core/devGatedFeatures.ts
+++ b/src/core/devGatedFeatures.ts
@@ -387,6 +387,12 @@ export const DEV_GATED_FEATURES: DevGatedFeature[] = [
     description: 'Resilient Degradation Ladder §4 — never-silent degradation tracking: a non-gating call that exhausts the ladder (→ caller heuristic) opens a tracked degradation; a successful real-LLM answer auto-resolves it; a genuinely-stuck one (≥1 retry, open past 15m) escalates ONE deduped attention item; a run-once/idle one TTL-auto-closes (no false alarm).',
     justification: 'Observe-and-escalate only — opens/resolves an in-memory map and, on a genuinely-stuck degradation, sends ONE deduped fixed-template attention line. Designed to NOT repeat the 2026-06-21 DegradationReporter wedge: bounded (MAX_OPEN), O(1) per open/resolve, the sweep NEVER calls report()/reportEvent()/gateHealthAlert (it surfaces via telegramSender directly), liveness-gated (a run-once component auto-closes, never escalates). No spend, no destructive action; the only egress is the deduped escalation line the operator explicitly wants ("never silently degraded"). No-op when off.',
   },
+  {
+    name: 'degradationLadderQueue',
+    configPath: 'intelligence.degradationLadder.queue.enabled',
+    description: 'Resilient Degradation Ladder §3b.3 — the DEFERRABLE queue rung: a non-gating call that exhausts framework-swap WAITS for capacity in a dedicated LlmQueue (the enqueued provider.evaluate honors the account-global breaker retryAfterMs) instead of dropping straight to the caller heuristic; an enqueue rejection (daily-cap/reserve) or queued-call failure falls through to the heuristic, never dropped. Includes the opt-in §3c herd-pacing gap (drainMinGapMs, 0/off by default).',
+    justification: 'Internal-call routing only; behavior-preserving when off (no llmQueue injected ⇒ the rung is a no-op ⇒ EXACTLY today\'s heuristic-on-exhaustion behavior). On a dev agent it runs live on DEFERRABLE (non-awaited, background) calls ONLY — a GATING call NEVER reaches the queue rung (structural: deferrable = !gating && deferrable; D5). The dedicated queue is bounded (maxConcurrent 1, its own small daily cap so it cannot starve interactive callers) and each enqueued call is timeout-bounded; it adds bounded WAITS, not new calls — no spend increase (same call count or fewer), no destructive action, no egress. Reuses the existing wedge-safe LlmQueue.',
+  },
 ];
 
 /**

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -3081,8 +3081,17 @@ export interface InstarConfig {
         ceilingMs?: number;    // default 8000 (clamp for a single wait)
         maxWaitMs?: number;    // default 60000 (hard cap on honoring a long server retry-after)
       };
-      /** Queue rung for DEFERRABLE calls (LlmQueue.enqueue; enqueue-rejection falls through). */
-      queue?: { enabled?: boolean };
+      /**
+       * Queue rung for DEFERRABLE calls (LlmQueue.enqueue; enqueue-rejection falls through to the
+       * caller's heuristic, never dropped). The enqueued provider.evaluate honors the account-global
+       * breaker's retryAfterMs via acquireOrWait — so the call WAITS for capacity (the §3b.3
+       * rate-awareness) instead of being dropped. `attemptTimeoutMs` bounds a single enqueued call so
+       * a stuck/abandoned one self-terminates (default 60000); `drainMinGapMs` is the opt-in §3c herd
+       * guard — a jittered minimum gap between BACKGROUND-lane dispatches so a burst of queued calls
+       * can't re-trip a just-recovered provider (0/off by default keeps today's drain behavior, zero
+       * blast radius for existing LlmQueue callers).
+       */
+      queue?: { enabled?: boolean; attemptTimeoutMs?: number; drainMinGapMs?: number };
       /** Never-silent degradation tracking (DegradationReporter open/auto-resolve/escalate lifecycle). */
       neverSilent?: {
         enabled?: boolean;

--- a/src/monitoring/LlmQueue.ts
+++ b/src/monitoring/LlmQueue.ts
@@ -31,6 +31,13 @@ export interface LlmQueueOptions {
   interactiveReservePct?: number;
   /** Daily spend cap in cents across both lanes. Default 100. */
   maxDailyCents?: number;
+  /**
+   * Herd-aware drain pacing (Resilient Degradation Ladder §3c). A jittered minimum gap (ms) between
+   * BACKGROUND-lane dispatches so a burst of queued background calls can't re-trip a just-recovered
+   * provider on recovery. Interactive-lane dispatches BYPASS pacing (latency-sensitive + preemptive).
+   * Default 0 = OFF (today's greedy drain, zero behavior change for existing callers).
+   */
+  backgroundDispatchMinGapMs?: number;
   /** Provide `Date.now()` — injectable for tests. */
   now?: () => number;
 }
@@ -53,10 +60,16 @@ export class LlmQueue {
   private maxConcurrent: number;
   private interactiveReservePct: number;
   private maxDailyCents: number;
+  private backgroundDispatchMinGapMs: number;
   private now: () => number;
 
   private inFlight: Set<InFlight> = new Set();
   private waiters: Waiter[] = [];
+
+  /** Wall-clock (via `now`) of the last BACKGROUND-lane dispatch — herd-pacing window anchor. */
+  private lastBackgroundStartAt = 0;
+  /** At most one pending paced re-drain timer; null when none scheduled. */
+  private pacingTimer: ReturnType<typeof setTimeout> | null = null;
 
   /** Daily spend ledger: { dateKey: 'YYYY-MM-DD', cents: number, interactive: number } */
   private dailySpendCents = 0;
@@ -67,6 +80,7 @@ export class LlmQueue {
     this.maxConcurrent = opts.maxConcurrent ?? 3;
     this.interactiveReservePct = opts.interactiveReservePct ?? 0.4;
     this.maxDailyCents = opts.maxDailyCents ?? 100;
+    this.backgroundDispatchMinGapMs = opts.backgroundDispatchMinGapMs ?? 0;
     this.now = opts.now ?? (() => Date.now());
   }
 
@@ -120,6 +134,23 @@ export class LlmQueue {
       const next = this.waiters[0];
 
       if (this.inFlight.size < this.maxConcurrent) {
+        // Herd guard (§3c): pace BACKGROUND-lane dispatches so a burst of queued calls can't re-trip
+        // a just-recovered provider. Interactive bypasses (latency-sensitive + preemptive). When a
+        // background dispatch is too soon after the previous one, schedule a paced re-drain instead of
+        // starting now. Because interactive waiters sort ahead, a background head means no interactive
+        // is waiting — so deferring it blocks nothing else. OFF when backgroundDispatchMinGapMs <= 0.
+        if (next.lane === 'background' && this.backgroundDispatchMinGapMs > 0 && this.lastBackgroundStartAt > 0) {
+          const since = this.now() - this.lastBackgroundStartAt;
+          // Jitter the gap (full-jitter low half) so independent recoveries don't re-sync into a herd.
+          const gap = Math.floor(this.backgroundDispatchMinGapMs * (0.5 + Math.random() * 0.5));
+          if (since < gap) {
+            this.schedulePacedDrain(gap - since);
+            break;
+          }
+        }
+        if (next.lane === 'background' && this.backgroundDispatchMinGapMs > 0) {
+          this.lastBackgroundStartAt = this.now();
+        }
         this.waiters.shift();
         this.start(next);
         continue;
@@ -141,6 +172,19 @@ export class LlmQueue {
       // of interactive calls. Wait for something to complete.
       break;
     }
+  }
+
+  /**
+   * Schedule a single paced re-drain (§3c herd guard). Coalesces to at most one pending timer so a
+   * burst of background enqueues can't stack timers. `unref`'d so it never holds the process open.
+   */
+  private schedulePacedDrain(delayMs: number): void {
+    if (this.pacingTimer) return;
+    this.pacingTimer = setTimeout(() => {
+      this.pacingTimer = null;
+      this.drain();
+    }, Math.max(1, delayMs));
+    this.pacingTimer.unref?.();
   }
 
   private start(w: Waiter): void {

--- a/tests/unit/LlmQueue.test.ts
+++ b/tests/unit/LlmQueue.test.ts
@@ -90,4 +90,53 @@ describe('LlmQueue', () => {
 
     expect(completionOrder).toEqual(['int', 'bg']);
   });
+
+  // Herd-aware background drain pacing (Resilient Degradation Ladder §3c).
+  it('paces a second BACKGROUND dispatch when backgroundDispatchMinGapMs is set, even with a free slot', async () => {
+    const q = new LlmQueue({ maxConcurrent: 3, maxDailyCents: 100, backgroundDispatchMinGapMs: 40 });
+    const a = deferred();
+    const b = deferred();
+    const pa = q.enqueue('background', () => a.promise); // dispatched immediately (first)
+    const pb = q.enqueue('background', () => b.promise); // paced — deferred despite a free slot
+
+    expect(q.getInFlightCount()).toBe(1); // only the first is in flight
+    expect(q.getWaitingCount()).toBe(1);  // the second waits out the pacing gap
+
+    a.resolve('a');
+    b.resolve('b');
+    expect(await pa).toBe('a');
+    expect(await pb).toBe('b'); // the paced re-drain eventually runs the second
+  });
+
+  it('does NOT pace when backgroundDispatchMinGapMs is 0/off (today behavior — both start at once)', async () => {
+    const q = new LlmQueue({ maxConcurrent: 3, maxDailyCents: 100 }); // no pacing
+    const a = deferred();
+    const b = deferred();
+    const pa = q.enqueue('background', () => a.promise);
+    const pb = q.enqueue('background', () => b.promise);
+
+    expect(q.getInFlightCount()).toBe(2); // both dispatched immediately (no gap)
+    expect(q.getWaitingCount()).toBe(0);
+
+    a.resolve('a');
+    b.resolve('b');
+    await pa;
+    await pb;
+  });
+
+  it('interactive dispatch BYPASSES background pacing (latency-sensitive)', async () => {
+    const q = new LlmQueue({ maxConcurrent: 3, maxDailyCents: 100, backgroundDispatchMinGapMs: 1000 });
+    const bgD = deferred();
+    const intD = deferred();
+    const pbg = q.enqueue('background', () => bgD.promise);   // first bg dispatched
+    const pint = q.enqueue('interactive', () => intD.promise); // interactive NOT paced
+
+    expect(q.getInFlightCount()).toBe(2); // bg + interactive both running; interactive bypassed pacing
+    expect(q.getWaitingCount()).toBe(0);
+
+    bgD.resolve('bg');
+    intD.resolve('int');
+    await pbg;
+    await pint;
+  });
 });

--- a/tests/unit/degradation-ladder.test.ts
+++ b/tests/unit/degradation-ladder.test.ts
@@ -174,3 +174,123 @@ describe('Resilient Degradation Ladder — never-silent hooks (§4)', () => {
     expect(fell).toEqual([]); // gating → fail closed, never a heuristic-fallthrough
   });
 });
+
+// Queue rung (§3b.3) — a DEFERRABLE call that exhausted framework-swap WAITS for capacity in the
+// LlmQueue before dropping to its heuristic. gating NEVER reaches the queue (D5, structural).
+const LADDER_Q = { ...LADDER, backoffEnabled: false, queueEnabled: true, queueAttemptTimeoutMs: 60000 };
+/** Stub queue that runs the enqueued fn immediately (simulates capacity becoming available). */
+const passQueue = {
+  enqueued: 0,
+  async enqueue(_lane: 'interactive' | 'background', fn: (s: AbortSignal) => Promise<string>) {
+    this.enqueued++;
+    return fn(new AbortController().signal);
+  },
+};
+/** Stub queue that REJECTS the enqueue (daily-cap / interactive-reserve breach). */
+const rejectQueue = {
+  enqueued: 0,
+  async enqueue(_lane: 'interactive' | 'background', _fn: (s: AbortSignal) => Promise<string>) {
+    this.enqueued++;
+    throw new Error('LLM daily spend cap exceeded');
+  },
+};
+
+describe('Resilient Degradation Ladder — queue rung (§3b.3)', () => {
+  it('deferrable: no swap configured → WAITS in the queue → queued call succeeds + onResolved fires', async () => {
+    let calls = 0;
+    const resolved: Array<[string, string]> = [];
+    const primary: IntelligenceProvider = {
+      async evaluate() { calls++; if (calls === 1) throw rle(); return 'queued-ok'; },
+    };
+    const q = { enqueued: 0, async enqueue(_l: 'interactive' | 'background', fn: (s: AbortSignal) => Promise<string>) { this.enqueued++; return fn(new AbortController().signal); } };
+    const router = new IntelligenceRouter({
+      defaultProvider: primary, defaultFramework: 'claude-code',
+      resolveConfig: () => ({}), buildProvider: () => null,
+      llmQueue: q, ladder: LADDER_Q, onResolved: (c, f) => resolved.push([c, f]),
+    });
+    expect(await router.evaluate('x', DEFERRABLE)).toBe('queued-ok');
+    expect(q.enqueued).toBe(1);            // the call was enqueued
+    expect(calls).toBe(2);                 // main attempt + the queued retry
+    expect(resolved).toContainEqual(['Sentinel', 'claude-code']); // served → auto-resolve
+  });
+
+  it('deferrable: swap exhausted → THEN queue (order backoff/swap → queue → success)', async () => {
+    const seq: string[] = [];
+    const primary: IntelligenceProvider = {
+      async evaluate() { seq.push('primary'); if (seq.filter((s) => s === 'primary').length === 1) throw rle(); return 'queued-ok'; },
+    };
+    const swap: IntelligenceProvider = { async evaluate() { seq.push('swap'); throw new Error('swap down'); } };
+    const q = { async enqueue(_l: 'interactive' | 'background', fn: (s: AbortSignal) => Promise<string>) { seq.push('queue'); return fn(new AbortController().signal); } };
+    const router = new IntelligenceRouter({
+      defaultProvider: primary, defaultFramework: 'claude-code',
+      resolveConfig: () => ({ failureSwap: ['codex-cli'] }),
+      buildProvider: (fw: IntelligenceFramework) => (fw === 'codex-cli' ? swap : null),
+      llmQueue: q, ladder: LADDER_Q,
+    });
+    expect(await router.evaluate('x', DEFERRABLE)).toBe('queued-ok');
+    // primary(fail) → swap(down) → queue → primary(ok): queue comes AFTER swap, before success.
+    expect(seq).toEqual(['primary', 'swap', 'queue', 'primary']);
+  });
+
+  it('GATING is NEVER queued (D5 — structural queue-skip)', async () => {
+    passQueue.enqueued = 0;
+    const primary: IntelligenceProvider = { async evaluate() { throw rle(); } };
+    const swap: IntelligenceProvider = { async evaluate() { throw new Error('swap down'); } };
+    const router = new IntelligenceRouter({
+      defaultProvider: primary, defaultFramework: 'claude-code',
+      resolveConfig: () => ({ failureSwap: ['codex-cli'] }),
+      buildProvider: (fw: IntelligenceFramework) => (fw === 'codex-cli' ? swap : null),
+      llmQueue: passQueue, ladder: LADDER_Q,
+    });
+    await expect(router.evaluate('x', GATING)).rejects.toThrow();
+    expect(passQueue.enqueued).toBe(0); // a gating call fails closed, never enqueued
+  });
+
+  it('enqueue REJECTION → falls through to heuristic (never dropped) + onHeuristicFallthrough fires', async () => {
+    rejectQueue.enqueued = 0;
+    const fell: Array<[string, string]> = [];
+    const primary: IntelligenceProvider = { async evaluate() { throw rle(); } };
+    const router = new IntelligenceRouter({
+      defaultProvider: primary, defaultFramework: 'claude-code',
+      resolveConfig: () => ({}), buildProvider: () => null,
+      llmQueue: rejectQueue, ladder: LADDER_Q, onHeuristicFallthrough: (c, f) => fell.push([c, f]),
+    });
+    await expect(router.evaluate('x', DEFERRABLE)).rejects.toThrow();
+    expect(rejectQueue.enqueued).toBe(1);                 // it tried the queue
+    expect(fell).toEqual([['Sentinel', 'claude-code']]);  // then fell through to heuristic, tracked
+  });
+
+  it('non-deferrable advisory call is NEVER queued', async () => {
+    passQueue.enqueued = 0;
+    const primary: IntelligenceProvider = { async evaluate() { throw rle(); } };
+    const router = new IntelligenceRouter({
+      defaultProvider: primary, defaultFramework: 'claude-code',
+      resolveConfig: () => ({}), buildProvider: () => null,
+      llmQueue: passQueue, ladder: LADDER_Q,
+    });
+    await expect(router.evaluate('x', { attribution: { component: 'Adv' } })).rejects.toThrow();
+    expect(passQueue.enqueued).toBe(0); // only deferrable calls reach the queue rung
+  });
+
+  it('queueEnabled but NO llmQueue injected ⇒ rung is a no-op (deferrable just throws)', async () => {
+    const primary: IntelligenceProvider = { async evaluate() { throw rle(); } };
+    const router = new IntelligenceRouter({
+      defaultProvider: primary, defaultFramework: 'claude-code',
+      resolveConfig: () => ({}), buildProvider: () => null,
+      ladder: LADDER_Q, // queueEnabled true but llmQueue absent
+    });
+    await expect(router.evaluate('x', DEFERRABLE)).rejects.toThrow();
+  });
+
+  it('queue rung OFF (queueEnabled false) ⇒ deferrable call is not enqueued even with a queue present', async () => {
+    passQueue.enqueued = 0;
+    const primary: IntelligenceProvider = { async evaluate() { throw rle(); } };
+    const router = new IntelligenceRouter({
+      defaultProvider: primary, defaultFramework: 'claude-code',
+      resolveConfig: () => ({}), buildProvider: () => null,
+      llmQueue: passQueue, ladder: { ...LADDER_Q, queueEnabled: false },
+    });
+    await expect(router.evaluate('x', DEFERRABLE)).rejects.toThrow();
+    expect(passQueue.enqueued).toBe(0);
+  });
+});

--- a/upgrades/next/resilient-degradation-ladder-increment-3.md
+++ b/upgrades/next/resilient-degradation-ladder-increment-3.md
@@ -1,0 +1,49 @@
+<!-- bump: minor -->
+<!-- change_type: feature -->
+
+## What Changed
+
+The last rung of the rate-limit principle: **wait for capacity before falling back.** When an internal
+background check gets rate-limited and has already tried slowing-down-and-retrying and switching
+frameworks, it can now WAIT in a small queue for capacity to free up — instead of immediately giving up
+and dropping to a basic rule. The wait is bounded and rate-aware (it rides the same circuit-breaker
+timing that protects the account), so a burst of queued checks can't re-trip the limit the moment it
+recovers. Only background, non-urgent checks queue; anything the agent is actively waiting on still
+fails fast. If the queue is full or over its daily budget, the check falls through to its basic rule
+exactly as before — never silently dropped.
+
+This is **off by default** (on for the dev agent first), reuses the existing wedge-safe queue, and
+changes nothing for any other queue user.
+
+## What to Tell Your User
+
+Nothing changes unless you turn it on. Once on, if a background check hits a rate limit, it will
+briefly wait its turn for capacity to come back before falling back to a simpler rule — so you lose the
+smart answer less often. Urgent checks you are waiting on still respond fast, and if there is no spare
+capacity the check just uses its basic rule like before.
+
+## Summary of New Capabilities
+
+- `IntelligenceRouter` DEFERRABLE queue rung (`tryDeferrableQueue`): a non-gating call that exhausts
+  backoff + framework-swap enqueues onto a dedicated `LlmQueue` (background lane) and WAITS for
+  capacity (the enqueued `provider.evaluate` honors the account-global breaker's `retryAfterMs`)
+  before dropping to the caller's heuristic. Inserted at both fall-through points.
+- A GATING call is NEVER queued (`deferrable = !gating && …`, code-enforced — D5). An enqueue
+  rejection (daily-cap / interactive-reserve) or queued-call failure falls through to the heuristic,
+  never dropped. Two new `onDegrade` reasons (`queued` / `queue-rejected`) for `/metrics/features` (D7).
+- `LlmQueue` opt-in `backgroundDispatchMinGapMs` (§3c herd guard): a jittered minimum gap between
+  background dispatches; interactive bypasses; default 0 = off (zero change for existing callers).
+- Config `intelligence.degradationLadder.queue` → `{ enabled?, attemptTimeoutMs?, drainMinGapMs? }`;
+  `DEV_GATED_FEATURES` entry `degradationLadderQueue` (live-on-dev / dark-on-fleet).
+
+## Evidence
+
+**Before:** a deferrable internal call that exhausted backoff + framework-swap dropped STRAIGHT to its
+heuristic — even when capacity would have freed up moments later. **After:** with the rung enabled, it
+WAITS for capacity in a bounded, rate-aware queue first, and only falls back if the queue rejects it or
+the queued call fails. Reproduced by `tests/unit/degradation-ladder.test.ts` (7 queue cases: success +
+auto-resolve; order backoff/swap → queue → success; GATING never queued; enqueue-rejection ⇒ heuristic
+fallthrough; non-deferrable never queued; no-llmQueue no-op; queueEnabled:false not enqueued) and
+`tests/unit/LlmQueue.test.ts` (3 pacing cases). The rung reuses the existing wedge-safe `LlmQueue` and
+never calls the DegradationReporter alert machinery, so the 2026-06-21 event-loop wedge cannot recur.
+Full `tsc` + dark-gate lint green; `no-silent-fallbacks` holds at baseline 476.

--- a/upgrades/side-effects/resilient-degradation-ladder-increment-3.md
+++ b/upgrades/side-effects/resilient-degradation-ladder-increment-3.md
@@ -1,0 +1,108 @@
+# Side-Effects Review — Resilient Degradation Ladder Increment 3 (queue rung)
+
+**Slug:** `resilient-degradation-ladder-increment-3` · **Tier:** 2 (spec-driven; the spec converged +
+operator-approved, rode Increments 1/2). **Spec:** `docs/specs/resilient-degradation-ladder.md` §3b.3,
+§3c, D1/D5/D7.
+
+## Summary of the change
+
+The third (and final) rung of the operator's degradation principle — "prefer slowing down over
+falling back". Dark/dev-gated:
+
+- `IntelligenceRouter` gains a DEFERRABLE **queue rung** (`tryDeferrableQueue`): a non-gating call
+  that has exhausted backoff + framework-swap now WAITS for capacity in a dedicated `LlmQueue`
+  (`background` lane) before dropping to the caller's heuristic. The enqueued `provider.evaluate`
+  honors the account-global breaker's `retryAfterMs` via `acquireOrWait` — that IS the §3b.3
+  rate-awareness. Inserted at BOTH fall-through points (no-swap-configured AND swap-exhausted) before
+  the existing `onHeuristicFallthrough` + throw.
+- A structural `DeferrableQueue` interface declared in `core` (the real `LlmQueue` satisfies it) so
+  `core` does NOT import `monitoring` (no layering cycle).
+- `LlmQueue` gains an opt-in `backgroundDispatchMinGapMs` (§3c herd guard): a jittered minimum gap
+  between BACKGROUND-lane dispatches; interactive bypasses. Default 0 = OFF (today's greedy drain).
+- Server wires a DEDICATED `LlmQueue` for the rung (built ONLY when the gate-resolved `queueEnabled`
+  is true), gate-resolves `queueEnabled`/`queueAttemptTimeoutMs` via `resolveDevAgentGate`, and the
+  ladder object is now present when ANY rung (backoff OR queue) is active.
+- `DEV_GATED_FEATURES` registration (`degradationLadderQueue`).
+- Config type extended: `degradationLadder.queue` → `{ enabled?, attemptTimeoutMs?, drainMinGapMs? }`.
+
+## Decision-point inventory (frozen)
+
+D1 (config + dark rollout), D5 (`gating:true` ⇒ queue-skipped, code-enforced), D7 (reason taxonomy
+`queued` / `queue-rejected`). Increment-3 bounds (sensible defaults, dark/reversible, fit D1's
+`{enabled, …bounds}` structure): `queueAttemptTimeoutMs` 60000, dedicated queue `maxConcurrent` 1 +
+`maxDailyCents` 25, `drainMinGapMs` 0 (off).
+
+**D9 (new, recorded here) — the §3c herd guard is opt-in, realized two ways:** (1) the PRIMARY
+rate-awareness is the provider-layer `acquireOrWait` — each enqueued `evaluate` waits for the
+account-global breaker window, so queued calls don't hammer a rate-limited account; (2) the dedicated
+queue's `maxConcurrent: 1` serializes deferrable retries (naturally herd-safe); (3) `drainMinGapMs`
+adds an OPTIONAL jittered inter-dispatch gap (off by default). Explicit pacing is opt-in so existing
+`LlmQueue` callers (PresenceProxy / PromiseBeacon) see ZERO behavior change. This faithfully delivers
+§3b.3/§3c without rebuilding shared infrastructure (round-1 "extend, don't rebuild").
+
+## 1. Over-block / false positive
+
+The rung only ADDS a wait-for-capacity step on a DEFERRABLE call that already exhausted swap; it never
+blocks an interactive/gating call. A queued call that fails or is rejected falls through to exactly
+today's heuristic — strictly no worse than before. No new block surface.
+
+## 2. Under-block
+
+A GATING call NEVER reaches the queue rung: `deferrable = !gating && options.deferrable === true`, so
+`if (deferrable) …tryDeferrableQueue` is structurally unreachable for a gate (D5). Unit-tested
+(`GATING is NEVER queued`). The gating fail-closed boundary is unchanged.
+
+## 4. Signal vs authority
+
+The queue rung takes no destructive action — it waits for capacity then returns a real answer, or
+falls through. The two `onDegrade` emissions (`queued` / `queue-rejected`) are observability signals
+(D7), never gates. Consistent with Signal-vs-Authority.
+
+## 5. Interactions — wedge-safety
+
+Reuses the EXISTING `LlmQueue` (the wedge-safe, bounded, daily-capped queue). The new drain-pacing is
+a bounded `setTimeout` coalesced to at most one pending timer (no stacking), `unref`'d (never holds the
+process open). No new recursion, no growing array, no `report()`/`reportEvent()` call from the rung —
+the 2026-06-21 DegradationReporter wedge class cannot recur here. The dedicated queue is built only
+when the rung is active, so the fleet allocates nothing.
+
+## 6. External surfaces
+
+No new route. No new egress — a queued call is the SAME provider.evaluate that would otherwise have
+run; it just waits for capacity. The new config (`intelligence.degradationLadder.queue.*`) is opt-in.
+
+## Framework generality
+
+Framework-agnostic — the rung keys on the resolved framework and enqueues whatever provider the
+component routes to.
+
+## 7. Multi-machine posture
+
+Machine-local: each machine's router + its dedicated queue are independent. No replicated state, no
+cross-machine contract (the dedicated queue is per-process, same posture as the existing per-sentinel
+queues).
+
+## 8. Rollback cost
+
+Trivial: dark on the fleet (`queueEnabled` resolves dark; no dedicated queue is built, the ladder's
+`queueEnabled` is false, and `tryDeferrableQueue` returns `{ ok: false }` immediately ⇒ exactly
+today's heuristic-on-exhaustion). Revert = remove an unused-on-fleet code path. `drainMinGapMs` defaults
+0 so existing `LlmQueue` callers are untouched.
+
+## Evidence pointers
+
+- `tests/unit/degradation-ladder.test.ts` (+7 queue cases): queue success + onResolved; order
+  backoff/swap → queue → success; GATING never queued (D5); enqueue REJECTION ⇒ heuristic fallthrough
+  + onHeuristicFallthrough; non-deferrable never queued; queueEnabled-but-no-llmQueue no-op;
+  queueEnabled:false not enqueued.
+- `tests/unit/LlmQueue.test.ts` (+3 pacing cases): paces a 2nd background dispatch when the gap is set;
+  no pacing when off (both start at once); interactive bypasses pacing.
+- `tests/unit/devGatedFeatures-wiring.test.ts` auto-covers `degradationLadderQueue` (live-on-dev /
+  dark-on-fleet). `tests/unit/no-silent-fallbacks.test.ts` stays at baseline 476. Full `tsc` +
+  `lint-dev-agent-dark-gate` green.
+
+## Conclusion
+
+Delivers the final rung of the operator's degradation principle — a deferrable call now WAITS for
+capacity (slow down) before ever dropping to a brittle heuristic, with the provider breaker supplying
+rate-awareness and an opt-in herd gap on top. Dark/dev-gated, no-op when off, wedge-safe. Ship.


### PR DESCRIPTION
## Resilient Degradation Ladder — Increment 3: the deferrable queue rung (#3, rate-limit robustness)

The final rung of the operator's degradation principle ("prefer slowing down over falling back"). Builds on #1243 (ladder core) and #1244 (never-silent tracking). Dark/dev-gated.

A DEFERRABLE non-gating call that has exhausted backoff + framework-swap now WAITS for capacity in a dedicated `LlmQueue` (background lane) before dropping to the caller's heuristic. The enqueued `provider.evaluate` honors the account-global breaker's `retryAfterMs` via `acquireOrWait` — that IS the §3b.3 rate-awareness. Inserted at both router fall-through points before `onHeuristicFallthrough` + throw.

- **GATING is NEVER queued** (`deferrable = !gating && …`, code-enforced — D5).
- An enqueue rejection (daily-cap / interactive-reserve) or queued-call failure falls through to the heuristic — never dropped. New `onDegrade` reasons `queued` / `queue-rejected` (D7).
- `LlmQueue` opt-in `backgroundDispatchMinGapMs` (§3c herd guard): jittered min-gap between background dispatches; interactive bypasses; default 0 = off (zero change for existing callers).
- Dedicated queue built ONLY when the gate-resolved `queueEnabled` is true. `DeferrableQueue` structural type avoids a `core→monitoring` import. `DEV_GATED_FEATURES` entry `degradationLadderQueue` (live-on-dev / dark-on-fleet).

**Wedge-safe** (reuses the bounded `LlmQueue`; never calls the DegradationReporter alert machinery, so the 2026-06-21 wedge class cannot recur). Dark on fleet, no-op when off.

### Tests
+10: 7 router queue cases (`tests/unit/degradation-ladder.test.ts`) + 3 LlmQueue pacing cases (`tests/unit/LlmQueue.test.ts`). `devGatedFeatures-wiring` auto-covers `degradationLadderQueue`; `no-silent-fallbacks` holds at baseline 476. Spec: `docs/specs/resilient-degradation-ladder.md` §3b.3/§3c/D1/D5/D7 (converged + approved).

## ELI16 — Background checks now wait their turn for capacity before falling back to a basic rule, instead of giving up the moment they hit a rate limit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
