### PR TITLE
feat(release): release-fragment-gate — no release silently skips merged work

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -77,6 +77,20 @@ jobs:
             echo "skip=false" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Loud-skip annotation (release-fragment-gate Layer 2)
+        # When the publish is about to SKIP (no fragment) but release-relevant
+        # work has merged since the last vX.Y.Z tag, emit a LOUD warning + step
+        # summary instead of a silent green run (the 2026-06-27 failure). SIGNAL
+        # ONLY — never fails the run (the script always exits 0); the durable,
+        # ack-able signal is the agent-side ReleaseReadinessSentinel.
+        # Spec: docs/specs/RELEASE-FRAGMENT-GATE-SPEC.md (Layer 2).
+        if: steps.guide-check.outputs.skip == 'true'
+        run: |
+          # The base checkout is shallow + tagless; fetch tags + enough history
+          # so the boundary tag (vX.Y.Z) and the unreleased window resolve.
+          git fetch --tags --deepen=200 origin main 2>/dev/null || git fetch --tags --unshallow 2>/dev/null || true
+          node scripts/release-skip-annotate.mjs
+
       - name: Release-tier gate (Layer 2)
         # Deployment Lockdown — Layer 2.
         # `.instar/release-tier.json` declares the active release line

--- a/.github/workflows/release-fragment-gate.yml
+++ b/.github/workflows/release-fragment-gate.yml
@@ -1,0 +1,77 @@
+# release-fragment-gate (Layer 1) — a release-affecting PR must carry a
+# release-note fragment, enforced SERVER-SIDE at the merge boundary.
+#
+# Why: a HARD pre-push gate already requires the fragment, but it runs in husky
+# LOCALLY — the server-side squash/bot/auto-merge path never runs husky, so a
+# fragment-less change reaches main and the publish SILENTLY skips the release
+# (2026-06-27: PRs #1295-#1297 stranded ~7h). This gate cannot be routed around.
+#
+# Spec: docs/specs/RELEASE-FRAGMENT-GATE-SPEC.md (converged + approved).
+#
+# SECURITY: on: pull_request (NEVER pull_request_target); read-only token; the
+# check module is loaded from the BASE ref (never PR-head), so a PR cannot
+# rewrite the predicate to always-pass or execute its own code in the runner.
+# Untrusted PR title arrives via env, never shell-interpolated.
+#
+# ROLLOUT: ships WARN-ONLY (reports the verdict, never blocks) per spec D2/D3.
+# Flip to blocking + register as a REQUIRED status check on `main` per the D3
+# criterion (>=15 release-relevant instar-repo PRs, zero false-positive FAILs,
+# >=7 days). The verdict line is emitted for the rollout log.
+
+name: release-fragment-gate
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+    branches:
+      - main
+
+# Collapse an edit/push storm on a single PR to the latest run.
+concurrency:
+  group: release-fragment-gate-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  release-fragment:
+    runs-on: ubuntu-latest
+    steps:
+      # Check out the BASE ref ONLY (never PR-head / merge ref) so the gate runs
+      # trusted base-repo code, not PR-author-controlled scripts. (Security N1.)
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+          persist-credentials: false
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+      - name: Fetch changed-file list (paginated, never truncated)
+        id: files
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          # Full pagination via gh api --paginate; emit a compact JSON array of
+          # { path, status }. The data is treated as opaque (jq), never shelled.
+          gh api --paginate "repos/${REPO}/pulls/${PR_NUMBER}/files" \
+            --jq '[.[] | {path: .filename, status: .status}]' \
+            | jq -s 'add' > /tmp/pr-files.json
+          echo "count=$(jq 'length' /tmp/pr-files.json)" >> "$GITHUB_OUTPUT"
+      - name: Release-note fragment must be present for a release-relevant PR
+        env:
+          PR_FILES_JSON_PATH: /tmp/pr-files.json
+          PR_AUTHOR_LOGIN: ${{ github.event.pull_request.user.login }}
+          PR_AUTHOR_TYPE: ${{ github.event.pull_request.user.type }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          # Soak phase: report the verdict, never block. Remove (or set to 0)
+          # to flip to blocking once the D3 criterion is met.
+          WARN_ONLY: '1'
+        run: |
+          # Read the (trusted-shape, untrusted-content) file list from disk into
+          # the env the checker expects — never interpolate it into the shell.
+          PR_FILES_JSON="$(cat "$PR_FILES_JSON_PATH")" \
+            node scripts/check-release-fragment.mjs

--- a/.github/workflows/release-fragment-gate.yml
+++ b/.github/workflows/release-fragment-gate.yml
@@ -71,6 +71,16 @@ jobs:
           # to flip to blocking once the D3 criterion is met.
           WARN_ONLY: '1'
         run: |
+          # Bootstrap no-op: the checker is loaded from the BASE ref (security:
+          # a PR cannot alter the gate that gates it). The very PR that ADDS or
+          # moves the checker therefore has no checker on base yet — skip
+          # gracefully rather than fail, since the gate cannot apply to the PR
+          # that introduces it. Once merged, base has the script and every later
+          # PR runs the real check.
+          if [ ! -f scripts/check-release-fragment.mjs ]; then
+            echo "::notice::release-fragment-gate: checker not present on the base ref yet (bootstrap PR) — skipping."
+            exit 0
+          fi
           # Read the (trusted-shape, untrusted-content) file list from disk into
           # the env the checker expects — never interpolate it into the shell.
           PR_FILES_JSON="$(cat "$PR_FILES_JSON_PATH")" \

--- a/.instar/instar-dev-decisions/2026-06-27T19-48-36-046Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-06-27T19-48-36-046Z-unknown.json
@@ -1,0 +1,17 @@
+{
+  "ts": "2026-06-27T19:48:36.046Z",
+  "slug": "unknown",
+  "suggestedTier": 2,
+  "declaredTier": 2,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "migration / fleet-rollout surface: scripts/check-release-fragment.mjs touches release script (fleet publish path)",
+    "migration / fleet-rollout surface: scripts/release-relevant-paths.mjs touches release script (fleet publish path)",
+    "migration / fleet-rollout surface: scripts/release-skip-annotate.mjs touches release script (fleet publish path)"
+  ],
+  "belowFloor": false,
+  "files": 6,
+  "loc": 508,
+  "causalAutopsy": null,
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-06-27T19-49-53-545Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-06-27T19-49-53-545Z-unknown.json
@@ -1,0 +1,17 @@
+{
+  "ts": "2026-06-27T19:49:53.545Z",
+  "slug": "unknown",
+  "suggestedTier": 2,
+  "declaredTier": 2,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "migration / fleet-rollout surface: scripts/check-release-fragment.mjs touches release script (fleet publish path)",
+    "migration / fleet-rollout surface: scripts/release-relevant-paths.mjs touches release script (fleet publish path)",
+    "migration / fleet-rollout surface: scripts/release-skip-annotate.mjs touches release script (fleet publish path)"
+  ],
+  "belowFloor": false,
+  "files": 6,
+  "loc": 508,
+  "causalAutopsy": null,
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-06-27T19-50-56-027Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-06-27T19-50-56-027Z-unknown.json
@@ -1,0 +1,17 @@
+{
+  "ts": "2026-06-27T19:50:56.027Z",
+  "slug": "unknown",
+  "suggestedTier": 2,
+  "declaredTier": 2,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "migration / fleet-rollout surface: scripts/check-release-fragment.mjs touches release script (fleet publish path)",
+    "migration / fleet-rollout surface: scripts/release-relevant-paths.mjs touches release script (fleet publish path)",
+    "migration / fleet-rollout surface: scripts/release-skip-annotate.mjs touches release script (fleet publish path)"
+  ],
+  "belowFloor": false,
+  "files": 6,
+  "loc": 508,
+  "causalAutopsy": null,
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-06-27T19-51-48-761Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-06-27T19-51-48-761Z-unknown.json
@@ -1,0 +1,17 @@
+{
+  "ts": "2026-06-27T19:51:48.761Z",
+  "slug": "unknown",
+  "suggestedTier": 2,
+  "declaredTier": 2,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "migration / fleet-rollout surface: scripts/check-release-fragment.mjs touches release script (fleet publish path)",
+    "migration / fleet-rollout surface: scripts/release-relevant-paths.mjs touches release script (fleet publish path)",
+    "migration / fleet-rollout surface: scripts/release-skip-annotate.mjs touches release script (fleet publish path)"
+  ],
+  "belowFloor": false,
+  "files": 6,
+  "loc": 508,
+  "causalAutopsy": null,
+  "verdict": "pass"
+}

--- a/docs/specs/RELEASE-FRAGMENT-GATE-SPEC.eli16.md
+++ b/docs/specs/RELEASE-FRAGMENT-GATE-SPEC.eli16.md
@@ -54,3 +54,9 @@ that only runs on your laptop is a guard people route around. A guard at the pla
 work actually merges is a guarantee. And a release that silently swallows finished
 work is exactly the "looks protected while being fake-protected" failure the
 constitution warns about.
+
+---
+
+*Status (2026-06-27): approved by Justin and built. Ships in this PR — the Layer-1
+PR check starts in warn-only mode; flip to a required blocking check per the spec's
+D3 criterion.*

--- a/docs/specs/RELEASE-FRAGMENT-GATE-SPEC.eli16.md
+++ b/docs/specs/RELEASE-FRAGMENT-GATE-SPEC.eli16.md
@@ -1,0 +1,56 @@
+# Release-Fragment Gate — ELI16
+
+## What's broken
+
+Every time instar ships a new version, the release robot needs a short "what
+changed" note (a little file under `upgrades/next/`). If that note is missing, the
+robot does the safe thing and **refuses to ship** — which is correct. The problem
+is it refuses **silently**: the release job lights up green and looks like it
+worked, but no new version actually came out.
+
+On June 27 this bit us. Three real bug fixes reached the main codebase, but nobody
+attached the "what changed" note. So the robot quietly skipped shipping them, and
+they sat unshipped for about seven hours. Worse, an earlier session saw the green
+checkmark and wrongly told the operator it was an "upstream pipeline glitch," when
+really it was our own missing note.
+
+## The twist the review uncovered
+
+There IS already a guard that demands the note — but it only runs on your own
+computer when you push code by hand. The way code actually lands these days (the
+robot squash-merges an approved pull request on the server) skips that guard
+entirely. So the rule existed but was checked in the one place merges don't happen.
+That's the real hole.
+
+## The fix
+
+Move the SAME rule to where merges actually land — the server — so it can't be
+skipped, and make any leftover silent skip **loud**:
+
+1. **A check on the pull request (the real fix).** Before code merges, a server-side
+   check notices "this PR changes real code but has no note" and asks the author to
+   add one — or to drop in a one-line "no user-facing note needed" marker for tiny
+   internal changes. Because it runs on the server, nobody can route around it. It
+   starts in "just warn" mode so we can watch for false alarms, then becomes a hard
+   block once it's proven calm.
+
+2. **A loud alarm for anything that still slips by.** If a release ever skips while
+   real code went unshipped, the agent's own release-watcher raises a visible alarm
+   instead of staying quiet, and the release log prints a big warning. No more silent
+   green.
+
+## What does NOT change
+
+The robot still refuses to ship a version with no note — that rule is right and
+stays. We're only making the refusal **un-skippable and loud** instead of
+locally-checked and silent. And the block is deliberately simple: "is a note (or a
+'no note needed' marker) there, yes or no?" — never a fuzzy judgment a regex would
+get wrong.
+
+## Why it matters
+
+This is the "build it into the structure, don't rely on remembering" rule. A guard
+that only runs on your laptop is a guard people route around. A guard at the place
+work actually merges is a guarantee. And a release that silently swallows finished
+work is exactly the "looks protected while being fake-protected" failure the
+constitution warns about.

--- a/docs/specs/RELEASE-FRAGMENT-GATE-SPEC.md
+++ b/docs/specs/RELEASE-FRAGMENT-GATE-SPEC.md
@@ -16,6 +16,9 @@ single-run-completable: true
 frontloaded-decisions: 11
 cheap-to-change-tags: 0
 contested-then-cleared: 1
+approved: true
+approved-by: Justin
+approved-via: "Telegram topic 28130 (2026-06-27 11:57 PDT): 'Approved and you have my preapproval for any decisions needed in this autonomy session', after reading the converged-spec ELI16 summary."
 ---
 
 # Spec — Release-Fragment Gate
@@ -259,7 +262,8 @@ guarantee. Secondary: **"No Silent Degradation to Brittle Fallback"** (exact reg
 article) — a green publish run that silently skips merged work is the textbook
 "looks-protected while fake-protected" degradation this article forbids; this spec
 extends it from LLM-gating calls to the release pipeline. Also engages **"Close the
-Loop / Deferral = Deletion"** (a release must not silently swallow merged work).
+Loop"** (a release must not silently swallow merged work — every shipped change is
+re-surfaced until it actually ships).
 
 ## Open questions
 

