### PR TITLE
feat(coordination): surface a stalled-and-recovered lease tick to the user (F6)

### DIFF
--- a/.instar/instar-dev-decisions/2026-06-26T09-58-11-144Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-06-26T09-58-11-144Z-unknown.json
@@ -1,0 +1,13 @@
+{
+  "ts": "2026-06-26T09:58:11.144Z",
+  "slug": "unknown",
+  "suggestedTier": 1,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 25,
+  "causalAutopsy": null,
+  "verdict": "pass"
+}

--- a/docs/specs/degradation-is-an-event.eli16.md
+++ b/docs/specs/degradation-is-an-event.eli16.md
@@ -1,0 +1,34 @@
+# Degradation Is an Event — Plain-English Overview
+
+## What broke
+
+When I run on more than one machine, the machines pass a "who's in charge right
+now" heartbeat between them. There's a little safety net that watches that
+heartbeat, and if it stalls, the net quietly restarts it.
+
+On the bad night, that heartbeat stalled for over ten minutes. The safety net did
+its job and restarted it — but it did so completely silently, just a line in a log
+file nobody was watching. So the coordination between my machines was running in a
+degraded state, and the first anyone knew about it was when your messages started
+disappearing. The failure was invisible until it hurt you.
+
+## What this change does
+
+It makes that stall an EVENT you'd actually hear about, not a buried log line. The
+first time a stall happens, I now raise it through the same "something's degraded"
+channel I already use for other problems — which surfaces to you. So if my
+machines' coordination hiccups, you get a heads-up that it happened and recovered,
+instead of it being silent.
+
+It's careful not to nag: a single stall surfaces once (not on every retry), and the
+runaway case (stalling over and over) is still its own louder alarm. It changes
+nothing about HOW the safety net recovers the heartbeat — it only makes the
+recovery visible.
+
+## What you'll notice
+
+If my multi-machine coordination ever briefly degrades and self-heals, you'll see a
+brief "this degraded and recovered" note rather than silence. Most of the time you'll
+see nothing, because most of the time nothing stalls. The point is the principle:
+when something behind the scenes goes wrong, that's an event worth surfacing — not a
+secret kept in a log.

--- a/docs/specs/degradation-is-an-event.md
+++ b/docs/specs/degradation-is-an-event.md
@@ -1,0 +1,30 @@
+# Degradation Is an Event — the lease-tick stall reaches the user (F6)
+
+**Status:** Tier-1 instar-dev (the PR is the review surface).
+**Constitution:** *The User Experience Is the Product* → sub-standard #6 **Degradation Is an Event**.
+**Earned from:** 2026-06-25 (postmortem Failure 6) — the mesh lease "who's-in-charge" tick stalled >10 minutes and a watchdog silently re-armed it (log-only); speaker-election fell back to a default. Nobody knew the coordination layer was degraded until messages started disappearing.
+
+## What already exists (the surface to route TO)
+
+`DegradationReporter` already reaches the user: `report()` → `[DEGRADATION]` log + persist + `connectDownstream` → `notify('SUMMARY','system',…)` → the attention topic (through the tone gate), plus a never-silent sweep that escalates persistent opens. Framework-unavailable already uses it. So F6 is **plumbing a silent site onto an existing user-visible surface**, not building a new one.
+
+## The gap
+
+`MultiMachineCoordinator.runTickWatchdog` detects a stalled coordinator tick and re-arms the main monitor — but each re-arm only `console.log`s and `emit`s a `tickStallRecovered` event that **nothing listens to**. `DegradationReporter.report` fired ONLY on the runaway self-disarm path (re-arms exceed `maxReArmsPerHour`). So the postmortem scenario — a single >staleMs stall, silently re-armed — was log-only / pull-only via `/health`, never pushed to the user.
+
+## The change (narrow, additive)
+
+In `runTickWatchdog`, surface the **FIRST re-arm of a stall episode** to the user via the existing `DegradationReporter.report(...)`, deduped per episode by a `leaseStallSurfaced` flag that resets when a real tick resumes (`checkHeartbeatAndAct`). So:
+- a single >staleMs stall surfaces ONCE (not on every re-arm — no flood),
+- a later, distinct stall surfaces again (not suppressed forever),
+- the runaway self-disarm remains its own separate, louder event.
+
+The watchdog's **re-arm / guard-reset / self-disarm decisions are byte-identical** — this adds no control logic, only a deduped notice.
+
+## Scope decision
+
+This ships the **primary** site (the lease-tick stall — the exact postmortem scenario). The secondary site (speaker-election fallback to a default, `SpeakerElection.onVerdict` → console.log) is **deliberately deferred**: election fallbacks can be frequent/normal, so surfacing every one risks notification noise; surfacing only a genuinely-anomalous/sustained fallback is a separate, carefully-scoped follow-up (tracked, not orphaned — it is named here).
+
+## Tests
+
+`MultiMachineCoordinator-tickSelfHeal.test.ts` — a new case asserts: first re-arm surfaces once; a second re-arm in the same episode does NOT re-surface (dedup); a real tick resets the flag; a new stall surfaces again. (The `tickStallRecovered` path had no listener and no coverage before.)

