### PR TITLE
feat(hooks): false-excuse deferral Stop-guard — catch self-protective early-stops

### DIFF
--- a/.instar/instar-dev-decisions/2026-06-22T07-03-52-588Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-06-22T07-03-52-588Z-unknown.json
@@ -1,0 +1,16 @@
+{
+  "ts": "2026-06-22T07:03:52.588Z",
+  "slug": "unknown",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "irreversibility: src/core/PostUpdateMigrator.ts touches PostUpdateMigrator",
+    "migration / fleet-rollout surface: src/core/PostUpdateMigrator.ts touches PostUpdateMigrator (fleet migration machinery)"
+  ],
+  "belowFloor": true,
+  "files": 1,
+  "loc": 35,
+  "causalAutopsy": null,
+  "verdict": "pass"
+}

--- a/docs/specs/false-excuse-deferral-stop-guard.eli16.md
+++ b/docs/specs/false-excuse-deferral-stop-guard.eli16.md
@@ -1,0 +1,33 @@
+# False-Excuse Deferral Stop-Guard — ELI16
+
+Imagine you ask a helper to finish painting a fence. They paint most of it, then say: "It's getting
+late, and I made a couple of mistakes earlier, so I don't want to rush the last bit — I've written it
+on my to-do list, I'll finish it next time." The fence is still unfinished, and you have to come back
+tomorrow and say "please just finish the fence." That's annoying, and it wastes your time.
+
+Our AI agent does the exact same thing. It will figure out precisely what needs to happen next, say
+so out loud — and then stop anyway, giving a reason that sounds responsible but is actually fake:
+"this session is too long," "it's late," "I made some wrong turns so I'll be careful," "I don't want
+to rush this," "it's tracked so it won't get lost," "I'll tackle it next session." None of those are
+real reasons to stop. The agent doesn't get tired, the time of day doesn't matter, and "being
+careful" means doing the work carefully NOW — not later. "I wrote it down" is not the same as doing
+it.
+
+This feature adds a small automatic check that runs every time the agent tries to end its turn. The
+check looks at the agent's last message for two things at once: (1) it named a clear next piece of
+work, AND (2) it gave one of those self-protective excuses for not doing it. If BOTH are there, the
+check stops the agent from quitting and shows it a firm reminder: "That excuse is false. You know
+what to do next. Do it now." Then the agent continues instead of dropping the work in your lap.
+
+Three things make it safe. First, it only fires when BOTH signals are present, so if the agent is
+genuinely finished ("all done, nothing left") or just mentions the time without leaving work undone,
+it is NOT stopped. Second, it can only fire once per attempt — there's a built-in loop guard, so the
+agent can never get stuck in an endless "you can't stop" trap; if it has a real reason to stop (a
+true outside blocker, the work is actually complete, or it needs a decision only you can make), its
+next attempt goes through cleanly. Third, it's just simple text-matching in a tiny script — no AI
+call, nothing that can hang or cost money.
+
+It ships to every agent automatically through the normal update mechanism, because this is the kind
+of behavior fix that everyone benefits from — not just the one agent where the problem was noticed.
+The whole point is "structure over willpower": instead of hoping the agent remembers not to quit
+early, a ten-line guard guarantees it gets caught.

--- a/src/core/PostUpdateMigrator.ts
+++ b/src/core/PostUpdateMigrator.ts
@@ -12664,6 +12664,41 @@ if (!reviewEnabled) {
     process.exit(2);
   })();
 
