### PR TITLE
fix(messaging): tone gate B5 stops blocking user-facing share links

### DIFF
--- a/.instar/instar-dev-decisions/2026-06-27T20-23-52-970Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-06-27T20-23-52-970Z-unknown.json
@@ -1,0 +1,13 @@
+{
+  "ts": "2026-06-27T20:23:52.970Z",
+  "slug": "unknown",
+  "suggestedTier": 1,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 10,
+  "causalAutopsy": null,
+  "verdict": "pass"
+}

--- a/src/core/MessagingToneGate.ts
+++ b/src/core/MessagingToneGate.ts
@@ -804,7 +804,13 @@ Your decision must be traceable to EXACTLY ONE of the explicit rules below. You 
 - **B2_FILE_PATH** — the \`file-path\` signal is detected AND a concrete path is shown for the user to open/edit. Conceptual references ("the config file") are fine even if a path-shaped token appears. (The legacy \`raw-file-path\` upstream signal, if present, corroborates this one.)
 - **B3_CONFIG_KEY** — the \`config-key\` signal is detected AND the dotted key is presented as something the user must set/edit. Describing the BEHAVIOR a setting controls, without handing the user the key to change, is fine.
 - **B4_COPY_PASTE_CODE** — the \`copy-paste-code\` signal is detected AND the snippet is clearly offered for the user to copy-paste. A short inline code reference inside an explanation is not automatically a block — judge whether the user is being asked to use it.
-- **B5_API_ENDPOINT** — the \`api-endpoint\` signal is detected AND the URL/route is handed to the user to call/open. "The server" / "the endpoint" as nouns, or an internal route mentioned while explaining mechanics, are fine.
+- **B5_API_ENDPOINT** — the \`api-endpoint\` signal is detected AND the URL/route is handed to the user as an API for the USER to CALL themselves — a request they are expected to issue (curl / POST / GET / "hit this endpoint"), or a bare host:port route presented as something to invoke. JUDGE BY INTENT (call-vs-open), NEVER BY SHAPE. The \`api-endpoint\` detector fires on EVERY URL — it cannot tell a call-target from a click-target — so the detected signal ALONE is never a block; you decide from how the URL is being used. DO NOT block a URL the user is meant to OPEN / CLICK / VISIT in a browser: a private-view link (e.g. \`/view/<id>\`, often carrying a \`?token=\`), a Cloudflare tunnel URL (\`*.trycloudflare.com/...\`), a published or Telegraph page, a dashboard link, a download/file link, or any http(s) link shared as a destination to look at. Those are CONTENT the user opens, not an API they call — they PASS even though the signal fired and even though they contain a host, a port, and a path. "The server" / "the endpoint" as nouns, or an internal route mentioned while explaining mechanics, are also fine.
+  WORKED EXAMPLES (the discriminator is call-vs-open, never the presence of host:port/path):
+  - BLOCK: "To check, run: curl http://localhost:4042/commitments" — an API call handed to the user to issue.
+  - BLOCK: "Hit POST /attention to queue it yourself." — a route the user is told to invoke.
+  - PASS: "Here's the rendered doc: https://abc123.trycloudflare.com/view/k3p9?token=…" — a link the user clicks to open.
+  - PASS: "Your dashboard is at http://localhost:4040/dashboard — PIN 123456" — a destination to visit.
+  - PASS: "Published it here: https://telegra.ph/My-Report-06-27" — a page to read.
 - **B6_ENV_VAR** — the \`env-var\` signal is detected AND the variable is presented for the user to set/export. Naming a variable while explaining behavior is fine.
 - **B7_CRON_OR_SLUG** — the \`cron-or-slug\` signal is detected AND a cron expression or an internal slug/tracker id is surfaced to the user as something to use or that they can act on. An internal id leaked into user-facing prose is exactly the kind of thing to block; a slug discussed between agent and user about the work itself may be fine — judge by whether it is actionable/meaningful to the user.
 
@@ -950,7 +956,7 @@ These rules only fire when the producer has explicitly marked the candidate as a
 - Naming an internal subsystem by its role when discussing what it did.
 - Quoting short strings from earlier messages for reference (e.g., discussing why a "test" message leaked).
 - Slash commands that work in chat (/reflect, /help, /build).
-- URLs the user can click to visit.
+- URLs the user OPENS / CLICKS / VISITS in a browser — a private-view link (including one carrying a \`?token=\`), a Cloudflare tunnel URL, a published or Telegraph page, a dashboard link, a download/file link, any http(s) destination shared for the user to look at. These are content destinations, not API calls — NEVER block them under B5 (B5 is only for an endpoint the user is told to CALL themselves).
 
 ## Response format
 

--- a/tests/unit/GateSignalDetectors.test.ts
+++ b/tests/unit/GateSignalDetectors.test.ts
@@ -56,6 +56,16 @@ describe('GateSignalDetectors — B1–B7 detection (signals, not blocks)', () =
     expect(kinds('POST to /telegram/post-update')).toContain('api-endpoint');
   });
 
+  it('B5 api-endpoint: fires on click/open destinations too (intentionally broad — the authority judges call-vs-open)', () => {
+    // The detector is a brittle SIGNAL, not a verdict: it cannot tell a curl
+    // target from a link-to-open, so it deliberately flags BOTH. The B5 prompt
+    // (MessagingToneGate) is the authority that passes a click-destination and
+    // blocks only a call-target. Documenting that breadth here keeps the
+    // signal-vs-authority split explicit.
+    expect(kinds('Rendered doc: https://abc123.trycloudflare.com/view/k3p9?token=secrettoken')).toContain('api-endpoint');
+    expect(kinds('Open http://localhost:4040/view/abc123')).toContain('api-endpoint');
+  });
+
   it('B6 env-var: detects assignments, $REFs, and process.env', () => {
     expect(kinds('AUTH_TOKEN=abc123')).toContain('env-var');
     expect(kinds('export $INSTAR_AUTH_TOKEN')).toContain('env-var');

--- a/tests/unit/MessagingToneGate.test.ts
+++ b/tests/unit/MessagingToneGate.test.ts
@@ -566,4 +566,84 @@ describe('MessagingToneGate', () => {
       expect(result.failedClosed).toBe(true);
     });
   });
+
+  // B5 link carve-out: the prompt must teach the model that an `api-endpoint`
+  // signal fires on EVERY URL, and that a click/open destination (private-view
+  // link, tunnel URL, published/Telegraph page, dashboard, signed-token link)
+  // PASSES while only a call-target (curl/POST an endpoint) blocks. The LLM is
+  // mocked in unit tests, so the deterministic guarantee we lock here is that
+  // the prompt carries the both-sides carve-out + worked examples — the regression
+  // that broke real agents was the prompt blocking click-targets under B5.
+  describe('B5 link carve-out (prompt teaches call-vs-open)', () => {
+    async function capturePrompt(): Promise<string> {
+      let captured = '';
+      const provider = mockProvider((p) => {
+        captured = p;
+        return JSON.stringify({ pass: true, issue: '', suggestion: '' });
+      });
+      const gate = new MessagingToneGate(provider);
+      await gate.review('Here is the link.', { channel: 'telegram' });
+      return captured;
+    }
+
+    it('B5 instructs judging by call-vs-open intent, not URL shape', async () => {
+      const prompt = await capturePrompt();
+      expect(prompt).toContain('B5_API_ENDPOINT');
+      // The discriminator must be intent, explicitly NOT the host:port/path shape.
+      expect(prompt).toMatch(/call-vs-open/i);
+      expect(prompt).toMatch(/NEVER BY SHAPE|never by the presence of host:port/i);
+    });
+
+    it('B5 explicitly exempts click/open destinations (the false-positive class)', async () => {
+      const prompt = await capturePrompt();
+      // The exact link kinds that broke real agents must be named as OPEN/PASS.
+      expect(prompt).toMatch(/private-view link/i);
+      expect(prompt).toMatch(/trycloudflare/i);
+      expect(prompt).toMatch(/telegraph/i);
+      expect(prompt).toMatch(/dashboard/i);
+      expect(prompt).toMatch(/\?token=/);
+    });
+
+    it('B5 still names a genuine call-target as a BLOCK (under-block guard)', async () => {
+      const prompt = await capturePrompt();
+      // Worked examples must cover BOTH sides of the boundary.
+      expect(prompt).toMatch(/BLOCK:.*curl http/i);
+      expect(prompt).toMatch(/PASS:.*\/view\//i);
+    });
+
+    it('the ALWAYS ALLOWED section names browser-open URLs specifically', async () => {
+      const prompt = await capturePrompt();
+      expect(prompt).toContain('ALWAYS ALLOWED');
+      expect(prompt).toMatch(/OPENS \/ CLICKS \/ VISITS/i);
+      expect(prompt).toMatch(/content destinations, not API calls/i);
+    });
+
+    it('honors the model verdict on both sides (plumbing): view link passes, call-target blocks', async () => {
+      // A click-destination — model passes it.
+      const passing = mockProvider(() =>
+        JSON.stringify({ pass: true, rule: '', issue: '', suggestion: '' }),
+      );
+      const passResult = await new MessagingToneGate(passing).review(
+        'Rendered doc: https://abc123.trycloudflare.com/view/k3p9?token=secrettoken',
+        { channel: 'telegram' },
+      );
+      expect(passResult.pass).toBe(true);
+
+      // A genuine API call handed to the user — model blocks it as B5.
+      const blocking = mockProvider(() =>
+        JSON.stringify({
+          pass: false,
+          rule: 'B5_API_ENDPOINT',
+          issue: 'curl endpoint handed to the user to call',
+          suggestion: 'Call it yourself and report the result.',
+        }),
+      );
+      const blockResult = await new MessagingToneGate(blocking).review(
+        'To check, run: curl http://localhost:4042/commitments',
+        { channel: 'telegram' },
+      );
+      expect(blockResult.pass).toBe(false);
+      expect(blockResult.rule).toBe('B5_API_ENDPOINT');
+    });
+  });
 });

--- a/upgrades/eli16/tone-gate-b5-link-carveout.md
+++ b/upgrades/eli16/tone-gate-b5-link-carveout.md
@@ -1,0 +1,34 @@
+# Tone Gate B5 — Stop Blocking the Links Agents Share — Plain-English Overview
+
+> The one-line version: the outbound safety gate was blocking the very links an agent uses to share a doc with you (private-view links, tunnel URLs, published pages) because they *look* like an API endpoint — so we taught it to judge a link by whether you CLICK it or CALL it, not by its shape.
+
+## The problem in one breath
+
+Every message an agent sends you passes through a small safety gate that blocks technical leakage — things like a raw API endpoint you'd be told to `curl`. One of its rules ("B5") was firing on *any* URL that has a host, a port, and a path. A signed view link like `…/view/abc?token=…` has exactly that shape, so the gate was blocking the agent's normal "here's your rendered doc" link as if it were an exposed endpoint. Multiple agents hit this. It's the gate failing its own standard: a gate with this much power should be smart enough to tell a useful link from a security problem.
+
+## What already exists
+
+- **The outbound tone gate** — a Haiku-backed reviewer that reads each outbound message and either passes it or blocks it, citing exactly one rule. It already has an "ALWAYS ALLOWED" list that *included* "URLs the user can click to visit" — but only as a vague one-liner.
+- **A set of brittle detectors** — cheap pattern-matchers that flag "this message contains something that looks like a CLI command / file path / API endpoint." They are deliberately dumb. The `api-endpoint` detector flags *every* URL, because it can't tell a click-target from a call-target. That's fine — it's only a *signal*.
+- **The signal-vs-authority split** — the detectors raise signals; the LLM is the *authority* that makes the final call using context. The bug was in the authority's instructions, not the detector.
+
+## What this adds
+
+The fix is entirely in the gate's instructions (its prompt) plus tests — no new code path, no new blocking power. We rewrote the B5 rule so it fires only when a URL is handed to you as an API to **call yourself** (curl/POST/"hit this endpoint"), and we told it explicitly to **never** block a URL you're meant to **open/click/visit** — a private-view link (even one carrying a `?token=`), a Cloudflare tunnel URL, a published or Telegraph page, a dashboard link, a download link. We added worked examples on *both* sides so the model judges by intent, not by the host:port/path shape. The weak "URLs you can click" line in the ALWAYS-ALLOWED list was promoted to name those exact link kinds.
+
+## The new pieces
+
+- **Rewritten B5 rule** — now says, in plain terms: a detected URL alone is never a block; decide from how it's being used. Call-target → block. Open/click destination → pass, even though it has a host, port, and path.
+- **Strengthened ALWAYS-ALLOWED line** — names private-view links, tunnel URLs, published/Telegraph pages, dashboard links, and download links as content destinations that are never blocked under B5.
+
+## The safeguards
+
+**Prevents over-blocking (the bug).** The whole point: real, clickable share links now pass. Tests lock the prompt so a future edit can't silently drop the carve-out.
+
+**Prevents under-blocking (the worry).** A genuine "run `curl http://…/commitments`" instruction is still blocked as B5. A worked BLOCK example and a test assert this side of the line, so loosening the click-case doesn't open a hole for call-targets.
+
+**No new authority.** The change only makes the existing smart authority smarter and *reduces* false-positive blocking. The brittle detector is untouched and keeps being just a signal.
+
+## What ships when
+
+It's a single self-contained change — the prompt rewrite, the strengthened allow-line, and the tests ship together in one patch release. Existing agents get it automatically when they update to the new instar version, because the gate is core server code, not an installed template. There's nothing to turn on and nothing to migrate.

