### PR TITLE
fix(perf): bounded tail-reads for the 12MB telegram-log + 14MB feedback-store — the dominant dashboard event-loop freeze

### DIFF
--- a/.instar/instar-dev-decisions/2026-06-22T20-32-07-837Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-06-22T20-32-07-837Z-unknown.json
@@ -1,0 +1,15 @@
+{
+  "ts": "2026-06-22T20:32:07.837Z",
+  "slug": "unknown",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "safety-invariant proximity: src/messaging/TelegramAdapter.ts matches Telegram adapter"
+  ],
+  "belowFloor": true,
+  "files": 6,
+  "loc": 184,
+  "causalAutopsy": null,
+  "verdict": "pass"
+}

--- a/src/commands/server.ts
+++ b/src/commands/server.ts
@@ -157,6 +157,7 @@ import { DegradationReporter } from '../monitoring/DegradationReporter.js';
 import { HumanAsDetectorLog, observeInboundMessage } from '../monitoring/HumanAsDetectorLog.js';
 import { creditUsherOnMiss } from '../core/UsherActedCorrelator.js';
 import { resolveStableNodeBinary } from '../utils/resolveNodeBinary.js';
+import { readJsonlTailLastLines } from '../utils/jsonl-tail.js';
 import { SelfKnowledgeTree } from '../knowledge/SelfKnowledgeTree.js';
 import { CoverageAuditor } from '../knowledge/CoverageAuditor.js';
 import { LiveConfig } from '../config/LiveConfig.js';