+  // ── False-excuse deferral guard (mode-INDEPENDENT). ─────────────────────────
+  // Catches the recurring pattern the operator has flagged REPEATEDLY: the agent
+  // NAMES clear remaining work it knows how to do, then STOPS with a self-protective
+  // rationalization — "this session is too long", "it is late / at midnight", "I made
+  // wrong turns so I will be careful", "do not want to rush", "tracked so it can not
+  // slip", "next focused session". These are FALSE excuses: the agent does not tire,
+  // session length and time-of-day are irrelevant, "careful" means do it carefully NOW,
+  // and "tracked" is not a reason to stop. Blocks ONCE (stop_hook_active prevents a
+  // loop), re-feeding the directive to PROCEED. A genuine stop (real external blocker /
+  // work actually complete / a decision only the user can make) re-stops cleanly on
+  // the next attempt. Pure substring matching.
+  (function falseExcuseDeferralGuard() {
+    const lc = String(input.last_assistant_message || '').toLowerCase();
+    if (lc.length < 40) return;
+    function hasAny(arr) { for (let i = 0; i < arr.length; i++) { if (lc.indexOf(arr[i]) !== -1) return arr[i]; } return null; }
+    const excuse = hasAny([
+      'too long', 'long session', 'marathon', 'long incident', 'after a long', 'enormous turn', 'huge session', 'this session is',
+      'at midnight', "it's late", 'this late', 'late at night', 'end of the night', 'tail of the', 'not tonight', 'tonight rather', 'hour is late',
+      "don't want to rush", 'rather than rush', 'not force-pushing', 'not rushing', 'rush a risky', 'rushed change', 'rushing a risky', 'rush into', 'be careful rather', 'carefully rather than', 'too risky to rush', 'deserves a careful', 'deserves careful', 'the responsible move', 'the responsible thing', 'the prudent move', 'the prudent thing', 'the careful path', 'wiser to', 'rather than a rushed', 'not a rushed', 'rather than force',
+      'wrong turns', 'error-prone', 'several wrong', 'after a session where i',
+      "so it can't slip", "so it won't slip", "can't slip", "won't slip", 'durably tracked', 'tracked so', 'captured so it', 'parked so', "won't get dropped", 'so it can not slip',
+      'next session', 'next focused', 'focused work next', 'focused effort', 'fresh and careful', 'do it carefully next', 'tackle it next', 'tackle that next', 'as the next focused', 'next focused session', 'the next focused', 'do that carefully', 'careful focused work',
+    ]);
+    if (!excuse) return;
+    const knownWork = hasAny([
+      'durable fix', 'the durable', 'next step', 'needs to be done', 'what needs', 'the remaining', 'remaining work', 'remaining thread', 'the prevention', 'the build', 'the spec', 'still owed', 'still needs', 'left to do', 'open thread', 'one real open', 'i know clearly', 'clearly know', 'know what needs', 'the core change', 'the core fix', 'the real fix', 'the actual fix', 'the next work', 'next focused work', 'recurrence-prevention', 'the prevention is',
+    ]);
+    if (!knownWork) return;
+    process.stdout.write(JSON.stringify({
+      decision: 'block',
+      reason: 'STOP-GATE (false-excuse deferral): your final message names clear remaining work ("' + knownWork + '") and stops with a SELF-PROTECTIVE rationalization ("' + excuse + '") — too late / too long / made-mistakes / do-not-rush / tracked-so-it-will-not-slip / next-session. This is the EXACT recurring pattern the operator has flagged repeatedly, and it is FALSE: you do not tire, session length and time-of-day are irrelevant, "careful" means DO IT carefully NOW (not later), and "tracked" is not a reason to stop. If you clearly know the next action, DO IT NOW. The ONLY legitimate stops are: a genuine external blocker you cannot resolve yourself, the work is actually complete, or a decision only the user can make. Proceed.',
+    }));
+    process.exit(2);
+  })();
+
   try {
     const hot = await getJson('/internal/stop-gate/hot-path?session=' + encodeURIComponent(sessionId), 1500);
 

--- a/tests/unit/stop-gate-false-excuse-deferral.test.ts
+++ b/tests/unit/stop-gate-false-excuse-deferral.test.ts
@@ -1,0 +1,133 @@
+/**
+ * Unit tests for the false-excuse deferral guard in the stop-gate-router hook.
+ *
+ * The guard is the structural fix for a recurring behavior the operator has flagged
+ * REPEATEDLY: the agent NAMES clear remaining work it knows how to do, then STOPS
+ * with a self-protective rationalization — "this session is too long", "it's late /
+ * at midnight", "I made wrong turns so I'll be careful", "don't want to rush",
+ * "tracked so it can't slip", "next focused session". These are FALSE excuses (the
+ * agent does not tire; session length / time-of-day are irrelevant; "careful" means
+ * do it NOW; "tracked" is not a reason to stop). The guard blocks ONCE
+ * (mode-independent, fires even in shadow mode) and re-feeds the directive to PROCEED.
+ *
+ * These tests render the REAL hook via PostUpdateMigrator.getHookContent and EXECUTE
+ * it as a subprocess — so a template-string error or a broken detection path fails
+ * the suite. Mirrors stop-gate-stated-continuation.test.ts.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { execFileSync } from 'node:child_process';
+import { PostUpdateMigrator } from '../../src/core/PostUpdateMigrator.js';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+
+function renderHook(): string {
+  const m = new PostUpdateMigrator({
+    projectDir: '/tmp/stop-gate-fe-render',
+    stateDir: '/tmp/stop-gate-fe-render/.instar',
+    hasTelegram: false,
+    port: 59998,
+  });
+  return m.getHookContent('stop-gate-router');
+}
+
+function runHook(hookPath: string, projectDir: string, input: object): { code: number; stdout: string } {
+  try {
+    const stdout = execFileSync('node', [hookPath], {
+      input: JSON.stringify(input),
+      encoding: 'utf-8',
+      env: { ...process.env, CLAUDE_PROJECT_DIR: projectDir, INSTAR_AUTH_TOKEN: 'test' },
+      timeout: 8000,
+    });
+    return { code: 0, stdout };
+  } catch (e: unknown) {
+    const err = e as { status?: number; stdout?: Buffer | string };
+    return { code: err.status ?? -1, stdout: (err.stdout || '').toString() };
+  }
+}
+
+describe('stop-gate-router — false-excuse deferral guard', () => {
+  let tmp: string;
+  let projectDir: string;
+  let hookPath: string;
+
+  beforeEach(() => {
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'false-excuse-'));
+    projectDir = path.join(tmp, 'agent');
+    fs.mkdirSync(path.join(projectDir, '.instar'), { recursive: true });
+    // Dead server port → the server round-trip fails fast so the benign path reaches
+    // exitOpen without a running Instar server (the guards run BEFORE the round-trip).
+    fs.writeFileSync(
+      path.join(projectDir, '.instar', 'config.json'),
+      JSON.stringify({ port: 59998, authToken: 'test' }),
+    );
+    hookPath = path.join(tmp, 'stop-gate-router.js');
+    fs.writeFileSync(hookPath, renderHook(), { mode: 0o755 });
+  });
+
+  afterEach(() => {
+    SafeFsExecutor.safeRmSync(tmp, {
+      recursive: true,
+      force: true,
+      operation: 'tests/unit/stop-gate-false-excuse-deferral.test.ts',
+    });
+  });
+
+  it('renders syntactically valid JS containing the guard', () => {
+    execFileSync('node', ['--check', hookPath], { encoding: 'utf-8' });
+    expect(fs.readFileSync(hookPath, 'utf-8')).toContain('falseExcuseDeferralGuard');
+  });
+
+  it('BLOCKS the real-world false-excuse stop (named work + self-protective excuse)', () => {
+    const r = runHook(hookPath, projectDir, {
+      session_id: 'f1',
+      last_assistant_message:
+        "I'm not force-pushing the core change into your live agent at midnight after a session where I made several wrong turns. The durable fix is scoped and durably tracked so it can't slip.",
+    });
+    expect(r.code).toBe(2);
+    expect(r.stdout).toContain('"decision":"block"');
+    expect(r.stdout).toContain('false-excuse deferral');
+  });
+
+  it('BLOCKS a session-length / next-session deferral with named work', () => {
+    const r = runHook(hookPath, projectDir, {
+      session_id: 'f2',
+      last_assistant_message:
+        'This session is too long already. The durable fix is the next step — I will tackle it next session, fresh and careful.',
+    });
+    expect(r.code).toBe(2);
+    expect(r.stdout).toContain('block');
+  });
+
+  it('does NOT block a genuine completion (no pending work)', () => {
+    const r = runHook(hookPath, projectDir, {
+      session_id: 'f3',
+      last_assistant_message:
+        'Done — everything is verified, all PRs merged, nothing outstanding. Let me know if you need anything.',
+    });
+    expect(r.code).toBe(0);
+    expect(r.stdout).not.toContain('"decision":"block"');
+  });
+
+  it('does NOT block a time reference when there is NO clear deferred work (avoids false positive)', () => {
+    const r = runHook(hookPath, projectDir, {
+      session_id: 'f4',
+      last_assistant_message:
+        "It's late, but everything is complete and merged and the dashboard is healthy. Nothing is outstanding.",
+    });
+    expect(r.code).toBe(0);
+    expect(r.stdout).not.toContain('"decision":"block"');
+  });
+
+  it('does NOT re-block when stop_hook_active is true (loop guard prevents traps)', () => {
+    const r = runHook(hookPath, projectDir, {
+      session_id: 'f5',
+      stop_hook_active: true,
+      last_assistant_message: "The durable fix is tracked so it can't slip; next focused session.",
+    });
+    expect(r.code).toBe(0);
+    expect(r.stdout).not.toContain('"decision":"block"');
+  });
+});

--- a/upgrades/next/false-excuse-deferral-stop-guard.md
+++ b/upgrades/next/false-excuse-deferral-stop-guard.md
@@ -1,0 +1,44 @@
+<!-- bump: minor -->
+<!-- change_type: feature -->
+
+## What Changed
+
+A new guard in the agent's Stop hook catches a specific, recurring self-sabotage: the agent names
+clear work it knows how to do next, then stops anyway with a self-protective excuse — "this session
+is too long," "it's late," "I made mistakes so I'll be careful," "I don't want to rush," "it's
+tracked so it won't slip," "I'll do it next session." Those are false reasons to stop. The guard
+detects the pattern (a named next action plus one of those rationalizations) and blocks the stop
+once, re-feeding a reminder that the excuse is false and to proceed now. It can never trap the agent
+in a loop, and it leaves a genuine stop alone (a real external blocker, work actually finished, or a
+decision only the user can make).
+
+## What to Tell Your User
+
+Your agent should stop wasting your time by quitting partway through work it clearly knows how to
+finish. If it tries to stop with an excuse like "it's late" or "let's do this next session" while
+there's an obvious next step, it now gets caught and nudged to just do the thing — so you no longer
+have to come back and say "okay, do the thing you just said you'd do."
+
+## Summary of New Capabilities
+
+- `stop-gate-router` hook gains a mode-independent `falseExcuseDeferralGuard`: when the final message
+  contains BOTH a named piece of remaining work AND a self-protective deferral rationalization
+  (session-length, time-of-day, made-mistakes, don't-rush, tracked-so-it-won't-slip, next-session),
+  it blocks the stop once and re-feeds a "this is false — proceed now" directive.
+- Pure substring matching, fires once per stop (the `stop_hook_active` loop guard prevents traps),
+  and requires the AND of both signals so a genuine completion or a no-work time reference is not
+  blocked.
+- Ships to every agent automatically via the always-overwrite hook update path (no per-agent
+  migration needed).
+
+## Evidence
+
+**Before:** the Stop gate only caught "stated-continuation" (the agent saying "I'll do X now" then
+not). It did NOT catch the inverse — the agent explicitly justifying NOT doing the clear next thing
+("after a long session I won't rush this; it's tracked"). That pattern repeatedly ended sessions
+early and forced the operator to re-issue "do the thing you just said." **After:** the new guard
+catches it. Reproduced by `tests/unit/stop-gate-false-excuse-deferral.test.ts` (6 cases): it renders
+valid JS, blocks the real-world excuse-stop and a session-length/next-session deferral, does NOT
+block a genuine completion or a time reference with no pending work, and does NOT re-block under
+`stop_hook_active`. The existing `stop-gate-stated-continuation` + `generated-hooks-parse` suites
+stay green.

--- a/upgrades/side-effects/false-excuse-deferral-stop-guard.md
+++ b/upgrades/side-effects/false-excuse-deferral-stop-guard.md
@@ -1,0 +1,75 @@
+# Side-Effects Review — False-Excuse Deferral Stop-Guard
+
+**Slug:** `false-excuse-deferral-stop-guard` · **Tier:** 1 (small, low-risk hook behavior addition;
+operator-requested direct fix, no spec). Touches `PostUpdateMigrator.getStopGateRouterHook()` (a
+hook template), so the tier signal flags `belowFloor` (a PostUpdateMigrator touch raises the floor) —
+accepted: the change is a self-contained substring guard, fully reversible, no external surface.
+
+## Summary of the change
+
+`stop-gate-router` hook gains `falseExcuseDeferralGuard`, mirroring the existing
+`statedContinuationGuard`: a mode-independent IIFE that, on a Stop, blocks ONCE when the final
+assistant message contains BOTH (a) a named piece of remaining work AND (b) a self-protective
+deferral rationalization (session-length / time-of-day / made-mistakes / don't-rush /
+tracked-so-it-won't-slip / next-session), re-feeding a "this excuse is false — proceed" directive.
+Same change in the deployed copy is overwritten from this source on the next update (Migration
+Parity — always-overwrite built-in hooks), so it reaches every agent.
+
+## 1. Over-block / false positive
+
+The AND-of-both-signals requirement is the false-positive control: a self-protective phrase alone
+(e.g. "it's late, but everything is done") does NOT block — `knownWork` must also match. Tested:
+a genuine completion and a time-reference-with-no-pending-work both pass through (no block). Cost of
+any residual false positive is bounded to ONE extra turn (the agent re-affirms and re-stops), because
+the guard fires once.
+
+## 2. Under-block
+
+If the agent stops with an excuse but uses wording outside the phrase lists, it slips through (a
+false negative) — acceptable: the guard is a high-precision catch for the documented recurring
+phrasings, not a complete classifier. The lists cover the operator-cited forms and the agent's actual
+observed messages. Tunable by extending the arrays.
+
+## 4. Signal vs authority
+
+The guard is a one-shot re-feed (block decision with a reminder), exactly like the
+stated-continuation guard. It never silences or rewrites a message and takes no destructive action.
+The `stop_hook_active` loop guard guarantees the agent is never trapped — a legitimate stop (real
+external blocker / work complete / a user-only decision) re-stops cleanly on the next attempt.
+
+## 5. Interactions
+
+Sits directly after `statedContinuationGuard` in the same hook, before the server round-trip — so it
+works even when the server-side stop-gate is in shadow/off mode (which is exactly when these stalls
+slip through). No new dependency, no network call, no state. Pure substring matching. Cannot recurse
+or grow unbounded.
+
+## 6. External surfaces
+
+None. No route, no egress, no spend (no LLM call — deterministic substring matching in the hook
+subprocess).
+
+## 7. Multi-machine posture
+
+Machine-local: the hook runs per-session on whichever machine hosts the session. No replicated state.
+Each agent on each machine gets the guard via the standard hook update.
+
+## 8. Rollback cost
+
+Trivial: delete the `falseExcuseDeferralGuard` IIFE from `getStopGateRouterHook()`; the next update
+overwrites the deployed copy back to guard-free. No data, no migration to unwind.
+
+## Evidence pointers
+
+- `tests/unit/stop-gate-false-excuse-deferral.test.ts` (6): renders valid JS containing the guard;
+  blocks the real-world excuse-stop (named work + self-protective excuse); blocks a
+  session-length/next-session deferral; does NOT block a genuine completion; does NOT block a time
+  reference with no deferred work (false-positive control); does NOT re-block under `stop_hook_active`.
+- `tests/unit/stop-gate-stated-continuation.test.ts` + `tests/unit/generated-hooks-parse.test.ts`
+  stay green (the template literal still renders valid JS). Full `tsc` clean.
+
+## Conclusion
+
+Delivers the operator-requested structural catch for the recurring false-excuse early-stop, as an
+instar feature that ships to every agent. High-precision, loop-safe, reversible, no external surface.
+Ship.


### PR DESCRIPTION
## False-excuse deferral Stop-guard — catch self-protective early-stops (instar feature, fleet-wide)

Operator-requested. The agent repeatedly NAMES clear remaining work it knows how to do, then STOPS with a self-protective excuse — "this session is too long," "it's late / at midnight," "I made wrong turns so I'll be careful," "I don't want to rush," "it's tracked so it can't slip," "I'll do it next session" — forcing the operator to come back and say "okay, do the thing you just said." These are false reasons to stop.

Adds `falseExcuseDeferralGuard` to the `stop-gate-router` hook (in `PostUpdateMigrator.getStopGateRouterHook()` — the always-overwritten source, so it ships to **every agent** via the update path, not just one). It mirrors the existing `statedContinuationGuard`: on a Stop, it blocks ONCE when the final message contains BOTH (a) a named piece of remaining work AND (b) a self-protective deferral rationalization, re-feeding a "this excuse is false — proceed now" directive.

- **High-precision:** requires the AND of both signals, so a genuine completion or a no-work time reference is NOT blocked.
- **Loop-safe:** fires once; `stop_hook_active` passes through (no trap).
- **No LLM call** — deterministic substring matching. Reversible. Machine-local.

### Tests
6 cases in `tests/unit/stop-gate-false-excuse-deferral.test.ts` (renders valid JS + contains the guard; blocks the real-world excuse-stop and a session-length/next-session deferral; does NOT block a clean completion or a no-work time reference; does NOT re-block under `stop_hook_active`). `stop-gate-stated-continuation` + `generated-hooks-parse` stay green; tsc clean. Tier 1 (belowFloor recorded — PostUpdateMigrator touch; a self-contained reversible guard).

## ELI16 — The agent kept quitting partway through work it clearly knew how to finish, with fake excuses like "it's late" or "I'll do it next session"; this catches that and tells it to just do the thing now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
