### PR TITLE
feat(mcp): per-session MCP profiles — launch a topic with only the servers it needs (dynamic-MCP lever 1)

### DIFF
--- a/.instar/instar-dev-decisions/2026-06-27T02-26-24-579Z-mcp-session-profiles.json
+++ b/.instar/instar-dev-decisions/2026-06-27T02-26-24-579Z-mcp-session-profiles.json
@@ -1,0 +1,21 @@
+{
+  "ts": "2026-06-27T02:26:24.579Z",
+  "slug": "mcp-session-profiles",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "new capability: new config key added"
+  ],
+  "belowFloor": true,
+  "files": 3,
+  "loc": 123,
+  "causalAutopsy": {
+    "origin": "prior-pr",
+    "relatedPrs": [
+      1291
+    ],
+    "notes": "Follow-up to the 2026-06-26 resource-exhaustion panic. #1290 fixed the disk arm; #1291 added the process-footprint MEASUREMENT. This is the first REDUCER: heavy idle MCP servers (Chromium/Electron) stacked across sessions were a dominant footprint; per-session profiles cut the baseline by launching each topic with only the servers it needs. Lever 2 (idle-live offload) follows."
+  },
+  "verdict": "pass"
+}

--- a/src/core/SessionManager.ts
+++ b/src/core/SessionManager.ts
@@ -69,6 +69,7 @@ import {
   resolveInteractiveFramework,
   resolveModelForFramework,
 } from './frameworkSessionLaunch.js';
