### PR TITLE
feat(mesh-self-heal): G1 core — three-signal zombie-relinquish decision

### DIFF
--- a/.instar/instar-dev-decisions/2026-06-28T09-50-40-448Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-06-28T09-50-40-448Z-unknown.json
@@ -1,0 +1,15 @@
+{
+  "ts": "2026-06-28T09:50:40.448Z",
+  "slug": "unknown",
+  "suggestedTier": 2,
+  "declaredTier": 2,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "new capability: new exported class / subsystem added"
+  ],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 159,
+  "causalAutopsy": null,
+  "verdict": "pass"
+}

--- a/src/core/zombieRelinquish.ts
+++ b/src/core/zombieRelinquish.ts
@@ -1,0 +1,159 @@
+/**
+ * MESH-SELF-HEAL G1 — lease↔job binding via a THREE-SIGNAL liveness model (pure core).
+ *
+ * Spec: MESH-SELF-HEAL-SPEC §3.1. The DEEPEST fix: the "in charge" lease means two
+ * things at once — "I'm the coordinator" AND "I'm actually serving you" — and
+ * conflating them is what let the 2026-06-19/27 zombie hold the badge while serving
+ * nothing. G1 binds the two: a holder that has stopped doing the JOB must relinquish
+ * the badge, decided from THREE machine-local, monotonic liveness signals sourced
+ * from the lifeline's ACTUAL-poll truth (FD10: server-intent ≠ lifeline-actual is
+ * exactly what hid the incident).
+ *
+ * This module is the PURE decision (no I/O) so every branch is unit-testable on both
+ * sides. The caller supplies freshness booleans (computed by comparing each
+ * machine-local monotonic watermark against `jobStaleThresholdMs` on its OWN clock —
+ * never a cross-process/cross-machine monotonic subtraction), the debounce result,
+ * and POSITIVE peer-evidence of a global outage. It is SIGNAL/decision only; the
+ * caller actuates via F3's `relinquishAndBroadcast()` (signed tombstone). Ships DARK.
+ *
+ * The three signals (all machine-local, evaluated by the machine about ITSELF):
+ *   - pollAttemptedMonoMs   — a getUpdates cycle was attempted (alive + trying)
+ *   - pollSucceededMonoMs   — a getUpdates response succeeded (channel reachable)
+ *   - serveProgressedMonoMs — a fetched update was dispatched/served (end-to-end)
+ */
+
+export interface ZombieRelinquishInput {
+  /** This machine currently holds the fenced lease. */
+  holdsLease: boolean;
+  /** The `active` lease role (NOT observe-only/deferential — those are F3's path,
+   *  not G1; finding Int-LOW). G1 only ever acts on an active holder. */
+  isActiveLeaseRole: boolean;
+  /**
+   * Updates are PENDING = `lastFetchedUpdateId > lastServedUpdateId` (the two
+   * poll-side counters) — NOT serve-queue depth, NOT the Telegram-acked offset
+   * (Adv2-F5/Adv3-F-D: the poller advances the offset on FETCH, so "offset not
+   * advanced" would falsely read non-pending even when serve silently dropped).
+   */
+  pending: boolean;
+  /** pollAttemptedMonoMs fresh (within jobStaleThresholdMs, own clock). */
+  pollAttemptedFresh: boolean;
+  /** pollSucceededMonoMs fresh. */
+  pollSucceededFresh: boolean;
+  /** serveProgressedMonoMs fresh (boot-epoch-fenced — a prior incarnation's stamp
+   *  reads as NOT fresh; round-4 Adv4-B). */
+  serveProgressedFresh: boolean;
+  /** The relevant-staleness has PERSISTED across N fresh evaluator ticks (Adv-F8 —
+   *  defeats an evaluator-resume false trip). The caller debounces. */
+  staleConfirmed: boolean;
+  /**
+   * POSITIVE evidence the outage is GLOBAL: a fresh, signed heartbeat from ≥1 live
+   * peer in-window that ALSO reports pollSucceeded-stale. "I can't hear any peer"
+   * must NEVER set this true (Adv2-F2 — a heartbeat-transport partition is not a
+   * global outage; misreading it would HOLD and protect a real zombie).
+   */
+  peerConfirmsGlobalOutage: boolean;
+}
+
+export type ZombieRelinquishAction =
+  | 'not-applicable'      // not an active holder — G1 does not act (F3 owns observe-only)
+  | 'healthy'             // the relevant liveness signal is fresh — keep serving
+  | 'await-confirm'       // relevant-stale but not yet confirmed across N ticks
+  | 'hold-global'         // confirmed-stale BUT peer-confirmed global outage → HOLD + route to G2
+  | 'relinquish'          // confirmed LOCAL staleness → relinquish (safe direction; G2 backstops)
+  | 'relinquish-wedged';  // poll loop itself wedged (pollAttempted stale) → relinquish unconditionally
+
+export interface ZombieRelinquishDecision {
+  action: ZombieRelinquishAction;
+  /** Should the caller run relinquishAndBroadcast() now? */
+  relinquish: boolean;
+  /** Short machine-readable reason for the audit log. */
+  reason: string;
+}
+
+/**
+ * Decide whether an active lease-HOLDER is a zombie that must relinquish. Pure;
+ * the caller actuates only on `relinquish` (quiesce the renew path + draw a
+ * tombstone nonce > the highest it will emit this epoch, then relinquishAndBroadcast).
+ */
+export function decideZombieRelinquish(input: ZombieRelinquishInput): ZombieRelinquishDecision {
+  const {
+    holdsLease, isActiveLeaseRole, pending,
+    pollAttemptedFresh, pollSucceededFresh, serveProgressedFresh,
+    staleConfirmed, peerConfirmsGlobalOutage,
+  } = input;
+
+  // G1 only acts on an ACTIVE holder. A non-holder / observe-only / deferential
+  // machine is handled elsewhere (F3 / G2), never here.
+  if (!holdsLease || !isActiveLeaseRole) {
+    return { action: 'not-applicable', relinquish: false, reason: 'not-an-active-holder' };
+  }
+
+  // The relevant liveness signal: end-to-end SERVE progress when updates are
+  // pending, else the poll-SUCCESS heartbeat when idle (no pending work to serve).
+  const relevantStale = pending ? !serveProgressedFresh : !pollSucceededFresh;
+  if (!relevantStale) {
+    return { action: 'healthy', relinquish: false, reason: pending ? 'serve-progressing' : 'poll-succeeding' };
+  }
+
+  // Debounce: a single stale read is not a zombie (an evaluator-resume blip).
+  if (!staleConfirmed) {
+    return { action: 'await-confirm', relinquish: false, reason: 'stale-not-yet-confirmed' };
+  }
+
+  // The poll LOOP itself is wedged (not even attempting) → relinquish unconditionally;
+  // a wedged holder serves nothing and HOLD cannot be justified.
+  if (!pollAttemptedFresh) {
+    return { action: 'relinquish-wedged', relinquish: true, reason: 'poll-loop-wedged-pollattempted-stale' };
+  }
+
+  // pollAttempted is fresh (alive + trying) but the channel/serve is stale. Only a
+  // POSITIVE peer confirmation that the outage is shared justifies HOLD; absent it,
+  // treat as LOCAL failure and relinquish (the safe direction — G2 picks a server).
+  if (peerConfirmsGlobalOutage) {
+    return { action: 'hold-global', relinquish: false, reason: 'global-outage-peer-confirmed-hold' };
+  }
+  return { action: 'relinquish', relinquish: true, reason: 'local-failure-relinquish-safe-direction' };
+}
+
+/**
+ * G1 soak/observability ledger — evaluable evidence (mirrors G2/G3 close-the-loop).
+ * Counts each decision-class transition. SIGNAL only.
+ */
+export interface ZombieRelinquishLedgerSummary {
+  evaluations: number;
+  relinquishedLocal: number;
+  relinquishedWedged: number;
+  heldGlobal: number;
+  healthy: number;
+  awaitConfirm: number;
+  firstAt: string | null;
+  lastAt: string | null;
+}
+
+export class ZombieRelinquishLedger {
+  private s: ZombieRelinquishLedgerSummary = {
+    evaluations: 0, relinquishedLocal: 0, relinquishedWedged: 0, heldGlobal: 0,
+    healthy: 0, awaitConfirm: 0, firstAt: null, lastAt: null,
+  };
+
+  record(decision: ZombieRelinquishDecision, nowIso: string): void {
+    if (decision.action === 'not-applicable') return; // a non-holder is a non-event
+    this.s.evaluations += 1;
+    switch (decision.action) {
+      case 'relinquish': this.s.relinquishedLocal += 1; break;
+      case 'relinquish-wedged': this.s.relinquishedWedged += 1; break;
+      case 'hold-global': this.s.heldGlobal += 1; break;
+      case 'healthy': this.s.healthy += 1; break;
+      case 'await-confirm': this.s.awaitConfirm += 1; break;
+    }
+    if (this.s.firstAt === null) this.s.firstAt = nowIso;
+    this.s.lastAt = nowIso;
+  }
+
+  summary(): ZombieRelinquishLedgerSummary {
+    return { ...this.s };
+  }
+}
+
+/** Process-wide shared G1 ledger (mirrors sharedG2NobodyPollingLedger). */
+export const sharedG1ZombieRelinquishLedger = new ZombieRelinquishLedger();

