### PR TITLE
fix(messaging): tone gate degrades to deterministic floor on LLM outage (F4)

### DIFF
--- a/.instar/instar-dev-decisions/2026-06-26T04-56-17-816Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-06-26T04-56-17-816Z-unknown.json
@@ -1,0 +1,15 @@
+{
+  "ts": "2026-06-26T04:56:17.816Z",
+  "slug": "unknown",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "new capability: new config key added"
+  ],
+  "belowFloor": true,
+  "files": 3,
+  "loc": 182,
+  "causalAutopsy": null,
+  "verdict": "pass"
+}

--- a/docs/specs/tone-gate-graceful-degradation.eli16.md
+++ b/docs/specs/tone-gate-graceful-degradation.eli16.md
@@ -1,0 +1,53 @@
+# Tone-Gate Graceful Degradation — Plain-English Overview
+
+## What broke
+
+Before any reply I send you on Telegram goes out, it passes a quick "tone check"
+— a small AI review that catches things I should never send (a leaked password, a
+file path, a raw command, an internal code name). That check is good. But it had
+one blunt rule: **if the AI doing the check wasn't reachable, hold EVERY message.**
+
+Tonight that rule backfired. The engine running the check got rate-limited and its
+safety switch flipped off. With the checker unreachable, the gate held every single
+reply I tried to send you — for hours. You saw "delivered" receipts but never got a
+reply. The safety mechanism became the outage.
+
+## What this change does
+
+It makes the gate degrade gracefully instead of going dark. When the AI checker is
+unreachable, the gate now falls back to a **fast, built-in, no-AI safety scan** that
+runs right inside the program (no network, no extra processes, so it works even when
+everything else is overloaded). That scan looks for the genuinely dangerous stuff —
+leaked commands, file paths, secrets, internal code names.
+
+- If your reply is **clean** by that scan → it **sends**. You hear from me even
+  during an outage.
+- If your reply actually **contains a leak** → it's still **held**. The dangerous
+  class never escapes, outage or not.
+
+## What already existed vs. what's new
+
+- **Already existed:** the AI tone check, the built-in leak detectors it uses, and a
+  config switch (`failClosedOnExhaustion`) to make the gate stricter or looser.
+- **New:** the gate now uses those same built-in leak detectors as a fallback when
+  the AI checker is down, instead of just freezing. One new internal flag marks a
+  message that went out via this fallback (for the logs).
+
+## The safeguards, in plain terms
+
+- A real leak is **never** sent on the fallback path — only messages the fast scan
+  clears go through.
+- The "host is overloaded" case (a different, brief, self-recovering condition) is
+  left exactly as it was: it still holds and retries. Only the *sustained* outage
+  case — the one that cut you off tonight — changed.
+- The tone/style judgments (is this too jargony, am I quitting on myself) aren't
+  checked during an outage, because those genuinely need the AI. A slightly-off
+  message reaching you beats silence; a leak does not. Full checking resumes the
+  moment the AI checker is back.
+
+## What you'd actually decide
+
+This is on by default because silence is the worse failure. If you ever want the old
+strict behavior back — hold everything when the checker is down, even clean messages
+— there's a one-line config switch (`failClosedOnExhaustion: true`) that restores it
+with no restart. That's the only knob; everything else is automatic.

--- a/docs/specs/tone-gate-graceful-degradation.md
+++ b/docs/specs/tone-gate-graceful-degradation.md
@@ -1,0 +1,85 @@
+# Tone-Gate Graceful Degradation (Postmortem F4)
+
+**Status:** shipped (default-on, operator-reversible)
+**Spec tag:** infra-fix
+**Origin:** 2026-06-25 user-reachability postmortem, failure F4 ("the outbound tone gate must degrade gracefully so the user is NEVER silently cut off"). See `docs/incidents/2026-06-25-user-reachability-postmortem.md`.
+
+## The bug
+
+`claude -p` one-shot calls were rate-limited; the per-provider circuit breaker
+opened; every `MessagingToneGate.review()` LLM call then threw a
+provider-exhaustion error. The gate's provider-error path was **fail-CLOSED by
+default** (`failClosedOnExhaustion !== false`), so it held EVERY outbound message
+unconditionally. The user saw delivery receipts but no replies for hours — a
+silent outbound outage caused by the safety gate itself.
+
+The root pattern (postmortem meta-finding): every guard pointed inward (agent
+correctness, self-continuity); none guarded the user's ability to *hear* the
+agent. A blunt fail-closed hold protects against leaks but, during a sustained
+backend outage, becomes the outage.
+
+## The fix — degrade to the deterministic floor, don't blunt-hold
+
+When the LLM tone authority is UNAVAILABLE for an **infra** reason (provider
+exhaustion / breaker-open / transport error — NOT a content verdict), the gate
+falls through to an **in-process deterministic leak floor** instead of holding:
+
+- `detectGateSignals(text)` — the B1–B7 artifact detectors (cli-command,
+  file-path, config-key, copy-paste-code, api-endpoint, env-var, cron-or-slug).
+- `detectInternalIdLeak(text)` — B20 internal-plumbing leak (CMT-/ACT- ids,
+  endpoint/sentinel names).
+
+The floor is **pure, synchronous, NO LLM and NO subprocess**, so it adds zero
+spawns (it respects the host spawn cap and runs even under saturation).
+
+- **Clean by the floor → SEND** (`pass:true`, `degradedToDeterministic:true`).
+  Closes the F4 gap: a clean message reaches the user during a backend outage.
+- **Leaked artifact → HOLD** (`pass:false`, `failedClosed:true`,
+  `degradedToDeterministic:true`, `rule` names the B-rule). A secret/path/command
+  leak must NEVER escape, even during an outage.
+
+## The decision boundary (degrade vs hold vs open)
+
+| Disposition source | What happened | Default behavior |
+|---|---|---|
+| **Discipline failure** (unparseable / contradictory / invalid-rule after one re-prompt) | The model produced an UNUSABLE verdict — NOT an infra outage | **Pure-hold** (`failedClosed`). Unchanged. |
+| **Capacity shed** (`LlmCapacityUnavailableError`, host spawn cap saturated) | Transient acquire-timeout; the existing retry path recovers | **Pure-hold** (`capacityUnavailable`). Unchanged — preserves the fork-bomb P3 invariant (forkbomb-prevention-simple §D-DISPOSITION). |
+| **Provider exhaustion / error** (breaker-open, rate-limit, transport — FAST throw) | The SUSTAINED outage class that cut the user off | **Degrade to the deterministic floor** (clean sends, leak holds). |
+| **Budget timeout** (the gate STALLS past the outbound route budget — SLOW stall) | The SAME rate-limit outage, slow manifestation (documented 2026-06-08) | **Degrade to the deterministic floor** at the route seam (`reviewWithinBudget`). |
+
+The rate-limit outage has two manifestations and BOTH degrade. The FAST one is a
+provider throw (breaker open) caught inside `review()`. The SLOW one is the gate
+waiting up to `RATE_LIMIT_WAIT_MS` (120s) for a rate-limit window and overrunning
+the route budget — historically the gate finished at 121–185s (the documented
+2026-06-08 failure). Whether tonight's outage threw fast or stalled slow was the
+only difference between "degraded-and-sent" and "still-silently-held"; covering
+both via the shared `buildDegradedToneResult` closes the gap completely. The
+three-valued `failClosedOnExhaustion` override governs both paths identically.
+
+Why capacity-shed is deliberately NOT degraded: it is a brief, self-recovering
+acquire-timeout under genuine host saturation, and the P3 spec mandates
+fail-closed there.
+
+Why behavioral rules (B11–B20 tone/self-stop/parked-on-user) are NOT covered by
+the floor: they require LLM judgment. During an outage a slightly-off-tone
+message reaching the user beats silence; a *leak* does not. The floor enforces
+exactly the non-negotiable subset (leak-class artifacts) deterministically.
+
+## Operator overrides (`messaging.toneGate.failClosedOnExhaustion`)
+
+Three-valued, read live per review (no restart):
+
+- **unset (default)** → degrade-to-deterministic (the F4 behavior above).
+- **`true`** → pure-hold on provider error (restore the legacy strict behavior;
+  No Silent Degradation §Design 6). Use for a channel where even a clean message
+  must not send unreviewed.
+- **`false`** → fail-open (send unchecked on provider error). Legacy permissive.
+
+## Tests
+
+- `tests/unit/MessagingToneGate.test.ts` — provider-throw default: clean SENDS
+  (`degradedToDeterministic`), file-path leak HOLDS (`B2_FILE_PATH`),
+  `failClosedOnExhaustion:true` restores pure-hold.
+- `tests/unit/spawn-cap-fail-closed-gates.test.ts` — test 3 (capacity shed) still
+  pure-holds; test 3b (provider error) degrades: clean sends, leak holds, override
+  pure-holds. Confirms the capacity-vs-provider boundary.

