### PR TITLE
test(multimachine): add Tier-3 feature-alive e2e for the ownership reconciler

### DIFF
--- a/docs/specs/reconciler-alive-e2e.eli16.md
+++ b/docs/specs/reconciler-alive-e2e.eli16.md
@@ -1,0 +1,48 @@
+# ELI16 — Add the missing Tier-3 feature-alive E2E for the ownership reconciler
+
+## What this is, in plain English
+
+The cross-machine "stuck move" fix (the ownership reconciler) shipped with unit tests
+and integration tests, but it never got the THIRD kind of test the project's Testing
+Integrity Standard requires for every feature with API routes: a "Tier-3 feature-alive"
+end-to-end test. That tier answers one blunt question — *when you actually start a real
+server, is the feature reachable and does it work, or does its API route return 503
+because something wasn't wired up?*
+
+This change adds exactly that test for the reconciler: it starts a real `AgentServer`
+with the reconciler wired in, then over real HTTP (with auth) it checks that
+`GET /pool/reconciler` returns **200, not 503**, that it reports it can see both
+machines, and — most importantly — that the reconciler **actually converges**: it ticks
+once and the topic that was pinned to the other machine gets handed off (marked
+"transferring" toward the pin target), and the live status route reflects that transfer.
+
+## Why this matters (and why it was missing)
+
+The reconciler is the feature that closes the cross-machine stuck-move bug. Its earlier
+"boot-ordering" defects — where the reconciler was never even constructed at server boot,
+so its route returned 503 on real machines — slipped past the unit and integration tests
+because those construct the reconciler by hand. They were caught only by a live
+two-machine run. A feature-alive E2E is the standing category of test that catches
+"the dependency wasn't wired" defects. The reconciler simply didn't have one, so this
+adds it (mirroring the existing `pool-placement-transfer-alive` E2E).
+
+## What's new
+
+One new test file: `tests/e2e/pool-reconciler-alive-lifecycle.test.ts` (4 tests). No
+runtime/source code changes at all — this is test-only coverage that completes the
+three-tier requirement (unit + integration + e2e) for the reconciler fix.
+
+## The safeguards, in plain terms
+
+- **Test-only.** It changes no shipping behavior; it can only make CI stricter, never
+  weaken it. Rollback is deleting one file.
+- **Honest scope.** It wires `AgentServer` directly (like its sibling E2E tests), so it
+  proves the route + the convergence are alive end-to-end. It deliberately does NOT claim
+  to re-run `server.ts`'s exact boot sequence; the boot-ordering construction itself is
+  covered by the reconciler unit tests' late-bound-dependency regression cases. The test
+  comment states this plainly so no future reader over-trusts it.
+
+## What you need to decide
+
+Nothing risky. This is additive test coverage that closes the missing Tier-3 tier for an
+already-shipped, already-proven fix. Merge it and the reconciler has all three test tiers.