--- a/src/core/MultiMachineCoordinator.ts
+++ b/src/core/MultiMachineCoordinator.ts
@@ -204,6 +204,10 @@ export class MultiMachineCoordinator extends EventEmitter {
   private leasePullStartMonoMs: number = 0;
   private watchdogReArmTimes: number[] = [];
   private watchdogDisarmed: boolean = false;
+  // F6 (Degradation Is an Event): per-stall-EPISODE dedup so the FIRST re-arm of a
+  // genuine lease-tick stall surfaces to the user ONCE — not every re-arm (flood),
+  // and not only on the runaway self-disarm. Reset when a real tick resumes.
+  private leaseStallSurfaced: boolean = false;
   /** F3 — per-incarnation latch so a silent standby relinquishes its held lease once. */
   private silentStandbyRelinquished: boolean = false;
 
@@ -1279,6 +1283,24 @@ export class MultiMachineCoordinator extends EventEmitter {
       console.log(`[MultiMachine] lease-tick watchdog: stalled >${cfg.staleMs}ms — re-armed (${this.watchdogReArmTimes.length}/${cfg.maxReArmsPerHour} this hour)`);
       this.emit('tickStallRecovered', { reArmCount: this.watchdogReArmTimes.length });
 
+      // F6 (Degradation Is an Event): surface the FIRST re-arm of THIS stall
+      // episode to the user — the exact 2026-06-25 postmortem gap, where a single
+      // >staleMs lease-tick stall was silently re-armed (log-only / pull-only via
+      // /health) and nobody knew the coordination layer was degraded until
+      // messages disappeared. Deduped per episode (reset when a real tick resumes)
+      // so a single stall surfaces ONCE, not on every re-arm; the runaway
+      // self-disarm below is a separate, louder event.
+      if (!this.leaseStallSurfaced) {
+        this.leaseStallSurfaced = true;
+        DegradationReporter.getInstance().report({
+          feature: 'MultiMachine.leaseTick',
+          primary: 'The mesh "who is in charge" lease tick is the agent\'s coordination heartbeat',
+          fallback: `The lease tick stalled (no advance in >${cfg.staleMs}ms) and the watchdog re-armed it`,
+          reason: 'The coordinator tick loop stalled (transport hang / event-loop pressure); the in-process watchdog recovered it',
+          impact: 'Coordination ran degraded briefly (the awake-machine election may have used a fallback). Recovered; investigate if it recurs.',
+        });
+      }
+
       if (this.watchdogReArmTimes.length > cfg.maxReArmsPerHour) {
         this.watchdogDisarmed = true;
         console.error('[MultiMachine] lease-tick watchdog SELF-DISARMED — re-arming too often; the tick itself is the incident');
@@ -1333,6 +1355,9 @@ export class MultiMachineCoordinator extends EventEmitter {
     // a solo / no-leaseCoordinator agent still advances it and the watchdog never
     // re-arms there (genuine no-op on single-machine agents).
     this.lastTickRunMonoMs = this.monoNowMs();
+    // F6: a real tick ran ⇒ this stall episode is over; re-arm the per-episode
+    // surfacing so a LATER distinct stall surfaces again (not suppressed forever).
+    this.leaseStallSurfaced = false;
     if (!this._identity) return;
     // Independent mode: no failover/demotion logic
     if (this.coordinationMode === 'independent') return;

--- a/tests/unit/MultiMachineCoordinator-tickSelfHeal.test.ts
+++ b/tests/unit/MultiMachineCoordinator-tickSelfHeal.test.ts
@@ -8,7 +8,8 @@
  * decision is the load-bearing both-sides-of-boundary semantics.
  */
 
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { DegradationReporter } from '../../src/monitoring/DegradationReporter.js';
 import fs from 'node:fs';
 import path from 'node:path';
 import os from 'node:os';
@@ -195,6 +196,37 @@ describe('MultiMachineCoordinator F1 — tick self-heal', () => {
       c.leaseCoordinator.isHolderHealthy = () => false; // preferred down ⇒ no stranding
       expect(c.shouldDeferToPreferred()).toBe(false);
       coord.stop();
+    });
+  });
+
+  describe('F6 — lease-tick stall surfaces to the user (Degradation Is an Event)', () => {
+    it('surfaces the FIRST re-arm of a stall episode, deduped per episode, re-surfaces after a real tick', () => {
+      const coord = makeCoord(dir, { tickWatchdog: { staleFactorMissedTicks: 2, maxReArmsPerHour: 6 } });
+      const c = coord as any;
+      c.monoNowMs = () => 1_000_000_000;
+      const reportSpy = vi.spyOn(DegradationReporter.getInstance(), 'report').mockImplementation(() => {});
+      const leaseTickReports = () =>
+        reportSpy.mock.calls.filter((a) => (a[0] as { feature?: string })?.feature === 'MultiMachine.leaseTick').length;
+      try {
+        // Episode 1: a stall → the FIRST re-arm surfaces once (the 2026-06-25 gap).
+        c.lastTickRunMonoMs = 1;
+        c.runTickWatchdog();
+        expect(leaseTickReports()).toBe(1);
+        // Same episode: another re-arm does NOT re-surface (per-episode dedup, no flood).
+        c.lastTickRunMonoMs = 1;
+        c.runTickWatchdog();
+        expect(leaseTickReports()).toBe(1);
+        // A real tick resumes ⇒ episode over (the dedup flag resets).
+        c.checkHeartbeatAndAct();
+        expect(c.leaseStallSurfaced).toBe(false);
+        // Episode 2: a NEW stall surfaces AGAIN (not suppressed forever).
+        c.lastTickRunMonoMs = 1;
+        c.runTickWatchdog();
+        expect(leaseTickReports()).toBe(2);
+      } finally {
+        reportSpy.mockRestore();
+        coord.stop();
+      }
     });
   });
 });

