### PR TITLE
feat(mesh-self-heal): G1 serve-progress watermark (third liveness signal, boot-epoch-fenced)

### DIFF
--- a/.instar/instar-dev-decisions/2026-06-28T10-09-36-886Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-06-28T10-09-36-886Z-unknown.json
@@ -1,0 +1,13 @@
+{
+  "ts": "2026-06-28T10:09:36.886Z",
+  "slug": "unknown",
+  "suggestedTier": 2,
+  "declaredTier": 2,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 109,
+  "causalAutopsy": null,
+  "verdict": "pass"
+}

--- a/.instar/instar-dev-decisions/2026-06-28T10-18-59-948Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-06-28T10-18-59-948Z-unknown.json
@@ -1,0 +1,13 @@
+{
+  "ts": "2026-06-28T10:18:59.948Z",
+  "slug": "unknown",
+  "suggestedTier": 1,
+  "declaredTier": 2,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 5,
+  "causalAutopsy": null,
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-06-28T10-19-52-539Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-06-28T10-19-52-539Z-unknown.json
@@ -1,0 +1,13 @@
+{
+  "ts": "2026-06-28T10:19:52.539Z",
+  "slug": "unknown",
+  "suggestedTier": 1,
+  "declaredTier": 2,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 5,
+  "causalAutopsy": null,
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-06-28T10-20-23-793Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-06-28T10-20-23-793Z-unknown.json
@@ -1,0 +1,13 @@
+{
+  "ts": "2026-06-28T10:20:23.793Z",
+  "slug": "unknown",
+  "suggestedTier": 1,
+  "declaredTier": 2,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 5,
+  "causalAutopsy": null,
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-06-28T10-21-10-222Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-06-28T10-21-10-222Z-unknown.json
@@ -1,0 +1,13 @@
+{
+  "ts": "2026-06-28T10:21:10.222Z",
+  "slug": "unknown",
+  "suggestedTier": 2,
+  "declaredTier": 2,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 114,
+  "causalAutopsy": null,
+  "verdict": "pass"
+}

--- a/src/core/serveProgress.ts
+++ b/src/core/serveProgress.ts
@@ -1,0 +1,114 @@
+/**
+ * MESH-SELF-HEAL G1 — the serve-progress watermark (MESH-SELF-HEAL-SPEC §3.1).
+ *
+ * `serveProgressedMonoMs` is the THIRD liveness signal — stamped when a fetched
+ * update is dispatched/served/durably-enqueued (proves end-to-end progress, closes
+ * the "fetched-and-dropped" gap, finding Adv-F4). It CANNOT share the lifeline's
+ * `lifeline-poll-active.json` (that record is the lifeline PROCESS's, atomically
+ * rewritten on every poll-state change with no serve field — a second-process write
+ * would clobber it). So it lives in its OWN single-writer record `state/serve-progress.json`,
+ * written by the dispatch seam and read cross-process by the relinquish evaluator
+ * (round-2 Int2-D / round-3 Les3-F1 — net-new, deliberately-acknowledged plumbing).
+ *
+ * THE LOAD-BEARING SAFETY: a **boot-epoch fence** (round-4 Adv4-B). Because this is a
+ * persisted file (one process can't read another's memory), a stamp written by a
+ * PRIOR incarnation must NEVER read as fresh after a crash/restart — else a
+ * crash-stale stamp would mask a non-serving new process (re-creating the zombie).
+ * The record carries a `bootId`; the reader discards any stamp whose `bootId` ≠ the
+ * current incarnation (a boot-epoch fence — NOT a raw monotonic compare, which
+ * across incarnations would be an invalid cross-domain subtraction). Within ONE
+ * incarnation the monotonic stamps share a clock domain, so the freshness compare is
+ * valid. The field is a single machine-global monotonic-MAX watermark (NOT per-topic
+ * state) — concurrent dispatch-seam writers are benign because it only ever advances
+ * (round-4 Adv4-A).
+ *
+ * Threat model + write posture mirror `pollIntent.ts`: local same-uid IPC, atomic
+ * tmp+rename so the reader never sees a torn record.
+ */
+
+import { existsSync, readFileSync, renameSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const SERVE_PROGRESS_FILE = 'serve-progress.json';
+
+export interface ServeProgressRecord {
+  /** Monotonic stamp (writer's monotonic clock) at the last served/enqueued update. */
+  serveProgressedMonoMs: number;
+  /** Writer process incarnation marker — the boot-epoch fence. */
+  bootId: string;
+  /** Writer pid (parity with pollIntent; diagnostics only). */
+  serverPid: number;
+  /** Wall-clock of the write (diagnostics; freshness uses the monotonic stamp). */
+  ts: number;
+}
+
+export function serveProgressPath(stateDir: string): string {
+  return join(stateDir, SERVE_PROGRESS_FILE);
+}
+
+export function readServeProgress(stateDir: string): ServeProgressRecord | null {
+  const p = serveProgressPath(stateDir);
+  if (!existsSync(p)) return null;
+  try {
+    const rec = JSON.parse(readFileSync(p, 'utf8')) as ServeProgressRecord;
+    if (
+      typeof rec?.serveProgressedMonoMs !== 'number' ||
+      typeof rec?.bootId !== 'string' ||
+      typeof rec?.ts !== 'number'
+    ) return null;
+    return rec;
+  } catch {
+    // @silent-fallback-ok — a corrupt/unreadable serve-progress record reads as
+    // "no progress yet" (null → serveProgressFresh false), the SAFE direction: a
+    // holder that cannot read its own serve watermark is treated as possibly-non-
+    // serving (a relinquish candidate), NEVER masked as healthy. A DegradationReporter
+    // event per failed read of a best-effort liveness file would be noise.
+    return null;
+  }
+}
+
+/**
+ * Stamp serve progress. Monotonic-MAX: only ever advances — a write with a
+ * `monoMs` not greater than the current record's (SAME incarnation) is dropped, so
+ * concurrent dispatch-seam writers never regress the watermark. A record from a
+ * different `bootId` is always overwritten (a new incarnation starts its own clock
+ * domain; the prior stamp must not survive as fresh — the boot-epoch fence).
+ */
+export function writeServeProgress(
+  stateDir: string,
+  args: { bootId: string; serverPid: number; monoMs: number },
+): void {
+  const { bootId, serverPid, monoMs } = args;
+  const existing = readServeProgress(stateDir);
+  if (existing && existing.bootId === bootId && existing.serveProgressedMonoMs >= monoMs) {
+    return; // monotonic-MAX within the same incarnation — never regress
+  }
+  const p = serveProgressPath(stateDir);
+  const tmp = `${p}.tmp.${process.pid}`;
+  writeFileSync(
+    tmp,
+    JSON.stringify({ serveProgressedMonoMs: monoMs, bootId, serverPid, ts: Date.now() } satisfies ServeProgressRecord),
+    'utf8',
+  );
+  renameSync(tmp, p);
+}
+
+/**
+ * Is serve progress FRESH (the relinquish evaluator's read)? Boot-epoch-fenced:
+ * a stamp from a different incarnation (`bootId` mismatch) is treated as "no
+ * progress yet" (false) — so a crash-stale on-disk stamp can never mask a
+ * non-serving new process. Within the current incarnation the monotonic compare is
+ * a valid same-clock-domain subtraction. `currentBootId` + `currentMonoMs` are
+ * injected (the reader's own incarnation + monotonic now) so this is pure + testable.
+ */
+export function serveProgressFresh(
+  stateDir: string,
+  currentBootId: string,
+  currentMonoMs: number,
+  thresholdMs: number,
+): boolean {
+  const rec = readServeProgress(stateDir);
+  if (!rec) return false;
+  if (rec.bootId !== currentBootId) return false; // boot-epoch fence
+  return currentMonoMs - rec.serveProgressedMonoMs < thresholdMs;
+}

--- a/tests/unit/serveProgress.test.ts
+++ b/tests/unit/serveProgress.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+import {
+  writeServeProgress,
+  readServeProgress,
+  serveProgressFresh,
+} from '../../src/core/serveProgress.js';
+
+let dir: string;
+beforeEach(() => { dir = fs.mkdtempSync(path.join(os.tmpdir(), 'serveprog-')); });
+afterEach(() => { try { SafeFsExecutor.safeRmSync(dir, { recursive: true, force: true, operation: 'tests/unit/serveProgress.test.ts' }); } catch { /* best-effort */ } });
+
+describe('serveProgress — G1 third liveness watermark', () => {
+  it('write → read roundtrip', () => {
+    writeServeProgress(dir, { bootId: 'boot-A', serverPid: 100, monoMs: 5000 });
+    const rec = readServeProgress(dir);
+    expect(rec?.serveProgressedMonoMs).toBe(5000);
+    expect(rec?.bootId).toBe('boot-A');
+    expect(rec?.serverPid).toBe(100);
+  });
+
+  it('missing file → null / not fresh', () => {
+    expect(readServeProgress(dir)).toBeNull();
+    expect(serveProgressFresh(dir, 'boot-A', 9999, 30_000)).toBe(false);
+  });
+
+  it('monotonic-MAX: a lower (or equal) monoMs in the SAME incarnation never regresses', () => {
+    writeServeProgress(dir, { bootId: 'boot-A', serverPid: 100, monoMs: 5000 });
+    writeServeProgress(dir, { bootId: 'boot-A', serverPid: 100, monoMs: 4000 }); // older — dropped
+    writeServeProgress(dir, { bootId: 'boot-A', serverPid: 100, monoMs: 5000 }); // equal — dropped
+    expect(readServeProgress(dir)?.serveProgressedMonoMs).toBe(5000);
+    writeServeProgress(dir, { bootId: 'boot-A', serverPid: 100, monoMs: 6000 }); // newer — advances
+    expect(readServeProgress(dir)?.serveProgressedMonoMs).toBe(6000);
+  });
+
+  it('a NEW incarnation (different bootId) always overwrites (own clock domain)', () => {
+    writeServeProgress(dir, { bootId: 'boot-A', serverPid: 100, monoMs: 9000 });
+    // boot-B's monotonic clock restarts low; it must overwrite, not be blocked by A's high stamp.
+    writeServeProgress(dir, { bootId: 'boot-B', serverPid: 200, monoMs: 10 });
+    const rec = readServeProgress(dir);
+    expect(rec?.bootId).toBe('boot-B');
+    expect(rec?.serveProgressedMonoMs).toBe(10);
+  });
+
+  it('freshness: within threshold (same incarnation) → fresh; past it → stale', () => {
+    writeServeProgress(dir, { bootId: 'boot-A', serverPid: 100, monoMs: 1000 });
+    expect(serveProgressFresh(dir, 'boot-A', 1000 + 10_000, 30_000)).toBe(true);  // 10s < 30s
+    expect(serveProgressFresh(dir, 'boot-A', 1000 + 40_000, 30_000)).toBe(false); // 40s > 30s
+  });
+
+  it('BOOT-EPOCH FENCE: a prior-incarnation stamp reads NOT fresh, even if recent (the zombie-mask guard)', () => {
+    // A crashed process left a fresh-looking stamp under boot-A; the new process is boot-B.
+    writeServeProgress(dir, { bootId: 'boot-A', serverPid: 100, monoMs: 1000 });
+    // boot-B reads: even with currentMonoMs right next to the stamp, the bootId mismatch
+    // forces NOT fresh — so a crash-stale stamp can never mask a non-serving new process.
+    expect(serveProgressFresh(dir, 'boot-B', 1000 + 1, 30_000)).toBe(false);
+  });
+});

--- a/upgrades/next/mesh-self-heal-g1-serve-progress.md
+++ b/upgrades/next/mesh-self-heal-g1-serve-progress.md
@@ -1,0 +1,19 @@
+## What Changed
+
+Mesh Self-Heal **G1 — serve-progress watermark** (wiring increment A, MESH-SELF-HEAL-SPEC §3.1). Adds `src/core/serveProgress.ts`: the third liveness signal (`serveProgressedMonoMs` — proof a fetched update was actually served end-to-end, closing the "fetched-and-dropped" gap), in its own single-writer record `state/serve-progress.json`.
+
+The load-bearing safety is a **boot-epoch fence**: a stamp left on disk by a crashed/prior process incarnation always reads as NOT fresh, so a crash-stale stamp can never mask a non-serving new process (which would re-create the zombie). Monotonic-MAX (only ever advances → concurrent writers benign), atomic tmp+rename, local same-uid IPC — mirrors `pollIntent.ts`.
+
+Pure plumbing, NOT yet wired — zero runtime effect until increment B (the dispatch-seam write + the relinquish evaluator) consumes it. This watermark is also the prerequisite that lets the G2 take-over flip use a real serve/poll-health signal instead of a liveness approximation.
+
+## Evidence
+
+- `tests/unit/serveProgress.test.ts` — 6 unit tests: write/read roundtrip; missing→null/not-fresh; monotonic-MAX no-regress; new-incarnation overwrite; freshness within/past threshold; and the BOOT-EPOCH FENCE (a prior-incarnation stamp reads not-fresh even when recent). Typecheck clean.
+
+## What to Tell Your User
+
+Nothing changes yet — this is inert internal plumbing for the deepest multi-machine self-heal piece (detecting a machine that holds the "in charge" badge but has stopped actually serving). No action needed.
+
+## Summary of New Capabilities
+
+- None user-facing. New internal record `state/serve-progress.json` + helpers (`src/core/serveProgress.ts`), consumed by a later wiring increment; no route, config, or runtime surface yet.

--- a/upgrades/side-effects/mesh-self-heal-g1-serve-progress.md
+++ b/upgrades/side-effects/mesh-self-heal-g1-serve-progress.md
@@ -1,0 +1,32 @@
+# Side-Effects Review — Mesh Self-Heal G1 (serve-progress watermark)
+
+**Change:** The serve-progress watermark record (MESH-SELF-HEAL-SPEC §3.1) — `src/core/serveProgress.ts` (`writeServeProgress` / `readServeProgress` / `serveProgressFresh`) + 6 unit tests. The THIRD G1 liveness signal (`serveProgressedMonoMs` — end-to-end serve progress), in its OWN single-writer record `state/serve-progress.json` (it cannot share the lifeline's poll-active record without clobbering it). This is G1-wiring increment A: the watermark plumbing only. NOT YET CALLED by any writer or reader — ZERO runtime effect until increment B (the dispatch-seam write + the relinquish evaluator) consumes it. It is also the named **G2-enforce-enable prerequisite #1** (`localPollSucceededFresh` graduates from a liveness approximation to this real watermark).
+
+**Decision point?** No — pure file I/O (a watermark record). Safety hinges on the boot-epoch fence (Q1/Q7).
+
+## 1. Over-block
+N/A — no gating. `serveProgressFresh` biases SAFE: missing record → false; bootId mismatch → false; only a same-incarnation in-threshold stamp → true.
+
+## 2. Under-block
+The boot-epoch fence is the guard against under-blocking (a crash-stale stamp masking a non-serving process): a prior incarnation's stamp (`bootId` mismatch) always reads NOT fresh. Tested.
+
+## 3. Level-of-abstraction fit
+Mirrors `pollIntent.ts` exactly (atomic tmp+rename, local same-uid IPC, integrity fields). Correct layer — a cross-process record + a pure freshness reader; the dispatch-seam wiring + the evaluator are increment B.
+
+## 4. Signal vs authority compliance
+COMPLIANT — pure I/O, no authority. It produces a freshness SIGNAL the relinquish decision will read; it never gates or actuates.
+
+## 5. Interactions
+Single-writer, monotonic-MAX → concurrent dispatch-seam writers are benign (only advances). Distinct file from `lifeline-poll-active.json` → no clobber of the lifeline's record. No reader/writer yet.
+
+## 6. External surfaces
+New file `state/serve-progress.json` (local, same-uid, like pollIntent). No route, no config. Written/read only once increment B wires it.
+
+## 7. Multi-machine posture (Cross-Machine Coherence)
+Machine-local, never replicated (Sca-F1) — read only by the owning machine for its OWN relinquish decision. The boot-epoch fence makes it survive-restart-safe (a prior incarnation's stamp can't mask the new one). No cross-machine surface.
+
+## 8. Rollback cost
+Trivial — revert the commit. Unreferenced; removing it cannot affect a running agent. The on-disk file (if ever written) is inert observability.
+
+## Second-pass review
+Not triggered (pure file-I/O building block, no live decision-point/authority/session-lifecycle touch). The Phase-5 second-pass IS required for increment B (it wires the dispatch-seam write + the relinquish evaluator into the lease holder branch + the F3 actuation).


### PR DESCRIPTION
## ELI16 — what this is, in plain English

The deepest self-heal piece (G1) decides whether a machine holding the "in charge" badge has secretly stopped doing the job, using three health signals. This PR adds the third + trickiest signal: **proof that the machine is actually SERVING fetched messages end-to-end** (not just fetching them and dropping them).

It lives in its own small file (`state/serve-progress.json`) because it can't share the existing poll-status file without overwriting it. The genuinely important safety bit is a **boot-epoch fence**: if a machine crashes and restarts, the old "I served recently" stamp left on disk must NOT count for the fresh process — otherwise a crashed-then-restarted-but-not-actually-serving machine would look healthy (exactly the zombie this whole effort kills). So every stamp is tagged with which process-incarnation wrote it, and the reader ignores any stamp from a previous incarnation.

This is pure plumbing — a writer + reader + freshness check — with **zero runtime effect** until the next increment wires it into the actual hand-off decision. It's also the missing piece that lets the G2 take-over use a real serve-health signal instead of a rough approximation.

## What's included
- `src/core/serveProgress.ts` — `writeServeProgress` (monotonic-MAX, atomic) / `readServeProgress` / `serveProgressFresh` (boot-epoch-fenced). Mirrors `pollIntent.ts`.
- `tests/unit/serveProgress.test.ts` — 6 tests, incl. the boot-epoch fence (a prior-incarnation stamp reads not-fresh even when recent).

## Parent principle
Cross-Machine Coherence — One Agent, Robust Under Degraded Conditions