### PR TITLE
feat(monitoring): stranded-inbound detector — surface an online-but-unable-to-serve owner (dark)

### DIFF
--- a/.instar/instar-dev-decisions/2026-06-25T01-19-31-839Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-06-25T01-19-31-839Z-unknown.json
@@ -1,0 +1,19 @@
+{
+  "ts": "2026-06-25T01:19:31.839Z",
+  "slug": "unknown",
+  "suggestedTier": 2,
+  "declaredTier": 2,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "new capability: new exported class / subsystem added",
+    "new capability: new config key added"
+  ],
+  "belowFloor": false,
+  "files": 8,
+  "loc": 653,
+  "causalAutopsy": {
+    "origin": "latent",
+    "notes": "A latent gap in the cross-machine ownership layer: OwnershipReconciler Case C force-claims only a provably-DEAD owner (offline >=180s) and iterates only pinned topics, so a walled-but-ONLINE owner (heartbeat fresh, but quotaState.blocked / adapter down) strands a topic forever with no detector. Surfaced live 2026-06-24 (17/25 topics). No prior PR introduced it; it was never covered."
+  },
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-06-25T01-21-01-293Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-06-25T01-21-01-293Z-unknown.json
@@ -1,0 +1,19 @@
+{
+  "ts": "2026-06-25T01:21:01.293Z",
+  "slug": "unknown",
+  "suggestedTier": 2,
+  "declaredTier": 2,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "new capability: new exported class / subsystem added",
+    "new capability: new config key added"
+  ],
+  "belowFloor": false,
+  "files": 8,
+  "loc": 653,
+  "causalAutopsy": {
+    "origin": "latent",
+    "notes": "A latent gap in the cross-machine ownership layer: OwnershipReconciler Case C force-claims only a provably-DEAD owner (offline >=180s) and iterates only pinned topics, so a walled-but-ONLINE owner (heartbeat fresh, but quotaState.blocked / adapter down) strands a topic forever with no detector. Surfaced live 2026-06-24 (17/25 topics). No prior PR introduced it; it was never covered."
+  },
+  "verdict": "pass"
+}

