### PR TITLE
fix(recovery): settle-gate the idle-monitor's rate-limit hand-off (dark)

### DIFF
--- a/.instar/instar-dev-decisions/2026-06-24T23-10-19-581Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-06-24T23-10-19-581Z-unknown.json
@@ -1,0 +1,16 @@
+{
+  "ts": "2026-06-24T23:10:19.581Z",
+  "slug": "unknown",
+  "suggestedTier": 2,
+  "declaredTier": 2,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 5,
+  "loc": 115,
+  "causalAutopsy": {
+    "origin": "latent",
+    "notes": "The SessionManager idle-monitor never had the settle discipline the SessionWatchdog uses — it emitted rateLimitedAtIdle on a single-glance detectRateLimited, so a stale/transient throttle line false-fired a recovery. Pre-existing since the idle-monitor was written; the milder cousin of the #1262 finished-session spam (CMT-1785 F3)."
+  },
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-06-24T23-11-10-542Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-06-24T23-11-10-542Z-unknown.json
@@ -1,0 +1,16 @@
+{
+  "ts": "2026-06-24T23:11:10.542Z",
+  "slug": "unknown",
+  "suggestedTier": 2,
+  "declaredTier": 2,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 5,
+  "loc": 115,
+  "causalAutopsy": {
+    "origin": "latent",
+    "notes": "The SessionManager idle-monitor never had the settle discipline the SessionWatchdog uses — it emitted rateLimitedAtIdle on a single-glance detectRateLimited, so a stale/transient throttle line false-fired a recovery. Pre-existing since the idle-monitor was written; the milder cousin of the #1262 finished-session spam (CMT-1785 F3)."
+  },
+  "verdict": "pass"
+}

--- a/docs/specs/idle-throttle-settle-gate.eli16.md
+++ b/docs/specs/idle-throttle-settle-gate.eli16.md
@@ -1,0 +1,21 @@
+# Idle-monitor throttle settle-gate — plain-English overview
+
+## The one-paragraph version
+
+Echo watches its own chat sessions and, when one looks stuck behind an AI-provider "slow down" (throttle) message, hands it to a recovery helper. There are two watchers that do this. One (the "watchdog") is careful: before it acts, it checks whether the screen has actually *stopped changing* — because a working session animates its little spinner every moment, so a frozen screen with a throttle message on it proves the session genuinely stopped on that throttle. The other watcher (the "idle monitor") was naive: it acted the instant it saw a throttle *word* on the screen, even if that word was just old text scrolled up from earlier, or a brief throttle that had already cleared. That naive trigger is what produced unnecessary "back online" pokes. This change teaches the idle monitor the same careful check the watchdog already uses — and ships it behind a dark switch so it only runs on this development machine until it's been soaked.
+
+## Why it's safe
+
+The careful check can only make the idle monitor act *less* often, never more — so it can't cause a recovery that wasn't already happening. A genuinely-stuck session still has a frozen screen, so it still settles and gets recovered (just a few seconds later than the old instant trigger). The only thing it stops is acting on a stale or already-cleared throttle word. With the switch off (everywhere except this dev machine), behavior is exactly as before.
+
+## What the review caught (and why that matters)
+
+The first version of this had a real bug: I put the "has the screen stopped changing?" check in a spot that only ran *once*, the moment a session first went idle. But a "did it stop changing?" check needs to look more than once — you can't tell a screen is frozen from a single glance. So as written, the check could never confirm "settled," and the idle monitor would have quietly handed the whole job to the backup watchdog instead of doing it itself. The adversarial reviewer caught that this broke the "strictly safer" promise in one edge case (if that backup watchdog were ever turned off). I restructured it to run the check every moment the session is idle, re-verified, and confirmed it's correct. This is the second time in this effort that putting a "small, safe" change through real adversarial review caught a flaw introduced *while fixing something* — which is exactly the point of the process.
+
+## What's deliberately left for later
+
+This adds the careful check to the idle monitor *alongside* the watchdog's, rather than merging the two watchers into one. Unifying them (so recovery isn't driven by two separate triggers, and so the screen is only captured once per moment instead of twice) is a bigger redesign tracked as a follow-up. This change is the safe, conservative, reversible first step.
+
+## What changes for you
+
+Nothing visible day-to-day — this is internal session-watching behavior, and it's off everywhere except the development machine until it's proven out. The benefit is fewer unnecessary "back online" pokes from a session that wasn't really stuck, by holding the idle monitor to the same evidence bar the careful watcher already meets.