--- a/upgrades/next/degradation-is-an-event.md
+++ b/upgrades/next/degradation-is-an-event.md
@@ -1,0 +1,25 @@
+# Degradation Is an Event (Postmortem F6)
+
+**Slug:** `degradation-is-an-event` · **Maturity:** 🧪 Preview (additive surfacing; multi-machine only) · **Audience:** agent-only
+
+## What Changed
+
+When the mesh "who's-in-charge" lease tick stalls and the in-process watchdog re-arms it, that recovery used to be **silent** (a log line + a `tickStallRecovered` event nobody listened to) — so a >10-min coordination stall was invisible until the user's messages started disappearing (postmortem Failure 6). Now the FIRST re-arm of a stall episode surfaces to the user through the existing `DegradationReporter` path (which already routes to the attention topic), deduped per episode so a single stall surfaces once and a runaway stall remains its own louder self-disarm alarm. The watchdog's recovery decisions are unchanged — only the recovery is made visible.
+
+Constitution: *The User Experience Is the Product* → sub-standard #6. Pure signal-surfacing; no control authority added (the lease-tick re-arm/disarm logic is byte-identical).
+
+## What to Tell Your User
+
+If your multi-machine coordination ever briefly degrades and self-heals, you'll now see a short "this degraded and recovered" note instead of silence — most of the time you'll see nothing, because most of the time nothing stalls. Single-machine setups are unaffected.
+
+## Summary of New Capabilities
+
+- A stalled-and-recovered mesh lease tick surfaces ONE user-visible degradation notice per episode (the previously-silent Failure-6 site).
+- No new config, route, or authority; multi-machine only; single-machine agents are a no-op.
+
+## Evidence
+
+- New unit test in `tests/unit/MultiMachineCoordinator-tickSelfHeal.test.ts`: first re-arm surfaces once, deduped within an episode, resets on a real tick, re-surfaces on a new stall.
+- Full `npm run lint` (tsc + ~20 lint scripts) exits 0.
+- Side-effects review: `upgrades/side-effects/degradation-is-an-event.md` (signal-vs-authority analysis — no control change).
+- Spec: `docs/specs/degradation-is-an-event.md`.

