### PR TITLE
fix(mcp): operator-approval tap page must be reachable by the operator's browser (auth-exempt + JSON body)

### DIFF
--- a/.instar/instar-dev-decisions/2026-06-27T07-43-00-000Z-mcp-approve-tap-page-auth-and-body.json
+++ b/.instar/instar-dev-decisions/2026-06-27T07-43-00-000Z-mcp-approve-tap-page-auth-and-body.json
@@ -1,0 +1,14 @@
+{
+  "ts": "2026-06-27T07:43:00.000Z",
+  "slug": "mcp-approve-tap-page-auth-and-body-fix",
+  "suggestedTier": 1,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": ["bugfix: operator-facing route reachability (auth-middleware exemption + request body parsing)"],
+  "belowFloor": false,
+  "files": 2,
+  "loc": 40,
+  "causalAutopsy": { "origin": "existing-code-bug" },
+  "verdict": "pass",
+  "notes": "Live-as-self test (operator browser opening the tap-approval page) surfaced TWO escapes the unit/integration tests missed because they bypass the real auth middleware + send JSON directly: (1) GET/POST /mcp/approve/:requestId were behind the global Bearer gate, so the operator's browser (PIN, no Bearer) got 401 before the page rendered — fixed by a middleware exemption mirroring /secrets/drop (opaque requestId + PIN are the auth). (2) the page used a plain urlencoded <form> POST but the server only registers express.json(), so req.body.pin was empty -> 403 — fixed by submitting via fetch()+JSON, matching the proven SecretDrop renderForm pattern. Regression tests added at the middleware unit layer + the real-AgentServer e2e layer (the layers that actually exercise auth)."
+}

--- a/src/server/middleware.ts
+++ b/src/server/middleware.ts
@@ -220,6 +220,19 @@ export function authMiddleware(authToken?: string | (() => string | undefined), 
       return;
     }
 
+    // Dynamic-MCP operator-approval TAP pages — opened by the operator's BROWSER,
+    // which carries no Bearer token (the operator has the dashboard PIN, not the
+    // agent token). Same posture as Secret Drop: the opaque single-use requestId in
+    // the URL gates the GET page (renders the change, never the nonce), and the POST
+    // submit is PIN-gated by checkMandatePin inside the handler. The Bearer middleware
+    // would otherwise 401 the page before it ever renders. Scoped to `/mcp/approve/<id>`
+    // (trailing slash) so the agent-only `/mcp/approve` (exact) + `/mcp/approval-link`
+    // + `/mcp/load|offload|session` stay Bearer-gated.
+    if (req.path.startsWith('/mcp/approve/')) {
+      next();
+      return;
+    }
+
     // View routes support signed URLs for browser access (see ?sig= below)
     if (req.path.startsWith('/view/') && req.method === 'GET') {
       const sig = typeof req.query.sig === 'string' ? req.query.sig : null;

--- a/src/server/routes.ts
+++ b/src/server/routes.ts
@@ -8341,9 +8341,28 @@ export function createRoutes(ctx: RouteContext): Router {
 <body><h2>Approve a tool change?</h2>
 <p>The agent wants to <b>${mcpHtmlEscape(verb)}</b> the <b>${mcpHtmlEscape(view.server)}</b> tool for this conversation (topic ${view.topicId}).</p>
 <p>Enter your dashboard PIN to approve. The agent cannot approve this itself.</p>
-<form method="POST" action="/mcp/approve/${mcpHtmlEscape(view.requestId)}">
-<p><input type="password" name="pin" inputmode="numeric" autocomplete="off" placeholder="Dashboard PIN" required></p>
-<p><button type="submit">Approve</button></p></form></body></html>`);
+<form id="mcpForm">
+<p><input id="mcpPin" type="password" inputmode="numeric" autocomplete="off" placeholder="Dashboard PIN" required></p>
+<p><button type="submit">Approve</button></p></form>
+<script>
+// Submit the PIN as JSON via fetch (the server parses application/json, not
+// urlencoded form bodies) and render the returned result page in place.
+document.getElementById('mcpForm').addEventListener('submit', async function (e) {
+  e.preventDefault();
+  var btn = this.querySelector('button'); btn.disabled = true; btn.textContent = 'Approving…';
+  try {
+    var r = await fetch(${JSON.stringify('/mcp/approve/' + view.requestId)}, {
+      method: 'POST', headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ pin: document.getElementById('mcpPin').value })
+    });
+    var html = await r.text();
+    document.open(); document.write(html); document.close();
+  } catch (err) {
+    btn.disabled = false; btn.textContent = 'Approve';
+    alert('Could not reach the server — please try again.');
+  }
+});
+</script></body></html>`);
   });
 
   // The PIN-gated submit → consume the request server-side + drive the change.

