### PR TITLE
feat(mesh-self-heal): G1 serve-progress dispatch-seam write (third signal goes live)

### DIFF
--- a/.instar/instar-dev-decisions/2026-06-28T10-46-05-482Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-06-28T10-46-05-482Z-unknown.json
@@ -1,0 +1,15 @@
+{
+  "ts": "2026-06-28T10:46:05.482Z",
+  "slug": "unknown",
+  "suggestedTier": 2,
+  "declaredTier": 2,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "new capability: new config key added"
+  ],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 16,
+  "causalAutopsy": null,
+  "verdict": "pass"
+}

--- a/src/server/routes.ts
+++ b/src/server/routes.ts
@@ -14,6 +14,8 @@ import { sharedG3SoakLedger, decideLeaseGatedSpawn } from '../core/leaseGatedSpa
 import { getHostSpawnSemaphore, configuredSpawnAcquireMs, configuredSpawnWaitersMax } from '../core/hostSpawnSemaphore.js';
 import { activeSpawnPollers } from '../core/SpawnCapIntelligenceProvider.js';
 import { poolPollerVerdict } from '../core/pollerCount.js';
+import { writeServeProgress } from '../core/serveProgress.js';
+import { getCurrentBootId } from './boot-id.js';
 import { decideNobodyPollingClaim, sharedG2NobodyPollingLedger } from '../core/nobodyPollingRecovery.js';
 import { canonicalPushKey } from '../core/PrHandLease.js';
 import { enrollPaneSessionName } from '../core/FrameworkLoginDriver.js';
@@ -16038,6 +16040,20 @@ document.getElementById('mcpForm').addEventListener('submit', async function (e)
         console.error(`[telegram-forward] exactly-once gate error (fail-open, routing normally): ${err instanceof Error ? err.message : err}`);
       }
     }
+
+    // G1 (MESH-SELF-HEAL-SPEC §3.1) — stamp serve-progress: this machine just
+    // committed to PROCESSING a fetched update (past dedup-drop + sentinel-stop),
+    // i.e. end-to-end progress on inbound. The relinquish evaluator reads this
+    // (serveProgressedMonoMs) to tell a serving holder from a fetched-and-dropped
+    // zombie. Machine-global monotonic-MAX watermark; boot-epoch-fenced. Best-effort
+    // — a write failure must never affect routing.
+    try {
+      writeServeProgress(ctx.config.stateDir, {
+        bootId: getCurrentBootId() ?? `boot-${process.pid}`,
+        serverPid: process.pid,
+        monoMs: performance.now(),
+      });
+    } catch { /* @silent-fallback-ok — serve-progress is a best-effort liveness watermark; never block routing */ }
 
     // Agent-to-agent Telegram comms hook (spec MENTOR-LIVE-READINESS §Recipient side).
     // The polling path invokes this gate inside the adapter; lifeline-forwarded messages

