### PR TITLE
feat(mesh-self-heal): G1 zombie-relinquish evaluator — lease↔job binding complete (dark+dryRun, 2nd-pass concurred)

### DIFF
--- a/.instar/instar-dev-decisions/2026-06-28T11-15-22-132Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-06-28T11-15-22-132Z-unknown.json
@@ -1,0 +1,15 @@
+{
+  "ts": "2026-06-28T11:15:22.132Z",
+  "slug": "unknown",
+  "suggestedTier": 2,
+  "declaredTier": 2,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "new capability: new config key added"
+  ],
+  "belowFloor": false,
+  "files": 2,
+  "loc": 115,
+  "causalAutopsy": null,
+  "verdict": "pass"
+}

--- a/src/config/ConfigDefaults.ts
+++ b/src/config/ConfigDefaults.ts
@@ -880,6 +880,13 @@ const SHARED_DEFAULTS: Record<string, unknown> = {
     // deliberate enforce promotion (gated on the pollSucceeded-watermark plumbing +
     // the Phase-5 second-pass live-verify on the real pair).
     nobodyPollingRecovery: { dryRun: true },
+    // G1 zombie self-relinquish (lease↔job binding, MESH-SELF-HEAL-SPEC §3.1). OMIT
+    // `enabled` ⇒ dev-agent gate; dryRun:true ⇒ the holder-branch evaluator detects
+    // a confirmed zombie + records "would relinquish" but performs NO actuation (no
+    // relinquishAndBroadcast). Flipping dryRun:false is the deliberate enforce
+    // promotion (gated on the pollSucceeded/serve watermark refinements + the
+    // Phase-5 second-pass live-verify on the real pair).
+    zombieRelinquish: { dryRun: true },
     // multi-transport-mesh-comms (Layers 0-2) — multi-rope mesh transport
     // (Tailscale/LAN/Cloudflare hedged failover). Ships ENABLED (strictly additive;
     // a single-machine agent is a no-op and keeps its 127.0.0.1 bind — the 0.0.0.0

--- a/src/core/MultiMachineCoordinator.ts
+++ b/src/core/MultiMachineCoordinator.ts
@@ -31,6 +31,9 @@ import { resolveDevAgentGate } from './devAgentGate.js';
 import { poolPollerVerdict } from './pollerCount.js';
 import { decideNobodyPollingClaim, sharedG2NobodyPollingLedger } from './nobodyPollingRecovery.js';
 import { applyNobodyPollingRecovery } from './nobodyPollingActuator.js';
+import { serveProgressFresh } from './serveProgress.js';
+import { decideZombieRelinquish, sharedG1ZombieRelinquishLedger } from './zombieRelinquish.js';
+import { getCurrentBootId } from '../server/boot-id.js';
 import { DegradationReporter } from '../monitoring/DegradationReporter.js';
 import type { MachineRole, MachineIdentity, MultiMachineConfig, CoordinationMode } from './types.js';
 
@@ -634,6 +637,102 @@ export class MultiMachineCoordinator extends EventEmitter {
     };
   }
 
