### PR TITLE
fix(multi-machine): wire the OwnershipReconciler — late-bound self-id (boot-ordering fix)

### DIFF
--- a/.instar/instar-dev-decisions/2026-06-30T06-11-22-094Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-06-30T06-11-22-094Z-unknown.json
@@ -1,0 +1,13 @@
+{
+  "ts": "2026-06-30T06:11:22.094Z",
+  "slug": "unknown",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 2,
+  "loc": 44,
+  "causalAutopsy": null,
+  "verdict": "pass"
+}

--- a/docs/specs/reconciler-meshself-ordering-fix.eli16.md
+++ b/docs/specs/reconciler-meshself-ordering-fix.eli16.md
@@ -1,0 +1,46 @@
+# Reconciler Boot-Ordering Fix — Plain-English Overview
+
+## What was broken
+
+The background "convergence loop" (the OwnershipReconciler) is the thing that's supposed to finish a
+cross-machine conversation move — it watches for "this topic is pinned to the other machine" and drives
+the hand-off. It turns out it has **never actually been running**.
+
+In the server's startup code, the loop is built inside a check that says "only build this if the machine
+already knows its own identity." But that identity value is set up about **950 lines later** in the same
+startup sequence. So at the moment the check runs, the identity is still empty, the check fails, and the
+loop is silently never built. Confirmed on the live machine: zero loop activity in the logs, and the loop's
+status endpoint reports it inactive even with both machines fully online.
+
+This is why the earlier "stuck move" never got fixed by the loop — the loop wasn't there. The earlier soak
+blamed "watch-only mode," but the real reason was this ordering bug. It was caught by **driving the feature
+through live** (the status endpoint shipped in the prior change is what exposed it).
+
+## What already exists
+
+This **exact** bug was already found and fixed for a sibling component — the part that *claims* a moved seat
+(the OwnershipApplier). Its identity lookup was made "late-bound": instead of reading the identity once at
+build time (when it's empty), it reads it each time it runs (by which point it's filled in). That fix has a
+shipped spec and unit tests.
+
+## What's new
+
+The same proven fix, applied to the convergence loop:
+- The loop is now built whenever its pin store exists — it no longer requires the identity to be set first.
+- The identity is now read **late** (each tick), not captured once at build time.
+- While the identity is still empty (very early boot), a tick is a strict no-op — it never acts without
+  knowing which machine it is (every decision is relative to "self", so acting blind would be unsound).
+  Once the identity fills in, the same loop instance starts working.
+
+## Safeguards (plain terms)
+
+- The loop still only acts on the operator's own machines, still dark/dev-gated, still no-ops when there's
+  only one machine. Nothing about *what* it does changed — only *that it now exists and runs*.
+- A new regression test proves both sides: a null identity no-ops the tick, and once the identity resolves
+  the same loop acts. Two other construction sites (tests) were updated to the new late-bound shape.
+
+## What you're deciding
+
+Whether to ship this small, proven-pattern ordering fix so the convergence loop actually runs (it follows
+the identical, already-approved fix used for its sibling component). Without it, the merged convergence fix
+is correct but inert.

