### PR TITLE
fix(multimachine): mirror transferring record into receive-side journal validator (completes #3)

### DIFF
--- a/.instar/instar-dev-decisions/2026-06-30T08-07-59-067Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-06-30T08-07-59-067Z-unknown.json
@@ -1,0 +1,13 @@
+{
+  "ts": "2026-06-30T08:07:59.067Z",
+  "slug": "unknown",
+  "suggestedTier": 1,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 18,
+  "causalAutopsy": null,
+  "verdict": "pass"
+}

--- a/docs/specs/reconciler-receive-validator-mirror.eli16.md
+++ b/docs/specs/reconciler-receive-validator-mirror.eli16.md
@@ -1,0 +1,68 @@
+# ELI16 — Mirror the cross-machine transfer record into the receive-side validator
+
+## What this is, in plain English
+
+When you run one agent across two machines, a conversation can be "owned" by one
+machine, and sometimes it needs to be handed to the other (you pinned it there, or
+the balancer wants it moved). The machine that currently owns it writes a little note
+into a shared log — *"I'm handing conversation 28730 to the other machine"* — and the
+other machine reads that log, sees the note, and takes ownership. That hand-off note is
+the core of the cross-machine "stuck move" fix (root cause #3).
+
+There are **two copies of the rule** that decides whether a log note is well-formed:
+one on the **sending** side (when a machine writes a note) and one on the **receiving**
+side (when the other machine reads it). The code literally carries a *"KEEP IN SYNC"*
+comment between them, because a log stream is validated on receipt and any note that
+fails validation makes the receiver declare the whole stream "suspect" and **stop
+reading it**.
+
+The earlier fix taught the **sending** side about the new hand-off note shape (a new
+`reason` value, `reconcile`, plus a few optional fields like `status: transferring`
+and `transferTo`). It **missed** teaching the **receiving** side. So in real life: the
+owner writes a perfectly valid hand-off note, the receiving machine reads it, doesn't
+recognize the new shape, marks the stream suspect, and stops — the transfer never
+arrives, and the target never claims the conversation. The move stays stuck.
+
+## What already exists
+
+- The cross-machine ownership reconciler (the loop that decides a move is needed and
+  writes the hand-off note). Proven working in a live two-machine run — it correctly
+  wrote the hand-off note for the real stuck conversation.
+- The send-side validator (`CoherenceJournal.validate`) which already accepts the new
+  hand-off note shape.
+- The receive-side validator (`JournalSyncApplier.validateData`), a hand-mirrored copy
+  of the send-side one, which did **not** accept it. That's the bug.
+
+## What's new
+
+One change: the receive-side validator's `topic-placement` branch is updated to mirror
+the send-side one **exactly** — it now accepts the `reconcile` reason and the optional
+hand-off fields (`status` must be `active` or `transferring`; `transferTo` a string;
+`timestamp` a finite number; `drainInFlight` a boolean), and it rejects a malformed
+one (so a garbage value is still refused, never silently half-accepted).
+
+## The safeguards, in plain terms
+
+- **Back-compatible:** an old-style note with no hand-off fields still validates exactly
+  as before (an absent `status` means "active", today's behavior).
+- **Strict on malformed:** a present-but-wrong field (e.g. `status: "bogus"`, or an
+  unknown extra key) is still rejected — the change only accepts the *correct* new
+  shape, it does not loosen the allowlist.
+- **No behavior flag needed:** this is a pure correctness fix to validation that should
+  always have matched the send side. It does not introduce a new capability or a new
+  decision; it makes an existing one correct.
+
+## Why the tests missed it (and how it's covered now)
+
+The earlier tests checked the send side and the "apply the materialized transfer" side
+**in one process**. The receive-side validation step only runs when a note actually
+travels **between two machines**, so a single-process test never exercised it. The new
+tests drive the receive-side validator directly with a real transferring note and assert
+the stream stays healthy (before the fix they fail — the stream goes suspect), plus
+guards that a malformed hand-off field is still rejected.
+
+## What you need to decide
+
+Nothing risky. This completes an already-approved fix (#3) so that it actually works
+across machines. Ship it, and the real stuck conversation finishes its move on its own —
+no manual intervention.

--- a/src/core/JournalSyncApplier.ts
+++ b/src/core/JournalSyncApplier.ts
@@ -588,12 +588,26 @@ export class JournalSyncApplier {
     }
 
     if (kind === 'topic-placement') {
-      const reasons: PlacementReason[] = ['user-move', 'placed', 'failover', 'released', 'quota-block-move'];
+      // KEEP IN SYNC with CoherenceJournal.validate() topic-placement branch (the
+      // emit-side source of truth). WS1.3/Fix #3 (#1311) added the 'reconcile' reason
+      // AND the cooperative-handoff fields (status/transferTo/timestamp/drainInFlight)
+      // on the emit side but NOT here — so a real cross-machine transferring record
+      // failed receive-validation, marked the peer stream `suspect`, and halted
+      // replication so the target never claimed (live two-machine proof catch,
+      // 2026-06-30; in-process tests covered emit + applier-materialize, never this
+      // receive-validation path). Mirror EXACTLY.
+      const reasons: PlacementReason[] = ['user-move', 'placed', 'failover', 'released', 'quota-block-move', 'reconcile'];
       if (typeof raw.owner !== 'string' || !raw.owner) return false;
       if (typeof raw.epoch !== 'number' || !Number.isFinite(raw.epoch)) return false;
       if (typeof raw.reason !== 'string' || !reasons.includes(raw.reason as PlacementReason)) return false;
       if (raw.prevOwner !== undefined && typeof raw.prevOwner !== 'string') return false;
-      const known = ['owner', 'epoch', 'reason', 'prevOwner'];
+      // Fix #3 OPTIONAL handoff fields. Back-compat: an absent `status` is `active`.
+      // A present-but-malformed field rejects the record (never a silent partial accept).
+      if (raw.status !== undefined && raw.status !== 'active' && raw.status !== 'transferring') return false;
+      if (raw.transferTo !== undefined && typeof raw.transferTo !== 'string') return false;
+      if (raw.timestamp !== undefined && (typeof raw.timestamp !== 'number' || !Number.isFinite(raw.timestamp))) return false;
+      if (raw.drainInFlight !== undefined && typeof raw.drainInFlight !== 'boolean') return false;
+      const known = ['owner', 'epoch', 'reason', 'prevOwner', 'status', 'transferTo', 'timestamp', 'drainInFlight'];
       return keys.every((k) => known.includes(k));
     }
     if (kind === 'session-lifecycle') {

--- a/tests/unit/JournalSyncApplier.test.ts
+++ b/tests/unit/JournalSyncApplier.test.ts
@@ -73,6 +73,30 @@ function placement(seq: number, machine: string, topic: number, epoch: number, t
   };
 }
 
+/**
+ * Build a cooperative-handoff (transferring) placement entry — WS1.3/Fix #3.
+ * `reason: 'reconcile'` + the optional handoff fields. This is the exact shape a
+ * real cross-machine ownership-reconciler transfer writes; the receive-side
+ * validator must accept it (the 2026-06-30 live-proof bug: it didn't).
+ */
+function transferringPlacement(
+  seq: number,
+  machine: string,
+  topic: number,
+  epoch: number,
+  transferTo: string,
+  extra: Record<string, unknown> = {},
+): JournalEntry {
+  return {
+    seq,
+    ts: new Date(1_700_000_000_000 + seq * 1000).toISOString(),
+    machine,
+    kind: 'topic-placement',
+    topic,
+    data: { owner: machine, epoch, reason: 'reconcile', status: 'transferring', transferTo, timestamp: 1_700_000_000_000 + seq * 1000, ...extra },
+  };
+}
+
 function lifecycle(seq: number, machine: string, sessionId: string, status: string, ts?: string): JournalEntry {
   return {
     seq,
@@ -96,6 +120,82 @@ function readReplicaEntries(machine: string, kind: JournalKind): JournalEntry[] 
 function newApplier(opts: Partial<ConstructorParameters<typeof JournalSyncApplier>[0]> = {}): JournalSyncApplier {
   return new JournalSyncApplier({ stateDir: tmpDir, ...opts });
 }
+
+// ---------------------------------------------------------------------------
+// Fix #3 receive-side validation of cooperative-handoff (transferring) records.
+// Regression for the 2026-06-30 live two-machine proof: the emit-side validator
+// (CoherenceJournal.validate) accepted reason:'reconcile' + status/transferTo/
+// timestamp/drainInFlight, but the receive-side mirror here did NOT — so a real
+// transfer record was rejected on receipt, the peer stream went `suspect`, and
+// cross-machine replication halted so the target never claimed. The receive-side
+// MUST mirror the emit-side. (In-process tests covered emit + applier-materialize,
+// never this cross-machine receive path — which is why two machines exposed it.)
+// ---------------------------------------------------------------------------
+
+describe('Fix #3 — receive-side accepts cooperative-handoff (transferring) records', () => {
+  it('a transferring record (reason:reconcile + handoff fields) is applied, NOT suspect', () => {
+    const a = newApplier();
+    const res = a.apply(PEER, [
+      {
+        kind: 'topic-placement',
+        incarnation: 'inc-1',
+        // seq 1 a normal active placement, seq 2 the transfer hand-off — exactly the
+        // real sequence the live proof produced (active(owner) → transferring(→target)).
+        entries: [placement(1, PEER, 28730, 2), transferringPlacement(2, PEER, 28730, 3, OWN)],
+      },
+    ]);
+    expect(res.applied).toBe(2);
+    expect(res.invalidEntries).toBe(0);
+    expect(readReplicaEntries(PEER, 'topic-placement').map((e) => e.seq)).toEqual([1, 2]);
+    // The crux: the stream stays current (before the fix this was 'suspect' and
+    // replication halted at seq 1, so the target never saw the transfer).
+    expect(a.getStreamStatus()[`${PEER}.topic-placement`]).toBe('current');
+    const applied = readReplicaEntries(PEER, 'topic-placement')[1];
+    expect(applied.data).toMatchObject({ reason: 'reconcile', status: 'transferring', transferTo: OWN });
+  });
+
+  it('accepts an explicit status:active record and an optional drainInFlight flag', () => {
+    const a = newApplier();
+    const res = a.apply(PEER, [
+      {
+        kind: 'topic-placement',
+        incarnation: 'inc-1',
+        entries: [transferringPlacement(1, PEER, 700, 5, OWN, { status: 'active', drainInFlight: true })],
+      },
+    ]);
+    expect(res.applied).toBe(1);
+    expect(a.getStreamStatus()[`${PEER}.topic-placement`]).toBe('current');
+  });
+
+  it('a present-but-malformed handoff field is still rejected → suspect (no silent partial accept)', () => {
+    const a = newApplier();
+    const res = a.apply(PEER, [
+      {
+        kind: 'topic-placement',
+        incarnation: 'inc-1',
+        // status must be 'active'|'transferring' — a bogus value rejects the record.
+        entries: [placement(1, PEER, 700, 1), transferringPlacement(2, PEER, 700, 2, OWN, { status: 'bogus' })],
+      },
+    ]);
+    expect(res.applied).toBe(1);
+    expect(res.invalidEntries).toBe(1);
+    expect(a.getStreamStatus()[`${PEER}.topic-placement`]).toBe('suspect');
+  });
+
+  it('an unknown extra field on a placement record is still rejected → suspect (keys allowlist intact)', () => {
+    const a = newApplier();
+    const res = a.apply(PEER, [
+      {
+        kind: 'topic-placement',
+        incarnation: 'inc-1',
+        entries: [transferringPlacement(1, PEER, 700, 2, OWN, { bogusKey: 'x' })],
+      },
+    ]);
+    expect(res.applied).toBe(0);
+    expect(res.invalidEntries).toBe(1);
+    expect(a.getStreamStatus()[`${PEER}.topic-placement`]).toBe('suspect');
+  });
+});
 
 // ---------------------------------------------------------------------------
 // Rule 2 — seq-gated apply (in-order / gap / duplicate)

--- a/upgrades/next/reconciler-receive-validator-mirror.md
+++ b/upgrades/next/reconciler-receive-validator-mirror.md
@@ -1,0 +1,42 @@
+<!-- bump: patch -->
+
+## What Changed
+
+Completes root cause #3 of the cross-machine "stuck move" fix. The ownership
+reconciler writes a cooperative-handoff record (`reason: 'reconcile'` + optional
+`status`/`transferTo`/`timestamp`/`drainInFlight`) into the coherence journal when it
+transfers a topic between machines. The journal has TWO hand-mirrored validators — emit
+(`CoherenceJournal.validate`) and receive (`JournalSyncApplier.validateData`) — that
+carry a "KEEP IN SYNC" comment. #1311 extended the emit side to accept the handoff shape
+but never mirrored it into the receive side. So the RECEIVING machine rejected every
+real transferring record, marked the peer's `topic-placement` stream `suspect`, and
+HALTED cross-machine replication — the target never claimed, the move stayed stuck. This
+mirrors the emit-side validation into the receive side (accept `reconcile` + the handoff
+fields with the same strict per-field checks and `known`-keys allowlist), so a transfer
+record replicates and the target claims. Surfaced by a live two-machine proof — the
+single-process tests covered emit + applier-materialize but never the cross-machine
+receive-validation step.
+
+## What to Tell Your User
+
+Nothing yet — the convergence loop remains off by default (dev-gated). This makes the
+already-shipped #3 fix actually work end-to-end across machines (it never did before:
+the receiving side rejected the hand-off). No change to normal use.
+
+## Summary of New Capabilities
+
+- (Dark) Cross-machine ownership transfers now replicate end-to-end: the receive-side
+  journal validator accepts the cooperative-handoff record the reconciler emits, so the
+  target machine claims the topic instead of the stream silently going `suspect`.
+
+## Evidence
+
+- Unit: `tests/unit/JournalSyncApplier.test.ts` — new describe block "Fix #3 — receive-side
+  accepts cooperative-handoff (transferring) records": a real transferring record applies
+  + stream stays `current` (FAILS before the fix — stream goes `suspect`); explicit
+  `status:active` + `drainInFlight` accepted; a malformed handoff field still rejected →
+  `suspect`; an unknown extra key still rejected. 30 tests pass; the 2 acceptance tests
+  fail for the right reason with the fix reverted (verified).
+- Related multi-machine suite green: JournalSyncApplier + CoherenceJournal +
+  OwnershipReconciler + OwnershipApplier + CoherenceJournalReader + topic-pin-replication
+  + pool-reconciler-route = 145 tests pass. `tsc --noEmit` clean.

--- a/upgrades/side-effects/reconciler-receive-validator-mirror.md
+++ b/upgrades/side-effects/reconciler-receive-validator-mirror.md
@@ -1,0 +1,79 @@
+# Side-Effects Review — Mirror transfer record into receive-side validator
+
+**Slug:** reconciler-receive-validator-mirror
+**Change:** Update `JournalSyncApplier.validateData`'s `topic-placement` branch to mirror
+the emit-side `CoherenceJournal.validate` — accept `reason: 'reconcile'` and the optional
+cooperative-handoff fields (`status`/`transferTo`/`timestamp`/`drainInFlight`), with the
+same strict per-field type checks and the same `known`-keys allowlist.
+
+**Why:** Live two-machine proof (2026-06-30). The ownership reconciler correctly wrote a
+real transferring record for the stuck topic 28730, but the RECEIVING machine rejected it
+in `validateData` (reason `reconcile` not in the receive-side `reasons` list; the handoff
+fields not in the receive-side `known` list), marking the peer's `topic-placement` stream
+`suspect` and halting cross-machine replication — so the target never claimed. Completes
+root cause #3 (`docs/specs/cross-machine-reconciler-convergence.md`), whose emit-side
+extension (#1311) was never mirrored to the receive side.
+
+## 1. Over-block — what legitimate inputs does this reject that it shouldn't?
+None. The change makes the receive-side validator MORE accepting, and only of inputs the
+emit-side already produces and accepts. Before the fix it over-blocked (rejected every
+valid transferring record); after, it accepts exactly the emit-side's accepted set. A
+normal active placement (no handoff fields) validates exactly as before.
+
+## 2. Under-block — what failure modes does this still miss?
+A malformed handoff field is still rejected (status not in {active,transferring};
+non-string transferTo; non-finite timestamp; non-boolean drainInFlight; any unknown key →
+the `known` allowlist still rejects). The validator does not cross-check semantic
+consistency (e.g. status:transferring with no transferTo) — but neither does the emit
+side, and the OwnershipApplier (the consumer) already validates transferTo against the
+known machine set + epoch fence + timestamp clamp before acting. So nothing actionable is
+under-blocked here; semantic checks live in the applier by design.
+
+## 3. Level-of-abstraction fit — right layer?
+Yes. This is exactly the receive-side schema mirror of the emit-side schema; the two are
+designed to be byte-for-byte equivalent (the source carries a "KEEP IN SYNC" comment).
+The fix belongs in `validateData` and nowhere else.
+
+## 4. Signal vs authority compliance
+This is a validator (accept/reject of a journal record on receipt) — it holds authority by
+design (an invalid record MUST be rejected). The relevant principle here is not
+signal-vs-authority but **schema-mirror integrity**: a hand-mirrored validator that drifts
+from its source silently breaks replication. The real structural follow-up (logged below)
+is to make the two validators share ONE source so they cannot drift again — but that is a
+larger refactor; this change first restores correctness. The fix does not ADD blocking
+authority; it corrects an existing validator that was wrongly rejecting valid input.
+
+## 5. Interactions — shadow / double-fire / race?
+None. `validateData` is the single receive-side gate; this branch only runs for
+`topic-placement`. It does not interact with the emit side (separate process/machine), the
+applier-materialize step (runs after a record is accepted), or any cleanup. It cannot
+double-fire (one validation per received entry).
+
+## 6. External surfaces — visible to other agents/users/systems?
+Yes, positively: it unblocks cross-machine ownership transfers that were silently halting.
+No new endpoint, config, or user-visible surface. The only observable change is that a
+peer's `topic-placement` stream no longer goes `suspect` on a transferring record, so
+`GET /pool/placement` / the per-machine ownership records converge as intended. Timing: the
+receiver picks up the transfer on its normal journal-pull cadence (seconds), unchanged.
+
+## 7. Multi-machine posture (Cross-Machine Coherence)
+This change IS a multi-machine coherence fix. Posture: **replicated** — the corrected
+validator is on the receive side of the CoherenceJournal cross-machine replication path
+(peer `topic-placement` stream → `JournalSyncApplier.apply`). The fix is symmetric (both
+machines run the same corrected validator), so transfers in either direction now validate.
+There is no single-machine assumption (single-machine agents never invoke the receive
+path; this is a strict no-op for them).
+
+## 8. Rollback cost
+Trivial. The change is a few added lines in one validator branch. Back-out = revert the
+commit; behavior returns to the (buggy) prior state. No data migration, no state repair: a
+journal stream that went `suspect` self-clears after K=20 clean applies once valid records
+flow, and the replica files are re-pulled from the source of truth (the authoring machine's
+journal). No durable corruption is possible from this change.
+
+## Follow-up logged
+The two validators (`CoherenceJournal.validate` emit-side and
+`JournalSyncApplier.validateData` receive-side) are hand-mirrored and CAN drift again. A
+structural fix — extract ONE shared per-kind schema both sides call — would prevent the
+whole bug class. Tracked: <!-- tracked: CMT-1840 --> (a structural refactor registered as a
+durable commitment; this PR restores correctness for the shipped transferring shape).


### PR DESCRIPTION
Completes root cause #3 of the cross-machine "stuck move" fix. **Found by driving the feature through live** — both machines on 1.3.701 ran the convergence loop and the Mini correctly transferred the real stuck topic, but the receiving machine never claimed it.

## ELI16

When one machine hands a conversation to another, it writes a "hand-off note" into a shared log, and the other machine reads that log to take over. There are TWO copies of the rule that decides "is this note well-formed?" — one on the SEND side, one on the RECEIVE side — and the code literally carries a "KEEP IN SYNC" comment between them, because the receiving machine validates every note on receipt and any note that fails makes it declare the whole log stream "suspect" and STOP reading it. #1311 taught the send side about the new hand-off note shape (a new `reason` value `reconcile`, plus optional `status`/`transferTo`/`timestamp`/`drainInFlight` fields) but never mirrored it into the receive side. So in a real two-machine run, the owner wrote a valid hand-off note, the receiver rejected it (unknown reason + unknown fields), marked the stream suspect, and halted replication — the transfer never arrived and the target never claimed. This mirrors the send-side validation into the receive side exactly: accept `reconcile` and the hand-off fields with the same strict per-field type checks and the same known-keys allowlist. Back-compatible (an absent hand-off field validates as before); malformed fields and unknown keys are still rejected.

## What changed
- `src/core/JournalSyncApplier.ts`: the `topic-placement` branch of `validateData` (the cross-machine RECEIVE validator) now mirrors `CoherenceJournal.validate` (the emit-side source of truth) field-for-field — `reasons` includes `reconcile`; `status` ∈ {active,transferring}; `transferTo` string; `timestamp` finite number; `drainInFlight` boolean; `known` keys allowlist extended to all 8.

## Why the tests missed it
The in-process tests covered the emit side and the apply-materialize side, but the receive-validation step only runs when a note travels BETWEEN machines — so a single-process test never exercised it. Two machines were required to expose it (same story as the three boot-ordering bugs in #1311/#1312/#1313).

## Tests
- `tests/unit/JournalSyncApplier.test.ts`: new "Fix #3 — receive-side accepts cooperative-handoff (transferring) records" block — a real transferring record applies and the stream stays `current` (FAILS for the right reason without the fix: stream goes `suspect`, replication stops at the prior seq); explicit `status:active` + `drainInFlight` accepted; a malformed handoff field still rejected → `suspect`; an unknown extra key still rejected. 30/30 pass.
- Related multi-machine suite green: JournalSyncApplier + CoherenceJournal + OwnershipReconciler + OwnershipApplier + CoherenceJournalReader + topic-pin-replication + pool-reconciler-route = 145 tests. `tsc --noEmit` clean.
- Independent second-pass reviewer concurred — verified the receive-side validator now EXACTLY mirrors the emit-side, is back-compatible, and rejects malformed input on both sides of the boundary.

## Evidence
145 related multi-machine tests pass; tsc clean; the new acceptance tests fail-without/pass-with the fix (verified by reverting the source while keeping the tests). Live: the Mini's reconciler wrote the transferring record (`transfer landed for 28730, epoch 3`); this fix lets the Laptop's receive-validation accept it so the target claims.

## Safety
Dark/dev-gated (`ws13Reconcile`), dry-run default — the reconciler that emits transferring records is off by default. Pure validation correctness fix (mirror an existing emit-side schema into its receive-side hand-mirror). Back-compatible; rollback = revert the commit (a suspect stream self-clears after 20 clean applies; replicas re-pull from source). Follow-up CMT-1840 to unify the two hand-mirrored validators into one shared schema so the drift class can't recur.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
