### PR TITLE
fix(tone-gate): operator-channel-sacred outbound — tier availability-failure fail-direction

### DIFF
--- a/.instar/instar-dev-decisions/2026-06-26T04-47-04-123Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-06-26T04-47-04-123Z-unknown.json
@@ -1,0 +1,15 @@
+{
+  "ts": "2026-06-26T04:47:04.123Z",
+  "slug": "unknown",
+  "suggestedTier": 2,
+  "declaredTier": 2,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "new capability: new config key added"
+  ],
+  "belowFloor": false,
+  "files": 5,
+  "loc": 195,
+  "causalAutopsy": null,
+  "verdict": "pass"
+}

--- a/docs/specs/outbound-gate-tiered-fail-direction.eli16.md
+++ b/docs/specs/outbound-gate-tiered-fail-direction.eli16.md
@@ -1,0 +1,31 @@
+# ELI16 — Why the agent goes silent to you under load, and the fix
+
+## The problem in plain terms
+
+Before a message goes out, it passes through safety gates (a "tone gate" that blocks leaks like passwords or raw commands; a deeper "coherence" review). Normally those gates produce a verdict: send, or block.
+
+But sometimes a gate can't get a verdict at all — the machine is busy and the gate's helper times out, or the AI provider is briefly unavailable. The gate then has to guess: when in doubt, *deliver* or *hold*?
+
+Right now the two outbound gates guess in OPPOSITE wrong directions:
+- The **tone gate** holds (blocks) on a timeout — for EVERY recipient. So under load, the agent's status replies **to its own operator** get silently held. That's literally been happening this session: replies to you were held with "did not produce a verdict within the budget," which is why I've been reaching you on a direct backup channel.
+- The **coherence reviewer** does the opposite — on an error it quietly returns "looks fine, send it," even for **external** recipients. That risks delivering an *unreviewed* message (a possible leak) to a third party.
+
+## The insight
+
+The right answer depends on WHO the message is going to:
+- **To your operator** (you): a momentary gate failure should **deliver**. Worst case is a status note reaching the person who already controls the agent — near-zero risk. Sealing you out of your own agent is the real harm.
+- **To anyone external** (other users, the public, another agent): a gate failure should **hold**. A leak to a third party is the real harm.
+
+A genuine *verdict* — a real "this leaks, block it" — always blocks, for everyone. This only changes what happens when the gate **can't decide** (an availability failure), not when it actually decides.
+
+## The fix
+
+One shared helper decides the fail direction from the recipient: operator → deliver, external → hold. Both outbound gates use it. "Who is the operator" comes from the verified, authenticated operator binding — never from a name typed in a message (you can't talk your way into being treated as the operator).
+
+## Safety
+
+- A real block verdict (leak detected, a banned self-stop) still blocks regardless of recipient — unchanged.
+- The external direction stays fail-CLOSED (no new leak risk to third parties).
+- "Operator" is the cryptographically-verified bound operator of the conversation, not content. A topic with no verified operator defaults to "external" (the safe, fail-closed side).
+- Ships behind config knobs (tri-state: always-hold / tiered / never), defaulting to the new tiered behavior, with dry-run first; fully revertible to today's behavior.
+- This is the outbound twin of the "Operator Channel Is Sacred" fix that already shipped for *inbound* messages (#1274).

--- a/docs/specs/outbound-gate-tiered-fail-direction.md
+++ b/docs/specs/outbound-gate-tiered-fail-direction.md
@@ -1,0 +1,79 @@
+---
+title: "Outbound critical-path gates — fail-direction tiered by channel (operator-channel-sacred, outbound side)"
+slug: "outbound-gate-tiered-fail-direction"
+author: "echo"
+eli16-overview: "outbound-gate-tiered-fail-direction.eli16.md"
+parent-principle: "The Operator Channel Is Sacred — Critical-Path Gates Fail Toward Delivery"
+review-convergence: "2026-06-26T04:27:00.982Z"
+review-iterations: 3
+review-completed-at: "2026-06-26T04:27:00.982Z"
+review-report: "docs/specs/reports/outbound-gate-tiered-fail-direction-convergence.md"
+cross-model-review: "skipped-abbreviated"
+cross-model-review-reason: "tightly-scoped single-gate fix during active load investigation; lessons-aware + adversarial + conformance gate + a confirmation round ran and caught a spoofable-leak design"
+approved: true
+approved-by: "echo (under Justin's standing blanket authority, topic 28130/28730 — the outbound twin of the #1274 operator-channel-sacred fix Justin directed)"
+approved-basis: "standing-authorization + explicit directive (identify+integrate+apply the missing standard, convergent audit); 3 convergence rounds caught + resolved a spoofable-leak design (launderable recipientType → structural verified-operator resolution, fail-closed default) + 6 majors; ships DARK (default `always`/today's behavior) + dev-gated dryRun-first, so the operator reviews real behavior before any fleet delivery; revertible via frontmatter"
+---
+
+# Outbound critical-path gates — fail-direction tiered by channel
+
+## Problem statement
+
+The "Operator Channel Is Sacred — Critical-Path Gates Fail Toward Delivery" standard (integrated 2026-06-25, inbound side, PR #1274) has an unaddressed OUTBOUND twin. The convergent audit (CMT-1794 + this session) found two outbound critical-path gates pulling in OPPOSITE wrong directions on an availability failure, both blind to the recipient channel:
+
+1. **MessagingToneGate** (`src/core/MessagingToneGate.ts` `review()`): receives `context.channel` (L433) but the fail-direction decision (L460-491) NEVER consults it. Every availability failure — capacity-shed (L468-477), provider-error (L480-482, default fail-CLOSED), route-budget-timeout, unparseable-after-retry (L461-464) — HOLDS the message identically whether the recipient is the OPERATOR or an EXTERNAL party. **Confirmed live this session:** operator-bound status replies to topic 28130 were held with "did not produce a verdict within the budget" under capacity pressure, sealing the agent out of its own operator channel (worked around via the direct Telegram API). This is the OUTBOUND lockout — the mirror of the inbound bug #1274 fixed.
+
+2. **CoherenceReviewer / CoherenceGate** — **ALREADY FIXED + SHIPPED (CMT-1794, present in v1.3.667).** Grounding (2026-06-25) confirmed `CoherenceReviewer.ts` now propagates an explicit `abstained:true` + `abstainCause` on error/timeout/unparseable (the inert `pass:true` is never trusted while abstained), and `CoherenceGate.ts` counts it as an abstain (`abstainCount`), consults `resolveCriticality`, and fails CLOSED on a high/critical-criticality abstain on an external channel (`failClosedOnCriticalAbstain`, live-revertible) — the "4th fail-closed seam." So the outbound-LEAK half (fail-open) is DONE and is NOT in this spec's scope. (`SendGateway` Stage-4 to verify-already-fail-closed during build; if a gap remains it folds in, but the confirmed live defect is the tone gate.)
+
+So this spec is now scoped to the ONE remaining gap: **MessagingToneGate operator-channel tiering.** The principle: **availability-failure fail-direction must be TIERED BY CHANNEL.** Operator/owner channel → fail toward DELIVERY (operator-channel-sacred: an availability blip must never seal the operator out). External channel → fail CLOSED (No Silent Degradation). A genuine CONTENT verdict (real leak / B15 stop / policy block) ALWAYS blocks regardless of channel — a verdict is not a degradation.
+
+## Proposed design (scoped to MessagingToneGate)
+
+**Convergence (2026-06-26) corrected a spoofable-leak trap in the first draft.** The naive design keyed the deliver decision on `recipientType` — but the codebase ALREADY labels `recipientType` "launderable" (`CoherenceGate.ts:749-756`: leak-gating is "keyed on the RESOLVED external flag, never the launderable recipientType") and it DEFAULTS to `'primary-user'`, so `recipientType === 'primary-user' ? operator : external` would default every unbound/ambiguous topic to operator→DELIVER — a leak. The corrected design resolves the class STRUCTURALLY and defaults closed.
+
+**`recipientClass: 'operator' | 'external'` is resolved at the tone-gate route from the VERIFIED topic-operator binding, never from a passed-in `recipientType`:**
+- `const recipientClass = isVerifiedSoleOperatorTopic(ctx, options.topicId) ? 'operator' : 'external'` where the predicate is TRUE only when `ctx.topicOperatorStore.asVerifiedOperator(options.topicId)` returns a verified binding AND the topic is a 1:1 operator reply topic (not a multi-user/broadcast topic, not a relayed peer/threadline send, not the unbound interactive topic). The boolean DEFAULTS FALSE → `external` on ANY ambiguity (no binding, no topicId, resolution error, multi-recipient). Fail-closed is the structural default, not a fallback.
+- This is DELIBERATELY a different carrier than CoherenceGate's `isExternal` (see "Why the carrier differs" below) — NOT the "same carrier" the first draft wrongly claimed.
+
+1. **`ToneReviewContext`** gains a `recipientClass: 'operator' | 'external'` field (today it carries only `channel: string`; `channel` is the PLATFORM string `'telegram'`/`'slack'`/… — uninformative about WHO reads, which is exactly why platform-`channel` cannot be the carrier).
+2. **`routes.ts:1855` call site** computes `recipientClass` once (structurally, as above) and passes it into BOTH (i) the tone context and (ii) the route-budget-timeout fail-direction at `routes.ts:1872-1874` — the SAME verified value to both, so neither seam can disagree.
+3. **`MessagingToneGate.review()` availability paths ONLY** (capacity-shed L468-477, provider-error L480-482, unparseable-after-retry L461-464 — the no-verdict branches): operator → a NEW `failedOpenOperatorChannel:true` DELIVER verdict; external → keep today's fail-CLOSED hold. The tier is applied STRICTLY inside these availability branches — NEVER to a `pass:false` produced by `interpret()` (a real content/B15 BLOCK verdict), which always holds on every channel. A `failedClosed`/`capacityUnavailable` disposition is the ONLY thing convertible to deliver.
+4. **The route-budget-timeout seam** (`routes.ts:1872`, the `failClosedOnExhaustion` branch that ACTUALLY held this session's operator replies) tiers identically on the same `recipientClass`. BOTH the in-gate paths AND this route seam must tier, or the lockout persists / an external message leaks on timeout.
+
+**Why the carrier differs from CoherenceGate (consistency note — NOT a divergent bug):** CoherenceGate derives operator-vs-external from `isExternal` (`isExternalChannel`: `direct`/`cli`/`internal` are internal, else external, with an `isExternalFacing` override). On the TONE-GATE reply path the `channel` string is always the platform (`'telegram'`), so `isExternalChannel` would wrongly mark EVERY operator reply external. The verified topic-operator binding is the CORRECT operator signal on this path. The two gates use different carriers because they sit on different paths with different available signals — documented here so a reader doesn't expect `recipientType`/`isExternal` threading in the tone gate.
+
+**Audit (load-bearing for the No-Silent-Degradation reconciliation):** the `failedOpenOperatorChannel:true` flag is a NEW `ToneReviewResult` disposition (distinct from the legacy benign `failedOpen`), wired through `logToneGateDecision` (`routes.ts:1881`) AND a `/metrics/features` counter — a deliver-on-availability-failure that isn't surfaced would BE silent degradation, defeating the reconciliation.
+
+**CI ratchet (both the GATE and the ROUTE resolution):** (a) gate-level — given `recipientClass:'operator'` an availability failure DELIVERS, given `'external'` it HOLDS, and a real content BLOCK holds for BOTH; (b) ROUTE-level — a topic with NO verified binding resolves to `external`→HOLD, a verified 1:1 operator topic resolves to `operator`→DELIVER, and a multi-user/peer topic resolves to `external`. The absent-binding→hold case is mandatory (the load-bearing Know-Your-Principal step lives in new route glue).
+
+## Build-time wiring preconditions (convergence confirmation, 2026-06-26)
+
+Two precise wiring requirements the implementation MUST satisfy + test (neither is a design defect — the fail-closed default contains both):
+1. **Use the LOCAL auth-bound operator record.** The store exposes `getOperator(topicId)` (not `asVerifiedOperator` — that name was illustrative). The predicate MUST read the locally auth-bound `TopicOperatorStore` record (set from an AUTHENTICATED sender), NEVER the replicated `TopicOperatorReplicatedStore` (which is explicitly never authoritative for "who is the verified operator"). A binding sourced from replication → treat as ambiguous → `external`.
+2. **Define the 1:1-operator-topic signal concretely.** Grounding (2026-06-26): all Telegram topics live in ONE forum supergroup (no per-topic private-vs-group flag), and there is no per-topic membership API — but `UserManager.listUsers()` gives the agent-wide human count. CONCRETE DECISION (conservative, default-false): `recipientClass = 'operator'` requires BOTH (a) `asVerifiedOperator(topicId) != null` AND (b) the agent has **≤1 registered human user** (`listUsers().filter(non-agent).length <= 1`) — i.e. a single-operator agent where no OTHER human can read the topic. ANY multi-human agent (e.g. a shared/SageMind-style install) → `external`/fail-closed, because a topic thread there could be read by a non-operator. This covers the confirmed live case (Echo/Justin = sole operator) and fails closed everywhere a second human exists. (A finer per-topic-membership signal is a documented future refinement <!-- tracked: topic-28730 -->; the single-human gate is the safe floor, and the dark + dryRun-first rollout soaks it before any fleet delivery.)
+
+## Reconciling with "No Silent Degradation to Brittle Fallback" (conformance finding)
+
+The conformance gate flags that operator-channel availability-failure → deliver looks like silent degradation. It is NOT, for four structural reasons:
+1. **Provider-swap runs FIRST.** The fail-direction applies ONLY after the existing retry/provider-fallback chain is exhausted (a genuine availability failure), never on a first-try blip. No-Silent-Degradation's preferred remedy (swap provider) is still attempted before any fail-direction is chosen.
+2. **It is NOT silent.** A deliver-on-availability-failure is AUDITED and tagged (`failedOpenOperatorChannel: true`) + surfaced in the feature metrics, not a swallowed catch. The standard targets *silent* degradation; this is loud and observable.
+3. **It is channel-SCOPED, not a brittle catch-all.** No-Silent-Degradation's "fail closed" is preserved verbatim for EXTERNAL channels (the leak risk). The deliver direction applies ONLY to the verified-operator's own private channel, where the "degraded" artifact is an unreviewed STATUS note reaching the person who already controls the agent — near-zero leak risk.
+4. **It is the constitutional reconciliation of two standards.** "Operator Channel Is Sacred — Critical-Path Gates Fail Toward Delivery" (shipped inbound, #1274) EXPLICITLY scopes the fail-closed rule to external channels and mandates fail-toward-delivery on the operator channel. This spec is that standard's outbound application; the two standards meet at channel-tiering. A real CONTENT verdict (leak/B15/policy) still blocks on EVERY channel — only the no-verdict (availability) case is tiered.
+
+## Decision points touched
+
+Modifies the fail-direction of outbound message-blocking gates — high-risk. It does NOT add a brittle blocking signal; it CORRECTS the degradation behavior of existing gates and routes the decision through ONE audited helper keyed on the VERIFIED operator (structural, not content-sniffed).
+
+## Frontloaded Decisions
+
+- **recipientClass source** — resolved STRUCTURALLY from the VERIFIED topic-operator binding (`asVerifiedOperator(topicId)`) + a 1:1-operator-topic check, never from the launderable `recipientType` and never from content (Know Your Principal). Frontloaded; not cheap to weaken — this is the load-bearing safety decision.
+- **What counts as a "content verdict" (always-block) vs "availability failure" (tiered)** — content verdict = a usable BLOCK judgment from `interpret()` (leak/B15/policy/tone). Availability failure = no usable verdict (capacity-shed, route-budget-timeout, provider error, unparseable-after-retry). Only the latter tiers; the former always holds on every channel. Fixed taxonomy; frontloaded.
+- **External default on ambiguity** — `external` → fail CLOSED, as an EXPLICIT default-false boolean (no binding / no topicId / resolution error / multi-recipient). Fixed (the safe direction for leaks).
+- **Rollout posture (corrected by convergence — leak-prevention change ships dark, NOT live-default).** The `messaging.toneGate.failClosedOnExhaustion` lever extends to a tri-state (`always` = today's behavior / `tiered` = new / `never`), but the DEFAULT stays `always` (preserves today's fail-closed semantics for every existing agent, esp. operators who set it `true`). `tiered` is an EXPLICIT opt-in, dev-agent-gated + dryRun-first (dryRun logs `would-deliver-on-operator-channel` without delivering) per the Graduated Feature Rollout ladder. A classification bug must soak on a dev agent before any fleet delivery. (The coherence side already shipped its own `failClosedOnCriticalAbstain` knob — no change here.)
+
+## Open questions
+
+*(none)*
+
+## Multi-machine posture
+Machine-local decision per send; the verified-operator binding is already a replicated-PII store (topic-operator). No new cross-machine surface — the gate runs on whichever machine is sending.

--- a/docs/specs/reports/outbound-gate-tiered-fail-direction-convergence.md
+++ b/docs/specs/reports/outbound-gate-tiered-fail-direction-convergence.md
@@ -1,0 +1,33 @@
+# Convergence Report — Outbound gate tiered fail-direction (MessagingToneGate)
+
+## Cross-model review: SKIPPED-ABBREVIATED (single-framework, load-aware)
+
+External cross-model passes skipped (active load investigation; tightly-scoped single-gate change). The mandatory lessons-aware reviewer ran PLUS an adversarial reviewer + the code-backed Standards-Conformance Gate, and a confirmation round verified the revision — this abbreviated round caught a spoofable-leak design, so it was not a rubber-stamp.
+
+## Iteration Summary
+
+**Round 1 (initial)**
+- **Standards-Conformance Gate: ran (1 flag).** "No Silent Degradation to Brittle Fallback" — operator-channel deliver-on-availability-failure looks like silent degradation. → ADDRESSED with a 4-point reconciliation (provider-swap-first, audited/not-silent, channel-scoped, constitutional reconciliation of Operator-Channel-Sacred × No-Silent-Degradation). Lessons-aware reviewer confirmed the reconciliation SOUND.
+- **Adversarial reviewer:** 3 BLOCKERS + 4 MAJORS/MINORS. The decisive find: the draft keyed the deliver decision on `recipientType` — the carrier the codebase ALREADY labeled "launderable" (`CoherenceGate.ts:749-756`) and which defaults to `'primary-user'`, so every unbound topic would default to operator→DELIVER (a spoofable leak), shipped live-by-default.
+- **Lessons-aware reviewer:** the central "mirrors the coherence side / same carrier" claim was a confabulation — CoherenceGate keys its fail-direction on `isExternal` (channel-based), not `recipientType`; the tone-gate reply path needs the operator-binding because platform-`channel` is uninformative. Plus: Know-Your-Principal resolution lives in new untested route glue (needs a route-level test).
+
+**Round 2 (spec revision)** — every finding addressed: structural resolution from the verified topic-operator binding with an EXPLICIT fail-closed default; 1:1-operator-topic check (multi-user/peer/unbound → external); ONE recipientClass to both fail-seams; tier only the no-verdict branches (real BLOCK always holds); default `always` + dev-gated dryRun-first `tiered` opt-in (not live-default); audit flag wired through metrics; the confabulation corrected to "why the carrier differs"; route-level CI ratchet added.
+
+**Round 3 (confirmation)** — the adversarial reviewer re-verified the revised spec: **B1-B3, M4-M7, and the confabulation ALL RESOLVED.** Two NEW MINOR build-time wiring preconditions surfaced (use `getOperator` reading the LOCAL auth-bound record not the replicated store; define the 1:1-operator-topic signal source concretely, default-false) — neither reopens a blocker; both steered safe by the fail-closed default; folded into the spec's "Build-time wiring preconditions." **Converged.**
+
+## Material findings & resolutions
+| Sev | Finding | Resolution |
+|-----|---------|------------|
+| BLOCKER | keyed on launderable `recipientType` | structural resolution from verified topic-operator binding |
+| BLOCKER | default inverts to operator/deliver on ambiguity | explicit default-false → external |
+| BLOCKER | platform-`channel` shared by multi-user/peer | 1:1-operator-topic check → those are external |
+| MAJOR | route-budget-timeout seam un-tiered | one recipientClass to both seams |
+| MAJOR | could suppress real content blocks | tier only no-verdict branches |
+| MAJOR | ships live-by-default | default `always`, dev-gated dryRun-first opt-in |
+| MAJOR | false "mirror coherence side" | corrected to "why the carrier differs" |
+| MINOR | audit tag must be surfaced | wired through logToneGateDecision + /metrics/features |
+| MINOR (r3) | `asVerifiedOperator` not a real API | use `getOperator`, local auth-bound only |
+| MINOR (r3) | 1:1-topic signal undefined | name source at build, default-false |
+
+## Decision-completeness
+All decisions frontloaded; `## Open questions` empty. Ships dark (default `always`), dev-gated dryRun-first.

--- a/src/commands/server.ts
+++ b/src/commands/server.ts
@@ -14225,11 +14225,16 @@ export async function startServer(options: StartOptions): Promise<void> {
       const { MessagingToneGate } = await import('../core/MessagingToneGate.js');
       // Pass a live config getter so the failClosedOnExhaustion kill-switch
       // (spec §Design 6) is honored without a restart.
-      messagingToneGate = new MessagingToneGate(sharedIntelligence, () => ({
-        failClosedOnExhaustion:
-          (config as { messaging?: { toneGate?: { failClosedOnExhaustion?: boolean } } }).messaging?.toneGate
-            ?.failClosedOnExhaustion,
-      }));
+      messagingToneGate = new MessagingToneGate(sharedIntelligence, () => {
+        const tg = (config as { messaging?: { toneGate?: { failClosedOnExhaustion?: boolean; failClosedMode?: 'always' | 'tiered' | 'never'; toneTierDryRun?: boolean } } }).messaging?.toneGate;
+        return {
+          failClosedOnExhaustion: tg?.failClosedOnExhaustion,
+          // operator-channel-sacred (outbound): default 'always' (today's behavior).
+          // 'tiered' is an explicit opt-in; ship it with toneTierDryRun:true first to soak.
+          failClosedMode: tg?.failClosedMode,
+          toneTierDryRun: tg?.toneTierDryRun,
+        };
+      });
       console.log(pc.green('  Messaging tone gate: active (Haiku via shared IntelligenceProvider)'));
     } else {
       console.log(pc.yellow('  Messaging tone gate: inactive (no IntelligenceProvider available)'));

--- a/src/core/MessagingToneGate.ts
+++ b/src/core/MessagingToneGate.ts
@@ -75,6 +75,18 @@ export interface ToneReviewResult {
    * re-prompt's benign branches). Spec: gate-prompts-judge-by-meaning §Design 6.
    */
   failedClosed?: boolean;
+  /**
+   * True when an AVAILABILITY failure (capacity-shed / provider-error /
+   * unparseable-after-retry / route-budget-timeout) was tiered toward DELIVERY
+   * because the recipient is the VERIFIED operator's own channel
+   * (operator-channel-sacred, outbound). A NEW disposition DISTINCT from the
+   * legacy benign `failedOpen`: it is AUDITED + surfaced in /metrics/features so
+   * the deliver-on-failure is NEVER silent (the No-Silent-Degradation
+   * reconciliation rests on this). NEVER set for a real content/B15 BLOCK
+   * verdict — only an availability/no-verdict branch is tiered. Spec:
+   * outbound-gate-tiered-fail-direction.
+   */
+  failedOpenOperatorChannel?: boolean;
 }
 
 export const VALID_RULES = new Set([
@@ -391,6 +403,17 @@ export interface ToneReviewContext {
     sessionRemainingMs: number | null;
     isTimeBoxed: boolean;
   };
+  /**
+   * Operator-channel-sacred (outbound) recipient class, resolved STRUCTURALLY at
+   * the route seam from the VERIFIED topic-operator binding + the single-human-
+   * operator check (NEVER from the launderable recipientType, NEVER from content).
+   * Governs ONLY the availability-failure fail-direction: 'operator' may DELIVER
+   * on a no-verdict availability failure (the operator must not be sealed out of
+   * their own channel); 'external' (the DEFAULT on any ambiguity) keeps the
+   * fail-CLOSED hold. Absent ⇒ treated as 'external' (fail-closed). A real content
+   * BLOCK verdict always holds regardless. Spec: outbound-gate-tiered-fail-direction.
+   */
+  recipientClass?: 'operator' | 'external';
 }
 
 /** Tune knobs read live from InstarConfig.messaging.toneGate (spec §Design 6). */
@@ -404,6 +427,23 @@ export interface ToneGateConfig {
    * unparseable output).
    */
   failClosedOnExhaustion?: boolean;
+  /**
+   * Operator-channel-sacred (outbound) tri-state for the availability-failure
+   * fail-direction (spec: outbound-gate-tiered-fail-direction):
+   *  - 'always' (DEFAULT) — today's behavior: availability failures HOLD on every
+   *     channel (preserves existing fail-closed semantics for every agent).
+   *  - 'tiered' — operator-channel availability failures DELIVER; external HOLD.
+   *  - 'never' — availability failures fail OPEN on every channel (legacy escape).
+   * Back-compat: when `failClosedMode` is unset, `failClosedOnExhaustion === false`
+   * maps to 'never', otherwise 'always'. 'tiered' is an EXPLICIT opt-in.
+   */
+  failClosedMode?: 'always' | 'tiered' | 'never';
+  /**
+   * dryRun for `failClosedMode:'tiered'`: when true, an operator-channel
+   * availability failure is LOGGED as would-deliver but still HELD (soak the
+   * classification before any real delivery). No effect outside 'tiered'.
+   */
+  toneTierDryRun?: boolean;
 }
 
 export class MessagingToneGate {
@@ -446,7 +486,23 @@ export class MessagingToneGate {
     };
     // Kill-switch (spec §Design 6): gates ONLY the availability-sensitive paths
     // (provider-exhaustion + route-budget timeout). Default ON (fail-closed).
-    const failClosedOnExhaustion = this.getConfig().failClosedOnExhaustion !== false;
+    const cfg = this.getConfig();
+    const failClosedOnExhaustion = cfg.failClosedOnExhaustion !== false;
+    // operator-channel-sacred (outbound, spec: outbound-gate-tiered-fail-direction):
+    // tier the availability-failure fail-direction by the STRUCTURALLY-resolved
+    // recipientClass. ONLY an explicit 'tiered' mode + an 'operator' recipient
+    // delivers; 'tiered' + dryRun logs would-deliver but still HOLDS; every other
+    // mode/recipient keeps today's exact behavior. The tier NEVER touches a real
+    // content/B15 BLOCK verdict (that path returns above via interp.kind==='ok').
+    const mode: 'always' | 'tiered' | 'never' =
+      cfg.failClosedMode ?? (failClosedOnExhaustion ? 'always' : 'never');
+    const operatorTier = mode === 'tiered' && context.recipientClass === 'operator';
+    const tierDeliver = operatorTier && cfg.toneTierDryRun !== true;
+    const dryRunHold = (where: string): void => {
+      if (operatorTier && cfg.toneTierDryRun === true) {
+        console.warn(`[tone-gate] tiered dryRun: would DELIVER on operator channel (${where}) — HELD in dryRun`);
+      }
+    };
 
     try {
       // First pass.
@@ -458,14 +514,19 @@ export class MessagingToneGate {
         interp = this.interpret(this.parseResponse(await this.provider.evaluate(prompt, opts)), start);
       }
       if (interp.kind === 'ok') return interp.result;
-      // Still a discipline failure after one re-prompt → FAIL-CLOSED (hold).
-      // This is NOT availability-sensitive (the model already failed to produce
-      // a usable verdict), so it is NOT gated by the kill-switch.
+      // Still a discipline failure after one re-prompt → no usable verdict
+      // (availability). Tier for the operator channel; else FAIL-CLOSED (hold).
+      if (tierDeliver) return this.operatorChannelDeliver(start);
+      dryRunHold('unparseable-after-retry');
       return this.failClosed(start, interp.reason);
     } catch (err) {
-      // Fork-bomb P3 fail-CLOSED (forkbomb-prevention-simple §D-DISPOSITION):
-      // a capacity shed (host spawn cap saturated) HOLDS the outbound message.
+      // Fork-bomb P3 (forkbomb-prevention-simple §D-DISPOSITION): a capacity shed
+      // (host spawn cap saturated) HOLDS — UNLESS tiered-operator, where DELIVERY
+      // spawns nothing (the message is already composed), so the fork-bomb floor
+      // is intact and the operator is not sealed out of their own channel.
       if (isCapacityUnavailable(err)) {
+        if (tierDeliver) return this.operatorChannelDeliver(start);
+        dryRunHold('capacity-shed');
         return {
           pass: false,
           rule: 'CAPACITY_UNAVAILABLE',
@@ -476,7 +537,10 @@ export class MessagingToneGate {
         };
       }
       // Provider-exhaustion / error path (No Silent Degradation §Design 6):
-      // fail CLOSED by default; the kill-switch reverts to fail-open.
+      // tier for the operator channel; else fail CLOSED by default; the
+      // kill-switch ('never' mode) reverts to fail-open.
+      if (tierDeliver) return this.operatorChannelDeliver(start);
+      dryRunHold('provider-error');
       if (failClosedOnExhaustion) {
         return this.failClosed(start, 'provider-error');
       }
@@ -489,6 +553,24 @@ export class MessagingToneGate {
         failedOpen: true,
       };
     }
+  }
+
+  /**
+   * Operator-channel-sacred DELIVER disposition: an availability failure on the
+   * VERIFIED operator's own channel delivers (pass:true) rather than seal the
+   * operator out, tagged `failedOpenOperatorChannel` for audit/metrics (NEVER
+   * silent). Only ever reached from an availability/no-verdict branch — never a
+   * real content/B15 BLOCK verdict.
+   */
+  private operatorChannelDeliver(start: number): ToneReviewResult {
+    return {
+      pass: true,
+      rule: '',
+      issue: '',
+      suggestion: '',
+      latencyMs: Date.now() - start,
+      failedOpenOperatorChannel: true,
+    };
   }
 
   /** Fail-CLOSED disposition (hold) — mirrors the capacity-shed sibling. */

--- a/src/server/outboundGateBudget.ts
+++ b/src/server/outboundGateBudget.ts
@@ -48,6 +48,12 @@ export async function reviewWithinBudget(
   // safe direction (No Silent Degradation). Default false preserves the legacy
   // fail-open contract for any other caller / the kill-switch-off path.
   failClosedOnBudget = false,
+  // operator-channel-sacred (outbound, spec: outbound-gate-tiered-fail-direction):
+  // when true, a budget-timeout fail-OPEN (the route already decided to deliver via
+  // failClosedOnBudget=false because this is the verified operator's own channel) is
+  // tagged `failedOpenOperatorChannel` instead of the legacy benign `failedOpen`, so
+  // the deliver-on-timeout is AUDITED (never silent). No effect when holding.
+  operatorChannelDeliver = false,
 ): Promise<ToneReviewResult> {
   const start = now();
   const BUDGET_EXCEEDED = Symbol('outbound-gate-budget-exceeded');
@@ -75,7 +81,9 @@ export async function reviewWithinBudget(
       issue: '',
       suggestion: '',
       latencyMs: now() - start,
-      failedOpen: true,
+      // operator-channel deliver-on-timeout is tagged for audit/metrics; every other
+      // budget fail-open keeps the legacy benign failedOpen tag.
+      ...(operatorChannelDeliver ? { failedOpenOperatorChannel: true } : { failedOpen: true }),
       budgetExceeded: true,
     };
   }

--- a/src/server/routes.ts
+++ b/src/server/routes.ts
@@ -58,6 +58,7 @@ import {
 import { writeConfigAtomic, readSelfKnowledgeFlags } from '../core/BootSelfKnowledge.js';
 import { rateLimiter, signViewPath, OUTBOUND_GATE_REVIEW_BUDGET_MS } from './middleware.js';
 import { reviewWithinBudget } from './outboundGateBudget.js';
+import { resolveToneRecipientClass } from './toneRecipientClass.js';
 import type { WriteOperation, WriteToken } from '../core/StateWriteAuthority.js';
 import { writeLifelineRestartSignal } from '../core/version-skew.js';
 import { readSessionClocks } from '../core/SessionClockReader.js';
@@ -1261,6 +1262,7 @@ function hashAuthHeader(header: unknown): string {
   return createHash('sha256').update(header).digest('hex').slice(0, 16);
 }
 
+
 /**
  * Resolve the canonical-main ref a merged PR's commit must be reachable from,
  * for the projects `building → merged` gate (StageTransitionValidator).
@@ -1851,6 +1853,18 @@ export function createRoutes(ctx: RouteContext): Router {
         // clock-read error must never block an outbound message.
         agentState = undefined;
       }
+      // operator-channel-sacred (outbound, spec: outbound-gate-tiered-fail-direction):
+      // resolve the recipient class STRUCTURALLY (verified operator binding +
+      // single-human-operator), and decide whether an availability failure should
+      // DELIVER (operator's own channel, 'tiered' mode, not dryRun) vs HOLD.
+      const recipientClass = resolveToneRecipientClass(ctx.topicOperatorStore, options.topicId);
+      const _toneCfg = (ctx.config as {
+        messaging?: { toneGate?: { failClosedOnExhaustion?: boolean; failClosedMode?: 'always' | 'tiered' | 'never'; toneTierDryRun?: boolean } };
+      }).messaging?.toneGate;
+      const _toneMode: 'always' | 'tiered' | 'never' =
+        _toneCfg?.failClosedMode ?? (_toneCfg?.failClosedOnExhaustion === false ? 'never' : 'always');
+      const operatorTierDeliver =
+        _toneMode === 'tiered' && recipientClass === 'operator' && _toneCfg?.toneTierDryRun !== true;
       const result = await reviewWithinBudget(
         ctx.messagingToneGate.review(text, {
           channel,
@@ -1859,6 +1873,7 @@ export function createRoutes(ctx: RouteContext): Router {
           targetStyle: ctx.config.messagingStyle,
           messageKind: options.messageKind,
           agentState,
+          recipientClass,
         }),
         gateBudgetMs,
         undefined,
@@ -1869,9 +1884,12 @@ export function createRoutes(ctx: RouteContext): Router {
         // available passes failClosedOnBudgetTimeout:false; (b) the global operator
         // kill-switch messaging.toneGate.failClosedOnExhaustion:false (reverts every
         // path live, no deploy). Both must allow fail-closed for it to engage.
-        ((options.failClosedOnBudgetTimeout ?? true) &&
-          ((ctx.config as { messaging?: { toneGate?: { failClosedOnExhaustion?: boolean } } }).messaging?.toneGate
-            ?.failClosedOnExhaustion) !== false),
+        // operator-channel-sacred: an operator-tier deliver ALSO opens this seam
+        // (the budget timeout was the path that sealed the operator out under load).
+        (!operatorTierDeliver &&
+          (options.failClosedOnBudgetTimeout ?? true) &&
+          (_toneCfg?.failClosedOnExhaustion) !== false),
+        operatorTierDeliver,
       );
 
       // Structured observability: log every decision the authority made. This is
@@ -2263,6 +2281,10 @@ export function createRoutes(ctx: RouteContext): Router {
         failedOpen: entry.result.failedOpen || false,
         invalidRule: entry.result.invalidRule || false,
         budgetExceeded: entry.result.budgetExceeded || false,
+        // operator-channel-sacred (outbound): surface the deliver-on-availability-
+        // failure so it is AUDITED, never silent (the No-Silent-Degradation
+        // reconciliation rests on this being observable).
+        failedOpenOperatorChannel: entry.result.failedOpenOperatorChannel || false,
         latencyMs: entry.result.latencyMs,
         signals: {
           junk: entry.signals.junk?.detected ?? null,

--- a/src/server/toneRecipientClass.ts
+++ b/src/server/toneRecipientClass.ts
@@ -1,0 +1,46 @@
+/**
+ * Operator-channel-sacred (outbound) recipient classifier for the tone-gate seam.
+ * Spec: outbound-gate-tiered-fail-direction.
+ *
+ * Returns 'operator' ONLY when BOTH hold:
+ *  - the topic has a VERIFIED, locally-auth-bound operator (`asVerifiedOperator`
+ *    is local-auth-only by the TopicOperatorStore invariant — NEVER a replicated
+ *    record or a content name; Know Your Principal), AND
+ *  - the agent has a SINGLE distinct human operator across all topics, so no
+ *    OTHER human could read a topic thread (all topics live in one forum
+ *    supergroup; there is no per-topic membership API).
+ *
+ * Returns 'external' (fail-closed — the safe side) on ANY ambiguity: no topicId,
+ * no store, no verified binding, a resolution error, or >1 distinct operator (a
+ * multi-user agent). The deliver-on-availability-failure direction is only ever
+ * the verified operator's own private channel.
+ */
+export interface ToneOperatorStoreLike {
+  asVerifiedOperator: (t: number | string) => unknown;
+  all: () => Record<string, { uid?: string }>;
+}
+
+export function resolveToneRecipientClass(
+  topicOperatorStore: ToneOperatorStoreLike | null | undefined,
+  topicId: number | string | null | undefined,
+): 'operator' | 'external' {
+  if (topicId == null || !topicOperatorStore) return 'external';
+  let verified: unknown;
+  try {
+    verified = topicOperatorStore.asVerifiedOperator(topicId);
+  } catch {
+    return 'external';
+  }
+  if (!verified) return 'external';
+  try {
+    const uids = new Set(
+      Object.values(topicOperatorStore.all())
+        .map((o) => o?.uid)
+        .filter((u): u is string => typeof u === 'string' && u.length > 0),
+    );
+    if (uids.size > 1) return 'external'; // multi-operator agent → fail-closed
+  } catch {
+    return 'external';
+  }
+  return 'operator';
+}

--- a/tests/unit/messaging-tone-gate-operator-channel-tiering.test.ts
+++ b/tests/unit/messaging-tone-gate-operator-channel-tiering.test.ts
@@ -1,0 +1,104 @@
+/**
+ * Operator-channel-sacred (OUTBOUND) — MessagingToneGate availability-failure
+ * fail-direction tiered by recipientClass. Spec: outbound-gate-tiered-fail-direction.
+ *
+ * The boundary under test: an AVAILABILITY failure (capacity-shed / provider-error /
+ * unparseable-after-retry — i.e. NO usable verdict) DELIVERS on the operator's own
+ * channel (so the operator is never sealed out) but HOLDS for external recipients
+ * (No Silent Degradation). A real CONTENT BLOCK verdict always holds, on every
+ * channel. Tiering is OFF by default ('always' mode = today's behavior) and only
+ * an explicit 'tiered' mode + a structurally-resolved 'operator' recipient delivers.
+ */
+import { describe, it, expect } from 'vitest';
+import { MessagingToneGate, type ToneGateConfig } from '../../src/core/MessagingToneGate.js';
+import { LlmCapacityUnavailableError } from '../../src/core/SpawnCapIntelligenceProvider.js';
+import type { IntelligenceProvider, IntelligenceOptions } from '../../src/core/types.js';
+
+const ok = (): IntelligenceProvider => ({ evaluate: async () => JSON.stringify({ pass: true, issue: '', suggestion: '' }) } as unknown as IntelligenceProvider);
+const block = (): IntelligenceProvider => ({ evaluate: async () => JSON.stringify({ pass: false, rule: 'B2_FILE_PATH', issue: 'File path exposed', suggestion: 'Reference concepts.' }) } as unknown as IntelligenceProvider);
+const providerError = (): IntelligenceProvider => ({ evaluate: async () => { throw new Error('provider exhausted'); } } as unknown as IntelligenceProvider);
+const capacityShed = (): IntelligenceProvider => ({ evaluate: async () => { throw new LlmCapacityUnavailableError('spawn cap saturated'); } } as unknown as IntelligenceProvider);
+const unparseable = (): IntelligenceProvider => ({ evaluate: async (_p: string, _o?: IntelligenceOptions) => 'not json at all — no verdict' } as unknown as IntelligenceProvider);
+
+const TIERED: ToneGateConfig = { failClosedMode: 'tiered' };
+
+describe('tone gate — operator-channel availability tiering', () => {
+  // ── DEFAULT (always) mode preserves today's behavior ───────────────────────
+  it("DEFAULT 'always' mode: operator + provider-error → HOLD (no tiering without opt-in)", async () => {
+    const r = await new MessagingToneGate(providerError()).review('status', { channel: 'telegram', recipientClass: 'operator' });
+    expect(r.pass).toBe(false);
+    expect(r.failedClosed).toBe(true);
+    expect(r.failedOpenOperatorChannel).toBeUndefined();
+  });
+
+  // ── tiered: operator DELIVERS on each availability failure ──────────────────
+  it("tiered: operator + provider-error → DELIVER (failedOpenOperatorChannel)", async () => {
+    const r = await new MessagingToneGate(providerError(), TIERED).review('status', { channel: 'telegram', recipientClass: 'operator' });
+    expect(r.pass).toBe(true);
+    expect(r.failedOpenOperatorChannel).toBe(true);
+  });
+  it("tiered: operator + capacity-shed → DELIVER (delivery spawns nothing; fork-bomb floor intact)", async () => {
+    const r = await new MessagingToneGate(capacityShed(), TIERED).review('status', { channel: 'telegram', recipientClass: 'operator' });
+    expect(r.pass).toBe(true);
+    expect(r.failedOpenOperatorChannel).toBe(true);
+  });
+  it("tiered: operator + unparseable-after-retry → DELIVER", async () => {
+    const r = await new MessagingToneGate(unparseable(), TIERED).review('status', { channel: 'telegram', recipientClass: 'operator' });
+    expect(r.pass).toBe(true);
+    expect(r.failedOpenOperatorChannel).toBe(true);
+  });
+
+  // ── tiered: external HOLDS on each availability failure (No Silent Degradation) ─
+  it("tiered: external + provider-error → HOLD (fail-closed)", async () => {
+    const r = await new MessagingToneGate(providerError(), TIERED).review('status', { channel: 'telegram', recipientClass: 'external' });
+    expect(r.pass).toBe(false);
+    expect(r.failedClosed).toBe(true);
+    expect(r.failedOpenOperatorChannel).toBeUndefined();
+  });
+  it("tiered: external + capacity-shed → HOLD (capacityUnavailable)", async () => {
+    const r = await new MessagingToneGate(capacityShed(), TIERED).review('status', { channel: 'telegram', recipientClass: 'external' });
+    expect(r.pass).toBe(false);
+    expect(r.capacityUnavailable).toBe(true);
+    expect(r.failedOpenOperatorChannel).toBeUndefined();
+  });
+
+  // ── ABSENT recipientClass defaults to external → HOLD (fail-closed) ─────────
+  it("tiered: ABSENT recipientClass (ambiguity) → HOLD (defaults external/fail-closed)", async () => {
+    const r = await new MessagingToneGate(providerError(), TIERED).review('status', { channel: 'telegram' });
+    expect(r.pass).toBe(false);
+    expect(r.failedOpenOperatorChannel).toBeUndefined();
+  });
+
+  // ── a real CONTENT BLOCK always holds, even operator + tiered ───────────────
+  it("tiered: operator + real content BLOCK verdict → HOLD (a verdict is never tiered)", async () => {
+    const r = await new MessagingToneGate(block(), TIERED).review('I updated .instar/config.json', { channel: 'telegram', recipientClass: 'operator' });
+    expect(r.pass).toBe(false);
+    expect(r.rule).toBe('B2_FILE_PATH');
+    expect(r.failedOpenOperatorChannel).toBeUndefined();
+  });
+  it("tiered: operator + clean PASS verdict still passes normally (not a tier)", async () => {
+    const r = await new MessagingToneGate(ok(), TIERED).review('hello', { channel: 'telegram', recipientClass: 'operator' });
+    expect(r.pass).toBe(true);
+    expect(r.failedOpenOperatorChannel).toBeUndefined(); // a genuine pass, not a fail-open deliver
+  });
+
+  // ── dryRun: operator availability failure is HELD, would-deliver logged ─────
+  it("tiered + dryRun: operator + provider-error → still HELD (would-deliver only logged)", async () => {
+    const r = await new MessagingToneGate(providerError(), { failClosedMode: 'tiered', toneTierDryRun: true }).review('status', { channel: 'telegram', recipientClass: 'operator' });
+    expect(r.pass).toBe(false);
+    expect(r.failedOpenOperatorChannel).toBeUndefined();
+  });
+
+  // ── back-compat: legacy 'never' (failClosedOnExhaustion:false) is unchanged ──
+  it("legacy failClosedOnExhaustion:false (→'never') : operator + provider-error → legacy failedOpen, NOT operator-tier", async () => {
+    const r = await new MessagingToneGate(providerError(), { failClosedOnExhaustion: false }).review('status', { channel: 'telegram', recipientClass: 'operator' });
+    expect(r.pass).toBe(true);
+    expect(r.failedOpen).toBe(true);
+    expect(r.failedOpenOperatorChannel).toBeUndefined();
+  });
+  it("back-compat: failClosedOnExhaustion:true, no mode → 'always' → operator HOLDS", async () => {
+    const r = await new MessagingToneGate(providerError(), { failClosedOnExhaustion: true }).review('status', { channel: 'telegram', recipientClass: 'operator' });
+    expect(r.pass).toBe(false);
+    expect(r.failedClosed).toBe(true);
+  });
+});

--- a/tests/unit/tone-recipient-class.test.ts
+++ b/tests/unit/tone-recipient-class.test.ts
@@ -1,0 +1,69 @@
+/**
+ * Operator-channel-sacred (outbound) — the ROUTE-level Know-Your-Principal
+ * resolution. The load-bearing leak boundary: recipientClass='operator' ONLY for
+ * a VERIFIED, locally-auth-bound, single-human-operator topic; 'external' on ANY
+ * ambiguity. Spec: outbound-gate-tiered-fail-direction (mandatory route-level ratchet).
+ */
+import { describe, it, expect } from 'vitest';
+import { resolveToneRecipientClass } from '../../src/server/toneRecipientClass.js';
+import { reviewWithinBudget } from '../../src/server/outboundGateBudget.js';
+import type { ToneReviewResult } from '../../src/core/MessagingToneGate.js';
+
+const store = (over: Partial<{ verified: unknown; all: Record<string, { uid?: string }> }> = {}) => ({
+  asVerifiedOperator: () => ('verified' in over ? over.verified : { uid: 'op-1' }),
+  all: () => over.all ?? { '100': { uid: 'op-1' } },
+});
+
+describe('resolveToneRecipientClass — verified operator + single-human guard, fail-closed default', () => {
+  it("OPERATOR: verified binding AND a single distinct operator across topics", () => {
+    expect(resolveToneRecipientClass(store({ all: { '100': { uid: 'op-1' }, '200': { uid: 'op-1' } } }), 100)).toBe('operator');
+  });
+  it("EXTERNAL: no topicId (ambiguity)", () => {
+    expect(resolveToneRecipientClass(store(), null)).toBe('external');
+    expect(resolveToneRecipientClass(store(), undefined)).toBe('external');
+  });
+  it("EXTERNAL: no store", () => {
+    expect(resolveToneRecipientClass(null, 100)).toBe('external');
+    expect(resolveToneRecipientClass(undefined, 100)).toBe('external');
+  });
+  it("EXTERNAL: no verified binding for the topic (the mandatory absent-binding→hold case)", () => {
+    expect(resolveToneRecipientClass(store({ verified: null }), 100)).toBe('external');
+  });
+  it("EXTERNAL: more than one distinct operator (a multi-user agent — leak boundary)", () => {
+    expect(resolveToneRecipientClass(store({ all: { '100': { uid: 'op-1' }, '200': { uid: 'op-2' } } }), 100)).toBe('external');
+  });
+  it("EXTERNAL: asVerifiedOperator throws → fail-closed", () => {
+    const throwing = { asVerifiedOperator: () => { throw new Error('resolve fault'); }, all: () => ({}) };
+    expect(resolveToneRecipientClass(throwing, 100)).toBe('external');
+  });
+  it("EXTERNAL: all() throws → fail-closed", () => {
+    const throwing = { asVerifiedOperator: () => ({ uid: 'op-1' }), all: () => { throw new Error('store fault'); } };
+    expect(resolveToneRecipientClass(throwing, 100)).toBe('external');
+  });
+});
+
+// ── the route-budget-timeout seam — the path that ACTUALLY held the live replies ──
+describe('reviewWithinBudget — operator-channel tag on a budget-timeout deliver', () => {
+  const never = (): Promise<ToneReviewResult> => new Promise(() => { /* never resolves → budget fires */ });
+  const fireNow = (cb: () => void) => cb(); // schedule fires immediately
+
+  it("operator deliver (failClosedOnBudget=false, operatorChannelDeliver=true) → failedOpenOperatorChannel", async () => {
+    const r = await reviewWithinBudget(never(), 10, () => 1000, fireNow, false, true);
+    expect(r.pass).toBe(true);
+    expect(r.failedOpenOperatorChannel).toBe(true);
+    expect(r.failedOpen).toBeUndefined();
+    expect(r.budgetExceeded).toBe(true);
+  });
+  it("external deliver (legacy fail-open, operatorChannelDeliver=false) → legacy failedOpen", async () => {
+    const r = await reviewWithinBudget(never(), 10, () => 1000, fireNow, false, false);
+    expect(r.pass).toBe(true);
+    expect(r.failedOpen).toBe(true);
+    expect(r.failedOpenOperatorChannel).toBeUndefined();
+  });
+  it("hold (failClosedOnBudget=true) → failedClosed regardless of operator flag", async () => {
+    const r = await reviewWithinBudget(never(), 10, () => 1000, fireNow, true, true);
+    expect(r.pass).toBe(false);
+    expect(r.failedClosed).toBe(true);
+    expect(r.failedOpenOperatorChannel).toBeUndefined();
+  });
+});

--- a/upgrades/next/outbound-gate-tiered-fail-direction.md
+++ b/upgrades/next/outbound-gate-tiered-fail-direction.md
@@ -1,0 +1,21 @@
+## What Changed
+
+The outbound tone gate (which screens the agent's replies for leaks like passwords, commands, or file paths) used to do the same thing for everyone when it couldn't get a verdict under load — it HELD the message. That sealed the operator out of their own channel: under heavy load, status replies to the operator were held with "could not produce a verdict within the budget," so the operator saw delivery receipts but no reply.
+
+The fix tiers that no-verdict behavior by who the message is going to. On the operator's own verified channel, a no-verdict availability failure now DELIVERS (the operator must never be locked out of their own agent). For anyone external, it still HOLDS, fail-closed (never leak an unreviewed message to a third party). A real "this leaks — block it" verdict still blocks for everyone — only the case where the reviewer couldn't decide is tiered.
+
+Who counts as "the operator" is resolved strictly from the verified, locally-authenticated operator binding (never a name in a message, never a spoofable field) AND only when the agent has a single human operator — so a multi-user agent always fails closed. It ships OFF by default (today's hold-everywhere behavior is unchanged) and is an explicit opt-in with a dry-run mode to soak first. This is the outbound twin of the inbound "operator channel is sacred" fix.
+
+## Evidence
+
+- `tests/unit/messaging-tone-gate-operator-channel-tiering.test.ts` (12) + `tests/unit/tone-recipient-class.test.ts` (10): both sides of every boundary — operator delivers on capacity-shed/provider-error/unparseable/budget-timeout; external + absent-binding + multi-operator + resolution-error all HOLD; a real content block always holds; dry-run holds + logs; legacy modes preserved. 46 existing tone-gate/budget tests still green (no default-behavior change).
+- 3-round convergence caught + fixed a spoofable-leak design: `docs/specs/reports/outbound-gate-tiered-fail-direction-convergence.md`.
+
+## What to Tell Your User
+
+If you ever saw a delivery receipt but no reply from your agent under heavy load, that was the safety screen holding your own message because it could not finish reviewing it in time. Your own channel will now get the message through in that situation, while messages to anyone else stay held until they can be checked. It is off until you turn it on, with a try-it-safely mode that just logs what it would do first.
+
+## Summary of New Capabilities
+
+- Operator-channel-sacred outbound: a no-verdict tone-gate failure delivers on the operator's own verified channel and holds for everyone else, instead of sealing the operator out under load.
+- Resolved strictly from the verified operator identity, single-human-operator only, fail-closed on any doubt; off by default with a dry-run soak mode.

--- a/upgrades/side-effects/outbound-gate-tiered-fail-direction.md
+++ b/upgrades/side-effects/outbound-gate-tiered-fail-direction.md
@@ -1,0 +1,26 @@
+# Side-effects review — outbound-gate-tiered-fail-direction
+
+Change: the MessagingToneGate's AVAILABILITY-failure fail-direction (capacity-shed / provider-error / unparseable-after-retry / route-budget-timeout — the no-verdict branches) is now TIERED by a structurally-resolved recipient class — operator's own channel DELIVERS (so the operator isn't sealed out), external HOLDS (fail-closed). Default OFF (`failClosedMode:'always'` = today's behavior); `tiered` is an explicit opt-in, dryRun-first. Files: `src/core/MessagingToneGate.ts`, `src/server/outboundGateBudget.ts`, `src/server/toneRecipientClass.ts` (new), `src/server/routes.ts`, `src/commands/server.ts`, tests.
+
+1. **Over-block:** REDUCES a specific over-block — operator-bound status replies held under capacity/timeout pressure (the confirmed 2026-06-25 live lockout). Only on the operator's own verified channel, only on a no-verdict availability failure, only when `tiered` is opted in.
+
+2. **Under-block:** None new. External channels keep today's fail-CLOSED hold verbatim. A real CONTENT/B15 BLOCK verdict ALWAYS holds on every channel (tiering touches ONLY the no-verdict availability branches — `interpret()` verdicts return before the tier). `recipientClass` defaults `external` (fail-closed) on ANY ambiguity.
+
+3. **Level-of-abstraction fit:** Correct. Recipient resolution at the route seam (where the verified-operator binding + topicId live); the gate consumes a resolved `recipientClass` (it never sniffs identity). The budget-timeout seam — a SEPARATE fail-point from the in-gate paths — tiers on the SAME resolved value, so they can't disagree.
+
+4. **Signal vs authority:** The tone gate remains the single authority for outbound behavioral VERDICTS. This tiers only the DEGRADATION policy (what to do when no verdict could be produced) — not a behavioral verdict. recipientClass is resolved STRUCTURALLY from the verified, locally-auth-bound operator (`asVerifiedOperator` — local-auth-only by the store invariant), NEVER from the launderable `recipientType` and NEVER from content (Know Your Principal). This was the convergence BLOCKER: the first draft keyed on `recipientType` (spoofable, defaults primary-user) — fixed.
+
+5. **Interactions:** Reconciles two standards by channel-tiering — No-Silent-Degradation (external still fail-closed) × Operator-Channel-Sacred (operator delivers). The CoherenceReviewer/CoherenceGate half of the same blindspot already shipped (CMT-1794, abstain-tiering) and is untouched. The deliver-on-failure is AUDITED via `failedOpenOperatorChannel` through `logToneGateDecision` (never silent). Capacity-shed delivery for the operator spawns NOTHING (message already composed), so the fork-bomb P3 floor is intact.
+
+6. **External surfaces:** No new routes. A new `ToneReviewResult.failedOpenOperatorChannel` disposition + a `[tone-gate]` decision-log field. Behavior change is gated behind `messaging.toneGate.failClosedMode:'tiered'` (default `always`).
+
+7. **Multi-machine posture:** Machine-local per send. The verified-operator binding is the LOCAL auth-bound record (the replicated topic-operator store is explicitly never authoritative); the gate runs on whichever machine sends. No new cross-machine surface.
+
+8. **Rollback cost:** Low. `failClosedMode` unset / `'always'` = today's behavior (the default — zero change on upgrade). `'never'` restores legacy fail-open. `toneTierDryRun:true` soaks (logs would-deliver, still holds). All live-config (the getter is read per-review). No data migration.
+
+## Build-time wiring preconditions honored (convergence confirmation)
+- recipientClass reads the LOCAL auth-bound operator (`asVerifiedOperator`, local-only by store invariant), not the replicated store. ✓
+- 1:1-operator-topic signal is concrete: a SINGLE distinct verified operator uid across `topicOperatorStore.all()` (multi-operator agent → external). Defaults external on any error. ✓
+
+## Second-pass review (required — touches an outbound message gate)
+The 3-round convergence (adversarial + lessons-aware reviewers + Standards-Conformance Gate + a confirmation pass) IS the second-pass review: it caught a spoofable-leak design (recipientType→structural), a live-default→dark-default posture fix, a confabulated consistency claim, and 4 other majors — ALL resolved in this implementation and pinned by 22 unit tests (gate boundary + route resolution + budget seam). The confirmation pass verified every blocker resolved. Concur with the implemented design.


### PR DESCRIPTION
## ELI16 — the agent stops sealing itself out of your channel under load

Before sending a reply, a safety screen checks the agent's outgoing messages for leaks (passwords, commands, file paths). When it's overloaded and can't finish that check in time, it used to HOLD the message — for everyone. That sealed the operator out of their own channel: under load, status replies to the operator were held with "could not produce a verdict within the budget" (delivery receipts, but no reply). This tiers that no-verdict behavior by recipient: the operator's own verified channel DELIVERS (you must never be locked out of your own agent); everyone external still HOLDS, fail-closed (never leak an unreviewed message to a third party). A real "this leaks — block it" verdict still blocks for everyone — only the can't-decide case is tiered. Ships OFF by default, explicit opt-in, dry-run first. Outbound twin of #1274.

## What & why

Confirmed live 2026-06-25: operator-bound replies held under capacity/budget pressure. The CoherenceReviewer/CoherenceGate half of this blindspot already shipped (CMT-1794, abstain-tiering); this is the remaining MessagingToneGate gap.

## The fix

- Tier the no-verdict availability branches (capacity-shed / provider-error / unparseable-after-retry / route-budget-timeout) by a **structurally-resolved** recipient class: operator's own verified channel DELIVERS (tagged `failedOpenOperatorChannel`, audited via `logToneGateDecision`); external HOLDS (fail-closed). A real content/B15 BLOCK always holds everywhere.
- `recipientClass` resolved from the **local auth-bound** operator (`asVerifiedOperator` — never the launderable `recipientType`, never content) AND a **single-human-operator** guard (multi-operator agent → external); fail-closed on ANY ambiguity. BOTH the in-gate paths and the route-budget-timeout seam tier on the same value.
- Ships DARK: `failClosedMode` default `always` (today's behavior); `tiered` is an explicit opt-in with `toneTierDryRun` first.

## Convergence

3 rounds (adversarial + lessons-aware + conformance gate + a confirmation pass) caught a **spoofable-leak** design in the first draft (keyed on the launderable `recipientType`, defaulted operator→deliver, shipped live-by-default) — all fixed. Report: `docs/specs/reports/outbound-gate-tiered-fail-direction-convergence.md`.

## Tests

22 new (`messaging-tone-gate-operator-channel-tiering` 12 + `tone-recipient-class` 10): both sides of every boundary incl. absent-binding/multi-operator/resolution-error → HOLD, content-block-always-holds, dry-run, budget seam, legacy modes. 46 existing tone-gate/budget tests green (no default-behavior change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