--- a/tests/integration/serve-progress-dispatch-seam.test.ts
+++ b/tests/integration/serve-progress-dispatch-seam.test.ts
@@ -1,0 +1,79 @@
+/**
+ * Wiring-integrity test (MESH-SELF-HEAL-SPEC §3.1): the /internal/telegram-forward
+ * dispatch seam ACTUALLY writes the serve-progress watermark when the server commits
+ * to processing a fetched update. Proves serveProgressedMonoMs is sourced from the
+ * real serve path (not a no-op) — the signal the relinquish evaluator reads.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import express from 'express';
+import request from 'supertest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { createRoutes } from '../../src/server/routes.js';
+import type { RouteContext } from '../../src/server/routes.js';
+import { readServeProgress } from '../../src/core/serveProgress.js';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+import { ProcessIntegrity } from '../../src/core/ProcessIntegrity.js';
+
+let stateDir: string;
+beforeEach(() => {
+  stateDir = fs.mkdtempSync(path.join(os.tmpdir(), 'serveseam-'));
+  // The handler caches a server version at route-registration; without it the
+  // forward 503s "server-boot-incomplete" before reaching the serve-progress write.
+  ProcessIntegrity.initialize('1.3.690');
+});
+afterEach(() => {
+  ProcessIntegrity.reset();
+  try { SafeFsExecutor.safeRmSync(stateDir, { recursive: true, force: true, operation: 'tests/integration/serve-progress-dispatch-seam.test.ts' }); } catch { /* best-effort */ }
+});
+
+function ctx(): RouteContext {
+  return {
+    // authToken '' → the version handshake is skipped (no lifelineVersion needed).
+    config: { projectName: 'echo', projectDir: path.dirname(stateDir), stateDir, port: 0, authToken: '' } as any,
+    sessionManager: { listRunningSessions: () => [] } as any,
+    state: { getJobState: () => null, getSession: () => null, getCoherenceJournal: () => null } as any,
+    // No sentinel / no messageLedger → the handler reaches the serve-progress write,
+    // then falls through to routing. telegram stub satisfies the pre-write calls.
+    telegram: {
+      logInboundMessage: () => {},
+      // Return handled=true so the handler short-circuits right AFTER the
+      // serve-progress write (which is before the a2a hook) — avoids exercising
+      // the full downstream user-routing/spawn path in this wiring test.
+      dispatchAgentMessageHook: async () => true,
+      getSessionForTopic: () => null,
+      sendToTopic: async () => {},
+    } as any,
+    scheduler: null, relationships: null, feedback: null, dispatches: null,
+    updateChecker: null, autoUpdater: null, autoDispatcher: null, quotaTracker: null,
+    publisher: null, viewer: null, tunnel: null, evolution: null, watchdog: null,
+    triageNurse: null, topicMemory: null, feedbackAnomalyDetector: null, discoveryEvaluator: null,
+    correctionLedger: null, coordinator: null,
+    startTime: new Date(),
+  } as any;
+}
+
+function app(): express.Express {
+  const a = express();
+  a.use(express.json());
+  a.use('/', createRoutes(ctx()));
+  return a;
+}
+
+describe('serve-progress dispatch-seam wiring', () => {
+  it('writes serve-progress.json when the forward handler processes a fetched update', async () => {
+    expect(readServeProgress(stateDir)).toBeNull(); // nothing yet
+    // POST WITHOUT lifelineVersion → version handshake skipped; no sentinel/ledger →
+    // the handler reaches the serve-progress write before routing.
+    await request(app())
+      .post('/internal/telegram-forward')
+      .send({ topicId: 1, text: 'hello', messageId: 'm-1', fromFirstName: 'T' });
+    // Regardless of how the later routing resolves, the watermark must be stamped.
+    const rec = readServeProgress(stateDir);
+    expect(rec).not.toBeNull();
+    expect(typeof rec!.serveProgressedMonoMs).toBe('number');
+    expect(typeof rec!.bootId).toBe('string');
+    expect(rec!.serverPid).toBe(process.pid);
+  });
+});

--- a/upgrades/next/mesh-self-heal-g1-dispatch-seam.md
+++ b/upgrades/next/mesh-self-heal-g1-dispatch-seam.md
@@ -1,0 +1,17 @@
+## What Changed
+
+Mesh Self-Heal **G1 — serve-progress dispatch-seam write** (wiring increment B1, MESH-SELF-HEAL-SPEC §3.1). Wires `writeServeProgress` into the `/internal/telegram-forward` handler — right after a fetched update is claimed for processing (past dedup-drop + sentinel-stop) — so the third liveness watermark (`serveProgressedMonoMs`) records REAL end-to-end serve progress instead of sitting unwritten.
+
+This makes the §3.1 third signal live: a machine that is actually serving fetched updates advances the watermark; a fetched-and-dropped zombie does not. Unconditional + best-effort (a write failure never affects routing); the watermark is still unread until the next increment (the relinquish evaluator).
+
+## Evidence
+
+- `tests/integration/serve-progress-dispatch-seam.test.ts` — drives the real `/internal/telegram-forward` handler and asserts `state/serve-progress.json` is written (with a monotonic stamp, bootId, serverPid) when the handler processes a fetched update. Typecheck clean.
+
+## What to Tell Your User
+
+Nothing changes in behavior — this is inert internal plumbing recording a health watermark (whether this machine is actually serving fetched messages) for the deepest multi-machine self-heal piece. No action needed.
+
+## Summary of New Capabilities
+
+- None user-facing. The serve-progress watermark (`state/serve-progress.json`) now records real data at the inbound dispatch seam; consumed by a later relinquish-evaluator increment.

