### PR TITLE
fix(reaper): real available memory on macOS (os.freemem false-critical → silent no-revival)

### DIFF
--- a/.instar/instar-dev-decisions/2026-06-26T20-06-26-425Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-06-26T20-06-26-425Z-unknown.json
@@ -1,0 +1,13 @@
+{
+  "ts": "2026-06-26T20:06:26.425Z",
+  "slug": "unknown",
+  "suggestedTier": 2,
+  "declaredTier": 2,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 3,
+  "loc": 204,
+  "causalAutopsy": null,
+  "verdict": "pass"
+}

--- a/docs/specs/macos-memory-pressure-metric.eli16.md
+++ b/docs/specs/macos-memory-pressure-metric.eli16.md
@@ -1,0 +1,29 @@
+# ELI16 — Why sessions vanished and never came back (a wrong memory gauge)
+
+## The problem in plain terms
+
+The agent has a janitor (the "reaper") that closes idle sessions when the machine is low on memory, and a "revival queue" that brings sessions back once the machine is calm again. Both rely on one number: how much memory is free.
+
+The trouble is HOW that number was measured. The code asked Node.js for "free memory" (`os.freemem()`). On a Mac, that returns only the tiny sliver of memory that's *completely* untouched — because macOS deliberately keeps that near zero and uses the rest for cache and compression that it can reclaim instantly. So on a perfectly healthy Mac with tons of usable memory, this number reads about **0.1%** — and the code thought memory was permanently in crisis.
+
+Two bad things followed:
+1. The reaper, thinking memory was always critical, closed idle sessions too eagerly.
+2. The revival queue only brings sessions back when memory looks "normal" — which, with this broken gauge, it never did. So once a session was closed, it **never came back, silently**. A whole topic would go quiet and the user would just see no replies. That's exactly what happened to the "machine swapping" topic (28744).
+
+## The fix
+
+Measure memory the way macOS itself does: real *available* memory = free + the reclaimable inactive and purgeable memory. The codebase already had this correct calculation in one place (the health checker, which reads `vm_stat`); it just wasn't being used by the reaper. The fix lifts that correct calculation into one shared helper and points the reaper at it. On Linux it uses the kernel's "MemAvailable" figure, which is the right one there too.
+
+On the actual machine where this broke: the old number said 0.17% (crisis), the correct number is about 20% available (healthy). So with the fix, the reaper sees the truth, stops over-closing sessions, and the revival queue brings them back.
+
+## Safety
+
+- The change can only make the reaper **less** aggressive and revival **more** available on macOS — the safe direction. It never makes the system close more or revive less.
+- It reuses the exact calculation already trusted by the health checker, now in one shared, unit-tested place (no more two copies that could drift apart).
+- The memory reader is bounded (a 5-second limit) and never throws — if it can't read, it falls back to a rough estimate, never freezing the janitor.
+- No thresholds or gates were loosened — on a real machine the corrected number already reads "normal," so the existing gates work correctly once they're given the truth.
+- One machine only; nothing crosses between machines.
+
+## What this does NOT cover (a separate, bigger follow-on)
+
+The operator also asked for a stronger guarantee: every agent should ALWAYS keep at least one session (the lifeline) the user can reach, no matter how tight resources get, and any time a session IS denied for resource reasons the user must be told clearly with guidance — never silence. That guaranteed "the agent is always reachable" floor is its own piece of work and standard, coming next; this fix removes the false-alarm metric that caused the silent denial in the first place.

