### PR TITLE
feat(mcp): operator-approval flow for Dynamic MCP — PIN-gated route + Mobile-Complete tap surface (C4-safe)

### DIFF
--- a/.instar/instar-dev-decisions/2026-06-27T05-46-04-000Z-dynamic-mcp-operator-approval-route.json
+++ b/.instar/instar-dev-decisions/2026-06-27T05-46-04-000Z-dynamic-mcp-operator-approval-route.json
@@ -1,0 +1,13 @@
+{
+  "ts": "2026-06-27T05:46:04.000Z",
+  "slug": "dynamic-mcp-operator-approval-route",
+  "suggestedTier": 2,
+  "declaredTier": 2,
+  "riskFloor": 2,
+  "riskFloorReasons": ["new capability: new route (router.<verb>() added"],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 30,
+  "causalAutopsy": { "origin": "new-code" },
+  "verdict": "pass"
+}

--- a/.instar/instar-dev-decisions/2026-06-27T06-05-00-000Z-dynamic-mcp-operator-approval-tap-surface.json
+++ b/.instar/instar-dev-decisions/2026-06-27T06-05-00-000Z-dynamic-mcp-operator-approval-tap-surface.json
@@ -1,0 +1,14 @@
+{
+  "ts": "2026-06-27T06:05:00.000Z",
+  "slug": "dynamic-mcp-operator-approval-tap-surface",
+  "suggestedTier": 2,
+  "declaredTier": 2,
+  "riskFloor": 2,
+  "riskFloorReasons": ["new capability: new routes (router.post/get '/mcp/approval-link', '/mcp/approve/:requestId' added)"],
+  "belowFloor": false,
+  "files": 4,
+  "loc": 120,
+  "causalAutopsy": { "origin": "new-code" },
+  "verdict": "pass",
+  "notes": "Phone-friendly tap flow over the existing PIN-gated approval. Opaque requestId keeps the server-minted nonce server-side (Secret-Drop posture); the GET page never renders the nonce; PIN-gated submit is single-use + TTL-bounded via PendingMcpApprovalStore. The bearer-only agent cannot satisfy the PIN gate, so approval authority stays structurally the operator's (C4 invariant preserved)."
+}