--- a/src/core/MessagingToneGate.ts
+++ b/src/core/MessagingToneGate.ts
@@ -21,7 +21,81 @@
 import crypto from 'node:crypto';
 import type { IntelligenceProvider } from './types.js';
 import { isCapacityUnavailable } from './SpawnCapIntelligenceProvider.js';
-import { detectGateSignals, type GateSignal } from './GateSignalDetectors.js';
+import {
+  detectGateSignals,
+  GATE_SIGNAL_KIND_TO_RULE,
+  type GateSignal,
+} from './GateSignalDetectors.js';
+import { detectInternalIdLeak } from './internal-id-leak.js';
+
+/**
+ * Why the LLM tone authority could not produce a verdict — an INFRA reason
+ * (the backend was unreachable / too slow), distinct from a content verdict.
+ * BOTH manifestations of the same rate-limit outage degrade to the
+ * deterministic floor by default (F4): `provider-error` is the fast throw
+ * (breaker open) inside `review()`; `budget-timeout` is the slow stall raced
+ * out at the outbound route seam (the DOCUMENTED 2026-06-08 production failure).
+ */
+export type DegradeReason = 'provider-error' | 'budget-timeout';
+
+/**
+ * The pure, synchronous deterministic leak floor used on the degraded path
+ * (F4 graceful degradation). NO LLM, NO subprocess — just the B1–B7 artifact
+ * detectors + the internal-id leak detector. Returns the first high-stakes
+ * artifact found (so the degraded path can HOLD it), or null when the text is
+ * clean by deterministic means (so the degraded path can SEND it). The
+ * behavioral rules (B11–B20) require LLM judgment and are deliberately NOT
+ * covered here — a slightly-off-tone message reaching the user beats silence,
+ * but a secret/path/command leak must never escape, even during an outage.
+ */
+export function detectDeterministicLeak(
+  text: string,
+): { rule: string; kind: string } | null {
+  for (const sig of detectGateSignals(text)) {
+    if (sig.detected) {
+      return { rule: GATE_SIGNAL_KIND_TO_RULE[sig.kind], kind: sig.kind };
+    }
+  }
+  if (detectInternalIdLeak(text).leaked) {
+    return { rule: 'B20_INTERNAL_ID_LEAK', kind: 'internal-id-leak' };
+  }
+  return null;
+}
+
+/**
+ * Build the F4 degraded-disposition result for a candidate: run the
+ * deterministic leak floor and SEND if clean / HOLD if it carries a leak. Pure
+ * and shared by BOTH degrade sites — `MessagingToneGate.review()` (provider
+ * throw) and the outbound route seam (`reviewWithinBudget`, slow-stall timeout)
+ * — so the slow and fast manifestations of the same outage degrade identically.
+ * `latencyMs` is supplied by the caller (each site measures its own elapsed).
+ */
+export function buildDegradedToneResult(
+  text: string,
+  latencyMs: number,
+  reason: DegradeReason,
+): ToneReviewResult {
+  const leak = detectDeterministicLeak(text);
+  if (leak) {
+    return {
+      pass: false,
+      rule: leak.rule,
+      issue: `Outbound tone review degraded to the deterministic floor (${reason}) and caught a leak (${leak.kind}).`,
+      suggestion: 'Held on the deterministic floor; revise to remove the leaked artifact, then retry.',
+      latencyMs,
+      failedClosed: true,
+      degradedToDeterministic: true,
+    };
+  }
+  return {
+    pass: true,
+    rule: '',
+    issue: '',
+    suggestion: '',
+    latencyMs,
+    degradedToDeterministic: true,
+  };
+}
 
 /**
  * This is the outbound message gate — the highest-value coherence-critical
@@ -87,6 +161,18 @@ export interface ToneReviewResult {
    * outbound-gate-tiered-fail-direction.
    */
   failedOpenOperatorChannel?: boolean;