--- a/tests/e2e/dynamic-mcp-routes-alive.test.ts
+++ b/tests/e2e/dynamic-mcp-routes-alive.test.ts
@@ -86,6 +86,27 @@ describe('/mcp/* routes E2E (alive on the real AgentServer boot)', () => {
     expect(res.status).not.toBe(404);
     expect(res.status).not.toBe(503); // enabled boot ⇒ not dark
   });
+
+  // Regression (live-as-self finding): the operator-approval TAP page is opened by the
+  // operator's BROWSER, which carries no Bearer token. Before the auth exemption it 401'd
+  // through the real middleware (the integration tests bypass the middleware, so they
+  // missed it). It must reach the handler WITHOUT a token — an unknown requestId 404s,
+  // never 401. This asserts through the REAL AgentServer auth stack.
+  it('GET /mcp/approve/<id> is reachable WITHOUT a Bearer token (404 unknown, never 401)', async () => {
+    const res = await request(app).get('/mcp/approve/nonexistent-request-id');
+    expect(res.status).not.toBe(401);
+    expect(res.status).toBe(404);
+  });
+
+  it('POST /mcp/approve/<id> is reachable WITHOUT a Bearer token (browser form submit; not 401)', async () => {
+    const res = await request(app).post('/mcp/approve/nonexistent-request-id').send({ pin: '000000' });
+    expect(res.status).not.toBe(401);
+  });
+
+  it('the agent-only /mcp/approval-link STAYS Bearer-gated (401 without a token)', async () => {
+    const res = await request(app).post('/mcp/approval-link').send({ topicId: 5, server: 'playwright', nonce: 'x' });
+    expect(res.status).toBe(401);
+  });
 });
 
 describe('/mcp/* routes E2E (503 on a DISABLED boot — the dark default)', () => {

--- a/tests/unit/auth-middleware-live-token.test.ts
+++ b/tests/unit/auth-middleware-live-token.test.ts
@@ -104,4 +104,37 @@ describe('authMiddleware live-token resolution', () => {
     const mw = authMiddleware(() => undefined);
     expect(run(mw, mockReq({ path: '/status' }), mockRes())).toBe(true);
   });
+
+  // Dynamic-MCP operator-approval TAP pages are opened by the operator's browser,
+  // which carries no Bearer token (it has the dashboard PIN). The page route must be
+  // exempt from the bearer gate — the opaque requestId in the URL + the PIN on submit
+  // are the auth. Regression: a live-as-self test found the browser got a 401 here
+  // because the route was behind the bearer middleware (the integration tests bypass
+  // the middleware, so they missed it).
+  describe('dynamic-MCP approval tap-page bearer exemption', () => {
+    const mw = authMiddleware('static-token');
+    it('GET /mcp/approve/<requestId> is exempt (no Bearer → next())', () => {
+      expect(run(mw, mockReq({ path: '/mcp/approve/abc123', method: 'GET' }), mockRes())).toBe(true);
+    });
+    it('POST /mcp/approve/<requestId> is exempt (browser form submit, no Bearer → next(); PIN-gated in handler)', () => {
+      expect(run(mw, mockReq({ path: '/mcp/approve/abc123', method: 'POST' }), mockRes())).toBe(true);
+    });
+    it('the exact agent-only /mcp/approve (no requestId) stays Bearer-gated (401 without a token)', () => {
+      const res = mockRes();
+      expect(run(mw, mockReq({ path: '/mcp/approve', method: 'POST' }), res)).toBe(false);
+      expect(res.statusCode).toBe(401);
+    });
+    it('/mcp/approval-link stays Bearer-gated (agent-only registration; 401 without a token)', () => {
+      const res = mockRes();
+      expect(run(mw, mockReq({ path: '/mcp/approval-link', method: 'POST' }), res)).toBe(false);
+      expect(res.statusCode).toBe(401);
+    });
+    it('the agent data routes /mcp/load|offload|session stay Bearer-gated', () => {
+      for (const p of ['/mcp/load', '/mcp/offload', '/mcp/session/5']) {
+        const res = mockRes();
+        expect(run(mw, mockReq({ path: p, method: 'POST' }), res)).toBe(false);
+        expect(res.statusCode).toBe(401);
+      }
+    });
+  });
 });


