### PR TITLE
fix(routing): register 13 uncategorized LLM components (move off default framework)

### DIFF
--- a/.instar/instar-dev-decisions/2026-07-02T05-06-24-655Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-07-02T05-06-24-655Z-unknown.json
@@ -1,0 +1,13 @@
+{
+  "ts": "2026-07-02T05:06:24.655Z",
+  "slug": "unknown",
+  "suggestedTier": 1,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 23,
+  "causalAutopsy": null,
+  "verdict": "pass"
+}

--- a/docs/specs/llm-routing-register-uncategorized-components.eli16.md
+++ b/docs/specs/llm-routing-register-uncategorized-components.eli16.md
@@ -1,0 +1,35 @@
+# Register 13 uncategorized LLM components — Plain-English Overview
+
+> The one-line version: thirteen background AI helpers were quietly running on Claude instead of the cheaper off-Claude models their peers use; this tells the router which category each belongs to so they route like everyone else.
+
+## The problem in one breath
+
+Instar runs dozens of small AI calls in the background — things that classify a message, validate a resumed session, summarize a screen, or distill a correction into a preference. There's a policy that routes those background calls OFF Claude (Claude's subscription rate-limits hard) onto other providers. But that policy only moves calls whose component name is listed in a central category map. Thirteen real AI call sites were never added to that map, so they silently fell through to Claude and burned Anthropic quota — while their near-identical siblings routed off-Claude correctly.
+
+## What already exists
+
+- **The category map** (`componentCategories.ts`) — a lookup table saying each component is a `sentinel`, `gate`, `reflector`, or `job`. The router reads it to decide which provider runs a given call. An unlisted name resolves to `other`, which falls back to the default provider (Claude).
+- **The provider-fallback policy** — already moves `sentinel`/`gate`/`reflector` calls off Claude automatically. It works today for every *registered* component.
+- **The wiring ratchet** (a CI test) — already scans the source for AI call sites and fails the build if one isn't either registered or explicitly pinned as a known exception. The thirteen components were sitting in that "known exception" backlog, explicitly deferred from an earlier PR because registering a name changes live routing and "each needs its own deliberate routing decision."
+
+## What this adds
+
+This is that deliberate decision. It adds the thirteen deferred components to the category map, each tagged by what it actually does, so they route off Claude like their peers. It then trims those thirteen out of the ratchet's "known exception" list — leaving only the five that are correctly handled a different way (they pass their category explicitly at the call site, so they never needed a map entry).
+
+The thirteen, by category: **sentinel** — the input classifier, the session-summary sentinel, the Telegram alert-suppression judge (this also fixes an asymmetry: the equivalent Slack judge was already registered); **gate** — the resume validator; **reflector** — the topic router, topic-intent extractor, pre-compaction fact flush, knowledge-tree synthesis, multi-machine conflict resolver, A2A conversation-brief writer, A2A check-in summarizer, correction-learning distiller, and mentor-stage-b forensics.
+
+## The new pieces
+
+No new modules and no new logic — this is a data-map change. Thirteen key/value rows are added to an existing table, and thirteen names are removed from an existing test's exception set. The router, the fallback policy, and the ratchet are all untouched.
+
+## The safeguards
+
+**Prevents a wrong-provider surprise.** Every one of the thirteen joins a category (`sentinel`/`gate`/`reflector`) that the fallback policy already routes for dozens of other components — so the target providers are already exercised in production. Nothing routes anywhere new; these calls just stop being the odd ones out.
+
+**Prevents silent recurrence.** The existing ratchet already fails CI if a *future* AI call site is added without being registered. This change strengthens that guarantee by clearing the backlog down to only the genuinely-exempt five, so the exception list now means exactly what it says.
+
+**Prevents mis-categorization drift.** The ratchet's second assertion verifies that everything still pinned as an exception genuinely resolves to `other` — so if someone later registers one of the remaining five, CI tells them to remove it from the list.
+
+## What ships when
+
+One PR, one Tier-1 change: the map addition and the exception-list trim ship together, guarded by the already-green routing and ratchet tests. It is reversible by removing the added rows. A follow-up (separate, operator-reviewed) will re-derive each category by task *nature* and by which model is reachable on a subsidized non-Claude subscription — this change simply stops the thirteen from leaking onto Claude in the meantime.