--- a/src/commands/server.ts
+++ b/src/commands/server.ts
@@ -16914,7 +16914,14 @@ export async function startServer(options: StartOptions): Promise<void> {
         // inbound message that delivery may never route" (the 2026-06-12 stuck
         // transfer-back). Dark + dry-run defaults; strict single-machine no-op
         // inside the module. Phase C: quorum logic is N-machine from day one.
-        if (_topicPinStore && _meshSelfId) {
+        // Construction gated on the pin store ALONE — NOT on `_meshSelfId` (Finding
+        // 2026-06-30, caught by the live proof): this block runs ~950 lines BEFORE
+        // `_meshSelfId` is assigned in the boot sequence, so the old `&& _meshSelfId` guard
+        // was ALWAYS null here → the reconciler was never built and never ticked (0 ticks in
+        // logs, /pool/reconciler 503 even with both machines online). `selfMachineId` is now a
+        // late-bound getter (read at tick time, no-op while null) — the SAME proven fix the
+        // sibling OwnershipApplier already uses (ownership-applier-meshself-ordering-fix).
+        if (_topicPinStore) {
           const ws13Cfg = () => ((config as Record<string, any>).multiMachine?.seamlessness ?? {}) as { ws13Reconcile?: boolean; ws13DryRun?: boolean; ws13TickMs?: number; ws13PinReplicate?: boolean };
           const { OwnershipReconciler } = await import('../core/OwnershipReconciler.js');
           // Fix #2 advisory-pin read: the merged replicated `topic-pin-record` view (HLC-ordered)
@@ -16932,7 +16939,7 @@ export async function startServer(options: StartOptions): Promise<void> {
             // ladder intends. Strict single-machine no-op inside the module.
             enabled: () => resolveDevAgentGate(ws13Cfg().ws13Reconcile, config),
             dryRun: () => ws13Cfg().ws13DryRun !== false,
-            selfMachineId: _meshSelfId,
+            selfMachineId: () => _meshSelfId, // late-bound (assigned ~950 lines below) — read at tick time
             pinStore: _topicPinStore,
             // Fix #2: the merged ADVISORY replicated pins (HLC-ordered). Gated by
             // ws13PinReplicate (resolves LIVE on a dev agent / DARK on the fleet) so a

--- a/src/core/OwnershipReconciler.ts
+++ b/src/core/OwnershipReconciler.ts
@@ -54,7 +54,15 @@ export interface OwnershipReconcilerDeps {
   enabled: () => boolean;
   /** Dry-run — log intended actions, never CAS. Read live. */
   dryRun: () => boolean;
-  selfMachineId: string;
+  /**
+   * This machine's mesh id, LATE-BOUND (Finding 2026-06-30: the boot-ordering bug the
+   * live proof caught). In server.ts the reconciler is wired ~950 lines BEFORE `_meshSelfId`
+   * is assigned, so a value here would always be null → the reconciler was never built and
+   * never ticked. A getter is read at TICK time (by which point the id resolves), exactly the
+   * pattern the sibling OwnershipApplier already uses (ownership-applier-meshself-ordering-fix).
+   * A tick while it is still null is a strict no-op (treated like single-machine).
+   */
+  selfMachineId: () => string | null;
   pinStore: TopicPlacementPinStore;
   /**
    * Cross-machine convergence (Fix #2): the merged ADVISORY replicated pins (move-intent
@@ -103,7 +111,7 @@ export interface ReconcileTickReport {
   deferredDebounce: number;
   deferredNoEvidence: number;
   dryRun: boolean;
-  skipped?: 'disabled' | 'single-machine';
+  skipped?: 'disabled' | 'single-machine' | 'self-id-unresolved';
 }
 
 /** Read-only per-topic decision explanation (Observable Intelligence): what the
@@ -171,7 +179,7 @@ export class OwnershipReconciler {
    *  from `updatedAt` (the migration for pre-Fix-#2 pins). */
   private deriveLocalPinHlc(pin: TopicPin): HlcTimestamp {
     if (pin.hlc) return pin.hlc;
-    return { physical: Date.parse(pin.updatedAt) || 0, logical: 0, node: this.d.selfMachineId };
+    return { physical: Date.parse(pin.updatedAt) || 0, logical: 0, node: this.d.selfMachineId() ?? '' };
   }
 
   /**
@@ -226,7 +234,13 @@ export class OwnershipReconciler {
       return this.finish(report);
     }
     const now = this.now();
-    const self = this.d.selfMachineId;
+    const self = this.d.selfMachineId();
+    if (!self) {
+      // The mesh id has not resolved yet (early boot). Strict no-op until it does — the
+      // FSM decisions are all relative to "self", so acting without it would be unsound.
+      report.skipped = 'self-id-unresolved';
+      return this.finish(report);
+    }
     const byId = new Map(machines.map((m) => [m.machineId, m]));
 
     for (const [sessionKey, pin] of Object.entries(this.effectivePins())) {
@@ -344,10 +358,11 @@ export class OwnershipReconciler {
       if (!countOnce) report[counter]++;
       return false; // dry-run never lands a CAS, so chained steps stop here
     }
+    const self = this.d.selfMachineId() ?? '';
     const r = this.d.ownership.cas(action, {
       sessionKey,
-      sender: this.d.selfMachineId,
-      nonce: `${this.d.selfMachineId}:${reason}:${sessionKey}:${this.now()}`,
+      sender: self,
+      nonce: `${self}:${reason}:${sessionKey}:${this.now()}`,
     });
     if (r.ok) {
       if (!countOnce) report[counter]++;
@@ -367,7 +382,7 @@ export class OwnershipReconciler {
    * the exact gap that left the cross-machine stuck-move bug a black box (2026-06-30).
    */
   explainTopic(sessionKey: string): TopicReconcileExplanation {
-    const self = this.d.selfMachineId;
+    const self = this.d.selfMachineId() ?? '(mesh id unresolved)';
     const machines = this.d.machines();
     const base = { sessionKey, self, machinesCount: machines.length };
     if (!this.d.enabled()) return { ...base, decision: 'skipped', reason: 'reconciler disabled' };
@@ -442,7 +457,7 @@ export class OwnershipReconciler {
     lastTickAt: string | null;
     lastReport: ReconcileTickReport | null;
     machinesCount: number;
-    selfMachineId: string;
+    selfMachineId: string | null;
   } {
     let machinesCount = 0;
     try { machinesCount = this.d.machines().length; } catch { /* best-effort */ }
@@ -452,7 +467,7 @@ export class OwnershipReconciler {
       lastTickAt: this.lastTickAtMs ? new Date(this.lastTickAtMs).toISOString() : null,
       lastReport: this.lastReport,
       machinesCount,
-      selfMachineId: this.d.selfMachineId,
+      selfMachineId: this.d.selfMachineId(),
     };
   }
 }

--- a/tests/integration/pool-reconciler-route.test.ts
+++ b/tests/integration/pool-reconciler-route.test.ts
@@ -65,7 +65,7 @@ function makeReconciler(): OwnershipReconciler {
   const pinStore = new TopicPlacementPinStore({ filePath: path.join(tmp, 'pins.json') });
   pinStore.set('700', 'm_a');
   return new OwnershipReconciler({
-    enabled: () => true, dryRun: () => false, selfMachineId: 'm_b',
+    enabled: () => true, dryRun: () => false, selfMachineId: () => 'm_b',
     pinStore, ownership: reg,
     machines: () => [{ machineId: 'm_a', online: true, lastSeenMs: Date.now() }, { machineId: 'm_b', online: true, lastSeenMs: Date.now() }],
     isTopicBusy: () => false, emitPlacement: () => {}, debounceMs: 0,

--- a/tests/unit/OwnershipReconciler.test.ts
+++ b/tests/unit/OwnershipReconciler.test.ts
@@ -88,6 +88,7 @@ interface Sim {
     debounceMs: number;
     now: () => number;
     advisoryPins: Map<number, { preferredMachine: string; hlc: { physical: number; logical: number; node: string } }>;
+    selfMachineId: () => string | null;
   }>) => OwnershipReconciler;
   /** Replicate the shared journal → run EVERY machine's applier (the cross-machine sync). */
   pump: () => void;
@@ -132,7 +133,7 @@ function makeSim(machines: ReconcilerMachineView[]): Sim {
       return new OwnershipReconciler({
         enabled: () => opts.enabled ?? true,
         dryRun: () => opts.dryRun ?? false,
-        selfMachineId: machineId,
+        selfMachineId: opts.selfMachineId ?? (() => machineId),
         pinStore: this.pinStoreFor(machineId),
         ...(opts.advisoryPins ? { advisoryPins: () => opts.advisoryPins! } : {}),
         ownership: regFor(machineId).reg, // PER-MACHINE registry (separate store)
@@ -227,7 +228,7 @@ describe('OwnershipReconciler — cooperative convergence', () => {
     seedActive(sim, '700', 'm_b');
     sim.pinStoreFor('m_b').set('700', 'm_a'); // just set — updatedAt = now
     const rec = new OwnershipReconciler({
-      enabled: () => true, dryRun: () => false, selfMachineId: 'm_b',
+      enabled: () => true, dryRun: () => false, selfMachineId: () => 'm_b',
       pinStore: sim.pinStoreFor('m_b'), ownership: sim.registryFor('m_b'),
       machines: () => TWO, isTopicBusy: () => false,
       emitPlacement: () => {}, debounceMs: 60_000, safePointDeadlineMs: 1000, deathEvidenceMs: 1000,
@@ -411,6 +412,34 @@ describe('OwnershipReconciler — WS1.2 drain-grace (transferring-to-me claims)'
     const rep = sim.reconcilerFor('m_a', { now: () => recAt + 1_000 }).tick();
     expect(rep.claims).toBe(1);
     expect(sim.read('700', 'm_a')!).toMatchObject({ status: 'active', ownerMachineId: 'm_a' });
+    sim.cleanup();
+  });
+});
+
+describe('OwnershipReconciler — late-bound self-id (boot-ordering fix, 2026-06-30 live-proof catch)', () => {
+  it('a null self-id (mesh id not resolved yet) is a STRICT no-op — never acts, even with a triggering pin', () => {
+    const sim = makeSim(TWO);
+    seedActive(sim, '700', 'm_b'); // m_b owns 700
+    sim.pinStoreFor('m_b').set('700', 'm_a'); // a pin that WOULD trigger a transfer if self resolved
+    const rep = sim.reconcilerFor('m_b', { selfMachineId: () => null }).tick();
+    expect(rep.skipped).toBe('self-id-unresolved');
+    expect(rep.transfers).toBe(0);
+    expect(sim.read('700', 'm_b')!.status).toBe('active'); // untouched
+    sim.cleanup();
+  });
+
+  it('once the self-id resolves (getter returns the id), the SAME reconciler acts — proving late-binding works', () => {
+    const sim = makeSim(TWO);
+    seedActive(sim, '700', 'm_b');
+    sim.pinStoreFor('m_b').set('700', 'm_a');
+    // A getter whose value flips from null → 'm_b' (models _meshSelfId being assigned after boot).
+    let resolved: string | null = null;
+    const rec = sim.reconcilerFor('m_b', { selfMachineId: () => resolved });
+    expect(rec.tick().skipped).toBe('self-id-unresolved'); // early boot: no-op
+    resolved = 'm_b'; // mesh id now assigned
+    const rep = rec.tick();
+    expect(rep.transfers).toBe(1); // same instance now transfers 700 → m_a
+    expect(sim.read('700', 'm_b')!.transferTo).toBe('m_a');
     sim.cleanup();
   });
 });

--- a/upgrades/next/reconciler-meshself-ordering-fix.md
+++ b/upgrades/next/reconciler-meshself-ordering-fix.md
@@ -1,0 +1,36 @@
+# Reconciler Boot-Ordering Fix — the convergence loop now actually runs
+
+## What Changed
+
+The cross-machine convergence loop (`OwnershipReconciler`) was being wired during server startup inside a
+guard that required the machine's mesh id to already be set — but that id is assigned ~950 lines later in the
+same synchronous boot sequence. So the guard was always null and **the reconciler was never constructed and
+never ticked** (live-confirmed: zero `OwnershipReconciler` lines in the server log; `/pool/reconciler` 503
+even with both machines online). This made the merged cross-machine "stuck move" fix correct but inert — the
+loop that consumes it didn't exist.
+
+The fix applies the exact pattern already shipped for the sibling `OwnershipApplier`
+(`ownership-applier-meshself-ordering-fix`): construction is now gated on the pin store alone, and
+`selfMachineId` is a **late-bound getter** read at tick time. While the id is still unresolved (very early
+boot) a tick is a strict no-op (`skipped: 'self-id-unresolved'`); once it resolves, the same loop instance
+acts. Found by driving the feature through live, exactly the value of the live-proof discipline.
+
+## Evidence
+
+- Unit: `tests/unit/OwnershipReconciler.test.ts` — 32 tests incl. two new regression tests (a null self-id is
+  a strict no-op even with a triggering pin; once the getter resolves, the SAME instance transfers). All four
+  `new OwnershipReconciler` construction sites updated to the late-bound shape.
+- Affected suites green: OwnershipReconciler, OwnershipApplier, CoherenceJournal, MachinePoolRegistry,
+  TopicPinReplicatedStore (123 tests).
+- The sibling `OwnershipApplier` already carries this identical fix + its own converged spec, establishing the
+  proven pattern.
+
+## What to Tell Your User
+
+Nothing yet — the convergence loop remains off by default (dev-gated). This fix simply means that when it is
+enabled, the loop actually runs (it never did before). No change to normal use until it's turned on.
+
+## Summary of New Capabilities
+
+- (Dark) The cross-machine convergence loop is now actually constructed and ticking on every machine that has
+  a pin store — the prerequisite for the merged stuck-move fix to take effect.

--- a/upgrades/side-effects/reconciler-meshself-ordering-fix.md
+++ b/upgrades/side-effects/reconciler-meshself-ordering-fix.md
@@ -1,0 +1,93 @@
+# Side-Effects Review — Reconciler Boot-Ordering Fix (late-bound self-id)
+
+**Version / slug:** `reconciler-meshself-ordering-fix`
+**Date:** 2026-06-30
+**Author:** echo (autonomous run, topic 28744)
+**Second-pass reviewer:** echo second-pass subagent (touches the reconciler decision surface)
+
+## Summary of the change
+
+The WS1.3 `OwnershipReconciler` was wired in `server.ts` inside `if (_topicPinStore && _meshSelfId)` at
+line ~16917 — but `_meshSelfId` is not assigned until line ~17877 (~950 lines later in the synchronous boot
+flow). So the guard was always null → the reconciler was NEVER constructed and never ticked. Live-confirmed:
+0 `OwnershipReconciler` lines in the server log; `/pool/reconciler` 503s even with both machines online. This
+is the identical boot-ordering bug already fixed for the sibling `OwnershipApplier`
+(`ownership-applier-meshself-ordering-fix`), which made its self-id a late-bound getter. This change applies
+the same pattern to the reconciler: (1) gate construction on `_topicPinStore` ALONE; (2) make the `selfMachineId`
+dep a getter `() => string | null`, read at tick time; (3) a tick while the id is still null is a strict no-op
+(`skipped: 'self-id-unresolved'`). Files: `src/core/OwnershipReconciler.ts` (dep + reads + null guard + skipped
+type), `src/commands/server.ts` (gate + getter), plus the two test construction sites and a new regression test.
+
+## Decision-point inventory
+
+- `OwnershipReconciler.tick()` decision FSM — **modify** — now resolves self-id via getter at the top and
+  no-ops the whole tick while null (never acts without a resolved self). Otherwise the decision tree is
+  byte-identical.
+- `server.ts` reconciler construction gate — **modify** — `&& _meshSelfId` dropped (the ordering bug);
+  construction now happens, self-id arrives late.
+
+## 1. Over-block
+
+No message block/allow surface. The only added "refusal" is the tick no-op while self-id is null — that is
+strictly MORE conservative than before (before, the loop never ran at all; now it runs but waits for the id).
+A legitimate action is never blocked once the id resolves (which happens within the first boot).
+
+## 2. Under-block
+
+The self-id null window is bounded to early boot (the id is assigned synchronously during the same boot). A
+tick in that window no-ops; the interval keeps ticking, so the first post-id tick acts. No failure mode is
+newly missed — the reconciler simply starts working where it never did before.
+
+## 3. Level-of-abstraction fit
+
+Correct — this is the exact pattern the sibling `OwnershipApplier` already uses (late-bound `getSelfMachineId`),
+extracted from the same boot-ordering bug. It does not add a new authority; it makes an existing (never-running)
+one actually run. The alternative (moving the `_meshSelfId` assignment ~950 lines earlier) is far riskier —
+many intervening consumers assume the current ordering.
+
+## 4. Signal vs authority compliance
+
+Compliant. The reconciler's authority (cooperative transfer / force-claim within the FSM) is unchanged. The
+late-bound self-id is a wiring correction, not a new decision. The force-claim path still gates on
+death-evidence + quorum from machine liveness. A null-self tick is a no-op, never an action.
+
+## 5. Interactions
+
+The late-bound getter mirrors the applier's, so both now resolve self-id consistently at tick time. No
+double-fire (one reconciler instance, one timer). The null-guard sits before any machinery, so a partial
+boot can't drive a half-initialized tick. The `skipped: 'self-id-unresolved'` value is additive to the
+report union.
+
+## 6. External surfaces
+
+`/pool/reconciler` now returns real status (not 503) once the server boots — this is the intended fix
+(the route exposed the bug). No new route/config. The reconciler beginning to actually tick is the
+behavioral change; it remains dark/dev-gated (`ws13Reconcile`), so the fleet is unaffected; a dev agent's
+reconciler now runs (in dry-run unless `ws13DryRun:false`).
+
+## 7. Multi-machine posture (Cross-Machine Coherence)
+
+This is squarely a multi-machine fix. The reconciler is **machine-local BY DESIGN** (each machine reconciles
+its own view against the shared journal). The fix ensures it is actually constructed on every machine that
+has a pin store. A single-machine agent still no-ops (machines() < 2). The self-id getter reads the same
+`_meshSelfId` every other multi-machine consumer uses.
+
+## 8. Rollback cost
+
+Cheap. The reconciler is dark/dev-gated (`ws13Reconcile` resolves dark on the fleet, live on a dev agent) and
+defaults to dry-run (`ws13DryRun !== false`). Back-out: set `ws13Reconcile` off (reconciler no-op) or
+`ws13DryRun:true` (logs, no CAS). No data migration, no state repair — a config flip. The change is also a
+pure wiring/ordering correction with no schema impact.
+
+## Second-pass reviewer response
+
+**Concur with the review.** An independent reviewer verified all five points against the code: (1) the
+null-self-id tick is a strict no-op — `const self = this.d.selfMachineId()` then `if (!self) { skipped =
+'self-id-unresolved'; return }` precedes `effectivePins()` and every `act()`/CAS; (2) every `selfMachineId`
+read goes through the getter `()` (deriveLocalPinHlc, tick, act, explainTopic, status) — none left as a bare
+property; (3) `server.ts` gates on `if (_topicPinStore)` alone and passes `selfMachineId: () => _meshSelfId`;
+(4) the constructor only stores `deps` — it never captures the id at construction, so late-binding holds; (5)
+no stale/transient-null unsoundness — `_meshSelfId` is a module var assigned once (null→value, never reverts),
+the only window is early boot which the guard covers, and the `?? ''` in `act()` is reached only after the
+tick guard (never an empty-sender CAS in practice). The pattern exactly mirrors the already-shipped
+`OwnershipApplier` fix. Not a correctness or safety defect.


### PR DESCRIPTION
Follow-up to #1311. **Found by driving the feature through live** — the convergence loop the prior PR fixed has never actually been running.

## ELI16

The cross-machine convergence loop (`OwnershipReconciler`) is built during server startup inside a guard that requires the machine's mesh id to already be set — but that id is assigned ~950 lines LATER in the same synchronous boot sequence. So the guard was always null and **the loop was never constructed and never ticked** (live-confirmed: zero `OwnershipReconciler` lines in the server log; `/pool/reconciler` 503 even with both machines online). That made the merged stuck-move fix correct but inert — the loop that consumes it didn't exist. This is the **identical** bug already fixed for the sibling `OwnershipApplier` (`ownership-applier-meshself-ordering-fix`), whose code comment literally documents the ~650-line gap. The fix applies the same proven pattern: gate construction on the pin store alone, and read the mesh id via a **late-bound getter** at tick time. While the id is still unresolved (early boot) a tick is a strict no-op; once it resolves, the same loop instance acts.

## What changed
- `src/commands/server.ts`: reconciler construction gated on `_topicPinStore` alone (was `&& _meshSelfId`, always null at that point); `selfMachineId: () => _meshSelfId` (late-bound).
- `src/core/OwnershipReconciler.ts`: `selfMachineId` dep is now `() => string | null`, read at tick time in every site (deriveLocalPinHlc, tick, act/CAS, explainTopic, status); a null self-id no-ops the tick (`skipped: 'self-id-unresolved'`).

## Tests
- `tests/unit/OwnershipReconciler.test.ts`: 32 tests incl. 2 new regression tests — a null self-id is a strict no-op even with a triggering pin; once the getter resolves, the SAME instance transfers. All `new OwnershipReconciler` construction sites updated to the late-bound shape.
- Affected suites green (123 tests). Second-pass reviewer concurred (verified the no-op guard precedes any CAS, all reads use the getter, no construction-time capture).

## Safety
Dark/dev-gated (`ws13Reconcile`), dry-run default (`ws13DryRun !== false`). Rollback = a config flip. Pure wiring/ordering correction, no schema impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