--- a/upgrades/next/tone-gate-b5-link-carveout.md
+++ b/upgrades/next/tone-gate-b5-link-carveout.md
@@ -1,0 +1,21 @@
+## What Changed
+
+The outbound tone gate (`MessagingToneGate`) no longer false-positives on user-facing share links. Its `B5_API_ENDPOINT` rule was firing on **any** URL with a host, port, and path — because the `api-endpoint` detector flags every URL and the rule blocked a link "handed to the user to call/open." That swept up the normal way an agent shares a rendered doc: private-view links (`/view/<id>?token=…`), Cloudflare tunnel URLs, published/Telegraph pages, and dashboard links.
+
+B5 is now intent-judged: it blocks only a URL handed to the user as an API to **call** themselves (`curl`/`POST`/"hit this endpoint"), and explicitly **passes** a URL meant to be **opened/clicked/visited** in a browser — even though it has a host, a port, and a path. Worked examples on both sides were added so the model judges by call-vs-open intent, not by URL shape, and the `ALWAYS ALLOWED` list now names the exact link classes that must never be blocked. The fix is entirely in the gate's LLM-authority prompt; the brittle detector is unchanged (it stays a broad signal), so no new blocking authority is introduced.
+
+## What to Tell Your User
+
+If your agent had started blocking its own "here's your link" messages — saying its safety gate was treating a view/doc link as an exposed endpoint — that's fixed. Signed view links, tunnel URLs, and published pages now pass through cleanly. A genuine "run this curl command yourself" instruction is still held back, as intended.
+
+## Summary of New Capabilities
+
+No new capabilities or endpoints — this is a correctness fix to an existing internal gate. Agents simply stop having their legitimate share links blocked.
+
+## Evidence
+
+- `src/core/MessagingToneGate.ts` — rewritten `B5_API_ENDPOINT` rule (call-vs-open, worked examples both sides) + strengthened `ALWAYS ALLOWED` URL line.
+- `tests/unit/MessagingToneGate.test.ts` — `describe('B5 link carve-out (prompt teaches call-vs-open)')`: 5 tests covering intent-not-shape wording, the named click/open link classes, a retained BLOCK worked example for a call-target, the ALWAYS-ALLOWED browser-open phrasing, and end-to-end plumbing on both verdicts.
+- `tests/unit/GateSignalDetectors.test.ts` — documents that the `api-endpoint` detector intentionally fires on click/open destinations too (the authority judges call-vs-open).
+- Local: `npx vitest run` on both files → 57 passed; `npm run build` → OK.
+- Live reproduction during development: a Telegram reply quoting a literal `http://localhost:4042/foo` was blocked by the pre-fix gate — the bug, observed first-hand.

