### PR TITLE
fix(config): loadConfig must pass sessions.dynamicMcp through (Dynamic MCP was un-enablable)

### DIFF
--- a/.instar/instar-dev-decisions/2026-06-27T08-45-00-000Z-config-dynamicmcp-passthrough.json
+++ b/.instar/instar-dev-decisions/2026-06-27T08-45-00-000Z-config-dynamicmcp-passthrough.json
@@ -1,0 +1,14 @@
+{
+  "ts": "2026-06-27T08:45:00.000Z",
+  "slug": "config-dynamicmcp-loadpath-passthrough",
+  "suggestedTier": 1,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": ["bugfix: loadConfig drops sessions.dynamicMcp — feature un-enablable on every deployed agent"],
+  "belowFloor": false,
+  "files": 2,
+  "loc": 30,
+  "causalAutopsy": { "origin": "existing-code-bug" },
+  "verdict": "pass",
+  "notes": "Live-as-self test (driving a real config-file enable + use) caught that loadConfig's sessions allowlist (Config.ts) never copied sessions.dynamicMcp from the file. #1293 added the feature + /mcp/* routes (read options.config.sessions.dynamicMcp.enabled) + SessionManager.buildSessionMcpFlags (reads config.sessions.dynamicMcp), but the loader dropped the field — so enabling it did nothing (routes 503'd, sessions never trimmed). THIRD instance of this exact load-path gap (componentFrameworks 2026-06-06, frameworkDefaultModels 2026-06-25, now dynamicMcp); e2e/integration tests build config objects in-memory, bypassing loadConfig, so the gap never surfaced. Fix mirrors the prior two passthroughs + adds a Config.test.ts regression pair (preserves + omits-when-absent). Verified live by hotpatch+restart: sessions now spawn lean (--strict-mcp-config) and load/offload trim the running session."
+}

--- a/src/core/Config.ts
+++ b/src/core/Config.ts
@@ -877,6 +877,21 @@ export function loadConfig(projectDir?: string): InstarConfig {
     typeof fileConfig.sessions.frameworkDefaultModels === 'object'
       ? { frameworkDefaultModels: fileConfig.sessions.frameworkDefaultModels }
       : {}),
+    // dynamicMcp (DYNAMIC-MCP-LIFECYCLE-SPEC). THE SAME LOAD-PATH GAP as
+    // componentFrameworks/frameworkDefaultModels above (THIRD instance — live-test
+    // 2026-06-27): #1293 added the feature, the `/mcp/*` routes (which read
+    // `options.config.sessions.dynamicMcp.enabled`), and SessionManager.buildSessionMcpFlags
+    // (which reads `config.sessions.dynamicMcp`) — but the loader never copied the field
+    // from the config FILE here. So the feature was UN-ENABLABLE on every deployed agent:
+    // setting `sessions.dynamicMcp.enabled: true` did nothing (routes 503'd, sessions never
+    // trimmed). The e2e/integration tests build config objects in-memory, bypassing
+    // loadConfig, so the file-load gap never surfaced until a real config-file enable was
+    // driven live. Pass it through (DynamicMcpService.enabled()/buildSessionMcpFlags still
+    // gate on `.enabled === true`, and the service construction is fail-safe).
+    ...(fileConfig.sessions?.dynamicMcp &&
+    typeof fileConfig.sessions.dynamicMcp === 'object'
+      ? { dynamicMcp: fileConfig.sessions.dynamicMcp }
+      : {}),
     // pi-cli subscription-guard override (PI-HARNESS-INTEGRATION-SPEC §4.3).
     // Config surface: top-level `piCli.allowAnthropicProviders` — file-config
     // only, deliberately NOT an env var (no per-boot bypass surface).

--- a/tests/unit/Config.test.ts
+++ b/tests/unit/Config.test.ts
@@ -145,6 +145,43 @@ describe('Config', () => {
       SafeFsExecutor.safeRmSync(tmpDir, { recursive: true, force: true, operation: 'tests/unit/Config.test.ts:frameworkDefaultModels-absent' });
     });
 
