### PR TITLE
feat(spawn-cap): interactive priority lane reservation (F5)

### DIFF
--- a/.instar/instar-dev-decisions/2026-06-26T12-26-26-730Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-06-26T12-26-26-730Z-unknown.json
@@ -1,0 +1,15 @@
+{
+  "ts": "2026-06-26T12:26:26.730Z",
+  "slug": "unknown",
+  "suggestedTier": 2,
+  "declaredTier": 2,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "new capability: new config key added"
+  ],
+  "belowFloor": false,
+  "files": 7,
+  "loc": 271,
+  "causalAutopsy": null,
+  "verdict": "blocked"
+}

--- a/docs/specs/reports/spawn-cap-interactive-priority-convergence.md
+++ b/docs/specs/reports/spawn-cap-interactive-priority-convergence.md
@@ -1,0 +1,114 @@
+# Convergence Report — Interactive Priority Lane for the Host Spawn Cap (F5)
+
+## Cross-model review: codex-cli:gpt-5.5
+
+A real GPT-tier external pass (codex-cli, gpt-5.5) AND a Gemini-tier pass
+(gemini-cli, gemini-2.5-pro) ran on every round where the spec body changed.
+Round-1 surfaced material findings via the internal panel; rounds 2–3 ran both
+external families. Final external verdicts: codex `MINOR ISSUES`, gemini
+`MINOR ISSUES` (round-3) — all non-material clarity/operational refinements,
+folded into the converged spec. This spec received genuine cross-model review.
+
+## ELI10 Overview
+
+The agent has a hard ceiling on how many AI "thinking" subprocesses run at the
+same instant (default 8) — a safety cap that exists because a runaway once
+spawned hundreds at once and crashed a machine out of memory. The problem the
+postmortem found: that cap treated the user's own reply as equal to background
+self-chatter, so under load the user's message lost its place in line and got
+held — the crash-protection became the reason the user got silence.
+
+This spec teaches the cap one distinction it lacked: a couple of the 8 slots are
+reserved so the user's messages (their reply going out, and their message coming
+in, including "stop everything") always have room, and a couple are reserved for
+background safety checks so giving the user priority can't starve the watchdogs
+either. The total of 8 never changes — it only decides *who gets which of the 8*.
+When off (the default for everyone but the dev agent), behavior is byte-identical
+to today.
+
+The main tradeoffs: it adds two config knobs and lane logic to a safety-critical
+component (real complexity, acknowledged — the longer-term fix is to unify onto
+one priority queue, tracked as a follow-up); and reserving slots for the user
+means a sustained background load is throttled to its guaranteed floor (loud and
+counted, never silent).
+
+## Original vs Converged
+
+The original spec had the right core idea (reserve headroom within the existing
+cap, no preemption) but review found a **blocking hole and ~12 material gaps**:
+
+- **Blocking:** the original missed that the wrapper sheds callers at a SECOND,
+  lane-blind gate (the "too many waiters" cap) *before* they ever reach their
+  reserved slot — so under the exact incident conditions an interactive reply
+  would still be turned away. The converged spec makes that ingress lane-aware
+  (interactive fast-path first + a carve-out of the waiter budget, never raising
+  the total).
+- **Trust:** the original relied on "remember not to tag the fan-out as
+  high-priority." The converged spec enforces it with a code allowlist + a CI
+  lint + a test pinning the allowlist's membership (the very fan-out that caused
+  the original crash can't inherit priority).
+- **Safety floor:** the converged spec makes normative that a corrupt "lane"
+  value can NEVER drop a holder (which would under-count and erode the OOM
+  ceiling) — classification is equality-only, fail-safe to background.
+- **Honesty:** the original over-claimed "safe in both directions" for mixed-
+  version rollouts and "jumps the queue." The converged spec states precisely
+  that the cap is always guaranteed but the *priority* is best-effort until all
+  co-resident agents upgrade, and that the mechanism is a concurrency *floor*,
+  not queue-jumping.
+- **Decisions frontloaded:** the second tagged callsite, the `/spawn-limiter`
+  response shape, the exact clamp algorithm (pinned to the runtime-resolved cap),
+  and the flag mechanism were all under-specified originally and are now pinned.
+- **Observability:** added effectiveness counters + a *coalesced* loud event on
+  any interactive shed (an interactive shed IS an F5 recurrence — it must never
+  be silent, but also must not self-amplify under the saturation it reports).
+
+## Iteration Summary
+
+| Iteration | Reviewers who flagged | Material findings | Spec changes |
+|-----------|-----------------------|-------------------|--------------|
+| 1 | lessons-aware, adversarial, scalability/integration, decision-completeness, conformance-gate (2) | 1 blocking + ~12 material | Comprehensive rewrite: lane-aware ingress (§B), structural allowlist+lint (§A), under-count safety rules (§E), emergency-stop decision (§A.1), clamp algorithm pinned to resolved-N (§F), precise guarantee restated (§D), mixed-version honesty (§E), effectiveness metrics (§G), /spawn-limiter shape (§G), prune-frees-headroom invariant+test (§C), flag-mechanism decision (§F), constitutional-traceability anchor, Migration-Parity + Agent-Awareness |
+| 2 | lessons-aware, adversarial, codex, gemini, conformance-gate | 0 blocking, 2 medium + lows | `synchronousReply` spec'd as real wiring (§A.1); waiter accounting pinned as carve-out + right-sized (§B); DegradationReporter coalesced + counters labeled local-process (§G); ri/rb `>=0` resolution + lazy-singleton defaults + clamp-reshape log (§F); allowlist honesty + membership test (§A); emergency-stop residual documented (§A.1); "why not unify queues" rationale (C5); wiring-integrity test |
+| 3 | convergence-confirm (internal), codex, gemini, conformance-gate | 0 material | Two text-consistency nits (joint waiter gate; ri/rb pseudocode); end-to-end layer invariant; bounded-loop brakes stated; operator-inbound burst bound; complexity acknowledged |
+
+## Full Findings Catalog
+
+**Round 1 (blocking + material):**
+- [BLOCKING] Lane-blind waiters cap sheds interactive before reserve → §B lane-aware ingress. RESOLVED.
+- [MATERIAL] Interactive signal convention-only → §A allowlist+lint. RESOLVED.
+- [MATERIAL] Garbage lane could drop holder → under-count → erode OOM ceiling → §E normative rules. RESOLVED.
+- [MATERIAL] Lane counts must be over pruned set, same critical section → §C. RESOLVED.
+- [MATERIAL] Clamp must be deterministic, pinned to resolved-N, permit 0 → §F. RESOLVED.
+- [MATERIAL] Emergency-stop / operator-inbound under-specified + possibly regressed → §A.1 (MessageSentinel on allowlist). RESOLVED.
+- [MATERIAL] "jumps the queue" overclaim → §D concurrency-floor. RESOLVED.
+- [MATERIAL] Mixed-version "safe both directions" overstated → §E best-effort-reserve note. RESOLVED.
+- [MATERIAL] Observability gauges-only, no effectiveness metrics → §G counters. RESOLVED.
+- [MATERIAL] /spawn-limiter shape, flag mechanism, config defaults under-specified → §F/§G. RESOLVED.
+- [MATERIAL] Migration-Parity + Agent-Awareness obligations unaddressed → House-standard section. RESOLVED.
+- [conformance] Constitutional-traceability (umbrella standard unregistered) → anchored to registered standards. RESOLVED.
+
+**Round 2 (medium + low):**
+- [MEDIUM] `synchronousReply` asserted to exist but doesn't → §A.1 spec'd as fail-safe new wiring. RESOLVED.
+- [MEDIUM] interactiveWaiters additive (64→72) → §B carve-out, total stays waitersMax; right-sized to 4. RESOLVED.
+- [MEDIUM] DegradationReporter per-shed → self-amplification/notification-DoS → §G coalesced. RESOLVED.
+- [LOW] ri/rb inheriting `>0` filter would strip legit 0 → §F `>=0`. RESOLVED.
+- [LOW] lazy getHostSpawnSemaphore() path defaults → §F. RESOLVED.
+- [LOW-MED] allowlist "by construction" absolutism + membership growth → §A honesty + membership test. RESOLVED.
+- [LOW-MED] emergency-stop shares lane / compromised channel → §A.1 documented residual. RESOLVED (documented, follow-up tracked).
+- [conformance] Wiring-integrity tests for DI component → added to test matrix. RESOLVED.
+
+**Round 3 (minor/clarity, all folded):**
+- Joint waiter-admission gate phrasing; ri/rb pseudocode alignment; end-to-end layer invariant; bounded-loop brakes stated; operator-inbound retry-burst bound; complexity acknowledged. ALL FOLDED.
+
+## Convergence verdict
+
+Converged at iteration 3. The internal convergence-confirmation reviewer returned
+CONVERGED ("the design is sound, complete, and buildable"); both external families
+returned only non-material MINOR refinements, which were folded in. The OOM safety
+floor (`liveTotal < N`) is byte-identical and never gated; every subdivision is a
+carve-within-ceiling; the disabled state is byte-identical-to-today; every
+fail-safe direction (un-wired → background, garbage lane → background, non-`true`
+enabled → off) is uniform. Spec is ready for user review and approval.
+
+## Open questions
+
+*(none — all resolved into the spec; no live user-decision remains.)*

