### PR TITLE
feat(enforced-termination): external hard-stop for runaway autonomous runs (F2)

### DIFF
--- a/.instar/instar-dev-decisions/2026-06-26T08-54-32-584Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-06-26T08-54-32-584Z-unknown.json
@@ -1,0 +1,13 @@
+{
+  "ts": "2026-06-26T08:54:32.584Z",
+  "slug": "unknown",
+  "suggestedTier": 1,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 11,
+  "causalAutopsy": null,
+  "verdict": "blocked"
+}

--- a/docs/specs/enforced-termination-watchdog.eli16.md
+++ b/docs/specs/enforced-termination-watchdog.eli16.md
@@ -39,3 +39,7 @@ Nothing yet. It ships **switched off everywhere except my own dev setup**, and e
 it only **watches and writes notes** at first — it won't actually stop anything until an
 operator deliberately turns that on after a live test. The point is a safety net against a
 runaway job, built so the net itself can never become a new problem.
+
+If it's ever turned fully on and it does stop a job, you won't be left guessing: it posts a
+plain note to that job's conversation saying it stopped the job because it ran past its time
+budget, and that anything unfinished is in its notes. A stop is never silent.

--- a/docs/specs/enforced-termination-watchdog.eli16.md
+++ b/docs/specs/enforced-termination-watchdog.eli16.md
@@ -1,0 +1,41 @@
+# Enforced Termination Watchdog — Plain-English Overview
+
+## What broke
+
+I can run long "autonomous" jobs in the background — work I keep doing on my own for
+a set stretch of time, like an overnight task with a 24-hour budget. Each job is
+supposed to stop itself when its time is up.
+
+But the only thing enforcing that deadline was the job checking its *own* clock at the
+end of each turn. That breaks in three ways: if the job gets stuck mid-step it never
+reaches the check; if a job was started with no time limit at all there's nothing to
+check; and if its start-time stamp is garbled, the check gives up and just keeps going.
+
+On June 25th exactly that happened — a job with a 24-hour budget ran about **46 hours**,
+churning the machine the whole time. Nothing outside the job forced it to stop.
+
+## What this change does
+
+It adds a separate **watchdog** that watches every long job *from the outside* — like a
+shift supervisor who can send someone home, instead of trusting them to clock out
+themselves.
+
+If a job has genuinely blown past its deadline, the watchdog stops it cleanly: it removes
+the job's marker so nothing restarts it, cancels any pending auto-restart, and shuts the
+session down so it can't be quietly brought back to life.
+
+It's careful on purpose:
+- It only ever acts on a **real** overrun — never a job that's still inside its time.
+- It has to see the overrun **twice in a row** before acting, so a one-second blip can't
+  trigger it.
+- If anything is **uncertain** (it can't read the job's state cleanly), it does nothing.
+- It can only stop so many jobs in a window, then it gives up loudly — it can never go on
+  a spree.
+- It writes down every decision it makes.
+
+## What you'll notice
+
+Nothing yet. It ships **switched off everywhere except my own dev setup**, and even there
+it only **watches and writes notes** at first — it won't actually stop anything until an
+operator deliberately turns that on after a live test. The point is a safety net against a
+runaway job, built so the net itself can never become a new problem.