--- a/tests/e2e/pool-reconciler-alive-lifecycle.test.ts
+++ b/tests/e2e/pool-reconciler-alive-lifecycle.test.ts
@@ -1,0 +1,132 @@
+/**
+ * Tier-3 "feature is alive" E2E for the WS1.3 OwnershipReconciler — the cross-machine
+ * stuck-move fix (root causes #1/#2/#3). Per CLAUDE.md the Tier-3 test is "the single
+ * most important test for any feature with API routes": it proves GET /pool/reconciler
+ * is reachable through the REAL AgentServer stack (auth middleware, error handling) and
+ * returns 200 — NOT 503 because the reconciler wasn't wired — AND that the reconciler
+ * actually CONVERGES a pinned topic (owner != pin -> transfer) through the real stack.
+ *
+ * WHY THIS TIER EXISTS HERE: the reconciler had NO tests/e2e/ coverage proving the
+ * /pool/reconciler route is alive (200, not 503) and the reconciler actually converges
+ * through the real AgentServer stack — only unit + integration tests that construct the
+ * reconciler by hand. A feature-alive E2E is the category that catches "the dep wasn't
+ * wired" defects — the same class as the boot-ordering bugs (#1312/#1313) that shipped
+ * because nothing exercised the reconciler as a live wired dependency (those were caught
+ * only by a live two-machine run). Like its sibling pool-placement-transfer-alive, this
+ * wires AgentServer directly (it does not re-run server.ts's boot sequence), so it proves
+ * the route + the convergence are alive end-to-end; the server.ts construction ordering
+ * itself is asserted by OwnershipReconciler.test.ts's late-bound-dep regression tests.
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { AgentServer } from '../../src/server/AgentServer.js';
+import { StateManager } from '../../src/core/StateManager.js';
+import { SessionManager } from '../../src/core/SessionManager.js';
+import { SessionOwnershipRegistry, InMemorySessionOwnershipStore } from '../../src/core/SessionOwnershipRegistry.js';
+import { TopicPlacementPinStore } from '../../src/core/TopicPlacementPinStore.js';
+import { OwnershipReconciler } from '../../src/core/OwnershipReconciler.js';
+import type { InstarConfig } from '../../src/core/types.js';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+
+describe('E2E: OwnershipReconciler is ALIVE + converges through the real AgentServer', () => {
+  const PORT = 47261;
+  const SELF = 'm_a'; // owns topic 700
+  const PEER = 'm_b'; // pin target — the reconciler should transfer 700 SELF -> PEER
+  const TOKEN = 'e2e-recon-token';
+  let dir: string;
+  let server: AgentServer;
+  let reconciler: OwnershipReconciler;
+  let ownReg: SessionOwnershipRegistry;
+  const base = `http://127.0.0.1:${PORT}`;
+  const auth = { Authorization: `Bearer ${TOKEN}`, 'Content-Type': 'application/json' };
+
+  beforeAll(async () => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'recon-alive-e2e-'));
+    const seen = new Set<string>();
+    ownReg = new SessionOwnershipRegistry({
+      store: new InMemorySessionOwnershipStore(),
+      seenNonce: (k) => seen.has(k),
+      recordNonce: (k) => seen.add(k),
+    });
+    // SELF actively owns topic 700.
+    ownReg.cas({ type: 'place', machineId: SELF }, { sessionKey: '700', sender: SELF, nonce: 'p' });
+    ownReg.cas({ type: 'claim', machineId: SELF }, { sessionKey: '700', sender: SELF, nonce: 'c' });
+    const pinStore = new TopicPlacementPinStore({ filePath: path.join(dir, 'topic-pins.json') });
+    pinStore.set('700', PEER); // pinned away -> the reconciler must transfer 700 to PEER
+
+    reconciler = new OwnershipReconciler({
+      enabled: () => true,
+      dryRun: () => false,
+      selfMachineId: () => SELF,
+      pinStore: () => pinStore,
+      ownership: ownReg,
+      machines: () => [
+        { machineId: SELF, online: true, lastSeenMs: Date.now() },
+        { machineId: PEER, online: true, lastSeenMs: Date.now() },
+      ],
+      isTopicBusy: () => false,
+      emitPlacement: () => {},
+      debounceMs: 0,
+    });
+
+    const config = {
+      projectName: 'recon-alive-e2e',
+      projectDir: dir,
+      stateDir: dir,
+      port: PORT,
+      authToken: TOKEN,
+    } as unknown as InstarConfig;
+
+    server = new AgentServer({
+      config,
+      sessionManager: new SessionManager({ projectDir: dir, port: PORT }),
+      state: new StateManager(dir),
+      sessionOwnershipRegistry: ownReg,
+      ownershipReconciler: reconciler,
+      meshSelfId: SELF,
+    });
+    await server.start();
+  }, 20000);
+
+  afterAll(async () => {
+    await server?.stop();
+    SafeFsExecutor.safeRmSync(dir, { recursive: true, force: true, operation: 'tests/e2e/pool-reconciler-alive-lifecycle.test.ts' });
+  });
+
+  it('GET /pool/reconciler is ALIVE (200, not 503) — the reconciler is wired through the real stack', async () => {
+    const res = await fetch(`${base}/pool/reconciler`, { headers: auth });
+    expect(res.status).toBe(200); // 503 here is the boot-ordering "never constructed" bug
+    const body = await res.json();
+    expect(body.status).toBeTruthy();
+    expect(body.status.machinesCount).toBe(2);
+    expect(body.status.selfMachineId).toBe(SELF);
+    expect(body.status.enabled).toBe(true);
+  });
+
+  it('GET /pool/reconciler?topic=N explains the convergence decision (owner != pin -> transfer)', async () => {
+    const res = await fetch(`${base}/pool/reconciler?topic=700`, { headers: auth });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.topic.decision).toBe('transfer');
+    expect(body.topic.preferredMachine).toBe(PEER);
+  });
+
+  it('the reconciler CONVERGES the pinned topic: one tick transfers 700 SELF -> PEER through the real stack', async () => {
+    reconciler.tick();
+    // The owner set the topic transferring toward the pin target (the cross-machine handoff start).
+    const rec = ownReg.read('700');
+    expect(rec?.status).toBe('transferring');
+    expect(rec?.transferTo).toBe(PEER);
+    // And the live status route reflects the transfer the reconciler just performed.
+    const res = await fetch(`${base}/pool/reconciler`, { headers: auth });
+    const body = await res.json();
+    expect(body.status.lastReport?.transfers).toBe(1);
+  });
+
+  it('GET /pool/reconciler sits behind auth (401/403 without a Bearer token) — proves the real middleware stack', async () => {
+    const res = await fetch(`${base}/pool/reconciler`);
+    expect([401, 403]).toContain(res.status);
+  });
+});

--- a/upgrades/next/reconciler-alive-e2e.md
+++ b/upgrades/next/reconciler-alive-e2e.md
@@ -1,0 +1,23 @@
+<!-- internal-only -->
+<!-- bump: patch -->
+
+## What Changed
+
+Adds the missing Tier-3 "feature is alive" E2E test for the WS1.3 OwnershipReconciler (the
+cross-machine stuck-move fix): `tests/e2e/pool-reconciler-alive-lifecycle.test.ts`. It
+starts a real `AgentServer` with the reconciler wired and asserts over HTTP that
+`GET /pool/reconciler` is alive (200, not 503), reports both machines, and that one
+reconciler tick CONVERGES a pinned topic (owner != pin → transferring toward the pin
+target), with the live status route reflecting the transfer. Test-only; no runtime change.
+This completes the unit + integration + e2e three-tier coverage the Testing Integrity
+Standard requires — the reconciler previously had unit + integration but no tests/e2e/
+feature-alive test (the tier that catches "the dependency wasn't wired" defects, the class
+the boot-ordering bugs belonged to).
+
+## Evidence
+
+- `tests/e2e/pool-reconciler-alive-lifecycle.test.ts` — 4 tests, all pass locally
+  (`vitest run --config vitest.e2e.config.ts`): route alive (200), decision explanation
+  (transfer), the tick converges (status `transferring`, transferTo = peer, lastReport
+  transfers = 1), and auth (401/403 without a Bearer token).
+- No source files changed (test-only); `tsc --noEmit` clean.

--- a/upgrades/side-effects/reconciler-alive-e2e.md
+++ b/upgrades/side-effects/reconciler-alive-e2e.md
@@ -1,0 +1,42 @@
+# Side-Effects Review — Tier-3 feature-alive E2E for the ownership reconciler
+
+**Slug:** reconciler-alive-e2e
+**Change:** Add `tests/e2e/pool-reconciler-alive-lifecycle.test.ts` (4 tests). Test-only;
+no runtime/source changes. Completes the unit + integration + **e2e** three-tier coverage
+required by the Testing Integrity Standard for the reconciler stuck-move fix.
+
+## 1. Over-block — what legitimate inputs does this reject that it shouldn't?
+N/A — it's a test, not a gate. It asserts the real behavior (200 not 503, decision=transfer,
+a tick converges). It cannot reject any production input.
+
+## 2. Under-block — what failure modes does this still miss?
+It does not re-run `server.ts`'s exact boot ordering (it wires AgentServer directly, like
+the sibling pool-placement-transfer-alive E2E), so the specific boot-construction ordering
+is NOT asserted here — that is covered by OwnershipReconciler.test.ts's late-bound-dep
+regression tests. The comment states this honestly so the test isn't over-trusted. It also
+exercises a single ownership registry (the route + the owner-side transfer), not the
+cross-machine journal replication (covered by JournalSyncApplier + topic-pin-replication).
+
+## 3. Level-of-abstraction fit — right layer?
+Yes. Tier-3 "feature is alive" is exactly the missing tier for a feature with an API route.
+It belongs in tests/e2e/ and mirrors the established pattern.
+
+## 4. Signal vs authority compliance
+N/A — a test holds no production authority. It only constrains CI.
+
+## 5. Interactions — shadow / double-fire / race?
+None. It binds an ephemeral port (47261) + a tmpdir, starts/stops its own AgentServer in
+before/afterAll, and cleans up. No shared state with other tests.
+
+## 6. External surfaces — visible to other agents/users/systems?
+No. Test-only; no endpoint, config, or user surface. Marked internal-only in the release
+notes (no runtime src change).
+
+## 7. Multi-machine posture (Cross-Machine Coherence)
+The test simulates the multi-machine reconciler decision (two machines in machines(), a
+topic owned by SELF pinned to PEER) within one process — the standard way the e2e tier
+proves a multi-machine feature is alive. It does not itself run on multiple machines (a
+test never does); it asserts the convergence LOGIC the real multi-machine path relies on.
+
+## 8. Rollback cost
+Trivial — delete one test file. No migration, no state, no behavior change.


### PR DESCRIPTION
Adds the missing **Tier-3 "feature is alive" E2E** for the WS1.3 OwnershipReconciler (the cross-machine stuck-move fix), completing the unit + integration + e2e three-tier coverage the Testing Integrity Standard requires.

## ELI16

The reconciler fix shipped with unit and integration tests but never got the THIRD tier the project requires for any feature with an API route: a "feature is alive" end-to-end test that starts a REAL server and checks the route returns 200 (not 503 because a dependency wasn't wired). That's the exact category of test that catches the bug class the reconciler's boot-ordering defects belonged to (the reconciler was never constructed, so its route 503'd live — caught only by a two-machine run, not by the hand-wired unit/integration tests). This adds that tier: a real `AgentServer` with the reconciler wired, asserting over HTTP that `GET /pool/reconciler` is alive, reports both machines, and that one reconciler tick CONVERGES a pinned topic (owner != pin → transferring toward the pin target). Test-only — no runtime change.

## What changed
- New `tests/e2e/pool-reconciler-alive-lifecycle.test.ts` (4 tests). No source/runtime files changed.

## Tests
- 4/4 pass: route alive (200, not 503); `?topic=N` decision = transfer; one tick converges (record `status: transferring`, `transferTo` = peer, `lastReport.transfers` = 1); auth (401/403 without Bearer).
- Honest scope (stated in the test comment): wires `AgentServer` directly like its sibling `pool-placement-transfer-alive`; it does not re-run `server.ts`'s boot ordering — that's asserted by `OwnershipReconciler.test.ts`'s late-bound-dep regression tests.

## Safety
Test-only; rollback = delete one file. Internal-only release note (no runtime surface).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
