### PR TITLE
fix(perf): async-ify WorktreeMonitor git scans — sync git over many worktrees froze the event loop (dashboard disconnects over tunnel)

### DIFF
--- a/.instar/instar-dev-decisions/2026-06-23T02-31-43-430Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-06-23T02-31-43-430Z-unknown.json
@@ -1,0 +1,16 @@
+{
+  "ts": "2026-06-23T02:31:43.430Z",
+  "slug": "unknown",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "new capability: new route (router.<verb>() added",
+    "new capability: new config key added"
+  ],
+  "belowFloor": true,
+  "files": 2,
+  "loc": 87,
+  "causalAutopsy": null,
+  "verdict": "pass"
+}

--- a/src/monitoring/WorktreeMonitor.ts
+++ b/src/monitoring/WorktreeMonitor.ts
@@ -12,11 +12,14 @@
  * Part of the Claude Code Feature Integration Audit (Item 1: Worktree Support).
  */
 
-import { spawnSync } from 'node:child_process';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
 import fs from 'node:fs';
 import path from 'node:path';
 import { EventEmitter } from 'node:events';
 import type { Session } from '../core/types.js';
+
+const execFileAsync = promisify(execFile);
 
 // ── Types ──────────────────────────────────────────────────────────
 
@@ -113,7 +116,7 @@ export class WorktreeMonitor extends EventEmitter {
    * Called from the sessionComplete event handler.
    */
   async onSessionComplete(session: Session): Promise<WorktreeReport> {
-    const report = this.scanWorktrees();
+    const report = await this.scanWorktrees();
 
     // Copy serendipity findings from worktrees before alerting
     for (const wt of report.worktrees) {
@@ -211,17 +214,18 @@ export class WorktreeMonitor extends EventEmitter {
    * Periodic health scan: detect stale worktrees and orphan branches.
    */
   async periodicScan(): Promise<WorktreeReport> {
-    const report = this.scanWorktrees();
+    const report = await this.scanWorktrees();
 
-    // Check for stale worktrees
+    // Check for stale worktrees (getWorktreeAge is async — resolve ages first, then filter)
     const staleThreshold = this.config.staleThresholdMs ?? DEFAULT_STALE_THRESHOLD;
-    const staleWorktrees = report.worktrees.filter(wt => {
-      const age = this.getWorktreeAge(wt);
+    const ages = await Promise.all(report.worktrees.map(wt => this.getWorktreeAge(wt)));
+    const staleWorktrees = report.worktrees.filter((_wt, i) => {
+      const age = ages[i];
       return age !== null && age > staleThreshold;
     });
 
     if (staleWorktrees.length > 0) {
-      const message = this.formatPeriodicAlert(report, staleWorktrees);
+      const message = await this.formatPeriodicAlert(report, staleWorktrees);
       report.actions.push(`Stale worktree alert: ${staleWorktrees.length} worktree(s)`);
       await this.sendAlert(message);
     }
@@ -234,7 +238,7 @@ export class WorktreeMonitor extends EventEmitter {
   /**
    * Core scan: list all worktrees and analyze their state.
    */
-  scanWorktrees(): WorktreeReport {
+  async scanWorktrees(): Promise<WorktreeReport> {
     const report: WorktreeReport = {
       timestamp: new Date().toISOString(),
       worktrees: [],
@@ -244,17 +248,17 @@ export class WorktreeMonitor extends EventEmitter {
     };
 
     // List all worktrees
-    const worktrees = this.listWorktrees();
+    const worktrees = await this.listWorktrees();
     report.worktrees = worktrees.filter(wt => !wt.isMain);
 
     // Get default branch for comparison
-    const defaultBranch = this.getDefaultBranch();
+    const defaultBranch = await this.getDefaultBranch();
 
     // Check each non-main worktree for unmerged work
     for (const wt of report.worktrees) {
       if (!wt.branch) continue;
 
-      const diff = this.checkUnmergedWork(wt, defaultBranch);
+      const diff = await this.checkUnmergedWork(wt, defaultBranch);
       if (diff && diff.commitsAhead > 0) {
         report.withUnmergedWork.push(diff);
       }
@@ -262,7 +266,7 @@ export class WorktreeMonitor extends EventEmitter {
 
     // Find orphan worktree branches (branches matching worktree-* pattern with no worktree)
     // This can find branches even when no active worktrees exist
-    const orphans = this.findOrphanBranches(worktrees);
+    const orphans = await this.findOrphanBranches(worktrees);
     report.orphanBranches = orphans;
 
     return report;
@@ -273,8 +277,8 @@ export class WorktreeMonitor extends EventEmitter {
   /**
    * Parse `git worktree list --porcelain` output into structured data.
    */
-  listWorktrees(): Worktree[] {
-    const output = this.gitCommand('worktree list --porcelain');
+  async listWorktrees(): Promise<Worktree[]> {
+    const output = await this.gitCommand('worktree list --porcelain');
     if (!output.trim()) return [];
 
     const worktrees: Worktree[] = [];
@@ -319,11 +323,11 @@ export class WorktreeMonitor extends EventEmitter {
   /**
    * Check how many commits a worktree branch has ahead of the default branch.
    */
-  checkUnmergedWork(wt: Worktree, defaultBranch: string): WorktreeWithDiff | null {
+  async checkUnmergedWork(wt: Worktree, defaultBranch: string): Promise<WorktreeWithDiff | null> {
     if (!wt.branch) return null;
 
     // Count commits ahead
-    const countOutput = this.gitCommand(
+    const countOutput = await this.gitCommand(
       `rev-list --count ${defaultBranch}..${wt.branch}`
     );
     const commitsAhead = parseInt(countOutput.trim(), 10) || 0;
@@ -331,7 +335,7 @@ export class WorktreeMonitor extends EventEmitter {
     if (commitsAhead === 0) return null;
 
     // Get changed files
-    const diffOutput = this.gitCommand(
+    const diffOutput = await this.gitCommand(
       `diff --name-only ${defaultBranch}...${wt.branch}`
     );
     const filesChanged = diffOutput.trim().split('\n').filter(f => f.trim());
@@ -342,8 +346,8 @@ export class WorktreeMonitor extends EventEmitter {
   /**
    * Find branches matching worktree-* pattern that have no corresponding worktree.
    */
-  findOrphanBranches(activeWorktrees: Worktree[]): string[] {
-    const branchOutput = this.gitCommand("branch --list 'worktree-*'");
+  async findOrphanBranches(activeWorktrees: Worktree[]): Promise<string[]> {
+    const branchOutput = await this.gitCommand("branch --list 'worktree-*'");
     if (!branchOutput.trim()) return [];
 
     const allWorktreeBranches = branchOutput
@@ -363,15 +367,15 @@ export class WorktreeMonitor extends EventEmitter {
   /**
    * Get the default branch name (main, master, etc.)
    */
-  getDefaultBranch(): string {
+  async getDefaultBranch(): Promise<string> {
     // Try symbolic ref first
-    const symbolic = this.gitCommand('symbolic-ref refs/remotes/origin/HEAD 2>/dev/null').trim();
+    const symbolic = (await this.gitCommand('symbolic-ref refs/remotes/origin/HEAD 2>/dev/null')).trim();
     if (symbolic) {
       return symbolic.replace('refs/remotes/origin/', '');
     }
 
     // Fallback: check if main or master exists
-    const branches = this.gitCommand('branch --list main master 2>/dev/null').trim();
+    const branches = (await this.gitCommand('branch --list main master 2>/dev/null')).trim();
     if (branches.includes('main')) return 'main';
     if (branches.includes('master')) return 'master';
 
@@ -381,9 +385,9 @@ export class WorktreeMonitor extends EventEmitter {
   /**
    * Get the age of a worktree by checking its HEAD commit timestamp.
    */
-  getWorktreeAge(wt: Worktree): number | null {
+  async getWorktreeAge(wt: Worktree): Promise<number | null> {
     if (!wt.head) return null;
-    const timestamp = this.gitCommand(`show -s --format=%ct ${wt.head}`).trim();
+    const timestamp = (await this.gitCommand(`show -s --format=%ct ${wt.head}`)).trim();
     if (!timestamp) return null;
     const commitTime = parseInt(timestamp, 10) * 1000;
     return Date.now() - commitTime;
@@ -418,11 +422,11 @@ export class WorktreeMonitor extends EventEmitter {
     return lines.join('\n');
   }
 
-  private formatPeriodicAlert(report: WorktreeReport, staleWorktrees: Worktree[]): string {
+  private async formatPeriodicAlert(report: WorktreeReport, staleWorktrees: Worktree[]): Promise<string> {
     const lines = ['🔍 Stale worktrees detected:'];
 
     for (const wt of staleWorktrees) {
-      const ageMs = this.getWorktreeAge(wt);
+      const ageMs = await this.getWorktreeAge(wt);
       const ageHours = ageMs ? Math.round(ageMs / 3_600_000) : '?';
       lines.push(`  ${wt.branch ?? wt.path} — ${ageHours}h old`);
     }
@@ -442,14 +446,27 @@ export class WorktreeMonitor extends EventEmitter {
 
   /**
    * Run a git command. Uses shell execution to support glob patterns (e.g., worktree-*).
+   *
+   * ASYNC (was spawnSync): on a repo with many worktrees `git worktree list` can take
+   * seconds, and the scans below issue several git calls — running them synchronously
+   * blocked the server event loop for seconds per scan (5-min periodic + every
+   * session-end), which over a tunnel drops the dashboard websocket. Async `execFile`
+   * keeps the loop responsive while git runs. Semantics preserved: returns stdout even
+   * on a non-zero exit / timeout (matching the old spawnSync `result.stdout ?? ''`).
    */
-  private gitCommand(args: string): string {
-    const result = spawnSync('/bin/sh', ['-c', `git ${args}`], {
-      cwd: this.config.projectDir,
-      encoding: 'utf-8',
-      timeout: 10_000,
-    });
-    return result.stdout ?? '';
+  private async gitCommand(args: string): Promise<string> {
+    try {
+      const { stdout } = await execFileAsync('/bin/sh', ['-c', `git ${args}`], {
+        cwd: this.config.projectDir,
+        encoding: 'utf-8',
+        timeout: 10_000,
+      });
+      return stdout ?? '';
+    } catch (err) {
+      // spawnSync returned stdout even on a non-zero exit / timeout; preserve that.
+      const stdout = (err as { stdout?: unknown })?.stdout;
+      return typeof stdout === 'string' ? stdout : '';
+    }
   }
 
   private async sendAlert(message: string): Promise<void> {

--- a/src/server/routes.ts
+++ b/src/server/routes.ts
@@ -3350,13 +3350,13 @@ export function createRoutes(ctx: RouteContext): Router {
 
   // ── Worktree Monitoring ───────────────────────────────────────
 
-  router.get('/hooks/worktrees', (_req, res) => {
+  router.get('/hooks/worktrees', async (_req, res) => {
     if (!ctx.worktreeMonitor) {
       res.status(503).json({ error: 'WorktreeMonitor not initialized' });
       return;
     }
 
-    const report = ctx.worktreeMonitor.scanWorktrees();
+    const report = await ctx.worktreeMonitor.scanWorktrees();
     res.json(report);
   });
 

--- a/tests/unit/worktree-monitor.test.ts
+++ b/tests/unit/worktree-monitor.test.ts
@@ -146,17 +146,17 @@ describe('WorktreeMonitor', () => {
   // ── Worktree Listing ─────────────────────────────────────────
 
   describe('listWorktrees()', () => {
-    it('returns only main worktree when no extras exist', () => {
-      const wts = monitor.listWorktrees();
+    it('returns only main worktree when no extras exist', async () => {
+      const wts = await monitor.listWorktrees();
       expect(wts).toHaveLength(1);
       expect(wts[0].isMain).toBe(true);
       expect(wts[0].branch).toBe('main');
     });
 
-    it('detects a created worktree', () => {
+    it('detects a created worktree', async () => {
       createWorktree(repoDir, 'feature-auth');
 
-      const wts = monitor.listWorktrees();
+      const wts = await monitor.listWorktrees();
       expect(wts).toHaveLength(2);
 
       const extra = wts.find(w => !w.isMain);
@@ -165,12 +165,12 @@ describe('WorktreeMonitor', () => {
       expect(extra!.path).toContain('feature-auth');
     });
 
-    it('detects multiple worktrees', () => {
+    it('detects multiple worktrees', async () => {
       createWorktree(repoDir, 'feature-a');
       createWorktree(repoDir, 'feature-b');
       createWorktree(repoDir, 'feature-c');
 
-      const wts = monitor.listWorktrees();
+      const wts = await monitor.listWorktrees();
       expect(wts).toHaveLength(4); // main + 3
 
       const nonMain = wts.filter(w => !w.isMain);
@@ -186,24 +186,24 @@ describe('WorktreeMonitor', () => {
   // ── Unmerged Work Detection ──────────────────────────────────
 
   describe('checkUnmergedWork()', () => {
-    it('returns null when worktree has no commits ahead', () => {
+    it('returns null when worktree has no commits ahead', async () => {
       createWorktree(repoDir, 'empty');
 
-      const wts = monitor.listWorktrees();
+      const wts = await monitor.listWorktrees();
       const wt = wts.find(w => w.branch === 'worktree-empty')!;
-      const result = monitor.checkUnmergedWork(wt, 'main');
+      const result = await monitor.checkUnmergedWork(wt, 'main');
       expect(result).toBeNull();
     });
 
-    it('detects commits ahead of main', () => {
+    it('detects commits ahead of main', async () => {
       createWorktree(repoDir, 'with-work', {
         addCommits: 3,
         files: ['auth.ts', 'config.ts', 'test.ts'],
       });
 
-      const wts = monitor.listWorktrees();
+      const wts = await monitor.listWorktrees();
       const wt = wts.find(w => w.branch === 'worktree-with-work')!;
-      const result = monitor.checkUnmergedWork(wt, 'main');
+      const result = await monitor.checkUnmergedWork(wt, 'main');
 
       expect(result).not.toBeNull();
       expect(result!.commitsAhead).toBe(3);
@@ -212,7 +212,7 @@ describe('WorktreeMonitor', () => {
       expect(result!.filesChanged).toContain('test.ts');
     });
 
-    it('returns null for worktree with no branch', () => {
+    it('returns null for worktree with no branch', async () => {
       const fakeBranchless: Worktree = {
         path: '/tmp/fake',
         head: 'abc123',
@@ -220,7 +220,7 @@ describe('WorktreeMonitor', () => {
         isMain: false,
         isBare: false,
       };
-      const result = monitor.checkUnmergedWork(fakeBranchless, 'main');
+      const result = await monitor.checkUnmergedWork(fakeBranchless, 'main');
       expect(result).toBeNull();
     });
   });
@@ -228,18 +228,18 @@ describe('WorktreeMonitor', () => {
   // ── Orphan Branch Detection ──────────────────────────────────
 
   describe('findOrphanBranches()', () => {
-    it('returns empty when no orphan branches exist', () => {
-      const wts = monitor.listWorktrees();
-      const orphans = monitor.findOrphanBranches(wts);
+    it('returns empty when no orphan branches exist', async () => {
+      const wts = await monitor.listWorktrees();
+      const orphans = await monitor.findOrphanBranches(wts);
       expect(orphans).toEqual([]);
     });
 
-    it('detects orphan worktree-* branches', () => {
+    it('detects orphan worktree-* branches', async () => {
       createOrphanBranch(repoDir, 'abandoned-feature');
       createOrphanBranch(repoDir, 'old-work');
 
-      const wts = monitor.listWorktrees();
-      const orphans = monitor.findOrphanBranches(wts);
+      const wts = await monitor.listWorktrees();
+      const orphans = await monitor.findOrphanBranches(wts);
 
       expect(orphans).toHaveLength(2);
       expect(orphans.sort()).toEqual([
@@ -248,12 +248,12 @@ describe('WorktreeMonitor', () => {
       ]);
     });
 
-    it('excludes branches that have active worktrees', () => {
+    it('excludes branches that have active worktrees', async () => {
       createWorktree(repoDir, 'active');
       createOrphanBranch(repoDir, 'orphaned');
 
-      const wts = monitor.listWorktrees();
-      const orphans = monitor.findOrphanBranches(wts);
+      const wts = await monitor.listWorktrees();
+      const orphans = await monitor.findOrphanBranches(wts);
 
       expect(orphans).toHaveLength(1);
       expect(orphans[0]).toBe('worktree-orphaned');
@@ -263,8 +263,8 @@ describe('WorktreeMonitor', () => {
   // ── Full Scan ────────────────────────────────────────────────
 
   describe('scanWorktrees()', () => {
-    it('returns clean report when no worktrees exist', () => {
-      const report = monitor.scanWorktrees();
+    it('returns clean report when no worktrees exist', async () => {
+      const report = await monitor.scanWorktrees();
 
       expect(report.worktrees).toEqual([]);
       expect(report.withUnmergedWork).toEqual([]);
@@ -272,21 +272,21 @@ describe('WorktreeMonitor', () => {
       expect(report.timestamp).toBeTruthy();
     });
 
-    it('detects worktrees with unmerged work', () => {
+    it('detects worktrees with unmerged work', async () => {
       createWorktree(repoDir, 'feature', { addCommits: 2, files: ['a.ts', 'b.ts'] });
 
-      const report = monitor.scanWorktrees();
+      const report = await monitor.scanWorktrees();
 
       expect(report.worktrees).toHaveLength(1);
       expect(report.withUnmergedWork).toHaveLength(1);
       expect(report.withUnmergedWork[0].commitsAhead).toBe(2);
     });
 
-    it('detects orphan branches alongside active worktrees', () => {
+    it('detects orphan branches alongside active worktrees', async () => {
       createWorktree(repoDir, 'active');
       createOrphanBranch(repoDir, 'orphaned');
 
-      const report = monitor.scanWorktrees();
+      const report = await monitor.scanWorktrees();
 
       expect(report.worktrees).toHaveLength(1); // active only (non-main)
       expect(report.orphanBranches).toHaveLength(1);
@@ -384,8 +384,8 @@ describe('WorktreeMonitor', () => {
   // ── Default Branch Detection ─────────────────────────────────
 
   describe('getDefaultBranch()', () => {
-    it('detects main as default branch', () => {
-      const branch = monitor.getDefaultBranch();
+    it('detects main as default branch', async () => {
+      const branch = await monitor.getDefaultBranch();
       expect(branch).toBe('main');
     });
   });

--- a/upgrades/eli16/worktree-monitor-async-git.md
+++ b/upgrades/eli16/worktree-monitor-async-git.md
@@ -1,0 +1,24 @@
+# ELI16 — Make the worktree scan stop freezing the server
+
+## The problem in plain words
+
+Instar's server runs everything on a single thread — one line at a time, like a single cashier serving a queue. If any one task takes a long time, *everything else waits*: the dashboard's live connection, the message handlers, all of it.
+
+One of the background helpers, the **WorktreeMonitor**, periodically looks at all the git "worktrees" (separate working copies of the code) to spot abandoned work. To do that it shells out to `git worktree list` and a few other git commands. The way it called git was **synchronous** — meaning the single thread sat there and *waited* for git to finish before doing anything else.
+
+That's fine when there are a handful of worktrees. But on a machine where worktrees pile up (one agent had ~282 of them!), `git worktree list` takes a few *seconds*. And this scan ran on a 5-minute timer **and** every time a background job finished. So every few minutes the whole server froze for a second or two.
+
+## Why it showed up as "dashboard disconnected"
+
+On the local address you'd never notice — the dashboard's live connection just reconnects instantly. But when you reach the dashboard through the internet tunnel, a one- or two-second server freeze is enough to **drop the live connection and time out the data**. The result is the dashboard showing "Disconnected, 0 sessions, 0% memory" — even though the server is actually fine, it was just frozen for a moment.
+
+## The fix
+
+Make the git calls **asynchronous**. Instead of the single thread sitting and waiting for git, it kicks off the git command and goes back to serving everyone else; when git finishes, it picks the result back up. Same scans, same schedule, same results — but the server stays responsive the whole time, so the dashboard's live connection never drops.
+
+## What changed and what didn't
+
+- Changed: the worktree scan's git calls no longer block the server thread.
+- Unchanged: it still scans on the same 5-minute timer and after each job, still reports the same things, and the `/hooks/worktrees` endpoint returns the exact same data. The git calls keep their old behavior of returning whatever output they produced even if git exits with an error.
+
+It's a small, low-risk change covered by the existing tests (all green), and it's the permanent replacement for a quick hotpatch that had temporarily disabled the scans to stop the freezing.

--- a/upgrades/side-effects/worktree-monitor-async-git.md
+++ b/upgrades/side-effects/worktree-monitor-async-git.md
@@ -1,0 +1,39 @@
+# Side-Effects Review — WorktreeMonitor async git scans
+
+**Version / slug:** `worktree-monitor-async-git`
+**Date:** `2026-06-23`
+**Author:** Echo (autonomous)
+**Tier:** 1 (behavior-preserving async refactor — no new feature, no decision points, no dark-gate, no migration)
+**Second-pass reviewer:** not-required (Tier 1; small, low-risk, fully covered by existing unit tests)
+
+## Summary of the change
+
+`WorktreeMonitor.scanWorktrees()` issues several git commands — `git worktree list --porcelain` plus per-worktree `rev-list`/`diff` — through a private `gitCommand()` that used **`spawnSync('/bin/sh', ['-c', 'git …'])`**. On a repository with many worktrees (Echo accumulated ~282) `git worktree list` alone takes seconds, and the scan ran on BOTH a 5-minute periodic timer AND on every `sessionComplete` event. Each scan therefore blocked the **server event loop** synchronously for seconds.
+
+That freeze was invisible on `localhost` (the dashboard websocket reconnects instantly), but over the Cloudflare tunnel (`echo.dawn-tunnel.dev`) a 1–2s freeze times out in-flight requests, dropping the dashboard websocket and failing its polls → the user-visible "Disconnected / 0 sessions / Mem 0%". This is the residual event-loop-block cause behind the dashboard "disconnected" reports, after the sync-READ fixes in #1247–#1251.
+
+## The change
+
+Convert `gitCommand` from `spawnSync` to async `execFile` (promisified), and propagate `await` through the scan call graph so the event loop stays responsive while git runs in the background.
+
+Files modified:
+- `src/monitoring/WorktreeMonitor.ts` — `gitCommand` → `async` (execFile, stdout-on-nonzero-exit/timeout semantics preserved to exactly match the old `spawnSync result.stdout ?? ''`); `listWorktrees`, `checkUnmergedWork`, `findOrphanBranches`, `getDefaultBranch`, `getWorktreeAge`, `scanWorktrees` → `async`; `periodicScan` resolves worktree ages with `Promise.all` before filtering; `formatPeriodicAlert` → `async`.
+- `src/server/routes.ts` — `GET /hooks/worktrees` handler → `async`, awaits `scanWorktrees()`.
+- `tests/unit/worktree-monitor.test.ts` — the 13 tests that called the now-async methods updated to `await` them.
+
+## Side effects & risk
+
+- **Behavior preserved.** The scans still run on the same triggers and the same 5-minute interval; only the blocking changed to non-blocking. `gitCommand`'s return contract (stdout even on a non-zero exit / timeout) is kept identically, so callers see the same strings.
+- **No external surface change.** `GET /hooks/worktrees` returns the same JSON; the periodic + post-session alert paths are unchanged.
+- **Concurrency.** Scans are serialized per the existing event flow (no new parallelism introduced beyond `Promise.all` over `getWorktreeAge`, which is read-only `git show` per worktree).
+- **Risk:** low. A behavior-preserving async conversion, fully covered by the existing 22 unit tests (updated to await) + the serendipity-routes integration tests, both green.
+
+## Verification
+
+- `tsc --noEmit`: 0 errors.
+- `tests/unit/worktree-monitor.test.ts`: 22/22 pass.
+- `tests/integration/serendipity-routes.test.ts`: 22/22 pass.
+
+## Rollout
+
+No flag, no migration — the fix is strictly better behavior on the existing code path and ships on the next release. (A shadow-dist hotpatch — disabling both scan triggers — relieved the freeze immediately on the affected agent; this PR is the durable replacement that keeps the feature working without blocking.)


### PR DESCRIPTION
## Problem

`WorktreeMonitor.scanWorktrees()` ran `git worktree list --porcelain` plus per-worktree git calls via **`spawnSync`**, on a 5-minute timer AND on every session/job completion (`onSessionComplete`). On a repo with many worktrees each scan blocked the **server event loop** for seconds.

This was invisible on `localhost` (instant websocket reconnect), but over the Cloudflare tunnel a 1–2s freeze times out in-flight requests → the dashboard websocket drops and polls fail → **"Disconnected / 0 sessions / Mem 0%"**. It's the residual event-loop-block cause behind the dashboard "disconnected" reports (after the sync-read fixes in #1247–#1251), and it only reproduces over the tunnel, not localhost.

## Fix

Convert `gitCommand` from `spawnSync` to async `execFile` (promisified), and propagate `await` through the scan call graph: `listWorktrees`, `checkUnmergedWork`, `findOrphanBranches`, `getDefaultBranch`, `getWorktreeAge`, `scanWorktrees`, `periodicScan`, `formatPeriodicAlert`, plus the one external caller (`GET /hooks/worktrees` in routes.ts). The event loop stays responsive while git runs in the background.

Behavior preserved: stdout-on-nonzero-exit/timeout semantics kept (matches the old `spawnSync result.stdout ?? ''`); the periodic + post-session scans still run, just non-blocking; the 5-min interval is unchanged.

## Testing

- `tsc --noEmit`: 0 errors
- `tests/unit/worktree-monitor.test.ts`: 22/22 pass (updated to `await` the now-async methods)
- `tests/integration/serendipity-routes.test.ts`: 22/22 pass

## ELI16 — My dashboard kept disconnecting because my server briefly froze whenever it ran a slow git command over a repo cluttered with hundreds of leftover work-copies; this change makes that command non-blocking, so my server stays responsive and the dashboard stays connected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