+import { resolveMcpProfileServers, filterMcpConfig, type McpJson } from './sessionMcpProfile.js';
 import { frameworkFromEnv } from './intelligenceProviderFactory.js';
 import { decideSdkVsSubscription, DEFAULT_SAFETY_MARGIN_FRACTION } from '../providers/costAwareRouting.js';
 import {
@@ -3724,6 +3725,33 @@ rm()  { "${shimRunner}" rm  "$@"; }
   }
 
   /**
+   * Per-session MCP profile (dynamic-MCP-lifecycle lever 1). Resolves the topic's
+   * MCP profile and, when one is configured, writes a filtered `.mcp.json` (only
+   * the profiled servers) to a per-session file and returns the launch flags
+   * `['--strict-mcp-config', '--mcp-config', <path>]`. Returns [] (full project
+   * `.mcp.json`, byte-for-byte today) when the feature is off, the topic has no
+   * profile, or on ANY error — the fail-safe, deletion-of-tools-averse direction.
+   */
+  private buildSessionMcpProfileFlags(topicId: number | undefined): string[] {
+    try {
+      const servers = resolveMcpProfileServers(topicId, this.config.mcpProfiles);
+      if (servers === null) return []; // no profile ⇒ full .mcp.json (default)
+      const mcpJsonPath = path.join(this.config.projectDir, '.mcp.json');
+      let full: McpJson;
+      try { full = JSON.parse(fs.readFileSync(mcpJsonPath, 'utf-8')) as McpJson; }
+      catch { return []; } // no/unreadable .mcp.json ⇒ nothing to filter ⇒ default
+      const filtered = filterMcpConfig(full, servers);
+      const outDir = path.join(this.config.projectDir, '.instar', 'state', 'session-mcp-config');
+      fs.mkdirSync(outDir, { recursive: true });
+      const outPath = path.join(outDir, `mcp-${topicId}-${Date.now()}.json`);
+      fs.writeFileSync(outPath, JSON.stringify(filtered, null, 2));
+      return ['--strict-mcp-config', '--mcp-config', outPath];
+    } catch {
+      return []; // @silent-fallback-ok — any failure ⇒ full .mcp.json (never strands a session without its tools)
+    }
+  }
+
+  /**
    * Spawn an interactive Claude Code session (no -p prompt — opens at the REPL).
    * Used for Telegram-driven conversational sessions.
    * Optionally sends an initial message after Claude is ready.
@@ -3912,6 +3940,18 @@ rm()  { "${shimRunner}" rm  "$@"; }
       // only; the builder validates the enum + drops an unknown value).
       ...(options?.effort ? { effort: options.effort } : {}),
     });
+
+    // Per-session MCP profile (dynamic-MCP-lifecycle lever 1, claude-code only):
+    // when this topic has an explicit lean profile, launch with ONLY those MCP
+    // servers (a filtered .mcp.json via --strict-mcp-config) instead of the full
+    // project set — cutting the heavy idle-MCP footprint that dominated the
+    // 2026-06-26 resource panic. Default NO-OP: returns [] when the feature is off,
+    // the topic has no profile, or on any error → the spawn is byte-for-byte
+    // unchanged (Claude reads the full .mcp.json as today).
+    if (framework === 'claude-code') {
+      const mcpProfileFlags = this.buildSessionMcpProfileFlags(options?.telegramTopicId);
+      if (mcpProfileFlags.length > 0) launchSpec.argv.push(...mcpProfileFlags);
+    }
 
     // Spawn the framework CLI in tmux — no bash -c shell intermediary.
     // Uses tmux -e flags to set/unset env vars directly, matching spawnSession pattern.

--- a/src/core/sessionMcpProfile.ts
+++ b/src/core/sessionMcpProfile.ts
@@ -1,0 +1,70 @@
+/**
+ * Per-session MCP profiles (lever 1 of dynamic-MCP-lifecycle) — pure resolution.
+ *
+ * Claude Code fixes a session's MCP server set AT LAUNCH (it reads the project's
+ * `.mcp.json`, or an explicit `--mcp-config`). MCP servers are heavy and mostly
+ * idle (a whole Chromium for Playwright, an Electron for some bridges) and were a
+ * dominant share of the steady-state process footprint behind the 2026-06-26
+ * resource-exhaustion panic. This lets a topic's interactive session launch with
+ * ONLY the MCP servers it needs instead of the full `.mcp.json`, cutting the
+ * baseline footprint.
+ *
+ * Pure + default-no-op: when the feature is off OR a topic has no explicit profile,
+ * resolution returns `null` ⇒ the caller adds NO `--mcp-config` flag ⇒ Claude reads
+ * the full `.mcp.json` exactly as today. A topic only loses a server by EXPLICIT
+ * configuration, so absent any config the spawn is byte-for-byte unchanged.
+ */
+
+/** The `sessions.mcpProfiles` config shape (all optional; absence ⇒ no-op). */
+export interface McpProfilesConfig {
+  /** Master switch — DARK by default. Off ⇒ resolution always returns null. */
+  enabled?: boolean;
+  /**
+   * Explicit per-topic allow-list of MCP server names (the keys in `.mcp.json`).
+   * A topic listed here launches with ONLY those servers. A topic NOT listed gets
+   * the full `.mcp.json` (default-keep-warm — including Playwright, used often).
+   */
+  topicServers?: Record<string, string[]>;
+}
+
+/**
+ * Resolve which MCP servers a topic's session should launch with.
+ * Returns `null` when the full `.mcp.json` should be used unchanged (the default):
+ *   - the feature is disabled, OR
+ *   - no explicit profile is configured for this topic.
+ * Returns a (possibly empty) server-name array when the topic has an explicit
+ * profile — the session launches with ONLY those servers.
+ */
+export function resolveMcpProfileServers(
+  topicId: number | string | undefined,
+  cfg: McpProfilesConfig | undefined,
+): string[] | null {
+  if (!cfg || cfg.enabled !== true) return null;
+  if (topicId === undefined || topicId === null) return null;
+  const key = String(topicId);
+  const entry = cfg.topicServers?.[key];
+  if (!Array.isArray(entry)) return null; // no explicit profile ⇒ full .mcp.json
+  // De-dupe + drop blanks; an explicit [] means "no MCP servers for this topic".
+  return [...new Set(entry.filter((s) => typeof s === 'string' && s.length > 0))];
+}
+
+/** The minimal `.mcp.json` shape we read/filter. */
+export interface McpJson {
+  mcpServers?: Record<string, unknown>;
+  [k: string]: unknown;
+}
+
+/**
+ * Filter a parsed `.mcp.json` down to the allowed server set, preserving every
+ * other top-level field. Unknown server names in `allowed` are simply ignored
+ * (they can't be launched). Pure — returns a new object, never mutates the input.
+ */
+export function filterMcpConfig(full: McpJson, allowed: string[]): McpJson {
+  const allowSet = new Set(allowed);
+  const srcServers = (full && typeof full === 'object' ? full.mcpServers : undefined) ?? {};
+  const filtered: Record<string, unknown> = {};
+  for (const [name, def] of Object.entries(srcServers)) {
+    if (allowSet.has(name)) filtered[name] = def;
+  }
+  return { ...full, mcpServers: filtered };
+}

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -161,6 +161,19 @@ export interface SessionManagerConfig {
   /** Path to tmux binary */
   tmuxPath: string;
   /**
+   * Per-session MCP profiles (dynamic-MCP-lifecycle lever 1): launch a topic's
+   * interactive session with ONLY its profiled MCP servers (a filtered .mcp.json)
+   * instead of the full project set, cutting the heavy idle-MCP footprint. DARK by
+   * default; absence / no topic entry = the full .mcp.json unchanged. See
+   * `src/core/sessionMcpProfile.ts`.
+   */
+  mcpProfiles?: {
+    /** Master switch (default off). */
+    enabled?: boolean;
+    /** Per-topic allow-list of MCP server names (keys in .mcp.json). */
+    topicServers?: Record<string, string[]>;
+  };
+  /**
    * Override for Claude Code's own internal retry count
    * (CLAUDE_CODE_MAX_RETRIES env), injected at spawn. When set, raises how
    * long Claude rides out a transient throttle/overload before surfacing the

--- a/tests/unit/session-mcp-profile-wiring.test.ts
+++ b/tests/unit/session-mcp-profile-wiring.test.ts
@@ -1,0 +1,38 @@
+/**
+ * Wiring-integrity guard for MCP lever-1 (per-session profiles). The pure resolver
+ * is useless if SessionManager never calls it — the "shipped inert" failure mode
+ * (see rate-limit-recovery-wiring.test.ts). This asserts SessionManager actually
+ * wires the profile flags into the INTERACTIVE claude-code spawn, on the
+ * deterministic default-no-op path.
+ */
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const SRC = fs.readFileSync(path.join(process.cwd(), 'src/core/SessionManager.ts'), 'utf-8');
+
+describe('MCP lever-1 — wiring integrity', () => {
+  it('imports the pure resolver/filter from sessionMcpProfile', () => {
+    expect(SRC).toContain("from './sessionMcpProfile.js'");
+    expect(SRC).toContain('resolveMcpProfileServers');
+    expect(SRC).toContain('filterMcpConfig');
+  });
+
+  it('defines the buildSessionMcpProfileFlags method that reads the topic profile + writes a filtered config', () => {
+    expect(SRC).toMatch(/private buildSessionMcpProfileFlags\(topicId/);
+    expect(SRC).toContain('resolveMcpProfileServers(topicId, this.config.mcpProfiles)');
+    expect(SRC).toContain("'--strict-mcp-config', '--mcp-config'");
+  });
+
+  it('calls the builder in the INTERACTIVE claude-code spawn, gated on framework + with the topic id', () => {
+    // The call must be inside the claude-code branch of spawnInteractiveSession,
+    // using the topic id already in scope (telegramTopicId), pushing onto launchSpec.
+    expect(SRC).toMatch(/this\.buildSessionMcpProfileFlags\(options\?\.telegramTopicId\)/);
+    expect(SRC).toMatch(/launchSpec\.argv\.push\(\.\.\.mcpProfileFlags\)/);
+  });
+
+  it('fail-safe: the method returns [] (full .mcp.json) on the default/no-profile/error paths', () => {
+    // resolveMcpProfileServers returns null ⇒ early [] ; a try/catch wraps the I/O.
+    expect(SRC).toMatch(/if \(servers === null\) return \[\]/);
+  });
+});

--- a/tests/unit/session-mcp-profile.test.ts
+++ b/tests/unit/session-mcp-profile.test.ts
@@ -1,0 +1,64 @@
+/**
+ * Per-session MCP profiles (lever 1 of dynamic-MCP-lifecycle) — pure resolution.
+ * Default-no-op is the load-bearing safety property: off / no-profile ⇒ null ⇒
+ * the full .mcp.json is used unchanged. Both sides of each boundary are covered.
+ */
+import { describe, it, expect } from 'vitest';
+import { resolveMcpProfileServers, filterMcpConfig, type McpProfilesConfig, type McpJson } from '../../src/core/sessionMcpProfile.js';
+
+describe('resolveMcpProfileServers — default-no-op safety', () => {
+  const cfg = (over: Partial<McpProfilesConfig>): McpProfilesConfig => ({ enabled: true, ...over });
+
+  it('returns null when the feature is disabled (use full .mcp.json)', () => {
+    expect(resolveMcpProfileServers(28130, { enabled: false, topicServers: { '28130': ['threadline'] } })).toBeNull();
+    expect(resolveMcpProfileServers(28130, undefined)).toBeNull();
+  });
+
+  it('returns null when the topic has NO explicit profile (default keep-warm)', () => {
+    expect(resolveMcpProfileServers(28130, cfg({ topicServers: { '999': ['threadline'] } }))).toBeNull();
+    expect(resolveMcpProfileServers(undefined, cfg({ topicServers: { '28130': ['threadline'] } }))).toBeNull();
+  });
+
+  it('returns the explicit server subset for a profiled topic (number or string key)', () => {
+    const c = cfg({ topicServers: { '28130': ['threadline', 'playwright'] } });
+    expect(resolveMcpProfileServers(28130, c)).toEqual(['threadline', 'playwright']);
+    expect(resolveMcpProfileServers('28130', c)).toEqual(['threadline', 'playwright']);
+  });
+
+  it('an explicit empty list means NO MCP servers for that topic', () => {
+    expect(resolveMcpProfileServers(28130, cfg({ topicServers: { '28130': [] } }))).toEqual([]);
+  });
+
+  it('de-dupes and drops blanks', () => {
+    expect(resolveMcpProfileServers(28130, cfg({ topicServers: { '28130': ['threadline', 'threadline', '', 'playwright'] } })))
+      .toEqual(['threadline', 'playwright']);
+  });
+});
+
+describe('filterMcpConfig — preserves shape, keeps only allowed servers', () => {
+  const full: McpJson = {
+    mcpServers: { playwright: { command: 'pw' }, threadline: { command: 'tl' } },
+    otherTopLevel: { keep: true },
+  };
+
+  it('keeps only allowed servers, preserving other top-level fields', () => {
+    const out = filterMcpConfig(full, ['threadline']);
+    expect(Object.keys(out.mcpServers ?? {})).toEqual(['threadline']);
+    expect(out.otherTopLevel).toEqual({ keep: true });
+    // input not mutated
+    expect(Object.keys(full.mcpServers ?? {})).toEqual(['playwright', 'threadline']);
+  });
+
+  it('an empty allow-list yields an empty mcpServers (no servers launch)', () => {
+    expect(filterMcpConfig(full, [])).toEqual({ mcpServers: {}, otherTopLevel: { keep: true } });
+  });
+
+  it('ignores unknown server names in the allow-list', () => {
+    const out = filterMcpConfig(full, ['threadline', 'does-not-exist']);
+    expect(Object.keys(out.mcpServers ?? {})).toEqual(['threadline']);
+  });
+
+  it('tolerates a .mcp.json with no mcpServers key', () => {
+    expect(filterMcpConfig({ foo: 1 } as McpJson, ['x'])).toEqual({ foo: 1, mcpServers: {} });
+  });
+});

--- a/upgrades/mcp-session-profiles.eli16.md
+++ b/upgrades/mcp-session-profiles.eli16.md
@@ -1,0 +1,39 @@
+# Per-session MCP profiles — ELI16 overview
+
+## The problem in plain words
+
+When the agent opens a session for a topic, it gives that session a set of "MCP servers"
+— helper tools like a browser (Playwright, which runs a whole Chromium) or an agent-to-
+agent bridge. Right now every topic's session gets the FULL set, whether it needs them or
+not. Those helpers are heavy and mostly idle, and stacked across many sessions they were a
+big part of the process pile-up that crashed the machine on 2026-06-26.
+
+## What this change does
+
+This lets a topic launch its session with ONLY the MCP servers it actually needs. A topic
+that just edits code doesn't need a browser, so it can launch with none of the heavy ones
+(maybe just the lightweight agent-to-agent bridge). A browser topic still gets Playwright.
+Fewer heavy helpers per session = a smaller baseline footprint.
+
+How it works under the hood: Claude reads its MCP server list from a project file
+(`.mcp.json`) at launch. When a topic has a configured profile, the agent writes a
+filtered copy of that file (only the chosen servers) and launches the session pointed at
+the filtered copy.
+
+## The safety property that matters
+
+This is **default-no-op**. If the feature is off, or a topic has no profile configured,
+the session launches with the full `.mcp.json` exactly as today — byte-for-byte. A topic
+only loses a server by EXPLICIT configuration. And on any error (a missing or unreadable
+`.mcp.json`, anything unexpected) it falls back to the full set. So a session can never be
+accidentally stranded without the tools it needs — the fail-safe always points at "give it
+everything," never "give it nothing."
+
+It ships **dark** (off by default) and is purely a launch-time choice — it never touches a
+running session. This is the first of two steps: this one reduces the BASELINE footprint
+(fewer heavy servers started in the first place); a later step will reclaim a heavy server
+that's been sitting idle under a live session. The process-footprint monitor shipped
+earlier lets us measure the reduction.
+
+Config: `sessions.mcpProfiles` — `{ enabled, topicServers: { "<topicId>": ["server", …] } }`.
+A topic not listed keeps the full set (so Playwright stays warm everywhere by default).

--- a/upgrades/next/mcp-session-profiles.md
+++ b/upgrades/next/mcp-session-profiles.md
@@ -1,0 +1,52 @@
+---
+user_announcement:
+  - audience: agent-only
+    maturity: preview
+    summary: "A topic's session can now launch with only the MCP servers it needs (per-session profiles), cutting the heavy idle-MCP footprint. Dark, default-no-op."
+---
+
+## What Changed
+
+Added **per-session MCP profiles** — lever 1 of the dynamic-MCP-lifecycle work. A topic's
+interactive session can now launch with ONLY its profiled MCP servers (a filtered
+`.mcp.json`) instead of the full project set. Heavy, mostly-idle MCP servers (a whole
+Chromium for Playwright, an Electron for some bridges) stacked across sessions were a
+dominant share of the steady-state process footprint behind the 2026-06-26 resource panic;
+this cuts the baseline by not starting servers a topic doesn't need.
+
+DEFAULT-NO-OP and dark: when the feature is off, or a topic has no profile, the session
+launches with the full `.mcp.json` byte-for-byte as today, and every error path fails safe
+to the full set — a session can never be stranded without its tools. Config:
+`sessions.mcpProfiles` = `{ enabled, topicServers: { "<topicId>": ["server", …] } }`. A
+topic not listed keeps the full set (so Playwright stays warm everywhere by default).
+
+This is the BASELINE reducer; a later increment (lever 2) will reclaim a heavy server that
+has been idle under a live session, gated on a mid-tool-use safety check. The
+process-footprint monitor shipped earlier lets us measure the reduction.
+
+## Evidence
+
+**Before:** every topic's interactive session launched with the full `.mcp.json` (here:
+playwright + threadline), so a plain coding topic still started Playwright's Chromium it
+never used — the kind of idle heavyweight that accumulated into the panic's footprint.
+
+**After:** when a topic is profiled, `spawnInteractiveSession` (claude-code) writes a
+filtered `.mcp.json` and launches with `--strict-mcp-config --mcp-config <filtered>`. Unit
+tests pin the resolver (off ⇒ null; no-profile ⇒ null; explicit subset; explicit empty;
+de-dupe) and the filter (keeps only allowed, preserves other fields, no mutation, tolerates
+a missing `mcpServers`). Wiring tests assert the builder is actually called in the
+interactive claude-code branch with the topic id, pushes onto the launch argv, and returns
+`[]` (full set) on the default/error paths. `tsc` clean.
+
+## What to Tell Your User
+
+If a user asks why a topic's session has fewer tools, or how to slim a session's footprint,
+the answer is per-session MCP profiles — a topic launches with only the servers it needs,
+and anything unconfigured keeps the full set. It only changes what a session starts with; it
+never removes tools from a running session.
+
+## Summary of New Capabilities
+
+- Per-topic MCP server profiles resolved at interactive session launch (claude-code).
+- A filtered `.mcp.json` is written per session; the source file is never mutated.
+- Default-no-op + fail-safe-to-full-set; dark by default (`sessions.mcpProfiles`).

--- a/upgrades/side-effects/mcp-session-profiles.md
+++ b/upgrades/side-effects/mcp-session-profiles.md
@@ -1,0 +1,73 @@
+# Side-Effects Review — Per-session MCP profiles (dynamic-MCP lever 1)
+
+**Version / slug:** `mcp-session-profiles`
+**Date:** `2026-06-27`
+**Author:** `echo`
+**Tier:** 1 — a launch-time spawn-arg choice on the INTERACTIVE claude-code path. DARK by
+default and DEFAULT-NO-OP (absent config ⇒ full `.mcp.json`, byte-for-byte today). No new
+authority, route, or deletion. Touches the critical spawn function, so the no-op default +
+fail-safe-to-full-set are the load-bearing safeties.
+
+## Summary of the change
+
+Lever 1 of the dynamic-MCP-lifecycle: launch a topic's interactive session with ONLY its
+profiled MCP servers instead of the full project `.mcp.json`, cutting the heavy idle-MCP
+footprint that dominated the 2026-06-26 panic. Files: `src/core/sessionMcpProfile.ts` (new
+— pure `resolveMcpProfileServers` + `filterMcpConfig`), `src/core/SessionManager.ts` (a
+private `buildSessionMcpProfileFlags` + a single injection in `spawnInteractiveSession`'s
+claude-code branch), `src/core/types.ts` (`SessionManagerConfig.mcpProfiles`). Tests: 9
+unit + 4 wiring.
+
+## 1. Over-block (over-restrict a session's tools)
+
+The risk that MATTERS: a session launched WITHOUT a server it needs. Mitigations: (a) the
+feature is dark by default; (b) a topic gets the full set unless EXPLICITLY profiled — no
+implicit restriction; (c) every failure path (feature off / no profile / missing or
+unreadable `.mcp.json` / any throw) returns `[]` ⇒ the full `.mcp.json` ⇒ all tools. The
+fail-safe ALWAYS points at "give it everything." Tested both sides (null ⇒ no flags; an
+explicit list ⇒ exactly that subset).
+
+## 2. Under-block
+
+Not a gate — no under-block surface. The closest "miss" is a profiled topic still getting a
+server it listed; the resolver is a pure pass-through of the configured allow-list.
+
+## 3. Level-of-abstraction fit
+
+Correct layer. Server selection is a launch-time decision, made where the launch argv is
+assembled (`spawnInteractiveSession`), using the topic id already in scope
+(`telegramTopicId`). The decision logic is isolated in a pure, fake-free-testable module;
+SessionManager only does the I/O (read `.mcp.json`, write the filtered file, return flags).
+
+## 4. Signal vs authority compliance
+
+No block/allow surface. The profile is a launch-configuration input, not a gate; it can only
+narrow a session's OWN tool set per explicit config, never block a message/session/action.
+
+## 5. Interactions
+
+- **Spawn paths:** wired ONLY into the interactive claude-code spawn (`spawnInteractiveSession`).
+  The headless/job and rerouted lanes are untouched (jobs use the existing
+  `disableProjectMcp` no-MCP path). Gated `framework === 'claude-code'`.
+- **disableProjectMcp:** orthogonal — that path already strips MCP for jobs; the profile only
+  applies on the interactive path that otherwise reads the full `.mcp.json`.
+- **Per-session file:** a filtered copy is written under `<projectDir>/.instar/state/session-mcp-config/`
+  per spawn; the source `.mcp.json` is NEVER mutated. (Cleanup of stale filtered files is a
+  tracked minor follow-up; they are tiny JSON and overwritten by topic+timestamp.)
+
+## 6. External surfaces
+
+- No new route, credential, or external call. The only new I/O is reading the project
+  `.mcp.json` and writing a filtered copy locally (jailed under the agent home).
+- Config: `sessions.mcpProfiles` (dark). No migration needed (absence ⇒ no-op via `?? `/null).
+
+## 7. Rollback
+
+Pure additive code + one config block. `sessions.mcpProfiles.enabled` unset/false ⇒ full
+`.mcp.json` verbatim. Reverting the commit removes the path entirely.
+
+## Known follow-ups (tracked, not in this increment)
+
+- Lever 2 (idle-live MCP offload) — the runtime reclaimer, gated on a mid-tool-use check.
+- Stale filtered-config-file cleanup.
+- Wiring the same profile into the rerouted-interactive job lane if/when those need it.


### PR DESCRIPTION
## ELI16 — launch a topic with only the MCP tools it needs

When the agent opens a session for a topic, it gives that session a set of MCP helper servers — a browser (Playwright, which runs a whole Chromium), an agent-to-agent bridge, etc. Today every topic gets the FULL set whether it needs them or not, and those heavy, mostly-idle helpers stacked across many sessions were a big part of the process pile-up that crashed the machine on 2026-06-26. This change lets a topic launch with ONLY the servers it needs: a plain coding topic can skip the browser; a browser topic still gets it. It's **default-no-op** — off by default, and a topic only loses a server by explicit config; on any error it falls back to the full set, so a session can never be stranded without its tools. It only changes what a session STARTS with; it never touches a running session.

## What & why

Lever 1 of dynamic-MCP-lifecycle. The heavy idle MCP servers (Chromium/Electron) stacked across sessions were a dominant share of the steady-state footprint behind the panic. Per-session profiles cut the **baseline** by not starting servers a topic doesn't need. Follow-up to #1290 (disk arm) + #1291 (the footprint measurement).

## How
- New pure module `src/core/sessionMcpProfile.ts`: `resolveMcpProfileServers(topicId, cfg)` (returns `null` = full `.mcp.json` unless the feature is on AND the topic has an explicit profile) + `filterMcpConfig`.
- `SessionManager.buildSessionMcpProfileFlags` + a single injection in `spawnInteractiveSession`'s **claude-code** branch (uses the `telegramTopicId` already in scope). Writes a filtered `.mcp.json` per session and launches with `--strict-mcp-config --mcp-config <filtered>`; the source `.mcp.json` is **never** mutated.
- Config `sessions.mcpProfiles` (dark). A topic not listed keeps the full set (Playwright stays warm everywhere by default).

## Safety
DEFAULT-NO-OP + fail-safe-to-full-set: feature off / no profile / missing-or-unreadable `.mcp.json` / any error ⇒ `[]` ⇒ the full `.mcp.json` byte-for-byte as today. The fail-safe always points at "give it everything," never "give it nothing" — so this critical spawn-path change can't strand a session without its tools. Wired ONLY into the interactive claude-code lane; headless/job/rerouted lanes untouched.

## Tests
9 unit (resolver both sides + filter) + 4 wiring-integrity (the injection is actually connected, gated, fail-safe). `tsc` clean. Lever 2 (idle-live offload) + template awareness are tracked follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