--- a/docs/specs/enforced-termination-watchdog.md
+++ b/docs/specs/enforced-termination-watchdog.md
@@ -1,0 +1,78 @@
+# Enforced Termination Watchdog — an external hard-stop for autonomous runs
+
+**Status:** draft (spec). Tag: pending review-convergence.
+**Constitution:** *The User Experience Is the Product* → sub-standard #2 **Enforced Termination**; an instance of *Structure beats Willpower* applied to the **end** of work; sibling of *An Autonomous Run Must Outlive Its Session* (which keeps a run alive across vessel events — this is its deliberate counterweight: keep a run from outliving its **budget**).
+**Earned from:** 2026-06-25 — an autonomous run (topic 27515) with a hard 24h budget ran ~46h (iteration 216), continuously churning the machine pool and spawning subprocesses. Nothing outside the run forced it to stop. Full context: `docs/incidents/2026-06-25-user-reachability-postmortem.md` (Failure 2).
+
+---
+
+## 1. The problem — enforcement lives inside the run
+
+Today an autonomous run's deadline is enforced in exactly one place: the per-session **Stop hook** (`.claude/skills/autonomous/hooks/autonomous-stop-hook.sh:472-489`), which checks `elapsed >= duration_seconds` at a Claude Code **Stop event** (a turn boundary) and removes the state file. That is *the run's own willpower* — and it has four holes the runaway fell through:
+
+1. **No Stop event ever fires.** A wedged or tight-looping session that never cleanly reaches a turn boundary never runs the check. (This is how 27515 ran 46h.)
+2. **Unbounded runs.** `duration_seconds` absent/0 ⇒ the hook's `[[ $DURATION_SECONDS -gt 0 ]]` guard skips, and `autonomousRunRemainingForTopic()` (`src/core/AutonomousSessions.ts:106-126`) returns `null` — the run has no deadline at all and is invisible to every "how long is left" path.
+3. **Unparseable `started_at`.** The hook fails *toward keep-running* (`autonomous-stop-hook.sh:486-488`).
+4. **No external clock.** Nothing outside the run's process holds the budget. There is no duration-based killer anywhere in `src/monitoring/` (confirmed). `SessionClockReader`/`SessionClock` only *compute and display* `remainingSeconds` — they never gate.
+
+Every structural pressure in Instar points toward **continuing** (the stop-gate, "No context-death self-stops", the completion-discipline that refuses premature exit). **None points toward terminating on time.** The discipline meant to prevent laziness instead sheltered a runaway. This spec adds the missing opposite force, as *structure outside the run*, never the run's own discretion.
+
+## 2. Design — `EnforcedTerminationWatchdog`
+
+A level-triggered monitoring loop (mirrors `AutonomousLivenessReconciler`) that, each tick, finds runs that have **provably overrun** and drives them to a **durable** terminated state. It is the external twin of the in-hook duration check — it does **not** reimplement the math, it reuses `autonomousRunRemainingForTopic()` and the raw frontmatter.
+
+### 2.1 Overrun predicate (per active run)
+
+A run is `overrun` when **any** of:
+- **Time budget exceeded:** `duration_seconds > 0` AND `now - started_at >= duration_seconds + graceSeconds`. (`graceSeconds` default 120s — lets the cooperative hook win the normal case; the watchdog only fires when the hook *didn't*.)
+- **Absolute ceiling (covers the unbounded + unparseable holes):** `now - started_at >= absoluteCeilingSeconds` (default 26h — just past the longest sanctioned run; a hard backstop that fires even when `duration_seconds` is null/0 or `started_at` is malformed-but-old). An unparseable `started_at` is treated as *file mtime* for this ceiling only (fail toward a bounded stop, never toward run-forever — the inverse of the hook's bias, because here the safe direction is termination).
+- **Iteration ceiling (optional):** `iteration >= maxIterations` when configured.
+
+`overrun` is computed from durable state only (the frontmatter + file mtime), so it survives a server restart.
+
+### 2.2 Two-phase confirm (no kill on a single read)
+
+Mirrors `SessionReaper`'s reap-pending pattern. Tick N marks a topic `terminate-pending` (persisted in durable cap state); a kill happens only when tick N+1 **re-confirms** the same topic is still overrun AND still has a live session. This absorbs a clock blip, an in-flight cooperative stop landing between ticks, and a just-completed run.
+
+### 2.3 The durable termination (the reconciler-coordination crux)
+
+A deliberately-terminated run must **stay** terminated against the **two** respawn paths — the `AutonomousLivenessReconciler` and the `ResumeQueueDrainer`. From the existing operator-stop coordination, a durable stop requires **all** of:
+
+1. `stopAutonomousTopic(stateDir, topic, journal)` — emits the `stopped` journal row and **deletes the state file** (`AutonomousSessions.ts:357-365`). Once gone, `listActiveRuns()` yields nothing → not a reconciler candidate. **Load-bearing across restarts.**
+2. `operatorStopRecorder(topic)` (the watchdog is an authorized internal stopper) — records the stop timestamp the reconciler rechecks at criteria-3, at actuation, and post-spawn (`AutonomousLivenessReconciler.ts:373,625,666`). Belt for the window where the file might be re-synced from a peer.
+3. `resumeQueue.cancelByTopic(topic)` — the ResumeQueue is a second respawn path that also honors `operatorStopSince` (`ResumeQueueDrainer.ts:566`).
+4. Clear mid-work, then hard-kill the live session: `sess.endedMidWork = false; state.saveSession(sess)` **then** `sessionManager.killSession(...)` — mirrors `settleKill` (`server.ts:8005-8016`) so the kill is not itself queued for revival.
+
+The **generation guard** (`AutonomousLivenessReconciler.ts:713-719`) already ensures a genuinely-new run on the same topic (newer `started_at`) is *not* blocked by an old termination — so re-launching the topic later is unaffected.
+
+### 2.4 What it must NOT do
+
+- **Never terminate a run still inside its budget** — even one that looks idle. (That is the reaper's job, under its own pressure rules; this watchdog fires *only* on budget overrun.)
+- **Never fight a cooperative stop.** The `graceSeconds` window gives the in-hook check first right of termination; the watchdog is the backstop for when it can't run.
+- **Never silently disable itself.** Registered unconditionally in the guard posture (below).
+
+## 3. User-facing surfacing (the standard's "loud" requirement)
+
+Per sub-standard #6 *Degradation Is an Event* and the umbrella rule that a stop is never silent: every enforced termination posts **one** plain-English notice to the run's report topic — *"I stopped the autonomous run on <topic> — it passed its <N>h budget by <M>. Anything unfinished is in its notes; tell me to relaunch if you want me to continue."* — and an Attention item if the report channel is unavailable. This is the inverse of the 27515 silence, where the overrun was visible to no one.
+
+## 4. Rollout & observability (mirror the fleet template)
+
+- **Dev-gate + dryRun-first:** `monitoring.enforcedTermination.enabled` **omitted** from `ConfigDefaults` ⇒ ships dark fleet-wide, resolves live on a development agent via `resolveDevAgentGate`; `dryRun: cfg.dryRun ?? true` ⇒ on dev it computes overruns and logs `would-terminate` + shadow cap counters but actuates nothing until a deliberate `dryRun:false`.
+- **Guard posture:** expose `guardStatus()` and `guardRegistry.register('monitoring.enforcedTermination.enabled', …)` **unconditionally** (even when disabled) so a silently-off watchdog reads `off-runtime-divergent` on `/guards`, not invisible.
+- **Audit:** append-only `logs/enforced-termination.jsonl` (5MB×1 rotation), one row per transition (`overrun-detected` / `terminate-pending` / `terminated` / `would-terminate` / `false-alarm` / `skipped-grace`), each stamped with topic, started_at, duration_seconds, elapsed, predicate-that-fired.
+- **Bounded actuation:** per-window cap on terminations (a flapping detector gives up LOUDLY via one aggregated Attention item rather than kill-looping — P19), durable cap state (`loadCapState`/`saveCapState`).
+- **Status route:** `GET /autonomous/enforced-termination` → `{ enabled, dryRun, graceSeconds, absoluteCeilingSeconds, lastTickAt, pending:[topics], terminated24h, wouldTerminate24h }` (503 when dark).
+
+## 5. Tests (all three tiers + wiring + both decision sides)
+
+- **Unit:** overrun predicate — within budget (no), past budget+grace (yes), unbounded run past absolute ceiling (yes), unparseable started_at older than ceiling by mtime (yes), iteration ceiling. Two-phase confirm: single overrun tick does NOT kill; two consecutive do. dryRun: computes + logs `would-terminate`, actuates zero.
+- **Durability/wiring:** a terminated topic is gone from `listActiveRuns`; `operatorStopRecorder` called; `resumeQueue.cancelByTopic` called; `endedMidWork` cleared before `killSession`. Integration with a stub reconciler: after termination, the reconciler does NOT respawn (criteria-3 stop recheck honored). A genuinely-new run on the same topic (newer started_at) IS allowed (generation guard).
+- **Integration (HTTP):** `/autonomous/enforced-termination` returns 200 with the feature on (dev), 503 when dark.
+- **E2E:** with the watchdog live (dryRun:false) on a throwaway agent, a seeded run with a 5s budget + a wedged (no-Stop-event) session is killed within ~2 ticks and stays dead; the report topic gets the plain-English notice.
+
+## 6. Open questions (for review-convergence)
+
+1. **`absoluteCeilingSeconds` default** — 26h assumes the longest sanctioned run is ~24h. Should it instead be `max(observed duration_seconds across runs) + margin`, or a config-derived multiple of the run's own budget (e.g. `1.5 × duration_seconds`, falling back to a flat ceiling only for unbounded runs)? The flat 26h is simplest and covers the incident; the per-run multiple is tighter for short runs.
+2. **Grace vs. wedge** — `graceSeconds` (120s) lets the cooperative hook win, but a truly wedged session never fires the hook, so grace just delays the inevitable kill by 2 min. Acceptable, or should a *separately-detected* wedge (no turn boundary in N min past deadline) skip grace entirely?
+3. **Unbounded runs** — should the watchdog instead *refuse to let a run start unbounded* (a `can-start` gate that requires a `duration_seconds`), making the absolute ceiling a backstop rather than the primary path? That is arguably the more structural fix (enforce a budget at creation), with this watchdog as defense-in-depth.
+4. **Interaction with a topic mid-move** — if a run is suspended for a cross-machine move (`move_suspended_at` set), the watchdog must treat it as not-active (no kill) and let the destination re-evaluate. Confirm the predicate excludes `move_suspended_at`/`moved_to` rows.

--- a/site/src/content/docs/reference/autonomous-liveness-backstops.md
+++ b/site/src/content/docs/reference/autonomous-liveness-backstops.md
@@ -55,3 +55,28 @@ Safety mechanisms (hardened across four convergence rounds):
 - Audit: `logs/autonomous-liveness.jsonl`.
 
 Constitutional anchor: **An Autonomous Run Must Outlive Its Session**.
+
+## EnforcedTerminationWatchdog — "alive past its deadline"
+
+The deliberate counterweight to the reconciler: the reconciler keeps a run *alive*;
+the `EnforcedTerminationWatchdog` keeps a run from *outliving its budget*. Born from a
+24h-budget run that reached ~46h (topic 27515, 2026-06-25) because the only deadline
+enforcement was the run's own in-hook Stop-event check — which a wedged/looping session
+never reaches, an unbounded run has no budget for, and an unparseable timestamp fails
+toward keep-running.
+
+The watchdog watches every run from the OUTSIDE. `computeOverrun` fires only on a provable
+overrun — a time budget past its grace, an absolute ceiling (default 26h, which covers
+unbounded runs and unparseable timestamps via file mtime), or an opt-in iteration ceiling —
+and gates out inactive/paused/mid-move runs (it is never a pressure/idle reaper). A
+`TerminationConfirmer` requires the overrun on two consecutive ticks before any kill. The
+durable kill reuses the reconciler's `settleKill` (clear `endedMidWork` → `killSession`)
+plus the state-file delete + operator-stop record + resume-queue cancel, so a terminated
+run is not revived. Every predicate failure fails safe (no kill on uncertainty); a per-window
+cap makes a flapping detector give up loudly rather than kill-loop.
+
+- Read surface: `GET /autonomous/enforced-termination` (503 when dark).
+- Config: `monitoring.enforcedTermination` (`enabled` omitted → dev-gate decides; `dryRun` defaults true; `graceSeconds` 120; `absoluteCeilingSeconds` 26h).
+- Audit: `logs/enforced-termination.jsonl`.
+
+Constitutional anchor: **The User Experience Is the Product** → sub-standard #2 Enforced Termination.

--- a/src/commands/server.ts
+++ b/src/commands/server.ts
@@ -39,7 +39,7 @@ import {
 import { CodexResumeMap, type CodexSpawnFence } from '../core/CodexResumeMap.js';
 import { paneIdleWithEmptyInput } from '../core/ModelSwapService.js';
 import { escalatedModelIds, normalizeTierEscalationConfig, type TierEscalationConfig } from '../core/ModelTierEscalation.js';
-import { activeAutonomousJobs, autonomousRunRemainingForTopic, listAutonomousJobs } from '../core/AutonomousSessions.js';
+import { activeAutonomousJobs, autonomousRunRemainingForTopic, listAutonomousJobs, stopAutonomousTopic } from '../core/AutonomousSessions.js';
 import { AGE_LIMIT_ACTIVE_RUN_REASON, COMMITMENT_ACTIVE_RUN_REASON } from '../core/WorkEvidence.js';
 import { gapBEligibleForTopic, recentUserMessageFromHistory, recentUserMessageAtFromHistory, resolveGapBInjectionGate, decideGapBInjection } from '../core/gapBCommitmentEvidence.js';
 import { TopicProfileTransferCarrier, createTopicProfilePullHandler } from '../core/TopicProfileTransferCarrier.js';
@@ -7400,6 +7400,9 @@ export async function startServer(options: StartOptions): Promise<void> {
     let autonomousLivenessReconciler:
       | import('../monitoring/AutonomousLivenessReconciler.js').AutonomousLivenessReconciler
       | null = null;
+    let enforcedTerminationWatchdog:
+      | import('../monitoring/EnforcedTerminationWatchdog.js').EnforcedTerminationWatchdog
+      | null = null;
     let prHandLease: import('../core/PrHandLease.js').PrHandLease | null = null;
     // GAP-B Part A surface (spec: autonomous-registration-guarantee.md) — the
     // aggregated-attention chokepoint reference, hoisted to the handler's scope.
@@ -8058,6 +8061,60 @@ export async function startServer(options: StartOptions): Promise<void> {
           autonomousLivenessReconciler = reconciler;
           guardRegistry.register('monitoring.autonomousLivenessReconciler.enabled', () => reconciler.guardStatus());
           console.log(pc.green(`  AutonomousLivenessReconciler started (${(livenessCfgRaw.dryRun ?? true) ? 'dry-run observe-only' : 'LIVE'})`));
+        }
+
+        // ── EnforcedTerminationWatchdog (spec: enforced-termination-watchdog.md) ──
+        // The counterweight to the reconciler: it keeps a run from outliving its
+        // BUDGET (the 46h-on-24h-runaway class). Constructed in the SAME queue-
+        // started scope so the durable-kill reuses the proven primitives the
+        // reconciler's settleKill uses (clear endedMidWork → killSession), plus the
+        // operator-stop record + resume-queue cancel so a terminated run is not
+        // revived. Dev-gated (enabled OMITTED in ConfigDefaults), dryRun-first.
+        const etCfgRaw = (config.monitoring as {
+          enforcedTermination?: { enabled?: boolean; dryRun?: boolean; graceSeconds?: number; absoluteCeilingSeconds?: number; maxIterations?: number; tickIntervalSec?: number; maxTerminationsPerWindow?: number; confirmThreshold?: number };
+        } | undefined)?.enforcedTermination ?? {};
+        if (resolveDevAgentGate(etCfgRaw.enabled, config)) {
+          const { EnforcedTerminationWatchdog } = await import('../monitoring/EnforcedTerminationWatchdog.js');
+          const { buildEnforcedTerminationListRuns, buildEnforcedTerminationAudit } = await import('../monitoring/enforcedTerminationWiring.js');
+          const etTerminate = async (topicId: string): Promise<boolean> => {
+            const tnum = Number(topicId);
+            let fileDeleted = false;
+            let sessionKilled = false;
+            try { fileDeleted = stopAutonomousTopic(config.stateDir, String(topicId)); } catch { /* state-file delete best-effort */ }
+            try { recordOperatorStop(tnum); } catch { /* operator-stop record best-effort */ }
+            try { rq.cancelByTopic(tnum); } catch { /* resume-cancel best-effort */ }
+            // Settle-kill: clear midWork FIRST (so the ResumeQueue does not revive an
+            // operator-stopped topic), then kill — mirrors the reconciler's settleKill.
+            try {
+              const sess = sessionManager.listRunningSessions().find((s) => resolveTopicForTmux(s.tmuxSession) === tnum);
+              if (sess) { sess.endedMidWork = false; state.saveSession(sess); sessionManager.killSession(sess.id); sessionKilled = true; }
+            } catch { /* settle-kill best-effort; the operator-stop record prevents future revival */ }
+            return fileDeleted || sessionKilled;
+          };
+          const etWatchdog = new EnforcedTerminationWatchdog(
+            {
+              listRuns: buildEnforcedTerminationListRuns(config.stateDir),
+              terminate: etTerminate,
+              audit: buildEnforcedTerminationAudit(path.join(_projectDir, 'logs')),
+            },
+            {
+              enabled: true, // constructed only when the dev-gate passed
+              dryRun: etCfgRaw.dryRun ?? true,
+              graceSeconds: etCfgRaw.graceSeconds,
+              absoluteCeilingSeconds: etCfgRaw.absoluteCeilingSeconds,
+              maxIterations: etCfgRaw.maxIterations,
+              tickIntervalSec: etCfgRaw.tickIntervalSec ?? 120,
+              maxTerminationsPerWindow: etCfgRaw.maxTerminationsPerWindow,
+              confirmThreshold: etCfgRaw.confirmThreshold,
+            },
+          );
+          etWatchdog.start();
+          enforcedTerminationWatchdog = etWatchdog;
+          guardRegistry.register('monitoring.enforcedTermination.enabled', () => {
+            const s = etWatchdog.guardStatus();
+            return { enabled: s.enabled, dryRun: s.dryRun, lastTickAt: s.lastTickAt ?? undefined };
+          });
+          console.log(pc.green(`  EnforcedTerminationWatchdog started (${(etCfgRaw.dryRun ?? true) ? 'dry-run observe-only' : 'LIVE'})`));
         }
       }
     }
@@ -18985,7 +19042,7 @@ export async function startServer(options: StartOptions): Promise<void> {
       }
     }
 
-    const server = new AgentServer({ config, sessionManager, state, scheduler, telegram, relationships, feedback, feedbackAnomalyDetector, dispatches, updateChecker, autoUpdater, autoDispatcher, quotaTracker, quotaManager, publisher, viewer, tunnel, evolution, watchdog, topicMemory, triageNurse, projectMapper, cartographer: cartographer ?? undefined, coherenceGate: scopeVerifier, contextHierarchy, canonicalState, operationGate, sentinel, adaptiveTrust, memoryMonitor, orphanReaper, coherenceMonitor, commitmentTracker, subscriptionPool, accountFollowMePeerViews: async () => { const nickById = new Map((_listPoolMachines?.() ?? []).map((m) => [m.machineId, m.nickname ?? m.machineId])); let peers = (_resolvePeerUrls?.() ?? []).map((p) => ({ machineId: p.machineId, nickname: nickById.get(p.machineId) ?? p.machineId, url: p.url })); if (peers.length === 0) { peers = (_listPoolMachines?.() ?? []).filter((m) => m.machineId !== _meshSelfId && !!m.lastKnownUrl).map((m) => ({ machineId: m.machineId, nickname: m.nickname ?? m.machineId, url: m.lastKnownUrl as string })); } if (peers.length === 0) return []; const { fetchPeerSubscriptionViews } = await import('../core/fetchPeerSubscriptionViews.js'); return fetchPeerSubscriptionViews({ peers: () => peers, fetchImpl: fetch as unknown as Parameters<typeof fetchPeerSubscriptionViews>[0]['fetchImpl'], authToken: config.authToken ?? '' }); }, quotaPoller, quotaAwareScheduler: _quotaAwareScheduler ?? undefined, proactiveSwapMonitor: _proactiveSwapMonitor ?? undefined, inUseAccountResolver, enrollmentWizard, accountFollowMeRevocation, credentialRepointing, semanticMemory, activitySentinel, rateLimitSentinel, releaseReadinessSentinel: releaseReadinessSentinel ?? undefined, greenPrAutoMerger: greenPrAutoMerger ?? undefined, guardLatchStore: guardLatchStore ?? undefined, messageRouter, summarySentinel, spawnManager, systemReviewer, capabilityMapper, selfKnowledgeTree, coverageAuditor, topicResumeMap: _topicResumeMap ?? undefined, topicProfile: _topicProfileCtx ?? undefined, sessionRefresh: _sessionRefresh ?? undefined, autonomyManager, trustElevationTracker, autonomousEvolution, coordinator: coordinator.enabled ? coordinator : undefined, meshBindActive: coordinator.managers.identityManager.hasIdentity() && config.multiMachine?.meshTransport?.enabled !== false, localSigningKeyPem, leaseTransport, peerEndpointRecorder, getSelfMeshEndpoints, onLeasePullRequest: () => leaseCoordinatorRef?.currentLease() ?? null, liveTailReceiver, handoffWireTransport, onHandoffBegin, onHandoffInitiate: handoffInitiate, handoffInProgress: handoffSentinelInProgress, messageLedger, currentInboundByTopic, replyMarkerTransport, onReplyMarker: messageLedger ? (marker: unknown) => { const m = marker as { dedupeKey: string; platform: string; replyIdempotencyKey: string; epoch: number; topic?: string | null }; messageLedger!.applyRemoteReplyMarker(m.dedupeKey, { platform: m.platform, replyIdempotencyKey: m.replyIdempotencyKey, epoch: m.epoch, topic: m.topic ?? null }); } : undefined, whatsapp: whatsappAdapter, slack: slackAdapter, imessage: imessageAdapter, whatsappBusinessBackend, messageBridge, hookEventReceiver, worktreeMonitor, subagentTracker, instructionsVerifier, handshakeManager: threadlineHandshake, threadlineRouter, conversationStore, threadLog, threadMessageRecorder, warrantsReplyGate, collaborationSurfacer, threadResumeMap, topicLinkageHandler: topicLinkageHandler ?? undefined, threadlineRelayClient, threadlineReplyWaiters, listenerManager: listenerManager ?? undefined, a2aDeliveryTracker: a2aDeliveryTracker ?? undefined, responseReviewGate, messagingToneGate, outboundDedupGate, telemetryHeartbeat, pasteManager, featureRegistry, discoveryEvaluator, completionEvaluator, unifiedTrust, liveConfig, sharedStateLedger, ledgerSessionRegistry, worktreeManager, oidcEnrolledRepos: parallelDevConfig?.oidcEnrolledRepos, initiativeTracker, projectRoundRunner, projectDriftChecker, machineHeartbeat, machinePoolRegistry, getInboundQueue: () => _inboundQueue, meshRpcDispatcher, workingSetPullCoordinator, commitmentReplicaStore, preferenceReplicaStore, replicatedRecordEmitter, conflictStore, rollbackUnmerge, droppedOriginRegistry, preferencesUnionReader, forwardCommitmentMutate, sessionOwnershipRegistry, topicPinStore: _topicPinStore ?? undefined, streamTicketStore: _streamTicketStore ?? undefined, poolStreamAllowRemoteInput: (config as { dashboard?: { poolStream?: { allowRemoteInput?: boolean } } }).dashboard?.poolStream?.allowRemoteInput ?? false, poolStreamConnector: _poolStreamConnector ?? undefined, secretSync: _secretSyncHandle ?? undefined, meshSelfId: _meshSelfId ?? undefined, resolveRouterUrl: _resolveRouterUrl ?? undefined, resolvePeerUrls: _resolvePeerUrls ?? undefined, guardRegistry, listPoolMachines: _listPoolMachines ?? undefined, deliverMandateToMachine: _deliverMandateToMachine ?? undefined, poolLink: _poolLink ?? undefined, poolPollCache: _poolPollCache ?? undefined, sessionPoolE2EResultStore, proxyCoordinator, topicIntentStore, topicIntentArcCheck, usherSignalStore, intelligence: sharedIntelligence ?? undefined, telegramBridgeConfig, telegramBridge: telegramBridge ?? undefined, threadlineObservability, briefDeps, workingMemory, taskFlowRegistry, threadlineFlowBridge, sessionReaper, agentWorktreeReaper, orphanedWorkSentinel, mcpProcessReaper, geminiLoopRunner, sleepController, agentActivityState, reapLog, resumeQueue, resumeDrainer, autonomousLivenessReconciler, prHandLease: prHandLease ?? undefined, operatorStopRecorder: recordOperatorStop, sleepWakeDetector, unjustifiedStopGate, stopGateDb, stopNotifier, liveTestGate, liveTestGateMode, liveTestRunnerCtx });    // Resolve the late-bound topic-operator getter (increment 2e): routing was
+    const server = new AgentServer({ config, sessionManager, state, scheduler, telegram, relationships, feedback, feedbackAnomalyDetector, dispatches, updateChecker, autoUpdater, autoDispatcher, quotaTracker, quotaManager, publisher, viewer, tunnel, evolution, watchdog, topicMemory, triageNurse, projectMapper, cartographer: cartographer ?? undefined, coherenceGate: scopeVerifier, contextHierarchy, canonicalState, operationGate, sentinel, adaptiveTrust, memoryMonitor, orphanReaper, coherenceMonitor, commitmentTracker, subscriptionPool, accountFollowMePeerViews: async () => { const nickById = new Map((_listPoolMachines?.() ?? []).map((m) => [m.machineId, m.nickname ?? m.machineId])); let peers = (_resolvePeerUrls?.() ?? []).map((p) => ({ machineId: p.machineId, nickname: nickById.get(p.machineId) ?? p.machineId, url: p.url })); if (peers.length === 0) { peers = (_listPoolMachines?.() ?? []).filter((m) => m.machineId !== _meshSelfId && !!m.lastKnownUrl).map((m) => ({ machineId: m.machineId, nickname: m.nickname ?? m.machineId, url: m.lastKnownUrl as string })); } if (peers.length === 0) return []; const { fetchPeerSubscriptionViews } = await import('../core/fetchPeerSubscriptionViews.js'); return fetchPeerSubscriptionViews({ peers: () => peers, fetchImpl: fetch as unknown as Parameters<typeof fetchPeerSubscriptionViews>[0]['fetchImpl'], authToken: config.authToken ?? '' }); }, quotaPoller, quotaAwareScheduler: _quotaAwareScheduler ?? undefined, proactiveSwapMonitor: _proactiveSwapMonitor ?? undefined, inUseAccountResolver, enrollmentWizard, accountFollowMeRevocation, credentialRepointing, semanticMemory, activitySentinel, rateLimitSentinel, releaseReadinessSentinel: releaseReadinessSentinel ?? undefined, greenPrAutoMerger: greenPrAutoMerger ?? undefined, guardLatchStore: guardLatchStore ?? undefined, messageRouter, summarySentinel, spawnManager, systemReviewer, capabilityMapper, selfKnowledgeTree, coverageAuditor, topicResumeMap: _topicResumeMap ?? undefined, topicProfile: _topicProfileCtx ?? undefined, sessionRefresh: _sessionRefresh ?? undefined, autonomyManager, trustElevationTracker, autonomousEvolution, coordinator: coordinator.enabled ? coordinator : undefined, meshBindActive: coordinator.managers.identityManager.hasIdentity() && config.multiMachine?.meshTransport?.enabled !== false, localSigningKeyPem, leaseTransport, peerEndpointRecorder, getSelfMeshEndpoints, onLeasePullRequest: () => leaseCoordinatorRef?.currentLease() ?? null, liveTailReceiver, handoffWireTransport, onHandoffBegin, onHandoffInitiate: handoffInitiate, handoffInProgress: handoffSentinelInProgress, messageLedger, currentInboundByTopic, replyMarkerTransport, onReplyMarker: messageLedger ? (marker: unknown) => { const m = marker as { dedupeKey: string; platform: string; replyIdempotencyKey: string; epoch: number; topic?: string | null }; messageLedger!.applyRemoteReplyMarker(m.dedupeKey, { platform: m.platform, replyIdempotencyKey: m.replyIdempotencyKey, epoch: m.epoch, topic: m.topic ?? null }); } : undefined, whatsapp: whatsappAdapter, slack: slackAdapter, imessage: imessageAdapter, whatsappBusinessBackend, messageBridge, hookEventReceiver, worktreeMonitor, subagentTracker, instructionsVerifier, handshakeManager: threadlineHandshake, threadlineRouter, conversationStore, threadLog, threadMessageRecorder, warrantsReplyGate, collaborationSurfacer, threadResumeMap, topicLinkageHandler: topicLinkageHandler ?? undefined, threadlineRelayClient, threadlineReplyWaiters, listenerManager: listenerManager ?? undefined, a2aDeliveryTracker: a2aDeliveryTracker ?? undefined, responseReviewGate, messagingToneGate, outboundDedupGate, telemetryHeartbeat, pasteManager, featureRegistry, discoveryEvaluator, completionEvaluator, unifiedTrust, liveConfig, sharedStateLedger, ledgerSessionRegistry, worktreeManager, oidcEnrolledRepos: parallelDevConfig?.oidcEnrolledRepos, initiativeTracker, projectRoundRunner, projectDriftChecker, machineHeartbeat, machinePoolRegistry, getInboundQueue: () => _inboundQueue, meshRpcDispatcher, workingSetPullCoordinator, commitmentReplicaStore, preferenceReplicaStore, replicatedRecordEmitter, conflictStore, rollbackUnmerge, droppedOriginRegistry, preferencesUnionReader, forwardCommitmentMutate, sessionOwnershipRegistry, topicPinStore: _topicPinStore ?? undefined, streamTicketStore: _streamTicketStore ?? undefined, poolStreamAllowRemoteInput: (config as { dashboard?: { poolStream?: { allowRemoteInput?: boolean } } }).dashboard?.poolStream?.allowRemoteInput ?? false, poolStreamConnector: _poolStreamConnector ?? undefined, secretSync: _secretSyncHandle ?? undefined, meshSelfId: _meshSelfId ?? undefined, resolveRouterUrl: _resolveRouterUrl ?? undefined, resolvePeerUrls: _resolvePeerUrls ?? undefined, guardRegistry, listPoolMachines: _listPoolMachines ?? undefined, deliverMandateToMachine: _deliverMandateToMachine ?? undefined, poolLink: _poolLink ?? undefined, poolPollCache: _poolPollCache ?? undefined, sessionPoolE2EResultStore, proxyCoordinator, topicIntentStore, topicIntentArcCheck, usherSignalStore, intelligence: sharedIntelligence ?? undefined, telegramBridgeConfig, telegramBridge: telegramBridge ?? undefined, threadlineObservability, briefDeps, workingMemory, taskFlowRegistry, threadlineFlowBridge, sessionReaper, agentWorktreeReaper, orphanedWorkSentinel, mcpProcessReaper, geminiLoopRunner, sleepController, agentActivityState, reapLog, resumeQueue, resumeDrainer, autonomousLivenessReconciler, enforcedTerminationStatus: () => enforcedTerminationWatchdog?.guardStatus() ?? null, prHandLease: prHandLease ?? undefined, operatorStopRecorder: recordOperatorStop, sleepWakeDetector, unjustifiedStopGate, stopGateDb, stopNotifier, liveTestGate, liveTestGateMode, liveTestRunnerCtx });    // Resolve the late-bound topic-operator getter (increment 2e): routing was
     // wired before the server existed; from here on inbound binds use the
     // server's own store instance.
     _agentServerRef = server;

--- a/src/commands/server.ts
+++ b/src/commands/server.ts
@@ -8089,6 +8089,17 @@ export async function startServer(options: StartOptions): Promise<void> {
               const sess = sessionManager.listRunningSessions().find((s) => resolveTopicForTmux(s.tmuxSession) === tnum);
               if (sess) { sess.endedMidWork = false; state.saveSession(sess); sessionManager.killSession(sess.id); sessionKilled = true; }
             } catch { /* settle-kill best-effort; the operator-stop record prevents future revival */ }
+            // spec §3: a termination is never silent to the user. Post one plain-English
+            // notice to the run's topic (etTerminate is only ever called outside dryRun, so
+            // this fires only on a REAL stop — "Degradation Is an Event").
+            if (fileDeleted || sessionKilled) {
+              try {
+                notify('SUMMARY', 'enforced-termination',
+                  'I stopped the autonomous run on this topic — it ran past the time budget it was given. ' +
+                  'Anything unfinished is in its notes; tell me to relaunch if you want me to continue.',
+                  tnum);
+              } catch { /* notice best-effort; the stop already happened */ }
+            }
             return fileDeleted || sessionKilled;
           };
           const etWatchdog = new EnforcedTerminationWatchdog(

--- a/src/monitoring/EnforcedTerminationWatchdog.ts
+++ b/src/monitoring/EnforcedTerminationWatchdog.ts
@@ -1,0 +1,229 @@
+/**
+ * EnforcedTerminationWatchdog — the external hard-stop loop for autonomous runs
+ * that overrun their budget. Wires the pure decision core (computeOverrun +
+ * TerminationConfirmer) to injected, side-effecting dependencies so the loop is
+ * unit-testable with fakes and the real (session-killing) actuation lives behind
+ * one interface. Spec: docs/specs/enforced-termination-watchdog.md.
+ *
+ * Constitution: "The User Experience Is the Product" → sub-standard #2 Enforced
+ * Termination — "Structure beats Willpower" applied to the END of work. The
+ * counterweight to "An Autonomous Run Must Outlive Its Session": that keeps a run
+ * alive across vessel events; THIS keeps a run from outliving its budget.
+ *
+ * Dark/dryRun-first rollout (mirrors AutonomousLivenessReconciler): ships with
+ * `enabled` omitted from config defaults (resolves live only on a dev agent) and
+ * `dryRun` defaulting true (logs would-terminate, actuates nothing) until a
+ * deliberate flip. The actuation is deliberately NOT in this class — it is the
+ * injected `terminate` actuator, so this orchestration never imports a session
+ * killer and stays provable in isolation.
+ */
+import {
+  computeOverrun,
+  TerminationConfirmer,
+  DEFAULT_ENFORCED_TERMINATION_CONFIG,
+  type AutonomousRunSnapshot,
+  type EnforcedTerminationConfig,
+  type OverrunReason,
+} from './enforcedTermination.js';
+
+export interface EnforcedTerminationDeps {
+  /** Returns the current durable snapshot of every autonomous run. */
+  listRuns: () => AutonomousRunSnapshot[];
+  /**
+   * Durably terminate a run so neither the liveness-reconciler nor the resume
+   * queue revives it (delete state file + record operator-stop + cancel resume +
+   * clear endedMidWork + killSession). Returns true on a clean actuation. Only
+   * ever called for a TWO-tick-confirmed overrun, and never in dryRun.
+   */
+  terminate: (topicId: string, reason: OverrunReason) => Promise<boolean>;
+  /** Append one audit row per transition. Must never throw into the loop. */
+  audit: (row: EnforcedTerminationAuditRow) => void;
+  /** Monotonic clock (injectable for tests). */
+  now?: () => number;
+}
+
+export interface EnforcedTerminationOptions extends Partial<EnforcedTerminationConfig> {
+  enabled: boolean;
+  dryRun?: boolean;
+  /** Consecutive overrun ticks required before a kill. Default 2. */
+  confirmThreshold?: number;
+  /** Per-window cap on actuations; a flapping detector gives up LOUDLY. Default 5. */
+  maxTerminationsPerWindow?: number;
+  tickIntervalSec?: number;
+}
+
+export interface EnforcedTerminationAuditRow {
+  ts: number;
+  topicId: string;
+  event:
+    | 'overrun-detected'
+    | 'terminate-pending'
+    | 'terminated'
+    | 'would-terminate'
+    | 'terminate-failed'
+    | 'cap-exceeded';
+  reason?: OverrunReason;
+  dryRun: boolean;
+}
+
+export interface EnforcedTerminationGuardStatus {
+  enabled: boolean;
+  dryRun: boolean;
+  graceSeconds: number;
+  absoluteCeilingSeconds: number;
+  lastTickAt: number | null;
+  pending: string[];
+  terminatedCount: number;
+  wouldTerminateCount: number;
+  capExceededCount: number;
+}
+
+export class EnforcedTerminationWatchdog {
+  private readonly cfg: EnforcedTerminationConfig;
+  private readonly confirmer: TerminationConfirmer;
+  private readonly now: () => number;
+  private timer: ReturnType<typeof setInterval> | null = null;
+
+  private lastTickAt: number | null = null;
+  private terminatedCount = 0;
+  private wouldTerminateCount = 0;
+  private capExceededCount = 0;
+  // Window of actuation timestamps for the per-window cap.
+  private readonly actuationTimes: number[] = [];
+  private readonly windowMs: number;
+
+  constructor(
+    private readonly deps: EnforcedTerminationDeps,
+    private readonly opts: EnforcedTerminationOptions,
+  ) {
+    this.cfg = {
+      graceSeconds: opts.graceSeconds ?? DEFAULT_ENFORCED_TERMINATION_CONFIG.graceSeconds,
+      absoluteCeilingSeconds:
+        opts.absoluteCeilingSeconds ?? DEFAULT_ENFORCED_TERMINATION_CONFIG.absoluteCeilingSeconds,
+      maxIterations: opts.maxIterations,
+    };
+    this.confirmer = new TerminationConfirmer(opts.confirmThreshold ?? 2);
+    this.now = deps.now ?? Date.now;
+    this.windowMs = (opts.tickIntervalSec ?? 60) * 1000 * 60; // ~60 ticks
+  }
+
+  /** Start the unref'd tick loop. No-op when disabled. */
+  start(): void {
+    if (!this.opts.enabled || this.timer) return;
+    const intervalMs = (this.opts.tickIntervalSec ?? 60) * 1000;
+    this.timer = setInterval(() => void this.tick().catch(() => {}), intervalMs);
+    if (typeof (this.timer as { unref?: () => void }).unref === 'function') {
+      (this.timer as { unref: () => void }).unref();
+    }
+  }
+
+  stop(): void {
+    if (this.timer) {
+      clearInterval(this.timer);
+      this.timer = null;
+    }
+  }
+
+  /**
+   * One reconcile pass. Pure-core decides overrun; the confirmer enforces the
+   * two-tick rule; only a CONFIRMED overrun actuates (and never in dryRun). Every
+   * predicate failure is swallowed toward NO actuation (fail-safe direction).
+   */
+  async tick(): Promise<void> {
+    if (!this.opts.enabled) return;
+    const t = this.now();
+    this.lastTickAt = t;
+
+    let runs: AutonomousRunSnapshot[];
+    try {
+      runs = this.deps.listRuns();
+    } catch {
+      return; // can't read state → do nothing (fail-safe: never kill on uncertainty)
+    }
+
+    const overrun = new Map<string, OverrunReason>();
+    for (const r of runs) {
+      let reason: OverrunReason | null = null;
+      try {
+        reason = computeOverrun(r, this.cfg, t);
+      } catch {
+        reason = null; // a malformed snapshot is not an overrun
+      }
+      if (reason) {
+        overrun.set(r.topicId, reason);
+        this.safeAudit({ ts: t, topicId: r.topicId, event: 'overrun-detected', reason, dryRun: this.dryRun });
+      }
+    }
+
+    const confirmed = this.confirmer.reconcile(overrun.keys());
+    // Topics overrun but not yet confirmed are terminate-pending.
+    for (const topic of this.confirmer.pendingTopics()) {
+      this.safeAudit({ ts: t, topicId: topic, event: 'terminate-pending', reason: overrun.get(topic), dryRun: this.dryRun });
+    }
+
+    for (const topic of confirmed) {
+      const reason = overrun.get(topic)!;
+      if (this.dryRun) {
+        this.wouldTerminateCount++;
+        this.safeAudit({ ts: t, topicId: topic, event: 'would-terminate', reason, dryRun: true });
+        this.confirmer.clear(topic);
+        continue;
+      }
+      if (!this.withinCap(t)) {
+        this.capExceededCount++;
+        this.safeAudit({ ts: t, topicId: topic, event: 'cap-exceeded', reason, dryRun: false });
+        continue; // give up LOUDLY (audited) rather than kill-loop; keep pending
+      }
+      let ok = false;
+      try {
+        ok = await this.deps.terminate(topic, reason);
+      } catch {
+        ok = false;
+      }
+      if (ok) {
+        this.terminatedCount++;
+        this.actuationTimes.push(t);
+        this.confirmer.clear(topic);
+        this.safeAudit({ ts: t, topicId: topic, event: 'terminated', reason, dryRun: false });
+      } else {
+        this.safeAudit({ ts: t, topicId: topic, event: 'terminate-failed', reason, dryRun: false });
+        // leave pending so a later tick retries (subject to the cap)
+      }
+    }
+  }
+
+  guardStatus(): EnforcedTerminationGuardStatus {
+    return {
+      enabled: this.opts.enabled,
+      dryRun: this.dryRun,
+      graceSeconds: this.cfg.graceSeconds,
+      absoluteCeilingSeconds: this.cfg.absoluteCeilingSeconds,
+      lastTickAt: this.lastTickAt,
+      pending: this.confirmer.pendingTopics(),
+      terminatedCount: this.terminatedCount,
+      wouldTerminateCount: this.wouldTerminateCount,
+      capExceededCount: this.capExceededCount,
+    };
+  }
+
+  private get dryRun(): boolean {
+    return this.opts.dryRun ?? true;
+  }
+
+  private withinCap(now: number): boolean {
+    const cap = this.opts.maxTerminationsPerWindow ?? 5;
+    // prune old actuations outside the window
+    while (this.actuationTimes.length && now - this.actuationTimes[0] > this.windowMs) {
+      this.actuationTimes.shift();
+    }
+    return this.actuationTimes.length < cap;
+  }
+
+  private safeAudit(row: EnforcedTerminationAuditRow): void {
+    try {
+      this.deps.audit(row);
+    } catch {
+      /* the audit sink must never endanger the loop */
+    }
+  }
+}

--- a/src/monitoring/EnforcedTerminationWatchdog.ts
+++ b/src/monitoring/EnforcedTerminationWatchdog.ts
@@ -111,7 +111,10 @@ export class EnforcedTerminationWatchdog {
   start(): void {
     if (!this.opts.enabled || this.timer) return;
     const intervalMs = (this.opts.tickIntervalSec ?? 60) * 1000;
-    this.timer = setInterval(() => void this.tick().catch(() => {}), intervalMs);
+    this.timer = setInterval(() => void this.tick().catch(() => {
+      // @silent-fallback-ok: tick() handles its own errors and fails safe toward
+      // NO actuation; a thrown tick must not crash the unref'd timer loop.
+    }), intervalMs);
     if (typeof (this.timer as { unref?: () => void }).unref === 'function') {
       (this.timer as { unref: () => void }).unref();
     }
@@ -138,7 +141,10 @@ export class EnforcedTerminationWatchdog {
     try {
       runs = this.deps.listRuns();
     } catch {
-      return; // can't read state → do nothing (fail-safe: never kill on uncertainty)
+      // @silent-fallback-ok: can't read state → do nothing. Fail-safe is the
+      // SAFE direction for a session-killer (never kill on uncertainty); a louder
+      // surface here would risk noise on a transient read while changing nothing.
+      return;
     }
 
     const overrun = new Map<string, OverrunReason>();
@@ -147,7 +153,9 @@ export class EnforcedTerminationWatchdog {
       try {
         reason = computeOverrun(r, this.cfg, t);
       } catch {
-        reason = null; // a malformed snapshot is not an overrun
+        // @silent-fallback-ok: a malformed snapshot is not an overrun → skip it
+        // (fail-safe: never classify-to-kill on a parse error).
+        reason = null;
       }
       if (reason) {
         overrun.set(r.topicId, reason);

--- a/src/monitoring/enforcedTermination.ts
+++ b/src/monitoring/enforcedTermination.ts
@@ -1,0 +1,168 @@
+/**
+ * Enforced Termination — the PURE decision core for the external hard-stop on
+ * autonomous runs. Spec: docs/specs/enforced-termination-watchdog.md.
+ * Constitution: "The User Experience Is the Product" → sub-standard #2 Enforced
+ * Termination; an instance of "Structure beats Willpower" applied to the END of
+ * work. Earned from 2026-06-25 (topic 27515 ran ~46h on a 24h budget).
+ *
+ * This module is intentionally dependency-free (no sessions, no fs, no clock of
+ * its own) so the overrun predicate and the two-phase confirm are unit-tested
+ * deterministically. The watchdog that actuates a kill (delete state file +
+ * record operator-stop + cancel resume + clear endedMidWork + killSession) wires
+ * THIS core to real deps — the safety-critical actuation is deliberately kept
+ * out of the pure logic so the decision boundary is provable in isolation.
+ */
+
+/** A durable snapshot of one autonomous run, parsed from its state frontmatter. */
+export interface AutonomousRunSnapshot {
+  /** Telegram topic id (string key of the run). */
+  topicId: string;
+  /** Parsed `started_at` epoch ms, or null when absent/unparseable. */
+  startedAtMs: number | null;
+  /**
+   * Fallback clock for the absolute ceiling ONLY — the run state file's mtime
+   * (ms). Used when `startedAtMs` is null so an unparseable timestamp still has
+   * a bounded ceiling (fail TOWARD termination, never toward run-forever).
+   */
+  fileMtimeMs: number;
+  /** `duration_seconds` budget. null or 0 ⇒ UNBOUNDED (no time budget). */
+  durationSeconds: number | null;
+  /** Current iteration count (for the optional iteration ceiling). */
+  iteration: number;
+  /** Whether the run is marked active. */
+  active: boolean;
+  /** Whether the run is paused (operator pause / move). Paused ⇒ never terminated. */
+  paused: boolean;
+  /**
+   * True when the run is mid cross-machine move (`move_suspended_at`/`moved_to`
+   * present). The destination re-evaluates; this watchdog must NOT kill it.
+   */
+  moveSuspended: boolean;
+}
+
+export interface EnforcedTerminationConfig {
+  /**
+   * Grace past the time budget before the watchdog fires, letting the
+   * cooperative in-hook duration check win the normal case. Default 120s.
+   */
+  graceSeconds: number;
+  /**
+   * Absolute hard ceiling from the run's start. Fires even for an UNBOUNDED run
+   * or an unparseable `started_at` (via file mtime). Default 26h.
+   */
+  absoluteCeilingSeconds: number;
+  /** Optional iteration ceiling. Unset ⇒ no iteration-based termination. */
+  maxIterations?: number;
+}
+
+export const DEFAULT_ENFORCED_TERMINATION_CONFIG: EnforcedTerminationConfig = {
+  graceSeconds: 120,
+  absoluteCeilingSeconds: 26 * 60 * 60, // 26h
+};
+
+export type OverrunReason =
+  | { kind: 'time-budget'; elapsedSeconds: number; budgetSeconds: number }
+  | {
+      kind: 'absolute-ceiling';
+      elapsedSeconds: number;
+      ceilingSeconds: number;
+      clock: 'started_at' | 'file-mtime';
+    }
+  | { kind: 'iteration-ceiling'; iteration: number; max: number };
+
+/**
+ * Decide whether a run has PROVABLY overrun its budget. Pure: same inputs →
+ * same output. Returns the first matching reason, or null when the run is
+ * within budget / not eligible.
+ *
+ * Eligibility gates (return null): not active, paused, or mid-move. A run that
+ * is not eligible is NEVER terminated by this watchdog — the reaper handles
+ * idle/pressure; this fires ONLY on a genuine budget overrun.
+ */
+export function computeOverrun(
+  run: AutonomousRunSnapshot,
+  cfg: EnforcedTerminationConfig,
+  nowMs: number,
+): OverrunReason | null {
+  if (!run.active || run.paused || run.moveSuspended) return null;
+
+  // Iteration ceiling (optional, explicit opt-in).
+  if (cfg.maxIterations != null && cfg.maxIterations > 0 && run.iteration >= cfg.maxIterations) {
+    return { kind: 'iteration-ceiling', iteration: run.iteration, max: cfg.maxIterations };
+  }
+
+  // Time budget — only for a BOUNDED run with a parseable start. The grace
+  // window gives the cooperative in-hook check first right of termination.
+  if (run.startedAtMs != null && run.durationSeconds != null && run.durationSeconds > 0) {
+    const elapsed = (nowMs - run.startedAtMs) / 1000;
+    if (elapsed >= run.durationSeconds + cfg.graceSeconds) {
+      return { kind: 'time-budget', elapsedSeconds: elapsed, budgetSeconds: run.durationSeconds };
+    }
+  }
+
+  // Absolute ceiling — the backstop that covers the holes the in-hook check
+  // can't: an UNBOUNDED run (no duration), and an UNPARSEABLE started_at (uses
+  // file mtime). Fail TOWARD a bounded stop, never toward run-forever.
+  const clockMs = run.startedAtMs ?? run.fileMtimeMs;
+  const clock: 'started_at' | 'file-mtime' = run.startedAtMs != null ? 'started_at' : 'file-mtime';
+  const elapsedAbs = (nowMs - clockMs) / 1000;
+  if (elapsedAbs >= cfg.absoluteCeilingSeconds) {
+    return {
+      kind: 'absolute-ceiling',
+      elapsedSeconds: elapsedAbs,
+      ceilingSeconds: cfg.absoluteCeilingSeconds,
+      clock,
+    };
+  }
+
+  return null;
+}
+
+/**
+ * Two-phase confirm — a topic is only terminated after it is observed overrun
+ * on TWO consecutive reconcile() ticks. This absorbs a clock blip, an in-flight
+ * cooperative stop landing between ticks, and a run that just completed. Mirrors
+ * SessionReaper's mark-pending / re-confirm pattern.
+ *
+ * Stateful but pure of side effects: it only tracks per-topic consecutive
+ * overrun counts. A topic that drops out of the overrun set is forgotten (its
+ * pending count resets), so a transient overrun never accumulates toward a kill.
+ */
+export class TerminationConfirmer {
+  private readonly pending = new Map<string, number>();
+  private readonly threshold: number;
+
+  constructor(confirmThreshold = 2) {
+    this.threshold = Math.max(1, confirmThreshold);
+  }
+
+  /**
+   * Feed the set of currently-overrun topic ids; returns the topics CONFIRMED
+   * for termination this tick (overrun for `threshold` consecutive ticks).
+   * Topics no longer overrun are cleared.
+   */
+  reconcile(overrunTopicIds: Iterable<string>): string[] {
+    const overrun = new Set(overrunTopicIds);
+    const confirmed: string[] = [];
+    for (const topic of overrun) {
+      const next = (this.pending.get(topic) ?? 0) + 1;
+      this.pending.set(topic, next);
+      if (next >= this.threshold) confirmed.push(topic);
+    }
+    // Forget topics that are no longer overrun (reset their streak).
+    for (const topic of [...this.pending.keys()]) {
+      if (!overrun.has(topic)) this.pending.delete(topic);
+    }
+    return confirmed;
+  }
+
+  /** Drop a topic's pending state once it has been actuated (or cancelled). */
+  clear(topicId: string): void {
+    this.pending.delete(topicId);
+  }
+
+  /** Topics currently marked terminate-pending (overrun but not yet confirmed). */
+  pendingTopics(): string[] {
+    return [...this.pending.entries()].filter(([, n]) => n < this.threshold).map(([t]) => t);
+  }
+}

--- a/src/monitoring/enforcedTerminationWiring.ts
+++ b/src/monitoring/enforcedTerminationWiring.ts
@@ -1,0 +1,79 @@
+/**
+ * EnforcedTerminationWatchdog wiring — the adapters that bridge the pure
+ * decision core to real instar state. This file holds the READ side (the
+ * `listRuns` adapter that reads autonomous state files into snapshots) plus the
+ * audit sink. The session-killing ACTUATOR is built in server.ts where the live
+ * SessionManager / ResumeQueue / operator-stop recorder are in scope, mirroring
+ * AutonomousLivenessReconciler.settleKill — it is deliberately NOT here so this
+ * module stays free of a session killer and remains unit-testable against real
+ * files. Spec: docs/specs/enforced-termination-watchdog.md.
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+import { listAutonomousJobs, readAutonomousRunMarkers } from '../core/AutonomousSessions.js';
+import type { AutonomousRunSnapshot } from './enforcedTermination.js';
+import type { EnforcedTerminationAuditRow } from './EnforcedTerminationWatchdog.js';
+
+/**
+ * Build the `listRuns` provider: read every per-topic autonomous run file and
+ * project it into the pure-core snapshot. Legacy single-file jobs (topic === null)
+ * are skipped — the watchdog only governs per-topic runs (the only ones with a
+ * resolvable session to terminate). Each snapshot is durable-state only (file
+ * frontmatter + mtime), so the overrun decision survives a server restart.
+ */
+export function buildEnforcedTerminationListRuns(stateDir: string): () => AutonomousRunSnapshot[] {
+  return () => {
+    const out: AutonomousRunSnapshot[] = [];
+    for (const job of listAutonomousJobs(stateDir)) {
+      if (!job.topic) continue; // skip legacy single-file jobs (no per-topic session)
+      const startedAtMs =
+        job.startedAt != null && Number.isFinite(new Date(job.startedAt).getTime())
+          ? new Date(job.startedAt).getTime()
+          : null;
+      let fileMtimeMs = 0;
+      try {
+        fileMtimeMs = fs.statSync(job.file).mtimeMs;
+      } catch {
+        fileMtimeMs = 0; // unreadable mtime → 0 epoch; the ceiling check then treats it as very old
+      }
+      const markers = readAutonomousRunMarkers(stateDir, job.topic);
+      const moveSuspended = markers != null && (markers.moveSuspended || markers.movedTo != null);
+      out.push({
+        topicId: job.topic,
+        startedAtMs,
+        fileMtimeMs,
+        durationSeconds: job.durationSeconds,
+        iteration: job.iteration ?? 0,
+        active: job.active,
+        paused: job.paused,
+        moveSuspended,
+      });
+    }
+    return out;
+  };
+}
+
+/**
+ * Build the audit sink: append one JSON line per transition to
+ * `logs/enforced-termination.jsonl`. Bounded rotation at ~5MB so the audit can
+ * never grow unbounded. Wrapped by the watchdog's safeAudit so a write error
+ * never reaches the loop, but we also swallow here for defense in depth.
+ */
+export function buildEnforcedTerminationAudit(logsDir: string): (row: EnforcedTerminationAuditRow) => void {
+  const file = path.join(logsDir, 'enforced-termination.jsonl');
+  const MAX_BYTES = 5 * 1024 * 1024;
+  return (row: EnforcedTerminationAuditRow) => {
+    try {
+      try {
+        const st = fs.statSync(file);
+        if (st.size > MAX_BYTES) fs.renameSync(file, `${file}.1`);
+      } catch {
+        /* no existing file */
+      }
+      fs.mkdirSync(logsDir, { recursive: true });
+      fs.appendFileSync(file, JSON.stringify(row) + '\n');
+    } catch {
+      /* audit must never endanger the loop */
+    }
+  };
+}

--- a/src/monitoring/guardManifest.ts
+++ b/src/monitoring/guardManifest.ts
@@ -309,6 +309,16 @@ export const GUARD_MANIFEST: readonly GuardManifestEntry[] = [
     description: 'Boot-time health beacon endpoint (dev-gated, CMT-1438).',
   },
   {
+    key: 'monitoring.enforcedTermination.enabled',
+    kind: 'config',
+    configPath: 'monitoring.enforcedTermination.enabled',
+    defaultEnabled: false,
+    process: 'server',
+    expectRuntime: false,
+    component: 'EnforcedTerminationWatchdog',
+    description: 'External hard-stop for autonomous runs that overrun their budget (dev-gated, F2).',
+  },
+  {
     key: 'monitoring.rateLimitSentinel.enabled',
     kind: 'config',
     configPath: 'monitoring.rateLimitSentinel.enabled',

--- a/src/server/AgentServer.ts
+++ b/src/server/AgentServer.ts
@@ -696,6 +696,9 @@ export class AgentServer {
     autonomousLivenessReconciler?:
       | import('../monitoring/AutonomousLivenessReconciler.js').AutonomousLivenessReconciler
       | null;
+    /** F2 enforced-termination watchdog status getter (spec: enforced-termination-watchdog.md).
+     *  Powers GET /autonomous/enforced-termination. Function-typed to avoid a class import. */
+    enforcedTerminationStatus?: (() => unknown) | null;
     /** Records operator stop instructions for the drainer's R2.6 validation. */
     operatorStopRecorder?: (topicId: number | null) => void;
     /** SleepWakeDetector — timer-drift sleep detection with CPU-starvation guard.
@@ -2254,6 +2257,7 @@ export class AgentServer {
       resumeQueue: options.resumeQueue ?? null,
       resumeDrainer: options.resumeDrainer ?? null,
       autonomousLivenessReconciler: options.autonomousLivenessReconciler ?? null,
+      enforcedTerminationStatus: options.enforcedTerminationStatus ?? null,
       operatorStopRecorder: options.operatorStopRecorder ?? null,
       sleepWakeDetector: options.sleepWakeDetector ?? null,
       telegramBridgeConfig: options.telegramBridgeConfig ?? null,

--- a/src/server/routes.ts
+++ b/src/server/routes.ts
@@ -1056,6 +1056,9 @@ export interface RouteContext {
   autonomousLivenessReconciler?:
     | import('../monitoring/AutonomousLivenessReconciler.js').AutonomousLivenessReconciler
     | null;
+  /** F2 enforced-termination watchdog status getter. Null when dark/disabled.
+   *  Powers GET /autonomous/enforced-termination (spec: enforced-termination-watchdog.md). */
+  enforcedTerminationStatus?: (() => unknown) | null;
   /** Records an operator stop instruction (per-topic, or null = global) so the
    *  drainer's R2.6 operator-stop validation can see stops that post-date an
    *  entry's enqueue. Wired by the boot block alongside the queue. */
@@ -4293,6 +4296,15 @@ export function createRoutes(ctx: RouteContext): Router {
       return;
     }
     res.json(ctx.autonomousLivenessReconciler.status());
+  });
+
+  // F2 Enforced Termination — external hard-stop status (spec: enforced-termination-watchdog.md).
+  router.get('/autonomous/enforced-termination', (_req, res) => {
+    if (!ctx.enforcedTerminationStatus) {
+      res.status(503).json({ error: 'enforced-termination watchdog not available on this agent' });
+      return;
+    }
+    res.json(ctx.enforcedTerminationStatus());
   });
 
   router.get('/autonomous/can-start', (req, res) => {

--- a/tests/unit/EnforcedTerminationWatchdog.test.ts
+++ b/tests/unit/EnforcedTerminationWatchdog.test.ts
@@ -1,0 +1,137 @@
+/**
+ * EnforcedTerminationWatchdog orchestration tests (Tier 1) — fake deps, no real
+ * sessions. Proves: dryRun never actuates, the two-tick confirm gates a kill,
+ * eligibility is respected, a failed actuation retries, the per-window cap gives
+ * up loudly, and a listRuns() throw fails SAFE (no kill). Spec:
+ * docs/specs/enforced-termination-watchdog.md.
+ */
+import { describe, it, expect } from 'vitest';
+import { EnforcedTerminationWatchdog, type EnforcedTerminationAuditRow } from '../../src/monitoring/EnforcedTerminationWatchdog.js';
+import type { AutonomousRunSnapshot } from '../../src/monitoring/enforcedTermination.js';
+
+const H = 60 * 60 * 1000;
+const NOW = 1_000_000_000_000;
+
+function overrunRun(topicId = 't1'): AutonomousRunSnapshot {
+  // 24h budget, started 46h ago → time-budget overrun
+  return {
+    topicId,
+    startedAtMs: NOW - 46 * H,
+    fileMtimeMs: NOW - 46 * H,
+    durationSeconds: 24 * 60 * 60,
+    iteration: 9,
+    active: true,
+    paused: false,
+    moveSuspended: false,
+  };
+}
+
+function harness(opts: { dryRun?: boolean; terminateOk?: boolean; runs?: AutonomousRunSnapshot[]; throwOnList?: boolean; cap?: number } = {}) {
+  const audit: EnforcedTerminationAuditRow[] = [];
+  const terminated: string[] = [];
+  const wd = new EnforcedTerminationWatchdog(
+    {
+      listRuns: () => {
+        if (opts.throwOnList) throw new Error('cannot read state');
+        return opts.runs ?? [overrunRun()];
+      },
+      terminate: async (topicId) => {
+        terminated.push(topicId);
+        return opts.terminateOk ?? true;
+      },
+      audit: (row) => audit.push(row),
+      now: () => NOW,
+    },
+    { enabled: true, dryRun: opts.dryRun ?? false, maxTerminationsPerWindow: opts.cap },
+  );
+  return { wd, audit, terminated };
+}
+
+describe('EnforcedTerminationWatchdog — actuation gating', () => {
+  it('a single overrun tick does NOT terminate (two-phase confirm)', async () => {
+    const { wd, terminated } = harness();
+    await wd.tick();
+    expect(terminated).toEqual([]);
+    expect(wd.guardStatus().pending).toEqual(['t1']);
+  });
+
+  it('two consecutive overrun ticks → terminate once', async () => {
+    const { wd, terminated } = harness();
+    await wd.tick();
+    await wd.tick();
+    expect(terminated).toEqual(['t1']);
+    expect(wd.guardStatus().terminatedCount).toBe(1);
+    expect(wd.guardStatus().pending).toEqual([]); // cleared after actuation
+  });
+
+  it('dryRun: confirmed overrun logs would-terminate but NEVER actuates', async () => {
+    const { wd, terminated, audit } = harness({ dryRun: true });
+    await wd.tick();
+    await wd.tick();
+    expect(terminated).toEqual([]);
+    expect(wd.guardStatus().wouldTerminateCount).toBe(1);
+    expect(audit.some((r) => r.event === 'would-terminate' && r.dryRun)).toBe(true);
+  });
+
+  it('an INELIGIBLE run (paused) is never terminated even past budget', async () => {
+    const paused = { ...overrunRun('p1'), paused: true };
+    const { wd, terminated } = harness({ runs: [paused] });
+    await wd.tick();
+    await wd.tick();
+    expect(terminated).toEqual([]);
+  });
+
+  it('a within-budget run is never terminated', async () => {
+    const ok = { ...overrunRun('ok1'), startedAtMs: NOW - 1 * H };
+    const { wd, terminated } = harness({ runs: [ok] });
+    await wd.tick();
+    await wd.tick();
+    expect(terminated).toEqual([]);
+  });
+
+  it('a FAILED actuation leaves the topic pending and retries next tick', async () => {
+    const { wd, terminated, audit } = harness({ terminateOk: false });
+    await wd.tick();
+    await wd.tick(); // confirmed → terminate attempted, fails
+    expect(terminated).toEqual(['t1']);
+    expect(audit.some((r) => r.event === 'terminate-failed')).toBe(true);
+    await wd.tick(); // still overrun → retried
+    expect(terminated).toEqual(['t1', 't1']);
+  });
+
+  it('the per-window cap gives up LOUDLY (cap-exceeded) instead of kill-looping', async () => {
+    // cap=1: first actuation succeeds, a second distinct topic is cap-blocked
+    const runs = [overrunRun('a'), overrunRun('b')];
+    const { wd, terminated, audit } = harness({ runs, cap: 1 });
+    await wd.tick();
+    await wd.tick(); // both confirmed; cap allows only one
+    expect(terminated.length).toBe(1);
+    expect(audit.some((r) => r.event === 'cap-exceeded')).toBe(true);
+    expect(wd.guardStatus().capExceededCount).toBeGreaterThan(0);
+  });
+
+  it('listRuns() throwing fails SAFE — no actuation, no crash', async () => {
+    const { wd, terminated } = harness({ throwOnList: true });
+    await expect(wd.tick()).resolves.toBeUndefined();
+    await wd.tick();
+    expect(terminated).toEqual([]);
+  });
+
+  it('disabled watchdog is a strict no-op', async () => {
+    const audit: EnforcedTerminationAuditRow[] = [];
+    const terminated: string[] = [];
+    const wd = new EnforcedTerminationWatchdog(
+      {
+        listRuns: () => [overrunRun()],
+        terminate: async (t) => { terminated.push(t); return true; },
+        audit: (r) => audit.push(r),
+        now: () => NOW,
+      },
+      { enabled: false },
+    );
+    await wd.tick();
+    await wd.tick();
+    expect(terminated).toEqual([]);
+    expect(audit).toEqual([]);
+  });
+});

--- a/tests/unit/enforced-termination-route.test.ts
+++ b/tests/unit/enforced-termination-route.test.ts
@@ -1,0 +1,68 @@
+/**
+ * GET /autonomous/enforced-termination — "feature is alive" route test (Tier 2,
+ * the single most important test per the Testing Integrity Standard). Stands up
+ * the real router with a minimal RouteContext and verifies: 200 + the live
+ * status when the watchdog status getter is wired, 503 when it's dark/absent.
+ * Spec: docs/specs/enforced-termination-watchdog.md.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import express from 'express';
+import type { AddressInfo } from 'node:net';
+import { createRoutes } from '../../src/server/routes.js';
+
+interface Server { url: string; close: () => Promise<void>; }
+async function listen(app: express.Express): Promise<Server> {
+  return new Promise((resolve) => {
+    const srv = app.listen(0, () => {
+      const port = (srv.address() as AddressInfo).port;
+      resolve({ url: `http://127.0.0.1:${port}`, close: () => new Promise<void>((r) => srv.close(() => r())) });
+    });
+  });
+}
+
+function buildApp(enforcedTerminationStatus: (() => unknown) | null): express.Express {
+  const app = express();
+  app.use(express.json());
+  const ctx: any = {
+    enforcedTerminationStatus,
+    config: { authToken: 'test', stateDir: '/tmp', port: 0 },
+    stateDir: '/tmp',
+  };
+  app.use(createRoutes(ctx));
+  return app;
+}
+
+let server: Server;
+afterEach(async () => { await server?.close(); });
+
+describe('GET /autonomous/enforced-termination', () => {
+  it('returns 200 + the live status when the watchdog is wired (feature alive)', async () => {
+    const status = {
+      enabled: true,
+      dryRun: true,
+      graceSeconds: 120,
+      absoluteCeilingSeconds: 93600,
+      lastTickAt: 1_700_000_000_000,
+      pending: ['28744'],
+      terminatedCount: 0,
+      wouldTerminateCount: 2,
+      capExceededCount: 0,
+    };
+    server = await listen(buildApp(() => status));
+    const res = await fetch(`${server.url}/autonomous/enforced-termination`);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.enabled).toBe(true);
+    expect(body.dryRun).toBe(true);
+    expect(body.wouldTerminateCount).toBe(2);
+    expect(body.pending).toEqual(['28744']);
+  });
+
+  it('returns 503 when the watchdog is dark/absent on this agent', async () => {
+    server = await listen(buildApp(null));
+    const res = await fetch(`${server.url}/autonomous/enforced-termination`);
+    expect(res.status).toBe(503);
+    const body = await res.json();
+    expect(body.error).toMatch(/not available/i);
+  });
+});

--- a/tests/unit/enforcedTermination.test.ts
+++ b/tests/unit/enforcedTermination.test.ts
@@ -1,0 +1,146 @@
+/**
+ * Enforced Termination — pure decision-core tests (Tier 1).
+ * Covers BOTH sides of every decision boundary in computeOverrun() and the
+ * two-phase TerminationConfirmer. Spec: docs/specs/enforced-termination-watchdog.md.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  computeOverrun,
+  TerminationConfirmer,
+  DEFAULT_ENFORCED_TERMINATION_CONFIG,
+  type AutonomousRunSnapshot,
+  type EnforcedTerminationConfig,
+} from '../../src/monitoring/enforcedTermination.js';
+
+const H = 60 * 60 * 1000; // ms in an hour
+const NOW = 1_000_000_000_000; // fixed clock
+
+const cfg: EnforcedTerminationConfig = { ...DEFAULT_ENFORCED_TERMINATION_CONFIG };
+
+function run(over: Partial<AutonomousRunSnapshot>): AutonomousRunSnapshot {
+  return {
+    topicId: '28744',
+    startedAtMs: NOW - 1 * H,
+    fileMtimeMs: NOW - 1 * H,
+    durationSeconds: 24 * 60 * 60, // 24h budget
+    iteration: 1,
+    active: true,
+    paused: false,
+    moveSuspended: false,
+    ...over,
+  };
+}
+
+describe('computeOverrun — eligibility gates', () => {
+  it('within budget → null (no overrun)', () => {
+    expect(computeOverrun(run({ startedAtMs: NOW - 1 * H }), cfg, NOW)).toBeNull();
+  });
+  it('inactive run → null even if past budget', () => {
+    expect(computeOverrun(run({ active: false, startedAtMs: NOW - 100 * H }), cfg, NOW)).toBeNull();
+  });
+  it('paused run → null even if past budget', () => {
+    expect(computeOverrun(run({ paused: true, startedAtMs: NOW - 100 * H }), cfg, NOW)).toBeNull();
+  });
+  it('mid-move run → null even if past budget (destination re-evaluates)', () => {
+    expect(computeOverrun(run({ moveSuspended: true, startedAtMs: NOW - 100 * H }), cfg, NOW)).toBeNull();
+  });
+});
+
+describe('computeOverrun — time budget', () => {
+  it('exactly at budget but within grace → null', () => {
+    // 24h budget, started 24h ago + 60s (under the 120s grace)
+    const r = run({ durationSeconds: 24 * 60 * 60, startedAtMs: NOW - (24 * H + 60_000) });
+    expect(computeOverrun(r, cfg, NOW)).toBeNull();
+  });
+  it('past budget + grace → time-budget overrun', () => {
+    const r = run({ durationSeconds: 24 * 60 * 60, startedAtMs: NOW - (24 * H + 121_000) });
+    const o = computeOverrun(r, cfg, NOW);
+    expect(o?.kind).toBe('time-budget');
+    if (o?.kind === 'time-budget') expect(o.budgetSeconds).toBe(24 * 60 * 60);
+  });
+  it('the 46h-on-24h incident (topic 27515) → time-budget overrun', () => {
+    const r = run({ durationSeconds: 24 * 60 * 60, startedAtMs: NOW - 46 * H, iteration: 216 });
+    expect(computeOverrun(r, cfg, NOW)?.kind).toBe('time-budget');
+  });
+});
+
+describe('computeOverrun — absolute ceiling (the holes the in-hook check misses)', () => {
+  it('UNBOUNDED run (no duration) under ceiling → null', () => {
+    const r = run({ durationSeconds: null, startedAtMs: NOW - 10 * H });
+    expect(computeOverrun(r, cfg, NOW)).toBeNull();
+  });
+  it('UNBOUNDED run past the 26h ceiling → absolute-ceiling overrun (started_at clock)', () => {
+    const r = run({ durationSeconds: null, startedAtMs: NOW - 27 * H });
+    const o = computeOverrun(r, cfg, NOW);
+    expect(o?.kind).toBe('absolute-ceiling');
+    if (o?.kind === 'absolute-ceiling') expect(o.clock).toBe('started_at');
+  });
+  it('duration_seconds:0 treated as unbounded → ceiling still applies', () => {
+    const r = run({ durationSeconds: 0, startedAtMs: NOW - 27 * H });
+    expect(computeOverrun(r, cfg, NOW)?.kind).toBe('absolute-ceiling');
+  });
+  it('UNPARSEABLE started_at, file mtime older than ceiling → absolute-ceiling (file-mtime clock)', () => {
+    const r = run({ startedAtMs: null, durationSeconds: null, fileMtimeMs: NOW - 27 * H });
+    const o = computeOverrun(r, cfg, NOW);
+    expect(o?.kind).toBe('absolute-ceiling');
+    if (o?.kind === 'absolute-ceiling') expect(o.clock).toBe('file-mtime');
+  });
+  it('UNPARSEABLE started_at but file mtime recent → null (a fresh run with a bad stamp is not killed)', () => {
+    const r = run({ startedAtMs: null, durationSeconds: null, fileMtimeMs: NOW - 1 * H });
+    expect(computeOverrun(r, cfg, NOW)).toBeNull();
+  });
+});
+
+describe('computeOverrun — iteration ceiling (opt-in)', () => {
+  it('no maxIterations configured → iteration never triggers', () => {
+    const r = run({ iteration: 9999, startedAtMs: NOW - 1 * H });
+    expect(computeOverrun(r, cfg, NOW)).toBeNull();
+  });
+  it('iteration >= maxIterations → iteration-ceiling overrun', () => {
+    const r = run({ iteration: 500, startedAtMs: NOW - 1 * H });
+    const o = computeOverrun(r, { ...cfg, maxIterations: 500 }, NOW);
+    expect(o?.kind).toBe('iteration-ceiling');
+  });
+  it('iteration below maxIterations → null', () => {
+    const r = run({ iteration: 499, startedAtMs: NOW - 1 * H });
+    expect(computeOverrun(r, { ...cfg, maxIterations: 500 }, NOW)).toBeNull();
+  });
+});
+
+describe('TerminationConfirmer — two-phase confirm', () => {
+  it('a single overrun tick does NOT confirm (absorbs a blip)', () => {
+    const c = new TerminationConfirmer();
+    expect(c.reconcile(['28744'])).toEqual([]);
+    expect(c.pendingTopics()).toEqual(['28744']);
+  });
+  it('two consecutive overrun ticks → confirmed', () => {
+    const c = new TerminationConfirmer();
+    c.reconcile(['28744']);
+    expect(c.reconcile(['28744'])).toEqual(['28744']);
+  });
+  it('a topic that drops out between ticks resets its streak (transient overrun never kills)', () => {
+    const c = new TerminationConfirmer();
+    c.reconcile(['28744']); // tick 1: pending
+    expect(c.reconcile([])).toEqual([]); // tick 2: cleared
+    expect(c.reconcile(['28744'])).toEqual([]); // tick 3: pending again, not confirmed
+    expect(c.reconcile(['28744'])).toEqual(['28744']); // tick 4: confirmed
+  });
+  it('clear() drops a topic after actuation', () => {
+    const c = new TerminationConfirmer();
+    c.reconcile(['28744']);
+    c.reconcile(['28744']); // confirmed
+    c.clear('28744');
+    expect(c.pendingTopics()).toEqual([]);
+    expect(c.reconcile(['28744'])).toEqual([]); // streak restarted from zero
+  });
+  it('multiple topics tracked independently', () => {
+    const c = new TerminationConfirmer();
+    c.reconcile(['a', 'b']);
+    const confirmed = c.reconcile(['a', 'b']);
+    expect(confirmed.sort()).toEqual(['a', 'b']);
+  });
+  it('confirmThreshold of 1 confirms immediately (for tests/overrides)', () => {
+    const c = new TerminationConfirmer(1);
+    expect(c.reconcile(['x'])).toEqual(['x']);
+  });
+});

--- a/tests/unit/enforcedTerminationWiring.test.ts
+++ b/tests/unit/enforcedTerminationWiring.test.ts
@@ -11,6 +11,7 @@ import {
   buildEnforcedTerminationListRuns,
   buildEnforcedTerminationAudit,
 } from '../../src/monitoring/enforcedTerminationWiring.js';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
 
 let stateDir: string;
 
@@ -27,7 +28,7 @@ beforeEach(() => {
   stateDir = fs.mkdtempSync(path.join(os.tmpdir(), 'et-wiring-'));
 });
 afterEach(() => {
-  fs.rmSync(stateDir, { recursive: true, force: true });
+  SafeFsExecutor.safeRmSync(stateDir, { recursive: true, force: true, operation: 'tests/unit/enforcedTerminationWiring.test.ts:cleanup' });
 });
 
 describe('buildEnforcedTerminationListRuns', () => {

--- a/tests/unit/enforcedTerminationWiring.test.ts
+++ b/tests/unit/enforcedTerminationWiring.test.ts
@@ -1,0 +1,111 @@
+/**
+ * EnforcedTermination wiring — listRuns adapter + audit sink, against REAL files
+ * (Tier 1, real fs). Proves the bridge from autonomous state frontmatter to the
+ * pure-core snapshot is correct, including the move/unparseable edge cases.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import {
+  buildEnforcedTerminationListRuns,
+  buildEnforcedTerminationAudit,
+} from '../../src/monitoring/enforcedTerminationWiring.js';
+
+let stateDir: string;
+
+function writeRun(topic: string, frontmatter: Record<string, string>): void {
+  const dir = path.join(stateDir, 'autonomous');
+  fs.mkdirSync(dir, { recursive: true });
+  const fm = Object.entries(frontmatter)
+    .map(([k, v]) => `${k}: ${v}`)
+    .join('\n');
+  fs.writeFileSync(path.join(dir, `${topic}.local.md`), `---\n${fm}\n---\n\nGoal body\n`);
+}
+
+beforeEach(() => {
+  stateDir = fs.mkdtempSync(path.join(os.tmpdir(), 'et-wiring-'));
+});
+afterEach(() => {
+  fs.rmSync(stateDir, { recursive: true, force: true });
+});
+
+describe('buildEnforcedTerminationListRuns', () => {
+  it('projects a per-topic run into a snapshot with parsed fields', () => {
+    writeRun('28744', {
+      report_topic: '28744',
+      active: 'true',
+      paused: 'false',
+      iteration: '7',
+      started_at: '2026-06-25T00:00:00.000Z',
+      duration_seconds: '86400',
+    });
+    const runs = buildEnforcedTerminationListRuns(stateDir)();
+    expect(runs).toHaveLength(1);
+    const r = runs[0];
+    expect(r.topicId).toBe('28744');
+    expect(r.active).toBe(true);
+    expect(r.paused).toBe(false);
+    expect(r.iteration).toBe(7);
+    expect(r.durationSeconds).toBe(86400);
+    expect(r.startedAtMs).toBe(new Date('2026-06-25T00:00:00.000Z').getTime());
+    expect(r.fileMtimeMs).toBeGreaterThan(0);
+  });
+
+  it('an UNBOUNDED run (no duration_seconds) → durationSeconds null', () => {
+    writeRun('100', { report_topic: '100', active: 'true', started_at: '2026-06-25T00:00:00.000Z' });
+    const r = buildEnforcedTerminationListRuns(stateDir)()[0];
+    expect(r.durationSeconds).toBeNull();
+  });
+
+  it('an UNPARSEABLE started_at → startedAtMs null, mtime still present (ceiling fallback)', () => {
+    writeRun('101', { report_topic: '101', active: 'true', started_at: 'not-a-date' });
+    const r = buildEnforcedTerminationListRuns(stateDir)()[0];
+    expect(r.startedAtMs).toBeNull();
+    expect(r.fileMtimeMs).toBeGreaterThan(0);
+  });
+
+  it('a mid-move run (moved_to present) → moveSuspended true', () => {
+    writeRun('102', { report_topic: '102', active: 'true', started_at: '2026-06-25T00:00:00.000Z', moved_to: 'the-mini' });
+    const r = buildEnforcedTerminationListRuns(stateDir)()[0];
+    expect(r.moveSuspended).toBe(true);
+  });
+
+  it('a move_suspended_at breadcrumb → moveSuspended true', () => {
+    writeRun('103', { report_topic: '103', active: 'true', started_at: '2026-06-25T00:00:00.000Z', move_suspended_at: '2026-06-25T01:00:00.000Z' });
+    const r = buildEnforcedTerminationListRuns(stateDir)()[0];
+    expect(r.moveSuspended).toBe(true);
+  });
+
+  it('empty state dir → no runs (no throw)', () => {
+    expect(buildEnforcedTerminationListRuns(stateDir)()).toEqual([]);
+  });
+
+  it('multiple runs are all projected', () => {
+    writeRun('1', { report_topic: '1', active: 'true', started_at: '2026-06-25T00:00:00.000Z' });
+    writeRun('2', { report_topic: '2', active: 'false', started_at: '2026-06-25T00:00:00.000Z' });
+    const runs = buildEnforcedTerminationListRuns(stateDir)();
+    expect(runs.map((r) => r.topicId).sort()).toEqual(['1', '2']);
+  });
+});
+
+describe('buildEnforcedTerminationAudit', () => {
+  it('appends one JSON line per row to enforced-termination.jsonl', () => {
+    const logsDir = path.join(stateDir, 'logs');
+    const audit = buildEnforcedTerminationAudit(logsDir);
+    audit({ ts: 1, topicId: 'a', event: 'overrun-detected', dryRun: true });
+    audit({ ts: 2, topicId: 'a', event: 'would-terminate', dryRun: true });
+    const lines = fs.readFileSync(path.join(logsDir, 'enforced-termination.jsonl'), 'utf8').trim().split('\n');
+    expect(lines).toHaveLength(2);
+    expect(JSON.parse(lines[0]).event).toBe('overrun-detected');
+    expect(JSON.parse(lines[1]).event).toBe('would-terminate');
+  });
+
+  it('a write to an impossible path never throws (audit must not endanger the loop)', () => {
+    // a logsDir under a file path → mkdir fails; audit swallows
+    const badParent = path.join(stateDir, 'afile');
+    fs.writeFileSync(badParent, 'x');
+    const audit = buildEnforcedTerminationAudit(path.join(badParent, 'logs'));
+    expect(() => audit({ ts: 1, topicId: 'a', event: 'terminated', dryRun: false })).not.toThrow();
+  });
+});

--- a/upgrades/next/enforced-termination-watchdog.md
+++ b/upgrades/next/enforced-termination-watchdog.md
@@ -1,0 +1,49 @@
+# Enforced Termination Watchdog (Postmortem F2)
+
+**Slug:** `enforced-termination-watchdog` · **Maturity:** ⚗️ Experimental (ships dark — dev-agent gated, dry-run first) · **Audience:** agent-only
+
+## What Changed
+
+Added `EnforcedTerminationWatchdog` — an external, level-triggered loop that hard-stops an
+autonomous run which has provably overrun its budget. It is the structural counterweight to
+the `AutonomousLivenessReconciler`: that keeps a run *alive* across vessel events; this keeps
+a run from *outliving its budget*. Previously the only deadline enforcement was the run's own
+in-hook Stop-event check — which a wedged/looping session never reaches, an unbounded run has
+no budget for, and an unparseable timestamp fails toward keep-running. That gap let an
+autonomous run with a 24h budget run ~46h (topic 27515, 2026-06-25). The watchdog reuses the
+reconciler's proven `settleKill` path plus the operator-stop record + resume-queue cancel, so
+a terminated run is durable and not revived; it gates out inactive/paused/mid-move runs, fires
+only on a provable overrun, requires a two-tick confirm, fails safe on uncertainty, caps
+actuations per window, and audits every transition to `logs/enforced-termination.jsonl`.
+
+Constitution: *The User Experience Is the Product* → sub-standard #2 (Enforced Termination);
+"Structure beats Willpower" applied to the END of work.
+
+## What to Tell Your User
+
+Nothing yet — this ships **dark on the fleet** (dev-agent gated) and **dry-run first** (it
+logs what it *would* stop and actuates nothing until a deliberate flip). It is a safety
+backstop against a runaway autonomous job blowing past its deadline; it has no user-facing
+behavior until an operator enables and live-tests it. Do not announce it as a finished
+capability.
+
+## Summary of New Capabilities
+
+- `GET /autonomous/enforced-termination` — read-only status (enabled/dryRun, grace +
+  ceiling, lastTickAt, pending topics, terminated/would-terminate/cap-exceeded counts). 503
+  when the watchdog is dark/disabled on the agent.
+- Config: `monitoring.enforcedTermination` (`enabled` omitted = dev-gated dark; `dryRun`
+  default true; `graceSeconds` 120; `absoluteCeilingSeconds` 26h; `maxIterations` opt-in;
+  `tickIntervalSec` 120; `maxTerminationsPerWindow` 5).
+- Guard posture: `monitoring.enforcedTermination.enabled` registered on `GET /guards`.
+- Audit: `logs/enforced-termination.jsonl`.
+
+## Evidence
+
+- 41 unit tests green (pure predicate + two-tick confirm: 21; orchestration incl. dryRun
+  never-actuates / fail-safe / cap: 9; read adapters against real files: 9; route
+  alive 200/503: 2), clean full `tsc`.
+- Side-effects review: `upgrades/side-effects/enforced-termination-watchdog.md` (the
+  KILL-path blast-radius analysis; second-pass reviewer verdict required before any
+  `dryRun:false`).
+- Spec: `docs/specs/enforced-termination-watchdog.md`.

--- a/upgrades/side-effects/enforced-termination-watchdog.md
+++ b/upgrades/side-effects/enforced-termination-watchdog.md
@@ -58,8 +58,10 @@ the END of work. Constitution: *The User Experience Is the Product* → sub-stan
 ## What it does NOT do
 
 - Does not touch legacy single-file (non-per-topic) jobs.
-- Does not message the user yet (the spec's §3 plain-English termination notice is a
-  follow-up; until then a kill is audit-only — acceptable while dryRun/dark).
+- A real termination is NOT silent (spec §3): the actuator posts one plain-English notice
+  to the run's topic on a real stop ("I stopped the autonomous run … it ran past its time
+  budget …"). It fires only outside dryRun (etTerminate is never called in dryRun), so a
+  dark/dryRun agent emits nothing. Best-effort (a notice failure never blocks the stop).
 - Does not change the cooperative in-hook duration check; it is the EXTERNAL backstop the
   grace window defers to.
 
@@ -71,5 +73,23 @@ the append-only audit log.
 
 ## Second-pass reviewer verdict
 
-_Pending — required before `dryRun:false` is ever flipped, and the live-flip is itself a
-separate operator-gated step (the spec's §5 livetest battery)._
+**Concur with the review** (independent reviewer, 2026-06-26 — verified the artifact's claims
+against the actual code, not just the prose).
+
+Verified: `computeOverrun` returns null for `!active||paused||moveSuspended` BEFORE any time
+check (enforcedTermination.ts:87); time-budget fires only at `elapsed >= duration+grace`; every
+uncertainty path (listRuns throw, computeOverrun throw, audit throw) fails toward NO actuation;
+the two-tick confirm is genuinely enforced (only `confirmer.reconcile()` output actuates, streak
+resets when a topic drops out); the durable kill composes delete-state-file → recordOperatorStop
+→ rq.cancelByTopic → clear endedMidWork → killSession in that order (server.ts etTerminate),
+mirroring the reconciler's proven settleKill, so a terminated run is not revived; and it is
+genuinely dark (absent from ConfigDefaults → not even constructed on the fleet) + dryRun-first
+(the dryRun path audits then `continue`s, never calling terminate). Cap bounds actuations to 5
+per ~2h window.
+
+Residual observation (NON-blocking, intended semantics): a doubly-corrupt run (unparseable
+`started_at` AND unreadable mtime → fileMtimeMs=0) classifies as past the absolute ceiling and
+fails TOWARD a kill — the deliberate, spec-documented inverse of the 27515 "fails toward
+run-forever" bug. It remains gated behind active+unpaused+not-moving + two-tick confirm + dryRun
++ dev-gate, so it is the intended fail-direction, not a hole — worth keeping visible when the §5
+live-flip battery runs.

--- a/upgrades/side-effects/enforced-termination-watchdog.md
+++ b/upgrades/side-effects/enforced-termination-watchdog.md
@@ -1,0 +1,75 @@
+# Side-Effects Review — Enforced Termination Watchdog (Postmortem F2)
+
+**Version / slug:** `enforced-termination-watchdog`
+**Date:** `2026-06-26`
+**Author:** `Echo (instar-dev agent)`
+**Second-pass reviewer:** `required (an autonomous-process KILL path + a new monitoring loop) — verdict appended at the end`
+
+## Summary of the change
+
+A new monitoring loop, `EnforcedTerminationWatchdog`, that **externally hard-stops an
+autonomous run which has provably overrun its budget** — the counterweight to the
+`AutonomousLivenessReconciler` (which keeps a run *alive*). It exists because on
+2026-06-25 an autonomous run (topic 27515) with a hard 24h budget ran ~46h: the only
+deadline enforcement was the run's OWN in-hook Stop-event check, which a wedged/looping
+session never reaches, which an unbounded run has no budget for, and which fails toward
+keep-running on an unparseable timestamp. This is "Structure beats Willpower" applied to
+the END of work. Constitution: *The User Experience Is the Product* → sub-standard #2.
+
+## What it touches (blast radius)
+
+- **NEW files only for the logic**: `src/monitoring/enforcedTermination.ts` (pure
+  predicate + two-tick confirmer), `EnforcedTerminationWatchdog.ts` (loop),
+  `enforcedTerminationWiring.ts` (read adapters + audit). No existing module's behavior
+  changes.
+- **`src/commands/server.ts`**: constructs + starts the watchdog in the existing
+  queue-started scope (alongside the reconciler). The durable-kill actuator **reuses the
+  exact primitives the reconciler's `settleKill` already uses** — it adds NO new
+  session-killing code path.
+- **`AgentServer.ts` / `routes.ts`**: a function-typed status getter threaded for the
+  read-only `GET /autonomous/enforced-termination` route. No mutation surface added.
+
+## The dangerous side effect: it KILLS sessions. How it is bounded.
+
+1. **Off by default, dry-run first.** `monitoring.enforcedTermination.enabled` is OMITTED
+   from `ConfigDefaults` → the dev-agent gate resolves it (dark on the fleet); `dryRun`
+   defaults `true` → it LOGS `would-terminate` and actuates NOTHING until a deliberate
+   `dryRun:false`. A fleet agent is a strict no-op.
+2. **Only a provable budget overrun.** `computeOverrun` fires solely on time-budget+grace,
+   an absolute ceiling (26h), or an opt-in iteration ceiling — and gates OUT inactive,
+   paused, and mid-move runs. It is NOT a pressure/idle reaper; it never kills a run inside
+   its budget.
+3. **Two-tick confirm.** A kill requires the SAME topic overrun on two consecutive ticks,
+   absorbing a clock blip / an in-flight cooperative stop / a just-completed run.
+4. **Fail-safe on uncertainty.** Every predicate failure (unreadable state, malformed
+   snapshot, a `listRuns` throw) swallows toward NO actuation. The watchdog never kills on
+   ambiguity.
+5. **Per-window cap.** A flapping detector gives up LOUDLY (`cap-exceeded`, audited) rather
+   than kill-loop (P19).
+6. **The kill is durable AND non-reviving.** The actuator composes, in order: delete the
+   state file (`stopAutonomousTopic`), record the operator-stop (`recordOperatorStop`),
+   cancel queued resumes (`rq.cancelByTopic`), then clear `endedMidWork` and `killSession`
+   (the reconciler's `settleKill` path). So neither the liveness reconciler nor the resume
+   queue revives a deliberately-terminated run — and the generation guard still lets a
+   genuinely-NEW run on the same topic start later.
+7. **Full audit.** Every transition → `logs/enforced-termination.jsonl` (rotating). The
+   guard posture is registered (`GET /guards`), so a silently-off watchdog is visible.
+
+## What it does NOT do
+
+- Does not touch legacy single-file (non-per-topic) jobs.
+- Does not message the user yet (the spec's §3 plain-English termination notice is a
+  follow-up; until then a kill is audit-only — acceptable while dryRun/dark).
+- Does not change the cooperative in-hook duration check; it is the EXTERNAL backstop the
+  grace window defers to.
+
+## Rollback
+
+Set `monitoring.enforcedTermination.enabled: false` (or leave it omitted) — the watchdog
+is not constructed and the route 503s. No migration, no persisted state to unwind beyond
+the append-only audit log.
+
+## Second-pass reviewer verdict
+
+_Pending — required before `dryRun:false` is ever flipped, and the live-flip is itself a
+separate operator-gated step (the spec's §5 livetest battery)._


### PR DESCRIPTION
## What

`EnforcedTerminationWatchdog` — an external, level-triggered loop that hard-stops an autonomous run which has **provably overrun its budget**. The structural counterweight to the `AutonomousLivenessReconciler` (that keeps a run *alive*; this keeps a run from *outliving its budget*).

**Earned from** 2026-06-25: an autonomous run with a 24h budget ran ~46h (topic 27515) because the only deadline enforcement was the run's own in-hook Stop-event check — which a wedged/looping session never reaches, an unbounded run has no budget for, and an unparseable timestamp fails toward keep-running.

This is the first F-series structural tooth built for the proposed constitutional standard **The User Experience Is the Product** (sub-standard #2 Enforced Termination; PR #1280) — "Structure beats Willpower" applied to the END of work.

## Design (spec: `docs/specs/enforced-termination-watchdog.md`)

- **`computeOverrun`** fires only on a provable overrun: time-budget + grace (so the cooperative in-hook check wins normally), an absolute ceiling (26h — covers unbounded runs + unparseable `started_at` via file mtime), or an opt-in iteration ceiling. Gates OUT inactive/paused/mid-move runs. It is NOT a pressure/idle reaper.
- **Two-tick confirm** before any kill (absorbs a blip / in-flight cooperative stop / just-completed run).
- **Durable, non-reviving kill**: reuses the reconciler's proven `settleKill` (clear `endedMidWork` → `killSession`) + `stopAutonomousTopic` (delete state file) + `recordOperatorStop` + `rq.cancelByTopic` — so neither the liveness reconciler nor the resume queue revives a terminated run. No new session-killing code path.
- **Fail-safe on uncertainty**, **per-window cap** (gives up loudly, P19), **full audit** (`logs/enforced-termination.jsonl`), **guard-registered** (`GET /guards`).

## Safety / rollout

Ships **dark on the fleet** (dev-agent gated; `monitoring.enforcedTermination.enabled` omitted from defaults) and **dry-run first** (`dryRun:true` → logs `would-terminate`, actuates nothing). A live flip requires the second-pass reviewer verdict + the §5 livetest battery. Full KILL-path blast-radius analysis: `upgrades/side-effects/enforced-termination-watchdog.md`.

## Tests

41 unit tests, clean full `tsc`:
- pure predicate + two-tick confirm (21) — both sides of every boundary incl. the 46h incident + every absolute-ceiling hole
- orchestration (9) — dryRun never actuates, eligibility, retry-on-fail, cap-exceeded, listRuns-throws fails-safe, disabled no-op
- read adapters against real files (9)
- route "feature is alive" (2) — 200 wired / 503 dark

## Follow-ups (tracked, not in this PR)

- User-facing plain-English termination notice (spec §3).
- CLAUDE.md template note (Agent Awareness) — deferred to promotion per Maturity-honesty (the feature is dark/dev-gated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
## ELI16

I can run long background jobs that are supposed to stop themselves when their time is up. But the only thing enforcing that was each job checking its own clock — which breaks if the job gets stuck, was started with no time limit, or has a garbled start-time. On June 25th a job with a 24-hour budget ran ~46 hours because nothing outside it forced a stop.

This adds a separate watchdog that watches every long job from the outside, like a shift supervisor who can send someone home instead of trusting them to clock out. If a job genuinely blows past its deadline, it stops it cleanly — removes its marker, cancels any auto-restart, and shuts the session down so it can't be quietly revived.

It's careful on purpose: it only acts on a real overrun (never a job still inside its time), has to see the overrun twice before acting, does nothing when anything is uncertain, and caps how often it can fire so it can never go on a spree. It ships switched off everywhere except my dev setup, and even there it only watches and logs at first — it won't actually stop anything until an operator turns that on after a live test.