--- a/upgrades/side-effects/tone-gate-b5-link-carveout.md
+++ b/upgrades/side-effects/tone-gate-b5-link-carveout.md
@@ -1,0 +1,122 @@
+# Side-Effects Review — Tone Gate B5: stop blocking user-facing share links
+
+**Version / slug:** `tone-gate-b5-link-carveout`
+**Date:** `2026-06-27`
+**Author:** `echo`
+**Second-pass reviewer:** `echo (dedicated reviewer subagent)`
+
+## Summary of the change
+
+The outbound MessagingToneGate's B5_API_ENDPOINT rule was blocking user-facing share links — private-view links (`/view/<id>?token=…`), Cloudflare tunnel URLs, published/Telegraph pages, dashboard links — as "exposed endpoints." The `api-endpoint` detector flags **every** URL (it cannot distinguish a call-target from a click-target), and the B5 prompt rule said to block when a URL was "handed to the user to call/**open**." A clickable share link is "handed to the user to open," so the authority blocked it. Reported by multiple agents on and off this machine. Files touched: `src/core/MessagingToneGate.ts` (B5 rule text + ALWAYS-ALLOWED line), `tests/unit/MessagingToneGate.test.ts` (5 prompt/plumbing tests), `tests/unit/GateSignalDetectors.test.ts` (1 detector-breadth test). The only decision point touched is the B5 authority instruction — a prompt-layer change that **relaxes** an over-tight gate; no new code path, no new blocking authority.
+
+## Decision-point inventory
+
+- `MessagingToneGate.buildPrompt` → B5_API_ENDPOINT rule (line ~807) — **modify** — narrow B5 to fire only on call-targets; explicitly pass open/click destinations; add worked examples both sides.
+- `MessagingToneGate.buildPrompt` → ALWAYS ALLOWED section (line ~953) — **modify** — promote the vague "URLs the user can click to visit" to specifically name view/tunnel/published/dashboard/download links as never-block-under-B5.
+- `GateSignalDetectors.detectApiEndpoint` — **pass-through** — unchanged; remains intentionally broad (a signal). Documented with a test, not modified.
+
+---
+
+## 1. Over-block
+
+**What legitimate inputs does this change reject that it shouldn't?**
+
+This change exists to **remove** an over-block, so it adds none. Before: any message containing a clickable view/tunnel/published link could be blocked under B5. After: those pass. The remaining B5 surface is narrower (call-targets only), so over-block strictly decreases. No new legitimate input is rejected.
+
+---
+
+## 2. Under-block
+
+**What failure modes does this still miss?**
+
+The risk in loosening B5 is letting a genuine "call this API yourself" instruction through. Mitigated: B5 still blocks a URL handed to the user to call (`curl http://…/commitments`, "hit POST /attention"), with a worked BLOCK example in the prompt and a test asserting that side. A truly adversarial framing — an API call disguised as "just open this" — could in principle pass, but (a) that is an agent-authored message, not untrusted user input, and (b) the same residual existed before for any call-target the model misread; this change does not widen it. The B1 (CLI command) rule still independently catches `curl …` presented as a command to run.
+
+---
+
+## 3. Level-of-abstraction fit
+
+**Is this at the right layer?**
+
+Yes — exactly. The brittle detector (`detectApiEndpoint`) stays a cheap, broad SIGNAL that flags all URLs. The call-vs-open judgment requires intent and context, which is the AUTHORITY's job (the LLM with the full message). Putting the carve-out in the prompt (authority) rather than teaching the regex (detector) to recognize "view links" is the correct split — a regex trying to enumerate every share-link shape would be brittle and wrong. No higher gate should own this; no lower primitive is being re-implemented.
+
+---
+
+## 4. Signal vs authority compliance
+
+**Required reference:** [docs/signal-vs-authority.md](../../docs/signal-vs-authority.md)
+
+- [x] **No — but the logic is a smart gate with full conversational context (LLM-backed).** The change lives entirely in the LLM authority's instructions. It adds **no** blocking authority and **reduces** existing false-positive blocking. The brittle detector is untouched and remains signal-only.
+
+The fix makes the smart authority smarter; it does not push any judgment down into a brittle detector. Fully compliant — arguably the textbook application of the principle (resolve a false positive at the authority, leave the signal broad).
+
+---
+
+## 5. Interactions
+
+- **Shadowing:** B5 sits beside B1–B7 in the same single-verdict prompt. Narrowing B5 cannot shadow another rule; a `curl`-style command is still caught by B1 (cli-command) independently. No shadow created or removed.
+- **Double-fire:** none — one gate, one verdict per call. The `api-endpoint` signal still fires (unchanged); only the authority's use of it narrows.
+- **Races:** none — pure prompt text + tests, no shared state, no lifecycle interaction.
+- **Feedback loops:** none.
+
+---
+
+## 6. External surfaces
+
+**Does this change anything visible outside the immediate code path?**
+
+- Other agents on the machine: yes, positively — every agent's outbound gate stops blocking their share links once they update.
+- Install base: ships as core server code in the next patch; reaches existing agents on update (see §Migration below).
+- External systems: none. Response shape of `review()` is unchanged (same `{pass, rule, issue, suggestion}`); callers (telegram-reply.sh etc.) see identical structure.
+- Persistent state: none.
+- **Operator surface (Mobile-Complete):** no operator-facing actions added or touched. Not applicable.
+
+---
+
+## 6b. Operator-surface quality
+
+No operator surface — not applicable. This change touches only the gate prompt and unit tests; no dashboard renderer, approval page, or grant/secret form is involved.
+
+---
+
+## 7. Multi-machine posture (Cross-Machine Coherence)
+
+**machine-local BY DESIGN — and identical on every machine.** The gate prompt is compiled server code shipped with the instar version; each machine runs its own gate over its own outbound messages. There is no per-machine state, no replication needed, and no divergence: every machine on the same version evaluates by the same rules. It emits no user-facing notices of its own (it only passes/holds a message the agent already authored, so one-voice gating is unaffected), holds no durable state (nothing to strand on topic transfer), and generates no URLs (it only *evaluates* URLs the agent wrote — and the fix specifically makes a cross-machine tunnel link survive the gate instead of being blocked). No single-machine assumption.
+
+---
+
+## 8. Rollback cost
+
+**Pure code change — revert and ship a patch.** No persistent state, no data migration, no agent-state repair. Reverting the one commit restores the prior B5 wording exactly. During the rollback window the only "regression" is the original bug returning (share links blocked again) — no data loss, no corruption, no user-visible breakage beyond that.
+
+**Migration Parity:** N/A for installed-file migration. The gate prompt is core server code (`src/core/MessagingToneGate.ts`), not an agent-installed template/hook/config/skill — so existing agents receive it through the normal version update, with no `PostUpdateMigrator` entry required. **Agent Awareness:** no CLAUDE.md template change — this is a behavior fix to an existing internal gate, not a new capability/endpoint/trigger.
+
+---
+
+## Conclusion
+
+The review produced no design changes — the fix is a clean, minimal, authority-layer correction that strictly reduces false-positive blocking while preserving the genuine B5 block on call-targets, with tests locking both sides of the boundary. It is the textbook signal-vs-authority application (broad signal, smart authority). No persistent state, no migration, single-commit rollback. Clear to ship.
+
+---
+
+## Second-pass review (if required)
+
+**Reviewer:** echo (dedicated reviewer subagent)
+**Independent read of the artifact: concur**
+
+Concur with the review. Audited against all five axes:
+- **Under-block (central risk):** robust. B5 still fires on call-targets; the discriminator is intent not shape, with two worked BLOCK examples vs three PASS. The "API call disguised as open" residual is non-widening — it's agent-authored (not adversarial user input), B1_CLI_COMMAND still independently catches a literal `curl …`, and the pre-fix prompt already said "call/open" so any misread call-target passed before too. Net under-block surface does not increase.
+- **Signal-vs-authority:** fully compliant — the diff is entirely inside `buildPrompt()` string literals (the LLM authority); `detectApiEndpoint` is untouched and stays broad, locked by the new detector-breadth test.
+- **Prompt coherence:** no contradiction — "open a link in a browser" is cleanly outside the general ARTIFACT framing's act-on set (copy/paste/run/edit); the new B5 recasts an open/click URL as content, consistent top-to-bottom.
+- **Test quality:** both sides covered; with the LLM mocked, asserting prompt content + verdict-plumbing is the correct deterministic guarantee and would catch the actual regression (dropping the carve-out / BLOCK example / call-vs-open language fails these).
+- **Interactions:** nothing material missed. Non-blocking note: the `http://localhost:4040/dashboard` PASS example is correct for the *gate's* call-vs-open boundary; a separate pre-existing localhost guard governs the automated-send path independently (different layer). Accurate §5/§6 analysis.
+
+Clean, minimal, authority-layer-only correction that strictly reduces false-positive blocking while preserving the genuine B5 block. Clear to ship.
+
+---
+
+## Evidence pointers
+
+- `tests/unit/MessagingToneGate.test.ts` → `describe('B5 link carve-out (prompt teaches call-vs-open)')` — 5 tests: prompt teaches call-vs-open intent (not shape); names the exact click/open link classes; keeps a BLOCK worked example for a call-target; ALWAYS-ALLOWED names browser-open URLs; plumbing honors both verdicts (view link passes, curl target blocks).
+- `tests/unit/GateSignalDetectors.test.ts` → "fires on click/open destinations too (intentionally broad)" — documents the detector's deliberate breadth.
+- Live reproduction during this session: an attempted Telegram reply quoting `http://localhost:4042/foo` was blocked by the live (pre-fix) gate — the bug, observed first-hand.
+- Local: `npx vitest run` on both files → 57 passed; `npm run build` → OK.


