### PR TITLE
fix(config): loadConfig must carry sessions.frameworkDefaultModels (pi-cli was silently unavailable)

### DIFF
--- a/.instar/instar-dev-decisions/2026-06-26T04-07-29-731Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-06-26T04-07-29-731Z-unknown.json
@@ -1,0 +1,13 @@
+{
+  "ts": "2026-06-26T04:07:29.731Z",
+  "slug": "unknown",
+  "suggestedTier": 1,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 12,
+  "causalAutopsy": null,
+  "verdict": "pass"
+}

--- a/docs/specs/pi-framework-default-models-loadpath-fix.eli16.md
+++ b/docs/specs/pi-framework-default-models-loadpath-fix.eli16.md
@@ -1,0 +1,44 @@
+# Why pi wouldn't turn on — explained simply
+
+## The short version
+Instar can run its background "thinking" tasks (like the check every message
+passes before it's sent) on different AI engines: Claude, Codex, Gemini, or Pi.
+Pi is the fastest. But no matter how you set things up, Pi would never actually
+switch on — the system kept marking it "unavailable." This fixes that.
+
+## What was actually broken
+Think of your settings file as a form you fill out. One box on that form says
+"which model should Pi use?" — and Pi flatly refuses to start without it (that's
+on purpose: starting Pi with no model picked would make every Pi call fail).
+
+The problem: when the system *read* your settings form at startup, it copied most
+boxes over but **silently skipped the "Pi's model" box.** So by the time it tried
+to start Pi, that box looked empty — even though you'd filled it in. Pi saw "no
+model" and shut itself off. Every single time. On every machine.
+
+The give-away was that the box right next to it ("which engine runs which task")
+had the *exact same bug* once before, back in June, and someone fixed that one but
+didn't notice its neighbor had the same hole.
+
+## The fix
+One small change: when the system reads your settings, also copy over the "Pi's
+model" box — exactly the way it already copies the box next to it. That's it.
+
+## What changes for you
+- If you've told Instar to use Pi, it now actually uses Pi.
+- If you haven't, nothing changes at all — the box stays empty like before.
+- Pi still only turns on if its program is actually installed AND a model is
+  picked, so this can't switch Pi on by accident.
+
+## How we know it works
+- Two automated tests: one proves the "Pi's model" box now gets copied; one proves
+  that if you leave it blank, it stays blank (no phantom values). Both pass.
+- On the live machine: after the fix, Pi shows up as available, the message-check
+  ran on Pi, and a real reply went through on the first try in about 6 seconds —
+  versus the slower, flakier fallback engine it had been stuck on.
+
+## Why it matters
+Pi being permanently off meant we were stuck on slower engines that kept jamming
+up — which is what made replies go quiet. Turning Pi back on restores the fast,
+reliable path and gives us a real fallback option instead of a single point of
+failure.

--- a/src/core/Config.ts
+++ b/src/core/Config.ts
@@ -865,6 +865,18 @@ export function loadConfig(projectDir?: string): InstarConfig {
     typeof fileConfig.sessions.componentFrameworks === 'object'
       ? { componentFrameworks: fileConfig.sessions.componentFrameworks }
       : {}),
+    // Per-framework default model pattern (frameworkDefaultModels['pi-cli'] →
+    // the pi-cli provider's required model). SAME LOAD-PATH GAP as componentFrameworks
+    // above (2026-06-25): server.ts reads config.sessions.frameworkDefaultModels to build
+    // the pi-cli provider, but the loader never copied it from the config FILE here — so
+    // the pattern was always undefined at boot, the factory degraded pi-cli to null
+    // ("binary missing / not built"), and pi-cli was silently UNAVAILABLE on every
+    // deployed agent despite a valid binary + config. Pass it through (the factory still
+    // guards each value; an absent/empty pattern degrades per design).
+    ...(fileConfig.sessions?.frameworkDefaultModels &&
+    typeof fileConfig.sessions.frameworkDefaultModels === 'object'
+      ? { frameworkDefaultModels: fileConfig.sessions.frameworkDefaultModels }
+      : {}),
     // pi-cli subscription-guard override (PI-HARNESS-INTEGRATION-SPEC §4.3).
     // Config surface: top-level `piCli.allowAnthropicProviders` — file-config
     // only, deliberately NOT an env var (no per-boot bypass surface).

--- a/tests/unit/Config.test.ts
+++ b/tests/unit/Config.test.ts
@@ -97,6 +97,54 @@ describe('Config', () => {
       SafeFsExecutor.safeRmSync(tmpDir, { recursive: true, force: true, operation: 'tests/unit/Config.test.ts:componentFrameworks-absent' });
     });
 
+    it('carries sessions.frameworkDefaultModels from config.json into the loaded config (load-path wiring)', () => {
+      // REGRESSION (2026-06-25): the SAME load-path gap class as componentFrameworks
+      // above. server.ts builds the pi-cli provider from
+      // config.sessions.frameworkDefaultModels['pi-cli'] (the required model pattern),
+      // and the docs told users to set it in `.instar/config.json` — but loadConfig
+      // never copied the field from the file, so the pattern was ALWAYS undefined at
+      // boot, the factory degraded pi-cli to null ("binary missing / not built"), and
+      // pi-cli was silently UNAVAILABLE on every deployed agent despite a valid binary.
+      // This is the exact-gap test: a FILE-loaded config must carry the model map.
+      const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'instar-config-test-'));
+      const stateDir = path.join(tmpDir, '.instar');
+      fs.mkdirSync(stateDir, { recursive: true });
+
+      const models = { 'pi-cli': 'openai-codex/gpt-5.5', 'gemini-cli': 'gemini-2.5-flash' };
+      fs.writeFileSync(
+        path.join(stateDir, 'config.json'),
+        JSON.stringify({
+          sessions: {
+            framework: 'claude-code',
+            claudePath: '/usr/local/bin/claude',
+            tmuxPath: '/usr/bin/tmux',
+            frameworkDefaultModels: models,
+          },
+        }),
+      );
+
+      const config = loadConfig(tmpDir);
+      expect(config.sessions.frameworkDefaultModels).toEqual(models);
+      expect(config.sessions.frameworkDefaultModels?.['pi-cli']).toBe('openai-codex/gpt-5.5');
+
+      SafeFsExecutor.safeRmSync(tmpDir, { recursive: true, force: true, operation: 'tests/unit/Config.test.ts:frameworkDefaultModels' });
+    });
+
+    it('omits frameworkDefaultModels when absent from the file (no phantom field)', () => {
+      const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'instar-config-test-'));
+      const stateDir = path.join(tmpDir, '.instar');
+      fs.mkdirSync(stateDir, { recursive: true });
+      fs.writeFileSync(
+        path.join(stateDir, 'config.json'),
+        JSON.stringify({
+          sessions: { framework: 'claude-code', claudePath: '/usr/local/bin/claude', tmuxPath: '/usr/bin/tmux' },
+        }),
+      );
+      const config = loadConfig(tmpDir);
+      expect(config.sessions.frameworkDefaultModels).toBeUndefined();
+      SafeFsExecutor.safeRmSync(tmpDir, { recursive: true, force: true, operation: 'tests/unit/Config.test.ts:frameworkDefaultModels-absent' });
+    });
+
     it('respects sessions.tmuxPath from config.json instead of auto-detecting', () => {
       const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'instar-config-test-'));
       const stateDir = path.join(tmpDir, '.instar');

