### PR TITLE
fix(recovery): never rescue a finished session + user-channel absence-proof harness

### DIFF
--- a/.instar/instar-dev-decisions/2026-06-24T21-02-35-459Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-06-24T21-02-35-459Z-unknown.json
@@ -1,0 +1,13 @@
+{
+  "ts": "2026-06-24T21:02:35.459Z",
+  "slug": "unknown",
+  "suggestedTier": 2,
+  "declaredTier": 2,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 6,
+  "loc": 287,
+  "causalAutopsy": null,
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-06-24T21-03-56-645Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-06-24T21-03-56-645Z-unknown.json
@@ -1,0 +1,13 @@
+{
+  "ts": "2026-06-24T21:03:56.645Z",
+  "slug": "unknown",
+  "suggestedTier": 2,
+  "declaredTier": 2,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 6,
+  "loc": 287,
+  "causalAutopsy": null,
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-06-24T21-04-29-408Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-06-24T21-04-29-408Z-unknown.json
@@ -1,0 +1,16 @@
+{
+  "ts": "2026-06-24T21:04:29.408Z",
+  "slug": "unknown",
+  "suggestedTier": 2,
+  "declaredTier": 2,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 6,
+  "loc": 287,
+  "causalAutopsy": {
+    "origin": "latent",
+    "notes": "Latent gap since the recovery sentinels were written: RateLimitSentinel + CompactionSentinel keyed recovery on terminal-output staleness with no live-session guard, and never cleared recovery state / unregistered a session on completion. A completed session (no new output) was indistinguishable from a throttled one, so it stayed a recovery target indefinitely. Surfaced fleet-wide via the Mini quota-wall incident (topic 28130, 2026-06-24). Fix moves the invariant to the recovery-ACTION boundary."
+  },
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-06-24T21-06-24-786Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-06-24T21-06-24-786Z-unknown.json
@@ -1,0 +1,16 @@
+{
+  "ts": "2026-06-24T21:06:24.786Z",
+  "slug": "unknown",
+  "suggestedTier": 2,
+  "declaredTier": 2,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 6,
+  "loc": 287,
+  "causalAutopsy": {
+    "origin": "latent",
+    "notes": "Latent gap since the recovery sentinels were written: RateLimitSentinel + CompactionSentinel keyed recovery on terminal-output staleness with no live-session guard, and never cleared recovery state / unregistered a session on completion. A completed session (no new output) was indistinguishable from a throttled one, so it stayed a recovery target indefinitely. Surfaced fleet-wide via the Mini quota-wall incident (topic 28130, 2026-06-24). Fix moves the invariant to the recovery-ACTION boundary."
+  },
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-06-24T21-07-16-622Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-06-24T21-07-16-622Z-unknown.json
@@ -1,0 +1,16 @@
+{
+  "ts": "2026-06-24T21:07:16.622Z",
+  "slug": "unknown",
+  "suggestedTier": 2,
+  "declaredTier": 2,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 6,
+  "loc": 287,
+  "causalAutopsy": {
+    "origin": "latent",
+    "notes": "Latent gap since the recovery sentinels were written: RateLimitSentinel + CompactionSentinel keyed recovery on terminal-output staleness with no live-session guard, and never cleared recovery state / unregistered a session on completion. A completed session (no new output) was indistinguishable from a throttled one, so it stayed a recovery target indefinitely. Surfaced fleet-wide via the Mini quota-wall incident (topic 28130, 2026-06-24). Fix moves the invariant to the recovery-ACTION boundary."
+  },
+  "verdict": "pass"
+}

--- a/.instar/instar-dev-decisions/2026-06-24T21-07-50-964Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-06-24T21-07-50-964Z-unknown.json
@@ -1,0 +1,16 @@
+{
+  "ts": "2026-06-24T21:07:50.964Z",
+  "slug": "unknown",
+  "suggestedTier": 2,
+  "declaredTier": 2,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 6,
+  "loc": 287,
+  "causalAutopsy": {
+    "origin": "latent",
+    "notes": "Latent gap since the recovery sentinels were written: RateLimitSentinel + CompactionSentinel keyed recovery on terminal-output staleness with no live-session guard, and never cleared recovery state / unregistered a session on completion. A completed session (no new output) was indistinguishable from a throttled one, so it stayed a recovery target indefinitely. Surfaced fleet-wide via the Mini quota-wall incident (topic 28130, 2026-06-24). Fix moves the invariant to the recovery-ACTION boundary."
+  },
+  "verdict": "pass"
+}

--- a/.instar/instar-dev-decisions/2026-06-24T21-25-24-522Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-06-24T21-25-24-522Z-unknown.json
@@ -1,0 +1,16 @@
+{
+  "ts": "2026-06-24T21:25:24.522Z",
+  "slug": "unknown",
+  "suggestedTier": 1,
+  "declaredTier": 2,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 2,
+  "loc": 10,
+  "causalAutopsy": {
+    "origin": "latent",
+    "notes": "Latent gap since the recovery sentinels were written: RateLimitSentinel + CompactionSentinel keyed recovery on terminal-output staleness with no live-session guard, and never cleared recovery state / unregistered a session on completion. A completed session (no new output) was indistinguishable from a throttled one, so it stayed a recovery target indefinitely. Surfaced fleet-wide via the Mini quota-wall incident (topic 28130, 2026-06-24). Fix moves the invariant to the recovery-ACTION boundary."
+  },
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-06-24T21-25-51-673Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-06-24T21-25-51-673Z-unknown.json
@@ -1,0 +1,16 @@
+{
+  "ts": "2026-06-24T21:25:51.673Z",
+  "slug": "unknown",
+  "suggestedTier": 1,
+  "declaredTier": 2,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 2,
+  "loc": 10,
+  "causalAutopsy": {
+    "origin": "latent",
+    "notes": "Latent gap since the recovery sentinels were written: RateLimitSentinel + CompactionSentinel keyed recovery on terminal-output staleness with no live-session guard, and never cleared recovery state / unregistered a session on completion. A completed session (no new output) was indistinguishable from a throttled one, so it stayed a recovery target indefinitely. Surfaced fleet-wide via the Mini quota-wall incident (topic 28130, 2026-06-24). Fix moves the invariant to the recovery-ACTION boundary."
+  },
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-06-24T21-26-26-511Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-06-24T21-26-26-511Z-unknown.json
@@ -1,0 +1,16 @@
+{
+  "ts": "2026-06-24T21:26:26.511Z",
+  "slug": "unknown",
+  "suggestedTier": 2,
+  "declaredTier": 2,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 6,
+  "loc": 293,
+  "causalAutopsy": {
+    "origin": "latent",
+    "notes": "Latent gap since the recovery sentinels were written: RateLimitSentinel + CompactionSentinel keyed recovery on terminal-output staleness with no live-session guard, and never cleared recovery state / unregistered a session on completion. A completed session (no new output) was indistinguishable from a throttled one, so it stayed a recovery target indefinitely. Surfaced fleet-wide via the Mini quota-wall incident (topic 28130, 2026-06-24). Fix moves the invariant to the recovery-ACTION boundary."
+  },
+  "verdict": "pass"
+}

--- a/.instar/instar-dev-decisions/2026-06-24T21-27-05-279Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-06-24T21-27-05-279Z-unknown.json
@@ -1,0 +1,16 @@
+{
+  "ts": "2026-06-24T21:27:05.279Z",
+  "slug": "unknown",
+  "suggestedTier": 2,
+  "declaredTier": 2,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 6,
+  "loc": 293,
+  "causalAutopsy": {
+    "origin": "latent",
+    "notes": "Latent gap since the recovery sentinels were written: RateLimitSentinel + CompactionSentinel keyed recovery on terminal-output staleness with no live-session guard, and never cleared recovery state / unregistered a session on completion. A completed session (no new output) was indistinguishable from a throttled one, so it stayed a recovery target indefinitely. Surfaced fleet-wide via the Mini quota-wall incident (topic 28130, 2026-06-24). Fix moves the invariant to the recovery-ACTION boundary."
+  },
+  "verdict": "pass"
+}

--- a/docs/specs/false-ratelimit-recovery-completed-sessions.eli16.md
+++ b/docs/specs/false-ratelimit-recovery-completed-sessions.eli16.md
@@ -1,0 +1,54 @@
+# ELI16 — Why your sessions stopped pinging you about a "throttle" that wasn't real
+
+## What was going wrong
+
+The agent has a safety helper that watches your chat sessions. If a session gets
+temporarily blocked by the AI provider (a "server is busy, slow down" throttle), the
+helper waits a bit and then nudges the session to continue — so your conversation
+doesn't silently die. Good idea.
+
+The bug: the helper decided a session was "throttled" by reading the last few lines of
+the session's screen and looking for the throttle message. But a session that had
+**already finished its work** sits quietly at a prompt with that old throttle message
+still on screen. The helper saw the old message, assumed the session was stuck, and
+tried to "rescue" a session that was actually just *done*. A finished session never
+produces new output, so the helper's rescue never "worked" — it kept retrying six
+times and kept sending you messages like *"The temporary server throttle should have
+cleared — please continue where you left off."* You'd see those pile up even though
+nothing was actually wrong. And because the helper code is shared by every agent, the
+same false alarm showed up on other agents too (this is what made it scary — it wasn't
+one agent misbehaving, it was the shared logic).
+
+Two more gaps made it worse: when a session finished, nothing ever told the helper to
+stop watching it, so finished sessions lingered as "rescue targets" forever; and a
+separate background check that asks "how much quota do I have left?" was logging a
+scary "rate limit!" warning every time its meter endpoint hiccuped, even though that
+wasn't a real limit.
+
+## What we changed
+
+1. A finished or killed session can no longer become a rescue target — the helper now
+   checks "is this session actually still running?" before doing anything, and bails
+   out silently if a session finishes mid-rescue.
+2. When a session ends, the helpers are told to stop watching it immediately.
+3. The noisy "rate limit!" log only fires now when there's a *sustained* problem, not
+   on a one-off hiccup.
+
+## The part that prevents this from happening again
+
+The real win isn't just this one fix — it's a new way to **catch this whole class of
+bug before it ships**. The agent already had a test system that talks to itself through
+real Telegram (as if it were you) and checks the replies. But it could only check
+"did the agent say the right thing?" — it couldn't catch the agent saying something it
+*shouldn't*. We taught it to do exactly that: a test can now drive a real conversation
+and then prove that **no unwanted background message** (like the false throttle nudge)
+shows up over the next stretch of time. If a future change brings the bug back, that
+test fails and the "is this done?" gate blocks the release. We proved this works: a
+deliberately-broken version gets caught and blocked.
+
+## What it means for you
+
+You'll stop getting phantom "throttle cleared, continue" messages that don't match
+anything actually happening. Real throttles are still handled — genuine rescues still
+run. And this class of "a background feature spams you by mistake" is now something the
+test system can catch before it ever reaches you.

--- a/docs/specs/false-ratelimit-recovery-completed-sessions.md
+++ b/docs/specs/false-ratelimit-recovery-completed-sessions.md
@@ -1,0 +1,250 @@
+---
+title: Fix false rate-limit/error recovery on finished sessions + user-channel proof harness
+slug: false-ratelimit-recovery-completed-sessions
+eli16-overview: false-ratelimit-recovery-completed-sessions.eli16.md
+status: draft
+parent-principle: "Structure beats Willpower — a finished session must be structurally incapable of becoming a recovery target, enforced at the recovery-ACTION boundary (the sentinel chokepoint), not merely at detection. Also instances Live-User-Channel Proof Before Done: the user-facing fix is not done until proven from the user's seat through the real channel."
+author: echo
+created: 2026-06-24
+review-convergence: "2026-06-24T20:54:04.708Z"
+review-iterations: 2
+review-completed-at: "2026-06-24T20:54:04.708Z"
+review-report: "docs/specs/reports/false-ratelimit-recovery-completed-sessions-convergence.md"
+cross-model-review: "codex-cli:gpt-5.5"
+single-run-completable: true
+frontloaded-decisions: 4
+cheap-to-change-tags: 2
+contested-then-cleared: 0
+approved: true
+approved-by: "echo (standing 8-hour autonomous-run pre-approval, 2026-06-24; spec D4)"
+---
+
+# Fix false rate-limit/error recovery on finished sessions + user-channel proof harness
+
+## Problem (observed live, 2026-06-24, topics 28130 / 28150 / mesh-debug)
+
+A user saw the same line repeated many times across topics:
+> "The temporary server throttle should have cleared — please continue where you left off."
+…with no matching rate-limit in the session logs. It also appeared on a *different* agent
+(AI Guy), i.e. it is fleet-wide, in shared detector logic, not agent-specific.
+
+### Root cause (grounded in current source @ v1.3.655)
+
+1. **Stale-scrollback false trigger.** `SessionManager`'s idle monitor
+   (`src/core/SessionManager.ts` ~L1593-1610) fires `rateLimitedAtIdle` /
+   `apiErrorAtIdle` when a session `isActuallyIdle` (idle-at-prompt + no active
+   processes) AND the last ~30 captured tmux lines match
+   `detectRateLimited()` / `TERMINAL_ERROR_PATTERNS`. A session that **finished**
+   right after a throttle is *also* "idle at a prompt" with the throttle string
+   still in scrollback → it is mistaken for a live-but-throttled session.
+
+2. **No session-status guard in recovery.** `RateLimitSentinel.report()`
+   (`src/monitoring/RateLimitSentinel.ts:235`) starts a full backoff→resume→verify
+   lifecycle without checking the session is still `running`. A finished session
+   never grows its jsonl, so verification fails every time → up to `maxAttempts`
+   (6) futile resume nudges (`RATE_LIMIT_RESUME_NUDGE`) + "still throttled" check-ins
+   over `maxWindowMs` (30m), then an escalation notice. Each is a user ping.
+
+3. **No cleanup on completion.** The three `sessionComplete` handlers
+   (`src/commands/server.ts` ~8501/8546/8593) never call
+   `rateLimitSentinel.clear()`, `compactionSentinel.clear()`, or
+   `telegram.unregisterTopic()`. So a finished session lingers as a recovery
+   target AND stays in the `topicToSession` map (re-visited by `PreCompact`'s
+   `getAllTopicSessions()` and the watchdog), re-arming the false trigger.
+
+4. **Sibling gap.** `CompactionSentinel` has the identical missing guard:
+   `clear()` exists but is never called on completion (confirmed: zero callers).
+
+5. **Secondary noise (not the nudge driver).** `QuotaCollector`'s OAuth usage poll
+   logs `429 retry-after:0` as a `[DEGRADATION]` warning on every transient meter
+   blip (716 lines observed). It has a 3-strike circuit breaker but still emits a
+   warning per blip. This is log noise, separate from the user-facing nudges.
+
+## Fix
+
+### F1 — Session-recoverability guard (primary, structural)
+Add a `isSessionRecoverable(sessionName): boolean` dep to **both** `RateLimitSentinel`
+and `CompactionSentinel`. Default (dep absent) preserves today's behavior so unit
+tests/bare installs are unchanged. When wired (server.ts), it returns false if the
+session is unknown OR its status ∈ {completed, failed, killed} OR it is not in
+`listRunningSessions()`.
+
+Consult it in two places:
+- **`report()`**: if not recoverable → no-op (do NOT send the "throttled" notice, do
+  NOT start recovery). This stops the false trigger at the door.
+- **`attemptResume()` / `verify()`**: re-check before each resume; if the session
+  became non-recoverable mid-flight (finished while backing off) → `finalize(..., 'recovered'?)`
+  no — finalize as a new terminal `aborted` reason without a user "still throttled"
+  ping. (Silent, audited stop — the session is gone, nothing to tell the user.)
+
+### F2 — Completion cleanup (structural)
+Add ONE consolidated `sessionComplete` handler (or extend an existing one) in
+server.ts that, for the completing session, calls:
+`rateLimitSentinel.clear(tmux)`, `compactionSentinel.clear(tmux)`, and
+`telegram.unregisterTopic(topicId)` (resolve topicId via
+`telegram.getTopicForSession`). Guard each call (feature may be disabled).
+This removes the lingering-target + stale-map class entirely.
+
+### F3 — Detection hardening (defense in depth)
+In `SessionManager`, gate the `rateLimitedAtIdle`/`apiErrorAtIdle` emit on
+`session.status === 'running'` (the loop already iterates running sessions, but the
+status can flip between capture and emit). Cheap, removes a race.
+
+### F4 — QuotaCollector 429-retry-after-0 noise (secondary)
+Downgrade a `429` with `retry-after: 0` (or absent) from a `[DEGRADATION] WARN` to a
+debug-level line once the circuit breaker is closed; keep the breaker. No behavior
+change to quota accounting — purely log-volume.
+
+## Test plan (ALL THREE TIERS + user-channel proof)
+
+### Unit (`tests/unit/`)
+- `RateLimitSentinel`: report() no-ops when `isSessionRecoverable` returns false (no
+  notify, no timer). A recovery in flight aborts silently when the session becomes
+  non-recoverable. Dep-absent path unchanged (regression lock).
+- `CompactionSentinel`: same guard, both sides of the boundary.
+- `SessionManager`: emit suppressed when status ≠ running with a throttle string in
+  scrollback; still emits for a genuinely-running stuck session.
+- Wiring-integrity: the server's `isSessionRecoverable` dep is non-null and delegates
+  to the real SessionManager (not a `() => true` stub).
+
+### Integration (`tests/integration/`)
+- Full server boot: completing a session clears both sentinels + unregisters the topic
+  (assert via the recovery-active predicate + `getAllTopicSessions()`).
+
+### E2E (`tests/e2e/`)
+- "Feature alive": a finished session with a throttle string in its pane produces ZERO
+  resume nudges (the regression that started this).
+
+### User-channel proof (NEW — the prevention layer, see companion harness spec)
+- Drive the real Telegram surface (browser-as-user) through scenarios: finished
+  session (no nudge), genuinely throttled session (recovery DOES run + recovers),
+  idle topic-bound session (no nudge), and a message-delivery-failure path. Record a
+  signed PASS/FAIL scenario matrix. Wire into the ship gate so future changes inherit it.
+
+## Migration parity
+No config-default or hook changes required (the recoverability dep is internal wiring).
+If F4 adds a `monitoring.quotaCollector.logLevel` knob, add a `migrateConfig` existence
+check. The new sentinel deps are server-internal; no agent-installed file changes.
+
+## Rollback
+Each fix is independently revertible. F1's guard is additive (dep-absent = old
+behavior). F2 is a pure cleanup addition. F4 is log-level only.
+
+## As-built (this PR)
+- **F1** — `isSessionRecoverable?` dep added to `RateLimitSentinel` and
+  `CompactionSentinel`; consulted in `report()` (no-op for a non-recoverable session,
+  no user notice), in `RateLimitSentinel.attemptResume()` AND in
+  `RateLimitSentinel.verify()` (silent `abort()` if the session finished mid-backoff
+  OR mid-verify — new `rate-limit:aborted` event, no escalation ping). The guard is at
+  ALL THREE lifecycle points so a session that finishes during the 25s verify window
+  cannot reach the "still can't get through" escalation notice (spec-converge finding).
+  `abort()` KEEPS the `recentReports` dedupe entry so a session flapping around the
+  liveness oracle cannot abort-then-rearm on every flap. Wired in `server.ts` as
+  `sessionName => sessionManager.listRunningSessions().some(...)` — membership in the
+  running set is the SOLE recoverability criterion (a finished/failed/killed session
+  drops out of it). `listRunningSessions()` fails OPEN on a transient tmux error
+  (`isSessionAlive` catch → alive), so a tmux hiccup does NOT drop a live session;
+  genuine termination is what removes it.
+- **F2** — a `sessionComplete` handler in `server.ts` calls `rateLimitSentinel.clear()`
+  + `compactionSentinel.clear()` (the completion cleanup that previously had zero
+  callers).
+- **F4** — `QuotaCollector` gates the OAuth-429 DegradationReport to fire only when the
+  3-strike breaker trips (kills the `retry-after:0` log spam); accounting + breaker
+  unchanged.
+- **Prevention layer** — extended the existing Live-User-Channel Proof harness
+  (`LiveTestHarness`) with an **absence assertion**: a scenario may set
+  `absenceWindowMs` + `expect.noMessageMatching` and the harness collects every message
+  on the channel over the window (new optional `ChannelDriver.collectMessages`) and
+  FAILs if any matches — the structural way to catch a spurious background message,
+  which a single send→reply could not. `rateLimitFalsePositiveMatrix.ts` defines the
+  scenarios; an unsupported driver yields BLOCKED (never a silent pass). Proven
+  end-to-end: a regressed run (spurious nudge) makes `LiveTestGate` VETO.
+- **Tests** — 16 unit (guards both sides + harness absence + matrix + wiring-integrity)
+  + 2 integration (harness→signed artifact→gate allow/veto). No regression across the
+  existing sentinel/quota/harness suites; clean `tsc`.
+
+### Scoping decisions (autonomous, reversible)
+- **F3 detection-redesign DEFERRED-with-rationale, not dropped — tracked as CMT-1785:** <!-- tracked: CMT-1785 -->
+  the idle-but-still-running stale-scrollback residual self-corrects to at most one
+  stray "back online" (not the 6-nudge spam, which requires a finished/non-growing
+  session that F1+F2 kill). The KNOWN one-layer-down fix already exists: the watchdog
+  path uses `evaluateThrottleSettle` (`src/monitoring/rateLimitDetection.ts` — throttle
+  string present AND pane byte-identical across polls = genuinely settled), but the
+  SessionManager idle path (`rateLimitedAtIdle`/`apiErrorAtIdle` emit, ~L1607/L1622)
+  does NOT. F3 is to adopt that settle-gate on the idle path; CMT-1785 carries it,
+  driven evidence-first by the new absence harness. **Why the deferral is harmless <!-- tracked: CMT-1785 -->
+  now:** the ONLY consumer of `rateLimitedAtIdle`/`apiErrorAtIdle` is the
+  `RateLimitSentinel.report()` chokepoint (verified — no other listeners), and F1
+  no-ops a non-recoverable report there, so a stale-scrollback emit on a FINISHED
+  session is fully neutralized; only the running-idle residual remains, bounded to
+  ≤1 self-correcting message.
+- **Topic-map unregister dropped from F2:** unregistering a completed session's
+  topic→session mapping risks the conversation-resume flow; F1 already neutralizes stale
+  map entries at the sentinel chokepoint (the `PreCompact` trigger enumerates the map but
+  `report()` no-ops a non-recoverable entry). **Caveat (review):** this offloads the
+  guard responsibility onto any FUTURE consumer of `topicToSession` — they too must not
+  assume a mapped session is alive. The blast radius today is contained (the watchdog
+  reads `listRunningSessions`, not the map; sentinels are F1-guarded). A delayed
+  garbage-collect of the map entry (retain for a resume grace period, then remove) is
+  the cleaner long-term fix and is folded into the CMT-1785 follow-up. <!-- tracked: CMT-1785 -->
+
+### Test authority (review clarification)
+The DETERMINISTIC unit tests (the guard both-sides, the verify/abort lifecycle, the
+wiring-integrity) are the AUTHORITY for correctness — the invariant is "a terminal
+session is never a recovery target," provable without a live channel. The user-channel
+absence harness is the regression-PREVENTION supplement: it proves the user never
+receives the spurious nudge end-to-end and blocks a reintroduction at the gate. The
+absence window must be ≥ (first backoff + verify window) ≈ 55s for the throttle class so
+a regression that only surfaces at the first resume/verify lands inside it — the default
+is 90s. The window covers the immediate-notice false positive (the observed incident);
+the escalation-path variant is covered by the deterministic unit tests, not the window.
+- **Live-drive HTTP route is a fast-follow:** the prevention capability is library-
+  invokable and gate-wired; a dedicated `/live-test/rate-limit-false-positive` route
+  (mirroring the capstone route) is additive polish, deferred to keep this PR's surface
+  tight. <!-- tracked: CMT-1785 -->
+
+## Decision points touched
+- **Adds** no new block/allow/route gate. The `isSessionRecoverable` guard is an
+  internal predicate that NO-OPS a recovery — it never blocks a user action.
+- **Extends** the existing `LiveTestGate` veto surface only by giving it a new
+  artifact (featureId `rate-limit-false-positive-fix`) to evaluate; the gate's
+  block/allow logic is unchanged.
+- **Signal vs authority:** every new element is a SIGNAL or a bounded no-op. The
+  sentinel guard suppresses a spurious notice (it removes an action, never adds an
+  authoritative block); the harness absence assertion produces a PASS/FAIL signal the
+  (already-dark, dry-run-default) gate consumes; the QuotaCollector change is
+  log-level only. Nothing here holds new blocking authority over a user.
+
+## Frontloaded Decisions
+- **D1 — F3 detection-redesign is deferred, not bundled.** <!-- tracked: CMT-1785 --> The idle-but-running
+  stale-scrollback residual is lower-severity (self-corrects to ≤1 stray "back
+  online", never the 6-nudge spam F1+F2 kill) and its fix is a detection redesign best
+  driven by the new absence-harness evidence. Reversible: a follow-up spec. <!-- tracked: CMT-1785 --> Ships
+  nothing dark/irreversible. *Cheap-to-change-after:* the residual is internal
+  messaging behavior behind no published interface.
+- **D2 — Topic-map unregister on completion is intentionally NOT done.** It risks the
+  conversation-resume flow; F1 already neutralizes stale map entries at the sentinel
+  chokepoint. Reversible.
+- **D3 — The live-drive HTTP route is a fast-follow.** The prevention capability is
+  library-invokable + gate-wired and fully tested via fake drivers; the dedicated
+  route is additive (mirrors the existing capstone route). *Cheap-to-change-after:* an
+  additive route behind the existing dark `liveTestGate` flag.
+- **D4 — `approved: true` is self-applied** under the operator's standing 8-hour
+  autonomous-run pre-approval (2026-06-24); design forks in scope are the agent's to
+  resolve, reversible + dark-shipped.
+
+## Multi-machine posture
+- The sentinel guards + QuotaCollector change are **machine-local by design**: each
+  machine runs its own sentinels over its own sessions; `listRunningSessions()` is the
+  local running set. No cross-machine state is introduced.
+- The Live-test artifact + ledger are **already per-machine segments** (existing
+  `LiveTestArtifactStore` design, hash-chained per `machineId`); this spec adds a new
+  featureId to that existing posture, not a new replication path.
+
+## Open questions
+*(none)*
+
+## Out of scope (separate spec/PR)
+The cross-machine ownership-handoff wedge (`pendingReplacement` never completing in
+the session-pool placement path) is a distinct subsystem and gets its own spec +
+tests + PR to avoid bundling unrelated changes.

--- a/docs/specs/reports/false-ratelimit-recovery-completed-sessions-convergence.md
+++ b/docs/specs/reports/false-ratelimit-recovery-completed-sessions-convergence.md
@@ -1,0 +1,82 @@
+# Convergence Report — Fix false rate-limit/error recovery on finished sessions + user-channel proof harness
+
+## Cross-model review: codex-cli:gpt-5.5
+
+A real GPT-tier external pass ran through the agent's own codex CLI in both rounds
+(`status: ok`, verdict MINOR ISSUES each). A Gemini-tier pass also ran successfully in
+round 1 (`status: ok`, MINOR ISSUES); the round-2 Gemini pass degraded (timeout) but a
+prior round succeeded, so the spec genuinely received cross-model review from BOTH
+non-Claude families. Aggregate per `aggregateRoundOutcomes`: clean RAN.
+
+## ELI10 Overview
+
+The agent has a safety helper that "rescues" chat sessions that get temporarily blocked
+by the AI provider (a "server busy, slow down" throttle). The bug: the helper decided a
+session was throttled by reading the last few lines of its screen — but a session that
+had already *finished* sits quietly with that old throttle message still on screen, so
+the helper kept trying to rescue a session that was simply done. Because a finished
+session never produces new output, the rescue never "worked", and it kept pinging the
+user with "the throttle should have cleared — please continue". The helper code is
+shared by every agent, so the same false alarm showed up fleet-wide.
+
+This change makes a finished or killed session structurally incapable of being a rescue
+target: the helper now checks "is this session actually still running?" at every point
+it can act (when it first decides to rescue, before each retry, AND before the
+"did it respond?" check), and bails out silently if a session ended. When a session
+completes, the helpers are told to stop watching it immediately. A separate noisy
+"rate limit!" log that fired on harmless meter hiccups is also quieted.
+
+The bigger win is prevention: the agent already had a system that talks to itself
+through real Telegram (as the user) and checks the replies — but it could only check
+that the agent *said* the right thing, not that it *didn't* say something it shouldn't.
+We taught it to assert the **absence** of an unwanted background message over a time
+window. A deliberately-broken version now gets caught and blocked by the "is this done?"
+gate. That's the catch-it-before-fleet-deploy guarantee, demonstrated working.
+
+## Original vs Converged
+
+- **Originally** the fix proposed a status guard at the detection site (F3) as one of
+  four fixes. Review established the detection loop ALREADY iterates only running
+  sessions, so that guard would be a no-op; the real residual (a *still-running* idle
+  session with stale throttle scrollback) needs a detection redesign (adopt the
+  watchdog's existing `evaluateThrottleSettle` settle-gate on the idle path). That was
+  correctly re-scoped to a durably-tracked follow-up (CMT-1785), with the invariant
+  reworded to "enforced at the recovery-ACTION boundary, not detection."
+- **The decisive review catch:** the recoverability guard was applied at `report()` and
+  `attemptResume()` but **not** at `verify()` — so a session finishing during the ~25s
+  verify window could still reach the "still can't get through" escalation notice. Both
+  a cross-model (codex) reviewer and the internal adversarial reviewer flagged it
+  independently. Added the guard at `verify()` + a test reproducing the exact case.
+- **Flap hardening:** `abort()` originally deleted the dedupe entry, letting a session
+  flapping around the liveness oracle abort-then-rearm repeatedly; it now keeps the
+  entry as a cooldown.
+- **Prevention-window correctness:** the absence window default was widened 60s→90s so a
+  regression surfacing at the first resume/verify (~55s envelope) lands inside it.
+- **Topic-map deferral** gained an explicit future-consumer caveat + a delayed-GC
+  follow-up (folded into CMT-1785).
+
+## Iteration Summary
+
+| Iteration | Reviewers who flagged | Material findings | Spec/code changes |
+|-----------|-----------------------|-------------------|-------------------|
+| 1 | security/adversarial, decision-completeness/lessons, codex, gemini | 3 material (verify-gap, abort-debounce/transient-miss, F3-tracking) + minors | verify() guard, abort() keeps recentReports, absenceWindowMs 60→90, CMT-1785 opened, spec: F3 mechanism+harmless proof, topic-map caveat, test-authority, predicate precision |
+| 2 | codex (2 addressed-repeats), internal convergence-check (CONVERGED) | 0 new material | parent-principle wording (recovery-action boundary) |
+| — | Standards-Conformance Gate | 0 at-risk (both rounds) | none |
+
+## Full Findings Catalog
+
+**Round 1 — material:**
+- *Adversarial F4 (codex echoed):* guard missing at `verify()` → finished-mid-verify escalation ping. **Resolved:** guard added at `verify()` → `abort()`; unit test added.
+- *Adversarial F3:* `abort()` deleting `recentReports` + single transient-liveness read could cancel a real recovery / enable flap churn. **Resolved:** `abort()` keeps `recentReports`; documented `listRunningSessions` fails-open on tmux error so a hiccup can't drop a live session.
+- *Decision-Completeness/Lessons + codex F3:* F3 deferral cited no tracking artifact; should name `evaluateThrottleSettle`. **Resolved:** CMT-1785 opened; D1 names the mechanism + proves harmlessness via the verified sole-consumer (`RateLimitSentinel.report()`) argument.
+
+**Round 1 — minor (addressed via spec/notes):** absence-window envelope (→90s); topic-map stale-entry future-consumer caveat + delayed-GC; recoverable-predicate precision; test-authority clarification (deterministic unit tests are the correctness authority, harness is regression-prevention); QuotaCollector F4 degradation-sensitivity note; optional perf nicety (cache the running set — not taken, low call frequency).
+
+**Round 2:** codex raised 2 addressed-repeats (F3 invariant wording, topic-map state model) — non-material per the convergence criteria (repeats of addressed concerns); the parent-principle was reworded to state enforcement is at the recovery-action boundary. Internal convergence-check verified all 5 round-1 findings RESOLVED against the actual code and found no new material finding.
+
+## Convergence verdict
+
+Converged at iteration 2. No material findings in the final round; the internal
+convergence-check confirmed all round-1 findings resolved against the implementation and
+a fresh 6-lens pass surfaced nothing new; the Standards-Conformance Gate reported 0
+at-risk. Spec is ready for approval.

--- a/scratchpad/push-28130.log
+++ b/scratchpad/push-28130.log
@@ -1,0 +1,2 @@
+remote: Invalid username or token. Password authentication is not supported for Git operations.
+fatal: Authentication failed for 'https://github.com/JKHeadley/instar.git/'

--- a/scratchpad/push2-28130.log
+++ b/scratchpad/push2-28130.log
@@ -1,0 +1,634 @@
+🔒 Running pre-push gate (NEXT.md + version check)...
+
+  Pre-Push Gate
+  ────────────────────────────────────────
+
+  ⚠️  package.json version (1.3.655) matches the latest published guide (1.3.655). Did you forget to bump the version? Run: npm version patch|minor|major
+
+🔒 Running pre-push fixture-pollution guard...
+🧪 Running smoke tier (tests affected by changes vs resolved base)...
+   Full suite runs in CI | Force full locally: INSTAR_PRE_PUSH_FULL=1 git push
+
+> instar@1.3.655 test:smoke
+> node scripts/pre-push-smoke.mjs
+
+🧪 Running smoke tier against JKHeadley/main (branch upstream); changed files: 22.
+🧪 Smoke affected set: 29 test files / 262 test cases.
+
+ RUN  v2.1.9 /Users/justin/.instar/agents/echo/.worktrees/fix-false-ratelimit-detection
+
+ ✓ tests/integration/realtime-wiring.test.ts (21 tests) 522ms
+   ✓ Phase 8 export verification > AgentBus class is exported from index 493ms
+stderr | tests/unit/quota-collector.test.ts > QuotaCollector > falls back to JSONL when OAuth fails
+[DEGRADATION] QuotaCollector.collect.oauth: OAuth failed: OAuth usage returned 500
+  Primary: Collect quota data from Anthropic OAuth API
+  Fallback: Falling back to JSONL-based estimation (lower confidence)
+  Impact: Quota data may be estimated rather than authoritative
+
+stderr | tests/unit/quota-collector.test.ts > QuotaCollector > respects request budget
+[DEGRADATION] QuotaCollector.collect.oauth: OAuth failed: Request budget exhausted for current window
+  Primary: Collect quota data from Anthropic OAuth API
+  Fallback: Falling back to JSONL-based estimation (lower confidence)
+  Impact: Quota data may be estimated rather than authoritative
+
+stderr | tests/unit/quota-collector.test.ts > QuotaCollector > OAuth circuit breaker > trips after 3 consecutive 429 responses
+[DEGRADATION] QuotaCollector.collect.oauth: OAuth failed: OAuth usage returned 429 retry-after: 0
+  Primary: Collect quota data from Anthropic OAuth API
+  Fallback: Falling back to JSONL-based estimation (lower confidence)
+  Impact: Quota data may be estimated rather than authoritative
+
+stderr | tests/unit/quota-collector.test.ts > QuotaCollector > OAuth circuit breaker > skips OAuth when circuit breaker is open
+[DEGRADATION] QuotaCollector.collect.oauth: OAuth failed: OAuth usage returned 429 retry-after: 0
+  Primary: Collect quota data from Anthropic OAuth API
+  Fallback: Falling back to JSONL-based estimation (lower confidence)
+  Impact: Quota data may be estimated rather than authoritative
+
+ ✓ tests/unit/quota-collector.test.ts (53 tests) 62ms
+ ✓ tests/unit/coherence-gate-escalation.test.ts (24 tests) 22ms
+stdout | tests/unit/CompactionSentinel.test.ts > CompactionSentinel > emits compaction:detected on first report and calls recoverFn
+[Sentinel] detected compaction on "s1" via watchdog-poll; baseline jsonl: foo.jsonl size=100
+[Sentinel] inject-attempted on "s1" (attempt 1/3, accepted=true)
+
+stdout | tests/unit/CompactionSentinel.test.ts > CompactionSentinel > dedupes reports within the dedupe window
+[Sentinel] detected compaction on "s1" via PreCompact; baseline jsonl: foo.jsonl size=100
+[Sentinel] inject-attempted on "s1" (attempt 1/3, accepted=true)
+
+stdout | tests/unit/CompactionSentinel.test.ts > CompactionSentinel > separate sessions recover independently
+[Sentinel] detected compaction on "session-a" via watchdog-poll; baseline jsonl: a.jsonl size=100
+[Sentinel] detected compaction on "session-b" via watchdog-poll; baseline jsonl: a.jsonl size=100
+[Sentinel] inject-attempted on "session-a" (attempt 1/3, accepted=true)
+[Sentinel] inject-attempted on "session-b" (attempt 1/3, accepted=true)
+
+stdout | tests/unit/CompactionSentinel.test.ts > CompactionSentinel > emits compaction:recovered when jsonl grows within the verify window
+[Sentinel] detected compaction on "s1" via watchdog-poll; baseline jsonl: foo.jsonl size=100
+[Sentinel] inject-attempted on "s1" (attempt 1/3, accepted=true)
+
+stdout | tests/unit/CompactionSentinel.test.ts > CompactionSentinel > emits compaction:recovered when jsonl grows within the verify window
+[Sentinel] recovered "s1" after 1 attempt(s) (jsonl grew by 400 bytes)
+
+stdout | tests/unit/CompactionSentinel.test.ts > CompactionSentinel > retries when jsonl does not grow, up to maxInjectAttempts
+[Sentinel] detected compaction on "s1" via watchdog-poll; baseline jsonl: foo.jsonl size=100
+[Sentinel] inject-attempted on "s1" (attempt 1/3, accepted=true)
+[Sentinel] retry "s1" (attempt 1/3 produced no output, re-injecting)
+[Sentinel] inject-attempted on "s1" (attempt 2/3, accepted=true)
+[Sentinel] retry "s1" (attempt 2/3 produced no output, re-injecting)
+[Sentinel] inject-attempted on "s1" (attempt 3/3, accepted=true)
+
+stderr | tests/unit/CompactionSentinel.test.ts > CompactionSentinel > retries when jsonl does not grow, up to maxInjectAttempts
+[Sentinel] failed "s1": no jsonl growth after 3 attempts (75000ms total wait)
+
+stdout | tests/unit/CompactionSentinel.test.ts > CompactionSentinel > STANDS DOWN (never force-injects) when the defer budget is exhausted but the session is STILL actively working
+[Sentinel] detected compaction on "s1" via watchdog-poll; baseline jsonl: foo.jsonl size=100
+[Sentinel] "s1" actively working — deferring inject (defer 1/2); NOT re-injecting
+[Sentinel] "s1" actively working — deferring inject (defer 2/2); NOT re-injecting
+[Sentinel] "s1" still actively working after 2 defers — standing down, NOT forcing an inject (session is alive + working; no resume nudge needed)
+
+stdout | tests/unit/CompactionSentinel.test.ts > CompactionSentinel > stops retrying as soon as jsonl grows (recovers on attempt 2)
+[Sentinel] detected compaction on "s1" via watchdog-poll; baseline jsonl: foo.jsonl size=100
+[Sentinel] inject-attempted on "s1" (attempt 1/3, accepted=true)
+[Sentinel] retry "s1" (attempt 1/3 produced no output, re-injecting)
+[Sentinel] inject-attempted on "s1" (attempt 2/3, accepted=true)
+[Sentinel] recovered "s1" after 2 attempt(s) (jsonl grew by 300 bytes)
+
+stdout | tests/unit/CompactionSentinel.test.ts > CompactionSentinel > isRecoveryActive returns true during recovery and false after success
+[Sentinel] detected compaction on "s1" via watchdog-poll; baseline jsonl: foo.jsonl size=100
+[Sentinel] inject-attempted on "s1" (attempt 1/3, accepted=true)
+[Sentinel] recovered "s1" after 1 attempt(s) (jsonl grew by 400 bytes)
+
+stdout | tests/unit/CompactionSentinel.test.ts > CompactionSentinel > finalizes as failed when recoverFn returns false
+[Sentinel] detected compaction on "s1" via watchdog-poll; baseline jsonl: foo.jsonl size=100
+[Sentinel] inject-attempted on "s1" (attempt 1/3, accepted=false)
+
+stderr | tests/unit/CompactionSentinel.test.ts > CompactionSentinel > finalizes as failed when recoverFn returns false
+[Sentinel] failed "s1": recoverFn declined (no pending work or session gone)
+
+stdout | tests/unit/CompactionSentinel.test.ts > CompactionSentinel > treats recoverFn throwing as acceptance=false and finalizes
+[Sentinel] detected compaction on "s1" via watchdog-poll; baseline jsonl: foo.jsonl size=100
+[Sentinel] inject-attempted on "s1" (attempt 1/3, accepted=false)
+
+stderr | tests/unit/CompactionSentinel.test.ts > CompactionSentinel > treats recoverFn throwing as acceptance=false and finalizes
+[Sentinel] recoverFn threw on "s1" (attempt 1): Error: kaboom
+    at /Users/justin/.instar/agents/echo/.worktrees/fix-false-ratelimit-detection/tests/unit/CompactionSentinel.test.ts:212:33
+    at file:///Users/justin/.instar/agents/echo/.worktrees/fix-false-ratelimit-detection/node_modules/@vitest/runner/dist/index.js:146:14
+    at file:///Users/justin/.instar/agents/echo/.worktrees/fix-false-ratelimit-detection/node_modules/@vitest/runner/dist/index.js:533:11
+    at runWithTimeout (file:///Users/justin/.instar/agents/echo/.worktrees/fix-false-ratelimit-detection/node_modules/@vitest/runner/dist/index.js:39:7)
+    at runTest (file:///Users/justin/.instar/agents/echo/.worktrees/fix-false-ratelimit-detection/node_modules/@vitest/runner/dist/index.js:1056:17)
+    at runSuite (file:///Users/justin/.instar/agents/echo/.worktrees/fix-false-ratelimit-detection/node_modules/@vitest/runner/dist/index.js:1205:15)
+    at runSuite (file:///Users/justin/.instar/agents/echo/.worktrees/fix-false-ratelimit-detection/node_modules/@vitest/runner/dist/index.js:1205:15)
+    at runFiles (file:///Users/justin/.instar/agents/echo/.worktrees/fix-false-ratelimit-detection/node_modules/@vitest/runner/dist/index.js:1262:5)
+    at startTests (file:///Users/justin/.instar/agents/echo/.worktrees/fix-false-ratelimit-detection/node_modules/@vitest/runner/dist/index.js:1271:3)
+    at file:///Users/justin/.instar/agents/echo/.worktrees/fix-false-ratelimit-detection/node_modules/vitest/dist/chunks/runBaseTests.3qpJUEJM.js:126:11
+[Sentinel] failed "s1": recoverFn declined (no pending work or session gone)
+
+stdout | tests/unit/CompactionSentinel.test.ts > CompactionSentinel > handles the no-jsonl case without crashing
+[Sentinel] detected compaction on "s1" via watchdog-poll; baseline jsonl: none size=n/a
+[Sentinel] inject-attempted on "s1" (attempt 1/3, accepted=true)
+[Sentinel] retry "s1" (attempt 1/3 produced no output, re-injecting)
+[Sentinel] inject-attempted on "s1" (attempt 2/3, accepted=true)
+
+stdout | tests/unit/CompactionSentinel.test.ts > CompactionSentinel > uses claudeSessionId to target the exact jsonl when available
+[Sentinel] detected compaction on "s1" via watchdog-poll; baseline jsonl: abc-123.jsonl size=100
+[Sentinel] inject-attempted on "s1" (attempt 1/3, accepted=true)
+[Sentinel] retry "s1" (attempt 1/3 produced no output, re-injecting)
+[Sentinel] inject-attempted on "s1" (attempt 2/3, accepted=true)
+[Sentinel] recovered "s1" after 2 attempt(s) (jsonl grew by 300 bytes)
+
+stdout | tests/unit/CompactionSentinel.test.ts > CompactionSentinel > falls back to newest jsonl when the stored claudeSessionId transcript is missing (phantom uuid)
+[CompactionSentinel] stale claudeSessionId for "echo-api-errors" (563a7027-432d-4b46-9706-caf43daa1016.jsonl missing) — falling back to newest jsonl in project root
+[Sentinel] detected compaction on "echo-api-errors" via watchdog-poll; baseline jsonl: live-conversation.jsonl size=100
+[Sentinel] inject-attempted on "echo-api-errors" (attempt 1/3, accepted=true)
+[CompactionSentinel] stale claudeSessionId for "echo-api-errors" (563a7027-432d-4b46-9706-caf43daa1016.jsonl missing) — falling back to newest jsonl in project root
+[Sentinel] recovered "echo-api-errors" after 1 attempt(s) (jsonl grew by 800 bytes)
+
+stdout | tests/unit/CompactionSentinel.test.ts > CompactionSentinel > detects growth via mtime change on a fixed-size jsonl
+[Sentinel] detected compaction on "s1" via watchdog-poll; baseline jsonl: foo.jsonl size=100
+[Sentinel] inject-attempted on "s1" (attempt 1/3, accepted=true)
+[Sentinel] recovered "s1" after 1 attempt(s) (jsonl grew by 0 bytes)
+
+stdout | tests/unit/CompactionSentinel.test.ts > CompactionSentinel > clear() removes active state
+[Sentinel] detected compaction on "s1" via watchdog-poll; baseline jsonl: foo.jsonl size=100
+[Sentinel] inject-attempted on "s1" (attempt 1/3, accepted=true)
+
+stdout | tests/unit/CompactionSentinel.test.ts > CompactionSentinel > allows re-recovery after a previous recovery finalizes
+[Sentinel] detected compaction on "s1" via watchdog-poll; baseline jsonl: foo.jsonl size=100
+[Sentinel] inject-attempted on "s1" (attempt 1/3, accepted=true)
+[Sentinel] recovered "s1" after 1 attempt(s) (jsonl grew by 300 bytes)
+[Sentinel] detected compaction on "s1" via watchdog-poll; baseline jsonl: foo.jsonl size=400
+[Sentinel] inject-attempted on "s1" (attempt 1/3, accepted=true)
+
+stdout | tests/unit/CompactionSentinel.test.ts > CompactionSentinel > stop() cleans up all state and timers
+[Sentinel] detected compaction on "a" via watchdog-poll; baseline jsonl: a.jsonl size=100
+[Sentinel] detected compaction on "b" via watchdog-poll; baseline jsonl: a.jsonl size=100
+[Sentinel] inject-attempted on "a" (attempt 1/3, accepted=true)
+[Sentinel] inject-attempted on "b" (attempt 1/3, accepted=true)
+
+stdout | tests/unit/CompactionSentinel.test.ts > CompactionSentinel > busy-session defer guard > defers the first inject while actively working — never calls recoverFn
+[Sentinel] detected compaction on "s1" via watchdog-poll; baseline jsonl: foo.jsonl size=100
+[Sentinel] "s1" actively working — deferring inject (defer 1/4); NOT re-injecting
+
+stdout | tests/unit/CompactionSentinel.test.ts > CompactionSentinel > busy-session defer guard > injects once the session stops working
+[Sentinel] detected compaction on "s1" via watchdog-poll; baseline jsonl: foo.jsonl size=100
+[Sentinel] "s1" actively working — deferring inject (defer 1/4); NOT re-injecting
+[Sentinel] retry "s1" (attempt 0/3 produced no output, re-injecting)
+[Sentinel] inject-attempted on "s1" (attempt 1/3, accepted=true)
+
+stdout | tests/unit/CompactionSentinel.test.ts > CompactionSentinel > busy-session defer guard > recovers WITHOUT injecting if the session emits while we defer (jsonl grows)
+[Sentinel] detected compaction on "s1" via watchdog-poll; baseline jsonl: foo.jsonl size=100
+[Sentinel] "s1" actively working — deferring inject (defer 1/4); NOT re-injecting
+[Sentinel] recovered "s1" after 0 attempt(s) (jsonl grew by 400 bytes)
+
+stdout | tests/unit/CompactionSentinel.test.ts > CompactionSentinel > busy-session defer guard > caps consecutive defers at maxWorkingDefers then STANDS DOWN (never force-injects a still-working session)
+[Sentinel] detected compaction on "s1" via watchdog-poll; baseline jsonl: foo.jsonl size=100
+[Sentinel] "s1" actively working — deferring inject (defer 1/4); NOT re-injecting
+[Sentinel] "s1" actively working — deferring inject (defer 2/4); NOT re-injecting
+[Sentinel] "s1" actively working — deferring inject (defer 3/4); NOT re-injecting
+[Sentinel] "s1" actively working — deferring inject (defer 4/4); NOT re-injecting
+
+stdout | tests/unit/CompactionSentinel.test.ts > CompactionSentinel > busy-session defer guard > caps consecutive defers at maxWorkingDefers then STANDS DOWN (never force-injects a still-working session)
+[Sentinel] "s1" still actively working after 4 defers — standing down, NOT forcing an inject (session is alive + working; no resume nudge needed)
+
+stdout | tests/unit/CompactionSentinel.test.ts > CompactionSentinel > busy-session defer guard > maxWorkingDefers=0 disables deferral (injects immediately even while working)
+[Sentinel] detected compaction on "s1" via watchdog-poll; baseline jsonl: foo.jsonl size=100
+[Sentinel] inject-attempted on "s1" (attempt 1/3, accepted=true)
+
+stdout | tests/unit/CompactionSentinel.test.ts > CompactionSentinel > busy-session defer guard > with no isActivelyWorking dep, never defers (backward compatible)
+[Sentinel] detected compaction on "s1" via watchdog-poll; baseline jsonl: foo.jsonl size=100
+[Sentinel] inject-attempted on "s1" (attempt 1/3, accepted=true)
+
+ ✓ tests/unit/CompactionSentinel.test.ts (24 tests) 40ms
+stdout | tests/integration/quota-manager-wiring.test.ts > QuotaManager Integration > event subscribers receive threshold crossings
+[QuotaNotifier] Weekly quota is at 88%. Only high-priority and critical jobs will run now. Let me know if you want to adjust the thresholds.
+
+stdout | tests/integration/quota-manager-wiring.test.ts > QuotaManager Integration > polling status returns correct state
+[QuotaManager] Started adaptive polling loop
+[QuotaManager] Stopped
+
+ ✓ tests/integration/quota-manager-wiring.test.ts (8 tests) 50ms
+stderr | tests/integration/quota-collection.test.ts > Quota Collection (integration) > OAuth 500 triggers JSONL fallback with real file parsing
+[DEGRADATION] QuotaCollector.collect.oauth: OAuth failed: OAuth usage returned 500
+  Primary: Collect quota data from Anthropic OAuth API
+  Fallback: Falling back to JSONL-based estimation (lower confidence)
+  Impact: Quota data may be estimated rather than authoritative
+
+ ✓ tests/integration/quota-collection.test.ts (9 tests) 43ms
+stderr | tests/e2e/quota-collection-lifecycle.test.ts > Quota Collection Lifecycle (e2e) > handles complete token loss gracefully — no credentials, no JSONL
+[quota] No quota state file found — all jobs will run (fail-open)
+
+ ✓ tests/e2e/quota-collection-lifecycle.test.ts (6 tests) 19ms
+stdout | tests/e2e/quota-manager-lifecycle.test.ts > QuotaManager E2E Lifecycle > full lifecycle: normal → high usage → threshold events → migration → cooldown
+[QuotaNotifier] Weekly quota is at 75%. Low-priority jobs will be held back from here. You can adjust these thresholds in config if you want different cutoffs.
+[QuotaNotifier] Weekly quota is at 88%. Only high-priority and critical jobs will run now. Let me know if you want to adjust the thresholds.
+
+stdout | tests/e2e/quota-manager-lifecycle.test.ts > QuotaManager E2E Lifecycle > tracker-only mode works without collector
+[QuotaManager] Started (tracker-only mode, no collector)
+[QuotaManager] Stopped
+
+stdout | tests/e2e/quota-manager-lifecycle.test.ts > QuotaManager E2E Lifecycle > notification retry survives initial failure
+[QuotaManager] Started (tracker-only mode, no collector)
+[QuotaManager] Stopped
+
+stdout | tests/e2e/quota-manager-lifecycle.test.ts > QuotaManager E2E Lifecycle > JSONL data does not trigger migration by default
+[QuotaNotifier] We've hit the weekly quota limit (138.8%). No new sessions will start until the quota resets.
+
+ ✓ tests/e2e/quota-manager-lifecycle.test.ts (4 tests) 11390ms
+   ✓ QuotaManager E2E Lifecycle > JSONL data does not trigger migration by default 11378ms
+stdout | tests/unit/RateLimitSentinel.test.ts > RateLimitSentinel > emits detected + sends the immediate "backing off" notice, but does NOT resume yet
+[RateLimitSentinel] detected throttle error on "s1" via watchdog-poll; baseline jsonl=foo.jsonl size=100
+
+stdout | tests/unit/RateLimitSentinel.test.ts > RateLimitSentinel > re-engages only AFTER the first backoff interval (quota-burn guard)
+[RateLimitSentinel] detected throttle error on "s1" via watchdog-poll; baseline jsonl=foo.jsonl size=100
+
+stdout | tests/unit/RateLimitSentinel.test.ts > RateLimitSentinel > re-engages only AFTER the first backoff interval (quota-burn guard)
+[RateLimitSentinel] resume-attempted on "s1" (attempt 1/6, accepted=true)
+
+stdout | tests/unit/RateLimitSentinel.test.ts > RateLimitSentinel > recovers when jsonl grows within the verify window after the nudge
+[RateLimitSentinel] detected throttle error on "s1" via watchdog-poll; baseline jsonl=foo.jsonl size=100
+[RateLimitSentinel] resume-attempted on "s1" (attempt 1/6, accepted=true)
+[RateLimitSentinel] recovered "s1" after 1 attempt(s) (jsonl grew by 700 bytes)
+
+stdout | tests/unit/RateLimitSentinel.test.ts > RateLimitSentinel > falls back to newest jsonl when the stored claudeSessionId transcript is missing (phantom uuid)
+[RateLimitSentinel] stale claudeSessionId for "echo-api-errors" (563a7027-432d-4b46-9706-caf43daa1016.jsonl missing) — falling back to newest jsonl in project root
+[RateLimitSentinel] detected throttle error on "echo-api-errors" via watchdog-poll; baseline jsonl=live-conversation.jsonl size=100
+[RateLimitSentinel] resume-attempted on "echo-api-errors" (attempt 1/6, accepted=true)
+[RateLimitSentinel] stale claudeSessionId for "echo-api-errors" (563a7027-432d-4b46-9706-caf43daa1016.jsonl missing) — falling back to newest jsonl in project root
+[RateLimitSentinel] recovered "echo-api-errors" after 1 attempt(s) (jsonl grew by 800 bytes)
+
+stdout | tests/unit/RateLimitSentinel.test.ts > RateLimitSentinel > still prefers the exact uuid transcript when it exists — sibling growth alone does not count
+[RateLimitSentinel] detected throttle error on "s1" via watchdog-poll; baseline jsonl=my-uuid.jsonl size=100
+[RateLimitSentinel] resume-attempted on "s1" (attempt 1/2, accepted=true)
+
+stdout | tests/unit/RateLimitSentinel.test.ts > RateLimitSentinel > escalates after maxAttempts with no jsonl growth
+[RateLimitSentinel] detected throttle error on "s1" via watchdog-poll; baseline jsonl=foo.jsonl size=100
+[RateLimitSentinel] resume-attempted on "s1" (attempt 1/3, accepted=true)
+
+stdout | tests/unit/RateLimitSentinel.test.ts > RateLimitSentinel > escalates after maxAttempts with no jsonl growth
+[RateLimitSentinel] resume-attempted on "s1" (attempt 2/3, accepted=true)
+[RateLimitSentinel] resume-attempted on "s1" (attempt 3/3, accepted=true)
+
+stderr | tests/unit/RateLimitSentinel.test.ts > RateLimitSentinel > escalates after maxAttempts with no jsonl growth
+[RateLimitSentinel] escalated "s1": no jsonl growth after 3 attempts over 1m
+
+stdout | tests/unit/RateLimitSentinel.test.ts > RateLimitSentinel > escalates immediately if resumeFn declines (no pending work / session gone)
+[RateLimitSentinel] detected throttle error on "s1" via idle-error; baseline jsonl=foo.jsonl size=100
+[RateLimitSentinel] resume-attempted on "s1" (attempt 1/6, accepted=false)
+
+stderr | tests/unit/RateLimitSentinel.test.ts > RateLimitSentinel > escalates immediately if resumeFn declines (no pending work / session gone)
+[RateLimitSentinel] escalated "s1": resumeFn declined (no pending work or session gone)
+
+stdout | tests/unit/RateLimitSentinel.test.ts > RateLimitSentinel > dedupes reports while a recovery is active
+[RateLimitSentinel] detected throttle error on "s1" via watchdog-poll; baseline jsonl=foo.jsonl size=100
+
+stdout | tests/unit/RateLimitSentinel.test.ts > RateLimitSentinel > isRecoveryActive is true during recovery, false before and after
+[RateLimitSentinel] detected throttle error on "s1" via watchdog-poll; baseline jsonl=foo.jsonl size=100
+[RateLimitSentinel] resume-attempted on "s1" (attempt 1/6, accepted=true)
+
+stdout | tests/unit/RateLimitSentinel.test.ts > RateLimitSentinel > does not spam check-ins: spaced by checkInEveryMs
+[RateLimitSentinel] detected throttle error on "s1" via watchdog-poll; baseline jsonl=foo.jsonl size=100
+[RateLimitSentinel] resume-attempted on "s1" (attempt 1/10, accepted=true)
+[RateLimitSentinel] resume-attempted on "s1" (attempt 2/10, accepted=true)
+[RateLimitSentinel] resume-attempted on "s1" (attempt 3/10, accepted=true)
+[RateLimitSentinel] resume-attempted on "s1" (attempt 4/10, accepted=true)
+
+stdout | tests/unit/RateLimitSentinel.test.ts > RateLimitSentinel > sends a check-in once spacing has elapsed
+[RateLimitSentinel] detected throttle error on "s1" via watchdog-poll; baseline jsonl=foo.jsonl size=100
+[RateLimitSentinel] resume-attempted on "s1" (attempt 1/10, accepted=true)
+
+stdout | tests/unit/RateLimitSentinel.test.ts > RateLimitSentinel > listActive surfaces state + nextBackoffMs for the status endpoint
+[RateLimitSentinel] detected throttle error on "s1" via watchdog-poll; baseline jsonl=foo.jsonl size=100
+
+stdout | tests/unit/RateLimitSentinel.test.ts > RateLimitSentinel > separate sessions recover independently
+[RateLimitSentinel] detected throttle error on "a" via watchdog-poll; baseline jsonl=foo.jsonl size=100
+[RateLimitSentinel] detected throttle error on "b" via idle-error; baseline jsonl=foo.jsonl size=100
+
+stdout | tests/unit/RateLimitSentinel.test.ts > RateLimitSentinel > errorClass: 'transient-api' > uses the FAST first backoff (5s, not the 30s throttle schedule)
+[RateLimitSentinel] detected transient-api error on "s1" via idle-error; baseline jsonl=foo.jsonl size=100
+[RateLimitSentinel] resume-attempted on "s1" (attempt 1/6, accepted=true)
+
+stdout | tests/unit/RateLimitSentinel.test.ts > RateLimitSentinel > errorClass: 'transient-api' > sends a transient-API-worded notice (not the throttle wording)
+[RateLimitSentinel] detected transient-api error on "s1" via idle-error; baseline jsonl=foo.jsonl size=100
+
+stdout | tests/unit/RateLimitSentinel.test.ts > RateLimitSentinel > errorClass: 'transient-api' > rides the full lifecycle: backoff → resume → verify(jsonl growth) → recovered
+[RateLimitSentinel] detected transient-api error on "s1" via idle-error; baseline jsonl=foo.jsonl size=100
+[RateLimitSentinel] resume-attempted on "s1" (attempt 1/6, accepted=true)
+[RateLimitSentinel] recovered "s1" after 1 attempt(s) (jsonl grew by 4900 bytes)
+
+stdout | tests/unit/RateLimitSentinel.test.ts > RateLimitSentinel > errorClass: 'transient-api' > records its errorClass + listActive reflects the short schedule
+[RateLimitSentinel] detected transient-api error on "s1" via idle-error; baseline jsonl=foo.jsonl size=100
+
+ ✓ tests/unit/RateLimitSentinel.test.ts (20 tests) 30ms
+stdout | tests/e2e/live-test-capstone-alive.test.ts > Live-User-Channel Proof capstone runner — E2E (feature is alive)
+[instar] Server listening on 127.0.0.1:61298
+[instar] Dashboard: http://127.0.0.1:61298/dashboard
+[instar] burn-detection auto-heal system started
+[instar] Server listening on 127.0.0.1:61299
+[instar] Dashboard: http://127.0.0.1:61299/dashboard
+[instar] burn-detection auto-heal system started
+
+stderr | tests/e2e/live-test-capstone-alive.test.ts > Live-User-Channel Proof capstone runner — E2E (feature is alive)
+[instar] model-tier escalation init failed (non-fatal): TypeError: options.sessionManager.on is not a function
+    at new AgentServer (/Users/justin/.instar/agents/echo/.worktrees/fix-false-ratelimit-detection/src/server/AgentServer.ts:2010:30)
+    at /Users/justin/.instar/agents/echo/.worktrees/fix-false-ratelimit-detection/tests/e2e/live-test-capstone-alive.test.ts:109:21
+    at processTicksAndRejections (node:internal/process/task_queues:105:5)
+    at callSuiteHook (file:///Users/justin/.instar/agents/echo/.worktrees/fix-false-ratelimit-detection/node_modules/@vitest/runner/dist/index.js:964:22)
+    at runSuite (file:///Users/justin/.instar/agents/echo/.worktrees/fix-false-ratelimit-detection/node_modules/@vitest/runner/dist/index.js:1175:29)
+    at runSuite (file:///Users/justin/.instar/agents/echo/.worktrees/fix-false-ratelimit-detection/node_modules/@vitest/runner/dist/index.js:1205:15)
+    at runFiles (file:///Users/justin/.instar/agents/echo/.worktrees/fix-false-ratelimit-detection/node_modules/@vitest/runner/dist/index.js:1262:5)
+    at startTests (file:///Users/justin/.instar/agents/echo/.worktrees/fix-false-ratelimit-detection/node_modules/@vitest/runner/dist/index.js:1271:3)
+    at file:///Users/justin/.instar/agents/echo/.worktrees/fix-false-ratelimit-detection/node_modules/vitest/dist/chunks/runBaseTests.3qpJUEJM.js:126:11
+    at withEnv (file:///Users/justin/.instar/agents/echo/.worktrees/fix-false-ratelimit-detection/node_modules/vitest/dist/chunks/runBaseTests.3qpJUEJM.js:90:5)
+[instar] credential-coherence: 4 identity surface(s) diverge from the agent's repo-local identity (see .instar/audit/credential-resolution.jsonl)
+[instar] model-tier escalation init failed (non-fatal): TypeError: options.sessionManager.on is not a function
+    at new AgentServer (/Users/justin/.instar/agents/echo/.worktrees/fix-false-ratelimit-detection/src/server/AgentServer.ts:2010:30)
+    at /Users/justin/.instar/agents/echo/.worktrees/fix-false-ratelimit-detection/tests/e2e/live-test-capstone-alive.test.ts:121:18
+    at processTicksAndRejections (node:internal/process/task_queues:105:5)
+    at callSuiteHook (file:///Users/justin/.instar/agents/echo/.worktrees/fix-false-ratelimit-detection/node_modules/@vitest/runner/dist/index.js:964:22)
+    at runSuite (file:///Users/justin/.instar/agents/echo/.worktrees/fix-false-ratelimit-detection/node_modules/@vitest/runner/dist/index.js:1175:29)
+    at runSuite (file:///Users/justin/.instar/agents/echo/.worktrees/fix-false-ratelimit-detection/node_modules/@vitest/runner/dist/index.js:1205:15)
+    at runFiles (file:///Users/justin/.instar/agents/echo/.worktrees/fix-false-ratelimit-detection/node_modules/@vitest/runner/dist/index.js:1262:5)
+    at startTests (file:///Users/justin/.instar/agents/echo/.worktrees/fix-false-ratelimit-detection/node_modules/@vitest/runner/dist/index.js:1271:3)
+    at file:///Users/justin/.instar/agents/echo/.worktrees/fix-false-ratelimit-detection/node_modules/vitest/dist/chunks/runBaseTests.3qpJUEJM.js:126:11
+    at withEnv (file:///Users/justin/.instar/agents/echo/.worktrees/fix-false-ratelimit-detection/node_modules/vitest/dist/chunks/runBaseTests.3qpJUEJM.js:90:5)
+[instar] credential-coherence: 4 identity surface(s) diverge from the agent's repo-local identity (see .instar/audit/credential-resolution.jsonl)
+
+stderr | tests/e2e/live-test-capstone-alive.test.ts > Live-User-Channel Proof capstone runner — E2E (feature is alive) > (a) WIRED: the capstone route runs the matrix, returns 200, records a signed artifact
+[auth] deprecation: bearer-only request to /live-test/multi-machine-capstone from ::ffff:127.0.0.1 — clients must send X-Instar-AgentId header. (deduped 1/hour per source)
+
+ ✓ tests/e2e/live-test-capstone-alive.test.ts (4 tests) 622ms
+ ✓ tests/integration/live-test-capstone-route.test.ts (7 tests) 93ms
+stdout | tests/e2e/rate-limit-sentinel-lifecycle.test.ts > RateLimitSentinel E2E lifecycle
+[instar] Server listening on 127.0.0.1:0
+[instar] Dashboard: http://127.0.0.1:0/dashboard
+[instar] burn-detection auto-heal system started
+
+stderr | tests/e2e/rate-limit-sentinel-lifecycle.test.ts > RateLimitSentinel E2E lifecycle
+[instar] model-tier escalation init failed (non-fatal): TypeError: options.sessionManager.on is not a function
+    at new AgentServer (/Users/justin/.instar/agents/echo/.worktrees/fix-false-ratelimit-detection/src/server/AgentServer.ts:2010:30)
+    at /Users/justin/.instar/agents/echo/.worktrees/fix-false-ratelimit-detection/tests/e2e/rate-limit-sentinel-lifecycle.test.ts:100:14
+    at runWithTimeout (file:///Users/justin/.instar/agents/echo/.worktrees/fix-false-ratelimit-detection/node_modules/@vitest/runner/dist/index.js:39:7)
+    at callSuiteHook (file:///Users/justin/.instar/agents/echo/.worktrees/fix-false-ratelimit-detection/node_modules/@vitest/runner/dist/index.js:964:28)
+    at runSuite (file:///Users/justin/.instar/agents/echo/.worktrees/fix-false-ratelimit-detection/node_modules/@vitest/runner/dist/index.js:1175:35)
+    at processTicksAndRejections (node:internal/process/task_queues:105:5)
+[instar] credential-coherence: 4 identity surface(s) diverge from the agent's repo-local identity (see .instar/audit/credential-resolution.jsonl)
+
+stderr | tests/e2e/rate-limit-sentinel-lifecycle.test.ts > RateLimitSentinel E2E lifecycle > Phase 1: Feature is alive (not 503, enabled:true) > GET /rate-limit/status returns 200 with enabled:true
+[auth] deprecation: bearer-only request to /rate-limit/status from ::ffff:127.0.0.1 — clients must send X-Instar-AgentId header. (deduped 1/hour per source)
+
+stdout | tests/e2e/rate-limit-sentinel-lifecycle.test.ts > RateLimitSentinel E2E lifecycle > Phase 2: Active recovery is observable on the wire > a reported throttle appears in /rate-limit/status with the documented shape
+[RateLimitSentinel] detected throttle error on "e2e-sess" via watchdog-poll; baseline jsonl=session.jsonl size=100
+
+ ✓ tests/e2e/rate-limit-sentinel-lifecycle.test.ts (4 tests) 145ms
+ ✓ tests/unit/LiveTestHarness.test.ts (6 tests) 13ms
+stderr | tests/unit/topic-operator-polling-bind.test.ts > polling-path operator auto-bind (increment 2e) > getter THROWS → caught, routing continues (fail-soft)
+[telegram] topic-operator auto-bind error (non-fatal): boom
+
+stderr | tests/unit/topic-operator-polling-bind.test.ts > polling-path operator auto-bind (increment 2e) > store.setOperator THROWS → caught, routing continues (fail-soft)
+[telegram] topic-operator auto-bind error (non-fatal): disk full
+
+ ✓ tests/unit/topic-operator-polling-bind.test.ts (6 tests) 8ms
+ ✓ tests/unit/rate-limit-false-positive-matrix.test.ts (6 tests) 11ms
+stdout | tests/e2e/compaction-busy-defer-lifecycle.test.ts > compaction busy-defer E2E — real disk + real timers > never injects while working, then recovers when the JSONL grows on disk
+[Sentinel] detected compaction on "sess" via watchdog-poll; baseline jsonl: sess.jsonl size=100
+[Sentinel] "sess" actively working — deferring inject (defer 1/8); NOT re-injecting
+
+stdout | tests/e2e/compaction-busy-defer-lifecycle.test.ts > compaction busy-defer E2E — real disk + real timers > never injects while working, then recovers when the JSONL grows on disk
+[Sentinel] "sess" actively working — deferring inject (defer 2/8); NOT re-injecting
+
+stdout | tests/e2e/compaction-busy-defer-lifecycle.test.ts > compaction busy-defer E2E — real disk + real timers > never injects while working, then recovers when the JSONL grows on disk
+[Sentinel] "sess" actively working — deferring inject (defer 3/8); NOT re-injecting
+
+stdout | tests/e2e/compaction-busy-defer-lifecycle.test.ts > compaction busy-defer E2E — real disk + real timers > never injects while working, then recovers when the JSONL grows on disk
+[Sentinel] "sess" actively working — deferring inject (defer 4/8); NOT re-injecting
+
+stdout | tests/e2e/compaction-busy-defer-lifecycle.test.ts > compaction busy-defer E2E — real disk + real timers > never injects while working, then recovers when the JSONL grows on disk
+[Sentinel] "sess" actively working — deferring inject (defer 5/8); NOT re-injecting
+
+stdout | tests/e2e/compaction-busy-defer-lifecycle.test.ts > compaction busy-defer E2E — real disk + real timers > never injects while working, then recovers when the JSONL grows on disk
+[Sentinel] recovered "sess" after 0 attempt(s) (jsonl grew by 500 bytes)
+
+stdout | tests/e2e/compaction-busy-defer-lifecycle.test.ts > compaction busy-defer E2E — real disk + real timers > idle-from-start session injects (recovery still works when genuinely stuck)
+[Sentinel] detected compaction on "sess" via watchdog-poll; baseline jsonl: sess.jsonl size=100
+[Sentinel] inject-attempted on "sess" (attempt 1/3, accepted=true)
+
+ ✓ tests/e2e/compaction-busy-defer-lifecycle.test.ts (4 tests) 343ms
+   ✓ compaction busy-defer E2E — real disk + real timers > never injects while working, then recovers when the JSONL grows on disk 315ms
+stdout | tests/unit/RateLimitSentinel-recoverable-guard.test.ts > RateLimitSentinel — isSessionRecoverable guard (false-positive on finished sessions) > NO-OPS when the session is not recoverable (finished/killed/unknown) — no notice, no recovery
+[RateLimitSentinel] ignoring idle-error for "echo-topic-28130" — not a live recovery target (finished/killed/unknown)
+
+stdout | tests/unit/RateLimitSentinel-recoverable-guard.test.ts > RateLimitSentinel — isSessionRecoverable guard (false-positive on finished sessions) > PROCEEDS normally when the session IS recoverable (genuine throttle still recovers)
+[RateLimitSentinel] detected throttle error on "echo-topic-28130" via idle-error; baseline jsonl=none size=n/a
+
+stdout | tests/unit/RateLimitSentinel-recoverable-guard.test.ts > RateLimitSentinel — isSessionRecoverable guard (false-positive on finished sessions) > dep ABSENT preserves prior behavior (recovers anything reported) — regression lock
+[RateLimitSentinel] detected throttle error on "echo-topic-28130" via idle-error; baseline jsonl=none size=n/a
+
+stdout | tests/unit/RateLimitSentinel-recoverable-guard.test.ts > RateLimitSentinel — isSessionRecoverable guard (false-positive on finished sessions) > ABORTS SILENTLY when the session finishes mid-backoff — no escalation ping, emits aborted
+[RateLimitSentinel] detected throttle error on "echo-topic-28130" via idle-error; baseline jsonl=none size=n/a
+[RateLimitSentinel] aborted "echo-topic-28130": session no longer recoverable (finished/killed during backoff)
+
+stdout | tests/unit/RateLimitSentinel-recoverable-guard.test.ts > RateLimitSentinel — isSessionRecoverable guard (false-positive on finished sessions) > ABORTS when the session finishes during the VERIFY window — no escalation ping (the finished-mid-verify hole)
+[RateLimitSentinel] detected throttle error on "echo-topic-28130" via idle-error; baseline jsonl=none size=n/a
+[RateLimitSentinel] resume-attempted on "echo-topic-28130" (attempt 1/6, accepted=true)
+[RateLimitSentinel] aborted "echo-topic-28130": session no longer recoverable (finished/killed during verify window)
+
+ ✓ tests/unit/RateLimitSentinel-recoverable-guard.test.ts (5 tests) 5ms
+stdout | tests/integration/compaction-busy-defer-wiring.test.ts > CompactionSentinel × SessionManager — busy-session defer wiring > defers (no inject) while the real SessionManager reports the session mid-turn
+[Sentinel] detected compaction on "echo-sess" via watchdog-poll; baseline jsonl: foo.jsonl size=100
+[Sentinel] "echo-sess" actively working — deferring inject (defer 1/5); NOT re-injecting
+
+stdout | tests/integration/compaction-busy-defer-wiring.test.ts > CompactionSentinel × SessionManager — busy-session defer wiring > injects once the real SessionManager reports the session idle
+[Sentinel] detected compaction on "echo-sess" via watchdog-poll; baseline jsonl: foo.jsonl size=100
+[Sentinel] "echo-sess" actively working — deferring inject (defer 1/5); NOT re-injecting
+[Sentinel] retry "echo-sess" (attempt 0/3 produced no output, re-injecting)
+[Sentinel] inject-attempted on "echo-sess" (attempt 1/3, accepted=true)
+
+stdout | tests/integration/compaction-busy-defer-wiring.test.ts > CompactionSentinel × SessionManager — busy-session defer wiring > injects immediately when the session is idle from the start (unchanged path)
+[Sentinel] detected compaction on "echo-sess" via watchdog-poll; baseline jsonl: foo.jsonl size=100
+[Sentinel] inject-attempted on "echo-sess" (attempt 1/3, accepted=true)
+
+stdout | tests/integration/compaction-busy-defer-wiring.test.ts > CompactionSentinel × SessionManager — busy-session defer wiring > defers while a real child process is running even with no footer
+[Sentinel] detected compaction on "echo-sess" via watchdog-poll; baseline jsonl: foo.jsonl size=100
+[Sentinel] "echo-sess" actively working — deferring inject (defer 1/5); NOT re-injecting
+
+ ✓ tests/integration/compaction-busy-defer-wiring.test.ts (4 tests) 11ms
+ ✓ tests/integration/topic-operator-polling-bind.test.ts (3 tests) 7ms
+stdout | tests/integration/rate-limit-status-routes.test.ts > RateLimitSentinel routes + wiring (integration) > GET /rate-limit/status reflects an active recovery
+[RateLimitSentinel] detected throttle error on "sess-1" via watchdog-poll; baseline jsonl=foo.jsonl size=100
+
+stdout | tests/integration/rate-limit-status-routes.test.ts > RateLimitSentinel routes + wiring (integration) > composed recovery-checker is true when EITHER sentinel owns the session
+[RateLimitSentinel] detected throttle error on "x" via idle-error; baseline jsonl=foo.jsonl size=100
+[Sentinel] detected compaction on "y" via watchdog-poll; baseline jsonl: foo.jsonl size=100
+[Sentinel] inject-attempted on "y" (attempt 1/3, accepted=true)
+
+stdout | tests/integration/rate-limit-status-routes.test.ts > RateLimitSentinel routes + wiring (integration) > rate-limit sentinel defers when compaction recovery owns the session
+[Sentinel] detected compaction on "z" via watchdog-poll; baseline jsonl: foo.jsonl size=100
+[Sentinel] inject-attempted on "z" (attempt 1/3, accepted=true)
+
+ ✓ tests/integration/rate-limit-status-routes.test.ts (4 tests) 32ms
+ ✓ tests/integration/rate-limit-false-positive-prevention.test.ts (2 tests) 9ms
+ ✓ tests/unit/LiveTestRunner.test.ts (5 tests) 7ms
+stdout | tests/unit/RateLimitSentinel-codex-recovery.test.ts > RateLimitSentinel — codex recovery via newest rollout (#33) > recovers a codex session when the newest rollout GROWS (account throttle cleared)
+[RateLimitSentinel] detected throttle error on "codey-1" via codex-usage-poll; baseline jsonl=rollout-2026-05-31T09-00-00-aaaa1111-0000-0000-0000-000000000001.jsonl size=100
+[RateLimitSentinel] resume-attempted on "codey-1" (attempt 1/6, accepted=true)
+[RateLimitSentinel] recovered "codey-1" after 1 attempt(s) (jsonl grew by 800 bytes)
+
+stdout | tests/unit/RateLimitSentinel-codex-recovery.test.ts > RateLimitSentinel — codex recovery via newest rollout (#33) > escalates a codex session when the rollout never grows (still throttled)
+[RateLimitSentinel] detected throttle error on "codey-1" via codex-usage-poll; baseline jsonl=rollout-2026-05-31T09-00-00-aaaa1111-0000-0000-0000-000000000001.jsonl size=100
+[RateLimitSentinel] resume-attempted on "codey-1" (attempt 1/6, accepted=true)
+[RateLimitSentinel] resume-attempted on "codey-1" (attempt 2/6, accepted=true)
+
+stdout | tests/unit/RateLimitSentinel-codex-recovery.test.ts > RateLimitSentinel — codex recovery via newest rollout (#33) > escalates a codex session when the rollout never grows (still throttled)
+[RateLimitSentinel] resume-attempted on "codey-1" (attempt 3/6, accepted=true)
+[RateLimitSentinel] resume-attempted on "codey-1" (attempt 4/6, accepted=true)
+[RateLimitSentinel] resume-attempted on "codey-1" (attempt 5/6, accepted=true)
+
+stderr | tests/unit/RateLimitSentinel-codex-recovery.test.ts > RateLimitSentinel — codex recovery via newest rollout (#33) > escalates a codex session when the rollout never grows (still throttled)
+[RateLimitSentinel] escalated "codey-1": no jsonl growth after 6 attempts over 21m
+
+stdout | tests/unit/RateLimitSentinel-codex-recovery.test.ts > RateLimitSentinel — codex recovery via newest rollout (#33) > escalates a codex session when the rollout never grows (still throttled)
+[RateLimitSentinel] resume-attempted on "codey-1" (attempt 6/6, accepted=true)
+
+stdout | tests/unit/RateLimitSentinel-codex-recovery.test.ts > RateLimitSentinel — codex recovery via newest rollout (#33) > vendor wording: codex throttle notices say OpenAI / status.openai.com, never Anthropic
+[RateLimitSentinel] detected throttle error on "codey-1" via codex-usage-poll; baseline jsonl=rollout-2026-05-31T09-00-00-aaaa1111-0000-0000-0000-000000000001.jsonl size=100
+[RateLimitSentinel] resume-attempted on "codey-1" (attempt 1/6, accepted=true)
+[RateLimitSentinel] resume-attempted on "codey-1" (attempt 2/6, accepted=true)
+
+stderr | tests/unit/RateLimitSentinel-codex-recovery.test.ts > RateLimitSentinel — codex recovery via newest rollout (#33) > vendor wording: codex throttle notices say OpenAI / status.openai.com, never Anthropic
+[RateLimitSentinel] escalated "codey-1": no jsonl growth after 6 attempts over 21m
+
+stdout | tests/unit/RateLimitSentinel-codex-recovery.test.ts > RateLimitSentinel — codex recovery via newest rollout (#33) > vendor wording: codex throttle notices say OpenAI / status.openai.com, never Anthropic
+[RateLimitSentinel] resume-attempted on "codey-1" (attempt 3/6, accepted=true)
+[RateLimitSentinel] resume-attempted on "codey-1" (attempt 4/6, accepted=true)
+[RateLimitSentinel] resume-attempted on "codey-1" (attempt 5/6, accepted=true)
+[RateLimitSentinel] resume-attempted on "codey-1" (attempt 6/6, accepted=true)
+
+ ✓ tests/unit/RateLimitSentinel-codex-recovery.test.ts (3 tests) 19ms
+ ✓ tests/unit/fix-command-routing.test.ts (17 tests) 2ms
+stdout | tests/integration/rate-limit-recovery-sentinel-lifecycle.test.ts > RateLimitSentinel × recovery factory — non-topic-bound lifecycle > recovers a non-topic-bound session: internal nudge + lifeline notice + recovered
+[RateLimitSentinel] detected throttle error on "dev-window" via idle-error; baseline jsonl=sess.jsonl size=100
+
+stdout | tests/integration/rate-limit-recovery-sentinel-lifecycle.test.ts > RateLimitSentinel × recovery factory — non-topic-bound lifecycle > recovers a non-topic-bound session: internal nudge + lifeline notice + recovered
+[RateLimitSentinel] resume-attempted on "dev-window" (attempt 1/6, accepted=true)
+
+stdout | tests/integration/rate-limit-recovery-sentinel-lifecycle.test.ts > RateLimitSentinel × recovery factory — non-topic-bound lifecycle > recovers a non-topic-bound session: internal nudge + lifeline notice + recovered
+[RateLimitSentinel] recovered "dev-window" after 1 attempt(s) (jsonl grew by 500 bytes)
+
+stdout | tests/integration/rate-limit-recovery-sentinel-lifecycle.test.ts > RateLimitSentinel × recovery factory — non-topic-bound lifecycle > no topic AND no lifeline → records recovery-unreachable, never silent
+[RateLimitSentinel] detected throttle error on "orphan" via idle-error; baseline jsonl=sess.jsonl size=100
+
+stdout | tests/integration/rate-limit-recovery-sentinel-lifecycle.test.ts > RateLimitSentinel × recovery factory — non-topic-bound lifecycle > no topic AND no lifeline → records recovery-unreachable, never silent
+[RateLimitSentinel] resume-attempted on "orphan" (attempt 1/6, accepted=true)
+
+ ✓ tests/integration/rate-limit-recovery-sentinel-lifecycle.test.ts (2 tests) 1318ms
+   ✓ RateLimitSentinel × recovery factory — non-topic-bound lifecycle > recovers a non-topic-bound session: internal nudge + lifeline notice + recovered 911ms
+   ✓ RateLimitSentinel × recovery factory — non-topic-bound lifecycle > no topic AND no lifeline → records recovery-unreachable, never silent 406ms
+ ✓ tests/unit/index-exports.test.ts (3 tests) 399ms
+   ✓ Package exports (src/index.ts) > exports all core classes 398ms
+stdout | tests/unit/CompactionSentinel-codex.test.ts > CompactionSentinel — codex recovery via newest rollout > recovers a codex session when its newest ROLLOUT jsonl grows
+[Sentinel] detected compaction on "codey-1" via watchdog-poll; baseline jsonl: rollout-2026-05-31T09-00-00-aaaa1111-0000-0000-0000-000000000001.jsonl size=100
+[Sentinel] inject-attempted on "codey-1" (attempt 1/3, accepted=true)
+
+stdout | tests/unit/CompactionSentinel-codex.test.ts > CompactionSentinel — codex recovery via newest rollout > recovers a codex session when its newest ROLLOUT jsonl grows
+[Sentinel] recovered "codey-1" after 1 attempt(s) (jsonl grew by 500 bytes)
+
+stdout | tests/unit/CompactionSentinel-codex.test.ts > CompactionSentinel — codex recovery via newest rollout > fails a codex session when the rollout never grows (no recovery)
+[Sentinel] detected compaction on "codey-1" via watchdog-poll; baseline jsonl: rollout-2026-05-31T09-00-00-aaaa1111-0000-0000-0000-000000000001.jsonl size=100
+[Sentinel] inject-attempted on "codey-1" (attempt 1/3, accepted=true)
+[Sentinel] retry "codey-1" (attempt 1/3 produced no output, re-injecting)
+[Sentinel] inject-attempted on "codey-1" (attempt 2/3, accepted=true)
+[Sentinel] retry "codey-1" (attempt 2/3 produced no output, re-injecting)
+[Sentinel] inject-attempted on "codey-1" (attempt 3/3, accepted=true)
+
+stderr | tests/unit/CompactionSentinel-codex.test.ts > CompactionSentinel — codex recovery via newest rollout > fails a codex session when the rollout never grows (no recovery)
+[Sentinel] failed "codey-1": no jsonl growth after 3 attempts (75000ms total wait)
+
+ ✓ tests/unit/CompactionSentinel-codex.test.ts (2 tests) 11ms
+ ✓ tests/unit/sentinel-recoverable-wiring.test.ts (3 tests) 2ms
+stdout | tests/unit/CompactionSentinel-recoverable-guard.test.ts > CompactionSentinel — isSessionRecoverable guard > NO-OPS for a non-recoverable (finished/killed) session — no recovery injected
+[Sentinel] ignoring PreCompact for "echo-topic-28130" — not a live recovery target (finished/killed/unknown)
+
+ ✓ tests/unit/CompactionSentinel-recoverable-guard.test.ts (3 tests) 3ms
+stdout | tests/unit/CompactionSentinel-recoverable-guard.test.ts > CompactionSentinel — isSessionRecoverable guard > PROCEEDS for a recoverable session — recovery starts
+[Sentinel] detected compaction on "echo-topic-28130" via PreCompact; baseline jsonl: none size=n/a
+[Sentinel] inject-attempted on "echo-topic-28130" (attempt 1/3, accepted=true)
+
+stdout | tests/unit/CompactionSentinel-recoverable-guard.test.ts > CompactionSentinel — isSessionRecoverable guard > dep ABSENT preserves prior behavior — regression lock
+[Sentinel] detected compaction on "echo-topic-28130" via PreCompact; baseline jsonl: none size=n/a
+[Sentinel] inject-attempted on "echo-topic-28130" (attempt 1/3, accepted=true)
+
+
+ Test Files  29 passed (29)
+      Tests  262 passed (262)
+   Start at  14:19:30
+   Duration  34.97s (transform 21ms, setup 22ms, collect 2.95s, tests 15.24s, environment 2ms, prepare 660ms)
+
+JSON report written to /var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-pre-push-smoke-zxV1ii/vitest-results.json
+🔒 Running path-scoped e2e gate...
+🧪 pre-push e2e scope: changed files touch tests/e2e/threadline/ — running their e2e suite(s)...
+   Opt out: INSTAR_PRE_PUSH_E2E_SKIP=1 git push (CI still runs the full e2e job)
+
+ RUN  v2.1.9 /Users/justin/.instar/agents/echo/.worktrees/fix-false-ratelimit-detection
+
+ ✓ tests/e2e/threadline/RESTServerE2E.test.ts (24 tests) 30ms
+ ✓ tests/e2e/threadline/conversation-keystone-wiring.test.ts (7 tests) 9ms
+stdout | tests/e2e/threadline/WarmSessionA2AE2E.test.ts > Warm-Session A2A — E2E lifecycle > two messages on one thread → SAME warm session (continuity); evict → next resumes via #746
+[ThreadlineRouter] Warm (keep-alive) session echo-warm-1 admitted for thread c299c60e-6ae8-45a6-b3c4-d87464e03ee8 (peer fp-dawn-peer)
+[ThreadlineRouter] Injected message into live session echo-warm-1 for thread c299c60e-6ae8-45a6-b3c4-d87464e03ee8
+[ThreadlineRouter] Live-session injection failed for thread c299c60e-6ae8-45a6-b3c4-d87464e03ee8 (echo-warm-1): Session not alive. Falling back to resume/spawn.
+
+ ✓ tests/e2e/threadline/WarmSessionA2AE2E.test.ts (1 test) 10ms
+ ✓ tests/e2e/threadline/TrustBootstrapE2E.test.ts (27 tests) 110ms
+ ✓ tests/e2e/threadline/OpenClawBridgeE2E.test.ts (33 tests) 113ms
+ ✓ tests/e2e/threadline/collaboration-surfacing-wiring.test.ts (5 tests) 8ms
+ ✓ tests/e2e/threadline/ThreadlineMCPE2E.test.ts (15 tests) 99ms
+ ✓ tests/e2e/threadline/ThreadlineE2E.test.ts (57 tests) 215ms
+ ✓ tests/e2e/threadline/A2AE2E.test.ts (31 tests) 274ms
+ ✓ tests/e2e/threadline/ThreadlineFullStack.test.ts (50 tests) 224ms
+ ✓ tests/e2e/threadline/AbuseDetectionE2E.test.ts (5 tests) 336ms
+   ✓ Abuse Detection E2E > metrics record message routing 309ms
+ ✓ tests/e2e/threadline/A2ABridgeE2E.test.ts (17 tests) 550ms
+   ✓ A2A Bridge E2E > Task lifecycle > task status reflects pending while waiting for agent 307ms
+ ✓ tests/e2e/threadline/RelayE2E.test.ts (17 tests) 581ms
+ ✓ tests/e2e/threadline/DuplicateIdentityResolveE2E.test.ts (1 test) 332ms
+   ✓ Threadline duplicate-identity resolution — E2E (live vs dead echo) > a sender resolves the name "echo" to the LIVE registration when a dead twin also exists 319ms
+ ✓ tests/e2e/threadline/send-honest-error-e2e.test.ts (1 test) 50ms
+ ✓ tests/e2e/threadline/identity-discovery-wiring.test.ts (2 tests) 703ms
+   ✓ Threadline identity-discovery wiring — advertised fp == relay-registered fp > advertises the exact fingerprint the relay client registers with 368ms
+   ✓ Threadline identity-discovery wiring — advertised fp == relay-registered fp > omits fingerprint + publicKey and does not throw when no routing identity exists 335ms
+ ✓ tests/e2e/threadline/OfflineQueueE2E.test.ts (8 tests) 15675ms
+   ✓ Offline Queue E2E > message queuing for offline agents > queues message when recipient is offline and delivers on reconnect 514ms
+   ✓ Offline Queue E2E > message queuing for offline agents > queues multiple messages and delivers in order 534ms
+   ✓ Offline Queue E2E > queue limits > rejects when per-sender-per-recipient limit exceeded 415ms
+   ✓ Offline Queue E2E > TTL expiry > expired messages are not delivered on reconnect 6522ms
+   ✓ Offline Queue E2E > TTL expiry > sender receives delivery_expired notification 6521ms
+   ✓ Offline Queue E2E > health endpoint with queue stats > includes offline queue stats in health response 320ms
+   ✓ Offline Queue E2E > edge cases > direct delivery when recipient is online (no queuing) 316ms
+   ✓ Offline Queue E2E > edge cases > messages from multiple senders to same offline recipient 520ms
+ ✓ tests/e2e/threadline/ThreadlineRelayComprehensive.test.ts (32 tests) 16904ms
+   ✓ Threadline Relay Comprehensive E2E > Scenario 1: Full encrypted message lifecycle > encrypts, routes through relay, and decrypts with real crypto 418ms
+   ✓ Threadline Relay Comprehensive E2E > Scenario 1: Full encrypted message lifecycle > encrypted message queued offline, delivered on reconnect, decryptable 511ms
+   ✓ Threadline Relay Comprehensive E2E > Scenario 2: Multi-agent encrypted mesh > three agents exchange encrypted messages in a triangle pattern 534ms
+   ✓ Threadline Relay Comprehensive E2E > Scenario 3: Displacement with queued message delivery > displaced client reconnects and receives queued messages 835ms
+   ✓ Threadline Relay Comprehensive E2E > Scenario 4: Discovery and presence across multiple agents > discovers agents with different capabilities and visibility 322ms
+   ✓ Threadline Relay Comprehensive E2E > Scenario 4: Discovery and presence across multiple agents > presence subscriptions fire for connect and disconnect 914ms
+   ✓ Threadline Relay Comprehensive E2E > Scenario 5: Admin ban/unban during active messaging > banning stops message routing, unbanning restores it 825ms
+   ✓ Threadline Relay Comprehensive E2E > Scenario 6: Offline queue with abuse detection > queued messages are tracked in metrics 412ms
+   ✓ Threadline Relay Comprehensive E2E > Scenario 7: Rapid connect/disconnect cycles > handles 5 rapid reconnections without state corruption 944ms
+   ✓ Threadline Relay Comprehensive E2E > Scenario 8: Concurrent multi-agent messaging > handles 4 agents sending messages simultaneously 719ms
+   ✓ Threadline Relay Comprehensive E2E > Scenario 10: Queue TTL expiry for encrypted messages > expired encrypted messages are purged and not delivered 4522ms
+   ✓ Threadline Relay Comprehensive E2E > Scenario 12: Edge cases > agent can send message to itself 410ms
+   ✓ Threadline Relay Comprehensive E2E > Scenario 12: Edge cases > handles invalid JSON frames without crashing 411ms
+   ✓ Threadline Relay Comprehensive E2E > Scenario 12: Edge cases > message to non-existent agent is queued 411ms
+   ✓ Threadline Relay Comprehensive E2E > Scenario 13: Bulk offline delivery from multiple senders > delivers messages from 3 senders when recipient comes online 717ms
+   ✓ Threadline Relay Comprehensive E2E > Scenario 14: Bidirectional encrypted conversation > two agents exchange encrypted messages back and forth 629ms
+   ✓ Threadline Relay Comprehensive E2E > Scenario 15: Queue overflow under pressure > respects per-sender limit and returns queue_full 624ms
+   ✓ Threadline Relay Comprehensive E2E > Scenario 17: Tampered message detection > decryption fails when message is tampered 415ms
+   ✓ Threadline Relay Comprehensive E2E > Scenario 18: Server state consistency > presence is cleaned up after disconnect 309ms
+   ✓ Threadline Relay Comprehensive E2E > Scenario 18: Server state consistency > connections count goes to zero when all clients disconnect 312ms
+   ✓ Threadline Relay Comprehensive E2E > Scenario 20: Complete pipeline test > full lifecycle: connect → discover → encrypt → route → queue → deliver → admin verify 831ms
+
+ Test Files  18 passed (18)
+      Tests  333 passed (333)
+   Start at  14:20:06
+   Duration  17.40s (transform 2.06s, setup 0ms, collect 5.05s, tests 36.22s, environment 2ms, prepare 973ms)
+
+✅ Scoped e2e suite passed.
+Everything up-to-date

--- a/src/commands/server.ts
+++ b/src/commands/server.ts
@@ -10016,10 +10016,19 @@ export async function startServer(options: StartOptions): Promise<void> {
     // calls that used to live here. Dedupes across the three triggers and
     // vetoes zombie cleanup while a recovery is in flight.
     const { CompactionSentinel } = await import('../monitoring/CompactionSentinel.js');
+    // A session is a legitimate recovery target ONLY while it is in the running
+    // set. A finished/failed/killed session drops out of listRunningSessions(),
+    // so this is the structural guard that stops both sentinels from "recovering"
+    // a session that is simply done — the false-positive that spammed the user
+    // with throttle-resume nudges on a finished session (live incident 2026-06-24).
+    const isSessionRecoverable = (sessionName: string): boolean =>
+      sessionManager.listRunningSessions().some(s => s.tmuxSession === sessionName);
+
     const compactionSentinel = new CompactionSentinel(
       {
         recoverFn: recoverCompactedSession,
         projectDir: config.projectDir,
+        isSessionRecoverable,
         getClaudeSessionId: (sessionName: string) => {
           const session = sessionManager.listRunningSessions()
             .find(s => s.tmuxSession === sessionName);
@@ -10117,6 +10126,7 @@ export async function startServer(options: StartOptions): Promise<void> {
         notifyFn: rateLimitNotify,
         projectDir: config.projectDir,
         getClaudeSessionId: getClaudeSessionIdForName,
+        isSessionRecoverable,
         // #33 codex parity: for codex sessions, recovery-verification reads the newest
         // codex rollout (account-wide throttle → newest-rollout growth = cleared) and
         // the user-facing messages use OpenAI wording.
@@ -10155,6 +10165,19 @@ export async function startServer(options: StartOptions): Promise<void> {
     // the whole transient-API class is the 2026-05-29 future-proofing ask (topic 13481).
     sessionManager.on('apiErrorAtIdle', (sessionName: string) => {
       rateLimitSentinel.report(sessionName, 'idle-error', { errorClass: 'transient-api' });
+    });
+    // When a session completes, immediately clear any in-flight recovery for it in
+    // BOTH sentinels. The recoverability guard already blocks NEW recoveries on a
+    // finished session and aborts an in-flight one at its next tick; clearing here
+    // frees the recovery slot (and lifts the zombie-kill veto) immediately instead
+    // of waiting for that tick — and is the explicit completion-cleanup the prior
+    // code lacked (clear() existed but had zero callers). (live incident 2026-06-24)
+    // clear() on both sentinels is a pure synchronous timer-cancel + Map.delete that
+    // cannot throw, so no defensive try/catch is needed here (a wrapper would only be a
+    // silent fallback the no-silent-fallbacks ratchet flags — see the methods).
+    sessionManager.on('sessionComplete', (session) => {
+      rateLimitSentinel.clear(session.tmuxSession);
+      compactionSentinel.clear(session.tmuxSession);
     });
     // #33 codex parity: the two triggers above read CLAUDE panes / claude-PID watchdog,
     // so a codex session throttled by OpenAI is invisible to them. This poll reads the

--- a/src/core/LiveTestHarness.ts
+++ b/src/core/LiveTestHarness.ts
@@ -35,6 +35,17 @@ export interface ChannelDriver {
   send(surface: Surface, channelId: string, text: string): Promise<SendResult>;
   /** Await the agent's reply (resolves null on timeout). */
   awaitReply(surface: Surface, channelId: string, opts: { timeoutMs: number; afterMessageId?: string }): Promise<ReplyResult | null>;
+  /**
+   * OPTIONAL — collect EVERY message that lands on the channel within a window
+   * (after `afterMessageId`). Backs ABSENCE assertions: "after X, no message
+   * matching <pattern> arrives within the window". A single awaitReply can't prove
+   * absence (it returns the first reply, and a spurious background nudge may land
+   * AFTER a legitimate reply). A driver that does not implement this makes an
+   * absence scenario BLOCKED (driver-unsupported), never a silent pass. The fix
+   * this enables to test: a finished session must emit ZERO throttle-resume nudges
+   * (live incident 2026-06-24).
+   */
+  collectMessages?(surface: Surface, channelId: string, opts: { windowMs: number; afterMessageId?: string }): Promise<ReplyResult[]>;
 }
 
 export type Volatility = 'safe' | 'volatile' | 'permission';
@@ -48,8 +59,27 @@ export interface HarnessScenario {
   channelId: string;
   /** The user message to send. */
   input: string;
-  /** Deterministic expectations checked against the captured reply. */
-  expect: { replyContains?: string; replyNotEmpty?: boolean; responderMachine?: string };
+  /**
+   * Deterministic expectations checked against the captured reply (or, for an
+   * absence scenario, against every message collected over `absenceWindowMs`).
+   * - replyContains / replyNotEmpty / responderMachine: assert the reply.
+   * - replyMustNotContain: the (first) reply must NOT contain this substring.
+   * - noMessageMatching: ABSENCE — paired with `absenceWindowMs`, asserts NO
+   *   message landing on the channel within the window contains this substring.
+   */
+  expect: {
+    replyContains?: string;
+    replyNotEmpty?: boolean;
+    responderMachine?: string;
+    replyMustNotContain?: string;
+    noMessageMatching?: string;
+  };
+  /**
+   * When set, this is an ABSENCE scenario: after sending `input`, the harness
+   * collects every message on the channel for this many ms and asserts none match
+   * `expect.noMessageMatching`. Requires a driver implementing `collectMessages`.
+   */
+  absenceWindowMs?: number;
   timeoutMs?: number;
 }
 
@@ -126,6 +156,38 @@ export class LiveTestHarness {
     const timeoutMs = s.timeoutMs ?? this.d.defaultTimeoutMs ?? 30_000;
     const maxRetries = this.d.maxReplyRetries ?? 2;
     const base: ScenarioRow = { id: s.id, description: s.description, surface: s.surface, riskCategory: s.riskCategory, verdict: 'FAIL' };
+
+    // ── ABSENCE scenario: assert NO message matching the pattern lands within the
+    // window (the structural way to catch a spurious background message — e.g. a
+    // throttle-resume nudge fired against a finished session).
+    if (s.absenceWindowMs != null) {
+      const pattern = s.expect.noMessageMatching;
+      if (!pattern) {
+        return { ...base, verdict: 'BLOCKED', blockedKind: 'operator-waiver', blockedReason: 'absence scenario missing expect.noMessageMatching' };
+      }
+      if (!this.d.driver.collectMessages) {
+        // Never silently pass — an absence assertion an unsupported driver cannot
+        // make is BLOCKED with a named reason, not a PASS.
+        return { ...base, verdict: 'BLOCKED', blockedKind: 'platform-error', blockedReason: 'driver does not support collectMessages (absence assertion unverifiable)' };
+      }
+      try {
+        const sent = await this.d.driver.send(s.surface, s.channelId, s.input);
+        const collected = await this.d.driver.collectMessages(s.surface, s.channelId, { windowMs: s.absenceWindowMs, afterMessageId: sent.messageId });
+        const offending = collected.find(m => m.text.includes(pattern));
+        const evidence = { channelId: s.channelId, messageIds: [sent.messageId, ...collected.map(m => m.messageId)] };
+        if (offending) {
+          this.log(`scenario ${s.id} FAIL: spurious message matched "${pattern}": ${JSON.stringify(offending.text.slice(0, 120))}`);
+          return { ...base, verdict: 'FAIL', evidence, blockedReason: `spurious message matched "${pattern}"` };
+        }
+        return { ...base, verdict: 'PASS', evidence };
+      } catch (err) {
+        // @silent-fallback-ok: not a silent fallback — a driver error is SURFACED as a
+        // FAIL verdict (with the error in blockedReason) that the LiveTestGate consumes
+        // and VETOES on. The error is escalated, not swallowed; this is the loud path.
+        return { ...base, verdict: 'FAIL', blockedReason: `driver error: ${err instanceof Error ? err.message : String(err)}` };
+      }
+    }
+
     try {
       const sent = await this.d.driver.send(s.surface, s.channelId, s.input);
       let reply: ReplyResult | null = null;
@@ -142,6 +204,7 @@ export class LiveTestHarness {
       const failures: string[] = [];
       if (s.expect.replyContains && !reply.text.includes(s.expect.replyContains)) failures.push(`reply missing "${s.expect.replyContains}"`);
       if (s.expect.replyNotEmpty && reply.text.trim() === '') failures.push('reply empty');
+      if (s.expect.replyMustNotContain && reply.text.includes(s.expect.replyMustNotContain)) failures.push(`reply unexpectedly contained "${s.expect.replyMustNotContain}"`);
       if (s.expect.responderMachine && reply.responderMachineId !== s.expect.responderMachine) failures.push(`responder ${reply.responderMachineId ?? 'unknown'} ≠ expected ${s.expect.responderMachine}`);
       if (failures.length) {
         this.log(`scenario ${s.id} FAIL: ${failures.join('; ')}`);

--- a/src/core/rateLimitFalsePositiveMatrix.ts
+++ b/src/core/rateLimitFalsePositiveMatrix.ts
@@ -1,0 +1,95 @@
+/**
+ * rateLimitFalsePositiveMatrix — the user-role scenario matrix that proves, through
+ * the REAL channel, that the rate-limit/error recovery no longer false-fires on a
+ * finished or idle session (live incident 2026-06-24). It is the prevention layer the
+ * fix needs: a unit test proves the guard logic; THIS proves the user never receives a
+ * spurious "throttle resume" nudge end-to-end.
+ *
+ * It exercises the harness's ABSENCE capability (`absenceWindowMs` +
+ * `expect.noMessageMatching`) — the structural way to catch a spurious background
+ * message, which a single send→reply assertion cannot. Pairs a happy-path scenario
+ * (the agent still replies normally) with the regression absence scenarios so the gate
+ * has a load-bearing PASS and the no-false-nudge guarantee in one signed artifact.
+ */
+
+import type { HarnessMatrix, HarnessScenario } from './LiveTestHarness.js';
+import type { RiskCategory, Surface } from './LiveTestArtifactStore.js';
+
+/** The exact user-facing string the false positive emitted — the thing we assert is ABSENT. */
+export const THROTTLE_RESUME_NUDGE_FRAGMENT = 'throttle should have cleared';
+
+export interface RateLimitFalsePositiveOpts {
+  featureId?: string;
+  telegramTopicId: string;
+  slackChannelId?: string;
+  /** A benign user message that elicits a normal reply (happy-path) + closes a turn. */
+  message?: string;
+  /** How long to watch for a spurious nudge after the turn finishes. */
+  absenceWindowMs?: number;
+  timeoutMs?: number;
+}
+
+export function buildRateLimitFalsePositiveMatrix(opts: RateLimitFalsePositiveOpts): HarnessMatrix {
+  const featureId = opts.featureId ?? 'rate-limit-false-positive-fix';
+  const tg = opts.telegramTopicId;
+  const message = opts.message ?? 'Quick check-in — are you there?';
+  // Default 90s: a real throttle false-positive fires its FIRST user notice
+  // immediately on report() (well inside the window), but the window must also exceed
+  // the throttle recovery's first backoff (30s) + verify window (25s) ≈ 55s so a
+  // regression that only surfaces at the first resume/verify still lands inside it.
+  // (spec-converge finding: a 60s window only barely cleared that ~55s envelope.)
+  const absenceWindowMs = opts.absenceWindowMs ?? 90_000;
+  const tmo = opts.timeoutMs;
+  const t = <T extends Partial<HarnessScenario>>(s: T): T => (tmo ? { ...s, timeoutMs: tmo } : s);
+
+  const scenarios: HarnessScenario[] = [
+    // Happy-path: the agent still answers a normal message (the fix must not mute it).
+    t({
+      id: 'rl-happy-path-normal-reply',
+      description: 'happy-path: a normal user message gets a non-empty reply (the recovery guard did not break normal replies)',
+      surface: 'telegram',
+      riskCategory: 'happy-path',
+      volatility: 'safe',
+      channelId: tg,
+      input: message,
+      expect: { replyNotEmpty: true, replyMustNotContain: THROTTLE_RESUME_NUDGE_FRAGMENT },
+    }) as HarnessScenario,
+    // Regression (absence): after the turn finishes, NO spurious throttle-resume nudge
+    // arrives in the topic within the window. This is the exact false positive.
+    t({
+      id: 'rl-finished-session-no-throttle-nudge',
+      description: 'regression: after a session finishes, zero throttle-resume nudges arrive within the window (the live incident)',
+      surface: 'telegram',
+      riskCategory: 'regression',
+      volatility: 'safe',
+      channelId: tg,
+      input: message,
+      absenceWindowMs,
+      expect: { noMessageMatching: THROTTLE_RESUME_NUDGE_FRAGMENT },
+    }) as HarnessScenario,
+  ];
+
+  const surfaces: Surface[] = ['telegram'];
+  const riskCategories: RiskCategory[] = ['happy-path', 'regression'];
+
+  // Channel parity: the same no-spurious-nudge guarantee must hold on Slack.
+  if (opts.slackChannelId) {
+    scenarios.push(
+      t({
+        id: 'rl-slack-parity-no-throttle-nudge',
+        description: 'channel-parity: Slack also emits no spurious throttle-resume nudge after a finished session',
+        surface: 'slack',
+        riskCategory: 'channel-parity',
+        volatility: 'safe',
+        channelId: opts.slackChannelId,
+        input: message,
+        absenceWindowMs,
+        expect: { noMessageMatching: THROTTLE_RESUME_NUDGE_FRAGMENT },
+      }) as HarnessScenario,
+    );
+    surfaces.push('slack');
+    riskCategories.push('channel-parity');
+  }
+
+  return { featureId, surfaces, riskCategories, scenarios };
+}

--- a/src/monitoring/CompactionSentinel.ts
+++ b/src/monitoring/CompactionSentinel.ts
@@ -113,6 +113,16 @@ export interface CompactionSentinelDeps {
   deferIf?: (sessionName: string) => boolean;
 
   /**
+   * Returns false when this session is NOT a legitimate recovery target — unknown,
+   * or status ∈ {completed, failed, killed}, or no longer in the running set. The
+   * `PreCompact` trigger reports EVERY session in the topic→session map (including
+   * finished ones the map never cleaned up), so without this guard a finished
+   * session gets a recovery injected against it. Dep ABSENT ⇒ today's behavior.
+   * (Companion to the same guard on RateLimitSentinel — live incident 2026-06-24.)
+   */
+  isSessionRecoverable?: (sessionName: string) => boolean;
+
+  /**
    * Is the session actively working RIGHT NOW (mid-turn)? When this returns
    * true the sentinel will NOT inject/re-inject a recovery prompt — it waits
    * another verify window instead, up to `maxWorkingDefers`. This is the fix
@@ -218,6 +228,14 @@ export class CompactionSentinel extends EventEmitter {
 
     if (this.active.has(sessionName)) {
       return; // Recovery already in flight — ignore duplicate trigger.
+    }
+    // A finished/killed session is never a recovery target. The PreCompact trigger
+    // enumerates the whole topic→session map (which is not cleaned up on completion),
+    // so a finished session can be reported here; injecting a recovery into it is the
+    // false-positive class this guard closes (live incident 2026-06-24).
+    if (this.deps.isSessionRecoverable && !this.deps.isSessionRecoverable(sessionName)) {
+      console.log(`[Sentinel] ignoring ${trigger} for "${sessionName}" — not a live recovery target (finished/killed/unknown)`);
+      return;
     }
     if (this.deferIf?.(sessionName)) {
       return; // Another recovery (e.g. rate-limit) owns this session — bidirectional defer.

--- a/src/monitoring/QuotaCollector.ts
+++ b/src/monitoring/QuotaCollector.ts
@@ -636,11 +636,14 @@ export class QuotaCollector extends EventEmitter {
           errors.push(`OAuth collection failed: ${msg}`);
 
           // Circuit breaker: track consecutive 429s to prevent runaway polling
-          if (msg.includes('429')) {
+          const is429 = msg.includes('429');
+          let breakerJustTripped = false;
+          if (is429) {
             this.oauthConsecutive429s++;
             if (this.oauthConsecutive429s >= QuotaCollector.OAUTH_429_TRIP_COUNT) {
               this.oauthBackoffUntil = Date.now() + QuotaCollector.OAUTH_BACKOFF_MS;
               const backoffMin = Math.round(QuotaCollector.OAUTH_BACKOFF_MS / 60000);
+              breakerJustTripped = true;
               errors.push(
                 `OAuth circuit breaker tripped after ${this.oauthConsecutive429s} consecutive 429s — ` +
                 `pausing OAuth for ${backoffMin} minutes`,
@@ -648,13 +651,23 @@ export class QuotaCollector extends EventEmitter {
             }
           }
 
-          DegradationReporter.getInstance().report({
-            feature: 'QuotaCollector.collect.oauth',
-            primary: 'Collect quota data from Anthropic OAuth API',
-            fallback: 'Falling back to JSONL-based estimation (lower confidence)',
-            reason: `OAuth failed: ${msg}`,
-            impact: 'Quota data may be estimated rather than authoritative',
-          });
+          // A single/transient OAuth 429 (especially `retry-after: 0`) is a
+          // meter-endpoint blip, not a genuine degradation — the JSONL-estimate
+          // fallback is invisible to the user. Reporting one per poll spammed the
+          // DEGRADATION log (716 lines in the 2026-06-24 incident) and read like a
+          // real rate limit. Only surface a 429 to DegradationReporter once the
+          // circuit breaker actually trips (sustained throttling). Non-429 errors
+          // (401/5xx/network) report immediately as before. The error is still
+          // recorded in `errors[]`, so quota accounting/observability is unchanged.
+          if (!is429 || breakerJustTripped) {
+            DegradationReporter.getInstance().report({
+              feature: 'QuotaCollector.collect.oauth',
+              primary: 'Collect quota data from Anthropic OAuth API',
+              fallback: 'Falling back to JSONL-based estimation (lower confidence)',
+              reason: `OAuth failed: ${msg}`,
+              impact: 'Quota data may be estimated rather than authoritative',
+            });
+          }
 
           // 401 means token expired — emit event
           if (msg.includes('401')) {

--- a/src/monitoring/RateLimitSentinel.ts
+++ b/src/monitoring/RateLimitSentinel.ts
@@ -118,6 +118,21 @@ export interface RateLimitSentinelDeps {
   /** Defer (skip starting) recovery when this returns true — e.g. compaction recovery in flight. */
   deferIf?: (sessionName: string) => boolean;
 
+  /**
+   * Returns false when this session is NOT a legitimate recovery target — it is
+   * unknown, or its status is completed/failed/killed, or it is no longer in the
+   * running set. A FINISHED session is "idle at a prompt" with whatever throttle
+   * string last printed still in its scrollback, so the idle-error detector
+   * mistakes it for a live-but-throttled session and reports it here. Without this
+   * guard the recovery runs its full backoff→resume→verify lifecycle against a
+   * session that will never produce new output — every verify fails, so it burns
+   * all `maxAttempts` resume nudges + check-ins, spamming the user with
+   * RATE_LIMIT_RESUME_NUDGE for a session that is simply done (live incident
+   * 2026-06-24). Dep ABSENT ⇒ today's behavior (recover anything reported), so
+   * bare/test installs are unchanged.
+   */
+  isSessionRecoverable?: (sessionName: string) => boolean;
+
   /** Override JSONL lookup root (tests). Defaults to $HOME/.claude/projects/<project-hash>. */
   jsonlRoot?: string;
 
@@ -176,6 +191,7 @@ export interface RateLimitSentinelEvents {
   'rate-limit:resuming': [RateLimitRecoveryState & { backoffMs: number }];
   'rate-limit:recovered': [RateLimitRecoveryState & { jsonlDelta: number }];
   'rate-limit:escalated': [RateLimitRecoveryState & { reason: string }];
+  'rate-limit:aborted': [RateLimitRecoveryState & { reason: string }];
 }
 
 function humanizeMs(ms: number): string {
@@ -238,6 +254,14 @@ export class RateLimitSentinel extends EventEmitter {
     const errorClass: ApiErrorClass = opts?.errorClass ?? 'throttle';
 
     if (this.active.has(sessionName)) return;            // recovery in flight
+    // A finished/killed session is "idle at a prompt" with stale throttle scrollback;
+    // the idle-error detector mis-reports it. Never start a recovery (nor send the
+    // "throttled, backing off" notice) for a session that is not a live recovery
+    // target (live incident 2026-06-24).
+    if (this.deps.isSessionRecoverable && !this.deps.isSessionRecoverable(sessionName)) {
+      console.log(`[RateLimitSentinel] ignoring ${trigger} for "${sessionName}" — not a live recovery target (finished/killed/unknown)`);
+      return;
+    }
     if (this.deferIf?.(sessionName)) return;             // another recovery owns it (S6)
     const lastReport = this.recentReports.get(sessionName);
     if (lastReport && now - lastReport < this.cfg.dedupeWindowMs) return;
@@ -298,6 +322,24 @@ export class RateLimitSentinel extends EventEmitter {
     this.active.delete(sessionName);
   }
 
+  /**
+   * Silent terminal stop for a recovery whose session is no longer a live target
+   * (it finished/was killed mid-flight). Unlike `finalize('escalated', ...)` this
+   * emits NO user-facing escalation event — there is nothing to tell the user, the
+   * session simply ended. Audited to the log + the `rate-limit:aborted` event for
+   * observability; clears all state so a genuinely-new throttle can recover later.
+   */
+  private abort(state: RateLimitRecoveryState, reason: string): void {
+    console.log(`[RateLimitSentinel] aborted "${state.sessionName}": ${reason}`);
+    this.emit('rate-limit:aborted', { ...state, reason });
+    // Clear timers + active state, but KEEP the recentReports entry: it acts as a
+    // dedupe cooldown so a session flapping around the liveness oracle (running →
+    // briefly-absent → running) cannot abort-then-immediately-rearm a fresh recovery
+    // on every flap. The entry ages out of the dedupe window normally.
+    // (spec-converge finding: deleting recentReports on abort enabled flap churn.)
+    this.clear(state.sessionName);
+  }
+
   stop(): void {
     for (const handle of this.timers.values()) this.clearTimer(handle);
     this.timers.clear();
@@ -337,6 +379,15 @@ export class RateLimitSentinel extends EventEmitter {
 
   private async attemptResume(state: RateLimitRecoveryState): Promise<void> {
     this.timers.delete(state.sessionName);
+    // The session may have FINISHED while we were backing off. Re-check before
+    // injecting: a done session will never grow its jsonl, so continuing would
+    // burn the remaining attempts and ping the user about a session that is gone.
+    // Abort silently (no user-facing "still throttled" notice — there is nothing
+    // to tell the user; the session simply ended).
+    if (this.deps.isSessionRecoverable && !this.deps.isSessionRecoverable(state.sessionName)) {
+      this.abort(state, 'session no longer recoverable (finished/killed during backoff)');
+      return;
+    }
     state.attempts += 1;
     state.lastInjectAt = this.now();
     state.status = 'resuming';
@@ -371,6 +422,16 @@ export class RateLimitSentinel extends EventEmitter {
 
   private async verify(state: RateLimitRecoveryState): Promise<void> {
     this.timers.delete(state.sessionName);
+    // The session may have FINISHED during the verify window. Without this check,
+    // verify() would see no jsonl growth (a done session never grows), and on the
+    // final attempt ESCALATE — sending the user a "Still can't get through after N
+    // tries" notice for a session that simply ended. Re-check and abort silently,
+    // matching the attemptResume() guard. (spec-converge finding: the guard was at
+    // report()/attemptResume() but not verify() — the finished-mid-verify hole.)
+    if (this.deps.isSessionRecoverable && !this.deps.isSessionRecoverable(state.sessionName)) {
+      this.abort(state, 'session no longer recoverable (finished/killed during verify window)');
+      return;
+    }
     const v = this.vendor(state.sessionName);
 
     const current = this.readJsonlBaseline(state.sessionName);

--- a/tests/integration/rate-limit-false-positive-prevention.test.ts
+++ b/tests/integration/rate-limit-false-positive-prevention.test.ts
@@ -1,0 +1,82 @@
+/**
+ * Tier-2 integration: the PREVENTION LAYER wired end-to-end. Drives the rate-limit
+ * false-positive matrix through the REAL LiveTestHarness → LiveTestArtifactStore
+ * (signed) → LiveTestGate, and proves the gate would have BLOCKED the live incident:
+ *   - a clean run (no spurious throttle nudge) → signed artifact → gate ALLOWS;
+ *   - a regressed run (a throttle-resume nudge lands in the window) → the regression
+ *     scenario FAILs → gate VETOES in veto mode.
+ * This is the structural answer to "catch the compounding side-effect before deploy":
+ * a background message that should not appear is now a gate-blocking, signed FAIL.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import crypto from 'node:crypto';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+import { LiveTestArtifactStore } from '../../src/core/LiveTestArtifactStore.js';
+import { LiveTestGate } from '../../src/core/LiveTestGate.js';
+import { LiveTestHarness, type ChannelDriver, type ReplyResult, type Surface } from '../../src/core/LiveTestHarness.js';
+import { buildRateLimitFalsePositiveMatrix } from '../../src/core/rateLimitFalsePositiveMatrix.js';
+
+const { publicKey, privateKey } = crypto.generateKeyPairSync('ed25519');
+const sign = (d: string) => crypto.sign(null, Buffer.from(d), privateKey).toString('base64');
+const verify = (d: string, s: string) => crypto.verify(null, Buffer.from(d), publicKey, Buffer.from(s, 'base64'));
+
+const FEATURE = 'rate-limit-false-positive-fix';
+
+/** Fake real-channel: replies normally; collectMessages returns whatever the run scripts. */
+function driver(spuriousByChannel: Record<string, ReplyResult[]>): ChannelDriver {
+  let n = 0;
+  const demo = new Set<string>(['telegram:tg-demo', 'slack:sl-demo']);
+  return {
+    isDemoChannel: (s: Surface, c: string) => demo.has(`${s}:${c}`),
+    async send() { return { messageId: `m${++n}` }; },
+    async awaitReply() { return { text: 'Yep, I am here.', messageId: `r${++n}` }; },
+    async collectMessages(_s, c) { return spuriousByChannel[c] ?? []; },
+  };
+}
+
+describe('rate-limit false-positive prevention (harness → gate)', () => {
+  let dir: string;
+  let store: LiveTestArtifactStore;
+  let gate: LiveTestGate;
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'rl-prev-'));
+    store = new LiveTestArtifactStore({ stateDir: dir, machineId: 'mac', signerFingerprint: 'fp', sign, verify });
+    gate = new LiveTestGate(store);
+  });
+  afterEach(() => SafeFsExecutor.safeRmSync(dir, { recursive: true, force: true, operation: 'tests/integration/rate-limit-false-positive-prevention.test.ts:cleanup' }));
+
+  function runMatrix(d: ChannelDriver) {
+    const harness = new LiveTestHarness({ store, driver: d, runnerFingerprint: 'fp', defaultTimeoutMs: 50 });
+    const matrix = buildRateLimitFalsePositiveMatrix({ featureId: FEATURE, telegramTopicId: 'tg-demo', slackChannelId: 'sl-demo', absenceWindowMs: 10 });
+    return harness.run(matrix);
+  }
+
+  it('clean run → signed artifact verifies → gate ALLOWS', async () => {
+    const { artifact } = await runMatrix(driver({})); // no spurious messages anywhere
+    expect(artifact.scenarios.every(s => s.verdict === 'PASS')).toBe(true);
+
+    // The signed artifact verifies from disk (gate reads disk, not the transcript).
+    const v = store.verifyEntry(FEATURE, artifact.runId);
+    expect(v.ok).toBe(true);
+
+    const result = gate.evaluate({ featureId: FEATURE, userFacing: true, goalText: 'fix false rate-limit nudges', requiredSurfaces: ['telegram', 'slack'], mode: 'veto' });
+    expect(result.outcome).toBe('allow');
+    expect(result.blocks).toBe(false);
+  });
+
+  it('regressed run (spurious throttle nudge lands) → gate VETOES', async () => {
+    const spurious: ReplyResult = { text: 'The temporary server throttle should have cleared — please continue where you left off.', messageId: 'spur1' };
+    // The nudge lands on BOTH channels (the bug was fleet-wide / both surfaces).
+    const { artifact } = await runMatrix(driver({ 'tg-demo': [spurious], 'sl-demo': [spurious] }));
+
+    const regression = artifact.scenarios.find(s => s.riskCategory === 'regression')!;
+    expect(regression.verdict).toBe('FAIL');
+
+    const result = gate.evaluate({ featureId: FEATURE, userFacing: true, goalText: 'fix false rate-limit nudges', requiredSurfaces: ['telegram', 'slack'], mode: 'veto' });
+    expect(result.outcome).toBe('veto');
+    expect(result.blocks).toBe(true);
+  });
+});

--- a/tests/unit/CompactionSentinel-recoverable-guard.test.ts
+++ b/tests/unit/CompactionSentinel-recoverable-guard.test.ts
@@ -1,0 +1,49 @@
+// Companion to RateLimitSentinel-recoverable-guard: the PreCompact trigger enumerates
+// the whole topic→session map (which is not cleaned up on completion), so a FINISHED
+// session can be reported to CompactionSentinel. Without the isSessionRecoverable guard
+// it would inject a compaction-recovery prompt into a session that is simply done.
+// (live incident 2026-06-24)
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { CompactionSentinel } from '../../src/monitoring/CompactionSentinel.js';
+
+describe('CompactionSentinel — isSessionRecoverable guard', () => {
+  let recoverFn: ReturnType<typeof vi.fn>;
+  let sentinel: CompactionSentinel;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    recoverFn = vi.fn().mockResolvedValue(true);
+  });
+  afterEach(() => {
+    sentinel?.stop?.();
+    vi.useRealTimers();
+  });
+
+  function build(recoverable: ((s: string) => boolean) | undefined) {
+    sentinel = new CompactionSentinel({
+      recoverFn: recoverFn as any,
+      projectDir: '/fake/project',
+      ...(recoverable ? { isSessionRecoverable: recoverable } : {}),
+    });
+  }
+
+  it('NO-OPS for a non-recoverable (finished/killed) session — no recovery injected', () => {
+    build(() => false);
+    sentinel.report('echo-topic-28130', 'PreCompact');
+    expect(recoverFn).not.toHaveBeenCalled();
+    expect(sentinel.isRecoveryActive('echo-topic-28130')).toBe(false);
+  });
+
+  it('PROCEEDS for a recoverable session — recovery starts', () => {
+    build(() => true);
+    sentinel.report('echo-topic-28130', 'PreCompact');
+    expect(sentinel.isRecoveryActive('echo-topic-28130')).toBe(true);
+  });
+
+  it('dep ABSENT preserves prior behavior — regression lock', () => {
+    build(undefined);
+    sentinel.report('echo-topic-28130', 'PreCompact');
+    expect(sentinel.isRecoveryActive('echo-topic-28130')).toBe(true);
+  });
+});

--- a/tests/unit/RateLimitSentinel-recoverable-guard.test.ts
+++ b/tests/unit/RateLimitSentinel-recoverable-guard.test.ts
@@ -1,0 +1,119 @@
+// Live incident 2026-06-24: a FINISHED session is "idle at a prompt" with a stale
+// throttle string still in its scrollback, so the idle-error detector mistakes it for
+// a live-but-throttled session and reports it. Without a session-status guard the
+// recovery runs its full backoff→resume→verify lifecycle against a session that will
+// never grow its jsonl — burning all attempts and spamming the user with the
+// RATE_LIMIT_RESUME_NUDGE. These tests lock the `isSessionRecoverable` guard:
+//   - report() no-ops (no notice, no recovery) when the session is not recoverable;
+//   - a recovery aborts SILENTLY (no "still throttled" ping) when the session finishes
+//     mid-backoff;
+//   - dep ABSENT preserves the prior behavior (regression lock).
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { RateLimitSentinel } from '../../src/monitoring/RateLimitSentinel.js';
+
+const FIRST_BACKOFF = 30_000;
+
+describe('RateLimitSentinel — isSessionRecoverable guard (false-positive on finished sessions)', () => {
+  let resumeFn: ReturnType<typeof vi.fn>;
+  let notifyFn: ReturnType<typeof vi.fn>;
+  let sentinel: RateLimitSentinel;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    resumeFn = vi.fn().mockResolvedValue(true);
+    notifyFn = vi.fn().mockResolvedValue(undefined);
+  });
+  afterEach(() => {
+    sentinel?.stop();
+    vi.useRealTimers();
+  });
+
+  function build(recoverable: ((s: string) => boolean) | undefined) {
+    sentinel = new RateLimitSentinel(
+      {
+        resumeFn: resumeFn as any,
+        notifyFn: notifyFn as any,
+        projectDir: '/fake/project',
+        // No jsonl on disk → readJsonlBaseline returns null; irrelevant for these tests.
+        ...(recoverable ? { isSessionRecoverable: recoverable } : {}),
+      },
+      { dedupeWindowMs: 60_000, verifyWindowMs: 25_000, maxAttempts: 6, maxWindowMs: 30 * 60_000, checkInEveryMs: 120_000 },
+    );
+  }
+
+  it('NO-OPS when the session is not recoverable (finished/killed/unknown) — no notice, no recovery', () => {
+    build(() => false);
+    sentinel.report('echo-topic-28130', 'idle-error');
+    // The whole point: a finished session must not get the "throttled, backing off" notice…
+    expect(notifyFn).not.toHaveBeenCalled();
+    // …and no recovery state is created.
+    expect(sentinel.getState('echo-topic-28130')).toBeUndefined();
+    expect(sentinel.isRecoveryActive('echo-topic-28130')).toBe(false);
+  });
+
+  it('PROCEEDS normally when the session IS recoverable (genuine throttle still recovers)', () => {
+    build(() => true);
+    sentinel.report('echo-topic-28130', 'idle-error');
+    // The immediate user notice is sent and a recovery is now active.
+    expect(notifyFn).toHaveBeenCalledTimes(1);
+    expect(sentinel.isRecoveryActive('echo-topic-28130')).toBe(true);
+  });
+
+  it('dep ABSENT preserves prior behavior (recovers anything reported) — regression lock', () => {
+    build(undefined);
+    sentinel.report('echo-topic-28130', 'idle-error');
+    expect(notifyFn).toHaveBeenCalledTimes(1);
+    expect(sentinel.isRecoveryActive('echo-topic-28130')).toBe(true);
+  });
+
+  it('ABORTS SILENTLY when the session finishes mid-backoff — no escalation ping, emits aborted', async () => {
+    let alive = true;
+    build(() => alive);
+    const aborted: any[] = [];
+    const escalated: any[] = [];
+    sentinel.on('rate-limit:aborted', p => aborted.push(p));
+    sentinel.on('rate-limit:escalated', p => escalated.push(p));
+
+    sentinel.report('echo-topic-28130', 'idle-error'); // starts; one notice sent
+    expect(notifyFn).toHaveBeenCalledTimes(1);
+
+    // Session finishes while we're backing off.
+    alive = false;
+    await vi.advanceTimersByTimeAsync(FIRST_BACKOFF + 100); // backoff fires → attemptResume
+
+    // It must NOT have injected a resume, must NOT have sent any further user message,
+    // and must NOT have escalated. It aborts silently.
+    expect(resumeFn).not.toHaveBeenCalled();
+    expect(notifyFn).toHaveBeenCalledTimes(1); // still just the first notice
+    expect(escalated).toHaveLength(0);
+    expect(aborted).toHaveLength(1);
+    expect(sentinel.isRecoveryActive('echo-topic-28130')).toBe(false);
+  });
+
+  it('ABORTS when the session finishes during the VERIFY window — no escalation ping (the finished-mid-verify hole)', async () => {
+    let alive = true;
+    build(() => alive);
+    const aborted: any[] = [];
+    const escalated: any[] = [];
+    sentinel.on('rate-limit:aborted', p => aborted.push(p));
+    sentinel.on('rate-limit:escalated', p => escalated.push(p));
+
+    sentinel.report('echo-topic-28130', 'idle-error'); // notice #1; backoff scheduled
+    expect(notifyFn).toHaveBeenCalledTimes(1);
+
+    // Backoff fires while the session is still alive → resume injected, verify scheduled.
+    await vi.advanceTimersByTimeAsync(FIRST_BACKOFF + 100);
+    expect(resumeFn).toHaveBeenCalledTimes(1);
+
+    // The session FINISHES during the verify window.
+    alive = false;
+    await vi.advanceTimersByTimeAsync(25_000 + 100); // verify fires
+
+    // verify() must abort silently — NOT escalate with a "still can't get through" ping.
+    expect(escalated).toHaveLength(0);
+    expect(aborted).toHaveLength(1);
+    expect(notifyFn).toHaveBeenCalledTimes(1); // still only the first notice
+    expect(sentinel.isRecoveryActive('echo-topic-28130')).toBe(false);
+  });
+});

--- a/tests/unit/rate-limit-false-positive-matrix.test.ts
+++ b/tests/unit/rate-limit-false-positive-matrix.test.ts
@@ -1,0 +1,102 @@
+/**
+ * Tier-1 tests for the rate-limit false-positive user-role matrix + the harness
+ * ABSENCE capability that backs it. Proves: the matrix builder shapes the right
+ * scenarios; the harness FAILS when a spurious throttle-resume nudge lands in the
+ * window, PASSES when none does, and BLOCKS (never silently passes) when the driver
+ * cannot verify absence. (live incident 2026-06-24)
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import crypto from 'node:crypto';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+import { LiveTestArtifactStore, type Surface } from '../../src/core/LiveTestArtifactStore.js';
+import { LiveTestHarness, type ChannelDriver, type ReplyResult } from '../../src/core/LiveTestHarness.js';
+import { buildRateLimitFalsePositiveMatrix, THROTTLE_RESUME_NUDGE_FRAGMENT } from '../../src/core/rateLimitFalsePositiveMatrix.js';
+
+const { publicKey, privateKey } = crypto.generateKeyPairSync('ed25519');
+const sign = (d: string) => crypto.sign(null, Buffer.from(d), privateKey).toString('base64');
+const verify = (d: string, s: string) => crypto.verify(null, Buffer.from(d), publicKey, Buffer.from(s, 'base64'));
+
+/** Fake driver: replies to a normal send, and returns a scripted message list for collectMessages. */
+function fakeDriver(opts: {
+  reply?: ReplyResult | null;
+  collected?: ReplyResult[];
+  supportsCollect?: boolean;
+}): ChannelDriver {
+  let n = 0;
+  const base: ChannelDriver = {
+    isDemoChannel: () => true,
+    async send() { return { messageId: `m${++n}` }; },
+    async awaitReply() { return opts.reply ?? { text: 'I am here.', messageId: `r${++n}` }; },
+  };
+  if (opts.supportsCollect !== false) {
+    base.collectMessages = async () => opts.collected ?? [];
+  }
+  return base;
+}
+
+describe('buildRateLimitFalsePositiveMatrix', () => {
+  it('shapes telegram-only happy-path + absence-regression scenarios', () => {
+    const m = buildRateLimitFalsePositiveMatrix({ telegramTopicId: 'tg1' });
+    expect(m.featureId).toBe('rate-limit-false-positive-fix');
+    expect(m.surfaces).toEqual(['telegram']);
+    expect(m.riskCategories).toEqual(['happy-path', 'regression']);
+    expect(m.scenarios.map(s => s.id)).toEqual(['rl-happy-path-normal-reply', 'rl-finished-session-no-throttle-nudge']);
+    const absence = m.scenarios.find(s => s.id === 'rl-finished-session-no-throttle-nudge')!;
+    expect(absence.absenceWindowMs).toBeGreaterThan(0);
+    expect(absence.expect.noMessageMatching).toBe(THROTTLE_RESUME_NUDGE_FRAGMENT);
+  });
+
+  it('adds a Slack channel-parity absence scenario when a Slack channel is given', () => {
+    const m = buildRateLimitFalsePositiveMatrix({ telegramTopicId: 'tg1', slackChannelId: 'sl1' });
+    expect(m.surfaces).toEqual(['telegram', 'slack']);
+    expect(m.riskCategories).toContain('channel-parity');
+    expect(m.scenarios.some(s => s.surface === 'slack' && s.expect.noMessageMatching === THROTTLE_RESUME_NUDGE_FRAGMENT)).toBe(true);
+  });
+});
+
+describe('LiveTestHarness — absence assertion', () => {
+  let dir: string;
+  let store: LiveTestArtifactStore;
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'rl-fp-'));
+    store = new LiveTestArtifactStore({ stateDir: dir, machineId: 'mac', signerFingerprint: 'fp', sign, verify });
+  });
+  afterEach(() => SafeFsExecutor.safeRmSync(dir, { recursive: true, force: true, operation: 'tests/unit/rate-limit-false-positive-matrix.test.ts:cleanup' }));
+
+  function run(driver: ChannelDriver) {
+    const harness = new LiveTestHarness({ store, driver, runnerFingerprint: 'fp', defaultTimeoutMs: 50 });
+    return harness.run(buildRateLimitFalsePositiveMatrix({ telegramTopicId: 'tg1', absenceWindowMs: 10 }));
+  }
+
+  it('PASSES the absence scenario when no spurious nudge lands in the window', async () => {
+    const { artifact } = await run(fakeDriver({ collected: [{ text: 'just a normal follow-up', messageId: 'x1' }] }));
+    const row = artifact.scenarios.find(s => s.id === 'rl-finished-session-no-throttle-nudge')!;
+    expect(row.verdict).toBe('PASS');
+  });
+
+  it('FAILS the absence scenario when a throttle-resume nudge lands in the window', async () => {
+    const spurious: ReplyResult = { text: 'The temporary server throttle should have cleared — please continue.', messageId: 'x2' };
+    const { artifact } = await run(fakeDriver({ collected: [spurious] }));
+    const row = artifact.scenarios.find(s => s.id === 'rl-finished-session-no-throttle-nudge')!;
+    expect(row.verdict).toBe('FAIL');
+    expect(row.blockedReason).toContain(THROTTLE_RESUME_NUDGE_FRAGMENT);
+  });
+
+  it('BLOCKS (never silently passes) the absence scenario when the driver cannot collect messages', async () => {
+    const { artifact } = await run(fakeDriver({ supportsCollect: false }));
+    const row = artifact.scenarios.find(s => s.id === 'rl-finished-session-no-throttle-nudge')!;
+    expect(row.verdict).toBe('BLOCKED');
+    expect(row.blockedReason).toContain('collectMessages');
+  });
+
+  it('happy-path scenario passes on a normal reply and flags a reply that contains the forbidden nudge', async () => {
+    const ok = await run(fakeDriver({ reply: { text: 'Yes, I am here.', messageId: 'r1' }, collected: [] }));
+    expect(ok.artifact.scenarios.find(s => s.id === 'rl-happy-path-normal-reply')!.verdict).toBe('PASS');
+
+    const bad = await run(fakeDriver({ reply: { text: 'The temporary server throttle should have cleared — continue.', messageId: 'r2' }, collected: [] }));
+    expect(bad.artifact.scenarios.find(s => s.id === 'rl-happy-path-normal-reply')!.verdict).toBe('FAIL');
+  });
+});

--- a/tests/unit/sentinel-recoverable-wiring.test.ts
+++ b/tests/unit/sentinel-recoverable-wiring.test.ts
@@ -1,0 +1,38 @@
+/**
+ * Wiring-integrity for the false-positive fix (live incident 2026-06-24). A guard
+ * that compiles but is wired to a no-op (always-recoverable) would silently keep the
+ * bug. These assert server.ts:
+ *   1. derives isSessionRecoverable from the REAL running-set (listRunningSessions),
+ *      not a `() => true` stub;
+ *   2. hands that SAME guard to BOTH sentinels;
+ *   3. clears BOTH sentinels on sessionComplete (the cleanup that never existed).
+ */
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const SERVER_SRC = fs.readFileSync(path.join(process.cwd(), 'src/commands/server.ts'), 'utf-8');
+
+describe('isSessionRecoverable wiring integrity', () => {
+  it('derives the guard from the real running set, not a stub', () => {
+    // Must reference listRunningSessions in the guard — a `() => true` would be the
+    // "shipped inert" failure mode.
+    expect(SERVER_SRC).toMatch(/const isSessionRecoverable[\s\S]{0,200}listRunningSessions/);
+    expect(SERVER_SRC).not.toMatch(/isSessionRecoverable\s*=\s*\(\s*\)\s*=>\s*true/);
+  });
+
+  it('passes the guard to BOTH the compaction and rate-limit sentinels', () => {
+    // The dep name appears at least twice (one per sentinel deps object).
+    const occurrences = (SERVER_SRC.match(/\bisSessionRecoverable\b/g) ?? []).length;
+    expect(occurrences).toBeGreaterThanOrEqual(3); // 1 definition + 2 wirings
+  });
+
+  it('clears BOTH sentinels on sessionComplete (the missing completion cleanup)', () => {
+    // The handler must call clear() on both — without it a finished session lingers
+    // as a recovery target (and clear() previously had ZERO callers).
+    const block = SERVER_SRC.match(/sessionManager\.on\('sessionComplete'[\s\S]{0,400}?\}\);/g) ?? [];
+    const joined = block.join('\n');
+    expect(joined).toContain('rateLimitSentinel.clear');
+    expect(joined).toContain('compactionSentinel.clear');
+  });
+});

--- a/upgrades/next/false-ratelimit-recovery-completed-sessions.md
+++ b/upgrades/next/false-ratelimit-recovery-completed-sessions.md
@@ -1,0 +1,73 @@
+---
+user_announcement:
+  - audience: user
+    maturity: stable
+    summary: "Stopped phantom 'the throttle should have cleared — please continue' messages that fired on sessions that had already finished."
+  - audience: agent-only
+    maturity: stable
+    summary: "Live-test harness can now assert the ABSENCE of a spurious background message over a window."
+---
+
+## What Changed
+
+A shared safety helper that rescues sessions blocked by an AI-provider throttle was
+mis-firing: a session that had already FINISHED sits idle with the old throttle message
+still on its screen, so the helper kept trying to "rescue" a session that was simply
+done and pinged the user with *"the temporary server throttle should have cleared —
+please continue where you left off."* Because the helper is shared, the false alarm
+showed up fleet-wide (it was also seen on AI Guy).
+
+The fix makes a finished/killed session structurally incapable of being a rescue target:
+the helper now checks the session is still running at every point it can act (when it
+decides to rescue, before each retry, AND before the "did it respond?" check) and bails
+out silently if the session ended. When a session completes, the helpers stop watching
+it immediately. A separate noisy "rate limit" log that fired on harmless quota-meter
+hiccups is also quieted (it now only logs on a sustained problem).
+
+It also adds a reusable prevention capability: the user-channel test harness can now
+prove that NO unwanted background message (like the false throttle nudge) appears over a
+time window — so this class of "a background feature messages you by mistake" is caught
+by the ship gate before it reaches the fleet.
+
+## Evidence
+
+**Reproduction (observed incident, 2026-06-24, topic 28130):** the Mac Mini's Claude
+account was quota-walled, so its session for the topic finished. The finished session
+sat idle with a throttle line still on its terminal; the RateLimitSentinel read that
+stale scrollback, classified the done session as "throttled," and began resume attempts
+that produced repeated *"the temporary server throttle should have cleared — please
+continue where you left off."* nudges across every topic the Mini owned. Server logs
+corroborated the second trigger: 716 "rate limit" hits were almost entirely
+`QuotaCollector.collect.oauth: OAuth usage returned 429 retry-after: 0` — the quota-meter
+endpoint briefly saying no, not a real rate limit (a genuine limit carries a meaningful
+retry-after). One healthy working session was false-flagged 54 times, confirming the
+detector — not any one agent — was the cause (it also surfaced on AI Guy).
+
+**Before:** a completed session, having no new terminal output, was indistinguishable
+from a throttled one and stayed a recovery target indefinitely (never cleared from the
+topic map) → repeated phantom nudges; junk `retry-after:0` 429s logged as rate limits.
+
+**After (verified):** the new `isSessionRecoverable` guard NO-OPS recovery for any session
+not in the live running set, at all three fire points (decide-to-rescue, pre-retry,
+pre-verify) — proven both-sides by `RateLimitSentinel-recoverable-guard` /
+`CompactionSentinel-recoverable-guard` unit tests; the finished-during-verify race is
+reproduced and locked by a dedicated test; the absence-assertion integration test drives
+a regressed build (false nudge reintroduced) and confirms the done gate VETOES it. The
+`retry-after:0` 429 is reclassified as a transient blip (log-level only). 16 unit + 2
+integration tests, no regression across the existing watcher/quota/harness suites, clean
+typecheck.
+
+## What to Tell Your User
+
+You should stop seeing phantom "throttle cleared, continue" messages that don't match
+anything actually happening in your session. Real throttles are still handled — genuine
+rescues still run and still tell you. Nothing you need to do; it takes effect on update.
+
+## Summary of New Capabilities
+
+- Finished/killed sessions can no longer trigger a false throttle/error recovery, and a
+  rescue whose session ends mid-flight stops silently instead of sending a stray
+  "still can't get through" message.
+- (Agent/dev) The live-test harness gained an absence-assertion: a scenario can drive a
+  real conversation and assert that no message matching a pattern arrives within a
+  window, with the result feeding the existing "is this done?" gate.

--- a/upgrades/side-effects/false-ratelimit-recovery-completed-sessions.md
+++ b/upgrades/side-effects/false-ratelimit-recovery-completed-sessions.md
@@ -1,0 +1,113 @@
+# Side-Effects Review — Fix false rate-limit/error recovery on finished sessions + user-channel proof harness
+
+**Version / slug:** `false-ratelimit-recovery-completed-sessions`
+**Date:** `2026-06-24`
+**Author:** Echo (autonomous, 8-hour run)
+**Spec:** `docs/specs/false-ratelimit-recovery-completed-sessions.md` (review-convergence + approved)
+**Second-pass reviewer:** REQUIRED (touches "sentinel"/"guard"/session-recovery) — verdict appended below.
+
+## Summary of the change
+
+A finished/idle session sitting at a prompt with a stale throttle string in its
+scrollback was mistaken for a live-but-throttled session, so `RateLimitSentinel` (and
+its sibling `CompactionSentinel`) ran a futile recovery and spammed the user with
+`RATE_LIMIT_RESUME_NUDGE` ("the temporary server throttle should have cleared…").
+Fleet-wide (shared detector). Fix makes a terminal session structurally incapable of
+being a recovery target, and adds a reusable test capability that catches spurious
+background messages before deploy.
+
+Files modified:
+- `src/monitoring/RateLimitSentinel.ts` — new optional `isSessionRecoverable?` dep,
+  consulted in `report()` (no-op + no notice for a non-recoverable session),
+  `attemptResume()` and `verify()` (silent `abort()` if the session finished mid-flight
+  — new `rate-limit:aborted` event; `abort()` keeps the `recentReports` dedupe entry as
+  a flap cooldown).
+- `src/monitoring/CompactionSentinel.ts` — the SAME `isSessionRecoverable?` guard in
+  `report()`.
+- `src/commands/server.ts` — defines `isSessionRecoverable = (name) =>
+  sessionManager.listRunningSessions().some(...)`; passes it to BOTH sentinels; adds a
+  `sessionComplete` handler that clears both sentinels (the completion cleanup that had
+  zero callers).
+- `src/monitoring/QuotaCollector.ts` — the OAuth-429 `DegradationReport` now fires only
+  when the 3-strike breaker trips (kills the `retry-after:0` log spam); the error is
+  still recorded in `errors[]`, breaker + quota accounting unchanged.
+- `src/core/LiveTestHarness.ts` — the prevention layer: an optional
+  `ChannelDriver.collectMessages` + a scenario `absenceWindowMs` + `expect.noMessageMatching`
+  / `expect.replyMustNotContain`. An absence scenario collects every channel message over
+  the window and FAILs if any matches; an unsupported driver yields BLOCKED (never a
+  silent pass).
+
+Files added:
+- `src/core/rateLimitFalsePositiveMatrix.ts` — the rate-limit user-role scenario matrix
+  (happy-path reply + absence regression, optional Slack parity).
+- `tests/unit/RateLimitSentinel-recoverable-guard.test.ts`,
+  `tests/unit/CompactionSentinel-recoverable-guard.test.ts`,
+  `tests/unit/rate-limit-false-positive-matrix.test.ts`,
+  `tests/unit/sentinel-recoverable-wiring.test.ts`,
+  `tests/integration/rate-limit-false-positive-prevention.test.ts`.
+- Spec + ELI16 + convergence report.
+
+## Decision-point inventory
+
+- **Added** `isSessionRecoverable` guard — a bounded NO-OP that SUPPRESSES a recovery
+  action; it never adds an authoritative block over a user. Signal-vs-authority: it
+  removes a spurious action, the safe direction.
+- **Added** harness absence assertion → a PASS/FAIL SIGNAL the already-dark, dry-run-
+  default `LiveTestGate` consumes. BLOCKED (not silent-pass) when unverifiable. No new
+  blocking authority.
+- **Modified** `QuotaCollector` 429 path — a LOG-LEVEL decision only (report vs not);
+  accounting + breaker untouched.
+
+## Side effects & blast radius
+
+- **Behavior change (intended):** a finished/killed session no longer receives recovery
+  nudges; a recovery whose session ends mid-flight aborts silently (no escalation ping).
+- **Preserved:** a genuinely-throttled RUNNING session still recovers — the notify
+  templates are byte-for-byte unchanged; dep-absent installs (bare/test) behave exactly
+  as before (regression-locked by tests).
+- **Fail direction:** `listRunningSessions()` fails OPEN on a transient tmux error, so a
+  hiccup cannot drop a live session and suppress a real recovery; only genuine
+  termination removes it.
+- **Machine-local:** each machine runs its own sentinels over its own running set; no
+  cross-machine state introduced. The QuotaCollector poll is already per-machine.
+- **Residual (scoped to CMT-1785):** a still-RUNNING idle session with stale throttle
+  scrollback can still trigger one self-correcting "back online" message (not the
+  6-nudge spam). The known fix (adopt the watchdog `evaluateThrottleSettle` settle-gate
+  on the idle path) is tracked, driven evidence-first by the new absence harness.
+
+## Migration parity
+
+None required. All changes are server-internal wiring + a log-level change — no
+`.claude/settings.json` hook, `.instar/config.json` default, CLAUDE.md template, or
+built-in-skill change ships. Existing agents pick this up on the normal code-update path.
+
+## Rollback
+
+Each fix is independently revertible: F1 is additive (dep-absent = old behavior); F2 is
+a pure cleanup addition; F4 is log-level only; the harness extension is additive (the
+absence path only runs when a scenario sets `absenceWindowMs`).
+
+## Tests
+
+16 unit (guards both-sides + verify/abort lifecycle + harness absence + matrix + wiring-
+integrity) + 2 integration (harness → signed artifact → `LiveTestGate` ALLOW on clean /
+VETO on a reintroduced regression). No regression across the existing sentinel (96),
+quota (53), and harness/gate (30) suites; clean `tsc`.
+
+---
+
+## Second-pass review
+
+**Concur with the review.** Independent audit of the diff verified: the
+`isSessionRecoverable` guard uses running-set membership (the correct criterion) and
+genuinely fails OPEN via `isSessionAlive`'s catch-returns-true path, so no genuine
+recovery is suppressed by a transient tmux error — only actual termination removes a
+session. The `verify()`/`attemptResume()` abort returns BEFORE any user-facing
+`notify()` (no escalation/"still throttled" ping for a finished session); `abort()`
+correctly keeps `recentReports` as the flap cooldown. The `sessionComplete` cleanup is
+best-effort try/catch and cannot break completion. The QuotaCollector change preserves
+the 429 signal in `errors[]` + the breaker, suppressing only transient per-poll log
+spam (no other consumer keys on that feature). The notify templates are byte-for-byte
+unchanged (a genuinely-throttled RUNNING session recovers as before). The harness
+returns BLOCKED (never a silent pass) when absence is unverifiable. All 322 relevant
+tests green. — independent second-pass reviewer, 2026-06-24.


### PR DESCRIPTION
## What & why

A finished/killed session could become a **false recovery target**. The `RateLimitSentinel` and `CompactionSentinel` decided a session was throttled / mid-compaction from **terminal-output staleness** — but a COMPLETED session also has no new output, so a session that finished right after a throttle line stayed a recovery target forever (never cleared from the topic→session map) and fired repeated *"the temporary server throttle should have cleared — please continue"* nudges. The same missing guard lived in the sibling `CompactionSentinel`, which is why this surfaced **fleet-wide** (observed on Echo and AI Guy).

Verified incident (topic 28130, 2026-06-24): the Mac Mini was quota-walled, its session finished, and the stale-scrollback detector kept "rescuing" the done session across every topic the Mini owned. Server logs showed 716 "rate limit" hits that were almost entirely `QuotaCollector ... OAuth usage returned 429 retry-after: 0` — the quota-meter endpoint briefly saying no, **not** a real rate limit. One healthy session was false-flagged 54 times, proving the *detector* was the cause, not any agent.

## The fix (additive, dark-safe, independently revertible)

- **`isSessionRecoverable` guard at the recovery-ACTION boundary** in BOTH sentinels: a session not in the live running set can never be a recovery target. Covers all three fire points (decide-to-rescue, pre-retry, **pre-verify** — the finished-during-verify race caught in review).
- A recovery mid-backoff whose session finishes **aborts silently** instead of escalating with a stray "still can't get through".
- **Completion clears** the recovery state + unregisters the session from both sentinels.
- `QuotaCollector`: a `429 retry-after:0` from the quota poller is reclassified as a **transient blip** (log-level only — accounting/breaker unchanged), killing the 716-line spam.

## Prevention layer (the structural ask)

`LiveTestHarness` gains an **absence-assertion**: a scenario can drive a real channel conversation and prove that **NO** unwanted background message (e.g. the throttle nudge) appears within a window. `rateLimitFalsePositiveMatrix` wires the scenarios through the existing `LiveTestGate`; a regressed build (false nudge reintroduced) produces a signed FAIL that **VETOES** the done gate. This is the catch-it-before-fleet-deploy guarantee — demonstrated working in the integration test.

## Tests
16 unit + 2 integration (both sides of every boundary, the finished-during-verify race, the absence-assertion, regression locks). No regression across the existing watcher / quota / harness suites; clean typecheck.

## Deferred (tracked CMT-1785)
F3 idle-but-still-running stale-scrollback detection redesign (self-corrects to ≤1 stray message; the 6-nudge spam requires a finished session, which F1+F2 kill), topic-map garbage-collect, and a dedicated live-drive HTTP route. Rationale + the exact existing mechanism to reuse are in the spec.

## ELI16
Echo has a safety helper that notices when one of its chat sessions got stuck behind an AI-provider "slow down" message and gently nudges it to keep going. The bug: the helper decided a session was stuck by checking whether its screen had stopped changing — but a session that has simply **finished** also has a frozen screen. So when a session ended right after a "slow down" notice, the helper thought it was still stuck and kept poking a session that was already done, sending the user the same "the throttle should have cleared, please continue" message over and over. Because this helper is shared by every agent, the false alarm showed up across the whole fleet. The fix makes a finished session structurally unable to be "rescued" — the helper now checks the session is genuinely still alive at every moment it might act, and stops watching a session the instant it completes. On top of the fix, this adds a reusable test that drives a real Telegram conversation and proves the agent does **not** send any surprise background message — wired into the ship gate so this whole class of "a feature messages you by mistake" bug gets caught before it ever reaches the fleet again.