--- a/src/core/componentCategories.ts
+++ b/src/core/componentCategories.ts
@@ -99,6 +99,29 @@ export const COMPONENT_CATEGORY: Readonly<Record<string, ComponentCategory>> = {
   // enrichment then never spends Anthropic quota. Only used by the dark
   // llmEnrichment path; the shipped deterministic auditor makes no LLM calls.
   StandardsCoverageEnrichment: 'job',
+
+  // ── Previously-uncategorized LLM callsites (LLM Routing Registry audit,
+  //    2026-07-01). Each calls an intelligence provider's .evaluate() but was
+  //    absent from this map AND passes no explicit attribution.category, so it
+  //    resolved to 'other' → the agent default framework (Claude) — silently
+  //    spending Anthropic quota instead of routing off-Claude like its peers.
+  //    Categorized by function (sentinel = background judgment call, gate =
+  //    pre-action allow/deny, reflector = extraction/summarization/analysis).
+  //    The drift-guard test (componentCategories-evaluate-coverage.test.ts)
+  //    keeps this map exhaustive over .evaluate() callsites going forward. ──
+  InputClassifier: 'sentinel',           // input auto-approve vs relay classification
+  SessionSummarySentinel: 'sentinel',    // summarize tmux output → task/phase/files
+  TelegramAdapter: 'sentinel',           // stall/idle alert-suppression judge (parity with SlackAdapter)
+  ResumeValidator: 'gate',               // does a resume UUID match the topic? (pre-resume gate)
+  Usher: 'reflector',                    // route a turn to candidate topics
+  TopicIntentExtractor: 'reflector',     // extract topic intent from a turn
+  PreCompactionFlush: 'reflector',       // extract durable facts before compaction
+  TreeSynthesis: 'reflector',            // synthesize knowledge fragments → answer
+  LLMConflictResolver: 'reflector',      // resolve divergent multi-machine state
+  openConversationBrief: 'reflector',    // generate an A2A conversation brief
+  'a2a-checkin': 'reflector',            // summarize A2A check-in threads (server:a2a-checkin)
+  'correction-learning': 'reflector',    // distill recurring corrections → preference (server:correction-learning)
+  'mentor-stage-b': 'reflector',         // classify mentor signals → forensic findings
 };
 
 /**

--- a/tests/unit/llm-attribution-ratchet.test.ts
+++ b/tests/unit/llm-attribution-ratchet.test.ts
@@ -162,34 +162,27 @@ export const x = 1; // intelligence.evaluate(p) in a line comment too`;
 
 describe('componentCategories wiring', () => {
   /**
-   * Pre-existing attribution labels that predate this wiring test and are NOT
-   * registered in COMPONENT_CATEGORY. Registering a name changes live
-   * per-component framework routing (it moves the component from the default
-   * framework to its category's configured framework), so each needs its own
-   * deliberate routing decision — out of scope for the token-audit PR. This
-   * list is PINNED: a NEW unregistered component name fails this test; the
-   * fix is registering it in src/core/componentCategories.ts, not extending
-   * this list.
+   * Attribution labels intentionally NOT registered in COMPONENT_CATEGORY because
+   * they pass an EXPLICIT `attribution.category` at their call site (so the router
+   * resolves them by that category, not by this map). `categoryForComponent` — which
+   * only consults the map — therefore returns 'other' for them, which is correct.
+   * This list is PINNED: a NEW map-unregistered component name that does NOT pass an
+   * explicit category fails this test; the fix is registering it in
+   * src/core/componentCategories.ts, not extending this list.
+   *
+   * (The LLM Routing Registry audit, 2026-07-01, cleared the remaining pre-existing
+   * backlog by registering InputClassifier, LLMConflictResolver, PreCompactionFlush,
+   * ResumeValidator, SessionSummarySentinel, TelegramAdapter, TopicIntentExtractor,
+   * TreeSynthesis, Usher, mentor-stage-b, openConversationBrief, a2a-checkin,
+   * correction-learning — moving them off the default framework. See
+   * docs/LLM-ROUTING-REGISTRY.md.)
    */
   const WIRING_EXCLUSIONS = new Set([
     'AmbientContributionGate',
     'BlockerSettleAuthority',
-    'InputClassifier',
     'IntentLlmJudge',
-    'LLMConflictResolver',
     'LlmIntentClassifier',
-    'PreCompactionFlush',
     'RelationshipAnomalyScorer',
-    'ResumeValidator',
-    'SessionSummarySentinel',
-    'TelegramAdapter',
-    'TopicIntentExtractor',
-    'TreeSynthesis',
-    'Usher',
-    'mentor-stage-b',
-    'openConversationBrief',
-    'a2a-checkin',
-    'correction-learning',
   ]);
 
   it('every literal attribution.component in src/ resolves to a registered category or a pinned exclusion', () => {

--- a/upgrades/next/llm-routing-register-uncategorized-components.md
+++ b/upgrades/next/llm-routing-register-uncategorized-components.md
@@ -1,0 +1,62 @@
+<!-- bump: patch -->
+
+## What Changed
+
+Thirteen background LLM call sites that were quietly running on the default
+framework (Claude) now route off-Claude with their peers. The framework router
+picks a provider by a component's category; these thirteen were absent from the
+category map, so they resolved to `other` and fell back to Claude — burning
+Anthropic quota while near-identical siblings routed to the cheaper, less
+rate-limited off-Claude providers.
+
+They were the pinned `WIRING_EXCLUSIONS` backlog explicitly deferred from the
+token-audit PR ("each needs its own deliberate routing decision"). This is that
+decision: each is registered by function — `InputClassifier`,
+`SessionSummarySentinel`, `TelegramAdapter` (sentinel; `TelegramAdapter` also fixes
+an asymmetry versus the already-registered `SlackAdapter` alert-suppression judge);
+`ResumeValidator` (gate); and `Usher`, `TopicIntentExtractor`, `PreCompactionFlush`,
+`TreeSynthesis`, `LLMConflictResolver`, `openConversationBrief`, `a2a-checkin`,
+`correction-learning`, `mentor-stage-b` (reflector).
+
+`WIRING_EXCLUSIONS` now holds only the five components that route via an explicit
+`attribution.category` and are correctly map-unregistered. The existing wiring
+ratchet remains the drift guard against future recurrence. Additive and fully
+reversible; no new logic, no new decision authority.
+
+## What to Tell Your User
+
+Thirteen of my small background AI helpers — the ones that classify messages,
+summarize sessions, extract facts before compaction, and similar housekeeping —
+were quietly running on Claude instead of the cheaper providers the rest of my
+background checks use. That was burning Claude subscription quota (the scarce,
+rate-limited resource) on work that never needed it. They now route off Claude
+like their peers, so more of your Claude quota stays available for the
+conversations and heavy work where it matters. Nothing changes in what these
+helpers do — only which provider quietly runs them.
+
+## Summary of New Capabilities
+
+None — no new API routes, config keys, or user-facing behavior. This is a
+routing-map completion: 13 existing internal LLM call sites now resolve to their
+proper category (`sentinel`/`gate`/`reflector`) so the existing
+Provider-Fallback Default Policy routes them off Claude. Operators can still
+override any of them per-agent via `sessions.componentFrameworks.overrides`.
+
+## Evidence
+
+Before: `GET /intelligence/routing` on a live agent showed these 13 components
+absent from the known-components registry, and `categoryForComponent()` in the
+deployed dist resolved each to `'other'` → the agent default framework (Claude).
+Verified against the deployed code during the 2026-07-01 LLM Routing Registry
+audit (docs/LLM-ROUTING-REGISTRY.md), not just the source branch — each of the
+13 calls `.evaluate()` with an `attribution.component` that had no map entry and
+no explicit `attribution.category`, while siblings like `SlackAdapter` (mapped)
+routed off-Claude.
+
+After: `categoryForComponent('InputClassifier')` → `'sentinel'` (and likewise
+for all 13; `'TelegramAdapter'` now matches the already-mapped `SlackAdapter`).
+The wiring ratchet (`tests/unit/llm-attribution-ratchet.test.ts`) proves both
+directions over the real source tree: every literal `attribution.component` in
+`src/` resolves to a registered category or a pinned explicit-category
+exception, and every remaining exception genuinely resolves to `'other'`. The
+router, integration, and e2e routing suites are green unchanged.

--- a/upgrades/side-effects/llm-routing-register-uncategorized-components.md
+++ b/upgrades/side-effects/llm-routing-register-uncategorized-components.md
@@ -1,0 +1,100 @@
+# Side-Effects Review — Register 13 uncategorized LLM components
+
+**Version / slug:** `llm-routing-register-uncategorized-components`
+**Date:** `2026-07-01`
+**Author:** `echo`
+**Second-pass reviewer:** `not required`
+
+## Summary of the change
+
+Adds 13 previously-unregistered LLM call-site component names to `COMPONENT_CATEGORY`
+in `src/core/componentCategories.ts`, each tagged `sentinel` / `gate` / `reflector`
+by function, so the framework router resolves them to a real category instead of
+`other` (which falls back to the agent default framework, Claude). Correspondingly
+removes those 13 names from the `WIRING_EXCLUSIONS` pinned backlog in
+`tests/unit/llm-attribution-ratchet.test.ts`, leaving only the 5 components that
+route via an explicit `attribution.category` (so they correctly stay map-unregistered).
+Files touched: `src/core/componentCategories.ts`, `tests/unit/llm-attribution-ratchet.test.ts`.
+The change interacts with one decision point — the router's category resolution
+(`categoryForComponent`) — but only feeds it more data; it adds no branching logic.
+
+## Decision-point inventory
+
+- `categoryForComponent` (src/core/componentCategories.ts) — **pass-through** — unchanged
+  function; this change only adds rows to the map it reads. No control-flow edit.
+- `IntelligenceRouter.resolveFramework` (per-component framework routing) — **pass-through** —
+  consumes the category; unchanged. The 13 components now resolve to their category's
+  configured framework instead of the default, which is the intended effect.
+
+---
+
+## 1. Over-block
+
+**What legitimate inputs does this change reject that it shouldn't?**
+
+No block/allow surface — over-block not applicable. This is a routing-map data change,
+not a gate. It changes WHICH provider runs a call, never WHETHER the call is allowed.
+
+---
+
+## 2. Under-block
+
+**What failure modes does this still miss?**
+
+No block/allow surface — under-block not applicable. The change cannot make any gate
+more permissive; gate *authority* is untouched. (The one `gate`-category addition,
+ResumeValidator, keeps its existing behavior; only its provider changes.)
+
+---
+
+## 3. Wrong-provider / routing correctness
+
+**Could a component now route to a provider that can't serve it correctly?**
+
+Low risk. All 13 join categories (`sentinel`/`gate`/`reflector`) that the
+Provider-Fallback Default Policy already routes off-Claude for dozens of live
+components — the target providers (codex-cli → pi-cli → gemini-cli, Claude last)
+are production-exercised. A rate-limited or missing framework degrades via the
+existing per-framework circuit breaker + fallback chain (unchanged). No component
+routes to a provider class not already in use for its category.
+
+The one behavioral nuance: components that make *nuanced/critical* judgments
+(e.g. LLMConflictResolver resolving divergent multi-machine state) now run on a
+non-Claude reasoning-capable model (gpt-5.5 via codex) rather than Claude. This is
+aligned with the operator directive to prefer subsidized non-Claude subscriptions,
+and gpt-5.5 is reasoning-capable. A later nature-based routing pass (operator-reviewed)
+will refine per-task model tiers; this change does not lock that in.
+
+---
+
+## 4. Reversibility / rollback
+
+Fully reversible: remove the 13 rows from `COMPONENT_CATEGORY` (and restore them to
+`WIRING_EXCLUSIONS`) and routing returns to the prior state. No migration, no state
+schema change, no persisted data. An operator can also override any single component
+per-agent via `sessions.componentFrameworks.overrides` without touching this map.
+
+---
+
+## 5. Blast radius
+
+Fleet-wide once shipped (it's a core map), but strictly additive and category-consistent.
+No new code paths execute; the router simply finds a category where it previously found
+none. Existing tests cover it: the wiring ratchet (`llm-attribution-ratchet.test.ts`)
+proves every live `.evaluate()` component now resolves, `intelligence-router.test.ts` and
+the integration/e2e routing suites remain green. Signal-vs-authority: N/A — no detector
+and no authority is added or modified; this is a data-map completion.
+
+---
+
+## 6. Test coverage
+
+- `tests/unit/llm-attribution-ratchet.test.ts` — the drift guard; asserts every literal
+  `attribution.component` in `src/` resolves to a registered category or a pinned
+  (explicit-category) exception, AND that every pinned exception still resolves to `other`.
+  Both sides green after the change.
+- `tests/unit/intelligence-router.test.ts`, `tests/unit/standards-coverage-component-category.test.ts`,
+  `tests/integration/intelligence-routing-routes.test.ts`,
+  `tests/integration/provider-fallback-default-routing.test.ts` — all green.
+- No NEW test added: the existing ratchet already IS the structural guard for this
+  invariant (adding a duplicate would be noise).


### PR DESCRIPTION
## Summary

Registers 13 previously-uncategorized LLM call-site components in `COMPONENT_CATEGORY` (`src/core/componentCategories.ts`) so the framework router resolves them to a real category instead of `other` — which fell back to the agent default framework (Claude). Correspondingly trims those 13 from the `WIRING_EXCLUSIONS` pinned backlog in `tests/unit/llm-attribution-ratchet.test.ts`, leaving only the 5 that route via an explicit `attribution.category`.

Discovered by the LLM Routing Registry audit (2026-07-01): these components call an intelligence provider's `.evaluate()` but were never in the category map, so they silently ran on Claude — burning Anthropic quota — while their sentinel/gate/reflector peers routed off-Claude via the Provider-Fallback Default Policy.

## ELI16 — Plain-English Overview

Instar runs dozens of small AI calls in the background — classifying a message, validating a resumed session, summarizing a screen, distilling a correction into a preference. A policy already routes those calls OFF Claude (whose subscription rate-limits hard) onto cheaper providers, but only for calls whose component name appears in a central category map. Thirteen real AI call sites were never added to that map, so they quietly fell through to Claude and spent Anthropic quota — while near-identical siblings routed off-Claude correctly. This PR is the deliberate routing decision for those thirteen: it tags each by what it does (a background judgment call → `sentinel`, a pre-action allow/deny → `gate`, an extraction/summarization/analysis → `reflector`) and adds it to the map, so they route like their peers. It then trims those thirteen out of a test's "known exception" list, leaving only the five components that are correctly handled a different way — they already pass their category explicitly at the call site, so they never needed a map entry. No new logic and no new decision authority: it's a data-map completion, guarded by the existing wiring ratchet and fully reversible by removing the rows.

### What's registered

- **sentinel** — `InputClassifier`, `SessionSummarySentinel`, `TelegramAdapter` (also fixes an asymmetry: the equivalent `SlackAdapter` alert-suppression judge was already registered)
- **gate** — `ResumeValidator`
- **reflector** — `Usher`, `TopicIntentExtractor`, `PreCompactionFlush`, `TreeSynthesis`, `LLMConflictResolver`, `openConversationBrief`, `a2a-checkin`, `correction-learning`, `mentor-stage-b`

`WIRING_EXCLUSIONS` now holds only the 5 explicit-category components: `AmbientContributionGate`, `BlockerSettleAuthority`, `IntentLlmJudge`, `LlmIntentClassifier`, `RelationshipAnomalyScorer`.

## Why this is safe (Tier 1)

- **Additive, category-consistent.** Every one of the 13 joins a category (`sentinel`/`gate`/`reflector`) that the fallback policy already routes off-Claude for dozens of production components — no new provider class is introduced.
- **No authority change.** The one `gate` addition (`ResumeValidator`) keeps its existing behavior; only its provider changes. Signal-vs-authority: N/A (no detector/authority added or modified).
- **Guarded against recurrence.** The existing wiring ratchet (`llm-attribution-ratchet.test.ts`) fails CI if any future `.evaluate()` component is unregistered — no new test needed (a duplicate would be noise).
- **Reversible.** Remove the rows (and restore them to `WIRING_EXCLUSIONS`); no migration, no persisted state.

## Test plan

- `tests/unit/llm-attribution-ratchet.test.ts` — the drift guard; both assertions green (every live `.evaluate()` component resolves to a category or a pinned explicit-category exception; every pinned exception still resolves to `other`).
- `tests/unit/intelligence-router.test.ts`, `tests/unit/standards-coverage-component-category.test.ts`, `tests/integration/intelligence-routing-routes.test.ts`, `tests/integration/provider-fallback-default-routing.test.ts` — green.
- Full pre-push suite green.

## Deferred (tracked — not in this PR)

- **Nature-based routing split.** Re-derive each component's provider/model by task *nature* (bounded verdict → fast small model; nuanced/critical judgment → reasoning model) rather than one framework per category. Touches critical-gate model selection → operator-reviewed, separate PR.
- **Subsidized-subscription routing axis + tiered fallback doors.** Per operator directive (2026-07-01): default each task to the best model reachable on a subsidized *non-Claude* subscription, with a benchmark-driven ordered fallback chain. Feeds the same follow-up.
- Both are captured in `docs/LLM-ROUTING-REGISTRY.md` and the benchmark-v2 plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