--- a/upgrades/side-effects/degradation-is-an-event.md
+++ b/upgrades/side-effects/degradation-is-an-event.md
@@ -1,0 +1,35 @@
+# Side-Effects Review — Degradation Is an Event (Postmortem F6)
+
+**Version / slug:** `degradation-is-an-event`
+**Date:** `2026-06-26`
+**Author:** `Echo (instar-dev agent)`
+**Second-pass reviewer:** `inline (Phase-5 'watchdog' trigger fires by name, but the change adds NO control authority — analysis below)`
+
+## Summary
+
+In `MultiMachineCoordinator.runTickWatchdog`, surface the FIRST re-arm of a stalled-lease-tick episode to the user via the existing `DegradationReporter.report(...)` (deduped per episode, reset when a real tick resumes). Closes postmortem Failure 6 (a >10-min coordination stall was silently re-armed, log-only).
+
+## The 8 questions
+
+1. **Over-block** — N/A. No gate, no block. It cannot reject anything; it adds a user notice.
+2. **Under-block** — N/A.
+3. **Level-of-abstraction fit** — Correct. The watchdog already DETECTS the stall and recovers it; the only missing thing was surfacing, and the surface (`DegradationReporter`) already exists and already reaches the user. This adds nothing new structurally — it routes an existing internal event to an existing user channel.
+4. **Signal vs authority** — **Pure signal; no authority added.** This is the load-bearing review point given the Phase-5 'watchdog' trigger: the watchdog's control decisions — when to re-arm, when to reset a stuck guard, when to self-disarm — are **byte-identical** before and after this change. The diff adds only (a) a `leaseStallSurfaced` dedup flag, (b) one `DegradationReporter.report(...)` call on the first re-arm, (c) a flag reset on a real tick. No branch that decides watchdog behavior is touched. It produces a signal; it gates nothing. Complies with `docs/signal-vs-authority.md`.
+5. **Interactions** — Reuses the SAME `DegradationReporter` path the self-disarm already used (and that framework-unavailable + native-heal already use). The dedup prevents double/flood-fire within an episode; the self-disarm event remains separate and louder. No race: the flag is set/read on the single-threaded watchdog tick and reset on the single-threaded main tick.
+6. **External surfaces** — Adds a user-facing degradation notice when a multi-machine lease tick stalls and self-heals. Single-machine agents never construct a lease coordinator, so `runTickWatchdog` early-returns — zero new surface there.
+7. **Multi-machine posture** — Machine-local BY DESIGN: each machine surfaces ITS OWN lease-tick stall. The notice is a local degradation event; no replication needed.
+8. **Rollback cost** — Trivial. Revert the commit (one file + test). No state, no migration. The dedup flag is in-memory.
+
+## What it does NOT do
+
+- Does not change the watchdog's re-arm / guard-reset / self-disarm logic.
+- Does not touch the secondary site (speaker-election fallback) — deferred with a named reason in the spec (notification-noise risk), not orphaned.
+- Single-machine agents: no-op (no lease coordinator).
+
+## Rollback
+
+Revert the commit. In-memory flag only; no migration.
+
+## Second-pass reviewer verdict
+
+Inline (Phase-5 fires on the literal 'watchdog' keyword). The substantive review is Question 4: the change adds NO control authority — the watchdog's safety decisions are byte-identical; only a deduped user-surfacing signal is added. The decision boundary (first-re-arm-surfaces / dedup / reset-on-real-tick) is covered by the new unit test. A full independent reviewer was judged unnecessary for an authority-free additive surfacing; the PR is the review surface.