--- a/docs/dynamic-mcp-live-as-self-harness.md
+++ b/docs/dynamic-mcp-live-as-self-harness.md
@@ -1,0 +1,154 @@
+# Dynamic MCP — Live-as-Self Test Harness
+
+> The **Live-User-Channel Proof** for the Dynamic MCP Lifecycle. A user-facing
+> feature is not "done" until a user-role session has driven it end-to-end through
+> its **real** user surface (Telegram), in a live environment, **before** the
+> operator is ever asked to test. This runbook is that proof for dynamic MCP.
+>
+> **Operator standard (verbatim):** *"part of this development cycle should be a
+> plan to test this feature fully using the test-as-self method… use Playwright with
+> the custom profile that's logged into my Telegram so that you can test the feature
+> by sending messages through Telegram as me… this should always be part of every
+> feature testing plan."* And: *"I also want to verify that it both loads on demand
+> and offloads when the work requiring the MCP is done — these thorough test
+> scenarios should be the default standard."*
+
+This is a **deterministic runbook the agent executes itself** (via the Playwright
+MCP) — not a promise and not a thing the operator runs. It is **gated** only on one
+external prerequisite the agent cannot self-provision: a browser profile logged into
+the operator's Telegram. Everything else is automatable.
+
+The CI-side complement already exists and runs on every build — the
+`FULL LIFECYCLE: lean baseline → load on demand → offload when done → back to lean`
+test in `tests/unit/dynamic-mcp-service.test.ts`. This harness drives the **same**
+state transitions through the **real** Telegram surface + a **real** session restart,
+which the unit test (faked host primitives) cannot.
+
+---
+
+## Prerequisite (the one gate) — a Telegram-logged-in Playwright profile
+
+The harness needs a Playwright **profile** whose browser session is logged into the
+operator's Telegram Web, registered in the Playwright Profile Registry. Verify first
+(Know Before You Claim):
+
+```bash
+curl -H "Authorization: Bearer $AUTH" \
+  "http://localhost:4042/playwright-profiles/resolve?service=telegram"
+# → {"profile": null}  ⇒ NOT set up yet, the harness cannot run
+# → {"profile": {...}}  ⇒ ready
+```
+
+To set it up (operator does this once, on the machine that will run the harness):
+
+1. The operator opens `https://web.telegram.org` in a dedicated browser profile and
+   logs in (their account).
+2. Register that profile's user-data-dir:
+   ```bash
+   curl -X POST -H "Authorization: Bearer $AUTH" \
+     http://localhost:4042/playwright-profiles \
+     -H 'Content-Type: application/json' \
+     -d '{"id":"justin-telegram","description":"Operator Telegram Web — live-as-self testing"}'
+   curl -X POST -H "Authorization: Bearer $AUTH" \
+     http://localhost:4042/playwright-profiles/justin-telegram/accounts \
+     -H 'Content-Type: application/json' \
+     -d '{"service":"telegram","identity":"<operator handle>","owner":"operator","vaultRefs":[],"loginMethod":"web-session"}'
+   ```
+3. Re-run the `resolve` check above — it should now return the profile.
+
+> **Know Your Principal:** this profile is **operator-owned**. Acting *as* the
+> operator through it is authorized ONLY for this explicitly-mandated test-as-self
+> flow against demo/non-destructive surfaces. The harness sends only benign test
+> prompts; it never takes a consequential action as the operator.
+
+---
+
+## Test environment
+
+- Run on a **throwaway / demo topic**, never a live operator conversation, for the
+  volatile/permission scenarios (Live-User-Channel Proof standard).
+- Enable the feature for the test only: `.instar/config.json` →
+  `sessions.dynamicMcp.enabled: true` (+ `keepWarm: ["threadline"]`, and for the
+  idle-offload scenario `sessions.dynamicMcp.sweep: { enabled: true, dryRun: false,
+  idleOffloadMs: 60000 }` — a short idle window so the sweep fires within the test).
+  Restart the target session so it picks up the lean baseline.
+- The agent drives Telegram Web through the registered profile using the Playwright
+  MCP (`browser_navigate`, `browser_snapshot`, `browser_type`, `browser_click`).
+
+---
+
+## Scenario matrix (the PASS/FAIL the proof records)
+
+Each row: act through the **real** Telegram surface as the operator, then verify the
+**real** server state. Record PASS/FAIL with evidence (the `GET /mcp/session` body +
+the session's `model`/restart marker).
+
+### S1 — Lean baseline (cold start)
+1. Confirm the target session is freshly spawned with the feature on.
+2. **Verify:** `GET /mcp/session/:topicId` → `servers: ["threadline"]`, `source:
+   "baseline"`. The heavy server (playwright) is **absent**.
+   **PASS** iff the session launched lean.
+
+### S2 — Load on demand (autonomous-preapproved path)
+1. With an active autonomous run on the topic (preapproved), the agent calls
+   `POST /mcp/load {topicId, server:"playwright"}`.
+2. **Verify:** response `applied`; the session restarted (`--resume`, conversation
+   intact — confirm the thread continues, not a re-greet); `GET /mcp/session` now
+   lists `playwright`, `source: "committed"`.
+   **PASS** iff the heavy server loaded and the conversation survived the restart.
+
+### S3 — Load on demand (interactive, operator-approval TAP path)
+1. On a **non-preapproved** interactive topic, the agent calls `POST /mcp/load` →
+   `needs-approval` + a server-minted nonce.
+2. The agent calls `POST /mcp/approval-link` and **sends the operator the link over
+   Telegram**.
+3. **As the operator (via Playwright):** open the link, confirm the page shows the
+   right server + topic and **no nonce**, type the dashboard PIN, tap Approve.
+4. **Verify:** the page shows "Approved"; `GET /mcp/session` lists `playwright`. A
+   second tap on the same link → 404 (single-use).
+   **PASS** iff the operator-approved load completed via the tap and the agent could
+   not self-approve (the C4 invariant — confirm a bearer-only `POST /mcp/approve/:id`
+   without the PIN is 403).
+
+### S4 — Offload when done (explicit)
+1. After the work needing playwright is finished, the agent calls
+   `POST /mcp/offload {topicId, server:"playwright"}`.
+2. **Verify:** `applied`; session restarted; `GET /mcp/session` back to
+   `["threadline"]`; the heavy child processes are gone — `GET /processes/mcp-reaper`
+   (or `ps`) shows no orphaned Chromium for that session.
+   **PASS** iff the server dropped **and** its leaked children were reclaimed (C1).
+
+### S5 — Offload when idle (automatic sweep)
+1. Load playwright (S2), then leave the session idle (no tool use) past
+   `idleOffloadMs`.
+2. **Verify:** the sweep fires, offloads playwright, and `GET /mcp/session` returns
+   to lean **without** the agent being asked — the idle clock + mid-tool-use guard
+   did the right thing (it must NOT offload while the pane shows active work).
+   **PASS** iff idle → auto-offload → back to lean, and a busy session is left alone.
+
+### S6 — Mid-tool-use safety
+1. While the session is **actively** using a playwright tool, trigger an offload.
+2. **Verify:** the offload **aborts** (`{status:"aborted", reason:"mid-tool-use"}`),
+   no restart, nothing reaped.
+   **PASS** iff a busy session is never yanked.
+
+### S7 — Dark by default (regression)
+1. Set `sessions.dynamicMcp.enabled: false`, restart.
+2. **Verify:** every `/mcp/*` route → 503; the session launches with the **full**
+   `.mcp.json` set (byte-identical to pre-feature). **PASS** iff off ⇒ no behavior
+   change.
+
+---
+
+## Recording the proof
+
+Capture, per scenario: the Telegram action (screenshot via `browser_take_screenshot`),
+the `GET /mcp/session` body before/after, and the restart/process evidence. A run is
+a **PASS** only when S1–S7 all pass. File the signed scenario matrix per the
+Live-User-Channel Proof standard (`docs/specs/live-user-channel-proof-standard.md`)
+**before** the `sessions.dynamicMcp.enabled` dev-gate flip — the operator should never
+be the first to drive this feature.
+
+> Until the Telegram profile prerequisite is met, this harness is **blocked at S2/S3
+> live execution only**; S1/S7 (and the full deterministic lifecycle) are already
+> proven by the CI unit/integration/e2e suite. The flip waits on the live run.

--- a/docs/eli16/pending-mcp-approval-store.eli16.md
+++ b/docs/eli16/pending-mcp-approval-store.eli16.md
@@ -1,0 +1,30 @@
+# Pending MCP approval store (ELI16 overview)
+
+## What this is
+
+When the assistant needs you to approve loading a tool mid-chat, we want you to be
+able to approve with a tap on a link — not by typing a technical command. For that,
+the link can't carry the secret one-time approval code in its address (links end up
+in browser history and server logs). So instead, this little server-side notebook
+holds the pending request (which tool, which conversation, and the secret code), and
+the link only carries a meaningless lookup id.
+
+When you open the link, the approval page looks up the request by that id and shows
+you "Approve loading the browser for this chat?" — WITHOUT ever putting the secret
+code on the page. When you tap Approve and enter your PIN, the server looks up the
+secret code from the notebook, uses it once, and removes it.
+
+## Why it's safe
+
+It's a small in-memory notebook with three operations: jot down a request (get back a
+random lookup id), peek at a request's details (never the secret code), and use-once
+(hand back the secret code a single time, then erase it). Entries expire after a few
+minutes. Six tests confirm: the lookup id is opaque, peeking never leaks the code,
+using is single-use, unknown ids return nothing, and entries expire on time.
+
+## Status
+
+This is the foundation for the "tap to approve" screen. The screen itself (the page +
+its routes) comes next and is intentionally built after the live test-through-Telegram
+run, because that run is what tells us the right shape for the approval experience.
+The notebook is UI-agnostic, so it's worth building now regardless of that shape.

--- a/site/src/content/docs/features/dynamic-mcp.md
+++ b/site/src/content/docs/features/dynamic-mcp.md
@@ -57,8 +57,19 @@ approval. Because the agent is the only caller of these routes over the shared b
 token, the agent-facing routes always act as the agent and never honor a nonce
 supplied in the request body. A change the agent isn't preapproved for returns
 `needs-approval` with a server-minted nonce and performs no restart — the agent
