### PR TITLE
fix(tone-gate): deterministic floor no longer blocks legitimate click-links

### DIFF
--- a/.instar/instar-dev-decisions/2026-06-28T18-35-24-129Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-06-28T18-35-24-129Z-unknown.json
@@ -1,0 +1,13 @@
+{
+  "ts": "2026-06-28T18:35:24.129Z",
+  "slug": "unknown",
+  "suggestedTier": 1,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 37,
+  "causalAutopsy": null,
+  "verdict": "pass"
+}

--- a/docs/specs/tonegate-floor-click-links.eli16.md
+++ b/docs/specs/tonegate-floor-click-links.eli16.md
@@ -1,0 +1,54 @@
+# ELI16 — Tone-gate floor stops blocking clickable links
+
+## What this is, in plain English
+
+Every message an Instar agent sends to its user passes through a safety gate
+(the "tone gate") that checks for leaks — things the user should never see, like
+raw shell commands, file paths, or internal endpoints meant for the agent to
+call itself, not for the user to run. Normally a smart LLM does that check, and
+it's clever enough to tell the difference between "here's a link to **open** in
+your browser" and "here's an endpoint to **call** with curl."
+
+But when that LLM is slow or down (e.g. the account is rate-limited), the gate
+falls back to a dumb, fast, pattern-only check called the **deterministic floor**
+so a user is never silently cut off during an outage. The problem: that dumb
+floor couldn't tell a clickable link from a callable endpoint. So during an
+outage it would **block every link the agent tried to share** — a private-view
+report, a dashboard link, a Secret-Drop one-time URL, a Telegraph page, a file
+download. This broke link-sharing for **all agents** whenever the LLM was
+degraded. It's exactly what just happened when an agent tried to send a Secret
+Drop link.
+
+## What already exists
+
+- The tone gate (`MessagingToneGate`) with its LLM judge (rules B1–B20).
+- The LLM path **already** carves out clickable links by intent (open-vs-call).
+- The deterministic floor (`detectDeterministicLeak`) used when the LLM can't
+  answer — this is the only piece that was missing the carve-out.
+
+## What's new
+
+A small helper, `scrubClickLinksForFloor(text)`, that runs **before** the floor's
+pattern scan. It removes `http(s)://…` URLs that are shared as click destinations
+so their host/port/path/token don't trip the floor's "looks like an endpoint"
+detectors — **unless** the text actually contains a call instruction (a `curl`/
+`wget` command, an uppercase `POST/GET …` against a URL, or an imperative like
+"hit the endpoint"). In that case nothing is scrubbed and the floor blocks as
+before. The floor then scans the scrubbed copy.
+
+## Safeguards in plain terms
+
+- It only ever **loosens a false positive on clickable links** — it can never let
+  a new kind of leak through.
+- It strips **only** scheme'd URLs. File paths, CLI commands, config keys,
+  internal ids, and every other leak class are left fully intact for the floor.
+- The moment a real "run this" instruction appears, the scrub backs off entirely
+  and the floor behaves exactly as it does today.
+- The LLM path is untouched — it keeps its existing intent-based judgment.
+
+## What you need to decide
+
+Nothing risky. This is a safe-direction bug fix: it stops the floor from
+blocking legitimate links during an LLM outage, while still holding real command/
+path/secret leaks. It's always-on (no flag) because the old behavior was simply
+wrong — there's no value in keeping the false positive available.

--- a/src/core/MessagingToneGate.ts
+++ b/src/core/MessagingToneGate.ts
@@ -49,15 +49,48 @@ export type DegradeReason = 'provider-error' | 'budget-timeout';
  * covered here — a slightly-off-tone message reaching the user beats silence,
  * but a secret/path/command leak must never escape, even during an outage.
  */
