### PR TITLE
fix(multi-machine): reconciler pin-store late-binding — completes #1312

### DIFF
--- a/.instar/instar-dev-decisions/2026-06-30T06-56-59-753Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-06-30T06-56-59-753Z-unknown.json
@@ -1,0 +1,13 @@
+{
+  "ts": "2026-06-30T06:56:59.753Z",
+  "slug": "unknown",
+  "suggestedTier": 1,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 2,
+  "loc": 24,
+  "causalAutopsy": null,
+  "verdict": "pass"
+}

--- a/docs/specs/reconciler-pinstore-ordering-fix.eli16.md
+++ b/docs/specs/reconciler-pinstore-ordering-fix.eli16.md
@@ -1,0 +1,38 @@
+# Reconciler Pin-Store Boot-Ordering Fix — Plain-English Overview
+
+## What was still broken
+
+The cross-machine convergence loop (`OwnershipReconciler`) is supposed to finish a "move a
+conversation between machines" hand-off. A prior fix (#1312) made it not depend on the machine's
+identity being set up first. But it turned out the loop's startup check depends on TWO things, and
+the SECOND one — the "pin store" (where the move instruction is recorded) — is set up about 2200
+lines LATER in the server's startup than the loop is wired. So the check still failed, and the loop
+was STILL never built. Live-confirmed: after deploying #1312 to both machines, the loop's status
+endpoint still reported it inactive, with zero activity in the logs.
+
+## What's new
+
+The same proven late-binding pattern, now applied to the pin store too:
+- The loop is built whenever the ownership registry exists (which is ready early) — its construction
+  no longer hinges on the late-assigned pin store at all.
+- The pin store is read **late**, at run-time (each tick), not captured at wire-time. While it's
+  still null (early boot) a tick simply sees no pins and does nothing; once it's ready, the same loop
+  instance starts converging.
+
+## What already exists
+
+This mirrors #1312 (the identity fix) and the sibling `OwnershipApplier`'s already-shipped fix — read
+late-assigned startup values at run-time, not wire-time, so server boot order stops mattering.
+
+## Safeguards (plain terms)
+
+- The loop still only acts on the operator's own machines, still dark/dev-gated, still no-ops with one
+  machine. Only the wiring changed — not what the loop does.
+- New regression tests now lock in BOTH late dependencies (identity AND pin store): with either one
+  not-yet-ready the loop does nothing; once ready, the same loop acts. So this whole "wired before its
+  dependencies exist" class of bug is guarded going forward.
+
+## What you're deciding
+
+Whether to ship this small completion of #1312 so the convergence loop is finally built and runs. Found
+by driving the feature through live — the only thing that exposes server boot-ordering bugs.