--- a/docs/specs/RELEASE-FRAGMENT-GATE-SPEC.md
+++ b/docs/specs/RELEASE-FRAGMENT-GATE-SPEC.md
@@ -1,0 +1,266 @@
+---
+title: Release-Fragment Gate — a release must never silently skip merged work
+date: 2026-06-27
+author: echo
+slug: release-fragment-gate
+parent-principle: "Structure beats Willpower"
+parent-principle-fit: "The release-note fragment (upgrades/next/<slug>.md) is required for a version to cut — the publish workflow refuses to bump without one — and a HARD local pre-push gate (scripts/pre-push-gate.js §3b) already blocks a fragment-less release-relevant push. Yet on 2026-06-27 PRs #1295/#1296/#1297 (real Dynamic-MCP fixes) reached main with no fragment and the publish ran GREEN and silently skipped: assemble-next-md found 'nothing to assemble', guide-check set skip=true, no version cut, fixes stranded ~7h, and a prior session misread the green run as an 'upstream pipeline hiccup'. The hard gate exists but runs in husky LOCALLY — it is bypassed by the server-side squash/bot/auto-merge path that never runs husky and by INSTAR_PRE_PUSH_SKIP=1. So the requirement is enforced everywhere EXCEPT where merges actually land, and its evasion is silent. Moving the SAME requirement to a server-side required CI check (un-bypassable) + making the residual silent-skip a LOUD agent-side event is the structural enforcement this principle demands: a guarantee at the merge boundary, not a local hook anyone can route around."
+eli16-overview: RELEASE-FRAGMENT-GATE-SPEC.eli16.md
+commitment: CMT-1819
+review-convergence: "2026-06-27T18:53:02.190Z"
+review-iterations: 3
+review-completed-at: "2026-06-27T18:53:02.190Z"
+review-report: "docs/specs/reports/release-fragment-gate-convergence.md"
+cross-model-review: "codex-cli:gpt-5.5"
+single-run-completable: true
+frontloaded-decisions: 11
+cheap-to-change-tags: 0
+contested-then-cleared: 1
+---
+
+# Spec — Release-Fragment Gate
+
+## Problem
+
+The publish pipeline (`.github/workflows/publish.yml`) gates the version bump on
+release-note content: `scripts/assemble-next-md.mjs` folds every
+`upgrades/next/*.md` fragment into `upgrades/NEXT.md`; with no fragments the
+`guide-check` step sets `skip=true` ("No NEXT.md found — nothing to publish") and
+every downstream step (bump, publish, tag) is `if: skip != true`. The run exits
+**green** having published nothing. The refusal is correct; its **silence** is the
+bug.
+
+### The requirement already exists — but only where merges DON'T happen
+
+A hard gate already enforces the fragment:
+
+- `scripts/pre-push-gate.js` **§3b** (the `#23` block) pushes a missing-fragment
+  finding to `errors` (not `warnings`) for a release-relevant `src/` push, with the
+  rationale literally "publish.yml SILENTLY SKIPS the release". It is a **hard**
+  block — but it runs in **husky on `git push`**, bypassable by
+  `INSTAR_PRE_PUSH_SKIP=1` and, crucially, by **any server-side merge** (GitHub
+  squash-merge, the green-PR auto-merge, a bot merge) that never runs husky at all.
+- `scripts/instar-dev-precommit.js` `inScope()` references `upgrades/next/` only in
+  an **advisory** nudge.
+
+So the requirement is enforced on a local `git push` and nowhere else. The
+2026-06-27 incident merged via the server-side path, evaded the only hard gate, and
+the publish swallowed the result silently. **The root cause is not "no gate" — it
+is "the gate is bypassable at the real merge boundary, and its bypass is silent."**
+
+### The incident (2026-06-27)
+
+PRs #1295 (operator-approval tap auth), #1296 (config loader dropped
+`sessions.dynamicMcp`), #1297 (load-ordering no-op) — all real `src/` fixes —
+reached main with no fragment. Publish ran green and skipped. v1.3.685 stayed the
+latest published version for ~7h. The unstick (PR #1298) was a single fragment; the
+moment it landed, v1.3.686 cut normally — proving the pipeline was never broken,
+just silent and locally-bypassed.
+
+## Goal
+
+A release-affecting change can **never** reach `main` and then silently fail to
+ship. Enforce the fragment requirement **at the merge boundary, server-side** — under
+branch-protection/ruleset coverage so the normal squash/auto-merge path cannot route
+around it (admins, ruleset exceptions, and emergency direct pushes remain a
+deliberate, logged escape, not a silent one — and the Layer-2 poller catches even
+those) — and make any residual fragment-less-but-merged state a **loud, durable,
+auditable event**, never a green no-op.
+
+## Signal vs. Authority (mandatory declaration)
+
+Per the constitution's *Signal vs. Authority* article and the design-pipeline P2
+rule (any spec proposing a guard/checker must declare which it is):
+
+- **Layer 1 (PR-time CI gate) is an AUTHORITY** — it blocks a merge. Its veto rests
+  on an **objective binary** ("a fragment, or an auditable opt-out, is present —
+  yes/no"), exactly the shape the existing `eli16-pr-gate` already establishes as an
+  acceptable blocking precedent. The `release-relevant` path predicate is declared a
+  **fallible signal**, never the thing that vetoes: a false positive is always
+  escapable by adding a one-line opt-out fragment. The block is carried by the
+  presence-or-optout condition, not by the predicate's correctness.
+- **Layer 2 (publish-side + agent-side backstop) is a SIGNAL** — it never fails a
+  build or vetoes a person; it surfaces. This matches the established posture of the
+  `ReleaseReadinessSentinel` (publish.yml comment: "surfaces the blocked release as
+  a signal") and keeps the publish *refusal* a deterministic refuse-to-self-act, not
+  a veto.
+
+## Frontloaded Decisions
+
+Every build-time decision is resolved here with a concrete default; **no decision is
+parked on the user.** (`## Open questions` is intentionally empty — see end.)
+
+| # | Decision | Resolution (default) |
+|---|----------|----------------------|
+| D1 | Layer 2 publish-step: fail the run, or surface? | **Surface, never fail the run.** The work is safely merged; the defect is visibility, and a red `main` publish is itself noise. Layer 2 emits a loud `::warning::` + `$GITHUB_STEP_SUMMARY` and the durable signal is raised agent-side (D7). |
+| D2 | Layer 1 first-ship posture | **Warn-only soak first** (comments via the gate, status reported but `neutral`/non-blocking), then flip to a **required, blocking** check. Flip criterion is a deliverable, not a later decision (D3). |
+| D3 | Warn→block flip criterion (mechanical) | Scope is **instar-repo PRs to `main`** (the only population this workflow observes — `.github/` does not reach the fleet), NOT "the fleet". The gate emits a machine-readable verdict line per PR to a rollout log (`logs/release-fragment-gate-rollout.jsonl`: pr#, verdict, whether a fragment/opt-out was later added). A **false-positive** is defined objectively: a `FAIL` verdict that the author resolved by adding a one-line `internal-only` opt-out fragment (i.e. the change genuinely needed no user note) — distinguished from a true-positive `FAIL` resolved by adding a real fragment. **Flip when: ≥15 release-relevant instar-repo PRs have passed through the gate with zero false-positive `FAIL` verdicts over ≥7 days.** The registration itself (marking the check required in branch protection) is the operator's one admin action — surfaced as a ready-to-do item when the criterion is met, never a fuzzy judgment. |
+| D4 | Include a Layer-0 husky advisory→hard change? | **No.** A hard local pre-push gate already exists (`pre-push-gate.js §3b`); the gap is server-side, which Layer 1 closes. Adding local-commit blast radius buys no incremental coverage. Excluded from this spec. |
+| D5 | Build scope | **Layer 1 (warn-only→required) + Layer 2 (fix the agent-side Sentinel trigger + a non-load-bearing CI annotation).** Layer 0 excluded. |
+| D6 | The `release-relevant` predicate | **A NEW single-source module `scripts/release-relevant-paths.mjs`** = the positive set (`src/`, `scripts/`, `.husky/`, skill code + `SKILL.md` under `skills/`) **+ explicit additions** (`package.json`, `package-lock.json`, `.github/workflows/**`, `.instar/config defaults` shipped in-repo, skill `templates/**`) **− explicit exemptions** (`**/*.test.ts`, `tests/**`, `docs/**`, `*.md` outside skill SKILL/templates, the fragment dir itself). Paths are **canonicalized** (normalized, `..`-rejected, case-folded on case-insensitive match) before matching. `inScope()` (precommit) and `pre-push-gate.js §3b` are **refactored to consume this module** so all three callsites share ONE definition (Structure beats Willpower / DRY). Publish-side Layer 2 biases **"relevant unless known-non-release"** (fail toward surfacing). |
+| D7 | Layer 2 durable surface | **The agent-side `ReleaseReadinessSentinel`** (a poller that reads `main` independently of CI, so it catches even `[skip ci]` pushes that bypass the publish job). It already detects "unreleased feat/fix AND guide blocks publish"; this spec (a) adds a **fast trigger** for the specific "release-relevant merge with no fragment" case so it does NOT wait out the 2-day backlog floor, and (b) documents honestly that it is **dev-gated/ships-dark** — Echo dogfoods it; on the fleet the CI `::warning::` is the (ephemeral, best-effort) surface until the Sentinel graduates. The CI step NEVER claims to raise an Attention item (it architecturally cannot reach the agent's Attention store). |
+| D8 | Opt-out mechanism | **Reuse the existing diff-verified `internal-only` fragment lane.** A genuinely no-user-impact change adds an `upgrades/next/<slug>.md` carrying the standalone `<!-- internal-only -->` directive (already understood by `assemble-next-md.mjs` and diff-verified by `pre-push-gate.js §3c`). This makes "needs a release but no user-facing prose" explicit and durable, satisfies the objective binary, and is auditable — **no new free-text PR-body marker** (which any fork author could self-assert, reintroducing a deliberate silent-skip at scale). |
+| D9 | Bot-author exemption | **Exempt ONLY the release-cut bot's authenticated actor identity** (`github.event.pull_request.user.login` == the known github-actions release bot login AND `user.type == Bot`), NEVER a title/commit-message string. A `chore: release` PR title is fully author-controllable, so matching on it would let any human title a fragment-less PR `chore: release …` to bypass Layer 1 — keyed on identity, that spoof fails. NOT a blanket `user.type == Bot` exemption (fleet work is agent/bot-authored; a blanket bot exemption makes Layer 1 inert for its target population). Agent authors are gated as humans. Evasion unit test: a human-authored PR titled `chore: release` is still gated. |
+| D10 | Fail posture of the gate code | **Fail-CLOSED.** A Layer-1 internal error (API error, malformed event, throw) reports the check **failed/red**, never green — a silent-skip inside the anti-silent-skip gate is the one outcome forbidden. Layer 2's detect, on its own internal error, raises the Sentinel's documented eval-failure signal, never a silent catch. |
+| D11 | Layer-2 commit-window boundary | **Bound on the actually-published source SHA, not the release commit's ancestry.** The authoritative source is the **annotated `vX.Y.Z` tag** (written only by the release bot, so it is not PR-mutable): the publish records the built-from SHA in the tag message, and the detect uses `git log <lastPublishedSha>..HEAD`. (An in-repo `.instar/last-published.json` is NOT trusted as the boundary — it is PR-mutable and D6 even classes config defaults as release-relevant, so an attacker could advance it to ~HEAD and blind the backstop; the tag is release-bot-only.) This survives the publish-side rebase-retry loop that otherwise replants the release commit above a concurrently-merged fragment-less PR and buries it (false-negative). A **missing/unparseable boundary** (e.g. the first publish after this ships, before any new-format tag exists) raises the eval-failure signal and surfaces ALL reachable commits — **never** a silent `sha=HEAD` empty range. Requires `fetch-depth: 0` (or a targeted fetch of the boundary tag) — a depth-1 checkout cannot resolve the window. |
+
+## Design
+
+### Layer 1 — required PR-time CI gate `release-fragment-gate` (prevention)
+
+A workflow mirroring `eli16-pr-gate.yml`'s **shape and discipline**:
+
+- **Trigger / permissions (hard security requirements):** `on: pull_request`
+  (NEVER `pull_request_target`), `permissions: contents: read` + `pull-requests:
+  read`. The gate **never checks out or executes PR-head code**: the predicate /
+  decision module is loaded **only from the base ref**
+  (`github.event.pull_request.base.sha`), never the PR-head or merge ref — otherwise
+  a PR author could rewrite `release-relevant-paths.mjs` to always-pass (neutering
+  the gate) AND run arbitrary JS in the runner. The gate reads only the
+  changed-file list + body. Untrusted PR body/title are passed via `env:` (not
+  `${{ }}` interpolation into a shell) and read in Node from `process.env` — the
+  exact injection-safe pattern `eli16-pr-description-check.mjs` already uses. **Labels
+  are NOT an opt-out path** (the only durable opt-out is the committed `internal-only`
+  fragment, D8 — a label is an ephemeral, triage-assignable self-assertion that would
+  reopen the silent-skip-at-scale hole); the meaningful re-trigger is `synchronize`
+  when a fragment commit is pushed.
+- **Decision (pure function `checkReleaseFragment({ files, body, authorLogin,
+  authorType, title })` + CLI wrapper):** FAIL iff — (a) changed files include a
+  release-relevant path (D6 predicate), AND (b) the PR adds/modifies no
+  `upgrades/next/*.md` file. The opt-out (D8) is itself an `upgrades/next/*.md` file,
+  so its presence already satisfies (b) at the **file-list level** Layer 1 operates
+  on — Layer 1 does NOT read fragment content (it has only the files API); the
+  *legitimacy* of an `internal-only` opt-out is enforced downstream at
+  `assemble-next-md` + `pre-push-gate.js §3c`, not here. The changed-file list is
+  fetched via the PR **files API** (`status` field, so add-vs-modify is known) with
+  **full pagination** (never a truncated list).
+- **Presence-not-validity is deliberate, and safe.** Layer 1 checks fragment
+  *presence*, not content (it has only the file list — reading content would require
+  executing/checking-out PR-head, the N1 vector). A bogus/empty fragment therefore
+  passes Layer 1 — but it does NOT re-open the silent skip: `assemble-next-md` THROWS
+  on a content-less or unparseable fragment (a loud RED publish run), and the
+  `internal-only` legitimacy is diff-verified by `pre-push-gate.js §3c`. So the worst
+  a junk fragment buys is a loud failure downstream, never a silent green skip — which
+  is the property that matters. (A future enhancement could add a cheap base-ref-safe
+  content sniff; out of scope here.)
+- **Rollout:** warn-only (non-blocking `neutral`) first; flip to required per D2/D3.
+  **Registering it as a required status check on `main` is an explicit deliverable**
+  — without that registration the gate is cosmetic. And because a required-check
+  registration can silently drift off (a ruleset edit, a renamed check, branch-
+  protection drift), a lightweight periodic audit asserts `release-fragment-gate` is
+  STILL a required check on `main` and surfaces a loud signal if it has been
+  de-scoped — closing the loop so the guarantee can't quietly evaporate the same way
+  the original silent skip did. (Reuses the existing guard-posture/release-readiness
+  surface rather than a new watcher.)
+- **Cost:** per-PR `concurrency: { group: release-fragment-gate-${{ pr }},
+  cancel-in-progress: true }` collapses an `edited`/`synchronize` storm; the job
+  early-exits fast when nothing is release-relevant (it does NOT use a workflow-level
+  `paths:` filter — a path-filtered required check sits "pending" forever and stalls
+  merges). No full `actions/checkout` of the tree — vendor/sparse-fetch only the
+  predicate module.
+
+### Layer 2 — the durable backstop (signal)
+
+Two non-load-bearing-in-CI parts that together guarantee the residual case
+(direct push, `[skip ci]`, a bot path that somehow evades Layer 1) is never silent:
+
+1. **Agent-side `ReleaseReadinessSentinel` (the durable surface, D7).** Extend its
+   blocked-detection to fire FAST on "release-relevant commits since the last
+   published SHA with no fragment" (path-predicate-aware, sharing D6), bypassing the
+   2-day backlog floor for this specific case. It raises ONE deduped Attention item
+   (its existing surface) — this is the durable, ack-able signal. Honest status: it
+   is dev-gated/ships-dark (Echo dogfoods); the spec does NOT pretend it covers the
+   fleet today.
+2. **Publish-side loud annotation (best-effort, CI-only).** In `publish.yml`'s
+   `guide-check` skip branch, when the skip would happen BUT the commits since the
+   last published SHA (D11) are release-relevant, emit a loud `::warning::` +
+   `$GITHUB_STEP_SUMMARY` naming the unreleased commits (count-capped). **Never fails
+   the run** (D1), **never claims to raise an Attention item**, and treats all
+   commit messages/filenames as **opaque data** — read via NUL-delimited
+   (`-z`) git output into Node `execFile`/`spawn` argv arrays, **never** a shell
+   string or `execSync` interpolation (the `instar-dev-precommit.js` string-interp
+   pattern is the explicit anti-pattern NOT to copy), and never echoed raw through
+   `::`-prefixed lines or `$GITHUB_OUTPUT`/`$GITHUB_ENV` (workflow-command
+   injection). A committed off-switch file mirrors the existing
+   `.instar/release-tier.json` precedent so the annotation can be silenced without a
+   workflow edit.
+
+### What this does NOT change
+
+- The publish refusal (no fragment ⇒ no version) is CORRECT and stays. We add
+  un-bypassable prevention + loud visibility; we never weaken the refusal.
+- No change to `resolve-publish-version.mjs` / `resolve-release-tier.mjs` /
+  `.instar/release-tier.json` semantics.
+
+## Cross-machine posture
+
+- **Layer 1** runs in GitHub Actions — machine-agnostic, no agent state, no
+  multi-machine concern.
+- **Layer 2 publish annotation** runs in Actions — machine-agnostic.
+- **Layer 2 Sentinel** is **machine-local by design** (a single dev agent runs the
+  `release-readiness-check` job; its dedup state lives in
+  `.instar/state/release-readiness.json`). Posture: **single-owner** — only one agent
+  runs the job. It deliberately needs **no fenced lease**: the dedup is advisory, the
+  boundary truth lives in `main` (not agent-local state), so the worst case if two
+  agents ran it is a duplicate Attention raise (re-derived from `main`), never a lost
+  signal or a corrupted decision — the failure direction is safe. On identity/topic
+  transfer the new host's first tick re-derives from `main`, so an episode is at worst
+  briefly re-raised, never lost. Documented, not silently single-machine.
+
+## Migration parity
+
+- `.github/workflows/**` and `scripts/**` are **repo files**. `.github/` reaches
+  only git-clone dev agents (Echo) via `git pull` and reaches the fleet not at all;
+  `scripts/` IS in the npm `files` payload (`package.json`) so it ships to the fleet,
+  replaced wholesale on npm update. **Neither needs a `PostUpdateMigrator` entry**
+  (a migrator patches agent-authored installed files; these are wholesale-shipped
+  repo files). Verified: `.husky/` is NOT in the npm `files` whitelist and
+  `migrateHooks()` writes only `.instar/hooks/instar/` — so the excluded Layer 0
+  (D4) would in any case NOT be a `migrateHooks()` concern; the earlier draft's claim
+  was wrong and is removed.
+- The Sentinel trigger change (D7) is `src/` code — ships in `dist` to the fleet via
+  npm, gated by the existing dev-gate + `release-readiness-check` job `enabled:false`
+  default (unchanged). No new migration.
+
+## Test tiers
+
+- **Unit:** the `release-relevant-paths` predicate — both sides of every boundary
+  AND **adversarial evasion cases** (case-fold, `..` traversal, trailing slash, a
+  runtime file shaped like a test path, the explicit config/template/lockfile
+  additions, the docs/test exemptions). **Anti-drift ownership rule:** a guard test
+  enumerates the current top-level shipped/runtime roots (derived from the npm `files`
+  whitelist) and FAILS if a new top-level root appears that the predicate does not
+  explicitly classify as relevant-or-exempt — so a future release-bearing directory
+  can't silently fall through as a false-negative. The opt-out parser (standalone
+  `<!-- internal-only -->` directive vs a prose mention of the marker — the
+  prose-mention-must-not-exempt collision); `checkReleaseFragment` full decision
+  table (both sides).
+- **Integration:** the Layer-1 CLI over synthetic PR file-lists + bodies + labels +
+  author types (fragment present ⇒ pass; release-relevant + no fragment + no optout
+  ⇒ fail; internal-only fragment ⇒ pass; test-only ⇒ pass; release-cut bot ⇒ exempt;
+  agent author ⇒ gated); the Layer-2 detect over a synthetic git log (release-relevant
+  since published-SHA + no fragment ⇒ surfaced; fragment present ⇒ quiet; docs-only
+  ⇒ quiet; the rebase-retry/concurrent-merge topology from D11 ⇒ still surfaced).
+- **Wiring-integrity (required):** the Sentinel's new fast-trigger is actually
+  invoked by the real tick with a non-null path predicate (not a no-op); the shared
+  predicate module is the SAME one consumed by `inScope()` and `pre-push-gate.js §3b`
+  (one import, not three copies); the gate's fail-closed path reports red on a thrown
+  error.
+- **E2E/CI:** a smoke proving the Layer-1 gate fails a release-relevant no-fragment
+  PR and passes one with a fragment (and one with an internal-only fragment); a smoke
+  proving the publish annotation fires on a no-fragment release-relevant skip and
+  stays quiet with a fragment.
+
+## Standards parent
+
+Primary: **"Structure beats Willpower"** (exact registry article) — move the
+fragment requirement from a locally-bypassable hook to an un-bypassable merge-boundary
+guarantee. Secondary: **"No Silent Degradation to Brittle Fallback"** (exact registry
+article) — a green publish run that silently skips merged work is the textbook
+"looks-protected while fake-protected" degradation this article forbids; this spec
+extends it from LLM-gating calls to the release pipeline. Also engages **"Close the
+Loop / Deferral = Deletion"** (a release must not silently swallow merged work).
+
+## Open questions
+
+*(none)*

--- a/docs/specs/reports/release-fragment-gate-convergence.md
+++ b/docs/specs/reports/release-fragment-gate-convergence.md
@@ -1,0 +1,138 @@
+# Convergence Report — Release-Fragment Gate
+
+## Cross-model review: codex-cli:gpt-5.5
+
+A real GPT-tier external pass (codex CLI, `gpt-5.5`) ran successfully in every round;
+a Gemini-tier pass (`gemini-2.5-pro`) ran in rounds 1 and 3 (round 2 degraded on a
+transient timeout). The spec received genuine, repeated non-Claude external review.
+Both external families converged from "MINOR ISSUES" with no critical/major findings
+remaining.
+
+## ELI10 Overview
+
+instar ships new versions through a robot pipeline. That robot needs a short
+"what changed" note (a small file) before it will cut a version — and if the note is
+missing it does the safe thing and refuses to ship. The problem: it refused
+**silently**. The release job went green and looked fine, but no version came out. On
+June 27, three real bug fixes merged with no note, the robot quietly skipped shipping
+them, and they sat unshipped for ~7 hours — and an earlier session even misread the
+green checkmark as someone else's pipeline glitch.
+
+This spec makes that impossible. The surprising thing the review uncovered: a guard
+demanding the note **already existed** — but it only ran on a developer's own laptop
+at `git push` time, and the way code actually lands now (the robot squash-merges an
+approved pull request on the server) skips that laptop guard entirely. So the rule was
+enforced in the one place merges don't happen. The fix moves the same rule to the
+server, as a check on the pull request itself, where it can't be routed around — and
+adds a loud alarm for anything that still slips through, so a skipped release is never
+silent again.
+
+The main tradeoffs, all resolved in review: the server check starts in "just warn"
+mode and only becomes a hard block once it's proven it doesn't raise false alarms
+(measured mechanically, not by gut feel); the "is a note present?" question is kept
+deliberately simple (a yes/no a regex can answer) so it never makes a fuzzy judgment;
+and the durable loud-alarm part ships first only on the developer agent (honestly
+stated), with the universal protection being the un-skippable pull-request check.
+
+## Original vs Converged
+
+- **Originally** the spec diagnosed the root cause as "nothing structurally requires a
+  fragment." **Review proved that wrong:** a *hard* pre-push gate already requires it
+  (`pre-push-gate.js §3b`) — the real gap is that it runs in a local git hook that
+  server-side squash/bot/auto-merges never execute. The whole framing was corrected:
+  the fix is moving the existing requirement to the un-bypassable merge boundary, not
+  inventing a new requirement.
+- **Originally** the loud-skip backstop was "a step in the publish workflow that raises
+  an Attention item via the watchdog." **Review showed this was architecturally
+  broken** three ways: a GitHub Actions runner can't reach the agent's Attention
+  store; the watchdog ships dark with a 2-day silent floor (so it wouldn't have caught
+  the 7-hour incident); and a `[skip ci]` commit turns off the whole publish job
+  including that step. Converged design: the durable surface is the **agent-side
+  Sentinel** (a poller that reads `main` independently of CI, with a new fast trigger),
+  honestly documented as dev-gated; the CI side is a loud-but-best-effort annotation
+  that never claims to do more than it can.
+- **Originally** the opt-out was a free-text PR-body marker. **Review flagged** that any
+  fork author could self-assert it, re-creating a deliberate silent-skip at scale.
+  Converged: the opt-out is the existing diff-verified `internal-only` fragment lane —
+  durable, auditable, and it still cuts a version.
+- **Security hardening added in review:** mandate `on: pull_request` (never
+  `pull_request_target`), load the predicate from the **base ref** (never PR-head, or a
+  PR could rewrite the gate to always-pass and run arbitrary CI code), key the bot
+  exemption on **authenticated identity** not a spoofable `chore: release` title, and
+  treat all git/commit data as opaque NUL-delimited argv (never shell-interpolated in
+  the token-bearing publish job).
+- **Correctness added in review:** the loud-skip window is bounded on the
+  **release-bot-only annotated tag** (not a PR-mutable in-repo file, and not the
+  release commit's ancestry — which the publish rebase-retry loop would bury a
+  concurrently-merged fragment-less PR beneath).
+- **Decision-completeness:** the original had ~6 decisions parked on the user. Converged
+  has a `## Frontloaded Decisions` table (D1–D11) with concrete defaults and an empty
+  `## Open questions`; the warn→block flip is a mechanical, log-derived criterion scoped
+  to the population the gate can actually observe.
+
+## Iteration Summary
+
+| Iteration | Reviewers who flagged material findings | Material findings | Standards-Conformance Gate | Cross-model |
+|-----------|------------------------------------------|-------------------|----------------------------|-------------|
+| 1 | security, adversarial, integration, decision-completeness, lessons-aware, scalability (all six) + codex + gemini | ~17 (incl. 3 critical: misdiagnosed root cause, Layer-2-can't-signal-from-CI, wrong symbol names) | ran (1 flag: Testing Integrity) | codex-cli:gpt-5.5 (ran), gemini-2.5-pro (ran) |
+| 2 | decision-completeness (D3 non-mechanical), security (N1–N4) | 5 (D3 + 4 security medium) | ran (1 flag: Cross-Machine Coherence) | codex-cli:gpt-5.5 (ran), gemini (degraded) |
+| 3 | (converged — security CONVERGED, decision-completeness CONVERGED) | 0 material (externals: MINOR ISSUES only) | ran (clean: fit resolved) | codex-cli:gpt-5.5 (ran), gemini-2.5-pro (ran) |
+
+## Full Findings Catalog
+
+### Round 1 (material)
+- **CRITICAL (lessons-aware):** spec misdiagnosed its foundation — a hard pre-push
+  fragment gate already exists; real gap is the bypassable server-side merge path.
+  → Problem section fully reframed.
+- **CRITICAL (adversarial/integration/lessons):** Layer 2 as a publish-workflow step
+  cannot raise an Attention item from GitHub Actions; the Sentinel ships dark + 2-day
+  silent floor; `[skip ci]` disables the whole publish job. → D7: durable surface is
+  the agent-side Sentinel (poller) with a fast trigger, honestly dev-gated; CI is
+  best-effort annotation only.
+- **CRITICAL (decision-completeness/lessons):** wrong symbol names
+  (`ReleaseReadinessWatchdog`→`Sentinel`, `isInScope`→`inScope`). → corrected.
+- **HIGH (lessons/conformance):** `parent-principle` "Structure > Willpower" won't
+  resolve against the registry → "Structure beats Willpower". Mis-cited "Degradation Is
+  an Event" → "No Silent Degradation to Brittle Fallback". → both fixed; Signal-vs-
+  Authority section added.
+- **HIGH (security C1/C2/M4):** trigger unspecified (`pull_request_target` = RCE);
+  untrusted git/body data interpolated in the token-bearing publish job; workflow-
+  command injection. → hard requirements added (pull_request, read-only perms, NUL-
+  delimited argv, no `::`-echo of untrusted data).
+- **HIGH (security M1/M2/M3, adversarial):** self-asserted body-marker opt-out;
+  gate inert unless a required check; predicate misclassification = silent bypass;
+  bot-exemption swallows the target population. → D8 (internal-only fragment opt-out),
+  D9 (identity-keyed exemption), D6 (canonicalized single-source predicate +
+  required-check deliverable).
+- **HIGH (scalability):** "since last chore: release" boundary buries concurrent
+  merges via the rebase-retry loop; shallow checkout starves history. → D11
+  (tag-bounded published-SHA window + fetch-depth:0).
+- **Conformance gate:** Testing Integrity — add wiring-integrity + both-sides semantic
+  tests. → test tiers expanded.
+
+### Round 2 (material)
+- **Decision-completeness NOT-CONVERGED:** D3 flip criterion non-mechanical
+  ("false-positive blocks" in a non-blocking phase; "fleet" unobservable). → D3
+  rewritten: instar-repo scope, objective false-positive definition, FAIL-verdict
+  language, log-derived count+duration.
+- **Security NOT-CONVERGED (N1–N4):** load module from base ref (not PR-head); bot
+  exemption keyed on identity not title string; remove the contradictory label
+  opt-out; trust the release-bot-only tag over PR-mutable in-repo JSON. → all four
+  folded.
+- **Conformance gate:** Cross-Machine Coherence — note the single-owner/no-fenced-lease
+  posture. → added (advisory dedup, re-raise-at-worst).
+
+### Round 3 (non-material / minor — converged)
+- codex/gemini MINOR: Layer 1 presence-not-validity tradeoff (→ explicit note: a junk
+  fragment fails loudly downstream, never silently); "un-bypassable" overstated (→
+  softened + periodic required-check drift audit added); durable backstop not universal
+  (→ already honestly stated as dev-gated). No material findings.
+
+## Convergence verdict
+
+**Converged at iteration 3.** No material findings in the final round: the security
+reviewer and the decision-completeness reviewer both returned CONVERGED, the
+Standards-Conformance Gate's parent-principle fit resolved, and both external models
+returned MINOR-ISSUES-only with every critical/major from earlier rounds folded. All
+build-time decisions are frontloaded (D1–D11); `## Open questions` is empty. The spec
+is ready for user review and approval.

--- a/scripts/check-release-fragment.mjs
+++ b/scripts/check-release-fragment.mjs
@@ -1,0 +1,152 @@
+#!/usr/bin/env node
+/**
+ * release-fragment-gate (Layer 1) — the server-side PR-time check that a
+ * release-affecting PR carries a release-note fragment.
+ *
+ * ── Why ───────────────────────────────────────────────────────────────
+ * A HARD pre-push gate already requires the fragment, but it runs in husky
+ * LOCALLY — the server-side squash/bot/auto-merge path that lands most merges
+ * never runs husky, so a fragment-less change reaches main and the publish
+ * SILENTLY skips the release (2026-06-27: PRs #1295-#1297 stranded ~7h). This
+ * gate moves the SAME requirement to the merge boundary, where it cannot be
+ * routed around.
+ *
+ * ── Signal vs Authority ───────────────────────────────────────────────
+ * This is an AUTHORITY (it can block a merge), but its veto rests on an
+ * OBJECTIVE BINARY — "a release-note fragment file is present, yes/no" — exactly
+ * the shape the existing eli16-pr-gate already establishes. The release-relevant
+ * path predicate is a FALLIBLE SIGNAL: a false positive is always escapable by
+ * adding a one-line `internal-only` fragment. The block is carried by the
+ * presence condition, never the predicate's correctness.
+ *
+ * ── Security ──────────────────────────────────────────────────────────
+ * Runs under `on: pull_request` (NOT pull_request_target), read-only token, no
+ * PR-head checkout. Untrusted PR title/body arrive via env (process.env), never
+ * shell-interpolated. The bot exemption keys on the AUTHENTICATED actor identity
+ * (login + type), never a spoofable title string. FAIL-CLOSED: any internal
+ * error reports the check FAILED, never green.
+ *
+ * Pure `checkReleaseFragment(...)` is exported for unit testing; the CLI wrapper
+ * reads env set by the workflow and exits 0 (pass/exempt) or 1 (fail).
+ */
+
+import { isReleaseRelevant } from './release-relevant-paths.mjs';
+
+/** A changed file that is a release-note fragment (the opt-out lane is itself such a file). */
+function isFragmentFile(p) {
+  if (typeof p !== 'string') return false;
+  const norm = p.trim().replace(/\\/g, '/').replace(/^\.\//, '');
+  return /^upgrades\/next\/.+\.md$/.test(norm) || norm === 'upgrades/NEXT.md';
+}
+
+/**
+ * @param {{
+ *   files?: Array<{ path: string, status?: string }> | string[],
+ *   authorLogin?: string|null,
+ *   authorType?: string|null,
+ *   title?: string|null,
+ *   releaseBotLogin?: string|null,   // the known release-cut bot login (default github-actions[bot])
+ * }} pr
+ * @returns {{ ok: boolean, exempt?: string, reason?: string, relevant?: string[] }}
+ */
+export function checkReleaseFragment(pr) {
+  const releaseBotLogin = (pr?.releaseBotLogin ?? 'github-actions[bot]');
+
+  // ── Exemption: ONLY the authenticated release-cut bot identity ──────
+  // Keyed on login + type, NEVER a title/commit-message string. A human-authored
+  // PR titled "chore: release …" is still gated (the spoof fails by construction).
+  const login = String(pr?.authorLogin ?? '');
+  const type = String(pr?.authorType ?? '');
+  if (type === 'Bot' && login && login === releaseBotLogin) {
+    return { ok: true, exempt: 'release-cut-bot' };
+  }
+
+  // Normalize the changed-file list (accept the files API shape OR a bare path list).
+  const rawFiles = Array.isArray(pr?.files) ? pr.files : [];
+  const paths = rawFiles.map((f) => (typeof f === 'string' ? f : f?.path)).filter((p) => typeof p === 'string');
+
+  // (a) Any release-relevant changed path?
+  const relevant = paths.filter((p) => isReleaseRelevant(p));
+  if (relevant.length === 0) {
+    return { ok: true, exempt: 'no-release-relevant-paths' };
+  }
+
+  // (b) A release-note fragment added/modified? (Presence, not content — Layer 1
+  //     has only the file list. The internal-only opt-out IS such a file, so its
+  //     presence satisfies this; its legitimacy is verified downstream at
+  //     assemble-next-md + pre-push-gate §3c.)
+  const hasFragment = paths.some(isFragmentFile);
+  if (hasFragment) {
+    return { ok: true };
+  }
+
+  return { ok: false, reason: 'release-relevant-no-fragment', relevant };
+}
+
+// ── CLI (used by .github/workflows/release-fragment-gate.yml) ─────────
+const invokedDirectly =
+  process.argv[1] && import.meta.url === new URL(`file://${process.argv[1]}`).href;
+
+if (invokedDirectly) {
+  // FAIL-CLOSED: any throw below exits non-zero (never a silent green).
+  try {
+    // The workflow provides the changed-file list as JSON in PR_FILES_JSON
+    // (array of { path/filename, status }), and PR_AUTHOR_LOGIN / PR_AUTHOR_TYPE
+    // / PR_TITLE from the event. WARN_ONLY=1 reports the verdict without failing
+    // (soak phase — spec D2/D3).
+    let files = [];
+    try {
+      const parsed = JSON.parse(process.env.PR_FILES_JSON || '[]');
+      if (Array.isArray(parsed)) {
+        files = parsed.map((f) => ({ path: f.path ?? f.filename, status: f.status }));
+      }
+    } catch (e) {
+      console.error(`release-fragment-gate: could NOT parse PR_FILES_JSON — failing closed. ${e?.message ?? e}`);
+      process.exit(1);
+    }
+
+    const res = checkReleaseFragment({
+      files,
+      authorLogin: process.env.PR_AUTHOR_LOGIN,
+      authorType: process.env.PR_AUTHOR_TYPE,
+      title: process.env.PR_TITLE,
+      releaseBotLogin: process.env.RELEASE_BOT_LOGIN || undefined,
+    });
+
+    const warnOnly = process.env.WARN_ONLY === '1';
+
+    if (res.ok) {
+      console.log(
+        res.exempt
+          ? `release-fragment-gate: exempt (${res.exempt}).`
+          : 'release-fragment-gate: OK — a release-note fragment is present.',
+      );
+      // Emit a machine-readable verdict line for the rollout log (spec D3).
+      console.log(`::notice::release-fragment-gate verdict=PASS exempt=${res.exempt ?? 'none'}`);
+      process.exit(0);
+    }
+
+    const msg =
+      `release-fragment-gate: this PR changes release-relevant files but adds NO release-note ` +
+      `fragment (upgrades/next/<slug>.md). Without one, the publish pipeline SILENTLY SKIPS the ` +
+      `release — your change would merge but never ship (the 2026-06-27 incident).\n` +
+      `  Release-relevant files:\n` +
+      res.relevant.slice(0, 8).map((f) => `    • ${f}`).join('\n') +
+      (res.relevant.length > 8 ? `\n    • …and ${res.relevant.length - 8} more` : '') +
+      `\n  Fix: add upgrades/next/<slug>.md describing the change (via /instar-dev). For a genuinely ` +
+      `no-user-impact change, add a fragment carrying the standalone <!-- internal-only --> marker.`;
+
+    if (warnOnly) {
+      console.log(`::warning::${msg.replace(/\n/g, ' ')}`);
+      console.log(`::notice::release-fragment-gate verdict=FAIL warn-only=1 (not blocking during soak)`);
+      process.exit(0); // soak phase: report, do not block
+    }
+    console.error(msg);
+    console.log(`::notice::release-fragment-gate verdict=FAIL blocking=1`);
+    process.exit(1);
+  } catch (e) {
+    // FAIL-CLOSED — an internal error must turn the check RED, never green.
+    console.error(`release-fragment-gate: internal error — failing closed. ${e?.stack ?? e}`);
+    process.exit(1);
+  }
+}

--- a/scripts/lint-no-direct-destructive.js
+++ b/scripts/lint-no-direct-destructive.js
@@ -134,6 +134,12 @@ const ALLOWLIST = new Set([
   // previous release. Build-time only; never executes on an agent's
   // machine. Per INSTAR-JOBS-AS-AGENTMD spec §Drift Classifier.
   'scripts/classify-default-drift.mjs',
+  // release-fragment-gate Layer 2 publish-side annotator — runs READ-ONLY git
+  // (`describe --tags`, `diff --name-only -z`, `log`, `ls-files`) inside the
+  // publish GitHub Action to detect unreleased release-relevant work on a skip.
+  // CI-only; never executes on an agent's machine, and TS isn't compiled there
+  // so it cannot import the SafeGitExecutor funnel. Per RELEASE-FRAGMENT-GATE-SPEC.
+  'scripts/release-skip-annotate.mjs',
   // Tier-3 CI ratchet for the cartographer doc-tree (cartographer-doc-freshness
   // spec #2). A standalone .mjs (parity with docs-coverage.mjs) that runs in CI
   // with NO build step, so it cannot import the TS SafeGitExecutor funnel. All

--- a/scripts/pre-push-gate.js
+++ b/scripts/pre-push-gate.js
@@ -15,6 +15,7 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { validateGuideContent } from './upgrade-guide-validator.mjs';
 import { assembleNextMd, gatherFragmentInputs, hasInternalOnlyMarker } from './assemble-next-md.mjs';
+import { isReleaseRelevant } from './release-relevant-paths.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, '..');
@@ -191,13 +192,19 @@ try {
   const fragmentChanges = changedFiles.filter(f =>
     f.startsWith('upgrades/next/') || f === 'upgrades/NEXT.md'
   );
-  if (srcChanges.length > 0 && fragmentChanges.length === 0) {
+  // Release-relevance is now the SHARED predicate (scripts/release-relevant-paths.mjs),
+  // the same one the server-side Layer-1 PR gate uses — so "needs a release note?"
+  // has one answer in both places. This BROADENS the old src/**.ts-only check to
+  // also catch scripts/, .github/workflows/, package.json, and skill code/templates
+  // (all of which ship behavior but previously slipped this local gate).
+  const releaseRelevantChanges = changedFiles.filter(isReleaseRelevant);
+  if (releaseRelevantChanges.length > 0 && fragmentChanges.length === 0) {
     errors.push(
-      `${srcChanges.length} source file(s) changed but no release-note fragment was added. ` +
+      `${releaseRelevantChanges.length} release-relevant file(s) changed but no release-note fragment was added. ` +
       `Without upgrades/next/<slug>.md (or upgrades/NEXT.md), publish.yml SILENTLY SKIPS the ` +
       `release — your change would merge but never ship. Add a fragment describing the change:\n` +
-      srcChanges.slice(0, 5).map(f => `      • ${f}`).join('\n') +
-      (srcChanges.length > 5 ? `\n      • ...and ${srcChanges.length - 5} more` : '')
+      releaseRelevantChanges.slice(0, 5).map(f => `      • ${f}`).join('\n') +
+      (releaseRelevantChanges.length > 5 ? `\n      • ...and ${releaseRelevantChanges.length - 5} more` : '')
     );
   }
 

--- a/scripts/release-relevant-paths.mjs
+++ b/scripts/release-relevant-paths.mjs
@@ -1,0 +1,171 @@
+#!/usr/bin/env node
+/**
+ * release-relevant-paths — the SINGLE SOURCE OF TRUTH for "does this changed
+ * file ship behavior that must carry a release-note fragment?"
+ *
+ * ── Why this exists ───────────────────────────────────────────────────
+ * The release-note fragment requirement was enforced by THREE independent
+ * predicates that could drift: `pre-push-gate.js §3b` (`src/**.ts` only — too
+ * narrow, missed scripts/workflows), and the publish-side skip is path-blind.
+ * On 2026-06-27 PRs #1295-#1297 merged with no fragment and the publish ran
+ * green and silently skipped (v1.3.685 stuck ~7h). This module is the one
+ * predicate the PR-time gate (Layer 1) AND the local pre-push gate share, so
+ * "is this release-relevant?" has exactly one answer everywhere.
+ *
+ * It answers ONE question: "needs a release note?". It is deliberately NOT
+ * `instar-dev-precommit.js`'s `inScope()` — that answers a DIFFERENT question
+ * ("needs instar-dev review?") and is intentionally narrower; merging them
+ * would silently change which changes require review. (See the spec's D6 +
+ * the side-effects artifact for the reconciliation.)
+ *
+ * ── The predicate (spec D6) ───────────────────────────────────────────
+ *   RELEASE-RELEVANT (positive): src/, scripts/, .husky/, skills/** code +
+ *     SKILL.md + templates/, package.json, package-lock.json,
+ *     .github/workflows/**.
+ *   EXEMPT (never release-relevant, even under a positive root):
+ *     any *.test.ts, the tests/ tree, the docs/ tree, a bare *.md (notes/readme)
+ *     that is NOT a SKILL.md or under a skill templates/ dir, the upgrades/ tree
+ *     (the fragment dir itself), the .instar/ tree (agent-local), and repo
+ *     dotfiles like .gitignore.
+ *
+ * Paths are canonicalized (POSIX separators, no leading ./, `..` REJECTED as
+ * relevant — the safe direction) and compared case-insensitively on the
+ * segment, so `Src/Foo.TS`, `src/../src/x.ts`, and `src/x.ts/` cannot evade.
+ *
+ * Pure + exported for unit testing; the CLI wrapper classifies a newline/comma
+ * list of paths.
+ */
+
+/** Canonicalize a changed-file path to a comparable POSIX form. Returns null if it escapes the tree. */
+export function canonicalizePath(raw) {
+  if (typeof raw !== 'string') return null;
+  let p = raw.trim();
+  if (!p) return null;
+  // Normalize separators + strip a leading ./, collapse duplicate slashes.
+  p = p.replace(/\\/g, '/').replace(/\/+/g, '/').replace(/^\.\//, '').replace(/\/+$/, '');
+  if (!p) return null;
+  // Reject any traversal segment — a `..` path is treated as release-relevant
+  // by the caller (fail toward "in scope"), never silently exempt.
+  const segments = p.split('/');
+  if (segments.some((s) => s === '..')) return { escaped: true, path: p };
+  return { escaped: false, path: p };
+}
+
+/** Lowercase form for case-insensitive matching (covers macOS/Windows case-fold FS). */
+function lc(p) {
+  return p.toLowerCase();
+}
+
+/**
+ * Is this changed file release-relevant (needs a release-note fragment)?
+ * @param {string} rawPath a repo-relative changed-file path
+ * @returns {boolean}
+ */
+export function isReleaseRelevant(rawPath) {
+  const c = canonicalizePath(rawPath);
+  if (c === null) return false;
+  // A traversal path is ambiguous → bias toward release-relevant (the safe
+  // direction: a false "needs a note" is escapable with a one-line fragment; a
+  // false exempt silently re-opens the 2026-06-27 silent-skip).
+  if (c.escaped) return true;
+  const p = lc(c.path);
+
+  // ── EXEMPT (checked first — exemptions override positive roots) ──────
+  // Test files anywhere.
+  if (p.endsWith('.test.ts') || p.endsWith('.test.js') || p.endsWith('.test.mjs')) return false;
+  if (p === 'tests' || p.startsWith('tests/')) return false;
+  // Docs + the release-notes machinery itself.
+  if (p === 'docs' || p.startsWith('docs/')) return false;
+  if (p === 'upgrades' || p.startsWith('upgrades/')) return false;
+  // Agent-local + repo dotfiles that ship no runtime behavior.
+  if (p.startsWith('.instar/')) return false;
+  if (p.startsWith('.github/') && !p.startsWith('.github/workflows/')) return false; // ISSUE_TEMPLATE etc.
+
+  // ── POSITIVE (release-relevant) ─────────────────────────────────────
+  if (p === 'package.json' || p === 'package-lock.json') return true;
+  if (p.startsWith('.github/workflows/')) return true;
+  if (p.startsWith('src/')) return true;
+  if (p.startsWith('scripts/')) return true;
+  if (p.startsWith('.husky/')) return true;
+  // Built-in skills under skills/ ship behavior.
+  if (p.startsWith('skills/')) return isSkillPathRelevant(p);
+  // SHIPPED .claude paths (package.json `files`): .claude/hooks/** and the
+  // built-in .claude/skills/<name>/ dirs are hand-maintained behavior that
+  // reaches the fleet via npm — NOT exempt (the second-pass-review fix). Other
+  // .claude/** is agent-local and not shipped → exempt.
+  if (p.startsWith('.claude/hooks/')) return true;
+  if (p.startsWith('.claude/skills/') && SHIPPED_CLAUDE_SKILLS.some((n) => p.startsWith(`.claude/skills/${n}/`))) {
+    return isSkillPathRelevant(p);
+  }
+
+  // ── Everything else: a bare *.md, assets, examples, site, etc. → exempt.
+  return false;
+}
+
+/** Built-in .claude/skills/<name> dirs shipped via package.json `files`. */
+const SHIPPED_CLAUDE_SKILLS = ['setup-wizard', 'secret-setup', 'autonomous', 'build'];
+
+/**
+ * Within a skill dir, classify a path. FAIL TOWARD RELEVANT: a SKILL.md, a
+ * templates/ file, or ANY code/data file is relevant; only a bare doc *.md that
+ * is NOT a SKILL.md and NOT under templates/ is exempt. (Broadened from a fixed
+ * extension allowlist so .cjs/.py/.json and future code types are not silently
+ * exempted — the second-pass-review fix.)
+ */
+function isSkillPathRelevant(p) {
+  if (p.endsWith('/skill.md')) return true;
+  if (p.includes('/templates/')) return true;
+  if (p.endsWith('.md')) return false; // a non-SKILL.md skill doc
+  return true; // any other file under a skill ships behavior/data
+}
+
+/**
+ * Classify a list of changed-file paths.
+ * @param {string[]} paths
+ * @returns {{ relevant: string[], exempt: string[] }}
+ */
+export function classifyPaths(paths) {
+  const relevant = [];
+  const exempt = [];
+  for (const raw of paths) {
+    const c = canonicalizePath(raw);
+    const display = c && !c.escaped ? c.path : (typeof raw === 'string' ? raw.trim() : String(raw));
+    if (isReleaseRelevant(raw)) relevant.push(display);
+    else if (display) exempt.push(display);
+  }
+  return { relevant, exempt };
+}
+
+/**
+ * The current top-level shipped/runtime roots, derived from package.json `files`.
+ * Used by the anti-drift guard test: a NEW top-level root the predicate does not
+ * explicitly classify must fail the test, so a future release-bearing directory
+ * cannot silently fall through as a false-negative (spec D6 anti-drift rule).
+ * @param {string[]} filesWhitelist package.json `files`
+ * @returns {string[]} distinct top-level segments
+ */
+export function shippedTopLevelRoots(filesWhitelist) {
+  const roots = new Set();
+  for (const entry of filesWhitelist || []) {
+    const c = canonicalizePath(entry);
+    if (!c || c.escaped) continue;
+    const top = c.path.split('/')[0];
+    if (top) roots.add(top);
+  }
+  return [...roots].sort();
+}
+
+// ── CLI: classify a newline/comma-separated list of paths from argv/stdin ──
+const invokedDirectly =
+  process.argv[1] && import.meta.url === new URL(`file://${process.argv[1]}`).href;
+
+if (invokedDirectly) {
+  const arg = process.argv.slice(2).join(' ').trim();
+  let input = arg;
+  if (!input) {
+    try { input = require('node:fs').readFileSync(0, 'utf8'); } catch { input = ''; }
+  }
+  const paths = input.split(/[\n,]/).map((s) => s.trim()).filter(Boolean);
+  const { relevant, exempt } = classifyPaths(paths);
+  process.stdout.write(JSON.stringify({ relevant, exempt, releaseRelevant: relevant.length > 0 }, null, 2) + '\n');
+}

--- a/scripts/release-skip-annotate.mjs
+++ b/scripts/release-skip-annotate.mjs
@@ -1,0 +1,133 @@
+#!/usr/bin/env node
+/**
+ * release-skip-annotate (Layer 2, publish-side) — when the publish pipeline is
+ * about to SKIP a release (no fragment → no version), check whether
+ * release-relevant work has merged since the last published tag, and if so emit
+ * a LOUD, count-capped annotation + step summary instead of a silent green run.
+ *
+ * Spec: docs/specs/RELEASE-FRAGMENT-GATE-SPEC.md (Layer 2, D1/D7/D11).
+ *
+ * It is a SIGNAL: it NEVER fails the run (always exits 0) and NEVER claims to
+ * raise an Attention item (a CI runner cannot reach the agent's Attention store —
+ * the durable surface is the agent-side ReleaseReadinessSentinel). Commit data is
+ * read NUL-delimited via execFile argv arrays — never a shell string — and never
+ * echoed raw through `::`-prefixed workflow commands beyond the bounded message.
+ *
+ * Boundary (D11): the authoritative window start is the most recent annotated
+ * `vX.Y.Z` tag (written only by the release bot, so it is NOT PR-mutable). A
+ * missing/unparseable boundary surfaces ALL reachable commits with an eval-note —
+ * never a silent empty range.
+ *
+ * Pure `classifyRange({ files })` is exported for testing; the CLI does the git I/O.
+ */
+
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import { isReleaseRelevant } from './release-relevant-paths.mjs';
+
+/**
+ * Given a list of changed file paths in the unreleased window, return the
+ * release-relevant subset.
+ * @param {{ files: string[] }} input
+ * @returns {{ relevant: string[] }}
+ */
+export function classifyRange({ files }) {
+  const relevant = (files || []).filter((f) => isReleaseRelevant(f));
+  return { relevant };
+}
+
+function git(args) {
+  // argv array — never a shell string. NUL-delimited callers split on \0.
+  return execFileSync('git', args, { encoding: 'utf8', maxBuffer: 64 * 1024 * 1024 });
+}
+
+/** Most recent annotated vX.Y.Z tag reachable from HEAD, or null. */
+function lastReleaseTag() {
+  try {
+    const out = git(['describe', '--tags', '--match', 'v[0-9]*', '--abbrev=0']).trim();
+    return out || null;
+  } catch {
+    return null;
+  }
+}
+
+/** Changed files in <range> as an array (NUL-delimited, opaque). */
+function changedFilesInRange(range) {
+  // --name-only -z gives NUL-delimited filenames; we never shell-interpolate them.
+  const raw = git(['diff', '--name-only', '-z', range]);
+  return raw.split('\0').map((s) => s.trim()).filter(Boolean);
+}
+
+/** Distinct commit subjects in <range> (count-capped, for the summary only). */
+function commitSubjects(range, cap) {
+  try {
+    const raw = git(['log', '--no-merges', '--format=%s%x00', range]);
+    return raw.split('\0').map((s) => s.trim()).filter(Boolean).slice(0, cap);
+  } catch {
+    return [];
+  }
+}
+
+const invokedDirectly =
+  process.argv[1] && import.meta.url === new URL(`file://${process.argv[1]}`).href;
+
+if (invokedDirectly) {
+  const SUMMARY_CAP = 20;
+  const emit = (line) => process.stdout.write(line + '\n');
+  const summaryFile = process.env.GITHUB_STEP_SUMMARY;
+  const writeSummary = (text) => {
+    if (summaryFile) {
+      try { fs.appendFileSync(summaryFile, text + '\n'); } catch { /* best effort */ }
+    }
+  };
+
+  // NEVER throw out of here — Layer 2 is signal-only; always exit 0.
+  try {
+    const tag = lastReleaseTag();
+    const range = tag ? `${tag}..HEAD` : null;
+    let files;
+    let boundaryNote = '';
+    if (range) {
+      files = changedFilesInRange(range);
+    } else {
+      // Missing boundary (e.g. first publish before any vX.Y.Z tag) — surface
+      // ALL reachable commits with an eval-note, never a silent empty range.
+      boundaryNote = ' (no release tag found — surfacing all reachable history)';
+      files = (() => { try { return git(['ls-files']).split('\n').map((s) => s.trim()).filter(Boolean); } catch { return []; } })();
+    }
+
+    const { relevant } = classifyRange({ files });
+    if (relevant.length === 0) {
+      emit(`::notice::release-skip-annotate: skip is clean — no release-relevant changes since ${tag ?? '(no tag)'}.`);
+      process.exit(0);
+    }
+
+    const subjects = range ? commitSubjects(range, SUMMARY_CAP) : [];
+    const capped = relevant.slice(0, SUMMARY_CAP);
+    const oneLine =
+      `release SKIPPED but ${relevant.length} release-relevant file(s) merged since ${tag ?? 'the start'}${boundaryNote} ` +
+      `with NO release-note fragment — these changes are NOT being shipped. Add upgrades/next/<slug>.md and re-publish.`;
+    emit(`::warning::${oneLine}`);
+
+    const summary =
+      `## ⚠ Release skipped with unreleased release-relevant work\n\n` +
+      `The publish run is about to skip (no release-note fragment), but the following ` +
+      `release-relevant files merged since \`${tag ?? '(no tag)'}\`${boundaryNote} and will NOT ship until a ` +
+      `fragment is added:\n\n` +
+      capped.map((f) => `- \`${f}\``).join('\n') +
+      (relevant.length > SUMMARY_CAP ? `\n- …and ${relevant.length - SUMMARY_CAP} more` : '') +
+      (subjects.length
+        ? `\n\nUnreleased commit subjects:\n\n` + subjects.map((s) => `- ${s.replace(/`/g, "'")}`).join('\n')
+        : '') +
+      `\n\n**Fix:** add \`upgrades/next/<slug>.md\` describing the change (via /instar-dev) and re-publish. ` +
+      `The durable, ack-able signal is raised by the agent-side ReleaseReadinessSentinel; this annotation is a ` +
+      `best-effort CI surface.\n`;
+    writeSummary(summary);
+    emit(`::notice::release-skip-annotate verdict=UNRELEASED-WORK count=${relevant.length}`);
+    process.exit(0);
+  } catch (e) {
+    // Signal-only: an internal error must NOT fail the publish run.
+    emit(`::warning::release-skip-annotate: internal error (non-fatal, release-skip detection only): ${String(e?.message ?? e)}`);
+    process.exit(0);
+  }
+}

--- a/src/monitoring/ReleaseReadinessSentinel.ts
+++ b/src/monitoring/ReleaseReadinessSentinel.ts
@@ -120,6 +120,15 @@ export interface ReleaseReadinessSentinelConfig {
   backlogAgeDaysHigh?: number;
   hysteresisHours?: number;
   staleEpisodeTtlDays?: number;
+  /**
+   * Fast-trigger (RELEASE-FRAGMENT-GATE-SPEC Layer 2, D7): when the block is
+   * specifically a missing release-note fragment (guideBlocksPublish) WITH
+   * unreleased feature/fix work — the case where publish.yml would SILENTLY
+   * SKIP — surface at LOW IMMEDIATELY instead of waiting out the multi-day age
+   * floor. This closes the "fresh fragment-less merge sits silent for 2 days"
+   * gap that the 2026-06-27 incident exposed. Default on.
+   */
+  fastTriggerOnGuideBlock?: boolean;
 }
 
 const DEFAULTS: Required<ReleaseReadinessSentinelConfig> = {
@@ -131,6 +140,7 @@ const DEFAULTS: Required<ReleaseReadinessSentinelConfig> = {
   backlogAgeDaysHigh: 7,
   hysteresisHours: 12,
   staleEpisodeTtlDays: 30,
+  fastTriggerOnGuideBlock: true,
 };
 
 const DAY_MS = 24 * 60 * 60 * 1000;
@@ -250,7 +260,8 @@ export class ReleaseReadinessSentinel extends EventEmitter {
       return;
     }
 
-    const blocked = this.isBlocked(report, await this.deps.guideBlocksPublish());
+    const guideBlocks = await this.deps.guideBlocksPublish();
+    const blocked = this.isBlocked(report, guideBlocks);
     if (!blocked) {
       // Backlog clear — resolve any open episodes.
       await this.resolveAll(state, 'cleared');
@@ -269,7 +280,17 @@ export class ReleaseReadinessSentinel extends EventEmitter {
     }
 
     const ageDays = (this.deps.now() - oldest.dateMs) / DAY_MS;
-    const priority = this.priorityForAge(ageDays);
+    const ageBasedPriority = this.priorityForAge(ageDays);
+
+    // Fast-trigger (D7): a missing-fragment block with unreleased feature/fix
+    // work is the SILENT-SKIP case — surface at LOW immediately, bypassing the
+    // multi-day age floor, instead of letting a fresh fragment-less merge sit
+    // silent for days (the 2026-06-27 gap).
+    const featureOrFix =
+      report.analysis.commitClassification.features + report.analysis.commitClassification.fixes;
+    const fastTriggered =
+      this.cfg.fastTriggerOnGuideBlock && guideBlocks && featureOrFix > 0 && !ageBasedPriority;
+    const priority: ReadinessPriority | null = ageBasedPriority ?? (fastTriggered ? 'LOW' : null);
 
     let episode = state.episodes.find((e) => e.oldestSha === oldest.sha && !e.resolvedMs);
     if (!episode) {
@@ -278,7 +299,7 @@ export class ReleaseReadinessSentinel extends EventEmitter {
     }
 
     if (!priority) {
-      // Below the silent threshold — recorded, no message.
+      // Below the silent threshold AND not a fast-trigger case — recorded, no message.
       this.reap(state);
       return;
     }
@@ -307,8 +328,8 @@ export class ReleaseReadinessSentinel extends EventEmitter {
       episode.attentionId = id;
       episode.lastPriority = priority;
       state.lastSignalAt = this.deps.now();
-      this.deps.audit({ kind: 'release-readiness', event: 'signal', oldestSha: oldest.sha, priority, ageDays: days, delivered });
-      this.emit('signal', { oldestSha: oldest.sha, priority });
+      this.deps.audit({ kind: 'release-readiness', event: 'signal', oldestSha: oldest.sha, priority, ageDays: days, delivered, fastTriggered });
+      this.emit('signal', { oldestSha: oldest.sha, priority, fastTriggered });
     }
     this.reap(state);
   }

--- a/tests/unit/ReleaseReadinessSentinel.test.ts
+++ b/tests/unit/ReleaseReadinessSentinel.test.ts
@@ -74,10 +74,48 @@ describe('ReleaseReadinessSentinel', () => {
 
   it('stays silent when a blocked backlog is below the age threshold', async () => {
     h.oldest = { sha: 'a'.repeat(40), dateMs: h.clock - 1 * DAY }; // 1 day < silent(2)
-    const s = new ReleaseReadinessSentinel(h.deps());
+    // Disable the missing-fragment fast-trigger so this test isolates the pure
+    // age-threshold semantic (the fast-trigger is covered separately below).
+    const s = new ReleaseReadinessSentinel(h.deps(), { fastTriggerOnGuideBlock: false });
     await s.tick();
     expect(h.posted).toHaveLength(0);
     expect(h.state.episodes).toHaveLength(1); // recorded, not surfaced
+  });
+
+  describe('fast-trigger on missing-fragment block (D7)', () => {
+    it('surfaces LOW immediately for a fresh fragment-less merge, bypassing the age floor', async () => {
+      // 0.1 days old (well below silent(2)), guide blocks publish (missing
+      // fragment), 1 feature commit → the silent-skip case → fast-trigger fires.
+      h.oldest = { sha: 'a'.repeat(40), dateMs: h.clock - Math.round(0.1 * DAY) };
+      h.guideBlocks = true;
+      h.analyzer = report(1, 0);
+      const s = new ReleaseReadinessSentinel(h.deps()); // default: fast-trigger ON
+      await s.tick();
+      expect(h.posted).toHaveLength(1);
+      expect(h.posted[0].priority).toBe('LOW');
+      const signal = h.audits.find((a) => a.event === 'signal');
+      expect(signal?.fastTriggered).toBe(true);
+    });
+
+    it('does NOT fast-trigger a coverage-gap block (only a missing fragment qualifies)', async () => {
+      // Fresh, but NOT a guide-block — blocked purely by a coverage gap. The
+      // fast-trigger is specific to the silent-skip (missing-fragment) case.
+      h.oldest = { sha: 'b'.repeat(40), dateMs: h.clock - Math.round(0.1 * DAY) };
+      h.guideBlocks = false;
+      h.analyzer = report(1, 0, 1, 0); // 1 critical coverage gap
+      const s = new ReleaseReadinessSentinel(h.deps());
+      await s.tick();
+      expect(h.posted).toHaveLength(0); // below age floor, not fast-triggered
+    });
+
+    it('respects the off-switch (fastTriggerOnGuideBlock:false → silent below age floor)', async () => {
+      h.oldest = { sha: 'c'.repeat(40), dateMs: h.clock - Math.round(0.1 * DAY) };
+      h.guideBlocks = true;
+      h.analyzer = report(1, 0);
+      const s = new ReleaseReadinessSentinel(h.deps(), { fastTriggerOnGuideBlock: false });
+      await s.tick();
+      expect(h.posted).toHaveLength(0);
+    });
   });
 
   it('raises exactly one deduped signal once the backlog ages past the threshold', async () => {

--- a/tests/unit/check-release-fragment.test.ts
+++ b/tests/unit/check-release-fragment.test.ts
@@ -1,0 +1,87 @@
+/**
+ * Unit tests — check-release-fragment.mjs (Layer 1 PR-gate decision function).
+ *
+ * The objective binary: a release-relevant PR must add/modify a release-note
+ * fragment (or be exempt). Both sides of every branch, plus the security cases
+ * (bot exemption keyed on identity not a spoofable title; internal-only fragment
+ * satisfies the presence check).
+ */
+
+import { describe, it, expect } from 'vitest';
+import { checkReleaseFragment } from '../../scripts/check-release-fragment.mjs';
+
+const F = (path: string, status = 'modified') => ({ path, status });
+
+describe('checkReleaseFragment', () => {
+  it('FAILS a release-relevant PR with no fragment', () => {
+    const res = checkReleaseFragment({ files: [F('src/foo.ts')], authorType: 'User', authorLogin: 'echo' });
+    expect(res.ok).toBe(false);
+    expect(res.reason).toBe('release-relevant-no-fragment');
+    expect(res.relevant).toContain('src/foo.ts');
+  });
+
+  it('PASSES when a fragment is added alongside the src change', () => {
+    const res = checkReleaseFragment({
+      files: [F('src/foo.ts'), F('upgrades/next/my-change.md', 'added')],
+      authorType: 'User', authorLogin: 'echo',
+    });
+    expect(res.ok).toBe(true);
+  });
+
+  it('PASSES an internal-only fragment (presence satisfies Layer 1; legitimacy is downstream)', () => {
+    // Layer 1 sees only the file list; an internal-only fragment IS a fragment file.
+    const res = checkReleaseFragment({
+      files: [F('src/foo.ts'), F('upgrades/next/internal.md', 'added')],
+      authorType: 'User', authorLogin: 'echo',
+    });
+    expect(res.ok).toBe(true);
+  });
+
+  it('PASSES (exempt) a docs/test-only PR', () => {
+    const res = checkReleaseFragment({
+      files: [F('docs/x.md'), F('src/foo.test.ts')],
+      authorType: 'User', authorLogin: 'echo',
+    });
+    expect(res.ok).toBe(true);
+    expect(res.exempt).toBe('no-release-relevant-paths');
+  });
+
+  it('exempts ONLY the authenticated release-cut bot identity', () => {
+    const res = checkReleaseFragment({
+      files: [F('src/foo.ts')],
+      authorType: 'Bot', authorLogin: 'github-actions[bot]',
+    });
+    expect(res.ok).toBe(true);
+    expect(res.exempt).toBe('release-cut-bot');
+  });
+
+  it('does NOT exempt a non-release bot', () => {
+    const res = checkReleaseFragment({
+      files: [F('src/foo.ts')],
+      authorType: 'Bot', authorLogin: 'dependabot[bot]',
+    });
+    expect(res.ok).toBe(false);
+  });
+
+  it('EVASION: a human PR titled "chore: release" is still gated (title is not the key)', () => {
+    const res = checkReleaseFragment({
+      files: [F('src/foo.ts')],
+      authorType: 'User', authorLogin: 'attacker', title: 'chore: release v9.9.9',
+    });
+    expect(res.ok).toBe(false);
+  });
+
+  it('accepts a bare path-list shape too', () => {
+    const res = checkReleaseFragment({ files: ['src/foo.ts'], authorType: 'User', authorLogin: 'echo' });
+    expect(res.ok).toBe(false);
+  });
+
+  it('a fragment alone (no src) passes', () => {
+    const res = checkReleaseFragment({
+      files: [F('upgrades/next/notes.md', 'added')],
+      authorType: 'User', authorLogin: 'echo',
+    });
+    // No release-relevant path → exempt before the fragment check even matters.
+    expect(res.ok).toBe(true);
+  });
+});

--- a/tests/unit/pre-push-gate.test.ts
+++ b/tests/unit/pre-push-gate.test.ts
@@ -136,7 +136,7 @@ describe('Pre-push gate integration — malformed NEXT.md', () => {
     // script would still see the production __dirname and walk the production
     // tree — making the integration test sensitive to unrelated changes in
     // the rest of the repo. Copying isolates the test to its scratch dir.
-    for (const file of ['pre-push-gate.js', 'upgrade-guide-validator.mjs', 'assemble-next-md.mjs', 'lint-no-direct-destructive.js', 'lint-no-direct-llm-http.js']) {
+    for (const file of ['pre-push-gate.js', 'upgrade-guide-validator.mjs', 'assemble-next-md.mjs', 'release-relevant-paths.mjs', 'lint-no-direct-destructive.js', 'lint-no-direct-llm-http.js']) {
       fs.copyFileSync(
         path.join(ROOT, 'scripts', file),
         path.join(scratch, 'scripts', file),
@@ -314,7 +314,7 @@ describe('Pre-push gate integration — release-note fragments', () => {
       path.join(scratch, 'package.json'),
       JSON.stringify({ name: 'instar-test', version: '0.28.999' }),
     );
-    for (const file of ['pre-push-gate.js', 'upgrade-guide-validator.mjs', 'assemble-next-md.mjs', 'lint-no-direct-destructive.js', 'lint-no-direct-llm-http.js']) {
+    for (const file of ['pre-push-gate.js', 'upgrade-guide-validator.mjs', 'assemble-next-md.mjs', 'release-relevant-paths.mjs', 'lint-no-direct-destructive.js', 'lint-no-direct-llm-http.js']) {
       fs.copyFileSync(path.join(ROOT, 'scripts', file), path.join(scratch, 'scripts', file));
     }
   });

--- a/tests/unit/release-relevant-paths.test.ts
+++ b/tests/unit/release-relevant-paths.test.ts
@@ -1,0 +1,151 @@
+/**
+ * Unit tests — release-relevant-paths.mjs (the shared "needs a release note?"
+ * predicate consumed by the Layer-1 PR gate and the local pre-push gate).
+ *
+ * This predicate is the single point that decides whether the release-fragment
+ * gate applies at all. A false EXEMPT re-opens the 2026-06-27 silent-skip; a
+ * false RELEVANT blocks a legit PR. So both sides AND adversarial evasion cases
+ * are covered, plus the anti-drift ownership guard.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  isReleaseRelevant,
+  classifyPaths,
+  canonicalizePath,
+  shippedTopLevelRoots,
+} from '../../scripts/release-relevant-paths.mjs';
+
+describe('isReleaseRelevant — positive (release-relevant) roots', () => {
+  for (const p of [
+    'src/foo.ts',
+    'src/monitoring/ReleaseReadinessSentinel.ts',
+    'scripts/check-release-fragment.mjs',
+    '.husky/pre-push',
+    'package.json',
+    'package-lock.json',
+    '.github/workflows/publish.yml',
+    'skills/build/SKILL.md',
+    'skills/foo/run.mjs',
+    'skills/foo/helper.sh',
+    'skills/foo/helper.cjs', // broadened: .cjs is not silently exempt
+    'skills/foo/run.py',
+    'skills/foo/templates/thing.md',
+    // SHIPPED .claude paths (package.json `files`) — behavior that reaches the fleet.
+    '.claude/hooks/before-prompt-recall.js',
+    '.claude/hooks/instar/some-hook.sh',
+    '.claude/skills/build/SKILL.md',
+    '.claude/skills/autonomous/run.mjs',
+  ]) {
+    it(`relevant: ${p}`, () => expect(isReleaseRelevant(p)).toBe(true));
+  }
+});
+
+describe('isReleaseRelevant — exempt (no release note needed)', () => {
+  for (const p of [
+    'src/foo.test.ts',
+    'tests/unit/whatever.test.ts',
+    'tests/fixtures/x.json',
+    'docs/specs/SOME-SPEC.md',
+    'docs/foo.md',
+    'README.md',
+    'upgrades/next/foo.md', // the fragment itself is not "release-relevant work"
+    'upgrades/NEXT.md',
+    '.instar/config.json',
+    '.github/ISSUE_TEMPLATE/bug.md',
+    'skills/foo/notes.md', // a stray skill doc, not SKILL.md / templates
+    '.claude/skills/notes.md', // a non-SKILL.md doc under a skill
+    '.claude/skills/some-local-skill/SKILL.md', // NOT one of the shipped skills → agent-local, exempt
+    '.claude/settings.json', // agent-local config, not shipped behavior gated here
+    'assets/logo.png',
+    'examples/demo.ts',
+    'site/index.html',
+  ]) {
+    it(`exempt: ${p}`, () => expect(isReleaseRelevant(p)).toBe(false));
+  }
+});
+
+describe('isReleaseRelevant — adversarial evasion (must NOT silently exempt)', () => {
+  it('case-folded src is still relevant', () => {
+    expect(isReleaseRelevant('Src/Foo.TS')).toBe(true);
+    expect(isReleaseRelevant('SRC/bar.ts')).toBe(true);
+  });
+  it('leading ./ is normalized', () => {
+    expect(isReleaseRelevant('./src/foo.ts')).toBe(true);
+  });
+  it('trailing slash does not evade', () => {
+    expect(isReleaseRelevant('src/foo.ts/')).toBe(true);
+  });
+  it('a `..` traversal path biases toward relevant (safe direction)', () => {
+    expect(isReleaseRelevant('src/../src/evil.ts')).toBe(true);
+    expect(isReleaseRelevant('../escape.ts')).toBe(true);
+  });
+  it('a runtime file shaped like a test path is NOT exempted just for "test" in the name', () => {
+    // Only a real *.test.* suffix is exempt; "src/testing/harness.ts" ships behavior.
+    expect(isReleaseRelevant('src/testing/harness.ts')).toBe(true);
+  });
+  it('empty / junk input is exempt, not a throw', () => {
+    expect(isReleaseRelevant('')).toBe(false);
+    expect(isReleaseRelevant('   ')).toBe(false);
+    // @ts-expect-error intentional bad input
+    expect(isReleaseRelevant(null)).toBe(false);
+  });
+});
+
+describe('canonicalizePath', () => {
+  it('flags traversal', () => {
+    expect(canonicalizePath('src/../x.ts')).toEqual({ escaped: true, path: 'src/../x.ts' });
+  });
+  it('normalizes separators + leading ./', () => {
+    expect(canonicalizePath('./a//b')).toEqual({ escaped: false, path: 'a/b' });
+  });
+  it('returns null for empty', () => {
+    expect(canonicalizePath('')).toBeNull();
+    expect(canonicalizePath('   ')).toBeNull();
+  });
+});
+
+describe('classifyPaths', () => {
+  it('splits a mixed list', () => {
+    const { relevant, exempt } = classifyPaths([
+      'src/a.ts',
+      'docs/b.md',
+      'scripts/c.mjs',
+      'src/a.test.ts',
+    ]);
+    expect(relevant.sort()).toEqual(['scripts/c.mjs', 'src/a.ts']);
+    expect(exempt.sort()).toEqual(['docs/b.md', 'src/a.test.ts']);
+  });
+});
+
+describe('anti-drift ownership guard (D6)', () => {
+  // The CURRENT shipped top-level roots from package.json `files`. Each must be
+  // explicitly classifiable by the predicate. If a NEW shipped root appears that
+  // the predicate doesn't classify as relevant-or-exempt deterministically, this
+  // test fails — forcing the author to classify it rather than let it silently
+  // fall through as a false-negative.
+  it('every shipped top-level root is explicitly classified', () => {
+    // Mirror of package.json `files` top-levels at authoring time.
+    const filesWhitelist = [
+      'dist', 'dashboard', 'upgrades', 'src/templates', 'src/data',
+      'src/threadline/data', 'skills', 'playbook-scripts', 'scripts',
+      '.claude/skills/setup-wizard', '.claude/skills/secret-setup',
+      '.claude/skills/autonomous', '.claude/skills/build', '.claude/hooks', 'src/scaffold',
+    ];
+    const roots = shippedTopLevelRoots(filesWhitelist);
+    // Known classification of each shipped root (relevant unless documented exempt).
+    const KNOWN: Record<string, 'relevant' | 'exempt'> = {
+      dist: 'exempt',       // build output, never hand-edited
+      dashboard: 'exempt',  // static assets; behavior changes ride src/
+      upgrades: 'exempt',   // the release-notes machinery itself
+      src: 'relevant',
+      skills: 'relevant',
+      'playbook-scripts': 'exempt', // data scripts, no runtime gate surface
+      scripts: 'relevant',
+      '.claude': 'relevant', // .claude/hooks/** + shipped .claude/skills/<name>/ are release-relevant
+    };
+    for (const root of roots) {
+      expect(KNOWN[root], `shipped root "${root}" is unclassified — classify it in release-relevant-paths + here`).toBeDefined();
+    }
+  });
+});

--- a/tests/unit/release-skip-annotate.test.ts
+++ b/tests/unit/release-skip-annotate.test.ts
@@ -1,0 +1,28 @@
+/**
+ * Unit tests — release-skip-annotate.mjs (Layer 2 publish-side classifier).
+ *
+ * The pure classifyRange: given the changed files in the unreleased window,
+ * return the release-relevant subset that would ship NOTHING on a silent skip.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { classifyRange } from '../../scripts/release-skip-annotate.mjs';
+
+describe('classifyRange', () => {
+  it('finds release-relevant files in the window', () => {
+    const { relevant } = classifyRange({
+      files: ['src/a.ts', 'docs/b.md', 'scripts/c.mjs', 'src/a.test.ts'],
+    });
+    expect(relevant.sort()).toEqual(['scripts/c.mjs', 'src/a.ts']);
+  });
+
+  it('returns empty when the window is docs/test-only (a clean skip)', () => {
+    const { relevant } = classifyRange({ files: ['docs/a.md', 'tests/b.test.ts', 'README.md'] });
+    expect(relevant).toHaveLength(0);
+  });
+
+  it('handles an empty window', () => {
+    expect(classifyRange({ files: [] }).relevant).toHaveLength(0);
+    expect(classifyRange({ files: undefined as unknown as string[] }).relevant).toHaveLength(0);
+  });
+});

--- a/upgrades/next/release-fragment-gate.md
+++ b/upgrades/next/release-fragment-gate.md
@@ -1,0 +1,58 @@
+<!-- bump: patch -->
+
+## What Changed
+
+Added the **release-fragment-gate** so a release-affecting PR can no longer merge and
+then SILENTLY skip the release (the 2026-06-27 incident: PRs #1295-#1297 merged with
+no `upgrades/next/` fragment, the publish ran green and cut no version, fixes stranded
+~7h).
+
+The fragment requirement already existed as a HARD local pre-push gate
+(`pre-push-gate.js §3b`) — but husky runs only on a local `git push`, so the
+server-side squash/bot/auto-merge path bypassed it. This change moves the same
+requirement to the merge boundary, server-side, where it can't be routed around:
+
+- **Layer 1 — `release-fragment-gate` CI check** (`.github/workflows/release-fragment-gate.yml`
+  + `scripts/check-release-fragment.mjs`): on every PR to `main`, a release-relevant
+  change with no fragment is flagged. Ships **warn-only** (reports the verdict, never
+  blocks) until the spec's D3 criterion is met and it's registered as a required check.
+  Security-hardened: `on: pull_request` (never `pull_request_target`), read-only token,
+  the gate code loads from the BASE ref (never PR-head), and the bot exemption keys on
+  authenticated identity, not a spoofable title. Fail-closed.
+- **Shared predicate** (`scripts/release-relevant-paths.mjs`): one "is this
+  release-relevant?" answer, consumed by both the PR gate and the local pre-push gate
+  (`§3b` is broadened from `src/**.ts` to also catch `scripts/`, `.github/workflows/`,
+  `package.json`, skill code, and shipped `.claude/hooks` + `.claude/skills`).
+- **Layer 2 — loud-skip backstop**: the publish pipeline now emits a loud warning +
+  step summary when it would skip with unreleased release-relevant work
+  (`scripts/release-skip-annotate.mjs`, signal-only, never fails the run), and the
+  `ReleaseReadinessSentinel` gains a **fast-trigger** so a missing-fragment merge
+  surfaces immediately instead of waiting out the multi-day age floor.
+
+## What to Tell Your User
+
+If a release ever stops cutting versions, the cause is almost always a merged change
+with no "what changed" note — and now you'll be told loudly instead of finding a
+green-but-empty release run hours later. Maintainer agents get an immediate heads-up
+when finished work is sitting unreleased for that reason. Nothing changes for everyday
+users; this is release-pipeline safety for the people who ship instar.
+
+## Summary of New Capabilities
+
+- A server-side PR check that catches a release-affecting change shipped without a
+  release note, before it merges (starts in warn-only mode).
+- One shared rule for "does this change need a release note?", used by both the
+  server check and the local pre-push check.
+- A loud alarm (instead of a silent green run) when the publish pipeline skips a
+  release that still has unreleased work, plus an immediate maintainer heads-up.
+
+## Evidence
+
+57 new unit tests (the shared predicate incl. adversarial path-evasion + an anti-drift
+ownership guard, the Layer-1 decision table incl. the bot-spoof evasion case, and the
+Layer-2 classifier) + the extended ReleaseReadinessSentinel suite (fast-trigger fires
+for the missing-fragment case, does NOT fire for a coverage-gap block, honors its
+off-switch). tsc clean. Driven by the converged + approved
+RELEASE-FRAGMENT-GATE-SPEC (3-round spec-converge, 6 internal + codex/gemini external
+reviewers) and an independent second-pass review that caught + fixed a `.claude`
+shipped-path exemption hole before commit.

--- a/upgrades/side-effects/release-fragment-gate.md
+++ b/upgrades/side-effects/release-fragment-gate.md
@@ -1,0 +1,136 @@
+# Side-Effects Review — release-fragment-gate
+
+Spec: `docs/specs/RELEASE-FRAGMENT-GATE-SPEC.md` (converged + approved).
+Change: a server-side PR-time CI gate + a shared release-relevant predicate + a
+publish-side loud-skip annotation + a ReleaseReadinessSentinel fast-trigger, so a
+release-affecting PR can no longer merge and then silently skip the release.
+
+## 1. Over-block — what legitimate inputs does this reject that it shouldn't?
+
+- **Layer 1 (PR gate):** a release-relevant PR with no fragment is FAILED. False
+  positives = a `src/`/`scripts/` change with genuinely no user impact (refactor,
+  logging). Mitigation: the one-line `internal-only` fragment opt-out (diff-verified,
+  auditable) clears it. AND the gate **ships warn-only** — it cannot block anything
+  until the D3 criterion is met and it is manually registered as required. So
+  over-block has zero blast radius at ship time.
+- **Predicate:** biases toward "relevant" on a `..` path (safe direction) — a
+  theoretical over-block, but such paths don't occur in normal PRs.
+
+## 2. Under-block — what failure modes does this still miss?
+
+- Layer 1 checks fragment **presence, not content** (it has only the file list; reading
+  content would require executing PR-head code — the security vector we explicitly
+  avoid). A junk/empty fragment passes Layer 1 — but does NOT re-open the silent skip:
+  `assemble-next-md` THROWS on a content-less fragment (a loud RED publish), and
+  `pre-push-gate §3c` diff-verifies the internal-only legitimacy. Worst case = a loud
+  downstream failure, never a silent green.
+- A direct push to `main` that bypasses PRs entirely (admin/ruleset escape) skips
+  Layer 1 — caught by Layer 2 (the Sentinel poller reads `main` independent of CI).
+- `[skip ci]` on a release-relevant push disables the publish job (incl. the Layer-2
+  annotation) — again caught by the agent-side Sentinel poller, not CI.
+
+## 3. Level-of-abstraction fit
+
+Correct layer. The fragment requirement already existed at the **local** (husky)
+layer; this moves the SAME requirement to the **server/merge-boundary** layer where
+it can't be bypassed, and the durable backstop sits in the **agent-side Sentinel**
+that already owns "unreleased work is piling up." No new parallel watcher — the
+Sentinel is extended (fast-trigger), and the existing eli16-pr-gate establishes the
+blocking-presence-check precedent the Layer-1 gate mirrors.
+
+## 4. Signal vs authority compliance (docs/signal-vs-authority.md)
+
+Declared explicitly in the spec's `## Signal vs. Authority` section.
+- **Layer 1 = AUTHORITY** but its veto is an OBJECTIVE BINARY ("a fragment file is
+  present, yes/no") — the same shape as eli16-pr-gate, NOT a brittle judgment wearing
+  blocking authority. The fallible `release-relevant` path predicate is a SIGNAL whose
+  false-positives are always escapable via the one-line opt-out — the escape hatch, not
+  the predicate's correctness, carries the authority.
+- **Layer 2 = SIGNAL** — the publish annotation never fails the run; the Sentinel
+  surfaces an Attention item, never blocks. Compliant.
+
+## 5. Interactions — shadowing / double-fire / races
+
+- `pre-push-gate §3b` now consumes the shared predicate (BROADENED from `src/**.ts`).
+  It is the LOCAL gate; Layer 1 is the SERVER gate. They check the same thing at two
+  layers (defense in depth) — intentional, not a double-fire (different surfaces; a
+  local push that passes still gets the server check on the PR).
+- `inScope()` (instar-dev review-scope) is deliberately NOT merged into the shared
+  predicate — it answers a DIFFERENT question ("needs instar-dev review?") and is
+  narrower. Merging would silently change which changes require review. Documented.
+- The Sentinel fast-trigger only adds a NEW path (fires LOW when it previously stayed
+  silent for the missing-fragment case); it does not change the age-based escalation,
+  dedup, hysteresis, or resolve logic. The existing "stays silent below threshold"
+  test was updated to isolate the age semantic (fast-trigger off) — no behavior was
+  weakened, a gap was closed.
+
+## 6. External surfaces
+
+- A NEW required-eligible CI check appears on instar-repo PRs (warn-only at first).
+- The publish run gains a `::warning::` + step-summary on a fragment-less skip.
+- The Sentinel may post an Attention item sooner (LOW, immediately) for the
+  missing-fragment case. Same surface (Attention queue), earlier timing.
+- No change visible to end-user agents (this is instar-repo dev infrastructure;
+  `.github/` does not ship to the fleet; `scripts/` ships but is CI/gate-only).
+
+## 7. Multi-machine posture (Cross-Machine Coherence)
+
+- **Layer 1 + Layer 2 publish annotation:** run in GitHub Actions — machine-agnostic,
+  no agent state, no multi-machine concern.
+- **Layer 2 Sentinel fast-trigger:** MACHINE-LOCAL BY DESIGN. The `release-readiness-check`
+  job is single-owner (one dev agent runs it); dedup state lives in
+  `.instar/state/release-readiness.json`. No fenced lease needed — the dedup is advisory
+  and the boundary truth lives in `main` (not agent-local), so the worst case if two
+  agents ran it is a duplicate Attention raise (re-derived from `main`), never a lost
+  signal. On topic/machine transfer the new host re-derives from `main`. Documented in
+  the spec's Cross-machine posture section.
+
+## 8. Rollback cost
+
+- **Layer 1 workflow:** delete/disable `.github/workflows/release-fragment-gate.yml`
+  (or it stays warn-only = non-blocking by default — zero rollback urgency).
+- **Layer 2 publish step:** the new step is `if: skip==true` and exits 0 always;
+  removing it is a one-line revert. It cannot break a real publish (it only runs on the
+  skip branch and never fails).
+- **Sentinel fast-trigger:** config off-switch `fastTriggerOnGuideBlock: false` (no
+  restart-blocking); or revert the src change. The feature ships behind the existing
+  `release-readiness-check` job which is `enabled: false` by default, so on the fleet
+  it is inert until explicitly enabled.
+- **Shared predicate / pre-push §3b broadening:** the broadening only makes the LOCAL
+  gate catch more (scripts/workflows); if it ever false-positives, `INSTAR_PRE_PUSH_SKIP=1`
+  is the existing escape and the predicate is a one-file revert.
+
+No data migration, no agent-state repair, no hot-fix-release dependency. Every layer
+fails safe (warn-only / signal-only / config-gated-off).
+
+## Second-pass review (Phase 5 — required: touches a gate + a sentinel)
+
+An independent reviewer audited the implementation against this artifact.
+
+**Concern raised (MEDIUM, RESOLVED):** the shared predicate exempted
+`.claude/hooks/**` and the four shipped `.claude/skills/<name>/` dirs — but those
+ARE shipped to the fleet via `package.json` `files`, so a `.claude`-only behavior
+change would have been wrongly exempt → re-opening the silent-skip for that path
+class. **Fix applied:** the predicate now classifies `.claude/hooks/**` and the
+shipped built-in `.claude/skills/{setup-wizard,secret-setup,autonomous,build}/`
+paths as release-relevant (non-shipped `.claude/**` stays agent-local/exempt); the
+anti-drift test's `KNOWN['.claude']` was corrected to `relevant` and path tests
+added.
+
+**Concern raised (LOW, RESOLVED):** the skills-code extension allowlist
+(`.sh/.mjs/.js/.ts`) silently exempted `.cjs`/`.py`/`.json`. **Fix applied:** the
+skill-path classifier now FAILS TOWARD RELEVANT — any non-doc file under a skill is
+relevant; only a bare non-SKILL.md `*.md` outside `templates/` is exempt. Tests
+added for `.cjs`/`.py`.
+
+**Concern noted (LOW/INFO, ACCEPTED):** the bot exemption fires for any
+`github-actions[bot]`-authored PR, not strictly the release-cut PR. Keyed on
+authenticated identity (not a spoofable title — evasion test confirms), and Layer 2
++ the Sentinel backstop it. Acceptable; narrow only if a non-release bot ever opens
+release-relevant PRs.
+
+**Reviewer verdict on everything else: Concur — no material concerns.** Layer-1
+security (base-ref load, read-only perms, no PR-head exec, env-passing), fail-closed
+behavior, signal-only Layer-2 annotation (NUL-delimited argv, always exit 0),
+publish-step gating, and the strictly-additive Sentinel fast-trigger were all
+independently confirmed correct.


### PR DESCRIPTION
## ELI16 — a release can never silently skip merged work again

Every time instar ships a version, the release robot needs a short "what changed" note. If it's missing, the robot safely refuses to ship — but it did so **silently**: the release job went green and looked fine, yet no version came out. On June 27, three real fixes merged with no note and sat unshipped ~7 hours before anyone noticed (and an earlier session even misread the green run as someone else's pipeline glitch).

The twist the review uncovered: a guard demanding the note **already existed** — but it only ran on a developer's laptop at push time. The way merges actually land (the bot squash-merges the approved PR on the server) skips that laptop guard entirely. So the rule was enforced in the one place merges don't happen.

This moves the same rule to the server, where it can't be routed around, and makes any leftover silent skip loud:

- **Layer 1 — a PR check** (`release-fragment-gate`) that flags a release-affecting PR with no note. Ships **warn-only** first (reports, never blocks), flips to a hard block on a measured criterion. Security-hardened: `pull_request` (never `pull_request_target`), read-only token, loads its code from the base ref (never PR-head), bot exemption keyed on authenticated identity not a spoofable title, fail-closed.
- **A shared "is this release-relevant?" rule** used by both the server check and the local gate — one answer, not three drifting copies (now also catches scripts/workflows/`.claude` the old local check missed).
- **Layer 2 — a loud alarm**: the publish pipeline warns (instead of silent green) when it skips with unreleased work, and my release-watcher fast-triggers so a missing-note merge surfaces immediately instead of after 2 days.

## What's NOT changed

The publish still refuses to ship a version with no note — that's correct and stays. We only made the refusal **un-bypassable and loud** instead of locally-checked and silent.

## Evidence

Spec converged via 3-round spec-converge (6 internal + codex/gemini external reviewers); independent second-pass review caught + fixed a `.claude` shipped-path exemption hole before commit. 81 unit tests (predicate incl. adversarial evasion + anti-drift guard, Layer-1 decision table incl. bot-spoof, Layer-2 classifier, sentinel fast-trigger), tsc clean.

Spec: `docs/specs/RELEASE-FRAGMENT-GATE-SPEC.md` · Convergence report: `docs/specs/reports/release-fragment-gate-convergence.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