--- a/docs/specs/macos-memory-pressure-metric.md
+++ b/docs/specs/macos-memory-pressure-metric.md
@@ -1,0 +1,61 @@
+---
+title: "macOS memory-pressure metric — read real available memory, not os.freemem"
+slug: "macos-memory-pressure-metric"
+author: "echo"
+eli16-overview: "macos-memory-pressure-metric.eli16.md"
+parent-principle: "No Silent Degradation to Brittle Fallback"
+review-convergence: "2026-06-26T20:03:20.433Z"
+review-iterations: 2
+review-completed-at: "2026-06-26T20:03:20.433Z"
+review-report: "docs/specs/reports/macos-memory-pressure-metric-convergence.md"
+cross-model-review: "skipped-abbreviated"
+approved: true
+approved-by: "echo (under Justin's standing blanket authority, topic 28130/28744 — live load-measurement incident, his explicit top priority)"
+approved-basis: "standing-authorization + explicit directive (the load-measurement issue is top priority); conformance gate + lessons-aware reviewer ran (no blockers; parser-realness + observability findings resolved); the change can only relax the reaper + free revival on macOS (safe direction), reuses the byte-identical proven vm_stat calc, 13 tests incl real fixtures + 121 existing green"
+cross-model-review-reason: "live incident fix (topic 28744 not responding); conformance gate + lessons-aware reviewer ran, parser-realness + observability findings resolved, no blockers"
+---
+
+# macOS memory-pressure metric — read real available memory, not os.freemem
+
+## Problem statement
+
+The SessionReaper's memory-pressure tier is computed from `freePct = os.freemem() / os.totalmem() * 100` (in `HostPressureSampler.sampleHostPressureInputs`). On macOS, `os.freemem()` returns ONLY "Pages free" — which macOS deliberately keeps near-zero (it uses the rest for cache / compressor / purgeable). So on a healthy 128GB machine `os.freemem()` reads ~0.1-0.4%, and `freePct < MEM_CRITICAL_FREE_PCT (5)` → `memTier: 'critical'` **permanently**, while the machine's REAL available memory is ~20-40%.
+
+Two fleet-wide failures result, both observed live (2026-06-26, topic 28744):
+1. **Over-reaping:** the SessionReaper takes the WORST of memory/CPU tier; a permanently-critical memory tier keeps pressure elevated, reaping idle sessions too aggressively.
+2. **Silent no-revival (the user-facing symptom):** the ResumeQueueDrainer's "machine calm" gate requires a `normal` pressure tier for `requiredCalmTicks` consecutive ticks. With memTier permanently critical, `calmTicks` resets to 0 every tick → reaped sessions NEVER revive, SILENTLY. A topic's session vanishes and never comes back; the user sees only silence. (This is the "machine swapping / 28744 not responding" incident.)
+
+The correct macOS available-memory figure (free + inactive + purgeable) ALREADY exists in `MemoryPressureMonitor.parseVmStat` (used by HealthChecker) — but `HostPressureSampler` (which feeds the reaper + the resume-queue calm-gate) does not use it; it uses raw `os.freemem()`.
+
+Grounded on the incident machine: `os.freemem()` = 0.17% (→ critical), but real available = 19.8% (→ `normal`, above the 12% moderate threshold). The metric is the entire bug; the gates are correct once fed the truth.
+
+## Proposed design
+
+Lift the platform-aware available-memory calculation into ONE shared, injectable, unit-tested helper and feed the reaper from it.
+
+1. **New `src/monitoring/hostMemoryPressure.ts`** — pure, injectable:
+   - `parseVmStat(output)` — macOS available = `Pages free + Pages inactive + Pages purgeable` (reclaimable), used% = (total − available)/total.
+   - `parseProcMeminfo(content)` — Linux `MemAvailable` (or `MemFree+Buffers+Cached`).
+   - `readSystemMemoryPressure(deps)` — platform-aware (darwin → vm_stat, linux → /proc/meminfo, else → rough RSS estimate); bounded (5s timeout); NEVER throws (falls back on any read error).
+   - `hostFreeMemPct(deps)` — `100 − pressurePercent`, clamped 0-100 — the corrected replacement for `os.freemem()/totalmem()*100`.
+2. **`HostPressureSampler.sampleHostPressureInputs`** computes `freePct` via `hostFreeMemPct()` instead of `os.freemem()`. The reaper + resume-queue + cartographer-sweep (all consumers of the one shared pressure signal) now read the truth.
+3. **`MemoryPressureMonitor`** delegates its private `readSystemMemory` to the shared `readSystemMemoryPressure` (removes the duplicate vm_stat/proc parsers — ONE definition, no drift).
+
+NO change to the reaper thresholds or the calm-gate: grounding shows the corrected metric reads `normal` on a healthy-but-busy machine, so the existing gates work correctly once fed the real figure. (The CPU side — 1-min load ÷ cores — is unchanged; that's a separate, already-tunable knob.)
+
+## Decision points touched
+
+This CORRECTS a measurement that feeds reaping + revival gates. It does NOT add a brittle gate or new blocking authority — it replaces a brittle, macOS-wrong metric (os.freemem) with the truthful one already proven in the codebase. The change can only make the reaper LESS aggressive and revival MORE available (the safe direction) on macOS; on Linux it switches free→MemAvailable (also more accurate, never less).
+
+## Frontloaded Decisions
+
+- **Signal choice** — available memory (free + reclaimable inactive + purgeable on macOS; MemAvailable on Linux), NOT the macOS kernel `vm_pressure_level` (which weights swap activity and would still over-report on a high-swap-but-high-available machine). Frontloaded.
+- **Fallback on read error** — the rough RSS estimate (existing MemoryPressureMonitor behavior), never a wedge. An observability metric must not throw.
+- **No threshold/calm-gate change** — grounded: the corrected metric reads `normal` (19.8% > 12%) on the incident machine; the gates are correct once fed the truth. (Separate, larger directive — a guaranteed lifeline session floor + loud no-silent-resource-rejection — is its own follow-on spec/standard, NOT this fix.) <!-- tracked: topic-28130 -->
+
+## Open questions
+
+*(none)*
+
+## Multi-machine posture
+Machine-local by design — each machine assesses its own memory. No replication/proxy surface; the reaper only ever evaluates its own host.

--- a/docs/specs/reports/macos-memory-pressure-metric-convergence.md
+++ b/docs/specs/reports/macos-memory-pressure-metric-convergence.md
@@ -1,0 +1,25 @@
+# Convergence Report — macOS memory-pressure metric
+
+## Cross-model review: SKIPPED-ABBREVIATED (single-framework, urgency)
+
+Live incident fix (topic 28744 not responding); external cross-model passes skipped. The code-backed Standards-Conformance Gate + the mandatory lessons-aware reviewer ran and produced real findings, so the abbreviated round was not a rubber-stamp.
+
+## Iteration Summary
+
+**Round 1**
+- **Standards-Conformance Gate: ran (1 flag).** "Scrape/Parser Fixture Realness — feed the parser the REAL bytes" (the code=t lesson): the spec adds vm_stat / /proc/meminfo parsers but the tests used only hand-written fixtures. → ADDRESSED: captured REAL `vm_stat` output from the incident machine (`tests/fixtures/memory/vm_stat-real-darwin.txt`) + a real-shape `/proc/meminfo` fixture, with tests asserting the parsers produce the correct available% against the real bytes (incl. the live bug shape — tiny raw free pages, healthy available).
+- **Lessons-aware reviewer: NO BLOCKERS.** Verified: (a) the RSS fallback biases toward LOW pressure (server RSS ≪ host RAM) → reaper LESS aggressive + revival MORE available — the SAFE direction; ResumeQueueDrainer.safeTier() independently fails closed on error (backstop). (b) The change correctly serves "No Silent Degradation to Brittle Fallback" (the bug WAS a brittle os.freemem metric silently degrading availability). (c) The reused vm_stat calc is byte-identical to the old MemoryPressureMonitor private parser (confirmed vs HEAD~1); `active`/`compressor` exclusions are correct (conservative, safe direction); delegation is behavior-preserving (with a minor improvement — empty/garbage output now falls to the RSS estimate instead of a false `normal`). (d) "No threshold/calm-gate change" is correct for the incident (machine reads `normal` at 19.8% > 12%).
+  - **Minor 1 (Observability) — ADDRESSED:** the fallback catch didn't log; added a one-line `console.warn` so a genuinely-broken vm_stat surfaces instead of hiding behind the RSS estimate.
+  - **Minor 2 (note, not a blocker) — TRACKED:** a machine genuinely at 5-12% available reads `moderate` and would still never reach 3 consecutive `normal` ticks → revival held (now for a REAL reason, not a measurement bug). This is the separate "guaranteed lifeline session floor + loud no-silent-resource-rejection" directive, already a frontloaded follow-on (`topic-28130`). Kept open — it's the real fix for the busy-but-healthy `moderate` machine.
+
+**Round 2 (convergence check)** — both minors resolved/tracked; no new material findings; the metric fix is correct + behavior-preserving + safe-direction. **Converged.**
+
+## Material findings & resolutions
+| Sev | Finding | Resolution |
+|-----|---------|------------|
+| flag | parser tests use synthetic, not real, bytes | real captured vm_stat + real-shape proc-meminfo fixtures |
+| MINOR | fallback not logged (Observability) | one-line warn on fallback |
+| NOTE | moderate-machine still never revives | tracked: lifeline-floor follow-on (topic-28130) |
+
+## Decision-completeness
+All decisions frontloaded; `## Open questions` empty. The change biases reaping/revival in the safe direction on macOS (and is more accurate on Linux); the larger session-floor + transparency directive is a tracked, separate follow-on.

--- a/src/monitoring/HostPressureSampler.ts
+++ b/src/monitoring/HostPressureSampler.ts
@@ -17,6 +17,7 @@
  */
 import os from 'node:os';
 import { computePressure, type PressureReading } from './SessionReaper.js';
+import { hostFreeMemPct } from './hostMemoryPressure.js';
 
 /** Per-core load thresholds. Defaults mirror the reaper's historical constants. */
 export interface HostPressureThresholds {
@@ -38,8 +39,12 @@ export interface HostPressureInputs {
 
 /** Sample the raw inputs from the OS. Pure read; never throws. */
 export function sampleHostPressureInputs(): HostPressureInputs {
-  const total = os.totalmem();
-  const freePct = total > 0 ? (os.freemem() / total) * 100 : 100;
+  // freePct is the CORRECTED available-memory percentage (free + inactive +
+  // purgeable on macOS via vm_stat; MemAvailable on Linux) — NOT os.freemem(),
+  // which on macOS reports only raw free pages (~0.1%) and falsely registered as
+  // critical, over-reaping sessions + permanently blocking revival.
+  // Spec: macos-memory-pressure-metric.
+  const freePct = hostFreeMemPct();
   // CPU pressure: 1-min load average ÷ core count. cores unknown ⇒ memory-only.
   const cores = os.cpus()?.length ?? 0;
   const loadPerCore = cores > 0 ? os.loadavg()[0] / cores : null;

--- a/src/monitoring/MemoryPressureMonitor.ts
+++ b/src/monitoring/MemoryPressureMonitor.ts
@@ -14,10 +14,9 @@
  */
 
 import { EventEmitter } from 'node:events';
-import { spawnSync } from 'node:child_process';
 import * as fs from 'node:fs';
-import os from 'node:os';
 import { DegradationReporter } from './DegradationReporter.js';
+import { readSystemMemoryPressure } from './hostMemoryPressure.js';
 
 export type MemoryPressureState = 'normal' | 'warning' | 'elevated' | 'critical';
 
@@ -61,7 +60,6 @@ const DEFAULT_THRESHOLDS = {
 
 const RING_BUFFER_SIZE = 20;
 const TREND_WINDOW = 6;
-const PAGE_SIZE_BYTES = 16384; // macOS Apple Silicon
 
 // Adaptive intervals
 const INTERVALS: Record<MemoryPressureState, number> = {
@@ -284,77 +282,10 @@ export class MemoryPressureMonitor extends EventEmitter {
    * Read system memory — platform-aware.
    */
   private readSystemMemory(): { pressurePercent: number; freeGB: number; totalGB: number } {
-    if (process.platform === 'darwin') {
-      return this.parseVmStat();
-    } else if (process.platform === 'linux') {
-      return this.parseProcMeminfo();
-    } else {
-      // Fallback: use Node's process.memoryUsage (very rough)
-      const mem = process.memoryUsage();
-      const totalGB = os.totalmem() / (1024 ** 3);
-      const usedGB = mem.rss / (1024 ** 3);
-      return {
-        pressurePercent: (usedGB / totalGB) * 100,
-        freeGB: totalGB - usedGB,
-        totalGB,
-      };
-    }
-  }
-
-  /**
-   * macOS: parse vm_stat
-   */
-  private parseVmStat(): { pressurePercent: number; freeGB: number; totalGB: number } {
-    const output = spawnSync('vm_stat', [], { encoding: 'utf-8', timeout: 5000 }).stdout ?? '';
-
-    const pageSizeMatch = output.match(/page size of (\d+) bytes/);
-    const pageSize = pageSizeMatch ? parseInt(pageSizeMatch[1], 10) : PAGE_SIZE_BYTES;
-
-    const parsePages = (label: string): number => {
-      const match = output.match(new RegExp(`${label}:\\s+(\\d+)`));
-      return match ? parseInt(match[1], 10) : 0;
-    };
-
-    const freePages = parsePages('Pages free');
-    const activePages = parsePages('Pages active');
-    const inactivePages = parsePages('Pages inactive');
-    const wiredPages = parsePages('Pages wired down');
-    const compressorPages = parsePages('Pages occupied by compressor');
-    const purgeablePages = parsePages('Pages purgeable');
-
-    const totalPages = freePages + activePages + inactivePages + wiredPages + compressorPages;
-    const totalBytes = totalPages * pageSize;
-    const totalGB = totalBytes / (1024 ** 3);
-
-    const availablePages = freePages + inactivePages + purgeablePages;
-    const availableBytes = availablePages * pageSize;
-    const freeGB = availableBytes / (1024 ** 3);
-
-    const usedPages = totalPages - availablePages;
-    const pressurePercent = totalPages > 0 ? (usedPages / totalPages) * 100 : 0;
-
-    return { pressurePercent, freeGB, totalGB };
-  }
-
-  /**
-   * Linux: parse /proc/meminfo
-   */
-  private parseProcMeminfo(): { pressurePercent: number; freeGB: number; totalGB: number } {
-    const content = fs.readFileSync('/proc/meminfo', 'utf-8');
-
-    const parseKB = (key: string): number => {
-      const match = content.match(new RegExp(`${key}:\\s+(\\d+)`));
-      return match ? parseInt(match[1], 10) : 0;
-    };
-
-    const totalKB = parseKB('MemTotal');
-    const availableKB = parseKB('MemAvailable') || (parseKB('MemFree') + parseKB('Buffers') + parseKB('Cached'));
-
-    const totalGB = totalKB / (1024 * 1024);
-    const freeGB = availableKB / (1024 * 1024);
-    const pressurePercent = totalKB > 0 ? ((totalKB - availableKB) / totalKB) * 100 : 0;
-
-    return { pressurePercent, freeGB, totalGB };
+    // Delegates to the ONE shared, platform-aware reader (macOS reads
+    // free+inactive+purgeable via vm_stat, Linux MemAvailable, never raw
+    // os.freemem). Spec: macos-memory-pressure-metric.
+    return readSystemMemoryPressure();
   }
 
   /**

--- a/src/monitoring/hostMemoryPressure.ts
+++ b/src/monitoring/hostMemoryPressure.ts
@@ -1,0 +1,116 @@
+/**
+ * hostMemoryPressure — THE one correct, platform-aware measure of host memory
+ * availability across the codebase. Spec: macos-memory-pressure-metric.
+ *
+ * THE BUG THIS FIXES: `os.freemem()` on macOS returns ONLY "Pages free" — which
+ * macOS keeps near-zero (it uses the rest for cache/compressor/purgeable), so
+ * `os.freemem()/totalmem()` reads ~0.1-0.4% on a healthy machine and falsely
+ * registers as "critical" memory pressure. That false-critical made the
+ * SessionReaper over-reap AND permanently blocked the ResumeQueueDrainer's
+ * "machine calm" gate (it can never reach a 'normal' tier), so reaped sessions
+ * never revived — silently. The CORRECT macOS available memory is
+ * free + inactive (reclaimable) + purgeable, exactly what `vm_stat` exposes and
+ * what MemoryPressureMonitor already computed for HealthChecker — this lifts that
+ * calculation into one shared, injectable, unit-tested helper.
+ */
+import { spawnSync } from 'node:child_process';
+import * as fs from 'node:fs';
+import os from 'node:os';
+import { withSyncOp } from '../core/InFlightSyncOpMarker.js';
+
+const PAGE_SIZE_BYTES = 16384; // macOS Apple Silicon default; overridden by vm_stat's own page size
+
+export interface SystemMemoryReading {
+  /** Used memory as a percentage (0-100). The inverse of available. */
+  pressurePercent: number;
+  freeGB: number;
+  totalGB: number;
+}
+
+/** Injectable IO so the parsers + reader unit-test without a real OS. */
+export interface MemReadDeps {
+  platform?: string;
+  vmStat?: () => string;
+  procMeminfo?: () => string;
+  memoryUsage?: () => { rss: number };
+  totalmem?: () => number;
+}
+
+/** Pure: parse `vm_stat` output → memory reading. Available = free + inactive + purgeable. */
+export function parseVmStat(output: string): SystemMemoryReading {
+  const pageSizeMatch = output.match(/page size of (\d+) bytes/);
+  const pageSize = pageSizeMatch ? parseInt(pageSizeMatch[1], 10) : PAGE_SIZE_BYTES;
+  const parsePages = (label: string): number => {
+    const match = output.match(new RegExp(`${label}:\\s+(\\d+)`));
+    return match ? parseInt(match[1], 10) : 0;
+  };
+  const freePages = parsePages('Pages free');
+  const activePages = parsePages('Pages active');
+  const inactivePages = parsePages('Pages inactive');
+  const wiredPages = parsePages('Pages wired down');
+  const compressorPages = parsePages('Pages occupied by compressor');
+  const purgeablePages = parsePages('Pages purgeable');
+
+  const totalPages = freePages + activePages + inactivePages + wiredPages + compressorPages;
+  const totalGB = (totalPages * pageSize) / (1024 ** 3);
+  const availablePages = freePages + inactivePages + purgeablePages;
+  const freeGB = (availablePages * pageSize) / (1024 ** 3);
+  const usedPages = totalPages - availablePages;
+  const pressurePercent = totalPages > 0 ? (usedPages / totalPages) * 100 : 0;
+  return { pressurePercent, freeGB, totalGB };
+}
+
+/** Pure: parse `/proc/meminfo` content → memory reading (Linux MemAvailable). */
+export function parseProcMeminfo(content: string): SystemMemoryReading {
+  const parseKB = (key: string): number => {
+    const match = content.match(new RegExp(`${key}:\\s+(\\d+)`));
+    return match ? parseInt(match[1], 10) : 0;
+  };
+  const totalKB = parseKB('MemTotal');
+  const availableKB = parseKB('MemAvailable') || (parseKB('MemFree') + parseKB('Buffers') + parseKB('Cached'));
+  const totalGB = totalKB / (1024 * 1024);
+  const freeGB = availableKB / (1024 * 1024);
+  const pressurePercent = totalKB > 0 ? ((totalKB - availableKB) / totalKB) * 100 : 0;
+  return { pressurePercent, freeGB, totalGB };
+}
+
+/** Read host memory pressure, platform-aware. Bounded + never throws (fallback on any error). */
+export function readSystemMemoryPressure(deps: MemReadDeps = {}): SystemMemoryReading {
+  const platform = deps.platform ?? process.platform;
+  try {
+    if (platform === 'darwin') {
+      // The real vm_stat read funnels through withSyncOp so the in-flight sync-op
+      // marker sees this blocking call (tmux-event-loop-resilience-spec). The
+      // injected `vmStat` (tests) is a pure stub and needs no funnel.
+      const out = deps.vmStat ? deps.vmStat() : withSyncOp(() => spawnSync('vm_stat', [], { encoding: 'utf-8', timeout: 5000 }).stdout ?? '');
+      if (out) return parseVmStat(out);
+    } else if (platform === 'linux') {
+      const content = deps.procMeminfo ? deps.procMeminfo() : fs.readFileSync('/proc/meminfo', 'utf-8');
+      if (content) return parseProcMeminfo(content);
+    }
+  } catch (err) {
+    // @silent-fallback-ok — a vm_stat/proc read failure falls back to the rough
+    // process.memoryUsage estimate below; an observability metric, never a gate
+    // that should wedge on a transient read error. NOT silent: the fallback is
+    // logged (No Silent Degradation — advisory degradation must be visible) so a
+    // genuinely-broken vm_stat surfaces instead of hiding behind a server-RSS
+    // estimate. The fallback biases toward LOW pressure (server RSS ≪ host RAM),
+    // the safe direction for a reaper (less aggressive) + revival (more available).
+    console.warn(`[hostMemoryPressure] ${platform} memory read failed; using rough RSS estimate: ${err instanceof Error ? err.message : String(err)}`);
+  }
+  // Fallback (other platforms or a read error): rough RSS-based estimate.
+  const totalGB = (deps.totalmem ? deps.totalmem() : os.totalmem()) / (1024 ** 3);
+  const usedGB = (deps.memoryUsage ? deps.memoryUsage() : process.memoryUsage()).rss / (1024 ** 3);
+  return { pressurePercent: totalGB > 0 ? (usedGB / totalGB) * 100 : 0, freeGB: totalGB - usedGB, totalGB };
+}
+
+/**
+ * Free/available host memory as a percentage (0-100) — the CORRECTED replacement
+ * for `os.freemem()/os.totalmem()*100`. Use this for any memory-pressure tier
+ * decision so macOS is read truthfully (free+inactive+purgeable), not as raw
+ * free pages.
+ */
+export function hostFreeMemPct(deps: MemReadDeps = {}): number {
+  const pct = 100 - readSystemMemoryPressure(deps).pressurePercent;
+  return Math.max(0, Math.min(100, pct));
+}

--- a/tests/fixtures/memory/proc-meminfo-real-linux.txt
+++ b/tests/fixtures/memory/proc-meminfo-real-linux.txt
@@ -1,0 +1,10 @@
+MemTotal:       32814904 kB
+MemFree:         1234567 kB
+MemAvailable:   18345678 kB
+Buffers:          456789 kB
+Cached:         12345678 kB
+SwapCached:        12345 kB
+Active:         15000000 kB
+Inactive:        8000000 kB
+SwapTotal:       8388604 kB
+SwapFree:        8000000 kB

--- a/tests/fixtures/memory/vm_stat-real-darwin.txt
+++ b/tests/fixtures/memory/vm_stat-real-darwin.txt
@@ -1,0 +1,23 @@
+Mach Virtual Memory Statistics: (page size of 16384 bytes)
+Pages free:                               35352.
+Pages active:                           1604227.
+Pages inactive:                         1581895.
+Pages speculative:                        21762.
+Pages throttled:                              0.
+Pages wired down:                        329590.
+Pages purgeable:                          36027.
+"Translation faults":              116773452941.
+Pages copy-on-write:                19195087073.
+Pages zero filled:                  40190666619.
+Pages reactivated:                    130343258.
+Pages purged:                         200674449.
+File-backed pages:                      1018945.
+Anonymous pages:                        2188939.
+Pages stored in compressor:             9262879.
+Pages occupied by compressor:           4755197.
+Decompressions:                        59712559.
+Compressions:                          87752648.
+Pageins:                             1128406576.
+Pageouts:                                702972.
+Swapins:                                8660756.
+Swapouts:                              12553827.

--- a/tests/unit/host-memory-pressure.test.ts
+++ b/tests/unit/host-memory-pressure.test.ts
@@ -1,0 +1,141 @@
+/**
+ * macOS memory-pressure metric fix. Spec: macos-memory-pressure-metric.
+ *
+ * THE BUG: os.freemem() on macOS returns only "Pages free" (~0.1%), so the
+ * reaper/resume-queue read a healthy machine as memory-CRITICAL, over-reaping
+ * sessions and permanently blocking revival. The fix reads REAL available memory
+ * (free + inactive + purgeable on macOS via vm_stat). These tests pin that a
+ * machine with tiny free pages but ample reclaimable memory reads as HEALTHY.
+ */
+import { describe, it, expect } from 'vitest';
+import { parseVmStat, parseProcMeminfo, readSystemMemoryPressure, hostFreeMemPct } from '../../src/monitoring/hostMemoryPressure.js';
+
+// A realistic macOS vm_stat: almost no "Pages free", but lots of reclaimable
+// inactive + purgeable — the exact shape that broke os.freemem.
+const VM_STAT_HEALTHY_LOW_FREE = `Mach Virtual Memory Statistics: (page size of 16384 bytes)
+Pages free:                               10000.
+Pages active:                           2000000.
+Pages inactive:                         1500000.
+Pages wired down:                        500000.
+Pages purgeable:                         800000.
+Pages occupied by compressor:            300000.
+`;
+
+describe('parseVmStat — available = free + inactive + purgeable (not raw free pages)', () => {
+  it('a machine with TINY free pages but ample reclaimable reads as HEALTHY (the bug case)', () => {
+    const r = parseVmStat(VM_STAT_HEALTHY_LOW_FREE);
+    // total = 10000+2000000+1500000+500000+300000 = 4,310,000
+    // available = 10000+1500000+800000 = 2,310,000 → ~53.6% available
+    const freePct = 100 - r.pressurePercent;
+    expect(freePct).toBeGreaterThan(40); // NOT the ~0.2% os.freemem would report
+    expect(r.totalGB).toBeGreaterThan(0);
+    expect(r.freeGB).toBeGreaterThan(0);
+  });
+  it('a genuinely critical machine reads low available', () => {
+    const critical = `Mach Virtual Memory Statistics: (page size of 16384 bytes)
+Pages free:                                1000.
+Pages active:                           4000000.
+Pages inactive:                           50000.
+Pages wired down:                       1000000.
+Pages purgeable:                          10000.
+Pages occupied by compressor:            500000.
+`;
+    const freePct = 100 - parseVmStat(critical).pressurePercent;
+    expect(freePct).toBeLessThan(5); // genuinely critical → low available
+  });
+  it('empty/garbage output does not throw and yields a finite reading', () => {
+    const r = parseVmStat('');
+    expect(Number.isFinite(r.pressurePercent)).toBe(true);
+  });
+});
+
+describe('parseProcMeminfo — uses MemAvailable (Linux)', () => {
+  it('reads MemAvailable as the free figure', () => {
+    const content = `MemTotal:       16000000 kB
+MemFree:          200000 kB
+MemAvailable:    8000000 kB
+Buffers:          100000 kB
+Cached:          5000000 kB
+`;
+    const r = parseProcMeminfo(content);
+    expect(100 - r.pressurePercent).toBeCloseTo(50, 0); // 8M/16M available
+  });
+  it('falls back to MemFree+Buffers+Cached when MemAvailable is absent', () => {
+    const content = `MemTotal:       16000000 kB
+MemFree:         1000000 kB
+Buffers:          500000 kB
+Cached:          2500000 kB
+`;
+    const r = parseProcMeminfo(content);
+    expect(100 - r.pressurePercent).toBeCloseTo(25, 0); // (1M+0.5M+2.5M)/16M
+  });
+});
+
+describe('readSystemMemoryPressure — platform-aware, never throws', () => {
+  it('darwin: uses injected vm_stat', () => {
+    const r = readSystemMemoryPressure({ platform: 'darwin', vmStat: () => VM_STAT_HEALTHY_LOW_FREE });
+    expect(100 - r.pressurePercent).toBeGreaterThan(40);
+  });
+  it('linux: uses injected proc-meminfo', () => {
+    const r = readSystemMemoryPressure({ platform: 'linux', procMeminfo: () => 'MemTotal: 16000000 kB\nMemAvailable: 8000000 kB\n' });
+    expect(100 - r.pressurePercent).toBeCloseTo(50, 0);
+  });
+  it('a thrown reader falls back to the RSS estimate (never throws)', () => {
+    const r = readSystemMemoryPressure({
+      platform: 'darwin',
+      vmStat: () => { throw new Error('vm_stat missing'); },
+      memoryUsage: () => ({ rss: 4 * 1024 ** 3 }),
+      totalmem: () => 16 * 1024 ** 3,
+    });
+    expect(Number.isFinite(r.pressurePercent)).toBe(true);
+    expect(r.pressurePercent).toBeCloseTo(25, 0); // 4GB rss / 16GB
+  });
+  it('an unknown platform uses the fallback', () => {
+    const r = readSystemMemoryPressure({ platform: 'sunos', memoryUsage: () => ({ rss: 2 * 1024 ** 3 }), totalmem: () => 8 * 1024 ** 3 });
+    expect(r.pressurePercent).toBeCloseTo(25, 0);
+  });
+});
+
+describe('hostFreeMemPct — the corrected os.freemem replacement', () => {
+  it('returns the available% (clamped 0-100)', () => {
+    const pct = hostFreeMemPct({ platform: 'darwin', vmStat: () => VM_STAT_HEALTHY_LOW_FREE });
+    expect(pct).toBeGreaterThan(40);
+    expect(pct).toBeLessThanOrEqual(100);
+  });
+  it('never returns < 0 or > 100', () => {
+    const pct = hostFreeMemPct({ platform: 'linux', procMeminfo: () => 'MemTotal: 100 kB\nMemAvailable: 999999 kB\n' });
+    expect(pct).toBeLessThanOrEqual(100);
+    expect(pct).toBeGreaterThanOrEqual(0);
+  });
+});
+
+// ── REAL captured fixtures (Scrape/Parser Fixture Realness standard — the code=t
+// lesson): the parsers must be fed the REAL bytes, not only hand-written shapes. ──
+import fs from 'node:fs';
+import path from 'node:path';
+
+describe('parsers against REAL captured OS output', () => {
+  const fixDir = path.join(__dirname, '..', 'fixtures', 'memory');
+
+  it('REAL macOS vm_stat: tiny raw free pages but correct available% reads HEALTHY (the live bug shape)', () => {
+    const real = fs.readFileSync(path.join(fixDir, 'vm_stat-real-darwin.txt'), 'utf-8');
+    const r = parseVmStat(real);
+    const freePct = 100 - r.pressurePercent;
+    // The real machine's RAW free pages are ~0.4% (what os.freemem saw → false critical);
+    // the CORRECT available% (free+inactive+purgeable) is materially higher.
+    expect(freePct).toBeGreaterThan(MEM_MODERATE_FLOOR); // not the false-critical os.freemem reading
+    expect(r.totalGB).toBeGreaterThan(8);                // a real machine has real total
+    expect(Number.isFinite(r.freeGB)).toBe(true);
+  });
+
+  it('REAL-shape /proc/meminfo: uses MemAvailable', () => {
+    const real = fs.readFileSync(path.join(fixDir, 'proc-meminfo-real-linux.txt'), 'utf-8');
+    const r = parseProcMeminfo(real);
+    const freePct = 100 - r.pressurePercent;
+    // MemAvailable 18345678 / MemTotal 32814904 ≈ 55.9%
+    expect(freePct).toBeGreaterThan(50);
+    expect(freePct).toBeLessThan(60);
+  });
+});
+
+const MEM_MODERATE_FLOOR = 5; // above the 5% critical threshold — the corrected metric clears it

--- a/upgrades/next/macos-memory-pressure-metric.md
+++ b/upgrades/next/macos-memory-pressure-metric.md
@@ -1,0 +1,20 @@
+## What Changed
+
+The agent measures how busy the machine's memory is to decide when to close idle sessions and when to bring them back. On macOS it was reading the wrong number — Node's raw "free memory," which macOS deliberately keeps near zero by using the rest for cache and compression. So a perfectly healthy Mac looked permanently out of memory. That made the cleanup close idle sessions too eagerly AND permanently blocked the revival queue from bringing them back — so a topic's session could vanish and never return, with no message to the user.
+
+The fix reads real available memory the way macOS itself does (free plus the reclaimable inactive and purgeable memory, via vm_stat), and the same correct figure on Linux. The correct calculation already existed in the health checker; this lifts it into one shared, tested place and points the cleanup at it. On the machine where this broke, the old reading was 0.17% (false crisis) and the correct reading is about 20% available (healthy), so sessions revive again.
+
+It can only make the cleanup less aggressive and revival more available on macOS — the safe direction — and a separate, larger guarantee (always keep at least one reachable session, and never silently deny a session for resource reasons) is coming next.
+
+## Evidence
+
+- `tests/unit/host-memory-pressure.test.ts` (13): includes REAL captured `vm_stat` from the incident machine — tiny raw free pages but correct available% reads healthy; a genuinely-critical shape reads low; platform-aware; never-throws fallback. 121 existing reaper/memory/resume-queue tests still green (no regression).
+- Convergence (conformance gate + lessons-aware reviewer, no blockers): `docs/specs/reports/macos-memory-pressure-metric-convergence.md`.
+
+## What to Tell Your User
+
+If a topic ever went quiet — you sent messages and got nothing back — one cause was the agent mis-reading its own memory on a Mac and refusing to bring a closed session back. That false alarm is fixed: it now reads real available memory, so sessions get cleaned up and revived based on the true picture.
+
+## Summary of New Capabilities
+
+- Correct, platform-aware host memory-availability measurement (free + reclaimable on macOS; MemAvailable on Linux) feeding the session reaper and revival queue — no more macOS false-critical from raw free pages.

--- a/upgrades/side-effects/macos-memory-pressure-metric.md
+++ b/upgrades/side-effects/macos-memory-pressure-metric.md
@@ -1,0 +1,15 @@
+# Side-effects review — macos-memory-pressure-metric
+
+Change: replace `os.freemem()`-based memory-pressure measurement with REAL available memory (free+inactive+purgeable via vm_stat on macOS; MemAvailable on Linux) in the SessionReaper's pressure input. New `src/monitoring/hostMemoryPressure.ts` (shared); `HostPressureSampler` + `MemoryPressureMonitor` use it. Files: hostMemoryPressure.ts (new), HostPressureSampler.ts, MemoryPressureMonitor.ts, tests + real fixtures.
+
+1. **Over-block:** REDUCES a false over-block — the reaper no longer reads a healthy macOS machine as memory-critical, so it stops over-reaping idle sessions and the resume queue's calm-gate can reach `normal` and revive reaped sessions.
+2. **Under-block:** None new. The corrected metric is conservative (excludes active + compressor from "available", the safe direction). On a genuinely memory-critical machine it correctly reads critical. A 5-12% `moderate` machine still holds revival (now for a REAL reason, not a false one) — tracked separately as the lifeline-floor follow-on (topic-28130).
+3. **Level-of-abstraction fit:** Correct. One shared, injectable memory reader feeds all consumers of the single host-pressure signal (reaper, resume-queue, cartographer-sweep). Removes a duplicate vm_stat parser (one definition).
+4. **Signal vs authority:** Not a gate — a measurement that FEEDS gates. The fix makes the signal truthful; it adds no blocking authority. Serves "No Silent Degradation to Brittle Fallback" (os.freemem was the brittle metric silently degrading availability).
+5. **Interactions:** The reaper's CPU side (1-min load ÷ cores) is unchanged. MemoryPressureMonitor delegation is byte-identical to its prior private parser (confirmed vs HEAD~1) — HealthChecker behavior preserved. The fallback (RSS estimate on read error) biases low-pressure (server RSS ≪ host RAM) → safe direction; now logged (Observability). ResumeQueueDrainer.safeTier() independently fails closed on error — backstop intact.
+6. **External surfaces:** No routes. `GET /sessions/reaper`'s `pressure.inputs.freePct` now reports real available% (was ~0.1% on macOS). A `[hostMemoryPressure]` warn on read-failure fallback.
+7. **Multi-machine posture:** Machine-local by design — each host measures its own memory. No replication/proxy surface.
+8. **Rollback cost:** Low. Pure measurement change; revert restores os.freemem. No data migration, no config. The change can only relax the reaper / free revival on macOS (the safe direction), so a bad outcome is bounded.
+
+## Second-pass review (touches the reaper pressure path)
+The lessons-aware convergence reviewer audited fail-direction, the parent standard, the reused vm_stat calc (byte-identical, correct exclusions), delegation (behavior-preserving), and the no-threshold-change claim. No blockers; one minor (log the fallback — DONE), one tracked note (moderate-machine residual → lifeline-floor follow-on). Concur.


### PR DESCRIPTION
## ELI16 — sessions vanished and never came back (a wrong memory gauge)

The agent measures how busy memory is to decide when to close idle sessions and when to bring them back. On macOS it read the wrong number — Node's raw "free memory," which macOS keeps near zero (it uses the rest for cache/compression). So a healthy Mac looked permanently out of memory: the cleanup closed idle sessions too eagerly AND the revival queue (which only acts when memory looks "normal") never brought them back — so a topic's session could vanish and never return, with NO message to the user (the live "topic 28744 not responding" incident). The fix reads real available memory the way macOS itself does (free + reclaimable inactive + purgeable, via vm_stat; MemAvailable on Linux) — a calc already proven in the health checker, now shared. On the incident machine the old reading was 0.17% (false crisis), the correct one is ~20% available (healthy). It can only make the cleanup less aggressive and revival more available — the safe direction.

## What & why

`HostPressureSampler` fed the SessionReaper's memory tier from `os.freemem()/totalmem()`. On macOS that's only raw "Pages free" (~0.1-0.4%) → permanent false-critical → over-reaping + a permanently-blocked revival calm-gate (silent no-revival).

## The fix

- New shared `src/monitoring/hostMemoryPressure.ts`: real available memory (free+inactive+purgeable via vm_stat on macOS; MemAvailable on Linux), injectable, bounded, never-throws (logged fallback). `vm_stat` funnels through `withSyncOp`.
- `HostPressureSampler` uses it instead of `os.freemem`; `MemoryPressureMonitor` delegates (one definition, no drift).
- NO threshold/calm-gate change — grounding: the corrected metric reads `normal` (19.8% > 12%) on the incident machine, so the gates are correct once fed the truth.

## Convergence

Conformance gate + lessons-aware reviewer, **no blockers**. Parser tests use REAL captured `vm_stat` (the code=t lesson); fallback logged (Observability). The vm_stat calc is byte-identical to the prior proven one (verified vs HEAD~1). Report: `docs/specs/reports/macos-memory-pressure-metric-convergence.md`.

## Tests

13 new (incl. real captured `vm_stat` from the incident machine) + 121 existing reaper/memory/resume-queue tests green (no regression).

## Follow-on (tracked, topic-28130)

A guaranteed lifeline session floor + loud no-silent-resource-rejection (the agent is always reachable; resource denials are never silent) — operator directive, its own spec/standard next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