--- a/src/commands/server.ts
+++ b/src/commands/server.ts
@@ -16921,7 +16921,13 @@ export async function startServer(options: StartOptions): Promise<void> {
         // logs, /pool/reconciler 503 even with both machines online). `selfMachineId` is now a
         // late-bound getter (read at tick time, no-op while null) — the SAME proven fix the
         // sibling OwnershipApplier already uses (ownership-applier-meshself-ordering-fix).
-        if (_topicPinStore) {
+        // Gate on `ownReg` (the ownership registry, available HERE inside durableOwnership) —
+        // NOT on `_topicPinStore` (Finding 2026-06-30 #2, live-proof's SECOND catch): the pin
+        // store is assigned ~2200 lines BELOW, so `if (_topicPinStore)` was ALWAYS null here →
+        // reconciler still never built even after the `_meshSelfId` fix. `pinStore` is now a
+        // late-bound getter too (read at tick time, no pins while null) — same pattern as
+        // `selfMachineId` + the sibling OwnershipApplier.
+        if (ownReg) {
           const ws13Cfg = () => ((config as Record<string, any>).multiMachine?.seamlessness ?? {}) as { ws13Reconcile?: boolean; ws13DryRun?: boolean; ws13TickMs?: number; ws13PinReplicate?: boolean };
           const { OwnershipReconciler } = await import('../core/OwnershipReconciler.js');
           // Fix #2 advisory-pin read: the merged replicated `topic-pin-record` view (HLC-ordered)
@@ -16940,7 +16946,8 @@ export async function startServer(options: StartOptions): Promise<void> {
             enabled: () => resolveDevAgentGate(ws13Cfg().ws13Reconcile, config),
             dryRun: () => ws13Cfg().ws13DryRun !== false,
             selfMachineId: () => _meshSelfId, // late-bound (assigned ~950 lines below) — read at tick time
-            pinStore: _topicPinStore,
+            pinStore: () => _topicPinStore, // late-bound (assigned ~2200 lines below) — read at tick time
+
             // Fix #2: the merged ADVISORY replicated pins (HLC-ordered). Gated by
             // ws13PinReplicate (resolves LIVE on a dev agent / DARK on the fleet) so a
             // dark/single-machine agent reads no advisory pins (today's behavior).

--- a/src/core/OwnershipReconciler.ts
+++ b/src/core/OwnershipReconciler.ts
@@ -63,7 +63,15 @@ export interface OwnershipReconcilerDeps {
    * A tick while it is still null is a strict no-op (treated like single-machine).
    */
   selfMachineId: () => string | null;
-  pinStore: TopicPlacementPinStore;
+  /**
+   * The local pin store, LATE-BOUND (Finding 2026-06-30 #2, the live proof's SECOND catch):
+   * in server.ts `_topicPinStore` is assigned ~2200 lines AFTER the reconciler is wired, so a
+   * value here (and the old `if (_topicPinStore)` construction gate) was ALWAYS null → the
+   * reconciler still never built even after the `_meshSelfId` fix. A getter read at TICK time
+   * resolves the store once boot completes; a tick while it is still null yields no pins (a
+   * natural no-op). Same late-bound pattern as `selfMachineId` + the sibling OwnershipApplier.
+   */
+  pinStore: () => TopicPlacementPinStore | null;
   /**
    * Cross-machine convergence (Fix #2): the merged ADVISORY replicated pins (move-intent
    * from peers, HLC-ordered). The OWNING machine has no LOCAL pin for a stuck move (the pin
@@ -191,7 +199,8 @@ export class OwnershipReconciler {
    * the owner cooperatively transfers toward; the force-claim path never reads it.
    */
   private effectivePins(): Record<string, TopicPin> {
-    const local = this.d.pinStore.all();
+    const ps = this.d.pinStore();
+    const local = ps ? ps.all() : {}; // null until _topicPinStore resolves at boot → no pins (natural no-op)
     const advisory = this.d.advisoryPins?.();
     if (!advisory || advisory.size === 0) return local;
     // Validate PRIMARY = membership/liveness (skew-proof): only act on a replicated pin

--- a/tests/integration/pool-reconciler-route.test.ts
+++ b/tests/integration/pool-reconciler-route.test.ts
@@ -66,7 +66,7 @@ function makeReconciler(): OwnershipReconciler {
   pinStore.set('700', 'm_a');
   return new OwnershipReconciler({
     enabled: () => true, dryRun: () => false, selfMachineId: () => 'm_b',
-    pinStore, ownership: reg,
+    pinStore: () => pinStore, ownership: reg,
     machines: () => [{ machineId: 'm_a', online: true, lastSeenMs: Date.now() }, { machineId: 'm_b', online: true, lastSeenMs: Date.now() }],
     isTopicBusy: () => false, emitPlacement: () => {}, debounceMs: 0,
   });

--- a/tests/unit/OwnershipReconciler.test.ts
+++ b/tests/unit/OwnershipReconciler.test.ts
@@ -89,6 +89,7 @@ interface Sim {
     now: () => number;
     advisoryPins: Map<number, { preferredMachine: string; hlc: { physical: number; logical: number; node: string } }>;
     selfMachineId: () => string | null;
+    pinStore: () => TopicPlacementPinStore | null;
   }>) => OwnershipReconciler;
   /** Replicate the shared journal → run EVERY machine's applier (the cross-machine sync). */
   pump: () => void;
@@ -134,7 +135,7 @@ function makeSim(machines: ReconcilerMachineView[]): Sim {
         enabled: () => opts.enabled ?? true,
         dryRun: () => opts.dryRun ?? false,
         selfMachineId: opts.selfMachineId ?? (() => machineId),
-        pinStore: this.pinStoreFor(machineId),
+        pinStore: opts.pinStore ?? (() => this.pinStoreFor(machineId)),
         ...(opts.advisoryPins ? { advisoryPins: () => opts.advisoryPins! } : {}),
         ownership: regFor(machineId).reg, // PER-MACHINE registry (separate store)
         machines: () => opts.machines ?? machines,
@@ -229,7 +230,7 @@ describe('OwnershipReconciler — cooperative convergence', () => {
     sim.pinStoreFor('m_b').set('700', 'm_a'); // just set — updatedAt = now
     const rec = new OwnershipReconciler({
       enabled: () => true, dryRun: () => false, selfMachineId: () => 'm_b',
-      pinStore: sim.pinStoreFor('m_b'), ownership: sim.registryFor('m_b'),
+      pinStore: () => sim.pinStoreFor('m_b'), ownership: sim.registryFor('m_b'),
       machines: () => TWO, isTopicBusy: () => false,
       emitPlacement: () => {}, debounceMs: 60_000, safePointDeadlineMs: 1000, deathEvidenceMs: 1000,
     });
@@ -425,6 +426,21 @@ describe('OwnershipReconciler — late-bound self-id (boot-ordering fix, 2026-06
     expect(rep.skipped).toBe('self-id-unresolved');
     expect(rep.transfers).toBe(0);
     expect(sim.read('700', 'm_b')!.status).toBe('active'); // untouched
+    sim.cleanup();
+  });
+
+  it('a null pinStore (not yet assigned at boot) is a no-op; once it resolves, the SAME reconciler acts (Finding #2)', () => {
+    const sim = makeSim(TWO);
+    seedActive(sim, '700', 'm_b');
+    // The pin lives in m_b's store, but the reconciler's pinStore getter returns null until boot completes.
+    sim.pinStoreFor('m_b').set('700', 'm_a');
+    let store: TopicPlacementPinStore | null = null;
+    const rec = sim.reconcilerFor('m_b', { pinStore: () => store });
+    expect(rec.tick().transfers).toBe(0); // pinStore null → no pins → no-op
+    expect(sim.read('700', 'm_b')!.status).toBe('active');
+    store = sim.pinStoreFor('m_b'); // _topicPinStore now assigned
+    expect(rec.tick().transfers).toBe(1); // same instance now sees the pin and transfers
+    expect(sim.read('700', 'm_b')!.transferTo).toBe('m_a');
     sim.cleanup();
   });
 

--- a/upgrades/next/reconciler-pinstore-ordering-fix.md
+++ b/upgrades/next/reconciler-pinstore-ordering-fix.md
@@ -1,0 +1,18 @@
+# Reconciler Pin-Store Boot-Ordering Fix — completes #1312
+
+## What Changed
+
+Completes #1312. The cross-machine convergence loop (`OwnershipReconciler`) was gated on `_topicPinStore`, which is assigned ~2200 lines LATER in the synchronous server boot than the loop is wired — so the gate was always null and the loop was STILL never constructed even after the `_meshSelfId` fix (live-confirmed: Mini on 1.3.700, `/pool/reconciler` still 503, 0 ticks). Fix: gate construction on the ownership registry (ready early) and read the pin store via a late-bound getter at tick time — the same pattern as #1312 and the sibling `OwnershipApplier`. With both late dependencies now read at run-time, the loop's construction no longer depends on boot order at all.
+
+## Evidence
+
+- Unit: `tests/unit/OwnershipReconciler.test.ts` — 33 tests incl. a new regression test (a null pin store at boot is a no-op even with a triggering pin; once it resolves, the SAME instance transfers) alongside the #1312 self-id regression tests — both late deps now guarded.
+- All `new OwnershipReconciler` construction sites updated to the late-bound pin-store shape. Build clean.
+
+## What to Tell Your User
+
+Nothing yet — the convergence loop remains off by default (dev-gated). This completes the wiring so that when it is enabled, the loop is actually built and runs (it never was before). No change to normal use.
+
+## Summary of New Capabilities
+
+- (Dark) The cross-machine convergence loop is now actually constructed on every multi-machine machine — both startup-ordering bugs that kept it from being built are fixed.

--- a/upgrades/side-effects/reconciler-pinstore-ordering-fix.md
+++ b/upgrades/side-effects/reconciler-pinstore-ordering-fix.md
@@ -1,0 +1,77 @@
+# Side-Effects Review — Reconciler Pin-Store Boot-Ordering Fix
+
+**Version / slug:** `reconciler-pinstore-ordering-fix`
+**Date:** 2026-06-30
+**Author:** echo (autonomous run, topic 28744)
+**Second-pass reviewer:** echo second-pass subagent (reconciler decision surface)
+
+## Summary of the change
+
+Completes #1312. The `OwnershipReconciler` construction in server.ts was gated `if (_topicPinStore)`,
+but `_topicPinStore` is assigned ~2200 lines LATER in the synchronous boot flow (line ~19134 vs the
+reconciler block ~16924) — so the gate was always null and the reconciler was STILL never constructed
+even after the `_meshSelfId` fix. Live-confirmed: Mini on 1.3.700, `/pool/reconciler` still 503, 0
+ticks. Fix: gate construction on `ownReg` (the ownership registry, available at the block since ~16885,
+inside `if (durableOwnershipOn)`), and make `pinStore` a late-bound getter `() => TopicPlacementPinStore
+| null` read at tick time — the SAME pattern as `selfMachineId` (#1312) and the sibling OwnershipApplier.
+A tick while the store is still null yields no pins (a natural no-op). Files: `src/core/OwnershipReconciler.ts`
+(dep getter + null-safe effectivePins), `src/commands/server.ts` (gate + getter), tests.
+
+## Decision-point inventory
+
+- `OwnershipReconciler` construction gate (server.ts) — **modify** — `if (_topicPinStore)` → `if (ownReg)`
+  (the late-null pin store no longer blocks construction; ownReg is always set within durableOwnership).
+- `OwnershipReconciler.effectivePins()` — **modify** — reads the pin store via the getter, null-safe
+  (no pins while null → natural no-op).
+
+## 1. Over-block
+
+No message surface. The only "refusal" is a tick yielding no pins while the store is null (early boot) —
+strictly more conservative than before (before, the loop never ran at all). Once the store resolves, no
+legitimate pin is missed.
+
+## 2. Under-block
+
+The null-store window is bounded to early boot (the store is assigned synchronously during boot). A tick
+in that window no-ops; the interval keeps ticking, so the first post-assignment tick acts. No failure mode
+is newly missed — the reconciler simply starts working where it never did.
+
+## 3. Level-of-abstraction fit
+
+Correct — identical late-binding pattern to #1312 + the OwnershipApplier. The alternative (relocating the
+construction ~2200 lines down to after the pin store) is far riskier (scope, ordering of intervening
+consumers). Late-binding makes the construction independent of boot order — the robust fix.
+
+## 4. Signal vs authority compliance
+
+Compliant. The reconciler's authority (cooperative transfer / force-claim within the FSM) is unchanged.
+A late-bound pin store is a wiring correction, not a new decision. A null-store tick is a no-op, never an
+action.
+
+## 5. Interactions
+
+The pin-store getter mirrors the self-id getter; both resolve at tick time. No double-fire (one instance,
+one timer). With both late deps now getters, the construction no longer depends on the assignment order of
+ANY late var — closing the whole ordering-bug class. The advisory-pin read path is unchanged.
+
+## 6. External surfaces
+
+`/pool/reconciler` now returns real status (not 503) once the reconciler constructs — the intended fix.
+No new route/config. The reconciler beginning to actually tick is the behavioral change; it remains
+dark/dev-gated (`ws13Reconcile`), so the fleet is unaffected; a dev agent's reconciler now runs.
+
+## 7. Multi-machine posture (Cross-Machine Coherence)
+
+A multi-machine fix. The reconciler is machine-local BY DESIGN (each machine reconciles its own view
+against the shared journal). The fix ensures it is actually constructed on every machine with an
+ownership registry (i.e. every durable-ownership / multi-machine machine). Single-machine still no-ops
+(machines() < 2).
+
+## 8. Rollback cost
+
+Cheap. Dark/dev-gated (`ws13Reconcile`), dry-run default (`ws13DryRun !== false`). Back-out = a config
+flip. Pure wiring/ordering correction, no schema impact.
+
+## Second-pass reviewer response
+
+**Concur with the review.** An independent reviewer verified all four points against the code: (1) `ownReg` is truthy at the construction gate (`sessionOwnershipRegistry` constructed at server.ts:16878, `ownReg` at 16885, both before the `if (ownReg)` gate at 16930) — and noted the registry is constructed unconditionally, which is immaterial/safe because the reconciler's own gates (`enabled()` via the `ws13Reconcile` dev-gate, and the `machines().length < 2 → skipped:'single-machine'` early return) keep it inert when it shouldn't act; (2) `pinStore` is read null-safely (the only runtime read is `const ps = this.d.pinStore(); const local = ps ? ps.all() : {}`); (3) **no THIRD late-assigned construction dep** — of the 10 deps, only `ownership: ownReg` is a direct value (resolved at 16885, before construction); every other dep is a getter/closure read at tick time, and the two module values read inside them use optional chaining; (4) a null-pinStore tick truly no-ops (`effectivePins()` returns `{}`, the loop never executes, zero CAS; plus `dryRun` defaults true). The fix correctly completes #1312.


### PR DESCRIPTION
Completes #1312. **Found by driving the feature through live** — after #1312 deployed, the convergence loop was STILL never constructed.

## ELI16

#1312 made the convergence loop not depend on the machine's identity being set up first. But its startup check depends on TWO things, and the SECOND — the "pin store" where the move instruction is recorded — is set up ~2200 lines LATER in the server's startup than the loop is wired. So the check still failed and the loop was STILL never built (live-confirmed: Mini on 1.3.700, the loop's status endpoint still 503, zero activity). The fix applies the same proven late-binding pattern to the pin store too: build the loop whenever the ownership registry exists (ready early), and read the pin store at run-time (each tick) instead of at wire-time. With both late dependencies now read at run-time, the loop's construction no longer depends on server boot order at all — closing the whole "wired before its dependencies exist" bug class.

## What changed
- `src/commands/server.ts`: reconciler construction gated on `ownReg` (available at the block) instead of the late `_topicPinStore`; `pinStore: () => _topicPinStore` (late-bound).
- `src/core/OwnershipReconciler.ts`: `pinStore` dep is now `() => TopicPlacementPinStore | null`, read null-safely at tick time (a null store yields no pins → natural no-op).

## Tests
- `tests/unit/OwnershipReconciler.test.ts`: 33 tests incl. a new regression test (null pin store at boot → no-op even with a triggering pin; once it resolves, the SAME instance transfers) alongside the #1312 self-id regression tests — both late deps guarded.
- Second-pass reviewer concurred, verifying there is **no third** late-assigned construction dep.

## Safety
Dark/dev-gated (`ws13Reconcile`), dry-run default. Rollback = a config flip. Pure wiring/ordering correction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