+/**
+ * Neutralize legitimate user-facing CLICK links before the deterministic floor
+ * scans the text, so a link the agent shares for the user to OPEN (a private
+ * view, tunnel, dashboard, Secret-Drop, Telegraph, or download URL) is not
+ * hard-blocked by the floor's api-endpoint / cron-or-slug signal detectors —
+ * which, unlike the LLM judge, cannot tell "open this in your browser" from
+ * "call this endpoint." This mirrors the LLM path's intent-based B5 carve-out
+ * (open-vs-call) at the floor.
+ *
+ * SAFETY: the scrub is suppressed (text returned UNCHANGED) the moment the text
+ * carries any CALL instruction — a shell fetch tool (curl/wget/xh/httpie), an
+ * uppercase HTTP method against a URL/path, or an imperative "hit/call/invoke
+ * the endpoint/url/api" phrase. So a genuine "run this curl" never escapes; only
+ * a bare clickable URL shared as a destination is removed before signal-scan.
+ * It ONLY strips scheme'd http(s) URLs — file paths, CLI commands, config keys,
+ * internal ids, and every other leak class are left fully intact for the floor.
+ */
+export function scrubClickLinksForFloor(text: string): string {
+  const CALL_CMD = /\b(?:curl|wget|xh|httpie)\b/i;
+  const CALL_METHOD = /\b(?:POST|GET|PUT|PATCH|DELETE)\s+(?:https?:\/\/|\/)/;
+  // Note: the article group carries its OWN trailing \s+ (no adjacent \s+…\s*),
+  // so a long whitespace run can't be split ambiguously — linear, no ReDoS.
+  const CALL_PHRASE =
+    /\b(?:hit|call|invoke|issue|send)\s+(?:(?:this|the|a)\s+)?(?:endpoint|url|api|request)\b/i;
+  if (CALL_CMD.test(text) || CALL_METHOD.test(text) || CALL_PHRASE.test(text)) {
+    return text;
+  }
+  return text.replace(/https?:\/\/[^\s)\]]+/gi, ' ');
+}
+
 export function detectDeterministicLeak(
   text: string,
 ): { rule: string; kind: string } | null {
-  for (const sig of detectGateSignals(text)) {
+  // Scan with click-destination URLs neutralized (unless a call-instruction is
+  // present) so a legitimate "open this link" message survives the floor.
+  const scanText = scrubClickLinksForFloor(text);
+  for (const sig of detectGateSignals(scanText)) {
     if (sig.detected) {
       return { rule: GATE_SIGNAL_KIND_TO_RULE[sig.kind], kind: sig.kind };
     }
   }
-  if (detectInternalIdLeak(text).leaked) {
+  if (detectInternalIdLeak(scanText).leaked) {
     return { rule: 'B20_INTERNAL_ID_LEAK', kind: 'internal-id-leak' };
   }
   return null;

--- a/tests/unit/MessagingToneGate.test.ts
+++ b/tests/unit/MessagingToneGate.test.ts
@@ -4,7 +4,11 @@
  */
 
 import { describe, it, expect, vi } from 'vitest';
-import { MessagingToneGate } from '../../src/core/MessagingToneGate.js';
+import {
+  MessagingToneGate,
+  detectDeterministicLeak,
+  scrubClickLinksForFloor,
+} from '../../src/core/MessagingToneGate.js';
 import type { IntelligenceProvider, IntelligenceOptions } from '../../src/core/types.js';
 
 function mockProvider(responseFn: (prompt: string) => string | Promise<string>): IntelligenceProvider {
@@ -691,6 +695,91 @@ describe('MessagingToneGate', () => {
       );
       expect(blockResult.pass).toBe(false);
       expect(blockResult.rule).toBe('B5_API_ENDPOINT');
+    });
+  });
+
+  // tonegate-floor-click-links: the deterministic floor (used when the LLM judge
+  // times out / errors) must NOT hard-block a legitimate user-facing CLICK link
+  // (a private view, tunnel, dashboard, Secret-Drop, Telegraph, download URL) —
+  // the LLM path already carves these out by intent; the floor did not, so a
+  // backend outage turned every shared link into a blocked message fleet-wide.
+  describe('deterministic floor — click-link carve-out (tonegate-floor-click-links)', () => {
+    const CLICK_LINKS = [
+      ['Secret Drop', 'Here is your one-time link to drop the key: https://abc-123.trycloudflare.com/secrets/drop/9f3a-2b1c'],
+      ['private view', 'I put the report here: http://localhost:4040/view/report-2026-06-28'],
+      ['dashboard', 'Open the dashboard: https://xyz.trycloudflare.com/dashboard?tab=files&path=docs/x.md'],
+      ['Telegraph', 'Published it publicly: https://telegra.ph/My-Page-06-28'],
+      ['download', 'Grab the file: http://localhost:4040/api/files/download?path=.claude/CLAUDE.md'],
+    ] as const;
+
+    for (const [label, msg] of CLICK_LINKS) {
+      it(`PASSES a ${label} click-link on the floor (no false hold)`, () => {
+        expect(detectDeterministicLeak(msg)).toBeNull();
+      });
+    }
+
+    it('still HOLDS a real CLI call instruction even when a URL is present', () => {
+      const leak = detectDeterministicLeak(
+        'To check, run: curl http://localhost:4042/commitments',
+      );
+      expect(leak).not.toBeNull();
+    });
+
+    it('still HOLDS an uppercase HTTP-method call against a URL', () => {
+      const leak = detectDeterministicLeak('POST https://localhost:4042/attention with that body');
+      expect(leak).not.toBeNull();
+    });
+
+    it('still HOLDS an imperative "hit the endpoint" call phrase with a URL', () => {
+      const leak = detectDeterministicLeak('hit the endpoint at https://localhost:4042/tunnel');
+      expect(leak).not.toBeNull();
+    });
+
+    it('still HOLDS a no-article call phrase ("call api") with a URL', () => {
+      const leak = detectDeterministicLeak('call api https://localhost:4042/commitments');
+      expect(leak).not.toBeNull();
+    });
+
+    it('scrubClickLinksForFloor runs in linear time on a long whitespace run (no ReDoS)', () => {
+      // A trigger verb followed by a huge whitespace run was the O(n²) backtracking
+      // shape; the hardened CALL_PHRASE must return promptly.
+      const adversarial = 'call' + ' '.repeat(200_000) + 'x https://a.com/y';
+      const start = Date.now();
+      scrubClickLinksForFloor(adversarial);
+      expect(Date.now() - start).toBeLessThan(200);
+    });
+
+    it('still HOLDS a file-path leak — scrub only removes scheme URLs', () => {
+      const leak = detectDeterministicLeak('see /Users/justin/.instar/config.json');
+      expect(leak?.rule).toBe('B2_FILE_PATH');
+    });
+
+    it('still HOLDS a bare CLI command leak alongside a click-link', () => {
+      const leak = detectDeterministicLeak(
+        'Open https://x.trycloudflare.com/view/abc — but first I ran: rm -rf node_modules && pnpm i',
+      );
+      expect(leak).not.toBeNull();
+    });
+
+    it('scrubClickLinksForFloor strips a scheme URL but leaves prose intact', () => {
+      expect(scrubClickLinksForFloor('open https://a.com/x/y now')).not.toMatch(/https?:\/\//);
+    });
+
+    it('scrubClickLinksForFloor leaves a curl call-instruction line UNCHANGED', () => {
+      const t = 'run: curl https://localhost:4042/x';
+      expect(scrubClickLinksForFloor(t)).toBe(t);
+    });
+
+    it('DEGRADES and SENDS a Secret-Drop link via review() when the provider throws (end-to-end)', async () => {
+      const provider = errorProvider(new Error('network timeout'));
+      const gate = new MessagingToneGate(provider);
+      const result = await gate.review(
+        'Your one-time Secret Drop link: https://abc-123.trycloudflare.com/secrets/drop/9f3a',
+        { channel: 'telegram' },
+      );
+      expect(result.pass).toBe(true);
+      expect(result.degradedToDeterministic).toBe(true);
+      expect(result.failedClosed).toBeFalsy();
     });
   });
 });