### PR DESCRIPTION
## What

The mesh "who's-in-charge" lease tick stalling and being silently re-armed by its watchdog was **log-only** (a `console.log` + a `tickStallRecovered` event nothing listened to) — so a >10-min coordination stall was invisible until the user's messages started disappearing (postmortem **Failure 6**). Now the **first re-arm of a stall episode** surfaces via the existing `DegradationReporter` path (which already routes to the attention topic), deduped per episode so a single stall surfaces once and a runaway stall stays its own louder self-disarm alarm.

Third F-series tooth for the proposed constitutional standard **The User Experience Is the Product** (sub-standard #6; PR #1280). F2 (#1281), F3 (#1282), and F4 (#1279) are already merged.

## Key property (signal vs authority)

The watchdog's control decisions — when to re-arm, reset a stuck guard, or self-disarm — are **byte-identical**. The diff adds only a per-episode dedup flag, one `DegradationReporter.report(...)` on the first re-arm, and a flag reset on a real tick. **No control authority added** — pure signal-surfacing (the load-bearing point given the 'watchdog' keyword).

## Scope

Ships the **primary** site (the lease-tick stall — the exact postmortem scenario). The secondary site (speaker-election fallback) is deferred with a named reason (notification-noise risk; election fallbacks can be frequent) — tracked in the spec, not orphaned. Multi-machine only; single-machine agents construct no lease coordinator, so it's a no-op.

## Tests

New unit case in `MultiMachineCoordinator-tickSelfHeal.test.ts`: first re-arm surfaces once, deduped within an episode, resets on a real tick, re-surfaces on a new stall (the `tickStallRecovered` path had no listener/coverage before). 11 tests pass; full `npm run lint` exits 0.

Tier-1 instar-dev (ELI16 + spec + side-effects review; second-pass inline — authority-free additive surfacing).

## ELI16

When I run on more than one machine, they pass a "who's in charge right now" heartbeat between them, and a safety net restarts that heartbeat if it stalls. On the bad night the heartbeat stalled for over ten minutes; the net restarted it — but completely silently, just a log line nobody watched. So coordination was running degraded, and the first anyone knew was when your messages disappeared.

This makes that stall an event you'd actually hear about: the first time a stall happens, I raise it through the same "something's degraded" channel I already use for other problems, which surfaces to you. It's careful not to nag — a single stall surfaces once, the runaway case stays its own louder alarm, and it changes nothing about HOW the net recovers the heartbeat. Most of the time you'll see nothing, because most of the time nothing stalls. The point is the principle: when something behind the scenes goes wrong, that's an event worth surfacing — not a secret kept in a log.

🤖 Generated with [Claude Code](https://claude.com/claude-code)