--- a/upgrades/next/pi-framework-default-models-loadpath-fix.md
+++ b/upgrades/next/pi-framework-default-models-loadpath-fix.md
@@ -1,0 +1,43 @@
+## What Changed
+
+Fixed a config load-path bug that made the `pi-cli` framework permanently
+unavailable on every deployed agent. `loadConfig` built the `sessions` block from
+an explicit field list and never copied `sessions.frameworkDefaultModels` from
+`.instar/config.json` — the same load-path gap class as the 2026-06-06
+`componentFrameworks` fix sitting right beside it. Since the pi-cli provider
+requires its model pattern (`frameworkDefaultModels['pi-cli']`) to build, the
+pattern was always `undefined` at boot, the factory degraded pi-cli to null
+("binary missing / not built"), and pi-cli was silently unavailable despite a
+valid binary and correct config. Added the `frameworkDefaultModels` pass-through
+(same `typeof === 'object'` guard) plus two unit tests (carries / omits-when-absent).
+
+## What to Tell Your User
+
+If you set up a default model for the Pi engine in your config, it now actually
+takes effect — before, it was silently dropped at startup, so Pi could never turn
+on. If you did not set one, nothing changes: Pi still only activates when both its
+program is installed and a model is chosen. This restores the fast, reliable Pi
+backend and gives you a real fallback option instead of a single point of failure.
+
+## Summary of New Capabilities
+
+- The per-framework default-model setting in your config is now honored at boot,
+  unblocking Pi (and any per-framework default-model) routing.
+- No new API surface; one additive, default-absent config field is now read.
+
+## Evidence
+
+- **Reproduction:** Load the real agent config through the v1.3.667 loader and
+  inspect the sessions block — `sessions.frameworkDefaultModels` comes back
+  `undefined` even though it is present in the config file (the loader omits it
+  from its sessions field list, while `componentFrameworks`/`frameworkBinaryPaths`
+  beside it survive).
+- **Observed before:** `/intelligence/routing` reported `pi-cli available:false`;
+  the boot log carried `framework 'pi-cli' unavailable (binary missing / not built)`
+  and `pi-cli routing requested but no model pattern is configured`, despite a valid
+  `pi` binary (0.78.1) and a correct config value.
+- **Observed after:** The patched loader returns the model map intact; deployed to
+  the running agent and restarted, `/intelligence/routing` shows `pi-cli
+  available:true`, the tone gate routed to pi-cli served a real verdict, and a
+  Telegram reply went through on the first attempt at ~6s (versus the slower,
+  flaky fallback it had been stuck on).