### PR DESCRIPTION
## Summary

A **live-as-self test** (driving the dynamic-MCP operator-approval flow through a real browser, as the operator would) caught two real escapes in #1294's tap surface that the unit + integration tests missed — because those tests bypass the real auth middleware and POST JSON directly, so neither exercised the actual browser path.

### Bug 1 — the approval page 401'd the operator's browser
`GET`/`POST /mcp/approve/:requestId` were behind the global Bearer-auth gate. The operator opens the link in a browser, which carries the **dashboard PIN, not the agent Bearer token** — so the page returned `{"error":"Missing or invalid Authorization header"}` before it ever rendered. The tap surface was unusable end-to-end.

**Fix:** exempt `/mcp/approve/<id>` in the auth middleware, exactly mirroring the existing `/secrets/drop/` and `/view/` operator-facing pages — the opaque single-use `requestId` in the URL gates the GET, and the PIN (`checkMandatePin`) gates the POST. The agent-only `/mcp/approve` (exact), `/mcp/approval-link`, and `/mcp/load|offload|session` stay Bearer-gated.

### Bug 2 — the PIN never reached the handler
The page submitted a plain urlencoded `<form>` POST, but the server only registers `express.json()` (no `express.urlencoded()`), so `req.body.pin` was empty and every real submit 403'd.

**Fix:** submit via `fetch()` + JSON, matching the proven `SecretDrop.renderForm` pattern (`express.json()` parses it). CSP is dashboard-scoped only, so the inline script runs.

## Why the original tests missed it

`dynamic-mcp-routes.test.ts` mounts `createRoutes` without the auth middleware and calls `.send({pin})` (already JSON). So it proved the handler logic but never the **browser reality** — no Bearer token, urlencoded form body. This is exactly the gap the Live-User-Channel Proof standard exists to close.

## Regression coverage (added where it bites — the layers that run auth)

- `tests/unit/auth-middleware-live-token.test.ts` — `/mcp/approve/<id>` (GET+POST) is exempt; the exact `/mcp/approve` + `/mcp/approval-link` + `/mcp/load|offload|session` stay 401-gated.
- `tests/e2e/dynamic-mcp-routes-alive.test.ts` — through the **real AgentServer auth stack**, GET/POST `/mcp/approve/<id>` reach the handler with no token (404 unknown, never 401); `/mcp/approval-link` stays 401.

tsc clean. 31 unit/integration + 7 e2e green locally.

## ELI16

Your AI assistant can ask you to approve loading a heavy tool by sending you a link to tap. We built that link last week — but it turned out the page was locked behind the assistant's *own* secret key, which your phone's browser doesn't have. So when you actually tapped the link, you'd just get an error and couldn't approve anything. We only found this by *actually trying it as you* in a real browser — the automated tests had been "knocking on a side door" that real phones don't use, so they never noticed the front door was locked. This fixes the front door: the page now opens with just the short PIN you already use for your dashboard (the unguessable one-time link is the other half of the security), and a second hidden problem where the PIN box wasn't actually sending the PIN to the server. Now the tap-to-approve flow works the way it was supposed to.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
