### PR TITLE
fix(mcp): commit dynamic-MCP loaded-set BEFORE the restart (LOAD was a no-op on its own restart)

### DIFF
--- a/.instar/instar-dev-decisions/2026-06-27T09-03-00-000Z-mcp-load-ordering-commit-before-restart.json
+++ b/.instar/instar-dev-decisions/2026-06-27T09-03-00-000Z-mcp-load-ordering-commit-before-restart.json
@@ -1,0 +1,14 @@
+{
+  "ts": "2026-06-27T09:03:00.000Z",
+  "slug": "mcp-load-commit-before-restart",
+  "suggestedTier": 2,
+  "declaredTier": 2,
+  "riskFloor": 2,
+  "riskFloorReasons": ["safety-critical concurrency: modifies the M1/M3 two-phase commit ordering in DynamicMcpManager; spec-backed change"],
+  "belowFloor": false,
+  "files": 3,
+  "loc": 40,
+  "causalAutopsy": { "origin": "existing-code-bug" },
+  "verdict": "pass",
+  "notes": "Live-test (2026-06-27) found dynamic-MCP LOAD was a no-op on its own restart. Root: the M1/M3 two-phase commit wrote the new loaded-set UN-committed BEFORE the restart and committed=true AFTER; the spawn builder ignores un-committed files, so the load's OWN respawn read the prior committed state and spawned from baseline (lean). It only took effect on a SUBSEQUENT restart. This directly contradicted the spec's own claim that the respawn 'DOES pick up the new flags'. Offload was unaffected (lean==its target). FIX: commit BEFORE the restart so the respawn deterministically reads the new set; the existing rollback (restart ok <=> new session up) preserves the failure-safety the original committed-after design targeted (a failed restart re-asserts the prior committed set). Spec M1/M3 updated with the correction + rationale. Tests: dynamic-mcp-manager.test.ts asserts commit-before-restart order (['write:true','restart']) + the rollback-to-prior; all 378 mcp tests green. Tier-2 (spec-backed safety-critical change)."
+}

--- a/docs/specs/DYNAMIC-MCP-LIFECYCLE-SPEC.md
+++ b/docs/specs/DYNAMIC-MCP-LIFECYCLE-SPEC.md
@@ -128,14 +128,24 @@ sibling branch and is NOT merged here.)
    (via the reaper's `tmuxPaneMap`/signature scan), before the kill — they will
    be reparented orphans after the restart and must be reaped by captured PID
    (fold C1: see "Offload actually reclaims" below).
-6. Write the new state file with `committed:false` (atomic temp+rename), and the
+6. Write the new state file with `committed:TRUE` (atomic temp+rename), and the
    new filtered `--mcp-config` to a UNIQUE per-restart path (fold m3 — never
    overwrite the file the LIVE old session launched from).
-7. Trigger the restart (see "Restart" below). **Only on a confirmed-scheduled
-   restart** do we flip the state file to `committed:true` (fold M1/M3 — state is
-   committed AFTER the restart is confirmed, never before; the spawn builder
-   ignores an un-committed file, so a restart that fails leaves the live session
-   on its OLD set, not a phantom unapproved change).
+   **COMMIT-BEFORE-RESTART correction (live-test 2026-06-27):** the spawn builder
+   reads the COMMITTED loaded-set, so the new set must be committed BEFORE the
+   restart, or the restart's own respawn reads the prior committed state and spawns
+   from baseline. The original M1/M3 fold committed AFTER the restart (un-committed
+   first) to make a failed restart leave the old set — but that ALSO made the
+   *successful* restart's respawn ignore the un-committed new set, so a LOAD was a
+   no-op on its own restart (it only took effect on a SUBSEQUENT restart), directly
+   contradicting "respawnSessionForTopic ... DOES pick up the new flags" below.
+   Committing before the restart makes the respawn deterministically pick up the new
+   set; the failure-safety is preserved by the rollback in step 7.
+7. Trigger the restart (see "Restart" below). On a **non-ok** restart, roll the
+   state file back to the PRIOR committed set (fold M1/M3): `refreshSession` returns
+   ok ⟺ the new session is up, so a non-ok restart means no new session came up and
+   the next spawn reads the rolled-back prior set — no phantom unapproved change
+   survives, the same safety the original committed-after design targeted.
 8. For an offload, after the respawn is confirmed up, reap the captured orphan
    PIDs directly. Release the lock.
 
@@ -148,8 +158,9 @@ Telegram/Slack-bound sessions; for an UNBOUND/headless session it returns
 (which the autonomous topic sessions in scope here are); on an unbound session
 `requestChange` returns `unsupported-unbound` (no-op, surfaced honestly), never a
 silent failure. A non-`ok` `RefreshResult` (`rate_limited`, `refresh_in_progress`,
-`session_not_found`) is surfaced to the caller AND rolls back step 6 (state stays
-un-committed) — it is never swallowed.
+`session_not_found`) is surfaced to the caller AND rolls back step 6 (re-asserts the
+PRIOR set as `committed:true`, so the next spawn reads the old set) — it is never
+swallowed.
 
 **Offload actually reclaims (fold C1 — THE critical fix).** The reaper's own
 header is explicit: killing a session's pid does NOT cascade to MCP children —