--- a/tests/unit/zombieRelinquish.test.ts
+++ b/tests/unit/zombieRelinquish.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect } from 'vitest';
+import {
+  decideZombieRelinquish,
+  ZombieRelinquishLedger,
+  type ZombieRelinquishInput,
+} from '../../src/core/zombieRelinquish.js';
+
+// A healthy active holder; override per case.
+function base(over: Partial<ZombieRelinquishInput> = {}): ZombieRelinquishInput {
+  return {
+    holdsLease: true,
+    isActiveLeaseRole: true,
+    pending: false,
+    pollAttemptedFresh: true,
+    pollSucceededFresh: true,
+    serveProgressedFresh: true,
+    staleConfirmed: true,
+    peerConfirmsGlobalOutage: false,
+    ...over,
+  };
+}
+
+describe('decideZombieRelinquish — G1 three-signal lease↔job binding', () => {
+  it('not a holder → not-applicable (never relinquishes)', () => {
+    const d = decideZombieRelinquish(base({ holdsLease: false }));
+    expect(d.action).toBe('not-applicable');
+    expect(d.relinquish).toBe(false);
+  });
+
+  it('holder but observe-only/deferential (not active role) → not-applicable (F3 owns it)', () => {
+    const d = decideZombieRelinquish(base({ isActiveLeaseRole: false }));
+    expect(d.action).toBe('not-applicable');
+  });
+
+  it('idle + poll succeeding → healthy', () => {
+    const d = decideZombieRelinquish(base({ pending: false, pollSucceededFresh: true }));
+    expect(d.action).toBe('healthy');
+    expect(d.relinquish).toBe(false);
+  });
+
+  it('pending + serve progressing → healthy (serve signal is what matters when pending)', () => {
+    // poll-success STALE but serve progressing while pending → still healthy.
+    const d = decideZombieRelinquish(base({ pending: true, serveProgressedFresh: true, pollSucceededFresh: false }));
+    expect(d.action).toBe('healthy');
+    expect(d.reason).toBe('serve-progressing');
+  });
+
+  it('idle keys on pollSucceeded — serve stale while idle is NOT a zombie', () => {
+    // idle (no pending work): a stale serveProgressed is irrelevant; poll fresh → healthy.
+    const d = decideZombieRelinquish(base({ pending: false, pollSucceededFresh: true, serveProgressedFresh: false }));
+    expect(d.action).toBe('healthy');
+    expect(d.reason).toBe('poll-succeeding');
+  });
+
+  it('relevant-stale but not yet confirmed across ticks → await-confirm (no relinquish)', () => {
+    const d = decideZombieRelinquish(base({ pending: false, pollSucceededFresh: false, staleConfirmed: false }));
+    expect(d.action).toBe('await-confirm');
+    expect(d.relinquish).toBe(false);
+  });
+
+  it('confirmed-stale + poll loop WEDGED (pollAttempted stale) → relinquish-wedged (unconditional)', () => {
+    const d = decideZombieRelinquish(base({
+      pending: false, pollSucceededFresh: false, staleConfirmed: true, pollAttemptedFresh: false,
+    }));
+    expect(d.action).toBe('relinquish-wedged');
+    expect(d.relinquish).toBe(true);
+  });
+
+  it('confirmed-stale + trying + peer CONFIRMS global outage → hold-global (do NOT relinquish)', () => {
+    const d = decideZombieRelinquish(base({
+      pending: false, pollSucceededFresh: false, staleConfirmed: true,
+      pollAttemptedFresh: true, peerConfirmsGlobalOutage: true,
+    }));
+    expect(d.action).toBe('hold-global');
+    expect(d.relinquish).toBe(false);
+  });
+
+  it('confirmed-stale + trying + NO peer evidence → relinquish (LOCAL failure, safe direction)', () => {
+    // "I can't hear any peer" ≠ global outage: peerConfirmsGlobalOutage stays false →
+    // relinquish so G2 picks a server (never HOLD on unproven global blindness).
+    const d = decideZombieRelinquish(base({
+      pending: false, pollSucceededFresh: false, staleConfirmed: true,
+      pollAttemptedFresh: true, peerConfirmsGlobalOutage: false,
+    }));
+    expect(d.action).toBe('relinquish');
+    expect(d.relinquish).toBe(true);
+  });
+
+  it('pending + serve STALE + confirmed + trying + no peer → relinquish (fetched-and-dropped zombie)', () => {
+    const d = decideZombieRelinquish(base({
+      pending: true, serveProgressedFresh: false, staleConfirmed: true,
+      pollAttemptedFresh: true, peerConfirmsGlobalOutage: false,
+    }));
+    expect(d.action).toBe('relinquish');
+    expect(d.relinquish).toBe(true);
+  });
+});
+
+describe('ZombieRelinquishLedger — evaluable soak evidence', () => {
+  const t = '2026-06-28T00:00:00.000Z';
+  it('counts each class; not-applicable is a non-event', () => {
+    const led = new ZombieRelinquishLedger();
+    led.record({ action: 'relinquish', relinquish: true, reason: 'x' }, t);
+    led.record({ action: 'relinquish-wedged', relinquish: true, reason: 'x' }, t);
+    led.record({ action: 'hold-global', relinquish: false, reason: 'x' }, t);
+    led.record({ action: 'healthy', relinquish: false, reason: 'x' }, t);
+    led.record({ action: 'await-confirm', relinquish: false, reason: 'x' }, t);
+    led.record({ action: 'not-applicable', relinquish: false, reason: 'x' }, t);
+    const s = led.summary();
+    expect(s.evaluations).toBe(5);
+    expect(s.relinquishedLocal).toBe(1);
+    expect(s.relinquishedWedged).toBe(1);
+    expect(s.heldGlobal).toBe(1);
+    expect(s.healthy).toBe(1);
+    expect(s.awaitConfirm).toBe(1);
+  });
+});

