### PR TITLE
feat(mesh-self-heal): G2 enforce — nobody-polling take-over (dark+dryRun, 2nd-pass concurred)

### DIFF
--- a/.instar/instar-dev-decisions/2026-06-28T09-30-01-929Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-06-28T09-30-01-929Z-unknown.json
@@ -1,0 +1,15 @@
+{
+  "ts": "2026-06-28T09:30:01.929Z",
+  "slug": "unknown",
+  "suggestedTier": 2,
+  "declaredTier": 2,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "new capability: new config key added"
+  ],
+  "belowFloor": false,
+  "files": 4,
+  "loc": 227,
+  "causalAutopsy": null,
+  "verdict": "pass"
+}

--- a/src/commands/server.ts
+++ b/src/commands/server.ts
@@ -16570,6 +16570,19 @@ export async function startServer(options: StartOptions): Promise<void> {
                 }
               }
             } catch { /* best-effort pool refresh */ }
+            // G2 enforce (MESH-SELF-HEAL-SPEC §3.2) — evaluate nobody-polling over
+            // the freshly-recorded pool on the same 30s cadence; the coordinator
+            // debounces a silence across these ticks. DARK + dryRun-gated INSIDE
+            // the coordinator (strict no-op when off; records-only in dryRun), so
+            // this is a safe observe-producer here. Fire-and-forget: a slow/failed
+            // eval must never block or fail the pool refresh.
+            void coordinator
+              .evaluateNobodyPolling(
+                machinePoolRegistry!.getCapacities().map((c) => ({ machineId: c.machineId, online: c.online, pollingActive: c.pollingActive })),
+                false,
+                new Date().toISOString(),
+              )
+              .catch(() => { /* @silent-fallback-ok — G2 eval is best-effort signal */ });
           };
           refreshPool();
           const poolTimer = setInterval(refreshPool, 30_000);