+  // ── G1 zombie self-relinquish (lease↔job binding) — MESH-SELF-HEAL-SPEC §3.1 ──
+  private _g1RelinquishStreak = 0;
+  private _g1Evaluating = false;
+  private static readonly G1_CONFIRM_OBSERVATIONS = 3;
+  private static readonly G1_STALE_THRESHOLD_MS = 90_000;
+
+  /** G1 gate: dark+dryRun-first (dev-gated). Flipping dryRun:false (the deliberate
+   *  enforce promotion) is what lets a confirmed zombie actually relinquish. */
+  private zombieRelinquishCfg(): { enabled: boolean; dryRun: boolean } {
+    const m = this.config.multiMachine as { zombieRelinquish?: { enabled?: boolean; dryRun?: boolean } } | undefined;
+    return {
+      enabled: resolveDevAgentGate(m?.zombieRelinquish?.enabled, this.config),
+      dryRun: m?.zombieRelinquish?.dryRun ?? true,
+    };
+  }
+
+  /**
+   * G1 evaluator — called from tickLease's HOLDER branch each tick. Reads the three
+   * machine-local liveness watermarks (about THIS machine), debounces the relevant
+   * staleness, runs the deterministic zombie-relinquish decision, records evidence,
+   * and — only on a confirmed zombie AND `dryRun:false` — relinquishes the lease
+   * (signed tombstone). DARK + dryRun-first: gate off ⇒ strict no-op; dryRun ⇒
+   * records "would relinquish", touches NOTHING.
+   *
+   * Watermark sourcing (FD10 — lifeline-ACTUAL truth, not server intent):
+   *  - serveProgressedMonoMs ← state/serve-progress.json, read with getCurrentBootId()
+   *    (the SAME boot id the dispatch seam wrote with — NOT this.bootId, which is a
+   *    distinct per-coordinator id) so the boot-epoch fence matches; `performance.now()`
+   *    is the shared same-process clock domain for the freshness subtraction.
+   *  - poll signals ← lifeline-poll-active.json (ts-fresh = attempted; +pollingActive
+   *    = succeeded). These are liveness approximations; richer per-signal monotonic
+   *    stamps + the lastFetched>lastServed `pending` counters + positive-peer
+   *    global-outage evidence are enforce-ENABLE refinements (consulted only at
+   *    dryRun:false). With them unwired: pending defaults false (idle→pollSucceeded
+   *    path) and globalOutage defaults false (the local-failure-SAFE direction).
+   */
+  async evaluateZombieRelinquish(
+    nowMonoMs: number,
+    nowIso: string,
+  ): Promise<{ skipped?: string; decision?: string; relinquished?: boolean }> {
+    const cfg = this.zombieRelinquishCfg();
+    if (!cfg.enabled || !this.leaseCoordinator || !this._identity) {
+      return { skipped: 'disabled-or-single-machine' };
+    }
+    if (!this.leaseCoordinator.holdsLease()) {
+      this._g1RelinquishStreak = 0; // only a holder can be a zombie
+      return { skipped: 'not-holder' };
+    }
+    if (this._g1Evaluating) return { skipped: 'already-evaluating' };
+    this._g1Evaluating = true;
+    try {
+      const threshold = MultiMachineCoordinator.G1_STALE_THRESHOLD_MS;
+      const bootId = getCurrentBootId();
+      // serve-progress freshness needs the dispatch-seam's boot id; if the boot id
+      // isn't initialized yet (server not fully up), don't evaluate (skip — never
+      // relinquish on an un-evaluable serve signal).
+      if (!bootId) return { skipped: 'boot-id-not-ready' };
+      const serveProgressedFresh = serveProgressFresh(this.config.stateDir, bootId, nowMonoMs, threshold);
+      const pa = readPollActive(this.config.stateDir);
+      const pollFresh = !!pa && pidAlive(pa.pid) && (Date.now() - pa.ts) < threshold;
+      const pollAttemptedFresh = pollFresh;
+      const pollSucceededFresh = pollFresh && pa!.pollingActive === true;
+      const pending = false; // refinement: lastFetched>lastServed counters not yet plumbed
+      // Debounce the relevant-stale signal (Adv-F8 — an evaluator-resume blip alone never trips).
+      const relevantStale = pending ? !serveProgressedFresh : !pollSucceededFresh;
+      if (relevantStale) this._g1RelinquishStreak += 1; else this._g1RelinquishStreak = 0;
+      const staleConfirmed = this._g1RelinquishStreak >= MultiMachineCoordinator.G1_CONFIRM_OBSERVATIONS;
+      const decision = decideZombieRelinquish({
+        holdsLease: true,
+        isActiveLeaseRole: this._role === 'awake',
+        pending,
+        pollAttemptedFresh,
+        pollSucceededFresh,
+        serveProgressedFresh,
+        staleConfirmed,
+        peerConfirmsGlobalOutage: false, // refinement → local-failure-safe direction
+      });
+      sharedG1ZombieRelinquishLedger.record(decision, nowIso);
+      if (decision.relinquish && !cfg.dryRun) {
+        // Quiesce + relinquish (signed tombstone). Best-effort — a failure retries next tick.
+        try {
+          await this.leaseCoordinator.relinquishAndBroadcast();
+          this._g1RelinquishStreak = 0;
+          console.log(`[MultiMachine] [g1-relinquish] zombie holder relinquished (${decision.reason})`);
+        } catch (err) {
+          console.error(`[MultiMachine] [g1-relinquish] relinquish failed: ${(err as Error).message}`);
+        }
+      } else if (decision.relinquish && cfg.dryRun) {
+        console.log(`[MultiMachine] [g1-relinquish] DRY-RUN would relinquish (${decision.reason})`);
+      }
+      return { decision: decision.action, relinquished: decision.relinquish && !cfg.dryRun };
+    } finally {
+      this._g1Evaluating = false;
+    }
+  }
+
   /**
    * G2 enforce evaluator — the SERVER calls this on its cadence with the live pool
    * capacities (which carry each machine's lifeline-actual `pollingActive`). It
@@ -961,7 +1060,14 @@ export class MultiMachineCoordinator extends EventEmitter {
         // F1a — bounded await: a hung renew can never wedge the tick.
         await this.withTickTimeout('renew', () => this.leaseCoordinator!.renew());
         this.reconcileRoleToLease('lease-tick');
-      } else if (this.shouldDeferToPreferred()) {
+        // G1 (MESH-SELF-HEAL-SPEC §3.1) — a holder that has stopped doing the JOB
+        // (serve/poll watermarks stale) relinquishes the badge so a healthy machine
+        // takes over. DARK + dryRun-gated INSIDE the evaluator (strict no-op when
+        // off; records-only in dryRun). `performance.now()` matches the dispatch
+        // seam's serve-progress clock domain (same process). Best-effort — a slow/
+        // failed eval must never wedge the lease tick.
+        await this.evaluateZombieRelinquish(performance.now(), new Date().toISOString())
+          .catch(() => { /* @silent-fallback-ok — G1 eval is best-effort; retried next tick */ });
         // F4 (preferred-awake, opt-in) — we are NON-preferred and observe the
         // preferred machine holding a HEALTHY lease: defer, do not contend. If the
         // preferred goes down/unhealthy, shouldDeferToPreferred() flips false and we

