### PR TITLE
feat(routing): latency-sensitive gate prefers fastest off-Claude framework

### DIFF
--- a/.instar/instar-dev-decisions/2026-06-26T11-10-25-489Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-06-26T11-10-25-489Z-unknown.json
@@ -1,0 +1,13 @@
+{
+  "ts": "2026-06-26T11:10:25.489Z",
+  "slug": "unknown",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 49,
+  "causalAutopsy": null,
+  "verdict": "pass"
+}

--- a/docs/specs/latency-sensitive-gate-framework.eli16.md
+++ b/docs/specs/latency-sensitive-gate-framework.eli16.md
@@ -1,0 +1,42 @@
+# Latency-Sensitive Gate Framework — Plain-English Overview
+
+## The setup
+
+I can run my internal background checks on different AI "engines" (Claude, Codex,
+Gemini, Pi) to spread the load off any one account. There's a default order for
+picking which engine: Codex first, then Pi, then Gemini, then Claude. That order
+was chosen to spread background work onto Codex — which is fine for background
+chores nobody's waiting on.
+
+## What was wrong
+
+One of those "checks" is the safety check on my replies to YOU — and you're
+sitting there waiting for the reply while it runs. That check got lumped in with
+all the background ones, so it defaulted to Codex too. The problem: Codex is the
+SLOWEST engine (about 30 seconds), and the reply check has a 20-second budget. So
+it would blow the budget and time out — which is one of the exact ways your
+replies went silent on the bad night.
+
+## What this change does
+
+It splits the difference. Background checks (the ones nobody's waiting on) keep
+using Codex-first, exactly as before — that still spreads the load nicely. But the
+check that's holding up YOUR reply now uses a different order, ranked by SPEED:
+Pi first (about 6 seconds), then Gemini (about 10), then Codex, then Claude. So
+the thing you're waiting on always grabs the fastest engine available, and stops
+timing out.
+
+It's a tiny, surgical change — one decision in one function. If only one non-Claude
+engine is installed, nothing changes at all (there's no faster option to pick). And
+it doesn't touch HOW the safety check decides what's safe — only which engine runs
+it. If you ever want the reply check back on Codex, setting it explicitly always
+wins over this default.
+
+## Why it matters
+
+This is part of the same lesson as the whole "your experience is the product"
+work: a default that was reasonable for background chores quietly degraded the one
+path where a human is actually waiting. The fix is to recognize that "a person is
+blocked on this" deserves the fast engine, not the load-spreading one. Small change,
+but it removes a real cause of slow or missing replies — and it's durable in the
+code now, not just patched into my own config.

--- a/docs/specs/provider-fallback-default-policy.md
+++ b/docs/specs/provider-fallback-default-policy.md
@@ -119,6 +119,22 @@ INTERNAL_FRAMEWORK_PREFERENCE = ['codex-cli', 'pi-cli', 'gemini-cli', 'claude-co
 Applies to the **internal, lightweight, high-frequency** categories: `sentinel`,
 `gate`, `reflector`. It does **NOT** apply to `job`, `other`, or spawned
 interactive sessions:
+
+> **Amendment (2026-06-26, Phase-A outbound reliability) — the `gate` category is
+> latency-sensitive and uses a SEPARATE, speed-ranked order.** A `gate` is a
+> *synchronous, action-blocking* check; the user-facing `MessagingToneGate` literally
+> has a human waiting on the reply. The codex-first order above optimizes for
+> *load-spreading* (right for background sentinels/reflectors), but `codex-cli` is the
+> SLOWEST off-Claude framework (~30s, which exceeds the 20s outbound-gate review budget
+> and times the gate out — the 2026-06-25 silent-outbound class). So the `gate`
+> category's PRIMARY is now resolved from a distinct
+> `LATENCY_SENSITIVE_FRAMEWORK_PREFERENCE = ['pi-cli','gemini-cli','codex-cli','claude-code']`
+> (fastest→slowest) — the fastest *active* off-Claude framework. `sentinel`/`reflector`
+> are UNCHANGED (codex-first); only `gate` diverges. `failureSwap` is unchanged
+> (shared tail). When only one off-Claude framework is active, `gate` === the other
+> categories' primary (byte-identical). This narrows, but does not revoke, the
+> codex-first operator directive: it stays in force everywhere a human is *not*
+> synchronously blocked.
 - **`job` is EXCLUDED** (resolves round-1 M3 / Q4). Routing the `job` category
   off-Claude by default would silently FLIP cost-bearing background jobs — most
   importantly the Cartographer freshness sweep (`CartographerSweep`, a `job`) —
@@ -144,8 +160,10 @@ lighter `which <cli>` probe because:
 ```
 const active = INTERNAL_FRAMEWORK_PREFERENCE.filter(fw => isActive(fw));
 // e.g. active = ['codex-cli','gemini-cli','claude-code'] (no PI installed/configured)
+const gatePrimary = LATENCY_SENSITIVE_FRAMEWORK_PREFERENCE.find(fw => active.includes(fw)) ?? active[0];
 componentFrameworks = {
-  categories: { sentinel: active[0], gate: active[0], reflector: active[0] },
+  // sentinel/reflector: codex-first (load-spread); gate: fastest active (here gemini, pi absent)
+  categories: { sentinel: active[0], gate: gatePrimary, reflector: active[0] },
   failureSwap: active.slice(1),   // ['gemini-cli','claude-code']
   fallback: 'default',
 };

--- a/src/core/internalFrameworkDefault.ts
+++ b/src/core/internalFrameworkDefault.ts
@@ -37,14 +37,49 @@ export const INTERNAL_FRAMEWORK_PREFERENCE: readonly IntelligenceFramework[] = [
 ] as const;
 
 /**
+ * The LATENCY-SENSITIVE preference chain — used for the `gate` category ONLY.
+ *
+ * A `gate` is a SYNCHRONOUS, action-blocking check (the user-facing
+ * `MessagingToneGate` is the canonical one — a human is waiting for their reply).
+ * The general `INTERNAL_FRAMEWORK_PREFERENCE` puts `codex-cli` first by operator
+ * directive (spread background LOAD off Claude), but codex-cli is the SLOWEST
+ * off-Claude framework (~30s, which exceeds the 20s outbound-gate review budget
+ * and times the gate out — the 2026-06-25 silent-outbound class). For a
+ * latency-sensitive gate the right default is the FASTEST available off-Claude
+ * framework, not the load-spreading order. Ranked fastest→slowest, Claude last.
+ *
+ * This does NOT override the codex-first directive for the BACKGROUND categories
+ * (`sentinel` / `reflector`) — their latency does not block a human, so they keep
+ * the load-spreading order. Only `gate` (where a user waits) goes fastest-first.
+ */
+export const LATENCY_SENSITIVE_FRAMEWORK_PREFERENCE: readonly IntelligenceFramework[] = [
+  'pi-cli',
+  'gemini-cli',
+  'codex-cli',
+  'claude-code',
+] as const;
+
+/** The first framework in `order` that is also present in `active`, else undefined. */
+function firstActiveIn(
+  order: readonly IntelligenceFramework[],
+  active: readonly IntelligenceFramework[],
+): IntelligenceFramework | undefined {
+  return order.find((fw) => active.includes(fw));
+}
+
+/**
  * Compute the default `componentFrameworks` from the active-framework set.
  *
  * @param activeFrameworks the preference chain filtered to frameworks ACTIVE in this
  *   agent, IN PREFERENCE ORDER (the caller filters `INTERNAL_FRAMEWORK_PREFERENCE`
  *   by `buildProvider(fw) !== null`). MUST already be ordered + de-duplicated.
  * @returns the effective `ComponentFrameworksConfig`:
- *   - `categories.{sentinel,gate,reflector}` = `active[0]` (first active off-Claude,
- *     or claude-code if that's all that's active)
+ *   - `categories.{sentinel,reflector}` = `active[0]` (first active off-Claude in the
+ *     codex-first load-spreading order, or claude-code if that's all that's active)
+ *   - `categories.gate` = the FASTEST active off-Claude framework
+ *     (`LATENCY_SENSITIVE_FRAMEWORK_PREFERENCE`: pi → gemini → codex → claude) — the
+ *     gate is synchronous + user-blocking, so it prefers speed over load-spreading.
+ *     Equals `active[0]` when only one off-Claude framework is active (no-op then).
  *   - `failureSwap` = `active.slice(1)` (the ordered tail, claude-code last)
  *   - `fallback: 'default'`
  *
@@ -67,10 +102,18 @@ export function resolveInternalFrameworkDefault(
   }
 
   const primary = active[0];
+  // The `gate` category is LATENCY-SENSITIVE: a synchronous, user-blocking check.
+  // It gets the FASTEST active off-Claude framework (pi → gemini → codex → claude),
+  // NOT the load-spreading codex-first order. `active` is in INTERNAL_FRAMEWORK_
+  // PREFERENCE order, so we re-rank it by the latency order to find the fastest.
+  // Falls back to `primary` if (somehow) no latency-ranked match — keeping the gate
+  // never worse than today. When only one off-Claude framework is active, gatePrimary
+  // === primary (byte-identical to the old behavior).
+  const gatePrimary = firstActiveIn(LATENCY_SENSITIVE_FRAMEWORK_PREFERENCE, active) ?? primary;
   return {
     categories: {
       sentinel: primary,
-      gate: primary,
+      gate: gatePrimary,
       reflector: primary,
       // `job` and `other` are deliberately ABSENT (§4.1).
     },

--- a/tests/integration/provider-fallback-default-routing.test.ts
+++ b/tests/integration/provider-fallback-default-routing.test.ts
@@ -4,9 +4,10 @@
  *
  * Exercises the real Express route over a real IntelligenceRouter wired with the
  * COMPUTED DEFAULT (no operator componentFrameworks). On a codex-active agent the
- * sentinel/gate/reflector components resolve to the first active off-Claude framework
- * (codex-cli), while `job` stays on the agent default — and a claude-only agent is a
- * no-op (everything stays on the default framework).
+ * sentinel/reflector components resolve to the first active off-Claude framework
+ * (codex-cli, load-spreading), the latency-sensitive `gate` resolves to the FASTEST
+ * active off-Claude framework (pi → gemini → codex), while `job` stays on the agent
+ * default — and a claude-only agent is a no-op (everything stays on the default).
  */
 import { describe, it, expect } from 'vitest';
 import express from 'express';
@@ -64,7 +65,7 @@ function routerWithComputedDefault(activeSet: IntelligenceFramework[]): Intellig
 }
 
 describe('GET /intelligence/routing — provider-fallback default policy (integration)', () => {
-  it('codex-active agent: sentinel/gate/reflector → codex-cli; job → agent default', async () => {
+  it('codex-active agent: sentinel/reflector → codex-cli; gate → gemini (fastest active); job → agent default', async () => {
     const router = routerWithComputedDefault(['codex-cli', 'gemini-cli', 'claude-code']);
     const res = await request(appWith(router)).get('/intelligence/routing');
     expect(res.status).toBe(200);
@@ -73,10 +74,12 @@ describe('GET /intelligence/routing — provider-fallback default policy (integr
     const byComponent = (name: string) =>
       res.body.components.find((c: any) => c.component === name);
 
-    // a sentinel, a gate, and a reflector all route to the first active off-Claude fw.
+    // sentinel + reflector route to the first active off-Claude fw (codex, load-spread).
     expect(byComponent('PresenceProxy')).toMatchObject({ category: 'sentinel', framework: 'codex-cli', available: true });
-    expect(byComponent('PromptGate')).toMatchObject({ category: 'gate', framework: 'codex-cli', available: true });
     expect(byComponent('JobReflector')).toMatchObject({ category: 'reflector', framework: 'codex-cli', available: true });
+    // the GATE is latency-sensitive → fastest active off-Claude (gemini here, pi absent),
+    // NOT the slow codex. This is the Phase-A outbound-reliability fix.
+    expect(byComponent('PromptGate')).toMatchObject({ category: 'gate', framework: 'gemini-cli', available: true });
 
     // a `job` component STAYS on the agent default (job is EXCLUDED from the default).
     const sweep = byComponent('CartographerSweep');

--- a/tests/unit/internalFrameworkDefault.test.ts
+++ b/tests/unit/internalFrameworkDefault.test.ts
@@ -11,6 +11,7 @@
 import { describe, it, expect } from 'vitest';
 import {
   INTERNAL_FRAMEWORK_PREFERENCE,
+  LATENCY_SENSITIVE_FRAMEWORK_PREFERENCE,
   resolveInternalFrameworkDefault,
 } from '../../src/core/internalFrameworkDefault.js';
 import {
@@ -55,11 +56,11 @@ describe('INTERNAL_FRAMEWORK_PREFERENCE (named constant)', () => {
 });
 
 describe('resolveInternalFrameworkDefault — category computation', () => {
-  it('all active: primary=codex, failureSwap=[pi,gemini,claude], categories only sentinel/gate/reflector', () => {
+  it('all active: sentinel/reflector=codex (load-spread), gate=pi (FASTEST), failureSwap=[pi,gemini,claude]', () => {
     const cfg = resolveInternalFrameworkDefault(['codex-cli', 'pi-cli', 'gemini-cli', 'claude-code']);
     expect(cfg.categories).toEqual({
       sentinel: 'codex-cli',
-      gate: 'codex-cli',
+      gate: 'pi-cli', // latency-sensitive → fastest off-Claude, NOT codex-first
       reflector: 'codex-cli',
     });
     // M3 regression guard: `job` (and `other`) are NEVER in the computed categories.
@@ -110,6 +111,67 @@ describe('resolveInternalFrameworkDefault — category computation', () => {
     // appears in the active set. Primary=codex, no tail.
     const cfg = resolveInternalFrameworkDefault(['codex-cli']);
     expect(cfg.categories?.sentinel).toBe('codex-cli');
+    // gate diverges to the fastest active — here only codex is active, so gate===codex.
+    expect(cfg.categories?.gate).toBe('codex-cli');
     expect(cfg.failureSwap).toEqual([]);
+  });
+});
+
+describe('LATENCY_SENSITIVE_FRAMEWORK_PREFERENCE (the gate-only fast order)', () => {
+  it('is exactly fastest→slowest: pi → gemini → codex → claude (claude last)', () => {
+    expect(LATENCY_SENSITIVE_FRAMEWORK_PREFERENCE).toEqual([
+      'pi-cli',
+      'gemini-cli',
+      'codex-cli',
+      'claude-code',
+    ]);
+    expect(LATENCY_SENSITIVE_FRAMEWORK_PREFERENCE[LATENCY_SENSITIVE_FRAMEWORK_PREFERENCE.length - 1]).toBe('claude-code');
+  });
+
+  it('every entry is a real IntelligenceFramework enum value', () => {
+    for (const fw of LATENCY_SENSITIVE_FRAMEWORK_PREFERENCE) {
+      expect(KNOWN_FRAMEWORKS).toContain(fw);
+    }
+  });
+
+  it('has no duplicates and is a permutation of the general preference chain', () => {
+    expect(new Set(LATENCY_SENSITIVE_FRAMEWORK_PREFERENCE).size).toBe(LATENCY_SENSITIVE_FRAMEWORK_PREFERENCE.length);
+    expect([...LATENCY_SENSITIVE_FRAMEWORK_PREFERENCE].sort()).toEqual([...INTERNAL_FRAMEWORK_PREFERENCE].sort());
+  });
+});
+
+describe('resolveInternalFrameworkDefault — the gate is latency-sensitive (the F5/Phase-A fix)', () => {
+  it('gate prefers the FASTEST off-Claude framework while sentinels keep codex-first', () => {
+    // The exact production case: all four active. Background categories spread load
+    // onto codex (slow but fine — no human waits); the user-facing gate goes to pi
+    // (fastest) so it never times out the 20s outbound-review budget.
+    const cfg = resolveInternalFrameworkDefault(['codex-cli', 'pi-cli', 'gemini-cli', 'claude-code']);
+    expect(cfg.categories?.gate).toBe('pi-cli');
+    expect(cfg.categories?.sentinel).toBe('codex-cli');
+    expect(cfg.categories?.reflector).toBe('codex-cli');
+    // The gate's primary is NOT the slow codex (the 2026-06-25 timeout class).
+    expect(cfg.categories?.gate).not.toBe('codex-cli');
+  });
+
+  it('pi DOWN, gemini up → gate falls to gemini (the next-fastest), not codex (task-2 case)', () => {
+    // pi unavailable at boot; codex + gemini + claude active. The gate must pick the
+    // fastest REMAINING off-Claude framework — gemini — and gemini is in failureSwap.
+    const cfg = resolveInternalFrameworkDefault(['codex-cli', 'gemini-cli', 'claude-code']);
+    expect(cfg.categories?.gate).toBe('gemini-cli'); // fastest active, NOT codex
+    expect(cfg.categories?.sentinel).toBe('codex-cli'); // background keeps codex-first
+    // gemini is reachable as a fallback for the gate's primary too.
+    expect(cfg.failureSwap).toContain('gemini-cli');
+  });
+
+  it('pi AND gemini both down → gate falls to codex (only off-Claude left), never worse than today', () => {
+    const cfg = resolveInternalFrameworkDefault(['codex-cli', 'claude-code']);
+    expect(cfg.categories?.gate).toBe('codex-cli'); // identical to sentinel — no divergence possible
+    expect(cfg.categories?.sentinel).toBe('codex-cli');
+  });
+
+  it('only one off-Claude framework active → gate === sentinel (byte-identical no-op)', () => {
+    const cfg = resolveInternalFrameworkDefault(['gemini-cli', 'claude-code']);
+    expect(cfg.categories?.gate).toBe('gemini-cli');
+    expect(cfg.categories?.gate).toBe(cfg.categories?.sentinel);
   });
 });

--- a/upgrades/next/latency-sensitive-gate-framework.md
+++ b/upgrades/next/latency-sensitive-gate-framework.md
@@ -1,0 +1,43 @@
+# Latency-Sensitive Gate Framework Default
+
+**Slug:** `latency-sensitive-gate-framework` · **Maturity:** 🧪 Preview (default-policy refinement) · **Audience:** agent-only
+
+## What Changed
+
+The provider-fallback default policy routed every internal off-Claude category
+(`sentinel`, `gate`, `reflector`) onto the same codex-first primary. But the
+`gate` category includes the **user-facing tone gate** — a synchronous check a
+human is waiting on — and `codex-cli` is the slowest off-Claude framework (~30s),
+which exceeds the 20s outbound-review budget and times the gate out (a cause of
+the 2026-06-25 silent-outbound incident). The `gate` category now resolves its
+default primary from a separate speed-ranked order (`pi → gemini → codex →
+claude`) — the fastest *active* off-Claude framework — while `sentinel`/`reflector`
+keep the codex-first load-spreading order. `failureSwap`, the gate's verdict
+logic, and the F4 degrade floor are all unchanged.
+
+## What to Tell Your User
+
+Your replies' safety check now runs on the fastest available engine instead of
+the slowest, so it stops timing out under load — one fewer cause of slow or
+missing replies. Background checks are unchanged. If only one non-Claude engine is
+installed, nothing changes.
+
+## Summary of New Capabilities
+
+- The latency-sensitive `gate` category defaults to the fastest active off-Claude
+  framework (`LATENCY_SENSITIVE_FRAMEWORK_PREFERENCE`), not the codex-first order.
+- `sentinel`/`reflector`/`job`/`other` routing and `failureSwap` are unchanged.
+- An explicit `categories.gate` in config always overrides the computed default.
+- Single-off-Claude-framework agents and claude-only agents: byte-identical no-op.
+
+## Evidence
+
+- `internalFrameworkDefault.test.ts`: gate prefers fastest (pi) while sentinel
+  stays codex; pi-down→gemini (the gemini-serves-when-pi-down case); both-down→codex
+  (never worse than today); single-framework→no divergence. 17 unit tests pass.
+- `provider-fallback-default-routing.test.ts` (integration): the gate component on
+  `GET /intelligence/routing` reports the fastest active framework. 3 pass.
+- `provider-fallback-default-policy-lifecycle.test.ts` (e2e): route alive, policy
+  live. `tsc --noEmit` clean. 24 affected tests green.
+- Side-effects review: `upgrades/side-effects/latency-sensitive-gate-framework.md`.
+- Spec amendment: `docs/specs/provider-fallback-default-policy.md` §4.1.

--- a/upgrades/side-effects/latency-sensitive-gate-framework.md
+++ b/upgrades/side-effects/latency-sensitive-gate-framework.md
@@ -1,0 +1,79 @@
+# Side-Effects Review — Latency-Sensitive Gate Framework Default
+
+**Version / slug:** `latency-sensitive-gate-framework`
+**Date:** `2026-06-26`
+**Author:** `Echo (instar-dev agent)`
+**Tier:** 1 (small, localized; one pure resolver function + its tests + docs)
+
+## Summary
+
+The provider-fallback default policy routes internal components off-Claude via a
+single codex-first preference chain (`codex-cli → pi-cli → gemini-cli →
+claude-code`). The `gate` category — which includes the **user-facing
+`MessagingToneGate`**, a synchronous check a human is waiting on — inherited that
+codex-first primary. But `codex-cli` is the SLOWEST off-Claude framework (~30s),
+which exceeds the 20s outbound-gate review budget and times the gate out (the
+2026-06-25 silent-outbound class). This change gives the `gate` category a
+SEPARATE, speed-ranked order (`LATENCY_SENSITIVE_FRAMEWORK_PREFERENCE = pi →
+gemini → codex → claude`) so it defaults to the FASTEST active off-Claude
+framework. `sentinel`/`reflector` (background) keep codex-first; `failureSwap` and
+all other categories are unchanged.
+
+## The 8 questions
+
+1. **Over-block** — N/A. This is not a gate; it selects which backend computes the
+   tone-gate verdict. It rejects nothing.
+2. **Under-block** — N/A. The tone gate's block/allow logic and its deterministic
+   degrade floor (F4) are byte-identical; only the LLM backend that produces the
+   verdict changes. A faster backend means FEWER budget-timeout degrades, i.e.
+   *more* real verdicts, not fewer.
+3. **Level-of-abstraction fit** — Correct. The change lives in the one pure policy
+   resolver (`resolveInternalFrameworkDefault`) that already computes per-category
+   primaries; `ComponentFrameworksConfig.categories` is already a per-category map,
+   so no routing-engine change is needed. The router consumes the config unchanged.
+4. **Signal vs authority** — No authority added. The resolver is a pure function
+   (active-set → config); it holds no blocking power. The tone gate's authority
+   (hold/send) is untouched. Complies with `docs/signal-vs-authority.md`.
+5. **Interactions** — The gate's PRIMARY now differs from `sentinel`/`reflector`.
+   `failureSwap` is the shared tail (`active.slice(1)`, codex-first); for a gate
+   whose primary is `pi`, the tail may list `pi` first (the just-tried framework) —
+   harmless: the failure-swap walk is circuit-checked, so a just-failed/open
+   provider is skipped. When only one off-Claude framework is active, `gatePrimary
+   === active[0]` (byte-identical no-op). No double-fire, no shadowing.
+6. **External surfaces** — `GET /intelligence/routing` now reports the gate
+   component on a (possibly) different framework than sentinels. That is the
+   intended, visible effect. No new route, no schema change.
+7. **Multi-machine posture** — **Machine-local BY DESIGN.** The default policy is
+   computed per-agent at boot from that agent's own active-framework set (which
+   frameworks' CLIs are installed/configured on THAT machine). No replication, no
+   cross-machine coupling. Each machine independently resolves the fastest gate
+   backend it has. Correct — framework availability is inherently per-machine.
+8. **Rollback cost** — Trivial. Revert the commit (one source file + tests + one
+   doc amendment). No state, no migration. An operator who wants the gate back on
+   codex sets `categories.gate` explicitly (the explicit config always wins over
+   the computed default). A single-off-Claude-framework agent is unaffected.
+
+## What it does NOT do
+
+- Does NOT change the tone gate's verdict/hold/send logic or the F4 degrade floor.
+- Does NOT touch `sentinel`/`reflector`/`job`/`other` routing, or `failureSwap`.
+- Does NOT introduce a measured latency model — the ranking (pi < gemini < codex)
+  is a documented static assertion from observed behavior (~6s / ~9-13s / ~30s),
+  owned in `LATENCY_SENSITIVE_FRAMEWORK_PREFERENCE` with a unit-tested enum guard.
+- Does NOT revoke the codex-first operator directive — it narrows it to exclude the
+  one latency-sensitive, user-blocking category.
+
+## Second-pass note (outbound-path touch)
+
+This touches the OUTBOUND tone-gate path, which is a Phase-5 trigger area. The
+substantive review point: the change adds NO block/allow authority — it only
+selects a faster backend for an existing gate, and the gate's safety behavior
+(including the deterministic degrade floor on backend failure) is unchanged. The
+decision boundary (gate diverges to fastest; background stays codex-first; single-
+framework is a no-op) is covered by the new unit + integration tests. A full
+independent reviewer was judged unnecessary for an authority-free routing-default
+change; the PR is the review surface.
+
+## Rollback
+
+Revert the commit. No migration, no state.


### PR DESCRIPTION
## What

The provider-fallback default policy routed every internal off-Claude category (`sentinel`, `gate`, `reflector`) onto the same **codex-first** primary. But the `gate` category includes the **user-facing `MessagingToneGate`** — a synchronous check a human is waiting on — and `codex-cli` is the slowest off-Claude framework (~30s), which exceeds the 20s outbound-gate review budget and times the gate out (a cause of the 2026-06-25 silent-outbound incident).

This gives the `gate` category a separate, speed-ranked default order — `LATENCY_SENSITIVE_FRAMEWORK_PREFERENCE = pi → gemini → codex → claude` — so it resolves to the **fastest active off-Claude framework**. `sentinel`/`reflector` keep the codex-first load-spreading order; `failureSwap`, the gate's verdict/hold/send logic, and the F4 degrade floor are all unchanged.

This is the **durable-in-code** version of a fix that was previously only in this dev agent's config (Phase-A outbound reliability).

## Scope / safety

- One pure resolver function (`resolveInternalFrameworkDefault`) + its tests + a spec amendment. No routing-engine change (`categories` is already a per-category map).
- No new authority — it selects which backend computes the tone-gate verdict, not whether to hold/send.
- **Machine-local by design** (framework availability is per-machine; computed at boot).
- Single-off-Claude-framework agents and claude-only agents: **byte-identical no-op**.
- An explicit `categories.gate` in config always overrides the computed default.

## Evidence

- `internalFrameworkDefault.test.ts` (17 pass): gate→fastest while sentinel→codex; pi-down→gemini; both-down→codex (never worse); single-framework→no divergence.
- `provider-fallback-default-routing.test.ts` (integration, 3 pass): `/intelligence/routing` reports the gate on the fastest active framework.
- `provider-fallback-default-policy-lifecycle.test.ts` (e2e, alive). `tsc --noEmit` clean; full `npm run lint` exits 0.

## ELI16

I can run my internal checks on different AI engines (Claude, Codex, Gemini, Pi) to spread load. The default order picks Codex first — fine for background chores nobody's waiting on. But one of those checks is the safety check on my replies to YOU, and you're waiting while it runs. It got lumped in with the background checks, so it used Codex — the SLOWEST engine (~30s) — against a 20-second budget, so it timed out. That's one of the exact ways replies went silent on the bad night.

This change splits it: background checks keep using Codex-first, but the check holding up your reply now uses a speed-ranked order (Pi ~6s, then Gemini ~10s, then Codex, then Claude) — always the fastest engine available. It's a tiny, surgical change to one decision in one function. If only one non-Claude engine is installed, nothing changes. It doesn't touch HOW the safety check decides what's safe — only which engine runs it. Same lesson as the whole "your experience is the product" work: a default that was fine for background chores quietly degraded the one path where a human is actually waiting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