--- a/upgrades/side-effects/pi-framework-default-models-loadpath-fix.md
+++ b/upgrades/side-effects/pi-framework-default-models-loadpath-fix.md
@@ -1,0 +1,56 @@
+# Side-Effects — pi-cli load-path fix: loadConfig must carry `sessions.frameworkDefaultModels`
+
+**Tier:** 1 (small, low-risk, single-field config-loader pass-through + tests)
+**Branch:** echo/fix-pi-framework-default-models (off JKHeadley/main @ v1.3.667)
+**Files:** `src/core/Config.ts`, `tests/unit/Config.test.ts`
+
+## What changed
+`loadConfig` (src/core/Config.ts) builds the `sessions` block from an explicit
+field list. It copied `componentFrameworks` (fixed 2026-06-06) but **never copied
+`sessions.frameworkDefaultModels`** from the config file. This change adds the
+identical pass-through for `frameworkDefaultModels`, guarded by the same
+`typeof === 'object'` check so an absent field stays absent (no phantom field).
+
+## Why (root cause)
+`server.ts` builds the pi-cli intelligence provider from
+`config.sessions.frameworkDefaultModels['pi-cli']` (pi's REQUIRED model pattern;
+the factory degrades pi to `null` without it). Because the loader dropped the
+field, the pattern was **always `undefined` at boot** → the factory degraded
+pi-cli to null and logged `framework 'pi-cli' unavailable (binary missing / not
+built)` → **pi-cli was silently UNAVAILABLE on every deployed agent**, despite a
+valid `pi` binary (0.78.1) and a correct config value. Confirmed empirically:
+`loadConfig()` over a config with `sessions.frameworkDefaultModels` returned it
+`undefined` before the fix and the correct map after.
+
+## Blast radius
+- **Surface:** one additive field on the loaded `SessionManagerConfig.sessions`
+  (the type already declares `frameworkDefaultModels?`). No signature changes.
+- **Behavior delta:** agents that set `sessions.frameworkDefaultModels` in
+  `.instar/config.json` now have it honored at boot. Agents that DON'T set it are
+  byte-identical (the field stays `undefined` — covered by the "omits when absent"
+  test). The pi-cli provider only builds when BOTH a binary is detected AND a
+  model pattern is present, so this cannot accidentally activate pi for an agent
+  without the binary.
+- **Who is affected:** any agent that wants pi-cli (or any per-framework default
+  model) — previously impossible to enable via the file; now works.
+
+## Risk / failure modes
+- Low. The field is optional and validated (`typeof === 'object'`). A malformed
+  value can at worst be passed to the factory, which already guards each model
+  value and degrades to the default framework with a report.
+- No migration needed (additive read of an existing-but-dropped file field;
+  default-absent behavior preserved).
+
+## Rollback
+Revert the single Config.ts hunk. The deployed live hotfix on the dev agent has a
+backup at `.instar/shadow-install/node_modules/instar/dist/core/Config.js.pre-pifix-bak`.
+
+## Verification
+- New unit tests: "carries sessions.frameworkDefaultModels …" and "omits …" —
+  both green (Config.test.ts: 9/9 pass).
+- Live: deployed to the running dev agent, restarted, `/intelligence/routing`
+  shows `pi-cli available:true`, the tone gate routed to pi-cli served a real
+  verdict, and a Telegram reply went through first-try at ~6s.
+
+## Tests
+- `tests/unit/Config.test.ts` — load-path wiring (carries) + no-phantom-field (omits).


### PR DESCRIPTION
## What

The config loader (`loadConfig` in src/core/Config.ts) builds the `sessions` block from an explicit field list and never copied `sessions.frameworkDefaultModels` from the config file — the **same load-path gap class** as the 2026-06-06 `componentFrameworks` fix sitting right beside it.

`server.ts` builds the pi-cli provider from `config.sessions.frameworkDefaultModels['pi-cli']` (pi's required model pattern; the factory degrades pi to null without it). Because the loader dropped the field, the pattern was **always undefined at boot**, the factory degraded pi-cli to null ("binary missing / not built"), and **pi-cli was silently UNAVAILABLE on every deployed agent** despite a valid binary (pi 0.78.1) and a correct config value.

## Fix

Add the `frameworkDefaultModels` pass-through in the loader (same `typeof === 'object'` guard as `componentFrameworks`). Additive; default-absent behavior preserved.

## Tests

- `tests/unit/Config.test.ts`: "carries sessions.frameworkDefaultModels …" + "omits when absent …". 9/9 green.

## Evidence (live)

- Before: `/intelligence/routing` → `pi-cli available:false`; boot log `framework 'pi-cli' unavailable (binary missing / not built)`.
- After (deployed to the running dev agent + restart): `pi-cli available:true`, the tone gate routed to pi-cli served a real verdict, and a Telegram reply went through first-try at ~6s.

Tier 1. ELI16 + side-effects + release-note fragment included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## ELI16 — When the agent reads its settings file at startup, it skipped the line that says which model each AI engine should use. So the fast "pi" engine never learned its model and got switched off as "unavailable" on every agent. This change makes the startup reader keep that setting, so pi works again.
