### PR TITLE
fix(SessionManager): treat pane_dead=1 as a dead session (fixes scheduler wedge under remain-on-exit on)

### DIFF
--- a/src/core/SessionManager.ts
+++ b/src/core/SessionManager.ts
@@ -2504,7 +2504,7 @@ rm()  { "${shimRunner}" rm  "$@"; }
     try {
       const paneInfo = withSyncOp(() => execFileSync(
         this.config.tmuxPath,
-        ['display-message', '-t', `=${tmuxSession}:`, '-p', '#{pane_current_command}||#{pane_start_command}'],
+        ['display-message', '-t', `=${tmuxSession}:`, '-p', '#{pane_dead}||#{pane_current_command}||#{pane_start_command}'],
         { encoding: 'utf-8', timeout: 5000 }
       )).trim();
       const [paneCmd, startCmd] = paneInfo.split('||');
@@ -2540,7 +2540,16 @@ rm()  { "${shimRunner}" rm  "$@"; }
    * original inline code, including the bare-shell log line.
    */
   private classifyPaneCommand(tmuxSession: string, paneInfo: string): boolean {
-    const [paneCmd, startCmd] = paneInfo.split('||');
+    const [paneDead, paneCmd, startCmd] = paneInfo.split('||');
+    // A dead-but-retained pane (tmux `remain-on-exit on`) keeps reporting its
+    // last command (e.g. "claude") after the process exited, which made instar
+    // read the session as ALIVE forever -> the maxParallelJobs slot was never
+    // freed -> scheduler wedge. Treat pane_dead=1 as dead so the session is
+    // reclaimed. Keys on actual process death, never age/duration.
+    if (paneDead === '1') {
+      console.log(`[SessionManager] Session "${tmuxSession}" pane is dead (pane_dead=1) — marking dead.`);
+      return false;
+    }
     if (paneCmd && (paneCmd.includes('claude') || paneCmd.includes('node'))) {
       return true;
     }
@@ -2589,7 +2598,7 @@ rm()  { "${shimRunner}" rm  "$@"; }
       try {
         const { stdout } = await execFileAsync(
           this.config.tmuxPath,
-          ['display-message', '-t', `=${tmuxSession}:`, '-p', '#{pane_current_command}||#{pane_start_command}'],
+          ['display-message', '-t', `=${tmuxSession}:`, '-p', '#{pane_dead}||#{pane_current_command}||#{pane_start_command}'],
           { timeout: 5000 }
         );
         return this.classifyPaneCommand(tmuxSession, stdout.trim());
@@ -2616,7 +2625,7 @@ rm()  { "${shimRunner}" rm  "$@"; }
       '-t',
       `=${tmuxSession}:`,
       '-p',
-      '#{pane_current_command}||#{pane_start_command}',
+      '#{pane_dead}||#{pane_current_command}||#{pane_start_command}',
     ]);
     if (disp.state !== 'success') return true; // unprobeable ⇒ assume alive (preserves the legacy catch)
     return this.classifyPaneCommand(tmuxSession, disp.stdout.trim());


### PR DESCRIPTION
## Problem

When tmux is configured with `set -g remain-on-exit on`, an exited job session's pane is **retained as a dead pane** (`pane_dead=1`) instead of the tmux session being torn down. `SessionManager.classifyPaneCommand` inspects only `#{pane_current_command}`, which a dead pane still reports as its last command (e.g. `claude`). So `isSessionAlive` returns `true` for a session whose process has already exited — the session never transitions `running → completed`, `notifyJobComplete` never fires, and its `maxParallelJobs` slot is never released.

Once every scheduler slot is held by a dead-retained phantom, the scheduler wedges and no further job runs (observed in the wild: a multi-hour wedge). This affects any environment that sets `remain-on-exit on` globally — e.g. to preserve panes for inspection after an OOM kill.

## Root cause

`classifyPaneCommand`, and the three pane-probe call sites that feed it — the sync `isSessionAlive`, the legacy `isSessionAliveAsync` body, and the tri-state async path — never look at `#{pane_dead}`. A dead-but-retained pane is indistinguishable from a live one by command name alone, so it is misclassified as alive forever.

## Fix

- Add `#{pane_dead}` to the three `display-message` probe formats.
- `classifyPaneCommand` short-circuits to **dead** when `pane_dead == '1'`.

It keys on actual process death, never on age or duration, so a legitimately long-running session is unaffected. Behavior is unchanged when `remain-on-exit` is off (the default): a live pane reports `pane_dead=0` and the existing command-name logic runs exactly as before.

## Test

Verified live against a real instar instance: a session whose process exited reports `pane_dead=1` and is now classified dead (its slot reclaimed); a running session reports `pane_dead=0` and stays alive. No change for `remain-on-exit off`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