--- a/docs/specs/idle-throttle-settle-gate.md
+++ b/docs/specs/idle-throttle-settle-gate.md
@@ -1,0 +1,67 @@
+---
+title: Idle-monitor throttle settle-gate — bring the idle path's throttle detection up to the watchdog's settle discipline
+slug: idle-throttle-settle-gate
+eli16-overview: idle-throttle-settle-gate.eli16.md
+status: draft
+parent-principle: "Structure beats Willpower — replace a fragile single-glance heuristic (emit recovery the instant a throttle STRING appears) with the same structural settle check the SessionWatchdog already uses (throttle present AND pane byte-identical across polls = the turn genuinely ended on the throttle), so the idle path cannot be fooled by a stale/transient throttle line."
+author: echo
+created: 2026-06-24
+review-convergence: "2026-06-24T23:08:11.183Z"
+review-iterations: 2
+review-completed-at: "2026-06-24T23:08:11.183Z"
+review-report: "docs/specs/reports/idle-throttle-settle-gate-convergence.md"
+cross-model-review: "codex-cli:gpt-5.5"
+single-run-completable: true
+frontloaded-decisions: 3
+cheap-to-change-tags: 3
+contested-then-cleared: 0
+approved: true
+approved-by: "echo (standing 8-hour autonomous-run pre-approval, 2026-06-24; design forks are mine to resolve)"
+---
+
+## Problem (the safe slice of the F3 residual, CMT-1785)
+
+PR #1262 fixed the user-facing false-rate-limit spam at its source: a FINISHED session can no longer become a recovery target (the `isSessionRecoverable` guard). The remaining residual is a still-RUNNING idle session: the SessionManager idle-monitor emits `rateLimitedAtIdle` the instant `detectRateLimited(last-30-lines)` matches — a SINGLE glance. That false-fires when the throttle line is stale scrollback the session has since moved past, or a transient throttle that already cleared. With PR #1262's guard in place this self-corrects to ≤1 stray "back online" message (not the spam), but it is still an unnecessary recovery.
+
+The SessionWatchdog ALREADY solves exactly this for its own path: `evaluateThrottleSettle` (monitoring/rateLimitDetection.ts) only hands to recovery when the throttle is present AND the pane is byte-identical across polls for ≥ settleMs — because a working Claude session animates its spinner/timer every tick, so an unchanged pane proves the turn ended on the throttle. The idle path does NOT use this discipline. This spec brings it up to parity.
+
+## Scope (what this ships — additive, dark-flagged, strictly more conservative)
+
+- **`nextIdleThrottleAction`** (new pure function next to `evaluateThrottleSettle`): given the settled-lines snapshot + per-session prior settle state + now, returns `'emit'` (settled → hand to recovery), `'wait'` (throttle present but not settled / pane changed → recheck next tick, do NOT emit), or `'fall-through'` (no throttle in the settled window → not a current throttle; continue to the generic-error check). Pure + clock-injected → unit-tested without tmux.
+- **SessionManager idle path**: behind a dark flag, on EVERY idle tick (not just the first — this is load-bearing: the settle clock must be re-sampled across polls to ever reach 'settled') the idle-monitor captures the settled-lines window and consults `nextIdleThrottleAction`. 'emit' → hand to the sentinel; 'wait' → re-sample next tick (do not emit, do not run the generic nudge / idle-kill while a throttle is present-but-unsettled — mirroring the watchdog's 'waiting'); 'fall-through' → no current throttle, proceed to the normal idle machinery. When the flag is ON this OWNS the rate-limit hand-off; the first-idle-tick block fires the legacy immediate emit only when the flag is OFF. Per-session settle state (`Map<tmuxSession, ThrottleSettleState>`), cleared on completion (unconditionally, in the constructor — not gated on `setPromptDetector`), on emit/fall-through, and when the session goes active again.
+- **Dark flag** `monitoring.idleThrottleSettleGate` (DEV_GATED_FEATURES, `enabled` omitted ⇒ dev-agent live / dark-fleet). Flag off ⇒ byte-identical legacy immediate emit.
+
+## Why this is safe (the load-bearing claim)
+
+It is STRICTLY more conservative than today: the gate can only ever make the idle path emit `rateLimitedAtIdle` LESS often, never more — so it cannot create a recovery that did not already happen. **It does not strand a genuinely-throttled idle session** because the settle check is re-sampled EVERY idle tick (not once): a real throttle has a stable pane (the turn ended on it), so it reaches 'settled' within `settleMs` and the idle path itself hands off — the recovery just arrives a few seconds later than the legacy single-glance, not never. (Adversarial round-1 caught the inverse: an earlier draft ran the check only on the first idle tick, making 'settled' unreachable and silently delegating to the watchdog — fixed by the per-tick re-sample.) The case the gate suppresses is exactly the target: a throttle string that is stale scrollback or a transient that cleared, where the pane is NOT stably the throttle. A pane that never settles means the session is animating output (working), not idle-stuck — the same property the SessionWatchdog's settle loop has, and the watchdog independently backstops the same class regardless. Reversible by flipping the flag.
+
+## Decision points
+
+- **Settle-gate the throttle emit only, not the generic `apiErrorAtIdle` path.** `evaluateThrottleSettle` is throttle-specific (it keys on the throttle string). The generic transient-API-error emit has no equivalent settle infra; gating it would need a parallel mechanism — out of scope. The throttle path is the one the incident implicated.
+- **Re-capture the settled-lines window (RATE_LIMIT_SETTLED_CAPTURE_LINES) for the check** rather than reuse the 30-line `recentOutput`, matching the watchdog exactly, so the two paths agree on what "throttle present" means.
+- **Pure decision extracted to `nextIdleThrottleAction`** so the new logic is unit-testable without tmux (the SessionManager idle loop is not unit-testable directly).
+- **Reuse, not duplicate, the watchdog's settle machinery.** `nextIdleThrottleAction` is a thin wrapper over the SAME `evaluateThrottleSettle` the watchdog uses (it only re-maps the 3-way decision for the idle caller) — no parallel settle implementation. The deeper refactor (a single shared settle path / removing the now-redundant idle emit) is the CMT-1785 follow-up; <!-- tracked: CMT-1785 --> this spec adds the discipline conservatively without that surgery (cross-model review noted the redundancy — it is deliberate and tracked).
+- **Per-tick capture cost (scalability, honest).** When the flag is ON, each idle session triggers one settled-lines tmux capture per monitor tick (only while idle) — the SAME per-tick capture the SessionWatchdog already does for every session. Bounded by idle-session count; dark/dev-only, so the fleet sees nothing until a deliberate soak. Acceptable for the dev-gated scope; a shared single capture is part of the CMT-1785 unification.
+
+## Signal vs authority
+
+The gate only ever WITHHOLDS a recovery signal (a spurious `rateLimitedAtIdle`); it adds no new kill, send, or authority. The RateLimitSentinel remains the recovery authority; this just stops feeding it a false trigger. `nextIdleThrottleAction` returns a decision the caller acts on — a signal, not an authority.
+
+## Multi-machine posture
+
+Machine-local-by-design: the idle-monitor + the per-session settle map are per-process state about sessions running ON this machine. No replicated/proxied state; single-machine and multi-machine behave identically.
+
+## Out of scope (the deeper F3 redesign stays CMT-1785)
+
+- Unifying the two detection paths (idle-monitor emit vs SessionWatchdog settle-check) so recovery isn't driven by two independent triggers — a design fork (gate-both vs remove-the-redundant-idle-emit, the latter needing a watchdog-coverage proof). This spec adds the settle discipline to the idle path WITHOUT removing it; the unification is the follow-up. <!-- tracked: CMT-1785 -->
+- Distinguishing an active-tail throttle from old scrollback in `detectRateLimited`/`throttleSignature` (the long-idle-stale case both paths still trip). That is a shared-detection redesign affecting the watchdog too.
+
+## Frontloaded Decisions
+
+- **D1 — Dark-flagged, strictly-conservative.** Ships behind `monitoring.idleThrottleSettleGate` (dev-live / dark-fleet); flag off = byte-identical legacy. *Cheap-to-change-after:* the flag.
+- **D2 — Throttle emit only (not apiError).** Scoped to the path with settle infra. *Cheap-to-change-after:* additive; the apiError path is untouched.
+- **D3 — Add the settle discipline, do NOT remove the idle emit.** The two-path unification is deferred (CMT-1785); <!-- tracked: CMT-1785 --> this is the safe additive half. *Cheap-to-change-after:* removing the idle emit later is a separate flag-gated change.
+
+## Open questions
+
+*(none)*

--- a/docs/specs/reports/idle-throttle-settle-gate-convergence.md
+++ b/docs/specs/reports/idle-throttle-settle-gate-convergence.md
@@ -1,0 +1,38 @@
+# Convergence Report — Idle-monitor throttle settle-gate
+
+## Cross-model review: codex-cli:gpt-5.5
+
+A real GPT-tier external pass ran through the agent's codex CLI (verdict MINOR ISSUES); gemini-2.5-pro also ran (MINOR). Both noted: (codex) the "cannot strand" claim leaned on the watchdog backstop and should be made explicit; (gemini) the new idle-path settle logic is architecturally redundant with the watchdog's (refactor vs parallel). Both folded into the spec — the safety claim now stands on the idle path's own per-tick re-sample (not the watchdog), and the redundancy is named as deliberate, reusing `evaluateThrottleSettle` (not a parallel implementation) with the unification tracked as CMT-1785. The Standards-Conformance Gate timed out (spawn-cap saturated by concurrent reviewers) — signal-only + fail-open, recorded unavailable, did not block.
+
+## ELI10 Overview
+
+Echo has two watchers that notice when a chat session is stuck on an AI-provider "slow down" message and hand it to a recovery helper. One (the watchdog) is careful — it only acts once the screen has stopped changing (a working session animates its spinner, so a frozen screen with a throttle on it proves the session genuinely stopped). The other (the idle monitor) was naive — it acted the instant it saw the throttle *word*, even if that word was stale scrollback or a throttle that already cleared. That naive trigger produced unnecessary recovery pokes. This change gives the idle monitor the same careful settle check, behind a dark switch (dev-only until soaked). It can only make the idle monitor act *less* often, never more, so it can't strand a genuinely-stuck session — it just stops acting on a stale/transient throttle word.
+
+## Original vs Converged
+
+The original draft put the settle check inside the idle monitor's *first-idle-tick* block. Adversarial review found that was a critical functional defect: a "has the screen stopped changing?" check needs to re-sample across ticks, but running it only once meant it could never reach "settled" — so with the flag on, the idle path would emit recovery *never*, silently delegating the entire job to the separately-disableable watchdog (breaking the "never strands" promise if the watchdog were off). The converged version runs the settle check on *every* idle tick (ahead of the first-tick gate), so "settled" is reachable on the idle path's own merits; the legacy instant emit is fenced to flag-off. A low-severity map-cleanup leak (cleanup registered only inside `setPromptDetector`) was moved to an unconditional constructor registration. The safety claim, the polling-vs-watchdog redundancy, and the per-tick capture cost were all made explicit per the external reviewers.
+
+## Iteration Summary
+
+| Iteration | Reviewers who flagged | Material findings | Spec/code changes | Standards-Conformance Gate |
+|-----------|-----------------------|-------------------|-------------------|----------------------------|
+| 1 | adversarial (1 critical + 1 low), codex+gemini (minor); decision-completeness + lessons/integration clean | 1 critical (F1: settle unreachable — first-tick-only) + 1 low (F2: cleanup leak) | Restructured to per-tick settle re-sample; unconditional cleanup; spec safety-claim + redundancy + capture-cost notes | unavailable (timed out — spawn-cap; fail-open) |
+| 2 | (verification) adversarial RESOLVED+CONVERGED | 0 | none | n/a |
+
+## Full Findings Catalog
+
+**Round 1 — material:**
+- **F1 (CRITICAL, adversarial)** — the settle check lived inside the first-idle-tick `if (!idlePromptSince.has)` block; the `'wait'` branch `continue`d without re-entering, so the settle clock was written once and never re-sampled → `'settled'` structurally unreachable → flag-ON emitted recovery never, delegating to the watchdog (a strand path if the watchdog is disabled). **Fix:** the settle check now runs on EVERY idle tick (a block inside `if (isActuallyIdle)` ahead of the first-tick gate); the legacy first-tick emit is fenced to `!idleThrottleSettleGate`. Verified resolved round 2.
+- **F2 (LOW, adversarial)** — the settle-map cleanup `sessionComplete` listener was registered only inside `setPromptDetector`, leaking the entry for a session killed mid-`'wait'` in a wiring that never sets a prompt detector. **Fix:** registered unconditionally in the constructor; conditional copy removed. Verified resolved round 2.
+
+**Round 1 — external minor (folded into the spec):**
+- codex: "cannot strand" overstated — leaned on the watchdog. Resolved: the claim now stands on the per-tick re-sample; the never-settling case = an animating (working) session, the same property the watchdog has.
+- gemini: architectural redundancy (parallel settle vs refactor). Resolved: named as deliberate — `nextIdleThrottleAction` reuses `evaluateThrottleSettle` (thin wrapper, not a duplicate); the two-path unification is CMT-1785.
+
+**Round 1 — clean:** decision-completeness (3 frontloaded verified, 0 contested, Open questions = none); lessons/integration (dev-gate wiring correct, machine-local, foundation sound, signal-not-authority correct, no double-recovery — `RateLimitSentinel.report()` dedupes the two emits).
+
+**Round 2 — verification (adversarial):** F1 + F2 resolved; new checks clean — `'wait'` deferring idle-kill is bounded (a never-settling pane = animating/working, not idle-stuck; it settles→emits or the throttle scrolls out → fall-through → idle-kill resumes); flag-OFF byte-identical to legacy; decision boundaries correct. One non-blocking note (per-tick wider capture cost when flag ON) — already documented in the spec's scalability note + deferred to the CMT-1785 unification; not a correctness gap.
+
+## Convergence verdict
+
+Converged at iteration 2. Zero material findings in the verification round; `## Open questions` is `*(none)*`. The one critical defect was caught by adversarial review and fixed with a structural per-tick re-sample (verified resolved); the low-severity leak was fixed. 130 unit tests green across the rate-limit / watchdog / new suites (6 new for `nextIdleThrottleAction` covering every decision boundary), no regression, clean typecheck, flag-off path byte-identical to legacy. Spec ready for approval.

--- a/src/commands/server.ts
+++ b/src/commands/server.ts
@@ -4690,6 +4690,10 @@ export async function startServer(options: StartOptions): Promise<void> {
       degradedTmuxGuard,
       tmuxCallTimeoutMs: config.monitoring?.tmuxResilience?.asyncHotPath?.timeoutMs,
       tmuxMaxInFlight: config.monitoring?.tmuxResilience?.asyncHotPath?.maxInFlight,
+      // DARK-FLAGGED (DEV_GATED_FEATURES idleThrottleSettleGate): settle-gate the
+      // idle-monitor's rateLimitedAtIdle hand-off. `enabled` OMITTED from defaults ⇒
+      // dev-agent live / dark-fleet.
+      idleThrottleSettleGate: resolveDevAgentGate(config.monitoring?.idleThrottleSettleGate?.enabled, config),
     });
     // Wire the SAME TTL-cached SDK-credit reader PR1's routing policy uses, so
     // the reroute 'auto' decision and the intelligence-funnel routing share one