--- a/upgrades/next/mesh-self-heal-g1-core.md
+++ b/upgrades/next/mesh-self-heal-g1-core.md
@@ -1,0 +1,20 @@
+## What Changed
+
+Mesh Self-Heal **G1 — core decision logic** (increment 1 of the lease↔job binding, MESH-SELF-HEAL-SPEC §3.1). Adds `src/core/zombieRelinquish.ts`: the PURE, deterministic decision for the deepest fix — the "in charge" lease currently means two things at once ("I'm the coordinator" AND "I'm actually serving you"), and conflating them is what let a machine hold the badge while serving nothing. G1 binds them: an active holder that has stopped doing the JOB must relinquish.
+
+- `decideZombieRelinquish` — three-signal liveness (pollAttempted / pollSucceeded / serveProgressed, all machine-local, about the machine ITSELF): `not-applicable` for a non-active-holder; `healthy`; `await-confirm` (debounced); `relinquish-wedged` (poll loop dead → unconditional); `hold-global` (only on POSITIVE peer evidence the outage is shared — "can't hear a peer" ≠ global); `relinquish` (confirmed LOCAL failure → safe direction, G2 backstops). Pending work keys on serve-progress; idle keys on poll-success.
+- `ZombieRelinquishLedger` — evaluable soak evidence (mirrors G2/G3).
+
+Pure decision logic, NOT yet wired — ZERO runtime effect until the next increment (the three-signal watermark plumbing incl. the new `state/serve-progress.json` record + the tickLease holder-branch wiring + F3 relinquish actuation) consumes it.
+
+## Evidence
+
+- `tests/unit/zombieRelinquish.test.ts` — 11 unit tests covering both sides of every branch: not-a-holder / observe-only → not-applicable; healthy (pending→serve, idle→poll); await-confirm; relinquish-wedged; hold-global (peer-confirmed); relinquish (no peer evidence = safe direction); fetched-and-dropped zombie; ledger accounting. Typecheck clean.
+
+## What to Tell Your User
+
+Nothing changes yet — inert internal decision logic for the deepest part of the multi-machine self-heal, not active anywhere. When the full feature lands, a machine that holds the "in charge" badge but has quietly stopped fetching/serving your messages will automatically hand the badge off (instead of sitting on it while messages drop) — and exactly one healthy machine takes over. No action needed.
+
+## Summary of New Capabilities
+
+- None user-facing in this increment. New internal module `src/core/zombieRelinquish.ts` (pure decision core) consumed by a later wiring increment; no route, config flag, or runtime surface added yet.