--- a/upgrades/side-effects/mesh-self-heal-g1-dispatch-seam.md
+++ b/upgrades/side-effects/mesh-self-heal-g1-dispatch-seam.md
@@ -1,0 +1,32 @@
+# Side-Effects Review — Mesh Self-Heal G1 (serve-progress dispatch-seam write)
+
+**Change:** Wires `writeServeProgress` into the `/internal/telegram-forward` handler (`src/server/routes.ts`) — right after the exactly-once ingress gate claims a fetched update for processing (past dedup-drop + sentinel-stop), so the serve-progress watermark records REAL end-to-end progress. + 1 integration (wiring) test. This makes the §3.1 third liveness signal live; the reader (the relinquish evaluator) is increment B2.
+
+**Decision point?** No — it WRITES an observability watermark; it gates/decides nothing. (Like `writePollActive`, unconditional + best-effort.)
+
+## 1. Over-block
+N/A — writes only, blocks nothing. Placed AFTER the dedup-drop + sentinel-stop returns, so a dropped duplicate / emergency-stop does NOT stamp serve-progress (correct — those aren't "serve progress").
+
+## 2. Under-block
+N/A. The watermark is unread until increment B2 (the relinquish evaluator). Stamping at the exactly-once-claim point means "the server committed to processing a fetched update" — the liveness B2 needs.
+
+## 3. Level-of-abstraction fit
+Correct seam: the telegram-forward handler is where lifeline-fetched updates arrive + are dispatched (the WS1.1 dispatch path for lifeline-owned-polling agents). The write reuses the merged `serveProgress.ts` module.
+
+## 4. Signal vs authority compliance
+COMPLIANT — pure observability write, no authority. It produces the serveProgressed SIGNAL; the relinquish decision (authority) is a separate, gated increment.
+
+## 5. Interactions
+Monotonic-MAX + machine-global → concurrent dispatch writes only advance (benign). Distinct file from `lifeline-poll-active.json` → no clobber. Best-effort try/catch (`@silent-fallback-ok`) → a write failure never affects routing. Boot-epoch-fenced at read time (the reader discards a prior-incarnation stamp).
+
+## 6. External surfaces
+Writes `state/serve-progress.json` on every processed inbound (local, same-uid, tiny, atomic — like `pollIntent`/`pollActive`). No route, no config, no user-visible change. Not flag-gated because it is pure observability plumbing (the consuming evaluator is the gated piece).
+
+## 7. Multi-machine posture (Cross-Machine Coherence)
+Machine-local, never replicated — each machine stamps its OWN serve progress for its OWN future relinquish decision. The boot-epoch fence makes it survive-restart-safe.
+
+## 8. Rollback cost
+Trivial — revert the one block. The file is inert (unread until B2). No migration, no behavior change to serving.
+
+## Second-pass review
+Not triggered: an observability watermark write with no decision/authority/session-lifecycle effect (it stamps a liveness file; it does not gate, kill, or route differently). The Phase-5 second-pass IS required for increment B2 (the relinquish evaluator wired into the lease holder-branch + the F3 actuation).


### PR DESCRIPTION
## ELI16 — what this is, in plain English

G1 (the deepest self-heal piece) decides whether a machine holding the "in charge" badge has secretly stopped doing the job, using three health signals. The third + trickiest signal — "am I actually SERVING fetched messages end-to-end?" — has a recording file (added in the previous PR) but nothing was writing to it yet. This PR wires the actual write: every time the server commits to processing an inbound message (after duplicate-drops and emergency-stops are filtered out), it stamps the serve-progress watermark.

So now a machine that's genuinely serving advances the mark; a machine that fetches messages but drops them (the zombie) does not. The write is unconditional, tiny, atomic, and best-effort — a write failure can never affect message routing. The mark is still unread until the final increment (the hand-off decision) consumes it.

## What's included
- `src/server/routes.ts` — `writeServeProgress(...)` at the `/internal/telegram-forward` dispatch seam, right after the exactly-once claim (so dedup-drops/stops don't count). Best-effort `@silent-fallback-ok`.
- `tests/integration/serve-progress-dispatch-seam.test.ts` — drives the real handler and asserts the watermark file is written.

## Parent principle
Cross-Machine Coherence — One Agent, Robust Under Degraded Conditions