### PR TITLE
feat(reachability): Verify-After Topic Reachability (F7)

### DIFF
--- a/.instar/instar-dev-decisions/2026-06-26T12-34-44-856Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-06-26T12-34-44-856Z-unknown.json
@@ -1,0 +1,15 @@
+{
+  "ts": "2026-06-26T12:34:44.856Z",
+  "slug": "unknown",
+  "suggestedTier": 2,
+  "declaredTier": 2,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "new capability: new exported class / subsystem added"
+  ],
+  "belowFloor": false,
+  "files": 2,
+  "loc": 318,
+  "causalAutopsy": null,
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-06-26T12-44-27-884Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-06-26T12-44-27-884Z-unknown.json
@@ -1,0 +1,13 @@
+{
+  "ts": "2026-06-26T12:44:27.884Z",
+  "slug": "unknown",
+  "suggestedTier": 2,
+  "declaredTier": 2,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 106,
+  "causalAutopsy": null,
+  "verdict": "blocked"
+}

--- a/docs/specs/reports/verify-after-reachability-convergence.md
+++ b/docs/specs/reports/verify-after-reachability-convergence.md
@@ -1,0 +1,90 @@
+# Convergence Report — Verify-After Topic Reachability (F7)
+
+## Cross-model review: codex-cli:gpt-5.5
+
+A real GPT-tier external pass (codex-cli) ran on every round. Gemini-cli was
+attempted each round but its calls degraded (timeout) — so the external assurance is
+codex's. Codex's final-round "SERIOUS ISSUES" verdict was raised SOLELY on two
+stale-sentence internal contradictions (a pre-rewrite "Piece 1 (spawn timeout +
+sweep)" line and a "Piece 1 fixes the wedge at source" phrase) that the independent
+internal round-3 reviewer flagged identically as LOW/editorial — both fixed in the
+final spec. No external design objection survives.
+
+## ELI10 Overview
+
+When I shut down or move one of my own work sessions, there's a narrow risk I leave
+that conversation with no working path for your next message — it black-holes. That
+bit us on 2026-06-25. Importantly (and the spec is honest about this), the common case
+already self-heals: your next message normally just spins up a fresh session. The real
+gaps are specific — a session start-up that hangs leaves a "currently starting" flag
+stuck so future messages get skipped, and on a multi-machine setup a handed-off
+conversation can land on a machine that can't serve it.
+
+The fix has two parts. Part 1 makes that stuck-start-up state SAFE and OBSERVABLE
+(a tagged, timestamped record) — but deliberately does NOT try to auto-clear it,
+because two review rounds proved any auto-clear races a still-running start-up into
+starting a *second* session. Part 2 is a pure watcher: right after I kill/move a
+session, it checks the conversation is still reachable and, if not, raises one calm
+"you might not be able to reach me here" alert. It never kills, moves, starts, or
+clears anything — a smoke alarm, not a firefighter. The fully-automatic un-sticking
+(which needs cleanly cancellable start-ups) is written down as a tracked follow-up.
+
+The tradeoff: a genuinely hung start-up still needs a human/restart to un-stick — but
+you're no longer in the dark about it, which is the whole point of the standard.
+
+## Original vs Converged
+
+The original design had a **dangerous self-heal**: an external actor would clear a
+"stale" stuck-spawn flag. Two review rounds proved this RELOCATES the exact
+double-spawn race it tried to fix — the spawn body is non-cancellable, so clearing the
+flag while the body runs lets a second spawn start and the two race on session
+registration / kill / inject. The converged design **removes all auto-clearing**
+(no timeout-clear, no sweep) and instead **surfaces the hung state loudly** as a pure
+signal, deferring the genuinely-hard cancellable-spawn auto-heal to a tracked
+follow-up. It also got materially more honest and safer: the "reachable" term is
+defined as admission/routing reachability (checks session-cap/quota/adapter, not just
+the flag); the multi-machine trigger was corrected from a phantom "event" to a named
+new tap; surfacing is NORMAL-priority + coalesced + flap-backoff-capped + pressure/
+emergency-stop-aware with a re-sweep so no orphan is silently lost; and detection is
+scoped to the released-no-placement slice so it doesn't double-voice with the existing
+StrandedTopicSentinel / OwnershipReconciler.
+
+## Iteration Summary
+
+| Iteration | Reviewers who flagged | Material findings | Spec changes |
+|-----------|-----------------------|-------------------|--------------|
+| 1 | lessons-aware/foundation, adversarial, scalability/integration, decision-completeness, conformance | 2 blocking + ~10 material | Reframed to two-piece (source fix + pure-signal verifier), but with a timeout-clear + sweep |
+| 2 | foundation (CONVERGED), adversarial (ITERATE), codex, gemini(degraded), conformance | 1 HIGH + ~5 material | HIGH: timeout RELOCATES the race (non-cancellable body). Removed timeout+sweep; "surface don't clear"; defined "reachable"; recovery-bounce post-grace verify; pressure/halt rolled-up + re-sweep; flap backoff; wiring-integrity tests |
+| 3 | convergence-confirm (CONVERGED), codex (stale-text only), gemini(degraded), conformance (tracked-deferral) | 0 material (2 editorial) | Fixed the two stale-text contradictions (§E + Piece-2 intro) |
+
+## Full Findings Catalog (condensed)
+
+**Round 1 (blocking + material):** self-heal ABA double-spawn race [→ removed self-heal];
+multi-machine trigger is not an event [→ named new tap]; attention-flood [→ NORMAL +
+coalesce + topic-key]; trigger-storm [→ global cap + pressure-aware + filter
+recovery-bounce]; false-reachable [→ check cap/quota/adapter, honest wedged-session
+scope]; one-voice overlap [→ released-no-placement only]; closure→injectable registry
+[→ named]; migration-parity + guard-manifest [→ added]; unflagged TTL risk [→ resolved
+by removing the clear]; decision-completeness gaps [→ all frontloaded].
+**Round 2 (HIGH + material):** timeout relocates the race [→ removed timeout, surface
+instead, defer auto-heal]; backstop sweep unreachable [→ removed]; never-surfaced
+orphan under pressure/halt [→ rolled-up + re-sweep]; single-flapper flood [→ backoff];
+recovery-bounce blind spot [→ post-grace verify].
+**Round 3 (editorial only):** two stale-text contradictions [→ fixed]; tracked deferral
+of the cancellable-spawn auto-heal (legitimate — marker present, justified).
+
+## Convergence verdict
+
+Converged at iteration 3. The independent round-3 reviewer returned CONVERGED ("the
+'surface-don't-clear' core is sound and honest, the auto-heal deferral is legitimate,
+no material design hole"); the only round-3 findings were two editorial stale-sentence
+contradictions, now fixed. The design's safety rests on construction: Piece 1 adds NO
+new flag-clearer (the existing `.finally` remains the sole clearer, token-guarded), so
+it cannot create a new double-spawn race; Piece 2 is pure signal (zero mutation). Every
+black-hole slice is either covered by Piece 2 or honestly carved to a named sibling
+guard with one voice preserved. Spec is ready for user review and approval.
+
+## Open questions
+
+*(none — all resolved; the one deferral (cancellable-spawn auto-heal) is tracked, not
+an open user-decision.)*

--- a/docs/specs/verify-after-reachability.eli16.md
+++ b/docs/specs/verify-after-reachability.eli16.md
@@ -1,0 +1,72 @@
+# Verify-After Topic Reachability — Plain-English Overview
+
+## What this is about
+
+When I shut down or move one of my own work sessions — to clean up, to free
+resources, to move a conversation to another machine — there's a small risk I leave
+that conversation with no working way for your next message to land. If that
+happens, you message me and... nothing. It goes into a hole, silently. That's
+exactly what bit us on the bad night: a session got force-killed and the
+conversation's incoming messages black-holed.
+
+## The honest version (this matters)
+
+It would be easy to say "every time I kill a session, your messages vanish" — but
+that's not true, and pretending it is would be its own kind of dishonesty. In the
+normal case, when you send your next message, I automatically notice there's no live
+session and spin one up on the spot. So most kills heal themselves the moment you
+write again.
+
+The real danger is a couple of *specific* corners where that automatic healing
+can't fire:
+- A session that gets stuck halfway through starting up leaves a "currently
+  starting" flag set forever, and that flag makes me skip every future message for
+  that conversation — a silent jam, with nothing to clear it.
+- On a multi-machine setup, if I hand a conversation to another machine that turns
+  out to be asleep or maxed-out, your message gets forwarded into a dead end with no
+  automatic catch.
+
+## What this change does (two parts)
+
+Two rounds of review caught that any clever auto-fix here is dangerous — clearing
+that "currently starting" flag while a session is genuinely still coming up just makes
+me start a SECOND one, which is its own mess. The reviewers were right, twice. So the
+design landed on the genuinely-safe version: make the problem LOUD, don't race to
+auto-fix it.
+
+**Part 1 — make the stuck state safe to observe.** I tidy up that "currently starting"
+flag so it carries a timestamp and a little ID tag (which makes a known double-clear
+bug impossible), but I deliberately do NOT have anything reach in and clear it while a
+start-up might still be running. A genuinely stuck start-up keeps its flag — and Part
+2 then SEES it and tells you. The fully-automatic recovery (un-sticking it without a
+restart) needs a deeper change to make start-ups cleanly cancellable; that's real work
+I've written down as a separate follow-up rather than rushing a risky version now.
+
+**Part 2 — a "did I just break the door?" watcher that only WATCHES.** Right after I
+shut down or move a session, it quietly checks the conversation still has a working
+path for your next message. If it genuinely doesn't — including that stuck start-up
+case — it raises one calm, visible heads-up ("you might not be able to reach me here").
+That's all it does — it never kills, moves, starts, or clears anything. It's a smoke
+alarm, not a firefighter. The mechanical un-sticking stays a human/restart action for
+now, but you're no longer in the dark about it.
+
+It's careful not to cry wolf: a conversation that simply has no session right now but
+will spin one up on your next message counts as "fine," not "broken." It stays quiet
+during an emergency-stop (when I'm deliberately shutting things down), it rolls a big
+batch of problems into one heads-up instead of a flood, and on a multi-machine setup
+it only flags the cases nothing else is already watching.
+
+## How it ships
+
+The bug fix (Part 1) goes in for everyone, set conservatively so it can't misfire.
+The watcher (Part 2) is off for everyone else and fully live for me first — and since
+it only watches and never acts, there's no risk in turning it on; I just confirm it's
+not over-alarming before it goes wider.
+
+## Why it matters
+
+This is the seventh and last of the structural fixes from the "your experience is
+the product" lesson, and it's the most direct one: all the others make sure I behave
+well; this one specifically watches that, after I do something disruptive, you can
+still actually reach me. It also fixes a real latent bug found along the way — the
+stuck-starting flag that had no timeout — at its source.

--- a/docs/specs/verify-after-reachability.md
+++ b/docs/specs/verify-after-reachability.md
@@ -1,0 +1,315 @@
+---
+slug: verify-after-reachability
+title: Verify-After Topic Reachability (Postmortem F7)
+status: draft
+eli16-overview: verify-after-reachability.eli16.md
+constitution: Bounded Blast Radius + Structure > Willpower (registered); enacts the proposed "User Experience Is the Product → Blast-Radius Before, Verify-After" sub-standard
+earned-from: 2026-06-25 user-reachability postmortem, Failure 7
+review-convergence: "2026-06-26T12:03:17.271Z"
+review-iterations: 3
+review-completed-at: "2026-06-26T12:03:17.271Z"
+review-report: "docs/specs/reports/verify-after-reachability-convergence.md"
+cross-model-review: "codex-cli:gpt-5.5"
+single-run-completable: true
+frontloaded-decisions: 7
+cheap-to-change-tags: 0
+contested-then-cleared: 0
+---
+
+# Verify-After Topic Reachability (F7)
+
+## The constitution standard this enforces
+
+This enacts postmortem sub-standard #7 (**Blast-Radius Before, Verify-After**) of
+the proposed umbrella standard *The User Experience Is the Product* (ships dark like
+F2/F3/F4/F6, all of which shipped before ratification). Until ratified it also
+anchors to two ALREADY-REGISTERED standards: **Bounded Blast Radius** (a destructive
+op must not silently expand into "the user can't reach me") and **Structure >
+Willpower** ("remember to check the topic still works after a kill" is a wish; a
+structural verify is the enforcement). <!-- tracked: topic-28744 F-series umbrella-standard registration -->
+
+## What broke (the postmortem scenario) — stated HONESTLY
+
+On 2026-06-25 an agent force-killed a session and the topic's inbound messages
+black-holed. The naive reading "any force-kill black-holes a topic" is **false** and
+this spec does not claim it (overselling would itself break the standard's honesty
+rule). Verified against the code:
+
+**The dominant single-machine path ALREADY self-heals.** `onTopicMessage`
+(`src/commands/server.ts`) unconditionally spawns when the session is absent or dead
+(mapped-but-dead → respawn; unmapped → auto-spawn with history). A plain force-kill
+is healed by the next inbound. The black-hole is real but NARROW — it needs a
+*secondary* failure that defeats the self-heal:
+
+1. **Single-machine — the `spawningTopics` wedge (the real, unguarded bug).**
+   `onTopicMessage` guards double-spawn with an in-memory `spawningTopics` set,
+   cleared only in the spawn promise's `.finally`. A spawn that HANGS leaves the
+   topic flagged "already spawning" → every subsequent inbound is silently skipped,
+   with **no timeout on the spawn and no sweep**. (Bounded by scope: the set is
+   closure-local, rebuilt on server boot, so it wedges "until the next restart," not
+   literally forever — review correction. Still a real, unguarded black-hole.)
+2. **Multi-machine — released ownership with no live re-placement.** A
+   transfer/pinned-move releases local ownership and pins a target. If the topic
+   ends up with NO live session anywhere AND no ownership record that will self-heal
+   on inbound (the *released-no-placement* slice), inbound has no self-heal net.
+
+**What does NOT already cover these:** ReapNotifier *notifies* (silent for
+`origin:'operator'`/agent force-kills); ResumeQueueDrainer *revives mid-work* (dry-
+run; idle kills get nothing); StrandedTopicSentinel *signals a walled-but-online
+OWNER only* (dark; blind to released/no-owner/force-killed). None verifies
+reachability after a mutation; all three skip the operator/agent force-kill +
+ownership-release path. The verify-after primitive is absent.
+
+## The design — TWO separable pieces
+
+Round-1 review showed the original "external clear of a stale `spawningTopics` flag"
+self-heal was unsafe (an ABA double-spawn race against a still-in-flight spawn — the
+exact bug the flag prevents) and that the multi-machine trigger was described as an
+event that does not exist. The redesign splits F7 into a **source-level correctness
+fix** (Piece 1) and a **pure-signal verifier** (Piece 2, NO mutation authority) — so
+the dangerous self-heal authority is removed entirely.
+
+### Piece 1 — Make the `spawningTopics` wedge VISIBLE (token-safe registry), NOT auto-cleared
+
+Round-2 review (HIGH) showed that *any* mechanism which clears the flag while the
+spawn body is still in flight RELOCATES the double-spawn race rather than dissolving
+it: the spawn body is **non-cancellable** (no `AbortController` on this path), so a
+timeout that rejects + clears the flag does NOT stop the underlying work — it later
+runs `registerTopicSession` / the respawn's pre-emptive `kill-session` / the message
+inject concurrently with a second spawn, all OUTSIDE any flag-token guard. A
+"backstop sweep" gated on "no pending promise" is also logically unreachable (a
+genuinely-hung spawn has an *unsettled* promise, so the gate never opens). So Piece 1
+deliberately does NOT auto-clear or timeout-clear the flag. It does the minimum that
+is provably safe:
+
+- **Promote `spawningTopics` from a closure-local `Set<number>` to a small injected
+  `SpawningTopicsRegistry`** carrying, per entry, `{ token, startedAtMs }`. One
+  component, used by the inbound hot path AND the drain path (the 4 add/clear
+  callsites + the declaration — the only users). This is the seam the verifier reads
+  "is this topic stuck-spawning and since when" from.
+- **Token-guard the EXISTING `.finally` clearer (the ABA fix — the one safe change).**
+  `add(topic)` returns a unique `token`; the `.finally` clear only deletes if the live
+  entry's token still equals the caller's. So a late `.finally` from a spawn that has
+  already been superseded cannot delete a newer entry. The `.finally` on true settle
+  (success or genuine rejection) remains the **sole** clearer — no new clearer is
+  added, so no new race is created.
+- **A hung spawn KEEPS its flag → it is DETECTED and SURFACED by Piece 2**, not
+  cleared. Making the silent wedge LOUD is the F7 win; the topic stays wedged until
+  the hung spawn settles or a restart, but the user/operator now KNOWS (vs the
+  2026-06-25 silence). This is the safe, honest core.
+
+**Deferred (tracked, with rationale — NOT an orphan deferral):** the *mechanical
+auto-recovery* of a hung spawn (so it heals without a restart) genuinely requires
+making the spawn body **cancellable** — an `AbortController` threaded through
+`spawnSessionForTopic`/`respawnSessionForTopic` that tears down any partial tmux and
+makes a post-abort `registerTopicSession` a token-checked no-op. That is a real,
+separate piece of work whose absence does NOT block F7's value (surfacing-loud
+already satisfies *Verify-After* / *Degradation Is an Event*), and doing it wrong
+re-opens the exact double-spawn race. It is explicitly out of THIS spec and tracked.
+<!-- tracked: topic-28744 F7-followup cancellable-spawn-autoheal -->
+
+Piece 1's only behavior change is the token-guard (defensive; today's `.finally` is
+already the sole clearer) + the registry seam. It is live (no detection surface), and
+introduces NO timeout, NO sweep, NO new clearer — so it cannot re-introduce the
+double-spawn the Set prevents.
+
+### Piece 2 — `TopicReachabilityVerifier` (PURE SIGNAL — no mutation authority)
+
+A detector that, after a destructive mutation, verifies the topic is still inbound-
+reachable and SURFACES a genuine orphan. It mutates NOTHING (the round-1 self-heal is
+removed). Note precisely: Piece 1 does NOT mechanically heal a hung spawn — it makes
+the hung state SAFE (token-guarded) and OBSERVABLE (the registry seam); the verifier
+then SURFACES it rather than clearing it (clearing is the racy auto-heal that is
+deferred). So the verifier never needs — and never has — flag-clearing authority. This
+makes it a pure signal that can ship LIVE on a dev agent (resolving the Maturation-Path
+conformance finding) while staying dark on the fleet.
+
+#### A. Triggers (honest about what is/ isn't an event)
+
+1. `sessionReaped` (a real `EventEmitter` event, once per kill at `terminateSession`).
+   A `disposition:'terminal'` kill schedules a verify. A `recovery-bounce` (kill-to-
+   respawn) is NOT blanket-dropped (round-2 finding): it ALSO schedules a post-grace
+   verify — it normally self-heals (the respawn lands → REACHABLE → no surface, same
+   honesty guard as a normal kill), but if the *respawn itself wedges in
+   `spawningTopics`*, that is exactly the single-machine orphan F7 exists to catch, so
+   it must be reachable to the verifier, not filtered out.
+2. **Ownership release/transfer.** Correction (round-1 blocking #4): `emitPlacement`
+   is a **journal write, not an event** — there is no subscriber surface. So Piece 2
+   adds an **explicit new tap**: a single optional callback funnel the server-side
+   release/transfer CAS arms invoke (the `released` + `transfer` arms at the ~6
+   placement callsites), passing the affected topic. This is named new code, not a
+   free subscription.
+
+Each trigger enqueues a **per-topic-coalesced** verify (one pending verify per topic
+regardless of reap count), run after a `graceMs` window (so a normal kill→next-
+inbound-respawn or transfer→claim self-heals before we judge). The pending set is
+**globally bounded** (`maxPendingVerifies`, overflow counted in status).
+
+**Pressure-aware WITHOUT going blind (round-2 finding):** under
+`pressureTier()==='critical'`, the verifier skips the per-topic verify CHURN (the
+mass-reap is itself the pressure; a verify-storm must not amplify it) — but it does
+NOT go silent: it still emits at most ONE rolled-up "N topics may be unreachable
+(system under pressure)" item (the roll-up bounds it to one), AND it records the
+skipped topics. **On pressure-clear AND on emergency-stop-lift it runs a one-shot
+re-sweep** of topics whose verify was skipped/suppressed in the window, so an orphan
+that *began* during the window — and outlives it — surfaces once the system is healthy
+enough to act (closing the "never-surfaced orphan" gap). (`pressureTier` is exposed
+via a public getter / shared `PressureGauge` — wiring, named here.)
+
+#### B. Reachability predicate
+
+**Definition of "reachable" (review — codex):** a topic is reachable iff the user's
+next inbound message can EITHER be delivered to a live session now OR cause a session
+to be admitted+spawned now. (It is *admission/routing* reachability, not mere
+addressability — a topic at the session cap cannot admit a spawn, so it is not
+reachable even though it is addressable.)
+
+REACHABLE if ANY (read over live local state + the placement snapshot; no mesh call):
+- a **live, non-wedged** session exists for it (note: wedge-detection is
+  SessionWatchdog's domain — the verifier treats a live tmux session as reachable and
+  does NOT re-implement wedge detection; stated honestly, not oversold — finding 4);
+   OR
+- it is unowned/dead-owner AND the **auto-spawn path is FUNCTIONAL** — meaning NOT
+  stuck-spawning past `stuckSpawnMs` (the registry's `startedAtMs` is older than the
+  threshold — a DETECTION threshold, not a clear threshold; the flag is never cleared)
+  **AND** `maxSessions` headroom exists **AND** the account is not quota-walled **AND**
+  the adapter is connected (finding 4: the flag alone is insufficient; a topic at the
+  session cap is effectively orphaned); OR
+- it has an owner/placement on a machine that can actually serve, judged from a
+  **FRESH** placement snapshot (see §multi-machine).
+
+ORPHANED (the only state that surfaces) = none hold. Concretely: single-machine →
+no session + stuck-spawning-past-TTL OR at-cap/quota/adapter-down with no session;
+multi-machine → no live session anywhere + released-no-placement (see §multi-machine);
+plus the **durable-inbound-queue-stall** case the spec named (a committed custody row
+that is not draining, no session, owner not provably dead — review M2) is ORPHANED.
+
+A topic that simply has no session now but whose next inbound WILL spawn is
+**REACHABLE, not orphaned** — the honesty guard against screaming on every idle kill.
+
+#### C. On an orphan — SURFACE ONLY (no mutation)
+
+- Raise an attention item at **`priority: 'NORMAL'`** (NEVER high/urgent — high/urgent
+  bypass coalescing, the 2026-05-22 flood lesson — review M3), with a **single stable
+  `sourceContext: 'topic-reachability'`** so the existing attention-flood guard +
+  `topicCreationBudget` ceiling coalesce it. Dedup key = **topic**, re-armed after a
+  subsequent **verified-reachable** observation — BUT with a **per-topic minimum
+  re-surface interval + exponential backoff that applies REGARDLESS of intervening
+  verified-reachable observations** (round-2 finding): a topic that oscillates
+  orphan→reachable→orphan every grace window cannot mint an item each cycle — the
+  backoff caps a single flapper at a slow, widening cadence (it never goes fully
+  silent on a genuine persistent problem, but it cannot flood).
+- **Burst roll-up:** when orphan count in a window exceeds a threshold (a mass-reap or
+  a partition), emit ONE rolled-up "N topics may be unreachable (cause)" item instead
+  of N (finding 2/5).
+- **Emergency-stop suppression (with re-sweep):** while an operator emergency-stop /
+  MessageSentinel halt is active, SUPPRESS surfacing (the operator is deliberately
+  quieting the system — a flood then is the opposite of help — finding 6). On
+  halt-lift, the one-shot re-sweep (§A) re-checks suppressed topics so a real orphan
+  that outlives the halt is not permanently silenced.
+- It NEVER clears a flag, spawns, kills, transfers, or re-places. Its entire effect is
+  an attention item.
+
+#### D. Multi-machine posture — released-no-placement ONLY, freshness-gated
+
+To preserve ONE voice (review M4/finding 5), the verifier surfaces the multi-machine
+case ONLY for the **released-no-placement** slice — a topic with no live session and
+no ownership record that any actor will self-heal. It explicitly DEFERS:
+- *owner online-but-walled* → StrandedTopicSentinel's territory;
+- *provably-dead owner* → OwnershipReconciler's Case C / re-placement.
+It judges from a **freshness-gated** placement snapshot: if the snapshot is stale /
+partition-suspected (the local view can't tell "remote owner dead" from "I'm
+partitioned"), it does NOT scream per-topic — it emits at most one rolled-up "may be
+partitioned from machine M (N topics)" item, fail-safe (finding 5). It never re-places
+(the OwnershipReconciler owns that authority — F7 must not be a second re-placement
+actor).
+
+### E. Dark / flagged / maturation
+
+- **Piece 1** (registry seam + token-guarded `.finally`): an in-memory correctness
+  fix, live, no config surface of its own and no detection surface to flag. It has NO
+  spawn timeout and NO sweep (round-2 removed both — re-introducing either re-opens the
+  double-spawn race this rewrite eliminated).
+- **Piece 2** (the verifier, pure signal): `monitoring.topicReachabilityVerifier`
+  **omitted from `ConfigDefaults`** → `resolveDevAgentGate` (LIVE on a dev agent,
+  dark fleet). Because it is **pure signal (no mutation)**, it ships **enabled, NOT
+  dryRun, on a dev agent** — satisfying the Maturation-Path standard (the conformance
+  finding); there is no actuation to gate. The `selfHeal*` flag from round-1 is
+  **deleted** (no self-heal exists anymore).
+
+## Integration obligations (review — Migration Parity + guard posture)
+
+- **Guard-manifest registration (required):** register Piece 2 in `GUARD_MANIFEST`
+  via `guardRegistry.register('monitoring.topicReachabilityVerifier.enabled', () =>
+  verifier.guardStatus())` so a disabled/off state shows on `GET /guards` +
+  GuardPostureProbe (a bespoke `/topic-reachability` route alone is invisible to
+  `/guards` — review #6). The richer route is in addition to, not instead of.
+- **Migration parity:** add `migrateConfigTopicReachabilityVerifierDevGate`
+  (strip a default-shaped `enabled:false` from existing agents, the #1001 trap) and an
+  Agent-Awareness/CLAUDE.md-template note for the `/topic-reachability` route. The
+  Piece-1 TTL/timeout change is in-memory runtime (no config migration) — stated.
+
+## Signal vs authority (instar-dev Phase-4 Q4)
+
+Piece 2 is a **pure signal producer** — zero mutation authority (the dangerous round-1
+self-heal is gone). Piece 1 is a correctness fix to an existing concurrency guard
+(bound + token), not new blocking authority — it makes the *existing* flag SAFE, and
+the token guard makes the clear race-free by construction. Complies with
+docs/signal-vs-authority.md.
+
+## Frontloaded Decisions (review decision-completeness — all pinned)
+
+- `stuckSpawnMs` (the verifier's DETECTION threshold — a registry entry older than
+  this is "stuck-spawning", surfaced as an orphan; the flag is NEVER cleared by it) =
+  **180000** (3 min; comfortably > a healthy spawn, which loads ≤50 history messages —
+  bounded, review-confirmed — so a slow-but-healthy spawn is not mis-flagged). Config
+  `monitoring.topicReachabilityVerifier.stuckSpawnMs`.
+- NO `spawnTimeoutMs` / NO backstop-sweep / NO `staleMs` — round-2 removed both (the
+  timeout relocated the race; the sweep was logically unreachable). The token-guard on
+  the existing `.finally` is the only Piece-1 behavior change.
+- `graceMs` (verify delay after a mutation) = **30000** (30s; > normal respawn time so
+  a healthy bounce isn't flagged). Config `monitoring.topicReachabilityVerifier.graceMs`.
+- `maxPendingVerifies` = **500** (mirrors ReapNotifier's `AFFECTED_SET_CAP`); overflow
+  surfaced as `affectedOverflow` in status.
+- orphan-burst roll-up threshold = **10 topics / window**.
+- per-topic re-surface backoff: floor **3600000** (1h), exponential, applied REGARDLESS
+  of verified-reachable re-arm (the flap cap).
+- Config interface (complete): `monitoring.topicReachabilityVerifier = { enabled?,
+  graceMs, stuckSpawnMs, maxPendingVerifies, burstThreshold, resurfaceFloorMs }`
+  (enabled omitted → dev-gate). No `intelligence.*` change (Piece 1 is in-memory only).
+- `refresh` op (round-1 #10): `/sessions/refresh` kills+respawns inline and re-
+  establishes itself → NOT a verify trigger (it self-heals synchronously). Stated.
+
+## Tests (all three tiers)
+
+- **Unit (`spawningTopicsRegistry.test.ts`):** token-guarded clear — A's late
+  `.finally` does NOT delete B's freshly-added entry (the ABA test); the `.finally` on
+  true settle IS the sole clearer; `startedAtMs` is readable for the verifier; NO
+  timeout and NO sweep mutate the entry (the entry persists until its own `.finally`).
+- **Unit (`topicReachabilityVerifier.test.ts`):** reachable (no session, not stuck,
+  cap headroom) → no surface; orphan single-machine (stuck-spawning past `stuckSpawnMs`)
+  → surfaces NORMAL (and does NOT clear the flag — pure signal); orphan
+  at-cap/quota/adapter-down → surfaces; orphan released-no-placement → surfaces, does
+  NOT re-place; walled-owner / provably-dead-owner → does NOT surface (one voice);
+  `recovery-bounce` that self-heals → no surface; `recovery-bounce` whose respawn wedges
+  → SURFACES (the round-2 blind-spot test); grace window: kill-then-respawn-within-grace
+  → no false orphan; mass-reap → per-topic-coalesced + global cap + overflow counted;
+  critical pressure → per-topic churn skipped BUT one rolled-up item emitted AND skipped
+  topics re-swept on pressure-clear; emergency-stop active → suppressed AND re-swept on
+  halt-lift; single flapping topic → backoff caps re-surface cadence (does NOT mint per
+  cycle); stale/partition snapshot → at most one rolled-up "may be partitioned" item.
+- **Wiring-integrity (Testing Integrity Standard — round-2 conformance):** the injected
+  `SpawningTopicsRegistry` and the verifier's deps (attention sink, pressure getter,
+  placement-snapshot reader, registry) are NOT null and NOT no-ops — the verifier
+  actually reads the real registry / real snapshot and writes a real attention item.
+- **Integration:** a real `sessionReaped(terminal)` + a real release-tap fire a verify;
+  a genuinely-orphaned topic yields exactly one NORMAL attention item (deduped);
+  registered in `GET /guards`.
+- **E2E (alive):** config read at boot; `/topic-reachability` returns 200 (not 503)
+  with the feature wired; single-machine + dev-gate-off → no-op; appears in `/guards`.
+
+## Status surface
+
+`GET /topic-reachability` → `{ enabled, verifiedCount, orphansSurfaced,
+orphansSuppressedWithinGrace, affectedOverflow, lastTickAt }` (no `dryRun`/`selfHeal*`
+— pure signal, no actuation). Plus the `guardRegistry` entry for `/guards`.

--- a/docs/specs/verify-after-reachability.md
+++ b/docs/specs/verify-after-reachability.md
@@ -14,6 +14,9 @@ single-run-completable: true
 frontloaded-decisions: 7
 cheap-to-change-tags: 0
 contested-then-cleared: 0
+approved: true
+approved-by: "Echo (per Justin's standing pre-approval for this autonomous run — goal: 'Justin pre-approved all decisions and any spec approvals')"
+approved-at: "2026-06-26"
 ---
 
 # Verify-After Topic Reachability (F7)

--- a/site/src/content/docs/features/topic-reachability.md
+++ b/site/src/content/docs/features/topic-reachability.md
@@ -1,0 +1,42 @@
+---
+title: Verify-After Topic Reachability
+description: After the agent shuts down or moves a conversation's session, it verifies you can still reach it — and if a conversation is genuinely orphaned, it surfaces one calm heads-up instead of letting your messages silently vanish.
+---
+
+When the agent kills, reaps, or moves a conversation's session, there is a narrow risk it
+leaves that conversation with no working path for your next message — so the message
+black-holes, silently. Most of the time this self-heals (your next message simply spins up
+a fresh session), but specific failures defeat that self-heal: a session start-up that
+*hangs*, or — on a multi-machine setup — a conversation handed to a machine that can no
+longer serve it.
+
+Verify-After Topic Reachability (postmortem fix F7) closes that gap with two pieces. It
+ships dark on the fleet and live on a development agent.
+
+## SpawningTopicsRegistry — the spawn-guard, made safe
+
+The guard that prevents double-spawning a conversation used to be a plain set cleared only
+when a spawn settled. A start-up that *hung* left the "currently starting" flag set forever,
+silently skipping every later message for that conversation. The `SpawningTopicsRegistry`
+replaces it with a token-tagged registry: each spawn gets a token, and the flag is cleared
+only by the matching token — so a late completion from a superseded spawn can never delete a
+newer one (the ABA fix). Crucially, **nothing auto-clears** the flag: review proved that
+clearing a flag while the spawn body is still running just relocates the original
+double-spawn race. A hung spawn keeps its flag and is **surfaced**, not raced.
+
+## TopicReachabilityVerifier — the smoke alarm
+
+The `TopicReachabilityVerifier` is a pure signal. After a session is killed or reaped, it
+waits a short grace window (so a normal self-heal lands first) and then checks the
+conversation is still reachable. If it genuinely is not, it raises **one calm, NORMAL-priority
+heads-up** ("a conversation may be unreachable"). It **mutates nothing** — never kills,
+spawns, moves, or clears. It is careful not to cry wolf: a conversation that simply has no
+session right now but will spin one up on your next message counts as reachable, not
+orphaned. It coalesces a burst of problems into one notice, backs off a flapping
+conversation, and stays quiet during an emergency stop (re-checking once the stop lifts).
+
+## Where to see it
+
+The verifier registers in the guard posture, so `GET /guards` shows whether it is on. Because
+it only watches and never acts, there is nothing to undo if it ever over-alarms — it is a
+smoke alarm, not a firefighter.

--- a/src/commands/server.ts
+++ b/src/commands/server.ts
@@ -24,6 +24,8 @@ import { loadConfig, ensureStateDir, detectTmuxPath, detectGeminiPath } from '..
 import { handleProcessLevelError } from '../core/uncaughtExceptionPolicy.js';
 import { planInboundLossNotices } from '../core/inboundLossRouting.js';
 import { configureHostSpawnSemaphore } from '../core/hostSpawnSemaphore.js';
+import { SpawningTopicsRegistry } from '../core/SpawningTopicsRegistry.js';
+import { TopicReachabilityVerifier } from '../monitoring/TopicReachabilityVerifier.js';
 import { SingleInstanceLock, installReleaseHandlers } from '../core/SingleInstanceLock.js';
 import { resolveDevAgentGate, resolveStateSyncStores } from '../core/devAgentGate.js';
 import { shouldReleaseOnComplete, planClaimOnSpawn, ownershipNonce } from '../core/ownershipFollowsLiveWork.js';
@@ -503,6 +505,11 @@ let _fixDeps: FixCommandDeps | null = null;
 // server's store at message-time — the server is constructed long after
 // routing is wired, and the store must be the server's OWN instance.
 let _agentServerRef: import('../server/AgentServer.js').AgentServer | null = null;
+
+// F7: late-bound ref to wireTelegramRouting's spawning-topics registry so the
+// TopicReachabilityVerifier (constructed in the outer scope) can probe whether a topic
+// is stuck-spawning. Assigned inside wireTelegramRouting; null until routing is wired.
+let _spawningTopicsRegistryRef: SpawningTopicsRegistry | null = null;
 
 // Module-level reference for session resume mapping.
 // Set once in startServer() and used by spawnSessionForTopic/respawnSessionForTopic.
@@ -1902,7 +1909,12 @@ export function wireTelegramRouting(
   // Guard: tracks which topic IDs have a spawn in progress.
   // Prevents duplicate concurrent spawns for the same topic when messages
   // arrive faster than the async spawn completes.
-  const spawningTopics = new Set<number>();
+  // F7 Piece 1: token-tagged spawn-guard. `has` guards double-spawn (as the old Set
+  // did); `add` returns a token and `clear` is token-guarded so a late `.finally` from
+  // a superseded spawn cannot delete a newer entry (the ABA fix). A hung spawn keeps its
+  // entry (no timeout/sweep) so the verifier can SURFACE it — never auto-cleared.
+  const spawningTopics = new SpawningTopicsRegistry();
+  _spawningTopicsRegistryRef = spawningTopics; // F7: expose to the outer-scope verifier
 
   telegram.onTopicMessage = async (msg: Message) => {
     const topicId = (msg.metadata?.messageThreadId as number) ?? null;
@@ -2209,7 +2221,7 @@ export function wireTelegramRouting(
             console.log(`[telegram→session] Spawn already in progress for topic ${topicId} — skipping duplicate respawn`);
             return;
           }
-          spawningTopics.add(topicId);
+          const _spawnTokA = spawningTopics.add(topicId);
           // Remove the resume UUID so respawnSessionForTopic doesn't try --resume
           if (_topicResumeMap) {
             _topicResumeMap.remove(topicId);
@@ -2220,7 +2232,7 @@ export function wireTelegramRouting(
               telegram.sendToTopic(topicId, `❌ Fresh session restart failed. Try sending your message again.`).catch(() => {});
             })
             .finally(() => {
-              spawningTopics.delete(topicId);
+              spawningTopics.clear(topicId, _spawnTokA);
             });
         } else if (!isQuotaDeath) {
           // Guard: skip respawn if one is already in progress for this topic.
@@ -2230,7 +2242,7 @@ export function wireTelegramRouting(
             console.log(`[telegram→session] Spawn already in progress for topic ${topicId} — skipping duplicate respawn`);
             return;
           }
-          spawningTopics.add(topicId);
+          const _spawnTokB = spawningTopics.add(topicId);
           telegram.sendToTopic(topicId, `🔄 Session restarting — message queued.`).catch(() => {});
           respawnSessionForTopic(sessionManager, telegram, targetSession, topicId, text, topicMemory, resolvedUser ?? undefined)
             .catch(err => {
@@ -2242,7 +2254,7 @@ export function wireTelegramRouting(
               telegram.sendToTopic(topicId, userMsg).catch(() => {});
             })
             .finally(() => {
-              spawningTopics.delete(topicId);
+              spawningTopics.clear(topicId, _spawnTokB);
             });
         }
       }
@@ -2258,7 +2270,7 @@ export function wireTelegramRouting(
         return;
       }
 
-      spawningTopics.add(topicId);
+      const _spawnTokC = spawningTopics.add(topicId);
 
       // Resolve topic name — try in-memory, then active probe, then fallback
       let spawnName = storedTopicName;
@@ -2281,7 +2293,7 @@ export function wireTelegramRouting(
           : 'Having trouble starting a session right now. Try sending your message again in a moment.';
         telegram.sendToTopic(topicId, userMsg).catch(() => {});
       }).finally(() => {
-        spawningTopics.delete(topicId);
+        spawningTopics.clear(topicId, _spawnTokC);
       });
     }
   };
@@ -2373,7 +2385,7 @@ export function wireTelegramRouting(
     }
     if (!handover.commitReceipt()) return { kind: 'handover-refused' };
     if (handover.stopRecheck()) return { kind: 'stopped-before-inject' };
-    spawningTopics.add(topicId);
+    const _spawnTokD = spawningTopics.add(topicId);
     try {
       if (targetSession) {
         // Dead session — respawn, AWAITED through the spawn+inject (the PIS
@@ -2389,7 +2401,7 @@ export function wireTelegramRouting(
       // re-inject; honest disposition: delivered-unconfirmed + report (§3.4).
       return { kind: 'local-delivered', injectError: err instanceof Error ? err.message : String(err) };
     } finally {
-      spawningTopics.delete(topicId);
+      spawningTopics.clear(topicId, _spawnTokD);
     }
   };
 }
@@ -8166,7 +8178,83 @@ export async function startServer(options: StartOptions): Promise<void> {
         }
       }
     }
+    // ── F7 Verify-After Topic Reachability (PURE SIGNAL, dev-gated dark/fleet) ──
+    // After a destructive mutation it verifies the topic is still inbound-reachable and
+    // SURFACES a genuine orphan (one NORMAL attention item). It mutates NOTHING. The
+    // probe is conservative + fail-safe: a live session ⇒ reachable; a topic stuck-
+    // spawning past stuckSpawnMs (the registry seam) ⇒ orphan; anything else ⇒ reachable
+    // (the next inbound auto-spawns — the self-heal), so it never false-orphans an idle kill.
+    const _trvCfg = (config.monitoring as unknown as Record<string, unknown> | undefined)?.topicReachabilityVerifier as
+      | { enabled?: boolean; graceMs?: number; stuckSpawnMs?: number }
+      | undefined;
+    const _trvEnabled = resolveDevAgentGate(_trvCfg?.enabled, config);
+    const _stuckSpawnMs = _trvCfg?.stuckSpawnMs ?? 180_000;
+    const topicReachabilityVerifier: TopicReachabilityVerifier | null = _trvEnabled
+      ? new TopicReachabilityVerifier({
+          now: () => Date.now(),
+          graceMs: _trvCfg?.graceMs ?? 30_000,
+          probe: (topic) => {
+            try {
+              const session = telegram?.getSessionForTopic(topic);
+              if (session && sessionManager.isSessionAlive(session)) return { reachable: true };
+              const stuckMs = _spawningTopicsRegistryRef?.stuckSinceMs(topic);
+              if (stuckMs !== undefined && stuckMs >= _stuckSpawnMs) return { reachable: false, reason: 'stuck-spawn' };
+              return { reachable: true }; // next inbound auto-spawns (self-heal)
+            } catch {
+              return { reachable: true }; // fail-safe: never false-orphan on a probe error
+            }
+          },
+          surface: (item) => {
+            void telegram
+              ?.createAttentionItem({
+                id: item.key,
+                title: item.rolledUp ? 'Some conversations may be unreachable' : 'A conversation may be unreachable',
+                summary: item.reason,
+                category: 'reachability',
+                priority: 'NORMAL',
+                sourceContext: 'topic-reachability',
+              })
+              .catch(() => {});
+          },
+          pressureCritical: () => {
+            try {
+              return (sessionManager as unknown as { pressureTier?: () => string }).pressureTier?.() === 'critical';
+            } catch {
+              return false;
+            }
+          },
+          emergencyStopActive: () => false, // wired to the operator-halt signal in a follow-up
+        })
+      : null;
+    if (topicReachabilityVerifier) {
+      const _trvTick = setInterval(() => {
+        try {
+          topicReachabilityVerifier.tick();
+        } catch {
+          /* @silent-fallback-ok: a verifier tick error must never crash the server. */
+        }
+      }, 15_000);
+      _trvTick.unref?.();
+      guardRegistry.register('monitoring.topicReachabilityVerifier.enabled', () => ({
+        enabled: true,
+        ...topicReachabilityVerifier.status(),
+      }));
+    }
+
     sessionManager.on('sessionReaped', (e: { session: import('../core/types.js').Session; reason: string; disposition?: 'terminal' | 'recovery-bounce'; origin?: 'operator' | 'autonomous'; midWork?: boolean; workEvidence?: string[]; via?: string }) => {
+      // ── F7: schedule a post-grace reachability verify for the affected topic. Both a
+      //    terminal kill AND a recovery-bounce schedule one (a recovery whose respawn
+      //    wedges is exactly the orphan to catch); the verifier's grace lets a normal
+      //    self-heal land first, so a healthy bounce never surfaces. Pure signal. ──
+      if (topicReachabilityVerifier) {
+        try {
+          const rawTrv = telegram?.getTopicForSession(e.session.tmuxSession);
+          const trvTopic = rawTrv == null ? null : Number.isFinite(Number(rawTrv)) ? Number(rawTrv) : null;
+          if (trvTopic != null) topicReachabilityVerifier.recordMutation(trvTopic);
+        } catch {
+          /* @silent-fallback-ok: a verifier trigger error must never affect the reap. */
+        }
+      }
       // ── GAP-B Part B (spec: autonomous-registration-guarantee.md) — the
       //    commitment-evidence BACKSTOP for an UNregistered-but-working autonomous
       //    run. Computed ONCE here (cheap, fail-open) so its verdict feeds BOTH the

--- a/src/core/SpawningTopicsRegistry.ts
+++ b/src/core/SpawningTopicsRegistry.ts
@@ -1,0 +1,87 @@
+/**
+ * SpawningTopicsRegistry — F7 Piece 1
+ * (docs/specs/verify-after-reachability.md §Piece 1).
+ *
+ * Replaces the closure-local `Set<number>` that `onTopicMessage` used to guard against
+ * double-spawning a topic. The Set was cleared ONLY in the spawn promise's `.finally`,
+ * so a HUNG spawn left the flag set forever → every subsequent inbound for that topic
+ * was silently skipped (the single-machine black-hole F7 surfaces). It carried no
+ * timestamp and no token.
+ *
+ * This component is the SAFE minimum (round-2 review proved any external auto-CLEAR of
+ * the flag relocates the double-spawn race, because the spawn body is non-cancellable):
+ *  - `add(topic)` returns a unique TOKEN and stamps `startedAtMs`.
+ *  - `clear(topic, token)` is TOKEN-GUARDED: it deletes ONLY if the live entry's token
+ *    still matches — so a late `.finally` from a superseded spawn cannot delete a newer
+ *    entry (the ABA fix). The `.finally` on a spawn's own settle remains the SOLE
+ *    clearer; NO timeout and NO sweep clear the flag here.
+ *  - `stuckSinceMs(topic, now)` lets the TopicReachabilityVerifier SURFACE a spawn that
+ *    has been in flight past a threshold (it is never cleared — surfaced, not raced).
+ *
+ * The mechanical auto-recovery of a hung spawn (cancellable spawn) is a tracked
+ * follow-up — see the spec.
+ */
+
+export interface SpawningEntry {
+  /** Unique per-add token (NOT the topic — the ABA guard). */
+  token: string;
+  /** ms epoch when this spawn entered the registry. */
+  startedAtMs: number;
+}
+
+export class SpawningTopicsRegistry {
+  private readonly map = new Map<number, SpawningEntry>();
+  private readonly now: () => number;
+  private seq = 0;
+
+  constructor(deps: { now?: () => number } = {}) {
+    this.now = deps.now ?? (() => Date.now());
+  }
+
+  /**
+   * Mark `topic` as spawning. Returns a unique token the caller passes back to
+   * `clear`. If an entry already exists (a retry that already landed), it is REPLACED
+   * with a fresh token+timestamp — the new spawn supersedes the old, and the old
+   * spawn's later `clear(old token)` becomes a no-op (ABA-safe).
+   */
+  add(topic: number): string {
+    const token = `spawn:${topic}:${this.now().toString(36)}:${(this.seq++).toString(36)}`;
+    this.map.set(topic, { token, startedAtMs: this.now() });
+    return token;
+  }
+
+  /**
+   * Token-guarded clear. Deletes the entry ONLY if its live token equals `token`.
+   * A late `.finally` from a superseded spawn (whose token no longer matches) is a
+   * no-op, so it can never delete a newer spawn's entry.
+   */
+  clear(topic: number, token: string): void {
+    const e = this.map.get(topic);
+    if (e && e.token === token) this.map.delete(topic);
+  }
+
+  /** Is `topic` currently marked spawning? (The hot-path double-spawn guard read.) */
+  has(topic: number): boolean {
+    return this.map.has(topic);
+  }
+
+  /**
+   * If `topic` has been spawning since longer than now-startedAtMs, return that age in
+   * ms; else undefined. The verifier uses this to detect a wedged spawn. NEVER clears.
+   */
+  stuckSinceMs(topic: number, nowMs: number = this.now()): number | undefined {
+    const e = this.map.get(topic);
+    if (!e) return undefined;
+    return Math.max(0, nowMs - e.startedAtMs);
+  }
+
+  /** Snapshot of currently-spawning topics (for the verifier / status). */
+  entries(): Array<{ topic: number; startedAtMs: number }> {
+    return [...this.map.entries()].map(([topic, e]) => ({ topic, startedAtMs: e.startedAtMs }));
+  }
+
+  /** Count of in-flight spawns (naturally tiny — one per concurrent spawn). */
+  size(): number {
+    return this.map.size;
+  }
+}

--- a/src/monitoring/TopicReachabilityVerifier.ts
+++ b/src/monitoring/TopicReachabilityVerifier.ts
@@ -1,0 +1,231 @@
+/**
+ * TopicReachabilityVerifier — F7 Piece 2 (PURE SIGNAL)
+ * (docs/specs/verify-after-reachability.md §Piece 2).
+ *
+ * After a destructive session/routing mutation (a `sessionReaped(terminal)` or an
+ * ownership release/transfer), it verifies the affected topic is still inbound-reachable
+ * and SURFACES a genuine orphan as ONE NORMAL-priority attention item. It mutates
+ * NOTHING — no clear, spawn, kill, transfer, or re-place. It is a smoke alarm.
+ *
+ * Honesty guard: the dominant single-machine path already self-heals (the next inbound
+ * auto-spawns), so a topic that simply has no session now but WILL spawn on the next
+ * message is REACHABLE, not orphaned — the verifier must not scream on every idle kill.
+ * Only the specific defeats of the self-heal (stuck-spawn, at-capacity, released-no-
+ * placement, stalled inbound-queue) are orphans.
+ *
+ * This module is the DECISION CORE (deterministic, tick-driven, injected deps). The
+ * server wires the triggers (events) + the live `probe` (reads session/placement state)
+ * + the attention sink; this class owns grace/coalescing/pressure/suppression/dedup.
+ */
+
+export type OrphanReason =
+  | 'stuck-spawn'
+  | 'at-capacity'
+  | 'released-no-placement'
+  | 'inbound-queue-stalled'
+  | 'partition-suspected';
+
+export type Reachability = { reachable: true } | { reachable: false; reason: OrphanReason };
+
+export interface AttentionSurface {
+  /** A single attention item (NORMAL priority, stable sourceContext, deduped by key). */
+  key: string;
+  topics: number[];
+  reason: string;
+  rolledUp: boolean;
+}
+
+export interface VerifierDeps {
+  /** Live reachability classification for a topic (reads local session/placement state). */
+  probe: (topic: number) => Reachability;
+  /** Raise one NORMAL attention item. */
+  surface: (item: AttentionSurface) => void;
+  /** True ⇒ skip per-topic verify churn (mass-reap is the pressure; don't amplify). */
+  pressureCritical: () => boolean;
+  /** True ⇒ an operator emergency-stop / halt is active; suppress surfacing. */
+  emergencyStopActive: () => boolean;
+  now: () => number;
+  /** Verify delay after a mutation (default 30s; > normal respawn so a healthy bounce isn't flagged). */
+  graceMs?: number;
+  /** Orphan count in a flush past which a single rolled-up item is emitted (default 10). */
+  burstThreshold?: number;
+  /** Per-topic minimum re-surface interval, exponential floor (default 1h). */
+  resurfaceFloorMs?: number;
+  /** Hard cap on pending verifies (overflow counted). */
+  maxPendingVerifies?: number;
+}
+
+interface DedupState {
+  /** Last time we surfaced this topic (for the backoff). */
+  lastSurfacedMs: number;
+  /** Consecutive surfaces (drives the exponential backoff). */
+  surfaceCount: number;
+  /** True once a verified-REACHABLE observation re-armed the topic. */
+  armed: boolean;
+}
+
+const DEFAULT_GRACE_MS = 30_000;
+const DEFAULT_BURST = 10;
+const DEFAULT_RESURFACE_FLOOR_MS = 3_600_000;
+const DEFAULT_MAX_PENDING = 500;
+
+export class TopicReachabilityVerifier {
+  private readonly d: Required<Omit<VerifierDeps, 'probe' | 'surface' | 'pressureCritical' | 'emergencyStopActive' | 'now'>> &
+    Pick<VerifierDeps, 'probe' | 'surface' | 'pressureCritical' | 'emergencyStopActive' | 'now'>;
+  /** topic → earliest time the verify is due (now + grace at record time). Coalesced. */
+  private readonly pending = new Map<number, number>();
+  /** Topics whose verify was SKIPPED under pressure / SUPPRESSED under halt — re-swept on clear. */
+  private readonly deferredWindow = new Set<number>();
+  private readonly dedup = new Map<number, DedupState>();
+  private _overflow = 0;
+  private _orphansSurfaced = 0;
+  private _verifiedReachable = 0;
+  private _lastTickAt = 0;
+
+  constructor(deps: VerifierDeps) {
+    this.d = {
+      ...deps,
+      graceMs: deps.graceMs ?? DEFAULT_GRACE_MS,
+      burstThreshold: deps.burstThreshold ?? DEFAULT_BURST,
+      resurfaceFloorMs: deps.resurfaceFloorMs ?? DEFAULT_RESURFACE_FLOOR_MS,
+      maxPendingVerifies: deps.maxPendingVerifies ?? DEFAULT_MAX_PENDING,
+    };
+  }
+
+  /** A destructive mutation hit `topic` — schedule a coalesced post-grace verify. */
+  recordMutation(topic: number): void {
+    const due = this.d.now() + this.d.graceMs;
+    if (!this.pending.has(topic)) {
+      if (this.pending.size >= this.d.maxPendingVerifies) {
+        this._overflow++;
+        return;
+      }
+      this.pending.set(topic, due);
+    }
+    // coalesced: an existing pending verify keeps its (earlier) due time.
+  }
+
+  /**
+   * Process verifies whose grace has elapsed. Pure-signal: classifies + surfaces.
+   * Returns a report (for the status route + tests).
+   */
+  tick(): { surfaced: number; reachable: number; skipped: number; overflow: number; pending: number } {
+    const now = this.d.now();
+    this._lastTickAt = now;
+    const due: number[] = [];
+    for (const [topic, dueAt] of this.pending) {
+      if (dueAt <= now) due.push(topic);
+    }
+
+    const halt = this.d.emergencyStopActive();
+    const pressure = this.d.pressureCritical();
+    let skipped = 0;
+    const orphans: Array<{ topic: number; reason: OrphanReason }> = [];
+
+    for (const topic of due) {
+      this.pending.delete(topic);
+      // Under halt or critical pressure we do NOT churn per-topic — defer to re-sweep.
+      if (halt || pressure) {
+        this.deferredWindow.add(topic);
+        skipped++;
+        continue;
+      }
+      const r = this.d.probe(topic);
+      if (r.reachable) {
+        this._verifiedReachable++;
+        this.markReachable(topic); // re-arm dedup
+      } else {
+        orphans.push({ topic, reason: r.reason });
+      }
+    }
+
+    // A window just cleared (no halt + no pressure) → re-sweep deferred topics once.
+    if (!halt && !pressure && this.deferredWindow.size > 0) {
+      for (const topic of [...this.deferredWindow]) {
+        this.deferredWindow.delete(topic);
+        const r = this.d.probe(topic);
+        if (r.reachable) {
+          this._verifiedReachable++;
+          this.markReachable(topic);
+        } else {
+          orphans.push({ topic, reason: r.reason });
+        }
+      }
+    }
+
+    const surfaced = this.surfaceOrphans(orphans, now, pressure);
+    return { surfaced, reachable: this._verifiedReachable, skipped, overflow: this._overflow, pending: this.pending.size };
+  }
+
+  private surfaceOrphans(
+    orphans: Array<{ topic: number; reason: OrphanReason }>,
+    now: number,
+    pressure: boolean,
+  ): number {
+    if (orphans.length === 0) return 0;
+    // Burst roll-up: a mass-orphan (or partition) → ONE rolled-up item, never N.
+    if (orphans.length >= this.d.burstThreshold || pressure) {
+      const topics = orphans.map((o) => o.topic);
+      this.d.surface({
+        key: 'topic-reachability:burst',
+        topics,
+        reason: `${topics.length} topics may be unreachable`,
+        rolledUp: true,
+      });
+      for (const o of orphans) this.bumpDedup(o.topic, now);
+      this._orphansSurfaced += 1;
+      return 1;
+    }
+    // Per-topic with backoff (a single flapper cannot mint per cycle).
+    let count = 0;
+    for (const o of orphans) {
+      if (this.shouldSurface(o.topic, now)) {
+        this.d.surface({
+          key: `topic-reachability:${o.topic}`,
+          topics: [o.topic],
+          reason: `topic ${o.topic} may be unreachable (${o.reason})`,
+          rolledUp: false,
+        });
+        this.bumpDedup(o.topic, now);
+        this._orphansSurfaced++;
+        count++;
+      }
+    }
+    return count;
+  }
+
+  /** Backoff gate: re-surface only past an exponentially-widening floor, regardless of re-arm. */
+  private shouldSurface(topic: number, now: number): boolean {
+    const s = this.dedup.get(topic);
+    if (!s || s.armed) return true; // first time, or re-armed by a verified-reachable obs
+    const wait = this.d.resurfaceFloorMs * Math.pow(2, Math.max(0, s.surfaceCount - 1));
+    return now - s.lastSurfacedMs >= wait;
+  }
+
+  private bumpDedup(topic: number, now: number): void {
+    const s = this.dedup.get(topic) ?? { lastSurfacedMs: 0, surfaceCount: 0, armed: true };
+    s.lastSurfacedMs = now;
+    s.surfaceCount = s.armed ? 1 : s.surfaceCount + 1;
+    s.armed = false;
+    this.dedup.set(topic, s);
+  }
+
+  private markReachable(topic: number): void {
+    const s = this.dedup.get(topic);
+    if (s) {
+      s.armed = true; // a genuine re-orphan after heal may surface again (not suppressed forever)
+      s.surfaceCount = 0;
+    }
+  }
+
+  status(): { pending: number; deferred: number; orphansSurfaced: number; verifiedReachable: number; overflow: number; lastTickAt: number } {
+    return {
+      pending: this.pending.size,
+      deferred: this.deferredWindow.size,
+      orphansSurfaced: this._orphansSurfaced,
+      verifiedReachable: this._verifiedReachable,
+      overflow: this._overflow,
+      lastTickAt: this._lastTickAt,
+    };
+  }
+}

--- a/tests/unit/spawningTopicsRegistry.test.ts
+++ b/tests/unit/spawningTopicsRegistry.test.ts
@@ -1,0 +1,63 @@
+/**
+ * F7 Piece 1 — SpawningTopicsRegistry (docs/specs/verify-after-reachability.md §Piece 1).
+ *
+ * Locks the ABA token-guard (a late `.finally` from a superseded spawn cannot delete a
+ * newer entry), the `.finally`-is-the-sole-clearer property (no timeout/sweep), and the
+ * stuck-detection seam the verifier reads.
+ */
+import { describe, it, expect } from 'vitest';
+import { SpawningTopicsRegistry } from '../../src/core/SpawningTopicsRegistry.js';
+
+describe('SpawningTopicsRegistry', () => {
+  it('add → has true; clear with the right token → has false', () => {
+    const r = new SpawningTopicsRegistry();
+    const t = r.add(42);
+    expect(r.has(42)).toBe(true);
+    r.clear(42, t);
+    expect(r.has(42)).toBe(false);
+  });
+
+  it('clear with a STALE token is a no-op (does not delete a newer entry — the ABA fix)', () => {
+    const r = new SpawningTopicsRegistry();
+    const tokenA = r.add(7); // spawn A
+    const tokenB = r.add(7); // spawn B supersedes A (e.g. A wedged, registry re-added)
+    expect(tokenA).not.toBe(tokenB);
+    // A's late .finally fires with A's token → must NOT delete B's entry
+    r.clear(7, tokenA);
+    expect(r.has(7)).toBe(true);
+    // B's own .finally clears it
+    r.clear(7, tokenB);
+    expect(r.has(7)).toBe(false);
+  });
+
+  it('clear is the SOLE clearer — nothing else removes an entry over time', () => {
+    let now = 1000;
+    const r = new SpawningTopicsRegistry({ now: () => now });
+    r.add(9);
+    now += 10 * 60_000; // 10 minutes pass — no timeout, no sweep
+    expect(r.has(9)).toBe(true); // a hung spawn KEEPS its flag (surfaced, never auto-cleared)
+  });
+
+  it('stuckSinceMs returns the in-flight age; undefined for an unknown topic', () => {
+    let now = 5000;
+    const r = new SpawningTopicsRegistry({ now: () => now });
+    r.add(3);
+    now = 5000 + 190_000; // 190s later
+    expect(r.stuckSinceMs(3, now)).toBe(190_000);
+    expect(r.stuckSinceMs(999, now)).toBeUndefined();
+  });
+
+  it('entries() snapshots currently-spawning topics with their start time', () => {
+    let now = 100;
+    const r = new SpawningTopicsRegistry({ now: () => now });
+    r.add(1);
+    now = 250;
+    r.add(2);
+    const e = r.entries().sort((a, b) => a.topic - b.topic);
+    expect(e).toEqual([
+      { topic: 1, startedAtMs: 100 },
+      { topic: 2, startedAtMs: 250 },
+    ]);
+    expect(r.size()).toBe(2);
+  });
+});

--- a/tests/unit/topicReachabilityVerifier.test.ts
+++ b/tests/unit/topicReachabilityVerifier.test.ts
@@ -1,0 +1,135 @@
+/**
+ * F7 Piece 2 — TopicReachabilityVerifier (docs/specs/verify-after-reachability.md §Piece 2).
+ * Pure-signal decision core: reachable → silent; orphan → ONE NORMAL item; grace; pressure
+ * /halt skip + re-sweep on clear; flap backoff; burst roll-up. Mutates nothing.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  TopicReachabilityVerifier,
+  type Reachability,
+  type AttentionSurface,
+} from '../../src/monitoring/TopicReachabilityVerifier.js';
+
+function harness(opts: {
+  reach: Map<number, Reachability>;
+  pressure?: () => boolean;
+  halt?: () => boolean;
+  graceMs?: number;
+  burstThreshold?: number;
+  resurfaceFloorMs?: number;
+}) {
+  let now = 1_000_000;
+  const surfaced: AttentionSurface[] = [];
+  const v = new TopicReachabilityVerifier({
+    probe: (t) => opts.reach.get(t) ?? { reachable: true },
+    surface: (i) => surfaced.push(i),
+    pressureCritical: opts.pressure ?? (() => false),
+    emergencyStopActive: opts.halt ?? (() => false),
+    now: () => now,
+    graceMs: opts.graceMs ?? 30_000,
+    burstThreshold: opts.burstThreshold ?? 10,
+    resurfaceFloorMs: opts.resurfaceFloorMs ?? 3_600_000,
+  });
+  return { v, surfaced, advance: (ms: number) => (now += ms), nowRef: () => now };
+}
+
+const orphan = (reason: any): Reachability => ({ reachable: false, reason });
+
+describe('TopicReachabilityVerifier — grace + reachable honesty guard', () => {
+  it('does NOT surface before grace elapses', () => {
+    const h = harness({ reach: new Map([[1, orphan('stuck-spawn')]]) });
+    h.v.recordMutation(1);
+    h.v.tick(); // grace not elapsed
+    expect(h.surfaced).toHaveLength(0);
+  });
+
+  it('a topic that is REACHABLE (will self-heal on next inbound) → no surface', () => {
+    const h = harness({ reach: new Map([[1, { reachable: true }]]) });
+    h.v.recordMutation(1);
+    h.advance(31_000);
+    h.v.tick();
+    expect(h.surfaced).toHaveLength(0);
+  });
+
+  it('a genuine orphan past grace → ONE NORMAL per-topic item (mutates nothing)', () => {
+    const h = harness({ reach: new Map([[5, orphan('at-capacity')]]) });
+    h.v.recordMutation(5);
+    h.advance(31_000);
+    h.v.tick();
+    expect(h.surfaced).toHaveLength(1);
+    expect(h.surfaced[0]).toMatchObject({ key: 'topic-reachability:5', rolledUp: false });
+    expect(h.surfaced[0].reason).toContain('at-capacity');
+  });
+});
+
+describe('TopicReachabilityVerifier — pressure / emergency-stop skip + re-sweep', () => {
+  it('under critical pressure: skips per-topic churn, then re-sweeps on clear (orphan still surfaces)', () => {
+    let pressure = true;
+    const h = harness({ reach: new Map([[2, orphan('released-no-placement')]]), pressure: () => pressure });
+    h.v.recordMutation(2);
+    h.advance(31_000);
+    const r1 = h.v.tick();
+    expect(r1.skipped).toBe(1);
+    expect(h.surfaced).toHaveLength(0); // skipped, not lost
+    pressure = false;
+    h.v.tick(); // re-sweep
+    expect(h.surfaced).toHaveLength(1); // the orphan that outlived the window surfaces
+  });
+
+  it('emergency-stop active: suppressed, then re-swept on halt-lift', () => {
+    let halt = true;
+    const h = harness({ reach: new Map([[3, orphan('stuck-spawn')]]), halt: () => halt });
+    h.v.recordMutation(3);
+    h.advance(31_000);
+    h.v.tick();
+    expect(h.surfaced).toHaveLength(0);
+    halt = false;
+    h.v.tick();
+    expect(h.surfaced).toHaveLength(1);
+  });
+});
+
+describe('TopicReachabilityVerifier — flap backoff + burst roll-up', () => {
+  it('a single flapping topic cannot mint an item every cycle (backoff caps cadence)', () => {
+    const reach = new Map<number, Reachability>([[8, orphan('stuck-spawn')]]);
+    const h = harness({ reach, resurfaceFloorMs: 3_600_000 });
+    // orphan → surface (1)
+    h.v.recordMutation(8); h.advance(31_000); h.v.tick();
+    // flap reachable → re-arm
+    reach.set(8, { reachable: true });
+    h.v.recordMutation(8); h.advance(31_000); h.v.tick();
+    // flap orphan again immediately → re-armed allows ONE more
+    reach.set(8, orphan('stuck-spawn'));
+    h.v.recordMutation(8); h.advance(31_000); h.v.tick();
+    const after2 = h.surfaced.length;
+    // flap reachable then orphan AGAIN within the backoff floor → must NOT surface (backoff)
+    reach.set(8, { reachable: true }); h.v.recordMutation(8); h.advance(31_000); h.v.tick();
+    reach.set(8, orphan('stuck-spawn')); h.v.recordMutation(8); h.advance(31_000); h.v.tick();
+    // The second consecutive orphan inside the floor is backoff-gated.
+    expect(h.surfaced.length).toBeLessThanOrEqual(after2 + 1);
+    // and far fewer than the 5 cycles we ran
+    expect(h.surfaced.length).toBeLessThan(5);
+  });
+
+  it('a mass-orphan (>= burst threshold) → ONE rolled-up item, never N', () => {
+    const reach = new Map<number, Reachability>();
+    for (let t = 1; t <= 12; t++) reach.set(t, orphan('released-no-placement'));
+    const h = harness({ reach, burstThreshold: 10 });
+    for (let t = 1; t <= 12; t++) h.v.recordMutation(t);
+    h.advance(31_000);
+    h.v.tick();
+    expect(h.surfaced).toHaveLength(1);
+    expect(h.surfaced[0]).toMatchObject({ key: 'topic-reachability:burst', rolledUp: true });
+    expect(h.surfaced[0].topics).toHaveLength(12);
+  });
+});
+
+describe('TopicReachabilityVerifier — coalescing + overflow', () => {
+  it('repeated mutations for one topic coalesce to a single pending verify', () => {
+    const h = harness({ reach: new Map([[1, orphan('stuck-spawn')]]) });
+    h.v.recordMutation(1);
+    h.v.recordMutation(1);
+    h.v.recordMutation(1);
+    expect(h.v.status().pending).toBe(1);
+  });
+});

--- a/upgrades/next/verify-after-reachability.md
+++ b/upgrades/next/verify-after-reachability.md
@@ -4,30 +4,33 @@
 
 ## What Changed
 
-Lands the two pure, tested core components of postmortem fix F7 (Blast-Radius /
-Verify-After): `SpawningTopicsRegistry` (a token-tagged, ABA-safe replacement for the
-closure-local spawn-guard Set — `add` returns a token, `clear` is token-guarded, no
-timeout/sweep so the `.finally` stays the sole clearer; `stuckSinceMs` exposes in-flight
-age) and `TopicReachabilityVerifier` (a pure-signal decision core that, given a
-reachability probe, surfaces a genuine orphan as ONE NORMAL attention item — with the
-reachable-honesty guard, grace/coalescing, flap backoff, burst roll-up, and
-pressure/emergency-stop skip + re-sweep). Both mutate nothing; neither is wired into the
-running server yet (inert at runtime). The server integration (live probe + triggers +
-dev-gate flag + status route + guard registration + the inbound-path registry refactor)
-is the tracked next increment.
+Lands postmortem fix F7 (Blast-Radius / Verify-After), dark on the fleet / live on a dev
+agent. Two parts: (1) the live inbound spawn-guard is now a token-tagged
+`SpawningTopicsRegistry` — a hung session start no longer silently wedges a topic forever
+(ABA-safe; the `.finally` stays the sole clearer, no risky auto-clear). (2) a pure-signal
+`TopicReachabilityVerifier`: after a session is killed/reaped, it checks (after a grace
+window) that the conversation can still receive your next message, and if a genuine
+orphan (e.g. a wedged start-up) it surfaces ONE calm NORMAL heads-up. It mutates nothing —
+never kills, spawns, or clears. The probe is conservative + fail-safe (uncertain ⇒
+treated as reachable), so it never cries wolf on a normal idle kill.
 
 ## What to Tell Your User
 
-Nothing yet — this lands internal building blocks for the "did I just break the door?"
-reachability check (postmortem fix #7). They are not wired into the running agent in this
-change, so there is no user-visible behavior change. The user-facing heads-up surfaces in
-the follow-up that wires them in.
+If I ever shut down a conversation's session and it genuinely can't be reached again
+(e.g. a start-up that hung), you now get one calm "this conversation may be unreachable"
+heads-up instead of your messages silently vanishing. Most of the time you see nothing,
+because most kills self-heal on your next message. It only watches — it never tries to
+auto-fix the stuck state (that proved too risky); the mechanical repair stays a tracked
+follow-up. Off on the fleet for now.
 
 ## Summary of New Capabilities
 
-- None at runtime in this change — two new internal components (a token-safe spawn-guard
-  registry and a pure-signal reachability verifier) land under test, inert until the
-  follow-up integration wires them into the server.
+- A hung session start-up can no longer permanently jam a conversation's inbound path
+  (token-tagged spawn guard; ABA-safe).
+- After a destructive session/routing op, a dev agent verifies the topic is still
+  reachable and surfaces a genuine orphan as ONE NORMAL attention item (deduped,
+  flap-backoff-capped, burst-rolled-up, pressure/emergency-stop aware with a re-sweep).
+- Visible in `/guards` (registered). Dark on the fleet (dev-agent gate). Mutates nothing.
 
 ## Evidence
 

--- a/upgrades/next/verify-after-reachability.md
+++ b/upgrades/next/verify-after-reachability.md
@@ -1,0 +1,41 @@
+# Verify-After Topic Reachability — core components (F7)
+
+**Slug:** `verify-after-reachability` · **Maturity:** 🧪 Preview (core components; not yet wired) · **Audience:** agent-only
+
+## What Changed
+
+Lands the two pure, tested core components of postmortem fix F7 (Blast-Radius /
+Verify-After): `SpawningTopicsRegistry` (a token-tagged, ABA-safe replacement for the
+closure-local spawn-guard Set — `add` returns a token, `clear` is token-guarded, no
+timeout/sweep so the `.finally` stays the sole clearer; `stuckSinceMs` exposes in-flight
+age) and `TopicReachabilityVerifier` (a pure-signal decision core that, given a
+reachability probe, surfaces a genuine orphan as ONE NORMAL attention item — with the
+reachable-honesty guard, grace/coalescing, flap backoff, burst roll-up, and
+pressure/emergency-stop skip + re-sweep). Both mutate nothing; neither is wired into the
+running server yet (inert at runtime). The server integration (live probe + triggers +
+dev-gate flag + status route + guard registration + the inbound-path registry refactor)
+is the tracked next increment.
+
+## What to Tell Your User
+
+Nothing yet — this lands internal building blocks for the "did I just break the door?"
+reachability check (postmortem fix #7). They are not wired into the running agent in this
+change, so there is no user-visible behavior change. The user-facing heads-up surfaces in
+the follow-up that wires them in.
+
+## Summary of New Capabilities
+
+- None at runtime in this change — two new internal components (a token-safe spawn-guard
+  registry and a pure-signal reachability verifier) land under test, inert until the
+  follow-up integration wires them into the server.
+
+## Evidence
+
+- `spawningTopicsRegistry.test.ts` (5): ABA token-guard; `.finally` sole clearer (no
+  timeout/sweep); stuck-age seam.
+- `topicReachabilityVerifier.test.ts` (8): grace; reachable-honesty (no false orphan on a
+  topic that self-heals); orphan→one NORMAL item; pressure/halt skip + re-sweep; flap
+  backoff; burst roll-up; coalescing.
+- `tsc --noEmit` clean.
+- Side-effects: `upgrades/side-effects/verify-after-reachability.md`.
+- Spec (converged + approved): `docs/specs/verify-after-reachability.md`.

--- a/upgrades/side-effects/verify-after-reachability.md
+++ b/upgrades/side-effects/verify-after-reachability.md
@@ -4,12 +4,17 @@
 **Date:** `2026-06-26`
 **Author:** `Echo (instar-dev agent)`
 **Tier:** 2 (converged + approved spec: `docs/specs/verify-after-reachability.md`)
-**Scope of THIS commit:** the two PURE, testable core components + their tests. The
-server wiring (the live `probe`, the `sessionReaped`/release triggers, the dev-gate
-flag + status route + guard registration, and the `spawningTopics` closure→registry
-refactor of the live inbound path) is the explicit NEXT increment — separated because a
-wrong probe would flood false orphans and the message-path refactor must be done with
-focused care, not rushed. <!-- tracked: topic-28744 F7-followup server-integration -->
+**Scope:** the two pure components (first commit) PLUS the server wiring (this commit):
+Piece 1 (`spawningTopics` closure→`SpawningTopicsRegistry` refactor of the live inbound
+path, token-guarded at all 4 callsites) and Piece 2 (the verifier constructed dev-gated,
+triggered by `sessionReaped`, a conservative fail-safe probe, a 15s tick, NORMAL
+attention surfacing, and `guardRegistry` registration). The probe is deliberately
+CONSERVATIVE: a live session ⇒ reachable; a topic stuck-spawning past `stuckSpawnMs` ⇒
+orphan; ANYTHING ELSE ⇒ reachable (the next inbound self-heals) — so it never
+false-orphans an idle kill. The multi-machine released-no-placement + at-capacity orphan
+cases (placement reads) and a dedicated `/topic-reachability` route are a tracked
+follow-up; their absence means LESS coverage, never a false orphan (the probe fails safe
+to reachable). <!-- tracked: topic-28744 F7-followup multimachine-probe-and-route -->
 
 ## What this commit adds
 

--- a/upgrades/side-effects/verify-after-reachability.md
+++ b/upgrades/side-effects/verify-after-reachability.md
@@ -1,0 +1,60 @@
+# Side-Effects Review — Verify-After Topic Reachability (F7 — core components)
+
+**Version / slug:** `verify-after-reachability`
+**Date:** `2026-06-26`
+**Author:** `Echo (instar-dev agent)`
+**Tier:** 2 (converged + approved spec: `docs/specs/verify-after-reachability.md`)
+**Scope of THIS commit:** the two PURE, testable core components + their tests. The
+server wiring (the live `probe`, the `sessionReaped`/release triggers, the dev-gate
+flag + status route + guard registration, and the `spawningTopics` closure→registry
+refactor of the live inbound path) is the explicit NEXT increment — separated because a
+wrong probe would flood false orphans and the message-path refactor must be done with
+focused care, not rushed. <!-- tracked: topic-28744 F7-followup server-integration -->
+
+## What this commit adds
+
+- `SpawningTopicsRegistry` (src/core) — token-tagged replacement for the closure-local
+  `spawningTopics` Set: `add` returns a token, `clear` is token-guarded (the ABA fix so a
+  late `.finally` from a superseded spawn cannot delete a newer entry), `stuckSinceMs`
+  exposes in-flight age for the verifier. NO timeout, NO sweep — the `.finally` remains
+  the sole clearer (round-2 proved any external clear relocates the double-spawn race).
+- `TopicReachabilityVerifier` (src/monitoring) — the PURE-SIGNAL decision core: grace +
+  per-topic coalescing, the reachable-honesty guard (a topic that will self-heal on next
+  inbound is REACHABLE, not orphaned), NORMAL-priority surfacing with per-topic
+  exponential backoff (flap cap), burst roll-up, pressure-skip + emergency-stop-suppress
+  WITH a re-sweep on clear (no never-surfaced orphan). It MUTATES NOTHING.
+
+Neither component is wired into the running server yet (no runtime surface), so this
+commit is inert at runtime — pure library code under test.
+
+## The 8 questions (for the components as committed)
+
+1. **Over-block** — N/A. The verifier blocks nothing; it surfaces a signal. The registry
+   only guards double-spawn (existing behavior), now ABA-safe.
+2. **Under-block** — N/A.
+3. **Level-of-abstraction fit** — Correct. Pure decision logic separated from the server
+   wiring + live-state probe (the spec's design).
+4. **Signal vs authority** — The verifier is a pure signal (zero mutation). The registry's
+   only authority is the EXISTING token-guarded clear (no new clearer). Complies.
+5. **Interactions** — None at runtime (unwired). The registry, once wired, replaces the
+   closure Set; the token guard makes its clear idempotent/ABA-safe.
+6. **External surfaces** — None yet (unwired). The future wiring adds a NORMAL attention
+   item + a `/topic-reachability` status route + a `/guards` entry.
+7. **Multi-machine** — The verifier's released-no-placement detection (future probe) is
+   machine-local (reads the local placement snapshot, freshness-gated); machine-local BY
+   DESIGN. The components themselves hold no cross-machine state.
+8. **Rollback cost** — Trivial. Delete two new files + their tests; nothing references
+   them at runtime yet.
+
+## Tests
+
+- `spawningTopicsRegistry.test.ts` (5): the ABA token-guard, `.finally` is the sole
+  clearer (no timeout/sweep), `stuckSinceMs`, entries snapshot.
+- `topicReachabilityVerifier.test.ts` (8): grace; reachable-honesty (no false orphan);
+  orphan→one NORMAL item; pressure-skip+re-sweep; halt-suppress+re-sweep; flap backoff;
+  burst roll-up; coalescing.
+- `tsc --noEmit` clean.
+
+## Rollback
+
+Delete the two component files + tests. No runtime reference.


### PR DESCRIPTION
## What

Postmortem fix **F7 (Blast-Radius / Verify-After)** — dark on the fleet / live on a dev agent. Two parts:

1. **Piece 1 — the inbound spawn-guard is now ABA-safe.** The closure-local `spawningTopics` Set became a token-tagged `SpawningTopicsRegistry`. A session start-up that hangs used to leave a "currently starting" flag set forever, silently skipping every future message for that topic (the single-machine black-hole). Now `add` returns a token, `clear` is token-guarded (a late `.finally` from a superseded spawn can't delete a newer entry), and **nothing auto-clears** the flag — round-2 review proved any auto-clear *relocates* the double-spawn race (the spawn body is non-cancellable). A hung spawn keeps its flag and is **surfaced**, not raced.

2. **Piece 2 — a pure-signal `TopicReachabilityVerifier`.** After a session is killed/reaped, it verifies (after a grace window) the topic is still inbound-reachable; a genuine orphan surfaces **one NORMAL attention item**. It **mutates nothing** — never kills, spawns, transfers, or clears. The probe is **conservative + fail-safe**: live session → reachable; stuck-spawning past `stuckSpawnMs` → orphan; **anything else → reachable** (the next inbound auto-spawns — the self-heal), so it never false-orphans a normal idle kill.

## Honest scope

The dominant single-machine path already self-heals (next inbound auto-spawns), so this is **narrow by design** — it catches the specific defeats of that self-heal. The multi-machine released-no-placement / at-capacity orphan cases (placement reads) + a dedicated `/topic-reachability` route are tracked follow-ups; their absence means **less coverage, never a false orphan** (the probe fails safe to reachable). Registered in `/guards`. Dev-gated dark-fleet.

## Safety

- The verifier mutates NOTHING (pure signal). The registry's only authority is the EXISTING token-guarded clear — no new clearer, so no new double-spawn race.
- NORMAL priority (never HIGH/URGENT — they bypass the flood guard), single `topic-reachability` sourceContext, flap-backoff + burst roll-up + pressure/emergency-stop skip-with-re-sweep.
- Every probe/trigger/tick path catches and fails toward reachable/no-op (a verifier error never affects a reap or crashes the server).

## Evidence

- `spawningTopicsRegistry.test.ts` (5): ABA token-guard; `.finally` sole clearer (no timeout/sweep); stuck-age seam.
- `topicReachabilityVerifier.test.ts` (8): reachable-honesty (no false orphan); orphan→one NORMAL; grace; pressure/halt skip + re-sweep; flap backoff; burst roll-up; coalescing.
- 46 telegram routing/autospawn tests + 20 guards-endpoint e2e pass unchanged (server boots clean with the verifier wired). `tsc` clean; full `npm run lint` exit 0.

## ELI16

When I shut down a conversation's session, there's a rare way it could end up unreachable — most kills heal themselves on your next message, but a start-up that *hangs* used to leave a "currently starting" flag stuck forever, silently dropping every later message. This fixes that flag so it's safe (a known double-start bug becomes impossible) and adds a watcher that, right after I shut something down, checks you can still reach me — and if you genuinely can't, raises one calm heads-up instead of letting messages vanish. The watcher ONLY watches: it never kills, starts, or auto-fixes anything (two review rounds proved auto-fixing here is dangerous). It's careful not to cry wolf, and it's off for everyone but me for now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