@@ -11231,8 +11232,11 @@ export async function startServer(options: StartOptions): Promise<void> {
         // the ack was on disk. Same isBriefAck export feeds both paths now.
         const checkLogForAgentResponse = (logPath: string, topicId: number, sinceIso: string): boolean => {
           try {
-            const content = fs.readFileSync(logPath, 'utf-8');
-            const lines = content.trim().split('\n').slice(-50);
+            // Bounded TAIL read — never the whole file. This only inspects the
+            // last 50 lines, so loading the full multi-MB telegram-messages.jsonl
+            // on every PresenceProxy tier verdict was an event-loop freeze
+            // (2026-06-22 batch). The 512KB window holds far more than 50 lines.
+            const lines = readJsonlTailLastLines(logPath, 50);
             for (const line of lines) {
               try {
                 const msg = JSON.parse(line);

--- a/src/feedback-factory/store/JsonlFeedbackStore.ts
+++ b/src/feedback-factory/store/JsonlFeedbackStore.ts
@@ -23,7 +23,7 @@
  * 148k-row artifact parses in well under a second.
  */
 
-import { appendFileSync, mkdirSync, readFileSync, existsSync, writeFileSync, renameSync } from 'node:fs';
+import { appendFileSync, mkdirSync, readFileSync, existsSync, writeFileSync, renameSync, statSync } from 'node:fs';
 import { join } from 'node:path';
 import type { FeedbackItem, Cluster } from '../processor/types.js';
 import type { ReopenDecision } from '../processor/reopen.js';
@@ -261,10 +261,35 @@ export class JsonlFeedbackStore implements FeedbackStore {
   }
 }
 
+/**
+ * (size, mtimeMs) load cache — skip the synchronous multi-MB read+parse when the
+ * on-disk file is byte-for-byte the one we last folded. `reload()` is called at
+ * the start of every processing pass, and the feedback.jsonl corpus is multiple
+ * MB; re-reading + JSON.parsing the whole file on the event loop when nothing
+ * changed since the last load was a needless freeze (2026-06-22 batch). Mirrors
+ * the JobRunHistory (size, mtime) cache pattern. Keyed per absolute path. The
+ * cached `rows` Map is cloned on serve so a caller's mutations never poison the
+ * cache (and the next genuine change still re-reads from disk).
+ */
+const loadCache = new Map<string, { size: number; mtimeMs: number; rows: Map<string, unknown>; totalLines: number }>();
+
 function loadJsonl<T>(path: string, idOf: (row: Record<string, unknown>) => string): LoadResult<T> {
   const rows = new Map<string, T>();
   let totalLines = 0;
-  if (!existsSync(path)) return { rows, totalLines };
+  if (!existsSync(path)) {
+    loadCache.delete(path);
+    return { rows, totalLines };
+  }
+  // (size, mtime) cache: serve a clone of the prior fold when the file is unchanged.
+  let fingerprint: { size: number; mtimeMs: number } | null = null;
+  try {
+    const st = statSync(path);
+    fingerprint = { size: st.size, mtimeMs: st.mtimeMs };
+    const cached = loadCache.get(path);
+    if (cached && cached.size === st.size && cached.mtimeMs === st.mtimeMs) {
+      return { rows: new Map(cached.rows as Map<string, T>), totalLines: cached.totalLines };
+    }
+  } catch { /* fall through to a full read — never let stat failure skip the load */ }
   const txt = readFileSync(path, 'utf8');
   for (const line of txt.split('\n')) {
     const trimmed = line.trim();
@@ -280,7 +305,18 @@ function loadJsonl<T>(path: string, idOf: (row: Record<string, unknown>) => stri
       // a full row. Durability beats strictness for an append log.
     }
   }
+  // Cache this fold against the fingerprint we read it at, so an unchanged file
+  // is served from memory next time. Store a clone so a caller mutating the
+  // returned Map can never poison the cache.
+  if (fingerprint) {
+    loadCache.set(path, { ...fingerprint, rows: new Map(rows), totalLines });
+  }
   return { rows, totalLines };
+}
+
+/** Test-only: clear the (size, mtime) load cache between cases. */
+export function __clearFeedbackLoadCacheForTests(): void {
+  loadCache.clear();
 }
 
 /** Resolve a row's primary-key id from the AS-IS field aliases (mirrors importRunner's pickId). */

--- a/src/messaging/TelegramAdapter.ts
+++ b/src/messaging/TelegramAdapter.ts
@@ -27,6 +27,7 @@ import { CallbackRegistry, isAllowedButtonKey } from '../core/CallbackRegistry.j
 import type { DetectedPrompt } from '../monitoring/PromptGate.js';
 import { sanitizeForPrompt } from '../monitoring/SessionRecovery.js';
 import { formatForTelegram, type FormatMode } from './TelegramMarkdownFormatter.js';
+import { readJsonlTailLastLines } from '../utils/jsonl-tail.js';
 import {
   recordFormatApplied,
   recordFormatLintIssue,
@@ -2625,8 +2626,11 @@ export class TelegramAdapter implements MessagingAdapter {
   getMessageLog(limit = 100): Array<{ topicId: number; text: string; fromUser: boolean; timestamp: string }> {
     try {
       if (!fs.existsSync(this.messageLogPath)) return [];
-      const content = fs.readFileSync(this.messageLogPath, 'utf-8');
-      const lines = content.trim().split('\n').filter(Boolean).slice(-limit);
+      // Bounded TAIL read — never the whole file. This only returns the last
+      // `limit` entries (default 100), so loading the full multi-MB
+      // telegram-messages.jsonl was a needless event-loop blocker (2026-06-22
+      // batch). The 512KB window holds ~2,600 recent lines, well over any limit.
+      const lines = readJsonlTailLastLines(this.messageLogPath, limit);
       return lines.map(line => {
         try {
           const entry = JSON.parse(line);

--- a/src/monitoring/CoherenceMonitor.ts
+++ b/src/monitoring/CoherenceMonitor.ts
@@ -23,6 +23,7 @@ import type { ComponentHealth } from '../core/types.js';
 import { ProcessIntegrity } from '../core/ProcessIntegrity.js';
 import { DegradationReporter } from './DegradationReporter.js';
 import { isSecretPlaceholder } from '../core/SecretMigrator.js';
+import { readJsonlTailLines } from '../utils/jsonl-tail.js';
 
 // ── Types ─────────────────────────────────────────────────────────
 
@@ -490,7 +491,11 @@ export class CoherenceMonitor extends EventEmitter {
     }
 
     try {
-      const lines = fs.readFileSync(logPath, 'utf-8').trim().split('\n');
+      // Bounded TAIL read — never the whole file. This check only inspects the
+      // last 50 agent messages, so loading the full multi-MB
+      // telegram-messages.jsonl on a 5-minute timer was a pure event-loop freeze
+      // (2026-06-22 batch). The 512KB window holds far more than the last 50.
+      const lines = readJsonlTailLines(logPath).lines;
       // Check last 50 agent messages (fromUser: false)
       const agentMessages: Array<{ text: string; timestamp: string }> = [];
       for (let i = lines.length - 1; i >= 0 && agentMessages.length < 50; i--) {

--- a/src/monitoring/CommitmentSentinel.ts
+++ b/src/monitoring/CommitmentSentinel.ts
@@ -17,6 +17,7 @@ import path from 'node:path';
 import type { IntelligenceProvider } from '../core/types.js';
 import type { CommitmentTracker, CommitmentType } from './CommitmentTracker.js';
 import { DegradationReporter } from './DegradationReporter.js';
+import { readJsonlTailLines } from '../utils/jsonl-tail.js';
 
 // ── Types ─────────────────────────────────────────────────────────
 
@@ -227,8 +228,12 @@ export class CommitmentSentinel {
     if (!fs.existsSync(this.messagesPath)) return [];
 
     try {
-      const content = fs.readFileSync(this.messagesPath, 'utf-8');
-      const lines = content.trim().split('\n');
+      // Bounded TAIL read — never the whole file. This scanner only ever
+      // inspects the last `maxPerScan*10` lines, so loading the full multi-MB
+      // telegram-messages.jsonl on a 5-minute timer was a pure event-loop
+      // freeze (2026-06-22 batch). The 512KB window holds ~2,600 recent lines,
+      // far more than maxPerScan*10, while staying O(window) regardless of size.
+      const lines = readJsonlTailLines(this.messagesPath).lines;
       const messages: TelegramMessage[] = [];
       const maxPerScan = this.config.maxMessagesPerScan ?? 20;
 

--- a/src/utils/jsonl-tail.ts
+++ b/src/utils/jsonl-tail.ts
@@ -1,0 +1,112 @@
+/**
+ * Bounded JSONL tail reader — read only the LAST window of an append-only log,
+ * never the whole file.
+ *
+ * Born from the 2026-06-22 event-loop-freeze batch: several timers and event
+ * handlers (CommitmentSentinel, CoherenceMonitor, PresenceProxy's
+ * checkLogForAgentResponse, TelegramAdapter.getMessageLog) each called
+ * `fs.readFileSync(messageLogPath, 'utf-8')` on the 12MB telegram-messages.jsonl
+ * just to look at the last ~50–200 lines. A 12MB synchronous read+split on a
+ * 5-minute timer froze the event loop for up to 20s per pass. These callers do
+ * not need the whole file — only its tail.
+ *
+ * Design (mirrors CoherenceJournal.readTailTolerant, generalized off the
+ * journal's typed entry shape):
+ *   - statSync the file (O(1)) — read at most `maxBytes` from the END.
+ *   - openSync + readSync the trailing window into a fixed buffer; never load
+ *     the whole file. O(maxBytes), not O(file).
+ *   - Discard the first (partial) line when the window started mid-file so a
+ *     truncated record is never mis-parsed.
+ *   - Return the raw trailing lines (newest LAST, file order preserved) — the
+ *     caller parses + filters exactly as it did over the full split before.
+ *
+ * Never throws — a read failure returns an empty result, matching the
+ * @silent-fallback-ok behavior of every former full-file caller. Observability
+ * / housekeeping reads must never endanger the observed operation.
+ */
+
+import fs from 'node:fs';
+
+/** Default trailing window: 512KB. At ~200 bytes/line that is ~2,600 recent
+ *  lines — far more than any caller's last-50/last-200 need, with headroom for
+ *  long messages, while staying a small bounded read regardless of file size. */
+export const DEFAULT_TAIL_BYTES = 512 * 1024;
+
+export interface TailReadResult {
+  /** Trailing lines in FILE order (oldest of the window first, newest last).
+   *  Non-empty lines only — blank lines are dropped. */
+  lines: string[];
+  /** True when the file was larger than the window (the head was not read). */
+  truncated: boolean;
+}
+
+/**
+ * Read the last `maxBytes` of `filePath` and return its non-empty lines in file
+ * order. Reads at most `maxBytes` from disk regardless of total file size.
+ */
+export function readJsonlTailLines(
+  filePath: string,
+  maxBytes: number = DEFAULT_TAIL_BYTES,
+): TailReadResult {
+  const empty: TailReadResult = { lines: [], truncated: false };
+  try {
+    if (!fs.existsSync(filePath)) return empty;
+  } catch {
+    return empty;
+  }
+
+  let size: number;
+  try {
+    size = fs.statSync(filePath).size;
+  } catch {
+    return empty;
+  }
+  if (size === 0) return empty;
+
+  const readBytes = Math.min(size, maxBytes);
+  const truncated = readBytes < size;
+  const start = size - readBytes;
+
+  let buf: Buffer;
+  let fd: number | null = null;
+  try {
+    fd = fs.openSync(filePath, 'r');
+    buf = Buffer.alloc(readBytes);
+    fs.readSync(fd, buf, 0, readBytes, start);
+  } catch {
+    return empty;
+  } finally {
+    if (fd !== null) {
+      try {
+        fs.closeSync(fd);
+      } catch {
+        /* best-effort */
+      }
+    }
+  }
+
+  let text = buf.toString('utf-8');
+  // If the window started mid-file, the first line is a partial record — drop it.
+  if (start > 0) {
+    const nl = text.indexOf('\n');
+    text = nl >= 0 ? text.slice(nl + 1) : '';
+  }
+
+  const lines = text.split('\n').filter((l) => l.length > 0);
+  return { lines, truncated };
+}
+
+/**
+ * Convenience: read the tail and return at most the last `limit` non-empty
+ * lines (file order). Equivalent to the common
+ * `readFileSync(...).split('\n').filter(Boolean).slice(-limit)` pattern, but
+ * bounded to a trailing `maxBytes` window instead of the whole file.
+ */
+export function readJsonlTailLastLines(
+  filePath: string,
+  limit: number,
+  maxBytes: number = DEFAULT_TAIL_BYTES,
+): string[] {
+  const { lines } = readJsonlTailLines(filePath, maxBytes);
+  return limit >= lines.length ? lines : lines.slice(-limit);
+}

--- a/tests/unit/CoherenceMonitor-bounded-read.test.ts
+++ b/tests/unit/CoherenceMonitor-bounded-read.test.ts
@@ -1,0 +1,75 @@
+/**
+ * Event-loop blocker regression (2026-06-22 batch) — CoherenceMonitor's
+ * output-sanity check must read only a bounded TAIL of telegram-messages.jsonl,
+ * never the whole multi-MB file. A 12MB synchronous read on a 5-minute timer
+ * froze the event loop (up to 20s). The check only inspects the last 50 agent
+ * messages, so the tail window is sufficient — and a bad pattern in a recent
+ * agent message must STILL be caught.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { CoherenceMonitor } from '../../src/monitoring/CoherenceMonitor.js';
+import { LiveConfig } from '../../src/config/LiveConfig.js';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+
+let stateDir: string;
+
+beforeEach(() => {
+  stateDir = fs.mkdtempSync(path.join(os.tmpdir(), 'coherence-bounded-'));
+  fs.mkdirSync(path.join(stateDir, 'state'), { recursive: true });
+  fs.writeFileSync(path.join(stateDir, 'config.json'), JSON.stringify({}, null, 2));
+});
+
+afterEach(() => {
+  SafeFsExecutor.safeRmSync(stateDir, { recursive: true, force: true, operation: 'tests/unit/CoherenceMonitor-bounded-read.test.ts' });
+  vi.restoreAllMocks();
+});
+
+function makeMonitor(): CoherenceMonitor {
+  return new CoherenceMonitor({ stateDir, liveConfig: new LiveConfig(stateDir) });
+}
+
+function writeBigLog(recentAgentText: string): void {
+  const logPath = path.join(stateDir, 'telegram-messages.jsonl');
+  const lines: string[] = [];
+  for (let i = 0; i < 25_000; i++) {
+    lines.push(JSON.stringify({ messageId: i, topicId: 1, text: 'older clean message '.repeat(4), fromUser: i % 2 === 0, timestamp: new Date().toISOString() }));
+  }
+  // The interesting recent agent message at the very END.
+  lines.push(JSON.stringify({ messageId: 99999, topicId: 1, text: recentAgentText, fromUser: false, timestamp: new Date().toISOString() }));
+  fs.writeFileSync(logPath, lines.join('\n') + '\n');
+  expect(fs.statSync(logPath).size).toBeGreaterThan(2_000_000);
+}
+
+describe('CoherenceMonitor output-sanity bounded read', () => {
+  it('never calls fs.readFileSync on the multi-MB message log', () => {
+    writeBigLog('all good here');
+    const logPath = path.join(stateDir, 'telegram-messages.jsonl');
+
+    const realReadFileSync = fs.readFileSync.bind(fs);
+    const spy = vi.spyOn(fs, 'readFileSync').mockImplementation(((p: fs.PathOrFileDescriptor, ...rest: unknown[]) => {
+      if (typeof p === 'string' && p === logPath) {
+        throw new Error('REGRESSION: full-file fs.readFileSync on telegram-messages.jsonl');
+      }
+      // @ts-expect-error pass-through
+      return realReadFileSync(p, ...rest);
+    }) as typeof fs.readFileSync);
+
+    const monitor = makeMonitor();
+    expect(() => monitor.runCheck()).not.toThrow();
+    spy.mockRestore();
+  });
+
+  it('still flags a bad pattern in a RECENT agent message at the tail of a large log', () => {
+    // A localhost URL in the newest agent message — must be caught via the tail read.
+    writeBigLog('Open your dashboard at http://localhost:4040/dashboard');
+    const monitor = makeMonitor();
+    const report = monitor.runCheck();
+    const sanity = report.checks.find((c) => c.name === 'output-sanity');
+    expect(sanity).toBeDefined();
+    expect(sanity!.passed).toBe(false); // the recent localhost message was reachable
+  });
+});

--- a/tests/unit/CommitmentSentinel.test.ts
+++ b/tests/unit/CommitmentSentinel.test.ts
@@ -579,6 +579,68 @@ describe('CommitmentSentinel', () => {
     });
   });
 
+  // ── Event-loop blocker regression (2026-06-22 batch) ──────────
+  // readNewMessages must NOT synchronously read the whole multi-MB
+  // telegram-messages.jsonl — only a bounded TAIL window. This is the
+  // freeze fix: a 12MB sync read on a 5-minute timer froze the loop ~20s.
+  describe('bounded tail read (does not load the whole message log)', () => {
+    it('never calls fs.readFileSync on the multi-MB message log', async () => {
+      const messagesPath = path.join(stateDir, 'telegram-messages.jsonl');
+      // ~3MB of older messages + a recent commitment pair at the very end.
+      const filler: string[] = [];
+      for (let i = 0; i < 30_000; i++) {
+        filler.push(JSON.stringify({
+          messageId: i, topicId: 100, text: 'x'.repeat(80), fromUser: i % 2 === 0,
+          timestamp: new Date().toISOString(),
+        }));
+      }
+      filler.push(JSON.stringify({ messageId: 99998, topicId: 100, text: 'Please turn off auto-updates', fromUser: true, timestamp: new Date().toISOString() }));
+      filler.push(JSON.stringify({ messageId: 99999, topicId: 100, text: "On it — I'll turn off auto-updates now", fromUser: false, timestamp: new Date().toISOString() }));
+      fs.writeFileSync(messagesPath, filler.join('\n') + '\n');
+      expect(fs.statSync(messagesPath).size).toBeGreaterThan(2_000_000);
+
+      // Spy: a full-file read of the message log would be a regression.
+      const realReadFileSync = fs.readFileSync.bind(fs);
+      const spy = vi.spyOn(fs, 'readFileSync').mockImplementation(((p: fs.PathOrFileDescriptor, ...rest: unknown[]) => {
+        if (typeof p === 'string' && p.endsWith('telegram-messages.jsonl')) {
+          throw new Error('REGRESSION: full-file fs.readFileSync on telegram-messages.jsonl');
+        }
+        // @ts-expect-error pass-through to the real impl for every other path
+        return realReadFileSync(p, ...rest);
+      }) as typeof fs.readFileSync);
+
+      const intelligence = createMockIntelligence('[]');
+      const { sentinel } = makeSentinel(stateDir, intelligence);
+
+      // Must not throw — the sentinel must reach the recent messages via the
+      // bounded tail reader (openSync/readSync), never a full readFileSync.
+      await expect(sentinel.scan()).resolves.toBeDefined();
+      spy.mockRestore();
+    });
+
+    it('still detects a recent commitment that sits at the END of a large log', async () => {
+      const messagesPath = path.join(stateDir, 'telegram-messages.jsonl');
+      const filler: string[] = [];
+      for (let i = 0; i < 20_000; i++) {
+        filler.push(JSON.stringify({ messageId: i, topicId: 100, text: 'old noise '.repeat(8), fromUser: i % 2 === 0, timestamp: new Date(Date.now() - 1_000_000).toISOString() }));
+      }
+      filler.push(JSON.stringify({ messageId: 90001, topicId: 100, text: 'Can you turn off auto-updates?', fromUser: true, timestamp: new Date().toISOString() }));
+      filler.push(JSON.stringify({ messageId: 90002, topicId: 100, text: "I'll turn off auto-updates for you", fromUser: false, timestamp: new Date().toISOString() }));
+      fs.writeFileSync(messagesPath, filler.join('\n') + '\n');
+
+      const intelligence = createMockIntelligence(JSON.stringify([
+        { commitment: 'turn off auto-updates', type: 'one-time-action', confidence: 0.9 },
+      ]));
+      const { sentinel } = makeSentinel(stateDir, intelligence);
+      const detected = await sentinel.scan();
+      // The recent user→agent pair sits at the very END of a 20k-line log. Reading
+      // only the bounded tail must STILL surface it: the LLM was invoked over the
+      // pair (proving the tail read reached the newest records, not just the head).
+      expect((intelligence.evaluate as ReturnType<typeof vi.fn>)).toHaveBeenCalled();
+      expect(typeof detected).toBe('number'); // scan() returns a count
+    });
+  });
+
   // ── Lifecycle ──────────────────────────────────────────
 
   describe('start() / stop()', () => {

--- a/tests/unit/feedback-factory/jsonl-feedback-store.test.ts
+++ b/tests/unit/feedback-factory/jsonl-feedback-store.test.ts
@@ -10,11 +10,11 @@
  * tolerance, and boot-time compaction with an atomic rewrite.
  */
 
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import fs from 'node:fs';
 import path from 'node:path';
 import os from 'node:os';
-import { JsonlFeedbackStore } from '../../../src/feedback-factory/store/JsonlFeedbackStore.js';
+import { JsonlFeedbackStore, __clearFeedbackLoadCacheForTests } from '../../../src/feedback-factory/store/JsonlFeedbackStore.js';
 import { SafeFsExecutor } from '../../../src/core/SafeFsExecutor.js';
 
 let dir: string;
@@ -138,5 +138,58 @@ describe('JsonlFeedbackStore — compaction', () => {
     ].join('\n') + '\n', 'utf8');
     new JsonlFeedbackStore(dir);
     expect(fs.readFileSync(p, 'utf8').trim().split('\n')).toHaveLength(2); // untouched
+  });
+});
+
+// ── Event-loop blocker regression (2026-06-22 batch) ────────────────────
+// reload() re-reads the multi-MB feedback.jsonl on every processing pass. A
+// (size, mtime) cache skips the synchronous read+parse when the file is
+// byte-identical to the last fold — but a genuine append MUST still be seen.
+describe('JsonlFeedbackStore — (size,mtime) load cache', () => {
+  beforeEach(() => __clearFeedbackLoadCacheForTests());
+
+  it('serves an unchanged file from cache WITHOUT re-reading it', () => {
+    const p = path.join(dir, 'feedback.jsonl');
+    const a = new JsonlFeedbackStore(dir); // first load populates the cache
+    a.addFeedback(item('fb-1'));           // append changes the file → cache invalidates
+
+    // A fresh store over the SAME unchanged dir loads the cached fold; a second
+    // fresh store must NOT call readFileSync on feedback.jsonl (served from cache).
+    new JsonlFeedbackStore(dir); // primes the cache against the current bytes
+    const realReadFileSync = fs.readFileSync.bind(fs);
+    let readTheFeedbackFile = false;
+    const spy = vi.spyOn(fs, 'readFileSync').mockImplementation(((fp: fs.PathOrFileDescriptor, ...rest: unknown[]) => {
+      if (typeof fp === 'string' && fp === p) readTheFeedbackFile = true;
+      // @ts-expect-error pass-through
+      return realReadFileSync(fp, ...rest);
+    }) as typeof fs.readFileSync);
+
+    const c = new JsonlFeedbackStore(dir);
+    expect(c.hasFeedback('fb-1')).toBe(true); // correct data
+    expect(readTheFeedbackFile).toBe(false);  // but served from the (size,mtime) cache
+    spy.mockRestore();
+  });
+
+  it('re-reads (cache invalidates) when the file genuinely grows', () => {
+    const p = path.join(dir, 'feedback.jsonl');
+    new JsonlFeedbackStore(dir); // populate cache (empty/absent file)
+    // Simulate ANOTHER process (the InboxDrainer) appending a new row.
+    fs.appendFileSync(p, JSON.stringify(item('fb-new')) + '\n');
+    // A fresh store must observe the appended row — cache keyed on (size,mtime)
+    // detects the change and re-folds from disk.
+    const after = new JsonlFeedbackStore(dir);
+    expect(after.hasFeedback('fb-new')).toBe(true);
+  });
+
+  it('two stores over the same unchanged file get independent row Maps (clone per serve)', () => {
+    const p = path.join(dir, 'feedback.jsonl');
+    fs.writeFileSync(p, JSON.stringify(item('fb-1')) + '\n', 'utf8');
+    const a = new JsonlFeedbackStore(dir); // first load → cache
+    const b = new JsonlFeedbackStore(dir); // served from the (size,mtime) cache
+    // Each store got `new Map(cached.rows)`, so a's later append never bleeds
+    // into b's Map identity (the cache hands out a fresh Map per serve).
+    a.addFeedback(item('fb-2'));
+    expect(a.hasFeedback('fb-2')).toBe(true);
+    expect(b.hasFeedback('fb-2')).toBe(false);
   });
 });

--- a/tests/unit/jsonl-tail.test.ts
+++ b/tests/unit/jsonl-tail.test.ts
@@ -1,0 +1,103 @@
+// safe-git-allow: test-tmpdir-cleanup — afterEach() removes this test's own
+// os.tmpdir() scratch directory (created via fs.mkdtempSync). A unit test
+// pulling in SafeFsExecutor just to delete its own jailed tmpdir is worse noise
+// than this scoped per-file allow (mirrors the destructive-lint allowlist note).
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { readJsonlTailLines, readJsonlTailLastLines, DEFAULT_TAIL_BYTES } from '../../src/utils/jsonl-tail.js';
+
+describe('jsonl-tail bounded reader', () => {
+  let tmpDir: string;
+  let file: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'jsonl-tail-'));
+    file = path.join(tmpDir, 'log.jsonl');
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  function writeLines(n: number, prefix = 'line'): void {
+    const out: string[] = [];
+    for (let i = 0; i < n; i++) out.push(JSON.stringify({ i, t: `${prefix}-${i}` }));
+    fs.writeFileSync(file, out.join('\n') + '\n');
+  }
+
+  it('returns empty for a missing file', () => {
+    const r = readJsonlTailLines(path.join(tmpDir, 'nope.jsonl'));
+    expect(r.lines).toEqual([]);
+    expect(r.truncated).toBe(false);
+  });
+
+  it('returns empty for an empty file', () => {
+    fs.writeFileSync(file, '');
+    const r = readJsonlTailLines(file);
+    expect(r.lines).toEqual([]);
+  });
+
+  it('returns all lines (file order) when the file fits the window', () => {
+    writeLines(5);
+    const r = readJsonlTailLines(file);
+    expect(r.lines).toHaveLength(5);
+    expect(r.truncated).toBe(false);
+    expect(JSON.parse(r.lines[0]).i).toBe(0);
+    expect(JSON.parse(r.lines[4]).i).toBe(4);
+  });
+
+  it('reads only the TAIL window of a large file — never the whole file', () => {
+    // 50,000 lines of ~30 bytes = ~1.5MB. With a tiny 4KB window we must read
+    // only a small suffix, not all 50k lines.
+    writeLines(50_000);
+    const fileSize = fs.statSync(file).size;
+    expect(fileSize).toBeGreaterThan(1_000_000);
+
+    const r = readJsonlTailLines(file, 4096);
+    expect(r.truncated).toBe(true);
+    // Far fewer than 50k lines were returned (only the ~4KB suffix).
+    expect(r.lines.length).toBeLessThan(500);
+    expect(r.lines.length).toBeGreaterThan(0);
+    // The LAST line of the file is present and is the newest record.
+    const last = JSON.parse(r.lines[r.lines.length - 1]);
+    expect(last.i).toBe(49_999);
+  });
+
+  it('drops the partial first line when the window starts mid-record', () => {
+    // Force a mid-record cut: write lines, then read a window that lands
+    // partway through some earlier line. Every returned line must parse.
+    writeLines(10_000);
+    const r = readJsonlTailLines(file, 2048);
+    expect(r.truncated).toBe(true);
+    for (const ln of r.lines) {
+      expect(() => JSON.parse(ln)).not.toThrow();
+    }
+  });
+
+  it('readJsonlTailLastLines returns at most `limit` newest lines', () => {
+    writeLines(1000);
+    const last50 = readJsonlTailLastLines(file, 50);
+    expect(last50).toHaveLength(50);
+    expect(JSON.parse(last50[0]).i).toBe(950);
+    expect(JSON.parse(last50[49]).i).toBe(999);
+  });
+
+  it('readJsonlTailLastLines returns all lines when limit exceeds count', () => {
+    writeLines(7);
+    const got = readJsonlTailLastLines(file, 100);
+    expect(got).toHaveLength(7);
+  });
+
+  it('skips blank lines', () => {
+    fs.writeFileSync(file, '{"i":0}\n\n{"i":1}\n\n');
+    const r = readJsonlTailLines(file);
+    expect(r.lines).toEqual(['{"i":0}', '{"i":1}']);
+  });
+
+  it('DEFAULT_TAIL_BYTES is a small bounded window (well under typical large logs)', () => {
+    expect(DEFAULT_TAIL_BYTES).toBeLessThanOrEqual(1024 * 1024);
+    expect(DEFAULT_TAIL_BYTES).toBeGreaterThan(0);
+  });
+});

--- a/upgrades/eli16/eventloop-bounded-jsonl-reads.md
+++ b/upgrades/eli16/eventloop-bounded-jsonl-reads.md
@@ -1,0 +1,47 @@
+# Bounded tail-reads for the 12MB telegram-log + 14MB feedback-store — ELI16
+
+## What this is
+
+Your agent's server runs everything on one main thread. If any single operation makes that thread
+wait, *everything* waits — the dashboard, your messages, every background check. When that wait is
+long enough, the dashboard's live connection drops (the "Disconnected" flapping you may have seen).
+
+This fixes the THIRD and FOURTH freezes behind that flapping. (The first was a slow shared terminal
+manager; the second was reading the macOS keychain the blocking way; the third was a 13MB job-history
+file re-read whole every minute — all already fixed.) This one is about two more big files.
+
+## What was wrong
+
+Your agent keeps a running log of every Telegram message it has ever sent or received, in a file
+called `telegram-messages.jsonl`. That file has grown to about **12 megabytes**. Several background
+checks only ever need to glance at the LAST few messages in that log — the last 50, or the last 100.
+But the way they were written, they read the **entire 12MB file** from disk and chopped it up, just
+to look at the tail. And some of these checks run on a **5-minute timer**, every few minutes, forever.
+Each one froze the server for up to **20 seconds**. (A second large file, a 14MB feedback log, had
+the same problem: it was re-read and re-parsed from scratch every processing pass even when nothing
+had changed.)
+
+A frozen main thread uses almost no CPU, so the freeze even looked to the agent like the laptop had
+briefly gone to sleep — a misleading signal on top of a real problem.
+
+## What's new
+
+Two simple changes, both behavior-preserving:
+
+- The background checks that only want the tail of the message log now read just the **last chunk**
+  of the file (a 512-kilobyte window — far more than enough to hold the last few hundred messages),
+  not the whole thing. So they're instant no matter how big the file gets.
+- The 14MB feedback log now remembers the file's size and last-modified time. If nothing changed
+  since it last read it, it returns the copy it already has, reading nothing from disk.
+
+So those per-call whole-file reads are gone from every one of these hot paths, and the freezes they
+caused are eliminated. Everything these checks actually do — what they look for, how they parse,
+how they recover from a corrupt file — is unchanged, and proven by tests. One of the new tests even
+plants a problem message at the very END of a multi-megabyte log to prove the tail-read still catches
+recent entries.
+
+## What you need to decide
+
+Nothing. It's self-contained and low-risk, fully covered by tests. One honest note: the log files
+themselves still grow large over time — putting a size cap on them is a separate cleanup I've flagged
+to track, not fixed here. Reading them is no longer a freeze; capping their growth comes next.

--- a/upgrades/next/eventloop-bounded-jsonl-reads.md
+++ b/upgrades/next/eventloop-bounded-jsonl-reads.md
@@ -1,0 +1,55 @@
+<!-- bump: patch -->
+
+# Bounded tail-reads stop the 12MB telegram-log + 14MB feedback-store from freezing the event loop
+
+## What Changed
+
+FOUR callers each did a synchronous `fs.readFileSync` of the ~12MB `.instar/telegram-messages.jsonl`
+just to inspect its last 50–200 lines: `CommitmentSentinel.parseRecentMessages` (5-min timer),
+`CoherenceMonitor`'s output-sanity check (5-min timer), `checkLogForAgentResponse` (PresenceProxy ack
+path, event-driven), and `TelegramAdapter.getMessageLog` (analysis route). A 12MB sync read + split
+on a 5-minute timer froze the event loop up to ~20s per pass — the same ~0-CPU false-sleep signature
+the JobRunHistory fix removed. Separately, `JsonlFeedbackStore` re-read + re-`JSON.parse`d the entire
+~14MB `feedback.jsonl` at the start of every processing pass even when nothing had changed. This is
+the THIRD + FOURTH event-loop-blocker class behind the dashboard "disconnected" flapping (after sync
+tmux, sync keychain, and the JobRunHistory 13MB re-read).
+
+The fix is two behavior-preserving mechanisms: (A) a shared bounded tail-read utility
+(`src/utils/jsonl-tail.ts`) that reads only the last 512KB via `openSync`/`readSync` — mirroring
+`CoherenceJournal.readTailTolerant` — used by the four telegram-log readers; and (B) a
+`(size, mtimeMs)` load cache in `JsonlFeedbackStore` (mirroring the JobRunHistory cache) that serves a
+clone of the prior parse when the file is byte-for-byte unchanged.
+
+## What to Tell Your User
+
+If your dashboard kept dropping its connection even after the tmux, keychain, and job-history fixes,
+these two large files were the remaining cause: a 12MB message log re-read whole on a 5-minute timer,
+and a 14MB feedback log re-parsed from scratch every pass. After this update both freezes are gone —
+the message-log checks read only the last chunk of the file (instant regardless of size), and the
+feedback log is served from memory when nothing changed. (A separate cleanup — capping those files'
+unbounded growth — is tracked separately.)
+
+## Summary of New Capabilities
+
+- New `src/utils/jsonl-tail.ts` bounded tail-reader (`readJsonlTailLines` / `readJsonlTailLastLines`):
+  reads only the last `maxBytes` (default 512KB ≈ 2,600 lines) via `statSync`/`openSync`/`readSync`,
+  drops the partial first line, never loads the whole file, never throws.
+- The four telegram-log tail readers (CommitmentSentinel, CoherenceMonitor, PresenceProxy ack path,
+  TelegramAdapter.getMessageLog) converted from whole-12MB-file sync reads to bounded tail-reads;
+  parsed/filtered results are identical to the old full-split-then-slice.
+- `JsonlFeedbackStore` gains a `(size, mtimeMs)`-keyed in-memory load cache: unchanged file = zero-IO
+  clone-on-serve, any change = full re-read. Existing load semantics (dedup-last-wins, torn-line skip,
+  corrupt-file recovery) preserved exactly.
+- Removes the third + fourth event-loop-blocker class behind the dashboard flapping and the
+  associated SleepWakeDetector false-wakes.
+
+## Evidence
+
+Root cause diagnosed by a live profiler catching the event loop frozen in a whole-file
+ReadFileUtf8 → split on a 5-minute timer (the ~0-CPU false-sleep signature). Fix covered by 48 tests
+across four files: `jsonl-tail` (9 — tail correctness, partial-line drop, missing/empty file,
+truncation flag), `CoherenceMonitor-bounded-read` (2 — a `fs.readFileSync` spy FAILS if the whole
+12MB log is read, AND a bad pattern in a RECENT agent message at the END of a multi-MB log is still
+detected via the tail), `CommitmentSentinel` (26), `jsonl-feedback-store` (11 — including cache-hit
+serves zero-IO and any change re-reads). Cross-impact suites green; tsc exit 0; no-silent-fallbacks +
+bounded-accumulation lints green.

--- a/upgrades/side-effects/eventloop-bounded-jsonl-reads.md
+++ b/upgrades/side-effects/eventloop-bounded-jsonl-reads.md
@@ -1,0 +1,96 @@
+# Side-Effects Review — bounded tail-reads for the 12MB telegram-log + 14MB feedback-store (event-loop freeze fix)
+
+**Slug:** `eventloop-bounded-jsonl-reads` · **Tier:** 1 (focused low-risk bounded-read class fix, no
+spec; live-profiler root-cause). Parent principles: **Structure beats Willpower** — never block the
+event loop (the THIRD + FOURTH distinct event-loop-blocker class behind the dashboard "disconnected"
+flapping, after sync tmux + sync keychain + the JobRunHistory 13MB re-read); and **Bounded
+Accumulation** (the size of an append-only log must never determine the cost of reading it).
+
+## Summary of the change
+
+FOUR callers each did `fs.readFileSync(messageLogPath, 'utf-8')` on the ~12MB
+`.instar/telegram-messages.jsonl` just to inspect the last 50–200 lines:
+- `CommitmentSentinel.parseRecentMessages` (`src/monitoring/CommitmentSentinel.ts`) — 5-minute timer,
+  only ever looks at the last `maxMessagesPerScan*10` lines.
+- `CoherenceMonitor` output-sanity check (`src/monitoring/CoherenceMonitor.ts`) — 5-minute timer,
+  only ever looks at the last 50 agent messages.
+- `checkLogForAgentResponse` (PresenceProxy ack path, `src/commands/server.ts`) — event-driven on
+  every PresenceProxy tier verdict, only ever looks at the last 50 lines.
+- `TelegramAdapter.getMessageLog` (`src/messaging/TelegramAdapter.ts`) — analysis route, only ever
+  returns the last `limit` (default 100) entries.
+
+A 12MB synchronous read + `.split('\n')` on a 5-minute timer froze the event loop for up to ~20s per
+pass — the same ~0-CPU false-sleep signature the JobRunHistory fix removed. PLUS `JsonlFeedbackStore`
+(`src/feedback-factory/store/JsonlFeedbackStore.ts`) re-read + re-`JSON.parse`d the entire ~14MB
+`feedback.jsonl` at the start of every processing pass even when nothing had changed.
+
+The fix is two behavior-preserving mechanisms:
+
+**(A) A shared bounded tail-read utility** — `src/utils/jsonl-tail.ts` (`readJsonlTailLines` /
+`readJsonlTailLastLines`). It `statSync`s the file (O(1)), `openSync` + `readSync`s only the trailing
+`maxBytes` (default 512KB ≈ ~2,600 recent lines, far more than any caller needs) into a fixed buffer,
+drops the first partial line when the window started mid-file, and returns the trailing lines in file
+order. It NEVER loads the whole file and NEVER throws (a read failure returns an empty result,
+matching the `@silent-fallback-ok` behavior of every former full-file caller). It mirrors
+`CoherenceJournal.readTailTolerant`, generalized off that journal's typed-entry shape. The four
+telegram-log readers above now call it instead of `readFileSync`.
+
+**(B) A `(size, mtimeMs)` load cache in `JsonlFeedbackStore.loadJsonl`** — when the on-disk file is
+byte-for-byte the one last folded, it serves a clone of the prior parse with ZERO IO/parse; any
+change (append, shrink, delete) re-reads from disk. Mirrors the JobRunHistory cache pattern. The
+clone-on-serve guarantees a caller mutating the returned Map can never poison the cache.
+
+## 1. Correctness / behavioral equivalence
+
+The telegram-log readers each consumed only a fixed tail (last 50 / last 200 / last `limit`) of the
+log, so the 512KB window (≈ 2,600 lines) is strictly a superset of every caller's need — the parsed +
+filtered result is identical to the old full-split-then-slice. The partial-first-line drop guarantees
+a truncated record at the window boundary is never mis-parsed. The feedback store's load semantics
+(per-line parse, dedup-last-wins-by-id, torn-line skip, corrupt-file recovery) are preserved exactly;
+the cache is only consulted when the fingerprint matches and is invalidated on any change. Verified:
+48/48 across the four touched test files (`jsonl-tail` 9, `CoherenceMonitor-bounded-read` 2,
+`CommitmentSentinel` 26, `jsonl-feedback-store` 11) plus the cross-impact suites; tsc exit 0; lints
+green. The two new regression tests spy on `fs.readFileSync` to FAIL if the whole telegram log is
+read, AND prove a bad pattern in a RECENT agent message at the END of a multi-MB log is still
+detected via the tail.
+
+## 2. Cache-coherence / multi-writer safety
+
+The telegram-log tail-read holds no state — every call re-reads the live tail, so a concurrent
+appender is always reflected. The feedback-store `(size, mtimeMs)` key invalidates on any byte/mtime
+change (append, compaction rewrite, delete-then-recreate), so an unchanged file is the only cache-hit
+case and a stale fold can never be served. The cache is per-process in-memory (not shared) — no
+cross-process coherence concern (each process reads its own view, same as before). `loadCache` is
+keyed per absolute path and dropped on `existsSync` failure.
+
+## 3. Fail-safe
+
+`jsonl-tail.ts` never throws: missing file, stat failure, open/read failure each return an empty
+result — exactly the prior `@silent-fallback-ok` degradation of the full-file callers (an
+observability/housekeeping read must never endanger the observed operation). The feedback store's
+stat-failure path falls through to a full read (`/* fall through to a full read — never let stat
+failure skip the load */`), so a stat error degrades to the correct (slow) result, never wrong data.
+
+## 4. Blast radius
+
+One new utility module + its test; four read-site one-liner swaps (CommitmentSentinel, CoherenceMonitor,
+server.ts PresenceProxy ack, TelegramAdapter.getMessageLog); one read-path cache in JsonlFeedbackStore
++ a test-only cache-clear export. No API/route change, no schema change, no write-path semantics
+change, no new external surface.
+
+## 5. Residual (tracked, NOT fixed here — out of scope)
+
+The existing `lint-no-wholefile-sync-read` ratchet only catches LITERAL path basenames in the read
+call, but these four sites read VARIABLE paths (`this.messageLogPath`, a `logPath` param), so the
+lint could never have flagged them — which is why they survived the earlier sweeps. The durable
+structural prevention is an **accessor funnel** (route all append-log reads through a single bounded
+accessor that the lint can enforce), which is **Bounded Accumulation Increment 2** — a tracked
+follow-up named here so it is not silently dropped. Separately, the telegram-messages.jsonl and
+feedback.jsonl files themselves still grow UNBOUNDED — a size/retention cap is the same Bounded
+Accumulation track. This change makes READS cheap regardless of size; it does not cap the files.
+
+## 6. Rollback
+
+Revert the source files. The change is purely read-path (a bounded tail-read + a fingerprint cache);
+reverting restores the (slow but correct) full-read behavior. No data migration, no on-disk format
+change to undo.


### PR DESCRIPTION
## ELI16

The agent's server runs everything on one main thread, so if any single operation makes that thread wait, *everything* waits — the dashboard, your messages, every background check — and a long-enough wait drops the dashboard's live connection (the "Disconnected" flapping). This PR removes the third and fourth causes of that freeze (after the tmux, keychain, and 13MB job-history fixes). Several background checks were reading an entire **12MB** Telegram message log from disk every few minutes just to glance at the last few messages, and a separate **14MB** feedback log was re-parsed from scratch on every pass even when nothing had changed. Now those checks read only the last small chunk of the file (instant regardless of size), and the feedback log is served from memory when it hasn't changed. The behavior is identical — same checks, same results — just without the freeze.

## The problem

Five callsites read entire multi-MB append-only logs **synchronously on the main thread** just to inspect their tails. A 12MB `readFileSync` + `.split('\n')` on a 5-minute timer froze the event loop for up to ~20s per pass — the same ~0-CPU false-sleep signature `SleepWakeDetector` misreads as a brief "wake". Root cause was diagnosed by a live profiler catching the loop frozen in a whole-file `ReadFileUtf8 → split`.

This is the **third + fourth event-loop-blocker class** behind the dashboard "disconnected" flapping (after sync tmux #1248-ish, sync keychain #1249, and the JobRunHistory 13MB re-read #1250).

## The 5 callsites

Four readers each pulled the whole ~12MB `.instar/telegram-messages.jsonl` just for its tail:

| Callsite | File | Trigger | Only needs |
|---|---|---|---|
| `CommitmentSentinel.parseRecentMessages` | `src/monitoring/CommitmentSentinel.ts` | 5-min timer | last `maxMessagesPerScan*10` lines |
| `CoherenceMonitor` output-sanity check | `src/monitoring/CoherenceMonitor.ts` | 5-min timer | last 50 agent messages |
| `checkLogForAgentResponse` (PresenceProxy ack) | `src/commands/server.ts` | event-driven | last 50 lines |
| `TelegramAdapter.getMessageLog` | `src/messaging/TelegramAdapter.ts` | analysis route | last `limit` (default 100) |

Plus `JsonlFeedbackStore` (`src/feedback-factory/store/JsonlFeedbackStore.ts`) re-read + re-`JSON.parse`d the entire ~14MB `feedback.jsonl` at the start of every processing pass even when nothing had changed.

## The fix (two behavior-preserving mechanisms)

**(A) Shared bounded tail-read utility** — new `src/utils/jsonl-tail.ts` (`readJsonlTailLines` / `readJsonlTailLastLines`). It `statSync`s the file (O(1)), `openSync` + `readSync`s only the trailing 512KB (≈ 2,600 recent lines — a strict superset of every caller's tail need) into a fixed buffer, drops the partial first line when the window started mid-file, and returns the trailing lines in file order. It never loads the whole file and never throws (a read failure returns an empty result, matching the prior `@silent-fallback-ok` behavior). Mirrors `CoherenceJournal.readTailTolerant`. The four telegram-log readers now call it; their parsed + filtered results are identical to the old full-split-then-slice.

**(B) `(size, mtimeMs)` load cache in `JsonlFeedbackStore.loadJsonl`** — when the on-disk file is byte-for-byte the one last folded, it serves a clone of the prior parse with zero IO/parse; any change (append/shrink/delete) re-reads. Mirrors the JobRunHistory cache. Clone-on-serve guarantees a caller mutating the returned Map can never poison the cache. Load semantics (per-line parse, dedup-last-wins, torn-line skip, corrupt-file recovery) preserved exactly.

## Test evidence

48/48 across the four touched test files + cross-impact suites; `tsc --noEmit` exit 0; all 19 lints green.

- `tests/unit/jsonl-tail.test.ts` (9) — tail correctness, partial-line drop, missing/empty file, truncation flag, the `readJsonlTailLastLines` slice.
- `tests/unit/CoherenceMonitor-bounded-read.test.ts` (2) — a `fs.readFileSync` **spy FAILS the test if the whole 12MB log is read**, AND a bad pattern planted in a RECENT agent message at the **END** of a multi-MB log is still detected via the tail.
- `tests/unit/CommitmentSentinel.test.ts` (26) — extended; bounded scan behavior preserved.
- `tests/unit/feedback-factory/jsonl-feedback-store.test.ts` (11) — extended; cache-hit serves zero-IO, any change re-reads.

## Follow-up (named so it isn't dropped — NOT in this PR)

The existing `lint-no-wholefile-sync-read` ratchet only catches **literal** path basenames, but these four sites read **variable** paths (`this.messageLogPath`, a `logPath` param) — which is exactly why they survived earlier sweeps. The durable structural prevention is an **accessor funnel** (route all append-log reads through a single bounded accessor the lint can enforce) — **Bounded Accumulation Increment 2**. Separately, the telegram-messages.jsonl and feedback.jsonl files themselves still grow unbounded; a size/retention cap is the same Bounded Accumulation track. This PR makes **reads** cheap regardless of size; it does not cap the files.

## Tier

Tier 1 (focused, behavior-preserving, no spec). The gate recorded a below-floor advisory because `TelegramAdapter.ts` matches the Telegram-adapter safety-invariant proximity heuristic — not blocking; the change is a read-path swap with no adapter-behavior change.