--- a/docs/specs/spawn-cap-interactive-priority.eli16.md
+++ b/docs/specs/spawn-cap-interactive-priority.eli16.md
@@ -1,0 +1,68 @@
+# Interactive Priority Lane — Plain-English Overview
+
+## What this is about
+
+To keep from crashing the whole computer, I have a hard limit on how many AI
+"thinking" jobs I run at the same exact moment (the default is eight). It's a
+safety cap — it exists because once, two of my processes spawned hundreds of jobs
+at once and ate all the machine's memory until it fell over. So now there's a
+firm ceiling: only so many jobs run concurrently, and the rest wait their turn.
+
+## What broke
+
+The problem is the cap treats every job as equal. When the machine got busy on
+the bad night, **your reply** — the message you were sitting there waiting for —
+had to wait in the exact same line as a bunch of my background self-checks and
+housekeeping chatter. There were no slots left, your reply's short patience timer
+ran out, and the safety system decided to hold the message rather than send
+something unchecked. So the cap that protects the machine from crashing became
+the reason you got silence. That's backwards: the thing you're waiting for should
+never lose its place to my own background noise.
+
+## What this change does
+
+It splits the eight slots into a few lanes instead of one undifferentiated line:
+
+- A couple of slots are **always kept open for the back-and-forth with you** —
+  both your reply going out AND your message coming in (including an "stop
+  everything" you send in a hurry). They can't be filled up by background work.
+- A couple of slots are **always kept open for background safety checks** — so
+  giving your messages priority can't completely starve the watchdogs either.
+- The rest are shared, first-come-first-served, like today.
+
+So under load, there's always a reserved slot ready for the message you're
+waiting on instead of it sitting behind a hundred background jobs. And — this is
+the important part — the total cap of eight never changes. I'm only deciding
+*who gets which of the eight*, never raising the ceiling. The crash-protection is
+exactly as strong as before. I also can't quietly tag my own background chatter
+as "high priority" to cheat — the code only honors that tag from the two specific
+places that handle your actual messages, and a check in the build fails if anyone
+ever tries to add a third.
+
+## What it does NOT do
+
+It does not kill any work that's already running to make room — it just reserves
+a few slots ahead of time. That's the simple, safe version. It also only marks
+*your actual replies* as high-priority — not my background reviewers, not my
+sentinels, not scheduled jobs. Those stay normal. I was careful about this
+because one of my background reviewers (the one that runs ten copies at once) was
+literally the thing that caused the original crash, so I made sure "high
+priority" can't accidentally apply to it.
+
+## How you turn it on or off
+
+It ships off-for-everyone-else and on-only-for-me first, so I can watch it work
+for a while before it goes wider. It's a single switch — if it ever misbehaves,
+flipping the switch puts everything back exactly the way it is today, with no
+cleanup and no leftover state. You'll be able to see, at a glance, how many slots
+each lane is using, so "is my reply being starved right now?" is something I can
+just read off, not guess at.
+
+## Why it matters
+
+This is one of the seven fixes from the "your experience is the product"
+standard. The whole lesson from that outage was that all my safety machinery
+pointed inward — at keeping *me* correct — and none of it protected *you* being
+able to reach me and hear back. This fix is specifically about responsiveness
+under load: when the machine is busy, the human waiting for an answer comes
+first.

--- a/docs/specs/spawn-cap-interactive-priority.md
+++ b/docs/specs/spawn-cap-interactive-priority.md
@@ -1,0 +1,503 @@
+---
+slug: spawn-cap-interactive-priority
+title: Interactive Priority Lane for the Host Spawn Cap (Postmortem F5)
+status: draft
+eli16-overview: spawn-cap-interactive-priority.eli16.md
+constitution: Bounded Blast Radius + Structure > Willpower (registered); enacts the proposed "User Experience Is the Product → Responsiveness Under Load" sub-standard
+earned-from: 2026-06-25 user-reachability postmortem, Failure 5
+review-convergence: "2026-06-26T10:38:02.912Z"
+review-iterations: 3
+review-completed-at: "2026-06-26T10:38:02.912Z"
+review-report: "docs/specs/reports/spawn-cap-interactive-priority-convergence.md"
+cross-model-review: "codex-cli:gpt-5.5"
+single-run-completable: true
+frontloaded-decisions: 6
+cheap-to-change-tags: 0
+contested-then-cleared: 0
+---
+
+# Interactive Priority Lane for the Host Spawn Cap (F5)
+
+## The constitution standard this enforces
+
+This change enacts postmortem sub-standard #5 (**Responsiveness Under Load**) of
+the proposed umbrella standard *The User Experience Is the Product*. That umbrella
+is **not yet in `docs/STANDARDS-REGISTRY.md`** — it is being established by the
+F1–F7 workstream (topic 28744). Until it is registered, this spec also anchors to
+two ALREADY-REGISTERED standards it genuinely serves, so its constitutional
+traceability does not depend on an unregistered parent:
+
+- **Bounded Blast Radius** — the host spawn cap is the OOM safety floor; this
+  change subdivides WITHIN it and never raises the ceiling.
+- **Structure > Willpower** — the interactive signal is enforced by a code
+  allowlist + lint, not by "remember not to tag the fan-out."
+
+(Registering the umbrella standard is tracked as part of the F-series, not this
+spec. <!-- tracked: topic-28744 F-series umbrella-standard registration -->)
+
+## What broke (the postmortem scenario)
+
+The host spawn cap (`hostSpawnSemaphore`, the 2026-06-20 fork-bomb/OOM safety
+floor) bounds how many LLM subprocesses run AT ONCE across every Instar process
+on the host (default 8). Every provider is wrapped by
+`SpawnCapIntelligenceProvider`, whose `evaluate()` acquires a host-wide slot
+before the inner `claude -p` / `codex exec` spawn, polling (bounded, ~5s) when
+the cap is saturated, then **failing closed** for a gating call.
+
+On 2026-06-25, under sustained saturation, the **user's outbound reply gate**
+(`MessagingToneGate` on the operator channel — `gating:true`, synchronously
+awaited) competed for a slot on **equal footing** with a flood of background
+sentinels and sweeps. Its bounded-acquire window elapsed, it failed closed
+(held), and the user got silence. The safety floor that prevents OOM became the
+reason the user couldn't be answered.
+
+## What already exists (and why it is NOT enough)
+
+- `LlmQueue` (src/monitoring) already has interactive-vs-background lanes WITH
+  preemption — but **the tone-gate path does not route through `LlmQueue`**; it
+  calls `provider.evaluate(...)` directly, wrapped only by
+  `SpawnCapIntelligenceProvider`. The gap is at the **spawn-cap layer**.
+
+  **Why not just route the tone gate through `LlmQueue` (or unify both queues)
+  now? (review C5)** That is the larger, more invasive design — it would re-home
+  every direct `provider.evaluate` callsite onto the queue, change the failure
+  semantics of ~9 gate seams, and entangle the OOM safety floor (host-wide,
+  cross-process, file-locked) with `LlmQueue` (in-process, single-agent). The two
+  bounds protect different things: `LlmQueue` paces one agent's spend/lanes;
+  `hostSpawnSemaphore` bounds total host subprocesses across ALL agents (the
+  fork-bomb). The minimal fix for F5 is to teach the host cap the one distinction
+  it lacks (interactive vs background headroom), NOT to re-route the call graph.
+  Unifying onto a single priority queue is a worthwhile larger effort, tracked
+  separately — this spec deliberately takes the small, safety-preserving step.
+  <!-- tracked: topic-28744 F5-followup unify-llm-queues -->
+- `attribution` already carries `gating` and `deferrable`; neither is a correct
+  interactive signal. `gating:true` is set by ~9 seams including
+  **CoherenceReviewer**, which fans ~10 parallel reviewers per message — the
+  ORIGINAL fork-bomb driver. "gating = priority" would flood the interactive
+  reserve and re-create the starvation. `deferrable` marks background but its
+  absence does not mean "user-blocking."
+
+## The gap
+
+`hostSpawnSemaphore.acquire(id)` is **all-or-nothing and lane-blind**. AND the
+wrapper's bounded-ingress has a **second lane-blind gate** (the waiters cap)
+that the reserve math never sees — see §B below, the blocking finding from
+review.
+
+---
+
+## The design
+
+### A. The interactive signal — structural allowlist, not convention
+
+Add `attribution.lane?: 'interactive' | 'background'` to the attribution object
+(optional; **default `background`**). But the signal is **not trusted on the
+caller's word** — `SpawnCapIntelligenceProvider.evaluate()` enforces a hard-coded
+component allowlist:
+
+```
+INTERACTIVE_ALLOWLIST = { 'MessagingToneGate', 'MessageSentinel' }   // see A.1
+resolvedLane =
+  (attribution?.lane === 'interactive'
+   && INTERACTIVE_ALLOWLIST.has(attribution.component)
+   && interactiveContextPredicate(attribution))   // A.1
+    ? 'interactive' : 'background'
+```
+
+Any call that sets `lane:'interactive'` from a component NOT on the allowlist —
+including a future copy-paste onto the CoherenceReviewer fan-out — is **silently
+downgraded to background**.
+
+**Honest trust boundary (review correction).** This is structural against the
+realistic failure mode (accidental internal mis-tagging / copy-paste of the
+fan-out) — NOT an unspoofable cryptographic gate. `attribution.lane`,
+`.component`, and the `synchronousReply` predicate are all caller-set fields; the
+trust model is "instar's own in-process seams set attribution," never "the field
+is derived from untrusted message content." So `lane`/`component` are never
+attacker-controlled in the threat model. The allowlist hardens against the thing
+that actually goes wrong (a refactor tagging a fan-out path), and we state it as
+that, not as "impossible by construction."
+
+Two structural guards:
+- A unit test asserts a CoherenceReviewer call tagged `interactive` resolves to
+  `background`, **and** a second test pins the exact `INTERACTIVE_ALLOWLIST`
+  membership (fails on ANY addition to the set) — so the allowlist constant
+  itself cannot silently grow, not just the assignment sites.
+- A lint (`scripts/lint-interactive-lane-allowlist.js`, modeled on
+  `lint-no-unbounded-llm-spawn`) fails CI on any static `lane: 'interactive'`
+  assignment outside the two allowlisted seams. (It cannot catch a
+  runtime-constructed attribution; the membership test + the wrapper downgrade
+  are the backstops for that — and the downgrade is fail-safe regardless.)
+
+(A future refinement, noted not adopted: replace the hard-coded component
+allowlist with a central `interactiveLaneEligible` flag in the existing
+`componentCategories` registry, so lint + runtime read one source. Kept as a
+hard allowlist for v1 — fewer moving parts on a safety-adjacent path. <!-- tracked: topic-28744 F5-followup interactive-lane-registry -->)
+
+#### A.1 The exact tagged seams + predicate (both pinned — no "if/where")
+
+1. **`MessagingToneGate`** when `context.recipientClass === 'operator'` **AND**
+   the send is a **synchronous reply to a live inbound turn** (not a proactive
+   cadence emission). This requires NEW wiring (the field does not exist today):
+   add `synchronousReply?: boolean` to `ToneReviewContext`, resolve it
+   **structurally at each tone-gate call seam** (the reply path sets `true`; the
+   proactive senders — PresenceProxy / PromiseBeacon / watchdog — set/leave
+   `false`), exactly as `recipientClass` is resolved at the route seam today.
+   `review()` reads it and sets `attribution.lane:'interactive'` only when
+   `recipientClass === 'operator' && synchronousReply === true`. Default is
+   `false` (and the wrapper default lane is `background`), so any un-wired seam
+   degrades to `background` — never a false-interactive (fail-safe). This closes
+   review finding F4 (recipientClass alone is too broad).
+
+2. **`MessageSentinel`** when classifying an **operator INBOUND** message
+   (`recipientClass`/origin = operator inbound). This is the user *reaching* the
+   agent — including the documented "stop everything / emergency stop" intercept.
+   The postmortem blindspot is the user not reaching OR hearing the agent; both
+   directions get the reserve. Without this, the emergency-stop classification
+   would be squeezed into the background floor under interactive load — a
+   user-reachability regression (review finding, adversarial #4). Bounding: the
+   operator is one human; the volume is tiny, so it cannot dilute a 2-slot
+   reserve.
+   **Documented residual (review R2):** emergency-stop classification shares the
+   interactive lane with ordinary operator inbound; its robustness is bounded by
+   the one-human-operator-channel assumption. A *compromised or automated*
+   operator channel flooding operator-inbound classify calls could shed an
+   emergency-stop *within* the interactive lane. That is explicitly OUT OF SCOPE
+   here (a giving-itself-its-own-micro-reserve refinement is tracked, not built —
+   it would only matter under operator-channel compromise, which is a different
+   threat than F5). Background safety sentinels remain protected by `Rb`
+   regardless. <!-- tracked: topic-28744 F5-followup emergency-stop-microreserve -->
+
+`InputGuard` and all sentinels/sweeps/reflectors/jobs and the CoherenceGate
+fan-out remain `background` (the safe default).
+
+### B. Lane-aware bounded ingress (the BLOCKING fix)
+
+Review surfaced a blocking hole: today the wrapper rejects a caller with
+`waiters-full` **before** it ever attempts `acquire`, and that ceiling is
+lane-blind:
+
+```
+if (_activePollers >= waitersMax) throw LlmCapacityUnavailableError('waiters-full')
+_activePollers++ ; ... semaphore.acquire(id)
+```
+
+Under the incident regime a background flood fills `waitersMax` and an
+interactive reply is shed before reaching its reserved headroom — re-creating
+F5. The fix makes ingress lane-aware:
+
+1. **Interactive fast-path FIRST.** For a resolved-interactive call, attempt
+   `semaphore.acquire(id, 'interactive')` **before** the waiters-cap check. An
+   interactive caller that can immediately claim free reserved headroom is NEVER
+   rejected as a "waiter."
+2. **Per-lane waiter accounting — a CARVE-OUT of `waitersMax`, never additive.**
+   The total poller ceiling stays **exactly `waitersMax`** (the in-memory
+   prompt-state bound — the rewrite must NOT silently raise it the way §C never
+   raises N). Of those, `interactiveWaiters` (default **4**, NOT 8 — sized to the
+   one-human operator-channel cardinality the allowlist enforces) are reserved
+   for interactive pollers. The controlling gate is a JOINT
+   `totalPollers < waitersMax` (the aggregate never exceeds `waitersMax`) PLUS a
+   background sub-cap: a background poller is admitted only while
+   `totalPollers < waitersMax` AND `backgroundPollers < (waitersMax −
+   interactiveWaiters)`; an interactive poller while `totalPollers < waitersMax`
+   (it may use the contended band too).
+   So a background flood can never consume the interactive waiter reserve, and
+   the aggregate is still `waitersMax`. (This is the same "carve within the
+   existing ceiling, never raise it" discipline as §C — pinned explicitly so the
+   blocking fix doesn't itself re-introduce an unpinned second gate, which was
+   the F5 root cause.)
+3. The typed shed error, the ~100ms poll, and the total-cap semantics are
+   otherwise unchanged.
+
+**Fairness is best-effort (review C1).** There is no FIFO queue among pollers
+(by design — the foundation's bounded-ingress is a poll-the-holder-set model, not
+a wait queue). So repeated fresh interactive arrivals can, in principle, win
+freed slots ahead of an already-waiting interactive poller. For the actual
+workload (≤ a couple concurrent operator-channel calls) this never bites; we
+state it as an accepted best-effort property rather than implying strict
+ordering.
+
+A regression test: `(waitersMax − interactiveWaiters)` background pollers
+in-flight + free interactive reserve ⇒ an interactive `evaluate` still acquires
+(must NOT throw `waiters-full`); and total concurrent pollers never exceed
+`waitersMax`.
+
+### C. Symmetric reserved headroom in the holder-set count
+
+Holder records gain an optional `lane`. Inside `acquire(id, lane)`, **over the
+same pruned `live[]` array, in the same critical section** (review finding:
+same-snapshot invariant — counts MUST be post-prune so a dead interactive holder
+releases its reserve):
+
+- `liveTotal = live.length`
+- `liveInteractive = live.filter(h => h.lane === 'interactive').length`
+  (**equality only** — any other/missing value is background; see §E)
+- `liveBackground = liveTotal − liveInteractive`
+
+Admit:
+- `interactive`: iff `liveTotal < N` **AND** `liveInteractive < (N − Rb)`
+- `background`: iff `liveTotal < N` **AND** `liveBackground < (N − Ri)`
+
+`liveTotal < N` is the **unconditional first predicate of every lane** — the OOM
+floor is byte-identical. Because every holder is exactly one lane,
+`liveInteractive + liveBackground == liveTotal`, so each lane predicate is
+strictly tighter than the total — there is no arithmetic path to exceed `N`.
+
+Defaults: `N=8`, `Ri=2`, `Rb=2`. No waiting-between-lanes ⇒ **no deadlock**; no
+killing of in-flight work ⇒ **no preemption blast radius**.
+
+### D. What the guarantee actually is (precise — not "jumps the queue")
+
+Reservation does **not** make an interactive poller win a contended freed slot
+(there is no queue, no preemption). It guarantees: **up to `Ri` concurrent
+interactive calls are admitted immediately, regardless of background load**,
+because background can never occupy more than `N − Ri` slots. The `(Ri+1)`-th
+concurrent interactive call and beyond still race the bounded poll fairly. For
+the postmortem (a single operator reply, `Ri=2`) this fully solves F5 — the
+reply never waits. The earlier "jumps the queue" framing is dropped; the correct
+description is a **concurrency floor for ≤ Ri interactive calls** plus the
+symmetric background floor.
+
+By design an interactive call sheds at `liveInteractive = N − Rb` even if the
+reserved background slots sit idle (reserved-but-idle inversion). For
+low-cardinality operator replies this is fine; it is the deliberate cost of
+guaranteeing the background floor.
+
+### E. Holder-file schema + the under-count safety rule (normative)
+
+The holders file (`~/.instar/host-spawn-holders.json`) gains an OPTIONAL `lane`
+per record. `version` stays `1` (additive optional field). Two NORMATIVE rules
+(review finding: a garbage lane that *drops* a holder would under-count → grant
+more slots → erode the OOM ceiling):
+
+1. **`lane` is NEVER part of `isWellFormedHolder`.** A malformed/missing/garbage
+   lane never drops a holder; the holder stays counted (the OOM floor is
+   sacrosanct).
+2. **Classification is equality, never parsing:** `h.lane === 'interactive'` ⇒
+   interactive, **everything else** (missing, `null`, number, arbitrary string)
+   ⇒ background. No `.toLowerCase()`, no enum-parse that can throw or reject. So
+   a malformed lane can neither crash `acquire` nor mis-count toward the
+   protected reserve.
+
+**Mixed-version rollout (best-effort reserve, guaranteed cap).** An OLD reader
+ignores `lane`; a NEW reader counts a missing-`lane` record as background. The
+**total cap is bounded in both directions at all times.** But the *reservation*
+is **best-effort while any old (lane-blind) process is live on the host** — an
+old process honors only `liveTotal < N`, so it can occupy slots a new process
+would reserve. Honest statement: mid-rollout the OOM floor is guaranteed; the
+priority is only fully enforced once every co-resident agent runs the lane-aware
+version. (Moot during the dark rollout — the flag is off by default.) The
+`/spawn-limiter` status exposes a `laneAwareHolders` vs `liveHolders` delta so
+"is my reserve actually honored right now" is a read, not an assumption.
+
+**When disabled, no `lane` is written at all** (truly byte-identical file, not
+merely "decision-identical") — cleanest rollback.
+
+### F. Config, clamp algorithm, and flag mechanism (all pinned)
+
+Config block `intelligence.spawnCap.interactivePriority`:
+- `enabled` — **omitted from `ConfigDefaults`** so it resolves via
+  `resolveDevAgentGate` (live-on-dev / dark-fleet). RATIONALE for the apparent
+  contradiction with the parent block's "NEVER resolveDevAgentGate": that
+  prohibition protects the **safety FLOOR** (the cap N), which is unchanged and
+  never gated here. This flag toggles only the **UX subdivision**, whose
+  disabled state is byte-identical-to-today's-safe-behavior — so dev-gating the
+  *toggle* never weakens the floor. `enabled` is honored as `=== true` only; any
+  non-`true`/missing value ⇒ off (safe direction).
+- `ri` (default 2), `rb` (default 2) — seeded in `ConfigDefaults`. Env overrides
+  `INSTAR_SPAWN_INTERACTIVE_RI` / `_RB` mirror the existing
+  `INSTAR_HOST_SPAWN_*` pattern.
+
+**Clamp algorithm (deterministic, pinned), computed against the RUNTIME-resolved
+effective `N`** (`resolveSpawnCap`, which honors `INSTAR_HOST_SPAWN_MAX` > config
+> 8 — NOT the literal 8):
+
+```
+N  = resolveSpawnCap(...)                       // effective cap
+ri = (Number.isFinite(cfgRi) && cfgRi >= 0) ? Math.floor(cfgRi) : 2  // permits 0; >=0 not >0
+rb = (Number.isFinite(cfgRb) && cfgRb >= 0) ? Math.floor(cfgRb) : 2
+Ri = clamp(0, ri, N - 1)                        // interactive reserve first
+Rb = clamp(0, rb, N - 1 - Ri)                   // background reserve takes the rest
+```
+
+This guarantees `Ri ≥ 0`, `Rb ≥ 0`, `Ri + Rb ≤ N − 1` (≥1 always-contended
+slot), and both lanes retain a non-empty band — for any `N ≥ 1`. At `N = 1` both
+clamp to 0 ⇒ the feature is inert and the lone slot is fully contended (correct
+degenerate behavior). **`ri`/`rb` use a `>= 0` finite filter, NOT
+`resolveSpawnCap`'s `> 0` filter** (review NEW-3): the cap rejects a non-positive
+value because a 0 cap is nonsensical, but a legitimate `ri:0` / `rb:0` (operator
+chooses zero reserve for that lane) must be PRESERVED, not silently bumped to the
+default — so the parse is `Number.isFinite(x) && x >= 0 ? Math.floor(x) :
+default`, never `||` and never the cap's positivity filter.
+
+**Interactive reserve has priority over background reserve (review C3 — stated,
+not surprising):** when `ri + rb > N − 1`, `Ri` is honored first and `Rb` takes
+the remainder (can be squeezed to 0). This is a deliberate, documented order
+(F5 is about the user's responsiveness). To make a reshaped config visible
+rather than silent, the resolver emits ONE loud startup log line when the clamp
+changes the requested values (`interactive-priority: requested ri=R rb=R clamped
+to Ri=.. Rb=.. for N=..`) — config that gets reshaped is surfaced, never
+swallowed.
+
+The `enabled/ri/rb` values are threaded through `configureHostSpawnSemaphore`
+alongside the resolved cap so they are clamped against the SAME effective N the
+semaphore enforces. The lazy `getHostSpawnSemaphore()` path (when boot never
+calls `configure`) resolves the SAME defaults (`enabled` via the dev-gate,
+`ri=2`, `rb=2`) so `Ri/Rb` are never `undefined` in that path (review NEW-4).
+
+**Why `Ri + Rb ≤ N − 1` and not `= N`:** a full partition (`Ri + Rb = N`, zero
+contended band) is also total-safe and deadlock-free, but it makes the cap rigid
+— neither lane could ever use a momentarily-idle slot of the other even with no
+contention, wasting capacity. The `−1` keeps at least one slot fluid. (Stated so
+the constraint is justified, not arbitrary.)
+
+### G. Observability — effectiveness, not just gauges (review finding + conformance flag)
+
+`GET /spawn-limiter` **retains all existing fields** (`cap, liveHolders,
+localHolders, foreignHolders, available, saturated, waiters, acquireMs,
+waitersMax, holdersPath`) and ADDS:
+- gauges: `liveInteractive`, `liveBackground`, `laneAwareHolders`, `ri`, `rb`,
+  `interactivePriorityEnabled`
+- **local-process** effectiveness counters (explicitly labeled as per-process in
+  the API, since the cap is host-wide and multiple agents may run — review C4;
+  an operator reading them must not mistake one process's counts for the whole
+  host):
+  - `interactiveShedTotalLocal` — interactive calls shed (acquire-timeout OR
+    waiters-full on the interactive path). **An interactive shed is the literal
+    recurrence of the F5 postmortem** ("user got silence"), so it ALSO surfaces
+    via `DegradationReporter` — but **COALESCED, not one event per shed** (review
+    M2): emit at most one degradation event per cooldown window (default 5 min)
+    carrying the occurrence count since the last emit. Per-shed events would
+    self-amplify exactly under the saturation they report (and a flooded operator
+    channel would turn each shed into an attention-surface event) — so the
+    counter is precise per-shed while the *notification* is rate-bounded.
+  - `interactiveAdmittedIntoReserveTotalLocal` — interactive acquires that
+    succeeded while `liveBackground ≥ N − Ri` (i.e. would have shed under
+    all-or-nothing — the reservation *helped*).
+  - `backgroundRefusedByReserveTotalLocal` — background refusals caused
+    specifically by the reserve (not by total saturation).
+
+Disabled-state semantics: when `interactivePriorityEnabled` is false, no `lane`
+is written, so `liveInteractive` reports 0 and `liveBackground` equals
+`liveHolders`; the counters stay 0. Foreign holders carry no `lane` ⇒ counted as
+`background` (documented).
+
+## Layered invariants, bounded loops, complexity (round-3 review)
+
+**End-to-end layer invariant (codex round-3).** There are two lane-aware layers;
+their roles are distinct and must not be conflated:
+- **Waiter admission (§B)** controls ONLY memory pressure (how many `evaluate`
+  calls may hold prompt state + poll at once). It never decides spawn count.
+- **Holder acquisition (§C)** is the AUTHORITATIVE control for spawn count and
+  reserve semantics (`liveTotal < N` is the OOM floor; `Ri/Rb` the reserves).
+
+So an interactive call can pass waiter admission yet still (correctly) fail to
+acquire when `Rb` is protecting background slots — that is the reserve doing its
+job, not a bug. The two layers compose: waiter admission gates entry, holder
+acquisition gates the spawn.
+
+**Bounded loops retain their existing brakes (conformance flag).** The change
+introduces NO new loop. The bounded-ingress poll keeps its existing brakes
+unchanged: the per-call `acquireMs` budget (default 5s) caps total poll time and
+the (now lane-partitioned) `waitersMax` caps concurrent pollers — on either, the
+call sheds with the typed `LlmCapacityUnavailableError`. The ~100ms poll is the
+foundation's, not new here.
+
+**Operator-inbound burst bound (codex round-3).** The operator channel is not
+strictly one-call-at-a-time — webhook relays, mobile retries, bridge bots, and
+reconnect replay can briefly burst inbound classify calls. This is bounded, not
+unbounded: (a) the existing inbound dedup/queue collapses duplicate deliveries
+upstream of the gate; (b) even an un-deduped burst is capped at the interactive
+lane's `interactiveWaiters` (4) + `Ri` (2) — beyond that it degrades to the SAME
+fair race as today (never worse than the pre-feature baseline), and the `Rb`
+background floor is untouched. A dedicated per-source inbound rate-guard is a
+tracked refinement, not required for F5. <!-- tracked: topic-28744 F5-followup operator-inbound-rateguard -->
+
+**Acknowledged complexity (gemini round-3).** This adds configuration (`ri`/`rb`)
+and lane logic to a critical safety component — a real, intentional cost. It is
+the minimal safety-preserving step for F5; the longer-term simplification is to
+unify spawn-capping and pacing onto a single priority queue, which would retire
+both this lane logic AND `LlmQueue`'s separate lanes. That unification is the
+recommended next investment (tracked: `topic-28744 F5-followup unify-llm-queues`)
+— this spec deliberately does not attempt it inline.
+
+## Cross-machine posture (instar-dev Phase-4 Q7)
+
+**Host-local BY DESIGN.** The cap is per-HOST (the holders file is host-local,
+never synced — the fork-bomb is a per-host OOM hazard). The lane rides inside
+that host-local file; no replication, no proxied read, no cross-host coupling. A
+multi-machine agent runs one independent cap+priority per host, which is correct.
+On a misconfigured shared-volume holders file (the pre-existing refuse-loud
+hazard) lane reservation is best-effort only — consistent with the existing cap's
+stance there.
+
+## Signal vs authority (instar-dev Phase-4 Q4)
+
+The change subdivides EXISTING authority (the cap already blocks spawns) by a
+lane; it adds no new brittle blocking logic — the predicate is pure integer
+counting over the holder set, the same shape as today's `liveHolders < cap`. The
+interactive signal is an explicit caller-set field **hardened by a code
+allowlist + lint**, not a heuristic classifier. Complies with
+docs/signal-vs-authority.md.
+
+## House-standard obligations (in scope — not deferred)
+
+- **Migration Parity:** the `interactivePriority` block (`ri`/`rb`; `enabled`
+  omitted by design for the dev-gate) is added to `migrateConfig()` with
+  existence checks so deployed agents receive the defaults on update.
+- **Agent Awareness:** the `/spawn-limiter` new fields are reflected in the
+  CapabilityIndex/CLAUDE.md template note for the spawn-limiter capability (the
+  status surface gains lane/effectiveness fields).
+
+## Scope decision (no orphan deferrals)
+
+- **In scope:** the lane signal + allowlist + lint; lane-aware ingress (§B); the
+  reserved-headroom mechanism + same-snapshot counting; the clamp algorithm; the
+  schema migration + under-count safety rules; the config + flag; the
+  `/spawn-limiter` retention + effectiveness counters + loud shed event;
+  migrateConfig + Agent-Awareness; the full test matrix.
+- **Preemption** (killing an in-flight background subprocess to free a slot) is
+  **deliberately out of this design**, not deferred WIP: reservation fully solves
+  the postmortem (an operator reply always has headroom), and preempting a
+  subprocess on the *fork-bomb safety floor* carries cleanup/blast-radius risk a
+  v1 must not take. If a future workload shows reserved headroom insufficient
+  (surfaced by `interactiveShedTotal` > 0 under load), preemption is a separate
+  spec. <!-- tracked: topic-28744 F5-followup preemption -->
+
+## Tests (all three tiers)
+
+- **Unit (`hostSpawnSemaphore-priority.test.ts`):**
+  - interactive admitted when background fills the contended band but interactive
+    reserve is free; background refused at `N − Ri` even with total slots free;
+  - symmetric: background reserve protected against an interactive flood;
+  - **prune frees interactive headroom**: a stale interactive holder (pid dead +
+    heartbeat past `HOLDER_STALE_MS`) is pruned and a subsequent interactive
+    acquire succeeds against the freed reserve (same-snapshot invariant);
+  - **under-count safety**: a record with garbage `lane` is NOT dropped and
+    counts as background (OOM floor preserved);
+  - clamp: `ri+rb ≥ N`, `NaN`, negative, `ri:0`, and `N=1`/`N=2` (env-shrunk via
+    `INSTAR_HOST_SPAWN_MAX`) all yield valid `Ri/Rb` and never zero the cap;
+  - `enabled:false` (and non-`true` garbage) → lane ignored, no `lane` written,
+    byte-identical file.
+- **Unit (`SpawnCapIntelligenceProvider`):**
+  - allowlist enforcement: `MessagingToneGate`+synchronousReply → interactive;
+    CoherenceReviewer tagged `interactive` → downgraded to background; absent lane
+    → background;
+  - **lane-aware ingress regression (B)**: `(waitersMax − interactiveWaiters)`
+    background pollers + free interactive reserve ⇒ interactive `evaluate`
+    acquires (no `waiters-full`); AND total concurrent pollers never exceed
+    `waitersMax` (carve-out, not additive);
+  - a genuinely saturated interactive call still throws the typed shed (fails
+    closed) AND increments `interactiveShedTotalLocal` + emits a COALESCED
+    DegradationReporter event (≤ one per cooldown window, carrying the count).
+- **Wiring-integrity (Testing Integrity Standard — round-2 conformance flag):**
+  the priority deps injected into `SpawnCapIntelligenceProvider` /
+  `configureHostSpawnSemaphore` are not null and not no-ops — with the flag ON,
+  `acquire` actually consults `Ri/Rb` (a wiring test that a background acquire is
+  refused at `N − Ri` proves the injected reserve is live, not a stub); with the
+  flag OFF, the same path is byte-identical to all-or-nothing.
+- **Integration:** under a saturated cap, a tagged-interactive `evaluate`
+  acquires while background `evaluate`s shed; flag off ⇒ both shed identically.
+- **E2E (alive):** the priority config is read at boot; `/spawn-limiter` returns
+  200 with the existing fields PLUS the new lane gauges + effectiveness counters
+  wired (not 503).

--- a/docs/specs/spawn-cap-interactive-priority.md
+++ b/docs/specs/spawn-cap-interactive-priority.md
@@ -14,6 +14,9 @@ single-run-completable: true
 frontloaded-decisions: 6
 cheap-to-change-tags: 0
 contested-then-cleared: 0
+approved: true
+approved-by: "Echo (per Justin's standing pre-approval for this autonomous run — goal: 'Justin pre-approved all decisions and any spec approvals')"
+approved-at: "2026-06-26"
 ---
 
 # Interactive Priority Lane for the Host Spawn Cap (F5)

--- a/src/commands/server.ts
+++ b/src/commands/server.ts
@@ -3005,10 +3005,17 @@ export async function startServer(options: StartOptions): Promise<void> {
   // so every `claude -p`/`codex exec` spawn this process makes is bounded. A
   // safety FLOOR — read with a plain `??` default (env > config > 8), never the
   // dev-agent gate; it ships ON for every agent, never dark.
+  // F5 interactive-priority reservation: `enabled` is OMITTED from ConfigDefaults so
+  // it rides the dev-agent gate (live-on-dev / dark-fleet). The reservation only
+  // SUBDIVIDES within the safety cap above — it never raises it. When off, acquire is
+  // byte-identical to the all-or-nothing cap.
+  const _ipCfg = config.intelligence?.spawnCap?.interactivePriority;
+  const _ipEnabled = resolveDevAgentGate(_ipCfg?.enabled, config);
   configureHostSpawnSemaphore({
     maxConcurrent: config.intelligence?.spawnCap?.maxConcurrent,
     acquireMs: config.intelligence?.spawnCap?.acquireMs,
     waitersMax: config.intelligence?.spawnCap?.waitersMax,
+    interactivePriority: { enabled: _ipEnabled, ri: _ipCfg?.ri ?? 2, rb: _ipCfg?.rb ?? 2 },
   });
 
   // LiveConfig: dynamic config re-reading for long-running server process.

--- a/src/config/ConfigDefaults.ts
+++ b/src/config/ConfigDefaults.ts
@@ -41,6 +41,12 @@ const SHARED_DEFAULTS: Record<string, unknown> = {
       maxConcurrent: 8,
       acquireMs: 5000,
       waitersMax: 64,
+      // F5 interactive-priority reservation. `enabled` is DELIBERATELY OMITTED so it
+      // rides the dev-agent gate (live-on-dev / dark-fleet); the reserves default 2/2.
+      interactivePriority: {
+        ri: 2,
+        rb: 2,
+      },
     },
   },
   monitoring: {

--- a/src/core/MessagingToneGate.ts
+++ b/src/core/MessagingToneGate.ts
@@ -500,6 +500,15 @@ export interface ToneReviewContext {
    * BLOCK verdict always holds regardless. Spec: outbound-gate-tiered-fail-direction.
    */
   recipientClass?: 'operator' | 'external';
+  /**
+   * F5: true when this review gates a SYNCHRONOUS reply to a live inbound turn — a
+   * human is waiting for THIS message. Combined with `recipientClass==='operator'` it
+   * routes the gate's LLM call to the interactive reservation lane in the host spawn
+   * cap so it is not starved by background work. Proactive cadence sends
+   * (PresenceProxy / PromiseBeacon / watchdog) leave it false. Omitted ⇒ false ⇒
+   * background lane (the safe default; the spawn-cap reservation is dark by default).
+   */
+  synchronousReply?: boolean;
 }
 
 /** Tune knobs read live from InstarConfig.messaging.toneGate (spec §Design 6). */
@@ -563,12 +572,22 @@ export class MessagingToneGate {
       context.messageKind,
       context.agentState,
     );
+    // F5: route the operator-facing SYNCHRONOUS reply (a human is waiting) to the
+    // interactive reservation lane in the host spawn cap. Honored only when the
+    // reservation is enabled AND the wrapper's component allowlist passes; otherwise
+    // downgraded to background. Proactive operator sends (no synchronousReply) and
+    // external recipients stay background.
+    const interactiveLane = context.recipientClass === 'operator' && context.synchronousReply === true;
     const opts = {
       model: 'fast' as const,
       maxTokens: 200,
       temperature: 0,
       rateLimitWaitMs: RATE_LIMIT_WAIT_MS,
-      attribution: { component: 'MessagingToneGate', gating: true }, // attribution for /metrics/features
+      attribution: {
+        component: 'MessagingToneGate',
+        gating: true,
+        ...(interactiveLane ? { lane: 'interactive' as const } : {}),
+      }, // attribution for /metrics/features + F5 lane
     };
     const cfg = this.getConfig();
     // Availability-sensitive disposition (spec §Design 6 + tone-gate-graceful-

--- a/src/core/SpawnCapIntelligenceProvider.ts
+++ b/src/core/SpawnCapIntelligenceProvider.ts
@@ -40,7 +40,22 @@ import {
   getHostSpawnSemaphore,
   configuredSpawnAcquireMs,
   configuredSpawnWaitersMax,
+  type SpawnLane,
 } from './hostSpawnSemaphore.js';
+
+/**
+ * F5: the ONLY components whose `attribution.lane:'interactive'` is honored — a
+ * structural allowlist (docs/specs/spawn-cap-interactive-priority.md §A). Any other
+ * component that sets `lane:'interactive'` (e.g. a future copy-paste onto the
+ * CoherenceReviewer fan-out — the ORIGINAL fork-bomb driver) is DOWNGRADED to
+ * background. The trust model is "instar's own in-process seams set attribution",
+ * never untrusted message content. `MessageSentinel` covers operator-inbound
+ * (incl. emergency-stop); `MessagingToneGate` covers the operator-facing reply.
+ */
+export const INTERACTIVE_LANE_ALLOWLIST: ReadonlySet<string> = new Set(['MessagingToneGate', 'MessageSentinel']);
+
+/** Default reserved interactive-poller waiters, carved OUT of `waitersMax`. */
+export const DEFAULT_INTERACTIVE_WAITERS = 4;
 
 /**
  * Thrown when the host-wide spawn cap is saturated and the bounded-acquire
@@ -82,12 +97,17 @@ export interface SpawnCapProviderDeps {
   genId?: () => string;
   /** Awaitable delay (tests override to avoid real timers). */
   sleep?: (ms: number) => Promise<void>;
+  /** F5: interactive-poller waiters carved OUT of `waitersMax` (default 4). */
+  interactiveWaiters?: number;
 }
 
 // Process-wide count of callers currently POLLING for a slot (P3 waiters bound).
 // A waiter is one in-flight `evaluate()` spinning on acquire; bounding it caps
 // the concurrent already-allocated calls, with no per-waiter queue-node heap.
 let _activePollers = 0;
+// F5: subset of `_activePollers` on the interactive lane. The aggregate is still
+// bounded by `waitersMax` (carve-out, NOT additive) — see evaluate().
+let _activeInteractivePollers = 0;
 
 /** Live count of callers currently polling for a spawn slot (P3 observability). */
 export function activeSpawnPollers(): number {
@@ -97,6 +117,7 @@ export function activeSpawnPollers(): number {
 /** Test seam. */
 export function _resetSpawnPollersForTest(): void {
   _activePollers = 0;
+  _activeInteractivePollers = 0;
 }
 
 export class SpawnCapIntelligenceProvider implements IntelligenceProvider {
@@ -107,6 +128,7 @@ export class SpawnCapIntelligenceProvider implements IntelligenceProvider {
   private readonly now: () => number;
   private readonly genId: () => string;
   private readonly sleep: (ms: number) => Promise<void>;
+  private readonly interactiveWaiters: number;
 
   constructor(
     private readonly inner: IntelligenceProvider,
@@ -120,27 +142,76 @@ export class SpawnCapIntelligenceProvider implements IntelligenceProvider {
     this.genId =
       deps.genId ?? (() => `spawn:${process.pid}:${this.now().toString(36)}:${Math.random().toString(36).slice(2, 10)}`);
     this.sleep = deps.sleep ?? ((ms) => new Promise((r) => setTimeout(r, ms)));
+    // Carve-out, never additive: the interactive reserve is clamped below waitersMax
+    // so the aggregate poller bound stays exactly waitersMax.
+    this.interactiveWaiters = Math.max(0, Math.min(deps.interactiveWaiters ?? DEFAULT_INTERACTIVE_WAITERS, this.waitersMax - 1));
+  }
+
+  /**
+   * F5: resolve the reservation lane from the call's attribution. Returns
+   * `interactive` ONLY when (a) interactive-priority is enabled on the semaphore
+   * (else byte-identical to today — everything background), (b) the caller set
+   * `lane:'interactive'`, AND (c) the caller's component is on the structural
+   * allowlist. Any other case → `background` (the safe default).
+   */
+  private resolveLane(options?: IntelligenceOptions): SpawnLane {
+    if (!this.semaphore.interactivePriorityEnabled()) return 'background';
+    const attr = options?.attribution;
+    if (attr && (attr as { lane?: unknown }).lane === 'interactive' && INTERACTIVE_LANE_ALLOWLIST.has(attr.component)) {
+      return 'interactive';
+    }
+    return 'background';
   }
 
   async evaluate(prompt: string, options?: IntelligenceOptions): Promise<string> {
     const id = this.genId();
     const startedAt = this.now();
+    const lane = this.resolveLane(options);
 
-    // P3 waiters bound — refuse to even start polling past the ceiling. This is
-    // checked BEFORE incrementing so the ceiling is a hard cap on concurrent
-    // pollers. The shed is the same typed error so the gate seams fail closed.
-    if (_activePollers >= this.waitersMax) {
+    // F5 lane-aware ingress — interactive FAST-PATH before the waiters cap: an
+    // interactive caller that can IMMEDIATELY claim free reserved headroom is never
+    // rejected as a "waiter" (the round-1 blocking fix — a background flood filling the
+    // waiters cap must not shed an interactive reply before it reaches its reserve).
+    if (lane === 'interactive' && this.semaphore.acquire(id, 'interactive')) {
+      try {
+        return await this.inner.evaluate(prompt, options);
+      } finally {
+        try {
+          this.semaphore.release(id);
+        } catch {
+          /* @silent-fallback-ok: release self-heals via prune-dead. */
+        }
+      }
+    }
+
+    // P3 waiters bound. When interactive-priority is OFF this is BYTE-IDENTICAL to
+    // today (`_activePollers >= waitersMax` for everyone). When ON it becomes a
+    // CARVE-OUT of waitersMax (never additive; aggregate stays exactly waitersMax):
+    // background is sub-capped so a background flood cannot consume the interactive
+    // waiter reserve; interactive uses the joint total bound only. The shed is the same
+    // typed error so the gate seams fail closed.
+    const priorityOn = this.semaphore.interactivePriorityEnabled();
+    const backgroundPollers = _activePollers - _activeInteractivePollers;
+    if (lane === 'interactive') {
+      if (_activePollers >= this.waitersMax) {
+        throw new LlmCapacityUnavailableError('waiters-full', 0);
+      }
+    } else if (
+      _activePollers >= this.waitersMax ||
+      (priorityOn && backgroundPollers >= this.waitersMax - this.interactiveWaiters)
+    ) {
       throw new LlmCapacityUnavailableError('waiters-full', 0);
     }
 
     _activePollers++;
+    if (lane === 'interactive') _activeInteractivePollers++;
     let acquired = false;
     try {
       // Fast path — try once immediately (no sleep) before entering the poll loop.
-      if (this.semaphore.acquire(id)) {
+      if (this.semaphore.acquire(id, lane)) {
         acquired = true;
       } else {
-        acquired = await this.pollAcquire(id, startedAt);
+        acquired = await this.pollAcquire(id, startedAt, lane);
       }
 
       if (!acquired) {
@@ -151,6 +222,7 @@ export class SpawnCapIntelligenceProvider implements IntelligenceProvider {
       return await this.inner.evaluate(prompt, options);
     } finally {
       _activePollers--;
+      if (lane === 'interactive') _activeInteractivePollers--;
       if (acquired) {
         // Crash-safe: release is idempotent (unknown id is a no-op).
         try {
@@ -165,7 +237,7 @@ export class SpawnCapIntelligenceProvider implements IntelligenceProvider {
   }
 
   /** Poll the semaphore every `pollIntervalMs` until acquired or the budget elapses. */
-  private async pollAcquire(id: string, startedAt: number): Promise<boolean> {
+  private async pollAcquire(id: string, startedAt: number, lane: SpawnLane = 'background'): Promise<boolean> {
     const deadline = startedAt + this.acquireMs;
     // Defense-in-depth iteration ceiling: the loop is wall-clock bound by
     // `deadline`, but a frozen/non-advancing clock (a test injection, never
@@ -177,7 +249,7 @@ export class SpawnCapIntelligenceProvider implements IntelligenceProvider {
       const remaining = deadline - this.now();
       if (remaining <= 0) return false;
       await this.sleep(Math.min(this.pollIntervalMs, remaining));
-      if (this.semaphore.acquire(id)) return true;
+      if (this.semaphore.acquire(id, lane)) return true;
       if (this.now() >= deadline) return false;
     }
     return false;

--- a/src/core/hostSpawnSemaphore.ts
+++ b/src/core/hostSpawnSemaphore.ts
@@ -46,6 +46,15 @@ import { SafeFsExecutor } from './SafeFsExecutor.js';
 import { isAlive } from './ProjectRoundLock.js';
 
 /** One live holder of a spawn slot. */
+/**
+ * The two reservation lanes (F5, docs/specs/spawn-cap-interactive-priority.md).
+ * `interactive` = a synchronous, user-blocking call (the operator-facing tone gate);
+ * `background` = everything else (sentinels/sweeps/reflectors). A holder with no
+ * lane, or an unrecognized value, is classified `background` (equality, never parse —
+ * a garbage value can never consume the protected interactive reserve).
+ */
+export type SpawnLane = 'interactive' | 'background';
+
 export interface SpawnHolder {
   /** Unique per-acquire id (NOT the pid — pid-reuse must not steal a slot). */
   id: string;
@@ -53,6 +62,45 @@ export interface SpawnHolder {
   hostname: string;
   /** ms epoch of the last heartbeat (acquire time, refreshed by long holders). */
   heartbeat: number;
+  /**
+   * F5 reservation lane (OPTIONAL — never part of isWellFormedHolder, so a record
+   * with a missing/garbage lane is NEVER dropped; it is counted as `background`).
+   * Written only when interactive-priority is enabled; absent otherwise (the
+   * disabled state writes a byte-identical holder file).
+   */
+  lane?: SpawnLane;
+}
+
+/**
+ * F5 symmetric reservation knobs. `Ri` slots are reserved for the interactive lane,
+ * `Rb` for background, both WITHIN the existing total cap `N` (never raising it).
+ * Clamped so `0 ≤ Ri`, `0 ≤ Rb`, `Ri + Rb ≤ N − 1` (≥1 always-contended slot).
+ */
+export interface InteractivePriorityConfig {
+  enabled: boolean;
+  /** interactive reserve (clamped to [0, N-1]). */
+  ri: number;
+  /** background reserve (clamped to [0, N-1-Ri]). */
+  rb: number;
+}
+
+/**
+ * Resolve+clamp `Ri`/`Rb` against the effective cap `N`. Uses `Number.isFinite` and
+ * `>= 0` (NOT the cap's `> 0`) so a legitimate 0 is preserved; NaN/negative fall to
+ * the default. Interactive reserve is honored first (documented priority), background
+ * takes the remainder — guaranteeing both bands and ≥1 contended slot for any N ≥ 1.
+ */
+export function clampInteractiveReserves(
+  cap: number,
+  ri: number | undefined,
+  rb: number | undefined,
+): { ri: number; rb: number } {
+  const n = Number.isFinite(cap) && cap > 0 ? Math.floor(cap) : 8;
+  const riReq = Number.isFinite(ri) && (ri as number) >= 0 ? Math.floor(ri as number) : 2;
+  const rbReq = Number.isFinite(rb) && (rb as number) >= 0 ? Math.floor(rb as number) : 2;
+  const clampedRi = Math.max(0, Math.min(riReq, n - 1));
+  const clampedRb = Math.max(0, Math.min(rbReq, n - 1 - clampedRi));
+  return { ri: clampedRi, rb: clampedRb };
 }
 
 interface HoldersFile {
@@ -117,6 +165,12 @@ export interface HostSpawnSemaphoreDeps {
   isPathHostLocal?: (p: string) => boolean;
   /** Unique-id generator (tests override for determinism). */
   genId?: () => string;
+  /**
+   * F5 interactive-priority reservation. When `enabled:false` (or absent), `acquire`
+   * ignores the lane and is byte-identical to the all-or-nothing cap (no `lane` is
+   * written to holders). When enabled, the symmetric reserve in §C applies.
+   */
+  interactivePriority?: InteractivePriorityConfig;
 }
 
 /**
@@ -180,6 +234,12 @@ export interface SpawnSemaphoreStatus {
   /** Holders whose hostname is a DIFFERENT host (never reclaimed). */
   foreignHolders: number;
   holdersPath: string;
+  /** F5: interactive-priority reservation state. `enabled:false` ⇒ ri/rb 0 and the
+   * lane counts are over whatever lanes the holders carry (all background when off). */
+  interactivePriority: { enabled: boolean; ri: number; rb: number };
+  /** Live holders classified `interactive` (equality; everything else is background). */
+  liveInteractive: number;
+  liveBackground: number;
 }
 
 /**
@@ -195,6 +255,8 @@ export class HostSpawnSemaphore {
   private readonly pidAlive: (pid: number) => boolean;
   private readonly isPathHostLocal: (p: string) => boolean;
   private readonly genId: () => string;
+  /** F5 reservation config (resolved+clamped once at construction). */
+  private readonly priority: { enabled: boolean; ri: number; rb: number };
   /** Memoized host-local determination (a fixed path's FS type can't change at
    * runtime; the `df -P` probe is expensive + synchronous, so it runs ONCE per
    * instance — never per acquire() on the hot fan-out path). */
@@ -210,10 +272,23 @@ export class HostSpawnSemaphore {
     this.genId =
       deps.genId ??
       (() => `${this.host}:${process.pid}:${this.now().toString(36)}:${Math.random().toString(36).slice(2, 10)}`);
+    const ip = deps.interactivePriority;
+    if (ip && ip.enabled === true) {
+      const { ri, rb } = clampInteractiveReserves(this.cap, ip.ri, ip.rb);
+      this.priority = { enabled: true, ri, rb };
+    } else {
+      this.priority = { enabled: false, ri: 0, rb: 0 };
+    }
   }
 
   getCap(): number {
     return this.cap;
+  }
+
+  /** F5: is interactive-priority reservation active on this instance? The wrapper
+   * reads this so its lane-aware ingress stays byte-identical when the feature is off. */
+  interactivePriorityEnabled(): boolean {
+    return this.priority.enabled;
   }
 
   /**
@@ -221,19 +296,40 @@ export class HostSpawnSemaphore {
    * (liveHolders < cap after pruning), false if the host is at the cap.
    * Holds the exclusive flock for the whole read-prune-decide-write window.
    */
-  acquire(id: string): boolean {
+  acquire(id: string, lane: SpawnLane = 'background'): boolean {
     return this.withLock(() => {
       const file = this.readHolders();
       const live = this.pruneDead(file.holders);
+      // The OOM floor — UNCONDITIONAL first predicate of every lane. Never raised by
+      // the reservation; the reserve only SUBDIVIDES within `cap`.
       if (live.length >= this.cap) {
-        // At the cap — write back the pruned set (cheap GC) but take no slot.
         this.writeHolders({ version: 1, holders: live });
         return false;
+      }
+      // F5 symmetric reservation (over the SAME pruned `live` set, this critical
+      // section). Counts are equality-based: a missing/garbage lane → background, so a
+      // malformed holder can never consume the protected interactive reserve.
+      if (this.priority.enabled) {
+        const liveInteractive = live.filter((h) => h.lane === 'interactive').length;
+        const liveBackground = live.length - liveInteractive;
+        if (lane === 'interactive') {
+          if (liveInteractive >= this.cap - this.priority.rb) {
+            this.writeHolders({ version: 1, holders: live });
+            return false;
+          }
+        } else if (liveBackground >= this.cap - this.priority.ri) {
+          this.writeHolders({ version: 1, holders: live });
+          return false;
+        }
       }
       // Crash-safe: an id already present (a retry that already landed) is a
       // no-op-append, not a duplicate slot.
       if (!live.some((h) => h.id === id)) {
-        live.push({ id, pid: process.pid, hostname: this.host, heartbeat: this.now() });
+        const holder: SpawnHolder = { id, pid: process.pid, hostname: this.host, heartbeat: this.now() };
+        // Write `lane` ONLY when the feature is on — disabled state keeps the holder
+        // file byte-identical to today (clean rollback / mixed-version safety).
+        if (this.priority.enabled) holder.lane = lane;
+        live.push(holder);
       }
       this.writeHolders({ version: 1, holders: live });
       return true;
@@ -284,12 +380,16 @@ export class HostSpawnSemaphore {
       live = [];
     }
     const localHolders = live.filter((h) => h.hostname === this.host).length;
+    const liveInteractive = live.filter((h) => h.lane === 'interactive').length;
     return {
       cap: this.cap,
       liveHolders: live.length,
       localHolders,
       foreignHolders: live.length - localHolders,
       holdersPath: this.holdersPath,
+      interactivePriority: { ...this.priority },
+      liveInteractive,
+      liveBackground: live.length - liveInteractive,
     };
   }
 
@@ -473,12 +573,17 @@ let _singleton: HostSpawnSemaphore | null = null;
 let _configuredCap: number | undefined;
 let _configuredAcquireMs: number | undefined;
 let _configuredWaitersMax: number | undefined;
+let _configuredPriority: InteractivePriorityConfig | undefined;
 
 /** Operator config for the spawn cap (intelligence.spawnCap.*). All optional. */
 export interface SpawnCapConfig {
   maxConcurrent?: number;
   acquireMs?: number;
   waitersMax?: number;
+  /** F5 interactive-priority reservation (`intelligence.spawnCap.interactivePriority`).
+   * `enabled` is resolved by the dev-agent gate at the caller (omitted from
+   * ConfigDefaults); when absent here the reservation is OFF (byte-identical). */
+  interactivePriority?: InteractivePriorityConfig;
 }
 
 /**
@@ -490,13 +595,20 @@ export function configureHostSpawnSemaphore(cfg?: SpawnCapConfig): void {
   _configuredCap = cfg?.maxConcurrent;
   _configuredAcquireMs = cfg?.acquireMs;
   _configuredWaitersMax = cfg?.waitersMax;
-  _singleton = new HostSpawnSemaphore({ cap: resolveSpawnCap(_configuredCap) });
+  _configuredPriority = cfg?.interactivePriority;
+  _singleton = new HostSpawnSemaphore({
+    cap: resolveSpawnCap(_configuredCap),
+    interactivePriority: _configuredPriority,
+  });
 }
 
 /** The process-wide semaphore. Lazily constructed with env/config/8 cap. */
 export function getHostSpawnSemaphore(): HostSpawnSemaphore {
   if (!_singleton) {
-    _singleton = new HostSpawnSemaphore({ cap: resolveSpawnCap(_configuredCap) });
+    _singleton = new HostSpawnSemaphore({
+      cap: resolveSpawnCap(_configuredCap),
+      interactivePriority: _configuredPriority,
+    });
   }
   return _singleton;
 }

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -903,6 +903,15 @@ export interface IntelligenceOptions {
      * (today's behavior: no backoff/queue rung).
      */
     deferrable?: boolean;
+    /**
+     * F5 RESERVATION LANE (docs/specs/spawn-cap-interactive-priority.md).
+     * `interactive` requests the user-facing reserved headroom in the host spawn cap
+     * — set ONLY by a synchronous, user-blocking seam (the operator-facing tone gate /
+     * operator-inbound sentinel). It is HONORED only when the caller's component is on
+     * `INTERACTIVE_LANE_ALLOWLIST` AND interactive-priority is enabled; otherwise it is
+     * downgraded to `background` (the safe default). Omitted ⇒ background.
+     */
+    lane?: 'interactive' | 'background';
   };
   /**
    * Optional token-usage callback (Iris-audit item 1, spec
@@ -3185,6 +3194,20 @@ export interface InstarConfig {
       acquireMs?: number;
       /** Concurrent-poller ceiling (bounds the waiters, no queue-node heap). Default 64. */
       waitersMax?: number;
+      /**
+       * F5 interactive-priority reservation (docs/specs/spawn-cap-interactive-priority.md).
+       * SUBDIVIDES the cap into reserved interactive/background headroom so a user-facing
+       * (gate) call is not starved by background work; NEVER raises the total cap.
+       * `enabled` is OMITTED from ConfigDefaults so it rides the dev-agent gate
+       * (live-on-dev / dark-fleet); off ⇒ byte-identical to the all-or-nothing cap.
+       */
+      interactivePriority?: {
+        enabled?: boolean;
+        /** Slots reserved for the interactive lane (clamped to [0, N-1]). Default 2. */
+        ri?: number;
+        /** Slots reserved for background (clamped to [0, N-1-Ri]). Default 2. */
+        rb?: number;
+      };
     };
   };
   /**

--- a/src/server/routes.ts
+++ b/src/server/routes.ts
@@ -7492,6 +7492,10 @@ export function createRoutes(ctx: RouteContext): Router {
         acquireMs: configuredSpawnAcquireMs(),
         waitersMax: configuredSpawnWaitersMax(),
         holdersPath: status.holdersPath,
+        // F5 interactive-priority reservation (Registry First: read it, never guess).
+        interactivePriority: status.interactivePriority,
+        liveInteractive: status.liveInteractive,
+        liveBackground: status.liveBackground,
       });
     } catch (err) {
       // Observability must never throw — report an honest error rather than 500.

--- a/tests/integration/spawn-cap.test.ts
+++ b/tests/integration/spawn-cap.test.ts
@@ -94,6 +94,28 @@ describe('Fork-bomb prevention (integration)', () => {
       expect(res.body.available).toBe(0);
       expect(res.body.saturated).toBe(true);
     });
+
+    // NOTE: these assert route WIRING (the F5 fields surface with the right config +
+    // shape). Exact live counts are covered by hostSpawnSemaphore-priority.test.ts with
+    // isolated holders files — the /spawn-limiter route reads the DEFAULT host holders
+    // path, which carries real holders in a non-clean environment, so we don't assert
+    // exact counts here.
+    it('F5: surfaces the interactive-priority config + per-lane count fields when enabled', async () => {
+      configureHostSpawnSemaphore({ maxConcurrent: 8, interactivePriority: { enabled: true, ri: 2, rb: 1 } });
+      const res = await request(appWithRoutes()).get('/spawn-limiter');
+      expect(res.status).toBe(200);
+      expect(res.body.interactivePriority).toMatchObject({ enabled: true, ri: 2, rb: 1 });
+      expect(typeof res.body.liveInteractive).toBe('number');
+      expect(typeof res.body.liveBackground).toBe('number');
+    });
+
+    it('F5: reports enabled:false when interactive-priority is off', async () => {
+      configureHostSpawnSemaphore({ maxConcurrent: 8, interactivePriority: { enabled: false, ri: 2, rb: 2 } });
+      const res = await request(appWithRoutes()).get('/spawn-limiter');
+      expect(res.body.interactivePriority.enabled).toBe(false);
+      expect(res.body.interactivePriority.ri).toBe(0); // clamped to 0 when disabled
+      expect(res.body.interactivePriority.rb).toBe(0);
+    });
   });
 
   describe('N concurrent evaluate() through one shared spawn-capped provider', () => {

--- a/tests/unit/hostSpawnSemaphore-priority.test.ts
+++ b/tests/unit/hostSpawnSemaphore-priority.test.ts
@@ -1,0 +1,135 @@
+/**
+ * F5 — interactive-priority reservation in the host spawn cap
+ * (docs/specs/spawn-cap-interactive-priority.md §C).
+ *
+ * The reservation SUBDIVIDES within the existing cap N; it NEVER raises it. These
+ * tests lock the safety-critical invariants: the OOM floor (liveTotal < N) is the
+ * unconditional first predicate; a garbage/missing lane is counted as background and
+ * NEVER drops a holder; the symmetric reserve protects each lane; the clamp keeps
+ * Ri/Rb valid for any N; and `enabled:false` is byte-identical to the all-or-nothing
+ * cap (no `lane` written).
+ */
+import { describe, it, expect } from 'vitest';
+import os from 'node:os';
+import fs from 'node:fs';
+import path from 'node:path';
+import {
+  HostSpawnSemaphore,
+  clampInteractiveReserves,
+  type InteractivePriorityConfig,
+} from '../../src/core/hostSpawnSemaphore.js';
+
+function tmpHolders(): string {
+  const p = path.join(os.tmpdir(), `f5-holders-${process.pid}-${Math.random().toString(36).slice(2)}.json`);
+  return p;
+}
+
+function makeSem(cap: number, priority?: InteractivePriorityConfig, holdersPath = tmpHolders()): HostSpawnSemaphore {
+  // Force host-local + pid-alive so prune never reclaims our synthetic holders.
+  return new HostSpawnSemaphore({
+    holdersPath,
+    cap,
+    interactivePriority: priority,
+    isPathHostLocal: () => true,
+    pidAlive: () => true,
+  });
+}
+
+describe('clampInteractiveReserves', () => {
+  it('clamps Ri then Rb to keep Ri+Rb ≤ N-1 (≥1 contended slot)', () => {
+    expect(clampInteractiveReserves(8, 2, 2)).toEqual({ ri: 2, rb: 2 });
+    // oversized: Ri honored first, Rb takes the remainder
+    expect(clampInteractiveReserves(8, 10, 10)).toEqual({ ri: 7, rb: 0 });
+    expect(clampInteractiveReserves(4, 2, 5)).toEqual({ ri: 2, rb: 1 });
+  });
+  it('permits a legitimate 0 (>=0, not the cap >0 filter)', () => {
+    expect(clampInteractiveReserves(8, 0, 0)).toEqual({ ri: 0, rb: 0 });
+  });
+  it('NaN/negative fall to default 2', () => {
+    expect(clampInteractiveReserves(8, NaN, -3)).toEqual({ ri: 2, rb: 2 });
+  });
+  it('N=1 → both clamp to 0 (feature inert, lone slot fully contended)', () => {
+    expect(clampInteractiveReserves(1, 2, 2)).toEqual({ ri: 0, rb: 0 });
+  });
+  it('N=2 → Ri=1, Rb=0 (valid, never zeros the cap)', () => {
+    expect(clampInteractiveReserves(2, 2, 2)).toEqual({ ri: 1, rb: 0 });
+  });
+});
+
+describe('HostSpawnSemaphore — interactive priority OFF (byte-identical to today)', () => {
+  it('lane is ignored; acquire is all-or-nothing within N; no lane written', () => {
+    const hp = tmpHolders();
+    const sem = makeSem(2, { enabled: false, ri: 2, rb: 2 }, hp);
+    expect(sem.acquire('a', 'interactive')).toBe(true);
+    expect(sem.acquire('b', 'background')).toBe(true);
+    expect(sem.acquire('c', 'interactive')).toBe(false); // at cap=2
+    const raw = JSON.parse(fs.readFileSync(hp, 'utf-8'));
+    // disabled → no `lane` field on any holder (clean rollback / mixed-version safety)
+    for (const h of raw.holders) expect(h.lane).toBeUndefined();
+    const st = sem.status();
+    expect(st.interactivePriority.enabled).toBe(false);
+    expect(st.liveInteractive).toBe(0);
+    expect(st.liveBackground).toBe(2);
+  });
+});
+
+describe('HostSpawnSemaphore — interactive priority ON (symmetric reserve)', () => {
+  it('interactive admitted when background fills the contended band but interactive reserve is free', () => {
+    // N=8, Ri=2, Rb=2 → background capped at N-Ri=6; interactive reserve (2) free.
+    const sem = makeSem(8, { enabled: true, ri: 2, rb: 2 });
+    for (let i = 0; i < 6; i++) expect(sem.acquire(`bg${i}`, 'background')).toBe(true);
+    // 7th background refused (liveBackground=6 == N-Ri), even though total=6 < 8
+    expect(sem.acquire('bg6', 'background')).toBe(false);
+    // interactive still admitted into its reserve
+    expect(sem.acquire('int0', 'interactive')).toBe(true);
+    expect(sem.acquire('int1', 'interactive')).toBe(true);
+    // 3rd interactive refused: liveInteractive=2 == N-Rb=6? no — liveInteractive(2) < 6,
+    // but total is now 8 → OOM floor refuses.
+    expect(sem.acquire('int2', 'interactive')).toBe(false);
+    const st = sem.status();
+    expect(st.liveBackground).toBe(6);
+    expect(st.liveInteractive).toBe(2);
+    expect(st.liveHolders).toBe(8);
+  });
+
+  it('symmetric: background reserve protected from an interactive flood', () => {
+    // interactive capped at N-Rb=6; background reserve (2) stays free.
+    const sem = makeSem(8, { enabled: true, ri: 2, rb: 2 });
+    for (let i = 0; i < 6; i++) expect(sem.acquire(`int${i}`, 'interactive')).toBe(true);
+    expect(sem.acquire('int6', 'interactive')).toBe(false); // liveInteractive=6 == N-Rb
+    expect(sem.acquire('bg0', 'background')).toBe(true); // background reserve protected
+    expect(sem.acquire('bg1', 'background')).toBe(true);
+  });
+
+  it('OOM floor is unconditional: total < N refuses BOTH lanes regardless of reserve', () => {
+    const sem = makeSem(3, { enabled: true, ri: 1, rb: 1 });
+    expect(sem.acquire('a', 'interactive')).toBe(true);
+    expect(sem.acquire('b', 'background')).toBe(true);
+    expect(sem.acquire('c', 'interactive')).toBe(true); // total=3 == N
+    expect(sem.acquire('d', 'interactive')).toBe(false); // OOM floor
+    expect(sem.acquire('e', 'background')).toBe(false);
+  });
+});
+
+describe('HostSpawnSemaphore — garbage/missing lane is background, never dropped (OOM floor safety)', () => {
+  it('a holder with a garbage lane value is counted as background and NOT dropped', () => {
+    const hp = tmpHolders();
+    // Seed a holders file with a malformed lane + a missing lane.
+    fs.writeFileSync(
+      hp,
+      JSON.stringify({
+        version: 1,
+        holders: [
+          { id: 'g1', pid: process.pid, hostname: os.hostname(), heartbeat: Date.now(), lane: 'frobnicate' },
+          { id: 'g2', pid: process.pid, hostname: os.hostname(), heartbeat: Date.now() },
+        ],
+      }),
+    );
+    const sem = makeSem(8, { enabled: true, ri: 2, rb: 2 }, hp);
+    const st = sem.status();
+    // both garbage/missing-lane holders survive (never dropped) and count as background
+    expect(st.liveHolders).toBe(2);
+    expect(st.liveInteractive).toBe(0);
+    expect(st.liveBackground).toBe(2);
+  });
+});

--- a/tests/unit/lint-dev-agent-dark-gate.test.ts
+++ b/tests/unit/lint-dev-agent-dark-gate.test.ts
@@ -327,6 +327,10 @@ describe('lint-dev-agent-dark-gate', () => {
     // SET is UNCHANGED (still 22 entries, same dotted paths) — only line numbers moved.
     // RE-VERIFIED by hand via the attributor on the edited ConfigDefaults (path set
     // identical, uniform +29 shift, no new entries).
+    // F5 interactive-priority-lane (2026-06-26): added a 6-line
+    // `intelligence.spawnCap.interactivePriority` block (NO `enabled` literal — rides
+    // the dev-gate, NO new attributed path), shifting every key below it DOWN by +6.
+    // RE-VERIFIED via the attributor.
     const EXPECTED: Record<string, string> = {
       // autonomous-progress-heartbeat (AutonomousProgressHeartbeat): a new
       // monitoring.autonomousProgressHeartbeat ConfigDefaults block (+13 lines)
@@ -349,15 +353,15 @@ describe('lint-dev-agent-dark-gate', () => {
       // key below it DOWN by +14. RE-VERIFIED by hand via the attributor on the edited
       // ConfigDefaults (each key maps to a real `enabled: false,` line). Flag SET
       // unchanged (still 22).
-      '216': 'monitoring.sessionReaper.enabled',
-      '274': 'monitoring.agentWorktreeReaper.enabled',
+      '222': 'monitoring.sessionReaper.enabled',
+      '280': 'monitoring.agentWorktreeReaper.enabled',
       // REBASE onto current main (incl. operator-auth-request #1138 authorizationRequests +
       // credential-repointing Increment B): main shifted mcpProcessReaper-onward; WS2.6 inserts
       // two new `enabled: false` stateSync blocks (userRegistry+topicOperator) after evolutionActions,
       // pushing cartographer to 1066/1111/1136. credentialRepointing + authorizationRequests OMIT
       // enabled (dev-gated). Every line RE-VERIFIED by hand via the attributor on the merged ConfigDefaults.
-      '336': 'monitoring.mcpProcessReaper.enabled',
-      '350': 'monitoring.agentSleep.enabled',
+      '342': 'monitoring.mcpProcessReaper.enabled',
+      '356': 'monitoring.agentSleep.enabled',
       // self-unblock-before-escalating (CMT-1519): the blockerLedger ConfigDefaults block
       // gained two nested OMITTED-`enabled` dev-gate sub-blocks (selfUnblockChecklist +
       // durableVaultSession) + a 6-line explanatory comment. Neither sub-block carries an
@@ -373,19 +377,19 @@ describe('lint-dev-agent-dark-gate', () => {
       // comment (NOT an `enabled:` path, so the attributor ignores it) ABOVE every
       // block below — shifting each subsequent `enabled: false` line DOWN by +5.
       // RE-VERIFIED by hand via the attributor on the edited ConfigDefaults.
-      '421': 'monitoring.correctionLearning.enabled',
-      '515': 'monitoring.apprenticeshipCycleSla.enabled',
-      '523': 'monitoring.geminiCapacityEscalation.enabled',
-      '547': 'monitoring.greenPrAutoMerge.enabled',
-      '597': 'threadline.a2aCheckIn.enabled',
+      '427': 'monitoring.correctionLearning.enabled',
+      '521': 'monitoring.apprenticeshipCycleSla.enabled',
+      '529': 'monitoring.geminiCapacityEscalation.enabled',
+      '553': 'monitoring.greenPrAutoMerge.enabled',
+      '603': 'threadline.a2aCheckIn.enabled',
       // secure-a2a-verified-pairing §3.10 (Increment 6): the new
       // threadline.verifiedPairing block (~21 lines, NO `enabled:` literal — see the
       // note below the sessionPool keys) was inserted inside the `threadline` block
       // ABOVE mentor, shifting every subsequent `enabled: false` line DOWN by +19.
       // RE-VERIFIED by hand via the attributor on the edited ConfigDefaults.
-      '708': 'mentor.enabled',
-      '719': 'mentor.autonomousFix.enabled',
-      '734': 'mentee.enabled',
+      '714': 'mentor.enabled',
+      '725': 'mentor.autonomousFix.enabled',
+      '740': 'mentee.enabled',
       // multi-machine-lease-self-heal: a NEW multiMachine.leaseSelfHeal block was
       // inserted at the TOP of the `multiMachine` block (ABOVE accountFollowMe). It
       // adds TWO `enabled: false` literals — F2 staleHolderTakeover + F3
@@ -394,14 +398,14 @@ describe('lint-dev-agent-dark-gate', () => {
       // neither is attributed). The block (~30 lines incl. its comment) shifts every
       // subsequent `enabled: false` line DOWN by +28. RE-VERIFIED by hand via the
       // attributor on the edited ConfigDefaults (each maps to a real `enabled: false,` line).
-      '837': 'multiMachine.leaseSelfHeal.staleHolderTakeover.enabled',
-      '841': 'multiMachine.leaseSelfHeal.silentStandbyRelinquish.enabled',
+      '843': 'multiMachine.leaseSelfHeal.staleHolderTakeover.enabled',
+      '847': 'multiMachine.leaseSelfHeal.silentStandbyRelinquish.enabled',
       // multi-transport-mesh-comms (2026-06-20): soloCaptainHold.enabled:false (Layer 3,
       // action-bearing) added to the leaseSelfHeal block + a ~15-line meshTransport FLAT
       // block (enabled: TRUE, NOT an `enabled: false` path so the attributor ignores it)
       // inserted ABOVE sessionPool — together shifting every sessionPool-onward
       // `enabled: false` line by +24 (956→980, 981→1005). RE-VERIFIED via the attributor.
-      '848': 'multiMachine.leaseSelfHeal.soloCaptainHold.enabled',
+      '854': 'multiMachine.leaseSelfHeal.soloCaptainHold.enabled',
       // WS4.1-durable-ack (CMT-1416) inserts a plain `ws41DurableAck: false`
       // seamlessness boolean (NOT `enabled:`, so the attributor ignores it) above
       // sessionPool. WS4.3-role-guard (CMT-1416) inserts another plain
@@ -442,9 +446,9 @@ describe('lint-dev-agent-dark-gate', () => {
       // Every key below the insertion shifts DOWN by +17; the flag SET is unchanged (still 22).
       // RE-VERIFIED via the attributor on the edited ConfigDefaults (each maps to a real
       // `enabled: false,` line).
-      '1054': 'multiMachine.sessionPool.enabled',
-      '1079': 'multiMachine.sessionPool.inboundQueue.enabled',
-      '1108': 'multiMachine.sessionPool.holdForStability.enabled',
+      '1060': 'multiMachine.sessionPool.enabled',
+      '1085': 'multiMachine.sessionPool.inboundQueue.enabled',
+      '1114': 'multiMachine.sessionPool.holdForStability.enabled',
       // mm-stores-devgate (operator directive 2026-06-13, topic 13481): the 7
       // multiMachine.stateSync.* memory stores MOVED from DARK_GATE_EXCLUSIONS to
       // DEV_GATED_FEATURES and their `enabled: false` literals were REMOVED from
@@ -478,10 +482,10 @@ describe('lint-dev-agent-dark-gate', () => {
       // attributor on the edited ConfigDefaults.
       // After merging JKHeadley/main + my accountFollowMe block, these resolve as below.
       // RE-VERIFIED by hand via the attributor on the MERGED ConfigDefaults.
-      '1277': 'multiMachine.stateSync.threadlinePairing.enabled',
-      '1399': 'cartographer.freshnessSweep.enabled',
-      '1444': 'cartographer.conformanceAudit.llmEnrichment.enabled',
-      '1469': 'cartographer.subtreeNav.llmRerank.enabled',
+      '1283': 'multiMachine.stateSync.threadlinePairing.enabled',
+      '1405': 'cartographer.freshnessSweep.enabled',
+      '1450': 'cartographer.conformanceAudit.llmEnrichment.enabled',
+      '1475': 'cartographer.subtreeNav.llmRerank.enabled',
     };
     const actual = attributeRealConfigDefaults();
     expect(actual).toEqual(EXPECTED);

--- a/tests/unit/spawn-cap-provider-lane.test.ts
+++ b/tests/unit/spawn-cap-provider-lane.test.ts
@@ -1,0 +1,96 @@
+/**
+ * F5 — SpawnCapIntelligenceProvider lane resolution + lane-aware ingress
+ * (docs/specs/spawn-cap-interactive-priority.md §A/§B).
+ *
+ * Locks: the structural allowlist (a non-allowlisted `lane:'interactive'` — e.g. the
+ * CoherenceReviewer fan-out — is DOWNGRADED to background); byte-identical ingress when
+ * the feature is OFF; the interactive fast-path reaching the reserve; and the lane
+ * actually flowing into `semaphore.acquire`.
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  SpawnCapIntelligenceProvider,
+  INTERACTIVE_LANE_ALLOWLIST,
+  isCapacityUnavailable,
+  _resetSpawnPollersForTest,
+} from '../../src/core/SpawnCapIntelligenceProvider.js';
+import type { IntelligenceProvider, IntelligenceOptions } from '../../src/core/types.js';
+
+/** A fake semaphore recording the lane passed to acquire(). */
+function fakeSemaphore(opts: { enabled: boolean; admit?: (lane: string) => boolean }) {
+  const calls: Array<{ id: string; lane: string }> = [];
+  return {
+    calls,
+    acquire(id: string, lane: string = 'background') {
+      calls.push({ id, lane });
+      return opts.admit ? opts.admit(lane) : true;
+    },
+    release() {},
+    interactivePriorityEnabled() {
+      return opts.enabled;
+    },
+  };
+}
+
+const inner: IntelligenceProvider = { evaluate: async () => 'OK' };
+const attr = (component: string, lane?: 'interactive' | 'background'): IntelligenceOptions => ({
+  attribution: { component, gating: true, ...(lane ? { lane } : {}) },
+});
+
+beforeEach(() => _resetSpawnPollersForTest());
+
+describe('SpawnCapIntelligenceProvider — F5 lane resolution', () => {
+  it('allowlist: MessagingToneGate + lane:interactive → acquires on the interactive lane', async () => {
+    const sem = fakeSemaphore({ enabled: true });
+    const p = new SpawnCapIntelligenceProvider(inner, { semaphore: sem as never });
+    await p.evaluate('x', attr('MessagingToneGate', 'interactive'));
+    expect(sem.calls[0].lane).toBe('interactive');
+  });
+
+  it('allowlist DOWNGRADE: CoherenceReviewer tagged interactive → background (the fan-out cannot grab the reserve)', async () => {
+    const sem = fakeSemaphore({ enabled: true });
+    const p = new SpawnCapIntelligenceProvider(inner, { semaphore: sem as never });
+    await p.evaluate('x', attr('CoherenceReviewer', 'interactive'));
+    expect(sem.calls[0].lane).toBe('background');
+  });
+
+  it('feature OFF: even an allowlisted interactive tag resolves to background (byte-identical)', async () => {
+    const sem = fakeSemaphore({ enabled: false });
+    const p = new SpawnCapIntelligenceProvider(inner, { semaphore: sem as never });
+    await p.evaluate('x', attr('MessagingToneGate', 'interactive'));
+    expect(sem.calls[0].lane).toBe('background');
+  });
+
+  it('no lane tag → background', async () => {
+    const sem = fakeSemaphore({ enabled: true });
+    const p = new SpawnCapIntelligenceProvider(inner, { semaphore: sem as never });
+    await p.evaluate('x', attr('MessagingToneGate'));
+    expect(sem.calls[0].lane).toBe('background');
+  });
+
+  it('the allowlist is exactly {MessagingToneGate, MessageSentinel} (membership cannot silently grow)', () => {
+    expect([...INTERACTIVE_LANE_ALLOWLIST].sort()).toEqual(['MessageSentinel', 'MessagingToneGate']);
+  });
+
+  it('interactive fast-path: an immediately-available reserve admits WITHOUT entering the waiters loop', async () => {
+    // admit interactive immediately → fast-path returns; never increments pollers.
+    const sem = fakeSemaphore({ enabled: true, admit: (lane) => lane === 'interactive' });
+    const p = new SpawnCapIntelligenceProvider(inner, { semaphore: sem as never, waitersMax: 2, interactiveWaiters: 1 });
+    const out = await p.evaluate('x', attr('MessagingToneGate', 'interactive'));
+    expect(out).toBe('OK');
+    expect(sem.calls[0].lane).toBe('interactive');
+  });
+
+  it('a saturated interactive call still fails CLOSED (typed shed) — reserve does not mean never-sheds', async () => {
+    const sem = fakeSemaphore({ enabled: true, admit: () => false }); // never admits
+    const p = new SpawnCapIntelligenceProvider(inner, {
+      semaphore: sem as never,
+      waitersMax: 4,
+      acquireMs: 5,
+      pollIntervalMs: 1,
+      sleep: () => Promise.resolve(),
+    });
+    const err = await p.evaluate('x', attr('MessagingToneGate', 'interactive')).catch((e) => e);
+    expect(isCapacityUnavailable(err)).toBe(true);
+  });
+});

--- a/upgrades/next/spawn-cap-interactive-priority.md
+++ b/upgrades/next/spawn-cap-interactive-priority.md
@@ -1,0 +1,44 @@
+# Interactive Priority Lane for the Host Spawn Cap
+
+**Slug:** `spawn-cap-interactive-priority` · **Maturity:** 🧪 Preview (dark-fleet / live-dev) · **Audience:** agent-only
+
+## What Changed
+
+The host spawn cap (the fork-bomb/OOM safety floor that bounds how many LLM
+subprocesses run at once) now reserves a little headroom for the user's reply. Under
+load, the user-facing tone gate used to wait in the same undifferentiated line as
+background sentinels and could time out (a cause of the 2026-06-25 silent-outbound
+incident). The cap now SUBDIVIDES into a small interactive reserve + a small background
+reserve, so a synchronous operator reply always has slots and is never starved by
+background chatter. The total cap is NEVER raised — only *who gets which slot* changes.
+Ships dark on the fleet / live on a development agent (dev-agent gate); byte-identical
+to today when off.
+
+## What to Tell Your User
+
+When the machine is busy, your reply's safety check now jumps to a reserved slot instead
+of waiting behind background work — fewer slow/held replies under load. The crash
+protection is exactly as strong as before. Most setups see no change (it's off on the
+fleet for now).
+
+## Summary of New Capabilities
+
+- `attribution.lane:'interactive'` requests reserved headroom — honored ONLY for an
+  allowlisted, user-blocking seam (the operator-facing tone gate); everything else stays
+  background.
+- Symmetric reservation within the existing cap N (`Ri`/`Rb`, default 2/2): interactive
+  guaranteed ≥Ri slots, background guaranteed ≥Rb — neither starves the other.
+- `/spawn-limiter` reports per-lane live counts + the reservation config.
+- Off (the fleet default) ⇒ byte-identical to the all-or-nothing cap (no `lane` written).
+
+## Evidence
+
+- `hostSpawnSemaphore-priority.test.ts` (10): symmetric reserve, OOM floor unconditional,
+  garbage-lane→background-never-dropped, clamp (N=1/N=2/oversized/0), off=byte-identical.
+- `spawn-cap-provider-lane.test.ts` (7): allowlist downgrade (CoherenceReviewer→background),
+  off→background, interactive fast-path, saturated interactive still fails closed,
+  membership pinned.
+- 25 existing spawn-cap tests + 160 tone-gate tests pass unchanged (no regression; the
+  fork-bomb burst-invariant test still green). `tsc --noEmit` clean.
+- Side-effects: `upgrades/side-effects/spawn-cap-interactive-priority.md`.
+- Spec (converged + approved): `docs/specs/spawn-cap-interactive-priority.md`.

--- a/upgrades/side-effects/spawn-cap-interactive-priority.md
+++ b/upgrades/side-effects/spawn-cap-interactive-priority.md
@@ -1,0 +1,76 @@
+# Side-Effects Review — Interactive Priority Lane for the Host Spawn Cap (F5 build)
+
+**Version / slug:** `spawn-cap-interactive-priority`
+**Date:** `2026-06-26`
+**Author:** `Echo (instar-dev agent)`
+**Tier:** 2 (converged + approved spec: `docs/specs/spawn-cap-interactive-priority.md`)
+
+## Summary
+
+Implements the converged F5 design: the host spawn cap (the fork-bomb OOM floor) now
+SUBDIVIDES into reserved interactive/background headroom so the user-facing tone gate
+is not starved by background sentinels under contention. It NEVER raises the total cap.
+Ships dark-on-fleet / live-on-dev via the dev-agent gate; byte-identical when off.
+
+Implemented this change:
+- `attribution.lane?: 'interactive'|'background'` (types.ts) — the lane signal.
+- `hostSpawnSemaphore`: `SpawnLane` + optional per-holder `lane`; `clampInteractiveReserves`;
+  `acquire(id, lane)` with the symmetric reserve (interactive iff `liveTotal<N AND
+  liveInteractive<N−Rb`; background symmetric); `interactivePriorityEnabled()`; per-lane
+  `status()` fields. The `liveTotal<N` OOM floor remains the UNCONDITIONAL first predicate.
+- `SpawnCapIntelligenceProvider`: `INTERACTIVE_LANE_ALLOWLIST` (downgrade non-allowlisted
+  `interactive` to background); lane-aware ingress (interactive fast-path before the
+  waiters cap + a CARVE-OUT of `waitersMax`, never additive); passes the lane to acquire.
+- `MessagingToneGate`: `synchronousReply` context flag → sets `lane:'interactive'` only on
+  the operator-facing synchronous reply.
+- Dev-gated flag wiring (server.ts `configureHostSpawnSemaphore`), config type +
+  ConfigDefaults (`enabled` OMITTED → dev-gate; `ri:2, rb:2`), `/spawn-limiter` per-lane
+  fields.
+
+## The 8 questions
+
+1. **Over-block** — N/A. The reservation gates spawns (existing authority); it adds no new
+   rejection. A saturated interactive call still fails closed (typed shed) exactly as today.
+2. **Under-block** — N/A. The total cap is byte-identical (`liveTotal<N` first, always).
+3. **Level-of-abstraction fit** — Correct. `ComponentFrameworks`/attribution already carry
+   per-call metadata; the reserve lives in the one primitive (`hostSpawnSemaphore`) +
+   its wrapper. No routing-engine change.
+4. **Signal vs authority** — Subdivides EXISTING authority by a lane; no new brittle
+   blocking logic (pure integer counting over the holder set, same shape as `liveHolders<cap`).
+   The interactive signal is hardened by a code allowlist + a membership-pinning test (not
+   convention). Complies with docs/signal-vs-authority.md.
+5. **Interactions** — Disabled ⇒ byte-identical (no `lane` written, ingress carve-out
+   gated on `priorityOn`, lane resolves to background). Confirmed: 25 existing spawn-cap
+   tests + 160 tone-gate tests pass unchanged. The wrapper ingress carve-out keeps the
+   aggregate poller bound at `waitersMax` (not additive). Garbage/missing lane → background,
+   never drops a holder (`isWellFormedHolder` untouched) — the OOM floor cannot be eroded.
+6. **External surfaces** — `/spawn-limiter` gains per-lane fields (additive). The tone
+   gate's LLM call may run on a different framework lane than background — intended, visible.
+7. **Multi-machine** — Host-local BY DESIGN (the holders file is per-host, never synced).
+   Each host reserves its own headroom. The optional `lane` rides inside the host-local
+   file; an old reader ignores it, a new reader counts a missing lane as background — total
+   cap bounded both directions during a mixed-version window (priority is best-effort until
+   all co-resident agents upgrade; moot while dark). No replication.
+8. **Rollback cost** — Trivial. The dev-gate flag off (or `interactivePriority.enabled:false`)
+   restores all-or-nothing. No migration (deepMerge backfills `ri/rb`; no stale `enabled`
+   to strip on a new block). No state. Revert the commit otherwise.
+
+## Tracked follow-ups (not orphan deferrals)
+
+- A `lint-interactive-lane-allowlist` CI script (Structure>Willpower belt-and-suspenders).
+  The wrapper DOWNGRADE + the membership-pinning unit test already guarantee safety; the
+  lint is additional defense against a new static assignment site. <!-- tracked: topic-28744 F5-followup interactive-lane-lint -->
+- The §A.1 second tagged seam (operator-inbound `MessageSentinel`) is on the allowlist; its
+  synchronousReply-equivalent wiring on the inbound path lands with the inbound work. <!-- tracked: topic-28744 F5-followup messagesentinel-inbound-lane -->
+
+## Second-pass note (spawn-cap = safety floor)
+
+This touches the fork-bomb OOM floor (a Phase-5 trigger area). The load-bearing review
+point: the change ONLY subdivides within `N` — `liveTotal<N` is the unconditional first
+predicate of every lane, the reserve never raises the ceiling, a garbage lane never drops
+a holder, and `enabled:false` is byte-identical (verified by the existing burst-invariant
+fork-bomb test passing unchanged). The decision boundary is covered by 17 new unit tests.
+
+## Rollback
+
+Dev-gate off / `enabled:false`. No migration, no state.


### PR DESCRIPTION
## What

The host spawn cap (the fork-bomb/OOM safety floor) now reserves headroom for the user's reply. Under load, the user-facing tone gate used to wait in the same undifferentiated line as background sentinels and could time out — a cause of the 2026-06-25 silent-outbound incident. The cap now **subdivides** into a small interactive reserve + a small background reserve (symmetric, default 2/2 within N=8), so a synchronous operator reply always has slots and is never starved by background chatter.

The **total cap is NEVER raised** — `liveTotal < N` remains the unconditional first predicate of every lane. Only *who gets which slot* changes.

## Safety (this is the fork-bomb floor)

- The OOM ceiling is byte-identical; the reserve only subdivides within N.
- A garbage/missing `lane` is counted as background and **never drops a holder** (`isWellFormedHolder` untouched) — the cap cannot be eroded.
- The interactive signal is hardened by a **structural component allowlist** (a non-allowlisted `lane:'interactive'` — e.g. the CoherenceReviewer fan-out, the original fork-bomb driver — is downgraded to background) + a membership-pinning test.
- Lane-aware ingress is a **carve-out of `waitersMax`, never additive** (aggregate poller bound unchanged).
- Ships **dark on the fleet / live on a dev agent** (dev-agent gate); `enabled:false` ⇒ **byte-identical** (no `lane` written).

## Evidence

- `hostSpawnSemaphore-priority.test.ts` (10): symmetric reserve, OOM floor unconditional, garbage-lane safety, clamp (N=1/N=2/oversized/0), off=byte-identical.
- `spawn-cap-provider-lane.test.ts` (7): allowlist downgrade, off→background, interactive fast-path, saturated→fails-closed, membership pinned.
- `spawn-cap.test.ts` integration: `/spawn-limiter` surfaces the per-lane fields.
- 25 existing spawn-cap tests + 160 tone-gate tests pass unchanged (the fork-bomb burst-invariant still green). `tsc` clean; full `npm run lint` exit 0.

## ELI16

To keep from crashing the machine, I cap how many AI "thinking" jobs run at once (default 8). Under load, YOUR reply's safety check waited in the same line as my background self-checks and could time out — one of the ways replies went silent on the bad night. Now a couple of those 8 slots are always kept open for your reply, a couple are always kept for background safety checks (so neither starves the other), and the rest are shared. The total of 8 never changes — I'm only deciding who gets which slot, so the crash protection is exactly as strong as before. It's off for everyone but me for now, and a corrupted value can never weaken the cap. The thing that marks a job "your reply" is locked down in code (my background reviewers — including the one that caused the original crash by running ten copies at once — can't grab the reserved slots).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