--- a/src/config/ConfigDefaults.ts
+++ b/src/config/ConfigDefaults.ts
@@ -873,6 +873,13 @@ const SHARED_DEFAULTS: Record<string, unknown> = {
     // would-action WITHOUT changing ingress (the live flip is gated on the Phase-4
     // two-host proof + B2/B5 live, so it can't disturb the Phase-0 stabilization).
     pollFollowsLease: { dryRun: true },
+    // G2 nobody-polling RECOVERY (MESH-SELF-HEAL-SPEC §3.2). OMIT `enabled` ⇒
+    // dev-agent gate (live-on-dev / dark-on-fleet); dryRun:true ⇒ the evaluator
+    // detects + elects + records the soak counterfactual but performs NO actuation
+    // (no fenced-CAS acquire, no poll-lever write). Flipping dryRun:false is the
+    // deliberate enforce promotion (gated on the pollSucceeded-watermark plumbing +
+    // the Phase-5 second-pass live-verify on the real pair).
+    nobodyPollingRecovery: { dryRun: true },
     // multi-transport-mesh-comms (Layers 0-2) — multi-rope mesh transport
     // (Tailscale/LAN/Cloudflare hedged failover). Ships ENABLED (strictly additive;
     // a single-machine agent is a no-op and keeps its 127.0.0.1 bind — the 0.0.0.0

--- a/src/core/MultiMachineCoordinator.ts
+++ b/src/core/MultiMachineCoordinator.ts
@@ -26,8 +26,11 @@ import type { LeaseCoordinator } from './LeaseCoordinator.js';
 import { SEAMLESSNESS_PROTOCOL_VERSION } from './seamlessnessConfig.js';
 import { FailureEpisodeLatch } from './FailureEpisodeLatch.js';
 import { ChurnBreaker } from './churnBreaker.js';
-import { writePollIntent } from './pollIntent.js';
+import { writePollIntent, readPollActive, pidAlive } from './pollIntent.js';
 import { resolveDevAgentGate } from './devAgentGate.js';
+import { poolPollerVerdict } from './pollerCount.js';
+import { decideNobodyPollingClaim, sharedG2NobodyPollingLedger } from './nobodyPollingRecovery.js';
+import { applyNobodyPollingRecovery } from './nobodyPollingActuator.js';
 import { DegradationReporter } from '../monitoring/DegradationReporter.js';
 import type { MachineRole, MachineIdentity, MultiMachineConfig, CoordinationMode } from './types.js';
 
@@ -608,6 +611,99 @@ export class MultiMachineCoordinator extends EventEmitter {
   private pollFollowsLeaseEnabled(): boolean {
     const m = this.config.multiMachine as { pollFollowsLease?: { enabled?: boolean } } | undefined;
     return resolveDevAgentGate(m?.pollFollowsLease?.enabled, this.config);
+  }
+
+  // ── G2 nobody-polling RECOVERY (enforce) — MESH-SELF-HEAL-SPEC §3.2 ──────────
+  /** Consecutive confirmed-silence reads (debounce so a handoff gap never trips). */
+  private _g2SilenceStreak = 0;
+  private static readonly G2_CONFIRM_OBSERVATIONS = 3;
+  /** Reentrancy guard: a slow eval must not overlap the next cadence tick (which
+   *  would double-increment the silence streak pre-await and trip the debounce
+   *  early). Mirrors `leaseTicking`. */
+  private _g2Evaluating = false;
+
+  /** Resolve the G2 enforce gate: dark+dryRun-first. OMIT `enabled` ⇒ dev-agent
+   *  gate (live-on-dev / dark-on-fleet); dryRun defaults TRUE (observe-only) so
+   *  enabling alone never actuates — flipping dryRun:false is the deliberate
+   *  enforce promotion. Read live so a config flip applies on the next tick. */
+  private nobodyPollingRecoveryCfg(): { enabled: boolean; dryRun: boolean } {
+    const m = this.config.multiMachine as { nobodyPollingRecovery?: { enabled?: boolean; dryRun?: boolean } } | undefined;
+    return {
+      enabled: resolveDevAgentGate(m?.nobodyPollingRecovery?.enabled, this.config),
+      dryRun: m?.nobodyPollingRecovery?.dryRun ?? true,
+    };
+  }
+
+  /**
+   * G2 enforce evaluator — the SERVER calls this on its cadence with the live pool
+   * capacities (which carry each machine's lifeline-actual `pollingActive`). It
+   * computes the B5 verdict, debounces a silence, runs the deterministic
+   * single-claimant decision, records the soak evidence, and — only on a genuine
+   * self-claim AND `dryRun:false` — actuates via the injected lease ports
+   * (acquire fenced CAS → re-verify own poll-freshness → start polling, else
+   * relinquish + self-exclude). DARK + dryRun-first: with the gate off it is a
+   * strict no-op; in dryRun it records "would claim" and touches NOTHING.
+   *
+   * NOTE (enforce-ENABLE prerequisite): the `localPollSucceededFresh` port here is
+   * a liveness approximation (lifeline pid alive + a fresh poll-active record). The
+   * true `pollSucceededMonoMs`/serve-progress watermark (spec §3.1 round-3) is a
+   * separate lifeline-side plumbing increment required BEFORE flipping dryRun:false
+   * on the fleet — but it is consulted ONLY when dryRun:false, so the dark soak
+   * never depends on it.
+   */
+  async evaluateNobodyPolling(
+    capacities: Array<{ machineId: string; online?: boolean; pollingActive?: boolean }>,
+    localSaw409: boolean,
+    nowIso: string,
+  ): Promise<{ skipped?: string; verdict?: string; silenceConfirmed?: boolean; decision?: string; actuation?: string }> {
+    const cfg = this.nobodyPollingRecoveryCfg();
+    if (!cfg.enabled || !this.leaseCoordinator || !this._identity) {
+      return { skipped: 'disabled-or-single-machine' };
+    }
+    // Reentrancy guard: never let a slow eval overlap the next cadence tick.
+    if (this._g2Evaluating) return { skipped: 'already-evaluating' };
+    this._g2Evaluating = true;
+    try {
+    const verdict = poolPollerVerdict(capacities, localSaw409);
+    if (verdict.verdict === 'silence') this._g2SilenceStreak += 1; else this._g2SilenceStreak = 0;
+    const silenceConfirmed = this._g2SilenceStreak >= MultiMachineCoordinator.G2_CONFIRM_OBSERVATIONS;
+    const decision = decideNobodyPollingClaim({
+      selfMachineId: this._identity.machineId,
+      pollerVerdict: verdict.verdict,
+      silenceConfirmed,
+      preferredAwakeMachineId: this.config.multiMachine?.leaseSelfHeal?.preferredAwakeMachineId ?? null,
+      // fit = heartbeat-fresh candidate (in a silence nobody is polling, so fitness
+      // is NOT tied to pollingActive); the post-CAS self-reverify checks real poll
+      // freshness before serving.
+      machines: capacities.map((c) => ({ machineId: c.machineId, fit: !!c.online })),
+      // Peer-evidence-of-global-outage plumbing is an enforce-ENABLE prerequisite;
+      // until then a confirmed silence proceeds to elect (the local-failure-safe
+      // direction — G2 picks a server rather than HOLD on unproven global blindness).
+      globalOutageEvidence: false,
+    });
+    sharedG2NobodyPollingLedger.recordClaim(decision, nowIso);
+    const outcome = await applyNobodyPollingRecovery({
+      decision,
+      dryRun: cfg.dryRun,
+      ledger: sharedG2NobodyPollingLedger,
+      nowIso,
+      log: (m) => console.log(`[MultiMachine] ${m}`),
+      ports: {
+        acquireFencedCas: () => this.leaseCoordinator!.acquireIfEligible(),
+        currentEpoch: () => this.leaseCoordinator!.currentEpoch(),
+        localPollSucceededFresh: () => {
+          const rec = readPollActive(this.config.stateDir);
+          if (!rec) return false;
+          return pidAlive(rec.pid) && (Date.now() - rec.ts) < 90_000;
+        },
+        startPolling: () => this.writeLeasePollIntent(true, 'awake'),
+        relinquishAndSelfExclude: () => { void this.leaseCoordinator!.relinquishAndBroadcast(); },
+      },
+    });
+    return { verdict: verdict.verdict, silenceConfirmed, decision: decision.action, actuation: outcome.result };
+    } finally {
+      this._g2Evaluating = false;
+    }
   }
 
   /**

--- a/src/core/nobodyPollingActuator.ts
+++ b/src/core/nobodyPollingActuator.ts
@@ -1,0 +1,109 @@
+/**
+ * MESH-SELF-HEAL G2 — enforce-mode ACTUATOR (dependency-injected, testable).
+ *
+ * Spec: MESH-SELF-HEAL-SPEC §3.2; build plan: MESH-SELF-HEAL-G2-BUILD.md.
+ *
+ * This is the ENFORCE half of G2: given a `claim` decision from
+ * `decideNobodyPollingClaim`, actually take poll-ownership — win the fenced
+ * epoch-CAS, RE-VERIFY live local poll-success (CAS-win is necessary-not-sufficient,
+ * Adv2-F1), then either start polling (drive the existing poll-follows-lease lever)
+ * or relinquish + self-exclude. The delicate cross-machine authority (the exact
+ * code whose hasty version caused the 2026-06-27 tug-of-war) is isolated behind
+ * INJECTED PORTS so it is unit-testable WITHOUT a live coordinator/lifeline, and so
+ * the dryRun gate is a single, auditable chokepoint.
+ *
+ * Ships DARK + dryRun-first. In dryRun it records "would actuate" and performs ZERO
+ * side effects (no CAS acquire, no poll-lever write) — pure observation. Only an
+ * explicit `dryRun:false` (the enforce promotion) ever touches the lease or polling.
+ *
+ * SECOND-PASS REVIEW REQUIRED before merge (this holds poll-ownership authority).
+ */
+
+import type { NobodyPollingDecision, NobodyPollingLedger } from './nobodyPollingRecovery.js';
+import { decidePostCasSelfReverify } from './nobodyPollingRecovery.js';
+
+/**
+ * The minimal authority surface the actuator needs — the real wiring supplies
+ * these from MultiMachineCoordinator/LeaseCoordinator/the poll-intent writer.
+ * Injected so the actuator is testable against fakes and so EVERY side effect is
+ * named + mockable (no hidden I/O).
+ */
+export interface NobodyPollingActuatorPorts {
+  /** Win the fenced epoch-CAS (LeaseCoordinator.acquireIfEligible). True = won. */
+  acquireFencedCas: () => Promise<boolean>;
+  /** This machine's OWN live poll-success freshness, read AFTER the CAS win. */
+  localPollSucceededFresh: () => boolean;
+  /** The won epoch (LeaseCoordinator.currentEpoch) — stamped into the poll intent. */
+  currentEpoch: () => number;
+  /** Start this machine polling: writePollIntent(shouldPoll:true, epoch) — the lever. */
+  startPolling: (epoch: number) => void;
+  /**
+   * Relinquish the just-won epoch (signed tombstone + G1 quiesce) AND advertise
+   * pollFresh:false + selfExcludedThisEpisode so peers skip this machine at once.
+   */
+  relinquishAndSelfExclude: () => void;
+}
+
+export type NobodyPollingActuationResult =
+  | 'no-action'             // decision wasn't a self-claim — nothing to actuate
+  | 'dry-run-would-claim'   // dryRun: would have acquired + served; NO side effect performed
+  | 'cas-lost'             // another machine won the fenced epoch first — stand down
+  | 'claimed-serving'       // won CAS + self-reverified fit → now polling
+  | 'self-excluded';        // won CAS but self-unfit on re-verify → relinquished + excluded
+
+export interface NobodyPollingActuationOutcome {
+  result: NobodyPollingActuationResult;
+  reason: string;
+}
+
+/**
+ * Actuate a G2 claim decision. Pure control-flow over injected ports; the only
+ * authority is exercised through the ports, and ONLY when `dryRun` is false and the
+ * decision is a genuine self-claim. Idempotent per call.
+ */
+export async function applyNobodyPollingRecovery(args: {
+  decision: NobodyPollingDecision;
+  dryRun: boolean;
+  ports: NobodyPollingActuatorPorts;
+  ledger: NobodyPollingLedger;
+  nowIso: string;
+  log?: (msg: string) => void;
+}): Promise<NobodyPollingActuationOutcome> {
+  const { decision, dryRun, ports, ledger, nowIso, log } = args;
+
+  // Only a genuine self-claim actuates. stand-down / veto / fail-closed / hold /
+  // escalate / await / no-op are non-actuating (the decision recorder already
+  // counted them); the actuator must NEVER touch the lease for those.
+  if (!decision.selfClaims || decision.action !== 'claim') {
+    return { result: 'no-action', reason: `decision=${decision.action}` };
+  }
+
+  // DARK / dryRun: observe only. Record the counterfactual; perform NO side effect.
+  if (dryRun) {
+    log?.(`[g2-actuator] DRY-RUN would claim poll-ownership (epoch n+1) — no CAS, no poll-lever write`);
+    return { result: 'dry-run-would-claim', reason: 'dry-run-observe-only' };
+  }
+
+  // ENFORCE: win the fenced epoch-CAS. Losing means a peer won the same episode —
+  // stand down (the single-claimant invariant holds via the fence, not our guess).
+  const won = await ports.acquireFencedCas();
+  if (!won) {
+    return { result: 'cas-lost', reason: 'another-machine-won-the-fenced-epoch' };
+  }
+
+  // CAS-win is necessary but NOT sufficient (Adv2-F1): re-verify OWN live poll
+  // freshness (current+local) before committing to serve.
+  const reverify = decidePostCasSelfReverify({ localPollSucceededFresh: ports.localPollSucceededFresh() });
+  if (!reverify.commit) {
+    ports.relinquishAndSelfExclude();
+    ledger.recordSelfExclusion(nowIso);
+    log?.(`[g2-actuator] won CAS but self-unfit on re-verify → relinquished + self-excluded`);
+    return { result: 'self-excluded', reason: reverify.reason };
+  }
+
+  // Committed: drive the poll-follows-lease lever to START polling at the won epoch.
+  // (The caller's post-claim live-verify confirms lifeline-poll-active.json advances.)
+  ports.startPolling(ports.currentEpoch());
+  log?.(`[g2-actuator] claimed poll-ownership + started polling at epoch ${ports.currentEpoch()}`);
+  return { result: 'claimed-serving', reason: 'cas-won-self-reverified-fit' };
+}

--- a/tests/unit/lint-dev-agent-dark-gate.test.ts
+++ b/tests/unit/lint-dev-agent-dark-gate.test.ts
@@ -446,10 +446,17 @@ describe('lint-dev-agent-dark-gate', () => {
       // Every key below the insertion shifts DOWN by +17; the flag SET is unchanged (still 22).
       // RE-VERIFIED via the attributor on the edited ConfigDefaults (each maps to a real
       // `enabled: false,` line).
-      '1060': 'multiMachine.sessionPool.enabled',
-      '1086': 'multiMachine.sessionPool.ownershipCheckedSpawn.enabled',
-      '1096': 'multiMachine.sessionPool.inboundQueue.enabled',
-      '1125': 'multiMachine.sessionPool.holdForStability.enabled',
+      // mesh-self-heal G2 enforce (2026-06-28): a NEW multiMachine.nobodyPollingRecovery
+      // block (`{ dryRun: true }` + a 6-line comment, ~7 lines) was inserted into the
+      // `multiMachine` block right after pollFollowsLease (ABOVE sessionPool). It OMITS
+      // the `enabled:` literal (dev-gated via resolveDevAgentGate — registered in
+      // DEV_GATED_FEATURES), so it adds NO new attributed path; it only shifts every
+      // sessionPool-onward `enabled: false` line DOWN by +7. RE-VERIFIED via the
+      // attributor on the edited ConfigDefaults (path set unchanged, uniform +7).
+      '1067': 'multiMachine.sessionPool.enabled',
+      '1093': 'multiMachine.sessionPool.ownershipCheckedSpawn.enabled',
+      '1103': 'multiMachine.sessionPool.inboundQueue.enabled',
+      '1132': 'multiMachine.sessionPool.holdForStability.enabled',
       // mm-stores-devgate (operator directive 2026-06-13, topic 13481): the 7
       // multiMachine.stateSync.* memory stores MOVED from DARK_GATE_EXCLUSIONS to
       // DEV_GATED_FEATURES and their `enabled: false` literals were REMOVED from
@@ -483,10 +490,11 @@ describe('lint-dev-agent-dark-gate', () => {
       // attributor on the edited ConfigDefaults.
       // After merging JKHeadley/main + my accountFollowMe block, these resolve as below.
       // RE-VERIFIED by hand via the attributor on the MERGED ConfigDefaults.
-      '1294': 'multiMachine.stateSync.threadlinePairing.enabled',
-      '1416': 'cartographer.freshnessSweep.enabled',
-      '1461': 'cartographer.conformanceAudit.llmEnrichment.enabled',
-      '1486': 'cartographer.subtreeNav.llmRerank.enabled',
+      // (+7 from the nobodyPollingRecovery block above — see the sessionPool note.)
+      '1301': 'multiMachine.stateSync.threadlinePairing.enabled',
+      '1423': 'cartographer.freshnessSweep.enabled',
+      '1468': 'cartographer.conformanceAudit.llmEnrichment.enabled',
+      '1493': 'cartographer.subtreeNav.llmRerank.enabled',
     };
     const actual = attributeRealConfigDefaults();
     expect(actual).toEqual(EXPECTED);

--- a/tests/unit/nobodyPollingActuator.test.ts
+++ b/tests/unit/nobodyPollingActuator.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from 'vitest';
+import { applyNobodyPollingRecovery, type NobodyPollingActuatorPorts } from '../../src/core/nobodyPollingActuator.js';
+import { NobodyPollingLedger, type NobodyPollingDecision } from '../../src/core/nobodyPollingRecovery.js';
+
+const t = '2026-06-28T00:00:00.000Z';
+
+function spyPorts(over: Partial<{ casWins: boolean; fresh: boolean; epoch: number }> = {}): {
+  ports: NobodyPollingActuatorPorts;
+  calls: { acquire: number; start: number[]; relinquish: number };
+} {
+  const calls = { acquire: 0, start: [] as number[], relinquish: 0 };
+  const ports: NobodyPollingActuatorPorts = {
+    acquireFencedCas: async () => { calls.acquire += 1; return over.casWins ?? true; },
+    localPollSucceededFresh: () => over.fresh ?? true,
+    currentEpoch: () => over.epoch ?? 42,
+    startPolling: (e) => { calls.start.push(e); },
+    relinquishAndSelfExclude: () => { calls.relinquish += 1; },
+  };
+  return { ports, calls };
+}
+
+const claim: NobodyPollingDecision = { action: 'claim', claimant: 'm_self', selfClaims: true, reason: 'lowest-id-fit' };
+const standDown: NobodyPollingDecision = { action: 'stand-down', claimant: 'm_a', selfClaims: false, reason: 'x' };
+
+describe('applyNobodyPollingRecovery — enforce actuator', () => {
+  it('non-self-claim decision → no-action, ZERO port calls (never touches the lease)', async () => {
+    const { ports, calls } = spyPorts();
+    const out = await applyNobodyPollingRecovery({ decision: standDown, dryRun: false, ports, ledger: new NobodyPollingLedger(), nowIso: t });
+    expect(out.result).toBe('no-action');
+    expect(calls.acquire).toBe(0);
+    expect(calls.start).toEqual([]);
+    expect(calls.relinquish).toBe(0);
+  });
+
+  it('dryRun + claim → dry-run-would-claim with NO side effects (the safety invariant)', async () => {
+    const { ports, calls } = spyPorts();
+    const out = await applyNobodyPollingRecovery({ decision: claim, dryRun: true, ports, ledger: new NobodyPollingLedger(), nowIso: t });
+    expect(out.result).toBe('dry-run-would-claim');
+    expect(calls.acquire).toBe(0);   // NO fenced-CAS acquire in dryRun
+    expect(calls.start).toEqual([]); // NO poll-lever write in dryRun
+    expect(calls.relinquish).toBe(0);
+  });
+
+  it('enforce + claim + CAS lost → cas-lost, does NOT start polling', async () => {
+    const { ports, calls } = spyPorts({ casWins: false });
+    const out = await applyNobodyPollingRecovery({ decision: claim, dryRun: false, ports, ledger: new NobodyPollingLedger(), nowIso: t });
+    expect(out.result).toBe('cas-lost');
+    expect(calls.acquire).toBe(1);
+    expect(calls.start).toEqual([]);
+  });
+
+  it('enforce + claim + CAS won + self-reverify FRESH → claimed-serving, starts polling at the won epoch', async () => {
+    const { ports, calls } = spyPorts({ casWins: true, fresh: true, epoch: 99 });
+    const out = await applyNobodyPollingRecovery({ decision: claim, dryRun: false, ports, ledger: new NobodyPollingLedger(), nowIso: t });
+    expect(out.result).toBe('claimed-serving');
+    expect(calls.acquire).toBe(1);
+    expect(calls.start).toEqual([99]);
+    expect(calls.relinquish).toBe(0);
+  });
+
+  it('enforce + claim + CAS won + self-reverify STALE → self-excluded, relinquishes + records, does NOT poll', async () => {
+    const { ports, calls } = spyPorts({ casWins: true, fresh: false });
+    const led = new NobodyPollingLedger();
+    const out = await applyNobodyPollingRecovery({ decision: claim, dryRun: false, ports, ledger: led, nowIso: t });
+    expect(out.result).toBe('self-excluded');
+    expect(calls.acquire).toBe(1);
+    expect(calls.relinquish).toBe(1);
+    expect(calls.start).toEqual([]);
+    expect(led.summary().selfExclusions).toBe(1);
+  });
+});

--- a/upgrades/next/mesh-self-heal-g2-enforce.md
+++ b/upgrades/next/mesh-self-heal-g2-enforce.md
@@ -1,0 +1,23 @@
+## What Changed
+
+Mesh Self-Heal **G2 enforce** (MESH-SELF-HEAL-SPEC §3.2) — the take-over actuation for the nobody-serving alarm. When NO machine is polling Telegram (the zombie-lease-holder state behind the message-drop incidents), exactly ONE fit machine now takes over poll-ownership — never zero (drops), never two (the Telegram 409 poll-war).
+
+- `src/core/nobodyPollingActuator.ts` (`applyNobodyPollingRecovery`) — dependency-injected actuator: win the fenced epoch-CAS → re-verify own poll-freshness (CAS-win is necessary-not-sufficient) → start polling, else relinquish + self-exclude.
+- `MultiMachineCoordinator.evaluateNobodyPolling()` — wires the detector + single-claimant election to the actuator with the real lease ports (`acquireIfEligible` / `currentEpoch` / `writeLeasePollIntent` / `relinquishAndBroadcast`), debounced (confirm=3) and reentrancy-guarded.
+- `server.ts` `refreshPool` — runs it on the existing 30s pool cadence, fire-and-forget.
+
+Ships **dark + dryRun-first** (`multiMachine.nobodyPollingRecovery`, OMITS `enabled` → dev-gated). In dryRun it detects + elects + records the soak counterfactual but performs ZERO side effects (no lease acquire, no poll-lever write) — verified by an independent second-pass review (the high-risk lease-authority gate). Flipping `dryRun:false` is the deliberate enforce promotion, gated on two tracked prerequisites: the real pollSucceeded watermark + the peer-confirmed global-outage plumbing (see MESH-SELF-HEAL-G2-BUILD.md).
+
+## Evidence
+
+- `tests/unit/nobodyPollingActuator.test.ts` — 5 tests, both sides of every boundary incl. the critical dryRun=zero-side-effects safety invariant (no CAS, no poll-write) and CAS-lost / self-excluded / claimed-serving.
+- Builds on the merged G2 core (18 unit) + observe route (4 integration). Dark-gate lint golden map updated for the +7 line shift. Typecheck clean; full G2 suite green.
+- Independent Phase-5 second-pass review: CONCUR (dryRun invariant holds; single-claimant is the fenced CAS; no tug-of-war). Its one minor concern (reentrancy guard) was fixed in this commit.
+
+## What to Tell Your User
+
+When this is turned on (it ships off, in observe-only mode for now), it fixes the "nobody is polling, so my messages silently drop" problem on multi-machine setups: if the in-charge machine goes quiet, exactly one healthy machine automatically takes over polling — no tug-of-war, no duplicates, no action needed from you. Single-machine setups are unaffected.
+
+## Summary of New Capabilities
+
+- `multiMachine.nobodyPollingRecovery` `{ dryRun }` — opt-in (dev-gated) nobody-polling take-over: detect → elect one machine → acquire the fenced lease → start polling. Dark + dryRun by default (observe-only; zero side effects until a deliberate enforce promotion).

--- a/upgrades/side-effects/mesh-self-heal-g2-enforce.md
+++ b/upgrades/side-effects/mesh-self-heal-g2-enforce.md
@@ -1,0 +1,38 @@
+# Side-Effects Review — Mesh Self-Heal G2 (enforce actuation)
+
+**Change:** The ENFORCE half of G2 (MESH-SELF-HEAL-SPEC §3.2) — actually taking over poll-ownership when nobody is polling. HIGH-RISK: it holds cross-machine poll-ownership authority (the area whose hasty version caused the 2026-06-27 tug-of-war). Pieces:
+- `src/core/nobodyPollingActuator.ts` (`applyNobodyPollingRecovery`) — dependency-injected actuator: dryRun gate → `acquireFencedCas` → `decidePostCasSelfReverify` → `startPolling` / `relinquishAndSelfExclude`. 5 unit tests.
+- `MultiMachineCoordinator.evaluateNobodyPolling()` — the wiring: gate (`nobodyPollingRecoveryCfg`) → B5 verdict → debounce (`_g2SilenceStreak`, confirm=3) → `decideNobodyPollingClaim` → record → actuate (real ports: `leaseCoordinator.acquireIfEligible` / `currentEpoch` / `writeLeasePollIntent(true)` / `relinquishAndBroadcast`). Reentrancy-guarded (`_g2Evaluating`).
+- `server.ts` `refreshPool` — the 30s cadence (fire-and-forget, gated inside the coordinator).
+- `ConfigDefaults`: `multiMachine.nobodyPollingRecovery: { dryRun: true }` (OMITS `enabled` → dev-gated). Dark-gate lint golden map updated (+7 line shift).
+
+**Decision point?** YES — it acquires the fenced lease + starts polling. Signal-vs-authority + the dryRun safety invariant are the load-bearing concerns.
+
+## 1. Over-block
+N/A (it grants poll-ownership, never blocks). It biases hard against acting: only a confirmed real silence where this machine is the deterministic single claimant AND wins the fenced CAS AND re-verifies its own poll-freshness ever serves.
+
+## 2. Under-block
+Ships dark+dryRun (default), so nothing actuates until a deliberate `dryRun:false`. **Enforce-ENABLE prerequisites (TRACKED, not orphan-deferred — see MESH-SELF-HEAL-G2-BUILD.md + the enforce note below):** (1) the real `pollSucceededMonoMs`/serve-progress watermark for `localPollSucceededFresh` (currently a lifeline-liveness approximation — consulted ONLY when dryRun:false); (2) peer-confirmed `globalOutageEvidence` plumbing (currently hard-coded false → a confirmed silence proceeds to elect, the local-failure-safe direction). Both are inert under dryRun.
+
+## 3. Level-of-abstraction fit
+The authority lives in the coordinator (it owns the leaseCoordinator); the server only supplies the cadence + capacities. The actuator isolates the delicate flow behind injected ports (testable without a live coordinator; the dryRun gate is a single chokepoint). Reuses `acquireIfEligible` (the SAME fence `tickLease` uses) — not a parallel acquire path.
+
+## 4. Signal vs authority compliance
+COMPLIANT with the safety design: the only authority (acquire CAS + start polling) is exercised through the ports ONLY when `dryRun:false` AND the decision is a genuine self-claim. The election is deterministic + machine-agnostic, but it is NOT the authority — the **fenced CAS is the single-claimant gate** (even if two machines diverge on the election under partition, `acquireIfEligible` admits exactly one; the loser gets `cas-lost` and stands down). `decidePostCasSelfReverify` enforces "CAS-win necessary-not-sufficient."
+
+## 5. Interactions
+- vs `tickLease`: a won CAS makes this machine the holder → `tickLease`'s non-holder acquire converges (doesn't fight); a successful claim flips the verdict to `ok` (self-terminating). Debounce + post-CAS reverify damp flap.
+- Reentrancy: `_g2Evaluating` prevents a >30s eval overlapping the 30s cadence (which would inflate the silence streak pre-await). Added per the 2nd-pass review.
+- Cadence: fire-and-forget with `.catch()` — a slow/failed eval never blocks or fails `refreshPool`.
+
+## 6. External surfaces
+No new route (the observe `/mesh-selfheal/g2` from the prior PR reads the same ledger). New config path `multiMachine.nobodyPollingRecovery` (dev-gated). When `dryRun:false` it WRITES the lease (poll-ownership) — the reason this is dark-first + 2nd-pass-gated.
+
+## 7. Multi-machine posture (Cross-Machine Coherence)
+This IS the cross-machine recovery actuator. Coherence is the deterministic election + the fenced CAS (one winner, pool-wide). The watermarks it reads are machine-local (skew-immune). Single-machine = strict no-op (no leaseCoordinator/peers → `skipped`).
+
+## 8. Rollback cost
+Trivial — ships dark+dryRun (strict no-op until a deliberate enable). Revert the commit, or leave the flag off. No migration, no state. Even enabled-in-dryRun performs zero side effects.
+
+## Second-Pass Review (REQUIRED — high-risk: lease/poll-ownership authority)
+An independent reviewer audited the actuator + coordinator method + cadence. **Verdict: CONCUR.** Verified: (a) the dryRun invariant HOLDS — the gate sits strictly before every port call; default `dryRun:true` (`?? true`) + dev-gated dark-on-fleet; test pins zero side-effects; (b) single-claimant is genuinely the fenced CAS, not the election guess — a partition divergence still admits exactly one (loser → `cas-lost`); (c) no tug-of-war — the won CAS converges with `tickLease`, debounce + self-reverify damp flap; (d) fail directions correct, hardcoded `globalOutageEvidence:false` is the documented local-safe direction + inert under dryRun. **One concern raised (minor, non-blocking given dark+dryRun): no reentrancy guard** on `evaluateNobodyPolling` — a >30s eval could overlap the 30s tick and inflate `_g2SilenceStreak`. **RESOLVED in this commit** (added `_g2Evaluating` guard, mirroring `leaseTicking`). The reviewer's two enforce-ENABLE prerequisites (the pollSucceeded watermark; the globalOutageEvidence plumbing) are tracked in MESH-SELF-HEAL-G2-BUILD.md as the gate before `dryRun:false`.


### PR DESCRIPTION
## ELI16 — what this is, in plain English

When you run one agent across two machines, exactly one is supposed to poll Telegram for your messages. The bug behind the message-drop incidents: a machine holds the "in charge" badge but quietly STOPS polling, so nobody fetches your messages and they silently drop.

The previous PR added the **detector + decision brain** (who should take over). This PR adds the **take-over itself**: when nobody is polling, the one elected machine actually grabs poll-ownership — wins a fenced "who's in charge" race (so only ONE machine ever takes over, never two = the dreaded 409 poll-war), double-checks its own poll health, then starts polling. If it turns out unfit after winning, it hands the badge back and steps aside.

The dangerous part is that this manipulates which machine polls — the exact thing that caused a tug-of-war when done hastily before. So it ships **off by default, and in observe-only (dry-run) mode even when enabled**: it detects, elects, and records what it *would* do, but performs ZERO real actions (no badge grab, no polling change) until a deliberate enforce flip. An independent safety reviewer confirmed the dry-run-does-nothing guarantee holds, that the fenced race (not a guess) is what guarantees a single winner, and that it won't fight the normal lease logic. The one issue the reviewer found (a missing reentrancy guard) is fixed in this PR.

Two prerequisites are tracked before the real enforce flip: a true "my polling is healthy" watermark, and peer-confirmed global-outage detection. Until then it stays observe-only.

## What's included
- `src/core/nobodyPollingActuator.ts` — dependency-injected actuator (dryRun gate → fenced CAS → self-reverify → start polling / relinquish+self-exclude) + 5 unit tests.
- `MultiMachineCoordinator.evaluateNobodyPolling()` — wires detector+election+actuator with the real lease ports; debounced + reentrancy-guarded.
- `server.ts` — 30s cadence (fire-and-forget, gated inside the coordinator).
- `ConfigDefaults` `multiMachine.nobodyPollingRecovery {dryRun:true}` (dev-gated); dark-gate lint golden map updated.

## Second-pass review
Independent reviewer: **CONCUR**. dryRun=zero-side-effects holds; single-claimant is the fenced CAS (partition-safe); no tug-of-war with tickLease. Its reentrancy concern is fixed here.

## Parent principle
Cross-Machine Coherence — One Agent, Robust Under Degraded Conditions