+  /**
+   * True when the LLM tone authority was UNAVAILABLE (provider-exhaustion,
+   * capacity-shed, or timeout — an INFRA reason, not a content verdict) and the
+   * review fell through to the in-process deterministic leak floor (B1–B7 +
+   * internal-id) instead of holding unconditionally. The floor needs NO LLM and
+   * NO subprocess, so it runs even under spawn-cap saturation. On this path a
+   * clean message SENDS (pass=true) — closing the F4 "user silently cut off"
+   * gap — while a real leaked artifact still HOLDS (pass=false, failedClosed).
+   * Operators restore pure-hold with `failClosedOnExhaustion: true`.
+   * Spec: docs/specs/tone-gate-graceful-degradation.md (postmortem F4).
+   */
+  degradedToDeterministic?: boolean;
 }
 
 export const VALID_RULES = new Set([
@@ -484,18 +570,25 @@ export class MessagingToneGate {
       rateLimitWaitMs: RATE_LIMIT_WAIT_MS,
       attribution: { component: 'MessagingToneGate', gating: true }, // attribution for /metrics/features
     };
-    // Kill-switch (spec §Design 6): gates ONLY the availability-sensitive paths
-    // (provider-exhaustion + route-budget timeout). Default ON (fail-closed).
     const cfg = this.getConfig();
-    const failClosedOnExhaustion = cfg.failClosedOnExhaustion !== false;
+    // Availability-sensitive disposition (spec §Design 6 + tone-gate-graceful-
+    // degradation F4). THREE-valued — distinguishes "operator forced pure-hold"
+    // from "default degrade-to-deterministic". RAW tri-state (NOT normalized):
+    //   true      → pure-hold (operator restore of the legacy strict behavior)
+    //   false     → fail-open (legacy permissive — send unchecked on outage)
+    //   undefined → DEFAULT: degrade to the in-process deterministic leak floor
+    //               (clean SENDS, leaked artifact HOLDS) — closes the F4 gap.
+    const failClosedOnExhaustion = cfg.failClosedOnExhaustion;
     // operator-channel-sacred (outbound, spec: outbound-gate-tiered-fail-direction):
     // tier the availability-failure fail-direction by the STRUCTURALLY-resolved
     // recipientClass. ONLY an explicit 'tiered' mode + an 'operator' recipient
     // delivers; 'tiered' + dryRun logs would-deliver but still HOLDS; every other
     // mode/recipient keeps today's exact behavior. The tier NEVER touches a real
     // content/B15 BLOCK verdict (that path returns above via interp.kind==='ok').
+    // mode default normalizes undefined→'always' (matching prior behavior) without
+    // collapsing the tri-state above.
     const mode: 'always' | 'tiered' | 'never' =
-      cfg.failClosedMode ?? (failClosedOnExhaustion ? 'always' : 'never');
+      cfg.failClosedMode ?? (cfg.failClosedOnExhaustion !== false ? 'always' : 'never');
     const operatorTier = mode === 'tiered' && context.recipientClass === 'operator';
     const tierDeliver = operatorTier && cfg.toneTierDryRun !== true;
     const dryRunHold = (where: string): void => {
@@ -523,7 +616,10 @@ export class MessagingToneGate {
       // Fork-bomb P3 (forkbomb-prevention-simple §D-DISPOSITION): a capacity shed
       // (host spawn cap saturated) HOLDS — UNLESS tiered-operator, where DELIVERY
       // spawns nothing (the message is already composed), so the fork-bomb floor
-      // is intact and the operator is not sealed out of their own channel.
+      // is intact and the operator is not sealed out of their own channel. This
+      // path is deliberately NOT degraded to the deterministic floor (F4): the
+      // host is too saturated to do extra work and the shed is brief/retryable,
+      // so the P3 invariant (a spawn-cap shed of a gating call fails closed) holds.
       if (isCapacityUnavailable(err)) {
         if (tierDeliver) return this.operatorChannelDeliver(start);
         dryRunHold('capacity-shed');
@@ -536,22 +632,34 @@ export class MessagingToneGate {
           capacityUnavailable: true,
         };
       }
-      // Provider-exhaustion / error path (No Silent Degradation §Design 6):
-      // tier for the operator channel; else fail CLOSED by default; the
-      // kill-switch ('never' mode) reverts to fail-open.
+      // Provider-exhaustion / error path — the SUSTAINED outage class that
+      // silently cut the user off (rate-limit → breaker open → every verdict
+      // dropped). operator-channel-sacred tiers toward DELIVERY for the verified
+      // operator; otherwise THREE-valued (tone-gate-graceful-degradation F4):
+      //   true → pure-hold · false → fail-open · undefined → degrade-to-deterministic.
       if (tierDeliver) return this.operatorChannelDeliver(start);
       dryRunHold('provider-error');
-      if (failClosedOnExhaustion) {
+      if (failClosedOnExhaustion === true) {
+        // Operator override → pure-hold (legacy strict, No Silent Degradation).
         return this.failClosed(start, 'provider-error');
       }
-      return {
-        pass: true,
-        rule: '',
-        issue: '',
-        suggestion: '',
-        latencyMs: Date.now() - start,
-        failedOpen: true,
-      };
+      if (failClosedOnExhaustion === false) {
+        // Operator override → fail-open (legacy permissive: send unchecked).
+        return {
+          pass: true,
+          rule: '',
+          issue: '',
+          suggestion: '',
+          latencyMs: Date.now() - start,
+          failedOpen: true,
+        };
+      }
+      // DEFAULT (F4): degrade to the in-process deterministic leak floor. No LLM,
+      // no subprocess — a clean message SENDS (the user is never silently cut
+      // off during a backend outage); a real leaked artifact still HOLDS. The
+      // SLOW manifestation of this same outage (the gate stalling past the route
+      // budget) degrades identically at the route seam via `reviewWithinBudget`.
+      return buildDegradedToneResult(text, Date.now() - start, 'provider-error');
     }
   }
 

--- a/src/server/outboundGateBudget.ts
+++ b/src/server/outboundGateBudget.ts
@@ -54,6 +54,15 @@ export async function reviewWithinBudget(
   // tagged `failedOpenOperatorChannel` instead of the legacy benign `failedOpen`, so
   // the deliver-on-timeout is AUDITED (never silent). No effect when holding.
   operatorChannelDeliver = false,
+  // tone-gate-graceful-degradation F4: the SLOW manifestation of the rate-limit
+  // outage is the gate STALLING past the budget (the documented 2026-06-08
+  // failure) — the same outage as the fast provider-throw, just slow. When the
+  // route's disposition is the default degrade (NOT a pure-hold override and NOT
+  // fail-open), it passes this callback so the budget timeout degrades to the
+  // SAME in-process deterministic leak floor as `review()`: a clean message
+  // SENDS, a leaked artifact HOLDS. `budgetDegrade` takes precedence over
+  // `failClosedOnBudget`; absent it, the prior hold/open behavior is unchanged.
+  budgetDegrade?: (latencyMs: number) => ToneReviewResult,
 ): Promise<ToneReviewResult> {
   const start = now();
   const BUDGET_EXCEEDED = Symbol('outbound-gate-budget-exceeded');
@@ -64,6 +73,11 @@ export async function reviewWithinBudget(
     ),
   ]);
   if (outcome === BUDGET_EXCEEDED) {
+    if (budgetDegrade) {
+      // F4 default: degrade-to-deterministic (clean sends, leak holds), tagged
+      // budgetExceeded so the latency audit still sees the slow review.
+      return { ...budgetDegrade(now() - start), budgetExceeded: true };
+    }
     if (failClosedOnBudget) {
       return {
         pass: false,

--- a/src/server/routes.ts
+++ b/src/server/routes.ts
@@ -59,6 +59,7 @@ import { writeConfigAtomic, readSelfKnowledgeFlags } from '../core/BootSelfKnowl
 import { rateLimiter, signViewPath, OUTBOUND_GATE_REVIEW_BUDGET_MS } from './middleware.js';
 import { reviewWithinBudget } from './outboundGateBudget.js';
 import { resolveToneRecipientClass } from './toneRecipientClass.js';
+import { buildDegradedToneResult } from '../core/MessagingToneGate.js';
 import type { WriteOperation, WriteToken } from '../core/StateWriteAuthority.js';
 import { writeLifelineRestartSignal } from '../core/version-skew.js';
 import { readSessionClocks } from '../core/SessionClockReader.js';
@@ -1865,6 +1866,24 @@ export function createRoutes(ctx: RouteContext): Router {
         _toneCfg?.failClosedMode ?? (_toneCfg?.failClosedOnExhaustion === false ? 'never' : 'always');
       const operatorTierDeliver =
         _toneMode === 'tiered' && recipientClass === 'operator' && _toneCfg?.toneTierDryRun !== true;
+      // §Design 6 + tone-gate-graceful-degradation F4. The slow-review timeout is
+      // the SLOW manifestation of the same rate-limit outage as a provider throw,
+      // so it mirrors `review()`'s disposition. Precedence (highest first):
+      //   - operator-tier deliver (operator's own channel, 'tiered', not dryRun) → fail-OPEN, tagged
+      //   - per-call opt-out (automated/fixed-template send) → fail-OPEN (stay available)
+      //   - failClosedOnExhaustion:false (operator kill-switch) → fail-OPEN
+      //   - failClosedOnExhaustion:true  (operator strict)      → pure-HOLD (GATE_TIMEOUT)
+      //   - default (unset)                                     → DEGRADE to the
+      //     deterministic leak floor (clean SENDS, leak HOLDS) — closes the F4 gap
+      //     for the slow path, not just the fast throw.
+      const perCallAllowsClosed = options.failClosedOnBudgetTimeout ?? true;
+      const globalFailClosed = _toneCfg?.failClosedOnExhaustion;
+      // Operator-tier delivery suppresses both fail-closed and degrade (we want OPEN).
+      const budgetFailClosed = !operatorTierDeliver && perCallAllowsClosed && globalFailClosed !== false;
+      const budgetDegrade =
+        budgetFailClosed && globalFailClosed !== true
+          ? (latencyMs: number) => buildDegradedToneResult(text, latencyMs, 'budget-timeout')
+          : undefined;
       const result = await reviewWithinBudget(
         ctx.messagingToneGate.review(text, {
           channel,
@@ -1878,18 +1897,15 @@ export function createRoutes(ctx: RouteContext): Router {
         gateBudgetMs,
         undefined,
         undefined,
-        // §Design 6: the slow-review timeout fails CLOSED by default (the safe
-        // direction). Two independent ways to fail OPEN instead: (a) the per-call
-        // opt-out — an automated/fixed-template send (post-update) that must stay
-        // available passes failClosedOnBudgetTimeout:false; (b) the global operator
-        // kill-switch messaging.toneGate.failClosedOnExhaustion:false (reverts every
-        // path live, no deploy). Both must allow fail-closed for it to engage.
-        // operator-channel-sacred: an operator-tier deliver ALSO opens this seam
-        // (the budget timeout was the path that sealed the operator out under load).
-        (!operatorTierDeliver &&
-          (options.failClosedOnBudgetTimeout ?? true) &&
-          (_toneCfg?.failClosedOnExhaustion) !== false),
+        // §Design 6 + F4: the slow-review timeout disposition mirrors review()'s.
+        // `budgetFailClosed` already folds in (a) the per-call opt-out, (b) the
+        // global kill-switch, and (c) operator-tier delivery (which suppresses
+        // fail-closed so the operator is never sealed out under load). When the
+        // disposition is the default (config unset), `budgetDegrade` is defined and
+        // takes precedence in reviewWithinBudget — degrading to the leak floor.
+        budgetFailClosed,
         operatorTierDeliver,
+        budgetDegrade,
       );
 
       // Structured observability: log every decision the authority made. This is

--- a/tests/e2e/provider-fallback-default-policy-lifecycle.test.ts
+++ b/tests/e2e/provider-fallback-default-policy-lifecycle.test.ts
@@ -141,18 +141,33 @@ describe('Wiring-integrity (M11): a gating CALLER receives the router re-throw w
     // routes through the router and receives the throw in its own catch. The
     // wiring-integrity point is that the throw REACHES the caller (the router did not
     // swallow it into a brittle heuristic), so the caller's OWN fail policy decides.
-    // CONTRACT CHANGE (gate-prompts-judge-by-meaning §Design 6): the delivery-path
-    // tone gate's policy on an EXHAUSTED swap chain is now fail-CLOSED (hold) — a
-    // dropped gating verdict is never silently delivered (No Silent Degradation).
-    // failClosedOnExhaustion defaults to true.
+    // CONTRACT (tone-gate-graceful-degradation F4): with failClosedOnExhaustion UNSET
+    // (the default), the delivery-path tone gate DEGRADES to the in-process
+    // deterministic leak floor on an exhausted chain — a CLEAN message SENDS (the user
+    // is never silently cut off) while a real leaked artifact still HOLDS. The throw
+    // having reached the caller is proven by degradedToDeterministic (only the caller's
+    // catch runs the floor). Operators restore pure-hold with failClosedOnExhaustion:true.
     const toneGate = new MessagingToneGate(router);
-    const result = await toneGate.review('hello there', {
-      channel: 'telegram',
-      recentMessages: [],
-      signals: {},
+    const clean = await toneGate.review('hello there', {
+      channel: 'telegram', recentMessages: [], signals: {},
     } as any);
-    expect(result.failedClosed).toBe(true);
-    expect(result.pass).toBe(false); // tone gate now HOLDS on exhaustion — but only AFTER the throw reached it
+    expect(clean.pass).toBe(true); // clean → degrade-SEND, not silenced
+    expect(clean.degradedToDeterministic).toBe(true); // proves the throw reached the caller's floor
+
+    // A real leak on the same exhausted chain still HOLDS — degrade is not a blanket pass.
+    const leak = await toneGate.review('see .instar/config.json', {
+      channel: 'telegram', recentMessages: [], signals: {},
+    } as any);
+    expect(leak.pass).toBe(false);
+    expect(leak.failedClosed).toBe(true);
+
+    // Operator strict override restores pure-hold even for a clean message.
+    const strict = new MessagingToneGate(router, { failClosedOnExhaustion: true });
+    const held = await strict.review('hello there', {
+      channel: 'telegram', recentMessages: [], signals: {},
+    } as any);
+    expect(held.failedClosed).toBe(true);
+    expect(held.pass).toBe(false);
   });
 
   it('a FAIL-CLOSED gating caller propagates the throw (does not silently pass)', async () => {

--- a/tests/integration/telegram-reply-b15-judge-by-meaning.test.ts
+++ b/tests/integration/telegram-reply-b15-judge-by-meaning.test.ts
@@ -9,8 +9,11 @@
  *   2. The §Design 1 structured-intermediate flows end-to-end: a model that
  *      returns pass:true but structured fields flagging an agent-state stop is
  *      DERIVED to a B15 block at the route (suppressed).
- *   3. FAIL-CLOSED: when the provider throws, the route HOLDS the message
- *      (pass=false, not delivered) — No Silent Degradation, end-to-end.
+ *   3. F4 graceful degradation: when the provider throws (LLM-backend outage)
+ *      with failClosedOnExhaustion unset, the route DEGRADES to the deterministic
+ *      leak floor end-to-end — a clean message SENDS (200), a leak HOLDS (422),
+ *      and the operator strict override restores pure-hold. (Replaces the prior
+ *      pure-fail-closed assertion; tone-gate-graceful-degradation, postmortem F4.)
  *   4. The happy path still delivers (200) — the rule does not over-block.
  */
 
@@ -94,11 +97,32 @@ describe('gate-prompts-judge-by-meaning — POST /telegram/reply integration', (
     expect(sent.length).toBe(0);
   });
 
-  it('FAILS CLOSED end-to-end when the provider throws — message HELD, not delivered', async () => {
+  // tone-gate-graceful-degradation F4: when the provider throws (LLM-backend
+  // outage) with failClosedOnExhaustion UNSET (the default), the route DEGRADES
+  // to the in-process deterministic leak floor end-to-end — a CLEAN message
+  // SENDS (200; the user is never silently cut off) while a real leak still
+  // HOLDS (422). Operators restore pure-hold with failClosedOnExhaustion:true.
+  it('F4: provider throws + CLEAN message → DEGRADE-SEND end-to-end (200, delivered)', async () => {
     const sent: Array<{ topicId: number; text: string }> = [];
     server = await listen(buildApp(new MessagingToneGate(providerThrowing()), sent));
     const r = await reply(28130, 'any outbound message');
-    expect(r.status).toBe(422); // held (pass=false) — not a 200 delivery
+    expect(r.status).toBe(200); // degrade-send — the floor passed a clean message
+    expect(sent).toEqual([{ topicId: 28130, text: 'any outbound message' }]);
+  });
+
+  it('F4: provider throws + LEAK → still HELD end-to-end (422), degrade is not a blanket pass', async () => {
+    const sent: Array<{ topicId: number; text: string }> = [];
+    server = await listen(buildApp(new MessagingToneGate(providerThrowing()), sent));
+    const r = await reply(28130, 'see .instar/config.json');
+    expect(r.status).toBe(422); // a real leak is held even on the degrade path
+    expect(sent.length).toBe(0);
+  });
+
+  it('F4 operator override: failClosedOnExhaustion:true + provider throws → pure-HOLD even for clean (422)', async () => {
+    const sent: Array<{ topicId: number; text: string }> = [];
+    server = await listen(buildApp(new MessagingToneGate(providerThrowing(), { failClosedOnExhaustion: true }), sent));
+    const r = await reply(28130, 'any outbound message');
+    expect(r.status).toBe(422); // strict mode restores the legacy fail-closed hold
     expect(sent.length).toBe(0);
   });
 

--- a/tests/unit/MessagingToneGate.test.ts
+++ b/tests/unit/MessagingToneGate.test.ts
@@ -329,14 +329,51 @@ describe('MessagingToneGate', () => {
   });
 
   describe('fail-CLOSED behavior (No Silent Degradation §Design 6)', () => {
-    it('fails CLOSED (pass=false, held) when the provider throws', async () => {
+    // F4 graceful degradation (tone-gate-graceful-degradation): the DEFAULT
+    // provider-throw disposition is no longer a blunt hold — it degrades to the
+    // in-process deterministic leak floor so a clean message still reaches the
+    // user during a backend outage (the bug that silently cut the user off when
+    // claude -p was rate-limited). A real leak still HOLDS on that path.
+    it('DEGRADES to the deterministic floor and SENDS a clean message when the provider throws (F4 default)', async () => {
       const provider = errorProvider(new Error('network timeout'));
       const gate = new MessagingToneGate(provider);
 
-      const result = await gate.review('some message', { channel: 'telegram' });
+      const result = await gate.review(
+        'I will run the migration and push the change for you.',
+        { channel: 'telegram' },
+      );
+
+      expect(result.pass).toBe(true);
+      expect(result.degradedToDeterministic).toBe(true);
+      expect(result.failedClosed).toBeFalsy();
+    });
+
+    it('still HOLDS a leaked artifact on the degraded floor when the provider throws (F4 leak-safety)', async () => {
+      const provider = errorProvider(new Error('network timeout'));
+      const gate = new MessagingToneGate(provider);
+
+      // A B2 file-path leak — the deterministic floor must catch it even with no LLM.
+      const result = await gate.review('see /Users/justin/.instar/config.json', {
+        channel: 'telegram',
+      });
 
       expect(result.pass).toBe(false);
       expect(result.failedClosed).toBe(true);
+      expect(result.degradedToDeterministic).toBe(true);
+      expect(result.rule).toBe('B2_FILE_PATH');
+    });
+
+    it('restores pure-hold on a provider throw when failClosedOnExhaustion is true (operator override)', async () => {
+      const provider = errorProvider(new Error('network timeout'));
+      const gate = new MessagingToneGate(provider, { failClosedOnExhaustion: true });
+
+      const result = await gate.review('I will run the migration for you.', {
+        channel: 'telegram',
+      });
+
+      expect(result.pass).toBe(false);
+      expect(result.failedClosed).toBe(true);
+      expect(result.degradedToDeterministic).toBeFalsy();
     });
 
     it('reverts the provider-throw path to fail-open when the kill-switch is off', async () => {

--- a/tests/unit/messaging-tone-gate-operator-channel-tiering.test.ts
+++ b/tests/unit/messaging-tone-gate-operator-channel-tiering.test.ts
@@ -20,12 +20,17 @@ const providerError = (): IntelligenceProvider => ({ evaluate: async () => { thr
 const capacityShed = (): IntelligenceProvider => ({ evaluate: async () => { throw new LlmCapacityUnavailableError('spawn cap saturated'); } } as unknown as IntelligenceProvider);
 const unparseable = (): IntelligenceProvider => ({ evaluate: async (_p: string, _o?: IntelligenceOptions) => 'not json at all — no verdict' } as unknown as IntelligenceProvider);
 
-const TIERED: ToneGateConfig = { failClosedMode: 'tiered' };
+// Strict baseline: pins the availability disposition to HOLD so these tests
+// isolate the TIERING boundary (operator delivers vs external/absent holds)
+// independent of the F4 default (which, with failClosedOnExhaustion unset,
+// DEGRADES clean messages — covered in MessagingToneGate.test.ts /
+// outbound-gate-budget.test.ts, and in the F4-interaction test at the bottom).
+const TIERED: ToneGateConfig = { failClosedMode: 'tiered', failClosedOnExhaustion: true };
 
 describe('tone gate — operator-channel availability tiering', () => {
-  // ── DEFAULT (always) mode preserves today's behavior ───────────────────────
-  it("DEFAULT 'always' mode: operator + provider-error → HOLD (no tiering without opt-in)", async () => {
-    const r = await new MessagingToneGate(providerError()).review('status', { channel: 'telegram', recipientClass: 'operator' });
+  // ── 'always' (strict) mode: no tiering without opt-in ──────────────────────
+  it("'always' mode (strict): operator + provider-error → HOLD (no tiering without opt-in)", async () => {
+    const r = await new MessagingToneGate(providerError(), { failClosedOnExhaustion: true }).review('status', { channel: 'telegram', recipientClass: 'operator' });
     expect(r.pass).toBe(false);
     expect(r.failedClosed).toBe(true);
     expect(r.failedOpenOperatorChannel).toBeUndefined();
@@ -84,8 +89,30 @@ describe('tone gate — operator-channel availability tiering', () => {
 
   // ── dryRun: operator availability failure is HELD, would-deliver logged ─────
   it("tiered + dryRun: operator + provider-error → still HELD (would-deliver only logged)", async () => {
-    const r = await new MessagingToneGate(providerError(), { failClosedMode: 'tiered', toneTierDryRun: true }).review('status', { channel: 'telegram', recipientClass: 'operator' });
+    const r = await new MessagingToneGate(providerError(), { failClosedMode: 'tiered', toneTierDryRun: true, failClosedOnExhaustion: true }).review('status', { channel: 'telegram', recipientClass: 'operator' });
     expect(r.pass).toBe(false);
+    expect(r.failedOpenOperatorChannel).toBeUndefined();
+  });
+
+  // ── F4 interaction: operator-tier DELIVER takes precedence over degrade ─────
+  // With failClosedOnExhaustion UNSET, the default availability disposition is
+  // F4 degrade-to-deterministic. But on the operator's own channel in 'tiered'
+  // mode, operator-tier DELIVERY still wins (checked before the degrade), so a
+  // would-be-HELD leak from the operator is delivered (sacred channel), tagged
+  // failedOpenOperatorChannel — NOT degradedToDeterministic.
+  it("F4 interaction: tiered operator + LEAK + provider-error → DELIVER via operator-tier (precedence over degrade)", async () => {
+    const r = await new MessagingToneGate(providerError(), { failClosedMode: 'tiered' }).review('see .instar/config.json', { channel: 'telegram', recipientClass: 'operator' });
+    expect(r.pass).toBe(true);
+    expect(r.failedOpenOperatorChannel).toBe(true);
+    expect(r.degradedToDeterministic).toBeUndefined();
+  });
+  // And the non-operator default (no config) degrades: a clean external message
+  // SENDS via the deterministic floor rather than holding (the F4 fix), without
+  // ever being tagged an operator-tier deliver.
+  it("F4 default (no config): external + clean + provider-error → DEGRADE-SEND (not operator-tier)", async () => {
+    const r = await new MessagingToneGate(providerError()).review('status', { channel: 'telegram', recipientClass: 'external' });
+    expect(r.pass).toBe(true);
+    expect(r.degradedToDeterministic).toBe(true);
     expect(r.failedOpenOperatorChannel).toBeUndefined();
   });
 

--- a/tests/unit/outbound-gate-budget.test.ts
+++ b/tests/unit/outbound-gate-budget.test.ts
@@ -17,7 +17,10 @@
 
 import { describe, it, expect } from 'vitest';
 import { reviewWithinBudget } from '../../src/server/outboundGateBudget.js';
-import type { ToneReviewResult } from '../../src/core/MessagingToneGate.js';
+import {
+  buildDegradedToneResult,
+  type ToneReviewResult,
+} from '../../src/core/MessagingToneGate.js';
 import {
   OUTBOUND_GATE_REVIEW_BUDGET_MS,
   OUTBOUND_MESSAGING_TIMEOUT_MS,
@@ -115,6 +118,55 @@ describe('reviewWithinBudget — outbound gate budget', () => {
     expect(result.pass).toBe(false); // HELD, not delivered
     expect(result.failedClosed).toBe(true);
     expect(result.budgetExceeded).toBe(true);
+  });
+
+  // tone-gate-graceful-degradation F4: the SLOW manifestation of the rate-limit
+  // outage (the gate stalling past budget) is the DOCUMENTED 2026-06-08 failure.
+  // By default the route now passes a budgetDegrade callback so the timeout
+  // degrades to the SAME deterministic leak floor as a fast provider throw —
+  // closing the F4 gap for the slow path, not just the fast one.
+  it('DEGRADES and SENDS a clean message on budget-exceed when budgetDegrade is supplied (F4 slow path)', async () => {
+    const neverResolves = new Promise<ToneReviewResult>(() => {});
+    let clock = 1000;
+    const result = await reviewWithinBudget(
+      neverResolves,
+      20_000,
+      () => {
+        const t = clock;
+        clock += 20_000;
+        return t;
+      },
+      immediateSchedule,
+      true, // failClosedOnBudget — budgetDegrade must take PRECEDENCE over it
+      false, // operatorChannelDeliver
+      (latencyMs) => buildDegradedToneResult('I will push the change for you.', latencyMs, 'budget-timeout'),
+    );
+    expect(result.pass).toBe(true); // clean → sent, not silently held
+    expect(result.degradedToDeterministic).toBe(true);
+    expect(result.budgetExceeded).toBe(true);
+  });
+
+  it('DEGRADES and HOLDS a leaked artifact on budget-exceed (F4 leak-safety on the slow path)', async () => {
+    const neverResolves = new Promise<ToneReviewResult>(() => {});
+    let clock = 1000;
+    const result = await reviewWithinBudget(
+      neverResolves,
+      20_000,
+      () => {
+        const t = clock;
+        clock += 20_000;
+        return t;
+      },
+      immediateSchedule,
+      true,
+      false, // operatorChannelDeliver
+      (latencyMs) => buildDegradedToneResult('see /Users/justin/.instar/config.json', latencyMs, 'budget-timeout'),
+    );
+    expect(result.pass).toBe(false); // a real leak is still HELD on the slow path
+    expect(result.failedClosed).toBe(true);
+    expect(result.degradedToDeterministic).toBe(true);
+    expect(result.budgetExceeded).toBe(true);
+    expect(result.rule).toBe('B2_FILE_PATH');
   });
 
   it('records a non-negative latencyMs on the budget-exceeded fail-open', async () => {

--- a/tests/unit/spawn-cap-fail-closed-gates.test.ts
+++ b/tests/unit/spawn-cap-fail-closed-gates.test.ts
@@ -87,18 +87,27 @@ describe('Fork-bomb P3 — four fail-CLOSED gate seams under capacity shed', () 
     expect(r.capacityUnavailable).toBe(true);
   });
 
-  it('3b. MessagingToneGate: a GENERIC LLM error now fails CLOSED (No-Silent-Degradation §Design 6)', async () => {
-    // CONTRACT CHANGE (gate-prompts-judge-by-meaning §Design 6): the delivery-path
-    // tone gate's provider-exhaustion path was flipped fail-OPEN → fail-CLOSED. A
-    // single erroring provider exhausts the swap chain → HOLD (pass:false), never a
-    // silent deliver. (`failClosedOnExhaustion` defaults to true.) The sentinel /
-    // input-guard generic-error paths above STILL fail open — only the outbound
-    // tone gate changed, because a held outbound message is recoverable via the
-    // existing retry path while a blocked inbound classification is more disruptive.
+  it('3b. MessagingToneGate: a GENERIC LLM error DEGRADES to the deterministic floor — clean SENDS, leak HOLDS (F4)', async () => {
+    // CONTRACT (tone-gate-graceful-degradation, postmortem F4): the delivery-path
+    // tone gate's provider-exhaustion path no longer blunt-holds. By default it
+    // degrades to the in-process deterministic leak floor (NO LLM, NO subprocess)
+    // so a CLEAN message still reaches the user during a backend outage — the bug
+    // that silently cut the user off when claude -p was rate-limited. A real LEAK
+    // still HOLDS on that path, and `failClosedOnExhaustion:true` restores pure-hold.
+    // (Distinct from the capacity-shed P3 path in test 3, which stays pure-hold.)
     const gate = new MessagingToneGate(erroring);
-    const r = await gate.review('some outbound message', { channel: 'telegram' });
-    expect(r.pass).toBe(false);
-    expect(r.failedClosed).toBe(true);
+    const clean = await gate.review('I will push the change for you.', { channel: 'telegram' });
+    expect(clean.pass).toBe(true);
+    expect(clean.degradedToDeterministic).toBe(true);
+
+    const leak = await gate.review('see /Users/justin/.instar/config.json', { channel: 'telegram' });
+    expect(leak.pass).toBe(false);
+    expect(leak.failedClosed).toBe(true);
+
+    const forced = new MessagingToneGate(erroring, { failClosedOnExhaustion: true });
+    const held = await forced.review('I will push the change for you.', { channel: 'telegram' });
+    expect(held.pass).toBe(false);
+    expect(held.failedClosed).toBe(true);
   });
 
   it('4. CoherenceReviewer.review: a capacity shed BLOCKS (pass:false), not pass:true', async () => {

--- a/upgrades/next/tone-gate-graceful-degradation.md
+++ b/upgrades/next/tone-gate-graceful-degradation.md
@@ -1,0 +1,60 @@
+# Tone gate degrades gracefully instead of silently cutting you off
+
+## What Changed
+
+The outbound message tone gate (`MessagingToneGate.review()`) used to HOLD every
+outbound message when its LLM reviewer was unavailable (provider rate-limited /
+circuit breaker open). During a sustained backend outage that turned the safety
+gate itself into the outage — the user saw delivery receipts but no replies for
+hours. (Postmortem failure F4.)
+
+Now, on a sustained provider-outage, the gate degrades to an in-process
+**deterministic leak floor** (the same B1–B7 artifact detectors + internal-id
+leak detector, run with NO LLM and NO subprocess): a clean message SENDS, a
+message carrying a high-stakes artifact (command, path, config key, endpoint,
+internal id) still HOLDS. The same outage has **two manifestations and both
+degrade**: the FAST one (the breaker throws inside `review()`) and the SLOW one
+(the gate stalls past the outbound route budget — the documented 2026-06-08
+failure) — covered via one shared degrade path so the slow stall no longer
+silently holds either. The fix distinguishes these dispositions:
+
+- INFRA-unavailable (provider error / breaker open, OR slow-stall budget timeout) → **degrade** to the floor (default).
+- CONTENT-unsafe (the model produced a real block verdict) → still **HOLD** (never degraded).
+- Host spawn-cap shed (transient capacity) → still **fail-closed** (P3 invariant intact).
+
+Operator override `messaging.toneGate.failClosedOnExhaustion` (governs both the
+throw and the budget-timeout paths): `true` restores the strict hold-everything
+behavior, `false` is legacy fail-open, unset is the new degrade default.
+
+## What to Tell Your User
+
+During a sustained AI-backend outage you now stay reachable — your clean replies
+still go through a fast safety check instead of being silently held, while any
+message that would leak a sensitive artifact is still held. You are never again
+silently cut off because the message-safety check lost its AI engine.
+
+## Summary of New Capabilities
+
+- The outbound tone gate degrades gracefully when its LLM reviewer is unavailable:
+  clean replies still send (via a fast in-process safety scan), leaks still hold.
+  Covers both the fast (breaker) and slow (budget-timeout) manifestations of an
+  LLM-backend outage, so you are not silently cut off during a rate-limit window.
+- New operator control: `messaging.toneGate.failClosedOnExhaustion` is now
+  three-valued — unset = degrade (default), `true` = strict hold-everything,
+  `false` = legacy fail-open. Read live (no restart).
+
+## Evidence
+
+- Fixes the 2026-06-25 silent-outbound outage (postmortem F4): a rate-limited
+  engine opened the circuit breaker and the gate held every message for hours.
+- 61 unit tests pass (MessagingToneGate + spawn-cap-fail-closed-gates +
+  outbound-gate-budget), covering BOTH paths: provider-throw + clean → sends;
+  provider-throw + leak → holds; budget-timeout + clean → sends; budget-timeout +
+  leak → holds; capacity-shed → fail-closed; content-block verdict → never
+  degraded; all three operator-override values.
+- Independent second-pass review concurred and surfaced the slow-path
+  (budget-timeout) sibling as a concern — closed in this same change (no deferral)
+  rather than shipped partial. The deterministic floor reuses the exact detector
+  set the LLM uses and is strictly more conservative (over-blocks, never
+  under-blocks); secret values remain handled by the separate unchanged redaction
+  pass.

--- a/upgrades/side-effects/tone-gate-graceful-degradation.md
+++ b/upgrades/side-effects/tone-gate-graceful-degradation.md
@@ -1,0 +1,211 @@
+# Side-Effects Review — Tone-Gate Graceful Degradation (Postmortem F4)
+
+**Version / slug:** `tone-gate-graceful-degradation`
+**Date:** `2026-06-25`
+**Author:** `Echo (instar-dev agent)`
+**Second-pass reviewer:** `required (outbound block/allow decision + "gate") — verdict + resolution appended at the end`
+
+## Summary of the change
+
+`MessagingToneGate.review()` is the outbound block/allow authority on the Telegram
+reply path. Its provider-exhaustion catch branch was **fail-CLOSED by default**:
+when the LLM backend was unavailable (breaker-open / rate-limit / transport error),
+it HELD every message unconditionally. Tonight that turned a `claude -p` rate-limit
+into a multi-hour silent outbound outage — the user saw delivery receipts but no
+replies. This change makes the outage path **degrade to an in-process deterministic
+leak floor** (`detectGateSignals` B1–B7 + `detectInternalIdLeak`, both pre-existing
+pure detectors): a clean message SENDS, a leaked artifact still HOLDS.
+
+The same rate-limit outage has **two manifestations**, and this change covers BOTH:
+the FAST throw (breaker open → `review()` rejects) degrades inside `review()`; the
+SLOW stall (the gate waits up to 120s for a rate-limit window and overruns the
+outbound route budget — the DOCUMENTED 2026-06-08 production failure) degrades at
+the route seam in `reviewWithinBudget`, via the shared `buildDegradedToneResult`.
+The capacity-shed (fork-bomb P3) path and the discipline-failure path are UNCHANGED.
+
+Files: `src/core/MessagingToneGate.ts` (the shared `buildDegradedToneResult` +
+`degradedToDeterministic` result flag + `DegradeReason`), `src/server/outboundGateBudget.ts`
+(budget-timeout degrade callback), `src/server/routes.ts` (three-valued route disposition),
+`tests/unit/MessagingToneGate.test.ts`, `tests/unit/spawn-cap-fail-closed-gates.test.ts`,
+`tests/unit/outbound-gate-budget.test.ts`, plus the spec + ELI16 + this artifact.
+
+## Decision-point inventory
+
+- `MessagingToneGate.review()` provider-exhaustion catch branch — **modify** — was pure-hold; now degrades to the deterministic floor by default (clean sends, leak holds).
+- `reviewWithinBudget` budget-timeout disposition (route seam) — **modify** — the slow-stall timeout was pure-hold (`GATE_TIMEOUT`) under the default; now degrades to the SAME floor by default (the slow sibling of the fast throw). Pure-hold/fail-open overrides still reachable.
+- `MessagingToneGate.review()` capacity-shed branch (`isCapacityUnavailable`) — **pass-through** — still pure-hold (fork-bomb P3 invariant preserved).
+- `MessagingToneGate.review()` discipline-failure branch (unparseable/contradictory after one re-prompt) — **pass-through** — still pure-hold (a model that produced an unusable verdict is not an infra outage).
+- `messaging.toneGate.failClosedOnExhaustion` config flag — **modify** — was 2-valued (default-true hold / false open); now 3-valued (unset = degrade, true = pure-hold, false = open) on BOTH the throw and the budget-timeout paths.
+
+---
+
+## 1. Over-block
+
+**What legitimate inputs does this change reject that it shouldn't?**
+
+The change strictly REDUCES over-block on the provider-exhaustion path: messages
+that were previously held during a backend outage now send if they carry no
+deterministic leak. The only inputs still held on the degraded path are those
+carrying a real B1–B7 artifact (a literal CLI command, file path, config key,
+code block, API endpoint, env var, cron/slug) or a B20 internal-id leak — the
+exact high-stakes content that must never escape. A message that legitimately
+*discusses* such an artifact in prose (e.g. "I'll run the migration for you")
+does NOT trip the detectors (verified by the GateSignalDetectors negative tests)
+and sends normally.
+
+---
+
+## 2. Under-block
+
+**What failure modes does this still miss?**
+
+On the degraded path the behavioral rules (B11–B20 tone/self-stop/false-blocker/
+parked-on-user/jargon) are NOT evaluated — they require LLM judgment that is, by
+definition, unavailable during the outage that triggers this path. So during a
+backend outage a slightly-off-tone or self-stop-shaped message could reach the
+user unchecked. This is a deliberate, bounded trade: a leak (the dangerous class)
+is still caught deterministically; a tone slip (the recoverable class) reaching
+the user beats silence (the F4 goal). When the backend recovers, full LLM review
+resumes automatically. Operators who want the strict behavior restore pure-hold
+with `failClosedOnExhaustion: true`.
+
+---
+
+## 3. Level-of-abstraction fit
+
+The degrade floor is the right layer: it REUSES the existing low-level
+deterministic detectors (`detectGateSignals`, `detectInternalIdLeak`) that the
+gate already calls to build its LLM prompt — it does not re-implement detection.
+The authority (send/hold) stays where it belongs, inside `review()`. No higher
+gate exists that should own this; `review()` IS the outbound authority. The
+change feeds an existing primitive into an existing authority's fallback path —
+no new abstraction introduced.
+
+---
+
+## 4. Signal vs authority compliance
+
+**Required reference:** `docs/signal-vs-authority.md`
+
+- [x] No — this change reuses EXISTING signal-producers (`detectGateSignals`,
+  `detectInternalIdLeak`) feeding the EXISTING smart authority (`review()`). It
+  adds no new brittle blocking check.
+
+The deterministic detectors are pure signal-producers; the gate is the authority.
+On the degraded path the authority consults those signals deterministically
+(LLM unavailable) and fails CLOSED on any positive signal. This is the
+signal-vs-authority pattern applied exactly as intended — the brittle detectors
+never gained new authority; they inform a fallback disposition that defaults to
+holding on any leak signal.
+
+---
+
+## 5. Interactions
+
+- **Shadowing:** the degrade branch runs ONLY in the provider-exhaustion catch,
+  after the LLM call throws. It cannot shadow the normal-verdict path (that path
+  `return`s before the catch) or the capacity-shed branch (which `return`s first
+  inside the catch). Ordering verified: capacity-shed check precedes the
+  provider-error disposition.
+- **Double-fire:** none — a single `review()` call returns exactly one
+  disposition.
+- **Races:** none — `review()` is a pure per-call function over its `text` +
+  live-read config; it shares no mutable state with concurrent calls.
+- **Feedback loops:** none — the floor reads the candidate text only; it does not
+  feed any system that feeds back into the gate.
+- The downstream retry path (`failClosedOnExhaustion` hold → queued for retry) is
+  unchanged for the held cases; a now-SENT clean message simply skips that queue.
+
+---
+
+## 6. External surfaces
+
+- **Other agents / users:** none directly. The install-base effect is the intended
+  one: during a backend outage, outbound replies degrade-and-send instead of
+  silently holding.
+- **External systems (Telegram):** a clean message now reaches Telegram during an
+  outage that previously held it. The held-leak case is byte-identical to before
+  (still `pass:false`, queued for retry).
+- **Persistent state:** none — no new state written.
+- **Operator surface:** no NEW operator surface. The change extends the value
+  semantics of the existing `messaging.toneGate.failClosedOnExhaustion` config
+  flag (a config edit, already documented) — it adds the `unset = degrade`
+  default and keeps `true`/`false` working. No new PIN-gated route or dashboard
+  form.
+- **Result shape:** adds an OPTIONAL `degradedToDeterministic?: boolean` to
+  `ToneReviewResult`. Existing consumers that don't read it are unaffected (the
+  `pass`/`rule`/`issue`/`failedClosed` contract is preserved).
+
+---
+
+## 6b. Operator-surface quality
+
+No operator surface — not applicable. The change touches no dashboard renderer,
+approval page, or grant/revoke/secret-drop form. The only operator-facing element
+is the pre-existing `failClosedOnExhaustion` config flag (a JSON edit), whose
+default and overrides are documented in the spec.
+
+---
+
+## 7. Multi-machine posture (Cross-Machine Coherence)
+
+**machine-local BY DESIGN.** The tone gate is a pure, stateless, per-message
+function evaluated on whichever machine is serving that outbound reply. It holds
+no durable state, emits no cross-machine notice, and generates no URL. Given the
+same candidate text + the same `failClosedOnExhaustion` config, the disposition
+is identical on every machine — so there is nothing to replicate or proxy. It
+does not strand on topic transfer (no state), needs no one-voice gating (it does
+not itself emit a user notice; it gates the agent's own reply, which is already
+single-voiced per topic), and creates no machine-bound link.
+
+---
+
+## 8. Rollback cost
+
+Cheap and instant, two independent levers:
+1. **Config (no deploy):** set `messaging.toneGate.failClosedOnExhaustion: true`
+   to restore the exact legacy pure-hold behavior on the provider-error path.
+   Read live per review — no restart.
+2. **Code:** revert the single commit. The change is isolated to one method's
+   catch branch + one shared helper + the route seam + one optional result field;
+   no migration, no state, no schema. No data repair or agent-state repair needed.
+
+---
+
+## Phase 5 — Second-pass review (independent reviewer)
+
+An independent reviewer subagent audited the change (code diff, `GateSignalDetectors`,
+`internal-id-leak`, the artifact, both test files, and ran the suites).
+
+**Verdict:** Concur with the core change — leak-safe, control-flow-correct, tests
+honest — with ONE substantive concern.
+
+- **Leak safety — PASS.** The degraded floor (B1–B7 + B20) is exactly the tone
+  gate's high-stakes artifact-leak class; everything else is behavioral/tone
+  (recoverable). Secrets/API-keys are redacted separately on BOTH paths (not a
+  regression). The floor is strictly *stricter* than the LLM on the leak class
+  (holds on any positive detection), so degrade can only over-hold, never
+  under-send a leak.
+- **Control flow — PASS.** Capacity-shed returns before the provider-error
+  disposition; the degrade branch cannot be reached for a discipline failure
+  (that path returns inside the `try`).
+- **3-valued flag — PASS.** `true`→hold, `false`→open, `undefined`→degrade; a
+  throwing config getter yields `{}`→`undefined`→degrade (safe default).
+- **Tests — PASS.** Non-vacuous inputs; the override test holds a message that
+  would otherwise send.
+
+**Concern raised (resolved in this change):** the original revision fixed only the
+provider-*throw* manifestation; the provider-*slow* (budget-timeout) sibling — the
+DOCUMENTED 2026-06-08 production failure — still pure-held under the default, so
+the F4 goal was only partially met and the artifact overstated the fix.
+
+**Resolution:** rather than defer (no-deferrals standard), the slow path was closed
+in this same change. `reviewWithinBudget` now takes a `budgetDegrade` callback; the
+route passes it under the default disposition so a budget timeout degrades to the
+SAME `buildDegradedToneResult` floor (clean sends, leak holds). Two new tests in
+`outbound-gate-budget.test.ts` prove the slow-path clean-send and leak-hold. The
+artifact summary + decision inventory above were corrected to describe both paths.
+The reviewer's two minor notes (dead capacity-arm in the degrade helper; B12
+health-jargon passing on degrade) were also addressed — the dead arm was removed in
+the `buildDegradedToneResult` refactor, and the B12 behavioral drop is documented as
+accepted in §2.


### PR DESCRIPTION
## What this fixes (plain English)

Before any reply I send you on Telegram goes out, it passes a quick AI "tone check" that catches things I should never send — a leaked password, a file path, a raw command, an internal code name. Good check. But it had one blunt rule: **if the AI doing the check wasn't reachable, hold EVERY message.**

On 2026-06-25 that backfired. The engine running the check got rate-limited, its breaker opened, and with the checker unreachable the gate held every reply I tried to send — for hours. The user saw "delivered" receipts but no replies. The safety mechanism became the outage (postmortem failure **F4**).

## The fix

When the LLM checker is unavailable, the gate now degrades to a **fast, in-process, no-AI safety scan** (the same B1–B7 artifact detectors + internal-id leak detector — no network, no subprocess, so it runs even under load):

- **Clean reply → sends.** You hear from me even during an outage.
- **Reply with a real leak → still held.** The dangerous class never escapes.

The same rate-limit outage has **two manifestations and both degrade** (closed in one change, no deferral):
- **FAST** throw (breaker open) → degrades inside `review()`.
- **SLOW** stall past the outbound route budget (the documented 2026-06-08 failure) → degrades at the `reviewWithinBudget` route seam, via the shared `buildDegradedToneResult`.

Unchanged: the capacity-shed (fork-bomb P3) path and the discipline-failure path still pure-hold.

## Operator control

`messaging.toneGate.failClosedOnExhaustion` is now three-valued on both paths (read live, no restart): **unset = degrade** (default) · **`true` = strict hold-everything** (restore legacy) · **`false` = fail-open**.

## Safety / review

- The deterministic floor is **strictly stricter** than the LLM on the leak class (holds on any positive detection) — it can only over-hold, never under-send a leak. Secret-value redaction is a separate, unchanged pass.
- Independent second-pass review **concurred**; its one concern (the slow-path sibling) was **closed in this same change**, not deferred.
- **61 unit tests** green (MessagingToneGate + spawn-cap-fail-closed-gates + outbound-gate-budget), covering both paths' clean-send + leak-hold + all three override values. `tsc` + lint clean.

## Rollback

Two levers: set `failClosedOnExhaustion: true` (live, no deploy) to restore the exact legacy hold-everything behavior, or revert the single commit (no migration, no state, no schema).

Spec: `docs/specs/tone-gate-graceful-degradation.md` · ELI16: `docs/specs/tone-gate-graceful-degradation.eli16.md` · Side-effects: `upgrades/side-effects/tone-gate-graceful-degradation.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## ELI16 — When the AI engines that check outbound messages for leaks are all busy or rate-limited, the gate used to silently hold every message — you'd see delivery receipts but no replies for hours. Now it falls through to a fast built-in check that needs no AI: a clean message goes through, a message carrying a sensitive item is still held. So a backend outage never again silently cuts you off.