--- a/upgrades/next/tonegate-floor-click-links.md
+++ b/upgrades/next/tonegate-floor-click-links.md
@@ -1,0 +1,53 @@
+<!-- bump: patch -->
+
+## What Changed
+
+Tone-gate deterministic-floor **click-link carve-out** (fixes the floor blocking
+legitimate user-facing links during an LLM outage). When the LLM tone-judge is
+slow or unavailable, outbound messages fall back to a fast pattern-only
+"deterministic floor" so the user is never silently cut off (the F4
+graceful-degradation path). That floor could not tell a clickable link from a
+callable endpoint, so it hard-blocked **every** link an agent tried to share —
+private views, dashboard links, Secret-Drop one-time URLs, Telegraph pages, file
+downloads — fleet-wide, whenever the LLM was degraded.
+
+The fix adds `scrubClickLinksForFloor`: before the floor's signal scan, scheme'd
+`http(s)://…` URLs shared as click destinations are neutralized so their
+host/port/path/token don't trip the floor's "looks like an endpoint" detectors —
+**unless** the text carries a real call instruction (`curl`/`wget`, an uppercase
+HTTP method against a URL, or "hit/call/invoke … the endpoint"), in which case
+nothing is scrubbed and the floor blocks as before. This mirrors the LLM path's
+existing intent-based (open-vs-call) carve-out, now at the degraded floor too.
+Safe-direction only: it loosens a false positive on clickable links and never
+lets a command, file path, config key, secret, or internal id escape.
+
+## What to Tell Your User
+
+You'll notice this only as the absence of a bug: when my LLM backend is
+rate-limited or slow, a link I send you (a report, a dashboard, a one-time
+Secret-Drop link) now actually reaches you instead of being silently held.
+Nothing to configure — it's always on, and it never weakens the gate that keeps
+raw commands and secrets out of our chat.
+
+## Summary of New Capabilities
+
+- The outbound tone gate's degraded "deterministic floor" no longer blocks
+  legitimate clickable links (private view / tunnel / dashboard / Secret-Drop /
+  Telegraph / download). Always-on correctness fix; no config knob. Real call
+  instructions (curl / uppercase-method-vs-URL / "hit the endpoint") are still
+  held, and command/path/secret/internal-id leaks are unaffected.
+
+## Evidence
+
+- New `deterministic floor — click-link carve-out` test block in
+  `tests/unit/MessagingToneGate.test.ts` (14 cases): each click-link class PASSES
+  the floor; curl / uppercase-method / "hit the endpoint" / no-article "call api"
+  calls still HOLD; file-path (`B2_FILE_PATH`) + bare-CLI leaks still HOLD; a
+  200k-char adversarial input proves the hardened call-phrase regex runs in
+  linear time (< 200ms); end-to-end `review()` degrades-and-SENDS a Secret-Drop
+  link on provider throw. Full file 55/55 green.
+- Independent Phase-5 second-pass review: **CONCUR** (leak-safety preserved across
+  eight bypass attempts; safe direction verified). One non-blocking latent-ReDoS
+  note **resolved in this PR** (no deferral): the call-phrase regex was hardened
+  to remove ambiguous whitespace backtracking.
+- tsc clean; budget + no-silent-fallbacks + dark-gate lint ratchets green.