--- a/upgrades/side-effects/mesh-self-heal-g1-core.md
+++ b/upgrades/side-effects/mesh-self-heal-g1-core.md
@@ -1,0 +1,32 @@
+# Side-Effects Review — Mesh Self-Heal G1 (core decision logic)
+
+**Change:** The PURE decision core of G1 (lease↔job binding via a three-signal liveness model) from MESH-SELF-HEAL-SPEC §3.1 — `src/core/zombieRelinquish.ts` (`decideZombieRelinquish` + `ZombieRelinquishLedger`) + 11 unit tests. This is increment 1 of G1: the decision only. It is NOT YET WIRED to any tick, watermark plumbing, or actuation — ZERO runtime effect until a later increment consumes it.
+
+**Decision point?** The module encodes a decision (is an active holder a zombie that must relinquish?), but nothing CALLS it yet, so there is no live decision-point in this increment. Signal-vs-authority assessed (Q4).
+
+## 1. Over-block
+N/A — unwired. By design it biases AGAINST relinquishing: `not-applicable` for a non-active-holder; `healthy` when the relevant signal is fresh; `await-confirm` until the staleness persists across N ticks. It only relinquishes on a CONFIRMED zombie.
+
+## 2. Under-block
+As pure logic, none in-scope. The KNOWN not-yet-built pieces (tracked, not orphan-deferred — see MESH-SELF-HEAL-G2-BUILD.md / spec §3.1): the three-signal watermark plumbing (`pollAttempted/SucceededMonoMs` from `lifeline-poll-active.json`; `serveProgressedMonoMs` in a NEW single-writer `state/serve-progress.json` with a boot-epoch fence), the `lastFetched>lastServed` pending counters, the per-tick debounce, the positive-peer-evidence global-outage signal, and the tickLease holder-branch wiring + F3 `relinquishAndBroadcast` actuation (with the tombstone-nonce quiesce). Until those land, this module is inert.
+
+## 3. Level-of-abstraction fit
+Correct. A pure decision module mirroring `nobodyPollingRecovery.ts` (G2) / `leaseGatedSpawn.ts` (G3) — no I/O, fully unit-testable, consumed by a thin wiring layer later. It encodes the spec's exact rule: pending → serveProgressed signal, idle → pollSucceeded signal; wedged poll loop → unconditional relinquish; "can't hear a peer" ≠ global (only positive peer evidence HOLDs).
+
+## 4. Signal vs authority compliance
+COMPLIANT. Pure function, no I/O, no authority. The actual authority (`relinquishAndBroadcast` — a signed tombstone) lives in the lease coordinator, which the future wiring calls; this module only DECIDES. The decision keys ONLY on machine-local signals about the machine ITSELF (never a peer-observed value driving a relinquish; finding Sec-F1) — the structural defense against a skew/partition-induced false relinquish.
+
+## 5. Interactions
+None in this increment (unwired). Intended (wiring increment): reads the lifeline-actual truth (FD10) + the new serve-progress record; the relinquish runs F3's path; it composes with G2 (a relinquished holder lets G2's single-claimant pick a server) and G3 (the lease it binds is the same fence G3's spawn gate reads).
+
+## 6. External surfaces
+None yet. No route, config flag, or watermark write in this increment — pure logic. The exported `sharedG1ZombieRelinquishLedger` singleton mirrors the G2/G3 ledgers; written/read only once the wiring lands.
+
+## 7. Multi-machine posture (Cross-Machine Coherence)
+This IS the deepest cross-machine coherence fix — binding "holds the lease" to "actually serving" so a zombie holder self-relinquishes. The three watermarks are machine-local, never replicated (Sca-F1), evaluated by each machine about ITSELF (skew-immune — no foreign-monotonic subtraction). The decision is local; coherence emerges because a zombie relinquishes and G2's fenced single-claimant picks the successor.
+
+## 8. Rollback cost
+Trivial — revert the commit. Unreferenced by any runtime path, so removing it cannot affect a running agent. No config, no migration, no state.
+
+## Second-pass review
+Not triggered for this increment (unwired pure logic, no live decision-point / block-allow authority / session-lifecycle touch). The Phase-5 second-pass IS required for the WIRING increment (it consumes lease-relinquish authority + adds cross-process watermark plumbing) and is flagged for that increment.


### PR DESCRIPTION
## ELI16 — what this is, in plain English

The deepest fix in the multi-machine self-heal. Right now the "in charge" badge secretly means TWO things at once: "I'm the coordinator" AND "I'm actually fetching/serving your messages." Conflating them is the root cause — a machine kept holding the badge (renewing it fine) while it had quietly stopped fetching, so everything looked healthy while messages silently dropped.

G1 binds the two: a machine that holds the badge but has stopped doing the JOB must hand the badge off. This PR adds the **decision brain** for that — a pure function that decides, from three machine-local health signals about ITSELF (is my poll loop even trying? is it succeeding? am I actually serving fetched messages end-to-end?), whether the holder has become a zombie that must relinquish.

The safety-critical rules baked in: it only judges itself by its OWN signals (never a peer's, which could be a clock/partition artifact); "I can't hear any other machine" is NOT treated as "the whole service is down" (that mistake would protect a real zombie) — only POSITIVE evidence from a live peer that it's *also* failing makes it HOLD; if its poll loop is completely wedged it relinquishes unconditionally; and a single stale reading isn't enough — the staleness must persist across several checks.

**This increment is pure decision logic with ZERO runtime effect** — nothing calls it yet. The next increment wires it to the three health watermarks (including a new serve-progress record) and the actual hand-off, shipping dark like the rest.

## What's included
- `src/core/zombieRelinquish.ts` — `decideZombieRelinquish` + `ZombieRelinquishLedger`. Pure; mirrors the G2/G3 core pattern.
- `tests/unit/zombieRelinquish.test.ts` — 11 tests, both sides of every branch.

## Parent principle
Cross-Machine Coherence — One Agent, Robust Under Degraded Conditions