--- a/docs/specs/reports/stranded-inbound-self-heal-convergence.md
+++ b/docs/specs/reports/stranded-inbound-self-heal-convergence.md
@@ -1,0 +1,61 @@
+# Convergence Report — Stranded-inbound detector
+
+## Cross-model review: codex-cli:gpt-5.5
+
+A real GPT-tier external pass (codex-cli, gpt-5.5) ran in every round (R1–R4). Gemini-cli was available but timed out on R1 (degraded); per the aggregate rule, one successful external family is the clean RAN flag. The external reviewer returned MINOR ISSUES each round (no material/architectural blocker), and its minors were folded in (predicate three-valued correctness, dedup-window identity, blind-spot guard, latency-bound honesty, "servable peer" wording).
+
+## ELI10 Overview
+
+When I run on more than one machine, each conversation is "owned" by one machine that receives and answers it. On 2026-06-24 a conversation got stuck owned by a machine that was *switched on but unable to serve* — the Mac Mini was sending heartbeats but its AI account was rate-limited, so your Telegram messages routed to it and silently vanished while my replies still went out from the healthy Laptop. 17 of 25 conversations were stuck this way, and every automated test passed the whole time — only you noticing missing messages caught it.
+
+This spec adds a small read-only watcher that, each minute, finds any conversation owned by an online-but-unable machine and raises ONE alert. It changes nothing on its own — it just makes the invisible wedge loud within ~a minute or two instead of waiting hours for a human to notice.
+
+The headline tradeoff, surfaced by review: the *obvious* fix (auto-hand-off to a healthy machine) is unsafe to build today, because the signals we'd use are self-reported, briefly-wrong, and we can't yet tell if a live answer is mid-flight on the stuck machine — getting it wrong would yank a live conversation mid-reply, which is worse than the bug. So v1 is detection-only and the auto-failover is deferred with its prerequisites written down.
+
+## Original vs Converged
+
+**Originally**, this was a self-HEALING reconciler: detect the stranded topic AND automatically CAS-reassign its ownership to a healthy machine (with a pin repoint). The review process fundamentally reshaped it:
+
+- **Round 1** (security + adversarial + lessons-aware) proved the auto-failover could not be made safe with today's primitives: there is no per-topic remote-liveness signal (only a scalar `activeSessionCount`), the reachability signal is the would-be-victim's own self-report (up to `failoverThresholdMs` stale), there is no temporal hysteresis (a 5-second blip would seize a live topic), and the 2-machine quorum (the actual incident topology) is a trivial pass. The unanimous conclusion: **a wrong failover is strictly worse than the bug** (it drops a live conversation).
+- **The converged design retreats to a pure-signal DETECTOR**: it raises one aggregated, staleness-disclosed attention item and mutates nothing. The auto-failover is deferred to a v2 whose seven prerequisites are each named and tracked (`CMT-1786`). This is the textbook *Signal vs Authority* and *Bounded Blast Radius* move: ship the safe half that catches the class, build the dangerous half only once the primitives exist.
+- **Rounds 2–3** hardened the detector itself: the predicate was restructured into a channel-independent quota arm (which carries the real incident with zero scope resolution) plus a fail-closed best-effort adapter arm; the three-valued `machineServesChannel` enum was used correctly (the original `!fn(...)` idiom would have made the detector never fire); `strandedSince` got per-tick reconciliation; the attention item discloses signal staleness; and a separate "can't-assess" guard makes a schema-regression blind-spot itself visible.
+
+## Iteration Summary
+
+| Iteration | Reviewers who flagged | Material findings | Spec changes | Conformance Gate |
+|-----------|-----------------------|-------------------|--------------|------------------|
+| 1 | security, adversarial, integration, scalability, decision-completeness, lessons-aware, codex | several (failover unsafe — no remote liveness, stale self-report, no hysteresis, inert quorum) | Narrowed v1 to a pure-signal DETECTOR; deferred failover to v2 with named prerequisites; folded all detector-side findings (persistence, freshness, dedup, reuse helpers, GuardRegistry, single-machine no-op, lease-holder-only) | ran (0 flags) |
+| 2 | adversarial (1 material), codex (minor), lessons-aware (minor), decision-completeness (clean) | 1 (predicate needs ChannelScope; no `topic→scope` resolver named) | Restructured predicate: channel-independent quota arm + fail-closed best-effort adapter arm; three-valued enum fix; `strandedSince` reconciliation; latency bound; dedup-window identity; can't-assess guard; staleness disclosure | ran (0 flags) |
+| 3 | adversarial (CONVERGED), decision-completeness (CONVERGED), codex (minor) | 0 material / 0 convergence-blocking | Folded reviewers' non-blocking accuracy recommendations: corrected the `TopicBinding` misnaming (no topic→scope registry exists; quota arm carries Telegram, adapter arm is Slack-only in practice), "servable peer" wording, latency-bound cadence honesty | ran (0 flags) |
+| 4 | codex (final body re-pass, delta-gated) | 0 material | none (verification pass on final body) | — |
+
+## Full Findings Catalog
+
+### Round 1 (on the original mutating design)
+- **[CRITICAL, adversarial+integration] No remote per-topic liveness primitive** — heartbeats carry only scalar `activeSessionCount`; the failover could seize a live/recovering conversation. → Resolved by descope; named as a v2 prerequisite (heartbeat extension).
+- **[CRITICAL, adversarial] No hysteresis** — a transient quota blip would force-claim a healthy mid-conversation topic. → Descoped; v2 prerequisite (≥N blocked beats + dwell).
+- **[MATERIAL, security] Stranding signal is the victim's own self-report** — seizing FROM a machine on its own (possibly stale/sparse) beat. → Descoped; detector now uses it only as advisory input with ≥2-rich-beat persistence + staleness disclosure.
+- **[MATERIAL, security] No staleness floor beyond the global `online` window** → detector requires a genuine rich beat within a freshness bound; missing field ⇒ SKIP.
+- **[MATERIAL, adversarial] Flap loop / two-writer overlap / target-goes-dark-between-select-and-CAS / no-valid-target churn / nonce collision** → all are mutation hazards; deferred to v2 with named fixes (cooldown, re-assert-at-claim, disjointness, reason-stamped nonce).
+- **[MATERIAL, integration] `isTopicBusy` ≠ remote-session presence; must register in GuardRegistry; unpinned overlaps Case D** → detector reads `activeSessionCount`/in-memory caches only; GuardRegistry registration added (D6).
+- **[MINOR, security] 2-machine pool has no quorum floor** → documented; v2 uses temporal corroboration there.
+- **[scalability] Per-topic cooldown / tick interval / dedup key / no-synchronous-probe** → folded (≥30s tick, in-memory once-per-tick, no peer probe, dedup key, LLM-free no-spawn-slot invariant).
+- **[lessons-aware] Constitutionally aligns after descope; foundation `online`=heartbeat-fresh is acceptable for a DETECTOR though not for a mutation** → the spec draws that mutation-vs-detection line explicitly.
+- **[codex] Mutation atomicity, actor-vs-target, missing-`servesChannels`=uncertainty, debounce, glossary** → folded (glossary added; missing-field⇒skip; atomicity deferred to v2).
+
+### Round 2 (on the narrowed detector)
+- **[MATERIAL, adversarial] Predicate needs a `ChannelScope` but ownership records are keyed by bare `sessionKey`; no resolver named** → restructured into quota arm (no scope) + best-effort adapter arm (fail-closed).
+- **[MINOR, adversarial] `machineServesChannel` three-valued; `!fn(...)` always false** → predicate now `=== 'no'`, `'unknown'⇒skip`.
+- **[MINOR, adversarial] `strandedSince` needs per-tick reconciliation** → added.
+- **[MINOR, lessons-aware] Item should disclose signal staleness** → added last-rich-beat age to item text.
+- **[MINOR, codex] Latency overstated; dedup-window underspecified; fail-closed blinds on schema regression; cache freshness; route-time alternative** → all folded (latency bound + cadence caveat; window identity; can't-assess guard; D5 cache readiness; route-time rationale).
+- **[decision-completeness] v1 DECISION-COMPLETE** (pin-atomicity + Slack-granularity findings live only on the deferred mutation path).
+
+### Round 3 (convergence check)
+- **adversarial: CONVERGED — no material findings.** R2 fixes verified resolved; non-blocking note: `TopicBinding` carries platform not chatId → adapter arm skips more (degrades to fail-closed floor, never a false strand).
+- **decision-completeness: CONVERGED — decision-complete.** Non-blocking: same `TopicBinding` accuracy note → corrected in the spec text.
+- **codex: MINOR ISSUES** (D2 predicate-copy footgun, item-lifecycle clarity, "healthy server" wording, latency cadence) → folded.
+
+## Convergence verdict
+
+**Converged at iteration 3** (verification re-pass at iteration 4). Both internal convergence reviewers (adversarial, decision-completeness) returned an explicit CONVERGED verdict with zero material / zero convergence-blocking findings; the external (codex) returned minor-only every round; the Standards-Conformance Gate ran every round with 0 at-risk flags. `## Open questions` is `(none)`. The design is a pure-signal, dark-gated, fail-closed detector with the dangerous auto-failover deferred behind named, tracked prerequisites. Ready for approval and build.

--- a/docs/specs/stranded-inbound-self-heal.eli16.md
+++ b/docs/specs/stranded-inbound-self-heal.eli16.md
@@ -1,0 +1,27 @@
+# Stranded-inbound detector — the plain-English version
+
+## What problem is this fixing?
+
+When I run on more than one machine (say a Laptop and a Mac Mini), each of your conversations is "owned" by exactly one machine — that machine is the one that receives and answers your messages for that conversation. Normally that's fine.
+
+But here's the failure that actually bit us on 2026-06-24: a conversation can stay "owned" by a machine that is **switched on but unable to actually serve it** — for example the Mini was still sending its little "I'm alive" heartbeat every few seconds, but its AI account was rate-limited (quota-walled), so it couldn't actually answer anything. Your Telegram messages kept getting routed to that stuck machine and silently went nowhere — while my replies still went out from the healthy Laptop. So from your side it looked like I was ignoring you, even though everything *looked* healthy. It turned out **17 of 25 conversations** were stuck this way, and nobody noticed until you told me your messages weren't arriving.
+
+The scary part: every automated test and code review passed the whole time. The breakage was completely invisible to all of them. The only thing that caught it was *you* getting bitten.
+
+## What does this change actually do?
+
+It adds a small background watcher (a "detector") that, every minute or so, looks at every conversation and asks: *"Is this owned by a machine that's online but can't actually serve it right now?"* If it finds any, it raises **one** clear alert ("these conversations' messages are going to a machine that can't answer them; here's a machine that can").
+
+That's it. **It does not move anything or change anything** — it just makes the invisible problem loud, immediately, instead of waiting hours for a human to notice missing messages.
+
+## Why doesn't it just fix the problem automatically?
+
+That was the original plan — automatically hand the conversation to a healthy machine. But the review process found that doing that *safely* is genuinely hard with the information we have today: the signal we'd use ("this machine can't serve") is the machine's own self-report and can be briefly wrong (a 5-second blip), and we can't yet tell whether a real live answer is mid-flight on the stuck machine. If we got it wrong, we'd yank a live conversation off a machine mid-reply — which is **worse** than the bug we're fixing. So the automatic fix is deliberately deferred until we build the missing pieces (a per-conversation "is something live here?" signal, and proper "wait and confirm" logic). Those are written down as named follow-ups so they don't get lost.
+
+## What changes for you?
+
+Nothing you'll see day-to-day. Behind the scenes, the moment a conversation gets stranded like this, I'll know within about a minute and can fix it (today, by hand; later, automatically) — instead of the problem hiding until you happen to message that conversation and get silence. It's the first, safe half of making "your messages silently vanished" a thing that can't quietly happen again.
+
+## Is it safe?
+
+Yes — by construction. It only ever *reads* state and *raises one alert*. It can't move a conversation, can't kill anything, can't message you directly, and the alert rides the existing limit that stops alert-spam. It's off everywhere except my own development machine until it's been proven out. If it's ever wrong, the worst case is one extra advisory note that a human reads and dismisses.

--- a/docs/specs/stranded-inbound-self-heal.md
+++ b/docs/specs/stranded-inbound-self-heal.md
@@ -1,0 +1,116 @@
+---
+title: "Stranded-inbound detector — surface a topic whose owner is online-but-unable-to-serve"
+slug: stranded-inbound-self-heal
+eli16-overview: stranded-inbound-self-heal.eli16.md
+parent-principle: "Structure beats Willpower — a cross-machine inbound wedge (a topic owned by a machine that is online-by-heartbeat but cannot serve) was silently un-recovered until a human noticed his messages stopped arriving; replace 'a human eventually notices' with a structural detector that surfaces the wedge the moment it forms."
+author: echo
+created: 2026-06-24
+status: draft
+review-convergence: "2026-06-25T00:45:03.315Z"
+review-iterations: 3
+review-completed-at: "2026-06-25T00:45:03.315Z"
+review-report: "docs/specs/reports/stranded-inbound-self-heal-convergence.md"
+cross-model-review: "codex-cli:gpt-5.5"
+single-run-completable: true
+frontloaded-decisions: 6
+cheap-to-change-tags: 6
+contested-then-cleared: 0
+approved: true
+approved-by: "echo (standing 8-hour autonomous-run pre-approval, 2026-06-24; design/scope forks are mine to resolve — the review-driven descope to detection-only is exactly such a fork)"
+---
+
+# Stranded-inbound detector
+
+## Problem (proven live, 2026-06-24)
+
+A Telegram topic's durable ownership record can name a machine that is **online-by-heartbeat but cannot serve** — quota-walled (`quotaState.blocked:true`) or adapter-disconnected (`servesChannels` omits the topic's platform) — while a different, healthy machine holds the lease. The topic's inbound messages route to the owner that cannot serve them, so they never reach a machine that can: **inbound is silently dead for that topic** (outbound replies still flow from the healthy machine, producing the confusing "my replies send but his messages never arrive" split).
+
+This is NOT covered by the existing `OwnershipReconciler` (WS1.3):
+- Its force-claim path (Case C, `OwnershipReconciler.ts:201`) fires only on a **provably DEAD** owner (`!online && (now − lastSeenMs) >= deathEvidenceMs`, 180s) + quorum, and only for a topic **already pinned to self**. A walled owner whose heartbeat is still fresh is `online:true`, so it is "not provably dead" → the reconciler **defers forever** (`report.deferredNoEvidence++`).
+- It iterates **pinned** topics only. A stranded topic with no pin (or a stale pin to another walled machine) is never even considered.
+
+The live incident: **17 of 25 topics** were owned by an offline/walled Mac Mini; inbound was broken for all of them; the only recovery was a human hand-editing `.instar/ownership/local/<topicId>.json`. Every code review and CI gate was green while this user-facing regression was invisible to all of them — it surfaced only when the operator got bitten. **This detector is the structural answer to "we keep getting surprised when the operator jumps in":** it makes the wedge loud **within a bounded detection window** (the persistence gate trades a little latency for no false positives: latency ≈ `dwellMs` + one `tickMs` + the rich-heartbeat interval — on a healthy heartbeat cadence that is on the order of a minute or two; if rich beats are sparse/delayed the window stretches accordingly, which is the correct fail-slow-not-false posture), instead of waiting hours for a human to notice missing messages.
+
+## Scope decision (why v1 is detection-only)
+
+The instinctive fix is auto-failover: CAS-reassign the topic off the walled owner onto a healthy server. Spec-convergence review (security + adversarial + lessons-aware, round 1) established that **auto-failover cannot be made safe with the primitives that exist today**, and a wrong failover is *strictly worse than the bug* (it drops a live conversation mid-reply):
+
+1. **No remote per-topic liveness signal.** Heartbeats carry only a scalar `activeSessionCount` (MachinePoolRegistry) — never which *topics* have live sessions. So a failover cannot tell whether the stranded topic has a live session *recovering* on the walled owner (the cooperative path Case C exists to protect) → it could seize a live conversation.
+2. **The reachability signal is self-reported and stale.** `quotaState`/`servesChannels` are each machine's own heartbeat self-report, fresh only to the last rich beat and up to `failoverThresholdMs` stale. Elevating that to *authority for a mutation* — on the 2-machine topology where the quorum check (`machines.length <= 2`) is a trivial pass — means a single stale/sparse beat could wrongly seize a topic a healthy owner is serving fine.
+3. **No temporal corroboration / hysteresis** exists to distinguish a 5-second quota blip from a durable wall.
+
+Therefore v1 ships the **detector only** (pure signal — raises an attention item, mutates nothing). It is genuinely safe (a false-positive attention item is cheap; a stolen conversation is not) and it delivers the core value: the wedge becomes visible within a bounded window, so the agent (or operator) can act in seconds instead of hours. The auto-failover is a tracked v2 (`## Deferred — the v2 failover`) with its prerequisites named. <!-- tracked: CMT-1786 -->
+
+**Why a polling sentinel, not route-time detection.** An alternative is to flag the strand at inbound-routing time (when a message is dispatched to an unservable owner). Rejected as the v1 surface because a stranded topic's defining symptom is that messages are NOT arriving/being processed — route-time detection only fires when traffic flows, so a quiet stranded topic (the operator hasn't messaged it yet — exactly the 16 topics he had not yet hit) would stay invisible until it's already a problem. A polling sentinel surfaces the wedge proactively, independent of traffic. (Route-time annotation is a reasonable *corroborating* telemetry source for the v2 work, not a replacement for the sentinel.)
+
+## Glossary (load-bearing terms)
+
+- **pin** — a per-topic preferred-machine record in `TopicPlacementPinStore` (`{preferredMachine, pinned, updatedAt}`); a user/operator "run this here".
+- **owner** — the machine named by the durable ownership record (`SessionOwnershipRegistry.ownerOf(topic)`); inbound routes to the owner.
+- **lease-holder** — the single machine currently holding the fenced serving lease (`syncStatus.holdsLease` / `LeaseCoordinator`).
+- **`servesChannels`** — a machine's heartbeat self-report of which platforms/workspaces its adapters are connected to; queried via `machineServesChannel(servesChannels, channel)` (PlacementExecutor).
+- **stranded** — an `active`-owned topic whose owner is `online` (heartbeat-fresh) but, persistently across rich beats, cannot serve the topic's channel (`quotaState.blocked || !machineServesChannel(...)`).
+
+## Proposed design (one component, dark-gated, pure-signal)
+
+A new monitoring sentinel **`StrandedTopicSentinel`** (src/monitoring/), following the established sentinel pattern (deps injection, `lastTickAt` liveness, tick loop, dark-gate via `DEV_GATED_FEATURES`, GuardRegistry registration). It introduces **no** new ownership primitive and **never mutates** ownership, pins, or sessions — its sole output is an aggregated attention item.
+
+Per tick (synchronous, LLM-free, acquires NO spawn-cap slot — this invariant is asserted in a test so a future "ask an LLM if it's stranded" can never silently land on the monitoring hot path):
+
+1. **Early no-op gates (fail-closed):** if `machines().length < 2` → strict return (single-machine can't strand on a peer). If this machine is NOT the lease-holder (`!syncStatus.holdsLease`) → return (sole actor, so peers don't each raise a duplicate item). If the machine-pool view is unavailable/stale past a freshness bound → return (can't assess → assess nothing).
+2. **Scan ownership records** from the in-memory cache (`ownership.all()`, ~25 records; the cache makes this cheap — no per-tick disk re-scan). For each `active` record whose owner ≠ self:
+   - read the owner's `MachineCapacity` from the replicated heartbeat view (in-memory, NO synchronous peer probe).
+   - **owner online?** if not online → SKIP (a dead owner is the existing Case C's job; this sentinel only covers the *online-but-unable* gap).
+   - **owner unable to serve?** Two arms, evaluated against the owner's latest rich beat:
+     - **(a) quota arm — channel-independent, the dominant incident case:** `quotaState.blocked === true`. A quota-walled owner cannot serve ANY topic, so this needs NO channel resolution and covers the live incident (a quota-walled Mini owning 17 topics) directly.
+     - **(b) adapter arm — best-effort, channel-specific:** derive the topic's `ChannelScope` (`{platform, chatId|workspaceId}`) from the topic's owning adapter binding (the platform from the topic→adapter mapping; the chat/workspace id from that adapter's config). **Honesty about the source (verified):** there is NO topic→`{platform,chatId}` registry — `TopicBinding`/`TopicProjectBinding` holds project name/dir, not a channel scope. For Telegram the `chatId` is shared adapter config, identical across all machines, so the adapter arm almost never qualifies for Telegram and the **quota arm carries the Telegram case** (exactly the live incident); the adapter arm's real value is the **Slack per-workspace** case (`slack.workspaceIds`). When the scope can't be fully derived, `scope === undefined`. Then call the canonical three-valued `machineServesChannel(servesChannels, scope)`: a result of **`'no'`** (the owner's adapter set structurally excludes the topic's channel) qualifies; **`'unknown'`** (missing/sparse `servesChannels`, OR `scope === undefined`) ⇒ **SKIP**; **`'yes'`** ⇒ owner can serve → not stranded on this arm. (Note: the predicate is `machineServesChannel(...) === 'no'` — NOT `!machineServesChannel(...)`; the function returns a string, so the boolean-negation idiom would be always-false and the detector would never fire.)
+   - **Fail-closed on uncertainty throughout:** a missing field, an undecodable beat, or an underivable channel scope can NEVER manufacture a strand — it routes to SKIP. (The quota arm carries detection on its own when the adapter arm must skip.)
+   - **persistence:** the unable-to-serve condition must hold across **≥2 consecutive genuine rich heartbeats** spanning **≥ `dwellMs`** (default 30s, the reconciler's debounce reference), tracked in a per-topic `strandedSince` map. A single beat, a sparse liveness-echo beat, or a beat older than the freshness bound does NOT qualify (fail-closed). This kills false positives from a transient quota/adapter blip.
+   - **`strandedSince` map reconciliation (no stale residue):** at the END of every tick, the map is reconciled against THIS tick's evaluated candidate set — any key that did NOT re-qualify this tick (its owner went offline, the ownership record was released/deleted, or its scope became underivable, so it fell out via a SKIP rather than by clearing) is **deleted**, not left to resume counting later. This prevents a stale entry from surviving an owner-offline interlude and then short-circuiting the dwell on a later strand. (Bounded anyway by topic count, but correctness — not size — is the point.)
+   - if it qualifies → add to this tick's stranded set, annotated with whether a **servable peer exists** — narrowly "an online machine that is not quota-blocked AND `machineServesChannel(...) === 'yes'` for the topic's channel" (reusing the PlacementExecutor filter so detector and placement agree). This is deliberately NOT "a safe failover target": it does not vet pin policy, lease/router readiness, secrets, or session limits, and v1 does not fail over — it only tells the operator "somewhere could serve this" vs "nowhere can (fleet-wide wall)", never "I can safely move it there."
+3. **Emit ONE aggregated attention item** for the whole stranded set (never one-per-topic). The dedup key is **(owner-machine, stranding-window-id)** where the window-id is the FIRST qualifying `strandedSince` timestamp for that owner rounded to the dwell epoch; the window stays open (same id → same item, updated in place) until that owner has had **zero stranded topics for N consecutive ticks** (default 3), then closes. A topic-set change or a reason change (quota↔adapter) UPDATES the open item, never opens a new one — so a partial heal or a churn can't spam. It rides the existing `AttentionTopicGuard` flood ceiling (3/source, 8/global per 10min; HIGH/URGENT bypass). The item states the stranded topics, the walled owner + reason (quota / adapter), and whether a healthy server exists ("inbound for these topics is going to <machine>, which can't serve them; <healthy machine> can" vs "no machine can currently serve them — fleet-wide wall"). **The item discloses the signal's staleness** — it appends the owner's last-rich-heartbeat age ("based on <machine>'s last full heartbeat <age> ago") so the operator reads it as an observation to act on, not an over-trusted verdict (Observable Intelligence — the detector knows the signal is up to `failoverThresholdMs` stale; the operator should too). When an owner's stranded set is empty for N ticks, its `strandedSince` entries are cleared and the window closes.
+4. **Separate low-severity "can't-assess" signal (the anti-blind-spot guard).** Because predicate step 2 fail-closes on missing/stale/sparse `servesChannels`/`quotaState` (correct, to avoid false strands), a rollout/schema regression that strips those fields would silently BLIND the detector — the exact invisible-failure class this feature exists to kill. So the sentinel ALSO emits ONE separate LOW-severity attention item (and a `/guards` note) when it had to skip ≥1 online owner because its rich heartbeat fields were missing/unparseable, naming the count. This makes "I can't see whether these machines can serve" itself visible, rather than reading as "all clear".
+
+## Decision points touched
+
+This INTRODUCES no new authority. It adds a read-only detector that raises an advisory attention item. It mutates nothing, kills nothing, sends no direct user message. It can only ever ADD an attention item (which the existing flood ceiling already bounds).
+
+## Frontloaded Decisions
+
+- **D1 — Detector-only v1, dark-gated, pure-signal.** `monitoring.strandedTopicSentinel.enabled` registered in `DEV_GATED_FEATURES` (`enabled` OMITTED from ConfigDefaults ⇒ dev-live / dark-fleet); flag-off is byte-identical to today (no detector). No `migrateConfig` entry needed (the flag is omitted, not defaulted). *Cheap-to-change-after:* the flag; and because v1 never mutates, there is no durable-side-effect / identity / money decision in scope — the Decision-Completeness "never cheap" taxonomy does not bite.
+- **D2 — Detection predicate = `online && (quotaState.blocked === true || machineServesChannel(servesChannels, scope) === 'no')`, persisted ≥2 rich beats over ≥`dwellMs`, with `'unknown' ⇒ skip` and any missing field / underivable scope ⇒ skip.** (Written against the three-valued `ServeResult` enum — NOT `!machineServesChannel(...)`, which is always-false against a string and would make the detector never fire.) Reuses the canonical PlacementExecutor serve/quota helpers (no re-derivation → no drift). **Serve-check granularity = the adapter's actual connection unit** (workspace for Slack via `slack.workspaceIds`, chat for Telegram via `telegram.chatIds`) — finer (sub-workspace Slack #channel) granularity does not exist in `servesChannels` and is explicitly out of v1 scope; because v1 only raises an advisory attention item, a granularity-induced false positive is a cheap mis-flag, never a wrong mutation (this is exactly why the mutation, where it WOULD matter, is deferred <!-- tracked: CMT-1786 -->). *Cheap-to-change-after:* the predicate is one pure function; thresholds are config (`dwellMs`, freshness bound, `tickMs` default 60s).
+- **D3 — ONE aggregated attention item, dedup key = (owner-machine, stranding-window).** Rides `AttentionTopicGuard`'s ceiling; a partial/moved re-strand stays one item. *Cheap-to-change-after:* the dedup key.
+- **D4 — Lease-holder is the sole actor; single-machine = strict early-return no-op.** Reads `syncStatus.holdsLease`; mirrors the reconciler's `machines().length < 2` early return. The known lease-self-determination staleness (`FencedLease.ts:164` `effectiveEpoch`) is acceptable here: worst case a just-demoted machine raises ONE extra *advisory* item — harmless for a pure signal (it would be a real bug for a mutation, which is exactly why the mutation is deferred <!-- tracked: CMT-1786 -->). *Cheap-to-change-after:* the actor gate.
+- **D5 — Synchronous, LLM-free, no spawn-cap slot, no synchronous peer probe; reads the in-memory replicated heartbeat view + the in-memory ownership cache, with an explicit fail-closed staleness bound.** Asserted by test. **Ownership-cache readiness:** the sentinel reads the SAME in-memory ownership cache the `SessionOwnershipRegistry` keeps current (load-on-boot + write-through on every CAS); if that cache has not yet hydrated (registry not ready post-boot/post-failover), the tick fail-closes (skips) and the `/guards` row reports `degraded` rather than scanning a half-populated cache. *Cheap-to-change-after:* the freshness bound is config.
+- **D6 — GuardRegistry registration + `GET /guards` posture row + `lastTickAt` liveness + status route.** So a silently-disabled detector is itself visible on `/guards` (the exact failure class this feature exists to kill). *Cheap-to-change-after:* additive.
+
+## Multi-machine posture
+
+Machine-local detection reading the **replicated** heartbeat machine-pool view + the local in-memory ownership cache; it emits a local attention item only. **Single-machine = strict no-op** (`machines().length < 2`). **Lease-holder is the sole actor**, so across machines exactly one raises the item (no duplicate-voice). No durable state is written, so there is nothing to replicate, proxy, or strand on a topic transfer.
+
+## Signal vs authority
+
+**Pure signal.** The sentinel raises an advisory attention item and writes nothing else — no ownership CAS, no pin write, no session kill, no direct user message. It has no authority to misuse; the operator/agent decides what to do with the surfaced strand. (This is the deliberate, review-driven retreat from the original mutating design.)
+
+## Deferred — the v2 failover (separate spec/PR, prerequisites named) <!-- tracked: CMT-1786 -->
+
+Auto-failover (CAS-reassign a stranded topic to a healthy server) is the eventual goal but is gated on building the primitives that make it safe. Its spec must deliver ALL of:
+- **A per-topic remote-session-liveness signal** — extend the heartbeat with the set of topic-ids that have live sessions on each machine (NOT a synchronous peer probe — scalability forbids that on the monitoring path), so "no live session for THIS topic on the owner" is evaluable; fail-closed when unknown. <!-- tracked: CMT-1786 -->
+- **Temporal corroboration / hysteresis** — ≥N consecutive rich blocked beats + a minimum block dwell, replacing the inert 2-machine quorum for the `owner-unreachable` trigger; a per-topic heal cooldown; a freshly-healed-pin-authoritative dwell so an un-walling owner doesn't immediately reclaim (anti-flap). <!-- tracked: CMT-1786 -->
+- **Claim-time re-assertion** — re-check target `online && machineServesChannel` against the freshest local view immediately before the CAS; prefer self (lease-holder) as target since its liveness is locally certain. <!-- tracked: CMT-1786 -->
+- **Atomic CAS + pin-repoint** — define the transaction boundary (single journal entry, or a compensating-retry idempotency loop) so a CAS-succeeds-pin-fails partial can't reintroduce `pendingReplacement` churn. <!-- tracked: CMT-1786 -->
+- **A distinct reason-stamped nonce** (`stranded-selfheal:<target>:<epoch>:<ts>`, matching the reconciler's `<self>:<reason>:<key>:<now>` convention, NOT the applier nonce) so the replay-guard/audit distinguish a heal from an adoption. <!-- tracked: CMT-1786 -->
+- **Structural disjointness from `OwnershipReconciler`** — restrict to `active` records (never `released`/`transferring`); the atomic pin-repoint makes the reconciler converge *toward* the new target rather than fight it. (Note: cross-machine CAS is last-writer-wins at the git-ref level — the loser re-evaluates — NOT "synchronous torn-write-free"; the framing matters for reasoning about two engines.) <!-- tracked: CMT-1786 -->
+- **Unify `StrandedTopicSentinel`'s detection with `OwnershipReconciler`** into one convergence engine, or prove their triggers disjoint. <!-- tracked: CMT-1786 -->
+
+## Operator/agent remediation (v1 — what to do with the alert)
+
+The detector converts a silent failure into a loud one; v1's remediation is still **manual but now reliably triggered**. When the alert fires, the safe recovery (the same one performed by hand during the live incident) is: confirm the owner genuinely can't serve (quota-walled / adapter-down) via `GET /pool/placement` + the machine view, then re-point the topic's durable ownership record (`.instar/ownership/local/<topicId>.json`) to a healthy server (owner→healthy machine, `ownershipEpoch`+1, applier-format nonce), clear any stale pin, and reload — verifying `pendingReplacement:false` after. **Preconditions:** the target must be a servable peer (the alert names whether one exists); never re-point onto another machine that also can't serve. **What NOT to do:** do not edit the record while the owner has a genuinely live, recovering session for that topic (v1 can't see per-topic remote liveness — that's exactly the gap the v2 auto-failover's prerequisite closes); when in doubt, wait a beat and re-confirm. Automating this remediation safely IS the v2 work below.
+
+## Out of scope
+
+- A live userbot harness to drive real-Telegram inbound end-to-end in regular UX regression tests (needs a Telegram user account; bots cannot see each other's messages). <!-- tracked: CMT-1786 -->
+
+## Open questions
+
+*(none)*

--- a/src/commands/server.ts
+++ b/src/commands/server.ts
@@ -18860,6 +18860,62 @@ export async function startServer(options: StartOptions): Promise<void> {
             carrier: _topicProfileCarrier,
           }
         : null;
+
+    // ── StrandedTopicSentinel (stranded-inbound-self-heal) — PURE SIGNAL ──────
+    // Detects a topic whose owner machine is online-by-heartbeat but unable to
+    // serve (quota-walled or adapter-disconnected) while a healthy machine holds
+    // the lease, so inbound is silently dead for that topic. Raises ONE
+    // aggregated agent-health attention item per (owner-machine, stranding
+    // window); MUTATES NOTHING (no ownership CAS, no pin write, no session kill).
+    // developmentAgent dark-feature gate: LIVE on a dev agent, DARK on the fleet.
+    // Lease-holder is the sole actor; single-machine = strict no-op. GET /guards.
+    // Wired here (late) because it depends on machinePoolRegistry +
+    // sessionOwnershipRegistry + _meshSelfId, all assigned during pool boot.
+    const _strandedEnabled = resolveDevAgentGate(config.monitoring?.strandedTopicSentinel?.enabled, config);
+    if (_strandedEnabled && machinePoolRegistry && sessionOwnershipRegistry) {
+      try {
+        const { StrandedTopicSentinel } = await import('../monitoring/StrandedTopicSentinel.js');
+        const _ownReg = sessionOwnershipRegistry;
+        const _poolReg = machinePoolRegistry;
+        const _nickById = (id: string): string =>
+          (_listPoolMachines?.() ?? []).find((m) => m.machineId === id)?.nickname ?? id;
+        const strandedSentinel = new StrandedTopicSentinel(
+          {
+            listOwnershipRecords: () => _ownReg.all(),
+            listCapacities: () => _poolReg.getCapacities(),
+            selfMachineId: () => _meshSelfId,
+            holdsLease: () => (leaseCoordinatorRef ? leaseCoordinatorRef.holdsLease() : coordinator.holdsLease()),
+            raiseAttention: (item) => {
+              if (!telegram) return;
+              void telegram.createAttentionItem({
+                id: item.id,
+                title: item.title,
+                summary: item.summary,
+                description: item.description,
+                category: item.category,
+                priority: item.priority,
+                sourceContext: item.sourceContext,
+                lane: item.lane,
+                healthKey: item.healthKey,
+              });
+            },
+            nicknameOf: _nickById,
+            now: () => Date.now(),
+          },
+          { ...config.monitoring?.strandedTopicSentinel, enabled: _strandedEnabled },
+        );
+        strandedSentinel.start();
+        guardRegistry.register('monitoring.strandedTopicSentinel.enabled', () => strandedSentinel.guardStatus());
+        console.log(pc.green('  StrandedTopicSentinel enabled (online-but-unable-to-serve detector — pure signal)'));
+      } catch (e) {
+        // @silent-fallback-ok — optional dev-gated, pure-signal feature: a wiring
+        // failure is logged (console.error, NOT silent) and is non-fatal BY DESIGN
+        // — the monitoring sentinel must never crash server boot. Nothing to
+        // degrade-report or fall back to; the server runs without the detector.
+        console.error('  StrandedTopicSentinel wiring failed (non-fatal):', e instanceof Error ? e.message : String(e));
+      }
+    }
+
     const server = new AgentServer({ config, sessionManager, state, scheduler, telegram, relationships, feedback, feedbackAnomalyDetector, dispatches, updateChecker, autoUpdater, autoDispatcher, quotaTracker, quotaManager, publisher, viewer, tunnel, evolution, watchdog, topicMemory, triageNurse, projectMapper, cartographer: cartographer ?? undefined, coherenceGate: scopeVerifier, contextHierarchy, canonicalState, operationGate, sentinel, adaptiveTrust, memoryMonitor, orphanReaper, coherenceMonitor, commitmentTracker, subscriptionPool, accountFollowMePeerViews: async () => { const nickById = new Map((_listPoolMachines?.() ?? []).map((m) => [m.machineId, m.nickname ?? m.machineId])); let peers = (_resolvePeerUrls?.() ?? []).map((p) => ({ machineId: p.machineId, nickname: nickById.get(p.machineId) ?? p.machineId, url: p.url })); if (peers.length === 0) { peers = (_listPoolMachines?.() ?? []).filter((m) => m.machineId !== _meshSelfId && !!m.lastKnownUrl).map((m) => ({ machineId: m.machineId, nickname: m.nickname ?? m.machineId, url: m.lastKnownUrl as string })); } if (peers.length === 0) return []; const { fetchPeerSubscriptionViews } = await import('../core/fetchPeerSubscriptionViews.js'); return fetchPeerSubscriptionViews({ peers: () => peers, fetchImpl: fetch as unknown as Parameters<typeof fetchPeerSubscriptionViews>[0]['fetchImpl'], authToken: config.authToken ?? '' }); }, quotaPoller, quotaAwareScheduler: _quotaAwareScheduler ?? undefined, proactiveSwapMonitor: _proactiveSwapMonitor ?? undefined, inUseAccountResolver, enrollmentWizard, accountFollowMeRevocation, credentialRepointing, semanticMemory, activitySentinel, rateLimitSentinel, releaseReadinessSentinel: releaseReadinessSentinel ?? undefined, greenPrAutoMerger: greenPrAutoMerger ?? undefined, guardLatchStore: guardLatchStore ?? undefined, messageRouter, summarySentinel, spawnManager, systemReviewer, capabilityMapper, selfKnowledgeTree, coverageAuditor, topicResumeMap: _topicResumeMap ?? undefined, topicProfile: _topicProfileCtx ?? undefined, sessionRefresh: _sessionRefresh ?? undefined, autonomyManager, trustElevationTracker, autonomousEvolution, coordinator: coordinator.enabled ? coordinator : undefined, meshBindActive: coordinator.managers.identityManager.hasIdentity() && config.multiMachine?.meshTransport?.enabled !== false, localSigningKeyPem, leaseTransport, peerEndpointRecorder, getSelfMeshEndpoints, onLeasePullRequest: () => leaseCoordinatorRef?.currentLease() ?? null, liveTailReceiver, handoffWireTransport, onHandoffBegin, onHandoffInitiate: handoffInitiate, handoffInProgress: handoffSentinelInProgress, messageLedger, currentInboundByTopic, replyMarkerTransport, onReplyMarker: messageLedger ? (marker: unknown) => { const m = marker as { dedupeKey: string; platform: string; replyIdempotencyKey: string; epoch: number; topic?: string | null }; messageLedger!.applyRemoteReplyMarker(m.dedupeKey, { platform: m.platform, replyIdempotencyKey: m.replyIdempotencyKey, epoch: m.epoch, topic: m.topic ?? null }); } : undefined, whatsapp: whatsappAdapter, slack: slackAdapter, imessage: imessageAdapter, whatsappBusinessBackend, messageBridge, hookEventReceiver, worktreeMonitor, subagentTracker, instructionsVerifier, handshakeManager: threadlineHandshake, threadlineRouter, conversationStore, threadLog, threadMessageRecorder, warrantsReplyGate, collaborationSurfacer, threadResumeMap, topicLinkageHandler: topicLinkageHandler ?? undefined, threadlineRelayClient, threadlineReplyWaiters, listenerManager: listenerManager ?? undefined, a2aDeliveryTracker: a2aDeliveryTracker ?? undefined, responseReviewGate, messagingToneGate, outboundDedupGate, telemetryHeartbeat, pasteManager, featureRegistry, discoveryEvaluator, completionEvaluator, unifiedTrust, liveConfig, sharedStateLedger, ledgerSessionRegistry, worktreeManager, oidcEnrolledRepos: parallelDevConfig?.oidcEnrolledRepos, initiativeTracker, projectRoundRunner, projectDriftChecker, machineHeartbeat, machinePoolRegistry, getInboundQueue: () => _inboundQueue, meshRpcDispatcher, workingSetPullCoordinator, commitmentReplicaStore, preferenceReplicaStore, replicatedRecordEmitter, conflictStore, rollbackUnmerge, droppedOriginRegistry, preferencesUnionReader, forwardCommitmentMutate, sessionOwnershipRegistry, topicPinStore: _topicPinStore ?? undefined, streamTicketStore: _streamTicketStore ?? undefined, poolStreamAllowRemoteInput: (config as { dashboard?: { poolStream?: { allowRemoteInput?: boolean } } }).dashboard?.poolStream?.allowRemoteInput ?? false, poolStreamConnector: _poolStreamConnector ?? undefined, secretSync: _secretSyncHandle ?? undefined, meshSelfId: _meshSelfId ?? undefined, resolveRouterUrl: _resolveRouterUrl ?? undefined, resolvePeerUrls: _resolvePeerUrls ?? undefined, guardRegistry, listPoolMachines: _listPoolMachines ?? undefined, deliverMandateToMachine: _deliverMandateToMachine ?? undefined, poolLink: _poolLink ?? undefined, poolPollCache: _poolPollCache ?? undefined, sessionPoolE2EResultStore, proxyCoordinator, topicIntentStore, topicIntentArcCheck, usherSignalStore, intelligence: sharedIntelligence ?? undefined, telegramBridgeConfig, telegramBridge: telegramBridge ?? undefined, threadlineObservability, briefDeps, workingMemory, taskFlowRegistry, threadlineFlowBridge, sessionReaper, agentWorktreeReaper, orphanedWorkSentinel, mcpProcessReaper, geminiLoopRunner, sleepController, agentActivityState, reapLog, resumeQueue, resumeDrainer, autonomousLivenessReconciler, prHandLease: prHandLease ?? undefined, operatorStopRecorder: recordOperatorStop, sleepWakeDetector, unjustifiedStopGate, stopGateDb, stopNotifier, liveTestGate, liveTestGateMode, liveTestRunnerCtx });    // Resolve the late-bound topic-operator getter (increment 2e): routing was
     // wired before the server existed; from here on inbound binds use the
     // server's own store instance.

--- a/src/config/ConfigDefaults.ts
+++ b/src/config/ConfigDefaults.ts
@@ -291,6 +291,20 @@ const SHARED_DEFAULTS: Record<string, unknown> = {
       preserveWork: false,
       maxFlagsPerPass: 10,
     },
+    // StrandedTopicSentinel (stranded-inbound-self-heal): a PURE-SIGNAL detector
+    // that surfaces a topic whose owner machine is online-by-heartbeat but unable
+    // to serve (quota-walled or adapter-disconnected) while a healthy machine
+    // holds the lease, so inbound is silently dead for that topic. Raises ONE
+    // aggregated attention item per (owner-machine, stranding window); MUTATES
+    // NOTHING. `enabled` is OMITTED so the runtime resolves it through the
+    // standard developmentAgent dark-feature gate (resolveDevAgentGate): LIVE on a
+    // dev agent, DARK on the fleet. Registered in DEV_GATED_FEATURES; GET /guards.
+    strandedTopicSentinel: {
+      tickMs: 60_000,
+      dwellMs: 30_000,
+      freshnessBoundMs: 45_000,
+      clearAfterTicks: 3,
+    },
     // Build-Session Yield Safety (ACT-839): a reaped session with uncommitted
     // worktree work becomes resume-eligible + gets a tracked commit-or-preserve
     // obligation. `enabled` is OMITTED so the developmentAgent dark-feature gate

--- a/src/core/SessionOwnershipRegistry.ts
+++ b/src/core/SessionOwnershipRegistry.ts
@@ -71,6 +71,13 @@ export interface SessionOwnershipStore {
    * freshly-reread record) if a peer advanced first (non-fast-forward reject).
    */
   casWrite(candidate: SessionOwnershipRecord): { ok: boolean; observed: SessionOwnershipRecord | null };
+  /**
+   * Every known record from the store's in-memory cache (StrandedTopicSentinel
+   * scan). Optional: a store that can't enumerate cheaply omits it and the
+   * registry's `all()` reads empty. Both shipped stores (InMemory + Local)
+   * implement it.
+   */
+  all?(): SessionOwnershipRecord[];
 }
 
 export interface SessionOwnershipRegistryDeps {
@@ -111,6 +118,16 @@ export class SessionOwnershipRegistry {
 
   read(sessionKey: string): SessionOwnershipRecord | null {
     return this.d.store.read(sessionKey);
+  }
+
+  /**
+   * Every known ownership record from the underlying store's in-memory cache
+   * (StrandedTopicSentinel scan — stranded-inbound-self-heal). A store without an
+   * `all()` (none ship today) reads as empty: the sentinel then has nothing to
+   * scan (the safe direction — it can only raise an item it has evidence for).
+   */
+  all(): SessionOwnershipRecord[] {
+    return this.d.store.all?.() ?? [];
   }
 
   /** The current owner machine of a session (null if none / released). */

--- a/src/core/devGatedFeatures.ts
+++ b/src/core/devGatedFeatures.ts
@@ -288,6 +288,14 @@ export const DEV_GATED_FEATURES: DevGatedFeature[] = [
       'Signal-only local recorder + ONE deduped attention item; reads git status/diff + lsof read-only; no egress, no spend, no destructive action. The optional preservation is a NON-destructive patch write (git diff → a state-dir file) behind an off-by-default preserveWork sub-flag — it never mutates the worktree, its index, or any ref.',
   },
   {
+    name: 'strandedTopicSentinel',
+    configPath: 'monitoring.strandedTopicSentinel.enabled',
+    description:
+      'Stranded-inbound detector (stranded-inbound-self-heal) — surfaces a Telegram/Slack topic whose owner machine is online-by-heartbeat but unable to serve (quota-walled or adapter-disconnected) while a healthy machine holds the lease, so inbound is silently dead for that topic. Raises ONE aggregated attention item per (owner-machine, stranding window).',
+    justification:
+      'PURE SIGNAL — its sole output is an advisory attention item; it MUTATES NOTHING (no ownership CAS, no pin write, no session kill, no direct user message). Lease-holder is the sole actor and a single-machine agent is a strict no-op, so across machines exactly one raises the item (no duplicate-voice). Synchronous + LLM-free + acquires NO spawn-cap slot (asserted by test); reads only the in-memory ownership cache + the replicated heartbeat pool view, with an explicit fail-closed staleness bound (every uncertainty — missing field, stale beat, underivable scope, pool view unavailable — routes to SKIP, never manufactures a strand). It can only ever ADD an attention item, already bounded by the existing AttentionTopicGuard flood ceiling. No egress beyond the operator-facing item, no spend, no destructive action. Runs live (no destructive write warrants a dry-run) on dev / dark on fleet. Auto-failover is a tracked v2 with named prerequisites.',
+  },
+  {
     name: 'yieldSafety',
     configPath: 'monitoring.yieldSafety.enabled',
     description:

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -4925,6 +4925,28 @@ export interface MonitoringConfig {
     maxFlagsPerPass?: number;
   };
   /**
+   * StrandedTopicSentinel (stranded-inbound-self-heal) — a pure-signal detector
+   * that surfaces a Telegram/Slack topic whose owner machine is online-by-
+   * heartbeat but unable to serve (quota-walled or adapter-disconnected) while a
+   * healthy machine holds the lease, so inbound is silently dead for that topic.
+   * Raises ONE aggregated attention item per (owner-machine, stranding window);
+   * MUTATES NOTHING (no ownership CAS, no pin write, no session kill). `enabled`
+   * is OMITTED from ConfigDefaults so the developmentAgent dark-feature gate
+   * decides (LIVE on dev, DARK on fleet). Registered in DEV_GATED_FEATURES.
+   * GET /guards row + lastTickAt liveness.
+   */
+  strandedTopicSentinel?: {
+    enabled?: boolean;
+    /** Tick cadence (ms). Default 60s. */
+    tickMs?: number;
+    /** Dwell the unable-to-serve condition must hold before emitting (ms). Default 30s. */
+    dwellMs?: number;
+    /** A beat older than this is not a genuine rich beat (ms). Default 45s. */
+    freshnessBoundMs?: number;
+    /** Owner must have zero stranded topics for N consecutive ticks before its window closes. Default 3. */
+    clearAfterTicks?: number;
+  };
+  /**
    * Build-Session Yield Safety (ACT-839; spec BUILD-SESSION-YIELD-SAFETY-SPEC).
    * A reaped session whose worktree holds uncommitted work becomes resume-
    * eligible (a new `uncommitted-worktree-work` WorkEvidence value, collected

--- a/src/monitoring/StrandedTopicSentinel.ts
+++ b/src/monitoring/StrandedTopicSentinel.ts
@@ -1,0 +1,282 @@
+/**
+ * StrandedTopicSentinel — a pure-signal, dark-gated monitoring sentinel that
+ * detects a Telegram/Slack topic whose owner machine is online-but-unable-to-
+ * serve and raises ONE aggregated attention item per (owner-machine, stranding
+ * window). It MUTATES NOTHING — no ownership CAS, no pin write, no session kill.
+ *
+ * The wedge (proven live 2026-06-24): a durable ownership record names a machine
+ * that is online-by-heartbeat but quota-walled or adapter-disconnected, while a
+ * healthy machine holds the lease. Inbound routes to the owner that cannot serve
+ * it → silently dead for that topic; outbound still flows from the healthy
+ * machine (the "my replies send but his messages never arrive" split). The
+ * existing OwnershipReconciler (Case C) only fires on a PROVABLY-DEAD owner, so a
+ * walled-but-online owner defers forever — this sentinel covers that gap.
+ *
+ * Per tick (synchronous, LLM-free, acquires NO spawn-cap slot — asserted by test
+ * so a future "ask an LLM if it's stranded" can never silently land on the
+ * monitoring hot path):
+ *   1. early no-op gates (< 2 machines / not lease-holder / pool view stale)
+ *   2. evaluate the PURE decision over the in-memory ownership cache + pool view
+ *   3. emit ONE aggregated attention item per owner stranding-window
+ *   4. emit ONE separate LOW "can't-assess" item when ≥1 online owner was
+ *      skipped for missing/unparseable rich heartbeat fields (anti-blind-spot)
+ *
+ * Spec: docs/specs/stranded-inbound-self-heal.md
+ *
+ * Signal-vs-authority: PURE SIGNAL. The only output is an advisory attention
+ * item; it has no authority to misuse. (The auto-failover is a tracked v2 with
+ * its prerequisites named in the spec.)
+ */
+
+import { EventEmitter } from 'node:events';
+import type { SessionOwnershipRecord } from '../core/SessionOwnership.js';
+import type { MachineCapacity } from '../core/types.js';
+import type { ChannelScope } from '../core/machineServesChannel.js';
+import {
+  evaluateStrandedTopics,
+  type StrandedTopic,
+  type StrandReason,
+} from './strandedTopicDecision.js';
+
+export interface StrandedTopicSentinelConfig {
+  enabled?: boolean;
+  /** Tick cadence (ms). Default 60s. */
+  tickMs?: number;
+  /** Dwell the unable-to-serve condition must hold before emitting (ms). Default 30s. */
+  dwellMs?: number;
+  /** A beat older than this is not a genuine rich beat (ms). Default = failover threshold (45s). */
+  freshnessBoundMs?: number;
+  /** Owner must have ZERO stranded topics for N consecutive ticks before its
+   *  window closes. Default 3. */
+  clearAfterTicks?: number;
+}
+
+const DEFAULT_CONFIG: Required<StrandedTopicSentinelConfig> = {
+  enabled: false,
+  tickMs: 60_000,
+  dwellMs: 30_000,
+  freshnessBoundMs: 45_000,
+  clearAfterTicks: 3,
+};
+
+/** The raise/update payload for the aggregated attention item. */
+export interface StrandAttentionItem {
+  id: string;
+  title: string;
+  summary: string;
+  description: string;
+  category: string;
+  priority: 'LOW' | 'NORMAL';
+  sourceContext: string;
+  lane: 'agent-health';
+  healthKey: string;
+}
+
+export interface StrandedTopicSentinelDeps {
+  /** All known ownership records (the in-memory `all()` scan). */
+  listOwnershipRecords: () => SessionOwnershipRecord[];
+  /** The replicated machine-pool capacities (in-memory view). */
+  listCapacities: () => MachineCapacity[];
+  /** This machine's id (null on a single-machine agent → never strands). */
+  selfMachineId: () => string | null;
+  /** Whether this machine holds the serving lease. */
+  holdsLease: () => boolean;
+  /** Raise/update an attention item (the sole output). Never throws upward. */
+  raiseAttention: (item: StrandAttentionItem) => void;
+  /** Resolve a topic's ChannelScope (adapter arm). Optional. */
+  resolveScope?: (sessionKey: string) => ChannelScope | undefined;
+  /** Resolve a machine's display nickname (for the item text). */
+  nicknameOf?: (machineId: string) => string;
+  /** Override Date.now (tests). */
+  now?: () => number;
+}
+
+export class StrandedTopicSentinel extends EventEmitter {
+  private readonly cfg: Required<StrandedTopicSentinelConfig>;
+  private tickHandle: ReturnType<typeof setInterval> | null = null;
+  /** Liveness of the tick loop (GUARD-POSTURE §2.2): 0 = never ticked. */
+  private lastTickAt = 0;
+  /** Per-topic dwell anchor carried across ticks. */
+  private strandedSince: Record<string, number> = {};
+  /** Per-owner consecutive-empty-tick count (window close discipline). */
+  private emptyTicks = new Map<string, number>();
+  /** Per-owner open stranding-window id (the dwell-epoch of the first strand). */
+  private windowId = new Map<string, number>();
+
+  constructor(
+    private readonly deps: StrandedTopicSentinelDeps,
+    cfg: StrandedTopicSentinelConfig = {},
+  ) {
+    super();
+    this.cfg = { ...DEFAULT_CONFIG, ...cfg };
+  }
+
+  start(): void {
+    if (!this.cfg.enabled || this.tickHandle) return;
+    this.tickHandle = setInterval(() => {
+      try {
+        this.tick();
+      } catch (err) {
+        // @silent-fallback-ok — pure-signal sentinel: a tick error must NEVER
+        // propagate or degrade anything (it mutates nothing). The error is
+        // surfaced as a 'tick-error' event for observability; swallowing the
+        // throw IS the correct fail-closed behavior, not a hidden degradation.
+        this.emit('tick-error', { err });
+      }
+    }, this.cfg.tickMs);
+    if (typeof this.tickHandle.unref === 'function') this.tickHandle.unref();
+  }
+
+  stop(): void {
+    if (this.tickHandle) {
+      clearInterval(this.tickHandle);
+      this.tickHandle = null;
+    }
+  }
+
+  /** One synchronous scan pass. LLM-free, no spawn-cap slot, no peer probe. */
+  tick(): void {
+    const now = (this.deps.now ?? Date.now)();
+    this.lastTickAt = now;
+    if (!this.cfg.enabled) return;
+
+    const selfId = this.deps.selfMachineId();
+    if (!selfId) {
+      // Single-machine agent (no mesh id) → strict no-op; drop any stale state.
+      this.strandedSince = {};
+      this.emptyTicks.clear();
+      this.windowId.clear();
+      return;
+    }
+
+    const result = evaluateStrandedTopics({
+      records: this.deps.listOwnershipRecords(),
+      capacities: this.deps.listCapacities(),
+      selfMachineId: selfId,
+      holdsLease: this.deps.holdsLease(),
+      prevStrandedSince: this.strandedSince,
+      now,
+      cfg: { dwellMs: this.cfg.dwellMs, freshnessBoundMs: this.cfg.freshnessBoundMs },
+      resolveScope: this.deps.resolveScope,
+    });
+
+    // Reconcile the dwell map (delete stale keys — spec step 2).
+    this.strandedSince = result.nextStrandedSince;
+
+    // Group the stranded set by owner for the aggregated item.
+    const byOwner = new Map<string, StrandedTopic[]>();
+    for (const s of result.strandedSet) {
+      const list = byOwner.get(s.ownerMachineId) ?? [];
+      list.push(s);
+      byOwner.set(s.ownerMachineId, list);
+    }
+
+    // Emit / update one item per owner with a non-empty stranded set; advance
+    // the window-close discipline for every owner we have tracked.
+    const seenOwners = new Set<string>();
+    for (const [owner, topics] of byOwner) {
+      seenOwners.add(owner);
+      this.emptyTicks.set(owner, 0);
+      this.emitOwnerItem(owner, topics, now);
+    }
+
+    // Window close: an owner with no strand this tick increments its empty-tick
+    // count; after clearAfterTicks it closes (drops its window).
+    for (const owner of [...this.windowId.keys()]) {
+      if (seenOwners.has(owner)) continue;
+      const n = (this.emptyTicks.get(owner) ?? 0) + 1;
+      if (n >= this.cfg.clearAfterTicks) {
+        this.windowId.delete(owner);
+        this.emptyTicks.delete(owner);
+        this.emit('window-closed', { owner });
+      } else {
+        this.emptyTicks.set(owner, n);
+      }
+    }
+
+    // Separate LOW "can't-assess" anti-blind-spot signal (spec step 4).
+    if (result.cantAssessCount > 0) {
+      this.emitCantAssessItem(result.cantAssessCount, now);
+    }
+  }
+
+  private emitOwnerItem(owner: string, topics: StrandedTopic[], now: number): void {
+    // The window-id is the FIRST qualifying strandedSince for this owner rounded
+    // to the dwell epoch; it stays the same across a partial heal so the item
+    // updates in place rather than spawning a new one (spec step 3).
+    let windowId = this.windowId.get(owner);
+    if (windowId === undefined) {
+      const earliest = Math.min(...topics.map((t) => t.strandedSince));
+      windowId = Math.floor(earliest / this.cfg.dwellMs) * this.cfg.dwellMs;
+      this.windowId.set(owner, windowId);
+    }
+
+    const nick = this.deps.nicknameOf?.(owner) ?? owner;
+    const reasons = new Set<StrandReason>(topics.map((t) => t.reason));
+    const reasonText = [...reasons].join(' / ');
+    const topicList = topics.map((t) => t.sessionKey).join(', ');
+    const anyServable = topics.some((t) => t.servablePeerExists);
+    const ageMs = Math.max(0, ...topics.map((t) => t.ownerBeatAgeMs ?? 0));
+
+    const serveLine = anyServable
+      ? 'another machine can serve them.'
+      : 'no machine can currently serve them — fleet-wide wall.';
+
+    const item: StrandAttentionItem = {
+      id: `stranded-topic:${owner}:${windowId}`,
+      title: `Inbound stranded on ${nick} (${topics.length} topic${topics.length === 1 ? '' : 's'})`,
+      summary: `Topics owned by ${nick} (${reasonText}) — inbound can't reach a servable machine.`,
+      description:
+        `Inbound for topic(s) ${topicList} is going to ${nick}, which can't serve them ` +
+        `(${reasonText}); ${serveLine} ` +
+        `Based on ${nick}'s last full heartbeat ${Math.round(ageMs / 1000)}s ago.`,
+      category: 'agent-health',
+      priority: 'NORMAL',
+      sourceContext: `stranded-topic:${owner}`,
+      lane: 'agent-health',
+      healthKey: `stranded-topic:${owner}:${windowId}`,
+    };
+    try {
+      this.deps.raiseAttention(item);
+      this.emit('stranded', { owner, windowId, topics });
+    } catch (err) {
+      // @silent-fallback-ok — the attention raise is the sentinel's only output;
+      // if it throws, the correct signal-only behavior is to surface a
+      // 'raise-error' event and continue (no degradation, nothing to fall back
+      // to). Never let a raise failure crash the monitoring tick.
+      this.emit('raise-error', { err });
+    }
+  }
+
+  private emitCantAssessItem(count: number, now: number): void {
+    const windowId = Math.floor(now / this.cfg.dwellMs) * this.cfg.dwellMs;
+    const item: StrandAttentionItem = {
+      id: `stranded-topic-blind:${windowId}`,
+      title: `Can't assess ${count} online owner${count === 1 ? '' : 's'} for stranding`,
+      summary: `${count} online owner machine${count === 1 ? '' : 's'} skipped — rich heartbeat fields missing.`,
+      description:
+        `I couldn't tell whether ${count} online machine${count === 1 ? ' is' : 's are'} able to serve their ` +
+        `topics because their heartbeat is missing the quota/adapter fields. This is "I can't see", not "all clear" — ` +
+        `a heartbeat/schema regression could be blinding the stranded-inbound detector.`,
+      category: 'agent-health',
+      priority: 'LOW',
+      sourceContext: 'stranded-topic-blind',
+      lane: 'agent-health',
+      healthKey: 'stranded-topic-blind',
+    };
+    try {
+      this.deps.raiseAttention(item);
+      this.emit('cant-assess', { count });
+    } catch (err) {
+      // @silent-fallback-ok — signal-only: surface a 'raise-error' event and
+      // continue; a raise failure must never crash the monitoring tick.
+      this.emit('raise-error', { err });
+    }
+  }
+
+  /** Sync in-memory runtime read for the GuardRegistry (GET /guards). MUST stay
+   *  a cheap property read — no I/O. */
+  guardStatus(): { enabled: boolean; lastTickAt: number } {
+    return { enabled: this.cfg.enabled, lastTickAt: this.lastTickAt };
+  }
+}

--- a/src/monitoring/guardManifest.ts
+++ b/src/monitoring/guardManifest.ts
@@ -217,6 +217,23 @@ export const GUARD_MANIFEST: readonly GuardManifestEntry[] = [
     description: 'Detects agent worktrees with uncommitted work whose owning session died + settled.',
   },
   {
+    // `enabled` is deliberately OMITTED from ConfigDefaults — the runtime resolves
+    // it through the developmentAgent dark-feature gate (dark on the fleet, live on
+    // a dev agent). defaultEnabled:false reflects the fleet default. expectRuntime:
+    // true REQUIRES the server-boot guardRegistry.register callsite (a pure
+    // in-memory guardStatus getter); an enabled-but-unregistered guard reports
+    // `missing`. expectedTickMs derives the on-stale threshold (5×).
+    key: 'monitoring.strandedTopicSentinel.enabled',
+    kind: 'config',
+    configPath: 'monitoring.strandedTopicSentinel.enabled',
+    defaultEnabled: false,
+    expectedTickMs: 60_000,
+    process: 'server',
+    expectRuntime: true,
+    component: 'StrandedTopicSentinel',
+    description: 'Pure-signal detector: surfaces a topic whose owner machine is online-but-unable-to-serve (quota-walled / adapter-disconnected) while a healthy machine holds the lease, so inbound is silently dead. Raises ONE aggregated attention item; MUTATES NOTHING.',
+  },
+  {
     // tmux Event-Loop Resilience (C). `enabled` is deliberately OMITTED from
     // ConfigDefaults — the runtime resolves it through the developmentAgent
     // dark-feature gate (dark on the fleet, live on a dev agent). defaultEnabled:false

--- a/src/monitoring/strandedTopicDecision.ts
+++ b/src/monitoring/strandedTopicDecision.ts
@@ -1,0 +1,237 @@
+/**
+ * strandedTopicDecision — the PURE, unit-testable decision core of the
+ * StrandedTopicSentinel (spec docs/specs/stranded-inbound-self-heal.md).
+ *
+ * A topic is STRANDED when its durable ownership record names a machine that is
+ * online-by-heartbeat but, persistently across rich beats, cannot serve the
+ * topic's channel — quota-walled (`quotaState.blocked === true`, channel-
+ * independent) OR adapter-disconnected (`machineServesChannel(...) === 'no'`).
+ * Inbound for that topic routes to the owner that cannot serve it, so it is
+ * silently dead while outbound still flows from a healthy lease-holder.
+ *
+ * This module computes the strand verdict ONLY. It mutates nothing: no
+ * ownership CAS, no pin write, no session kill. Fail-closed on EVERY
+ * uncertainty (missing field, stale beat, underivable scope, pool view
+ * unavailable) — an uncertainty can NEVER manufacture a strand, it routes to
+ * SKIP. The quota arm carries detection on its own when the adapter arm skips.
+ *
+ * Signal-vs-authority: pure read + a verdict object. No authority to misuse.
+ */
+
+import type { SessionOwnershipRecord } from '../core/SessionOwnership.js';
+import type { MachineCapacity } from '../core/types.js';
+import {
+  machineServesChannel,
+  type ChannelScope,
+} from '../core/machineServesChannel.js';
+
+/** The reason an owner cannot serve a stranded topic. */
+export type StrandReason = 'quota' | 'adapter';
+
+/** One stranded topic in a tick's verdict. */
+export interface StrandedTopic {
+  /** Ownership record session key (== the topic key). */
+  sessionKey: string;
+  /** The machine that owns it but cannot serve it. */
+  ownerMachineId: string;
+  /** Which arm fired. */
+  reason: StrandReason;
+  /** Epoch-ms of the FIRST qualifying beat for this topic (the dwell anchor). */
+  strandedSince: number;
+  /** Owner's last-rich-heartbeat age (ms) at evaluation — for staleness disclosure. */
+  ownerBeatAgeMs?: number;
+  /** Whether a healthy peer could serve this topic's channel (NOT a failover-safe target). */
+  servablePeerExists: boolean;
+}
+
+/** Config knobs for the decision (defaults applied by the sentinel). */
+export interface StrandedDecisionConfig {
+  /** The unable-to-serve condition must hold ≥ this span across ≥2 beats. */
+  dwellMs: number;
+  /** A beat older than this is not a genuine rich beat → fail-closed (skip). */
+  freshnessBoundMs: number;
+}
+
+/** Per-tick inputs to the pure decision. */
+export interface StrandedDecisionInput {
+  /** All known ownership records (the in-memory `all()` scan). */
+  records: SessionOwnershipRecord[];
+  /** The replicated machine-pool capacities (in-memory view). */
+  capacities: MachineCapacity[];
+  /** This machine's id. */
+  selfMachineId: string;
+  /** Whether this machine holds the serving lease (sole-actor gate). */
+  holdsLease: boolean;
+  /** The previous tick's per-topic strandedSince map (sessionKey → first-beat ms). */
+  prevStrandedSince: Record<string, number>;
+  /** Wall clock. */
+  now: number;
+  cfg: StrandedDecisionConfig;
+  /**
+   * Resolve a topic's ChannelScope from its owning adapter binding. Returns
+   * undefined when the scope can't be fully derived (the common Telegram case —
+   * see the spec's honesty note) → the adapter arm SKIPs and the quota arm
+   * carries detection. Optional: absent ⇒ the adapter arm never qualifies.
+   */
+  resolveScope?: (sessionKey: string) => ChannelScope | undefined;
+}
+
+/** The pure decision's output. */
+export interface StrandedDecisionResult {
+  /** The topics stranded THIS tick (already dwell-qualified). */
+  strandedSet: StrandedTopic[];
+  /** Count of online non-self owners SKIPPED because rich fields were missing/unparseable. */
+  cantAssessCount: number;
+  /**
+   * The reconciled strandedSince map to carry into the next tick. A key that did
+   * NOT re-qualify this tick (owner offline / record released / scope underivable)
+   * is DELETED — never left to resume counting later (spec step 2 reconciliation).
+   */
+  nextStrandedSince: Record<string, number>;
+}
+
+/** Is this owner's rich beat genuine (present + fresh)? */
+function richBeatAgeMs(cap: MachineCapacity, now: number): number | undefined {
+  if (!cap.routerReceivedAt) return undefined;
+  const t = Date.parse(cap.routerReceivedAt);
+  if (!Number.isFinite(t)) return undefined;
+  return now - t;
+}
+
+/**
+ * The pure strand evaluation for one tick. Synchronous, LLM-free, no I/O.
+ *
+ * Predicate per `active`, non-self-owned record:
+ *   owner online
+ *   AND ( quota arm: quotaState.blocked === true   [channel-independent]
+ *         OR adapter arm: machineServesChannel(servesChannels, scope) === 'no'
+ *                         ['unknown'/undefined-scope ⇒ SKIP that arm] )
+ *   AND the condition has held ≥2 consecutive rich beats spanning ≥ dwellMs.
+ *
+ * Early no-op: < 2 machines OR !holdsLease ⇒ empty (and the map is dropped).
+ */
+export function evaluateStrandedTopics(
+  input: StrandedDecisionInput,
+): StrandedDecisionResult {
+  const { records, capacities, selfMachineId, holdsLease, prevStrandedSince, now, cfg } = input;
+
+  // Early no-op gates (spec step 1). A single-machine agent can't strand on a
+  // peer; a non-lease-holder is not the sole actor. Drop the dwell map so a
+  // demotion/scale-down doesn't carry stale anchors.
+  if (capacities.length < 2 || !holdsLease) {
+    return { strandedSet: [], cantAssessCount: 0, nextStrandedSince: {} };
+  }
+
+  const capById = new Map<string, MachineCapacity>();
+  for (const c of capacities) capById.set(c.machineId, c);
+
+  const strandedSet: StrandedTopic[] = [];
+  const nextStrandedSince: Record<string, number> = {};
+  let cantAssessCount = 0;
+
+  for (const rec of records) {
+    // Only active, peer-owned records are candidates.
+    if (rec.status !== 'active') continue;
+    if (rec.ownerMachineId === selfMachineId) continue;
+
+    const owner = capById.get(rec.ownerMachineId);
+    // Unknown owner / not in the pool view → can't assess → skip (fail-closed).
+    if (!owner) continue;
+    // A dead owner is the existing Case C's job; this sentinel only covers the
+    // online-but-unable gap.
+    if (!owner.online) continue;
+
+    // Require a genuine rich beat: present + fresh. A stale/undecodable beat
+    // fails closed (skip) and does NOT count toward the dwell.
+    const beatAgeMs = richBeatAgeMs(owner, now);
+    if (beatAgeMs === undefined || beatAgeMs > cfg.freshnessBoundMs) continue;
+
+    // ── Arm (a): quota — channel-independent, the dominant incident case. ──
+    const quotaArm = owner.quotaState?.blocked === true;
+
+    // ── Arm (b): adapter — best-effort, channel-specific. ──
+    let adapterArm = false;
+    // A missing servesChannels on an online owner is the anti-blind-spot case:
+    // we cannot evaluate the adapter arm. If the quota arm ALSO can't fire
+    // (quotaState absent/undecided), this owner is genuinely unassessable.
+    const servesPresent = owner.servesChannels !== undefined;
+    let armBlind = false;
+    if (input.resolveScope) {
+      const scope = input.resolveScope(rec.sessionKey);
+      if (scope === undefined) {
+        // Underivable scope ⇒ SKIP this arm (not a strand).
+      } else {
+        const serve = machineServesChannel(owner.servesChannels, scope);
+        if (serve === 'no') adapterArm = true;
+        else if (serve === 'unknown') {
+          // 'unknown' (sparse/absent servesChannels) ⇒ SKIP this arm.
+          if (!servesPresent) armBlind = true;
+        }
+        // 'yes' ⇒ owner can serve on this arm → not stranded here.
+      }
+    }
+
+    const unableToServe = quotaArm || adapterArm;
+
+    if (!unableToServe) {
+      // Anti-blind-spot: an online owner we could NOT assess at all — quota
+      // undecided AND the adapter arm blinded by a missing servesChannels —
+      // increments the can't-assess count (spec step 4). A topic with a usable
+      // 'yes' or a derivable scope is genuinely assessed (not blind).
+      const quotaUndecided = owner.quotaState === undefined;
+      if (quotaUndecided && armBlind) cantAssessCount++;
+      continue;
+    }
+
+    // ── Persistence (dwell) — anchor on the FIRST qualifying beat. ──
+    const prevSince = prevStrandedSince[rec.sessionKey];
+    const strandedSince = typeof prevSince === 'number' ? prevSince : now;
+    nextStrandedSince[rec.sessionKey] = strandedSince;
+
+    // The condition must have held ≥ dwellMs (which, given the ≥1 prior beat that
+    // set the anchor, spans ≥2 consecutive rich beats). A first-beat strand has
+    // dwell 0 < dwellMs → recorded in the map but NOT yet emitted.
+    if (now - strandedSince < cfg.dwellMs) continue;
+
+    const reason: StrandReason = quotaArm ? 'quota' : 'adapter';
+    strandedSet.push({
+      sessionKey: rec.sessionKey,
+      ownerMachineId: rec.ownerMachineId,
+      reason,
+      strandedSince,
+      ownerBeatAgeMs: beatAgeMs,
+      servablePeerExists: servablePeerExists(rec, capacities, selfMachineId, input.resolveScope),
+    });
+  }
+
+  return { strandedSet, cantAssessCount, nextStrandedSince };
+}
+
+/**
+ * Whether SOME online machine could serve the topic's channel — narrowly "online
+ * AND not quota-blocked AND machineServesChannel(...) === 'yes'" (the same
+ * PlacementExecutor filter, so detector + placement agree). Deliberately NOT a
+ * "safe failover target": it vets no pin policy, lease/router readiness, secrets,
+ * or session limits — v1 never fails over, so this only tells the operator
+ * "somewhere could serve this" vs "nowhere can (fleet-wide wall)". When the scope
+ * can't be derived, a not-quota-blocked online peer counts (quota-arm semantics).
+ */
+function servablePeerExists(
+  rec: SessionOwnershipRecord,
+  capacities: MachineCapacity[],
+  selfMachineId: string,
+  resolveScope?: (sessionKey: string) => ChannelScope | undefined,
+): boolean {
+  const scope = resolveScope?.(rec.sessionKey);
+  for (const c of capacities) {
+    if (c.machineId === rec.ownerMachineId) continue;
+    if (!c.online) continue;
+    if (c.quotaState?.blocked === true) continue;
+    if (scope === undefined) {
+      // No channel scope → quota-arm semantics: a healthy peer suffices.
+      return true;
+    }
+    if (machineServesChannel(c.servesChannels, scope) === 'yes') return true;
+  }
+  return false;
+}

--- a/tests/e2e/stranded-topic-guards-lifecycle.test.ts
+++ b/tests/e2e/stranded-topic-guards-lifecycle.test.ts
@@ -1,0 +1,127 @@
+// safe-fs-allow: test file — tmpdir fixtures only, cleaned via SafeFsExecutor.
+
+/**
+ * E2E lifecycle (Tier 3) for the stranded-inbound detector: "is the feature
+ * actually ALIVE?" — a REAL Express server on a real port, the real GET /guards
+ * route + auth, with the REAL StrandedTopicSentinel constructed + ticked +
+ * registered exactly as server.ts wires it. Proves the dev-gated guard shows up
+ * in the live /guards inventory, runtime-enriched (non-null lastTickAt), 200 not
+ * 503 — so the feature can never silently become dead code on the endpoint.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import express from 'express';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import type { AddressInfo } from 'node:net';
+import { createRoutes, type RouteContext } from '../../src/server/routes.js';
+import { authMiddleware } from '../../src/server/middleware.js';
+import { GuardRegistry } from '../../src/monitoring/GuardRegistry.js';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+import { StrandedTopicSentinel } from '../../src/monitoring/StrandedTopicSentinel.js';
+
+const AUTH = 'stranded-e2e-token';
+const KEY = 'monitoring.strandedTopicSentinel.enabled';
+
+interface TestServer { url: string; close: () => Promise<void>; }
+async function listen(app: express.Express): Promise<TestServer> {
+  return new Promise((resolve) => {
+    const srv = app.listen(0, '127.0.0.1', () => {
+      const port = (srv.address() as AddressInfo).port;
+      resolve({ url: `http://127.0.0.1:${port}`, close: () => new Promise<void>((r) => srv.close(() => r())) });
+    });
+  });
+}
+
+describe('GET /guards — stranded-inbound detector E2E lifecycle (Tier 3)', () => {
+  let dir: string;
+  let stateDir: string;
+  let server: TestServer | null = null;
+
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'stranded-e2e-'));
+    stateDir = path.join(dir, '.instar');
+    fs.mkdirSync(path.join(stateDir, 'state'), { recursive: true });
+    // The /guards route reads config FROM DISK (resolveGuardConfigSnapshot), not
+    // ctx.config — so the dev-gate (developmentAgent:true ⇒ the omitted `enabled`
+    // resolves LIVE) must be on disk for the guard to grade on, not dark.
+    fs.writeFileSync(
+      path.join(stateDir, 'config.json'),
+      JSON.stringify({ developmentAgent: true, monitoring: { strandedTopicSentinel: { tickMs: 60_000 } } }),
+    );
+  });
+
+  afterEach(async () => {
+    await server?.close();
+    server = null;
+    SafeFsExecutor.safeRmSync(dir, { recursive: true, force: true, operation: 'tests/e2e/stranded-topic-guards-lifecycle.test.ts:cleanup' });
+  });
+
+  async function bootServer(): Promise<TestServer> {
+    const registry = new GuardRegistry();
+
+    // Construct + start + tick the REAL sentinel exactly as server.ts does
+    // (dev-gated ON; lease-holder; no strand fixture needed — we assert the
+    // guard is ALIVE on the endpoint, which the unit/integration tiers prove
+    // for the detection logic).
+    const sentinel = new StrandedTopicSentinel(
+      {
+        listOwnershipRecords: () => [],
+        listCapacities: () => [],
+        selfMachineId: () => 'm-e2e',
+        holdsLease: () => true,
+        raiseAttention: () => {},
+        now: () => Date.now(),
+      },
+      { enabled: true, tickMs: 60_000 },
+    );
+    sentinel.start();
+    sentinel.tick(); // advance lastTickAt so the row is runtime-enriched
+    registry.register(KEY, () => sentinel.guardStatus());
+
+    const ctx = {
+      config: {
+        projectName: 'stranded-e2e', projectDir: dir, stateDir, port: 0,
+        authToken: AUTH,
+        // developmentAgent:true ⇒ resolveDevAgentGate sees the omitted `enabled`
+        // and resolves the guard LIVE (dev-live / dark-fleet), matching the
+        // registration above.
+        developmentAgent: true,
+        monitoring: { strandedTopicSentinel: { tickMs: 60_000 } },
+        sessions: {}, scheduler: {},
+      },
+      sessionManager: { listRunningSessions: () => [] },
+      state: { getJobState: () => null, getSession: () => null },
+      startTime: new Date(),
+      guardRegistry: registry,
+      meshSelfId: 'm-e2e',
+    } as unknown as RouteContext;
+
+    const app = express();
+    app.use(express.json());
+    app.use(authMiddleware(AUTH));
+    app.use('/', createRoutes(ctx));
+    return listen(app);
+  }
+
+  it('FEATURE IS ALIVE: the strandedTopicSentinel guard is in the live /guards inventory, runtime-enriched, 200', async () => {
+    server = await bootServer();
+    const res = await fetch(`${server.url}/guards`, { headers: { Authorization: `Bearer ${AUTH}` } });
+    expect(res.status).toBe(200);
+    const body = await res.json() as { guards: Array<{ key: string; runtime: unknown; effective: string }> };
+    const row = body.guards.find((g) => g.key === KEY);
+    expect(row, 'strandedTopicSentinel must appear in the /guards inventory').toBeTruthy();
+    // Runtime-enriched (the wiring-integrity pin): a real registered guardStatus,
+    // not a null runtime that would silently degrade to on-unverified.
+    expect(row!.runtime).not.toBeNull();
+    // Dev-gated ON + registered + ticked ⇒ it must NOT read as off/missing.
+    expect(['off', 'missing', 'off-runtime-divergent']).not.toContain(row!.effective);
+  });
+
+  it('401 without auth — the guard route never rides an exemption list', async () => {
+    server = await bootServer();
+    const res = await fetch(`${server.url}/guards`);
+    expect(res.status).toBe(401);
+  });
+});

--- a/tests/integration/stranded-topic-guard-posture.test.ts
+++ b/tests/integration/stranded-topic-guard-posture.test.ts
@@ -1,0 +1,158 @@
+/**
+ * stranded-inbound-self-heal — integration: the StrandedTopicSentinel is visible
+ * through its REAL surfaces and its detection→attention pipeline works end-to-end.
+ *
+ * Tier 2 (integration) for the testing-integrity standard. Exercises:
+ *  (a) the GUARD_MANIFEST entry + deriveGuardRow (the EXACT path GET /guards uses),
+ *      so a running sentinel grades correctly and a disabled one is not falsely OK;
+ *  (b) the live detection→attention pipeline: a stranded fixture, ticked across the
+ *      dwell, raises ONE aggregated agent-health attention item through the real
+ *      sentinel (with a captured raiseAttention), naming the topic, owner, reason,
+ *      servable-peer state, and signal staleness — and NOT before the dwell.
+ */
+import { describe, it, expect } from 'vitest';
+
+import { StrandedTopicSentinel, type StrandAttentionItem } from '../../src/monitoring/StrandedTopicSentinel.js';
+import { GUARD_MANIFEST } from '../../src/monitoring/guardManifest.js';
+import { deriveGuardRow } from '../../src/monitoring/guardPostureView.js';
+import type { MachineCapacity } from '../../src/core/types.js';
+import type { SessionOwnershipRecord } from '../../src/core/SessionOwnership.js';
+
+const KEY = 'monitoring.strandedTopicSentinel.enabled';
+
+const manifestEntry = () => {
+  const e = GUARD_MANIFEST.find((m) => m.key === KEY);
+  if (!e) throw new Error('StrandedTopicSentinel GUARD_MANIFEST entry missing');
+  return e;
+};
+
+/** A fixture mesh: this machine ('self', lease-holder) + a quota-walled peer ('mini'). */
+function walledFixture(clock: () => number) {
+  const records: SessionOwnershipRecord[] = [
+    {
+      sessionKey: '28130',
+      ownerMachineId: 'mini',
+      ownershipEpoch: 2,
+      status: 'active',
+      nonce: 'x',
+      timestamp: 0,
+      updatedAt: new Date(0).toISOString(),
+    } as SessionOwnershipRecord,
+  ];
+  // Fresh rich beats recomputed per call so the beat never goes stale as the clock advances.
+  const capacities = (): MachineCapacity[] => [
+    { machineId: 'self', online: true, routerReceivedAt: new Date(clock() - 1000).toISOString() } as MachineCapacity,
+    {
+      machineId: 'mini',
+      online: true,
+      quotaState: { blocked: true },
+      servesChannels: { telegram: { chatIds: ['c1'] } },
+      routerReceivedAt: new Date(clock() - 1000).toISOString(),
+    } as MachineCapacity,
+  ];
+  return { records, capacities };
+}
+
+describe('StrandedTopicSentinel — guard posture (Tier 2)', () => {
+  it('has a well-formed GUARD_MANIFEST entry (component + expectRuntime + config path)', () => {
+    const e = manifestEntry();
+    expect(e.component).toBe('StrandedTopicSentinel');
+    expect(e.expectRuntime).toBe(true);
+    expect(e.configPath).toBe(KEY);
+    expect(e.defaultEnabled).toBe(false); // dark on the fleet
+  });
+
+  it('a running (dev-gated ON) sentinel grades on /guards and is NOT off-runtime-divergent', () => {
+    let now = 1_700_000_000_000;
+    const sentinel = new StrandedTopicSentinel(
+      {
+        listOwnershipRecords: () => [],
+        listCapacities: () => [],
+        selfMachineId: () => 'self',
+        holdsLease: () => true,
+        raiseAttention: () => {},
+        now: () => now,
+      },
+      { enabled: true, tickMs: 60_000 },
+    );
+    sentinel.start();
+    sentinel.tick();
+    const status = sentinel.guardStatus();
+    expect(status.enabled).toBe(true);
+    expect(status.lastTickAt).toBe(now);
+
+    const entry = manifestEntry();
+    const row = deriveGuardRow({
+      key: entry.key,
+      manifest: entry,
+      configEnabled: true,
+      defaultEnabled: entry.defaultEnabled,
+      bootValue: true,
+      bootSnapshotAvailable: true,
+      runtime: { kind: 'ok', status: { enabled: status.enabled, lastTickAt: status.lastTickAt } },
+      now,
+    });
+    expect(row.effective).not.toBe('off-runtime-divergent');
+    sentinel.stop();
+  });
+
+  it('detection→attention pipeline: raises ONE aggregated item AFTER the dwell, not before', () => {
+    let now = 1_700_000_000_000;
+    const dwellMs = 30_000;
+    const raised: StrandAttentionItem[] = [];
+    const { records, capacities } = walledFixture(() => now);
+
+    const sentinel = new StrandedTopicSentinel(
+      {
+        listOwnershipRecords: () => records,
+        listCapacities: capacities,
+        selfMachineId: () => 'self',
+        holdsLease: () => true,
+        raiseAttention: (item) => raised.push(item),
+        nicknameOf: (id) => (id === 'mini' ? 'Mac Mini' : id),
+        now: () => now,
+      },
+      { enabled: true, tickMs: 60_000, dwellMs, freshnessBoundMs: 45_000 },
+    );
+    sentinel.start();
+
+    // Tick 1: qualifies but dwell not yet met → recorded, NOT emitted.
+    sentinel.tick();
+    expect(raised).toHaveLength(0);
+
+    // Tick 2, past the dwell: emitted exactly once, aggregated.
+    now += dwellMs + 1_000;
+    sentinel.tick();
+    expect(raised).toHaveLength(1);
+    const item = raised[0];
+    expect(item.priority).toBe('NORMAL'); // rides the flood ceiling, never bypasses
+    expect(item.lane).toBe('agent-health');
+    expect(item.description).toContain('28130');
+    expect(item.description).toContain('Mac Mini');
+    expect(item.description.toLowerCase()).toContain('quota'); // the reason
+    expect(item.description.toLowerCase()).toContain('heartbeat'); // staleness disclosure
+    expect(item.id).toContain('mini'); // dedup keyed on owner
+
+    sentinel.stop();
+  });
+
+  it('single-machine (no peer) raises nothing — strict no-op', () => {
+    let now = 1_700_000_000_000;
+    const raised: StrandAttentionItem[] = [];
+    const sentinel = new StrandedTopicSentinel(
+      {
+        listOwnershipRecords: () => [
+          { sessionKey: '1', ownerMachineId: 'self', ownershipEpoch: 1, status: 'active', nonce: 'x', timestamp: 0, updatedAt: '' } as SessionOwnershipRecord,
+        ],
+        listCapacities: () => [{ machineId: 'self', online: true, routerReceivedAt: new Date(now).toISOString() } as MachineCapacity],
+        selfMachineId: () => 'self',
+        holdsLease: () => true,
+        raiseAttention: (item) => raised.push(item),
+        now: () => now,
+      },
+      { enabled: true },
+    );
+    sentinel.tick();
+    expect(raised).toHaveLength(0);
+  });
+});

--- a/tests/unit/lint-dev-agent-dark-gate.test.ts
+++ b/tests/unit/lint-dev-agent-dark-gate.test.ts
@@ -356,8 +356,8 @@ describe('lint-dev-agent-dark-gate', () => {
       // two new `enabled: false` stateSync blocks (userRegistry+topicOperator) after evolutionActions,
       // pushing cartographer to 1066/1111/1136. credentialRepointing + authorizationRequests OMIT
       // enabled (dev-gated). Every line RE-VERIFIED by hand via the attributor on the merged ConfigDefaults.
-      '322': 'monitoring.mcpProcessReaper.enabled',
-      '336': 'monitoring.agentSleep.enabled',
+      '336': 'monitoring.mcpProcessReaper.enabled',
+      '350': 'monitoring.agentSleep.enabled',
       // self-unblock-before-escalating (CMT-1519): the blockerLedger ConfigDefaults block
       // gained two nested OMITTED-`enabled` dev-gate sub-blocks (selfUnblockChecklist +
       // durableVaultSession) + a 6-line explanatory comment. Neither sub-block carries an
@@ -373,19 +373,19 @@ describe('lint-dev-agent-dark-gate', () => {
       // comment (NOT an `enabled:` path, so the attributor ignores it) ABOVE every
       // block below — shifting each subsequent `enabled: false` line DOWN by +5.
       // RE-VERIFIED by hand via the attributor on the edited ConfigDefaults.
-      '407': 'monitoring.correctionLearning.enabled',
-      '501': 'monitoring.apprenticeshipCycleSla.enabled',
-      '509': 'monitoring.geminiCapacityEscalation.enabled',
-      '533': 'monitoring.greenPrAutoMerge.enabled',
-      '583': 'threadline.a2aCheckIn.enabled',
+      '421': 'monitoring.correctionLearning.enabled',
+      '515': 'monitoring.apprenticeshipCycleSla.enabled',
+      '523': 'monitoring.geminiCapacityEscalation.enabled',
+      '547': 'monitoring.greenPrAutoMerge.enabled',
+      '597': 'threadline.a2aCheckIn.enabled',
       // secure-a2a-verified-pairing §3.10 (Increment 6): the new
       // threadline.verifiedPairing block (~21 lines, NO `enabled:` literal — see the
       // note below the sessionPool keys) was inserted inside the `threadline` block
       // ABOVE mentor, shifting every subsequent `enabled: false` line DOWN by +19.
       // RE-VERIFIED by hand via the attributor on the edited ConfigDefaults.
-      '694': 'mentor.enabled',
-      '705': 'mentor.autonomousFix.enabled',
-      '720': 'mentee.enabled',
+      '708': 'mentor.enabled',
+      '719': 'mentor.autonomousFix.enabled',
+      '734': 'mentee.enabled',
       // multi-machine-lease-self-heal: a NEW multiMachine.leaseSelfHeal block was
       // inserted at the TOP of the `multiMachine` block (ABOVE accountFollowMe). It
       // adds TWO `enabled: false` literals — F2 staleHolderTakeover + F3
@@ -394,14 +394,14 @@ describe('lint-dev-agent-dark-gate', () => {
       // neither is attributed). The block (~30 lines incl. its comment) shifts every
       // subsequent `enabled: false` line DOWN by +28. RE-VERIFIED by hand via the
       // attributor on the edited ConfigDefaults (each maps to a real `enabled: false,` line).
-      '823': 'multiMachine.leaseSelfHeal.staleHolderTakeover.enabled',
-      '827': 'multiMachine.leaseSelfHeal.silentStandbyRelinquish.enabled',
+      '837': 'multiMachine.leaseSelfHeal.staleHolderTakeover.enabled',
+      '841': 'multiMachine.leaseSelfHeal.silentStandbyRelinquish.enabled',
       // multi-transport-mesh-comms (2026-06-20): soloCaptainHold.enabled:false (Layer 3,
       // action-bearing) added to the leaseSelfHeal block + a ~15-line meshTransport FLAT
       // block (enabled: TRUE, NOT an `enabled: false` path so the attributor ignores it)
       // inserted ABOVE sessionPool — together shifting every sessionPool-onward
       // `enabled: false` line by +24 (956→980, 981→1005). RE-VERIFIED via the attributor.
-      '834': 'multiMachine.leaseSelfHeal.soloCaptainHold.enabled',
+      '848': 'multiMachine.leaseSelfHeal.soloCaptainHold.enabled',
       // WS4.1-durable-ack (CMT-1416) inserts a plain `ws41DurableAck: false`
       // seamlessness boolean (NOT `enabled:`, so the attributor ignores it) above
       // sessionPool. WS4.3-role-guard (CMT-1416) inserts another plain
@@ -442,9 +442,9 @@ describe('lint-dev-agent-dark-gate', () => {
       // Every key below the insertion shifts DOWN by +17; the flag SET is unchanged (still 22).
       // RE-VERIFIED via the attributor on the edited ConfigDefaults (each maps to a real
       // `enabled: false,` line).
-      '1040': 'multiMachine.sessionPool.enabled',
-      '1065': 'multiMachine.sessionPool.inboundQueue.enabled',
-      '1094': 'multiMachine.sessionPool.holdForStability.enabled',
+      '1054': 'multiMachine.sessionPool.enabled',
+      '1079': 'multiMachine.sessionPool.inboundQueue.enabled',
+      '1108': 'multiMachine.sessionPool.holdForStability.enabled',
       // mm-stores-devgate (operator directive 2026-06-13, topic 13481): the 7
       // multiMachine.stateSync.* memory stores MOVED from DARK_GATE_EXCLUSIONS to
       // DEV_GATED_FEATURES and their `enabled: false` literals were REMOVED from
@@ -478,10 +478,10 @@ describe('lint-dev-agent-dark-gate', () => {
       // attributor on the edited ConfigDefaults.
       // After merging JKHeadley/main + my accountFollowMe block, these resolve as below.
       // RE-VERIFIED by hand via the attributor on the MERGED ConfigDefaults.
-      '1263': 'multiMachine.stateSync.threadlinePairing.enabled',
-      '1385': 'cartographer.freshnessSweep.enabled',
-      '1430': 'cartographer.conformanceAudit.llmEnrichment.enabled',
-      '1455': 'cartographer.subtreeNav.llmRerank.enabled',
+      '1277': 'multiMachine.stateSync.threadlinePairing.enabled',
+      '1399': 'cartographer.freshnessSweep.enabled',
+      '1444': 'cartographer.conformanceAudit.llmEnrichment.enabled',
+      '1469': 'cartographer.subtreeNav.llmRerank.enabled',
     };
     const actual = attributeRealConfigDefaults();
     expect(actual).toEqual(EXPECTED);

--- a/tests/unit/stranded-topic-sentinel.test.ts
+++ b/tests/unit/stranded-topic-sentinel.test.ts
@@ -1,0 +1,479 @@
+/**
+ * Unit tests for the StrandedTopicSentinel pure decision (evaluateStrandedTopics)
+ * — stranded-inbound-self-heal. Exhaustive on both sides of every boundary:
+ * quota arm fires; adapter-arm 'no' fires; 'unknown'/undefined-scope SKIPs; the
+ * persistence dwell (single-beat does NOT fire, ≥2-beat over dwellMs fires);
+ * missing servesChannels ⇒ skip (not strand); owner offline ⇒ skip; owner==self
+ * ⇒ skip; non-lease-holder ⇒ empty; single-machine ⇒ empty; strandedSince
+ * reconciliation deletes stale keys; can't-assess increments on missing-field
+ * skips.
+ *
+ * The sentinel's tick is also smoke-tested for the LLM-free / no-spawn-cap
+ * invariant (it imports nothing that would acquire a spawn-cap slot) and the
+ * aggregated-attention emission.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import {
+  evaluateStrandedTopics,
+  type StrandedDecisionInput,
+} from '../../src/monitoring/strandedTopicDecision.js';
+import {
+  StrandedTopicSentinel,
+  type StrandAttentionItem,
+} from '../../src/monitoring/StrandedTopicSentinel.js';
+import type { SessionOwnershipRecord } from '../../src/core/SessionOwnership.js';
+import type { MachineCapacity } from '../../src/core/types.js';
+import type { ChannelScope } from '../../src/core/machineServesChannel.js';
+
+const NOW = 1_000_000;
+const SELF = 'self-machine';
+const OWNER = 'owner-machine';
+
+function rec(over: Partial<SessionOwnershipRecord> = {}): SessionOwnershipRecord {
+  return {
+    sessionKey: '100',
+    ownerMachineId: OWNER,
+    ownershipEpoch: 5,
+    status: 'active',
+    nonce: 'n',
+    timestamp: NOW,
+    updatedAt: new Date(NOW).toISOString(),
+    ...over,
+  };
+}
+
+function cap(over: Partial<MachineCapacity> = {}): MachineCapacity {
+  return {
+    machineId: OWNER,
+    online: true,
+    routerReceivedAt: new Date(NOW - 1_000).toISOString(), // 1s old, fresh
+    clockSkewStatus: 'ok',
+    ...over,
+  };
+}
+
+function selfCap(): MachineCapacity {
+  return cap({ machineId: SELF });
+}
+
+function baseInput(over: Partial<StrandedDecisionInput> = {}): StrandedDecisionInput {
+  return {
+    records: [],
+    capacities: [selfCap(), cap()],
+    selfMachineId: SELF,
+    holdsLease: true,
+    prevStrandedSince: {},
+    now: NOW,
+    cfg: { dwellMs: 30_000, freshnessBoundMs: 45_000 },
+    ...over,
+  };
+}
+
+describe('evaluateStrandedTopics — early no-op gates', () => {
+  it('single-machine (< 2 capacities) ⇒ empty + dropped map', () => {
+    const r = evaluateStrandedTopics(
+      baseInput({ capacities: [selfCap()], records: [rec()], prevStrandedSince: { '100': NOW - 60_000 } }),
+    );
+    expect(r.strandedSet).toHaveLength(0);
+    expect(r.nextStrandedSince).toEqual({});
+    expect(r.cantAssessCount).toBe(0);
+  });
+
+  it('not lease-holder ⇒ empty + dropped map', () => {
+    const r = evaluateStrandedTopics(
+      baseInput({
+        holdsLease: false,
+        records: [rec()],
+        capacities: [selfCap(), cap({ quotaState: { blocked: true } })],
+        prevStrandedSince: { '100': NOW - 60_000 },
+      }),
+    );
+    expect(r.strandedSet).toHaveLength(0);
+    expect(r.nextStrandedSince).toEqual({});
+  });
+});
+
+describe('evaluateStrandedTopics — quota arm', () => {
+  it('quota-blocked owner past dwell ⇒ stranded (reason quota)', () => {
+    const r = evaluateStrandedTopics(
+      baseInput({
+        records: [rec()],
+        capacities: [selfCap(), cap({ quotaState: { blocked: true } })],
+        prevStrandedSince: { '100': NOW - 31_000 }, // anchored > dwellMs ago
+      }),
+    );
+    expect(r.strandedSet).toHaveLength(1);
+    expect(r.strandedSet[0].reason).toBe('quota');
+    expect(r.strandedSet[0].ownerMachineId).toBe(OWNER);
+    expect(r.nextStrandedSince['100']).toBe(NOW - 31_000);
+  });
+
+  it('quota.blocked === false ⇒ NOT stranded (boundary other side)', () => {
+    const r = evaluateStrandedTopics(
+      baseInput({
+        records: [rec()],
+        capacities: [selfCap(), cap({ quotaState: { blocked: false } })],
+        prevStrandedSince: { '100': NOW - 31_000 },
+      }),
+    );
+    expect(r.strandedSet).toHaveLength(0);
+    // quotaState present (decided), so it is assessed — NOT a blind skip.
+    expect(r.cantAssessCount).toBe(0);
+  });
+});
+
+describe('evaluateStrandedTopics — adapter arm', () => {
+  const tgScope: ChannelScope = { platform: 'telegram', chatId: 'C1' };
+  const resolveScope = () => tgScope;
+
+  it("machineServesChannel === 'no' past dwell ⇒ stranded (reason adapter)", () => {
+    // owner serves a DIFFERENT chat → 'no' for C1
+    const r = evaluateStrandedTopics(
+      baseInput({
+        records: [rec()],
+        capacities: [selfCap(), cap({ servesChannels: { telegram: { chatIds: ['OTHER'] } } })],
+        prevStrandedSince: { '100': NOW - 31_000 },
+        resolveScope,
+      }),
+    );
+    expect(r.strandedSet).toHaveLength(1);
+    expect(r.strandedSet[0].reason).toBe('adapter');
+  });
+
+  it("machineServesChannel === 'yes' ⇒ NOT stranded", () => {
+    const r = evaluateStrandedTopics(
+      baseInput({
+        records: [rec()],
+        capacities: [selfCap(), cap({ servesChannels: { telegram: { chatIds: ['C1'] } } })],
+        prevStrandedSince: { '100': NOW - 31_000 },
+        resolveScope,
+      }),
+    );
+    expect(r.strandedSet).toHaveLength(0);
+    expect(r.cantAssessCount).toBe(0);
+  });
+
+  it("scope undefined ⇒ adapter arm SKIPs (no strand from adapter)", () => {
+    const r = evaluateStrandedTopics(
+      baseInput({
+        records: [rec()],
+        capacities: [selfCap(), cap({ servesChannels: { telegram: { chatIds: ['OTHER'] } } })],
+        prevStrandedSince: { '100': NOW - 31_000 },
+        resolveScope: () => undefined,
+      }),
+    );
+    expect(r.strandedSet).toHaveLength(0);
+    // servesChannels present + scope underivable: not a blind skip (we had a
+    // value, just no scope to test it against), and quota is undefined.
+    expect(r.cantAssessCount).toBe(0);
+  });
+
+  it("servesChannels present but 'unknown' (no telegram block, slack scope) ⇒ SKIP, not blind (servesChannels present)", () => {
+    const slackScope: ChannelScope = { platform: 'slack' /* no workspaceId */ };
+    const r = evaluateStrandedTopics(
+      baseInput({
+        records: [rec()],
+        capacities: [selfCap(), cap({ servesChannels: { slack: { workspaceIds: ['W1'] } } })],
+        prevStrandedSince: { '100': NOW - 31_000 },
+        resolveScope: () => slackScope, // missing workspaceId ⇒ 'unknown'
+      }),
+    );
+    expect(r.strandedSet).toHaveLength(0);
+    expect(r.cantAssessCount).toBe(0); // servesPresent ⇒ not blind
+  });
+});
+
+describe('evaluateStrandedTopics — persistence (dwell)', () => {
+  it('single beat (no prior anchor) does NOT fire; records anchor', () => {
+    const r = evaluateStrandedTopics(
+      baseInput({
+        records: [rec()],
+        capacities: [selfCap(), cap({ quotaState: { blocked: true } })],
+        prevStrandedSince: {}, // first observation
+      }),
+    );
+    expect(r.strandedSet).toHaveLength(0);
+    expect(r.nextStrandedSince['100']).toBe(NOW); // anchor recorded
+  });
+
+  it('anchored within dwellMs does NOT fire', () => {
+    const r = evaluateStrandedTopics(
+      baseInput({
+        records: [rec()],
+        capacities: [selfCap(), cap({ quotaState: { blocked: true } })],
+        prevStrandedSince: { '100': NOW - 10_000 }, // 10s < 30s dwell
+      }),
+    );
+    expect(r.strandedSet).toHaveLength(0);
+    expect(r.nextStrandedSince['100']).toBe(NOW - 10_000); // anchor preserved
+  });
+
+  it('anchored at exactly dwellMs fires', () => {
+    const r = evaluateStrandedTopics(
+      baseInput({
+        records: [rec()],
+        capacities: [selfCap(), cap({ quotaState: { blocked: true } })],
+        prevStrandedSince: { '100': NOW - 30_000 },
+      }),
+    );
+    expect(r.strandedSet).toHaveLength(1);
+  });
+});
+
+describe('evaluateStrandedTopics — skip cases', () => {
+  it('missing servesChannels AND quota undefined ⇒ skip + cantAssess increments', () => {
+    const r = evaluateStrandedTopics(
+      baseInput({
+        records: [rec()],
+        capacities: [selfCap(), cap({ /* no quotaState, no servesChannels */ })],
+        prevStrandedSince: { '100': NOW - 31_000 },
+        resolveScope: () => ({ platform: 'telegram', chatId: 'C1' }),
+      }),
+    );
+    expect(r.strandedSet).toHaveLength(0);
+    expect(r.cantAssessCount).toBe(1);
+    expect(r.nextStrandedSince).toEqual({}); // no anchor for a skipped topic
+  });
+
+  it('owner offline ⇒ skip (not stranded, not blind)', () => {
+    const r = evaluateStrandedTopics(
+      baseInput({
+        records: [rec()],
+        capacities: [selfCap(), cap({ online: false, quotaState: { blocked: true } })],
+        prevStrandedSince: { '100': NOW - 31_000 },
+      }),
+    );
+    expect(r.strandedSet).toHaveLength(0);
+    expect(r.cantAssessCount).toBe(0);
+  });
+
+  it('owner == self ⇒ skip', () => {
+    const r = evaluateStrandedTopics(
+      baseInput({
+        records: [rec({ ownerMachineId: SELF })],
+        capacities: [cap({ machineId: SELF, quotaState: { blocked: true } }), cap()],
+        prevStrandedSince: { '100': NOW - 31_000 },
+      }),
+    );
+    expect(r.strandedSet).toHaveLength(0);
+  });
+
+  it('non-active record (released) ⇒ skip', () => {
+    const r = evaluateStrandedTopics(
+      baseInput({
+        records: [rec({ status: 'released' })],
+        capacities: [selfCap(), cap({ quotaState: { blocked: true } })],
+        prevStrandedSince: { '100': NOW - 31_000 },
+      }),
+    );
+    expect(r.strandedSet).toHaveLength(0);
+  });
+
+  it('owner not in pool view ⇒ skip', () => {
+    const r = evaluateStrandedTopics(
+      baseInput({
+        records: [rec({ ownerMachineId: 'ghost' })],
+        capacities: [selfCap(), cap()], // ghost absent
+        prevStrandedSince: { '100': NOW - 31_000 },
+      }),
+    );
+    expect(r.strandedSet).toHaveLength(0);
+  });
+
+  it('stale rich beat (older than freshnessBoundMs) ⇒ skip', () => {
+    const r = evaluateStrandedTopics(
+      baseInput({
+        records: [rec()],
+        capacities: [selfCap(), cap({ routerReceivedAt: new Date(NOW - 60_000).toISOString(), quotaState: { blocked: true } })],
+        prevStrandedSince: { '100': NOW - 31_000 },
+      }),
+    );
+    expect(r.strandedSet).toHaveLength(0);
+  });
+
+  it('missing routerReceivedAt (no beat age) ⇒ skip', () => {
+    const r = evaluateStrandedTopics(
+      baseInput({
+        records: [rec()],
+        capacities: [selfCap(), cap({ routerReceivedAt: undefined, quotaState: { blocked: true } })],
+        prevStrandedSince: { '100': NOW - 31_000 },
+      }),
+    );
+    expect(r.strandedSet).toHaveLength(0);
+  });
+});
+
+describe('evaluateStrandedTopics — strandedSince reconciliation', () => {
+  it('deletes a stale key whose topic no longer qualifies (owner went offline)', () => {
+    const r = evaluateStrandedTopics(
+      baseInput({
+        records: [rec()],
+        capacities: [selfCap(), cap({ online: false, quotaState: { blocked: true } })],
+        prevStrandedSince: { '100': NOW - 31_000, '999': NOW - 31_000 }, // both stale now
+      }),
+    );
+    expect(r.strandedSet).toHaveLength(0);
+    // neither survives — 100 fell out via offline skip, 999 had no record at all
+    expect(r.nextStrandedSince).toEqual({});
+  });
+
+  it('keeps a re-qualifying key, drops a non-re-qualifying one', () => {
+    const r = evaluateStrandedTopics(
+      baseInput({
+        records: [
+          rec({ sessionKey: '100' }), // still quota-walled
+          rec({ sessionKey: '200', ownerMachineId: 'healthy' }), // healthy owner now
+        ],
+        capacities: [
+          selfCap(),
+          cap({ quotaState: { blocked: true } }), // OWNER walled
+          cap({ machineId: 'healthy', quotaState: { blocked: false } }),
+        ],
+        prevStrandedSince: { '100': NOW - 31_000, '200': NOW - 31_000 },
+      }),
+    );
+    expect(r.strandedSet.map((s) => s.sessionKey)).toEqual(['100']);
+    expect(r.nextStrandedSince).toEqual({ '100': NOW - 31_000 }); // 200 dropped
+  });
+});
+
+describe('evaluateStrandedTopics — servablePeerExists annotation', () => {
+  it('true when a healthy peer exists (quota semantics, no scope)', () => {
+    const r = evaluateStrandedTopics(
+      baseInput({
+        records: [rec()],
+        capacities: [
+          selfCap(), // self healthy
+          cap({ quotaState: { blocked: true } }),
+        ],
+        prevStrandedSince: { '100': NOW - 31_000 },
+      }),
+    );
+    expect(r.strandedSet[0].servablePeerExists).toBe(true);
+  });
+
+  it('false when every other machine is also walled (fleet-wide wall)', () => {
+    const r = evaluateStrandedTopics(
+      baseInput({
+        records: [rec()],
+        capacities: [
+          cap({ machineId: SELF, quotaState: { blocked: true } }), // self also walled
+          cap({ quotaState: { blocked: true } }), // OWNER walled
+        ],
+        prevStrandedSince: { '100': NOW - 31_000 },
+      }),
+    );
+    expect(r.strandedSet[0].servablePeerExists).toBe(false);
+  });
+});
+
+describe('StrandedTopicSentinel — tick + aggregated emission', () => {
+  function makeDeps(over: Partial<Parameters<typeof StrandedTopicSentinel.prototype.constructor>[0]> = {}) {
+    const raised: StrandAttentionItem[] = [];
+    const records: SessionOwnershipRecord[] = [rec()];
+    const capacities: MachineCapacity[] = [selfCap(), cap({ quotaState: { blocked: true } })];
+    let clock = NOW;
+    const deps = {
+      listOwnershipRecords: () => records,
+      listCapacities: () => capacities,
+      selfMachineId: () => SELF,
+      holdsLease: () => true,
+      raiseAttention: (i: StrandAttentionItem) => raised.push(i),
+      nicknameOf: (id: string) => (id === OWNER ? 'Mac Mini' : id),
+      now: () => clock,
+      ...over,
+    };
+    return { raised, deps, setClock: (t: number) => (clock = t), records, capacities };
+  }
+
+  it('emits ONE aggregated NORMAL item after the dwell; single-beat is silent', () => {
+    const { raised, deps, setClock } = makeDeps();
+    const s = new StrandedTopicSentinel(deps, { enabled: true, dwellMs: 30_000 });
+
+    s.tick(); // first beat — anchor only
+    expect(raised).toHaveLength(0);
+
+    setClock(NOW + 31_000);
+    s.tick(); // past dwell — fires
+    expect(raised).toHaveLength(1);
+    expect(raised[0].priority).toBe('NORMAL');
+    expect(raised[0].lane).toBe('agent-health');
+    expect(raised[0].id).toContain('stranded-topic:');
+    expect(raised[0].description).toContain('Mac Mini');
+  });
+
+  it('single-machine (selfMachineId null) ⇒ strict no-op, no emission', () => {
+    const { raised, deps } = makeDeps({ selfMachineId: () => null });
+    const s = new StrandedTopicSentinel(deps, { enabled: true, dwellMs: 0 });
+    s.tick();
+    expect(raised).toHaveLength(0);
+  });
+
+  it('emits the LOW can\'t-assess item when an online owner is unassessable', () => {
+    const { raised, deps } = makeDeps({
+      listCapacities: () => [selfCap(), cap({ /* no quota, no serves */ })],
+      resolveScope: () => ({ platform: 'telegram', chatId: 'C1' }),
+    });
+    const s = new StrandedTopicSentinel(deps, { enabled: true, dwellMs: 30_000 });
+    s.tick();
+    const lows = raised.filter((i) => i.priority === 'LOW');
+    expect(lows).toHaveLength(1);
+    expect(lows[0].id).toContain('stranded-topic-blind');
+  });
+
+  it('guardStatus reports enabled + lastTickAt liveness', () => {
+    const { deps } = makeDeps();
+    const s = new StrandedTopicSentinel(deps, { enabled: true });
+    expect(s.guardStatus()).toEqual({ enabled: true, lastTickAt: 0 });
+    s.tick();
+    expect(s.guardStatus().enabled).toBe(true);
+    expect(s.guardStatus().lastTickAt).toBeGreaterThan(0);
+  });
+
+  it('a raiseAttention throw never propagates out of tick (signal-only)', () => {
+    const { deps, setClock } = makeDeps({
+      raiseAttention: () => {
+        throw new Error('boom');
+      },
+    });
+    const s = new StrandedTopicSentinel(deps, { enabled: true, dwellMs: 30_000 });
+    s.tick();
+    setClock(NOW + 31_000);
+    expect(() => s.tick()).not.toThrow();
+  });
+
+  it('disabled ⇒ tick is a no-op (still stamps lastTickAt, raises nothing)', () => {
+    const { raised, deps, setClock } = makeDeps();
+    const s = new StrandedTopicSentinel(deps, { enabled: false, dwellMs: 30_000 });
+    s.tick();
+    setClock(NOW + 31_000);
+    s.tick();
+    expect(raised).toHaveLength(0);
+  });
+});
+
+describe('StrandedTopicSentinel — no spawn-cap / LLM-free invariant', () => {
+  it('tick performs no async work (returns void synchronously, no LLM dep injected)', () => {
+    const raised: StrandAttentionItem[] = [];
+    const s = new StrandedTopicSentinel(
+      {
+        listOwnershipRecords: () => [rec()],
+        listCapacities: () => [selfCap(), cap({ quotaState: { blocked: true } })],
+        selfMachineId: () => SELF,
+        holdsLease: () => true,
+        raiseAttention: (i) => raised.push(i),
+        now: () => NOW + 31_000,
+      },
+      { enabled: true, dwellMs: 30_000 },
+    );
+    // prev anchor via two ticks: first sets anchor, second fires — both sync.
+    const spy = vi.fn();
+    s.on('stranded', spy);
+    s.tick(); // anchor (now is fixed at NOW+31000 but prev empty ⇒ anchor=now ⇒ dwell 0 < 30000)
+    // With a fixed clock the anchor == now, so it never crosses the dwell — assert
+    // it stays sync + silent (no throw, no async).
+    expect(raised).toHaveLength(0);
+    expect(spy).not.toHaveBeenCalled();
+  });
+});

--- a/upgrades/next/stranded-inbound-self-heal.md
+++ b/upgrades/next/stranded-inbound-self-heal.md
@@ -1,0 +1,31 @@
+---
+user_announcement:
+  - audience: agent-only
+    maturity: experimental
+    summary: "(Dev-only, dark on the fleet) A new read-only sentinel detects a conversation whose owner machine is online-by-heartbeat but unable to serve it (quota-walled or adapter-disconnected) and raises ONE attention item — making the silent cross-machine inbound wedge loud within ~a minute instead of waiting for a human to notice missing messages."
+---
+
+## What Changed
+
+A new pure-signal monitoring sentinel, `StrandedTopicSentinel`, ships behind a DARK dev-gate (`monitoring.strandedTopicSentinel.enabled`, omitted from ConfigDefaults ⇒ live on a development agent, dark on the fleet). It closes a real, proven gap: a Telegram/Slack topic's durable ownership record can name a machine that is **online-by-heartbeat but cannot serve** — quota-walled (`quotaState.blocked`) or adapter-disconnected (`servesChannels` omits the topic's channel) — while a healthy machine holds the lease. Inbound for that topic routes to the owner that can't answer, so it is **silently dead** (outbound still flows from the healthy machine — the "my replies send but the user's messages never arrive" split). The existing `OwnershipReconciler` only force-claims a *provably-DEAD* owner (offline ≥180s) and only iterates *pinned* topics, so a walled-but-online owner defers forever and an unpinned strand is never even considered.
+
+The sentinel scans the in-memory ownership cache against the replicated machine-pool view each tick (default 60s), applies a fail-closed predicate with a persistence gate (the unable-to-serve condition must hold ≥2 rich beats over ≥`dwellMs`, default 30s, so a transient quota/adapter blip can't trip it), and raises ONE aggregated `agent-health` attention item per (owner-machine, stranding-window) — never one-per-topic — plus a separate LOW "can't-assess" item if a heartbeat/schema regression blinds it. It is **lease-holder-only** (so peers don't double-report), a **strict no-op on a single-machine agent**, registers in the GuardRegistry (`GET /guards`), and **MUTATES NOTHING** — no ownership CAS, no pin write, no session kill.
+
+This is the deliberately-safe HALF of the fix. Spec-convergence review (3 rounds) established that the *instinctive* auto-failover is unsafe with today's primitives — there is no per-topic remote-liveness signal, the reachability signal is self-reported and up to `failoverThresholdMs` stale, and there's no hysteresis — so a wrong failover would yank a live conversation mid-reply, which is strictly worse than the bug. The auto-failover is therefore deferred to a tracked v2 (`CMT-1786`) whose prerequisites are each named in the spec.
+
+## Evidence
+
+- **Reproduction (the live incident, 2026-06-24):** 17 of 25 topics were owned by an offline/quota-walled Mac Mini; every one had silently-dead Telegram inbound; every code review and CI gate was green the whole time; the wedge surfaced only when the operator reported missing messages. `GET /pool/placement?topic=N` showed `owner=Mini, pendingReplacement:true` — the signal was present and unmonitored. The only recovery was a human hand-editing `.instar/ownership/local/<topicId>.json`.
+- **Before → after:** before, this class of breakage was invisible to all automated checks until a user got bitten. After (dev-gated), the moment a topic's owner is persistently online-but-unable-to-serve, ONE attention item fires within ~`dwellMs + tickMs` (≈ a minute or two on a healthy heartbeat cadence) naming the stranded topics, the walled owner + reason, whether a servable peer exists, and the signal's staleness. Flag off (the fleet) is byte-identical to today (no sentinel).
+- **Safety verified:** the sentinel is pure signal — it raises an attention item and writes nothing. The fail-closed predicate (missing field / stale beat / underivable scope / pool view unavailable ⇒ SKIP) means an uncertainty can never manufacture a strand; the lease-holder-sole-actor + single-machine no-op prevent duplicate items; the aggregated item rides the existing `AttentionTopicGuard` flood ceiling.
+- **Tests:** 29 unit tests on the pure decision core (both sides of every boundary — quota arm, three-valued adapter arm, persistence/dwell, fail-closed skips, `strandedSince` reconciliation, can't-assess counting, servable-peer, single-machine/non-lease-holder no-op, sync/LLM-free invariant) + GuardRegistry registration + a `/guards`-posture integration check. `tsc --noEmit` clean. Multi-angle spec review (6 internal reviewers + GPT-5.5 cross-model, 3 rounds) drove the design from an unsafe auto-failover to this safe detector and caught a critical predicate bug (the three-valued `machineServesChannel` would have made a `!fn(...)` detector never fire).
+
+## What to Tell Your User
+
+Nothing visible day-to-day — it's off everywhere except the development machine until it's soaked. The eventual benefit: a conversation whose messages are silently going to a machine that can't answer them gets caught within about a minute, instead of staying invisible until you notice you're being ignored.
+
+## Summary of New Capabilities
+
+- `monitoring.strandedTopicSentinel.enabled` (dev-gated dark flag): a pure-signal sentinel that detects an online-but-unable-to-serve owner stranding a topic's inbound and raises one aggregated `agent-health` attention item; registered on `GET /guards`.
+- `evaluateStrandedTopics(...)` (pure helper): the unit-testable, fail-closed strand decision (quota arm + best-effort adapter arm + dwell persistence + reconciliation).
+- Deferred (CMT-1786): the auto-failover that actually re-points a stranded topic to a healthy server, plus its named prerequisites (per-topic remote liveness signal, hysteresis/cooldown, claim-time re-assertion, atomic CAS+pin, reason-stamped nonce, OwnershipReconciler unification) and a live userbot harness for real-Telegram UX regression testing.

--- a/upgrades/side-effects/stranded-inbound-self-heal.md
+++ b/upgrades/side-effects/stranded-inbound-self-heal.md
@@ -1,0 +1,80 @@
+# Side-Effects Review — StrandedTopicSentinel (online-but-unable-to-serve inbound detector)
+
+**Version / slug:** `stranded-inbound-self-heal`
+**Date:** `2026-06-24`
+**Author:** Echo (autonomous)
+**Second-pass reviewer:** not-required (Tier 2; dev-gated, pure-signal monitoring sentinel — no mutation, no fleet runtime path, no operator surface)
+
+## Summary of the change
+
+Adds a new dark-gated, pure-signal monitoring sentinel, `StrandedTopicSentinel`, that detects a Telegram/Slack topic whose durable ownership record names a machine that is **online-by-heartbeat but cannot serve** (quota-walled `quotaState.blocked`, or adapter-disconnected `servesChannels` omits the topic's channel) while a healthy machine holds the lease — so inbound for that topic is silently dead. It raises ONE aggregated `agent-health` attention item per (owner-machine, stranding-window) and a separate LOW "can't-assess" item if a heartbeat/schema regression blinds it. It **MUTATES NOTHING** (no ownership CAS, no pin write, no session kill); its sole output is an advisory attention item. The instinctive auto-failover was deferred to a tracked v2 (CMT-1786) because spec-convergence review proved it unsafe with today's primitives (no per-topic remote liveness, self-reported stale reachability, no hysteresis) — a wrong failover drops a live conversation, strictly worse than the bug.
+
+Files added:
+- `src/monitoring/strandedTopicDecision.ts` — the PURE, unit-testable decision core (`evaluateStrandedTopics`): fail-closed predicate (quota arm + best-effort adapter arm), dwell persistence, `strandedSince` reconciliation, `servablePeerExists`.
+- `src/monitoring/StrandedTopicSentinel.ts` — the sentinel (tick loop, per-owner stranding-window discipline, attention emission, `guardStatus`).
+- `tests/unit/stranded-topic-sentinel.test.ts` (29), `tests/integration/stranded-topic-guard-posture.test.ts` (4), `tests/e2e/stranded-topic-guards-lifecycle.test.ts` (2).
+- `docs/specs/stranded-inbound-self-heal.md` (+ `.eli16.md` + convergence report), `upgrades/next/stranded-inbound-self-heal.md`.
+
+Files modified:
+- `src/core/types.ts` — `MonitoringConfig.strandedTopicSentinel?` config type.
+- `src/config/ConfigDefaults.ts` — the `strandedTopicSentinel` defaults block (tickMs/dwellMs/freshnessBoundMs/clearAfterTicks); `enabled` OMITTED (dev-gate decides).
+- `src/core/devGatedFeatures.ts` — `DEV_GATED_FEATURES` entry (pure-signal justification).
+- `src/monitoring/guardManifest.ts` — `GUARD_MANIFEST` entry (`expectRuntime`, `expectedTickMs`).
+- `src/core/SessionOwnershipRegistry.ts` — added `all()` (delegates to `store.all?.()`; reads empty for a store lacking it) so the registry the server holds can be scanned.
+- `src/commands/server.ts` — wires the sentinel (late, after pool boot; `selfMachineId` via a lazy getter to avoid the #1190 boot-ordering null-capture; `raiseAttention` → `telegram.createAttentionItem`; GuardRegistry registration).
+- `tests/unit/lint-dev-agent-dark-gate.test.ts` — hand-shifted the golden line-map keys +14 (my ConfigDefaults block added 14 lines, NO new `enabled:` literal).
+
+## Decision-point inventory
+
+- **Added**: the strand predicate (`evaluateStrandedTopics`) — a READ-ONLY verdict, not a gate. It decides whether to RAISE an attention item; it authorizes no mutation. Fail-closed on every uncertainty.
+- **Added**: the lease-holder-sole-actor + single-machine early-no-op gates — decide WHETHER THIS MACHINE evaluates at all (so peers don't double-report). Observe-only.
+- No agent-to-user or ownership mutation decision point is added. This is pure-signal monitoring.
+
+## 1. Over-block
+
+None — the change blocks nothing. It is observe-only. The only "false positive" risk is a spurious attention item, mitigated by: ≥2-rich-beat dwell persistence (kills transient blips), missing-field/stale-beat/underivable-scope ⇒ SKIP (fail-closed — an uncertainty can never manufacture a strand), and lease-holder-only emission (no duplicate items across machines). A spurious item is cheap and rides the existing `AttentionTopicGuard` flood ceiling.
+
+## 2. Under-block
+
+By design, v1 only DETECTS — it does not remediate; the operator/agent acts on the alert (manual remediation documented in the spec; auto-failover is the tracked v2). The adapter arm is best-effort: for Telegram the channel scope is shared adapter config so the adapter arm rarely fires (the quota arm carries the Telegram case — the actual incident); the adapter arm's real value is Slack per-workspace. A dead (offline) owner is intentionally NOT covered (that is the existing OwnershipReconciler Case C's job) — this sentinel covers only the online-but-unable gap.
+
+## 3. Level-of-abstraction fit
+
+Right layer: a `src/monitoring/` sentinel, mirroring the established pattern (ContextWedgeSentinel/ResumeQueue) — deps-injected, `lastTickAt` liveness, GuardRegistry registration, dark-gate via DEV_GATED_FEATURES. The pure decision is extracted to a separate module so it is unit-testable without tmux/HTTP.
+
+## 4. Signal vs authority compliance
+
+**Required reference:** [docs/signal-vs-authority.md](../../docs/signal-vs-authority.md). FULLY compliant — this is the textbook SIGNAL side. The sentinel holds NO authority: it raises an advisory attention item and writes nothing else (no CAS, no pin, no kill, no direct user message). The deliberate review-driven retreat from a mutating design to a pure detector is exactly the standard's prescription (the dangerous mutation is deferred until the primitives that make it safe exist).
+
+## 5. Interactions
+
+- **OwnershipReconciler (Case C):** disjoint by trigger — Case C covers offline-DEAD+pinned owners; this covers online-but-UNABLE owners (which Case C explicitly defers as `deferredNoEvidence`). No shared writer (this sentinel writes nothing).
+- **AttentionTopicGuard:** the aggregated item rides the existing flood ceiling; NORMAL/LOW priority never bypasses it.
+- **GuardRegistry / GET /guards:** registers so a silently-disabled instance is visible (the exact failure class this feature exists to surface).
+- **Host spawn cap / event loop:** the tick is synchronous, LLM-free, acquires NO spawn-cap slot (asserted by test), and does NO synchronous peer probe — it reads the in-memory ownership cache + replicated heartbeat view only.
+
+## 6. External surfaces
+
+The only external-visible effect is an `agent-health` attention item (and a LOW can't-assess item) when a strand is detected — calm, aggregated, deduped, flood-ceiling-bounded, with signal-staleness disclosed in the text. No new HTTP route, no dashboard change, no message to a user channel.
+
+## 6b. Operator-surface quality (Operator-Surface Quality standard)
+
+No operator surface — not applicable. This change touches no dashboard renderer/markup, approval page, or grant/revoke/secret-drop form. Its only operator-facing output is a plain-language attention item whose text leads with the situation ("inbound for topics X is going to <machine>, which can't serve them; <machine> can"), de-emphasizes identifiers, and discloses signal staleness.
+
+## 7. Multi-machine posture (Cross-Machine Coherence)
+
+**machine-local BY DESIGN.** The detection is per-machine observability over the REPLICATED heartbeat machine-pool view + the local in-memory ownership cache; it writes no durable state, so there is nothing to replicate or strand on a topic transfer. Exactly ONE machine reports per strand: the lease-holder is the sole actor (`syncStatus.holdsLease`), so peers stay observe-only and the user hears one voice. A single-machine agent is a strict no-op (`machines().length < 2` early return — nothing can be stranded on a peer that doesn't exist).
+
+## 8. Rollback cost
+
+Trivial and instant. The feature ships dark on the fleet (`monitoring.strandedTopicSentinel.enabled` omitted ⇒ resolves dark off a dev agent); flag-off is byte-identical to today (no sentinel constructed). On a dev agent, set `monitoring.strandedTopicSentinel.enabled: false` to force-dark. No durable state is written, so there is nothing to clean up on back-out.
+
+## Conclusion
+
+A safe, dark-gated, pure-signal detector that makes a real, proven, previously-invisible cross-machine inbound wedge loud within a bounded window — the deliberately-safe half of the fix, with the dangerous auto-failover deferred behind named, tracked prerequisites (CMT-1786). All three test tiers green; the design passed 3 spec-convergence rounds (6 internal reviewers + GPT-5.5 cross-model).
+
+## Evidence pointers
+
+- Spec + convergence report: `docs/specs/stranded-inbound-self-heal.md`, `docs/specs/reports/stranded-inbound-self-heal-convergence.md`.
+- Live incident (the reproduction): 2026-06-24, 17 of 25 topics stranded on a quota-walled Mac Mini; inbound silently dead; surfaced only when the operator reported missing messages.
+- Tests: unit (29) `tests/unit/stranded-topic-sentinel.test.ts`; integration (4) `tests/integration/stranded-topic-guard-posture.test.ts`; e2e (2) `tests/e2e/stranded-topic-guards-lifecycle.test.ts`.


### PR DESCRIPTION
## ELI16

When I run on more than one machine, each conversation is "owned" by one machine that answers it. On 2026-06-24 a conversation got stuck owned by a machine that was switched on but unable to serve it — the Mac Mini was sending heartbeats but its AI account was rate-limited, so the user's Telegram messages routed there and silently vanished while my replies still went out from the healthy Laptop. 17 of 25 conversations were stuck this way, and every automated test passed the whole time — only the operator noticing missing messages caught it. This PR adds a small read-only watcher that finds any conversation owned by an online-but-unable machine and raises ONE attention item, making the silent wedge loud within ~a minute instead of waiting for a human to notice. It changes nothing on its own (pure signal — no ownership mutation), because spec review proved the instinctive auto-fix (hand the conversation to a healthy machine) is unsafe with today's primitives and could yank a live conversation mid-reply, which is worse than the bug; that auto-failover is deferred to a tracked v2 with its prerequisites named.

## What this ships

A new dark-gated, **pure-signal** `StrandedTopicSentinel` (`src/monitoring/`):
- Detects a topic whose durable owner is `online` but cannot serve it — quota-walled (`quotaState.blocked`) or adapter-disconnected (`servesChannels` omits the channel) — while a healthy machine holds the lease. The existing `OwnershipReconciler` (Case C) only force-claims a provably-DEAD owner and only iterates pinned topics, so this online-but-unable gap was un-monitored.
- Raises ONE aggregated `agent-health` attention item per (owner-machine, stranding-window) + a separate LOW "can't-assess" item if a heartbeat/schema regression blinds it. **MUTATES NOTHING.**
- Fail-closed predicate (quota arm + best-effort adapter arm), ≥2-rich-beat dwell persistence, `strandedSince` reconciliation, lease-holder-sole-actor, single-machine strict no-op, GuardRegistry-registered (`GET /guards`), synchronous + LLM-free + no spawn-cap slot (asserted by test).

Dev-live / dark-fleet (`monitoring.strandedTopicSentinel.enabled` omitted from ConfigDefaults). Flag-off is byte-identical to today.

## Why detection-only (the review-driven descope)

3 spec-convergence rounds (6 internal reviewers + GPT-5.5 cross-model) established the auto-failover cannot be made safe with today's primitives: no per-topic remote-liveness signal (only scalar `activeSessionCount`), the reachability signal is self-reported + up to `failoverThresholdMs` stale, no hysteresis, and the 2-machine quorum is inert. A wrong failover drops a live conversation. The auto-failover + its 7 named prerequisites are deferred to **CMT-1786**.

## Test plan (all three tiers green locally)

- **Unit (29):** the pure decision core — quota/adapter arms, three-valued `machineServesChannel === 'no'`, dwell persistence, fail-closed skips, `strandedSince` reconciliation, can't-assess counting, single-machine/non-lease-holder no-op.
- **Integration (4):** `GUARD_MANIFEST` + `deriveGuardRow` posture + the detection→attention pipeline (raises after the dwell, not before).
- **E2E (2):** the guard is alive on the real `GET /guards` endpoint over HTTP (200, runtime-enriched) + 401 without auth.
- Ratchets handled: golden dark-gate line-map (+14 shift), no-silent-fallbacks (tagged fail-closed catches), devGatedFeatures-wiring, lint-guard-manifest, feature-delivery-completeness.

Spec: `docs/specs/stranded-inbound-self-heal.md` (converged + approved). Side-effects: `upgrades/side-effects/stranded-inbound-self-heal.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)