--- a/upgrades/side-effects/tonegate-floor-click-links.md
+++ b/upgrades/side-effects/tonegate-floor-click-links.md
@@ -1,0 +1,147 @@
+# Side-Effects Review — Tone-gate deterministic floor: click-link carve-out
+
+**Tier:** 1 (small, surgical, safe-direction false-positive fix). **Risk floor will signal Tier 2** (messaging block/allow gate) — Phase-5 second-pass review performed regardless; `belowFloor` audit accepted (I hold authority; the override is recorded).
+**Anchor:** `docs/specs/tone-gate-graceful-degradation.md` (the F4 deterministic floor this fix extends) + `docs/specs/tonegate-floor-click-links.eli16.md`. The precise-subject spec is the shipped F4 postmortem fix; this is a follow-up false-positive correction to that floor. (Not Tier-2-anchored: that spec carries no `approved:true`, and I must never self-approve.)
+**Files:** `src/core/MessagingToneGate.ts`, `tests/unit/MessagingToneGate.test.ts`
+
+## What changed
+
+1. **`scrubClickLinksForFloor(text)` (new, exported):** removes scheme'd `http(s)://…`
+   URLs (the click-destination token) from a copy of the text BEFORE the floor's
+   signal scan — UNLESS the text carries a CALL instruction: a fetch tool
+   (`curl`/`wget`/`xh`/`httpie`), an uppercase HTTP method against a URL/path
+   (`POST https://…` / `GET /…`), or an imperative call phrase ("hit/call/invoke/
+   issue/send … endpoint/url/api/request"). On any of those it returns the text
+   UNCHANGED, so the floor sees the call verbatim and blocks as today.
+2. **`detectDeterministicLeak(text)`:** now scans `scrubClickLinksForFloor(text)`
+   instead of raw `text` — for BOTH `detectGateSignals` and `detectInternalIdLeak`.
+   Nothing else about the floor changed; the LLM path is untouched.
+
+## 1. Over-block
+
+- **Before:** the floor over-blocked EVERY clickable link an agent shared during an
+  LLM outage (private view, tunnel, dashboard, Secret-Drop, Telegraph, download) —
+  the host/port/path/token tripped the `api-endpoint` / `cron-or-slug` signals.
+  This is the bug being fixed (it just blocked a real Secret-Drop link).
+- **After:** a bare clickable URL no longer trips the floor. No new over-block is
+  introduced — the scrub only REMOVES match surface, never adds a rule.
+
+## 2. Under-block
+
+- The scrub removes scheme'd URLs only. A leak embedded in a URL's path/query
+  (e.g. a file path inside `…/download?path=.claude/CLAUDE.md`) is removed along
+  with the URL — acceptable, because the agent deliberately shared that as a
+  click destination (the same intent the LLM path already passes). A file path or
+  command written OUTSIDE a URL is left fully intact and still HELD (proven by the
+  file-path + bare-CLI tests).
+- A call instruction that uses none of the three recognized forms (no curl/wget,
+  no uppercase method, no "hit/call/…" phrase) — e.g. a lowercase prose "open this
+  api 〈url〉" — would have its URL scrubbed. This is acceptable: such phrasing reads
+  as an open instruction, the host/path is gone, and no command/path/secret
+  escapes. The floor is the DEGRADED path (LLM down); the LLM path catches intent
+  precisely when up. Erring toward delivering a link beats silencing the user.
+
+## 3. Level-of-abstraction fit
+
+- Correct layer. The fix lives exactly where the false positive lives — the
+  deterministic floor (`detectDeterministicLeak`), the degraded-path counterpart
+  to the LLM judge's existing intent-based B5 carve-out. It does NOT touch
+  `GateSignalDetectors` (those feed the LLM prompt too and must stay literal); it
+  pre-processes only the floor's input. The smarter gate (the LLM) already owns
+  the precise judgment when available; this only narrows the dumb fallback's known
+  false-positive class.
+
+## 4. Signal vs authority compliance
+
+- The floor HOLDS authority (it blocks under degradation) but with deliberately
+  brittle logic — that is its established design (F4: never silently cut the user
+  off; hold only hard artifact leaks). This change only REDUCES that authority's
+  false-positive surface in the safe direction (fewer wrong holds), never expands
+  what it lets through. No new blocking authority is added. Per
+  `docs/signal-vs-authority.md`, loosening a brittle authority's over-block while
+  preserving its leak-safety is the correct direction.
+
+## 5. Interactions
+
+- `buildDegradedToneResult` (both degrade sites: provider-throw in `review()` and
+  the slow-stall seam in `reviewWithinBudget`) calls `detectDeterministicLeak`, so
+  both degrade sites inherit the carve-out identically — no divergence.
+- The `failClosedOnExhaustion: true` operator override is unaffected: it bypasses
+  the floor entirely (pure hold), so its behavior is unchanged.
+- No race, no double-fire, no shadowing — pure synchronous string pre-processing.
+
+## 6. External surfaces
+
+- No new route, no config key, no schema, no migration. Behavior visible to users
+  only as: during an LLM outage, a shared click-link now reaches them instead of
+  being silently held. No timing/runtime-state dependence (pure function).
+
+## 7. Multi-machine posture
+
+- **Machine-local BY DESIGN, identical on every machine.** The tone gate runs
+  per-message on whichever machine is serving; this is a pure-function change to
+  that per-message logic. No state, no replication, no cross-machine surface.
+  Every machine applies the identical floor. No one-voice / transfer / URL-survival
+  concern (it has no durable state and emits no notice).
+
+## 8. Rollback cost
+
+- Trivial. Revert the two edits in `MessagingToneGate.ts` (delete the helper +
+  restore `detectGateSignals(text)` / `detectInternalIdLeak(text)`). No data, no
+  config, no agent-state repair. Always-on with no flag because the prior behavior
+  was simply incorrect.
+
+## Tests
+
+- `tests/unit/MessagingToneGate.test.ts` — new `deterministic floor — click-link
+  carve-out` describe (12 cases): each click-link class (Secret-Drop / private
+  view / dashboard / Telegraph / download) PASSES the floor; a `curl` call, an
+  uppercase-method call, and a "hit the endpoint" phrase still HOLD; a file-path
+  leak still HOLDS (`B2_FILE_PATH`); a bare CLI command alongside a link still
+  HOLDS; `scrubClickLinksForFloor` unit behavior (strips a URL, leaves a curl line
+  unchanged); and an end-to-end `review()` degrade-and-SEND of a Secret-Drop link
+  on provider throw. Full file: 53/53 green. Budget + no-silent-fallbacks +
+  dark-gate lint ratchets: green. tsc clean.
+
+## Agent awareness
+
+- No CLAUDE.md change required: this is an internal correctness fix to an existing
+  safety gate with no new user-facing capability, route, or config knob. The
+  user-visible effect (links reach you during an outage) needs no agent
+  instruction.
+
+## Phase-5 second-pass review (independent reviewer)
+
+**VERDICT: Concur with the review** — the change preserves leak-safety while
+fixing the false positive. The reviewer empirically ran the scrub against eight
+bypass attempts and verified:
+
+- No new leak class escapes. Leaks written OUTSIDE a URL are fully preserved
+  (env-var `GITHUB_TOKEN=…`, config-key, file-path `/Users/…/id_rsa` all still
+  trip after the scrub). The scrub regex consumes only scheme'd URL tokens up to
+  whitespace/`)`/`]`, so an adjacent space-separated leak survives — the
+  safe-direction claim is real.
+- "Secret inside a URL escapes" is out-of-scope by correct layering, not a gap:
+  the floor has no secret detector (raw-credential redaction is a separate
+  `redactSecrets`/`guardProxyOutput` pass), so the scrub removes nothing the floor
+  was protecting. A token inside a URL the agent chose to share as a click
+  destination is the intended open-vs-call trade (matches the LLM B5 carve-out).
+- Call-instruction suppression is sound (curl / uppercase-method-vs-URL /
+  "hit … endpoint" all still HOLD). The one documented loosening (a file path
+  inside a `…/download?path=…` URL) is acknowledged in §2 and acceptable on the
+  degraded path.
+- Internal-id detector on scrubbed text does not weaken meaningfully: a bare
+  `CMT-1234` in prose (the actual anti-pattern) is untouched; only an id embedded
+  in a shared click-URL is skipped — benign by the rule's own intent.
+- Both degrade sites inherit the carve-out via the single
+  `buildDegradedToneResult → detectDeterministicLeak` chokepoint; the
+  `failClosedOnExhaustion:true` override (pure hold) is unaffected. No race/state.
+
+**Non-blocking concern raised → RESOLVED in this PR (no deferral):** the reviewer
+flagged latent O(n²) backtracking in `CALL_PHRASE` (`\s+(?:…)?\s*` adjacency),
+harmless at Telegram's ~4096-char cap (~9ms) but a hardening risk for any future
+unbounded-input caller. Fixed immediately: the article group now carries its own
+trailing `\s+` (`(?:(?:this|the|a)\s+)?`), eliminating the ambiguous whitespace
+split — linear time. Guarded by a new test (`scrubClickLinksForFloor runs in
+linear time on a long whitespace run`, 200k-char adversarial input < 200ms) and a
+no-article call-phrase HOLD test.


### PR DESCRIPTION
## ELI16 — What this fixes

Every message I send you passes a safety gate that checks for leaks — raw shell commands, file paths, internal endpoints meant for me to call, not for you. Normally a smart LLM does that check and can tell "here's a link to **open**" from "here's an endpoint to **call**". But when that LLM is slow or rate-limited, the gate falls back to a dumb, fast, pattern-only check (the "deterministic floor") so you're never silently cut off. That floor couldn't tell a clickable link from a callable endpoint — so during any LLM slowdown it **blocked every link an agent tried to share** (private views, dashboard, Secret-Drop one-time URLs, Telegraph pages, downloads), fleet-wide. This is what just blocked a real Secret Drop link.

The fix adds `scrubClickLinksForFloor`: before the floor scans, it neutralizes `http(s)://…` URLs shared as click destinations so their host/path/token don't trip the floor's "looks like an endpoint" detectors — **unless** the text carries a real call instruction (`curl`/`wget`, an uppercase HTTP method against a URL, or "hit/call/invoke … the endpoint"), in which case nothing is scrubbed and the floor blocks as before. This mirrors the LLM path's existing intent-based (open-vs-call) carve-out, now at the degraded floor too. **Safe-direction only:** it loosens a false positive on links and never lets a command, file path, config key, secret, or internal id escape. The LLM path is untouched.

## What changed
- `src/core/MessagingToneGate.ts`: new exported `scrubClickLinksForFloor(text)`; `detectDeterministicLeak` scans the scrubbed copy (both `detectGateSignals` and `detectInternalIdLeak`). Both degrade sites (provider-throw in `review()` and the slow-stall seam) inherit it via the single `buildDegradedToneResult` chokepoint.
- Call-phrase regex hardened to remove ambiguous whitespace backtracking (latent O(n²) → linear).

## Tier
Tier 1 (small, surgical, safe-direction false-positive fix). Risk floor signalled 1 (not belowFloor). Phase-5 second-pass review performed regardless since it touches a messaging block/allow gate — independent reviewer **CONCUR** (leak-safety preserved across 8 bypass attempts).

## Evidence
- `tests/unit/MessagingToneGate.test.ts` new `deterministic floor — click-link carve-out` block (14 cases): each click-link class PASSES; curl / uppercase-method / "hit the endpoint" / no-article "call api" still HOLD; file-path (`B2_FILE_PATH`) + bare-CLI leaks still HOLD; 200k-char adversarial input proves linear-time regex; end-to-end `review()` degrades-and-SENDS a Secret-Drop link on provider throw. Full file 55/55 green.
- tsc clean; budget + no-silent-fallbacks + dark-gate lint ratchets green.
- Side-effects artifact: `upgrades/side-effects/tonegate-floor-click-links.md` (incl. appended Phase-5 reviewer verdict). ELI16: `docs/specs/tonegate-floor-click-links.eli16.md`. Anchor: `docs/specs/tone-gate-graceful-degradation.md` (the F4 floor this extends).

🤖 Generated with [Claude Code](https://claude.com/claude-code)