--- a/src/core/SessionManager.ts
+++ b/src/core/SessionManager.ts
@@ -53,7 +53,7 @@ export interface SessionDiagnostics {
   suggestions: string[];
 }
 import { DegradationReporter } from '../monitoring/DegradationReporter.js';
-import { detectRateLimited } from '../monitoring/rateLimitDetection.js';
+import { detectRateLimited, nextIdleThrottleAction, RATE_LIMIT_SETTLED_CAPTURE_LINES, type ThrottleSettleState } from '../monitoring/rateLimitDetection.js';
 import { InputGuard, type TopicBinding } from './InputGuard.js';
 import type { InputDetector } from '../monitoring/PromptGate.js';
 
@@ -272,6 +272,14 @@ export interface SessionManagerOptions {
    *  Server boot threads monitoring.tmuxResilience.asyncHotPath.maxInFlight;
    *  absent ⇒ TMUX_MAX_INFLIGHT_DEFAULT (8). */
   tmuxMaxInFlight?: number;
+  /** DARK-FLAGGED: when true, the idle-monitor gates the `rateLimitedAtIdle` emit
+   *  behind the SAME settle discipline the SessionWatchdog already uses (a throttle
+   *  must be present AND the pane byte-identical across polls before handing to
+   *  recovery), instead of firing on a single glance. Strictly more conservative —
+   *  can only emit LESS often. Resolved server-side via
+   *  resolveDevAgentGate(monitoring.idleThrottleSettleGate.enabled). Absent ⇒ legacy
+   *  immediate emit, unchanged. */
+  idleThrottleSettleGate?: boolean;
 }
 
 export class SessionManager extends EventEmitter {
@@ -421,6 +429,10 @@ export class SessionManager extends EventEmitter {
    *  When false (the default + every off-path/test caller) the legacy sync hot
    *  path runs byte-for-byte; monitorTick never touches the async wrapper. */
   private readonly tmuxAsyncEnabled: boolean;
+  /** DARK-FLAGGED idle-monitor throttle settle-gate (see SessionManagerOptions). */
+  private readonly idleThrottleSettleGate: boolean;
+  /** Per-session settle tracking for the dark idle-throttle settle-gate (tmuxSession → state). */
+  private readonly idleThrottleSettle = new Map<string, ThrottleSettleState>();
   /** (C) latency feed — optional-chained so (A) lands independently of the guard. */
   private readonly degradedTmuxGuard?: DegradedTmuxGuard;
   /** Per-call SIGKILL-bounded timeout for the async wrapper (ms). */
@@ -471,6 +483,11 @@ export class SessionManager extends EventEmitter {
     // (A)/(C) tmux-event-loop-resilience wiring — resolved server-side and threaded
     // in. Absent (every 2-arg/test caller) ⇒ the legacy sync hot path runs unchanged.
     this.tmuxAsyncEnabled = opts.tmuxAsyncEnabled === true;
+    this.idleThrottleSettleGate = opts.idleThrottleSettleGate === true;
+    // UNCONDITIONAL cleanup of the dark idle-throttle settle map on completion — NOT gated
+    // on setPromptDetector() (a bare/test wiring may never call it), so a session killed
+    // while mid-'wait' can't leak its settle entry.
+    this.on('sessionComplete', (session: Session) => { this.idleThrottleSettle.delete(session.tmuxSession); });
     this.degradedTmuxGuard = opts.degradedTmuxGuard;
     this.tmuxCallTimeoutMs =
       typeof opts.tmuxCallTimeoutMs === 'number' && Number.isFinite(opts.tmuxCallTimeoutMs) && opts.tmuxCallTimeoutMs > 0
@@ -1569,6 +1586,37 @@ rm()  { "${shimRunner}" rm  "$@"; }
 
           if (isActuallyIdle) {
             const now = Date.now();
+            // DARK-FLAGGED idle-throttle settle-gate (monitoring.idleThrottleSettleGate):
+            // runs on EVERY idle tick (NOT just the first) so the pane can be re-sampled
+            // across polls to reach 'settled' — mirroring the SessionWatchdog's per-tick
+            // settle loop. When enabled this OWNS the rate-limit hand-off (the first-idle-
+            // tick block below fires the legacy immediate emit only when the flag is OFF).
+            // A throttle string alone can linger in a session's scrollback after the
+            // throttle cleared; requiring the pane byte-identical across polls (a working
+            // session animates its spinner) proves the turn genuinely ended on the throttle.
+            // Strictly more conservative than the legacy single-glance emit.
+            if (this.idleThrottleSettleGate) {
+              const settledSnapshot = await this.captureOutputMaybeAsync(session.tmuxSession, RATE_LIMIT_SETTLED_CAPTURE_LINES);
+              const { action, nextState } = nextIdleThrottleAction(
+                settledSnapshot,
+                this.idleThrottleSettle.get(session.tmuxSession),
+                now,
+              );
+              if (action === 'emit') {
+                this.idleThrottleSettle.delete(session.tmuxSession);
+                this.emit('rateLimitedAtIdle', session.tmuxSession);
+                continue; // Settled → sentinel owns recovery.
+              }
+              if (action === 'wait') {
+                if (nextState) this.idleThrottleSettle.set(session.tmuxSession, nextState);
+                continue; // Not settled yet — re-sample next idle tick; do NOT emit, and
+                          // (like the watchdog's 'waiting') do not run the generic-error
+                          // nudge or idle-kill while a throttle is present-but-unsettled.
+              }
+              // 'fall-through': no current throttle in the settled window (a stale buffer
+              // line) → clear tracking and proceed to the normal idle machinery below.
+              this.idleThrottleSettle.delete(session.tmuxSession);
+            }
             if (!this.idlePromptSince.has(session.id)) {
               this.idlePromptSince.set(session.id, now);
 
@@ -1603,7 +1651,12 @@ rm()  { "${shimRunner}" rm  "$@"; }
                   // the single-nudge token, so a later generic API error can
                   // still get its one nudge. The sentinel dedupes the re-emits
                   // that persist while the throttle string stays on the pane.
-                  if (detectRateLimited(recentOutput)) {
+                  if (detectRateLimited(recentOutput) && !this.idleThrottleSettleGate) {
+                    // Legacy (flag OFF): hand straight to the RateLimitSentinel on a single
+                    // glance. When the settle-gate is ON, the per-idle-tick settle check
+                    // above (which re-samples the pane every tick to reach 'settled') OWNS
+                    // this hand-off — so we deliberately do NOT also fire the immediate emit
+                    // here, which would defeat the gate.
                     this.emit('rateLimitedAtIdle', session.tmuxSession);
                     continue; // Skip to next session — sentinel owns recovery.
                   }
@@ -1683,6 +1736,7 @@ rm()  { "${shimRunner}" rm  "$@"; }
             // is NOT cleared here — it's the lifetime runaway cap.)
             this.idlePromptSince.delete(session.id);
             this.errorNudgedSessions.delete(session.id);
+            this.idleThrottleSettle.delete(session.tmuxSession); // session moved on — reset the settle clock
           }
         }
       }

--- a/src/core/devGatedFeatures.ts
+++ b/src/core/devGatedFeatures.ts
@@ -248,6 +248,14 @@ export const DEV_GATED_FEATURES: DevGatedFeature[] = [
     justification: 'Coordinates the operator\'s OWN machines only — no external egress, no third-party spend, no destructive fs/git action. Parts A/B add TWO fenced-epoch CAS callsites to the EXISTING replicated ownership lifecycle (the same SessionOwnershipRegistry.cas + emitPlacement path the user-move release/transfer already use): every write is best-effort, CAS-fenced at epoch+1, loses safely to a higher epoch, and is NEVER forced (force-claim stays the reconciler\'s death-evidence verb). Part D\'s ownerOf read is a SIGNAL that only ever WITHHOLDS a local re-run / forwards to the owner — it can never cause a new kill or a new send (strictly reduces double-dispatch). Single-machine agents are a strict no-op (_meshSelfId null short-circuits every gate). Runs live (no destructive write warrants a dry-run) on dev / dark on fleet. Spec\'s fleet-promotion exit is an evidence-gated dev soak.',
   },
   {
+    name: 'idleThrottleSettleGate',
+    configPath: 'monitoring.idleThrottleSettleGate.enabled',
+    description:
+      'Idle-monitor throttle settle-gate (false-ratelimit-recovery follow-up, CMT-1785) — the SessionManager idle-monitor gates its `rateLimitedAtIdle` hand-off behind the SAME settle discipline the SessionWatchdog already uses (throttle present AND pane byte-identical across polls = the turn genuinely ended on the throttle), instead of firing on a single glance at a throttle string that may be stale scrollback or a just-cleared transient throttle.',
+    justification:
+      'STRICTLY more conservative than the legacy behavior — it can only ever emit `rateLimitedAtIdle` LESS often, never more, so it cannot create a recovery that did not already happen; the genuine-throttle case still settles and hands off (after a bounded settle wait the watchdog also backstops). Pure decision extracted to `nextIdleThrottleAction` (unit-tested without tmux). No external egress, no third-party spend, no destructive action, no new authority — it only WITHHOLDS a spurious recovery signal. Reversible (flip the flag → legacy immediate emit). Runs live (no destructive write warrants a dry-run) on dev / dark on fleet; the deeper two-path detection unification stays a tracked follow-up.',
+  },
+  {
     name: 'canonicalHistoryConversationDiscipline',
     configPath: 'threadline.canonicalHistory.conversationDiscipline.enabled',
     description:

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -4238,6 +4238,16 @@ export interface MonitoringConfig {
     enabled?: boolean;
   };
   /**
+   * DARK-FLAGGED (DEV_GATED_FEATURES idleThrottleSettleGate; CMT-1785 follow-up):
+   * settle-gate the SessionManager idle-monitor's `rateLimitedAtIdle` hand-off so it
+   * requires the throttle to be present AND the pane byte-identical across polls
+   * (the watchdog's discipline), instead of firing on a single glance at a possibly
+   * stale/transient throttle line. `enabled` OMITTED ⇒ dev-agent live / dark-fleet.
+   */
+  idleThrottleSettleGate?: {
+    enabled?: boolean;
+  };
+  /**
    * honest-session-state-surfaces Finding (b): lift the Tier-3 honest
    * stuck-state classification into PresenceProxy Tier 1 / Tier 2 standby —
    * so a live-but-failing session (rate-limited / policy-wedge / context-wedge /

--- a/src/monitoring/rateLimitDetection.ts
+++ b/src/monitoring/rateLimitDetection.ts
@@ -153,3 +153,38 @@ export function evaluateThrottleSettle(
   }
   return { decision: 'waiting', next: prev };
 }
+
+export type IdleThrottleAction = 'emit' | 'wait' | 'fall-through';
+
+/**
+ * The SessionManager idle-monitor's SETTLE-GATED decision for a session whose recent
+ * output already matched a throttle string. Today the idle path emits `rateLimitedAtIdle`
+ * on that single glance — which false-fires on a transient throttle that has already
+ * cleared, or a throttle line still scrolled in the buffer of a session that has since
+ * moved on. This re-checks the settled-lines window with the SAME discipline the
+ * SessionWatchdog already uses (`evaluateThrottleSettle`: throttle present AND pane
+ * byte-identical across polls = the turn genuinely ended on the throttle), and returns:
+ *   - 'emit'         : settled → hand to recovery now (clear tracking).
+ *   - 'wait'         : throttle present but pane still changing / not settled long enough
+ *                      → recheck next idle tick, do NOT emit yet (carry `nextState`).
+ *   - 'fall-through' : no throttle in the settled window → not a current throttle; clear
+ *                      tracking and let the caller continue to its generic-error check.
+ *
+ * Pure + clock-injected (no tmux) so the new decision is fully unit-testable. STRICTLY
+ * more conservative than the legacy immediate emit — it can only ever emit LESS often,
+ * never more — so it cannot create a recovery it didn't already make. Gated behind the
+ * dark `monitoring.idleThrottleSettleGate` flag; the deeper redesign (unifying the idle +
+ * watchdog detection paths, and distinguishing an active-tail throttle from old
+ * scrollback) stays a tracked follow-up.
+ */
+export function nextIdleThrottleAction(
+  snapshot: string | null | undefined,
+  prev: ThrottleSettleState | undefined,
+  now: number,
+  opts?: { settleMs?: number; captureLines?: number },
+): { action: IdleThrottleAction; nextState: ThrottleSettleState | undefined } {
+  const { decision, next } = evaluateThrottleSettle(snapshot, prev, now, opts);
+  if (decision === 'settled') return { action: 'emit', nextState: undefined };
+  if (decision === 'waiting') return { action: 'wait', nextState: next };
+  return { action: 'fall-through', nextState: undefined }; // 'no-throttle'
+}

--- a/tests/unit/idle-throttle-settle-gate.test.ts
+++ b/tests/unit/idle-throttle-settle-gate.test.ts
@@ -1,0 +1,63 @@
+/**
+ * Tier-1 tests for the DARK-FLAGGED idle-monitor throttle settle-gate decision
+ * (CMT-1785 follow-up to the false-ratelimit-recovery fix). `nextIdleThrottleAction` is
+ * the pure decision the SessionManager idle path consults BEHIND the flag: instead of
+ * emitting `rateLimitedAtIdle` on a single glance at a throttle string (which false-fires
+ * on a stale/transient line), it requires the throttle to SETTLE (present AND pane
+ * byte-identical across polls — a working session animates its spinner, so an unchanged
+ * pane proves the turn ended on the throttle). Strictly more conservative: emit LESS,
+ * never more. Pure + clock-injected → no tmux needed.
+ */
+import { describe, it, expect } from 'vitest';
+import { nextIdleThrottleAction, type ThrottleSettleState } from '../../src/monitoring/rateLimitDetection.js';
+
+const THROTTLE = 'Server is temporarily limiting requests (not your usage limit) · Rate limited';
+const settleMs = 10_000;
+const opts = { settleMs };
+
+describe('nextIdleThrottleAction (idle-throttle settle-gate decision)', () => {
+  it('no throttle in the snapshot → fall-through (let the caller continue to its error check), no state', () => {
+    const r = nextIdleThrottleAction('all calm, working normally', undefined, 1_000, opts);
+    expect(r.action).toBe('fall-through');
+    expect(r.nextState).toBeUndefined();
+  });
+
+  it('throttle present, FIRST sighting → wait (start the settle clock), never emit on a single glance', () => {
+    const r = nextIdleThrottleAction(`...\n${THROTTLE}\n`, undefined, 1_000, opts);
+    expect(r.action).toBe('wait');
+    expect(r.nextState).toBeDefined();
+    expect(r.nextState!.since).toBe(1_000);
+  });
+
+  it('throttle present, pane UNCHANGED for >= settleMs → emit (genuinely settled, hand to recovery)', () => {
+    const snap = `...\n${THROTTLE}\n`;
+    const first = nextIdleThrottleAction(snap, undefined, 1_000, opts);
+    const r = nextIdleThrottleAction(snap, first.nextState, 1_000 + settleMs, opts);
+    expect(r.action).toBe('emit');
+    expect(r.nextState).toBeUndefined();
+  });
+
+  it('throttle present, pane unchanged but NOT settled long enough → wait (carry state)', () => {
+    const snap = `...\n${THROTTLE}\n`;
+    const first = nextIdleThrottleAction(snap, undefined, 1_000, opts);
+    const r = nextIdleThrottleAction(snap, first.nextState, 1_000 + settleMs - 1, opts);
+    expect(r.action).toBe('wait');
+    expect(r.nextState!.since).toBe(1_000); // clock NOT restarted — same pane
+  });
+
+  it('throttle present but pane CHANGED since last poll → wait + RESTART the settle clock (a working session)', () => {
+    const prev: ThrottleSettleState = { sig: 'old-signature', since: 1_000 };
+    const r = nextIdleThrottleAction(`...\n${THROTTLE}\n some NEW output line\n`, prev, 9_999, opts);
+    expect(r.action).toBe('wait');
+    expect(r.nextState!.since).toBe(9_999); // restarted because the pane changed
+  });
+
+  it('a transient throttle that CLEARS before settling never emits (the false-fire this fixes)', () => {
+    const throttled = `...\n${THROTTLE}\n`;
+    const first = nextIdleThrottleAction(throttled, undefined, 1_000, opts);       // wait
+    expect(first.action).toBe('wait');
+    const cleared = nextIdleThrottleAction('resumed — working again', first.nextState, 1_000 + settleMs, opts);
+    expect(cleared.action).toBe('fall-through'); // throttle gone → never emitted
+    expect(cleared.nextState).toBeUndefined();
+  });
+});

--- a/upgrades/next/idle-throttle-settle-gate.md
+++ b/upgrades/next/idle-throttle-settle-gate.md
@@ -1,0 +1,26 @@
+---
+user_announcement:
+  - audience: agent-only
+    maturity: experimental
+    summary: "(Dev-only, dark on the fleet) The idle session-monitor's rate-limit recovery trigger now uses the same 'has the screen actually stopped changing?' settle check the watchdog uses, instead of firing on a single glance at a throttle line."
+---
+
+## What Changed
+
+The SessionManager idle-monitor used to hand a session to rate-limit recovery the instant it saw a throttle line in the last ~30 terminal lines — a single glance. That false-fires when the throttle line is stale scrollback the session has moved past, or a transient throttle that already cleared (the milder cousin of the false-rate-limit spam fixed in #1262). Behind a DARK flag (`monitoring.idleThrottleSettleGate`, dev-agent live / dark on the fleet), the idle-monitor now gates that hand-off behind the SAME settle discipline the SessionWatchdog already uses: a throttle must be present AND the terminal pane byte-identical across polls (a working session animates its spinner every tick, so a frozen pane proves the turn genuinely ended on the throttle). It is strictly more conservative — it can only ever trigger recovery LESS often, never more, so it cannot strand a genuinely-stuck session.
+
+## Evidence
+
+- **Reproduction (the gap):** the idle-monitor's `rateLimitedAtIdle` emit fired on `detectRateLimited(recentOutput)` from a single capture, with no settle check — unlike the SessionWatchdog's `checkRateLimited`, which already required a settled (pane-unchanged-across-polls) throttle before acting.
+- **Before → after:** before, a still-running idle session with a stale/transient throttle line in its buffer got an unnecessary recovery hand-off (≤1 stray "back online" message, after #1262 neutralized the finished-session spam). After, the idle-monitor re-samples the pane every idle tick and only hands off once the throttle has genuinely settled; a stale or already-cleared throttle line no longer triggers recovery. Flag off (the fleet) is byte-identical to the legacy behavior.
+- **Verified:** 6 unit tests for the pure settle decision (`nextIdleThrottleAction`, every boundary), 130 green across the rate-limit/watchdog suites, no regression, clean typecheck. Multi-angle review (3 internal lenses + codex + gemini, 2 rounds) caught a critical defect in an earlier draft (the settle check running only on the first idle tick, making "settled" unreachable) — fixed to re-sample every tick and verified.
+
+## What to Tell Your User
+
+Nothing visible day-to-day — this is internal session-watching behavior and it's off everywhere except the development machine until it's soaked. The eventual benefit is fewer unnecessary "back online" pokes from a session that wasn't really stuck.
+
+## Summary of New Capabilities
+
+- `monitoring.idleThrottleSettleGate` (dev-gated dark flag): settle-gate the idle-monitor's rate-limit recovery hand-off, bringing it to parity with the SessionWatchdog's settle discipline.
+- `nextIdleThrottleAction` (pure helper): the unit-testable settle decision (`emit`/`wait`/`fall-through`) the idle path consults each tick.
+- Deferred (CMT-1785): unifying the idle-monitor and watchdog detection paths (one shared trigger + one shared per-tick capture) + distinguishing an active-tail throttle from old scrollback.

--- a/upgrades/side-effects/idle-throttle-settle-gate.md
+++ b/upgrades/side-effects/idle-throttle-settle-gate.md
@@ -1,0 +1,37 @@
+# Side-Effects Review — Idle-monitor throttle settle-gate
+
+**Version / slug:** `idle-throttle-settle-gate`
+**Date:** `2026-06-24`
+**Author:** Echo (autonomous, 8-hour run)
+**Spec:** `docs/specs/idle-throttle-settle-gate.md` (review-convergence + approved)
+**Second-pass reviewer:** REQUIRED (touches the SessionManager idle/recovery path) — verdict appended below.
+
+## Summary of the change
+
+The safe slice of the false-rate-limit F3 residual (CMT-1785). The SessionManager idle-monitor emitted `rateLimitedAtIdle` (handing to RateLimitSentinel recovery) the instant `detectRateLimited(last-30-lines)` matched — a single glance, which false-fires on a stale/transient throttle line. Behind a DARK flag, the idle-monitor now gates that hand-off behind the SAME settle discipline the SessionWatchdog already uses (`evaluateThrottleSettle`: throttle present AND pane byte-identical across polls = the turn genuinely ended on the throttle). Strictly more conservative — it can only ever emit `rateLimitedAtIdle` LESS often, never more.
+
+Files modified:
+- `src/monitoring/rateLimitDetection.ts` — new pure `nextIdleThrottleAction` (a thin wrapper over the existing `evaluateThrottleSettle`; returns `'emit'`/`'wait'`/`'fall-through'`). No change to `evaluateThrottleSettle` or `detectRateLimited`.
+- `src/core/SessionManager.ts` — (a) new dark-flagged per-tick settle check inside `if (isActuallyIdle)` AHEAD of the first-idle-tick gate, so the pane is re-sampled every tick (load-bearing — see F1 below); (b) the first-tick legacy emit fenced to `detectRateLimited(recentOutput) && !this.idleThrottleSettleGate` (flag-off only); (c) per-session `idleThrottleSettle` Map + `idleThrottleSettleGate` field from new opt; (d) unconditional cleanup of the Map on `sessionComplete` (constructor) + on session-active.
+- `src/core/devGatedFeatures.ts` — new `idleThrottleSettleGate` DEV_GATED_FEATURES entry (`monitoring.idleThrottleSettleGate.enabled`, omitted ⇒ dev-live/dark-fleet).
+- `src/core/types.ts` — `MonitoringConfig.idleThrottleSettleGate?: { enabled?: boolean }`.
+- `src/commands/server.ts` — resolves the flag via `resolveDevAgentGate(...)` and threads it into the SessionManager opts.
+
+Files added:
+- `tests/unit/idle-throttle-settle-gate.test.ts` — 6 unit tests for `nextIdleThrottleAction` (every decision boundary: no-throttle→fall-through, first-sighting→wait, unchanged≥settleMs→emit, unchanged<settleMs→wait, pane-changed→wait+restart, transient-clears→fall-through).
+- `docs/specs/idle-throttle-settle-gate.md` (+ `.eli16.md`, convergence report).
+
+## Blast radius
+
+- **Flag OFF (the FLEET, by default):** byte-identical to legacy. The per-tick block is skipped entirely (`if (this.idleThrottleSettleGate)` false); the first-tick emit fires exactly as before; the `idleThrottleSettle` Map is never written (cleanup deletes are no-ops on an empty map). Confirmed by the adversarial reviewer + the existing watcher/quota suites unchanged.
+- **Flag ON (dev only):** the idle-path rate-limit hand-off is settle-gated. It only WITHHOLDS a spurious `rateLimitedAtIdle`; it never adds a kill/send/authority. RateLimitSentinel stays the recovery authority. The SessionWatchdog independently settle-gates the same class (the two emits are deduped by `RateLimitSentinel.report()`), so no double-recovery and no coverage gap.
+- **Multi-machine:** machine-local-by-design — per-process state about locally-running sessions; no replicated/proxied state.
+- **Migration parity:** dev-gated flag, `enabled` omitted from ConfigDefaults (no user default written) ⇒ no migration surface. No hooks/CLAUDE.md/skill/dashboard changes.
+
+## Rollback
+
+Flip `monitoring.idleThrottleSettleGate.enabled` false (or revert the commit) ⇒ legacy immediate emit. Fully additive and reversible; nothing irreversible ships.
+
+## Second-pass reviewer verdict
+
+Multi-angle spec-converge (adversarial + decision-completeness + lessons/integration internal lenses, + codex-cli:gpt-5.5 + gemini-2.5-pro external) over 2 rounds. Round 1 caught a CRITICAL functional defect (F1: the settle check ran only on the first idle tick → `'settled'` unreachable → flag-ON would emit recovery never, silently delegating to the watchdog) and a LOW map-cleanup leak (F2). Both fixed (per-tick re-sample; unconditional constructor cleanup) and verified RESOLVED + CONVERGED in round 2, with new adversarial checks (idle-kill starvation, flag-off regression, decision boundaries) clean. External minors (overstated safety claim; polling redundancy) folded into the spec. 130 unit tests green, no regression, clean typecheck. The one non-blocking note (per-tick wider capture cost when flag ON) is documented + deferred to the CMT-1785 unification. Verdict: APPROVED.


### PR DESCRIPTION
## What & why

The safe slice of the false-rate-limit **F3 residual** (CMT-1785), the follow-up to #1262. The SessionManager idle-monitor emitted `rateLimitedAtIdle` (handing a session to `RateLimitSentinel` recovery) the instant `detectRateLimited(last-30-lines)` matched — a **single glance**, which false-fires when the throttle line is stale scrollback the session moved past, or a transient throttle that already cleared. With #1262's guard in place this self-corrects to ≤1 stray "back online" message (not the spam), but it's still an unnecessary recovery.

The `SessionWatchdog` already solves exactly this for its own path: `evaluateThrottleSettle` only acts when the throttle is present **AND the pane byte-identical across polls** — because a working Claude session animates its spinner every tick, so a frozen pane proves the turn genuinely ended on the throttle. This brings the idle path to parity.

## The change (additive, DARK-flagged, strictly more conservative)

Behind `monitoring.idleThrottleSettleGate` (dev-agent live / **dark on the fleet**), the idle-monitor gates its rate-limit hand-off behind the same settle check, **re-sampled every idle tick**. It can only ever emit `rateLimitedAtIdle` **less** often, never more — so it can't strand a genuinely-stuck session (a real throttle has a stable pane → it settles and hands off a few seconds later; the watchdog independently backstops). Flag off (the fleet) is **byte-identical** to legacy.

- New pure `nextIdleThrottleAction` (thin wrapper over `evaluateThrottleSettle`): `emit` / `wait` / `fall-through`. Unit-tested without tmux (6 tests, every boundary).
- The settle check runs on **every** idle tick (ahead of the first-tick gate) so the pane is re-sampled to reach `'settled'`; the legacy first-tick emit is fenced to flag-off.

## Review caught a real defect

Multi-angle review (adversarial + decision-completeness + lessons/integration + codex-cli:gpt-5.5 + gemini-2.5-pro, 2 rounds) caught a **CRITICAL** functional defect in my first draft: I put the settle check in the *first-idle-tick* block, so it ran once and could never re-sample to reach `'settled'` — meaning flag-ON would emit recovery *never*, silently delegating to the watchdog (a strand path if the watchdog were disabled). Fixed by re-sampling every tick; verified RESOLVED in round 2. A low-severity map-cleanup leak was also fixed (unconditional constructor registration). This is the second self-introduced flaw the review process caught in this effort — the point of putting even a "safe" change through the gate.

## Tests
6 new unit (every `nextIdleThrottleAction` boundary) + 130 green across the rate-limit / watchdog suites, no regression, clean typecheck. Flag-off path byte-identical to legacy (confirmed by the adversarial reviewer).

## Deferred (CMT-1785)
Unifying the two detection paths (one shared trigger + one shared per-tick capture) and distinguishing an active-tail throttle from old scrollback — a shared-detection redesign affecting the watchdog too.

## ELI16
Echo has two watchers that notice when a chat session is stuck on an AI-provider "slow down" message and hand it to a recovery helper. One (the watchdog) is careful — it only acts once the screen has actually stopped changing (a working session animates its spinner, so a frozen screen with a throttle on it proves the session genuinely stopped). The other (the idle monitor) was naive — it acted the instant it saw the throttle *word*, even if that word was just old text scrolled up or a brief throttle that already cleared. That naive trigger produced unnecessary "back online" pokes. This change gives the idle monitor the same careful "has the screen stopped changing?" check, behind a dark switch that only runs on the development machine until it's soaked. It can only make the idle monitor act LESS often, never more, so it can't strand a genuinely-stuck session — it just stops acting on a stale or already-cleared throttle word. The review process caught a real bug in my first attempt: I put the "stopped changing?" check somewhere it only ran once, but you can't tell a screen is frozen from a single glance — so it could never confirm "settled." I fixed it to look every idle moment and re-verified. Nothing changes day-to-day; it's off everywhere except the dev machine, and the eventual benefit is fewer unnecessary pokes from a session that wasn't really stuck.