@@ -235,9 +246,11 @@ a one-line warning rather than silently vanishing.
   unreadable but config readable ⇒ lean baseline (NOT full config); only a config
   read failure ⇒ `[]`. Tool-availability preserved AND the panic condition is not
   re-created on a transient error (fold M6).
-- **Two-phase + serialized + atomic-checked restart.** State commits only after a
-  confirmed restart; concurrent requests serialize per-topic; a non-`ok` refresh
-  rolls back and is surfaced (fold M1/M2/M3).
+- **Commit-before-restart + serialized + atomic-checked restart.** State is
+  committed BEFORE the restart so the respawn deterministically reads the new set
+  (live-test correction — committing AFTER left a LOAD a no-op on its own restart);
+  concurrent requests serialize per-topic; a non-`ok` refresh rolls back to the
+  prior committed set and is surfaced (fold M1/M2/M3).
 - **Authority is server-held.** A restart happens only for a re-checked-live
   preapproved topic OR a nonce-matched operator-authenticated approval; an
   agent-supplied `approved:true` is structurally insufficient (fold C4).

--- a/src/core/DynamicMcpManager.ts
+++ b/src/core/DynamicMcpManager.ts
@@ -150,12 +150,20 @@ export class DynamicMcpManager {
     // ── Offload-only: capture heavy child pids BEFORE the kill (C1) ──
     const capturedPids = op === 'offload' ? this.deps.captureHeavyPids(topicId, server) : [];
 
-    // ── Two-phase: write un-committed, restart, commit only on success (M1/M3) ──
-    this.deps.writeLoadedSet(topicId, result.servers, false, op);
+    // ── Commit-before-restart (M1/M3) ──
+    // The spawn builder reads the COMMITTED loaded-set, so the new set MUST be committed
+    // BEFORE the restart, or the restart's own respawn reads the OLD committed state and
+    // spawns from baseline. Pre-fix this wrote the new set UN-committed first, so a LOAD's
+    // own respawn ignored it and came up lean — load was a no-op on its own restart, only
+    // taking effect on a SUBSEQUENT restart (live-test 2026-06-27; offload was unaffected
+    // because lean is also its target). Safety is preserved by the rollback: a non-ok
+    // restart means no new session came up (restartSession returns ok ⟺ the new session is
+    // up), so re-asserting the prior committed set keeps the next spawn on the old set.
+    this.deps.writeLoadedSet(topicId, result.servers, true, op);
     const restart = await this.deps.restartSession(topicId);
     if (!restart.ok) {
-      // Roll back to the prior committed set; the spawn builder already ignores
-      // the un-committed write, but re-asserting the committed truth is cleaner.
+      // Roll back to the prior committed set — a failed restart yields no new session, so
+      // re-asserting the prior committed truth keeps the live/next session on the old set.
       this.deps.writeLoadedSet(topicId, current, true, `${op}-rollback`);
       const code = restart.code ?? 'unknown';
       this.audit({ topicId, op, server, outcome: 'restart-failed', code });
@@ -163,7 +171,8 @@ export class DynamicMcpManager {
       return { status: 'restart-failed', code };
     }
 
-    this.deps.writeLoadedSet(topicId, result.servers, true, op);
+    // The new committed set is already in place; the respawn picked it up. For an offload,
+    // reap the heavy child pids captured before the kill (they reparented to launchd — C1).
     if (op === 'offload' && capturedPids.length > 0) {
       this.deps.reapPids(capturedPids);
     }

--- a/tests/unit/dynamic-mcp-manager.test.ts
+++ b/tests/unit/dynamic-mcp-manager.test.ts
@@ -94,11 +94,21 @@ describe('DynamicMcpManager — authorization gate (C4: verified, never trusted)
 });
 
 describe('DynamicMcpManager — two-phase commit + rollback (M1/M3)', () => {
-  it('applied: writes un-committed THEN committed, restart in between', async () => {
-    const { deps, rec } = makeDeps();
+  it('applied: COMMITS the new set BEFORE the restart (so the respawn reads it), with NO post-restart commit', async () => {
+    // Regression for the load-ordering bug (live-test 2026-06-27): the spawn builder reads
+    // the COMMITTED loaded-set, so the new set must be committed BEFORE the restart. Pre-fix
+    // wrote it un-committed first ([false, true] with restart between), so the load's own
+    // respawn ignored it and spawned lean — load was a no-op on its own restart. This asserts
+    // the committed=true write now precedes the restart.
+    const order: string[] = [];
+    const { deps, rec } = makeDeps({
+      writeLoadedSet: (_t, servers, committed, reason) => { order.push(`write:${committed}`); rec.writes.push({ servers, committed, reason }); },
+      restartSession: async () => { order.push('restart'); rec.restarts++; return { ok: true }; },
+    });
     await new DynamicMcpManager(deps).requestChange({ topicId: 1, op: 'load', server: 'playwright', actor: { kind: 'agent' } });
-    expect(rec.writes.map((w) => w.committed)).toEqual([false, true]);
-    expect(rec.writes[1].servers.sort()).toEqual(['playwright', 'threadline']);
+    expect(order).toEqual(['write:true', 'restart']); // committed BEFORE the restart; no post-restart commit
+    expect(rec.writes.map((w) => w.committed)).toEqual([true]);
+    expect(rec.writes[0].servers.sort()).toEqual(['playwright', 'threadline']);
     expect(rec.restarts).toBe(1);
   });
 
@@ -106,8 +116,11 @@ describe('DynamicMcpManager — two-phase commit + rollback (M1/M3)', () => {
     const { deps, rec } = makeDeps({ restartSession: async () => ({ ok: false, code: 'rate_limited' }) });
     const r = await new DynamicMcpManager(deps).requestChange({ topicId: 1, op: 'load', server: 'playwright', actor: { kind: 'agent' } });
     expect(r).toEqual({ status: 'restart-failed', code: 'rate_limited' });
-    // un-committed write, then a committed rollback to the ORIGINAL set
-    expect(rec.writes[0]).toMatchObject({ committed: false });
+    // committed the new set, then a committed ROLLBACK to the ORIGINAL set. A failed restart
+    // means no new session came up (restartSession ok ⟺ new session up), so the next spawn
+    // reads the rolled-back prior set — no phantom change survives.
+    expect(rec.writes[0]).toMatchObject({ committed: true });
+    expect(rec.writes[0].servers.sort()).toEqual(['playwright', 'threadline']);
     const last = rec.writes[rec.writes.length - 1];
     expect(last).toMatchObject({ committed: true });
     expect(last.servers).toEqual(['threadline']); // rolled back to prior


### PR DESCRIPTION
## Summary

A **live-as-self test** found that a dynamic-MCP **LOAD did not take effect on its own restart** — the session came back lean despite the committed loaded-set including the loaded server. Only a *subsequent* restart actually loaded it. (Offload was unaffected.)

### Root cause — the M1/M3 two-phase commit ordering

`DynamicMcpManager.requestChange` wrote the new loaded-set **un-committed** (`committed:false`) **before** the restart and flipped it to `committed:true` **after**. But the spawn builder (`buildSessionMcpFlags`) **ignores an un-committed file** — so the load's *own* respawn read the **prior** committed state and spawned from baseline (lean). The `committed:true` write landed *after* the respawn, affecting only the next restart.

This directly contradicted the spec's own claim that `respawnSessionForTopic ... DOES pick up the new flags`. The original "commit after the restart" fold optimized for "a failed restart leaves the old set" but, by writing un-committed first, also made the *successful* restart's respawn ignore the new set.

### Fix — commit before the restart

Commit the new set **before** the restart so the respawn deterministically reads it. The failure-safety the original design targeted is preserved by the existing **rollback**: `refreshSession` returns `ok` ⟺ the new session is up, so a non-`ok` restart means no new session came up, and re-asserting the prior committed set keeps the next spawn on the old set — no phantom unapproved change survives.

### Changes

- `DynamicMcpManager.requestChange`: `writeLoadedSet(committed:true)` before the restart; the post-restart commit is removed; rollback unchanged.
- `DYNAMIC-MCP-LIFECYCLE-SPEC.md`: M1/M3 steps 6–7 + the safety summary updated with the commit-before-restart correction + rationale (this is a deliberate correction to the adversarially-reviewed M1/M3 fold).
- `dynamic-mcp-manager.test.ts`: now asserts the committed write **precedes** the restart (order `['write:true','restart']`, a single committed write) and the rollback-to-prior on a failed restart. All 378 mcp tests green.

### Verification

Verified live on a dev agent (real session, topic 29038): before this fix, after a load+approve the session launched `--strict-mcp-config` with `[threadline]` only for 27s (a manual refresh was needed to load playwright). With commit-before-restart, the load's restart launches the session with the new set directly. Offload + reclaim remains correct.

## ELI16

When the assistant loads a heavy tool, it has to restart the session so the tool comes online. The restart reads a little "what tools should I have" file at startup. The bug: the code wrote the new tool list marked "not final yet," did the restart, and only marked it "final" *after* — but the startup deliberately skips "not final yet" lists, so the restart came back with the OLD tools. The tool only showed up on the *next* restart. So "load a tool" quietly did nothing the first time. The fix is to mark the list "final" *before* the restart, so the restart actually reads it. If the restart fails, we put the old list back — same safety as before, but now loading a tool actually works on the first try. (Dropping a tool always worked because "drop" lands on the lean default the restart produces anyway.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