-surfaces it and waits. The operator-authenticated approval route (which consumes the
-nonce) is a tracked follow-up.
+surfaces it and waits.
+
+The operator-authenticated approval route consumes that nonce. `POST /mcp/approve`
+takes the change plus the dashboard PIN; the PIN gate is what the agent (bearer-only,
+no PIN) cannot satisfy, so the approval authority is structurally the operator's. For
+a phone-friendly tap flow, **`PendingMcpApprovalStore`** holds the pending change
+behind an opaque `requestId` so the server-minted nonce never travels in a URL (the
+same posture as Secret Drop's opaque tokens). The agent calls `POST /mcp/approval-link`
+to register the pending change and surfaces the returned link; the operator opens
+`GET /mcp/approve/:requestId` (a page that renders the change details but **never** the
+nonce), and the PIN-gated `POST /mcp/approve/:requestId` consumes the request once and
+drives the change. `PendingMcpApprovalStore` is single-use and TTL-bounded, so a
+consumed or expired link is inert.
 
 When the agent offloads a heavy server, it captures the server's child process IDs
 before the restart and cleans them up after the new session is confirmed up — those
@@ -71,6 +82,14 @@ otherwise leak a browser process each time.
   with, whether the topic is preapproved, and the provenance.
 - `POST /mcp/load` — request that a server be loaded (`{ topicId, server }`).
 - `POST /mcp/offload` — request that an idle server be dropped.
+- `POST /mcp/approve` — operator-authenticated approval of a pending change
+  (`{ topicId, server, nonce, pin }`); PIN-gated.
+- `POST /mcp/approval-link` — register a pending change for the tap flow; returns an
+  opaque `requestId` + link (bearer-gated, agent-called).
+- `GET /mcp/approve/:requestId` — the tappable approval page (renders details, never
+  the nonce).
+- `POST /mcp/approve/:requestId` — the PIN-gated submit that consumes the request and
+  drives the change.
 
 All routes are bearer-gated and return 503 while the feature is dark. The full design
 and convergence record live in `docs/specs/DYNAMIC-MCP-LIFECYCLE-SPEC.md`.

--- a/src/core/DynamicMcpService.ts
+++ b/src/core/DynamicMcpService.ts
@@ -16,6 +16,7 @@ import fs from 'node:fs';
 import { DynamicMcpManager, type DynamicMcpDeps, type RequestActor, type RequestChangeResult } from './DynamicMcpManager.js';
 import { McpLoadedSetStore } from './McpLoadedSetStore.js';
 import { McpApprovalNonceStore } from './McpApprovalNonceStore.js';
+import { PendingMcpApprovalStore, type PendingMcpApprovalView, type McpChangeKind } from './PendingMcpApprovalStore.js';
 import { resolveBaselineServers, type DynamicMcpConfig, type McpJson } from './dynamicMcpConfig.js';
 
 export interface DynamicMcpServicePrimitives {
@@ -49,6 +50,7 @@ export interface SessionMcpState {
 export class DynamicMcpService {
   private readonly loadedSet: McpLoadedSetStore;
   private readonly nonces = new McpApprovalNonceStore();
+  private readonly pendingApprovals = new PendingMcpApprovalStore();
   private readonly manager: DynamicMcpManager;
 
   constructor(private readonly p: DynamicMcpServicePrimitives) {
@@ -101,5 +103,33 @@ export class DynamicMcpService {
 
   requestOffload(topicId: number, server: string, actor: RequestActor): Promise<RequestChangeResult> {
     return this.manager.requestChange({ topicId, op: 'offload', server, actor });
+  }
+
+  // ── Operator-approval TAP surface (the nonce stays server-side) ──
+
+  /** Register a pending change for the tap surface and get back an opaque
+   *  requestId to put in the approval link. The agent (which already holds the
+   *  nonce from its needs-approval response) calls this; the nonce never travels
+   *  in the URL. */
+  registerApproval(topicId: number, kind: McpChangeKind, server: string, nonce: string): string {
+    return this.pendingApprovals.register({ topicId, kind, server, nonce });
+  }
+
+  /** What the approval PAGE may render — details WITHOUT the nonce. */
+  peekApproval(requestId: string): PendingMcpApprovalView | null {
+    return this.pendingApprovals.peek(requestId);
+  }
+
+  /** The PIN-gated submit: consume the pending request (single-use) and drive the
+   *  change via the operator-approved actor. The caller (route) MUST have already
+   *  verified the operator PIN — this method does NOT itself authenticate. Returns
+   *  `unknown-request` when the requestId is absent/expired/already used. */
+  async approveByRequestId(requestId: string): Promise<RequestChangeResult | { status: 'unknown-request' }> {
+    const p = this.pendingApprovals.consume(requestId);
+    if (!p) return { status: 'unknown-request' };
+    const actor: RequestActor = { kind: 'operator-approved', nonce: p.nonce };
+    return p.kind === 'load'
+      ? this.requestLoad(p.topicId, p.server, actor)
+      : this.requestOffload(p.topicId, p.server, actor);
   }
 }

--- a/src/core/PendingMcpApprovalStore.ts
+++ b/src/core/PendingMcpApprovalStore.ts
@@ -1,0 +1,86 @@
+/**
+ * PendingMcpApprovalStore — the server-side registry behind the dynamic-MCP
+ * operator-approval TAP surface (DYNAMIC-MCP-LIFECYCLE-SPEC follow-up). When a
+ * non-preapproved interactive change needs operator approval, the agent registers
+ * the pending change here and gets back an OPAQUE `requestId` to put in a tap link
+ * — the server-minted nonce stays SERVER-SIDE and never travels in the URL (the
+ * same posture as Secret Drop's opaque tokens, vs. a nonce-in-query-string leak).
+ *
+ * The approval PAGE reads the request via `peek` (which NEVER returns the nonce),
+ * renders "Approve load of X on topic N?", and the PIN-gated submit calls `consume`
+ * (which returns the nonce once + removes the entry) so the route can drive the
+ * existing `{kind:'operator-approved', nonce}` change. Single-use + TTL-bounded.
+ */
+
+import crypto from 'node:crypto';
+
+export type McpChangeKind = 'load' | 'offload';
+
+export interface PendingMcpApproval {
+  topicId: number;
+  kind: McpChangeKind;
+  server: string;
+  nonce: string;
+  expiresAt: number;
+}
+
+/** What the approval page may see — deliberately WITHOUT the nonce. */
+export interface PendingMcpApprovalView {
+  requestId: string;
+  topicId: number;
+  kind: McpChangeKind;
+  server: string;
+}
+
+const DEFAULT_TTL_MS = 10 * 60 * 1000; // 10 min — long enough for a human tap
+
+export class PendingMcpApprovalStore {
+  private readonly byId = new Map<string, PendingMcpApproval>();
+
+  constructor(
+    private readonly ttlMs: number = DEFAULT_TTL_MS,
+    /** Injectable clock for tests; defaults to real time. */
+    private readonly now: () => number = () => Date.now(),
+  ) {}
+
+  /** Register a pending change; returns an opaque single-use requestId. */
+  register(input: { topicId: number; kind: McpChangeKind; server: string; nonce: string }): string {
+    const requestId = crypto.randomBytes(18).toString('base64url');
+    this.byId.set(requestId, {
+      topicId: input.topicId, kind: input.kind, server: input.server, nonce: input.nonce,
+      expiresAt: this.now() + this.ttlMs,
+    });
+    return requestId;
+  }
+
+  /** Read a pending request for the approval page — NEVER exposes the nonce.
+   *  Returns null when absent or expired (an expired entry is dropped). */
+  peek(requestId: string): PendingMcpApprovalView | null {
+    const e = this.byId.get(requestId);
+    if (!e) return null;
+    if (this.now() > e.expiresAt) { this.byId.delete(requestId); return null; }
+    return { requestId, topicId: e.topicId, kind: e.kind, server: e.server };
+  }
+
+  /** Consume (verify + invalidate) for the PIN-gated submit. Returns the full
+   *  entry INCLUDING the nonce once, then removes it (single-use). Null when
+   *  absent/expired. */
+  consume(requestId: string): PendingMcpApproval | null {
+    const e = this.byId.get(requestId);
+    if (!e) return null;
+    this.byId.delete(requestId); // single-use regardless of expiry
+    if (this.now() > e.expiresAt) return null;
+    return e;
+  }
+
+  /** Best-effort sweep of expired entries. */
+  pruneExpired(): number {
+    const t = this.now();
+    let removed = 0;
+    for (const [id, e] of this.byId) { if (t > e.expiresAt) { this.byId.delete(id); removed++; } }
+    return removed;
+  }
+
+  /** Outstanding (unconsumed, unexpired) count — for status/tests. */
+  size(): number { this.pruneExpired(); return this.byId.size; }
+}

--- a/src/server/routes.ts
+++ b/src/server/routes.ts
@@ -8275,6 +8275,37 @@ export function createRoutes(ctx: RouteContext): Router {
   router.post('/mcp/load', (req, res) => { void handleMcpChange('load')(req, res); });
   router.post('/mcp/offload', (req, res) => { void handleMcpChange('offload')(req, res); });
 
+  // POST /mcp/approve — the OPERATOR-AUTHENTICATED approval for a non-preapproved
+  // load/offload. PIN-GATED (the dashboard PIN), so the agent — which only holds the
+  // shared Bearer token and NEVER the PIN — structurally cannot reach this route to
+  // self-approve (the C4 invariant: an interactive change completes only via a live
+  // preapproval OR this operator-PIN-authenticated path). The operator supplies the
+  // server-minted nonce (which the agent surfaced from its needs-approval response)
+  // + the PIN; this consumes the nonce via the {kind:'operator-approved'} actor. A
+  // wrong/expired nonce simply fails the gate and returns needs-approval again.
+  const handleMcpApprove = async (req: ExpressRequest, res: ExpressResponse): Promise<void> => {
+    const svc = ctx.dynamicMcpService;
+    if (!svc || !svc.enabled()) { res.status(503).json({ error: 'dynamic-mcp disabled' }); return; }
+    if (!checkMandatePin(req, res)) return; // dashboard-PIN gate (rate-limited); response already sent on failure
+    const body = (req.body ?? {}) as { topicId?: unknown; kind?: unknown; server?: unknown; nonce?: unknown };
+    const topicId = Number(body.topicId);
+    const kind: 'load' | 'offload' = body.kind === 'offload' ? 'offload' : 'load';
+    const server = typeof body.server === 'string' ? body.server.trim() : '';
+    const nonce = typeof body.nonce === 'string' ? body.nonce : '';
+    if (!Number.isFinite(topicId) || !server || !nonce) {
+      res.status(400).json({ error: 'topicId (number), server (string), and nonce (string) are required' }); return;
+    }
+    const result = kind === 'load'
+      ? await svc.requestLoad(topicId, server, { kind: 'operator-approved', nonce })
+      : await svc.requestOffload(topicId, server, { kind: 'operator-approved', nonce });
+    const httpStatus =
+      result.status === 'applied' || result.status === 'no-op' ? 200
+        : result.status === 'needs-approval' ? 403 // the nonce didn't match/expired → approval did NOT take
+          : 409;
+    res.status(httpStatus).json({ ok: result.status === 'applied' || result.status === 'no-op', ...result });
+  };
+  router.post('/mcp/approve', (req, res) => { void handleMcpApprove(req, res); });
+
   // ── Feedback-factory processing (feedback-factory-migration §191) ──
   // Wires the already-parity'd processUnprocessed clustering pass into a real
   // triggerable capability. Both routes are dev-gated: ctx.feedbackProcessing is

--- a/src/server/routes.ts
+++ b/src/server/routes.ts
@@ -8306,6 +8306,59 @@ export function createRoutes(ctx: RouteContext): Router {
   };
   router.post('/mcp/approve', (req, res) => { void handleMcpApprove(req, res); });
 
+  // ── Operator-approval TAP surface (Mobile-Complete: tap a link, enter PIN) ──
+  // The agent registers a pending change (it holds the nonce from needs-approval) and
+  // surfaces the returned link; the operator taps it, sees the request (NO nonce on
+  // the page), and approves with the dashboard PIN. The nonce stays server-side
+  // (opaque requestId in the URL), and the PIN gate keeps the agent (Bearer-only,
+  // no PIN) from self-approving — the C4 invariant, made tappable.
+  const mcpHtmlEscape = (s: string): string => s.replace(/[&<>"']/g, (c) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c] as string));
+
+  // The agent (Bearer) registers a pending approval → opaque requestId + a tap URL.
+  router.post('/mcp/approval-link', (req, res) => {
+    const svc = ctx.dynamicMcpService;
+    if (!svc || !svc.enabled()) { res.status(503).json({ error: 'dynamic-mcp disabled' }); return; }
+    const body = (req.body ?? {}) as { topicId?: unknown; kind?: unknown; server?: unknown; nonce?: unknown };
+    const topicId = Number(body.topicId);
+    const kind: 'load' | 'offload' = body.kind === 'offload' ? 'offload' : 'load';
+    const server = typeof body.server === 'string' ? body.server.trim() : '';
+    const nonce = typeof body.nonce === 'string' ? body.nonce : '';
+    if (!Number.isFinite(topicId) || !server || !nonce) { res.status(400).json({ error: 'topicId, server, nonce required' }); return; }
+    const requestId = svc.registerApproval(topicId, kind, server, nonce);
+    const path = `/mcp/approve/${requestId}`;
+    res.json({ ok: true, requestId, path, url: ctx.tunnel?.getExternalUrl(path) ?? `http://localhost:${ctx.config.port}${path}` });
+  });
+
+  // The operator opens the link → a tappable approval page (NO nonce, NO PIN shown).
+  router.get('/mcp/approve/:requestId', (req, res) => {
+    const svc = ctx.dynamicMcpService;
+    if (!svc || !svc.enabled()) { res.status(503).type('html').send('<p>This approval feature is not enabled.</p>'); return; }
+    const view = svc.peekApproval(String(req.params.requestId));
+    if (!view) { res.status(404).type('html').send('<p>This approval request is no longer valid (used or expired).</p>'); return; }
+    const verb = view.kind === 'load' ? 'load' : 'drop';
+    res.type('html').send(`<!DOCTYPE html><html><head><meta name="viewport" content="width=device-width,initial-scale=1"><title>Approve MCP change</title>
+<style>body{font-family:system-ui,sans-serif;max-width:30rem;margin:2rem auto;padding:0 1rem}button{font-size:1.1rem;padding:.6rem 1.2rem;width:100%}input{font-size:1.1rem;padding:.5rem;width:100%;box-sizing:border-box}</style></head>
+<body><h2>Approve a tool change?</h2>
+<p>The agent wants to <b>${mcpHtmlEscape(verb)}</b> the <b>${mcpHtmlEscape(view.server)}</b> tool for this conversation (topic ${view.topicId}).</p>
+<p>Enter your dashboard PIN to approve. The agent cannot approve this itself.</p>
+<form method="POST" action="/mcp/approve/${mcpHtmlEscape(view.requestId)}">
+<p><input type="password" name="pin" inputmode="numeric" autocomplete="off" placeholder="Dashboard PIN" required></p>
+<p><button type="submit">Approve</button></p></form></body></html>`);
+  });
+
+  // The PIN-gated submit → consume the request server-side + drive the change.
+  router.post('/mcp/approve/:requestId', (req, res) => {
+    void (async (): Promise<void> => {
+      const svc = ctx.dynamicMcpService;
+      if (!svc || !svc.enabled()) { res.status(503).type('html').send('<p>Not enabled.</p>'); return; }
+      if (!checkMandatePin(req, res)) return; // dashboard-PIN gate (rate-limited); response already sent on failure
+      const result = await svc.approveByRequestId(String(req.params.requestId));
+      if (result.status === 'unknown-request') { res.status(404).type('html').send('<p>This approval request is no longer valid (used or expired).</p>'); return; }
+      const ok = result.status === 'applied';
+      res.status(ok ? 200 : 409).type('html').send(`<!DOCTYPE html><html><head><meta name="viewport" content="width=device-width,initial-scale=1"><style>body{font-family:system-ui,sans-serif;max-width:30rem;margin:2rem auto;padding:0 1rem}</style></head><body><h2>${ok ? '✅ Approved' : '⚠️ Not applied'}</h2><p>${ok ? 'The tool change was approved and is being applied — the session will restart briefly and continue.' : `The change was not applied (status: ${mcpHtmlEscape(result.status)}). You can close this page.`}</p></body></html>`);
+    })();
+  });
+
   // ── Feedback-factory processing (feedback-factory-migration §191) ──
   // Wires the already-parity'd processUnprocessed clustering pass into a real
   // triggerable capability. Both routes are dev-gated: ctx.feedbackProcessing is

--- a/tests/integration/dynamic-mcp-routes.test.ts
+++ b/tests/integration/dynamic-mcp-routes.test.ts
@@ -163,4 +163,82 @@ describe('/mcp/* routes', () => {
       expect(r.body.status).toBe('needs-approval');
     });
   });
+
+  describe('TAP surface — /mcp/approval-link + GET/POST /mcp/approve/:requestId', () => {
+    const PIN = '424242';
+
+    it('503 on every tap route when the feature is disabled', async () => {
+      const app = appWith(makeService({}, false), path.join(dir, '.instar'));
+      expect((await request(app).post('/mcp/approval-link').send({ topicId: 5, server: 'playwright', nonce: 'x' })).status).toBe(503);
+      expect((await request(app).get('/mcp/approve/anything')).status).toBe(503);
+      expect((await request(app).post('/mcp/approve/anything').send({ pin: PIN })).status).toBe(503);
+    });
+
+    it('approval-link validates input (missing nonce ⇒ 400)', async () => {
+      const app = appWith(makeService({}, true, false), path.join(dir, '.instar'));
+      const r = await request(app).post('/mcp/approval-link').send({ topicId: 5, server: 'playwright' });
+      expect(r.status).toBe(400);
+    });
+
+    it('the GET approval page renders details but NEVER the nonce', async () => {
+      const svc = makeService({}, true, /*preapproved*/ false);
+      const app = appWith(svc, path.join(dir, '.instar'));
+      const need = await request(app).post('/mcp/load').send({ topicId: 7, server: 'playwright' });
+      const nonce = need.body.nonce as string;
+      const link = await request(app).post('/mcp/approval-link').send({ topicId: 7, kind: 'load', server: 'playwright', nonce });
+      expect(link.status).toBe(200);
+      const requestId = link.body.requestId as string;
+      expect(requestId).toBeTruthy();
+      expect(link.body.path).toBe(`/mcp/approve/${requestId}`);
+      const page = await request(app).get(`/mcp/approve/${requestId}`);
+      expect(page.status).toBe(200);
+      expect(page.text).toContain('playwright');
+      expect(page.text).toContain('topic 7');
+      expect(page.text).not.toContain(nonce); // the nonce stays server-side
+    });
+
+    it('the full tap round trip: link → page → PIN submit ⇒ 200 applied + a restart', async () => {
+      const svc = makeService({}, true, /*preapproved*/ false);
+      const app = appWith(svc, path.join(dir, '.instar'));
+      const need = await request(app).post('/mcp/load').send({ topicId: 9, server: 'playwright' });
+      const nonce = need.body.nonce as string;
+      const link = await request(app).post('/mcp/approval-link').send({ topicId: 9, kind: 'load', server: 'playwright', nonce });
+      const requestId = link.body.requestId as string;
+      const before = restarts;
+      const ok = await request(app).post(`/mcp/approve/${requestId}`).send({ pin: PIN });
+      expect(ok.status).toBe(200);
+      expect(ok.text).toContain('Approved');
+      expect(restarts).toBe(before + 1);
+    });
+
+    it('the PIN gate holds — no PIN ⇒ 403, the agent (Bearer-only) cannot self-approve', async () => {
+      const svc = makeService({}, true, false);
+      const app = appWith(svc, path.join(dir, '.instar'));
+      const need = await request(app).post('/mcp/load').send({ topicId: 11, server: 'playwright' });
+      const nonce = need.body.nonce as string;
+      const link = await request(app).post('/mcp/approval-link').send({ topicId: 11, kind: 'load', server: 'playwright', nonce });
+      const requestId = link.body.requestId as string;
+      const r = await request(app).post(`/mcp/approve/${requestId}`).send({}); // no pin
+      expect(r.status).toBe(403);
+    });
+
+    it('single-use — a second PIN submit on the same requestId ⇒ 404 (consumed)', async () => {
+      const svc = makeService({}, true, false);
+      const app = appWith(svc, path.join(dir, '.instar'));
+      const need = await request(app).post('/mcp/load').send({ topicId: 13, server: 'playwright' });
+      const nonce = need.body.nonce as string;
+      const link = await request(app).post('/mcp/approval-link').send({ topicId: 13, kind: 'load', server: 'playwright', nonce });
+      const requestId = link.body.requestId as string;
+      const first = await request(app).post(`/mcp/approve/${requestId}`).send({ pin: PIN });
+      expect(first.status).toBe(200);
+      const second = await request(app).post(`/mcp/approve/${requestId}`).send({ pin: PIN });
+      expect(second.status).toBe(404);
+    });
+
+    it('an unknown requestId ⇒ GET 404 and POST(valid PIN) 404', async () => {
+      const app = appWith(makeService({}, true, false), path.join(dir, '.instar'));
+      expect((await request(app).get('/mcp/approve/nope')).status).toBe(404);
+      expect((await request(app).post('/mcp/approve/nope').send({ pin: PIN })).status).toBe(404);
+    });
+  });
 });

--- a/tests/integration/dynamic-mcp-routes.test.ts
+++ b/tests/integration/dynamic-mcp-routes.test.ts
@@ -18,7 +18,7 @@ const MCP_JSON = { mcpServers: { playwright: { command: 'npx' }, threadline: { c
 
 function appWith(service: DynamicMcpService | null, stateDir: string) {
   const ctx = {
-    config: { projectName: 'test', projectDir: '/tmp', stateDir, port: 0, sessions: {} as unknown, scheduler: {} as unknown } as unknown,
+    config: { projectName: 'test', projectDir: '/tmp', stateDir, port: 0, dashboardPin: '424242', sessions: {} as unknown, scheduler: {} as unknown } as unknown,
     sessionManager: { listRunningSessions: () => [] } as unknown,
     state: { getJobState: () => null, getSession: () => null } as unknown,
     scheduler: null, telegram: null, relationships: null, feedback: null, dispatches: null,
@@ -117,5 +117,50 @@ describe('/mcp/* routes', () => {
     const r = await request(appWith(svc, path.join(dir, ".instar"))).post('/mcp/offload').send({ topicId: 5, server: 'playwright' });
     expect(r.status).toBe(409);
     expect(r.body.status).toBe('aborted');
+  });
+
+  describe('POST /mcp/approve — operator-authenticated (PIN-gated) approval', () => {
+    const PIN = '424242';
+
+    it('503 when the feature is disabled', async () => {
+      const r = await request(appWith(makeService({}, false), path.join(dir, ".instar")))
+        .post('/mcp/approve').send({ topicId: 5, server: 'playwright', nonce: 'x', pin: PIN });
+      expect(r.status).toBe(503);
+    });
+
+    it('requires the operator PIN (no pin ⇒ 403, the agent cannot self-approve)', async () => {
+      const r = await request(appWith(makeService({}, true, false), path.join(dir, ".instar")))
+        .post('/mcp/approve').send({ topicId: 5, server: 'playwright', nonce: 'x' });
+      expect(r.status).toBe(403);
+    });
+
+    it('a WRONG pin ⇒ 403', async () => {
+      const r = await request(appWith(makeService({}, true, false), path.join(dir, ".instar")))
+        .post('/mcp/approve').send({ topicId: 5, server: 'playwright', nonce: 'x', pin: 'wrong' });
+      expect(r.status).toBe(403);
+    });
+
+    it('valid PIN + the real nonce from a needs-approval ⇒ 200 applied (the round trip)', async () => {
+      const svc = makeService({}, true, /*preapproved*/ false); // interactive, not preapproved
+      const app = appWith(svc, path.join(dir, ".instar"));
+      // 1) the agent (Bearer) requests a load → needs-approval + a server-minted nonce
+      const need = await request(app).post('/mcp/load').send({ topicId: 5, server: 'playwright' });
+      expect(need.status).toBe(202);
+      const nonce = need.body.nonce as string;
+      expect(nonce).toBeTruthy();
+      // 2) the operator (PIN) approves with that nonce → the load completes
+      const ok = await request(app).post('/mcp/approve').send({ topicId: 5, server: 'playwright', nonce, pin: PIN });
+      expect(ok.status).toBe(200);
+      expect(ok.body).toMatchObject({ ok: true, status: 'applied' });
+    });
+
+    it('valid PIN but a WRONG nonce ⇒ 403 needs-approval (the approval did not take)', async () => {
+      const svc = makeService({}, true, false);
+      const app = appWith(svc, path.join(dir, ".instar"));
+      await request(app).post('/mcp/load').send({ topicId: 5, server: 'playwright' }); // mint a real nonce
+      const r = await request(app).post('/mcp/approve').send({ topicId: 5, server: 'playwright', nonce: 'FORGED', pin: PIN });
+      expect(r.status).toBe(403);
+      expect(r.body.status).toBe('needs-approval');
+    });
   });
 });

--- a/tests/unit/dynamic-mcp-service.test.ts
+++ b/tests/unit/dynamic-mcp-service.test.ts
@@ -112,4 +112,44 @@ describe('DynamicMcpService', () => {
     // committed set is still the baseline (rollback), playwright NOT persisted as committed
     expect(committedOf(5)).toEqual(['threadline']);
   });
+
+  // The default-standard "thorough scenario" (operator mandate): a feature must be
+  // proven to BOTH load on demand AND offload when the work is done — as one
+  // continuous flow over the real service state, not just isolated operations. This
+  // is the deterministic, runs-in-CI complement to the live-as-self Playwright proof
+  // (which drives the same flow through a real session). See
+  // docs/specs/DYNAMIC-MCP-LIFECYCLE-SPEC.md and the live harness in
+  // docs/dynamic-mcp-live-as-self-harness.md.
+  it('FULL LIFECYCLE: lean baseline → load on demand → offload when done → back to lean', async () => {
+    const captured = [9001, 9002];
+    const svc = make({ captureHeavyPids: () => captured });
+    const TOPIC = 42;
+
+    // 1) starts LEAN — only the keep-warm baseline, no heavy server, no restart yet.
+    expect(svc.getSessionState(TOPIC)).toMatchObject({ servers: ['threadline'], source: 'baseline' });
+    expect(restarts).toBe(0);
+
+    // 2) LOADS ON DEMAND — the heavy server is added and the session restarts once.
+    const load = await svc.requestLoad(TOPIC, 'playwright', { kind: 'agent' });
+    expect(load.status).toBe('applied');
+    expect(restarts).toBe(1);
+    const afterLoad = svc.getSessionState(TOPIC);
+    expect(new Set(afterLoad.servers)).toEqual(new Set(['threadline', 'playwright']));
+    expect(afterLoad.source).toBe('committed'); // the load is durably committed, survives a re-read
+    expect(reaped).toHaveLength(0);              // nothing reaped on a load
+
+    // 3) OFFLOADS WHEN DONE — the heavy server is dropped, the session restarts again,
+    //    and the heavy child processes captured-before-kill are actually reaped (C1:
+    //    they reparent to launchd, so the offload must clean them up explicitly).
+    const offload = await svc.requestOffload(TOPIC, 'playwright', { kind: 'agent' });
+    expect(offload.status).toBe('applied');
+    expect(restarts).toBe(2);
+    expect(reaped).toEqual([captured]); // the leaked browser children are reclaimed
+
+    // 4) BACK TO LEAN — the committed set is the keep-warm baseline again; a fresh
+    //    read sees no heavy server. The machine reclaimed the footprint it borrowed.
+    const afterOffload = svc.getSessionState(TOPIC);
+    expect(afterOffload.servers).toEqual(['threadline']);
+    expect(committedOf(TOPIC)).toEqual(['threadline']);
+  });
 });

--- a/tests/unit/pending-mcp-approval-store.test.ts
+++ b/tests/unit/pending-mcp-approval-store.test.ts
@@ -1,0 +1,64 @@
+/**
+ * PendingMcpApprovalStore — the registry behind the operator-approval tap surface.
+ * Verifies opaque ids, peek-never-exposes-nonce, single-use consume, TTL.
+ */
+import { describe, it, expect } from 'vitest';
+import { PendingMcpApprovalStore } from '../../src/core/PendingMcpApprovalStore.js';
+
+describe('PendingMcpApprovalStore', () => {
+  it('register returns an opaque id; peek exposes details but NEVER the nonce', () => {
+    const s = new PendingMcpApprovalStore();
+    const id = s.register({ topicId: 5, kind: 'load', server: 'playwright', nonce: 'SECRET' });
+    expect(typeof id).toBe('string');
+    const view = s.peek(id);
+    expect(view).toMatchObject({ requestId: id, topicId: 5, kind: 'load', server: 'playwright' });
+    expect(JSON.stringify(view)).not.toContain('SECRET'); // the nonce never leaks to the page
+    expect((view as Record<string, unknown>).nonce).toBeUndefined();
+  });
+
+  it('consume returns the full entry (incl. nonce) ONCE, then it is gone (single-use)', () => {
+    const s = new PendingMcpApprovalStore();
+    const id = s.register({ topicId: 5, kind: 'load', server: 'playwright', nonce: 'SECRET' });
+    const first = s.consume(id);
+    expect(first).toMatchObject({ topicId: 5, kind: 'load', server: 'playwright', nonce: 'SECRET' });
+    expect(s.consume(id)).toBeNull(); // single-use
+    expect(s.peek(id)).toBeNull();
+  });
+
+  it('peek does NOT consume (the page can render repeatedly before approval)', () => {
+    const s = new PendingMcpApprovalStore();
+    const id = s.register({ topicId: 5, kind: 'load', server: 'playwright', nonce: 'n' });
+    expect(s.peek(id)).not.toBeNull();
+    expect(s.peek(id)).not.toBeNull(); // still there
+    expect(s.consume(id)).not.toBeNull();
+  });
+
+  it('an unknown id ⇒ peek/consume null', () => {
+    const s = new PendingMcpApprovalStore();
+    expect(s.peek('nope')).toBeNull();
+    expect(s.consume('nope')).toBeNull();
+  });
+
+  it('expires after the TTL (peek and consume both null)', () => {
+    let t = 1000;
+    const s = new PendingMcpApprovalStore(5000, () => t);
+    const id = s.register({ topicId: 5, kind: 'load', server: 'playwright', nonce: 'n' });
+    t = 6001;
+    expect(s.peek(id)).toBeNull();
+    // a fresh entry to test consume-expiry independently
+    t = 0; const s2 = new PendingMcpApprovalStore(5000, () => t);
+    const id2 = s2.register({ topicId: 1, kind: 'offload', server: 'x', nonce: 'n' });
+    t = 6000;
+    expect(s2.consume(id2)).toBeNull();
+  });
+
+  it('size reflects outstanding entries and prunes expired', () => {
+    let t = 0;
+    const s = new PendingMcpApprovalStore(1000, () => t);
+    s.register({ topicId: 1, kind: 'load', server: 'a', nonce: 'n' });
+    s.register({ topicId: 2, kind: 'load', server: 'b', nonce: 'n' });
+    expect(s.size()).toBe(2);
+    t = 2000;
+    expect(s.size()).toBe(0);
+  });
+});

--- a/upgrades/next/dynamic-mcp-operator-approval.md
+++ b/upgrades/next/dynamic-mcp-operator-approval.md
@@ -1,0 +1,36 @@
+<!-- bump: patch -->
+<!-- audience: agent-only -->
+<!-- maturity: experimental -->
+
+## What Changed
+
+Added the **operator-approval route** (`POST /mcp/approve`) for the Dynamic MCP
+Lifecycle (⚗️ experimental, dark) — the piece that lets an **interactive** session
+(not just an autonomous-preapproved one) complete a load-on-demand. It is **PIN-gated**
+(the dashboard PIN), so the agent — which holds only the shared Bearer token and never
+the PIN — structurally cannot reach it to self-approve. The operator supplies the
+server-minted nonce (which the agent surfaced) plus the PIN, and the change completes
+via the existing `{kind:'operator-approved'}` path. This is the concrete completion of
+the C4 "agent can't approve its own change" invariant the dynamic-MCP spec required.
+
+Still dark by default. NOT yet operator-complete: the Mobile-Complete "tap to approve"
+surface (so the operator taps rather than POSTs) is the explicit next increment.
+
+## What to Tell Your User
+
+If a user asks "how do I approve the agent loading a tool mid-chat?" — once the
+feature is enabled, the agent surfaces the request and the user approves it with their
+dashboard PIN; the agent cannot approve on its own behalf.
+
+## Summary of New Capabilities
+
+- `POST /mcp/approve` — operator-PIN-authenticated approval of a non-preapproved MCP
+  load/offload (dark; 503 when the feature is off).
+
+## Evidence
+
+14 integration tests over the real createRoutes pipeline, including the full round
+trip (agent `needs-approval` → server-minted nonce → operator PIN + nonce → `applied`),
+plus the C4 cases (no PIN ⇒ 403, wrong PIN ⇒ 403, wrong/expired nonce ⇒ 403
+needs-approval). Backed by the converged+approved DYNAMIC-MCP-LIFECYCLE-SPEC, which
+named this route as the follow-up. tsc clean.

--- a/upgrades/side-effects/dynamic-mcp-operator-approval-route.md
+++ b/upgrades/side-effects/dynamic-mcp-operator-approval-route.md
@@ -1,0 +1,44 @@
+# Side-effects review — dynamic-MCP operator-approval route (POST /mcp/approve)
+
+**Change:** Add `POST /mcp/approve` to routes.ts — the operator-authenticated approval
+for a non-preapproved interactive load/offload. The DYNAMIC-MCP-LIFECYCLE-SPEC named
+this as the follow-up so an INTERACTIVE session (not just an autonomous-preapproved
+one) can complete a load-on-demand.
+
+## 1. Blast radius
+Zero until enabled. The route 503s when `dynamicMcpService` is absent/disabled (dark
+default), exactly like the other /mcp/* routes.
+
+## 2. Reversibility
+Fully reversible — remove the handler + route.
+
+## 3. State / data touched
+None new. On a valid PIN + nonce it calls the existing
+`DynamicMcpService.requestLoad/Offload(..., {kind:'operator-approved', nonce})`, which
+consumes the server-minted nonce and (on success) drives the existing gated change.
+
+## 4. Failure modes
+Fail-closed: 503 (dark) / 403 (no PIN, wrong PIN) / 400 (missing topicId/server/nonce)
+/ 403 needs-approval (nonce wrong/expired ⇒ the approval did NOT take). A wrong nonce
+can never approve; a wrong PIN can never approve.
+
+## 5. Security / authority — THE load-bearing review (C4 + Know Your Principal)
+The route is **PIN-GATED** (the dashboard PIN, via the existing rate-limited
+checkMandatePin). The agent holds only the shared Bearer token and NEVER the PIN
+(CLAUDE.md: the PIN is operator-only), so the agent **structurally cannot reach this
+route to self-approve** — this is the concrete completion of the C4 invariant: an
+interactive change completes only via a live preapproval OR this operator-PIN-
+authenticated path. The agent-facing /mcp/load|offload routes still NEVER honor a body
+nonce. The operator supplies the nonce (which the agent surfaced) + the PIN together.
+
+## 6. Operator-surface quality (honest)
+This commit ships the MECHANISM (the route), not yet the Mobile-Complete tap surface.
+Until a dashboard "Approve" button lands (the explicit next increment), an operator
+would have to POST the route — which does NOT meet "Operators Act in Taps, Not Text".
+So this is NOT operator-complete yet; it is the auth-correct mechanism the tap surface
+will call. Not claimed as done.
+
+## 7. Tests
+14 integration tests (+5): 503 dark; PIN required (no pin ⇒ 403 — agent can't
+self-approve); wrong PIN ⇒ 403; the real round trip (agent needs-approval → nonce →
+operator PIN+nonce ⇒ applied); wrong nonce ⇒ 403 needs-approval. tsc clean.

--- a/upgrades/side-effects/pending-mcp-approval-store.md
+++ b/upgrades/side-effects/pending-mcp-approval-store.md
@@ -1,0 +1,33 @@
+# Side-effects review — PendingMcpApprovalStore (operator-approval tap-surface foundation)
+
+**Change:** New `src/core/PendingMcpApprovalStore.ts` — an in-memory registry that
+lets the operator-approval tap surface put an OPAQUE requestId in the link while the
+server-minted nonce stays server-side (vs. a nonce-in-URL leak). 6 unit tests.
+
+## 1. Blast radius
+Zero at runtime. No importer yet — the approval-page routes (the next increment,
+sequenced after the live-test informs the UI) will use it. Inert + dark-feature.
+
+## 2. Reversibility
+Fully reversible — delete the file + tests. In-memory only; no persisted state.
+
+## 3. State / data touched
+None on disk. An in-memory Map keyed by an opaque requestId → {topicId, kind, server,
+nonce, expiresAt}, TTL-pruned.
+
+## 4. Failure modes
+Fail-closed: peek/consume return null on absent/expired; consume is single-use
+(removes regardless). peek NEVER returns the nonce (the page can't leak it).
+
+## 5. Security / authority
+The nonce is the approval secret; this store keeps it SERVER-SIDE and exposes it only
+once via `consume` (called by the PIN-gated submit), never via `peek` (the page). The
+opaque requestId carries no secret. No authority is exercised — it's a holding ledger;
+the PIN gate + nonce consume in the route are the authority.
+
+## 6. Framework generality
+Framework-neutral in-memory store; no launch/inject surface.
+
+## 7. Tests
+6 unit tests: opaque id + peek-never-leaks-nonce; single-use consume; peek-doesn't-
+consume; unknown-id null; TTL expiry (peek + consume); size/prune. tsc clean.


### PR DESCRIPTION
## Summary

Follow-up to the Dynamic MCP Lifecycle (#1293, merged). Adds the **operator-approval flow** so an **interactive** session — not just an autonomous-preapproved one — can complete a load-on-demand. Without it, an interactive `needs-approval` had no operator-authenticated way to be consumed.

Ships in two layers, both **dark by default** (503 when the feature is off):
1. **`POST /mcp/approve`** — the auth-correct mechanism (agent supplies the surfaced nonce + the dashboard PIN in one body).
2. **The Mobile-Complete tap surface** — `POST /mcp/approval-link` (agent registers the pending change, gets back an opaque `requestId` + link) → `GET /mcp/approve/:requestId` (a tappable approval page) → `POST /mcp/approve/:requestId` (PIN-gated submit). This satisfies "Operators Act in Taps, Not Text."

## The C4 invariant, made concrete

Every approval path is **PIN-gated** (the dashboard PIN, via the rate-limited `checkMandatePin`). The agent holds only the shared Bearer token and **never** the PIN, so it **structurally cannot self-approve** — completing the C4 "agent can't approve its own change" invariant. The agent-facing `/mcp/load|offload` routes still never honor a body nonce.

## Nonce stays server-side (Secret-Drop posture)

The tap surface puts an **opaque `requestId`** in the link, never the nonce. `PendingMcpApprovalStore` holds the server-minted nonce; the `GET` page renders the change details but **never** the nonce; the PIN-gated submit `consume`s the request **once** (single-use + TTL-bounded) and drives the existing `{kind:'operator-approved', nonce}` change. So a leaked/expired link is inert and the nonce never travels in a URL.

## Tests

21 integration tests over the real `createRoutes` pipeline + 6 unit tests for `PendingMcpApprovalStore`. Covers: 503 (dark); PIN required (no pin ⇒ 403 — the agent can't self-approve); wrong PIN ⇒ 403; the direct round trip (agent `needs-approval` → server-minted nonce → operator PIN + nonce ⇒ `applied`); wrong/expired nonce ⇒ 403; and the **tap** round trip (link → page → PIN submit ⇒ `applied` + a restart), nonce-never-rendered, single-use (second submit ⇒ 404), unknown-id ⇒ 404. tsc clean. Backed by the converged+approved `DYNAMIC-MCP-LIFECYCLE-SPEC`.

## ELI16

Your AI assistant can now ask to load a heavy tool (like a web browser) only when it actually needs one, instead of always carrying it. If the assistant is running on its own (an overnight autonomous job), it's pre-trusted to do that itself. But when it's chatting with you live and isn't pre-trusted, it has to ask you first. This change adds the "you approve it" path — and makes it a **tap**: the assistant sends you a link, you open it on your phone, see exactly what it wants to load, and approve by typing your private dashboard PIN. The important safety bit is that the assistant talks to its own server with a shared key that is NOT the PIN — so it can't quietly approve its own request and load tools without you. The secret one-time code that authorizes the change stays on the server and never shows up in the link, so even if someone saw the link they couldn't use it. This is all off by default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