--- a/tests/unit/lint-dev-agent-dark-gate.test.ts
+++ b/tests/unit/lint-dev-agent-dark-gate.test.ts
@@ -453,10 +453,16 @@ describe('lint-dev-agent-dark-gate', () => {
       // DEV_GATED_FEATURES), so it adds NO new attributed path; it only shifts every
       // sessionPool-onward `enabled: false` line DOWN by +7. RE-VERIFIED via the
       // attributor on the edited ConfigDefaults (path set unchanged, uniform +7).
-      '1067': 'multiMachine.sessionPool.enabled',
-      '1093': 'multiMachine.sessionPool.ownershipCheckedSpawn.enabled',
-      '1103': 'multiMachine.sessionPool.inboundQueue.enabled',
-      '1132': 'multiMachine.sessionPool.holdForStability.enabled',
+      // mesh-self-heal G1 zombieRelinquish (2026-06-28): a NEW
+      // multiMachine.zombieRelinquish block (`{ dryRun: true }` + ~7-line comment)
+      // was inserted right after nobodyPollingRecovery (ABOVE sessionPool). It OMITS
+      // `enabled` (dev-gated via resolveDevAgentGate), so NO new attributed path; it
+      // only shifts every sessionPool-onward `enabled: false` line DOWN by +7.
+      // RE-VERIFIED via the attributor on the edited ConfigDefaults (uniform +7).
+      '1074': 'multiMachine.sessionPool.enabled',
+      '1100': 'multiMachine.sessionPool.ownershipCheckedSpawn.enabled',
+      '1110': 'multiMachine.sessionPool.inboundQueue.enabled',
+      '1139': 'multiMachine.sessionPool.holdForStability.enabled',
       // mm-stores-devgate (operator directive 2026-06-13, topic 13481): the 7
       // multiMachine.stateSync.* memory stores MOVED from DARK_GATE_EXCLUSIONS to
       // DEV_GATED_FEATURES and their `enabled: false` literals were REMOVED from
@@ -491,10 +497,11 @@ describe('lint-dev-agent-dark-gate', () => {
       // After merging JKHeadley/main + my accountFollowMe block, these resolve as below.
       // RE-VERIFIED by hand via the attributor on the MERGED ConfigDefaults.
       // (+7 from the nobodyPollingRecovery block above — see the sessionPool note.)
-      '1301': 'multiMachine.stateSync.threadlinePairing.enabled',
-      '1423': 'cartographer.freshnessSweep.enabled',
-      '1468': 'cartographer.conformanceAudit.llmEnrichment.enabled',
-      '1493': 'cartographer.subtreeNav.llmRerank.enabled',
+      // (+7 from the zombieRelinquish block above — see the sessionPool note.)
+      '1308': 'multiMachine.stateSync.threadlinePairing.enabled',
+      '1430': 'cartographer.freshnessSweep.enabled',
+      '1475': 'cartographer.conformanceAudit.llmEnrichment.enabled',
+      '1500': 'cartographer.subtreeNav.llmRerank.enabled',
     };
     const actual = attributeRealConfigDefaults();
     expect(actual).toEqual(EXPECTED);

--- a/upgrades/next/mesh-self-heal-g1-evaluator.md
+++ b/upgrades/next/mesh-self-heal-g1-evaluator.md
@@ -1,0 +1,18 @@
+## What Changed
+
+Mesh Self-Heal **G1 zombie-relinquish evaluator** (the FINAL G1 piece, MESH-SELF-HEAL-SPEC §3.1). Wires `decideZombieRelinquish` into `MultiMachineCoordinator.tickLease()`'s holder branch via `evaluateZombieRelinquish()`: each tick, a lease-HOLDER reads its three machine-local liveness watermarks (poll-attempted / poll-succeeded / serve-progressed), debounces the relevant staleness (3 ticks), and — on a confirmed zombie — relinquishes the badge so a healthy machine takes over (via G2's single-claimant). This completes the lease↔job binding: holding the badge now requires actually doing the job.
+
+Ships **dark + dryRun-first** (`multiMachine.zombieRelinquish`, dev-gated): gate-off is a strict no-op; dryRun records "would relinquish" and performs NO actuation. Two independent gates (`enabled` + `dryRun`) protect the relinquish. A key correctness fix: the serve-progress watermark is read with the SAME boot id the dispatch seam wrote with (`getCurrentBootId()`), so the boot-epoch fence matches. Flipping `dryRun:false` (the enforce promotion) is gated on tracked refinements (the pending counters, peer global-outage evidence, the boot-id-null fallback reconciliation) + a live-verify on the real pair.
+
+## Evidence
+
+- Builds on the merged pure `decideZombieRelinquish` (11 unit tests) + `serveProgress` (6 unit tests) + the dispatch-seam write. Dark-gate lint golden map updated (+7); no-silent-fallbacks ratchet at baseline; typecheck clean; G1 unit suite green.
+- Independent Phase-5 second-pass review: **CONCUR** (dryRun safety guaranteed; the bootId-consistency fix correct; false-relinquish safe; no tick-wedge). One non-blocking enforce-enable note recorded.
+
+## What to Tell Your User
+
+When this is turned on (it ships off, observe-only for now), it fixes the root cause behind the message-drop incidents: a machine that holds the "in charge" badge but has quietly stopped fetching/serving your messages will automatically hand the badge off — instead of sitting on it while messages drop — and a healthy machine takes over. No action needed; single-machine setups are unaffected.
+
+## Summary of New Capabilities
+
+- `multiMachine.zombieRelinquish` `{ dryRun }` — opt-in (dev-gated) zombie self-relinquish: a lease-holder that has stopped serving gives up the badge. Dark + dryRun by default (observe-only; zero actuation until a deliberate enforce promotion).

--- a/upgrades/side-effects/mesh-self-heal-g1-evaluator.md
+++ b/upgrades/side-effects/mesh-self-heal-g1-evaluator.md
@@ -1,0 +1,33 @@
+# Side-Effects Review — Mesh Self-Heal G1 (zombie-relinquish evaluator)
+
+**Change:** The FINAL G1 piece (MESH-SELF-HEAL-SPEC §3.1) — `MultiMachineCoordinator.evaluateZombieRelinquish()` wired into `tickLease()`'s HOLDER branch (after renew). HIGH-RISK: it makes a holder GIVE UP the fenced awake-lease when its three machine-local liveness watermarks go stale. Ships DARK + dryRun-first behind `multiMachine.zombieRelinquish` (dev-gated). + `zombieRelinquishCfg()` gate, debounce (`_g1RelinquishStreak`, confirm=3), reentrancy guard (`_g1Evaluating`), ConfigDefaults block, dark-gate golden-map +7.
+
+**Decision point?** YES — relinquish authority. The dryRun safety invariant + the bootId-consistency fix are load-bearing.
+
+## 1. Over-block
+N/A (it relinquishes, never blocks). Biases against relinquishing: not-a-holder → skip; relevant signal fresh → healthy; stale → debounced 3 ticks; only a confirmed zombie relinquishes.
+
+## 2. Under-block
+Ships dark+dryRun → no actuation until a deliberate `dryRun:false`. **Enforce-ENABLE prerequisites (TRACKED):** (1) the `lastFetched>lastServed` `pending` counters (currently `pending=false` → keys on pollSucceeded; serveProgressedFresh is computed but inert until pending is wired); (2) positive-peer `globalOutageEvidence` (currently false → local-failure-safe direction); (3) the boot-id-null writer/reader fallback asymmetry (writer falls back to `boot-${pid}`, reader SKIPS on null — reconcile before flipping `pending` live; raised by the 2nd-pass). All inert under dryRun.
+
+## 3. Level-of-abstraction fit
+The authority (relinquishAndBroadcast) lives in the leaseCoordinator; the evaluator only decides + calls it. Mirrors `evaluateNobodyPolling`. Reads watermarks via the merged `serveProgress`/`pollIntent` modules.
+
+## 4. Signal vs authority compliance
+COMPLIANT: the only authority (relinquish) fires ONLY when `decision.relinquish && !dryRun`, double-gated (enabled + dryRun). The decision keys on machine-local-about-itself signals (Sec-F1) — never a peer value drives a relinquish.
+
+## 5. Interactions
+- **bootId consistency (the key correctness fix):** serve-progress is WRITTEN with `getCurrentBootId()` (routes.ts dispatch seam) and READ with `getCurrentBootId()` here — NOT `this.bootId` (a distinct `${pid}-${hrtime}`). Using `this.bootId` would always mismatch the boot-epoch fence → serve never fresh → false zombie. Confirmed correct by the 2nd-pass. `performance.now()` is the shared same-process clock for the freshness subtraction.
+- vs tickLease: runs AFTER renew+reconcile in the holder branch; relinquish (when enabled) hands off → next tick the machine is a non-holder → skip. Debounce + reentrancy guard prevent flap/overlap.
+
+## 6. External surfaces
+New config `multiMachine.zombieRelinquish` (dev-gated). When `dryRun:false` it WRITES the lease (relinquish) — the reason it ships dark + 2nd-pass-gated. Records to `sharedG1ZombieRelinquishLedger`.
+
+## 7. Multi-machine posture (Cross-Machine Coherence)
+The deepest cross-machine fix: binds lease-holding to actually-serving. Machine-local watermarks (skew-immune); the relinquish lets G2's fenced single-claimant pick the successor. Single-machine = no leaseCoordinator → strict no-op.
+
+## 8. Rollback cost
+Trivial — ships dark+dryRun (strict no-op). Revert or leave the flag off. No migration.
+
+## Second-Pass Review (REQUIRED — high-risk: lease-relinquish authority)
+Independent reviewer: **CONCUR.** (a) dryRun safety GUARANTEED — relinquish reachable only under `!cfg.dryRun`, double-gated by `enabled` (dev-gate, false on fleet); shipped `dryRun ?? true`. (b) The bootId fix is CORRECT — reader uses `getCurrentBootId()` (same source as the writer), not `this.bootId`; `performance.now()` same clock domain. (c)/(d) False-relinquish safe — `pending=false` keys on pollSucceeded (serveProgressedFresh inert until enforce-enable); debounce + isActiveLeaseRole + null-bootId skip + no-poll-active→wedged-only-after-confirm; global-outage=false is the safe direction. (e) reentrancy guard + `.catch` + try/finally → can't wedge/double-fire. **One non-blocking note** (enforce-ENABLE prerequisite, NOT a merge blocker given dark+dryRun): the boot-id-null writer-fallback vs reader-skip asymmetry — reconcile before flipping `pending` live. Recorded in §2 above.


### PR DESCRIPTION
## ELI16 — what this is, in plain English

The FINAL piece of the multi-machine self-heal, and the deepest. The root cause behind the whole saga: a machine could hold the "in charge" badge (renewing it perfectly) while it had quietly stopped fetching/serving messages — so everything looked healthy while messages silently dropped. The badge meant "I'm the coordinator" but said nothing about "I'm actually doing the job."

This wires the decision brain into the lease loop: every tick, a machine holding the badge checks its own three health signals (is my poll loop trying? succeeding? am I actually serving messages end-to-end?). If it's a confirmed zombie — stale across several checks — it gives up the badge, so a healthy machine takes over (via the take-over piece already built). Holding the badge now structurally requires doing the job.

This is the riskiest spot in the whole effort (giving up the badge wrongly = coverage loss / tug-of-war), so it ships **off by default, observe-only even when enabled** (it records "would relinquish" but does nothing), behind two independent gates, and an independent safety reviewer confirmed: it can't relinquish in observe mode, a key boot-identity correctness fix is right (else a healthy machine would look like a zombie), and a healthy holder won't wrongly give up. The reviewer's one note (a boot-id edge case) is tracked as a prerequisite before the real turn-on.

With this, the entire self-heal family (duplicate-prevention + nobody-serving take-over + badge↔job binding) is built and shipping dark — ready for a careful staged turn-on with live verification on the real two machines.

## What's included
- `src/core/MultiMachineCoordinator.ts` — `evaluateZombieRelinquish()` + `zombieRelinquishCfg()` gate + debounce + reentrancy guard, wired into `tickLease()`'s holder branch. Reads serve-progress with `getCurrentBootId()` (the bootId-consistency fix).
- `src/config/ConfigDefaults.ts` — `multiMachine.zombieRelinquish { dryRun: true }` (dev-gated); dark-gate golden map +7.

## Second-pass review
Independent reviewer: **CONCUR** — dryRun safety guaranteed (double-gated); the bootId fix correct; false-relinquish safe; no tick-wedge. One non-blocking enforce-enable note recorded.

## Parent principle
Cross-Machine Coherence — One Agent, Robust Under Degraded Conditions