+    it('preserves sessions.dynamicMcp from the config file (the exact-gap test — feature un-enablable without it)', () => {
+      // THIRD instance of the load-path gap (componentFrameworks, frameworkDefaultModels,
+      // now dynamicMcp). #1293 added the feature + routes + SessionManager.buildSessionMcpFlags
+      // (all read config.sessions.dynamicMcp), but the loader never copied it from the FILE —
+      // so setting `sessions.dynamicMcp.enabled: true` did nothing (routes 503'd, sessions never
+      // trimmed). A FILE-loaded config MUST carry dynamicMcp or the feature can't be turned on.
+      const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'instar-config-test-'));
+      const stateDir = path.join(tmpDir, '.instar');
+      fs.mkdirSync(stateDir, { recursive: true });
+      const dynamicMcp = { enabled: true, keepWarm: ['threadline'] };
+      fs.writeFileSync(
+        path.join(stateDir, 'config.json'),
+        JSON.stringify({
+          sessions: { framework: 'claude-code', claudePath: '/usr/local/bin/claude', tmuxPath: '/usr/bin/tmux', dynamicMcp },
+        }),
+      );
+      const config = loadConfig(tmpDir);
+      expect(config.sessions.dynamicMcp).toEqual(dynamicMcp);
+      expect(config.sessions.dynamicMcp?.enabled).toBe(true);
+      SafeFsExecutor.safeRmSync(tmpDir, { recursive: true, force: true, operation: 'tests/unit/Config.test.ts:dynamicMcp' });
+    });
+
+    it('omits dynamicMcp when absent from the file (no phantom field)', () => {
+      const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'instar-config-test-'));
+      const stateDir = path.join(tmpDir, '.instar');
+      fs.mkdirSync(stateDir, { recursive: true });
+      fs.writeFileSync(
+        path.join(stateDir, 'config.json'),
+        JSON.stringify({
+          sessions: { framework: 'claude-code', claudePath: '/usr/local/bin/claude', tmuxPath: '/usr/bin/tmux' },
+        }),
+      );
+      const config = loadConfig(tmpDir);
+      expect(config.sessions.dynamicMcp).toBeUndefined();
+      SafeFsExecutor.safeRmSync(tmpDir, { recursive: true, force: true, operation: 'tests/unit/Config.test.ts:dynamicMcp-absent' });
+    });
+
     it('respects sessions.tmuxPath from config.json instead of auto-detecting', () => {
       const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'instar-config-test-'));
       const stateDir = path.join(tmpDir, '.instar');


### PR DESCRIPTION
## Summary

A **live-as-self test** (driving a real config-file enable of the Dynamic MCP Lifecycle, then actually using it) caught that the feature was **un-enablable on every deployed agent**: setting `sessions.dynamicMcp.enabled: true` did nothing — the `/mcp/*` routes 503'd and sessions never spawned lean.

### Root cause

`loadConfig` (Config.ts) builds `config.sessions` as a **field-by-field allowlist**, and `dynamicMcp` was never added — so the loader **silently dropped** it from every FILE-loaded config. Both consumers read it from there:
- the routes' `enabled()` reads `options.config.sessions.dynamicMcp.enabled`,
- `SessionManager.buildSessionMcpFlags` reads `config.sessions.dynamicMcp`.

With the field stripped, both saw the feature as disabled, regardless of the config file.

### This is the THIRD instance of the same gap

Config.ts already documents two prior instances of this exact load-path bug — **componentFrameworks** (2026-06-06) and **frameworkDefaultModels** (2026-06-25): a `sessions.*` field added + consumed but never copied from the FILE in `loadConfig`, "silently dead on every deployed agent ... the feature's tests built config objects in-memory, which is why the file-load gap never surfaced." `dynamicMcp` is the same story, and the same reason CI was green: the e2e/integration tests construct config objects directly, bypassing `loadConfig`.

### Fix

Pass `sessions.dynamicMcp` through, mirroring the existing two passthroughs. `dynamicMcp?` is already on the `SessionManagerConfig` type, and `DynamicMcpService.enabled()` / `buildSessionMcpFlags` still gate on `.enabled === true`, so this only un-strips the field.

### Verification

- Regression tests: `Config.test.ts` gains a **preserve** + **omit-when-absent** pair (the same shape as the frameworkDefaultModels regression tests). They fail on the unpatched loader and pass with the fix.
- **Verified live** (hotpatch + restart on a dev agent): after the passthrough, `/mcp/session` returns 200, a fresh session launches with `--strict-mcp-config` carrying only `[threadline]` (lean), and a load/offload cycle genuinely trims the running session — load adds the playwright MCP process, offload drops it and the leaked browser process is reclaimed.

## ELI16

The "load a heavy tool only when needed" feature had an on-switch that did nothing. When the program reads its settings file, it copies over settings one-by-one from a known list — and whoever added this feature forgot to add it to that list. So the setting got thrown away every time the program started, and flipping it "on" changed nothing. All the automated tests passed because they hand the program a settings object directly instead of loading a real file — so they never exercised the part that was broken. We only found it by actually turning the feature on for real and watching it do nothing. The fix is one line (copy the setting over, like the others), plus a test that loads a real settings file and checks the setting survives. Embarrassingly, this is the third time this same "forgot to add it to the list" bug has happened — the code even has comments about the previous two.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