### PR DESCRIPTION
## ELI16 — what this fixes, in plain words

Every message an agent sends you goes through a small safety gate that blocks technical leakage — like a raw API endpoint you'd be told to `curl`. One rule ("B5") was firing on **any** URL with a host, a port, and a path. A signed view link like `…/view/abc?token=…` has exactly that shape, so the gate was blocking the agent's normal "here's your rendered doc" link as if it were an exposed endpoint. Multiple agents hit this — the gate failing its own standard: it couldn't tell a link you **click to open** from an endpoint you **call**.

This teaches B5 to judge by intent, not shape: block a URL the user is told to **call** themselves (curl/POST/"hit this endpoint"); **pass** a URL meant to be **opened/clicked/visited** — a private-view link (even with a `?token=`), a Cloudflare tunnel URL, a published/Telegraph page, a dashboard link — even though it has a host, port, and path. Worked examples on both sides lock the call-vs-open distinction, and the ALWAYS-ALLOWED list now names those link classes. The fix is entirely in the gate's LLM prompt; the brittle URL detector is untouched (it stays a broad signal), so **no new blocking authority** is added — it only *reduces* a false positive.

## What changed
- `src/core/MessagingToneGate.ts` — rewrote `B5_API_ENDPOINT` (call-vs-open, worked examples both sides) + strengthened the `ALWAYS ALLOWED` URL line.
- `tests/unit/MessagingToneGate.test.ts` — new `describe('B5 link carve-out')`: 5 tests covering intent-not-shape wording, the named click/open link classes, a retained BLOCK example for a call-target, the ALWAYS-ALLOWED phrasing, and end-to-end plumbing on both verdicts.
- `tests/unit/GateSignalDetectors.test.ts` — documents the `api-endpoint` detector's intentional breadth (signal stays broad; authority decides).

## Review trail
- Tier 1 (instar-dev), at the risk floor. ELI16 overview + side-effects artifact staged.
- Second-pass review (outbound allow/block decision): **concur** — under-block surface does not increase (B1 still catches literal `curl`; the residual is non-widening), signal-vs-authority compliant, prompt coherent with the general ARTIFACT framing.

## Evidence
- Local: `npx vitest run` across 11 tone-gate test files → 142 passed; `npm run build` → OK.
- Live repro during development: a Telegram reply quoting a literal `http://localhost:4042/foo` was blocked by the pre-fix gate — the bug, first-hand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)